### PR TITLE
feat(Whispering): Adjust initial app size and page layouts.

### DIFF
--- a/apps/whispering/src-tauri/tauri.conf.json
+++ b/apps/whispering/src-tauri/tauri.conf.json
@@ -53,8 +53,8 @@
 			{
 				"resizable": true,
 				"title": "Whispering",
-				"width": 800,
-				"height": 600,
+				"width": 1000,
+				"height": 700,
 				"minHeight": 84,
 				"minWidth": 72
 			}


### PR DESCRIPTION
- 1000px was selected as a happy medium between the widths of the small home page and wider remaining pages (esp. the Recordings List.)
- 1000px was still quite narrow for the Recordings list, so at smaller breakpoints list item rows were broken up into subrows:
  1. Timestamp, id, title, etc
  2. Transcribed Text, Latest Transformation Output
  3. Audio, Action Buttons
- Motivation: it is easier to scroll down than across; an entire row can be viewed all at once.
  - (The single row layout that requires horizontal scrolling has been preserved at wider breakpoints.)
- To reduce visual clutter and maximize text shown, the 3rd subrow is hidden until hover
  - Mobile doesn't have hover, so the current work-around is to also show the 3rd subrow when the row is checked. The final version will investigate how to handle mobile better.
- The current code is an experiment resulting from several iterations with OpenCode. If there is general support for the direction this PR is going, better code will be investigated (less CSS, more tailwind, less conditional rendering/boilerplate, etc)

**Before:**
<img width="912" height="712" alt="image" src="https://github.com/user-attachments/assets/cc574baf-031f-4623-83ac-b019f0b4239b" />

**After:**
<img width="1112" height="812" alt="image" src="https://github.com/user-attachments/assets/87d79490-72a6-4143-bf51-cf87293941b2" />
