### PR TITLE
feat(MigrationDialog): show database button in dev mode or when migration needed

### DIFF
--- a/apps/whispering/src/lib/components/MigrationDialog.svelte
+++ b/apps/whispering/src/lib/components/MigrationDialog.svelte
@@ -1218,28 +1218,30 @@
 		}
 	}}
 >
-	<Dialog.Trigger>
-		{#snippet child({ props })}
-			<div class="fixed top-4 right-4 z-50">
-				<Button
-					size="icon"
-					class="rounded-full shadow-lg transition-transform hover:scale-110 relative"
-					aria-label="Open Migration Manager"
-					{...props}
-				>
-					<Database class="h-5 w-5" />
-					{#if migrationDialog.hasIndexedDBData}
-						<span
-							class="absolute -top-0.5 -right-0.5 h-3 w-3 rounded-full bg-amber-500 animate-ping"
-						></span>
-						<span
-							class="absolute -top-0.5 -right-0.5 h-3 w-3 rounded-full bg-amber-500"
-						></span>
-					{/if}
-				</Button>
-			</div>
-		{/snippet}
-	</Dialog.Trigger>
+	{#if import.meta.env.DEV || migrationDialog.hasIndexedDBData}
+		<Dialog.Trigger>
+			{#snippet child({ props })}
+				<div class="fixed top-4 right-4 z-50">
+					<Button
+						size="icon"
+						class="rounded-full shadow-lg transition-transform hover:scale-110 relative"
+						aria-label="Open Migration Manager"
+						{...props}
+					>
+						<Database class="h-5 w-5" />
+						{#if migrationDialog.hasIndexedDBData}
+							<span
+								class="absolute -top-0.5 -right-0.5 h-3 w-3 rounded-full bg-amber-500 animate-ping"
+							></span>
+							<span
+								class="absolute -top-0.5 -right-0.5 h-3 w-3 rounded-full bg-amber-500"
+							></span>
+						{/if}
+					</Button>
+				</div>
+			{/snippet}
+		</Dialog.Trigger>
+	{/if}
 	<Dialog.Content class="max-h-[90vh] max-w-3xl overflow-y-auto">
 		<Dialog.Header>
 			<Dialog.Title>Database Migration Manager</Dialog.Title>


### PR DESCRIPTION
This change makes the migration dialog's database button conditionally visible based on whether it's actually needed.

Previously, the database button was always visible in the top-right corner. This change makes it show only when there's a reason to display it: either during development (for testing) or when there's actual data that needs migrating.

The button now appears when either condition is met:
- Development mode (`import.meta.env.DEV` is true)
- Migration is needed (`hasIndexedDBData` returns true, meaning there are non-zero counts of recordings, transformations, or runs in IndexedDB)

The amber badge indicator continues to work as before, showing only when there's actual data to migrate.