### PR TITLE
fix: resolve Biome linting issues

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -50,7 +50,7 @@ app.use(
 	'/trpc/*',
 	trpcServer({
 		router: appRouter,
-		createContext: (opts, c) => createContext(c),
+		createContext: (_opts, c) => createContext(c),
 	}),
 );
 

--- a/apps/sh/src/lib/client/client/client.ts
+++ b/apps/sh/src/lib/client/client/client.ts
@@ -14,7 +14,7 @@ import {
  * Request initialization options with custom body and headers handling
  */
 type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
-	body?: any;
+	body?: unknown;
 	headers: ReturnType<typeof mergeHeaders>;
 };
 
@@ -130,7 +130,7 @@ export const createClient = (config: Config = {}): Client => {
 					? getParseAs(response.headers.get('Content-Type'))
 					: opts.parseAs) ?? 'json';
 
-			let data: any;
+			let data: unknown;
 			switch (parseAs) {
 				case 'arrayBuffer':
 				case 'blob':

--- a/apps/sh/src/lib/client/client/types.ts
+++ b/apps/sh/src/lib/client/client/types.ts
@@ -89,8 +89,8 @@ export type OptionsLegacyParser<
 	TData = unknown,
 	ThrowOnError extends boolean = boolean,
 	TResponseStyle extends ResponseStyle = 'fields',
-> = TData extends { body?: any }
-	? TData extends { headers?: any }
+> = TData extends { body?: unknown }
+	? TData extends { headers?: unknown }
 		? OmitKeys<
 				RequestOptions<TResponseStyle, ThrowOnError>,
 				'body' | 'headers' | 'url'
@@ -99,7 +99,7 @@ export type OptionsLegacyParser<
 		: OmitKeys<RequestOptions<TResponseStyle, ThrowOnError>, 'body' | 'url'> &
 				Pick<RequestOptions<TResponseStyle, ThrowOnError>, 'headers'> &
 				TData
-	: TData extends { headers?: any }
+	: TData extends { headers?: unknown }
 		? OmitKeys<
 				RequestOptions<TResponseStyle, ThrowOnError>,
 				'headers' | 'url'


### PR DESCRIPTION
Fixes Biome linting warnings that were causing the quality check to fail.

**Changes:**
- Prefix unused `opts` parameter with underscore in `apps/api/src/index.ts`
- Replace `any` types with `unknown` for better type safety in `apps/sh/src/lib/client/client/`

**Issues fixed:**
- `lint/correctness/noUnusedFunctionParameters` in apps/api/src/index.ts:53
- `lint/suspicious/noExplicitAny` in apps/sh client files

This improves code quality and type safety while resolving CI failures.