### PR TITLE
feat: auto enter on over

### DIFF
--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -70,6 +70,7 @@ pub async fn run() {
     // Register command handlers (same for all platforms now)
     let builder = builder.invoke_handler(tauri::generate_handler![
         write_text,
+        press_enter,
         // Audio recorder commands
         get_current_recording_id,
         enumerate_recording_devices,
@@ -166,6 +167,34 @@ async fn write_text(app: tauri::AppHandle, text: String) -> Result<(), String> {
             .write_text(&content)
             .map_err(|e| format!("Failed to restore clipboard: {}", e))?;
     }
+
+    Ok(())
+}
+
+/// Simulates pressing the Enter key
+///
+/// This function simulates pressing the Enter key to trigger actions like submitting
+/// forms or sending messages. It's useful for automating user actions after
+/// transcription completes.
+#[tauri::command]
+async fn press_enter() -> Result<(), String> {
+    let mut enigo = Enigo::new(&Settings::default()).map_err(|e| e.to_string())?;
+
+    // Use virtual key codes for Enter/Return to work with any keyboard layout
+    #[cfg(target_os = "macos")]
+    let enter_key = Key::Other(36); // Virtual key code for Return on macOS
+    #[cfg(target_os = "windows")]
+    let enter_key = Key::Other(0x0D); // VK_RETURN on Windows
+    #[cfg(target_os = "linux")]
+    let enter_key = Key::Return; // Return key on Linux
+
+    // Press and release Enter
+    enigo
+        .key(enter_key, Direction::Press)
+        .map_err(|e| format!("Failed to press Enter key: {}", e))?;
+    enigo
+        .key(enter_key, Direction::Release)
+        .map_err(|e| format!("Failed to release Enter key: {}", e))?;
 
     Ok(())
 }

--- a/apps/whispering/src/lib/query/text.ts
+++ b/apps/whispering/src/lib/query/text.ts
@@ -18,4 +18,11 @@ export const text = {
 			return await services.text.writeToCursor(text);
 		},
 	}),
+	pressEnter: defineMutation({
+		mutationKey: ['text', 'pressEnter'],
+		resultMutationFn: async () => {
+			// Simulates pressing the Enter key
+			return await services.text.pressEnter();
+		},
+	}),
 };

--- a/apps/whispering/src/lib/services/text/desktop.ts
+++ b/apps/whispering/src/lib/services/text/desktop.ts
@@ -31,5 +31,17 @@ export function createTextServiceDesktop(): TextService {
 						cause: error,
 					}),
 			}),
+
+		pressEnter: () =>
+			tryAsync({
+				try: () => invoke<void>('press_enter'),
+				catch: (error) =>
+					TextServiceErr({
+						message:
+							'There was an error simulating the Enter key press. Please try pressing Enter manually.',
+						context: {},
+						cause: error,
+					}),
+			}),
 	};
 }

--- a/apps/whispering/src/lib/services/text/types.ts
+++ b/apps/whispering/src/lib/services/text/types.ts
@@ -20,16 +20,23 @@ export type TextService = {
 	/**
 	 * Writes the provided text at the current cursor position.
 	 * Uses the clipboard sandwich technique to preserve the user's existing clipboard content.
-	 * 
+	 *
 	 * This method:
 	 * 1. Saves the current clipboard
 	 * 2. Writes the text to clipboard
 	 * 3. Simulates paste (Cmd+V on macOS, Ctrl+V elsewhere)
 	 * 4. Restores the original clipboard
-	 * 
+	 *
 	 * @param text The text to write at the cursor position.
 	 */
 	writeToCursor: (
 		text: string,
 	) => MaybePromise<Result<void, TextServiceError | WhisperingError>>;
+
+	/**
+	 * Simulates pressing the Enter key.
+	 * This is useful for automatically submitting forms or sending messages
+	 * after transcription completes.
+	 */
+	pressEnter: () => Promise<Result<void, TextServiceError>>;
 };

--- a/apps/whispering/src/lib/services/text/web.ts
+++ b/apps/whispering/src/lib/services/text/web.ts
@@ -35,5 +35,15 @@ export function createTextServiceWeb(): TextService {
 				cause: undefined,
 			});
 		},
+
+		pressEnter: async () => {
+			// In web browsers, we cannot programmatically simulate key presses for security reasons
+			return TextServiceErr({
+				message:
+					'Enter key simulation is not supported in web browsers for security reasons. Please press Enter manually.',
+				context: {},
+				cause: undefined,
+			});
+		},
 	};
 }


### PR DESCRIPTION
# Add automatic Enter key press on "Over" voice command

  This feature enables hands-free message submission by automatically pressing Enter when transcribed audio ends with "Over".

  ## What it does

  When recording audio that ends with "Over" (case-insensitive, with optional punctuation), the system will:
  1. Remove "Over" from the transcribed text before delivery
  2. Deliver the cleaned text normally (clipboard/cursor writing)
  3. Automatically press Enter to submit the message

  ## Use case

  Perfect for voice-to-chat workflows with Claude or other interfaces where you want to record a message, have it transcribed and automatically submitted without
  manual interaction.

  **Example:**
  - Say: "Hello Claude, can you help me debug this code? Over."
  - Result: "Hello Claude, can you help me debug this code?" → *Enter pressed automatically*

  ## Implementation

  **Backend (Rust):**
  - Added `press_enter()` function using existing `enigo` library with cross-platform key codes
  - Registered new Tauri command handler

  **Frontend (TypeScript):**
  - Extended text service interface with `pressEnter()` method
  - Added detection utilities in `transcription-triggers.ts`:
    - `shouldTriggerEnterOnOver()` - detects "Over" at text end
    - `removeOverFromEnd()` - cleanly strips "Over" and punctuation
  - Integrated into delivery pipeline to process text before clipboard/cursor operations

  **Flow:**
  1. Transcription completes with "Over" detection
  2. Text gets cleaned (Over removed) before any delivery operations
  3. Normal delivery proceeds with cleaned text (clipboard, notifications, etc.)
  4. Enter key automatically pressed after 200ms delay
