### PR TITLE
feat(db): add Recording schema versioning and V6→V7 migration

### DIFF
--- a/apps/whispering/src/lib/query/actions.ts
+++ b/apps/whispering/src/lib/query/actions.ts
@@ -2,6 +2,7 @@ import { nanoid } from 'nanoid/non-secure';
 import { Err, Ok } from 'wellcrafted/result';
 import { fromTaggedError, WhisperingErr } from '$lib/result';
 import { DbServiceErr } from '$lib/services/db';
+import { CURRENT_RECORDING_VERSION } from '$lib/services/db/models';
 import { settings } from '$lib/stores/settings.svelte';
 import * as transformClipboardWindow from '../../routes/transform-clipboard/transformClipboardWindow.tauri';
 import { rpc } from './';
@@ -623,6 +624,7 @@ async function processRecordingPipeline({
 
 	const recording = {
 		id: newRecordingId,
+		version: CURRENT_RECORDING_VERSION,
 		title: '',
 		subtitle: '',
 		timestamp: now,

--- a/apps/whispering/src/lib/services/db/file-system.ts
+++ b/apps/whispering/src/lib/services/db/file-system.ts
@@ -45,6 +45,7 @@ function parseMarkdownToRecording(
 ): Result<Recording, { summary: string }> {
 	const { data: frontMatter, content: body } = matter(content);
 
+	// Recording validator accepts V6 or V7 input and always outputs V7
 	const result = Recording({
 		...frontMatter,
 		transcribedText: body, // V6 schema: body maps to transcribedText, version defaults to 6

--- a/apps/whispering/src/lib/services/db/file-system.ts
+++ b/apps/whispering/src/lib/services/db/file-system.ts
@@ -14,7 +14,7 @@ import { Ok, tryAsync } from 'wellcrafted/result';
 import { getExtensionFromMimeType } from '$lib/constants/mime';
 import { PATHS } from '$lib/constants/paths';
 import * as services from '$lib/services';
-import type { Recording } from './models';
+import { CURRENT_RECORDING_VERSION, type Recording } from './models';
 import { Transformation, TransformationRun } from './models';
 import type { DbService } from './types';
 import { DbServiceErr } from './types';
@@ -36,14 +36,16 @@ type RecordingFrontMatter = typeof RecordingFrontMatter.infer;
 
 /**
  * Convert Recording to markdown format (frontmatter + body)
+ * The version field is excluded from frontmatter as it's only used for IndexedDB migrations.
  */
 function recordingToMarkdown(recording: Recording): string {
-	const { transcript, ...frontMatter } = recording;
+	const { transcript, version: _version, ...frontMatter } = recording;
 	return matter.stringify(transcript ?? '', frontMatter);
 }
 
 /**
  * Convert markdown file (YAML frontmatter + body) to Recording
+ * Always constructs with current version as desktop storage doesn't track versions.
  */
 function markdownToRecording({
 	frontMatter,
@@ -54,6 +56,7 @@ function markdownToRecording({
 }): Recording {
 	return {
 		...frontMatter,
+		version: CURRENT_RECORDING_VERSION,
 		transcript: body,
 	};
 }

--- a/apps/whispering/src/lib/services/db/file-system.ts
+++ b/apps/whispering/src/lib/services/db/file-system.ts
@@ -14,12 +14,7 @@ import { Ok, tryAsync } from 'wellcrafted/result';
 import { getExtensionFromMimeType } from '$lib/constants/mime';
 import { PATHS } from '$lib/constants/paths';
 import * as services from '$lib/services';
-import {
-	CURRENT_RECORDING_VERSION,
-	Recording,
-	type Recording as RecordingType,
-} from './models';
-import { Transformation, TransformationRun } from './models';
+import { Recording, Transformation, TransformationRun } from './models';
 import type { DbService } from './types';
 import { DbServiceErr } from './types';
 
@@ -34,7 +29,7 @@ import { DbServiceErr } from './types';
  * they always store transcript in the body (never had transcribedText in frontmatter).
  * When reading, we use the Recording validator which handles any schema version.
  */
-function recordingToMarkdown(recording: RecordingType): string {
+function recordingToMarkdown(recording: Recording): string {
 	const { transcript, version: _version, ...frontMatter } = recording;
 	return matter.stringify(transcript ?? '', frontMatter);
 }
@@ -53,7 +48,7 @@ function recordingToMarkdown(recording: RecordingType): string {
  */
 function parseMarkdownToRecording(
 	content: string,
-): RecordingType | { error: string } {
+): Recording | { error: string } {
 	const { data: frontMatter, content: body } = matter(content);
 
 	// Combine frontmatter + body, defaulting version to 6 for old files without version
@@ -131,7 +126,7 @@ export function createFileSystemDb(): DbService {
 
 						// Filter out any null entries and sort by timestamp (newest first)
 						const validRecordings = recordings.filter(
-							(r): r is RecordingType => r !== null,
+							(r): r is Recording => r !== null,
 						);
 						validRecordings.sort(
 							(a, b) =>
@@ -219,7 +214,7 @@ export function createFileSystemDb(): DbService {
 					recording,
 					audio,
 				}: {
-					recording: RecordingType;
+					recording: Recording;
 					audio: Blob;
 				}): Promise<void> => {
 					const recordingsPath = await PATHS.DB.RECORDINGS();
@@ -277,7 +272,7 @@ export function createFileSystemDb(): DbService {
 				const recordingWithTimestamp = {
 					...recording,
 					updatedAt: now,
-				} satisfies RecordingType;
+				} satisfies Recording;
 
 				return tryAsync({
 					try: async () => {

--- a/apps/whispering/src/lib/services/db/index.ts
+++ b/apps/whispering/src/lib/services/db/index.ts
@@ -12,6 +12,7 @@ export type {
 	TransformationStepRun,
 } from './models';
 export {
+	CURRENT_RECORDING_VERSION,
 	generateDefaultTransformation,
 	generateDefaultTransformationStep,
 	TRANSFORMATION_STEP_TYPES,

--- a/apps/whispering/src/lib/services/db/models/index.ts
+++ b/apps/whispering/src/lib/services/db/models/index.ts
@@ -25,8 +25,7 @@ export {
 	TransformationStepRunRunning,
 } from './transformation-runs';
 export type {
-	TransformationStepV1,
-	TransformationStepV2,
+	TransformationStep,
 	TransformationV1,
 	TransformationV2,
 } from './transformations';
@@ -37,5 +36,4 @@ export {
 	TRANSFORMATION_STEP_TYPES,
 	TRANSFORMATION_STEP_TYPES_TO_LABELS,
 	Transformation,
-	TransformationStep,
 } from './transformations';

--- a/apps/whispering/src/lib/services/db/models/index.ts
+++ b/apps/whispering/src/lib/services/db/models/index.ts
@@ -1,7 +1,9 @@
 // Recordings
-
-export type {
+export {
+	CURRENT_RECORDING_VERSION,
 	Recording,
+} from './recordings';
+export type {
 	RecordingStoredInIndexedDB,
 	RecordingsDbSchemaV1,
 	RecordingsDbSchemaV2,
@@ -10,10 +12,6 @@ export type {
 	RecordingsDbSchemaV5,
 	RecordingsDbSchemaV6,
 	SerializedAudio,
-} from './recordings';
-export {
-	CURRENT_RECORDING_VERSION,
-	validateAndMigrateRecording,
 } from './recordings';
 // Transformation Runs
 export {

--- a/apps/whispering/src/lib/services/db/models/index.ts
+++ b/apps/whispering/src/lib/services/db/models/index.ts
@@ -1,4 +1,5 @@
 // Recordings
+
 export type {
 	Recording,
 	RecordingStoredInIndexedDB,
@@ -7,7 +8,12 @@ export type {
 	RecordingsDbSchemaV3,
 	RecordingsDbSchemaV4,
 	RecordingsDbSchemaV5,
+	RecordingsDbSchemaV6,
 	SerializedAudio,
+} from './recordings';
+export {
+	CURRENT_RECORDING_VERSION,
+	validateAndMigrateRecording,
 } from './recordings';
 // Transformation Runs
 export {

--- a/apps/whispering/src/lib/services/db/models/recordings.ts
+++ b/apps/whispering/src/lib/services/db/models/recordings.ts
@@ -70,7 +70,18 @@ type RecordingV7 = typeof RecordingV7.infer;
 
 /**
  * Recording validator with automatic migration.
- * Accepts V6 or V7 and always outputs V7.
+ *
+ * Input: Raw object with either V6 fields (transcribedText) or V7 fields (transcript).
+ *        If version is missing, defaults to 6.
+ *
+ * Output: Always returns the latest schema (V7) with 'transcript' field.
+ *         V6 inputs are automatically migrated via the .pipe() transformation.
+ *
+ * Usage:
+ * ```ts
+ * const result = Recording({ ...frontMatter, transcribedText: body });
+ * // result is always V7 shape: { version: 7, transcript: string, ... }
+ * ```
  */
 export const Recording = RecordingV6.or(RecordingV7).pipe(
 	(recording): RecordingV7 => {

--- a/apps/whispering/src/lib/services/db/models/recordings.ts
+++ b/apps/whispering/src/lib/services/db/models/recordings.ts
@@ -79,56 +79,26 @@ type RecordingV7 = {
 };
 
 // ============================================================================
-// MIGRATING VALIDATORS
+// MIGRATING VALIDATOR
 // ============================================================================
-// These accept any version and migrate to the latest (V7).
-// Use these when reading data that might be from an older schema version.
-// ============================================================================
-
-/**
- * Migrates a Recording from V6 to V7.
- * Renames 'transcribedText' to 'transcript'.
- */
-function migrateV6ToV7(recording: RecordingV6): Recording {
-	const { transcribedText, version: _version, ...rest } = recording;
-	return {
-		...rest,
-		version: 7,
-		transcript: transcribedText,
-	};
-}
 
 /**
  * Recording validator with automatic migration.
  * Accepts V6 or V7 and always outputs V7.
- *
- * Use this when reading data that might contain old schema versions.
- * Internal use only - not exported to avoid type conflicts.
  */
-const RecordingMigrator = RecordingV6.or(RecordingV7).pipe(
-	(recording): Recording => {
+export const Recording = RecordingV6.or(RecordingV7).pipe(
+	(recording): RecordingV7 => {
 		if (recording.version === 6) {
-			return migrateV6ToV7(recording);
+			const { transcribedText, version: _version, ...rest } = recording;
+			return {
+				...rest,
+				version: 7,
+				transcript: transcribedText,
+			};
 		}
 		return recording;
 	},
 );
-
-/**
- * Validate and migrate a recording from any version to current (V7).
- * Use this when reading data that might be from an older schema version.
- */
-export function validateAndMigrateRecording(data: unknown): Recording | null {
-	const result = RecordingMigrator(data);
-	if (result instanceof type.errors) {
-		console.error('Recording validation failed:', result.summary);
-		return null;
-	}
-	return result;
-}
-
-/** Current version constant for use when creating new recordings */
-export { CURRENT_RECORDING_VERSION };
 
 /**
  * Recording intermediate representation.

--- a/apps/whispering/src/lib/services/db/models/recordings.ts
+++ b/apps/whispering/src/lib/services/db/models/recordings.ts
@@ -113,8 +113,10 @@ export const Recording = RecordingV6.or(RecordingV7).pipe(
  * - `db.recordings.getAudioBlob(id)` to fetch audio as a Blob
  * - `db.recordings.ensureAudioPlaybackUrl(id)` to get a playback URL
  * - `db.recordings.revokeAudioUrl(id)` to clean up cached URLs
+ *
+ * Derived from the migrating validator's output type.
  */
-export type Recording = RecordingV7;
+export type Recording = typeof Recording.infer;
 
 // ============================================================================
 // INDEXEDDB STORAGE TYPES

--- a/apps/whispering/src/lib/services/db/models/recordings.ts
+++ b/apps/whispering/src/lib/services/db/models/recordings.ts
@@ -155,37 +155,105 @@ export type RecordingStoredInIndexedDB = Recording & {
 // ============================================================================
 // DEXIE SCHEMA VERSIONS (for IndexedDB migrations)
 // ============================================================================
-// These types represent the structure of the IndexedDB tables at each Dexie version.
-// They are separate from the Recording schema versions above.
+// FROZEN SNAPSHOTS: Each type is a complete, self-contained definition of what
+// the data looked like at that Dexie version. Do not derive from current types!
+// When Recording changes, these historical types must NOT change.
 // ============================================================================
 
+/**
+ * Dexie v0.7 (CURRENT): Recording V7 with 'transcript' field and 'version' field.
+ * FROZEN: This represents the schema after the V6→V7 migration.
+ */
 export type RecordingsDbSchemaV6 = {
-	recordings: RecordingStoredInIndexedDB;
-};
-
-export type RecordingsDbSchemaV5 = {
-	recordings: Omit<RecordingStoredInIndexedDB, 'transcript' | 'version'> & {
-		transcribedText: string;
-	};
-};
-
-export type RecordingsDbSchemaV4 = {
-	recordings: RecordingsDbSchemaV3['recordings'] & {
-		// V4 added 'createdAt' and 'updatedAt' fields
+	recordings: {
+		id: string;
+		title: string;
+		subtitle: string;
+		timestamp: string;
 		createdAt: string;
 		updatedAt: string;
+		version: 7;
+		transcript: string;
+		transcriptionStatus: 'UNPROCESSED' | 'TRANSCRIBING' | 'DONE' | 'FAILED';
+		serializedAudio: SerializedAudio | undefined;
 	};
 };
 
+/**
+ * Dexie v0.5: Recording with 'transcribedText' field, no 'version' field.
+ * FROZEN: This represents the schema BEFORE the V6→V7 migration.
+ */
+export type RecordingsDbSchemaV5 = {
+	recordings: {
+		id: string;
+		title: string;
+		subtitle: string;
+		timestamp: string;
+		createdAt: string;
+		updatedAt: string;
+		transcribedText: string;
+		transcriptionStatus: 'UNPROCESSED' | 'TRANSCRIBING' | 'DONE' | 'FAILED';
+		serializedAudio: SerializedAudio | undefined;
+	};
+};
+
+/**
+ * Dexie v0.4: Added createdAt/updatedAt, still uses Blob for audio.
+ * FROZEN: Do not modify.
+ */
+export type RecordingsDbSchemaV4 = {
+	recordings: {
+		id: string;
+		title: string;
+		subtitle: string;
+		timestamp: string;
+		createdAt: string;
+		updatedAt: string;
+		transcribedText: string;
+		transcriptionStatus: 'UNPROCESSED' | 'TRANSCRIBING' | 'DONE' | 'FAILED';
+		blob: Blob | undefined;
+	};
+};
+
+/**
+ * Dexie v0.3: Merged recordingMetadata + recordingBlobs back into recordings.
+ * FROZEN: Do not modify.
+ */
 export type RecordingsDbSchemaV3 = {
-	recordings: RecordingsDbSchemaV1['recordings'];
+	recordings: {
+		id: string;
+		title: string;
+		subtitle: string;
+		timestamp: string;
+		transcribedText: string;
+		transcriptionStatus: 'UNPROCESSED' | 'TRANSCRIBING' | 'DONE' | 'FAILED';
+		blob: Blob | undefined;
+	};
 };
 
+/**
+ * Dexie v0.2: Split recordings into recordingMetadata + recordingBlobs.
+ * FROZEN: Do not modify.
+ */
 export type RecordingsDbSchemaV2 = {
-	recordingMetadata: Omit<RecordingsDbSchemaV1['recordings'], 'blob'>;
-	recordingBlobs: { id: string; blob: Blob | undefined };
+	recordingMetadata: {
+		id: string;
+		title: string;
+		subtitle: string;
+		timestamp: string;
+		transcribedText: string;
+		transcriptionStatus: 'UNPROCESSED' | 'TRANSCRIBING' | 'DONE' | 'FAILED';
+	};
+	recordingBlobs: {
+		id: string;
+		blob: Blob | undefined;
+	};
 };
 
+/**
+ * Dexie v0.1: Original recordings table with Blob storage.
+ * FROZEN: Do not modify.
+ */
 export type RecordingsDbSchemaV1 = {
 	recordings: {
 		id: string;
@@ -193,14 +261,7 @@ export type RecordingsDbSchemaV1 = {
 		subtitle: string;
 		timestamp: string;
 		transcribedText: string;
-		blob: Blob | undefined;
-		/**
-		 * A recording
-		 * 1. Begins in an 'UNPROCESSED' state
-		 * 2. Moves to 'TRANSCRIBING' while the audio is being transcribed
-		 * 3. Finally is marked as 'DONE' when the transcription is complete.
-		 * 4. If the transcription fails, it is marked as 'FAILED'
-		 */
 		transcriptionStatus: 'UNPROCESSED' | 'TRANSCRIBING' | 'DONE' | 'FAILED';
+		blob: Blob | undefined;
 	};
 };

--- a/apps/whispering/src/lib/services/db/models/recordings.ts
+++ b/apps/whispering/src/lib/services/db/models/recordings.ts
@@ -8,7 +8,7 @@ import { type } from 'arktype';
  * - V6: Original schema with 'transcribedText' field (implicit, no version field stored)
  * - V7: Renamed 'transcribedText' to 'transcript'
  */
-const CURRENT_RECORDING_VERSION = 7 as const;
+export const CURRENT_RECORDING_VERSION = 7 as const;
 
 // ============================================================================
 // VERSION 6 (FROZEN)
@@ -62,21 +62,7 @@ const RecordingV7 = type({
 	transcriptionStatus: '"UNPROCESSED" | "TRANSCRIBING" | "DONE" | "FAILED"',
 });
 
-// NOTE: We use an explicit type here rather than `typeof RecordingV7.infer`
-// because arktype's inferred types cause "two different types with this name"
-// errors when the type flows through re-exports. The explicit type ensures
-// TypeScript sees a consistent type across all import paths.
-type RecordingV7 = {
-	version: 7;
-	id: string;
-	title: string;
-	subtitle: string;
-	timestamp: string;
-	createdAt: string;
-	updatedAt: string;
-	transcript: string;
-	transcriptionStatus: 'UNPROCESSED' | 'TRANSCRIBING' | 'DONE' | 'FAILED';
-};
+type RecordingV7 = typeof RecordingV7.infer;
 
 // ============================================================================
 // MIGRATING VALIDATOR

--- a/apps/whispering/src/lib/services/db/models/recordings.ts
+++ b/apps/whispering/src/lib/services/db/models/recordings.ts
@@ -32,7 +32,7 @@ const RecordingV6 = type({
 	transcriptionStatus: '"UNPROCESSED" | "TRANSCRIBING" | "DONE" | "FAILED"',
 });
 
-type RecordingV6 = typeof RecordingV6.infer;
+export type RecordingV6 = typeof RecordingV6.infer;
 
 // ============================================================================
 // VERSION 7 (CURRENT)
@@ -62,7 +62,7 @@ const RecordingV7 = type({
 	transcriptionStatus: '"UNPROCESSED" | "TRANSCRIBING" | "DONE" | "FAILED"',
 });
 
-type RecordingV7 = typeof RecordingV7.infer;
+export type RecordingV7 = typeof RecordingV7.infer;
 
 // ============================================================================
 // MIGRATING VALIDATOR
@@ -155,46 +155,24 @@ export type RecordingStoredInIndexedDB = Recording & {
 // ============================================================================
 // DEXIE SCHEMA VERSIONS (for IndexedDB migrations)
 // ============================================================================
-// FROZEN SNAPSHOTS: Each type is a complete, self-contained definition of what
-// the data looked like at that Dexie version. Do not derive from current types!
-// When Recording changes, these historical types must NOT change.
+// V6 and V5 derive from their respective arktype validators.
+// V4 and earlier are FROZEN SNAPSHOTS since they predate the versioned validators.
 // ============================================================================
 
 /**
  * Dexie v0.7 (CURRENT): Recording V7 with 'transcript' field and 'version' field.
- * FROZEN: This represents the schema after the V6→V7 migration.
+ * Derives from RecordingV7 arktype validator.
  */
 export type RecordingsDbSchemaV6 = {
-	recordings: {
-		id: string;
-		title: string;
-		subtitle: string;
-		timestamp: string;
-		createdAt: string;
-		updatedAt: string;
-		version: 7;
-		transcript: string;
-		transcriptionStatus: 'UNPROCESSED' | 'TRANSCRIBING' | 'DONE' | 'FAILED';
-		serializedAudio: SerializedAudio | undefined;
-	};
+	recordings: RecordingV7 & { serializedAudio: SerializedAudio | undefined };
 };
 
 /**
- * Dexie v0.5: Recording with 'transcribedText' field, no 'version' field.
- * FROZEN: This represents the schema BEFORE the V6→V7 migration.
+ * Dexie v0.5: Recording with 'transcribedText' field.
+ * Derives from RecordingV6 arktype validator.
  */
 export type RecordingsDbSchemaV5 = {
-	recordings: {
-		id: string;
-		title: string;
-		subtitle: string;
-		timestamp: string;
-		createdAt: string;
-		updatedAt: string;
-		transcribedText: string;
-		transcriptionStatus: 'UNPROCESSED' | 'TRANSCRIBING' | 'DONE' | 'FAILED';
-		serializedAudio: SerializedAudio | undefined;
-	};
+	recordings: RecordingV6 & { serializedAudio: SerializedAudio | undefined };
 };
 
 /**

--- a/apps/whispering/src/lib/services/db/models/transformations.ts
+++ b/apps/whispering/src/lib/services/db/models/transformations.ts
@@ -19,9 +19,9 @@ export const TRANSFORMATION_STEP_TYPES_TO_LABELS = {
 } as const satisfies Record<(typeof TRANSFORMATION_STEP_TYPES)[number], string>;
 
 /**
- * The current version of the TransformationStep schema.
- * Increment this when adding new fields or making breaking changes.
- */
+	* The current version of the TransformationStep schema.
+	* Increment this when adding new fields or making breaking changes.
+	*/
 const CURRENT_TRANSFORMATION_STEP_VERSION = 2 as const;
 
 // ============================================================================
@@ -32,11 +32,11 @@ const CURRENT_TRANSFORMATION_STEP_VERSION = 2 as const;
 // ============================================================================
 
 /**
- * Base fields shared between TransformationStep V1 and V2.
- * FROZEN for V1/V2: Do not modify without considering impact on both versions.
- *
- * Uses arktype's type() directly so we can use .merge() for composition.
- */
+	* Base fields shared between TransformationStep V1 and V2.
+	* FROZEN for V1/V2: Do not modify without considering impact on both versions.
+	*
+	* Uses arktype's type() directly so we can use .merge() for composition.
+	*/
 const TransformationStepBase = type({
 	id: 'string',
 	type: type.enumerated(...TRANSFORMATION_STEP_TYPES),
@@ -65,14 +65,14 @@ const TransformationStepBase = type({
 });
 
 /**
- * Fields for Transformation. These have NOT changed since the initial schema.
- * Only TransformationStep has versioning (V1 → V2 added Custom provider fields).
- *
- * If a future version adds/changes Transformation-level fields (not just steps),
- * introduce versioning at that point.
- *
- * Uses arktype's type() directly so we can use .merge() for composition.
- */
+	* Fields for Transformation. These have NOT changed since the initial schema.
+	* Only TransformationStep has versioning (V1 → V2 added Custom provider fields).
+	*
+	* If a future version adds/changes Transformation-level fields (not just steps),
+	* introduce versioning at that point.
+	*
+	* Uses arktype's type() directly so we can use .merge() for composition.
+	*/
 const TransformationBase = type({
 	id: 'string',
 	title: 'string',
@@ -86,11 +86,11 @@ const TransformationBase = type({
 // ============================================================================
 
 /**
- * V1: Original schema without Custom provider fields.
- * Old data has no version field, so we default to 1.
- *
- * FROZEN: Do not modify. This represents the historical V1 schema.
- */
+	* V1: Original schema without Custom provider fields.
+	* Old data has no version field, so we default to 1.
+	*
+	* FROZEN: Do not modify. This represents the historical V1 schema.
+	*/
 const TransformationStepV1 = TransformationStepBase.merge({
 	version: '1 = 1',
 });
@@ -98,12 +98,12 @@ const TransformationStepV1 = TransformationStepBase.merge({
 export type TransformationStepV1 = typeof TransformationStepV1.infer;
 
 /**
- * Transformation type containing V1 steps (before Custom provider fields).
- * Used only for typing old data during Dexie migration in web.ts.
- *
- * Note: The Transformation fields themselves are unchanged; only the step
- * schema differs between "V1" and "V2".
- */
+	* Transformation type containing V1 steps (before Custom provider fields).
+	* Used only for typing old data during Dexie migration in web.ts.
+	*
+	* Note: The Transformation fields themselves are unchanged; only the step
+	* schema differs between "V1" and "V2".
+	*/
 export type TransformationV1 = {
 	id: string;
 	title: string;
@@ -118,32 +118,32 @@ export type TransformationV1 = {
 // ============================================================================
 
 /**
- * V2: Added Custom provider fields for local LLM endpoints.
- * - Custom.model: Model name for custom endpoints
- * - Custom.baseUrl: Per-step base URL (falls back to global setting)
- *
- * CURRENT VERSION: This is the latest schema.
- */
+	* V2: Added Custom provider fields for local LLM endpoints.
+	* - Custom.model: Model name for custom endpoints
+	* - Custom.baseUrl: Per-step base URL (falls back to global setting)
+	*
+	* CURRENT VERSION: This is the latest schema.
+	*/
 const TransformationStepV2 = TransformationStepBase.merge({
 	version: '2',
 	/** Custom provider for local LLM endpoints (Ollama, LM Studio, llama.cpp, etc.) */
 	'prompt_transform.inference.provider.Custom.model': 'string',
 	/**
-	 * Per-step base URL for custom endpoints. Allows different steps to use
-	 * different local services (e.g., Ollama on :11434, LM Studio on :1234).
-	 * Falls back to global `completion.Custom.baseUrl` setting if empty.
-	 */
+		* Per-step base URL for custom endpoints. Allows different steps to use
+		* different local services (e.g., Ollama on :11434, LM Studio on :1234).
+		* Falls back to global `completion.Custom.baseUrl` setting if empty.
+		*/
 	'prompt_transform.inference.provider.Custom.baseUrl': 'string',
 });
 
 export type TransformationStepV2 = typeof TransformationStepV2.infer;
 
 /**
- * Current Transformation schema with V2 steps.
- *
- * Note: The Transformation fields themselves are unchanged from V1;
- * "V2" refers to the step schema version contained within.
- */
+	* Current Transformation schema with V2 steps.
+	*
+	* Note: The Transformation fields themselves are unchanged from V1;
+	* "V2" refers to the step schema version contained within.
+	*/
 const TransformationV2 = TransformationBase.merge({
 	steps: [TransformationStepV2, '[]'],
 });
@@ -158,26 +158,19 @@ export type TransformationV2 = typeof TransformationV2.infer;
 // ============================================================================
 
 /**
- * Migrates a TransformationStep from V1 to V2.
- */
-function migrateStepV1ToV2(step: TransformationStepV1): TransformationStepV2 {
-	return {
-		...step,
-		version: 2,
-		'prompt_transform.inference.provider.Custom.model': '',
-		'prompt_transform.inference.provider.Custom.baseUrl': '',
-	};
-}
-
-/**
- * TransformationStep validator with automatic migration.
- * Accepts V1 or V2 and always outputs V2.
- */
+	* TransformationStep validator with automatic migration.
+	* Accepts V1 or V2 and always outputs V2.
+	*/
 export const TransformationStep = TransformationStepV1.or(
 	TransformationStepV2,
 ).pipe((step): TransformationStepV2 => {
 	if (step.version === 1) {
-		return migrateStepV1ToV2(step);
+		return {
+			...step,
+			version: 2,
+			'prompt_transform.inference.provider.Custom.model': '',
+			'prompt_transform.inference.provider.Custom.baseUrl': '',
+		}
 	}
 	return step;
 });
@@ -185,10 +178,10 @@ export const TransformationStep = TransformationStepV1.or(
 export type TransformationStep = TransformationStepV2;
 
 /**
- * Transformation validator with automatic step migration.
- * Accepts transformations with V1 or V2 steps and migrates all steps to V2.
- * Use this when reading data that might contain old schema versions.
- */
+	* Transformation validator with automatic step migration.
+	* Accepts transformations with V1 or V2 steps and migrates all steps to V2.
+	* Use this when reading data that might contain old schema versions.
+	*/
 export const Transformation = TransformationBase.merge({
 	steps: [TransformationStep, '[]'],
 });
@@ -199,7 +192,7 @@ export type Transformation = TransformationV2;
 // FACTORY FUNCTIONS
 // ============================================================================
 
-export function generateDefaultTransformation(): TransformationV2 {
+export function generateDefaultTransformation (): TransformationV2 {
 	const now = new Date().toISOString();
 	return {
 		id: nanoid(),
@@ -211,7 +204,7 @@ export function generateDefaultTransformation(): TransformationV2 {
 	};
 }
 
-export function generateDefaultTransformationStep(): TransformationStepV2 {
+export function generateDefaultTransformationStep (): TransformationStepV2 {
 	return {
 		version: CURRENT_TRANSFORMATION_STEP_VERSION,
 		id: nanoid(),

--- a/apps/whispering/src/lib/services/db/web.ts
+++ b/apps/whispering/src/lib/services/db/web.ts
@@ -24,8 +24,8 @@ import {
 	type TransformationStepRunCompleted,
 	type TransformationStepRunFailed,
 	type TransformationStepRunRunning,
-	type TransformationStepV2,
 	type TransformationV1,
+	type TransformationV2,
 } from './models';
 import type { DbService } from './types';
 import { DbServiceErr } from './types';
@@ -323,7 +323,7 @@ class WhisperingDatabase extends Dexie {
 							.toArray();
 
 						for (const transformation of transformations) {
-							const updatedSteps: TransformationStepV2[] =
+							const updatedSteps: TransformationV2['steps'] =
 								transformation.steps.map((step) => ({
 									...step,
 									// Explicitly set V2 fields (overwrites any existing values)

--- a/apps/whispering/src/lib/services/db/web.ts
+++ b/apps/whispering/src/lib/services/db/web.ts
@@ -279,6 +279,7 @@ class WhisperingDatabase extends Dexie {
 										: undefined;
 									return {
 										...recordWithoutBlob,
+										version: 6,
 										serializedAudio,
 									} satisfies RecordingsDbSchemaV5['recordings'];
 								}),
@@ -368,7 +369,7 @@ class WhisperingDatabase extends Dexie {
 								// @ts-expect-error - We're migrating the schema, so these fields don't exist yet
 								recording.transcript = transcribedText ?? '';
 								// @ts-expect-error - Adding new field during migration
-								recording.version = CURRENT_RECORDING_VERSION;
+								recording.version = 7;
 								// @ts-expect-error - Removing old field during migration
 								delete recording.transcribedText;
 							});

--- a/apps/whispering/src/lib/services/db/web.ts
+++ b/apps/whispering/src/lib/services/db/web.ts
@@ -16,6 +16,7 @@ import {
 	type RecordingsDbSchemaV5,
 	type RecordingsDbSchemaV6,
 	type SerializedAudio,
+	type Transformation,
 	type TransformationRun,
 	type TransformationRunCompleted,
 	type TransformationRunFailed,
@@ -24,7 +25,6 @@ import {
 	type TransformationStepRunFailed,
 	type TransformationStepRunRunning,
 	type TransformationStepV2,
-	type Transformation,
 	type TransformationV1,
 } from './models';
 import type { DbService } from './types';

--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -19,7 +19,7 @@
 	} from '$lib/constants/audio';
 	import { rpc } from '$lib/query';
 	import * as services from '$lib/services';
-	import type { Recording } from '$lib/services/db';
+	import { CURRENT_RECORDING_VERSION, type Recording } from '$lib/services/db';
 	import { settings } from '$lib/stores/settings.svelte';
 	import { createBlobUrlManager } from '$lib/utils/blobUrlManager';
 	import { getRecordingTransitionId } from '$lib/utils/getRecordingTransitionId';
@@ -45,6 +45,7 @@
 	const latestRecording = $derived<Recording>(
 		latestRecordingQuery.data ?? {
 			id: '',
+			version: CURRENT_RECORDING_VERSION,
 			title: '',
 			subtitle: '',
 			createdAt: '',

--- a/docs/articles/freezing-schema-types-for-migrations.md
+++ b/docs/articles/freezing-schema-types-for-migrations.md
@@ -1,0 +1,69 @@
+# Freezing Schema Types for Database Migrations
+
+While working on IndexedDB migrations, I ran into a subtle bug: my schema types for each migration version were derived from the current types, so when the current types changed, all my historical schema definitions silently drifted.
+
+## The Problem
+
+Here's what I had:
+
+```typescript
+// Historical schema types derived from current type
+export type RecordingsDbSchemaV5 = {
+  recordings: Omit<RecordingStoredInIndexedDB, 'transcript' | 'version'> & {
+    transcribedText: string;
+  };
+};
+```
+
+This looks clever. V5 is "the current type minus the new fields, plus the old field." But it's fragile.
+
+When I renamed `transcribedText` to `transcript` and added `version`, the `Omit<...>` derivation broke subtly. The derived type was no longer an accurate snapshot of what V5 data actually looked like in the database.
+
+## The Solution: Freeze Historical Types
+
+Each schema version should be a complete, self-contained type definition. Don't derive from current types.
+
+```typescript
+// ============================================================================
+// FROZEN SNAPSHOTS: Do not derive from current types!
+// When Recording changes, these historical types must NOT change.
+// ============================================================================
+
+/**
+ * Dexie v0.5: Recording with 'transcribedText' field.
+ * FROZEN: Do not modify.
+ */
+export type RecordingsDbSchemaV5 = {
+  recordings: {
+    id: string;
+    title: string;
+    transcribedText: string;  // Old field name
+    transcriptionStatus: 'UNPROCESSED' | 'TRANSCRIBING' | 'DONE' | 'FAILED';
+    // ... all fields explicitly listed
+  };
+};
+```
+
+Yes, this means copying fields across multiple type definitions. That's the point.
+
+## The Exception: Current Schema
+
+The current schema version can derive from your runtime types, since they should match:
+
+```typescript
+// Current version can derive from the arktype validator
+export type RecordingsDbSchemaV6 = {
+  recordings: RecordingV7 & { serializedAudio: SerializedAudio | undefined };
+};
+```
+
+But once you create a new version, freeze the old one as an explicit snapshot.
+
+## The Pattern
+
+1. When you create a new schema version, copy the current type definition verbatim
+2. Mark it as FROZEN with a comment
+3. Never derive historical types from current types
+4. Accept the duplication; it's intentional
+
+Schema migrations deal with historical data. Historical types should be historical facts, not derived computations that drift when the present changes.

--- a/docs/articles/freezing-schema-types-for-migrations.md
+++ b/docs/articles/freezing-schema-types-for-migrations.md
@@ -111,7 +111,7 @@ export const Recording = RecordingV6.or(RecordingV7).pipe(
 export type Recording = typeof Recording.infer;
 ```
 
-The `.or()` accepts either shape. The `.pipe()` normalizes everything to V7. Your app code only ever sees the latest type.
+The `.or()` accepts either shape. The `.pipe()` normalizes everything to V7. Your app code only ever sees the latest type. (I wrote more about this pattern in [Migrate-on-Read: Schema Versioning with Arktype](./migrate-on-read-with-arktype.md).)
 
 ## The Pattern
 

--- a/docs/articles/freezing-schema-types-for-migrations.md
+++ b/docs/articles/freezing-schema-types-for-migrations.md
@@ -1,69 +1,124 @@
-# Freezing Schema Types for Database Migrations
+# Freezing Your Types and Schemas for Local-First Database Migrations
 
-While working on IndexedDB migrations, I ran into a subtle bug: my schema types for each migration version were derived from the current types, so when the current types changed, all my historical schema definitions silently drifted.
+While working on IndexedDB migrations in a local-first app, I ran into a subtle issue: the schema types for each migration version were derived from the current types, and when the current types changed, all the historical schema definitions silently drifted.
 
 ## The Problem
 
 Here's what I had:
 
 ```typescript
-// Historical schema types derived from current type
-export type RecordingsDbSchemaV5 = {
-  recordings: Omit<RecordingStoredInIndexedDB, 'transcript' | 'version'> & {
-    transcribedText: string;
-  };
+// Current Recording type (changes over time)
+export type Recording = {
+  id: string;
+  transcript: string; // Was 'transcribedText' before
+  version: 7;         // Didn't exist before
+  // ...
+};
+
+// Historical schema derived from current type
+export type RecordingV6 = Omit<Recording, 'transcript' | 'version'> & {
+  transcribedText: string;
 };
 ```
 
-This looks clever. V5 is "the current type minus the new fields, plus the old field." But it's fragile.
+This looks clever. V6 is "the current type minus the new fields, plus the old field." But it's fragile.
 
-When I renamed `transcribedText` to `transcript` and added `version`, the `Omit<...>` derivation broke subtly. The derived type was no longer an accurate snapshot of what V5 data actually looked like in the database.
+When I renamed `transcribedText` to `transcript` and added `version` in Recording, the `Omit<..., 'transcript' | 'version'>` derivation broke subtly in RecordingV6. The derived type RecordingV6 was no longer an accurate snapshot of what V6 data actually looked like.
 
 ## The Solution: Freeze Historical Types
 
-Each schema version should be a complete, self-contained type definition. Don't derive from current types.
+Each schema version should be a complete, self-contained definition. Don't derive from current types.
 
 ```typescript
 // ============================================================================
-// FROZEN SNAPSHOTS: Do not derive from current types!
-// When Recording changes, these historical types must NOT change.
+// VERSION 6 (FROZEN)
 // ============================================================================
 
 /**
- * Dexie v0.5: Recording with 'transcribedText' field.
- * FROZEN: Do not modify.
+ * V6: Original schema with 'transcribedText' field.
+ * Old data has no version field, so we default to 6.
+ *
+ * FROZEN: Do not modify. This represents the historical V6 schema.
  */
-export type RecordingsDbSchemaV5 = {
-  recordings: {
-    id: string;
-    title: string;
-    transcribedText: string;  // Old field name
-    transcriptionStatus: 'UNPROCESSED' | 'TRANSCRIBING' | 'DONE' | 'FAILED';
-    // ... all fields explicitly listed
-  };
-};
+const RecordingV6 = type({
+  version: '6 = 6',
+  id: 'string',
+  title: 'string',
+  subtitle: 'string',
+  timestamp: 'string',
+  createdAt: 'string',
+  updatedAt: 'string',
+  transcribedText: 'string',
+  transcriptionStatus: '"UNPROCESSED" | "TRANSCRIBING" | "DONE" | "FAILED"',
+});
+
+export type RecordingV6 = typeof RecordingV6.infer;
+
+// ============================================================================
+// VERSION 7 (CURRENT)
+// ============================================================================
+
+/**
+ * V7: Renamed 'transcribedText' to 'transcript'.
+ *
+ * CURRENT VERSION: This is the latest schema.
+ */
+const RecordingV7 = type({
+  version: '7',
+  id: 'string',
+  title: 'string',
+  subtitle: 'string',
+  timestamp: 'string',
+  createdAt: 'string',
+  updatedAt: 'string',
+  transcript: 'string',
+  transcriptionStatus: '"UNPROCESSED" | "TRANSCRIBING" | "DONE" | "FAILED"',
+});
+
+export type RecordingV7 = typeof RecordingV7.infer;
 ```
 
-Yes, this means copying fields across multiple type definitions. That's the point.
+Yes, this means copying fields across multiple definitions. That's the point.
 
-## The Exception: Current Schema
+## The Migration Validator
 
-The current schema version can derive from your runtime types, since they should match:
+With frozen types, you can build a migrating validator that accepts either version and always outputs the latest:
 
 ```typescript
-// Current version can derive from the arktype validator
-export type RecordingsDbSchemaV6 = {
-  recordings: RecordingV7 & { serializedAudio: SerializedAudio | undefined };
-};
+/**
+ * Recording validator with automatic migration.
+ *
+ * Input: Raw object with either V6 fields (transcribedText) or V7 fields (transcript).
+ *        If version is missing, defaults to 6.
+ *
+ * Output: Always returns the latest schema (V7) with 'transcript' field.
+ *         V6 inputs are automatically migrated via the .pipe() transformation.
+ */
+export const Recording = RecordingV6.or(RecordingV7).pipe(
+  (recording): RecordingV7 => {
+    if (recording.version === 6) {
+      const { transcribedText, version: _version, ...rest } = recording;
+      return {
+        ...rest,
+        version: 7,
+        transcript: transcribedText,
+      };
+    }
+    return recording;
+  },
+);
+
+export type Recording = typeof Recording.infer;
 ```
 
-But once you create a new version, freeze the old one as an explicit snapshot.
+The `.or()` accepts either shape. The `.pipe()` normalizes everything to V7. Your app code only ever sees the latest type.
 
 ## The Pattern
 
-1. When you create a new schema version, copy the current type definition verbatim
+1. When you create a new schema version, copy the current definition verbatim
 2. Mark it as FROZEN with a comment
 3. Never derive historical types from current types
-4. Accept the duplication; it's intentional
+4. Use `.or().pipe()` to build a migrating validator
+5. Accept the duplication; it's intentional
 
-Schema migrations deal with historical data. Historical types should be historical facts, not derived computations that drift when the present changes.
+The lesson: Schema migrations deal with historical data. Historical types should be historical facts, not derived computations that drift when the present changes.

--- a/docs/articles/migrate-on-read-with-arktype.md
+++ b/docs/articles/migrate-on-read-with-arktype.md
@@ -1,170 +1,16 @@
-# Migrate-on-Read: Schema Versioning for Local-First Apps
+# Migrate-on-Read: Schema Versioning with Arktype
 
-I was building a local-first app where user data lives in markdown files on disk. New feature meant new fields. The typical response? Write a migration script that walks every file and updates the schema.
+In Epicenter, I use an arktype schema validator that validates the data, migrates if needed, and returns the latest version—all in one pass. This is parsing, not just validation.
 
-But here's the thing: the file system doesn't have a migration mechanism. There's no Dexie version number, no Prisma migrate, no Rails migration runner. Just files.
+## The Pattern: `.or().pipe()`
 
-So I asked: what if I didn't migrate at all? What if I validated and migrated in one pass, on read?
-
-## The Problem with Traditional Migrations
-
-Traditional database migrations run once, update everything, and you're done. But for local-first apps with file-based storage:
-
-1. You can't guarantee all files are migrated (user might have files synced from another device)
-2. Batch migrations are expensive for large datasets
-3. A migration script is another thing to maintain and test
-4. If something goes wrong, you've corrupted the user's data
-
-I wanted something simpler. Validate the data, migrate if needed, always get the latest version out.
-
-## The Insight: Version Discriminators with Defaults
-
-The key is arktype's default value syntax. When you write `version: '1 = 1'`, you're saying: "this field should be 1, and if it's missing, default to 1."
-
-Old data doesn't have a version field. New data does. The default bridges the gap.
-
-```typescript
-// V1: Original schema (no version field in old data)
-const TransformationStepV1 = TransformationStepBase.merge({
-  version: '1 = 1',  // Default to 1 if missing
-});
-
-// V2: Added new fields
-const TransformationStepV2 = TransformationStepBase.merge({
-  version: '2',  // Explicit version, no default
-  'provider.Custom.model': 'string',
-  'provider.Custom.baseUrl': 'string',
-});
-```
-
-See what's happening? V1 accepts data without a version field and assigns it `version: 1`. V2 requires `version: 2` explicitly. This gives us a clean discriminator for the union.
-
-## The Pattern: .or().pipe()
-
-Here's the migration validator:
+Here's a migrating validator from the actual codebase:
 
 ```typescript
 /**
- * Accepts V1 or V2, always outputs V2.
+ * TransformationStep validator with automatic migration.
+ * Accepts V1 or V2 and always outputs V2.
  */
-export const TransformationStep = TransformationStepV1
-  .or(TransformationStepV2)
-  .pipe((step): TransformationStepV2 => {
-    if (step.version === 1) {
-      return {
-        ...step,
-        version: 2,
-        'provider.Custom.model': '',
-        'provider.Custom.baseUrl': '',
-      };
-    }
-    return step;
-  });
-```
-
-That's it. The validator:
-1. Accepts V1 (with default version) OR V2 (explicit version)
-2. Pipes the result through a transformation
-3. Returns V2 in all cases
-
-No separate migration script. No batch processing. Just read the file, get the latest version.
-
-## How It Works in Practice
-
-```typescript
-// Reading a markdown file
-const { data } = matter(fileContent);
-const validated = Transformation(data);
-
-if (validated instanceof type.errors) {
-  // Handle validation error
-  return;
-}
-
-// validated is always the latest version
-// Old files are migrated in memory on read
-```
-
-The migration happens transparently. When the user edits and saves, the file is written with the new schema. Files migrate lazily as they're accessed.
-
-## Why the Version Field is Worth It
-
-You might wonder: can't arktype distinguish versions by field presence?
-
-It can, but explicit version discriminators are cleaner:
-
-1. **Readable migration logic**: `if (step.version === 1)` is clearer than checking for missing fields
-2. **Future-proof**: Adding V3 is trivial; just add another version number
-3. **Deterministic**: No ambiguity about which version you have
-4. **Small cost**: One number per record is negligible
-
-## Composing Validators
-
-For nested structures, compose the validators:
-
-```typescript
-const TransformationV2 = TransformationBase.merge({
-  steps: [TransformationStep, '[]'],  // Array of migrating validators
-});
-
-// Now the whole transformation migrates its steps automatically
-const Transformation = TransformationBase.merge({
-  steps: [TransformationStep, '[]'],
-});
-```
-
-Each step in the array runs through the migration pipe. The parent doesn't need to know about versioning.
-
-## When to Use This Pattern
-
-This pattern works well when:
-
-- **File-based storage**: No built-in migration mechanism
-- **Lazy loading**: You don't need all data upfront
-- **User-owned data**: Files might come from anywhere (sync, backup, manual edit)
-- **Incremental changes**: Migrations are additive (new fields with defaults)
-
-It's less suited for:
-
-- **Destructive migrations**: Renaming fields, changing types
-- **Database storage**: Use the database's migration system instead
-- **Large structural changes**: Might be clearer as a batch script
-
-## The Bigger Picture
-
-This is part of a broader philosophy: validation and transformation are the same concern.
-
-We don't have "raw data" and "validated data." We have data at different stages of a pipeline. Arktype's `.pipe()` makes that pipeline explicit.
-
-The traditional approach separates concerns: parse JSON, validate shape, migrate schema, use data. Four steps.
-
-The arktype approach unifies them: define what valid data looks like, including how to get there from older versions. One validator, one source of truth.
-
-## What Actually Shipped
-
-```typescript
-// ============================================================================
-// VERSION 1 (FROZEN)
-// ============================================================================
-
-const TransformationStepV1 = TransformationStepBase.merge({
-  version: '1 = 1',
-});
-
-// ============================================================================
-// VERSION 2 (CURRENT)
-// ============================================================================
-
-const TransformationStepV2 = TransformationStepBase.merge({
-  version: '2',
-  'prompt_transform.inference.provider.Custom.model': 'string',
-  'prompt_transform.inference.provider.Custom.baseUrl': 'string',
-});
-
-// ============================================================================
-// MIGRATING VALIDATORS
-// ============================================================================
-
 export const TransformationStep = TransformationStepV1
   .or(TransformationStepV2)
   .pipe((step): TransformationStepV2 => {
@@ -179,9 +25,131 @@ export const TransformationStep = TransformationStepV1
     return step;
   });
 
-export type TransformationStep = TransformationStepV2;
+export type TransformationStep = typeof TransformationStep.infer;
 ```
 
-The type exported is always the latest version. Consumers don't need to know about V1. They just get validated, migrated data.
+That's it. The validator accepts V1 or V2, pipes through a transformation, and always outputs V2. The exported type is the latest version. Consumers never see V1.
 
-The lesson: For local-first apps with file storage, migrate-on-read beats migrate-on-deploy. Let the validator be the migration. One pass, always current.
+## Version Discriminators with Defaults
+
+The magic is in how each version is defined:
+
+```typescript
+// V1: Old data has no version field, so we default to 1
+const TransformationStepV1 = TransformationStepBase.merge({
+  version: '1 = 1',  // If missing, default to 1
+});
+
+// V2: New data has an explicit version
+const TransformationStepV2 = TransformationStepBase.merge({
+  version: '2',  // Must be exactly 2
+  'prompt_transform.inference.provider.Custom.model': 'string',
+  'prompt_transform.inference.provider.Custom.baseUrl': 'string',
+});
+```
+
+When you write `version: '1 = 1'`, you're saying: "this field should be 1, and if it's missing, default to 1."
+
+The user's existing data doesn't have a version field yet. The default bridges the gap. New data has `version: 2` explicitly. This gives us a clean discriminator for the union—arktype can tell which variant it's parsing and apply the right schema.
+
+## Frozen Types
+
+Each version definition is a complete, self-contained snapshot. You don't derive V1 from V2; you freeze V1 and never touch it again.
+
+```typescript
+// ============================================================================
+// VERSION 1 (FROZEN)
+// ============================================================================
+
+/**
+ * V1: Original schema without Custom provider fields.
+ * FROZEN: Do not modify. This represents the historical V1 schema.
+ */
+const TransformationStepV1 = TransformationStepBase.merge({
+  version: '1 = 1',
+});
+
+// ============================================================================
+// VERSION 2 (CURRENT)
+// ============================================================================
+
+/**
+ * V2: Added Custom provider fields for local LLM endpoints.
+ */
+const TransformationStepV2 = TransformationStepBase.merge({
+  version: '2',
+  'prompt_transform.inference.provider.Custom.model': 'string',
+  'prompt_transform.inference.provider.Custom.baseUrl': 'string',
+});
+```
+
+Yes, this means some duplication. That's the point. Historical types should be historical facts, not derived computations that drift when the present changes. (I wrote more about this in [Freezing Your Types for Migrations](./freezing-schema-types-for-migrations.md).)
+
+## Why Not Traditional Migrations?
+
+Traditional database migrations run once, update everything, and you're done. But Epicenter is a local-first app with file-based storage (markdown files on disk, IndexedDB). The file system doesn't have a migration mechanism. There's no Prisma migrate, no Rails migration runner. Just files.
+
+The problems:
+
+1. **You can't guarantee all files are migrated**—a user might have files synced from another device
+2. **Batch migrations are expensive** for large datasets
+3. **A migration script is another thing** to maintain and test
+4. **If something goes wrong**, you've corrupted the user's data
+
+So I asked: what if I didn't migrate at all? What if I validated and migrated in one pass, on read?
+
+## In Practice
+
+```typescript
+// Reading and validating data
+const validated = TransformationStep(rawData);
+
+if (validated instanceof type.errors) {
+  // Handle validation error
+  return;
+}
+
+// validated is always the latest version (V2)
+// Old data was migrated in memory during parsing
+```
+
+The migration happens transparently. When the user edits and saves, the data is written with the new schema. Records migrate lazily as they're accessed.
+
+## Composing Validators
+
+For nested structures, compose the migrating validators:
+
+```typescript
+export const Transformation = TransformationBase.merge({
+  steps: [TransformationStep, '[]'],  // Array of migrating validators
+});
+
+export type Transformation = typeof Transformation.infer;
+```
+
+Each step in the array runs through the migration pipe. The parent doesn't need to know about versioning—it just uses the migrating `TransformationStep` validator, and each step comes out as V2.
+
+## When This Works
+
+This pattern works well when:
+
+- **File-based or local storage**: No built-in migration mechanism
+- **Lazy loading**: You don't need all data upfront
+- **User-owned data**: Files might come from anywhere (sync, backup, manual edit)
+- **Incremental changes**: Migrations are additive (new fields with defaults)
+
+It's less suited for:
+
+- **Destructive migrations**: Removing fields, changing types in breaking ways
+- **Database storage**: Use the database's migration system instead
+- **Large structural changes**: Might be clearer as a batch script
+
+## The Bigger Picture
+
+Validation and transformation are the same concern. We don't have "raw data" and "validated data." We have data at different stages of a pipeline. Arktype's `.pipe()` makes that pipeline explicit.
+
+The traditional approach separates concerns: parse JSON, validate shape, migrate schema, use data. Four steps.
+
+The arktype approach unifies them: define what valid data looks like, including how to get there from older versions. One validator, one source of truth.
+
+The lesson: For local-first apps, migrate-on-read beats migrate-on-deploy. Let the validator be the migration.

--- a/docs/articles/migrate-on-read-with-arktype.md
+++ b/docs/articles/migrate-on-read-with-arktype.md
@@ -1,0 +1,187 @@
+# Migrate-on-Read: Schema Versioning for Local-First Apps
+
+I was building a local-first app where user data lives in markdown files on disk. New feature meant new fields. The typical response? Write a migration script that walks every file and updates the schema.
+
+But here's the thing: the file system doesn't have a migration mechanism. There's no Dexie version number, no Prisma migrate, no Rails migration runner. Just files.
+
+So I asked: what if I didn't migrate at all? What if I validated and migrated in one pass, on read?
+
+## The Problem with Traditional Migrations
+
+Traditional database migrations run once, update everything, and you're done. But for local-first apps with file-based storage:
+
+1. You can't guarantee all files are migrated (user might have files synced from another device)
+2. Batch migrations are expensive for large datasets
+3. A migration script is another thing to maintain and test
+4. If something goes wrong, you've corrupted the user's data
+
+I wanted something simpler. Validate the data, migrate if needed, always get the latest version out.
+
+## The Insight: Version Discriminators with Defaults
+
+The key is arktype's default value syntax. When you write `version: '1 = 1'`, you're saying: "this field should be 1, and if it's missing, default to 1."
+
+Old data doesn't have a version field. New data does. The default bridges the gap.
+
+```typescript
+// V1: Original schema (no version field in old data)
+const TransformationStepV1 = TransformationStepBase.merge({
+  version: '1 = 1',  // Default to 1 if missing
+});
+
+// V2: Added new fields
+const TransformationStepV2 = TransformationStepBase.merge({
+  version: '2',  // Explicit version, no default
+  'provider.Custom.model': 'string',
+  'provider.Custom.baseUrl': 'string',
+});
+```
+
+See what's happening? V1 accepts data without a version field and assigns it `version: 1`. V2 requires `version: 2` explicitly. This gives us a clean discriminator for the union.
+
+## The Pattern: .or().pipe()
+
+Here's the migration validator:
+
+```typescript
+/**
+ * Accepts V1 or V2, always outputs V2.
+ */
+export const TransformationStep = TransformationStepV1
+  .or(TransformationStepV2)
+  .pipe((step): TransformationStepV2 => {
+    if (step.version === 1) {
+      return {
+        ...step,
+        version: 2,
+        'provider.Custom.model': '',
+        'provider.Custom.baseUrl': '',
+      };
+    }
+    return step;
+  });
+```
+
+That's it. The validator:
+1. Accepts V1 (with default version) OR V2 (explicit version)
+2. Pipes the result through a transformation
+3. Returns V2 in all cases
+
+No separate migration script. No batch processing. Just read the file, get the latest version.
+
+## How It Works in Practice
+
+```typescript
+// Reading a markdown file
+const { data } = matter(fileContent);
+const validated = Transformation(data);
+
+if (validated instanceof type.errors) {
+  // Handle validation error
+  return;
+}
+
+// validated is always the latest version
+// Old files are migrated in memory on read
+```
+
+The migration happens transparently. When the user edits and saves, the file is written with the new schema. Files migrate lazily as they're accessed.
+
+## Why the Version Field is Worth It
+
+You might wonder: can't arktype distinguish versions by field presence?
+
+It can, but explicit version discriminators are cleaner:
+
+1. **Readable migration logic**: `if (step.version === 1)` is clearer than checking for missing fields
+2. **Future-proof**: Adding V3 is trivial; just add another version number
+3. **Deterministic**: No ambiguity about which version you have
+4. **Small cost**: One number per record is negligible
+
+## Composing Validators
+
+For nested structures, compose the validators:
+
+```typescript
+const TransformationV2 = TransformationBase.merge({
+  steps: [TransformationStep, '[]'],  // Array of migrating validators
+});
+
+// Now the whole transformation migrates its steps automatically
+const Transformation = TransformationBase.merge({
+  steps: [TransformationStep, '[]'],
+});
+```
+
+Each step in the array runs through the migration pipe. The parent doesn't need to know about versioning.
+
+## When to Use This Pattern
+
+This pattern works well when:
+
+- **File-based storage**: No built-in migration mechanism
+- **Lazy loading**: You don't need all data upfront
+- **User-owned data**: Files might come from anywhere (sync, backup, manual edit)
+- **Incremental changes**: Migrations are additive (new fields with defaults)
+
+It's less suited for:
+
+- **Destructive migrations**: Renaming fields, changing types
+- **Database storage**: Use the database's migration system instead
+- **Large structural changes**: Might be clearer as a batch script
+
+## The Bigger Picture
+
+This is part of a broader philosophy: validation and transformation are the same concern.
+
+We don't have "raw data" and "validated data." We have data at different stages of a pipeline. Arktype's `.pipe()` makes that pipeline explicit.
+
+The traditional approach separates concerns: parse JSON, validate shape, migrate schema, use data. Four steps.
+
+The arktype approach unifies them: define what valid data looks like, including how to get there from older versions. One validator, one source of truth.
+
+## What Actually Shipped
+
+```typescript
+// ============================================================================
+// VERSION 1 (FROZEN)
+// ============================================================================
+
+const TransformationStepV1 = TransformationStepBase.merge({
+  version: '1 = 1',
+});
+
+// ============================================================================
+// VERSION 2 (CURRENT)
+// ============================================================================
+
+const TransformationStepV2 = TransformationStepBase.merge({
+  version: '2',
+  'prompt_transform.inference.provider.Custom.model': 'string',
+  'prompt_transform.inference.provider.Custom.baseUrl': 'string',
+});
+
+// ============================================================================
+// MIGRATING VALIDATORS
+// ============================================================================
+
+export const TransformationStep = TransformationStepV1
+  .or(TransformationStepV2)
+  .pipe((step): TransformationStepV2 => {
+    if (step.version === 1) {
+      return {
+        ...step,
+        version: 2,
+        'prompt_transform.inference.provider.Custom.model': '',
+        'prompt_transform.inference.provider.Custom.baseUrl': '',
+      };
+    }
+    return step;
+  });
+
+export type TransformationStep = TransformationStepV2;
+```
+
+The type exported is always the latest version. Consumers don't need to know about V1. They just get validated, migrated data.
+
+The lesson: For local-first apps with file storage, migrate-on-read beats migrate-on-deploy. Let the validator be the migration. One pass, always current.

--- a/rules/documentation.md
+++ b/rules/documentation.md
@@ -44,6 +44,24 @@ Don't just name the section; state what the reader will learn.
   // ============================================================================
   ```
 
+### Acknowledge Tradeoffs Directly
+
+Don't hide the cost of your solution. State it, then explain why it's worth it.
+
+- Good: "Yes, this means copying fields across multiple type definitions. That's the point."
+- Bad: Silently hoping readers won't notice the downside
+
+The reader is already thinking about tradeoffs. Beat them to it.
+
+### Build Tension, Then Release
+
+Set up the problem before revealing why it's a problem.
+
+- Good: "This looks clever. V5 is 'the current type minus the new fields.' But it's fragile."
+- Bad: "This anti-pattern causes bugs because..."
+
+The "But" creates a turn. The reader leans in.
+
 ### What to Cut
 
 - Bullet lists explaining "why this works" (the solution already shows why)

--- a/rules/documentation.md
+++ b/rules/documentation.md
@@ -1,36 +1,75 @@
 # Documentation & README Writing Guidelines
 
-## Technical Writing Voice
+## Technical Articles
+
+### Read It Out Loud
+
+The article should flow when spoken. Conversational prose, not terse reference cards.
+
+- Good: "This looks clever. V5 is 'the current type minus the new fields.' But it's fragile."
+- Bad: "Anti-pattern: deriving historical types from current types."
+
+### Keep the Opening Tight
+
+One or two sentences that set the scene and state the problem, then show code. The issue isn't personal intros; it's multiple sentences of buildup before substance.
+
+- Good: "While working on IndexedDB migrations, I ran into a subtle bug: my schema types drifted when the current types changed."
+- Good: "I hit an interesting problem while working on IndexedDB migrations in a local-first app. The schema types for each migration version were derived from the current types..."
+- Bad: "I hit an interesting problem. Let me tell you about the journey. It all started when..."
+
+### Section Titles Should Contain the Insight
+
+Don't just name the section; state what the reader will learn.
+
+- Good: "The Solution: Freeze Historical Types"
+- Bad: "The Solution"
+
+### Structure
+
+1. **Setup** (1-2 sentences): What you were doing and what went wrong
+2. **The Problem**: Show the broken code with brief explanation
+3. **The Solution: [Insight]**: Show the fix with brief explanation
+4. **The Pattern**: Actionable steps (numbered list is fine here)
+5. **The Lesson** (optional): One punchy sentence at the end
+
+### Code Samples
+
+- Show enough to understand the pattern, trim the rest
+- Use `// ...` to indicate omitted boilerplate
+- Comments should highlight what matters: `// Old field name`
+- Banner comments can make patterns scannable:
+  ```typescript
+  // ============================================================================
+  // FROZEN SNAPSHOTS: Do not derive from current types!
+  // ============================================================================
+  ```
+
+### What to Cut
+
+- Bullet lists explaining "why this works" (the solution already shows why)
+- Redundant explanations between code and prose
+- Sections that exist because articles "should have" them
+
+## General Technical Writing
 
 ### Core Principles
 
-- **Start with the problem or decision**: "I was building X and hit this decision" not "When building applications..."
 - **Show the insight first**: Lead with what you realized, then explain why
 - **Use concrete examples**: Show actual code or scenarios, not abstract concepts
-- **Make it conversational**: Write like you're explaining to a colleague at lunch
+- **Make it conversational**: Write like you're explaining to a colleague
 
 ### Sentence Structure
 
 - **Short, punchy observations**: "That's it. No Result types. No error handling dance."
 - **Build rhythm**: Mix short sentences with longer explanations
 - **Use fragments for emphasis**: "Every. Single. Operation."
-- **Ask the reader's unspoken question**: "But why all this complexity for localStorage?"
-
-### Technical Explanations
-
-- **Explain the 'why' before the 'how'**: "localStorage is synchronous. Why am I adding async complexity?"
-- **Call out the obvious**: "Here's the thing that took me too long to realize"
-- **Use comparisons**: "I was treating localStorage like a remote database. But it's not."
-- **End with the lesson**: Not generic advice, but what YOU learned
 
 ### Avoiding Academic/Corporate Tone
 
 - Don't: "This article explores two architectural approaches..."
-- Do: "I hit an interesting architectural decision"
 - Don't: "Let's examine the implications"
-- Do: "Here's what I mean"
 - Don't: "In conclusion, both patterns have merit"
-- Do: "The lesson: Not every data access needs a service"
+- Do: State the lesson directly
 
 ## Authentic Communication Style
 


### PR DESCRIPTION
This PR adds the migration infrastructure needed to support the `transcribedText` → `transcript` rename from #1042. Without this migration, existing user data would break when users upgrade to a version with the renamed field.

The Recording type now includes a `version` field (currently `7`), and a migration pipeline validates and upgrades V6 records (with `transcribedText`) to V7 (with `transcript`). For IndexedDB (web), a Dexie migration (v0.7) handles the upgrade. For desktop, markdown files don't store version numbers; they're constructed with the current version on read since the field name in the body doesn't change.

**Depends on:** #1042

Note: Pre-existing type errors in settings page bindings and test-persist-toast page are unrelated to these changes.