### PR TITLE
fix(tooltip): coordinate tooltips globally and adjust delay timing

### DIFF
--- a/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/RecordingRowActions.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/RecordingRowActions.svelte
@@ -120,25 +120,23 @@
 		{#if latestTransformationRunByRecordingIdQuery.isPending}
 			<Spinner />
 		{:else if latestTransformationRunByRecordingIdQuery.isError}
-			<Tooltip.Provider>
-				<Tooltip.Root>
-					<Tooltip.Trigger>
-						{#snippet child({ props })}
-							<AlertCircleIcon
-								class="text-red-500"
-								{...props}
-								id={getRecordingTransitionId({
-									recordingId,
-									propertyName: 'latestTransformationRunOutput',
-								})}
-							/>
-						{/snippet}
-					</Tooltip.Trigger>
-					<Tooltip.Content class="max-w-xs text-center">
-						Error fetching latest transformation run output
-					</Tooltip.Content>
-				</Tooltip.Root>
-			</Tooltip.Provider>
+			<Tooltip.Root>
+				<Tooltip.Trigger>
+					{#snippet child({ props })}
+						<AlertCircleIcon
+							class="text-red-500"
+							{...props}
+							id={getRecordingTransitionId({
+								recordingId,
+								propertyName: 'latestTransformationRunOutput',
+							})}
+						/>
+					{/snippet}
+				</Tooltip.Trigger>
+				<Tooltip.Content class="max-w-xs text-center">
+					Error fetching latest transformation run output
+				</Tooltip.Content>
+			</Tooltip.Root>
 		{:else}
 			<CopyButton
 				text={latestTransformationRunByRecordingIdQuery.data?.status ===

--- a/apps/whispering/src/routes/+layout.svelte
+++ b/apps/whispering/src/routes/+layout.svelte
@@ -6,6 +6,7 @@
 	import { ModeWatcher, mode } from 'mode-watcher';
 	import { Toaster, type ToasterProps } from 'svelte-sonner';
 	import '@epicenter/ui/app.css';
+	import * as Tooltip from '@epicenter/ui/tooltip';
 
 	let { children } = $props();
 
@@ -42,7 +43,9 @@
 </svelte:head>
 
 <QueryClientProvider client={queryClient}>
-	{@render children()}
+	<Tooltip.Provider delayDuration={300} skipDelayDuration={150}>
+		{@render children()}
+	</Tooltip.Provider>
 </QueryClientProvider>
 
 <Toaster

--- a/packages/ui/src/button/button.svelte
+++ b/packages/ui/src/button/button.svelte
@@ -37,6 +37,11 @@
 		WithElementRef<HTMLAnchorAttributes> & {
 			variant?: ButtonVariant;
 			size?: ButtonSize;
+			/**
+			 * Tooltip text to display on hover.
+			 * Requires a parent `<Tooltip.Provider>` in the component tree.
+			 * Wrap your app root with `<Tooltip.Provider>` to enable tooltip coordination.
+			 */
 			tooltip?: string;
 		};
 </script>
@@ -88,19 +93,21 @@
 	{/if}
 {/snippet}
 
+<!--
+	When using the tooltip prop, this component requires a parent Tooltip.Provider.
+	Wrap your app root with <Tooltip.Provider> to enable tooltip coordination.
+-->
 {#if tooltip}
-	<Tooltip.Provider>
-		<Tooltip.Root>
-			<Tooltip.Trigger>
-				{#snippet child({ props })}
-					{@render buttonContent(props)}
-				{/snippet}
-			</Tooltip.Trigger>
-			<Tooltip.Content class="max-w-xs text-center">
-				{tooltip}
-			</Tooltip.Content>
-		</Tooltip.Root>
-	</Tooltip.Provider>
+	<Tooltip.Root>
+		<Tooltip.Trigger>
+			{#snippet child({ props })}
+				{@render buttonContent(props)}
+			{/snippet}
+		</Tooltip.Trigger>
+		<Tooltip.Content class="max-w-xs text-center">
+			{tooltip}
+		</Tooltip.Content>
+	</Tooltip.Root>
 {:else}
 	{@render buttonContent()}
 {/if}

--- a/packages/ui/src/link/link.svelte
+++ b/packages/ui/src/link/link.svelte
@@ -6,6 +6,11 @@
 	import type { HTMLAnchorAttributes } from 'svelte/elements';
 
 	export type LinkProps = HTMLAnchorAttributes & {
+		/**
+		 * Tooltip text to display on hover.
+		 * Requires a parent `<Tooltip.Provider>` in the component tree.
+		 * Wrap your app root with `<Tooltip.Provider>` to enable tooltip coordination.
+		 */
 		tooltip?: string;
 	};
 </script>
@@ -30,19 +35,21 @@
 	</a>
 {/snippet}
 
+<!--
+	When using the tooltip prop, this component requires a parent Tooltip.Provider.
+	Wrap your app root with <Tooltip.Provider> to enable tooltip coordination.
+-->
 {#if tooltip}
-	<Tooltip.Provider>
-		<Tooltip.Root>
-			<Tooltip.Trigger>
-				{#snippet child({ props })}
-					{@render linkContent(props)}
-				{/snippet}
-			</Tooltip.Trigger>
-			<Tooltip.Content class="max-w-xs text-center">
-				{tooltip}
-			</Tooltip.Content>
-		</Tooltip.Root>
-	</Tooltip.Provider>
+	<Tooltip.Root>
+		<Tooltip.Trigger>
+			{#snippet child({ props })}
+				{@render linkContent(props)}
+			{/snippet}
+		</Tooltip.Trigger>
+		<Tooltip.Content class="max-w-xs text-center">
+			{tooltip}
+		</Tooltip.Content>
+	</Tooltip.Root>
 {:else}
 	{@render linkContent()}
 {/if}


### PR DESCRIPTION
This PR implements the tooltip coordination approach originally proposed by @thisisharsh7 in #636, adapted to the current codebase architecture.

The core idea is to move `Tooltip.Provider` to the app root layout with `delayDuration={300}` and `skipDelayDuration={150}`. This ensures coordinated tooltip behavior across the app: only one tooltip is visible at a time when quickly hovering between triggers, and tooltips appear with a consistent delay.

Button and Link components no longer wrap tooltips with their own provider; they now require a parent `Tooltip.Provider` in the component tree. JSDoc and HTML comments document this requirement for consumers of the UI library.

Components like `sidebar-provider` and `pm-command` retain their own `Tooltip.Provider` with `delayDuration={0}` for instant tooltips where appropriate.

Closes #636