### PR TITLE
fix(shortcuts): unregister old global shortcuts before reset

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -63,7 +63,7 @@ While using Epicenter:
 
 ## Disclosure Policy
 
-We follow the principle of [Coordinated Vulnerability Disclosure](https://vuls.cert.org/confluence/display/Wiki/Vulnerability+Disclosure+Policy):
+We follow the principle of [Coordinated Vulnerability Disclosure](https://certcc.github.io/CERT-Guide-to-CVD/):
 
 1. Security issues are handled with highest priority
 2. We work privately with reporters to understand and fix issues

--- a/apps/whispering/src/lib/query/shortcuts.ts
+++ b/apps/whispering/src/lib/query/shortcuts.ts
@@ -61,4 +61,9 @@ export const shortcuts = {
 			return await services.globalShortcutManager.unregister(accelerator);
 		},
 	}),
+
+	unregisterAllGlobalShortcuts: defineMutation({
+		mutationKey: ['shortcuts', 'unregisterAllGlobalShortcuts'] as const,
+		resultMutationFn: async () => services.globalShortcutManager.unregisterAll(),
+	}),
 };

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/global/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/global/+page.svelte
@@ -34,7 +34,8 @@
 			<Button
 				variant="outline"
 				size="sm"
-				onclick={() => {
+				onclick={async () => {
+					await rpc.shortcuts.unregisterAllGlobalShortcuts.execute();
 					settings.resetGlobalShortcuts();
 					rpc.notify.success.execute({
 						title: 'Shortcuts reset',


### PR DESCRIPTION
## Summary

Fixed the "Reset to defaults" button for global shortcuts. Previously, old shortcuts stayed active alongside new ones until you restarted the app. Now they're unregistered immediately when you hit reset.

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `refactor`: Code refactoring (no functional changes)
- [ ] `perf`: Performance improvement
- [ ] `test`: Test additions or changes
- [ ] `chore`: Maintenance tasks
- [ ] `style`: Code style changes

## Changes Made

Added `unregisterAllGlobalShortcuts` RPC endpoint and called it before re-registering shortcuts. Global shortcuts use Tauri's system API which adds registrations rather than replacing them, so we need to clear old ones first.

## Testing

### Desktop App Testing
- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] Not applicable (web-only change)

### General Testing
- [ ] Tested with multiple API providers (if applicable)
- [x] Verified no API keys are exposed in logs or storage
- [x] Checked for console errors
- [ ] Tested on different screen sizes (if UI change)

## Checklist

- [x] My code follows the project's coding standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I've used `type` instead of `interface` in TypeScript
- [x] I've used absolute imports where applicable
- [x] I've tested my changes thoroughly
- [ ] I've added/updated tests for my changes (if applicable)
- [x] My changes don't break existing functionality
- [ ] I've updated documentation (if needed)

## Screenshots/Recordings

Not applicable - backend logic change only.

## Additional Notes

Local shortcuts don't have this issue because they use a Map keyed by command ID, which automatically replaces entries. Global shortcuts needed explicit unregistration.
