### PR TITLE
refactor(epicenter): migrate insert/insertMany to upsert/upsertMany

### DIFF
--- a/docs/guides/yjs-persistence-guide.md
+++ b/docs/guides/yjs-persistence-guide.md
@@ -25,7 +25,7 @@ Every workspace has a `Y.Doc` instance. This document:
 const ydoc = new Y.Doc({ guid: 'my-workspace-id' });
 
 // Your table operations update the YDoc:
-db.tables.posts.insert({ id: '1', title: 'Hello' });
+db.tables.posts.upsert({ id: '1', title: 'Hello' });
 // ↓
 // YDoc updated → Indexes notified → Files saved
 ```

--- a/examples/basic-workspace/README.md
+++ b/examples/basic-workspace/README.md
@@ -183,7 +183,7 @@ This makes your data:
 await blog.createPost({ title: 'Hello', content: 'World', category: 'tech' });
 
 // Through table helper
-db.posts.insert({ id: '1', title: 'Hello', /* ... */ });
+db.posts.upsert({ id: '1', title: 'Hello', /* ... */ });
 
 // Result: YJS updated → Saved to .epicenter/blog.yjs → SQLite synced → Markdown file created
 ```

--- a/examples/basic-workspace/epicenter.config.ts
+++ b/examples/basic-workspace/epicenter.config.ts
@@ -178,7 +178,7 @@ const blogWorkspace = defineWorkspace({
 					views: 0,
 					publishedAt: null,
 				} satisfies typeof db.posts.$inferSerializedRow;
-				db.posts.insert(post);
+				db.posts.upsert(post);
 				return Ok(post);
 			},
 		}),
@@ -215,7 +215,7 @@ const blogWorkspace = defineWorkspace({
 					content,
 					createdAt: new Date().toISOString(),
 				} satisfies typeof db.comments.$inferSerializedRow;
-				db.comments.insert(comment);
+				db.comments.upsert(comment);
 				return Ok(comment);
 			},
 		}),

--- a/examples/content-hub/browser/browser.workspace.ts
+++ b/examples/content-hub/browser/browser.workspace.ts
@@ -280,7 +280,7 @@ export const browser = defineWorkspace({
 						if (win.id === undefined) continue;
 
 						const window_id = generateId();
-						db.windows.insert({
+						db.windows.upsert({
 							id: window_id,
 							browser_id: win.id,
 							state: win.state ?? 'normal',
@@ -300,7 +300,7 @@ export const browser = defineWorkspace({
 						for (const tab of win.tabs ?? []) {
 							if (tab.id === undefined) continue;
 
-							db.tabs.insert({
+							db.tabs.upsert({
 								id: generateId(),
 								browser_id: tab.id,
 								window_id,
@@ -437,7 +437,7 @@ export const browser = defineWorkspace({
 				}
 
 				const tab_id = generateId();
-				db.tabs.insert({
+				db.tabs.upsert({
 					id: tab_id,
 					browser_id: newTab.id,
 					window_id: target_window_id,
@@ -747,7 +747,7 @@ export const browser = defineWorkspace({
 
 				const new_tab_id = generateId();
 
-				db.tabs.insert({
+				db.tabs.upsert({
 					id: new_tab_id,
 					browser_id: newTab.id,
 					window_id: tab.window_id,

--- a/examples/content-hub/clippings/clippings.workspace.ts
+++ b/examples/content-hub/clippings/clippings.workspace.ts
@@ -297,7 +297,7 @@ ${instructions}`;
 				}).toJSON();
 
 				// Insert into database
-				db.articles.insert({
+				db.articles.upsert({
 					id: generateId(),
 					url,
 					title: result.title,
@@ -412,7 +412,7 @@ ${instructions}`;
 					timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 				}).toJSON();
 
-				db.landing_pages.insert({
+				db.landing_pages.upsert({
 					id: generateId(),
 					url,
 					title,
@@ -493,7 +493,7 @@ ${instructions}`;
 					timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 				}).toJSON();
 
-				db.github_repos.insert({
+				db.github_repos.upsert({
 					id: generateId(),
 					url,
 					title: finalTitle,
@@ -524,7 +524,7 @@ ${instructions}`;
 					timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 				}).toJSON();
 
-				db.doc_sites.insert({
+				db.doc_sites.upsert({
 					id: generateId(),
 					url,
 					title,
@@ -551,7 +551,7 @@ ${instructions}`;
 
 				const book_id = generateId();
 
-				db.books.insert({
+				db.books.upsert({
 					id: book_id,
 					title,
 					author,
@@ -587,7 +587,7 @@ ${instructions}`;
 					timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 				}).toJSON();
 
-				db.book_excerpts.insert({
+				db.book_excerpts.upsert({
 					id: generateId(),
 					book_id,
 					content,
@@ -624,7 +624,7 @@ ${instructions}`;
 					timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 				}).toJSON();
 
-				db.article_excerpts.insert({
+				db.article_excerpts.upsert({
 					id: generateId(),
 					article_id,
 					content,
@@ -686,7 +686,7 @@ ${instructions}`;
 				}).toJSON();
 
 				// Insert into database
-				db.essays.insert({
+				db.essays.upsert({
 					id: generateId(),
 					url,
 					title: result.title,
@@ -736,7 +736,7 @@ ${instructions}`;
 
 				const recipe_id = generateId();
 
-				db.recipes.insert({
+				db.recipes.upsert({
 					id: recipe_id,
 					title,
 					description: description ?? null,

--- a/examples/content-hub/gmail/gmail.workspace.ts
+++ b/examples/content-hub/gmail/gmail.workspace.ts
@@ -333,7 +333,7 @@ export const gmail = defineWorkspace({
 
 					const emailDate = parseEmailDate(getHeader(headers, 'Date'));
 
-					db.emails.insert({
+					db.emails.upsert({
 						id: generateId(),
 						gmail_id: message.id ?? gmailId,
 						thread_id: message.threadId ?? '',

--- a/examples/content-hub/pages/pages.workspace.ts
+++ b/examples/content-hub/pages/pages.workspace.ts
@@ -247,7 +247,7 @@ export const pages = defineWorkspace({
 						};
 
 						if (!dryRun) {
-							db.pages.insert(page);
+							db.pages.upsert(page);
 						}
 
 						stats.success++;

--- a/examples/content-hub/whispering/whispering.workspace.ts
+++ b/examples/content-hub/whispering/whispering.workspace.ts
@@ -153,7 +153,7 @@ export const whispering = defineWorkspace({
 						};
 
 						if (!dryRun) {
-							db.entries.insert(entry);
+							db.entries.upsert(entry);
 						}
 
 						stats.success++;

--- a/examples/stress-test/README.md
+++ b/examples/stress-test/README.md
@@ -34,21 +34,21 @@ bun run stress-test-write-delete-write.ts 5000
 
 ## What These Tests Measure
 
-1. **Bulk insertion performance** with `insertMany`
+1. **Bulk insertion performance** with `upsertMany`
 2. **YJS document size** as data grows
 3. **Performance degradation** patterns under load
 4. **Deletion behavior** and tombstone overhead
 
 ## Key Observations
 
-### insertMany vs insert: ~500x Difference
+### upsertMany vs upsert: ~500x Difference
 
 | Method | Speed | Why |
 |--------|-------|-----|
-| `insert()` | ~34/s | Each call = separate YJS transaction |
-| `insertMany()` | ~20,000/s | Single YJS transaction for all rows |
+| `upsert()` | ~34/s | Each call = separate YJS transaction |
+| `upsertMany()` | ~20,000/s | Single YJS transaction for all rows |
 
-Always use `insertMany({ rows: [...] })` for bulk operations. It uses `$transact` internally to batch all changes into one YJS update.
+Always use `upsertMany({ rows: [...] })` for bulk operations. It uses `$transact` internally to batch all changes into one YJS update.
 
 ### Performance Degradation at Scale
 

--- a/examples/stress-test/stress-test-write-delete-write.ts
+++ b/examples/stress-test/stress-test-write-delete-write.ts
@@ -134,7 +134,7 @@ for (let tableIndex = 0; tableIndex < TABLES.length; tableIndex++) {
 			});
 		}
 
-		tableDb.insertMany({ rows: items });
+		tableDb.upsertMany({ rows: items });
 		inserted += batchCount;
 
 		const batchElapsed = performance.now() - batchStart;
@@ -267,7 +267,7 @@ for (let tableIndex = 0; tableIndex < TABLES.length; tableIndex++) {
 			});
 		}
 
-		tableDb.insertMany({ rows: items });
+		tableDb.upsertMany({ rows: items });
 		inserted += batchCount;
 
 		const batchElapsed = performance.now() - batchStart;

--- a/examples/stress-test/stress-test.ts
+++ b/examples/stress-test/stress-test.ts
@@ -3,21 +3,21 @@
  *
  * Tests bulk insertion performance and YJS file size with large datasets.
  *
- * ## Performance Note: insertMany vs insert
+ * ## Performance Note: upsertMany vs upsert
  *
- * This test uses `insertMany` which is ~500x faster than individual `insert` calls:
+ * This test uses `upsertMany` which is ~500x faster than individual `upsert` calls:
  *
- * - `insert()`: ~34 items/second (each insert triggers a separate YJS transaction)
- * - `insertMany()`: ~20,000 items/second (batches all inserts into a single YJS transaction)
+ * - `upsert()`: ~34 items/second (each upsert triggers a separate YJS transaction)
+ * - `upsertMany()`: ~20,000 items/second (batches all upserts into a single YJS transaction)
  *
- * The key difference is that `insertMany` uses `$transact` internally, which wraps
+ * The key difference is that `upsertMany` uses `$transact` internally, which wraps
  * all operations in a single YJS transaction. This dramatically reduces overhead from:
  * 1. YJS document updates (one update vs N updates)
  * 2. Observer notifications (one notification vs N notifications)
  * 3. Persistence writes (one write vs potentially N writes)
  *
  * When doing bulk operations, always prefer:
- * - `insertMany({ rows: [...] })` over multiple `insert()` calls
+ * - `upsertMany({ rows: [...] })` over multiple `upsert()` calls
  * - `updateMany({ rows: [...] })` over multiple `update()` calls
  * - `$transact(() => { ... })` to batch arbitrary operations
  *
@@ -40,7 +40,7 @@ import epicenterConfig from './epicenter.config';
 
 // Configuration - can override via CLI args
 const ITEMS_PER_TABLE = Number(process.argv[2]) || 10_000; // Default 10k for balanced stress test
-const BATCH_SIZE = 1_000; // Insert in batches of 1k using insertMany
+const BATCH_SIZE = 1_000; // Insert in batches of 1k using upsertMany
 
 const TABLES = [
 	'items_a',
@@ -73,7 +73,7 @@ function formatRate(count: number, ms: number): string {
 }
 
 console.log('='.repeat(60));
-console.log('YJS Stress Test (using insertMany for bulk inserts)');
+console.log('YJS Stress Test (using upsertMany for bulk inserts)');
 console.log('='.repeat(60));
 console.log(`Items per table: ${ITEMS_PER_TABLE.toLocaleString()}`);
 console.log(`Batch size: ${BATCH_SIZE.toLocaleString()}`);
@@ -122,7 +122,7 @@ for (let tableIndex = 0; tableIndex < TABLES.length; tableIndex++) {
 		}
 
 		// Bulk insert
-		tableDb.insertMany({ rows: items });
+		tableDb.upsertMany({ rows: items });
 		inserted += batchCount;
 
 		const batchElapsed = performance.now() - batchStart;

--- a/packages/epicenter/specs/20251014T105903 bidirectional-markdown-sync.md
+++ b/packages/epicenter/specs/20251014T105903 bidirectional-markdown-sync.md
@@ -206,7 +206,7 @@ All tests pass (4/4) with no failures.
 
 ### Implementation Challenges Resolved
 
-1. **YJS Type Conversion**: Discovered that `table.insert()` doesn't automatically convert plain values (strings, arrays) to YJS types (Y.Text, Y.Array). Solution: Added conversion logic in `updateYJSRowFromMarkdown()` before insert.
+1. **YJS Type Conversion**: Discovered that `table.upsert()` doesn't automatically convert plain values (strings, arrays) to YJS types (Y.Text, Y.Array). Solution: Added conversion logic in `updateYJSRowFromMarkdown()` before upsert.
 
 2. **Validation Mismatch**: Core validation expects Y.Text/Y.Array instances, but markdown parsing yields plain values. Solution: Created custom validation in `parseMarkdownWithValidation()` that accepts both YJS types and plain values.
 

--- a/packages/epicenter/specs/20251022T180000-markdown-index-serialization-refactor.md
+++ b/packages/epicenter/specs/20251022T180000-markdown-index-serialization-refactor.md
@@ -51,7 +51,7 @@ This duplicates what `serializeRow()` already does, with added type assertions.
 Multiple `as any` assertions throughout:
 - `(row as any)[contentField]` (lines 134, 184)
 - `frontmatter as Record<string, any>` (implicit in filtering)
-- `table.insert(convertedRow as any)` (line 457)
+- `table.upsert(convertedRow as any)` (line 457)
 - `table.update({ id: rowId, [columnName]: ... } as any)` (lines 492, 507, 515)
 
 ## Proposed Solution
@@ -303,7 +303,7 @@ All markdown bidirectional sync tests pass:
 ### Remaining Type Assertions
 
 Three `as any` assertions remain in `updateYJSRowFromMarkdown` function:
-- Line 440: `table.insert(convertedRow as any)`
+- Line 440: `table.upsert(convertedRow as any)`
 - Line 475, 490, 498: `table.update({ ... } as any)`
 
 **Why they're necessary:** The table API expects specific typed objects, but we're building them dynamically from the schema. TypeScript's type system can't prove that our dynamically constructed objects match the expected types, even though they do at runtime. These assertions are an acceptable trade-off for generic, schema-driven code.

--- a/packages/epicenter/src/core/db/core-types.test.ts
+++ b/packages/epicenter/src/core/db/core-types.test.ts
@@ -261,7 +261,7 @@ describe('YjsDoc Type Inference', () => {
 		}
 	});
 
-	test('should properly type insertMany with array of rows', () => {
+	test('should properly type upsertMany with array of rows', () => {
 		const doc = createEpicenterDb(new Y.Doc({ guid: 'test-workspace' }), {
 			comments: {
 				id: id(),

--- a/packages/epicenter/src/core/schema/validation.ts
+++ b/packages/epicenter/src/core/schema/validation.ts
@@ -81,7 +81,7 @@ export type TableValidators<TSchema extends TableSchema = TableSchema> = {
 	 *
 	 * **Primary use case**: Batch insert/upsert action input schemas
 	 * - Used for operations that accept multiple rows at once
-	 * - Example: `insertMany: defineMutation({ input: validators.toStandardSchemaArray() })`
+	 * - Example: `upsertMany: defineMutation({ input: validators.toStandardSchemaArray() })`
 	 *
 	 * **MCP compatibility**: Returns `{ rows: T[] }` instead of bare `T[]` because
 	 * MCP protocol requires all tool inputSchema to have `type: "object"` at the root.

--- a/specs/20251101T120000 table-helpers-query-mutations.md
+++ b/specs/20251101T120000 table-helpers-query-mutations.md
@@ -75,10 +75,9 @@ YJS Storage
    - Input: `type({ ids: 'string[]' })`
    - Array of IDs wrapped in object
 
-5. **Array mutations (insertMany, updateMany, upsertMany)**:
+5. **Array mutations (updateMany, upsertMany)**:
    - Use `.array()` on base validators
-   - `insertMany`: input is `schema.toStandardSchema().array()` (wait, arktype doesn't work like this...)
-   - Actually: input is arktype array validator for SerializedRow[]
+   - `upsertMany`: input is arktype array validator for SerializedRow[]
 
 ## Implementation Plan
 
@@ -88,7 +87,6 @@ YJS Storage
 - Location: `packages/epicenter/src/db/errors.ts` (new file)
 - Create `createTaggedError` for table operations
 - Define error variants:
-  - `RowAlreadyExists`: Insert/upsert on existing id
   - `RowNotFound`: Update/delete on missing id
   - `ValidationError`: Schema validation failed
   - `TransactionError`: YJS transaction failed
@@ -154,12 +152,10 @@ YJS Storage
 - Wrap each method:
   - `get({id})`: defineQuery with `{id: 'string'}` input validator
   - `getAll()`: defineQuery with no input
-  - `insert(row)`: defineMutation with `toStandardSchema()` input
   - `update(partial)`: defineMutation with `toPartialStandardSchema()` input
   - `upsert(row)`: defineMutation with `toStandardSchema()` input
   - `delete({id})`: defineMutation with `{id: 'string'}` input
   - `deleteMany(ids)`: defineMutation with `string[]` input
-  - `insertMany(rows)`: defineMutation with `toStandardSchema().array()` input
   - `updateMany(partials)`: defineMutation with `toPartialStandardSchema().array()` input
   - `upsertMany(rows)`: defineMutation with `toStandardSchema().array()` input
   - `clear()`: defineMutation with no input
@@ -202,7 +198,7 @@ YJS Storage
    - **Decision**: Input should be `{ id: string }`
    - Wraps as: `defineMutation({ input: { id: 'string' }, handler })`
 
-4. **Array inputs**: For `insertMany/updateMany`, should input validation be:
+4. **Array inputs**: For `upsertMany/updateMany`, should input validation be:
    - Arktype array validator like `type({ id: 'string', ... }).array()`?
    - **Recommendation**: Yes, use `.array()` on the base validator
 

--- a/specs/20251126T083538-flatten-db-namespace.md
+++ b/specs/20251126T083538-flatten-db-namespace.md
@@ -26,7 +26,7 @@ This creates a clear, consistent rule. The only constraint is that table names c
 
 ```typescript
 // Tables (primary use case - 95% of usage)
-db.posts.insert(...)
+db.posts.upsert(...)
 db.emails.getAll()
 
 // Utilities (all prefixed with $)


### PR DESCRIPTION
Following PR #1093 which removed `insert` and `insertMany` from the table API, this updates all remaining usages throughout the codebase to use `upsert` and `upsertMany` instead.

Every migrated call site was generating fresh IDs with `generateId()`, so the semantic behavior is identical. In a CRDT database like Y.js, `upsert` is the correct primitive since the old `RowAlreadyExistsError` only caught local duplicates within a single runtime and couldn't prevent distributed conflicts when multiple clients insert with the same ID simultaneously.

The migration covers:
- Example workspaces (basic-workspace, content-hub, stress-test)
- Documentation and guides
- Spec files with outdated API references
- Test descriptions and comments