### PR TITLE
chore: standardize lint/format/check script conventions

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -41,7 +41,7 @@ jobs:
           bun run --filter epicenter astro check || true
 
       - name: Run linting
-        run: bun run lint
+        run: bun run lint:check
 
       - name: Build all packages
         run: bun run build

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,7 +22,7 @@ jobs:
         run: bun install
       - name: Format check
         run: bun run format:check
-      - name: Lint
-        run: bun run lint
-      - name: Code check
+      - name: Lint check
+        run: bun run lint:check
+      - name: Type check
         run: bun run check

--- a/apps/posthog-reverse-proxy/package.json
+++ b/apps/posthog-reverse-proxy/package.json
@@ -7,7 +7,8 @@
 	"scripts": {
 		"dev": "wrangler dev",
 		"deploy": "wrangler deploy --minify",
-		"tail": "wrangler tail"
+		"tail": "wrangler tail",
+		"check": "tsc --noEmit"
 	},
 	"devDependencies": {
 		"@repo/config": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -54,11 +54,15 @@
 	"scripts": {
 		"build": "turbo run build",
 		"dev": "turbo run dev",
+
 		"format": "biome check --write --linter-enabled=false; prettier --write \"**/*.{svelte,astro,html}\"",
 		"format:check": "biome ci --linter-enabled=false; prettier --check \"**/*.{svelte,astro,html}\"",
-		"lint": "concurrently -raw \"turbo run lint\" \"eslint\" \"biome lint\"",
+
+		"lint": "eslint --fix; biome lint --write",
+		"lint:check": "concurrently -raw \"eslint\" \"biome lint\"",
+
 		"check": "turbo run check",
-		"format-and-lint": "concurrently \"bun run format\" \"bun run lint\"",
+
 		"bump-version": "bun run scripts/bump-version.ts"
 	},
 	"devDependencies": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -7,6 +7,9 @@
 		"./eslint": "./eslint.config.ts",
 		"./prettier": "./prettier.js"
 	},
+	"scripts": {
+		"check": "tsc --noEmit"
+	},
 	"peerDependencies": {
 		"eslint": ">=9.0.0",
 		"prettier": ">=3.0.0"

--- a/packages/epicenter/package.json
+++ b/packages/epicenter/package.json
@@ -16,7 +16,7 @@
 	"license": "AGPL-3.0",
 	"scripts": {
 		"lint": "eslint .",
-		"typecheck": "tsc --noEmit"
+		"check": "tsc --noEmit"
 	},
 	"dependencies": {
 		"@hocuspocus/provider": "^3.4.0",

--- a/packages/vault-core/package.json
+++ b/packages/vault-core/package.json
@@ -14,7 +14,7 @@
 		"format": "echo 'skip format'",
 		"format:check": "echo 'skip format check'",
 		"lint": "echo 'skip lint'",
-		"check": "echo \"TODO add this in a later commit\""
+		"check": "tsc --noEmit"
 	},
 	"dependencies": {
 		"arktype": "catalog:",

--- a/rules/general-guidelines.md
+++ b/rules/general-guidelines.md
@@ -48,3 +48,27 @@ Specs always live at the root level of their scope (not inside `docs/`):
 - **`/packages/[pkg]/specs/`** - Package-specific implementation details
 
 When in doubt, use `/specs/`. Move to app/package-specific only if the spec truly belongs there.
+
+# Script Commands
+
+The monorepo uses consistent script naming conventions:
+
+| Command | Purpose | When to use |
+|---------|---------|-------------|
+| `bun format` | **Fix** formatting (biome + prettier) | Development |
+| `bun format:check` | Check formatting | CI |
+| `bun lint` | **Fix** lint issues (eslint + biome) | Development |
+| `bun lint:check` | Check lint issues | CI |
+| `bun check` | Type checking (tsc, svelte-check, astro check) | Both |
+
+**Convention:**
+- No suffix = **fix** (modifies files)
+- `:check` suffix = check only (for CI, no modifications)
+- `check` alone = type checking (separate concern, cannot auto-fix)
+
+**After completing code changes**, run type checking to verify:
+```bash
+bun check
+```
+
+This runs `turbo run check` which executes the `check` script in each package (e.g., `tsc --noEmit`, `svelte-check`).


### PR DESCRIPTION
This change establishes consistent script naming conventions across the monorepo. Previously, `format` would fix files while `lint` would only report issues; now both follow the same pattern.

**Convention:**
- No suffix = **fix** (modifies files): `format`, `lint`
- `:check` suffix = check only (for CI): `format:check`, `lint:check`
- `check` = type checking (separate concern, runs per-package via turbo)

**Changes:**

1. **Root package.json**: Standardized scripts
   - `lint` now fixes (was check-only)
   - Added `lint:check` for CI

2. **CI workflows**: Updated to use `lint:check`
   - `.github/workflows/format.yml`
   - `.github/workflows/deploy-cloudflare.yml`

3. **Package scripts**: Added missing `check` scripts
   - `packages/vault-core`: Was TODO, now `tsc --noEmit`
   - `packages/epicenter`: Renamed `typecheck` to `check`
   - `packages/config`: Added `check` script
   - `apps/posthog-reverse-proxy`: Added `check` script

4. **Documentation**: Added script conventions to `rules/general-guidelines.md`