### PR TITLE
feat(transformations): add file output step for saving to disk

### DIFF
--- a/apps/whispering/src/lib/components/transformations-editor/Configuration.svelte
+++ b/apps/whispering/src/lib/components/transformations-editor/Configuration.svelte
@@ -30,6 +30,7 @@
 	import type { Transformation } from '$lib/services/db';
 	import { generateDefaultTransformationStep } from '$lib/services/db';
 	import CopyIcon from '@lucide/svelte/icons/copy';
+	import FolderOpenIcon from '@lucide/svelte/icons/folder-open';
 	import PlusIcon from '@lucide/svelte/icons/plus';
 	import TrashIcon from '@lucide/svelte/icons/trash';
 	import { slide } from 'svelte/transition';
@@ -643,6 +644,140 @@
 										</Accordion.Content>
 									</Accordion.Item>
 								</Accordion.Root>
+							</div>
+						{:else if step.type === 'file_output'}
+							<div class="space-y-6">
+								{#if !window.__TAURI_INTERNALS__}
+									<Alert.Root>
+										<Alert.Title>Desktop Only</Alert.Title>
+										<Alert.Description>
+											File output is only available in the desktop app. This
+											step will be skipped in the web version.
+										</Alert.Description>
+									</Alert.Root>
+								{/if}
+
+								<Field.Field>
+									<Field.Label for="file_output.outputDirectory"
+										>Output Directory</Field.Label
+									>
+									<div class="flex items-center gap-2">
+										<Input
+											id="file_output.outputDirectory"
+											value={step['file_output.outputDirectory']}
+											oninput={(e) => {
+												transformation = {
+													...transformation,
+													steps: transformation.steps.map((s, i) =>
+														i === index
+															? {
+																	...s,
+																	'file_output.outputDirectory':
+																		e.currentTarget.value,
+																}
+															: s,
+													),
+												};
+											}}
+											placeholder="/path/to/output/folder"
+											class="flex-1"
+										/>
+										{#if window.__TAURI_INTERNALS__}
+											<WhisperingButton
+												tooltipContent="Browse for folder"
+												variant="outline"
+												size="icon"
+												onclick={async () => {
+													const { open } = await import(
+														'@tauri-apps/plugin-dialog'
+													);
+													const selected = await open({
+														directory: true,
+														multiple: false,
+														title: 'Select Output Folder',
+													});
+													if (selected) {
+														transformation = {
+															...transformation,
+															steps: transformation.steps.map((s, i) =>
+																i === index
+																	? {
+																			...s,
+																			'file_output.outputDirectory': selected,
+																		}
+																	: s,
+															),
+														};
+													}
+												}}
+											>
+												<FolderOpenIcon class="size-4" />
+											</WhisperingButton>
+										{/if}
+									</div>
+									<Field.Description>
+										The folder where output files will be saved
+									</Field.Description>
+								</Field.Field>
+
+								<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+									<Field.Field>
+										<Field.Label for="file_output.filenameTemplate"
+											>Filename Template</Field.Label
+										>
+										<Input
+											id="file_output.filenameTemplate"
+											value={step['file_output.filenameTemplate']}
+											oninput={(e) => {
+												transformation = {
+													...transformation,
+													steps: transformation.steps.map((s, i) =>
+														i === index
+															? {
+																	...s,
+																	'file_output.filenameTemplate':
+																		e.currentTarget.value,
+																}
+															: s,
+													),
+												};
+											}}
+											placeholder={`{{date}}-{{time}}-transcription`}
+										/>
+										<Field.Description>
+											Use {`{{date}}`}, {`{{time}}`}, {`{{timestamp}}`},
+											{`{{recording_title}}`}, {`{{transformation_title}}`}
+										</Field.Description>
+									</Field.Field>
+
+									<Field.Field>
+										<Field.Label for="file_output.fileExtension"
+											>File Extension</Field.Label
+										>
+										<Input
+											id="file_output.fileExtension"
+											value={step['file_output.fileExtension']}
+											oninput={(e) => {
+												transformation = {
+													...transformation,
+													steps: transformation.steps.map((s, i) =>
+														i === index
+															? {
+																	...s,
+																	'file_output.fileExtension':
+																		e.currentTarget.value,
+																}
+															: s,
+													),
+												};
+											}}
+											placeholder="md"
+										/>
+										<Field.Description>
+											Without the leading dot (e.g., txt, md)
+										</Field.Description>
+									</Field.Field>
+								</div>
 							</div>
 						{/if}
 					</Card.Content>

--- a/apps/whispering/src/lib/constants/database/transformation-types.ts
+++ b/apps/whispering/src/lib/constants/database/transformation-types.ts
@@ -5,11 +5,13 @@
 export const TRANSFORMATION_STEP_TYPES = [
 	'prompt_transform',
 	'find_replace',
+	'file_output',
 ] as const;
 
 export const TRANSFORMATION_STEP_TYPES_TO_LABEL = {
 	prompt_transform: 'Prompt Transform',
 	find_replace: 'Find Replace',
+	file_output: 'File Output',
 } as const satisfies Record<(typeof TRANSFORMATION_STEP_TYPES)[number], string>;
 
 export const TRANSFORMATION_STEP_TYPE_OPTIONS = TRANSFORMATION_STEP_TYPES.map(

--- a/apps/whispering/src/lib/query/transformer.ts
+++ b/apps/whispering/src/lib/query/transformer.ts
@@ -14,6 +14,7 @@ import type {
 	TransformationStep,
 } from '$lib/services/db';
 import { settings } from '$lib/stores/settings.svelte';
+import { sanitizeFilename } from '$lib/utils/filename';
 import { asTemplateString, interpolateTemplate } from '$lib/utils/template';
 import { defineMutation, queryClient } from './_client';
 import { dbKeys } from './db';
@@ -115,6 +116,7 @@ export const transformer = {
 					input: recording.transcribedText,
 					transformation,
 					recordingId,
+					recordingTitle: recording.title,
 				});
 
 			if (transformationRunError)
@@ -141,9 +143,14 @@ export const transformer = {
 async function handleStep({
 	input,
 	step,
+	context,
 }: {
 	input: string;
 	step: TransformationStep;
+	context?: {
+		recordingTitle?: string;
+		transformationTitle?: string;
+	};
 }): Promise<Result<string, string>> {
 	switch (step.type) {
 		case 'find_replace': {
@@ -294,6 +301,76 @@ async function handleStep({
 			}
 		}
 
+		case 'file_output': {
+			if (!window.__TAURI_INTERNALS__) {
+				console.warn(
+					'file_output step is only supported on desktop; skipping',
+				);
+				return Ok(input);
+			}
+
+			const outputDirectory = step['file_output.outputDirectory'];
+			const filenameTemplate = step['file_output.filenameTemplate'];
+			const fileExtension = step['file_output.fileExtension'];
+
+			if (!outputDirectory.trim()) {
+				return Err('Output directory not configured for file_output step');
+			}
+
+			const now = new Date();
+			const dateStr = now.toISOString().slice(0, 10);
+			const timeStr = now.toTimeString().slice(0, 8).replace(/:/g, '');
+			const timestampStr = `${dateStr}T${timeStr}`;
+
+			const variables = {
+				date: dateStr,
+				time: timeStr,
+				timestamp: timestampStr,
+				recording_title: context?.recordingTitle ?? 'untitled',
+				transformation_title: context?.transformationTitle ?? 'transformation',
+			};
+
+			const filename = interpolateTemplate(
+				asTemplateString(filenameTemplate),
+				variables,
+			);
+
+			const sanitizedFilename = sanitizeFilename(filename);
+
+			const { join } = await import('@tauri-apps/api/path');
+			const { writeTextFile, mkdir } = await import('@tauri-apps/plugin-fs');
+
+			try {
+				await mkdir(outputDirectory, { recursive: true });
+			} catch (mkdirError) {
+				const errMsg = extractErrorMessage(mkdirError);
+				if (!errMsg.toLowerCase().includes('already exists')) {
+					return Err(`Failed to create output directory: ${errMsg}`);
+				}
+			}
+
+			const ext = fileExtension.trim()
+				? fileExtension.startsWith('.')
+					? fileExtension
+					: `.${fileExtension}`
+				: '';
+			const filePath = await join(
+				outputDirectory,
+				`${sanitizedFilename}${ext}`,
+			);
+
+			try {
+				await writeTextFile(filePath, input);
+			} catch (writeError) {
+				return Err(
+					`Failed to write file "${sanitizedFilename}${ext}": ${extractErrorMessage(writeError)}`,
+				);
+			}
+
+			console.log(`[file_output] Wrote: ${filePath}`);
+			return Ok(input);
+		}
+
 		default:
 			return Err(`Unsupported step type: ${step.type}`);
 	}
@@ -303,10 +380,12 @@ async function runTransformation({
 	input,
 	transformation,
 	recordingId,
+	recordingTitle,
 }: {
 	input: string;
 	transformation: Transformation;
 	recordingId: string | null;
+	recordingTitle?: string;
 }): Promise<
 	Result<
 		TransformationRunCompleted | TransformationRunFailed,
@@ -375,6 +454,10 @@ async function runTransformation({
 		const handleStepResult = await handleStep({
 			input: currentInput,
 			step,
+			context: {
+				recordingTitle,
+				transformationTitle: transformation.title,
+			},
 		});
 
 		if (isErr(handleStepResult)) {

--- a/apps/whispering/src/lib/services/db/models/transformations.ts
+++ b/apps/whispering/src/lib/services/db/models/transformations.ts
@@ -13,18 +13,18 @@ import {
  * The current version of the TransformationStep schema.
  * Increment this when adding new fields or making breaking changes.
  */
-const CURRENT_TRANSFORMATION_STEP_VERSION = 2 as const;
+const CURRENT_TRANSFORMATION_STEP_VERSION = 3 as const;
 
 // ============================================================================
 // SHARED BASE FIELDS
 // ============================================================================
-// These are shared between V1 and V2. If V3 needs different base fields,
-// create a new base or define V3 from scratch.
+// These are shared across all versions (V1, V2, V3). If a future version
+// needs different base fields, create a new base or define it from scratch.
 // ============================================================================
 
 /**
- * Base fields shared between TransformationStep V1 and V2.
- * FROZEN for V1/V2: Do not modify without considering impact on both versions.
+ * Base fields shared across all TransformationStep versions.
+ * FROZEN: Do not modify without considering impact on all versions.
  *
  * Uses arktype's type() directly so we can use .merge() for composition.
  */
@@ -105,7 +105,7 @@ export type TransformationV1 = {
 };
 
 // ============================================================================
-// VERSION 2 (CURRENT)
+// VERSION 2 (FROZEN)
 // ============================================================================
 
 /**
@@ -129,11 +129,44 @@ const TransformationStepV2 = TransformationStepBase.merge({
 
 export type TransformationStepV2 = typeof TransformationStepV2.infer;
 
+// ============================================================================
+// VERSION 3 (CURRENT)
+// ============================================================================
+
 /**
- * Current Transformation schema with V2 steps.
+ * V3: Added file_output step type fields.
+ * - outputDirectory: Directory to write output files
+ * - filenameTemplate: Template with {{variable}} placeholders for filename
+ * - fileExtension: File extension without leading dot
+ *
+ * CURRENT VERSION: This is the latest schema.
+ */
+const TransformationStepV3 = TransformationStepV2.merge({
+	version: '3',
+	/** Output directory for file_output steps */
+	'file_output.outputDirectory': 'string',
+	/** Filename template with {{variable}} placeholders (e.g., {{date}}-{{time}}-transcription) */
+	'file_output.filenameTemplate': 'string',
+	/** File extension without leading dot (e.g., 'txt', 'md') */
+	'file_output.fileExtension': 'string',
+});
+
+export type TransformationStepV3 = typeof TransformationStepV3.infer;
+
+/**
+ * Current Transformation schema with V3 steps.
  *
  * Note: The Transformation fields themselves are unchanged from V1;
- * "V2" refers to the step schema version contained within.
+ * "V3" refers to the step schema version contained within.
+ */
+const TransformationV3 = TransformationBase.merge({
+	steps: [TransformationStepV3, '[]'],
+});
+
+export type TransformationV3 = typeof TransformationV3.infer;
+
+/**
+ * Legacy Transformation schema with V2 steps (for migration).
  */
 const TransformationV2 = TransformationBase.merge({
 	steps: [TransformationStepV2, '[]'],
@@ -144,7 +177,7 @@ export type TransformationV2 = typeof TransformationV2.infer;
 // ============================================================================
 // MIGRATING VALIDATORS
 // ============================================================================
-// These accept any version and migrate to the latest (V2).
+// These accept any version and migrate to the latest (V3).
 // Use these when reading data that might be from an older schema version.
 // ============================================================================
 
@@ -161,36 +194,52 @@ function migrateStepV1ToV2(step: TransformationStepV1): TransformationStepV2 {
 }
 
 /**
- * TransformationStep validator with automatic migration.
- * Accepts V1 or V2 and always outputs V2.
+ * Migrates a TransformationStep from V2 to V3.
  */
-export const TransformationStep = TransformationStepV1.or(
-	TransformationStepV2,
-).pipe((step): TransformationStepV2 => {
-	if (step.version === 1) {
-		return migrateStepV1ToV2(step);
-	}
-	return step;
-});
+function migrateStepV2ToV3(step: TransformationStepV2): TransformationStepV3 {
+	return {
+		...step,
+		version: 3,
+		'file_output.outputDirectory': '',
+		'file_output.filenameTemplate': '{{date}}-{{time}}-transcription',
+		'file_output.fileExtension': 'md',
+	};
+}
 
-export type TransformationStep = TransformationStepV2;
+/**
+ * TransformationStep validator with automatic migration.
+ * Accepts V1, V2, or V3 and always outputs V3.
+ */
+export const TransformationStep = TransformationStepV1.or(TransformationStepV2)
+	.or(TransformationStepV3)
+	.pipe((step): TransformationStepV3 => {
+		if (step.version === 1) {
+			return migrateStepV2ToV3(migrateStepV1ToV2(step));
+		}
+		if (step.version === 2) {
+			return migrateStepV2ToV3(step);
+		}
+		return step;
+	});
+
+export type TransformationStep = TransformationStepV3;
 
 /**
  * Transformation validator with automatic step migration.
- * Accepts transformations with V1 or V2 steps and migrates all steps to V2.
+ * Accepts transformations with V1, V2, or V3 steps and migrates all steps to V3.
  * Use this when reading data that might contain old schema versions.
  */
 export const Transformation = TransformationBase.merge({
 	steps: [TransformationStep, '[]'],
 });
 
-export type Transformation = TransformationV2;
+export type Transformation = TransformationV3;
 
 // ============================================================================
 // FACTORY FUNCTIONS
 // ============================================================================
 
-export function generateDefaultTransformation(): TransformationV2 {
+export function generateDefaultTransformation(): TransformationV3 {
 	const now = new Date().toISOString();
 	return {
 		id: nanoid(),
@@ -202,7 +251,7 @@ export function generateDefaultTransformation(): TransformationV2 {
 	};
 }
 
-export function generateDefaultTransformationStep(): TransformationStepV2 {
+export function generateDefaultTransformationStep(): TransformationStepV3 {
 	return {
 		version: CURRENT_TRANSFORMATION_STEP_VERSION,
 		id: nanoid(),
@@ -225,5 +274,10 @@ export function generateDefaultTransformationStep(): TransformationStepV2 {
 		'find_replace.findText': '',
 		'find_replace.replaceText': '',
 		'find_replace.useRegex': false,
+
+		// File output fields - empty by default, user configures when using file_output step
+		'file_output.outputDirectory': '',
+		'file_output.filenameTemplate': '{{date}}-{{time}}-transcription',
+		'file_output.fileExtension': 'md',
 	};
 }

--- a/apps/whispering/src/lib/utils/filename.ts
+++ b/apps/whispering/src/lib/utils/filename.ts
@@ -1,0 +1,12 @@
+/**
+ * Sanitizes a filename by removing invalid characters and normalizing dashes.
+ * Returns 'output' if the result would be empty.
+ */
+export function sanitizeFilename(filename: string): string {
+	return (
+		filename
+			.replace(/[<>:"/\\|?*]/g, '-')
+			.replace(/-+/g, '-')
+			.replace(/^-|-$/g, '') || 'output'
+	);
+}


### PR DESCRIPTION
# Disclaimer
Fair warning: I'm not familiar with the tauri ecosystem, and only have casual experience with svelte.
I took a guess at what this might look like and have manually tested it on my mac machine (though I had to change the cargo lock to get the build to work (excluded from the pr though as I think thats a rust environment issue), happy to make any changes.

# Description

This adds a new "File Output" transformation step that writes the transformed text to a file on disk, addressing the workflow automation use case described in #1071.

The step includes a directory picker, filename templating with multiple variables (date, time, recording title, transformation title), and configurable file extensions. Files are written using Tauri's filesystem API with automatic directory creation, and filenames are sanitized to remove invalid characters like `<>:"/\|?*`.

The implementation adds the step type to the transformation constants, extends the schema to V3 with three new fields (outputDirectory, filenameTemplate, fileExtension), and implements the file-writing logic in the transformer with proper error handling. The UI provides a folder browser button on desktop and shows a warning on web that the step will be skipped (since file system access requires Tauri).

Desktop-only limitation is enforced by checking for `window.__TAURI_INTERNALS__`. The step gracefully skips on web and logs a warning rather than failing the entire transformation.

Closes #1071