### PR TITLE
fix(transcription): convert number input to string for temperature setting

### DIFF
--- a/apps/whispering/src/lib/settings/settings.ts
+++ b/apps/whispering/src/lib/settings/settings.ts
@@ -170,7 +170,16 @@ export const settingsSchema = z.object({
 	// Shared settings in transcription
 	'transcription.outputLanguage': z.enum(SUPPORTED_LANGUAGES).default('auto'),
 	'transcription.prompt': z.string().default(''),
-	'transcription.temperature': z.string().default('0.0'),
+	'transcription.temperature': z
+		.string()
+		.default('0.0')
+		.refine(
+			(val) => {
+				const num = Number.parseFloat(val);
+				return !Number.isNaN(num) && num >= 0 && num <= 1;
+			},
+			{ message: 'Temperature must be a number between 0 and 1' },
+		),
 	// Audio compression settings
 	'transcription.compressionEnabled': z.boolean().default(false),
 	'transcription.compressionOptions': z

--- a/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
@@ -597,7 +597,15 @@
 		placeholder="0"
 		bind:value={
 			() => settings.value['transcription.temperature'],
-			(value) => settings.updateKey('transcription.temperature', value)
+			(value) => {
+				// Convert to number, clamp to valid range [0, 1], then convert to string
+				const numValue = Number(value);
+				if (Number.isNaN(numValue)) {
+					return;
+				}
+				const clampedValue = Math.max(0, Math.min(1, numValue));
+				settings.updateKey('transcription.temperature', clampedValue.toString());
+			}
 		}
 		description={isPromptAndTemperatureNotSupported
 			? 'Temperature is not supported for local models (transcribe-rs)'


### PR DESCRIPTION
## Summary
Updated temperature `number` input to `string` for temperature setting

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [x] `fix`: Bug fix

## Related Issue

<!-- Link to the issue this PR addresses, if applicable -->
Closes #961

## Changes Made
Fixed temperature setting reset bug caused by type mismatch between HTML number input and Zod string schema.

Modified `apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte` to convert number input to string with validation and clamping to [0, 1] range.

Added Zod `.refine()` validation in `apps/whispering/src/lib/settings/settings.ts` to ensure stored temperature values are valid numbers between 0 and 1.

## Testing

<!-- Describe the tests you ran to verify your changes -->

### Desktop App Testing
- [ ] Tested on macOS
- [ ] Tested on Windows
- [x] Tested on Linux
- [ ] Not applicable (web-only change)

### General Testing
- [x] Tested with multiple API providers (if applicable)
- [x] Verified no API keys are exposed in logs or storage
- [x] Checked for console errors
- [ ] Tested on different screen sizes (if UI change)

## Checklist

<!-- Make sure you've completed these steps -->

- [x] My code follows the project's coding standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I've used `type` instead of `interface` in TypeScript
- [x] I've used absolute imports where applicable
- [x] I've tested my changes thoroughly
- [ ] I've added/updated tests for my changes (if applicable)
- [x] My changes don't break existing functionality
- [ ] I've updated documentation (if needed)

## Screenshots/Recordings

<!-- If this is a UI change, please include screenshots or recordings -->

## Additional Notes
The bug affected all transcription services (OpenAI, Groq, Mistral, ElevenLabs, Deepgram) since they all share the same temperature setting. The fix ensures temperature values are properly validated and persisted regardless of which service is selected.

The validation happens at two levels:
1. UI layer: Converts number input to string, handles NaN, clamps to [0, 1]
2. Schema layer: Zod .refine() ensures stored values are always valid numbers in range

This dual validation provides robustness against both user input issues and potential data corruption.