### PR TITLE
feat: add window state persistence

### DIFF
--- a/apps/whispering/src-tauri/Cargo.lock
+++ b/apps/whispering/src-tauri/Cargo.lock
@@ -5473,6 +5473,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5f6fe3291bfa609c7e0b0ee3bedac294d94c7018934086ce782c1d0f2a468e"
+dependencies = [
+ "bitflags 2.9.1",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.16",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6608,6 +6623,7 @@ dependencies = [
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
+ "tauri-plugin-window-state",
  "tempfile",
  "thiserror 2.0.16",
  "tokio",

--- a/apps/whispering/src-tauri/Cargo.toml
+++ b/apps/whispering/src-tauri/Cargo.toml
@@ -66,6 +66,7 @@ core-foundation-sys =  "0.8.7"
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
+tauri-plugin-window-state = "2"
 
 [profile.dev]
 incremental = true # Compile your binary in smaller steps.

--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -66,12 +66,14 @@ pub async fn run() {
 
     #[cfg(desktop)]
     {
-        builder = builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
-            let _ = app
-                .get_webview_window("main")
-                .expect("no main window")
-                .set_focus();
-        }));
+        builder = builder
+            .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+                let _ = app
+                    .get_webview_window("main")
+                    .expect("no main window")
+                    .set_focus();
+            }))
+            .plugin(tauri_plugin_window_state::Builder::default().build());
     }
 
     // Register command handlers (same for all platforms now)

--- a/apps/whispering/src/lib/components/NavItems.svelte
+++ b/apps/whispering/src/lib/components/NavItems.svelte
@@ -5,12 +5,15 @@
 	import * as DropdownMenu from '@repo/ui/dropdown-menu';
 	import { cn } from '@repo/ui/utils';
 	import { LogicalSize, getCurrentWindow } from '@tauri-apps/api/window';
+	import { invoke } from '@tauri-apps/api/core';
+	import { toast } from 'svelte-sonner';
 	import {
 		LayersIcon,
 		ListIcon,
 		Minimize2Icon,
 		MoonIcon,
 		MoreVerticalIcon,
+		RotateCcwIcon,
 		SettingsIcon,
 		SunIcon,
 	} from '@lucide/svelte';
@@ -20,6 +23,18 @@
 		class: className,
 		collapsed = false,
 	}: { class?: string; collapsed?: boolean } = $props();
+
+	const resetWindowSize = async () => {
+		try {
+			await invoke('reset_window_size');
+			const window = getCurrentWindow();
+			await window.setSize(new LogicalSize(1080, 800));
+			toast.success('Window size reset to default');
+		} catch (error) {
+			console.error('Failed to reset window size:', error);
+			toast.error(`Failed to reset window size: ${error}`);
+		}
+	};
 
 	const navItems = [
 		{
@@ -61,6 +76,12 @@
 						icon: Minimize2Icon,
 						type: 'button',
 						action: () => getCurrentWindow().setSize(new LogicalSize(72, 84)),
+					},
+					{
+						label: 'Reset window size',
+						icon: RotateCcwIcon,
+						type: 'button',
+						action: resetWindowSize,
 					},
 				] as const)
 			: []),

--- a/bun.lock
+++ b/bun.lock
@@ -3,9 +3,6 @@
   "workspaces": {
     "": {
       "name": "epicenter",
-      "dependencies": {
-        "wellcrafted": "catalog:",
-      },
       "devDependencies": {
         "@biomejs/biome": "^2.3.1",
         "@eslint/compat": "^1.4.0",
@@ -148,7 +145,7 @@
     },
     "apps/whispering": {
       "name": "@repo/whispering",
-      "version": "7.7.0",
+      "version": "7.7.1",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@aptabase/tauri": "^0.4.1",


### PR DESCRIPTION
## Summary
Adds automatic window state persistence to remember window size and position across app restarts.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] `feat`: New feature

## Related Issue

Closes #878 

## Changes Made

- Added `tauri-plugin-window-state` v2.4.0 dependency
- Registered window-state plugin in Rust backend
- Window size, position, and state (maximized/minimized) now persist automatically

The plugin uses Tauri v2's default permission system - all window-state operations are enabled by default with no additional configuration needed. State is saved automatically on window changes and restored on app launch.

## Testing

1. Resize/move the window
2. Close the app
3. Reopen - window should restore to previous size and position

### Desktop App Testing
- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
