### PR TITLE
fix(ci): correct artifact upload paths for cross-compiled macOS builds

### DIFF
--- a/.github/workflows/pr-preview-builds.yml
+++ b/.github/workflows/pr-preview-builds.yml
@@ -160,6 +160,8 @@ jobs:
         with:
           name: whispering-pr${{ github.event.pull_request.number }}-${{ steps.artifact.outputs.suffix }}
           path: |
+            apps/whispering/src-tauri/target/*/release/bundle/**/*.dmg
+            apps/whispering/src-tauri/target/*/release/bundle/**/*.app
             apps/whispering/src-tauri/target/release/bundle/**/*.dmg
             apps/whispering/src-tauri/target/release/bundle/**/*.app
             apps/whispering/src-tauri/target/release/bundle/**/*.AppImage


### PR DESCRIPTION
This fixes the macOS artifact upload issue in the PR preview workflow where artifacts from cross-compiled builds were not being uploaded.

The problem occurred because when building with --target flags (aarch64-apple-darwin and x86_64-apple-darwin), Tauri outputs artifacts to target/<target-triple>/release/bundle/ instead of target/release/bundle/. The upload step was only checking the latter path, causing macOS artifacts to be skipped with a "No files were found" warning.

The fix adds glob patterns (target/*/release/bundle/**/*.dmg and target/*/release/bundle/**/*.app) that match any target-specific directory, while maintaining backward compatibility with native builds that output to target/release/bundle/.

This ensures both macOS artifacts (arm64 and intel) will be properly uploaded alongside Linux and Windows artifacts in PR preview builds.