### PR TITLE
fix: TypeScript fixes and fs service refactoring

### DIFF
--- a/apps/whispering/src/lib/services/fs/desktop.ts
+++ b/apps/whispering/src/lib/services/fs/desktop.ts
@@ -18,7 +18,8 @@ export function createFsServiceDesktop(): FsService {
 				try: async () => {
 					const fileBytes = await readFile(path);
 					const mimeType = getMimeType(path);
-					return new Blob([fileBytes], { type: mimeType });
+					// Cast is safe: Tauri's readFile always returns ArrayBuffer-backed Uint8Array, never SharedArrayBuffer
+					return new Blob([fileBytes as Uint8Array<ArrayBuffer>], { type: mimeType });
 				},
 				catch: (error) =>
 					FsServiceErr({
@@ -33,7 +34,8 @@ export function createFsServiceDesktop(): FsService {
 					const fileBytes = await readFile(path);
 					const fileName = await basename(path);
 					const mimeType = getMimeType(path);
-					return new File([fileBytes], fileName, { type: mimeType });
+					// Cast is safe: Tauri's readFile always returns ArrayBuffer-backed Uint8Array, never SharedArrayBuffer
+					return new File([fileBytes as Uint8Array<ArrayBuffer>], fileName, { type: mimeType });
 				},
 				catch: (error) =>
 					FsServiceErr({
@@ -50,7 +52,8 @@ export function createFsServiceDesktop(): FsService {
 						const fileBytes = await readFile(path);
 						const fileName = await basename(path);
 						const mimeType = getMimeType(path);
-						const file = new File([fileBytes], fileName, { type: mimeType });
+						// Cast is safe: Tauri's readFile always returns ArrayBuffer-backed Uint8Array, never SharedArrayBuffer
+						const file = new File([fileBytes as Uint8Array<ArrayBuffer>], fileName, { type: mimeType });
 						files.push(file);
 					}
 					return files;

--- a/apps/whispering/src/lib/services/fs/desktop.ts
+++ b/apps/whispering/src/lib/services/fs/desktop.ts
@@ -6,6 +6,50 @@ import { tryAsync } from 'wellcrafted/result';
 import type { FsService } from './types';
 import { FsServiceErr } from './types';
 
+export function createFsServiceDesktop(): FsService {
+	return {
+		pathToBlob: (path: string) =>
+			tryAsync({
+				try: () => createBlobFromPath(path),
+				catch: (error) =>
+					FsServiceErr({
+						message: `Failed to read file as Blob: ${path}: ${extractErrorMessage(error)}`,
+					}),
+			}),
+
+		pathToFile: (path: string) =>
+			tryAsync({
+				try: () => createFileFromPath(path),
+				catch: (error) =>
+					FsServiceErr({
+						message: `Failed to read file as File: ${path}: ${extractErrorMessage(error)}`,
+					}),
+			}),
+
+		pathsToFiles: (paths: string[]) =>
+			tryAsync({
+				try: () => Promise.all(paths.map(createFileFromPath)),
+				catch: (error) =>
+					FsServiceErr({
+						message: `Failed to read files: ${paths.join(', ')}: ${extractErrorMessage(error)}`,
+					}),
+			}),
+	};
+}
+
+/** Reads a file from disk and creates a Blob with the correct MIME type. */
+async function createBlobFromPath(path: string): Promise<Blob> {
+	const { bytes, mimeType } = await readFileWithMimeType(path);
+	return new Blob([bytes], { type: mimeType });
+}
+
+/** Reads a file from disk and creates a File object with the correct MIME type. */
+async function createFileFromPath(path: string): Promise<File> {
+	const { bytes, mimeType } = await readFileWithMimeType(path);
+	const fileName = await basename(path);
+	return new File([bytes], fileName, { type: mimeType });
+}
+
 /**
  * Reads a file and returns its bytes with the correct type for Blob/File constructors,
  * along with the inferred MIME type.
@@ -21,48 +65,4 @@ async function readFileWithMimeType(path: string): Promise<{
 	const bytes = (await readFile(path)) as Uint8Array<ArrayBuffer>;
 	const mimeType = mime.getType(path) ?? 'application/octet-stream';
 	return { bytes, mimeType };
-}
-
-/** Reads a file from disk and creates a File object with the correct MIME type. */
-async function createFileFromPath(path: string): Promise<File> {
-	const { bytes, mimeType } = await readFileWithMimeType(path);
-	const fileName = await basename(path);
-	return new File([bytes], fileName, { type: mimeType });
-}
-
-export function createFsServiceDesktop(): FsService {
-	return {
-		pathToBlob: async (path: string) => {
-			return tryAsync({
-				try: async () => {
-					const { bytes, mimeType } = await readFileWithMimeType(path);
-					return new Blob([bytes], { type: mimeType });
-				},
-				catch: (error) =>
-					FsServiceErr({
-						message: `Failed to read file as Blob: ${path}: ${extractErrorMessage(error)}`,
-					}),
-			});
-		},
-
-		pathToFile: async (path: string) => {
-			return tryAsync({
-				try: () => createFileFromPath(path),
-				catch: (error) =>
-					FsServiceErr({
-						message: `Failed to read file as File: ${path}: ${extractErrorMessage(error)}`,
-					}),
-			});
-		},
-
-		pathsToFiles: async (paths: string[]) => {
-			return tryAsync({
-				try: () => Promise.all(paths.map(createFileFromPath)),
-				catch: (error) =>
-					FsServiceErr({
-						message: `Failed to read files: ${paths.join(', ')}: ${extractErrorMessage(error)}`,
-					}),
-			});
-		},
-	};
 }

--- a/apps/whispering/src/lib/services/os/types.ts
+++ b/apps/whispering/src/lib/services/os/types.ts
@@ -5,5 +5,5 @@ export const { OsServiceError, OsServiceErr } =
 	createTaggedError('OsServiceError');
 
 export type OsService = {
-	type: () => Exclude<OsType, 'android' | 'ios'>;
+	type: () => OsType;
 };

--- a/apps/whispering/src/lib/services/recorder/cpal.ts
+++ b/apps/whispering/src/lib/services/recorder/cpal.ts
@@ -239,7 +239,8 @@ export function createCpalRecorderService(): RecorderService {
 			const { data: blob, error: readRecordingFileError } = await tryAsync({
 				try: async () => {
 					const fileBytes = await readFile(filePath);
-					return new Blob([fileBytes], { type: 'audio/wav' });
+					// Cast is safe: Tauri's readFile always returns ArrayBuffer-backed Uint8Array, never SharedArrayBuffer
+					return new Blob([fileBytes as Uint8Array<ArrayBuffer>], { type: 'audio/wav' });
 				},
 				catch: (error) =>
 					RecorderServiceErr({

--- a/apps/whispering/src/lib/stores/settings.svelte.ts
+++ b/apps/whispering/src/lib/stores/settings.svelte.ts
@@ -214,10 +214,7 @@ async function stopAllRecordingModesExcept(modeToKeep: RecordingMode) {
 	);
 
 	// Execute all stops in parallel
-	const results: Result<
-		Blob | undefined,
-		RecorderServiceError | WhisperingError
-	>[] = await Promise.all(stopPromises);
+	const results = await Promise.all(stopPromises);
 
 	// Partition results into successes and errors
 	const { errs } = partitionResults(results);

--- a/apps/whispering/src/lib/utils/createPressedKeys.svelte.ts
+++ b/apps/whispering/src/lib/utils/createPressedKeys.svelte.ts
@@ -3,6 +3,7 @@ import { createSubscriber } from 'svelte/reactivity';
 import {
 	isSupportedKey,
 	type KeyboardEventPossibleKey,
+	type KeyboardEventSupportedKey,
 	normalizeOptionKeyCharacter,
 } from '$lib/constants/keyboard';
 import { IS_MACOS } from '$lib/constants/platform';
@@ -47,8 +48,9 @@ export function createPressedKeys({
 }) {
 	/**
 	 * Pressed and normalized keys, internally stored and synced via createSubscriber.
+	 * Only contains supported keys (filtered by isSupportedKey guard).
 	 */
-	let pressedKeys = $state<KeyboardEventPossibleKey[]>([]);
+	let pressedKeys = $state<KeyboardEventSupportedKey[]>([]);
 
 	/**
 	 * Creates a reactive subscription that tracks key events.


### PR DESCRIPTION
This PR contains TypeScript type fixes and refactoring of the fs service that were done while investigating recording restart issues.

**TypeScript Fixes:**
- fix(os): allow OsService to return all OsType values including mobile platforms
- fix(fs): cast Uint8Array to ArrayBuffer-backed type for Blob/File constructors
- fix(ffmpeg): add desktop platform validation and fix type errors
- fix(keyboard): use KeyboardEventSupportedKey type for pressedKeys array
- fix(settings): remove incorrect Result type annotation on stopPromises results

**FsService Refactoring:**
- Extract `readFileBytes` helper and use FsService in cpal recorder
- Combine `readFileBytes` and `getMimeType` into single `readFileWithMimeType` helper
- Extract `createFileFromPath` helper and parallelize pathsToFiles with Promise.all
- Reorganize with progressive disclosure and add `createBlobFromPath` helper

The fs service changes follow progressive disclosure: simple helpers at the top, complex composed helpers below.