### PR TITLE
fix(whispering): prevent white flash on startup in dark mode

### DIFF
--- a/apps/whispering/src/app.html
+++ b/apps/whispering/src/app.html
@@ -5,6 +5,7 @@
 		<link rel="icon" href="%sveltekit.assets%/favicon.ico" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Whispering</title>
+		<link rel="stylesheet" href="%sveltekit.assets%/darkmode-bootstrap.css" />
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/apps/whispering/static/darkmode-bootstrap.css
+++ b/apps/whispering/static/darkmode-bootstrap.css
@@ -1,0 +1,6 @@
+@media (prefers-color-scheme: dark) {
+	:root {
+		/* Must match --background in @epicenter/ui dark theme */
+		background-color: oklch(0.129 0.042 264.695);
+	}
+}

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -69,6 +69,7 @@
 
 .dark {
 	--font-sans: "Manrope Variable", sans-serif;
+	/* Sync with: apps/whispering/static/darkmode-bootstrap.css */
 	--background: oklch(0.129 0.042 264.695);
 	--foreground: oklch(0.984 0.003 247.858);
 	--card: oklch(0.208 0.042 265.755);


### PR DESCRIPTION
## Summary

Prevents the white flash that appears briefly when launching Whispering in dark mode by loading a minimal CSS file early in the HTML before the main bundle loads.

## Type of Change

- [x] `fix`: Bug fix

## Related Issue

Closes #1146

## Changes Made

- Added `darkmode-bootstrap.css` that sets the background color immediately using `@media (prefers-color-scheme: dark)`
- Load this CSS in `app.html` before any scripts
- Used the exact OKLCH color value (`oklch(0.129 0.042 264.695)`) from the `@epicenter/ui` dark theme for consistency
- Added cross-reference comments in both files to keep colors in sync

## Testing

### Desktop App Testing
- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] Not applicable (web-only change)

### General Testing
- [ ] Tested with multiple API providers (if applicable)
- [ ] Verified no API keys are exposed in logs or storage
- [ ] Checked for console errors
- [ ] Tested on different screen sizes (if UI change)

## Checklist

- [x] My code follows the project's coding standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I've used `type` instead of `interface` in TypeScript
- [x] I've used absolute imports where applicable
- [ ] I've tested my changes thoroughly
- [x] I've added/updated tests for my changes (if applicable)
- [x] My changes don't break existing functionality
- [x] I've updated documentation (if needed)
