### PR TITLE
feat: add bun clean and nuke scripts for cache clearing

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,24 @@ cd apps/whispering
 bun dev
 ```
 
+### Troubleshooting
+
+If you encounter issues after switching branches or pulling changes (like "render_fn is not a function" errors), run from the repo root:
+
+```bash
+bun clean    # Clears caches and node_modules
+bun install  # Reinstall dependencies
+```
+
+For a complete reset including Rust build artifacts (~10GB, takes longer to rebuild):
+
+```bash
+bun nuke     # Clears everything including Rust target
+bun install
+```
+
+Note: You rarely need `bun nuke` since Cargo handles incremental Rust builds well. Use `bun clean` first; reserve `bun nuke` for when things are truly broken.
+
 ## Join Us
 
 ## Discord Community

--- a/package.json
+++ b/package.json
@@ -63,7 +63,10 @@
 
 		"check": "turbo run check",
 
-		"bump-version": "bun run scripts/bump-version.ts"
+		"bump-version": "bun run scripts/bump-version.ts",
+
+		"clean": "rm -rf .turbo node_modules apps/*/.svelte-kit apps/*/dist apps/*/node_modules packages/*/.svelte-kit packages/*/dist packages/*/node_modules examples/*/node_modules",
+		"nuke": "bun clean && rm -rf apps/whispering/src-tauri/target"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "catalog:",


### PR DESCRIPTION
This adds two scripts to help developers recover from stale cache issues that commonly occur after switching branches or pulling changes.

The problem: After switching branches, the Whispering UI often fails to load with errors like "render_fn is not a function" such as in #779 . This happens because the stale `.svelte-kit` cache contains compiled components from a different branch that are incompatible with the current code. Similarly, pushing changes that work locally but fail on fresh clones can happen when builds rely on cached artifacts.

Two scripts are now available from the repo root:

**`bun clean`** handles the common case. It removes:
- `.turbo` (Turborepo cache)
- `node_modules` at root and in all workspaces
- `.svelte-kit` directories in all apps and packages
- `dist` build output directories

**`bun nuke`** is the nuclear option. It runs `clean` and additionally removes:
- `apps/whispering/src-tauri/target` (~10GB of Rust build artifacts)

Most of the time, `bun clean` followed by `bun install` is all you need. The Rust target is excluded from `clean` because Cargo handles incremental builds well; when you run `bun dev`, Cargo automatically detects what changed and only recompiles affected modules. Reserve `nuke` for when Rust builds are truly corrupted.

This approach follows the convention used in most Turborepo and monorepo projects, where `clean` is the standard name for cache-clearing scripts.

Closes the discussion started by @Leftium in Discord about adding a clean command.