### PR TITLE
refactor(query): migrate to accessor pattern for wellcrafted v0.26.0

### DIFF
--- a/apps/whispering/src/lib/components/TransformationPickerBody.svelte
+++ b/apps/whispering/src/lib/components/TransformationPickerBody.svelte
@@ -10,7 +10,7 @@
 	import { onMount } from 'svelte';
 
 	const transformationsQuery = createQuery(
-		rpc.db.transformations.getAll.options,
+		() => rpc.db.transformations.getAll.options,
 	);
 
 	const transformations = $derived(transformationsQuery.data ?? []);

--- a/apps/whispering/src/lib/components/settings/CompressionBody.svelte
+++ b/apps/whispering/src/lib/components/settings/CompressionBody.svelte
@@ -61,7 +61,7 @@
 	}
 
 	// Check if FFmpeg is installed
-	const ffmpegQuery = createQuery(rpc.ffmpeg.checkFfmpegInstalled.options);
+	const ffmpegQuery = createQuery(() => rpc.ffmpeg.checkFfmpegInstalled.options);
 
 	const isFfmpegInstalled = $derived(ffmpegQuery.data ?? false);
 	const isFfmpegCheckLoading = $derived(ffmpegQuery.isPending);

--- a/apps/whispering/src/lib/components/settings/selectors/ManualDeviceSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/ManualDeviceSelector.svelte
@@ -47,7 +47,7 @@
 	} as const;
 
 	const getDevicesQuery = createQuery(() => ({
-		...rpc.recorder.enumerateDevices.options(),
+		...rpc.recorder.enumerateDevices.options,
 		enabled: combobox.open,
 	}));
 

--- a/apps/whispering/src/lib/components/settings/selectors/TransformationSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/TransformationSelector.svelte
@@ -17,7 +17,7 @@
 	import LayersIcon from '@lucide/svelte/icons/layers';
 
 	const transformationsQuery = createQuery(
-		rpc.db.transformations.getAll.options,
+		() => rpc.db.transformations.getAll.options,
 	);
 
 	const transformations = $derived(transformationsQuery.data ?? []);

--- a/apps/whispering/src/lib/components/settings/selectors/VadDeviceSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/VadDeviceSelector.svelte
@@ -23,7 +23,7 @@
 	const isDeviceSelected = $derived(!!selectedDeviceId);
 
 	const getDevicesQuery = createQuery(() => ({
-		...vadRecorder.enumerateDevices.options(),
+		...vadRecorder.enumerateDevices.options,
 		enabled: combobox.open,
 	}));
 

--- a/apps/whispering/src/lib/components/transformations-editor/Editor.svelte
+++ b/apps/whispering/src/lib/components/transformations-editor/Editor.svelte
@@ -11,7 +11,7 @@
 		$props();
 
 	const transformationRunsByTransformationIdQuery = createQuery(
-		rpc.db.runs.getByTransformationId(() => transformation.id).options,
+		() => rpc.db.runs.getByTransformationId(() => transformation.id).options,
 	);
 </script>
 

--- a/apps/whispering/src/lib/components/transformations-editor/Runs.svelte
+++ b/apps/whispering/src/lib/components/transformations-editor/Runs.svelte
@@ -22,7 +22,7 @@
 
 	let expandedRunId = $state<string | null>(null);
 
-	const deleteRunMutation = createMutation(rpc.db.runs.delete.options);
+	const deleteRunMutation = createMutation(() => rpc.db.runs.delete.options);
 
 	function toggleRunExpanded(runId: string) {
 		expandedRunId = expandedRunId === runId ? null : runId;

--- a/apps/whispering/src/lib/components/transformations-editor/Test.svelte
+++ b/apps/whispering/src/lib/components/transformations-editor/Test.svelte
@@ -10,7 +10,7 @@
 	import { Spinner } from '@epicenter/ui/spinner';
 	import PlayIcon from '@lucide/svelte/icons/play';
 
-	const transformInput = createMutation(rpc.transformer.transformInput.options);
+	const transformInput = createMutation(() => rpc.transformer.transformInput.options);
 
 	let { transformation }: { transformation: Transformation } = $props();
 

--- a/apps/whispering/src/lib/query/vad.svelte.ts
+++ b/apps/whispering/src/lib/query/vad.svelte.ts
@@ -21,7 +21,7 @@ import { defineQuery } from './_client';
  * - Access state reactively: `vadRecorder.state` (triggers effects when changed)
  * - Start listening: `await vadRecorder.startActiveListening({ onSpeechStart, onSpeechEnd })`
  * - Stop listening: `await vadRecorder.stopActiveListening()`
- * - Enumerate devices: `createQuery(vadRecorder.enumerateDevices.options)`
+ * - Enumerate devices: `createQuery(() => vadRecorder.enumerateDevices.options)`
  */
 function createVadRecorder() {
 	// Private state
@@ -42,7 +42,7 @@ function createVadRecorder() {
 		 * Enumerate available audio input devices.
 		 *
 		 * Usage:
-		 * - With createQuery: `createQuery(vadRecorder.enumerateDevices.options)`
+		 * - With createQuery: `createQuery(() => vadRecorder.enumerateDevices.options)`
 		 */
 		enumerateDevices: defineQuery({
 			queryKey: ['vad', 'devices'],

--- a/apps/whispering/src/routes/(app)/(config)/+layout.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/+layout.svelte
@@ -22,7 +22,7 @@
 	import { MediaQuery } from 'svelte/reactivity';
 
 	const getRecorderStateQuery = createQuery(
-		rpc.recorder.getRecorderState.options,
+		() => rpc.recorder.getRecorderState.options,
 	);
 
 	let { children } = $props();

--- a/apps/whispering/src/routes/(app)/(config)/install-ffmpeg/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/install-ffmpeg/+page.svelte
@@ -22,7 +22,7 @@
 	const platform = services.os.type();
 
 	const ffmpegQuery = createQuery(() => ({
-		...rpc.ffmpeg.checkFfmpegInstalled.options(),
+		...rpc.ffmpeg.checkFfmpegInstalled.options,
 		refetchInterval: (query) => {
 			const isInstalled = query.state.data;
 			return isInstalled ? 30000 : 5000;

--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -76,11 +76,11 @@
 		};
 	}
 
-	const getAllRecordingsQuery = createQuery(rpc.db.recordings.getAll.options);
+	const getAllRecordingsQuery = createQuery(() => rpc.db.recordings.getAll.options);
 	const transcribeRecordings = createMutation(
-		rpc.transcription.transcribeRecordings.options,
+		() => rpc.transcription.transcribeRecordings.options,
 	);
-	const deleteRecordings = createMutation(rpc.db.recordings.delete.options);
+	const deleteRecordings = createMutation(() => rpc.db.recordings.delete.options);
 
 	const DATE_FORMAT = 'PP p'; // e.g., Aug 13, 2025, 10:00 AM
 

--- a/apps/whispering/src/routes/(app)/(config)/recordings/LatestTransformationRunOutputByRecordingId.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/LatestTransformationRunOutputByRecordingId.svelte
@@ -12,7 +12,7 @@
 	} = $props();
 
 	const latestTransformationRunByRecordingIdQuery = createQuery(
-		rpc.db.runs.getLatestByRecordingId(() => recordingId).options,
+		() => rpc.db.runs.getLatestByRecordingId(() => recordingId).options,
 	);
 
 	const id = getRecordingTransitionId({

--- a/apps/whispering/src/routes/(app)/(config)/recordings/RenderAudioUrl.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/RenderAudioUrl.svelte
@@ -8,7 +8,7 @@
 	let { id }: { id: string } = $props();
 
 	const audioUrlQuery = createQuery(
-		rpc.db.recordings.getAudioPlaybackUrl(() => id).options,
+		() => rpc.db.recordings.getAudioPlaybackUrl(() => id).options,
 	);
 
 	onDestroy(() => {

--- a/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/EditRecordingModal.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/EditRecordingModal.svelte
@@ -13,9 +13,9 @@
 	import { Spinner } from '@epicenter/ui/spinner';
 	import { onDestroy } from 'svelte';
 
-	const updateRecording = createMutation(rpc.db.recordings.update.options);
+	const updateRecording = createMutation(() => rpc.db.recordings.update.options);
 
-	const deleteRecording = createMutation(rpc.db.recordings.delete.options);
+	const deleteRecording = createMutation(() => rpc.db.recordings.delete.options);
 
 	let { recording }: { recording: Recording } = $props();
 
@@ -69,7 +69,7 @@
 	 * Uses accessor pattern for reactive updates.
 	 */
 	const audioPlaybackUrlQuery = createQuery(
-		rpc.db.recordings.getAudioPlaybackUrl(() => recording.id).options,
+		() => rpc.db.recordings.getAudioPlaybackUrl(() => recording.id).options,
 	);
 
 	const audioUrl = $derived(audioPlaybackUrlQuery.data);

--- a/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/RecordingRowActions.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/RecordingRowActions.svelte
@@ -22,23 +22,23 @@
 	import { nanoid } from 'nanoid/non-secure';
 
 	const transcribeRecording = createMutation(
-		rpc.transcription.transcribeRecording.options,
+		() => rpc.transcription.transcribeRecording.options,
 	);
 
-	const deleteRecording = createMutation(rpc.db.recordings.delete.options);
+	const deleteRecording = createMutation(() => rpc.db.recordings.delete.options);
 
 	const downloadRecording = createMutation(
-		rpc.download.downloadRecording.options,
+		() => rpc.download.downloadRecording.options,
 	);
 
 	let { recordingId }: { recordingId: string } = $props();
 
 	const latestTransformationRunByRecordingIdQuery = createQuery(
-		rpc.db.runs.getLatestByRecordingId(() => recordingId).options,
+		() => rpc.db.runs.getLatestByRecordingId(() => recordingId).options,
 	);
 
 	const recordingQuery = createQuery(
-		rpc.db.recordings.getById(() => recordingId).options,
+		() => rpc.db.recordings.getById(() => recordingId).options,
 	);
 
 	const recording = $derived(recordingQuery.data);

--- a/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/TransformationPicker.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/TransformationPicker.svelte
@@ -12,7 +12,7 @@
 	const combobox = useCombobox();
 
 	const transformRecording = createMutation(
-		rpc.transformer.transformRecording.options,
+		() => rpc.transformer.transformRecording.options,
 	);
 
 	let { recordingId }: { recordingId: string } = $props();

--- a/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/ViewTransformationRunsDialog.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/ViewTransformationRunsDialog.svelte
@@ -9,7 +9,7 @@
 	let { recordingId }: { recordingId: string } = $props();
 
 	const transformationRunsByRecordingIdQuery = createQuery(
-		rpc.db.runs.getByRecordingId(() => recordingId).options,
+		() => rpc.db.runs.getByRecordingId(() => recordingId).options,
 	);
 
 	let isOpen = $state(false);

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/FfmpegCommandBuilder.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/FfmpegCommandBuilder.svelte
@@ -36,7 +36,7 @@
 		outputOptions: string;
 	} = $props();
 
-	const getDevicesQuery = createQuery(rpc.recorder.enumerateDevices.options);
+	const getDevicesQuery = createQuery(() => rpc.recorder.enumerateDevices.options);
 
 	// Get the selected device identifier with proper fallback chain
 	const selectedDeviceId = $derived(

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/ManualSelectRecordingDevice.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/ManualSelectRecordingDevice.svelte
@@ -13,7 +13,7 @@
 	} = $props();
 
 	// Use recorder.enumerateDevices for manual recording (includes desktop devices)
-	const getDevicesQuery = createQuery(rpc.recorder.enumerateDevices.options);
+	const getDevicesQuery = createQuery(() => rpc.recorder.enumerateDevices.options);
 
 	$effect(() => {
 		if (getDevicesQuery.isError) {

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/VadSelectRecordingDevice.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/VadSelectRecordingDevice.svelte
@@ -14,7 +14,7 @@
 	} = $props();
 
 	// Use vadRecorder.enumerateDevices for VAD (navigator devices only)
-	const getDevicesQuery = createQuery(vadRecorder.enumerateDevices.options);
+	const getDevicesQuery = createQuery(() => vadRecorder.enumerateDevices.options);
 
 	$effect(() => {
 		if (getDevicesQuery.isError) {

--- a/apps/whispering/src/routes/(app)/(config)/transformations/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/transformations/+page.svelte
@@ -42,10 +42,10 @@
 	import { PATHS } from '$lib/constants/paths';
 
 	const transformationsQuery = createQuery(
-		rpc.db.transformations.getAll.options,
+		() => rpc.db.transformations.getAll.options,
 	);
 	const deleteTransformations = createMutation(
-		rpc.db.transformations.delete.options,
+		() => rpc.db.transformations.delete.options,
 	);
 
 	const columns: ColumnDef<Transformation>[] = [

--- a/apps/whispering/src/routes/(app)/(config)/transformations/CreateTransformationButton.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/transformations/CreateTransformationButton.svelte
@@ -10,7 +10,7 @@
 	import PlusIcon from '@lucide/svelte/icons/plus';
 
 	const createTransformation = createMutation(
-		rpc.db.transformations.create.options,
+		() => rpc.db.transformations.create.options,
 	);
 
 	let isDialogOpen = $state(false);

--- a/apps/whispering/src/routes/(app)/(config)/transformations/EditTransformationModal.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/transformations/EditTransformationModal.svelte
@@ -15,11 +15,11 @@
 	import MarkTransformationActiveButton from './MarkTransformationActiveButton.svelte';
 
 	const updateTransformation = createMutation(
-		rpc.db.transformations.update.options,
+		() => rpc.db.transformations.update.options,
 	);
 
 	const deleteTransformation = createMutation(
-		rpc.db.transformations.delete.options,
+		() => rpc.db.transformations.delete.options,
 	);
 
 	let {

--- a/apps/whispering/src/routes/(app)/(config)/transformations/TransformationRowActions.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/transformations/TransformationRowActions.svelte
@@ -10,11 +10,11 @@
 	let { transformationId }: { transformationId: string } = $props();
 
 	const deleteTransformation = createMutation(
-		rpc.db.transformations.delete.options,
+		() => rpc.db.transformations.delete.options,
 	);
 
 	const transformationQuery = createQuery(
-		rpc.db.transformations.getById(() => transformationId).options,
+		() => rpc.db.transformations.getById(() => transformationId).options,
 	);
 	const transformation = $derived(transformationQuery.data);
 </script>

--- a/apps/whispering/src/routes/(app)/(config)/transformations/new/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/transformations/new/+page.svelte
@@ -8,7 +8,7 @@
 	import { createMutation } from '@tanstack/svelte-query';
 
 	const createTransformation = createMutation(
-		rpc.db.transformations.create.options,
+		() => rpc.db.transformations.create.options,
 	);
 
 	let transformation = $state(generateDefaultTransformation());

--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -37,9 +37,9 @@
 	import { onDestroy, onMount } from 'svelte';
 
 	const getRecorderStateQuery = createQuery(
-		rpc.recorder.getRecorderState.options,
+		() => rpc.recorder.getRecorderState.options,
 	);
-	const latestRecordingQuery = createQuery(rpc.db.recordings.getLatest.options);
+	const latestRecordingQuery = createQuery(() => rpc.db.recordings.getLatest.options);
 
 	const latestRecording = $derived<Recording>(
 		latestRecordingQuery.data ?? {

--- a/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
+++ b/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
@@ -34,7 +34,7 @@
 	import { registerOnboarding } from '../_layout-utils/register-onboarding';
 
 	const getRecorderStateQuery = createQuery(
-		rpc.recorder.getRecorderState.options,
+		() => rpc.recorder.getRecorderState.options,
 	);
 
 	let cleanupAccessibilityPermission: (() => void) | undefined;

--- a/apps/whispering/src/routes/(app)/_layout-utils/alwaysOnTop.svelte.ts
+++ b/apps/whispering/src/routes/(app)/_layout-utils/alwaysOnTop.svelte.ts
@@ -6,7 +6,7 @@ import { settings } from '$lib/stores/settings.svelte';
 
 export function syncWindowAlwaysOnTopWithRecorderState() {
 	const getRecorderStateQuery = createQuery(() => ({
-		...rpc.recorder.getRecorderState.options(),
+		...rpc.recorder.getRecorderState.options,
 		enabled: settings.value['recording.mode'] === 'manual',
 	}));
 

--- a/apps/whispering/src/routes/(app)/_layout-utils/syncIconWithRecorderState.svelte.ts
+++ b/apps/whispering/src/routes/(app)/_layout-utils/syncIconWithRecorderState.svelte.ts
@@ -3,7 +3,7 @@ import { rpc } from '$lib/query';
 
 export function syncIconWithRecorderState() {
 	const getRecorderStateQuery = createQuery(
-		rpc.recorder.getRecorderState.options,
+		() => rpc.recorder.getRecorderState.options,
 	);
 
 	$effect(() => {

--- a/apps/whispering/src/routes/transform-clipboard/+page.svelte
+++ b/apps/whispering/src/routes/transform-clipboard/+page.svelte
@@ -16,7 +16,7 @@
 	const combobox = useCombobox();
 
 	const clipboardQuery = createQuery(() => ({
-		...rpc.text.readFromClipboard.options(),
+		...rpc.text.readFromClipboard.options,
 		refetchInterval: 1000,
 	}));
 


### PR DESCRIPTION
This PR migrates all `createQuery` and `createMutation` usages to the new accessor pattern required by wellcrafted v0.26.0.

The wellcrafted library's TanStack Query integration changed how `.options` works with Svelte 5's reactivity system. The `.options` property now returns the options object directly, so Svelte's `createQuery` and `createMutation` need an accessor function wrapper to ensure proper reactivity.

**Before:**
```typescript
const query = createQuery(rpc.foo.options);
const mutation = createMutation(rpc.bar.options);
```

**After:**
```typescript
const query = createQuery(() => rpc.foo.options);
const mutation = createMutation(() => rpc.bar.options);
```

The changes are organized into three commits:
1. **createQuery migrations** - 24 files with query pattern updates
2. **createMutation migrations** - 6 files with mutation pattern updates
3. **Documentation** - Updated JSDoc examples in vad.svelte.ts

All usages have been verified via grep to ensure no old patterns remain in the codebase.