### PR TITLE
refactor(epicenter): add iterActions generator for functional action traversal

### DIFF
--- a/docs/patterns/function-extraction-balance.md
+++ b/docs/patterns/function-extraction-balance.md
@@ -8,8 +8,9 @@ I had this code for building an MCP tool registry:
 
 ```typescript
 async function buildMcpToolRegistry(client): Promise<Map<string, McpToolEntry>> {
-  const actions = [...iterActions(client)];
-  const entries = await Promise.all(actions.map(buildToolEntry));
+  const entries = await Promise.all(
+    iterActions(client).map(buildToolEntry)
+  );
   return new Map(entries.filter((e) => e !== undefined));
 }
 
@@ -53,7 +54,7 @@ Inline `buildToolEntry`, keep the schema function (renamed for clarity):
 ```typescript
 async function buildMcpToolRegistry(client): Promise<Map<string, McpToolEntry>> {
   const entries = await Promise.all(
-    [...iterActions(client)].map(async ({ workspaceId, actionPath, action }) => {
+    iterActions(client).map(async ({ workspaceId, actionPath, action }) => {
       const toolName = [workspaceId, ...actionPath].join('_');
       const inputSchema = await getValidInputSchema(action, toolName);
       if (!inputSchema) return undefined;

--- a/docs/patterns/function-extraction-balance.md
+++ b/docs/patterns/function-extraction-balance.md
@@ -1,0 +1,100 @@
+# Function Extraction: Finding the Right Balance
+
+There's a tension in code organization: every function should do one thing, but too many layers of abstraction creates exhausting indirection. Here's how I think about finding the balance.
+
+## The Problem
+
+I had this code for building an MCP tool registry:
+
+```typescript
+async function buildMcpToolRegistry(client): Promise<Map<string, McpToolEntry>> {
+  const actions = [...iterActions(client)];
+  const entries = await Promise.all(actions.map(buildToolEntry));
+  return new Map(entries.filter((e) => e !== undefined));
+}
+
+async function buildToolEntry(info: ActionInfo): Promise<[string, McpToolEntry] | undefined> {
+  const toolName = [info.workspaceId, ...info.actionPath].join('_');
+  const inputSchema = await buildMcpInputSchema(info.action, toolName);
+  if (!inputSchema) return undefined;
+  return [toolName, { action: info.action, inputSchema }];
+}
+
+async function buildMcpInputSchema(action: Action, toolName: string): Promise<JSONSchema7 | undefined> {
+  if (!action.input) return EMPTY_OBJECT_SCHEMA;
+  const schema = await safeToJsonSchema(action.input);
+  if (schema.type !== 'object' && schema.type !== undefined) {
+    console.warn(`[MCP] Skipping tool "${toolName}": input has type "${schema.type}" but MCP requires "object".`);
+    return undefined;
+  }
+  return schema;
+}
+```
+
+Three functions. Each does "one thing." But is this better than two? One?
+
+## The Heuristic
+
+I ask two questions:
+
+1. **Does the extracted function have real logic, or is it just glue?**
+2. **Would inlining it make the parent function unreadable?**
+
+Let's analyze each function:
+
+**`buildToolEntry`** (5 lines): This is pure glue code. It joins strings, calls another function, returns a tuple. No branching logic, no validation, no side effects beyond what it delegates. The name doesn't tell me anything I can't see from the code itself.
+
+**`buildMcpInputSchema`** (12 lines): This has real logic. It handles the empty-input case, validates the schema type, and logs a warning. The warning text alone justifies extraction; it's domain-specific behavior that clutters the main flow.
+
+## The Refactor
+
+Inline `buildToolEntry`, keep the schema function (renamed for clarity):
+
+```typescript
+async function buildMcpToolRegistry(client): Promise<Map<string, McpToolEntry>> {
+  const entries = await Promise.all(
+    [...iterActions(client)].map(async ({ workspaceId, actionPath, action }) => {
+      const toolName = [workspaceId, ...actionPath].join('_');
+      const inputSchema = await getValidInputSchema(action, toolName);
+      if (!inputSchema) return undefined;
+      return [toolName, { action, inputSchema }] as const;
+    }),
+  );
+
+  return new Map(entries.filter((e): e is NonNullable<typeof e> => e !== undefined));
+}
+
+async function getValidInputSchema(action: Action, toolName: string): Promise<JSONSchema7 | undefined> {
+  if (!action.input) return EMPTY_OBJECT_SCHEMA;
+  const schema = await safeToJsonSchema(action.input);
+  if (schema.type !== 'object' && schema.type !== undefined) {
+    console.warn(
+      `[MCP] Skipping tool "${toolName}": input has type "${schema.type}" but MCP requires "object".`
+    );
+    return undefined;
+  }
+  return schema;
+}
+```
+
+Two functions instead of three. The main function is slightly longer but completely readable. The inline callback is 5 lines; that's fine for a map operation.
+
+## When to Extract
+
+Extract a function when:
+- It has meaningful branching logic or validation
+- It has side effects worth naming (logging, I/O)
+- It's reused in multiple places
+- The parent function becomes unreadable without extraction
+
+Keep code inline when:
+- It's just data transformation (map, join, construct)
+- The "function" is 3-5 lines of straight-line code
+- Naming it doesn't add information beyond what the code shows
+- It's only called in one place
+
+## The Deeper Principle
+
+"One function, one thing" is about mental chunking, not line counts. A function should represent one conceptual step in a process. If that step is "build a tool entry from action info," and building a tool entry is trivial, then it's not worth naming.
+
+The goal is code you can read top-to-bottom without constantly jumping to definitions. Sometimes that means more functions. Sometimes fewer.

--- a/docs/patterns/function-extraction-balance.md
+++ b/docs/patterns/function-extraction-balance.md
@@ -1,10 +1,12 @@
 # Function Extraction: Finding the Right Balance
 
-There's a tension in code organization: every function should do one thing, but too many layers of abstraction creates exhausting indirection. Here's how I think about finding the balance.
+Every function should ideally do one thing, but too many functions creates unnecessary indirection and cognitive overhead.
+
+This is a key tension in code organization: what does "one thing" really mean? You shouldn't necessarily over extract functions so that they do one thing. You should think more about intent rather than imperative steps. In that way, functions do do one thing.
 
 ## The Problem
 
-I had this code for building an MCP tool registry:
+Consider the following code I wrote for building an MCP tool registry:
 
 ```typescript
 async function buildMcpToolRegistry(client): Promise<Map<string, McpToolEntry>> {
@@ -49,7 +51,9 @@ Let's analyze each function:
 
 ## The Refactor
 
-On closer inspection, both helper functions are essentially glue. The schema validation is straightforward enough to inline. The result is a single function that reads top-to-bottom:
+On closer inspection, the schema validation is straightforward enough to inline.
+
+Think: does `buildToolEntry` or `buildMcpInputSchema` really do something? Or does it make the reader more confused? The result is a single function that reads top-to-bottom:
 
 ```typescript
 async function buildMcpToolRegistry(client): Promise<Map<string, McpToolEntry>> {
@@ -96,6 +100,6 @@ Keep code inline when:
 
 ## The Deeper Principle
 
-"One function, one thing" is about mental chunking, not line counts. A function should represent one conceptual step in a process. If that step is "build a tool entry from action info," and building a tool entry is trivial, then it's not worth naming.
+"One function, one thing" is about mental chunking, not line counts. A function should represent one conceptual action, but not necessarily every step must be extracted into a smaller function. If that step is "build a tool entry from action info," and building a tool entry is trivial, then it's not worth naming.
 
 The goal is code you can read top-to-bottom without constantly jumping to definitions. Sometimes that means more functions. Sometimes fewer.

--- a/packages/epicenter/src/cli/server.ts
+++ b/packages/epicenter/src/cli/server.ts
@@ -54,7 +54,7 @@ export async function startServer(
 
 	console.log('📦 Available Tools:\n');
 	const actionsByWorkspace = Object.groupBy(
-		[...iterActions(client)],
+		iterActions(client),
 		(info) => info.workspaceId,
 	);
 

--- a/packages/epicenter/src/cli/server.ts
+++ b/packages/epicenter/src/cli/server.ts
@@ -1,4 +1,4 @@
-import { type EpicenterConfig, forEachAction } from '../core/epicenter';
+import { type EpicenterConfig, forEachAction, iterActions } from '../core/epicenter';
 import { createServer } from '../server/server';
 
 export const DEFAULT_PORT = 3913;
@@ -53,17 +53,14 @@ export async function startServer(
 	);
 
 	console.log('📦 Available Tools:\n');
-	const workspaceActions = new Map<string, string[][]>();
-	forEachAction(client, ({ workspaceId, actionPath }) => {
-		if (!workspaceActions.has(workspaceId)) {
-			workspaceActions.set(workspaceId, []);
-		}
-		workspaceActions.get(workspaceId)?.push(actionPath);
-	});
+	const actionsByWorkspace = Object.groupBy(
+		[...iterActions(client)],
+		(info) => info.workspaceId,
+	);
 
-	for (const [workspaceId, actionPaths] of workspaceActions) {
+	for (const [workspaceId, actions] of Object.entries(actionsByWorkspace)) {
 		console.log(`  • ${workspaceId}`);
-		for (const actionPath of actionPaths) {
+		for (const { actionPath } of actions ?? []) {
 			const mcpToolName = [workspaceId, ...actionPath].join('_');
 			console.log(`    └─ ${mcpToolName}`);
 		}

--- a/packages/epicenter/src/cli/server.ts
+++ b/packages/epicenter/src/cli/server.ts
@@ -1,4 +1,4 @@
-import { type EpicenterConfig, forEachAction, iterActions } from '../core/epicenter';
+import { type EpicenterConfig, iterActions } from '../core/epicenter';
 import { createServer } from '../server/server';
 
 export const DEFAULT_PORT = 3913;
@@ -41,11 +41,11 @@ export async function startServer(
 	console.log(`🔌 MCP Endpoint: http://localhost:${port}/mcp\n`);
 
 	console.log('📚 REST API Endpoints:\n');
-	forEachAction(client, ({ workspaceId, actionPath, action }) => {
+	for (const { workspaceId, actionPath, action } of iterActions(client)) {
 		const method = ({ query: 'GET', mutation: 'POST' } as const)[action.type];
 		const restPath = `/${workspaceId}/${actionPath.join('/')}`;
 		console.log(`  ${method} http://localhost:${port}${restPath}`);
-	});
+	}
 
 	console.log('\n🔧 Connect to Claude Code:\n');
 	console.log(

--- a/packages/epicenter/src/core/epicenter/client.ts
+++ b/packages/epicenter/src/core/epicenter/client.ts
@@ -191,29 +191,3 @@ export function* iterActions<TWorkspaces extends readonly AnyWorkspaceConfig[]>(
 	}
 }
 
-/**
- * Iterate over all workspace actions in an Epicenter client (callback-based).
- *
- * This is the imperative variant of {@link iterActions}. Use `iterActions` when you need
- * to collect, transform, or compose actions functionally. Use `forEachAction` for
- * simple side-effect operations like logging.
- *
- * @param client - The Epicenter client with workspace namespaces
- * @param callback - Function invoked for each action
- *
- * @example
- * ```typescript
- * // Log all REST endpoints
- * forEachAction(client, ({ workspaceId, actionPath, action }) => {
- *   const method = action.type === 'query' ? 'GET' : 'POST';
- *   console.log(`${method} /${workspaceId}/${actionPath.join('/')}`);
- * });
- * ```
- */
-export function forEachAction<
-	TWorkspaces extends readonly AnyWorkspaceConfig[],
->(client: EpicenterClient<TWorkspaces>, callback: (info: ActionInfo) => void): void {
-	for (const info of iterActions(client)) {
-		callback(info);
-	}
-}

--- a/packages/epicenter/src/core/epicenter/client.ts
+++ b/packages/epicenter/src/core/epicenter/client.ts
@@ -143,12 +143,12 @@ export type ActionInfo = {
  *
  * @example
  * ```typescript
- * // Collect all actions into an array
- * const actions = [...iterActions(client)];
+ * // Map over actions directly (Iterator Helpers)
+ * const toolNames = iterActions(client).map(info => info.workspaceId);
  *
  * // Group actions by workspace
  * const byWorkspace = Object.groupBy(
- *   [...iterActions(client)],
+ *   iterActions(client),
  *   info => info.workspaceId
  * );
  *

--- a/packages/epicenter/src/core/epicenter/index.ts
+++ b/packages/epicenter/src/core/epicenter/index.ts
@@ -2,6 +2,6 @@
 
 export type { ActionInfo, EpicenterClient } from './client';
 // Runtime (client side)
-export { createEpicenterClient, forEachAction, iterActions } from './client';
+export { createEpicenterClient, iterActions } from './client';
 export type { EpicenterConfig } from './config';
 export { defineEpicenter } from './config';

--- a/packages/epicenter/src/core/epicenter/index.ts
+++ b/packages/epicenter/src/core/epicenter/index.ts
@@ -1,7 +1,7 @@
 // Definition (config side)
 
-export type { EpicenterClient } from './client';
+export type { ActionInfo, EpicenterClient } from './client';
 // Runtime (client side)
-export { createEpicenterClient, forEachAction } from './client';
+export { createEpicenterClient, forEachAction, iterActions } from './client';
 export type { EpicenterConfig } from './config';
 export { defineEpicenter } from './config';

--- a/packages/epicenter/src/index.ts
+++ b/packages/epicenter/src/index.ts
@@ -65,12 +65,13 @@ export {
 	RowAlreadyExistsErr,
 	RowNotFoundErr,
 } from './core/db/table-helper';
-export type { EpicenterClient, EpicenterConfig } from './core/epicenter';
+export type { ActionInfo, EpicenterClient, EpicenterConfig } from './core/epicenter';
 // Epicenter - compose multiple workspaces
 export {
 	createEpicenterClient,
 	defineEpicenter,
 	forEachAction,
+	iterActions,
 } from './core/epicenter';
 export type {
 	EpicenterOperationError,

--- a/packages/epicenter/src/index.ts
+++ b/packages/epicenter/src/index.ts
@@ -70,7 +70,6 @@ export type { ActionInfo, EpicenterClient, EpicenterConfig } from './core/epicen
 export {
 	createEpicenterClient,
 	defineEpicenter,
-	forEachAction,
 	iterActions,
 } from './core/epicenter';
 export type {

--- a/packages/epicenter/src/server/mcp.ts
+++ b/packages/epicenter/src/server/mcp.ts
@@ -217,7 +217,7 @@ async function buildMcpToolRegistry<
 	TWorkspaces extends readonly AnyWorkspaceConfig[],
 >(client: EpicenterClient<TWorkspaces>): Promise<Map<string, McpToolEntry>> {
 	const entries = await Promise.all(
-		[...iterActions(client)].map(async ({ workspaceId, actionPath, action }) => {
+		iterActions(client).map(async ({ workspaceId, actionPath, action }) => {
 			const toolName = [workspaceId, ...actionPath].join('_');
 			const inputSchema = await getValidInputSchema(action, toolName);
 			if (!inputSchema) return undefined;

--- a/rules/typescript.md
+++ b/rules/typescript.md
@@ -3,6 +3,14 @@
 ## Core Rules
 
 - Always use `type` instead of `interface` in TypeScript.
+- TypeScript 5.5+ automatically infers type predicates in `.filter()` callbacks. Don't add manual type assertions:
+  ```typescript
+  // Good - TypeScript infers the narrowed type automatically
+  const filtered = items.filter((x) => x !== undefined);
+
+  // Bad - unnecessary type predicate
+  const filtered = items.filter((x): x is NonNullable<typeof x> => x !== undefined);
+  ```
 - When moving components to new locations, always update relative imports to absolute imports (e.g., change `import Component from '../Component.svelte'` to `import Component from '$lib/components/Component.svelte'`)
 - When functions are only used in the return statement of a factory/creator function, use object method shorthand syntax instead of defining them separately. For example, instead of:
   ```typescript


### PR DESCRIPTION
The existing `forEachAction` helper is imperative (callback-based), but it was being used functionally to build up data structures. This created awkward patterns like pushing to external arrays and manually implementing groupBy inside callbacks.

This PR introduces `iterActions` as a generator-based alternative that enables functional composition with standard library methods. The existing usage patterns transform from imperative to declarative:

```typescript
// Before (mcp.ts) - collect actions
const actions: ActionInfo[] = [];
forEachAction(client, (info) => actions.push(info));

// After
const actions = [...iterActions(client)];
```

```typescript
// Before (server.ts) - group by workspace
const workspaceActions = new Map<string, string[][]>();
forEachAction(client, ({ workspaceId, actionPath }) => {
    if (!workspaceActions.has(workspaceId)) {
        workspaceActions.set(workspaceId, []);
    }
    workspaceActions.get(workspaceId)?.push(actionPath);
});

// After
const actionsByWorkspace = Object.groupBy(
    [...iterActions(client)],
    info => info.workspaceId
);
```

The generator approach mirrors the existing `walkActions` pattern (which already uses generators internally), provides lazy evaluation for early breaks, and composes naturally with array methods.