### PR TITLE
feat(wiki): add wiki workspace for evergreen knowledge entries

### DIFF
--- a/docs/specs/20251201T000000-wiki-workspace.md
+++ b/docs/specs/20251201T000000-wiki-workspace.md
@@ -1,0 +1,112 @@
+# Wiki Workspace and Content Flow Refactor
+
+## Overview
+
+Create a wiki workspace for evergreen knowledge base entries that serve as the source of truth for all distributed content. Refactor the posts workspace to reference wiki entries instead of pages.
+
+## Motivation
+
+The current content model has:
+- **clippings**: External content you save (articles, books, recipes)
+- **pages**: Content you write with a publishing workflow (Draft → Published)
+- **posts**: Social media distribution across platforms
+
+The problem: `posts` currently references `page_id`, but the relationship between pages and posts is unclear. Pages have a publishing lifecycle that doesn't match the "source of truth" concept.
+
+The solution: Create a **wiki** workspace for permanent, evergreen reference content. Posts derive from wiki entries, creating a clear content flow:
+
+```
+wiki.entries (source of truth, permanent)
+    ↓ derives
+posts.* (distribution, platform-specific)
+```
+
+## Implementation Plan
+
+### 1. Create Wiki Workspace
+
+- [ ] Create `examples/content-hub/wiki/wiki.workspace.ts`
+- [ ] Create `examples/content-hub/wiki/README.md`
+
+**Schema:**
+```typescript
+schema: {
+  entries: {
+    id: id(),
+    title: text(),
+    content: text(),
+    summary: text({ nullable: true }),
+    tags: tags({ nullable: true }),
+    created_at: date(),
+    updated_at: date(),
+  },
+}
+```
+
+Key differences from pages:
+- No `status` field (no publishing lifecycle)
+- No `visibility` field (wiki entries are internal reference)
+- Simpler schema focused on content
+
+### 2. Refactor Posts Workspace
+
+- [ ] Remove `page_id` from all post schemas
+- [ ] Add `entry_id` (required) to all post schemas
+- [ ] Update JSDoc comments to reflect new relationship
+
+**Before:**
+```typescript
+const SHORT_FORM_VIDEO_SCHEMA = {
+  id: id(),
+  page_id: text(),  // References pages
+  // ...
+}
+```
+
+**After:**
+```typescript
+const SHORT_FORM_VIDEO_SCHEMA = {
+  id: id(),
+  entry_id: text(),  // References wiki.entries (required)
+  // ...
+}
+```
+
+### 3. Documentation
+
+The wiki README should explain:
+1. What wiki entries are (evergreen source of truth)
+2. How they differ from pages (no publishing lifecycle)
+3. The content flow to posts
+4. Markdown linking between entries
+
+## Design Decisions
+
+1. **entry_id is required**: Every post must derive from a wiki entry. This enforces a disciplined content workflow where you think first (wiki), then distribute (posts).
+
+2. **No additional wiki tables**: Entries can link to each other via markdown links in content. No need for a separate `entry_links` table.
+
+3. **Wiki replaces page_id in posts**: Pages serve a different purpose (publishing workflow) and shouldn't be the source for posts.
+
+## Review
+
+### Changes Made
+
+1. **Created `wiki/wiki.workspace.ts`**: New workspace with `entries` table for evergreen knowledge base content. Schema includes title, content, summary, tags, and timestamps. Uses markdown index with body field for content.
+
+2. **Created `wiki/README.md`**: Documentation explaining:
+   - What wiki entries are (evergreen source of truth)
+   - Content flow diagram (wiki.entries → posts.*)
+   - Comparison table: wiki vs pages
+   - How entries link to each other via markdown
+
+3. **Refactored `posts/posts.workspace.ts`**:
+   - Renamed `page_id` to `entry_id` in all three schema constants
+   - Updated JSDoc comments to describe the wiki → posts content flow
+   - Made `entry_id` required (not nullable) to enforce disciplined workflow
+
+### Files Changed
+
+- `examples/content-hub/wiki/wiki.workspace.ts` (new)
+- `examples/content-hub/wiki/README.md` (new)
+- `examples/content-hub/posts/posts.workspace.ts` (modified)

--- a/examples/content-hub/posts/posts.workspace.ts
+++ b/examples/content-hub/posts/posts.workspace.ts
@@ -24,10 +24,11 @@ const NICHES = [
 
 /**
  * Schema for short-form video content (YouTube, Instagram, TikTok)
+ * References wiki.entries via entry_id for source of truth.
  */
 const SHORT_FORM_VIDEO_SCHEMA = {
 	id: id(),
-	page_id: text(),
+	entry_id: text(),
 	title: text(),
 	description: text(),
 	niche: select({ options: NICHES }),
@@ -37,10 +38,11 @@ const SHORT_FORM_VIDEO_SCHEMA = {
 
 /**
  * Schema for long-form text content (Medium, Substack, Personal Blog, Epicenter Blog)
+ * References wiki.entries via entry_id for source of truth.
  */
 const LONG_FORM_TEXT_SCHEMA = {
 	id: id(),
-	page_id: text(),
+	entry_id: text(),
 	title: text(),
 	subtitle: text(),
 	content: text(),
@@ -51,10 +53,11 @@ const LONG_FORM_TEXT_SCHEMA = {
 
 /**
  * Schema for short-form text content (Reddit, Twitter, Hacker News, Discord, Product Hunt, Bookface)
+ * References wiki.entries via entry_id for source of truth.
  */
 const SHORT_FORM_TEXT_SCHEMA = {
 	id: id(),
-	page_id: text(),
+	entry_id: text(),
 	content: text(),
 	title: text({ nullable: true }),
 	niche: select({ options: NICHES }),
@@ -65,10 +68,14 @@ const SHORT_FORM_TEXT_SCHEMA = {
 /**
  * Posts workspace
  *
- * Consolidated workspace for all social media content across platforms.
+ * Distribution layer for social media content across platforms.
+ * All posts reference wiki.entries via entry_id for source of truth.
+ *
+ * Content flow: wiki.entries (source) → posts.* (distribution)
+ *
  * Organizes content by platform type:
  * - Video: youtube, tiktok, instagram
- * - Blogs: medium, substack, personalBlog, epicenterBlog
+ * - Blogs: medium, substack, personal_blog, epicenter_blog
  * - Social: reddit, twitter, discord, hackernews, producthunt, bookface
  */
 export const posts = defineWorkspace({

--- a/examples/content-hub/wiki/README.md
+++ b/examples/content-hub/wiki/README.md
@@ -32,37 +32,28 @@ Think of them like your personal Wikipedia: authoritative, topic-focused, and al
 
 Every post must reference a wiki entry via `entry_id`. This enforces a disciplined workflow: think first (wiki), then distribute (posts).
 
-## How Wiki Differs from Pages
+## Dual Markdown Indexes
 
-| Aspect | Wiki Entries | Pages |
-|--------|--------------|-------|
-| Purpose | Reference knowledge | Published content |
-| Lifecycle | Continuously updated | Draft → Published |
-| Time-bound | No (evergreen) | Yes (publication date) |
-| Audience | Internal reference | External publication |
+The wiki workspace has two markdown indexes for different purposes:
 
-Use wiki for "what I know about X." Use pages for "what I published on Y date."
+### 1. Local Storage (`markdown`)
 
-## Linking Between Entries
-
-Entries can link to each other using standard markdown:
-
-```markdown
-See also [Related Topic](./related-topic.md) for more context.
-```
-
-No separate linking table needed; the connections live in the content itself.
-
-## Schema
+Default storage for all wiki content. Uses the standard `withBodyField('content')` config.
 
 ```typescript
-entries: {
-  id: id(),
-  title: text(),           // The topic name
-  content: text(),         // Markdown body (evergreen content)
-  summary: text(),         // Short description for listings
-  tags: tags(),            // Categorization
-  created_at: date(),      // When first written
-  updated_at: date(),      // When last modified
-}
+// Sync operations
+pullToMarkdown(); // YJS → local markdown files
+pushFromMarkdown(); // local markdown files → YJS
+```
+
+### 2. Blog Content Collection (`blog`)
+
+Syncs entries to your Astro blog at `/Users/braden/Code/blog/src/content/articles/`.
+
+Field names are kept consistent (no remapping). Dates are serialized as Date objects with timezone stored separately.
+
+```typescript
+// Sync operations
+pullToBlog(); // YJS → blog content collection
+pushFromBlog(); // blog content collection → YJS
 ```

--- a/examples/content-hub/wiki/README.md
+++ b/examples/content-hub/wiki/README.md
@@ -1,0 +1,68 @@
+# Wiki Workspace
+
+Evergreen knowledge base entries that serve as the source of truth for all content.
+
+## What Are Wiki Entries?
+
+Wiki entries are permanent reference documents on specific topics. Unlike blog posts or articles that have a publication date and become stale, wiki entries are living documents that you continuously update as your understanding evolves.
+
+Think of them like your personal Wikipedia: authoritative, topic-focused, and always current.
+
+## Content Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                                                                 │
+│   wiki.entries                                                  │
+│   ────────────                                                  │
+│   Source of truth. Permanent. Evergreen.                        │
+│   Your authoritative take on a topic.                           │
+│                                                                 │
+│              │                                                  │
+│              │ derives                                          │
+│              ▼                                                  │
+│                                                                 │
+│   posts.*                                                       │
+│   ───────                                                       │
+│   Distribution. Platform-specific. Timestamped.                 │
+│   Twitter, Reddit, YouTube, etc.                                │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Every post must reference a wiki entry via `entry_id`. This enforces a disciplined workflow: think first (wiki), then distribute (posts).
+
+## How Wiki Differs from Pages
+
+| Aspect | Wiki Entries | Pages |
+|--------|--------------|-------|
+| Purpose | Reference knowledge | Published content |
+| Lifecycle | Continuously updated | Draft → Published |
+| Time-bound | No (evergreen) | Yes (publication date) |
+| Audience | Internal reference | External publication |
+
+Use wiki for "what I know about X." Use pages for "what I published on Y date."
+
+## Linking Between Entries
+
+Entries can link to each other using standard markdown:
+
+```markdown
+See also [Related Topic](./related-topic.md) for more context.
+```
+
+No separate linking table needed; the connections live in the content itself.
+
+## Schema
+
+```typescript
+entries: {
+  id: id(),
+  title: text(),           // The topic name
+  content: text(),         // Markdown body (evergreen content)
+  summary: text(),         // Short description for listings
+  tags: tags(),            // Categorization
+  created_at: date(),      // When first written
+  updated_at: date(),      // When last modified
+}
+```

--- a/examples/content-hub/wiki/wiki.workspace.ts
+++ b/examples/content-hub/wiki/wiki.workspace.ts
@@ -1,14 +1,29 @@
+import path from 'node:path';
 import {
+	DateWithTimezone,
+	DateWithTimezoneFromString,
 	date,
 	defineWorkspace,
 	id,
 	markdownIndex,
+	select,
+	type SerializedRow,
 	sqliteIndex,
 	tags,
 	text,
 	withBodyField,
 } from '@epicenter/hq';
+import { QUALITY_OPTIONS } from '../shared/quality';
+import { MarkdownIndexErr } from '@epicenter/hq/indexes/markdown';
 import { setupPersistence } from '@epicenter/hq/providers';
+import { type } from 'arktype';
+import { Ok } from 'wellcrafted/result';
+
+/**
+ * Path to the blog's content collection for articles
+ * This is where Astro expects content collection markdown files
+ */
+const BLOG_ARTICLES_PATH = '/Users/braden/Code/blog/src/content/articles';
 
 /**
  * Wiki workspace
@@ -19,6 +34,10 @@ import { setupPersistence } from '@epicenter/hq/providers';
  *
  * Content flow:
  *   wiki.entries (source of truth) → posts.* (distribution)
+ *
+ * Two markdown indexes:
+ *   1. `markdown` - local storage for all wiki content
+ *   2. `blog` - syncs entries to Astro blog content collection
  *
  * Wiki entries can link to each other using standard markdown links.
  * Each entry represents your authoritative take on a topic.
@@ -31,8 +50,9 @@ export const wiki = defineWorkspace({
 			id: id(),
 			title: text(),
 			content: text(),
-			summary: text({ nullable: true }),
+			type: tags({ nullable: true }),
 			tags: tags({ nullable: true }),
+			resonance: select({ options: QUALITY_OPTIONS, nullable: true }),
 			created_at: date(),
 			updated_at: date(),
 		},
@@ -40,10 +60,111 @@ export const wiki = defineWorkspace({
 
 	indexes: {
 		sqlite: (c) => sqliteIndex(c),
+
+		/**
+		 * Local markdown storage for wiki entries
+		 */
 		markdown: (c) =>
 			markdownIndex(c, {
 				tableConfigs: {
 					entries: withBodyField('content'),
+				},
+			}),
+
+		/**
+		 * Blog content collection sync
+		 *
+		 * Syncs wiki entries to Astro's content collection format.
+		 * Field names are kept consistent (no remapping).
+		 * Dates are serialized as Date objects, timezone stored separately.
+		 */
+		blog: (c) =>
+			markdownIndex(c, {
+				directory: BLOG_ARTICLES_PATH,
+				tableConfigs: {
+					entries: {
+						serialize: ({ row }) => {
+							const {
+								id: rowId,
+								content,
+								title,
+								type,
+								tags,
+								resonance,
+								created_at,
+								updated_at,
+							} = row;
+
+							// Destructure date and timezone from DateWithTimezoneString
+							const { date: createdDate, timezone } =
+								DateWithTimezoneFromString(created_at);
+							const { date: updatedDate } =
+								DateWithTimezoneFromString(updated_at);
+
+							// Build frontmatter with consistent field names
+							const frontmatter = {
+								title,
+								type,
+								tags,
+								resonance,
+								timezone,
+								created_at: createdDate,
+								updated_at: updatedDate,
+							};
+
+							return {
+								frontmatter,
+								body: content,
+								filename: `${rowId}.md`,
+							};
+						},
+
+						deserialize: ({ frontmatter, body, filename, table }) => {
+							const rowId = path.basename(filename, '.md');
+
+							// Parse frontmatter with consistent field names
+							const EntryFrontmatter = type({
+								title: 'string',
+								'type?': 'string[]',
+								'tags?': 'string[]',
+								'resonance?': 'string | null',
+								timezone: 'string',
+								created_at: 'Date',
+								updated_at: 'Date',
+							});
+
+							const parsed = EntryFrontmatter(frontmatter);
+							if (parsed instanceof type.errors) {
+								return MarkdownIndexErr({
+									message: `Invalid frontmatter for entry ${rowId}`,
+									context: {
+										filename,
+										id: rowId,
+										reason: parsed.summary,
+									},
+								});
+							}
+
+							const row = {
+								id: rowId,
+								title: parsed.title,
+								content: body,
+								type: parsed.type ?? null,
+								tags: parsed.tags ?? null,
+								resonance: parsed.resonance ?? null,
+								created_at: DateWithTimezone({
+									date: parsed.created_at,
+									timezone: parsed.timezone,
+								}).toJSON(),
+								updated_at: DateWithTimezone({
+									date: parsed.updated_at,
+									timezone: parsed.timezone,
+								}).toJSON(),
+							} satisfies SerializedRow<typeof table.schema>;
+
+							return Ok(row);
+						},
+					},
 				},
 			}),
 	},
@@ -52,8 +173,16 @@ export const wiki = defineWorkspace({
 
 	exports: ({ db, indexes }) => ({
 		...db.entries,
+
+		// Local markdown sync
 		pullToMarkdown: indexes.markdown.pullToMarkdown,
 		pushFromMarkdown: indexes.markdown.pushFromMarkdown,
+
+		// Blog content collection sync
+		pullToBlog: indexes.blog.pullToMarkdown,
+		pushFromBlog: indexes.blog.pushFromMarkdown,
+
+		// SQLite sync
 		pullToSqlite: indexes.sqlite.pullToSqlite,
 		pushFromSqlite: indexes.sqlite.pushFromSqlite,
 	}),

--- a/examples/content-hub/wiki/wiki.workspace.ts
+++ b/examples/content-hub/wiki/wiki.workspace.ts
@@ -1,0 +1,60 @@
+import {
+	date,
+	defineWorkspace,
+	id,
+	markdownIndex,
+	sqliteIndex,
+	tags,
+	text,
+	withBodyField,
+} from '@epicenter/hq';
+import { setupPersistence } from '@epicenter/hq/providers';
+
+/**
+ * Wiki workspace
+ *
+ * Evergreen knowledge base entries that serve as the source of truth.
+ * Unlike pages (which have a publishing lifecycle), wiki entries are
+ * permanent reference documents that are continuously updated.
+ *
+ * Content flow:
+ *   wiki.entries (source of truth) → posts.* (distribution)
+ *
+ * Wiki entries can link to each other using standard markdown links.
+ * Each entry represents your authoritative take on a topic.
+ */
+export const wiki = defineWorkspace({
+	id: 'wiki',
+
+	schema: {
+		entries: {
+			id: id(),
+			title: text(),
+			content: text(),
+			summary: text({ nullable: true }),
+			tags: tags({ nullable: true }),
+			created_at: date(),
+			updated_at: date(),
+		},
+	},
+
+	indexes: {
+		sqlite: (c) => sqliteIndex(c),
+		markdown: (c) =>
+			markdownIndex(c, {
+				tableConfigs: {
+					entries: withBodyField('content'),
+				},
+			}),
+	},
+
+	providers: [setupPersistence],
+
+	exports: ({ db, indexes }) => ({
+		...db.entries,
+		pullToMarkdown: indexes.markdown.pullToMarkdown,
+		pushFromMarkdown: indexes.markdown.pushFromMarkdown,
+		pullToSqlite: indexes.sqlite.pullToSqlite,
+		pushFromSqlite: indexes.sqlite.pushFromSqlite,
+	}),
+});


### PR DESCRIPTION
This introduces a wiki workspace for permanent, evergreen reference content that serves as the source of truth for all distributed content.

The wiki workspace stores entries that are continuously updated knowledge documents, unlike pages which have a publishing lifecycle. Every post in the posts workspace now requires an `entry_id` reference to a wiki entry, enforcing a disciplined workflow: think first (wiki), then distribute (posts).

The wiki includes two markdown indexes: local storage for all wiki content, and a blog sync that persists entries to the Astro blog content collection at `/Users/braden/Code/blog/src/content/articles/`. Field names are kept consistent between indexes with dates serialized as Date objects and timezone stored separately in frontmatter.

Schema includes title, content, type (tags), tags, resonance (quality rating), and timestamps with timezone support. The posts workspace was refactored to replace `page_id` with `entry_id` across all platform schemas.