### PR TITLE
fix(db): support all audio/video formats in findAudioFile

### DIFF
--- a/apps/whispering/src/lib/services/db/file-system.ts
+++ b/apps/whispering/src/lib/services/db/file-system.ts
@@ -11,6 +11,8 @@ import {
 import { type } from 'arktype';
 import matter from 'gray-matter';
 import mime from 'mime';
+import standardTypes from 'mime/types/standard.js';
+import otherTypes from 'mime/types/other.js';
 import { Ok, tryAsync } from 'wellcrafted/result';
 import { PATHS } from '$lib/constants/paths';
 import * as services from '$lib/services';
@@ -1148,14 +1150,23 @@ export function createFileSystemDb(): DbService {
 	};
 }
 
+/** All audio/* and video/* MIME types from the mime package. */
+const AUDIO_VIDEO_MIME_TYPES = Object.keys({ ...standardTypes, ...otherTypes }).filter(
+	(type) => type.startsWith('audio/') || type.startsWith('video/'),
+);
+
+/** All supported audio/video file extensions, derived via mime.getAllExtensions(). */
+const SUPPORTED_MEDIA_EXTENSIONS = AUDIO_VIDEO_MIME_TYPES.flatMap(
+	(type) => [...(mime.getAllExtensions(type) ?? [])],
+);
+
 /**
  * Helper function to find audio file by ID.
- * Tries multiple extensions: .wav, .opus, .mp3, .ogg
+ * Checks all supported media extensions from the mime package.
  */
 async function findAudioFile(dir: string, id: string): Promise<string | null> {
-	const extensions = ['.wav', '.opus', '.mp3', '.ogg'];
-	for (const ext of extensions) {
-		const filename = `${id}${ext}`;
+	for (const ext of SUPPORTED_MEDIA_EXTENSIONS) {
+		const filename = `${id}.${ext}`;
 		const filePath = await join(dir, filename);
 		const fileExists = await exists(filePath);
 		if (fileExists) return filename;

--- a/docs/articles/mime-enumerate-extensions.md
+++ b/docs/articles/mime-enumerate-extensions.md
@@ -1,0 +1,81 @@
+# Enumerating All Extensions for a MIME Category
+
+I needed to find audio files by ID, but they could be saved with any extension: `.mp3`, `.wav`, `.m4a`, `.ogg`, `.flac`. My first instinct was to hardcode a list:
+
+```typescript
+const extensions = ['.wav', '.opus', '.mp3', '.ogg'];
+```
+
+Then a user dragged an m4a file and it broke. iOS Voice Memos use m4a. I'd missed it.
+
+## The Problem with Hardcoding
+
+Every time a new format comes up, you have to remember to update the list. Miss one and users hit cryptic errors. It's a maintenance burden that grows over time.
+
+## Using mime v4's Public API
+
+The `mime` package (v4+) has `getAllExtensions(type)` which returns all extensions for a MIME type:
+
+```typescript
+import mime from 'mime';
+
+mime.getAllExtensions('audio/mpeg');
+// Set { 'mpga', 'mp2', 'mp2a', 'mp3', 'm2a', 'm3a' }
+
+mime.getAllExtensions('audio/mp4');
+// Set { 'm4a', 'mp4a', 'm4b' }
+```
+
+But what if you want all audio extensions? You need to know every audio MIME type first.
+
+## Enumerating All MIME Types
+
+The `mime` package exports its type definitions as plain objects:
+
+```typescript
+import standardTypes from 'mime/types/standard.js';
+import otherTypes from 'mime/types/other.js';
+
+// These are objects: { 'audio/mpeg': ['mpga', 'mp2', ...], ... }
+const allTypes = { ...standardTypes, ...otherTypes };
+
+// Get all MIME types
+Object.keys(allTypes);
+// ['application/json', 'audio/mpeg', 'video/mp4', ...]
+```
+
+## Getting All Audio/Video Extensions
+
+Combine both approaches:
+
+```typescript
+import mime from 'mime';
+import standardTypes from 'mime/types/standard.js';
+import otherTypes from 'mime/types/other.js';
+
+const AUDIO_VIDEO_MIME_TYPES = Object.keys({ ...standardTypes, ...otherTypes })
+  .filter(type => type.startsWith('audio/') || type.startsWith('video/'));
+
+const SUPPORTED_EXTENSIONS = AUDIO_VIDEO_MIME_TYPES.flatMap(
+  type => [...(mime.getAllExtensions(type) ?? [])]
+);
+
+// 124 extensions: ['mp3', 'm4a', 'wav', 'ogg', 'opus', 'flac', 'webm', 'mp4', 'mov', ...]
+```
+
+Now my file lookup checks all 124 audio/video extensions instead of 4 hardcoded ones.
+
+## Why Two Imports?
+
+- `standardTypes`: IANA-registered types (the official ones)
+- `otherTypes`: Vendor and unofficial types (`x-*`, `vnd.*`, etc.)
+
+For comprehensive coverage, merge both. For stricter validation, use only `standardTypes`.
+
+## The Lesson
+
+The `mime` package isn't just for `getType()` and `getExtension()`. Its type definition exports let you enumerate all registered MIME types, which is useful whenever you need to support "all audio formats" or "all video formats" without maintaining a list yourself.
+
+## Reference
+
+See the implementation: [PR #1051](https://github.com/EpicenterHQ/epicenter/pull/1051)


### PR DESCRIPTION
This fixes the issue where m4a files (like iOS Voice Memos transferred to macOS) would fail with "Failed to fetch audio" after being dragged onto Whispering. The files were being saved correctly, but `findAudioFile()` couldn't locate them because it only checked 4 hardcoded extensions: `.wav`, `.opus`, `.mp3`, `.ogg`.

The fix uses mime v4's `getAllExtensions()` API to dynamically derive all supported audio/video extensions. Instead of hardcoding a small list, we now:

1. Get all audio/* and video/* MIME types from mime's public type maps
2. Use `getAllExtensions()` to get all extensions for each type
3. Check all 124 supported extensions when looking up audio files

This means Whispering now properly supports m4a, aac, flac, webm, mp4, mov, mkv, avi, and many other formats that users might drag onto the app.

Closes #1002