### PR TITLE
fix(tooltip): coordinate tooltips globally and adjust delay timing

### DIFF
--- a/apps/whispering/src/lib/components/WhisperingTooltip.svelte
+++ b/apps/whispering/src/lib/components/WhisperingTooltip.svelte
@@ -25,18 +25,16 @@
 	{/if}
 {/snippet}
 
-<Tooltip.Provider>
-	<Tooltip.Root>
-		<Tooltip.Trigger {id}>
-			{#snippet child({ props: tooltipProps })}
-				{@render trigger?.({
-					tooltipProps: mergeProps(tooltipProps, restProps),
-					tooltip,
-				})}
-			{/snippet}
-		</Tooltip.Trigger>
-		<Tooltip.Content class="max-w-xs text-center">
-			{@render tooltip()}
-		</Tooltip.Content>
-	</Tooltip.Root>
-</Tooltip.Provider>
+<Tooltip.Root>
+	<Tooltip.Trigger {id}>
+		{#snippet child({ props: tooltipProps })}
+			{@render trigger?.({
+				tooltipProps: mergeProps(tooltipProps, restProps),
+				tooltip,
+			})}
+		{/snippet}
+	</Tooltip.Trigger>
+	<Tooltip.Content class="max-w-xs text-center">
+		{@render tooltip()}
+	</Tooltip.Content>
+</Tooltip.Root>

--- a/apps/whispering/src/routes/+layout.svelte
+++ b/apps/whispering/src/routes/+layout.svelte
@@ -6,6 +6,7 @@
 	import { SvelteQueryDevtools } from '@tanstack/svelte-query-devtools';
 	import '@repo/ui/app.css';
 	import * as services from '$lib/services';
+	import * as Tooltip from '@repo/ui/tooltip';
 	import AppShell from './+layout/AppShell.svelte';
 
 	let { children } = $props();
@@ -37,9 +38,11 @@
 </svelte:head>
 
 <QueryClientProvider client={queryClient}>
-	<AppShell>
-		{@render children()}
-	</AppShell>
+	<Tooltip.Provider delayDuration={300} skipDelayDuration={150}>
+		<AppShell>
+			{@render children()}
+		</AppShell>
+	</Tooltip.Provider>
 </QueryClientProvider>
 
 <SvelteQueryDevtools client={queryClient} buttonPosition="bottom-left" />


### PR DESCRIPTION
This PR fixes two related tooltip behavior issues:

1. **Tooltip delay duration** — Reduced the delay so users see the tooltip almost instantly, without having to wait too long.
2. **Multiple tooltips visible** — When quickly hovering between different triggers, more than one tooltip could remain visible at the same time.

### Changes Made
- Set `delayDuration` to `300` and `skipDelayDuration` to `150` for faster tooltip display and instant hide behavior.
- Added logic to ensure only one tooltip can be open at any time when switching between triggers.

### Testing Steps
1. Hover over a tooltip — it should appear almost immediately.
2. Quickly hover between two or more tooltip triggers — only the most recent tooltip should be visible.

### Impact
Improves user experience by:
- Making tooltips appear without unnecessary waiting.
- Preventing overlapping tooltips when moving quickly between elements.