### PR TITLE
perf(startup): parallelize async init operations to prevent white screen

### DIFF
--- a/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
+++ b/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import * as Dialog from '@repo/ui/dialog';
-	// import { extension } from '@repo/extension';
+	import { extension } from '@repo/extension';
 	import { createQuery } from '@tanstack/svelte-query';
 	import { onDestroy, onMount } from 'svelte';
 	import { goto } from '$app/navigation';
@@ -40,28 +40,32 @@
 	let cleanupAccessibilityPermission: (() => void) | undefined;
 	let cleanupMicrophonePermission: (() => void) | undefined;
 
-	onMount(async () => {
+	onMount(() => {
+		// Sync operations - run immediately, these are fast
 		window.commands = commandCallbacks;
 		window.goto = goto;
-
 		syncLocalShortcutsWithSettings();
 		resetLocalShortcutsToDefaultIfDuplicates();
-		await checkFfmpegRecordingMethodCompatibility();
-		await checkCompressionRecommendation();
+		registerOnboarding();
+		cleanupAccessibilityPermission = registerAccessibilityPermission();
+		cleanupMicrophonePermission = registerMicrophonePermission();
+
 		if (window.__TAURI_INTERNALS__) {
 			syncGlobalShortcutsWithSettings();
 			resetGlobalShortcutsToDefaultIfDuplicates();
-			await checkForUpdates();
-			await checkIndexedDBMigration();
-		} else {
-			// const _notifyWhisperingTabReadyResult =
-			// await extension.notifyWhisperingTabReady(undefined);
-		}
-		registerOnboarding();
 
-		// Register permission checkers separately
-		cleanupAccessibilityPermission = registerAccessibilityPermission();
-		cleanupMicrophonePermission = registerMicrophonePermission();
+			// Async operations - fire and forget, don't block UI rendering
+			// These show toasts/notifications on completion, no need to await
+			Promise.allSettled([
+				checkFfmpegRecordingMethodCompatibility(),
+				checkCompressionRecommendation(),
+				checkForUpdates(),
+				checkIndexedDBMigration(),
+			]);
+		} else {
+			// Browser extension context - notify that the Whispering tab is ready
+			extension.notifyWhisperingTabReady(undefined);
+		}
 	});
 
 	onDestroy(() => {


### PR DESCRIPTION
This addresses #918 where users reported a 30-second white screen on Windows before the app interface appeared.

The root cause was the `onMount` in `AppLayout.svelte` sequentially awaiting multiple async operations. On Windows with slow I/O (especially the IndexedDB migration check), this blocked UI rendering for an extended period.

The fix restructures initialization to separate sync operations (which run immediately) from async operations (which now run in parallel via `Promise.allSettled` without blocking):

**Sync operations (immediate, fast):**
- Window command/goto setup
- Local and global shortcut sync
- Onboarding registration
- Permission checkers

**Async operations (parallel, fire-and-forget):**
- FFmpeg compatibility checks
- Update check
- IndexedDB migration check

All async operations already handle their own errors internally (showing toasts or logging), so there's no need to await them or process their results. The UI can now render immediately while background checks complete.

Also re-enabled the `extension.notifyWhisperingTabReady` call for the browser extension context.