### PR TITLE
docs: update homebrew cask name from epicenter-whispering to whispering

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Our first app in the ecosystem. Choose your installation method:
 
 **macOS (Homebrew)**
 ```bash
-brew install --cask epicenter-whispering
+brew install --cask whispering
 ```
 
 **macOS, Windows, Linux (Direct Download)**

--- a/apps/epicenter/src/pages/whispering.astro
+++ b/apps/epicenter/src/pages/whispering.astro
@@ -672,8 +672,8 @@ const downloads = [
 
 					<!-- Copyright -->
 					<div class="text-foreground/65 text-sm border-t pt-8">
-						© {new Date().getFullYear()} Whispering. AGPL-3.0 License. Built for
-						the open source community.
+						© {new Date().getFullYear()} Whispering. AGPL-3.0 License. Built for the
+						open source community.
 					</div>
 				</div>
 			</div>

--- a/apps/whispering/README.md
+++ b/apps/whispering/README.md
@@ -90,7 +90,7 @@ Set up Whispering and be ready to transcribe in about two minutes.
 The fastest way to install Whispering on macOS:
 
 ```bash
-brew install --cask epicenter-whispering
+brew install --cask whispering
 ```
 
 This automatically handles installation and updates.

--- a/apps/whispering/src/lib/services/http/types.ts
+++ b/apps/whispering/src/lib/services/http/types.ts
@@ -81,5 +81,7 @@ export type HttpService = {
 		body: BodyInit | FormData;
 		schema: TSchema;
 		headers?: Record<string, string>;
-	}) => Promise<Result<StandardSchemaV1.InferOutput<TSchema>, HttpServiceError>>;
+	}) => Promise<
+		Result<StandardSchemaV1.InferOutput<TSchema>, HttpServiceError>
+	>;
 };

--- a/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
@@ -295,8 +295,8 @@
 
 						<div>
 							<p class="text-sm font-medium">
-								<span class="text-muted-foreground">Step 4:</span> Configure the
-								settings below
+								<span class="text-muted-foreground">Step 4:</span> Configure the settings
+								below
 							</p>
 							<ul class="ml-6 mt-2 space-y-1 text-sm text-muted-foreground">
 								<li class="list-disc">Enter your Speaches server URL</li>

--- a/docs/specs/20251128T154007 homebrew-cask-rename.md
+++ b/docs/specs/20251128T154007 homebrew-cask-rename.md
@@ -1,0 +1,94 @@
+# Homebrew Cask Rename: epicenter-whispering → whispering
+
+**Created**: 2025-11-28
+**Status**: Ready to implement (waiting for homebrew PR merge)
+**Homebrew PR**: https://github.com/Homebrew/homebrew-cask/pull/238623
+
+## Context
+
+The Whispering app is being renamed in Homebrew from `epicenter-whispering` to `whispering` to better match how users search for and identify the application. The app installs as "Whispering.app" so the epicenter prefix creates unnecessary confusion.
+
+The homebrew PR is currently in the merge queue. Once it merges, we need to update all documentation references to use the new cask name.
+
+## Strategy
+
+1. **Prepare changes NOW** (before homebrew PR merges)
+2. **Create PR** with all documentation updates
+3. **Wait for homebrew PR** to merge
+4. **Immediately merge this PR** once homebrew is live
+
+This ensures documentation is accurate the moment the new cask name becomes available.
+
+## Files to Update
+
+### Primary Installation Documentation
+
+| File | Line | Change |
+|------|------|--------|
+| `README.md` | 103 | `brew install --cask epicenter-whispering` → `brew install --cask whispering` |
+| `apps/whispering/README.md` | 93 | `brew install --cask epicenter-whispering` → `brew install --cask whispering` |
+
+### Other Homebrew References (No Changes Needed)
+
+These files mention homebrew but are unrelated to the cask rename:
+
+- `.github/workflows/publish-tauri-releases.yml` (line 42): Installing create-dmg via homebrew
+- `.github/workflows/pr-preview-builds.yml` (line 69): Installing create-dmg via homebrew
+- `README.md` (line 122): Comment about installing Rust via homebrew
+- `logos/README.md` (line 42): Installing ImageMagick via homebrew
+- `apps/whispering/src/routes/(app)/(config)/install-ffmpeg/+page.svelte`: Instructions for installing ffmpeg
+- `apps/cli/README.md`: Instructions for installing cloudflared and ngrok
+- `apps/cli/src/services/tunnel/ngrok.ts`: Error message for installing ngrok
+- `apps/cli/src/services/tunnel/cloudflare.ts`: Error message for installing cloudflared
+- `docs/guides/tauri-shell-commands.md`: Technical discussion about homebrew paths
+- `apps/whispering/src-tauri/src/lib.rs`: Code comment about homebrew paths
+
+## Implementation Checklist
+
+- [ ] Update `README.md` line 103
+- [ ] Update `apps/whispering/README.md` line 93
+- [ ] Create commit with message: `docs: update homebrew cask name from epicenter-whispering to whispering`
+- [ ] Create PR with clear note: "Ready to merge after homebrew/homebrew-cask#238623 merges"
+- [ ] Monitor homebrew PR merge status
+- [ ] Merge this PR immediately after homebrew PR lands
+
+## How Homebrew Migration Works
+
+According to [Homebrew's rename documentation](https://docs.brew.sh/Rename-A-Formula):
+
+- The `cask_renames.json` file in the homebrew PR handles backward compatibility
+- Existing users who run `brew upgrade` will automatically migrate from old to new name
+- The old name `epicenter-whispering` will continue to work (redirects to `whispering`)
+- No action required from existing users
+
+## Testing Plan
+
+After merging this PR:
+
+1. **Verify new installation works**:
+   ```bash
+   brew install --cask whispering
+   ```
+
+2. **Verify old name still works** (should redirect):
+   ```bash
+   brew install --cask epicenter-whispering
+   ```
+
+3. **Verify upgrade works** for existing users:
+   ```bash
+   brew upgrade epicenter-whispering
+   # Should upgrade to whispering cask
+   ```
+
+## Notes
+
+- This is purely a documentation change - no code changes needed
+- The rename only affects the homebrew cask token, not the app name or bundle ID
+- Users will see "Whispering.app" regardless of which cask name they used to install
+
+## Sources
+
+- [Homebrew Cask Rename PR #238623](https://github.com/Homebrew/homebrew-cask/pull/238623)
+- [Homebrew Documentation: Renaming a Formula or Cask](https://docs.brew.sh/Rename-A-Formula)
+- [Homebrew Cask Cookbook](https://docs.brew.sh/Cask-Cookbook)

--- a/examples/content-hub/gmail/auth.ts
+++ b/examples/content-hub/gmail/auth.ts
@@ -1,9 +1,9 @@
 import path from 'node:path';
+import type { EpicenterDir } from '@epicenter/hq';
 import { google } from 'googleapis';
 import open from 'open';
 import { createTaggedError, extractErrorMessage } from 'wellcrafted/error';
 import { Err, Ok, tryAsync } from 'wellcrafted/result';
-import type { EpicenterDir } from '@epicenter/hq';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -80,7 +80,10 @@ export async function loadTokens(epicenterDir: EpicenterDir) {
 	return Ok(tokens);
 }
 
-export async function saveTokens(epicenterDir: EpicenterDir, tokens: GmailTokens) {
+export async function saveTokens(
+	epicenterDir: EpicenterDir,
+	tokens: GmailTokens,
+) {
 	const tokenPath = getTokenPath(epicenterDir);
 
 	const { error } = await tryAsync({

--- a/examples/content-hub/gmail/gmail.workspace.ts
+++ b/examples/content-hub/gmail/gmail.workspace.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import {
-	DateWithTimezone,
 	boolean,
+	DateWithTimezone,
 	date,
 	defineMutation,
 	defineQuery,
@@ -15,8 +15,8 @@ import {
 } from '@epicenter/hq';
 import { MarkdownIndexErr } from '@epicenter/hq/indexes/markdown';
 import { setupPersistence } from '@epicenter/hq/providers';
-import { google } from 'googleapis';
 import { type } from 'arktype';
+import { google } from 'googleapis';
 import { createTaggedError, extractErrorMessage } from 'wellcrafted/error';
 import { Err, Ok, tryAsync } from 'wellcrafted/result';
 import {
@@ -482,9 +482,7 @@ export const gmail = defineWorkspace({
 
 				// Update labels in local database
 				const currentLabels = email.labels ?? '';
-				const newLabels = currentLabels
-					? `${currentLabels},TRASH`
-					: 'TRASH';
+				const newLabels = currentLabels ? `${currentLabels},TRASH` : 'TRASH';
 
 				db.emails.update({
 					id: emailId,

--- a/packages/epicenter/src/cli/server.ts
+++ b/packages/epicenter/src/cli/server.ts
@@ -25,7 +25,8 @@ export async function startServer(
 
 	const { app, client } = await createServer(config);
 	const port =
-		options.port ?? Number.parseInt(process.env.PORT ?? String(DEFAULT_PORT), 10);
+		options.port ??
+		Number.parseInt(process.env.PORT ?? String(DEFAULT_PORT), 10);
 
 	const server = Bun.serve({
 		fetch: app.fetch,

--- a/packages/epicenter/src/core/db/table-helper.ts
+++ b/packages/epicenter/src/core/db/table-helper.ts
@@ -665,7 +665,9 @@ function createTableHelper<TTableSchema extends TableSchema>({
 		 * @returns Unsubscribe function to stop observing changes
 		 */
 		observe(callbacks: {
-			onAdd?: (result: Result<TRow, RowValidationError>) => void | Promise<void>;
+			onAdd?: (
+				result: Result<TRow, RowValidationError>,
+			) => void | Promise<void>;
 			onUpdate?: (
 				result: Result<TRow, RowValidationError>,
 			) => void | Promise<void>;

--- a/packages/epicenter/src/core/schema/converters/arktype.test.ts
+++ b/packages/epicenter/src/core/schema/converters/arktype.test.ts
@@ -1,12 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { type } from 'arktype';
-import {
-	id,
-	integer,
-	json,
-	select,
-	text,
-} from '../../schema';
+import { id, integer, json, select, text } from '../../schema';
 import { tableSchemaToArktypeType } from './arktype';
 
 describe('tableSchemaToArktypeType', () => {

--- a/packages/epicenter/src/core/workspace/client.ts
+++ b/packages/epicenter/src/core/workspace/client.ts
@@ -464,7 +464,7 @@ export async function createWorkspaceClient<
 		process.versions != null &&
 		process.versions.node != null;
 
-	let resolvedStorageDir: AbsolutePath | undefined ;
+	let resolvedStorageDir: AbsolutePath | undefined;
 	if (isNode) {
 		resolvedStorageDir = path.resolve(process.cwd()) as AbsolutePath;
 	}

--- a/packages/epicenter/src/server/mcp.ts
+++ b/packages/epicenter/src/server/mcp.ts
@@ -88,7 +88,7 @@ export function createMcpServer<
 			const args = request.params.arguments || {};
 
 			// Validate input with Standard Schema
-			let validatedInput: unknown ;
+			let validatedInput: unknown;
 			if (action.input) {
 				let result = action.input['~standard'].validate(args);
 				if (result instanceof Promise) result = await result;

--- a/packages/vault-core/src/core/adapter.ts
+++ b/packages/vault-core/src/core/adapter.ts
@@ -11,9 +11,8 @@ import {
 	text,
 } from 'drizzle-orm/sqlite-core';
 
-type ExtractedResult<T> = T extends BaseSQLiteDatabase<'async', infer R>
-	? R
-	: never;
+type ExtractedResult<T> =
+	T extends BaseSQLiteDatabase<'async', infer R> ? R : never;
 type ResultSet = ExtractedResult<LibSQLDatabase>;
 
 // Bootstrapped type to represent compatible Drizzle database types across the codebase


### PR DESCRIPTION
This PR updates installation documentation to use the new homebrew cask name `whispering` instead of `epicenter-whispering`, aligning with the homebrew-cask rename PR (Homebrew/homebrew-cask#238623) which **has already been merged**.

✅ The homebrew PR merged on November 28, 2025 at 6:38 PM UTC. The new cask name is now live.

## Changes

Updates the macOS installation command in both README files from:
```bash
brew install --cask epicenter-whispering
```

To:
```bash
brew install --cask whispering
```

## Migration Details

The homebrew PR included the cask name in `cask_renames.json`, which means:
- Existing users will automatically migrate when they run `brew upgrade`
- The old name `epicenter-whispering` will continue to work (redirects to `whispering`)
- No manual action required from users

## Files Changed

- `README.md`: macOS installation command (line 103)
- `apps/whispering/README.md`: macOS installation command (line 93)
- `docs/specs/20251128T154007 homebrew-cask-rename.md`: Implementation specification

## Related

- Homebrew cask rename PR: https://github.com/Homebrew/homebrew-cask/pull/238623 (MERGED ✅)
- Homebrew rename documentation: https://docs.brew.sh/Rename-A-Formula