### PR TITLE
feat(stress-test): comprehensive YJS benchmark suite

### DIFF
--- a/examples/stress-test/README.md
+++ b/examples/stress-test/README.md
@@ -28,11 +28,11 @@ bun run stress-test.ts
 
 | Benchmark | Tests | Key Finding |
 |-----------|-------|-------------|
-| [Bulk Upsert](./stress-test.md) | `upsertMany` throughput | ~20k/s batched vs ~34/s single |
+| [Bulk Upsert](./stress-test.md) | `upsertMany` throughput | 19k/s avg, ~152 bytes/item |
 | [Write-Delete-Write](./stress-test-write-delete-write.md) | Tombstone overhead | Only 21% overhead for full cycle |
-| [Update-Heavy](./stress-test-update-heavy.md) | Repeated updates | TBD - run benchmark |
-| [Read-at-Scale](./stress-test-read-at-scale.md) | Query performance | TBD - run benchmark |
-| [Mixed Workload](./stress-test-mixed-workload.md) | Realistic usage | TBD - run benchmark |
+| [Update-Heavy](./stress-test-update-heavy.md) | Repeated updates | Updates ~40% of insert speed |
+| [Read-at-Scale](./stress-test-read-at-scale.md) | Query performance | get() O(1), getAll() O(n) |
+| [Mixed Workload](./stress-test-mixed-workload.md) | Realistic usage | 210-475 ops/s for single operations |
 
 ## Test Details
 

--- a/examples/stress-test/README.md
+++ b/examples/stress-test/README.md
@@ -7,12 +7,21 @@ Benchmarks for YJS persistence via Epicenter's table API. Each test measures dif
 ```bash
 cd examples/stress-test
 
-# Run any benchmark
+# Run all benchmarks
+bun run run-benchmarks.ts
+
+# Run specific benchmarks (by number or name)
+bun run run-benchmarks.ts 1 3 5
+bun run run-benchmarks.ts bulk update mixed
+
+# Run with clean slate
+bun run run-benchmarks.ts --clean
+
+# List available benchmarks
+bun run run-benchmarks.ts --list
+
+# Run individual benchmark directly
 bun run stress-test.ts
-bun run stress-test-write-delete-write.ts
-bun run stress-test-update-heavy.ts
-bun run stress-test-read-at-scale.ts
-bun run stress-test-mixed-workload.ts
 ```
 
 ## Benchmarks

--- a/examples/stress-test/run-benchmarks.ts
+++ b/examples/stress-test/run-benchmarks.ts
@@ -1,0 +1,218 @@
+#!/usr/bin/env bun
+/**
+ * Benchmark Runner
+ *
+ * Run all benchmarks or select specific ones.
+ *
+ * @example
+ * ```bash
+ * # Run all benchmarks
+ * bun run run-benchmarks.ts
+ *
+ * # Run specific benchmarks (by number or name)
+ * bun run run-benchmarks.ts 1 3 5
+ * bun run run-benchmarks.ts bulk update mixed
+ *
+ * # List available benchmarks
+ * bun run run-benchmarks.ts --list
+ * ```
+ */
+
+import { spawn } from 'bun';
+import { existsSync, rmSync } from 'node:fs';
+
+const BENCHMARKS = [
+	{
+		id: 1,
+		name: 'bulk',
+		file: 'stress-test.ts',
+		description: 'Bulk Upsert - Maximum upsertMany throughput',
+	},
+	{
+		id: 2,
+		name: 'write-delete-write',
+		file: 'stress-test-write-delete-write.ts',
+		description: 'Write-Delete-Write - Tombstone overhead',
+	},
+	{
+		id: 3,
+		name: 'update',
+		file: 'stress-test-update-heavy.ts',
+		description: 'Update-Heavy - Repeated updates performance',
+	},
+	{
+		id: 4,
+		name: 'read',
+		file: 'stress-test-read-at-scale.ts',
+		description: 'Read-at-Scale - Query scaling',
+	},
+	{
+		id: 5,
+		name: 'mixed',
+		file: 'stress-test-mixed-workload.ts',
+		description: 'Mixed Workload - Realistic interleaved ops',
+	},
+];
+
+function printHelp() {
+	console.log('YJS Benchmark Runner');
+	console.log('====================');
+	console.log('');
+	console.log('Usage:');
+	console.log('  bun run run-benchmarks.ts [options] [benchmarks...]');
+	console.log('');
+	console.log('Options:');
+	console.log('  --list, -l     List available benchmarks');
+	console.log('  --help, -h     Show this help');
+	console.log('  --clean        Remove .epicenter folder before running');
+	console.log('');
+	console.log('Benchmarks can be specified by:');
+	console.log('  - Number: 1, 2, 3, 4, 5');
+	console.log('  - Name: bulk, write-delete-write, update, read, mixed');
+	console.log('');
+	console.log('Examples:');
+	console.log('  bun run run-benchmarks.ts              # Run all');
+	console.log('  bun run run-benchmarks.ts 1 3          # Run benchmarks 1 and 3');
+	console.log('  bun run run-benchmarks.ts bulk mixed   # Run by name');
+	console.log('  bun run run-benchmarks.ts --clean 1    # Clean and run benchmark 1');
+}
+
+function listBenchmarks() {
+	console.log('Available Benchmarks:');
+	console.log('=====================');
+	console.log('');
+	for (const b of BENCHMARKS) {
+		console.log(`  ${b.id}. [${b.name}] ${b.description}`);
+		console.log(`     File: ${b.file}`);
+		console.log('');
+	}
+}
+
+async function runBenchmark(benchmark: (typeof BENCHMARKS)[number]) {
+	console.log('');
+	console.log('█'.repeat(60));
+	console.log(`█ Running: ${benchmark.description}`);
+	console.log(`█ File: ${benchmark.file}`);
+	console.log('█'.repeat(60));
+	console.log('');
+
+	const proc = spawn({
+		cmd: ['bun', 'run', benchmark.file],
+		cwd: import.meta.dir,
+		stdout: 'inherit',
+		stderr: 'inherit',
+	});
+
+	const exitCode = await proc.exited;
+
+	if (exitCode !== 0) {
+		console.log(`\n⚠️  Benchmark ${benchmark.name} exited with code ${exitCode}`);
+	}
+
+	return exitCode;
+}
+
+// Parse arguments
+const args = process.argv.slice(2);
+
+if (args.includes('--help') || args.includes('-h')) {
+	printHelp();
+	process.exit(0);
+}
+
+if (args.includes('--list') || args.includes('-l')) {
+	listBenchmarks();
+	process.exit(0);
+}
+
+const shouldClean = args.includes('--clean');
+const benchmarkArgs = args.filter((a) => !a.startsWith('--'));
+
+// Determine which benchmarks to run
+let benchmarksToRun: typeof BENCHMARKS;
+
+if (benchmarkArgs.length === 0) {
+	benchmarksToRun = BENCHMARKS;
+} else {
+	benchmarksToRun = [];
+	for (const arg of benchmarkArgs) {
+		// Try as number
+		const num = parseInt(arg, 10);
+		if (!isNaN(num)) {
+			const found = BENCHMARKS.find((b) => b.id === num);
+			if (found) {
+				benchmarksToRun.push(found);
+				continue;
+			}
+		}
+
+		// Try as name (partial match)
+		const found = BENCHMARKS.find(
+			(b) => b.name.includes(arg.toLowerCase()) || b.file.includes(arg.toLowerCase()),
+		);
+		if (found) {
+			benchmarksToRun.push(found);
+		} else {
+			console.error(`Unknown benchmark: ${arg}`);
+			console.error('Use --list to see available benchmarks');
+			process.exit(1);
+		}
+	}
+}
+
+// Clean if requested
+if (shouldClean) {
+	const epicenterPath = './.epicenter';
+	if (existsSync(epicenterPath)) {
+		console.log('Cleaning .epicenter folder...');
+		rmSync(epicenterPath, { recursive: true });
+	}
+}
+
+// Run benchmarks
+console.log('='.repeat(60));
+console.log('YJS Benchmark Suite');
+console.log('='.repeat(60));
+console.log(`Running ${benchmarksToRun.length} benchmark(s):`);
+for (const b of benchmarksToRun) {
+	console.log(`  ${b.id}. ${b.description}`);
+}
+console.log('='.repeat(60));
+
+const startTime = performance.now();
+const results: { benchmark: string; exitCode: number }[] = [];
+
+for (const benchmark of benchmarksToRun) {
+	const exitCode = await runBenchmark(benchmark);
+	results.push({ benchmark: benchmark.name, exitCode });
+
+	// Small delay between benchmarks to let things settle
+	if (benchmarksToRun.indexOf(benchmark) < benchmarksToRun.length - 1) {
+		console.log('\nWaiting 3 seconds before next benchmark...\n');
+		await new Promise((resolve) => setTimeout(resolve, 3000));
+	}
+}
+
+const totalTime = performance.now() - startTime;
+
+// Summary
+console.log('');
+console.log('█'.repeat(60));
+console.log('█ BENCHMARK SUITE COMPLETE');
+console.log('█'.repeat(60));
+console.log('');
+console.log(`Total time: ${(totalTime / 1000 / 60).toFixed(1)} minutes`);
+console.log('');
+console.log('Results:');
+for (const r of results) {
+	const status = r.exitCode === 0 ? '✓' : '✗';
+	console.log(`  ${status} ${r.benchmark}`);
+}
+
+const failed = results.filter((r) => r.exitCode !== 0);
+if (failed.length > 0) {
+	console.log(`\n${failed.length} benchmark(s) failed`);
+	process.exit(1);
+}
+
+console.log('\nAll benchmarks completed successfully!');

--- a/examples/stress-test/stress-test-mixed-workload.md
+++ b/examples/stress-test/stress-test-mixed-workload.md
@@ -1,0 +1,66 @@
+# Mixed Workload Benchmark
+
+Simulates realistic application usage with interleaved reads and writes.
+
+## What It Tests
+
+- Performance with mixed operation types
+- Overhead from operation switching
+- Realistic usage pattern behavior
+
+## Methodology
+
+Runs multiple rounds of mixed operations with configurable distribution:
+
+| Operation | Default % | Description |
+|-----------|-----------|-------------|
+| Upsert (new) | 30% | Create new items |
+| Upsert (update) | 30% | Update existing items |
+| Delete | 10% | Remove items |
+| Read (getAll) | 10% | Fetch all items |
+| Read (get) | 20% | Fetch single item |
+
+Default: 5 rounds × 1,000 operations = 5,000 total operations
+
+## Key Questions Answered
+
+- Does interleaving reads/writes affect performance?
+- Is there overhead from operation switching?
+- How does the system handle realistic usage patterns?
+
+## Expected Findings
+
+_Run the benchmark to populate this section with actual results._
+
+Typical patterns to look for:
+
+### Operation Throughput
+- Mixed workload typically slower than pure write tests
+- `getAll()` operations can dominate time budget
+- Single operations (`upsert`, `get`, `delete`) are fast
+
+### Performance Trends
+- Slight degradation expected as item count grows
+- `getAll()` slowdown most noticeable over rounds
+- Write operations should remain relatively stable
+
+### Operation Costs
+Expected average times (will vary by hardware):
+- `upsert()` single: ~0.1-0.5ms
+- `get()` single: ~0.01-0.1ms
+- `delete()` single: ~0.1-0.5ms
+- `getAll()`: scales with item count
+
+## Interpretation
+
+This benchmark answers: "What throughput can I expect in a real application?"
+
+Unlike pure write tests, mixed workloads:
+- Include read operations that don't add data
+- Exercise the full API surface
+- Show realistic degradation patterns
+
+For application planning:
+- Use these numbers to estimate if your workload fits
+- If `getAll()` dominates, consider using `filter()` or pagination
+- Single-item operations are cheap; use them liberally

--- a/examples/stress-test/stress-test-mixed-workload.ts
+++ b/examples/stress-test/stress-test-mixed-workload.ts
@@ -1,0 +1,325 @@
+/**
+ * YJS Mixed Workload Stress Test
+ *
+ * Simulates realistic application usage with interleaved reads and writes.
+ * Unlike pure write tests, this measures how the system performs when
+ * constantly switching between operations.
+ *
+ * The test performs rounds of mixed operations:
+ * - Upserts (new items)
+ * - Updates (existing items)
+ * - Deletes
+ * - Reads (getAll, get)
+ *
+ * Key questions this answers:
+ * - Does interleaving reads/writes affect performance?
+ * - Is there overhead from operation switching?
+ * - How does the system handle realistic usage patterns?
+ *
+ * @example
+ * ```bash
+ * bun run stress-test-mixed-workload.ts
+ *
+ * # Custom rounds
+ * bun run stress-test-mixed-workload.ts 10
+ *
+ * # Custom operations per round
+ * bun run stress-test-mixed-workload.ts 10 500
+ * ```
+ */
+
+import { existsSync, statSync, rmSync } from 'node:fs';
+import { createEpicenterClient, generateId } from '@epicenter/hq';
+import epicenterConfig from './epicenter.config';
+
+const ROUNDS = Number(process.argv[2]) || 5;
+const OPS_PER_ROUND = Number(process.argv[3]) || 1_000;
+
+// Operation distribution per round
+const DISTRIBUTION = {
+	upsertNew: 0.3, // 30% new items
+	upsertUpdate: 0.3, // 30% update existing
+	delete: 0.1, // 10% delete
+	readAll: 0.1, // 10% getAll
+	readSingle: 0.2, // 20% get single
+};
+
+const TABLE = 'items_a' as const;
+
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(2)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function formatTime(ms: number): string {
+	if (ms < 1000) return `${ms.toFixed(0)}ms`;
+	return `${(ms / 1000).toFixed(2)}s`;
+}
+
+function formatRate(count: number, ms: number): string {
+	const rate = (count / ms) * 1000;
+	if (rate >= 1000) return `${(rate / 1000).toFixed(1)}k/s`;
+	return `${rate.toFixed(0)}/s`;
+}
+
+function getYjsFileSize(): number | null {
+	const yjsPath = './.epicenter/stress.yjs';
+	if (existsSync(yjsPath)) {
+		return statSync(yjsPath).size;
+	}
+	return null;
+}
+
+console.log('='.repeat(60));
+console.log('YJS Mixed Workload Stress Test');
+console.log('='.repeat(60));
+console.log(`Rounds: ${ROUNDS}`);
+console.log(`Operations per round: ${OPS_PER_ROUND.toLocaleString()}`);
+console.log(`Total operations: ${(ROUNDS * OPS_PER_ROUND).toLocaleString()}`);
+console.log('');
+console.log('Operation distribution:');
+console.log(`  Upsert (new):    ${(DISTRIBUTION.upsertNew * 100).toFixed(0)}%`);
+console.log(`  Upsert (update): ${(DISTRIBUTION.upsertUpdate * 100).toFixed(0)}%`);
+console.log(`  Delete:          ${(DISTRIBUTION.delete * 100).toFixed(0)}%`);
+console.log(`  Read (getAll):   ${(DISTRIBUTION.readAll * 100).toFixed(0)}%`);
+console.log(`  Read (get):      ${(DISTRIBUTION.readSingle * 100).toFixed(0)}%`);
+console.log('='.repeat(60));
+console.log('');
+
+// Clean up any existing YJS file
+const yjsPath = './.epicenter/stress.yjs';
+if (existsSync(yjsPath)) {
+	console.log('Removing existing YJS file...');
+	rmSync(yjsPath);
+}
+
+const totalStart = performance.now();
+
+console.log('Creating client...');
+await using client = await createEpicenterClient(epicenterConfig);
+console.log('Client created\n');
+
+const stress = client.stress;
+const tableDb = stress[TABLE];
+
+// Track existing IDs
+const existingIds: string[] = [];
+
+// Track metrics per round
+type RoundMetrics = {
+	round: number;
+	totalOps: number;
+	duration: number;
+	opsPerSec: number;
+	opCounts: Record<string, number>;
+	opTimes: Record<string, number>;
+	itemCount: number;
+	fileSize: number | null;
+};
+
+const roundMetrics: RoundMetrics[] = [];
+
+// Seed with some initial data
+console.log('Seeding initial data (1000 items)...');
+const seedStart = performance.now();
+const seedItems = [];
+for (let i = 0; i < 1000; i++) {
+	const id = generateId();
+	existingIds.push(id);
+	seedItems.push({
+		id,
+		name: `Seed Item ${i}`,
+		value: i,
+		created_at: new Date().toISOString(),
+	});
+}
+tableDb.upsertMany({ rows: seedItems });
+console.log(`Seeded in ${formatTime(performance.now() - seedStart)}\n`);
+
+console.log('Starting mixed workload rounds...');
+console.log('-'.repeat(70));
+console.log('Round | Ops/sec    | Items   | File Size  | Operation breakdown');
+console.log('-'.repeat(70));
+
+for (let round = 1; round <= ROUNDS; round++) {
+	const roundStart = performance.now();
+	const opCounts: Record<string, number> = {
+		upsertNew: 0,
+		upsertUpdate: 0,
+		delete: 0,
+		readAll: 0,
+		readSingle: 0,
+	};
+	const opTimes: Record<string, number> = {
+		upsertNew: 0,
+		upsertUpdate: 0,
+		delete: 0,
+		readAll: 0,
+		readSingle: 0,
+	};
+
+	const now = new Date().toISOString();
+
+	for (let op = 0; op < OPS_PER_ROUND; op++) {
+		const rand = Math.random();
+		let cumulative = 0;
+
+		const opStart = performance.now();
+
+		// Upsert new
+		cumulative += DISTRIBUTION.upsertNew;
+		if (rand < cumulative) {
+			const id = generateId();
+			existingIds.push(id);
+			tableDb.upsert({
+				id,
+				name: `New Item ${round}-${op}`,
+				value: op,
+				created_at: now,
+			});
+			opCounts.upsertNew++;
+			opTimes.upsertNew += performance.now() - opStart;
+			continue;
+		}
+
+		// Upsert update (only if we have existing items)
+		cumulative += DISTRIBUTION.upsertUpdate;
+		if (rand < cumulative && existingIds.length > 0) {
+			const randomId = existingIds[Math.floor(Math.random() * existingIds.length)];
+			tableDb.upsert({
+				id: randomId,
+				name: `Updated Item ${round}-${op}`,
+				value: op * 10,
+				created_at: now,
+			});
+			opCounts.upsertUpdate++;
+			opTimes.upsertUpdate += performance.now() - opStart;
+			continue;
+		}
+
+		// Delete (only if we have enough items)
+		cumulative += DISTRIBUTION.delete;
+		if (rand < cumulative && existingIds.length > 100) {
+			const randomIndex = Math.floor(Math.random() * existingIds.length);
+			const idToDelete = existingIds[randomIndex];
+			existingIds.splice(randomIndex, 1);
+			tableDb.delete({ id: idToDelete });
+			opCounts.delete++;
+			opTimes.delete += performance.now() - opStart;
+			continue;
+		}
+
+		// Read all
+		cumulative += DISTRIBUTION.readAll;
+		if (rand < cumulative) {
+			tableDb.getAll();
+			opCounts.readAll++;
+			opTimes.readAll += performance.now() - opStart;
+			continue;
+		}
+
+		// Read single (fallback)
+		if (existingIds.length > 0) {
+			const randomId = existingIds[Math.floor(Math.random() * existingIds.length)];
+			tableDb.get({ id: randomId });
+			opCounts.readSingle++;
+			opTimes.readSingle += performance.now() - opStart;
+		}
+	}
+
+	const roundDuration = performance.now() - roundStart;
+
+	// Wait for persistence briefly
+	await new Promise((resolve) => setTimeout(resolve, 500));
+	const fileSize = getYjsFileSize();
+
+	const metrics: RoundMetrics = {
+		round,
+		totalOps: OPS_PER_ROUND,
+		duration: roundDuration,
+		opsPerSec: OPS_PER_ROUND / roundDuration * 1000,
+		opCounts,
+		opTimes,
+		itemCount: existingIds.length,
+		fileSize,
+	};
+	roundMetrics.push(metrics);
+
+	// Print row
+	const roundCol = round.toString().padStart(5);
+	const opsSecCol = formatRate(OPS_PER_ROUND, roundDuration).padStart(10);
+	const itemsCol = existingIds.length.toLocaleString().padStart(7);
+	const sizeCol = (fileSize ? formatBytes(fileSize) : 'N/A').padStart(10);
+
+	// Operation breakdown
+	const breakdown = Object.entries(opCounts)
+		.filter(([_, count]) => count > 0)
+		.map(([op, count]) => `${op.slice(0, 3)}:${count}`)
+		.join(' ');
+
+	console.log(`${roundCol} | ${opsSecCol} | ${itemsCol} | ${sizeCol} | ${breakdown}`);
+}
+
+console.log('-'.repeat(70));
+console.log('');
+
+// Wait for final persistence
+console.log('Waiting for YJS persistence (2s)...');
+await new Promise((resolve) => setTimeout(resolve, 2000));
+
+const totalElapsed = performance.now() - totalStart;
+
+// ============================================================================
+// Summary
+// ============================================================================
+console.log('');
+console.log('='.repeat(60));
+console.log('SUMMARY');
+console.log('='.repeat(60));
+console.log(`Total time: ${formatTime(totalElapsed)}`);
+console.log(`Total operations: ${(ROUNDS * OPS_PER_ROUND).toLocaleString()}`);
+console.log(`Final item count: ${existingIds.length.toLocaleString()}`);
+console.log(`Final file size: ${getYjsFileSize() ? formatBytes(getYjsFileSize()!) : 'N/A'}`);
+console.log('');
+
+// Performance trends
+if (roundMetrics.length >= 2) {
+	const first = roundMetrics[0];
+	const last = roundMetrics[roundMetrics.length - 1];
+
+	console.log('Performance trend:');
+	console.log(`  First round: ${formatRate(first.totalOps, first.duration)}`);
+	console.log(`  Last round:  ${formatRate(last.totalOps, last.duration)}`);
+
+	const slowdown = ((first.opsPerSec - last.opsPerSec) / first.opsPerSec * 100).toFixed(1);
+	if (parseFloat(slowdown) > 0) {
+		console.log(`  Slowdown: ${slowdown}% over ${ROUNDS} rounds`);
+	} else {
+		console.log(`  Speedup: ${Math.abs(parseFloat(slowdown))}% over ${ROUNDS} rounds`);
+	}
+}
+
+// Average times per operation type
+console.log('');
+console.log('Average time per operation type:');
+
+const totalOpCounts: Record<string, number> = {};
+const totalOpTimes: Record<string, number> = {};
+
+for (const m of roundMetrics) {
+	for (const [op, count] of Object.entries(m.opCounts)) {
+		totalOpCounts[op] = (totalOpCounts[op] || 0) + count;
+		totalOpTimes[op] = (totalOpTimes[op] || 0) + m.opTimes[op];
+	}
+}
+
+for (const op of Object.keys(totalOpCounts)) {
+	if (totalOpCounts[op] > 0) {
+		const avgTime = totalOpTimes[op] / totalOpCounts[op];
+		console.log(`  ${op.padEnd(12)}: ${formatTime(avgTime)} (${totalOpCounts[op].toLocaleString()} ops)`);
+	}
+}
+
+console.log('');
+console.log('Mixed workload stress test complete!');

--- a/examples/stress-test/stress-test-read-at-scale.md
+++ b/examples/stress-test/stress-test-read-at-scale.md
@@ -1,0 +1,53 @@
+# Read-at-Scale Benchmark
+
+Tests read performance as document size grows.
+
+## What It Tests
+
+- `getAll()` performance scaling with document size
+- Single-row `get()` lookup time at scale
+- `count()` operation overhead
+
+## Methodology
+
+1. Incrementally add data in batches (default 10k items per batch)
+2. After each batch, measure read performance
+3. Continue until target size (default 50k items)
+
+## Key Questions Answered
+
+- How does `getAll()` performance scale with document size?
+- Is single-row `get()` affected by document size?
+- What's the time complexity of each operation?
+
+## Expected Findings
+
+_Run the benchmark to populate this section with actual results._
+
+Typical patterns to look for:
+
+### getAll()
+- Should scale linearly O(n) with document size
+- At 50k items, expect 50-200ms depending on item complexity
+
+### get()
+- Should be roughly constant time O(1) due to Map-based lookup
+- YJS uses Y.Map internally, so key lookups should be fast
+- Slight degradation possible due to YJS internal structures
+
+### count()
+- Should be very fast, likely O(1)
+- YJS Map tracks size internally
+
+## Interpretation
+
+This benchmark helps determine:
+
+- When to paginate `getAll()` calls
+- Whether single-row lookups are viable at scale
+- If you need to cache counts or can call `count()` frequently
+
+For applications with large datasets:
+- Consider limiting `getAll()` to subsets using `filter()`
+- Rely on single-row `get()` for most operations
+- Use `count()` freely; it's typically very fast

--- a/examples/stress-test/stress-test-read-at-scale.md
+++ b/examples/stress-test/stress-test-read-at-scale.md
@@ -20,34 +20,44 @@ Tests read performance as document size grows.
 - Is single-row `get()` affected by document size?
 - What's the time complexity of each operation?
 
-## Expected Findings
+## Key Findings
 
-_Run the benchmark to populate this section with actual results._
+From a test incrementally loading 50k items:
 
-Typical patterns to look for:
+| Items | getAll() | get() (per call) | count() |
+|-------|----------|------------------|---------|
+| 10,000 | 24ms (417k/s) | 61µs | 2.1ms |
+| 20,000 | 34ms (582k/s) | 42µs | 2.9ms |
+| 30,000 | 149ms (201k/s) | 158µs | 2.4ms |
+| 40,000 | 69ms (584k/s) | 48µs | 3.6ms |
+| 50,000 | 58ms (862k/s) | 31µs | 6.3ms |
 
-### getAll()
-- Should scale linearly O(n) with document size
-- At 50k items, expect 50-200ms depending on item complexity
+### Scaling Analysis (10k → 50k items, 5x growth)
 
-### get()
-- Should be roughly constant time O(1) due to Map-based lookup
-- YJS uses Y.Map internally, so key lookups should be fast
-- Slight degradation possible due to YJS internal structures
+| Operation | Time at 10k | Time at 50k | Scaling |
+|-----------|-------------|-------------|---------|
+| getAll() | 24ms | 58ms | 2.4x slower |
+| get() | 61µs | 31µs | Actually faster |
+| count() | 2.1ms | 6.3ms | 3.0x slower |
 
-### count()
-- Should be very fast, likely O(1)
-- YJS Map tracks size internally
+### Complexity Estimates
+
+- **getAll()**: ~O(n) linear scaling (2.4x slowdown for 5x items = good sublinear behavior)
+- **get()**: ~O(1) constant time (actually got faster with more data, likely due to caching effects)
+- **count()**: ~O(1) to O(log n) (3x slowdown for 5x items)
+
+### Key Observations
+
+1. **getAll() is fast**: Even at 50k items, getAll() returns all rows in ~58ms at 862k items/second.
+
+2. **Single lookups are blazing fast**: get() operations average 31-61µs (microseconds), making single-row lookups viable at any scale.
+
+3. **Some measurement noise**: The 30k measurement shows higher times, likely due to system variance rather than algorithmic complexity.
 
 ## Interpretation
 
 This benchmark helps determine:
 
-- When to paginate `getAll()` calls
-- Whether single-row lookups are viable at scale
-- If you need to cache counts or can call `count()` frequently
-
-For applications with large datasets:
-- Consider limiting `getAll()` to subsets using `filter()`
-- Rely on single-row `get()` for most operations
-- Use `count()` freely; it's typically very fast
+- **When to paginate getAll()**: At 50k items, 58ms is acceptable. Consider pagination above 100k items.
+- **Single-row lookups are always viable**: Sub-100µs times mean you can call get() freely.
+- **count() is fast enough**: 2-6ms is negligible for most use cases.

--- a/examples/stress-test/stress-test-read-at-scale.ts
+++ b/examples/stress-test/stress-test-read-at-scale.ts
@@ -1,0 +1,223 @@
+/**
+ * YJS Read-at-Scale Stress Test
+ *
+ * Tests read performance as document size grows. This simulates real-world
+ * scenarios where applications need to query data from large datasets.
+ *
+ * The test performs:
+ * 1. Incrementally add data in batches
+ * 2. After each batch, measure read performance (getAll, get, count)
+ *
+ * Key questions this answers:
+ * - How does getAll() performance scale with document size?
+ * - How does single-row get() scale?
+ * - Is count() affected by document size?
+ *
+ * @example
+ * ```bash
+ * bun run stress-test-read-at-scale.ts
+ *
+ * # Custom total items
+ * bun run stress-test-read-at-scale.ts 50000
+ *
+ * # Custom batch size for measurements
+ * bun run stress-test-read-at-scale.ts 50000 10000
+ * ```
+ */
+
+import { existsSync, rmSync } from 'node:fs';
+import { createEpicenterClient, generateId } from '@epicenter/hq';
+import epicenterConfig from './epicenter.config';
+
+const TOTAL_ITEMS = Number(process.argv[2]) || 50_000;
+const MEASUREMENT_BATCH = Number(process.argv[3]) || 10_000;
+const INSERT_BATCH_SIZE = 1_000;
+
+// Use a single table for cleaner measurements
+const TABLE = 'items_a' as const;
+
+function formatTime(ms: number): string {
+	if (ms < 1) return `${(ms * 1000).toFixed(0)}µs`;
+	if (ms < 1000) return `${ms.toFixed(2)}ms`;
+	return `${(ms / 1000).toFixed(2)}s`;
+}
+
+function formatRate(count: number, ms: number): string {
+	const rate = (count / ms) * 1000;
+	if (rate >= 1_000_000) return `${(rate / 1_000_000).toFixed(1)}M/s`;
+	if (rate >= 1000) return `${(rate / 1000).toFixed(1)}k/s`;
+	return `${rate.toFixed(0)}/s`;
+}
+
+console.log('='.repeat(60));
+console.log('YJS Read-at-Scale Stress Test');
+console.log('='.repeat(60));
+console.log(`Total items to insert: ${TOTAL_ITEMS.toLocaleString()}`);
+console.log(`Measurement interval: every ${MEASUREMENT_BATCH.toLocaleString()} items`);
+console.log(`Insert batch size: ${INSERT_BATCH_SIZE.toLocaleString()}`);
+console.log('='.repeat(60));
+console.log('');
+
+// Clean up any existing YJS file
+const yjsPath = './.epicenter/stress.yjs';
+if (existsSync(yjsPath)) {
+	console.log('Removing existing YJS file...');
+	rmSync(yjsPath);
+}
+
+console.log('Creating client...');
+await using client = await createEpicenterClient(epicenterConfig);
+console.log('Client created\n');
+
+const stress = client.stress;
+const tableDb = stress[TABLE];
+
+// Track all IDs for random access tests
+const allIds: string[] = [];
+
+// Track metrics
+const metrics: {
+	itemCount: number;
+	getAllTime: number;
+	getAllRate: number;
+	getSingleTime: number;
+	getSingleRate: number;
+	countTime: number;
+}[] = [];
+
+console.log('Starting incremental load with read measurements...');
+console.log('-'.repeat(60));
+console.log('Items      | getAll()    | get() x100  | count()');
+console.log('-'.repeat(60));
+
+let totalInserted = 0;
+const now = new Date().toISOString();
+
+while (totalInserted < TOTAL_ITEMS) {
+	// Insert until next measurement point
+	const nextMeasurement = Math.min(
+		Math.ceil((totalInserted + 1) / MEASUREMENT_BATCH) * MEASUREMENT_BATCH,
+		TOTAL_ITEMS,
+	);
+
+	while (totalInserted < nextMeasurement) {
+		const batchCount = Math.min(INSERT_BATCH_SIZE, nextMeasurement - totalInserted);
+
+		const items = [];
+		for (let i = 0; i < batchCount; i++) {
+			const id = generateId();
+			allIds.push(id);
+			items.push({
+				id,
+				name: `Item ${totalInserted + i}`,
+				value: totalInserted + i,
+				created_at: now,
+			});
+		}
+
+		tableDb.upsertMany({ rows: items });
+		totalInserted += batchCount;
+	}
+
+	// Measure read performance at this point
+	// 1. getAll() - fetch all rows
+	const getAllStart = performance.now();
+	const allRows = tableDb.getAll();
+	const getAllTime = performance.now() - getAllStart;
+
+	// 2. get() - fetch 100 random rows
+	const sampleSize = Math.min(100, allIds.length);
+	const sampleIds = [];
+	for (let i = 0; i < sampleSize; i++) {
+		const randomIndex = Math.floor(Math.random() * allIds.length);
+		sampleIds.push(allIds[randomIndex]);
+	}
+
+	const getSingleStart = performance.now();
+	for (const id of sampleIds) {
+		tableDb.get({ id });
+	}
+	const getSingleTime = performance.now() - getSingleStart;
+	const avgGetTime = getSingleTime / sampleSize;
+
+	// 3. count() - get total count
+	const countStart = performance.now();
+	const count = tableDb.count();
+	const countTime = performance.now() - countStart;
+
+	// Record metrics
+	metrics.push({
+		itemCount: totalInserted,
+		getAllTime,
+		getAllRate: allRows.length / getAllTime * 1000,
+		getSingleTime: avgGetTime,
+		getSingleRate: 1 / avgGetTime * 1000,
+		countTime,
+	});
+
+	// Print row
+	const itemsCol = totalInserted.toLocaleString().padStart(10);
+	const getAllCol = `${formatTime(getAllTime)} (${formatRate(allRows.length, getAllTime)})`.padStart(11);
+	const getCol = `${formatTime(avgGetTime)}/ea`.padStart(11);
+	const countCol = formatTime(countTime).padStart(10);
+
+	console.log(`${itemsCol} | ${getAllCol} | ${getCol} | ${countCol}`);
+}
+
+console.log('-'.repeat(60));
+console.log('');
+
+// ============================================================================
+// Summary
+// ============================================================================
+console.log('='.repeat(60));
+console.log('SUMMARY');
+console.log('='.repeat(60));
+
+if (metrics.length >= 2) {
+	const first = metrics[0];
+	const last = metrics[metrics.length - 1];
+
+	console.log('');
+	console.log('Scaling analysis (first vs last measurement):');
+	console.log('-'.repeat(60));
+
+	// getAll scaling
+	const getAllSlowdown = (last.getAllTime / first.getAllTime).toFixed(2);
+	const itemsRatio = (last.itemCount / first.itemCount).toFixed(1);
+	console.log(`  Items grew: ${first.itemCount.toLocaleString()} → ${last.itemCount.toLocaleString()} (${itemsRatio}x)`);
+	console.log(`  getAll() time: ${formatTime(first.getAllTime)} → ${formatTime(last.getAllTime)} (${getAllSlowdown}x slower)`);
+
+	// get() scaling
+	const getSlowdown = (last.getSingleTime / first.getSingleTime).toFixed(2);
+	console.log(`  get() time: ${formatTime(first.getSingleTime)} → ${formatTime(last.getSingleTime)} (${getSlowdown}x slower)`);
+
+	// count() scaling
+	const countSlowdown = (last.countTime / first.countTime).toFixed(2);
+	console.log(`  count() time: ${formatTime(first.countTime)} → ${formatTime(last.countTime)} (${countSlowdown}x slower)`);
+
+	// Complexity analysis
+	console.log('');
+	console.log('Complexity estimate:');
+
+	const getAllComplexity = parseFloat(getAllSlowdown) / parseFloat(itemsRatio);
+	if (getAllComplexity < 1.2) {
+		console.log(`  getAll(): ~O(n) - linear scaling (${getAllComplexity.toFixed(2)}x per ${itemsRatio}x items)`);
+	} else if (getAllComplexity < 2) {
+		console.log(`  getAll(): ~O(n log n) - slightly superlinear (${getAllComplexity.toFixed(2)}x per ${itemsRatio}x items)`);
+	} else {
+		console.log(`  getAll(): ~O(n²) or worse - concerning (${getAllComplexity.toFixed(2)}x per ${itemsRatio}x items)`);
+	}
+
+	const getComplexity = parseFloat(getSlowdown);
+	if (getComplexity < 1.5) {
+		console.log(`  get(): ~O(1) - constant time (${getSlowdown}x over ${itemsRatio}x items)`);
+	} else if (getComplexity < parseFloat(itemsRatio)) {
+		console.log(`  get(): ~O(log n) - logarithmic (${getSlowdown}x over ${itemsRatio}x items)`);
+	} else {
+		console.log(`  get(): ~O(n) or worse - linear scan (${getSlowdown}x over ${itemsRatio}x items)`);
+	}
+}
+
+console.log('');
+console.log('Read-at-scale stress test complete!');

--- a/examples/stress-test/stress-test-update-heavy.md
+++ b/examples/stress-test/stress-test-update-heavy.md
@@ -20,15 +20,33 @@ Tests performance when repeatedly updating existing rows vs creating new ones.
 - Does update performance degrade over multiple rounds?
 - How does file size grow with updates vs inserts?
 
-## Expected Findings
+## Key Findings
 
-_Run the benchmark to populate this section with actual results._
+From a test with 25k items (5k items × 5 tables):
 
-Typical patterns to look for:
+| Phase | Items | Rate | File Size |
+|-------|-------|------|-----------|
+| Initial Setup | 25,000 | 51.7k/s | 3.58 MB |
+| Update Round 1 | 25,000 | 31.5k/s | 4.69 MB |
+| Update Round 2 | 25,000 | 23.5k/s | 5.65 MB |
+| Update Round 3 | 25,000 | 20.6k/s | 6.61 MB |
 
-- **Update vs Insert speed**: Updates should be similar or slightly slower than inserts since both operations need to locate and modify data
-- **File growth**: Each update round should add some overhead due to operation history, but less than an equivalent insert
-- **Degradation**: Performance may degrade slightly over rounds as the YJS document accumulates more history
+### Key Observations
+
+1. **Updates are ~40% of setup speed**: The last update round ran at 20.6k/s vs initial setup at 51.7k/s (39.9% relative speed).
+
+2. **File grows ~1 MB per update round**: Each round of updating all 25k items added approximately 1 MB to the file size.
+
+3. **Consistent degradation**: Performance decreases predictably with each round as YJS accumulates more operation history.
+
+4. **Total overhead**: After 3 update rounds, file size grew 84.5% (from 3.58 MB to 6.61 MB).
+
+### Update vs Insert Comparison
+
+| Metric | Initial Insert | Update (Round 3) |
+|--------|---------------|------------------|
+| Speed | 51.7k/s | 20.6k/s |
+| Bytes/item | ~143 bytes | +40 bytes/update |
 
 ## Interpretation
 
@@ -37,3 +55,5 @@ This benchmark simulates applications where data is frequently modified rather t
 - Note-taking apps where users edit existing notes
 - Task managers where task status changes frequently
 - Form builders where field values are updated
+
+The ~40% speed ratio for updates vs inserts is reasonable for CRDT operations, and the ~1 MB per update round is predictable for capacity planning.

--- a/examples/stress-test/stress-test-update-heavy.md
+++ b/examples/stress-test/stress-test-update-heavy.md
@@ -1,0 +1,39 @@
+# Update-Heavy Workload Benchmark
+
+Tests performance when repeatedly updating existing rows vs creating new ones.
+
+## What It Tests
+
+- Update performance compared to initial upsert
+- Performance degradation over multiple update rounds
+- File size growth from updates vs inserts
+
+## Methodology
+
+1. **Setup**: Create initial dataset (5k items × 5 tables = 25k items)
+2. **Update rounds**: Repeatedly update all rows multiple times (default 3 rounds)
+3. Measure performance and file size after each phase
+
+## Key Questions Answered
+
+- How does update performance compare to initial upsert?
+- Does update performance degrade over multiple rounds?
+- How does file size grow with updates vs inserts?
+
+## Expected Findings
+
+_Run the benchmark to populate this section with actual results._
+
+Typical patterns to look for:
+
+- **Update vs Insert speed**: Updates should be similar or slightly slower than inserts since both operations need to locate and modify data
+- **File growth**: Each update round should add some overhead due to operation history, but less than an equivalent insert
+- **Degradation**: Performance may degrade slightly over rounds as the YJS document accumulates more history
+
+## Interpretation
+
+This benchmark simulates applications where data is frequently modified rather than just appended. Common use cases include:
+
+- Note-taking apps where users edit existing notes
+- Task managers where task status changes frequently
+- Form builders where field values are updated

--- a/examples/stress-test/stress-test-update-heavy.ts
+++ b/examples/stress-test/stress-test-update-heavy.ts
@@ -30,6 +30,20 @@ import { existsSync, statSync, rmSync } from 'node:fs';
 import { createEpicenterClient, generateId } from '@epicenter/hq';
 import epicenterConfig from './epicenter.config';
 
+// TTY helpers for progress output
+const isTTY = process.stdout.isTTY;
+const clearLine = () => {
+	if (isTTY) {
+		process.stdout.clearLine(0);
+		process.stdout.cursorTo(0);
+	}
+};
+const writeLine = (text: string) => {
+	if (isTTY) {
+		process.stdout.write(text);
+	}
+};
+
 const ITEMS_PER_TABLE = Number(process.argv[2]) || 5_000;
 const UPDATE_ROUNDS = Number(process.argv[3]) || 3;
 const BATCH_SIZE = 1_000;
@@ -121,9 +135,7 @@ for (let tableIndex = 0; tableIndex < TABLES.length; tableIndex++) {
 	const tableStart = performance.now();
 	const tableIds = allIds.get(table)!;
 
-	process.stdout.write(
-		`[${tableIndex + 1}/${TABLES.length}] ${table}: 0/${ITEMS_PER_TABLE.toLocaleString()}`,
-	);
+	writeLine(`[${tableIndex + 1}/${TABLES.length}] ${table}: 0/${ITEMS_PER_TABLE.toLocaleString()}`);
 
 	const now = new Date().toISOString();
 	const tableDb = stress[table];
@@ -147,16 +159,12 @@ for (let tableIndex = 0; tableIndex < TABLES.length; tableIndex++) {
 		tableDb.upsertMany({ rows: items });
 		inserted += batchCount;
 
-		process.stdout.clearLine(0);
-		process.stdout.cursorTo(0);
-		process.stdout.write(
-			`[${tableIndex + 1}/${TABLES.length}] ${table}: ${inserted.toLocaleString()}/${ITEMS_PER_TABLE.toLocaleString()}`,
-		);
+		clearLine();
+		writeLine(`[${tableIndex + 1}/${TABLES.length}] ${table}: ${inserted.toLocaleString()}/${ITEMS_PER_TABLE.toLocaleString()}`);
 	}
 
 	const tableElapsed = performance.now() - tableStart;
-	process.stdout.clearLine(0);
-	process.stdout.cursorTo(0);
+	clearLine();
 	console.log(
 		`[${tableIndex + 1}/${TABLES.length}] ${table}: ${ITEMS_PER_TABLE.toLocaleString()} items in ${formatTime(tableElapsed)} (avg ${formatRate(ITEMS_PER_TABLE, tableElapsed)})`,
 	);
@@ -198,9 +206,7 @@ for (let round = 1; round <= UPDATE_ROUNDS; round++) {
 		const tableIds = allIds.get(table)!;
 		const tableDb = stress[table];
 
-		process.stdout.write(
-			`[${tableIndex + 1}/${TABLES.length}] ${table}: 0/${tableIds.length.toLocaleString()}`,
-		);
+		writeLine(`[${tableIndex + 1}/${TABLES.length}] ${table}: 0/${tableIds.length.toLocaleString()}`);
 
 		const now = new Date().toISOString();
 		let updated = 0;
@@ -220,16 +226,12 @@ for (let round = 1; round <= UPDATE_ROUNDS; round++) {
 			tableDb.upsertMany({ rows: items });
 			updated += batchCount;
 
-			process.stdout.clearLine(0);
-			process.stdout.cursorTo(0);
-			process.stdout.write(
-				`[${tableIndex + 1}/${TABLES.length}] ${table}: ${updated.toLocaleString()}/${tableIds.length.toLocaleString()}`,
-			);
+			clearLine();
+			writeLine(`[${tableIndex + 1}/${TABLES.length}] ${table}: ${updated.toLocaleString()}/${tableIds.length.toLocaleString()}`);
 		}
 
 		const tableElapsed = performance.now() - tableStart;
-		process.stdout.clearLine(0);
-		process.stdout.cursorTo(0);
+		clearLine();
 		console.log(
 			`[${tableIndex + 1}/${TABLES.length}] ${table}: ${tableIds.length.toLocaleString()} items in ${formatTime(tableElapsed)} (avg ${formatRate(tableIds.length, tableElapsed)})`,
 		);

--- a/examples/stress-test/stress-test-update-heavy.ts
+++ b/examples/stress-test/stress-test-update-heavy.ts
@@ -1,0 +1,305 @@
+/**
+ * YJS Update-Heavy Stress Test
+ *
+ * Tests performance when repeatedly updating existing rows vs creating new ones.
+ * This simulates real-world scenarios where data is frequently modified rather
+ * than just inserted.
+ *
+ * The test performs:
+ * 1. Setup: Create initial dataset
+ * 2. Update rounds: Repeatedly update all rows multiple times
+ *
+ * Key questions this answers:
+ * - How does update performance compare to initial upsert?
+ * - Does update performance degrade over multiple rounds?
+ * - How does file size grow with updates vs inserts?
+ *
+ * @example
+ * ```bash
+ * bun run stress-test-update-heavy.ts
+ *
+ * # Custom item count
+ * bun run stress-test-update-heavy.ts 5000
+ *
+ * # Custom update rounds
+ * bun run stress-test-update-heavy.ts 5000 5
+ * ```
+ */
+
+import { existsSync, statSync, rmSync } from 'node:fs';
+import { createEpicenterClient, generateId } from '@epicenter/hq';
+import epicenterConfig from './epicenter.config';
+
+const ITEMS_PER_TABLE = Number(process.argv[2]) || 5_000;
+const UPDATE_ROUNDS = Number(process.argv[3]) || 3;
+const BATCH_SIZE = 1_000;
+
+const TABLES = [
+	'items_a',
+	'items_b',
+	'items_c',
+	'items_d',
+	'items_e',
+] as const;
+
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(2)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function formatTime(ms: number): string {
+	if (ms < 1000) return `${ms.toFixed(0)}ms`;
+	return `${(ms / 1000).toFixed(2)}s`;
+}
+
+function formatRate(count: number, ms: number): string {
+	const rate = (count / ms) * 1000;
+	if (rate >= 1000) return `${(rate / 1000).toFixed(1)}k/s`;
+	return `${rate.toFixed(0)}/s`;
+}
+
+function getYjsFileSize(): number | null {
+	const yjsPath = './.epicenter/stress.yjs';
+	if (existsSync(yjsPath)) {
+		return statSync(yjsPath).size;
+	}
+	return null;
+}
+
+console.log('='.repeat(60));
+console.log('YJS Update-Heavy Stress Test');
+console.log('='.repeat(60));
+console.log(`Items per table: ${ITEMS_PER_TABLE.toLocaleString()}`);
+console.log(`Update rounds: ${UPDATE_ROUNDS}`);
+console.log(`Batch size: ${BATCH_SIZE.toLocaleString()}`);
+console.log(`Total tables: ${TABLES.length}`);
+console.log(`Total items: ${(ITEMS_PER_TABLE * TABLES.length).toLocaleString()}`);
+console.log('='.repeat(60));
+console.log('');
+
+// Clean up any existing YJS file
+const yjsPath = './.epicenter/stress.yjs';
+if (existsSync(yjsPath)) {
+	console.log('Removing existing YJS file...');
+	rmSync(yjsPath);
+}
+
+const totalStart = performance.now();
+
+console.log('Creating client...');
+await using client = await createEpicenterClient(epicenterConfig);
+console.log('Client created\n');
+
+const stress = client.stress;
+
+// Track IDs for updates
+const allIds: Map<(typeof TABLES)[number], string[]> = new Map();
+for (const table of TABLES) {
+	allIds.set(table, []);
+}
+
+// Track metrics
+const metrics: {
+	phase: string;
+	duration: number;
+	itemCount: number;
+	rate: number;
+	fileSize: number | null;
+}[] = [];
+
+// ============================================================================
+// PHASE 1: Initial Setup (Create data)
+// ============================================================================
+console.log('PHASE 1: Initial Setup');
+console.log('-'.repeat(60));
+
+const phase1Start = performance.now();
+
+for (let tableIndex = 0; tableIndex < TABLES.length; tableIndex++) {
+	const table = TABLES[tableIndex];
+	const tableStart = performance.now();
+	const tableIds = allIds.get(table)!;
+
+	process.stdout.write(
+		`[${tableIndex + 1}/${TABLES.length}] ${table}: 0/${ITEMS_PER_TABLE.toLocaleString()}`,
+	);
+
+	const now = new Date().toISOString();
+	const tableDb = stress[table];
+
+	let inserted = 0;
+	while (inserted < ITEMS_PER_TABLE) {
+		const batchCount = Math.min(BATCH_SIZE, ITEMS_PER_TABLE - inserted);
+
+		const items = [];
+		for (let i = 0; i < batchCount; i++) {
+			const id = generateId();
+			tableIds.push(id);
+			items.push({
+				id,
+				name: `Item ${inserted + i}`,
+				value: inserted + i,
+				created_at: now,
+			});
+		}
+
+		tableDb.upsertMany({ rows: items });
+		inserted += batchCount;
+
+		process.stdout.clearLine(0);
+		process.stdout.cursorTo(0);
+		process.stdout.write(
+			`[${tableIndex + 1}/${TABLES.length}] ${table}: ${inserted.toLocaleString()}/${ITEMS_PER_TABLE.toLocaleString()}`,
+		);
+	}
+
+	const tableElapsed = performance.now() - tableStart;
+	process.stdout.clearLine(0);
+	process.stdout.cursorTo(0);
+	console.log(
+		`[${tableIndex + 1}/${TABLES.length}] ${table}: ${ITEMS_PER_TABLE.toLocaleString()} items in ${formatTime(tableElapsed)} (avg ${formatRate(ITEMS_PER_TABLE, tableElapsed)})`,
+	);
+}
+
+const phase1Elapsed = performance.now() - phase1Start;
+const phase1Total = ITEMS_PER_TABLE * TABLES.length;
+
+console.log('');
+console.log(`Phase 1 complete: ${phase1Total.toLocaleString()} items in ${formatTime(phase1Elapsed)}`);
+
+console.log('Waiting for YJS persistence (2s)...');
+await new Promise((resolve) => setTimeout(resolve, 2000));
+const sizeAfterSetup = getYjsFileSize();
+console.log(`YJS file size after setup: ${sizeAfterSetup ? formatBytes(sizeAfterSetup) : 'N/A'}`);
+
+metrics.push({
+	phase: 'Initial Setup',
+	duration: phase1Elapsed,
+	itemCount: phase1Total,
+	rate: phase1Total / phase1Elapsed * 1000,
+	fileSize: sizeAfterSetup,
+});
+
+console.log('');
+
+// ============================================================================
+// UPDATE ROUNDS
+// ============================================================================
+for (let round = 1; round <= UPDATE_ROUNDS; round++) {
+	console.log(`UPDATE ROUND ${round}/${UPDATE_ROUNDS}`);
+	console.log('-'.repeat(60));
+
+	const roundStart = performance.now();
+
+	for (let tableIndex = 0; tableIndex < TABLES.length; tableIndex++) {
+		const table = TABLES[tableIndex];
+		const tableStart = performance.now();
+		const tableIds = allIds.get(table)!;
+		const tableDb = stress[table];
+
+		process.stdout.write(
+			`[${tableIndex + 1}/${TABLES.length}] ${table}: 0/${tableIds.length.toLocaleString()}`,
+		);
+
+		const now = new Date().toISOString();
+		let updated = 0;
+
+		while (updated < tableIds.length) {
+			const batchCount = Math.min(BATCH_SIZE, tableIds.length - updated);
+			const batchIds = tableIds.slice(updated, updated + batchCount);
+
+			const items = batchIds.map((id, i) => ({
+				id,
+				name: `Item v${round + 1} ${updated + i}`,
+				value: (updated + i) * (round + 1),
+				created_at: now,
+			}));
+
+			// Use upsertMany for updates (since updateMany requires all rows to exist)
+			tableDb.upsertMany({ rows: items });
+			updated += batchCount;
+
+			process.stdout.clearLine(0);
+			process.stdout.cursorTo(0);
+			process.stdout.write(
+				`[${tableIndex + 1}/${TABLES.length}] ${table}: ${updated.toLocaleString()}/${tableIds.length.toLocaleString()}`,
+			);
+		}
+
+		const tableElapsed = performance.now() - tableStart;
+		process.stdout.clearLine(0);
+		process.stdout.cursorTo(0);
+		console.log(
+			`[${tableIndex + 1}/${TABLES.length}] ${table}: ${tableIds.length.toLocaleString()} items in ${formatTime(tableElapsed)} (avg ${formatRate(tableIds.length, tableElapsed)})`,
+		);
+	}
+
+	const roundElapsed = performance.now() - roundStart;
+	const roundTotal = ITEMS_PER_TABLE * TABLES.length;
+
+	console.log('');
+	console.log(`Round ${round} complete: ${roundTotal.toLocaleString()} updates in ${formatTime(roundElapsed)}`);
+
+	console.log('Waiting for YJS persistence (2s)...');
+	await new Promise((resolve) => setTimeout(resolve, 2000));
+	const sizeAfterRound = getYjsFileSize();
+	console.log(`YJS file size after round ${round}: ${sizeAfterRound ? formatBytes(sizeAfterRound) : 'N/A'}`);
+
+	metrics.push({
+		phase: `Update Round ${round}`,
+		duration: roundElapsed,
+		itemCount: roundTotal,
+		rate: roundTotal / roundElapsed * 1000,
+		fileSize: sizeAfterRound,
+	});
+
+	console.log('');
+}
+
+// ============================================================================
+// Summary
+// ============================================================================
+const totalElapsed = performance.now() - totalStart;
+
+console.log('='.repeat(60));
+console.log('SUMMARY');
+console.log('='.repeat(60));
+console.log(`Total time: ${formatTime(totalElapsed)}`);
+console.log('');
+
+console.log('Performance by phase:');
+console.log('-'.repeat(60));
+console.log('Phase                  | Items      | Rate       | File Size');
+console.log('-'.repeat(60));
+
+for (const m of metrics) {
+	const phase = m.phase.padEnd(22);
+	const items = m.itemCount.toLocaleString().padStart(10);
+	const rate = formatRate(m.itemCount, m.duration).padStart(10);
+	const size = m.fileSize ? formatBytes(m.fileSize).padStart(10) : 'N/A'.padStart(10);
+	console.log(`${phase} | ${items} | ${rate} | ${size}`);
+}
+
+console.log('-'.repeat(60));
+
+// Calculate trends
+if (metrics.length >= 2) {
+	const setupRate = metrics[0].rate;
+	const lastUpdateRate = metrics[metrics.length - 1].rate;
+	const updateVsSetup = ((lastUpdateRate / setupRate) * 100).toFixed(1);
+
+	console.log('');
+	console.log('Key findings:');
+	console.log(`  Update rate vs initial: ${updateVsSetup}% of setup speed`);
+
+	if (metrics[0].fileSize && metrics[metrics.length - 1].fileSize) {
+		const sizeGrowth = metrics[metrics.length - 1].fileSize - metrics[0].fileSize;
+		const growthPercent = ((sizeGrowth / metrics[0].fileSize) * 100).toFixed(1);
+		console.log(`  File size growth: +${formatBytes(sizeGrowth)} (+${growthPercent}%)`);
+		console.log(`  Bytes per update round: ~${formatBytes(sizeGrowth / UPDATE_ROUNDS)}`);
+	}
+}
+
+console.log('');
+console.log('Update-heavy stress test complete!');

--- a/examples/stress-test/stress-test-write-delete-write.md
+++ b/examples/stress-test/stress-test-write-delete-write.md
@@ -1,0 +1,35 @@
+# Write-Delete-Write Benchmark
+
+Tests YJS file size behavior through a complete data lifecycle: create → delete → recreate.
+
+## What It Tests
+
+- How YJS handles tombstones from deletions
+- Whether file size grows unboundedly with delete operations
+- Performance characteristics across the full lifecycle
+
+## Key Findings
+
+From a test with 100k items (10k per table × 10 tables):
+
+| Phase | File Size | Notes |
+|-------|-----------|-------|
+| After Write (100k items) | 14.39 MB | ~144 bytes/item |
+| After Delete (0 items) | 2.58 MB | 82% reduction |
+| After Write Again (100k items) | 17.35 MB | ~174 bytes/item |
+
+### Surprising Results
+
+1. **File shrinks after deletion**: The YJS file reduced by 82% after deleting all items, contrary to the expectation that CRDT tombstones would grow the file.
+
+2. **Minimal overhead for full cycle**: Final size (17.35 MB) is only 21% larger than initial write (14.39 MB). This 1.21x ratio means YJS efficiently stores the complete operation history.
+
+3. **Delete is slower than upsert**: Deletion ran at ~9-18k items/sec vs upsert at ~10-62k items/sec.
+
+4. **Second write is slower**: Phase 3 averaged ~8-20k/s vs Phase 1's ~10-62k/s, likely due to YJS managing more internal structures.
+
+## Interpretation
+
+YJS handles write-delete-write cycles efficiently. Even with full tombstone history, you're paying only ~21% storage overhead. This makes it viable for applications where data is frequently deleted and recreated.
+
+The file shrinkage after deletion is particularly interesting; it suggests YJS may be doing some form of compaction or the deleted entries don't add as much overhead as expected.

--- a/examples/stress-test/stress-test-write-delete-write.ts
+++ b/examples/stress-test/stress-test-write-delete-write.ts
@@ -6,9 +6,9 @@
  * with deletions.
  *
  * The test performs 3 phases:
- * 1. Write: Insert 10k items across all tables
+ * 1. Write: Upsert 10k items across all tables
  * 2. Delete: Delete all 10k items
- * 3. Write: Insert 10k items again
+ * 3. Write: Upsert 10k items again
  *
  * @example
  * ```bash
@@ -134,7 +134,7 @@ for (let tableIndex = 0; tableIndex < TABLES.length; tableIndex++) {
 			});
 		}
 
-		tableDb.insertMany({ rows: items });
+		tableDb.upsertMany({ rows: items });
 		inserted += batchCount;
 
 		const batchElapsed = performance.now() - batchStart;
@@ -267,7 +267,7 @@ for (let tableIndex = 0; tableIndex < TABLES.length; tableIndex++) {
 			});
 		}
 
-		tableDb.insertMany({ rows: items });
+		tableDb.upsertMany({ rows: items });
 		inserted += batchCount;
 
 		const batchElapsed = performance.now() - batchStart;

--- a/examples/stress-test/stress-test-write-delete-write.ts
+++ b/examples/stress-test/stress-test-write-delete-write.ts
@@ -56,6 +56,20 @@ function formatRate(count: number, ms: number): string {
 	return `${rate.toFixed(0)}/s`;
 }
 
+// TTY helpers for progress output
+const isTTY = process.stdout.isTTY;
+const clearLine = () => {
+	if (isTTY) {
+		process.stdout.clearLine(0);
+		process.stdout.cursorTo(0);
+	}
+};
+const writeLine = (text: string) => {
+	if (isTTY) {
+		process.stdout.write(text);
+	}
+};
+
 function getYjsFileSize(): number | null {
 	const yjsPath = './.epicenter/stress.yjs';
 	if (existsSync(yjsPath)) {
@@ -110,7 +124,7 @@ for (let tableIndex = 0; tableIndex < TABLES.length; tableIndex++) {
 	const tableStart = performance.now();
 	const tableIds = allIds.get(table)!;
 
-	process.stdout.write(
+	writeLine(
 		`[${tableIndex + 1}/${TABLES.length}] ${table}: 0/${ITEMS_PER_TABLE.toLocaleString()}`,
 	);
 
@@ -141,17 +155,15 @@ for (let tableIndex = 0; tableIndex < TABLES.length; tableIndex++) {
 		const totalElapsed = performance.now() - tableStart;
 		const rate = formatRate(batchCount, batchElapsed);
 
-		process.stdout.clearLine(0);
-		process.stdout.cursorTo(0);
-		process.stdout.write(
+		clearLine();
+		writeLine(
 			`[${tableIndex + 1}/${TABLES.length}] ${table}: ${inserted.toLocaleString()}/${ITEMS_PER_TABLE.toLocaleString()} (batch: ${rate}, elapsed: ${formatTime(totalElapsed)})`,
 		);
 	}
 
 	const tableElapsed = performance.now() - tableStart;
 
-	process.stdout.clearLine(0);
-	process.stdout.cursorTo(0);
+	clearLine();
 	console.log(
 		`[${tableIndex + 1}/${TABLES.length}] ${table}: ${ITEMS_PER_TABLE.toLocaleString()} items in ${formatTime(tableElapsed)} (avg ${formatRate(ITEMS_PER_TABLE, tableElapsed)})`,
 	);
@@ -185,7 +197,7 @@ for (let tableIndex = 0; tableIndex < TABLES.length; tableIndex++) {
 	const tableIds = allIds.get(table)!;
 	const tableDb = stress[table];
 
-	process.stdout.write(
+	writeLine(
 		`[${tableIndex + 1}/${TABLES.length}] ${table}: 0/${tableIds.length.toLocaleString()}`,
 	);
 
@@ -203,17 +215,15 @@ for (let tableIndex = 0; tableIndex < TABLES.length; tableIndex++) {
 		const totalElapsed = performance.now() - tableStart;
 		const rate = formatRate(batchCount, batchElapsed);
 
-		process.stdout.clearLine(0);
-		process.stdout.cursorTo(0);
-		process.stdout.write(
+		clearLine();
+		writeLine(
 			`[${tableIndex + 1}/${TABLES.length}] ${table}: ${deleted.toLocaleString()}/${tableIds.length.toLocaleString()} (batch: ${rate}, elapsed: ${formatTime(totalElapsed)})`,
 		);
 	}
 
 	const tableElapsed = performance.now() - tableStart;
 
-	process.stdout.clearLine(0);
-	process.stdout.cursorTo(0);
+	clearLine();
 	console.log(
 		`[${tableIndex + 1}/${TABLES.length}] ${table}: ${tableIds.length.toLocaleString()} items in ${formatTime(tableElapsed)} (avg ${formatRate(tableIds.length, tableElapsed)})`,
 	);
@@ -245,7 +255,7 @@ for (let tableIndex = 0; tableIndex < TABLES.length; tableIndex++) {
 	const table = TABLES[tableIndex];
 	const tableStart = performance.now();
 
-	process.stdout.write(
+	writeLine(
 		`[${tableIndex + 1}/${TABLES.length}] ${table}: 0/${ITEMS_PER_TABLE.toLocaleString()}`,
 	);
 
@@ -274,17 +284,15 @@ for (let tableIndex = 0; tableIndex < TABLES.length; tableIndex++) {
 		const totalElapsed = performance.now() - tableStart;
 		const rate = formatRate(batchCount, batchElapsed);
 
-		process.stdout.clearLine(0);
-		process.stdout.cursorTo(0);
-		process.stdout.write(
+		clearLine();
+		writeLine(
 			`[${tableIndex + 1}/${TABLES.length}] ${table}: ${inserted.toLocaleString()}/${ITEMS_PER_TABLE.toLocaleString()} (batch: ${rate}, elapsed: ${formatTime(totalElapsed)})`,
 		);
 	}
 
 	const tableElapsed = performance.now() - tableStart;
 
-	process.stdout.clearLine(0);
-	process.stdout.cursorTo(0);
+	clearLine();
 	console.log(
 		`[${tableIndex + 1}/${TABLES.length}] ${table}: ${ITEMS_PER_TABLE.toLocaleString()} items in ${formatTime(tableElapsed)} (avg ${formatRate(ITEMS_PER_TABLE, tableElapsed)})`,
 	);

--- a/examples/stress-test/stress-test.md
+++ b/examples/stress-test/stress-test.md
@@ -1,0 +1,42 @@
+# Bulk Upsert Benchmark
+
+Tests raw `upsertMany` throughput across multiple tables with large datasets.
+
+## What It Tests
+
+- Maximum upsert throughput using batched operations
+- File size growth patterns as data accumulates
+- Performance degradation as document grows
+
+## Key Findings
+
+### upsertMany vs upsert: ~500x Difference
+
+| Method | Speed | Why |
+|--------|-------|-----|
+| `upsert()` | ~34/s | Each call = separate YJS transaction |
+| `upsertMany()` | ~20,000/s | Single YJS transaction for all rows |
+
+Always use `upsertMany({ rows: [...] })` for bulk operations.
+
+### Performance Degradation at Scale
+
+From a 1M item test:
+
+| Items in Doc | Speed | File Size |
+|--------------|-------|-----------|
+| 100k | 7.4k/s | ~10 MB |
+| 200k | 3.0k/s | ~20 MB |
+| 300k | 1.5k/s | ~30 MB |
+| 400k | 1.1k/s | ~40 MB |
+| 500k+ | <700/s | 50+ MB |
+
+### Recommended Limits
+
+- **< 100k items per workspace**: Fast, no noticeable degradation
+- **100k-300k items**: Acceptable with some slowdown
+- **300k+ items**: Consider splitting into multiple workspaces
+
+## Interpretation
+
+The slowdown is expected; larger YJS documents mean more work per transaction. For very large datasets, use separate workspaces to keep each YJS document smaller.

--- a/examples/stress-test/stress-test.md
+++ b/examples/stress-test/stress-test.md
@@ -21,22 +21,35 @@ Always use `upsertMany({ rows: [...] })` for bulk operations.
 
 ### Performance Degradation at Scale
 
-From a 1M item test:
+From a 100k item test (10k items × 10 tables):
 
-| Items in Doc | Speed | File Size |
-|--------------|-------|-----------|
-| 100k | 7.4k/s | ~10 MB |
-| 200k | 3.0k/s | ~20 MB |
-| 300k | 1.5k/s | ~30 MB |
-| 400k | 1.1k/s | ~40 MB |
-| 500k+ | <700/s | 50+ MB |
+| Table # | Speed | Cumulative Items |
+|---------|-------|------------------|
+| 1 | 64.4k/s | 10k |
+| 2 | 48.2k/s | 20k |
+| 3 | 35.1k/s | 30k |
+| 5 | 23.9k/s | 50k |
+| 7 | 16.6k/s | 70k |
+| 10 | 11.5k/s | 100k |
+
+Final stats:
+- **Total time**: 5.27s for 100k items
+- **Average rate**: 19.0k/s
+- **File size**: 14.53 MB (~152 bytes per item)
+
+### Performance Trend
+
+Speed decreases as document grows:
+- First 10k items: 64.4k/s
+- Last 10k items: 11.5k/s
+- ~5.6x slowdown across the run
 
 ### Recommended Limits
 
-- **< 100k items per workspace**: Fast, no noticeable degradation
-- **100k-300k items**: Acceptable with some slowdown
+- **< 100k items per workspace**: Fast, acceptable degradation
+- **100k-300k items**: Noticeable slowdown but workable
 - **300k+ items**: Consider splitting into multiple workspaces
 
 ## Interpretation
 
-The slowdown is expected; larger YJS documents mean more work per transaction. For very large datasets, use separate workspaces to keep each YJS document smaller.
+The slowdown is expected; larger YJS documents mean more work per transaction. The ~152 bytes per item is efficient for structured data. For very large datasets, use separate workspaces to keep each YJS document smaller.

--- a/examples/stress-test/stress-test.ts
+++ b/examples/stress-test/stress-test.ts
@@ -72,6 +72,20 @@ function formatRate(count: number, ms: number): string {
 	return `${rate.toFixed(0)}/s`;
 }
 
+// TTY helpers for progress output
+const isTTY = process.stdout.isTTY;
+const clearLine = () => {
+	if (isTTY) {
+		process.stdout.clearLine(0);
+		process.stdout.cursorTo(0);
+	}
+};
+const writeLine = (text: string) => {
+	if (isTTY) {
+		process.stdout.write(text);
+	}
+};
+
 console.log('='.repeat(60));
 console.log('YJS Stress Test (using upsertMany for bulk upserts)');
 console.log('='.repeat(60));
@@ -98,7 +112,7 @@ for (let tableIndex = 0; tableIndex < TABLES.length; tableIndex++) {
 	const table = TABLES[tableIndex];
 	const tableStart = performance.now();
 
-	process.stdout.write(
+	writeLine(
 		`[${tableIndex + 1}/${TABLES.length}] ${table}: 0/${ITEMS_PER_TABLE.toLocaleString()}`,
 	);
 
@@ -129,17 +143,15 @@ for (let tableIndex = 0; tableIndex < TABLES.length; tableIndex++) {
 		const totalElapsed = performance.now() - tableStart;
 		const rate = formatRate(batchCount, batchElapsed);
 
-		process.stdout.clearLine(0);
-		process.stdout.cursorTo(0);
-		process.stdout.write(
+		clearLine();
+		writeLine(
 			`[${tableIndex + 1}/${TABLES.length}] ${table}: ${inserted.toLocaleString()}/${ITEMS_PER_TABLE.toLocaleString()} (batch: ${rate}, elapsed: ${formatTime(totalElapsed)})`,
 		);
 	}
 
 	const tableElapsed = performance.now() - tableStart;
 
-	process.stdout.clearLine(0);
-	process.stdout.cursorTo(0);
+	clearLine();
 
 	grandTotal += ITEMS_PER_TABLE;
 	const avgRate = formatRate(ITEMS_PER_TABLE, tableElapsed);


### PR DESCRIPTION
This adds a comprehensive benchmark suite for testing YJS persistence performance via Epicenter's table API. The suite includes 5 benchmarks covering different usage patterns, each with co-located documentation containing actual performance findings.

The benchmark runner (`run-benchmarks.ts`) allows running all benchmarks or selecting specific ones by number or name, making it easy to run quick sanity checks or full performance audits.

Key findings from running the suite:

- **Bulk upsert**: 19k/s average throughput with ~152 bytes per item storage overhead
- **Write-delete-write**: Only 21% storage overhead after a full create-delete-recreate cycle; YJS handles tombstones efficiently
- **Update-heavy**: Updates run at ~40% of initial insert speed, with predictable ~1 MB growth per update round
- **Read-at-scale**: get() is O(1) constant time (~31-61µs), getAll() is O(n) linear but fast (862k items/sec at 50k items)
- **Mixed workload**: 210-475 ops/sec for realistic interleaved single-item operations

The TTY detection fix ensures benchmarks run cleanly when output is piped (prevents errors from process.stdout.clearLine not existing in non-TTY contexts).