### PR TITLE
refactor(FfmpegCommandBuilder): use flex gap for inline labels

### DIFF
--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/FfmpegCommandBuilder.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/FfmpegCommandBuilder.svelte
@@ -248,9 +248,9 @@
 		<!-- Output Options (Primary) -->
 		<div class="rounded-lg border p-4 space-y-3">
 			<div class="flex items-center justify-between">
-				<h5 class="text-sm font-medium">
+				<h5 class="text-sm font-medium flex items-baseline gap-2">
 					<span class="text-primary">Output</span>
-					<span class="text-xs text-muted-foreground font-normal ml-2"
+					<span class="text-xs text-muted-foreground font-normal"
 						>Primary settings</span
 					>
 				</h5>
@@ -394,10 +394,10 @@
 		<!-- Advanced Options (Collapsible) -->
 		<details class="group">
 			<summary
-				class="cursor-pointer select-none rounded-lg border px-4 py-3 hover:bg-muted/50 transition-colors"
+				class="cursor-pointer select-none rounded-lg border px-4 py-3 hover:bg-muted/50 transition-colors flex items-baseline gap-2"
 			>
 				<span class="text-sm font-medium">Advanced Options</span>
-				<span class="text-xs text-muted-foreground ml-2"
+				<span class="text-xs text-muted-foreground"
 					>Raw FFmpeg parameters</span
 				>
 			</summary>


### PR DESCRIPTION
This replaces `ml-2` margin on subtitle spans with `flex items-baseline gap-2` on parent elements, following the Button component pattern established in #1116 where the parent controls spacing via gap rather than children using margins.

The change affects two inline label patterns in the FFmpeg settings:
- Output section header: "Output" + "Primary settings"
- Advanced Options summary: "Advanced Options" + "Raw FFmpeg parameters"

Using `items-baseline` ensures proper text alignment across different font sizes (the primary label is `text-sm font-medium` while the subtitle is `text-xs text-muted-foreground`).