### PR TITLE
fix(recordings): correct storage location text based on platform

### DIFF
--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -364,7 +364,8 @@
 		Recordings
 	</h1>
 	<p class="text-muted-foreground">
-		Your latest recordings and transcriptions, stored locally in IndexedDB.
+		Your latest recordings and transcriptions, stored locally
+		{window.__TAURI_INTERNALS__ ? 'on your file system' : 'in IndexedDB'}.
 	</p>
 	<Card class="flex flex-col gap-4 p-6">
 		<div class="flex flex-col md:flex-row items-center justify-between gap-2">


### PR DESCRIPTION
The recordings page previously displayed "stored locally in IndexedDB" for all users, which was misleading for desktop users. On desktop (Tauri), recordings are stored on the file system in the app data directory, while the web version uses IndexedDB.

This change adds platform detection using `window.__TAURI_INTERNALS__` to dynamically render the appropriate storage location text. Desktop users now see "on your file system" while web users see "in IndexedDB", providing accurate information about where their data is stored.