### PR TITLE
fix(ffmpeg): prevent race condition on Windows with file verification

### DIFF
--- a/apps/whispering/src/lib/services/ffmpeg/desktop.ts
+++ b/apps/whispering/src/lib/services/ffmpeg/desktop.ts
@@ -57,6 +57,17 @@ export function createFfmpegService(): FfmpegService {
 						const inputContents = new Uint8Array(await blob.arrayBuffer());
 						await writeFile(inputPath, inputContents);
 
+						// Verify file is accessible (forces OS flush on Windows)
+						const { error: verifyError } = await tryAsync({
+							try: () => services.fs.pathToBlob(inputPath),
+							catch: (error) =>
+								FfmpegServiceErr({
+									message: 'Temp file not accessible',
+									cause: error,
+								}),
+						});
+						if (verifyError) throw new Error(verifyError.message);
+
 						// Build FFmpeg command for compression using the utility function
 						const command = buildCompressionCommand({
 							inputPath,


### PR DESCRIPTION
This adds file verification after writing temporary files to force Windows OS buffer flushing, preventing race conditions where FFmpeg attempts to read files before they're fully written to disk.