### PR TITLE
feat(inference): add GPT-5 and GPT-5 mini model support

### DIFF
--- a/apps/whispering/src/lib/constants/inference/openai-models.ts
+++ b/apps/whispering/src/lib/constants/inference/openai-models.ts
@@ -5,6 +5,8 @@
  */
 
 export const OPENAI_INFERENCE_MODELS = [
+	'gpt-5',
+	'gpt-5-mini',
 	'gpt-4.1',
 	'gpt-4.1-mini',
 	'gpt-4.1-nano',


### PR DESCRIPTION
Adds GPT-5 and GPT-5 mini to the OpenAI inference models list, making them available for text transformations.

The models are placed at the top of the list since they're the newest. The existing architecture handles them automatically since the completion service passes any model string to OpenAI's API, and the arktype schema validates against the models array.

Closes #910