### PR TITLE
refactor(table-helper): use status-based discriminated unions for read API

### DIFF
--- a/examples/content-hub/browser/browser.workspace.ts
+++ b/examples/content-hub/browser/browser.workspace.ts
@@ -340,13 +340,13 @@ export const browser = defineWorkspace({
 			description: 'Close a tab by its stable ID',
 			handler: async ({ tabId }) => {
 				const result = db.tabs.get({ id: tabId });
-				if (!result?.data) {
+				if (result.status !== 'valid') {
 					return TabNotFoundErr({
 						message: 'Tab not found',
 						context: { tabId },
 					});
 				}
-				const tab = result.data;
+				const tab = result.row;
 
 				const { error } = await tryAsync({
 					try: () => browserApi.tabs.remove(tab.browser_id),
@@ -383,13 +383,13 @@ export const browser = defineWorkspace({
 				let browser_window_id: number | undefined;
 				if (window_id) {
 					const winResult = db.windows.get({ id: window_id });
-					if (!winResult?.data) {
+					if (winResult.status !== 'valid') {
 						return WindowNotFoundErr({
 							message: 'Window not found',
 							context: { windowId: window_id },
 						});
 					}
-					browser_window_id = winResult.data.browser_id;
+					browser_window_id = winResult.row.browser_id;
 				}
 
 				const { data: newTab, error } = await tryAsync({
@@ -424,7 +424,7 @@ export const browser = defineWorkspace({
 				// Need to find which window the tab ended up in
 				const target_window_id =
 					window_id ??
-					db.windows.getAll().find((w) => w.browser_id === newTab.windowId)?.id;
+					db.windows.getAllValid().find((w) => w.browser_id === newTab.windowId)?.id;
 
 				if (!target_window_id) {
 					return BrowserResponseErr({
@@ -474,25 +474,25 @@ export const browser = defineWorkspace({
 			description: 'Move a tab to a different position or window',
 			handler: async ({ tab_id, window_id, index }) => {
 				const tabResult = db.tabs.get({ id: tab_id });
-				if (!tabResult?.data) {
+				if (tabResult.status !== 'valid') {
 					return TabNotFoundErr({
 						message: 'Tab not found',
 						context: { tabId: tab_id },
 					});
 				}
-				const tab = tabResult.data;
+				const tab = tabResult.row;
 
 				// Look up browser window ID if provided
 				let browser_window_id: number | undefined;
 				if (window_id) {
 					const winResult = db.windows.get({ id: window_id });
-					if (!winResult?.data) {
+					if (winResult.status !== 'valid') {
 						return WindowNotFoundErr({
 							message: 'Window not found',
 							context: { windowId: window_id },
 						});
 					}
-					browser_window_id = winResult.data.browser_id;
+					browser_window_id = winResult.row.browser_id;
 				}
 
 				const { data: movedTab, error } = await tryAsync({
@@ -517,7 +517,7 @@ export const browser = defineWorkspace({
 				const moved = Array.isArray(movedTab) ? movedTab[0] : movedTab;
 				const target_window_id =
 					window_id ??
-					db.windows.getAll().find((w) => w.browser_id === moved?.windowId)
+					db.windows.getAllValid().find((w) => w.browser_id === moved?.windowId)
 						?.id ??
 					tab.window_id;
 
@@ -539,13 +539,13 @@ export const browser = defineWorkspace({
 			description: 'Pin a tab',
 			handler: async ({ tab_id }) => {
 				const result = db.tabs.get({ id: tab_id });
-				if (!result?.data) {
+				if (result.status !== 'valid') {
 					return TabNotFoundErr({
 						message: 'Tab not found',
 						context: { tabId: tab_id },
 					});
 				}
-				const tab = result.data;
+				const tab = result.row;
 
 				const { error } = await tryAsync({
 					try: () => browserApi.tabs.update(tab.browser_id, { pinned: true }),
@@ -574,13 +574,13 @@ export const browser = defineWorkspace({
 			description: 'Unpin a tab',
 			handler: async ({ tab_id }) => {
 				const result = db.tabs.get({ id: tab_id });
-				if (!result?.data) {
+				if (result.status !== 'valid') {
 					return TabNotFoundErr({
 						message: 'Tab not found',
 						context: { tabId: tab_id },
 					});
 				}
-				const tab = result.data;
+				const tab = result.row;
 
 				const { error } = await tryAsync({
 					try: () => browserApi.tabs.update(tab.browser_id, { pinned: false }),
@@ -609,13 +609,13 @@ export const browser = defineWorkspace({
 			description: 'Mute a tab',
 			handler: async ({ tab_id }) => {
 				const result = db.tabs.get({ id: tab_id });
-				if (!result?.data) {
+				if (result.status !== 'valid') {
 					return TabNotFoundErr({
 						message: 'Tab not found',
 						context: { tabId: tab_id },
 					});
 				}
-				const tab = result.data;
+				const tab = result.row;
 
 				const { error } = await tryAsync({
 					try: () => browserApi.tabs.update(tab.browser_id, { muted: true }),
@@ -644,13 +644,13 @@ export const browser = defineWorkspace({
 			description: 'Unmute a tab',
 			handler: async ({ tab_id }) => {
 				const result = db.tabs.get({ id: tab_id });
-				if (!result?.data) {
+				if (result.status !== 'valid') {
 					return TabNotFoundErr({
 						message: 'Tab not found',
 						context: { tabId: tab_id },
 					});
 				}
-				const tab = result.data;
+				const tab = result.row;
 
 				const { error } = await tryAsync({
 					try: () => browserApi.tabs.update(tab.browser_id, { muted: false }),
@@ -679,13 +679,13 @@ export const browser = defineWorkspace({
 			description: 'Reload a tab',
 			handler: async ({ tab_id }) => {
 				const result = db.tabs.get({ id: tab_id });
-				if (!result?.data) {
+				if (result.status !== 'valid') {
 					return TabNotFoundErr({
 						message: 'Tab not found',
 						context: { tabId: tab_id },
 					});
 				}
-				const tab = result.data;
+				const tab = result.row;
 
 				const { error } = await tryAsync({
 					try: () => browserApi.tabs.reload(tab.browser_id),
@@ -714,13 +714,13 @@ export const browser = defineWorkspace({
 			description: 'Duplicate a tab',
 			handler: async ({ tab_id }) => {
 				const result = db.tabs.get({ id: tab_id });
-				if (!result?.data) {
+				if (result.status !== 'valid') {
 					return TabNotFoundErr({
 						message: 'Tab not found',
 						context: { tabId: tab_id },
 					});
 				}
-				const tab = result.data;
+				const tab = result.row;
 
 				const { data: newTab, error } = await tryAsync({
 					try: () => browserApi.tabs.duplicate(tab.browser_id),
@@ -784,13 +784,13 @@ export const browser = defineWorkspace({
 			description: 'Close a window and all its tabs',
 			handler: async ({ window_id }) => {
 				const winResult = db.windows.get({ id: window_id });
-				if (!winResult?.data) {
+				if (winResult.status !== 'valid') {
 					return WindowNotFoundErr({
 						message: 'Window not found',
 						context: { windowId: window_id },
 					});
 				}
-				const win = winResult.data;
+				const win = winResult.row;
 
 				const { error } = await tryAsync({
 					try: () => browserApi.windows.remove(win.browser_id),
@@ -810,7 +810,7 @@ export const browser = defineWorkspace({
 				db.$transact(() => {
 					// Delete all tabs in this window
 					const tabsInWindow = db.tabs
-						.getAll()
+						.getAllValid()
 						.filter((t) => t.window_id === window_id);
 					db.tabs.deleteMany({ ids: tabsInWindow.map((t) => t.id) });
 
@@ -831,7 +831,7 @@ export const browser = defineWorkspace({
 		 */
 		getAllTabs: defineQuery({
 			description: 'Get all tabs from the database',
-			handler: () => db.tabs.getAll().map((t) => t.toJSON()),
+			handler: () => db.tabs.getAllValid().map((t) => t.toJSON()),
 		}),
 
 		/**
@@ -839,7 +839,7 @@ export const browser = defineWorkspace({
 		 */
 		getAllWindows: defineQuery({
 			description: 'Get all windows from the database',
-			handler: () => db.windows.getAll().map((w) => w.toJSON()),
+			handler: () => db.windows.getAllValid().map((w) => w.toJSON()),
 		}),
 	}),
 });

--- a/examples/content-hub/clippings/clippings.workspace.ts
+++ b/examples/content-hub/clippings/clippings.workspace.ts
@@ -371,25 +371,25 @@ ${instructions}`;
 				};
 
 				// Dedupe articles (timestamp: saved_at)
-				const articleIds = findDuplicateIds(db.articles.getAll(), 'saved_at');
+				const articleIds = findDuplicateIds(db.articles.getAllValid(), 'saved_at');
 				db.articles.deleteMany({ ids: articleIds });
 				totalDeleted += articleIds.length;
 
 				// Dedupe github_repos (timestamp: added_at)
-				const repoIds = findDuplicateIds(db.github_repos.getAll(), 'added_at');
+				const repoIds = findDuplicateIds(db.github_repos.getAllValid(), 'added_at');
 				db.github_repos.deleteMany({ ids: repoIds });
 				totalDeleted += repoIds.length;
 
 				// Dedupe landing_pages (timestamp: added_at)
 				const landingPageIds = findDuplicateIds(
-					db.landing_pages.getAll(),
+					db.landing_pages.getAllValid(),
 					'added_at',
 				);
 				db.landing_pages.deleteMany({ ids: landingPageIds });
 				totalDeleted += landingPageIds.length;
 
 				// Dedupe doc_sites (timestamp: added_at)
-				const docSiteIds = findDuplicateIds(db.doc_sites.getAll(), 'added_at');
+				const docSiteIds = findDuplicateIds(db.doc_sites.getAllValid(), 'added_at');
 				db.doc_sites.deleteMany({ ids: docSiteIds });
 				totalDeleted += docSiteIds.length;
 
@@ -612,7 +612,7 @@ ${instructions}`;
 			handler: ({ article_id, content, comment }) => {
 				// Verify the article exists
 				const article = db.articles.get({ id: article_id });
-				if (!article) {
+				if (article.status !== 'valid') {
 					return Err({
 						message: 'Article not found',
 						context: { article_id },

--- a/examples/stress-test/stress-test-mixed-workload.ts
+++ b/examples/stress-test/stress-test-mixed-workload.ts
@@ -213,7 +213,7 @@ for (let round = 1; round <= ROUNDS; round++) {
 		// Read all
 		cumulative += DISTRIBUTION.readAll;
 		if (rand < cumulative) {
-			tableDb.getAll();
+			tableDb.getAllValid();
 			opCounts.readAll++;
 			opTimes.readAll += performance.now() - opStart;
 			continue;

--- a/examples/stress-test/stress-test-read-at-scale.ts
+++ b/examples/stress-test/stress-test-read-at-scale.ts
@@ -120,9 +120,9 @@ while (totalInserted < TOTAL_ITEMS) {
 	}
 
 	// Measure read performance at this point
-	// 1. getAll() - fetch all rows
+	// 1. getAllValid() - fetch all valid rows
 	const getAllStart = performance.now();
-	const allRows = tableDb.getAll();
+	const allRows = tableDb.getAllValid();
 	const getAllTime = performance.now() - getAllStart;
 
 	// 2. get() - fetch 100 random rows

--- a/packages/epicenter/src/cli/cli-end-to-end.test.ts
+++ b/packages/epicenter/src/cli/cli-end-to-end.test.ts
@@ -94,12 +94,15 @@ describe('CLI End-to-End Tests', () => {
 				}),
 				handler: async ({ id, views }) => {
 					const result = db.posts.get({ id });
-					if (!result?.data) {
+					if (result.status !== 'valid') {
 						return Ok(null);
 					}
 					db.posts.update({ id, views });
 					const updatedResult = db.posts.get({ id });
-					return Ok(updatedResult?.data?.toJSON());
+					if (updatedResult.status !== 'valid') {
+						return Ok(null);
+					}
+					return Ok(updatedResult.row.toJSON());
 				},
 			}),
 		}),

--- a/packages/epicenter/src/core/db/core-types.test.ts
+++ b/packages/epicenter/src/core/db/core-types.test.ts
@@ -32,24 +32,21 @@ describe('YjsDoc Type Inference', () => {
 			published: false,
 		});
 
-		// Test get() - returns Result<Row, ArkErrors> | null
+		// Test get() - returns GetResult<Row>
 		const result = doc.posts.get({ id: '1' });
-		expect(result).not.toBeNull();
+		expect(result.status).toBe('valid');
 
-		if (result) {
-			expect(result.data).toBeDefined();
-			if (result.data) {
-				const row = result.data;
-				// Verify property access works
-				expect(row.id).toBe('1');
-				expect(row.title).toBe('Test Post');
-				expect(row.view_count).toBe(0);
-				expect(row.published).toBe(false);
+		if (result.status === 'valid') {
+			const row = result.row;
+			// Verify property access works
+			expect(row.id).toBe('1');
+			expect(row.title).toBe('Test Post');
+			expect(row.view_count).toBe(0);
+			expect(row.published).toBe(false);
 
-				// Verify YJS types are properly inferred
-				expect(row.content).toBeInstanceOf(Y.Text);
-				expect(row.tags).toBeInstanceOf(Y.Array);
-			}
+			// Verify YJS types are properly inferred
+			expect(row.content).toBeInstanceOf(Y.Text);
+			expect(row.tags).toBeInstanceOf(Y.Array);
 		}
 	});
 
@@ -70,8 +67,8 @@ describe('YjsDoc Type Inference', () => {
 			],
 		});
 
-		// getAll() now returns Row[] directly
-		const products = doc.products.getAll();
+		// getAllValid() returns Row[] directly
+		const products = doc.products.getAllValid();
 		// Expected type: Array<{ id: string; name: string; price: number; in_stock: boolean }>
 
 		expect(products).toHaveLength(2);
@@ -190,10 +187,10 @@ describe('YjsDoc Type Inference', () => {
 		});
 
 		const article1Result = doc.articles.get({ id: '1' });
-		expect(article1Result).not.toBeNull();
-		if (article1Result?.data) {
-			expect(article1Result.data.description).toBeNull();
-			expect(article1Result.data.content).toBeNull();
+		expect(article1Result.status).toBe('valid');
+		if (article1Result.status === 'valid') {
+			expect(article1Result.row.description).toBeNull();
+			expect(article1Result.row.content).toBeNull();
 		}
 
 		// Test with string values (automatically converted to Y.Text internally)
@@ -205,9 +202,10 @@ describe('YjsDoc Type Inference', () => {
 		});
 
 		const article2Result = doc.articles.get({ id: '2' });
-		if (article2Result?.data) {
-			expect(article2Result.data.description).toBeInstanceOf(Y.Text);
-			expect(article2Result.data.content).toBeInstanceOf(Y.Text);
+		expect(article2Result.status).toBe('valid');
+		if (article2Result.status === 'valid') {
+			expect(article2Result.row.description).toBeInstanceOf(Y.Text);
+			expect(article2Result.row.content).toBeInstanceOf(Y.Text);
 		}
 	});
 
@@ -237,7 +235,7 @@ describe('YjsDoc Type Inference', () => {
 		});
 
 		const authorResult = doc.authors.get({ id: 'author-1' });
-		// Hover to verify type: Result<{ id: string; name: string; bio: Y.Text | null }, ArkErrors> | null
+		// Hover to verify type: GetResult<{ id: string; name: string; bio: Y.Text | null }>
 
 		// Test books table - use plain array (converted to Y.Array internally)
 		doc.books.upsert({
@@ -249,15 +247,15 @@ describe('YjsDoc Type Inference', () => {
 		});
 
 		const bookResult = doc.books.get({ id: 'book-1' });
-		// Hover to verify type: Result<{ id: string; author_id: string; title: string; chapters: Y.Array<string>; published: boolean }, ArkErrors> | null
+		// Hover to verify type: GetResult<{ id: string; author_id: string; title: string; chapters: Y.Array<string>; published: boolean }>
 
-		expect(authorResult).not.toBeNull();
-		expect(bookResult).not.toBeNull();
-		if (authorResult?.data) {
-			expect(authorResult.data.name).toBe('John Doe');
+		expect(authorResult.status).toBe('valid');
+		expect(bookResult.status).toBe('valid');
+		if (authorResult.status === 'valid') {
+			expect(authorResult.row.name).toBe('John Doe');
 		}
-		if (bookResult?.data) {
-			expect(bookResult.data.title).toBe('My Book');
+		if (bookResult.status === 'valid') {
+			expect(bookResult.row.title).toBe('My Book');
 		}
 	});
 
@@ -278,7 +276,7 @@ describe('YjsDoc Type Inference', () => {
 
 		doc.comments.upsertMany({ rows: commentsToAdd });
 
-		const comments = doc.comments.getAll();
+		const comments = doc.comments.getAllValid();
 		expect(comments).toHaveLength(2);
 	});
 
@@ -304,9 +302,10 @@ describe('YjsDoc Type Inference', () => {
 
 		// Test retrieval and mutations
 		const retrievedResult = doc.documents.get({ id: 'doc-1' });
+		expect(retrievedResult.status).toBe('valid');
 
-		if (retrievedResult?.data) {
-			const retrieved = retrievedResult.data;
+		if (retrievedResult.status === 'valid') {
+			const retrieved = retrievedResult.row;
 			// These should all be properly typed
 			expect(retrieved.body).toBeInstanceOf(Y.Text);
 			expect(retrieved.tags).toBeInstanceOf(Y.Array);

--- a/packages/epicenter/src/core/db/core.test.ts
+++ b/packages/epicenter/src/core/db/core.test.ts
@@ -25,11 +25,11 @@ describe('createEpicenterDb', () => {
 
 		// Retrieve the row
 		const result = doc.posts.get({ id: '1' });
-		expect(result).not.toBeNull();
-		if (result?.data) {
-			expect(result.data.title).toBe('Test Post');
-			expect(result.data.view_count).toBe(0);
-			expect(result.data.published).toBe(false);
+		expect(result.status).toBe('valid');
+		if (result.status === 'valid') {
+			expect(result.row.title).toBe('Test Post');
+			expect(result.row.view_count).toBe(0);
+			expect(result.row.published).toBe(false);
 		}
 	});
 
@@ -55,13 +55,13 @@ describe('createEpicenterDb', () => {
 		// Retrieve and verify rows
 		const row1 = doc.posts.get({ id: '1' });
 		const row2 = doc.posts.get({ id: '2' });
-		expect(row1).not.toBeNull();
-		expect(row2).not.toBeNull();
-		if (row1?.data) {
-			expect(row1.data.title).toBe('Post 1');
+		expect(row1.status).toBe('valid');
+		expect(row2.status).toBe('valid');
+		if (row1.status === 'valid') {
+			expect(row1.row.title).toBe('Post 1');
 		}
-		if (row2?.data) {
-			expect(row2.data.title).toBe('Post 2');
+		if (row2.status === 'valid') {
+			expect(row2.row.title).toBe('Post 2');
 		}
 	});
 
@@ -96,7 +96,7 @@ describe('createEpicenterDb', () => {
 		}
 	});
 
-	test('should return not-found status for non-existent rows', () => {
+	test('should return not_found status for non-existent rows', () => {
 		const ydoc = new Y.Doc({ guid: 'test-workspace' });
 		const doc = createEpicenterDb(ydoc, {
 			posts: {
@@ -109,7 +109,10 @@ describe('createEpicenterDb', () => {
 
 		// Test get() with non-existent id
 		const getResult = doc.posts.get({ id: 'non-existent' });
-		expect(getResult).toBeNull();
+		expect(getResult.status).toBe('not_found');
+		if (getResult.status === 'not_found') {
+			expect(getResult.id).toBe('non-existent');
+		}
 
 		// Test find() with no matches
 		const findResult = doc.posts.find((post) => post.id === 'non-existent');
@@ -135,12 +138,12 @@ describe('createEpicenterDb', () => {
 
 		// Get returns Y.js objects
 		const result1 = doc.posts.get({ id: '1' });
-		expect(result1).not.toBeNull();
-		if (result1?.data) {
-			expect(result1.data.title).toBeInstanceOf(Y.Text);
-			expect(result1.data.tags).toBeInstanceOf(Y.Array);
-			expect(result1.data.title.toString()).toBe('Hello World');
-			expect(result1.data.tags.toArray()).toEqual(['typescript', 'javascript']);
+		expect(result1.status).toBe('valid');
+		if (result1.status === 'valid') {
+			expect(result1.row.title).toBeInstanceOf(Y.Text);
+			expect(result1.row.tags).toBeInstanceOf(Y.Array);
+			expect(result1.row.title.toString()).toBe('Hello World');
+			expect(result1.row.tags.toArray()).toEqual(['typescript', 'javascript']);
 		}
 
 		// Upsert another post
@@ -150,12 +153,14 @@ describe('createEpicenterDb', () => {
 			tags: ['python'],
 		});
 
-		// getAll returns Y.js objects
-		const rows = doc.posts.getAll();
+		// getAllValid returns Y.js objects
+		const rows = doc.posts.getAllValid();
 		expect(rows).toHaveLength(2);
-		expect(rows[0].title).toBeInstanceOf(Y.Text);
-		expect(rows[0].tags).toBeInstanceOf(Y.Array);
-		expect(rows[0].title.toString()).toBe('Hello World');
-		expect(rows[1].title.toString()).toBe('Second Post');
+		const firstRow = rows[0]!;
+		const secondRow = rows[1]!;
+		expect(firstRow.title).toBeInstanceOf(Y.Text);
+		expect(firstRow.tags).toBeInstanceOf(Y.Array);
+		expect(firstRow.title.toString()).toBe('Hello World');
+		expect(secondRow.title.toString()).toBe('Second Post');
 	});
 });

--- a/packages/epicenter/src/core/workspace.test.ts
+++ b/packages/epicenter/src/core/workspace.test.ts
@@ -679,12 +679,15 @@ describe('Workspace Action Handlers', () => {
 					}),
 					handler: async ({ id, views }) => {
 						const result = db.posts.get({ id });
-						if (!result?.data) {
+						if (result.status !== 'valid') {
 							return Ok(null);
 						}
 						db.posts.update({ id, views });
 						const updatedResult = db.posts.get({ id });
-						return Ok(updatedResult?.data?.toJSON());
+						if (updatedResult.status !== 'valid') {
+							return Ok(null);
+						}
+						return Ok(updatedResult.row.toJSON());
 					},
 				}),
 			};

--- a/packages/epicenter/src/index.ts
+++ b/packages/epicenter/src/index.ts
@@ -56,7 +56,7 @@ export {
 export type { Db, TableHelper } from './core/db/core';
 // Database utilities
 export { createEpicenterDb } from './core/db/core';
-export type { YRow } from './core/db/table-helper';
+export type { GetResult, RowResult, YRow } from './core/db/table-helper';
 export type { ActionInfo, EpicenterClient, EpicenterConfig } from './core/epicenter';
 // Epicenter - compose multiple workspaces
 export {

--- a/packages/epicenter/src/indexes/markdown/markdown-index.ts
+++ b/packages/epicenter/src/indexes/markdown/markdown-index.ts
@@ -869,8 +869,8 @@ export const markdownIndex = (async <TSchema extends WorkspaceSchema>(
 			tracking[table.name] = createBidirectionalMap();
 		}
 
-		// Get all rows from YJS
-		const rows = table.getAll();
+		// Get all valid rows from YJS
+		const rows = table.getAllValid();
 
 		// Serialize each row to extract filename and populate tracking in BOTH directions
 		for (const row of rows) {
@@ -956,8 +956,8 @@ export const markdownIndex = (async <TSchema extends WorkspaceSchema>(
 								}),
 							);
 
-							// Write all current YJS rows for this table to markdown files
-							const rows = table.getAll();
+							// Write all current valid YJS rows for this table to markdown files
+							const rows = table.getAllValid();
 
 							for (const row of rows) {
 								const serializedRow = row.toJSON();

--- a/packages/epicenter/src/indexes/sqlite/sqlite-index.ts
+++ b/packages/epicenter/src/indexes/sqlite/sqlite-index.ts
@@ -183,7 +183,7 @@ export const sqliteIndex = (async <TSchema extends WorkspaceSchema>(
 				throw new Error(`Drizzle table for "${table.name}" not found`);
 			}
 
-			const rows = table.getAll();
+			const rows = table.getAllValid();
 
 			if (rows.length > 0) {
 				const { error } = await tryAsync({
@@ -279,7 +279,7 @@ export const sqliteIndex = (async <TSchema extends WorkspaceSchema>(
 			throw new Error(`Drizzle table for "${table.name}" not found`);
 		}
 
-		const rows = table.getAll();
+		const rows = table.getAllValid();
 
 		if (rows.length > 0) {
 			const { error } = await tryAsync({

--- a/specs/20251206T201800-table-helper-status-api.md
+++ b/specs/20251206T201800-table-helper-status-api.md
@@ -1,0 +1,131 @@
+# Table Helper Status-Based API Redesign
+
+## Context
+
+The current `get()` method returns `Result<TRow, RowValidationError> | null` using wellcrafted's Result type which has `{ data, error }` shape. This has a few issues:
+
+1. `null` for "not found" is inconsistent with the object-based Result type
+2. The `{ data, error }` discriminant is less domain-specific than `{ status: 'valid' | 'invalid' }`
+3. `getAll()` currently only returns valid rows, silently skipping invalid ones
+
+## Goals
+
+1. Use a status-based discriminated union instead of Result types for read operations
+2. Make all three states explicit: `valid`, `invalid`, `not_found`
+3. Provide both combined (`getAll`) and filtered (`getAllValid`, `getAllInvalid`) methods
+
+## New Types
+
+```typescript
+/**
+ * Result of getting a single row by ID.
+ */
+export type GetResult<TRow> =
+  | { status: 'valid'; row: TRow }
+  | { status: 'invalid'; id: string; error: RowValidationError }
+  | { status: 'not_found'; id: string };
+
+/**
+ * Result of getting a row from iteration (getAll).
+ * Does not include 'not_found' since we're iterating existing rows.
+ */
+export type RowResult<TRow> =
+  | { status: 'valid'; row: TRow }
+  | { status: 'invalid'; id: string; error: RowValidationError };
+```
+
+## API Changes
+
+### get({ id })
+
+**Before:**
+```typescript
+get({ id }): Result<TRow, RowValidationError> | null
+```
+
+**After:**
+```typescript
+get({ id }): GetResult<TRow>
+```
+
+### getAll() / getAllValid() / getAllInvalid()
+
+**Before:**
+- `getAll()` returns `TRow[]` (only valid rows)
+- `getAllInvalid()` returns `RowValidationError[]`
+
+**After:**
+- `getAll()` returns `RowResult<TRow>[]` (both valid and invalid)
+- `getAllValid()` returns `TRow[]` (only valid rows - what `getAll` used to do)
+- `getAllInvalid()` returns `RowValidationError[]` (unchanged)
+
+## Usage Examples
+
+```typescript
+// Get single row
+const result = db.posts.get({ id: '123' });
+switch (result.status) {
+  case 'valid':
+    console.log(result.row.title);
+    break;
+  case 'invalid':
+    console.log('Validation failed:', result.error.context.summary);
+    break;
+  case 'not_found':
+    console.log('Not found:', result.id);
+    break;
+}
+
+// Get all rows (both valid and invalid)
+const all = db.posts.getAll();
+for (const item of all) {
+  if (item.status === 'valid') {
+    console.log(item.row.title);
+  } else {
+    console.log('Invalid row:', item.id);
+  }
+}
+
+// Just valid rows (common case)
+const posts = db.posts.getAllValid();
+
+// Just invalid rows (for migration/debugging)
+const errors = db.posts.getAllInvalid();
+```
+
+## Implementation Tasks
+
+- [x] Add `GetResult` and `RowResult` types to table-helper.ts
+- [x] Update `get()` method to return `GetResult<TRow>`
+- [x] Rename current `getAll()` to `getAllValid()`
+- [x] Create new `getAll()` returning `RowResult<TRow>[]`
+- [x] Update all usages of `get()` across codebase
+- [x] Update all usages of `getAll()` to `getAllValid()` where needed
+- [x] Update exports in index.ts
+- [x] Update README documentation
+- [x] Run type check to verify changes
+
+## Files to Update
+
+### Core Implementation
+- `packages/epicenter/src/core/db/table-helper.ts`
+- `packages/epicenter/src/index.ts`
+
+### Usages (get)
+- `examples/basic-workspace/epicenter.config.ts`
+- `examples/content-hub/browser/browser.workspace.ts`
+- `examples/content-hub/clippings/clippings.workspace.ts`
+- `packages/epicenter/src/core/db/core.test.ts`
+- `packages/epicenter/src/core/db/core-types.test.ts`
+- `packages/epicenter/src/cli/cli-end-to-end.test.ts`
+- `packages/epicenter/src/core/workspace.test.ts`
+
+### Usages (getAll -> getAllValid)
+- `examples/stress-test/stress-test-mixed-workload.ts`
+- `examples/stress-test/stress-test-read-at-scale.ts`
+- `examples/content-hub/browser/browser.workspace.ts`
+- `examples/content-hub/clippings/clippings.workspace.ts`
+- `packages/epicenter/src/indexes/sqlite/sqlite-index.ts`
+
+### Documentation
+- `packages/epicenter/README.md`


### PR DESCRIPTION
The current `get()` method returns `Result<TRow, RowValidationError> | null` using wellcrafted's Result type which has `{ data, error }` shape. This has a few issues: `null` for "not found" is inconsistent with the object-based Result type, the `{ data, error }` discriminant is less domain-specific than explicit statuses, and `getAll()` only returns valid rows while silently skipping invalid ones.

This PR introduces status-based discriminated unions that make all three row states explicit:

```typescript
type GetResult<TRow> =
  | { status: 'valid'; row: TRow }
  | { status: 'invalid'; id: string; error: RowValidationError }
  | { status: 'not_found'; id: string };
```

The `get()` method now returns `GetResult<TRow>`, enabling clean switch statements:

```typescript
const result = db.posts.get({ id: '123' });
switch (result.status) {
  case 'valid':
    console.log(result.row.title);
    break;
  case 'invalid':
    console.log('Validation failed:', result.error.context.summary);
    break;
  case 'not_found':
    console.log('Not found:', result.id);
    break;
}
```

The `getAll()` method now returns `RowResult<TRow>[]` containing both valid and invalid rows, making it possible to handle schema migration scenarios where some rows may fail validation. The previous behavior (only valid rows) is available via the new `getAllValid()` method.