### PR TITLE
fix: migrate remaining lucide imports to individual icon paths

### DIFF
--- a/apps/whispering/src/routes/(app)/(config)/desktop-app/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/desktop-app/+page.svelte
@@ -3,7 +3,10 @@
 	import { ChromeWebStoreIcon } from '$lib/components/icons';
 	import { Button } from '@repo/ui/button';
 	import { Card } from '@repo/ui/card';
-	import { CommandIcon, DownloadIcon, MicIcon, ZapIcon } from '@lucide/svelte';
+	import CommandIcon from '@lucide/svelte/icons/command';
+	import DownloadIcon from '@lucide/svelte/icons/download';
+	import MicIcon from '@lucide/svelte/icons/mic';
+	import ZapIcon from '@lucide/svelte/icons/zap';
 </script>
 
 <svelte:head>

--- a/apps/whispering/src/routes/(app)/(config)/global-shortcut/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/global-shortcut/+page.svelte
@@ -2,7 +2,7 @@
 	import WhisperingButton from '$lib/components/WhisperingButton.svelte';
 	import { ChromeWebStoreIcon } from '$lib/components/icons';
 	import { Button } from '@repo/ui/button';
-	import { LaptopIcon as DesktopIcon } from '@lucide/svelte';
+	import DesktopIcon from '@lucide/svelte/icons/laptop';
 </script>
 
 <svelte:head>

--- a/apps/whispering/src/routes/(app)/(config)/install-ffmpeg/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/install-ffmpeg/+page.svelte
@@ -6,15 +6,13 @@
 	import * as Tabs from '@repo/ui/tabs';
 	import { Snippet } from '@repo/ui/snippet';
 	import { Badge } from '@repo/ui/badge';
-	import {
-		DownloadIcon,
-		CheckCircleIcon,
-		XCircleIcon,
-		LoaderIcon,
-		RefreshCwIcon,
-		ExternalLinkIcon,
-		ArrowLeftIcon,
-	} from '@lucide/svelte';
+	import DownloadIcon from '@lucide/svelte/icons/download';
+	import CheckCircleIcon from '@lucide/svelte/icons/check-circle';
+	import XCircleIcon from '@lucide/svelte/icons/x-circle';
+	import LoaderIcon from '@lucide/svelte/icons/loader';
+	import RefreshCwIcon from '@lucide/svelte/icons/refresh-cw';
+	import ExternalLinkIcon from '@lucide/svelte/icons/external-link';
+	import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
 	import * as services from '$lib/services';
 	import { goto } from '$app/navigation';
 	import { createQuery } from '@tanstack/svelte-query';

--- a/apps/whispering/src/routes/(app)/(config)/macos-enable-accessibility/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/macos-enable-accessibility/+page.svelte
@@ -2,7 +2,9 @@
 	import { Button } from '@repo/ui/button';
 	import { Badge } from '@repo/ui/badge';
 	import * as Card from '@repo/ui/card';
-	import { SettingsIcon, CheckIcon, ArrowLeft } from '@lucide/svelte';
+	import SettingsIcon from '@lucide/svelte/icons/settings';
+	import CheckIcon from '@lucide/svelte/icons/check';
+	import ArrowLeft from '@lucide/svelte/icons/arrow-left';
 	import * as services from '$lib/services';
 	import { toast } from 'svelte-sonner';
 	import { asShellCommand } from '$lib/services/command/types';

--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -35,13 +35,11 @@
 		getPaginationRowModel,
 		getSortedRowModel,
 	} from '@tanstack/table-core';
-	import {
-		ChevronDownIcon,
-		EllipsisIcon,
-		EllipsisIcon as LoadingTranscriptionIcon,
-		RepeatIcon as RetryTranscriptionIcon,
-		PlayIcon as StartTranscriptionIcon,
-	} from '@lucide/svelte';
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+	import EllipsisIcon from '@lucide/svelte/icons/ellipsis';
+	import LoadingTranscriptionIcon from '@lucide/svelte/icons/ellipsis';
+	import RetryTranscriptionIcon from '@lucide/svelte/icons/repeat';
+	import StartTranscriptionIcon from '@lucide/svelte/icons/play';
 	import { nanoid } from 'nanoid/non-secure';
 	import { createRawSnippet } from 'svelte';
 	import { z } from 'zod';

--- a/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/EditRecordingModal.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/EditRecordingModal.svelte
@@ -10,7 +10,8 @@
 	import type { Recording } from '$lib/services/db';
 	import * as services from '$lib/services';
 	import { createMutation, createQuery } from '@tanstack/svelte-query';
-	import { PencilIcon as EditIcon, Loader2Icon } from '@lucide/svelte';
+	import EditIcon from '@lucide/svelte/icons/pencil';
+	import Loader2Icon from '@lucide/svelte/icons/loader-2';
 	import { onDestroy } from 'svelte';
 
 	const updateRecording = createMutation(rpc.db.recordings.update.options);

--- a/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/RecordingRowActions.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/RecordingRowActions.svelte
@@ -8,15 +8,13 @@
 	import { rpc } from '$lib/query';
 	import { getRecordingTransitionId } from '$lib/utils/getRecordingTransitionId';
 	import { createMutation, createQuery } from '@tanstack/svelte-query';
-	import {
-		AlertCircleIcon,
-		DownloadIcon,
-		EllipsisIcon,
-		FileStackIcon,
-		Loader2Icon,
-		PlayIcon,
-		RepeatIcon,
-	} from '@lucide/svelte';
+	import AlertCircleIcon from '@lucide/svelte/icons/alert-circle';
+	import DownloadIcon from '@lucide/svelte/icons/download';
+	import EllipsisIcon from '@lucide/svelte/icons/ellipsis';
+	import FileStackIcon from '@lucide/svelte/icons/file-stack';
+	import Loader2Icon from '@lucide/svelte/icons/loader-2';
+	import PlayIcon from '@lucide/svelte/icons/play';
+	import RepeatIcon from '@lucide/svelte/icons/repeat';
 	import EditRecordingModal from './EditRecordingModal.svelte';
 	import TransformationPicker from './TransformationPicker.svelte';
 	import ViewTransformationRunsDialog from './ViewTransformationRunsDialog.svelte';

--- a/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/TransformationPicker.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/TransformationPicker.svelte
@@ -5,7 +5,7 @@
 	import TransformationPickerBody from '$lib/components/TransformationPickerBody.svelte';
 	import * as Popover from '@repo/ui/popover';
 	import { useCombobox } from '@repo/ui/hooks';
-	import { LayersIcon } from '@lucide/svelte';
+	import LayersIcon from '@lucide/svelte/icons/layers';
 	import { rpc } from '$lib/query';
 	import { createMutation } from '@tanstack/svelte-query';
 

--- a/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/ViewTransformationRunsDialog.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/ViewTransformationRunsDialog.svelte
@@ -5,7 +5,7 @@
 	import * as Dialog from '@repo/ui/dialog';
 	import { rpc } from '$lib/query';
 	import { createQuery } from '@tanstack/svelte-query';
-	import { HistoryIcon } from '@lucide/svelte';
+	import HistoryIcon from '@lucide/svelte/icons/history';
 
 	let { recordingId }: { recordingId: string } = $props();
 

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
@@ -5,7 +5,7 @@
 	import { Separator } from '@repo/ui/separator';
 	import * as Alert from '@repo/ui/alert';
 	import { Link } from '@repo/ui/link';
-	import { InfoIcon } from '@lucide/svelte';
+	import InfoIcon from '@lucide/svelte/icons/info';
 	import {
 		BITRATE_OPTIONS,
 		RECORDING_MODE_OPTIONS,

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/DesktopOutputFolder.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/DesktopOutputFolder.svelte
@@ -3,7 +3,9 @@
 	import { rpc } from '$lib/query';
 	import { getDefaultRecordingsFolder } from '$lib/services/recorder';
 	import { settings } from '$lib/stores/settings.svelte';
-	import { ExternalLink, FolderOpen, RotateCcw } from '@lucide/svelte';
+	import ExternalLink from '@lucide/svelte/icons/external-link';
+	import FolderOpen from '@lucide/svelte/icons/folder-open';
+	import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
 	import { Input } from '@repo/ui/input';
 	import { Ok, tryAsync } from 'wellcrafted/result';
 

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/FfmpegCommandBuilder.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/FfmpegCommandBuilder.svelte
@@ -11,7 +11,7 @@
 	import { join } from '@tauri-apps/api/path';
 	import { nanoid } from 'nanoid/non-secure';
 	import WhisperingButton from '$lib/components/WhisperingButton.svelte';
-	import { RotateCcw } from '@lucide/svelte';
+	import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
 	import {
 		buildFfmpegCommand,
 		formatDeviceForPlatform,

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/global/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/global/+page.svelte
@@ -3,7 +3,8 @@
 	import { Link } from '@repo/ui/link';
 	import { Separator } from '@repo/ui/separator';
 	import { rpc } from '$lib/query';
-	import { Layers2Icon, RotateCcw } from '@lucide/svelte';
+	import Layers2Icon from '@lucide/svelte/icons/layers-2';
+	import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
 	import ShortcutFormatHelp from '../keyboard-shortcut-recorder/ShortcutFormatHelp.svelte';
 	import ShortcutTable from '../keyboard-shortcut-recorder/ShortcutTable.svelte';
 	import { settings } from '$lib/stores/settings.svelte';

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/KeyboardShortcutRecorder.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/KeyboardShortcutRecorder.svelte
@@ -7,7 +7,10 @@
 	import type { KeyboardEventSupportedKey } from '$lib/constants/keyboard';
 	import { IS_MACOS } from '$lib/constants/platform';
 	import { cn } from '@repo/ui/utils';
-	import { AlertTriangle, Keyboard, Pencil, XIcon } from '@lucide/svelte';
+	import AlertTriangle from '@lucide/svelte/icons/alert-triangle';
+	import Keyboard from '@lucide/svelte/icons/keyboard';
+	import Pencil from '@lucide/svelte/icons/pencil';
+	import XIcon from '@lucide/svelte/icons/x';
 	import { type KeyRecorder } from './create-key-recorder.svelte';
 
 	const {

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
@@ -13,7 +13,9 @@
 		OPTION_DEAD_KEYS,
 	} from '$lib/constants/keyboard';
 	import { IS_MACOS } from '$lib/constants/platform';
-	import { AlertTriangle, ExternalLink, HelpCircle } from '@lucide/svelte';
+	import AlertTriangle from '@lucide/svelte/icons/alert-triangle';
+	import ExternalLink from '@lucide/svelte/icons/external-link';
+	import HelpCircle from '@lucide/svelte/icons/help-circle';
 
 	let { type }: { type: 'local' | 'global' } = $props();
 	let dialogOpen = $state(false);

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutTable.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutTable.svelte
@@ -5,7 +5,7 @@
 	import { rpc } from '$lib/query';
 	import { getDefaultSettings } from '$lib/settings';
 	import { createPressedKeys } from '$lib/utils/createPressedKeys.svelte';
-	import { Search } from '@lucide/svelte';
+	import Search from '@lucide/svelte/icons/search';
 	import GlobalKeyboardShortcutRecorder from './GlobalKeyboardShortcutRecorder.svelte';
 	import LocalKeyboardShortcutRecorder from './LocalKeyboardShortcutRecorder.svelte';
 

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/local/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/local/+page.svelte
@@ -2,7 +2,7 @@
 	import { Button } from '@repo/ui/button';
 	import { Separator } from '@repo/ui/separator';
 	import { rpc } from '$lib/query';
-	import { RotateCcw } from '@lucide/svelte';
+	import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
 	import ShortcutFormatHelp from '../keyboard-shortcut-recorder/ShortcutFormatHelp.svelte';
 	import ShortcutTable from '../keyboard-shortcut-recorder/ShortcutTable.svelte';
 	import { settings } from '$lib/stores/settings.svelte';

--- a/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
@@ -25,7 +25,8 @@
 	import { PARAKEET_MODELS } from '$lib/services/transcription/local/parakeet';
 	import { WHISPER_MODELS } from '$lib/services/transcription/local/whispercpp';
 	import { settings } from '$lib/stores/settings.svelte';
-	import { CheckIcon, InfoIcon } from '@lucide/svelte';
+	import CheckIcon from '@lucide/svelte/icons/check';
+	import InfoIcon from '@lucide/svelte/icons/info';
 	import * as Alert from '@repo/ui/alert';
 	import { Badge } from '@repo/ui/badge';
 	import { Button } from '@repo/ui/button';

--- a/apps/whispering/src/routes/(app)/(config)/transformations/CreateTransformationButton.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/transformations/CreateTransformationButton.svelte
@@ -7,7 +7,7 @@
 	import { rpc } from '$lib/query';
 	import { generateDefaultTransformation } from '$lib/services/db';
 	import { createMutation } from '@tanstack/svelte-query';
-	import { PlusIcon } from '@lucide/svelte';
+	import PlusIcon from '@lucide/svelte/icons/plus';
 
 	const createTransformation = createMutation(
 		rpc.db.transformations.create.options,

--- a/apps/whispering/src/routes/(app)/(config)/transformations/EditTransformationModal.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/transformations/EditTransformationModal.svelte
@@ -9,12 +9,10 @@
 	import { rpc } from '$lib/query';
 	import type { Transformation } from '$lib/services/db';
 	import { createMutation } from '@tanstack/svelte-query';
-	import {
-		HistoryIcon,
-		Loader2Icon,
-		PlayIcon,
-		TrashIcon,
-	} from '@lucide/svelte';
+	import HistoryIcon from '@lucide/svelte/icons/history';
+	import Loader2Icon from '@lucide/svelte/icons/loader-2';
+	import PlayIcon from '@lucide/svelte/icons/play';
+	import TrashIcon from '@lucide/svelte/icons/trash';
 	import MarkTransformationActiveButton from './MarkTransformationActiveButton.svelte';
 
 	const updateTransformation = createMutation(

--- a/apps/whispering/src/routes/(app)/(config)/transformations/MarkTransformationActiveButton.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/transformations/MarkTransformationActiveButton.svelte
@@ -2,7 +2,8 @@
 	import WhisperingButton from '$lib/components/WhisperingButton.svelte';
 	import type { Transformation } from '$lib/services/db';
 	import { settings } from '$lib/stores/settings.svelte';
-	import { CheckCircleIcon, CircleIcon } from '@lucide/svelte';
+	import CheckCircleIcon from '@lucide/svelte/icons/check-circle';
+	import CircleIcon from '@lucide/svelte/icons/circle';
 
 	let {
 		transformation,

--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -23,7 +23,7 @@
 	import { settings } from '$lib/stores/settings.svelte';
 	import { createBlobUrlManager } from '$lib/utils/blobUrlManager';
 	import { getRecordingTransitionId } from '$lib/utils/getRecordingTransitionId';
-	import { Loader2Icon } from '@lucide/svelte';
+	import Loader2Icon from '@lucide/svelte/icons/loader-2';
 	import {
 		ACCEPT_AUDIO,
 		ACCEPT_VIDEO,

--- a/docs/articles/blog-post-self-contained-components.md
+++ b/docs/articles/blog-post-self-contained-components.md
@@ -25,7 +25,7 @@ So I created `DeleteWorkspaceButton.svelte`:
 <script lang="ts">
   import { Button } from '@repo/ui/button';
   import * as AlertDialog from '@repo/ui/alert-dialog';
-  import { Trash2 } from '@lucide/svelte';
+  import Trash2 from '@lucide/svelte/icons/trash-2';
   import { workspaces } from '$lib/stores/workspaces.svelte';
   
   let { workspace } = $props();

--- a/docs/specs/20250120T012752 ui-overhaul.md
+++ b/docs/specs/20250120T012752 ui-overhaul.md
@@ -90,8 +90,8 @@ const sessionsQuery = createQuery(
   import { FileDropZone, ACCEPT_AUDIO, ACCEPT_VIDEO, MEGABYTE } from '@repo/ui/file-drop-zone';
   import { Button } from '@repo/ui/button';
   import { Textarea } from '@repo/ui/textarea';
-  import { PaperclipIcon } from '@lucide/svelte';
-  
+  import PaperclipIcon from '@lucide/svelte/icons/paperclip';
+
   let {
     value = $bindable(''),
     onSubmit,

--- a/docs/specs/20251106T150000 reposition-migration-button.md
+++ b/docs/specs/20251106T150000 reposition-migration-button.md
@@ -87,7 +87,7 @@ Extract just the trigger button from MigrationDialog:
 ```svelte
 <script lang="ts">
   import WhisperingButton from '$lib/components/WhisperingButton.svelte';
-  import { Database } from '@lucide/svelte';
+  import Database from '@lucide/svelte/icons/database';
 
   let { onclick, hasIndicator = false } = $props();
 </script>

--- a/docs/specs/20251126T095145 fix-lucide-imports.md
+++ b/docs/specs/20251126T095145 fix-lucide-imports.md
@@ -100,8 +100,8 @@ import MoreVerticalIcon from '@lucide/svelte/icons/more-vertical';
 // Bad: Don't import multiple icons from lucide-svelte
 import { Database, MinusIcon, MoreVerticalIcon } from 'lucide-svelte';
 
-// Bad: Don't import from @lucide/svelte root
-import { Database, MinusIcon, MoreVerticalIcon } from '@lucide/svelte';
+// Bad: Don't import from @lucide/svelte root (this is what NOT to do)
+// import { Database, MinusIcon, MoreVerticalIcon } from '@lucide/svelte';
 ```
 
 The path uses kebab-case (e.g., `more-vertical`, `minimize-2`), and you can name the import whatever you want (typically PascalCase with optional Icon suffix).

--- a/packages/ui/src/table/SortableTableHeader.svelte
+++ b/packages/ui/src/table/SortableTableHeader.svelte
@@ -1,11 +1,9 @@
 <script lang="ts" generics="TColumn extends Column<any, any>">
 	import type { Column } from '@tanstack/svelte-table';
 
-	import {
-		ArrowDown as ArrowDownIcon,
-		ArrowUpDown as ArrowUpDownIcon,
-		ArrowUp as ArrowUpIcon,
-	} from '@lucide/svelte';
+	import ArrowDownIcon from '@lucide/svelte/icons/arrow-down';
+	import ArrowUpDownIcon from '@lucide/svelte/icons/arrow-up-down';
+	import ArrowUpIcon from '@lucide/svelte/icons/arrow-up';
 
 	import { Button } from '../button/index.js';
 


### PR DESCRIPTION
Completes the migration from `import { Icon } from '@lucide/svelte'` to `import Icon from '@lucide/svelte/icons/icon-name'` pattern across 23 Svelte files and 4 documentation files.

PR #1003 was marked complete but missed these files. This ensures consistent imports throughout the codebase for better tree-shaking and follows the pattern documented in the Svelte guidelines.

Files updated:
- 23 Svelte components in apps/whispering and packages/ui
- 4 documentation files with code examples