### PR TITLE
fix: align compression presets with modern FFmpeg

### DIFF
--- a/apps/whispering/src/lib/components/settings/CompressionBody.svelte
+++ b/apps/whispering/src/lib/components/settings/CompressionBody.svelte
@@ -3,7 +3,10 @@
 	import WhisperingButton from '$lib/components/WhisperingButton.svelte';
 	import { Badge } from '@repo/ui/badge';
 	import { Checkbox } from '@repo/ui/checkbox';
-	import { FFMPEG_DEFAULT_COMPRESSION_OPTIONS } from '$lib/services/recorder/ffmpeg';
+	import {
+		FFMPEG_DEFAULT_COMPRESSION_OPTIONS,
+		FFMPEG_SMALLEST_COMPRESSION_OPTIONS,
+	} from '$lib/services/recorder/ffmpeg';
 	import { settings } from '$lib/stores/settings.svelte';
 	import { cn } from '@repo/ui/utils';
 	import { RotateCcw, AlertTriangle } from '@lucide/svelte';
@@ -31,8 +34,7 @@
 			label: 'Smallest',
 			icon: '🗜️',
 			description: 'Maximum compression with silence removal',
-			options:
-				'-af silenceremove=start_periods=1:start_duration=0.1:start_threshold=-50dB:detection=peak,aformat=sample_fmts=s16:sample_rates=16000:channel_layouts=mono -c:a libopus -b:a 16k -ar 16000 -ac 1 -compression_level 10',
+			options: FFMPEG_SMALLEST_COMPRESSION_OPTIONS,
 		},
 		compatible: {
 			label: 'MP3',

--- a/apps/whispering/src/lib/components/settings/CompressionBody.svelte
+++ b/apps/whispering/src/lib/components/settings/CompressionBody.svelte
@@ -32,7 +32,7 @@
 			icon: '🗜️',
 			description: 'Maximum compression with silence removal',
 			options:
-				'-af silenceremove=start_periods=1:start_duration=0.1:start_threshold=-50dB:detection=peak,aformat=s16:16000:1 -c:a libopus -b:a 16k -ar 16000 -ac 1 -compression_level 10',
+				'-af silenceremove=start_periods=1:start_duration=0.1:start_threshold=-50dB:detection=peak,aformat=sample_fmts=s16:sample_rates=16000:channel_layouts=mono -c:a libopus -b:a 16k -ar 16000 -ac 1 -compression_level 10',
 		},
 		compatible: {
 			label: 'MP3',

--- a/apps/whispering/src/lib/services/recorder/ffmpeg.ts
+++ b/apps/whispering/src/lib/services/recorder/ffmpeg.ts
@@ -89,7 +89,7 @@ export const FFMPEG_DEFAULT_OUTPUT_OPTIONS =
  * const command = `ffmpeg -i input.wav ${FFMPEG_DEFAULT_COMPRESSION_OPTIONS} output.opus`;
  */
 export const FFMPEG_DEFAULT_COMPRESSION_OPTIONS =
-	'-af silenceremove=start_periods=1:start_duration=0.1:start_threshold=-50dB:detection=peak,aformat=s16:16000:1 -c:a libopus -b:a 32k -ar 16000 -ac 1 -compression_level 10' as const;
+	'-af silenceremove=start_periods=1:start_duration=0.1:start_threshold=-50dB:detection=peak,aformat=sample_fmts=s16:sample_rates=16000:channel_layouts=mono -c:a libopus -b:a 32k -ar 16000 -ac 1 -compression_level 10' as const;
 
 /**
  * Default FFmpeg input options for the current platform.

--- a/apps/whispering/src/lib/services/recorder/ffmpeg.ts
+++ b/apps/whispering/src/lib/services/recorder/ffmpeg.ts
@@ -92,6 +92,15 @@ export const FFMPEG_DEFAULT_COMPRESSION_OPTIONS =
 	'-af silenceremove=start_periods=1:start_duration=0.1:start_threshold=-50dB:detection=peak,aformat=sample_fmts=s16:sample_rates=16000:channel_layouts=mono -c:a libopus -b:a 32k -ar 16000 -ac 1 -compression_level 10' as const;
 
 /**
+ * Variant of the default compression preset prioritizing smallest file size.
+ *
+ * Identical to {@link FFMPEG_DEFAULT_COMPRESSION_OPTIONS} except for the lower
+ * Opus bitrate (16kbps instead of 32kbps).
+ */
+export const FFMPEG_SMALLEST_COMPRESSION_OPTIONS =
+	FFMPEG_DEFAULT_COMPRESSION_OPTIONS.replace('-b:a 32k', '-b:a 16k') as const;
+
+/**
  * Default FFmpeg input options for the current platform.
  *
  * Specifies the audio capture framework to use based on the operating system:


### PR DESCRIPTION
## Summary
- replace shorthand aformat syntax with explicit sample format/sample rate/channel layout options so current FFmpeg builds accept the filter graph
- keep UI "Smallest" preset in sync with the default options

## Testing
- ffmpeg -f lavfi -i sine=frequency=1000:duration=1 -af 'silenceremove=start_periods=1:start_duration=0.1:start_threshold=-50dB:detection=peak,aformat=sample_fmts=s16:sample_rates=16000:channel_layouts=mono' -c:a libopus -b:a 32k -ar 16000 -ac 1 -compression_level 10 /tmp/verify.opus
