### PR TITLE
feat: vertical navigation

### DIFF
--- a/apps/whispering/src/lib/components/NavItems.svelte
+++ b/apps/whispering/src/lib/components/NavItems.svelte
@@ -19,27 +19,28 @@
 	let {
 		class: className,
 		collapsed = false,
-	}: { class?: string; collapsed?: boolean } = $props();
+		pathPrefix = '',
+	}: { class?: string; collapsed?: boolean; pathPrefix?: string } = $props();
 
 	const navItems = [
 		{
 			label: 'Recordings',
 			icon: ListIcon,
 			type: 'anchor',
-			href: '/recordings',
+			href: `${pathPrefix}/recordings`,
 		},
 		{
 			label: 'Transformations',
 			icon: LayersIcon,
 			type: 'anchor',
-			href: '/transformations',
+			href: `${pathPrefix}/transformations`,
 		},
 		{
 			label: 'Settings',
 			icon: SettingsIcon,
 			type: 'anchor',
-			href: '/settings',
-			activePathPrefix: '/settings',
+			href: `${pathPrefix}/settings`,
+			activePathPrefix: `${pathPrefix}/settings`,
 		},
 		{
 			label: 'View project on GitHub',

--- a/apps/whispering/src/lib/components/icons/EpicenterLogo.svelte
+++ b/apps/whispering/src/lib/components/icons/EpicenterLogo.svelte
@@ -1,0 +1,8 @@
+<!-- Epicenter logo: two overlapping circles -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" {...$$props}>
+	<!-- Top-left circle (gray) - uses opacity for subtle contrast -->
+	<circle cx="170" cy="170" r="100" fill="currentColor" opacity="0.6" />
+
+	<!-- Bottom-right circle (foreground) -->
+	<circle cx="230" cy="230" r="100" fill="currentColor" opacity="1" />
+</svg>

--- a/apps/whispering/src/lib/components/icons/index.ts
+++ b/apps/whispering/src/lib/components/icons/index.ts
@@ -5,6 +5,7 @@
 
 export { default as ChromeWebStoreIcon } from './ChromeWebStore.svelte';
 export { default as ClipboardIcon } from './Clipboard.svelte';
+export { default as EpicenterLogo } from './EpicenterLogo.svelte';
 export { default as GithubIcon } from './Github.svelte';
 export { default as PencilIcon } from './Pencil.svelte';
 export { default as TrashIcon } from './Trash.svelte';

--- a/apps/whispering/src/lib/components/recording/ManualRecordingButton.svelte
+++ b/apps/whispering/src/lib/components/recording/ManualRecordingButton.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	import { commandCallbacks } from '$lib/commands';
+	import { recorderStateToIcons } from '$lib/constants/audio';
+	import WhisperingButton from '$lib/components/WhisperingButton.svelte';
+	import type { CreateQueryResult } from '@tanstack/svelte-query';
+	import type { WhisperingRecordingState } from '$lib/constants/audio/recording-states';
+	import { cn } from '@repo/ui/utils';
+
+	interface Props {
+		getRecorderStateQuery: CreateQueryResult<WhisperingRecordingState, Error>;
+		unstyled?: boolean;
+		showLabel?: boolean;
+	}
+
+	let {
+		getRecorderStateQuery,
+		unstyled = false,
+		showLabel = false,
+	}: Props = $props();
+
+	const state = $derived(getRecorderStateQuery.data ?? 'IDLE');
+	const icon = $derived(recorderStateToIcons[state]);
+
+	const labelText = $derived(
+		state === 'IDLE' ? 'Start manual recording' : 'Stop manual recording',
+	);
+</script>
+
+{#if unstyled}
+	<!-- Sidebar mode: unstyled button with sidebar classes -->
+	<button
+		type="button"
+		onclick={commandCallbacks.toggleManualRecording}
+		class="peer/menu-button outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm transition-[width,height,padding] focus-visible:ring-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0"
+		title={labelText}
+	>
+		<div class="relative shrink-0">
+			<span class="text-base flex items-center justify-center size-4"
+				>{icon}</span
+			>
+		</div>
+		{#if showLabel}
+			<span>{labelText}</span>
+		{/if}
+	</button>
+{:else}
+	<!-- Standard mode: WhisperingButton with tooltip -->
+	<WhisperingButton
+		tooltipContent={labelText}
+		onclick={commandCallbacks.toggleManualRecording}
+		variant="ghost"
+		size="icon"
+	>
+		{icon}
+	</WhisperingButton>
+{/if}

--- a/apps/whispering/src/lib/components/recording/VadRecordingButton.svelte
+++ b/apps/whispering/src/lib/components/recording/VadRecordingButton.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	import { commandCallbacks } from '$lib/commands';
+	import { vadStateToIcons, type VadState } from '$lib/constants/audio';
+	import WhisperingButton from '$lib/components/WhisperingButton.svelte';
+	import type { CreateQueryResult } from '@tanstack/svelte-query';
+	import { cn } from '@repo/ui/utils';
+
+	interface Props {
+		getVadStateQuery: CreateQueryResult<VadState, Error>;
+		unstyled?: boolean;
+		showLabel?: boolean;
+	}
+
+	let {
+		getVadStateQuery,
+		unstyled = false,
+		showLabel = false,
+	}: Props = $props();
+
+	const state = $derived(getVadStateQuery.data ?? 'IDLE');
+	const icon = $derived(vadStateToIcons[state]);
+
+	const labelText = $derived(
+		state === 'IDLE'
+			? 'Start voice activated session'
+			: 'Stop voice activated session',
+	);
+</script>
+
+{#if unstyled}
+	<!-- Sidebar mode: unstyled button with sidebar classes -->
+	<button
+		type="button"
+		onclick={commandCallbacks.toggleVadRecording}
+		class="peer/menu-button outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm transition-[width,height,padding] focus-visible:ring-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0"
+		title={labelText}
+	>
+		<div class="relative shrink-0">
+			<span class="text-base flex items-center justify-center size-4"
+				>{icon}</span
+			>
+		</div>
+		{#if showLabel}
+			<span>{labelText}</span>
+		{/if}
+	</button>
+{:else}
+	<!-- Standard mode: WhisperingButton with tooltip -->
+	<WhisperingButton
+		tooltipContent={labelText}
+		onclick={commandCallbacks.toggleVadRecording}
+		variant="ghost"
+		size="icon"
+	>
+		{icon}
+	</WhisperingButton>
+{/if}

--- a/apps/whispering/src/lib/components/settings/selectors/CompressionSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/CompressionSelector.svelte
@@ -35,12 +35,11 @@
 		settings.value['transcription.compressionEnabled'],
 	);
 
-	// Label text for button (matches tooltip)
-	const labelText = $derived(
-		isCompressionEnabled
-			? 'Compression enabled - click to configure'
-			: 'Audio compression disabled - click to enable',
-	);
+	// Tooltip text - only shows current value
+	const tooltipText = $derived(isCompressionEnabled ? 'Enabled' : 'Disabled');
+
+	// Label text - only shows setting name
+	const labelText = 'Compression';
 </script>
 
 <Popover.Root bind:open={popover.open}>
@@ -49,9 +48,7 @@
 			{#if unstyled}
 				<button
 					{...props}
-					title={isCompressionEnabled
-						? 'Compression enabled - click to configure'
-						: 'Audio compression disabled - click to enable'}
+					title={tooltipText}
 					class={cn(
 						'peer/menu-button outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm transition-[width,height,padding] [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
 						'relative',
@@ -80,9 +77,7 @@
 				<WhisperingButton
 					{...props}
 					class={cn('relative', className)}
-					tooltipContent={isCompressionEnabled
-						? 'Compression enabled - click to configure'
-						: 'Audio compression disabled - click to enable'}
+					tooltipContent={tooltipText}
 					variant="ghost"
 					size={showLabel ? 'default' : 'icon'}
 				>

--- a/apps/whispering/src/lib/components/settings/selectors/CompressionSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/CompressionSelector.svelte
@@ -68,7 +68,7 @@
 						<!-- Recommended badge indicator -->
 						{#if shouldShowRecommendedBadge}
 							<span
-								class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-blue-500 before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-blue-500/50 before:animate-ping"
+								class="absolute -right-1.5 -top-1.5 size-2 rounded-full bg-blue-500 before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-blue-500/50 before:animate-ping"
 							></span>
 						{/if}
 					</div>
@@ -96,7 +96,7 @@
 						<!-- Recommended badge indicator -->
 						{#if shouldShowRecommendedBadge}
 							<span
-								class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-blue-500 before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-blue-500/50 before:animate-ping"
+								class="absolute -right-1.5 -top-1.5 size-2 rounded-full bg-blue-500 before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-blue-500/50 before:animate-ping"
 							></span>
 						{/if}
 					</div>

--- a/apps/whispering/src/lib/components/settings/selectors/CompressionSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/CompressionSelector.svelte
@@ -58,21 +58,22 @@
 						className,
 					)}
 				>
-					<SlidersIcon
-						class={cn(
-							'size-4 shrink-0',
-							isCompressionEnabled ? 'opacity-100' : 'opacity-60',
-						)}
-					/>
+					<div class="relative shrink-0">
+						<SlidersIcon
+							class={cn(
+								'size-4 shrink-0',
+								isCompressionEnabled ? 'opacity-100' : 'opacity-60',
+							)}
+						/>
+						<!-- Recommended badge indicator -->
+						{#if shouldShowRecommendedBadge}
+							<span
+								class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-blue-500 before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-blue-500/50 before:animate-ping"
+							></span>
+						{/if}
+					</div>
 					{#if showLabel}
 						<span class="truncate min-w-0">{labelText}</span>
-					{/if}
-
-					<!-- Recommended badge indicator -->
-					{#if shouldShowRecommendedBadge}
-						<span
-							class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-blue-500 before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-blue-500/50 before:animate-ping"
-						></span>
 					{/if}
 				</button>
 			{:else}
@@ -85,21 +86,22 @@
 					variant="ghost"
 					size={showLabel ? 'default' : 'icon'}
 				>
-					<SlidersIcon
-						class={cn(
-							'size-4 shrink-0',
-							isCompressionEnabled ? 'opacity-100' : 'opacity-60',
-						)}
-					/>
+					<div class="relative shrink-0">
+						<SlidersIcon
+							class={cn(
+								'size-4 shrink-0',
+								isCompressionEnabled ? 'opacity-100' : 'opacity-60',
+							)}
+						/>
+						<!-- Recommended badge indicator -->
+						{#if shouldShowRecommendedBadge}
+							<span
+								class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-blue-500 before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-blue-500/50 before:animate-ping"
+							></span>
+						{/if}
+					</div>
 					{#if showLabel}
 						<span class="truncate min-w-0">{labelText}</span>
-					{/if}
-
-					<!-- Recommended badge indicator -->
-					{#if shouldShowRecommendedBadge}
-						<span
-							class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-blue-500 before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-blue-500/50 before:animate-ping"
-						></span>
 					{/if}
 				</WhisperingButton>
 			{/if}

--- a/apps/whispering/src/lib/components/settings/selectors/CompressionSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/CompressionSelector.svelte
@@ -9,9 +9,21 @@
 	import { settings } from '$lib/stores/settings.svelte';
 	import { cn } from '@repo/ui/utils';
 	import { isCompressionRecommended } from '../../../../routes/(app)/_layout-utils/check-ffmpeg';
-	import { PackageIcon, SettingsIcon } from '@lucide/svelte';
+	import { SlidersIcon, SettingsIcon } from '@lucide/svelte';
 
-	let { class: className }: { class?: string } = $props();
+	let {
+		class: className,
+		side = 'bottom' as 'top' | 'right' | 'bottom' | 'left',
+		align = 'center' as 'start' | 'center' | 'end',
+		showLabel = false,
+		unstyled = false,
+	}: {
+		class?: string;
+		side?: 'top' | 'right' | 'bottom' | 'left';
+		align?: 'start' | 'center' | 'end';
+		showLabel?: boolean;
+		unstyled?: boolean;
+	} = $props();
 
 	const popover = useCombobox();
 
@@ -22,40 +34,83 @@
 	const isCompressionEnabled = $derived(
 		settings.value['transcription.compressionEnabled'],
 	);
+
+	// Label text for button (matches tooltip)
+	const labelText = $derived(
+		isCompressionEnabled
+			? 'Compression enabled - click to configure'
+			: 'Audio compression disabled - click to enable',
+	);
 </script>
 
 <Popover.Root bind:open={popover.open}>
 	<Popover.Trigger bind:ref={popover.triggerRef}>
 		{#snippet child({ props })}
-			<WhisperingButton
-				{...props}
-				class={cn('relative', className)}
-				tooltipContent={isCompressionEnabled
-					? 'Compression enabled - click to configure'
-					: 'Audio compression disabled - click to enable'}
-				variant="ghost"
-				size="icon"
-			>
-				<PackageIcon
+			{#if unstyled}
+				<button
+					{...props}
+					title={isCompressionEnabled
+						? 'Compression enabled - click to configure'
+						: 'Audio compression disabled - click to enable'}
 					class={cn(
-						'text-lg',
-						isCompressionEnabled ? 'opacity-100' : 'opacity-60',
+						'peer/menu-button outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm transition-[width,height,padding] [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
+						'relative',
+						className,
 					)}
 				>
-					🗜️
-				</PackageIcon>
+					<SlidersIcon
+						class={cn(
+							'size-4 shrink-0',
+							isCompressionEnabled ? 'opacity-100' : 'opacity-60',
+						)}
+					/>
+					{#if showLabel}
+						<span class="truncate min-w-0">{labelText}</span>
+					{/if}
 
-				<!-- Recommended badge indicator -->
-				{#if shouldShowRecommendedBadge}
-					<span
-						class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-blue-500 before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-blue-500/50 before:animate-ping"
-					></span>
-				{/if}
-			</WhisperingButton>
+					<!-- Recommended badge indicator -->
+					{#if shouldShowRecommendedBadge}
+						<span
+							class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-blue-500 before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-blue-500/50 before:animate-ping"
+						></span>
+					{/if}
+				</button>
+			{:else}
+				<WhisperingButton
+					{...props}
+					class={cn('relative', className)}
+					tooltipContent={isCompressionEnabled
+						? 'Compression enabled - click to configure'
+						: 'Audio compression disabled - click to enable'}
+					variant="ghost"
+					size={showLabel ? 'default' : 'icon'}
+				>
+					<SlidersIcon
+						class={cn(
+							'size-4 shrink-0',
+							isCompressionEnabled ? 'opacity-100' : 'opacity-60',
+						)}
+					/>
+					{#if showLabel}
+						<span class="truncate min-w-0">{labelText}</span>
+					{/if}
+
+					<!-- Recommended badge indicator -->
+					{#if shouldShowRecommendedBadge}
+						<span
+							class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-blue-500 before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-blue-500/50 before:animate-ping"
+						></span>
+					{/if}
+				</WhisperingButton>
+			{/if}
 		{/snippet}
 	</Popover.Trigger>
 
-	<Popover.Content class="sm:w-[36rem] max-h-[40vh] overflow-auto p-0">
+	<Popover.Content
+		class="sm:w-[36rem] max-h-[40vh] overflow-auto p-0"
+		{side}
+		{align}
+	>
 		<div class="p-4">
 			<CompressionBody />
 		</div>

--- a/apps/whispering/src/lib/components/settings/selectors/ManualDeviceSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/ManualDeviceSelector.svelte
@@ -33,6 +33,11 @@
 
 	const isDeviceSelected = $derived(!!selectedDeviceId);
 
+	// Get selected device name
+	const selectedDevice = $derived(
+		getDevicesQuery.data?.find((d) => d.id === selectedDeviceId),
+	);
+
 	// Recording method options with descriptions
 	const RECORDING_METHODS = {
 		cpal: {
@@ -55,12 +60,11 @@
 		},
 	} as const;
 
-	// Label text for button (matches tooltip)
-	const labelText = $derived(
-		isDeviceSelected
-			? `Recording via ${RECORDING_METHODS[selectedMethod].label} - Change device or method`
-			: `Select recording device (${RECORDING_METHODS[selectedMethod].label} method)`,
-	);
+	// Tooltip text - only shows current value
+	const tooltipText = $derived(selectedDevice?.label || 'No device selected');
+
+	// Label text - only shows setting name
+	const labelText = 'Recording Device';
 
 	const getDevicesQuery = createQuery(() => ({
 		...rpc.recorder.enumerateDevices.options(),
@@ -82,9 +86,7 @@
 					{...props}
 					role="combobox"
 					aria-expanded={combobox.open}
-					title={isDeviceSelected
-						? `Recording via ${RECORDING_METHODS[selectedMethod].label} - Change device or method`
-						: `Select recording device (${RECORDING_METHODS[selectedMethod].label} method)`}
+					title={tooltipText}
 					class="peer/menu-button outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm transition-[width,height,padding] [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0"
 				>
 					{#if isDeviceSelected}
@@ -99,9 +101,7 @@
 			{:else}
 				<WhisperingButton
 					{...props}
-					tooltipContent={isDeviceSelected
-						? `Recording via ${RECORDING_METHODS[selectedMethod].label} - Change device or method`
-						: `Select recording device (${RECORDING_METHODS[selectedMethod].label} method)`}
+					tooltipContent={tooltipText}
 					role="combobox"
 					aria-expanded={combobox.open}
 					variant="ghost"

--- a/apps/whispering/src/lib/components/settings/selectors/ManualDeviceSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/ManualDeviceSelector.svelte
@@ -10,6 +10,18 @@
 	import { CheckIcon, MicIcon, RefreshCwIcon } from '@lucide/svelte';
 	import { Badge } from '@repo/ui/badge';
 
+	let {
+		side = 'bottom' as 'top' | 'right' | 'bottom' | 'left',
+		align = 'center' as 'start' | 'center' | 'end',
+		showLabel = false,
+		unstyled = false,
+	}: {
+		side?: 'top' | 'right' | 'bottom' | 'left';
+		align?: 'start' | 'center' | 'end';
+		showLabel?: boolean;
+		unstyled?: boolean;
+	} = $props();
+
 	const combobox = useCombobox();
 
 	const selectedMethod = $derived(settings.value['recording.method']);
@@ -43,6 +55,13 @@
 		},
 	} as const;
 
+	// Label text for button (matches tooltip)
+	const labelText = $derived(
+		isDeviceSelected
+			? `Recording via ${RECORDING_METHODS[selectedMethod].label} - Change device or method`
+			: `Select recording device (${RECORDING_METHODS[selectedMethod].label} method)`,
+	);
+
 	const getDevicesQuery = createQuery(() => ({
 		...rpc.recorder.enumerateDevices.options(),
 		enabled: combobox.open,
@@ -58,25 +77,50 @@
 <Popover.Root bind:open={combobox.open}>
 	<Popover.Trigger bind:ref={combobox.triggerRef}>
 		{#snippet child({ props })}
-			<WhisperingButton
-				{...props}
-				tooltipContent={isDeviceSelected
-					? `Recording via ${RECORDING_METHODS[selectedMethod].label} - Change device or method`
-					: `Select recording device (${RECORDING_METHODS[selectedMethod].label} method)`}
-				role="combobox"
-				aria-expanded={combobox.open}
-				variant="ghost"
-				size="icon"
-			>
-				{#if isDeviceSelected}
-					<MicIcon class="size-4 text-green-500" />
-				{:else}
-					<MicIcon class="size-4 text-amber-500" />
-				{/if}
-			</WhisperingButton>
+			{#if unstyled}
+				<button
+					{...props}
+					role="combobox"
+					aria-expanded={combobox.open}
+					title={isDeviceSelected
+						? `Recording via ${RECORDING_METHODS[selectedMethod].label} - Change device or method`
+						: `Select recording device (${RECORDING_METHODS[selectedMethod].label} method)`}
+					class="peer/menu-button outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm transition-[width,height,padding] [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0"
+				>
+					{#if isDeviceSelected}
+						<MicIcon class="size-4 shrink-0 text-green-500" />
+					{:else}
+						<MicIcon class="size-4 shrink-0 text-amber-500" />
+					{/if}
+					{#if showLabel}
+						<span class="truncate min-w-0">{labelText}</span>
+					{/if}
+				</button>
+			{:else}
+				<WhisperingButton
+					{...props}
+					tooltipContent={isDeviceSelected
+						? `Recording via ${RECORDING_METHODS[selectedMethod].label} - Change device or method`
+						: `Select recording device (${RECORDING_METHODS[selectedMethod].label} method)`}
+					role="combobox"
+					aria-expanded={combobox.open}
+					variant="ghost"
+					size={showLabel ? 'default' : 'icon'}
+					class={showLabel ? 'justify-start w-full gap-2' : ''}
+				>
+					{#if isDeviceSelected}
+						<MicIcon class="size-4 shrink-0 text-green-500" />
+					{:else}
+						<MicIcon class="size-4 shrink-0 text-amber-500" />
+					{/if}
+					{#if showLabel}
+						<span class="truncate min-w-0">{labelText}</span>
+					{/if}
+				</WhisperingButton>
+			{/if}
 		{/snippet}
 	</Popover.Trigger>
-	<Popover.Content class="p-0">
+	<Popover.Content class="p-0" {side} {align}>
 		<Command.Root loop>
 			<Command.Input placeholder="Search devices and methods..." />
 			<Command.List class="max-h-[40vh]">

--- a/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
@@ -120,28 +120,30 @@
 						className,
 					)}
 				>
-					{#if selectedService}
-						<div
-							class={cn(
-								'size-4 shrink-0 flex items-center justify-center [&>svg]:size-full',
-								selectedService.invertInDarkMode &&
-									'dark:[&>svg]:invert dark:[&>svg]:brightness-90',
-								!isTranscriptionServiceConfigured(selectedService) &&
-									'opacity-60',
-							)}
-						>
-							{@html selectedService.icon}
-						</div>
-					{:else}
-						<MicIcon class="size-4 shrink-0 text-muted-foreground" />
-					{/if}
+					<div class="relative shrink-0">
+						{#if selectedService}
+							<div
+								class={cn(
+									'size-4 shrink-0 flex items-center justify-center [&>svg]:size-full',
+									selectedService.invertInDarkMode &&
+										'dark:[&>svg]:invert dark:[&>svg]:brightness-90',
+									!isTranscriptionServiceConfigured(selectedService) &&
+										'opacity-60',
+								)}
+							>
+								{@html selectedService.icon}
+							</div>
+						{:else}
+							<MicIcon class="size-4 shrink-0 text-muted-foreground" />
+						{/if}
+						{#if selectedService && !isTranscriptionServiceConfigured(selectedService)}
+							<span
+								class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-amber-500 before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-amber-500/50 before:animate-ping"
+							></span>
+						{/if}
+					</div>
 					{#if showLabel}
 						<span class="truncate min-w-0">{labelText}</span>
-					{/if}
-					{#if selectedService && !isTranscriptionServiceConfigured(selectedService)}
-						<span
-							class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-amber-500 before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-amber-500/50 before:animate-ping"
-						></span>
 					{/if}
 				</button>
 			{:else}
@@ -154,28 +156,30 @@
 					variant="ghost"
 					size={showLabel ? 'default' : 'icon'}
 				>
-					{#if selectedService}
-						<div
-							class={cn(
-								'size-4 shrink-0 flex items-center justify-center [&>svg]:size-full',
-								selectedService.invertInDarkMode &&
-									'dark:[&>svg]:invert dark:[&>svg]:brightness-90',
-								!isTranscriptionServiceConfigured(selectedService) &&
-									'opacity-60',
-							)}
-						>
-							{@html selectedService.icon}
-						</div>
-					{:else}
-						<MicIcon class="size-4 shrink-0 text-muted-foreground" />
-					{/if}
+					<div class="relative shrink-0">
+						{#if selectedService}
+							<div
+								class={cn(
+									'size-4 shrink-0 flex items-center justify-center [&>svg]:size-full',
+									selectedService.invertInDarkMode &&
+										'dark:[&>svg]:invert dark:[&>svg]:brightness-90',
+									!isTranscriptionServiceConfigured(selectedService) &&
+										'opacity-60',
+								)}
+							>
+								{@html selectedService.icon}
+							</div>
+						{:else}
+							<MicIcon class="size-4 shrink-0 text-muted-foreground" />
+						{/if}
+						{#if selectedService && !isTranscriptionServiceConfigured(selectedService)}
+							<span
+								class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-amber-500 before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-amber-500/50 before:animate-ping"
+							></span>
+						{/if}
+					</div>
 					{#if showLabel}
 						<span class="truncate min-w-0">{labelText}</span>
-					{/if}
-					{#if selectedService && !isTranscriptionServiceConfigured(selectedService)}
-						<span
-							class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-amber-500 before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-amber-500/50 before:animate-ping"
-						></span>
 					{/if}
 				</WhisperingButton>
 			{/if}

--- a/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
@@ -138,7 +138,7 @@
 						{/if}
 						{#if selectedService && !isTranscriptionServiceConfigured(selectedService)}
 							<span
-								class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-amber-500 before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-amber-500/50 before:animate-ping"
+								class="absolute -right-1.5 -top-1.5 size-2 rounded-full bg-amber-500 before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-amber-500/50 before:animate-ping"
 							></span>
 						{/if}
 					</div>
@@ -174,7 +174,7 @@
 						{/if}
 						{#if selectedService && !isTranscriptionServiceConfigured(selectedService)}
 							<span
-								class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-amber-500 before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-amber-500/50 before:animate-ping"
+								class="absolute -right-1.5 -top-1.5 size-2 rounded-full bg-amber-500 before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-amber-500/50 before:animate-ping"
 							></span>
 						{/if}
 					</div>

--- a/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
@@ -39,16 +39,13 @@
 
 	const selectedService = $derived(getSelectedTranscriptionService());
 
-	// Label text for button (matches tooltip)
-	const labelText = $derived(
-		selectedService
-			? `${selectedService.name}${
-					selectedService.location === 'cloud'
-						? ` - ${getSelectedModelNameOrUrl(selectedService)}`
-						: ''
-				}`
-			: 'Select transcription service',
+	// Tooltip text - only shows current value
+	const tooltipText = $derived(
+		selectedService ? selectedService.name : 'No service selected',
 	);
+
+	// Label text - only shows setting name
+	const labelText = 'Transcription Model';
 
 	function getSelectedModelNameOrUrl(service: TranscriptionService) {
 		switch (service.location) {
@@ -111,7 +108,7 @@
 			{#if unstyled}
 				<button
 					{...props}
-					title={labelText}
+					title={tooltipText}
 					role="combobox"
 					aria-expanded={combobox.open}
 					class={cn(
@@ -150,7 +147,7 @@
 				<WhisperingButton
 					{...props}
 					class={cn('relative', className)}
-					tooltipContent={labelText}
+					tooltipContent={tooltipText}
 					role="combobox"
 					aria-expanded={combobox.open}
 					variant="ghost"

--- a/apps/whispering/src/lib/components/settings/selectors/TransformationSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/TransformationSelector.svelte
@@ -92,7 +92,7 @@
 						{/if}
 						{#if !selectedTransformation}
 							<span
-								class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-primary before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-primary/50 before:animate-ping"
+								class="absolute -right-1.5 -top-1.5 size-2 rounded-full bg-primary before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-primary/50 before:animate-ping"
 							></span>
 						{/if}
 					</div>
@@ -121,7 +121,7 @@
 						{/if}
 						{#if !selectedTransformation}
 							<span
-								class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-primary before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-primary/50 before:animate-ping"
+								class="absolute -right-1.5 -top-1.5 size-2 rounded-full bg-primary before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-primary/50 before:animate-ping"
 							></span>
 						{/if}
 					</div>

--- a/apps/whispering/src/lib/components/settings/selectors/TransformationSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/TransformationSelector.svelte
@@ -84,18 +84,20 @@
 						transformationId: selectedTransformation?.id ?? null,
 					})}"
 				>
-					{#if selectedTransformation}
-						<SparklesIcon class="size-4 shrink-0 text-green-500" />
-					{:else}
-						<WandIcon class="size-4 shrink-0 text-amber-500" />
-					{/if}
+					<div class="relative shrink-0">
+						{#if selectedTransformation}
+							<SparklesIcon class="size-4 shrink-0 text-green-500" />
+						{:else}
+							<WandIcon class="size-4 shrink-0 text-amber-500" />
+						{/if}
+						{#if !selectedTransformation}
+							<span
+								class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-primary before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-primary/50 before:animate-ping"
+							></span>
+						{/if}
+					</div>
 					{#if showLabel}
 						<span class="truncate min-w-0">{labelText}</span>
-					{/if}
-					{#if !selectedTransformation}
-						<span
-							class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-primary before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-primary/50 before:animate-ping"
-						></span>
 					{/if}
 				</button>
 			{:else}
@@ -111,18 +113,20 @@
 						transformationId: selectedTransformation?.id ?? null,
 					})}"
 				>
-					{#if selectedTransformation}
-						<SparklesIcon class="size-4 shrink-0 text-green-500" />
-					{:else}
-						<WandIcon class="size-4 shrink-0 text-amber-500" />
-					{/if}
+					<div class="relative shrink-0">
+						{#if selectedTransformation}
+							<SparklesIcon class="size-4 shrink-0 text-green-500" />
+						{:else}
+							<WandIcon class="size-4 shrink-0 text-amber-500" />
+						{/if}
+						{#if !selectedTransformation}
+							<span
+								class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-primary before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-primary/50 before:animate-ping"
+							></span>
+						{/if}
+					</div>
 					{#if showLabel}
 						<span class="truncate min-w-0">{labelText}</span>
-					{/if}
-					{#if !selectedTransformation}
-						<span
-							class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-primary before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-primary/50 before:animate-ping"
-						></span>
 					{/if}
 				</WhisperingButton>
 			{/if}

--- a/apps/whispering/src/lib/components/settings/selectors/TransformationSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/TransformationSelector.svelte
@@ -45,12 +45,13 @@
 		),
 	);
 
-	// Label text for button (matches tooltip)
-	const labelText = $derived(
-		selectedTransformation
-			? 'Change post-processing transformation to run after your text is transcribed'
-			: 'Select a post-processing transformation to run after your text is transcribed',
+	// Tooltip text - only shows current value
+	const tooltipText = $derived(
+		selectedTransformation?.title || 'None selected',
 	);
+
+	// Label text - only shows setting name
+	const labelText = 'Transformation';
 
 	const combobox = useCombobox();
 </script>
@@ -72,7 +73,7 @@
 			{#if unstyled}
 				<button
 					{...props}
-					title={labelText}
+					title={tooltipText}
 					role="combobox"
 					aria-expanded={combobox.open}
 					class={cn(
@@ -104,7 +105,7 @@
 				<WhisperingButton
 					{...props}
 					class={cn('relative', className)}
-					tooltipContent={labelText}
+					tooltipContent={tooltipText}
 					role="combobox"
 					aria-expanded={combobox.open}
 					variant="ghost"

--- a/apps/whispering/src/lib/components/settings/selectors/TransformationSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/TransformationSelector.svelte
@@ -26,8 +26,16 @@
 
 	let {
 		class: className,
+		side = 'bottom' as 'top' | 'right' | 'bottom' | 'left',
+		align = 'center' as 'start' | 'center' | 'end',
+		showLabel = false,
+		unstyled = false,
 	}: {
 		class?: string;
+		side?: 'top' | 'right' | 'bottom' | 'left';
+		align?: 'start' | 'center' | 'end';
+		showLabel?: boolean;
+		unstyled?: boolean;
 	} = $props();
 
 	const selectedTransformation = $derived(
@@ -35,6 +43,13 @@
 			(t) =>
 				t.id === settings.value['transformations.selectedTransformationId'],
 		),
+	);
+
+	// Label text for button (matches tooltip)
+	const labelText = $derived(
+		selectedTransformation
+			? 'Change post-processing transformation to run after your text is transcribed'
+			: 'Select a post-processing transformation to run after your text is transcribed',
 	);
 
 	const combobox = useCombobox();
@@ -54,34 +69,66 @@
 <Popover.Root bind:open={combobox.open}>
 	<Popover.Trigger bind:ref={combobox.triggerRef}>
 		{#snippet child({ props })}
-			<WhisperingButton
-				{...props}
-				class={cn('relative', className)}
-				tooltipContent={selectedTransformation
-					? 'Change post-processing transformation to run after your text is transcribed'
-					: 'Select a post-processing transformation to run after your text is transcribed'}
-				role="combobox"
-				aria-expanded={combobox.open}
-				variant="ghost"
-				size="icon"
-				style="view-transition-name: {createTransformationViewTransitionName({
-					transformationId: selectedTransformation?.id ?? null,
-				})}"
-			>
-				{#if selectedTransformation}
-					<SparklesIcon class="size-4 text-green-500" />
-				{:else}
-					<WandIcon class="size-4 text-amber-500" />
-				{/if}
-				{#if !selectedTransformation}
-					<span
-						class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-primary before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-primary/50 before:animate-ping"
-					></span>
-				{/if}
-			</WhisperingButton>
+			{#if unstyled}
+				<button
+					{...props}
+					title={labelText}
+					role="combobox"
+					aria-expanded={combobox.open}
+					class={cn(
+						'peer/menu-button outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm transition-[width,height,padding] [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
+						'relative',
+						className,
+					)}
+					style="view-transition-name: {createTransformationViewTransitionName({
+						transformationId: selectedTransformation?.id ?? null,
+					})}"
+				>
+					{#if selectedTransformation}
+						<SparklesIcon class="size-4 shrink-0 text-green-500" />
+					{:else}
+						<WandIcon class="size-4 shrink-0 text-amber-500" />
+					{/if}
+					{#if showLabel}
+						<span class="truncate min-w-0">{labelText}</span>
+					{/if}
+					{#if !selectedTransformation}
+						<span
+							class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-primary before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-primary/50 before:animate-ping"
+						></span>
+					{/if}
+				</button>
+			{:else}
+				<WhisperingButton
+					{...props}
+					class={cn('relative', className)}
+					tooltipContent={labelText}
+					role="combobox"
+					aria-expanded={combobox.open}
+					variant="ghost"
+					size={showLabel ? 'default' : 'icon'}
+					style="view-transition-name: {createTransformationViewTransitionName({
+						transformationId: selectedTransformation?.id ?? null,
+					})}"
+				>
+					{#if selectedTransformation}
+						<SparklesIcon class="size-4 shrink-0 text-green-500" />
+					{:else}
+						<WandIcon class="size-4 shrink-0 text-amber-500" />
+					{/if}
+					{#if showLabel}
+						<span class="truncate min-w-0">{labelText}</span>
+					{/if}
+					{#if !selectedTransformation}
+						<span
+							class="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-primary before:absolute before:left-0 before:top-0 before:h-full before:w-full before:rounded-full before:bg-primary/50 before:animate-ping"
+						></span>
+					{/if}
+				</WhisperingButton>
+			{/if}
 		{/snippet}
 	</Popover.Trigger>
-	<Popover.Content class="w-80 max-w-xl p-0">
+	<Popover.Content class="w-80 max-w-xl p-0" {side} {align}>
 		<Command.Root loop>
 			<Command.Input placeholder="Select transcription post-processing..." />
 			<Command.Empty>No transformation found.</Command.Empty>

--- a/apps/whispering/src/lib/components/settings/selectors/VadDeviceSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/VadDeviceSelector.svelte
@@ -9,6 +9,18 @@
 	import { createQuery } from '@tanstack/svelte-query';
 	import { CheckIcon, MicIcon, RefreshCwIcon } from '@lucide/svelte';
 
+	let {
+		side = 'bottom' as 'top' | 'right' | 'bottom' | 'left',
+		align = 'center' as 'start' | 'center' | 'end',
+		showLabel = false,
+		unstyled = false,
+	}: {
+		side?: 'top' | 'right' | 'bottom' | 'left';
+		align?: 'start' | 'center' | 'end';
+		showLabel?: boolean;
+		unstyled?: boolean;
+	} = $props();
+
 	const combobox = useCombobox();
 
 	// VAD always uses navigator device ID
@@ -17,6 +29,13 @@
 	const selectedDeviceId = $derived(settings.value[settingKey]);
 
 	const isDeviceSelected = $derived(!!selectedDeviceId);
+
+	// Label text for button (matches tooltip)
+	const labelText = $derived(
+		isDeviceSelected
+			? 'Change VAD recording device'
+			: 'Select a VAD recording device',
+	);
 
 	const getDevicesQuery = createQuery(() => ({
 		...rpc.vadRecorder.enumerateDevices.options(),
@@ -33,26 +52,50 @@
 <Popover.Root bind:open={combobox.open}>
 	<Popover.Trigger bind:ref={combobox.triggerRef}>
 		{#snippet child({ props })}
-			<WhisperingButton
-				{...props}
-				tooltipContent={isDeviceSelected
-					? 'Change VAD recording device'
-					: 'Select a VAD recording device'}
-				role="combobox"
-				aria-expanded={combobox.open}
-				variant="ghost"
-				size="icon"
-				class="relative"
-			>
-				{#if isDeviceSelected}
-					<MicIcon class="size-4 text-green-500" />
-				{:else}
-					<MicIcon class="size-4 text-amber-500" />
-				{/if}
-			</WhisperingButton>
+			{#if unstyled}
+				<button
+					{...props}
+					role="combobox"
+					aria-expanded={combobox.open}
+					title={isDeviceSelected
+						? 'Change VAD recording device'
+						: 'Select a VAD recording device'}
+					class="peer/menu-button outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm transition-[width,height,padding] [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0"
+				>
+					{#if isDeviceSelected}
+						<MicIcon class="size-4 shrink-0 text-green-500" />
+					{:else}
+						<MicIcon class="size-4 shrink-0 text-amber-500" />
+					{/if}
+					{#if showLabel}
+						<span class="truncate min-w-0">{labelText}</span>
+					{/if}
+				</button>
+			{:else}
+				<WhisperingButton
+					{...props}
+					tooltipContent={isDeviceSelected
+						? 'Change VAD recording device'
+						: 'Select a VAD recording device'}
+					role="combobox"
+					aria-expanded={combobox.open}
+					variant="ghost"
+					size={showLabel ? 'default' : 'icon'}
+					class={showLabel ? 'justify-start w-full gap-2' : 'relative'}
+				>
+					{#if isDeviceSelected}
+						<MicIcon class="size-4 shrink-0 text-green-500" />
+					{:else}
+						<MicIcon class="size-4 shrink-0 text-amber-500" />
+					{/if}
+					{#if showLabel}
+						<span class="truncate min-w-0">{labelText}</span>
+					{/if}
+				</WhisperingButton>
+			{/if}
 		{/snippet}
 	</Popover.Trigger>
-	<Popover.Content class="p-0">
+	<Popover.Content class="p-0" {side} {align}>
 		<Command.Root loop>
 			<Command.Input placeholder="Select VAD recording device..." />
 			<Command.Empty>No recording devices found.</Command.Empty>

--- a/apps/whispering/src/lib/components/settings/selectors/VadDeviceSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/VadDeviceSelector.svelte
@@ -30,12 +30,16 @@
 
 	const isDeviceSelected = $derived(!!selectedDeviceId);
 
-	// Label text for button (matches tooltip)
-	const labelText = $derived(
-		isDeviceSelected
-			? 'Change VAD recording device'
-			: 'Select a VAD recording device',
+	// Get selected device name
+	const selectedDevice = $derived(
+		getDevicesQuery.data?.find((d) => d.deviceId === selectedDeviceId),
 	);
+
+	// Tooltip text - only shows current value
+	const tooltipText = $derived(selectedDevice?.label || 'No device selected');
+
+	// Label text - only shows setting name
+	const labelText = 'Recording Device';
 
 	const getDevicesQuery = createQuery(() => ({
 		...rpc.vadRecorder.enumerateDevices.options(),
@@ -57,9 +61,7 @@
 					{...props}
 					role="combobox"
 					aria-expanded={combobox.open}
-					title={isDeviceSelected
-						? 'Change VAD recording device'
-						: 'Select a VAD recording device'}
+					title={tooltipText}
 					class="peer/menu-button outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm transition-[width,height,padding] [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0"
 				>
 					{#if isDeviceSelected}
@@ -74,9 +76,7 @@
 			{:else}
 				<WhisperingButton
 					{...props}
-					tooltipContent={isDeviceSelected
-						? 'Change VAD recording device'
-						: 'Select a VAD recording device'}
+					tooltipContent={tooltipText}
 					role="combobox"
 					aria-expanded={combobox.open}
 					variant="ghost"

--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -409,5 +409,20 @@
 				{/if}
 			</p>
 		</div>
+
+		<!-- Layout Switcher (Development) -->
+		<div class="mt-8 pt-4 border-t border-border/40">
+			<p class="text-muted-foreground text-center text-sm">
+				<strong>Dev:</strong> Switch to{' '}
+				<WhisperingButton
+					href="/verticalnav"
+					variant="link"
+					class="text-sm"
+					tooltipContent="Switch to vertical nav layout"
+				>
+					Vertical Nav Layout
+				</WhisperingButton>
+			</p>
+		</div>
 	</div>
 </main>

--- a/apps/whispering/src/routes/(app)/verticalnav/+layout.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+layout.svelte
@@ -1,21 +1,8 @@
 <script lang="ts">
-	import { commandCallbacks } from '$lib/commands';
-	import NavItems from '$lib/components/NavItems.svelte';
-	import WhisperingButton from '$lib/components/WhisperingButton.svelte';
-	import {
-		RecordingModeSelector,
-		CompressionSelector,
-		TranscriptionSelector,
-		TransformationSelector,
-	} from '$lib/components/settings';
-	import ManualDeviceSelector from '$lib/components/settings/selectors/ManualDeviceSelector.svelte';
-	import VadDeviceSelector from '$lib/components/settings/selectors/VadDeviceSelector.svelte';
-	import { recorderStateToIcons, vadStateToIcons } from '$lib/constants/audio';
+	import * as Sidebar from '@repo/ui/sidebar';
 	import { rpc } from '$lib/query';
-	import { settings } from '$lib/stores/settings.svelte';
-	import { cn } from '@repo/ui/utils';
 	import { createQuery } from '@tanstack/svelte-query';
-	import { MediaQuery } from 'svelte/reactivity';
+	import VerticalNav from './+layout/VerticalNav.svelte';
 
 	const getRecorderStateQuery = createQuery(
 		rpc.recorder.getRecorderState.options,
@@ -23,132 +10,44 @@
 	const getVadStateQuery = createQuery(rpc.vadRecorder.getVadState.options);
 
 	let { children } = $props();
-
-	const isMobile = new MediaQuery('(max-width: 640px)');
 </script>
 
-<header
-	class={cn(
-		'border-border/40 bg-background/95 supports-backdrop-filter:bg-background/60 sticky top-0 z-50 border-b shadow-xs backdrop-blur-sm ',
-		'flex h-14 w-full items-center justify-between px-4 sm:px-8',
-	)}
-	style="view-transition-name: header"
->
-	<WhisperingButton
-		tooltipContent="Go home"
-		href="/"
-		variant="ghost"
-		class="-ml-4"
-	>
-		<span class="text-lg font-bold">whispering</span>
-	</WhisperingButton>
-
-	<div class="flex items-center gap-1.5">
-		<div class="flex items-center gap-1.5">
-			{#if settings.value['recording.mode'] === 'manual'}
-				{#if getRecorderStateQuery.data === 'RECORDING'}
-					<WhisperingButton
-						tooltipContent="Cancel recording"
-						onclick={commandCallbacks.cancelManualRecording}
-						variant="ghost"
-						size="icon"
-						style="view-transition-name: cancel-icon;"
-					>
-						🚫
-					</WhisperingButton>
-				{:else}
-					<ManualDeviceSelector />
-					<CompressionSelector />
-					<TranscriptionSelector />
-					<TransformationSelector />
-				{/if}
-				{#if getRecorderStateQuery.data === 'RECORDING'}
-					<WhisperingButton
-						tooltipContent="Stop recording"
-						onclick={commandCallbacks.toggleManualRecording}
-						variant="ghost"
-						size="icon"
-						style="view-transition-name: microphone-icon"
-					>
-						{recorderStateToIcons[getRecorderStateQuery.data ?? 'IDLE']}
-					</WhisperingButton>
-				{:else}
-					<div class="flex">
-						<WhisperingButton
-							tooltipContent="Start recording"
-							onclick={commandCallbacks.toggleManualRecording}
-							variant="ghost"
-							size="icon"
-							style="view-transition-name: microphone-icon"
-							class="rounded-r-none border-r-0"
-						>
-							{recorderStateToIcons[getRecorderStateQuery.data ?? 'IDLE']}
-						</WhisperingButton>
-						<RecordingModeSelector class="rounded-l-none" />
-					</div>
-				{/if}
-			{:else if settings.value['recording.mode'] === 'vad'}
-				{#if getVadStateQuery.data === 'IDLE'}
-					<VadDeviceSelector />
-					<CompressionSelector />
-					<TranscriptionSelector />
-					<TransformationSelector />
-				{/if}
-				{#if getVadStateQuery.data === 'IDLE'}
-					<div class="flex">
-						<WhisperingButton
-							tooltipContent="Start voice activated recording"
-							onclick={commandCallbacks.toggleVadRecording}
-							variant="ghost"
-							size="icon"
-							style="view-transition-name: microphone-icon"
-							class="rounded-r-none border-r-0"
-						>
-							{vadStateToIcons[getVadStateQuery.data ?? 'IDLE']}
-						</WhisperingButton>
-						<RecordingModeSelector class="rounded-l-none" />
-					</div>
-				{:else}
-					<WhisperingButton
-						tooltipContent="Stop voice activated recording"
-						onclick={commandCallbacks.toggleVadRecording}
-						variant="ghost"
-						size="icon"
-						style="view-transition-name: microphone-icon"
-					>
-						{vadStateToIcons[getVadStateQuery.data ?? 'IDLE']}
-					</WhisperingButton>
-				{/if}
-			{:else if settings.value['recording.mode'] === 'upload'}
-				<CompressionSelector />
-				<TranscriptionSelector />
-				<TransformationSelector />
-				<RecordingModeSelector />
-			{:else if settings.value['recording.mode'] === 'live'}
-				<ManualDeviceSelector />
-				<CompressionSelector />
-				<TranscriptionSelector />
-				<TransformationSelector />
-				<div class="flex">
-					<WhisperingButton
-						tooltipContent="Toggle live recording"
-						onclick={() => {
-							// TODO: Implement live recording toggle
-							alert('Live recording not yet implemented');
-						}}
-						variant="ghost"
-						size="icon"
-						style="view-transition-name: microphone-icon"
-						class="rounded-r-none border-r-0"
-					>
-						🎬
-					</WhisperingButton>
-					<RecordingModeSelector class="rounded-l-none" />
-				</div>
-			{/if}
+<Sidebar.Provider>
+	<VerticalNav {getRecorderStateQuery} {getVadStateQuery} />
+	<Sidebar.Inset>
+		<!-- Trigger button for mobile (always visible - opens Sheet) -->
+		<div class="fixed left-2 top-2 z-40 md:hidden">
+			<Sidebar.Trigger />
 		</div>
-		<NavItems class="-mr-4" collapsed={isMobile.current} />
-	</div>
-</header>
+		{@render children()}
+	</Sidebar.Inset>
+</Sidebar.Provider>
 
-{@render children()}
+<style>
+	/* Move Svelte Inspector to top-right for verticalnav */
+	:global(#svelte-inspector-host button) {
+		top: 16px !important;
+		bottom: auto !important;
+		right: 16px !important;
+		left: auto !important;
+		transform: none !important;
+	}
+
+	/* Move TanStack Query Devtools to bottom-right for verticalnav */
+	:global(.tsqd-open-btn-container) {
+		bottom: 16px !important;
+		right: 16px !important;
+		left: auto !important;
+	}
+
+	/* Position the NotificationLog button right above sidebar footer button */
+	/* Make it invisible but keep it for popover anchor */
+	:global(button.fixed.bottom-4.right-4.z-50.hidden.xs\:inline-flex) {
+		opacity: 0 !important;
+		pointer-events: none !important;
+		/* Position it at the sidebar footer location */
+		left: 16px !important;
+		right: auto !important;
+		bottom: 8px !important;
+	}
+</style>

--- a/apps/whispering/src/routes/(app)/verticalnav/+layout.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+layout.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+	import { commandCallbacks } from '$lib/commands';
+	import NavItems from '$lib/components/NavItems.svelte';
+	import WhisperingButton from '$lib/components/WhisperingButton.svelte';
+	import {
+		RecordingModeSelector,
+		CompressionSelector,
+		TranscriptionSelector,
+		TransformationSelector,
+	} from '$lib/components/settings';
+	import ManualDeviceSelector from '$lib/components/settings/selectors/ManualDeviceSelector.svelte';
+	import VadDeviceSelector from '$lib/components/settings/selectors/VadDeviceSelector.svelte';
+	import { recorderStateToIcons, vadStateToIcons } from '$lib/constants/audio';
+	import { rpc } from '$lib/query';
+	import { settings } from '$lib/stores/settings.svelte';
+	import { cn } from '@repo/ui/utils';
+	import { createQuery } from '@tanstack/svelte-query';
+	import { MediaQuery } from 'svelte/reactivity';
+
+	const getRecorderStateQuery = createQuery(
+		rpc.recorder.getRecorderState.options,
+	);
+	const getVadStateQuery = createQuery(rpc.vadRecorder.getVadState.options);
+
+	let { children } = $props();
+
+	const isMobile = new MediaQuery('(max-width: 640px)');
+</script>
+
+<header
+	class={cn(
+		'border-border/40 bg-background/95 supports-backdrop-filter:bg-background/60 sticky top-0 z-50 border-b shadow-xs backdrop-blur-sm ',
+		'flex h-14 w-full items-center justify-between px-4 sm:px-8',
+	)}
+	style="view-transition-name: header"
+>
+	<WhisperingButton
+		tooltipContent="Go home"
+		href="/"
+		variant="ghost"
+		class="-ml-4"
+	>
+		<span class="text-lg font-bold">whispering</span>
+	</WhisperingButton>
+
+	<div class="flex items-center gap-1.5">
+		<div class="flex items-center gap-1.5">
+			{#if settings.value['recording.mode'] === 'manual'}
+				{#if getRecorderStateQuery.data === 'RECORDING'}
+					<WhisperingButton
+						tooltipContent="Cancel recording"
+						onclick={commandCallbacks.cancelManualRecording}
+						variant="ghost"
+						size="icon"
+						style="view-transition-name: cancel-icon;"
+					>
+						🚫
+					</WhisperingButton>
+				{:else}
+					<ManualDeviceSelector />
+					<CompressionSelector />
+					<TranscriptionSelector />
+					<TransformationSelector />
+				{/if}
+				{#if getRecorderStateQuery.data === 'RECORDING'}
+					<WhisperingButton
+						tooltipContent="Stop recording"
+						onclick={commandCallbacks.toggleManualRecording}
+						variant="ghost"
+						size="icon"
+						style="view-transition-name: microphone-icon"
+					>
+						{recorderStateToIcons[getRecorderStateQuery.data ?? 'IDLE']}
+					</WhisperingButton>
+				{:else}
+					<div class="flex">
+						<WhisperingButton
+							tooltipContent="Start recording"
+							onclick={commandCallbacks.toggleManualRecording}
+							variant="ghost"
+							size="icon"
+							style="view-transition-name: microphone-icon"
+							class="rounded-r-none border-r-0"
+						>
+							{recorderStateToIcons[getRecorderStateQuery.data ?? 'IDLE']}
+						</WhisperingButton>
+						<RecordingModeSelector class="rounded-l-none" />
+					</div>
+				{/if}
+			{:else if settings.value['recording.mode'] === 'vad'}
+				{#if getVadStateQuery.data === 'IDLE'}
+					<VadDeviceSelector />
+					<CompressionSelector />
+					<TranscriptionSelector />
+					<TransformationSelector />
+				{/if}
+				{#if getVadStateQuery.data === 'IDLE'}
+					<div class="flex">
+						<WhisperingButton
+							tooltipContent="Start voice activated recording"
+							onclick={commandCallbacks.toggleVadRecording}
+							variant="ghost"
+							size="icon"
+							style="view-transition-name: microphone-icon"
+							class="rounded-r-none border-r-0"
+						>
+							{vadStateToIcons[getVadStateQuery.data ?? 'IDLE']}
+						</WhisperingButton>
+						<RecordingModeSelector class="rounded-l-none" />
+					</div>
+				{:else}
+					<WhisperingButton
+						tooltipContent="Stop voice activated recording"
+						onclick={commandCallbacks.toggleVadRecording}
+						variant="ghost"
+						size="icon"
+						style="view-transition-name: microphone-icon"
+					>
+						{vadStateToIcons[getVadStateQuery.data ?? 'IDLE']}
+					</WhisperingButton>
+				{/if}
+			{:else if settings.value['recording.mode'] === 'upload'}
+				<CompressionSelector />
+				<TranscriptionSelector />
+				<TransformationSelector />
+				<RecordingModeSelector />
+			{:else if settings.value['recording.mode'] === 'live'}
+				<ManualDeviceSelector />
+				<CompressionSelector />
+				<TranscriptionSelector />
+				<TransformationSelector />
+				<div class="flex">
+					<WhisperingButton
+						tooltipContent="Toggle live recording"
+						onclick={() => {
+							// TODO: Implement live recording toggle
+							alert('Live recording not yet implemented');
+						}}
+						variant="ghost"
+						size="icon"
+						style="view-transition-name: microphone-icon"
+						class="rounded-r-none border-r-0"
+					>
+						🎬
+					</WhisperingButton>
+					<RecordingModeSelector class="rounded-l-none" />
+				</div>
+			{/if}
+		</div>
+		<NavItems class="-mr-4" collapsed={isMobile.current} />
+	</div>
+</header>
+
+{@render children()}

--- a/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
@@ -85,7 +85,7 @@
 	collapsible="icon"
 	side="left"
 	variant="sidebar"
-	class="overflow-x-hidden [&_[data-slot='sidebar-inner']]:group-data-[collapsible=icon]:opacity-40 [&_[data-slot='sidebar-inner']]:group-data-[collapsible=icon]:hover:opacity-100 [&_[data-slot='sidebar-inner']]:transition-opacity [&_[data-slot='sidebar-inner']]:duration-200"
+	class="overflow-x-hidden [&_[data-slot='sidebar-inner']]:group-data-[collapsible=icon]:[filter:grayscale(50%)] [&_[data-slot='sidebar-inner']]:group-data-[collapsible=icon]:opacity-80 [&_[data-slot='sidebar-inner']]:group-data-[collapsible=icon]:hover:[filter:grayscale(0%)] [&_[data-slot='sidebar-inner']]:group-data-[collapsible=icon]:hover:opacity-100 [&_[data-slot='sidebar-inner']]:transition-[filter,opacity] [&_[data-slot='sidebar-inner']]:duration-200"
 >
 	<Sidebar.Rail />
 	<Sidebar.Header

--- a/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
@@ -166,12 +166,12 @@
 					<Sidebar.MenuItem>
 						{#if settings.value['recording.mode'] === 'manual'}
 							<ManualDeviceSelector
-								showLabel={sidebar.state === 'expanded'}
+								showLabel={sidebar.state === 'expanded' || sidebar.isMobile}
 								unstyled
 							/>
 						{:else if settings.value['recording.mode'] === 'vad'}
 							<VadDeviceSelector
-								showLabel={sidebar.state === 'expanded'}
+								showLabel={sidebar.state === 'expanded' || sidebar.isMobile}
 								unstyled
 							/>
 						{:else}
@@ -196,7 +196,7 @@
 					<!-- Compression Selector -->
 					<Sidebar.MenuItem>
 						<CompressionSelector
-							showLabel={sidebar.state === 'expanded'}
+							showLabel={sidebar.state === 'expanded' || sidebar.isMobile}
 							unstyled
 						/>
 					</Sidebar.MenuItem>
@@ -204,7 +204,7 @@
 					<!-- Transcription Provider Selector -->
 					<Sidebar.MenuItem>
 						<TranscriptionSelector
-							showLabel={sidebar.state === 'expanded'}
+							showLabel={sidebar.state === 'expanded' || sidebar.isMobile}
 							unstyled
 						/>
 					</Sidebar.MenuItem>
@@ -212,7 +212,7 @@
 					<!-- Transformation Provider Selector -->
 					<Sidebar.MenuItem>
 						<TransformationSelector
-							showLabel={sidebar.state === 'expanded'}
+							showLabel={sidebar.state === 'expanded' || sidebar.isMobile}
 							unstyled
 						/>
 					</Sidebar.MenuItem>
@@ -237,7 +237,7 @@
 						<VadRecordingButton
 							{getVadStateQuery}
 							unstyled
-							showLabel={sidebar.state === 'expanded'}
+							showLabel={sidebar.state === 'expanded' || sidebar.isMobile}
 						/>
 					</Sidebar.MenuItem>
 
@@ -246,7 +246,7 @@
 						<ManualRecordingButton
 							{getRecorderStateQuery}
 							unstyled
-							showLabel={sidebar.state === 'expanded'}
+							showLabel={sidebar.state === 'expanded' || sidebar.isMobile}
 						/>
 					</Sidebar.MenuItem>
 

--- a/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
@@ -41,7 +41,7 @@
 
 	// Navigation items
 	const navItems = [
-		{ label: 'Home', href: '/verticalnav', icon: HomeIcon },
+		{ label: 'Home', href: '/verticalnav', icon: HomeIcon, exact: true },
 		{ label: 'Recordings', href: '/verticalnav/recordings', icon: ListIcon },
 		{
 			label: 'Transformations',
@@ -72,8 +72,12 @@
 	];
 
 	// Check if route is active
-	const isActive = (href: string) => {
-		return page.url.pathname === href;
+	const isActive = (href: string, exact: boolean = false) => {
+		if (exact) {
+			return page.url.pathname === href;
+		}
+		// For non-exact matches, check if pathname starts with href
+		return page.url.pathname.startsWith(href);
 	};
 </script>
 
@@ -106,6 +110,9 @@
 		</div>
 	</Sidebar.Header>
 
+	<!-- Divider after logo/branding (only visible when collapsed) -->
+	<Separator class="hidden group-data-[collapsible=icon]:block my-2" />
+
 	<Sidebar.Content class="overflow-x-hidden">
 		<!-- Main Navigation Group -->
 		<Sidebar.Group
@@ -117,16 +124,17 @@
 					class="gap-0.5 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:items-center"
 				>
 					{#each navItems as item}
+						{@const active = isActive(item.href, item.exact ?? false)}
 						<Sidebar.MenuItem class="relative">
-							{#if isActive(item.href)}
+							{#if active}
 								<div
 									class="absolute left-0 top-0 bottom-0 w-1 bg-primary z-10"
 								></div>
 							{/if}
 							<Sidebar.MenuButton
-								isActive={isActive(item.href)}
-								class={isActive(item.href)
-									? 'bg-primary/10 text-primary font-semibold'
+								isActive={active}
+								class={active
+									? '!bg-primary/20 !text-primary !font-semibold hover:!bg-primary/25'
 									: ''}
 							>
 								{#snippet child({ props })}

--- a/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
@@ -10,8 +10,9 @@
 		LogsIcon,
 		Minimize2Icon,
 		MicIcon,
+		PanelLeftIcon,
 	} from '@lucide/svelte';
-	import { EpicenterLogo, GithubIcon } from '$lib/components/icons';
+	import { GithubIcon } from '$lib/components/icons';
 	import { Separator } from '@repo/ui/separator';
 	import { page } from '$app/state';
 	import { toggleMode } from 'mode-watcher';
@@ -99,14 +100,11 @@
 				class="flex items-center gap-2"
 				title="Toggle sidebar"
 			>
-				<EpicenterLogo
-					class="size-8 shrink-0 group-data-[collapsible=icon]:size-6"
-				/>
+				<PanelLeftIcon class="size-5 shrink-0" />
 				<span class="font-bold text-base group-data-[collapsible=icon]:hidden">
 					Whispering
 				</span>
 			</button>
-			<Sidebar.Trigger class="group-data-[collapsible=icon]:hidden" />
 		</div>
 	</Sidebar.Header>
 

--- a/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
@@ -21,6 +21,9 @@
 	import { notificationLog } from '$lib/components/NotificationLog.svelte';
 	import type { CreateQueryResult } from '@tanstack/svelte-query';
 	import { useSidebar } from '@repo/ui/sidebar';
+	import ManualDeviceSelector from '$lib/components/settings/selectors/ManualDeviceSelector.svelte';
+	import VadDeviceSelector from '$lib/components/settings/selectors/VadDeviceSelector.svelte';
+	import { settings } from '$lib/stores/settings.svelte';
 
 	let {
 		getRecorderStateQuery,
@@ -76,9 +79,8 @@
 		},
 	] as const;
 
-	// Quick Settings placeholder items
+	// Quick Settings placeholder items (excluding device selector)
 	const quickSettingsPlaceholders = [
-		{ label: 'Device Selector', icon: MicIcon },
 		{ label: 'Compression', icon: SlidersIcon },
 		{ label: 'Transcription Provider', icon: WandIcon },
 		{ label: 'Transformation Provider', icon: LayersIcon },
@@ -99,14 +101,17 @@
 <Sidebar.Root collapsible="icon" side="left" variant="sidebar">
 	<Sidebar.Rail />
 	<Sidebar.Header>
-		<div class="flex items-center justify-between gap-2 px-2 py-2">
+		<div class="flex items-center justify-between gap-2">
 			<button
 				onclick={sidebar.toggle}
-				class="flex items-center gap-2 hover:opacity-80 transition-opacity"
+				class="flex items-center gap-2 p-2 hover:bg-sidebar-accent rounded-md transition-colors w-full"
 				title="Toggle sidebar"
 			>
-				<span class="text-2xl">🎙️</span>
-				<span class="font-bold text-lg group-data-[collapsible=icon]:hidden">
+				<span
+					class="flex items-center justify-center size-4 text-base leading-none"
+					>🎙️</span
+				>
+				<span class="font-bold text-base group-data-[collapsible=icon]:hidden">
 					Whispering
 				</span>
 			</button>
@@ -136,11 +141,34 @@
 			</Sidebar.GroupContent>
 		</Sidebar.Group>
 
-		<!-- Quick Settings Group (Placeholder) -->
+		<!-- Quick Settings Group -->
 		<Sidebar.Group>
 			<Sidebar.GroupLabel>Quick Settings</Sidebar.GroupLabel>
 			<Sidebar.GroupContent>
 				<Sidebar.Menu>
+					<!-- Device Selector (mode-aware) -->
+					<Sidebar.MenuItem>
+						{#if settings.value['recording.mode'] === 'manual'}
+							<ManualDeviceSelector showLabel unstyled />
+						{:else if settings.value['recording.mode'] === 'vad'}
+							<VadDeviceSelector showLabel unstyled />
+						{:else}
+							<Sidebar.MenuButton disabled>
+								{#snippet child({ props })}
+									<button
+										{...props}
+										disabled
+										title="Device selector (not available in upload mode)"
+									>
+										<MicIcon />
+										<span class="text-muted-foreground">Device Selector</span>
+									</button>
+								{/snippet}
+							</Sidebar.MenuButton>
+						{/if}
+					</Sidebar.MenuItem>
+
+					<!-- Other placeholders -->
 					{#each quickSettingsPlaceholders as item}
 						<Sidebar.MenuItem>
 							<Sidebar.MenuButton disabled>

--- a/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
@@ -77,29 +77,36 @@
 	};
 </script>
 
-<Sidebar.Root collapsible="icon" side="left" variant="sidebar">
+<Sidebar.Root
+	collapsible="icon"
+	side="left"
+	variant="sidebar"
+	class="overflow-x-hidden"
+>
 	<Sidebar.Rail />
 	<Sidebar.Header
 		class="group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center"
 	>
-		<button
-			onclick={sidebar.toggle}
+		<div
 			class="flex items-center justify-between gap-2 p-2 hover:bg-sidebar-accent rounded-md transition-[width,height,padding] w-full group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-1! group-data-[collapsible=icon]:w-auto"
-			title="Toggle sidebar"
 		>
-			<div class="flex items-center gap-2">
+			<button
+				onclick={sidebar.toggle}
+				class="flex items-center gap-2"
+				title="Toggle sidebar"
+			>
 				<EpicenterLogo
 					class="size-8 shrink-0 group-data-[collapsible=icon]:size-6"
 				/>
 				<span class="font-bold text-base group-data-[collapsible=icon]:hidden">
 					Whispering
 				</span>
-			</div>
+			</button>
 			<Sidebar.Trigger class="group-data-[collapsible=icon]:hidden" />
-		</button>
+		</div>
 	</Sidebar.Header>
 
-	<Sidebar.Content>
+	<Sidebar.Content class="overflow-x-hidden">
 		<!-- Main Navigation Group -->
 		<Sidebar.Group
 			class="p-1 pb-0 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:items-center"
@@ -110,8 +117,18 @@
 					class="gap-0.5 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:items-center"
 				>
 					{#each navItems as item}
-						<Sidebar.MenuItem>
-							<Sidebar.MenuButton isActive={isActive(item.href)}>
+						<Sidebar.MenuItem class="relative">
+							{#if isActive(item.href)}
+								<div
+									class="absolute left-0 top-0 bottom-0 w-1 bg-primary z-10"
+								></div>
+							{/if}
+							<Sidebar.MenuButton
+								isActive={isActive(item.href)}
+								class={isActive(item.href)
+									? 'bg-primary/10 text-primary font-semibold'
+									: ''}
+							>
 								{#snippet child({ props })}
 									<a href={item.href} {...props} title={item.label}>
 										<svelte:component this={item.icon} />
@@ -135,7 +152,7 @@
 			<Sidebar.GroupLabel>Quick Settings</Sidebar.GroupLabel>
 			<Sidebar.GroupContent>
 				<Sidebar.Menu
-					class="gap-0.5 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:items-center"
+					class="gap-0.5 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:items-center overflow-x-hidden"
 				>
 					<!-- Device Selector (mode-aware) -->
 					<Sidebar.MenuItem>
@@ -205,7 +222,7 @@
 			<Sidebar.GroupLabel>Quick Transcription</Sidebar.GroupLabel>
 			<Sidebar.GroupContent>
 				<Sidebar.Menu
-					class="gap-0.5 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:items-center"
+					class="gap-0.5 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:items-center overflow-x-hidden"
 				>
 					<!-- VAD Recording Button (toggles start/stop) -->
 					<Sidebar.MenuItem>
@@ -260,7 +277,7 @@
 		>
 			<Sidebar.GroupContent>
 				<Sidebar.Menu
-					class="gap-0.5 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:items-center"
+					class="gap-0.5 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:items-center overflow-x-hidden"
 				>
 					<!-- Toggle dark mode -->
 					<Sidebar.MenuItem>
@@ -307,7 +324,7 @@
 
 	<Sidebar.Footer>
 		<Sidebar.Menu
-			class="gap-0.5 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:items-center"
+			class="gap-0.5 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:items-center overflow-x-hidden"
 		>
 			{#each footerItems as item}
 				<Sidebar.MenuItem>

--- a/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
@@ -82,23 +82,21 @@
 	<Sidebar.Header
 		class="group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center"
 	>
-		<div
-			class="flex items-center justify-between gap-2 group-data-[collapsible=icon]:w-auto"
+		<button
+			onclick={sidebar.toggle}
+			class="flex items-center justify-between gap-2 p-2 hover:bg-sidebar-accent rounded-md transition-[width,height,padding] w-full group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-1! group-data-[collapsible=icon]:w-auto"
+			title="Toggle sidebar"
 		>
-			<button
-				onclick={sidebar.toggle}
-				class="flex items-center gap-2 p-2 hover:bg-sidebar-accent rounded-md transition-[width,height,padding] w-full group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-1!"
-				title="Toggle sidebar"
-			>
+			<div class="flex items-center gap-2">
 				<EpicenterLogo
 					class="size-8 shrink-0 group-data-[collapsible=icon]:size-6"
 				/>
 				<span class="font-bold text-base group-data-[collapsible=icon]:hidden">
 					Whispering
 				</span>
-			</button>
+			</div>
 			<Sidebar.Trigger class="group-data-[collapsible=icon]:hidden" />
-		</div>
+		</button>
 	</Sidebar.Header>
 
 	<Sidebar.Content>

--- a/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
@@ -288,6 +288,9 @@
 		<!-- Divider (only visible when collapsed) -->
 		<Separator class="hidden group-data-[collapsible=icon]:block my-2" />
 
+		<!-- Spacer to push Additional Actions to bottom -->
+		<div class="flex-grow"></div>
+
 		<!-- Additional Actions (scrollable, not sticky) -->
 		<Sidebar.Group
 			class="p-1 pb-0 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:items-center"

--- a/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
@@ -12,6 +12,7 @@
 		MicIcon,
 	} from '@lucide/svelte';
 	import { EpicenterLogo, GithubIcon } from '$lib/components/icons';
+	import { Separator } from '@repo/ui/separator';
 	import { page } from '$app/state';
 	import { toggleMode } from 'mode-watcher';
 	import { getCurrentWindow, LogicalSize } from '@tauri-apps/api/window';
@@ -126,6 +127,9 @@
 			</Sidebar.GroupContent>
 		</Sidebar.Group>
 
+		<!-- Divider (only visible when collapsed) -->
+		<Separator class="hidden group-data-[collapsible=icon]:block my-2" />
+
 		<!-- Quick Settings Group -->
 		<Sidebar.Group
 			class="p-1 pb-0 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:items-center"
@@ -193,6 +197,9 @@
 			</Sidebar.GroupContent>
 		</Sidebar.Group>
 
+		<!-- Divider (only visible when collapsed) -->
+		<Separator class="hidden group-data-[collapsible=icon]:block my-2" />
+
 		<!-- Quick Transcription Group -->
 		<Sidebar.Group
 			class="p-1 pb-0 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:items-center"
@@ -245,6 +252,9 @@
 				</Sidebar.Menu>
 			</Sidebar.GroupContent>
 		</Sidebar.Group>
+
+		<!-- Divider (only visible when collapsed) -->
+		<Separator class="hidden group-data-[collapsible=icon]:block my-2" />
 
 		<!-- Additional Actions (scrollable, not sticky) -->
 		<Sidebar.Group

--- a/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
@@ -138,7 +138,16 @@
 									: ''}
 							>
 								{#snippet child({ props })}
-									<a href={item.href} {...props} title={item.label}>
+									<a
+										href={item.href}
+										{...props}
+										title={item.label}
+										onclick={() => {
+											if (sidebar.isMobile) {
+												sidebar.setOpenMobile(false);
+											}
+										}}
+									>
 										<svelte:component this={item.icon} />
 										<span>{item.label}</span>
 									</a>

--- a/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
@@ -24,6 +24,8 @@
 	import ManualDeviceSelector from '$lib/components/settings/selectors/ManualDeviceSelector.svelte';
 	import VadDeviceSelector from '$lib/components/settings/selectors/VadDeviceSelector.svelte';
 	import CompressionSelector from '$lib/components/settings/selectors/CompressionSelector.svelte';
+	import TranscriptionSelector from '$lib/components/settings/selectors/TranscriptionSelector.svelte';
+	import TransformationSelector from '$lib/components/settings/selectors/TransformationSelector.svelte';
 	import { settings } from '$lib/stores/settings.svelte';
 
 	let {
@@ -80,11 +82,8 @@
 		},
 	] as const;
 
-	// Quick Settings placeholder items (excluding device selector and compression)
-	const quickSettingsPlaceholders = [
-		{ label: 'Transcription Provider', icon: WandIcon },
-		{ label: 'Transformation Provider', icon: LayersIcon },
-	] as const;
+	// Quick Settings - no placeholders remaining, all implemented
+	const quickSettingsPlaceholders = [] as const;
 
 	// Quick Transcription placeholder items
 	const quickTranscriptionPlaceholders = [
@@ -173,19 +172,15 @@
 						<CompressionSelector showLabel unstyled />
 					</Sidebar.MenuItem>
 
-					<!-- Other placeholders -->
-					{#each quickSettingsPlaceholders as item}
-						<Sidebar.MenuItem>
-							<Sidebar.MenuButton disabled>
-								{#snippet child({ props })}
-									<button {...props} disabled title={`TODO: ${item.label}`}>
-										<svelte:component this={item.icon} />
-										<span class="text-muted-foreground">{item.label}</span>
-									</button>
-								{/snippet}
-							</Sidebar.MenuButton>
-						</Sidebar.MenuItem>
-					{/each}
+					<!-- Transcription Provider Selector -->
+					<Sidebar.MenuItem>
+						<TranscriptionSelector showLabel unstyled />
+					</Sidebar.MenuItem>
+
+					<!-- Transformation Provider Selector -->
+					<Sidebar.MenuItem>
+						<TransformationSelector showLabel unstyled />
+					</Sidebar.MenuItem>
 				</Sidebar.Menu>
 			</Sidebar.GroupContent>
 		</Sidebar.Group>

--- a/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
@@ -1,0 +1,226 @@
+<script lang="ts">
+	import * as Sidebar from '@repo/ui/sidebar';
+	import {
+		HomeIcon,
+		ListIcon,
+		LayersIcon,
+		SettingsIcon,
+		SunIcon,
+		MoonIcon,
+		LogsIcon,
+		Minimize2Icon,
+		MicIcon,
+		WandIcon,
+		SlidersIcon,
+		SquareIcon,
+	} from '@lucide/svelte';
+	import { GithubIcon } from '$lib/components/icons';
+	import { page } from '$app/state';
+	import { toggleMode } from 'mode-watcher';
+	import { getCurrentWindow, LogicalSize } from '@tauri-apps/api/window';
+	import { notificationLog } from '$lib/components/NotificationLog.svelte';
+	import type { CreateQueryResult } from '@tanstack/svelte-query';
+	import { useSidebar } from '@repo/ui/sidebar';
+
+	let {
+		getRecorderStateQuery,
+		getVadStateQuery,
+	}: {
+		getRecorderStateQuery: CreateQueryResult<any>;
+		getVadStateQuery: CreateQueryResult<any>;
+	} = $props();
+
+	const sidebar = useSidebar();
+
+	// Navigation items
+	const navItems = [
+		{ label: 'Home', href: '/verticalnav', icon: HomeIcon },
+		{ label: 'Recordings', href: '/verticalnav/recordings', icon: ListIcon },
+		{
+			label: 'Transformations',
+			href: '/verticalnav/transformations',
+			icon: LayersIcon,
+		},
+		{ label: 'Settings', href: '/verticalnav/settings', icon: SettingsIcon },
+	] as const;
+
+	// Footer items with conditional Tauri-only minimize
+	const footerItems = [
+		{
+			label: 'Toggle dark mode',
+			icon: SunIcon,
+			action: toggleMode,
+			isTheme: true,
+		},
+		{
+			label: 'View project on GitHub',
+			icon: GithubIcon,
+			href: 'https://github.com/epicenter-md/epicenter',
+			external: true,
+		},
+		...(window.__TAURI_INTERNALS__
+			? [
+					{
+						label: 'Minimize',
+						icon: Minimize2Icon,
+						action: () => getCurrentWindow().setSize(new LogicalSize(72, 84)),
+					},
+				]
+			: []),
+		{
+			label: 'Notification History',
+			icon: LogsIcon,
+			action: () => {
+				notificationLog.isOpen = true;
+			},
+		},
+	] as const;
+
+	// Quick Settings placeholder items
+	const quickSettingsPlaceholders = [
+		{ label: 'Device Selector', icon: MicIcon },
+		{ label: 'Compression', icon: SlidersIcon },
+		{ label: 'Transcription Provider', icon: WandIcon },
+		{ label: 'Transformation Provider', icon: LayersIcon },
+	] as const;
+
+	// Quick Transcription placeholder items
+	const quickTranscriptionPlaceholders = [
+		{ label: 'Recording Controls', icon: SquareIcon },
+		{ label: 'Recording Mode', icon: MicIcon },
+	] as const;
+
+	// Check if route is active
+	const isActive = (href: string) => {
+		return page.url.pathname === href;
+	};
+</script>
+
+<Sidebar.Root collapsible="icon" side="left" variant="sidebar">
+	<Sidebar.Rail />
+	<Sidebar.Header>
+		<div class="flex items-center justify-between gap-2 px-2 py-2">
+			<button
+				onclick={sidebar.toggle}
+				class="flex items-center gap-2 hover:opacity-80 transition-opacity"
+				title="Toggle sidebar"
+			>
+				<span class="text-2xl">🎙️</span>
+				<span class="font-bold text-lg group-data-[collapsible=icon]:hidden">
+					Whispering
+				</span>
+			</button>
+			<Sidebar.Trigger class="group-data-[collapsible=icon]:hidden" />
+		</div>
+	</Sidebar.Header>
+
+	<Sidebar.Content>
+		<!-- Main Navigation Group -->
+		<Sidebar.Group>
+			<Sidebar.GroupLabel>Navigation</Sidebar.GroupLabel>
+			<Sidebar.GroupContent>
+				<Sidebar.Menu>
+					{#each navItems as item}
+						<Sidebar.MenuItem>
+							<Sidebar.MenuButton isActive={isActive(item.href)}>
+								{#snippet child({ props })}
+									<a href={item.href} {...props} title={item.label}>
+										<svelte:component this={item.icon} />
+										<span>{item.label}</span>
+									</a>
+								{/snippet}
+							</Sidebar.MenuButton>
+						</Sidebar.MenuItem>
+					{/each}
+				</Sidebar.Menu>
+			</Sidebar.GroupContent>
+		</Sidebar.Group>
+
+		<!-- Quick Settings Group (Placeholder) -->
+		<Sidebar.Group>
+			<Sidebar.GroupLabel>Quick Settings</Sidebar.GroupLabel>
+			<Sidebar.GroupContent>
+				<Sidebar.Menu>
+					{#each quickSettingsPlaceholders as item}
+						<Sidebar.MenuItem>
+							<Sidebar.MenuButton disabled>
+								{#snippet child({ props })}
+									<button {...props} disabled title={`TODO: ${item.label}`}>
+										<svelte:component this={item.icon} />
+										<span class="text-muted-foreground">{item.label}</span>
+									</button>
+								{/snippet}
+							</Sidebar.MenuButton>
+						</Sidebar.MenuItem>
+					{/each}
+				</Sidebar.Menu>
+			</Sidebar.GroupContent>
+		</Sidebar.Group>
+
+		<!-- Quick Transcription Group (Placeholder) -->
+		<Sidebar.Group>
+			<Sidebar.GroupLabel>Quick Transcription</Sidebar.GroupLabel>
+			<Sidebar.GroupContent>
+				<Sidebar.Menu>
+					{#each quickTranscriptionPlaceholders as item}
+						<Sidebar.MenuItem>
+							<Sidebar.MenuButton disabled>
+								{#snippet child({ props })}
+									<button {...props} disabled title={`TODO: ${item.label}`}>
+										<svelte:component this={item.icon} />
+										<span class="text-muted-foreground">{item.label}</span>
+									</button>
+								{/snippet}
+							</Sidebar.MenuButton>
+						</Sidebar.MenuItem>
+					{/each}
+				</Sidebar.Menu>
+			</Sidebar.GroupContent>
+		</Sidebar.Group>
+	</Sidebar.Content>
+
+	<Sidebar.Footer>
+		<Sidebar.Menu>
+			{#each footerItems as item}
+				<Sidebar.MenuItem>
+					{#if 'href' in item}
+						<Sidebar.MenuButton>
+							{#snippet child({ props })}
+								<a
+									href={item.href}
+									target={item.external ? '_blank' : undefined}
+									rel={item.external ? 'noopener noreferrer' : undefined}
+									{...props}
+									title={item.label}
+								>
+									<svelte:component this={item.icon} />
+									<span>{item.label}</span>
+								</a>
+							{/snippet}
+						</Sidebar.MenuButton>
+					{:else if 'action' in item}
+						<!-- Remove tooltip to fix click issue -->
+						<Sidebar.MenuButton>
+							{#snippet child({ props })}
+								<button onclick={item.action} {...props} title={item.label}>
+									{#if item.isTheme}
+										<!-- Theme toggle with animated icons -->
+										<SunIcon
+											class="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0"
+										/>
+										<MoonIcon
+											class="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100"
+										/>
+									{:else}
+										<svelte:component this={item.icon} />
+									{/if}
+									<span>{item.label}</span>
+								</button>
+							{/snippet}
+						</Sidebar.MenuButton>
+					{/if}
+				</Sidebar.MenuItem>
+			{/each}
+		</Sidebar.Menu>
+	</Sidebar.Footer>
+</Sidebar.Root>

--- a/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
@@ -23,6 +23,7 @@
 	import { useSidebar } from '@repo/ui/sidebar';
 	import ManualDeviceSelector from '$lib/components/settings/selectors/ManualDeviceSelector.svelte';
 	import VadDeviceSelector from '$lib/components/settings/selectors/VadDeviceSelector.svelte';
+	import CompressionSelector from '$lib/components/settings/selectors/CompressionSelector.svelte';
 	import { settings } from '$lib/stores/settings.svelte';
 
 	let {
@@ -79,9 +80,8 @@
 		},
 	] as const;
 
-	// Quick Settings placeholder items (excluding device selector)
+	// Quick Settings placeholder items (excluding device selector and compression)
 	const quickSettingsPlaceholders = [
-		{ label: 'Compression', icon: SlidersIcon },
 		{ label: 'Transcription Provider', icon: WandIcon },
 		{ label: 'Transformation Provider', icon: LayersIcon },
 	] as const;
@@ -166,6 +166,11 @@
 								{/snippet}
 							</Sidebar.MenuButton>
 						{/if}
+					</Sidebar.MenuItem>
+
+					<!-- Compression Selector -->
+					<Sidebar.MenuItem>
+						<CompressionSelector showLabel unstyled />
 					</Sidebar.MenuItem>
 
 					<!-- Other placeholders -->

--- a/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
@@ -11,7 +11,7 @@
 		Minimize2Icon,
 		MicIcon,
 	} from '@lucide/svelte';
-	import { GithubIcon } from '$lib/components/icons';
+	import { EpicenterLogo, GithubIcon } from '$lib/components/icons';
 	import { page } from '$app/state';
 	import { toggleMode } from 'mode-watcher';
 	import { getCurrentWindow, LogicalSize } from '@tauri-apps/api/window';
@@ -78,17 +78,20 @@
 
 <Sidebar.Root collapsible="icon" side="left" variant="sidebar">
 	<Sidebar.Rail />
-	<Sidebar.Header>
-		<div class="flex items-center justify-between gap-2">
+	<Sidebar.Header
+		class="group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center"
+	>
+		<div
+			class="flex items-center justify-between gap-2 group-data-[collapsible=icon]:w-auto"
+		>
 			<button
 				onclick={sidebar.toggle}
-				class="flex items-center gap-2 p-2 hover:bg-sidebar-accent rounded-md transition-colors w-full"
+				class="flex items-center gap-2 p-2 hover:bg-sidebar-accent rounded-md transition-[width,height,padding] w-full group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-1!"
 				title="Toggle sidebar"
 			>
-				<span
-					class="flex items-center justify-center size-4 text-base leading-none"
-					>🎙️</span
-				>
+				<EpicenterLogo
+					class="size-8 shrink-0 group-data-[collapsible=icon]:size-6"
+				/>
 				<span class="font-bold text-base group-data-[collapsible=icon]:hidden">
 					Whispering
 				</span>
@@ -99,10 +102,14 @@
 
 	<Sidebar.Content>
 		<!-- Main Navigation Group -->
-		<Sidebar.Group class="p-1 pb-0">
+		<Sidebar.Group
+			class="p-1 pb-0 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:items-center"
+		>
 			<Sidebar.GroupLabel>Navigation</Sidebar.GroupLabel>
 			<Sidebar.GroupContent>
-				<Sidebar.Menu class="gap-0.5">
+				<Sidebar.Menu
+					class="gap-0.5 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:items-center"
+				>
 					{#each navItems as item}
 						<Sidebar.MenuItem>
 							<Sidebar.MenuButton isActive={isActive(item.href)}>
@@ -120,16 +127,26 @@
 		</Sidebar.Group>
 
 		<!-- Quick Settings Group -->
-		<Sidebar.Group class="p-1 pb-0">
+		<Sidebar.Group
+			class="p-1 pb-0 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:items-center"
+		>
 			<Sidebar.GroupLabel>Quick Settings</Sidebar.GroupLabel>
 			<Sidebar.GroupContent>
-				<Sidebar.Menu class="gap-0.5">
+				<Sidebar.Menu
+					class="gap-0.5 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:items-center"
+				>
 					<!-- Device Selector (mode-aware) -->
 					<Sidebar.MenuItem>
 						{#if settings.value['recording.mode'] === 'manual'}
-							<ManualDeviceSelector showLabel unstyled />
+							<ManualDeviceSelector
+								showLabel={sidebar.state === 'expanded'}
+								unstyled
+							/>
 						{:else if settings.value['recording.mode'] === 'vad'}
-							<VadDeviceSelector showLabel unstyled />
+							<VadDeviceSelector
+								showLabel={sidebar.state === 'expanded'}
+								unstyled
+							/>
 						{:else}
 							<Sidebar.MenuButton disabled>
 								{#snippet child({ props })}
@@ -139,7 +156,10 @@
 										title="Device selector (not available in upload mode)"
 									>
 										<MicIcon />
-										<span class="text-muted-foreground">Device Selector</span>
+										<span
+											class="text-muted-foreground group-data-[collapsible=icon]:hidden"
+											>Device Selector</span
+										>
 									</button>
 								{/snippet}
 							</Sidebar.MenuButton>
@@ -148,35 +168,56 @@
 
 					<!-- Compression Selector -->
 					<Sidebar.MenuItem>
-						<CompressionSelector showLabel unstyled />
+						<CompressionSelector
+							showLabel={sidebar.state === 'expanded'}
+							unstyled
+						/>
 					</Sidebar.MenuItem>
 
 					<!-- Transcription Provider Selector -->
 					<Sidebar.MenuItem>
-						<TranscriptionSelector showLabel unstyled />
+						<TranscriptionSelector
+							showLabel={sidebar.state === 'expanded'}
+							unstyled
+						/>
 					</Sidebar.MenuItem>
 
 					<!-- Transformation Provider Selector -->
 					<Sidebar.MenuItem>
-						<TransformationSelector showLabel unstyled />
+						<TransformationSelector
+							showLabel={sidebar.state === 'expanded'}
+							unstyled
+						/>
 					</Sidebar.MenuItem>
 				</Sidebar.Menu>
 			</Sidebar.GroupContent>
 		</Sidebar.Group>
 
 		<!-- Quick Transcription Group -->
-		<Sidebar.Group class="p-1 pb-0">
+		<Sidebar.Group
+			class="p-1 pb-0 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:items-center"
+		>
 			<Sidebar.GroupLabel>Quick Transcription</Sidebar.GroupLabel>
 			<Sidebar.GroupContent>
-				<Sidebar.Menu class="gap-0.5">
+				<Sidebar.Menu
+					class="gap-0.5 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:items-center"
+				>
 					<!-- VAD Recording Button (toggles start/stop) -->
 					<Sidebar.MenuItem>
-						<VadRecordingButton {getVadStateQuery} unstyled showLabel />
+						<VadRecordingButton
+							{getVadStateQuery}
+							unstyled
+							showLabel={sidebar.state === 'expanded'}
+						/>
 					</Sidebar.MenuItem>
 
 					<!-- Manual Recording Button (toggles start/stop) -->
 					<Sidebar.MenuItem>
-						<ManualRecordingButton {getRecorderStateQuery} unstyled showLabel />
+						<ManualRecordingButton
+							{getRecorderStateQuery}
+							unstyled
+							showLabel={sidebar.state === 'expanded'}
+						/>
 					</Sidebar.MenuItem>
 
 					<!-- Cancel Manual Recording (fixed position - no layout shift) -->
@@ -184,7 +225,7 @@
 						<button
 							type="button"
 							onclick={commandCallbacks.cancelManualRecording}
-							class="peer/menu-button outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm transition-[width,height,padding,opacity] focus-visible:ring-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 {getRecorderStateQuery.data !==
+							class="peer/menu-button outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm transition-[width,height,padding,opacity] focus-visible:ring-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! {getRecorderStateQuery.data !==
 							'RECORDING'
 								? 'opacity-0 pointer-events-none'
 								: ''}"
@@ -196,7 +237,9 @@
 									>🚫</span
 								>
 							</div>
-							<span>Cancel recording</span>
+							<span class="group-data-[collapsible=icon]:hidden"
+								>Cancel recording</span
+							>
 						</button>
 					</Sidebar.MenuItem>
 				</Sidebar.Menu>
@@ -204,9 +247,13 @@
 		</Sidebar.Group>
 
 		<!-- Additional Actions (scrollable, not sticky) -->
-		<Sidebar.Group class="p-1 pb-0">
+		<Sidebar.Group
+			class="p-1 pb-0 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:items-center"
+		>
 			<Sidebar.GroupContent>
-				<Sidebar.Menu class="gap-0.5">
+				<Sidebar.Menu
+					class="gap-0.5 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:items-center"
+				>
 					<!-- Toggle dark mode -->
 					<Sidebar.MenuItem>
 						<Sidebar.MenuButton>
@@ -251,7 +298,9 @@
 	</Sidebar.Content>
 
 	<Sidebar.Footer>
-		<Sidebar.Menu class="gap-0.5">
+		<Sidebar.Menu
+			class="gap-0.5 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:items-center"
+		>
 			{#each footerItems as item}
 				<Sidebar.MenuItem>
 					{#if 'href' in item}

--- a/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte
@@ -85,7 +85,7 @@
 	collapsible="icon"
 	side="left"
 	variant="sidebar"
-	class="overflow-x-hidden"
+	class="overflow-x-hidden [&_[data-slot='sidebar-inner']]:group-data-[collapsible=icon]:opacity-40 [&_[data-slot='sidebar-inner']]:group-data-[collapsible=icon]:hover:opacity-100 [&_[data-slot='sidebar-inner']]:transition-opacity [&_[data-slot='sidebar-inner']]:duration-200"
 >
 	<Sidebar.Rail />
 	<Sidebar.Header

--- a/apps/whispering/src/routes/(app)/verticalnav/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+page.svelte
@@ -1,0 +1,413 @@
+<script lang="ts">
+	import { commandCallbacks } from '$lib/commands';
+	import NavItems from '$lib/components/NavItems.svelte';
+	import WhisperingButton from '$lib/components/WhisperingButton.svelte';
+	import CopyToClipboardButton from '$lib/components/copyable/CopyToClipboardButton.svelte';
+	import { ClipboardIcon } from '$lib/components/icons';
+	import {
+		CompressionSelector,
+		TranscriptionSelector,
+		TransformationSelector,
+	} from '$lib/components/settings';
+	import ManualDeviceSelector from '$lib/components/settings/selectors/ManualDeviceSelector.svelte';
+	import VadDeviceSelector from '$lib/components/settings/selectors/VadDeviceSelector.svelte';
+	import {
+		RECORDING_MODE_OPTIONS,
+		type RecordingMode,
+		recorderStateToIcons,
+		vadStateToIcons,
+	} from '$lib/constants/audio';
+	import { rpc } from '$lib/query';
+	import * as services from '$lib/services';
+	import type { Recording } from '$lib/services/db';
+	import { settings } from '$lib/stores/settings.svelte';
+	import { createBlobUrlManager } from '$lib/utils/blobUrlManager';
+	import { getRecordingTransitionId } from '$lib/utils/getRecordingTransitionId';
+	import { Loader2Icon } from '@lucide/svelte';
+	import {
+		ACCEPT_AUDIO,
+		ACCEPT_VIDEO,
+		FileDropZone,
+		MEGABYTE,
+	} from '@repo/ui/file-drop-zone';
+	import * as ToggleGroup from '@repo/ui/toggle-group';
+	import { createQuery } from '@tanstack/svelte-query';
+	import type { UnlistenFn } from '@tauri-apps/api/event';
+	import { onDestroy, onMount } from 'svelte';
+	import TranscribedTextDialog from '$lib/components/copyable/TranscribedTextDialog.svelte';
+
+	const getRecorderStateQuery = createQuery(
+		rpc.recorder.getRecorderState.options,
+	);
+	const getVadStateQuery = createQuery(rpc.vadRecorder.getVadState.options);
+	const latestRecordingQuery = createQuery(rpc.db.recordings.getLatest.options);
+
+	const latestRecording = $derived<Recording>(
+		latestRecordingQuery.data ?? {
+			id: '',
+			title: '',
+			subtitle: '',
+			createdAt: '',
+			updatedAt: '',
+			timestamp: '',
+			blob: new Blob(),
+			transcribedText: '',
+			transcriptionStatus: 'UNPROCESSED',
+		},
+	);
+
+	const blobUrlManager = createBlobUrlManager();
+
+	const blobUrl = $derived.by(() => {
+		if (!latestRecording.blob) return undefined;
+		return blobUrlManager.createUrl(latestRecording.blob);
+	});
+
+	const hasNoTranscribedText = $derived(
+		!latestRecording.transcribedText?.trim(),
+	);
+
+	const availableModes = $derived(
+		RECORDING_MODE_OPTIONS.filter((mode) => {
+			if (!mode.desktopOnly) return true;
+			// Desktop only, only show if Tauri is available
+			return window.__TAURI_INTERNALS__;
+		}),
+	);
+
+	const AUDIO_EXTENSIONS = [
+		'mp3',
+		'wav',
+		'm4a',
+		'aac',
+		'ogg',
+		'flac',
+		'wma',
+		'opus',
+	] as const;
+
+	const VIDEO_EXTENSIONS = [
+		'mp4',
+		'avi',
+		'mov',
+		'wmv',
+		'flv',
+		'mkv',
+		'webm',
+		'm4v',
+	] as const;
+
+	// Store unlisten function for drag drop events
+	let unlistenDragDrop: UnlistenFn | undefined;
+
+	// Set up desktop drag and drop listener
+	onMount(async () => {
+		if (!window.__TAURI_INTERNALS__) return;
+		try {
+			const { getCurrentWebview } = await import('@tauri-apps/api/webview');
+			const { extname } = await import('@tauri-apps/api/path');
+
+			const isAudio = async (path: string) =>
+				AUDIO_EXTENSIONS.includes(
+					(await extname(path)) as (typeof AUDIO_EXTENSIONS)[number],
+				);
+			const isVideo = async (path: string) =>
+				VIDEO_EXTENSIONS.includes(
+					(await extname(path)) as (typeof VIDEO_EXTENSIONS)[number],
+				);
+
+			unlistenDragDrop = await getCurrentWebview().onDragDropEvent(
+				async (event) => {
+					if (settings.value['recording.mode'] !== 'upload') return;
+					if (event.payload.type !== 'drop' || event.payload.paths.length === 0)
+						return;
+
+					// Filter for audio/video files based on extension
+					const pathResults = await Promise.all(
+						event.payload.paths.map(async (path) => ({
+							path,
+							isValid: (await isAudio(path)) || (await isVideo(path)),
+						})),
+					);
+					const validPaths = pathResults
+						.filter(({ isValid }) => isValid)
+						.map(({ path }) => path);
+
+					if (validPaths.length === 0) {
+						rpc.notify.warning.execute({
+							title: '⚠️ No valid files',
+							description: 'Please drop audio or video files',
+						});
+						return;
+					}
+
+					await settings.switchRecordingMode('upload');
+
+					// Convert file paths to File objects using the fs service
+					const { data: files, error } =
+						await services.fs.pathsToFiles(validPaths);
+
+					if (error) {
+						rpc.notify.error.execute({
+							title: '❌ Failed to read files',
+							description: error.message,
+						});
+						return;
+					}
+
+					if (files.length > 0) {
+						await rpc.commands.uploadRecordings.execute({ files });
+					}
+				},
+			);
+		} catch (error) {
+			rpc.notify.error.execute({
+				title: '❌ Failed to set up drag drop listener',
+				description: `${error}`,
+			});
+		}
+	});
+
+	onDestroy(() => {
+		blobUrlManager.revokeCurrentUrl();
+		unlistenDragDrop?.();
+	});
+</script>
+
+<svelte:head>
+	<title>Whispering</title>
+</svelte:head>
+
+<main class="flex flex-1 flex-col items-center justify-center gap-4">
+	<!-- Container wrapper for consistent max-width -->
+	<div class="w-full max-w-2xl px-4 flex flex-col items-center gap-4">
+		<div class="xs:flex hidden flex-col items-center gap-4">
+			<h1 class="scroll-m-20 text-4xl font-bold tracking-tight lg:text-5xl">
+				Whispering
+			</h1>
+			<p class="text-muted-foreground text-center">
+				Press shortcut → speak → get text. Free and open source ❤️
+			</p>
+		</div>
+
+		<ToggleGroup.Root
+			type="single"
+			bind:value={
+				() => settings.value['recording.mode'],
+				(mode) => {
+					if (!mode) return;
+					settings.switchRecordingMode(mode);
+				}
+			}
+			class="w-full"
+		>
+			{#each availableModes as option}
+				<ToggleGroup.Item
+					value={option.value}
+					aria-label={`Switch to ${option.label.toLowerCase()} mode`}
+				>
+					{option.icon}
+					{option.label}
+				</ToggleGroup.Item>
+			{/each}
+		</ToggleGroup.Root>
+
+		<div class="w-full flex justify-center pt-1">
+			{#if settings.value['recording.mode'] === 'manual'}
+				<!-- Container with relative positioning for the button and absolute selectors -->
+				<div class="relative">
+					<!-- Recording button -->
+					<WhisperingButton
+						tooltipContent={getRecorderStateQuery.data === 'IDLE'
+							? 'Start recording'
+							: 'Stop recording'}
+						onclick={commandCallbacks.toggleManualRecording}
+						variant="ghost"
+						class="shrink-0 size-32 sm:size-36 lg:size-40 xl:size-44 transform items-center justify-center overflow-hidden duration-300 ease-in-out"
+					>
+						<span
+							style="filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.5)); view-transition-name: microphone-icon;"
+							class="text-[100px] sm:text-[110px] lg:text-[120px] xl:text-[130px] leading-none"
+						>
+							{recorderStateToIcons[getRecorderStateQuery.data ?? 'IDLE']}
+						</span>
+					</WhisperingButton>
+					<!-- Absolutely positioned selectors -->
+					{#if getRecorderStateQuery.data === 'RECORDING'}
+						<div class="absolute -right-12 bottom-4 flex items-center">
+							<WhisperingButton
+								tooltipContent="Cancel recording"
+								onclick={commandCallbacks.cancelManualRecording}
+								variant="ghost"
+								size="icon"
+								style="view-transition-name: cancel-icon;"
+							>
+								🚫
+							</WhisperingButton>
+						</div>
+					{:else}
+						<div class="absolute -right-32 bottom-4 flex items-center gap-0.5">
+							<ManualDeviceSelector />
+							<CompressionSelector />
+							<TranscriptionSelector />
+							<TransformationSelector />
+						</div>
+					{/if}
+				</div>
+			{:else if settings.value['recording.mode'] === 'vad'}
+				<!-- Container with relative positioning for the button and absolute selectors -->
+				<div class="relative">
+					<!-- Recording button -->
+					<WhisperingButton
+						tooltipContent={getVadStateQuery.data === 'IDLE'
+							? 'Start voice activated session'
+							: 'Stop voice activated session'}
+						onclick={commandCallbacks.toggleVadRecording}
+						variant="ghost"
+						class="shrink-0 size-32 sm:size-36 lg:size-40 xl:size-44 transform items-center justify-center overflow-hidden duration-300 ease-in-out"
+					>
+						<span
+							style="filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.5)); view-transition-name: microphone-icon;"
+							class="text-[100px] sm:text-[110px] lg:text-[120px] xl:text-[130px] leading-none"
+						>
+							{vadStateToIcons[getVadStateQuery.data ?? 'IDLE']}
+						</span>
+					</WhisperingButton>
+					<!-- Absolutely positioned selectors -->
+					{#if getVadStateQuery.data === 'IDLE'}
+						<div class="absolute -right-32 bottom-4 flex items-center gap-0.5">
+							<VadDeviceSelector />
+							<CompressionSelector />
+							<TranscriptionSelector />
+							<TransformationSelector />
+						</div>
+					{/if}
+				</div>
+			{:else if settings.value['recording.mode'] === 'upload'}
+				<!-- Full width spanning all columns -->
+				<div class="col-span-3 flex flex-col items-center gap-4 w-full">
+					<FileDropZone
+						accept="{ACCEPT_AUDIO}, {ACCEPT_VIDEO}"
+						maxFiles={10}
+						maxFileSize={25 * MEGABYTE}
+						onUpload={(files) => {
+							if (files.length > 0) {
+								rpc.commands.uploadRecordings.execute({ files });
+							}
+						}}
+						onFileRejected={({ file, reason }) => {
+							rpc.notify.error.execute({
+								title: '❌ File rejected',
+								description: `${file.name}: ${reason}`,
+							});
+						}}
+						class="h-32 sm:h-36 lg:h-40 xl:h-44 w-full"
+					/>
+					<div class="flex items-center gap-1.5">
+						<CompressionSelector />
+						<TranscriptionSelector />
+						<TransformationSelector />
+					</div>
+				</div>
+			{/if}
+		</div>
+
+		<div class="xxs:flex hidden w-full flex-col items-center gap-2">
+			<div class="flex w-full items-center gap-2">
+				<div class="flex-1">
+					<TranscribedTextDialog
+						recordingId={latestRecording.id}
+						transcribedText={latestRecording.transcriptionStatus ===
+						'TRANSCRIBING'
+							? '...'
+							: latestRecording.transcribedText}
+						rows={1}
+						disabled={latestRecording.transcriptionStatus === 'TRANSCRIBING' ||
+							hasNoTranscribedText}
+					/>
+				</div>
+				<CopyToClipboardButton
+					contentDescription="transcribed text"
+					textToCopy={latestRecording.transcribedText}
+					viewTransitionName={getRecordingTransitionId({
+						recordingId: latestRecording.id,
+						propertyName: 'transcribedText',
+					})}
+					size="default"
+					variant="secondary"
+					disabled={latestRecording.transcriptionStatus === 'TRANSCRIBING' ||
+						hasNoTranscribedText}
+				>
+					{#if latestRecording.transcriptionStatus === 'TRANSCRIBING'}
+						<Loader2Icon class="size-6 animate-spin" />
+					{:else}
+						<ClipboardIcon class="size-6" />
+					{/if}
+				</CopyToClipboardButton>
+			</div>
+
+			{#if blobUrl}
+				<audio
+					style="view-transition-name: {getRecordingTransitionId({
+						recordingId: latestRecording.id,
+						propertyName: 'blob',
+					})}"
+					src={blobUrl}
+					controls
+					class="h-8 w-full"
+				></audio>
+			{/if}
+		</div>
+
+		<NavItems class="xs:flex -mb-2.5 -mt-1 hidden" />
+
+		<div class="xs:flex hidden flex-col items-center gap-3">
+			<p class="text-foreground/75 text-center text-sm">
+				Click the microphone or press
+				{' '}<WhisperingButton
+					tooltipContent="Go to local shortcut in settings"
+					href="/settings/shortcuts/local"
+					variant="link"
+				>
+					<kbd
+						class="bg-muted relative rounded px-[0.3rem] py-[0.15rem] font-mono text-sm font-semibold"
+					>
+						{settings.value['shortcuts.local.toggleManualRecording']}
+					</kbd>
+				</WhisperingButton>{' '}
+				to start recording here.
+			</p>
+			{#if window.__TAURI_INTERNALS__}
+				<p class="text-foreground/75 text-sm">
+					Press
+					{' '}<WhisperingButton
+						tooltipContent="Go to global shortcut in settings"
+						href="/settings/shortcuts/global"
+						variant="link"
+					>
+						<kbd
+							class="bg-muted relative rounded px-[0.3rem] py-[0.15rem] font-mono text-sm font-semibold"
+						>
+							{settings.value['shortcuts.global.toggleManualRecording']}
+						</kbd>
+					</WhisperingButton>{' '}
+					to start recording anywhere.
+				</p>
+			{/if}
+			<p class="text-muted-foreground text-center text-sm font-light">
+				{#if !window.__TAURI_INTERNALS__}
+					Tired of switching tabs?
+					<WhisperingButton
+						tooltipContent="Get Whispering for desktop"
+						href="https://epicenter.so/whispering"
+						target="_blank"
+						rel="noopener noreferrer"
+						variant="link"
+					>
+						Get the native desktop app
+					</WhisperingButton>
+				{/if}
+			</p>
+		</div>
+	</div>
+</main>

--- a/apps/whispering/src/routes/(app)/verticalnav/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+page.svelte
@@ -185,10 +185,7 @@
 	<!-- Container wrapper for consistent max-width -->
 	<div class="w-full max-w-2xl px-4 flex flex-col items-center gap-4">
 		<div class="xs:flex hidden flex-col items-center gap-4">
-			<h1
-				class="scroll-m-20 text-4xl font-bold tracking-tight lg:text-5xl transition-opacity"
-				class:invisible={sidebar.state === 'expanded' && !sidebar.isMobile}
-			>
+			<h1 class="scroll-m-20 text-4xl font-bold tracking-tight lg:text-5xl">
 				Whispering
 			</h1>
 			<p class="text-muted-foreground text-center">

--- a/apps/whispering/src/routes/(app)/verticalnav/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+page.svelte
@@ -359,7 +359,8 @@
 			{/if}
 		</div>
 
-		<NavItems class="xs:flex -mb-2.5 -mt-1 hidden" />
+		<!-- TODO: Remove NavItems - using VerticalNav sidebar instead -->
+		<!-- <NavItems class="xs:flex -mb-2.5 -mt-1 hidden" /> -->
 
 		<div class="xs:flex hidden flex-col items-center gap-3">
 			<p class="text-foreground/75 text-center text-sm">
@@ -407,6 +408,21 @@
 						Get the native desktop app
 					</WhisperingButton>
 				{/if}
+			</p>
+		</div>
+
+		<!-- Layout Switcher (Development) -->
+		<div class="mt-8 pt-4 border-t border-border/40">
+			<p class="text-muted-foreground text-center text-sm">
+				<strong>Dev:</strong> Switch to{' '}
+				<WhisperingButton
+					href="/"
+					variant="link"
+					class="text-sm"
+					tooltipContent="Switch to topbar layout"
+				>
+					Topbar Layout
+				</WhisperingButton>
 			</p>
 		</div>
 	</div>

--- a/apps/whispering/src/routes/(app)/verticalnav/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+page.svelte
@@ -187,7 +187,7 @@
 		<div class="xs:flex hidden flex-col items-center gap-4">
 			<h1
 				class="scroll-m-20 text-4xl font-bold tracking-tight lg:text-5xl transition-opacity"
-				class:invisible={sidebar.state === 'expanded'}
+				class:invisible={sidebar.state === 'expanded' && !sidebar.isMobile}
 			>
 				Whispering
 			</h1>

--- a/apps/whispering/src/routes/(app)/verticalnav/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+page.svelte
@@ -251,8 +251,8 @@
 								🚫
 							</WhisperingButton>
 						</div>
-					{:else if false}
-						<!-- Selectors hidden - available in sidebar Quick Settings -->
+					{:else}
+						<!-- Quick Settings Controls -->
 						<div class="absolute -right-32 bottom-4 flex items-center gap-0.5">
 							<ManualDeviceSelector />
 							<CompressionSelector />
@@ -281,15 +281,13 @@
 						</span>
 					</WhisperingButton>
 					<!-- Absolutely positioned selectors -->
-					{#if false}
-						<!-- Selectors hidden - available in sidebar Quick Settings -->
-						<div class="absolute -right-32 bottom-4 flex items-center gap-0.5">
-							<VadDeviceSelector />
-							<CompressionSelector />
-							<TranscriptionSelector />
-							<TransformationSelector />
-						</div>
-					{/if}
+					<!-- Quick Settings Controls -->
+					<div class="absolute -right-32 bottom-4 flex items-center gap-0.5">
+						<VadDeviceSelector />
+						<CompressionSelector />
+						<TranscriptionSelector />
+						<TransformationSelector />
+					</div>
 				</div>
 			{:else if settings.value['recording.mode'] === 'upload'}
 				<!-- Full width spanning all columns -->
@@ -311,14 +309,12 @@
 						}}
 						class="h-32 sm:h-36 lg:h-40 xl:h-44 w-full"
 					/>
-					{#if false}
-						<!-- Selectors hidden - available in sidebar Quick Settings -->
-						<div class="flex items-center gap-1.5">
-							<CompressionSelector />
-							<TranscriptionSelector />
-							<TransformationSelector />
-						</div>
-					{/if}
+					<!-- Quick Settings Controls -->
+					<div class="flex items-center gap-1.5">
+						<CompressionSelector />
+						<TranscriptionSelector />
+						<TransformationSelector />
+					</div>
 				</div>
 			{/if}
 		</div>

--- a/apps/whispering/src/routes/(app)/verticalnav/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+page.svelte
@@ -363,8 +363,7 @@
 			{/if}
 		</div>
 
-		<!-- TODO: Remove NavItems - using VerticalNav sidebar instead -->
-		<!-- <NavItems class="xs:flex -mb-2.5 -mt-1 hidden" /> -->
+		<NavItems class="xs:flex -mb-2.5 -mt-1 hidden" pathPrefix="/verticalnav" />
 
 		<div class="xs:flex hidden flex-col items-center gap-3">
 			<p class="text-foreground/75 text-center text-sm">

--- a/apps/whispering/src/routes/(app)/verticalnav/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/+page.svelte
@@ -30,11 +30,14 @@
 		FileDropZone,
 		MEGABYTE,
 	} from '@repo/ui/file-drop-zone';
+	import { useSidebar } from '@repo/ui/sidebar';
 	import * as ToggleGroup from '@repo/ui/toggle-group';
 	import { createQuery } from '@tanstack/svelte-query';
 	import type { UnlistenFn } from '@tauri-apps/api/event';
 	import { onDestroy, onMount } from 'svelte';
 	import TranscribedTextDialog from '$lib/components/copyable/TranscribedTextDialog.svelte';
+
+	const sidebar = useSidebar();
 
 	const getRecorderStateQuery = createQuery(
 		rpc.recorder.getRecorderState.options,
@@ -182,7 +185,10 @@
 	<!-- Container wrapper for consistent max-width -->
 	<div class="w-full max-w-2xl px-4 flex flex-col items-center gap-4">
 		<div class="xs:flex hidden flex-col items-center gap-4">
-			<h1 class="scroll-m-20 text-4xl font-bold tracking-tight lg:text-5xl">
+			<h1
+				class="scroll-m-20 text-4xl font-bold tracking-tight lg:text-5xl transition-opacity"
+				class:invisible={sidebar.state === 'expanded'}
+			>
 				Whispering
 			</h1>
 			<p class="text-muted-foreground text-center">
@@ -245,7 +251,8 @@
 								🚫
 							</WhisperingButton>
 						</div>
-					{:else}
+					{:else if false}
+						<!-- Selectors hidden - available in sidebar Quick Settings -->
 						<div class="absolute -right-32 bottom-4 flex items-center gap-0.5">
 							<ManualDeviceSelector />
 							<CompressionSelector />
@@ -274,7 +281,8 @@
 						</span>
 					</WhisperingButton>
 					<!-- Absolutely positioned selectors -->
-					{#if getVadStateQuery.data === 'IDLE'}
+					{#if false}
+						<!-- Selectors hidden - available in sidebar Quick Settings -->
 						<div class="absolute -right-32 bottom-4 flex items-center gap-0.5">
 							<VadDeviceSelector />
 							<CompressionSelector />
@@ -303,11 +311,14 @@
 						}}
 						class="h-32 sm:h-36 lg:h-40 xl:h-44 w-full"
 					/>
-					<div class="flex items-center gap-1.5">
-						<CompressionSelector />
-						<TranscriptionSelector />
-						<TransformationSelector />
-					</div>
+					{#if false}
+						<!-- Selectors hidden - available in sidebar Quick Settings -->
+						<div class="flex items-center gap-1.5">
+							<CompressionSelector />
+							<TranscriptionSelector />
+							<TransformationSelector />
+						</div>
+					{/if}
 				</div>
 			{/if}
 		</div>

--- a/apps/whispering/src/routes/(app)/verticalnav/desktop-app/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/desktop-app/+page.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import DesktopAppPage from '../../(config)/desktop-app/+page.svelte';
+	import { useSidebar } from '@repo/ui/sidebar';
+	import { onMount } from 'svelte';
+
+	const sidebar = useSidebar();
+
+	// Collapse sidebar on mount for focused utility page experience
+	onMount(() => {
+		if (sidebar.state === 'expanded') {
+			sidebar.setOpen(false);
+		}
+	});
+</script>
+
+<DesktopAppPage />

--- a/apps/whispering/src/routes/(app)/verticalnav/global-shortcut/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/global-shortcut/+page.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import GlobalShortcutPage from '../../(config)/global-shortcut/+page.svelte';
+	import { useSidebar } from '@repo/ui/sidebar';
+	import { onMount } from 'svelte';
+
+	const sidebar = useSidebar();
+
+	// Collapse sidebar on mount for focused utility page experience
+	onMount(() => {
+		if (sidebar.state === 'expanded') {
+			sidebar.setOpen(false);
+		}
+	});
+</script>
+
+<GlobalShortcutPage />

--- a/apps/whispering/src/routes/(app)/verticalnav/install-ffmpeg/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/install-ffmpeg/+page.svelte
@@ -1,0 +1,462 @@
+<script lang="ts">
+	import { Button, buttonVariants } from '@repo/ui/button';
+	import { Link } from '@repo/ui/link';
+	import * as Card from '@repo/ui/card';
+	import * as Alert from '@repo/ui/alert';
+	import * as Tabs from '@repo/ui/tabs';
+	import { Snippet } from '@repo/ui/snippet';
+	import { Badge } from '@repo/ui/badge';
+	import {
+		DownloadIcon,
+		CheckCircleIcon,
+		XCircleIcon,
+		LoaderIcon,
+		RefreshCwIcon,
+		ExternalLinkIcon,
+		ArrowLeftIcon,
+	} from '@lucide/svelte';
+	import * as services from '$lib/services';
+	import { goto } from '$app/navigation';
+	import { createQuery } from '@tanstack/svelte-query';
+	import { rpc } from '$lib/query';
+	import { useSidebar } from '@repo/ui/sidebar';
+	import { onMount } from 'svelte';
+
+	const platform = services.os.type();
+	const sidebar = useSidebar();
+
+	// Collapse sidebar on mount for focused utility page experience
+	onMount(() => {
+		if (sidebar.state === 'expanded') {
+			sidebar.setOpen(false);
+		}
+	});
+
+	const ffmpegQuery = createQuery(() => ({
+		...rpc.ffmpeg.checkFfmpegInstalled.options(),
+		refetchInterval: (query) => {
+			const isInstalled = query.state.data;
+			return isInstalled ? 30000 : 5000;
+		},
+		refetchOnWindowFocus: true,
+		staleTime: 1000,
+	}));
+</script>
+
+<svelte:head>
+	<title>Install FFmpeg - Whispering</title>
+</svelte:head>
+
+<main class="flex flex-1 items-center justify-center p-8">
+	<div class="w-full min-w-[640px] max-w-4xl">
+		<Card.Root>
+			<Card.Header>
+				<div class="flex items-center justify-between">
+					<div class="space-y-3 flex-1 pr-8">
+						<Card.Title class="text-3xl">Install FFmpeg</Card.Title>
+						<Card.Description class="text-base leading-relaxed">
+							FFmpeg converts audio to WAV format for local transcription and
+							compresses files for efficient cloud API transmission.
+						</Card.Description>
+					</div>
+
+					<div class="flex flex-col items-end gap-3">
+						{#if ffmpegQuery.isPending}
+							<Badge variant="secondary" class="gap-1.5">
+								<LoaderIcon class="size-3 animate-spin" />
+								Checking
+							</Badge>
+						{:else if ffmpegQuery.data === true}
+							<Badge
+								variant="default"
+								class="gap-1.5 bg-green-500/10 text-green-600 dark:text-green-400 border-green-500/20"
+							>
+								<CheckCircleIcon class="size-3" />
+								Installed
+							</Badge>
+						{:else if ffmpegQuery.data === false}
+							<Badge variant="destructive" class="gap-1.5">
+								<XCircleIcon class="size-3" />
+								Not Found
+							</Badge>
+						{/if}
+
+						<Button
+							size="icon"
+							variant="ghost"
+							onclick={() => ffmpegQuery.refetch()}
+							title="Check again"
+							class="size-8"
+						>
+							<RefreshCwIcon
+								class="size-4 {ffmpegQuery.isFetching ? 'animate-spin' : ''}"
+							/>
+						</Button>
+					</div>
+				</div>
+			</Card.Header>
+
+			<Card.Content class="space-y-8">
+				{#if ffmpegQuery.data === true}
+					<Alert.Root class="border-green-500/20 bg-green-500/5">
+						<CheckCircleIcon
+							class="size-4 text-green-600 dark:text-green-400"
+						/>
+						<Alert.Title class="text-green-600 dark:text-green-400">
+							FFmpeg is installed!
+						</Alert.Title>
+						<Alert.Description>
+							FFmpeg has been detected on your system. You can now use all audio
+							processing features.
+						</Alert.Description>
+					</Alert.Root>
+
+					<div class="flex gap-3">
+						<Link
+							href="/verticalnav/settings/transcription"
+							class={buttonVariants({ class: 'flex-1' })}
+						>
+							Continue to Settings
+						</Link>
+						<Button variant="outline" onclick={() => goto('/verticalnav')}>
+							Go to Home
+						</Button>
+					</div>
+				{:else}
+					<Tabs.Root value={platform}>
+						<Tabs.List class="grid w-full grid-cols-3">
+							<Tabs.Trigger value="macos">macOS</Tabs.Trigger>
+							<Tabs.Trigger value="windows">Windows</Tabs.Trigger>
+							<Tabs.Trigger value="linux">Linux</Tabs.Trigger>
+						</Tabs.List>
+
+						<Tabs.Content value="macos" class="mt-6">
+							<div class="space-y-6">
+								<h3 class="text-lg font-semibold">macOS Installation</h3>
+
+								<div class="space-y-3">
+									<p class="text-sm font-medium">
+										Install using Homebrew (supports both Intel and Apple
+										Silicon)
+									</p>
+									<Snippet text="brew install ffmpeg" />
+
+									<p class="text-xs text-muted-foreground">
+										Don't have Homebrew?
+										<Link
+											href="https://brew.sh"
+											target="_blank"
+											rel="noopener noreferrer"
+											class="underline"
+										>
+											Install it from brew.sh
+										</Link>
+									</p>
+								</div>
+
+								<div class="border-t pt-4">
+									<p class="text-sm font-medium mb-2">Verify Installation</p>
+									<p class="text-sm text-muted-foreground mb-2">
+										After installation, verify FFmpeg is working:
+									</p>
+									<Snippet text="ffmpeg -version" variant="secondary" />
+								</div>
+							</div>
+						</Tabs.Content>
+
+						<Tabs.Content value="windows" class="mt-6">
+							<div class="space-y-8">
+								<!-- Windows Installation Section -->
+								<div class="space-y-6">
+									<div class="space-y-2">
+										<h3 class="text-lg font-semibold">Windows Installation</h3>
+									</div>
+
+									<ol class="space-y-6 text-sm text-muted-foreground">
+										<li class="flex gap-4">
+											<span class="font-semibold text-foreground shrink-0"
+												>1.</span
+											>
+											<div class="space-y-3 flex-1">
+												<p>Download FFmpeg from GitHub:</p>
+												<Button
+													href="https://github.com/BtbN/FFmpeg-Builds/releases"
+													target="_blank"
+													rel="noopener noreferrer"
+													variant="default"
+													size="lg"
+													class="w-full sm:w-auto"
+												>
+													<DownloadIcon class="size-5 mr-2" />
+													Download FFmpeg for Windows
+												</Button>
+											</div>
+										</li>
+
+										<li class="flex gap-4">
+											<span class="font-semibold text-foreground shrink-0"
+												>2.</span
+											>
+											<div class="space-y-2 flex-1">
+												<p>
+													Download the latest <code
+														class="bg-muted px-2 py-1 rounded text-xs font-mono"
+														>ffmpeg-master-latest-win64-gpl-shared.zip</code
+													>
+												</p>
+											</div>
+										</li>
+
+										<li class="flex gap-4">
+											<span class="font-semibold text-foreground shrink-0"
+												>3.</span
+											>
+											<div class="space-y-2 flex-1">
+												<p>
+													Extract the ZIP file to <code
+														class="bg-muted px-2 py-1 rounded text-xs font-mono"
+														>C:\ffmpeg</code
+													>
+												</p>
+											</div>
+										</li>
+
+										<li class="flex gap-4">
+											<span class="font-semibold text-foreground shrink-0"
+												>4.</span
+											>
+											<div class="space-y-6 flex-1">
+												<p>
+													Add <code
+														class="bg-muted px-2 py-1 rounded text-xs font-mono"
+														>C:\ffmpeg\bin</code
+													> to your Windows PATH:
+												</p>
+
+												<!-- Method 1 -->
+												<div class="space-y-4 border-l-2 border-muted pl-6">
+													<p class="text-base font-semibold text-foreground">
+														Method 1: Using Windows Settings (Recommended)
+													</p>
+													<ol class="space-y-3 text-sm text-muted-foreground">
+														<li class="flex gap-3">
+															<span class="shrink-0">a.</span>
+															<span
+																>Press <kbd
+																	class="bg-muted px-2 py-1 rounded font-mono text-xs"
+																	>Windows + X</kbd
+																> and select "System"</span
+															>
+														</li>
+														<li class="flex gap-3">
+															<span class="shrink-0">b.</span>
+															<span
+																>Click "Advanced system settings" → "Environment
+																Variables..."</span
+															>
+														</li>
+														<li class="flex gap-3">
+															<span class="shrink-0">c.</span>
+															<span
+																>Under "System variables", select "Path" →
+																"Edit..." → "New"</span
+															>
+														</li>
+														<li class="flex gap-3">
+															<span class="shrink-0">d.</span>
+															<span
+																>Add: <code
+																	class="bg-muted px-2 py-1 rounded font-mono text-xs"
+																	>C:\ffmpeg\bin</code
+																></span
+															>
+														</li>
+														<li class="flex gap-3">
+															<span class="shrink-0">e.</span>
+															<span>Click "OK" on all dialogs</span>
+														</li>
+													</ol>
+												</div>
+
+												<!-- Method 2 -->
+												<div class="space-y-4 border-l-2 border-muted pl-6">
+													<p class="text-base font-semibold text-foreground">
+														Method 2: PowerShell (One Command)
+													</p>
+													<div class="space-y-3">
+														<Snippet
+															text="[Environment]::SetEnvironmentVariable(&quot;Path&quot;, $env:Path + &quot;;C:\ffmpeg\bin&quot;, &quot;Machine&quot;)"
+														/>
+														<p class="text-xs text-muted-foreground">
+															<strong>Note:</strong> Run PowerShell as Administrator
+															for this command
+														</p>
+													</div>
+												</div>
+
+												<!-- Video Tutorial -->
+												<div
+													class="border rounded-lg p-4 bg-muted/20 space-y-3"
+												>
+													<p class="text-sm font-medium">
+														📹 Need help with PATH setup?
+													</p>
+													<Button
+														href="https://www.youtube.com/watch?v=eRZRXpzZfM4&t=85s"
+														target="_blank"
+														rel="noopener noreferrer"
+														variant="outline"
+														size="sm"
+													>
+														<ExternalLinkIcon class="size-3 mr-2" />
+														Watch Tutorial Video
+													</Button>
+												</div>
+											</div>
+										</li>
+										<li class="flex gap-4">
+											<span class="font-semibold text-foreground shrink-0"
+												>5.</span
+											>
+											<div class="space-y-3 flex-1">
+												<p class="text-sm text-muted-foreground">
+													Restart Whispering, then verify FFmpeg is working:
+												</p>
+												<Snippet text="ffmpeg -version" variant="secondary" />
+											</div>
+										</li>
+									</ol>
+								</div>
+
+								<!-- Troubleshooting Section -->
+								<div class="space-y-6 border-t pt-8">
+									<h3 class="text-lg font-semibold">Troubleshooting</h3>
+
+									<div class="space-y-5">
+										<div class="p-5 border rounded-lg bg-muted/10 space-y-4">
+											<p class="text-base font-semibold">
+												🚫 "ffmpeg is not recognized as an internal or external
+												command"
+											</p>
+											<ul
+												class="space-y-3 ml-4 list-disc text-sm text-muted-foreground"
+											>
+												<li>
+													Make sure you added <code
+														class="bg-muted px-2 py-1 rounded font-mono text-xs"
+														>C:\ffmpeg\bin</code
+													>
+													to PATH (not just
+													<code
+														class="bg-muted px-2 py-1 rounded font-mono text-xs"
+														>C:\ffmpeg</code
+													>)
+												</li>
+												<li>
+													Restart Whispering completely after adding to PATH
+												</li>
+												<li>
+													Test in a new Command Prompt: <code
+														class="bg-muted px-2 py-1 rounded font-mono text-xs"
+														>ffmpeg -version</code
+													>
+												</li>
+											</ul>
+										</div>
+
+										<details class="border rounded-lg">
+											<summary
+												class="p-4 cursor-pointer hover:bg-muted/5 text-base font-semibold"
+											>
+												🔧 Advanced Troubleshooting
+											</summary>
+											<div class="px-5 pb-5 space-y-4 border-t bg-muted/5 pt-4">
+												<ul
+													class="space-y-3 ml-4 list-disc text-sm text-muted-foreground"
+												>
+													<li>
+														Log out and back into Windows to refresh environment
+														variables
+													</li>
+													<li>Check if Windows Defender is blocking FFmpeg</li>
+													<li>
+														Verify the ffmpeg.exe file exists at <code
+															class="bg-muted px-2 py-1 rounded font-mono text-xs"
+															>C:\ffmpeg\bin\ffmpeg.exe</code
+														>
+													</li>
+												</ul>
+											</div>
+										</details>
+									</div>
+								</div>
+							</div>
+						</Tabs.Content>
+
+						<Tabs.Content value="linux" class="mt-6">
+							<div class="space-y-4">
+								<h3 class="text-lg font-semibold">Linux Installation</h3>
+
+								<div class="space-y-4">
+									<div>
+										<p class="text-sm font-medium mb-2">Ubuntu/Debian:</p>
+										<Snippet
+											text="sudo apt update && sudo apt install ffmpeg"
+										/>
+									</div>
+
+									<div>
+										<p class="text-sm font-medium mb-2">Fedora/RHEL:</p>
+										<Snippet text="sudo dnf install ffmpeg" />
+									</div>
+
+									<div>
+										<p class="text-sm font-medium mb-2">Arch Linux:</p>
+										<Snippet text="sudo pacman -S ffmpeg" />
+									</div>
+								</div>
+
+								<div class="border-t pt-4">
+									<p class="text-sm font-medium mb-2">Verify Installation</p>
+									<p class="text-sm text-muted-foreground mb-2">
+										After installation, verify FFmpeg is working by running this
+										command:
+									</p>
+									<Snippet text="ffmpeg -version" variant="secondary" />
+								</div>
+							</div>
+						</Tabs.Content>
+					</Tabs.Root>
+				{/if}
+			</Card.Content>
+
+			{#if ffmpegQuery.data !== true}
+				<Card.Footer class="flex justify-center">
+					<Button
+						href="/verticalnav/settings/transcription"
+						variant="ghost"
+						size="sm"
+					>
+						<ArrowLeftIcon class="size-4 mr-2" />
+						Back to Settings
+					</Button>
+				</Card.Footer>
+			{/if}
+		</Card.Root>
+	</div>
+</main>
+
+<style>
+	:global(.animate-spin) {
+		animation: spin 1s linear infinite;
+	}
+
+	@keyframes spin {
+		from {
+			transform: rotate(0deg);
+		}
+		to {
+			transform: rotate(360deg);
+		}
+	}
+</style>

--- a/apps/whispering/src/routes/(app)/verticalnav/macos-enable-accessibility/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/macos-enable-accessibility/+page.svelte
@@ -1,0 +1,183 @@
+<script lang="ts">
+	import { Button } from '@repo/ui/button';
+	import { Badge } from '@repo/ui/badge';
+	import * as Card from '@repo/ui/card';
+	import { SettingsIcon, CheckIcon, ArrowLeft } from '@lucide/svelte';
+	import * as services from '$lib/services';
+	import { toast } from 'svelte-sonner';
+	import { asShellCommand } from '$lib/services/command/types';
+	import { goto } from '$app/navigation';
+	import { useSidebar } from '@repo/ui/sidebar';
+	import { onMount } from 'svelte';
+
+	let { data } = $props();
+	const isAccessibilityGranted = $derived(data.isAccessibilityGranted);
+	const sidebar = useSidebar();
+
+	// Collapse sidebar on mount for focused utility page experience
+	onMount(() => {
+		if (sidebar.state === 'expanded') {
+			sidebar.setOpen(false);
+		}
+	});
+
+	async function requestPermissionOrShowGuidance() {
+		const { error } = await services.permissions.accessibility.request();
+
+		if (error) {
+			toast.error('Failed to open accessibility settings', {
+				description:
+					'Please enable Accessibility in System Settings > Privacy & Security > Accessibility manually',
+				action: {
+					label: 'Open Accessibility Settings',
+					onClick: () => openSystemSettings(),
+				},
+			});
+		}
+	}
+
+	async function openSystemSettings() {
+		// Try opening System Settings directly (works on macOS 13+)
+		const { error: commandError } = await services.command.execute(
+			asShellCommand(
+				'open x-apple.systemsettings:com.apple.SystemSettings.extension',
+			),
+		);
+
+		if (commandError) {
+			console.error('Failed to open System Settings:', commandError);
+
+			// Fallback: Show detailed instructions
+			toast.info('Open System Settings Manually', {
+				description:
+					'Click Apple menu → System Settings → Privacy & Security → Accessibility',
+				duration: 10000,
+			});
+			return;
+		}
+
+		// Show helpful toast since we can't open directly to accessibility
+		toast.info('System Settings Opened', {
+			description:
+				'Navigate to Privacy & Security > Accessibility to grant permissions.',
+			duration: 8000,
+		});
+	}
+</script>
+
+<svelte:head>
+	<title>MacOS Accessibility</title>
+</svelte:head>
+
+<main class="flex flex-1 items-center justify-center">
+	<Card.Root class="w-full max-w-2xl">
+		<Card.Header>
+			<Card.Title class="text-xl">MacOS Accessibility</Card.Title>
+			<Card.Description class="leading-7">
+				Follow the steps below to re-enable Whispering in your macOS
+				Accessibility settings. This often is needed after installing new
+				versions of Whispering due to a macOS bug.
+			</Card.Description>
+		</Card.Header>
+		<Card.Content>
+			<div class="flex flex-col items-center gap-2">
+				{#if window.__TAURI_INTERNALS__}
+					<!-- YouTube embed for Tauri app (external videos don't work well) -->
+					<iframe
+						class="max-w-md rounded-lg border"
+						width="560"
+						height="315"
+						src="https://www.youtube.com/embed/FJRktNkr1Fs"
+						title="macOS Accessibility Settings Guide"
+						frameborder="0"
+						allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+						allowfullscreen
+					></iframe>
+				{:else}
+					<!-- Direct video for web version -->
+					<video
+						class="max-w-md rounded-lg border"
+						src="https://github.com/epicenter-md/epicenter/releases/download/_assets/macos_enable_accessibility.mp4"
+						autoplay
+						loop
+						controls
+						muted
+						playsinline
+					>
+						<p class="text-muted-foreground text-sm">
+							Video guide not available. Please follow the written instructions
+							below.
+						</p>
+					</video>
+				{/if}
+				<ol
+					class="text-muted-foreground list-inside list-decimal space-y-1 text-sm leading-7"
+				>
+					<li>
+						Go to <span class="text-primary font-semibold tracking-tight">
+							System Settings > Privacy & Security > Accessibility
+						</span> or click the button below.
+					</li>
+
+					<li>
+						Click on <span class="text-primary font-semibold tracking-tight"
+							>🎙️ Whispering</span
+						> and remove it using the minus icon (-).
+					</li>
+					<li>
+						Re-add Whispering by pressing the plus icon (+) and selecting <span
+							class="text-primary font-semibold tracking-tight"
+							>🎙️ Whispering.app</span
+						>
+					</li>
+				</ol>
+			</div>
+		</Card.Content>
+		<Card.Footer>
+			{#if !isAccessibilityGranted}
+				<div class="flex gap-3 w-full">
+					<Button
+						variant="outline"
+						onclick={() => goto('/verticalnav')}
+						class="flex-1 text-sm"
+					>
+						<ArrowLeft class="mr-2 size-4" />
+						Back to Home
+					</Button>
+					<Button
+						onclick={() => requestPermissionOrShowGuidance()}
+						class="flex-1 text-sm"
+					>
+						<SettingsIcon class="mr-2 size-4" />
+						Request Permission
+					</Button>
+				</div>
+			{:else}
+				<div class="flex flex-col gap-3 w-full">
+					<Badge variant="success">
+						<CheckIcon class="size-4" />
+						Accessibility permissions granted
+					</Badge>
+					<div class="flex gap-3">
+						<Button
+							variant="outline"
+							onclick={() => goto('/verticalnav')}
+							class="flex-1 text-sm"
+						>
+							<ArrowLeft class="mr-2 size-4" />
+							Back to Home
+						</Button>
+						<Button
+							onclick={() => openSystemSettings()}
+							variant="outline"
+							class="flex-1 text-sm"
+						>
+							<SettingsIcon class="mr-2 size-4" />
+							Open Settings
+						</Button>
+					</div>
+				</div>
+			{/if}
+		</Card.Footer>
+	</Card.Root>
+</main>

--- a/apps/whispering/src/routes/(app)/verticalnav/macos-enable-accessibility/+page.ts
+++ b/apps/whispering/src/routes/(app)/verticalnav/macos-enable-accessibility/+page.ts
@@ -1,0 +1,10 @@
+import * as services from '$lib/services';
+
+export const load = async () => {
+	const { data: isAccessibilityGranted } =
+		await services.permissions.accessibility.check();
+
+	return {
+		isAccessibilityGranted: isAccessibilityGranted ?? false,
+	};
+};

--- a/apps/whispering/src/routes/(app)/verticalnav/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/recordings/+page.svelte
@@ -5,12 +5,22 @@
 	const sidebar = useSidebar();
 </script>
 
-<div class:hidden-header={sidebar.state === 'expanded'}>
+<div class:hidden-header={sidebar.state === 'expanded' && !sidebar.isMobile}>
 	<RecordingsPage />
 </div>
 
 <style>
 	.hidden-header :global(h1) {
 		display: none;
+	}
+
+	:global(h1) {
+		padding-left: 1.375rem;
+	}
+
+	@media (min-width: 768px) {
+		:global(h1) {
+			padding-left: 0;
+		}
 	}
 </style>

--- a/apps/whispering/src/routes/(app)/verticalnav/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/recordings/+page.svelte
@@ -1,19 +1,10 @@
 <script lang="ts">
 	import RecordingsPage from '../../(config)/recordings/+page.svelte';
-	import { useSidebar } from '@repo/ui/sidebar';
-
-	const sidebar = useSidebar();
 </script>
 
-<div class:hidden-header={sidebar.state === 'expanded' && !sidebar.isMobile}>
-	<RecordingsPage />
-</div>
+<RecordingsPage />
 
 <style>
-	.hidden-header :global(h1) {
-		display: none;
-	}
-
 	:global(h1) {
 		padding-left: 1.375rem;
 	}

--- a/apps/whispering/src/routes/(app)/verticalnav/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/recordings/+page.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import RecordingsPage from '../../(config)/recordings/+page.svelte';
+	import { useSidebar } from '@repo/ui/sidebar';
+
+	const sidebar = useSidebar();
+</script>
+
+<div class:hidden-header={sidebar.state === 'expanded'}>
+	<RecordingsPage />
+</div>
+
+<style>
+	.hidden-header :global(h1) {
+		display: none;
+	}
+</style>

--- a/apps/whispering/src/routes/(app)/verticalnav/settings/+layout.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/settings/+layout.svelte
@@ -45,11 +45,9 @@
 		class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between"
 	>
 		<div class="space-y-0.5">
-			{#if sidebar.state === 'collapsed' || sidebar.isMobile}
-				<h2 class="text-2xl font-bold tracking-tight pl-[1.375rem] md:pl-0">
-					Settings
-				</h2>
-			{/if}
+			<h2 class="text-2xl font-bold tracking-tight pl-[1.375rem] md:pl-0">
+				Settings
+			</h2>
 			<p class="text-muted-foreground">
 				{#await versionPromise}
 					Customize your Whispering experience.

--- a/apps/whispering/src/routes/(app)/verticalnav/settings/+layout.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/settings/+layout.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+	import { confirmationDialog } from '$lib/components/ConfirmationDialog.svelte';
+	import { Button } from '@repo/ui/button';
+	import { Link } from '@repo/ui/link';
+	import { Separator } from '@repo/ui/separator';
+	import { rpc } from '$lib/query';
+	import { RotateCcw } from '@lucide/svelte';
+	import SidebarNav from './SidebarNav.svelte';
+	import { settings } from '$lib/stores/settings.svelte';
+	import { useSidebar } from '@repo/ui/sidebar';
+
+	let { children } = $props();
+
+	const sidebar = useSidebar();
+
+	const isString = (value: unknown): value is string =>
+		typeof value === 'string';
+	const versionPromise = (async () => {
+		const res = await fetch(
+			'https://api.github.com/repos/epicenter-md/epicenter/releases/latest',
+		);
+		const { html_url: latestReleaseUrl, tag_name: latestVersion } =
+			await res.json();
+		if (!isString(latestVersion) || !isString(latestReleaseUrl)) {
+			throw new Error('Failed to fetch latest version');
+		}
+		if (!window.__TAURI_INTERNALS__)
+			return { isOutdated: false, version: latestVersion } as const;
+		const { getVersion } = await import('@tauri-apps/api/app');
+		const currentVersion = `v${await getVersion()}`;
+		if (latestVersion === currentVersion) {
+			return { isOutdated: false, version: currentVersion } as const;
+		}
+		return {
+			isOutdated: true,
+			latestVersion,
+			currentVersion,
+			latestReleaseUrl,
+		} as const;
+	})();
+</script>
+
+<main class="flex w-full flex-1 flex-col pb-4 pt-2 px-4 mx-auto max-w-6xl">
+	<div
+		class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between"
+	>
+		<div class="space-y-0.5">
+			{#if sidebar.state === 'collapsed'}
+				<h2 class="text-2xl font-bold tracking-tight">Settings</h2>
+			{/if}
+			<p class="text-muted-foreground">
+				{#await versionPromise}
+					Customize your Whispering experience.
+				{:then v}
+					{#if v.isOutdated}
+						{@const { latestVersion, currentVersion, latestReleaseUrl } = v}
+						Customize your experience for Whispering {currentVersion} (latest
+						<Link
+							href={latestReleaseUrl}
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							{latestVersion}
+						</Link>).
+					{:else}
+						{@const { version } = v}
+						Customize your experience for Whispering {version}.
+					{/if}
+				{:catch error}
+					Customize your Whispering experience.
+				{/await}
+			</p>
+		</div>
+		<Button
+			variant="outline"
+			size="sm"
+			onclick={() => {
+				confirmationDialog.open({
+					title: 'Reset All Settings',
+					subtitle:
+						'This will reset all settings to their default values. This action cannot be undone.',
+					confirmText: 'Reset Settings',
+					onConfirm: () => {
+						settings.reset();
+						rpc.notify.success.execute({
+							title: 'Settings reset',
+							description: 'All settings have been reset to defaults.',
+						});
+					},
+				});
+			}}
+			class="shrink-0"
+		>
+			<RotateCcw class="mr-2 size-4" />
+			Reset to defaults
+		</Button>
+	</div>
+	<Separator class="my-6" />
+	<div class="flex flex-col space-y-8 lg:flex-row lg:gap-8">
+		<aside class="lg:w-1/6">
+			<SidebarNav />
+		</aside>
+		<main class="flex-1 lg:max-w-3xl">
+			{@render children()}
+		</main>
+	</div>
+</main>

--- a/apps/whispering/src/routes/(app)/verticalnav/settings/+layout.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/settings/+layout.svelte
@@ -96,11 +96,19 @@
 		</Button>
 	</div>
 	<Separator class="my-6" />
-	<div class="flex flex-col space-y-8 lg:flex-row lg:gap-8">
-		<aside class="lg:w-1/6">
+	<div
+		class={sidebar.state === 'collapsed'
+			? 'flex flex-col space-y-8 lg:flex-row lg:gap-8'
+			: 'flex flex-col space-y-8 xl:flex-row xl:gap-8'}
+	>
+		<aside class={sidebar.state === 'collapsed' ? 'lg:w-1/6' : 'xl:w-1/6'}>
 			<SidebarNav />
 		</aside>
-		<main class="flex-1 lg:max-w-3xl">
+		<main
+			class={sidebar.state === 'collapsed'
+				? 'flex-1 lg:max-w-3xl'
+				: 'flex-1 xl:max-w-3xl'}
+		>
 			{@render children()}
 		</main>
 	</div>

--- a/apps/whispering/src/routes/(app)/verticalnav/settings/+layout.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/settings/+layout.svelte
@@ -45,8 +45,10 @@
 		class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between"
 	>
 		<div class="space-y-0.5">
-			{#if sidebar.state === 'collapsed'}
-				<h2 class="text-2xl font-bold tracking-tight">Settings</h2>
+			{#if sidebar.state === 'collapsed' || sidebar.isMobile}
+				<h2 class="text-2xl font-bold tracking-tight pl-[1.375rem] md:pl-0">
+					Settings
+				</h2>
 			{/if}
 			<p class="text-muted-foreground">
 				{#await versionPromise}

--- a/apps/whispering/src/routes/(app)/verticalnav/settings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/settings/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import SettingsPage from '../../(config)/settings/+page.svelte';
+</script>
+
+<SettingsPage />

--- a/apps/whispering/src/routes/(app)/verticalnav/settings/SidebarNav.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/settings/SidebarNav.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { Button } from '@repo/ui/button';
+	import { cn } from '@repo/ui/utils';
+	import { cubicInOut } from 'svelte/easing';
+	import { crossfade } from 'svelte/transition';
+
+	const items = [
+		{ title: 'General', href: '/verticalnav/settings' },
+		{ title: 'Recording', href: '/verticalnav/settings/recording' },
+		{ title: 'Transcription', href: '/verticalnav/settings/transcription' },
+		{ title: 'API Keys', href: '/verticalnav/settings/api-keys' },
+		{ title: 'Sound', href: '/verticalnav/settings/sound' },
+		{
+			title: 'Shortcuts',
+			href: '/verticalnav/settings/shortcuts/local',
+			activePathPrefix: '/verticalnav/settings/shortcuts',
+		},
+		{ title: 'Privacy & Analytics', href: '/verticalnav/settings/analytics' },
+	] satisfies {
+		title: string;
+		href: string;
+		/**
+		 * If provided, the item is considered active if the current pathname starts with this prefix.
+		 * Otherwise, it is considered active if the current pathname is exactly equal to the item's href.
+		 */
+		activePathPrefix?: string;
+	}[];
+
+	const [send, receive] = crossfade({
+		duration: 250,
+		easing: cubicInOut,
+	});
+</script>
+
+<nav
+	class="flex gap-2 overflow-auto lg:flex-col lg:gap-1"
+	aria-label="Settings navigation"
+>
+	{#each items as item (item.href)}
+		{@const isActive = item.activePathPrefix
+			? page.url.pathname.startsWith(item.activePathPrefix)
+			: page.url.pathname === item.href}
+
+		<Button
+			href={item.href}
+			variant="ghost"
+			class={cn(
+				'relative justify-start text-left font-normal transition-colors',
+				isActive
+					? 'text-sidebar-accent-foreground hover:bg-sidebar-accent/50'
+					: 'text-sidebar-foreground hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground',
+			)}
+			aria-current={isActive ? 'page' : undefined}
+			data-sveltekit-noscroll
+		>
+			{#if isActive}
+				<div
+					class="bg-sidebar-accent absolute inset-0 rounded-md"
+					in:send={{ key: 'active-sidebar-tab' }}
+					out:receive={{ key: 'active-sidebar-tab' }}
+				></div>
+			{/if}
+			<span class="relative z-10">
+				{item.title}
+			</span>
+		</Button>
+	{/each}
+</nav>

--- a/apps/whispering/src/routes/(app)/verticalnav/settings/SidebarNav.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/settings/SidebarNav.svelte
@@ -4,6 +4,9 @@
 	import { cn } from '@repo/ui/utils';
 	import { cubicInOut } from 'svelte/easing';
 	import { crossfade } from 'svelte/transition';
+	import { useSidebar } from '@repo/ui/sidebar';
+
+	const sidebar = useSidebar();
 
 	const items = [
 		{ title: 'General', href: '/verticalnav/settings' },
@@ -34,7 +37,12 @@
 </script>
 
 <nav
-	class="flex gap-2 overflow-auto lg:flex-col lg:gap-1"
+	class={cn(
+		'flex gap-2 overflow-auto',
+		sidebar.state === 'collapsed'
+			? 'lg:flex-col lg:gap-1'
+			: 'xl:flex-col xl:gap-1',
+	)}
 	aria-label="Settings navigation"
 >
 	{#each items as item (item.href)}

--- a/apps/whispering/src/routes/(app)/verticalnav/settings/analytics/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/settings/analytics/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import AnalyticsPage from '../../../(config)/settings/analytics/+page.svelte';
+</script>
+
+<AnalyticsPage />

--- a/apps/whispering/src/routes/(app)/verticalnav/settings/api-keys/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/settings/api-keys/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import ApiKeysPage from '../../../(config)/settings/api-keys/+page.svelte';
+</script>
+
+<ApiKeysPage />

--- a/apps/whispering/src/routes/(app)/verticalnav/settings/recording/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/settings/recording/+page.svelte
@@ -1,0 +1,344 @@
+<script lang="ts">
+	import DesktopOutputFolder from '../../../(config)/settings/recording/DesktopOutputFolder.svelte';
+	import FfmpegCommandBuilder from '../../../(config)/settings/recording/FfmpegCommandBuilder.svelte';
+	import { LabeledSelect } from '$lib/components/labeled/index.js';
+	import { Separator } from '@repo/ui/separator';
+	import * as Alert from '@repo/ui/alert';
+	import { Link } from '@repo/ui/link';
+	import { InfoIcon } from '@lucide/svelte';
+	import {
+		BITRATE_OPTIONS,
+		RECORDING_MODE_OPTIONS,
+	} from '$lib/constants/audio';
+	import { settings } from '$lib/stores/settings.svelte';
+	import ManualSelectRecordingDevice from '../../../(config)/settings/recording/ManualSelectRecordingDevice.svelte';
+	import VadSelectRecordingDevice from '../../../(config)/settings/recording/VadSelectRecordingDevice.svelte';
+	import {
+		isCompressionRecommended,
+		COMPRESSION_RECOMMENDED_MESSAGE,
+		hasNavigatorLocalTranscriptionIssue,
+	} from '../../../_layout-utils/check-ffmpeg';
+	import { IS_MACOS, IS_LINUX, PLATFORM_TYPE } from '$lib/constants/platform';
+	import { Button } from '@repo/ui/button';
+
+	const { data } = $props();
+
+	const SAMPLE_RATE_OPTIONS = [
+		{ value: '16000', label: 'Voice Quality (16kHz): Optimized for speech' },
+		{ value: '44100', label: 'Standard Quality (44.1kHz): CD quality' },
+		{ value: '48000', label: 'High Quality (48kHz): Professional audio' },
+	] as const;
+
+	const RECORDING_METHOD_OPTIONS = [
+		{
+			value: 'cpal',
+			label: 'CPAL',
+			description: IS_MACOS
+				? 'Native Rust audio method. Records uncompressed WAV, reliable with shortcuts. Works with all transcription methods.'
+				: 'Native Rust audio method. Records uncompressed WAV format. Works with all transcription methods.',
+		},
+		{
+			value: 'ffmpeg',
+			label: 'FFmpeg',
+			description: {
+				macos:
+					'Supports all audio formats with advanced customization options. Reliable with keyboard shortcuts.',
+				linux:
+					'Recommended for Linux. Supports all audio formats with advanced customization options. Helps bypass common audio issues.',
+				windows:
+					'Supports all audio formats with advanced customization options.',
+			}[PLATFORM_TYPE],
+		},
+		{
+			value: 'navigator',
+			label: 'Browser API',
+			description: IS_MACOS
+				? 'Web MediaRecorder API. Creates compressed files suitable for cloud transcription. Requires FFmpeg for local transcription (Whisper C++/Parakeet). May have delays with shortcuts when app is in background (macOS AppNap).'
+				: 'Web MediaRecorder API. Creates compressed files suitable for cloud transcription. Requires FFmpeg for local transcription (Whisper C++/Parakeet).',
+		},
+	];
+
+	const isUsingNavigatorMethod = $derived(
+		!window.__TAURI_INTERNALS__ ||
+			settings.value['recording.method'] === 'navigator',
+	);
+
+	const isUsingFfmpegMethod = $derived(
+		settings.value['recording.method'] === 'ffmpeg',
+	);
+
+	const localTranscriptionServiceName = $derived(
+		settings.value['transcription.selectedTranscriptionService'] ===
+			'whispercpp'
+			? 'Whisper C++'
+			: 'Parakeet',
+	);
+</script>
+
+<svelte:head>
+	<title>Recording Settings - Whispering</title>
+</svelte:head>
+
+<div class="space-y-6">
+	<div>
+		<h3 class="text-lg font-medium">Recording</h3>
+		<p class="text-muted-foreground text-sm">
+			Configure your Whispering recording preferences.
+		</p>
+	</div>
+	<Separator />
+
+	<LabeledSelect
+		id="recording-mode"
+		label="Recording Mode"
+		items={RECORDING_MODE_OPTIONS}
+		bind:selected={
+			() => settings.value['recording.mode'],
+			(selected) => settings.updateKey('recording.mode', selected)
+		}
+		placeholder="Select a recording mode"
+		description={`Choose how you want to activate recording: ${RECORDING_MODE_OPTIONS.map(
+			(option) => option.label.toLowerCase(),
+		).join(', ')}`}
+	/>
+
+	{#if window.__TAURI_INTERNALS__ && settings.value['recording.mode'] === 'manual'}
+		<LabeledSelect
+			id="recording-method"
+			label="Recording Method"
+			items={RECORDING_METHOD_OPTIONS}
+			bind:selected={
+				() => settings.value['recording.method'],
+				(selected) =>
+					settings.updateKey(
+						'recording.method',
+						selected as 'cpal' | 'navigator' | 'ffmpeg',
+					)
+			}
+			placeholder="Select a recording method"
+			description={RECORDING_METHOD_OPTIONS.find(
+				(option) => option.value === settings.value['recording.method'],
+			)?.description}
+		>
+			{#snippet renderOption({ item })}
+				<div class="flex flex-col gap-0.5">
+					<div class="font-medium">{item.label}</div>
+					{#if item.description}
+						<div class="text-xs text-muted-foreground">{item.description}</div>
+					{/if}
+				</div>
+			{/snippet}
+		</LabeledSelect>
+
+		{#if IS_MACOS && settings.value['recording.method'] === 'navigator'}
+			<Alert.Root class="border-amber-500/20 bg-amber-500/5">
+				<InfoIcon class="size-4 text-amber-600 dark:text-amber-400" />
+				<Alert.Title class="text-amber-600 dark:text-amber-400">
+					Global Shortcuts May Be Unreliable
+				</Alert.Title>
+				<Alert.Description>
+					When using the navigator recorder, macOS App Nap may prevent the
+					browser recording logic from starting when not in focus. Consider
+					using the CPAL method for reliable global shortcut support.
+				</Alert.Description>
+			</Alert.Root>
+		{/if}
+
+		{#if settings.value['recording.method'] === 'ffmpeg' && !data.ffmpegInstalled}
+			<Alert.Root class="border-red-500/20 bg-red-500/5">
+				<InfoIcon class="size-4 text-red-600 dark:text-red-400" />
+				<Alert.Title class="text-red-600 dark:text-red-400">
+					FFmpeg Not Installed
+				</Alert.Title>
+				<Alert.Description>
+					FFmpeg is required for the FFmpeg recording method. Please install it
+					to use this feature.
+					<Link
+						href="/verticalnav/install-ffmpeg"
+						class="font-medium underline underline-offset-4 hover:text-red-700 dark:hover:text-red-300"
+					>
+						Install FFmpeg →
+					</Link>
+				</Alert.Description>
+			</Alert.Root>
+		{:else if isCompressionRecommended()}
+			<Alert.Root class="border-blue-500/20 bg-blue-500/5">
+				<InfoIcon class="size-4 text-blue-600 dark:text-blue-400" />
+				<Alert.Title class="text-blue-600 dark:text-blue-400">
+					Enable Compression for Faster Uploads
+				</Alert.Title>
+				<Alert.Description>
+					{COMPRESSION_RECOMMENDED_MESSAGE}
+					<Link
+						href="/verticalnav/settings/transcription"
+						class="font-medium underline underline-offset-4 hover:text-blue-700 dark:hover:text-blue-300"
+					>
+						Enable in Transcription Settings →
+					</Link>
+				</Alert.Description>
+			</Alert.Root>
+		{/if}
+
+		{#if hasNavigatorLocalTranscriptionIssue( { isFFmpegInstalled: data.ffmpegInstalled ?? false }, )}
+			<Alert.Root class="border-red-500/20 bg-red-500/5">
+				<InfoIcon class="size-4 text-red-600 dark:text-red-400" />
+				<Alert.Title class="text-red-600 dark:text-red-400">
+					Local Transcription Requires FFmpeg or CPAL Recording
+				</Alert.Title>
+				<Alert.Description>
+					The Browser API recording method produces compressed audio that
+					requires FFmpeg for local transcription with {localTranscriptionServiceName}.
+					<div class="mt-3 space-y-3">
+						<div class="flex items-center gap-2">
+							<span class="text-sm"><strong>Option 1:</strong></span>
+							<Button
+								onclick={() => settings.updateKey('recording.method', 'cpal')}
+								variant="secondary"
+								size="sm"
+							>
+								Switch to CPAL Recording
+							</Button>
+						</div>
+						<div class="text-sm">
+							<strong>Option 2:</strong>
+							<Link href="/verticalnav/install-ffmpeg">Install FFmpeg</Link>
+							to keep using Browser API recording
+						</div>
+						<div class="text-sm">
+							<strong>Option 3:</strong>
+							Switch to a cloud transcription service (OpenAI, Groq, Deepgram, etc.)
+							which work with all recording methods
+						</div>
+					</div>
+				</Alert.Description>
+			</Alert.Root>
+		{/if}
+	{/if}
+
+	{#if settings.value['recording.mode'] === 'manual'}
+		{@const method = settings.value['recording.method']}
+		<ManualSelectRecordingDevice
+			bind:selected={
+				() => settings.value[`recording.${method}.deviceId`],
+				(selected) =>
+					settings.updateKey(`recording.${method}.deviceId`, selected)
+			}
+		/>
+	{:else if settings.value['recording.mode'] === 'vad'}
+		{#if IS_LINUX}
+			<Alert.Root class="border-red-500/20 bg-red-500/5">
+				<InfoIcon class="size-4 text-red-600 dark:text-red-400" />
+				<Alert.Title class="text-red-600 dark:text-red-400">
+					VAD Mode Not Supported on Linux
+				</Alert.Title>
+				<Alert.Description>
+					Voice Activated Detection (VAD) mode requires the browser's Navigator
+					API, which is not fully supported in Tauri on Linux. Device
+					enumeration and recording will fail. Please use Manual recording mode
+					instead.
+					<Link
+						href="https://github.com/epicenter-md/epicenter/issues/839"
+						target="_blank"
+						class="font-medium underline underline-offset-4 hover:text-red-700 dark:hover:text-red-300"
+					>
+						Learn more →
+					</Link>
+				</Alert.Description>
+			</Alert.Root>
+		{:else}
+			<Alert.Root class="border-blue-500/20 bg-blue-500/5">
+				<InfoIcon class="size-4 text-blue-600 dark:text-blue-400" />
+				<Alert.Title class="text-blue-600 dark:text-blue-400">
+					Voice Activated Detection Mode
+				</Alert.Title>
+				<Alert.Description>
+					VAD mode uses the browser's Web Audio API for real-time voice
+					detection and records via the browser's MediaRecorder API. Audio is
+					encoded to uncompressed WAV format. VAD mode has its own recording
+					method and cannot use CPAL or FFmpeg.
+				</Alert.Description>
+			</Alert.Root>
+		{/if}
+
+		<VadSelectRecordingDevice
+			bind:selected={
+				() => settings.value['recording.navigator.deviceId'],
+				(selected) =>
+					settings.updateKey('recording.navigator.deviceId', selected)
+			}
+		/>
+	{/if}
+
+	{#if settings.value['recording.mode'] === 'manual' || settings.value['recording.mode'] === 'vad'}
+		{#if isUsingNavigatorMethod}
+			<!-- Browser method settings -->
+			<LabeledSelect
+				id="bit-rate"
+				label="Bitrate"
+				items={BITRATE_OPTIONS.map((option) => ({
+					value: option.value,
+					label: option.label,
+				}))}
+				bind:selected={
+					() => settings.value['recording.navigator.bitrateKbps'],
+					(selected) =>
+						settings.updateKey('recording.navigator.bitrateKbps', selected)
+				}
+				placeholder="Select a bitrate"
+				description="The bitrate of the recording. Higher values mean better quality but larger file sizes."
+			/>
+		{:else if isUsingFfmpegMethod}
+			<!-- FFmpeg method settings -->
+			<div class="space-y-2">
+				<label for="output-folder" class="text-sm font-medium">
+					Recording Output Folder
+				</label>
+				<DesktopOutputFolder></DesktopOutputFolder>
+				<p class="text-xs text-muted-foreground">
+					Choose where to save your recordings. Default location is secure and
+					managed by the app.
+				</p>
+			</div>
+
+			<FfmpegCommandBuilder
+				bind:globalOptions={
+					() => settings.value['recording.ffmpeg.globalOptions'],
+					(v) => settings.updateKey('recording.ffmpeg.globalOptions', v)
+				}
+				bind:inputOptions={
+					() => settings.value['recording.ffmpeg.inputOptions'],
+					(v) => settings.updateKey('recording.ffmpeg.inputOptions', v)
+				}
+				bind:outputOptions={
+					() => settings.value['recording.ffmpeg.outputOptions'],
+					(v) => settings.updateKey('recording.ffmpeg.outputOptions', v)
+				}
+			/>
+		{:else}
+			<!-- CPAL method settings -->
+			<LabeledSelect
+				id="sample-rate"
+				label="Sample Rate"
+				items={SAMPLE_RATE_OPTIONS}
+				bind:selected={
+					() => settings.value['recording.cpal.sampleRate'],
+					(selected) =>
+						settings.updateKey('recording.cpal.sampleRate', selected)
+				}
+				placeholder="Select sample rate"
+				description="Higher sample rates provide better quality but create larger files"
+			/>
+
+			<div class="space-y-2">
+				<label for="output-folder" class="text-sm font-medium">
+					Recording Output Folder
+				</label>
+				<DesktopOutputFolder></DesktopOutputFolder>
+				<p class="text-xs text-muted-foreground">
+					Choose where to save your recordings. Default location is secure and
+					managed by the app.
+				</p>
+			</div>
+		{/if}
+	{/if}
+</div>

--- a/apps/whispering/src/routes/(app)/verticalnav/settings/recording/+page.ts
+++ b/apps/whispering/src/routes/(app)/verticalnav/settings/recording/+page.ts
@@ -1,0 +1,10 @@
+import { rpc } from '$lib/query';
+
+export const load = async () => {
+	const { data: ffmpegInstalled } =
+		await rpc.ffmpeg.checkFfmpegInstalled.ensure();
+
+	return {
+		ffmpegInstalled: ffmpegInstalled === true,
+	};
+};

--- a/apps/whispering/src/routes/(app)/verticalnav/settings/shortcuts/+layout.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/settings/shortcuts/+layout.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { Button } from '@repo/ui/button';
+	import { cn } from '@repo/ui/utils';
+	import { cubicInOut } from 'svelte/easing';
+	import { crossfade } from 'svelte/transition';
+
+	let { children } = $props();
+
+	const [send, receive] = crossfade({
+		duration: 250,
+		easing: cubicInOut,
+	});
+
+	const items = [
+		{ href: '/verticalnav/settings/shortcuts/local', title: 'Local Shortcuts' },
+		{
+			href: '/verticalnav/settings/shortcuts/global',
+			title: 'Global Shortcuts',
+		},
+	] as const;
+</script>
+
+<div class="mx-auto max-w-4xl space-y-6 py-6">
+	<header>
+		<h1 class="text-3xl font-bold tracking-tight">Keyboard Shortcuts</h1>
+		<p class="mt-2 text-muted-foreground">
+			Configure keyboard shortcuts to quickly access Whispering features.
+		</p>
+	</header>
+
+	<nav class="flex w-full gap-1 rounded-lg bg-muted p-1">
+		{#each items as item (item.href)}
+			{@const isActive = page.url.pathname === item.href}
+			<Button
+				href={item.href}
+				variant="ghost"
+				class={cn(
+					'relative flex-1 justify-center transition-colors',
+					isActive
+						? 'text-foreground hover:text-foreground'
+						: 'text-muted-foreground hover:text-foreground',
+				)}
+				data-sveltekit-noscroll
+			>
+				{#if isActive}
+					<div
+						class="absolute inset-0 rounded-md bg-background shadow-sm"
+						in:send={{ key: 'active-tab' }}
+						out:receive={{ key: 'active-tab' }}
+					></div>
+				{/if}
+				<span class="relative z-10">
+					{item.title}
+				</span>
+			</Button>
+		{/each}
+	</nav>
+
+	{@render children()}
+</div>

--- a/apps/whispering/src/routes/(app)/verticalnav/settings/shortcuts/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/settings/shortcuts/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import ShortcutsPage from '../../../(config)/settings/shortcuts/+page.svelte';
+</script>
+
+<ShortcutsPage />

--- a/apps/whispering/src/routes/(app)/verticalnav/settings/shortcuts/global/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/settings/shortcuts/global/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import GlobalShortcutsPage from '../../../../(config)/settings/shortcuts/global/+page.svelte';
+</script>
+
+<GlobalShortcutsPage />

--- a/apps/whispering/src/routes/(app)/verticalnav/settings/shortcuts/local/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/settings/shortcuts/local/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import LocalShortcutsPage from '../../../../(config)/settings/shortcuts/local/+page.svelte';
+</script>
+
+<LocalShortcutsPage />

--- a/apps/whispering/src/routes/(app)/verticalnav/settings/sound/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/settings/sound/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import SoundPage from '../../../(config)/settings/sound/+page.svelte';
+</script>
+
+<SoundPage />

--- a/apps/whispering/src/routes/(app)/verticalnav/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/settings/transcription/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import TranscriptionPage from '../../../(config)/settings/transcription/+page.svelte';
+
+	const { data } = $props();
+</script>
+
+<TranscriptionPage {data} />

--- a/apps/whispering/src/routes/(app)/verticalnav/settings/transcription/+page.ts
+++ b/apps/whispering/src/routes/(app)/verticalnav/settings/transcription/+page.ts
@@ -1,0 +1,10 @@
+import { rpc } from '$lib/query';
+
+export const load = async () => {
+	const { data: ffmpegInstalled } =
+		await rpc.ffmpeg.checkFfmpegInstalled.ensure();
+
+	return {
+		ffmpegInstalled: ffmpegInstalled === true,
+	};
+};

--- a/apps/whispering/src/routes/(app)/verticalnav/transformations/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/transformations/+page.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import TransformationsPage from '../../(config)/transformations/+page.svelte';
+	import { useSidebar } from '@repo/ui/sidebar';
+
+	const sidebar = useSidebar();
+</script>
+
+<div class:hidden-header={sidebar.state === 'expanded'}>
+	<TransformationsPage />
+</div>
+
+<style>
+	.hidden-header :global(h1) {
+		display: none;
+	}
+</style>

--- a/apps/whispering/src/routes/(app)/verticalnav/transformations/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/transformations/+page.svelte
@@ -5,12 +5,22 @@
 	const sidebar = useSidebar();
 </script>
 
-<div class:hidden-header={sidebar.state === 'expanded'}>
+<div class:hidden-header={sidebar.state === 'expanded' && !sidebar.isMobile}>
 	<TransformationsPage />
 </div>
 
 <style>
 	.hidden-header :global(h1) {
 		display: none;
+	}
+
+	:global(h1) {
+		padding-left: 1.375rem;
+	}
+
+	@media (min-width: 768px) {
+		:global(h1) {
+			padding-left: 0;
+		}
 	}
 </style>

--- a/apps/whispering/src/routes/(app)/verticalnav/transformations/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/transformations/+page.svelte
@@ -1,19 +1,10 @@
 <script lang="ts">
 	import TransformationsPage from '../../(config)/transformations/+page.svelte';
-	import { useSidebar } from '@repo/ui/sidebar';
-
-	const sidebar = useSidebar();
 </script>
 
-<div class:hidden-header={sidebar.state === 'expanded' && !sidebar.isMobile}>
-	<TransformationsPage />
-</div>
+<TransformationsPage />
 
 <style>
-	.hidden-header :global(h1) {
-		display: none;
-	}
-
 	:global(h1) {
 		padding-left: 1.375rem;
 	}

--- a/apps/whispering/src/routes/(app)/verticalnav/transformations/new/+page.svelte
+++ b/apps/whispering/src/routes/(app)/verticalnav/transformations/new/+page.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { Editor } from '$lib/components/transformations-editor';
+	import { Button } from '@repo/ui/button';
+	import * as Card from '@repo/ui/card';
+	import { rpc } from '$lib/query';
+	import { generateDefaultTransformation } from '$lib/services/db';
+	import { createMutation } from '@tanstack/svelte-query';
+
+	const createTransformation = createMutation(
+		rpc.db.transformations.create.options,
+	);
+
+	let transformation = $state(generateDefaultTransformation());
+</script>
+
+<Card.Root class="w-full max-w-4xl">
+	<Card.Header>
+		<Card.Title>Create Transformation</Card.Title>
+		<Card.Description>
+			Create a new transformation to transform text.
+		</Card.Description>
+	</Card.Header>
+	<Card.Content class="space-y-6">
+		<Editor bind:transformation />
+		<Card.Footer class="flex justify-end gap-2">
+			<Button
+				onclick={() =>
+					createTransformation.mutate($state.snapshot(transformation), {
+						onSuccess: () => {
+							goto('/verticalnav/transformations');
+							rpc.notify.success.execute({
+								title: 'Created transformation!',
+								description:
+									'Your transformation has been created successfully.',
+							});
+						},
+						onError: (error) => {
+							rpc.notify.error.execute({
+								title: 'Failed to create transformation!',
+								description: 'Your transformation could not be created.',
+								action: { type: 'more-details', error },
+							});
+						},
+					})}
+			>
+				Create Transformation
+			</Button>
+		</Card.Footer>
+	</Card.Content>
+</Card.Root>

--- a/bun.lock
+++ b/bun.lock
@@ -97,6 +97,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@repo/constants": "workspace:*",
+        "@repo/shared": "workspace:*",
         "@tanstack/svelte-query": "^6.0.0",
         "@tanstack/svelte-query-devtools": "^6.0.0",
         "@trpc/client": "^11.0.3",
@@ -143,7 +144,7 @@
     },
     "apps/whispering": {
       "name": "@repo/whispering",
-      "version": "7.5.5",
+      "version": "7.7.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@aptabase/tauri": "^0.4.1",
@@ -151,6 +152,7 @@
         "@google/generative-ai": "^0.24.1",
         "@mistralai/mistralai": "^1.9.18",
         "@repo/constants": "workspace:*",
+        "@repo/shared": "workspace:*",
         "@repo/svelte-utils": "workspace:*",
         "@ricky0123/vad-web": "^0.0.24",
         "@standard-schema/spec": "^1.0.0",
@@ -283,14 +285,14 @@
       "version": "0.0.1",
       "dependencies": {
         "@fontsource-variable/manrope": "^5.2.6",
-        "@lucide/svelte": "^0.525.0",
+        "@lucide/svelte": "^0.544.0",
         "@tanstack/svelte-table": "catalog:",
-        "bits-ui": "catalog:",
+        "bits-ui": "^2.11.0",
         "clsx": "catalog:",
         "paneforge": "^1.0.0-next.5",
         "svelte-check": "^4.3.1",
         "tailwind-merge": "catalog:",
-        "tailwind-variants": "catalog:",
+        "tailwind-variants": "^3.1.1",
       },
       "devDependencies": {
         "@internationalized/date": "^3.8.1",
@@ -1131,7 +1133,7 @@
 
     "better-call": ["better-call@1.0.15", "", { "dependencies": { "@better-fetch/fetch": "^1.1.4", "rou3": "^0.5.1", "set-cookie-parser": "^2.7.1", "uncrypto": "^0.1.3" } }, "sha512-u4ZNRB1yBx5j3CltTEbY2ZoFPVcgsuvciAqTEmPvnZpZ483vlZf4LGJ5aVau1yMlrvlyHxOCica3OqXBLhmsUw=="],
 
-    "bits-ui": ["bits-ui@2.8.10", "", { "dependencies": { "@floating-ui/core": "^1.7.1", "@floating-ui/dom": "^1.7.1", "esm-env": "^1.1.2", "runed": "^0.29.1", "svelte-toolbelt": "^0.9.3", "tabbable": "^6.2.0" }, "peerDependencies": { "@internationalized/date": "^3.8.1", "svelte": "^5.33.0" } }, "sha512-MOobkqapDZNrpcNmeL2g664xFmH4tZBOKBTxFmsQYMZQuybSZHQnPXy+AjM5XZEXRmCFx5+XRmo6+fC3vHh1hQ=="],
+    "bits-ui": ["bits-ui@2.14.1", "", { "dependencies": { "@floating-ui/core": "^1.7.1", "@floating-ui/dom": "^1.7.1", "esm-env": "^1.1.2", "runed": "^0.35.1", "svelte-toolbelt": "^0.10.6", "tabbable": "^6.2.0" }, "peerDependencies": { "@internationalized/date": "^3.8.1", "svelte": "^5.33.0" } }, "sha512-FkQTBDF+BLh5fgwioi04JJD8kpsQ+pVjPwzxUYYd39pYR0uKAyMLmoKo3EAWJIszV7fjTv1ZiNzxTkpGutJ32w=="],
 
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
@@ -1781,6 +1783,8 @@
 
     "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
     "magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
 
     "magicast": ["magicast@0.3.5", "", { "dependencies": { "@babel/parser": "^7.25.4", "@babel/types": "^7.25.4", "source-map-js": "^1.2.0" } }, "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ=="],
@@ -2341,7 +2345,7 @@
 
     "tailwind-merge": ["tailwind-merge@3.3.1", "", {}, "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g=="],
 
-    "tailwind-variants": ["tailwind-variants@1.0.0", "", { "dependencies": { "tailwind-merge": "3.0.2" }, "peerDependencies": { "tailwindcss": "*" } }, "sha512-2WSbv4ulEEyuBKomOunut65D8UZwxrHoRfYnxGcQNnHqlSCp2+B7Yz2W+yrNDrxRodOXtGD/1oCcKGNBnUqMqA=="],
+    "tailwind-variants": ["tailwind-variants@3.1.1", "", { "peerDependencies": { "tailwind-merge": ">=3.0.0", "tailwindcss": "*" }, "optionalPeers": ["tailwind-merge"] }, "sha512-ftLXe3krnqkMHsuBTEmaVUXYovXtPyTK7ckEfDRXS8PBZx0bAUas+A0jYxuKA5b8qg++wvQ3d2MQ7l/xeZxbZQ=="],
 
     "tailwindcss": ["tailwindcss@4.1.12", "", {}, "sha512-DzFtxOi+7NsFf7DBtI3BJsynR+0Yp6etH+nRPTbpWnS2pZBaSksv/JGctNwSWzbFjp0vxSqknaUylseZqMDGrA=="],
 
@@ -2713,7 +2717,11 @@
 
     "@repo/svelte-utils/svelte": ["svelte@5.14.4", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@jridgewell/sourcemap-codec": "^1.5.0", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "acorn-typescript": "^1.4.13", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "esm-env": "^1.2.1", "esrap": "^1.3.1", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-2iR/UHHA2Dsldo4JdXDcdqT+spueuh+uNYw1FoTKBbpnFEECVISeqSo0uubPS4AfBE0xI6u7DGHxcdq3DTDmoQ=="],
 
-    "@repo/ui/@lucide/svelte": ["@lucide/svelte@0.525.0", "", { "peerDependencies": { "svelte": "^5" } }, "sha512-dyUxkXzepagLUzL8jHQNdeH286nC66ClLACsg+Neu/bjkRJWPWMzkT+H0DKlE70QdkicGCfs1ZGmXCc351hmZA=="],
+    "@repo/ui/@lucide/svelte": ["@lucide/svelte@0.544.0", "", { "peerDependencies": { "svelte": "^5" } }, "sha512-9f9O6uxng2pLB01sxNySHduJN3HTl5p0HDu4H26VR51vhZfiMzyOMe9Mhof3XAk4l813eTtl+/DYRvGyoRR+yw=="],
+
+    "@repo/whispering/bits-ui": ["bits-ui@2.8.10", "", { "dependencies": { "@floating-ui/core": "^1.7.1", "@floating-ui/dom": "^1.7.1", "esm-env": "^1.1.2", "runed": "^0.29.1", "svelte-toolbelt": "^0.9.3", "tabbable": "^6.2.0" }, "peerDependencies": { "@internationalized/date": "^3.8.1", "svelte": "^5.33.0" } }, "sha512-MOobkqapDZNrpcNmeL2g664xFmH4tZBOKBTxFmsQYMZQuybSZHQnPXy+AjM5XZEXRmCFx5+XRmo6+fC3vHh1hQ=="],
+
+    "@repo/whispering/tailwind-variants": ["tailwind-variants@1.0.0", "", { "dependencies": { "tailwind-merge": "3.0.2" }, "peerDependencies": { "tailwindcss": "*" } }, "sha512-2WSbv4ulEEyuBKomOunut65D8UZwxrHoRfYnxGcQNnHqlSCp2+B7Yz2W+yrNDrxRodOXtGD/1oCcKGNBnUqMqA=="],
 
     "@rollup/plugin-inject/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
@@ -2779,9 +2787,9 @@
 
     "astro/vite": ["vite@6.3.5", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ=="],
 
-    "bits-ui/runed": ["runed@0.29.2", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-0cq6cA6sYGZwl/FvVqjx9YN+1xEBu9sDDyuWdDW1yWX7JF2wmvmVKfH+hVCZs+csW+P3ARH92MjI3H9QTagOQA=="],
+    "bits-ui/runed": ["runed@0.35.1", "", { "dependencies": { "dequal": "^2.0.3", "esm-env": "^1.0.0", "lz-string": "^1.5.0" }, "peerDependencies": { "@sveltejs/kit": "^2.21.0", "svelte": "^5.7.0" }, "optionalPeers": ["@sveltejs/kit"] }, "sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q=="],
 
-    "bits-ui/svelte-toolbelt": ["svelte-toolbelt@0.9.3", "", { "dependencies": { "clsx": "^2.1.1", "runed": "^0.29.0", "style-to-object": "^1.0.8" }, "peerDependencies": { "svelte": "^5.30.2" } }, "sha512-HCSWxCtVmv+c6g1ACb8LTwHVbDqLKJvHpo6J8TaqwUme2hj9ATJCpjCPNISR1OCq2Q4U1KT41if9ON0isINQZw=="],
+    "bits-ui/svelte-toolbelt": ["svelte-toolbelt@0.10.6", "", { "dependencies": { "clsx": "^2.1.1", "runed": "^0.35.1", "style-to-object": "^1.0.8" }, "peerDependencies": { "svelte": "^5.30.2" } }, "sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ=="],
 
     "boxen/chalk": ["chalk@5.6.0", "", {}, "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ=="],
 
@@ -2886,8 +2894,6 @@
     "svelte-sonner/runed": ["runed@0.28.0", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-k2xx7RuO9hWcdd9f+8JoBeqWtYrm5CALfgpkg2YDB80ds/QE4w0qqu34A7fqiAwiBBSBQOid7TLxwxVC27ymWQ=="],
 
     "svelte-toolbelt/runed": ["runed@0.23.4", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA=="],
-
-    "tailwind-variants/tailwind-merge": ["tailwind-merge@3.0.2", "", {}, "sha512-l7z+OYZ7mu3DTqrL88RiKrKIqO3NcpEO8V/Od04bNpvk0kiIFndGEoqfuzvj4yuhRkHKjRkII2z+KS2HfPcSxw=="],
 
     "tr46/punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
@@ -3012,6 +3018,12 @@
     "@octokit/rest/@octokit/core/before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
 
     "@repo/svelte-utils/svelte/esrap": ["esrap@1.4.9", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" } }, "sha512-3OMlcd0a03UGuZpPeUC1HxR3nA23l+HEyCiZw3b3FumJIN9KphoGzDJKMXI1S72jVS1dsenDyQC0kJlO1U9E1g=="],
+
+    "@repo/whispering/bits-ui/runed": ["runed@0.29.2", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-0cq6cA6sYGZwl/FvVqjx9YN+1xEBu9sDDyuWdDW1yWX7JF2wmvmVKfH+hVCZs+csW+P3ARH92MjI3H9QTagOQA=="],
+
+    "@repo/whispering/bits-ui/svelte-toolbelt": ["svelte-toolbelt@0.9.3", "", { "dependencies": { "clsx": "^2.1.1", "runed": "^0.29.0", "style-to-object": "^1.0.8" }, "peerDependencies": { "svelte": "^5.30.2" } }, "sha512-HCSWxCtVmv+c6g1ACb8LTwHVbDqLKJvHpo6J8TaqwUme2hj9ATJCpjCPNISR1OCq2Q4U1KT41if9ON0isINQZw=="],
+
+    "@repo/whispering/tailwind-variants/tailwind-merge": ["tailwind-merge@3.0.2", "", {}, "sha512-l7z+OYZ7mu3DTqrL88RiKrKIqO3NcpEO8V/Od04bNpvk0kiIFndGEoqfuzvj4yuhRkHKjRkII2z+KS2HfPcSxw=="],
 
     "@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@8.40.0", "", {}, "sha512-ETdbFlgbAmXHyFPwqUIYrfc12ArvpBhEVgGAxVYSwli26dn8Ko+lIo4Su9vI9ykTZdJn+vJprs/0eZU0YMAEQg=="],
 

--- a/docs/specs/20251029T143423-vertical-nav.md
+++ b/docs/specs/20251029T143423-vertical-nav.md
@@ -1,0 +1,1361 @@
+# Vertical Navigation Migration
+
+**Status:** Planning
+**Created:** 2025-10-29
+**Target:** Whispering v7.6.0+
+
+## Problem Statement
+
+The current Whispering app uses a topbar navigation layout that:
+
+- Only appears on config routes (`/recordings`, `/transformations`, `/settings`)
+- Is absent from the home page, causing inconsistent navigation
+- Duplicates recording controls between topbar and home page content
+- Creates navigation confusion for users
+- Limits screen real estate for content on smaller displays
+
+The topbar navigation may eventually be deprecated in favor of a more consistent vertical navigation approach.
+
+## Proposed Solution
+
+Implement a **vertical navigation layout** as a new route group that:
+
+1. Provides consistent navigation across ALL routes (including home)
+2. Consolidates recording controls in one location (vertical nav)
+3. Removes duplicate selectors from home page content
+4. Preserves existing topbar layout as "legacy" with minimal modifications
+5. Allows gradual migration and eventual removal of topbar layout
+6. Uses shadcn-svelte Sidebar component following existing patterns in `/packages/ui`
+   - Based on [sidebar-07](https://www.shadcn-svelte.com/blocks/sidebar#sidebar-07) - collapses to icons
+   - Consistent with project's shadcn-svelte usage
+
+## Design Decisions
+
+### Route Structure: Separate Route Groups
+
+**Chosen approach:** Create new `verticalnav/` route group alongside existing `(config)/` route group.
+
+**Rationale:**
+
+- Minimal modification to existing files (topbar becomes legacy)
+- Clean separation allows independent evolution
+- Easy to delete legacy later by removing entire `(config)/` folder
+- No conditional complexity in shared layout files
+- Safe rollback if issues arise
+
+### AppShell: Shared at Root
+
+**Decision:** Keep `AppShell.svelte` at root level, shared by both layouts.
+
+**Rationale:**
+
+- AppShell handles app lifecycle (updates, migrations, permissions, shortcuts)
+- These concerns are layout-agnostic
+- Avoids duplication of critical initialization logic
+- Single source of truth for global services
+
+### Implementation: Copy and Modify
+
+**Decision:** Copy `(config)/+layout.svelte` logic, create new sidebar UI from scratch.
+
+**Rationale:**
+
+- Preserves complex state management (recorder queries, mode switching)
+- Reduces risk of missing edge cases
+- Allows gradual UI transformation
+- Keeps all conditional recording mode logic working
+
+## Vertical Navigation Layout Design
+
+### VerticalNav Sections (Top to Bottom)
+
+1. **App Branding** (Header - no group label)
+   - Whispering logo/name
+   - Non-interactive, just branding
+
+2. **Navigation** (Group - no group label)
+   - Home
+   - Recordings
+   - Transformations
+   - Settings
+
+3. **Quick Settings** (Group label: "Quick Settings")
+   - Device selector (Manual/VAD based on mode)
+   - Compression selector
+   - Transcription selector
+   - Transformation selector
+
+4. **Quick Transcription** (Group label: "Quick Transcription")
+   - Recording action button (🎙️ / 👂 / 🎬)
+   - Recording mode selector dropdown
+   - Cancel button (when recording)
+
+5. **Footer Actions** (Footer - no group label)
+   - Theme toggle (dark/light mode)
+   - GitHub link
+   - Minimize button (desktop only)
+
+### Responsive Behavior
+
+- **Desktop (≥768px)**: Full vertical nav visible, ~240px width
+- **Tablet (640px-768px)**: Collapsible vertical nav
+- **Mobile (<640px)**: Offcanvas drawer (slides in/out)
+
+### Collapse States and Toggle Button
+
+The vertical nav implements a **two-state system** using the built-in shadcn-svelte collapse behavior.
+
+#### Initial Implementation: Expanded ↔ Icon-only
+
+**Decision:** Start with the simpler two-state pattern. A third "completely hidden" state can be added later if users request it.
+
+**Rationale:**
+
+- Icon-only mode (~48px) already provides significant space savings
+- Users maintain quick access to navigation and recording controls
+- Simpler implementation, less state management
+- Follows shadcn-svelte sidebar-07 pattern directly
+- Mobile already has "hidden" state via offcanvas drawer
+
+#### State Management (Initial)
+
+```svelte
+// No custom state needed - use built-in Sidebar.Trigger
+<Sidebar.Provider>
+	<Sidebar.Root collapsible="icon">
+		<Sidebar.Header>
+			<span>Whispering</span>
+		</Sidebar.Header>
+		<Sidebar.Content>
+			<!-- Nav items -->
+		</Sidebar.Content>
+	</Sidebar.Root>
+
+	<Sidebar.Inset>
+		<header>
+			<!-- Built-in toggle button -->
+			<Sidebar.Trigger />
+			<span>Page Title</span>
+		</header>
+		<main>{@render children()}</main>
+	</Sidebar.Inset>
+</Sidebar.Provider>
+```
+
+#### Two States
+
+1. **Expanded** - Full vertical nav with labels (~240px)
+2. **Icon-only** - Collapsed to icons (~48px)
+
+Toggle via `<Sidebar.Trigger />` component in content header, or keyboard shortcut (`Cmd/Ctrl + B`).
+
+#### Mobile Behavior
+
+On mobile (`<640px`):
+
+- Use `collapsible="offcanvas"` for drawer behavior
+- Vertical nav hidden by default, slides in when opened
+- Single toggle button in header
+- Provides the "hidden" state that desktop may add later
+
+### Home Page Changes
+
+**Remove from home page content:**
+
+- Duplicate recording selectors (device, compression, transcription, transformation)
+- Recording mode toggle group (move to vertical nav)
+- Scattered control buttons
+
+**Keep on home page:**
+
+- Large visual recording indicator/button (for discoverability)
+- Transcription output display
+- Audio player
+- Help text and shortcuts
+
+## Implementation Plan
+
+### Phase 1: Create Vertical Navigation Layout
+
+**Goal:** New vertical nav layout working alongside existing topbar layout.
+
+**Important:** During Phases 1-2, we use `(app)/verticalnav/` (without parentheses) to avoid SvelteKit route conflicts with `(app)/(config)/`. Both route groups would match the same URLs, causing errors. In Phase 3, we'll move the vertical nav layout directly into `(app)/+layout.svelte` after removing `(config)/`.
+
+**Note:** The main codebase now organizes all app routes under `(app)/` group. Our vertical nav will follow this pattern.
+
+**Why no `(verticalnav)/` route group in final state?**
+
+- After removing topbar, there's only ONE layout, so no need for route grouping
+- Simpler structure: vertical nav lives directly in `(app)/+layout.svelte`
+- Standard pattern: most apps have layout directly in route group without extra nesting
+- Follows YAGNI principle: don't add grouping unless there's a real need
+
+#### Temporary Layout Switching Links
+
+**Purpose:** Allow easy switching between topbar and vertical nav layouts during development/testing.
+
+**Implementation:**
+
+Add a link to the bottom of the content on each home page:
+
+1. **Topbar home page** (`(app)/(config)/+page.svelte`):
+
+   ```svelte
+   <!-- At bottom of page content -->
+   <div class="mt-8 text-center">
+   	<a
+   		href="/verticalnav"
+   		class="text-sm text-muted-foreground hover:underline"
+   	>
+   		Try the new vertical navigation layout
+   	</a>
+   </div>
+   ```
+
+2. **VerticalNav home page** (`(app)/verticalnav/+page.svelte`):
+   ```svelte
+   <!-- At bottom of page content -->
+   <div class="mt-8 text-center">
+   	<a href="/" class="text-sm text-muted-foreground hover:underline">
+   		Return to classic topbar layout
+   	</a>
+   </div>
+   ```
+
+**Location:** Bottom of main content area, after transcription output and help text.
+
+**Styling:**
+
+- Small, subtle text (`text-sm text-muted-foreground`)
+- Hover underline for affordance
+- Center-aligned
+
+**Removal:** Delete these links in Phase 3 when finalizing vertical nav as default (no need for switching after topbar is removed).
+
+#### Step 1.1: Create Route Structure
+
+```
+apps/whispering/src/routes/
+  (app)/
+    verticalnav/              # WITHOUT parentheses (development)
+      +layout.svelte          # Copy from (app)/(config)/+layout.svelte
+      +layout/
+        VerticalNav.svelte    # New component (created from scratch)
+      +page.svelte            # Copy from (app)/+page.svelte
+```
+
+**Access via:**
+
+- Topbar (existing): `http://localhost:5173/recordings`
+- VerticalNav (new): `http://localhost:5173/verticalnav/recordings`
+
+**Tasks:**
+
+- [ ] Create `(app)/verticalnav/` directory (without parentheses on verticalnav)
+- [ ] Copy `(app)/(config)/+layout.svelte` → `(app)/verticalnav/+layout.svelte`
+- [ ] Copy `(app)/+page.svelte` → `(app)/verticalnav/+page.svelte`
+
+#### Step 1.2: Install and Setup shadcn-svelte Sidebar
+
+**Prerequisites:**
+
+First, add the sidebar component to `/packages/ui`:
+
+```bash
+cd packages/ui
+pnpm dlx shadcn-svelte@latest add https://shadcn-svelte.com/registry/default/ui/sidebar.json
+```
+
+This will add the necessary Sidebar primitives to `/packages/ui/src/sidebar/`.
+
+**Tasks:**
+
+- [ ] Install sidebar component in `/packages/ui`
+- [ ] Export sidebar components from `/packages/ui/src/index.ts`
+- [ ] Verify imports work in whispering app
+
+#### Step 1.3: Create App VerticalNav Component
+
+**File:** `apps/whispering/src/routes/(app)/verticalnav/+layout/VerticalNav.svelte`
+
+Based on [sidebar-07](https://www.shadcn-svelte.com/blocks/sidebar#sidebar-07) pattern (collapses to icons).
+
+**Props interface:**
+
+```typescript
+interface Props {
+	getRecorderStateQuery: CreateQueryResult;
+	getVadStateQuery: CreateQueryResult;
+	isMobile: boolean;
+}
+```
+
+**Structure using shadcn-svelte components:**
+
+```svelte
+<script lang="ts">
+	import { page } from '$app/state';
+	import * as Sidebar from '@repo/ui/sidebar';
+	import { HomeIcon, ListIcon, LayersIcon, SettingsIcon } from '@lucide/svelte';
+
+	let { getRecorderStateQuery, getVadStateQuery, isMobile }: Props = $props();
+
+	// Navigation items array (similar to NavItems.svelte)
+	const navItems = [
+		{
+			label: 'Home',
+			icon: HomeIcon,
+			href: '/',
+		},
+		{
+			label: 'Recordings',
+			icon: ListIcon,
+			href: '/recordings',
+		},
+		{
+			label: 'Transformations',
+			icon: LayersIcon,
+			href: '/transformations',
+		},
+		{
+			label: 'Settings',
+			icon: SettingsIcon,
+			href: '/settings',
+		},
+	] as const;
+
+	const isItemActive = (item: (typeof navItems)[number]) => {
+		if (item.href === '/') {
+			return page.url.pathname === '/';
+		}
+		return page.url.pathname.startsWith(item.href);
+	};
+</script>
+
+<Sidebar.Root collapsible="icon">
+	<Sidebar.Header>
+		<div class="flex items-center px-2">
+			<span class="font-bold text-lg">Whispering</span>
+		</div>
+	</Sidebar.Header>
+
+	<Sidebar.Content>
+		<!-- Section order: 1. Branding, 2. Navigation (no label), 3. Quick Settings, 4. Quick Transcription, 5. Footer -->
+
+		<!-- Navigation group - no label -->
+		<Sidebar.Group>
+			<Sidebar.GroupContent>
+				<Sidebar.Menu>
+					{#each navItems as item}
+						{@const Icon = item.icon}
+						{@const isActive = isItemActive(item)}
+						<Sidebar.MenuItem>
+							<Sidebar.MenuButton href={item.href} {isActive}>
+								<Icon />
+								<span>{item.label}</span>
+							</Sidebar.MenuButton>
+						</Sidebar.MenuItem>
+					{/each}
+				</Sidebar.Menu>
+			</Sidebar.GroupContent>
+		</Sidebar.Group>
+
+		<Sidebar.Group>
+			<Sidebar.GroupLabel>Quick Settings</Sidebar.GroupLabel>
+			<Sidebar.GroupContent>
+				<!-- Device, Compression, Transcription, Transformation selectors -->
+			</Sidebar.GroupContent>
+		</Sidebar.Group>
+
+		<Sidebar.Group>
+			<Sidebar.GroupLabel>Quick Transcription</Sidebar.GroupLabel>
+			<Sidebar.GroupContent>
+				<!-- Recording action button, mode selector -->
+			</Sidebar.GroupContent>
+		</Sidebar.Group>
+	</Sidebar.Content>
+
+	<Sidebar.Footer>
+		<!-- No group label in footer -->
+		<Sidebar.Menu>
+			{#each footerItems as item}
+				{@const Icon = item.icon}
+				<Sidebar.MenuItem>
+					{#if item.type === 'anchor'}
+						<Sidebar.MenuButton
+							href={item.href}
+							target={item.external ? '_blank' : undefined}
+							rel={item.external ? 'noopener noreferrer' : undefined}
+						>
+							<Icon />
+							<span>{item.label}</span>
+						</Sidebar.MenuButton>
+					{:else if item.type === 'button'}
+						<Sidebar.MenuButton onclick={item.action}>
+							<Icon />
+							<span>{item.label}</span>
+						</Sidebar.MenuButton>
+					{:else if item.type === 'theme'}
+						<Sidebar.MenuButton onclick={item.action}>
+							<SunIcon
+								class="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0"
+							/>
+							<MoonIcon
+								class="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100"
+							/>
+							<span>{item.label}</span>
+						</Sidebar.MenuButton>
+					{/if}
+				</Sidebar.MenuItem>
+			{/each}
+		</Sidebar.Menu>
+	</Sidebar.Footer>
+</Sidebar.Root>
+```
+
+**Footer items array (similar to NavItems.svelte):**
+
+```svelte
+<script lang="ts">
+	import { toggleMode } from 'mode-watcher';
+	import { getCurrentWindow } from '@tauri-apps/api/window';
+	import { LogicalSize } from '@tauri-apps/api/window';
+	import { notificationLog } from '$lib/components/NotificationLog.svelte';
+	import { LogsIcon } from '@lucide/svelte';
+
+	const footerItems = [
+		{
+			label: 'Toggle dark mode',
+			icon: SunIcon,
+			type: 'theme' as const,
+			action: toggleMode,
+		},
+		{
+			label: 'View project on GitHub',
+			icon: GithubIcon,
+			href: 'https://github.com/epicenter-md/epicenter',
+			type: 'anchor' as const,
+			external: true,
+		},
+		...(window.__TAURI_INTERNALS__
+			? ([
+					{
+						label: 'Minimize',
+						icon: Minimize2Icon,
+						type: 'button' as const,
+						action: () => getCurrentWindow().setSize(new LogicalSize(72, 84)),
+					},
+				] as const)
+			: []),
+		{
+			label: 'Notifications',
+			icon: LogsIcon,
+			type: 'button' as const,
+			action: () => {
+				notificationLog.isOpen = !notificationLog.isOpen;
+			},
+		},
+	];
+</script>
+```
+
+**Implementation Notes:**
+
+- Use array-based navigation pattern similar to `NavItems.svelte` (lines 24-67)
+- Define `navItems` array with label, icon, href
+- Define `footerItems` array with label, icon, type (anchor/button/theme), action/href
+- Use `{#each}` to iterate and render items dynamically
+- Keep `isItemActive()` helper for active state logic
+- This approach makes items easy to add/remove/reorder
+
+**Tasks:**
+
+- [ ] Create VerticalNav.svelte component
+- [ ] Set `collapsible="icon"` on Sidebar.Root
+- [ ] Implement header with branding
+- [ ] Define `navItems` array (Home, Recordings, Transformations, Settings)
+- [ ] Define `footerItems` array (Theme, GitHub, Minimize, Notifications)
+- [ ] Import `notificationLog` from NotificationLog.svelte
+- [ ] Render navigation items using `{#each navItems}`
+- [ ] Implement active route highlighting with `isItemActive()` helper
+- [ ] Add configuration selectors section (Quick Settings)
+- [ ] Add recording controls section (Quick Transcription)
+- [ ] Render footer items using `{#each footerItems}`
+- [ ] Remove floating NotificationLog button from AppLayout.svelte
+- [ ] Update dev tools positioning (TanStack bottom-right, Inspector top-right)
+- [ ] Test collapse to icon functionality (via Sidebar.Trigger in layout)
+- [ ] Style to match Whispering theme
+
+#### Step 1.4: Migrate Recording Controls to VerticalNav
+
+**Source logic:** `(app)/(config)/+layout.svelte` lines 46-149
+
+**Strategy:** Extract recording controls into reusable components.
+
+**New components:**
+
+```
+(app)/verticalnav/+layout/
+  VerticalNav.svelte
+  RecordingControls.svelte      # Action button + mode selector
+  RecordingSelectors.svelte     # Device, compression, transcription, transformation
+```
+
+**Tasks:**
+
+- [ ] Create RecordingControls.svelte
+  - [ ] Manual mode: microphone button + mode dropdown
+  - [ ] VAD mode: ear button + mode dropdown
+  - [ ] Upload mode: mode dropdown only
+  - [ ] Live mode: camera button + mode dropdown
+- [ ] Create RecordingSelectors.svelte
+  - [ ] Conditional device selector (Manual vs VAD)
+  - [ ] Compression selector
+  - [ ] Transcription selector
+  - [ ] Transformation selector
+  - [ ] Handle state-based visibility (hide during recording)
+- [ ] Extract NavItems logic for vertical nav context
+- [ ] Test all recording modes and state transitions
+
+#### Step 1.5: Update VerticalNav Layout File
+
+**File:** `(app)/verticalnav/+layout.svelte`
+
+**Structure:**
+
+```svelte
+<script lang="ts">
+  import VerticalNav from './+layout/VerticalNav.svelte';
+  import * as Sidebar from '@repo/ui/sidebar';
+  
+  // Keep all state management from (app)/(config)/+layout.svelte
+  const getRecorderStateQuery = createQuery(...);
+  const getVadStateQuery = createQuery(...);
+  const isMobile = new MediaQuery(...);
+  
+  let { children } = $props();
+</script>
+
+<Sidebar.Provider>
+	<VerticalNav {getRecorderStateQuery} {getVadStateQuery} {isMobile} />
+
+	<Sidebar.Inset>
+		<header class="flex h-14 items-center gap-2 border-b px-4">
+			<!-- Built-in toggle button -->
+			<Sidebar.Trigger />
+			<span class="text-lg font-semibold">Page Title</span>
+		</header>
+
+		<main class="flex-1 overflow-auto">
+			{@render children()}
+		</main>
+	</Sidebar.Inset>
+</Sidebar.Provider>
+```
+
+**Tasks:**
+
+- [ ] Wrap in `Sidebar.Provider`
+- [ ] Use built-in `<Sidebar.Trigger />` in content header
+- [ ] Pass state queries as props to VerticalNav
+- [ ] Use `Sidebar.Inset` for main content area
+- [ ] Add proper overflow handling (prevent double scrollbars)
+- [ ] Test layout on various screen sizes
+- [ ] Test keyboard shortcut (Cmd/Ctrl + B)
+
+#### Step 1.6: Update VerticalNav Home Page
+
+**File:** `(app)/verticalnav/+page.svelte`
+
+**Remove:**
+
+- Recording mode toggle group (now in vertical nav)
+- Device/compression/transcription/transformation selectors (now in vertical nav)
+- Inline recording controls
+
+**Keep:**
+
+- Large visual recording indicator
+- Transcription output display
+- Audio player
+- Help text and shortcuts
+- NavItems links (now redundant with vertical nav, consider removing)
+
+**Tasks:**
+
+- [ ] Remove duplicate recording selectors
+- [ ] Remove recording mode toggle group
+- [ ] Simplify layout to focus on output
+- [ ] Keep large visual microphone/indicator for UX
+- [ ] Update help text to reference vertical nav controls
+- [ ] Test responsive behavior
+
+### Phase 2: Add Page Routes to VerticalNav Group
+
+**Goal:** Copy/link all existing pages to work with vertical nav layout.
+
+#### Step 2.1: Recordings Page
+
+```
+(app)/verticalnav/recordings/
+  +page.svelte                           # Import from (app)/(config)
+  row-actions/
+    EditRecordingModal.svelte            # Symlink or import
+    RecordingRowActions.svelte           # Symlink or import
+    TransformationPicker.svelte          # Symlink or import
+    ViewTransformationRunsDialog.svelte  # Symlink or import
+  LatestTransformationRunOutputByRecordingId.svelte
+  RenderAudioUrl.svelte
+```
+
+**Strategy:** Re-export components from (app)/(config) to avoid duplication.
+
+**Tasks:**
+
+- [ ] Create `(app)/verticalnav/recordings/+page.svelte`
+- [ ] Import and re-export from `(app)/(config)/recordings/+page.svelte`
+- [ ] Test functionality with vertical nav layout
+- [ ] Verify row actions and dialogs work correctly
+
+#### Step 2.2: Transformations Page
+
+```
+(app)/verticalnav/transformations/
+  +page.svelte
+  new/
+    +page.svelte
+  CreateTransformationButton.svelte
+  EditTransformationModal.svelte
+  MarkTransformationActiveButton.svelte
+  TransformationRowActions.svelte
+```
+
+**Tasks:**
+
+- [ ] Create `(app)/verticalnav/transformations/+page.svelte`
+- [ ] Import and re-export from `(app)/(config)/transformations/+page.svelte`
+- [ ] Copy `new/+page.svelte` or import
+- [ ] Test transformation editor with vertical nav layout
+- [ ] Verify all modals and actions work
+
+#### Step 2.3: Settings Pages
+
+```
+(app)/verticalnav/settings/
+  +layout.svelte                    # May need modification
+  +page.svelte
+  SidebarNav.svelte                 # Settings sub-navigation (no collision with VerticalNav)
+  analytics/+page.svelte
+  api-keys/+page.svelte
+  recording/+page.svelte
+  shortcuts/
+    +layout.svelte
+    +page.svelte
+    global/+page.svelte
+    local/+page.svelte
+  sound/+page.svelte
+  transcription/+page.svelte
+```
+
+**Note:** Settings already has its own `SidebarNav.svelte` for sub-navigation (no name collision with VerticalNav).
+
+**Tasks:**
+
+- [ ] Create `(app)/verticalnav/settings/+layout.svelte`
+- [ ] Import pages from `(app)/(config)/settings/`
+- [ ] Ensure settings sidebar works with app vertical nav
+- [ ] Test nested navigation
+- [ ] Verify all settings pages render correctly
+
+#### Step 2.4: Special Pages
+
+```
+(app)/verticalnav/
+  desktop-app/+page.svelte
+  global-shortcut/+page.svelte
+  install-ffmpeg/+page.svelte
+  macos-enable-accessibility/+page.svelte
+```
+
+**Tasks:**
+
+- [ ] Copy or import special pages
+- [ ] Test onboarding flows with vertical nav
+- [ ] Verify desktop-specific pages work
+
+### Phase 3: Finalize VerticalNav as Default
+
+**Goal:** Make vertical nav the default layout and remove topbar.
+
+#### Step 3.1: Move VerticalNav to Main App Layout
+
+**Strategy:** Move vertical nav directly into `(app)/+layout.svelte` - no need for a separate route group since there's only one layout.
+
+**Tasks:**
+
+- [ ] Delete `(app)/(config)/` folder entirely
+- [ ] Move `(app)/verticalnav/+layout.svelte` content into `(app)/+layout.svelte`
+- [ ] Move `(app)/verticalnav/_components/` to `(app)/_components/` (or keep inline if small)
+- [ ] Move all page routes from `(app)/verticalnav/*` to `(app)/*`
+  - `(app)/verticalnav/recordings/` → `(app)/recordings/`
+  - `(app)/verticalnav/transformations/` → `(app)/transformations/`
+  - `(app)/verticalnav/settings/` → `(app)/settings/`
+  - etc.
+- [ ] Update any hardcoded links that used `/verticalnav/` prefix (should be none if using relative links)
+- [ ] Test all routes work at root level (e.g., `/recordings`, `/settings`)
+- [ ] Verify VerticalNav renders correctly in main app layout
+
+**Final structure:**
+
+```
+routes/
+  (app)/
+    +layout.svelte           # Now includes VerticalNav
+    _components/
+      AppLayout.svelte       # Existing app lifecycle wrapper
+      VerticalNav.svelte     # Vertical nav component
+      RecordingControls.svelte
+      RecordingSelectors.svelte
+    _layout-utils/           # Existing utilities
+    recordings/
+    transformations/
+    settings/
+    +page.svelte
+```
+
+#### Step 3.2: Optional - Add UI Preference Setting (Not Recommended)
+
+**Skip this step.** Since we're removing topbar entirely, there's no need for a layout preference setting. This was only considered if supporting both layouts temporarily, which adds unnecessary complexity.
+
+#### Step 3.3: Update Release Notes
+
+**Document the change for users:**
+
+**Tasks:**
+
+- [ ] Update CHANGELOG with vertical nav migration
+- [ ] Create release notes highlighting new layout
+- [ ] Document any breaking changes
+- [ ] Add screenshots of new vertical nav
+- [ ] Mention topbar removal
+
+### Phase 4: Testing and Refinement
+
+**Goal:** Ensure vertical nav layout is production-ready.
+
+#### Step 4.1: Functional Testing
+
+**Test cases:**
+
+- [ ] All recording modes work (manual, VAD, upload, live)
+- [ ] Recording state transitions (idle → recording → stopped)
+- [ ] Selectors open and close properly
+- [ ] Navigation works on all pages
+- [ ] Dialogs and modals render correctly
+- [ ] Theme switching works
+- [ ] Minimize works (desktop)
+- [ ] Permissions flows work
+- [ ] Shortcuts work with sidebar visible
+- [ ] Update checks and notifications appear
+
+#### Step 4.2: Responsive Testing
+
+**Breakpoints to test:**
+
+- [ ] Large desktop (≥1280px)
+- [ ] Desktop (1024px-1280px)
+- [ ] Tablet landscape (768px-1024px)
+- [ ] Tablet portrait (640px-768px)
+- [ ] Mobile (320px-640px)
+- [ ] Tiny mobile (<320px)
+
+**Issues to verify:**
+
+- [ ] No horizontal scrollbars
+- [ ] Content doesn't overflow
+- [ ] VerticalNav collapses appropriately
+- [ ] Touch targets are adequate (44px minimum)
+- [ ] Text remains readable
+- [ ] No layout shifts
+
+#### Step 4.3: Performance Testing
+
+**Metrics:**
+
+- [ ] Initial load time
+- [ ] Navigation between pages
+- [ ] Recording start latency
+- [ ] Memory usage
+- [ ] VerticalNav collapse/expand smoothness
+
+#### Step 4.4: Accessibility Testing
+
+**Requirements:**
+
+- [ ] Keyboard navigation works
+- [ ] Focus management is correct
+- [ ] ARIA labels present
+- [ ] Screen reader compatibility
+- [ ] Color contrast meets WCAG AA
+- [ ] No keyboard traps
+
+### Phase 5: Documentation and Release
+
+**Goal:** Document changes and release to users.
+
+#### Step 5.1: Update Documentation
+
+**Files to update:**
+
+- [ ] `apps/whispering/README.md` - Add vertical nav layout info
+- [ ] Release notes - Document new vertical nav layout
+- [ ] User guide - Update screenshots and instructions
+- [ ] Developer docs - Document route structure
+
+#### Step 5.2: Analytics Integration
+
+**Events to track:**
+
+- [ ] `vertical_nav_layout_enabled` - User switches to vertical nav
+- [ ] `vertical_nav_layout_disabled` - User switches back to topbar
+- [ ] `vertical_nav_collapsed` - User collapses vertical nav
+- [ ] `vertical_nav_expanded` - User expands vertical nav
+- [ ] Usage by page/route
+
+**Tasks:**
+
+- [ ] Add analytics events
+- [ ] Test event firing
+- [ ] Verify PostHog dashboard
+
+#### Step 5.3: Release Strategy
+
+**Simplified rollout (single layout approach):**
+
+1. **Beta release** (v7.6.0-beta.1)
+   - VerticalNav replaces topbar completely
+   - Gather feedback from beta testers
+   - Fix critical issues
+
+2. **Stable release** (v7.6.0)
+   - VerticalNav is the default and only layout
+   - `(config)/` routes removed
+   - Release notes document the change
+   - Provide support for user questions
+
+**Tasks:**
+
+- [ ] Create beta build with vertical nav
+- [ ] Announce on Discord/GitHub
+- [ ] Collect feedback
+- [ ] Fix critical bugs
+- [ ] Release stable version
+- [ ] Monitor for issues
+
+## Technical Considerations
+
+### Overflow and Scrolling
+
+**Challenge:** Prevent double scrollbars (body + vertical nav + content).
+
+**Solution:**
+
+```css
+html,
+body {
+	height: 100vh;
+	overflow: hidden;
+}
+
+.app-with-vertical-nav {
+	display: flex;
+	height: 100vh;
+}
+
+.vertical-nav {
+	overflow-y: auto;
+	flex-shrink: 0;
+}
+
+.main-content {
+	overflow-y: auto;
+	flex: 1;
+	min-width: 0;
+}
+```
+
+### State Management
+
+**Challenge:** Recording controls need access to recorder state, settings, and commands.
+
+**Solution:** Pass state down from parent layout as props, or use existing context/stores.
+
+### Mobile Considerations
+
+**Options for mobile vertical nav:**
+
+1. **Slide-out drawer** - Activated by hamburger button
+2. **Bottom navigation** - Recording controls + nav icons
+3. **Full-screen overlay** - Tappable sections
+
+**Recommendation:** Start with slide-out drawer (most familiar pattern).
+
+### Recording Control Placement
+
+**Decision:** Keep recording controls at top of vertical nav (always visible).
+
+**Rationale:**
+
+- Primary action should be immediately accessible
+- State indicators need to be visible at all times
+- Users expect recording controls to be prominent
+
+### Settings Sidebar Conflict
+
+**Issue:** Settings already has `SidebarNav.svelte` for subsection navigation.
+
+**Solution:**
+
+- New app vertical nav named `VerticalNav.svelte`
+- Keep existing settings `SidebarNav.svelte` as is (no changes to existing file, no name collision)
+- Both work together (app VerticalNav + settings SidebarNav sub-navigation)
+
+### Notification History Integration
+
+**Decision:** Move notification history button from floating (bottom-right) to vertical nav footer (bottom-most position).
+
+**Current Implementation:**
+
+The app already has `NotificationLog.svelte`:
+
+- Floating button at bottom-right with `LogsIcon`
+- Opens popover with scrollable log of past notifications
+- Shows title, description, variant (success/error/warning/info/loading)
+- Currently rendered in `AppLayout.svelte`
+
+**Changes:**
+
+1. **Add to footer items array** (last position = bottom-most):
+
+   ```svelte
+   {
+     label: 'Notifications',
+     icon: LogsIcon,
+     type: 'button' as const,
+     action: () => { notificationLog.isOpen = !notificationLog.isOpen },
+   }
+   ```
+
+2. **Remove floating button** from `AppLayout.svelte` (or conditionally hide when vertical nav is active)
+
+3. **Keep popover in root layout** so it's always accessible
+
+**Benefits:**
+
+- Frees up bottom-right corner for dev tools
+- More discoverable (always visible in nav, not floating)
+- Consistent with other app controls (theme, GitHub, minimize)
+- Bottom-most position = most accessible
+
+**Note:** No unread count badge needed - keep it simple.
+
+### Development Tools Positioning
+
+**Decision:** Reposition dev tools to top-right and bottom-right corners now that vertical nav uses left side.
+
+**Rationale:**
+
+- Top-right corner is now free (topbar removed)
+- Bottom-right freed up by moving notifications to vertical nav
+- Clear separation: production UI (left) vs dev tools (right edge)
+
+**Implementation:**
+
+```svelte
+<!-- Root +layout.svelte -->
+
+<!-- TanStack Query Devtools: Bottom Right -->
+<SvelteQueryDevtools client={queryClient} buttonPosition="bottom-right" />
+
+<style>
+	/* Svelte Inspector: Top Right */
+	:global(#svelte-inspector-host button) {
+		top: 16px !important;
+		right: 16px !important;
+		bottom: auto !important;
+		left: auto !important;
+		transform: none !important;
+	}
+</style>
+```
+
+**Final Layout (Development Mode):**
+
+```
+┌──────────────┬─────────────────────────────────┐
+│              │  [Svelte Inspector] 🔍          │ ← Top right (dev)
+│ VerticalNav  │                                 │
+│              │         Content                 │
+│              │                                 │
+│ [Theme] 🌙   │                                 │
+│ [GitHub] 🐙  │                                 │
+│ [Notif] 🔔   │                [TanStack] 🔧    │ ← Bottom right (dev)
+└──────────────┴─────────────────────────────────┘
+```
+
+**Corner Usage:**
+
+- **Top-left:** Vertical nav header (branding)
+- **Top-right:** Svelte Inspector (dev only)
+- **Bottom-left:** Notifications button (in vertical nav footer)
+- **Bottom-right:** TanStack Query Devtools (dev only)
+
+### Button Component Strategy
+
+**Decision:** Do NOT use `WhisperingButton` component in VerticalNav implementation.
+
+**Context:**
+
+`WhisperingButton` (`apps/whispering/src/lib/components/WhisperingButton.svelte`) is a Button + Tooltip wrapper created for the topbar navigation:
+
+```svelte
+<WhisperingButton tooltipContent="Go home" href="/">
+	<span>whispering</span>
+</WhisperingButton>
+```
+
+This component exists because the topbar has extremely constrained horizontal space, requiring tooltips to explain icon-only buttons.
+
+**Why NOT to use it in VerticalNav:**
+
+1. **Context Difference:**
+   - **Topbar:** ~800px horizontal space shared by branding, selectors, controls, navigation → tooltips necessary
+   - **VerticalNav Expanded:** ~240px vertical space → plenty of room for visible text labels
+   - **VerticalNav Icon-only:** ~48px → shadcn-svelte `Sidebar.MenuButton` has built-in tooltip behavior
+
+2. **Built-in Tooltip Support:**
+   - `<Sidebar.MenuButton>` automatically shows tooltips when sidebar is collapsed to icon-only mode
+   - The library handles this pattern natively: labels when expanded, tooltips when collapsed
+   - No need for custom wrapper components
+
+3. **Semantic Difference:**
+   - `WhisperingButton` treats labels as secondary (hidden in tooltips)
+   - VerticalNav should have **visible labels as primary UI**, not tooltips
+   - Icons are supplementary, not the primary interface
+
+4. **Accessibility & Discoverability:**
+   - Visible labels are more accessible than icon-only + hover tooltips
+   - New users can discover features by reading labels
+   - Tooltips should be progressive enhancement, not the only affordance
+
+**What to Use Instead:**
+
+**Navigation Items:**
+
+```svelte
+<Sidebar.MenuButton href="/recordings">
+	<ListIcon />
+	<span>Recordings</span>
+	<!-- Visible when expanded, tooltip when collapsed -->
+</Sidebar.MenuButton>
+```
+
+**Action Buttons (Recording Controls):**
+
+```svelte
+<Button onclick={commandCallbacks.toggleManualRecording}>
+	{recorderStateToIcons[state]}
+	<span>Start Recording</span>
+	<!-- Visible label -->
+</Button>
+```
+
+**Footer Actions:**
+
+```svelte
+<Sidebar.MenuButton onclick={toggleTheme}>
+	<SunIcon />
+	<span>Toggle theme</span>
+</Sidebar.MenuButton>
+```
+
+**Summary:**
+
+- Keep `WhisperingButton` for topbar (legacy, space-constrained UI)
+- Use standard shadcn-svelte Sidebar components for VerticalNav
+- Leverage built-in tooltip behavior instead of custom wrappers
+- Prioritize visible labels over icon-only + tooltips
+
+### Active Route Highlighting
+
+**Requirement:** Navigation items must visually indicate which page is currently active.
+
+**Implementation:**
+
+Use SvelteKit's `$page` store to determine active routes:
+
+```svelte
+<script lang="ts">
+	import { page } from '$app/stores';
+</script>
+
+<Sidebar.MenuButton href="/" isActive={$page.url.pathname === '/'}>
+	<HomeIcon />
+	<span>Home</span>
+</Sidebar.MenuButton>
+
+<Sidebar.MenuButton
+	href="/recordings"
+	isActive={$page.url.pathname.startsWith('/recordings')}
+>
+	<ListIcon />
+	<span>Recordings</span>
+</Sidebar.MenuButton>
+```
+
+**Logic:**
+
+- **Home:** Exact match `pathname === '/'`
+- **Recordings, Transformations, Settings:** Prefix match `pathname.startsWith('/recordings')` to handle sub-routes
+  - Example: `/recordings`, `/recordings/123`, `/recordings/edit` all highlight "Recordings"
+  - Example: `/settings`, `/settings/api-keys`, `/settings/shortcuts/global` all highlight "Settings"
+
+**Styling:**
+
+The `isActive` prop on `Sidebar.MenuButton` will apply shadcn-svelte's built-in active styles (typically background color change, accent border, or font weight).
+
+**Note:** Verify that shadcn-svelte Sidebar components support `isActive` prop. If not, use `data-active` attribute or custom class:
+
+```svelte
+<Sidebar.MenuButton
+  href="/recordings"
+  data-active={$page.url.pathname.startsWith('/recordings')}
+  class={cn($page.url.pathname.startsWith('/recordings') && 'bg-accent')}
+>
+```
+
+## Success Metrics
+
+### Adoption Metrics
+
+- % of users who enable vertical nav layout
+- % of users who switch back to topbar
+- Time to first recording with vertical nav
+- User feedback sentiment
+
+### Performance Metrics
+
+- Page load time (no regression)
+- Navigation speed (no regression)
+- Memory usage (no significant increase)
+
+### Bug Metrics
+
+- Number of vertical nav-specific bugs reported
+- Time to resolution
+- Regression rate
+
+## Risks and Mitigations
+
+### Risk 1: User Confusion During Transition
+
+**Mitigation:**
+
+- Clear migration prompt with preview
+- In-app help/tutorial for vertical nav
+- Allow easy switching back to topbar
+- Announce change in release notes
+
+### Risk 2: Mobile Layout Challenges
+
+**Mitigation:**
+
+- Extensive testing on various devices
+- Fallback to topbar on very small screens (<320px)
+- Progressive enhancement approach
+
+### Risk 3: Breaking Existing Workflows
+
+**Mitigation:**
+
+- Keep topbar available during transition
+- Gather user feedback early
+- Iterate based on usage patterns
+
+### Risk 4: Increased Maintenance Burden
+
+**Mitigation:**
+
+- Plan for quick deprecation of topbar
+- Set clear timeline for removal
+- Minimize conditional logic
+
+## Open Questions
+
+1. **Mobile layout:** Slide-out drawer, bottom nav, or hybrid?
+2. **VerticalNav width:** Fixed 240px or user-resizable?
+3. **Collapse behavior:** Remember state or reset on navigation?
+4. **Recording indicator:** Keep large visual on home page or vertical nav-only?
+5. **Settings sub-nav:** Keep horizontal tabs or integrate into vertical nav tree?
+
+## Future Enhancements
+
+### Completely Hidden VerticalNav State
+
+**Status:** Not included in initial implementation. Add if users request it.
+
+**Rationale for deferring:**
+
+- Icon-only mode (~48px) already provides significant space savings
+- Difference between 48px and 0px is marginal on most displays
+- Users maintain quick access to navigation in icon mode
+- Simpler initial implementation reduces risk
+- Can validate need with actual usage data
+
+**Implementation pattern (if added later):**
+
+```svelte
+<script lang="ts">
+	let verticalNavVisible = $state(true); // false = completely hidden
+
+	function toggleHidden() {
+		verticalNavVisible = !verticalNavVisible;
+	}
+</script>
+
+<Sidebar.Provider>
+	{#if verticalNavVisible}
+		<Sidebar.Root collapsible="icon">
+			<!-- content -->
+		</Sidebar.Root>
+	{/if}
+
+	<Sidebar.Inset>
+		<header>
+			{#if verticalNavVisible}
+				<Sidebar.Trigger /> <!-- Built-in collapse toggle -->
+			{/if}
+			<button onclick={toggleHidden}>
+				<Menu />
+				<!-- Hide/show toggle -->
+			</button>
+		</header>
+	</Sidebar.Inset>
+</Sidebar.Provider>
+```
+
+**Features when implemented:**
+
+- Third state: Completely hidden vertical nav
+- Separate toggle button for hide/show
+- Keyboard shortcut: `Cmd/Ctrl + Shift + B` for super-hide
+- User preference saved in settings
+- Focus mode for presentations/recordings
+
+**Usage tracking:**
+
+- Monitor collapse/expand usage in analytics
+- Survey users about need for complete hiding
+- Implement if >20% of users request it
+
+### App-Level Header (Gmail-style)
+
+**Status:** Not included in initial implementation. Add if unified header is desired.
+
+**Current Implementation (sidebar-07 pattern):**
+
+- Each page has its own header inside `Sidebar.Inset`
+- Header contains: `Sidebar.Trigger` + breadcrumbs/page title
+- Header is part of page content, scrolls with content
+
+**Proposed Enhancement (Gmail-style):**
+
+- Single app-level header above vertical nav and content
+- Header spans full width (vertical nav + content area)
+- Header contains: branding + search + toggle + user menu
+- Header is sticky/fixed at top, always visible
+
+**Visual comparison:**
+
+```
+Current (sidebar-07):
+┌──────────────┬──────────────────────┐
+│              │ [☰] Breadcrumb       │ ← Per-page header
+│ VerticalNav  ├──────────────────────┤
+│              │                      │
+│              │  Page Content        │
+└──────────────┴──────────────────────┘
+
+Proposed (Gmail-style):
+┌────────────────────────────────┐
+│ Logo [Search] [☰] [User]      │ ← App-level header
+├──────────────┬─────────────────┤
+│              │                 │
+│ VerticalNav  │  Page Content   │
+│              │                 │
+└──────────────┴─────────────────┘
+```
+
+**Implementation pattern:**
+
+```svelte
+<Sidebar.Provider>
+	<!-- App-level header -->
+	<header class="sticky top-0 z-50 flex h-14 items-center gap-4 border-b px-4">
+		<span class="font-bold">Whispering</span>
+		<input type="search" placeholder="Search..." class="flex-1 max-w-md" />
+		<Sidebar.Trigger />
+		<UserMenu />
+	</header>
+
+	<div class="flex flex-1">
+		<VerticalNav />
+		<Sidebar.Inset>
+			<!-- No header here, content starts immediately -->
+			<main class="flex-1 p-4">
+				{@render children()}
+			</main>
+		</Sidebar.Inset>
+	</div>
+</Sidebar.Provider>
+```
+
+**Benefits:**
+
+- Consistent branding always visible
+- Global search accessible from anywhere
+- Single toggle button location
+- User menu always accessible
+- Cleaner page content (no repeated header elements)
+
+**Trade-offs:**
+
+- Less flexibility per page (can't customize header easily)
+- Header takes vertical space even when not needed
+- Deviates from shadcn-svelte patterns (less maintainable)
+
+**When to implement:**
+
+- After initial release is stable
+- If users request global search
+- If branding visibility is important
+- See sidebar-16 example for reference pattern
+
+**Reference:** [sidebar-16](https://www.shadcn-svelte.com/blocks/sidebar#sidebar-16) shows a sticky site header pattern.
+
+### Other Enhancements
+
+- User-resizable vertical nav width
+- Drag-and-drop reordering of nav items
+- Collapsible sections in vertical nav
+- Pinned/favorited transformations in vertical nav
+- Quick recording history in vertical nav
+- Mini-player in vertical nav for last recording
+- Global command palette (Cmd+K search)
+
+## References
+
+- Current topbar implementation: `apps/whispering/src/routes/(app)/(config)/+layout.svelte`
+- AppLayout implementation: `apps/whispering/src/routes/(app)/_components/AppLayout.svelte`
+- NavItems component: `apps/whispering/src/lib/components/NavItems.svelte`
+- Recording controls: Lines 46-149 in `(app)/(config)/+layout.svelte`

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,14 +20,14 @@
 	},
 	"dependencies": {
 		"@fontsource-variable/manrope": "^5.2.6",
-		"@lucide/svelte": "^0.525.0",
+		"@lucide/svelte": "^0.544.0",
 		"@tanstack/svelte-table": "catalog:",
-		"bits-ui": "catalog:",
+		"bits-ui": "^2.11.0",
 		"clsx": "catalog:",
 		"paneforge": "^1.0.0-next.5",
 		"svelte-check": "^4.3.1",
 		"tailwind-merge": "catalog:",
-		"tailwind-variants": "catalog:"
+		"tailwind-variants": "^3.1.1"
 	},
 	"peerDependencies": {
 		"svelte": ">=5.0.0"

--- a/packages/ui/src/hooks/is-mobile.svelte.ts
+++ b/packages/ui/src/hooks/is-mobile.svelte.ts
@@ -1,0 +1,9 @@
+import { MediaQuery } from "svelte/reactivity";
+
+const DEFAULT_MOBILE_BREAKPOINT = 768;
+
+export class IsMobile extends MediaQuery {
+	constructor(breakpoint: number = DEFAULT_MOBILE_BREAKPOINT) {
+		super(`max-width: ${breakpoint - 1}px`);
+	}
+}

--- a/packages/ui/src/sheet/index.ts
+++ b/packages/ui/src/sheet/index.ts
@@ -1,0 +1,36 @@
+import { Dialog as SheetPrimitive } from "bits-ui";
+import Trigger from "./sheet-trigger.svelte";
+import Close from "./sheet-close.svelte";
+import Overlay from "./sheet-overlay.svelte";
+import Content from "./sheet-content.svelte";
+import Header from "./sheet-header.svelte";
+import Footer from "./sheet-footer.svelte";
+import Title from "./sheet-title.svelte";
+import Description from "./sheet-description.svelte";
+
+const Root = SheetPrimitive.Root;
+const Portal = SheetPrimitive.Portal;
+
+export {
+	Root,
+	Close,
+	Trigger,
+	Portal,
+	Overlay,
+	Content,
+	Header,
+	Footer,
+	Title,
+	Description,
+	//
+	Root as Sheet,
+	Close as SheetClose,
+	Trigger as SheetTrigger,
+	Portal as SheetPortal,
+	Overlay as SheetOverlay,
+	Content as SheetContent,
+	Header as SheetHeader,
+	Footer as SheetFooter,
+	Title as SheetTitle,
+	Description as SheetDescription,
+};

--- a/packages/ui/src/sheet/sheet-close.svelte
+++ b/packages/ui/src/sheet/sheet-close.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: SheetPrimitive.CloseProps = $props();
+</script>
+
+<SheetPrimitive.Close bind:ref data-slot="sheet-close" {...restProps} />

--- a/packages/ui/src/sheet/sheet-content.svelte
+++ b/packages/ui/src/sheet/sheet-content.svelte
@@ -1,0 +1,58 @@
+<script lang="ts" module>
+	import { tv, type VariantProps } from "tailwind-variants";
+	export const sheetVariants = tv({
+		base: "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+		variants: {
+			side: {
+				top: "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
+				bottom: "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
+				left: "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+				right: "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+			},
+		},
+		defaultVariants: {
+			side: "right",
+		},
+	});
+
+	export type Side = VariantProps<typeof sheetVariants>["side"];
+</script>
+
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+	import XIcon from "@lucide/svelte/icons/x";
+	import type { Snippet } from "svelte";
+	import SheetOverlay from "./sheet-overlay.svelte";
+	import { cn, type WithoutChildrenOrChild } from "#/utils/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		side = "right",
+		portalProps,
+		children,
+		...restProps
+	}: WithoutChildrenOrChild<SheetPrimitive.ContentProps> & {
+		portalProps?: SheetPrimitive.PortalProps;
+		side?: Side;
+		children: Snippet;
+	} = $props();
+</script>
+
+<SheetPrimitive.Portal {...portalProps}>
+	<SheetOverlay />
+	<SheetPrimitive.Content
+		bind:ref
+		data-slot="sheet-content"
+		class={cn(sheetVariants({ side }), className)}
+		{...restProps}
+	>
+		{@render children?.()}
+		<SheetPrimitive.Close
+			class="ring-offset-background focus-visible:ring-ring rounded-xs focus-visible:outline-hidden absolute right-4 top-4 opacity-70 transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none"
+		>
+			<XIcon class="size-4" />
+			<span class="sr-only">Close</span>
+		</SheetPrimitive.Close>
+	</SheetPrimitive.Content>
+</SheetPrimitive.Portal>

--- a/packages/ui/src/sheet/sheet-description.svelte
+++ b/packages/ui/src/sheet/sheet-description.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+	import { cn } from "#/utils/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: SheetPrimitive.DescriptionProps = $props();
+</script>
+
+<SheetPrimitive.Description
+	bind:ref
+	data-slot="sheet-description"
+	class={cn("text-muted-foreground text-sm", className)}
+	{...restProps}
+/>

--- a/packages/ui/src/sheet/sheet-footer.svelte
+++ b/packages/ui/src/sheet/sheet-footer.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="sheet-footer"
+	class={cn("mt-auto flex flex-col gap-2 p-4", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/sheet/sheet-header.svelte
+++ b/packages/ui/src/sheet/sheet-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="sheet-header"
+	class={cn("flex flex-col gap-1.5 p-4", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/sheet/sheet-overlay.svelte
+++ b/packages/ui/src/sheet/sheet-overlay.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+	import { cn } from "#/utils/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: SheetPrimitive.OverlayProps = $props();
+</script>
+
+<SheetPrimitive.Overlay
+	bind:ref
+	data-slot="sheet-overlay"
+	class={cn(
+		"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+		className
+	)}
+	{...restProps}
+/>

--- a/packages/ui/src/sheet/sheet-title.svelte
+++ b/packages/ui/src/sheet/sheet-title.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+	import { cn } from "#/utils/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: SheetPrimitive.TitleProps = $props();
+</script>
+
+<SheetPrimitive.Title
+	bind:ref
+	data-slot="sheet-title"
+	class={cn("text-foreground font-semibold", className)}
+	{...restProps}
+/>

--- a/packages/ui/src/sheet/sheet-trigger.svelte
+++ b/packages/ui/src/sheet/sheet-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: SheetPrimitive.TriggerProps = $props();
+</script>
+
+<SheetPrimitive.Trigger bind:ref data-slot="sheet-trigger" {...restProps} />

--- a/packages/ui/src/sidebar/constants.ts
+++ b/packages/ui/src/sidebar/constants.ts
@@ -1,0 +1,6 @@
+export const SIDEBAR_COOKIE_NAME = "sidebar:state";
+export const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
+export const SIDEBAR_WIDTH = "16rem";
+export const SIDEBAR_WIDTH_MOBILE = "18rem";
+export const SIDEBAR_WIDTH_ICON = "3rem";
+export const SIDEBAR_KEYBOARD_SHORTCUT = "b";

--- a/packages/ui/src/sidebar/context.svelte.ts
+++ b/packages/ui/src/sidebar/context.svelte.ts
@@ -1,0 +1,81 @@
+import { IsMobile } from "#/hooks/is-mobile.svelte.js";
+import { getContext, setContext } from "svelte";
+import { SIDEBAR_KEYBOARD_SHORTCUT } from "./constants.js";
+
+type Getter<T> = () => T;
+
+export type SidebarStateProps = {
+	/**
+	 * A getter function that returns the current open state of the sidebar.
+	 * We use a getter function here to support `bind:open` on the `Sidebar.Provider`
+	 * component.
+	 */
+	open: Getter<boolean>;
+
+	/**
+	 * A function that sets the open state of the sidebar. To support `bind:open`, we need
+	 * a source of truth for changing the open state to ensure it will be synced throughout
+	 * the sub-components and any `bind:` references.
+	 */
+	setOpen: (open: boolean) => void;
+};
+
+class SidebarState {
+	readonly props: SidebarStateProps;
+	open = $derived.by(() => this.props.open());
+	openMobile = $state(false);
+	setOpen: SidebarStateProps["setOpen"];
+	#isMobile: IsMobile;
+	state = $derived.by(() => (this.open ? "expanded" : "collapsed"));
+
+	constructor(props: SidebarStateProps) {
+		this.setOpen = props.setOpen;
+		this.#isMobile = new IsMobile();
+		this.props = props;
+	}
+
+	// Convenience getter for checking if the sidebar is mobile
+	// without this, we would need to use `sidebar.isMobile.current` everywhere
+	get isMobile() {
+		return this.#isMobile.current;
+	}
+
+	// Event handler to apply to the `<svelte:window>`
+	handleShortcutKeydown = (e: KeyboardEvent) => {
+		if (e.key === SIDEBAR_KEYBOARD_SHORTCUT && (e.metaKey || e.ctrlKey)) {
+			e.preventDefault();
+			this.toggle();
+		}
+	};
+
+	setOpenMobile = (value: boolean) => {
+		this.openMobile = value;
+	};
+
+	toggle = () => {
+		return this.#isMobile.current
+			? (this.openMobile = !this.openMobile)
+			: this.setOpen(!this.open);
+	};
+}
+
+const SYMBOL_KEY = "scn-sidebar";
+
+/**
+ * Instantiates a new `SidebarState` instance and sets it in the context.
+ *
+ * @param props The constructor props for the `SidebarState` class.
+ * @returns  The `SidebarState` instance.
+ */
+export function setSidebar(props: SidebarStateProps): SidebarState {
+	return setContext(Symbol.for(SYMBOL_KEY), new SidebarState(props));
+}
+
+/**
+ * Retrieves the `SidebarState` instance from the context. This is a class instance,
+ * so you cannot destructure it.
+ * @returns The `SidebarState` instance.
+ */
+export function useSidebar(): SidebarState {
+	return getContext(Symbol.for(SYMBOL_KEY));
+}

--- a/packages/ui/src/sidebar/index.ts
+++ b/packages/ui/src/sidebar/index.ts
@@ -1,0 +1,75 @@
+import { useSidebar } from "./context.svelte.js";
+import Content from "./sidebar-content.svelte";
+import Footer from "./sidebar-footer.svelte";
+import GroupAction from "./sidebar-group-action.svelte";
+import GroupContent from "./sidebar-group-content.svelte";
+import GroupLabel from "./sidebar-group-label.svelte";
+import Group from "./sidebar-group.svelte";
+import Header from "./sidebar-header.svelte";
+import Input from "./sidebar-input.svelte";
+import Inset from "./sidebar-inset.svelte";
+import MenuAction from "./sidebar-menu-action.svelte";
+import MenuBadge from "./sidebar-menu-badge.svelte";
+import MenuButton from "./sidebar-menu-button.svelte";
+import MenuItem from "./sidebar-menu-item.svelte";
+import MenuSkeleton from "./sidebar-menu-skeleton.svelte";
+import MenuSubButton from "./sidebar-menu-sub-button.svelte";
+import MenuSubItem from "./sidebar-menu-sub-item.svelte";
+import MenuSub from "./sidebar-menu-sub.svelte";
+import Menu from "./sidebar-menu.svelte";
+import Provider from "./sidebar-provider.svelte";
+import Rail from "./sidebar-rail.svelte";
+import Separator from "./sidebar-separator.svelte";
+import Trigger from "./sidebar-trigger.svelte";
+import Root from "./sidebar.svelte";
+
+export {
+	Content,
+	Footer,
+	Group,
+	GroupAction,
+	GroupContent,
+	GroupLabel,
+	Header,
+	Input,
+	Inset,
+	Menu,
+	MenuAction,
+	MenuBadge,
+	MenuButton,
+	MenuItem,
+	MenuSkeleton,
+	MenuSub,
+	MenuSubButton,
+	MenuSubItem,
+	Provider,
+	Rail,
+	Root,
+	Separator,
+	//
+	Root as Sidebar,
+	Content as SidebarContent,
+	Footer as SidebarFooter,
+	Group as SidebarGroup,
+	GroupAction as SidebarGroupAction,
+	GroupContent as SidebarGroupContent,
+	GroupLabel as SidebarGroupLabel,
+	Header as SidebarHeader,
+	Input as SidebarInput,
+	Inset as SidebarInset,
+	Menu as SidebarMenu,
+	MenuAction as SidebarMenuAction,
+	MenuBadge as SidebarMenuBadge,
+	MenuButton as SidebarMenuButton,
+	MenuItem as SidebarMenuItem,
+	MenuSkeleton as SidebarMenuSkeleton,
+	MenuSub as SidebarMenuSub,
+	MenuSubButton as SidebarMenuSubButton,
+	MenuSubItem as SidebarMenuSubItem,
+	Provider as SidebarProvider,
+	Rail as SidebarRail,
+	Separator as SidebarSeparator,
+	Trigger as SidebarTrigger,
+	Trigger,
+	useSidebar,
+};

--- a/packages/ui/src/sidebar/sidebar-content.svelte
+++ b/packages/ui/src/sidebar/sidebar-content.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="sidebar-content"
+	data-sidebar="content"
+	class={cn(
+		"flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/sidebar/sidebar-footer.svelte
+++ b/packages/ui/src/sidebar/sidebar-footer.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="sidebar-footer"
+	data-sidebar="footer"
+	class={cn("flex flex-col gap-2 p-2", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/sidebar/sidebar-group-action.svelte
+++ b/packages/ui/src/sidebar/sidebar-group-action.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import type { Snippet } from "svelte";
+	import type { HTMLButtonAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		child,
+		...restProps
+	}: WithElementRef<HTMLButtonAttributes> & {
+		child?: Snippet<[{ props: Record<string, unknown> }]>;
+	} = $props();
+
+	const mergedProps = $derived({
+		class: cn(
+			"text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground outline-hidden absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+			// Increases the hit area of the button on mobile.
+			"after:absolute after:-inset-2 md:after:hidden",
+			"group-data-[collapsible=icon]:hidden",
+			className
+		),
+		"data-slot": "sidebar-group-action",
+		"data-sidebar": "group-action",
+		...restProps,
+	});
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<button bind:this={ref} {...mergedProps}>
+		{@render children?.()}
+	</button>
+{/if}

--- a/packages/ui/src/sidebar/sidebar-group-content.svelte
+++ b/packages/ui/src/sidebar/sidebar-group-content.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="sidebar-group-content"
+	data-sidebar="group-content"
+	class={cn("w-full text-sm", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/sidebar/sidebar-group-label.svelte
+++ b/packages/ui/src/sidebar/sidebar-group-label.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import type { Snippet } from "svelte";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		children,
+		child,
+		class: className,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> & {
+		child?: Snippet<[{ props: Record<string, unknown> }]>;
+	} = $props();
+
+	const mergedProps = $derived({
+		class: cn(
+			"text-sidebar-foreground/70 ring-sidebar-ring outline-hidden flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+			"group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
+			className
+		),
+		"data-slot": "sidebar-group-label",
+		"data-sidebar": "group-label",
+		...restProps,
+	});
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<div bind:this={ref} {...mergedProps}>
+		{@render children?.()}
+	</div>
+{/if}

--- a/packages/ui/src/sidebar/sidebar-group.svelte
+++ b/packages/ui/src/sidebar/sidebar-group.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="sidebar-group"
+	data-sidebar="group"
+	class={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/sidebar/sidebar-header.svelte
+++ b/packages/ui/src/sidebar/sidebar-header.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="sidebar-header"
+	data-sidebar="header"
+	class={cn("flex flex-col gap-2 p-2", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/sidebar/sidebar-input.svelte
+++ b/packages/ui/src/sidebar/sidebar-input.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import type { ComponentProps } from "svelte";
+	import { Input } from "#/input/index.js";
+	import { cn } from "#/utils/utils.js";
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(""),
+		class: className,
+		...restProps
+	}: ComponentProps<typeof Input> = $props();
+</script>
+
+<Input
+	bind:ref
+	bind:value
+	data-slot="sidebar-input"
+	data-sidebar="input"
+	class={cn("bg-background h-8 w-full shadow-none", className)}
+	{...restProps}
+/>

--- a/packages/ui/src/sidebar/sidebar-inset.svelte
+++ b/packages/ui/src/sidebar/sidebar-inset.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<main
+	bind:this={ref}
+	data-slot="sidebar-inset"
+	class={cn(
+		"bg-background relative flex w-full flex-1 flex-col",
+		"md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</main>

--- a/packages/ui/src/sidebar/sidebar-menu-action.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu-action.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import type { Snippet } from "svelte";
+	import type { HTMLButtonAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		showOnHover = false,
+		children,
+		child,
+		...restProps
+	}: WithElementRef<HTMLButtonAttributes> & {
+		child?: Snippet<[{ props: Record<string, unknown> }]>;
+		showOnHover?: boolean;
+	} = $props();
+
+	const mergedProps = $derived({
+		class: cn(
+			"text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground outline-hidden absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+			// Increases the hit area of the button on mobile.
+			"after:absolute after:-inset-2 md:after:hidden",
+			"peer-data-[size=sm]/menu-button:top-1",
+			"peer-data-[size=default]/menu-button:top-1.5",
+			"peer-data-[size=lg]/menu-button:top-2.5",
+			"group-data-[collapsible=icon]:hidden",
+			showOnHover &&
+				"peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0",
+			className
+		),
+		"data-slot": "sidebar-menu-action",
+		"data-sidebar": "menu-action",
+		...restProps,
+	});
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<button bind:this={ref} {...mergedProps}>
+		{@render children?.()}
+	</button>
+{/if}

--- a/packages/ui/src/sidebar/sidebar-menu-badge.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu-badge.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="sidebar-menu-badge"
+	data-sidebar="menu-badge"
+	class={cn(
+		"text-sidebar-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 select-none items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums",
+		"peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground",
+		"peer-data-[size=sm]/menu-button:top-1",
+		"peer-data-[size=default]/menu-button:top-1.5",
+		"peer-data-[size=lg]/menu-button:top-2.5",
+		"group-data-[collapsible=icon]:hidden",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/sidebar/sidebar-menu-button.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu-button.svelte
@@ -1,0 +1,103 @@
+<script lang="ts" module>
+	import { tv, type VariantProps } from "tailwind-variants";
+
+	export const sidebarMenuButtonVariants = tv({
+		base: "peer/menu-button outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground group-has-data-[sidebar=menu-action]/menu-item:pr-8 data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm transition-[width,height,padding] focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:font-medium [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+		variants: {
+			variant: {
+				default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+				outline:
+					"bg-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_var(--sidebar-border)] hover:shadow-[0_0_0_1px_var(--sidebar-accent)]",
+			},
+			size: {
+				default: "h-8 text-sm",
+				sm: "h-7 text-xs",
+				lg: "group-data-[collapsible=icon]:p-0! h-12 text-sm",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+			size: "default",
+		},
+	});
+
+	export type SidebarMenuButtonVariant = VariantProps<
+		typeof sidebarMenuButtonVariants
+	>["variant"];
+	export type SidebarMenuButtonSize = VariantProps<typeof sidebarMenuButtonVariants>["size"];
+</script>
+
+<script lang="ts">
+	import * as Tooltip from "#/tooltip/index.js";
+	import { cn, type WithElementRef, type WithoutChildrenOrChild } from "#/utils/utils.js";
+	import { mergeProps } from "bits-ui";
+	import type { ComponentProps, Snippet } from "svelte";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { useSidebar } from "./context.svelte.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		child,
+		variant = "default",
+		size = "default",
+		isActive = false,
+		tooltipContent,
+		tooltipContentProps,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLButtonElement>, HTMLButtonElement> & {
+		isActive?: boolean;
+		variant?: SidebarMenuButtonVariant;
+		size?: SidebarMenuButtonSize;
+		tooltipContent?: Snippet | string;
+		tooltipContentProps?: WithoutChildrenOrChild<ComponentProps<typeof Tooltip.Content>>;
+		child?: Snippet<[{ props: Record<string, unknown> }]>;
+	} = $props();
+
+	const sidebar = useSidebar();
+
+	const buttonProps = $derived({
+		class: cn(sidebarMenuButtonVariants({ variant, size }), className),
+		"data-slot": "sidebar-menu-button",
+		"data-sidebar": "menu-button",
+		"data-size": size,
+		"data-active": isActive,
+		...restProps,
+	});
+</script>
+
+{#snippet Button({ props }: { props?: Record<string, unknown> })}
+	{@const mergedProps = mergeProps(buttonProps, props)}
+	{#if child}
+		{@render child({ props: mergedProps })}
+	{:else}
+		<button bind:this={ref} {...mergedProps}>
+			{@render children?.()}
+		</button>
+	{/if}
+{/snippet}
+
+{#if !tooltipContent}
+	{@render Button({})}
+{:else}
+	<Tooltip.Root>
+		<Tooltip.Trigger>
+			{#snippet child({ props })}
+				{@render Button({ props })}
+			{/snippet}
+		</Tooltip.Trigger>
+		<Tooltip.Content
+			side="right"
+			align="center"
+			hidden={sidebar.state !== "collapsed" || sidebar.isMobile}
+			{...tooltipContentProps}
+		>
+			{#if typeof tooltipContent === "string"}
+				{tooltipContent}
+			{:else if tooltipContent}
+				{@render tooltipContent()}
+			{/if}
+		</Tooltip.Content>
+	</Tooltip.Root>
+{/if}

--- a/packages/ui/src/sidebar/sidebar-menu-item.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu-item.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLLIElement>, HTMLLIElement> = $props();
+</script>
+
+<li
+	bind:this={ref}
+	data-slot="sidebar-menu-item"
+	data-sidebar="menu-item"
+	class={cn("group/menu-item relative", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</li>

--- a/packages/ui/src/sidebar/sidebar-menu-skeleton.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu-skeleton.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import { Skeleton } from "#/skeleton/index.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		showIcon = false,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> & {
+		showIcon?: boolean;
+	} = $props();
+
+	// Random width between 50% and 90%
+	const width = `${Math.floor(Math.random() * 40) + 50}%`;
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="sidebar-menu-skeleton"
+	data-sidebar="menu-skeleton"
+	class={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
+	{...restProps}
+>
+	{#if showIcon}
+		<Skeleton class="size-4 rounded-md" data-sidebar="menu-skeleton-icon" />
+	{/if}
+	<Skeleton
+		class="max-w-(--skeleton-width) h-4 flex-1"
+		data-sidebar="menu-skeleton-text"
+		style="--skeleton-width: {width};"
+	/>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/sidebar/sidebar-menu-sub-button.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu-sub-button.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import type { Snippet } from "svelte";
+	import type { HTMLAnchorAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		children,
+		child,
+		class: className,
+		size = "md",
+		isActive = false,
+		...restProps
+	}: WithElementRef<HTMLAnchorAttributes> & {
+		child?: Snippet<[{ props: Record<string, unknown> }]>;
+		size?: "sm" | "md";
+		isActive?: boolean;
+	} = $props();
+
+	const mergedProps = $derived({
+		class: cn(
+			"text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground outline-hidden flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+			"data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
+			size === "sm" && "text-xs",
+			size === "md" && "text-sm",
+			"group-data-[collapsible=icon]:hidden",
+			className
+		),
+		"data-slot": "sidebar-menu-sub-button",
+		"data-sidebar": "menu-sub-button",
+		"data-size": size,
+		"data-active": isActive,
+		...restProps,
+	});
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<a bind:this={ref} {...mergedProps}>
+		{@render children?.()}
+	</a>
+{/if}

--- a/packages/ui/src/sidebar/sidebar-menu-sub-item.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu-sub-item.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		children,
+		class: className,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLLIElement>> = $props();
+</script>
+
+<li
+	bind:this={ref}
+	data-slot="sidebar-menu-sub-item"
+	data-sidebar="menu-sub-item"
+	class={cn("group/menu-sub-item relative", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</li>

--- a/packages/ui/src/sidebar/sidebar-menu-sub.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu-sub.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLUListElement>> = $props();
+</script>
+
+<ul
+	bind:this={ref}
+	data-slot="sidebar-menu-sub"
+	data-sidebar="menu-sub"
+	class={cn(
+		"border-sidebar-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l px-2.5 py-0.5",
+		"group-data-[collapsible=icon]:hidden",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</ul>

--- a/packages/ui/src/sidebar/sidebar-menu.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLUListElement>, HTMLUListElement> = $props();
+</script>
+
+<ul
+	bind:this={ref}
+	data-slot="sidebar-menu"
+	data-sidebar="menu"
+	class={cn("flex w-full min-w-0 flex-col gap-1", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</ul>

--- a/packages/ui/src/sidebar/sidebar-provider.svelte
+++ b/packages/ui/src/sidebar/sidebar-provider.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import * as Tooltip from "#/tooltip/index.js";
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+	import {
+		SIDEBAR_COOKIE_MAX_AGE,
+		SIDEBAR_COOKIE_NAME,
+		SIDEBAR_WIDTH,
+		SIDEBAR_WIDTH_ICON,
+	} from "./constants.js";
+	import { setSidebar } from "./context.svelte.js";
+
+	let {
+		ref = $bindable(null),
+		open = $bindable(true),
+		onOpenChange = () => {},
+		class: className,
+		style,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		open?: boolean;
+		onOpenChange?: (open: boolean) => void;
+	} = $props();
+
+	const sidebar = setSidebar({
+		open: () => open,
+		setOpen: (value: boolean) => {
+			open = value;
+			onOpenChange(value);
+
+			// This sets the cookie to keep the sidebar state.
+			document.cookie = `${SIDEBAR_COOKIE_NAME}=${open}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+		},
+	});
+</script>
+
+<svelte:window onkeydown={sidebar.handleShortcutKeydown} />
+
+<Tooltip.Provider delayDuration={0}>
+	<div
+		data-slot="sidebar-wrapper"
+		style="--sidebar-width: {SIDEBAR_WIDTH}; --sidebar-width-icon: {SIDEBAR_WIDTH_ICON}; {style}"
+		class={cn(
+			"group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
+			className
+		)}
+		bind:this={ref}
+		{...restProps}
+	>
+		{@render children?.()}
+	</div>
+</Tooltip.Provider>

--- a/packages/ui/src/sidebar/sidebar-rail.svelte
+++ b/packages/ui/src/sidebar/sidebar-rail.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { useSidebar } from "./context.svelte.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLButtonElement>, HTMLButtonElement> = $props();
+
+	const sidebar = useSidebar();
+</script>
+
+<button
+	bind:this={ref}
+	data-sidebar="rail"
+	data-slot="sidebar-rail"
+	aria-label="Toggle Sidebar"
+	tabIndex={-1}
+	onclick={sidebar.toggle}
+	title="Toggle Sidebar"
+	class={cn(
+		"hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-[calc(1/2*100%-1px)] after:w-[2px] group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
+		"in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
+		"[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+		"hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",
+		"[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+		"[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</button>

--- a/packages/ui/src/sidebar/sidebar-separator.svelte
+++ b/packages/ui/src/sidebar/sidebar-separator.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { Separator } from "#/separator/index.js";
+	import { cn } from "#/utils/utils.js";
+	import type { ComponentProps } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: ComponentProps<typeof Separator> = $props();
+</script>
+
+<Separator
+	bind:ref
+	data-slot="sidebar-separator"
+	data-sidebar="separator"
+	class={cn("bg-sidebar-border", className)}
+	{...restProps}
+/>

--- a/packages/ui/src/sidebar/sidebar-trigger.svelte
+++ b/packages/ui/src/sidebar/sidebar-trigger.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import { Button } from "#/button/index.js";
+	import { cn } from "#/utils/utils.js";
+	import PanelLeftIcon from "@lucide/svelte/icons/panel-left";
+	import type { ComponentProps } from "svelte";
+	import { useSidebar } from "./context.svelte.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		onclick,
+		...restProps
+	}: ComponentProps<typeof Button> & {
+		onclick?: (e: MouseEvent) => void;
+	} = $props();
+
+	const sidebar = useSidebar();
+</script>
+
+<Button
+	data-sidebar="trigger"
+	data-slot="sidebar-trigger"
+	variant="ghost"
+	size="icon"
+	class={cn("size-7", className)}
+	type="button"
+	onclick={(e) => {
+		onclick?.(e);
+		sidebar.toggle();
+	}}
+	{...restProps}
+>
+	<PanelLeftIcon />
+	<span class="sr-only">Toggle Sidebar</span>
+</Button>

--- a/packages/ui/src/sidebar/sidebar.svelte
+++ b/packages/ui/src/sidebar/sidebar.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+	import * as Sheet from "#/sheet/index.js";
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { SIDEBAR_WIDTH_MOBILE } from "./constants.js";
+	import { useSidebar } from "./context.svelte.js";
+
+	let {
+		ref = $bindable(null),
+		side = "left",
+		variant = "sidebar",
+		collapsible = "offcanvas",
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		side?: "left" | "right";
+		variant?: "sidebar" | "floating" | "inset";
+		collapsible?: "offcanvas" | "icon" | "none";
+	} = $props();
+
+	const sidebar = useSidebar();
+</script>
+
+{#if collapsible === "none"}
+	<div
+		class={cn(
+			"bg-sidebar text-sidebar-foreground w-(--sidebar-width) flex h-full flex-col",
+			className
+		)}
+		bind:this={ref}
+		{...restProps}
+	>
+		{@render children?.()}
+	</div>
+{:else if sidebar.isMobile}
+	<Sheet.Root
+		bind:open={() => sidebar.openMobile, (v) => sidebar.setOpenMobile(v)}
+		{...restProps}
+	>
+		<Sheet.Content
+			data-sidebar="sidebar"
+			data-slot="sidebar"
+			data-mobile="true"
+			class="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
+			style="--sidebar-width: {SIDEBAR_WIDTH_MOBILE};"
+			{side}
+		>
+			<Sheet.Header class="sr-only">
+				<Sheet.Title>Sidebar</Sheet.Title>
+				<Sheet.Description>Displays the mobile sidebar.</Sheet.Description>
+			</Sheet.Header>
+			<div class="flex h-full w-full flex-col">
+				{@render children?.()}
+			</div>
+		</Sheet.Content>
+	</Sheet.Root>
+{:else}
+	<div
+		bind:this={ref}
+		class="text-sidebar-foreground group peer hidden md:block"
+		data-state={sidebar.state}
+		data-collapsible={sidebar.state === "collapsed" ? collapsible : ""}
+		data-variant={variant}
+		data-side={side}
+		data-slot="sidebar"
+	>
+		<!-- This is what handles the sidebar gap on desktop -->
+		<div
+			data-slot="sidebar-gap"
+			class={cn(
+				"w-(--sidebar-width) relative bg-transparent transition-[width] duration-200 ease-linear",
+				"group-data-[collapsible=offcanvas]:w-0",
+				"group-data-[side=right]:rotate-180",
+				variant === "floating" || variant === "inset"
+					? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
+					: "group-data-[collapsible=icon]:w-(--sidebar-width-icon)"
+			)}
+		></div>
+		<div
+			data-slot="sidebar-container"
+			class={cn(
+				"w-(--sidebar-width) fixed inset-y-0 z-10 hidden h-svh transition-[left,right,width] duration-200 ease-linear md:flex",
+				side === "left"
+					? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
+					: "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
+				// Adjust the padding for floating and inset variants.
+				variant === "floating" || variant === "inset"
+					? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
+					: "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
+				className
+			)}
+			{...restProps}
+		>
+			<div
+				data-sidebar="sidebar"
+				data-slot="sidebar-inner"
+				class="bg-sidebar group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
+			>
+				{@render children?.()}
+			</div>
+		</div>
+	</div>
+{/if}


### PR DESCRIPTION
> [!tip]
> 
> - Read the summary, check out the before/after screen shots, and try it out.
> - This PR is not ready to merge because the current top nav was left intact.
> - However, the vertical navigation is so much better I don't think there is any reason to keep the existing top nav.

## Summary

- Vertical sidebar navigation
- Intended to replace current top navigation
  - Some code was duplicated
  - This PR may be refactored to support top navigation as an option, refactoring duplicated code into shared imports.
- Temporary links were added to home pages to easily switch between vertical and top navigation
- Major UX changes were made:
  - Top nav recording method drop down removed (manual, VAD, upload)
    - "File upload" option did not make sense in this context
    - Replaced with two buttons that start manual recording or voice-activated session
  - Epicenter logo used instead of mic emoji (overlap with manual recording icon)
  - Headings on pages hidden if navbar is expanded

This is a POC. Potential improvements:
- possible to add 3rd state (hidden, icons-only, expanded) that more closely resembles top nav home page.
- Remove layout shift in side bar nav component
- Reorder groups of items?
- Rename/reword labels to fit better within navbar
  

## Type of Change

- [x] `feat`: New feature

## Related Issue

<!-- Link to the issue this PR addresses, if applicable -->

- https://github.com/epicenter-md/epicenter/issues/710
- https://github.com/epicenter-md/epicenter/issues/644
- https://discord.com/channels/1391098486178582549/1414709940957876274/1414709940957876274
- https://github.com/epicenter-md/epicenter/issues/694
- https://discord.com/channels/1391098486178582549/1403145437434745044/1408000840840773632
- https://discord.com/channels/1391098486178582549/1403145437434745044/1408019827607732294
- https://discord.com/channels/1391098486178582549/1407187732975063160/threads/1409735960937103440

## Screenshots/Recordings

<!-- Screenshots showing:
1. Collapsed vs Expanded sidebar states
2. Mobile sheet overlay
3. Quick Settings in action (badge indicators)
4. Settings responsive navigation
5. Active state improvements
-->


<img width="2164" height="862" alt="image" src="https://github.com/user-attachments/assets/094194ca-0d46-4d42-a96d-f79815adc6f0" />

<img width="2164" height="862" alt="image" src="https://github.com/user-attachments/assets/df06578f-1ce8-4ff4-9c81-b6886275cc64" />


<img width="2164" height="862" alt="image" src="https://github.com/user-attachments/assets/dfe682f2-665b-4871-8cd2-fccd90723dd2" />

<img width="2164" height="862" alt="image" src="https://github.com/user-attachments/assets/8ce3e6fd-2c34-46fb-a175-113d4590ed92" />

<details>
<summary>


## Less important (mostly AI-generated) info


</summary>


## Changes Made

### New Sidebar Component System

- Added complete shadcn-svelte sidebar component library to `@repo/ui` (sidebar-07 pattern)
- Implemented responsive sidebar with collapsible/expandable states on desktop
- Added mobile sheet overlay for small screens
- Created `VerticalNav.svelte` with 4 groups: Navigation, Quick Settings, Quick Transcription, Footer

### Parallel Route Structure

- Created `/verticalnav/*` routes mirroring all existing functionality:
  - Home page with responsive "Whispering" heading (hidden when sidebar expanded)
  - Recordings list page
  - Transformations list and "new transformation" pages
  - Complete Settings section (13 pages total):
    - Main settings with responsive sub-navigation
    - Analytics, API Keys, Recording, Sound, Transcription pages
    - Shortcuts section with nested layout (main, local, global)
  - Utility pages: Desktop App, Global Shortcut, FFmpeg Install, macOS Accessibility

### Quick Settings Integration

- Refactored 5 selector components to work in both sidebar and page contexts:
  - `ManualDeviceSelector` and `VadDeviceSelector`
  - `CompressionSelector`
  - `TranscriptionSelector`
  - `TransformationSelector`
- Added badge indicators showing active selections
- Created reusable recording button components

### UX Enhancements

- **Active State**: Enhanced contrast (20% background vs 10%), 4px left indicator bar
- **Sub-route Active State**: Navigation items remain active on sub-routes (e.g., Settings active when on `/verticalnav/settings/api-keys`)
- **Smart Auto-collapse**: Utility pages automatically collapse sidebar for focused setup experience
- **Responsive Navigation**: Settings sub-navigation adapts breakpoints based on sidebar state
- **Visual Hierarchy**: Dividers between groups (collapsed state only)
- **Branding**: Added Epicenter logo to collapsed sidebar

### Development Features

- Layout switcher links on both layouts for easy testing
- Non-breaking: Existing topbar routes remain fully functional
- Allows gradual migration and A/B testing

## Testing

### Desktop App Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] Not applicable (web-only change)

### General Testing

- [ ] Tested with multiple API providers (if applicable)
- [x] Verified no API keys are exposed in logs or storage
- [x] Checked for console errors
- [x] Tested on different screen sizes (if UI change)

## Checklist

- [x] My code follows the project's coding standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I've used `type` instead of `interface` in TypeScript
- [x] I've used absolute imports where applicable
- [ ] I've tested my changes thoroughly
- [ ] I've added/updated tests for my changes (if applicable)
- [x] My changes don't break existing functionality
- [x] I've updated documentation (if needed)



## Additional Notes

### Implementation Patterns

- **Wrapper Pattern**: Simple pages import components from existing `(config)` routes
- **Copy Pattern**: Pages with navigation logic copied with path corrections to `/verticalnav/*`
- **Auto-collapse Pattern**: Utility pages collapse sidebar on mount for focused UX

### Technical Decisions

- Parallel routes allow safe testing without affecting production
- Settings navigation uses dynamic breakpoints (`lg:` when sidebar collapsed, `xl:` when expanded)
- All selectors now support both inline and sidebar contexts through props
- Preserved view transitions and accessibility features

### Migration Path

1. Test vertical navigation thoroughly
2. Gather user feedback on both layouts
3. Decide on migration strategy (gradual rollout vs complete switch)
4. Optionally add redirects from old routes to new

### Known Issues

- Home page has pre-existing errors (blob property, table overflow) - unrelated to this PR
- Some utility pages use deprecated Lucide icons (can be addressed in follow-up)
</details>
