### PR TITLE
chore: add conductor.json for workspace setup

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,7 @@
+{
+	"scripts": {
+		"setup": "bun install && ln -sf \"$CONDUCTOR_ROOT_PATH/examples/content-hub/.env\" examples/content-hub/.env 2>/dev/null || true",
+		"run": "cd apps/whispering && bun run dev"
+	},
+	"runScriptMode": "nonconcurrent"
+}

--- a/docs/patterns/silent-failure-pattern.md
+++ b/docs/patterns/silent-failure-pattern.md
@@ -1,0 +1,59 @@
+# Silent Failure Pattern in Bash
+
+You might see this pattern in shell scripts:
+
+```bash
+some_command 2>/dev/null || true
+```
+
+Here's what each part does:
+
+## `2>/dev/null`
+
+- `2` is stderr (standard error output)
+- `>` redirects it
+- `/dev/null` is a black hole that discards anything sent to it
+
+This suppresses error messages.
+
+## `|| true`
+
+- `||` means "if the previous command failed, run this"
+- `true` is a command that always succeeds (exit code 0)
+
+This ensures the overall expression always succeeds.
+
+## When to Use It
+
+Use this for optional operations that shouldn't fail your script. For example, symlinking an optional `.env` file:
+
+```bash
+ln -sf "$CONDUCTOR_ROOT_PATH/examples/content-hub/.env" examples/content-hub/.env 2>/dev/null || true
+```
+
+If the source `.env` doesn't exist:
+- Without the pattern: symlink fails → script exits with error
+- With the pattern: symlink silently skipped → script continues
+
+## Real Example
+
+In a setup script where `.env` is optional:
+
+```json
+{
+  "scripts": {
+    "setup": "bun install && ln -sf \"$CONDUCTOR_ROOT_PATH/examples/content-hub/.env\" examples/content-hub/.env 2>/dev/null || true"
+  }
+}
+```
+
+The `bun install` must succeed, but the symlink is best-effort. If someone hasn't created their `.env` yet, setup still completes successfully.
+
+## When NOT to Use It
+
+Don't use this for operations that must succeed. If a failure should stop the script, let it fail naturally:
+
+```bash
+# This SHOULD fail if the database isn't reachable
+./scripts/migrate-db.sh
+```


### PR DESCRIPTION
This adds Conductor configuration to automate workspace setup and provide a one-click run command.

The `conductor.json` configures three things:

1. **Setup script**: Runs `bun install` and symlinks the optional `.env` file from the root repo into `examples/content-hub/.env`. The symlink uses `$CONDUCTOR_ROOT_PATH` so each workspace shares the same env file rather than copying it.

2. **Run script**: Launches the Whispering Tauri app with `cd apps/whispering && bun run dev`.

3. **Nonconcurrent mode**: Ensures clicking "Run" again kills the previous dev server before starting a new one.

Also adds a quick reference doc explaining the `2>/dev/null || true` pattern used for optional operations in shell scripts.