### PR TITLE
feat(epicenter): add KV store for singleton workspace configuration

### DIFF
--- a/packages/epicenter/src/core/kv/core.ts
+++ b/packages/epicenter/src/core/kv/core.ts
@@ -26,13 +26,6 @@ export function createKv<TKvSchema extends KvSchema>(
 				`KV key "${keyName}" is invalid: must start with a lowercase letter and contain only lowercase letters, numbers, and underscores (e.g., "theme", "last_sync", "count2")`,
 			);
 		}
-
-		const columnSchema = schema[keyName];
-		if (columnSchema.type === 'id') {
-			throw new Error(
-				`KV key "${keyName}" uses "id()" column type, which is not allowed in KV schemas. Use text(), integer(), or other value types instead.`,
-			);
-		}
 	}
 
 	const ykvMap = ydoc.getMap<KvValue>('kv') as YKvMap;
@@ -58,7 +51,7 @@ export function createKv<TKvSchema extends KvSchema>(
 					result[keyName] = serializeCellValue(value);
 				} else {
 					const helper = kvHelpers[keyName as keyof typeof kvHelpers];
-					const defaultVal = helper.get.handler(undefined);
+					const defaultVal = helper.get();
 					result[keyName] =
 						defaultVal !== undefined
 							? serializeCellValue(defaultVal as KvValue)

--- a/packages/epicenter/src/core/kv/core.ts
+++ b/packages/epicenter/src/core/kv/core.ts
@@ -1,0 +1,88 @@
+import type * as Y from 'yjs';
+
+import { defineMutation } from '../actions';
+import type { KvSchema, KvValue, SerializedKvValue } from '../schema';
+import { serializeCellValue } from '../schema';
+
+import type { KvHelper, YKvMap } from './kv-helper';
+import { createKvHelpers } from './kv-helper';
+
+const KV_KEY_PATTERN = /^[a-z][a-z0-9_]*$/;
+
+export type { KvHelper } from './kv-helper';
+
+export function createKv<TKvSchema extends KvSchema>(
+	ydoc: Y.Doc,
+	schema: TKvSchema,
+) {
+	for (const keyName of Object.keys(schema)) {
+		if (keyName.startsWith('$')) {
+			throw new Error(
+				`KV key "${keyName}" is invalid: cannot start with "$" (reserved for utilities)`,
+			);
+		}
+		if (!KV_KEY_PATTERN.test(keyName)) {
+			throw new Error(
+				`KV key "${keyName}" is invalid: must start with a lowercase letter and contain only lowercase letters, numbers, and underscores (e.g., "theme", "last_sync", "count2")`,
+			);
+		}
+
+		const columnSchema = schema[keyName];
+		if (columnSchema.type === 'id') {
+			throw new Error(
+				`KV key "${keyName}" uses "id()" column type, which is not allowed in KV schemas. Use text(), integer(), or other value types instead.`,
+			);
+		}
+	}
+
+	const ykvMap = ydoc.getMap<KvValue>('kv') as YKvMap;
+
+	const kvHelpers = createKvHelpers({
+		ydoc,
+		schema,
+		ykvMap,
+	});
+
+	return {
+		...kvHelpers,
+
+		$all() {
+			return Object.values(kvHelpers) as KvHelper<TKvSchema[keyof TKvSchema]>[];
+		},
+
+		$toJSON() {
+			const result: Record<string, unknown> = {};
+			for (const keyName of Object.keys(schema)) {
+				const value = ykvMap.get(keyName);
+				if (value !== undefined) {
+					result[keyName] = serializeCellValue(value);
+				} else {
+					const helper = kvHelpers[keyName as keyof typeof kvHelpers];
+					const defaultVal = helper.get.handler(undefined);
+					result[keyName] =
+						defaultVal !== undefined
+							? serializeCellValue(defaultVal as KvValue)
+							: null;
+				}
+			}
+			return result as {
+				[K in keyof TKvSchema]: SerializedKvValue<TKvSchema[K]>;
+			};
+		},
+
+		clearAll: defineMutation({
+			description: 'Clear all KV values in the workspace',
+			handler: () => {
+				ydoc.transact(() => {
+					for (const keyName of Object.keys(schema)) {
+						ykvMap.delete(keyName);
+					}
+				});
+			},
+		}),
+	};
+}
+
+export type Kv<TKvSchema extends KvSchema> = ReturnType<
+	typeof createKv<TKvSchema>
+>;

--- a/packages/epicenter/src/core/kv/index.ts
+++ b/packages/epicenter/src/core/kv/index.ts
@@ -1,0 +1,2 @@
+export type { Kv, KvHelper } from './core';
+export { createKv } from './core';

--- a/packages/epicenter/src/core/kv/kv-helper.ts
+++ b/packages/epicenter/src/core/kv/kv-helper.ts
@@ -40,7 +40,7 @@ export function createKvHelpers<TKvSchema extends KvSchema>({
 	};
 }
 
-function createKvHelper<TColumnSchema extends KvColumnSchema>({
+export function createKvHelper<TColumnSchema extends KvColumnSchema>({
 	ydoc,
 	keyName,
 	ykvMap,
@@ -50,7 +50,7 @@ function createKvHelper<TColumnSchema extends KvColumnSchema>({
 	keyName: string;
 	ykvMap: YKvMap;
 	schema: TColumnSchema;
-}): KvHelper<TColumnSchema> {
+}) {
 	type TValue = KvValue<TColumnSchema>;
 	type TSerializedValue = SerializedKvValue<TColumnSchema>;
 
@@ -150,7 +150,7 @@ function createKvHelper<TColumnSchema extends KvColumnSchema>({
 			},
 		}),
 
-		observe(callback) {
+		observe(callback: (value: TValue) => void) {
 			const handler = (event: Y.YMapEvent<KvValue>) => {
 				if (event.keysChanged.has(keyName)) {
 					callback(getCurrentValue());
@@ -224,15 +224,6 @@ function createInputSchema(schema: KvColumnSchema) {
 	}
 }
 
-export type KvHelper<TColumnSchema extends KvColumnSchema> = {
-	name: string;
-	schema: TColumnSchema;
-	get: ReturnType<typeof defineQuery<undefined, KvValue<TColumnSchema>>>;
-	set: ReturnType<
-		typeof defineMutation<ReturnType<typeof type<{ value: unknown }>>, void>
-	>;
-	observe: (callback: (value: KvValue<TColumnSchema>) => void) => () => void;
-	reset: ReturnType<typeof defineMutation<undefined, void>>;
-	$inferValue: KvValue<TColumnSchema>;
-	$inferSerializedValue: SerializedKvValue<TColumnSchema>;
-};
+export type KvHelper<TColumnSchema extends KvColumnSchema> = ReturnType<
+	typeof createKvHelper<TColumnSchema>
+>;

--- a/packages/epicenter/src/core/kv/kv-helper.ts
+++ b/packages/epicenter/src/core/kv/kv-helper.ts
@@ -1,0 +1,238 @@
+import { type } from 'arktype';
+import * as Y from 'yjs';
+
+import { defineMutation, defineQuery } from '../actions';
+import type {
+	KvColumnSchema,
+	KvSchema,
+	KvValue,
+	SerializedKvValue,
+} from '../schema';
+import { isDateWithTimezoneString, serializeCellValue } from '../schema';
+import { updateYArrayFromArray, updateYTextFromString } from '../utils/yjs';
+
+export type YKvMap = Y.Map<KvValue>;
+
+/**
+ * Creates a collection of typed KV helpers for all keys in a schema.
+ */
+export function createKvHelpers<TKvSchema extends KvSchema>({
+	ydoc,
+	schema,
+	ykvMap,
+}: {
+	ydoc: Y.Doc;
+	schema: TKvSchema;
+	ykvMap: YKvMap;
+}) {
+	return Object.fromEntries(
+		Object.entries(schema).map(([keyName, columnSchema]) => [
+			keyName,
+			createKvHelper({
+				ydoc,
+				keyName,
+				ykvMap,
+				schema: columnSchema,
+			}),
+		]),
+	) as {
+		[K in keyof TKvSchema]: KvHelper<TKvSchema[K]>;
+	};
+}
+
+function createKvHelper<TColumnSchema extends KvColumnSchema>({
+	ydoc,
+	keyName,
+	ykvMap,
+	schema,
+}: {
+	ydoc: Y.Doc;
+	keyName: string;
+	ykvMap: YKvMap;
+	schema: TColumnSchema;
+}): KvHelper<TColumnSchema> {
+	type TValue = KvValue<TColumnSchema>;
+	type TSerializedValue = SerializedKvValue<TColumnSchema>;
+
+	const getOrCreateYjsValue = (): TValue => {
+		const existing = ykvMap.get(keyName);
+		if (existing !== undefined) {
+			return existing as TValue;
+		}
+
+		if (schema.type === 'ytext') {
+			const ytext = new Y.Text();
+			ykvMap.set(keyName, ytext);
+			return ytext as TValue;
+		}
+
+		if (schema.type === 'multi-select') {
+			const yarray = new Y.Array<string>();
+			ykvMap.set(keyName, yarray);
+			return yarray as TValue;
+		}
+
+		return undefined as unknown as TValue;
+	};
+
+	const getDefaultValue = (): TValue | undefined => {
+		if ('default' in schema && schema.default !== undefined) {
+			const def = schema.default;
+			return (typeof def === 'function' ? def() : def) as TValue;
+		}
+		return undefined;
+	};
+
+	const getCurrentValue = (): TValue => {
+		const value = ykvMap.get(keyName);
+
+		if (value === undefined) {
+			const defaultVal = getDefaultValue();
+			if (defaultVal !== undefined) {
+				return defaultVal;
+			}
+			if (schema.nullable) {
+				return null as TValue;
+			}
+		}
+
+		if (schema.type === 'ytext' || schema.type === 'multi-select') {
+			return getOrCreateYjsValue();
+		}
+
+		return value as TValue;
+	};
+
+	const setValueFromSerialized = (input: TSerializedValue): void => {
+		ydoc.transact(() => {
+			if (input === null) {
+				ykvMap.set(keyName, null);
+				return;
+			}
+
+			if (schema.type === 'ytext' && typeof input === 'string') {
+				const ytext = getOrCreateYjsValue() as Y.Text;
+				updateYTextFromString(ytext, input);
+				return;
+			}
+
+			if (schema.type === 'multi-select' && Array.isArray(input)) {
+				const yarray = getOrCreateYjsValue() as Y.Array<string>;
+				updateYArrayFromArray(yarray, input);
+				return;
+			}
+
+			if (schema.type === 'date' && isDateWithTimezoneString(input)) {
+				ykvMap.set(keyName, input);
+				return;
+			}
+
+			ykvMap.set(keyName, input as KvValue);
+		});
+	};
+
+	const inputSchema = createInputSchema(schema);
+
+	return {
+		name: keyName,
+		schema,
+
+		get: defineQuery({
+			description: `Get ${keyName} value`,
+			handler: () => getCurrentValue(),
+		}),
+
+		set: defineMutation({
+			input: inputSchema,
+			description: `Set ${keyName} value`,
+			handler: (input) => {
+				setValueFromSerialized(input.value as TSerializedValue);
+			},
+		}),
+
+		observe(callback) {
+			const handler = (event: Y.YMapEvent<KvValue>) => {
+				if (event.keysChanged.has(keyName)) {
+					callback(getCurrentValue());
+				}
+			};
+			ykvMap.observe(handler);
+			return () => ykvMap.unobserve(handler);
+		},
+
+		reset: defineMutation({
+			description: `Reset ${keyName} to default`,
+			handler: () => {
+				ydoc.transact(() => {
+					const defaultVal = getDefaultValue();
+					if (defaultVal !== undefined) {
+						setValueFromSerialized(
+							serializeCellValue(defaultVal) as TSerializedValue,
+						);
+					} else if (schema.nullable) {
+						ykvMap.set(keyName, null);
+					} else {
+						ykvMap.delete(keyName);
+					}
+				});
+			},
+		}),
+
+		$inferValue: null as unknown as TValue,
+		$inferSerializedValue: null as unknown as TSerializedValue,
+	};
+}
+
+function createInputSchema(schema: KvColumnSchema) {
+	switch (schema.type) {
+		case 'text':
+			return schema.nullable
+				? type({ value: 'string | null' })
+				: type({ value: 'string' });
+		case 'ytext':
+			return schema.nullable
+				? type({ value: 'string | null' })
+				: type({ value: 'string' });
+		case 'integer':
+			return schema.nullable
+				? type({ value: 'number | null' })
+				: type({ value: 'number' });
+		case 'real':
+			return schema.nullable
+				? type({ value: 'number | null' })
+				: type({ value: 'number' });
+		case 'boolean':
+			return schema.nullable
+				? type({ value: 'boolean | null' })
+				: type({ value: 'boolean' });
+		case 'date':
+			return schema.nullable
+				? type({ value: 'string | null' })
+				: type({ value: 'string' });
+		case 'select':
+			return schema.nullable
+				? type({ value: 'string | null' })
+				: type({ value: 'string' });
+		case 'multi-select':
+			return schema.nullable
+				? type({ value: 'string[] | null' })
+				: type({ value: 'string[]' });
+		case 'json':
+			return type({ value: 'unknown' });
+		default:
+			return type({ value: 'unknown' });
+	}
+}
+
+export type KvHelper<TColumnSchema extends KvColumnSchema> = {
+	name: string;
+	schema: TColumnSchema;
+	get: ReturnType<typeof defineQuery<undefined, KvValue<TColumnSchema>>>;
+	set: ReturnType<
+		typeof defineMutation<ReturnType<typeof type<{ value: unknown }>>, void>
+	>;
+	observe: (callback: (value: KvValue<TColumnSchema>) => void) => () => void;
+	reset: ReturnType<typeof defineMutation<undefined, void>>;
+	$inferValue: KvValue<TColumnSchema>;
+	$inferSerializedValue: SerializedKvValue<TColumnSchema>;
+};

--- a/packages/epicenter/src/core/schema/index.ts
+++ b/packages/epicenter/src/core/schema/index.ts
@@ -73,11 +73,16 @@ export type {
 	IdColumnSchema,
 	IntegerColumnSchema,
 	JsonColumnSchema,
+	// KV schema types
+	KvColumnSchema,
+	KvSchema,
+	KvValue,
 	PartialSerializedRow,
 	RealColumnSchema,
 	Row,
 	SelectColumnSchema,
 	SerializedCellValue,
+	SerializedKvValue,
 	SerializedRow,
 	// Table and workspace schemas
 	TableSchema,

--- a/packages/epicenter/src/core/schema/types.ts
+++ b/packages/epicenter/src/core/schema/types.ts
@@ -380,3 +380,60 @@ export type PartialSerializedRow<
 > = {
 	id: string;
 } & Partial<Omit<SerializedRow<TTableSchema>, 'id'>>;
+
+// ============================================================================
+// KV Schema Types
+// ============================================================================
+
+/**
+ * Column schema types allowed in KV stores.
+ *
+ * KV stores use the same column types as tables, except `id` columns are not
+ * allowed since the key name itself serves as the identifier.
+ */
+export type KvColumnSchema = Exclude<ColumnSchema, IdColumnSchema>;
+
+/**
+ * KV schema - maps key names to their column schemas.
+ *
+ * Unlike tables which require an `id` column, KV schemas map key names directly
+ * to value types. Each key is a singleton value, not a collection of rows.
+ *
+ * @example
+ * ```typescript
+ * const kvSchema = {
+ *   theme: text({ default: 'light' }),
+ *   locale: text({ default: 'en-US' }),
+ *   lastSyncAt: date({ nullable: true }),
+ *   currentDraft: ytext({ nullable: true }),
+ * } satisfies KvSchema;
+ * ```
+ */
+export type KvSchema = Record<string, KvColumnSchema>;
+
+/**
+ * Maps a KvColumnSchema to its value type (Y.js types or primitives).
+ *
+ * This is the same as CellValue but for KV schemas (which exclude id columns).
+ *
+ * @example
+ * ```typescript
+ * type ThemeValue = KvValue<TextColumnSchema<false>>; // string
+ * type DraftValue = KvValue<YtextColumnSchema<true>>; // Y.Text | null
+ * ```
+ */
+export type KvValue<C extends KvColumnSchema = KvColumnSchema> = CellValue<C>;
+
+/**
+ * Maps a KvColumnSchema to its serialized value type.
+ *
+ * This is the same as SerializedCellValue but for KV schemas.
+ *
+ * @example
+ * ```typescript
+ * type ThemeSerialized = SerializedKvValue<TextColumnSchema<false>>; // string
+ * type DraftSerialized = SerializedKvValue<YtextColumnSchema<true>>; // string | null
+ * ```
+ */
+export type SerializedKvValue<C extends KvColumnSchema = KvColumnSchema> =
+	SerializedCellValue<C>;

--- a/packages/epicenter/src/core/workspace/client.browser.ts
+++ b/packages/epicenter/src/core/workspace/client.browser.ts
@@ -8,8 +8,10 @@
  * @see https://github.com/yjs/y-indexeddb
  */
 import * as Y from 'yjs';
+
 import { type Actions, walkActions } from '../actions';
 import { createTables } from '../db/core';
+import { createKv } from '../kv';
 import type { Providers, WorkspaceProviderMap } from '../provider';
 import { createWorkspaceValidators, type WorkspaceSchema } from '../schema';
 import type {
@@ -424,6 +426,11 @@ function initializeWorkspacesSync<
 		// Initialize Epicenter tables (wraps YJS with table/record API)
 		const tables = createTables(ydoc, workspaceConfig.tables);
 
+		// Initialize KV store (if schema defined)
+		const kv = workspaceConfig.kv
+			? createKv(ydoc, workspaceConfig.kv)
+			: createKv(ydoc, {});
+
 		// Create validators for runtime validation and arktype composition
 		const validators = createWorkspaceValidators(workspaceConfig.tables);
 
@@ -474,6 +481,8 @@ function initializeWorkspacesSync<
 		const actions = workspaceConfig.actions({
 			ydoc,
 			tables,
+			// biome-ignore lint/suspicious/noExplicitAny: KV type inference requires explicit cast for empty schema case
+			kv: kv as any,
 			validators,
 			providers,
 			// biome-ignore lint/suspicious/noExplicitAny: Runtime types are correct, generic constraint too strict
@@ -503,6 +512,8 @@ function initializeWorkspacesSync<
 			...actions,
 			$ydoc: ydoc,
 			$tables: tables,
+			// biome-ignore lint/suspicious/noExplicitAny: KV type requires explicit cast for empty schema case
+			$kv: kv as any,
 			$providers: providers,
 			$validators: validators,
 			$workspaces: workspaceClients,

--- a/packages/epicenter/src/core/workspace/client.shared.ts
+++ b/packages/epicenter/src/core/workspace/client.shared.ts
@@ -7,11 +7,13 @@
  */
 
 import type * as Y from 'yjs';
+
 import type { Action, Actions } from '../actions';
 import type { WorkspaceBlobs } from '../blobs';
 import type { Tables } from '../db/core';
+import type { Kv } from '../kv';
 import type { WorkspaceProviderMap } from '../provider';
-import type { WorkspaceSchema, WorkspaceValidators } from '../schema';
+import type { KvSchema, WorkspaceSchema, WorkspaceValidators } from '../schema';
 import type { WorkspacePaths } from './config';
 
 /**
@@ -38,6 +40,7 @@ import type { WorkspacePaths } from './config';
  */
 export type WorkspaceClientInternals<
 	TSchema extends WorkspaceSchema = WorkspaceSchema,
+	TKvSchema extends KvSchema = KvSchema,
 	TProviders extends WorkspaceProviderMap = WorkspaceProviderMap,
 > = {
 	/**
@@ -72,6 +75,26 @@ export type WorkspaceClientInternals<
 	 * ```
 	 */
 	$tables: Tables<TSchema>;
+
+	/**
+	 * KV store for singleton configuration and state values.
+	 *
+	 * Use this for settings, cursors, feature flags, and other singleton values
+	 * that don't fit the table/rows model.
+	 *
+	 * @example
+	 * ```typescript
+	 * // Get and set KV values
+	 * const theme = client.$kv.theme.get();  // → 'light'
+	 * client.$kv.theme.set('dark');
+	 *
+	 * // Observe changes
+	 * client.$kv.theme.observe((value) => {
+	 *   console.log('Theme changed to:', value);
+	 * });
+	 * ```
+	 */
+	$kv: Kv<TKvSchema>;
 
 	/**
 	 * Direct access to workspace providers.

--- a/packages/epicenter/src/index.shared.ts
+++ b/packages/epicenter/src/index.shared.ts
@@ -57,6 +57,9 @@ export type { TableHelper, Tables } from './core/db/core';
 // Database utilities
 export { createTables } from './core/db/core';
 
+export type { Kv, KvHelper } from './core/kv';
+export { createKv } from './core/kv';
+
 export type {
 	DeleteManyResult,
 	DeleteResult,
@@ -93,11 +96,15 @@ export type {
 	IdColumnSchema,
 	IntegerColumnSchema,
 	JsonColumnSchema,
+	KvColumnSchema,
+	KvSchema,
+	KvValue,
 	PartialSerializedRow,
 	RealColumnSchema,
 	Row,
 	SelectColumnSchema,
 	SerializedCellValue,
+	SerializedKvValue,
 	SerializedRow,
 	TableSchema,
 	TableValidators,

--- a/packages/epicenter/src/server/kv.ts
+++ b/packages/epicenter/src/server/kv.ts
@@ -41,7 +41,7 @@ export function createKvPlugin(
 			app.get(
 				keyPath,
 				() => {
-					const value = helper.get.handler(undefined);
+					const value = helper.get();
 					return Ok(value);
 				},
 				{
@@ -53,7 +53,7 @@ export function createKvPlugin(
 				keyPath,
 				({ body }) => {
 					const { value } = body as { value: unknown };
-					helper.set.handler({ value });
+					helper.set({ value });
 					return Ok({ success: true });
 				},
 				{
@@ -64,7 +64,7 @@ export function createKvPlugin(
 			app.delete(
 				keyPath,
 				() => {
-					helper.reset.handler(undefined);
+					helper.reset();
 					return Ok({ success: true });
 				},
 				{

--- a/packages/epicenter/src/server/kv.ts
+++ b/packages/epicenter/src/server/kv.ts
@@ -1,0 +1,78 @@
+import { Elysia } from 'elysia';
+import { Ok } from 'wellcrafted/result';
+import type { Actions } from '../core/actions';
+import type { WorkspaceClient } from '../core/workspace';
+
+/**
+ * Creates an Elysia plugin that exposes KV store endpoints.
+ *
+ * Endpoints:
+ * - GET /workspaces/{workspaceId}/kv - List all KV pairs as JSON
+ * - GET /workspaces/{workspaceId}/kv/{key} - Get single value
+ * - PUT /workspaces/{workspaceId}/kv/{key} - Set value (body: { value: T })
+ * - DELETE /workspaces/{workspaceId}/kv/{key} - Reset to default
+ */
+export function createKvPlugin(
+	workspaceClients: Record<string, WorkspaceClient<Actions>>,
+) {
+	const app = new Elysia();
+
+	for (const [workspaceId, workspaceClient] of Object.entries(
+		workspaceClients,
+	)) {
+		const kv = workspaceClient.$kv;
+		const kvHelpers = kv.$all();
+		const basePath = `/workspaces/${workspaceId}/kv`;
+		const tags = [workspaceId, 'kv'];
+
+		app.get(
+			basePath,
+			() => {
+				return Ok(kv.$toJSON());
+			},
+			{
+				detail: { description: `List all KV pairs for ${workspaceId}`, tags },
+			},
+		);
+
+		for (const helper of kvHelpers) {
+			const keyPath = `${basePath}/${helper.name}` as const;
+
+			app.get(
+				keyPath,
+				() => {
+					const value = helper.get.handler(undefined);
+					return Ok(value);
+				},
+				{
+					detail: { description: `Get ${helper.name} value`, tags },
+				},
+			);
+
+			app.put(
+				keyPath,
+				({ body }) => {
+					const { value } = body as { value: unknown };
+					helper.set.handler({ value });
+					return Ok({ success: true });
+				},
+				{
+					detail: { description: `Set ${helper.name} value`, tags },
+				},
+			);
+
+			app.delete(
+				keyPath,
+				() => {
+					helper.reset.handler(undefined);
+					return Ok({ success: true });
+				},
+				{
+					detail: { description: `Reset ${helper.name} to default`, tags },
+				},
+			);
+		}
+	}
+
+	return app;
+}

--- a/packages/epicenter/src/server/server.ts
+++ b/packages/epicenter/src/server/server.ts
@@ -8,6 +8,7 @@ import type {
 	WorkspaceClient,
 	WorkspacesToClients,
 } from '../core/workspace';
+import { createKvPlugin } from './kv';
 import { createSyncPlugin } from './sync';
 import { createTablesPlugin } from './tables';
 
@@ -33,6 +34,7 @@ export type StartServerOptions = {
  * - `/workspaces/{workspaceId}/sync` - WebSocket sync endpoint (y-websocket protocol)
  * - `/workspaces/{workspaceId}/actions/{action}` - Workspace actions (queries: GET, mutations: POST)
  * - `/workspaces/{workspaceId}/tables/{table}` - RESTful table CRUD
+ * - `/workspaces/{workspaceId}/kv` - KV store (GET all, GET/PUT/DELETE individual keys)
  *
  * @param client - Initialized Epicenter client from createClient()
  * @returns Object with Elysia app and start method
@@ -81,6 +83,11 @@ export function createServer<
 		)
 		.use(
 			createTablesPlugin(
+				client.$workspaces as Record<string, WorkspaceClient<Actions>>,
+			),
+		)
+		.use(
+			createKvPlugin(
 				client.$workspaces as Record<string, WorkspaceClient<Actions>>,
 			),
 		)

--- a/specs/20251230T132500-kv-store-feature.md
+++ b/specs/20251230T132500-kv-store-feature.md
@@ -1,0 +1,641 @@
+# KV Store Feature Specification
+
+**Date**: 2025-12-30
+**Status**: Draft
+**Author**: AI-assisted
+
+## Overview
+
+Add a `kv` (key-value) store capability to Epicenter workspaces alongside the existing `tables` system. The KV store uses the same column type constructors (`text()`, `integer()`, `ytext()`, etc.) but with a simpler one-level-shallower data structure optimized for singleton values rather than collections of rows.
+
+## Motivation
+
+Tables are excellent for collections of records (posts, users, sessions), but many use cases require singleton configuration or state values:
+
+- **Settings**: `theme: 'dark'`, `locale: 'en-US'`
+- **Cursors**: `lastSyncTimestamp`, `currentPageIndex`
+- **Feature flags**: `betaFeaturesEnabled: true`
+- **Session state**: `currentUserId`, `authToken`
+
+Currently, these must be stored as single-row tables, which is awkward:
+
+```typescript
+// Current workaround: awkward single-row table pattern
+tables: {
+  settings: {
+    id: id(),  // Always 'singleton' - wasteful
+    theme: text({ default: 'light' }),
+    locale: text({ default: 'en-US' }),
+  }
+}
+// Usage: tables.settings.get({ id: 'singleton' })
+```
+
+With KV:
+
+```typescript
+// Proposed: clean singleton values
+kv: {
+  theme: text({ default: 'light' }),
+  locale: text({ default: 'en-US' }),
+}
+// Usage: kv.theme.get() → 'light'
+```
+
+## Design Principles
+
+1. **Same column types**: Reuse all existing column constructors from `core/schema/columns.ts`
+2. **One level shallower**: KV is `Y.Map(keyName → value)` vs tables' `Y.Map(tableName → Y.Map(rowId → Y.Map(field → value)))`
+3. **Consistent API pattern**: `$kv` mirrors `$tables` on the workspace client
+4. **Server parity**: REST endpoints follow the same URL hierarchy pattern
+
+## Architecture Comparison
+
+### Tables (Current)
+
+```
+Y.Doc
+└── Y.Map('tables')
+    └── Y.Map('posts')           // Table name
+        └── Y.Map('row-123')     // Row ID
+            ├── id: 'row-123'
+            ├── title: 'Hello'
+            └── content: Y.Text
+```
+
+### KV (Proposed)
+
+```
+Y.Doc
+└── Y.Map('kv')
+    ├── theme: 'dark'           // Key → primitive value
+    ├── locale: 'en-US'         // Key → primitive value
+    └── currentDoc: Y.Text      // Key → Y.js type
+```
+
+## API Design
+
+### Workspace Configuration
+
+```typescript
+import {
+	defineWorkspace,
+	id,
+	text,
+	ytext,
+	integer,
+	boolean,
+	date,
+	json,
+} from '@epicenter/hq';
+
+const appWorkspace = defineWorkspace({
+	id: 'app',
+
+	tables: {
+		posts: {
+			id: id(),
+			title: text(),
+			content: ytext(),
+		},
+	},
+
+	// NEW: KV store configuration
+	kv: {
+		// Same column types as tables, but NO `id` column (keys are the identifiers)
+		theme: text({ default: 'light' }),
+		locale: text({ default: 'en-US' }),
+		lastSyncAt: date({ nullable: true }),
+		betaFeatures: boolean({ default: false }),
+		currentDraft: ytext({ nullable: true }),
+		userPrefs: json({
+			schema: type({ notifications: 'boolean', fontSize: 'number' }),
+			default: { notifications: true, fontSize: 14 },
+		}),
+	},
+
+	providers: {
+		/* ... */
+	},
+
+	actions: ({ tables, kv, providers }) => ({
+		// KV is available in actions context
+		setTheme: defineMutation({
+			input: type({ theme: '"light" | "dark"' }),
+			handler: ({ theme }) => {
+				kv.theme.set(theme);
+			},
+		}),
+
+		getTheme: defineQuery({
+			handler: () => kv.theme.get(),
+		}),
+	}),
+});
+```
+
+### Client API
+
+```typescript
+const client = await createClient(appWorkspace);
+
+// Access KV store via $kv (mirrors $tables pattern)
+client.$kv.theme.get(); // → 'light' (default)
+client.$kv.theme.set('dark'); // Set value
+client.$kv.theme.get(); // → 'dark'
+
+// Nullable values
+client.$kv.lastSyncAt.get(); // → null (not set)
+client.$kv.lastSyncAt.set(
+	DateWithTimezone({ date: new Date(), timezone: 'UTC' }),
+);
+
+// Y.js collaborative types
+const draft = client.$kv.currentDraft.get(); // → Y.Text or null
+if (draft) {
+	draft.insert(0, 'Hello'); // Collaborative editing
+}
+
+// JSON values
+const prefs = client.$kv.userPrefs.get(); // → { notifications: true, fontSize: 14 }
+client.$kv.userPrefs.set({ notifications: false, fontSize: 16 });
+
+// Observe changes (reactive)
+const unsubscribe = client.$kv.theme.observe((value) => {
+	console.log('Theme changed to:', value);
+});
+```
+
+### KV Helper Methods
+
+Each KV key exposes a typed helper with these methods:
+
+| Method              | Description                   | Signature                                    |
+| ------------------- | ----------------------------- | -------------------------------------------- |
+| `get()`             | Get current value             | `() => T \| null` (if nullable) or `() => T` |
+| `set(value)`        | Set value                     | `(value: T) => void`                         |
+| `observe(callback)` | Watch for changes             | `(cb: (value: T) => void) => () => void`     |
+| `reset()`           | Reset to default (if defined) | `() => void`                                 |
+
+### Server Endpoints
+
+Following the existing URL hierarchy pattern:
+
+```
+/workspaces/{workspaceId}/kv                    # List all KV keys and values (GET)
+/workspaces/{workspaceId}/kv/{keyName}          # Single key operations
+  - GET    → Get value
+  - PUT    → Set value
+  - DELETE → Reset to default (or null if no default)
+```
+
+**Examples:**
+
+```bash
+# Get theme value
+GET /workspaces/app/kv/theme
+# Response: { "data": "dark" }
+
+# Set theme value
+PUT /workspaces/app/kv/theme
+Content-Type: application/json
+{ "value": "light" }
+# Response: { "data": "light" }
+
+# List all KV pairs
+GET /workspaces/app/kv
+# Response: { "data": { "theme": "dark", "locale": "en-US", ... } }
+
+# Reset to default
+DELETE /workspaces/app/kv/theme
+# Response: { "data": "light" } (returns the default value)
+```
+
+## Type System
+
+### KV Schema Types
+
+```typescript
+// New type: KV schema is a record of column schemas (no id column)
+export type KvSchema = Record<string, Exclude<ColumnSchema, IdColumnSchema>>;
+
+// KV value type (similar to CellValue but excludes id handling)
+export type KvValue<C extends ColumnSchema> = CellValue<C>;
+
+// Serialized KV value (for transport)
+export type SerializedKvValue<C extends ColumnSchema> = SerializedCellValue<C>;
+```
+
+### WorkspaceConfig Extension
+
+```typescript
+export type WorkspaceConfig<
+	TDeps extends readonly AnyWorkspaceConfig[],
+	TId extends string,
+	TWorkspaceSchema extends WorkspaceSchema,
+	TKvSchema extends KvSchema, // NEW
+	TProviderResults extends WorkspaceProviderMap,
+	TActions extends Actions,
+> = {
+	id: TId;
+	tables: TWorkspaceSchema;
+	kv?: TKvSchema; // NEW: Optional KV config
+	dependencies?: TDeps;
+	providers: {
+		/* ... */
+	};
+	actions: (context: {
+		ydoc: Y.Doc;
+		tables: Tables<TWorkspaceSchema>;
+		kv: Kv<TKvSchema>; // NEW: KV in actions context
+		validators: WorkspaceValidators<TWorkspaceSchema>;
+		workspaces: WorkspacesToActions<TDeps>;
+		providers: TProviderResults;
+		blobs: WorkspaceBlobs<TWorkspaceSchema>;
+		paths: WorkspacePaths | undefined;
+	}) => TActions;
+};
+```
+
+### KV Helper Type
+
+```typescript
+/**
+ * Type-safe KV helper for a single key.
+ */
+export type KvHelper<TColumnSchema extends ColumnSchema> = {
+	/** Get the current value */
+	get: Query<void, KvValue<TColumnSchema>>;
+
+	/** Set the value */
+	set: Mutation<SerializedKvValue<TColumnSchema>, void>;
+
+	/** Observe value changes */
+	observe: (callback: (value: KvValue<TColumnSchema>) => void) => () => void;
+
+	/** Reset to default value (if defined) or null */
+	reset: Mutation<void, void>;
+
+	/** The column schema for this key */
+	schema: TColumnSchema;
+
+	/** The key name */
+	name: string;
+
+	/** Type inference helper */
+	$inferValue: KvValue<TColumnSchema>;
+};
+
+/**
+ * Maps KV schema to KV helpers.
+ */
+export type Kv<TKvSchema extends KvSchema> = {
+	[K in keyof TKvSchema]: KvHelper<TKvSchema[K]>;
+} & {
+	/** Get all KV helpers as an array */
+	$all(): KvHelper<TKvSchema[keyof TKvSchema]>[];
+
+	/** Get all values as a plain object */
+	$toJSON(): { [K in keyof TKvSchema]: SerializedKvValue<TKvSchema[K]> };
+};
+```
+
+## Implementation Plan
+
+### Phase 1: Core KV System
+
+- [ ] **1.1** Add `KvSchema` type to `core/schema/types.ts`
+- [ ] **1.2** Create `core/kv/kv-helper.ts` with `createKvHelper()` function
+- [ ] **1.3** Create `core/kv/core.ts` with `createKv()` function (mirrors `createTables()`)
+- [ ] **1.4** Add `kv` and `Kv` type exports to `core/schema/index.ts`
+
+### Phase 2: Workspace Integration
+
+- [ ] **2.1** Extend `WorkspaceConfig` type to include optional `kv` field
+- [ ] **2.2** Update `defineWorkspace()` to validate KV schema (no `id` column allowed)
+- [ ] **2.3** Update `client.node.ts` `initializeWorkspaces()` to create KV helpers
+- [ ] **2.4** Update `client.browser.ts` `initializeWorkspacesSync()` similarly
+- [ ] **2.5** Add `$kv` to `WorkspaceClientInternals` type
+- [ ] **2.6** Pass `kv` to actions factory context
+
+### Phase 3: Server Endpoints
+
+- [ ] **3.1** Create `server/kv.ts` with `createKvPlugin()` function
+- [ ] **3.2** Implement GET `/workspaces/{id}/kv` (list all)
+- [ ] **3.3** Implement GET `/workspaces/{id}/kv/{key}` (get single)
+- [ ] **3.4** Implement PUT `/workspaces/{id}/kv/{key}` (set value)
+- [ ] **3.5** Implement DELETE `/workspaces/{id}/kv/{key}` (reset)
+- [ ] **3.6** Add KV plugin to main `server.ts`
+
+### Phase 4: Provider Support
+
+- [ ] **4.1** Update SQLite provider to sync KV values (single-row table per workspace)
+- [ ] **4.2** Update Markdown provider to optionally persist KV as frontmatter or separate file
+
+### Phase 5: Documentation & Tests
+
+- [ ] **5.1** Add KV section to `packages/epicenter/README.md`
+- [ ] **5.2** Create `core/kv/kv.test.ts` with unit tests
+- [ ] **5.3** Add KV integration tests to `core/workspace.test.ts`
+- [ ] **5.4** Add server endpoint tests
+
+## File Structure
+
+```
+packages/epicenter/src/
+├── core/
+│   ├── kv/                          # NEW
+│   │   ├── core.ts                  # createKv() function
+│   │   ├── kv-helper.ts             # KvHelper implementation
+│   │   └── index.ts                 # Barrel exports
+│   ├── schema/
+│   │   └── types.ts                 # Add KvSchema type
+│   └── workspace/
+│       ├── config.ts                # Extend WorkspaceConfig
+│       ├── client.node.ts           # Add KV initialization
+│       ├── client.browser.ts        # Add KV initialization
+│       └── client.shared.ts         # Add $kv to internals
+├── server/
+│   ├── kv.ts                        # NEW: createKvPlugin()
+│   └── server.ts                    # Add KV plugin
+└── index.shared.ts                  # Export KV types
+```
+
+## Implementation Details
+
+### YJS Structure for KV
+
+```typescript
+// In core/kv/core.ts
+export function createKv<TKvSchema extends KvSchema>(
+	ydoc: Y.Doc,
+	schema: TKvSchema,
+) {
+	// Single-level Y.Map for all KV pairs
+	const ykvMap = ydoc.getMap<CellValue>('kv');
+
+	// Create helpers for each key
+	const kvHelpers = Object.fromEntries(
+		Object.entries(schema).map(([keyName, columnSchema]) => [
+			keyName,
+			createKvHelper({
+				ydoc,
+				keyName,
+				ykvMap,
+				schema: columnSchema,
+			}),
+		]),
+	);
+
+	return {
+		...kvHelpers,
+
+		$all() {
+			return Object.values(kvHelpers);
+		},
+
+		$toJSON() {
+			const result: Record<string, unknown> = {};
+			for (const [key, helper] of Object.entries(kvHelpers)) {
+				result[key] = serializeCellValue(helper.get());
+			}
+			return result;
+		},
+	} as Kv<TKvSchema>;
+}
+```
+
+### KV Helper Implementation
+
+```typescript
+// In core/kv/kv-helper.ts
+function createKvHelper<TColumnSchema extends ColumnSchema>({
+	ydoc,
+	keyName,
+	ykvMap,
+	schema,
+}: {
+	ydoc: Y.Doc;
+	keyName: string;
+	ykvMap: Y.Map<CellValue>;
+	schema: TColumnSchema;
+}): KvHelper<TColumnSchema> {
+	// For Y.js types (ytext, tags), create lazily
+	const getOrCreateYjsValue = () => {
+		let value = ykvMap.get(keyName);
+		if (!value && schema.type === 'ytext') {
+			value = new Y.Text();
+			ykvMap.set(keyName, value);
+		}
+		if (!value && schema.type === 'multi-select') {
+			value = new Y.Array();
+			ykvMap.set(keyName, value);
+		}
+		return value;
+	};
+
+	return {
+		name: keyName,
+		schema,
+
+		get: defineQuery({
+			description: `Get ${keyName} value`,
+			handler: () => {
+				const value = ykvMap.get(keyName);
+				if (value === undefined) {
+					// Return default if defined, otherwise null
+					return getDefaultValue(schema) ?? null;
+				}
+				return value as KvValue<TColumnSchema>;
+			},
+		}),
+
+		set: defineMutation({
+			input: createKvInputSchema(schema),
+			description: `Set ${keyName} value`,
+			handler: (input) => {
+				ydoc.transact(() => {
+					if (schema.type === 'ytext') {
+						const ytext = getOrCreateYjsValue() as Y.Text;
+						updateYTextFromString(ytext, input as string);
+					} else if (schema.type === 'multi-select') {
+						const yarray = getOrCreateYjsValue() as Y.Array<string>;
+						updateYArrayFromArray(yarray, input as string[]);
+					} else {
+						ykvMap.set(keyName, input);
+					}
+				});
+			},
+		}),
+
+		observe(callback) {
+			const handler = () => {
+				callback(ykvMap.get(keyName) as KvValue<TColumnSchema>);
+			};
+			ykvMap.observe(handler);
+			return () => ykvMap.unobserve(handler);
+		},
+
+		reset: defineMutation({
+			description: `Reset ${keyName} to default`,
+			handler: () => {
+				ydoc.transact(() => {
+					const defaultValue = getDefaultValue(schema);
+					if (defaultValue !== undefined) {
+						ykvMap.set(keyName, defaultValue);
+					} else {
+						ykvMap.delete(keyName);
+					}
+				});
+			},
+		}),
+
+		$inferValue: null as unknown as KvValue<TColumnSchema>,
+	};
+}
+```
+
+### Server KV Plugin
+
+```typescript
+// In server/kv.ts
+export function createKvPlugin(
+	workspaceClients: Record<string, WorkspaceClient<Actions>>,
+) {
+	const app = new Elysia();
+
+	for (const [workspaceId, workspaceClient] of Object.entries(
+		workspaceClients,
+	)) {
+		const kv = workspaceClient.$kv;
+		if (!kv) continue; // Skip workspaces without KV
+
+		const basePath = `/workspaces/${workspaceId}/kv`;
+		const tags = [workspaceId, 'kv'];
+
+		// List all KV pairs
+		app.get(basePath, () => kv.$toJSON(), {
+			detail: { description: `List all KV pairs for ${workspaceId}`, tags },
+		});
+
+		// Per-key endpoints
+		for (const kvHelper of kv.$all()) {
+			const keyPath = `${basePath}/${kvHelper.name}`;
+
+			// Get value
+			app.get(keyPath, () => kvHelper.get(), {
+				detail: { description: `Get ${kvHelper.name}`, tags },
+			});
+
+			// Set value
+			app.put(
+				keyPath,
+				({ body }) => {
+					kvHelper.set(body.value);
+					return { data: kvHelper.get() };
+				},
+				{
+					body: t.Object({
+						value: kvHelper.schema /* convert to Elysia schema */,
+					}),
+					detail: { description: `Set ${kvHelper.name}`, tags },
+				},
+			);
+
+			// Reset value
+			app.delete(
+				keyPath,
+				() => {
+					kvHelper.reset();
+					return { data: kvHelper.get() };
+				},
+				{
+					detail: { description: `Reset ${kvHelper.name} to default`, tags },
+				},
+			);
+		}
+	}
+
+	return app;
+}
+```
+
+## Validation Rules
+
+1. **No `id` column in KV**: KV keys serve as identifiers; `id()` columns are not allowed
+2. **Reserved key names**: Keys starting with `$` are reserved (consistent with tables)
+3. **Key naming**: Same pattern as table/column names (`/^[a-z][a-z0-9_]*$/`)
+4. **Type validation**: Values are validated against column schemas on set
+
+## Edge Cases
+
+### Default Values
+
+- If a column has a `default`, `get()` returns the default when no value is set
+- `reset()` restores the default value (or deletes if no default)
+
+### Nullable Values
+
+- Nullable columns return `null` when not set and no default exists
+- Non-nullable columns without defaults throw on `get()` if never set (or return schema error)
+
+### Y.js Types (ytext, tags)
+
+- Created lazily on first access or set
+- `get()` returns the Y.js type directly for collaborative editing
+- `set()` uses sync utilities to apply minimal changes
+
+### Sync Behavior
+
+- KV values sync via the same Y.Doc as tables
+- WebSocket sync provider automatically includes KV changes
+- SQLite provider stores KV in a dedicated `_kv` table per workspace
+
+## Open Questions
+
+1. **Should KV support `observe()` at the store level?** (e.g., `$kv.$observe()` for any change)
+2. **Should providers expose KV separately?** (e.g., `providers.sqlite.$kv` vs merged)
+3. **Should KV keys support nested objects natively?** (vs. using `json()` column type)
+
+## Alternatives Considered
+
+### Alternative 1: Single-Row Table Pattern
+
+Keep using tables with a singleton row. Rejected because:
+
+- Requires wasteful `id` column
+- Awkward API (`get({ id: 'singleton' })`)
+- Misleading semantics (it's not really a "table")
+
+### Alternative 2: Separate Y.Doc for KV
+
+Use a dedicated Y.Doc for KV storage. Rejected because:
+
+- Complicates sync (two docs per workspace)
+- Adds provider complexity
+- No clear benefit over shared Y.Doc
+
+### Alternative 3: JSON Blob Storage
+
+Store all KV as a single JSON blob. Rejected because:
+
+- Loses field-level CRDT merging
+- Can't use Y.Text/Y.Array for collaborative editing
+- Coarse-grained change detection
+
+## Success Criteria
+
+- [ ] KV config works in `defineWorkspace()` with full type inference
+- [ ] `$kv` is accessible on workspace client with typed helpers
+- [ ] All column types work in KV (except `id`)
+- [ ] Y.js types (ytext, tags) support collaborative editing
+- [ ] Server endpoints match the URL hierarchy pattern
+- [ ] SQLite provider syncs KV values
+- [ ] Documentation covers all use cases
+
+## References
+
+- `packages/epicenter/src/core/db/core.ts` - Tables implementation to mirror
+- `packages/epicenter/src/core/db/table-helper.ts` - Helper pattern to follow
+- `packages/epicenter/src/server/tables.ts` - Server endpoint pattern
+- `packages/epicenter/src/core/schema/columns.ts` - Column type constructors


### PR DESCRIPTION
> [!NOTE]
> This is a preliminary implementation. The core is there, but it needs more testing and documentation.

## What is the KV Store?

The KV store is a key-value storage layer that sits "one level shallower" than tables. While tables are designed for collections of rows (many items with IDs), the KV store is for singleton values: settings, cursors, feature flags, last-sync timestamps—things where you only ever have one value per key.

## Defining the Schema

```typescript
const workspace = defineWorkspace({
  id: 'my-workspace',
  
  // Tables: collections of rows with IDs
  tables: {
    posts: table({
      title: text(),
      content: text(),
    }),
  },
  
  // KV: singleton values (one level shallower, no IDs)
  kv: {
    theme: text({ default: 'light' }),
    lastSyncCursor: text({ nullable: true }),
    enableBetaFeatures: boolean({ default: false }),
  },
  
  providers: { /* ... */ },
  actions: ({ tables, kv }) => ({ /* ... */ }),
});
```

## Usage in Actions

```typescript
actions: ({ tables, kv }) => ({
  // Tables: work with collections
  getPosts: defineQuery({
    handler: () => tables.posts.all(),
  }),
  
  // KV: work with single values
  getTheme: defineQuery({
    handler: () => kv.theme.get(),
  }),
  setTheme: defineMutation({
    input: type({ value: '"light" | "dark"' }),
    handler: ({ value }) => kv.theme.set({ value }),
  }),
}),
```