### PR TITLE
Fixing Download Links for Windows release

### DIFF
--- a/apps/whispering/README.md
+++ b/apps/whispering/README.md
@@ -128,8 +128,8 @@ This automatically handles installation and updates.
 
 | Installer Type    | Download                                                                                                                                        | Description                            |
 | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
-| **MSI Installer** | [Whispering_7.7.2_x64_en-US_windows.msi](https://github.com/epicenter-md/epicenter/releases/download/v7.7.2/Whispering_7.7.2_x64_en-US_windows.msi) | Recommended Standard Windows installer |
-| **EXE Installer** | [Whispering_7.7.2_x64-setup_windows.exe](https://github.com/epicenter-md/epicenter/releases/download/v7.7.2/Whispering_7.7.2_x64-setup_windows.exe) | Alternative installer option           |
+| **MSI Installer** | [Whispering_7.7.2_x64_en-US_windows.msi](https://github.com/EpicenterHQ/epicenter/releases/download/v7.7.2/Whispering_7.7.2_x64_en-US.msi) | Recommended Standard Windows installer |
+| **EXE Installer** | [Whispering_7.7.2_x64-setup_windows.exe](https://github.com/EpicenterHQ/epicenter/releases/download/v7.7.2/Whispering_7.7.2_x64-setup.exe) | Alternative installer option           |
 
 #### Installation
 


### PR DESCRIPTION
## Summary

The links in this document returned a 404 error. The links mentioned on https://github.com/EpicenterHQ/epicenter/releases/tag/v7.7.2 are correct, so I copied those over

## Type of Change

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [X] `docs`: Documentation update
- [ ] `refactor`: Code refactoring (no functional changes)
- [ ] `perf`: Performance improvement
- [ ] `test`: Test additions or changes
- [ ] `chore`: Maintenance tasks
- [ ] `style`: Code style changes