### PR TITLE
refactor(ui): remove redundant items prop from Select components

### DIFF
--- a/apps/whispering/src/lib/components/settings/TranscriptionServiceSelect.svelte
+++ b/apps/whispering/src/lib/components/settings/TranscriptionServiceSelect.svelte
@@ -72,12 +72,7 @@
 	<Label class={cn('text-sm', hideLabel && 'sr-only')} for={id}>
 		{label}
 	</Label>
-	<Select.Root
-		type="single"
-		items={items.map((service) => ({ value: service.id, label: service.name }))}
-		bind:value={selected}
-		{disabled}
-	>
+	<Select.Root type="single" bind:value={selected} {disabled}>
 		<Select.Trigger class={cn('w-full', className)} {id}>
 			<div class="flex items-center gap-2">
 				{#if selectedService}

--- a/apps/whispering/src/lib/components/transformations-editor/Configuration.svelte
+++ b/apps/whispering/src/lib/components/transformations-editor/Configuration.svelte
@@ -156,7 +156,6 @@
 								</Card.Title>
 								<Select.Root
 									type="single"
-									items={TRANSFORMATION_STEP_TYPE_OPTIONS}
 									bind:value={
 										() => step.type,
 										(value) => {
@@ -301,7 +300,6 @@
 										<Field.Label for="prompt_transform.inference.provider">Provider</Field.Label>
 										<Select.Root
 											type="single"
-											items={INFERENCE_PROVIDER_OPTIONS}
 											bind:value={
 												() => step['prompt_transform.inference.provider'],
 												(value) => {
@@ -337,7 +335,6 @@
 											<Field.Label for="prompt_transform.inference.provider.OpenAI.model">Model</Field.Label>
 											<Select.Root
 												type="single"
-												items={OPENAI_INFERENCE_MODEL_OPTIONS}
 												bind:value={
 													() =>
 														step[
@@ -376,7 +373,6 @@
 											<Field.Label for="prompt_transform.inference.provider.Groq.model">Model</Field.Label>
 											<Select.Root
 												type="single"
-												items={GROQ_INFERENCE_MODEL_OPTIONS}
 												bind:value={
 													() =>
 														step[
@@ -415,7 +411,6 @@
 											<Field.Label for="prompt_transform.inference.provider.Anthropic.model">Model</Field.Label>
 											<Select.Root
 												type="single"
-												items={ANTHROPIC_INFERENCE_MODEL_OPTIONS}
 												bind:value={
 													() =>
 														step[
@@ -454,7 +449,6 @@
 											<Field.Label for="prompt_transform.inference.provider.Google.model">Model</Field.Label>
 											<Select.Root
 												type="single"
-												items={GOOGLE_INFERENCE_MODEL_OPTIONS}
 												bind:value={
 													() =>
 														step[

--- a/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
@@ -159,7 +159,6 @@
 		<Field.Label for="recording-retention-strategy">Auto Delete Recordings</Field.Label>
 		<Select.Root
 			type="single"
-			items={retentionItems}
 			bind:value={
 				() => settings.value['database.recordingRetentionStrategy'],
 				(v) => settings.updateKey('database.recordingRetentionStrategy', v)
@@ -181,7 +180,6 @@
 			<Field.Label for="max-recording-count">Maximum Recordings</Field.Label>
 			<Select.Root
 				type="single"
-				items={maxRecordingItems}
 				bind:value={
 					() => settings.value['database.maxRecordingCount'],
 					(v) => settings.updateKey('database.maxRecordingCount', v)
@@ -204,7 +202,6 @@
 			<Field.Label for="always-on-top">Always On Top</Field.Label>
 			<Select.Root
 				type="single"
-				items={ALWAYS_ON_TOP_MODE_OPTIONS}
 				bind:value={
 					() => settings.value['system.alwaysOnTop'],
 					(v) => settings.updateKey('system.alwaysOnTop', v)

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
@@ -113,7 +113,6 @@
 		<Field.Label for="recording-mode">Recording Mode</Field.Label>
 		<Select.Root
 			type="single"
-			items={RECORDING_MODE_OPTIONS}
 			bind:value={
 				() => settings.value['recording.mode'],
 				(selected) => {
@@ -142,7 +141,6 @@
 			<Field.Label for="recording-method">Recording Method</Field.Label>
 			<Select.Root
 				type="single"
-				items={RECORDING_METHOD_OPTIONS}
 				bind:value={
 					() => settings.value['recording.method'],
 					(selected) => {
@@ -325,10 +323,6 @@
 				<Field.Label for="bit-rate">Bitrate</Field.Label>
 				<Select.Root
 					type="single"
-					items={BITRATE_OPTIONS.map((option) => ({
-						value: option.value,
-						label: option.label,
-					}))}
 					bind:value={
 						() => settings.value['recording.navigator.bitrateKbps'],
 						(selected) => {
@@ -384,7 +378,6 @@
 				<Field.Label for="sample-rate">Sample Rate</Field.Label>
 				<Select.Root
 					type="single"
-					items={SAMPLE_RATE_OPTIONS}
 					bind:value={
 						() => settings.value['recording.cpal.sampleRate'],
 						(selected) => {

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/FfmpegCommandBuilder.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/FfmpegCommandBuilder.svelte
@@ -282,7 +282,6 @@
 						<Field.Label for="ffmpeg-format">Format</Field.Label>
 						<Select.Root
 							type="single"
-							items={audioFormatOptions}
 							bind:value={
 								() => selected.format,
 								(value) => {
@@ -310,7 +309,6 @@
 						<Field.Label for="ffmpeg-sample-rate">Sample Rate</Field.Label>
 						<Select.Root
 							type="single"
-							items={SAMPLE_RATE_OPTIONS}
 							bind:value={
 								() => selected.sampleRate,
 								(value) => {
@@ -340,7 +338,6 @@
 							<Field.Label for="ffmpeg-quality">Quality</Field.Label>
 							<Select.Root
 								type="single"
-								items={qualityItems}
 								bind:value={
 									() => selected.quality,
 									(value) => {
@@ -369,7 +366,6 @@
 							<Field.Label for="ffmpeg-bitrate">Bitrate</Field.Label>
 							<Select.Root
 								type="single"
-								items={bitrateItems}
 								bind:value={
 									() => selected.bitrate,
 									(value) => {

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/ManualSelectRecordingDevice.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/ManualSelectRecordingDevice.svelte
@@ -36,7 +36,7 @@
 {#if getDevicesQuery.isPending}
 	<Field.Field>
 		<Field.Label for="manual-recording-device">Recording Device</Field.Label>
-		<Select.Root type="single" items={[{ value: '', label: 'Loading devices...' }]} disabled>
+		<Select.Root type="single" disabled>
 			<Select.Trigger id="manual-recording-device" class="w-full">
 				Loading devices...
 			</Select.Trigger>
@@ -54,7 +54,6 @@
 		<Field.Label for="manual-recording-device">Recording Device</Field.Label>
 		<Select.Root
 			type="single"
-			{items}
 			bind:value={
 				() => selected ?? asDeviceIdentifier(''),
 				(value) => (selected = value ? asDeviceIdentifier(value) : null)

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/VadSelectRecordingDevice.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/VadSelectRecordingDevice.svelte
@@ -36,7 +36,7 @@
 {#if getDevicesQuery.isPending}
 	<Field.Field>
 		<Field.Label for="vad-recording-device">VAD Recording Device</Field.Label>
-		<Select.Root type="single" items={[{ value: '', label: 'Loading devices...' }]} disabled>
+		<Select.Root type="single" disabled>
 			<Select.Trigger id="vad-recording-device" class="w-full">
 				Loading devices...
 			</Select.Trigger>
@@ -54,7 +54,6 @@
 		<Field.Label for="vad-recording-device">VAD Recording Device</Field.Label>
 		<Select.Root
 			type="single"
-			{items}
 			bind:value={
 				() => selected ?? asDeviceIdentifier(''),
 				(value) => (selected = value ? asDeviceIdentifier(value) : null)

--- a/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
@@ -149,7 +149,6 @@
 			<Field.Label for="openai-model">OpenAI Model</Field.Label>
 			<Select.Root
 				type="single"
-				items={openaiModelItems}
 				bind:value={
 					() => settings.value['transcription.openai.model'],
 					(v) => settings.updateKey('transcription.openai.model', v)
@@ -182,7 +181,6 @@
 			<Field.Label for="groq-model">Groq Model</Field.Label>
 			<Select.Root
 				type="single"
-				items={groqModelItems}
 				bind:value={
 					() => settings.value['transcription.groq.model'],
 					(v) => settings.updateKey('transcription.groq.model', v)
@@ -215,7 +213,6 @@
 			<Field.Label for="deepgram-model">Deepgram Model</Field.Label>
 			<Select.Root
 				type="single"
-				items={deepgramModelItems}
 				bind:value={
 					() => settings.value['transcription.deepgram.model'],
 					(v) => settings.updateKey('transcription.deepgram.model', v)
@@ -239,7 +236,6 @@
 			<Field.Label for="mistral-model">Mistral Model</Field.Label>
 			<Select.Root
 				type="single"
-				items={mistralModelItems}
 				bind:value={
 					() => settings.value['transcription.mistral.model'],
 					(v) => settings.updateKey('transcription.mistral.model', v)
@@ -274,7 +270,6 @@
 			<Field.Label for="elevenlabs-model">ElevenLabs Model</Field.Label>
 			<Select.Root
 				type="single"
-				items={elevenlabsModelItems}
 				bind:value={
 					() => settings.value['transcription.elevenlabs.model'],
 					(v) => settings.updateKey('transcription.elevenlabs.model', v)
@@ -677,7 +672,6 @@
 		<Field.Label for="output-language">Output Language</Field.Label>
 		<Select.Root
 			type="single"
-			items={SUPPORTED_LANGUAGES_OPTIONS}
 			bind:value={
 				() => settings.value['transcription.outputLanguage'],
 				(v) => settings.updateKey('transcription.outputLanguage', v)


### PR DESCRIPTION
The shadcn-svelte Select component's `items` prop is optional when items are explicitly rendered via `{#each}` loops inside `Select.Content`. This change removes the redundant prop from all `Select.Root` components that already have their items rendered via loops.

According to the [shadcn-svelte Select documentation](https://shadcn-svelte.com/docs/components/select), the `items` prop provides type inference and autocomplete benefits but is not required when using explicit item rendering. Since all affected components already render items via `{#each}` loops, the prop was redundant and its removal simplifies the component usage without any functional changes.