### PR TITLE
Added configurable paste shortcut for Linux using Ctrl+Shift+V

### DIFF
--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -207,8 +207,16 @@ use tauri_plugin_clipboard_manager::ClipboardExt;
 ///
 /// This approach is faster than typing character-by-character and preserves
 /// the user's clipboard, making it ideal for inserting transcribed text.
+///
+/// # Arguments
+/// * `text` - The text to paste at the cursor
+/// * `use_ctrl_shift_v` - On Linux, use Ctrl+Shift+V instead of Ctrl+V (for terminals)
 #[tauri::command]
-async fn write_text(app: tauri::AppHandle, text: String) -> Result<(), String> {
+async fn write_text(
+    app: tauri::AppHandle,
+    text: String,
+    use_ctrl_shift_v: bool,
+) -> Result<(), String> {
     // 1. Save current clipboard content
     let original_clipboard = app.clipboard().read_text().ok();
 
@@ -225,24 +233,34 @@ async fn write_text(app: tauri::AppHandle, text: String) -> Result<(), String> {
 
     // Use virtual key codes for V to work with any keyboard layout
     #[cfg(target_os = "macos")]
-    let (modifier, v_key) = (Key::Meta, Key::Other(9)); // Virtual key code for V on macOS
+    let (modifier, v_key, use_shift) = (Key::Meta, Key::Other(9), false); // Virtual key code for V on macOS
     #[cfg(target_os = "windows")]
-    let (modifier, v_key) = (Key::Control, Key::Other(0x56)); // VK_V on Windows
+    let (modifier, v_key, use_shift) = (Key::Control, Key::Other(0x56), false); // VK_V on Windows
     #[cfg(target_os = "linux")]
-    let (modifier, v_key) = (Key::Control, Key::Unicode('v')); // Fallback for Linux
+    let (modifier, v_key, use_shift) = (Key::Control, Key::Unicode('v'), use_ctrl_shift_v); // Configurable for Linux
 
-    // Press modifier + V
+    // Press modifier (and optionally Shift) + V
     enigo
         .key(modifier, Direction::Press)
         .map_err(|e| format!("Failed to press modifier key: {}", e))?;
+    if use_shift {
+        enigo
+            .key(Key::Shift, Direction::Press)
+            .map_err(|e| format!("Failed to press Shift key: {}", e))?;
+    }
     enigo
         .key(v_key, Direction::Press)
         .map_err(|e| format!("Failed to press V key: {}", e))?;
 
-    // Release V + modifier (in reverse order for proper cleanup)
+    // Release V + (optionally Shift) + modifier (in reverse order for proper cleanup)
     enigo
         .key(v_key, Direction::Release)
         .map_err(|e| format!("Failed to release V key: {}", e))?;
+    if use_shift {
+        enigo
+            .key(Key::Shift, Direction::Release)
+            .map_err(|e| format!("Failed to release Shift key: {}", e))?;
+    }
     enigo
         .key(modifier, Direction::Release)
         .map_err(|e| format!("Failed to release modifier key: {}", e))?;

--- a/apps/whispering/src/lib/query/text.ts
+++ b/apps/whispering/src/lib/query/text.ts
@@ -1,4 +1,5 @@
 import * as services from '$lib/services';
+import { settings } from '$lib/stores/settings.svelte';
 import { defineMutation, defineQuery } from './_client';
 
 const textKeys = {
@@ -25,9 +26,11 @@ export const text = {
 			// writeToCursor handles everything internally:
 			// 1. Saves current clipboard
 			// 2. Writes text to clipboard
-			// 3. Simulates paste
+			// 3. Simulates paste (with Ctrl+Shift+V on Linux if configured)
 			// 4. Restores original clipboard
-			return await services.text.writeToCursor(text);
+			return await services.text.writeToCursor(text, {
+				useCtrlShiftV: settings.value['system.linux.useCtrlShiftV'],
+			});
 		},
 	}),
 	simulateEnterKeystroke: defineMutation({

--- a/apps/whispering/src/lib/services/text/desktop.ts
+++ b/apps/whispering/src/lib/services/text/desktop.ts
@@ -29,9 +29,13 @@ export function createTextServiceDesktop(): TextService {
 					}),
 			}),
 
-		writeToCursor: async (text) =>
+		writeToCursor: async (text, options) =>
 			tryAsync({
-				try: () => invoke<void>('write_text', { text }),
+				try: () =>
+					invoke<void>('write_text', {
+						text,
+						useCtrlShiftV: options?.useCtrlShiftV ?? false,
+					}),
 				catch: (error) =>
 					TextServiceErr({
 						message:

--- a/apps/whispering/src/lib/services/text/extension.ts
+++ b/apps/whispering/src/lib/services/text/extension.ts
@@ -25,7 +25,7 @@ export function createTextServiceExtension(): TextService {
 					}),
 			}),
 
-		writeToCursor: (text) =>
+		writeToCursor: (text, _options) =>
 			tryAsync({
 				try: async () => {
 					// Copy to clipboard and insert at cursor

--- a/apps/whispering/src/lib/services/text/types.ts
+++ b/apps/whispering/src/lib/services/text/types.ts
@@ -31,9 +31,11 @@ export type TextService = {
 	 * 4. Restores the original clipboard
 	 *
 	 * @param text The text to write at the cursor position.
+	 * @param options Optional configuration for the paste operation.
 	 */
 	writeToCursor: (
 		text: string,
+		options?: { useCtrlShiftV?: boolean },
 	) => MaybePromise<Result<void, TextServiceError | WhisperingError>>;
 
 	/**

--- a/apps/whispering/src/lib/services/text/web.ts
+++ b/apps/whispering/src/lib/services/text/web.ts
@@ -35,7 +35,7 @@ export function createTextServiceWeb(): TextService {
 			return Ok(undefined);
 		},
 
-		writeToCursor: async (text) => {
+		writeToCursor: async (text, _options) => {
 			// In web browsers, we cannot programmatically paste for security reasons
 			// We can copy the text to clipboard but the user must manually paste with Cmd/Ctrl+V
 			await navigator.clipboard.writeText(text);

--- a/apps/whispering/src/lib/settings/settings.ts
+++ b/apps/whispering/src/lib/settings/settings.ts
@@ -105,6 +105,12 @@ export const Settings = type({
 	'system.alwaysOnTop': type
 		.enumerated(...ALWAYS_ON_TOP_MODES)
 		.default('Never'),
+	/**
+	 * Linux paste shortcut configuration.
+	 * - false: Use Ctrl+V (default, works in most applications)
+	 * - true: Use Ctrl+Shift+V (required for terminals and some Linux apps)
+	 */
+	'system.linux.useCtrlShiftV': 'boolean = false',
 
 	// UI settings
 	/**

--- a/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
@@ -4,6 +4,7 @@
 	import * as Select from '@epicenter/ui/select';
 	import { Switch } from '@epicenter/ui/switch';
 	import { createMutation, createQuery } from '@tanstack/svelte-query';
+	import { IS_LINUX } from '$lib/constants/platform';
 	import {
 		ALWAYS_ON_TOP_MODE_OPTIONS,
 		LAYOUT_MODE_OPTIONS,
@@ -112,6 +113,20 @@
 						/>
 						<Field.Label for="transcription.simulateEnterAfterOutput">
 							Press Enter after pasting transcript
+						</Field.Label>
+					</Field.Field>
+				{/if}
+				{#if IS_LINUX && window.__TAURI_INTERNALS__ && (settings.value['transcription.writeToCursorOnSuccess'] || settings.value['transformation.writeToCursorOnSuccess'])}
+					<Field.Field orientation="horizontal">
+						<Switch
+							id="system.linux.useCtrlShiftV"
+							bind:checked={
+								() => settings.value['system.linux.useCtrlShiftV'],
+								(v) => settings.updateKey('system.linux.useCtrlShiftV', v)
+							}
+						/>
+						<Field.Label for="system.linux.useCtrlShiftV">
+							Use Ctrl+Shift+V to paste (for terminals)
 						</Field.Label>
 					</Field.Field>
 				{/if}

--- a/bun.lock
+++ b/bun.lock
@@ -67,7 +67,7 @@
     },
     "apps/whispering": {
       "name": "@epicenter/whispering",
-      "version": "7.10.0",
+      "version": "7.11.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.55.0",
         "@aptabase/tauri": "^0.4.1",
@@ -2542,8 +2542,6 @@
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
-    "@epicenter/hq/@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
-
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
@@ -2717,8 +2715,6 @@
     "@astrojs/check/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "@astrojs/svelte/@sveltejs/vite-plugin-svelte/@sveltejs/vite-plugin-svelte-inspector": ["@sveltejs/vite-plugin-svelte-inspector@4.0.1", "", { "dependencies": { "debug": "^4.3.7" }, "peerDependencies": { "@sveltejs/vite-plugin-svelte": "^5.0.0", "svelte": "^5.0.0", "vite": "^6.0.0" } }, "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw=="],
-
-    "@epicenter/hq/@types/bun/bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 


### PR DESCRIPTION
## Summary

Adds a configurable paste shortcut for Linux users. Some Linux applications (particularly terminals) require Ctrl+Shift+V instead of Ctrl+V to paste. This PR adds a setting to toggle between the two shortcuts.

## Type of Change

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `refactor`: Code refactoring (no functional changes)
- [ ] `perf`: Performance improvement
- [ ] `test`: Test additions or changes
- [ ] `chore`: Maintenance tasks
- [ ] `style`: Code style changes

## Related Issue

Closes #1152

## Changes Made

1. Settings schema (src/lib/settings/settings.ts): Added system.linux.useCtrlShiftV boolean setting (defaults to false)
2. Rust command (src-tauri/src/lib.rs): Modified write_text to accept use_ctrl_shift_v parameter and conditionally press Shift when pasting on Linux
3. TypeScript service layer:
    - Updated TextService type to accept optional { useCtrlShiftV?: boolean } for writeToCursor
    - Desktop service passes the option to Tauri
    - Web/extension services accept but ignore the option
5. Query layer (src/lib/query/text.ts): Reads the setting and passes it to the service
6. Settings UI (src/routes/(app)/(config)/settings/+page.svelte): Added toggle that appears only on Linux when paste-at-cursor is enabled: "Use Ctrl+Shift+V to paste (for terminals)"

## Testing

<!-- Describe the tests you ran to verify your changes -->

### Desktop App Testing
- [ ] Tested on macOS
- [ ] Tested on Windows
- [x] Tested on Linux
- [ ] Not applicable (web-only change)

### General Testing
- [ ] Tested with multiple API providers (if applicable)
- [x] Verified no API keys are exposed in logs or storage
- [x] Checked for console errors
- [x] Tested on different screen sizes (if UI change)

## Checklist

<!-- Make sure you've completed these steps -->

- [x] My code follows the project's coding standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I've used `type` instead of `interface` in TypeScript
- [x] I've used absolute imports where applicable
- [x] I've tested my changes thoroughly
- [x] I've added/updated tests for my changes (if applicable)
- [x] My changes don't break existing functionality
- [ ] I've updated documentation (if needed)

## Screenshots/Recordings
[Screencast from 2025-12-22 12-04-06.webm](https://github.com/user-attachments/assets/ece0ac4d-9ac8-4542-ac60-e2db3def9996)

<!-- If this is a UI change, please include screenshots or recordings -->

## Additional Notes

  - The setting only affects Linux; macOS and Windows ignore the parameter
  - The toggle only appears when running as a desktop app on Linux and when at least one paste-at-cursor option is enabled