### PR TITLE
fix(windows): disable moonshine due to CRT conflicts

### DIFF
--- a/apps/whispering/src-tauri/Cargo.toml
+++ b/apps/whispering/src-tauri/Cargo.toml
@@ -59,9 +59,11 @@ nix = { version = "0.29", features = ["signal"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_System_Console"] }
-# Windows: whisper-cpp disabled due to MSVC runtime library conflicts (MT_StaticRelease vs MD_DynamicRelease)
-# between whisper-rs-sys and tokenizers/esaxx-rs crates
-transcribe-rs = { version = "0.2.1", features = ["parakeet", "moonshine"] }
+# Windows: Only parakeet is available due to MSVC runtime library conflicts (MT_StaticRelease vs MD_DynamicRelease)
+# - whisper-cpp: whisper-rs-sys conflicts with tokenizers/esaxx-rs
+# - moonshine: tokenizers/esaxx-rs (static CRT) conflicts with ort (dynamic CRT)
+# Parakeet works because it uses ort without tokenizers dependency
+transcribe-rs = { version = "0.2.1", features = ["parakeet"] }
 
 [target.'cfg(not(windows))'.dependencies]
 # macOS/Linux: full whisper-cpp support

--- a/apps/whispering/src-tauri/src/transcription/mod.rs
+++ b/apps/whispering/src-tauri/src/transcription/mod.rs
@@ -8,11 +8,10 @@ use std::io::Write;
 #[cfg(target_os = "windows")]
 use std::os::windows::process::CommandExt;
 use std::path::PathBuf;
+#[cfg(not(target_os = "windows"))]
+use transcribe_rs::engines::moonshine::MoonshineModelParams;
 use transcribe_rs::{
-    engines::{
-        moonshine::MoonshineModelParams,
-        parakeet::{ParakeetInferenceParams, TimestampGranularity},
-    },
+    engines::parakeet::{ParakeetInferenceParams, TimestampGranularity},
     TranscriptionEngine,
 };
 #[cfg(not(target_os = "windows"))]
@@ -592,7 +591,7 @@ pub async fn transcribe_audio_whisper(
     _model_manager: tauri::State<'_, ModelManager>,
 ) -> Result<String, TranscriptionError> {
     Err(TranscriptionError::TranscriptionError {
-        message: "Whisper C++ is not available on Windows due to build compatibility issues. Please use Moonshine or Parakeet for local transcription.".to_string(),
+        message: "Whisper C++ is not available on Windows due to build compatibility issues. Please use Parakeet for local transcription.".to_string(),
     })
 }
 
@@ -681,6 +680,7 @@ pub async fn transcribe_audio_parakeet(
     Ok(transcript)
 }
 
+#[cfg(not(target_os = "windows"))]
 #[tauri::command]
 pub async fn transcribe_audio_moonshine(
     audio_data: Vec<u8>,
@@ -790,4 +790,16 @@ pub async fn transcribe_audio_moonshine(
         transcript.len()
     );
     Ok(transcript)
+}
+
+#[cfg(target_os = "windows")]
+#[tauri::command]
+pub async fn transcribe_audio_moonshine(
+    _audio_data: Vec<u8>,
+    _model_path: String,
+    _model_manager: tauri::State<'_, ModelManager>,
+) -> Result<String, TranscriptionError> {
+    Err(TranscriptionError::TranscriptionError {
+        message: "Moonshine is not available on Windows due to build compatibility issues. Please use Parakeet for local transcription.".to_string(),
+    })
 }

--- a/apps/whispering/src-tauri/src/transcription/model_manager.rs
+++ b/apps/whispering/src-tauri/src/transcription/model_manager.rs
@@ -2,6 +2,7 @@ use log::error;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
+#[cfg(not(target_os = "windows"))]
 use transcribe_rs::engines::moonshine::{MoonshineEngine, MoonshineModelParams};
 use transcribe_rs::engines::parakeet::{ParakeetEngine, ParakeetModelParams};
 #[cfg(not(target_os = "windows"))]
@@ -13,6 +14,7 @@ pub enum Engine {
     #[cfg(not(target_os = "windows"))]
     Whisper(WhisperEngine),
     Parakeet(ParakeetEngine),
+    #[cfg(not(target_os = "windows"))]
     Moonshine(MoonshineEngine),
 }
 
@@ -22,6 +24,7 @@ impl Engine {
             Engine::Parakeet(e) => e.unload_model(),
             #[cfg(not(target_os = "windows"))]
             Engine::Whisper(e) => e.unload_model(),
+            #[cfg(not(target_os = "windows"))]
             Engine::Moonshine(e) => e.unload_model(),
         }
     }
@@ -165,9 +168,10 @@ impl ModelManager {
         &self,
         _model_path: PathBuf,
     ) -> Result<Arc<Mutex<Option<Engine>>>, String> {
-        Err("Whisper C++ is not available on Windows due to build compatibility issues. Please use Moonshine or Parakeet for local transcription.".to_string())
+        Err("Whisper C++ is not available on Windows due to build compatibility issues. Please use Parakeet for local transcription.".to_string())
     }
 
+    #[cfg(not(target_os = "windows"))]
     pub fn get_or_load_moonshine(
         &self,
         model_path: PathBuf,
@@ -196,7 +200,6 @@ impl ModelManager {
                 }
                 true
             }
-            #[cfg(not(target_os = "windows"))]
             (Some(Engine::Whisper(_)), _) => {
                 // Wrong engine type, unload and reload
                 if let Some(mut engine) = engine_guard.take() {
@@ -232,6 +235,15 @@ impl ModelManager {
         *last_activity_guard = SystemTime::now();
 
         Ok(self.engine.clone())
+    }
+
+    #[cfg(target_os = "windows")]
+    pub fn get_or_load_moonshine(
+        &self,
+        _model_path: PathBuf,
+        _variant: &str,
+    ) -> Result<Arc<Mutex<Option<Engine>>>, String> {
+        Err("Moonshine is not available on Windows due to build compatibility issues. Please use Parakeet for local transcription.".to_string())
     }
 
     pub fn unload_if_idle(&self) {

--- a/apps/whispering/src/lib/services/isomorphic/transcription/registry.ts
+++ b/apps/whispering/src/lib/services/isomorphic/transcription/registry.ts
@@ -107,15 +107,21 @@ export const TRANSCRIPTION_SERVICES = [
 		modelPathField: 'transcription.parakeet.modelPath',
 		location: 'local',
 	},
-	{
-		id: 'moonshine',
-		name: 'Moonshine',
-		icon: moonshineIcon,
-		invertInDarkMode: false,
-		description: 'Efficient ONNX model by UsefulSensors',
-		modelPathField: 'transcription.moonshine.modelPath',
-		location: 'local',
-	},
+	// Moonshine is not available on Windows due to MSVC runtime library conflicts
+	// between tokenizers/esaxx-rs (static CRT) and ort (dynamic CRT)
+	...(IS_WINDOWS
+		? []
+		: [
+				{
+					id: 'moonshine',
+					name: 'Moonshine',
+					icon: moonshineIcon,
+					invertInDarkMode: false,
+					description: 'Efficient ONNX model by UsefulSensors',
+					modelPathField: 'transcription.moonshine.modelPath',
+					location: 'local',
+				} as const,
+			]),
 	// Cloud services (API-based)
 	{
 		id: 'Groq',


### PR DESCRIPTION
Moonshine also has MSVC runtime library conflicts on Windows. The `tokenizers` crate (via `esaxx-rs`) uses static CRT (`MT_StaticRelease`) while `ort` (ONNX Runtime) uses dynamic CRT (`MD_DynamicRelease`). These cannot coexist in the same binary.

This leaves Parakeet as the only local transcription option on Windows, which works because it uses `ort` without pulling in `tokenizers`.

## Windows local transcription options

| Engine | Status | Reason |
|--------|--------|--------|
| Whisper C++ | Disabled | whisper-rs-sys conflicts with tokenizers/esaxx-rs |
| Moonshine | Disabled | tokenizers/esaxx-rs conflicts with ort |
| Parakeet | **Works** | Uses ort without tokenizers |

Windows users can still use all cloud transcription services (Groq, OpenAI, Deepgram, ElevenLabs, Mistral).

## Temporary limitation

This is not a perfect solution, but a necessary workaround due to fundamental difficulties with cross-compiling these local transcription libraries on Windows. The MSVC runtime conflicts stem from how different Rust crates link against the C runtime, and resolving this would require upstream changes to multiple dependencies.

This approach also resolves the `vulkan-1.dll` errors that Windows users were experiencing (#829, #840), since whisper-cpp (which required Vulkan) is no longer included in Windows builds.

Fixes #829, fixes #840

## Verification

- [x] Windows build succeeds
- [x] Windows app shows only Parakeet for local transcription
- [x] macOS/Linux builds include all three local engines