### PR TITLE
ci(pr-preview-builds): auto-cancel builds when PR is merged

### DIFF
--- a/.github/workflows/pr-preview-builds.yml
+++ b/.github/workflows/pr-preview-builds.yml
@@ -1,11 +1,45 @@
 name: PR Preview Builds
 
+# This workflow builds Tauri applications for all platforms when a PR is opened or updated.
+# It automatically cancels previous builds to save CI minutes in two scenarios:
+#
+# 1. When new commits are pushed to the PR (synchronize event):
+#    - Cancels the previous build for the same PR
+#    - Starts a new build with the latest code
+#
+# 2. When the PR is merged or closed:
+#    - Cancels any in-progress builds for that PR
+#    - Runs a lightweight job that triggers the cancellation via concurrency groups
+#
+# How it works:
+# - All workflow runs for the same PR share the same concurrency group (keyed by PR number)
+# - When a new run starts, GitHub Actions automatically cancels previous runs in that group
+# - The 'closed' trigger activates a fast dummy job that joins the concurrency group and triggers cancellation
+
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, closed]
+
+concurrency:
+  # Group all runs for the same PR together
+  # When a new run starts, previous runs in this group are automatically cancelled
+  group: tauri-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
+  # Lightweight job that runs when PR is closed/merged
+  # Purpose: Trigger concurrency-based cancellation of in-progress builds
+  # This job starts quickly, joins the concurrency group, and causes GitHub to cancel
+  # any running builds for this PR, saving CI minutes
+  cancel-on-close:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "PR closed - cancelling in-progress builds via concurrency group"
+
+  # Main build job - runs on PR open and updates, skipped when PR is closed
   build-preview:
+    if: github.event.action != 'closed'
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
This change adds automatic cancellation of in-progress Tauri builds to save CI minutes.

## How It Works

The implementation uses GitHub Actions' built-in concurrency feature to cancel builds in two scenarios:

**When new commits are pushed to a PR:**
- Previous builds for that PR are automatically cancelled
- New build starts with the latest code
- Saves CI minutes by not completing outdated builds

**When a PR is merged or closed:**
- Any in-progress builds are immediately cancelled
- A lightweight `cancel-on-close` job triggers (takes ~5 seconds)
- This job joins the same concurrency group, activating GitHub's cancellation mechanism

## Technical Implementation

All workflow runs for the same PR share a concurrency group keyed by PR number. When a new run starts, GitHub Actions automatically cancels all jobs in previous runs within that group.

The key components:
- Added `closed` to the `pull_request` trigger types
- Added `cancel-on-close` job that runs only when PR is closed
- Added condition to `build-preview` to skip when PR is closed
- Concurrency group ensures automatic cancellation across all events

This approach is more reliable than API-based cancellation because it leverages GitHub's native concurrency mechanism without queue delays or timing issues.