### PR TITLE
refactor(epicenter): use /workspaces prefix for REST API routes

### DIFF
--- a/packages/epicenter/README.md
+++ b/packages/epicenter/README.md
@@ -1369,15 +1369,24 @@ A long-running HTTP server models Epicenter's folder-based architecture:
 
 ### Route Handling
 
-Workspace actions are exposed via REST endpoints:
+Workspace actions are exposed via REST endpoints under the `/workspaces` prefix:
 
 **Query Actions** (HTTP GET):
-- Path: `/{workspaceId}/{actionName}`
+- Path: `/workspaces/{workspaceId}/{actionName}`
 - Input: Query string parameters
 
 **Mutation Actions** (HTTP POST):
-- Path: `/{workspaceId}/{actionName}`
+- Path: `/workspaces/{workspaceId}/{actionName}`
 - Input: JSON request body
+
+**URL Hierarchy:**
+```
+/                                    - API root/discovery
+/openapi                             - OpenAPI spec (JSON)
+/scalar                              - Scalar UI documentation
+/mcp                                 - MCP endpoint
+/workspaces/{workspaceId}/{action}   - Workspace actions
+```
 
 ### Setup
 

--- a/packages/epicenter/src/cli/server.ts
+++ b/packages/epicenter/src/cli/server.ts
@@ -43,7 +43,7 @@ export async function startServer(
 	console.log('📚 REST API Endpoints:\n');
 	for (const { workspaceId, actionPath, action } of iterActions(client)) {
 		const method = ({ query: 'GET', mutation: 'POST' } as const)[action.type];
-		const restPath = `/${workspaceId}/${actionPath.join('/')}`;
+		const restPath = `/workspaces/${workspaceId}/${actionPath.join('/')}`;
 		console.log(`  ${method} http://localhost:${port}${restPath}`);
 	}
 

--- a/packages/epicenter/src/core/epicenter/README.md
+++ b/packages/epicenter/src/core/epicenter/README.md
@@ -42,7 +42,7 @@ const { app, client } = await createServer(config);
 Bun.serve({ fetch: app.fetch, port: 3913 });
 
 // Other processes can now use the HTTP API
-await fetch('http://localhost:3913/pages/createPage', {
+await fetch('http://localhost:3913/workspaces/pages/createPage', {
   method: 'POST',
   body: JSON.stringify({ title: 'New Post', ... }),
 });

--- a/packages/epicenter/src/server/README.md
+++ b/packages/epicenter/src/server/README.md
@@ -81,7 +81,7 @@ If you need to run scripts while the server is running, use the HTTP API instead
 }
 
 // ✅ DO: Use the server's HTTP API
-await fetch('http://localhost:3913/pages/createPage', {
+await fetch('http://localhost:3913/workspaces/pages/createPage', {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
   body: JSON.stringify({ title: 'New Post', content: '...' }),
@@ -138,8 +138,8 @@ Bun.serve({
 
 Now your actions are available as HTTP endpoints:
 
-- `GET http://localhost:3913/getAllPosts`
-- `POST http://localhost:3913/createPost` with JSON body `{ "title": "My Post" }`
+- `GET http://localhost:3913/workspaces/blog/getAllPosts`
+- `POST http://localhost:3913/workspaces/blog/createPost` with JSON body `{ "title": "My Post" }`
 
 ### Multiple Workspaces (Epicenter)
 
@@ -159,11 +159,20 @@ Bun.serve({
 });
 ```
 
-Actions from each workspace get their own namespace:
+Actions from each workspace get their own namespace under `/workspaces`:
 
-- `GET http://localhost:3913/blog/getAllPosts`
-- `POST http://localhost:3913/auth/login`
-- `GET http://localhost:3913/storage/listFiles`
+- `GET http://localhost:3913/workspaces/blog/getAllPosts`
+- `POST http://localhost:3913/workspaces/auth/login`
+- `GET http://localhost:3913/workspaces/storage/listFiles`
+
+**URL Hierarchy:**
+```
+/                                    - API root/discovery
+/openapi                             - OpenAPI spec (JSON)
+/scalar                              - Scalar UI documentation
+/mcp                                 - MCP endpoint
+/workspaces/{workspaceId}/{action}   - Workspace actions
+```
 
 ## How It Works
 
@@ -303,8 +312,8 @@ console.log('Notes API running at http://localhost:8080');
 
 Now you have a fully functional notes API:
 
-- `POST /createNote` - Create notes
-- `GET /searchNotes?query=important` - Search notes
+- `POST /workspaces/notes/createNote` - Create notes
+- `GET /workspaces/notes/searchNotes?query=important` - Search notes
 - `POST /mcp/tools/call` - Let AI create/search notes
 
 ## When to Use This

--- a/packages/epicenter/src/server/server.ts
+++ b/packages/epicenter/src/server/server.ts
@@ -14,9 +14,16 @@ import type { AnyWorkspaceConfig } from '../core/workspace';
  * Create a unified server with REST, MCP, and API documentation endpoints
  *
  * This creates an Elysia server that exposes workspace actions through multiple interfaces:
- * - REST endpoints: GET `/{workspace}/{action}` for queries, POST for mutations
+ * - REST endpoints: GET `/workspaces/{workspace}/{action}` for queries, POST for mutations
  * - MCP endpoint: POST `/mcp` for Model Context Protocol clients (using Server-Sent Events)
  * - API documentation: `/openapi` (Scalar UI by default)
+ *
+ * URL Hierarchy:
+ * - `/` - API root/discovery
+ * - `/openapi` - OpenAPI spec (JSON)
+ * - `/scalar` - Scalar UI documentation
+ * - `/mcp` - MCP endpoint
+ * - `/workspaces/{workspaceId}/{action}` - Workspace actions
  *
  * The function initializes the Epicenter client, registers REST routes for all workspace actions,
  * and configures an MCP server instance for protocol-based access.
@@ -98,9 +105,9 @@ export async function createServer<
 
 	// Register REST endpoints for each workspace action
 	// Supports nested exports: actionPath like ['users', 'crud', 'create']
-	// becomes route path '/workspace/users/crud/create'
+	// becomes route path '/workspaces/workspace/users/crud/create'
 	for (const { workspaceId, actionPath, action } of iterActions(client)) {
-		const path = `/${workspaceId}/${actionPath.join('/')}`;
+		const path = `/workspaces/${workspaceId}/${actionPath.join('/')}`;
 
 		// Tag with both workspace and operation type for multi-dimensional grouping
 		const operationType = (

--- a/packages/epicenter/tests/integration/server.test.ts
+++ b/packages/epicenter/tests/integration/server.test.ts
@@ -15,7 +15,7 @@ import {
 	select,
 	text,
 } from '../../src/index.node';
-import { sqliteIndex } from '../../src/indexes/sqlite';
+import { sqliteProvider } from '../../src/indexes/sqlite';
 
 // Helper to parse SSE response from MCP endpoint
 async function parseMcpResponse(response: Response): Promise<any> {
@@ -31,7 +31,7 @@ describe('Server Integration Tests', () => {
 	const blogWorkspace = defineWorkspace({
 		id: 'blog',
 
-		schema: {
+		tables: {
 			posts: {
 				id: id(),
 				title: text(),
@@ -44,11 +44,11 @@ describe('Server Integration Tests', () => {
 			},
 		},
 
-		indexes: {
-			sqlite: (c) => sqliteIndex(c),
+		providers: {
+			sqlite: (c) => sqliteProvider(c),
 		},
 
-		exports: ({ db, indexes }) => ({
+		exports: ({ tables, providers }) => ({
 			createPost: defineMutation({
 				input: type({
 					title: 'string >= 1',
@@ -65,7 +65,7 @@ describe('Server Integration Tests', () => {
 						views: 0,
 						published: false,
 					};
-					db.posts.upsert(post);
+					tables.posts.upsert(post);
 					return Ok(post);
 				},
 			}),
@@ -73,9 +73,9 @@ describe('Server Integration Tests', () => {
 			getAllPosts: defineQuery({
 				description: 'Get all blog posts',
 				handler: async () => {
-					const posts = await indexes.sqlite.db
+					const posts = await providers.sqlite.db
 						.select()
-						.from(indexes.sqlite.posts);
+						.from(providers.sqlite.posts);
 					return Ok(posts);
 				},
 			}),
@@ -86,10 +86,10 @@ describe('Server Integration Tests', () => {
 				}),
 				description: 'Get posts by category',
 				handler: async ({ category }) => {
-					const posts = await indexes.sqlite.db
+					const posts = await providers.sqlite.db
 						.select()
-						.from(indexes.sqlite.posts)
-						.where(eq(indexes.sqlite.posts.category, category));
+						.from(providers.sqlite.posts)
+						.where(eq(providers.sqlite.posts.category, category));
 					return Ok(posts);
 				},
 			}),
@@ -114,9 +114,9 @@ describe('Server Integration Tests', () => {
 			});
 		});
 
-		test('creates post via POST /blog/createPost', async () => {
+		test('creates post via POST /workspaces/blog/createPost', async () => {
 			const response = await fetch(
-				`http://localhost:${server.port}/blog/createPost`,
+				`http://localhost:${server.port}/workspaces/blog/createPost`,
 				{
 					method: 'POST',
 					headers: { 'Content-Type': 'application/json' },
@@ -135,9 +135,9 @@ describe('Server Integration Tests', () => {
 			expect(data.data.category).toBe('tech');
 		});
 
-		test('gets all posts via GET /blog/getAllPosts', async () => {
+		test('gets all posts via GET /workspaces/blog/getAllPosts', async () => {
 			const response = await fetch(
-				`http://localhost:${server.port}/blog/getAllPosts`,
+				`http://localhost:${server.port}/workspaces/blog/getAllPosts`,
 			);
 
 			expect(response.status).toBe(200);
@@ -146,9 +146,9 @@ describe('Server Integration Tests', () => {
 			expect(Array.isArray(data.data)).toBe(true);
 		});
 
-		test('gets posts by category via GET /blog/getPostsByCategory', async () => {
+		test('gets posts by category via GET /workspaces/blog/getPostsByCategory', async () => {
 			const response = await fetch(
-				`http://localhost:${server.port}/blog/getPostsByCategory?category=tech`,
+				`http://localhost:${server.port}/workspaces/blog/getPostsByCategory?category=tech`,
 			);
 
 			expect(response.status).toBe(200);
@@ -236,7 +236,7 @@ describe('Server Integration Tests', () => {
 		const authWorkspace = defineWorkspace({
 			id: 'auth',
 
-			schema: {
+			tables: {
 				users: {
 					id: id(),
 					email: text(),
@@ -244,14 +244,14 @@ describe('Server Integration Tests', () => {
 				},
 			},
 
-			indexes: {
-				sqlite: (db) =>
-					sqliteIndex(db, {
+			providers: {
+				sqlite: (c) =>
+					sqliteProvider(c, {
 						database: ':memory:',
 					}),
 			},
 
-			exports: ({ db }) => ({
+			exports: ({ tables }) => ({
 				createUser: defineMutation({
 					input: type({
 						email: 'string',
@@ -263,7 +263,7 @@ describe('Server Integration Tests', () => {
 							id: generateId(),
 							...input,
 						};
-						db.users.upsert(user);
+						tables.users.upsert(user);
 						return Ok(user);
 					},
 				}),
@@ -287,9 +287,9 @@ describe('Server Integration Tests', () => {
 			});
 		});
 
-		test('creates post via POST /blog/createPost', async () => {
+		test('creates post via POST /workspaces/blog/createPost', async () => {
 			const response = await fetch(
-				`http://localhost:${server.port}/blog/createPost`,
+				`http://localhost:${server.port}/workspaces/blog/createPost`,
 				{
 					method: 'POST',
 					headers: { 'Content-Type': 'application/json' },
@@ -305,9 +305,9 @@ describe('Server Integration Tests', () => {
 			expect(data.data.title).toBe('Epicenter Test');
 		});
 
-		test('creates user via POST /auth/createUser', async () => {
+		test('creates user via POST /workspaces/auth/createUser', async () => {
 			const response = await fetch(
-				`http://localhost:${server.port}/auth/createUser`,
+				`http://localhost:${server.port}/workspaces/auth/createUser`,
 				{
 					method: 'POST',
 					headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
This changes the URL pattern for workspace actions from `/{workspaceId}/{action}` to `/workspaces/{workspaceId}/{action}`.

The motivation is to create a cleaner, more RESTful URL hierarchy that separates workspace actions from reserved system endpoints. The new hierarchy:

```
/                                    - API root/discovery
/openapi                             - OpenAPI spec (JSON)
/scalar                              - Scalar UI documentation
/mcp                                 - MCP endpoint
/workspaces/{workspaceId}/{action}   - Workspace actions
```

This prevents potential collisions if a workspace ID happens to match a reserved endpoint name, and follows more standard REST conventions where resources are grouped under a plural noun prefix.

The implementation updates the route registration in server.ts, the console output in cli/server.ts, all relevant documentation in READMEs, and the integration tests. Also fixed the integration tests to use the current API (`tables`/`providers` instead of the deprecated `schema`/`indexes`).