### PR TITLE
refactor: remove redundant type annotations from JSDoc comments

### DIFF
--- a/apps/whispering/src/lib/services/ffmpeg/web.ts
+++ b/apps/whispering/src/lib/services/ffmpeg/web.ts
@@ -6,17 +6,12 @@ import { FfmpegServiceErr } from './types';
  * Creates a web-compatible FFmpeg service implementation.
  * This service provides stub implementations that indicate FFmpeg operations
  * are not supported in web environments.
- *
- * @returns {FfmpegService} A service object with methods that return appropriate
- *   responses for web environments where FFmpeg is not available
  */
 export function createFfmpegServiceWeb(): FfmpegService {
 	return {
 		/**
 		 * Checks if FFmpeg is installed on the system.
 		 * Always returns false for web environments since FFmpeg is not available.
-		 *
-		 * @returns {Promise<Ok<boolean>>} Promise resolving to Ok(false)
 		 */
 		async checkInstalled() {
 			// FFmpeg check is not available in web version, assume not installed
@@ -27,9 +22,8 @@ export function createFfmpegServiceWeb(): FfmpegService {
 		 * Attempts to compress an audio blob using FFmpeg.
 		 * Always returns an error for web environments since FFmpeg is not available.
 		 *
-		 * @param {Blob} _blob - The audio blob to compress (unused in web version)
-		 * @param {string} compressionOptions - The compression options to apply
-		 * @returns {FfmpegServiceErr} Error indicating compression is not available in web version
+		 * @param _blob - The audio blob to compress (unused in web version)
+		 * @param compressionOptions - The compression options to apply
 		 */
 		async compressAudioBlob(_blob: Blob, compressionOptions: string) {
 			// Audio compression is not available in web version

--- a/apps/whispering/src/lib/services/notifications/desktop.ts
+++ b/apps/whispering/src/lib/services/notifications/desktop.ts
@@ -19,16 +19,13 @@ import {
 /**
  * Creates a desktop notification service implementation using Tauri's notification plugin.
  * Handles permission requests, notification display, and cleanup of active notifications.
- *
- * @returns {NotificationService} A notification service with notify and clear methods
  */
 export function createNotificationServiceDesktop(): NotificationService {
 	/**
 	 * Removes a notification by its numeric ID from the active notifications list.
 	 * Retrieves all active notifications, finds the matching one, and removes it if found.
 	 *
-	 * @param {number} id - The numeric ID of the notification to remove
-	 * @returns {Promise<Result<void, NotificationServiceError>>} Success result or error details
+	 * @param id - The numeric ID of the notification to remove
 	 */
 	const removeNotificationById = async (
 		id: number,
@@ -64,8 +61,7 @@ export function createNotificationServiceDesktop(): NotificationService {
 		 * Generates a unique ID if none provided, requests permissions if needed,
 		 * removes any existing notification with the same ID, then sends the new notification.
 		 *
-		 * @param {UnifiedNotificationOptions} options - Notification configuration including title, description, and optional ID
-		 * @returns {Promise<Result<string, NotificationServiceError>>} The notification ID string or error details
+		 * @param options - Notification configuration including title, description, and optional ID
 		 */
 		async notify(options: UnifiedNotificationOptions) {
 			const idStringified = options.id ?? nanoid();
@@ -100,8 +96,7 @@ export function createNotificationServiceDesktop(): NotificationService {
 		 * Clears a notification by its string ID.
 		 * Converts the string ID to a numeric hash and removes the corresponding notification.
 		 *
-		 * @param {string} idStringified - The string ID of the notification to clear
-		 * @returns {Promise<Result<void, NotificationServiceError>>} Success result or error details
+		 * @param idStringified - The string ID of the notification to clear
 		 */
 		clear: async (idStringified) => {
 			const removeNotificationResult = await removeNotificationById(

--- a/apps/whispering/src/lib/services/notifications/web.ts
+++ b/apps/whispering/src/lib/services/notifications/web.ts
@@ -7,8 +7,6 @@ import { NotificationServiceErr, toBrowserNotification } from './types';
 /**
  * Creates a web-based notification service that handles browser notifications
  * with fallback support for extension-based notifications.
- *
- * @returns {NotificationService} A notification service instance with notify and clear methods
  */
 export function createNotificationServiceWeb(): NotificationService {
 	// Cache extension detection result
@@ -18,8 +16,6 @@ export function createNotificationServiceWeb(): NotificationService {
 	/**
 	 * Detects if a browser extension is available for enhanced notification support.
 	 * Results are cached to avoid repeated detection attempts.
-	 *
-	 * @returns {Promise<boolean>} True if extension is available, false otherwise
 	 */
 	const detectExtension = async (): Promise<boolean> => {
 		if (extensionChecked) return hasExtension;
@@ -38,8 +34,7 @@ export function createNotificationServiceWeb(): NotificationService {
 		 * Sends a notification using the best available method (extension or browser API).
 		 * Automatically handles permission requests and converts unified options to browser format.
 		 *
-		 * @param {UnifiedNotificationOptions} options - Notification configuration including title, body, and actions
-		 * @returns {Promise<Result<string, NotificationServiceError>>} Success with notification ID or error
+		 * @param options - Notification configuration including title, body, and actions
 		 */
 		async notify(options: UnifiedNotificationOptions) {
 			const notificationId = options.id ?? nanoid();
@@ -110,8 +105,7 @@ export function createNotificationServiceWeb(): NotificationService {
 		 * Clears a notification by ID. Currently a no-op for browser notifications
 		 * as they don't provide a direct clear API.
 		 *
-		 * @param {string} id - The notification ID to clear
-		 * @returns {Promise<Result<undefined, NotificationServiceError>>} Success or error result
+		 * @param _id - The notification ID to clear (unused, browser notifications auto-dismiss)
 		 */
 		async clear(_id: string) {
 			// Browser notifications don't have a direct clear API

--- a/apps/whispering/src/lib/services/recorder/cpal.ts
+++ b/apps/whispering/src/lib/services/recorder/cpal.ts
@@ -30,14 +30,10 @@ type AudioRecording = {
  * Creates a CPAL recorder service that interfaces with Rust audio recording methods.
  * This service handles device enumeration, recording start/stop operations, and file management
  * for desktop audio recording using the CPAL library.
- *
- * @returns {RecorderService} A recorder service instance with methods for audio recording operations
  */
 export function createCpalRecorderService(): RecorderService {
 	/**
 	 * Enumerates available recording devices from the system.
-	 *
-	 * @returns {Promise<Result<Device[], RecorderServiceError>>} A promise that resolves to either a list of available devices or an error
 	 */
 	const enumerateDevices = async (): Promise<
 		Result<Device[], RecorderServiceError>
@@ -61,8 +57,6 @@ export function createCpalRecorderService(): RecorderService {
 	return {
 		/**
 		 * Gets the current state of the recorder.
-		 *
-		 * @returns {Promise<Result<WhisperingRecordingState, RecorderServiceError>>} A promise that resolves to either 'RECORDING' or 'IDLE' state, or an error
 		 */
 		getRecorderState: async (): Promise<
 			Result<WhisperingRecordingState, RecorderServiceError>
@@ -85,10 +79,8 @@ export function createCpalRecorderService(): RecorderService {
 		 * Starts a recording session with the specified parameters.
 		 * Handles device selection, fallback logic, and recording initialization.
 		 *
-		 * @param {CpalRecordingParams} params - Recording parameters including device ID, recording ID, output folder, and sample rate
-		 * @param {Object} callbacks - Callback functions for status updates
-		 * @param {Function} callbacks.sendStatus - Function to send status updates during the recording process
-		 * @returns {Promise<Result<DeviceAcquisitionOutcome, RecorderServiceError>>} A promise that resolves to device acquisition outcome or an error
+		 * @param params - Recording parameters including device ID, recording ID, output folder, and sample rate
+		 * @param callbacks - Callback functions for status updates
 		 */
 		startRecording: async (
 			{
@@ -104,8 +96,6 @@ export function createCpalRecorderService(): RecorderService {
 
 			/**
 			 * Acquires a recording device, either the selected one or a fallback.
-			 *
-			 * @returns {Result<DeviceAcquisitionOutcome, RecorderServiceError>} The device acquisition result
 			 */
 			const acquireDevice = (): Result<
 				DeviceAcquisitionOutcome,
@@ -207,9 +197,7 @@ export function createCpalRecorderService(): RecorderService {
 		 * Stops the current recording session and returns the recorded audio as a Blob.
 		 * Handles file reading, session cleanup, and resource management.
 		 *
-		 * @param {Object} callbacks - Callback functions for status updates
-		 * @param {Function} callbacks.sendStatus - Function to send status updates during the stop process
-		 * @returns {Promise<Result<Blob, RecorderServiceError>>} A promise that resolves to the recorded audio blob or an error
+		 * @param callbacks - Callback functions for status updates
 		 */
 		stopRecording: async ({
 			sendStatus,
@@ -263,9 +251,7 @@ export function createCpalRecorderService(): RecorderService {
 		 * Cancels the current recording session and cleans up resources.
 		 * Deletes any temporary recording files and closes the recording session.
 		 *
-		 * @param {Object} callbacks - Callback functions for status updates
-		 * @param {Function} callbacks.sendStatus - Function to send status updates during the cancel process
-		 * @returns {Promise<Result<CancelRecordingResult, RecorderServiceError>>} A promise that resolves to the cancellation result or an error
+		 * @param callbacks - Callback functions for status updates
 		 */
 		cancelRecording: async ({
 			sendStatus,
@@ -341,10 +327,8 @@ export const CpalRecorderServiceLive = createCpalRecorderService();
  * Wrapper function for Tauri invoke calls that handles errors consistently.
  * Converts Tauri invoke calls into Result types for better error handling.
  *
- * @template T - The expected return type from the Tauri command
- * @param {string} command - The Tauri command to invoke
- * @param {Record<string, unknown>} [args] - Optional arguments to pass to the command
- * @returns {Promise<Result<T, {name: 'TauriInvokeError', command: string, error: unknown}>>} A promise that resolves to either the command result or a structured error
+ * @param command - The Tauri command to invoke
+ * @param args - Optional arguments to pass to the command
  */
 async function invoke<T>(command: string, args?: Record<string, unknown>) {
 	return tryAsync({

--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -59,8 +59,8 @@
 
 	/**
 	 * Returns a cell renderer for a date/time column using date-fns format.
-	 * @param {string} formatString - date-fns format string
-	 * @returns {(args: { getValue: () => string }) => string}
+	 *
+	 * @param formatString - date-fns format string
 	 */
 	function formattedCell(formatString: string) {
 		return ({ getValue }: { getValue: () => string }) => {


### PR DESCRIPTION
TypeScript already provides type information through function signatures, making explicit `{type}` annotations in JSDoc redundant and prone to becoming outdated.

This removes them in favor of simpler `@param name - description` format, which follows TSDoc conventions for TypeScript projects.

Files updated:
- `notifications/web.ts`
- `notifications/desktop.ts`
- `recorder/cpal.ts`
- `ffmpeg/web.ts`
- `recordings/+page.svelte`