### PR TITLE
refactor(macos-accessibility): migrate Command.create to services.command.execute

### DIFF
--- a/apps/whispering/src/routes/(config)/macos-enable-accessibility/+page.svelte
+++ b/apps/whispering/src/routes/(config)/macos-enable-accessibility/+page.svelte
@@ -5,7 +5,7 @@
 	import { SettingsIcon, CheckIcon, ArrowLeft } from '@lucide/svelte';
 	import * as services from '$lib/services';
 	import { toast } from 'svelte-sonner';
-	import { Command } from '@tauri-apps/plugin-shell';
+	import { asShellCommand } from '$lib/services/command/types';
 	import type { PageData } from './$types';
 	import { goto } from '$app/navigation';
 
@@ -28,21 +28,13 @@
 	}
 
 	async function openSystemSettings() {
-		try {
-			// Try opening System Settings directly (works on macOS 13+)
-			const command = Command.create('open', [
-				'x-apple.systemsettings:com.apple.SystemSettings.extension',
-			]);
-			await command.execute();
+		// Try opening System Settings directly (works on macOS 13+)
+		const { error: commandError } = await services.command.execute(
+			asShellCommand('open x-apple.systemsettings:com.apple.SystemSettings.extension'),
+		);
 
-			// Show helpful toast since we can't open directly to accessibility
-			toast.info('System Settings Opened', {
-				description:
-					'Navigate to Privacy & Security > Accessibility to grant permissions.',
-				duration: 8000,
-			});
-		} catch (error) {
-			console.error('Failed to open System Settings:', error);
+		if (commandError) {
+			console.error('Failed to open System Settings:', commandError);
 
 			// Fallback: Show detailed instructions
 			toast.info('Open System Settings Manually', {
@@ -50,7 +42,15 @@
 					'Click Apple menu → System Settings → Privacy & Security → Accessibility',
 				duration: 10000,
 			});
+			return;
 		}
+
+		// Show helpful toast since we can't open directly to accessibility
+		toast.info('System Settings Opened', {
+			description:
+				'Navigate to Privacy & Security > Accessibility to grant permissions.',
+			duration: 8000,
+		});
 	}
 </script>
 


### PR DESCRIPTION
This completes the migration from `Command.create` to the unified `services.command.execute` pattern for the macOS accessibility settings page.

The unified command service provides consistent error handling, prevents Windows console flash, and offers better logging across the codebase. This was the last remaining instance of the old `Command.create` pattern in production code.

Changes:
- Replaced `Command.create('open', [...])` with `services.command.execute(asShellCommand(...))`
- Simplified error handling using Result types instead of try-catch
- Maintained the same user-facing behavior with improved error logging