### PR TITLE
fix(ci): restore Vulkan SDK installation for whisper-cpp builds

### DIFF
--- a/.github/workflows/pr-preview-builds.yml
+++ b/.github/workflows/pr-preview-builds.yml
@@ -74,10 +74,28 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxdo-dev libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev
 
+      # Linux Vulkan SDK installation (required for whisper-cpp GPU acceleration)
+      - name: Install Vulkan SDK (Ubuntu)
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.290-jammy.list https://packages.lunarg.com/vulkan/1.3.290/lunarg-vulkan-1.3.290-jammy.list
+          sudo apt update
+          sudo apt install -y vulkan-sdk mesa-vulkan-drivers
+
       - name: setup bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: "package.json"
+
+      # Windows Vulkan SDK installation (required for whisper-cpp GPU acceleration)
+      - name: Install Vulkan SDK (Windows)
+        if: matrix.platform == 'windows-latest'
+        uses: jakoch/install-vulkan-sdk-action@v1.0.5
+        with:
+          vulkan_version: 1.4.309.0
+          install_runtime: true
+          cache: true
 
       - name: setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/publish-tauri-releases.yml
+++ b/.github/workflows/publish-tauri-releases.yml
@@ -100,11 +100,31 @@ jobs:
           # - libxrandr-dev: X11 RandR extension for display configuration
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxdo-dev libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev
 
+      # Linux Vulkan SDK installation (required for whisper-cpp GPU acceleration)
+      - name: Install Vulkan SDK (Ubuntu)
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          # Add official Vulkan SDK repository
+          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
+          # Note: Using "jammy" for Ubuntu 22.04
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.290-jammy.list https://packages.lunarg.com/vulkan/1.3.290/lunarg-vulkan-1.3.290-jammy.list
+          sudo apt update
+          sudo apt install -y vulkan-sdk mesa-vulkan-drivers
+
       # Setup Bun package manager
       - name: setup bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: "package.json"
+
+      # Windows Vulkan SDK installation (required for whisper-cpp GPU acceleration)
+      - name: Install Vulkan SDK (Windows)
+        if: matrix.platform == 'windows-latest'
+        uses: jakoch/install-vulkan-sdk-action@v1.0.5
+        with:
+          vulkan_version: 1.4.309.0
+          install_runtime: true
+          cache: true
 
       # Setup Node.js for compatibility
       - name: setup node


### PR DESCRIPTION
The v7.11.0 release build is failing on Ubuntu and Windows because Vulkan SDK is missing.

When PR #1176 re-enabled whisper-cpp by adding the `"whisper"` feature back to transcribe-rs, it didn't restore the Vulkan SDK installation that was removed in commit 747dc63d8. The transcribe-rs library hardcodes Vulkan as the GPU backend for Linux and Windows (Metal is used on macOS).

This restores Vulkan SDK installation to both CI workflows:

**Linux (Ubuntu 22.04):**
- Adds LunarG Vulkan SDK repository
- Installs vulkan-sdk and mesa-vulkan-drivers

**Windows:**
- Uses jakoch/install-vulkan-sdk-action@v1.0.5
- Installs Vulkan 1.4.309.0 with runtime support

After merging, the v7.11.0 release build should succeed.