### PR TITLE
feat(table-helper): add strongly-typed RowValidationError with context

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -373,7 +373,7 @@
     "turbo": "^2.5.8",
     "typescript": "^5.8.3",
     "vite": "^7.0.5",
-    "wellcrafted": "^0.23.1",
+    "wellcrafted": "^0.25.0",
     "zod": "^3.25.67",
   },
   "packages": {
@@ -2643,7 +2643,7 @@
 
     "webidl-conversions": ["webidl-conversions@8.0.0", "", {}, "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA=="],
 
-    "wellcrafted": ["wellcrafted@0.23.1", "", {}, "sha512-QgxShbsgsake+pKUyGV/P6jsnLg8xsohRn6CpDZTTflv/lV6dAGAX8CQ8/w4VaqhQCdM2omYsfRqjNWEjN3ICw=="],
+    "wellcrafted": ["wellcrafted@0.25.0", "", {}, "sha512-HSMkCNQLl8rrbEogs5VaPBsSHWPKr2H/E/54LZNMI55BnPPN4tHzdU2tRUPJHKfoYqax3gb4pyQzhJRbIXaNzA=="],
 
     "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 			"drizzle-orm": "^0.44.3",
 			"zod": "^3.25.67",
 			"nanoid": "^5.1.5",
-			"wellcrafted": "^0.23.1",
+			"wellcrafted": "^0.25.0",
 			"date-fns": "^4.1.0",
 			"@biomejs/biome": "latest",
 			"turbo": "^2.5.8",

--- a/packages/epicenter/src/indexes/markdown/markdown-index.ts
+++ b/packages/epicenter/src/indexes/markdown/markdown-index.ts
@@ -499,11 +499,8 @@ export const markdownIndex = (async <TSchema extends WorkspaceSchema>(
 						logger.log(
 							IndexError({
 								message: `YJS observer onAdd: validation failed for ${table.name}`,
-								context: {
-									tableName: table.name,
-									validationErrors: result.error.summary,
-								},
-								cause: undefined,
+								context: result.error.context,
+								cause: result.error,
 							}),
 						);
 						return;
@@ -535,11 +532,8 @@ export const markdownIndex = (async <TSchema extends WorkspaceSchema>(
 						logger.log(
 							IndexError({
 								message: `YJS observer onUpdate: validation failed for ${table.name}`,
-								context: {
-									tableName: table.name,
-									validationErrors: result.error.summary,
-								},
-								cause: undefined,
+								context: result.error.context,
+								cause: result.error,
 							}),
 						);
 						return;

--- a/packages/epicenter/src/indexes/sqlite/sqlite-index.ts
+++ b/packages/epicenter/src/indexes/sqlite/sqlite-index.ts
@@ -143,11 +143,8 @@ export const sqliteIndex = (async <TSchema extends WorkspaceSchema>({
 					logger.log(
 						IndexError({
 							message: `SQLite index onAdd: validation failed for ${table.name}`,
-							context: {
-								tableName: table.name,
-								validationErrors: result.error.summary,
-							},
-							cause: undefined,
+							context: result.error.context,
+							cause: result.error,
 						}),
 					);
 					return;
@@ -181,11 +178,8 @@ export const sqliteIndex = (async <TSchema extends WorkspaceSchema>({
 					logger.log(
 						IndexError({
 							message: `SQLite index onUpdate: validation failed for ${table.name}`,
-							context: {
-								tableName: table.name,
-								validationErrors: result.error.summary,
-							},
-							cause: undefined,
+							context: result.error.context,
+							cause: result.error,
 						}),
 					);
 					return;


### PR DESCRIPTION
This introduces `RowValidationError` with a fixed context type for type-safe validation error handling in the table helpers.

The `RowValidationContext` type now includes:
- `tableName`: The table where validation failed
- `id`: The row ID that failed validation
- `errors`: The full `ArkErrors` object for programmatic access
- `summary`: The human-readable error summary string

This enables consumers to access validation details with full TypeScript inference, and allows the markdown/sqlite indexes to simply spread `result.error.context` when logging errors rather than manually extracting each field.

Also bumps wellcrafted to v0.25.0 which includes the updated `TaggedError` generic order where context is the 2nd parameter and cause is the 3rd.