### PR TITLE
fix(epicenter): use async destroy method in shutdown handler

### DIFF
--- a/packages/epicenter/src/cli/server.ts
+++ b/packages/epicenter/src/cli/server.ts
@@ -81,7 +81,7 @@ export async function startServer(
 		console.log(`\n🛑 Received ${signal}, shutting down gracefully...`);
 
 		server.stop();
-		client[Symbol.dispose]();
+		await client.destroy();
 
 		console.log('✅ Server stopped cleanly\n');
 		process.exit(0);


### PR DESCRIPTION
This fixes the TypeError when pressing Ctrl+C to stop the server. The shutdown handler was calling the non-existent `client[Symbol.dispose]()` synchronous method, but the EpicenterClient only provides async cleanup: `destroy()` and `Symbol.asyncDispose`.

Changed to `await client.destroy()` to properly clean up resources during graceful shutdown. The shutdown function is already async, so this change integrates seamlessly.