### PR TITLE
feat: temporarily disable whisper.cpp, add Moonshine as default

### DIFF
--- a/.github/workflows/pr-preview-builds.yml
+++ b/.github/workflows/pr-preview-builds.yml
@@ -74,25 +74,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxdo-dev libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev
 
-      - name: Prepare Vulkan SDK for Ubuntu
-        if: matrix.platform == 'ubuntu-22.04'
-        run: |
-          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.290-jammy.list https://packages.lunarg.com/vulkan/1.3.290/lunarg-vulkan-1.3.290-jammy.list
-          sudo apt update
-          sudo apt install -y vulkan-sdk mesa-vulkan-drivers
-
       - name: setup bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: "package.json"
-
-      - name: Install Vulkan SDK
-        if: matrix.platform == 'windows-latest'
-        uses: humbletim/install-vulkan-sdk@v1.2
-        with:
-          version: 1.4.309.0
-          cache: true
 
       - name: setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/publish-tauri-releases.yml
+++ b/.github/workflows/publish-tauri-releases.yml
@@ -100,30 +100,11 @@ jobs:
           # - libxrandr-dev: X11 RandR extension for display configuration
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxdo-dev libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev
 
-      # Linux Vulkan SDK installation
-      - name: Prepare Vulkan SDK for Ubuntu
-        if: matrix.platform == 'ubuntu-22.04'
-        run: |
-          # Add official Vulkan SDK repository
-          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
-          # Note: Using "jammy" for Ubuntu 22.04 (not "noble" which is for 24.04)
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.290-jammy.list https://packages.lunarg.com/vulkan/1.3.290/lunarg-vulkan-1.3.290-jammy.list
-          sudo apt update
-          sudo apt install -y vulkan-sdk mesa-vulkan-drivers
-
       # Setup Bun package manager
       - name: setup bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: "package.json"
-
-      # Windows Vulkan SDK installation
-      - name: Install Vulkan SDK
-        if: matrix.platform == 'windows-latest'
-        uses: humbletim/install-vulkan-sdk@v1.2
-        with:
-          version: 1.4.309.0
-          cache: true
 
       # Setup Node.js for compatibility
       - name: setup node

--- a/apps/whispering/src-tauri/Cargo.lock
+++ b/apps/whispering/src-tauri/Cargo.lock
@@ -368,26 +368,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
 
 [[package]]
-name = "bindgen"
-version = "0.71.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
-dependencies = [
- "bitflags 2.10.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.111",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,15 +638,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom 7.1.3",
-]
-
-[[package]]
 name = "cfb"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,32 +683,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading 0.8.9",
-]
-
-[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b042e5d8a74ae91bb0961acd039822472ec99f8ab0948cbf6d1369588f8be586"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1694,12 +1645,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2631,15 +2576,6 @@ checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
 dependencies = [
  "is-docker",
  "once_cell",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -4151,16 +4087,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.111",
-]
-
-[[package]]
 name = "primal-check"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4521,7 +4447,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
 dependencies = [
  "either",
- "itertools 0.14.0",
+ "itertools",
  "rayon",
 ]
 
@@ -6285,7 +6211,7 @@ dependencies = [
  "esaxx-rs",
  "getrandom 0.3.4",
  "indicatif",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "macro_rules_attribute",
  "monostate",
@@ -6557,7 +6483,6 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.17",
  "tokenizers",
- "whisper-rs",
 ]
 
 [[package]]
@@ -7162,28 +7087,6 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
-
-[[package]]
-name = "whisper-rs"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ea5d2401f30f51d08126a2d133fee4c1955136519d7ac6cf6f5ac0a91e6bc8"
-dependencies = [
- "libc",
- "whisper-rs-sys",
-]
-
-[[package]]
-name = "whisper-rs-sys"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e2a6e06e7ac7b8f53c53a5f50bb0bc823ba69b63ecd887339f807a5598bbd2"
-dependencies = [
- "bindgen",
- "cfg-if",
- "cmake",
- "fs_extra",
-]
 
 [[package]]
 name = "whispering"

--- a/apps/whispering/src-tauri/Cargo.toml
+++ b/apps/whispering/src-tauri/Cargo.toml
@@ -48,7 +48,7 @@ tempfile = "3.8"
 rubato = "0.15"
 tauri-plugin-macos-permissions = "2.3.0"
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
-transcribe-rs = { version = "0.2.0", features = ["whisper", "parakeet", "moonshine"] }
+transcribe-rs = { version = "0.2.0", features = ["parakeet", "moonshine"] }
 regex = "1"
 rayon = "1.10"
 log = "0.4"

--- a/apps/whispering/src-tauri/src/transcription/mod.rs
+++ b/apps/whispering/src-tauri/src/transcription/mod.rs
@@ -12,10 +12,11 @@ use transcribe_rs::{
     engines::{
         moonshine::MoonshineModelParams,
         parakeet::{ParakeetInferenceParams, TimestampGranularity},
-        whisper::WhisperInferenceParams,
     },
     TranscriptionEngine,
 };
+#[cfg(feature = "whisper")]
+use transcribe_rs::engines::whisper::WhisperInferenceParams;
 
 #[cfg(target_os = "windows")]
 const CREATE_NO_WINDOW: u32 = 0x08000000;
@@ -486,6 +487,7 @@ fn extract_samples_from_wav(wav_data: Vec<u8>) -> Result<Vec<f32>, Transcription
     Ok(samples)
 }
 
+#[cfg(feature = "whisper")]
 #[tauri::command]
 pub async fn transcribe_audio_whisper(
     audio_data: Vec<u8>,
@@ -578,6 +580,20 @@ pub async fn transcribe_audio_whisper(
         transcript.len()
     );
     Ok(transcript)
+}
+
+#[cfg(not(feature = "whisper"))]
+#[tauri::command]
+pub async fn transcribe_audio_whisper(
+    _audio_data: Vec<u8>,
+    _model_path: String,
+    _language: Option<String>,
+    _initial_prompt: Option<String>,
+    _model_manager: tauri::State<'_, ModelManager>,
+) -> Result<String, TranscriptionError> {
+    Err(TranscriptionError::TranscriptionError {
+        message: "Whisper C++ is temporarily unavailable due to upstream build issues. Please use Moonshine or Parakeet for local transcription, or a cloud provider.".to_string(),
+    })
 }
 
 #[tauri::command]

--- a/apps/whispering/src-tauri/src/transcription/model_manager.rs
+++ b/apps/whispering/src-tauri/src/transcription/model_manager.rs
@@ -4,12 +4,14 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 use transcribe_rs::engines::moonshine::{MoonshineEngine, MoonshineModelParams};
 use transcribe_rs::engines::parakeet::{ParakeetEngine, ParakeetModelParams};
+#[cfg(feature = "whisper")]
 use transcribe_rs::engines::whisper::WhisperEngine;
 use transcribe_rs::TranscriptionEngine;
 
 /// Engine type for managing different transcription engines
 pub enum Engine {
     Parakeet(ParakeetEngine),
+    #[cfg(feature = "whisper")]
     Whisper(WhisperEngine),
     Moonshine(MoonshineEngine),
 }
@@ -18,6 +20,7 @@ impl Engine {
     fn unload(&mut self) {
         match self {
             Engine::Parakeet(e) => e.unload_model(),
+            #[cfg(feature = "whisper")]
             Engine::Whisper(e) => e.unload_model(),
             Engine::Moonshine(e) => e.unload_model(),
         }
@@ -68,6 +71,7 @@ impl ModelManager {
                 }
                 true
             }
+            #[cfg(feature = "whisper")]
             (Some(Engine::Whisper(_)), _) => {
                 // Wrong engine type, unload and reload
                 if let Some(mut engine) = engine_guard.take() {
@@ -98,6 +102,7 @@ impl ModelManager {
         Ok(self.engine.clone())
     }
 
+    #[cfg(feature = "whisper")]
     pub fn get_or_load_whisper(
         &self,
         model_path: PathBuf,
@@ -155,6 +160,14 @@ impl ModelManager {
         Ok(self.engine.clone())
     }
 
+    #[cfg(not(feature = "whisper"))]
+    pub fn get_or_load_whisper(
+        &self,
+        _model_path: PathBuf,
+    ) -> Result<Arc<Mutex<Option<Engine>>>, String> {
+        Err("Whisper C++ is temporarily unavailable due to upstream build issues. Use Moonshine or Parakeet instead.".to_string())
+    }
+
     pub fn get_or_load_moonshine(
         &self,
         model_path: PathBuf,
@@ -183,7 +196,15 @@ impl ModelManager {
                 }
                 true
             }
-            (Some(Engine::Whisper(_)), _) | (Some(Engine::Parakeet(_)), _) => {
+            #[cfg(feature = "whisper")]
+            (Some(Engine::Whisper(_)), _) => {
+                // Wrong engine type, unload and reload
+                if let Some(mut engine) = engine_guard.take() {
+                    engine.unload();
+                }
+                true
+            }
+            (Some(Engine::Parakeet(_)), _) => {
                 // Wrong engine type, unload and reload
                 if let Some(mut engine) = engine_guard.take() {
                     engine.unload();

--- a/apps/whispering/src/lib/query/transcription.ts
+++ b/apps/whispering/src/lib/query/transcription.ts
@@ -244,19 +244,20 @@ async function transcribeBlob(
 							modelName: settings.value['transcription.mistral.model'],
 						},
 					);
-				case 'whispercpp': {
-					// Pure Rust audio conversion now handles most formats without FFmpeg
-					// Only compressed formats (MP3, M4A) require FFmpeg, which will be
-					// handled automatically as a fallback in the Rust conversion pipeline
-					return await services.transcriptions.whispercpp.transcribe(
-						audioToTranscribe,
-						{
-							outputLanguage: settings.value['transcription.outputLanguage'],
-							modelPath: settings.value['transcription.whispercpp.modelPath'],
-							prompt: settings.value['transcription.prompt'],
-						},
-					);
-				}
+				// case 'whispercpp': {
+				// 	// Temporarily disabled due to upstream build issues
+				// // Pure Rust audio conversion now handles most formats without FFmpeg
+				// // Only compressed formats (MP3, M4A) require FFmpeg, which will be
+				// // handled automatically as a fallback in the Rust conversion pipeline
+				// 	return await services.transcriptions.whispercpp.transcribe(
+				// 		audioToTranscribe,
+				// 		{
+				// 			outputLanguage: settings.value['transcription.outputLanguage'],
+				// 			modelPath: settings.value['transcription.whispercpp.modelPath'],
+				// 			prompt: settings.value['transcription.prompt'],
+				// 		},
+				// 	);
+				// }
 				case 'parakeet': {
 					// Pure Rust audio conversion now handles most formats without FFmpeg
 					// Only compressed formats (MP3, M4A) require FFmpeg, which will be

--- a/apps/whispering/src/lib/services/transcription/registry.ts
+++ b/apps/whispering/src/lib/services/transcription/registry.ts
@@ -196,6 +196,10 @@ export const TRANSCRIPTION_SERVICE_OPTIONS = TRANSCRIPTION_SERVICES.map(
 	}),
 );
 
+export const TRANSCRIPTION_SERVICE_ID_TO_LABEL = Object.fromEntries(
+	TRANSCRIPTION_SERVICES.map((s) => [s.id, s.name]),
+) as Record<TranscriptionServiceId, string>;
+
 export type TranscriptionService = (typeof TRANSCRIPTION_SERVICES)[number];
 
 /**

--- a/apps/whispering/src/lib/services/transcription/registry.ts
+++ b/apps/whispering/src/lib/services/transcription/registry.ts
@@ -35,7 +35,7 @@ type TranscriptionModel =
 	| MistralModel;
 
 export const TRANSCRIPTION_SERVICE_IDS = [
-	'whispercpp',
+	// 'whispercpp', // Temporarily disabled due to upstream build issues
 	'parakeet',
 	'moonshine',
 	'Groq',
@@ -82,15 +82,15 @@ type SatisfiedTranscriptionService =
 
 export const TRANSCRIPTION_SERVICES = [
 	// Local services first (truly offline)
-	{
-		id: 'whispercpp',
-		name: 'Whisper C++',
-		icon: ggmlIcon,
-		invertInDarkMode: true,
-		description: 'Fast local transcription with no internet required',
-		modelPathField: 'transcription.whispercpp.modelPath',
-		location: 'local',
-	},
+	// {
+	// 	id: 'whispercpp',
+	// 	name: 'Whisper C++',
+	// 	icon: ggmlIcon,
+	// 	invertInDarkMode: true,
+	// 	description: 'Fast local transcription with no internet required',
+	// 	modelPathField: 'transcription.whispercpp.modelPath',
+	// 	location: 'local',
+	// }, // Temporarily disabled due to upstream build issues
 	{
 		id: 'parakeet',
 		name: 'Parakeet',
@@ -235,7 +235,7 @@ type ServiceCapabilities = {
  * ```
  */
 export const TRANSCRIPTION_SERVICE_CAPABILITIES = {
-	whispercpp: { supportsPrompt: true, supportsTemperature: false, supportsLanguage: true },
+	// whispercpp: { supportsPrompt: true, supportsTemperature: false, supportsLanguage: true }, // Temporarily disabled
 	parakeet: { supportsPrompt: false, supportsTemperature: false, supportsLanguage: false },
 	moonshine: { supportsPrompt: false, supportsTemperature: false, supportsLanguage: false },
 	Groq: { supportsPrompt: true, supportsTemperature: true, supportsLanguage: true },

--- a/apps/whispering/src/lib/settings/settings.ts
+++ b/apps/whispering/src/lib/settings/settings.ts
@@ -170,7 +170,7 @@ export const Settings = type({
 
 	'transcription.selectedTranscriptionService': type
 		.enumerated(...TRANSCRIPTION_SERVICE_IDS)
-		.default('whispercpp'),
+		.default('moonshine'),
 	// Shared settings in transcription
 	'transcription.outputLanguage': type
 		.enumerated(...SUPPORTED_LANGUAGES)

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
@@ -91,10 +91,12 @@
 	);
 
 	const localTranscriptionServiceName = $derived(
-		settings.value['transcription.selectedTranscriptionService'] ===
-			'whispercpp'
-			? 'Whisper C++'
-			: 'Parakeet',
+		(
+			{
+				parakeet: 'Parakeet',
+				moonshine: 'Moonshine',
+			} as const
+		)[settings.value['transcription.selectedTranscriptionService']],
 	);
 </script>
 
@@ -110,307 +112,310 @@
 	<Field.Separator />
 	<Field.Group>
 		<Field.Field>
-		<Field.Label for="recording-mode">Recording Mode</Field.Label>
-		<Select.Root
-			type="single"
-			bind:value={
-				() => settings.value['recording.mode'],
-				(selected) => {
-					if (selected) settings.updateKey('recording.mode', selected);
-				}
-			}
-		>
-			<Select.Trigger id="recording-mode" class="w-full">
-				{recordingModeLabel ?? 'Select a recording mode'}
-			</Select.Trigger>
-			<Select.Content>
-				{#each RECORDING_MODE_OPTIONS as item}
-					<Select.Item value={item.value} label={item.label} />
-				{/each}
-			</Select.Content>
-		</Select.Root>
-		<Field.Description>
-			Choose how you want to activate recording: {RECORDING_MODE_OPTIONS.map(
-				(option) => option.label.toLowerCase(),
-			).join(', ')}
-		</Field.Description>
-	</Field.Field>
-
-	{#if window.__TAURI_INTERNALS__ && settings.value['recording.mode'] === 'manual'}
-		<Field.Field>
-			<Field.Label for="recording-method">Recording Method</Field.Label>
+			<Field.Label for="recording-mode">Recording Mode</Field.Label>
 			<Select.Root
 				type="single"
 				bind:value={
-					() => settings.value['recording.method'],
+					() => settings.value['recording.mode'],
 					(selected) => {
-						if (selected)
-							settings.updateKey(
-								'recording.method',
-								selected as 'cpal' | 'navigator' | 'ffmpeg',
-							);
+						if (selected) settings.updateKey('recording.mode', selected);
 					}
 				}
 			>
-				<Select.Trigger id="recording-method" class="w-full">
-					{recordingMethodLabel ?? 'Select a recording method'}
+				<Select.Trigger id="recording-mode" class="w-full">
+					{recordingModeLabel ?? 'Select a recording mode'}
 				</Select.Trigger>
 				<Select.Content>
-					{#each RECORDING_METHOD_OPTIONS as item}
-						<Select.Item value={item.value} label={item.label}>
-							<div class="flex flex-col gap-0.5">
-								<div class="font-medium">{item.label}</div>
-								{#if item.description}
-									<div class="text-xs text-muted-foreground">
-										{item.description}
-									</div>
-								{/if}
-							</div>
-						</Select.Item>
+					{#each RECORDING_MODE_OPTIONS as item}
+						<Select.Item value={item.value} label={item.label} />
 					{/each}
 				</Select.Content>
 			</Select.Root>
 			<Field.Description>
-				{RECORDING_METHOD_OPTIONS.find(
-					(option) => option.value === settings.value['recording.method'],
-				)?.description}
+				Choose how you want to activate recording: {RECORDING_MODE_OPTIONS.map(
+					(option) => option.label.toLowerCase(),
+				).join(', ')}
 			</Field.Description>
 		</Field.Field>
 
-		{#if IS_MACOS && settings.value['recording.method'] === 'navigator'}
-			<Alert.Root class="border-warning/20 bg-warning/5">
-				<InfoIcon class="size-4 text-warning dark:text-warning" />
-				<Alert.Title class="text-warning dark:text-warning">
-					Global Shortcuts May Be Unreliable
-				</Alert.Title>
-				<Alert.Description>
-					When using the navigator recorder, macOS App Nap may prevent the
-					browser recording logic from starting when not in focus. Consider
-					using the CPAL method for reliable global shortcut support.
-				</Alert.Description>
-			</Alert.Root>
-		{/if}
-
-		{#if settings.value['recording.method'] === 'ffmpeg' && !data.ffmpegInstalled}
-			<Alert.Root class="border-red-500/20 bg-red-500/5">
-				<InfoIcon class="size-4 text-red-600 dark:text-red-400" />
-				<Alert.Title class="text-red-600 dark:text-red-400">
-					FFmpeg Not Installed
-				</Alert.Title>
-				<Alert.Description>
-					FFmpeg is required for the FFmpeg recording method. Please install it
-					to use this feature.
-					<Link
-						href="/install-ffmpeg"
-						class="font-medium underline underline-offset-4 hover:text-red-700 dark:hover:text-red-300"
-					>
-						Install FFmpeg →
-					</Link>
-				</Alert.Description>
-			</Alert.Root>
-		{:else if isCompressionRecommended()}
-			<Alert.Root class="border-blue-500/20 bg-blue-500/5">
-				<InfoIcon class="size-4 text-blue-600 dark:text-blue-400" />
-				<Alert.Title class="text-blue-600 dark:text-blue-400">
-					Enable Compression for Faster Uploads
-				</Alert.Title>
-				<Alert.Description>
-					{COMPRESSION_RECOMMENDED_MESSAGE}
-					<Link
-						href="/settings/transcription"
-						class="font-medium underline underline-offset-4 hover:text-blue-700 dark:hover:text-blue-300"
-					>
-						Enable in Transcription Settings →
-					</Link>
-				</Alert.Description>
-			</Alert.Root>
-		{/if}
-
-		{#if hasNavigatorLocalTranscriptionIssue( { isFFmpegInstalled: data.ffmpegInstalled ?? false }, )}
-			<Alert.Root class="border-red-500/20 bg-red-500/5">
-				<InfoIcon class="size-4 text-red-600 dark:text-red-400" />
-				<Alert.Title class="text-red-600 dark:text-red-400">
-					Local Transcription Requires FFmpeg or CPAL Recording
-				</Alert.Title>
-				<Alert.Description>
-					The Browser API recording method produces compressed audio that
-					requires FFmpeg for local transcription with {localTranscriptionServiceName}.
-					<div class="mt-3 space-y-3">
-						<div class="flex items-center gap-2">
-							<span class="text-sm"><strong>Option 1:</strong></span>
-							<Button
-								onclick={() => settings.updateKey('recording.method', 'cpal')}
-								variant="secondary"
-								size="sm"
-							>
-								Switch to CPAL Recording
-							</Button>
-						</div>
-						<div class="text-sm">
-							<strong>Option 2:</strong>
-							<Link href="/install-ffmpeg">Install FFmpeg</Link>
-							to keep using Browser API recording
-						</div>
-						<div class="text-sm">
-							<strong>Option 3:</strong>
-							Switch to a cloud transcription service (OpenAI, Groq, Deepgram, etc.)
-							which work with all recording methods
-						</div>
-					</div>
-				</Alert.Description>
-			</Alert.Root>
-		{/if}
-	{/if}
-
-	{#if settings.value['recording.mode'] === 'manual'}
-		{@const method = settings.value['recording.method']}
-		<ManualSelectRecordingDevice
-			bind:selected={
-				() => settings.value[`recording.${method}.deviceId`],
-				(selected) =>
-					settings.updateKey(`recording.${method}.deviceId`, selected)
-			}
-		/>
-	{:else if settings.value['recording.mode'] === 'vad'}
-		{#if IS_LINUX}
-			<Alert.Root class="border-red-500/20 bg-red-500/5">
-				<InfoIcon class="size-4 text-red-600 dark:text-red-400" />
-				<Alert.Title class="text-red-600 dark:text-red-400">
-					VAD Mode Not Supported on Linux
-				</Alert.Title>
-				<Alert.Description>
-					Voice Activated Detection (VAD) mode requires the browser's Navigator
-					API, which is not fully supported in Tauri on Linux. Device
-					enumeration and recording will fail. Please use Manual recording mode
-					instead.
-					<Link
-						href="https://github.com/EpicenterHQ/epicenter/issues/839"
-						target="_blank"
-						class="font-medium underline underline-offset-4 hover:text-red-700 dark:hover:text-red-300"
-					>
-						Learn more →
-					</Link>
-				</Alert.Description>
-			</Alert.Root>
-		{:else}
-			<Alert.Root class="border-blue-500/20 bg-blue-500/5">
-				<InfoIcon class="size-4 text-blue-600 dark:text-blue-400" />
-				<Alert.Title class="text-blue-600 dark:text-blue-400">
-					Voice Activated Detection Mode
-				</Alert.Title>
-				<Alert.Description>
-					VAD mode uses the browser's Web Audio API for real-time voice
-					detection and records via the browser's MediaRecorder API. Audio is
-					encoded to uncompressed WAV format. VAD mode has its own recording
-					method and cannot use CPAL or FFmpeg.
-				</Alert.Description>
-			</Alert.Root>
-		{/if}
-
-		<VadSelectRecordingDevice
-			bind:selected={
-				() => settings.value['recording.navigator.deviceId'],
-				(selected) =>
-					settings.updateKey('recording.navigator.deviceId', selected)
-			}
-		/>
-	{/if}
-
-	{#if settings.value['recording.mode'] === 'manual' || settings.value['recording.mode'] === 'vad'}
-		{#if isUsingNavigatorMethod}
-			<!-- Browser method settings -->
+		{#if window.__TAURI_INTERNALS__ && settings.value['recording.mode'] === 'manual'}
 			<Field.Field>
-				<Field.Label for="bit-rate">Bitrate</Field.Label>
+				<Field.Label for="recording-method">Recording Method</Field.Label>
 				<Select.Root
 					type="single"
 					bind:value={
-						() => settings.value['recording.navigator.bitrateKbps'],
+						() => settings.value['recording.method'],
 						(selected) => {
 							if (selected)
-								settings.updateKey('recording.navigator.bitrateKbps', selected);
+								settings.updateKey(
+									'recording.method',
+									selected as 'cpal' | 'navigator' | 'ffmpeg',
+								);
 						}
 					}
 				>
-					<Select.Trigger id="bit-rate" class="w-full">
-						{bitrateLabel ?? 'Select a bitrate'}
+					<Select.Trigger id="recording-method" class="w-full">
+						{recordingMethodLabel ?? 'Select a recording method'}
 					</Select.Trigger>
 					<Select.Content>
-						{#each BITRATE_OPTIONS as item}
-							<Select.Item value={item.value} label={item.label} />
+						{#each RECORDING_METHOD_OPTIONS as item}
+							<Select.Item value={item.value} label={item.label}>
+								<div class="flex flex-col gap-0.5">
+									<div class="font-medium">{item.label}</div>
+									{#if item.description}
+										<div class="text-xs text-muted-foreground">
+											{item.description}
+										</div>
+									{/if}
+								</div>
+							</Select.Item>
 						{/each}
 					</Select.Content>
 				</Select.Root>
 				<Field.Description>
-					The bitrate of the recording. Higher values mean better quality but
-					larger file sizes.
+					{RECORDING_METHOD_OPTIONS.find(
+						(option) => option.value === settings.value['recording.method'],
+					)?.description}
 				</Field.Description>
 			</Field.Field>
-		{:else if isUsingFfmpegMethod}
-			<!-- FFmpeg method settings -->
-			<div class="space-y-2">
-				<label for="output-folder" class="text-sm font-medium">
-					Recording Output Folder
-				</label>
-				<DesktopOutputFolder></DesktopOutputFolder>
-				<p class="text-xs text-muted-foreground">
-					Choose where to save your recordings. Default location is secure and
-					managed by the app.
-				</p>
-			</div>
 
-			<FfmpegCommandBuilder
-				bind:globalOptions={
-					() => settings.value['recording.ffmpeg.globalOptions'],
-					(v) => settings.updateKey('recording.ffmpeg.globalOptions', v)
-				}
-				bind:inputOptions={
-					() => settings.value['recording.ffmpeg.inputOptions'],
-					(v) => settings.updateKey('recording.ffmpeg.inputOptions', v)
-				}
-				bind:outputOptions={
-					() => settings.value['recording.ffmpeg.outputOptions'],
-					(v) => settings.updateKey('recording.ffmpeg.outputOptions', v)
+			{#if IS_MACOS && settings.value['recording.method'] === 'navigator'}
+				<Alert.Root class="border-warning/20 bg-warning/5">
+					<InfoIcon class="size-4 text-warning dark:text-warning" />
+					<Alert.Title class="text-warning dark:text-warning">
+						Global Shortcuts May Be Unreliable
+					</Alert.Title>
+					<Alert.Description>
+						When using the navigator recorder, macOS App Nap may prevent the
+						browser recording logic from starting when not in focus. Consider
+						using the CPAL method for reliable global shortcut support.
+					</Alert.Description>
+				</Alert.Root>
+			{/if}
+
+			{#if settings.value['recording.method'] === 'ffmpeg' && !data.ffmpegInstalled}
+				<Alert.Root class="border-red-500/20 bg-red-500/5">
+					<InfoIcon class="size-4 text-red-600 dark:text-red-400" />
+					<Alert.Title class="text-red-600 dark:text-red-400">
+						FFmpeg Not Installed
+					</Alert.Title>
+					<Alert.Description>
+						FFmpeg is required for the FFmpeg recording method. Please install
+						it to use this feature.
+						<Link
+							href="/install-ffmpeg"
+							class="font-medium underline underline-offset-4 hover:text-red-700 dark:hover:text-red-300"
+						>
+							Install FFmpeg →
+						</Link>
+					</Alert.Description>
+				</Alert.Root>
+			{:else if isCompressionRecommended()}
+				<Alert.Root class="border-blue-500/20 bg-blue-500/5">
+					<InfoIcon class="size-4 text-blue-600 dark:text-blue-400" />
+					<Alert.Title class="text-blue-600 dark:text-blue-400">
+						Enable Compression for Faster Uploads
+					</Alert.Title>
+					<Alert.Description>
+						{COMPRESSION_RECOMMENDED_MESSAGE}
+						<Link
+							href="/settings/transcription"
+							class="font-medium underline underline-offset-4 hover:text-blue-700 dark:hover:text-blue-300"
+						>
+							Enable in Transcription Settings →
+						</Link>
+					</Alert.Description>
+				</Alert.Root>
+			{/if}
+
+			{#if hasNavigatorLocalTranscriptionIssue( { isFFmpegInstalled: data.ffmpegInstalled ?? false }, )}
+				<Alert.Root class="border-red-500/20 bg-red-500/5">
+					<InfoIcon class="size-4 text-red-600 dark:text-red-400" />
+					<Alert.Title class="text-red-600 dark:text-red-400">
+						Local Transcription Requires FFmpeg or CPAL Recording
+					</Alert.Title>
+					<Alert.Description>
+						The Browser API recording method produces compressed audio that
+						requires FFmpeg for local transcription with {localTranscriptionServiceName}.
+						<div class="mt-3 space-y-3">
+							<div class="flex items-center gap-2">
+								<span class="text-sm"><strong>Option 1:</strong></span>
+								<Button
+									onclick={() => settings.updateKey('recording.method', 'cpal')}
+									variant="secondary"
+									size="sm"
+								>
+									Switch to CPAL Recording
+								</Button>
+							</div>
+							<div class="text-sm">
+								<strong>Option 2:</strong>
+								<Link href="/install-ffmpeg">Install FFmpeg</Link>
+								to keep using Browser API recording
+							</div>
+							<div class="text-sm">
+								<strong>Option 3:</strong>
+								Switch to a cloud transcription service (OpenAI, Groq, Deepgram, etc.)
+								which work with all recording methods
+							</div>
+						</div>
+					</Alert.Description>
+				</Alert.Root>
+			{/if}
+		{/if}
+
+		{#if settings.value['recording.mode'] === 'manual'}
+			{@const method = settings.value['recording.method']}
+			<ManualSelectRecordingDevice
+				bind:selected={
+					() => settings.value[`recording.${method}.deviceId`],
+					(selected) =>
+						settings.updateKey(`recording.${method}.deviceId`, selected)
 				}
 			/>
-		{:else}
-			<!-- CPAL method settings -->
-			<Field.Field>
-				<Field.Label for="sample-rate">Sample Rate</Field.Label>
-				<Select.Root
-					type="single"
-					bind:value={
-						() => settings.value['recording.cpal.sampleRate'],
-						(selected) => {
-							if (selected)
-								settings.updateKey('recording.cpal.sampleRate', selected);
-						}
-					}
-				>
-					<Select.Trigger id="sample-rate" class="w-full">
-						{sampleRateLabel ?? 'Select sample rate'}
-					</Select.Trigger>
-					<Select.Content>
-						{#each SAMPLE_RATE_OPTIONS as item}
-							<Select.Item value={item.value} label={item.label} />
-						{/each}
-					</Select.Content>
-				</Select.Root>
-				<Field.Description>
-					Higher sample rates provide better quality but create larger files
-				</Field.Description>
-			</Field.Field>
+		{:else if settings.value['recording.mode'] === 'vad'}
+			{#if IS_LINUX}
+				<Alert.Root class="border-red-500/20 bg-red-500/5">
+					<InfoIcon class="size-4 text-red-600 dark:text-red-400" />
+					<Alert.Title class="text-red-600 dark:text-red-400">
+						VAD Mode Not Supported on Linux
+					</Alert.Title>
+					<Alert.Description>
+						Voice Activated Detection (VAD) mode requires the browser's
+						Navigator API, which is not fully supported in Tauri on Linux.
+						Device enumeration and recording will fail. Please use Manual
+						recording mode instead.
+						<Link
+							href="https://github.com/EpicenterHQ/epicenter/issues/839"
+							target="_blank"
+							class="font-medium underline underline-offset-4 hover:text-red-700 dark:hover:text-red-300"
+						>
+							Learn more →
+						</Link>
+					</Alert.Description>
+				</Alert.Root>
+			{:else}
+				<Alert.Root class="border-blue-500/20 bg-blue-500/5">
+					<InfoIcon class="size-4 text-blue-600 dark:text-blue-400" />
+					<Alert.Title class="text-blue-600 dark:text-blue-400">
+						Voice Activated Detection Mode
+					</Alert.Title>
+					<Alert.Description>
+						VAD mode uses the browser's Web Audio API for real-time voice
+						detection and records via the browser's MediaRecorder API. Audio is
+						encoded to uncompressed WAV format. VAD mode has its own recording
+						method and cannot use CPAL or FFmpeg.
+					</Alert.Description>
+				</Alert.Root>
+			{/if}
 
-			<div class="space-y-2">
-				<label for="output-folder" class="text-sm font-medium">
-					Recording Output Folder
-				</label>
-				<DesktopOutputFolder></DesktopOutputFolder>
-				<p class="text-xs text-muted-foreground">
-					Choose where to save your recordings. Default location is secure and
-					managed by the app.
-				</p>
-			</div>
+			<VadSelectRecordingDevice
+				bind:selected={
+					() => settings.value['recording.navigator.deviceId'],
+					(selected) =>
+						settings.updateKey('recording.navigator.deviceId', selected)
+				}
+			/>
 		{/if}
-	{/if}
+
+		{#if settings.value['recording.mode'] === 'manual' || settings.value['recording.mode'] === 'vad'}
+			{#if isUsingNavigatorMethod}
+				<!-- Browser method settings -->
+				<Field.Field>
+					<Field.Label for="bit-rate">Bitrate</Field.Label>
+					<Select.Root
+						type="single"
+						bind:value={
+							() => settings.value['recording.navigator.bitrateKbps'],
+							(selected) => {
+								if (selected)
+									settings.updateKey(
+										'recording.navigator.bitrateKbps',
+										selected,
+									);
+							}
+						}
+					>
+						<Select.Trigger id="bit-rate" class="w-full">
+							{bitrateLabel ?? 'Select a bitrate'}
+						</Select.Trigger>
+						<Select.Content>
+							{#each BITRATE_OPTIONS as item}
+								<Select.Item value={item.value} label={item.label} />
+							{/each}
+						</Select.Content>
+					</Select.Root>
+					<Field.Description>
+						The bitrate of the recording. Higher values mean better quality but
+						larger file sizes.
+					</Field.Description>
+				</Field.Field>
+			{:else if isUsingFfmpegMethod}
+				<!-- FFmpeg method settings -->
+				<div class="space-y-2">
+					<label for="output-folder" class="text-sm font-medium">
+						Recording Output Folder
+					</label>
+					<DesktopOutputFolder></DesktopOutputFolder>
+					<p class="text-xs text-muted-foreground">
+						Choose where to save your recordings. Default location is secure and
+						managed by the app.
+					</p>
+				</div>
+
+				<FfmpegCommandBuilder
+					bind:globalOptions={
+						() => settings.value['recording.ffmpeg.globalOptions'],
+						(v) => settings.updateKey('recording.ffmpeg.globalOptions', v)
+					}
+					bind:inputOptions={
+						() => settings.value['recording.ffmpeg.inputOptions'],
+						(v) => settings.updateKey('recording.ffmpeg.inputOptions', v)
+					}
+					bind:outputOptions={
+						() => settings.value['recording.ffmpeg.outputOptions'],
+						(v) => settings.updateKey('recording.ffmpeg.outputOptions', v)
+					}
+				/>
+			{:else}
+				<!-- CPAL method settings -->
+				<Field.Field>
+					<Field.Label for="sample-rate">Sample Rate</Field.Label>
+					<Select.Root
+						type="single"
+						bind:value={
+							() => settings.value['recording.cpal.sampleRate'],
+							(selected) => {
+								if (selected)
+									settings.updateKey('recording.cpal.sampleRate', selected);
+							}
+						}
+					>
+						<Select.Trigger id="sample-rate" class="w-full">
+							{sampleRateLabel ?? 'Select sample rate'}
+						</Select.Trigger>
+						<Select.Content>
+							{#each SAMPLE_RATE_OPTIONS as item}
+								<Select.Item value={item.value} label={item.label} />
+							{/each}
+						</Select.Content>
+					</Select.Root>
+					<Field.Description>
+						Higher sample rates provide better quality but create larger files
+					</Field.Description>
+				</Field.Field>
+
+				<div class="space-y-2">
+					<label for="output-folder" class="text-sm font-medium">
+						Recording Output Folder
+					</label>
+					<DesktopOutputFolder></DesktopOutputFolder>
+					<p class="text-xs text-muted-foreground">
+						Choose where to save your recordings. Default location is secure and
+						managed by the app.
+					</p>
+				</div>
+			{/if}
+		{/if}
 	</Field.Group>
 </Field.Set>

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
@@ -19,6 +19,7 @@
 		COMPRESSION_RECOMMENDED_MESSAGE,
 		hasNavigatorLocalTranscriptionIssue,
 	} from '$routes/(app)/_layout-utils/check-ffmpeg';
+	import { TRANSCRIPTION_SERVICE_ID_TO_LABEL } from '$lib/services/transcription/registry';
 	import { IS_MACOS, IS_LINUX, PLATFORM_TYPE } from '$lib/constants/platform';
 	import { Button } from '@epicenter/ui/button';
 
@@ -88,15 +89,6 @@
 
 	const isUsingFfmpegMethod = $derived(
 		settings.value['recording.method'] === 'ffmpeg',
-	);
-
-	const localTranscriptionServiceName = $derived(
-		(
-			{
-				parakeet: 'Parakeet',
-				moonshine: 'Moonshine',
-			} as const
-		)[settings.value['transcription.selectedTranscriptionService']],
 	);
 </script>
 
@@ -236,7 +228,7 @@
 					</Alert.Title>
 					<Alert.Description>
 						The Browser API recording method produces compressed audio that
-						requires FFmpeg for local transcription with {localTranscriptionServiceName}.
+						requires FFmpeg for local transcription with {TRANSCRIPTION_SERVICE_ID_TO_LABEL[settings.value['transcription.selectedTranscriptionService']]}.
 						<div class="mt-3 space-y-3">
 							<div class="flex items-center gap-2">
 								<span class="text-sm"><strong>Option 1:</strong></span>

--- a/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
@@ -20,7 +20,7 @@
 	import { OPENAI_TRANSCRIPTION_MODELS } from '$lib/services/transcription/cloud/openai';
 	import { MOONSHINE_MODELS } from '$lib/services/transcription/local/moonshine';
 	import { PARAKEET_MODELS } from '$lib/services/transcription/local/parakeet';
-	import { WHISPER_MODELS } from '$lib/services/transcription/local/whispercpp';
+	// import { WHISPER_MODELS } from '$lib/services/transcription/local/whispercpp'; // Temporarily disabled
 	import { TRANSCRIPTION_SERVICE_CAPABILITIES } from '$lib/services/transcription/registry';
 	import { settings } from '$lib/stores/settings.svelte';
 	import InfoIcon from '@lucide/svelte/icons/info';
@@ -448,9 +448,10 @@
 				</CopyButton>
 			</Field.Description>
 		</Field.Field>
-	{:else if settings.value['transcription.selectedTranscriptionService'] === 'whispercpp'}
+	<!-- whispercpp UI temporarily disabled due to upstream build issues -->
+	<!-- {:else if settings.value['transcription.selectedTranscriptionService'] === 'whispercpp'}
 		<div class="space-y-4">
-			<!-- Whisper Model Selector Component -->
+			<! -- Whisper Model Selector Component -- >
 			{#if window.__TAURI_INTERNALS__}
 				<LocalModelSelector
 					models={WHISPER_MODELS}
@@ -541,7 +542,7 @@
 					</Alert.Root>
 				{/if}
 			{/if}
-		</div>
+		</div> -->
 	{:else if settings.value['transcription.selectedTranscriptionService'] === 'parakeet'}
 		<div class="space-y-4">
 			<!-- Parakeet Model Selector Component -->

--- a/apps/whispering/src/routes/(app)/_layout-utils/check-ffmpeg.ts
+++ b/apps/whispering/src/routes/(app)/_layout-utils/check-ffmpeg.ts
@@ -14,7 +14,10 @@ export const RECORDING_COMPATIBILITY_MESSAGE =
 
 function isUsingLocalTranscription(): boolean {
 	const service = settings.value['transcription.selectedTranscriptionService'];
-	return service === 'whispercpp' || service === 'parakeet';
+	return (
+		// service === 'whispercpp' ||
+		service === 'parakeet' || service === 'moonshine'
+	);
 }
 
 /**
@@ -31,8 +34,9 @@ export function hasNavigatorLocalTranscriptionIssue({
 	const isUsingNavigator = settings.value['recording.method'] === 'navigator';
 	const isUsingLocalTranscription =
 		settings.value['transcription.selectedTranscriptionService'] ===
-			'whispercpp' ||
-		settings.value['transcription.selectedTranscriptionService'] === 'parakeet';
+			'parakeet' ||
+		settings.value['transcription.selectedTranscriptionService'] ===
+			'moonshine';
 
 	return isUsingNavigator && isUsingLocalTranscription && !isFFmpegInstalled;
 }

--- a/bun.lock
+++ b/bun.lock
@@ -2539,19 +2539,11 @@
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
-    "@epicenter/hq/@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
-
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
-
-    "@examples/basic-workspace/@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
-
-    "@examples/content-hub/@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
-
-    "@examples/stress-test/@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
 
     "@libsql/hrana-client/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
@@ -2721,8 +2713,6 @@
 
     "@astrojs/svelte/@sveltejs/vite-plugin-svelte/@sveltejs/vite-plugin-svelte-inspector": ["@sveltejs/vite-plugin-svelte-inspector@4.0.1", "", { "dependencies": { "debug": "^4.3.7" }, "peerDependencies": { "@sveltejs/vite-plugin-svelte": "^5.0.0", "svelte": "^5.0.0", "vite": "^6.0.0" } }, "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw=="],
 
-    "@epicenter/hq/@types/bun/bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
-
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.18.20", "", { "os": "android", "cpu": "arm64" }, "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ=="],
@@ -2766,12 +2756,6 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
-
-    "@examples/basic-workspace/@types/bun/bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
-
-    "@examples/content-hub/@types/bun/bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
-
-    "@examples/stress-test/@types/bun/bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 


### PR DESCRIPTION
The whisper-rs crate has upstream build issues that are blocking our CI/CD pipeline. Rather than hold up releases, this PR temporarily disables Whisper C++ support and switches the default local transcription engine to Moonshine.

We upgraded to the latest transcribe-rs (0.2.0) and removed the whisper feature flag. The Rust code now compiles conditionally: the whisper command returns an error message when the feature is disabled, and the model manager gracefully handles the missing engine type. This keeps the codebase ready to re-enable Whisper C++ once the upstream issues are resolved.

The CI workflows no longer need Vulkan SDK setup (that was only required for whisper-rs GPU acceleration), which simplifies the build process. New users will now default to Moonshine, which is a lightweight ONNX model around 30MB that works well for most use cases.

Also added a `TRANSCRIPTION_SERVICE_ID_TO_LABEL` map to the registry for cleaner display name lookups throughout the codebase.