### PR TITLE
fix(ui): preserve onclick handlers when button has tooltip

### DIFF
--- a/packages/ui/src/button/button.svelte
+++ b/packages/ui/src/button/button.svelte
@@ -68,8 +68,8 @@
 			aria-disabled={disabled}
 			role={disabled ? "link" : undefined}
 			tabindex={disabled ? -1 : undefined}
-			{...restProps}
 			{...tooltipProps}
+			{...restProps}
 		>
 			{@render children?.()}
 		</a>
@@ -80,8 +80,8 @@
 			class={cn(buttonVariants({ variant, size }), className)}
 			{type}
 			{disabled}
-			{...restProps}
 			{...tooltipProps}
+			{...restProps}
 		>
 			{@render children?.()}
 		</button>


### PR DESCRIPTION
When the Button component was updated to support tooltips via the `tooltip` prop, the prop spread order caused user-provided event handlers to be overwritten.

The issue was that `tooltipProps` (from bits-ui's Tooltip.Trigger child snippet) was spread after `restProps`. In Svelte 5, later prop spreads override earlier ones, so any `onclick` handler passed to the Button would be replaced by the tooltip's internal handlers.

The fix swaps the spread order so user props take precedence:

```svelte
{...tooltipProps}
{...restProps}
```

The tooltip continues to work correctly because its ARIA attributes and hover/focus handlers that users don't typically override are still applied.