### PR TITLE
fix(ci): rename GITHUB_* secrets and env vars to GH_*

### DIFF
--- a/.github/workflows/add-sponsors-to-readme.yml
+++ b/.github/workflows/add-sponsors-to-readme.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Generate Sponsors 💖
         uses: JamesIves/github-sponsors-readme-action@v1
         with:
-          token: ${{ secrets.GITHUB_ACTIONS_PAT }}
+          token: ${{ secrets.GH_ACTIONS_PAT }}
           file: 'README.md'
 
       - name: Deploy to GitHub Pages 🚀

--- a/.github/workflows/sync-agents-files.yml
+++ b/.github/workflows/sync-agents-files.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_ACTIONS_PAT }}
+          token: ${{ secrets.GH_ACTIONS_PAT }}
           fetch-depth: 0  # Full history for better diff analysis
       
       - name: Check if sync is needed

--- a/.github/workflows/sync-releases-epicenter-to-whispering.yml
+++ b/.github/workflows/sync-releases-epicenter-to-whispering.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Check if release exists in downstream
         id: check_release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_ACTIONS_PAT }}
+          GH_TOKEN: ${{ secrets.GH_ACTIONS_PAT }}
         run: |
           TAG="${{ steps.get_tag.outputs.tag }}"
           if gh release view "$TAG" --repo braden-w/whispering >/dev/null 2>&1; then
@@ -73,7 +73,7 @@ jobs:
       - name: Delete existing release if it exists
         if: steps.check_release.outputs.exists == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_ACTIONS_PAT }}
+          GH_TOKEN: ${{ secrets.GH_ACTIONS_PAT }}
         run: |
           TAG="${{ steps.get_tag.outputs.tag }}"
           echo "Deleting existing release $TAG..."
@@ -81,7 +81,7 @@ jobs:
 
       - name: Create release in downstream repository
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_ACTIONS_PAT }}
+          GH_TOKEN: ${{ secrets.GH_ACTIONS_PAT }}
         run: |
           TAG="${{ steps.get_tag.outputs.tag }}"
           NAME="${{ steps.source_release.outputs.name }}"

--- a/.github/workflows/update-readme-version.yml
+++ b/.github/workflows/update-readme-version.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           # Use a PAT or the default token with proper permissions
-          token: ${{ secrets.GITHUB_ACTIONS_PAT }}
+          token: ${{ secrets.GH_ACTIONS_PAT }}
           # Fetch all history for proper git operations
           fetch-depth: 0
 

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -44,8 +44,8 @@ export const auth = (env: CloudflareEnv) => {
 		database: drizzleAdapter(db, { provider: 'pg' }),
 		socialProviders: {
 			github: {
-				clientId: env.GITHUB_CLIENT_ID,
-				clientSecret: env.GITHUB_CLIENT_SECRET,
+				clientId: env.GH_CLIENT_ID,
+				clientSecret: env.GH_CLIENT_SECRET,
 			},
 		},
 		trustedOrigins: APP_URLS(env),

--- a/packages/constants/src/cloudflare.ts
+++ b/packages/constants/src/cloudflare.ts
@@ -14,8 +14,8 @@ const cloudflareEnvSchema = type({
 	DATABASE_URL: 'string.url',
 	BETTER_AUTH_URL: 'string.url',
 	BETTER_AUTH_SECRET: 'string',
-	GITHUB_CLIENT_ID: 'string',
-	GITHUB_CLIENT_SECRET: 'string',
+	GH_CLIENT_ID: 'string',
+	GH_CLIENT_SECRET: 'string',
 });
 
 export function validateCloudflareEnv(env: unknown): CloudflareEnv {

--- a/packages/constants/src/node.ts
+++ b/packages/constants/src/node.ts
@@ -13,8 +13,8 @@ const nodeEnvSchema = type({
 	DATABASE_URL: 'string.url',
 	BETTER_AUTH_URL: 'string.url',
 	BETTER_AUTH_SECRET: 'string',
-	GITHUB_CLIENT_ID: 'string',
-	GITHUB_CLIENT_SECRET: 'string',
+	GH_CLIENT_ID: 'string',
+	GH_CLIENT_SECRET: 'string',
 });
 
 export function validateNodeEnv(env: unknown): NodeEnv {


### PR DESCRIPTION
This fixes the release sync workflow that has been failing silently.

GitHub doesn't allow secrets or environment variables that start with `GITHUB_` prefix as it's reserved for built-in variables. The release sync from epicenter-md/epicenter to braden-w/whispering has been stuck at v7.5.1 while the main repo is at v7.5.5 because the workflow was failing with an empty `GH_TOKEN`.

This PR renames all `GITHUB_*` prefixed secrets and environment variables to `GH_*` to comply with GitHub's naming restrictions.

**Workflow Changes:**
- All workflows now use `GH_ACTIONS_PAT` instead of `GITHUB_ACTIONS_PAT`

**Environment Variable Changes:**
- `GITHUB_CLIENT_ID` → `GH_CLIENT_ID`
- `GITHUB_CLIENT_SECRET` → `GH_CLIENT_SECRET`

**Action Required After Merge:**
1. Add the `GH_ACTIONS_PAT` secret to the epicenter-md/epicenter repository with a Personal Access Token that has `repo` scope
2. Update your `.env` files to use `GH_CLIENT_ID` and `GH_CLIENT_SECRET`
3. Manually sync the missing releases (v7.5.2, v7.5.3, v7.5.4, v7.5.5) using the workflow_dispatch trigger