### PR TITLE
Fix: remove duplicate DeepGramApiKeyInput component

### DIFF
--- a/apps/whispering/src/routes/(app)/(config)/settings/api-keys/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/api-keys/+page.svelte
@@ -32,6 +32,5 @@
 	<GroqApiKeyInput />
 	<GoogleApiKeyInput />
 	<ElevenLabsApiKeyInput />
-	<DeepgramApiKeyInput />
 	<MistralApiKeyInput />
 </div>


### PR DESCRIPTION
## Summary

For some reason, we had this component twice, subtle bug. 

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `refactor`: Code refactoring (no functional changes)
- [ ] `perf`: Performance improvement
- [ ] `test`: Test additions or changes
- [ ] `chore`: Maintenance tasks
- [ ] `style`: Code style changes

## Related Issue

## Changes Made

Remove the second component

## Testing

Verify in web

### Desktop App Testing
- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] Not applicable (web-only change)

### General Testing
- [ ] Tested with multiple API providers (if applicable)
- [ ] Verified no API keys are exposed in logs or storage
- [ ] Checked for console errors
- [ ] Tested on different screen sizes (if UI change)

## Checklist

<!-- Make sure you've completed these steps -->

- [ ] My code follows the project's coding standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I've used `type` instead of `interface` in TypeScript
- [ ] I've used absolute imports where applicable
- [ ] I've tested my changes thoroughly
- [ ] I've added/updated tests for my changes (if applicable)
- [ ] My changes don't break existing functionality
- [ ] I've updated documentation (if needed)

## Screenshots/Recordings

<!-- If this is a UI change, please include screenshots or recordings -->

## Additional Notes

<!-- Any additional context, considerations, or discussion points -->