### PR TITLE
fix(transcription): map non-standard audio extensions for Groq/OpenAI/Mistral

### DIFF
--- a/apps/whispering/src/lib/services/isomorphic/transcription/utils.ts
+++ b/apps/whispering/src/lib/services/isomorphic/transcription/utils.ts
@@ -11,5 +11,12 @@ import mime from 'mime';
  * always have valid MIME types like 'audio/webm' or 'audio/mp4'.
  */
 export function getAudioExtension(mimeType: string): string {
-	return mime.getExtension(mimeType) ?? 'mp3';
+	const extension = mime.getExtension(mimeType) ?? 'mp3';
+	// The `mime` library returns technically correct but non-standard extensions
+	// that transcription APIs don't recognize:
+	// - 'weba' for audio/webm (should be 'webm')
+	// - 'oga' for audio/ogg (should be 'ogg')
+	// Groq/OpenAI/Mistral support: flac, mp3, mp4, mpeg, mpga, m4a, ogg, opus, wav, webm
+	const extensionMapping: Record<string, string> = { weba: 'webm', oga: 'ogg' };
+	return extensionMapping[extension] ?? extension;
 }


### PR DESCRIPTION
## Summary
- Fixed Groq 400 error: `file must be one of the following types: [flac mp3 mp4 mpeg mpga m4a ogg opus wav webm]`
- The `mime` library returns `weba` for `audio/webm` and `oga` for `audio/ogg`, but transcription APIs only accept `webm` and `ogg`
- Added simple extension mapping to convert these non-standard extensions to API-compatible ones

## Test plan
- [ ] Record audio in browser (produces `audio/webm;codecs=opus`)
- [ ] Transcribe with Groq - should work without 400 error