### PR TITLE
refactor: simplify home page HTML structure

### DIFF
--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -179,7 +179,9 @@
 	<title>Whispering</title>
 </svelte:head>
 
-<div class="flex flex-1 flex-col items-center justify-center gap-4 w-full max-w-md mx-auto px-4">
+<div
+	class="flex flex-1 flex-col items-center justify-center gap-4 w-full max-w-md mx-auto px-4"
+>
 	<div class="xs:flex hidden flex-col items-center gap-4">
 		<h1 class="scroll-m-20 text-4xl font-bold tracking-tight lg:text-5xl">
 			Whispering
@@ -190,224 +192,219 @@
 	</div>
 
 	<ToggleGroup.Root
-			type="single"
-			bind:value={
-				() => settings.value['recording.mode'],
-				(mode) => {
-					if (!mode) return;
-					settings.switchRecordingMode(mode);
-				}
+		type="single"
+		bind:value={
+			() => settings.value['recording.mode'],
+			(mode) => {
+				if (!mode) return;
+				settings.switchRecordingMode(mode);
 			}
-			class="w-full"
-		>
-			{#each availableModes as option}
-				<ToggleGroup.Item
-					value={option.value}
-					aria-label={`Switch to ${option.label.toLowerCase()} mode`}
-				>
-					{option.icon}
-					{option.label}
-				</ToggleGroup.Item>
-			{/each}
-		</ToggleGroup.Root>
+		}
+		class="w-full"
+	>
+		{#each availableModes as option}
+			<ToggleGroup.Item
+				value={option.value}
+				aria-label={`Switch to ${option.label.toLowerCase()} mode`}
+			>
+				{option.icon}
+				{option.label}
+			</ToggleGroup.Item>
+		{/each}
+	</ToggleGroup.Root>
 
-		<div class="w-full flex justify-center pt-1">
-			{#if settings.value['recording.mode'] === 'manual'}
-				<!-- Container with relative positioning for the button and absolute selectors -->
-				<div class="relative">
-					<!-- Recording button -->
+	{#if settings.value['recording.mode'] === 'manual'}
+		<!-- Container with relative positioning for the button and absolute selectors -->
+		<div class="relative">
+			<WhisperingButton
+				tooltipContent={getRecorderStateQuery.data === 'IDLE'
+					? 'Start recording'
+					: 'Stop recording'}
+				onclick={commandCallbacks.toggleManualRecording}
+				variant="ghost"
+				class="shrink-0 size-32 sm:size-36 lg:size-40 xl:size-44 transform items-center justify-center overflow-hidden duration-300 ease-in-out"
+			>
+				<span
+					style="filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.5)); view-transition-name: microphone-icon;"
+					class="text-[100px] sm:text-[110px] lg:text-[120px] xl:text-[130px] leading-none"
+				>
+					{RECORDER_STATE_TO_ICON[getRecorderStateQuery.data ?? 'IDLE']}
+				</span>
+			</WhisperingButton>
+			{#if getRecorderStateQuery.data === 'RECORDING'}
+				<div class="absolute -right-12 bottom-4 flex items-center">
 					<WhisperingButton
-						tooltipContent={getRecorderStateQuery.data === 'IDLE'
-							? 'Start recording'
-							: 'Stop recording'}
-						onclick={commandCallbacks.toggleManualRecording}
+						tooltipContent="Cancel recording"
+						onclick={commandCallbacks.cancelManualRecording}
 						variant="ghost"
-						class="shrink-0 size-32 sm:size-36 lg:size-40 xl:size-44 transform items-center justify-center overflow-hidden duration-300 ease-in-out"
+						size="icon"
+						style="view-transition-name: cancel-icon;"
 					>
-						<span
-							style="filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.5)); view-transition-name: microphone-icon;"
-							class="text-[100px] sm:text-[110px] lg:text-[120px] xl:text-[130px] leading-none"
-						>
-							{RECORDER_STATE_TO_ICON[getRecorderStateQuery.data ?? 'IDLE']}
-						</span>
+						🚫
 					</WhisperingButton>
-					<!-- Absolutely positioned selectors -->
-					{#if getRecorderStateQuery.data === 'RECORDING'}
-						<div class="absolute -right-12 bottom-4 flex items-center">
-							<WhisperingButton
-								tooltipContent="Cancel recording"
-								onclick={commandCallbacks.cancelManualRecording}
-								variant="ghost"
-								size="icon"
-								style="view-transition-name: cancel-icon;"
-							>
-								🚫
-							</WhisperingButton>
-						</div>
-					{:else}
-						<div class="absolute -right-32 bottom-4 flex items-center gap-0.5">
-							<ManualDeviceSelector />
-							<CompressionSelector />
-							<TranscriptionSelector />
-							<TransformationSelector />
-						</div>
-					{/if}
 				</div>
-			{:else if settings.value['recording.mode'] === 'vad'}
-				<!-- Container with relative positioning for the button and absolute selectors -->
-				<div class="relative">
-					<!-- Recording button -->
-					<WhisperingButton
-						tooltipContent={vadRecorder.state === 'IDLE'
-							? 'Start voice activated session'
-							: 'Stop voice activated session'}
-						onclick={commandCallbacks.toggleVadRecording}
-						variant="ghost"
-						class="shrink-0 size-32 sm:size-36 lg:size-40 xl:size-44 transform items-center justify-center overflow-hidden duration-300 ease-in-out"
-					>
-						<span
-							style="filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.5)); view-transition-name: microphone-icon;"
-							class="text-[100px] sm:text-[110px] lg:text-[120px] xl:text-[130px] leading-none"
-						>
-							{VAD_STATE_TO_ICON[vadRecorder.state]}
-						</span>
-					</WhisperingButton>
-					<!-- Absolutely positioned selectors -->
-					{#if vadRecorder.state === 'IDLE'}
-						<div class="absolute -right-32 bottom-4 flex items-center gap-0.5">
-							<VadDeviceSelector />
-							<CompressionSelector />
-							<TranscriptionSelector />
-							<TransformationSelector />
-						</div>
-					{/if}
-				</div>
-			{:else if settings.value['recording.mode'] === 'upload'}
-				<!-- Full width spanning all columns -->
-				<div class="flex flex-col items-center gap-4 w-full">
-					<FileDropZone
-						accept="{ACCEPT_AUDIO}, {ACCEPT_VIDEO}"
-						maxFiles={10}
-						maxFileSize={25 * MEGABYTE}
-						onUpload={(files) => {
-							if (files.length > 0) {
-								rpc.commands.uploadRecordings.execute({ files });
-							}
-						}}
-						onFileRejected={({ file, reason }) => {
-							rpc.notify.error.execute({
-								title: '❌ File rejected',
-								description: `${file.name}: ${reason}`,
-							});
-						}}
-						class="h-32 sm:h-36 lg:h-40 xl:h-44 w-full"
-					/>
-					<div class="flex items-center gap-1.5">
-						<CompressionSelector />
-						<TranscriptionSelector />
-						<TransformationSelector />
-					</div>
+			{:else}
+				<div class="absolute -right-32 bottom-4 flex items-center gap-0.5">
+					<ManualDeviceSelector />
+					<CompressionSelector />
+					<TranscriptionSelector />
+					<TransformationSelector />
 				</div>
 			{/if}
 		</div>
-
-		<div class="xxs:flex hidden w-full flex-col items-center gap-2">
-			<div class="flex w-full items-center gap-2">
-				<div class="flex-1">
-					<TranscriptDialog
-						recordingId={latestRecording.id}
-						transcribedText={latestRecording.transcriptionStatus ===
-						'TRANSCRIBING'
-							? '...'
-							: latestRecording.transcribedText}
-						rows={1}
-						disabled={latestRecording.transcriptionStatus === 'TRANSCRIBING' ||
-							hasNoTranscribedText}
-					/>
+	{:else if settings.value['recording.mode'] === 'vad'}
+		<!-- Container with relative positioning for the button and absolute selectors -->
+		<div class="relative">
+			<WhisperingButton
+				tooltipContent={vadRecorder.state === 'IDLE'
+					? 'Start voice activated session'
+					: 'Stop voice activated session'}
+				onclick={commandCallbacks.toggleVadRecording}
+				variant="ghost"
+				class="shrink-0 size-32 sm:size-36 lg:size-40 xl:size-44 transform items-center justify-center overflow-hidden duration-300 ease-in-out"
+			>
+				<span
+					style="filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.5)); view-transition-name: microphone-icon;"
+					class="text-[100px] sm:text-[110px] lg:text-[120px] xl:text-[130px] leading-none"
+				>
+					{VAD_STATE_TO_ICON[vadRecorder.state]}
+				</span>
+			</WhisperingButton>
+			{#if vadRecorder.state === 'IDLE'}
+				<div class="absolute -right-32 bottom-4 flex items-center gap-0.5">
+					<VadDeviceSelector />
+					<CompressionSelector />
+					<TranscriptionSelector />
+					<TransformationSelector />
 				</div>
-				<CopyToClipboardButton
-					contentDescription="transcript"
-					textToCopy={latestRecording.transcribedText}
-					viewTransitionName={getRecordingTransitionId({
-						recordingId: latestRecording.id,
-						propertyName: 'transcribedText',
-					})}
-					size="default"
-					variant="secondary"
+			{/if}
+		</div>
+	{:else if settings.value['recording.mode'] === 'upload'}
+		<div class="flex flex-col items-center gap-4 w-full">
+			<FileDropZone
+				accept="{ACCEPT_AUDIO}, {ACCEPT_VIDEO}"
+				maxFiles={10}
+				maxFileSize={25 * MEGABYTE}
+				onUpload={(files) => {
+					if (files.length > 0) {
+						rpc.commands.uploadRecordings.execute({ files });
+					}
+				}}
+				onFileRejected={({ file, reason }) => {
+					rpc.notify.error.execute({
+						title: '❌ File rejected',
+						description: `${file.name}: ${reason}`,
+					});
+				}}
+				class="h-32 sm:h-36 lg:h-40 xl:h-44 w-full"
+			/>
+			<div class="flex items-center gap-1.5">
+				<CompressionSelector />
+				<TranscriptionSelector />
+				<TransformationSelector />
+			</div>
+		</div>
+	{/if}
+
+	<div class="xxs:flex hidden w-full flex-col gap-2">
+		<div class="flex w-full items-center gap-2">
+			<div class="flex-1">
+				<TranscriptDialog
+					recordingId={latestRecording.id}
+					transcribedText={latestRecording.transcriptionStatus ===
+					'TRANSCRIBING'
+						? '...'
+						: latestRecording.transcribedText}
+					rows={1}
 					disabled={latestRecording.transcriptionStatus === 'TRANSCRIBING' ||
 						hasNoTranscribedText}
-				>
-					{#if latestRecording.transcriptionStatus === 'TRANSCRIBING'}
-						<Loader2Icon class="size-6 animate-spin" />
-					{:else}
-						<ClipboardIcon class="size-6" />
-					{/if}
-				</CopyToClipboardButton>
+				/>
 			</div>
-
-			{#if blobUrl}
-				<audio
-					style="view-transition-name: {getRecordingTransitionId({
-						recordingId: latestRecording.id,
-						propertyName: 'blob',
-					})}"
-					src={blobUrl}
-					controls
-					class="h-8 w-full"
-				></audio>
-			{/if}
+			<CopyToClipboardButton
+				contentDescription="transcript"
+				textToCopy={latestRecording.transcribedText}
+				viewTransitionName={getRecordingTransitionId({
+					recordingId: latestRecording.id,
+					propertyName: 'transcribedText',
+				})}
+				size="default"
+				variant="secondary"
+				disabled={latestRecording.transcriptionStatus === 'TRANSCRIBING' ||
+					hasNoTranscribedText}
+			>
+				{#if latestRecording.transcriptionStatus === 'TRANSCRIBING'}
+					<Loader2Icon class="size-6 animate-spin" />
+				{:else}
+					<ClipboardIcon class="size-6" />
+				{/if}
+			</CopyToClipboardButton>
 		</div>
 
-		{#if settings.value['ui.layoutMode'] === 'nav-items'}
-			<NavItems class="xs:flex -mb-2.5 -mt-1 hidden" />
+		{#if blobUrl}
+			<audio
+				style="view-transition-name: {getRecordingTransitionId({
+					recordingId: latestRecording.id,
+					propertyName: 'blob',
+				})}"
+				src={blobUrl}
+				controls
+				class="h-8 w-full"
+			></audio>
 		{/if}
+	</div>
 
-		<div class="xs:flex hidden flex-col items-center gap-3">
-			<p class="text-foreground/75 text-center text-sm">
-				Click the microphone or press
+	{#if settings.value['ui.layoutMode'] === 'nav-items'}
+		<NavItems class="xs:flex -mb-2.5 -mt-1 hidden" />
+	{/if}
+
+	<div class="xs:flex hidden flex-col items-center gap-3">
+		<p class="text-foreground/75 text-center text-sm">
+			Click the microphone or press
+			{' '}<WhisperingButton
+				tooltipContent="Go to local shortcut in settings"
+				href="/settings/shortcuts/local"
+				variant="link"
+			>
+				<kbd
+					class="bg-muted relative rounded px-[0.3rem] py-[0.15rem] font-mono text-sm font-semibold"
+				>
+					{getShortcutDisplayLabel(
+						settings.value['shortcuts.local.toggleManualRecording'],
+					)}
+				</kbd>
+			</WhisperingButton>{' '}
+			to start recording here.
+		</p>
+		{#if window.__TAURI_INTERNALS__}
+			<p class="text-foreground/75 text-sm">
+				Press
 				{' '}<WhisperingButton
-					tooltipContent="Go to local shortcut in settings"
-					href="/settings/shortcuts/local"
+					tooltipContent="Go to global shortcut in settings"
+					href="/settings/shortcuts/global"
 					variant="link"
 				>
 					<kbd
 						class="bg-muted relative rounded px-[0.3rem] py-[0.15rem] font-mono text-sm font-semibold"
 					>
-						{getShortcutDisplayLabel(settings.value['shortcuts.local.toggleManualRecording'])}
+						{settings.value['shortcuts.global.toggleManualRecording']}
 					</kbd>
 				</WhisperingButton>{' '}
-				to start recording here.
+				to start recording anywhere.
 			</p>
-			{#if window.__TAURI_INTERNALS__}
-				<p class="text-foreground/75 text-sm">
-					Press
-					{' '}<WhisperingButton
-						tooltipContent="Go to global shortcut in settings"
-						href="/settings/shortcuts/global"
-						variant="link"
-					>
-						<kbd
-							class="bg-muted relative rounded px-[0.3rem] py-[0.15rem] font-mono text-sm font-semibold"
-						>
-							{settings.value['shortcuts.global.toggleManualRecording']}
-						</kbd>
-					</WhisperingButton>{' '}
-					to start recording anywhere.
-				</p>
+		{/if}
+		<p class="text-muted-foreground text-center text-sm font-light">
+			{#if !window.__TAURI_INTERNALS__}
+				Tired of switching tabs?
+				<WhisperingButton
+					tooltipContent="Get Whispering for desktop"
+					href="https://epicenter.so/whispering"
+					target="_blank"
+					rel="noopener noreferrer"
+					variant="link"
+				>
+					Get the native desktop app
+				</WhisperingButton>
 			{/if}
-			<p class="text-muted-foreground text-center text-sm font-light">
-				{#if !window.__TAURI_INTERNALS__}
-					Tired of switching tabs?
-					<WhisperingButton
-						tooltipContent="Get Whispering for desktop"
-						href="https://epicenter.so/whispering"
-						target="_blank"
-						rel="noopener noreferrer"
-						variant="link"
-					>
-						Get the native desktop app
-					</WhisperingButton>
-				{/if}
-			</p>
-		</div>
+		</p>
+	</div>
 </div>


### PR DESCRIPTION
This removes unnecessary wrapper elements and fixes inconsistent indentation in the home page component.

The main simplification is removing `<div class="w-full flex justify-center pt-1">` which wrapped the recording mode sections. This wrapper was redundant because the parent already has `items-center` for horizontal centering in a flex-col layout. The `pt-1` padding was negligible compared to the existing `gap-4` spacing between siblings.

Also removed `items-center` from the transcript section wrapper since both children have `w-full`, making the centering have no visible effect. Fixed inconsistent indentation throughout the file to use consistent tab levels.