### PR TITLE
refactor(epicenter): remove insert and insertMany table operations

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",
@@ -164,13 +163,6 @@
         "@types/bun": "catalog:",
         "@types/jsdom": "^27.0.0",
         "drizzle-kit": "catalog:",
-      },
-    },
-    "examples/sqlite-rebuild-benchmark": {
-      "name": "sqlite-rebuild-benchmark",
-      "dependencies": {
-        "@tursodatabase/database": "^0.3.2",
-        "drizzle-orm": "catalog:",
       },
     },
     "examples/stress-test": {
@@ -2208,8 +2200,6 @@
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
-
-    "sqlite-rebuild-benchmark": ["sqlite-rebuild-benchmark@workspace:examples/sqlite-rebuild-benchmark"],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 

--- a/packages/epicenter/src/cli/cli-end-to-end.test.ts
+++ b/packages/epicenter/src/cli/cli-end-to-end.test.ts
@@ -82,7 +82,7 @@ describe('CLI End-to-End Tests', () => {
 						category,
 						views: 0,
 					} satisfies typeof db.posts.$inferSerializedRow;
-					db.posts.insert(post);
+					db.posts.upsert(post);
 					return Ok(post);
 				},
 			}),

--- a/packages/epicenter/src/cli/integration.test.ts
+++ b/packages/epicenter/src/cli/integration.test.ts
@@ -40,7 +40,7 @@ describe('CLI Integration', () => {
 						name,
 						count: String(count),
 					};
-					db.items.insert(item);
+					db.items.upsert(item);
 					return Ok(item);
 				},
 			}),

--- a/packages/epicenter/src/core/db/core-types.test.ts
+++ b/packages/epicenter/src/core/db/core-types.test.ts
@@ -22,8 +22,8 @@ describe('YjsDoc Type Inference', () => {
 			},
 		});
 
-		// Test insert() - accepts serialized values (strings for ytext, arrays for multi-select)
-		doc.posts.insert({
+		// Test upsert() - accepts serialized values (strings for ytext, arrays for multi-select)
+		doc.posts.upsert({
 			id: '1',
 			title: 'Test Post',
 			content: 'Post content', // string (gets converted to Y.Text internally)
@@ -63,7 +63,7 @@ describe('YjsDoc Type Inference', () => {
 			},
 		});
 
-		doc.products.insertMany({
+		doc.products.upsertMany({
 			rows: [
 				{ id: '1', name: 'Widget', price: 1000, in_stock: true },
 				{ id: '2', name: 'Gadget', price: 2000, in_stock: false },
@@ -87,7 +87,7 @@ describe('YjsDoc Type Inference', () => {
 			},
 		});
 
-		doc.tasks.insertMany({
+		doc.tasks.upsertMany({
 			rows: [
 				{ id: '1', title: 'Task 1', completed: false, priority: 'high' },
 				{ id: '2', title: 'Task 2', completed: true, priority: 'low' },
@@ -112,7 +112,7 @@ describe('YjsDoc Type Inference', () => {
 			},
 		});
 
-		doc.items.insertMany({
+		doc.items.upsertMany({
 			rows: [
 				{ id: '1', name: 'Item 1', quantity: 5 },
 				{ id: '2', name: 'Item 2', quantity: 0 },
@@ -159,7 +159,7 @@ describe('YjsDoc Type Inference', () => {
 			},
 		});
 
-		doc.notifications.insert({
+		doc.notifications.upsert({
 			id: '1',
 			message: 'Test notification',
 			read: false,
@@ -182,7 +182,7 @@ describe('YjsDoc Type Inference', () => {
 		});
 
 		// Test with null values
-		doc.articles.insert({
+		doc.articles.upsert({
 			id: '1',
 			title: 'Article without content',
 			description: null,
@@ -197,7 +197,7 @@ describe('YjsDoc Type Inference', () => {
 		}
 
 		// Test with string values (automatically converted to Y.Text internally)
-		doc.articles.insert({
+		doc.articles.upsert({
 			id: '2',
 			title: 'Article with content',
 			description: 'A short description',
@@ -230,7 +230,7 @@ describe('YjsDoc Type Inference', () => {
 		});
 
 		// Test authors table - use plain string (converted to Y.Text internally)
-		doc.authors.insert({
+		doc.authors.upsert({
 			id: 'author-1',
 			name: 'John Doe',
 			bio: 'Author bio',
@@ -240,7 +240,7 @@ describe('YjsDoc Type Inference', () => {
 		// Hover to verify type: Result<{ id: string; name: string; bio: Y.Text | null }, ArkErrors> | null
 
 		// Test books table - use plain array (converted to Y.Array internally)
-		doc.books.insert({
+		doc.books.upsert({
 			id: 'book-1',
 			author_id: 'author-1',
 			title: 'My Book',
@@ -276,7 +276,7 @@ describe('YjsDoc Type Inference', () => {
 			{ id: '2', text: 'Second comment', upvotes: 10 },
 		];
 
-		doc.comments.insertMany({ rows: commentsToAdd });
+		doc.comments.upsertMany({ rows: commentsToAdd });
 
 		const comments = doc.comments.getAll();
 		expect(comments).toHaveLength(2);
@@ -293,8 +293,8 @@ describe('YjsDoc Type Inference', () => {
 			},
 		});
 
-		// Insert with plain values (automatically converted to Y.js types internally)
-		doc.documents.insert({
+		// Upsert with plain values (automatically converted to Y.js types internally)
+		doc.documents.upsert({
 			id: 'doc-1',
 			title: 'My Document',
 			body: 'Hello World',

--- a/packages/epicenter/src/core/db/core.test.ts
+++ b/packages/epicenter/src/core/db/core.test.ts
@@ -16,7 +16,7 @@ describe('createEpicenterDb', () => {
 		});
 
 		// Create a row
-		doc.posts.insert({
+		doc.posts.upsert({
 			id: '1',
 			title: 'Test Post',
 			view_count: 0,
@@ -45,13 +45,12 @@ describe('createEpicenterDb', () => {
 		});
 
 		// Create multiple rows
-		const { error: insertError } = doc.posts.insertMany({
+		doc.posts.upsertMany({
 			rows: [
 				{ id: '1', title: 'Post 1', view_count: 10, published: true },
 				{ id: '2', title: 'Post 2', view_count: 20, published: false },
 			],
 		});
-		expect(insertError).toBeNull();
 
 		// Retrieve and verify rows
 		const row1 = doc.posts.get({ id: '1' });
@@ -77,7 +76,7 @@ describe('createEpicenterDb', () => {
 			},
 		});
 
-		doc.posts.insertMany({
+		doc.posts.upsertMany({
 			rows: [
 				{ id: '1', title: 'Post 1', view_count: 10, published: true },
 				{ id: '2', title: 'Post 2', view_count: 20, published: false },
@@ -127,8 +126,8 @@ describe('createEpicenterDb', () => {
 			},
 		});
 
-		// Insert with plain strings and arrays (the documented API)
-		doc.posts.insert({
+		// Upsert with plain strings and arrays (the documented API)
+		doc.posts.upsert({
 			id: '1',
 			title: 'Hello World',
 			tags: ['typescript', 'javascript'],
@@ -144,8 +143,8 @@ describe('createEpicenterDb', () => {
 			expect(result1.data.tags.toArray()).toEqual(['typescript', 'javascript']);
 		}
 
-		// Insert another post
-		doc.posts.insert({
+		// Upsert another post
+		doc.posts.upsert({
 			id: '2',
 			title: 'Second Post',
 			tags: ['python'],

--- a/packages/epicenter/src/core/db/core.ts
+++ b/packages/epicenter/src/core/db/core.ts
@@ -76,14 +76,14 @@ export type { TableHelper } from './table-helper';
  * });
  *
  * // Tables are accessed directly (no .tables namespace)
- * db.posts.insert({ id: '1', title: 'Hello', published: false });
+ * db.posts.upsert({ id: '1', title: 'Hello', published: false });
  * db.posts.getAll();
  *
  * // Utilities are prefixed with $
  * db.$clearAll();
  * db.$transact(() => {
- *   db.posts.insert({ ... });
- *   db.comments.insert({ ... });
+ *   db.posts.upsert({ ... });
+ *   db.comments.upsert({ ... });
  * });
  * ```
  */
@@ -162,7 +162,7 @@ export function createEpicenterDb<TWorkspaceSchema extends WorkspaceSchema>(
 		 * // Cross-table transaction
 		 * db.$transact(() => {
 		 *   db.posts.upsertMany([...]);
-		 *   db.comments.insert({ ... });
+		 *   db.comments.upsert({ ... });
 		 * }, 'bulk-import');
 		 * ```
 		 */
@@ -177,7 +177,7 @@ export function createEpicenterDb<TWorkspaceSchema extends WorkspaceSchema>(
 		 * ```typescript
 		 * // Clear everything before importing fresh data
 		 * db.$clearAll();
-		 * db.posts.insertMany(importedPosts);
+		 * db.posts.upsertMany(importedPosts);
 		 * ```
 		 */
 		$clearAll(): void {
@@ -224,7 +224,7 @@ export function createEpicenterDb<TWorkspaceSchema extends WorkspaceSchema>(
  * type MyDb = Db<typeof mySchema>;
  *
  * function doSomething(db: MyDb) {
- *   db.posts.insert(...);  // Direct table access
+ *   db.posts.upsert(...);  // Direct table access
  *   db.$clearAll();        // Utility access
  * }
  * ```

--- a/packages/epicenter/src/core/workspace.test.ts
+++ b/packages/epicenter/src/core/workspace.test.ts
@@ -667,7 +667,7 @@ describe('Workspace Action Handlers', () => {
 							category,
 							views: 0,
 						};
-						db.posts.insert(post);
+						db.posts.upsert(post);
 						return Ok(post);
 					},
 				}),

--- a/packages/epicenter/src/index.ts
+++ b/packages/epicenter/src/index.ts
@@ -56,15 +56,8 @@ export {
 export type { Db, TableHelper } from './core/db/core';
 // Database utilities
 export { createEpicenterDb } from './core/db/core';
-export type {
-	RowAlreadyExistsError,
-	RowNotFoundError,
-	YRow,
-} from './core/db/table-helper';
-export {
-	RowAlreadyExistsErr,
-	RowNotFoundErr,
-} from './core/db/table-helper';
+export type { RowNotFoundError, YRow } from './core/db/table-helper';
+export { RowNotFoundErr } from './core/db/table-helper';
 export type { ActionInfo, EpicenterClient, EpicenterConfig } from './core/epicenter';
 // Epicenter - compose multiple workspaces
 export {

--- a/packages/epicenter/src/indexes/markdown/README.md
+++ b/packages/epicenter/src/indexes/markdown/README.md
@@ -421,8 +421,8 @@ Once configured, you can work with your data in two ways:
 **Through the application**:
 
 ```typescript
-// Insert a post (markdown file created automatically)
-db.tables.posts.insert({
+// Upsert a post (markdown file created automatically)
+db.tables.posts.upsert({
 	id: 'hello-world',
 	title: 'Hello World',
 	content: 'My first post',

--- a/packages/epicenter/src/indexes/markdown/markdown-index.ts
+++ b/packages/epicenter/src/indexes/markdown/markdown-index.ts
@@ -745,11 +745,7 @@ export const markdownIndex = (async <TSchema extends WorkspaceSchema>(
 						diagnostics.remove({ filePath });
 
 						// Insert or update the row in YJS
-						if (table.has({ id: row.id })) {
-							table.update(validatedRow);
-						} else {
-							table.insert(validatedRow);
-						}
+						table.upsert(validatedRow);
 					}
 
 					syncCoordination.isProcessingFileChange = false;
@@ -1097,17 +1093,7 @@ export const markdownIndex = (async <TSchema extends WorkspaceSchema>(
 
 									// Insert into YJS
 									// @ts-expect-error SerializedRow<TSchema[string]> is not assignable to parameter of type SerializedRow<TTableSchema> due to union type from $tables() iteration
-									const insertResult = table.insert(row);
-									if (insertResult.error) {
-										// Log insert errors (operational errors, not validation errors)
-										logger.log(
-											IndexError({
-												message: `pushFromMarkdown: failed to insert ${table.name}/${row.id} into YJS`,
-												context: { tableName: table.name, rowId: row.id },
-												cause: insertResult.error,
-											}),
-										);
-									}
+									table.upsert(row);
 								}),
 							);
 						}

--- a/packages/epicenter/src/indexes/sqlite/sqlite-index.ts
+++ b/packages/epicenter/src/indexes/sqlite/sqlite-index.ts
@@ -358,21 +358,7 @@ export const sqliteIndex = (async <TSchema extends WorkspaceSchema>(
 							const rows = await sqliteDb.select().from(drizzleTable);
 							for (const row of rows) {
 								// @ts-expect-error InferSelectModel<DrizzleTable> is not assignable to InferInsertModel<TableHelper<TSchema[string]>> due to union type from $tables() iteration
-								const result = table.insert(row);
-								if (result.error) {
-									// @ts-expect-error row.id exists but TypeScript cannot narrow the union type from $tables() iteration
-									const rowId = row.id;
-									logger.log(
-										IndexError({
-											message: `Failed to insert row ${rowId} from SQLite into YJS table ${table.name}`,
-											context: {
-												rowId,
-												tableName: table.name,
-												cause: result.error,
-											},
-										}),
-									);
-								}
+								table.upsert(row);
 							}
 						}
 

--- a/packages/epicenter/src/server/README.md
+++ b/packages/epicenter/src/server/README.md
@@ -271,7 +271,7 @@ const notesWorkspace = defineWorkspace({
 			}),
 			handler: async (input) => {
 				const note = { id: generateId(), ...input };
-				db.tables.notes.insert(note);
+				db.tables.notes.upsert(note);
 				return Ok(note);
 			},
 		}),

--- a/packages/epicenter/tests/integration/server.test.ts
+++ b/packages/epicenter/tests/integration/server.test.ts
@@ -65,7 +65,7 @@ describe('Server Integration Tests', () => {
 						views: 0,
 						published: false,
 					};
-					db.posts.insert(post);
+					db.posts.upsert(post);
 					return Ok(post);
 				},
 			}),
@@ -263,7 +263,7 @@ describe('Server Integration Tests', () => {
 							id: generateId(),
 							...input,
 						};
-						db.users.insert(user);
+						db.users.upsert(user);
 						return Ok(user);
 					},
 				}),


### PR DESCRIPTION
In a CRDT database like Y.js, the concept of "insert that fails on duplicate" doesn't provide meaningful guarantees. The `RowAlreadyExistsError` only caught local duplicates within your own runtime, but couldn't prevent distributed duplicates since multiple clients can insert with the same ID simultaneously and the data merges via CRDT conflict resolution.

This made `insert`/`insertMany` provide a false sense of uniqueness guarantees that the underlying system couldn't actually enforce. Since `upsert`/`upsertMany` perform the same underlying Y.js operations without the misleading local-only check, all code now uses `upsert`/`upsertMany` exclusively.

The same philosophical issue applies to `update`/`updateMany` with `RowNotFoundError` (checking if a row "exists" locally is equally meaningless in a distributed CRDT), which will be addressed in a follow-up change.