### PR TITLE
fix(migration): delete skipped items from IndexedDB during migration

### DIFF
--- a/apps/whispering/src/lib/components/MigrationDialog.svelte
+++ b/apps/whispering/src/lib/components/MigrationDialog.svelte
@@ -572,6 +572,21 @@
 
 							if (existing) {
 								skipped++;
+
+								// Delete from IndexedDB since it already exists in file system
+								const { error: deleteError } =
+									await indexedDb.recordings.delete(recording);
+
+								if (deleteError) {
+									onProgress(
+										`[Migration] ⚠️  Warning: Failed to delete skipped recording ${recording.id} from IndexedDB`,
+									);
+								} else {
+									onProgress(
+										`[Migration] ✓ Deleted skipped recording ${recording.id} from IndexedDB`,
+									);
+								}
+
 								continue;
 							}
 
@@ -725,6 +740,21 @@
 
 							if (existing) {
 								skipped++;
+
+								// Delete from IndexedDB since it already exists in file system
+								const { error: deleteError } =
+									await indexedDb.transformations.delete(transformation);
+
+								if (deleteError) {
+									onProgress(
+										`[Migration] ⚠️  Warning: Failed to delete skipped transformation ${transformation.id} from IndexedDB`,
+									);
+								} else {
+									onProgress(
+										`[Migration] ✓ Deleted skipped transformation ${transformation.id} from IndexedDB`,
+									);
+								}
+
 								continue;
 							}
 
@@ -865,6 +895,20 @@
 
 							if (existing) {
 								skipped++;
+
+								// Delete from IndexedDB since it already exists in file system
+								const { error: deleteError } = await indexedDb.runs.delete(run);
+
+								if (deleteError) {
+									onProgress(
+										`[Migration] ⚠️  Warning: Failed to delete skipped transformation run ${run.id} from IndexedDB`,
+									);
+								} else {
+									onProgress(
+										`[Migration] ✓ Deleted skipped transformation run ${run.id} from IndexedDB`,
+									);
+								}
+
 								continue;
 							}
 

--- a/docs/specs/20251106T140000 fix-migration-cleanup.md
+++ b/docs/specs/20251106T140000 fix-migration-cleanup.md
@@ -1,0 +1,312 @@
+# Fix Migration Dialog Cleanup Issue
+
+## Problem
+
+The Database Migration Manager is not deleting items from IndexedDB when they are "skipped" because they already exist in the file system. This leaves orphaned data in IndexedDB indefinitely.
+
+### Current Behavior
+
+In the screenshot:
+- **IndexedDB**: 2 recordings remain
+- **File System**: 610 recordings exist
+- **Migration Result**: "Total: 0 | Successful: 0 | Failed: 0 | Skipped: 2"
+
+The code in `MigrationDialog.svelte:573-576` shows:
+
+```typescript
+if (existing) {
+  skipped++;
+  continue; // Does NOT delete from IndexedDB
+}
+```
+
+This means:
+1. When an item already exists in the destination, it's counted as "skipped"
+2. The migration continues to the next item WITHOUT deleting the skipped item
+3. The skipped items remain in IndexedDB forever
+
+### Root Causes
+
+**Primary Issue**: Skipped items are not cleaned up
+- Items that already exist in file system are skipped
+- No deletion happens for skipped items
+- This prevents full migration completion
+
+**Secondary Issue**: Delete failures are not properly handled
+- Even when migration succeeds, if the delete operation fails, the item remains
+- Lines 609-617 show the delete error is logged as a warning but migration is still counted as successful
+- This can lead to duplicate data across both systems
+
+## Proposed Solutions
+
+### Solution 1: Delete Skipped Items (Recommended)
+
+Modify the migration logic to delete items from IndexedDB even when they're skipped:
+
+```typescript
+if (existing) {
+  skipped++;
+
+  // Still delete from IndexedDB since it exists in destination
+  const { error: deleteError } = await indexedDb.recordings.delete(recording);
+
+  if (deleteError) {
+    onProgress(
+      `[Migration] ⚠️  Warning: Failed to delete skipped recording ${recording.id} from IndexedDB`
+    );
+  } else {
+    onProgress(
+      `[Migration] ✓ Deleted skipped recording ${recording.id} from IndexedDB`
+    );
+  }
+
+  continue;
+}
+```
+
+**Benefits**:
+- Completes the migration properly
+- Removes all data from IndexedDB once it's confirmed in file system
+- Fixes the root cause
+
+**Risks**:
+- If the "existing" check is wrong, we might delete data that didn't actually migrate
+- Need to ensure `fileSystemDb.recordings.getById()` is reliable
+
+### Solution 2: Add Manual Cleanup Button (Production-Safe)
+
+Add a "Clear IndexedDB" button that's available in production (not just dev mode):
+
+**Option A: Accordion with Advanced Options**
+```svelte
+<Collapsible.Root>
+  <Collapsible.Trigger>
+    <Button variant="ghost" size="sm">
+      Advanced Options
+    </Button>
+  </Collapsible.Trigger>
+  <Collapsible.Content>
+    <div class="space-y-2 p-4">
+      <p class="text-sm text-muted-foreground">
+        If migration is complete but items remain in IndexedDB, you can safely clear them.
+      </p>
+      <Button
+        onclick={clearIndexedDB}
+        variant="destructive"
+        size="sm"
+      >
+        Clear Remaining IndexedDB Data
+      </Button>
+    </div>
+  </Collapsible.Content>
+</Collapsible.Root>
+```
+
+**Option B: Conditional Button After Migration**
+Only show the cleanup button after migration completes AND items still exist:
+
+```svelte
+{#if migrationComplete && counts.indexedDb.total > 0}
+  <div class="rounded-lg border border-amber-500 bg-amber-50 p-4">
+    <p class="text-sm mb-2">
+      {counts.indexedDb.total} items remain in IndexedDB.
+      They appear to already exist in the file system.
+    </p>
+    <Button onclick={clearRemainingData} variant="outline" size="sm">
+      Clear Remaining Data
+    </Button>
+  </div>
+{/if}
+```
+
+**Benefits**:
+- Gives users a safe way to complete cleanup
+- Less risky than automatic deletion
+- Only appears when needed
+
+**Risks**:
+- Requires manual user action
+- Doesn't fix the root cause
+
+### Solution 3: Hybrid Approach (Best of Both)
+
+1. **Automatic cleanup of skipped items** (Solution 1) for the primary fix
+2. **Manual cleanup button** (Solution 2B) as a safety net for edge cases
+3. **Better error handling** for delete failures
+
+This ensures:
+- Normal migrations complete fully automatically
+- Edge cases (delete failures) can be handled manually
+- Users have visibility and control
+
+## Recommended Implementation
+
+### Phase 1: Fix the Core Issue
+
+**Step 1**: Modify `_migrateRecordings()` to delete skipped items:
+- [ ] Update lines 573-576 to delete skipped items from IndexedDB
+- [ ] Add proper error handling for skipped item deletion
+- [ ] Update progress logging to reflect skipped item deletion
+
+**Step 2**: Apply same fix to transformations and runs:
+- [ ] Update `_migrateTransformations()` (lines 722-729)
+- [ ] Update `_migrateTransformationRuns()` (lines 861-869)
+
+**Step 3**: Improve delete error handling:
+- [ ] Count delete failures separately from migration failures
+- [ ] Show delete failures in the results summary
+- [ ] Consider retrying delete operations
+
+### Phase 2: Add Safety Net
+
+**Step 4**: Add conditional cleanup button:
+- [ ] Show after migration completes if items remain
+- [ ] Display clear explanation of what will be deleted
+- [ ] Require confirmation for safety
+- [ ] Use Collapsible or Alert with subtle styling
+
+**Step 5**: Update UI messaging:
+- [ ] Clarify what "skipped" means in the logs
+- [ ] Show that skipped items are being cleaned up
+- [ ] Display final counts more prominently
+
+## Technical Details
+
+### Files to Modify
+
+1. **MigrationDialog.svelte**
+   - `_migrateRecordings()` (lines 515-661)
+   - `_migrateTransformations()` (lines 667-799)
+   - `_migrateTransformationRuns()` (lines 805-941)
+   - UI section (lines 1213-1392)
+
+### Testing Checklist
+
+- [ ] Test with items that already exist (should be deleted)
+- [ ] Test with items that don't exist (should migrate normally)
+- [ ] Test delete failures (should show in results)
+- [ ] Test manual cleanup button (should clear all remaining data)
+- [ ] Test with no remaining data (cleanup button should not appear)
+- [ ] Test in dev mode (existing dev tools should still work)
+
+## Questions to Resolve
+
+1. **Should we delete skipped items automatically?**
+   - Pro: Completes migration fully
+   - Con: Might delete data if "already exists" check is wrong
+   - **My recommendation**: Yes, but add validation to ensure file system copy is valid
+
+2. **Where should the cleanup button appear?**
+   - After migration completes?
+   - In an accordion?
+   - As a subtle link?
+   - **My recommendation**: Conditional alert after migration if items remain
+
+3. **Should we validate file system data before deleting IndexedDB data?**
+   - Check that audio blob exists in file system
+   - Compare metadata
+   - **My recommendation**: Yes for skipped items, quick validation
+
+4. **What should happen if manual cleanup fails?**
+   - Show error message
+   - Allow retry
+   - Provide instructions for manual intervention
+   - **My recommendation**: Show detailed error and allow item-by-item deletion
+
+## Additional Considerations
+
+### Data Integrity
+
+Before deleting skipped items, verify:
+- File system entry actually exists
+- Audio blob is accessible
+- Metadata matches
+
+### User Experience
+
+- Clear progress indication during cleanup
+- Explain why items were skipped
+- Show confidence that data is safe to delete
+
+### Edge Cases
+
+- What if file system is corrupted?
+- What if user has multiple migration sessions?
+- What if IndexedDB is locked?
+
+## Implementation Priority
+
+1. **High**: Fix skipped item deletion (Solution 1)
+2. **High**: Better delete error handling
+3. **Medium**: Add manual cleanup button (Solution 2B)
+4. **Low**: Additional validation and safety checks
+
+---
+
+## Implementation Review
+
+### Changes Made
+
+**File Modified**: `apps/whispering/src/lib/components/MigrationDialog.svelte`
+
+Applied Solution 1 (Delete Skipped Items) to all three migration functions:
+
+1. **`_migrateRecordings()`** (lines 567-591)
+   - Added deletion of skipped recordings from IndexedDB
+   - Logs success/warning for each skipped item deletion
+   - Items already in file system are now properly cleaned up
+
+2. **`_migrateTransformations()`** (lines 736-759)
+   - Added deletion of skipped transformations from IndexedDB
+   - Logs success/warning for each skipped item deletion
+   - Consistent with recordings implementation
+
+3. **`_migrateTransformationRuns()`** (lines 890-913)
+   - Added deletion of skipped transformation runs from IndexedDB
+   - Logs success/warning for each skipped item deletion
+   - Consistent with other implementations
+
+### Implementation Details
+
+For each skipped item:
+```typescript
+if (existing) {
+  skipped++;
+
+  // Delete from IndexedDB since it already exists in file system
+  const { error: deleteError } = await indexedDb.[table].delete(item);
+
+  if (deleteError) {
+    onProgress(
+      `[Migration] ⚠️  Warning: Failed to delete skipped [type] ${item.id} from IndexedDB`
+    );
+  } else {
+    onProgress(
+      `[Migration] ✓ Deleted skipped [type] ${item.id} from IndexedDB`
+    );
+  }
+
+  continue;
+}
+```
+
+### Benefits
+
+- Migration now completes fully, removing all data from IndexedDB
+- Users won't have orphaned data remaining after migration
+- Clear logging shows what's being cleaned up
+- Consistent implementation across all three data types
+
+### Testing Notes
+
+The fix should resolve the issue where 2 recordings remained in IndexedDB. When the migration runs again:
+- It will detect those 2 recordings already exist in file system
+- Mark them as "skipped"
+- Delete them from IndexedDB
+- Show "2 skipped" with proper cleanup messages
+
+### Future Enhancements (Not Implemented)
+
+- Manual cleanup button (Solution 2B) - deferred as this fix should resolve the core issue
+- Additional validation before deletion - current implementation trusts the `getById()` check
+- Better error handling for delete failures - currently logs warnings but doesn't retry


### PR DESCRIPTION
This fixes the issue where items marked as "skipped" during migration remain in IndexedDB indefinitely, preventing complete migration.

When the migration detects that an item already exists in the file system, it marks it as "skipped" and continues to the next item. Previously, these skipped items were never deleted from IndexedDB, leaving orphaned data that would never be cleaned up.

This change modifies all three migration functions (_migrateRecordings, _migrateTransformations, _migrateTransformationRuns) to delete skipped items from IndexedDB after confirming they exist in the destination. Each deletion is logged with either a success message or warning if the deletion fails, providing visibility into the cleanup process.

The fix ensures that migrations complete fully, removing all data from IndexedDB once it's confirmed to exist in the file system. This resolves cases where users see items remaining in IndexedDB after migration completes.