### PR TITLE
refactor(result): remove fromTaggedError, add serviceError field to WhisperingErr

### DIFF
--- a/apps/whispering/src/lib/query/actions.ts
+++ b/apps/whispering/src/lib/query/actions.ts
@@ -1,6 +1,6 @@
 import { nanoid } from 'nanoid/non-secure';
-import { Err, Ok } from 'wellcrafted/result';
-import { fromTaggedError, WhisperingErr } from '$lib/result';
+import { Ok } from 'wellcrafted/result';
+import { WhisperingErr } from '$lib/result';
 import { DbServiceErr } from '$lib/services/db';
 import { settings } from '$lib/stores/settings.svelte';
 import * as transformClipboardWindow from '../../routes/transform-clipboard/transformClipboardWindow.tauri';
@@ -512,12 +512,10 @@ export const commands = {
 				await db.transformations.getById(() => transformationId).fetch();
 
 			if (getTransformationError) {
-				return Err(
-					fromTaggedError(getTransformationError, {
-						title: '❌ Failed to get transformation',
-						action: { type: 'more-details', error: getTransformationError },
-					}),
-				);
+				return WhisperingErr({
+					title: '❌ Failed to get transformation',
+					serviceError: getTransformationError,
+				});
 			}
 
 			if (!transformation) {
@@ -539,12 +537,10 @@ export const commands = {
 				await text.readFromClipboard.fetch();
 
 			if (readClipboardError) {
-				return Err(
-					fromTaggedError(readClipboardError, {
-						title: '❌ Failed to read clipboard',
-						action: { type: 'more-details', error: readClipboardError },
-					}),
-				);
+				return WhisperingErr({
+					title: '❌ Failed to read clipboard',
+					serviceError: readClipboardError,
+				});
 			}
 
 			if (!clipboardText?.trim()) {
@@ -696,12 +692,10 @@ async function processRecordingPipeline({
 	const transformationNoLongerExists = !transformation;
 
 	if (getTransformationError) {
-		notify.error.execute(
-			fromTaggedError(getTransformationError, {
-				title: '❌ Failed to get transformation',
-				action: { type: 'more-details', error: getTransformationError },
-			}),
-		);
+		notify.error.execute({
+			title: '❌ Failed to get transformation',
+			serviceError: getTransformationError,
+		});
 		return;
 	}
 

--- a/apps/whispering/src/lib/query/ffmpeg.ts
+++ b/apps/whispering/src/lib/query/ffmpeg.ts
@@ -1,5 +1,5 @@
 import { Ok } from 'wellcrafted/result';
-import { fromTaggedErr } from '$lib/result';
+import { WhisperingErr } from '$lib/result';
 import * as services from '$lib/services';
 import { defineQuery } from './_client';
 
@@ -9,8 +9,9 @@ export const ffmpeg = {
 		queryFn: async () => {
 			const { data, error } = await services.ffmpeg.checkInstalled();
 			if (error) {
-				return fromTaggedErr(error, {
+				return WhisperingErr({
 					title: '❌ Error checking FFmpeg installation',
+					serviceError: error,
 				});
 			}
 			return Ok(data);

--- a/apps/whispering/src/lib/query/recorder.ts
+++ b/apps/whispering/src/lib/query/recorder.ts
@@ -1,7 +1,7 @@
 import { nanoid } from 'nanoid/non-secure';
 import { Ok } from 'wellcrafted/result';
 import type { WhisperingRecordingState } from '$lib/constants/audio';
-import { fromTaggedErr, WhisperingErr } from '$lib/result';
+import { WhisperingErr } from '$lib/result';
 import * as services from '$lib/services';
 import { getDefaultRecordingsFolder } from '$lib/services/recorder';
 import { settings } from '$lib/stores/settings.svelte';
@@ -32,9 +32,9 @@ export const recorder = {
 		queryFn: async () => {
 			const { data, error } = await recorderService().enumerateDevices();
 			if (error) {
-				return fromTaggedErr(error, {
+				return WhisperingErr({
 					title: '❌ Failed to enumerate devices',
-					action: { type: 'more-details', error },
+					serviceError: error,
 				});
 			}
 			return Ok(data);
@@ -48,9 +48,9 @@ export const recorder = {
 			const { data: state, error: getStateError } =
 				await recorderService().getRecorderState();
 			if (getStateError) {
-				return fromTaggedErr(getStateError, {
+				return WhisperingErr({
 					title: '❌ Failed to get recorder state',
-					action: { type: 'more-details', error: getStateError },
+					serviceError: getStateError,
 				});
 			}
 			return Ok(state);
@@ -117,9 +117,9 @@ export const recorder = {
 				});
 
 			if (startRecordingError) {
-				return fromTaggedErr(startRecordingError, {
+				return WhisperingErr({
 					title: '❌ Failed to start recording',
-					action: { type: 'more-details', error: startRecordingError },
+					serviceError: startRecordingError,
 				});
 			}
 			return Ok(deviceAcquisitionOutcome);
@@ -139,9 +139,9 @@ export const recorder = {
 			if (stopRecordingError) {
 				// Reset recording ID on error
 				currentRecordingId = null;
-				return fromTaggedErr(stopRecordingError, {
+				return WhisperingErr({
 					title: '❌ Failed to stop recording',
-					action: { type: 'more-details', error: stopRecordingError },
+					serviceError: stopRecordingError,
 				});
 			}
 
@@ -178,9 +178,9 @@ export const recorder = {
 			currentRecordingId = null;
 
 			if (cancelRecordingError) {
-				return fromTaggedErr(cancelRecordingError, {
+				return WhisperingErr({
 					title: '❌ Failed to cancel recording',
-					action: { type: 'more-details', error: cancelRecordingError },
+					serviceError: cancelRecordingError,
 				});
 			}
 

--- a/apps/whispering/src/lib/query/transformer.ts
+++ b/apps/whispering/src/lib/query/transformer.ts
@@ -2,7 +2,6 @@ import { nanoid } from 'nanoid/non-secure';
 import { createTaggedError, extractErrorMessage } from 'wellcrafted/error';
 import { Err, isErr, Ok, type Result } from 'wellcrafted/result';
 import {
-	fromTaggedErr,
 	WhisperingErr,
 	type WhisperingError,
 	type WhisperingResult,
@@ -51,9 +50,9 @@ export const transformer = {
 					});
 
 				if (transformationRunError)
-					return fromTaggedErr(transformationRunError, {
+					return WhisperingErr({
 						title: '⚠️ Transformation failed',
-						action: { type: 'more-details', error: transformationRunError },
+						serviceError: transformationRunError,
 					});
 
 				if (transformationRun.status === 'failed') {
@@ -120,9 +119,9 @@ export const transformer = {
 				});
 
 			if (transformationRunError)
-				return fromTaggedErr(transformationRunError, {
+				return WhisperingErr({
 					title: '⚠️ Transformation failed',
-					action: { type: 'more-details', error: transformationRunError },
+					serviceError: transformationRunError,
 				});
 
 			queryClient.invalidateQueries({

--- a/apps/whispering/src/lib/query/tray.ts
+++ b/apps/whispering/src/lib/query/tray.ts
@@ -1,6 +1,6 @@
 import { Ok, type Result } from 'wellcrafted/result';
 import type { WhisperingRecordingState } from '$lib/constants/audio';
-import { fromTaggedErr, type WhisperingError } from '$lib/result';
+import { WhisperingErr, type WhisperingError } from '$lib/result';
 import * as services from '$lib/services';
 import { defineMutation } from './_client';
 
@@ -19,9 +19,9 @@ export const tray = {
 			const { data, error } = await services.tray.setTrayIcon(icon);
 
 			if (error) {
-				return fromTaggedErr(error, {
+				return WhisperingErr({
 					title: '⚠️ Failed to set tray icon',
-					action: { type: 'more-details', error },
+					serviceError: error,
 				});
 			}
 

--- a/apps/whispering/src/lib/query/vad.svelte.ts
+++ b/apps/whispering/src/lib/query/vad.svelte.ts
@@ -2,7 +2,7 @@ import { MicVAD, utils } from '@ricky0123/vad-web';
 import { extractErrorMessage } from 'wellcrafted/error';
 import { Err, Ok, tryAsync, trySync } from 'wellcrafted/result';
 import type { VadState } from '$lib/constants/audio';
-import { fromTaggedErr, WhisperingErr } from '$lib/result';
+import { WhisperingErr } from '$lib/result';
 import {
 	cleanupRecordingStream,
 	enumerateDevices,
@@ -49,9 +49,9 @@ function createVadRecorder() {
 			queryFn: async () => {
 				const { data, error } = await enumerateDevices();
 				if (error) {
-					return fromTaggedErr(error, {
+					return WhisperingErr({
 						title: '❌ Failed to enumerate devices',
-						action: { type: 'more-details', error },
+						serviceError: error,
 					});
 				}
 				return Ok(data);
@@ -96,9 +96,9 @@ function createVadRecorder() {
 				});
 
 			if (streamError) {
-				return fromTaggedErr(streamError, {
+				return WhisperingErr({
 					title: '❌ Failed to get recording stream',
-					action: { type: 'more-details', error: streamError },
+					serviceError: streamError,
 				});
 			}
 

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/GlobalKeyboardShortcutRecorder.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/GlobalKeyboardShortcutRecorder.svelte
@@ -10,7 +10,6 @@
 	import { type PressedKeys } from '$lib/utils/createPressedKeys.svelte';
 	import KeyboardShortcutRecorder from './KeyboardShortcutRecorder.svelte';
 	import { createKeyRecorder } from './create-key-recorder.svelte';
-	import { fromTaggedError } from '$lib/result';
 
 	const {
 		command,
@@ -100,11 +99,10 @@
 				});
 
 			if (unregisterError) {
-				rpc.notify.error.execute(
-					fromTaggedError(unregisterError, {
-						title: 'Error clearing global shortcut',
-					}),
-				);
+				rpc.notify.error.execute({
+					title: 'Error clearing global shortcut',
+					serviceError: unregisterError,
+				});
 			}
 
 			settings.updateKey(`shortcuts.global.${command.id}`, null);


### PR DESCRIPTION
WhisperingErr now accepts a serviceError field that auto-extracts .message as description and auto-adds the more-details action. This eliminates the fromTaggedError/fromTaggedErr helper functions entirely.

Previously, adapting a service error to a UI error required verbose boilerplate:

```typescript
return Err(fromTaggedError(error, {
  title: '❌ Failed to start recording',
  action: { type: 'more-details', error },
}));
```

Now it's a single line:

```typescript
return WhisperingErr({
  title: '❌ Failed to start recording',
  serviceError: error,
});
```

The normalizeInput function handles extracting .message as description and adding the more-details action automatically when serviceError is provided. Migrated 16 usages across 7 files.