### PR TITLE
fix(ci): restore original Windows Vulkan action and remove unused whisper feature flags

### DIFF
--- a/.github/workflows/pr-preview-builds.yml
+++ b/.github/workflows/pr-preview-builds.yml
@@ -91,10 +91,9 @@ jobs:
       # Windows Vulkan SDK installation (required for whisper-cpp GPU acceleration)
       - name: Install Vulkan SDK (Windows)
         if: matrix.platform == 'windows-latest'
-        uses: jakoch/install-vulkan-sdk-action@v1.0.5
+        uses: humbletim/install-vulkan-sdk@v1.2
         with:
-          vulkan_version: 1.4.309.0
-          install_runtime: true
+          version: 1.4.309.0
           cache: true
 
       - name: setup node

--- a/.github/workflows/publish-tauri-releases.yml
+++ b/.github/workflows/publish-tauri-releases.yml
@@ -120,10 +120,9 @@ jobs:
       # Windows Vulkan SDK installation (required for whisper-cpp GPU acceleration)
       - name: Install Vulkan SDK (Windows)
         if: matrix.platform == 'windows-latest'
-        uses: jakoch/install-vulkan-sdk-action@v1.0.5
+        uses: humbletim/install-vulkan-sdk@v1.2
         with:
-          vulkan_version: 1.4.309.0
-          install_runtime: true
+          version: 1.4.309.0
           cache: true
 
       # Setup Node.js for compatibility

--- a/apps/whispering/src-tauri/src/transcription/mod.rs
+++ b/apps/whispering/src-tauri/src/transcription/mod.rs
@@ -15,7 +15,6 @@ use transcribe_rs::{
     },
     TranscriptionEngine,
 };
-#[cfg(feature = "whisper")]
 use transcribe_rs::engines::whisper::WhisperInferenceParams;
 
 #[cfg(target_os = "windows")]
@@ -487,7 +486,6 @@ fn extract_samples_from_wav(wav_data: Vec<u8>) -> Result<Vec<f32>, Transcription
     Ok(samples)
 }
 
-#[cfg(feature = "whisper")]
 #[tauri::command]
 pub async fn transcribe_audio_whisper(
     audio_data: Vec<u8>,
@@ -580,20 +578,6 @@ pub async fn transcribe_audio_whisper(
         transcript.len()
     );
     Ok(transcript)
-}
-
-#[cfg(not(feature = "whisper"))]
-#[tauri::command]
-pub async fn transcribe_audio_whisper(
-    _audio_data: Vec<u8>,
-    _model_path: String,
-    _language: Option<String>,
-    _initial_prompt: Option<String>,
-    _model_manager: tauri::State<'_, ModelManager>,
-) -> Result<String, TranscriptionError> {
-    Err(TranscriptionError::TranscriptionError {
-        message: "Whisper C++ is temporarily unavailable due to upstream build issues. Please use Moonshine or Parakeet for local transcription, or a cloud provider.".to_string(),
-    })
 }
 
 #[tauri::command]

--- a/apps/whispering/src-tauri/src/transcription/model_manager.rs
+++ b/apps/whispering/src-tauri/src/transcription/model_manager.rs
@@ -4,14 +4,12 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 use transcribe_rs::engines::moonshine::{MoonshineEngine, MoonshineModelParams};
 use transcribe_rs::engines::parakeet::{ParakeetEngine, ParakeetModelParams};
-#[cfg(feature = "whisper")]
 use transcribe_rs::engines::whisper::WhisperEngine;
 use transcribe_rs::TranscriptionEngine;
 
 /// Engine type for managing different transcription engines
 pub enum Engine {
     Parakeet(ParakeetEngine),
-    #[cfg(feature = "whisper")]
     Whisper(WhisperEngine),
     Moonshine(MoonshineEngine),
 }
@@ -20,7 +18,6 @@ impl Engine {
     fn unload(&mut self) {
         match self {
             Engine::Parakeet(e) => e.unload_model(),
-            #[cfg(feature = "whisper")]
             Engine::Whisper(e) => e.unload_model(),
             Engine::Moonshine(e) => e.unload_model(),
         }
@@ -71,7 +68,6 @@ impl ModelManager {
                 }
                 true
             }
-            #[cfg(feature = "whisper")]
             (Some(Engine::Whisper(_)), _) => {
                 // Wrong engine type, unload and reload
                 if let Some(mut engine) = engine_guard.take() {
@@ -102,7 +98,6 @@ impl ModelManager {
         Ok(self.engine.clone())
     }
 
-    #[cfg(feature = "whisper")]
     pub fn get_or_load_whisper(
         &self,
         model_path: PathBuf,
@@ -160,14 +155,6 @@ impl ModelManager {
         Ok(self.engine.clone())
     }
 
-    #[cfg(not(feature = "whisper"))]
-    pub fn get_or_load_whisper(
-        &self,
-        _model_path: PathBuf,
-    ) -> Result<Arc<Mutex<Option<Engine>>>, String> {
-        Err("Whisper C++ is temporarily unavailable due to upstream build issues. Use Moonshine or Parakeet instead.".to_string())
-    }
-
     pub fn get_or_load_moonshine(
         &self,
         model_path: PathBuf,
@@ -196,7 +183,6 @@ impl ModelManager {
                 }
                 true
             }
-            #[cfg(feature = "whisper")]
             (Some(Engine::Whisper(_)), _) => {
                 // Wrong engine type, unload and reload
                 if let Some(mut engine) = engine_guard.take() {


### PR DESCRIPTION
This fixes two issues preventing whisper-cpp from working in the v7.11.0 release:

**Windows Vulkan Action**: PR #1177 accidentally changed the Windows Vulkan SDK action from `humbletim/install-vulkan-sdk@v1.2` to `jakoch/install-vulkan-sdk-action@v1.0.5`. This restores the original action that matches the project's historical configuration.

**Rust Feature Flag Bug**: The codebase had `#[cfg(feature = "whisper")]` guards around whisper-cpp code, but these were checking for a feature on the `whispering` crate (which doesn't exist). The `whisper` feature only exists on the `transcribe-rs` dependency. Since `transcribe-rs` is compiled with `features = ["whisper", "parakeet", "moonshine"]`, whisper-cpp is available and these guards were incorrectly disabling all whisper code at compile time. This removes all the guards so whisper-cpp functionality is actually included in the build.