### PR TITLE
revert: disable experimental Biome Svelte support

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -21,14 +21,9 @@
 			"!pnpm-lock.yaml",
 			"!yarn.lock",
 			"!.DS_Store",
+			"!**/*.svelte",
 			"!**/*.astro"
 		]
-	},
-	"html": {
-		"experimentalFullSupportEnabled": true,
-		"formatter": {
-			"indentScriptAndStyle": false
-		}
 	},
 	"formatter": {
 		"enabled": true,

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
 	"scripts": {
 		"build": "turbo run build",
 		"dev": "turbo run dev",
-		"format": "biome check --write --linter-enabled=false; prettier --write \"**/*.{astro,html}\"",
-		"format:check": "biome ci --linter-enabled=false; prettier --check \"**/*.{astro,html}\"",
+		"format": "biome check --write --linter-enabled=false; prettier --write \"**/*.{svelte,astro,html}\"",
+		"format:check": "biome ci --linter-enabled=false; prettier --check \"**/*.{svelte,astro,html}\"",
 		"lint": "concurrently -raw \"turbo run lint\" \"eslint\" \"biome lint\"",
 		"check": "turbo run check",
 		"format-and-lint": "concurrently \"bun run format\" \"bun run lint\"",


### PR DESCRIPTION
This partially reverts PR #923 by disabling Biome's experimental Svelte support while keeping the Biome 2.3.1 upgrade. While the version upgrade is valuable, Biome's experimental Svelte support is not yet stable enough for production use.

The changes restore Prettier as the formatter for .svelte files by adding them back to Biome's ignore list and removing the `html.experimentalFullSupportEnabled` configuration. This ensures Svelte files continue to be formatted consistently while we wait for Biome's Svelte support to mature.

Biome 2.3.1 remains upgraded and continues to handle all TypeScript, JavaScript, and other supported file types.