### PR TITLE
fix: use extractErrorMessage for unused error params in catch handlers

### DIFF
--- a/apps/whispering/src/lib/services/db/file-system.ts
+++ b/apps/whispering/src/lib/services/db/file-system.ts
@@ -10,6 +10,7 @@ import {
 import { type } from 'arktype';
 import matter from 'gray-matter';
 import mime from 'mime';
+import { extractErrorMessage } from 'wellcrafted/error';
 import { Ok, tryAsync } from 'wellcrafted/result';
 import { PATHS } from '$lib/constants/paths';
 import * as services from '$lib/services';
@@ -139,7 +140,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error getting all recordings from file system',
+							message: `Error getting all recordings from file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -155,7 +156,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error getting latest recording from file system',
+							message: `Error getting latest recording from file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -172,8 +173,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message:
-								'Error getting transcribing recording ids from file system',
+							message: `Error getting transcribing recording ids from file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -202,7 +202,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error getting recording by id from file system',
+							message: `Error getting recording by id from file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -248,7 +248,7 @@ export function createFileSystemDb(): DbService {
 						},
 						catch: (error) =>
 							DbServiceErr({
-								message: 'Error bulk creating recordings in file system',
+								message: `Error bulk creating recordings in file system: ${extractErrorMessage(error)}`,
 							}),
 					});
 
@@ -257,7 +257,7 @@ export function createFileSystemDb(): DbService {
 					try: () => createSingleRecording(params),
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error creating recording in file system',
+							message: `Error creating recording in file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -297,7 +297,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error updating recording in file system',
+							message: `Error updating recording in file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -331,7 +331,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error deleting recordings from file system',
+							message: `Error deleting recordings from file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -356,7 +356,7 @@ export function createFileSystemDb(): DbService {
 							},
 							catch: (error) =>
 								DbServiceErr({
-									message: 'Error cleaning up expired recordings',
+									message: `Error cleaning up expired recordings: ${extractErrorMessage(error)}`,
 								}),
 						});
 					}
@@ -386,7 +386,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error getting audio blob from file system',
+							message: `Error getting audio blob from file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -412,7 +412,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error getting audio playback URL from file system',
+							message: `Error getting audio playback URL from file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -439,7 +439,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error clearing recordings from file system',
+							message: `Error clearing recordings from file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -455,7 +455,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error getting recordings count from file system',
+							message: `Error getting recordings count from file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -497,7 +497,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error getting all transformations from file system',
+							message: `Error getting all transformations from file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -524,7 +524,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error getting transformation by id from file system',
+							message: `Error getting transformation by id from file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -553,7 +553,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error creating transformation in file system',
+							message: `Error creating transformation in file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -585,7 +585,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error updating transformation in file system',
+							message: `Error updating transformation in file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -611,7 +611,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error deleting transformations from file system',
+							message: `Error deleting transformations from file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -628,7 +628,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error clearing transformations from file system',
+							message: `Error clearing transformations from file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -642,7 +642,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error getting transformations count from file system',
+							message: `Error getting transformations count from file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -683,7 +683,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error getting all transformation runs from file system',
+							message: `Error getting all transformation runs from file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -712,8 +712,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message:
-								'Error getting transformation run by id from file system',
+							message: `Error getting transformation run by id from file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -762,8 +761,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message:
-								'Error getting transformation runs by transformation id from file system',
+							message: `Error getting transformation runs by transformation id from file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -812,8 +810,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message:
-								'Error getting transformation runs by recording id from file system',
+							message: `Error getting transformation runs by recording id from file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -841,8 +838,7 @@ export function createFileSystemDb(): DbService {
 						},
 						catch: (error) =>
 							DbServiceErr({
-								message:
-									'Error bulk creating transformation runs in file system',
+								message: `Error bulk creating transformation runs in file system: ${extractErrorMessage(error)}`,
 							}),
 					});
 				}
@@ -882,7 +878,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error creating transformation run in file system',
+							message: `Error creating transformation run in file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -921,7 +917,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error adding step to transformation run in file system',
+							message: `Error adding step to transformation run in file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -962,10 +958,9 @@ export function createFileSystemDb(): DbService {
 
 						return failedRun;
 					},
-					catch: (error) =>
+					catch: (e) =>
 						DbServiceErr({
-							message:
-								'Error failing step in transformation run in file system',
+							message: `Error failing step in transformation run in file system: ${extractErrorMessage(e)}`,
 						}),
 				});
 			},
@@ -1005,8 +1000,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message:
-								'Error completing step in transformation run in file system',
+							message: `Error completing step in transformation run in file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -1038,7 +1032,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error completing transformation run in file system',
+							message: `Error completing transformation run in file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -1059,7 +1053,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error deleting transformation runs from file system',
+							message: `Error deleting transformation runs from file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -1076,7 +1070,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error clearing transformation runs from file system',
+							message: `Error clearing transformation runs from file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -1090,8 +1084,7 @@ export function createFileSystemDb(): DbService {
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message:
-								'Error getting transformation runs count from file system',
+							message: `Error getting transformation runs count from file system: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},

--- a/apps/whispering/src/lib/services/db/web.ts
+++ b/apps/whispering/src/lib/services/db/web.ts
@@ -401,7 +401,7 @@ export function createDbServiceWeb({
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error getting all recordings from Dexie',
+							message: `Error getting all recordings from Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -420,7 +420,7 @@ export function createDbServiceWeb({
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error getting latest recording from Dexie',
+							message: `Error getting latest recording from Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -434,7 +434,7 @@ export function createDbServiceWeb({
 							.primaryKeys(),
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error getting transcribing recording ids from Dexie',
+							message: `Error getting transcribing recording ids from Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -450,7 +450,7 @@ export function createDbServiceWeb({
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error getting recording by id from Dexie',
+							message: `Error getting recording by id from Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -473,7 +473,7 @@ export function createDbServiceWeb({
 						},
 						catch: (error) =>
 							DbServiceErr({
-								message: 'Error bulk adding recordings to Dexie',
+								message: `Error bulk adding recordings to Dexie: ${extractErrorMessage(error)}`,
 							}),
 					});
 					if (bulkCreateError) return Err(bulkCreateError);
@@ -498,7 +498,7 @@ export function createDbServiceWeb({
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error adding recording to Dexie',
+							message: `Error adding recording to Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 				if (createRecordingError) return Err(createRecordingError);
@@ -528,7 +528,7 @@ export function createDbServiceWeb({
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error updating recording in Dexie',
+							message: `Error updating recording in Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 				if (updateRecordingError) return Err(updateRecordingError);
@@ -544,7 +544,7 @@ export function createDbServiceWeb({
 					try: () => db.recordings.bulkDelete(ids),
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error deleting recordings from Dexie',
+							message: `Error deleting recordings from Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 				if (deleteRecordingsError) return Err(deleteRecordingsError);
@@ -574,8 +574,7 @@ export function createDbServiceWeb({
 							try: () => db.recordings.count(),
 							catch: (error) =>
 								DbServiceErr({
-									message:
-										'Unable to get recording count while cleaning up old recordings',
+									message: `Unable to get recording count while cleaning up old recordings: ${extractErrorMessage(error)}`,
 								}),
 						});
 						if (countError) return Err(countError);
@@ -595,7 +594,7 @@ export function createDbServiceWeb({
 							},
 							catch: (error) =>
 								DbServiceErr({
-									message: 'Unable to clean up old recordings',
+									message: `Unable to clean up old recordings: ${extractErrorMessage(error)}`,
 								}),
 						});
 					}
@@ -622,7 +621,7 @@ export function createDbServiceWeb({
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error getting audio blob from IndexedDB',
+							message: `Error getting audio blob from IndexedDB: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -657,7 +656,7 @@ export function createDbServiceWeb({
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error ensuring audio playback URL from IndexedDB',
+							message: `Error ensuring audio playback URL from IndexedDB: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -675,7 +674,7 @@ export function createDbServiceWeb({
 					try: () => db.recordings.clear(),
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error clearing recordings from Dexie',
+							message: `Error clearing recordings from Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -685,7 +684,7 @@ export function createDbServiceWeb({
 					try: () => db.recordings.count(),
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error getting recordings count from Dexie',
+							message: `Error getting recordings count from Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -697,7 +696,7 @@ export function createDbServiceWeb({
 					try: () => db.transformations.toArray(),
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error getting all transformations from Dexie',
+							message: `Error getting all transformations from Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -711,7 +710,7 @@ export function createDbServiceWeb({
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error getting transformation by id from Dexie',
+							message: `Error getting transformation by id from Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -723,7 +722,7 @@ export function createDbServiceWeb({
 						try: () => db.transformations.bulkAdd(transformation),
 						catch: (error) =>
 							DbServiceErr({
-								message: 'Error bulk adding transformations to Dexie',
+								message: `Error bulk adding transformations to Dexie: ${extractErrorMessage(error)}`,
 							}),
 					});
 					if (bulkCreateError) return Err(bulkCreateError);
@@ -735,7 +734,7 @@ export function createDbServiceWeb({
 					try: () => db.transformations.add(transformation),
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error adding transformation to Dexie',
+							message: `Error adding transformation to Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 				if (createTransformationError) return Err(createTransformationError);
@@ -752,7 +751,7 @@ export function createDbServiceWeb({
 					try: () => db.transformations.put(transformationWithTimestamp),
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error updating transformation in Dexie',
+							message: `Error updating transformation in Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 				if (updateTransformationError) return Err(updateTransformationError);
@@ -768,7 +767,7 @@ export function createDbServiceWeb({
 					try: () => db.transformations.bulkDelete(ids),
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error deleting transformations from Dexie',
+							message: `Error deleting transformations from Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 				if (deleteTransformationsError) return Err(deleteTransformationsError);
@@ -780,7 +779,7 @@ export function createDbServiceWeb({
 					try: () => db.transformations.clear(),
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error clearing transformations from Dexie',
+							message: `Error clearing transformations from Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -790,7 +789,7 @@ export function createDbServiceWeb({
 					try: () => db.transformations.count(),
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error getting transformations count from Dexie',
+							message: `Error getting transformations count from Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -805,7 +804,7 @@ export function createDbServiceWeb({
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error getting all transformation runs from Dexie',
+							message: `Error getting all transformation runs from Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -818,7 +817,7 @@ export function createDbServiceWeb({
 					try: () => db.transformationRuns.where('id').equals(id).first(),
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error getting transformation run by id from Dexie',
+							message: `Error getting transformation run by id from Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 				if (getTransformationRunByIdError)
@@ -845,8 +844,7 @@ export function createDbServiceWeb({
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message:
-								'Error getting transformation runs by transformation id from Dexie',
+							message: `Error getting transformation runs by transformation id from Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -869,8 +867,7 @@ export function createDbServiceWeb({
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message:
-								'Error getting transformation runs by recording id from Dexie',
+							message: `Error getting transformation runs by recording id from Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -885,7 +882,7 @@ export function createDbServiceWeb({
 						try: () => db.transformationRuns.bulkAdd(runs),
 						catch: (error) =>
 							DbServiceErr({
-								message: 'Error bulk adding transformation runs to Dexie',
+								message: `Error bulk adding transformation runs to Dexie: ${extractErrorMessage(error)}`,
 							}),
 					});
 					if (bulkCreateError) return Err(bulkCreateError);
@@ -908,7 +905,7 @@ export function createDbServiceWeb({
 					try: () => db.transformationRuns.add(transformationRunWithTimestamps),
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error adding transformation run to Dexie',
+							message: `Error adding transformation run to Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 				if (createTransformationRunError)
@@ -936,7 +933,7 @@ export function createDbServiceWeb({
 					try: () => db.transformationRuns.put(updatedRun),
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error adding step run to transformation run in Dexie',
+							message: `Error adding step run to transformation run in Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 				if (addStepRunToTransformationRunError)
@@ -972,7 +969,7 @@ export function createDbServiceWeb({
 					try: () => db.transformationRuns.put(failedRun),
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error updating transformation run as failed in Dexie',
+							message: `Error updating transformation run as failed in Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 				if (updateTransformationStepRunError)
@@ -1005,7 +1002,7 @@ export function createDbServiceWeb({
 					try: () => db.transformationRuns.put(updatedRun),
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error updating transformation step run status in Dexie',
+							message: `Error updating transformation step run status in Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 				if (updateTransformationStepRunError)
@@ -1029,8 +1026,7 @@ export function createDbServiceWeb({
 					try: () => db.transformationRuns.put(completedRun),
 					catch: (error) =>
 						DbServiceErr({
-							message:
-								'Error updating transformation run as completed in Dexie',
+							message: `Error updating transformation run as completed in Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 				if (updateTransformationStepRunError)
@@ -1050,7 +1046,7 @@ export function createDbServiceWeb({
 					},
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error deleting transformation runs from Dexie',
+							message: `Error deleting transformation runs from Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -1060,7 +1056,7 @@ export function createDbServiceWeb({
 					try: () => db.transformationRuns.clear(),
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error clearing transformation runs from Dexie',
+							message: `Error clearing transformation runs from Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},
@@ -1070,7 +1066,7 @@ export function createDbServiceWeb({
 					try: () => db.transformationRuns.count(),
 					catch: (error) =>
 						DbServiceErr({
-							message: 'Error getting transformation runs count from Dexie',
+							message: `Error getting transformation runs count from Dexie: ${extractErrorMessage(error)}`,
 						}),
 				});
 			},

--- a/apps/whispering/src/lib/services/ffmpeg/desktop.ts
+++ b/apps/whispering/src/lib/services/ffmpeg/desktop.ts
@@ -59,7 +59,7 @@ export function createFfmpegService(): FfmpegService {
 							try: () => services.fs.pathToBlob(inputPath),
 							catch: (error) =>
 								FfmpegServiceErr({
-									message: 'Temp file not accessible',
+									message: `Temp file not accessible: ${extractErrorMessage(error)}`,
 								}),
 						});
 						if (verifyError) throw new Error(verifyError.message);

--- a/apps/whispering/src/lib/services/fs/desktop.ts
+++ b/apps/whispering/src/lib/services/fs/desktop.ts
@@ -1,6 +1,7 @@
 import { basename } from '@tauri-apps/api/path';
 import { readFile } from '@tauri-apps/plugin-fs';
 import mime from 'mime';
+import { extractErrorMessage } from 'wellcrafted/error';
 import { tryAsync } from 'wellcrafted/result';
 import type { FsService } from './types';
 import { FsServiceErr } from './types';
@@ -21,7 +22,7 @@ export function createFsServiceDesktop(): FsService {
 				},
 				catch: (error) =>
 					FsServiceErr({
-						message: `Failed to read file as Blob: ${path}`,
+						message: `Failed to read file as Blob: ${path}: ${extractErrorMessage(error)}`,
 					}),
 			});
 		},
@@ -36,7 +37,7 @@ export function createFsServiceDesktop(): FsService {
 				},
 				catch: (error) =>
 					FsServiceErr({
-						message: `Failed to read file as File: ${path}`,
+						message: `Failed to read file as File: ${path}: ${extractErrorMessage(error)}`,
 					}),
 			});
 		},
@@ -56,7 +57,7 @@ export function createFsServiceDesktop(): FsService {
 				},
 				catch: (error) =>
 					FsServiceErr({
-						message: `Failed to read files: ${paths.join(', ')}`,
+						message: `Failed to read files: ${paths.join(', ')}: ${extractErrorMessage(error)}`,
 					}),
 			});
 		},

--- a/apps/whispering/src/lib/services/http/desktop.ts
+++ b/apps/whispering/src/lib/services/http/desktop.ts
@@ -17,7 +17,7 @@ export function createHttpServiceDesktop(): HttpService {
 					}),
 				catch: (error) =>
 					ConnectionErr({
-						message: 'Failed to establish connection',
+						message: `Failed to establish connection: ${extractErrorMessage(error)}`,
 					}),
 			});
 			if (responseError) return Err(responseError);
@@ -42,7 +42,7 @@ export function createHttpServiceDesktop(): HttpService {
 				},
 				catch: (error) =>
 					ParseErr({
-						message: 'Failed to parse response',
+						message: `Failed to parse response: ${extractErrorMessage(error)}`,
 					}),
 			});
 			return parseResult;

--- a/apps/whispering/src/lib/services/http/web.ts
+++ b/apps/whispering/src/lib/services/http/web.ts
@@ -16,7 +16,7 @@ export function createHttpServiceWeb(): HttpService {
 					}),
 				catch: (error) =>
 					ConnectionErr({
-						message: 'Failed to establish connection',
+						message: `Failed to establish connection: ${extractErrorMessage(error)}`,
 					}),
 			});
 			if (responseError) return Err(responseError);
@@ -41,7 +41,7 @@ export function createHttpServiceWeb(): HttpService {
 				},
 				catch: (error) =>
 					ParseErr({
-						message: 'Failed to parse response',
+						message: `Failed to parse response: ${extractErrorMessage(error)}`,
 					}),
 			});
 			return parseResult;

--- a/apps/whispering/src/lib/services/notifications/desktop.ts
+++ b/apps/whispering/src/lib/services/notifications/desktop.ts
@@ -6,6 +6,7 @@ import {
 	sendNotification,
 } from '@tauri-apps/plugin-notification';
 import { nanoid } from 'nanoid/non-secure';
+import { extractErrorMessage } from 'wellcrafted/error';
 import { Err, Ok, type Result, tryAsync } from 'wellcrafted/result';
 import type { NotificationService, UnifiedNotificationOptions } from './types';
 import {
@@ -37,7 +38,7 @@ export function createNotificationServiceDesktop(): NotificationService {
 				try: async () => await active(),
 				catch: (error) =>
 					NotificationServiceErr({
-						message: 'Unable to retrieve active desktop notifications.',
+						message: `Unable to retrieve active desktop notifications: ${extractErrorMessage(error)}`,
 					}),
 			});
 		if (activeNotificationsError) return Err(activeNotificationsError);
@@ -49,7 +50,7 @@ export function createNotificationServiceDesktop(): NotificationService {
 				try: async () => await removeActive([matchingActiveNotification]),
 				catch: (error) =>
 					NotificationServiceErr({
-						message: `Unable to remove notification with id ${id}.`,
+						message: `Unable to remove notification with id ${id}: ${extractErrorMessage(error)}`,
 					}),
 			});
 			if (removeActiveError) return Err(removeActiveError);
@@ -89,7 +90,7 @@ export function createNotificationServiceDesktop(): NotificationService {
 				},
 				catch: (error) =>
 					NotificationServiceErr({
-						message: 'Could not send notification',
+						message: `Could not send notification: ${extractErrorMessage(error)}`,
 					}),
 			});
 			if (notifyError) return Err(notifyError);

--- a/apps/whispering/src/lib/services/notifications/web.ts
+++ b/apps/whispering/src/lib/services/notifications/web.ts
@@ -1,4 +1,5 @@
 import { nanoid } from 'nanoid/non-secure';
+import { extractErrorMessage } from 'wellcrafted/error';
 import { Err, Ok, tryAsync } from 'wellcrafted/result';
 import type { NotificationService, UnifiedNotificationOptions } from './types';
 import { NotificationServiceErr, toBrowserNotification } from './types';
@@ -97,7 +98,7 @@ export function createNotificationServiceWeb(): NotificationService {
 				},
 				catch: (error) =>
 					NotificationServiceErr({
-						message: 'Failed to send browser notification',
+						message: `Failed to send browser notification: ${extractErrorMessage(error)}`,
 					}),
 			});
 

--- a/apps/whispering/src/lib/services/recorder/cpal.ts
+++ b/apps/whispering/src/lib/services/recorder/cpal.ts
@@ -1,5 +1,6 @@
 import { invoke as tauriInvoke } from '@tauri-apps/api/core';
 import { readFile, remove } from '@tauri-apps/plugin-fs';
+import { extractErrorMessage } from 'wellcrafted/error';
 import { Err, Ok, type Result, tryAsync } from 'wellcrafted/result';
 import type {
 	CancelRecordingResult,
@@ -242,7 +243,7 @@ export function createCpalRecorderService(): RecorderService {
 				},
 				catch: (error) =>
 					RecorderServiceErr({
-						message: 'Unable to read recording file. Please try again.',
+						message: `Unable to read recording file. Please try again: ${extractErrorMessage(error)}`,
 					}),
 			});
 			if (readRecordingFileError) return Err(readRecordingFileError);
@@ -306,7 +307,7 @@ export function createCpalRecorderService(): RecorderService {
 					try: () => remove(filePath),
 					catch: (error) =>
 						RecorderServiceErr({
-							message: 'Failed to delete recording file.',
+							message: `Failed to delete recording file: ${extractErrorMessage(error)}`,
 						}),
 				});
 				if (removeError)

--- a/apps/whispering/src/lib/services/recorder/ffmpeg.ts
+++ b/apps/whispering/src/lib/services/recorder/ffmpeg.ts
@@ -517,7 +517,7 @@ export function createFfmpegRecorderService(): RecorderService {
 					},
 					catch: (error) =>
 						RecorderServiceErr({
-							message: 'Failed to delete recording file',
+							message: `Failed to delete recording file: ${extractErrorMessage(error)}`,
 						}),
 				});
 

--- a/apps/whispering/src/lib/services/sound/desktop.ts
+++ b/apps/whispering/src/lib/services/sound/desktop.ts
@@ -1,3 +1,4 @@
+import { extractErrorMessage } from 'wellcrafted/error';
 import { tryAsync } from 'wellcrafted/result';
 import type { PlaySoundService } from '.';
 import { audioElements } from './assets';
@@ -12,7 +13,7 @@ export function createPlaySoundServiceDesktop(): PlaySoundService {
 				},
 				catch: (error) =>
 					PlaySoundServiceErr({
-						message: 'Failed to play sound',
+						message: `Failed to play sound: ${extractErrorMessage(error)}`,
 					}),
 			}),
 	};

--- a/apps/whispering/src/lib/services/text/extension.ts
+++ b/apps/whispering/src/lib/services/text/extension.ts
@@ -1,3 +1,4 @@
+import { extractErrorMessage } from 'wellcrafted/error';
 import { tryAsync } from 'wellcrafted/result';
 import { type TextService, TextServiceErr } from './types';
 
@@ -11,7 +12,7 @@ export function createTextServiceExtension(): TextService {
 				},
 				catch: (error) =>
 					TextServiceErr({
-						message: 'Unable to read from clipboard',
+						message: `Unable to read from clipboard: ${extractErrorMessage(error)}`,
 					}),
 			}),
 
@@ -20,7 +21,7 @@ export function createTextServiceExtension(): TextService {
 				try: () => navigator.clipboard.writeText(text),
 				catch: (error) =>
 					TextServiceErr({
-						message: 'Unable to copy to clipboard',
+						message: `Unable to copy to clipboard: ${extractErrorMessage(error)}`,
 					}),
 			}),
 
@@ -33,7 +34,7 @@ export function createTextServiceExtension(): TextService {
 				},
 				catch: (error) =>
 					TextServiceErr({
-						message: 'Unable to write text at cursor position',
+						message: `Unable to write text at cursor position: ${extractErrorMessage(error)}`,
 					}),
 			}),
 

--- a/apps/whispering/src/lib/services/tray.ts
+++ b/apps/whispering/src/lib/services/tray.ts
@@ -3,7 +3,7 @@ import { resolveResource } from '@tauri-apps/api/path';
 import { TrayIcon } from '@tauri-apps/api/tray';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { exit } from '@tauri-apps/plugin-process';
-import { createTaggedError } from 'wellcrafted/error';
+import { createTaggedError, extractErrorMessage } from 'wellcrafted/error';
 // import { commandCallbacks } from '$lib/commands';
 import { type Err, Ok, tryAsync } from 'wellcrafted/result';
 import { goto } from '$app/navigation';
@@ -52,7 +52,7 @@ export function createTrayIconDesktopService(): SetTrayIconService {
 				},
 				catch: (error) =>
 					SetTrayIconServiceErr({
-						message: 'Failed to set tray icon',
+						message: `Failed to set tray icon: ${extractErrorMessage(error)}`,
 					}),
 			}),
 	};


### PR DESCRIPTION
This addresses TypeScript errors where error parameters in catch handlers were declared but never used. Rather than removing the parameters or prefixing with underscore, these errors are now properly utilized by passing them through `extractErrorMessage()` to provide more informative error messages.

The pattern applied consistently across all affected files:

```typescript
// Before
catch: (error) =>
  ServiceErr({
    message: 'Something failed',
  }),

// After  
catch: (error) =>
  ServiceErr({
    message: `Something failed: ${extractErrorMessage(error)}`,
  }),
```

This improves debugging by including the original error context in the error messages shown to users, while also satisfying the TypeScript compiler's unused variable checks.