### PR TITLE
fix(epicenter): MCP server fixes and schema compatibility

### DIFF
--- a/packages/epicenter/src/cli/README.md
+++ b/packages/epicenter/src/cli/README.md
@@ -132,11 +132,11 @@ Test your CLI commands programmatically:
 ```typescript
 import { createCLI } from '@repo/epicenter/cli';
 
-const cli = await createCLI(epicenter, {
+// createCLI parses and executes the command internally
+await createCLI({
+  config: epicenter,
   argv: ['reddit', 'import', '--url', 'https://...', '--count', '5']
 });
-
-await cli.parse(); // Executes the command
 ```
 
 ## Implementation Architecture

--- a/packages/epicenter/src/cli/bin.ts
+++ b/packages/epicenter/src/cli/bin.ts
@@ -19,8 +19,7 @@ async function main() {
 			const { config } = await loadEpicenterConfig(process.cwd());
 
 			// Create and run the CLI
-			const cli = await createCLI({ config, argv: hideBin(process.argv) });
-			await cli.parse();
+			await createCLI({ config, argv: hideBin(process.argv) });
 		},
 		catch: (error) => {
 			if (error instanceof Error) {

--- a/packages/epicenter/src/cli/cli-end-to-end.test.ts
+++ b/packages/epicenter/src/cli/cli-end-to-end.test.ts
@@ -129,7 +129,8 @@ describe('CLI End-to-End Tests', () => {
 	});
 
 	test('CLI can create a post', async () => {
-		const cli = await createCLI({
+		// createCLI parses and executes the command internally
+		await createCLI({
 			config: epicenter,
 			argv: [
 				'posts',
@@ -143,9 +144,6 @@ describe('CLI End-to-End Tests', () => {
 			],
 		});
 
-		// Parse will execute the command
-		await cli.parse();
-
 		// Verify the post was created by checking the markdown file
 		await new Promise((resolve) => setTimeout(resolve, 200));
 		const files = await Bun.$`ls ${TEST_MARKDOWN}/posts`.text();
@@ -154,7 +152,7 @@ describe('CLI End-to-End Tests', () => {
 
 	test('CLI can query posts', async () => {
 		// First create a post
-		const createCli = await createCLI({
+		await createCLI({
 			config: epicenter,
 			argv: [
 				'posts',
@@ -165,27 +163,23 @@ describe('CLI End-to-End Tests', () => {
 				'tech',
 			],
 		});
-		await createCli.parse();
 
 		// Wait for the post to be created
 		await new Promise((resolve) => setTimeout(resolve, 200));
 
 		// Now query all posts
-		const listCli = await createCLI({
+		await createCLI({
 			config: epicenter,
 			argv: ['posts', 'listPosts'],
 		});
-		await listCli.parse();
 	});
 
 	test('CLI handles missing required options', async () => {
-		const cli = await createCLI({
-			config: epicenter,
-			argv: ['posts', 'createPost', '--title', 'Missing Category'],
-		});
-
 		try {
-			await cli.parse();
+			await createCLI({
+				config: epicenter,
+				argv: ['posts', 'createPost', '--title', 'Missing Category'],
+			});
 			expect(false).toBe(true); // Should not reach here
 		} catch (error) {
 			// Expected to fail due to missing required field
@@ -194,7 +188,15 @@ describe('CLI End-to-End Tests', () => {
 	});
 
 	test('CLI properly formats success output', async () => {
-		const cli = await createCLI({
+		// Capture console output
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (...args: unknown[]) => {
+			logs.push(args.join(' '));
+			originalLog(...args);
+		};
+
+		await createCLI({
 			config: epicenter,
 			argv: [
 				'posts',
@@ -205,16 +207,6 @@ describe('CLI End-to-End Tests', () => {
 				'test',
 			],
 		});
-
-		// Capture console output
-		const logs: string[] = [];
-		const originalLog = console.log;
-		console.log = (...args: any[]) => {
-			logs.push(args.join(' '));
-			originalLog(...args);
-		};
-
-		await cli.parse();
 
 		console.log = originalLog;
 

--- a/packages/epicenter/src/core/db/core-types.test.ts
+++ b/packages/epicenter/src/core/db/core-types.test.ts
@@ -17,7 +17,7 @@ describe('YjsDoc Type Inference', () => {
 				title: text(),
 				content: ytext({ nullable: true }),
 				tags: tags({ options: ['tech', 'personal', 'work'] }),
-				viewCount: integer(),
+				view_count: integer(),
 				published: boolean(),
 			},
 		});
@@ -28,7 +28,7 @@ describe('YjsDoc Type Inference', () => {
 			title: 'Test Post',
 			content: 'Post content', // string (gets converted to Y.Text internally)
 			tags: ['tech'], // array (gets converted to Y.Array internally)
-			viewCount: 0,
+			view_count: 0,
 			published: false,
 		});
 
@@ -43,7 +43,7 @@ describe('YjsDoc Type Inference', () => {
 				// Verify property access works
 				expect(row.id).toBe('1');
 				expect(row.title).toBe('Test Post');
-				expect(row.viewCount).toBe(0);
+				expect(row.view_count).toBe(0);
 				expect(row.published).toBe(false);
 
 				// Verify YJS types are properly inferred
@@ -59,18 +59,20 @@ describe('YjsDoc Type Inference', () => {
 				id: id(),
 				name: text(),
 				price: integer(),
-				inStock: boolean(),
+				in_stock: boolean(),
 			},
 		});
 
-		doc.products.insertMany([
-			{ id: '1', name: 'Widget', price: 1000, inStock: true },
-			{ id: '2', name: 'Gadget', price: 2000, inStock: false },
-		]);
+		doc.products.insertMany({
+			rows: [
+				{ id: '1', name: 'Widget', price: 1000, in_stock: true },
+				{ id: '2', name: 'Gadget', price: 2000, in_stock: false },
+			],
+		});
 
 		// getAll() now returns Row[] directly
 		const products = doc.products.getAll();
-		// Expected type: Array<{ id: string; name: string; price: number; inStock: boolean }>
+		// Expected type: Array<{ id: string; name: string; price: number; in_stock: boolean }>
 
 		expect(products).toHaveLength(2);
 	});
@@ -85,10 +87,12 @@ describe('YjsDoc Type Inference', () => {
 			},
 		});
 
-		doc.tasks.insertMany([
-			{ id: '1', title: 'Task 1', completed: false, priority: 'high' },
-			{ id: '2', title: 'Task 2', completed: true, priority: 'low' },
-		]);
+		doc.tasks.insertMany({
+			rows: [
+				{ id: '1', title: 'Task 1', completed: false, priority: 'high' },
+				{ id: '2', title: 'Task 2', completed: true, priority: 'low' },
+			],
+		});
 
 		// Hover over 'task' parameter to verify inferred type
 		// filter() now returns Row[] directly
@@ -108,10 +112,12 @@ describe('YjsDoc Type Inference', () => {
 			},
 		});
 
-		doc.items.insertMany([
-			{ id: '1', name: 'Item 1', quantity: 5 },
-			{ id: '2', name: 'Item 2', quantity: 0 },
-		]);
+		doc.items.insertMany({
+			rows: [
+				{ id: '1', name: 'Item 1', quantity: 5 },
+				{ id: '2', name: 'Item 2', quantity: 0 },
+			],
+		});
 
 		// Hover over 'item' parameter to verify inferred type
 		// find() now returns Row | null directly
@@ -214,7 +220,7 @@ describe('YjsDoc Type Inference', () => {
 			},
 			books: {
 				id: id(),
-				authorId: text(),
+				author_id: text(),
 				title: text(),
 				chapters: tags({
 					options: ['Chapter 1', 'Chapter 2', 'Chapter 3'],
@@ -236,14 +242,14 @@ describe('YjsDoc Type Inference', () => {
 		// Test books table - use plain array (converted to Y.Array internally)
 		doc.books.insert({
 			id: 'book-1',
-			authorId: 'author-1',
+			author_id: 'author-1',
 			title: 'My Book',
 			chapters: ['Chapter 1', 'Chapter 2'],
 			published: true,
 		});
 
 		const bookResult = doc.books.get({ id: 'book-1' });
-		// Hover to verify type: Result<{ id: string; authorId: string; title: string; chapters: Y.Array<string>; published: boolean }, ArkErrors> | null
+		// Hover to verify type: Result<{ id: string; author_id: string; title: string; chapters: Y.Array<string>; published: boolean }, ArkErrors> | null
 
 		expect(authorResult).not.toBeNull();
 		expect(bookResult).not.toBeNull();
@@ -270,7 +276,7 @@ describe('YjsDoc Type Inference', () => {
 			{ id: '2', text: 'Second comment', upvotes: 10 },
 		];
 
-		doc.comments.insertMany(commentsToAdd);
+		doc.comments.insertMany({ rows: commentsToAdd });
 
 		const comments = doc.comments.getAll();
 		expect(comments).toHaveLength(2);

--- a/packages/epicenter/src/core/db/core.test.ts
+++ b/packages/epicenter/src/core/db/core.test.ts
@@ -10,7 +10,7 @@ describe('createEpicenterDb', () => {
 			posts: {
 				id: id(),
 				title: text(),
-				viewCount: integer(),
+				view_count: integer(),
 				published: boolean(),
 			},
 		});
@@ -19,7 +19,7 @@ describe('createEpicenterDb', () => {
 		doc.posts.insert({
 			id: '1',
 			title: 'Test Post',
-			viewCount: 0,
+			view_count: 0,
 			published: false,
 		});
 
@@ -28,7 +28,7 @@ describe('createEpicenterDb', () => {
 		expect(result).not.toBeNull();
 		if (result?.data) {
 			expect(result.data.title).toBe('Test Post');
-			expect(result.data.viewCount).toBe(0);
+			expect(result.data.view_count).toBe(0);
 			expect(result.data.published).toBe(false);
 		}
 	});
@@ -39,16 +39,18 @@ describe('createEpicenterDb', () => {
 			posts: {
 				id: id(),
 				title: text(),
-				viewCount: integer(),
+				view_count: integer(),
 				published: boolean(),
 			},
 		});
 
 		// Create multiple rows
-		const { error: insertError } = doc.posts.insertMany([
-			{ id: '1', title: 'Post 1', viewCount: 10, published: true },
-			{ id: '2', title: 'Post 2', viewCount: 20, published: false },
-		]);
+		const { error: insertError } = doc.posts.insertMany({
+			rows: [
+				{ id: '1', title: 'Post 1', view_count: 10, published: true },
+				{ id: '2', title: 'Post 2', view_count: 20, published: false },
+			],
+		});
 		expect(insertError).toBeNull();
 
 		// Retrieve and verify rows
@@ -70,16 +72,18 @@ describe('createEpicenterDb', () => {
 			posts: {
 				id: id(),
 				title: text(),
-				viewCount: integer(),
+				view_count: integer(),
 				published: boolean(),
 			},
 		});
 
-		doc.posts.insertMany([
-			{ id: '1', title: 'Post 1', viewCount: 10, published: true },
-			{ id: '2', title: 'Post 2', viewCount: 20, published: false },
-			{ id: '3', title: 'Post 3', viewCount: 30, published: true },
-		]);
+		doc.posts.insertMany({
+			rows: [
+				{ id: '1', title: 'Post 1', view_count: 10, published: true },
+				{ id: '2', title: 'Post 2', view_count: 20, published: false },
+				{ id: '3', title: 'Post 3', view_count: 30, published: true },
+			],
+		});
 
 		// Filter published posts
 		const publishedPosts = doc.posts.filter((post) => post.published);
@@ -99,7 +103,7 @@ describe('createEpicenterDb', () => {
 			posts: {
 				id: id(),
 				title: text(),
-				viewCount: integer(),
+				view_count: integer(),
 				published: boolean(),
 			},
 		});

--- a/packages/epicenter/src/core/db/table-helper.ts
+++ b/packages/epicenter/src/core/db/table-helper.ts
@@ -249,9 +249,9 @@ function createTableHelper<TTableSchema extends TableSchema>({
 		insertMany: defineMutation({
 			input: validators.toStandardSchemaArray(),
 			description: `Insert multiple rows into the ${tableName} table`,
-			handler: (serializedRows) => {
+			handler: ({ rows }) => {
 				// Check for duplicates first
-				for (const serializedRow of serializedRows) {
+				for (const serializedRow of rows) {
 					if (ytable.has(serializedRow.id)) {
 						return RowAlreadyExistsErr({
 							message: `Row with id "${serializedRow.id}" already exists in table "${tableName}"`,
@@ -265,7 +265,7 @@ function createTableHelper<TTableSchema extends TableSchema>({
 				}
 
 				ydoc.transact(() => {
-					for (const serializedRow of serializedRows) {
+					for (const serializedRow of rows) {
 						const yrow = new Y.Map<CellValue>();
 						updateYRowFromSerializedRow({ yrow, serializedRow, schema });
 						ytable.set(serializedRow.id, yrow);
@@ -280,9 +280,9 @@ function createTableHelper<TTableSchema extends TableSchema>({
 		upsertMany: defineMutation({
 			input: validators.toStandardSchemaArray(),
 			description: `Insert or update multiple rows in the ${tableName} table`,
-			handler: (serializedRows) => {
+			handler: ({ rows }) => {
 				ydoc.transact(() => {
-					for (const serializedRow of serializedRows) {
+					for (const serializedRow of rows) {
 						let yrow = ytable.get(serializedRow.id);
 						if (!yrow) {
 							yrow = new Y.Map<CellValue>();
@@ -298,9 +298,9 @@ function createTableHelper<TTableSchema extends TableSchema>({
 		updateMany: defineMutation({
 			input: validators.toPartialStandardSchemaArray(),
 			description: `Update multiple rows in the ${tableName} table`,
-			handler: (partialSerializedRows) => {
+			handler: ({ rows }) => {
 				// Check all rows exist first
-				for (const partialSerializedRow of partialSerializedRows) {
+				for (const partialSerializedRow of rows) {
 					if (!ytable.has(partialSerializedRow.id)) {
 						return RowNotFoundErr({
 							message: `Row with id "${partialSerializedRow.id}" not found in table "${tableName}"`,
@@ -314,7 +314,7 @@ function createTableHelper<TTableSchema extends TableSchema>({
 				}
 
 				ydoc.transact(() => {
-					for (const partialSerializedRow of partialSerializedRows) {
+					for (const partialSerializedRow of rows) {
 						// Safe to assert non-null because we checked all IDs exist above
 						const yrow = ytable.get(partialSerializedRow.id);
 						if (!yrow) continue; // Skip if somehow missing (defensive)

--- a/packages/epicenter/src/core/schema/safe-json-schema.ts
+++ b/packages/epicenter/src/core/schema/safe-json-schema.ts
@@ -6,39 +6,72 @@ import { Ok, tryAsync } from 'wellcrafted/result';
 /**
  * Safely convert a Standard Schema to JSON Schema with graceful error handling.
  *
- * Handles arktype-specific edge cases:
- * - `undefined` in unions (optional properties become `T | undefined` internally)
- * - Other unit types that can't be represented in JSON Schema
+ * ## Why this wrapper exists
  *
- * If conversion still fails after fallback handling, returns a permissive empty
- * JSON schema that accepts any input. This ensures tools remain functional.
+ * standard-json is a vendor-agnostic library that converts any Standard Schema
+ * (zod, arktype, valibot, etc.) to JSON Schema. It detects the vendor from
+ * `schema["~standard"].vendor` and delegates to the appropriate handler.
+ *
+ * For arktype specifically, the handler passes options directly to arktype's
+ * `Type.toJsonSchema()` method. The options aren't typed in standard-json
+ * (they're `Record<string, unknown>`) because each vendor has different options.
+ *
+ * ## Two-layer safety net
+ *
+ * 1. **Fallback handlers (arktype API)**: Intercept conversion issues per-node
+ *    in the schema tree, allowing partial success. If a schema has 10 fields
+ *    and only 1 has an unconvertible type, the other 9 are preserved.
+ *
+ * 2. **Outer catch**: Last-resort failsafe for truly catastrophic failures.
+ *    Returns `{}` (permissive empty schema) if everything else fails.
+ *
+ * ## The `undefined` problem
+ *
+ * Arktype represents optional properties as `T | undefined` internally.
+ * JSON Schema doesn't have an `undefined` type; it handles optionality via
+ * the `required` array. The `unit` fallback handler strips `undefined` from
+ * unions so the conversion succeeds.
+ *
+ * @see https://github.com/standard-community/standard-json - standard-json repo
+ * @see https://arktype.io/docs/json-schema - arktype's toJsonSchema docs
  *
  * @param schema - Standard Schema to convert
- * @returns JSON Schema representation, or permissive fallback on error
+ * @returns JSON Schema representation, or permissive `{}` on catastrophic error
  */
 export async function safeToJsonSchema(
 	schema: StandardSchemaV1,
 ): Promise<JSONSchema7> {
 	const { data } = await tryAsync({
 		try: async () =>
+			// The second argument is passed through to arktype's toJsonSchema().
+			// Types are loose (Record<string, unknown>) because standard-json is
+			// vendor-agnostic. These options are arktype-specific.
+			// See: https://arktype.io/docs/json-schema#fallback
 			await toJsonSchema(schema, {
-				// Handle arktype types that don't have JSON Schema equivalents
 				fallback: {
-					// Handle `undefined` in unions (e.g., optional properties: `string | undefined`)
-					// We ignore undefined since JSON Schema handles optionality via `required` array
+					// Called when arktype encounters a "unit" type (literal value like
+					// `undefined`, `null`, `true`, etc.) that can't be represented in JSON Schema.
+					//
+					// ctx.unit: The literal value (e.g., undefined)
+					// ctx.base: The partial JSON Schema generated so far for this node
 					unit: (ctx: { unit: unknown; base: JSONSchema7 }) => {
 						if (ctx.unit === undefined) {
-							// Return empty schema to effectively remove undefined from the union
-							// The property will still be marked as optional via the `required` array
+							// Return empty schema `{}` to remove undefined from the union.
+							// Example: `string | undefined` becomes just `string` in the output.
+							// The property's optionality is preserved via JSON Schema's `required` array.
 							return {};
 						}
-						// For other unit types, preserve the base schema
+						// For other unit types (null, true, etc.), keep whatever was generated
 						return ctx.base;
 					},
-					// Fallback for any other incompatible types
+					// Catch-all for any other incompatible arktype features (morphs,
+					// predicates, symbolic keys, etc.). Preserves partial schema.
 					default: (ctx: { base: JSONSchema7 }) => ctx.base,
 				},
 			}),
+		// Last-resort fallback: if the entire conversion throws (shouldn't happen
+		// with the fallback handlers above, but defensive coding), return a
+		// permissive empty schema `{}` that accepts any input.
 		catch: (e) => {
 			console.warn('Failed to convert schema, using permissive fallback:', e);
 			return Ok({} satisfies JSONSchema7);

--- a/packages/epicenter/src/core/schema/safe-json-schema.ts
+++ b/packages/epicenter/src/core/schema/safe-json-schema.ts
@@ -6,8 +6,12 @@ import { Ok, tryAsync } from 'wellcrafted/result';
 /**
  * Safely convert a Standard Schema to JSON Schema with graceful error handling.
  *
- * If conversion fails, returns a permissive empty JSON schema that accepts any input.
- * This ensures tools remain functional even if schema conversion encounters errors.
+ * Handles arktype-specific edge cases:
+ * - `undefined` in unions (optional properties become `T | undefined` internally)
+ * - Other unit types that can't be represented in JSON Schema
+ *
+ * If conversion still fails after fallback handling, returns a permissive empty
+ * JSON schema that accepts any input. This ensures tools remain functional.
  *
  * @param schema - Standard Schema to convert
  * @returns JSON Schema representation, or permissive fallback on error
@@ -16,7 +20,25 @@ export async function safeToJsonSchema(
 	schema: StandardSchemaV1,
 ): Promise<JSONSchema7> {
 	const { data } = await tryAsync({
-		try: async () => await toJsonSchema(schema),
+		try: async () =>
+			await toJsonSchema(schema, {
+				// Handle arktype types that don't have JSON Schema equivalents
+				fallback: {
+					// Handle `undefined` in unions (e.g., optional properties: `string | undefined`)
+					// We ignore undefined since JSON Schema handles optionality via `required` array
+					unit: (ctx: { unit: unknown; base: JSONSchema7 }) => {
+						if (ctx.unit === undefined) {
+							// Return empty schema to effectively remove undefined from the union
+							// The property will still be marked as optional via the `required` array
+							return {};
+						}
+						// For other unit types, preserve the base schema
+						return ctx.base;
+					},
+					// Fallback for any other incompatible types
+					default: (ctx: { base: JSONSchema7 }) => ctx.base,
+				},
+			}),
 		catch: (e) => {
 			console.warn('Failed to convert schema, using permissive fallback:', e);
 			return Ok({} satisfies JSONSchema7);

--- a/packages/epicenter/src/server/server.ts
+++ b/packages/epicenter/src/server/server.ts
@@ -142,7 +142,7 @@ export async function createServer<
 	});
 
 	// Create and configure MCP server for /mcp endpoint
-	const mcpServer = createMcpServer(client, config);
+	const mcpServer = await createMcpServer(client, config);
 
 	// Initialize transport once (per @hono/mcp docs, transport should be reused)
 	const transport = new StreamableHTTPTransport();

--- a/packages/epicenter/src/server/server.ts
+++ b/packages/epicenter/src/server/server.ts
@@ -144,10 +144,16 @@ export async function createServer<
 	// Create and configure MCP server for /mcp endpoint
 	const mcpServer = createMcpServer(client, config);
 
+	// Initialize transport once (per @hono/mcp docs, transport should be reused)
+	const transport = new StreamableHTTPTransport();
+
 	// Register MCP endpoint using StreamableHTTPTransport
 	app.all('/mcp', async (c) => {
-		const transport = new StreamableHTTPTransport();
-		await mcpServer.connect(transport);
+		// Only connect if not already connected (connection persists across requests)
+		// Server.transport is set when connect() is called
+		if (mcpServer.transport === undefined) {
+			await mcpServer.connect(transport);
+		}
 		return transport.handleRequest(c);
 	});
 


### PR DESCRIPTION
This PR addresses several issues with the Epicenter CLI and MCP server that were causing tool registration failures and runtime errors.

## Context

The MCP (Model Context Protocol) server exposes Epicenter workspace actions as tools that AI assistants can call. Several issues were preventing proper tool registration and execution:

1. **CLI crash on startup**: `createCLI` was returning void but callers were trying to call `.parse()` on the result
2. **Silent tool registration failures**: Schemas using `'prop': 'string | undefined'` syntax couldn't be converted to JSON Schema because `undefined` isn't a valid JSON type
3. **Transport instance recreation**: The `StreamableHTTPTransport` was being created per-request instead of reused, violating the @hono/mcp docs
4. **MCP protocol violation**: MCP requires all tool inputSchema to have `type: "object"` at root, but `insertMany`/`upsertMany`/`updateMany` were using bare arrays

## Changes

### CLI Fix
Removed redundant `.parse()` calls on `createCLI` result since it already calls `cli.parse()` internally.

### Schema Conversion Safety Net
Added fallback handlers to `safeToJsonSchema` that detect `unit: undefined` errors from the converter and return permissive fallbacks instead of crashing. While `'prop?': 'string'` is the preferred syntax for optional properties, this ensures backwards compatibility.

### MCP Transport Reuse
Create `StreamableHTTPTransport` once and reuse across requests. Added connection check to avoid reconnecting if already connected.

### MCP Object Input Requirement
Changed `toStandardSchemaArray()` and `toPartialStandardSchemaArray()` to return `{ rows: T[] }` instead of bare `T[]`. This is because MCP protocol requires all tool inputSchema to have `type: "object"` at the root level.

Updated batch operation handlers (`insertMany`, `upsertMany`, `updateMany`) to destructure the wrapped object.

### MCP Tool Registry Refactor
Refactored the MCP tool registry for better efficiency and compliance:

- Pre-compute JSON schemas once during registry build (parallelized with `Promise.all`)
- Filter out actions with non-object input schemas with a clear console warning
- Actions with array/primitive inputs still work via HTTP and TypeScript clients, just not MCP
- Extracted `buildToolEntry` and `buildMcpInputSchema` for clarity
- Made `createMcpServer` async to support parallel schema computation

The warning message explains what happened and how to fix it:
```
[MCP] Skipping tool "workspace_action": input has type "array" but MCP requires "object".
This action will still work via HTTP and TypeScript clients.
To enable MCP, wrap your input in an object (e.g., { rows: T[] } instead of T[]).
```

### Test Updates
- Updated `insertMany` calls to use `{ rows: [...] }` wrapper
- Fixed column names to use snake_case to comply with column naming validation