### PR TITLE
fix(windows): disable whisper-cpp and remove Vulkan SDK

### DIFF
--- a/.github/workflows/pr-preview-builds.yml
+++ b/.github/workflows/pr-preview-builds.yml
@@ -74,7 +74,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxdo-dev libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev
 
-      # Linux Vulkan SDK installation (required for whisper-cpp GPU acceleration)
+      # Linux Vulkan SDK installation (required for whisper-cpp GPU acceleration on Linux)
+      # Note: Windows whisper-cpp is disabled due to MSVC runtime conflicts, so no Vulkan needed there
       - name: Install Vulkan SDK (Ubuntu)
         if: matrix.platform == 'ubuntu-22.04'
         run: |
@@ -87,14 +88,6 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: "package.json"
-
-      # Windows Vulkan SDK installation (required for whisper-cpp GPU acceleration)
-      - name: Install Vulkan SDK (Windows)
-        if: matrix.platform == 'windows-latest'
-        uses: humbletim/install-vulkan-sdk@v1.2
-        with:
-          version: 1.4.309.0
-          cache: true
 
       - name: setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/publish-tauri-releases.yml
+++ b/.github/workflows/publish-tauri-releases.yml
@@ -100,7 +100,8 @@ jobs:
           # - libxrandr-dev: X11 RandR extension for display configuration
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxdo-dev libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev
 
-      # Linux Vulkan SDK installation (required for whisper-cpp GPU acceleration)
+      # Linux Vulkan SDK installation (required for whisper-cpp GPU acceleration on Linux)
+      # Note: Windows whisper-cpp is disabled due to MSVC runtime conflicts, so no Vulkan needed there
       - name: Install Vulkan SDK (Ubuntu)
         if: matrix.platform == 'ubuntu-22.04'
         run: |
@@ -116,14 +117,6 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: "package.json"
-
-      # Windows Vulkan SDK installation (required for whisper-cpp GPU acceleration)
-      - name: Install Vulkan SDK (Windows)
-        if: matrix.platform == 'windows-latest'
-        uses: humbletim/install-vulkan-sdk@v1.2
-        with:
-          version: 1.4.309.0
-          cache: true
 
       # Setup Node.js for compatibility
       - name: setup node

--- a/apps/whispering/src/lib/components/settings/TranscriptionServiceSelect.svelte
+++ b/apps/whispering/src/lib/components/settings/TranscriptionServiceSelect.svelte
@@ -5,7 +5,7 @@
 	import { cn } from '@epicenter/ui/utils';
 	import type { Snippet } from 'svelte';
 	import {
-		AVAILABLE_TRANSCRIPTION_SERVICES,
+		TRANSCRIPTION_SERVICES,
 		type TranscriptionService,
 		TRANSCRIPTION_SERVICE_IDS,
 	} from '$lib/services/isomorphic/transcription/registry';
@@ -31,21 +31,19 @@
 	} = $props();
 
 	const selectedService = $derived(
-		AVAILABLE_TRANSCRIPTION_SERVICES.find((service) => service.id === selected),
+		TRANSCRIPTION_SERVICES.find((service) => service.id === selected),
 	);
 
 	const localServices = $derived(
-		AVAILABLE_TRANSCRIPTION_SERVICES.filter((service) => service.location === 'local'),
+		TRANSCRIPTION_SERVICES.filter((service) => service.location === 'local'),
 	);
 
 	const cloudServices = $derived(
-		AVAILABLE_TRANSCRIPTION_SERVICES.filter((service) => service.location === 'cloud'),
+		TRANSCRIPTION_SERVICES.filter((service) => service.location === 'cloud'),
 	);
 
 	const selfHostedServices = $derived(
-		AVAILABLE_TRANSCRIPTION_SERVICES.filter(
-			(service) => service.location === 'self-hosted',
-		),
+		TRANSCRIPTION_SERVICES.filter((service) => service.location === 'self-hosted'),
 	);
 
 	// Create items array with group information

--- a/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
@@ -6,7 +6,7 @@
 	import * as Popover from '@epicenter/ui/popover';
 	import { useCombobox } from '@epicenter/ui/hooks';
 	import {
-		AVAILABLE_TRANSCRIPTION_SERVICES,
+		TRANSCRIPTION_SERVICES,
 		type TranscriptionService,
 	} from '$lib/services/isomorphic/transcription/registry';
 	import {
@@ -37,17 +37,15 @@
 	}
 
 	const cloudServices = $derived(
-		AVAILABLE_TRANSCRIPTION_SERVICES.filter((service) => service.location === 'cloud'),
+		TRANSCRIPTION_SERVICES.filter((service) => service.location === 'cloud'),
 	);
 
 	const selfHostedServices = $derived(
-		AVAILABLE_TRANSCRIPTION_SERVICES.filter(
-			(service) => service.location === 'self-hosted',
-		),
+		TRANSCRIPTION_SERVICES.filter((service) => service.location === 'self-hosted'),
 	);
 
 	const localServices = $derived(
-		AVAILABLE_TRANSCRIPTION_SERVICES.filter((service) => service.location === 'local'),
+		TRANSCRIPTION_SERVICES.filter((service) => service.location === 'local'),
 	);
 
 	const combobox = useCombobox();

--- a/apps/whispering/src/lib/services/isomorphic/transcription/registry.ts
+++ b/apps/whispering/src/lib/services/isomorphic/transcription/registry.ts
@@ -2,7 +2,6 @@
  * Transcription service configurations
  */
 
-import { IS_WINDOWS } from '$lib/constants/platform';
 import deepgramIcon from '$lib/constants/icons/deepgram.svg?raw';
 import elevenlabsIcon from '$lib/constants/icons/elevenlabs.svg?raw';
 import ggmlIcon from '$lib/constants/icons/ggml.svg?raw';
@@ -13,6 +12,7 @@ import moonshineIcon from '$lib/constants/icons/moonshine.svg?raw';
 import nvidiaIcon from '$lib/constants/icons/nvidia.svg?raw';
 import openaiIcon from '$lib/constants/icons/openai.svg?raw';
 import speachesIcon from '$lib/constants/icons/speaches.svg?raw';
+import { IS_WINDOWS } from '$lib/constants/platform';
 import type { Settings } from '$lib/settings';
 import {
 	DEEPGRAM_TRANSCRIPTION_MODELS,
@@ -84,15 +84,20 @@ type SatisfiedTranscriptionService =
 
 export const TRANSCRIPTION_SERVICES = [
 	// Local services first (truly offline)
-	{
-		id: 'whispercpp',
-		name: 'Whisper C++',
-		icon: ggmlIcon,
-		invertInDarkMode: true,
-		description: 'Fast local transcription with no internet required',
-		modelPathField: 'transcription.whispercpp.modelPath',
-		location: 'local',
-	},
+	// Whisper C++ is not available on Windows due to upstream whisper-rs limitations and MSVC runtime library conflicts
+	...(IS_WINDOWS
+		? []
+		: [
+				{
+					id: 'whispercpp',
+					name: 'Whisper C++',
+					icon: ggmlIcon,
+					invertInDarkMode: true,
+					description: 'Fast local transcription with no internet required',
+					modelPathField: 'transcription.whispercpp.modelPath',
+					location: 'local',
+				} as const,
+			]),
 	{
 		id: 'parakeet',
 		name: 'Parakeet',
@@ -107,7 +112,7 @@ export const TRANSCRIPTION_SERVICES = [
 		name: 'Moonshine',
 		icon: moonshineIcon,
 		invertInDarkMode: false,
-		description: 'Efficient ONNX model by UsefulSensors (~30 MB)',
+		description: 'Efficient ONNX model by UsefulSensors',
 		modelPathField: 'transcription.moonshine.modelPath',
 		location: 'local',
 	},
@@ -191,15 +196,7 @@ export const TRANSCRIPTION_SERVICES = [
 	// },
 ] as const satisfies SatisfiedTranscriptionService[];
 
-/**
- * Services available on the current platform.
- * Whisper C++ is not available on Windows due to build compatibility issues.
- */
-export const AVAILABLE_TRANSCRIPTION_SERVICES = IS_WINDOWS
-	? TRANSCRIPTION_SERVICES.filter((s) => s.id !== 'whispercpp')
-	: TRANSCRIPTION_SERVICES;
-
-export const TRANSCRIPTION_SERVICE_OPTIONS = AVAILABLE_TRANSCRIPTION_SERVICES.map(
+export const TRANSCRIPTION_SERVICE_OPTIONS = TRANSCRIPTION_SERVICES.map(
 	(service) => ({
 		label: service.name,
 		value: service.id,

--- a/apps/whispering/src/lib/settings/transcription-validation.ts
+++ b/apps/whispering/src/lib/settings/transcription-validation.ts
@@ -1,5 +1,5 @@
 import {
-	AVAILABLE_TRANSCRIPTION_SERVICES,
+	TRANSCRIPTION_SERVICES,
 	type TranscriptionService,
 } from '$lib/services/isomorphic/transcription/registry';
 import { settings } from '$lib/stores/settings.svelte';
@@ -15,7 +15,7 @@ export function getSelectedTranscriptionService():
 	| undefined {
 	const selectedServiceId =
 		settings.value['transcription.selectedTranscriptionService'];
-	return AVAILABLE_TRANSCRIPTION_SERVICES.find((s) => s.id === selectedServiceId);
+	return TRANSCRIPTION_SERVICES.find((s) => s.id === selectedServiceId);
 }
 
 /**


### PR DESCRIPTION
This PR completes the Windows whisper-cpp disabling work started in the previous commit on main. The v7.11.0 Windows build was failing due to MSVC runtime library conflicts between `whisper-rs-sys` (which uses `MD_DynamicRelease`) and `tokenizers/esaxx-rs` (which uses `MT_StaticRelease`). Rather than attempting complex build configuration workarounds, we disable whisper-cpp on Windows entirely since users have Moonshine and Parakeet as alternatives.

The frontend changes here use conditional array spreading (`...(IS_WINDOWS ? [] : [...])`) to include/exclude the whispercpp entry directly in the `TRANSCRIPTION_SERVICES` array definition. This is cleaner than the previous approach of maintaining a separate `AVAILABLE_TRANSCRIPTION_SERVICES` constant and filtering at runtime. All component imports have been updated to use the single `TRANSCRIPTION_SERVICES` constant.

With whisper-cpp disabled on Windows, the Vulkan SDK installation step in CI/CD is no longer needed there. The Windows Vulkan installation has been removed from both `pr-preview-builds.yml` and `publish-tauri-releases.yml`. Linux still requires Vulkan for whisper-cpp GPU acceleration and is unchanged.

## Verification

**Manual testing needed:**
- [ ] Windows build succeeds without whisper-cpp and Vulkan
- [ ] macOS/Linux builds continue to include whisper-cpp
- [ ] UI shows only Parakeet/Moonshine for local transcription on Windows
- [ ] UI shows all three local options on macOS/Linux