### PR TITLE
refactor(epicenter): introduce paths namespace and restructure provider storage

### DIFF
--- a/docs/articles/factory-function-pattern.md
+++ b/docs/articles/factory-function-pattern.md
@@ -149,7 +149,7 @@ payments.charge({ amount: 1000, currency: 'usd' });
 **Epicenter Client + Server:**
 
 ```typescript
-const client = createClient(workspaces, { storageDir });
+const client = createClient(workspaces, { projectDir });
 const server = createServer(client, { cors: true });
 server.start({ port: 3913 });
 ```

--- a/examples/content-hub/gmail/gmail.workspace.ts
+++ b/examples/content-hub/gmail/gmail.workspace.ts
@@ -37,8 +37,8 @@ import {
  * Stores tokens in the provider's dedicated directory:
  * `.epicenter/providers/gmailAuth/token.json`
  */
-function gmailAuthProvider({ providerDir }: ProviderContext) {
-	if (!providerDir) {
+function gmailAuthProvider({ paths }: ProviderContext) {
+	if (!paths) {
 		return {
 			isAvailable: false as const,
 		};
@@ -46,11 +46,11 @@ function gmailAuthProvider({ providerDir }: ProviderContext) {
 
 	return {
 		isAvailable: true as const,
-		providerDir,
-		loadTokens: () => loadTokens(providerDir),
-		deleteTokens: () => deleteTokens(providerDir),
-		getAuthenticatedClient: () => getAuthenticatedClient(providerDir),
-		performOAuthLogin: () => performOAuthLogin(providerDir),
+		providerDir: paths.provider,
+		loadTokens: () => loadTokens(paths.provider),
+		deleteTokens: () => deleteTokens(paths.provider),
+		getAuthenticatedClient: () => getAuthenticatedClient(paths.provider),
+		performOAuthLogin: () => performOAuthLogin(paths.provider),
 	};
 }
 import {
@@ -127,6 +127,7 @@ export const gmail = defineWorkspace({
 	providers: {
 		persistence: setupPersistence,
 		sqlite: (c) => sqliteProvider(c),
+		gmailAuth: gmailAuthProvider,
 		markdown: (c) =>
 			markdownProvider(c, {
 				tableConfigs: {

--- a/examples/content-hub/gmail/gmail.workspace.ts
+++ b/examples/content-hub/gmail/gmail.workspace.ts
@@ -9,6 +9,7 @@ import {
 	generateId,
 	id,
 	markdownProvider,
+	type ProviderContext,
 	type SerializedRow,
 	sqliteProvider,
 	text,
@@ -25,6 +26,33 @@ import {
 	loadTokens,
 	performOAuthLogin,
 } from './auth';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Gmail Auth Provider
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Gmail auth provider that manages OAuth2 tokens.
+ *
+ * Stores tokens in the provider's dedicated directory:
+ * `.epicenter/providers/gmailAuth/token.json`
+ */
+function gmailAuthProvider({ providerDir }: ProviderContext) {
+	if (!providerDir) {
+		return {
+			isAvailable: false as const,
+		};
+	}
+
+	return {
+		isAvailable: true as const,
+		providerDir,
+		loadTokens: () => loadTokens(providerDir),
+		deleteTokens: () => deleteTokens(providerDir),
+		getAuthenticatedClient: () => getAuthenticatedClient(providerDir),
+		performOAuthLogin: () => performOAuthLogin(providerDir),
+	};
+}
 import {
 	extractPlainText,
 	getHeader,

--- a/packages/epicenter/README.md
+++ b/packages/epicenter/README.md
@@ -215,7 +215,7 @@ exports: ({ providers }) => ({
 })
 ```
 
-Provider functions receive a context object with `{ id, ydoc, storageDir, tables }` and can return exports. For example, sync providers:
+Provider functions receive a context object with `{ id, providerId, ydoc, schema, tables, paths }` and can return exports. For example, sync providers:
 
 ```typescript
 providers: {
@@ -1124,9 +1124,17 @@ type Provider<TExports> = (
 
 type ProviderContext = {
 	id: string; // Workspace ID
+	providerId: string; // Provider key (e.g., 'sqlite', 'persistence')
 	ydoc: Y.Doc; // YJS document
-	storageDir: AbsolutePath | undefined; // Node.js: absolute path, Browser: undefined
+	schema: TSchema; // Workspace schema (table definitions)
 	tables: Tables<TSchema>; // Access to workspace tables
+	paths: ProviderPaths | undefined; // Filesystem paths (undefined in browser)
+};
+
+type ProviderPaths = {
+	project: ProjectDir; // Project root for user content
+	epicenter: EpicenterDir; // .epicenter directory
+	provider: ProviderDir; // .epicenter/providers/{providerId}/
 };
 ```
 
@@ -1153,7 +1161,7 @@ providers: {
   }),
 
   // Custom provider
-  custom: ({ id, ydoc, storageDir }) => {
+  custom: ({ id, ydoc, paths }) => {
     console.log(`Setting up workspace: ${id}`);
     // Attach custom capabilities
   },
@@ -1188,7 +1196,7 @@ await client.destroy();
 await using client = await createClient(blogWorkspace);
 ```
 
-**storageDir**: Defaults to `process.cwd()` in Node.js, `undefined` in browser.
+**projectDir**: Defaults to `process.cwd()` in Node.js, `undefined` in browser.
 
 ## Architecture & Lifecycle
 
@@ -1405,7 +1413,7 @@ await client.destroy();
 await using client = await createClient(blogWorkspace);
 ```
 
-**storageDir**: Defaults to `process.cwd()` in Node.js, `undefined` in browser.
+**projectDir**: Defaults to `process.cwd()` in Node.js, `undefined` in browser.
 
 ## API Reference
 

--- a/packages/epicenter/src/cli/README.md
+++ b/packages/epicenter/src/cli/README.md
@@ -142,7 +142,7 @@ Test your CLI commands programmatically:
 import { createClient } from '@epicenter/hq';
 import { createCLI } from '@epicenter/hq/cli';
 
-const client = await createClient(workspaces, { storageDir: '...' });
+const client = await createClient(workspaces, { projectDir: '...' });
 await createCLI(client).run([
 	'reddit',
 	'import',

--- a/packages/epicenter/src/cli/bin.ts
+++ b/packages/epicenter/src/cli/bin.ts
@@ -16,10 +16,10 @@ async function main() {
 			// Enable automatic watch mode
 			await enableWatchMode();
 
-			const { workspaces, storageDir } = await loadEpicenterConfig(
+			const { workspaces, projectDir } = await loadEpicenterConfig(
 				process.cwd(),
 			);
-			const client = await createClient(workspaces, { storageDir });
+			const client = await createClient(workspaces, { projectDir });
 			await createCLI(client).run(hideBin(process.argv));
 		},
 		catch: (error) => {

--- a/packages/epicenter/src/cli/cli-end-to-end.test.ts
+++ b/packages/epicenter/src/cli/cli-end-to-end.test.ts
@@ -109,7 +109,7 @@ describe('CLI End-to-End Tests', () => {
 	});
 
 	const workspaces = [testWorkspace] as const;
-	const options = { storageDir: TEST_DIR };
+	const options = { projectDir: TEST_DIR };
 
 	beforeEach(async () => {
 		// Clean up test data

--- a/packages/epicenter/src/cli/load-config.test.ts
+++ b/packages/epicenter/src/cli/load-config.test.ts
@@ -73,7 +73,7 @@ describe('loadEpicenterConfig', () => {
 		const result = await loadEpicenterConfig(testDir);
 		expect(Array.isArray(result.workspaces)).toBe(true);
 		expect(result.workspaces[0]!.id).toBe('test-workspace');
-		expect(result.configPath).toBe(configPath);
+		expect(result.projectDir as string).toBe(testDir);
 	});
 
 	test('loads config with ES module syntax', async () => {

--- a/packages/epicenter/src/cli/load-config.ts
+++ b/packages/epicenter/src/cli/load-config.ts
@@ -1,4 +1,5 @@
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import type { ProjectDir } from '../core/types';
 import type { AnyWorkspaceConfig } from '../core/workspace';
 
 /**
@@ -8,12 +9,12 @@ import type { AnyWorkspaceConfig } from '../core/workspace';
  * The config file should export an array of workspace configurations.
  *
  * @param configDir - Directory containing epicenter.config.ts
- * @returns Object containing workspaces array and config file path
+ * @returns Object containing workspaces array and project directory
  * @throws Error if no config file is found or if the config is invalid
  */
 export async function loadEpicenterConfig(configDir: string): Promise<{
 	workspaces: readonly AnyWorkspaceConfig[];
-	configPath: string;
+	projectDir: ProjectDir;
 }> {
 	const configFiles = [
 		'epicenter.config.ts',
@@ -49,7 +50,10 @@ export async function loadEpicenterConfig(configDir: string): Promise<{
 			);
 		}
 
-		return { workspaces: config, configPath };
+		return {
+			workspaces: config,
+			projectDir: dirname(configPath) as ProjectDir,
+		};
 	} catch (error) {
 		if (error instanceof Error) {
 			throw new Error(

--- a/packages/epicenter/src/core/blobs/index.ts
+++ b/packages/epicenter/src/core/blobs/index.ts
@@ -10,8 +10,8 @@ export type BlobStoreContext<TSchema extends Record<string, unknown>> = {
 	id: string;
 	/** Workspace schema (table names become subdirectories) */
 	schema: TSchema;
-	/** Base storage directory (required for Node/Bun, undefined for browser) */
-	storageDir: string | undefined;
+	/** Project root directory (required for Node/Bun, undefined for browser) */
+	projectDir: string | undefined;
 };
 
 /**
@@ -32,12 +32,12 @@ function isBrowserWithOPFS(): boolean {
  * - Node/Bun (no OPFS) → Filesystem with Bun APIs
  *
  * @param tableName The table name (used as subdirectory)
- * @param storageDir The base storage directory (required for Node/Bun, ignored for browser)
+ * @param projectDir The project root directory (required for Node/Bun, ignored for browser)
  * @returns A TableBlobStore implementation
  */
 export async function createTableBlobStore(
 	tableName: string,
-	storageDir?: string,
+	projectDir?: string,
 ): Promise<TableBlobStore> {
 	if (isBrowserWithOPFS()) {
 		// Browser: use OPFS (Origin Private File System)
@@ -46,11 +46,11 @@ export async function createTableBlobStore(
 	}
 
 	// Node/Bun: use filesystem
-	if (!storageDir) {
-		throw new Error('storageDir is required for Node/Bun blob storage');
+	if (!projectDir) {
+		throw new Error('projectDir is required for Node/Bun blob storage');
 	}
 	const { createNodeTableBlobStore } = await import('./node.js');
-	return createNodeTableBlobStore(storageDir, tableName);
+	return createNodeTableBlobStore(projectDir, tableName);
 }
 
 /**

--- a/packages/epicenter/src/core/blobs/index.ts
+++ b/packages/epicenter/src/core/blobs/index.ts
@@ -65,7 +65,7 @@ export async function createTableBlobStore(
  *     posts: table({ ... }),
  *     users: table({ ... }),
  *   },
- *   storageDir: '/path/to/storage',
+ *   projectDir: '/path/to/project',
  * });
  * // blobs.posts, blobs.users are now available
  *
@@ -75,23 +75,23 @@ export async function createTableBlobStore(
  *
  * @param context.id - Workspace ID (used as parent directory)
  * @param context.schema - The workspace schema object
- * @param context.storageDir - The base storage directory (required for Node/Bun)
+ * @param context.projectDir - The project root directory (required for Node/Bun)
  * @returns WorkspaceBlobs object with stores for each table
  */
 export async function createWorkspaceBlobs<
 	TSchema extends Record<string, unknown>,
 >(context: BlobStoreContext<TSchema>): Promise<WorkspaceBlobs<TSchema>> {
-	const { id, schema, storageDir } = context;
+	const { id, schema, projectDir } = context;
 
 	// For Node/Bun, construct the workspace-specific storage path
-	// Storage layout: {storageDir}/{workspaceId}/{tableName}/{filename}
-	const workspaceStorageDir = storageDir ? join(storageDir, id) : undefined;
+	// Storage layout: {projectDir}/{workspaceId}/{tableName}/{filename}
+	const workspaceProjectDir = projectDir ? join(projectDir, id) : undefined;
 
 	const tableNames = Object.keys(schema);
 	const stores = await Promise.all(
 		tableNames.map(async (tableName) => [
 			tableName,
-			await createTableBlobStore(tableName, workspaceStorageDir),
+			await createTableBlobStore(tableName, workspaceProjectDir),
 		]),
 	);
 	return Object.fromEntries(stores) as WorkspaceBlobs<TSchema>;

--- a/packages/epicenter/src/core/blobs/node.ts
+++ b/packages/epicenter/src/core/blobs/node.ts
@@ -10,15 +10,15 @@ import { validateFilename } from './utils.js';
  * Create a blob store for a table using Bun's filesystem APIs.
  * This implementation is used in Node/Bun environments.
  *
- * @param storageDir The base storage directory (absolute path)
+ * @param projectDir The project root directory (absolute path)
  * @param tableName The table name (used as subdirectory)
  * @returns A TableBlobStore implementation
  */
 export function createNodeTableBlobStore(
-	storageDir: string,
+	projectDir: string,
 	tableName: string,
 ): TableBlobStore {
-	const tableDir = join(storageDir, tableName);
+	const tableDir = join(projectDir, tableName);
 
 	return {
 		async put(filename, data) {

--- a/packages/epicenter/src/core/paths.ts
+++ b/packages/epicenter/src/core/paths.ts
@@ -1,0 +1,46 @@
+import path from 'node:path';
+import type { EpicenterDir, ProviderDir, StorageDir } from './types';
+
+/**
+ * Compute the `.epicenter` directory path from the storage directory.
+ *
+ * @param storageDir - The project root directory
+ * @returns Absolute path to the `.epicenter` directory
+ *
+ * @example
+ * ```typescript
+ * const epicenterDir = getEpicenterDir(storageDir);
+ * // '/Users/me/project' → '/Users/me/project/.epicenter'
+ * ```
+ */
+export function getEpicenterDir(storageDir: StorageDir): EpicenterDir {
+	return path.join(storageDir, '.epicenter') as EpicenterDir;
+}
+
+/**
+ * Compute the provider's dedicated directory within `.epicenter/providers/`.
+ *
+ * Each provider gets its own isolated directory for storing internal artifacts
+ * like databases, logs, caches, and tokens. This keeps provider data organized
+ * and enables selective gitignore (only `.epicenter/providers/` is ignored).
+ *
+ * @param epicenterDir - The `.epicenter` directory path
+ * @param providerId - The provider's key in the workspace providers map (e.g., 'sqlite', 'markdown', 'gmail')
+ * @returns Absolute path to the provider's directory
+ *
+ * @example
+ * ```typescript
+ * const providerDir = getProviderDir(epicenterDir, 'sqlite');
+ * // '/Users/me/project/.epicenter' → '/Users/me/project/.epicenter/providers/sqlite'
+ *
+ * // Store provider artifacts:
+ * const dbPath = path.join(providerDir, `${workspaceId}.db`);
+ * const logPath = path.join(providerDir, 'logs', `${workspaceId}.log`);
+ * ```
+ */
+export function getProviderDir(
+	epicenterDir: EpicenterDir,
+	providerId: string,
+): ProviderDir {
+	return path.join(epicenterDir, 'providers', providerId) as ProviderDir;
+}

--- a/packages/epicenter/src/core/paths.ts
+++ b/packages/epicenter/src/core/paths.ts
@@ -1,46 +1,30 @@
 import path from 'node:path';
-import type { EpicenterDir, ProviderDir, StorageDir } from './types';
+import type {
+	EpicenterDir,
+	ProjectDir,
+	ProviderDir,
+	ProviderPaths,
+} from './types';
 
-/**
- * Compute the `.epicenter` directory path from the storage directory.
- *
- * @param storageDir - The project root directory
- * @returns Absolute path to the `.epicenter` directory
- *
- * @example
- * ```typescript
- * const epicenterDir = getEpicenterDir(storageDir);
- * // '/Users/me/project' → '/Users/me/project/.epicenter'
- * ```
- */
-export function getEpicenterDir(storageDir: StorageDir): EpicenterDir {
-	return path.join(storageDir, '.epicenter') as EpicenterDir;
+export function getEpicenterDir(projectDir: ProjectDir): EpicenterDir {
+	return path.join(projectDir, '.epicenter') as EpicenterDir;
 }
 
-/**
- * Compute the provider's dedicated directory within `.epicenter/providers/`.
- *
- * Each provider gets its own isolated directory for storing internal artifacts
- * like databases, logs, caches, and tokens. This keeps provider data organized
- * and enables selective gitignore (only `.epicenter/providers/` is ignored).
- *
- * @param epicenterDir - The `.epicenter` directory path
- * @param providerId - The provider's key in the workspace providers map (e.g., 'sqlite', 'markdown', 'gmail')
- * @returns Absolute path to the provider's directory
- *
- * @example
- * ```typescript
- * const providerDir = getProviderDir(epicenterDir, 'sqlite');
- * // '/Users/me/project/.epicenter' → '/Users/me/project/.epicenter/providers/sqlite'
- *
- * // Store provider artifacts:
- * const dbPath = path.join(providerDir, `${workspaceId}.db`);
- * const logPath = path.join(providerDir, 'logs', `${workspaceId}.log`);
- * ```
- */
 export function getProviderDir(
 	epicenterDir: EpicenterDir,
 	providerId: string,
 ): ProviderDir {
 	return path.join(epicenterDir, 'providers', providerId) as ProviderDir;
+}
+
+export function buildProviderPaths(
+	projectDir: ProjectDir,
+	providerId: string,
+): ProviderPaths {
+	const epicenterDir = getEpicenterDir(projectDir);
+	return {
+		project: projectDir,
+		epicenter: epicenterDir,
+		provider: getProviderDir(epicenterDir, providerId),
+	};
 }

--- a/packages/epicenter/src/core/provider.ts
+++ b/packages/epicenter/src/core/provider.ts
@@ -1,56 +1,82 @@
 import type * as Y from 'yjs';
 import type { Tables } from './db/core';
 import type { WorkspaceSchema } from './schema';
-import type { EpicenterDir, StorageDir } from './types';
+import type { ProviderDir, StorageDir } from './types';
 
 /**
  * Context provided to each provider function.
  *
- * Provides workspace metadata, the YJS document, and table access for providers.
+ * Providers began as data indexes (SQLite, markdown) but have evolved to handle
+ * many workspace capabilities: persistence, sync, authentication, and more.
  *
  * @property id - The workspace ID (e.g., 'blog', 'content-hub')
  * @property providerId - This provider's key in the providers map (e.g., 'sqlite', 'persistence')
  * @property ydoc - The YJS document that providers can attach to
  * @property schema - The workspace schema (table definitions)
  * @property tables - The Epicenter tables instance for observing/querying data
- * @property storageDir - Absolute storage directory path resolved from epicenter config
- *   - Node.js: Resolved to absolute path (defaults to `process.cwd()` if not specified in config)
- *   - Browser: `undefined` (filesystem operations not available)
- * @property epicenterDir - Absolute path to the `.epicenter` directory
- *   - Computed as `path.join(storageDir, '.epicenter')`
- *   - `undefined` in browser environment
+ * @property storageDir - Project root directory for user-facing content (e.g., markdown vault)
+ * @property providerDir - Provider's dedicated directory for internal artifacts (databases, logs, tokens)
  *
- * @example Persistence provider (uses ydoc only)
+ * ## Path Context
+ *
+ * Providers receive two path variables for different purposes:
+ *
+ * - **`storageDir`**: Project root. Use for user-facing content that lives outside `.epicenter/`.
+ *   Example: markdown files in `./vault/`, config files, user-editable content.
+ *
+ * - **`providerDir`**: Provider's isolated directory at `.epicenter/providers/{providerId}/`.
+ *   Use for internal artifacts like databases, logs, caches, and tokens.
+ *   This directory is gitignored.
+ *
+ * Both are `undefined` in browser environments where filesystem access isn't available.
+ *
+ * @example Persistence provider (stores YJS state)
  * ```typescript
- * const persistenceProvider: Provider = ({ id, ydoc, epicenterDir }) => {
- *   if (!epicenterDir) throw new Error('Requires Node.js');
- *   const filePath = path.join(epicenterDir, `${id}.yjs`);
+ * const persistenceProvider: Provider = ({ id, providerDir }) => {
+ *   if (!providerDir) throw new Error('Requires Node.js');
+ *   const filePath = path.join(providerDir, `${id}.yjs`);
  *   // Load/save ydoc state...
  * };
  * ```
  *
- * @example Materializer provider (uses tables)
+ * @example SQLite index (internal artifacts)
  * ```typescript
- * const sqliteProvider: Provider<MySchema, SqliteExports> = ({ id, providerId, tables, epicenterDir }) => {
- *   // Observe table changes, sync to SQLite...
- *   return defineProviderExports({
- *     destroy: () => client.close(),
- *     db: sqliteDb,
- *   });
+ * const sqliteProvider: Provider = ({ id, providerDir }) => {
+ *   const dbPath = path.join(providerDir, `${id}.db`);
+ *   const logPath = path.join(providerDir, 'logs', `${id}.log`);
+ *   // ...
+ * };
+ * ```
+ *
+ * @example Markdown provider (user content + internal logs)
+ * ```typescript
+ * const markdownProvider: Provider = ({ id, storageDir, providerDir }, config) => {
+ *   // User content: resolve relative to project root
+ *   const contentDir = path.resolve(storageDir, config.directory);
+ *
+ *   // Internal logs: use provider directory
+ *   const logPath = path.join(providerDir, 'logs', `${id}.log`);
+ * };
+ * ```
+ *
+ * @example Auth provider (tokens and credentials)
+ * ```typescript
+ * const gmailProvider: Provider = ({ providerDir }) => {
+ *   const tokenPath = path.join(providerDir, 'token.json');
+ *   // OAuth tokens stored in provider's isolated directory
  * };
  * ```
  */
-export type ProviderContext<
-	TSchema extends WorkspaceSchema = WorkspaceSchema,
-> = {
-	id: string;
-	providerId: string;
-	ydoc: Y.Doc;
-	schema: TSchema;
-	tables: Tables<TSchema>;
-	storageDir: StorageDir | undefined;
-	epicenterDir: EpicenterDir | undefined;
-};
+export type ProviderContext<TSchema extends WorkspaceSchema = WorkspaceSchema> =
+	{
+		id: string;
+		providerId: string;
+		ydoc: Y.Doc;
+		schema: TSchema;
+		tables: Tables<TSchema>;
+		storageDir: StorageDir | undefined;
+		providerDir: ProviderDir | undefined;
+	};
 
 /**
  * Provider exports type - an object with optional cleanup function and any exported resources.
@@ -77,30 +103,22 @@ export type ProviderExports = {
 /**
  * A provider function that attaches external capabilities to a workspace.
  *
- * Providers can be:
+ * Providers handle many workspace capabilities:
  * - **Persistence**: Save/load YDoc state (filesystem, IndexedDB)
  * - **Synchronization**: Real-time collaboration (WebSocket, WebRTC)
  * - **Materializers**: Sync data to external stores (SQLite, markdown, vector DB)
+ * - **Authentication**: OAuth tokens, API keys, credentials storage
  * - **Observability**: Logging, debugging, analytics
  *
  * Providers can be synchronous or asynchronous. All providers are awaited during initialization.
  * Providers can optionally return exports that are accessible in the workspace exports factory.
  *
- * @example Persistence provider (no exports)
- * ```typescript
- * const persistenceProvider: Provider = ({ ydoc }) => {
- *   new IndexeddbPersistence('my-db', ydoc);
- * };
- * ```
- *
  * @example Materializer provider (with exports)
  * ```typescript
- * const sqliteProvider: Provider<MySchema, SqliteExports> = async ({ tables, epicenterDir }) => {
- *   const client = new Database(path.join(epicenterDir, 'data.db'));
+ * const sqliteProvider: Provider<MySchema, SqliteExports> = async ({ id, providerDir, tables }) => {
+ *   const client = new Database(path.join(providerDir, `${id}.db`));
  *   const sqliteDb = drizzle({ client });
- *
  *   // Set up observers...
- *
  *   return defineProviderExports({
  *     destroy: () => client.close(),
  *     db: sqliteDb,

--- a/packages/epicenter/src/core/types.ts
+++ b/packages/epicenter/src/core/types.ts
@@ -13,7 +13,7 @@ export type AbsolutePath = string & Brand<'AbsolutePath'>;
  *
  * This is where user-facing content lives: markdown vaults, config files,
  * and any content that should be version-controlled. Configured via
- * `storageDir` option in `createClient()`. Defaults to `process.cwd()`.
+ * `projectDir` option in `createClient()`. Defaults to `process.cwd()`.
  *
  * @example
  * ```typescript
@@ -138,6 +138,3 @@ export type ProviderPaths = {
 	/** Provider's isolated directory at `.epicenter/providers/{providerId}/`. */
 	provider: ProviderDir;
 };
-
-/** @deprecated Use `ProjectDir` instead */
-export type StorageDir = ProjectDir;

--- a/packages/epicenter/src/core/types.ts
+++ b/packages/epicenter/src/core/types.ts
@@ -56,25 +56,39 @@ export type StorageDir = AbsolutePath & Brand<'StorageDir'>;
  * Branded type for the `.epicenter` directory path
  *
  * This is the absolute path to the `.epicenter` directory where all Epicenter
- * data is stored (YJS documents, SQLite databases, logs, tokens, etc.).
+ * data is stored. Providers store their data inside `.epicenter/providers/{providerId}/`.
  *
- * Computed once from `storageDir` and passed to providers, indexes, and exports
- * to avoid repeated `path.join(storageDir, '.epicenter')` calls.
+ * Most providers should use `providerDir` instead of `epicenterDir` directly.
+ * This type exists for computing `providerDir` and for rare cases where
+ * direct access to the `.epicenter` root is needed.
+ *
+ * @see ProviderDir - The preferred path for provider artifacts
+ */
+export type EpicenterDir = AbsolutePath & Brand<'EpicenterDir'>;
+
+/**
+ * Branded type for a provider's dedicated directory path
+ *
+ * Each provider gets its own isolated directory at `.epicenter/providers/{providerId}/`.
+ * This is where providers should store all their internal artifacts:
+ * - Databases (e.g., `{workspaceId}.db`)
+ * - Logs (e.g., `logs/{workspaceId}.log`)
+ * - Caches, tokens, and other provider-specific data
+ *
+ * The `providers/` subdirectory is gitignored, keeping provider data separate
+ * from workspace definitions that may be committed.
  *
  * @example
  * ```typescript
- * // In a workspace export
- * exports: ({ epicenterDir }) => ({
- *   login: defineMutation({
- *     handler: async () => {
- *       if (!epicenterDir) {
- *         return Err({ message: 'Requires filesystem access' });
- *       }
- *       const tokenPath = path.join(epicenterDir, 'gmail-token.json');
- *       // ...
- *     }
- *   })
- * })
+ * // In a provider
+ * const sqliteProvider: Provider = ({ providerDir, id }) => {
+ *   if (!providerDir) {
+ *     throw new Error('Requires Node.js environment');
+ *   }
+ *   const dbPath = path.join(providerDir, `${id}.db`);
+ *   const logPath = path.join(providerDir, 'logs', `${id}.log`);
+ *   // ...
+ * };
  * ```
  */
-export type EpicenterDir = AbsolutePath & Brand<'EpicenterDir'>;
+export type ProviderDir = AbsolutePath & Brand<'ProviderDir'>;

--- a/packages/epicenter/src/core/workspace.test.ts
+++ b/packages/epicenter/src/core/workspace.test.ts
@@ -698,7 +698,7 @@ describe('Workspace Action Handlers', () => {
 
 	test('createPost mutation creates a post', async () => {
 		await using client = await createClient(postsWorkspace, {
-			storageDir: TEST_DIR,
+			projectDir: TEST_DIR,
 		});
 
 		const result = await client.createPost({
@@ -717,7 +717,7 @@ describe('Workspace Action Handlers', () => {
 
 	test('listPosts query returns created posts', async () => {
 		await using client = await createClient(postsWorkspace, {
-			storageDir: TEST_DIR,
+			projectDir: TEST_DIR,
 		});
 
 		// Create a post first
@@ -741,7 +741,7 @@ describe('Workspace Action Handlers', () => {
 
 	test('getPost query retrieves specific post', async () => {
 		await using client = await createClient(postsWorkspace, {
-			storageDir: TEST_DIR,
+			projectDir: TEST_DIR,
 		});
 
 		// Create a post
@@ -769,7 +769,7 @@ describe('Workspace Action Handlers', () => {
 
 	test('updateViews mutation updates post view count', async () => {
 		await using client = await createClient(postsWorkspace, {
-			storageDir: TEST_DIR,
+			projectDir: TEST_DIR,
 		});
 
 		// Create a post
@@ -793,7 +793,7 @@ describe('Workspace Action Handlers', () => {
 
 	test('updateViews returns null for non-existent post', async () => {
 		await using client = await createClient(postsWorkspace, {
-			storageDir: TEST_DIR,
+			projectDir: TEST_DIR,
 		});
 
 		// Try to update views on non-existent post
@@ -808,7 +808,7 @@ describe('Workspace Action Handlers', () => {
 
 	test('createPost with optional content field', async () => {
 		await using client = await createClient(postsWorkspace, {
-			storageDir: TEST_DIR,
+			projectDir: TEST_DIR,
 		});
 
 		const result = await client.createPost({

--- a/packages/epicenter/src/core/workspace/client.browser.ts
+++ b/packages/epicenter/src/core/workspace/client.browser.ts
@@ -78,7 +78,7 @@ export async function createClient(
 	if (Array.isArray(input)) {
 		validateWorkspaces(input);
 
-		const clients = await initializeWorkspaces(input, undefined, undefined);
+		const clients = await initializeWorkspaces(input, undefined);
 
 		const cleanup = async () => {
 			await Promise.all(
@@ -105,11 +105,7 @@ export async function createClient(
 	}
 	allWorkspaceConfigs.push(workspace);
 
-	const clients = await initializeWorkspaces(
-		allWorkspaceConfigs,
-		undefined,
-		undefined,
-	);
+	const clients = await initializeWorkspaces(allWorkspaceConfigs, undefined);
 
 	const workspaceClient = clients[workspace.id as keyof typeof clients];
 	if (!workspaceClient) {

--- a/packages/epicenter/src/core/workspace/client.browser.ts
+++ b/packages/epicenter/src/core/workspace/client.browser.ts
@@ -2,7 +2,7 @@
  * Browser workspace client implementation.
  *
  * Provides createClient for browser environments (web apps, Tauri).
- * Uses undefined storageDir since browsers use IndexedDB for persistence
+ * Uses undefined projectDir since browsers use IndexedDB for persistence
  * rather than filesystem paths.
  */
 import type { WorkspaceExports } from '../actions';
@@ -26,7 +26,7 @@ export type {
  * Create a client for a single workspace (browser version).
  * Initializes the workspace and its dependencies, returns only the target workspace's client.
  *
- * In browser environments, storageDir is always undefined (no filesystem access).
+ * In browser environments, projectDir is always undefined (no filesystem access).
  *
  * @param workspace - Workspace configuration to initialize
  * @returns Initialized workspace client with access to all workspace exports
@@ -57,7 +57,7 @@ export async function createClient<
  * Create a client for multiple workspaces (browser version).
  * Initializes all workspaces in dependency order, returns an object mapping workspace IDs to clients.
  *
- * In browser environments, storageDir is always undefined (no filesystem access).
+ * In browser environments, projectDir is always undefined (no filesystem access).
  *
  * @param workspaces - Array of workspace configurations to initialize
  * @returns Initialized client with access to all workspace exports by workspace ID

--- a/packages/epicenter/src/core/workspace/client.shared.ts
+++ b/packages/epicenter/src/core/workspace/client.shared.ts
@@ -3,7 +3,7 @@
  *
  * This file contains platform-agnostic logic for workspace initialization.
  * Platform-specific entry points (client.browser.ts, client.node.ts) call
- * initializeWorkspaces with the appropriate storageDir/epicenterDir values.
+ * initializeWorkspaces with the appropriate projectDir value.
  */
 
 import * as Y from 'yjs';

--- a/packages/epicenter/src/core/workspace/config.ts
+++ b/packages/epicenter/src/core/workspace/config.ts
@@ -7,7 +7,18 @@ import type {
 	WorkspaceProviderMap,
 } from '../provider';
 import type { WorkspaceSchema, WorkspaceValidators } from '../schema';
-import type { EpicenterDir, StorageDir } from '../types';
+import type { EpicenterDir, ProjectDir } from '../types';
+
+/**
+ * Filesystem paths available to workspace exports factory.
+ *
+ * Unlike `ProviderPaths`, this omits `provider` since the exports factory
+ * operates at the workspace level, not the individual provider level.
+ */
+export type WorkspacePaths = {
+	project: ProjectDir;
+	epicenter: EpicenterDir;
+};
 
 /**
  * Define a collaborative workspace with YJS-first architecture.
@@ -215,8 +226,7 @@ export type WorkspaceConfig<
 		workspaces: WorkspacesToExports<TDeps>;
 		providers: TProviderResults;
 		blobs: WorkspaceBlobs<TWorkspaceSchema>;
-		storageDir: StorageDir | undefined;
-		epicenterDir: EpicenterDir | undefined;
+		paths: WorkspacePaths | undefined;
 	}) => TExports;
 };
 

--- a/packages/epicenter/src/index.browser.ts
+++ b/packages/epicenter/src/index.browser.ts
@@ -8,7 +8,7 @@
 // All platform-agnostic exports
 export * from './index.shared';
 
-// Browser-specific: client creation (no storageDir option)
+// Browser-specific: client creation (no projectDir option)
 export { createClient } from './core/workspace/client.browser';
 
 // Client types (shared across platforms)

--- a/packages/epicenter/src/index.node.ts
+++ b/packages/epicenter/src/index.node.ts
@@ -8,7 +8,7 @@
 // All platform-agnostic exports
 export * from './index.shared';
 
-// Node-specific: client creation with options (storageDir)
+// Node-specific: client creation with options (projectDir)
 export {
 	createClient,
 	type CreateClientOptions,

--- a/packages/epicenter/src/index.shared.ts
+++ b/packages/epicenter/src/index.shared.ts
@@ -155,7 +155,7 @@ export {
 } from './core/schema';
 
 // Core types
-export type { AbsolutePath, EpicenterDir, StorageDir } from './core/types';
+export type { AbsolutePath, EpicenterDir, ProjectDir } from './core/types';
 
 // Workspace types (shared across platforms)
 export type {

--- a/packages/epicenter/src/indexes/error-logger.ts
+++ b/packages/epicenter/src/indexes/error-logger.ts
@@ -124,7 +124,7 @@ type IndexLogger = {
  * @example
  * ```typescript
  * const logger = createIndexLogger({
- *   logPath: path.join(storageDir, '.epicenter', 'markdown', `${workspaceId}.log`)
+ *   logPath: path.join(paths.provider, 'logs', `${workspaceId}.log`)
  * });
  *
  * // Synchronous: doesn't block, queues internally

--- a/packages/epicenter/src/indexes/markdown/README.md
+++ b/packages/epicenter/src/indexes/markdown/README.md
@@ -127,9 +127,10 @@ The provider ID (`markdown`, `markdownDocs`, etc.) is automatically passed via `
 ### Layer 1: Workspace Configuration
 
 **`directory`** (optional): The workspace-level directory where all markdown files for this workspace are stored.
+
 - Defaults to the workspace `id`
-- Can be a relative path (resolved from `storageDir`) or absolute path
-- Example: If workspace id is "blog", defaults to `<storageDir>/blog`
+- Can be a relative path (resolved from `paths.project`) or absolute path
+- Example: If workspace id is "blog", defaults to `<projectDir>/blog`
 
 **`tableConfigs`** (optional): Per-table configuration object where keys are table names and values define how each table is handled.
 
@@ -138,14 +139,17 @@ The provider ID (`markdown`, `markdownDocs`, etc.) is automatically passed via `
 Each table in `tableConfigs` can have these properties:
 
 **`directory`** (optional): The directory for this specific table's markdown files.
+
 - Defaults to the table name
 - Resolved relative to the workspace directory (unless absolute)
 
 **`serialize()`**: Converts a database row into markdown format.
+
 - Input: `{ row, table }`
 - Output: `{ frontmatter, body, filename }`
 
 **`deserialize()`**: Converts markdown back into a database row.
+
 - Input: `{ frontmatter, body, filename, table }`
 - Output: `Result<SerializedRow, MarkdownProviderError>`
 
@@ -154,7 +158,7 @@ Each table in `tableConfigs` can have these properties:
 With default configuration:
 
 ```
-storageDir/
+projectDir/
 └── blog/                    (workspace.id = "blog")
     ├── posts/               (table name = "posts")
     │   ├── post-1.md
@@ -167,7 +171,7 @@ storageDir/
 With custom paths:
 
 ```
-storageDir/
+projectDir/
 └── content/                 (workspace.directory = "./content")
     ├── blog-posts/          (posts.directory = "./blog-posts")
     │   ├── post-1.md
@@ -187,7 +191,7 @@ When you don't provide custom configuration:
 - **Deserialize**: Extract `id` from filename, validate frontmatter against schema
 
 ```
-storageDir/
+projectDir/
 └── {workspace.id}/
     └── {tableName}/
         └── {rowId}.md
@@ -242,12 +246,12 @@ providers: {
 
 #### Custom Storage Directory
 
-To store files in a different location (relative to storageDir):
+To store files in a different location (relative to project directory):
 
 ```typescript
 providers: {
   markdown: (context) => markdownProvider(context, {
-    directory: './vault',  // → <storageDir>/vault
+    directory: './vault',  // → <projectDir>/vault
   }),
 }
 ```

--- a/packages/epicenter/src/indexes/markdown/markdown-index.ts
+++ b/packages/epicenter/src/indexes/markdown/markdown-index.ts
@@ -310,33 +310,33 @@ export const markdownProvider = (async <TSchema extends WorkspaceSchema>(
 	context: ProviderContext<TSchema>,
 	config: MarkdownProviderConfig<TSchema> = {},
 ) => {
-	const { id, tables, storageDir, providerDir } = context;
+	const { id, tables, paths } = context;
 	const { directory = `./${id}` } = config;
 
 	const userTableConfigs: TableConfigs<TSchema> = config.tableConfigs ?? {};
-	if (!storageDir || !providerDir) {
+	if (!paths) {
 		throw new Error(
 			'Markdown provider requires Node.js environment with filesystem access',
 		);
 	}
 
 	// Provider artifacts: .epicenter/providers/markdown/diagnostics/{workspaceId}.json
-	const diagnosticsDir = path.join(providerDir, 'diagnostics');
+	const diagnosticsDir = path.join(paths.provider, 'diagnostics');
 	const diagnostics = createDiagnosticsManager({
 		diagnosticsPath: path.join(diagnosticsDir, `${id}.json`),
 	});
 
 	// Logs: .epicenter/providers/markdown/logs/{workspaceId}.log
-	const logsDir = path.join(providerDir, 'logs');
+	const logsDir = path.join(paths.provider, 'logs');
 	const logger = createIndexLogger({
 		logPath: path.join(logsDir, `${id}.log`),
 	});
 
 	// Resolve workspace directory to absolute path
-	// If directory is relative, resolve it relative to storageDir
+	// If directory is relative, resolve it relative to projectDir (paths.project)
 	// If directory is absolute, use it as-is
 	const absoluteWorkspaceDir = path.resolve(
-		storageDir,
+		paths.project,
 		directory,
 	) as AbsolutePath;
 

--- a/packages/epicenter/src/indexes/markdown/markdown-index.ts
+++ b/packages/epicenter/src/indexes/markdown/markdown-index.ts
@@ -247,16 +247,16 @@ export type MarkdownProviderConfig<
 	 *
 	 * **Optional**: Defaults to the workspace `id` if not provided
 	 * ```typescript
-	 * // If workspace id is "blog", defaults to "<storageDir>/blog"
-	 * markdownIndex({ id, db, storageDir })
+	 * // If workspace id is "blog", defaults to "<projectDir>/blog"
+	 * markdownIndex({ id, db, paths })
 	 * ```
 	 *
 	 * **Three ways to specify the path**:
 	 *
-	 * **Option 1: Relative paths** (recommended): Resolved relative to storageDir from epicenter config
+	 * **Option 1: Relative paths** (recommended): Resolved relative to paths.project from epicenter config
 	 * ```typescript
-	 * directory: './vault'      // → <storageDir>/vault
-	 * directory: '../content'   // → <storageDir>/../content
+	 * directory: './vault'      // → <projectDir>/vault
+	 * directory: '../content'   // → <projectDir>/../content
 	 * ```
 	 *
 	 * **Option 2: Absolute paths**: Used as-is, no resolution needed

--- a/packages/epicenter/src/indexes/markdown/markdown-index.ts
+++ b/packages/epicenter/src/indexes/markdown/markdown-index.ts
@@ -310,34 +310,26 @@ export const markdownProvider = (async <TSchema extends WorkspaceSchema>(
 	context: ProviderContext<TSchema>,
 	config: MarkdownProviderConfig<TSchema> = {},
 ) => {
-	const { id, providerId, tables, storageDir, epicenterDir } = context;
+	const { id, tables, storageDir, providerDir } = context;
 	const { directory = `./${id}` } = config;
 
-	// User-provided table configs (sparse - only contains overrides, may be empty)
-	// Access via userTableConfigs[tableName] returns undefined when user didn't provide config
 	const userTableConfigs: TableConfigs<TSchema> = config.tableConfigs ?? {};
-	// Require Node.js environment with filesystem access
-	if (!storageDir || !epicenterDir) {
+	if (!storageDir || !providerDir) {
 		throw new Error(
 			'Markdown provider requires Node.js environment with filesystem access',
 		);
 	}
 
-	// Workspace-specific directory for all provider artifacts
-	// Structure: .epicenter/{workspaceId}/{providerId}.{suffix}
-	const workspaceConfigDir = path.join(epicenterDir, id);
-
-	// Create diagnostics manager for tracking validation errors (current state)
+	// Provider artifacts: .epicenter/providers/markdown/diagnostics/{workspaceId}.json
+	const diagnosticsDir = path.join(providerDir, 'diagnostics');
 	const diagnostics = createDiagnosticsManager({
-		diagnosticsPath: path.join(
-			workspaceConfigDir,
-			`${providerId}.diagnostics.json`,
-		),
+		diagnosticsPath: path.join(diagnosticsDir, `${id}.json`),
 	});
 
-	// Create logger for historical error record (append-only audit trail)
+	// Logs: .epicenter/providers/markdown/logs/{workspaceId}.log
+	const logsDir = path.join(providerDir, 'logs');
 	const logger = createIndexLogger({
-		logPath: path.join(workspaceConfigDir, `${providerId}.log`),
+		logPath: path.join(logsDir, `${id}.log`),
 	});
 
 	// Resolve workspace directory to absolute path

--- a/packages/epicenter/src/indexes/sqlite/sqlite-index.ts
+++ b/packages/epicenter/src/indexes/sqlite/sqlite-index.ts
@@ -87,11 +87,11 @@ type SqliteProviderOptions = {
  * ```
  */
 export const sqliteProvider = (async <TSchema extends WorkspaceSchema>(
-	{ id, schema, tables, providerDir }: ProviderContext<TSchema>,
+	{ id, schema, tables, paths }: ProviderContext<TSchema>,
 	options: SqliteProviderOptions = {},
 ) => {
 	const debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
-	if (!providerDir) {
+	if (!paths) {
 		throw new Error(
 			'SQLite provider requires Node.js environment with filesystem access',
 		);
@@ -100,8 +100,8 @@ export const sqliteProvider = (async <TSchema extends WorkspaceSchema>(
 	const drizzleTables = convertWorkspaceSchemaToDrizzle(schema);
 
 	// Storage: .epicenter/providers/sqlite/{workspaceId}.db
-	const databasePath = path.join(providerDir, `${id}.db`);
-	await mkdir(providerDir, { recursive: true });
+	const databasePath = path.join(paths.provider, `${id}.db`);
+	await mkdir(paths.provider, { recursive: true });
 
 	// WAL mode for better concurrent access
 	const client = new Database(databasePath);
@@ -109,7 +109,7 @@ export const sqliteProvider = (async <TSchema extends WorkspaceSchema>(
 	const sqliteDb = drizzle({ client, schema: drizzleTables });
 
 	// Logs: .epicenter/providers/sqlite/logs/{workspaceId}.log
-	const logsDir = path.join(providerDir, 'logs');
+	const logsDir = path.join(paths.provider, 'logs');
 	await mkdir(logsDir, { recursive: true });
 	const logPath = path.join(logsDir, `${id}.log`);
 	const logger = createIndexLogger({ logPath });

--- a/packages/epicenter/src/indexes/sqlite/sqlite-index.ts
+++ b/packages/epicenter/src/indexes/sqlite/sqlite-index.ts
@@ -87,35 +87,31 @@ type SqliteProviderOptions = {
  * ```
  */
 export const sqliteProvider = (async <TSchema extends WorkspaceSchema>(
-	{ id, providerId, schema, tables, epicenterDir }: ProviderContext<TSchema>,
+	{ id, schema, tables, providerDir }: ProviderContext<TSchema>,
 	options: SqliteProviderOptions = {},
 ) => {
 	const debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
-	// Require Node.js environment with filesystem access
-	if (!epicenterDir) {
+	if (!providerDir) {
 		throw new Error(
 			'SQLite provider requires Node.js environment with filesystem access',
 		);
 	}
 
-	// Convert table schemas to Drizzle tables
 	const drizzleTables = convertWorkspaceSchemaToDrizzle(schema);
 
-	// Set up storage paths
-	const databasePath = path.join(epicenterDir, `${id}.db`);
-	await mkdir(path.dirname(databasePath), { recursive: true });
+	// Storage: .epicenter/providers/sqlite/{workspaceId}.db
+	const databasePath = path.join(providerDir, `${id}.db`);
+	await mkdir(providerDir, { recursive: true });
 
-	// Create database connection with schema for proper type inference
-	// WAL mode is enabled for better concurrent access
-	// Using lazy connection - Database will auto-connect on first query
+	// WAL mode for better concurrent access
 	const client = new Database(databasePath);
 	client.exec('PRAGMA journal_mode = WAL');
 	const sqliteDb = drizzle({ client, schema: drizzleTables });
 
-	// Create error logger for this provider
-	// Structure: .epicenter/{workspaceId}/{providerId}.log
-	const workspaceConfigDir = path.join(epicenterDir, id);
-	const logPath = path.join(workspaceConfigDir, `${providerId}.log`);
+	// Logs: .epicenter/providers/sqlite/logs/{workspaceId}.log
+	const logsDir = path.join(providerDir, 'logs');
+	await mkdir(logsDir, { recursive: true });
+	const logPath = path.join(logsDir, `${id}.log`);
 	const logger = createIndexLogger({ logPath });
 
 	// Prevents infinite loop during pushFromSqlite: when we insert into YJS,

--- a/packages/epicenter/src/providers/persistence/desktop.ts
+++ b/packages/epicenter/src/providers/persistence/desktop.ts
@@ -5,19 +5,19 @@ import type { Provider } from '../../core/provider';
 
 /**
  * YJS document persistence provider using the filesystem.
- * Stores the YDoc as a binary file in the `.epicenter` directory.
+ * Stores the YDoc as a binary file in the provider's directory.
  *
  * **Platform**: Node.js/Desktop (Tauri, Electron, Bun)
  *
  * **How it works**:
- * 1. Creates `.epicenter` directory if it doesn't exist
- * 2. Loads existing state from `.epicenter/${workspaceId}.yjs` on startup
+ * 1. Creates provider directory if it doesn't exist
+ * 2. Loads existing state from `.epicenter/providers/persistence/${workspaceId}.yjs` on startup
  * 3. Auto-saves to disk on every YJS update (synchronous to ensure data is persisted before process exits)
  *
- * **Storage location**: `.epicenter/${workspaceId}.yjs` relative to storageDir from epicenter config
+ * **Storage location**: `.epicenter/providers/persistence/${workspaceId}.yjs`
  * - Each workspace gets its own file named after its ID
  * - Binary format (not human-readable)
- * - Should be gitignored (add `.epicenter/` to `.gitignore`)
+ * - Should be gitignored (add `.epicenter/providers/` to `.gitignore`)
  *
  * @example Basic usage
  * ```typescript
@@ -28,46 +28,22 @@ import type { Provider } from '../../core/provider';
  *   id: 'blog',
  *   tables: { ... },
  *   providers: {
- *     persistence: setupPersistence,  // Auto-saves to {storageDir}/.epicenter/blog.yjs
- *   },
- *   exports: ({ tables }) => ({ ... }),
- * });
- * ```
- *
- * @example Multi-workspace setup
- * ```typescript
- * // All workspaces persist to .epicenter/ directory
- * const pages = defineWorkspace({
- *   id: 'pages',
- *   tables: { ... },
- *   providers: {
- *     persistence: setupPersistence,  // → {storageDir}/.epicenter/pages.yjs
- *   },
- *   exports: ({ tables }) => ({ ... }),
- * });
- *
- * const blog = defineWorkspace({
- *   id: 'blog',
- *   tables: { ... },
- *   providers: {
- *     persistence: setupPersistence,  // → {storageDir}/.epicenter/blog.yjs
+ *     persistence: setupPersistence,  // → .epicenter/providers/persistence/blog.yjs
  *   },
  *   exports: ({ tables }) => ({ ... }),
  * });
  * ```
  */
-export const setupPersistence = (async ({ id, ydoc, epicenterDir }) => {
-	// Require Node.js environment with filesystem access
-	if (!epicenterDir) {
+export const setupPersistence = (async ({ id, ydoc, providerDir }) => {
+	if (!providerDir) {
 		throw new Error(
 			'Persistence provider requires Node.js environment with filesystem access',
 		);
 	}
 
-	const filePath = path.join(epicenterDir, `${id}.yjs`);
+	const filePath = path.join(providerDir, `${id}.yjs`);
 
-	// Ensure .epicenter directory exists
-	mkdirSync(epicenterDir, { recursive: true });
+	mkdirSync(providerDir, { recursive: true });
 
 	// Try to load existing state from disk using Bun.file
 	// No need to check existence first - just try to read and handle failure

--- a/packages/epicenter/src/providers/persistence/desktop.ts
+++ b/packages/epicenter/src/providers/persistence/desktop.ts
@@ -34,16 +34,16 @@ import type { Provider } from '../../core/provider';
  * });
  * ```
  */
-export const setupPersistence = (async ({ id, ydoc, providerDir }) => {
-	if (!providerDir) {
+export const setupPersistence = (async ({ id, ydoc, paths }) => {
+	if (!paths) {
 		throw new Error(
 			'Persistence provider requires Node.js environment with filesystem access',
 		);
 	}
 
-	const filePath = path.join(providerDir, `${id}.yjs`);
+	const filePath = path.join(paths.provider, `${id}.yjs`);
 
-	mkdirSync(providerDir, { recursive: true });
+	mkdirSync(paths.provider, { recursive: true });
 
 	// Try to load existing state from disk using Bun.file
 	// No need to check existence first - just try to read and handle failure


### PR DESCRIPTION
## Why This Change

The previous API had flat, ambiguous path parameters that didn't make their purpose clear:

```typescript
// Before: What's the difference between these?
({ storageDir, epicenterDir, providerDir }) => { ... }
```

Providers need to distinguish between:
1. **User content paths** (version-controlled, user-editable markdown files)
2. **Internal artifact paths** (gitignored, provider-specific databases/logs)

The flat parameter list made this distinction invisible, leading to confusion about which path to use when.

## Solution: Structured `paths` Namespace

```typescript
// After: Intent is self-documenting
({ paths }) => {
  const content = path.resolve(paths.project, './vault');   // User content
  const db = path.join(paths.provider, 'blog.db');          // Internal artifacts
}
```

The namespace structure makes the semantic difference immediately clear:
- `paths.project` → User content (version-controlled)
- `paths.provider` → Provider artifacts (gitignored)
- `paths.epicenter` → .epicenter root (rarely needed)

## Additional Changes

**Terminology**: Renamed `storageDir` → `projectDir` throughout. "Storage" was misleading since this directory contains user content that should be committed to git, not just storage artifacts.

**Provider Isolation**: Each provider now gets its own directory at `.epicenter/providers/{providerId}/` instead of sharing the flat `.epicenter/` root. This improves organization and makes selective gitignore easier.

## Storage Structure

```
myproject/                    ← paths.project (ProjectDir)
├── epicenter.config.ts
├── vault/                    ← User markdown content (version-controlled)
│   └── posts/
│       └── hello-world.md
└── .epicenter/               ← paths.epicenter (EpicenterDir)
    └── providers/
        ├── persistence/      ← paths.provider for persistence provider
        │   └── blog.yjs
        ├── sqlite/           ← paths.provider for sqlite provider
        │   └── blog.db
        └── markdown/         ← paths.provider for markdown provider
            └── diagnostics.json
```