### PR TITLE
fix: prevent dark mode FOUC on app load

### DIFF
--- a/apps/whispering/src/app.html
+++ b/apps/whispering/src/app.html
@@ -5,6 +5,16 @@
 		<link rel="icon" href="%sveltekit.assets%/favicon.ico" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>Whispering</title>
+		<script>
+			const mode = localStorage.getItem('mode-watcher-mode') ?? 'dark';
+			const isLight =
+				mode === 'light' ||
+				(mode === 'system' &&
+					matchMedia('(prefers-color-scheme: light)').matches);
+			document.documentElement.classList.toggle('dark', !isLight);
+			document.documentElement.style.colorScheme = isLight ? 'light' : 'dark';
+			localStorage.setItem('mode-watcher-mode', mode);
+		</script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">


### PR DESCRIPTION
Fixes the flash of unstyled content (FOUC) when loading the app in dark mode. The app now renders with the correct theme immediately, with no white flash.

Closes #1146

## The Problem

When the app loads, there's a brief flash of white background before dark mode kicks in. This happens because:

1. The browser renders HTML before JavaScript executes
2. mode-watcher (our theme library) only applies the `dark` class after hydration
3. Users see a jarring white → dark transition

## Approaches Considered

### 1. CSS-only approach (Leftium's PR #1154)

```css
@media (prefers-color-scheme: dark) {
  :root { background-color: black; }
}
```

**Why it doesn't work:** This only respects the OS preference. If a user explicitly chose dark mode in the app but their OS is set to light, they still get FOUC. The CSS shows white, then JS loads and flashes to dark.

### 2. SvelteKit hooks with nonce (initial attempt)

```html
<script nonce="%sveltekit.nonce%">...</script>
```

**Why it doesn't work:** With `adapter-static` and `ssr=false`, pages are prerendered at build time. The `%sveltekit.nonce%` placeholder never gets replaced because there's no server to inject a runtime nonce. The script fails CSP validation.

### 3. Server hooks for script injection

We tried using `hooks.server.ts` to inject the theme script via `transformPageChunk`. 

**Why it doesn't work:** Same issue—with prerendering, there's no server-side transform happening at runtime. The hooks never execute for the actual user request.

### 4. Inline script reading localStorage (this PR) ✓

```html
<script>
  const mode = localStorage.getItem('mode-watcher-mode') ?? 'dark';
  const isLight = mode === 'light' || (mode === 'system' && matchMedia('(prefers-color-scheme: light)').matches);
  document.documentElement.classList.toggle('dark', !isLight);
  document.documentElement.style.colorScheme = isLight ? 'light' : 'dark';
  localStorage.setItem('mode-watcher-mode', mode);
</script>
```

**Why this works:**
- Executes synchronously before first paint (blocking script in `<head>`)
- Reads the same localStorage key that mode-watcher uses (`mode-watcher-mode`)
- Handles all three states: `light`, `dark`, and `system`
- For `system` mode, respects OS preference via `matchMedia`
- Defaults to `dark` for new users (matching our app's default)
- Sets `colorScheme` for native elements (scrollbars, form controls)

## Changes

- `apps/whispering/src/app.html`: Added 5-line inline script for theme sync
- Deleted `hooks.server.ts` (was unnecessary complexity that didn't work with prerendering)

## Testing

1. Clear localStorage, load app → renders dark (our default)
2. Set to light mode, refresh → no flash, stays light
3. Set to dark mode, refresh → no flash, stays dark
4. Set to system mode with OS light → no flash, renders light
5. Set to system mode with OS dark → no flash, renders dark

## Acknowledgments

Thank you to @Leftium for his work on PR #1154 investigating this issue. While we went with a different approach, his research into the problem was valuable. He's included as a co-author on this commit.

## References

- Issue #1146 (this repo)
- PR #1154 by Leftium (CSS-only approach)
- [SvelteKit issue #13307](https://github.com/sveltejs/kit/issues/13307) - CSP nonce limitations with prerendering
- [mode-watcher library](https://github.com/svecosystem/mode-watcher)