### PR TITLE
chore: migrate to zod v4 and standard schema

### DIFF
--- a/apps/whispering/src/lib/services/http/desktop.ts
+++ b/apps/whispering/src/lib/services/http/desktop.ts
@@ -1,3 +1,4 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { fetch } from '@tauri-apps/plugin-http';
 import { extractErrorMessage } from 'wellcrafted/error';
 import { Err, tryAsync } from 'wellcrafted/result';
@@ -35,7 +36,13 @@ export function createHttpServiceDesktop(): HttpService {
 			const parseResult = await tryAsync({
 				try: async () => {
 					const json = await response.json();
-					return schema.parse(json);
+					const result = await schema['~standard'].validate(json);
+					if (result.issues) {
+						throw new Error(
+							result.issues.map((issue) => issue.message).join(', '),
+						);
+					}
+					return result.value as StandardSchemaV1.InferOutput<typeof schema>;
 				},
 				catch: (error) =>
 					ParseErr({

--- a/apps/whispering/src/lib/services/http/types.ts
+++ b/apps/whispering/src/lib/services/http/types.ts
@@ -1,6 +1,6 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { createTaggedError } from 'wellcrafted/error';
 import type { Result } from 'wellcrafted/result';
-import type { z } from 'zod';
 
 /**
  * Network-level connection failure that prevents the HTTP request from reaching the server.
@@ -48,7 +48,7 @@ export const ResponseErr = (args: Omit<ResponseError, 'name'>) => ({
 });
 
 /**
- * Failed to parse the response body as valid JSON or validate against the Zod schema.
+ * Failed to parse the response body as valid JSON or validate against the schema.
  *
  * Server returned 2xx status but the response body is malformed JSON or doesn't match
  * the expected schema structure/types.
@@ -69,15 +69,17 @@ export type HttpService = {
 	/**
 	 * Makes a POST request with automatic JSON parsing and schema validation.
 	 *
+	 * Accepts any schema that implements the StandardSchemaV1 interface (Zod, Valibot, ArkType, etc.)
+	 *
 	 * **Error Handling Strategy:**
 	 * 1. **Connection Phase:** Catches network-level failures (ConnectionError)
 	 * 2. **Response Phase:** Validates HTTP status codes (ResponseError)
 	 * 3. **Parse Phase:** Validates JSON structure and schema (ParseError)
 	 */
-	post: <TSchema extends z.ZodTypeAny>(config: {
+	post: <TSchema extends StandardSchemaV1>(config: {
 		url: string;
 		body: BodyInit | FormData;
 		schema: TSchema;
 		headers?: Record<string, string>;
-	}) => Promise<Result<z.infer<TSchema>, HttpServiceError>>;
+	}) => Promise<Result<StandardSchemaV1.InferOutput<TSchema>, HttpServiceError>>;
 };

--- a/apps/whispering/src/lib/services/http/web.ts
+++ b/apps/whispering/src/lib/services/http/web.ts
@@ -1,3 +1,4 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { extractErrorMessage } from 'wellcrafted/error';
 import { Err, tryAsync } from 'wellcrafted/result';
 import type { HttpService } from '.';
@@ -34,7 +35,13 @@ export function createHttpServiceWeb(): HttpService {
 			const parseResult = await tryAsync({
 				try: async () => {
 					const json = await response.json();
-					return schema.parse(json);
+					const result = await schema['~standard'].validate(json);
+					if (result.issues) {
+						throw new Error(
+							result.issues.map((issue) => issue.message).join(', '),
+						);
+					}
+					return result.value as StandardSchemaV1.InferOutput<typeof schema>;
 				},
 				catch: (error) =>
 					ParseErr({

--- a/apps/whispering/src/lib/services/transcription/self-hosted/speaches.ts
+++ b/apps/whispering/src/lib/services/transcription/self-hosted/speaches.ts
@@ -47,7 +47,6 @@ export function createSpeachesTranscriptionService({
 				await HttpService.post({
 					url: `${options.baseUrl}/v1/audio/transcriptions`,
 					body: formData,
-					headers: undefined, // No headers needed for Speaches
 					schema: whisperApiResponseSchema,
 				});
 

--- a/bun.lock
+++ b/bun.lock
@@ -381,7 +381,7 @@
     "wellcrafted": "^0.25.0",
     "wrangler": "^4.51.0",
     "yargs": "^18.0.0",
-    "zod": "^3.25.67",
+    "zod": "^4.1.13",
   },
   "packages": {
     "@acemir/cssom": ["@acemir/cssom@0.9.24", "", {}, "sha512-5YjgMmAiT2rjJZU7XK1SNI7iqTy92DpaYVgG6x63FxkJ11UpYfLndHJATtinWJClAXiOlW9XWaUyAQf8pMrQPg=="],
@@ -2720,7 +2720,7 @@
 
     "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.1.13", "", {}, "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig=="],
 
     "zod-openapi": ["zod-openapi@5.4.3", "", { "peerDependencies": { "zod": "^3.25.74 || ^4.0.0" } }, "sha512-6kJ/gJdvHZtuxjYHoMtkl2PixCwRuZ/s79dVkEr7arHvZGXfx7Cvh53X3HfJ5h9FzGelXOXlnyjwfX0sKEPByw=="],
 
@@ -2748,8 +2748,6 @@
 
     "@astrojs/yaml2ts/yaml": ["yaml@2.8.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw=="],
 
-    "@better-auth/core/zod": ["zod@4.1.13", "", {}, "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig=="],
-
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
     "@epicenter/opencode/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.15.1", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-W/XlN9c528yYn+9MQkVjxiTPgPxoxt+oczfjHBDsJx0+59+O7B75Zhsp0B16Xbwbz8ANISDajh6+V7nIcPMc5w=="],
@@ -2772,13 +2770,15 @@
 
     "@eslint/eslintrc/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
+    "@hono/zod-validator/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
     "@libsql/hrana-client/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "@libsql/isomorphic-ws/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
-    "@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+    "@mistralai/mistralai/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "@modelcontextprotocol/sdk/zod": ["zod@4.1.13", "", {}, "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig=="],
+    "@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
     "@octokit/core/@octokit/graphql": ["@octokit/graphql@7.1.1", "", { "dependencies": { "@octokit/request": "^8.4.1", "@octokit/types": "^13.0.0", "universal-user-agent": "^6.0.0" } }, "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g=="],
 
@@ -2868,7 +2868,7 @@
 
     "astro/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
-    "better-auth/zod": ["zod@4.1.13", "", {}, "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig=="],
+    "astro/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "bits-ui/runed": ["runed@0.29.2", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-0cq6cA6sYGZwl/FvVqjx9YN+1xEBu9sDDyuWdDW1yWX7JF2wmvmVKfH+hVCZs+csW+P3ARH92MjI3H9QTagOQA=="],
 
@@ -2938,6 +2938,8 @@
 
     "node-stdlib-browser/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
+    "openai/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
     "p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "paneforge/runed": ["runed@0.23.4", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA=="],
@@ -2999,6 +3001,8 @@
     "yaml-language-server/yaml": ["yaml@2.7.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ=="],
 
     "youch/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "zod-to-ts/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@apidevtools/json-schema-ref-parser/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 

--- a/docs/specs/20251128T100000-zod-v4-migration.md
+++ b/docs/specs/20251128T100000-zod-v4-migration.md
@@ -214,3 +214,73 @@ The actual time depends on:
 - Complexity of error customization
 - Usage of `z.function()` schemas
 - Test coverage to validate changes
+
+## Review Notes
+
+### Migration Completed: 2025-11-28
+
+**Changes Made:**
+
+1. **Updated Zod version** in `package.json` catalog:
+   - From: `"zod": "^3.25.67"`
+   - To: `"zod": "^4.1.13"`
+
+2. **Updated `z.ZodTypeAny` to `z.ZodType`** in `apps/whispering/src/lib/services/http/types.ts`:
+   - Zod v4 eliminated `ZodTypeAny` in favor of the simpler `ZodType` generic constraint
+   - This change affects how generic schema parameters are typed
+
+3. **Removed explicit `headers: undefined`** in `apps/whispering/src/lib/services/transcription/self-hosted/speaches.ts`:
+   - With `exactOptionalPropertyTypes: true`, you cannot pass `undefined` to optional properties
+   - Simply omitting the property is the correct pattern
+
+### Breaking Changes NOT Encountered
+
+The codebase does not use any of these deprecated Zod v3 patterns:
+- `{ message: ... }` error customization (none found)
+- `invalid_type_error` or `required_error` parameters (none found)
+- `errorMap` parameter (none found)
+- `.email()`, `.uuid()`, `.ip()` string validators (none found)
+- `.strict()`, `.passthrough()`, `.deepPartial()`, `.merge()` object methods (none found on Zod objects)
+- `z.function()` schemas (none found)
+- `.format()`, `.flatten()`, `.addIssue()` error methods (none found)
+
+### Pre-existing Issues (Unrelated to Zod)
+
+The following errors appeared during `bun run check` but are NOT related to Zod:
+
+1. **`better-auth/crypto` import error** in `packages/db`:
+   - `hashToBase64` is not exported from `better-auth/crypto`
+   - This is a dependency version issue, not a Zod issue
+
+2. **wellcrafted error type mismatches**:
+   - Several files have `Result` type errors where error objects are missing `context` and `cause` properties
+   - This is about the wellcrafted library's error type requirements
+
+3. **`exactOptionalPropertyTypes` issues**:
+   - Multiple files have type errors related to passing `undefined` to optional properties
+   - This is a TypeScript strictness issue, not Zod-related
+
+### Follow-up: Standard Schema Migration
+
+After the Zod v4 migration, the HTTP service types were updated to use Standard Schema (`@standard-schema/spec`) instead of Zod-specific types. This makes the HTTP service work with any validation library that implements the Standard Schema spec (Zod, Valibot, ArkType, etc.).
+
+**Changes Made:**
+
+1. **Updated `apps/whispering/src/lib/services/http/types.ts`**:
+   - Changed import from `import type { z } from 'zod'` to `import type { StandardSchemaV1 } from '@standard-schema/spec'`
+   - Changed generic constraint from `z.ZodType` to `StandardSchemaV1`
+   - Changed type inference from `z.infer<TSchema>` to `StandardSchemaV1.InferOutput<TSchema>`
+
+2. **Updated `apps/whispering/src/lib/services/http/desktop.ts` and `web.ts`**:
+   - Changed from Zod's `schema.parse(json)` to Standard Schema's `schema['~standard'].validate(json)`
+   - Added proper error handling for validation issues
+   - Added type assertion for the validated value
+
+**Why Standard Schema?**
+- Validation library agnostic: works with Zod, Valibot, ArkType, etc.
+- Future-proof: can switch validation libraries without changing the HTTP service
+- Already a dependency in the project via `@standard-schema/spec`
+
+### Summary
+
+The Zod v4 migration was minimal because the codebase uses Zod in a straightforward way without relying on deprecated features. The initial required code change was updating the generic constraint from `z.ZodTypeAny` to `z.ZodType`, followed by a switch to Standard Schema for better validation library flexibility.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 			"drizzle-arktype": "^0.1.3",
 			"drizzle-kit": "^0.31.7",
 			"drizzle-orm": "^0.44.7",
-			"zod": "^3.25.67",
+			"zod": "^4.1.13",
 			"nanoid": "latest",
 			"wellcrafted": "^0.25.0",
 			"date-fns": "^4.1.0",


### PR DESCRIPTION
This updates Zod from v3 to v4 and switches the HTTP service to use Standard Schema for validation library flexibility.

The Zod v4 migration was straightforward since the codebase doesn't use any deprecated v3 features. The main change was updating `z.ZodTypeAny` to `z.ZodType`, but we went further and switched to Standard Schema entirely for the HTTP service types.

The HTTP service now accepts any validation library that implements the Standard Schema spec (Zod, Valibot, ArkType, etc.) instead of being Zod-specific. This is done by:
- Using `StandardSchemaV1` as the generic constraint instead of `z.ZodType`
- Using `schema['~standard'].validate(json)` instead of `schema.parse(json)`
- Using `StandardSchemaV1.InferOutput<T>` for type inference

Pre-existing type errors (wellcrafted error types, exactOptionalPropertyTypes issues, better-auth import) are unrelated to this migration and remain unchanged.