### PR TITLE
fix(ShortcutFormatHelp): improve modal scrolling and layout

### DIFF
--- a/apps/whispering/src/routes/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
+++ b/apps/whispering/src/routes/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
@@ -55,7 +55,7 @@
 </WhisperingButton>
 
 <Dialog.Root bind:open={dialogOpen}>
-	<Dialog.Content class="sm:max-w-3xl">
+	<Dialog.Content class="sm:max-w-3xl max-h-[83vh] overflow-y-hidden flex flex-col">
 		<Dialog.Header>
 			<Dialog.Title>
 				{isLocal ? 'Local' : 'Global'} Shortcut Format Guide
@@ -67,7 +67,7 @@
 			</Dialog.Description>
 		</Dialog.Header>
 
-		<div class="flex flex-col gap-4">
+		<div class="flex flex-col gap-4 overflow-y-auto flex-1 rounded-md">
 			<!-- Quick format summary -->
 			<div class="rounded-lg bg-muted p-4">
 				<p class="text-sm">

--- a/apps/whispering/src/routes/+layout/AppShell.svelte
+++ b/apps/whispering/src/routes/+layout/AppShell.svelte
@@ -120,6 +120,7 @@
 <Toaster
 	offset={16}
 	class="xs:block hidden"
+	style="z-index: 90;"
 	theme={mode.current}
 	{...TOASTER_SETTINGS}
 />

--- a/packages/ui/src/alert-dialog/alert-dialog-content.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-content.svelte
@@ -25,6 +25,8 @@
 		data-slot="alert-dialog-content"
 		class={cn(
 			'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+			// Override to z-[110] to ensure alert-dialogs appear above regular dialogs (z-[100])
+			'z-[110]',
 			className,
 		)}
 		{...restProps}

--- a/packages/ui/src/alert-dialog/alert-dialog-overlay.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-overlay.svelte
@@ -14,6 +14,8 @@
 	data-slot="alert-dialog-overlay"
 	class={cn(
 		'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+		// Override to z-[110] to ensure alert-dialogs appear above regular dialogs (z-[100])
+		'z-[110]',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/dialog/dialog-content.svelte
+++ b/packages/ui/src/dialog/dialog-content.svelte
@@ -29,8 +29,8 @@
 		class={cn(
 			'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
 			'overflow-y-auto max-h-[calc(100vh-2rem)]',
-			// Override to z-40 to ensure that alert-dialogs (which are at z-50) are always on top of dialogs
-			'z-40',
+			// Override to z-[100] to ensure dialogs appear above sticky headers (z-50)
+			'z-[100]',
 			className,
 		)}
 		{...restProps}

--- a/packages/ui/src/dialog/dialog-overlay.svelte
+++ b/packages/ui/src/dialog/dialog-overlay.svelte
@@ -14,8 +14,8 @@
 	data-slot="dialog-overlay"
 	class={cn(
 		'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
-		// Override to z-40 to ensure that alert-dialogs (which are at z-50) are always on top of dialogs
-		'z-40',
+		// Override to z-[100] to ensure dialogs appear above sticky headers (z-50)
+		'z-[100]',
 		className,
 	)}
 	{...restProps}


### PR DESCRIPTION
  - ✅ Fixed vertical overflow: Dialog won't exceed viewport height
  - ✅ Fixed navbar collision: 83vh leaves space for navbar
  - ✅ Better scrolling UX: Header/footer stay fixed, content scrolls
  - ✅ Proper border radius: Scrollable area respects modal corners
  - ❌ Navbar white space: Still present (scrollbar compensation issue)
  
  before: 
  
<img width="1279" height="800" alt="Screenshot 2025-08-21 at 1 11 28 PM" src="https://github.com/user-attachments/assets/a0ceb7c7-06a5-4201-a0de-547e9499c7c0" />


after: 

<img width="1279" height="800" alt="Screenshot 2025-08-21 at 1 12 13 PM" src="https://github.com/user-attachments/assets/7ad4fb70-36a9-4276-9268-cf91f6b90b00" />
