### PR TITLE
refactor(ui): remove redundant icon margins in buttons

### DIFF
--- a/apps/whispering/src/lib/components/OpenFolderButton.svelte
+++ b/apps/whispering/src/lib/components/OpenFolderButton.svelte
@@ -85,7 +85,7 @@
 		</Button>
 	{:else}
 		<Button tooltip={tooltipText} variant="outline" onclick={openFolder}>
-			<ExternalLink class="h-4 w-4 mr-2" />
+			<ExternalLink class="h-4 w-4" />
 			{tooltipText}
 		</Button>
 	{/if}

--- a/apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte
@@ -367,7 +367,7 @@
 			</Button>
 		{:else}
 			<Button size="sm" variant="outline" onclick={downloadModel}>
-				<Download class="size-4 mr-2" />
+				<Download class="size-4" />
 				Download
 			</Button>
 		{/if}

--- a/apps/whispering/src/lib/components/settings/selectors/CompressionSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/CompressionSelector.svelte
@@ -69,7 +69,7 @@
 				popover.open = false;
 			}}
 		>
-			<SettingsIcon class="mr-2 h-4 w-4" />
+			<SettingsIcon class="h-4 w-4" />
 			Configure in transcription settings
 		</Button>
 	</Popover.Content>

--- a/apps/whispering/src/lib/components/transformations-editor/Configuration.svelte
+++ b/apps/whispering/src/lib/components/transformations-editor/Configuration.svelte
@@ -736,7 +736,7 @@
 			variant={transformation.steps.length === 0 ? 'default' : 'outline'}
 			class="w-full"
 		>
-			<PlusIcon class="mr-2 size-4" />
+			<PlusIcon class="size-4" />
 			{transformation.steps.length === 0
 				? 'Add Your First Step'
 				: 'Add Another Step'}

--- a/apps/whispering/src/lib/components/transformations-editor/Runs.svelte
+++ b/apps/whispering/src/lib/components/transformations-editor/Runs.svelte
@@ -76,7 +76,7 @@
 				}}
 				disabled={deleteRunMutation.isPending}
 			>
-				<Trash2 class="mr-2 size-4" />
+				<Trash2 class="size-4" />
 				{#if deleteRunMutation.isPending}
 					Deleting...
 				{:else}

--- a/apps/whispering/src/routes/(app)/(config)/desktop-app/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/desktop-app/+page.svelte
@@ -71,7 +71,7 @@
 					size="lg"
 					class="min-w-[200px]"
 				>
-					<DownloadIcon class="mr-2 size-5" />
+					<DownloadIcon class="size-5" />
 					Download for Desktop
 				</Button>
 				<Button
@@ -82,7 +82,7 @@
 					variant="outline"
 					size="lg"
 				>
-					<ChromeWebStoreIcon class="mr-2 size-5" />
+					<ChromeWebStoreIcon class="size-5" />
 					Chrome Extension
 				</Button>
 			</div>

--- a/apps/whispering/src/routes/(app)/(config)/global-shortcut/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/global-shortcut/+page.svelte
@@ -25,7 +25,7 @@
 				variant="default"
 				size="lg"
 			>
-				<DesktopIcon class="mr-2 size-6" />
+				<DesktopIcon class="size-6" />
 				Download for Desktop
 			</Button>
 			<Button
@@ -36,7 +36,7 @@
 				variant="outline"
 				size="lg"
 			>
-				<ChromeWebStoreIcon class="mr-2 size-6" />
+				<ChromeWebStoreIcon class="size-6" />
 				Get Chrome Extension
 			</Button>
 		</div>

--- a/apps/whispering/src/routes/(app)/(config)/install-ffmpeg/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/install-ffmpeg/+page.svelte
@@ -178,7 +178,7 @@
 													size="lg"
 													class="w-full sm:w-auto"
 												>
-													<DownloadIcon class="size-5 mr-2" />
+													<DownloadIcon class="size-5" />
 													Download FFmpeg for Windows
 												</Button>
 											</div>
@@ -297,7 +297,7 @@
 														variant="outline"
 														size="sm"
 													>
-														<ExternalLinkIcon class="size-3 mr-2" />
+														<ExternalLinkIcon class="size-3" />
 														Watch Tutorial Video
 													</Button>
 												</div>
@@ -422,7 +422,7 @@
 			{#if ffmpegQuery.data !== true}
 				<Card.Footer class="flex justify-center">
 					<Button href="/settings/transcription" variant="ghost" size="sm">
-						<ArrowLeftIcon class="size-4 mr-2" />
+						<ArrowLeftIcon class="size-4" />
 						Back to Settings
 					</Button>
 				</Card.Footer>

--- a/apps/whispering/src/routes/(app)/(config)/macos-enable-accessibility/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/macos-enable-accessibility/+page.svelte
@@ -134,14 +134,14 @@
 						onclick={() => goto('/')}
 						class="flex-1 text-sm"
 					>
-						<ArrowLeft class="mr-2 size-4" />
+						<ArrowLeft class="size-4" />
 						Back to Home
 					</Button>
 					<Button
 						onclick={() => requestPermissionOrShowGuidance()}
 						class="flex-1 text-sm"
 					>
-						<SettingsIcon class="mr-2 size-4" />
+						<SettingsIcon class="size-4" />
 						Request Permission
 					</Button>
 				</div>
@@ -157,7 +157,7 @@
 							onclick={() => goto('/')}
 							class="flex-1 text-sm"
 						>
-							<ArrowLeft class="mr-2 size-4" />
+							<ArrowLeft class="size-4" />
 							Back to Home
 						</Button>
 						<Button
@@ -165,7 +165,7 @@
 							variant="outline"
 							class="flex-1 text-sm"
 						>
-							<SettingsIcon class="mr-2 size-4" />
+							<SettingsIcon class="size-4" />
 							Open Settings
 						</Button>
 					</div>

--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -559,7 +559,7 @@
 						)}
 					>
 						Columns <ChevronDownIcon
-							class="ml-2 size-4 transition-transform duration-200"
+							class="size-4 transition-transform duration-200"
 						/>
 					</DropdownMenu.Trigger>
 					<DropdownMenu.Content>

--- a/apps/whispering/src/routes/(app)/(config)/settings/+layout.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/+layout.svelte
@@ -86,7 +86,7 @@
 			}}
 			class="shrink-0"
 		>
-			<RotateCcw class="mr-2 size-4" />
+			<RotateCcw class="size-4" />
 			Reset to defaults
 		</Button>
 	</div>

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/global/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/global/+page.svelte
@@ -45,7 +45,7 @@
 				}}
 				class="shrink-0"
 			>
-				<RotateCcw class="mr-2 size-4" />
+				<RotateCcw class="size-4" />
 				Reset to defaults
 			</Button>
 		</div>

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/KeyboardShortcutRecorder.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/KeyboardShortcutRecorder.svelte
@@ -170,7 +170,7 @@
 								class="flex-1"
 								onclick={() => keyRecorder.clear()}
 							>
-								<XIcon class="mr-2 size-3" />
+								<XIcon class="size-3" />
 								Clear
 							</Button>
 						{/if}
@@ -184,7 +184,7 @@
 								keyRecorder.stop();
 							}}
 						>
-							<Pencil class="mr-2 size-3" />
+							<Pencil class="size-3" />
 							Edit manually
 						</Button>
 					</div>

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
@@ -157,7 +157,7 @@
 					target="_blank"
 					rel="noreferrer"
 				>
-					<ExternalLink class="mr-2 size-4" />
+					<ExternalLink class="size-4" />
 					View documentation
 				</Button>
 			{/if}

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/local/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/local/+page.svelte
@@ -40,7 +40,7 @@
 			}}
 			class="shrink-0"
 		>
-			<RotateCcw class="mr-2 size-4" />
+			<RotateCcw class="size-4" />
 			Reset to defaults
 		</Button>
 	</div>

--- a/apps/whispering/src/routes/(app)/(config)/transformations/CreateTransformationButton.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/transformations/CreateTransformationButton.svelte
@@ -32,7 +32,7 @@
 	<Dialog.Trigger>
 		{#snippet child({ props })}
 			<Button {...props}>
-				<PlusIcon class="size-4 mr-2" />
+				<PlusIcon class="size-4" />
 				Create Transformation
 			</Button>
 		{/snippet}

--- a/packages/ui/src/table/SortableTableHeader.svelte
+++ b/packages/ui/src/table/SortableTableHeader.svelte
@@ -19,10 +19,10 @@
 >
 	{headerText}
 	{#if column.getIsSorted() === 'asc'}
-		<ArrowUpIcon class="ml-2 size-4" />
+		<ArrowUpIcon class="size-4" />
 	{:else if column.getIsSorted() === 'desc'}
-		<ArrowDownIcon class="ml-2 size-4" />
+		<ArrowDownIcon class="size-4" />
 	{:else}
-		<ArrowUpDownIcon class="ml-2 size-4" />
+		<ArrowUpDownIcon class="size-4" />
 	{/if}
 </Button>


### PR DESCRIPTION
The Button component base class includes `gap-2` for spacing between children, making `mr-2`/`ml-2` classes on icons inside buttons redundant. This removes those margin classes from Lucide icons inside Button components across the codebase.

This is a purely visual cleanup; the Button's built-in gap handles the spacing automatically, so no visual changes should occur.