### PR TITLE
feat(ui): add Empty component and standardize empty states

### DIFF
--- a/apps/whispering/src/lib/components/NotificationLog.svelte
+++ b/apps/whispering/src/lib/components/NotificationLog.svelte
@@ -27,10 +27,12 @@
 <script lang="ts">
 	import * as Alert from '@epicenter/ui/alert';
 	import * as Dialog from '@epicenter/ui/dialog';
+	import * as Empty from '@epicenter/ui/empty';
 	import type { UnifiedNotificationOptions } from '$lib/services/notifications/types';
 	import { ScrollArea } from '@epicenter/ui/scroll-area';
 	import AlertCircle from '@lucide/svelte/icons/alert-circle';
 	import AlertTriangle from '@lucide/svelte/icons/alert-triangle';
+	import BellIcon from '@lucide/svelte/icons/bell';
 	import CheckCircle2 from '@lucide/svelte/icons/check-circle-2';
 	import Info from '@lucide/svelte/icons/info';
 	import Loader from '@lucide/svelte/icons/loader';
@@ -93,11 +95,17 @@
 			{/each}
 
 			{#if notificationLog.logs.length === 0}
-				<div
-					class="flex h-32 items-center justify-center text-sm text-muted-foreground"
-				>
-					No logs to display
-				</div>
+				<Empty.Root class="h-32">
+					<Empty.Header>
+						<Empty.Media variant="icon">
+							<BellIcon />
+						</Empty.Media>
+						<Empty.Title>No notifications yet</Empty.Title>
+						<Empty.Description>
+							Notifications will appear here as they occur.
+						</Empty.Description>
+					</Empty.Header>
+				</Empty.Root>
 			{/if}
 		</ScrollArea>
 	</Dialog.Content>

--- a/apps/whispering/src/lib/components/transformations-editor/Runs.svelte
+++ b/apps/whispering/src/lib/components/transformations-editor/Runs.svelte
@@ -7,8 +7,10 @@
 	import { getTransformationStepRunTransitionId } from '$lib/utils/getRecordingTransitionId';
 	import ChevronDown from '@lucide/svelte/icons/chevron-down';
 	import ChevronRight from '@lucide/svelte/icons/chevron-right';
+	import PlayIcon from '@lucide/svelte/icons/play';
 	import Trash2 from '@lucide/svelte/icons/trash-2';
 	import { Badge } from '@epicenter/ui/badge';
+	import * as Empty from '@epicenter/ui/empty';
 	import { Button } from '@epicenter/ui/button';
 	import * as Card from '@epicenter/ui/card';
 	import { Label } from '@epicenter/ui/label';
@@ -32,19 +34,17 @@
 </script>
 
 {#if runs.length === 0}
-	<div class="flex h-full items-center justify-center">
-		<div class="flex flex-col items-center gap-4 text-center">
-			<div class="rounded-full bg-muted p-4">
-				<ChevronRight class="size-6 text-muted-foreground" />
-			</div>
-			<div class="space-y-1">
-				<h3 class="text-xl font-semibold">No Runs Yet</h3>
-				<p class="text-muted-foreground">
-					When you run a transformation, the results will appear here.
-				</p>
-			</div>
-		</div>
-	</div>
+	<Empty.Root class="h-full">
+		<Empty.Header>
+			<Empty.Media variant="icon">
+				<PlayIcon />
+			</Empty.Media>
+			<Empty.Title>No runs yet</Empty.Title>
+			<Empty.Description>
+				When you run a transformation, the results will appear here.
+			</Empty.Description>
+		</Empty.Header>
+	</Empty.Root>
 {:else}
 	<div class="space-y-4">
 		<div class="flex justify-end px-2">

--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -34,7 +34,10 @@
 		getPaginationRowModel,
 		getSortedRowModel,
 	} from '@tanstack/table-core';
+	import * as Empty from '@epicenter/ui/empty';
 	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+	import MicIcon from '@lucide/svelte/icons/mic';
+	import SearchIcon from '@lucide/svelte/icons/search';
 	import EllipsisIcon from '@lucide/svelte/icons/ellipsis';
 	import LoadingTranscriptionIcon from '@lucide/svelte/icons/ellipsis';
 	import RetryTranscriptionIcon from '@lucide/svelte/icons/repeat';
@@ -637,12 +640,32 @@
 						{/each}
 					{:else}
 						<Table.Row>
-							<Table.Cell colspan={columns.length} class="h-24 text-center">
-								{#if globalFilter}
-									No recordings found.
-								{:else}
-									No recordings yet. Start recording to add one.
-								{/if}
+							<Table.Cell colspan={columns.length}>
+								<Empty.Root class="py-8">
+									<Empty.Header>
+										<Empty.Media variant="icon">
+											{#if globalFilter}
+												<SearchIcon />
+											{:else}
+												<MicIcon />
+											{/if}
+										</Empty.Media>
+										<Empty.Title>
+											{#if globalFilter}
+												No recordings found
+											{:else}
+												No recordings yet
+											{/if}
+										</Empty.Title>
+										<Empty.Description>
+											{#if globalFilter}
+												Try adjusting your search or filters.
+											{:else}
+												Start recording to add one.
+											{/if}
+										</Empty.Description>
+									</Empty.Header>
+								</Empty.Root>
 							</Table.Cell>
 						</Table.Row>
 					{/if}

--- a/apps/whispering/src/routes/(app)/(config)/transformations/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/transformations/+page.svelte
@@ -29,6 +29,9 @@
 		getPaginationRowModel,
 		getSortedRowModel,
 	} from '@tanstack/table-core';
+	import * as Empty from '@epicenter/ui/empty';
+	import SearchIcon from '@lucide/svelte/icons/search';
+	import WandSparklesIcon from '@lucide/svelte/icons/wand-sparkles';
 	import { createRawSnippet } from 'svelte';
 	import { type } from 'arktype';
 	import CreateTransformationButton from './CreateTransformationButton.svelte';
@@ -305,13 +308,32 @@
 					{/each}
 				{:else}
 					<Table.Row>
-						<Table.Cell colspan={columns.length} class="h-24 text-center">
-							{#if globalFilter}
-								No transformations found.
-							{:else}
-								No transformations yet. Click "Create Transformation" to add
-								one.
-							{/if}
+						<Table.Cell colspan={columns.length}>
+							<Empty.Root class="py-8">
+								<Empty.Header>
+									<Empty.Media variant="icon">
+										{#if globalFilter}
+											<SearchIcon />
+										{:else}
+											<WandSparklesIcon />
+										{/if}
+									</Empty.Media>
+									<Empty.Title>
+										{#if globalFilter}
+											No transformations found
+										{:else}
+											No transformations yet
+										{/if}
+									</Empty.Title>
+									<Empty.Description>
+										{#if globalFilter}
+											Try adjusting your search or filters.
+										{:else}
+											Click "Create Transformation" to add one.
+										{/if}
+									</Empty.Description>
+								</Empty.Header>
+							</Empty.Root>
 						</Table.Cell>
 					</Table.Row>
 				{/if}

--- a/packages/ui/src/empty/empty-content.svelte
+++ b/packages/ui/src/empty/empty-content.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="empty-content"
+	class={cn(
+		"flex w-full min-w-0 max-w-sm flex-col items-center gap-4 text-balance text-sm",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/empty/empty-description.svelte
+++ b/packages/ui/src/empty/empty-description.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="empty-description"
+	class={cn(
+		"text-muted-foreground [&>a:hover]:text-primary text-sm/relaxed [&>a]:underline [&>a]:underline-offset-4",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/empty/empty-header.svelte
+++ b/packages/ui/src/empty/empty-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="empty-header"
+	class={cn("flex max-w-sm flex-col items-center gap-2 text-center", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/empty/empty-media.svelte
+++ b/packages/ui/src/empty/empty-media.svelte
@@ -1,0 +1,41 @@
+<script lang="ts" module>
+	import { tv, type VariantProps } from "tailwind-variants";
+
+	export const emptyMediaVariants = tv({
+		base: "mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		variants: {
+			variant: {
+				default: "bg-transparent",
+				icon: "bg-muted text-foreground flex size-10 shrink-0 items-center justify-center rounded-lg [&_svg:not([class*='size-'])]:size-6",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+		},
+	});
+
+	export type EmptyMediaVariant = VariantProps<typeof emptyMediaVariants>["variant"];
+</script>
+
+<script lang="ts">
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		variant = "default",
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & { variant?: EmptyMediaVariant } = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="empty-icon"
+	data-variant={variant}
+	class={cn(emptyMediaVariants({ variant }), className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/empty/empty-title.svelte
+++ b/packages/ui/src/empty/empty-title.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="empty-title"
+	class={cn("text-lg font-medium tracking-tight", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/empty/empty.svelte
+++ b/packages/ui/src/empty/empty.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "#/utils/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="empty"
+	class={cn(
+		"flex min-w-0 flex-1 flex-col items-center justify-center gap-6 text-balance rounded-lg border-dashed p-6 text-center md:p-12",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/empty/index.ts
+++ b/packages/ui/src/empty/index.ts
@@ -1,0 +1,22 @@
+import Root from "./empty.svelte";
+import Header from "./empty-header.svelte";
+import Media from "./empty-media.svelte";
+import Title from "./empty-title.svelte";
+import Description from "./empty-description.svelte";
+import Content from "./empty-content.svelte";
+
+export {
+	Root,
+	Header,
+	Media,
+	Title,
+	Description,
+	Content,
+	//
+	Root as Empty,
+	Header as EmptyHeader,
+	Media as EmptyMedia,
+	Title as EmptyTitle,
+	Description as EmptyDescription,
+	Content as EmptyContent,
+};


### PR DESCRIPTION
This adds the Empty component from shadcn-svelte to the UI package and migrates four existing empty state implementations to use it, creating visual consistency across the app.

Previously, empty states were implemented ad-hoc with plain text in table cells or custom div layouts. Now they all share a common structure: icon + title + description, which gives users better visual feedback about what's missing and what action to take.

Each empty state uses a contextually appropriate icon:
- **Recordings table**: Mic icon when truly empty ("No recordings yet"), search icon when filtered with no results
- **Transformations table**: Wand-sparkles icon when empty, search icon when filtered
- **Transformation runs**: Play icon, since runs are created by executing transformations
- **Notification log**: Bell icon to match the notification theme

The table empty states also distinguish between "nothing exists yet" and "nothing matches your filter" with different messages and icons, which helps users understand whether they need to create new data or adjust their search.