### PR TITLE
fix: resolve biome lint errors and update to latest

### DIFF
--- a/apps/whispering/svelte.config.js
+++ b/apps/whispering/svelte.config.js
@@ -8,14 +8,12 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		alias: {
-			'#': '../../packages/ui/src',
-		},
 		adapter: staticAdapter({
 			fallback: 'index.html', // SPA fallback for dynamic routes
 		}),
 		alias: {
 			$routes: './src/routes',
+			'#': '../../packages/ui/src',
 		},
 	},
 

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.3.7/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.3.1/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.3.1/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -29,7 +29,7 @@
 			"!.DS_Store",
 			"!**/*.svelte",
 			"!**/*.astro",
-			"!docs/articles/**"
+			"!docs/articles"
 		]
 	},
 	"formatter": {

--- a/bun.lock
+++ b/bun.lock
@@ -346,7 +346,7 @@
     },
   },
   "catalog": {
-    "@biomejs/biome": "^2.2.6",
+    "@biomejs/biome": "latest",
     "@lucide/svelte": "^0.536.0",
     "@sveltejs/kit": "^2.37.0",
     "@sveltejs/vite-plugin-svelte": "^6.1.3",
@@ -449,23 +449,23 @@
 
     "@better-fetch/fetch": ["@better-fetch/fetch@1.1.18", "", {}, "sha512-rEFOE1MYIsBmoMJtQbl32PGHHXuG2hDxvEd7rUHE0vCBoFQVSDqaVs9hkZEtHCxRoY+CljXKFCOuJ8uxqw1LcA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.3.7", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.7", "@biomejs/cli-darwin-x64": "2.3.7", "@biomejs/cli-linux-arm64": "2.3.7", "@biomejs/cli-linux-arm64-musl": "2.3.7", "@biomejs/cli-linux-x64": "2.3.7", "@biomejs/cli-linux-x64-musl": "2.3.7", "@biomejs/cli-win32-arm64": "2.3.7", "@biomejs/cli-win32-x64": "2.3.7" }, "bin": { "biome": "bin/biome" } }, "sha512-CTbAS/jNAiUc6rcq94BrTB8z83O9+BsgWj2sBCQg9rD6Wkh2gjfR87usjx0Ncx0zGXP1NKgT7JNglay5Zfs9jw=="],
+    "@biomejs/biome": ["@biomejs/biome@2.3.8", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.8", "@biomejs/cli-darwin-x64": "2.3.8", "@biomejs/cli-linux-arm64": "2.3.8", "@biomejs/cli-linux-arm64-musl": "2.3.8", "@biomejs/cli-linux-x64": "2.3.8", "@biomejs/cli-linux-x64-musl": "2.3.8", "@biomejs/cli-win32-arm64": "2.3.8", "@biomejs/cli-win32-x64": "2.3.8" }, "bin": { "biome": "bin/biome" } }, "sha512-Qjsgoe6FEBxWAUzwFGFrB+1+M8y/y5kwmg5CHac+GSVOdmOIqsAiXM5QMVGZJ1eCUCLlPZtq4aFAQ0eawEUuUA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LirkamEwzIUULhXcf2D5b+NatXKeqhOwilM+5eRkbrnr6daKz9rsBL0kNZ16Hcy4b8RFq22SG4tcLwM+yx/wFA=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-HM4Zg9CGQ3txTPflxD19n8MFPrmUAjaC7PQdLkugeeC0cQ+PiVrd7i09gaBS/11QKsTDBJhVg85CEIK9f50Qww=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-Q4TO633kvrMQkKIV7wmf8HXwF0dhdTD9S458LGE24TYgBjSRbuhvio4D5eOQzirEYg6eqxfs53ga/rbdd8nBKg=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-lUDQ03D7y/qEao7RgdjWVGCu+BLYadhKTm40HkpJIi6kn8LSv5PAwRlew/DmwP4YZ9ke9XXoTIQDO1vAnbRZlA=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-inHOTdlstUBzgjDcx0ge71U4SVTbwAljmkfi3MC5WzsYCRhancqfeL+sa4Ke6v2ND53WIwCFD5hGsYExoI3EZQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-Uo1OJnIkJgSgF+USx970fsM/drtPcQ39I+JO+Fjsaa9ZdCN1oysQmy6oAGbyESlouz+rzEckLTF6DS7cWse95g=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-/afy8lto4CB8scWfMdt+NoCZtatBUF62Tk3ilWH2w8ENd5spLhM77zKlFZEvsKJv9AFNHknMl03zO67CiklL2Q=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-PShR4mM0sjksUMyxbyPNMxoKFPVF48fU8Qe8Sfx6w6F42verbwRLbz+QiKNiDPRJwUoMG1nPM50OBL3aOnTevA=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.7", "", { "os": "linux", "cpu": "x64" }, "sha512-fJMc3ZEuo/NaMYo5rvoWjdSS5/uVSW+HPRQujucpZqm2ZCq71b8MKJ9U4th9yrv2L5+5NjPF0nqqILCl8HY/fg=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.8", "", { "os": "linux", "cpu": "x64" }, "sha512-QDPMD5bQz6qOVb3kiBui0zKZXASLo0NIQ9JVJio5RveBEFgDgsvJFUvZIbMbUZT3T00M/1wdzwWXk4GIh0KaAw=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.7", "", { "os": "linux", "cpu": "x64" }, "sha512-CQUtgH1tIN6e5wiYSJqzSwJumHYolNtaj1dwZGCnZXm2PZU1jOJof9TsyiP3bXNDb+VOR7oo7ZvY01If0W3iFQ=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.8", "", { "os": "linux", "cpu": "x64" }, "sha512-YGLkqU91r1276uwSjiUD/xaVikdxgV1QpsicT0bIA1TaieM6E5ibMZeSyjQ/izBn4tKQthUSsVZacmoJfa3pDA=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-aJAE8eCNyRpcfx2JJAtsPtISnELJ0H4xVVSwnxm13bzI8RwbXMyVtxy2r5DV1xT3WiSP+7LxORcApWw0LM8HiA=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-H4IoCHvL1fXKDrTALeTKMiE7GGWFAraDwBYFquE/L/5r1927Te0mYIGseXi4F+lrrwhSWbSGt5qPFswNoBaCxg=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.7", "", { "os": "win32", "cpu": "x64" }, "sha512-pulzUshqv9Ed//MiE8MOUeeEkbkSHVDVY5Cz5wVAnH1DUqliCQG3j6s1POaITTFqFfo7AVIx2sWdKpx/GS+Nqw=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.8", "", { "os": "win32", "cpu": "x64" }, "sha512-RguzimPoZWtBapfKhKjcWXBVI91tiSprqdBYu7tWhgN8pKRZhw24rFeNZTNf6UiBfjCYCi9eFQs/JzJZIhuK4w=="],
 
     "@capsizecss/unpack": ["@capsizecss/unpack@3.0.1", "", { "dependencies": { "fontkit": "^2.0.2" } }, "sha512-8XqW8xGn++Eqqbz3e9wKuK7mxryeRjs4LOHLxbh2lwKeSbuNR4NFifDZT4KzvjU6HMOPbiNTsWpniK5EJfTWkg=="],
 

--- a/examples/basic-workspace/yjs-persistence.test.ts
+++ b/examples/basic-workspace/yjs-persistence.test.ts
@@ -1,6 +1,5 @@
-import { afterAll, beforeAll, expect, test } from 'bun:test';
+import { expect, test } from 'bun:test';
 import { existsSync } from 'node:fs';
-import type { EpicenterClient } from '@epicenter/hq';
 import { createEpicenterClient } from '@epicenter/hq';
 import epicenterConfig from './epicenter.config';
 

--- a/examples/content-hub/email/email.workspace.ts
+++ b/examples/content-hub/email/email.workspace.ts
@@ -3,7 +3,6 @@ import {
 	date,
 	defineWorkspace,
 	id,
-	isDateWithTimezoneString,
 	markdownIndex,
 	type SerializedRow,
 	sqliteIndex,

--- a/examples/content-hub/epicenter/epicenter.workspace.ts
+++ b/examples/content-hub/epicenter/epicenter.workspace.ts
@@ -3,7 +3,6 @@ import {
 	date,
 	defineWorkspace,
 	id,
-	isDateWithTimezoneString,
 	markdownIndex,
 	type SerializedRow,
 	select,

--- a/examples/content-hub/pages/pages.workspace.ts
+++ b/examples/content-hub/pages/pages.workspace.ts
@@ -136,7 +136,7 @@ export const pages = defineWorkspace({
 
 			try {
 				const date = new Date(isoDate);
-				if (isNaN(date.getTime())) return null;
+				if (Number.isNaN(date.getTime())) return null;
 
 				return DateWithTimezone({ date, timezone }).toJSON();
 			} catch {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 			"nanoid": "^5.1.5",
 			"wellcrafted": "^0.23.1",
 			"date-fns": "^4.1.0",
-			"@biomejs/biome": "^2.2.6",
+			"@biomejs/biome": "latest",
 			"turbo": "^2.5.8",
 			"concurrently": "^9.2.1"
 		}

--- a/packages/epicenter/src/cli/cli.ts
+++ b/packages/epicenter/src/cli/cli.ts
@@ -2,10 +2,9 @@ import type { TaggedError } from 'wellcrafted/error';
 import { isResult, type Result } from 'wellcrafted/result';
 import type { Argv } from 'yargs';
 import yargs from 'yargs';
-import { type WorkspaceExports, walkActions } from '../core/actions';
+import { walkActions } from '../core/actions';
 import type { EpicenterConfig } from '../core/epicenter';
 import { createEpicenterClient } from '../core/epicenter';
-import type { WorkspaceClient } from '../core/workspace';
 import { DEFAULT_PORT, startServer } from './server';
 import { standardSchemaToYargs } from './standardschema-to-yargs';
 

--- a/packages/epicenter/src/cli/load-config.test.ts
+++ b/packages/epicenter/src/cli/load-config.test.ts
@@ -38,7 +38,7 @@ describe('loadEpicenterConfig', () => {
 	});
 
 	test('throws error when no config file found', async () => {
-		const nonExistentDir = '/tmp/nonexistent-epicenter-test-dir-' + Date.now();
+		const nonExistentDir = `/tmp/nonexistent-epicenter-test-dir-${Date.now()}`;
 
 		await expect(loadEpicenterConfig(nonExistentDir)).rejects.toThrow(
 			/No epicenter config file found/,

--- a/packages/epicenter/src/cli/server.ts
+++ b/packages/epicenter/src/cli/server.ts
@@ -25,7 +25,7 @@ export async function startServer(
 
 	const { app, client } = await createServer(config);
 	const port =
-		options.port ?? Number.parseInt(process.env.PORT ?? String(DEFAULT_PORT));
+		options.port ?? Number.parseInt(process.env.PORT ?? String(DEFAULT_PORT), 10);
 
 	const server = Bun.serve({
 		fetch: app.fetch,

--- a/packages/epicenter/src/cli/standardschema-to-yargs.ts
+++ b/packages/epicenter/src/cli/standardschema-to-yargs.ts
@@ -215,9 +215,6 @@ function addFieldByType({
 				demandOption: isRequired,
 			});
 			break;
-
-		case 'object':
-		case 'null':
 		default:
 			// For complex types, omit 'type' - yargs accepts any value
 			// Validation happens via Standard Schema at runtime

--- a/packages/epicenter/src/core/db/core-types.test.ts
+++ b/packages/epicenter/src/core/db/core-types.test.ts
@@ -145,10 +145,10 @@ describe('YjsDoc Type Inference', () => {
 					addedNotifications.push(result.data);
 				}
 			},
-			onUpdate: (result) => {
+			onUpdate: (_result) => {
 				// result type should be: Result<{ id: string; message: string; read: boolean }, ArkErrors>
 			},
-			onDelete: (id) => {
+			onDelete: (_id) => {
 				// id type should be: string
 			},
 		});
@@ -185,7 +185,7 @@ describe('YjsDoc Type Inference', () => {
 
 		const article1Result = doc.articles.get({ id: '1' });
 		expect(article1Result).not.toBeNull();
-		if (article1Result && article1Result.data) {
+		if (article1Result?.data) {
 			expect(article1Result.data.description).toBeNull();
 			expect(article1Result.data.content).toBeNull();
 		}
@@ -199,7 +199,7 @@ describe('YjsDoc Type Inference', () => {
 		});
 
 		const article2Result = doc.articles.get({ id: '2' });
-		if (article2Result && article2Result.data) {
+		if (article2Result?.data) {
 			expect(article2Result.data.description).toBeInstanceOf(Y.Text);
 			expect(article2Result.data.content).toBeInstanceOf(Y.Text);
 		}
@@ -247,10 +247,10 @@ describe('YjsDoc Type Inference', () => {
 
 		expect(authorResult).not.toBeNull();
 		expect(bookResult).not.toBeNull();
-		if (authorResult && authorResult.data) {
+		if (authorResult?.data) {
 			expect(authorResult.data.name).toBe('John Doe');
 		}
-		if (bookResult && bookResult.data) {
+		if (bookResult?.data) {
 			expect(bookResult.data.title).toBe('My Book');
 		}
 	});
@@ -299,7 +299,7 @@ describe('YjsDoc Type Inference', () => {
 		// Test retrieval and mutations
 		const retrievedResult = doc.documents.get({ id: 'doc-1' });
 
-		if (retrievedResult && retrievedResult.data) {
+		if (retrievedResult?.data) {
 			const retrieved = retrievedResult.data;
 			// These should all be properly typed
 			expect(retrieved.body).toBeInstanceOf(Y.Text);

--- a/packages/epicenter/src/core/db/core.test.ts
+++ b/packages/epicenter/src/core/db/core.test.ts
@@ -26,7 +26,7 @@ describe('createEpicenterDb', () => {
 		// Retrieve the row
 		const result = doc.posts.get({ id: '1' });
 		expect(result).not.toBeNull();
-		if (result && result.data) {
+		if (result?.data) {
 			expect(result.data.title).toBe('Test Post');
 			expect(result.data.viewCount).toBe(0);
 			expect(result.data.published).toBe(false);
@@ -56,10 +56,10 @@ describe('createEpicenterDb', () => {
 		const row2 = doc.posts.get({ id: '2' });
 		expect(row1).not.toBeNull();
 		expect(row2).not.toBeNull();
-		if (row1 && row1.data) {
+		if (row1?.data) {
 			expect(row1.data.title).toBe('Post 1');
 		}
-		if (row2 && row2.data) {
+		if (row2?.data) {
 			expect(row2.data.title).toBe('Post 2');
 		}
 	});
@@ -133,7 +133,7 @@ describe('createEpicenterDb', () => {
 		// Get returns Y.js objects
 		const result1 = doc.posts.get({ id: '1' });
 		expect(result1).not.toBeNull();
-		if (result1 && result1.data) {
+		if (result1?.data) {
 			expect(result1.data.title).toBeInstanceOf(Y.Text);
 			expect(result1.data.tags).toBeInstanceOf(Y.Array);
 			expect(result1.data.title.toString()).toBe('Hello World');

--- a/packages/epicenter/src/core/db/table-helper.ts
+++ b/packages/epicenter/src/core/db/table-helper.ts
@@ -1,4 +1,4 @@
-import { ArkErrors, type } from 'arktype';
+import { type ArkErrors, type } from 'arktype';
 import { createTaggedError } from 'wellcrafted/error';
 import { Err, Ok, type Result } from 'wellcrafted/result';
 import * as Y from 'yjs';

--- a/packages/epicenter/src/core/epicenter.test.ts
+++ b/packages/epicenter/src/core/epicenter.test.ts
@@ -86,19 +86,19 @@ describe('Action Exposure and Dependency Resolution', () => {
 		await using client = await createEpicenterClient(epicenter);
 
 		// BOTH workspaces are exposed by their ids
-		expect(client['a']).toBeDefined();
-		expect(client['b']).toBeDefined();
+		expect(client.a).toBeDefined();
+		expect(client.b).toBeDefined();
 
 		// Both have their actions
-		expect(client['a']!.getValue).toBeDefined();
-		expect(client['b']!.getValue).toBeDefined();
-		expect(client['b']!.getValueFromDependency).toBeDefined();
+		expect(client.a?.getValue).toBeDefined();
+		expect(client.b?.getValue).toBeDefined();
+		expect(client.b?.getValueFromDependency).toBeDefined();
 
 		// Can call actions on both
-		const resultA = await client['a']!.getValue();
+		const resultA = await client.a?.getValue();
 		expect(resultA.data).toBe('value-from-a');
 
-		const resultB = await client['b']!.getValue();
+		const resultB = await client.b?.getValue();
 		expect(resultB.data).toBe('value-from-b');
 	});
 
@@ -133,15 +133,15 @@ describe('Action Exposure and Dependency Resolution', () => {
 		await using client = await createEpicenterClient(epicenter);
 
 		// All workspaces are exposed
-		expect(client['a']).toBeDefined();
-		expect(client['b']).toBeDefined();
-		expect(client['c']).toBeDefined();
+		expect(client.a).toBeDefined();
+		expect(client.b).toBeDefined();
+		expect(client.c).toBeDefined();
 
 		// Can call actions on all workspaces
-		const resultA = await client['a']!.getValue();
+		const resultA = await client.a?.getValue();
 		expect(resultA.data).toBe('value-from-a');
 
-		const resultB = await client['b']!.getValueFromDependency!();
+		const resultB = await client.b?.getValueFromDependency?.();
 		expect(resultB.data).toBe('value-from-a');
 	});
 
@@ -158,18 +158,18 @@ describe('Action Exposure and Dependency Resolution', () => {
 		await using client = await createEpicenterClient(epicenter);
 
 		// All three workspaces exposed
-		expect(client['a']).toBeDefined();
-		expect(client['b']).toBeDefined();
-		expect(client['c']).toBeDefined();
+		expect(client.a).toBeDefined();
+		expect(client.b).toBeDefined();
+		expect(client.c).toBeDefined();
 
 		// All have their actions
-		const resultA = await client['a']!.getValue();
+		const resultA = await client.a?.getValue();
 		expect(resultA.data).toBe('value-from-a');
 
-		const resultB = await client['b']!.getValue();
+		const resultB = await client.b?.getValue();
 		expect(resultB.data).toBe('value-from-b');
 
-		const resultC = await client['c']!.getValue();
+		const resultC = await client.c?.getValue();
 		expect(resultC.data).toBe('value-from-c');
 	});
 });

--- a/packages/epicenter/src/core/epicenter/client.ts
+++ b/packages/epicenter/src/core/epicenter/client.ts
@@ -93,7 +93,7 @@ export async function createEpicenterClient<
 		process.versions != null &&
 		process.versions.node != null;
 
-	let storageDir: AbsolutePath | undefined = undefined;
+	let storageDir: AbsolutePath | undefined ;
 	if (isNode) {
 		const configuredPath = config.storageDir ?? process.cwd();
 		storageDir = path.resolve(configuredPath) as AbsolutePath;

--- a/packages/epicenter/src/core/schema/converters/arktype.test.ts
+++ b/packages/epicenter/src/core/schema/converters/arktype.test.ts
@@ -1,16 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 import { type } from 'arktype';
 import {
-	boolean,
-	date,
 	id,
 	integer,
 	json,
-	real,
 	select,
-	tags,
 	text,
-	ytext,
 } from '../../schema';
 import { tableSchemaToArktypeType } from './arktype';
 

--- a/packages/epicenter/src/core/schema/types.ts
+++ b/packages/epicenter/src/core/schema/types.ts
@@ -13,7 +13,7 @@
  */
 
 import type { Type } from 'arktype';
-import * as Y from 'yjs';
+import type * as Y from 'yjs';
 import type { YRow } from '../db/table-helper';
 import type {
 	DateWithTimezone,

--- a/packages/epicenter/src/core/utils/ytext.test.ts
+++ b/packages/epicenter/src/core/utils/ytext.test.ts
@@ -120,7 +120,7 @@ describe('updateYTextFromString', () => {
 		ytext.insert(0, 'Hello World');
 
 		// Get length before sync
-		const initialLength = ytext.length;
+		const _initialLength = ytext.length;
 
 		// Sync to similar string (should preserve some characters)
 		updateYTextFromString(ytext, 'Hello Universe');

--- a/packages/epicenter/src/core/workspace.test.ts
+++ b/packages/epicenter/src/core/workspace.test.ts
@@ -3,7 +3,6 @@ import path from 'node:path';
 import { type } from 'arktype';
 import { eq } from 'drizzle-orm';
 import { Ok } from 'wellcrafted/result';
-import { markdownIndex } from '../indexes/markdown';
 import { sqliteIndex } from '../indexes/sqlite';
 import { defineMutation, defineQuery } from './actions';
 import { createEpicenterClient, defineEpicenter } from './epicenter';
@@ -506,7 +505,7 @@ describe('createWorkspaceClient - Topological Sort', () => {
 					handler: () => Ok('value-from-b'),
 				}),
 				callA: defineQuery({
-					handler: async () => workspaces['a'].getValueFromA(),
+					handler: async () => workspaces.a.getValueFromA(),
 				}),
 			}),
 		});
@@ -575,10 +574,10 @@ describe('createWorkspaceClient - Topological Sort', () => {
 					handler: () => Ok('value-from-c'),
 				}),
 				getFromA: defineQuery({
-					handler: async () => workspaces['a'].getValue(),
+					handler: async () => workspaces.a.getValue(),
 				}),
 				getFromB: defineQuery({
-					handler: async () => workspaces['b'].getValue(),
+					handler: async () => workspaces.b.getValue(),
 				}),
 			}),
 		});
@@ -610,7 +609,7 @@ describe('createWorkspaceClient - Topological Sort', () => {
  */
 describe('Workspace Action Handlers', () => {
 	const TEST_DIR = path.join(import.meta.dir, '.data/action-handler-test');
-	const TEST_DB = path.join(TEST_DIR, 'test.db');
+	const _TEST_DB = path.join(TEST_DIR, 'test.db');
 	const TEST_MARKDOWN = path.join(TEST_DIR, 'content');
 
 	// Define a test workspace with CRUD operations
@@ -779,7 +778,7 @@ describe('Workspace Action Handlers', () => {
 		});
 
 		expect(createResult.data).toBeDefined();
-		const postId = createResult.data!.id;
+		const postId = createResult.data?.id;
 
 		// Wait for indexes to sync
 		await new Promise((resolve) => setTimeout(resolve, 200));
@@ -811,7 +810,7 @@ describe('Workspace Action Handlers', () => {
 		});
 
 		expect(createResult.data).toBeDefined();
-		const postId = createResult.data!.id;
+		const postId = createResult.data?.id;
 
 		// Update views
 		const updateResult = await client.updateViews({

--- a/packages/epicenter/src/core/workspace/client.ts
+++ b/packages/epicenter/src/core/workspace/client.ts
@@ -190,7 +190,7 @@ export async function initializeWorkspaces<
 			for (const dep of workspaceConfig.dependencies) {
 				// Add edge: dep.id -> id (id depends on dep.id)
 				// Note: Dependencies are already verified in Phase 2
-				dependents.get(dep.id)!.push(id);
+				dependents.get(dep.id)?.push(id);
 
 				// Increment in-degree for the dependent workspace
 				inDegree.set(id, inDegree.get(id)! + 1);
@@ -453,7 +453,7 @@ export async function createWorkspaceClient<
 		process.versions != null &&
 		process.versions.node != null;
 
-	let resolvedStorageDir: AbsolutePath | undefined = undefined;
+	let resolvedStorageDir: AbsolutePath | undefined ;
 	if (isNode) {
 		resolvedStorageDir = path.resolve(process.cwd()) as AbsolutePath;
 	}

--- a/packages/epicenter/src/server/mcp.ts
+++ b/packages/epicenter/src/server/mcp.ts
@@ -88,7 +88,7 @@ export function createMcpServer<
 			const args = request.params.arguments || {};
 
 			// Validate input with Standard Schema
-			let validatedInput: unknown = undefined;
+			let validatedInput: unknown ;
 			if (action.input) {
 				let result = action.input['~standard'].validate(args);
 				if (result instanceof Promise) result = await result;

--- a/packages/epicenter/tests/integration/server.test.ts
+++ b/packages/epicenter/tests/integration/server.test.ts
@@ -102,7 +102,7 @@ describe('Server Integration Tests', () => {
 			workspaces: [blogWorkspace],
 		});
 
-		let app: Awaited<ReturnType<typeof createServer>>['app'];
+		let _app: Awaited<ReturnType<typeof createServer>>['app'];
 		let server: any;
 
 		beforeAll(async () => {
@@ -275,7 +275,7 @@ describe('Server Integration Tests', () => {
 			workspaces: [blogWorkspace, authWorkspace],
 		});
 
-		let app: Awaited<ReturnType<typeof createServer>>['app'];
+		let _app: Awaited<ReturnType<typeof createServer>>['app'];
 		let server: any;
 
 		beforeAll(async () => {


### PR DESCRIPTION
This PR applies Biome auto-fixes to reduce lint errors and updates Biome to the latest version in the catalog.

The auto-fix with `biome lint --write --unsafe` reduced errors from 5 errors + 115 warnings to 4 errors + 74 warnings. The changes include removing unused imports, converting `isNaN` to `Number.isNaN`, fixing folder ignore patterns, and merging duplicate alias objects in svelte.config.js.

Additionally, Biome was updated from ^2.2.6 to "latest" in the catalog (now resolves to 2.3.8), and the schema reference was updated to match.

Remaining lint errors that require manual fixes:
- `as any` usages in tunnel services and test files
- Unused variables with rest destructuring
- A few other unused variables in error handling code