### PR TITLE
feat(ui): add ButtonGroup component for pagination buttons

### DIFF
--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -3,6 +3,7 @@
 	import { ClipboardIcon, TrashIcon } from '$lib/components/icons';
 	import { Badge } from '@epicenter/ui/badge';
 	import { Button, buttonVariants } from '@epicenter/ui/button';
+	import * as ButtonGroup from '@epicenter/ui/button-group';
 	import { Card } from '@epicenter/ui/card';
 	import { Checkbox } from '@epicenter/ui/checkbox';
 	import * as Dialog from '@epicenter/ui/dialog';
@@ -655,7 +656,7 @@
 				{selectedRecordingRows.length} of {table.getFilteredRowModel().rows
 					.length} row(s) selected.
 			</div>
-			<div class="flex items-center space-x-2">
+			<ButtonGroup.Root>
 				<Button
 					variant="outline"
 					size="sm"
@@ -672,7 +673,7 @@
 				>
 					Next
 				</Button>
-			</div>
+			</ButtonGroup.Root>
 		</div>
 	</Card>
 </main>

--- a/apps/whispering/src/routes/(app)/(config)/transformations/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/transformations/+page.svelte
@@ -3,6 +3,7 @@
 	import { TrashIcon } from '$lib/components/icons';
 	import { Badge } from '@epicenter/ui/badge';
 	import { Button } from '@epicenter/ui/button';
+	import * as ButtonGroup from '@epicenter/ui/button-group';
 	import { Checkbox } from '@epicenter/ui/checkbox';
 	import { Input } from '@epicenter/ui/input';
 	import { Skeleton } from '@epicenter/ui/skeleton';
@@ -324,7 +325,7 @@
 			{selectedTransformationRows.length} of {table.getFilteredRowModel().rows
 				.length} row(s) selected.
 		</div>
-		<div class="flex items-center space-x-2">
+		<ButtonGroup.Root>
 			<Button
 				variant="outline"
 				size="sm"
@@ -341,6 +342,6 @@
 			>
 				Next
 			</Button>
-		</div>
+		</ButtonGroup.Root>
 	</div>
 </main>

--- a/bun.lock
+++ b/bun.lock
@@ -276,7 +276,7 @@
         "@fontsource-variable/manrope": "^5.2.6",
         "@lucide/svelte": "catalog:",
         "@tanstack/svelte-table": "catalog:",
-        "bits-ui": "catalog:",
+        "bits-ui": "^2.11.0",
         "clsx": "catalog:",
         "paneforge": "^1.0.2",
         "svelte-check": "catalog:",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -23,7 +23,7 @@
 		"@fontsource-variable/manrope": "^5.2.6",
 		"@lucide/svelte": "catalog:",
 		"@tanstack/svelte-table": "catalog:",
-		"bits-ui": "catalog:",
+		"bits-ui": "^2.11.0",
 		"clsx": "catalog:",
 		"paneforge": "^1.0.2",
 		"svelte-check": "catalog:",

--- a/packages/ui/src/button-group/button-group-separator.svelte
+++ b/packages/ui/src/button-group/button-group-separator.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn } from "#/utils/utils.js";
+	import type { ComponentProps } from "svelte";
+	import { Separator } from "#/separator/index.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		orientation = "vertical",
+		...restProps
+	}: ComponentProps<typeof Separator> = $props();
+</script>
+
+<Separator
+	bind:ref
+	data-slot="button-group-separator"
+	{orientation}
+	class={cn("bg-input relative !m-0 self-stretch data-[orientation=vertical]:h-auto", className)}
+	{...restProps}
+/>

--- a/packages/ui/src/button-group/button-group-text.svelte
+++ b/packages/ui/src/button-group/button-group-text.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+	import type { Snippet } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		child,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		child?: Snippet<[{ props: Record<string, unknown> }]>;
+	} = $props();
+
+	const mergedProps = $derived({
+		...restProps,
+		class: cn(
+			"bg-muted shadow-xs flex items-center gap-2 rounded-md border px-4 text-sm font-medium [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none",
+			className
+		),
+	});
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<div bind:this={ref} {...mergedProps}>
+		{@render mergedProps.children?.()}
+	</div>
+{/if}

--- a/packages/ui/src/button-group/button-group.svelte
+++ b/packages/ui/src/button-group/button-group.svelte
@@ -1,0 +1,46 @@
+<script lang="ts" module>
+	import { tv, type VariantProps } from "tailwind-variants";
+
+	export const buttonGroupVariants = tv({
+		base: "flex w-fit items-stretch has-[>[data-slot=button-group]]:gap-2 [&>*]:focus-visible:relative [&>*]:focus-visible:z-10 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-e-md [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
+		variants: {
+			orientation: {
+				horizontal:
+					"[&>*:not(:first-child)]:rounded-s-none [&>*:not(:first-child)]:border-s-0 [&>*:not(:last-child)]:rounded-e-none",
+				vertical:
+					"flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:border-t-0 [&>*:not(:last-child)]:rounded-b-none",
+			},
+		},
+		defaultVariants: {
+			orientation: "horizontal",
+		},
+	});
+
+	export type ButtonGroupOrientation = VariantProps<typeof buttonGroupVariants>["orientation"];
+</script>
+
+<script lang="ts">
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		orientation = "horizontal",
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		orientation?: ButtonGroupOrientation;
+	} = $props();
+</script>
+
+<div
+	bind:this={ref}
+	role="group"
+	data-slot="button-group"
+	data-orientation={orientation}
+	class={cn(buttonGroupVariants({ orientation }), className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/button-group/index.ts
+++ b/packages/ui/src/button-group/index.ts
@@ -1,0 +1,13 @@
+import Root from "./button-group.svelte";
+import Text from "./button-group-text.svelte";
+import Separator from "./button-group-separator.svelte";
+
+export {
+	Root,
+	Text,
+	Separator,
+	//
+	Root as ButtonGroup,
+	Text as ButtonGroupText,
+	Separator as ButtonGroupSeparator,
+};


### PR DESCRIPTION
This adds the shadcn-svelte ButtonGroup component and uses it to visually group the Previous/Next pagination buttons on the recordings and transformations data table pages.

The ButtonGroup connects adjacent buttons by removing the border radius between them, creating a cleaner visual indication that these buttons are related navigation controls. This follows the shadcn-svelte pattern and improves the visual hierarchy of the data table toolbar.

Note: ButtonGroup only works correctly when Button components are direct children. Components wrapped in Dialog.Trigger, DropdownMenu.Root, or similar wrappers break the CSS selectors that handle border-radius removal. For this reason, only the pagination buttons use ButtonGroup; the action toolbar buttons remain as regular flex containers with gap spacing.