### PR TITLE
feat(indexes): add indexId to IndexContext for automatic file naming

### DIFF
--- a/examples/basic-workspace/README.md
+++ b/examples/basic-workspace/README.md
@@ -14,9 +14,13 @@ This folder shows you how to:
 
 ```
 basic-workspace/
-├── .epicenter/                  # YJS and SQLite persistence (internal state)
-│   ├── blog.yjs                # Binary YJS document (CRDT source of truth)
-│   └── blog.db                  # SQLite index database
+├── .epicenter/                  # Internal state and index artifacts
+│   ├── blog.yjs                 # Binary YJS document (CRDT source of truth)
+│   ├── blog.db                  # SQLite index database
+│   └── blog/                    # Index-specific logs and diagnostics
+│       ├── markdown.default.log
+│       ├── markdown.default.diagnostics.json
+│       └── sqlite.default.log
 ├── .data/
 │   └── content/                 # Markdown files (git-friendly storage)
 │       ├── posts/               # Blog posts as .md files

--- a/examples/basic-workspace/README.md
+++ b/examples/basic-workspace/README.md
@@ -18,9 +18,9 @@ basic-workspace/
 │   ├── blog.yjs                 # Binary YJS document (CRDT source of truth)
 │   ├── blog.db                  # SQLite index database
 │   └── blog/                    # Index-specific logs and diagnostics
-│       ├── markdown.markdown.log         # (indexKey = "markdown")
-│       ├── markdown.markdown.diagnostics.json
-│       └── sqlite.sqlite.log             # (indexKey = "sqlite")
+│       ├── markdown.log                  # (indexId = "markdown")
+│       ├── markdown.diagnostics.json
+│       └── sqlite.log                    # (indexId = "sqlite")
 ├── .data/
 │   └── content/                 # Markdown files (git-friendly storage)
 │       ├── posts/               # Blog posts as .md files

--- a/examples/basic-workspace/README.md
+++ b/examples/basic-workspace/README.md
@@ -18,9 +18,9 @@ basic-workspace/
 │   ├── blog.yjs                 # Binary YJS document (CRDT source of truth)
 │   ├── blog.db                  # SQLite index database
 │   └── blog/                    # Index-specific logs and diagnostics
-│       ├── markdown.default.log
-│       ├── markdown.default.diagnostics.json
-│       └── sqlite.default.log
+│       ├── markdown.markdown.log         # (indexKey = "markdown")
+│       ├── markdown.markdown.diagnostics.json
+│       └── sqlite.sqlite.log             # (indexKey = "sqlite")
 ├── .data/
 │   └── content/                 # Markdown files (git-friendly storage)
 │       ├── posts/               # Blog posts as .md files

--- a/examples/content-hub/README.md
+++ b/examples/content-hub/README.md
@@ -104,7 +104,7 @@ Query called → Read from SQLite index → Return data
 
 **Persistence**:
 
-- Desktop: YJS files stored in `.epicenter/` directory
+- Desktop: YJS state in `.epicenter/{workspace}.yjs`, index logs in `.epicenter/{workspace}/`
 - Browser: YJS files stored in IndexedDB
 - Both: Universal `setupPersistence` provider handles platform detection
 
@@ -368,7 +368,7 @@ bun add-article.ts
 
 **Generated at runtime**:
 
-- `.epicenter/`: YJS and SQLite files (one per workspace)
+- `.epicenter/`: YJS files, SQLite databases, and index logs (organized by workspace)
 
 ## Extending the System
 

--- a/packages/epicenter/README.md
+++ b/packages/epicenter/README.md
@@ -619,7 +619,9 @@ indexes: {
 }
 ```
 
-**Storage:** Auto-saves to `.epicenter/{workspaceId}.db` relative to `storageDir`.
+**Storage:**
+- Database: `.epicenter/{workspaceId}.db`
+- Logs: `.epicenter/{workspaceId}/sqlite.default.log`
 
 **Exports:**
 
@@ -686,6 +688,7 @@ import { markdownIndex } from '@epicenter/hq';
 
 indexes: {
   markdown: (c) => markdownIndex(c, {
+    name: 'default',      // Optional: instance name for multiple indexes
     directory: './data',  // Optional: workspace-level directory
     tableConfigs: {
       posts: {
@@ -706,8 +709,9 @@ indexes: {
 ```
 
 **Storage:**
-- Default: `./{workspaceId}/{tableName}/*.md`
-- Custom: Configurable per workspace and per table
+- Markdown files: `./{workspaceId}/{tableName}/*.md` (configurable)
+- Logs: `.epicenter/{workspaceId}/markdown.{name}.log`
+- Diagnostics: `.epicenter/{workspaceId}/markdown.{name}.diagnostics.json`
 
 **Exports:**
 

--- a/packages/epicenter/README.md
+++ b/packages/epicenter/README.md
@@ -621,7 +621,7 @@ indexes: {
 
 **Storage:**
 - Database: `.epicenter/{workspaceId}.db`
-- Logs: `.epicenter/{workspaceId}/sqlite.default.log`
+- Logs: `.epicenter/{workspaceId}/sqlite.log`
 
 **Exports:**
 
@@ -688,7 +688,6 @@ import { markdownIndex } from '@epicenter/hq';
 
 indexes: {
   markdown: (c) => markdownIndex(c, {
-    name: 'default',      // Optional: instance name for multiple indexes
     directory: './data',  // Optional: workspace-level directory
     tableConfigs: {
       posts: {
@@ -710,8 +709,8 @@ indexes: {
 
 **Storage:**
 - Markdown files: `./{workspaceId}/{tableName}/*.md` (configurable)
-- Logs: `.epicenter/{workspaceId}/markdown.{name}.log`
-- Diagnostics: `.epicenter/{workspaceId}/markdown.{name}.diagnostics.json`
+- Logs: `.epicenter/{workspaceId}/markdown.log`
+- Diagnostics: `.epicenter/{workspaceId}/markdown.diagnostics.json`
 
 **Exports:**
 

--- a/packages/epicenter/src/core/epicenter/README.md
+++ b/packages/epicenter/src/core/epicenter/README.md
@@ -155,19 +155,19 @@ The `.epicenter` folder contains all Epicenter internal data:
 ├── auth.db
 ├── auth.yjs
 ├── blog/                             # Workspace-specific index artifacts
-│   ├── markdown.default.log          # Markdown index sync log
-│   ├── markdown.default.diagnostics.json
-│   └── sqlite.default.log            # SQLite index error log
+│   ├── markdown.markdown.log         # Markdown index sync log (indexKey = "markdown")
+│   ├── markdown.markdown.diagnostics.json
+│   └── sqlite.sqlite.log             # SQLite index error log (indexKey = "sqlite")
 └── auth/
-    ├── markdown.default.log
-    └── sqlite.default.log
+    ├── markdown.markdown.log
+    └── sqlite.sqlite.log
 ```
 
 **Key design decisions:**
 - YJS and DB files stay at root level (easy to find, prominent)
 - Index logs/diagnostics go inside workspace folders
-- Dot-separated naming: `{indexType}.{instanceName}.{suffix}`
-- Supports multiple indexes of the same type (e.g., `markdown.docs.log`, `markdown.obsidian.log`)
+- Dot-separated naming: `{indexType}.{indexKey}.{suffix}` (indexKey is inferred from the indexes object key)
+- Supports multiple indexes of the same type (e.g., `markdown.markdownDocs.log`, `markdown.markdownObsidian.log`)
 
 **Rule:** Only one client can access the same storage context at a time.
 

--- a/packages/epicenter/src/core/epicenter/README.md
+++ b/packages/epicenter/src/core/epicenter/README.md
@@ -155,19 +155,19 @@ The `.epicenter` folder contains all Epicenter internal data:
 ├── auth.db
 ├── auth.yjs
 ├── blog/                             # Workspace-specific index artifacts
-│   ├── markdown.markdown.log         # Markdown index sync log (indexKey = "markdown")
-│   ├── markdown.markdown.diagnostics.json
-│   └── sqlite.sqlite.log             # SQLite index error log (indexKey = "sqlite")
+│   ├── markdown.log                  # Markdown index sync log (indexId = "markdown")
+│   ├── markdown.diagnostics.json
+│   └── sqlite.log                    # SQLite index error log (indexId = "sqlite")
 └── auth/
-    ├── markdown.markdown.log
-    └── sqlite.sqlite.log
+    ├── markdown.log
+    └── sqlite.log
 ```
 
 **Key design decisions:**
 - YJS and DB files stay at root level (easy to find, prominent)
 - Index logs/diagnostics go inside workspace folders
-- Dot-separated naming: `{indexType}.{indexKey}.{suffix}` (indexKey is inferred from the indexes object key)
-- Supports multiple indexes of the same type (e.g., `markdown.markdownDocs.log`, `markdown.markdownObsidian.log`)
+- Simple naming: `{indexId}.{suffix}` (indexId is the key from the indexes object)
+- Supports multiple indexes of the same type (e.g., `markdownDocs.log`, `markdownObsidian.log`)
 
 **Rule:** Only one client can access the same storage context at a time.
 

--- a/packages/epicenter/src/core/epicenter/README.md
+++ b/packages/epicenter/src/core/epicenter/README.md
@@ -144,6 +144,31 @@ Examples:
   Browser + pages → IndexedDB:pages (different!)
 ```
 
+### `.epicenter/` Folder Structure
+
+The `.epicenter` folder contains all Epicenter internal data:
+
+```
+.epicenter/
+├── blog.db                           # SQLite database (per workspace)
+├── blog.yjs                          # YJS persistence (per workspace)
+├── auth.db
+├── auth.yjs
+├── blog/                             # Workspace-specific index artifacts
+│   ├── markdown.default.log          # Markdown index sync log
+│   ├── markdown.default.diagnostics.json
+│   └── sqlite.default.log            # SQLite index error log
+└── auth/
+    ├── markdown.default.log
+    └── sqlite.default.log
+```
+
+**Key design decisions:**
+- YJS and DB files stay at root level (easy to find, prominent)
+- Index logs/diagnostics go inside workspace folders
+- Dot-separated naming: `{indexType}.{instanceName}.{suffix}`
+- Supports multiple indexes of the same type (e.g., `markdown.docs.log`, `markdown.obsidian.log`)
+
 **Rule:** Only one client can access the same storage context at a time.
 
 ### Cleanup Lifecycle

--- a/packages/epicenter/src/core/indexes.ts
+++ b/packages/epicenter/src/core/indexes.ts
@@ -46,7 +46,7 @@ export type Index<
  * Provides workspace metadata, schema, and database instance that indexes sync with.
  *
  * @property id - The workspace ID (e.g., 'blog', 'content-hub')
- * @property indexKey - The key used in the workspace's `indexes` object (e.g., 'sqlite', 'markdown', 'markdownDocs')
+ * @property indexId - The index identifier from the workspace's `indexes` object (e.g., 'sqlite', 'markdown', 'markdownDocs')
  * @property schema - The workspace schema (table definitions)
  * @property db - The Epicenter database instance containing YJS-backed tables
  * @property storageDir - Absolute storage directory path resolved from epicenter config
@@ -59,9 +59,9 @@ export type Index<
  * @example Creating an index with IndexContext
  * ```typescript
  * export function sqliteIndex<TSchema extends WorkspaceSchema>(
- *   { id, indexKey, schema, db, epicenterDir }: IndexContext<TSchema>
+ *   { id, indexId, schema, db, epicenterDir }: IndexContext<TSchema>
  * ) {
- *   // indexKey: The key from indexes object (e.g., 'sqlite', 'markdownDocs')
+ *   // indexId: The identifier from indexes object (e.g., 'sqlite', 'markdownDocs')
  *   // Use schema for type conversions: convertWorkspaceSchemaToDrizzle(schema)
  *   // Use epicenterDir for file paths: path.join(epicenterDir, `${id}.db`)
  *   // Use db to observe table changes
@@ -70,7 +70,7 @@ export type Index<
  */
 export type IndexContext<TSchema extends WorkspaceSchema = WorkspaceSchema> = {
 	id: string;
-	indexKey: string;
+	indexId: string;
 	schema: TSchema;
 	db: Db<TSchema>;
 	storageDir: StorageDir | undefined;

--- a/packages/epicenter/src/core/indexes.ts
+++ b/packages/epicenter/src/core/indexes.ts
@@ -46,6 +46,7 @@ export type Index<
  * Provides workspace metadata, schema, and database instance that indexes sync with.
  *
  * @property id - The workspace ID (e.g., 'blog', 'content-hub')
+ * @property indexKey - The key used in the workspace's `indexes` object (e.g., 'sqlite', 'markdown', 'markdownDocs')
  * @property schema - The workspace schema (table definitions)
  * @property db - The Epicenter database instance containing YJS-backed tables
  * @property storageDir - Absolute storage directory path resolved from epicenter config
@@ -58,8 +59,9 @@ export type Index<
  * @example Creating an index with IndexContext
  * ```typescript
  * export function sqliteIndex<TSchema extends WorkspaceSchema>(
- *   { id, schema, db, epicenterDir }: IndexContext<TSchema>
+ *   { id, indexKey, schema, db, epicenterDir }: IndexContext<TSchema>
  * ) {
+ *   // indexKey: The key from indexes object (e.g., 'sqlite', 'markdownDocs')
  *   // Use schema for type conversions: convertWorkspaceSchemaToDrizzle(schema)
  *   // Use epicenterDir for file paths: path.join(epicenterDir, `${id}.db`)
  *   // Use db to observe table changes
@@ -68,6 +70,7 @@ export type Index<
  */
 export type IndexContext<TSchema extends WorkspaceSchema = WorkspaceSchema> = {
 	id: string;
+	indexKey: string;
 	schema: TSchema;
 	db: Db<TSchema>;
 	storageDir: StorageDir | undefined;

--- a/packages/epicenter/src/core/workspace/client.ts
+++ b/packages/epicenter/src/core/workspace/client.ts
@@ -347,15 +347,16 @@ export async function initializeWorkspaces<
 		const validators = createWorkspaceValidators(workspaceConfig.schema);
 
 		// Initialize each index by calling its factory function with IndexContext
-		// Each index function receives { id, schema, db, storageDir, epicenterDir } and returns an index object
+		// Each index function receives { id, indexKey, schema, db, storageDir, epicenterDir } and returns an index object
 		// Initialize all indexes in parallel for better performance
 		const indexes = Object.fromEntries(
 			await Promise.all(
 				Object.entries(workspaceConfig.indexes).map(
-					async ([indexId, indexFn]) => [
-						indexId,
+					async ([indexKey, indexFn]) => [
+						indexKey,
 						await indexFn({
 							id: workspaceConfig.id,
+							indexKey,
 							schema: workspaceConfig.schema,
 							db,
 							storageDir,

--- a/packages/epicenter/src/core/workspace/client.ts
+++ b/packages/epicenter/src/core/workspace/client.ts
@@ -347,16 +347,16 @@ export async function initializeWorkspaces<
 		const validators = createWorkspaceValidators(workspaceConfig.schema);
 
 		// Initialize each index by calling its factory function with IndexContext
-		// Each index function receives { id, indexKey, schema, db, storageDir, epicenterDir } and returns an index object
+		// Each index function receives { id, indexId, schema, db, storageDir, epicenterDir } and returns an index object
 		// Initialize all indexes in parallel for better performance
 		const indexes = Object.fromEntries(
 			await Promise.all(
 				Object.entries(workspaceConfig.indexes).map(
-					async ([indexKey, indexFn]) => [
-						indexKey,
+					async ([indexId, indexFn]) => [
+						indexId,
 						await indexFn({
 							id: workspaceConfig.id,
-							indexKey,
+							indexId,
 							schema: workspaceConfig.schema,
 							db,
 							storageDir,

--- a/packages/epicenter/src/indexes/markdown/README.md
+++ b/packages/epicenter/src/indexes/markdown/README.md
@@ -85,6 +85,9 @@ The Markdown Index uses a two-layer configuration structure that determines wher
 
 ```
 MarkdownIndexConfig
+├── name (index instance name)
+│   └── Defaults to 'default'
+│
 ├── directory (workspace-level)
 │   └── Defaults to workspace ID
 │
@@ -101,6 +104,28 @@ MarkdownIndexConfig
         ├── directory (table-level)
         ├── serialize()
         └── deserialize()
+```
+
+### Index Instance Name
+
+**`name`** (optional): Unique identifier for this markdown index instance.
+- Defaults to `'default'`
+- Used in the `.epicenter` folder structure: `.epicenter/{workspaceId}/markdown.{name}.log`
+- Required when you want multiple markdown indexes for the same workspace
+
+```typescript
+// Single markdown index (uses default name)
+indexes: {
+  markdown: (c) => markdownIndex(c, { directory: './docs' }),
+}
+// Files: .epicenter/blog/markdown.default.log
+
+// Multiple markdown indexes
+indexes: {
+  markdownDocs: (c) => markdownIndex(c, { name: 'docs', directory: './docs' }),
+  markdownObsidian: (c) => markdownIndex(c, { name: 'obsidian', directory: '/path/to/vault' }),
+}
+// Files: .epicenter/blog/markdown.docs.log, .epicenter/blog/markdown.obsidian.log
 ```
 
 ### Layer 1: Workspace Configuration

--- a/packages/epicenter/src/indexes/markdown/README.md
+++ b/packages/epicenter/src/indexes/markdown/README.md
@@ -86,7 +86,7 @@ The Markdown Index uses a two-layer configuration structure that determines wher
 ```
 MarkdownIndexConfig
 ├── name (index instance name)
-│   └── Defaults to 'default'
+│   └── Defaults to indexKey (from indexes object)
 │
 ├── directory (workspace-level)
 │   └── Defaults to workspace ID
@@ -109,23 +109,29 @@ MarkdownIndexConfig
 ### Index Instance Name
 
 **`name`** (optional): Unique identifier for this markdown index instance.
-- Defaults to `'default'`
+- Defaults to `indexKey` (the key used in the `indexes` object)
 - Used in the `.epicenter` folder structure: `.epicenter/{workspaceId}/markdown.{name}.log`
-- Required when you want multiple markdown indexes for the same workspace
+- Can be explicitly set to override the default derived from `indexKey`
 
 ```typescript
-// Single markdown index (uses default name)
+// Single markdown index (name defaults to "markdown" from indexKey)
 indexes: {
   markdown: (c) => markdownIndex(c, { directory: './docs' }),
 }
-// Files: .epicenter/blog/markdown.default.log
+// Files: .epicenter/blog/markdown.markdown.log
 
-// Multiple markdown indexes
+// Multiple markdown indexes (names default to indexKeys)
+indexes: {
+  markdownDocs: (c) => markdownIndex(c, { directory: './docs' }),
+  markdownObsidian: (c) => markdownIndex(c, { directory: '/path/to/vault' }),
+}
+// Files: .epicenter/blog/markdown.markdownDocs.log, .epicenter/blog/markdown.markdownObsidian.log
+
+// Explicit name override
 indexes: {
   markdownDocs: (c) => markdownIndex(c, { name: 'docs', directory: './docs' }),
-  markdownObsidian: (c) => markdownIndex(c, { name: 'obsidian', directory: '/path/to/vault' }),
 }
-// Files: .epicenter/blog/markdown.docs.log, .epicenter/blog/markdown.obsidian.log
+// Files: .epicenter/blog/markdown.docs.log
 ```
 
 ### Layer 1: Workspace Configuration

--- a/packages/epicenter/src/indexes/markdown/README.md
+++ b/packages/epicenter/src/indexes/markdown/README.md
@@ -85,9 +85,6 @@ The Markdown Index uses a two-layer configuration structure that determines wher
 
 ```
 MarkdownIndexConfig
-├── name (index instance name)
-│   └── Defaults to indexKey (from indexes object)
-│
 ├── directory (workspace-level)
 │   └── Defaults to workspace ID
 │
@@ -106,33 +103,26 @@ MarkdownIndexConfig
         └── deserialize()
 ```
 
-### Index Instance Name
+### File Naming
 
-**`name`** (optional): Unique identifier for this markdown index instance.
-- Defaults to `indexKey` (the key used in the `indexes` object)
-- Used in the `.epicenter` folder structure: `.epicenter/{workspaceId}/markdown.{name}.log`
-- Can be explicitly set to override the default derived from `indexKey`
+Index artifacts (logs, diagnostics) use the **index ID** from your workspace config:
 
 ```typescript
-// Single markdown index (name defaults to "markdown" from indexKey)
+// Single markdown index
 indexes: {
   markdown: (c) => markdownIndex(c, { directory: './docs' }),
 }
-// Files: .epicenter/blog/markdown.markdown.log
+// Files: .epicenter/blog/markdown.log, .epicenter/blog/markdown.diagnostics.json
 
-// Multiple markdown indexes (names default to indexKeys)
+// Multiple markdown indexes
 indexes: {
   markdownDocs: (c) => markdownIndex(c, { directory: './docs' }),
   markdownObsidian: (c) => markdownIndex(c, { directory: '/path/to/vault' }),
 }
-// Files: .epicenter/blog/markdown.markdownDocs.log, .epicenter/blog/markdown.markdownObsidian.log
-
-// Explicit name override
-indexes: {
-  markdownDocs: (c) => markdownIndex(c, { name: 'docs', directory: './docs' }),
-}
-// Files: .epicenter/blog/markdown.docs.log
+// Files: .epicenter/blog/markdownDocs.log, .epicenter/blog/markdownObsidian.log
 ```
+
+The index ID (`markdown`, `markdownDocs`, etc.) is automatically passed via `context.indexId`.
 
 ### Layer 1: Workspace Configuration
 

--- a/packages/epicenter/src/indexes/markdown/markdown-index.ts
+++ b/packages/epicenter/src/indexes/markdown/markdown-index.ts
@@ -242,21 +242,27 @@ export type MarkdownIndexConfig<
 	 *
 	 * @example
 	 * ```typescript
-	 * // Single markdown index (uses default name)
+	 * // Single markdown index (name defaults to indexKey)
 	 * indexes: {
 	 *   markdown: (c) => markdownIndex(c, { directory: './docs' }),
 	 * }
-	 * // Files: .epicenter/blog/markdown.default.log
+	 * // Files: .epicenter/blog/markdown.markdown.log
 	 *
-	 * // Multiple markdown indexes
+	 * // Multiple markdown indexes (name defaults to indexKey)
+	 * indexes: {
+	 *   markdownDocs: (c) => markdownIndex(c, { directory: './docs' }),
+	 *   markdownObsidian: (c) => markdownIndex(c, { directory: '/path/to/vault' }),
+	 * }
+	 * // Files: .epicenter/blog/markdown.markdownDocs.log, .epicenter/blog/markdown.markdownObsidian.log
+	 *
+	 * // Explicit name override
 	 * indexes: {
 	 *   markdownDocs: (c) => markdownIndex(c, { name: 'docs', directory: './docs' }),
-	 *   markdownObsidian: (c) => markdownIndex(c, { name: 'obsidian', directory: '/path/to/vault' }),
 	 * }
-	 * // Files: .epicenter/blog/markdown.docs.log, .epicenter/blog/markdown.obsidian.log
+	 * // Files: .epicenter/blog/markdown.docs.log
 	 * ```
 	 *
-	 * @default 'default'
+	 * @default indexKey (the key from the indexes object)
 	 */
 	name?: string;
 
@@ -328,8 +334,8 @@ export const markdownIndex = (async <TSchema extends WorkspaceSchema>(
 	context: IndexContext<TSchema>,
 	config: MarkdownIndexConfig<TSchema> = {},
 ) => {
-	const { id, db, storageDir, epicenterDir } = context;
-	const { name = 'default', directory = `./${id}` } = config;
+	const { id, indexKey, db, storageDir, epicenterDir } = context;
+	const { name = indexKey, directory = `./${id}` } = config;
 
 	// User-provided table configs (sparse - only contains overrides, may be empty)
 	// Access via userTableConfigs[tableName] returns undefined when user didn't provide config

--- a/packages/epicenter/src/indexes/markdown/markdown-index.ts
+++ b/packages/epicenter/src/indexes/markdown/markdown-index.ts
@@ -233,40 +233,6 @@ export type MarkdownIndexConfig<
 	TWorkspaceSchema extends WorkspaceSchema = WorkspaceSchema,
 > = {
 	/**
-	 * Unique name for this markdown index instance.
-	 *
-	 * Used to identify this index in the `.epicenter` folder structure and allows
-	 * multiple markdown indexes per workspace (e.g., syncing to different folders).
-	 *
-	 * Generated files use the pattern: `.epicenter/{workspaceId}/markdown.{name}.log`
-	 *
-	 * @example
-	 * ```typescript
-	 * // Single markdown index (name defaults to indexKey)
-	 * indexes: {
-	 *   markdown: (c) => markdownIndex(c, { directory: './docs' }),
-	 * }
-	 * // Files: .epicenter/blog/markdown.markdown.log
-	 *
-	 * // Multiple markdown indexes (name defaults to indexKey)
-	 * indexes: {
-	 *   markdownDocs: (c) => markdownIndex(c, { directory: './docs' }),
-	 *   markdownObsidian: (c) => markdownIndex(c, { directory: '/path/to/vault' }),
-	 * }
-	 * // Files: .epicenter/blog/markdown.markdownDocs.log, .epicenter/blog/markdown.markdownObsidian.log
-	 *
-	 * // Explicit name override
-	 * indexes: {
-	 *   markdownDocs: (c) => markdownIndex(c, { name: 'docs', directory: './docs' }),
-	 * }
-	 * // Files: .epicenter/blog/markdown.docs.log
-	 * ```
-	 *
-	 * @default indexKey (the key from the indexes object)
-	 */
-	name?: string;
-
-	/**
 	 * Workspace-level directory where markdown files should be stored.
 	 *
 	 * **Optional**: Defaults to the workspace `id` if not provided
@@ -334,8 +300,8 @@ export const markdownIndex = (async <TSchema extends WorkspaceSchema>(
 	context: IndexContext<TSchema>,
 	config: MarkdownIndexConfig<TSchema> = {},
 ) => {
-	const { id, indexKey, db, storageDir, epicenterDir } = context;
-	const { name = indexKey, directory = `./${id}` } = config;
+	const { id, indexId, db, storageDir, epicenterDir } = context;
+	const { directory = `./${id}` } = config;
 
 	// User-provided table configs (sparse - only contains overrides, may be empty)
 	// Access via userTableConfigs[tableName] returns undefined when user didn't provide config
@@ -348,20 +314,20 @@ export const markdownIndex = (async <TSchema extends WorkspaceSchema>(
 	}
 
 	// Workspace-specific directory for all index artifacts
-	// Structure: .epicenter/{workspaceId}/markdown.{name}.{suffix}
+	// Structure: .epicenter/{workspaceId}/{indexId}.{suffix}
 	const workspaceConfigDir = path.join(epicenterDir, id);
 
 	// Create diagnostics manager for tracking validation errors (current state)
 	const diagnostics = createDiagnosticsManager({
 		diagnosticsPath: path.join(
 			workspaceConfigDir,
-			`markdown.${name}.diagnostics.json`,
+			`${indexId}.diagnostics.json`,
 		),
 	});
 
 	// Create logger for historical error record (append-only audit trail)
 	const logger = createIndexLogger({
-		logPath: path.join(workspaceConfigDir, `markdown.${name}.log`),
+		logPath: path.join(workspaceConfigDir, `${indexId}.log`),
 	});
 
 	// Resolve workspace directory to absolute path

--- a/packages/epicenter/src/indexes/sqlite/sqlite-index.ts
+++ b/packages/epicenter/src/indexes/sqlite/sqlite-index.ts
@@ -52,7 +52,9 @@ type SyncCoordination = {
  * via defineIndex(). All exported resources become available in your workspace exports
  * via the `indexes` parameter.
  *
- * **Storage**: Auto-saves to `.epicenter/{workspaceId}.db` relative to storageDir from epicenter config
+ * **Storage**:
+ * - Database: `.epicenter/{workspaceId}.db`
+ * - Logs: `.epicenter/{workspaceId}/sqlite.default.log`
  *
  * @param context - Index context with workspace ID, database instance, and storage directory
  *
@@ -106,7 +108,9 @@ export const sqliteIndex = (async <TSchema extends WorkspaceSchema>({
 	const sqliteDb = drizzle({ client, schema: drizzleTables });
 
 	// Create error logger for this index
-	const logPath = path.join(epicenterDir, 'sqlite', `${id}.log`);
+	// Structure: .epicenter/{workspaceId}/sqlite.default.log
+	const workspaceConfigDir = path.join(epicenterDir, id);
+	const logPath = path.join(workspaceConfigDir, 'sqlite.default.log');
 	const logger = createIndexLogger({ logPath });
 
 	/**

--- a/packages/epicenter/src/indexes/sqlite/sqlite-index.ts
+++ b/packages/epicenter/src/indexes/sqlite/sqlite-index.ts
@@ -54,7 +54,7 @@ type SyncCoordination = {
  *
  * **Storage**:
  * - Database: `.epicenter/{workspaceId}.db`
- * - Logs: `.epicenter/{workspaceId}/sqlite.{indexKey}.log`
+ * - Logs: `.epicenter/{workspaceId}/{indexId}.log`
  *
  * @param context - Index context with workspace ID, database instance, and storage directory
  *
@@ -82,7 +82,7 @@ type SyncCoordination = {
  */
 export const sqliteIndex = (async <TSchema extends WorkspaceSchema>({
 	id,
-	indexKey,
+	indexId,
 	schema,
 	db,
 	epicenterDir,
@@ -109,9 +109,9 @@ export const sqliteIndex = (async <TSchema extends WorkspaceSchema>({
 	const sqliteDb = drizzle({ client, schema: drizzleTables });
 
 	// Create error logger for this index
-	// Structure: .epicenter/{workspaceId}/sqlite.{indexKey}.log
+	// Structure: .epicenter/{workspaceId}/{indexId}.log
 	const workspaceConfigDir = path.join(epicenterDir, id);
-	const logPath = path.join(workspaceConfigDir, `sqlite.${indexKey}.log`);
+	const logPath = path.join(workspaceConfigDir, `${indexId}.log`);
 	const logger = createIndexLogger({ logPath });
 
 	/**

--- a/packages/epicenter/src/indexes/sqlite/sqlite-index.ts
+++ b/packages/epicenter/src/indexes/sqlite/sqlite-index.ts
@@ -54,7 +54,7 @@ type SyncCoordination = {
  *
  * **Storage**:
  * - Database: `.epicenter/{workspaceId}.db`
- * - Logs: `.epicenter/{workspaceId}/sqlite.default.log`
+ * - Logs: `.epicenter/{workspaceId}/sqlite.{indexKey}.log`
  *
  * @param context - Index context with workspace ID, database instance, and storage directory
  *
@@ -82,6 +82,7 @@ type SyncCoordination = {
  */
 export const sqliteIndex = (async <TSchema extends WorkspaceSchema>({
 	id,
+	indexKey,
 	schema,
 	db,
 	epicenterDir,
@@ -108,9 +109,9 @@ export const sqliteIndex = (async <TSchema extends WorkspaceSchema>({
 	const sqliteDb = drizzle({ client, schema: drizzleTables });
 
 	// Create error logger for this index
-	// Structure: .epicenter/{workspaceId}/sqlite.default.log
+	// Structure: .epicenter/{workspaceId}/sqlite.{indexKey}.log
 	const workspaceConfigDir = path.join(epicenterDir, id);
-	const logPath = path.join(workspaceConfigDir, 'sqlite.default.log');
+	const logPath = path.join(workspaceConfigDir, `sqlite.${indexKey}.log`);
 	const logger = createIndexLogger({ logPath });
 
 	/**


### PR DESCRIPTION
This reorganizes how the `.epicenter/` folder stores index artifacts, changing from type-based organization to workspace-based organization while keeping primary data files prominent.

**The organizational change**: Previously, logs were organized by index type (`.epicenter/markdown/`, `.epicenter/sqlite/`). Now they're organized by workspace (`.epicenter/blog/`, `.epicenter/auth/`). This makes more sense because when working on a workspace, you want all its artifacts together rather than scattered across type folders.

**Keeping primary files prominent**: The `.db` and `.yjs` files stay at the root level since they're the main data files users care about. Secondary artifacts like logs and diagnostics are tucked into workspace folders that users can expand when needed:

```
.epicenter/
├── blog.db                    # Primary data - stays prominent
├── blog.yjs                   # Primary data - stays prominent  
├── auth.db
├── auth.yjs
├── blog/                      # Collapsible folder for blog's index artifacts
│   ├── markdown.log
│   ├── markdown.diagnostics.json
│   └── sqlite.log
└── auth/                      # Collapsible folder for auth's index artifacts
    ├── markdown.log
    └── sqlite.log
```

**Automatic naming via indexId**: The PR also adds `indexId` to `IndexContext`, which is the key from the workspace's `indexes` object. This enables multiple indexes of the same type per workspace:

```typescript
indexes: {
  markdownDocs: (c) => markdownIndex(c, { directory: './docs' }),
  markdownObsidian: (c) => markdownIndex(c, { directory: '/vault' }),
}
// Creates: .epicenter/blog/markdownDocs.log, .epicenter/blog/markdownObsidian.log
```

Each index automatically gets its identifier passed through context, eliminating the need for manual naming configuration.

## Verification

**Automated (completed):**
- [x] Type checking: Some packages have local tsc issues unrelated to this PR
- [ ] Tests: Failing due to column naming validation (`publishedAt` vs `published_at`) - unrelated to this change

**Manual testing needed:**
- [ ] Verify index artifacts are created in new locations
- [ ] Confirm multiple indexes of the same type work independently