### PR TITLE
fix(sidebar): default to collapsed state

### DIFF
--- a/apps/whispering/src/routes/(app)/+layout.svelte
+++ b/apps/whispering/src/routes/(app)/+layout.svelte
@@ -11,6 +11,7 @@
 
 	let { children } = $props();
 
+	let sidebarOpen = $state(false);
 	let unlistenNavigate: UnlistenFn | null = null;
 
 	$effect(() => {
@@ -38,7 +39,7 @@
 	});
 </script>
 
-<Sidebar.Provider>
+<Sidebar.Provider bind:open={sidebarOpen}>
 	{#if settings.value['ui.layoutMode'] === 'sidebar'}
 		<VerticalNav />
 	{/if}


### PR DESCRIPTION
The sidebar now starts in the collapsed state instead of expanded. This uses a state variable with `bind:open` to ensure proper two-way binding so users can still toggle the sidebar open and closed.