### PR TITLE
feat(clippings): add books and bookExcerpts tables

### DIFF
--- a/examples/content-hub/clippings/clippings.workspace.ts
+++ b/examples/content-hub/clippings/clippings.workspace.ts
@@ -70,6 +70,21 @@ export const clippings = defineWorkspace({
 			quality: select({ options: QUALITY_OPTIONS }),
 			addedAt: date(),
 		},
+		books: {
+			id: id(),
+			title: text(),
+			author: text(),
+			addedAt: date(),
+			readAt: date({ nullable: true }),
+		},
+		bookClippings: {
+			id: id(),
+			bookId: text(),
+			content: text(),
+			comment: text({ nullable: true }),
+			createdAt: date(),
+			updatedAt: date(),
+		},
 	},
 
 	indexes: {
@@ -380,6 +395,81 @@ export const clippings = defineWorkspace({
 					title,
 					quality,
 					addedAt: now,
+				});
+
+				return Ok(undefined);
+			},
+		}),
+
+		/**
+		 * Add a book
+		 *
+		 * Creates a new book entry. Returns the book ID for use with addBookClipping.
+		 */
+		addBook: defineMutation({
+			input: type({
+				title: 'string',
+				author: 'string',
+				'readAt?': 'string',
+			}),
+			handler: ({ title, author, readAt }) => {
+				const now = DateWithTimezone({
+					date: new Date(),
+					timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+				}).toJSON();
+
+				const bookId = generateId();
+
+				db.books.insert({
+					id: bookId,
+					title,
+					author,
+					addedAt: now,
+					readAt: readAt
+						? DateWithTimezone({
+								date: new Date(readAt),
+								timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+							}).toJSON()
+						: null,
+				});
+
+				return Ok({ bookId });
+			},
+		}),
+
+		/**
+		 * Add a clipping from a book
+		 *
+		 * Creates a new clipping associated with an existing book.
+		 */
+		addBookClipping: defineMutation({
+			input: type({
+				bookId: 'string',
+				content: 'string',
+				'comment?': 'string',
+			}),
+			handler: ({ bookId, content, comment }) => {
+				// Verify the book exists
+				const book = db.books.get(bookId);
+				if (!book) {
+					return Err({
+						message: 'Book not found',
+						context: { bookId },
+					});
+				}
+
+				const now = DateWithTimezone({
+					date: new Date(),
+					timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+				}).toJSON();
+
+				db.bookClippings.insert({
+					id: generateId(),
+					bookId,
+					content,
+					comment: comment ?? null,
+					createdAt: now,
+					updatedAt: now,
 				});
 
 				return Ok(undefined);

--- a/examples/content-hub/clippings/clippings.workspace.ts
+++ b/examples/content-hub/clippings/clippings.workspace.ts
@@ -77,7 +77,7 @@ export const clippings = defineWorkspace({
 			addedAt: date(),
 			readAt: date({ nullable: true }),
 		},
-		bookClippings: {
+		bookExcerpts: {
 			id: id(),
 			bookId: text(),
 			content: text(),
@@ -407,11 +407,7 @@ export const clippings = defineWorkspace({
 		 * Creates a new book entry. Returns the book ID for use with addBookClipping.
 		 */
 		addBook: defineMutation({
-			input: type({
-				title: 'string',
-				author: 'string',
-				'readAt?': 'string',
-			}),
+			input: db.books.validators.toArktype().pick('title', 'author', 'readAt'),
 			handler: ({ title, author, readAt }) => {
 				const now = DateWithTimezone({
 					date: new Date(),
@@ -425,12 +421,7 @@ export const clippings = defineWorkspace({
 					title,
 					author,
 					addedAt: now,
-					readAt: readAt
-						? DateWithTimezone({
-								date: new Date(readAt),
-								timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-							}).toJSON()
-						: null,
+					readAt: readAt ?? null,
 				});
 
 				return Ok({ bookId });
@@ -438,16 +429,14 @@ export const clippings = defineWorkspace({
 		}),
 
 		/**
-		 * Add a clipping from a book
+		 * Add an excerpt from a book
 		 *
-		 * Creates a new clipping associated with an existing book.
+		 * Creates a new excerpt associated with an existing book.
 		 */
-		addBookClipping: defineMutation({
-			input: type({
-				bookId: 'string',
-				content: 'string',
-				'comment?': 'string',
-			}),
+		addBookExcerpt: defineMutation({
+			input: db.bookExcerpts.validators
+				.toArktype()
+				.pick('bookId', 'content', 'comment'),
 			handler: ({ bookId, content, comment }) => {
 				// Verify the book exists
 				const book = db.books.get(bookId);
@@ -463,7 +452,7 @@ export const clippings = defineWorkspace({
 					timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 				}).toJSON();
 
-				db.bookClippings.insert({
+				db.bookExcerpts.insert({
 					id: generateId(),
 					bookId,
 					content,


### PR DESCRIPTION
This adds support for tracking books and their excerpts in the clippings workspace.

Two new tables:
- `books`: id, title, author, addedAt, readAt (nullable)
- `bookExcerpts`: id, bookId, content, comment (nullable), createdAt, updatedAt

Two new mutations:
- `addBook`: creates a book entry, returns `{ bookId }`
- `addBookExcerpt`: adds an excerpt to an existing book (validates book exists)

The mutation inputs are derived from table validators using `.toArktype().pick()` to keep schemas in sync with table definitions.