### PR TITLE
Fix: Deepgram Nova-3 fails when system prompts are used due to unsupported keywords parameter

### DIFF
--- a/apps/whispering/src/lib/services/transcription/cloud/deepgram.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/deepgram.ts
@@ -113,7 +113,12 @@ export function createDeepgramTranscriptionService({
 			}
 
 			if (options.prompt) {
-				params.append('keywords', options.prompt);
+				const promptParameter = options.modelName
+    					.toLowerCase()
+    					.startsWith('nova-3')
+    					? 'keyterm'
+    					: 'keywords';
+    				params.append(promptParameter, options.prompt);
 			}
 
 			// Send raw audio data directly as recommended by Deepgram docs

--- a/apps/whispering/src/lib/services/transcription/cloud/deepgram.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/deepgram.ts
@@ -112,14 +112,10 @@ export function createDeepgramTranscriptionService({
 				params.append('language', options.outputLanguage);
 			}
 
-			if (options.prompt) {
-				const promptParameter = options.modelName
-    					.toLowerCase()
-    					.startsWith('nova-3')
-    					? 'keyterm'
-    					: 'keywords';
-    				params.append(promptParameter, options.prompt);
-			}
+		if (options.prompt) {
+			const isNova3 = options.modelName.toLowerCase().includes('nova-3');
+			params.append(isNova3 ? 'keyterm' : 'keywords', options.prompt);
+		}
 
 			// Send raw audio data directly as recommended by Deepgram docs
 			const { data: deepgramResponse, error: postError } =


### PR DESCRIPTION
When using Deepgram’s **Nova-3** model with system prompts, transcription requests fail, even though **Nova-2** handles them correctly.
The issue is caused by Nova-3 no longer supporting the `keywords` query parameter. The API now requires the `keyterm` parameter instead.

### Error Log

```json
{
  "err_code": "INVALID_QUERY_PARAMETER",
  "err_msg": "Keywords are not supported for Nova-3. Please use `keyterm` instead.",
  "request_id": "85cc44f8-f1d5-4281-99b0-fbfcb5797dd4"
}
```

### Steps to Reproduce

1. Use Deepgram Nova-3 with a system prompt in the request.
2. Observe the error message indicating `keywords` is not supported.
3. Run the same setup with Nova-2 — it works as expected.


### Expected Behavior

Nova-3 should process system prompts successfully without returning an invalid query parameter error.

### Proposed Solution

This PR replaces the deprecated keywords parameter with keyterm for Nova-3 requests to ensure compatibility with the latest Deepgram API.