### PR TITLE
chore(ci): sync bun version across all workflows

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     types: [closed]
 
-env:
-  BUN_VERSION: 'latest'
-
 jobs:
   cleanup-preview:
     name: Delete Preview Worker
@@ -18,7 +15,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: ${{ env.BUN_VERSION }}
+          bun-version-file: "package.json"
 
       - name: Delete preview worker
         run: |

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -11,7 +11,6 @@ concurrency:
 
 env:
   NODE_VERSION: '22'
-  BUN_VERSION: 'latest'
 
 jobs:
   validate:
@@ -26,13 +25,12 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: ${{ env.BUN_VERSION }}
+          bun-version-file: "package.json"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'bun'
 
       - name: Install dependencies
         run: bun ci
@@ -83,7 +81,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: ${{ env.BUN_VERSION }}
+          bun-version-file: "package.json"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -149,7 +147,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: ${{ env.BUN_VERSION }}
+          bun-version-file: "package.json"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/pr-preview-builds.yml
+++ b/.github/workflows/pr-preview-builds.yml
@@ -85,7 +85,7 @@ jobs:
       - name: setup bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version-file: "package.json"
 
       - name: Install Vulkan SDK
         if: matrix.platform == 'windows-latest'

--- a/.github/workflows/preview-deployment.yml
+++ b/.github/workflows/preview-deployment.yml
@@ -14,7 +14,6 @@ concurrency:
 
 env:
   NODE_VERSION: '22'
-  BUN_VERSION: 'latest'
 
 jobs:
   deploy-preview:
@@ -31,7 +30,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: ${{ env.BUN_VERSION }}
+          bun-version-file: "package.json"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish-tauri-releases.yml
+++ b/.github/workflows/publish-tauri-releases.yml
@@ -74,7 +74,7 @@ jobs:
       - name: setup bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version-file: "package.json"
 
       # Windows Vulkan SDK installation
       - name: Install Vulkan SDK

--- a/docs/bun-version-sync.md
+++ b/docs/bun-version-sync.md
@@ -1,0 +1,61 @@
+# Syncing Bun Versions Across Local and CI
+
+We had Bun version drift: `package.json` said 1.3.0, local had 1.3.1, and CI used `latest`. Not a crisis, but annoying when debugging CI failures that work locally.
+
+## What We Had Before
+
+The workflows were inconsistent:
+
+```yaml
+# Some workflows used an env variable
+env:
+  BUN_VERSION: 'latest'
+
+- uses: oven-sh/setup-bun@v2
+  with:
+    bun-version: ${{ env.BUN_VERSION }}
+
+# Others just hardcoded "latest"
+- uses: oven-sh/setup-bun@v2
+  with:
+    bun-version: latest
+
+# Only format.yml was doing it right
+- uses: oven-sh/setup-bun@v2
+  with:
+    bun-version-file: "package.json"
+```
+
+Meanwhile `package.json` had `"packageManager": "bun@1.3.0"` which nobody was reading except one workflow.
+
+## The Fix
+
+Make `package.json` the single source of truth.
+
+In `package.json`:
+```json
+"packageManager": "bun@1.3.3"
+```
+
+In every GitHub Actions workflow:
+```yaml
+- name: Setup Bun
+  uses: oven-sh/setup-bun@v2
+  with:
+    bun-version-file: "package.json"
+```
+
+We updated these workflows:
+- `deploy-cloudflare.yml` (3 places)
+- `publish-tauri-releases.yml`
+- `pr-preview-builds.yml`
+- `preview-deployment.yml`
+- `cleanup-preview.yml`
+
+Now when you want to upgrade Bun, change one line in `package.json` and everything follows.
+
+## Pro Tip
+
+The `oven-sh/setup-bun` action reads the version from your `packageManager` field automatically. No need to hardcode versions in workflow files or maintain a separate `.bun-version` file.
+
+This also works with `.tool-versions` if you're using asdf, but `package.json` is already there so why add another file.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 			"concurrently": "^9.2.1"
 		}
 	},
-	"packageManager": "bun@1.3.0",
+	"packageManager": "bun@1.3.3",
 	"scripts": {
 		"build": "turbo run build",
 		"dev": "turbo run dev",


### PR DESCRIPTION
All CI workflows now read the Bun version from package.json's packageManager field instead of using hardcoded "latest" or env variables. This creates a single source of truth for Bun versioning.

Before this change, workflows were inconsistent: some used `BUN_VERSION: 'latest'` env vars, others hardcoded `bun-version: latest`, and only `format.yml` correctly used `bun-version-file`. Meanwhile `package.json` specified `bun@1.3.0` which most workflows ignored.

Now every workflow uses `bun-version-file: "package.json"`, so upgrading Bun is a one-line change. Also bumped to the latest stable version (1.3.3).

Updated workflows:
- `deploy-cloudflare.yml` (3 setup steps)
- `publish-tauri-releases.yml`
- `pr-preview-builds.yml`
- `preview-deployment.yml`
- `cleanup-preview.yml`

Added `docs/bun-version-sync.md` explaining the change and the pattern for future reference.