### PR TITLE
fix(windows): bundle vulkan-1.dll to fix startup crash

### DIFF
--- a/.github/workflows/pr-preview-builds.yml
+++ b/.github/workflows/pr-preview-builds.yml
@@ -94,6 +94,18 @@ jobs:
           version: 1.4.309.0
           cache: true
 
+      # Bundle Vulkan DLL for Windows users without Vulkan runtime
+      - name: Bundle Vulkan DLL (Windows)
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        run: |
+          $vulkanDll = "$env:VULKAN_SDK\Bin\vulkan-1.dll"
+          $destination = "apps/whispering/src-tauri/vulkan-1.dll"
+          Write-Host "Copying Vulkan DLL from: $vulkanDll"
+          Write-Host "Copying Vulkan DLL to: $destination"
+          Copy-Item $vulkanDll $destination
+          Write-Host "Vulkan DLL bundled successfully"
+
       - name: setup node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/pr-preview-builds.yml
+++ b/.github/workflows/pr-preview-builds.yml
@@ -87,34 +87,48 @@ jobs:
         with:
           bun-version-file: "package.json"
 
+      # Install Vulkan SDK with runtime (vulkan-1.dll) for Windows builds
+      # Using jakoch/install-vulkan-sdk-action because it supports install_runtime option
+      # which provides vulkan-1.dll needed for users without GPU drivers
       - name: Install Vulkan SDK
         if: matrix.platform == 'windows-latest'
-        uses: humbletim/install-vulkan-sdk@v1.2
+        uses: jakoch/install-vulkan-sdk-action@v1
         with:
-          version: 1.4.309.0
+          vulkan_version: 1.4.309.0
+          install_runtime: true
           cache: true
 
       # Bundle Vulkan DLL for Windows users without Vulkan runtime
+      # The DLL is placed in src-tauri where tauri.windows.conf.json resources config picks it up
+      # This fixes the "vulkan-1.dll not found" error on Windows systems without GPU/Vulkan drivers
       - name: Bundle Vulkan DLL (Windows)
         if: matrix.platform == 'windows-latest'
         shell: pwsh
         run: |
           Write-Host "VULKAN_SDK: $env:VULKAN_SDK"
-          Write-Host "Searching for vulkan-1.dll..."
 
-          # Find vulkan-1.dll in the SDK directory
-          $vulkanDll = Get-ChildItem -Path $env:VULKAN_SDK -Recurse -Filter "vulkan-1.dll" -ErrorAction SilentlyContinue | Select-Object -First 1
+          # With jakoch/install-vulkan-sdk-action and install_runtime: true,
+          # vulkan-1.dll is located in the runtime/x64 subdirectory
+          $vulkanDll = "$env:VULKAN_SDK\runtime\x64\vulkan-1.dll"
 
-          if (-not $vulkanDll) {
-            Write-Host "ERROR: vulkan-1.dll not found in VULKAN_SDK"
-            Write-Host "Directory contents of VULKAN_SDK:"
-            Get-ChildItem -Path $env:VULKAN_SDK -Recurse -Depth 2 | ForEach-Object { Write-Host $_.FullName }
+          if (-not (Test-Path $vulkanDll)) {
+            Write-Host "ERROR: vulkan-1.dll not found at expected path: $vulkanDll"
+            Write-Host "Searching for vulkan-1.dll in SDK directory..."
+            $found = Get-ChildItem -Path $env:VULKAN_SDK -Recurse -Filter "vulkan-1.dll" -ErrorAction SilentlyContinue
+            if ($found) {
+              Write-Host "Found vulkan-1.dll at:"
+              $found | ForEach-Object { Write-Host "  $($_.FullName)" }
+            } else {
+              Write-Host "vulkan-1.dll not found anywhere in SDK"
+              Write-Host "Directory contents:"
+              Get-ChildItem -Path $env:VULKAN_SDK -Recurse -Depth 2 | ForEach-Object { Write-Host $_.FullName }
+            }
             exit 1
           }
 
-          Write-Host "Found vulkan-1.dll at: $($vulkanDll.FullName)"
+          Write-Host "Found vulkan-1.dll at: $vulkanDll"
           $destination = "apps/whispering/src-tauri/vulkan-1.dll"
-          Copy-Item $vulkanDll.FullName $destination
+          Copy-Item $vulkanDll $destination
           Write-Host "Vulkan DLL bundled successfully to: $destination"
 
       - name: setup node

--- a/.github/workflows/pr-preview-builds.yml
+++ b/.github/workflows/pr-preview-builds.yml
@@ -99,12 +99,23 @@ jobs:
         if: matrix.platform == 'windows-latest'
         shell: pwsh
         run: |
-          $vulkanDll = "$env:VULKAN_SDK\Bin\vulkan-1.dll"
+          Write-Host "VULKAN_SDK: $env:VULKAN_SDK"
+          Write-Host "Searching for vulkan-1.dll..."
+
+          # Find vulkan-1.dll in the SDK directory
+          $vulkanDll = Get-ChildItem -Path $env:VULKAN_SDK -Recurse -Filter "vulkan-1.dll" -ErrorAction SilentlyContinue | Select-Object -First 1
+
+          if (-not $vulkanDll) {
+            Write-Host "ERROR: vulkan-1.dll not found in VULKAN_SDK"
+            Write-Host "Directory contents of VULKAN_SDK:"
+            Get-ChildItem -Path $env:VULKAN_SDK -Recurse -Depth 2 | ForEach-Object { Write-Host $_.FullName }
+            exit 1
+          }
+
+          Write-Host "Found vulkan-1.dll at: $($vulkanDll.FullName)"
           $destination = "apps/whispering/src-tauri/vulkan-1.dll"
-          Write-Host "Copying Vulkan DLL from: $vulkanDll"
-          Write-Host "Copying Vulkan DLL to: $destination"
-          Copy-Item $vulkanDll $destination
-          Write-Host "Vulkan DLL bundled successfully"
+          Copy-Item $vulkanDll.FullName $destination
+          Write-Host "Vulkan DLL bundled successfully to: $destination"
 
       - name: setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/publish-tauri-releases.yml
+++ b/.github/workflows/publish-tauri-releases.yml
@@ -125,6 +125,20 @@ jobs:
           version: 1.4.309.0
           cache: true
 
+      # Bundle Vulkan DLL for Windows users without Vulkan runtime
+      # The DLL is placed in src-tauri where tauri.conf.json resources config picks it up
+      # This fixes the "vulkan-1.dll not found" error on Windows systems without GPU/Vulkan drivers
+      - name: Bundle Vulkan DLL (Windows)
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        run: |
+          $vulkanDll = "$env:VULKAN_SDK\Bin\vulkan-1.dll"
+          $destination = "apps/whispering/src-tauri/vulkan-1.dll"
+          Write-Host "Copying Vulkan DLL from: $vulkanDll"
+          Write-Host "Copying Vulkan DLL to: $destination"
+          Copy-Item $vulkanDll $destination
+          Write-Host "Vulkan DLL bundled successfully"
+
       # Setup Node.js for compatibility
       - name: setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/publish-tauri-releases.yml
+++ b/.github/workflows/publish-tauri-releases.yml
@@ -132,12 +132,23 @@ jobs:
         if: matrix.platform == 'windows-latest'
         shell: pwsh
         run: |
-          $vulkanDll = "$env:VULKAN_SDK\Bin\vulkan-1.dll"
+          Write-Host "VULKAN_SDK: $env:VULKAN_SDK"
+          Write-Host "Searching for vulkan-1.dll..."
+
+          # Find vulkan-1.dll in the SDK directory
+          $vulkanDll = Get-ChildItem -Path $env:VULKAN_SDK -Recurse -Filter "vulkan-1.dll" -ErrorAction SilentlyContinue | Select-Object -First 1
+
+          if (-not $vulkanDll) {
+            Write-Host "ERROR: vulkan-1.dll not found in VULKAN_SDK"
+            Write-Host "Directory contents of VULKAN_SDK:"
+            Get-ChildItem -Path $env:VULKAN_SDK -Recurse -Depth 2 | ForEach-Object { Write-Host $_.FullName }
+            exit 1
+          }
+
+          Write-Host "Found vulkan-1.dll at: $($vulkanDll.FullName)"
           $destination = "apps/whispering/src-tauri/vulkan-1.dll"
-          Write-Host "Copying Vulkan DLL from: $vulkanDll"
-          Write-Host "Copying Vulkan DLL to: $destination"
-          Copy-Item $vulkanDll $destination
-          Write-Host "Vulkan DLL bundled successfully"
+          Copy-Item $vulkanDll.FullName $destination
+          Write-Host "Vulkan DLL bundled successfully to: $destination"
 
       # Setup Node.js for compatibility
       - name: setup node

--- a/.github/workflows/publish-tauri-releases.yml
+++ b/.github/workflows/publish-tauri-releases.yml
@@ -117,37 +117,48 @@ jobs:
         with:
           bun-version-file: "package.json"
 
-      # Windows Vulkan SDK installation
+      # Install Vulkan SDK with runtime (vulkan-1.dll) for Windows builds
+      # Using jakoch/install-vulkan-sdk-action because it supports install_runtime option
+      # which provides vulkan-1.dll needed for users without GPU drivers
       - name: Install Vulkan SDK
         if: matrix.platform == 'windows-latest'
-        uses: humbletim/install-vulkan-sdk@v1.2
+        uses: jakoch/install-vulkan-sdk-action@v1
         with:
-          version: 1.4.309.0
+          vulkan_version: 1.4.309.0
+          install_runtime: true
           cache: true
 
       # Bundle Vulkan DLL for Windows users without Vulkan runtime
-      # The DLL is placed in src-tauri where tauri.conf.json resources config picks it up
+      # The DLL is placed in src-tauri where tauri.windows.conf.json resources config picks it up
       # This fixes the "vulkan-1.dll not found" error on Windows systems without GPU/Vulkan drivers
       - name: Bundle Vulkan DLL (Windows)
         if: matrix.platform == 'windows-latest'
         shell: pwsh
         run: |
           Write-Host "VULKAN_SDK: $env:VULKAN_SDK"
-          Write-Host "Searching for vulkan-1.dll..."
 
-          # Find vulkan-1.dll in the SDK directory
-          $vulkanDll = Get-ChildItem -Path $env:VULKAN_SDK -Recurse -Filter "vulkan-1.dll" -ErrorAction SilentlyContinue | Select-Object -First 1
+          # With jakoch/install-vulkan-sdk-action and install_runtime: true,
+          # vulkan-1.dll is located in the runtime/x64 subdirectory
+          $vulkanDll = "$env:VULKAN_SDK\runtime\x64\vulkan-1.dll"
 
-          if (-not $vulkanDll) {
-            Write-Host "ERROR: vulkan-1.dll not found in VULKAN_SDK"
-            Write-Host "Directory contents of VULKAN_SDK:"
-            Get-ChildItem -Path $env:VULKAN_SDK -Recurse -Depth 2 | ForEach-Object { Write-Host $_.FullName }
+          if (-not (Test-Path $vulkanDll)) {
+            Write-Host "ERROR: vulkan-1.dll not found at expected path: $vulkanDll"
+            Write-Host "Searching for vulkan-1.dll in SDK directory..."
+            $found = Get-ChildItem -Path $env:VULKAN_SDK -Recurse -Filter "vulkan-1.dll" -ErrorAction SilentlyContinue
+            if ($found) {
+              Write-Host "Found vulkan-1.dll at:"
+              $found | ForEach-Object { Write-Host "  $($_.FullName)" }
+            } else {
+              Write-Host "vulkan-1.dll not found anywhere in SDK"
+              Write-Host "Directory contents:"
+              Get-ChildItem -Path $env:VULKAN_SDK -Recurse -Depth 2 | ForEach-Object { Write-Host $_.FullName }
+            }
             exit 1
           }
 
-          Write-Host "Found vulkan-1.dll at: $($vulkanDll.FullName)"
+          Write-Host "Found vulkan-1.dll at: $vulkanDll"
           $destination = "apps/whispering/src-tauri/vulkan-1.dll"
-          Copy-Item $vulkanDll.FullName $destination
+          Copy-Item $vulkanDll $destination
           Write-Host "Vulkan DLL bundled successfully to: $destination"
 
       # Setup Node.js for compatibility

--- a/apps/whispering/src-tauri/.gitignore
+++ b/apps/whispering/src-tauri/.gitignore
@@ -9,3 +9,6 @@
 # Environment variables
 .env
 .env.local
+
+# Vulkan DLL copied during CI build (not committed, generated from VULKAN_SDK)
+vulkan-1.dll

--- a/apps/whispering/src-tauri/nsis/installer-hooks.nsh
+++ b/apps/whispering/src-tauri/nsis/installer-hooks.nsh
@@ -1,0 +1,21 @@
+; Whispering NSIS Installer Hooks
+; This file is included by the Tauri NSIS installer to handle custom installation tasks
+
+; NSIS_HOOK_POSTINSTALL
+; Called after all files are installed to $INSTDIR
+; We need to move vulkan-1.dll from resources/ to the exe directory
+; because Windows needs DLLs next to the executable for load-time linking
+!macro NSIS_HOOK_POSTINSTALL
+  ; Check if the DLL exists in resources and copy it to exe directory
+  ${If} ${FileExists} "$INSTDIR\resources\vulkan-1.dll"
+    CopyFiles /SILENT "$INSTDIR\resources\vulkan-1.dll" "$INSTDIR\vulkan-1.dll"
+    Delete "$INSTDIR\resources\vulkan-1.dll"
+  ${EndIf}
+!macroend
+
+; NSIS_HOOK_POSTUNINSTALL
+; Called after uninstallation to clean up any remaining files
+!macro NSIS_HOOK_POSTUNINSTALL
+  ; Clean up the DLL if it exists
+  Delete "$INSTDIR\vulkan-1.dll"
+!macroend

--- a/apps/whispering/src-tauri/tauri.windows.conf.json
+++ b/apps/whispering/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://schema.tauri.app/config/2",
+	"bundle": {
+		"resources": ["vulkan-1.dll"],
+		"windows": {
+			"nsis": {
+				"installerHooks": "nsis/installer-hooks.nsh"
+			}
+		}
+	}
+}


### PR DESCRIPTION
Windows users without the Vulkan runtime installed were experiencing "vulkan-1.dll not found" errors that prevented the app from starting. This affected Windows 10 systems, machines without dedicated GPUs, virtual machines, and clean Windows installations.

The root cause: our migration to transcribe-rs (PR #791) introduced a hard dependency on Vulkan through whisper-rs. Windows checks all DLLs in the import table at process startup, so the app fails immediately before any code runs.

The fix bundles vulkan-1.dll from the Vulkan SDK during CI builds. Since Tauri's `bundle.resources` places files in a `resources/` subdirectory rather than next to the executable, I added NSIS installer hooks that move the DLL to the correct location after installation. Once the DLL is present, whisper.cpp's GGML backend gracefully falls back to CPU transcription on systems without GPU/Vulkan drivers.

Note: This fix works for NSIS installers (the default). MSI installers don't support the same hook mechanism, but NSIS is the primary distribution method.

Fixes #829, fixes #840