### PR TITLE
feat(keyboard): add display labels for browser keyboard shortcuts

### DIFF
--- a/apps/whispering/src/lib/constants/keyboard/display-labels.ts
+++ b/apps/whispering/src/lib/constants/keyboard/display-labels.ts
@@ -1,0 +1,128 @@
+import type { KeyboardEventSupportedKey } from './browser/supported-keys';
+
+/**
+ * Display labels for browser keys that need human-readable representation.
+ * Exhaustive mapping for all non-trivial keys.
+ */
+const BROWSER_KEY_DISPLAY_LABELS: Partial<
+	Record<KeyboardEventSupportedKey, string>
+> = {
+	// Whitespace (PRIMARY FIX)
+	' ': 'Space',
+	enter: 'Enter',
+	tab: 'Tab',
+
+	// Modifiers
+	control: 'Ctrl',
+	shift: 'Shift',
+	alt: 'Alt',
+	meta: 'Cmd',
+	altgraph: 'AltGr',
+	capslock: 'CapsLock',
+	numlock: 'NumLock',
+	scrolllock: 'ScrollLock',
+	fn: 'Fn',
+	fnlock: 'FnLock',
+	super: 'Super',
+
+	// Navigation
+	arrowleft: '←',
+	arrowright: '→',
+	arrowup: '↑',
+	arrowdown: '↓',
+	home: 'Home',
+	end: 'End',
+	pageup: 'PgUp',
+	pagedown: 'PgDn',
+
+	// Editing
+	backspace: '⌫',
+	delete: 'Del',
+	insert: 'Ins',
+	clear: 'Clear',
+	copy: 'Copy',
+	cut: 'Cut',
+	paste: 'Paste',
+	redo: 'Redo',
+	undo: 'Undo',
+
+	// Special
+	escape: 'Esc',
+	contextmenu: 'Menu',
+	pause: 'Pause',
+	break: 'Break',
+	printscreen: 'PrtSc',
+	help: 'Help',
+
+	// Media
+	mediaplaypause: 'Play/Pause',
+	mediaplay: 'Play',
+	mediapause: 'Pause',
+	mediastop: 'Stop',
+	mediatracknext: 'Next Track',
+	mediatrackprevious: 'Prev Track',
+	volumeup: 'Vol+',
+	volumedown: 'Vol-',
+	volumemute: 'Mute',
+
+	// Other keys
+	dead: 'Dead',
+	compose: 'Compose',
+	accept: 'Accept',
+	again: 'Again',
+	attn: 'Attn',
+	cancel: 'Cancel',
+	execute: 'Execute',
+	find: 'Find',
+	finish: 'Finish',
+	props: 'Props',
+	select: 'Select',
+	zoomout: 'Zoom Out',
+	zoomin: 'Zoom In',
+};
+
+/**
+ * Gets display label for a full shortcut string.
+ *
+ * @param shortcut - The shortcut string (e.g., "control+shift+ ", "a")
+ * @returns Human-readable display (e.g., "Ctrl+Shift+Space", "A")
+ *
+ * @example
+ * getShortcutDisplayLabel(' ')           // 'Space'
+ * getShortcutDisplayLabel('control+a')   // 'Ctrl+A'
+ * getShortcutDisplayLabel(null)          // ''
+ */
+export function getShortcutDisplayLabel(shortcut: string | null): string {
+	if (!shortcut) return '';
+
+	return shortcut
+		.split('+')
+		.map((key) => formatKeyForDisplay(key.toLowerCase()))
+		.join('+');
+}
+
+/**
+ * Internal helper: formats a single key for display.
+ */
+function formatKeyForDisplay(key: string): string {
+	const label = BROWSER_KEY_DISPLAY_LABELS[key as KeyboardEventSupportedKey];
+	if (label) return label;
+
+	// Single letters: uppercase
+	if (key.length === 1 && key >= 'a' && key <= 'z') {
+		return key.toUpperCase();
+	}
+
+	// Function keys: uppercase (f1 -> F1)
+	if (/^f\d{1,2}$/.test(key)) {
+		return key.toUpperCase();
+	}
+
+	// Fallback for unknown multi-char keys: capitalize first letter
+	if (key.length > 1) {
+		return key.charAt(0).toUpperCase() + key.slice(1);
+	}
+
+	// Single char non-letters (numbers, punctuation): return as-is
+	return key;
+}

--- a/apps/whispering/src/lib/constants/keyboard/index.ts
+++ b/apps/whispering/src/lib/constants/keyboard/index.ts
@@ -23,3 +23,5 @@ export {
 } from './macos-option-key-map';
 
 export { CommandOrAlt, CommandOrControl } from './modifiers';
+
+export { getShortcutDisplayLabel } from './display-labels';

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/KeyboardShortcutRecorder.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/KeyboardShortcutRecorder.svelte
@@ -4,7 +4,10 @@
 	import { Button } from '@epicenter/ui/button';
 	import { Input } from '@epicenter/ui/input';
 	import * as Popover from '@epicenter/ui/popover';
-	import type { KeyboardEventSupportedKey } from '$lib/constants/keyboard';
+	import {
+		getShortcutDisplayLabel,
+		type KeyboardEventSupportedKey,
+	} from '$lib/constants/keyboard';
 	import { IS_MACOS } from '$lib/constants/platform';
 	import { cn } from '@epicenter/ui/utils';
 	import AlertTriangle from '@lucide/svelte/icons/alert-triangle';
@@ -39,7 +42,7 @@
 <div class="flex items-center justify-end gap-2">
 	{#if rawKeyCombination}
 		<Badge variant="secondary" class="font-mono text-xs">
-			{rawKeyCombination}
+			{getShortcutDisplayLabel(rawKeyCombination)}
 		</Badge>
 		<Button
 			variant="ghost"
@@ -135,7 +138,7 @@
 							>
 								{#if rawKeyCombination && !keyRecorder.isListening}
 									<Badge variant="secondary" class="font-mono text-xs">
-										{rawKeyCombination ?? ''}
+										{getShortcutDisplayLabel(rawKeyCombination)}
 									</Badge>
 								{:else if !keyRecorder.isListening}
 									<span class="truncate text-muted-foreground"

--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -17,6 +17,7 @@
 		type RecordingMode,
 		VAD_STATE_TO_ICON,
 	} from '$lib/constants/audio';
+	import { getShortcutDisplayLabel } from '$lib/constants/keyboard';
 	import { rpc } from '$lib/query';
 	import * as services from '$lib/services';
 	import type { Recording } from '$lib/services/db';
@@ -372,7 +373,7 @@
 					<kbd
 						class="bg-muted relative rounded px-[0.3rem] py-[0.15rem] font-mono text-sm font-semibold"
 					>
-						{settings.value['shortcuts.local.toggleManualRecording']}
+						{getShortcutDisplayLabel(settings.value['shortcuts.local.toggleManualRecording'])}
 					</kbd>
 				</WhisperingButton>{' '}
 				to start recording here.


### PR DESCRIPTION
Local shortcuts store keys as raw KeyboardEvent.key values. When Space is the shortcut, it's stored as `' '` (a literal space character), which renders as invisible whitespace in `<kbd>` elements. The UI showed "Click the microphone or press [ ] to start recording" with an empty box where Space should be.

This adds a `getShortcutDisplayLabel` function that transforms raw key values into human-readable labels. The function handles ~50 special keys with explicit mappings (Space, Enter, modifiers, arrows, media keys, etc.) and applies sensible fallbacks for letters (uppercase) and function keys (F1-F24).

| Input | Output |
|-------|--------|
| `' '` | `Space` |
| `'control+shift+ '` | `Ctrl+Shift+Space` |
| `'a'` | `A` |
| `'arrowleft'` | `←` |
| `'backspace'` | `⌫` |
| `'f12'` | `F12` |

The implementation follows the existing pattern from `macos-option-key-map.ts`: a private lookup map with a public utility function. Only `getShortcutDisplayLabel` is exported; the internal map and helper function remain private.