### PR TITLE
refactor(errors): migrate to wellcrafted v0.28.0 explicit context/cause API

### DIFF
--- a/apps/whispering/src/lib/components/MigrationDialog.svelte
+++ b/apps/whispering/src/lib/components/MigrationDialog.svelte
@@ -669,7 +669,6 @@
 					);
 					throw DbServiceErr({
 						message: 'Failed to migrate recordings',
-						cause: error,
 					});
 				},
 			});
@@ -822,7 +821,6 @@
 					);
 					throw DbServiceErr({
 						message: 'Failed to migrate transformations',
-						cause: error,
 					});
 				},
 			});
@@ -978,7 +976,6 @@
 					);
 					throw DbServiceErr({
 						message: 'Failed to migrate transformation runs',
-						cause: error,
 					});
 				},
 			});
@@ -1041,7 +1038,6 @@
 				catch: (error) => {
 					throw DbServiceErr({
 						message: 'Failed to get migration counts',
-						cause: error,
 					});
 				},
 			});

--- a/apps/whispering/src/lib/query/actions.ts
+++ b/apps/whispering/src/lib/query/actions.ts
@@ -435,8 +435,6 @@ export const commands = {
 			if (validFiles.length === 0) {
 				return DbServiceErr({
 					message: 'No valid audio or video files found.',
-					context: { providedFiles: files.length },
-					cause: undefined,
 				});
 			}
 

--- a/apps/whispering/src/lib/query/transformer.ts
+++ b/apps/whispering/src/lib/query/transformer.ts
@@ -316,8 +316,6 @@ async function runTransformation({
 	if (!input.trim()) {
 		return TransformServiceErr({
 			message: 'Empty input. Please enter some text to transform',
-			cause: undefined,
-			context: { input, transformationId: transformation.id },
 		});
 	}
 
@@ -325,8 +323,6 @@ async function runTransformation({
 		return TransformServiceErr({
 			message:
 				'No steps configured. Please add at least one transformation step',
-			cause: undefined,
-			context: { transformation },
 		});
 	}
 
@@ -340,13 +336,6 @@ async function runTransformation({
 	if (createTransformationRunError)
 		return TransformServiceErr({
 			message: 'Unable to start transformation run',
-			cause: createTransformationRunError,
-			context: {
-				transformationId: transformation.id,
-				recordingId,
-				input,
-				createTransformationRunError,
-			},
 		});
 
 	let currentInput = input;
@@ -363,13 +352,6 @@ async function runTransformation({
 		if (addTransformationStepRunError)
 			return TransformServiceErr({
 				message: 'Unable to initialize transformation step',
-				cause: addTransformationStepRunError,
-				context: {
-					transformationRun,
-					stepId: step.id,
-					input: currentInput,
-					addTransformationStepRunError,
-				},
 			});
 
 		const handleStepResult = await handleStep({
@@ -389,13 +371,6 @@ async function runTransformation({
 			if (markTransformationRunAndRunStepAsFailedError)
 				return TransformServiceErr({
 					message: 'Unable to save failed transformation step result',
-					cause: markTransformationRunAndRunStepAsFailedError,
-					context: {
-						transformationRun,
-						stepId: newTransformationStepRun.id,
-						error: handleStepResult.error,
-						markTransformationRunAndRunStepAsFailedError,
-					},
 				});
 			return Ok(markedFailedTransformationRun);
 		}
@@ -412,13 +387,6 @@ async function runTransformation({
 		if (markTransformationRunStepAsCompletedError)
 			return TransformServiceErr({
 				message: 'Unable to save completed transformation step result',
-				cause: markTransformationRunStepAsCompletedError,
-				context: {
-					transformationRun,
-					stepRunId: newTransformationStepRun.id,
-					output: handleStepOutput,
-					markTransformationRunStepAsCompletedError,
-				},
 			});
 
 		currentInput = handleStepOutput;
@@ -432,12 +400,6 @@ async function runTransformation({
 	if (markTransformationRunAsCompletedError)
 		return TransformServiceErr({
 			message: 'Unable to save completed transformation run',
-			cause: markTransformationRunAsCompletedError,
-			context: {
-				transformationRun,
-				output: currentInput,
-				markTransformationRunAsCompletedError,
-			},
 		});
 	return Ok(markedCompletedTransformationRun);
 }

--- a/apps/whispering/src/lib/services/analytics/desktop.ts
+++ b/apps/whispering/src/lib/services/analytics/desktop.ts
@@ -1,4 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
+import { extractErrorMessage } from 'wellcrafted/error';
 import { tryAsync } from 'wellcrafted/result';
 import type { AnalyticsService } from './types';
 import { AnalyticsServiceErr } from './types';
@@ -16,9 +17,7 @@ export function createAnalyticsServiceDesktop(): AnalyticsService {
 				},
 				catch: (error) =>
 					AnalyticsServiceErr({
-						message: 'Failed to log analytics event via Tauri',
-						context: { event },
-						cause: error,
+						message: `Failed to log analytics event via Tauri: ${extractErrorMessage(error)}`,
 					}),
 			}),
 	};

--- a/apps/whispering/src/lib/services/analytics/web.ts
+++ b/apps/whispering/src/lib/services/analytics/web.ts
@@ -1,4 +1,5 @@
 import { init, trackEvent } from '@aptabase/web';
+import { extractErrorMessage } from 'wellcrafted/error';
 import { tryAsync } from 'wellcrafted/result';
 import type { AnalyticsService } from './types';
 import { AnalyticsServiceErr } from './types';
@@ -15,9 +16,7 @@ export function createAnalyticsServiceWeb(): AnalyticsService {
 				},
 				catch: (error) =>
 					AnalyticsServiceErr({
-						message: 'Failed to log analytics event',
-						context: { event },
-						cause: error,
+						message: `Failed to log analytics event: ${extractErrorMessage(error)}`,
 					}),
 			}),
 	};

--- a/apps/whispering/src/lib/services/command/desktop.ts
+++ b/apps/whispering/src/lib/services/command/desktop.ts
@@ -30,8 +30,6 @@ export function createCommandServiceDesktop(): CommandService {
 					console.error('[TS] execute: error:', error);
 					return CommandServiceErr({
 						message: 'Failed to execute command',
-						context: { command },
-						cause: error,
 					});
 				},
 			});
@@ -67,8 +65,6 @@ export function createCommandServiceDesktop(): CommandService {
 					console.error('[TS] spawn: error:', error);
 					return CommandServiceErr({
 						message: `Failed to spawn command: ${extractErrorMessage(error)}`,
-						context: { command },
-						cause: error,
 					});
 				},
 			});

--- a/apps/whispering/src/lib/services/command/web.ts
+++ b/apps/whispering/src/lib/services/command/web.ts
@@ -6,12 +6,10 @@ export function createCommandServiceWeb(): CommandService {
 		execute: async (_command: ShellCommand) =>
 			CommandServiceErr({
 				message: 'Command execution is not supported in web environment',
-				cause: undefined,
 			}),
 		spawn: async (_command: ShellCommand) =>
 			CommandServiceErr({
 				message: 'Command execution is not supported in web environment',
-				cause: undefined,
 			}),
 	};
 }

--- a/apps/whispering/src/lib/services/completion/anthropic.ts
+++ b/apps/whispering/src/lib/services/completion/anthropic.ts
@@ -41,8 +41,6 @@ export function createAnthropicCompletionService(): CompletionService {
 						message:
 							message ??
 							`Invalid request to Anthropic API. ${error?.message ?? ''}`.trim(),
-						context: { status, name },
-						cause: anthropicApiError,
 					});
 				}
 
@@ -52,8 +50,6 @@ export function createAnthropicCompletionService(): CompletionService {
 						message:
 							message ??
 							'Your API key appears to be invalid or expired. Please update your API key in settings.',
-						context: { status, name },
-						cause: anthropicApiError,
 					});
 				}
 
@@ -63,8 +59,6 @@ export function createAnthropicCompletionService(): CompletionService {
 						message:
 							message ??
 							"Your account doesn't have access to this model or feature.",
-						context: { status, name },
-						cause: anthropicApiError,
 					});
 				}
 
@@ -74,8 +68,6 @@ export function createAnthropicCompletionService(): CompletionService {
 						message:
 							message ??
 							'The requested model was not found. Please check the model name.',
-						context: { status, name },
-						cause: anthropicApiError,
 					});
 				}
 
@@ -85,8 +77,6 @@ export function createAnthropicCompletionService(): CompletionService {
 						message:
 							message ??
 							'The request was valid but the server cannot process it. Please check your parameters.',
-						context: { status, name },
-						cause: anthropicApiError,
 					});
 				}
 
@@ -94,8 +84,6 @@ export function createAnthropicCompletionService(): CompletionService {
 				if (status === 429) {
 					return CompletionServiceErr({
 						message: message ?? 'Too many requests. Please try again later.',
-						context: { status, name },
-						cause: anthropicApiError,
 					});
 				}
 
@@ -105,8 +93,6 @@ export function createAnthropicCompletionService(): CompletionService {
 						message:
 							message ??
 							`The Anthropic service is temporarily unavailable (Error ${status}). Please try again in a few minutes.`,
-						context: { status, name },
-						cause: anthropicApiError,
 					});
 				}
 
@@ -116,16 +102,12 @@ export function createAnthropicCompletionService(): CompletionService {
 						message:
 							message ??
 							'Unable to connect to the Anthropic service. This could be a network issue or temporary service interruption.',
-						context: { name },
-						cause: anthropicApiError,
 					});
 				}
 
 				// Catch-all for unexpected errors
 				return CompletionServiceErr({
 					message: message ?? 'An unexpected error occurred. Please try again.',
-					context: { status, name },
-					cause: anthropicApiError,
 				});
 			}
 
@@ -138,8 +120,6 @@ export function createAnthropicCompletionService(): CompletionService {
 			if (!responseText) {
 				return CompletionServiceErr({
 					message: 'Anthropic API returned an empty response',
-					context: { model, completion },
-					cause: undefined,
 				});
 			}
 

--- a/apps/whispering/src/lib/services/completion/custom.ts
+++ b/apps/whispering/src/lib/services/completion/custom.ts
@@ -13,15 +13,11 @@ export const CustomCompletionServiceLive = createOpenAiCompatibleCompletionServi
 		if (!params.baseUrl) {
 			return CompletionServiceErr({
 				message: 'Custom provider requires a base URL.',
-				context: { status: 400, name: 'MissingBaseUrl' },
-				cause: null,
 			});
 		}
 		if (!params.model) {
 			return CompletionServiceErr({
 				message: 'Custom provider requires a model name.',
-				context: { status: 400, name: 'MissingModel' },
-				cause: null,
 			});
 		}
 		return Ok(undefined);

--- a/apps/whispering/src/lib/services/completion/google.ts
+++ b/apps/whispering/src/lib/services/completion/google.ts
@@ -28,8 +28,6 @@ export function createGoogleCompletionService(): CompletionService {
 				catch: (error) =>
 					CompletionServiceErr({
 						message: `Google API Error: ${extractErrorMessage(error)}`,
-						context: { model: modelName, systemPrompt, userPrompt },
-						cause: error,
 					}),
 			});
 
@@ -38,8 +36,6 @@ export function createGoogleCompletionService(): CompletionService {
 			if (!completion) {
 				return CompletionServiceErr({
 					message: 'Google API returned an empty response',
-					context: { model: modelName, systemPrompt, userPrompt },
-					cause: completionError,
 				});
 			}
 

--- a/apps/whispering/src/lib/services/completion/groq.ts
+++ b/apps/whispering/src/lib/services/completion/groq.ts
@@ -38,8 +38,6 @@ export function createGroqCompletionService(): CompletionService {
 						message:
 							message ??
 							`Invalid request to Groq API. ${error?.message ?? ''}`.trim(),
-						context: { status, name },
-						cause: groqApiError,
 					});
 				}
 
@@ -49,8 +47,6 @@ export function createGroqCompletionService(): CompletionService {
 						message:
 							message ??
 							'Your API key appears to be invalid or expired. Please update your API key in settings.',
-						context: { status, name },
-						cause: groqApiError,
 					});
 				}
 
@@ -60,8 +56,6 @@ export function createGroqCompletionService(): CompletionService {
 						message:
 							message ??
 							"Your account doesn't have access to this model or feature.",
-						context: { status, name },
-						cause: groqApiError,
 					});
 				}
 
@@ -71,8 +65,6 @@ export function createGroqCompletionService(): CompletionService {
 						message:
 							message ??
 							'The requested model was not found. Please check the model name.',
-						context: { status, name },
-						cause: groqApiError,
 					});
 				}
 
@@ -82,8 +74,6 @@ export function createGroqCompletionService(): CompletionService {
 						message:
 							message ??
 							'The request was valid but the server cannot process it. Please check your parameters.',
-						context: { status, name },
-						cause: groqApiError,
 					});
 				}
 
@@ -91,8 +81,6 @@ export function createGroqCompletionService(): CompletionService {
 				if (status === 429) {
 					return CompletionServiceErr({
 						message: message ?? 'Too many requests. Please try again later.',
-						context: { status, name },
-						cause: groqApiError,
 					});
 				}
 
@@ -102,8 +90,6 @@ export function createGroqCompletionService(): CompletionService {
 						message:
 							message ??
 							`The Groq service is temporarily unavailable (Error ${status}). Please try again in a few minutes.`,
-						context: { status, name },
-						cause: groqApiError,
 					});
 				}
 
@@ -113,16 +99,12 @@ export function createGroqCompletionService(): CompletionService {
 						message:
 							message ??
 							'Unable to connect to the Groq service. This could be a network issue or temporary service interruption.',
-						context: { name },
-						cause: groqApiError,
 					});
 				}
 
 				// Catch-all for unexpected errors
 				return CompletionServiceErr({
 					message: message ?? 'An unexpected error occurred. Please try again.',
-					context: { status, name },
-					cause: groqApiError,
 				});
 			}
 
@@ -131,8 +113,6 @@ export function createGroqCompletionService(): CompletionService {
 			if (!responseText) {
 				return CompletionServiceErr({
 					message: 'Groq API returned an empty response',
-					context: { model, completion },
-					cause: undefined,
 				});
 			}
 

--- a/apps/whispering/src/lib/services/completion/openai-compatible.ts
+++ b/apps/whispering/src/lib/services/completion/openai-compatible.ts
@@ -157,8 +157,6 @@ export function createOpenAiCompatibleCompletionService(
 					if (override) {
 						return CompletionServiceErr({
 							message: override,
-							context: { status, name },
-							cause: apiError,
 						});
 					}
 				}
@@ -168,8 +166,6 @@ export function createOpenAiCompatibleCompletionService(
 						message:
 							message ??
 							`Invalid request to ${config.providerLabel} API. ${error?.message ?? ''}`.trim(),
-						context: { status, name },
-						cause: apiError,
 					});
 				}
 
@@ -178,8 +174,6 @@ export function createOpenAiCompatibleCompletionService(
 						message:
 							message ??
 							`Your ${config.providerLabel} API key appears to be invalid or expired. Please update your API key in settings.`,
-						context: { status, name },
-						cause: apiError,
 					});
 				}
 
@@ -188,8 +182,6 @@ export function createOpenAiCompatibleCompletionService(
 						message:
 							message ??
 							`Your ${config.providerLabel} account doesn't have access to this model or feature.`,
-						context: { status, name },
-						cause: apiError,
 					});
 				}
 
@@ -198,8 +190,6 @@ export function createOpenAiCompatibleCompletionService(
 						message:
 							message ??
 							`The requested model was not found on ${config.providerLabel}. Please check the model name.`,
-						context: { status, name },
-						cause: apiError,
 					});
 				}
 
@@ -208,8 +198,6 @@ export function createOpenAiCompatibleCompletionService(
 						message:
 							message ??
 							`The request was valid but ${config.providerLabel} cannot process it. Please check your parameters.`,
-						context: { status, name },
-						cause: apiError,
 					});
 				}
 
@@ -218,8 +206,6 @@ export function createOpenAiCompatibleCompletionService(
 						message:
 							message ??
 							`${config.providerLabel} rate limit exceeded. Please try again later.`,
-						context: { status, name },
-						cause: apiError,
 					});
 				}
 
@@ -228,8 +214,6 @@ export function createOpenAiCompatibleCompletionService(
 						message:
 							message ??
 							`The ${config.providerLabel} service is temporarily unavailable (Error ${status}). Please try again in a few minutes.`,
-						context: { status, name },
-						cause: apiError,
 					});
 				}
 
@@ -238,8 +222,6 @@ export function createOpenAiCompatibleCompletionService(
 						message:
 							message ??
 							`Unable to connect to the ${config.providerLabel} service. This could be a network issue or temporary service interruption.`,
-						context: { name },
-						cause: apiError,
 					});
 				}
 
@@ -247,8 +229,6 @@ export function createOpenAiCompatibleCompletionService(
 					message:
 						message ??
 						`An unexpected error occurred with ${config.providerLabel}. Please try again.`,
-					context: { status, name },
-					cause: apiError,
 				});
 			}
 
@@ -256,8 +236,6 @@ export function createOpenAiCompatibleCompletionService(
 			if (!responseText) {
 				return CompletionServiceErr({
 					message: `${config.providerLabel} API returned an empty response`,
-					context: { model: params.model, completion },
-					cause: undefined,
 				});
 			}
 

--- a/apps/whispering/src/lib/services/db/desktop.ts
+++ b/apps/whispering/src/lib/services/db/desktop.ts
@@ -42,11 +42,6 @@ export function createDbServiceDesktop({
 					return Err({
 						name: 'DbServiceError' as const,
 						message: 'Error getting all recordings from both sources',
-						context: {
-							fileSystemError: fsResult.error,
-							indexedDbError: idbResult.error,
-						},
-						cause: fsResult.error,
 					});
 				}
 
@@ -102,11 +97,6 @@ export function createDbServiceDesktop({
 						name: 'DbServiceError' as const,
 						message:
 							'Error getting transcribing recording ids from both sources',
-						context: {
-							fileSystemError: fsResult.error,
-							indexedDbError: idbResult.error,
-						},
-						cause: fsResult.error,
 					});
 				}
 
@@ -142,12 +132,6 @@ export function createDbServiceDesktop({
 					return Err({
 						name: 'DbServiceError' as const,
 						message: 'Error getting recording by id from both sources',
-						context: {
-							id,
-							fileSystemError: fsResult.error,
-							indexedDbError: idbResult.error,
-						},
-						cause: fsResult.error,
 					});
 				}
 
@@ -182,12 +166,6 @@ export function createDbServiceDesktop({
 					return Err({
 						name: 'DbServiceError' as const,
 						message: 'Error deleting recordings from both sources',
-						context: {
-							recordings,
-							fileSystemError: fsResult.error,
-							indexedDbError: idbResult.error,
-						},
-						cause: fsResult.error,
 					});
 				}
 
@@ -207,12 +185,6 @@ export function createDbServiceDesktop({
 					return Err({
 						name: 'DbServiceError' as const,
 						message: 'Error cleaning up expired recordings from both sources',
-						context: {
-							...params,
-							fileSystemError: fsResult.error,
-							indexedDbError: idbResult.error,
-						},
-						cause: fsResult.error,
 					});
 				}
 
@@ -243,12 +215,6 @@ export function createDbServiceDesktop({
 					return Err({
 						name: 'DbServiceError' as const,
 						message: 'Error getting audio blob from both sources',
-						context: {
-							recordingId,
-							fileSystemError: fsResult.error,
-							indexedDbError: idbResult.error,
-						},
-						cause: fsResult.error,
 					});
 				}
 
@@ -280,12 +246,6 @@ export function createDbServiceDesktop({
 					return Err({
 						name: 'DbServiceError' as const,
 						message: 'Error getting audio playback URL from both sources',
-						context: {
-							recordingId,
-							fileSystemError: fsResult.error,
-							indexedDbError: idbResult.error,
-						},
-						cause: fsResult.error,
 					});
 				}
 
@@ -311,11 +271,6 @@ export function createDbServiceDesktop({
 					return Err({
 						name: 'DbServiceError' as const,
 						message: 'Error clearing recordings from both sources',
-						context: {
-							fileSystemError: fsResult.error,
-							indexedDbError: idbResult.error,
-						},
-						cause: fsResult.error,
 					});
 				}
 
@@ -341,11 +296,6 @@ export function createDbServiceDesktop({
 					return Err({
 						name: 'DbServiceError' as const,
 						message: 'Error getting all transformations from both sources',
-						context: {
-							fileSystemError: fsResult.error,
-							indexedDbError: idbResult.error,
-						},
-						cause: fsResult.error,
 					});
 				}
 
@@ -389,12 +339,6 @@ export function createDbServiceDesktop({
 					return Err({
 						name: 'DbServiceError' as const,
 						message: 'Error getting transformation by id from both sources',
-						context: {
-							id,
-							fileSystemError: fsResult.error,
-							indexedDbError: idbResult.error,
-						},
-						cause: fsResult.error,
 					});
 				}
 
@@ -424,12 +368,6 @@ export function createDbServiceDesktop({
 					return Err({
 						name: 'DbServiceError' as const,
 						message: 'Error deleting transformations from both sources',
-						context: {
-							transformations,
-							fileSystemError: fsResult.error,
-							indexedDbError: idbResult.error,
-						},
-						cause: fsResult.error,
 					});
 				}
 
@@ -449,11 +387,6 @@ export function createDbServiceDesktop({
 					return Err({
 						name: 'DbServiceError' as const,
 						message: 'Error clearing transformations from both sources',
-						context: {
-							fileSystemError: fsResult.error,
-							indexedDbError: idbResult.error,
-						},
-						cause: fsResult.error,
 					});
 				}
 
@@ -480,11 +413,6 @@ export function createDbServiceDesktop({
 					return Err({
 						name: 'DbServiceError' as const,
 						message: 'Error getting all transformation runs from both sources',
-						context: {
-							fileSystemError: fsResult.error,
-							indexedDbError: idbResult.error,
-						},
-						cause: fsResult.error,
 					});
 				}
 
@@ -528,12 +456,6 @@ export function createDbServiceDesktop({
 					return Err({
 						name: 'DbServiceError' as const,
 						message: 'Error getting transformation run by id from both sources',
-						context: {
-							id,
-							fileSystemError: fsResult.error,
-							indexedDbError: idbResult.error,
-						},
-						cause: fsResult.error,
 					});
 				}
 
@@ -554,12 +476,6 @@ export function createDbServiceDesktop({
 						name: 'DbServiceError' as const,
 						message:
 							'Error getting transformation runs by transformation id from both sources',
-						context: {
-							transformationId,
-							fileSystemError: fsResult.error,
-							indexedDbError: idbResult.error,
-						},
-						cause: fsResult.error,
 					});
 				}
 
@@ -601,12 +517,6 @@ export function createDbServiceDesktop({
 						name: 'DbServiceError' as const,
 						message:
 							'Error getting transformation runs by recording id from both sources',
-						context: {
-							recordingId,
-							fileSystemError: fsResult.error,
-							indexedDbError: idbResult.error,
-						},
-						cause: fsResult.error,
 					});
 				}
 
@@ -671,12 +581,6 @@ export function createDbServiceDesktop({
 				if (fsResult.error && idbResult.error) {
 					return DbServiceErr({
 						message: 'Error deleting transformation runs from both sources',
-						context: {
-							runs,
-							fileSystemError: fsResult.error,
-							indexedDbError: idbResult.error,
-						},
-						cause: fsResult.error,
 					});
 				}
 
@@ -695,11 +599,6 @@ export function createDbServiceDesktop({
 				if (fsResult.error && idbResult.error) {
 					return DbServiceErr({
 						message: 'Error clearing transformation runs from both sources',
-						context: {
-							fileSystemError: fsResult.error,
-							indexedDbError: idbResult.error,
-						},
-						cause: fsResult.error,
 					});
 				}
 

--- a/apps/whispering/src/lib/services/db/file-system.ts
+++ b/apps/whispering/src/lib/services/db/file-system.ts
@@ -140,7 +140,6 @@ export function createFileSystemDb(): DbService {
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error getting all recordings from file system',
-							cause: error,
 						}),
 				});
 			},
@@ -157,7 +156,6 @@ export function createFileSystemDb(): DbService {
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error getting latest recording from file system',
-							cause: error,
 						}),
 				});
 			},
@@ -176,7 +174,6 @@ export function createFileSystemDb(): DbService {
 						DbServiceErr({
 							message:
 								'Error getting transcribing recording ids from file system',
-							cause: error,
 						}),
 				});
 			},
@@ -206,8 +203,6 @@ export function createFileSystemDb(): DbService {
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error getting recording by id from file system',
-							context: { id },
-							cause: error,
 						}),
 				});
 			},
@@ -254,8 +249,6 @@ export function createFileSystemDb(): DbService {
 						catch: (error) =>
 							DbServiceErr({
 								message: 'Error bulk creating recordings in file system',
-								context: { count: params.length },
-								cause: error,
 							}),
 					});
 
@@ -265,8 +258,6 @@ export function createFileSystemDb(): DbService {
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error creating recording in file system',
-							context: { recording: params.recording },
-							cause: error,
 						}),
 				});
 			},
@@ -307,8 +298,6 @@ export function createFileSystemDb(): DbService {
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error updating recording in file system',
-							context: { recording },
-							cause: error,
 						}),
 				});
 			},
@@ -343,8 +332,6 @@ export function createFileSystemDb(): DbService {
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error deleting recordings from file system',
-							context: { recordings },
-							cause: error,
 						}),
 				});
 			},
@@ -370,8 +357,6 @@ export function createFileSystemDb(): DbService {
 							catch: (error) =>
 								DbServiceErr({
 									message: 'Error cleaning up expired recordings',
-									context: { recordingRetentionStrategy, maxRecordingCount },
-									cause: error,
 								}),
 						});
 					}
@@ -402,8 +387,6 @@ export function createFileSystemDb(): DbService {
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error getting audio blob from file system',
-							context: { recordingId },
-							cause: error,
 						}),
 				});
 			},
@@ -430,8 +413,6 @@ export function createFileSystemDb(): DbService {
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error getting audio playback URL from file system',
-							context: { recordingId },
-							cause: error,
 						}),
 				});
 			},
@@ -459,7 +440,6 @@ export function createFileSystemDb(): DbService {
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error clearing recordings from file system',
-							cause: error,
 						}),
 				});
 			},
@@ -476,7 +456,6 @@ export function createFileSystemDb(): DbService {
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error getting recordings count from file system',
-							cause: error,
 						}),
 				});
 			},
@@ -519,7 +498,6 @@ export function createFileSystemDb(): DbService {
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error getting all transformations from file system',
-							cause: error,
 						}),
 				});
 			},
@@ -547,8 +525,6 @@ export function createFileSystemDb(): DbService {
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error getting transformation by id from file system',
-							context: { id },
-							cause: error,
 						}),
 				});
 			},
@@ -578,8 +554,6 @@ export function createFileSystemDb(): DbService {
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error creating transformation in file system',
-							context: { transformation },
-							cause: error,
 						}),
 				});
 			},
@@ -612,8 +586,6 @@ export function createFileSystemDb(): DbService {
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error updating transformation in file system',
-							context: { transformation },
-							cause: error,
 						}),
 				});
 			},
@@ -640,8 +612,6 @@ export function createFileSystemDb(): DbService {
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error deleting transformations from file system',
-							context: { transformations },
-							cause: error,
 						}),
 				});
 			},
@@ -659,7 +629,6 @@ export function createFileSystemDb(): DbService {
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error clearing transformations from file system',
-							cause: error,
 						}),
 				});
 			},
@@ -674,7 +643,6 @@ export function createFileSystemDb(): DbService {
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error getting transformations count from file system',
-							cause: error,
 						}),
 				});
 			},
@@ -716,7 +684,6 @@ export function createFileSystemDb(): DbService {
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error getting all transformation runs from file system',
-							cause: error,
 						}),
 				});
 			},
@@ -747,8 +714,6 @@ export function createFileSystemDb(): DbService {
 						DbServiceErr({
 							message:
 								'Error getting transformation run by id from file system',
-							context: { id },
-							cause: error,
 						}),
 				});
 			},
@@ -799,8 +764,6 @@ export function createFileSystemDb(): DbService {
 						DbServiceErr({
 							message:
 								'Error getting transformation runs by transformation id from file system',
-							context: { transformationId },
-							cause: error,
 						}),
 				});
 			},
@@ -851,8 +814,6 @@ export function createFileSystemDb(): DbService {
 						DbServiceErr({
 							message:
 								'Error getting transformation runs by recording id from file system',
-							context: { recordingId },
-							cause: error,
 						}),
 				});
 			},
@@ -882,8 +843,6 @@ export function createFileSystemDb(): DbService {
 							DbServiceErr({
 								message:
 									'Error bulk creating transformation runs in file system',
-								context: { count: params.length },
-								cause: error,
 							}),
 					});
 				}
@@ -924,8 +883,6 @@ export function createFileSystemDb(): DbService {
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error creating transformation run in file system',
-							context: { transformationId, recordingId, input },
-							cause: error,
 						}),
 				});
 			},
@@ -965,8 +922,6 @@ export function createFileSystemDb(): DbService {
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error adding step to transformation run in file system',
-							context: { run, step },
-							cause: error,
 						}),
 				});
 			},
@@ -1011,8 +966,6 @@ export function createFileSystemDb(): DbService {
 						DbServiceErr({
 							message:
 								'Error failing step in transformation run in file system',
-							context: { run, stepRunId, error },
-							cause: error,
 						}),
 				});
 			},
@@ -1054,8 +1007,6 @@ export function createFileSystemDb(): DbService {
 						DbServiceErr({
 							message:
 								'Error completing step in transformation run in file system',
-							context: { run, stepRunId, output },
-							cause: error,
 						}),
 				});
 			},
@@ -1088,8 +1039,6 @@ export function createFileSystemDb(): DbService {
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error completing transformation run in file system',
-							context: { run, output },
-							cause: error,
 						}),
 				});
 			},
@@ -1111,8 +1060,6 @@ export function createFileSystemDb(): DbService {
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error deleting transformation runs from file system',
-							context: { runs },
-							cause: error,
 						}),
 				});
 			},
@@ -1130,7 +1077,6 @@ export function createFileSystemDb(): DbService {
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error clearing transformation runs from file system',
-							cause: error,
 						}),
 				});
 			},
@@ -1146,7 +1092,6 @@ export function createFileSystemDb(): DbService {
 						DbServiceErr({
 							message:
 								'Error getting transformation runs count from file system',
-							cause: error,
 						}),
 				});
 			},

--- a/apps/whispering/src/lib/services/db/web.ts
+++ b/apps/whispering/src/lib/services/db/web.ts
@@ -402,7 +402,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error getting all recordings from Dexie',
-							cause: error,
 						}),
 				});
 			},
@@ -422,7 +421,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error getting latest recording from Dexie',
-							cause: error,
 						}),
 				});
 			},
@@ -437,7 +435,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error getting transcribing recording ids from Dexie',
-							cause: error,
 						}),
 				});
 			},
@@ -454,8 +451,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error getting recording by id from Dexie',
-							context: { id },
-							cause: error,
 						}),
 				});
 			},
@@ -479,8 +474,6 @@ export function createDbServiceWeb({
 						catch: (error) =>
 							DbServiceErr({
 								message: 'Error bulk adding recordings to Dexie',
-								context: { count: params.length },
-								cause: error,
 							}),
 					});
 					if (bulkCreateError) return Err(bulkCreateError);
@@ -506,8 +499,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error adding recording to Dexie',
-							context: { recording },
-							cause: error,
 						}),
 				});
 				if (createRecordingError) return Err(createRecordingError);
@@ -538,8 +529,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error updating recording in Dexie',
-							context: { recording },
-							cause: error,
 						}),
 				});
 				if (updateRecordingError) return Err(updateRecordingError);
@@ -556,8 +545,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error deleting recordings from Dexie',
-							context: { recordings },
-							cause: error,
 						}),
 				});
 				if (deleteRecordingsError) return Err(deleteRecordingsError);
@@ -589,8 +576,6 @@ export function createDbServiceWeb({
 								DbServiceErr({
 									message:
 										'Unable to get recording count while cleaning up old recordings',
-									context: { maxRecordingCount, recordingRetentionStrategy },
-									cause: error,
 								}),
 						});
 						if (countError) return Err(countError);
@@ -611,8 +596,6 @@ export function createDbServiceWeb({
 							catch: (error) =>
 								DbServiceErr({
 									message: 'Unable to clean up old recordings',
-									context: { count, maxCount, recordingRetentionStrategy },
-									cause: error,
 								}),
 						});
 					}
@@ -640,8 +623,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error getting audio blob from IndexedDB',
-							context: { recordingId },
-							cause: error,
 						}),
 				});
 			},
@@ -677,8 +658,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error ensuring audio playback URL from IndexedDB',
-							context: { recordingId },
-							cause: error,
 						}),
 				});
 			},
@@ -697,7 +676,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error clearing recordings from Dexie',
-							cause: error,
 						}),
 				});
 			},
@@ -708,7 +686,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error getting recordings count from Dexie',
-							cause: error,
 						}),
 				});
 			},
@@ -721,7 +698,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error getting all transformations from Dexie',
-							cause: error,
 						}),
 				});
 			},
@@ -736,8 +712,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error getting transformation by id from Dexie',
-							context: { id },
-							cause: error,
 						}),
 				});
 			},
@@ -750,8 +724,6 @@ export function createDbServiceWeb({
 						catch: (error) =>
 							DbServiceErr({
 								message: 'Error bulk adding transformations to Dexie',
-								context: { count: transformation.length },
-								cause: error,
 							}),
 					});
 					if (bulkCreateError) return Err(bulkCreateError);
@@ -764,8 +736,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error adding transformation to Dexie',
-							context: { transformation },
-							cause: error,
 						}),
 				});
 				if (createTransformationError) return Err(createTransformationError);
@@ -783,8 +753,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error updating transformation in Dexie',
-							context: { transformation },
-							cause: error,
 						}),
 				});
 				if (updateTransformationError) return Err(updateTransformationError);
@@ -801,8 +769,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error deleting transformations from Dexie',
-							context: { transformations },
-							cause: error,
 						}),
 				});
 				if (deleteTransformationsError) return Err(deleteTransformationsError);
@@ -815,7 +781,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error clearing transformations from Dexie',
-							cause: error,
 						}),
 				});
 			},
@@ -826,7 +791,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error getting transformations count from Dexie',
-							cause: error,
 						}),
 				});
 			},
@@ -842,7 +806,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error getting all transformation runs from Dexie',
-							cause: error,
 						}),
 				});
 			},
@@ -856,8 +819,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error getting transformation run by id from Dexie',
-							context: { id },
-							cause: error,
 						}),
 				});
 				if (getTransformationRunByIdError)
@@ -886,8 +847,6 @@ export function createDbServiceWeb({
 						DbServiceErr({
 							message:
 								'Error getting transformation runs by transformation id from Dexie',
-							context: { transformationId },
-							cause: error,
 						}),
 				});
 			},
@@ -912,8 +871,6 @@ export function createDbServiceWeb({
 						DbServiceErr({
 							message:
 								'Error getting transformation runs by recording id from Dexie',
-							context: { recordingId },
-							cause: error,
 						}),
 				});
 			},
@@ -929,8 +886,6 @@ export function createDbServiceWeb({
 						catch: (error) =>
 							DbServiceErr({
 								message: 'Error bulk adding transformation runs to Dexie',
-								context: { count: params.length },
-								cause: error,
 							}),
 					});
 					if (bulkCreateError) return Err(bulkCreateError);
@@ -954,8 +909,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error adding transformation run to Dexie',
-							context: { transformationId, recordingId, input },
-							cause: error,
 						}),
 				});
 				if (createTransformationRunError)
@@ -984,8 +937,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error adding step run to transformation run in Dexie',
-							context: { run, step },
-							cause: error,
 						}),
 				});
 				if (addStepRunToTransformationRunError)
@@ -1022,8 +973,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error updating transformation run as failed in Dexie',
-							context: { run, stepId: stepRunId, error },
-							cause: error,
 						}),
 				});
 				if (updateTransformationStepRunError)
@@ -1057,8 +1006,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error updating transformation step run status in Dexie',
-							context: { run, stepId: stepRunId, output },
-							cause: error,
 						}),
 				});
 				if (updateTransformationStepRunError)
@@ -1084,8 +1031,6 @@ export function createDbServiceWeb({
 						DbServiceErr({
 							message:
 								'Error updating transformation run as completed in Dexie',
-							context: { run, output },
-							cause: error,
 						}),
 				});
 				if (updateTransformationStepRunError)
@@ -1106,8 +1051,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error deleting transformation runs from Dexie',
-							context: { runs },
-							cause: error,
 						}),
 				});
 			},
@@ -1118,7 +1061,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error clearing transformation runs from Dexie',
-							cause: error,
 						}),
 				});
 			},
@@ -1129,7 +1071,6 @@ export function createDbServiceWeb({
 					catch: (error) =>
 						DbServiceErr({
 							message: 'Error getting transformation runs count from Dexie',
-							cause: error,
 						}),
 				});
 			},

--- a/apps/whispering/src/lib/services/device-stream.ts
+++ b/apps/whispering/src/lib/services/device-stream.ts
@@ -32,7 +32,6 @@ async function hasExistingAudioPermission(): Promise<boolean> {
 				DeviceStreamServiceErr({
 					message:
 						'We need permission to see your microphones. Check your browser settings and try again.',
-					cause: error,
 				}),
 		});
 		if (!error) return permissionStatus.state === 'granted';
@@ -72,7 +71,6 @@ export async function enumerateDevices(): Promise<
 			DeviceStreamServiceErr({
 				message:
 					'We need permission to see your microphones. Check your browser settings and try again.',
-				cause: error,
 			}),
 	});
 }
@@ -105,11 +103,6 @@ async function getStreamForDeviceIdentifier(
 			DeviceStreamServiceErr({
 				message:
 					'Unable to connect to the selected microphone. This could be because the device is already in use by another application, has been disconnected, or lacks proper permissions. Please check that your microphone is connected, not being used elsewhere, and that you have granted microphone permissions.',
-				context: {
-					deviceIdentifier,
-					hasPermission,
-				},
-				cause: error,
 			}),
 	});
 }
@@ -172,7 +165,6 @@ export async function getRecordingStream({
 			return DeviceStreamServiceErr({
 				message:
 					'Error enumerating recording devices and acquiring first available stream. Please make sure you have given permission to access your audio devices',
-				cause: enumerateDevicesError,
 			});
 
 		for (const device of devices) {
@@ -186,8 +178,6 @@ export async function getRecordingStream({
 
 		return DeviceStreamServiceErr({
 			message: 'Unable to connect to any available microphone',
-			context: { devices },
-			cause: undefined,
 		});
 	};
 
@@ -200,8 +190,6 @@ export async function getRecordingStream({
 			: "Hmm... We couldn't find any microphones to use. Check your connections and try again!";
 		return DeviceStreamServiceErr({
 			message: errorMessage,
-			context: { selectedDeviceId },
-			cause: getFallbackStreamError,
 		});
 	}
 

--- a/apps/whispering/src/lib/services/download/desktop.ts
+++ b/apps/whispering/src/lib/services/download/desktop.ts
@@ -18,16 +18,12 @@ export function createDownloadServiceDesktop(): DownloadService {
 					DownloadServiceErr({
 						message:
 							'There was an error saving the recording using the Tauri Filesystem API. Please try again.',
-						context: { name, blob },
-						cause: error,
 					}),
 			});
 			if (saveError) return Err(saveError);
 			if (path === null) {
 				return DownloadServiceErr({
 					message: 'Please specify a path to save the recording.',
-					context: { name, blob },
-					cause: undefined,
 				});
 			}
 			const { error: writeError } = await tryAsync({
@@ -39,8 +35,6 @@ export function createDownloadServiceDesktop(): DownloadService {
 					DownloadServiceErr({
 						message:
 							'There was an error saving the recording using the Tauri Filesystem API. Please try again.',
-						context: { name, blob, path },
-						cause: error,
 					}),
 			});
 			if (writeError) return Err(writeError);

--- a/apps/whispering/src/lib/services/download/web.ts
+++ b/apps/whispering/src/lib/services/download/web.ts
@@ -21,8 +21,6 @@ export function createDownloadServiceWeb(): DownloadService {
 					DownloadServiceErr({
 						message:
 							'There was an error saving the recording in your browser. Please try again.',
-						context: { name, blob },
-						cause: error,
 					}),
 			}),
 	};

--- a/apps/whispering/src/lib/services/ffmpeg/desktop.ts
+++ b/apps/whispering/src/lib/services/ffmpeg/desktop.ts
@@ -23,7 +23,6 @@ export function createFfmpegService(): FfmpegService {
 					catch: (error) =>
 						FfmpegServiceErr({
 							message: `Unable to determine if FFmpeg is installed through shell. ${extractErrorMessage(error)}`,
-							cause: error,
 						}),
 				});
 
@@ -61,7 +60,6 @@ export function createFfmpegService(): FfmpegService {
 							catch: (error) =>
 								FfmpegServiceErr({
 									message: 'Temp file not accessible',
-									cause: error,
 								}),
 						});
 						if (verifyError) throw new Error(verifyError.message);
@@ -121,8 +119,6 @@ export function createFfmpegService(): FfmpegService {
 				catch: (error) =>
 					FfmpegServiceErr({
 						message: `Audio compression failed: ${extractErrorMessage(error)}`,
-						context: { compressionOptions },
-						cause: error,
 					}),
 			});
 		},

--- a/apps/whispering/src/lib/services/ffmpeg/web.ts
+++ b/apps/whispering/src/lib/services/ffmpeg/web.ts
@@ -36,8 +36,6 @@ export function createFfmpegServiceWeb(): FfmpegService {
 			return FfmpegServiceErr({
 				message:
 					'Audio compression is not available in the web version. FFmpeg is only supported in the desktop application.',
-				context: { compressionOptions },
-				cause: undefined,
 			});
 		},
 	};

--- a/apps/whispering/src/lib/services/fs/desktop.ts
+++ b/apps/whispering/src/lib/services/fs/desktop.ts
@@ -22,7 +22,6 @@ export function createFsServiceDesktop(): FsService {
 				catch: (error) =>
 					FsServiceErr({
 						message: `Failed to read file as Blob: ${path}`,
-						cause: error,
 					}),
 			});
 		},
@@ -38,7 +37,6 @@ export function createFsServiceDesktop(): FsService {
 				catch: (error) =>
 					FsServiceErr({
 						message: `Failed to read file as File: ${path}`,
-						cause: error,
 					}),
 			});
 		},
@@ -59,7 +57,6 @@ export function createFsServiceDesktop(): FsService {
 				catch: (error) =>
 					FsServiceErr({
 						message: `Failed to read files: ${paths.join(', ')}`,
-						cause: error,
 					}),
 			});
 		},

--- a/apps/whispering/src/lib/services/fs/web.ts
+++ b/apps/whispering/src/lib/services/fs/web.ts
@@ -6,19 +6,16 @@ export function createFsServiceWeb(): FsService {
 		pathToBlob: async () =>
 			FsServiceErr({
 				message: 'File system access not available in browser',
-				cause: undefined,
 			}),
 
 		pathToFile: async () =>
 			FsServiceErr({
 				message: 'File system access not available in browser',
-				cause: undefined,
 			}),
 
 		pathsToFiles: async () =>
 			FsServiceErr({
 				message: 'File system access not available in browser',
-				cause: undefined,
 			}),
 	};
 }

--- a/apps/whispering/src/lib/services/global-shortcut-manager.ts
+++ b/apps/whispering/src/lib/services/global-shortcut-manager.ts
@@ -56,8 +56,6 @@ export function createGlobalShortcutManager() {
 			if (!isValidElectronAccelerator(accelerator)) {
 				return InvalidAcceleratorErr({
 					message: `Invalid accelerator format: '${accelerator}'. Must follow Electron accelerator specification.`,
-					context: { accelerator },
-					cause: undefined,
 				});
 			}
 
@@ -71,8 +69,6 @@ export function createGlobalShortcutManager() {
 				catch: (error) =>
 					GlobalShortcutServiceErr({
 						message: `Failed to register global shortcut '${accelerator}': ${extractErrorMessage(error)}`,
-						context: { accelerator, error },
-						cause: error,
 					}),
 			});
 			/**
@@ -104,11 +100,6 @@ export function createGlobalShortcutManager() {
 				catch: (error) =>
 					GlobalShortcutServiceErr({
 						message: `Failed to unregister global shortcut '${accelerator}': ${extractErrorMessage(error)}`,
-						context: {
-							accelerator,
-							originalError: error,
-						},
-						cause: error,
 					}),
 			});
 			if (unregisterError) return Err(unregisterError);
@@ -126,8 +117,6 @@ export function createGlobalShortcutManager() {
 				catch: (error) =>
 					GlobalShortcutServiceErr({
 						message: `Failed to unregister all global shortcuts: ${extractErrorMessage(error)}`,
-						context: { error },
-						cause: error,
 					}),
 			});
 			if (unregisterAllError) return Err(unregisterAllError);
@@ -191,15 +180,11 @@ export function pressedKeysToTauriAccelerator(
 	if (keyCodes.length === 0) {
 		return InvalidAcceleratorErr({
 			message: 'No valid key code found in pressed keys',
-			context: { pressedKeys },
-			cause: undefined,
 		});
 	}
 	if (keyCodes.length > 1) {
 		return InvalidAcceleratorErr({
 			message: 'Multiple key codes not allowed in accelerator',
-			context: { pressedKeys, keyCodes },
-			cause: undefined,
 		});
 	}
 
@@ -215,8 +200,6 @@ export function pressedKeysToTauriAccelerator(
 	if (!isValidElectronAccelerator(accelerator)) {
 		return InvalidAcceleratorErr({
 			message: `Generated invalid accelerator: ${accelerator}`,
-			context: { pressedKeys, accelerator },
-			cause: undefined,
 		});
 	}
 

--- a/apps/whispering/src/lib/services/http/desktop.ts
+++ b/apps/whispering/src/lib/services/http/desktop.ts
@@ -18,8 +18,6 @@ export function createHttpServiceDesktop(): HttpService {
 				catch: (error) =>
 					ConnectionErr({
 						message: 'Failed to establish connection',
-						context: { url, body, headers },
-						cause: error,
 					}),
 			});
 			if (responseError) return Err(responseError);
@@ -28,8 +26,6 @@ export function createHttpServiceDesktop(): HttpService {
 				return ResponseErr({
 					status: response.status,
 					message: extractErrorMessage(await response.json()),
-					context: { url, body, headers },
-					cause: responseError,
 				});
 			}
 
@@ -47,8 +43,6 @@ export function createHttpServiceDesktop(): HttpService {
 				catch: (error) =>
 					ParseErr({
 						message: 'Failed to parse response',
-						context: { url, body, headers },
-						cause: error,
 					}),
 			});
 			return parseResult;

--- a/apps/whispering/src/lib/services/http/web.ts
+++ b/apps/whispering/src/lib/services/http/web.ts
@@ -17,8 +17,6 @@ export function createHttpServiceWeb(): HttpService {
 				catch: (error) =>
 					ConnectionErr({
 						message: 'Failed to establish connection',
-						context: { url, body, headers },
-						cause: error,
 					}),
 			});
 			if (responseError) return Err(responseError);
@@ -27,8 +25,6 @@ export function createHttpServiceWeb(): HttpService {
 				return ResponseErr({
 					status: response.status,
 					message: extractErrorMessage(await response.json()),
-					context: { url, body, headers },
-					cause: responseError,
 				});
 			}
 
@@ -46,8 +42,6 @@ export function createHttpServiceWeb(): HttpService {
 				catch: (error) =>
 					ParseErr({
 						message: 'Failed to parse response',
-						context: { url, body, headers },
-						cause: error,
 					}),
 			});
 			return parseResult;

--- a/apps/whispering/src/lib/services/notifications/desktop.ts
+++ b/apps/whispering/src/lib/services/notifications/desktop.ts
@@ -38,8 +38,6 @@ export function createNotificationServiceDesktop(): NotificationService {
 				catch: (error) =>
 					NotificationServiceErr({
 						message: 'Unable to retrieve active desktop notifications.',
-						context: { id },
-						cause: error,
 					}),
 			});
 		if (activeNotificationsError) return Err(activeNotificationsError);
@@ -52,8 +50,6 @@ export function createNotificationServiceDesktop(): NotificationService {
 				catch: (error) =>
 					NotificationServiceErr({
 						message: `Unable to remove notification with id ${id}.`,
-						context: { id, matchingActiveNotification },
-						cause: error,
 					}),
 			});
 			if (removeActiveError) return Err(removeActiveError);
@@ -94,12 +90,6 @@ export function createNotificationServiceDesktop(): NotificationService {
 				catch: (error) =>
 					NotificationServiceErr({
 						message: 'Could not send notification',
-						context: {
-							idStringified,
-							title: options.title,
-							description: options.description,
-						},
-						cause: error,
 					}),
 			});
 			if (notifyError) return Err(notifyError);

--- a/apps/whispering/src/lib/services/notifications/web.ts
+++ b/apps/whispering/src/lib/services/notifications/web.ts
@@ -98,8 +98,6 @@ export function createNotificationServiceWeb(): NotificationService {
 				catch: (error) =>
 					NotificationServiceErr({
 						message: 'Failed to send browser notification',
-						context: { notificationId, title: options.title },
-						cause: error,
 					}),
 			});
 

--- a/apps/whispering/src/lib/services/permissions/index.ts
+++ b/apps/whispering/src/lib/services/permissions/index.ts
@@ -36,7 +36,6 @@ function createPermissionsService(): PermissionsService {
 					catch: (error) =>
 						PermissionsServiceErr({
 							message: `Failed to check accessibility permissions: ${extractErrorMessage(error)}`,
-							cause: error,
 						}),
 				});
 			},
@@ -54,7 +53,6 @@ function createPermissionsService(): PermissionsService {
 					catch: (error) =>
 						PermissionsServiceErr({
 							message: `Failed to request accessibility permissions: ${extractErrorMessage(error)}`,
-							cause: error,
 						}),
 				});
 			},
@@ -74,7 +72,6 @@ function createPermissionsService(): PermissionsService {
 					catch: (error) =>
 						PermissionsServiceErr({
 							message: `Failed to check microphone permissions: ${extractErrorMessage(error)}`,
-							cause: error,
 						}),
 				});
 			},
@@ -92,7 +89,6 @@ function createPermissionsService(): PermissionsService {
 					catch: (error) =>
 						PermissionsServiceErr({
 							message: `Failed to request microphone permissions: ${extractErrorMessage(error)}`,
-							cause: error,
 						}),
 				});
 			},

--- a/apps/whispering/src/lib/services/recorder/cpal.ts
+++ b/apps/whispering/src/lib/services/recorder/cpal.ts
@@ -45,7 +45,6 @@ export function createCpalRecorderService(): RecorderService {
 		if (enumerateRecordingDevicesError) {
 			return RecorderServiceErr({
 				message: 'Failed to enumerate recording devices',
-				cause: enumerateRecordingDevicesError,
 			});
 		}
 		// On desktop, device names serve as both ID and label
@@ -73,8 +72,6 @@ export function createCpalRecorderService(): RecorderService {
 				return RecorderServiceErr({
 					message:
 						'We encountered an issue while getting the recorder state. This could be because your microphone is being used by another app, your microphone permissions are denied, or the selected recording device is disconnected',
-					context: { error: getRecorderStateError },
-					cause: getRecorderStateError,
 				});
 
 			return Ok(recordingId ? 'RECORDING' : 'IDLE');
@@ -119,8 +116,6 @@ export function createCpalRecorderService(): RecorderService {
 						message: selectedDeviceId
 							? "We couldn't find the selected microphone. Make sure it's connected and try again!"
 							: "We couldn't find any microphones. Make sure they're connected and try again!",
-						context: { selectedDeviceId, deviceIds },
-						cause: undefined,
 					});
 				}
 
@@ -188,11 +183,6 @@ export function createCpalRecorderService(): RecorderService {
 				return RecorderServiceErr({
 					message:
 						'We encountered an issue while setting up your recording session. This could be because your microphone is being used by another app, your microphone permissions are denied, or the selected recording device is disconnected',
-					context: {
-						selectedDeviceId,
-						deviceIdentifier,
-					},
-					cause: initRecordingSessionError,
 				});
 
 			sendStatus({
@@ -206,8 +196,6 @@ export function createCpalRecorderService(): RecorderService {
 				return RecorderServiceErr({
 					message:
 						'Unable to start recording. Please check your microphone and try again.',
-					context: { deviceIdentifier, deviceOutcome },
-					cause: startRecordingError,
 				});
 
 			return Ok(deviceOutcome);
@@ -229,8 +217,6 @@ export function createCpalRecorderService(): RecorderService {
 			if (stopRecordingError) {
 				return RecorderServiceErr({
 					message: 'Unable to save your recording. Please try again.',
-					context: { operation: 'stopRecording' },
-					cause: stopRecordingError,
 				});
 			}
 
@@ -239,11 +225,6 @@ export function createCpalRecorderService(): RecorderService {
 			if (!filePath) {
 				return RecorderServiceErr({
 					message: 'Recording file path not provided by method.',
-					context: {
-						operation: 'stopRecording',
-						audioRecording,
-					},
-					cause: undefined,
 				});
 			}
 			// audioRecording is now AudioRecordingWithFile
@@ -262,8 +243,6 @@ export function createCpalRecorderService(): RecorderService {
 				catch: (error) =>
 					RecorderServiceErr({
 						message: 'Unable to read recording file. Please try again.',
-						context: { audioRecording },
-						cause: error,
 					}),
 			});
 			if (readRecordingFileError) return Err(readRecordingFileError);
@@ -303,8 +282,6 @@ export function createCpalRecorderService(): RecorderService {
 				return RecorderServiceErr({
 					message:
 						'Unable to check recording state. Please try closing the app and starting again.',
-					context: { operation: 'cancelRecording' },
-					cause: getRecordingIdError,
 				});
 			}
 
@@ -330,8 +307,6 @@ export function createCpalRecorderService(): RecorderService {
 					catch: (error) =>
 						RecorderServiceErr({
 							message: 'Failed to delete recording file.',
-							context: { audioRecording },
-							cause: error,
 						}),
 				});
 				if (removeError)

--- a/apps/whispering/src/lib/services/recorder/ffmpeg.ts
+++ b/apps/whispering/src/lib/services/recorder/ffmpeg.ts
@@ -228,7 +228,6 @@ export function createFfmpegRecorderService(): RecorderService {
 		if (executeError) {
 			return RecorderServiceErr({
 				message: 'Failed to enumerate recording devices',
-				cause: executeError,
 			});
 		}
 
@@ -240,8 +239,6 @@ export function createFfmpegRecorderService(): RecorderService {
 		if (devices.length === 0) {
 			return RecorderServiceErr({
 				message: 'No recording devices found',
-				context: { output },
-				cause: undefined,
 			});
 		}
 
@@ -287,8 +284,6 @@ export function createFfmpegRecorderService(): RecorderService {
 						message: selectedDeviceId
 							? "We couldn't find the selected microphone. Make sure it's connected and try again!"
 							: "We couldn't find any microphones. Make sure they're connected and try again!",
-						context: { selectedDeviceId, deviceIds },
-						cause: undefined,
 					});
 				}
 
@@ -361,8 +356,6 @@ export function createFfmpegRecorderService(): RecorderService {
 				// The spawn function already caught the FFmpeg error and extracted the message
 				return RecorderServiceErr({
 					message: 'Failed to start recording',
-					context: { command },
-					cause: startError,
 				});
 			}
 
@@ -388,7 +381,6 @@ export function createFfmpegRecorderService(): RecorderService {
 			if (!child || !session) {
 				return RecorderServiceErr({
 					message: 'No active recording to stop',
-					cause: undefined,
 				});
 			}
 
@@ -417,7 +409,6 @@ export function createFfmpegRecorderService(): RecorderService {
 				catch: (error) =>
 					RecorderServiceErr({
 						message: `Failed to stop FFmpeg process: ${extractErrorMessage(error)}`,
-						cause: error,
 					}),
 			});
 
@@ -485,7 +476,6 @@ export function createFfmpegRecorderService(): RecorderService {
 			if (readError) {
 				return RecorderServiceErr({
 					message: 'Unable to read recording file',
-					cause: readError,
 				});
 			}
 
@@ -493,8 +483,6 @@ export function createFfmpegRecorderService(): RecorderService {
 			if (!blob || blob.size === 0) {
 				return RecorderServiceErr({
 					message: 'Recording file is empty',
-					context: { blobSize: blob?.size },
-					cause: undefined,
 				});
 			}
 
@@ -530,8 +518,6 @@ export function createFfmpegRecorderService(): RecorderService {
 					catch: (error) =>
 						RecorderServiceErr({
 							message: 'Failed to delete recording file',
-							context: { path: pathToCleanup },
-							cause: error,
 						}),
 				});
 

--- a/apps/whispering/src/lib/services/recorder/navigator.ts
+++ b/apps/whispering/src/lib/services/recorder/navigator.ts
@@ -41,8 +41,6 @@ export function createNavigatorRecorderService(): RecorderService {
 			if (error) {
 				return RecorderServiceErr({
 					message: error.message,
-					context: error.context,
-					cause: error,
 				});
 			}
 			return Ok(devices);
@@ -57,8 +55,6 @@ export function createNavigatorRecorderService(): RecorderService {
 				return RecorderServiceErr({
 					message:
 						'A recording is already in progress. Please stop the current recording before starting a new one.',
-					context: { activeRecording },
-					cause: undefined,
 				});
 			}
 
@@ -73,8 +69,6 @@ export function createNavigatorRecorderService(): RecorderService {
 			if (acquireStreamError) {
 				return RecorderServiceErr({
 					message: acquireStreamError.message,
-					context: acquireStreamError.context,
-					cause: acquireStreamError,
 				});
 			}
 
@@ -89,8 +83,6 @@ export function createNavigatorRecorderService(): RecorderService {
 					RecorderServiceErr({
 						message:
 							'Failed to initialize the audio recorder. This could be due to unsupported audio settings, microphone conflicts, or browser limitations. Please check your microphone is working and try adjusting your audio settings.',
-						context: { selectedDeviceId, bitrateKbps },
-						cause: error,
 					}),
 			});
 
@@ -132,8 +124,6 @@ export function createNavigatorRecorderService(): RecorderService {
 				return RecorderServiceErr({
 					message:
 						'Cannot stop recording because no active recording session was found. Make sure you have started recording before attempting to stop it.',
-					context: { activeRecording },
-					cause: undefined,
 				});
 			}
 
@@ -161,12 +151,6 @@ export function createNavigatorRecorderService(): RecorderService {
 					RecorderServiceErr({
 						message:
 							'Failed to properly stop and save the recording. This might be due to corrupted audio data, insufficient storage space, or a browser issue. Your recording data may be lost.',
-						context: {
-							chunksCount: recording.recordedChunks.length,
-							mimeType: recording.mediaRecorder.mimeType,
-							state: recording.mediaRecorder.state,
-						},
-						cause: error,
 					}),
 			});
 

--- a/apps/whispering/src/lib/services/sound/desktop.ts
+++ b/apps/whispering/src/lib/services/sound/desktop.ts
@@ -13,8 +13,6 @@ export function createPlaySoundServiceDesktop(): PlaySoundService {
 				catch: (error) =>
 					PlaySoundServiceErr({
 						message: 'Failed to play sound',
-						context: { soundName },
-						cause: error,
 					}),
 			}),
 	};

--- a/apps/whispering/src/lib/services/text/desktop.ts
+++ b/apps/whispering/src/lib/services/text/desktop.ts
@@ -16,8 +16,6 @@ export function createTextServiceDesktop(): TextService {
 					TextServiceErr({
 						message:
 							'There was an error reading from the clipboard using the Tauri Clipboard Manager API. Please try again.',
-						context: {},
-						cause: error,
 					}),
 			}),
 
@@ -28,8 +26,6 @@ export function createTextServiceDesktop(): TextService {
 					TextServiceErr({
 						message:
 							'There was an error copying to the clipboard using the Tauri Clipboard Manager API. Please try again.',
-						context: { text },
-						cause: error,
 					}),
 			}),
 
@@ -40,8 +36,6 @@ export function createTextServiceDesktop(): TextService {
 					TextServiceErr({
 						message:
 							'There was an error writing the text. Please try pasting manually with Cmd/Ctrl+V.',
-						context: { text },
-						cause: error,
 					}),
 			}),
 
@@ -52,8 +46,6 @@ export function createTextServiceDesktop(): TextService {
 					TextServiceErr({
 						message:
 							'There was an error simulating the Enter keystroke. Please press Enter manually.',
-						context: {},
-						cause: error,
 					}),
 			}),
 	};

--- a/apps/whispering/src/lib/services/text/extension.ts
+++ b/apps/whispering/src/lib/services/text/extension.ts
@@ -12,8 +12,6 @@ export function createTextServiceExtension(): TextService {
 				catch: (error) =>
 					TextServiceErr({
 						message: 'Unable to read from clipboard',
-						context: {},
-						cause: error,
 					}),
 			}),
 
@@ -23,8 +21,6 @@ export function createTextServiceExtension(): TextService {
 				catch: (error) =>
 					TextServiceErr({
 						message: 'Unable to copy to clipboard',
-						context: { text },
-						cause: error,
 					}),
 			}),
 
@@ -38,8 +34,6 @@ export function createTextServiceExtension(): TextService {
 				catch: (error) =>
 					TextServiceErr({
 						message: 'Unable to write text at cursor position',
-						context: { text },
-						cause: error,
 					}),
 			}),
 
@@ -47,8 +41,6 @@ export function createTextServiceExtension(): TextService {
 			TextServiceErr({
 				message:
 					'Simulating keystrokes is not supported in browser extensions for security reasons.',
-				context: {},
-				cause: undefined,
 			}),
 	};
 }

--- a/apps/whispering/src/lib/services/text/web.ts
+++ b/apps/whispering/src/lib/services/text/web.ts
@@ -14,8 +14,6 @@ export function createTextServiceWeb(): TextService {
 					TextServiceErr({
 						message:
 							'There was an error reading from the clipboard using the browser Clipboard API. Please try again.',
-						context: {},
-						cause: error,
 					}),
 			}),
 
@@ -26,8 +24,6 @@ export function createTextServiceWeb(): TextService {
 					TextServiceErr({
 						message:
 							'There was an error copying to the clipboard using the browser Clipboard API. Please try again.',
-						context: { text },
-						cause: error,
 					}),
 			});
 
@@ -46,8 +42,6 @@ export function createTextServiceWeb(): TextService {
 			return TextServiceErr({
 				message:
 					'Text copied to clipboard. Automatic paste is not supported in web browsers for security reasons. Please paste manually using Cmd/Ctrl+V.',
-				context: { text },
-				cause: undefined,
 			});
 		},
 
@@ -55,8 +49,6 @@ export function createTextServiceWeb(): TextService {
 			TextServiceErr({
 				message:
 					'Simulating keystrokes is not supported in web browsers for security reasons.',
-				context: {},
-				cause: undefined,
 			}),
 	};
 }

--- a/apps/whispering/src/lib/services/transcription/cloud/deepgram.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/deepgram.ts
@@ -132,7 +132,7 @@ export function createDeepgramTranscriptionService({
 							title: '🌐 Connection Issue',
 							description:
 								'Unable to connect to Deepgram service. Please check your internet connection.',
-							action: { type: 'more-details', error: postError.cause },
+							action: { type: 'more-details', error: postError },
 						});
 					}
 
@@ -145,7 +145,7 @@ export function createDeepgramTranscriptionService({
 								description:
 									message ||
 									'Invalid request parameters. Please check your audio file and settings.',
-								action: { type: 'more-details', error: postError.cause },
+								action: { type: 'more-details', error: postError },
 							});
 						}
 
@@ -168,7 +168,7 @@ export function createDeepgramTranscriptionService({
 								description:
 									message ||
 									'Your account does not have access to this feature or model.',
-								action: { type: 'more-details', error: postError.cause },
+								action: { type: 'more-details', error: postError },
 							});
 						}
 
@@ -177,7 +177,7 @@ export function createDeepgramTranscriptionService({
 								title: '📦 Audio File Too Large',
 								description:
 									'Your audio file exceeds the maximum size limit. Try splitting it into smaller segments.',
-								action: { type: 'more-details', error: postError.cause },
+								action: { type: 'more-details', error: postError },
 							});
 						}
 
@@ -186,7 +186,7 @@ export function createDeepgramTranscriptionService({
 								title: '🎵 Unsupported Format',
 								description:
 									"This audio format isn't supported. Please convert your file to a supported format.",
-								action: { type: 'more-details', error: postError.cause },
+								action: { type: 'more-details', error: postError },
 							});
 						}
 
@@ -195,7 +195,7 @@ export function createDeepgramTranscriptionService({
 								title: '⏱️ Rate Limit Reached',
 								description:
 									'Too many requests. Please wait before trying again.',
-								action: { type: 'more-details', error: postError.cause },
+								action: { type: 'more-details', error: postError },
 							});
 						}
 
@@ -203,7 +203,7 @@ export function createDeepgramTranscriptionService({
 							return WhisperingErr({
 								title: '🔧 Service Unavailable',
 								description: `The Deepgram service is temporarily unavailable (Error ${status}). Please try again later.`,
-								action: { type: 'more-details', error: postError.cause },
+								action: { type: 'more-details', error: postError },
 							});
 						}
 
@@ -212,7 +212,7 @@ export function createDeepgramTranscriptionService({
 							description:
 								message ||
 								'An unexpected error occurred during transcription. Please try again.',
-							action: { type: 'more-details', error: postError.cause },
+							action: { type: 'more-details', error: postError },
 						});
 					}
 
@@ -221,7 +221,7 @@ export function createDeepgramTranscriptionService({
 							title: '🔍 Response Error',
 							description:
 								'Received an unexpected response from Deepgram service. Please try again.',
-							action: { type: 'more-details', error: postError.cause },
+							action: { type: 'more-details', error: postError },
 						});
 
 					default:

--- a/apps/whispering/src/lib/services/transcription/self-hosted/speaches.ts
+++ b/apps/whispering/src/lib/services/transcription/self-hosted/speaches.ts
@@ -58,7 +58,7 @@ export function createSpeachesTranscriptionService({
 							title: '🌐 Connection Issue',
 							description:
 								'Unable to connect to the transcription service. This could be a network issue or temporary service interruption. Please try again in a moment.',
-							action: { type: 'more-details', error: postError.cause },
+							action: { type: 'more-details', error: postError },
 						});
 					}
 
@@ -83,7 +83,7 @@ export function createSpeachesTranscriptionService({
 								title: '⛔ Access Restricted',
 								description:
 									"Your account doesn't have access to this feature. This may be due to plan limitations or account restrictions. Please check your account status.",
-								action: { type: 'more-details', error: postError.cause },
+								action: { type: 'more-details', error: postError },
 							});
 						}
 
@@ -92,7 +92,7 @@ export function createSpeachesTranscriptionService({
 								title: '📦 Audio File Too Large',
 								description:
 									'Your audio file exceeds the maximum size limit (typically 25MB). Try splitting it into smaller segments or reducing the audio quality.',
-								action: { type: 'more-details', error: postError.cause },
+								action: { type: 'more-details', error: postError },
 							});
 						}
 
@@ -101,7 +101,7 @@ export function createSpeachesTranscriptionService({
 								title: '🎵 Unsupported Format',
 								description:
 									"This audio format isn't supported. Please convert your file to MP3, WAV, M4A, or another common audio format.",
-								action: { type: 'more-details', error: postError.cause },
+								action: { type: 'more-details', error: postError },
 							});
 						}
 
@@ -122,14 +122,14 @@ export function createSpeachesTranscriptionService({
 							return WhisperingErr({
 								title: '🔧 Service Unavailable',
 								description: `The transcription service is temporarily unavailable (Error ${status}). Please try again in a few minutes.`,
-								action: { type: 'more-details', error: postError.cause },
+								action: { type: 'more-details', error: postError },
 							});
 						}
 
 						return WhisperingErr({
 							title: '❌ Request Failed',
 							description: `The request failed with error ${status}. This may be temporary - please try again. If the problem persists, please contact support.`,
-							action: { type: 'more-details', error: postError.cause },
+							action: { type: 'more-details', error: postError },
 						});
 					}
 
@@ -138,7 +138,7 @@ export function createSpeachesTranscriptionService({
 							title: '🔍 Response Error',
 							description:
 								'Received an unexpected response from the transcription service. This is usually temporary - please try again.',
-							action: { type: 'more-details', error: postError.cause },
+							action: { type: 'more-details', error: postError },
 						});
 
 					default:

--- a/apps/whispering/src/lib/services/tray.ts
+++ b/apps/whispering/src/lib/services/tray.ts
@@ -53,8 +53,6 @@ export function createTrayIconDesktopService(): SetTrayIconService {
 				catch: (error) =>
 					SetTrayIconServiceErr({
 						message: 'Failed to set tray icon',
-						context: { icon: recorderState },
-						cause: error,
 					}),
 			}),
 	};

--- a/bun.lock
+++ b/bun.lock
@@ -346,7 +346,7 @@
     "turbo": "^2.6.1",
     "typescript": "^5.9.3",
     "vite": "^7.2.4",
-    "wellcrafted": "^0.25.1",
+    "wellcrafted": "^0.28.0",
     "wrangler": "^4.51.0",
     "yargs": "^18.0.0",
   },
@@ -917,7 +917,7 @@
 
     "@tursodatabase/database-win32-x64-msvc": ["@tursodatabase/database-win32-x64-msvc@0.3.2", "", { "os": "win32", "cpu": "x64" }, "sha512-i3cPcH22R9twSrgVeQxs+9tG6nYfLebUkg+UIOkh4XYeZCmN9Nx24ddzKTx1IJ0vkm7sbpOg1hmPbwPlyfQbWA=="],
 
-    "@types/bun": ["@types/bun@1.3.3", "", { "dependencies": { "bun-types": "1.3.3" } }, "sha512-ogrKbJ2X5N0kWLLFKeytG0eHDleBYtngtlbu9cyBKFtNL3cnpDZkNdQj8flVf6WTZUX5ulI9AY1oa7ljhSrp+g=="],
+    "@types/bun": ["@types/bun@1.3.4", "", { "dependencies": { "bun-types": "1.3.4" } }, "sha512-EEPTKXHP+zKGPkhRLv+HI0UEX8/o+65hqARxLy8Ov5rIxMBPNTjeZww00CIihrIQGEQBYg+0roO5qOnS/7boGA=="],
 
     "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
 
@@ -1121,7 +1121,7 @@
 
     "builtin-status-codes": ["builtin-status-codes@3.0.0", "", {}, "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ=="],
 
-    "bun-types": ["bun-types@1.3.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-z3Xwlg7j2l9JY27x5Qn3Wlyos8YAp0kKRlrePAOjgjMGS5IG6E7Jnlx736vH9UVI4wUICwwhC9anYL++XeOgTQ=="],
+    "bun-types": ["bun-types@1.3.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
@@ -2461,7 +2461,7 @@
 
     "webidl-conversions": ["webidl-conversions@8.0.0", "", {}, "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA=="],
 
-    "wellcrafted": ["wellcrafted@0.25.1", "", {}, "sha512-ouRBQGF4O/NfmH8bgjucOjbuztoI6rnm45g+5/h4/4gjMZsVzioWaQAOYxalEF6R26WyGycrHLDJKa159rjdvA=="],
+    "wellcrafted": ["wellcrafted@0.28.0", "", {}, "sha512-alZo8qTuQCC7ZWnoXHp2zhD2o0CJzSxm2AizRCc+mjNEEMNNB3f10oCwtzqBxoKU8wDb/LnZ9MtDQTXVa2mbmg=="],
 
     "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 			"drizzle-kit": "^0.31.7",
 			"drizzle-orm": "^0.44.7",
 			"nanoid": "latest",
-			"wellcrafted": "^0.25.1",
+			"wellcrafted": "^0.28.0",
 			"date-fns": "^4.1.0",
 			"@biomejs/biome": "latest",
 			"turbo": "^2.6.1",

--- a/packages/epicenter/src/core/blobs/types.ts
+++ b/packages/epicenter/src/core/blobs/types.ts
@@ -1,4 +1,4 @@
-import { createTaggedError, type TaggedError } from 'wellcrafted/error';
+import { createTaggedError } from 'wellcrafted/error';
 import type { Result } from 'wellcrafted/result';
 
 /**
@@ -42,9 +42,8 @@ export type BlobContext = {
  * });
  * ```
  */
-export const { BlobError, BlobErr } =
-	createTaggedError<'BlobError', BlobContext>('BlobError');
-export type BlobError = TaggedError<'BlobError', BlobContext>;
+export const { BlobError, BlobErr } = createTaggedError('BlobError').withContext<BlobContext>();
+export type BlobError = ReturnType<typeof BlobError>;
 
 /**
  * Blob store for a single table namespace.

--- a/packages/epicenter/src/core/db/table-helper.ts
+++ b/packages/epicenter/src/core/db/table-helper.ts
@@ -1,5 +1,5 @@
 import { type ArkErrors, type } from 'arktype';
-import { createTaggedError, type TaggedError } from 'wellcrafted/error';
+import { createTaggedError } from 'wellcrafted/error';
 import { Ok, type Result } from 'wellcrafted/result';
 import * as Y from 'yjs';
 import { defineMutation, defineQuery } from '../actions';
@@ -29,15 +29,11 @@ type RowValidationContext = {
 /**
  * Error thrown when a row fails schema validation
  */
-export const { RowValidationError, RowValidationErr } = createTaggedError<
+export const { RowValidationError, RowValidationErr } = createTaggedError(
 	'RowValidationError',
-	RowValidationContext
->('RowValidationError');
+).withContext<RowValidationContext>();
 
-export type RowValidationError = TaggedError<
-	'RowValidationError',
-	RowValidationContext
->;
+export type RowValidationError = ReturnType<typeof RowValidationError>;
 
 /**
  * YJS representation of a row

--- a/packages/epicenter/src/core/errors.ts
+++ b/packages/epicenter/src/core/errors.ts
@@ -10,9 +10,25 @@ export type EpicenterOperationError = ReturnType<
 >;
 
 /**
- * Error type for index operations
+ * Context type for index operation errors
+ * Used for structured logging with table/file context
  */
-export const { IndexError, IndexErr } = createTaggedError('IndexError');
+type IndexErrorContext = {
+	tableName?: string;
+	rowId?: string;
+	filename?: string;
+	filePath?: string;
+	directory?: string;
+	operation?: string;
+};
+
+/**
+ * Error type for index operations
+ * Includes optional context for structured logging
+ */
+export const { IndexError, IndexErr } = createTaggedError(
+	'IndexError',
+).withContext<IndexErrorContext | undefined>();
 export type IndexError = ReturnType<typeof IndexError>;
 
 /**

--- a/packages/epicenter/src/indexes/error-logger.ts
+++ b/packages/epicenter/src/indexes/error-logger.ts
@@ -4,11 +4,21 @@ import type { TaggedError } from 'wellcrafted/error';
 import { Ok, tryAsync, trySync } from 'wellcrafted/result';
 
 /**
+ * Error type accepted by the logger.
+ * Supports errors with optional context (Record<string, unknown> | undefined).
+ */
+type LoggableError = TaggedError<
+	string,
+	Record<string, unknown> | undefined,
+	undefined
+>;
+
+/**
  * Log entry format: timestamp + full tagged error
  */
 type LogEntry = {
 	timestamp: string;
-} & TaggedError;
+} & LoggableError;
 
 /**
  * Configuration for creating an index logger
@@ -33,9 +43,9 @@ type IndexLogger = {
 	 *
 	 * Safe to call from multiple locations concurrently.
 	 *
-	 * @param error - The tagged error to log
+	 * @param error - The tagged error to log (with optional context)
 	 */
-	log(error: TaggedError): void;
+	log(error: LoggableError): void;
 
 	/**
 	 * Close the logger and flush all pending entries.

--- a/packages/epicenter/src/indexes/markdown/io.ts
+++ b/packages/epicenter/src/indexes/markdown/io.ts
@@ -80,7 +80,6 @@ export async function readMarkdownFile(filePath: string): Promise<
 		catch: (error) =>
 			MarkdownOperationErr({
 				message: `Failed to read markdown file ${filePath}: ${extractErrorMessage(error)}`,
-				context: { filePath },
 			}),
 	});
 }
@@ -110,7 +109,6 @@ export async function writeMarkdownFile({
 		catch: (error) =>
 			MarkdownOperationErr({
 				message: `Failed to write markdown file ${filePath}: ${extractErrorMessage(error)}`,
-				context: { filePath },
 			}),
 	});
 }
@@ -130,7 +128,6 @@ export async function deleteMarkdownFile({
 		catch: (error) =>
 			MarkdownOperationErr({
 				message: `Failed to delete markdown file ${filePath}: ${extractErrorMessage(error)}`,
-				context: { filePath },
 			}),
 	});
 }

--- a/packages/epicenter/src/indexes/sqlite/sqlite-index.ts
+++ b/packages/epicenter/src/indexes/sqlite/sqlite-index.ts
@@ -194,8 +194,7 @@ export const sqliteIndex = (async <TSchema extends WorkspaceSchema>(
 					},
 					catch: (e) =>
 						IndexErr({
-							message: `Failed to sync ${rows.length} rows to SQLite: ${extractErrorMessage(e)}`,
-							context: { rowCount: rows.length, tableName: table.name },
+							message: `Failed to sync ${rows.length} rows to table "${table.name}" in SQLite: ${extractErrorMessage(e)}`,
 						}),
 				});
 
@@ -237,8 +236,6 @@ export const sqliteIndex = (async <TSchema extends WorkspaceSchema>(
 					logger.log(
 						IndexError({
 							message: `SQLite index onAdd: validation failed for ${table.name}`,
-							context: result.error.context,
-							cause: result.error,
 						}),
 					);
 					return;
@@ -251,8 +248,6 @@ export const sqliteIndex = (async <TSchema extends WorkspaceSchema>(
 					logger.log(
 						IndexError({
 							message: `SQLite index onUpdate: validation failed for ${table.name}`,
-							context: result.error.context,
-							cause: result.error,
 						}),
 					);
 					return;
@@ -290,8 +285,7 @@ export const sqliteIndex = (async <TSchema extends WorkspaceSchema>(
 				},
 				catch: (e) =>
 					IndexErr({
-						message: `Failed to sync ${rows.length} rows to SQLite during init: ${extractErrorMessage(e)}`,
-						context: { rowCount: rows.length, tableName: table.name },
+						message: `Failed to sync ${rows.length} rows to table "${table.name}" in SQLite during init: ${extractErrorMessage(e)}`,
 					}),
 			});
 
@@ -330,8 +324,7 @@ export const sqliteIndex = (async <TSchema extends WorkspaceSchema>(
 					try: () => rebuildSqlite(),
 					catch: (error) =>
 						IndexErr({
-							message: `SQLite index pull failed: ${extractErrorMessage(error)}`,
-							context: { operation: 'pull' },
+							message: `SQLite index pull operation failed: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -367,8 +360,7 @@ export const sqliteIndex = (async <TSchema extends WorkspaceSchema>(
 					catch: (error) => {
 						isPushingFromSqlite = false;
 						return IndexErr({
-							message: `SQLite index push failed: ${extractErrorMessage(error)}`,
-							context: { operation: 'push' },
+							message: `SQLite index push operation failed: ${extractErrorMessage(error)}`,
 						});
 					},
 				});

--- a/packages/svelte-utils/src/createPersistedState.svelte.ts
+++ b/packages/svelte-utils/src/createPersistedState.svelte.ts
@@ -183,17 +183,14 @@ export function createPersistedState<TSchema extends StandardSchemaV1>({
 	};
 }
 
-const { ParseJsonErr } = createTaggedError<'ParseJsonError', { value: string }>(
-	'ParseJsonError',
-);
+const { ParseJsonErr } = createTaggedError('ParseJsonError');
 
 function parseJson(value: string) {
 	return trySync({
 		try: () => JSON.parse(value) as unknown,
 		catch: (e) =>
 			ParseJsonErr({
-				message: `Failed to parse JSON: ${extractErrorMessage(e)}`,
-				context: { value },
+				message: `Failed to parse JSON for value "${value.slice(0, 100)}...": ${extractErrorMessage(e)}`,
 			}),
 	});
 }

--- a/specs/20251207T120000-wellcrafted-error-migration.md
+++ b/specs/20251207T120000-wellcrafted-error-migration.md
@@ -1,0 +1,213 @@
+# Well-Crafted Error Migration Plan
+
+## Overview
+
+This document outlines the migration from the old `createTaggedError` API to the new v0.28.0 fluent API with explicit opt-in for `context` and `cause` properties.
+
+## Key Philosophy Changes
+
+### Before (v0.27.0 and earlier)
+All errors had optional `context` and `cause` by default:
+```typescript
+const { ApiError } = createTaggedError('ApiError');
+// ApiError had: { name, message, context?: Record<string, unknown>, cause?: AnyTaggedError }
+```
+
+### After (v0.28.0)
+Errors only have `{ name, message }` by default. Context and cause must be explicitly added:
+```typescript
+// Minimal error
+const { ApiError } = createTaggedError('ApiError');
+// { name, message }
+
+// With context
+const { ApiError } = createTaggedError('ApiError')
+  .withContext<{ endpoint: string }>();
+// { name, message, context: { endpoint: string } }
+
+// With optional cause
+const { ApiError } = createTaggedError('ApiError')
+  .withCause<NetworkError | undefined>();
+// { name, message, cause?: NetworkError }
+```
+
+### Cause Philosophy
+- `cause` is ONLY for TaggedError chains (Service A wraps Service B error)
+- Raw unknown errors from catch blocks should:
+  1. Have their message extracted via `extractErrorMessage(error)`
+  2. Optionally be stored in `context.originalError` for debugging
+- Leaf services (that don't call other TaggedError-returning services) should NOT have a cause property
+
+---
+
+## Audit Results
+
+### Category 1: Pure Leaf Services (No Context, No Cause)
+
+These services don't need context or cause. They should use the simplest form:
+
+| File | Error Type | Current | New |
+|------|-----------|---------|-----|
+| `services/sound/types.ts` | `PlaySoundServiceError` | flexible | `createTaggedError('PlaySoundServiceError')` |
+| `services/recorder/types.ts` | `RecorderServiceError` | flexible | `createTaggedError('RecorderServiceError')` |
+| `services/text/types.ts` | `TextServiceError` | flexible | `createTaggedError('TextServiceError')` |
+| `services/fs/types.ts` | `FsServiceError` | flexible | `createTaggedError('FsServiceError')` |
+| `services/permissions/index.ts` | `PermissionsServiceError` | flexible | `createTaggedError('PermissionsServiceError')` |
+| `services/tray.ts` | `SetTrayIconServiceError` | flexible | `createTaggedError('SetTrayIconServiceError')` |
+| `services/analytics/types.ts` | `AnalyticsServiceError` | flexible | `createTaggedError('AnalyticsServiceError')` |
+| `services/notifications/types.ts` | `NotificationServiceError` | flexible | `createTaggedError('NotificationServiceError')` |
+| `services/completion/types.ts` | `CompletionServiceError` | flexible | `createTaggedError('CompletionServiceError')` |
+| `services/db/types.ts` | `DbServiceError` | flexible | `createTaggedError('DbServiceError')` |
+| `services/global-shortcut-manager.ts` | `InvalidAcceleratorError` | flexible | `createTaggedError('InvalidAcceleratorError')` |
+| `services/global-shortcut-manager.ts` | `GlobalShortcutServiceError` | flexible | `createTaggedError('GlobalShortcutServiceError')` |
+| `services/device-stream.ts` | `DeviceStreamServiceError` | flexible | `createTaggedError('DeviceStreamServiceError')` |
+| `services/http/types.ts` | `ConnectionError` | flexible | `createTaggedError('ConnectionError')` |
+| `services/http/types.ts` | `ParseError` | flexible | `createTaggedError('ParseError')` |
+| `services/http/types.ts` | `ResponseError` | custom wrapper | Keep as-is (has custom `status` property) |
+
+**Action**: These are already correct for v0.28.0 defaults. No changes needed to declarations. However, usages that pass `cause: error` need fixing.
+
+---
+
+### Category 2: Errors with Structured Context
+
+These need `.withContext<T>()`:
+
+| File | Error Type | Context Type | Migration |
+|------|-----------|--------------|-----------|
+| `packages/epicenter/src/core/blobs/types.ts` | `BlobError` | `{ filename: string; code: BlobErrorCode }` | `.withContext<BlobContext>()` |
+| `packages/epicenter/src/core/db/table-helper.ts` | `RowValidationError` | `{ tableName: string; id: string; errors: ArkErrors; summary: string }` | `.withContext<RowValidationContext>()` |
+
+---
+
+### Category 3: Errors with Both Context and Cause (Error Chains)
+
+These wrap other TaggedErrors and need both `.withContext<T>()` and `.withCause<T | undefined>()`:
+
+| File | Error Type | Wraps | Migration |
+|------|-----------|-------|-----------|
+| `services/device-stream.ts` | `DeviceStreamServiceError` | Self (chained calls) | `.withCause<DeviceStreamServiceError \| undefined>()` |
+
+---
+
+### Category 4: Incorrect Cause Usages (FIXES NEEDED)
+
+These pass `cause: error` where `error` is `unknown`. They need to be fixed:
+
+#### `services/analytics/web.ts` (line 20)
+```typescript
+// BEFORE
+AnalyticsServiceErr({
+  message: 'Failed to log analytics event',
+  context: { event },
+  cause: error,  // ❌ error is unknown
+})
+
+// AFTER
+AnalyticsServiceErr({
+  message: `Failed to log analytics event: ${extractErrorMessage(error)}`,
+})
+```
+
+#### `services/analytics/desktop.ts` (line 21)
+Same pattern as web.ts.
+
+#### `services/device-stream.ts` (lines 35, 75, 112)
+```typescript
+// BEFORE
+DeviceStreamServiceErr({
+  message: '...',
+  cause: error,  // ❌ error is unknown
+})
+
+// AFTER - for leaf errors (lines 35, 75)
+DeviceStreamServiceErr({
+  message: `...: ${extractErrorMessage(error)}`,
+})
+
+// AFTER - for chained errors (lines 172, 204 - wraps DeviceStreamServiceError)
+// These are correct! They wrap TaggedErrors, not unknown errors
+```
+
+#### `services/global-shortcut-manager.ts` (lines 57-60, 72-76, 104-112, 127-131)
+```typescript
+// BEFORE
+InvalidAcceleratorErr({
+  message: '...',
+  context: { accelerator },
+  cause: undefined,  // This is fine, but unnecessary
+})
+
+GlobalShortcutServiceErr({
+  message: `...: ${extractErrorMessage(error)}`,
+  context: { accelerator, error },  // ❌ storing raw error in context
+  cause: error,  // ❌ error is unknown
+})
+
+// AFTER
+InvalidAcceleratorErr({
+  message: '...',
+})  // No context or cause needed
+
+GlobalShortcutServiceErr({
+  message: `...: ${extractErrorMessage(error)}`,
+})  // extractErrorMessage already captures the error info in the message
+```
+
+#### `services/permissions/index.ts` (lines 37-40, 54-58, 75-79, 93-97)
+```typescript
+// BEFORE
+PermissionsServiceErr({
+  message: `Failed to check accessibility permissions: ${extractErrorMessage(error)}`,
+  cause: error,  // ❌ error is unknown
+})
+
+// AFTER
+PermissionsServiceErr({
+  message: `Failed to check accessibility permissions: ${extractErrorMessage(error)}`,
+})  // extractErrorMessage already captures the info
+```
+
+#### `services/completion/*.ts`
+Multiple files pass `cause: apiError` or `cause: error`. These need review.
+
+---
+
+## Implementation Tasks
+
+### Phase 1: Update Error Declarations (Minimal Impact)
+
+- [ ] Review all `createTaggedError` declarations
+- [ ] For errors that need context, add `.withContext<T>()`
+- [ ] For errors that wrap other TaggedErrors, add `.withCause<T | undefined>()`
+- [ ] Remove `cause: null` and `cause: undefined` from error usages (they're now implicit)
+
+### Phase 2: Fix Incorrect Cause Usages
+
+- [ ] `services/analytics/web.ts` - Remove cause, ensure extractErrorMessage in message
+- [ ] `services/analytics/desktop.ts` - Remove cause, ensure extractErrorMessage in message
+- [ ] `services/device-stream.ts` - Remove cause from unknown error catches
+- [ ] `services/global-shortcut-manager.ts` - Remove cause and context from error constructors
+- [ ] `services/permissions/index.ts` - Remove cause from error constructors
+- [ ] `services/notifications/web.ts` - Review and fix
+- [ ] `services/completion/*.ts` - Review and fix all files
+
+### Phase 3: Update Epicenter Package
+
+- [ ] `packages/epicenter/src/core/blobs/types.ts` - Migrate to fluent API
+- [ ] `packages/epicenter/src/core/db/table-helper.ts` - Migrate to fluent API
+
+---
+
+## Review Section
+
+_To be filled after implementation_
+
+---
+
+## Notes
+
+1. The new v0.28.0 defaults are actually simpler for most leaf services
+2. The key insight: `cause` chains TaggedErrors, `context` holds debug data
+3. Use `extractErrorMessage(error)` to put raw error info in the message string
+4. Remove all `cause: error` where `error` is `unknown` from catch blocks


### PR DESCRIPTION
This migration aligns with wellcrafted v0.28.0's new explicit opt-in philosophy for error context and cause properties. The library now follows a Rust-inspired pattern where `context` and `cause` must be explicitly added via `.withContext<T>()` and `.withCause<T>()` - by default, errors only have `{ name, message }`.

The core insight driving this change: `cause` should only be used for TaggedError chains (typed error propagation), not for wrapping raw `unknown` errors from catch blocks. For raw errors, we now use `extractErrorMessage(error)` to embed the error info directly in the message string.

**Type-level changes:**

`IndexError` and `MarkdownIndexError` now have optional typed context:
```typescript
// IndexError with optional context for structured logging
export const { IndexError, IndexErr } = createTaggedError('IndexError')
  .withContext<IndexErrorContext | undefined>();

// MarkdownIndexError with optional context for diagnostics
export const { MarkdownIndexError, MarkdownIndexErr } = createTaggedError('MarkdownIndexError')
  .withContext<MarkdownIndexContext | undefined>();
```

The `| undefined` makes context optional while still providing type safety when context is provided.

**Migration pattern:**

For leaf services (services that don't chain errors from other services), we removed `cause:` entirely and embedded error info in the message:

```typescript
// Before
catch: (error) => ServiceErr({
  message: 'Operation failed',
  cause: error,
})

// After
catch: (error) => ServiceErr({
  message: `Operation failed: ${extractErrorMessage(error)}`,
})
```

This simplifies the error model while preserving all debugging information.

**Files affected:** 48 files across whispering app services and epicenter packages, resulting in a net reduction of ~280 lines as redundant `cause:` and `context:` properties were removed.