### PR TITLE
fix(whispering:transformations): bypass CORS for custom endpoints on desktop

### DIFF
--- a/apps/whispering/src/lib/services/completion/groq.ts
+++ b/apps/whispering/src/lib/services/completion/groq.ts
@@ -1,12 +1,15 @@
+import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
 import Groq from 'groq-sdk';
 import { Err, Ok, tryAsync } from 'wellcrafted/result';
 import type { CompletionService } from './types';
 import { CompletionServiceErr } from './types';
 
+
+const customFetch = window.__TAURI_INTERNALS__ ? tauriFetch : undefined;
 export function createGroqCompletionService(): CompletionService {
 	return {
 		async complete({ apiKey, model, systemPrompt, userPrompt }) {
-			const client = new Groq({ apiKey, dangerouslyAllowBrowser: true });
+			const client = new Groq({ apiKey, dangerouslyAllowBrowser: true, fetch: customFetch });
 			// Call Groq API
 			const { data: completion, error: groqApiError } = await tryAsync({
 				try: () =>

--- a/apps/whispering/src/lib/services/completion/openai-compatible.ts
+++ b/apps/whispering/src/lib/services/completion/openai-compatible.ts
@@ -1,7 +1,10 @@
+import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
 import OpenAI from 'openai';
 import { Err, isErr, Ok, type Result, tryAsync } from 'wellcrafted/result';
 import type { CompletionService } from './types';
 import { CompletionServiceErr, type CompletionServiceError } from './types';
+
+const customFetch = window.__TAURI_INTERNALS__ ? tauriFetch : undefined;
 
 export type OpenAiCompatibleConfig = {
 	/**
@@ -130,6 +133,7 @@ export function createOpenAiCompatibleCompletionService(
 				baseURL: effectiveBaseUrl,
 				dangerouslyAllowBrowser: true,
 				defaultHeaders: config.defaultHeaders,
+				fetch: customFetch,
 			});
 
 			const { data: completion, error: apiError } = await tryAsync({

--- a/apps/whispering/src/lib/services/transcription/cloud/groq.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/groq.ts
@@ -1,9 +1,12 @@
+import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
 import Groq from 'groq-sdk';
 import { Err, Ok, type Result, tryAsync, trySync } from 'wellcrafted/result';
 import { WhisperingErr, type WhisperingError } from '$lib/result';
 import { getExtensionFromAudioBlob } from '$lib/services/_utils';
 import type { Settings } from '$lib/settings';
 
+
+const customFetch = window.__TAURI_INTERNALS__ ? tauriFetch : undefined;
 export const GROQ_MODELS = [
 	{
 		name: 'whisper-large-v3',
@@ -112,6 +115,7 @@ export function createGroqTranscriptionService() {
 					new Groq({
 						apiKey: options.apiKey,
 						dangerouslyAllowBrowser: true,
+						fetch: customFetch,
 						...(options.baseURL && { baseURL: options.baseURL }),
 					}).audio.transcriptions.create({
 						file,

--- a/apps/whispering/src/lib/services/transcription/cloud/openai.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/openai.ts
@@ -1,8 +1,11 @@
+import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
 import OpenAI from 'openai';
 import { Err, Ok, type Result, tryAsync, trySync } from 'wellcrafted/result';
 import { WhisperingErr, type WhisperingError } from '$lib/result';
 import { getExtensionFromAudioBlob } from '$lib/services/_utils';
 import type { Settings } from '$lib/settings';
+
+const customFetch = window.__TAURI_INTERNALS__ ? tauriFetch : undefined;
 
 export const OPENAI_TRANSCRIPTION_MODELS = [
 	{
@@ -118,6 +121,7 @@ export function createOpenaiTranscriptionService() {
 					new OpenAI({
 						apiKey: options.apiKey,
 						dangerouslyAllowBrowser: true,
+						fetch: customFetch,
 						...(options.baseURL && { baseURL: options.baseURL }),
 					}).audio.transcriptions.create({
 						file,


### PR DESCRIPTION
## Summary

Custom OpenAI-compatible endpoints fail on desktop when the server doesn't send CORS headers. The OpenAI SDK uses browser fetch internally, which is subject to CORS even in Tauri's webview. This passes Tauri's HTTP plugin fetch to the OpenAI client, bypassing CORS restrictions.

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `refactor`: Code refactoring (no functional changes)
- [ ] `perf`: Performance improvement
- [ ] `test`: Test additions or changes
- [ ] `chore`: Maintenance tasks
- [ ] `style`: Code style changes

## Related Issue

N/A

## Changes Made

- Pass Tauri's fetch to the OpenAI client on desktop
- Web builds continue using native fetch

## Testing

<!-- Describe the tests you ran to verify your changes -->

### Desktop App Testing
- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] Not applicable (web-only change)

### General Testing
- [x] Tested with multiple API providers (if applicable)
- [x] Verified no API keys are exposed in logs or storage
- [x] Checked for console errors
- [ ] Tested on different screen sizes (if UI change)

## Checklist

<!-- Make sure you've completed these steps -->

- [x] My code follows the project's coding standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I've used `type` instead of `interface` in TypeScript
- [x] I've used absolute imports where applicable
- [x] I've tested my changes thoroughly
- [x] I've added/updated tests for my changes (if applicable)
- [x] My changes don't break existing functionality
- [x] I've updated documentation (if needed)

## Screenshots/Recordings

<img width="2550" height="1208" alt="Screenshot 2025-12-09 at 11 41 10@2x" src="https://github.com/user-attachments/assets/32b403c2-5f8b-4b8b-a73c-58d02fbd5aed" />

## Additional Notes

The app already uses @tauri-apps/plugin-http for other HTTP requests (like `http/desktop.ts`). This change follows the same pattern.