### PR TITLE
feat(whispering): show mode-specific instructions

### DIFF
--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -320,35 +320,72 @@
 	{/if}
 
 	<div class="xs:flex hidden flex-col items-center gap-3">
-		<p class="text-foreground/75 text-center text-sm">
-			Click the microphone or press
-			{' '}<Link
-				tooltip="Go to local shortcut in settings"
-				href="/settings/shortcuts/local"
-			>
-				<Kbd.Root
-					>{getShortcutDisplayLabel(
-						settings.value['shortcuts.local.toggleManualRecording'],
-					)}</Kbd.Root
-				>
-			</Link>{' '}
-			to start recording here.
-		</p>
-		{#if window.__TAURI_INTERNALS__}
-			<p class="text-foreground/75 text-sm">
-				Press
+		{#if settings.value['recording.mode'] === 'manual'}
+			<p class="text-foreground/75 text-center text-sm">
+				Click the microphone or press
 				{' '}<Link
-					tooltip="Go to global shortcut in settings"
-					href="/settings/shortcuts/global"
+					tooltip="Go to local shortcut in settings"
+					href="/settings/shortcuts/local"
 				>
 					<Kbd.Root
 						>{getShortcutDisplayLabel(
-							settings.value['shortcuts.global.toggleManualRecording'],
+							settings.value['shortcuts.local.toggleManualRecording'],
 						)}</Kbd.Root
 					>
 				</Link>{' '}
-				to start recording anywhere.
+				to start recording here.
 			</p>
+			{#if window.__TAURI_INTERNALS__}
+				<p class="text-foreground/75 text-sm">
+					Press
+					{' '}<Link
+						tooltip="Go to global shortcut in settings"
+						href="/settings/shortcuts/global"
+					>
+						<Kbd.Root
+							>{getShortcutDisplayLabel(
+								settings.value['shortcuts.global.toggleManualRecording'],
+							)}</Kbd.Root
+						>
+					</Link>{' '}
+					to start recording anywhere.
+				</p>
+			{/if}
+		{:else if settings.value['recording.mode'] === 'vad'}
+			<p class="text-foreground/75 text-center text-sm">
+				Click the microphone or press
+				{' '}<Link
+					tooltip="Go to local shortcut in settings"
+					href="/settings/shortcuts/local"
+				>
+					<Kbd.Root
+						>{getShortcutDisplayLabel(
+							settings.value['shortcuts.local.toggleVadRecording'],
+						)}</Kbd.Root
+					>
+				</Link>{' '}
+				to start a voice activated session.
+			</p>
+		{:else if settings.value['recording.mode'] === 'upload'}
+			<p class="text-foreground/75 text-center text-sm">
+				Drag files here or click to browse.
+			</p>
+			{#if window.__TAURI_INTERNALS__}
+				<p class="text-foreground/75 text-sm">
+					Press
+					{' '}<Link
+						tooltip="Go to global shortcut in settings"
+						href="/settings/shortcuts/global"
+					>
+						<Kbd.Root
+							>{getShortcutDisplayLabel(
+								settings.value['shortcuts.global.toggleManualRecording'],
+							)}</Kbd.Root
+						>
+					</Link>{' '}
+					to start recording instead.
+				</p>
+			{/if}
 		{/if}
 		<p class="text-muted-foreground text-center text-sm font-light">
 			{#if !window.__TAURI_INTERNALS__}


### PR DESCRIPTION
The instruction text at the bottom of the home page now updates based on the selected recording mode rather than always showing manual recording instructions.

Previously, users selecting 'Upload File' mode would see confusing instructions like 'Click the microphone or press Space to start recording' even though there's no microphone in that mode.

Now each mode shows appropriate instructions:
- **Manual**: Click the microphone or press `Space` to start recording here. Press global shortcut to start recording anywhere.
- **Voice Activated**: Click the microphone or press `V` to start a voice activated session.
- **Upload File**: Drag files here or click to browse. Press global shortcut to start recording instead.

Thanks to @thisisharsh7 for the idea and implementation! Included as a co-author 🔥

<img width="2430" height="1080" alt="image" src="https://github.com/user-attachments/assets/21579f93-029a-4525-aacb-00dd8b5e9a1c" />
