### PR TITLE
refactor: migrate keyboard shortcuts to Kbd component

### DIFF
--- a/apps/whispering/src/lib/constants/keyboard/display-labels.ts
+++ b/apps/whispering/src/lib/constants/keyboard/display-labels.ts
@@ -95,10 +95,25 @@ const BROWSER_KEY_DISPLAY_LABELS: Partial<
 export function getShortcutDisplayLabel(shortcut: string | null): string {
 	if (!shortcut) return '';
 
-	return shortcut
-		.split('+')
-		.map((key) => formatKeyForDisplay(key.toLowerCase()))
-		.join('+');
+	return getShortcutDisplayKeys(shortcut).join('+');
+}
+
+/**
+ * Gets an array of display keys for a shortcut string.
+ * Use this with Kbd.Group to render each key separately.
+ *
+ * @param shortcut - The shortcut string (e.g., "control+shift+a")
+ * @returns Array of formatted key strings (e.g., ["Ctrl", "Shift", "A"])
+ *
+ * @example
+ * getShortcutDisplayKeys('control+a')    // ['Ctrl', 'A']
+ * getShortcutDisplayKeys('meta+shift+p') // ['Cmd', 'Shift', 'P']
+ * getShortcutDisplayKeys(null)           // []
+ */
+export function getShortcutDisplayKeys(shortcut: string | null): string[] {
+	if (!shortcut) return [];
+
+	return shortcut.split('+').map((key) => formatKeyForDisplay(key.toLowerCase()));
 }
 
 /**

--- a/apps/whispering/src/lib/constants/keyboard/display-labels.ts
+++ b/apps/whispering/src/lib/constants/keyboard/display-labels.ts
@@ -85,35 +85,20 @@ const BROWSER_KEY_DISPLAY_LABELS: Partial<
  * Gets display label for a full shortcut string.
  *
  * @param shortcut - The shortcut string (e.g., "control+shift+ ", "a")
- * @returns Human-readable display (e.g., "Ctrl+Shift+Space", "A")
+ * @returns Human-readable display (e.g., "Ctrl + Shift + Space", "A")
  *
  * @example
  * getShortcutDisplayLabel(' ')           // 'Space'
- * getShortcutDisplayLabel('control+a')   // 'Ctrl+A'
+ * getShortcutDisplayLabel('control+a')   // 'Ctrl + A'
  * getShortcutDisplayLabel(null)          // ''
  */
 export function getShortcutDisplayLabel(shortcut: string | null): string {
 	if (!shortcut) return '';
 
-	return getShortcutDisplayKeys(shortcut).join('+');
-}
-
-/**
- * Gets an array of display keys for a shortcut string.
- * Use this with Kbd.Group to render each key separately.
- *
- * @param shortcut - The shortcut string (e.g., "control+shift+a")
- * @returns Array of formatted key strings (e.g., ["Ctrl", "Shift", "A"])
- *
- * @example
- * getShortcutDisplayKeys('control+a')    // ['Ctrl', 'A']
- * getShortcutDisplayKeys('meta+shift+p') // ['Cmd', 'Shift', 'P']
- * getShortcutDisplayKeys(null)           // []
- */
-export function getShortcutDisplayKeys(shortcut: string | null): string[] {
-	if (!shortcut) return [];
-
-	return shortcut.split('+').map((key) => formatKeyForDisplay(key.toLowerCase()));
+	return shortcut
+		.split('+')
+		.map((key) => formatKeyForDisplay(key.toLowerCase()))
+		.join(' + ');
 }
 
 /**

--- a/apps/whispering/src/lib/constants/keyboard/index.ts
+++ b/apps/whispering/src/lib/constants/keyboard/index.ts
@@ -16,12 +16,9 @@ export {
 	KEYBOARD_EVENT_SUPPORTED_KEYS,
 	type KeyboardEventSupportedKey,
 } from './browser/supported-keys';
-
+export { getShortcutDisplayLabel } from './display-labels';
 export {
 	normalizeOptionKeyCharacter,
 	OPTION_DEAD_KEYS,
 } from './macos-option-key-map';
-
 export { CommandOrAlt, CommandOrControl } from './modifiers';
-
-export { getShortcutDisplayKeys, getShortcutDisplayLabel } from './display-labels';

--- a/apps/whispering/src/lib/constants/keyboard/index.ts
+++ b/apps/whispering/src/lib/constants/keyboard/index.ts
@@ -24,4 +24,4 @@ export {
 
 export { CommandOrAlt, CommandOrControl } from './modifiers';
 
-export { getShortcutDisplayLabel } from './display-labels';
+export { getShortcutDisplayKeys, getShortcutDisplayLabel } from './display-labels';

--- a/apps/whispering/src/routes/(app)/(config)/install-ffmpeg/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/install-ffmpeg/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Button, buttonVariants } from '@epicenter/ui/button';
+	import * as Kbd from '@epicenter/ui/kbd';
 	import { Link } from '@epicenter/ui/link';
 	import * as Card from '@epicenter/ui/card';
 	import * as Alert from '@epicenter/ui/alert';
@@ -230,10 +231,8 @@
 														<li class="flex gap-3">
 															<span class="shrink-0">a.</span>
 															<span
-																>Press <kbd
-																	class="bg-muted px-2 py-1 rounded font-mono text-xs"
-																	>Windows + X</kbd
-																> and select "System"</span
+																>Press <Kbd.Root>Windows + X</Kbd.Root> and select
+																"System"</span
 															>
 														</li>
 														<li class="flex gap-3">

--- a/apps/whispering/src/routes/(app)/(config)/install-ffmpeg/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/install-ffmpeg/+page.svelte
@@ -231,11 +231,8 @@
 														<li class="flex gap-3">
 															<span class="shrink-0">a.</span>
 															<span
-																>Press <Kbd.Group
-																	><Kbd.Root>Windows</Kbd.Root><Kbd.Root
-																		>X</Kbd.Root
-																	></Kbd.Group
-																> and select "System"</span
+																>Press <Kbd.Root>Windows + X</Kbd.Root> and select
+																"System"</span
 															>
 														</li>
 														<li class="flex gap-3">

--- a/apps/whispering/src/routes/(app)/(config)/install-ffmpeg/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/install-ffmpeg/+page.svelte
@@ -231,8 +231,11 @@
 														<li class="flex gap-3">
 															<span class="shrink-0">a.</span>
 															<span
-																>Press <Kbd.Root>Windows + X</Kbd.Root> and select
-																"System"</span
+																>Press <Kbd.Group
+																	><Kbd.Root>Windows</Kbd.Root><Kbd.Root
+																		>X</Kbd.Root
+																	></Kbd.Group
+																> and select "System"</span
 															>
 														</li>
 														<li class="flex gap-3">

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/KeyboardShortcutRecorder.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/KeyboardShortcutRecorder.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import * as Alert from '@epicenter/ui/alert';
-	import { Badge } from '@epicenter/ui/badge';
 	import { Button } from '@epicenter/ui/button';
+	import * as Kbd from '@epicenter/ui/kbd';
 	import { Input } from '@epicenter/ui/input';
 	import * as Popover from '@epicenter/ui/popover';
 	import {
@@ -41,9 +41,7 @@
 
 <div class="flex items-center justify-end gap-2">
 	{#if rawKeyCombination}
-		<Badge variant="secondary" class="font-mono text-xs">
-			{getShortcutDisplayLabel(rawKeyCombination)}
-		</Badge>
+		<Kbd.Root>{getShortcutDisplayLabel(rawKeyCombination)}</Kbd.Root>
 		<Button
 			variant="ghost"
 			size="icon"
@@ -137,9 +135,9 @@
 								class="flex grow items-center gap-1.5 overflow-x-auto pr-2 scrollbar-none"
 							>
 								{#if rawKeyCombination && !keyRecorder.isListening}
-									<Badge variant="secondary" class="font-mono text-xs">
+									<Kbd.Root>
 										{getShortcutDisplayLabel(rawKeyCombination)}
-									</Badge>
+									</Kbd.Root>
 								{:else if !keyRecorder.isListening}
 									<span class="truncate text-muted-foreground"
 										>{placeholder}</span

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/KeyboardShortcutRecorder.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/KeyboardShortcutRecorder.svelte
@@ -5,7 +5,7 @@
 	import { Input } from '@epicenter/ui/input';
 	import * as Popover from '@epicenter/ui/popover';
 	import {
-		getShortcutDisplayLabel,
+		getShortcutDisplayKeys,
 		type KeyboardEventSupportedKey,
 	} from '$lib/constants/keyboard';
 	import { IS_MACOS } from '$lib/constants/platform';
@@ -41,7 +41,11 @@
 
 <div class="flex items-center justify-end gap-2">
 	{#if rawKeyCombination}
-		<Kbd.Root>{getShortcutDisplayLabel(rawKeyCombination)}</Kbd.Root>
+		<Kbd.Group>
+			{#each getShortcutDisplayKeys(rawKeyCombination) as key}
+				<Kbd.Root>{key}</Kbd.Root>
+			{/each}
+		</Kbd.Group>
 		<Button
 			variant="ghost"
 			size="icon"
@@ -135,9 +139,11 @@
 								class="flex grow items-center gap-1.5 overflow-x-auto pr-2 scrollbar-none"
 							>
 								{#if rawKeyCombination && !keyRecorder.isListening}
-									<Kbd.Root>
-										{getShortcutDisplayLabel(rawKeyCombination)}
-									</Kbd.Root>
+									<Kbd.Group>
+										{#each getShortcutDisplayKeys(rawKeyCombination) as key}
+											<Kbd.Root>{key}</Kbd.Root>
+										{/each}
+									</Kbd.Group>
 								{:else if !keyRecorder.isListening}
 									<span class="truncate text-muted-foreground"
 										>{placeholder}</span

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/KeyboardShortcutRecorder.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/KeyboardShortcutRecorder.svelte
@@ -5,7 +5,7 @@
 	import { Input } from '@epicenter/ui/input';
 	import * as Popover from '@epicenter/ui/popover';
 	import {
-		getShortcutDisplayKeys,
+		getShortcutDisplayLabel,
 		type KeyboardEventSupportedKey,
 	} from '$lib/constants/keyboard';
 	import { IS_MACOS } from '$lib/constants/platform';
@@ -41,11 +41,7 @@
 
 <div class="flex items-center justify-end gap-2">
 	{#if rawKeyCombination}
-		<Kbd.Group>
-			{#each getShortcutDisplayKeys(rawKeyCombination) as key}
-				<Kbd.Root>{key}</Kbd.Root>
-			{/each}
-		</Kbd.Group>
+		<Kbd.Root>{getShortcutDisplayLabel(rawKeyCombination)}</Kbd.Root>
 		<Button
 			variant="ghost"
 			size="icon"
@@ -139,11 +135,7 @@
 								class="flex grow items-center gap-1.5 overflow-x-auto pr-2 scrollbar-none"
 							>
 								{#if rawKeyCombination && !keyRecorder.isListening}
-									<Kbd.Group>
-										{#each getShortcutDisplayKeys(rawKeyCombination) as key}
-											<Kbd.Root>{key}</Kbd.Root>
-										{/each}
-									</Kbd.Group>
+									<Kbd.Root>{getShortcutDisplayLabel(rawKeyCombination)}</Kbd.Root>
 								{:else if !keyRecorder.isListening}
 									<span class="truncate text-muted-foreground"
 										>{placeholder}</span

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import * as Alert from '@epicenter/ui/alert';
-	import { Badge } from '@epicenter/ui/badge';
 	import { Button } from '@epicenter/ui/button';
+	import * as Kbd from '@epicenter/ui/kbd';
 	import * as Dialog from '@epicenter/ui/dialog';
 	import {
 		ACCELERATOR_SECTIONS,
@@ -90,9 +90,7 @@
 					<p class="text-xs text-muted-foreground mb-2">Hold with other keys</p>
 					<div class="flex flex-wrap sm:flex-col gap-1">
 						{#each (isLocal ? KEYBOARD_EVENT_SUPPORTED_KEY_SECTIONS.at(0) : ACCELERATOR_SECTIONS.at(0)).keys as modifier}
-							<Badge variant="outline" class="font-mono text-sm justify-start">
-								{modifier}
-							</Badge>
+							<Kbd.Root>{modifier}</Kbd.Root>
 						{/each}
 					</div>
 				</div>
@@ -108,9 +106,7 @@
 								</p>
 								<div class="flex flex-wrap gap-1">
 									{#each section.keys as key}
-										<Badge variant="secondary" class="font-mono text-xs">
-											{key}
-										</Badge>
+										<Kbd.Root>{key}</Kbd.Root>
 									{/each}
 								</div>
 							</div>
@@ -140,9 +136,7 @@
 						</p>
 						<div class="flex flex-wrap gap-1 my-2">
 							{#each OPTION_DEAD_KEYS as key}
-								<Badge variant="outline" class="font-mono text-xs">
-									Option+{key.toUpperCase()}
-								</Badge>
+								<Kbd.Root>Option+{key.toUpperCase()}</Kbd.Root>
 							{/each}
 						</div>
 						<p class="font-medium">Workarounds:</p>

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
@@ -136,7 +136,10 @@
 						</p>
 						<div class="flex flex-wrap gap-1 my-2">
 							{#each OPTION_DEAD_KEYS as key}
-								<Kbd.Root>Option+{key.toUpperCase()}</Kbd.Root>
+								<Kbd.Group>
+									<Kbd.Root>Option</Kbd.Root>
+									<Kbd.Root>{key.toUpperCase()}</Kbd.Root>
+								</Kbd.Group>
 							{/each}
 						</div>
 						<p class="font-medium">Workarounds:</p>

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
@@ -136,10 +136,7 @@
 						</p>
 						<div class="flex flex-wrap gap-1 my-2">
 							{#each OPTION_DEAD_KEYS as key}
-								<Kbd.Group>
-									<Kbd.Root>Option</Kbd.Root>
-									<Kbd.Root>{key.toUpperCase()}</Kbd.Root>
-								</Kbd.Group>
+								<Kbd.Root>Option + {key.toUpperCase()}</Kbd.Root>
 							{/each}
 						</div>
 						<p class="font-medium">Workarounds:</p>

--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -19,7 +19,7 @@
 		type RecordingMode,
 		VAD_STATE_TO_ICON,
 	} from '$lib/constants/audio';
-	import { getShortcutDisplayKeys } from '$lib/constants/keyboard';
+	import { getShortcutDisplayLabel } from '$lib/constants/keyboard';
 	import { rpc } from '$lib/query';
 	import { vadRecorder } from '$lib/query/vad.svelte';
 	import * as services from '$lib/services';
@@ -366,11 +366,7 @@
 				tooltip="Go to local shortcut in settings"
 				href="/settings/shortcuts/local"
 			>
-				<Kbd.Group>
-					{#each getShortcutDisplayKeys(settings.value['shortcuts.local.toggleManualRecording']) as key}
-						<Kbd.Root>{key}</Kbd.Root>
-					{/each}
-				</Kbd.Group>
+	<Kbd.Root>{getShortcutDisplayLabel(settings.value['shortcuts.local.toggleManualRecording'])}</Kbd.Root>
 			</Link>{' '}
 			to start recording here.
 		</p>
@@ -381,11 +377,7 @@
 					tooltip="Go to global shortcut in settings"
 					href="/settings/shortcuts/global"
 				>
-					<Kbd.Group>
-						{#each getShortcutDisplayKeys(settings.value['shortcuts.global.toggleManualRecording']) as key}
-							<Kbd.Root>{key}</Kbd.Root>
-						{/each}
-					</Kbd.Group>
+	<Kbd.Root>{getShortcutDisplayLabel(settings.value['shortcuts.global.toggleManualRecording'])}</Kbd.Root>
 				</Link>{' '}
 				to start recording anywhere.
 			</p>

--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -3,6 +3,7 @@
 	import NavItems from '$lib/components/NavItems.svelte';
 	import CopyToClipboardButton from '$lib/components/copyable/CopyToClipboardButton.svelte';
 	import { Button } from '@epicenter/ui/button';
+	import * as Kbd from '@epicenter/ui/kbd';
 	import { Link } from '@epicenter/ui/link';
 	import { ClipboardIcon } from '$lib/components/icons';
 	import {
@@ -365,13 +366,11 @@
 				tooltip="Go to local shortcut in settings"
 				href="/settings/shortcuts/local"
 			>
-				<kbd
-					class="bg-muted relative rounded px-[0.3rem] py-[0.15rem] font-mono text-sm font-semibold"
-				>
+				<Kbd.Root>
 					{getShortcutDisplayLabel(
 						settings.value['shortcuts.local.toggleManualRecording'],
 					)}
-				</kbd>
+				</Kbd.Root>
 			</Link>{' '}
 			to start recording here.
 		</p>
@@ -382,11 +381,9 @@
 					tooltip="Go to global shortcut in settings"
 					href="/settings/shortcuts/global"
 				>
-					<kbd
-						class="bg-muted relative rounded px-[0.3rem] py-[0.15rem] font-mono text-sm font-semibold"
-					>
+					<Kbd.Root>
 						{settings.value['shortcuts.global.toggleManualRecording']}
-					</kbd>
+					</Kbd.Root>
 				</Link>{' '}
 				to start recording anywhere.
 			</p>

--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -19,7 +19,7 @@
 		type RecordingMode,
 		VAD_STATE_TO_ICON,
 	} from '$lib/constants/audio';
-	import { getShortcutDisplayLabel } from '$lib/constants/keyboard';
+	import { getShortcutDisplayKeys } from '$lib/constants/keyboard';
 	import { rpc } from '$lib/query';
 	import { vadRecorder } from '$lib/query/vad.svelte';
 	import * as services from '$lib/services';
@@ -366,11 +366,11 @@
 				tooltip="Go to local shortcut in settings"
 				href="/settings/shortcuts/local"
 			>
-				<Kbd.Root>
-					{getShortcutDisplayLabel(
-						settings.value['shortcuts.local.toggleManualRecording'],
-					)}
-				</Kbd.Root>
+				<Kbd.Group>
+					{#each getShortcutDisplayKeys(settings.value['shortcuts.local.toggleManualRecording']) as key}
+						<Kbd.Root>{key}</Kbd.Root>
+					{/each}
+				</Kbd.Group>
 			</Link>{' '}
 			to start recording here.
 		</p>
@@ -381,9 +381,11 @@
 					tooltip="Go to global shortcut in settings"
 					href="/settings/shortcuts/global"
 				>
-					<Kbd.Root>
-						{settings.value['shortcuts.global.toggleManualRecording']}
-					</Kbd.Root>
+					<Kbd.Group>
+						{#each getShortcutDisplayKeys(settings.value['shortcuts.global.toggleManualRecording']) as key}
+							<Kbd.Root>{key}</Kbd.Root>
+						{/each}
+					</Kbd.Group>
 				</Link>{' '}
 				to start recording anywhere.
 			</p>


### PR DESCRIPTION
This PR migrates keyboard shortcut displays to use the semantic `Kbd.Root` component from shadcn-svelte and simplifies the display formatting.

The first commit replaced raw `<kbd>` elements and Badge components with `Kbd.Group` containing individual `Kbd.Root` elements for each key. The second commit simplifies this further by formatting shortcuts with spaced plus signs (e.g., "Ctrl + Shift + A") directly in `getShortcutDisplayLabel`, which allows using a single `Kbd.Root` instead of the more verbose `Kbd.Group` + `{#each}` pattern.

Badge components that were using `font-mono` to display keyboard shortcuts have been converted to Kbd.Root, while non-keyboard Badge usages (status indicators, IDs, costs) remain unchanged.