### PR TITLE
fix(vad): reset state to LISTENING on misfire

### DIFF
--- a/apps/whispering/src/lib/services/vad-recorder.ts
+++ b/apps/whispering/src/lib/services/vad-recorder.ts
@@ -82,6 +82,7 @@ export function createVadService() {
 							onSpeechEnd(blob);
 						},
 						onVADMisfire: () => {
+							vadState = 'LISTENING';
 							onVADMisfire();
 						},
 						onSpeechRealStart: () => {


### PR DESCRIPTION
When the VAD library detects a false positive (misfire), the `onVADMisfire` callback is called but `vadState` was never reset back to `'LISTENING'`. This caused the ear emoji (👂) to persist indefinitely after brief background noises or sounds that triggered `onSpeechStart` but then misfired.

The fix adds a single line to reset `vadState = 'LISTENING'` in the `onVADMisfire` callback, mirroring the behavior in `onSpeechEnd`.