### PR TITLE
fix(ui): improve topbar and sidebar layout behavior

### DIFF
--- a/apps/whispering/src/lib/components/NotificationLog.svelte
+++ b/apps/whispering/src/lib/components/NotificationLog.svelte
@@ -26,7 +26,7 @@
 
 <script lang="ts">
 	import * as Alert from '@epicenter/ui/alert';
-	import * as Popover from '@epicenter/ui/popover';
+	import * as Dialog from '@epicenter/ui/dialog';
 	import type { UnifiedNotificationOptions } from '$lib/services/notifications/types';
 	import { ScrollArea } from '@epicenter/ui/scroll-area';
 	import AlertCircle from '@lucide/svelte/icons/alert-circle';
@@ -34,42 +34,18 @@
 	import CheckCircle2 from '@lucide/svelte/icons/check-circle-2';
 	import Info from '@lucide/svelte/icons/info';
 	import Loader from '@lucide/svelte/icons/loader';
-	import LogsIcon from '@lucide/svelte/icons/file-text';
 	import { mode } from 'mode-watcher';
-	import WhisperingButton from './WhisperingButton.svelte';
-	import { cn } from '@epicenter/ui/utils';
 </script>
 
-<Popover.Root bind:open={notificationLog.isOpen}>
-	<Popover.Trigger>
-		{#snippet child({ props })}
-			{@const { class: propsClass, ...restProps } = props}
-			<WhisperingButton
-				tooltipContent="Notification History"
-				class={cn(
-					'fixed bottom-4 right-4 z-50 hidden xs:inline-flex',
-					propsClass,
-				)}
-				variant="outline"
-				size="icon"
-				{...restProps}
-			>
-				<LogsIcon class="size-4" />
-			</WhisperingButton>
-		{/snippet}
-	</Popover.Trigger>
-	<Popover.Content
-		class={cn(
-			'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-[90vw] max-w-md p-4',
-		)}
-	>
-		<div class="flex flex-col space-y-1.5">
-			<h1 class="text-lg font-semibold">Notification History</h1>
-			<h2 class="text-sm text-muted-foreground">View past notifications</h2>
-		</div>
+<Dialog.Root bind:open={notificationLog.isOpen}>
+	<Dialog.Content class="max-w-md">
+		<Dialog.Header>
+			<Dialog.Title>Notification History</Dialog.Title>
+			<Dialog.Description>View past notifications</Dialog.Description>
+		</Dialog.Header>
 
 		<ScrollArea
-			class="mt-4 h-[60vh] overflow-y-auto rounded-md border bg-background p-4"
+			class="h-[60vh] overflow-y-auto rounded-md border bg-background p-4"
 			data-sonner-toaster
 			data-theme={mode.current}
 			data-rich-colors="true"
@@ -124,11 +100,11 @@
 				</div>
 			{/if}
 		</ScrollArea>
-	</Popover.Content>
-</Popover.Root>
+	</Dialog.Content>
+</Dialog.Root>
 
 <style>
-	:global([data-slot='popover-content'] [data-sonner-toast]) {
+	:global([data-slot='dialog-content'] [data-sonner-toast]) {
 		position: relative;
 	}
 </style>

--- a/apps/whispering/src/routes/(app)/(config)/+layout.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/+layout.svelte
@@ -33,7 +33,7 @@
 
 <header
 	class={cn(
-		'border-border/40 bg-background/95 supports-backdrop-filter:bg-background/60 sticky top-0 z-50 border-b shadow-xs backdrop-blur-sm ',
+		'border-border/40 bg-background/95 supports-backdrop-filter:bg-background/60 z-30 border-b shadow-xs backdrop-blur-sm',
 		'flex h-14 w-full items-center justify-between px-4 sm:px-8',
 	)}
 	style="view-transition-name: header"
@@ -157,4 +157,6 @@
 	</div>
 </header>
 
-{@render children()}
+<div class="flex-1 overflow-x-auto">
+	{@render children()}
+</div>

--- a/apps/whispering/src/routes/(app)/+layout.svelte
+++ b/apps/whispering/src/routes/(app)/+layout.svelte
@@ -42,9 +42,9 @@
 	{#if settings.value['ui.layoutMode'] === 'sidebar'}
 		<VerticalNav />
 	{/if}
-	<main class="flex flex-1 flex-col">
+	<Sidebar.Inset>
 		<AppLayout>
 			{@render children()}
 		</AppLayout>
-	</main>
+	</Sidebar.Inset>
 </Sidebar.Provider>

--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -179,7 +179,7 @@
 	<title>Whispering</title>
 </svelte:head>
 
-<div class="flex flex-1 flex-col items-center justify-center gap-4 w-full max-w-md px-4">
+<div class="flex flex-1 flex-col items-center justify-center gap-4 w-full max-w-md mx-auto px-4">
 	<div class="xs:flex hidden flex-col items-center gap-4">
 		<h1 class="scroll-m-20 text-4xl font-bold tracking-tight lg:text-5xl">
 			Whispering

--- a/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
+++ b/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
@@ -107,7 +107,7 @@
 	</span>
 </button>
 
-<div class="hidden flex-1 flex-col items-center gap-2 xxs:flex min-w-0 w-full">
+<div class="hidden flex-1 flex-col gap-2 xxs:flex min-w-0 w-full">
 	{@render children()}
 </div>
 

--- a/apps/whispering/src/routes/+layout.svelte
+++ b/apps/whispering/src/routes/+layout.svelte
@@ -52,7 +52,7 @@
 	{...TOASTER_SETTINGS}
 />
 <ModeWatcher />
-<SvelteQueryDevtools client={queryClient} buttonPosition="bottom-left" />
+<SvelteQueryDevtools client={queryClient} buttonPosition="bottom-right" />
 
 <style>
 	/* Override inspector button to bottom-center positioning */

--- a/packages/ui/src/sidebar/sidebar-inset.svelte
+++ b/packages/ui/src/sidebar/sidebar-inset.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="sidebar-inset"
 	class={cn(
-		"bg-background relative flex w-full flex-1 flex-col",
+		"bg-background relative flex min-w-0 flex-1 flex-col",
 		"md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ms-0 md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ms-2 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm",
 		className
 	)}


### PR DESCRIPTION
This PR fixes several UI issues with the topbar and sidebar layout that were causing modal overlays to appear incorrectly and content width to not adjust properly when the sidebar expands/collapses (thank you @Leftium for your help identifying them!)

The topbar previously had `z-50` which placed it above modal overlays (z-40), causing visual layering issues. It now uses `z-30` so dialogs and drawers properly dim and cover the entire screen including the topbar. The header is also no longer sticky, which was unnecessary given the layout structure.

The NotificationLog component was converted from a Popover with a floating trigger button to a Dialog without a trigger. This removes the redundant floating button since the sidebar already has a "Notifications" entry that opens the dialog. The TanStack devtools button was also moved from bottom-left to bottom-right to avoid collision with other UI elements.

The main content area width issue was fixed by changing `w-full` to `min-w-0` in the Sidebar.Inset component. In a flex container, `w-full` (width: 100%) overrides flex behavior and makes the element 100% of the parent width regardless of siblings. With `min-w-0`, the element can shrink properly to fill remaining space after the sidebar gap element. The home page now uses `mx-auto` for horizontal centering within the content area.