### PR TITLE
refactor(epicenter): remove id field from defineEpicenter

### DIFF
--- a/docs/guides/handoff-yjs-persistence-rollout.md
+++ b/docs/guides/handoff-yjs-persistence-rollout.md
@@ -7,6 +7,7 @@
 ## Executive Summary
 
 The `basic-workspace` example has been successfully updated with a complete YJS persistence pattern that provides:
+
 - Binary YJS persistence (CRDT source of truth)
 - Markdown index (git-friendly storage)
 - SQLite index (queryable snapshots)
@@ -62,6 +63,7 @@ project-root/
 ```
 
 **How It Works**:
+
 1. Each workspace is created with a unique `id` (e.g., `'blog'`, `'pages'`, `'content-hub'`)
 2. YJS creates a document with that ID as its GUID: `new Y.Doc({ guid: ws.id })`
 3. `setupYDoc` callback uses the workspace ID to create a unique filename: `.epicenter/${id}.yjs`
@@ -109,7 +111,7 @@ project-root/
 
 ```typescript
 const blogWorkspace = defineWorkspace({
-	id: 'blog',  // ← This ID determines the .yjs filename
+	id: 'blog', // ← This ID determines the .yjs filename
 	version: 1,
 	name: 'blog',
 	// ... schema, indexes, actions ...
@@ -123,7 +125,7 @@ const blogWorkspace = defineWorkspace({
 	 */
 	setupYDoc: (ydoc) => {
 		const storagePath = './.epicenter';
-		const filePath = path.join(storagePath, 'blog.yjs');  // ← Use workspace ID here
+		const filePath = path.join(storagePath, 'blog.yjs'); // ← Use workspace ID here
 
 		// Ensure .epicenter directory exists (shared by all workspaces)
 		if (!fs.existsSync(storagePath)) {
@@ -144,28 +146,29 @@ const blogWorkspace = defineWorkspace({
 			const state = Y.encodeStateAsUpdate(ydoc);
 			fs.writeFileSync(filePath, state);
 		});
-	}
+	},
 });
 ```
 
 **Pattern for Multiple Workspaces**:
+
 ```typescript
 // Pages workspace
 const pages = defineWorkspace({
-	id: 'pages',  // → .epicenter/pages.yjs
+	id: 'pages', // → .epicenter/pages.yjs
 	setupYDoc: (ydoc) => {
 		const filePath = path.join('./.epicenter', 'pages.yjs');
 		// ... same persistence logic ...
-	}
+	},
 });
 
 // Content-hub workspace
 const contentHub = defineWorkspace({
-	id: 'content-hub',  // → .epicenter/content-hub.yjs
+	id: 'content-hub', // → .epicenter/content-hub.yjs
 	setupYDoc: (ydoc) => {
 		const filePath = path.join('./.epicenter', 'content-hub.yjs');
 		// ... same persistence logic ...
-	}
+	},
 });
 ```
 
@@ -190,7 +193,6 @@ export default workspaceName;
 
 // After:
 export default defineEpicenter({
-	id: 'workspace-id',
 	workspaces: [workspaceName],
 });
 ```
@@ -231,15 +233,16 @@ Ensure CLI script is available:
 
 ### Current Workspaces
 
-| Workspace Directory | Status | Workspace Name | Notes |
-|-------------------|--------|----------------|-------|
-| `examples/basic-workspace` | ✅ Complete | `blog` | Reference implementation |
-| `examples/content-hub` | ❌ Needs Update | `content-hub`, `pages` | Two workspaces in one file |
-| `examples/e2e-tests` | ❌ Needs Update | `blog` | Comprehensive test workspace |
+| Workspace Directory        | Status          | Workspace Name         | Notes                        |
+| -------------------------- | --------------- | ---------------------- | ---------------------------- |
+| `examples/basic-workspace` | ✅ Complete     | `blog`                 | Reference implementation     |
+| `examples/content-hub`     | ❌ Needs Update | `content-hub`, `pages` | Two workspaces in one file   |
+| `examples/e2e-tests`       | ❌ Needs Update | `blog`                 | Comprehensive test workspace |
 
 ### Workspace Details
 
 #### 1. examples/basic-workspace ✅
+
 - **Status**: Complete (reference implementation)
 - **Workspace**: `blog`
 - **Tables**: `posts`, `comments`
@@ -249,6 +252,7 @@ Ensure CLI script is available:
 - **Test files**: `test-yjs-persistence.ts`, `test-bidirectional-sync.ts`
 
 #### 2. examples/content-hub ❌
+
 - **Status**: Needs YJS persistence
 - **Workspaces**: `pages` (dependency), `content-hub` (main)
 - **Tables**:
@@ -263,6 +267,7 @@ Ensure CLI script is available:
   - No test files or CLI scripts in package.json
 
 #### 3. examples/e2e-tests ❌
+
 - **Status**: Needs YJS persistence
 - **Workspace**: `blog`
 - **Tables**: `posts`, `comments`
@@ -360,7 +365,6 @@ export default workspaceName;
 
 // After:
 export default defineEpicenter({
-	id: '<descriptive-id>',
 	workspaces: [workspaceName],
 });
 ```
@@ -369,7 +373,6 @@ For files with multiple workspaces (like `content-hub`), include all:
 
 ```typescript
 export default defineEpicenter({
-	id: 'content-hub-example',
 	workspaces: [pages, contentHub],
 });
 ```
@@ -404,6 +407,7 @@ If `package.json` doesn't exist or lacks CLI scripts, create/update:
 #### Step 7: Test the Implementation
 
 1. **Test YJS persistence**:
+
    ```bash
    cd examples/<workspace-directory>
 
@@ -418,6 +422,7 @@ If `package.json` doesn't exist or lacks CLI scripts, create/update:
    ```
 
 2. **Test markdown sync**:
+
    ```bash
    # Check markdown files were created
    ls -la test-data/content/<table-name>/
@@ -427,6 +432,7 @@ If `package.json` doesn't exist or lacks CLI scripts, create/update:
    ```
 
 3. **Test multi-session persistence**:
+
    ```bash
    # Session 1: Create data
    bun cli <workspace-name> <mutation-action> --arg value
@@ -443,6 +449,7 @@ If `package.json` doesn't exist or lacks CLI scripts, create/update:
 ### Current State
 
 The `basic-workspace` example uses:
+
 - `test-yjs-persistence.ts` - Programmatic multi-session persistence tests
 - `test-bidirectional-sync.ts` - Markdown bidirectional sync tests
 
@@ -459,11 +466,13 @@ The `basic-workspace` example uses:
 ### When to Use `*.test.ts`
 
 Use `*.test.ts` format ONLY when:
+
 - Using a test runner (vitest, jest, bun test)
 - Writing automated test suites
 - Integrating with CI/CD
 
 **Example**: The `e2e-tests` workspace correctly uses:
+
 - `cli.test.ts` - Automated tests with vitest
 - `server.test.ts` - Automated tests with vitest
 
@@ -515,30 +524,32 @@ Use this checklist for each workspace:
 
 **Issue**: `content-hub` has `pages` as a dependency.
 **Solution**: Each workspace gets its own `setupYDoc` callback and `.yjs` file:
+
 - `pages` → `.epicenter/pages.yjs`
 - `content-hub` → `.epicenter/content-hub.yjs`
 
 Both workspaces are completely isolated. The dependency relationship is at the API level (content-hub can call pages' actions), not at the persistence level. Each maintains its own state.
 
 **Concrete Example**:
+
 ```typescript
 // Pages workspace (dependency)
 const pages = defineWorkspace({
-	id: 'pages',  // → .epicenter/pages.yjs
+	id: 'pages', // → .epicenter/pages.yjs
 	setupYDoc: (ydoc) => {
 		const filePath = path.join('./.epicenter', 'pages.yjs');
 		// ... persistence logic ...
-	}
+	},
 });
 
 // Content-hub workspace (depends on pages)
 const contentHub = defineWorkspace({
-	id: 'content-hub',  // → .epicenter/content-hub.yjs
+	id: 'content-hub', // → .epicenter/content-hub.yjs
 	dependencies: [pages],
 	setupYDoc: (ydoc) => {
 		const filePath = path.join('./.epicenter', 'content-hub.yjs');
 		// ... persistence logic ...
-	}
+	},
 });
 ```
 
@@ -551,12 +562,12 @@ Result: Two `.yjs` files in the same `.epicenter/` directory, each with its own 
 
 ```typescript
 export default defineEpicenter({
-	id: 'content-hub-example',
-	workspaces: [pages, contentHub],  // Both registered
+	workspaces: [pages, contentHub], // Both registered
 });
 ```
 
 When you run CLI commands:
+
 - `bun cli pages createPage` → Uses `.epicenter/pages.yjs`
 - `bun cli content-hub addYoutubeVideo` → Uses `.epicenter/content-hub.yjs`
 
@@ -566,6 +577,7 @@ Both workspaces can run concurrently without conflicts.
 
 **Issue**: `e2e-tests` has existing automated tests.
 **Solution**:
+
 - Add persistence without breaking existing tests
 - Tests should verify persistence works
 - May need to add cleanup logic to prevent test pollution
@@ -575,6 +587,7 @@ Both workspaces can run concurrently without conflicts.
 
 **Issue**: Multiple test runs could conflict with persisted data.
 **Solution**:
+
 - For automated tests: Clean `.epicenter/` directory before/after tests
 - For manual testing: Embrace persistence as expected behavior
 - Document how to reset state: `rm -rf .epicenter/ test-data/`
@@ -583,6 +596,7 @@ Both workspaces can run concurrently without conflicts.
 
 **Issue**: Binary `.yjs` files aren't git-friendly.
 **Solution**: This is by design:
+
 - `.yjs` files → Binary, fast, gitignored (ephemeral state)
 - `.md` files → Text, git-friendly, committed (source of truth for version control)
 - `.db` files → Binary, gitignored (queryable snapshot)
@@ -627,10 +641,7 @@ After updating each workspace, verify:
 9. ✅ Console logs show `[Persistence] Loaded workspace from...` on subsequent runs
 10. ✅ Existing tests pass (if applicable)
 
-**For multi-workspace files**:
-11. ✅ Each workspace creates its own `.yjs` file (e.g., both `pages.yjs` and `content-hub.yjs` exist)
-12. ✅ Workspaces don't interfere with each other (can run CLI commands for different workspaces)
-13. ✅ Each workspace maintains isolated state
+**For multi-workspace files**: 11. ✅ Each workspace creates its own `.yjs` file (e.g., both `pages.yjs` and `content-hub.yjs` exist) 12. ✅ Workspaces don't interfere with each other (can run CLI commands for different workspaces) 13. ✅ Each workspace maintains isolated state
 
 ## Testing Strategy
 
@@ -674,6 +685,7 @@ For workspaces with automated tests (like `e2e-tests`):
 **A**: Yes! This is the intended design. Each workspace uses `.epicenter/${workspaceId}.yjs` for its state. Multiple workspaces = multiple `.yjs` files in the shared `.epicenter/` directory.
 
 Example:
+
 - Workspace `id: 'blog'` → `.epicenter/blog.yjs`
 - Workspace `id: 'pages'` → `.epicenter/pages.yjs`
 - Workspace `id: 'content-hub'` → `.epicenter/content-hub.yjs`
@@ -695,9 +707,11 @@ All workspaces share the same `.epicenter/` directory but have completely isolat
 ### Q: How do I reset a workspace completely?
 
 **A**: Delete all persistence files:
+
 ```bash
 rm -rf .epicenter/ test-data/
 ```
+
 Next run will start fresh.
 
 ### Q: Can multiple processes use the same workspace simultaneously?

--- a/examples/basic-workspace/epicenter.config.ts
+++ b/examples/basic-workspace/epicenter.config.ts
@@ -241,6 +241,5 @@ const blogWorkspace = defineWorkspace({
 });
 
 export default defineEpicenter({
-	id: 'basic-workspace-example',
 	workspaces: [blogWorkspace],
 });

--- a/examples/content-hub/epicenter.config.ts
+++ b/examples/content-hub/epicenter.config.ts
@@ -25,7 +25,6 @@ import { whispering } from './whispering/whispering.workspace';
  * - CLI auto-generation
  */
 export default defineEpicenter({
-	id: 'content-hub',
 	workspaces: [
 		// Central content repository
 		pages,

--- a/examples/stress-test/epicenter.config.ts
+++ b/examples/stress-test/epicenter.config.ts
@@ -91,6 +91,5 @@ const stressWorkspace = defineWorkspace({
 });
 
 export default defineEpicenter({
-	id: 'stress-test',
 	workspaces: [stressWorkspace],
 });

--- a/packages/epicenter/src/cli/README.md
+++ b/packages/epicenter/src/cli/README.md
@@ -22,22 +22,22 @@ Write your workspace actions like you normally would:
 import { type } from 'arktype';
 
 const reddit = defineWorkspace({
-  name: 'reddit',
-  exports: ({ db }) => ({
-    import: defineMutation({
-      input: type({
-        'url': 'string',
-        'count': 'number = 10'
-      }).describe({
-        url: 'Reddit URL to import',
-        count: 'Number of posts'
-      }),
-      handler: async ({ url, count }) => {
-        // Your import logic here
-        return Ok(result);
-      }
-    })
-  })
+	name: 'reddit',
+	exports: ({ db }) => ({
+		import: defineMutation({
+			input: type({
+				url: 'string',
+				count: 'number = 10',
+			}).describe({
+				url: 'Reddit URL to import',
+				count: 'Number of posts',
+			}),
+			handler: async ({ url, count }) => {
+				// Your import logic here
+				return Ok(result);
+			},
+		}),
+	}),
 });
 ```
 
@@ -50,8 +50,7 @@ import { defineEpicenter } from '@epicenter/hq';
 import { reddit, blog } from './workspaces';
 
 export default defineEpicenter({
-  id: 'my-app',
-  workspaces: [reddit, blog],
+	workspaces: [reddit, blog],
 });
 ```
 
@@ -78,6 +77,7 @@ Your action's input schema automatically becomes CLI flags:
 - `.describe({})` → shows descriptions in `--help`
 
 **Array values**: Use spaces to separate multiple values:
+
 ```bash
 epicenter workspace action --tags tech productivity typescript
 ```
@@ -89,11 +89,11 @@ The CLI uses Standard Schema for validation. The `standardSchemaToYargs` functio
 ```typescript
 // Your ArkType schema
 const schema = type({
-  url: 'string',
-  'count?': 'number = 10'
+	url: 'string',
+	'count?': 'number = 10',
 }).describe({
-  url: 'Reddit URL',
-  count: 'Number of posts'
+	url: 'Reddit URL',
+	count: 'Number of posts',
 });
 
 // Automatically converted to yargs options:
@@ -134,8 +134,8 @@ import { createCLI } from '@epicenter/hq/cli';
 
 // createCLI parses and executes the command internally
 await createCLI({
-  config: epicenter,
-  argv: ['reddit', 'import', '--url', 'https://...', '--count', '5']
+	config: epicenter,
+	argv: ['reddit', 'import', '--url', 'https://...', '--count', '5'],
 });
 ```
 
@@ -146,12 +146,14 @@ await createCLI({
 The CLI uses a two-phase approach to balance speed and functionality:
 
 **Phase 1: CLI Setup (Fast - ~10-20ms)**
+
 - Extracts metadata using mock context (no YJS initialization)
 - Builds yargs command hierarchy (workspace → action)
 - Converts Standard Schema definitions to CLI flags
 - Enables fast `--help` commands
 
 **Phase 2: Command Execution (On-Demand)**
+
 - Creates real workspace client with YJS docs
 - Initializes indexes and dependencies
 - Executes action handler
@@ -167,7 +169,7 @@ const actions = workspace.actions(mockContext);
 
 // Extract metadata without executing handlers
 for (const [name, action] of Object.entries(actions)) {
-  console.log(name, action.type, action.input);
+	console.log(name, action.type, action.input);
 }
 ```
 

--- a/packages/epicenter/src/cli/cli-end-to-end.test.ts
+++ b/packages/epicenter/src/cli/cli-end-to-end.test.ts
@@ -109,7 +109,6 @@ describe('CLI End-to-End Tests', () => {
 	});
 
 	const epicenter = defineEpicenter({
-		id: 'cli-e2e-test',
 		storageDir: TEST_DIR,
 		workspaces: [testWorkspace],
 	});

--- a/packages/epicenter/src/cli/integration.test.ts
+++ b/packages/epicenter/src/cli/integration.test.ts
@@ -43,7 +43,6 @@ describe('CLI Integration', () => {
 	});
 
 	const epicenter = defineEpicenter({
-		id: 'test-cli-epicenter',
 		workspaces: [testWorkspace],
 	});
 

--- a/packages/epicenter/src/cli/load-config.test.ts
+++ b/packages/epicenter/src/cli/load-config.test.ts
@@ -67,12 +67,12 @@ describe('loadEpicenterConfig', () => {
 		const configPath = path.join(testDir, 'epicenter.config.js');
 		await writeFile(
 			configPath,
-			`module.exports = { id: 'test-config', workspaces: [] };`,
+			`module.exports = { workspaces: [{ id: 'test-workspace', exports: () => ({}) }] };`,
 		);
 
 		const result = await loadEpicenterConfig(testDir);
-		expect(result.config.id).toBe('test-config');
 		expect(Array.isArray(result.config.workspaces)).toBe(true);
+		expect(result.config.workspaces[0].id).toBe('test-workspace');
 		expect(result.configPath).toBe(configPath);
 	});
 
@@ -80,24 +80,24 @@ describe('loadEpicenterConfig', () => {
 		const configPath = path.join(testDir, 'epicenter.config.mjs');
 		await writeFile(
 			configPath,
-			`export default { id: 'test-esm-config', workspaces: [] };`,
+			`export default { workspaces: [{ id: 'esm-workspace', exports: () => ({}) }] };`,
 		);
 
 		const result = await loadEpicenterConfig(testDir);
-		expect(result.config.id).toBe('test-esm-config');
+		expect(result.config.workspaces[0].id).toBe('esm-workspace');
 	});
 
 	test('prefers .ts over other extensions when multiple exist', async () => {
 		await writeFile(
 			path.join(testDir, 'epicenter.config.ts'),
-			`module.exports = { id: 'typescript-config', workspaces: [] };`,
+			`module.exports = { workspaces: [{ id: 'ts-workspace', exports: () => ({}) }] };`,
 		);
 		await writeFile(
 			path.join(testDir, 'epicenter.config.js'),
-			`module.exports = { id: 'javascript-config', workspaces: [] };`,
+			`module.exports = { workspaces: [{ id: 'js-workspace', exports: () => ({}) }] };`,
 		);
 
 		const result = await loadEpicenterConfig(testDir);
-		expect(result.config.id).toBe('typescript-config');
+		expect(result.config.workspaces[0].id).toBe('ts-workspace');
 	});
 });

--- a/packages/epicenter/src/cli/server.ts
+++ b/packages/epicenter/src/cli/server.ts
@@ -21,7 +21,7 @@ export async function startServer(
 	config: EpicenterConfig,
 	options: ServeOptions = {},
 ): Promise<void> {
-	console.log(`🔨 Creating HTTP server for app: ${config.id}`);
+	console.log(`🔨 Creating HTTP server for epicenter...`);
 
 	const { app, client } = await createServer(config);
 	const port =
@@ -49,7 +49,7 @@ export async function startServer(
 
 	console.log('\n🔧 Connect to Claude Code:\n');
 	console.log(
-		`  claude mcp add ${config.id} --transport http --scope user http://localhost:${port}/mcp\n`,
+		`  claude mcp add my-epicenter --transport http --scope user http://localhost:${port}/mcp\n`,
 	);
 
 	console.log('📦 Available Tools:\n');

--- a/packages/epicenter/src/core/epicenter.test.ts
+++ b/packages/epicenter/src/core/epicenter.test.ts
@@ -30,7 +30,6 @@ describe('Epicenter Error Handling', () => {
 
 		expect(() =>
 			defineEpicenter({
-				id: 'test',
 				workspaces: [workspace1, workspace2],
 			}),
 		).toThrow('Duplicate workspace IDs detected');
@@ -77,7 +76,6 @@ describe('Action Exposure and Dependency Resolution', () => {
 		const workspaceB = createTestWorkspace('b', [workspaceA]);
 
 		const epicenter = defineEpicenter({
-			id: 'test',
 			workspaces: [workspaceA, workspaceB],
 		});
 
@@ -107,7 +105,6 @@ describe('Action Exposure and Dependency Resolution', () => {
 
 		// Only include B and C in epicenter, not A (missing dependency)
 		const epicenter = defineEpicenter({
-			id: 'test',
 			workspaces: [workspaceB, workspaceC],
 		});
 
@@ -124,7 +121,6 @@ describe('Action Exposure and Dependency Resolution', () => {
 
 		// Correctly include ALL workspaces (flat/hoisted)
 		const epicenter = defineEpicenter({
-			id: 'test',
 			workspaces: [workspaceA, workspaceB, workspaceC],
 		});
 
@@ -149,7 +145,6 @@ describe('Action Exposure and Dependency Resolution', () => {
 		const workspaceC = createTestWorkspace('c');
 
 		const epicenter = defineEpicenter({
-			id: 'test',
 			workspaces: [workspaceA, workspaceB, workspaceC],
 		});
 

--- a/packages/epicenter/src/core/epicenter/client.browser.ts
+++ b/packages/epicenter/src/core/epicenter/client.browser.ts
@@ -23,11 +23,8 @@ export { iterActions } from './client.shared';
  * @returns Initialized epicenter client with access to all workspace exports
  */
 export async function createEpicenterClient<
-	const TId extends string,
 	const TWorkspaces extends readonly AnyWorkspaceConfig[],
->(
-	config: EpicenterConfig<TId, TWorkspaces>,
-): Promise<EpicenterClient<TWorkspaces>> {
+>(config: EpicenterConfig<TWorkspaces>): Promise<EpicenterClient<TWorkspaces>> {
 	// Browser: no storage directory resolution
 	const clients = await initializeWorkspaces(
 		config.workspaces,

--- a/packages/epicenter/src/core/epicenter/client.node.ts
+++ b/packages/epicenter/src/core/epicenter/client.node.ts
@@ -56,11 +56,8 @@ export { iterActions } from './client.shared';
  * ```
  */
 export async function createEpicenterClient<
-	const TId extends string,
 	const TWorkspaces extends readonly AnyWorkspaceConfig[],
->(
-	config: EpicenterConfig<TId, TWorkspaces>,
-): Promise<EpicenterClient<TWorkspaces>> {
+>(config: EpicenterConfig<TWorkspaces>): Promise<EpicenterClient<TWorkspaces>> {
 	// Node.js: resolve storage directory and epicenter directory
 	const storageDir = path.resolve(
 		config.storageDir ?? process.cwd(),

--- a/packages/epicenter/src/core/epicenter/config.browser.ts
+++ b/packages/epicenter/src/core/epicenter/config.browser.ts
@@ -18,10 +18,9 @@ import {
  * in browser environments.
  */
 export type EpicenterConfig<
-	TId extends string = string,
 	TWorkspaces extends
 		readonly AnyWorkspaceConfig[] = readonly AnyWorkspaceConfig[],
-> = EpicenterConfigBase<TId, TWorkspaces>;
+> = EpicenterConfigBase<TWorkspaces>;
 
 /**
  * Define an epicenter configuration (browser version)
@@ -33,17 +32,13 @@ export type EpicenterConfig<
  * @example
  * ```typescript
  * export const epicenter = defineEpicenter({
- *   id: 'my-app',
  *   workspaces: [pages, contentHub],
  * });
  * ```
  */
 export function defineEpicenter<
-	const TId extends string,
 	const TWorkspaces extends readonly AnyWorkspaceConfig[],
->(
-	config: EpicenterConfig<TId, TWorkspaces>,
-): EpicenterConfig<TId, TWorkspaces> {
+>(config: EpicenterConfig<TWorkspaces>): EpicenterConfig<TWorkspaces> {
 	validateEpicenterConfig(config);
 	return config;
 }

--- a/packages/epicenter/src/core/epicenter/config.node.ts
+++ b/packages/epicenter/src/core/epicenter/config.node.ts
@@ -17,10 +17,9 @@ import {
  * Extends base config with storageDir for filesystem-based storage.
  */
 export type EpicenterConfig<
-	TId extends string = string,
 	TWorkspaces extends
 		readonly AnyWorkspaceConfig[] = readonly AnyWorkspaceConfig[],
-> = EpicenterConfigBase<TId, TWorkspaces> & {
+> = EpicenterConfigBase<TWorkspaces> & {
 	/**
 	 * Base directory for all Epicenter storage (databases, markdown files, persistence)
 	 *
@@ -55,18 +54,14 @@ export type EpicenterConfig<
  * @example
  * ```typescript
  * export const epicenter = defineEpicenter({
- *   id: 'my-app',
  *   storageDir: './data',
  *   workspaces: [pages, contentHub],
  * });
  * ```
  */
 export function defineEpicenter<
-	const TId extends string,
 	const TWorkspaces extends readonly AnyWorkspaceConfig[],
->(
-	config: EpicenterConfig<TId, TWorkspaces>,
-): EpicenterConfig<TId, TWorkspaces> {
+>(config: EpicenterConfig<TWorkspaces>): EpicenterConfig<TWorkspaces> {
 	validateEpicenterConfig(config);
 	return config;
 }

--- a/packages/epicenter/src/core/epicenter/config.shared.ts
+++ b/packages/epicenter/src/core/epicenter/config.shared.ts
@@ -13,7 +13,6 @@ import type { AnyWorkspaceConfig } from '../workspace';
  * @example
  * ```typescript
  * const epicenter = defineEpicenter({
- *   id: 'my-app',
  *   workspaces: [pages, contentHub, auth],
  * });
  *
@@ -26,18 +25,9 @@ import type { AnyWorkspaceConfig } from '../workspace';
  * ```
  */
 export type EpicenterConfigBase<
-	TId extends string = string,
 	TWorkspaces extends
 		readonly AnyWorkspaceConfig[] = readonly AnyWorkspaceConfig[],
 > = {
-	/**
-	 * Unique identifier for this epicenter instance
-	 * Used to distinguish between different epicenter configurations
-	 *
-	 * @example 'my-app', 'content-platform', 'analytics-dashboard'
-	 */
-	id: TId;
-
 	/**
 	 * Array of workspace configurations to compose
 	 * Each workspace will be initialized and made available in the client
@@ -63,13 +53,8 @@ export type EpicenterConfigBase<
  * @throws {Error} If configuration is invalid
  */
 export function validateEpicenterConfig(
-	config: EpicenterConfigBase<string, readonly AnyWorkspaceConfig[]>,
+	config: EpicenterConfigBase<readonly AnyWorkspaceConfig[]>,
 ): void {
-	// Validate epicenter ID
-	if (!config.id || typeof config.id !== 'string') {
-		throw new Error('Epicenter must have a valid string ID');
-	}
-
 	// Validate workspaces array
 	if (!Array.isArray(config.workspaces)) {
 		throw new Error('Workspaces must be an array of workspace configs');

--- a/packages/epicenter/src/core/schema/generate-json-schema.ts
+++ b/packages/epicenter/src/core/schema/generate-json-schema.ts
@@ -48,7 +48,7 @@ export function generateJsonSchema(schema: StandardJSONSchemaV1): JsonSchema {
 		// permissive empty schema `{}` that accepts any input.
 		catch: (e) => {
 			console.warn(
-				'[safeToJsonSchema] Conversion failure, using permissive fallback:',
+				'[generateJsonSchema] Conversion failure, using permissive fallback:',
 				e,
 			);
 			return Ok({} satisfies JsonSchema);

--- a/packages/epicenter/src/core/schema/index.ts
+++ b/packages/epicenter/src/core/schema/index.ts
@@ -54,7 +54,7 @@ export {
 	ISO_DATETIME_REGEX,
 	TIMEZONE_ID_REGEX,
 } from './regex';
-export { safeToJsonSchema } from './safe-json-schema';
+export { generateJsonSchema } from './generate-json-schema';
 // ============================================================================
 // Serialization
 // ============================================================================

--- a/packages/epicenter/src/core/workspace.test.ts
+++ b/packages/epicenter/src/core/workspace.test.ts
@@ -700,7 +700,6 @@ describe('Workspace Action Handlers', () => {
 
 	test('createPost mutation creates a post', async () => {
 		const epicenter = defineEpicenter({
-			id: 'test-epicenter',
 			storageDir: TEST_DIR,
 			workspaces: [postsWorkspace],
 		});
@@ -723,7 +722,6 @@ describe('Workspace Action Handlers', () => {
 
 	test('listPosts query returns created posts', async () => {
 		const epicenter = defineEpicenter({
-			id: 'test-epicenter',
 			storageDir: TEST_DIR,
 			workspaces: [postsWorkspace],
 		});
@@ -751,7 +749,6 @@ describe('Workspace Action Handlers', () => {
 
 	test('getPost query retrieves specific post', async () => {
 		const epicenter = defineEpicenter({
-			id: 'test-epicenter',
 			storageDir: TEST_DIR,
 			workspaces: [postsWorkspace],
 		});
@@ -783,7 +780,6 @@ describe('Workspace Action Handlers', () => {
 
 	test('updateViews mutation updates post view count', async () => {
 		const epicenter = defineEpicenter({
-			id: 'test-epicenter',
 			storageDir: TEST_DIR,
 			workspaces: [postsWorkspace],
 		});
@@ -811,7 +807,6 @@ describe('Workspace Action Handlers', () => {
 
 	test('updateViews returns null for non-existent post', async () => {
 		const epicenter = defineEpicenter({
-			id: 'test-epicenter',
 			storageDir: TEST_DIR,
 			workspaces: [postsWorkspace],
 		});
@@ -830,7 +825,6 @@ describe('Workspace Action Handlers', () => {
 
 	test('createPost with optional content field', async () => {
 		const epicenter = defineEpicenter({
-			id: 'test-epicenter',
 			storageDir: TEST_DIR,
 			workspaces: [postsWorkspace],
 		});

--- a/packages/epicenter/src/server/README.md
+++ b/packages/epicenter/src/server/README.md
@@ -147,7 +147,6 @@ Now your actions are available as HTTP endpoints:
 import { defineEpicenter, createHttpServer } from '@epicenter/hq';
 
 const epicenter = defineEpicenter({
-	id: 'my-app',
 	workspaces: [blogWorkspace, authWorkspace, storageWorkspace],
 });
 
@@ -166,6 +165,7 @@ Actions from each workspace get their own namespace under `/workspaces`:
 - `GET http://localhost:3913/workspaces/storage/listFiles`
 
 **URL Hierarchy:**
+
 ```
 /                                    - API root/discovery
 /openapi                             - OpenAPI spec (JSON)

--- a/packages/epicenter/tests/integration/server.test.ts
+++ b/packages/epicenter/tests/integration/server.test.ts
@@ -98,7 +98,6 @@ describe('Server Integration Tests', () => {
 
 	describe('Single Workspace Server', () => {
 		const singleWorkspaceEpicenter = defineEpicenter({
-			id: 'single-workspace-test',
 			workspaces: [blogWorkspace],
 		});
 
@@ -271,7 +270,6 @@ describe('Server Integration Tests', () => {
 		});
 
 		const epicenter = defineEpicenter({
-			id: 'test-app',
 			workspaces: [blogWorkspace, authWorkspace],
 		});
 

--- a/packages/epicenter/tests/integration/sync-client-compat.test.ts
+++ b/packages/epicenter/tests/integration/sync-client-compat.test.ts
@@ -54,7 +54,6 @@ describe('y-websocket Client Compatibility', () => {
 	});
 
 	const epicenter = defineEpicenter({
-		id: 'y-websocket-compat-test',
 		workspaces: [notesWorkspace],
 	});
 

--- a/packages/epicenter/tests/integration/sync.test.ts
+++ b/packages/epicenter/tests/integration/sync.test.ts
@@ -65,7 +65,6 @@ describe('WebSocket Sync Integration Tests', () => {
 	});
 
 	const epicenter = defineEpicenter({
-		id: 'sync-test-app',
 		workspaces: [notesWorkspace],
 	});
 

--- a/specs/20251224T232100-remove-epicenter-id.md
+++ b/specs/20251224T232100-remove-epicenter-id.md
@@ -1,0 +1,131 @@
+# Remove `id` from defineEpicenter
+
+## Summary
+
+Remove the `id` field from `defineEpicenter` configuration since we're moving to Tailscale network topology where device discovery is handled by the network itself. The `id` is still needed in `defineWorkspace`.
+
+## Motivation
+
+The `id` field in `defineEpicenter`:
+
+1. **Is defined** in `EpicenterConfigBase` type
+2. **Is validated** in `validateEpicenterConfig`
+3. **Is NOT used at runtime** - never accessed in `createEpicenterClient`
+
+With Tailscale network topology, the epicenter ID becomes unnecessary since:
+
+- Network discovery replaces the need for explicit epicenter identification
+- Workspace IDs remain the primary sync boundary
+- The `id` was purely validation overhead with no runtime benefit
+
+## Changes
+
+### Core Types
+
+- [x] `config.shared.ts`: Remove `id` from `EpicenterConfigBase`, remove `TId` generic, remove validation
+- [x] `config.browser.ts`: Remove `TId` generic from type and function
+- [x] `config.node.ts`: Remove `TId` generic from type and function
+- [x] `client.browser.ts`: Remove `TId` generic from `createEpicenterClient`
+- [x] `client.node.ts`: Remove `TId` generic from `createEpicenterClient`
+
+### Tests
+
+- [x] `epicenter.test.ts`: Remove `id` from all `defineEpicenter` calls
+- [x] `workspace.test.ts`: Remove `id` from all `defineEpicenter` calls
+- [x] `cli/integration.test.ts`: Remove `id` from `defineEpicenter` calls
+- [x] `cli/cli-end-to-end.test.ts`: Remove `id` from `defineEpicenter` calls
+- [x] `tests/integration/server.test.ts`: Remove `id` from `defineEpicenter` calls
+- [x] `tests/integration/sync.test.ts`: Remove `id` from `defineEpicenter` calls
+- [x] `tests/integration/sync-client-compat.test.ts`: Remove `id` from `defineEpicenter` calls
+
+### Examples
+
+- [x] `examples/basic-workspace/epicenter.config.ts`: Remove `id`
+- [x] `examples/content-hub/epicenter.config.ts`: Remove `id`
+- [x] `examples/stress-test/epicenter.config.ts`: Remove `id`
+
+### Documentation
+
+- [x] `packages/epicenter/README.md`: Update examples
+- [x] `packages/epicenter/src/core/epicenter/README.md`: Update examples
+- [x] `packages/epicenter/src/server/README.md`: Update examples
+- [x] `packages/epicenter/src/cli/README.md`: Update examples
+- [x] Various spec files referencing `defineEpicenter` with `id`
+
+## Before/After
+
+### Before
+
+```typescript
+export type EpicenterConfigBase<
+	TId extends string = string,
+	TWorkspaces extends readonly AnyWorkspaceConfig[] =
+		readonly AnyWorkspaceConfig[],
+> = {
+	id: TId;
+	workspaces: TWorkspaces;
+};
+
+const epicenter = defineEpicenter({
+	id: 'my-app',
+	workspaces: [blogWorkspace, authWorkspace],
+});
+```
+
+### After
+
+```typescript
+export type EpicenterConfigBase<
+	TWorkspaces extends readonly AnyWorkspaceConfig[] =
+		readonly AnyWorkspaceConfig[],
+> = {
+	workspaces: TWorkspaces;
+};
+
+const epicenter = defineEpicenter({
+	workspaces: [blogWorkspace, authWorkspace],
+});
+```
+
+## Review
+
+Changes made successfully across 25+ files:
+
+**Core Types (5 files)**:
+
+- `config.shared.ts`: Removed `id` from `EpicenterConfigBase`, `TId` generic, and validation
+- `config.browser.ts`: Simplified type and function signatures
+- `config.node.ts`: Simplified type and function signatures
+- `client.browser.ts`: Removed `TId` generic from `createEpicenterClient`
+- `client.node.ts`: Removed `TId` generic from `createEpicenterClient`
+
+**Tests (7 files)**:
+
+- `epicenter.test.ts`: Removed `id` from all test cases
+- `workspace.test.ts`: Removed `id` from all `defineEpicenter` calls
+- `cli/integration.test.ts`: Updated test config
+- `cli/cli-end-to-end.test.ts`: Updated test config
+- `cli/load-config.test.ts`: Updated test assertions to use workspace id instead
+- `tests/integration/server.test.ts`: Updated both test configs
+- `tests/integration/sync.test.ts`: Updated test config
+- `tests/integration/sync-client-compat.test.ts`: Updated test config
+
+**Examples (3 files)**:
+
+- `examples/basic-workspace/epicenter.config.ts`: Removed `id`
+- `examples/content-hub/epicenter.config.ts`: Removed `id`
+- `examples/stress-test/epicenter.config.ts`: Removed `id`
+
+**CLI (1 file)**:
+
+- `cli/server.ts`: Removed references to `config.id` in console output
+
+**Documentation (5 files)**:
+
+- `packages/epicenter/src/cli/README.md`
+- `packages/epicenter/src/server/README.md`
+- `packages/epicenter/src/core/epicenter/README.md`
+- `docs/guides/handoff-yjs-persistence-rollout.md`
+- `specs/20251014T101252 epicenter-server.md`
+
+**Note**: There's a pre-existing codebase issue (missing `safe-json-schema` module) that prevents running tests, but this is unrelated to these changes. Type checking confirms no `id`-related type errors remain.


### PR DESCRIPTION
## Summary

Remove the `id` field from `defineEpicenter` configuration—workspace IDs are now sufficient for Yjs sync identity.

## Context

The `id` field was originally designed to group Epicenter instances that should synchronize with each other. Even if two devices had the same workspace ID, they also needed matching epicenter IDs to sync via Yjs.

With the architectural shift to Tailscale, we can assume all syncing devices are on the same network. This means the workspace ID alone is sufficient to uniquely identify what to sync against within the Tailscale network—the epicenter-level grouping becomes redundant.