### PR TITLE
fix: update broken documentation links in settings pages

### DIFF
--- a/apps/whispering/src/routes/(app)/(config)/settings/analytics/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/analytics/+page.svelte
@@ -141,7 +141,7 @@
 		<Card.Content class="space-y-3">
 			<div class="grid gap-2 text-sm">
 				<a
-					href="https://github.com/EpicenterHQ/epicenter/tree/main/apps/whispering/src/lib/services/analytics.ts"
+					href="https://github.com/EpicenterHQ/epicenter/blob/main/apps/whispering/src/lib/services/analytics/types.ts"
 					target="_blank"
 					rel="noopener noreferrer"
 					class="group flex items-center gap-2 text-primary hover:text-primary/80 transition-colors"

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
@@ -161,7 +161,7 @@
 			{#if !isLocal}
 				<Button
 					variant="outline"
-					href="https://www.electronjs.org/docs/latest/api/accelerator"
+					href="https://v2.tauri.app/plugin/global-shortcut/"
 					target="_blank"
 					rel="noreferrer"
 				>


### PR DESCRIPTION
The shortcut format help dialog linked to Electron's accelerator documentation, but Whispering is a Tauri app. Updated to point to the Tauri v2 global shortcut plugin docs instead.

The analytics settings page linked to a nonexistent file path (`analytics.ts`) using the wrong GitHub URL format (`/tree/` instead of `/blob/`). The actual event definitions live in `analytics/types.ts`, so updated the link to point there.