### PR TITLE
feat: add option to simulate Enter keystroke after transcription

### DIFF
--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -77,6 +77,7 @@ pub async fn run() {
     // Register command handlers (same for all platforms now)
     let builder = builder.invoke_handler(tauri::generate_handler![
         write_text,
+        simulate_enter_keystroke,
         // Audio recorder commands
         get_current_recording_id,
         enumerate_recording_devices,
@@ -179,6 +180,22 @@ async fn write_text(app: tauri::AppHandle, text: String) -> Result<(), String> {
             .write_text(&content)
             .map_err(|e| format!("Failed to restore clipboard: {}", e))?;
     }
+
+    Ok(())
+}
+
+/// Simulates pressing the Enter/Return key
+///
+/// This is useful for automatically submitting text in chat applications
+/// after transcription has been pasted.
+#[tauri::command]
+async fn simulate_enter_keystroke() -> Result<(), String> {
+    let mut enigo = Enigo::new(&Settings::default()).map_err(|e| e.to_string())?;
+
+    // Use Direction::Click for a combined press+release action
+    enigo
+        .key(Key::Return, Direction::Click)
+        .map_err(|e| format!("Failed to simulate Enter key: {}", e))?;
 
     Ok(())
 }

--- a/apps/whispering/src/lib/query/delivery.ts
+++ b/apps/whispering/src/lib/query/delivery.ts
@@ -171,6 +171,18 @@ export const delivery = {
 				});
 				if (!writeError) {
 					written = true;
+					// Optionally simulate Enter keystroke after successful write
+					if (settings.value['transcription.simulateEnterAfterOutput']) {
+						const { error: enterError } =
+							await rpc.text.simulateEnterKeystroke.execute();
+						if (enterError) {
+							rpc.notify.warning.execute({
+								title: 'Unable to simulate Enter keystroke',
+								description: enterError.message,
+								action: { type: 'more-details', error: enterError },
+							});
+						}
+					}
 				} else {
 					warnWriteToCursorFailed(writeError);
 				}
@@ -347,6 +359,18 @@ export const delivery = {
 				});
 				if (!writeError) {
 					written = true;
+					// Optionally simulate Enter keystroke after successful write
+					if (settings.value['transformation.simulateEnterAfterOutput']) {
+						const { error: enterError } =
+							await rpc.text.simulateEnterKeystroke.execute();
+						if (enterError) {
+							rpc.notify.warning.execute({
+								title: 'Unable to simulate Enter keystroke',
+								description: enterError.message,
+								action: { type: 'more-details', error: enterError },
+							});
+						}
+					}
 				} else {
 					warnWriteToCursorFailed(writeError);
 				}

--- a/apps/whispering/src/lib/query/text.ts
+++ b/apps/whispering/src/lib/query/text.ts
@@ -6,6 +6,7 @@ const textKeys = {
 	readFromClipboard: ['text', 'readFromClipboard'] as const,
 	copyToClipboard: ['text', 'copyToClipboard'] as const,
 	writeToCursor: ['text', 'writeToCursor'] as const,
+	simulateEnterKeystroke: ['text', 'simulateEnterKeystroke'] as const,
 } as const;
 
 export const text = {
@@ -28,5 +29,9 @@ export const text = {
 			// 4. Restores original clipboard
 			return await services.text.writeToCursor(text);
 		},
+	}),
+	simulateEnterKeystroke: defineMutation({
+		mutationKey: textKeys.simulateEnterKeystroke,
+		resultMutationFn: () => services.text.simulateEnterKeystroke(),
 	}),
 };

--- a/apps/whispering/src/lib/services/text/desktop.ts
+++ b/apps/whispering/src/lib/services/text/desktop.ts
@@ -44,5 +44,17 @@ export function createTextServiceDesktop(): TextService {
 						cause: error,
 					}),
 			}),
+
+		simulateEnterKeystroke: () =>
+			tryAsync({
+				try: () => invoke<void>('simulate_enter_keystroke'),
+				catch: (error) =>
+					TextServiceErr({
+						message:
+							'There was an error simulating the Enter keystroke. Please press Enter manually.',
+						context: {},
+						cause: error,
+					}),
+			}),
 	};
 }

--- a/apps/whispering/src/lib/services/text/extension.ts
+++ b/apps/whispering/src/lib/services/text/extension.ts
@@ -3,6 +3,20 @@ import { type TextService, TextServiceErr } from './types';
 
 export function createTextServiceExtension(): TextService {
 	return {
+		readFromClipboard: () =>
+			tryAsync({
+				try: async () => {
+					const text = await navigator.clipboard.readText();
+					return text || null;
+				},
+				catch: (error) =>
+					TextServiceErr({
+						message: 'Unable to read from clipboard',
+						context: {},
+						cause: error,
+					}),
+			}),
+
 		copyToClipboard: (text) =>
 			tryAsync({
 				try: () => navigator.clipboard.writeText(text),
@@ -27,6 +41,14 @@ export function createTextServiceExtension(): TextService {
 						context: { text },
 						cause: error,
 					}),
+			}),
+
+		simulateEnterKeystroke: async () =>
+			TextServiceErr({
+				message:
+					'Simulating keystrokes is not supported in browser extensions for security reasons.',
+				context: {},
+				cause: undefined,
 			}),
 	};
 }

--- a/apps/whispering/src/lib/services/text/types.ts
+++ b/apps/whispering/src/lib/services/text/types.ts
@@ -35,4 +35,13 @@ export type TextService = {
 	writeToCursor: (
 		text: string,
 	) => MaybePromise<Result<void, TextServiceError | WhisperingError>>;
+
+	/**
+	 * Simulates pressing the Enter/Return key.
+	 * Useful for automatically submitting text in chat applications after transcription.
+	 *
+	 * Note: This is only supported on desktop (Tauri). Web browsers cannot simulate keystrokes
+	 * for security reasons.
+	 */
+	simulateEnterKeystroke: () => Promise<Result<void, TextServiceError>>;
 };

--- a/apps/whispering/src/lib/services/text/web.ts
+++ b/apps/whispering/src/lib/services/text/web.ts
@@ -50,5 +50,13 @@ export function createTextServiceWeb(): TextService {
 				cause: undefined,
 			});
 		},
+
+		simulateEnterKeystroke: async () =>
+			TextServiceErr({
+				message:
+					'Simulating keystrokes is not supported in web browsers for security reasons.',
+				context: {},
+				cause: undefined,
+			}),
 	};
 }

--- a/apps/whispering/src/lib/settings/settings.ts
+++ b/apps/whispering/src/lib/settings/settings.ts
@@ -97,8 +97,10 @@ export const settingsSchema = z.object({
 
 	'transcription.copyToClipboardOnSuccess': z.boolean().default(true),
 	'transcription.writeToCursorOnSuccess': z.boolean().default(true),
+	'transcription.simulateEnterAfterOutput': z.boolean().default(false),
 	'transformation.copyToClipboardOnSuccess': z.boolean().default(true),
 	'transformation.writeToCursorOnSuccess': z.boolean().default(false),
+	'transformation.simulateEnterAfterOutput': z.boolean().default(false),
 
 	'system.alwaysOnTop': z.enum(ALWAYS_ON_TOP_VALUES).default('Never'),
 

--- a/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
@@ -41,6 +41,17 @@
 		}
 	/>
 
+	{#if window.__TAURI_INTERNALS__ && settings.value['transcription.writeToCursorOnSuccess']}
+		<LabeledSwitch
+			id="transcription.simulateEnterAfterOutput"
+			label="Press Enter after pasting transcript"
+			bind:checked={
+				() => settings.value['transcription.simulateEnterAfterOutput'],
+				(v) => settings.updateKey('transcription.simulateEnterAfterOutput', v)
+			}
+		/>
+	{/if}
+
 	<Separator />
 
 	<LabeledSwitch
@@ -60,6 +71,17 @@
 			(v) => settings.updateKey('transformation.writeToCursorOnSuccess', v)
 		}
 	/>
+
+	{#if window.__TAURI_INTERNALS__ && settings.value['transformation.writeToCursorOnSuccess']}
+		<LabeledSwitch
+			id="transformation.simulateEnterAfterOutput"
+			label="Press Enter after pasting transformed text"
+			bind:checked={
+				() => settings.value['transformation.simulateEnterAfterOutput'],
+				(v) => settings.updateKey('transformation.simulateEnterAfterOutput', v)
+			}
+		/>
+	{/if}
 
 	<Separator />
 

--- a/specs/20251129T000000-enter-after-transcription.md
+++ b/specs/20251129T000000-enter-after-transcription.md
@@ -1,0 +1,118 @@
+# Feature: Simulate Enter Keystroke After Transcription
+
+## Context
+
+From [GitHub Issue #720](https://github.com/EpicenterHQ/epicenter/issues/720):
+
+> Is there a way to submit the enter key after a transcription is successfully pasted? Question for normal transcribe and also voice activated.
+
+Users want an option to automatically press Enter after transcription is pasted. This is useful for chat applications where pressing Enter submits the message.
+
+## Implementation Plan
+
+### 1. Settings Schema Update (`settings.ts`)
+
+- [ ] Add `'transcription.simulateEnterAfterOutput': z.boolean().default(false)`
+- [ ] Add `'transformation.simulateEnterAfterOutput': z.boolean().default(false)`
+
+### 2. Rust Command (`lib.rs`)
+
+- [ ] Add new Tauri command `simulate_enter_keystroke` that:
+  - Uses `enigo` to press and release the Enter/Return key
+  - Handles all three platforms (macOS, Windows, Linux)
+
+### 3. TextService Update
+
+- [ ] Add `simulateEnterKeystroke()` method to `TextService` type in `types.ts`
+- [ ] Implement in `desktop.ts`: Calls Tauri command `simulate_enter_keystroke`
+- [ ] Implement in `web.ts`: Returns error (browsers can't simulate keystrokes)
+- [ ] Update `extension.ts` if needed
+
+### 4. Text RPC Layer (`query/text.ts`)
+
+- [ ] Add `simulateEnterKeystroke` query/mutation definition
+
+### 5. Delivery Logic Update (`delivery.ts`)
+
+- [ ] In `deliverTranscriptionResult`: After write-to-cursor succeeds and setting is enabled, call `simulateEnterKeystroke`
+- [ ] In `deliverTransformationResult`: Same logic for transformation
+
+Note: Enter should only be simulated when `writeToCursorOnSuccess` is enabled AND the new `simulateEnterAfterOutput` setting is enabled.
+
+### 6. Settings UI (`settings/+page.svelte`)
+
+- [ ] Add "Press Enter after pasting transcript" switch (under "Paste transcript at cursor")
+- [ ] Add "Press Enter after pasting transformed text" switch (under "Paste transformed text at cursor")
+- [ ] These switches should only be visible/enabled when their parent "Paste..." setting is enabled
+
+## Technical Notes
+
+### Enigo Enter Key Implementation
+
+```rust
+// Enter key on all platforms
+let enter_key = Key::Return;
+
+enigo.key(enter_key, Direction::Press)?;
+enigo.key(enter_key, Direction::Release)?;
+```
+
+### Flow Diagram
+
+```
+Recording → Transcription → Delivery
+                              ↓
+                    Check settings
+                              ↓
+          ┌─────────────────────────────────────┐
+          │ copyToClipboardOnSuccess?           │
+          │        ↓ yes                        │
+          │    Copy to clipboard                │
+          └─────────────────────────────────────┘
+                              ↓
+          ┌─────────────────────────────────────┐
+          │ writeToCursorOnSuccess?             │
+          │        ↓ yes                        │
+          │    Write to cursor (paste)          │
+          │        ↓                            │
+          │ simulateEnterAfterOutput?           │
+          │        ↓ yes                        │
+          │    Simulate Enter keystroke         │
+          └─────────────────────────────────────┘
+```
+
+## Review
+
+### Changes Made
+
+1. **Settings** (`apps/whispering/src/lib/settings/settings.ts`):
+   - Added `transcription.simulateEnterAfterOutput` (default: false)
+   - Added `transformation.simulateEnterAfterOutput` (default: false)
+
+2. **Rust Command** (`apps/whispering/src-tauri/src/lib.rs`):
+   - Added `simulate_enter_keystroke` Tauri command using `enigo` crate
+   - Registered in command handler
+
+3. **TextService**:
+   - `types.ts`: Added `simulateEnterKeystroke()` method to type definition
+   - `desktop.ts`: Implemented via Tauri `invoke('simulate_enter_keystroke')`
+   - `web.ts`: Returns error (not supported in browsers)
+   - `extension.ts`: Returns error (not supported in extensions) + added missing `readFromClipboard`
+
+4. **Text RPC** (`apps/whispering/src/lib/query/text.ts`):
+   - Added `simulateEnterKeystroke` mutation
+
+5. **Delivery** (`apps/whispering/src/lib/query/delivery.ts`):
+   - Both `deliverTranscriptionResult` and `deliverTransformationResult` now call `simulateEnterKeystroke` when:
+     - Write to cursor succeeds
+     - `simulateEnterAfterOutput` setting is enabled
+
+6. **Settings UI** (`apps/whispering/src/routes/(app)/(config)/settings/+page.svelte`):
+   - Added "Press Enter after pasting transcript" switch (transcription)
+   - Added "Press Enter after pasting transformed text" switch (transformation)
+   - Both only visible on desktop (`window.__TAURI_INTERNALS__`) when their parent paste setting is enabled
+
+### Build Status
+
+- TypeScript: Pre-existing type errors in the codebase (unrelated to this feature)
+- Rust: Compiles successfully (only pre-existing unused import warning)


### PR DESCRIPTION
This adds a new setting that allows users to automatically press Enter after transcription or transformation text is pasted at the cursor. This is useful for chat applications like Slack, Discord, or iMessage where pressing Enter submits the message.

The implementation uses the `enigo` crate (already used for paste simulation) with `Key::Return` and `Direction::Click`, which DeepWiki confirmed is the idiomatic approach. The feature is desktop-only since browsers cannot simulate keystrokes for security reasons.

The setting only appears in the UI when the parent "paste at cursor" setting is enabled, and is gated behind `window.__TAURI_INTERNALS__` so web users don't see an option they can't use.

Closes #720