### PR TITLE
feat(whispering): add training opt-out setting for Deepgram

### DIFF
--- a/apps/whispering/src/lib/query/transcription.ts
+++ b/apps/whispering/src/lib/query/transcription.ts
@@ -217,6 +217,8 @@ async function transcribeBlob(
 							temperature: settings.value['transcription.temperature'],
 							apiKey: settings.value['apiKeys.deepgram'],
 							modelName: settings.value['transcription.deepgram.model'],
+							mipOptOut:
+								settings.value['transcription.deepgram.modelImprovementProgramOptOut'],
 						},
 					);
 				case 'whispercpp':

--- a/apps/whispering/src/lib/services/transcription/deepgram.ts
+++ b/apps/whispering/src/lib/services/transcription/deepgram.ts
@@ -72,6 +72,7 @@ export function createDeepgramTranscriptionService({
                 outputLanguage: Settings['transcription.outputLanguage'];
                 apiKey: string;
                 modelName: (string & {}) | DeepgramModel['name'];
+                mipOptOut?: boolean;
             },
         ): Promise<Result<string, WhisperingError>> {
             // Pre-validation: Check API key
@@ -111,6 +112,10 @@ export function createDeepgramTranscriptionService({
             
             if (options.prompt) {
                 params.append('keywords', options.prompt);
+            }
+
+            if (options.mipOptOut === true) {
+                params.append('mip_opt_out', 'true');
             }
 
             // Send raw audio data directly as recommended by Deepgram docs

--- a/apps/whispering/src/lib/settings/settings.ts
+++ b/apps/whispering/src/lib/settings/settings.ts
@@ -193,6 +193,10 @@ export const settingsSchema = z.object({
 		.string()
 		.transform((val) => val as (string & {}) | DeepgramModel['name'])
 		.default('nova-3' satisfies DeepgramModel['name']),
+	// Deepgram: Opt out of model improvement program
+	'transcription.deepgram.modelImprovementProgramOptOut': z
+		.boolean()
+		.default(false),
 	'transcription.speaches.baseUrl': z.string().default('http://localhost:8000'),
 	'transcription.speaches.modelId': z
 		.string()

--- a/apps/whispering/src/routes/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(config)/settings/transcription/+page.svelte
@@ -5,6 +5,7 @@
 		LabeledInput,
 		LabeledSelect,
 		LabeledTextarea,
+		LabeledSwitch,
 	} from '$lib/components/labeled/index.js';
 	import {
 		CompressionBody,
@@ -137,6 +138,19 @@
 			renderOption={renderModelOption}
 		/>
 		<DeepgramApiKeyInput />
+
+		<LabeledSwitch
+			id="deepgram-mip-opt-out"
+			label="Model Training Opt-Out (may increase costs)"
+			bind:checked={
+				() => settings.value['transcription.deepgram.modelImprovementProgramOptOut'],
+				(v) =>
+					settings.updateKey(
+						'transcription.deepgram.modelImprovementProgramOptOut',
+						v,
+					)
+			}
+		/>
 	{:else if settings.value['transcription.selectedTranscriptionService'] === 'ElevenLabs'}
 		<LabeledSelect
 			id="elevenlabs-model"


### PR DESCRIPTION
### Summary

This PR allows Whispering users using the Deepgram API to opt out of the Deepgram [Model Improvement Partnership Program](https://developers.deepgram.com/docs/the-deepgram-model-improvement-partnership-program) by adding the mip_opt_out=true parameter to their API requests. Users who opt-out using this switch will not have their transcriptions included within Deepgram's training dataset, but may incur an additional 50% cost for opting out.

### Changes:

- transcription.ts now includes a mipOptOut parameter for the Deepgram provider
- add a mipOptOut option to deepgram.ts
- add a default setting of false for mipOptOut in settings.ts
- add a LabeledSwitch to +page.svelte that allows a user to toggle mipOptOut, with a warning that it may increase costs.

I tested this by sending transcriptions to Deepgram, and reviewing my usage in Deepgram's console (Usage -> Logs), with the LabeledSwitch toggled to false and true respectively. 

Thank you as always for making this software freely available. 