### PR TITLE
feat(examples): add YJS stress test for bulk insertion benchmarking

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -66,7 +66,7 @@
     },
     "apps/whispering": {
       "name": "@epicenter/whispering",
-      "version": "7.8.0",
+      "version": "7.9.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@aptabase/tauri": "^0.4.1",
@@ -164,6 +164,18 @@
         "@types/bun": "catalog:",
         "@types/jsdom": "^27.0.0",
         "drizzle-kit": "catalog:",
+      },
+    },
+    "examples/stress-test": {
+      "name": "@examples/stress-test",
+      "version": "0.0.1",
+      "dependencies": {
+        "@epicenter/hq": "workspace:*",
+        "arktype": "catalog:",
+        "wellcrafted": "catalog:",
+      },
+      "devDependencies": {
+        "@types/bun": "catalog:",
       },
     },
     "packages/config": {
@@ -553,6 +565,8 @@
     "@examples/basic-workspace": ["@examples/basic-workspace@workspace:examples/basic-workspace"],
 
     "@examples/content-hub": ["@examples/content-hub@workspace:examples/content-hub"],
+
+    "@examples/stress-test": ["@examples/stress-test@workspace:examples/stress-test"],
 
     "@floating-ui/core": ["@floating-ui/core@1.7.3", "", { "dependencies": { "@floating-ui/utils": "^0.2.10" } }, "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w=="],
 

--- a/examples/stress-test/README.md
+++ b/examples/stress-test/README.md
@@ -1,0 +1,67 @@
+# YJS Stress Test
+
+Stress tests YJS persistence with bulk insertions across multiple tables.
+
+## Running
+
+```bash
+cd examples/stress-test
+
+# Default (20k items per table, 200k total) - ~1-2 minutes
+bun test
+
+# Quick test (10k per table, 100k total) - ~10 seconds
+bun test 10000
+
+# Full stress test (100k per table, 1M total) - 10+ minutes, expect slowdown
+bun test 100000
+```
+
+## What This Tests
+
+1. **Bulk insertion performance** with `insertMany`
+2. **YJS document size** as data grows
+3. **Performance degradation** patterns under load
+
+## Key Observations
+
+### insertMany vs insert: ~500x Difference
+
+| Method | Speed | Why |
+|--------|-------|-----|
+| `insert()` | ~34/s | Each call = separate YJS transaction |
+| `insertMany()` | ~20,000/s | Single YJS transaction for all rows |
+
+Always use `insertMany({ rows: [...] })` for bulk operations. It uses `$transact` internally to batch all changes into one YJS update.
+
+### Performance Degradation at Scale
+
+YJS document size affects write performance. From a 1M item test:
+
+| Items in Doc | Speed | File Size |
+|--------------|-------|-----------|
+| 100k | 7.4k/s | ~10 MB |
+| 200k | 3.0k/s | ~20 MB |
+| 300k | 1.5k/s | ~30 MB |
+| 400k | 1.1k/s | ~40 MB |
+| 500k+ | <700/s | 50+ MB |
+
+The slowdown is expected - larger YJS documents mean more work per transaction.
+
+### Recommended Limits
+
+- **< 100k items per workspace**: Fast, no noticeable degradation
+- **100k-300k items**: Acceptable with some slowdown
+- **300k+ items**: Consider splitting into multiple workspaces
+
+For very large datasets, use separate workspaces to keep each YJS document smaller.
+
+## Output
+
+The test reports:
+- Per-table insertion time and rate
+- Total time and average rate
+- Final `.yjs` file size
+- Bytes per item (storage efficiency)
+
+Files are saved to `.epicenter/stress.yjs`.

--- a/examples/stress-test/epicenter.config.ts
+++ b/examples/stress-test/epicenter.config.ts
@@ -1,0 +1,97 @@
+import {
+	defineEpicenter,
+	defineWorkspace,
+	id,
+	integer,
+	sqliteIndex,
+	text,
+} from '@epicenter/hq';
+import { setupPersistence } from '@epicenter/hq/providers';
+
+/**
+ * Stress test workspace
+ *
+ * 10 identical tables for stress testing YJS persistence with 1 million items.
+ */
+const stressWorkspace = defineWorkspace({
+	id: 'stress',
+
+	schema: {
+		items_a: {
+			id: id(),
+			name: text(),
+			value: integer(),
+			created_at: text(),
+		},
+		items_b: {
+			id: id(),
+			name: text(),
+			value: integer(),
+			created_at: text(),
+		},
+		items_c: {
+			id: id(),
+			name: text(),
+			value: integer(),
+			created_at: text(),
+		},
+		items_d: {
+			id: id(),
+			name: text(),
+			value: integer(),
+			created_at: text(),
+		},
+		items_e: {
+			id: id(),
+			name: text(),
+			value: integer(),
+			created_at: text(),
+		},
+		items_f: {
+			id: id(),
+			name: text(),
+			value: integer(),
+			created_at: text(),
+		},
+		items_g: {
+			id: id(),
+			name: text(),
+			value: integer(),
+			created_at: text(),
+		},
+		items_h: {
+			id: id(),
+			name: text(),
+			value: integer(),
+			created_at: text(),
+		},
+		items_i: {
+			id: id(),
+			name: text(),
+			value: integer(),
+			created_at: text(),
+		},
+		items_j: {
+			id: id(),
+			name: text(),
+			value: integer(),
+			created_at: text(),
+		},
+	},
+
+	indexes: {
+		sqlite: (c) => sqliteIndex(c),
+	},
+
+	providers: [setupPersistence],
+
+	exports: ({ db }) => ({
+		// Expose raw table access for bulk inserts
+		...db,
+	}),
+});
+
+export default defineEpicenter({
+	id: 'stress-test',
+	workspaces: [stressWorkspace],
+});

--- a/examples/stress-test/package.json
+++ b/examples/stress-test/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "@examples/stress-test",
+	"version": "0.0.1",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"test": "bun stress-test.ts"
+	},
+	"dependencies": {
+		"@epicenter/hq": "workspace:*",
+		"arktype": "catalog:",
+		"wellcrafted": "catalog:"
+	},
+	"devDependencies": {
+		"@types/bun": "catalog:"
+	}
+}

--- a/examples/stress-test/stress-test.ts
+++ b/examples/stress-test/stress-test.ts
@@ -1,0 +1,173 @@
+/**
+ * YJS Stress Test
+ *
+ * Tests bulk insertion performance and YJS file size with large datasets.
+ *
+ * ## Performance Note: insertMany vs insert
+ *
+ * This test uses `insertMany` which is ~500x faster than individual `insert` calls:
+ *
+ * - `insert()`: ~34 items/second (each insert triggers a separate YJS transaction)
+ * - `insertMany()`: ~20,000 items/second (batches all inserts into a single YJS transaction)
+ *
+ * The key difference is that `insertMany` uses `$transact` internally, which wraps
+ * all operations in a single YJS transaction. This dramatically reduces overhead from:
+ * 1. YJS document updates (one update vs N updates)
+ * 2. Observer notifications (one notification vs N notifications)
+ * 3. Persistence writes (one write vs potentially N writes)
+ *
+ * When doing bulk operations, always prefer:
+ * - `insertMany({ rows: [...] })` over multiple `insert()` calls
+ * - `updateMany({ rows: [...] })` over multiple `update()` calls
+ * - `$transact(() => { ... })` to batch arbitrary operations
+ *
+ * @example
+ * ```bash
+ * # Run with default 20k items per table (200k total) - recommended
+ * bun test
+ *
+ * # Quick test (10k per table = 100k total)
+ * bun test 10000
+ *
+ * # Full stress test (100k per table = 1M total) - expect slowdown
+ * bun test 100000
+ * ```
+ */
+
+import { existsSync, statSync } from 'node:fs';
+import { createEpicenterClient, generateId } from '@epicenter/hq';
+import epicenterConfig from './epicenter.config';
+
+// Configuration - can override via CLI args
+const ITEMS_PER_TABLE = Number(process.argv[2]) || 20_000; // Default 20k for balanced stress test
+const BATCH_SIZE = 1_000; // Insert in batches of 1k using insertMany
+
+const TABLES = [
+	'items_a',
+	'items_b',
+	'items_c',
+	'items_d',
+	'items_e',
+	'items_f',
+	'items_g',
+	'items_h',
+	'items_i',
+	'items_j',
+] as const;
+
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(2)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function formatTime(ms: number): string {
+	if (ms < 1000) return `${ms.toFixed(0)}ms`;
+	return `${(ms / 1000).toFixed(2)}s`;
+}
+
+function formatRate(count: number, ms: number): string {
+	const rate = (count / ms) * 1000;
+	if (rate >= 1000) return `${(rate / 1000).toFixed(1)}k/s`;
+	return `${rate.toFixed(0)}/s`;
+}
+
+console.log('='.repeat(60));
+console.log('YJS Stress Test (using insertMany for bulk inserts)');
+console.log('='.repeat(60));
+console.log(`Items per table: ${ITEMS_PER_TABLE.toLocaleString()}`);
+console.log(`Batch size: ${BATCH_SIZE.toLocaleString()}`);
+console.log(`Total tables: ${TABLES.length}`);
+console.log(`Total items: ${(ITEMS_PER_TABLE * TABLES.length).toLocaleString()}`);
+console.log('='.repeat(60));
+console.log('');
+
+const totalStart = performance.now();
+
+console.log('Creating client...');
+await using client = await createEpicenterClient(epicenterConfig);
+console.log('Client created\n');
+
+const stress = client.stress;
+
+let grandTotal = 0;
+
+for (let tableIndex = 0; tableIndex < TABLES.length; tableIndex++) {
+	const table = TABLES[tableIndex];
+	const tableStart = performance.now();
+
+	process.stdout.write(
+		`[${tableIndex + 1}/${TABLES.length}] ${table}: 0/${ITEMS_PER_TABLE.toLocaleString()}`,
+	);
+
+	const now = new Date().toISOString();
+	const tableDb = stress[table];
+
+	let inserted = 0;
+	while (inserted < ITEMS_PER_TABLE) {
+		const batchStart = performance.now();
+		const batchCount = Math.min(BATCH_SIZE, ITEMS_PER_TABLE - inserted);
+
+		// Generate batch of items
+		const items = [];
+		for (let i = 0; i < batchCount; i++) {
+			items.push({
+				id: generateId(),
+				name: `Item ${inserted + i}`,
+				value: inserted + i,
+				created_at: now,
+			});
+		}
+
+		// Bulk insert
+		tableDb.insertMany({ rows: items });
+		inserted += batchCount;
+
+		const batchElapsed = performance.now() - batchStart;
+		const totalElapsed = performance.now() - tableStart;
+		const rate = formatRate(batchCount, batchElapsed);
+
+		process.stdout.clearLine(0);
+		process.stdout.cursorTo(0);
+		process.stdout.write(
+			`[${tableIndex + 1}/${TABLES.length}] ${table}: ${inserted.toLocaleString()}/${ITEMS_PER_TABLE.toLocaleString()} (batch: ${rate}, elapsed: ${formatTime(totalElapsed)})`,
+		);
+	}
+
+	const tableElapsed = performance.now() - tableStart;
+
+	process.stdout.clearLine(0);
+	process.stdout.cursorTo(0);
+
+	grandTotal += ITEMS_PER_TABLE;
+	const avgRate = formatRate(ITEMS_PER_TABLE, tableElapsed);
+	console.log(
+		`[${tableIndex + 1}/${TABLES.length}] ${table}: ${ITEMS_PER_TABLE.toLocaleString()} items in ${formatTime(tableElapsed)} (avg ${avgRate})`,
+	);
+}
+
+const totalElapsed = performance.now() - totalStart;
+console.log('');
+console.log('='.repeat(60));
+console.log(`Total: ${grandTotal.toLocaleString()} items in ${formatTime(totalElapsed)}`);
+console.log(`Average rate: ${formatRate(grandTotal, totalElapsed)}`);
+console.log('='.repeat(60));
+
+// Wait for persistence to complete
+console.log('');
+console.log('Waiting for YJS persistence (2s)...');
+await new Promise((resolve) => setTimeout(resolve, 2000));
+
+// Check YJS file size
+const yjsPath = './.epicenter/stress.yjs';
+if (existsSync(yjsPath)) {
+	const stats = statSync(yjsPath);
+	console.log(`YJS file: ${yjsPath}`);
+	console.log(`YJS file size: ${formatBytes(stats.size)}`);
+	console.log(`Bytes per item: ${(stats.size / grandTotal).toFixed(2)}`);
+} else {
+	console.log(`YJS file not found at ${yjsPath}`);
+}
+
+console.log('');
+console.log('Stress test complete!');

--- a/specs/20251205T162000-yjs-stress-test.md
+++ b/specs/20251205T162000-yjs-stress-test.md
@@ -1,0 +1,61 @@
+# YJS Stress Test Script
+
+## Goal
+
+Create a stress test script that inserts 1 million items across 10 different tables and measures the resulting `.yjs` file size.
+
+## Plan
+
+- [ ] Create new example directory `examples/stress-test/`
+- [ ] Create `package.json` with dependencies on `@epicenter/hq`, `arktype`, `wellcrafted`
+- [ ] Create `epicenter.config.ts` with a workspace defining 10 simple tables
+- [ ] Create `stress-test.ts` script that:
+  - Uses `await using client = await createEpicenterClient(config)` pattern
+  - Inserts 100,000 items into each of 10 tables (1 million total)
+  - Uses batch inserts for performance
+  - Measures and reports elapsed time
+  - Reports final `.yjs` file size
+- [ ] Test the script
+
+## Tables Design
+
+Keep tables simple to focus on the stress test. Each table will have:
+- `id` (id type)
+- `name` (text)
+- `value` (integer)
+- `created_at` (text for timestamp)
+
+Tables:
+1. `items_a`
+2. `items_b`
+3. `items_c`
+4. `items_d`
+5. `items_e`
+6. `items_f`
+7. `items_g`
+8. `items_h`
+9. `items_i`
+10. `items_j`
+
+## Expected Output
+
+```
+Starting YJS stress test...
+Inserting 100,000 items into each of 10 tables (1,000,000 total)...
+
+Table items_a: 100000 items inserted in X.XXs
+Table items_b: 100000 items inserted in X.XXs
+...
+Table items_j: 100000 items inserted in X.XXs
+
+Total time: XXXs
+Waiting for persistence...
+YJS file size: XX.XX MB
+```
+
+## Notes
+
+- The `setupPersistence` provider automatically saves to `.epicenter/{workspace-id}.yjs`
+- We only need the sqlite index for this test (no markdown index needed)
+- Use `generateId()` for row IDs
+- Insert in batches to avoid memory issues


### PR DESCRIPTION
Adds a stress test example that measures YJS persistence performance with large datasets across 10 tables.

The test revealed important performance characteristics:

- `insertMany` is ~500x faster than individual `insert` calls because it uses `$transact` internally to batch all changes into a single YJS transaction
- Performance degrades as the YJS document grows: 7.4k/s at 100k items down to <700/s at 500k+ items
- Recommended limit of ~100k items per workspace for good performance; larger datasets should be split across multiple workspaces

The example includes a README with usage instructions, performance observations, and the key insight about using `insertMany`/`$transact` for bulk operations.