### PR TITLE
docs(agents): add git worktree handling rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,25 @@ Load these domain-specific guidelines only when working in their respective doma
 - Technical writing, README guidelines, punctuation: @rules/documentation.md
 - LinkedIn, Reddit, Twitter post guidelines: @rules/social-media.md
 
+## Git Worktree Handling
+
+CRITICAL: When working in a git worktree (such as `.conductor/` directories), ALL file operations and git commands MUST be performed within that worktree, not the parent repository.
+
+**Detection**: If the working directory contains `.conductor/` in the path, you are in a worktree.
+
+**Rules**:
+
+- Use the working directory path for ALL file reads, writes, and edits
+- Create branches and commits within the worktree's git context
+- Never `cd` to the parent repo or use parent repo paths for edits
+- The worktree has its own branch; changes in parent repo are separate
+
+**Example**:
+
+- Working directory: `/Users/foo/Code/repo/.conductor/riyadh`
+- Correct file path: `/Users/foo/Code/repo/.conductor/riyadh/apps/app/file.ts`
+- WRONG file path: `/Users/foo/Code/repo/apps/app/file.ts`
+
 ## General Guidelines
 
 Read the following file immediately as it's relevant to all workflows: @rules/general-guidelines.md.


### PR DESCRIPTION
## Summary

- Add explicit rules to AGENTS.md for handling git worktrees (`.conductor/` directories) to prevent AI assistants from accidentally modifying files in the wrong repository context

## Context

When working in a git worktree, all file operations and git commands must be performed within that worktree's directory structure, not the parent repository. This rule prevents changes from being applied to the wrong branch or repository.