### PR TITLE
refactor(capabilities): rename transformation-picker to transform-clipboard

### DIFF
--- a/apps/whispering/src-tauri/capabilities/transform-clipboard.json
+++ b/apps/whispering/src-tauri/capabilities/transform-clipboard.json
@@ -1,12 +1,13 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
-  "identifier": "transformation-picker-capability",
-  "description": "Minimal capability for transformation picker window",
-  "windows": ["transformation-picker"],
+  "identifier": "transform-clipboard-capability",
+  "description": "Capability for transform clipboard window",
+  "windows": ["transform-clipboard"],
   "permissions": [
     "core:default",
     "core:window:allow-close",
     "core:window:allow-hide",
+    "core:window:allow-set-focus",
     "core:event:allow-emit",
     "core:event:allow-listen",
     "clipboard-manager:allow-read-text",


### PR DESCRIPTION
This completes the window rename that was started in commit aab4ca1c0 but never fully applied to the capability file on the main branch.

When the window was renamed from "transformation-picker" to "transform-clipboard" in the code, the capability file name was not updated to match. This created a mismatch where the code referenced a window label "transform-clipboard" but the capability file was still named "transformation-picker.json" and configured for the old window label.

The fix was applied in v7.6.0 (commit 47bd2880f) but that release branch was never merged back to main, so main progressed to v7.7.0 without the fix. This PR restores that fix by renaming the capability file to match the actual window label used in the code.

Changes:
- Renames `transformation-picker.json` to `transform-clipboard.json`
- Updates the identifier to `transform-clipboard-capability`
- Updates the window label reference to `["transform-clipboard"]`
- Adds `core:window:allow-set-focus` permission for better window focus management

This resolves clipboard reading errors in the transform-clipboard window by ensuring the window has proper permissions to access the Tauri Clipboard Manager API.