### PR TITLE
fix(MigrationDialog): delete items from IndexedDB after successful migration

### DIFF
--- a/apps/whispering/src/lib/components/MigrationDialog.svelte
+++ b/apps/whispering/src/lib/components/MigrationDialog.svelte
@@ -607,6 +607,16 @@
 								continue;
 							}
 
+							// Delete from IndexedDB after successful migration
+							const { error: deleteError } =
+								await indexedDb.recordings.delete(recording);
+
+							if (deleteError) {
+								onProgress?.(
+									`[Migration] ⚠️  Warning: Failed to delete recording ${recording.id} from IndexedDB after migration`,
+								);
+							}
+
 							// Success!
 							succeeded++;
 						}
@@ -735,6 +745,16 @@
 								);
 								failed++;
 								continue;
+							}
+
+							// Delete from IndexedDB after successful migration
+							const { error: deleteError } =
+								await indexedDb.transformations.delete(transformation);
+
+							if (deleteError) {
+								onProgress?.(
+									`[Migration] ⚠️  Warning: Failed to delete transformation ${transformation.id} from IndexedDB after migration`,
+								);
 							}
 
 							// Success!
@@ -868,6 +888,15 @@
 								);
 								failed++;
 								continue;
+							}
+
+							// Delete from IndexedDB after successful migration
+							const { error: deleteError } = await indexedDb.runs.delete(run);
+
+							if (deleteError) {
+								onProgress?.(
+									`[Migration] ⚠️  Warning: Failed to delete transformation run ${run.id} from IndexedDB after migration`,
+								);
 							}
 
 							// Success!
@@ -1265,13 +1294,15 @@
 				</div>
 			{/if}
 
-			<Button
-				onclick={migrationDialog.startMigration}
-				disabled={migrationDialog.isRunning}
-				class="w-full"
-			>
-				{migrationDialog.isRunning ? 'Migrating...' : 'Start Migration'}
-			</Button>
+			{#if migrationDialog.hasIndexedDBData}
+				<Button
+					onclick={migrationDialog.startMigration}
+					disabled={migrationDialog.isRunning}
+					class="w-full"
+				>
+					{migrationDialog.isRunning ? 'Migrating...' : 'Start Migration'}
+				</Button>
+			{/if}
 
 			<!-- Logs Section -->
 			{#if migrationDialog.logs.length > 0}


### PR DESCRIPTION
This fixes the migration not properly removing items from IndexedDB after copying them to the file system.

Previously, the migration would copy all data from IndexedDB to the file system but never delete the originals. This meant the IndexedDB counts stayed the same even after running the migration, making it appear as if the migration did nothing.

After each item is successfully migrated to the file system, it is now deleted from IndexedDB. This ensures the migration actually moves the data rather than just copying it. The migration button is also hidden when all IndexedDB data has been migrated (when all counts are 0), providing clearer feedback about when migration is needed.