### PR TITLE
feat: update Anthropic models to latest Claude 4.5 generation

### DIFF
--- a/apps/whispering/src/lib/constants/inference/anthropic-models.ts
+++ b/apps/whispering/src/lib/constants/inference/anthropic-models.ts
@@ -4,9 +4,30 @@
  */
 
 export const ANTHROPIC_INFERENCE_MODELS = [
-	'claude-opus-4-0',
-	'claude-sonnet-4-0',
-	'claude-3-7-sonnet-latest',
+	// Claude 4.5 models (latest generation - recommended)
+	'claude-sonnet-4-5-20250929',
+	'claude-sonnet-4-5', // alias for latest Sonnet 4.5
+	'claude-haiku-4-5-20251001',
+	'claude-haiku-4-5', // alias for latest Haiku 4.5
+	'claude-opus-4-1-20250805',
+	'claude-opus-4-1', // alias for latest Opus 4.1
+	
+	// Claude 4 models (legacy but still available)
+	'claude-sonnet-4-20250514',
+	'claude-sonnet-4-0', // alias
+	'claude-opus-4-20250514',
+	'claude-opus-4-0', // alias
+	
+	// Claude 3.7 models (legacy)
+	'claude-3-7-sonnet-20250219',
+	'claude-3-7-sonnet-latest', // alias
+	
+	// Claude 3.5 models (legacy)
+	'claude-3-5-haiku-20241022',
+	'claude-3-5-haiku-latest', // alias
+	
+	// Claude 3 models (legacy)
+	'claude-3-haiku-20240307',
 ] as const;
 
 export const ANTHROPIC_INFERENCE_MODEL_OPTIONS = ANTHROPIC_INFERENCE_MODELS.map(


### PR DESCRIPTION
This PR updates the Anthropic models configuration to include the latest Claude 4.5 generation models while maintaining backwards compatibility with legacy models.

The update adds Claude 4.5 Sonnet, Claude 4.5 Haiku, and Claude 4.1 Opus models with both their specific snapshot dates and aliases. All legacy Claude 4, 3.7, 3.5, and 3 models remain available for backwards compatibility. Models are now organized by generation with clear comments for better maintainability.

All models are sourced from the official Anthropic documentation as of January 2025.