### PR TITLE
fix: small linter error

### DIFF
--- a/apps/whispering/src-tauri/src/transcription/mod.rs
+++ b/apps/whispering/src-tauri/src/transcription/mod.rs
@@ -10,7 +10,7 @@ use std::io::Write;
 use transcribe_rs::{
     TranscriptionEngine,
     engines::{
-        whisper::{WhisperEngine, WhisperInferenceParams},
+        whisper::WhisperInferenceParams,
         parakeet::{ParakeetInferenceParams, TimestampGranularity},
     },
 };


### PR DESCRIPTION
## Summary

Remove this very annoying Linter error showing up everytime i start the server

<img width="558" height="241" alt="Screenshot 2025-11-09 at 12 32 06 PM" src="https://github.com/user-attachments/assets/f5410d3a-d86a-41e6-856a-cc6cf785194d" />

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `refactor`: Code refactoring (no functional changes)
- [ ] `perf`: Performance improvement
- [ ] `test`: Test additions or changes
- [ ] `chore`: Maintenance tasks
- [ ] `style`: Code style changes

## Related Issue


## Changes Made

Remove unused import

### Desktop App Testing
- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] Not applicable (web-only change)

### General Testing
- [ ] Tested with multiple API providers (if applicable)
- [ ] Verified no API keys are exposed in logs or storage
- [ ] Checked for console errors
- [ ] Tested on different screen sizes (if UI change)

## Checklist

<!-- Make sure you've completed these steps -->

- [ ] My code follows the project's coding standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I've used `type` instead of `interface` in TypeScript
- [ ] I've used absolute imports where applicable
- [ ] I've tested my changes thoroughly
- [ ] I've added/updated tests for my changes (if applicable)
- [ ] My changes don't break existing functionality
- [ ] I've updated documentation (if needed)

## Screenshots/Recordings

<!-- If this is a UI change, please include screenshots or recordings -->

## Additional Notes

<!-- Any additional context, considerations, or discussion points -->