### PR TITLE
Use the correct retry icon

### DIFF
--- a/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/RecordingRowActions.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/RecordingRowActions.svelte
@@ -16,6 +16,7 @@
 	import { Spinner } from '@epicenter/ui/spinner';
 	import PlayIcon from '@lucide/svelte/icons/play';
 	import RepeatIcon from '@lucide/svelte/icons/repeat';
+	import RotateCcwIcon from '@lucide/svelte/icons/rotate-ccw';
 	import EditRecordingModal from './EditRecordingModal.svelte';
 	import TransformationPicker from './TransformationPicker.svelte';
 	import ViewTransformationRunsDialog from './ViewTransformationRunsDialog.svelte';
@@ -98,7 +99,7 @@
 			{:else if recording.transcriptionStatus === 'DONE'}
 				<RepeatIcon class="size-4 text-green-500" />
 			{:else if recording.transcriptionStatus === 'FAILED'}
-				<AlertCircleIcon class="size-4 text-red-500" />
+				<RotateCcwIcon class="size-4 text-red-500" />
 			{/if}
 		</Button>
 


### PR DESCRIPTION
## Summary

The retry icon always threw me off because it didn't look like a retry icon. This PR improves the UX by using the globally accepted retry button. 

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [x] `refactor`: Code refactoring (no functional changes)
- [ ] `perf`: Performance improvement
- [ ] `test`: Test additions or changes
- [x] `chore`: Maintenance tasks
- [ ] `style`: Code style changes

## Related Issue

<!-- Link to the issue this PR addresses, if applicable -->

## Changes Made

<!-- Describe your changes in detail. What did you change and how? -->

## Testing

<!-- Describe the tests you ran to verify your changes -->

### Desktop App Testing
- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] Not applicable (web-only change)

### General Testing
- [ ] Tested with multiple API providers (if applicable)
- [ ] Verified no API keys are exposed in logs or storage
- [ ] Checked for console errors
- [x] Tested on different screen sizes (if UI change)

## Checklist

<!-- Make sure you've completed these steps -->

- [x] My code follows the project's coding standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I've used `type` instead of `interface` in TypeScript
- [x] I've used absolute imports where applicable
- [x] I've tested my changes thoroughly
- [x] I've added/updated tests for my changes (if applicable)
- [x] My changes don't break existing functionality
- [x] I've updated documentation (if needed)

## Screenshots/Recordings

> old

<img width="290" height="51" alt="Screenshot 2025-12-22 at 7 18 37 PM" src="https://github.com/user-attachments/assets/383f71b3-8e99-428a-8ebf-1ceb29bcac8a" />

> new

<img width="324" height="59" alt="Screenshot 2025-12-22 at 7 17 59 PM" src="https://github.com/user-attachments/assets/f75b84d1-9914-4761-b0ab-81e52375b580" />


## Additional Notes

<!-- Any additional context, considerations, or discussion points -->