### PR TITLE
fix(transcription): validate model downloads and detect corrupted files

### DIFF
--- a/apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte
@@ -1,30 +1,29 @@
 <script lang="ts">
-	import { Button } from '@repo/ui/button';
-	import { Badge } from '@repo/ui/badge';
-	import { Progress } from '@repo/ui/progress';
-	import Download from '@lucide/svelte/icons/download';
+	import { PATHS } from '$lib/constants/paths';
+	import {
+		isModelFileSizeValid,
+		type LocalModelConfig,
+	} from '$lib/services/transcription/local/types';
+	import { settings } from '$lib/stores/settings.svelte';
 	import CheckIcon from '@lucide/svelte/icons/check';
+	import Download from '@lucide/svelte/icons/download';
 	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
 	import X from '@lucide/svelte/icons/x';
-	import { toast } from 'svelte-sonner';
+	import { Badge } from '@repo/ui/badge';
+	import { Button } from '@repo/ui/button';
+	import { Progress } from '@repo/ui/progress';
 	import { join } from '@tauri-apps/api/path';
 	import {
 		exists,
 		mkdir,
-		writeFile,
 		remove,
 		stat,
+		writeFile,
 	} from '@tauri-apps/plugin-fs';
 	import { fetch } from '@tauri-apps/plugin-http';
+	import { toast } from 'svelte-sonner';
 	import { extractErrorMessage } from 'wellcrafted/error';
-	import { tryAsync, Ok } from 'wellcrafted/result';
-	import { PATHS } from '$lib/constants/paths';
-	import { settings } from '$lib/stores/settings.svelte';
-	import type {
-		LocalModelConfig,
-		WhisperModelConfig,
-		ParakeetModelConfig,
-	} from '$lib/services/transcription/local/types';
+	import { Ok, tryAsync } from 'wellcrafted/result';
 
 	let {
 		model,
@@ -76,22 +75,46 @@
 	async function isModelValid(path: string): Promise<boolean> {
 		switch (model.engine) {
 			case 'whispercpp': {
-				// For Whisper models, file existence is sufficient
-				return await exists(path);
-			}
-			case 'parakeet': {
 				if (!(await exists(path))) return false;
-				// For Parakeet models, path must be a directory containing all files
+				// Check file size to detect corrupted/incomplete downloads
 				const { data: stats } = await tryAsync({
 					try: () => stat(path),
 					catch: () => Ok(null),
 				});
-				if (!stats?.isDirectory) return false;
+				if (!stats) return false;
+				if (!isModelFileSizeValid(stats.size, model.sizeBytes)) {
+					console.warn(
+						`Model file appears corrupted: ${Math.round(stats.size / 1_000_000)}MB, expected ~${Math.round(model.sizeBytes / 1_000_000)}MB`,
+					);
+					return false;
+				}
+				return true;
+			}
+			case 'parakeet': {
+				if (!(await exists(path))) return false;
+				// For Parakeet models, path must be a directory containing all files
+				const { data: dirStats } = await tryAsync({
+					try: () => stat(path),
+					catch: () => Ok(null),
+				});
+				if (!dirStats?.isDirectory) return false;
 
-				// Check that all required files exist
+				// Check that all required files exist and have valid sizes
 				for (const file of model.files) {
 					const filePath = await join(path, file.filename);
 					if (!(await exists(filePath))) return false;
+					// Check file size to detect corrupted/incomplete downloads
+					const { data: fileStats } = await tryAsync({
+						try: () => stat(filePath),
+						catch: () => Ok(null),
+					});
+					if (!fileStats) return false;
+					if (!isModelFileSizeValid(fileStats.size, file.sizeBytes)) {
+						console.warn(
+							`Parakeet file "${file.filename}" appears corrupted: ${Math.round(fileStats.size / 1_000_000)}MB, expected ~${Math.round(file.sizeBytes / 1_000_000)}MB`,
+						);
+						return false;
+					}
 				}
 				return true;
 			}
@@ -175,6 +198,16 @@
 						downloadedBytes += value.length;
 						const progress = Math.round((downloadedBytes / totalBytes) * 100);
 						onProgress(progress);
+					}
+
+					// Validate download completeness
+					if (downloadedBytes < totalBytes) {
+						await remove(filePath);
+						const downloadedMB = Math.round(downloadedBytes / 1_000_000);
+						const expectedMB = Math.round(totalBytes / 1_000_000);
+						throw new Error(
+							`Download incomplete: received ${downloadedMB}MB but expected ${expectedMB}MB. Please check your network connection and try again.`,
+						);
 					}
 				};
 

--- a/apps/whispering/src/lib/services/transcription/local/types.ts
+++ b/apps/whispering/src/lib/services/transcription/local/types.ts
@@ -53,3 +53,14 @@ export type ParakeetModelConfig = BaseModelConfig & {
  * Union type for all supported local model configurations.
  */
 export type LocalModelConfig = WhisperModelConfig | ParakeetModelConfig;
+
+/**
+ * Checks if a model file size is valid (at least 90% of expected size).
+ * Used to detect corrupted or incomplete downloads.
+ */
+export function isModelFileSizeValid(
+	actualBytes: number,
+	expectedBytes: number,
+): boolean {
+	return actualBytes >= expectedBytes * 0.9;
+}

--- a/apps/whispering/src/lib/services/transcription/local/whispercpp.ts
+++ b/apps/whispering/src/lib/services/transcription/local/whispercpp.ts
@@ -1,11 +1,11 @@
 import { invoke } from '@tauri-apps/api/core';
-import { exists } from '@tauri-apps/plugin-fs';
+import { exists, stat } from '@tauri-apps/plugin-fs';
 import { type } from 'arktype';
 import { extractErrorMessage } from 'wellcrafted/error';
 import { Ok, type Result, tryAsync } from 'wellcrafted/result';
 import { WhisperingErr, type WhisperingError } from '$lib/result';
 import type { Settings } from '$lib/settings';
-import type { WhisperModelConfig } from './types';
+import { isModelFileSizeValid, type WhisperModelConfig } from './types';
 
 /**
  * Pre-built Whisper models available for download from Hugging Face.
@@ -17,7 +17,7 @@ export const WHISPER_MODELS: readonly WhisperModelConfig[] = [
 		name: 'Tiny',
 		description: 'Fastest, basic accuracy',
 		size: '78 MB',
-		sizeBytes: 77_700_000,
+		sizeBytes: 77_691_713,
 		engine: 'whispercpp',
 		file: {
 			url: 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin',
@@ -29,7 +29,7 @@ export const WHISPER_MODELS: readonly WhisperModelConfig[] = [
 		name: 'Small',
 		description: 'Fast, good accuracy',
 		size: '488 MB',
-		sizeBytes: 488_000_000,
+		sizeBytes: 487_601_967,
 		engine: 'whispercpp',
 		file: {
 			url: 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin',
@@ -41,7 +41,7 @@ export const WHISPER_MODELS: readonly WhisperModelConfig[] = [
 		name: 'Medium',
 		description: 'Balanced speed & accuracy',
 		size: '1.5 GB',
-		sizeBytes: 1_530_000_000,
+		sizeBytes: 1_533_763_059,
 		engine: 'whispercpp',
 		file: {
 			url: 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.bin',
@@ -53,7 +53,7 @@ export const WHISPER_MODELS: readonly WhisperModelConfig[] = [
 		name: 'Large v3 Turbo',
 		description: 'Best accuracy, slower',
 		size: '1.6 GB',
-		sizeBytes: 1_620_000_000,
+		sizeBytes: 1_624_555_275,
 		engine: 'whispercpp',
 		file: {
 			url: 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin',
@@ -105,6 +105,31 @@ export function createWhisperCppTranscriptionService() {
 						href: '/settings/transcription',
 					},
 				});
+			}
+
+			// Check for corrupted/incomplete model files
+			const modelConfig = WHISPER_MODELS.find((m) =>
+				options.modelPath.endsWith(m.file.filename),
+			);
+			if (modelConfig) {
+				const { data: fileStats } = await tryAsync({
+					try: () => stat(options.modelPath),
+					catch: () => Ok(null),
+				});
+				if (
+					fileStats &&
+					!isModelFileSizeValid(fileStats.size, modelConfig.sizeBytes)
+				) {
+					return WhisperingErr({
+						title: '⚠️ Model File Appears Corrupted',
+						description: `The model file is ${Math.round(fileStats.size / 1000000)}MB but should be ~${Math.round(modelConfig.sizeBytes / 1000000)}MB. This usually happens when a download was interrupted. Please delete and re-download the model.`,
+						action: {
+							type: 'link',
+							label: 'Re-download model',
+							href: '/settings/transcription',
+						},
+					});
+				}
 			}
 
 			// Convert audio blob to byte array


### PR DESCRIPTION
Users on Windows were experiencing "Failed to load model: Failed to create a new whisper context" errors because the in-app downloader was producing incomplete files. For example, the Large v3 Turbo model would download as 600MB instead of 1.6GB, and the Small model as 362MB instead of 488MB.

This PR adds validation at three points to catch and prevent corrupted downloads:

**Download validation**: After the download loop completes, we now verify that `downloadedBytes` matches the Content-Length from the server. If incomplete, we delete the partial file and show a clear error message asking the user to check their network and try again.

**Model validation on status check**: The `isModelValid()` function now checks file sizes for both Whisper (single file) and Parakeet (multiple files) models. If a file is less than 90% of expected size, it's treated as "not downloaded" so users see a Download button instead of a broken "Downloaded" state.

**Pre-transcription validation**: Before invoking the Rust backend, we check if the model file size is suspiciously small. If so, we return a clear error: "Model file is 600MB but should be ~1624MB. This usually happens when a download was interrupted. Please delete and re-download the model."

Also updated `sizeBytes` for all Whisper models to match actual HuggingFace Content-Length values, and extracted the 90% threshold into a shared `isModelFileSizeValid()` helper in types.ts.

Fixes #905