### PR TITLE
feat(transcription): add Moonshine engine and upgrade transcribe-rs to 0.2

### DIFF
--- a/apps/whispering/package.json
+++ b/apps/whispering/package.json
@@ -71,6 +71,7 @@
 		"@tauri-apps/plugin-shell": "^2.3.0",
 		"@tauri-apps/plugin-updater": "^2.9.0",
 		"@types/dompurify": "^3.2.0",
+		"arkregex": "catalog:",
 		"arktype": "catalog:",
 		"audio-recorder-polyfill": "^0.4.1",
 		"bits-ui": "catalog:",

--- a/apps/whispering/src-tauri/Cargo.lock
+++ b/apps/whispering/src-tauri/Cargo.lock
@@ -29,6 +29,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,43 +245,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-openai"
-version = "0.29.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58fd812d4b7152e0f748254c03927f27126a5d83fccf265b2baddaaa1aeea41"
-dependencies = [
- "async-openai-macros",
- "backoff",
- "base64 0.22.1",
- "bytes",
- "derive_builder",
- "eventsource-stream",
- "futures",
- "rand 0.9.2",
- "reqwest",
- "reqwest-eventsource",
- "secrecy",
- "serde",
- "serde_json",
- "thiserror 2.0.17",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "async-openai-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0289cba6d5143bfe8251d57b4a8cac036adf158525a76533a7082ba65ec76398"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
 name = "async-process"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,18 +344,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
+name = "base64"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
-dependencies = [
- "futures-core",
- "getrandom 0.2.16",
- "instant",
- "pin-project-lite",
- "rand 0.8.5",
- "tokio",
-]
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -394,9 +363,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
 
 [[package]]
 name = "bindgen"
@@ -407,7 +376,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -664,6 +633,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.54"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+checksum = "b042e5d8a74ae91bb0961acd039822472ec99f8ab0948cbf6d1369588f8be586"
 dependencies = [
  "cc",
 ]
@@ -773,12 +751,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1095,6 +1101,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dary_heap"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,6 +1384,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,6 +1503,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,17 +1529,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
- "pin-project-lite",
-]
-
-[[package]]
-name = "eventsource-stream"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
-dependencies = [
- "futures-core",
- "nom 7.1.3",
  "pin-project-lite",
 ]
 
@@ -1779,12 +1798,6 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -2172,7 +2185,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -2324,7 +2337,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -2554,21 +2566,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "infer"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -2619,9 +2635,18 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2885,6 +2910,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2956,16 +2997,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2996,6 +3027,28 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3041,7 +3094,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 2.11.1",
+ "security-framework",
  "security-framework-sys",
  "tempfile",
 ]
@@ -3586,6 +3639,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "onig"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "open"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3775,6 +3850,12 @@ dependencies = [
  "smallvec 1.15.1",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
@@ -4434,6 +4515,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools 0.14.0",
+ "rayon",
+]
+
+[[package]]
 name = "rayon-core"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4554,13 +4646,11 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4579,22 +4669,6 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
-]
-
-[[package]]
-name = "reqwest-eventsource"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
-dependencies = [
- "eventsource-stream",
- "futures-core",
- "futures-timer",
- "mime",
- "nom 7.1.3",
- "pin-project-lite",
- "reqwest",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4763,18 +4837,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-native-certs"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework 3.5.1",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4895,16 +4957,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
-name = "secrecy"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
-dependencies = [
- "serde",
- "zeroize",
-]
-
-[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4912,19 +4964,6 @@ checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
-dependencies = [
- "bitflags 2.10.0",
- "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5305,6 +5344,18 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom 7.1.3",
+ "serde",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -6221,6 +6272,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+dependencies = [
+ "ahash 0.8.12",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "indicatif",
+ "itertools 0.14.0",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand 0.9.2",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.17",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
 name = "tokio"
 version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6266,17 +6351,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
-dependencies = [
- "futures-core",
- "pin-project-lite",
  "tokio",
 ]
 
@@ -6467,12 +6541,10 @@ dependencies = [
 
 [[package]]
 name = "transcribe-rs"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f01738c67d77f6dc84be57e376ec32f846c177c492e46f9685bdb2801870fe84"
+checksum = "06b34ced239a20ddef245dbe84c9976f871521c5fa479576f5580e2d24814f12"
 dependencies = [
- "async-openai",
- "async-trait",
  "derive_builder",
  "env_logger",
  "hound",
@@ -6481,8 +6553,10 @@ dependencies = [
  "once_cell",
  "ort",
  "regex",
+ "serde",
+ "serde_json",
  "thiserror 2.0.17",
- "tokio",
+ "tokenizers",
  "whisper-rs",
 ]
 
@@ -6600,22 +6674,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicase"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec 1.15.1",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "untrusted"

--- a/apps/whispering/src-tauri/Cargo.toml
+++ b/apps/whispering/src-tauri/Cargo.toml
@@ -48,7 +48,7 @@ tempfile = "3.8"
 rubato = "0.15"
 tauri-plugin-macos-permissions = "2.3.0"
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
-transcribe-rs = "0.1.5"
+transcribe-rs = { version = "0.2.0", features = ["whisper", "parakeet", "moonshine"] }
 regex = "1"
 rayon = "1.10"
 log = "0.4"

--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -10,7 +10,9 @@ use recorder::commands::{
 };
 
 pub mod transcription;
-use transcription::{transcribe_audio_parakeet, transcribe_audio_whisper, ModelManager};
+use transcription::{
+    transcribe_audio_moonshine, transcribe_audio_parakeet, transcribe_audio_whisper, ModelManager,
+};
 
 pub mod windows_path;
 use windows_path::fix_windows_path;
@@ -155,6 +157,7 @@ pub async fn run() {
         cancel_recording,
         transcribe_audio_whisper,
         transcribe_audio_parakeet,
+        transcribe_audio_moonshine,
         send_sigint,
         // Command execution (prevents console window flash on Windows)
         execute_command,

--- a/apps/whispering/src-tauri/src/transcription/model_manager.rs
+++ b/apps/whispering/src-tauri/src/transcription/model_manager.rs
@@ -2,6 +2,7 @@ use log::error;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
+use transcribe_rs::engines::moonshine::{MoonshineEngine, MoonshineModelParams};
 use transcribe_rs::engines::parakeet::{ParakeetEngine, ParakeetModelParams};
 use transcribe_rs::engines::whisper::WhisperEngine;
 use transcribe_rs::TranscriptionEngine;
@@ -10,6 +11,7 @@ use transcribe_rs::TranscriptionEngine;
 pub enum Engine {
     Parakeet(ParakeetEngine),
     Whisper(WhisperEngine),
+    Moonshine(MoonshineEngine),
 }
 
 impl Engine {
@@ -17,6 +19,7 @@ impl Engine {
         match self {
             Engine::Parakeet(e) => e.unload_model(),
             Engine::Whisper(e) => e.unload_model(),
+            Engine::Moonshine(e) => e.unload_model(),
         }
     }
 }
@@ -139,6 +142,64 @@ impl ModelManager {
                 .map_err(|e| format!("Failed to load Whisper model: {}", e))?;
 
             *engine_guard = Some(Engine::Whisper(engine));
+            *current_path_guard = Some(model_path);
+        }
+
+        // Update last activity
+        let mut last_activity_guard = self
+            .last_activity
+            .lock()
+            .map_err(|e| format!("Last activity mutex poisoned: {}", e))?;
+        *last_activity_guard = SystemTime::now();
+
+        Ok(self.engine.clone())
+    }
+
+    pub fn get_or_load_moonshine(
+        &self,
+        model_path: PathBuf,
+        variant: MoonshineModelParams,
+    ) -> Result<Arc<Mutex<Option<Engine>>>, String> {
+        let mut engine_guard = self.engine.lock().map_err(|e| {
+            format!(
+                "Engine mutex poisoned (likely due to previous panic): {}",
+                e
+            )
+        })?;
+        let mut current_path_guard = self.current_model_path.lock().map_err(|e| {
+            format!(
+                "Model path mutex poisoned (likely due to previous panic): {}",
+                e
+            )
+        })?;
+
+        // Check if we need to load a new model
+        let needs_load = match (&*engine_guard, &*current_path_guard) {
+            (None, _) => true,
+            (Some(_), Some(path)) if path != &model_path => {
+                // Different model requested, unload current one
+                if let Some(mut engine) = engine_guard.take() {
+                    engine.unload();
+                }
+                true
+            }
+            (Some(Engine::Whisper(_)), _) | (Some(Engine::Parakeet(_)), _) => {
+                // Wrong engine type, unload and reload
+                if let Some(mut engine) = engine_guard.take() {
+                    engine.unload();
+                }
+                true
+            }
+            _ => false,
+        };
+
+        if needs_load {
+            let mut engine = MoonshineEngine::new();
+            engine
+                .load_model_with_params(&model_path, variant)
+                .map_err(|e| format!("Failed to load Moonshine model: {}", e))?;
+
+            *engine_guard = Some(Engine::Moonshine(engine));
             *current_path_guard = Some(model_path);
         }
 

--- a/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
@@ -71,6 +71,7 @@
 				case 'whispercpp':
 					return value.endsWith(m.file.filename);
 				case 'parakeet':
+				case 'moonshine':
 					return value.endsWith(m.directoryName);
 			}
 		}) ?? null,

--- a/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { sep } from '@tauri-apps/api/path';
 	import { Button } from '@epicenter/ui/button';
 	import * as Command from '@epicenter/ui/command';
 	import * as Popover from '@epicenter/ui/popover';
@@ -156,7 +157,7 @@
 								<div class="font-medium text-sm">{service.name}</div>
 								{#if modelPath}
 									<div class="text-xs text-muted-foreground truncate">
-										{modelPath.split('/').pop() || modelPath}
+										{modelPath.split(sep()).pop() || modelPath}
 									</div>
 								{:else if !isConfigured}
 									<span class="text-xs text-warning">

--- a/apps/whispering/src/lib/constants/paths.ts
+++ b/apps/whispering/src/lib/constants/paths.ts
@@ -10,6 +10,11 @@ export const PATHS = {
 			const dir = await appDataDir();
 			return await join(dir, 'models', 'parakeet');
 		},
+		async MOONSHINE() {
+			const { appDataDir, join } = await import('@tauri-apps/api/path');
+			const dir = await appDataDir();
+			return await join(dir, 'models', 'moonshine');
+		},
 	},
 	DB: {
 		async RECORDINGS() {

--- a/apps/whispering/src/lib/query/transcription.ts
+++ b/apps/whispering/src/lib/query/transcription.ts
@@ -266,6 +266,16 @@ async function transcribeBlob(
 						{ modelPath: settings.value['transcription.parakeet.modelPath'] },
 					);
 				}
+				case 'moonshine': {
+					// Moonshine uses ONNX Runtime with encoder-decoder architecture
+					return await services.transcriptions.moonshine.transcribe(
+						audioToTranscribe,
+						{
+							modelPath: settings.value['transcription.moonshine.modelPath'],
+							variant: settings.value['transcription.moonshine.variant'],
+						},
+					);
+				}
 				default:
 					return WhisperingErr({
 						title: '⚠️ No transcription service selected',

--- a/apps/whispering/src/lib/query/transcription.ts
+++ b/apps/whispering/src/lib/query/transcription.ts
@@ -268,11 +268,11 @@ async function transcribeBlob(
 				}
 				case 'moonshine': {
 					// Moonshine uses ONNX Runtime with encoder-decoder architecture
+					// Variant is extracted from modelPath (e.g., "moonshine-tiny-en" → "tiny")
 					return await services.transcriptions.moonshine.transcribe(
 						audioToTranscribe,
 						{
 							modelPath: settings.value['transcription.moonshine.modelPath'],
-							variant: settings.value['transcription.moonshine.variant'],
 						},
 					);
 				}

--- a/apps/whispering/src/lib/services/transcription/index.ts
+++ b/apps/whispering/src/lib/services/transcription/index.ts
@@ -6,8 +6,9 @@ import { ElevenlabsTranscriptionServiceLive } from './cloud/elevenlabs';
 import { GroqTranscriptionServiceLive } from './cloud/groq';
 import { MistralTranscriptionServiceLive } from './cloud/mistral';
 import { OpenaiTranscriptionServiceLive } from './cloud/openai';
-import { ParakeetTranscriptionServiceLive } from './local/parakeet';
 // Local transcription services
+import { MoonshineTranscriptionServiceLive } from './local/moonshine';
+import { ParakeetTranscriptionServiceLive } from './local/parakeet';
 import { WhisperCppTranscriptionServiceLive } from './local/whispercpp';
 
 // Self-hosted transcription services
@@ -16,6 +17,7 @@ import { SpeachesTranscriptionServiceLive } from './self-hosted/speaches';
 export {
 	WhisperCppTranscriptionServiceLive as whispercpp,
 	ParakeetTranscriptionServiceLive as parakeet,
+	MoonshineTranscriptionServiceLive as moonshine,
 	DeepgramTranscriptionServiceLive as deepgram,
 	ElevenlabsTranscriptionServiceLive as elevenlabs,
 	GroqTranscriptionServiceLive as groq,

--- a/apps/whispering/src/lib/services/transcription/local/moonshine.ts
+++ b/apps/whispering/src/lib/services/transcription/local/moonshine.ts
@@ -1,0 +1,235 @@
+import { invoke } from '@tauri-apps/api/core';
+import { exists, stat } from '@tauri-apps/plugin-fs';
+import { type } from 'arktype';
+import { extractErrorMessage } from 'wellcrafted/error';
+import { Ok, type Result, tryAsync } from 'wellcrafted/result';
+import { WhisperingErr, type WhisperingError } from '$lib/result';
+import type { MoonshineModelConfig } from './types';
+
+/**
+ * HuggingFace base URL for Moonshine models.
+ * Models are distributed across different directories:
+ * - ONNX models: onnx/merged/[variant]/quantized/
+ * - Tokenizer: ctranslate2/tiny/ (shared across all models)
+ */
+const HF_BASE = 'https://huggingface.co/UsefulSensors/moonshine/resolve/main';
+
+/**
+ * Pre-built Moonshine models available for download from HuggingFace.
+ * These are ONNX models using encoder-decoder architecture with KV caching.
+ *
+ * Note: Language-specific models (ar, zh, ja, ko, uk, vi, es) exist but only
+ * have float versions available. We provide quantized English models for now
+ * since they offer the best size/performance tradeoff.
+ */
+export const MOONSHINE_MODELS: readonly MoonshineModelConfig[] = [
+	{
+		id: 'moonshine-tiny-en',
+		name: 'Moonshine Tiny (English)',
+		description: 'Fast and efficient English transcription (~28 MB)',
+		size: '~30 MB',
+		sizeBytes: 30_166_481, // encoder + decoder + tokenizer
+		engine: 'moonshine',
+		variant: 'tiny',
+		language: 'en',
+		directoryName: 'moonshine-tiny-en',
+		files: [
+			{
+				url: `${HF_BASE}/onnx/merged/tiny/quantized/encoder_model.onnx`,
+				filename: 'encoder_model.onnx',
+				sizeBytes: 7_937_661,
+			},
+			{
+				url: `${HF_BASE}/onnx/merged/tiny/quantized/decoder_model_merged.onnx`,
+				filename: 'decoder_model_merged.onnx',
+				sizeBytes: 20_243_286,
+			},
+			{
+				url: `${HF_BASE}/ctranslate2/tiny/tokenizer.json`,
+				filename: 'tokenizer.json',
+				sizeBytes: 1_985_534,
+			},
+		],
+	},
+	{
+		id: 'moonshine-base-en',
+		name: 'Moonshine Base (English)',
+		description: 'Higher accuracy English transcription (~65 MB)',
+		size: '~65 MB',
+		sizeBytes: 64_997_467, // encoder + decoder + tokenizer
+		engine: 'moonshine',
+		variant: 'base',
+		language: 'en',
+		directoryName: 'moonshine-base-en',
+		files: [
+			{
+				url: `${HF_BASE}/onnx/merged/base/quantized/encoder_model.onnx`,
+				filename: 'encoder_model.onnx',
+				sizeBytes: 20_513_063,
+			},
+			{
+				url: `${HF_BASE}/onnx/merged/base/quantized/decoder_model_merged.onnx`,
+				filename: 'decoder_model_merged.onnx',
+				sizeBytes: 42_498_870,
+			},
+			{
+				url: `${HF_BASE}/ctranslate2/tiny/tokenizer.json`,
+				filename: 'tokenizer.json',
+				sizeBytes: 1_985_534,
+			},
+		],
+	},
+] as const;
+
+const MoonshineErrorType = type({
+	name: "'AudioReadError' | 'FfmpegNotFoundError' | 'ModelLoadError' | 'TranscriptionError'",
+	message: 'string',
+});
+
+export function createMoonshineTranscriptionService() {
+	return {
+		async transcribe(
+			audioBlob: Blob,
+			options: { modelPath: string; variant: string },
+		): Promise<Result<string, WhisperingError>> {
+			// Pre-validation
+			if (!options.modelPath) {
+				return WhisperingErr({
+					title: 'Model Directory Required',
+					description: 'Please select a Moonshine model directory in settings.',
+					action: {
+						type: 'link',
+						label: 'Configure model',
+						href: '/settings/transcription',
+					},
+				});
+			}
+
+			// Check if model directory exists
+			const { data: isExists } = await tryAsync({
+				try: () => exists(options.modelPath),
+				catch: () => Ok(false),
+			});
+
+			if (!isExists) {
+				return WhisperingErr({
+					title: 'Model Directory Not Found',
+					description: `The model directory "${options.modelPath}" does not exist.`,
+					action: {
+						type: 'link',
+						label: 'Select model',
+						href: '/settings/transcription',
+					},
+				});
+			}
+
+			// Check if it's actually a directory
+			const { data: stats } = await tryAsync({
+				try: () => stat(options.modelPath),
+				catch: () => Ok(null),
+			});
+
+			if (!stats || !stats.isDirectory) {
+				return WhisperingErr({
+					title: 'Invalid Model Path',
+					description:
+						'Moonshine models must be directories containing model files.',
+					action: {
+						type: 'link',
+						label: 'Select model directory',
+						href: '/settings/transcription',
+					},
+				});
+			}
+
+			// Convert audio blob to byte array
+			const arrayBuffer = await audioBlob.arrayBuffer();
+			const audioData = Array.from(new Uint8Array(arrayBuffer));
+
+			// Call Tauri command to transcribe with Moonshine
+			// Note: Moonshine supports limited languages (en, ar, zh, ja, ko, es, uk, vi)
+			const result = await tryAsync({
+				try: () =>
+					invoke<string>('transcribe_audio_moonshine', {
+						audioData: audioData,
+						modelPath: options.modelPath,
+						variant: options.variant,
+					}),
+				catch: (unknownError) => {
+					const result = MoonshineErrorType(unknownError);
+					if (result instanceof type.errors) {
+						return WhisperingErr({
+							title: 'Unexpected Moonshine Error',
+							description: extractErrorMessage(unknownError),
+							action: { type: 'more-details', error: unknownError },
+						});
+					}
+					const error = result;
+
+					switch (error.name) {
+						case 'ModelLoadError':
+							return WhisperingErr({
+								title: 'Model Loading Error',
+								description: error.message,
+								action: {
+									type: 'more-details',
+									error: new Error(error.message),
+								},
+							});
+
+						case 'FfmpegNotFoundError':
+							return WhisperingErr({
+								title: 'FFmpeg Not Installed',
+								description:
+									'Moonshine requires FFmpeg to convert audio formats. Please install FFmpeg or switch to CPAL recording at 16kHz.',
+								action: {
+									type: 'link',
+									label: 'Install FFmpeg',
+									href: '/install-ffmpeg',
+								},
+							});
+
+						case 'AudioReadError':
+							return WhisperingErr({
+								title: 'Audio Read Error',
+								description: error.message,
+								action: {
+									type: 'more-details',
+									error: new Error(error.message),
+								},
+							});
+
+						case 'TranscriptionError':
+							return WhisperingErr({
+								title: 'Transcription Error',
+								description: error.message,
+								action: {
+									type: 'more-details',
+									error: new Error(error.message),
+								},
+							});
+
+						default:
+							return WhisperingErr({
+								title: 'Moonshine Error',
+								description: 'An unexpected error occurred.',
+								action: {
+									type: 'more-details',
+									error: new Error(String(error)),
+								},
+							});
+					}
+				},
+			});
+
+			return result;
+		},
+	};
+}
+
+export type MoonshineTranscriptionService = ReturnType<
+	typeof createMoonshineTranscriptionService
+>;
+
+export const MoonshineTranscriptionServiceLive =
+	createMoonshineTranscriptionService();

--- a/apps/whispering/src/lib/services/transcription/local/moonshine.ts
+++ b/apps/whispering/src/lib/services/transcription/local/moonshine.ts
@@ -18,6 +18,20 @@ const HF_BASE = 'https://huggingface.co/UsefulSensors/moonshine/resolve/main';
  * Pre-built Moonshine models available for download from HuggingFace.
  * These are ONNX models using encoder-decoder architecture with KV caching.
  *
+ * ## Why `variant` is stored separately from `modelPath`
+ *
+ * Unlike Whisper (where the `.bin` file is self-describing) or Parakeet (which
+ * includes a `config.json`), Moonshine's ONNX files don't contain all the metadata
+ * the engine needs. The `variant` tells transcribe-rs about the model architecture
+ * (layer count, hidden dimensions, etc.) so it can properly interpret the ONNX files.
+ *
+ * When transcribing, we pass both:
+ * - `modelPath`: Where the ONNX files are stored
+ * - `variant`: Architecture metadata ("tiny" or "base")
+ *
+ * The Rust command converts the variant string to `MoonshineModelParams::tiny()` or
+ * `MoonshineModelParams::base()`, which the engine needs to correctly load the model.
+ *
  * Note: Language-specific models (ar, zh, ja, ko, uk, vi, es) exist but only
  * have float versions available. We provide quantized English models for now
  * since they offer the best size/performance tradeoff.

--- a/apps/whispering/src/lib/services/transcription/local/moonshine.ts
+++ b/apps/whispering/src/lib/services/transcription/local/moonshine.ts
@@ -1,11 +1,17 @@
 import { invoke } from '@tauri-apps/api/core';
-import { sep } from '@tauri-apps/api/path';
 import { stat } from '@tauri-apps/plugin-fs';
+import { regex } from 'arkregex';
 import { type } from 'arktype';
 import { extractErrorMessage } from 'wellcrafted/error';
 import { Ok, type Result, tryAsync } from 'wellcrafted/result';
 import { WhisperingErr, type WhisperingError } from '$lib/result';
-import type { MoonshineModelConfig } from './types';
+import {
+	MOONSHINE_LANGUAGES,
+	MOONSHINE_VARIANTS,
+	type MoonshineLanguage,
+	type MoonshineModelConfig,
+	type MoonshineVariant,
+} from './types';
 
 /**
  * HuggingFace base URL for Moonshine models.
@@ -16,43 +22,34 @@ import type { MoonshineModelConfig } from './types';
 const HF_BASE = 'https://huggingface.co/UsefulSensors/moonshine/resolve/main';
 
 /**
- * Extracts the model variant ("tiny" or "base") from a model path.
+ * Type-safe regex pattern for validating Moonshine model paths.
+ * Matches paths ending with `moonshine-{variant}-{lang}`.
  *
- * Moonshine's ONNX files don't self-describe their architecture (unlike Whisper
- * .bin files which contain metadata, or Parakeet which includes config.json).
- * The variant tells transcribe-rs the layer count and hidden dimensions needed
- * to load the model correctly.
- *
- * Model paths follow the convention: `.../moonshine-{variant}-{lang}`
- * Examples:
- * - `/path/to/moonshine-tiny-en` → "tiny"
- * - `/path/to/moonshine-base-en` → "base"
- *
- * @param modelPath - Full path to the moonshine model directory
- * @returns The variant string to pass to transcribe-rs
+ * Built from MOONSHINE_VARIANTS and MOONSHINE_LANGUAGES arrays for consistency.
+ * The Rust side extracts variant from the path to determine model architecture.
  */
-export function extractVariantFromPath(modelPath: string): 'tiny' | 'base' {
-	const dirName = modelPath.split(sep()).pop() ?? '';
-	if (dirName.includes('base')) return 'base';
-	return 'tiny'; // Default to tiny if we can't determine
-}
+const MOONSHINE_DIR_PATTERN = regex.as<
+	`moonshine-${MoonshineVariant}-${MoonshineLanguage}`,
+	{ captures: [MoonshineVariant, MoonshineLanguage] }
+>(`moonshine-(${MOONSHINE_VARIANTS.join('|')})-(${MOONSHINE_LANGUAGES.join('|')})$`);
 
 /**
  * Pre-built Moonshine models available for download from HuggingFace.
  * These are ONNX models using encoder-decoder architecture with KV caching.
  *
- * ## How variant is determined
+ * ## Directory Naming Convention
  *
- * The variant ("tiny" or "base") is extracted from the directory name at
- * transcription time using `extractVariantFromPath()`. This avoids storing
- * redundant metadata since our directory naming convention already encodes
- * the architecture information.
+ * Model directories MUST follow the format: `moonshine-{variant}-{lang}`
+ * - variant: "tiny" or "base" (determines model architecture)
+ * - lang: language code (e.g., "en", "ar", "zh")
+ *
+ * The Rust side extracts the variant from the directory name to determine
+ * which MoonshineModelParams to use (tiny: 6 layers, base: 8 layers).
+ *
+ * ## Model Sizes
  *
  * - "tiny" models: 6 layers, head_dim=36 (~30 MB quantized)
  * - "base" models: 8 layers, head_dim=52 (~65 MB quantized)
- *
- * The Rust command converts this to `MoonshineModelParams::tiny()` or
- * `MoonshineModelParams::base()` for the engine.
  *
  * Note: Language-specific models (ar, zh, ja, ko, uk, vi, es) exist but only
  * have float versions available. We provide quantized English models for now
@@ -67,7 +64,7 @@ export const MOONSHINE_MODELS = [
 		sizeBytes: 30_166_481, // encoder + decoder + tokenizer
 		engine: 'moonshine',
 		language: 'en',
-		directoryName: 'moonshine-tiny-en', // variant "tiny" extracted at transcription time
+		directoryName: 'moonshine-tiny-en',
 		files: [
 			{
 				url: `${HF_BASE}/onnx/merged/tiny/quantized/encoder_model.onnx`,
@@ -94,7 +91,7 @@ export const MOONSHINE_MODELS = [
 		sizeBytes: 64_997_467, // encoder + decoder + tokenizer
 		engine: 'moonshine',
 		language: 'en',
-		directoryName: 'moonshine-base-en', // variant "base" extracted at transcription time
+		directoryName: 'moonshine-base-en',
 		files: [
 			{
 				url: `${HF_BASE}/onnx/merged/base/quantized/encoder_model.onnx`,
@@ -170,21 +167,30 @@ export function createMoonshineTranscriptionService() {
 				});
 			}
 
+			// Validate path ends with moonshine-{variant}-{lang}
+			if (!MOONSHINE_DIR_PATTERN.test(options.modelPath)) {
+				return WhisperingErr({
+					title: 'Invalid Model Directory Name',
+					description: `Model path must end with moonshine-{variant}-{lang} (e.g., "moonshine-tiny-en", "moonshine-base-en")`,
+					action: {
+						type: 'link',
+						label: 'Select valid model',
+						href: '/settings/transcription',
+					},
+				});
+			}
+
 			// Convert audio blob to byte array
 			const arrayBuffer = await audioBlob.arrayBuffer();
 			const audioData = Array.from(new Uint8Array(arrayBuffer));
 
-			// Extract variant from the model path (e.g., "moonshine-tiny-en" → "tiny")
-			const variant = extractVariantFromPath(options.modelPath);
-
 			// Call Tauri command to transcribe with Moonshine
-			// Note: Moonshine supports limited languages (en, ar, zh, ja, ko, es, uk, vi)
+			// The Rust side extracts variant from the model path directory name
 			const result = await tryAsync({
 				try: () =>
 					invoke<string>('transcribe_audio_moonshine', {
-						audioData: audioData,
+						audioData,
 						modelPath: options.modelPath,
-						variant,
 					}),
 				catch: (unknownError) => {
 					const result = MoonshineErrorType(unknownError);

--- a/apps/whispering/src/lib/services/transcription/local/moonshine.ts
+++ b/apps/whispering/src/lib/services/transcription/local/moonshine.ts
@@ -1,4 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
+import { sep } from '@tauri-apps/api/path';
 import { exists, stat } from '@tauri-apps/plugin-fs';
 import { type } from 'arktype';
 import { extractErrorMessage } from 'wellcrafted/error';
@@ -31,7 +32,7 @@ const HF_BASE = 'https://huggingface.co/UsefulSensors/moonshine/resolve/main';
  * @returns The variant string to pass to transcribe-rs
  */
 export function extractVariantFromPath(modelPath: string): 'tiny' | 'base' {
-	const dirName = modelPath.split('/').pop() ?? '';
+	const dirName = modelPath.split(sep()).pop() ?? '';
 	if (dirName.includes('base')) return 'base';
 	return 'tiny'; // Default to tiny if we can't determine
 }
@@ -65,9 +66,8 @@ export const MOONSHINE_MODELS: readonly MoonshineModelConfig[] = [
 		size: '~30 MB',
 		sizeBytes: 30_166_481, // encoder + decoder + tokenizer
 		engine: 'moonshine',
-		variant: 'tiny',
 		language: 'en',
-		directoryName: 'moonshine-tiny-en',
+		directoryName: 'moonshine-tiny-en', // variant "tiny" extracted at transcription time
 		files: [
 			{
 				url: `${HF_BASE}/onnx/merged/tiny/quantized/encoder_model.onnx`,
@@ -93,9 +93,8 @@ export const MOONSHINE_MODELS: readonly MoonshineModelConfig[] = [
 		size: '~65 MB',
 		sizeBytes: 64_997_467, // encoder + decoder + tokenizer
 		engine: 'moonshine',
-		variant: 'base',
 		language: 'en',
-		directoryName: 'moonshine-base-en',
+		directoryName: 'moonshine-base-en', // variant "base" extracted at transcription time
 		files: [
 			{
 				url: `${HF_BASE}/onnx/merged/base/quantized/encoder_model.onnx`,

--- a/apps/whispering/src/lib/services/transcription/local/parakeet.ts
+++ b/apps/whispering/src/lib/services/transcription/local/parakeet.ts
@@ -10,7 +10,7 @@ import type { ParakeetModelConfig } from './types';
  * Pre-built Parakeet models available for download from GitHub releases.
  * These are NVIDIA NeMo models consisting of multiple ONNX files.
  */
-export const PARAKEET_MODELS: readonly ParakeetModelConfig[] = [
+export const PARAKEET_MODELS = [
 	{
 		id: 'parakeet-tdt-0.6b-v3-int8',
 		name: 'Parakeet TDT 0.6B v3 (INT8)',
@@ -47,7 +47,7 @@ export const PARAKEET_MODELS: readonly ParakeetModelConfig[] = [
 			},
 		],
 	},
-] as const;
+] as const satisfies readonly ParakeetModelConfig[];
 
 const ParakeetErrorType = type({
 	name: "'AudioReadError' | 'FfmpegNotFoundError' | 'ModelLoadError' | 'TranscriptionError'",

--- a/apps/whispering/src/lib/services/transcription/local/types.ts
+++ b/apps/whispering/src/lib/services/transcription/local/types.ts
@@ -1,4 +1,44 @@
 /**
+ * Supported languages for Moonshine models.
+ * This is the source of truth for:
+ * 1. The `language` field type in MoonshineModelConfig
+ * 2. The regex validation pattern in moonshine.ts
+ *
+ * Moonshine supports 8 languages with varying model availability:
+ * - tiny variants: en, ar, zh, ja, ko, uk, vi (most have only float versions)
+ * - base variants: en, es (most have only float versions)
+ *
+ * Currently only English quantized models are provided as pre-built options.
+ */
+export const MOONSHINE_LANGUAGES = [
+	'en',
+	'ar',
+	'zh',
+	'ja',
+	'ko',
+	'es',
+	'uk',
+	'vi',
+] as const;
+
+/**
+ * Valid language codes for Moonshine models.
+ * Derived from MOONSHINE_LANGUAGES array.
+ */
+export type MoonshineLanguage = (typeof MOONSHINE_LANGUAGES)[number];
+
+/**
+ * Valid variant codes for Moonshine models.
+ * Determines the model architecture (layer count, hidden dimensions).
+ */
+export const MOONSHINE_VARIANTS = ['tiny', 'base'] as const;
+
+/**
+ * Valid variant type for Moonshine models.
+ */
+export type MoonshineVariant = (typeof MOONSHINE_VARIANTS)[number];
+
+/**
  * Base configuration for a local AI model that can be downloaded and used for transcription.
  */
 type BaseModelConfig = {
@@ -71,13 +111,13 @@ export type ParakeetModelConfig = BaseModelConfig & {
 export type MoonshineModelConfig = BaseModelConfig & {
 	engine: 'moonshine';
 	/** Language code for this model variant */
-	language: 'en' | 'ar' | 'zh' | 'ja' | 'ko' | 'es' | 'uk' | 'vi';
+	language: MoonshineLanguage;
 	/**
 	 * Name of the directory where files will be stored.
 	 * Convention: `moonshine-{variant}-{lang}` (e.g., "moonshine-tiny-en")
-	 * The variant is extracted from this name at transcription time via `extractVariantFromPath()`.
+	 * The variant and language are extracted from this name at transcription time.
 	 */
-	directoryName: string;
+	directoryName: `moonshine-${MoonshineVariant}-${MoonshineLanguage}`;
 	/** Array of ONNX files that make up the model */
 	files: Array<{
 		/** URL to download this file from */

--- a/apps/whispering/src/lib/services/transcription/local/types.ts
+++ b/apps/whispering/src/lib/services/transcription/local/types.ts
@@ -50,9 +50,35 @@ export type ParakeetModelConfig = BaseModelConfig & {
 };
 
 /**
+ * Configuration for Moonshine models, which consist of ONNX encoder/decoder files in a directory.
+ * Moonshine is optimized for fast, efficient transcription with support for 8 languages.
+ */
+export type MoonshineModelConfig = BaseModelConfig & {
+	engine: 'moonshine';
+	/** Model variant: tiny (~190MB) or base (~400MB) */
+	variant: 'tiny' | 'base';
+	/** Language code for this model variant */
+	language: 'en' | 'ar' | 'zh' | 'ja' | 'ko' | 'es' | 'uk' | 'vi';
+	/** Name of the directory where files will be stored */
+	directoryName: string;
+	/** Array of ONNX files that make up the model */
+	files: Array<{
+		/** URL to download this file from */
+		url: string;
+		/** Filename to save this file as */
+		filename: string;
+		/** Size of this individual file in bytes */
+		sizeBytes: number;
+	}>;
+};
+
+/**
  * Union type for all supported local model configurations.
  */
-export type LocalModelConfig = WhisperModelConfig | ParakeetModelConfig;
+export type LocalModelConfig =
+	| WhisperModelConfig
+	| ParakeetModelConfig
+	| MoonshineModelConfig;
 
 /**
  * Checks if a model file size is valid (at least 90% of expected size).

--- a/apps/whispering/src/lib/services/transcription/local/types.ts
+++ b/apps/whispering/src/lib/services/transcription/local/types.ts
@@ -63,22 +63,19 @@ export type ParakeetModelConfig = BaseModelConfig & {
  * "moonshine-tiny-en", "moonshine-base-en") and extract it at transcription time using
  * `extractVariantFromPath()`. This avoids redundant metadata while keeping our download
  * configs simple.
+ *
+ * Variant architecture:
+ * - "tiny": 6 layers, head_dim=36 (~30 MB quantized)
+ * - "base": 8 layers, head_dim=52 (~65 MB quantized)
  */
 export type MoonshineModelConfig = BaseModelConfig & {
 	engine: 'moonshine';
-	/**
-	 * Model architecture variant used for download configuration.
-	 * At transcription time, variant is extracted from directoryName via `extractVariantFromPath()`.
-	 * - "tiny": 6 layers, head_dim=36 (~30 MB quantized)
-	 * - "base": 8 layers, head_dim=52 (~65 MB quantized)
-	 */
-	variant: 'tiny' | 'base';
 	/** Language code for this model variant */
 	language: 'en' | 'ar' | 'zh' | 'ja' | 'ko' | 'es' | 'uk' | 'vi';
 	/**
 	 * Name of the directory where files will be stored.
 	 * Convention: `moonshine-{variant}-{lang}` (e.g., "moonshine-tiny-en")
-	 * The variant is extracted from this name at transcription time.
+	 * The variant is extracted from this name at transcription time via `extractVariantFromPath()`.
 	 */
 	directoryName: string;
 	/** Array of ONNX files that make up the model */

--- a/apps/whispering/src/lib/services/transcription/local/types.ts
+++ b/apps/whispering/src/lib/services/transcription/local/types.ts
@@ -52,10 +52,20 @@ export type ParakeetModelConfig = BaseModelConfig & {
 /**
  * Configuration for Moonshine models, which consist of ONNX encoder/decoder files in a directory.
  * Moonshine is optimized for fast, efficient transcription with support for 8 languages.
+ *
+ * The `variant` field is required because Moonshine's ONNX files don't self-describe their
+ * architecture. Unlike Whisper `.bin` files (which contain model metadata) or Parakeet
+ * directories (which include a `config.json`), Moonshine requires the caller to specify
+ * whether the model is "tiny" or "base" so transcribe-rs knows the layer count and hidden
+ * dimensions needed to properly load and run inference.
  */
 export type MoonshineModelConfig = BaseModelConfig & {
 	engine: 'moonshine';
-	/** Model variant: tiny (~190MB) or base (~400MB) */
+	/**
+	 * Model architecture variant. This is passed to transcribe-rs as `MoonshineModelParams`
+	 * so the engine knows how to interpret the ONNX files. Required because the ONNX format
+	 * doesn't include this metadata.
+	 */
 	variant: 'tiny' | 'base';
 	/** Language code for this model variant */
 	language: 'en' | 'ar' | 'zh' | 'ja' | 'ko' | 'es' | 'uk' | 'vi';

--- a/apps/whispering/src/lib/services/transcription/local/whispercpp.ts
+++ b/apps/whispering/src/lib/services/transcription/local/whispercpp.ts
@@ -11,7 +11,7 @@ import { isModelFileSizeValid, type WhisperModelConfig } from './types';
  * Pre-built Whisper models available for download from Hugging Face.
  * These are ggml-format models compatible with whisper.cpp.
  */
-export const WHISPER_MODELS: readonly WhisperModelConfig[] = [
+export const WHISPER_MODELS = [
 	{
 		id: 'tiny',
 		name: 'Tiny',
@@ -60,7 +60,7 @@ export const WHISPER_MODELS: readonly WhisperModelConfig[] = [
 			filename: 'ggml-large-v3-turbo.bin',
 		},
 	},
-] as const;
+] as const satisfies readonly WhisperModelConfig[];
 
 const WhisperCppErrorType = type({
 	name: "'AudioReadError' | 'FfmpegNotFoundError' | 'GpuError' | 'ModelLoadError' | 'TranscriptionError'",

--- a/apps/whispering/src/lib/services/transcription/registry.ts
+++ b/apps/whispering/src/lib/services/transcription/registry.ts
@@ -37,6 +37,7 @@ type TranscriptionModel =
 export const TRANSCRIPTION_SERVICE_IDS = [
 	'whispercpp',
 	'parakeet',
+	'moonshine',
 	'Groq',
 	'OpenAI',
 	'ElevenLabs',
@@ -97,6 +98,15 @@ export const TRANSCRIPTION_SERVICES = [
 		invertInDarkMode: false,
 		description: 'NVIDIA NeMo model for fast local transcription',
 		modelPathField: 'transcription.parakeet.modelPath',
+		location: 'local',
+	},
+	{
+		id: 'moonshine',
+		name: 'Moonshine',
+		icon: ggmlIcon, // Using GGML icon as placeholder for ONNX models
+		invertInDarkMode: true,
+		description: 'Efficient ONNX model by UsefulSensors (~30 MB)',
+		modelPathField: 'transcription.moonshine.modelPath',
 		location: 'local',
 	},
 	// Cloud services (API-based)
@@ -227,6 +237,7 @@ type ServiceCapabilities = {
 export const TRANSCRIPTION_SERVICE_CAPABILITIES = {
 	whispercpp: { supportsPrompt: true, supportsTemperature: false, supportsLanguage: true },
 	parakeet: { supportsPrompt: false, supportsTemperature: false, supportsLanguage: false },
+	moonshine: { supportsPrompt: false, supportsTemperature: false, supportsLanguage: false },
 	Groq: { supportsPrompt: true, supportsTemperature: true, supportsLanguage: true },
 	OpenAI: { supportsPrompt: true, supportsTemperature: true, supportsLanguage: true },
 	ElevenLabs: { supportsPrompt: true, supportsTemperature: true, supportsLanguage: true },

--- a/apps/whispering/src/lib/settings/settings.ts
+++ b/apps/whispering/src/lib/settings/settings.ts
@@ -206,9 +206,6 @@ export const Settings = type({
 	'transcription.whispercpp.modelPath': "string = ''",
 	'transcription.parakeet.modelPath': "string = ''",
 	'transcription.moonshine.modelPath': "string = ''",
-	'transcription.moonshine.variant': type
-		.enumerated('tiny', 'base')
-		.default('tiny'),
 
 	'transformations.selectedTransformationId': 'string | null = null',
 

--- a/apps/whispering/src/lib/settings/settings.ts
+++ b/apps/whispering/src/lib/settings/settings.ts
@@ -205,6 +205,10 @@ export const Settings = type({
 	),
 	'transcription.whispercpp.modelPath': "string = ''",
 	'transcription.parakeet.modelPath': "string = ''",
+	'transcription.moonshine.modelPath': "string = ''",
+	'transcription.moonshine.variant': type
+		.enumerated('tiny', 'base')
+		.default('tiny'),
 
 	'transformations.selectedTransformationId': 'string | null = null',
 

--- a/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
@@ -18,6 +18,7 @@
 	import { GROQ_MODELS } from '$lib/services/transcription/cloud/groq';
 	import { MISTRAL_TRANSCRIPTION_MODELS } from '$lib/services/transcription/cloud/mistral';
 	import { OPENAI_TRANSCRIPTION_MODELS } from '$lib/services/transcription/cloud/openai';
+	import { MOONSHINE_MODELS } from '$lib/services/transcription/local/moonshine';
 	import { PARAKEET_MODELS } from '$lib/services/transcription/local/parakeet';
 	import { WHISPER_MODELS } from '$lib/services/transcription/local/whispercpp';
 	import { TRANSCRIPTION_SERVICE_CAPABILITIES } from '$lib/services/transcription/registry';
@@ -648,6 +649,113 @@
 				{/if}
 			{/if}
 		</div>
+	{:else if settings.value['transcription.selectedTranscriptionService'] === 'moonshine'}
+		<div class="space-y-4">
+			<!-- Moonshine Model Selector Component -->
+			{#if window.__TAURI_INTERNALS__}
+				<LocalModelSelector
+					models={MOONSHINE_MODELS}
+					title="Moonshine Model"
+					description="Moonshine is an efficient ONNX model by UsefulSensors. English-only with fast inference and small model sizes (~30 MB)."
+					fileSelectionMode="directory"
+					bind:value={
+						() => settings.value['transcription.moonshine.modelPath'],
+						(v) => settings.updateKey('transcription.moonshine.modelPath', v)
+					}
+				>
+					{#snippet prebuiltFooter()}
+						<p class="text-sm text-muted-foreground">
+							Models are downloaded from{' '}
+							<Link
+								href="https://huggingface.co/UsefulSensors/moonshine"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								Hugging Face
+							</Link>
+							{' '}and stored in your app data directory. Moonshine uses
+							quantized ONNX models for efficient local inference.
+						</p>
+					{/snippet}
+
+					{#snippet manualInstructions()}
+						<Card.Root class="bg-muted/50">
+							<Card.Content class="p-4">
+								<h4 class="mb-2 text-sm font-medium">
+									Getting Moonshine Models
+								</h4>
+								<ul class="space-y-2 text-sm text-muted-foreground">
+									<li class="flex items-start gap-2">
+										<span
+											class="mt-0.5 block size-1.5 rounded-full bg-muted-foreground/50"
+										/>
+										<span>
+											Download pre-built models from the "Pre-built Models" tab
+										</span>
+									</li>
+									<li class="flex items-start gap-2">
+										<span
+											class="mt-0.5 block size-1.5 rounded-full bg-muted-foreground/50"
+										/>
+										<span>
+											Or download from{' '}
+											<Link
+												href="https://huggingface.co/UsefulSensors/moonshine"
+												target="_blank"
+												rel="noopener noreferrer"
+											>
+												UsefulSensors on Hugging Face
+											</Link>
+										</span>
+									</li>
+									<li class="flex items-start gap-2">
+										<span
+											class="mt-0.5 block size-1.5 rounded-full bg-muted-foreground/50"
+										/>
+										<span>
+											Moonshine models are directories containing ONNX files
+											and tokenizer
+										</span>
+									</li>
+								</ul>
+							</Card.Content>
+						</Card.Root>
+					{/snippet}
+				</LocalModelSelector>
+
+				{#if hasNavigatorLocalTranscriptionIssue( { isFFmpegInstalled: data.ffmpegInstalled ?? false }, )}
+					<Alert.Root class="border-red-500/20 bg-red-500/5">
+						<InfoIcon class="size-4 text-red-600 dark:text-red-400" />
+						<Alert.Title class="text-red-600 dark:text-red-400">
+							Browser API Recording Requires FFmpeg
+						</Alert.Title>
+						<Alert.Description>
+							You're using the Browser API recording method, which produces
+							compressed audio that requires FFmpeg for Moonshine transcription.
+							<div class="mt-3 space-y-3">
+								<div class="text-sm">
+									<strong>Option 1:</strong>
+									<Link href="/settings/recording"
+										>Switch to CPAL recording</Link
+									>
+									for direct compatibility with local transcription
+								</div>
+								<div class="text-sm">
+									<strong>Option 2:</strong>
+									<Link href="/install-ffmpeg">Install FFmpeg</Link>
+									to keep using Browser API recording
+								</div>
+								<div class="text-sm">
+									<strong>Option 3:</strong>
+									Switch to a cloud transcription service (OpenAI, Groq, Deepgram,
+									etc.) which work with all recording methods
+								</div>
+							</div>
+						</Alert.Description>
+					</Alert.Root>
+				{/if}
+			{/if}
+		</div>
 	{/if}
 
 	<!-- Audio Compression Settings -->
@@ -674,7 +782,9 @@
 		</Select.Root>
 		{#if !currentServiceCapabilities.supportsLanguage}
 			<Field.Description>
-				Parakeet automatically detects the language
+				{settings.value['transcription.selectedTranscriptionService'] === 'moonshine'
+					? 'Moonshine is English-only'
+					: 'Parakeet automatically detects the language'}
 			</Field.Description>
 		{/if}
 	</Field.Field>
@@ -717,7 +827,7 @@
 		<Field.Description>
 			{currentServiceCapabilities.supportsPrompt
 				? 'Helps transcription service (e.g., Whisper) better recognize specific terms, names, or context during initial transcription. Not for text transformations - use the Transformations tab for post-processing rules.'
-				: 'System prompt is not supported for Parakeet'}
+				: 'System prompt is not supported for local models (Parakeet, Moonshine)'}
 		</Field.Description>
 	</Field.Field>
 	</Field.Group>

--- a/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
@@ -718,6 +718,18 @@
 										</span>
 									</li>
 								</ul>
+								<div class="mt-3 rounded border border-amber-500/20 bg-amber-500/5 p-3">
+									<p class="text-xs font-medium text-amber-600 dark:text-amber-400">
+										Directory Naming Requirement
+									</p>
+									<p class="mt-1 text-xs text-muted-foreground">
+										The model directory must be named{' '}
+										<code class="rounded bg-muted px-1 py-0.5 font-mono">moonshine-&#123;variant&#125;-&#123;lang&#125;</code>
+										{' '}(e.g., <code class="rounded bg-muted px-1 py-0.5 font-mono">moonshine-tiny-en</code>,
+										{' '}<code class="rounded bg-muted px-1 py-0.5 font-mono">moonshine-base-en</code>).
+										The variant (tiny/base) determines model architecture.
+									</p>
+								</div>
 							</Card.Content>
 						</Card.Root>
 					{/snippet}

--- a/bun.lock
+++ b/bun.lock
@@ -98,6 +98,7 @@
         "@tauri-apps/plugin-shell": "^2.3.0",
         "@tauri-apps/plugin-updater": "^2.9.0",
         "@types/dompurify": "^3.2.0",
+        "arkregex": "catalog:",
         "arktype": "catalog:",
         "audio-recorder-polyfill": "^0.4.1",
         "bits-ui": "catalog:",
@@ -324,6 +325,7 @@
     "@types/bun": "latest",
     "@types/node": "^22.18.10",
     "@types/yargs": "^17.0.35",
+    "arkregex": "^0.0.5",
     "arktype": "^2.1.27",
     "bits-ui": "2.14.4",
     "clsx": "latest",
@@ -396,23 +398,23 @@
 
     "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.3.8", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.8", "@biomejs/cli-darwin-x64": "2.3.8", "@biomejs/cli-linux-arm64": "2.3.8", "@biomejs/cli-linux-arm64-musl": "2.3.8", "@biomejs/cli-linux-x64": "2.3.8", "@biomejs/cli-linux-x64-musl": "2.3.8", "@biomejs/cli-win32-arm64": "2.3.8", "@biomejs/cli-win32-x64": "2.3.8" }, "bin": { "biome": "bin/biome" } }, "sha512-Qjsgoe6FEBxWAUzwFGFrB+1+M8y/y5kwmg5CHac+GSVOdmOIqsAiXM5QMVGZJ1eCUCLlPZtq4aFAQ0eawEUuUA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.3.10", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.10", "@biomejs/cli-darwin-x64": "2.3.10", "@biomejs/cli-linux-arm64": "2.3.10", "@biomejs/cli-linux-arm64-musl": "2.3.10", "@biomejs/cli-linux-x64": "2.3.10", "@biomejs/cli-linux-x64-musl": "2.3.10", "@biomejs/cli-win32-arm64": "2.3.10", "@biomejs/cli-win32-x64": "2.3.10" }, "bin": { "biome": "bin/biome" } }, "sha512-/uWSUd1MHX2fjqNLHNL6zLYWBbrJeG412/8H7ESuK8ewoRoMPUgHDebqKrPTx/5n6f17Xzqc9hdg3MEqA5hXnQ=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-HM4Zg9CGQ3txTPflxD19n8MFPrmUAjaC7PQdLkugeeC0cQ+PiVrd7i09gaBS/11QKsTDBJhVg85CEIK9f50Qww=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-M6xUjtCVnNGFfK7HMNKa593nb7fwNm43fq1Mt71kpLpb+4mE7odO8W/oWVDyBVO4ackhresy1ZYO7OJcVo/B7w=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-lUDQ03D7y/qEao7RgdjWVGCu+BLYadhKTm40HkpJIi6kn8LSv5PAwRlew/DmwP4YZ9ke9XXoTIQDO1vAnbRZlA=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-Vae7+V6t/Avr8tVbFNjnFSTKZogZHFYl7MMH62P/J1kZtr0tyRQ9Fe0onjqjS2Ek9lmNLmZc/VR5uSekh+p1fg=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-Uo1OJnIkJgSgF+USx970fsM/drtPcQ39I+JO+Fjsaa9ZdCN1oysQmy6oAGbyESlouz+rzEckLTF6DS7cWse95g=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-hhPw2V3/EpHKsileVOFynuWiKRgFEV48cLe0eA+G2wO4SzlwEhLEB9LhlSrVeu2mtSn205W283LkX7Fh48CaxA=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-PShR4mM0sjksUMyxbyPNMxoKFPVF48fU8Qe8Sfx6w6F42verbwRLbz+QiKNiDPRJwUoMG1nPM50OBL3aOnTevA=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-B9DszIHkuKtOH2IFeeVkQmSMVUjss9KtHaNXquYYWCjH8IstNgXgx5B0aSBQNr6mn4RcKKRQZXn9Zu1rM3O0/A=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.8", "", { "os": "linux", "cpu": "x64" }, "sha512-QDPMD5bQz6qOVb3kiBui0zKZXASLo0NIQ9JVJio5RveBEFgDgsvJFUvZIbMbUZT3T00M/1wdzwWXk4GIh0KaAw=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.10", "", { "os": "linux", "cpu": "x64" }, "sha512-wwAkWD1MR95u+J4LkWP74/vGz+tRrIQvr8kfMMJY8KOQ8+HMVleREOcPYsQX82S7uueco60L58Wc6M1I9WA9Dw=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.8", "", { "os": "linux", "cpu": "x64" }, "sha512-YGLkqU91r1276uwSjiUD/xaVikdxgV1QpsicT0bIA1TaieM6E5ibMZeSyjQ/izBn4tKQthUSsVZacmoJfa3pDA=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.10", "", { "os": "linux", "cpu": "x64" }, "sha512-QTfHZQh62SDFdYc2nfmZFuTm5yYb4eO1zwfB+90YxUumRCR171tS1GoTX5OD0wrv4UsziMPmrePMtkTnNyYG3g=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-H4IoCHvL1fXKDrTALeTKMiE7GGWFAraDwBYFquE/L/5r1927Te0mYIGseXi4F+lrrwhSWbSGt5qPFswNoBaCxg=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-o7lYc9n+CfRbHvkjPhm8s9FgbKdYZu5HCcGVMItLjz93EhgJ8AM44W+QckDqLA9MKDNFrR8nPbO4b73VC5kGGQ=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.8", "", { "os": "win32", "cpu": "x64" }, "sha512-RguzimPoZWtBapfKhKjcWXBVI91tiSprqdBYu7tWhgN8pKRZhw24rFeNZTNf6UiBfjCYCi9eFQs/JzJZIhuK4w=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.10", "", { "os": "win32", "cpu": "x64" }, "sha512-pHEFgq7dUEsKnqG9mx9bXihxGI49X+ar+UBrEIj3Wqj3UCZp1rNgV+OoyjFgcXsjCWpuEAF4VJdkZr3TrWdCbQ=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.1.1", "", {}, "sha512-5L/uBxmjaCIX5h8Z+uu+kA9BQLkc/Wl06UGR5ajNRxu+/XjonB5i8JpgFMrPj3LXTCPA0pv8yxUvbUi+QthGGA=="],
 
@@ -962,7 +964,7 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
-    "@types/bun": ["@types/bun@1.3.4", "", { "dependencies": { "bun-types": "1.3.4" } }, "sha512-EEPTKXHP+zKGPkhRLv+HI0UEX8/o+65hqARxLy8Ov5rIxMBPNTjeZww00CIihrIQGEQBYg+0roO5qOnS/7boGA=="],
+    "@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
 
     "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
 
@@ -1080,7 +1082,7 @@
 
     "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
-    "arkregex": ["arkregex@0.0.4", "", { "dependencies": { "@ark/util": "0.56.0" } }, "sha512-biS/FkvSwQq59TZ453piUp8bxMui11pgOMV9WHAnli1F8o0ayNCZzUwQadL/bGIUic5TkS/QlPcyMuI8ZIwedQ=="],
+    "arkregex": ["arkregex@0.0.5", "", { "dependencies": { "@ark/util": "0.56.0" } }, "sha512-ncYjBdLlh5/QnVsAA8De16Tc9EqmYM7y/WU9j+236KcyYNUXogpz3sC4ATIZYzzLxwI+0sEOaQLEmLmRleaEXw=="],
 
     "arktype": ["arktype@2.1.28", "", { "dependencies": { "@ark/schema": "0.56.0", "@ark/util": "0.56.0", "arkregex": "0.0.4" } }, "sha512-LVZqXl2zWRpNFnbITrtFmqeqNkPPo+KemuzbGSY6jvJwCb4v8NsDzrWOLHnQgWl26TkJeWWcUNUeBpq2Mst1/Q=="],
 
@@ -1160,7 +1162,7 @@
 
     "builtin-status-codes": ["builtin-status-codes@3.0.0", "", {}, "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ=="],
 
-    "bun-types": ["bun-types@1.3.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ=="],
+    "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
@@ -2579,6 +2581,8 @@
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "arktype/arkregex": ["arkregex@0.0.4", "", { "dependencies": { "@ark/util": "0.56.0" } }, "sha512-biS/FkvSwQq59TZ453piUp8bxMui11pgOMV9WHAnli1F8o0ayNCZzUwQadL/bGIUic5TkS/QlPcyMuI8ZIwedQ=="],
 
     "asn1.js/bn.js": ["bn.js@4.12.2", "", {}, "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw=="],
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 			"svelte-sonner": "^1.0.6",
 			"@lucide/svelte": "^0.555.0",
 			"@tanstack/svelte-table": "9.0.0-alpha.10",
+			"arkregex": "^0.0.5",
 			"arktype": "^2.1.27",
 			"drizzle-arktype": "^0.1.3",
 			"drizzle-kit": "^0.31.7",

--- a/specs/20251214T120000-transcribe-rs-0.2.0-upgrade.md
+++ b/specs/20251214T120000-transcribe-rs-0.2.0-upgrade.md
@@ -1,0 +1,83 @@
+# transcribe-rs 0.2.0 Upgrade Spec
+
+**Date**: 2025-12-14
+**Status**: Completed
+
+## Summary
+
+Upgraded transcribe-rs from 0.1.5 to 0.2.0. The upgrade was straightforward with only one required change: enabling feature flags for the engines we use.
+
+## Changes Made
+
+### Cargo.toml Update
+
+```toml
+# Before
+transcribe-rs = "0.1.5"
+
+# After
+transcribe-rs = { version = "0.2.0", features = ["whisper", "parakeet"] }
+```
+
+## Key Findings from Research
+
+### What Changed in 0.2.0
+
+1. **Feature Flags (Breaking Build Change)**: All engines are now optional and must be explicitly enabled via Cargo features
+2. **New Engines Added**: Moonshine, Whisperfile (we don't use these)
+3. **HTTP Client Migration**: Whisperfile now uses ureq instead of async client
+4. **No API Breaking Changes**: The `TranscriptionEngine` trait and all existing engine APIs remain identical
+
+### Available Feature Flags
+
+| Feature | Description | We Use? |
+|---------|-------------|---------|
+| `whisper` | OpenAI Whisper via whisper-rs | Yes |
+| `parakeet` | NVIDIA Parakeet ONNX | Yes |
+| `moonshine` | UsefulSensors ONNX | No |
+| `whisperfile` | Mozilla whisperfile server | No |
+| `openai` | OpenAI API (remote) | No |
+| `all` | Enable all engines | No |
+
+### CI Simplification Analysis
+
+**No significant CI simplification is possible** because:
+
+1. **No Pre-built Binaries**: transcribe-rs doesn't provide pre-built binaries
+2. **whisper.cpp Compilation Required**: The whisper-rs dependency compiles whisper.cpp from source
+3. **GPU Dependencies Required**: Vulkan (Linux/Windows) and Metal (macOS) are required for GPU acceleration
+
+**Minor Optimizations Available**:
+- Specifying only needed features (already done) saves ~30-60s per platform
+- Using `WHISPER_DONT_GENERATE_BINDINGS=1` could save ~15-30s per platform
+
+### Handy App Patterns
+
+The Handy app (which uses transcribe-rs) follows similar patterns to Whispering:
+- Manager pattern for transcription engines
+- `Arc<Mutex<Option<Engine>>>` for thread-safe state
+- Lazy model loading with idle timeout for unloading
+- Uses `ParakeetModelParams::int8()` for quantization
+
+## Migration Notes for Future Reference
+
+If you ever need to update transcribe-rs again:
+
+1. **Feature Flags**: Always specify the engines you need
+2. **TranscriptionResult.segments**: In 0.2.0+, segments is `Option<Vec<TranscriptionSegment>>` not `Vec<TranscriptionSegment>` (we don't use segments currently so no code change needed)
+3. **No API Changes**: The engine APIs are stable
+
+## Testing
+
+- [x] `cargo check` passes
+- [ ] Manual testing with Whisper engine
+- [ ] Manual testing with Parakeet engine
+
+## Review
+
+The upgrade was simple. The main change in 0.2.0 is modularizing engines via feature flags, which is actually beneficial as it:
+- Reduces compile time by not building unused engines
+- Reduces binary size
+- Reduces dependencies
+
+Our existing code using `WhisperEngine`, `WhisperInferenceParams`, `ParakeetEngine`, `ParakeetInferenceParams`, `ParakeetModelParams`, and `TimestampGranularity` continues to work unchanged.

--- a/specs/20251214T180000-moonshine-addition-whispercpp-disable.md
+++ b/specs/20251214T180000-moonshine-addition-whispercpp-disable.md
@@ -1,0 +1,599 @@
+# Moonshine Addition and Whisper-cpp Disable Spec
+
+**Date**: 2025-12-14
+**Status**: Planning
+**Branch**: braden-w/transcribe-rs-0.2
+
+## Summary
+
+Add Moonshine as a new local transcription provider and temporarily disable whisper-cpp due to upstream build issues. The goal is minimal changes that preserve the codebase for easy restoration when whisper-rs build issues are resolved.
+
+## Background
+
+### Why Disable Whisper-cpp?
+
+The whisper-rs crate (which wraps whisper.cpp) has build issues:
+- **Windows**: Vulkan CMake errors
+- **macOS aarch64**: ARM cross-compilation i8mm instruction errors
+
+These are compile-time issues, not runtime issues. Existing builds work fine; we just can't build new releases.
+
+### Why Add Moonshine?
+
+Moonshine is an excellent alternative because:
+- Uses ONNX Runtime (prebuilt binaries, no compilation from source)
+- 5-15x faster than Whisper
+- Similar or better accuracy for supported languages
+- transcribe-rs already has the `moonshine` feature flag
+- Same model management pattern as Parakeet (ONNX directory-based)
+
+### Moonshine Limitations
+
+| Aspect | Moonshine | Whisper |
+|--------|-----------|---------|
+| Languages | 8 (EN, AR, ZH, JA, KO, ES, UK, VI) | 99 |
+| Timestamps | None | Yes (word-level) |
+| Model Sizes | Tiny (~190MB), Base (~400MB) | Tiny to Large-v3 |
+| Model Format | ONNX (2 files + tokenizer) | GGML (single .bin) |
+
+## Implementation Plan
+
+### Phase 1: Add Moonshine Provider
+
+#### 1.1 Rust Changes (src-tauri)
+
+**File: `Cargo.toml`**
+```toml
+# Change from:
+transcribe-rs = { version = "0.2.0", features = ["whisper", "parakeet"] }
+
+# To:
+transcribe-rs = { version = "0.2.0", features = ["whisper", "parakeet", "moonshine"] }
+```
+
+**File: `src/transcription/mod.rs`**
+
+Add new Tauri command:
+```rust
+#[tauri::command]
+pub async fn transcribe_audio_moonshine(
+    audio_data: Vec<u8>,
+    model_path: String,
+    model_manager: tauri::State<'_, ModelManager>,
+) -> Result<String, TranscriptionError> {
+    // 1. Convert audio to 16kHz mono PCM (reuse existing convert_audio_for_whisper)
+    // 2. Extract samples
+    // 3. Load model via model_manager.get_or_load_moonshine()
+    // 4. Transcribe with MoonshineEngine
+    // 5. Return text (no timestamps available)
+}
+```
+
+**File: `src/transcription/model_manager.rs`**
+
+Add to Engine enum:
+```rust
+pub enum Engine {
+    Parakeet(ParakeetEngine),
+    Whisper(WhisperEngine),
+    Moonshine(MoonshineEngine),  // New
+}
+```
+
+Add `get_or_load_moonshine()` method following the existing pattern.
+
+**File: `src/transcription/error.rs`**
+
+Add Moonshine-specific error variant:
+```rust
+#[derive(Error, Debug, Serialize, Deserialize)]
+#[serde(tag = "name")]
+pub enum TranscriptionError {
+    AudioReadError { message: String },
+    FfmpegNotFoundError { message: String },
+    GpuError { message: String },
+    ModelLoadError { message: String },
+    TranscriptionError { message: String },
+    MoonshineError { message: String },  // New (optional, may reuse existing)
+}
+```
+
+**File: `src/lib.rs`**
+
+Register new command:
+```rust
+.invoke_handler(tauri::generate_handler![
+    // ... existing commands
+    transcription::transcribe_audio_moonshine,  // New
+])
+```
+
+#### 1.2 TypeScript Changes (src/lib)
+
+**File: `services/transcription/local/moonshine.ts` (NEW)**
+
+```typescript
+import { invoke } from '@tauri-apps/api/core';
+import { exists, mkdir } from '@tauri-apps/plugin-fs';
+import { join } from '@tauri-apps/api/path';
+import { type } from 'arktype';
+import { type Result, tryAsync, Ok } from 'wellcrafted/result';
+import { WhisperingErr, type WhisperingError } from '$lib/result';
+import { extractErrorMessage } from '$lib/utils';
+import type { Settings } from '$lib/settings.svelte';
+import { PATHS } from '$lib/constants/paths';
+import type { MoonshineModelConfig } from './types';
+
+// Moonshine supports 9 variants across 8 languages
+export const MOONSHINE_MODELS: readonly MoonshineModelConfig[] = [
+  {
+    id: 'moonshine-tiny-en',
+    name: 'Moonshine Tiny (English)',
+    description: 'Fastest, English only, 5-15x faster than Whisper',
+    size: '~190 MB',
+    sizeBytes: 199_229_440,  // Approximate
+    engine: 'moonshine',
+    variant: 'tiny',
+    language: 'en',
+    directoryName: 'moonshine-tiny-en',
+    files: [
+      {
+        url: 'https://huggingface.co/UsefulSensors/moonshine/resolve/main/onnx/tiny/encoder_model.onnx',
+        filename: 'encoder_model.onnx',
+        sizeBytes: 100_000_000, // Placeholder - verify actual
+      },
+      {
+        url: 'https://huggingface.co/UsefulSensors/moonshine/resolve/main/onnx/tiny/decoder_model_merged.onnx',
+        filename: 'decoder_model_merged.onnx',
+        sizeBytes: 90_000_000, // Placeholder - verify actual
+      },
+      // Tokenizer files - TODO: Verify exact files needed
+    ],
+  },
+  {
+    id: 'moonshine-base-en',
+    name: 'Moonshine Base (English)',
+    description: 'Better accuracy, English only, faster than Whisper',
+    size: '~400 MB',
+    sizeBytes: 419_430_400,  // Approximate
+    engine: 'moonshine',
+    variant: 'base',
+    language: 'en',
+    directoryName: 'moonshine-base-en',
+    files: [
+      // Similar structure to tiny
+    ],
+  },
+  // Add more variants as needed (AR, ZH, JA, KO, ES, UK, VI)
+] as const;
+
+const MoonshineErrorType = type({
+  name: "'AudioReadError' | 'ModelLoadError' | 'TranscriptionError'",
+  message: 'string',
+});
+
+export function createMoonshineTranscriptionService() {
+  return {
+    async transcribe(
+      audioBlob: Blob,
+      options: {
+        modelPath: string;
+      },
+    ): Promise<Result<string, WhisperingError>> {
+      // Pre-validation
+      if (!options.modelPath) {
+        return WhisperingErr({
+          title: '📁 Model Directory Required',
+          description: 'Please select a Moonshine model directory in settings.',
+          action: {
+            type: 'link',
+            label: 'Configure model',
+            href: '/settings/transcription',
+          },
+        });
+      }
+
+      // Check if model directory exists
+      const { data: isExists } = await tryAsync({
+        try: () => exists(options.modelPath),
+        catch: () => Ok(false),
+      });
+
+      if (!isExists) {
+        return WhisperingErr({
+          title: '❌ Model Directory Not Found',
+          description: `The model directory "${options.modelPath}" does not exist.`,
+          action: {
+            type: 'link',
+            label: 'Select model',
+            href: '/settings/transcription',
+          },
+        });
+      }
+
+      // Convert audio blob to byte array
+      const arrayBuffer = await audioBlob.arrayBuffer();
+      const audioData = Array.from(new Uint8Array(arrayBuffer));
+
+      // Call Tauri command
+      const result = await tryAsync({
+        try: () =>
+          invoke<string>('transcribe_audio_moonshine', {
+            audioData: audioData,
+            modelPath: options.modelPath,
+          }),
+        catch: (unknownError) => {
+          const result = MoonshineErrorType(unknownError);
+          if (result instanceof type.errors) {
+            return WhisperingErr({
+              title: '❌ Unexpected Moonshine Error',
+              description: extractErrorMessage(unknownError),
+              action: { type: 'more-details', error: unknownError },
+            });
+          }
+          const error = result;
+
+          switch (error.name) {
+            case 'ModelLoadError':
+              return WhisperingErr({
+                title: '🤖 Model Loading Error',
+                description: error.message,
+                action: { type: 'more-details', error: new Error(error.message) },
+              });
+            case 'AudioReadError':
+              return WhisperingErr({
+                title: '🔊 Audio Processing Error',
+                description: error.message,
+                action: { type: 'more-details', error: new Error(error.message) },
+              });
+            case 'TranscriptionError':
+              return WhisperingErr({
+                title: '❌ Transcription Failed',
+                description: error.message,
+                action: { type: 'more-details', error: new Error(error.message) },
+              });
+          }
+        },
+      });
+
+      return result;
+    },
+  };
+}
+
+export const MoonshineTranscriptionServiceLive = createMoonshineTranscriptionService();
+```
+
+**File: `services/transcription/local/types.ts`**
+
+Add Moonshine config type:
+```typescript
+export type MoonshineModelConfig = BaseModelConfig & {
+  engine: 'moonshine';
+  variant: 'tiny' | 'base';
+  language: 'en' | 'ar' | 'zh' | 'ja' | 'ko' | 'es' | 'uk' | 'vi';
+  directoryName: string;
+  files: Array<{
+    url: string;
+    filename: string;
+    sizeBytes: number;
+  }>;
+};
+
+// Update LocalModelConfig union
+export type LocalModelConfig = WhisperModelConfig | ParakeetModelConfig | MoonshineModelConfig;
+```
+
+**File: `services/transcription/registry.ts`**
+
+Add to service IDs and metadata:
+```typescript
+export const TRANSCRIPTION_SERVICE_IDS = [
+  'whispercpp',
+  'parakeet',
+  'moonshine',  // New
+  // ... cloud services
+] as const;
+
+// In TRANSCRIPTION_SERVICES array:
+{
+  id: 'moonshine',
+  name: 'Moonshine',
+  icon: moonshineLogo,  // Need to add icon
+  invertInDarkMode: false,
+  description: 'Ultra-fast local transcription (5-15x faster than Whisper)',
+  modelPathField: 'transcription.moonshine.modelPath',
+  location: 'local',
+},
+
+// In TRANSCRIPTION_SERVICE_CAPABILITIES:
+moonshine: { supportsPrompt: false, supportsTemperature: false, supportsLanguage: false },
+```
+
+**Note on Languages**: For now, we pass language through as-is. Moonshine only supports 8 languages, so unsupported languages will use the default model behavior. Future enhancement: add per-service language constants.
+
+**File: `services/transcription/index.ts`**
+
+Add export:
+```typescript
+import { MoonshineTranscriptionServiceLive } from './local/moonshine';
+
+export {
+  // ... existing
+  MoonshineTranscriptionServiceLive as moonshine,
+};
+```
+
+**File: `query/transcription.ts`**
+
+Add routing case:
+```typescript
+case 'moonshine': {
+  return await services.transcriptions.moonshine.transcribe(
+    audioToTranscribe,
+    { modelPath: settings.value['transcription.moonshine.modelPath'] },
+  );
+}
+```
+
+**File: `constants/paths.ts`**
+
+Add Moonshine path:
+```typescript
+MOONSHINE() {
+  const { appDataDir, join } = await import('@tauri-apps/api/path');
+  const dir = await appDataDir();
+  return await join(dir, 'models', 'moonshine');
+},
+```
+
+#### 1.3 UI Changes
+
+**File: `routes/(app)/(config)/settings/transcription/+page.svelte`**
+
+Add Moonshine section:
+```svelte
+{:else if settings.value['transcription.selectedTranscriptionService'] === 'moonshine'}
+  <LocalModelSelector
+    models={MOONSHINE_MODELS}
+    title="Moonshine Model"
+    description="Ultra-fast ONNX-based transcription. Supports: English, Arabic, Chinese, Japanese, Korean, Spanish, Ukrainian, Vietnamese."
+    fileSelectionMode="directory"
+    bind:value={
+      () => settings.value['transcription.moonshine.modelPath'],
+      (v) => settings.updateKey('transcription.moonshine.modelPath', v)
+    }
+  >
+    {#snippet prebuiltFooter()}
+      <p class="text-sm text-muted-foreground mt-2">
+        Note: Moonshine does not provide timestamp information in transcripts.
+      </p>
+    {/snippet}
+  </LocalModelSelector>
+```
+
+**File: `components/settings/LocalModelDownloadCard.svelte`**
+
+Add moonshine case to download logic:
+```typescript
+// In ensureModelDestinationPath():
+case 'moonshine': {
+  const modelsDir = await PATHS.MODELS.MOONSHINE();
+  if (!(await exists(modelsDir))) {
+    await mkdir(modelsDir, { recursive: true });
+  }
+  return await join(modelsDir, model.directoryName);
+}
+
+// In downloadModel():
+else if (model.engine === 'moonshine') {
+  // Same multi-file pattern as Parakeet
+  const totalBytes = model.sizeBytes;
+  let downloadedBytes = 0;
+
+  await mkdir(path, { recursive: true });
+
+  for (const file of model.files) {
+    const filePath = await join(path, file.filename);
+    await downloadFileContent(/* ... */);
+    downloadedBytes += file.sizeBytes;
+  }
+}
+```
+
+### Phase 2: Disable Whisper-cpp (Minimal Changes)
+
+#### 2.1 Cargo.toml Feature Flag
+
+```toml
+# Change from:
+transcribe-rs = { version = "0.2.0", features = ["whisper", "parakeet", "moonshine"] }
+
+# To:
+transcribe-rs = { version = "0.2.0", features = ["parakeet", "moonshine"] }
+# Note: "whisper" feature removed
+```
+
+This single change:
+- Removes whisper-rs dependency
+- Eliminates whisper.cpp compilation
+- Removes build issues
+
+#### 2.2 Rust Conditional Compilation
+
+**File: `src/transcription/mod.rs`**
+
+Wrap whisper command:
+```rust
+#[cfg(feature = "whisper")]
+#[tauri::command]
+pub async fn transcribe_audio_whisper(/* ... */) -> Result<String, TranscriptionError> {
+    // Existing implementation
+}
+
+#[cfg(not(feature = "whisper"))]
+#[tauri::command]
+pub async fn transcribe_audio_whisper(
+    _audio_data: Vec<u8>,
+    _model_path: String,
+    _language: Option<String>,
+    _initial_prompt: Option<String>,
+    _model_manager: tauri::State<'_, ModelManager>,
+) -> Result<String, TranscriptionError> {
+    Err(TranscriptionError::TranscriptionError {
+        message: "Whisper C++ is temporarily unavailable due to upstream build issues. Please use Moonshine or Parakeet for local transcription, or a cloud provider.".to_string(),
+    })
+}
+```
+
+**File: `src/transcription/model_manager.rs`**
+
+Wrap whisper-related code:
+```rust
+pub enum Engine {
+    Parakeet(ParakeetEngine),
+    #[cfg(feature = "whisper")]
+    Whisper(WhisperEngine),
+    Moonshine(MoonshineEngine),
+}
+
+#[cfg(feature = "whisper")]
+pub fn get_or_load_whisper(&self, model_path: PathBuf) -> Result</* ... */> {
+    // Existing implementation
+}
+
+#[cfg(not(feature = "whisper"))]
+pub fn get_or_load_whisper(&self, _model_path: PathBuf) -> Result</* ... */> {
+    Err("Whisper is not available in this build".into())
+}
+```
+
+#### 2.3 TypeScript Changes
+
+**File: `services/transcription/registry.ts`**
+
+Mark whisper as unavailable (optional - could also hide entirely):
+```typescript
+{
+  id: 'whispercpp',
+  name: 'Whisper C++ (Temporarily Unavailable)',  // Updated name
+  icon: ggmlIcon,
+  invertInDarkMode: true,
+  description: 'Currently unavailable due to upstream build issues. Use Moonshine instead.',
+  modelPathField: 'transcription.whispercpp.modelPath',
+  location: 'local',
+  disabled: true,  // New field
+},
+```
+
+Alternative: Remove from `TRANSCRIPTION_SERVICE_IDS` to hide completely.
+
+#### 2.4 UI Changes (Optional)
+
+Either:
+1. **Hide whisper-cpp**: Don't show it in service selector
+2. **Show as disabled**: Show with explanation of unavailability
+
+Recommendation: Hide it to avoid confusion.
+
+## Todo Checklist
+
+### Phase 1: Moonshine Addition
+- [ ] Update Cargo.toml to add `moonshine` feature
+- [ ] Add MoonshineEngine to model_manager.rs Engine enum
+- [ ] Add get_or_load_moonshine() method to ModelManager
+- [ ] Add transcribe_audio_moonshine Tauri command
+- [ ] Register command in lib.rs
+- [ ] Create moonshine.ts service file with model configs
+- [ ] Add MoonshineModelConfig to types.ts
+- [ ] Add moonshine to registry.ts (ID, metadata, capabilities)
+- [ ] Add moonshine export to index.ts
+- [ ] Add moonshine routing case in query/transcription.ts
+- [ ] Add MOONSHINE() path to constants/paths.ts
+- [ ] Add moonshine UI section in settings page
+- [ ] Add moonshine case to LocalModelDownloadCard
+- [ ] Test model download flow
+- [ ] Test transcription flow
+
+### Phase 2: Whisper-cpp Disable
+- [ ] Remove `whisper` from Cargo.toml features
+- [ ] Add `#[cfg(feature = "whisper")]` guards to mod.rs
+- [ ] Add `#[cfg(feature = "whisper")]` guards to model_manager.rs
+- [ ] Hide/disable whispercpp in registry.ts
+- [ ] Update service selector UI (optional)
+- [ ] Verify cargo check passes
+- [ ] Verify CI builds pass
+
+### Testing
+- [ ] Manual test Moonshine tiny model download
+- [ ] Manual test Moonshine transcription
+- [ ] Manual test Parakeet still works
+- [ ] Manual test whispercpp returns appropriate error
+- [ ] Manual test service switching
+- [ ] Run cargo check on all platforms (CI)
+
+## Model Files Research
+
+### Moonshine Model Structure
+
+Based on transcribe-rs source, Moonshine expects:
+```
+model_dir/
+├── encoder_model.onnx
+├── decoder_model_merged.onnx
+└── tokenizer files (TBD - need to verify exact files)
+```
+
+**Download Sources**:
+- https://huggingface.co/UsefulSensors/moonshine/tree/main/onnx/tiny
+- https://huggingface.co/UsefulSensors/moonshine/tree/main/onnx/base
+
+**TODO**: Verify exact file list and sizes by inspecting HuggingFace repo.
+
+### Model Variants Available in transcribe-rs
+
+From `engine.rs`:
+```rust
+pub enum ModelVariant {
+    TinyEn,    // tiny, English
+    BaseEn,    // base, English
+    TinyAr,    // tiny, Arabic
+    TinyZh,    // tiny, Chinese
+    TinyJa,    // tiny, Japanese
+    TinyKo,    // tiny, Korean
+    TinyUk,    // tiny, Ukrainian
+    TinyVi,    // tiny, Vietnamese
+    BaseEs,    // base, Spanish
+}
+```
+
+## Future Considerations
+
+### Per-Service Language Constants
+
+Currently, we have global language constants. Moonshine only supports 8 languages while Whisper supports 99. Options:
+
+1. **Pass through (current plan)**: Let unsupported languages fall back to model default
+2. **Filter UI options**: Show only supported languages per service
+3. **Validation with warning**: Allow selection but warn user
+
+Recommendation: Start with pass-through, add filtering later if needed.
+
+### Restoration of Whisper-cpp
+
+When whisper-rs build issues are resolved:
+1. Add `"whisper"` back to Cargo.toml features
+2. Remove `#[cfg(feature = "whisper")]` guards (or keep for flexibility)
+3. Re-enable in registry.ts
+4. Test thoroughly
+
+The minimal change approach makes restoration a 5-minute task.
+
+## Review
+
+This plan:
+- **Adds value**: Moonshine provides faster transcription with ONNX (no build issues)
+- **Minimizes disruption**: Whisper-cpp is disabled at compile time, not removed
+- **Follows patterns**: Uses exact same patterns as Parakeet (ONNX, directory-based, multi-file)
+- **Enables restoration**: Single-line Cargo.toml change to restore whisper-cpp
+- **No breaking changes**: Existing settings and model paths remain valid

--- a/specs/20251221T000000-moonshine-integration-handoff.md
+++ b/specs/20251221T000000-moonshine-integration-handoff.md
@@ -1,0 +1,92 @@
+# Moonshine Integration Handoff
+
+## Summary
+
+Added Moonshine as a new local transcription engine to Whispering, integrating with transcribe-rs 0.2.0.
+
+## What Was Done
+
+### Rust Side (Already Committed Previously)
+
+1. **Cargo.toml**: Added `moonshine` feature flag to transcribe-rs dependency
+2. **model_manager.rs**: Added `MoonshineEngine` variant and initialization logic
+3. **lib.rs**: Added `transcribe_audio_moonshine` Tauri command
+
+### TypeScript Side
+
+1. **moonshine.ts** (new file):
+   - `MOONSHINE_MODELS` config with two models: tiny-en (~30MB) and base-en (~65MB)
+   - `extractVariantFromPath()` helper to derive model variant from directory name
+   - `createMoonshineTranscriptionService()` with full error handling
+
+2. **types.ts**:
+   - Added `MoonshineModelConfig` type (simplified - no redundant `variant` field)
+
+3. **registry.ts**:
+   - Added moonshine to `TRANSCRIPTION_SERVICE_IDS`
+   - Added moonshine service entry and capabilities
+
+4. **settings.ts**:
+   - Added `transcription.moonshine.modelPath` setting
+   - Removed redundant `transcription.moonshine.variant` (derived from path)
+
+5. **transcription.ts** (query layer):
+   - Added moonshine case in the transcribe switch statement
+
+6. **UI Components**:
+   - LocalModelSelector.svelte: Added moonshine case
+   - LocalModelDownloadCard.svelte: Added moonshine case
+   - +page.svelte (transcription settings): Added moonshine tab
+
+## Key Design Decisions
+
+### Variant Inference from Directory Name
+
+Moonshine ONNX files don't self-describe their architecture (unlike Whisper .bin or Parakeet config.json). Rather than storing variant as a separate setting, we:
+
+1. Use directory naming convention: `moonshine-{variant}-{lang}` (e.g., `moonshine-tiny-en`)
+2. Extract variant at transcription time via `extractVariantFromPath()`
+3. Pass variant to Rust command which converts to `MoonshineModelParams::tiny()` or `::base()`
+
+This eliminates redundant metadata while keeping the design simple.
+
+### Model Architecture Reference
+
+| Variant | Layers | Head Dim | Size (quantized) |
+|---------|--------|----------|------------------|
+| tiny    | 6      | 36       | ~30 MB           |
+| base    | 8      | 52       | ~65 MB           |
+
+Language-specific variants (ar, zh, ja, ko, uk, vi, es) share architecture with their base variant but have different tokenizers/training.
+
+### Cross-Platform Path Handling
+
+Uses Tauri's `sep()` from `@tauri-apps/api/path` instead of hardcoded `/` for Windows compatibility.
+
+## Files Modified
+
+```
+apps/whispering/src/lib/services/transcription/local/moonshine.ts (new)
+apps/whispering/src/lib/services/transcription/local/types.ts
+apps/whispering/src/lib/services/transcription/index.ts
+apps/whispering/src/lib/services/transcription/registry.ts
+apps/whispering/src/lib/query/transcription.ts
+apps/whispering/src/lib/settings/settings.ts
+apps/whispering/src/lib/constants/paths.ts
+apps/whispering/src/lib/components/settings/selectors/LocalModelSelector.svelte
+apps/whispering/src/lib/components/settings/selectors/LocalModelDownloadCard.svelte
+apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
+apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
+```
+
+## HuggingFace Model URLs
+
+- Base: `https://huggingface.co/UsefulSensors/moonshine/resolve/main`
+- ONNX files: `onnx/merged/{variant}/quantized/`
+- Tokenizer: `ctranslate2/tiny/tokenizer.json` (shared across all variants)
+
+## Potential Future Work
+
+1. Add language-specific models when quantized versions become available
+2. Consider caching the `sep()` call since it's synchronous but called on every transcription
+3. Add GPU acceleration options if transcribe-rs exposes them for Moonshine

--- a/specs/20251221T120000-language-settings-redesign.md
+++ b/specs/20251221T120000-language-settings-redesign.md
@@ -1,0 +1,298 @@
+# Language Settings Redesign
+
+## Problem Statement
+
+The current language system has a fundamental mismatch between storage (global) and usage (model-specific):
+
+1. **Global storage, varied capabilities**: `transcription.outputLanguage` stores one language, but models support different language sets
+2. **Binary capability flag**: Services only declare `supportsLanguage: boolean`, not which languages
+3. **Model-specific languages ignored**: Moonshine embeds language in model path (e.g., `moonshine-tiny-en`), but this isn't surfaced to users
+4. **Confusing disabled state**: When language selector is disabled (Moonshine/Parakeet), users don't understand what language will be used
+
+## Current Architecture
+
+```
+settings.ts:175-177
+├── transcription.outputLanguage: 'auto' | 'en' | 'fr' | ... (66 languages)
+
+registry.ts:237-247
+├── ServiceCapabilities.supportsLanguage: boolean
+│   ├── whispercpp: true
+│   ├── parakeet: false (auto-detects)
+│   ├── moonshine: false (English-only currently)
+│   └── cloud services: true
+
++page.svelte:764-790
+└── Language dropdown disabled when supportsLanguage === false
+```
+
+## Model Language Categories
+
+| Category | Examples | Language Behavior |
+|----------|----------|-------------------|
+| **Multilingual API** | OpenAI, Groq, Deepgram, Mistral | All 66 languages via API parameter |
+| **Multilingual Local** | WhisperCPP | All 66 languages via Rust parameter |
+| **Auto-Detect** | Parakeet | Detects language from audio |
+| **Language-Specific** | Moonshine | Language baked into model file |
+
+## Design Options
+
+### Option A: Global Preference + Model Awareness
+
+Keep global language, but make each model "aware" of whether it can honor that preference.
+
+```typescript
+// settings.ts - unchanged
+'transcription.outputLanguage': type.enumerated(...SUPPORTED_LANGUAGES).default('auto')
+
+// registry.ts - enhanced
+type LanguageCapability =
+  | { type: 'multilingual'; languages: SupportedLanguage[] }
+  | { type: 'auto-detect' }
+  | { type: 'model-specific' }; // language derived from model path
+
+// UI behavior
+// - Show global preference (always)
+// - Show model-specific status: "Moonshine: English only (ignores your preference)"
+// - At transcription: warn if mismatch, proceed anyway
+```
+
+**Pros:**
+- Minimal settings.ts changes
+- Clear user preference
+- One-time setup for polyglot users
+
+**Cons:**
+- Confusing when preference is ignored
+- Warning fatigue
+- Moonshine users never see their preference honored
+
+### Option B: Per-Model Language Settings (Recommended)
+
+Each model has its own language setting, validated against its capabilities.
+
+```typescript
+// settings.ts - per-service language
+'transcription.whispercpp.language': type.enumerated(...SUPPORTED_LANGUAGES).default('auto'),
+'transcription.openai.language': type.enumerated(...SUPPORTED_LANGUAGES).default('auto'),
+'transcription.groq.language': type.enumerated(...SUPPORTED_LANGUAGES).default('auto'),
+// ... other multilingual services
+
+// Moonshine: no language setting - derived from model path
+// Parakeet: no language setting - auto-detects
+
+// Migration: copy current outputLanguage to all per-service settings
+
+// UI behavior
+// - Each service tab shows its own language selector (if applicable)
+// - Moonshine tab shows: "Language: English (from model: tiny-en)"
+// - Parakeet tab shows: "Language: Auto-detected from audio"
+```
+
+**Pros:**
+- Clear what each service will do
+- No warnings or confusion
+- Model-specific services just show their language
+- Users can have different languages per service (rare but valid use case)
+
+**Cons:**
+- More settings to manage
+- Polyglot users set language on each service
+- Migration complexity
+
+### Option C: Superset with Warnings
+
+Show all languages from all services, warn at transcription time.
+
+```typescript
+// Keep global setting
+'transcription.outputLanguage': type.enumerated(...SUPPORTED_LANGUAGES).default('auto')
+
+// At transcription time
+if (!model.supportsLanguage(selectedLanguage)) {
+  toast.warning(`${model.name} doesn't support ${language}, using ${model.defaultLanguage}`);
+}
+```
+
+**Pros:**
+- Simplest implementation
+- No migration needed
+
+**Cons:**
+- Warning fatigue
+- Unclear what language will actually be used
+- Poor UX for Moonshine/Parakeet users
+
+---
+
+## Recommended Design: Option B (Per-Model Language)
+
+### Phase 1: Add Per-Service Language Settings
+
+**settings.ts changes:**
+```typescript
+// Multilingual services get their own language setting
+'transcription.whispercpp.language': type.enumerated(...SUPPORTED_LANGUAGES).default('auto'),
+'transcription.openai.language': type.enumerated(...SUPPORTED_LANGUAGES).default('auto'),
+'transcription.groq.language': type.enumerated(...SUPPORTED_LANGUAGES).default('auto'),
+'transcription.deepgram.language': type.enumerated(...SUPPORTED_LANGUAGES).default('auto'),
+'transcription.elevenlabs.language': type.enumerated(...SUPPORTED_LANGUAGES).default('auto'),
+'transcription.mistral.language': type.enumerated(...SUPPORTED_LANGUAGES).default('auto'),
+'transcription.speaches.language': type.enumerated(...SUPPORTED_LANGUAGES).default('auto'),
+
+// Remove or deprecate
+// 'transcription.outputLanguage' - keep temporarily for migration
+```
+
+### Phase 2: Enhanced Registry
+
+**registry.ts changes:**
+```typescript
+type LanguageCapability =
+  | { type: 'multilingual'; languages: SupportedLanguage[] }
+  | { type: 'auto-detect'; description: string }
+  | { type: 'model-specific'; extractLanguage: (modelPath: string) => string };
+
+const TRANSCRIPTION_SERVICE_CAPABILITIES = {
+  whispercpp: {
+    languageCapability: { type: 'multilingual', languages: SUPPORTED_LANGUAGES },
+    // ... other capabilities
+  },
+  parakeet: {
+    languageCapability: { type: 'auto-detect', description: 'Parakeet automatically detects language from audio' },
+  },
+  moonshine: {
+    languageCapability: {
+      type: 'model-specific',
+      extractLanguage: (path) => extractMoonshineLanguage(path) // Returns 'en', 'fr', etc.
+    },
+  },
+  // ... cloud services all get multilingual
+};
+```
+
+### Phase 3: UI Updates
+
+**+page.svelte changes:**
+
+Each service tab renders its appropriate language UI:
+
+```svelte
+{#if capability.languageCapability.type === 'multilingual'}
+  <Select.Root bind:value={settings.value[`transcription.${service}.language`]}>
+    <!-- Standard language dropdown -->
+  </Select.Root>
+{:else if capability.languageCapability.type === 'auto-detect'}
+  <Field.Description>
+    {capability.languageCapability.description}
+  </Field.Description>
+{:else if capability.languageCapability.type === 'model-specific'}
+  {@const detectedLanguage = capability.languageCapability.extractLanguage(modelPath)}
+  <Field.Description>
+    Language: {SUPPORTED_LANGUAGES_TO_LABEL[detectedLanguage]} (determined by downloaded model)
+  </Field.Description>
+{/if}
+```
+
+### Phase 4: Transcription Layer Updates
+
+**transcription.ts changes:**
+
+```typescript
+// For multilingual services
+const language = settings.value[`transcription.${service}.language`];
+
+// For model-specific (Moonshine)
+const language = extractMoonshineLanguage(settings.value['transcription.moonshine.modelPath']);
+
+// For auto-detect (Parakeet)
+// Don't pass language parameter
+```
+
+### Phase 5: Migration
+
+Create migration to copy global language to all per-service settings:
+
+```typescript
+// In settings initialization
+function migrateLanguageSettings(settings: Settings) {
+  const globalLanguage = settings['transcription.outputLanguage'];
+  if (globalLanguage && globalLanguage !== 'auto') {
+    // Copy to all multilingual services that haven't been set
+    for (const service of MULTILINGUAL_SERVICES) {
+      if (!settings[`transcription.${service}.language`]) {
+        settings[`transcription.${service}.language`] = globalLanguage;
+      }
+    }
+  }
+}
+```
+
+---
+
+## Moonshine Language-in-Model Design
+
+For Moonshine specifically, language is determined by which model is downloaded:
+
+1. **Current models**: Only English (tiny-en, base-en)
+2. **Future models**: Other languages (tiny-ar, tiny-zh, etc.)
+
+The UI should:
+1. Show available models with language in name: "Tiny (English)", "Base (English)"
+2. When downloaded, extract language from path
+3. Display: "Language: English (from your downloaded model)"
+
+No separate language setting needed - the model selection IS the language selection.
+
+---
+
+## Alternative: Hybrid Approach
+
+If per-model feels like too much friction:
+
+1. Keep global `transcription.outputLanguage` as "preferred language"
+2. Add per-service override: `transcription.{service}.languageOverride: 'global' | SupportedLanguage`
+3. Default to 'global' (uses global setting)
+4. User can override per-service if needed
+
+This gives:
+- Simple default (one language for everything)
+- Power user flexibility (override per service)
+- Clear behavior for model-specific services (ignore preference, show what they use)
+
+---
+
+## Decision Needed
+
+1. **Option B (Per-Model)**: Cleaner long-term, more upfront work
+2. **Hybrid**: Best of both worlds, but adds complexity
+3. **Option C (Superset + Warnings)**: Quick fix, but poor UX
+
+My recommendation: **Option B (Per-Model)** for these reasons:
+- Matches how models actually work (language is model-specific)
+- No confusing warnings or disabled states
+- Clear UX: "each tab shows what that model will do"
+- Scales well when more language-specific local models are added
+- One-time setup cost is minimal (most users pick one service and stick with it)
+
+---
+
+## Todo List
+
+- [ ] Add per-service language settings to settings.ts
+- [ ] Add migration from global to per-service
+- [ ] Update registry.ts with LanguageCapability type
+- [ ] Update transcription.ts to use per-service language
+- [ ] Update UI to show per-service language selector
+- [ ] Add language extraction for Moonshine model paths
+- [ ] Add "auto-detect" display for Parakeet
+- [ ] Test migration path
+- [ ] Remove deprecated global outputLanguage (later)
+
+---
+
+## Questions for Review
+
+1. Should we keep the global setting as a "default for new services" or fully remove it?
+2. For Moonshine, should we support multiple downloaded models (user picks which language model to use)?
+3. Should the migration be automatic or require user action?


### PR DESCRIPTION
This adds Moonshine as a new local transcription engine, providing a fast, lightweight ONNX-based alternative to whisper-cpp. Moonshine models are 5-15x faster than equivalent Whisper models and use prebuilt ONNX binaries, avoiding the complex compilation issues that have plagued whisper-cpp builds (particularly with Vulkan on Windows).

The implementation follows the established patterns from Parakeet integration. Moonshine models are downloaded from HuggingFace (UsefulSensors/moonshine) and stored in the app's data directory. Two model variants are available: Tiny (~30 MB, 6-layer) and Base (~65 MB, 8-layer), both English-only.

On the Rust side, the `transcribe-rs` dependency was upgraded from 0.1.5 to 0.2.0 with explicit feature flags for each engine (`whisper`, `parakeet`, `moonshine`). The ModelManager now lazily loads Moonshine engines following the same mutex-guarded pattern used for other engines, with automatic unloading when switching between engine types.

The TypeScript integration adds a complete service implementation with type-safe model configurations, HuggingFace download URLs, and error handling using arktype for runtime validation of Rust error types. The UI components (LocalModelDownloadCard, LocalModelSelector, TranscriptionSelector) were extended to support the new engine.

Note: whisper-cpp remains enabled in this PR. Disabling it and removing Vulkan dependencies is planned as a separate change once Moonshine is validated in production.