### PR TITLE
refactor(query): migrate to wellcrafted v0.29.0 API naming

### DIFF
--- a/.claude/agents/query-layer-specialist.md
+++ b/.claude/agents/query-layer-specialist.md
@@ -36,7 +36,7 @@ Your core competencies include:
 - You coordinate multiple services within single operations (like the notify API)
 
 **Best Practices You Enforce**
-- Always use `defineMutation` with `resultMutationFn` for proper Result type handling
+- Always use `defineMutation` with `mutationFn` for proper Result type handling
 - Prefer `createMutation` in Svelte files for reactive state, `.execute()` in TypeScript files
 - Pass callbacks as the second argument to `.mutate()` for maximum context access
 - Keep query functions simple - complex logic belongs in services

--- a/apps/whispering/ARCHITECTURE.md
+++ b/apps/whispering/ARCHITECTURE.md
@@ -90,7 +90,7 @@ It's often unclear where exactly you should mutate the cache with the query clie
 ```typescript
 // From recordings mutations
 createRecording: defineMutation({
-  resultMutationFn: async (recording: Recording) => {
+  mutationFn: async (recording: Recording) => {
     const { data, error } = await services.db.createRecording(recording);
     if (error) return Err(error);
 
@@ -111,7 +111,7 @@ This design keeps all reactive state management isolated in the query layer, all
 
 ## Error Transformation
 
-The query layer also transforms service-specific errors into `WhisperingError` types that integrate seamlessly with the toast notification system. This happens inside `resultMutationFn` or `resultQueryFn`, creating a clean boundary between business logic errors and UI presentation:
+The query layer also transforms service-specific errors into `WhisperingError` types that integrate seamlessly with the toast notification system. This happens inside `mutationFn` or `queryFn`, creating a clean boundary between business logic errors and UI presentation:
 
 ```typescript
 // Service returns domain-specific error

--- a/apps/whispering/src/lib/query/actions.ts
+++ b/apps/whispering/src/lib/query/actions.ts
@@ -45,7 +45,7 @@ let isRecordingOperationBusy = false;
 // Internal mutations for manual recording
 const startManualRecording = defineMutation({
 	mutationKey: ['commands', 'startManualRecording'] as const,
-	resultMutationFn: async () => {
+	mutationFn: async () => {
 		// Prevent concurrent recording operations
 		if (isRecordingOperationBusy) {
 			console.info('Recording operation already in progress, ignoring start');
@@ -130,7 +130,7 @@ const startManualRecording = defineMutation({
 
 const stopManualRecording = defineMutation({
 	mutationKey: ['commands', 'stopManualRecording'] as const,
-	resultMutationFn: async () => {
+	mutationFn: async () => {
 		// Prevent concurrent recording operations
 		if (isRecordingOperationBusy) {
 			console.info('Recording operation already in progress, ignoring stop');
@@ -196,7 +196,7 @@ const stopManualRecording = defineMutation({
 // Internal mutations for VAD recording
 const startVadRecording = defineMutation({
 	mutationKey: ['commands', 'startVadRecording'] as const,
-	resultMutationFn: async () => {
+	mutationFn: async () => {
 		await settings.switchRecordingMode('vad');
 
 		const toastId = nanoid();
@@ -300,7 +300,7 @@ const startVadRecording = defineMutation({
 
 const stopVadRecording = defineMutation({
 	mutationKey: ['commands', 'stopVadRecording'] as const,
-	resultMutationFn: async () => {
+	mutationFn: async () => {
 		const toastId = nanoid();
 		console.info('Stopping voice activated capture');
 		notify.loading.execute({
@@ -332,7 +332,7 @@ export const commands = {
 	// Toggle manual recording
 	toggleManualRecording: defineMutation({
 		mutationKey: ['commands', 'toggleManualRecording'] as const,
-		resultMutationFn: async () => {
+		mutationFn: async () => {
 			const { data: recorderState, error: getRecorderStateError } =
 				await recorder.getRecorderState.fetch();
 			if (getRecorderStateError) {
@@ -349,7 +349,7 @@ export const commands = {
 	// Cancel manual recording
 	cancelManualRecording: defineMutation({
 		mutationKey: ['commands', 'cancelManualRecording'] as const,
-		resultMutationFn: async () => {
+		mutationFn: async () => {
 			// Prevent concurrent recording operations
 			if (isRecordingOperationBusy) {
 				console.info(
@@ -405,7 +405,7 @@ export const commands = {
 	// Toggle VAD recording
 	toggleVadRecording: defineMutation({
 		mutationKey: ['commands', 'toggleVadRecording'] as const,
-		resultMutationFn: async () => {
+		mutationFn: async () => {
 			if (vadRecorder.state === 'LISTENING' || vadRecorder.state === 'SPEECH_DETECTED') {
 				return await stopVadRecording.execute(undefined);
 			}
@@ -416,7 +416,7 @@ export const commands = {
 	// Upload recordings (supports multiple files)
 	uploadRecordings: defineMutation({
 		mutationKey: ['recordings', 'uploadRecordings'] as const,
-		resultMutationFn: async ({ files }: { files: File[] }) => {
+		mutationFn: async ({ files }: { files: File[] }) => {
 			await settings.switchRecordingMode('upload');
 			// Partition files into valid and invalid in a single pass
 			const { valid: validFiles, invalid: invalidFiles } = files.reduce<{
@@ -478,7 +478,7 @@ export const commands = {
 	// Open transformation picker to select a transformation
 	openTransformationPicker: defineMutation({
 		mutationKey: ['commands', 'openTransformationPicker'] as const,
-		resultMutationFn: async () => {
+		mutationFn: async () => {
 			await transformClipboardWindow.toggle();
 			return Ok(undefined);
 		},
@@ -487,7 +487,7 @@ export const commands = {
 	// Run selected transformation on clipboard
 	runTransformationOnClipboard: defineMutation({
 		mutationKey: ['commands', 'runTransformationOnClipboard'] as const,
-		resultMutationFn: async () => {
+		mutationFn: async () => {
 			// Get selected transformation from settings
 			const transformationId =
 				settings.value['transformations.selectedTransformationId'];

--- a/apps/whispering/src/lib/query/analytics.ts
+++ b/apps/whispering/src/lib/query/analytics.ts
@@ -18,7 +18,7 @@ export const analytics = {
 	 */
 	logEvent: defineMutation({
 		mutationKey: analyticsKeys.logEvent,
-		resultMutationFn: async (event: Event): Promise<Result<void, never>> => {
+		mutationFn: async (event: Event): Promise<Result<void, never>> => {
 			// Check if analytics is enabled in settings
 			if (!settings.value['analytics.enabled']) {
 				// Analytics disabled, skip anonymous analytics

--- a/apps/whispering/src/lib/query/db.ts
+++ b/apps/whispering/src/lib/query/db.ts
@@ -41,12 +41,12 @@ export const db = {
 	recordings: {
 		getAll: defineQuery({
 			queryKey: dbKeys.recordings.all,
-			resultQueryFn: () => services.db.recordings.getAll(),
+			queryFn: () => services.db.recordings.getAll(),
 		}),
 
 		getLatest: defineQuery({
 			queryKey: dbKeys.recordings.latest,
-			resultQueryFn: () => services.db.recordings.getLatest(),
+			queryFn: () => services.db.recordings.getLatest(),
 			initialData: () =>
 				queryClient
 					.getQueryData<Recording[]>(dbKeys.recordings.all)
@@ -61,7 +61,7 @@ export const db = {
 		getById: (id: Accessor<string>) =>
 			defineQuery({
 				queryKey: dbKeys.recordings.byId(id()),
-				resultQueryFn: () => services.db.recordings.getById(id()),
+				queryFn: () => services.db.recordings.getById(id()),
 				initialData: () =>
 					queryClient
 						.getQueryData<Recording[]>(dbKeys.recordings.all)
@@ -78,13 +78,13 @@ export const db = {
 		getAudioPlaybackUrl: (id: Accessor<string>) =>
 			defineQuery({
 				queryKey: dbKeys.recordings.audioPlaybackUrl(id()),
-				resultQueryFn: () =>
+				queryFn: () =>
 					services.db.recordings.ensureAudioPlaybackUrl(id()),
 			}),
 
 		create: defineMutation({
 			mutationKey: ['db', 'recordings', 'create'] as const,
-			resultMutationFn: async (params: {
+			mutationFn: async (params: {
 				recording: Recording;
 				audio: Blob;
 			}) => {
@@ -116,7 +116,7 @@ export const db = {
 
 		update: defineMutation({
 			mutationKey: ['db', 'recordings', 'update'] as const,
-			resultMutationFn: async (recording: Recording) => {
+			mutationFn: async (recording: Recording) => {
 				const { data, error } = await services.db.recordings.update(recording);
 				if (error) return Err(error);
 
@@ -143,7 +143,7 @@ export const db = {
 
 		delete: defineMutation({
 			mutationKey: ['db', 'recordings', 'delete'] as const,
-			resultMutationFn: async (recordings: Recording | Recording[]) => {
+			mutationFn: async (recordings: Recording | Recording[]) => {
 				const recordingsArray = Array.isArray(recordings)
 					? recordings
 					: [recordings];
@@ -184,13 +184,13 @@ export const db = {
 	transformations: {
 		getAll: defineQuery({
 			queryKey: dbKeys.transformations.all,
-			resultQueryFn: () => services.db.transformations.getAll(),
+			queryFn: () => services.db.transformations.getAll(),
 		}),
 
 		getById: (id: Accessor<string>) =>
 			defineQuery({
 				queryKey: dbKeys.transformations.byId(id()),
-				resultQueryFn: () => services.db.transformations.getById(id()),
+				queryFn: () => services.db.transformations.getById(id()),
 				initialData: () =>
 					queryClient
 						.getQueryData<Transformation[]>(dbKeys.transformations.all)
@@ -202,7 +202,7 @@ export const db = {
 
 		create: defineMutation({
 			mutationKey: ['db', 'transformations', 'create'] as const,
-			resultMutationFn: async (transformation: Transformation) => {
+			mutationFn: async (transformation: Transformation) => {
 				const { data, error } =
 					await services.db.transformations.create(transformation);
 				if (error) return Err(error);
@@ -225,7 +225,7 @@ export const db = {
 
 		update: defineMutation({
 			mutationKey: ['db', 'transformations', 'update'] as const,
-			resultMutationFn: async (transformation: Transformation) => {
+			mutationFn: async (transformation: Transformation) => {
 				const { data, error } =
 					await services.db.transformations.update(transformation);
 				if (error) return Err(error);
@@ -250,7 +250,7 @@ export const db = {
 
 		delete: defineMutation({
 			mutationKey: ['db', 'transformations', 'delete'] as const,
-			resultMutationFn: async (
+			mutationFn: async (
 				transformations: Transformation | Transformation[],
 			) => {
 				const transformationsArray = Array.isArray(transformations)
@@ -297,25 +297,25 @@ export const db = {
 		getByTransformationId: (id: Accessor<string>) =>
 			defineQuery({
 				queryKey: dbKeys.runs.byTransformationId(id()),
-				resultQueryFn: () => services.db.runs.getByTransformationId(id()),
+				queryFn: () => services.db.runs.getByTransformationId(id()),
 			}),
 
 		getByRecordingId: (recordingId: Accessor<string>) =>
 			defineQuery({
 				queryKey: dbKeys.runs.byRecordingId(recordingId()),
-				resultQueryFn: () => services.db.runs.getByRecordingId(recordingId()),
+				queryFn: () => services.db.runs.getByRecordingId(recordingId()),
 			}),
 
 		getLatestByRecordingId: (recordingId: Accessor<string>) =>
 			defineQuery({
 				queryKey: dbKeys.runs.byRecordingId(recordingId()),
-				resultQueryFn: () => services.db.runs.getByRecordingId(recordingId()),
+				queryFn: () => services.db.runs.getByRecordingId(recordingId()),
 				select: (data) => data.at(0),
 			}),
 
 		delete: defineMutation({
 			mutationKey: ['db', 'runs', 'delete'] as const,
-			resultMutationFn: async (
+			mutationFn: async (
 				runs: TransformationRun | TransformationRun[],
 			) => {
 				const runsArray = Array.isArray(runs) ? runs : [runs];

--- a/apps/whispering/src/lib/query/delivery.ts
+++ b/apps/whispering/src/lib/query/delivery.ts
@@ -35,7 +35,7 @@ export const delivery = {
 	 */
 	deliverTranscriptionResult: defineMutation({
 		mutationKey: ['delivery', 'deliverTranscriptionResult'],
-		resultMutationFn: async ({
+		mutationFn: async ({
 			text,
 			toastId,
 		}: {
@@ -223,7 +223,7 @@ export const delivery = {
 	 */
 	deliverTransformationResult: defineMutation({
 		mutationKey: ['delivery', 'deliverTransformationResult'],
-		resultMutationFn: async ({
+		mutationFn: async ({
 			text,
 			toastId,
 		}: {

--- a/apps/whispering/src/lib/query/download.ts
+++ b/apps/whispering/src/lib/query/download.ts
@@ -8,7 +8,7 @@ import { defineMutation } from './_client';
 export const download = {
 	downloadRecording: defineMutation({
 		mutationKey: ['download', 'downloadRecording'] as const,
-		resultMutationFn: async (
+		mutationFn: async (
 			recording: Recording,
 		): Promise<Result<void, WhisperingError | DownloadServiceError>> => {
 			// Fetch audio blob by ID

--- a/apps/whispering/src/lib/query/ffmpeg.ts
+++ b/apps/whispering/src/lib/query/ffmpeg.ts
@@ -6,7 +6,7 @@ import { defineQuery } from './_client';
 export const ffmpeg = {
 	checkFfmpegInstalled: defineQuery({
 		queryKey: ['ffmpeg.checkInstalled'],
-		resultQueryFn: async () => {
+		queryFn: async () => {
 			const { data, error } = await services.ffmpeg.checkInstalled();
 			if (error) {
 				return fromTaggedErr(error, {

--- a/apps/whispering/src/lib/query/notify.ts
+++ b/apps/whispering/src/lib/query/notify.ts
@@ -11,7 +11,7 @@ const createNotifyMutation = (
 ) =>
 	defineMutation({
 		mutationKey: ['notify', variant],
-		resultMutationFn: async (
+		mutationFn: async (
 			options: Omit<UnifiedNotificationOptions, 'variant'>,
 		) => {
 			const fullOptions: UnifiedNotificationOptions = { ...options, variant };

--- a/apps/whispering/src/lib/query/recorder.ts
+++ b/apps/whispering/src/lib/query/recorder.ts
@@ -29,7 +29,7 @@ export const recorder = {
 	// Query that enumerates available recording devices with labels
 	enumerateDevices: defineQuery({
 		queryKey: recorderKeys.devices,
-		resultQueryFn: async () => {
+		queryFn: async () => {
 			const { data, error } = await recorderService().enumerateDevices();
 			if (error) {
 				return fromTaggedErr(error, {
@@ -44,7 +44,7 @@ export const recorder = {
 	// Query that returns the recorder state (IDLE or RECORDING)
 	getRecorderState: defineQuery({
 		queryKey: recorderKeys.recorderState,
-		resultQueryFn: async () => {
+		queryFn: async () => {
 			const { data: state, error: getStateError } =
 				await recorderService().getRecorderState();
 			if (getStateError) {
@@ -60,7 +60,7 @@ export const recorder = {
 
 	startRecording: defineMutation({
 		mutationKey: recorderKeys.startRecording,
-		resultMutationFn: async ({ toastId }: { toastId: string }) => {
+		mutationFn: async ({ toastId }: { toastId: string }) => {
 			// Generate a unique recording ID that will serve as the file name
 			const recordingId = nanoid();
 
@@ -129,7 +129,7 @@ export const recorder = {
 
 	stopRecording: defineMutation({
 		mutationKey: recorderKeys.stopRecording,
-		resultMutationFn: async ({ toastId }: { toastId: string }) => {
+		mutationFn: async ({ toastId }: { toastId: string }) => {
 			const { data: blob, error: stopRecordingError } =
 				await recorderService().stopRecording({
 					sendStatus: (options) =>
@@ -167,7 +167,7 @@ export const recorder = {
 
 	cancelRecording: defineMutation({
 		mutationKey: recorderKeys.cancelRecording,
-		resultMutationFn: async ({ toastId }: { toastId: string }) => {
+		mutationFn: async ({ toastId }: { toastId: string }) => {
 			const { data: cancelResult, error: cancelRecordingError } =
 				await recorderService().cancelRecording({
 					sendStatus: (options) =>

--- a/apps/whispering/src/lib/query/shortcuts.ts
+++ b/apps/whispering/src/lib/query/shortcuts.ts
@@ -9,7 +9,7 @@ import { defineMutation } from './_client';
 export const shortcuts = {
 	registerCommandLocally: defineMutation({
 		mutationKey: ['shortcuts', 'registerCommandLocally'] as const,
-		resultMutationFn: ({
+		mutationFn: ({
 			command,
 			keyCombination,
 		}: {
@@ -26,13 +26,13 @@ export const shortcuts = {
 
 	unregisterCommandLocally: defineMutation({
 		mutationKey: ['shortcuts', 'unregisterCommandLocally'] as const,
-		resultMutationFn: async ({ commandId }: { commandId: CommandId }) =>
+		mutationFn: async ({ commandId }: { commandId: CommandId }) =>
 			services.localShortcutManager.unregister(commandId),
 	}),
 
 	registerCommandGlobally: defineMutation({
 		mutationKey: ['shortcuts', 'registerCommandGlobally'] as const,
-		resultMutationFn: ({
+		mutationFn: ({
 			command,
 			// Parameter renamed to indicate it may contain legacy "CommandOrControl" syntax
 			// Legacy format: "CommandOrControl+Shift+R" → Modern format: "Command+Shift+R" (macOS) or "Control+Shift+R" (Windows/Linux)
@@ -57,14 +57,14 @@ export const shortcuts = {
 
 	unregisterCommandGlobally: defineMutation({
 		mutationKey: ['shortcuts', 'unregisterCommandGlobally'] as const,
-		resultMutationFn: async ({ accelerator }: { accelerator: Accelerator }) => {
+		mutationFn: async ({ accelerator }: { accelerator: Accelerator }) => {
 			return await services.globalShortcutManager.unregister(accelerator);
 		},
 	}),
 
 	unregisterAllGlobalShortcuts: defineMutation({
 		mutationKey: ['shortcuts', 'unregisterAllGlobalShortcuts'] as const,
-		resultMutationFn: async () =>
+		mutationFn: async () =>
 			services.globalShortcutManager.unregisterAll(),
 	}),
 };

--- a/apps/whispering/src/lib/query/sound.ts
+++ b/apps/whispering/src/lib/query/sound.ts
@@ -13,7 +13,7 @@ const soundKeys = {
 export const sound = {
 	playSoundIfEnabled: defineMutation({
 		mutationKey: soundKeys.playSoundIfEnabled,
-		resultMutationFn: async (
+		mutationFn: async (
 			soundName: WhisperingSoundNames,
 		): Promise<Result<void, PlaySoundServiceError>> => {
 			if (!settings.value[`sound.playOn.${soundName}`]) {

--- a/apps/whispering/src/lib/query/text.ts
+++ b/apps/whispering/src/lib/query/text.ts
@@ -12,16 +12,16 @@ const textKeys = {
 export const text = {
 	readFromClipboard: defineQuery({
 		queryKey: textKeys.readFromClipboard,
-		resultQueryFn: () => services.text.readFromClipboard(),
+		queryFn: () => services.text.readFromClipboard(),
 	}),
 	copyToClipboard: defineMutation({
 		mutationKey: ['text', 'copyToClipboard'],
-		resultMutationFn: ({ text }: { text: string }) =>
+		mutationFn: ({ text }: { text: string }) =>
 			services.text.copyToClipboard(text),
 	}),
 	writeToCursor: defineMutation({
 		mutationKey: ['text', 'writeToCursor'],
-		resultMutationFn: async ({ text }: { text: string }) => {
+		mutationFn: async ({ text }: { text: string }) => {
 			// writeToCursor handles everything internally:
 			// 1. Saves current clipboard
 			// 2. Writes text to clipboard
@@ -32,6 +32,6 @@ export const text = {
 	}),
 	simulateEnterKeystroke: defineMutation({
 		mutationKey: textKeys.simulateEnterKeystroke,
-		resultMutationFn: () => services.text.simulateEnterKeystroke(),
+		mutationFn: () => services.text.simulateEnterKeystroke(),
 	}),
 };

--- a/apps/whispering/src/lib/query/transcription.ts
+++ b/apps/whispering/src/lib/query/transcription.ts
@@ -22,7 +22,7 @@ export const transcription = {
 	},
 	transcribeRecording: defineMutation({
 		mutationKey: transcriptionKeys.isTranscribing,
-		resultMutationFn: async (
+		mutationFn: async (
 			recording: Recording,
 		): Promise<Result<string, WhisperingError>> => {
 			// Fetch audio blob by ID
@@ -97,7 +97,7 @@ export const transcription = {
 
 	transcribeRecordings: defineMutation({
 		mutationKey: transcriptionKeys.isTranscribing,
-		resultMutationFn: async (recordings: Recording[]) => {
+		mutationFn: async (recordings: Recording[]) => {
 			const results = await Promise.all(
 				recordings.map(async (recording) => {
 					// Fetch audio blob by ID

--- a/apps/whispering/src/lib/query/transformer.ts
+++ b/apps/whispering/src/lib/query/transformer.ts
@@ -31,7 +31,7 @@ const transformerKeys = {
 export const transformer = {
 	transformInput: defineMutation({
 		mutationKey: transformerKeys.transformInput,
-		resultMutationFn: async ({
+		mutationFn: async ({
 			input,
 			transformation,
 		}: {
@@ -87,7 +87,7 @@ export const transformer = {
 
 	transformRecording: defineMutation({
 		mutationKey: transformerKeys.transformRecording,
-		resultMutationFn: async ({
+		mutationFn: async ({
 			recordingId,
 			transformation,
 		}: {

--- a/apps/whispering/src/lib/query/tray.ts
+++ b/apps/whispering/src/lib/query/tray.ts
@@ -11,7 +11,7 @@ const setTrayIconKeys = {
 export const tray = {
 	setTrayIcon: defineMutation({
 		mutationKey: setTrayIconKeys.setTrayIcon,
-		resultMutationFn: async ({
+		mutationFn: async ({
 			icon,
 		}: {
 			icon: WhisperingRecordingState;

--- a/apps/whispering/src/lib/query/vad.svelte.ts
+++ b/apps/whispering/src/lib/query/vad.svelte.ts
@@ -46,7 +46,7 @@ function createVadRecorder() {
 		 */
 		enumerateDevices: defineQuery({
 			queryKey: ['vad', 'devices'],
-			resultQueryFn: async () => {
+			queryFn: async () => {
 				const { data, error } = await enumerateDevices();
 				if (error) {
 					return fromTaggedErr(error, {

--- a/bun.lock
+++ b/bun.lock
@@ -346,7 +346,7 @@
     "turbo": "^2.6.1",
     "typescript": "^5.9.3",
     "vite": "^7.2.4",
-    "wellcrafted": "^0.28.0",
+    "wellcrafted": "^0.29.0",
     "wrangler": "^4.51.0",
     "yargs": "^18.0.0",
   },
@@ -2461,7 +2461,7 @@
 
     "webidl-conversions": ["webidl-conversions@8.0.0", "", {}, "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA=="],
 
-    "wellcrafted": ["wellcrafted@0.28.0", "", {}, "sha512-alZo8qTuQCC7ZWnoXHp2zhD2o0CJzSxm2AizRCc+mjNEEMNNB3f10oCwtzqBxoKU8wDb/LnZ9MtDQTXVa2mbmg=="],
+    "wellcrafted": ["wellcrafted@0.29.0", "", {}, "sha512-A7RveTHJN1yyXBblJjlo4HHE7WTQ2EVi7JyH+uEb0fg8PJp+bv9dJXlnEva9TMhE/1m0ib7WGGuixpuCtNAC7A=="],
 
     "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
 

--- a/docs/articles/accessor-pattern-explained.md
+++ b/docs/articles/accessor-pattern-explained.md
@@ -154,7 +154,7 @@ Here's the actual implementation from our codebase:
 getById: (id: Accessor<string>) =>
   defineQuery({
     queryKey: dbKeys.recordings.byId(id()),
-    resultQueryFn: () => services.db.recordings.getById(id()),
+    queryFn: () => services.db.recordings.getById(id()),
   }),
 ```
 
@@ -229,13 +229,13 @@ runs: {
   getByRecordingId: (recordingId: Accessor<string>) =>
     defineQuery({
       queryKey: dbKeys.runs.byRecordingId(recordingId()),
-      resultQueryFn: () => services.db.runs.getByRecordingId(recordingId()),
+      queryFn: () => services.db.runs.getByRecordingId(recordingId()),
     }),
 
   getLatestByRecordingId: (recordingId: Accessor<string>) =>
     defineQuery({
       queryKey: dbKeys.runs.byRecordingId(recordingId()),
-      resultQueryFn: () => services.db.runs.getByRecordingId(recordingId()),
+      queryFn: () => services.db.runs.getByRecordingId(recordingId()),
       select: (data) => data.at(0),
     }),
 },
@@ -257,7 +257,7 @@ const query = createQuery(
 
 // The query is created with:
 // queryKey: ['db', 'recordings', 'abc']
-// resultQueryFn: () => services.db.recordings.getById('abc')
+// queryFn: () => services.db.recordings.getById('abc')
 ```
 
 Later:
@@ -267,7 +267,7 @@ recordingId = 'xyz';  // Signal updates
 
 // But the query STILL has:
 // queryKey: ['db', 'recordings', 'abc']
-// resultQueryFn: () => services.db.recordings.getById('abc')
+// queryFn: () => services.db.recordings.getById('abc')
 
 // Your UI shows old data from recording 'abc'
 // Even though you wanted recording 'xyz'
@@ -287,7 +287,7 @@ const query = createQuery(
 
 // The query is created with:
 // queryKey: ['db', 'recordings', <result of calling accessor>]
-// resultQueryFn: () => services.db.recordings.getById(<result of calling accessor>)
+// queryFn: () => services.db.recordings.getById(<result of calling accessor>)
 ```
 
 Later:

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 			"drizzle-kit": "^0.31.7",
 			"drizzle-orm": "^0.44.7",
 			"nanoid": "latest",
-			"wellcrafted": "^0.28.0",
+			"wellcrafted": "^0.29.0",
 			"date-fns": "^4.1.0",
 			"@biomejs/biome": "latest",
 			"turbo": "^2.6.1",

--- a/specs/20250118T192845-error-handling-pattern.md
+++ b/specs/20250118T192845-error-handling-pattern.md
@@ -41,7 +41,7 @@ export function createManualRecorderService() {
 // In query/manual-recorder.ts
 getRecorderState: defineQuery({
     queryKey: recorderKeys.state,
-    resultQueryFn: async () => {
+    queryFn: async () => {
         const { data: recorderState, error: getRecorderStateError } =
             await services.manualRecorder.getRecorderState();
         if (getRecorderStateError) {
@@ -89,7 +89,7 @@ if (getRecorderStateError) {
 // BAD: Query layer should wrap errors, not return raw service errors
 getRecorderState: defineQuery({
     queryKey: recorderKeys.state,
-    resultQueryFn: () => services.manualRecorder.getRecorderState(), // Missing error wrapping!
+    queryFn: () => services.manualRecorder.getRecorderState(), // Missing error wrapping!
     initialData: 'IDLE' as WhisperingRecordingState,
 })
 ```

--- a/specs/20250120T012752 ui-overhaul.md
+++ b/specs/20250120T012752 ui-overhaul.md
@@ -174,7 +174,7 @@ import { defineMutation } from './_client';
 
 export const sendMessage = defineMutation({
   mutationKey: ['sendMessage'],
-  resultMutationFn: async ({ 
+  mutationFn: async ({ 
     workspace, 
     sessionId, 
     mode = 'chat',

--- a/specs/20251027T172102 transform-clipboard-command.md
+++ b/specs/20251027T172102 transform-clipboard-command.md
@@ -100,7 +100,7 @@ File: `apps/whispering/src/lib/query/commands.ts`
 ```typescript
 transformClipboard: defineMutation({
   mutationKey: ['commands', 'transformClipboard'],
-  resultMutationFn: async (): Promise<WhisperingResult<void>> => {
+  mutationFn: async (): Promise<WhisperingResult<void>> => {
     // 1. Read clipboard
     const { data: clipboardText, error: readError } =
       await rpc.text.readFromClipboard.execute();

--- a/specs/20251218T194432 query-layer-commands-refactor.md
+++ b/specs/20251218T194432 query-layer-commands-refactor.md
@@ -133,7 +133,7 @@ export const commands = {
   // Push to talk command
   pushToTalk: defineMutation({
     mutationKey: ['commands', 'pushToTalk'] as const,
-    resultMutationFn: async () => {
+    mutationFn: async () => {
       const { data: recorderState, error } = 
         await manualRecorder.getRecorderState.fetch();
       
@@ -156,7 +156,7 @@ export const commands = {
   // Toggle manual recording
   toggleManualRecording: defineMutation({
     mutationKey: ['commands', 'toggleManualRecording'] as const,
-    resultMutationFn: async () => {
+    mutationFn: async () => {
       // Similar implementation to pushToTalk
     },
   }),
@@ -164,7 +164,7 @@ export const commands = {
   // Start manual recording (internal command)
   startManualRecording: defineMutation({
     mutationKey: ['commands', 'startManualRecording'] as const,
-    resultMutationFn: async () => {
+    mutationFn: async () => {
       const toastId = nanoid();
       
       notify.loading.execute({
@@ -194,7 +194,7 @@ export const commands = {
   // Stop manual recording (internal command)
   stopManualRecording: defineMutation({
     mutationKey: ['commands', 'stopManualRecording'] as const,
-    resultMutationFn: async () => {
+    mutationFn: async () => {
       const toastId = nanoid();
       
       // ... implementation
@@ -214,7 +214,7 @@ export const commands = {
   // Cancel manual recording
   cancelManualRecording: defineMutation({
     mutationKey: ['commands', 'cancelManualRecording'] as const,
-    resultMutationFn: async () => {
+    mutationFn: async () => {
       // ... implementation
     },
   }),
@@ -222,7 +222,7 @@ export const commands = {
   // Toggle VAD recording
   toggleVadRecording: defineMutation({
     mutationKey: ['commands', 'toggleVadRecording'] as const,
-    resultMutationFn: async () => {
+    mutationFn: async () => {
       // ... implementation
     },
   }),
@@ -231,14 +231,14 @@ export const commands = {
   ...(window.__TAURI_INTERNALS__ ? {
     toggleCpalRecording: defineMutation({
       mutationKey: ['commands', 'toggleCpalRecording'] as const,
-      resultMutationFn: async () => {
+      mutationFn: async () => {
         // ... implementation
       },
     }),
     
     cancelCpalRecording: defineMutation({
       mutationKey: ['commands', 'cancelCpalRecording'] as const,
-      resultMutationFn: async () => {
+      mutationFn: async () => {
         // ... implementation
       },
     }),
@@ -340,7 +340,7 @@ The `uploadRecording` mutation in `recordings.ts` should also use the shared `pr
 ```typescript
 uploadRecording: defineMutation({
   mutationKey: ['recordings', 'uploadRecording'] as const,
-  resultMutationFn: async ({ file }: { file: File }) => {
+  mutationFn: async ({ file }: { file: File }) => {
     // Validate file type
     if (!file.type.startsWith('audio/')) {
       return DbServiceErr({

--- a/specs/20251219T120345 bulk-file-upload.md
+++ b/specs/20251219T120345 bulk-file-upload.md
@@ -71,7 +71,7 @@ This plan outlines how to add support for uploading multiple audio/video files a
 ```typescript
 uploadMultipleRecordings: defineMutation({
   mutationKey: ['recordings', 'uploadMultiple'] as const,
-  resultMutationFn: async ({ files }: { files: File[] }) => {
+  mutationFn: async ({ files }: { files: File[] }) => {
     const results = [];
     
     for (const file of files) {


### PR DESCRIPTION
This migrates the codebase to wellcrafted v0.29.0's renamed API, replacing the Hungarian notation prefixes with cleaner names.

The `result` prefix was encoding type information that TypeScript already captures in the type signature, making it redundant. This change aligns with wellcrafted v0.29.0's API where:
- `resultQueryFn` becomes `queryFn`
- `resultMutationFn` becomes `mutationFn`

Updated all 15 query layer files, documentation, specs, and agent configuration to use the new naming. Also bumped the wellcrafted catalog dependency from ^0.28.0 to ^0.29.0.