### PR TITLE
On mobile, hide some action items in ellipses menu.

### DIFF
--- a/apps/whispering/src/lib/components/copyable/CopyToClipboardButton.svelte
+++ b/apps/whispering/src/lib/components/copyable/CopyToClipboardButton.svelte
@@ -17,6 +17,7 @@
 		class: className,
 		size = 'icon',
 		variant = 'ghost',
+		only = 'default',
 		disabled,
 	}: {
 		/**
@@ -41,7 +42,7 @@
 		contentDescription: string;
 		viewTransitionName?: string;
 		class?: string;
-	} & Pick<Props, 'disabled' | 'variant' | 'size'> = $props();
+	} & Pick<Props, 'disabled' | 'variant' | 'size' | 'only' > = $props();
 
 	let hasCopied = $state(false);
 </script>
@@ -77,6 +78,7 @@
 	class={className}
 	{size}
 	{variant}
+	{only}
 	{disabled}
 >
 	<span class="sr-only">Copy</span>

--- a/apps/whispering/src/routes/(config)/recordings/row-actions/EditRecordingModal.svelte
+++ b/apps/whispering/src/routes/(config)/recordings/row-actions/EditRecordingModal.svelte
@@ -21,7 +21,7 @@
 		rpc.recordings.deleteRecording.options,
 	);
 
-	let { recording }: { recording: Recording } = $props();
+	let { recording, only }: { recording: Recording; only: string } = $props();
 
 	let isDialogOpen = $state(false);
 
@@ -106,7 +106,7 @@
 				tooltipContent="Edit recording"
 				variant="ghost"
 				size="icon"
-				only="desktop"
+				{only}
 				{...props}
 			>
 				<EditIcon class="size-4" />

--- a/apps/whispering/src/routes/(config)/recordings/row-actions/EditRecordingModal.svelte
+++ b/apps/whispering/src/routes/(config)/recordings/row-actions/EditRecordingModal.svelte
@@ -106,6 +106,7 @@
 				tooltipContent="Edit recording"
 				variant="ghost"
 				size="icon"
+				only="desktop"
 				{...props}
 			>
 				<EditIcon class="size-4" />

--- a/apps/whispering/src/routes/(config)/recordings/row-actions/RecordingRowActions.svelte
+++ b/apps/whispering/src/routes/(config)/recordings/row-actions/RecordingRowActions.svelte
@@ -21,6 +21,7 @@
 	import EditRecordingModal from './EditRecordingModal.svelte';
 	import TransformationPicker from './TransformationPicker.svelte';
 	import ViewTransformationRunsDialog from './ViewTransformationRunsDialog.svelte';
+	import RowActionsOverflowMenu from './RowActionsOverflowMenu.svelte';
 
 	const transcribeRecording = createMutation(
 		rpc.transcription.transcribeRecording.options,
@@ -151,7 +152,10 @@
 			}}
 		/>
 
-		<EditRecordingModal {recording} />
+		{#snippet editRecordingButton(only = 'default')}
+			<EditRecordingModal {recording} {only} />
+		{/snippet}
+		{@render editRecordingButton('default')}
 
 		<CopyToClipboardButton
 			contentDescription="transcribed text"
@@ -164,73 +168,83 @@
 			<ClipboardIcon class="size-4" />
 		</CopyToClipboardButton>
 
-		{#if latestTransformationRunByRecordingIdQuery.isPending}
-			<Loader2Icon class="size-4 animate-spin" />
-		{:else if latestTransformationRunByRecordingIdQuery.isError}
-			<WhisperingTooltip
-				id={getRecordingTransitionId({
-					recordingId,
-					propertyName: 'latestTransformationRunOutput',
-				})}
-				tooltipContent="Error fetching latest transformation run output"
-			>
-				{#snippet trigger({ tooltip, tooltipProps })}
-					<AlertCircleIcon class="text-red-500" {...tooltipProps} />
-					<span class="sr-only">
-						{@render tooltip()}
-					</span>
-				{/snippet}
-			</WhisperingTooltip>
-		{:else}
-			<CopyToClipboardButton
-				contentDescription="latest transformation run output"
-				textToCopy={latestTransformationRunByRecordingIdQuery.data?.status ===
-				'completed'
-					? latestTransformationRunByRecordingIdQuery.data.output
-					: ''}
-				viewTransitionName={getRecordingTransitionId({
-					recordingId,
-					propertyName: 'latestTransformationRunOutput',
-				})}
-			>
-				<FileStackIcon class="size-4" />
-			</CopyToClipboardButton>
-		{/if}
-
-		<ViewTransformationRunsDialog {recordingId} />
-
-		<WhisperingButton
-			tooltipContent="Download recording"
-			onclick={() =>
-				downloadRecording.mutate(recording, {
-					onError: (error) => {
-						if (error.name === 'WhisperingError') {
-							rpc.notify.error.execute(error);
-							return;
-						}
-						rpc.notify.error.execute({
-							title: 'Failed to download recording!',
-							description: 'Your recording could not be downloaded.',
-							action: { type: 'more-details', error },
-						});
-					},
-					onSuccess: () => {
-						rpc.notify.success.execute({
-							title: 'Recording downloaded!',
-							description: 'Your recording has been downloaded.',
-						});
-					},
-				})}
-			variant="ghost"
-			size="icon"
-			only="desktop"
-		>
-			{#if downloadRecording.isPending}
+		{#snippet copyTransformationButton(only = 'default')}
+			{#if latestTransformationRunByRecordingIdQuery.isPending}
 				<Loader2Icon class="size-4 animate-spin" />
+			{:else if latestTransformationRunByRecordingIdQuery.isError}
+				<WhisperingTooltip
+					id={getRecordingTransitionId({
+						recordingId,
+						propertyName: 'latestTransformationRunOutput',
+					})}
+					tooltipContent="Error fetching latest transformation run output"
+				>
+					{#snippet trigger({ tooltip, tooltipProps })}
+						<AlertCircleIcon class="text-red-500" {...tooltipProps} />
+						<span class="sr-only">
+							{@render tooltip()}
+						</span>
+					{/snippet}
+				</WhisperingTooltip>
 			{:else}
-				<DownloadIcon class="size-4" />
+				<CopyToClipboardButton
+					contentDescription="latest transformation run output"
+					textToCopy={latestTransformationRunByRecordingIdQuery.data?.status ===
+					'completed'
+						? latestTransformationRunByRecordingIdQuery.data.output
+						: ''}
+					viewTransitionName={getRecordingTransitionId({
+						recordingId,
+						propertyName: 'latestTransformationRunOutput',
+					})}
+					{only}
+				>
+					<FileStackIcon class="size-4" />
+				</CopyToClipboardButton>
 			{/if}
-		</WhisperingButton>
+		{/snippet}
+		{@render copyTransformationButton('desktop')}
+
+		{#snippet viewTransformationRunsDialogButton(only = 'default')}
+			<ViewTransformationRunsDialog {recordingId} {only} />
+		{/snippet}
+		{@render viewTransformationRunsDialogButton('desktop')}
+
+		{#snippet downloadRecordingButton(only = 'default')}
+			<WhisperingButton
+				tooltipContent="Download recording"
+				onclick={() =>
+					downloadRecording.mutate(recording, {
+						onError: (error) => {
+							if (error.name === 'WhisperingError') {
+								rpc.notify.error.execute(error);
+								return;
+							}
+							rpc.notify.error.execute({
+								title: 'Failed to download recording!',
+								description: 'Your recording could not be downloaded.',
+								action: { type: 'more-details', error },
+							});
+						},
+						onSuccess: () => {
+							rpc.notify.success.execute({
+								title: 'Recording downloaded!',
+								description: 'Your recording has been downloaded.',
+							});
+						},
+					})}
+				variant="ghost"
+				size="icon"
+				{only}
+			>
+				{#if downloadRecording.isPending}
+					<Loader2Icon class="size-4 animate-spin" />
+				{:else}
+					<DownloadIcon class="size-4" />
+				{/if}
+			</WhisperingButton>
+		{/snippet}
+		{@render downloadRecordingButton('desktop')}
 
 		<WhisperingButton
 			tooltipContent="Delete recording"
@@ -263,16 +277,11 @@
 			<TrashIcon class="size-4" />
 		</WhisperingButton>
 
-		<WhisperingButton
-			tooltipContent="Overflow Menu"
-			onclick={() => {
-				
-			}}
-			variant="ghost"
-			size="icon"
-			only="mobile"
-		>
-			<EllipsisIcon class="size-4" />
-		</WhisperingButton>
+		<RowActionsOverflowMenu>
+			{@render editRecordingButton()}
+			{@render copyTransformationButton()}
+			{@render viewTransformationRunsDialogButton()}
+			{@render downloadRecordingButton()}
+		</RowActionsOverflowMenu>
 	{/if}
 </div>

--- a/apps/whispering/src/routes/(config)/recordings/row-actions/RecordingRowActions.svelte
+++ b/apps/whispering/src/routes/(config)/recordings/row-actions/RecordingRowActions.svelte
@@ -114,43 +114,47 @@
 			{/if}
 		</WhisperingButton>
 
-		<TransformationPicker
-			onSelect={(transformation) => {
-				const toastId = nanoid();
-				rpc.notify.loading.execute({
-					id: toastId,
-					title: '🔄 Running transformation...',
-					description:
-						'Applying your selected transformation to the transcribed text...',
-				});
-				transformRecording.mutate(
-					{ recordingId: recording.id, transformation },
-					{
-						onError: (error) => rpc.notify.error.execute(error),
-						onSuccess: (transformationRun) => {
-							if (transformationRun.status === 'failed') {
-								rpc.notify.error.execute({
-									title: '⚠️ Transformation error',
-									description: transformationRun.error,
-									action: {
-										type: 'more-details',
-										error: transformationRun.error,
-									},
+		{#snippet transformationPickerButton(only = 'default')}
+			<TransformationPicker
+				onSelect={(transformation) => {
+					const toastId = nanoid();
+					rpc.notify.loading.execute({
+						id: toastId,
+						title: '🔄 Running transformation...',
+						description:
+							'Applying your selected transformation to the transcribed text...',
+					});
+					transformRecording.mutate(
+						{ recordingId: recording.id, transformation },
+						{
+							onError: (error) => rpc.notify.error.execute(error),
+							onSuccess: (transformationRun) => {
+								if (transformationRun.status === 'failed') {
+									rpc.notify.error.execute({
+										title: '⚠️ Transformation error',
+										description: transformationRun.error,
+										action: {
+											type: 'more-details',
+											error: transformationRun.error,
+										},
+									});
+									return;
+								}
+
+								rpc.sound.playSoundIfEnabled.execute('transformationComplete');
+
+								rpc.delivery.deliverTransformationResult.execute({
+									text: transformationRun.output,
+									toastId,
 								});
-								return;
-							}
-
-							rpc.sound.playSoundIfEnabled.execute('transformationComplete');
-
-							rpc.delivery.deliverTransformationResult.execute({
-								text: transformationRun.output,
-								toastId,
-							});
+							},
 						},
-					},
-				);
-			}}
-		/>
+					);
+				}}
+				{only}
+			/>
+		{/snippet}
+		{@render transformationPickerButton('desktop')}
 
 		{#snippet editRecordingButton(only = 'default')}
 			<EditRecordingModal {recording} {only} />
@@ -278,6 +282,7 @@
 		</WhisperingButton>
 
 		<RowActionsOverflowMenu>
+			{@render transformationPickerButton()}
 			{@render editRecordingButton()}
 			{@render copyTransformationButton()}
 			{@render viewTransformationRunsDialogButton()}

--- a/apps/whispering/src/routes/(config)/recordings/row-actions/RecordingRowActions.svelte
+++ b/apps/whispering/src/routes/(config)/recordings/row-actions/RecordingRowActions.svelte
@@ -114,7 +114,7 @@
 			{/if}
 		</WhisperingButton>
 
-		{#snippet transformationPickerButton(only = 'default')}
+		{#snippet transformationPickerSnippet(only = 'default')}
 			<TransformationPicker
 				onSelect={(transformation) => {
 					const toastId = nanoid();
@@ -154,12 +154,12 @@
 				{only}
 			/>
 		{/snippet}
-		{@render transformationPickerButton('desktop')}
+		{@render transformationPickerSnippet('desktop')}
 
-		{#snippet editRecordingButton(only = 'default')}
+		{#snippet editRecordingModalSnippet(only = 'default')}
 			<EditRecordingModal {recording} {only} />
 		{/snippet}
-		{@render editRecordingButton('default')}
+		{@render editRecordingModalSnippet('default')}
 
 		<CopyToClipboardButton
 			contentDescription="transcribed text"
@@ -172,7 +172,7 @@
 			<ClipboardIcon class="size-4" />
 		</CopyToClipboardButton>
 
-		{#snippet copyTransformationButton(only = 'default')}
+		{#snippet copyTransformationButtonSnippet(only = 'default')}
 			{#if latestTransformationRunByRecordingIdQuery.isPending}
 				<Loader2Icon class="size-4 animate-spin" />
 			{:else if latestTransformationRunByRecordingIdQuery.isError}
@@ -207,14 +207,14 @@
 				</CopyToClipboardButton>
 			{/if}
 		{/snippet}
-		{@render copyTransformationButton('desktop')}
+		{@render copyTransformationButtonSnippet('desktop')}
 
-		{#snippet viewTransformationRunsDialogButton(only = 'default')}
+		{#snippet viewTransformationRunsDialogSnippet(only = 'default')}
 			<ViewTransformationRunsDialog {recordingId} {only} />
 		{/snippet}
-		{@render viewTransformationRunsDialogButton('desktop')}
+		{@render viewTransformationRunsDialogSnippet('desktop')}
 
-		{#snippet downloadRecordingButton(only = 'default')}
+		{#snippet downloadRecordingButtonSnippet(only = 'default')}
 			<WhisperingButton
 				tooltipContent="Download recording"
 				onclick={() =>
@@ -248,7 +248,7 @@
 				{/if}
 			</WhisperingButton>
 		{/snippet}
-		{@render downloadRecordingButton('desktop')}
+		{@render downloadRecordingButtonSnippet('desktop')}
 
 		<WhisperingButton
 			tooltipContent="Delete recording"
@@ -282,11 +282,11 @@
 		</WhisperingButton>
 
 		<RowActionsOverflowMenu>
-			{@render transformationPickerButton()}
-			{@render editRecordingButton()}
-			{@render copyTransformationButton()}
-			{@render viewTransformationRunsDialogButton()}
-			{@render downloadRecordingButton()}
+			{@render transformationPickerSnippet()}
+			{@render editRecordingModalSnippet()}
+			{@render copyTransformationButtonSnippet()}
+			{@render viewTransformationRunsDialogSnippet()}
+			{@render downloadRecordingButtonSnippet()}
 		</RowActionsOverflowMenu>
 	{/if}
 </div>

--- a/apps/whispering/src/routes/(config)/recordings/row-actions/RecordingRowActions.svelte
+++ b/apps/whispering/src/routes/(config)/recordings/row-actions/RecordingRowActions.svelte
@@ -223,6 +223,7 @@
 				})}
 			variant="ghost"
 			size="icon"
+			only="desktop"
 		>
 			{#if downloadRecording.isPending}
 				<Loader2Icon class="size-4 animate-spin" />
@@ -260,6 +261,18 @@
 			size="icon"
 		>
 			<TrashIcon class="size-4" />
+		</WhisperingButton>
+
+		<WhisperingButton
+			tooltipContent="Overflow Menu"
+			onclick={() => {
+				
+			}}
+			variant="ghost"
+			size="icon"
+			only="mobile"
+		>
+			<EllipsisIcon class="size-4" />
 		</WhisperingButton>
 	{/if}
 </div>

--- a/apps/whispering/src/routes/(config)/recordings/row-actions/RowActionsOverflowMenu.svelte
+++ b/apps/whispering/src/routes/(config)/recordings/row-actions/RowActionsOverflowMenu.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import WhisperingButton from '$lib/components/WhisperingButton.svelte';
+	import * as Popover from '@repo/ui/popover';
+	import { useCombobox } from '@repo/ui/hooks';
+
+	import { EllipsisIcon } from '@lucide/svelte';
+
+	let { children } = $props();
+
+	const combobox = useCombobox();
+</script>
+
+<Popover.Root bind:open={combobox.open}>
+	<Popover.Trigger bind:ref={combobox.triggerRef}>
+		{#snippet child({ props })}
+			<WhisperingButton
+				{...props}
+				tooltipContent="Overflow Actions"
+				role="combobox"
+				aria-expanded={combobox.open}
+				variant="ghost"
+				size="icon"
+				only="mobile"
+			>
+				<EllipsisIcon class="size-4" />
+			</WhisperingButton>
+		{/snippet}
+	</Popover.Trigger>
+	<Popover.Content class="flex w-auto m-1 p-1 z-20">
+		{@render children()}
+	</Popover.Content>
+</Popover.Root>

--- a/apps/whispering/src/routes/(config)/recordings/row-actions/TransformationPicker.svelte
+++ b/apps/whispering/src/routes/(config)/recordings/row-actions/TransformationPicker.svelte
@@ -21,9 +21,11 @@
 	let {
 		class: className,
 		onSelect,
+		only,
 	}: {
 		class?: string;
 		onSelect: (transformation: Transformation) => void;
+		only: string;
 	} = $props();
 </script>
 
@@ -49,7 +51,7 @@
 				aria-expanded={combobox.open}
 				variant="ghost"
 				size="icon"
-				only="desktop"
+				{only}
 			>
 				<LayersIcon class="size-4" />
 			</WhisperingButton>

--- a/apps/whispering/src/routes/(config)/recordings/row-actions/TransformationPicker.svelte
+++ b/apps/whispering/src/routes/(config)/recordings/row-actions/TransformationPicker.svelte
@@ -49,6 +49,7 @@
 				aria-expanded={combobox.open}
 				variant="ghost"
 				size="icon"
+				only="desktop"
 			>
 				<LayersIcon class="size-4" />
 			</WhisperingButton>

--- a/apps/whispering/src/routes/(config)/recordings/row-actions/ViewTransformationRunsDialog.svelte
+++ b/apps/whispering/src/routes/(config)/recordings/row-actions/ViewTransformationRunsDialog.svelte
@@ -7,7 +7,7 @@
 	import { createQuery } from '@tanstack/svelte-query';
 	import { HistoryIcon } from '@lucide/svelte';
 
-	let { recordingId }: { recordingId: string } = $props();
+	let { recordingId, only }: { recordingId: string; only: string } = $props();
 
 	const transformationRunsByRecordingIdQuery = createQuery(
 		rpc.transformationRuns.getTransformationRunsByRecordingId(() => recordingId)
@@ -24,7 +24,7 @@
 				{...props}
 				variant="ghost"
 				size="icon"
-				only="desktop"
+				{only}
 				tooltipContent="View Transformation Runs"
 			>
 				<HistoryIcon class="size-4" />

--- a/apps/whispering/src/routes/(config)/recordings/row-actions/ViewTransformationRunsDialog.svelte
+++ b/apps/whispering/src/routes/(config)/recordings/row-actions/ViewTransformationRunsDialog.svelte
@@ -24,6 +24,7 @@
 				{...props}
 				variant="ghost"
 				size="icon"
+				only="desktop"
 				tooltipContent="View Transformation Runs"
 			>
 				<HistoryIcon class="size-4" />

--- a/packages/ui/src/button/button.svelte
+++ b/packages/ui/src/button/button.svelte
@@ -12,6 +12,7 @@
 		defaultVariants: {
 			size: 'default',
 			variant: 'default',
+			only: 'default',
 		},
 		variants: {
 			size: {
@@ -34,6 +35,11 @@
 				secondary:
 					'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
 			},
+			only: {
+				default: '',
+				mobile: 'md:hidden',
+				desktop: 'hidden md:flex'
+			}
 		},
 	});
 
@@ -57,6 +63,7 @@
 		size = 'default',
 		type = 'button',
 		variant = 'default',
+		only = 'default',
 		...restProps
 	}: ButtonProps = $props();
 </script>
@@ -65,7 +72,7 @@
 	<a
 		bind:this={ref}
 		data-slot="button"
-		class={cn(buttonVariants({ size, variant }), className)}
+		class={cn(buttonVariants({ size, variant, only }), className)}
 		href={disabled ? undefined : href}
 		aria-disabled={disabled}
 		role={disabled ? 'link' : undefined}
@@ -78,7 +85,7 @@
 	<button
 		bind:this={ref}
 		data-slot="button"
-		class={cn(buttonVariants({ size, variant }), className)}
+		class={cn(buttonVariants({ size, variant, only }), className)}
 		{type}
 		{disabled}
 		{...restProps}


### PR DESCRIPTION
This is an attempt to create more space for the textareas (and reduce visual clutter) on  Recordings list rows (https://github.com/epicenter-so/epicenter/issues/632)

- The ellipses menu only appears on mobile (sm + md Tailwind breakpoints)
- On desktop, all the action icons still appear without ellipses menu.

### Before:

<img width="619" height="146" alt="image" src="https://github.com/user-attachments/assets/b04c30ff-a4cb-4d83-ba4e-4c7ea4cb0d7a" />

### After:

<img width="526" height="172" alt="image" src="https://github.com/user-attachments/assets/b5cc7a2b-293f-45db-8f6f-6d4ad89671b3" />

### Things to consider:
- The ellipses icon is already used by the action buttons to indicate a transcription or transformation is in progress
  - An alternate ellipses icon (like vertical ellipses or circled ellipses) could be used to differentiate.
  - The pending/error state of a transformation will be hidden inside the ellipses menu on mobile.
- The edit button already disappeared on mobile, even before this PR.
  - The edit button was added to the ellipses menu, but does not appear.
  - This is because the [<Modal.Trigger> is not rendered](https://github.com/epicenter-so/epicenter/blob/2f3aa9690f8493085028ac7ccbf70ef8fbd4f9fd/apps/whispering/src/routes/(config)/recordings/row-actions/EditRecordingModal.svelte#L102-L261) on mobile and there is no <Drawer.Trigger>. 
