### PR TITLE
refactor: replace toast with rpc.notify for migration notification

### DIFF
--- a/apps/whispering/src/lib/components/MigrationDialog.svelte
+++ b/apps/whispering/src/lib/components/MigrationDialog.svelte
@@ -1200,30 +1200,28 @@
 		}
 	}}
 >
-	{#if import.meta.env.DEV}
-		<Dialog.Trigger>
-			{#snippet child({ props })}
-				<div class="fixed top-4 right-4 z-50">
-					<Button
-						size="icon"
-						class="rounded-full shadow-lg transition-transform hover:scale-110 relative"
-						aria-label="Open Migration Manager"
-						{...props}
-					>
-						<Database class="h-5 w-5" />
-						{#if migrationDialog.hasIndexedDBData}
-							<span
-								class="absolute -top-0.5 -right-0.5 h-3 w-3 rounded-full bg-amber-500 animate-ping"
-							></span>
-							<span
-								class="absolute -top-0.5 -right-0.5 h-3 w-3 rounded-full bg-amber-500"
-							></span>
-						{/if}
-					</Button>
-				</div>
-			{/snippet}
-		</Dialog.Trigger>
-	{/if}
+	<Dialog.Trigger>
+		{#snippet child({ props })}
+			<div class="fixed top-4 right-4 z-50">
+				<Button
+					size="icon"
+					class="rounded-full shadow-lg transition-transform hover:scale-110 relative"
+					aria-label="Open Migration Manager"
+					{...props}
+				>
+					<Database class="h-5 w-5" />
+					{#if migrationDialog.hasIndexedDBData}
+						<span
+							class="absolute -top-0.5 -right-0.5 h-3 w-3 rounded-full bg-amber-500 animate-ping"
+						></span>
+						<span
+							class="absolute -top-0.5 -right-0.5 h-3 w-3 rounded-full bg-amber-500"
+						></span>
+					{/if}
+				</Button>
+			</div>
+		{/snippet}
+	</Dialog.Trigger>
 	<Dialog.Content class="max-h-[90vh] max-w-3xl overflow-y-auto">
 		<Dialog.Header>
 			<Dialog.Title>Database Migration Manager</Dialog.Title>

--- a/apps/whispering/src/routes/(app)/_layout-utils/check-indexeddb-migration.ts
+++ b/apps/whispering/src/routes/(app)/_layout-utils/check-indexeddb-migration.ts
@@ -1,5 +1,5 @@
-import { toast } from 'svelte-sonner';
 import { migrationDialog } from '$lib/components/MigrationDialog.svelte';
+import { rpc } from '$lib/query';
 
 /**
  * Check if IndexedDB has data and show a migration toast if it does.
@@ -14,16 +14,18 @@ export async function checkIndexedDBMigration(): Promise<void> {
 	await migrationDialog.refreshCounts();
 
 	if (migrationDialog.hasIndexedDBData) {
-		toast.info('Database Migration Available', {
+		rpc.notify.info.execute({
+			title: 'Database Migration Available',
 			description:
 				'You have data in IndexedDB. Click here to migrate to the faster file system storage.',
-			duration: 10000,
 			action: {
-				label: 'Migrate Now',
+				type: 'button',
+				label: 'View Update',
 				onClick: () => {
 					migrationDialog.isOpen = true;
 				},
 			},
+			persist: true,
 		});
 	}
 }


### PR DESCRIPTION
This change replaces the svelte-sonner toast notification with the RPC notification system for the IndexedDB migration prompt. The RPC notification system provides better persistence control and a more consistent notification experience across the application.

The migration notification now uses `rpc.notify.info.execute()` instead of `toast.info()`, which allows the notification to persist until explicitly dismissed. This ensures users won't miss the important migration prompt, even if they're not immediately ready to take action.