### PR TITLE
feat(clippings): add essays with resonance rating and URL support

### DIFF
--- a/examples/content-hub/clippings/scripts/add-essay.ts
+++ b/examples/content-hub/clippings/scripts/add-essay.ts
@@ -1,0 +1,12 @@
+import { createEpicenterClient } from '@epicenter/hq';
+import epicenter from '../../epicenter.config';
+
+await using client = await createEpicenterClient(epicenter);
+
+// Add Paul Graham's "Founder Mode" essay
+await client.clippings.addEssayFromUrl({
+	url: 'https://paulgraham.com/foundermode.html',
+	resonance: 'excellent',
+});
+
+console.log('✓ Essay added');


### PR DESCRIPTION
This adds essay support to the clippings workspace, treating essays as long-form content rated by their resonance/impact rather than generic quality.

The essays schema now includes url, title, author (nullable), content, word_count, and resonance fields. The resonance field uses the same gradation scale as quality (decent, good, great, excellent) but semantically represents how much the essay impacts or resonates with the reader.

The `addEssayFromUrl` mutation fetches content using JSDOM and extracts it with Defuddle, matching the existing article pattern. Essays are also added to the markdown index for export support.

An example script (`add-essay.ts`) demonstrates adding Paul Graham's "Founder Mode" essay with excellent resonance.