### PR TITLE
chore: update biome schema and fix import ordering

### DIFF
--- a/apps/epicenter/src/pages/whispering.astro
+++ b/apps/epicenter/src/pages/whispering.astro
@@ -672,8 +672,8 @@ const downloads = [
 
 					<!-- Copyright -->
 					<div class="text-foreground/65 text-sm border-t pt-8">
-						© {new Date().getFullYear()} Whispering. AGPL-3.0 License. Built for the
-						open source community.
+						© {new Date().getFullYear()} Whispering. AGPL-3.0 License. Built for
+						the open source community.
 					</div>
 				</div>
 			</div>

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.3.1/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.3.7/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/examples/basic-workspace/bidirectional-sync.test.ts
+++ b/examples/basic-workspace/bidirectional-sync.test.ts
@@ -1,8 +1,8 @@
-import { test, expect } from 'bun:test';
-import { createEpicenterClient } from '@epicenter/hq';
-import epicenterConfig from './epicenter.config';
+import { expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { createEpicenterClient } from '@epicenter/hq';
+import epicenterConfig from './epicenter.config';
 
 test('markdown file edits sync back to YJS', async () => {
 	console.log('🚀 Testing bidirectional markdown sync...');

--- a/examples/basic-workspace/cli.ts
+++ b/examples/basic-workspace/cli.ts
@@ -1,5 +1,5 @@
-import { hideBin } from 'yargs/helpers';
 import { createCLI } from '@epicenter/hq/cli';
+import { hideBin } from 'yargs/helpers';
 import config from './epicenter.config';
 
 // Create and run CLI

--- a/examples/basic-workspace/epicenter.config.ts
+++ b/examples/basic-workspace/epicenter.config.ts
@@ -1,6 +1,5 @@
 import path from 'node:path';
 import {
-	type SerializedRow,
 	defineEpicenter,
 	defineMutation,
 	defineQuery,
@@ -11,6 +10,7 @@ import {
 	integer,
 	isNotNull,
 	markdownIndex,
+	type SerializedRow,
 	select,
 	sqliteIndex,
 	text,

--- a/examples/basic-workspace/server.test.ts
+++ b/examples/basic-workspace/server.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, beforeAll, afterAll } from 'bun:test';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { createServer } from '@epicenter/hq';
 import epicenterConfig from './epicenter.config';
 

--- a/examples/basic-workspace/yjs-persistence.test.ts
+++ b/examples/basic-workspace/yjs-persistence.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, expect, test } from 'bun:test';
 import { existsSync } from 'node:fs';
-import { createEpicenterClient } from '@epicenter/hq';
 import type { EpicenterClient } from '@epicenter/hq';
+import { createEpicenterClient } from '@epicenter/hq';
 import epicenterConfig from './epicenter.config';
 
 let post1Id: string;

--- a/examples/content-hub/cli.ts
+++ b/examples/content-hub/cli.ts
@@ -1,5 +1,5 @@
-import { hideBin } from 'yargs/helpers';
 import { createCLI } from '@epicenter/hq/cli';
+import { hideBin } from 'yargs/helpers';
 import config from './epicenter.config';
 
 // Create and run CLI

--- a/examples/content-hub/clippings/clippings.workspace.ts
+++ b/examples/content-hub/clippings/clippings.workspace.ts
@@ -2,7 +2,6 @@ import path from 'node:path';
 import {
 	DateWithTimezone,
 	DateWithTimezoneFromString,
-	type SerializedRow,
 	date,
 	defineMutation,
 	defineWorkspace,
@@ -10,6 +9,7 @@ import {
 	id,
 	integer,
 	markdownIndex,
+	type SerializedRow,
 	select,
 	sqliteIndex,
 	text,

--- a/examples/content-hub/email/email.workspace.ts
+++ b/examples/content-hub/email/email.workspace.ts
@@ -1,11 +1,11 @@
 import path from 'node:path';
 import {
-	type SerializedRow,
 	date,
 	defineWorkspace,
 	id,
 	isDateWithTimezoneString,
 	markdownIndex,
+	type SerializedRow,
 	sqliteIndex,
 	tags,
 	text,

--- a/examples/content-hub/epicenter/epicenter.workspace.ts
+++ b/examples/content-hub/epicenter/epicenter.workspace.ts
@@ -1,11 +1,11 @@
 import path from 'node:path';
 import {
-	type SerializedRow,
 	date,
 	defineWorkspace,
 	id,
 	isDateWithTimezoneString,
 	markdownIndex,
+	type SerializedRow,
 	select,
 	text,
 } from '@epicenter/hq';

--- a/examples/content-hub/journal/journal.workspace.ts
+++ b/examples/content-hub/journal/journal.workspace.ts
@@ -1,10 +1,10 @@
 import { basename } from 'node:path';
 import {
-	type SerializedRow,
 	date,
 	defineWorkspace,
 	id,
 	markdownIndex,
+	type SerializedRow,
 	select,
 	sqliteIndex,
 	tags,

--- a/examples/content-hub/pages/pages.workspace.ts
+++ b/examples/content-hub/pages/pages.workspace.ts
@@ -8,9 +8,9 @@ import {
 	generateId,
 	id,
 	markdownIndex,
-	tags,
 	select,
 	sqliteIndex,
+	tags,
 	text,
 } from '@epicenter/hq';
 import { readMarkdownFile } from '@epicenter/hq/indexes/markdown';

--- a/examples/content-hub/scripts/01-normalize-markdown.ts
+++ b/examples/content-hub/scripts/01-normalize-markdown.ts
@@ -15,7 +15,7 @@ import {
 	readMarkdownFile,
 	writeMarkdownFile,
 } from '@epicenter/hq/indexes/markdown';
-import { Ok, Err, type Result } from 'wellcrafted/result';
+import { Err, Ok, type Result } from 'wellcrafted/result';
 
 const sourcePath = process.env.MARKDOWN_SOURCE_PATH;
 if (!sourcePath) {

--- a/examples/content-hub/scripts/02-transform-dates.ts
+++ b/examples/content-hub/scripts/02-transform-dates.ts
@@ -9,15 +9,12 @@
  * 5. Writes files back
  */
 
+import { isDateWithTimezoneString, isIsoDateTimeString } from '@epicenter/hq';
 import {
 	listMarkdownFiles,
 	readMarkdownFile,
 	writeMarkdownFile,
 } from '@epicenter/hq/indexes/markdown';
-import {
-	isIsoDateTimeString,
-	isDateWithTimezoneString,
-} from '@epicenter/hq';
 
 /**
  * Frontmatter field that contains timezone information.
@@ -176,9 +173,7 @@ if (errors.length > 0) {
 }
 
 if (dryRun) {
-	console.log(
-		'💡 This was a dry run. Run without --dry-run to apply changes.',
-	);
+	console.log('💡 This was a dry run. Run without --dry-run to apply changes.');
 } else if (modified.length > 0) {
 	console.log('✅ Date transformation completed successfully.');
 }

--- a/examples/content-hub/scripts/03-migrate-from-epicenter.ts
+++ b/examples/content-hub/scripts/03-migrate-from-epicenter.ts
@@ -10,7 +10,7 @@
 
 import { unlink } from 'node:fs/promises';
 import { basename } from 'node:path';
-import { type SerializedRow, createEpicenterClient } from '@epicenter/hq';
+import { createEpicenterClient, type SerializedRow } from '@epicenter/hq';
 import {
 	listMarkdownFiles,
 	readMarkdownFile,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
 	"license": "AGPL-3.0",
 	"author": "",
 	"workspaces": {
-		"packages": ["apps/*", "packages/*", "examples/*"],
+		"packages": [
+			"apps/*",
+			"packages/*",
+			"examples/*"
+		],
 		"catalog": {
 			"@types/node": "^22.18.10",
 			"typescript": "^5.8.3",

--- a/packages/epicenter/src/cli/bin.ts
+++ b/packages/epicenter/src/cli/bin.ts
@@ -112,7 +112,9 @@ async function enableWatchMode() {
 	 */
 	const scriptPath = process.argv[1];
 	if (!scriptPath) {
-		throw new Error('Internal error: Failed to start epicenter (missing script path)');
+		throw new Error(
+			'Internal error: Failed to start epicenter (missing script path)',
+		);
 	}
 
 	const proc = Bun.spawn(

--- a/packages/epicenter/src/cli/cli.ts
+++ b/packages/epicenter/src/cli/cli.ts
@@ -1,7 +1,7 @@
 import type { TaggedError } from 'wellcrafted/error';
-import { type Result, isResult } from 'wellcrafted/result';
-import yargs from 'yargs';
+import { isResult, type Result } from 'wellcrafted/result';
 import type { Argv } from 'yargs';
+import yargs from 'yargs';
 import { type WorkspaceExports, walkActions } from '../core/actions';
 import type { EpicenterConfig } from '../core/epicenter';
 import { createEpicenterClient } from '../core/epicenter';

--- a/packages/epicenter/src/cli/index.ts
+++ b/packages/epicenter/src/cli/index.ts
@@ -1,8 +1,6 @@
-export { loadEpicenterConfig } from './load-config';
-
 // Programmatic CLI generation
 export { createCLI } from './cli';
-export { standardSchemaToYargs } from './standardschema-to-yargs';
-
+export { loadEpicenterConfig } from './load-config';
 // Server
-export { startServer, type ServeOptions } from './server';
+export { type ServeOptions, startServer } from './server';
+export { standardSchemaToYargs } from './standardschema-to-yargs';

--- a/packages/epicenter/src/cli/load-config.test.ts
+++ b/packages/epicenter/src/cli/load-config.test.ts
@@ -1,4 +1,11 @@
-import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from 'bun:test';
 import { existsSync } from 'node:fs';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
@@ -10,7 +17,10 @@ describe('loadEpicenterConfig', () => {
 
 	beforeEach(async () => {
 		// Create unique test directory for each test
-		testDir = path.join(BASE_TEST_DIR, `test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		testDir = path.join(
+			BASE_TEST_DIR,
+			`test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
 		await mkdir(testDir, { recursive: true });
 	});
 
@@ -31,31 +41,25 @@ describe('loadEpicenterConfig', () => {
 		const nonExistentDir = '/tmp/nonexistent-epicenter-test-dir-' + Date.now();
 
 		await expect(loadEpicenterConfig(nonExistentDir)).rejects.toThrow(
-			/No epicenter config file found/
+			/No epicenter config file found/,
 		);
 	});
 
 	test('throws error when config has no id', async () => {
 		const configPath = path.join(testDir, 'epicenter.config.js');
-		await writeFile(
-			configPath,
-			`module.exports = { workspaces: [] };`,
-		);
+		await writeFile(configPath, `module.exports = { workspaces: [] };`);
 
 		await expect(loadEpicenterConfig(testDir)).rejects.toThrow(
-			/must have a valid string id/
+			/must have a valid string id/,
 		);
 	});
 
 	test('throws error when config has no workspaces array', async () => {
 		const configPath = path.join(testDir, 'epicenter.config.js');
-		await writeFile(
-			configPath,
-			`module.exports = { id: 'test' };`,
-		);
+		await writeFile(configPath, `module.exports = { id: 'test' };`);
 
 		await expect(loadEpicenterConfig(testDir)).rejects.toThrow(
-			/must have a workspaces array/
+			/must have a workspaces array/,
 		);
 	});
 

--- a/packages/epicenter/src/cli/load-config.ts
+++ b/packages/epicenter/src/cli/load-config.ts
@@ -12,7 +12,6 @@ import type { EpicenterConfig } from '../core/epicenter';
 export async function loadEpicenterConfig(
 	configDir: string,
 ): Promise<{ config: EpicenterConfig; configPath: string }> {
-
 	// Try different config file extensions
 	const configFiles = [
 		'epicenter.config.ts',
@@ -56,7 +55,9 @@ export async function loadEpicenterConfig(
 		return { config, configPath };
 	} catch (error) {
 		if (error instanceof Error) {
-			throw new Error(`Failed to load epicenter config from ${configPath}: ${error.message}`);
+			throw new Error(
+				`Failed to load epicenter config from ${configPath}: ${error.message}`,
+			);
 		}
 		throw error;
 	}

--- a/packages/epicenter/src/cli/standardschema-to-yargs.test.ts
+++ b/packages/epicenter/src/cli/standardschema-to-yargs.test.ts
@@ -67,7 +67,9 @@ describe('standardSchemaToYargs', () => {
 		const options = (result as any).getOptions();
 		expect(options.string).toContain('role');
 		// Order doesn't matter, just check all choices are present
-		expect(options.choices.role).toEqual(expect.arrayContaining(['admin', 'user', 'guest']));
+		expect(options.choices.role).toEqual(
+			expect.arrayContaining(['admin', 'user', 'guest']),
+		);
 		expect(options.choices.role.length).toBe(3);
 	});
 
@@ -102,7 +104,9 @@ describe('standardSchemaToYargs', () => {
 		expect(options.string).toContain('content');
 		expect(options.number).toContain('views');
 		// Order doesn't matter, just check all choices are present
-		expect(options.choices.category).toEqual(expect.arrayContaining(['tech', 'personal', 'tutorial']));
+		expect(options.choices.category).toEqual(
+			expect.arrayContaining(['tech', 'personal', 'tutorial']),
+		);
 		expect(options.choices.category.length).toBe(3);
 	});
 

--- a/packages/epicenter/src/cli/standardschema-to-yargs.ts
+++ b/packages/epicenter/src/cli/standardschema-to-yargs.ts
@@ -1,5 +1,9 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec';
-import type { JSONSchema7, JSONSchema7Definition, JSONSchema7TypeName } from 'json-schema';
+import type {
+	JSONSchema7,
+	JSONSchema7Definition,
+	JSONSchema7TypeName,
+} from 'json-schema';
 import type { Argv } from 'yargs';
 import { safeToJsonSchema } from '../core/schema/safe-json-schema';
 
@@ -40,7 +44,7 @@ export async function standardSchemaToYargs(
 
 	// JSON Schema should be an object type with properties
 	if (jsonSchema.type === 'object' && jsonSchema.properties) {
-		const required = new Set((jsonSchema.required) ?? []);
+		const required = new Set(jsonSchema.required ?? []);
 
 		for (const [key, fieldSchema] of Object.entries(jsonSchema.properties)) {
 			const isRequired = required.has(key);
@@ -51,7 +55,6 @@ export async function standardSchemaToYargs(
 	return yargs;
 }
 
-
 /**
  * Add a single JSON Schema field to yargs as an option
  *
@@ -59,13 +62,17 @@ export async function standardSchemaToYargs(
  * still create the CLI option - just be more lenient. Let Standard Schema validation
  * happen when the action actually runs.
  */
-function addFieldToYargs({ key, fieldSchema, isRequired, yargs }: {
+function addFieldToYargs({
+	key,
+	fieldSchema,
+	isRequired,
+	yargs,
+}: {
 	key: string;
 	fieldSchema: JSONSchema7Definition;
 	isRequired: boolean;
 	yargs: Argv;
 }): void {
-
 	// JSONSchema7 properties can be boolean or JSONSchema7Definition
 	// For boolean schemas (true/false), accept any value (no type specified)
 	if (typeof fieldSchema === 'boolean') {
@@ -79,7 +86,8 @@ function addFieldToYargs({ key, fieldSchema, isRequired, yargs }: {
 	// Handle explicit enum property
 	if (fieldSchema.enum) {
 		const choices = fieldSchema.enum.filter(
-			(v): v is string | number => typeof v === 'string' || typeof v === 'number',
+			(v): v is string | number =>
+				typeof v === 'string' || typeof v === 'number',
 		);
 		if (choices.length > 0) {
 			yargs.option(key, {
@@ -98,11 +106,17 @@ function addFieldToYargs({ key, fieldSchema, isRequired, yargs }: {
 
 		// Check if it's a union of string literals (const values)
 		const stringLiterals = variants
-			.filter((v): v is JSONSchema7 => typeof v !== 'boolean' && v.const !== undefined)
+			.filter(
+				(v): v is JSONSchema7 =>
+					typeof v !== 'boolean' && v.const !== undefined,
+			)
 			.map((v) => v.const)
 			.filter((c): c is string => typeof c === 'string');
 
-		if (stringLiterals.length === variants.length && stringLiterals.length > 0) {
+		if (
+			stringLiterals.length === variants.length &&
+			stringLiterals.length > 0
+		) {
 			yargs.option(key, {
 				type: 'string',
 				choices: stringLiterals,
@@ -115,7 +129,8 @@ function addFieldToYargs({ key, fieldSchema, isRequired, yargs }: {
 		// For any other union (string | number, string | null, etc),
 		// just accept any value - let Standard Schema validate at runtime
 		yargs.option(key, {
-			description: fieldSchema.description ?? 'Union type (validation at runtime)',
+			description:
+				fieldSchema.description ?? 'Union type (validation at runtime)',
 			demandOption: isRequired,
 		});
 		return;
@@ -124,9 +139,17 @@ function addFieldToYargs({ key, fieldSchema, isRequired, yargs }: {
 	// Handle standard types
 	if (fieldSchema.type) {
 		// JSONSchema7TypeName can be a string or array of strings
-		const primaryType = Array.isArray(fieldSchema.type) ? fieldSchema.type[0] : fieldSchema.type;
+		const primaryType = Array.isArray(fieldSchema.type)
+			? fieldSchema.type[0]
+			: fieldSchema.type;
 		if (primaryType) {
-			addFieldByType({ key, type: primaryType, description: fieldSchema.description, isRequired, yargs });
+			addFieldByType({
+				key,
+				type: primaryType,
+				description: fieldSchema.description,
+				isRequired,
+				yargs,
+			});
 			return;
 		}
 	}
@@ -139,7 +162,6 @@ function addFieldToYargs({ key, fieldSchema, isRequired, yargs }: {
 	});
 }
 
-
 /**
  * Add a field to yargs based on JSON Schema type
  *
@@ -147,14 +169,19 @@ function addFieldToYargs({ key, fieldSchema, isRequired, yargs }: {
  * For unsupported types, we accept them as strings and rely on
  * Standard Schema validation at runtime.
  */
-function addFieldByType({ key, type, description, isRequired, yargs }: {
+function addFieldByType({
+	key,
+	type,
+	description,
+	isRequired,
+	yargs,
+}: {
 	key: string;
 	type: JSONSchema7TypeName;
 	description: string | undefined;
 	isRequired: boolean;
 	yargs: Argv;
 }): void {
-
 	switch (type) {
 		case 'string':
 			yargs.option(key, {

--- a/packages/epicenter/src/core/actions.ts
+++ b/packages/epicenter/src/core/actions.ts
@@ -248,9 +248,7 @@ export function defineQuery<
  */
 export function defineQuery<TOutput, TInput extends StandardSchemaV1>(config: {
 	input: TInput;
-	handler: (
-		input: StandardSchemaV1.InferOutput<NoInfer<TInput>>,
-	) => TOutput;
+	handler: (input: StandardSchemaV1.InferOutput<NoInfer<TInput>>) => TOutput;
 	description?: string;
 }): Query<TOutput, never, TInput, false>;
 
@@ -441,9 +439,7 @@ export function defineMutation<
 	TInput extends StandardSchemaV1,
 >(config: {
 	input: TInput;
-	handler: (
-		input: StandardSchemaV1.InferOutput<NoInfer<TInput>>,
-	) => TOutput;
+	handler: (input: StandardSchemaV1.InferOutput<NoInfer<TInput>>) => TOutput;
 	description?: string;
 }): Mutation<TOutput, never, TInput, false>;
 
@@ -582,7 +578,8 @@ export function isAction(value: unknown): value is Action {
 	return (
 		typeof value === 'function' &&
 		typeof (value as Action).type === 'string' &&
-		((value as Action).type === 'query' || (value as Action).type === 'mutation')
+		((value as Action).type === 'query' ||
+			(value as Action).type === 'mutation')
 	);
 }
 
@@ -755,4 +752,3 @@ export function defineWorkspaceExports<T extends WorkspaceExports>(
 ): T {
 	return exports;
 }
-

--- a/packages/epicenter/src/core/db/core-types.test.ts
+++ b/packages/epicenter/src/core/db/core-types.test.ts
@@ -1,15 +1,7 @@
-import { describe, test, expect } from 'bun:test';
-import { createEpicenterDb } from './core';
-import {
-	id,
-	text,
-	ytext,
-	integer,
-	boolean,
-	select,
-	tags,
-} from '../schema';
+import { describe, expect, test } from 'bun:test';
 import * as Y from 'yjs';
+import { boolean, id, integer, select, tags, text, ytext } from '../schema';
+import { createEpicenterDb } from './core';
 
 /**
  * Type inference test file for YjsDoc
@@ -123,9 +115,7 @@ describe('YjsDoc Type Inference', () => {
 
 		// Hover over 'item' parameter to verify inferred type
 		// find() now returns Row | null directly
-		const outOfStockItem = doc.items.find(
-			(item) => item.quantity === 0,
-		);
+		const outOfStockItem = doc.items.find((item) => item.quantity === 0);
 		// item type should be: { id: string; name: string; quantity: number }
 
 		expect(outOfStockItem).not.toBeNull();
@@ -175,7 +165,7 @@ describe('YjsDoc Type Inference', () => {
 		unsubscribe();
 	});
 
-		test('should handle nullable YJS types correctly', () => {
+	test('should handle nullable YJS types correctly', () => {
 		const doc = createEpicenterDb(new Y.Doc({ guid: 'test-workspace' }), {
 			articles: {
 				id: id(),
@@ -321,5 +311,4 @@ describe('YjsDoc Type Inference', () => {
 			expect(retrieved.tags.length).toBe(3);
 		}
 	});
-
 });

--- a/packages/epicenter/src/core/db/core.test.ts
+++ b/packages/epicenter/src/core/db/core.test.ts
@@ -109,9 +109,7 @@ describe('createEpicenterDb', () => {
 		expect(getResult).toBeNull();
 
 		// Test find() with no matches
-		const findResult = doc.posts.find(
-			(post) => post.id === 'non-existent',
-		);
+		const findResult = doc.posts.find((post) => post.id === 'non-existent');
 		expect(findResult).toBeNull();
 	});
 

--- a/packages/epicenter/src/core/db/core.ts
+++ b/packages/epicenter/src/core/db/core.ts
@@ -2,9 +2,9 @@ import * as Y from 'yjs';
 import type { WorkspaceSchema } from '../schema';
 import { createWorkspaceValidators } from '../schema';
 import {
+	createTableHelpers,
 	type TableHelper,
 	type YRow,
-	createTableHelpers,
 } from './table-helper';
 
 /**

--- a/packages/epicenter/src/core/epicenter.test.ts
+++ b/packages/epicenter/src/core/epicenter.test.ts
@@ -1,12 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { Ok } from 'wellcrafted/result';
-import {
-	defineQuery,
-	defineWorkspace,
-	id,
-	sqliteIndex,
-	text,
-} from '../index';
+import { defineQuery, defineWorkspace, id, sqliteIndex, text } from '../index';
 import { createEpicenterClient, defineEpicenter } from './epicenter/index';
 
 /**
@@ -47,10 +41,7 @@ describe('Action Exposure and Dependency Resolution', () => {
 	/**
 	 * Helper to create a simple workspace with actions for testing action exposure
 	 */
-	const createTestWorkspace = (
-		workspaceId: string,
-		deps: any[] = [],
-	) => {
+	const createTestWorkspace = (workspaceId: string, deps: any[] = []) => {
 		return defineWorkspace({
 			id: workspaceId,
 			dependencies: deps,
@@ -73,9 +64,7 @@ describe('Action Exposure and Dependency Resolution', () => {
 								handler: async () => {
 									// Access the first dependency's action
 									const depId = deps[0].id;
-									const result = await (workspaces as any)[
-										depId
-									].getValue();
+									const result = await (workspaces as any)[depId].getValue();
 									return result;
 								},
 							}),
@@ -116,10 +105,7 @@ describe('Action Exposure and Dependency Resolution', () => {
 	test('requires all transitive dependencies in workspaces array (flat/hoisted)', () => {
 		const workspaceA = createTestWorkspace('a');
 		const workspaceB = createTestWorkspace('b', [workspaceA]);
-		const workspaceC = createTestWorkspace('c', [
-			workspaceA,
-			workspaceB,
-		]);
+		const workspaceC = createTestWorkspace('c', [workspaceA, workspaceB]);
 
 		// Only include B and C in epicenter, not A (missing dependency)
 		const epicenter = defineEpicenter({
@@ -136,10 +122,7 @@ describe('Action Exposure and Dependency Resolution', () => {
 	test('flat/hoisted model: all dependencies must be explicitly listed', async () => {
 		const workspaceA = createTestWorkspace('a');
 		const workspaceB = createTestWorkspace('b', [workspaceA]);
-		const workspaceC = createTestWorkspace('c', [
-			workspaceA,
-			workspaceB,
-		]);
+		const workspaceC = createTestWorkspace('c', [workspaceA, workspaceB]);
 
 		// Correctly include ALL workspaces (flat/hoisted)
 		const epicenter = defineEpicenter({

--- a/packages/epicenter/src/core/epicenter/client.ts
+++ b/packages/epicenter/src/core/epicenter/client.ts
@@ -1,14 +1,10 @@
 import path from 'node:path';
-import {
-	type Action,
-	type WorkspaceExports,
-	walkActions,
-} from '../actions';
+import { type Action, type WorkspaceExports, walkActions } from '../actions';
 import type { AbsolutePath } from '../types';
 import type { AnyWorkspaceConfig, WorkspaceClient } from '../workspace';
 import {
-	type WorkspacesToClients,
 	initializeWorkspaces,
+	type WorkspacesToClients,
 } from '../workspace/client';
 import type { EpicenterConfig } from './config';
 

--- a/packages/epicenter/src/core/epicenter/config.ts
+++ b/packages/epicenter/src/core/epicenter/config.ts
@@ -21,7 +21,8 @@ import type { AnyWorkspaceConfig } from '../workspace';
  */
 export type EpicenterConfig<
 	TId extends string = string,
-	TWorkspaces extends readonly AnyWorkspaceConfig[] = readonly AnyWorkspaceConfig[],
+	TWorkspaces extends
+		readonly AnyWorkspaceConfig[] = readonly AnyWorkspaceConfig[],
 > = {
 	/**
 	 * Unique identifier for this epicenter instance
@@ -90,7 +91,9 @@ export type EpicenterConfig<
 export function defineEpicenter<
 	const TId extends string,
 	const TWorkspaces extends readonly AnyWorkspaceConfig[],
->(config: EpicenterConfig<TId, TWorkspaces>): EpicenterConfig<TId, TWorkspaces> {
+>(
+	config: EpicenterConfig<TId, TWorkspaces>,
+): EpicenterConfig<TId, TWorkspaces> {
 	// Validate epicenter ID
 	if (!config.id || typeof config.id !== 'string') {
 		throw new Error('Epicenter must have a valid string ID');

--- a/packages/epicenter/src/core/epicenter/index.ts
+++ b/packages/epicenter/src/core/epicenter/index.ts
@@ -1,7 +1,7 @@
 // Definition (config side)
-export { defineEpicenter } from './config';
-export type { EpicenterConfig } from './config';
 
+export type { EpicenterClient } from './client';
 // Runtime (client side)
 export { createEpicenterClient, forEachAction } from './client';
-export type { EpicenterClient } from './client';
+export type { EpicenterConfig } from './config';
+export { defineEpicenter } from './config';

--- a/packages/epicenter/src/core/schema/columns.ts
+++ b/packages/epicenter/src/core/schema/columns.ts
@@ -339,16 +339,12 @@ export function tags<const TOptions extends readonly [string, ...string[]]>({
 export function json<const TSchema extends Type>(opts: {
 	schema: TSchema;
 	nullable: true;
-	default?:
-		| TSchema['infer']
-		| (() => TSchema['infer']);
+	default?: TSchema['infer'] | (() => TSchema['infer']);
 }): JsonColumnSchema<TSchema, true>;
 export function json<const TSchema extends Type>(opts: {
 	schema: TSchema;
 	nullable?: false;
-	default?:
-		| TSchema['infer']
-		| (() => TSchema['infer']);
+	default?: TSchema['infer'] | (() => TSchema['infer']);
 }): JsonColumnSchema<TSchema, false>;
 export function json<const TSchema extends Type>({
 	schema,
@@ -357,9 +353,7 @@ export function json<const TSchema extends Type>({
 }: {
 	schema: TSchema;
 	nullable?: boolean;
-	default?:
-		| TSchema['infer']
-		| (() => TSchema['infer']);
+	default?: TSchema['infer'] | (() => TSchema['infer']);
 }): JsonColumnSchema<TSchema, boolean> {
 	return {
 		type: 'json',

--- a/packages/epicenter/src/core/schema/converters/arktype-yjs.ts
+++ b/packages/epicenter/src/core/schema/converters/arktype-yjs.ts
@@ -179,7 +179,7 @@ function columnSchemaToYjsArktypeType<C extends ColumnSchema>(
 	}
 
 	// Handle nullable columns
-	return (columnSchema.nullable
-		? baseType.or(type.null)
-		: baseType) as ColumnSchemaToYjsArktypeType<C>;
+	return (
+		columnSchema.nullable ? baseType.or(type.null) : baseType
+	) as ColumnSchemaToYjsArktypeType<C>;
 }

--- a/packages/epicenter/src/core/schema/converters/arktype.test.ts
+++ b/packages/epicenter/src/core/schema/converters/arktype.test.ts
@@ -1,18 +1,18 @@
 import { describe, expect, test } from 'bun:test';
 import { type } from 'arktype';
-import { tableSchemaToArktypeType } from './arktype';
 import {
-	id,
-	text,
-	ytext,
-	integer,
-	real,
 	boolean,
 	date,
+	id,
+	integer,
+	json,
+	real,
 	select,
 	tags,
-	json,
+	text,
+	ytext,
 } from '../../schema';
+import { tableSchemaToArktypeType } from './arktype';
 
 describe('tableSchemaToArktypeType', () => {
 	test('returns a complete arktype Type instance', () => {
@@ -160,7 +160,10 @@ describe('tableSchemaToArktypeType', () => {
 			title: text(),
 			subtitle: text({ nullable: true }),
 			count: integer({ nullable: true }),
-			status: select({ options: ['draft', 'published'] as const, nullable: true }),
+			status: select({
+				options: ['draft', 'published'] as const,
+				nullable: true,
+			}),
 		};
 
 		const validator = tableSchemaToArktypeType(schema);

--- a/packages/epicenter/src/core/schema/converters/arktype.ts
+++ b/packages/epicenter/src/core/schema/converters/arktype.ts
@@ -12,6 +12,7 @@
 
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { type Type, type } from 'arktype';
+import type { ObjectType } from 'arktype/internal/variants/object.ts';
 import type {
 	BooleanColumnSchema,
 	ColumnSchema,
@@ -29,7 +30,6 @@ import type {
 	YtextColumnSchema,
 } from '../../schema';
 import { DATE_WITH_TIMEZONE_STRING_REGEX } from '../regex';
-import type { ObjectType } from 'arktype/internal/variants/object.ts';
 
 /**
  * Maps a ColumnSchema to its corresponding arktype Type
@@ -73,10 +73,7 @@ export type ColumnSchemaToArktypeType<C extends ColumnSchema> =
 										? TNullable extends true
 											? Type<TOptions[number][] | null>
 											: Type<TOptions[number][]>
-										: C extends JsonColumnSchema<
-													infer TSchema,
-													infer TNullable
-											  >
+										: C extends JsonColumnSchema<infer TSchema, infer TNullable>
 											? TNullable extends true
 												? Type<StandardSchemaV1.InferOutput<TSchema> | null>
 												: Type<StandardSchemaV1.InferOutput<TSchema>>
@@ -117,8 +114,8 @@ export function tableSchemaToArktypeType<TSchema extends TableSchema>(
 			Object.entries(tableSchema).map(([fieldName, columnSchema]) => [
 				fieldName,
 				columnSchemaToArktypeType(columnSchema),
-			])
-		)
+			]),
+		),
 	) as ObjectType<SerializedRow<TSchema>>;
 }
 
@@ -185,7 +182,7 @@ function columnSchemaToArktypeType<C extends ColumnSchema>(
 
 	// Nullable columns: allow null values AND default missing fields to null
 	// This enables serialize to strip nulls while deserialize restores them
-	return (columnSchema.nullable
-		? baseType.or(type.null).default(null)
-		: baseType) as ColumnSchemaToArktypeType<C>;
+	return (
+		columnSchema.nullable ? baseType.or(type.null).default(null) : baseType
+	) as ColumnSchemaToArktypeType<C>;
 }

--- a/packages/epicenter/src/core/schema/converters/drizzle.ts
+++ b/packages/epicenter/src/core/schema/converters/drizzle.ts
@@ -1,13 +1,13 @@
 import type { IsPrimaryKey, NotNull } from 'drizzle-orm';
 import {
+	integer,
+	real,
 	type SQLiteBooleanBuilderInitial,
 	type SQLiteCustomColumnBuilder,
 	type SQLiteIntegerBuilderInitial,
 	type SQLiteRealBuilderInitial,
 	type SQLiteTable,
 	type SQLiteTextBuilderInitial,
-	integer,
-	real,
 	sqliteTable,
 	text,
 } from 'drizzle-orm/sqlite-core';

--- a/packages/epicenter/src/core/schema/date-with-timezone.ts
+++ b/packages/epicenter/src/core/schema/date-with-timezone.ts
@@ -7,10 +7,7 @@
  */
 
 import type { Brand } from 'wellcrafted/brand';
-import {
-	DATE_WITH_TIMEZONE_STRING_REGEX,
-	ISO_DATETIME_REGEX,
-} from './regex';
+import { DATE_WITH_TIMEZONE_STRING_REGEX, ISO_DATETIME_REGEX } from './regex';
 
 /**
  * ISO 8601 UTC datetime string from Date.toISOString()

--- a/packages/epicenter/src/core/schema/index.ts
+++ b/packages/epicenter/src/core/schema/index.ts
@@ -5,103 +5,47 @@
  */
 
 // ============================================================================
-// Types
-// ============================================================================
-export type {
-	// Column schema types
-	IdColumnSchema,
-	TextColumnSchema,
-	YtextColumnSchema,
-	IntegerColumnSchema,
-	RealColumnSchema,
-	BooleanColumnSchema,
-	DateColumnSchema,
-	SelectColumnSchema,
-	TagsColumnSchema,
-	JsonColumnSchema,
-	ColumnSchema,
-	ColumnType,
-
-	// Table and workspace schemas
-	TableSchema,
-	WorkspaceSchema,
-
-	// Value types
-	CellValue,
-	SerializedCellValue,
-	Row,
-	SerializedRow,
-	PartialSerializedRow,
-} from './types';
-
-export type {
-	// Validator types
-	TableValidators,
-	WorkspaceValidators,
-} from './validation';
-
-// ============================================================================
 // Column Factories
 // ============================================================================
 export {
-	id,
-	text,
-	ytext,
-	integer,
-	real,
 	boolean,
 	date,
+	id,
+	integer,
+	json,
+	real,
 	select,
 	tags,
-	json,
+	text,
+	ytext,
 } from './columns';
-
-// ============================================================================
-// Validation
-// ============================================================================
-export {
-	createTableValidators,
-	createWorkspaceValidators,
-} from './validation';
-
-// ============================================================================
-// Serialization
-// ============================================================================
-export { serializeCellValue } from './serialization';
-
-// ============================================================================
-// Utilities
-// ============================================================================
-export type { Id } from './id';
-export { generateId } from './id';
-
-export { safeToJsonSchema } from './safe-json-schema';
-
-export type {
-	DateIsoString,
-	TimezoneId,
-	DateWithTimezoneString,
-} from './date-with-timezone';
-export {
-	DateWithTimezone,
-	isDateWithTimezone,
-	isIsoDateTimeString,
-	isDateWithTimezoneString,
-	DateWithTimezoneFromString,
-} from './date-with-timezone';
-
 // ============================================================================
 // Converters
 // ============================================================================
 export type { ColumnSchemaToArktypeType } from './converters/arktype';
 export { tableSchemaToArktypeType } from './converters/arktype';
-
 export type { WorkspaceSchemaToDrizzleTables } from './converters/drizzle';
 export {
 	convertTableSchemaToDrizzle,
 	convertWorkspaceSchemaToDrizzle,
 } from './converters/drizzle';
-
+export type {
+	DateIsoString,
+	DateWithTimezoneString,
+	TimezoneId,
+} from './date-with-timezone';
+export {
+	DateWithTimezone,
+	DateWithTimezoneFromString,
+	isDateWithTimezone,
+	isDateWithTimezoneString,
+	isIsoDateTimeString,
+} from './date-with-timezone';
+// ============================================================================
+// Utilities
+// ============================================================================
+export type { Id } from './id';
+export { generateId } from './id';
 // ============================================================================
 // Regex
 // ============================================================================
@@ -110,3 +54,47 @@ export {
 	ISO_DATETIME_REGEX,
 	TIMEZONE_ID_REGEX,
 } from './regex';
+export { safeToJsonSchema } from './safe-json-schema';
+// ============================================================================
+// Serialization
+// ============================================================================
+export { serializeCellValue } from './serialization';
+// ============================================================================
+// Types
+// ============================================================================
+export type {
+	BooleanColumnSchema,
+	// Value types
+	CellValue,
+	ColumnSchema,
+	ColumnType,
+	DateColumnSchema,
+	// Column schema types
+	IdColumnSchema,
+	IntegerColumnSchema,
+	JsonColumnSchema,
+	PartialSerializedRow,
+	RealColumnSchema,
+	Row,
+	SelectColumnSchema,
+	SerializedCellValue,
+	SerializedRow,
+	// Table and workspace schemas
+	TableSchema,
+	TagsColumnSchema,
+	TextColumnSchema,
+	WorkspaceSchema,
+	YtextColumnSchema,
+} from './types';
+export type {
+	// Validator types
+	TableValidators,
+	WorkspaceValidators,
+} from './validation';
+// ============================================================================
+// Validation
+// ============================================================================
+export {
+	createTableValidators,
+	createWorkspaceValidators,
+} from './validation';

--- a/packages/epicenter/src/core/schema/regex.test.ts
+++ b/packages/epicenter/src/core/schema/regex.test.ts
@@ -243,9 +243,7 @@ describe('DATE_WITH_TIMEZONE_STRING_REGEX', () => {
 		});
 
 		test('date only with timezone', () => {
-			expect(DATE_WITH_TIMEZONE_STRING_REGEX.test('2024-01-01|UTC')).toBe(
-				true,
-			);
+			expect(DATE_WITH_TIMEZONE_STRING_REGEX.test('2024-01-01|UTC')).toBe(true);
 		});
 
 		test('datetime with offset and timezone', () => {

--- a/packages/epicenter/src/core/schema/validation.test.ts
+++ b/packages/epicenter/src/core/schema/validation.test.ts
@@ -1,5 +1,5 @@
-import { type } from 'arktype';
 import { describe, expect, test } from 'bun:test';
+import { type } from 'arktype';
 import * as Y from 'yjs';
 import {
 	createTableValidators,
@@ -9,7 +9,7 @@ import {
 	select,
 	tags,
 	text,
-	ytext
+	ytext,
 } from './index';
 
 describe('createTableValidators', () => {

--- a/packages/epicenter/src/core/schema/validation.ts
+++ b/packages/epicenter/src/core/schema/validation.ts
@@ -17,7 +17,7 @@ import type {
 	Row,
 	SerializedRow,
 	TableSchema,
-	WorkspaceSchema
+	WorkspaceSchema,
 } from './types';
 
 /**
@@ -44,7 +44,6 @@ import type {
  * ```
  */
 export type TableValidators<TSchema extends TableSchema = TableSchema> = {
-
 	/**
 	 * Generates a StandardSchemaV1 for full SerializedRow
 	 *
@@ -263,7 +262,6 @@ export function createWorkspaceValidators<
 export function createTableValidators<TSchema extends TableSchema>(
 	schema: TSchema,
 ): TableValidators<TSchema> {
-
 	return {
 		toArktype() {
 			return tableSchemaToArktypeType(schema);
@@ -281,7 +279,7 @@ export function createTableValidators<TSchema extends TableSchema>(
 			// Make all keys optional, then override 'id' to remain required
 			return this.toArktype()
 				.partial()
-				.merge({ id: "string" }) as StandardSchemaV1<
+				.merge({ id: 'string' }) as StandardSchemaV1<
 				PartialSerializedRow<TSchema>
 			>;
 		},

--- a/packages/epicenter/src/core/workspace/client.ts
+++ b/packages/epicenter/src/core/workspace/client.ts
@@ -3,7 +3,7 @@ import * as Y from 'yjs';
 import type { WorkspaceActionMap, WorkspaceExports } from '../actions';
 import { createEpicenterDb } from '../db/core';
 import type { WorkspaceIndexMap } from '../indexes';
-import { type WorkspaceSchema, createWorkspaceValidators } from '../schema';
+import { createWorkspaceValidators, type WorkspaceSchema } from '../schema';
 import type { AbsolutePath } from '../types';
 import type { AnyWorkspaceConfig, WorkspaceConfig } from './config';
 

--- a/packages/epicenter/src/core/workspace/config.ts
+++ b/packages/epicenter/src/core/workspace/config.ts
@@ -1,8 +1,8 @@
 import type { WorkspaceExports } from '../actions';
 import type { Db } from '../db/core';
 import type { Index, WorkspaceIndexMap } from '../indexes';
-import type { WorkspaceSchema, WorkspaceValidators } from '../schema';
 import type { Provider } from '../provider';
+import type { WorkspaceSchema, WorkspaceValidators } from '../schema';
 
 /**
  * Define a collaborative workspace with YJS-first architecture.

--- a/packages/epicenter/src/core/workspace/index.ts
+++ b/packages/epicenter/src/core/workspace/index.ts
@@ -1,17 +1,16 @@
 // Definition (config side)
-export { defineWorkspace } from './config';
-export type {
-	WorkspaceConfig,
-	AnyWorkspaceConfig,
-	WorkspacesToExports,
-} from './config';
 
 // Provider types
 export type { Provider, ProviderContext } from '../provider';
-
-// Runtime (client side)
-export { createWorkspaceClient } from './client';
 export type {
 	WorkspaceClient,
 	WorkspacesToClients,
 } from './client';
+// Runtime (client side)
+export { createWorkspaceClient } from './client';
+export type {
+	AnyWorkspaceConfig,
+	WorkspaceConfig,
+	WorkspacesToExports,
+} from './config';
+export { defineWorkspace } from './config';

--- a/packages/epicenter/src/index.ts
+++ b/packages/epicenter/src/index.ts
@@ -15,128 +15,68 @@
  * Write to YJS → Indexes auto-sync → Query indexes
  */
 
-// Core workspace definition
-export { defineWorkspace } from './core/workspace';
-export type {
-	WorkspaceConfig,
-	AnyWorkspaceConfig,
-	WorkspacesToExports,
-	WorkspacesToClients,
-	Provider,
-	ProviderContext,
-} from './core/workspace';
-
-// Column schema system
+// Re-export commonly used Drizzle utilities for querying indexes
 export {
-	id,
-	text,
-	ytext,
-	integer,
-	real,
-	boolean,
-	date,
-	select,
-	tags,
-	generateId,
-	createTableValidators,
-	createWorkspaceValidators,
-	isIsoDateTimeString,
-	isDateWithTimezoneString,
-	isDateWithTimezone,
-	DateWithTimezoneFromString,
-	serializeCellValue,
-	DATE_WITH_TIMEZONE_STRING_REGEX,
-	ISO_DATETIME_REGEX,
-	TIMEZONE_ID_REGEX,
-} from './core/schema';
-export { DateWithTimezone } from './core/schema';
+	and,
+	asc,
+	desc,
+	eq,
+	gt,
+	gte,
+	inArray,
+	isNotNull,
+	isNull,
+	like,
+	lt,
+	lte,
+	ne,
+	not,
+	or,
+	sql,
+} from 'drizzle-orm';
 export type {
-	ColumnSchema,
-	ColumnType,
-	TableSchema,
-	TableValidators,
-	WorkspaceValidators,
-	Row,
-	SerializedRow,
-	PartialSerializedRow,
-	Id,
-	DateWithTimezoneString,
-	DateIsoString,
-	TimezoneId,
-	IdColumnSchema,
-	TextColumnSchema,
-	YtextColumnSchema,
-	IntegerColumnSchema,
-	RealColumnSchema,
-	BooleanColumnSchema,
-	DateColumnSchema,
-	SelectColumnSchema,
-	TagsColumnSchema,
-	WorkspaceSchema,
-	CellValue,
-	SerializedCellValue,
-} from './core/schema';
-
-// Action helpers
-export {
-	defineQuery,
-	defineMutation,
-	isAction,
-	isQuery,
-	isMutation,
-	isNamespace,
-	extractActions,
-	walkActions,
-	defineWorkspaceExports,
-} from './core/actions';
-export type {
-	Query,
-	Mutation,
 	Action,
+	Mutation,
+	Query,
 	WorkspaceActionMap,
 	WorkspaceExports,
 } from './core/actions';
-
-// Runtime
-export { createWorkspaceClient } from './core/workspace';
-export type { WorkspaceClient } from './core/workspace';
-
-// Epicenter - compose multiple workspaces
+// Action helpers
 export {
-	defineEpicenter,
-	createEpicenterClient,
-	forEachAction,
-} from './core/epicenter';
-export type { EpicenterConfig, EpicenterClient } from './core/epicenter';
-
+	defineMutation,
+	defineQuery,
+	defineWorkspaceExports,
+	extractActions,
+	isAction,
+	isMutation,
+	isNamespace,
+	isQuery,
+	walkActions,
+} from './core/actions';
+export type { Db, TableHelper } from './core/db/core';
 // Database utilities
 export { createEpicenterDb } from './core/db/core';
-export type { TableHelper, Db } from './core/db/core';
-export {
-	RowAlreadyExistsErr,
-	RowNotFoundErr,
-} from './core/db/table-helper';
 export type {
 	RowAlreadyExistsError,
 	RowNotFoundError,
 	YRow,
 } from './core/db/table-helper';
-
-// Index system
-export { defineIndexExports } from './core/indexes';
+export {
+	RowAlreadyExistsErr,
+	RowNotFoundErr,
+} from './core/db/table-helper';
+export type { EpicenterClient, EpicenterConfig } from './core/epicenter';
+// Epicenter - compose multiple workspaces
+export {
+	createEpicenterClient,
+	defineEpicenter,
+	forEachAction,
+} from './core/epicenter';
 export type {
-	Index,
-	IndexExports,
-	IndexContext,
-	WorkspaceIndexMap,
-} from './core/indexes';
-
-// Indexes (implementations)
-export { sqliteIndex } from './indexes/sqlite';
-
-export { markdownIndex } from './indexes/markdown';
-export type { MarkdownIndexConfig } from './indexes/markdown';
-
+	EpicenterOperationError,
+	IndexError,
+	ValidationError,
+} from './core/errors';
 // Error types
 export {
 	EpicenterOperationErr,
@@ -144,33 +84,80 @@ export {
 	ValidationErr,
 } from './core/errors';
 export type {
-	EpicenterOperationError,
-	IndexError,
-	ValidationError,
-} from './core/errors';
-
-// Server - expose workspaces as REST API and MCP servers
-export { createServer } from './server';
-
+	Index,
+	IndexContext,
+	IndexExports,
+	WorkspaceIndexMap,
+} from './core/indexes';
+// Index system
+export { defineIndexExports } from './core/indexes';
+export type {
+	BooleanColumnSchema,
+	CellValue,
+	ColumnSchema,
+	ColumnType,
+	DateColumnSchema,
+	DateIsoString,
+	DateWithTimezoneString,
+	Id,
+	IdColumnSchema,
+	IntegerColumnSchema,
+	PartialSerializedRow,
+	RealColumnSchema,
+	Row,
+	SelectColumnSchema,
+	SerializedCellValue,
+	SerializedRow,
+	TableSchema,
+	TableValidators,
+	TagsColumnSchema,
+	TextColumnSchema,
+	TimezoneId,
+	WorkspaceSchema,
+	WorkspaceValidators,
+	YtextColumnSchema,
+} from './core/schema';
+// Column schema system
+export {
+	boolean,
+	createTableValidators,
+	createWorkspaceValidators,
+	DATE_WITH_TIMEZONE_STRING_REGEX,
+	DateWithTimezone,
+	DateWithTimezoneFromString,
+	date,
+	generateId,
+	ISO_DATETIME_REGEX,
+	id,
+	integer,
+	isDateWithTimezone,
+	isDateWithTimezoneString,
+	isIsoDateTimeString,
+	real,
+	select,
+	serializeCellValue,
+	TIMEZONE_ID_REGEX,
+	tags,
+	text,
+	ytext,
+} from './core/schema';
 // Core types
 export type { AbsolutePath } from './core/types';
-
-// Re-export commonly used Drizzle utilities for querying indexes
-export {
-	eq,
-	ne,
-	gt,
-	gte,
-	lt,
-	lte,
-	and,
-	or,
-	not,
-	like,
-	inArray,
-	isNull,
-	isNotNull,
-	sql,
-	desc,
-	asc,
-} from 'drizzle-orm';
+export type {
+	AnyWorkspaceConfig,
+	Provider,
+	ProviderContext,
+	WorkspaceClient,
+	WorkspaceConfig,
+	WorkspacesToClients,
+	WorkspacesToExports,
+} from './core/workspace';
+// Core workspace definition
+// Runtime
+export { createWorkspaceClient, defineWorkspace } from './core/workspace';
+export type { MarkdownIndexConfig } from './indexes/markdown';
+export { markdownIndex } from './indexes/markdown';
+// Indexes (implementations)
+export { sqliteIndex } from './indexes/sqlite';
+// Server - expose workspaces as REST API and MCP servers
+export { createServer } from './server';

--- a/packages/epicenter/src/indexes/error-logger.ts
+++ b/packages/epicenter/src/indexes/error-logger.ts
@@ -1,5 +1,5 @@
-import path from 'node:path';
 import { mkdirSync } from 'node:fs';
+import path from 'node:path';
 import type { TaggedError } from 'wellcrafted/error';
 import { Ok, tryAsync, trySync } from 'wellcrafted/result';
 
@@ -127,9 +127,7 @@ type IndexLogger = {
  * await logger.close();
  * ```
  */
-export function createIndexLogger({
-	logPath,
-}: IndexLoggerConfig): IndexLogger {
+export function createIndexLogger({ logPath }: IndexLoggerConfig): IndexLogger {
 	// Create parent directory if it doesn't exist
 	const logDir = path.dirname(logPath);
 	trySync({

--- a/packages/epicenter/src/indexes/markdown/diagnostics-manager.ts
+++ b/packages/epicenter/src/indexes/markdown/diagnostics-manager.ts
@@ -321,12 +321,10 @@ export function createDiagnosticsManager({
 	 * @param operation - Async operation to queue (usually writeToDisk)
 	 */
 	function queueWrite(operation: () => Promise<void>): void {
-		writeQueue = writeQueue
-			.then(operation)
-			.catch((error) => {
-				// Log error but don't break the queue
-				console.error('Queued write operation failed:', error);
-			});
+		writeQueue = writeQueue.then(operation).catch((error) => {
+			// Log error but don't break the queue
+			console.error('Queued write operation failed:', error);
+		});
 	}
 
 	return {

--- a/packages/epicenter/src/indexes/markdown/index.ts
+++ b/packages/epicenter/src/indexes/markdown/index.ts
@@ -5,20 +5,20 @@
  * and utilities for custom serializers and error handling.
  */
 
-// Main index implementation
-export { markdownIndex } from './markdown-index';
-
-// Types
-export type { MarkdownIndexConfig } from './markdown-index';
-
-// Error types for custom serializers
-export { MarkdownIndexErr, MarkdownIndexError } from './markdown-index';
-
+export type { MarkdownOperationError } from './io';
 // Markdown file operations
 export {
+	deleteMarkdownFile,
 	listMarkdownFiles,
 	readMarkdownFile,
 	writeMarkdownFile,
-	deleteMarkdownFile,
 } from './io';
-export type { MarkdownOperationError } from './io';
+// Types
+export type { MarkdownIndexConfig } from './markdown-index';
+// Main index implementation
+// Error types for custom serializers
+export {
+	MarkdownIndexErr,
+	MarkdownIndexError,
+	markdownIndex,
+} from './markdown-index';

--- a/packages/epicenter/src/indexes/markdown/markdown-index.ts
+++ b/packages/epicenter/src/indexes/markdown/markdown-index.ts
@@ -8,9 +8,9 @@ import { defineQuery } from '../../core/actions';
 import type { TableHelper } from '../../core/db/table-helper';
 import { IndexErr, IndexError } from '../../core/errors';
 import {
+	defineIndexExports,
 	type Index,
 	type IndexContext,
-	defineIndexExports,
 } from '../../core/indexes';
 import type {
 	Row,
@@ -457,7 +457,9 @@ export const markdownIndex = (async <TSchema extends WorkspaceSchema>(
 
 				// Check if we need to clean up an old file before updating tracking
 				// biome-ignore lint/style/noNonNullAssertion: tracking is initialized at loop start for each table
-				const oldFilename = tracking[table.name]!.getFilename({ rowId: row.id });
+				const oldFilename = tracking[table.name]!.getFilename({
+					rowId: row.id,
+				});
 
 				/**
 				 * This is checking if there's an old filename AND if it's different
@@ -497,7 +499,10 @@ export const markdownIndex = (async <TSchema extends WorkspaceSchema>(
 						logger.log(
 							IndexError({
 								message: `YJS observer onAdd: validation failed for ${table.name}`,
-								context: { tableName: table.name, validationErrors: result.error.summary },
+								context: {
+									tableName: table.name,
+									validationErrors: result.error.summary,
+								},
 								cause: undefined,
 							}),
 						);
@@ -530,7 +535,10 @@ export const markdownIndex = (async <TSchema extends WorkspaceSchema>(
 						logger.log(
 							IndexError({
 								message: `YJS observer onUpdate: validation failed for ${table.name}`,
-								context: { tableName: table.name, validationErrors: result.error.summary },
+								context: {
+									tableName: table.name,
+									validationErrors: result.error.summary,
+								},
 								cause: undefined,
 							}),
 						);
@@ -614,7 +622,10 @@ export const markdownIndex = (async <TSchema extends WorkspaceSchema>(
 				catch: (error) =>
 					IndexErr({
 						message: `Failed to create table directory: ${extractErrorMessage(error)}`,
-						context: { tableName: table.name, directory: tableConfig.directory },
+						context: {
+							tableName: table.name,
+							directory: tableConfig.directory,
+						},
 					}),
 			});
 
@@ -647,7 +658,9 @@ export const markdownIndex = (async <TSchema extends WorkspaceSchema>(
 
 						if (!exists) {
 							// File was deleted: find and delete the row
-							const rowIdToDelete = tracking[table.name]?.getRowId({ filename });
+							const rowIdToDelete = tracking[table.name]?.getRowId({
+								filename,
+							});
 
 							if (rowIdToDelete) {
 								if (table.has({ id: rowIdToDelete })) {
@@ -987,7 +1000,11 @@ export const markdownIndex = (async <TSchema extends WorkspaceSchema>(
 									logger.log(
 										IndexError({
 											message: `pullToMarkdown: failed to write ${filePath}`,
-											context: { filePath, tableName: table.name, rowId: row.id },
+											context: {
+												filePath,
+												tableName: table.name,
+												rowId: row.id,
+											},
 											cause: error,
 										}),
 									);

--- a/packages/epicenter/src/indexes/sqlite/index.ts
+++ b/packages/epicenter/src/indexes/sqlite/index.ts
@@ -5,19 +5,18 @@
  * and utilities for working with Drizzle schemas.
  */
 
-// Main index implementation
-export { sqliteIndex } from './sqlite-index';
-
 // Schema utilities (builders + converter)
 export type { WorkspaceSchemaToDrizzleTables } from './schema';
 export {
-	convertWorkspaceSchemaToDrizzle,
+	boolean,
 	convertTableSchemaToDrizzle,
+	convertWorkspaceSchemaToDrizzle,
+	date,
 	id,
-	text,
 	integer,
 	real,
-	boolean,
-	date,
 	tags,
+	text,
 } from './schema';
+// Main index implementation
+export { sqliteIndex } from './sqlite-index';

--- a/packages/epicenter/src/indexes/sqlite/schema/builders.ts
+++ b/packages/epicenter/src/indexes/sqlite/schema/builders.ts
@@ -1,3 +1,4 @@
+import { type ArkErrors, type Type, type } from 'arktype';
 import type {
 	ColumnBuilderBase,
 	ColumnBuilderBaseConfig,
@@ -17,7 +18,6 @@ import type {
 	DateWithTimezone as DateWithTimezoneType,
 } from '../../../core/schema';
 import { DateWithTimezone, generateId } from '../../../core/schema';
-import { type, type ArkErrors, type Type } from 'arktype';
 
 /**
  * Type helper that composes Drizzle column modifiers based on options
@@ -291,7 +291,10 @@ type TagsArray<TOptions extends readonly string[] | undefined> =
 export function tags<
 	const TOptions extends readonly string[] | undefined = undefined,
 	TNullable extends boolean = false,
-	TDefault extends TagsArray<TOptions> | (() => TagsArray<TOptions>) | undefined = undefined,
+	TDefault extends
+		| TagsArray<TOptions>
+		| (() => TagsArray<TOptions>)
+		| undefined = undefined,
 >({
 	options,
 	nullable = false as TNullable,
@@ -392,8 +395,7 @@ export function json<
 		driverData: string;
 	}>({
 		dataType: () => 'text',
-		toDriver: (value: TSchema['infer']): string =>
-			JSON.stringify(value),
+		toDriver: (value: TSchema['infer']): string => JSON.stringify(value),
 		fromDriver: (value: string): TSchema['infer'] => {
 			// Let JSON.parse throw on invalid JSON
 			const parsed = JSON.parse(value);
@@ -401,9 +403,7 @@ export function json<
 			// Validate with Arktype
 			const result = schema(parsed) as TSchema['infer'] | ArkErrors;
 			if (result instanceof type.errors) {
-				throw new Error(
-					`JSON validation failed: ${result.summary}`,
-				);
+				throw new Error(`JSON validation failed: ${result.summary}`);
 			}
 
 			return result;

--- a/packages/epicenter/src/indexes/sqlite/schema/index.ts
+++ b/packages/epicenter/src/indexes/sqlite/schema/index.ts
@@ -4,12 +4,12 @@
  * Column builders and schema conversion tools for working with Drizzle ORM.
  */
 
-// Column builders for defining Drizzle schemas
-export { id, text, integer, real, boolean, date, tags } from './builders';
+export type { WorkspaceSchemaToDrizzleTables } from '../../../core/schema/converters/drizzle';
 
 // Schema converter (Epicenter → Drizzle)
 export {
-	convertWorkspaceSchemaToDrizzle,
 	convertTableSchemaToDrizzle,
+	convertWorkspaceSchemaToDrizzle,
 } from '../../../core/schema/converters/drizzle';
-export type { WorkspaceSchemaToDrizzleTables } from '../../../core/schema/converters/drizzle';
+// Column builders for defining Drizzle schemas
+export { boolean, date, id, integer, real, tags, text } from './builders';

--- a/packages/epicenter/src/indexes/sqlite/sqlite-index.ts
+++ b/packages/epicenter/src/indexes/sqlite/sqlite-index.ts
@@ -6,15 +6,15 @@ import {
 	type BetterSQLite3Database,
 	drizzle,
 } from 'drizzle-orm/better-sqlite3';
-import { type SQLiteTable, getTableConfig } from 'drizzle-orm/sqlite-core';
+import { getTableConfig, type SQLiteTable } from 'drizzle-orm/sqlite-core';
 import { extractErrorMessage } from 'wellcrafted/error';
 import { tryAsync } from 'wellcrafted/result';
 import { defineQuery } from '../../core/actions';
 import { IndexErr, IndexError } from '../../core/errors';
 import {
+	defineIndexExports,
 	type Index,
 	type IndexContext,
-	defineIndexExports,
 } from '../../core/indexes';
 import type { WorkspaceSchema } from '../../core/schema';
 import { convertWorkspaceSchemaToDrizzle } from '../../core/schema/converters/drizzle';
@@ -143,7 +143,10 @@ export const sqliteIndex = (async <TSchema extends WorkspaceSchema>({
 					logger.log(
 						IndexError({
 							message: `SQLite index onAdd: validation failed for ${table.name}`,
-							context: { tableName: table.name, validationErrors: result.error.summary },
+							context: {
+								tableName: table.name,
+								validationErrors: result.error.summary,
+							},
 							cause: undefined,
 						}),
 					);
@@ -178,7 +181,10 @@ export const sqliteIndex = (async <TSchema extends WorkspaceSchema>({
 					logger.log(
 						IndexError({
 							message: `SQLite index onUpdate: validation failed for ${table.name}`,
-							context: { tableName: table.name, validationErrors: result.error.summary },
+							context: {
+								tableName: table.name,
+								validationErrors: result.error.summary,
+							},
 							cause: undefined,
 						}),
 					);

--- a/packages/epicenter/src/server/mcp.ts
+++ b/packages/epicenter/src/server/mcp.ts
@@ -7,7 +7,7 @@ import {
 	McpError,
 } from '@modelcontextprotocol/sdk/types.js';
 import type { TaggedError } from 'wellcrafted/error';
-import { type Result, isResult } from 'wellcrafted/result';
+import { isResult, type Result } from 'wellcrafted/result';
 import type { Action } from '../core/actions';
 import {
 	type EpicenterClient,

--- a/packages/epicenter/src/server/server.ts
+++ b/packages/epicenter/src/server/server.ts
@@ -3,11 +3,11 @@ import { swaggerUI } from '@hono/swagger-ui';
 import { Scalar } from '@scalar/hono-api-reference';
 import { Hono } from 'hono';
 import { describeRoute, openAPIRouteHandler, validator } from 'hono-openapi';
-import { Err, Ok, isResult } from 'wellcrafted/result';
+import { Err, isResult, Ok } from 'wellcrafted/result';
 import {
+	createEpicenterClient,
 	type EpicenterClient,
 	type EpicenterConfig,
-	createEpicenterClient,
 	forEachAction,
 } from '../core/epicenter';
 import type { AnyWorkspaceConfig } from '../core/workspace';

--- a/packages/epicenter/tsconfig.json
+++ b/packages/epicenter/tsconfig.json
@@ -1,34 +1,34 @@
 {
-  "compilerOptions": {
-    // Environment setup & latest features
-    "lib": ["ESNext"],
-    "target": "es2022",
-    "module": "Preserve",
-    "moduleDetection": "force",
-    "allowJs": true,
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "isolatedModules": true,
+	"compilerOptions": {
+		// Environment setup & latest features
+		"lib": ["ESNext"],
+		"target": "es2022",
+		"module": "Preserve",
+		"moduleDetection": "force",
+		"allowJs": true,
+		"resolveJsonModule": true,
+		"esModuleInterop": true,
+		"isolatedModules": true,
 
-    // Bundler mode
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
-    "noEmit": true,
+		// Bundler mode
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"verbatimModuleSyntax": true,
+		"noEmit": true,
 
-    // Source maps for debugging
-    "sourceMap": true,
+		// Source maps for debugging
+		"sourceMap": true,
 
-    // Best practices
-    "strict": true,
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
+		// Best practices
+		"strict": true,
+		"skipLibCheck": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedIndexedAccess": true,
+		"noImplicitOverride": true,
 
-    // Some stricter flags (disabled by default)
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noPropertyAccessFromIndexSignature": false
-  }
+		// Some stricter flags (disabled by default)
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noPropertyAccessFromIndexSignature": false
+	}
 }


### PR DESCRIPTION
Updates biome.jsonc schema version from 2.3.1 to 2.3.7 to match the CI environment. The version mismatch was causing the Code quality workflow to fail with a deserialize warning.

Also runs the formatter to fix import ordering issues in 55 files, primarily in `packages/epicenter` and `examples/`. These were flagged by Biome's `organizeImports` rule.