### PR TITLE
feat(transcription): upgrade transcribe-rs and add initial_prompt support

### DIFF
--- a/apps/whispering/src-tauri/Cargo.lock
+++ b/apps/whispering/src-tauri/Cargo.lock
@@ -400,25 +400,22 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
+version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
  "itertools",
- "lazy_static",
- "lazycell",
  "log",
  "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "shlex",
  "syn 2.0.111",
- "which",
 ]
 
 [[package]]
@@ -2742,12 +2739,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4245,7 +4236,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "socket2",
  "thiserror 2.0.17",
@@ -4265,7 +4256,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -4701,12 +4692,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -6482,9 +6467,9 @@ dependencies = [
 
 [[package]]
 name = "transcribe-rs"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856646076d3d9739998ba693ebfff3afe95c0cdb71d4fead32e761b11496094f"
+checksum = "f01738c67d77f6dc84be57e376ec32f846c177c492e46f9685bdb2801870fe84"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -7084,31 +7069,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
-
-[[package]]
 name = "whisper-rs"
-version = "0.13.2"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6fc553156b521663bfa8e713e7ad58c7ca262d46de9998cd7f2e4de5ba0d9"
+checksum = "71ea5d2401f30f51d08126a2d133fee4c1955136519d7ac6cf6f5ac0a91e6bc8"
 dependencies = [
+ "libc",
  "whisper-rs-sys",
 ]
 
 [[package]]
 name = "whisper-rs-sys"
-version = "0.11.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bab42b2c319e3a1e0280137c59368072348d3277873c7588b6466a127dca58"
+checksum = "b5e2a6e06e7ac7b8f53c53a5f50bb0bc823ba69b63ecd887339f807a5598bbd2"
 dependencies = [
  "bindgen",
  "cfg-if",

--- a/apps/whispering/src-tauri/Cargo.toml
+++ b/apps/whispering/src-tauri/Cargo.toml
@@ -48,7 +48,7 @@ tempfile = "3.8"
 rubato = "0.15"
 tauri-plugin-macos-permissions = "2.3.0"
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
-transcribe-rs = "0.1.0"
+transcribe-rs = "0.1.5"
 regex = "1"
 rayon = "1.10"
 log = "0.4"

--- a/apps/whispering/src-tauri/src/transcription/mod.rs
+++ b/apps/whispering/src-tauri/src/transcription/mod.rs
@@ -490,6 +490,7 @@ pub async fn transcribe_audio_whisper(
     audio_data: Vec<u8>,
     model_path: String,
     language: Option<String>,
+    initial_prompt: Option<String>,
     model_manager: tauri::State<'_, ModelManager>,
 ) -> Result<String, TranscriptionError> {
     info!(
@@ -527,6 +528,7 @@ pub async fn transcribe_audio_whisper(
     // Configure inference parameters
     let mut params = WhisperInferenceParams::default();
     params.language = language;
+    params.initial_prompt = initial_prompt;
     params.print_special = false;
     params.print_progress = false;
     params.print_realtime = false;

--- a/apps/whispering/src/lib/query/transcription.ts
+++ b/apps/whispering/src/lib/query/transcription.ts
@@ -253,6 +253,7 @@ async function transcribeBlob(
 						{
 							outputLanguage: settings.value['transcription.outputLanguage'],
 							modelPath: settings.value['transcription.whispercpp.modelPath'],
+							prompt: settings.value['transcription.prompt'],
 						},
 					);
 				}

--- a/apps/whispering/src/lib/services/transcription/local/whispercpp.ts
+++ b/apps/whispering/src/lib/services/transcription/local/whispercpp.ts
@@ -74,6 +74,7 @@ export function createWhisperCppTranscriptionService() {
 			options: {
 				outputLanguage: Settings['transcription.outputLanguage'];
 				modelPath: string;
+				prompt: Settings['transcription.prompt'];
 			},
 		): Promise<Result<string, WhisperingError>> {
 			// Pre-validation
@@ -137,7 +138,7 @@ export function createWhisperCppTranscriptionService() {
 			const audioData = Array.from(new Uint8Array(arrayBuffer));
 
 			// Call Tauri command to transcribe with whisper-cpp
-			// Note: temperature and prompt are not supported by local models (transcribe-rs)
+			// Note: temperature is not supported by local models (transcribe-rs)
 			const result = await tryAsync({
 				try: () =>
 					invoke<string>('transcribe_audio_whisper', {
@@ -145,6 +146,7 @@ export function createWhisperCppTranscriptionService() {
 						modelPath: options.modelPath,
 						language:
 							options.outputLanguage === 'auto' ? null : options.outputLanguage,
+						initialPrompt: options.prompt || null,
 					}),
 				catch: (unknownError) => {
 					const result = WhisperCppErrorType(unknownError);

--- a/apps/whispering/src/lib/services/transcription/registry.ts
+++ b/apps/whispering/src/lib/services/transcription/registry.ts
@@ -193,11 +193,37 @@ export type TranscriptionService = (typeof TRANSCRIPTION_SERVICES)[number];
  * Used to conditionally enable/disable UI elements based on what each service supports.
  */
 type ServiceCapabilities = {
+	/**
+	 * Whether the service accepts a system prompt / initial prompt for context.
+	 * Prompts help the model recognize domain-specific terms, names, or style.
+	 * Example: "This is a medical consultation discussing myocardial infarction."
+	 */
 	supportsPrompt: boolean;
+	/**
+	 * Whether the service accepts a temperature parameter (0.0-1.0).
+	 * Temperature controls randomness: 0 is deterministic, 1 is more creative.
+	 * Local models (transcribe-rs) do not support this parameter.
+	 */
 	supportsTemperature: boolean;
+	/**
+	 * Whether the service accepts a target language hint.
+	 * When false, the service auto-detects the language (e.g., Parakeet).
+	 */
 	supportsLanguage: boolean;
 };
 
+/**
+ * Declares what features each transcription service supports.
+ *
+ * Use this to conditionally enable/disable UI elements based on the
+ * currently selected service. Lookup by service ID:
+ *
+ * @example
+ * ```ts
+ * const caps = TRANSCRIPTION_SERVICE_CAPABILITIES[selectedServiceId];
+ * if (caps.supportsPrompt) { ... }
+ * ```
+ */
 export const TRANSCRIPTION_SERVICE_CAPABILITIES = {
 	whispercpp: { supportsPrompt: true, supportsTemperature: false, supportsLanguage: true },
 	parakeet: { supportsPrompt: false, supportsTemperature: false, supportsLanguage: false },

--- a/apps/whispering/src/lib/services/transcription/registry.ts
+++ b/apps/whispering/src/lib/services/transcription/registry.ts
@@ -187,3 +187,24 @@ export const TRANSCRIPTION_SERVICE_OPTIONS = TRANSCRIPTION_SERVICES.map(
 );
 
 export type TranscriptionService = (typeof TRANSCRIPTION_SERVICES)[number];
+
+/**
+ * Feature capabilities for each transcription service.
+ * Used to conditionally enable/disable UI elements based on what each service supports.
+ */
+type ServiceCapabilities = {
+	supportsPrompt: boolean;
+	supportsTemperature: boolean;
+	supportsLanguage: boolean;
+};
+
+export const TRANSCRIPTION_SERVICE_CAPABILITIES = {
+	whispercpp: { supportsPrompt: true, supportsTemperature: false, supportsLanguage: true },
+	parakeet: { supportsPrompt: false, supportsTemperature: false, supportsLanguage: false },
+	Groq: { supportsPrompt: true, supportsTemperature: true, supportsLanguage: true },
+	OpenAI: { supportsPrompt: true, supportsTemperature: true, supportsLanguage: true },
+	ElevenLabs: { supportsPrompt: true, supportsTemperature: true, supportsLanguage: true },
+	Deepgram: { supportsPrompt: true, supportsTemperature: true, supportsLanguage: true },
+	Mistral: { supportsPrompt: true, supportsTemperature: true, supportsLanguage: true },
+	speaches: { supportsPrompt: true, supportsTemperature: true, supportsLanguage: true },
+} as const satisfies Record<TranscriptionServiceId, ServiceCapabilities>;

--- a/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
@@ -36,7 +36,11 @@
 
 	const { data } = $props();
 
-	const serviceCapabilities = $derived(
+	/**
+	 * Feature capabilities for the currently selected transcription service.
+	 * Used to conditionally disable UI fields that aren't supported by the service.
+	 */
+	const currentServiceCapabilities = $derived(
 		TRANSCRIPTION_SERVICE_CAPABILITIES[
 			settings.value['transcription.selectedTranscriptionService']
 		],
@@ -657,7 +661,7 @@
 				() => settings.value['transcription.outputLanguage'],
 				(v) => settings.updateKey('transcription.outputLanguage', v)
 			}
-			disabled={!serviceCapabilities.supportsLanguage}
+			disabled={!currentServiceCapabilities.supportsLanguage}
 		>
 			<Select.Trigger id="output-language" class="w-full">
 				{outputLanguageLabel ?? 'Select a language'}
@@ -668,7 +672,7 @@
 				{/each}
 			</Select.Content>
 		</Select.Root>
-		{#if !serviceCapabilities.supportsLanguage}
+		{#if !currentServiceCapabilities.supportsLanguage}
 			<Field.Description>
 				Parakeet automatically detects the language
 			</Field.Description>
@@ -685,7 +689,7 @@
 			step="0.1"
 			placeholder="0"
 			autocomplete="off"
-			disabled={!serviceCapabilities.supportsTemperature}
+			disabled={!currentServiceCapabilities.supportsTemperature}
 			bind:value={
 				() => settings.value['transcription.temperature'],
 				(value) =>
@@ -693,7 +697,7 @@
 			}
 		/>
 		<Field.Description>
-			{serviceCapabilities.supportsTemperature
+			{currentServiceCapabilities.supportsTemperature
 				? "Controls randomness in the model's output. 0 is focused and deterministic, 1 is more creative."
 				: 'Temperature is not supported for local models (transcribe-rs)'}
 		</Field.Description>
@@ -704,14 +708,14 @@
 		<Textarea
 			id="transcription-prompt"
 			placeholder="e.g., This is an academic lecture about quantum physics with technical terms like 'eigenvalue' and 'Schrödinger'"
-			disabled={!serviceCapabilities.supportsPrompt}
+			disabled={!currentServiceCapabilities.supportsPrompt}
 			bind:value={
 				() => settings.value['transcription.prompt'],
 				(value) => settings.updateKey('transcription.prompt', value)
 			}
 		/>
 		<Field.Description>
-			{serviceCapabilities.supportsPrompt
+			{currentServiceCapabilities.supportsPrompt
 				? 'Helps transcription service (e.g., Whisper) better recognize specific terms, names, or context during initial transcription. Not for text transformations - use the Transformations tab for post-processing rules.'
 				: 'System prompt is not supported for Parakeet'}
 		</Field.Description>

--- a/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
@@ -35,12 +35,17 @@
 
 	const { data } = $props();
 
-	// Prompt and temperature are not supported for local models like transcribe-rs (whispercpp/parakeet)
-	const isPromptAndTemperatureNotSupported = $derived(
+	// Temperature is not supported for local models like transcribe-rs (whispercpp/parakeet)
+	const isTemperatureNotSupported = $derived(
 		settings.value['transcription.selectedTranscriptionService'] ===
 			'whispercpp' ||
 			settings.value['transcription.selectedTranscriptionService'] ===
 				'parakeet',
+	);
+
+	// Prompt is not supported for parakeet (but now supported for whispercpp via initial_prompt)
+	const isPromptNotSupported = $derived(
+		settings.value['transcription.selectedTranscriptionService'] === 'parakeet',
 	);
 
 	// Parakeet doesn't support language selection (auto-detect only)
@@ -691,7 +696,7 @@
 			step="0.1"
 			placeholder="0"
 			autocomplete="off"
-			disabled={isPromptAndTemperatureNotSupported}
+			disabled={isTemperatureNotSupported}
 			bind:value={
 				() => settings.value['transcription.temperature'],
 				(value) =>
@@ -699,7 +704,7 @@
 			}
 		/>
 		<Field.Description>
-			{isPromptAndTemperatureNotSupported
+			{isTemperatureNotSupported
 				? 'Temperature is not supported for local models (transcribe-rs)'
 				: "Controls randomness in the model's output. 0 is focused and deterministic, 1 is more creative."}
 		</Field.Description>
@@ -710,15 +715,15 @@
 		<Textarea
 			id="transcription-prompt"
 			placeholder="e.g., This is an academic lecture about quantum physics with technical terms like 'eigenvalue' and 'Schrödinger'"
-			disabled={isPromptAndTemperatureNotSupported}
+			disabled={isPromptNotSupported}
 			bind:value={
 				() => settings.value['transcription.prompt'],
 				(value) => settings.updateKey('transcription.prompt', value)
 			}
 		/>
 		<Field.Description>
-			{isPromptAndTemperatureNotSupported
-				? 'System prompt is not supported for local models (transcribe-rs)'
+			{isPromptNotSupported
+				? 'System prompt is not supported for Parakeet'
 				: 'Helps transcription service (e.g., Whisper) better recognize specific terms, names, or context during initial transcription. Not for text transformations - use the Transformations tab for post-processing rules.'}
 		</Field.Description>
 	</Field.Field>


### PR DESCRIPTION
This change upgrades transcribe-rs from version 0.1.0 to 0.1.5, which resolves critical crash issues affecting users on Linux and Windows systems with older CPUs (#914). The crashes manifested as illegal instruction errors (SIGILL) when users attempted to use Whisper C++ for transcription. The underlying issue was in whisper-rs 0.13.2, which compiled whisper.cpp with CPU-specific optimizations that weren't compatible with all processors. The upgrade to whisper-rs 0.15.1 eliminates this problem by removing the aggressive optimization flags that caused the crashes.

Beyond fixing the crash, this upgrade unlocks the initial_prompt feature for local Whisper C++ transcription. Users can now provide system prompts to improve transcription accuracy for domain-specific content, technical terms, speaker names, or stylistic preferences. The implementation passes the user's System Prompt setting through the Rust Tauri command to the whisper-rs library, which uses it to provide context during transcription. This feature was already available in cloud-based providers but was missing from local transcription.

To support the new feature properly, I refactored the service capability checking system. Previously, the settings UI used scattered negative conditions to determine which fields to show for each provider. This approach was error-prone and made it difficult to enable System Prompt for Whisper C++ without breaking other checks. The new implementation introduces a centralized TRANSCRIPTION_SERVICE_CAPABILITIES registry where each service explicitly declares its capabilities through a type-safe object. This makes it clear which features each service supports and provides a single source of truth for the settings UI to reference.

The changes span both the Rust backend and TypeScript frontend. On the Rust side, the transcribe_audio_whisper command now accepts an optional initial_prompt parameter that gets passed to the WhisperParams builder. On the TypeScript side, the whispercpp service now includes the system prompt in its transcription requests, and the settings page references the new capabilities registry to determine which input fields to display. The refactoring ensures that future capability additions will be simpler and less prone to bugs.