### PR TITLE
Whispering: add global hotkeys to set output language

### DIFF
--- a/apps/whispering/src/lib/commands.ts
+++ b/apps/whispering/src/lib/commands.ts
@@ -96,6 +96,24 @@ export const commands = [
 		callback: () =>
 			rpc.commands.runTransformationOnClipboard.execute(undefined),
 	},
+	{
+		id: 'setOutputLanguageEn',
+		title: 'Set output language to English',
+		on: ['Pressed'],
+		callback: () => rpc.commands.setOutputLanguage.execute({ language: 'en' }),
+	},
+	{
+		id: 'setOutputLanguageJa',
+		title: 'Set output language to Japanese',
+		on: ['Pressed'],
+		callback: () => rpc.commands.setOutputLanguage.execute({ language: 'ja' }),
+	},
+	{
+		id: 'setOutputLanguageZh',
+		title: 'Set output language to Chinese',
+		on: ['Pressed'],
+		callback: () => rpc.commands.setOutputLanguage.execute({ language: 'zh' }),
+	},
 ] as const satisfies SatisfiedCommand[];
 
 export type Command = (typeof commands)[number];

--- a/apps/whispering/src/lib/query/actions.ts
+++ b/apps/whispering/src/lib/query/actions.ts
@@ -1,5 +1,6 @@
 import { nanoid } from 'nanoid/non-secure';
 import { Ok } from 'wellcrafted/result';
+import type { SupportedLanguage } from '$lib/constants/languages';
 import { WhisperingErr } from '$lib/result';
 import { DbServiceErr } from '$lib/services/db';
 import { settings } from '$lib/stores/settings.svelte';
@@ -580,6 +581,14 @@ export const commands = {
 		},
 		onError: (error) => {
 			notify.error.execute(error);
+		},
+	}),
+
+	setOutputLanguage: defineMutation({
+		mutationKey: ['commands', 'setOutputLanguage'] as const,
+		mutationFn: async ({ language }: { language: SupportedLanguage }) => {
+			settings.updateKey('transcription.outputLanguage', language);
+			return Ok(undefined);
 		},
 	}),
 };

--- a/apps/whispering/src/lib/settings/settings.ts
+++ b/apps/whispering/src/lib/settings/settings.ts
@@ -241,6 +241,9 @@ export const Settings = type({
 	'shortcuts.local.pushToTalk': "string | null = 'p'",
 	'shortcuts.local.openTransformationPicker': "string | null = 't'",
 	'shortcuts.local.runTransformationOnClipboard': "string | null = 'r'",
+	'shortcuts.local.setOutputLanguageEn': 'string | null = null',
+	'shortcuts.local.setOutputLanguageJa': 'string | null = null',
+	'shortcuts.local.setOutputLanguageZh': 'string | null = null',
 
 	// Global shortcuts (system-wide shortcuts)
 	'shortcuts.global.toggleManualRecording': type('string | null').default(
@@ -263,6 +266,15 @@ export const Settings = type({
 	'shortcuts.global.runTransformationOnClipboard': type(
 		'string | null',
 	).default(`${CommandOrControl}+Shift+R`),
+	'shortcuts.global.setOutputLanguageEn': type('string | null').default(
+		'Shift+F1',
+	),
+	'shortcuts.global.setOutputLanguageJa': type('string | null').default(
+		'Shift+F2',
+	),
+	'shortcuts.global.setOutputLanguageZh': type('string | null').default(
+		'Shift+F3',
+	),
 });
 
 /**


### PR DESCRIPTION
Adds three new commands to quickly set transcription output language:\n\n- Shift+F1 → en\n- Shift+F2 → ja\n- Shift+F3 → zh\n\nThese defaults are configurable in Settings → Shortcuts → Global.