### PR TITLE
fix(audio): enable asset protocol for audio playback in recordings table

### DIFF
--- a/apps/whispering/package.json
+++ b/apps/whispering/package.json
@@ -54,7 +54,7 @@
 		"@tanstack/svelte-query-devtools": "^6.0.0",
 		"@tanstack/svelte-table": "catalog:",
 		"@tanstack/table-core": "9.0.0-alpha.10",
-		"@tauri-apps/api": "^2.7.0",
+		"@tauri-apps/api": "^2.9.0",
 		"@tauri-apps/plugin-clipboard-manager": "^2.3.0",
 		"@tauri-apps/plugin-dialog": "^2.3.2",
 		"@tauri-apps/plugin-fs": "^2.4.1",

--- a/apps/whispering/src-tauri/Cargo.lock
+++ b/apps/whispering/src-tauri/Cargo.lock
@@ -2021,6 +2021,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5091,6 +5097,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "image",
  "jni",
  "libc",

--- a/apps/whispering/src-tauri/Cargo.toml
+++ b/apps/whispering/src-tauri/Cargo.toml
@@ -27,7 +27,7 @@ tokio = { version = "1", features = ["full"] }
 dotenvy_macro = "0.15"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
-tauri = { version = "2", features = [ "macos-private-api", "image-png", "tray-icon"] }
+tauri = { version = "2", features = ["protocol-asset", "macos-private-api", "image-png", "tray-icon"] }
 tauri-plugin-opener = "2"
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-dialog = "2"

--- a/apps/whispering/src-tauri/tauri.conf.json
+++ b/apps/whispering/src-tauri/tauri.conf.json
@@ -60,7 +60,11 @@
 			}
 		],
 		"security": {
-			"csp": null
+			"csp": null,
+			"assetProtocol": {
+				"enable": true,
+				"scope": ["**"]
+			}
 		}
 	}
 }

--- a/apps/whispering/src/lib/query/db.ts
+++ b/apps/whispering/src/lib/query/db.ts
@@ -147,6 +147,12 @@ export const db = {
 				const recordingsArray = Array.isArray(recordings)
 					? recordings
 					: [recordings];
+
+				// Clean up audio URLs before deleting to prevent memory leaks
+				for (const recording of recordingsArray) {
+					services.db.recordings.revokeAudioUrl(recording.id);
+				}
+
 				const { error } = await services.db.recordings.delete(recordingsArray);
 				if (error) return Err(error);
 

--- a/apps/whispering/src/lib/services/db/file-system.ts
+++ b/apps/whispering/src/lib/services/db/file-system.ts
@@ -402,7 +402,10 @@ export function createFileSystemDb(): DbService {
 				return tryAsync({
 					try: async () => {
 						const recordingsPath = await PATHS.DB.RECORDINGS();
+						console.log('[DEBUG] recordingsPath:', recordingsPath);
+
 						const audioFile = await findAudioFile(recordingsPath, recordingId);
+						console.log('[DEBUG] audioFile:', audioFile);
 
 						if (!audioFile) {
 							throw new Error(
@@ -411,9 +414,18 @@ export function createFileSystemDb(): DbService {
 						}
 
 						const audioPath = await join(recordingsPath, audioFile);
-						const assetUrl = convertFileSrc(audioPath);
+						console.log('[DEBUG] audioPath after join():', audioPath);
 
-						return assetUrl;
+						const assetUrl = convertFileSrc(audioPath);
+						console.log('[DEBUG] assetUrl after convertFileSrc():', assetUrl);
+
+						// Fix Tauri v2.7.0 bug: convertFileSrc() incorrectly encodes forward slashes
+						// as %2F. We need to decode only the slashes while keeping other encoded
+						// characters (like %20 for spaces) intact.
+						const fixedUrl = assetUrl.replace(/%2F/g, '/');
+						console.log('[DEBUG] fixedUrl after replacing %2F:', fixedUrl);
+
+						return fixedUrl;
 					},
 					catch: (error) =>
 						DbServiceErr({

--- a/apps/whispering/src/lib/services/db/file-system.ts
+++ b/apps/whispering/src/lib/services/db/file-system.ts
@@ -402,10 +402,7 @@ export function createFileSystemDb(): DbService {
 				return tryAsync({
 					try: async () => {
 						const recordingsPath = await PATHS.DB.RECORDINGS();
-						console.log('[DEBUG] recordingsPath:', recordingsPath);
-
 						const audioFile = await findAudioFile(recordingsPath, recordingId);
-						console.log('[DEBUG] audioFile:', audioFile);
 
 						if (!audioFile) {
 							throw new Error(
@@ -414,18 +411,11 @@ export function createFileSystemDb(): DbService {
 						}
 
 						const audioPath = await join(recordingsPath, audioFile);
-						console.log('[DEBUG] audioPath after join():', audioPath);
-
 						const assetUrl = convertFileSrc(audioPath);
-						console.log('[DEBUG] assetUrl after convertFileSrc():', assetUrl);
 
-						// Fix Tauri v2.7.0 bug: convertFileSrc() incorrectly encodes forward slashes
-						// as %2F. We need to decode only the slashes while keeping other encoded
-						// characters (like %20 for spaces) intact.
-						const fixedUrl = assetUrl.replace(/%2F/g, '/');
-						console.log('[DEBUG] fixedUrl after replacing %2F:', fixedUrl);
-
-						return fixedUrl;
+						// Return the URL as-is from convertFileSrc()
+						// The Tauri backend handles URL decoding automatically
+						return assetUrl;
 					},
 					catch: (error) =>
 						DbServiceErr({

--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -202,15 +202,15 @@
 		},
 		{
 			id: 'Audio',
-			accessorFn: ({ id, blob }) => ({ id, blob }),
+			accessorFn: ({ id }) => id,
 			header: ({ column }) =>
 				renderComponent(SortableTableHeader, {
 					column,
 					headerText: 'Audio',
 				}),
 			cell: ({ getValue }) => {
-				const { id, blob } = getValue<Pick<Recording, 'id' | 'blob'>>();
-				return renderComponent(RenderAudioUrl, { id, blob });
+				const id = getValue<string>();
+				return renderComponent(RenderAudioUrl, { id });
 			},
 		},
 		{

--- a/apps/whispering/src/routes/(app)/(config)/recordings/RenderAudioUrl.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/RenderAudioUrl.svelte
@@ -1,13 +1,20 @@
 <script lang="ts">
 	import { rpc } from '$lib/query';
+	import * as services from '$lib/services';
 	import { getRecordingTransitionId } from '$lib/utils/getRecordingTransitionId';
 	import { createQuery } from '@tanstack/svelte-query';
+	import { onDestroy } from 'svelte';
 
 	let { id }: { id: string } = $props();
 
 	const audioUrlQuery = createQuery(
 		rpc.db.recordings.getAudioPlaybackUrl(() => id).options,
 	);
+
+	onDestroy(() => {
+		// Clean up audio URL when component unmounts to prevent memory leaks
+		services.db.recordings.revokeAudioUrl(id);
+	});
 </script>
 
 {#if audioUrlQuery.data}

--- a/apps/whispering/src/routes/(app)/(config)/recordings/RenderAudioUrl.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/RenderAudioUrl.svelte
@@ -1,32 +1,24 @@
 <script lang="ts">
-	import type { Recording } from '$lib/services/db';
-	import { createBlobUrlManager } from '$lib/utils/blobUrlManager';
+	import { rpc } from '$lib/query';
 	import { getRecordingTransitionId } from '$lib/utils/getRecordingTransitionId';
-	import { onDestroy } from 'svelte';
+	import { createQuery } from '@tanstack/svelte-query';
 
-	let { id, blob }: Pick<Recording, 'id' | 'blob'> = $props();
+	let { id }: { id: string } = $props();
 
-	const blobUrlManager = createBlobUrlManager();
-
-	const blobUrl = $derived.by(() => {
-		if (!blob) return undefined;
-		return blobUrlManager.createUrl(blob);
-	});
-
-	onDestroy(() => {
-		blobUrlManager.revokeCurrentUrl();
-	});
+	const audioUrlQuery = createQuery(
+		rpc.db.recordings.getAudioPlaybackUrl(() => id).options,
+	);
 </script>
 
-{#if blobUrl}
+{#if audioUrlQuery.data}
 	<audio
 		class="h-8"
 		style="view-transition-name: {getRecordingTransitionId({
 			recordingId: id,
-			propertyName: 'blob',
+			propertyName: 'id',
 		})}"
 		controls
-		src={blobUrl}
+		src={audioUrlQuery.data}
 	>
 		Your browser does not support the audio element.
 	</audio>

--- a/bun.lock
+++ b/bun.lock
@@ -3,9 +3,6 @@
   "workspaces": {
     "": {
       "name": "epicenter",
-      "dependencies": {
-        "wellcrafted": "catalog:",
-      },
       "devDependencies": {
         "@biomejs/biome": "^2.3.1",
         "@eslint/compat": "^1.4.0",
@@ -148,7 +145,7 @@
     },
     "apps/whispering": {
       "name": "@repo/whispering",
-      "version": "7.7.0",
+      "version": "7.7.1",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@aptabase/tauri": "^0.4.1",

--- a/bun.lock
+++ b/bun.lock
@@ -161,7 +161,7 @@
         "@tanstack/svelte-query-devtools": "^6.0.0",
         "@tanstack/svelte-table": "catalog:",
         "@tanstack/table-core": "9.0.0-alpha.10",
-        "@tauri-apps/api": "^2.7.0",
+        "@tauri-apps/api": "^2.9.0",
         "@tauri-apps/plugin-clipboard-manager": "^2.3.0",
         "@tauri-apps/plugin-dialog": "^2.3.2",
         "@tauri-apps/plugin-fs": "^2.4.1",
@@ -936,7 +936,7 @@
 
     "@tanstack/table-core": ["@tanstack/table-core@9.0.0-alpha.10", "", {}, "sha512-f2kEGGL+d+I7evkhU926cID2MyH7nPI8acAPcwpaAR1DrgTNStAMp3NS+tgMDyrYtc8zd+RyTxC8m+NBhHhFmA=="],
 
-    "@tauri-apps/api": ["@tauri-apps/api@2.8.0", "", {}, "sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw=="],
+    "@tauri-apps/api": ["@tauri-apps/api@2.9.0", "", {}, "sha512-qD5tMjh7utwBk9/5PrTA/aGr3i5QaJ/Mlt7p8NilQ45WgbifUNPyKWsA63iQ8YfQq6R8ajMapU+/Q8nMcPRLNw=="],
 
     "@tauri-apps/cli": ["@tauri-apps/cli@2.8.1", "", { "optionalDependencies": { "@tauri-apps/cli-darwin-arm64": "2.8.1", "@tauri-apps/cli-darwin-x64": "2.8.1", "@tauri-apps/cli-linux-arm-gnueabihf": "2.8.1", "@tauri-apps/cli-linux-arm64-gnu": "2.8.1", "@tauri-apps/cli-linux-arm64-musl": "2.8.1", "@tauri-apps/cli-linux-riscv64-gnu": "2.8.1", "@tauri-apps/cli-linux-x64-gnu": "2.8.1", "@tauri-apps/cli-linux-x64-musl": "2.8.1", "@tauri-apps/cli-win32-arm64-msvc": "2.8.1", "@tauri-apps/cli-win32-ia32-msvc": "2.8.1", "@tauri-apps/cli-win32-x64-msvc": "2.8.1" }, "bin": { "tauri": "tauri.js" } }, "sha512-ONVAfI7PFUO6MdSq9dh2YwlIb1cAezrzqrWw2+TChVskoqzDyyzncU7yXlcph/H/nR/kNDEY3E1pC8aV3TVCNQ=="],
 
@@ -2744,6 +2744,28 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@tauri-apps/plugin-clipboard-manager/@tauri-apps/api": ["@tauri-apps/api@2.8.0", "", {}, "sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw=="],
+
+    "@tauri-apps/plugin-dialog/@tauri-apps/api": ["@tauri-apps/api@2.8.0", "", {}, "sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw=="],
+
+    "@tauri-apps/plugin-fs/@tauri-apps/api": ["@tauri-apps/api@2.8.0", "", {}, "sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw=="],
+
+    "@tauri-apps/plugin-global-shortcut/@tauri-apps/api": ["@tauri-apps/api@2.8.0", "", {}, "sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw=="],
+
+    "@tauri-apps/plugin-http/@tauri-apps/api": ["@tauri-apps/api@2.8.0", "", {}, "sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw=="],
+
+    "@tauri-apps/plugin-notification/@tauri-apps/api": ["@tauri-apps/api@2.8.0", "", {}, "sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw=="],
+
+    "@tauri-apps/plugin-opener/@tauri-apps/api": ["@tauri-apps/api@2.8.0", "", {}, "sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw=="],
+
+    "@tauri-apps/plugin-os/@tauri-apps/api": ["@tauri-apps/api@2.8.0", "", {}, "sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw=="],
+
+    "@tauri-apps/plugin-process/@tauri-apps/api": ["@tauri-apps/api@2.8.0", "", {}, "sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw=="],
+
+    "@tauri-apps/plugin-shell/@tauri-apps/api": ["@tauri-apps/api@2.8.0", "", {}, "sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw=="],
+
+    "@tauri-apps/plugin-updater/@tauri-apps/api": ["@tauri-apps/api@2.8.0", "", {}, "sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw=="],
+
     "@types/fontkit/@types/node": ["@types/node@22.17.2", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w=="],
 
     "@types/node-fetch/@types/node": ["@types/node@22.17.2", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w=="],
@@ -2899,6 +2921,8 @@
     "svelte-toolbelt/runed": ["runed@0.23.4", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA=="],
 
     "tailwind-variants/tailwind-merge": ["tailwind-merge@3.0.2", "", {}, "sha512-l7z+OYZ7mu3DTqrL88RiKrKIqO3NcpEO8V/Od04bNpvk0kiIFndGEoqfuzvj4yuhRkHKjRkII2z+KS2HfPcSxw=="],
+
+    "tauri-plugin-macos-permissions-api/@tauri-apps/api": ["@tauri-apps/api@2.8.0", "", {}, "sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw=="],
 
     "tr46/punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 


### PR DESCRIPTION
This fixes audio playback in the recordings table by enabling Tauri's asset protocol, which was preventing audio elements from loading local recording files.

The root cause was that the asset protocol wasn't enabled in the Tauri security configuration. Without this, WebKit had no way to handle `asset://` URLs, rejecting them as "unsupported URLs" even though the URLs were correctly formatted.

The fix required enabling the asset protocol in `tauri.conf.json` with appropriate scope permissions, updating Tauri dependencies, and removing an incorrect URL decoding workaround that was interfering with Tauri's internal URL handling mechanism.

The recordings table architecture was already correct, using the query layer pattern to fetch audio URLs on demand. It just needed the protocol enabled to function properly.