### PR TITLE
fix(whispering): Recordings Page Output Folder Button Inconsistency

### DIFF
--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -50,6 +50,7 @@
 	import { format } from 'date-fns';
 	import OpenFolderButton from '$lib/components/OpenFolderButton.svelte';
 	import { PATHS } from '$lib/constants/paths';
+	import { settings } from '$lib/stores/settings.svelte';
 
 	/**
 	 * Returns a cell renderer for a date/time column using date-fns format.
@@ -505,8 +506,7 @@
 												},
 												onError: (error) => {
 													rpc.notify.error.execute({
-														title:
-															'Error copying transcripts to clipboard',
+														title: 'Error copying transcripts to clipboard',
 														description: error.message,
 														action: { type: 'more-details', error: error },
 													});
@@ -560,7 +560,13 @@
 				{/if}
 
 				<OpenFolderButton
-					getFolderPath={PATHS.DB.RECORDINGS}
+					getFolderPath={async () => {
+						// Use the configured output folder if set, otherwise use default
+						return (
+							settings.value['recording.cpal.outputFolder'] ??
+							(await PATHS.DB.RECORDINGS())
+						);
+					}}
 					tooltipText="Open recordings folder"
 				/>
 


### PR DESCRIPTION
## Fix: Recordings Page Output Folder Button Inconsistency

This fixes the "Open Recordings Folder" button on the Recordings page to respect the user's custom output folder setting from Settings > Recording. Previously, only the Settings page button opened the correct location, while the Recordings page button always opened the hardcoded default app data directory.

The fix ensures both buttons use the same logic: check `settings.value['recording.cpal.outputFolder']` first, then fall back to `PATHS.DB.RECORDINGS()` if not configured.

**Key areas affected:**

- Recordings page OpenFolderButton component (`/routes/(app)/(config)/recordings/+page.svelte`)
- Both CPAL and FFmpeg recording methods (they share the same output folder setting)

**User impact before fix:**

1. User changes output folder in Settings to custom location (e.g., `~/Documents/Recordings`)
2. New recordings are correctly saved to `~/Documents/Recordings`
3. Settings page "Open Folder" button correctly opens `~/Documents/Recordings`
4. **Bug:** Recordings page "Open Folder" button still opens `~/Library/Application Support/whispering/recordings` (default location)

**After fix:**

Both "Open Output Folder" buttons consistently open the user's configured output folder, making it easy to access recordings from either location in the app.

## Type of Change

- [x] `fix`: Bug fix

## Related Issue

Closes #1106 

<img width="1822" height="1184" alt="Screenshot 2025-12-07 at 11 08 38 AM" src="https://github.com/user-attachments/assets/d6b7c4f7-642a-4b9e-90cc-0bca5aaa655b" />
<img width="1822" height="1184" alt="Screenshot 2025-12-07 at 11 09 06 AM" src="https://github.com/user-attachments/assets/1a67c957-14ca-49e8-9522-9cae980154e6" />
