### PR TITLE
fix(transcription): convert number input to string for temperature setting

### DIFF
--- a/apps/whispering/src/lib/settings/settings.ts
+++ b/apps/whispering/src/lib/settings/settings.ts
@@ -170,7 +170,16 @@ export const settingsSchema = z.object({
 	// Shared settings in transcription
 	'transcription.outputLanguage': z.enum(SUPPORTED_LANGUAGES).default('auto'),
 	'transcription.prompt': z.string().default(''),
-	'transcription.temperature': z.string().default('0.0'),
+	'transcription.temperature': z
+		.string()
+		.default('0.0')
+		.refine(
+			(val) => {
+				const num = Number.parseFloat(val);
+				return !Number.isNaN(num) && num >= 0 && num <= 1;
+			},
+			{ message: 'Temperature must be a number between 0 and 1' },
+		),
 	// Audio compression settings
 	'transcription.compressionEnabled': z.boolean().default(false),
 	'transcription.compressionOptions': z

--- a/apps/whispering/src/lib/settings/settings.ts
+++ b/apps/whispering/src/lib/settings/settings.ts
@@ -170,16 +170,7 @@ export const settingsSchema = z.object({
 	// Shared settings in transcription
 	'transcription.outputLanguage': z.enum(SUPPORTED_LANGUAGES).default('auto'),
 	'transcription.prompt': z.string().default(''),
-	'transcription.temperature': z
-		.string()
-		.default('0.0')
-		.refine(
-			(val) => {
-				const num = Number.parseFloat(val);
-				return !Number.isNaN(num) && num >= 0 && num <= 1;
-			},
-			{ message: 'Temperature must be a number between 0 and 1' },
-		),
+	'transcription.temperature': z.string().default('0.0'),
 	// Audio compression settings
 	'transcription.compressionEnabled': z.boolean().default(false),
 	'transcription.compressionOptions': z

--- a/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
@@ -597,7 +597,15 @@
 		placeholder="0"
 		bind:value={
 			() => settings.value['transcription.temperature'],
-			(value) => settings.updateKey('transcription.temperature', value)
+			(value) => {
+				// Convert to number, clamp to valid range [0, 1], then convert to string
+				const numValue = Number(value);
+				if (Number.isNaN(numValue)) {
+					return;
+				}
+				const clampedValue = Math.max(0, Math.min(1, numValue));
+				settings.updateKey('transcription.temperature', clampedValue.toString());
+			}
 		}
 		description={isPromptAndTemperatureNotSupported
 			? 'Temperature is not supported for local models (transcribe-rs)'

--- a/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
@@ -597,15 +597,7 @@
 		placeholder="0"
 		bind:value={
 			() => settings.value['transcription.temperature'],
-			(value) => {
-				// Convert to number, clamp to valid range [0, 1], then convert to string
-				const numValue = Number(value);
-				if (Number.isNaN(numValue)) {
-					return;
-				}
-				const clampedValue = Math.max(0, Math.min(1, numValue));
-				settings.updateKey('transcription.temperature', clampedValue.toString());
-			}
+			(value) => settings.updateKey('transcription.temperature', String(value))
 		}
 		description={isPromptAndTemperatureNotSupported
 			? 'Temperature is not supported for local models (transcribe-rs)'


### PR DESCRIPTION
This fixes the temperature setting reset bug where the value would revert to 0.0 when navigating away from the settings page or after performing a transcription.

The root cause is a type mismatch: HTML `<input type="number">` returns numeric values, but the settings schema expects strings. When Zod validation fails due to this type mismatch, the progressive validation system discards the invalid value and falls back to the default "0.0".

The fix converts the number to a string at the binding site, right where the type boundary exists between the HTML input and the settings store. This is the minimal change needed; the HTML input already enforces `min="0" max="1" step="0.1"` constraints, making additional validation redundant.

Thank you to @Cprakhar for #1018 and @vishesh-sachan for #1019; both identified the issue correctly and provided working fixes. This PR takes the same approach as #1018 (converting at the binding site) but simplifies it to just the essential `String(value)` conversion, since the HTML input constraints already handle validation.

Closes #961
Supersedes #1018 and #1019