### PR TITLE
fix(whispering): prevent temperature setting from resetting to default

### DIFF
--- a/apps/whispering/src/lib/settings/settings.ts
+++ b/apps/whispering/src/lib/settings/settings.ts
@@ -170,7 +170,7 @@ export const settingsSchema = z.object({
 	// Shared settings in transcription
 	'transcription.outputLanguage': z.enum(SUPPORTED_LANGUAGES).default('auto'),
 	'transcription.prompt': z.string().default(''),
-	'transcription.temperature': z.string().default('0.0'),
+	'transcription.temperature': z.coerce.string().default('0.0'),
 	// Audio compression settings
 	'transcription.compressionEnabled': z.boolean().default(false),
 	'transcription.compressionOptions': z


### PR DESCRIPTION
## Summary

This PR fixes the temperature setting reset bug

## Type of Change

- [X] `fix`: Bug fix

## Related Issue

Closes #961 

## Changes Made

Problem
When users set the Temperature value in transcription settings (e.g., 0.8), it would:
- Reset to 0.0 when navigating away and returning to Settings or Reloading
- Be ignored during transcription (always using default 0.0)

Root Cause
The temperature input uses [type="number"], which returns numeric values, but the settings schema expected string values. This type mismatch caused validation to fail, discarding the user's setting and reverting to the default.

Solution
Changed the schema to use [z.coerce.string()] instead of [z.string()] for the temperature field. This automatically converts number inputs to strings during validation, preserving user settings while maintaining the number input UX.

Files Modified
`apps/whispering/src/lib/settings/settings.ts`

## Testing

 - Set temperature to 0.8, reload page → value persists
 - Verify temperature is included in transcription API calls
 - Check localStorage contains string value "0.8"
