### PR TITLE
refactor(epicenter): use StandardSchemaWithJSONSchema for action inputs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "epicenter",
       "dependencies": {
-        "arktype": "^2.1.27",
+        "arktype": "^2.1.29",
       },
       "devDependencies": {
         "@biomejs/biome": "catalog:",
@@ -220,8 +220,7 @@
       },
       "dependencies": {
         "@elysiajs/openapi": "^1.4.11",
-        "@standard-community/standard-json": "^0.3.5",
-        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/spec": "^1.1.0",
         "@tursodatabase/database": "^0.3.2",
         "@types/bun": "catalog:",
         "arktype": "catalog:",
@@ -834,9 +833,7 @@
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.12", "", {}, "sha512-uilwrK0Ygyri5dToHYdZSjcvpS2ZwX0w5aSt3GCEN9hrjxWCoeV4Z2DTXuxjwbntaLQIEEAlCeNQss5SoHvAEA=="],
 
-    "@standard-community/standard-json": ["@standard-community/standard-json@0.3.5", "", { "peerDependencies": { "@standard-schema/spec": "^1.0.0", "@types/json-schema": "^7.0.15", "@valibot/to-json-schema": "^1.3.0", "arktype": "^2.1.20", "effect": "^3.16.8", "quansync": "^0.2.11", "sury": "^10.0.0", "typebox": "^1.0.17", "valibot": "^1.1.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.24.5" }, "optionalPeers": ["@valibot/to-json-schema", "arktype", "effect", "sury", "typebox", "valibot", "zod", "zod-to-json-schema"] }, "sha512-4+ZPorwDRt47i+O7RjyuaxHRK/37QY/LmgxlGrRrSTLYoFatEOzvqIc85GTlM18SFZ5E91C+v0o/M37wZPpUHA=="],
-
-    "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.8", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA=="],
 
@@ -1080,9 +1077,9 @@
 
     "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
-    "arkregex": ["arkregex@0.0.4", "", { "dependencies": { "@ark/util": "0.56.0" } }, "sha512-biS/FkvSwQq59TZ453piUp8bxMui11pgOMV9WHAnli1F8o0ayNCZzUwQadL/bGIUic5TkS/QlPcyMuI8ZIwedQ=="],
+    "arkregex": ["arkregex@0.0.5", "", { "dependencies": { "@ark/util": "0.56.0" } }, "sha512-ncYjBdLlh5/QnVsAA8De16Tc9EqmYM7y/WU9j+236KcyYNUXogpz3sC4ATIZYzzLxwI+0sEOaQLEmLmRleaEXw=="],
 
-    "arktype": ["arktype@2.1.28", "", { "dependencies": { "@ark/schema": "0.56.0", "@ark/util": "0.56.0", "arkregex": "0.0.4" } }, "sha512-LVZqXl2zWRpNFnbITrtFmqeqNkPPo+KemuzbGSY6jvJwCb4v8NsDzrWOLHnQgWl26TkJeWWcUNUeBpq2Mst1/Q=="],
+    "arktype": ["arktype@2.1.29", "", { "dependencies": { "@ark/schema": "0.56.0", "@ark/util": "0.56.0", "arkregex": "0.0.5" } }, "sha512-jyfKk4xIOzvYNayqnD8ZJQqOwcrTOUbIU4293yrzAjA3O1dWh61j71ArMQ6tS/u4pD7vabSPe7nG3RCyoXW6RQ=="],
 
     "array-iterate": ["array-iterate@2.0.1", "", {}, "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg=="],
 
@@ -2040,7 +2037,7 @@
 
     "qs": ["qs@6.14.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w=="],
 
-    "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
+    "quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 
     "querystring-es3": ["querystring-es3@0.2.1", "", {}, "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA=="],
 
@@ -2540,21 +2537,29 @@
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
+    "@epicenter/hq/@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
+
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
+    "@examples/basic-workspace/@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
+
+    "@examples/content-hub/@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
+
+    "@examples/stress-test/@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
+
     "@libsql/hrana-client/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "@poppinss/dumper/supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
-    "@quansync/fs/quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
-
     "@rollup/plugin-inject/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@sveltejs/kit/@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
     "@sveltejs/kit/cookie": ["cookie@0.6.0", "", {}, "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="],
 
@@ -2686,10 +2691,6 @@
 
     "tr46/punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
-    "unconfig/quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
-
-    "unconfig-core/quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
-
     "unicode-trie/pako": ["pako@0.2.9", "", {}, "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="],
 
     "uri-js/punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
@@ -2715,6 +2716,8 @@
     "@astrojs/check/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "@astrojs/svelte/@sveltejs/vite-plugin-svelte/@sveltejs/vite-plugin-svelte-inspector": ["@sveltejs/vite-plugin-svelte-inspector@4.0.1", "", { "dependencies": { "debug": "^4.3.7" }, "peerDependencies": { "@sveltejs/vite-plugin-svelte": "^5.0.0", "svelte": "^5.0.0", "vite": "^6.0.0" } }, "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw=="],
+
+    "@epicenter/hq/@types/bun/bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 
@@ -2759,6 +2762,12 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
+    "@examples/basic-workspace/@types/bun/bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
+
+    "@examples/content-hub/@types/bun/bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
+
+    "@examples/stress-test/@types/bun/bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 

--- a/package.json
+++ b/package.json
@@ -81,6 +81,6 @@
 		"jsrepo": "^3.0.8"
 	},
 	"dependencies": {
-		"arktype": "^2.1.27"
+		"arktype": "^2.1.29"
 	}
 }

--- a/packages/epicenter/package.json
+++ b/packages/epicenter/package.json
@@ -31,8 +31,7 @@
 	"dependencies": {
 		"mime": "catalog:",
 		"@elysiajs/openapi": "^1.4.11",
-		"@standard-community/standard-json": "^0.3.5",
-		"@standard-schema/spec": "^1.0.0",
+		"@standard-schema/spec": "^1.1.0",
 		"@tursodatabase/database": "^0.3.2",
 		"@types/bun": "catalog:",
 		"arktype": "catalog:",

--- a/packages/epicenter/src/cli/cli.ts
+++ b/packages/epicenter/src/cli/cli.ts
@@ -5,7 +5,7 @@ import { walkActions } from '../core/actions';
 import type { EpicenterConfig } from '../core/epicenter';
 import { createEpicenterClient } from '../core/epicenter';
 import { DEFAULT_PORT, startServer } from './server';
-import { standardSchemaToYargs } from './standardschema-to-yargs';
+import { standardJsonSchemaToYargs } from './standard-json-schema-to-yargs';
 
 /**
  * Create and run CLI from Epicenter config.
@@ -111,7 +111,7 @@ export async function createCLI({
 						action.description || `Execute ${actionName} ${action.type}`,
 						(yargs) => {
 							if (action.input) {
-								return standardSchemaToYargs(action.input, yargs);
+								return standardJsonSchemaToYargs(action.input, yargs);
 							}
 							return yargs;
 						},

--- a/packages/epicenter/src/cli/cli.ts
+++ b/packages/epicenter/src/cli/cli.ts
@@ -1,6 +1,5 @@
 import type { TaggedError } from 'wellcrafted/error';
 import { isResult, type Result } from 'wellcrafted/result';
-import type { Argv } from 'yargs';
 import yargs from 'yargs';
 import { walkActions } from '../core/actions';
 import type { EpicenterConfig } from '../core/epicenter';
@@ -110,10 +109,9 @@ export async function createCLI({
 					workspaceCli = workspaceCli.command(
 						actionName,
 						action.description || `Execute ${actionName} ${action.type}`,
-						async (yargs) => {
-							// Convert input schema to yargs options
+						(yargs) => {
 							if (action.input) {
-								return await standardSchemaToYargs(action.input, yargs);
+								return standardSchemaToYargs(action.input, yargs);
 							}
 							return yargs;
 						},

--- a/packages/epicenter/src/cli/standard-json-schema-to-yargs.test.ts
+++ b/packages/epicenter/src/cli/standard-json-schema-to-yargs.test.ts
@@ -1,19 +1,19 @@
 import { describe, expect, test } from 'bun:test';
 import { type } from 'arktype';
 import yargs from 'yargs';
-import { standardSchemaToYargs } from './standardschema-to-yargs';
+import { standardJsonSchemaToYargs } from './standard-json-schema-to-yargs';
 
-describe('standardSchemaToYargs', () => {
+describe('standardJsonSchemaToYargs', () => {
 	test('returns yargs unchanged when schema is undefined', async () => {
 		const cli = yargs([]);
-		const result = await standardSchemaToYargs(undefined, cli);
+		const result = await standardJsonSchemaToYargs(undefined, cli);
 		expect(result).toBe(cli);
 	});
 
 	test('converts simple string field', async () => {
 		const schema = type({ name: 'string' });
 		const cli = yargs([]);
-		const result = await standardSchemaToYargs(schema, cli);
+		const result = await standardJsonSchemaToYargs(schema, cli);
 
 		// Verify the option was added by checking internal state
 		const options = (result as any).getOptions();
@@ -23,7 +23,7 @@ describe('standardSchemaToYargs', () => {
 	test('converts optional string field', async () => {
 		const schema = type({ name: 'string?' });
 		const cli = yargs([]);
-		const result = await standardSchemaToYargs(schema, cli);
+		const result = await standardJsonSchemaToYargs(schema, cli);
 
 		const options = (result as any).getOptions();
 		expect(options.string).toContain('name');
@@ -34,7 +34,7 @@ describe('standardSchemaToYargs', () => {
 	test('converts required string field', async () => {
 		const schema = type({ name: 'string' });
 		const cli = yargs([]);
-		await standardSchemaToYargs(schema, cli);
+		await standardJsonSchemaToYargs(schema, cli);
 
 		const options = (cli as any).getOptions();
 		// Required fields should be in demandedOptions
@@ -44,7 +44,7 @@ describe('standardSchemaToYargs', () => {
 	test('converts number field', async () => {
 		const schema = type({ age: 'number' });
 		const cli = yargs([]);
-		const result = await standardSchemaToYargs(schema, cli);
+		const result = await standardJsonSchemaToYargs(schema, cli);
 
 		const options = (result as any).getOptions();
 		expect(options.number).toContain('age');
@@ -53,7 +53,7 @@ describe('standardSchemaToYargs', () => {
 	test('converts boolean field', async () => {
 		const schema = type({ active: 'boolean' });
 		const cli = yargs([]);
-		const result = await standardSchemaToYargs(schema, cli);
+		const result = await standardJsonSchemaToYargs(schema, cli);
 
 		const options = (result as any).getOptions();
 		expect(options.boolean).toContain('active');
@@ -62,7 +62,7 @@ describe('standardSchemaToYargs', () => {
 	test('converts string union as enum choices', async () => {
 		const schema = type({ role: "'admin' | 'user' | 'guest'" });
 		const cli = yargs([]);
-		const result = await standardSchemaToYargs(schema, cli);
+		const result = await standardJsonSchemaToYargs(schema, cli);
 
 		const options = (result as any).getOptions();
 		expect(options.string).toContain('role');
@@ -80,7 +80,7 @@ describe('standardSchemaToYargs', () => {
 			active: 'boolean?',
 		});
 		const cli = yargs([]);
-		const result = await standardSchemaToYargs(schema, cli);
+		const result = await standardJsonSchemaToYargs(schema, cli);
 
 		const options = (result as any).getOptions();
 		expect(options.string).toContain('name');
@@ -96,7 +96,7 @@ describe('standardSchemaToYargs', () => {
 			views: 'number?',
 		});
 		const cli = yargs([]);
-		const result = await standardSchemaToYargs(schema, cli);
+		const result = await standardJsonSchemaToYargs(schema, cli);
 
 		const options = (result as any).getOptions();
 		expect(options.string).toContain('title');
@@ -116,7 +116,7 @@ describe('standardSchemaToYargs', () => {
 			count: 'number',
 		});
 		const cli = yargs([]);
-		await standardSchemaToYargs(schema, cli);
+		await standardJsonSchemaToYargs(schema, cli);
 
 		const result = await cli.parse(['--name', 'test', '--count', '42']);
 		expect(result.name).toBe('test');
@@ -126,7 +126,7 @@ describe('standardSchemaToYargs', () => {
 	test('validates enum choices at runtime', async () => {
 		const schema = type({ role: "'admin' | 'user'" });
 		const cli = yargs([]);
-		await standardSchemaToYargs(schema, cli);
+		await standardJsonSchemaToYargs(schema, cli);
 
 		// Valid choice should work
 		const validResult = await cli.parse(['--role', 'admin']);
@@ -134,7 +134,7 @@ describe('standardSchemaToYargs', () => {
 
 		// Invalid choice should fail
 		const invalidCli = yargs([]);
-		await standardSchemaToYargs(schema, invalidCli);
+		await standardJsonSchemaToYargs(schema, invalidCli);
 		invalidCli.exitProcess(false); // Prevent process exit in tests
 
 		try {
@@ -149,7 +149,7 @@ describe('standardSchemaToYargs', () => {
 	test('handles arrays', async () => {
 		const schema = type({ tags: 'string[]' });
 		const cli = yargs([]);
-		const result = await standardSchemaToYargs(schema, cli);
+		const result = await standardJsonSchemaToYargs(schema, cli);
 
 		const options = (result as any).getOptions();
 		expect(options.array).toContain('tags');

--- a/packages/epicenter/src/cli/standard-json-schema-to-yargs.ts
+++ b/packages/epicenter/src/cli/standard-json-schema-to-yargs.ts
@@ -30,14 +30,14 @@ function isEnumSchema(
 function isUnionSchema(
 	schema: JsonSchema,
 ): schema is JsonSchema.Union {
-	return 'anyOf' in schema;
+	return 'anyOf' in schema && schema.anyOf !== undefined;
 }
 
 /** Check if schema is a oneOf union */
 function isOneOfSchema(
 	schema: JsonSchema,
 ): schema is JsonSchema.OneOf {
-	return 'oneOf' in schema;
+	return 'oneOf' in schema && schema.oneOf !== undefined;
 }
 
 /** Check if schema has a const value */

--- a/packages/epicenter/src/cli/standard-json-schema-to-yargs.ts
+++ b/packages/epicenter/src/cli/standard-json-schema-to-yargs.ts
@@ -1,7 +1,7 @@
 import type { StandardJSONSchemaV1 } from '@standard-schema/spec';
 import type { JsonSchema } from 'arktype';
 import type { Argv } from 'yargs';
-import { safeToJsonSchema } from '../core/schema/safe-json-schema';
+import { generateJsonSchema } from '../core/schema/generate-json-schema';
 
 // =============================================================================
 // Type Guards for JsonSchema discriminated union
@@ -90,7 +90,7 @@ export function standardJsonSchemaToYargs(
 ): Argv {
 	if (!schema) return yargs;
 
-	const jsonSchema = safeToJsonSchema(schema);
+	const jsonSchema = generateJsonSchema(schema);
 
 	if (!isObjectSchema(jsonSchema)) return yargs;
 

--- a/packages/epicenter/src/cli/standard-json-schema-to-yargs.ts
+++ b/packages/epicenter/src/cli/standard-json-schema-to-yargs.ts
@@ -73,7 +73,7 @@ function hasType(
  * ```typescript
  * import { type } from 'arktype';
  * import yargs from 'yargs';
- * import { standardSchemaToYargs } from './standardschema-to-yargs';
+ * import { standardJsonSchemaToYargs } from './standard-json-schema-to-yargs';
  *
  * const schema = type({
  *   name: "string",
@@ -81,10 +81,10 @@ function hasType(
  *   active: "boolean?"
  * });
  *
- * const cli = standardSchemaToYargs(schema, yargs);
+ * const cli = standardJsonSchemaToYargs(schema, yargs);
  * ```
  */
-export function standardSchemaToYargs(
+export function standardJsonSchemaToYargs(
 	schema: StandardJSONSchemaV1 | undefined,
 	yargs: Argv,
 ): Argv {

--- a/packages/epicenter/src/core/schema/generate-json-schema.ts
+++ b/packages/epicenter/src/core/schema/generate-json-schema.ts
@@ -33,7 +33,7 @@ import { ARKTYPE_JSON_SCHEMA_FALLBACK } from './arktype-fallback';
  * @param schema - Standard JSON Schema to convert
  * @returns JSON Schema representation, or permissive `{}` on error
  */
-export function safeToJsonSchema(schema: StandardJSONSchemaV1): JsonSchema {
+export function generateJsonSchema(schema: StandardJSONSchemaV1): JsonSchema {
 	const { data } = trySync({
 		try: () =>
 			schema['~standard'].jsonSchema.input({

--- a/packages/epicenter/src/core/schema/safe-json-schema.ts
+++ b/packages/epicenter/src/core/schema/safe-json-schema.ts
@@ -1,25 +1,18 @@
-import { toJsonSchema } from '@standard-community/standard-json';
-import type { StandardSchemaV1 } from '@standard-schema/spec';
+import type { StandardJSONSchemaV1 } from '@standard-schema/spec';
 import type { JsonSchema } from 'arktype';
-import { Ok, tryAsync } from 'wellcrafted/result';
+import { Ok, trySync } from 'wellcrafted/result';
 import { ARKTYPE_JSON_SCHEMA_FALLBACK } from './arktype-fallback';
 
 /**
- * Safely convert a Standard Schema to JSON Schema with graceful error handling.
+ * Safely convert a Standard JSON Schema to JSON Schema with graceful error handling.
  *
- * ## Why this wrapper exists
- *
- * standard-json is a vendor-agnostic library that converts any Standard Schema
- * (zod, arktype, valibot, etc.) to JSON Schema. It detects the vendor from
- * `schema["~standard"].vendor` and delegates to the appropriate handler.
- *
- * For arktype specifically, the handler passes options directly to arktype's
- * `Type.toJsonSchema()` method. The options aren't typed in standard-json
- * (they're `Record<string, unknown>`) because each vendor has different options.
+ * Uses the Standard JSON Schema interface (`~standard.jsonSchema.input`) which
+ * is vendor-agnostic. For arktype, fallback handlers are passed via `libraryOptions`
+ * to handle unconvertible types gracefully.
  *
  * ## Two-layer safety net
  *
- * 1. **Fallback handlers (arktype API)**: Intercept conversion issues per-node
+ * 1. **Fallback handlers (arktype-specific)**: Intercept conversion issues per-node
  *    in the schema tree, allowing partial success. If a schema has 10 fields
  *    and only 1 has an unconvertible type, the other 9 are preserved.
  *
@@ -33,31 +26,29 @@ import { ARKTYPE_JSON_SCHEMA_FALLBACK } from './arktype-fallback';
  * the `required` array. The `unit` fallback handler strips `undefined` from
  * unions so the conversion succeeds.
  *
- * @see https://github.com/standard-community/standard-json - standard-json repo
+ * @see https://standardschema.dev/json-schema - Standard JSON Schema spec
  * @see https://arktype.io/docs/json-schema - arktype's toJsonSchema docs
  * @see ARKTYPE_JSON_SCHEMA_FALLBACK in ./arktype-fallback.ts for fallback handlers
  *
- * @param schema - Standard Schema to convert
- * @returns JSON Schema representation, or permissive `{}` on catastrophic error
+ * @param schema - Standard JSON Schema to convert
+ * @returns JSON Schema representation, or permissive `{}` on error
  */
-export async function safeToJsonSchema(
-	schema: StandardSchemaV1,
-): Promise<JsonSchema> {
-	const { data } = await tryAsync({
-		try: async () =>
-			// The second argument is passed through to arktype's toJsonSchema().
-			// Types are loose (Record<string, unknown>) because standard-json is
-			// vendor-agnostic. These options are arktype-specific.
-			// See: https://arktype.io/docs/json-schema#fallback
-			await toJsonSchema(schema, {
-				fallback: ARKTYPE_JSON_SCHEMA_FALLBACK,
-			}),
-		// Last-resort fallback: if the entire conversion throws (shouldn't happen
-		// with the fallback handlers above, but defensive coding), return a
+export function safeToJsonSchema(schema: StandardJSONSchemaV1): JsonSchema {
+	const { data } = trySync({
+		try: () =>
+			schema['~standard'].jsonSchema.input({
+				target: 'draft-2020-12',
+				// Pass arktype-specific fallback handlers via libraryOptions.
+				// Other vendors will ignore this if they don't support it.
+				libraryOptions: {
+					fallback: ARKTYPE_JSON_SCHEMA_FALLBACK,
+				},
+			}) as JsonSchema,
+		// Last-resort fallback: if the entire conversion throws, return a
 		// permissive empty schema `{}` that accepts any input.
 		catch: (e) => {
 			console.warn(
-				'[arktype→JSON Schema] Catastrophic conversion failure, using permissive fallback:',
+				'[safeToJsonSchema] Conversion failure, using permissive fallback:',
 				e,
 			);
 			return Ok({} satisfies JsonSchema);

--- a/packages/epicenter/src/server/mcp.ts
+++ b/packages/epicenter/src/server/mcp.ts
@@ -1,5 +1,5 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
 	CallToolRequestSchema,
 	type CallToolResult,
@@ -7,7 +7,7 @@ import {
 	ListToolsRequestSchema,
 	McpError,
 } from '@modelcontextprotocol/sdk/types.js';
-import type { JSONSchema7 } from 'json-schema';
+import type { JsonSchema } from 'arktype';
 import type { TaggedError } from 'wellcrafted/error';
 import { isResult, type Result } from 'wellcrafted/result';
 import type { Action } from '../core/actions';
@@ -22,11 +22,11 @@ import type { AnyWorkspaceConfig } from '../core/workspace';
 export type McpToolEntry = {
 	action: Action;
 	/** Pre-computed JSON Schema for the action's input (guaranteed to be object type) */
-	inputSchema: JSONSchema7;
+	inputSchema: JsonSchema;
 };
 
 /** Default schema for actions without input: empty object */
-const EMPTY_OBJECT_SCHEMA: JSONSchema7 = { type: 'object', properties: {} };
+const EMPTY_OBJECT_SCHEMA: JsonSchema = { type: 'object', properties: {} };
 
 /**
  * Setup MCP tool handlers on an existing MCP server instance.
@@ -195,11 +195,11 @@ export function setupMcpTools(
  * // Nested export: { users: { crud: { create: defineMutation(...) } } }
  * // → MCP tool name: "workspace_users_crud_create"
  */
-export async function buildMcpToolRegistry<
+export function buildMcpToolRegistry<
 	TWorkspaces extends readonly AnyWorkspaceConfig[],
->(client: EpicenterClient<TWorkspaces>): Promise<Map<string, McpToolEntry>> {
-	const entries = await Promise.all(
-		iterActions(client).map(async ({ workspaceId, actionPath, action }) => {
+>(client: EpicenterClient<TWorkspaces>): Map<string, McpToolEntry> {
+	const entries = iterActions(client).map(
+		({ workspaceId, actionPath, action }) => {
 			const toolName = [workspaceId, ...actionPath].join('_');
 
 			// Build input schema - MCP requires object type at root
@@ -210,17 +210,18 @@ export async function buildMcpToolRegistry<
 				] as const;
 			}
 
-			const schema = await safeToJsonSchema(action.input);
-			if (schema.type !== 'object' && schema.type !== undefined) {
+			const schema = safeToJsonSchema(action.input);
+			const schemaType = 'type' in schema ? schema.type : undefined;
+			if (schemaType !== 'object' && schemaType !== undefined) {
 				console.warn(
-					`[MCP] Skipping tool "${toolName}": input has type "${schema.type}" but MCP requires "object". ` +
+					`[MCP] Skipping tool "${toolName}": input has type "${schemaType}" but MCP requires "object". ` +
 						`This action will still work via HTTP and TypeScript clients.`,
 				);
 				return undefined;
 			}
 
 			return [toolName, { action, inputSchema: schema }] as const;
-		}),
+		},
 	);
 
 	return new Map(entries.filter((e) => e !== undefined));

--- a/packages/epicenter/src/server/mcp.ts
+++ b/packages/epicenter/src/server/mcp.ts
@@ -12,7 +12,7 @@ import type { TaggedError } from 'wellcrafted/error';
 import { isResult, type Result } from 'wellcrafted/result';
 import type { Action } from '../core/actions';
 import { type EpicenterClient, iterActions } from '../core/epicenter';
-import { safeToJsonSchema } from '../core/schema/safe-json-schema';
+import { generateJsonSchema } from '../core/schema/generate-json-schema';
 import type { AnyWorkspaceConfig } from '../core/workspace';
 
 /**
@@ -210,7 +210,7 @@ export function buildMcpToolRegistry<
 				] as const;
 			}
 
-			const schema = safeToJsonSchema(action.input);
+			const schema = generateJsonSchema(action.input);
 			const schemaType = 'type' in schema ? schema.type : undefined;
 			if (schemaType !== 'object' && schemaType !== undefined) {
 				console.warn(


### PR DESCRIPTION
This refactors the CLI and MCP tooling to use `StandardSchemaWithJSONSchema` for action inputs, making JSON Schema generation explicit at the type level rather than relying on runtime fallbacks.

The key insight: we were generating JSON Schema from arktype schemas just to introspect them back for yargs options. This worked but felt indirect. By requiring `StandardSchemaWithJSONSchema` at the type level, we make the JSON Schema requirement explicit and get better type safety.

The main changes:

1. **Renamed `safeToJsonSchema` → `generateJsonSchema`** in `packages/epicenter/src/core/schema/generate-json-schema.ts`. The new name better reflects what it does (it generates JSON Schema, it doesn't "safely" do anything special).

2. **Renamed `standardSchemaToYargs` → `standardJsonSchemaToYargs`** to clarify that we're converting JSON Schema (not the raw StandardSchema) to yargs options.

3. **Made JSON Schema type guards consistent** across the codebase. The guards now follow a uniform pattern with proper type narrowing.

4. **Updated action inputs** to use `StandardSchemaWithJSONSchema` instead of just `StandardSchemaV1`. This catches missing JSON Schema support at compile time rather than runtime.

5. **Split transformation models** into separate files (`transformation-steps.ts` and `transformations.ts`) for better organization.

6. **Enhanced ConfirmationDialog** with async support, text confirmation input, and skip confirmation options. The dialog now properly handles loading states when `onConfirm` returns a Promise.

7. **Cleaned up JSDoc comments** to remove redundant type annotations that TypeScript already infers.

The attached spec document (`docs/specs/20251221-standard-json-schema-to-yargs-refactor.md`) contains the full analysis of the current approach vs direct arktype introspection, and why we're keeping the JSON Schema approach for StandardSchema compatibility.