### PR TITLE
refactor(commands): always return Ok after notifying errors

### DIFF
--- a/apps/whispering/src/lib/commands.ts
+++ b/apps/whispering/src/lib/commands.ts
@@ -1,6 +1,14 @@
 import { rpc } from '$lib/query';
 import type { ShortcutTriggerState } from './services/_shortcut-trigger-state';
 
+/**
+ * Registry of available commands in the application.
+ * Defines what commands exist and how they're triggered (keyboard shortcuts, voice, command palette, etc.).
+ *
+ * The actual command implementations live in /lib/query/actions.ts as reusable mutations
+ * that can be invoked from anywhere in the UI, not just through this command registry.
+ */
+
 type SatisfiedCommand = {
 	id: string;
 	title: string;

--- a/apps/whispering/src/lib/query/README.md
+++ b/apps/whispering/src/lib/query/README.md
@@ -863,9 +863,9 @@ Each feature file typically exports an object with:
 - Helper functions
 - Utility methods
 
-## Commands: Always Return Ok
+## Actions: Always Return Ok
 
-Commands in the query layer always return `Ok` after handling errors. They notify the user and return success because the command itself executed—error handling is part of that execution.
+Actions in the query layer always return `Ok` after handling errors. They notify the user and return success because the action itself executed—error handling is part of that execution.
 
 ```typescript
 const startManualRecording = defineMutation({
@@ -873,7 +873,7 @@ const startManualRecording = defineMutation({
 		const { error } = await recorder.startRecording.execute();
 		if (error) {
 			notify.error.execute(error); // Notify user
-			return Ok(undefined);         // Command succeeded
+			return Ok(undefined);         // Action succeeded
 		}
 		notify.success.execute({ title: 'Recording started' });
 		return Ok(undefined);
@@ -881,7 +881,7 @@ const startManualRecording = defineMutation({
 });
 ```
 
-Commands are invoked by the UI command handler (`/lib/commands.ts`), which calls these mutations. The UI handler doesn't need to check for errors because they're already handled at the query layer.
+Actions are UI-boundary mutations invoked from anywhere: command registry (`/lib/commands.ts`), components, stores, etc. Since they're the end of the operation chain, errors flow sideways through notifications rather than up the call stack.
 
 ## Best Practices
 

--- a/apps/whispering/src/lib/query/README.md
+++ b/apps/whispering/src/lib/query/README.md
@@ -863,6 +863,53 @@ Each feature file typically exports an object with:
 - Helper functions
 - Utility methods
 
+## Commands: Terminal Operations That Always Succeed
+
+Commands are special mutations that represent the end of an operation chain. They handle errors by notifying the user and then returning `Ok`, since from the command's perspective, it successfully executed (including handling any failures).
+
+```typescript
+// ✅ Command Pattern: notify error, then return Ok
+const startManualRecording = defineMutation({
+	mutationKey: ['commands', 'startManualRecording'] as const,
+	resultMutationFn: async () => {
+		const { data, error } = await recorder.startRecording.execute();
+
+		// Error occurred? Notify the user.
+		if (error) {
+			notify.error.execute(error);
+			return Ok(undefined); // Command itself succeeded
+		}
+
+		// Continue with success path
+		notify.success.execute({ title: 'Recording started' });
+		return Ok(undefined);
+	},
+});
+
+// ❌ Anti-pattern: returning Err from a command
+// const { error } = await startManualRecording.execute();
+// if (error) { /* Can't do anything - command already failed */ }
+```
+
+### Why Commands Always Return Ok
+
+Commands sit at the UI boundary where errors are already communicated to the user. The command's job is to coordinate operations and show notifications. Since it does this successfully (even when the underlying operations fail), it returns `Ok` to signal "the command executed and handled its result appropriately."
+
+This simplifies error handling because:
+1. Errors are already shown to the user via notifications
+2. Command handlers don't need to check error results
+3. The distinction between "operation failed" and "command succeeded" becomes clear
+
+### Command Pattern Examples
+
+**Recording commands** (`/lib/query/commands.ts`):
+- `startManualRecording`, `stopManualRecording`
+- `startVadRecording`, `stopVadRecording`
+- `toggleManualRecording`, `cancelManualRecording`
+- `uploadRecordings`, `runTransformationOnClipboard`
+
+All follow the same pattern: handle errors with `notify.error.execute()`, then return `Ok`.
+
 ## Best Practices
 
 1. Always use Result types - Never throw errors in query/mutation functions
@@ -871,13 +918,14 @@ Each feature file typically exports an object with:
    - **In `.ts` files**: Always use `.execute()` since createMutation requires component context
    - This gives you consistent loading states, error handling, and better UX in components
 3. **Mutation callback pattern**: When using `createMutation`, pass callbacks as the second argument to `.mutate()` for maximum context
-4. Choose the right interface for the job:
+4. **Command pattern**: Commands always return `Ok` after notifying errors, since they represent terminal operations
+5. Choose the right interface for the job:
    - Use `.execute()` in `.ts` files and when you don't need pending state
    - Use `createMutation()` when you need reactive state for UI feedback
-5. Keep queries simple - Complex logic belongs in services or orchestration mutations
-6. Update cache optimistically - Better UX for mutations
-7. Use proper query keys - Hierarchical and consistent
-8. Leverage direct client access - Our static architecture enables powerful patterns unavailable in SSR apps
+6. Keep queries simple - Complex logic belongs in services or orchestration mutations
+7. Update cache optimistically - Better UX for mutations
+8. Use proper query keys - Hierarchical and consistent
+9. Leverage direct client access - Our static architecture enables powerful patterns unavailable in SSR apps
 
 ## Quick Reference: Common RPC Patterns
 

--- a/apps/whispering/src/lib/query/actions.ts
+++ b/apps/whispering/src/lib/query/actions.ts
@@ -17,9 +17,12 @@ import { transformer } from './transformer';
 import { vadRecorder } from './vad-recorder';
 
 /**
- * Query layer commands. These mutations always return Ok() after handling errors.
- * Errors are notified to the user and then the command succeeds, so the UI command
- * handler doesn't need to check for errors.
+ * Application actions. These are mutations at the UI boundary that can be invoked
+ * from anywhere: command registry, components, stores, etc.
+ *
+ * They always return Ok() because there's nowhere left to propagate errors—errors flow
+ * sideways through notify.error.execute() instead of up the call stack. Actions are
+ * the end of the operation chain.
  */
 
 // Track manual recording start time for duration calculation

--- a/apps/whispering/src/lib/query/commands.ts
+++ b/apps/whispering/src/lib/query/commands.ts
@@ -36,7 +36,7 @@ const startManualRecording = defineMutation({
 
 		if (startRecordingError) {
 			notify.error.execute({ id: toastId, ...startRecordingError });
-			return Err(startRecordingError);
+			return Ok(undefined);
 		}
 
 		switch (deviceAcquisitionOutcome.outcome) {
@@ -107,7 +107,7 @@ const stopManualRecording = defineMutation({
 			await recorder.stopRecording.execute({ toastId });
 		if (stopRecordingError) {
 			notify.error.execute({ id: toastId, ...stopRecordingError });
-			return Err(stopRecordingError);
+			return Ok(undefined);
 		}
 
 		notify.success.execute({
@@ -190,7 +190,7 @@ const startVadRecording = defineMutation({
 			});
 		if (startActiveListeningError) {
 			notify.error.execute({ id: toastId, ...startActiveListeningError });
-			return Err(startActiveListeningError);
+			return Ok(undefined);
 		}
 
 		// Handle device acquisition outcome
@@ -260,7 +260,7 @@ const stopVadRecording = defineMutation({
 			await vadRecorder.stopActiveListening.execute(undefined);
 		if (stopVadError) {
 			notify.error.execute({ id: toastId, ...stopVadError });
-			return Err(stopVadError);
+			return Ok(undefined);
 		}
 		notify.success.execute({
 			id: toastId,
@@ -286,7 +286,7 @@ export const commands = {
 				await recorder.getRecorderState.fetch();
 			if (getRecorderStateError) {
 				notify.error.execute(getRecorderStateError);
-				return Err(getRecorderStateError);
+				return Ok(undefined);
 			}
 			if (recorderState === 'RECORDING') {
 				return await stopManualRecording.execute(undefined);
@@ -309,7 +309,7 @@ export const commands = {
 				await recorder.cancelRecording.execute({ toastId });
 			if (cancelRecordingError) {
 				notify.error.execute({ id: toastId, ...cancelRecordingError });
-				return Err(cancelRecordingError);
+				return Ok(undefined);
 			}
 			switch (cancelRecordingResult.status) {
 				case 'no-recording': {
@@ -506,7 +506,7 @@ export const commands = {
 
 			if (transformError) {
 				notify.error.execute({ id: toastId, ...transformError });
-				return Err(transformError);
+				return Ok(undefined);
 			}
 
 			sound.playSoundIfEnabled.execute('transformationComplete');

--- a/apps/whispering/src/lib/query/commands.ts
+++ b/apps/whispering/src/lib/query/commands.ts
@@ -16,6 +16,31 @@ import { transcription } from './transcription';
 import { transformer } from './transformer';
 import { vadRecorder } from './vad-recorder';
 
+/**
+ * Commands are terminal mutations at the UI boundary. They handle errors by notifying the user
+ * and then returning Ok(). This pattern simplifies error handling because:
+ *
+ * 1. Errors are communicated to the user via notifications (not error propagation)
+ * 2. Commands represent successful execution even when underlying operations fail
+ * 3. Command handlers don't need to check or handle error results
+ *
+ * Example:
+ * ```typescript
+ * if (error) {
+ *   notify.error.execute(error);  // Show error to user
+ *   return Ok(undefined);          // Command executed successfully
+ * }
+ * ```
+ *
+ * NOT:
+ * ```typescript
+ * if (error) {
+ *   notify.error.execute(error);
+ *   return Err(error);  // ❌ Unnecessary error propagation
+ * }
+ * ```
+ */
+
 // Track manual recording start time for duration calculation
 let manualRecordingStartTime: number | null = null;
 

--- a/apps/whispering/src/lib/query/commands.ts
+++ b/apps/whispering/src/lib/query/commands.ts
@@ -17,28 +17,9 @@ import { transformer } from './transformer';
 import { vadRecorder } from './vad-recorder';
 
 /**
- * Commands are terminal mutations at the UI boundary. They handle errors by notifying the user
- * and then returning Ok(). This pattern simplifies error handling because:
- *
- * 1. Errors are communicated to the user via notifications (not error propagation)
- * 2. Commands represent successful execution even when underlying operations fail
- * 3. Command handlers don't need to check or handle error results
- *
- * Example:
- * ```typescript
- * if (error) {
- *   notify.error.execute(error);  // Show error to user
- *   return Ok(undefined);          // Command executed successfully
- * }
- * ```
- *
- * NOT:
- * ```typescript
- * if (error) {
- *   notify.error.execute(error);
- *   return Err(error);  // ❌ Unnecessary error propagation
- * }
- * ```
+ * Query layer commands. These mutations always return Ok() after handling errors.
+ * Errors are notified to the user and then the command succeeds, so the UI command
+ * handler doesn't need to check for errors.
  */
 
 // Track manual recording start time for duration calculation

--- a/apps/whispering/src/lib/query/index.ts
+++ b/apps/whispering/src/lib/query/index.ts
@@ -1,6 +1,6 @@
 // Import all query modules
 import { analytics } from './analytics';
-import { commands } from './commands';
+import { commands } from './actions';
 import { db } from './db';
 import { delivery } from './delivery';
 import { download } from './download';


### PR DESCRIPTION
Commands are terminal operations in the UI layer. Instead of propagating errors up the chain, they handle them by notifying the user and returning Ok to indicate the command itself executed successfully.

This change applies a consistent pattern across all command handlers: when an error occurs, we call `notify.error.execute()` to show the error to the user, then return `Ok(undefined)` rather than `Err(error)`. This makes semantic sense because from the command's perspective, it successfully handled the operation (including handling its failure).

Updated 7 command handlers:
- startManualRecording
- stopManualRecording
- startVadRecording
- stopVadRecording
- toggleManualRecording
- cancelManualRecording
- runTransformationOnClipboard

The net result is cleaner error handling that doesn't require propagating error states through the mutation layer.