### PR TITLE
refactor(ui): add Spinner component and replace animate-spin loaders

### DIFF
--- a/apps/whispering/src/lib/components/NotificationLog.svelte
+++ b/apps/whispering/src/lib/components/NotificationLog.svelte
@@ -33,7 +33,7 @@
 	import AlertTriangle from '@lucide/svelte/icons/alert-triangle';
 	import CheckCircle2 from '@lucide/svelte/icons/check-circle-2';
 	import Info from '@lucide/svelte/icons/info';
-	import Loader from '@lucide/svelte/icons/loader';
+	import { Spinner } from '@epicenter/ui/spinner';
 	import { mode } from 'mode-watcher';
 </script>
 
@@ -75,7 +75,7 @@
 							<div data-icon class="text-info"><Info class="size-4" /></div>
 						{:else if log.variant === 'loading'}
 							<div data-icon class="text-muted-foreground">
-								<Loader class="size-4 animate-spin" />
+								<Spinner />
 							</div>
 						{/if}
 						<div class="flex-1">

--- a/apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte
@@ -7,7 +7,7 @@
 	import { settings } from '$lib/stores/settings.svelte';
 	import CheckIcon from '@lucide/svelte/icons/check';
 	import Download from '@lucide/svelte/icons/download';
-	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
+	import { Spinner } from '@epicenter/ui/spinner';
 	import X from '@lucide/svelte/icons/x';
 	import { Badge } from '@epicenter/ui/badge';
 	import { Button } from '@epicenter/ui/button';
@@ -347,7 +347,7 @@
 	<div class="flex items-center gap-2">
 		{#if modelState.type === 'downloading'}
 			<div class="flex items-center gap-2 min-w-[120px]">
-				<LoaderCircle class="size-4 animate-spin" />
+				<Spinner />
 				<span class="text-sm font-medium">{modelState.progress}%</span>
 			</div>
 		{:else if modelState.type === 'ready'}

--- a/apps/whispering/src/lib/components/settings/selectors/ManualDeviceSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/ManualDeviceSelector.svelte
@@ -10,6 +10,7 @@
 	import CheckIcon from '@lucide/svelte/icons/check';
 	import MicIcon from '@lucide/svelte/icons/mic';
 	import RefreshCwIcon from '@lucide/svelte/icons/refresh-cw';
+	import { Spinner } from '@epicenter/ui/spinner';
 	import { Badge } from '@epicenter/ui/badge';
 
 	const combobox = useCombobox();
@@ -167,12 +168,11 @@
 							getDevicesQuery.refetch();
 						}}
 					>
-						<RefreshCwIcon
-							class={cn(
-								'mr-2 size-4',
-								getDevicesQuery.isRefetching && 'animate-spin',
-							)}
-						/>
+						{#if getDevicesQuery.isRefetching}
+							<Spinner />
+						{:else}
+							<RefreshCwIcon class="size-4" />
+						{/if}
 						Refresh devices
 					</Command.Item>
 				</Command.Group>

--- a/apps/whispering/src/lib/components/settings/selectors/VadDeviceSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/VadDeviceSelector.svelte
@@ -11,6 +11,7 @@
 	import CheckIcon from '@lucide/svelte/icons/check';
 	import MicIcon from '@lucide/svelte/icons/mic';
 	import RefreshCwIcon from '@lucide/svelte/icons/refresh-cw';
+	import { Spinner } from '@epicenter/ui/spinner';
 
 	const combobox = useCombobox();
 
@@ -102,12 +103,11 @@
 						getDevicesQuery.refetch();
 					}}
 				>
-					<RefreshCwIcon
-						class={cn(
-							'mr-2 size-4',
-							getDevicesQuery.isRefetching && 'animate-spin',
-						)}
-					/>
+					{#if getDevicesQuery.isRefetching}
+						<Spinner />
+					{:else}
+						<RefreshCwIcon class="size-4" />
+					{/if}
 					Refresh devices
 				</Command.Item>
 			</Command.Group>

--- a/apps/whispering/src/lib/components/transformations-editor/Test.svelte
+++ b/apps/whispering/src/lib/components/transformations-editor/Test.svelte
@@ -7,7 +7,7 @@
 	import { rpc } from '$lib/query';
 	import type { Transformation } from '$lib/services/db';
 	import { createMutation } from '@tanstack/svelte-query';
-	import Loader2Icon from '@lucide/svelte/icons/loader-2';
+	import { Spinner } from '@epicenter/ui/spinner';
 	import PlayIcon from '@lucide/svelte/icons/play';
 
 	const transformInput = createMutation(rpc.transformer.transformInput.options);
@@ -67,9 +67,9 @@
 		class="w-full"
 	>
 		{#if transformInput.isPending}
-			<Loader2Icon class="mr-2 size-4 animate-spin" />
+			<Spinner />
 		{:else}
-			<PlayIcon class="mr-2 size-4" />
+			<PlayIcon class="size-4" />
 		{/if}
 		{transformInput.isPending
 			? 'Running Transformation...'

--- a/apps/whispering/src/routes/(app)/(config)/install-ffmpeg/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/install-ffmpeg/+page.svelte
@@ -10,7 +10,7 @@
 	import DownloadIcon from '@lucide/svelte/icons/download';
 	import CheckCircleIcon from '@lucide/svelte/icons/check-circle';
 	import XCircleIcon from '@lucide/svelte/icons/x-circle';
-	import LoaderIcon from '@lucide/svelte/icons/loader';
+	import { Spinner } from '@epicenter/ui/spinner';
 	import RefreshCwIcon from '@lucide/svelte/icons/refresh-cw';
 	import ExternalLinkIcon from '@lucide/svelte/icons/external-link';
 	import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
@@ -52,7 +52,7 @@
 					<div class="flex flex-col items-end gap-3">
 						{#if ffmpegQuery.isPending}
 							<Badge variant="secondary" class="gap-1.5">
-								<LoaderIcon class="size-3 animate-spin" />
+								<Spinner class="size-3" />
 								Checking
 							</Badge>
 						{:else if ffmpegQuery.data === true}
@@ -77,9 +77,11 @@
 							title="Check again"
 							class="size-8"
 						>
-							<RefreshCwIcon
-								class="size-4 {ffmpegQuery.isFetching ? 'animate-spin' : ''}"
-							/>
+							{#if ffmpegQuery.isFetching}
+								<Spinner />
+							{:else}
+								<RefreshCwIcon class="size-4" />
+							{/if}
 						</Button>
 					</div>
 				</div>
@@ -428,18 +430,3 @@
 		</Card.Root>
 	</div>
 </main>
-
-<style>
-	:global(.animate-spin) {
-		animation: spin 1s linear infinite;
-	}
-
-	@keyframes spin {
-		from {
-			transform: rotate(0deg);
-		}
-		to {
-			transform: rotate(360deg);
-		}
-	}
-</style>

--- a/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/EditRecordingModal.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/EditRecordingModal.svelte
@@ -10,7 +10,7 @@
 	import * as services from '$lib/services';
 	import { createMutation, createQuery } from '@tanstack/svelte-query';
 	import EditIcon from '@lucide/svelte/icons/pencil';
-	import Loader2Icon from '@lucide/svelte/icons/loader-2';
+	import { Spinner } from '@epicenter/ui/spinner';
 	import { onDestroy } from 'svelte';
 
 	const updateRecording = createMutation(rpc.db.recordings.update.options);
@@ -223,7 +223,7 @@
 				disabled={deleteRecording.isPending}
 			>
 				{#if deleteRecording.isPending}
-					<Loader2Icon class="mr-2 size-4 animate-spin" />
+					<Spinner />
 				{/if}
 				Delete
 			</Button>
@@ -252,7 +252,7 @@
 				disabled={updateRecording.isPending || !isWorkingCopyDirty}
 			>
 				{#if updateRecording.isPending}
-					<Loader2Icon class="mr-2 size-4 animate-spin" />
+					<Spinner />
 				{/if}
 				Save
 			</Button>

--- a/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/RecordingRowActions.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/RecordingRowActions.svelte
@@ -12,7 +12,7 @@
 	import DownloadIcon from '@lucide/svelte/icons/download';
 	import EllipsisIcon from '@lucide/svelte/icons/ellipsis';
 	import FileStackIcon from '@lucide/svelte/icons/file-stack';
-	import Loader2Icon from '@lucide/svelte/icons/loader-2';
+	import { Spinner } from '@epicenter/ui/spinner';
 	import PlayIcon from '@lucide/svelte/icons/play';
 	import RepeatIcon from '@lucide/svelte/icons/repeat';
 	import EditRecordingModal from './EditRecordingModal.svelte';
@@ -119,7 +119,7 @@
 		</CopyToClipboardButton>
 
 		{#if latestTransformationRunByRecordingIdQuery.isPending}
-			<Loader2Icon class="size-4 animate-spin" />
+			<Spinner />
 		{:else if latestTransformationRunByRecordingIdQuery.isError}
 			<Tooltip.Provider>
 				<Tooltip.Root>
@@ -184,7 +184,7 @@
 			size="icon"
 		>
 			{#if downloadRecording.isPending}
-				<Loader2Icon class="size-4 animate-spin" />
+				<Spinner />
 			{:else}
 				<DownloadIcon class="size-4" />
 			{/if}

--- a/apps/whispering/src/routes/(app)/(config)/transformations/EditTransformationModal.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/transformations/EditTransformationModal.svelte
@@ -9,7 +9,7 @@
 	import type { Transformation } from '$lib/services/db';
 	import { createMutation } from '@tanstack/svelte-query';
 	import HistoryIcon from '@lucide/svelte/icons/history';
-	import Loader2Icon from '@lucide/svelte/icons/loader-2';
+	import { Spinner } from '@epicenter/ui/spinner';
 	import PlayIcon from '@lucide/svelte/icons/play';
 	import TrashIcon from '@lucide/svelte/icons/trash';
 	import MarkTransformationActiveButton from './MarkTransformationActiveButton.svelte';
@@ -170,9 +170,9 @@
 				disabled={deleteTransformation.isPending}
 			>
 				{#if deleteTransformation.isPending}
-					<Loader2Icon class="mr-2 size-4 animate-spin" />
+					<Spinner />
 				{:else}
-					<TrashIcon class="size-4 mr-1" />
+					<TrashIcon class="size-4" />
 				{/if}
 				Delete
 			</Button>
@@ -204,7 +204,7 @@
 					disabled={updateTransformation.isPending || !isWorkingCopyDirty}
 				>
 					{#if updateTransformation.isPending}
-						<Loader2Icon class="mr-2 size-4 animate-spin" />
+						<Spinner />
 					{/if}
 					Save
 				</Button>

--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -27,7 +27,7 @@
 	import { settings } from '$lib/stores/settings.svelte';
 	import { createBlobUrlManager } from '$lib/utils/blobUrlManager';
 	import { getRecordingTransitionId } from '$lib/utils/getRecordingTransitionId';
-	import Loader2Icon from '@lucide/svelte/icons/loader-2';
+	import { Spinner } from '@epicenter/ui/spinner';
 	import {
 		ACCEPT_AUDIO,
 		ACCEPT_VIDEO,
@@ -335,7 +335,7 @@
 					hasNoTranscribedText}
 			>
 				{#if latestRecording.transcriptionStatus === 'TRANSCRIBING'}
-					<Loader2Icon class="size-6 animate-spin" />
+					<Spinner class="size-6" />
 				{:else}
 					<ClipboardIcon class="size-6" />
 				{/if}

--- a/bun.lock
+++ b/bun.lock
@@ -274,7 +274,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@fontsource-variable/manrope": "^5.2.6",
-        "@lucide/svelte": "catalog:",
+        "@lucide/svelte": "^0.544.0",
         "@tanstack/svelte-table": "catalog:",
         "bits-ui": "catalog:",
         "clsx": "catalog:",
@@ -2552,6 +2552,8 @@
     "@cloudflare/kv-asset-handler/mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
+    "@epicenter/ui/@lucide/svelte": ["@lucide/svelte@0.544.0", "", { "peerDependencies": { "svelte": "^5" } }, "sha512-9f9O6uxng2pLB01sxNySHduJN3HTl5p0HDu4H26VR51vhZfiMzyOMe9Mhof3XAk4l813eTtl+/DYRvGyoRR+yw=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,7 +21,7 @@
 	},
 	"dependencies": {
 		"@fontsource-variable/manrope": "^5.2.6",
-		"@lucide/svelte": "catalog:",
+		"@lucide/svelte": "^0.544.0",
 		"@tanstack/svelte-table": "catalog:",
 		"bits-ui": "catalog:",
 		"clsx": "catalog:",

--- a/packages/ui/src/spinner/index.ts
+++ b/packages/ui/src/spinner/index.ts
@@ -1,0 +1,1 @@
+export { default as Spinner } from "./spinner.svelte";

--- a/packages/ui/src/spinner/spinner.svelte
+++ b/packages/ui/src/spinner/spinner.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { cn } from "#/utils/utils.js";
+	import Loader2Icon from "@lucide/svelte/icons/loader-2";
+	import type { ComponentProps } from "svelte";
+
+	let { class: className, ...restProps }: ComponentProps<typeof Loader2Icon> = $props();
+</script>
+
+<Loader2Icon
+	role="status"
+	aria-label="Loading"
+	class={cn("size-4 animate-spin", className)}
+	{...restProps}
+/>


### PR DESCRIPTION
This introduces a dedicated Spinner component from shadcn-svelte and replaces all ad-hoc loader icon implementations that used the animate-spin class. Previously, various loader icons (Loader2Icon, LoaderIcon, LoaderCircle) were scattered throughout the codebase with manual animate-spin classes.

The new Spinner component encapsulates the loading animation in one place, making it easier to maintain consistent loading indicators. For refresh buttons that previously spun conditionally, they now swap to a Spinner during refetch rather than animating the refresh icon itself.

I also removed manual mr-2 spacing classes from icons inside Button and Command.Item components since both already have gap-2 built into their base styles. The redundant CSS keyframes in install-ffmpeg that duplicated Tailwind's animate-spin were also cleaned up.