### PR TITLE
docs(git): add merge strategy guidelines

### DIFF
--- a/rules/git.md
+++ b/rules/git.md
@@ -80,6 +80,25 @@
 - Include any breaking changes prominently
 - Link to relevant issues
 
+### Merge Strategy
+
+Always use **"Create a merge commit"** when merging pull requests. Never squash.
+
+**GitHub UI:**
+- Click "Create a merge commit" (default green button)
+
+**Git CLI:**
+```bash
+git merge --no-ff <branch>
+```
+
+**GitHub CLI:**
+```bash
+gh pr merge <PR-NUMBER> --merge
+# Use --admin flag if needed to bypass branch protections
+gh pr merge <PR-NUMBER> --merge --admin
+```
+
 ### Pull Request Body Format
 
 Use clean paragraph format instead of bullet points or structured sections:


### PR DESCRIPTION
This adds explicit merge strategy documentation to the git workflow guidelines. The new section clarifies that merge commits should always be used when merging pull requests, never squash merges.

The documentation includes practical commands for three merge approaches: GitHub UI (using the default "Create a merge commit" button), Git CLI (using git merge --no-ff), and GitHub CLI (using gh pr merge --merge). The --no-ff flag ensures merge commits are created even when fast-forward is possible, maintaining consistency with GitHub's merge commit behavior and preserving branch structure in the history.