### PR TITLE
refactor(schema): integrate Standard Schema compliance with x-component discriminant

### DIFF
--- a/docs/articles/introspection-boundary.md
+++ b/docs/articles/introspection-boundary.md
@@ -1,0 +1,230 @@
+# The Introspection Boundary: Where Functions Kill Discoverability
+
+**TL;DR**: If you need to know what an API can do without actually running it (for CLI help, MCP registration, or OpenAPI generation), don't wrap your definitions in functions. Use static objects for metadata/structure and reserve functions for the execution logic.
+
+---
+
+You're building a new CLI for your application. You want to show a helpful list of available commands when the user runs `--help`.
+
+You reach for your workspace configuration:
+
+```typescript
+const workspace = {
+  id: 'posts',
+  actions: (context) => ({
+    create: { handler: () => context.db.insert(...) },
+    list: { handler: () => context.db.select(...) },
+  })
+};
+```
+
+To list those actions, you realize you have a problem. You can't just look at `workspace.actions`. You have to _call_ it. But calling it requires a `context`. And that `context` needs a database connection, a file system handle, and maybe an API key.
+
+Suddenly, just to show a help message, your CLI needs to connect to the database. If the database is down, your help message fails. If the user hasn't configured their API key yet, your help message fails.
+
+You've just hit the **Introspection Boundary**.
+
+## What is Introspection?
+
+In API design, **introspection** is the ability to examine and enumerate capabilities at runtime (or build-time) without executing the underlying logic.
+
+It’s the difference between a restaurant menu and ordering a "chef's surprise." With a menu, you can see what's available, how much it costs, and if it's vegetarian—all before you commit to eating. With a "chef's surprise," you don't know what you're getting until it's already on your plate (and you've already paid).
+
+In the world of software, we rely on introspection for:
+
+- **CLI Help**: Enumerating commands and their arguments.
+- **IDE Autocomplete**: Showing available methods as you type.
+- **MCP Tool Registration**: Telling an AI assistant what tools are available.
+- **OpenAPI/Swagger**: Generating documentation from your code.
+- **GUI Generation**: Building a dashboard that shows buttons for every available action.
+
+## The Fundamental Tension
+
+When we design APIs in TypeScript, we often reach for functions first. Functions are the ultimate tool for abstraction! They give us:
+
+1. **Dependency Injection**: Pass in what you need (like `context.db`) and keep your logic decoupled from specific implementations.
+2. **Generics**: Create type-safe wrappers that adapt to their input, providing incredible flexibility across different data models.
+3. **Lazy Evaluation**: Postpone expensive computations or side effects until they are absolutely necessary.
+4. **Composability**: Wrap functions in other functions to build complex pipelines of logic.
+
+But functions are **opaque**. From the perspective of your tools—your CLI, your IDE, your documentation generator—a function is a "black box." In the JavaScript runtime, you can't "peek" inside a function to see what keys it _would_ return if you called it with a certain argument. You can't serialize a function to JSON to send it over the wire to a remote AI assistant.
+
+This opacity creates a wall. On one side of the wall is your code, where everything is flexible and dynamic. On the other side is your tooling, which is desperately trying to figure out what your code actually _is_.
+
+**Static objects**, conversely, are **transparent**. You can iterate over their keys using `Object.keys()`, you can inspect their properties at runtime, and you can easily serialize them to JSON (provided they don't contain circular references or functions themselves). They are immediately discoverable by both humans and machines.
+
+The goal of good API design isn't to choose one over the other, but to find the correct boundary: **Structure and metadata should be static; behavior and execution should be dynamic.**
+
+## Type Inference is NOT Introspection
+
+Intermediate TypeScript developers often confuse **type inference** with **introspection**. This is an easy mistake to make because TypeScript is so good at following types through functions.
+
+You might think: _"If I hover over my workspace client in VS Code, I can see all the actions! Doesn't that mean it's introspectable?"_
+
+Not exactly. That is **static analysis** performed by your IDE using your source code. It works while you are writing code in your editor. But **introspection** needs to work when your program is actually running (or when a tool is analyzing your compiled JavaScript).
+
+Imagine you're building a dashboard that needs to show a button for every available action in your workspace.
+
+- **Static Analysis**: Helps you write `client.createPost()` correctly.
+- **Introspection**: Allows your dashboard code to do `workspaces.map(w => w.actions.map(renderButton))`.
+
+If your actions are hidden behind a factory function, your dashboard logic is stuck. It has to boot up the entire system just to find out which buttons to draw. This is where the developer experience starts to degrade.
+
+## Example 1: The "Lazy" Action Pattern
+
+Let's look at a common pattern (inspired by early versions of Epicenter) that kills introspection.
+
+### ❌ The "Function-Wrapped" API
+
+```typescript
+// To list these actions, we MUST call the function
+const blogWorkspace = {
+	actions: (context: Context) => ({
+		createPost: {
+			description: 'Create a new blog post',
+			handler: (input) => context.db.posts.insert(input),
+		},
+	}),
+};
+
+// ❌ Discovery requires full initialization
+const ctx = await initializeDatabaseAndFilesystem();
+const availableActions = Object.keys(blogWorkspace.actions(ctx));
+```
+
+This pattern is a nightmare for tooling. If you want to register these actions as "Tools" for an AI assistant (via the Model Context Protocol), the server has to fully boot up and connect to every dependency just to tell the AI what it _could_ do.
+
+### ✅ The "Static Structure" API
+
+Instead, define the _shape_ of the API as a static object, and keep the _behavior_ inside the handler.
+
+```typescript
+const blogWorkspace = {
+	actions: {
+		createPost: {
+			description: 'Create a new blog post',
+			// The handler receives the context at call-time
+			handler: (context: Context, input: PostInput) => {
+				return context.db.posts.insert(input);
+			},
+		},
+	},
+};
+
+// ✅ Discovery is instant and "free"
+const availableActions = Object.keys(blogWorkspace.actions);
+```
+
+Now, `Object.keys(blogWorkspace.actions)` works immediately. No database connection required.
+
+## Example 2: Standard Schema's `~standard`
+
+The TypeScript ecosystem recently introduced [Standard Schema](https://github.com/standard-schema/standard-schema), a common interface for validation libraries. It was born from a collaboration between the authors of Zod, ArkType, and Valibot, who realized that every library was reinventing the same "validation" wheel.
+
+The challenge they faced was exactly the introspection boundary. How do you allow a library like TanStack Form or Hono to accept _any_ schema (Zod, ArkType, etc.) without making them understand the internals of every single library?
+
+The solution was a perfect implementation of the static-metadata/dynamic-behavior split. Every compatible schema must have a `~standard` property:
+
+```typescript
+const mySchema = {
+	// Static property that tools can check for
+	'~standard': {
+		version: 1, // Static: Metadata
+		vendor: 'zod', // Static: Metadata
+		// Function: The actual work
+		validate: (value) => {
+			// ... complex validation logic ...
+		},
+	},
+};
+```
+
+By making `~standard` a static property on the object, any library can do a simple check: `if ('~standard' in schema)`. They don't have to call a function or initialize a provider. They can instantly discover if the object they've been given is a valid schema and which version of the protocol it follows.
+
+If the authors had chosen a function-based approach—like `schema.getStandardInfo()`—they would have introduced unnecessary friction. Every consumer would have to call that function, handle potential errors, and manage the execution context. By sticking to a static boundary, they made the entire ecosystem more interoperable.
+
+## Example 3: The CLI Help Problem (and the "Boot-Loop" Trap)
+
+Imagine you're building a CLI where the available commands are fetched from a database or a remote API. This sounds like a great way to build a "dynamic" and "pluggable" system.
+
+```typescript
+// ❌ The "Boot-Loop" Trap
+export async function getCommands(db: Database) {
+	const plugins = await db.query('SELECT * FROM registered_plugins');
+	return plugins.map((p) => ({
+		name: p.command_name,
+		description: p.description,
+		run: (args) => executePlugin(p.id, args),
+	}));
+}
+```
+
+The problem with this pattern is what I call the **"Boot-Loop" Trap**. When a user runs `my-cli --help`, they expect an instant response. But because your commands are wrapped in an async function that depends on a database, the CLI must now:
+
+1. Locate the configuration file.
+2. Parse the configuration.
+3. Establish a connection to the database (which might involve network latency or local socket issues).
+4. Execute a SQL query.
+5. _Then finally_ render the help text.
+
+This is a brittle architecture. If the database is offline, or if the user's configuration is slightly wrong, they can't even see the help message that might tell them how to fix it!
+
+### The Better Way: Static Manifests
+
+If you need dynamic commands, don't discover them at the moment of introspection. Discover them during a **sync** or **build** step, and save the result as a static manifest.
+
+```typescript
+// ✅ The Manifest Pattern
+// commands-manifest.json (generated during 'my-cli sync')
+[
+	{ name: 'deploy', description: 'Deploy to production' },
+	{ name: 'test', description: 'Run local tests' },
+];
+
+// Now your --help logic just reads a JSON file.
+// It's fast, offline-compatible, and never crashes.
+```
+
+By separating the **discovery of commands** (dynamic) from the **display of commands** (static), you respect the introspection boundary and create a much more robust user experience.
+
+## The Trade-offs Table
+
+| Approach                               | Introspectable | Flexible | Dependency Injection |  Generics  |
+| :------------------------------------- | :------------: | :------: | :------------------: | :--------: |
+| **Static Object**                      |     ✅ Yes     |  ❌ No   |        ❌ No         |   ❌ No    |
+| **Callback Factory**                   |     ❌ No      |  ✅ Yes  |        ✅ Yes        |   ✅ Yes   |
+| **Static Structure + Dynamic Handler** |     ✅ Yes     |  ✅ Yes  |    ✅ In handler     | ⚠️ Limited |
+
+## The Golden Rule: Metadata Static, Execution Dynamic
+
+If you're designing a library or a system that others will build on, ask yourself: **"Do I need to enumerate this without running it?"**
+
+If the answer is yes, follow this pattern:
+
+1. **Define the keys and metadata statically.** (Names, descriptions, input schemas).
+2. **Pass the "World" (Context/Dependencies) into the handlers.**
+3. **Avoid "Middleman Functions"** that sit between the definition and the data.
+
+### Analogy: The Restaurant Menu
+
+- **The Menu (Static Object)**: You can read it standing on the sidewalk. You know they serve Pasta, Pizza, and Salad. You know the prices. You don't need a table to read it.
+- **The Kitchen (Context)**: The stove, the ingredients, the chef.
+- **The Meal (Execution)**: You only "invoke" the kitchen once you've looked at the menu and decided what you want.
+
+In software, we too often force our users to walk into the kitchen, sit down, and fire up the stove just to see if the restaurant serves Pasta.
+
+## Practical Guidance
+
+When you find yourself wanting to wrap an object in a function "just in case I need to pass something in later," stop.
+
+**Try this instead**:
+
+- Define the object as a plain constant.
+- If you need dependency injection, make the _methods_ on that object take the dependencies as arguments.
+- If you need to generate parts of the object dynamically, do it at a specific "build step" and output a static manifest (like a `metadata.json` or a generated `.ts` file).
+
+Introspection is the foundation of a great developer experience. Don't let your functions hide your API's potential.
+
+---
+
+**Next Steps**: Check out our article on the [Accessor Pattern](/docs/articles/accessor-pattern-explained.md) to see where functions _are_ the right tool for preserving reactivity.

--- a/packages/epicenter/src/core/schema/README.md
+++ b/packages/epicenter/src/core/schema/README.md
@@ -1,0 +1,111 @@
+# Epicenter Schema System
+
+## Philosophy
+
+Epicenter schemas are **the** schema definition for your data. They serve multiple purposes from a single source of truth:
+
+- **Validation**: Runtime type checking and constraint enforcement
+- **Forms**: Automatic UI generation with appropriate input components
+- **Introspection**: JSON Schema export for tooling, documentation, and interop
+- **Persistence**: Database column definitions
+
+The key insight: a schema that knows it will render as a select dropdown can also validate enum constraints and serialize to JSON Schema's `enum` keyword. These aren't separate concerns—they're facets of the same definition.
+
+## Bidirectional Serialization
+
+Every schema can be serialized to JSON Schema and reconstructed back:
+
+```
+Schema Definition  ←→  JSON Schema  ←→  Schema Definition
+```
+
+This enables:
+
+- **Storage**: Save schema definitions as JSON
+- **Transfer**: Send schemas over the network
+- **Tooling**: Use any JSON Schema-compatible tool
+- **Versioning**: Track schema changes in version control as data
+
+### What Serializes
+
+| Aspect      | JSON Schema Representation                             |
+| ----------- | ------------------------------------------------------ |
+| Types       | `type: "string"`, `type: "integer"`, etc.              |
+| Constraints | `minLength`, `maxLength`, `minimum`, `maximum`, `enum` |
+| Formats     | `format: "email"`, `format: "uri"`, `format: "date"`   |
+| Nullability | `type: ["string", "null"]`                             |
+| Defaults    | `default: "value"`                                     |
+| UI Hints    | `x-component`, `x-placeholder`, `x-rows`               |
+
+### What Doesn't Serialize (By Design)
+
+- **Handlers**: Business logic lives outside schemas
+- **TypeScript Types**: Runtime JSON has no generics; types are inferred on reconstruction
+
+## Core Constraints
+
+### Static Defaults
+
+All default values must be JSON-serializable. No functions, no lazy evaluation.
+
+```typescript
+// Allowed
+text({ default: 'draft' });
+tags({ default: ['typescript'] });
+
+// Not allowed
+date({ default: () => new Date() }); // Function - not serializable
+```
+
+Dynamic values (timestamps, IDs) are set at runtime in handlers, not in schema definitions.
+
+### JSON-Serializable
+
+Everything in a schema definition must survive a JSON round-trip:
+
+```typescript
+JSON.parse(JSON.stringify(schema)); // Must preserve all information
+```
+
+This means: strings, numbers, booleans, null, arrays, and plain objects only.
+
+## Reconstruction Contract
+
+Given a JSON Schema with Epicenter's `x-component` hints, you can rebuild the original schema:
+
+1. Read `x-component` to determine the component type
+2. Extract constraints from standard JSON Schema keywords
+3. Extract UI hints from `x-*` extension keywords
+4. Reconstruct the schema object with validation function
+
+The validation function isn't serialized—it's **derived** from the constraints. Same constraints produce same validation behavior.
+
+## Mental Model
+
+Think of schemas as **data that describes data**:
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Schema Definition (TypeScript)                     │
+│  ─────────────────────────────────                  │
+│  select({ options: ['draft', 'published'] })        │
+└─────────────────────────────────────────────────────┘
+                         ↓ serialize
+┌─────────────────────────────────────────────────────┐
+│  JSON Schema (portable data)                        │
+│  ─────────────────────────────                      │
+│  {                                                  │
+│    "type": "string",                                │
+│    "enum": ["draft", "published"],                  │
+│    "x-component": "select"                          │
+│  }                                                  │
+└─────────────────────────────────────────────────────┘
+                         ↓ reconstruct
+┌─────────────────────────────────────────────────────┐
+│  Schema Definition (rebuilt)                        │
+│  ─────────────────────────────                      │
+│  Same validation, same UI, same constraints         │
+└─────────────────────────────────────────────────────┘
+```
+
+The schema is the schema. JSON Schema is just its portable representation.

--- a/packages/epicenter/src/core/schema/columns.ts
+++ b/packages/epicenter/src/core/schema/columns.ts
@@ -142,7 +142,7 @@ export function text({
 			...(defaultValue !== undefined && { default: defaultValue }),
 		},
 		validate: (value): StandardSchemaV1.Result<string | null> => {
-			if (nullable && value === null) return { value: null };
+			if (nullable && value === null) return { value };
 			if (typeof value !== 'string') {
 				return { issues: [{ message: 'Expected string', path: [] }] };
 			}
@@ -192,7 +192,7 @@ export function ytext({
 			type: nullable ? (['string', 'null'] as const) : ('string' as const),
 		},
 		validate: (value): StandardSchemaV1.Result<string | null> => {
-			if (nullable && value === null) return { value: null };
+			if (nullable && value === null) return { value };
 			if (typeof value !== 'string') {
 				return { issues: [{ message: 'Expected string', path: [] }] };
 			}
@@ -233,7 +233,7 @@ export function integer({
 			...(defaultValue !== undefined && { default: defaultValue }),
 		},
 		validate: (value): StandardSchemaV1.Result<number | null> => {
-			if (nullable && value === null) return { value: null };
+			if (nullable && value === null) return { value };
 			if (typeof value !== 'number' || !Number.isInteger(value)) {
 				return { issues: [{ message: 'Expected integer', path: [] }] };
 			}
@@ -274,7 +274,7 @@ export function real({
 			...(defaultValue !== undefined && { default: defaultValue }),
 		},
 		validate: (value): StandardSchemaV1.Result<number | null> => {
-			if (nullable && value === null) return { value: null };
+			if (nullable && value === null) return { value };
 			if (typeof value !== 'number') {
 				return { issues: [{ message: 'Expected number', path: [] }] };
 			}
@@ -315,7 +315,7 @@ export function boolean({
 			...(defaultValue !== undefined && { default: defaultValue }),
 		},
 		validate: (value): StandardSchemaV1.Result<boolean | null> => {
-			if (nullable && value === null) return { value: null };
+			if (nullable && value === null) return { value };
 			if (typeof value !== 'boolean') {
 				return { issues: [{ message: 'Expected boolean', path: [] }] };
 			}
@@ -359,7 +359,7 @@ export function date({
 			...(defaultValue !== undefined && { default: defaultValue }),
 		},
 		validate: (value): StandardSchemaV1.Result<string | null> => {
-			if (nullable && value === null) return { value: null };
+			if (nullable && value === null) return { value };
 			if (typeof value !== 'string' || !isDateWithTimezoneString(value)) {
 				return { issues: [{ message: 'Expected date string', path: [] }] };
 			}
@@ -409,7 +409,7 @@ export function select<const TOptions extends readonly [string, ...string[]]>({
 			...(defaultValue !== undefined && { default: defaultValue }),
 		},
 		validate: (value): StandardSchemaV1.Result<TOptions[number] | null> => {
-			if (nullable && value === null) return { value: null };
+			if (nullable && value === null) return { value };
 			if (
 				typeof value !== 'string' ||
 				!options.includes(value as TOptions[number])
@@ -484,7 +484,7 @@ export function tags<const TOptions extends readonly [string, ...string[]]>({
 			}),
 		},
 		validate: (value): StandardSchemaV1.Result<TOptions[number][] | null> => {
-			if (nullable && value === null) return { value: null };
+			if (nullable && value === null) return { value };
 			if (!Array.isArray(value)) {
 				return { issues: [{ message: 'Expected array', path: [] }] };
 			}
@@ -564,7 +564,7 @@ export function json<const TSchema extends StandardSchemaWithJSONSchema>({
 		validate: (
 			value,
 		): StandardSchemaV1.Result<StandardSchemaV1.InferOutput<TSchema> | null> => {
-			if (nullable && value === null) return { value: null };
+			if (nullable && value === null) return { value };
 			const result = schema['~standard'].validate(value);
 			if ('issues' in result && result.issues) {
 				return {

--- a/packages/epicenter/src/core/schema/columns.ts
+++ b/packages/epicenter/src/core/schema/columns.ts
@@ -37,6 +37,7 @@ import type {
 } from './standard-schema';
 import type {
 	BooleanColumnSchema,
+	ColumnComponent,
 	DateColumnSchema,
 	IdColumnSchema,
 	IntegerColumnSchema,
@@ -66,7 +67,10 @@ type ColumnStandard<T> = {
  * @internal Used by all column factory functions
  */
 function createColumnSchema<
-	const TJSONSchema extends Record<string, unknown>,
+	const TJSONSchema extends {
+		'x-component': ColumnComponent;
+		type: string | readonly string[];
+	},
 	TOutput,
 >({
 	jsonSchema,

--- a/packages/epicenter/src/core/schema/columns.ts
+++ b/packages/epicenter/src/core/schema/columns.ts
@@ -135,11 +135,10 @@ export function text({
 	nullable?: boolean;
 	default?: string;
 } = {}): TextColumnSchema<boolean> {
-	const type = nullable ? (['string', 'null'] as const) : ('string' as const);
 	return withStandard({
 		jsonSchema: {
 			'x-component': 'text',
-			type,
+			type: nullable ? (['string', 'null'] as const) : ('string' as const),
 			...(defaultValue !== undefined && { default: defaultValue }),
 		},
 		validate: (value): StandardSchemaV1.Result<string | null> => {
@@ -187,9 +186,11 @@ export function ytext({
 }: {
 	nullable?: boolean;
 } = {}): YtextColumnSchema<boolean> {
-	const type = nullable ? (['string', 'null'] as const) : ('string' as const);
 	return withStandard({
-		jsonSchema: { 'x-component': 'ytext', type },
+		jsonSchema: {
+			'x-component': 'ytext',
+			type: nullable ? (['string', 'null'] as const) : ('string' as const),
+		},
 		validate: (value): StandardSchemaV1.Result<string | null> => {
 			if (nullable && value === null) return { value: null };
 			if (typeof value !== 'string') {
@@ -225,11 +226,10 @@ export function integer({
 	nullable?: boolean;
 	default?: number;
 } = {}): IntegerColumnSchema<boolean> {
-	const type = nullable ? (['integer', 'null'] as const) : ('integer' as const);
 	return withStandard({
 		jsonSchema: {
 			'x-component': 'integer',
-			type,
+			type: nullable ? (['integer', 'null'] as const) : ('integer' as const),
 			...(defaultValue !== undefined && { default: defaultValue }),
 		},
 		validate: (value): StandardSchemaV1.Result<number | null> => {
@@ -267,11 +267,10 @@ export function real({
 	nullable?: boolean;
 	default?: number;
 } = {}): RealColumnSchema<boolean> {
-	const type = nullable ? (['number', 'null'] as const) : ('number' as const);
 	return withStandard({
 		jsonSchema: {
 			'x-component': 'real',
-			type,
+			type: nullable ? (['number', 'null'] as const) : ('number' as const),
 			...(defaultValue !== undefined && { default: defaultValue }),
 		},
 		validate: (value): StandardSchemaV1.Result<number | null> => {
@@ -309,11 +308,10 @@ export function boolean({
 	nullable?: boolean;
 	default?: boolean;
 } = {}): BooleanColumnSchema<boolean> {
-	const type = nullable ? (['boolean', 'null'] as const) : ('boolean' as const);
 	return withStandard({
 		jsonSchema: {
 			'x-component': 'boolean',
-			type,
+			type: nullable ? (['boolean', 'null'] as const) : ('boolean' as const),
 			...(defaultValue !== undefined && { default: defaultValue }),
 		},
 		validate: (value): StandardSchemaV1.Result<boolean | null> => {
@@ -353,11 +351,10 @@ export function date({
 	nullable?: boolean;
 	default?: DateWithTimezone;
 } = {}): DateColumnSchema<boolean> {
-	const type = nullable ? (['string', 'null'] as const) : ('string' as const);
 	return withStandard({
 		jsonSchema: {
 			'x-component': 'date',
-			type,
+			type: nullable ? (['string', 'null'] as const) : ('string' as const),
 			format: 'date',
 			...(defaultValue !== undefined && { default: defaultValue }),
 		},
@@ -404,11 +401,10 @@ export function select<const TOptions extends readonly [string, ...string[]]>({
 	nullable?: boolean;
 	default?: TOptions[number];
 }): SelectColumnSchema<TOptions, boolean> {
-	const type = nullable ? (['string', 'null'] as const) : ('string' as const);
 	return withStandard({
 		jsonSchema: {
 			'x-component': 'select',
-			type,
+			type: nullable ? (['string', 'null'] as const) : ('string' as const),
 			enum: options,
 			...(defaultValue !== undefined && { default: defaultValue }),
 		},
@@ -475,15 +471,13 @@ export function tags<const TOptions extends readonly [string, ...string[]]>({
 	nullable?: boolean;
 	default?: TOptions[number][] | string[];
 } = {}): TagsColumnSchema<TOptions, boolean> {
-	const type = nullable ? (['array', 'null'] as const) : ('array' as const);
-	const items = options
-		? { type: 'string' as const, enum: options }
-		: { type: 'string' as const };
 	return withStandard({
 		jsonSchema: {
 			'x-component': 'tags',
-			type,
-			items,
+			type: nullable ? (['array', 'null'] as const) : ('array' as const),
+			items: options
+				? { type: 'string' as const, enum: options }
+				: { type: 'string' as const },
 			uniqueItems: true,
 			...(defaultValue !== undefined && {
 				default: defaultValue as TOptions[number][],
@@ -560,11 +554,10 @@ export function json<const TSchema extends StandardSchemaWithJSONSchema>({
 	nullable?: boolean;
 	default?: StandardSchemaV1.InferOutput<TSchema>;
 }): JsonColumnSchema<TSchema, boolean> {
-	const type = nullable ? (['object', 'null'] as const) : ('object' as const);
 	return withStandard({
 		jsonSchema: {
 			'x-component': 'json',
-			type,
+			type: nullable ? (['object', 'null'] as const) : ('object' as const),
 			schema,
 			...(defaultValue !== undefined && { default: defaultValue }),
 		},

--- a/packages/epicenter/src/core/schema/columns.ts
+++ b/packages/epicenter/src/core/schema/columns.ts
@@ -8,17 +8,17 @@
  * ## Architecture
  *
  * Column schemas are JSON Schema objects with an embedded `~standard` property
- * for Standard Schema compliance. The `withStandard` helper eliminates duplication
+ * for Standard Schema compliance. The `createColumnSchema` helper eliminates duplication
  * by deriving the JSON Schema representation from the schema object itself.
  *
- * ## Key Pattern: `withStandard`
+ * ## Key Pattern: `createColumnSchema`
  *
  * Uses two positional arguments for better TypeScript inference:
  * - First arg: JSON schema object (literal types preserved via `const TJSONSchema`)
  * - Second arg: validate function (output type inferred via `TValidate`)
  *
  * ```typescript
- * return withStandard(
+ * return createColumnSchema(
  *   { 'x-component': 'text', type: 'string' },
  *   (value) => {
  *     if (typeof value !== 'string') return { issues: [...] };
@@ -65,7 +65,7 @@ type ColumnStandard<T> = {
  *
  * @internal Used by all column factory functions
  */
-function withStandard<
+function createColumnSchema<
 	const TJSONSchema extends Record<string, unknown>,
 	TOutput,
 >({
@@ -99,7 +99,7 @@ function withStandard<
  * ```
  */
 export function id(): IdColumnSchema {
-	return withStandard({
+	return createColumnSchema({
 		jsonSchema: { 'x-component': 'id', type: 'string' },
 		validate: (value): StandardSchemaV1.Result<string> => {
 			if (typeof value !== 'string') {
@@ -135,7 +135,7 @@ export function text({
 	nullable?: boolean;
 	default?: string;
 } = {}): TextColumnSchema<boolean> {
-	return withStandard({
+	return createColumnSchema({
 		jsonSchema: {
 			'x-component': 'text',
 			type: nullable ? (['string', 'null'] as const) : ('string' as const),
@@ -186,7 +186,7 @@ export function ytext({
 }: {
 	nullable?: boolean;
 } = {}): YtextColumnSchema<boolean> {
-	return withStandard({
+	return createColumnSchema({
 		jsonSchema: {
 			'x-component': 'ytext',
 			type: nullable ? (['string', 'null'] as const) : ('string' as const),
@@ -226,7 +226,7 @@ export function integer({
 	nullable?: boolean;
 	default?: number;
 } = {}): IntegerColumnSchema<boolean> {
-	return withStandard({
+	return createColumnSchema({
 		jsonSchema: {
 			'x-component': 'integer',
 			type: nullable ? (['integer', 'null'] as const) : ('integer' as const),
@@ -267,7 +267,7 @@ export function real({
 	nullable?: boolean;
 	default?: number;
 } = {}): RealColumnSchema<boolean> {
-	return withStandard({
+	return createColumnSchema({
 		jsonSchema: {
 			'x-component': 'real',
 			type: nullable ? (['number', 'null'] as const) : ('number' as const),
@@ -308,7 +308,7 @@ export function boolean({
 	nullable?: boolean;
 	default?: boolean;
 } = {}): BooleanColumnSchema<boolean> {
-	return withStandard({
+	return createColumnSchema({
 		jsonSchema: {
 			'x-component': 'boolean',
 			type: nullable ? (['boolean', 'null'] as const) : ('boolean' as const),
@@ -351,7 +351,7 @@ export function date({
 	nullable?: boolean;
 	default?: DateWithTimezone;
 } = {}): DateColumnSchema<boolean> {
-	return withStandard({
+	return createColumnSchema({
 		jsonSchema: {
 			'x-component': 'date',
 			type: nullable ? (['string', 'null'] as const) : ('string' as const),
@@ -401,7 +401,7 @@ export function select<const TOptions extends readonly [string, ...string[]]>({
 	nullable?: boolean;
 	default?: TOptions[number];
 }): SelectColumnSchema<TOptions, boolean> {
-	return withStandard({
+	return createColumnSchema({
 		jsonSchema: {
 			'x-component': 'select',
 			type: nullable ? (['string', 'null'] as const) : ('string' as const),
@@ -471,7 +471,7 @@ export function tags<const TOptions extends readonly [string, ...string[]]>({
 	nullable?: boolean;
 	default?: TOptions[number][] | string[];
 } = {}): TagsColumnSchema<TOptions, boolean> {
-	return withStandard({
+	return createColumnSchema({
 		jsonSchema: {
 			'x-component': 'tags',
 			type: nullable ? (['array', 'null'] as const) : ('array' as const),
@@ -554,7 +554,7 @@ export function json<const TSchema extends StandardSchemaWithJSONSchema>({
 	nullable?: boolean;
 	default?: StandardSchemaV1.InferOutput<TSchema>;
 }): JsonColumnSchema<TSchema, boolean> {
-	return withStandard({
+	return createColumnSchema({
 		jsonSchema: {
 			'x-component': 'json',
 			type: nullable ? (['object', 'null'] as const) : ('object' as const),

--- a/packages/epicenter/src/core/schema/columns.ts
+++ b/packages/epicenter/src/core/schema/columns.ts
@@ -68,10 +68,13 @@ type ColumnStandard<T> = {
 function withStandard<
 	const TJSONSchema extends Record<string, unknown>,
 	TOutput,
->(
-	jsonSchema: TJSONSchema,
-	validate: (value: unknown) => StandardSchemaV1.Result<TOutput>,
-): TJSONSchema & ColumnStandard<TOutput> {
+>({
+	jsonSchema,
+	validate,
+}: {
+	jsonSchema: TJSONSchema;
+	validate: (value: unknown) => StandardSchemaV1.Result<TOutput>;
+}): TJSONSchema & ColumnStandard<TOutput> {
 	return {
 		...jsonSchema,
 		'~standard': {
@@ -96,15 +99,15 @@ function withStandard<
  * ```
  */
 export function id(): IdColumnSchema {
-	return withStandard(
-		{ 'x-component': 'id', type: 'string' },
-		(value): StandardSchemaV1.Result<string> => {
+	return withStandard({
+		jsonSchema: { 'x-component': 'id', type: 'string' },
+		validate: (value): StandardSchemaV1.Result<string> => {
 			if (typeof value !== 'string') {
 				return { issues: [{ message: 'Expected string', path: [] }] };
 			}
 			return { value };
 		},
-	);
+	});
 }
 
 /**
@@ -133,20 +136,20 @@ export function text({
 	default?: string;
 } = {}): TextColumnSchema<boolean> {
 	const type = nullable ? (['string', 'null'] as const) : ('string' as const);
-	return withStandard(
-		{
+	return withStandard({
+		jsonSchema: {
 			'x-component': 'text',
 			type,
 			...(defaultValue !== undefined && { default: defaultValue }),
 		},
-		(value): StandardSchemaV1.Result<string | null> => {
+		validate: (value): StandardSchemaV1.Result<string | null> => {
 			if (nullable && value === null) return { value: null };
 			if (typeof value !== 'string') {
 				return { issues: [{ message: 'Expected string', path: [] }] };
 			}
 			return { value };
 		},
-	);
+	});
 }
 
 /**
@@ -185,16 +188,16 @@ export function ytext({
 	nullable?: boolean;
 } = {}): YtextColumnSchema<boolean> {
 	const type = nullable ? (['string', 'null'] as const) : ('string' as const);
-	return withStandard(
-		{ 'x-component': 'ytext', type },
-		(value): StandardSchemaV1.Result<string | null> => {
+	return withStandard({
+		jsonSchema: { 'x-component': 'ytext', type },
+		validate: (value): StandardSchemaV1.Result<string | null> => {
 			if (nullable && value === null) return { value: null };
 			if (typeof value !== 'string') {
 				return { issues: [{ message: 'Expected string', path: [] }] };
 			}
 			return { value };
 		},
-	);
+	});
 }
 
 /**
@@ -223,20 +226,20 @@ export function integer({
 	default?: number;
 } = {}): IntegerColumnSchema<boolean> {
 	const type = nullable ? (['integer', 'null'] as const) : ('integer' as const);
-	return withStandard(
-		{
+	return withStandard({
+		jsonSchema: {
 			'x-component': 'integer',
 			type,
 			...(defaultValue !== undefined && { default: defaultValue }),
 		},
-		(value): StandardSchemaV1.Result<number | null> => {
+		validate: (value): StandardSchemaV1.Result<number | null> => {
 			if (nullable && value === null) return { value: null };
 			if (typeof value !== 'number' || !Number.isInteger(value)) {
 				return { issues: [{ message: 'Expected integer', path: [] }] };
 			}
 			return { value };
 		},
-	);
+	});
 }
 
 /**
@@ -265,20 +268,20 @@ export function real({
 	default?: number;
 } = {}): RealColumnSchema<boolean> {
 	const type = nullable ? (['number', 'null'] as const) : ('number' as const);
-	return withStandard(
-		{
+	return withStandard({
+		jsonSchema: {
 			'x-component': 'real',
 			type,
 			...(defaultValue !== undefined && { default: defaultValue }),
 		},
-		(value): StandardSchemaV1.Result<number | null> => {
+		validate: (value): StandardSchemaV1.Result<number | null> => {
 			if (nullable && value === null) return { value: null };
 			if (typeof value !== 'number') {
 				return { issues: [{ message: 'Expected number', path: [] }] };
 			}
 			return { value };
 		},
-	);
+	});
 }
 
 /**
@@ -307,20 +310,20 @@ export function boolean({
 	default?: boolean;
 } = {}): BooleanColumnSchema<boolean> {
 	const type = nullable ? (['boolean', 'null'] as const) : ('boolean' as const);
-	return withStandard(
-		{
+	return withStandard({
+		jsonSchema: {
 			'x-component': 'boolean',
 			type,
 			...(defaultValue !== undefined && { default: defaultValue }),
 		},
-		(value): StandardSchemaV1.Result<boolean | null> => {
+		validate: (value): StandardSchemaV1.Result<boolean | null> => {
 			if (nullable && value === null) return { value: null };
 			if (typeof value !== 'boolean') {
 				return { issues: [{ message: 'Expected boolean', path: [] }] };
 			}
 			return { value };
 		},
-	);
+	});
 }
 
 /**
@@ -351,21 +354,21 @@ export function date({
 	default?: DateWithTimezone;
 } = {}): DateColumnSchema<boolean> {
 	const type = nullable ? (['string', 'null'] as const) : ('string' as const);
-	return withStandard(
-		{
+	return withStandard({
+		jsonSchema: {
 			'x-component': 'date',
 			type,
 			format: 'date',
 			...(defaultValue !== undefined && { default: defaultValue }),
 		},
-		(value): StandardSchemaV1.Result<string | null> => {
+		validate: (value): StandardSchemaV1.Result<string | null> => {
 			if (nullable && value === null) return { value: null };
 			if (typeof value !== 'string' || !isDateWithTimezoneString(value)) {
 				return { issues: [{ message: 'Expected date string', path: [] }] };
 			}
 			return { value };
 		},
-	);
+	});
 }
 
 /**
@@ -402,14 +405,14 @@ export function select<const TOptions extends readonly [string, ...string[]]>({
 	default?: TOptions[number];
 }): SelectColumnSchema<TOptions, boolean> {
 	const type = nullable ? (['string', 'null'] as const) : ('string' as const);
-	return withStandard(
-		{
+	return withStandard({
+		jsonSchema: {
 			'x-component': 'select',
 			type,
 			enum: options,
 			...(defaultValue !== undefined && { default: defaultValue }),
 		},
-		(value): StandardSchemaV1.Result<TOptions[number] | null> => {
+		validate: (value): StandardSchemaV1.Result<TOptions[number] | null> => {
 			if (nullable && value === null) return { value: null };
 			if (
 				typeof value !== 'string' ||
@@ -423,7 +426,7 @@ export function select<const TOptions extends readonly [string, ...string[]]>({
 			}
 			return { value: value as TOptions[number] };
 		},
-	);
+	});
 }
 
 /**
@@ -476,8 +479,8 @@ export function tags<const TOptions extends readonly [string, ...string[]]>({
 	const items = options
 		? { type: 'string' as const, enum: options }
 		: { type: 'string' as const };
-	return withStandard(
-		{
+	return withStandard({
+		jsonSchema: {
 			'x-component': 'tags',
 			type,
 			items,
@@ -486,7 +489,7 @@ export function tags<const TOptions extends readonly [string, ...string[]]>({
 				default: defaultValue as TOptions[number][],
 			}),
 		},
-		(value): StandardSchemaV1.Result<TOptions[number][] | null> => {
+		validate: (value): StandardSchemaV1.Result<TOptions[number][] | null> => {
 			if (nullable && value === null) return { value: null };
 			if (!Array.isArray(value)) {
 				return { issues: [{ message: 'Expected array', path: [] }] };
@@ -502,7 +505,7 @@ export function tags<const TOptions extends readonly [string, ...string[]]>({
 			}
 			return { value: value as TOptions[number][] };
 		},
-	);
+	});
 }
 
 /**
@@ -558,14 +561,14 @@ export function json<const TSchema extends StandardSchemaWithJSONSchema>({
 	default?: StandardSchemaV1.InferOutput<TSchema>;
 }): JsonColumnSchema<TSchema, boolean> {
 	const type = nullable ? (['object', 'null'] as const) : ('object' as const);
-	return withStandard(
-		{
+	return withStandard({
+		jsonSchema: {
 			'x-component': 'json',
 			type,
 			schema,
 			...(defaultValue !== undefined && { default: defaultValue }),
 		},
-		(
+		validate: (
 			value,
 		): StandardSchemaV1.Result<StandardSchemaV1.InferOutput<TSchema> | null> => {
 			if (nullable && value === null) return { value: null };
@@ -580,5 +583,5 @@ export function json<const TSchema extends StandardSchemaWithJSONSchema>({
 					.value as StandardSchemaV1.InferOutput<TSchema>,
 			};
 		},
-	);
+	});
 }

--- a/packages/epicenter/src/core/schema/converters/arktype-yjs.test.ts
+++ b/packages/epicenter/src/core/schema/converters/arktype-yjs.test.ts
@@ -22,12 +22,12 @@ test('validates Y.Text for ytext columns', () => {
 	};
 
 	const validator = tableSchemaToYjsArktypeType(schema);
-	const ytext = new Y.Text();
-	ytext.insert(0, 'Hello World');
+	const ytextInstance = new Y.Text();
+	ytextInstance.insert(0, 'Hello World');
 
 	const result = validator({
 		id: '123',
-		content: ytext,
+		content: ytextInstance,
 	});
 
 	expect(result instanceof type.errors).toBe(false);
@@ -42,10 +42,10 @@ test('validates Y.Text | null for nullable ytext columns', () => {
 	const validator = tableSchemaToYjsArktypeType(schema);
 
 	// Test with Y.Text
-	const ytext = new Y.Text();
+	const ytextInstance = new Y.Text();
 	const result1 = validator({
 		id: '123',
-		content: ytext,
+		content: ytextInstance,
 	});
 	expect(result1 instanceof type.errors).toBe(false);
 
@@ -79,7 +79,7 @@ test('rejects string for ytext columns', () => {
 test('validates Y.Array for multi-select columns', () => {
 	const schema = {
 		id: id(),
-		tags: tags(['tech', 'blog', 'news']),
+		tags: tags({ options: ['tech', 'blog', 'news'] }),
 	};
 
 	const validator = tableSchemaToYjsArktypeType(schema);
@@ -97,7 +97,7 @@ test('validates Y.Array for multi-select columns', () => {
 test('validates Y.Array | null for nullable multi-select columns', () => {
 	const schema = {
 		id: id(),
-		tags: tags(['tech', 'blog'], { nullable: true }),
+		tags: tags({ options: ['tech', 'blog'], nullable: true }),
 	};
 
 	const validator = tableSchemaToYjsArktypeType(schema);
@@ -121,7 +121,7 @@ test('validates Y.Array | null for nullable multi-select columns', () => {
 test('rejects plain array for multi-select columns', () => {
 	const schema = {
 		id: id(),
-		tags: tags(['tech', 'blog']),
+		tags: tags({ options: ['tech', 'blog'] }),
 	};
 
 	const validator = tableSchemaToYjsArktypeType(schema);
@@ -241,7 +241,7 @@ test('validates date strings for date columns', () => {
 test('validates select options for select columns', () => {
 	const schema = {
 		id: id(),
-		status: select(['draft', 'published', 'archived']),
+		status: select({ options: ['draft', 'published', 'archived'] }),
 	};
 
 	const validator = tableSchemaToYjsArktypeType(schema);
@@ -257,7 +257,7 @@ test('validates select options for select columns', () => {
 test('rejects invalid options for select columns', () => {
 	const schema = {
 		id: id(),
-		status: select(['draft', 'published']),
+		status: select({ options: ['draft', 'published'] }),
 	};
 
 	const validator = tableSchemaToYjsArktypeType(schema);
@@ -317,7 +317,7 @@ test('validates complex Row with YJS types', () => {
 		id: id(),
 		title: text(),
 		content: ytext(),
-		tags: tags(['tech', 'blog']),
+		tags: tags({ options: ['tech', 'blog'] }),
 		published: boolean(),
 		viewCount: integer(),
 		rating: real({ nullable: true }),
@@ -325,15 +325,15 @@ test('validates complex Row with YJS types', () => {
 
 	const validator = tableSchemaToYjsArktypeType(schema);
 
-	const ytext = new Y.Text();
-	ytext.insert(0, 'Content here');
+	const ytextInstance = new Y.Text();
+	ytextInstance.insert(0, 'Content here');
 	const yarray = new Y.Array();
 	yarray.push(['tech']);
 
 	const result = validator({
 		id: '123',
 		title: 'Test Post',
-		content: ytext,
+		content: ytextInstance,
 		tags: yarray,
 		published: true,
 		viewCount: 42,
@@ -353,13 +353,13 @@ test('validates Row with getters (buildRowFromYRow pattern)', () => {
 	const validator = tableSchemaToYjsArktypeType(schema);
 
 	// Simulate buildRowFromYRow pattern with getters
-	const ytext = new Y.Text();
-	ytext.insert(0, 'Content');
+	const ytextInstance = new Y.Text();
+	ytextInstance.insert(0, 'Content');
 
-	const mockYRow = new Map([
+	const mockYRow = new Map<string, string | Y.Text>([
 		['id', '123'],
 		['title', 'Test'],
-		['content', ytext],
+		['content', ytextInstance],
 	]);
 
 	const row: Record<string, unknown> = {};

--- a/packages/epicenter/src/core/schema/index.ts
+++ b/packages/epicenter/src/core/schema/index.ts
@@ -47,6 +47,7 @@ export { generateJsonSchema } from './generate-json-schema';
 // ============================================================================
 export type { Id } from './id';
 export { generateId } from './id';
+export { isNullableColumnSchema } from './nullability';
 // ============================================================================
 // Regex
 // ============================================================================
@@ -75,8 +76,8 @@ export type {
 	BooleanColumnSchema,
 	// Value types
 	CellValue,
+	ColumnComponent,
 	ColumnSchema,
-	ColumnType,
 	DateColumnSchema,
 	// Column schema types
 	IdColumnSchema,

--- a/packages/epicenter/src/core/schema/nullability.ts
+++ b/packages/epicenter/src/core/schema/nullability.ts
@@ -1,0 +1,28 @@
+import type { ColumnSchema } from './types';
+
+/**
+ * Determine whether a column schema accepts `null`.
+ *
+ * Epicenter encodes nullability using native JSON Schema unions:
+ * - Non-nullable: `type: 'string'`
+ * - Nullable: `type: ['string', 'null']`
+ *
+ * We check specifically for `'null'` in the type array rather than just
+ * `Array.isArray(type)` because JSON Schema allows non-nullable unions
+ * (e.g., `['string', 'number']`).
+ *
+ * @example
+ * ```typescript
+ * import { isNullableColumnSchema } from './nullability';
+ *
+ * if (!isNullableColumnSchema(schema)) {
+ *   column = column.notNull();
+ * }
+ * ```
+ */
+export function isNullableColumnSchema(
+	schema: Pick<ColumnSchema, 'type'>,
+): boolean {
+	const { type } = schema;
+	return Array.isArray(type) && (type as readonly unknown[]).includes('null');
+}

--- a/packages/epicenter/src/core/schema/types.ts
+++ b/packages/epicenter/src/core/schema/types.ts
@@ -6,6 +6,10 @@
  * - Table and workspace schemas
  * - Row value types (CellValue, SerializedRow, Row)
  *
+ * Nullability is encoded in JSON Schema `type` field:
+ * - Non-nullable: `type: 'string'`
+ * - Nullable: `type: ['string', 'null']`
+ *
  * Other schema-related types are co-located with their implementations:
  * - Id type and generateId function → id.ts
  * - DateWithTimezone types and functions → date-with-timezone.ts
@@ -19,53 +23,55 @@ import type {
 	DateWithTimezoneString,
 } from './date-with-timezone';
 import type {
+	StandardJSONSchemaV1,
 	StandardSchemaV1,
 	StandardSchemaWithJSONSchema,
 } from './standard-schema';
 
-// ============================================================================
-// Column Schema Types
-// ============================================================================
+type ColumnStandard<T> = {
+	'~standard': StandardSchemaV1.Props<T> & StandardJSONSchemaV1.Props<T>;
+};
 
-/**
- * Individual column schema types
- */
-export type IdColumnSchema = { type: 'id'; nullable: false };
+export type IdColumnSchema = {
+	'x-component': 'id';
+	type: 'string';
+} & ColumnStandard<string>;
 
 export type TextColumnSchema<TNullable extends boolean = boolean> = {
-	type: 'text';
-	nullable: TNullable;
+	'x-component': 'text';
+	type: TNullable extends true ? readonly ['string', 'null'] : 'string';
 	default?: string;
-};
+} & ColumnStandard<TNullable extends true ? string | null : string>;
 
 export type YtextColumnSchema<TNullable extends boolean = boolean> = {
-	type: 'ytext';
-	nullable: TNullable;
-};
+	'x-component': 'ytext';
+	type: TNullable extends true ? readonly ['string', 'null'] : 'string';
+} & ColumnStandard<TNullable extends true ? string | null : string>;
 
 export type IntegerColumnSchema<TNullable extends boolean = boolean> = {
-	type: 'integer';
-	nullable: TNullable;
+	'x-component': 'integer';
+	type: TNullable extends true ? readonly ['integer', 'null'] : 'integer';
 	default?: number;
-};
+} & ColumnStandard<TNullable extends true ? number | null : number>;
 
 export type RealColumnSchema<TNullable extends boolean = boolean> = {
-	type: 'real';
-	nullable: TNullable;
+	'x-component': 'real';
+	type: TNullable extends true ? readonly ['number', 'null'] : 'number';
 	default?: number;
-};
+} & ColumnStandard<TNullable extends true ? number | null : number>;
 
 export type BooleanColumnSchema<TNullable extends boolean = boolean> = {
-	type: 'boolean';
-	nullable: TNullable;
+	'x-component': 'boolean';
+	type: TNullable extends true ? readonly ['boolean', 'null'] : 'boolean';
 	default?: boolean;
-};
+} & ColumnStandard<TNullable extends true ? boolean | null : boolean>;
 
 export type DateColumnSchema<TNullable extends boolean = boolean> = {
-	type: 'date';
-	nullable: TNullable;
+	'x-component': 'date';
+	type: TNullable extends true ? readonly ['string', 'null'] : 'string';
+	format: 'date';
 	default?: DateWithTimezone;
-};
+} & ColumnStandard<TNullable extends true ? string | null : string>;
 
 export type SelectColumnSchema<
 	TOptions extends readonly [string, ...string[]] = readonly [
@@ -74,19 +80,14 @@ export type SelectColumnSchema<
 	],
 	TNullable extends boolean = boolean,
 > = {
-	type: 'select';
-	nullable: TNullable;
-	options: TOptions;
+	'x-component': 'select';
+	type: TNullable extends true ? readonly ['string', 'null'] : 'string';
+	enum: TOptions;
 	default?: TOptions[number];
-};
+} & ColumnStandard<
+	TNullable extends true ? TOptions[number] | null : TOptions[number]
+>;
 
-/**
- * Tags column schema for storing arrays of strings.
- * Use with the tags() function for validated or unconstrained string arrays.
- * @example
- * tags({ options: ['a', 'b'] }) // TagsColumnSchema<['a', 'b'], false>
- * tags() // TagsColumnSchema<[string, ...string[]], false>
- */
 export type TagsColumnSchema<
 	TOptions extends readonly [string, ...string[]] = readonly [
 		string,
@@ -94,79 +95,29 @@ export type TagsColumnSchema<
 	],
 	TNullable extends boolean = boolean,
 > = {
-	type: 'multi-select';
-	nullable: TNullable;
-	options?: TOptions;
+	'x-component': 'tags';
+	type: TNullable extends true ? readonly ['array', 'null'] : 'array';
+	items: { type: 'string'; enum?: TOptions };
+	uniqueItems: true;
 	default?: TOptions[number][];
-};
+} & ColumnStandard<
+	TNullable extends true ? TOptions[number][] | null : TOptions[number][]
+>;
 
-/**
- * JSON column schema - stores arbitrary JSON-serializable values with StandardSchemaV1 validation.
- *
- * Unlike other column types, JSON columns use a `schema` property instead of `options`.
- * The schema must extend StandardSchemaV1 and is always required.
- *
- * **⚠️ Schema Property Constraints**
- *
- * The `schema` property value is converted to JSON Schema when this table schema is used
- * as an action input (via `validators.toStandardSchema()`) for MCP/CLI/OpenAPI. Avoid:
- *
- * - **Transforms**: `.pipe()` (ArkType), `.transform()` (Zod), `transform()` action (Valibot)
- * - **Custom validation**: `.filter()` (ArkType), `.refine()` (Zod), `check()`/`custom()` (Valibot)
- * - **Non-JSON types**: `bigint`, `symbol`, `undefined`, `Date`, `Map`, `Set`
- *
- * Use basic types (`string`, `number`, `boolean`, objects, arrays) and `.matching(regex)` for patterns.
- * For complex validation, validate in the handler instead.
- *
- * Learn more:
- * - Zod: https://zod.dev/json-schema?id=unrepresentable
- * - Valibot: https://www.npmjs.com/package/@valibot/to-json-schema
- * - ArkType: https://arktype.io/docs/configuration#fallback-codes
- *
- * @example
- * ```typescript
- * import { json } from 'epicenter/schema';
- * import { type } from 'arktype';
- *
- * // ✅ Good: JSON Schema compatible
- * const userPrefs = json({
- *   schema: type({
- *     theme: type.enumerated('light', 'dark'),
- *     notifications: 'boolean',
- *   }),
- * });
- *
- * // ✅ Good: With nullable and default
- * const metadata = json({
- *   schema: type({ key: 'string', value: 'string' }).array(),
- *   nullable: true,
- *   default: [],
- * });
- *
- * // ❌ Bad: Uses .filter() (custom validation)
- * // const badSchema = json({
- * //   schema: type('string').filter(s => s.includes('test'))
- * // });
- *
- * // ❌ Bad: Uses .pipe() (transformation)
- * // const badSchema = json({
- * //   schema: type('string').pipe(s => s.toUpperCase())
- * // });
- * ```
- */
 export type JsonColumnSchema<
 	TSchema extends StandardSchemaWithJSONSchema = StandardSchemaWithJSONSchema,
 	TNullable extends boolean = boolean,
 > = {
-	type: 'json';
-	nullable: TNullable;
+	'x-component': 'json';
+	type: TNullable extends true ? readonly ['object', 'null'] : 'object';
 	schema: TSchema;
 	default?: StandardSchemaV1.InferOutput<TSchema>;
-};
+} & ColumnStandard<
+	TNullable extends true
+		? StandardSchemaV1.InferOutput<TSchema> | null
+		: StandardSchemaV1.InferOutput<TSchema>
+>;
 
-/**
- * Discriminated union of all column types
- */
 export type ColumnSchema =
 	| IdColumnSchema
 	| TextColumnSchema
@@ -179,97 +130,53 @@ export type ColumnSchema =
 	| TagsColumnSchema
 	| JsonColumnSchema;
 
-/**
- * Extract just the type names from ColumnSchema
- */
-export type ColumnType = ColumnSchema['type'];
+export type ColumnComponent = ColumnSchema['x-component'];
 
-/**
- * Table schema - maps column names to their schemas.
- * This is the pure schema definition that describes the structure of a table.
- * Must always include an 'id' column with IdColumnSchema.
- */
-export type TableSchema = { id: IdColumnSchema } & Record<string, ColumnSchema>;
+type IsNullableType<T> = T extends readonly [unknown, 'null'] ? true : false;
 
-/**
- * Workspace schema - maps table names to their table schemas
- */
-export type WorkspaceSchema = Record<string, TableSchema>;
-
-/**
- * Maps a ColumnSchema to its cell value type (Y.js types or primitives).
- * Handles nullable fields and returns Y.js types for ytext and multi-select.
- * Date columns store DateWithTimezoneString (atomic string format, not objects).
- *
- * @example
- * ```typescript
- * type IdValue = CellValue<{ type: 'id' }>; // string
- * type TextField = CellValue<{ type: 'text'; nullable: true }>; // string | null
- * type YtextField = CellValue<{ type: 'ytext'; nullable: false }>; // Y.Text
- * type DateField = CellValue<{ type: 'date'; nullable: false }>; // DateWithTimezoneString
- * type TagsField = CellValue<{ type: 'multi-select'; nullable: false; options: readonly ['x', 'y'] }>; // Y.Array<string>
- * type AnyCellValue = CellValue; // Union of all possible cell values
- * ```
- */
 export type CellValue<C extends ColumnSchema = ColumnSchema> =
 	C extends IdColumnSchema
 		? string
-		: C extends TextColumnSchema<infer TNullable>
-			? TNullable extends true
+		: C extends TextColumnSchema
+			? IsNullableType<C['type']> extends true
 				? string | null
 				: string
-			: C extends YtextColumnSchema<infer TNullable>
-				? TNullable extends true
+			: C extends YtextColumnSchema
+				? IsNullableType<C['type']> extends true
 					? Y.Text | null
 					: Y.Text
-				: C extends IntegerColumnSchema<infer TNullable>
-					? TNullable extends true
+				: C extends IntegerColumnSchema
+					? IsNullableType<C['type']> extends true
 						? number | null
 						: number
-					: C extends RealColumnSchema<infer TNullable>
-						? TNullable extends true
+					: C extends RealColumnSchema
+						? IsNullableType<C['type']> extends true
 							? number | null
 							: number
-						: C extends BooleanColumnSchema<infer TNullable>
-							? TNullable extends true
+						: C extends BooleanColumnSchema
+							? IsNullableType<C['type']> extends true
 								? boolean | null
 								: boolean
-							: C extends DateColumnSchema<infer TNullable>
-								? TNullable extends true
+							: C extends DateColumnSchema
+								? IsNullableType<C['type']> extends true
 									? DateWithTimezoneString | null
 									: DateWithTimezoneString
-								: C extends SelectColumnSchema<infer TOptions, infer TNullable>
-									? TNullable extends true
+								: C extends SelectColumnSchema<infer TOptions>
+									? IsNullableType<C['type']> extends true
 										? TOptions[number] | null
 										: TOptions[number]
-									: C extends TagsColumnSchema<infer TOptions, infer TNullable>
-										? TNullable extends true
+									: C extends TagsColumnSchema<infer TOptions>
+										? IsNullableType<C['type']> extends true
 											? Y.Array<TOptions[number]> | null
 											: Y.Array<TOptions[number]>
-										: C extends JsonColumnSchema<infer TSchema, infer TNullable>
-											? TNullable extends true
+										: C extends JsonColumnSchema<
+													infer TSchema extends StandardSchemaWithJSONSchema
+												>
+											? IsNullableType<C['type']> extends true
 												? StandardSchemaV1.InferOutput<TSchema> | null
 												: StandardSchemaV1.InferOutput<TSchema>
 											: never;
 
-/**
- * Maps a ColumnSchema to its serialized cell value type.
- * This is the serialized equivalent of CellValue - what you get after calling serializeCellValue().
- * Uses a distributive conditional type to transform Y.js types to their serialized equivalents.
- * - Y.Text → string
- * - Y.Array<T> → T[]
- * - DateWithTimezone → DateWithTimezoneString
- * - Other types → unchanged
- *
- * @example
- * ```typescript
- * type IdSerialized = SerializedCellValue<{ type: 'id' }>; // string
- * type YtextSerialized = SerializedCellValue<{ type: 'ytext'; nullable: false }>; // string
- * type YtextNullable = SerializedCellValue<{ type: 'ytext'; nullable: true }>; // string | null
- * type Tags = SerializedCellValue<{ type: 'multi-select'; nullable: false; options: readonly ['a', 'b'] }>; // string[]
- * type AnySerialized = SerializedCellValue; // Union of all possible serialized values
- * ```
- */
 export type SerializedCellValue<C extends ColumnSchema = ColumnSchema> =
 	CellValue<C> extends infer T
 		? T extends Y.Text
@@ -278,165 +185,37 @@ export type SerializedCellValue<C extends ColumnSchema = ColumnSchema> =
 				? U[]
 				: T extends DateWithTimezone
 					? DateWithTimezoneString
-					: T // JSON values are already plain JavaScript, no conversion needed
+					: T
 		: never;
 
-/**
- * Maps a TableSchema to a row type with properly typed fields AND Proxy methods.
- * This is a Proxy-wrapped YRow that provides:
- * - Type-safe property access: `row.title`, `row.content`, etc.
- * - `.toJSON()` method: Convert to fully serialized object (Y.Text → string, Y.Array → array[], etc.)
- * - `.$yRow` property: Access underlying YRow when needed
- *
- * Each column name becomes a property with its corresponding YJS or primitive type.
- * Since `TableSchema` always requires an `id` column, every row type includes a guaranteed `id: string` property.
- *
- * @example
- * ```typescript
- * // Type-safe with specific schema
- * type PostSchema = {
- *   id: { type: 'id' };
- *   title: { type: 'text'; nullable: false };
- *   content: { type: 'ytext'; nullable: false };
- *   viewCount: { type: 'integer'; nullable: false };
- * };
- *
- * const row: Row<PostSchema> = table.get('123').row;
- *
- * // Type-safe property access (returns Y.js types)
- * console.log(row.title);         // string
- * console.log(row.content);       // Y.Text
- * console.log(row.viewCount);     // number
- *
- * // Convert to fully serialized object (Y.Text → string, etc.)
- * const serialized = row.toJSON();     // SerializedRow<PostSchema>
- * // { id: string, title: string, content: string, viewCount: number }
- *
- * // Access underlying YRow
- * const yrow = row.$yRow;         // YRow
- * ```
- */
+export type TableSchema = { id: IdColumnSchema } & Record<string, ColumnSchema>;
+
+export type WorkspaceSchema = Record<string, TableSchema>;
+
 export type Row<TTableSchema extends TableSchema = TableSchema> = {
 	readonly [K in keyof TTableSchema]: CellValue<TTableSchema[K]>;
 } & {
-	/**
-	 * Convert the row to a fully serialized plain object.
-	 * Y.Text → string, Y.Array → array[], DateWithTimezone → string, etc.
-	 */
 	toJSON(): SerializedRow<TTableSchema>;
-
-	/**
-	 * Access the underlying YRow for advanced YJS operations.
-	 * Use this when you need direct Y.Map API access.
-	 */
 	readonly $yRow: YRow;
 };
 
-/**
- * Serialized row - all cell values converted to plain JavaScript types.
- * This type is useful for:
- * - Storing data in formats that don't support YJS types (SQLite, markdown, JSON APIs)
- * - Passing data across boundaries where YJS types aren't available
- * - Input validation before converting to YJS types
- *
- * The `id` field is explicitly typed as `string` since all TableSchemas require
- * an IdColumnSchema for the id field, which always serializes to string.
- *
- * @example
- * ```typescript
- * type PostSchema = {
- *   id: { type: 'id' };
- *   title: { type: 'ytext'; nullable: false };
- *   tags: { type: 'multi-select'; options: ['a', 'b']; nullable: false };
- *   publishedAt: { type: 'date'; nullable: false };
- * };
- *
- * type SerializedPost = SerializedRow<PostSchema>;
- * // { id: string; title: string; tags: string[]; publishedAt: DateWithTimezoneString }
- * ```
- */
 export type SerializedRow<TTableSchema extends TableSchema = TableSchema> = {
 	[K in keyof TTableSchema]: K extends 'id'
 		? string
 		: SerializedCellValue<TTableSchema[K]>;
 };
 
-/**
- * Represents a partial row update where id is required but all other fields are optional.
- *
- * Takes a TableSchema, converts it to SerializedRow to get the input variant,
- * then makes all fields except 'id' optional.
- *
- * Only the fields you include will be updated - the rest remain unchanged. Each field is
- * updated individually in the underlying YJS Map.
- *
- * @example
- * // Update only the title field, leaving other fields unchanged
- * db.posts.update({ id: '123', title: 'New Title' });
- *
- * @example
- * // Update multiple fields at once
- * db.posts.update({ id: '123', title: 'New Title', published: true });
- */
 export type PartialSerializedRow<
 	TTableSchema extends TableSchema = TableSchema,
 > = {
 	id: string;
 } & Partial<Omit<SerializedRow<TTableSchema>, 'id'>>;
 
-// ============================================================================
-// KV Schema Types
-// ============================================================================
-
-/**
- * Column schema types allowed in KV stores.
- *
- * KV stores use the same column types as tables, except `id` columns are not
- * allowed since the key name itself serves as the identifier.
- */
 export type KvColumnSchema = Exclude<ColumnSchema, IdColumnSchema>;
 
-/**
- * KV schema - maps key names to their column schemas.
- *
- * Unlike tables which require an `id` column, KV schemas map key names directly
- * to value types. Each key is a singleton value, not a collection of rows.
- *
- * @example
- * ```typescript
- * const kvSchema = {
- *   theme: text({ default: 'light' }),
- *   locale: text({ default: 'en-US' }),
- *   lastSyncAt: date({ nullable: true }),
- *   currentDraft: ytext({ nullable: true }),
- * } satisfies KvSchema;
- * ```
- */
 export type KvSchema = Record<string, KvColumnSchema>;
 
-/**
- * Maps a KvColumnSchema to its value type (Y.js types or primitives).
- *
- * This is the same as CellValue but for KV schemas (which exclude id columns).
- *
- * @example
- * ```typescript
- * type ThemeValue = KvValue<TextColumnSchema<false>>; // string
- * type DraftValue = KvValue<YtextColumnSchema<true>>; // Y.Text | null
- * ```
- */
 export type KvValue<C extends KvColumnSchema = KvColumnSchema> = CellValue<C>;
 
-/**
- * Maps a KvColumnSchema to its serialized value type.
- *
- * This is the same as SerializedCellValue but for KV schemas.
- *
- * @example
- * ```typescript
- * type ThemeSerialized = SerializedKvValue<TextColumnSchema<false>>; // string
- * type DraftSerialized = SerializedKvValue<YtextColumnSchema<true>>; // string | null
- * ```
- */
 export type SerializedKvValue<C extends KvColumnSchema = KvColumnSchema> =
 	SerializedCellValue<C>;

--- a/packages/epicenter/src/core/utils/yjs.ts
+++ b/packages/epicenter/src/core/utils/yjs.ts
@@ -268,14 +268,17 @@ export function updateYRowFromSerializedRow<TSchema extends TableSchema>({
 
 			const columnSchema = schema[fieldName];
 
-			if (columnSchema?.type === 'ytext' && typeof value === 'string') {
+			if (
+				columnSchema?.['x-component'] === 'ytext' &&
+				typeof value === 'string'
+			) {
 				const ytext = existing instanceof Y.Text ? existing : new Y.Text();
 				if (!(existing instanceof Y.Text)) {
 					yrow.set(fieldName, ytext);
 				}
 				updateYTextFromString(ytext, value);
 			} else if (
-				columnSchema?.type === 'date' &&
+				columnSchema?.['x-component'] === 'date' &&
 				isDateWithTimezoneString(value)
 			) {
 				if (existing !== value) {

--- a/packages/epicenter/src/core/workspace/config.ts
+++ b/packages/epicenter/src/core/workspace/config.ts
@@ -151,7 +151,7 @@ export function defineWorkspace<
 
 	if (workspace.kv) {
 		for (const [keyName, columnSchema] of Object.entries(workspace.kv)) {
-			if (columnSchema.type === 'id') {
+			if (columnSchema['x-component'] === 'id') {
 				throw new Error(
 					`KV key "${keyName}" uses "id()" column type, which is not allowed in KV schemas. Use text(), integer(), or other value types instead.`,
 				);

--- a/skills/documentation/SKILL.md
+++ b/skills/documentation/SKILL.md
@@ -5,6 +5,88 @@ description: Technical writing, README guidelines, and punctuation rules. Use wh
 
 # Documentation & README Writing Guidelines
 
+## Technical Article Structure (Deep Dive Articles)
+
+When writing technical articles that explain a concept or pattern, use this structure:
+
+### 1. TL;DR First
+
+Start with a 1-2 sentence summary that a busy reader can skim. Bold the key insight.
+
+```markdown
+**TL;DR**: If you need to know what an API can do without running it, don't wrap definitions in functions. Use static objects for metadata, functions for execution.
+```
+
+### 2. Problem-First Opening
+
+Drop the reader into a scenario where they feel the pain. Don't start with definitions.
+
+```markdown
+❌ "Introspection is the ability to examine an API's capabilities..."
+✅ "You're building a CLI. You want to show --help. You reach for your config and realize you have a problem."
+```
+
+### 3. Name Your Concepts
+
+Give memorable names to problems and patterns. This makes them discussable and searchable.
+
+- "The Introspection Boundary"
+- "The Boot-Loop Trap"
+- "The Accessor Pattern"
+
+### 4. Use ❌/✅ Comparison Blocks
+
+Show bad code, then good code. Label them clearly.
+
+```markdown
+### ❌ The "Function-Wrapped" API
+
+[code that has the problem]
+
+### ✅ The "Static Structure" API
+
+[code that solves it]
+```
+
+### 5. Address Common Misconceptions
+
+If readers often confuse two related concepts, call it out explicitly:
+
+```markdown
+## Type Inference is NOT Introspection
+
+Intermediate developers often confuse these...
+```
+
+### 6. Use One Analogy Consistently
+
+Pick a concrete analogy (restaurant menu, filing cabinet, etc.) and reference it throughout. Don't switch analogies mid-article.
+
+### 7. Include a Trade-offs Table
+
+For pattern comparisons, summarize with a table:
+
+```markdown
+| Approach | Introspectable | Flexible | DI Support |
+| -------- | -------------- | -------- | ---------- |
+| Static   | ✅ Yes         | ❌ No    | ❌ No      |
+| Callback | ❌ No          | ✅ Yes   | ✅ Yes     |
+```
+
+### 8. End with a "Golden Rule"
+
+Distill to one memorable principle:
+
+```markdown
+## The Golden Rule: Metadata Static, Execution Dynamic
+```
+
+### 9. Multiple Concrete Examples
+
+Don't just show one example. Show 2-3 different scenarios where the same principle applies. This helps readers generalize.
+
+---
+
 ## Voice Matching Priority
 
 When the user provides a voice transcript, tone guidance, or example text to match, that takes priority over all other rules below. Match their voice exactly:
@@ -22,11 +104,13 @@ Not every article needs a story arc. Some are just direct statements of practice
 Not every article needs a personal narrative. Choose based on content type:
 
 **Instructional (second person)**: Use for pattern explanations, best practices, guidelines.
+
 - "When you have related functions, you use a factory pattern"
 - "You can import X directly, but the relationship is implicit"
 - Direct, generalizable, focused on the pattern itself
 
 **Narrative (first person)**: Use for experience reports, lessons learned, project retrospectives.
+
 - "I was building X and hit this decision"
 - "Here's what I realized after debugging for hours"
 - Personal, story-driven, focused on the journey
@@ -249,3 +333,86 @@ So I built Whispering to cut out the middleman. You bring your own API key, your
 - Bad: "This was built to..." (corporate)
 - Good: "$0.02/hour" (specific)
 - Bad: "affordable pricing" (vague)
+
+---
+
+## Prompting Document-Writer Agents
+
+When delegating article writing to a `document-writer` subagent, structure your prompt for best results:
+
+### Required Elements
+
+1. **Target audience**: Who is reading? What do they already know?
+
+   ```
+   "Developers intermediate in TypeScript but new to API design trade-offs"
+   ```
+
+2. **Numbered themes**: List 5-8 specific topics to cover
+
+   ```
+   1. What is introspection?
+   2. The fundamental tension (functions vs objects)
+   3. Example 1: Workspace system
+   4. Example 2: Standard Schema
+   ...
+   ```
+
+3. **Code examples in prompt**: Provide ❌/✅ patterns for the agent to expand on
+
+   ```typescript
+   // ❌ Cannot introspect
+   actions: (ctx) => ({ create: { handler: () => ctx.db.insert() } });
+
+   // ✅ Can introspect
+   actions: {
+   	create: {
+   		handler: (input, ctx) => ctx.db.insert();
+   	}
+   }
+   ```
+
+4. **Style constraints**: Word count, TL;DR requirement, analogy suggestions
+
+   ```
+   "~1500-2000 words, include TL;DR at top, use restaurant menu analogy"
+   ```
+
+5. **Exact output path**: No ambiguity
+   ```
+   "Save to: /path/to/docs/articles/my-article.md"
+   ```
+
+### Example Full Prompt
+
+```
+Write a beginner-friendly technical article about [CONCEPT].
+
+**Target audience**: [WHO] who are [SKILL LEVEL] in [TOPIC].
+
+**Title suggestion**: "[CATCHY TITLE]"
+
+**Key themes to cover**:
+1. [THEME 1]
+2. [THEME 2]
+...
+
+**Concrete examples**:
+[CODE BLOCK showing bad approach]
+[CODE BLOCK showing good approach]
+
+**Style**:
+- Use code examples liberally
+- ~1500-2000 words
+- Include TL;DR at top
+- Use [SPECIFIC ANALOGY] throughout
+
+**Output**: /path/to/file.md
+```
+
+### What NOT to Do
+
+- Don't just say "write an article about X" (too vague)
+- Don't skip code examples (agent will make up worse ones)
+- Don't forget the audience (tone will be wrong)
+- Don't omit output path (creates confusion)

--- a/specs/20251231T173000-introspection-boundary-article.md
+++ b/specs/20251231T173000-introspection-boundary-article.md
@@ -1,0 +1,52 @@
+# Spec: The Introspection Boundary Article
+
+Write a technical article about the trade-offs between static objects and functions for API design, focusing on introspection.
+
+## Background
+
+In the Epicenter codebase (specifically `packages/epicenter`), there's a recurring pattern where workspace actions are defined using a factory function: `actions: ({ tables, providers }) => ({ ... })`. While this provides great flexibility and dependency injection, it makes "introspection" (discovering what actions exist without running the system) difficult.
+
+## Objectives
+
+- Explain what introspection is and why it matters.
+- Compare static objects vs. callback functions for API definitions.
+- Provide concrete examples from Epicenter-like architectures and Standard Schema.
+- Offer practical guidance on where to draw the "introspection boundary".
+
+## Proposed Content Structure
+
+1. **TL;DR**: Quick summary of the core advice (metadata static, execution dynamic).
+2. **Introduction**: The "Restaurant Menu" analogy.
+3. **What is Introspection?**: Define it in terms of CLI help, IDE autocomplete, and MCP registration.
+4. **The Tension**: Why we love functions (composability) and why they fail at discovery.
+5. **Case Study 1: The Epicenter Workspace**:
+   - Show the `actions: (context) => ({ ... })` pattern.
+   - Explain why listing actions requires full system initialization.
+   - Show the better alternative: static metadata + dynamic handlers.
+6. **Case Study 2: Standard Schema**:
+   - Explain the `~standard` property.
+   - How it uses static version/vendor info but dynamic validation.
+7. **Case Study 3: CLI Help**:
+   - The problem of connecting to a DB just to print `--help`.
+8. **Trade-offs Table**: Comparison of approaches.
+9. **The Golden Rule**: Metadata static, execution dynamic.
+10. **Conclusion**: When to use each approach.
+
+## Tasks
+
+- [x] Research specific Epicenter action definitions for realistic examples
+- [x] Draft the article content in `docs/articles/introspection-boundary.md`
+- [x] Verify technical accuracy of code examples
+- [x] Review for tone and clarity (following the "strong opinionated" technical writer style)
+
+## Review
+
+The article "The Introspection Boundary: Where Functions Kill Discoverability" has been written and saved to `docs/articles/introspection-boundary.md`.
+
+### Key highlights:
+
+- Word count: 1887 words (fits the 1500-2000 target).
+- Style: Direct, factual, and opinionated, following the repository's established technical writing style.
+- Content: Covers introspection definition, the fundamental tension, 3 concrete examples (Epicenter workspaces, Standard Schema, CLI help), and the "Golden Rule".
+- Punctuation: Adheres to the punctuation guidelines (avoiding AI artifacts like " - ").
+- Examples: Use the requested "❌" and "✅" pattern with technically accurate Epicenter-inspired code.


### PR DESCRIPTION
This PR refactors the schema system to be fully Standard Schema compliant while adopting JSON Schema conventions for better interoperability.

**Key Changes:**

1. **Discriminant Migration**: Changed from `type` to `x-component` as the schema discriminant, following JSON Schema extension conventions. This avoids collision with JSON Schema's native `type` field.

2. **Nullability via JSON Schema**: Replaced the separate `nullable` boolean with JSON Schema's native type array pattern:
   - Non-nullable: `type: 'string'`  
   - Nullable: `type: ['string', 'null']`

3. **Standard Schema Integration**: Every column schema now includes a `~standard` property with:
   - `validate()` for runtime validation
   - `jsonSchema.input/output()` for JSON Schema serialization

4. **DRY Helper**: Introduced `createColumnSchema()` to eliminate duplication between the schema object and its JSON Schema representation.

**Migration Examples:**

```typescript
// Before
{ type: 'text', nullable: true }

// After  
{ 'x-component': 'text', type: ['string', 'null'], '~standard': {...} }
```

**Files Changed:**
- `core/schema/types.ts` - Updated type definitions
- `core/schema/columns.ts` - Factory functions with Standard Schema
- `core/schema/converters/*` - Updated to use `x-component` discriminant
- `core/schema/nullability.ts` - New `isNullableColumnSchema()` helper

This enables MCP/OpenAPI export compatibility and positions the schema system for future UI generation from schemas.