### PR TITLE
fix(whispering): use Modal instead of Dialog for mobile-friendly UI

### DIFF
--- a/apps/whispering/src/lib/components/MoreDetailsDialog.svelte
+++ b/apps/whispering/src/lib/components/MoreDetailsDialog.svelte
@@ -58,20 +58,20 @@
 </script>
 
 <script lang="ts">
-	import * as Dialog from '@epicenter/ui/dialog';
+	import * as Modal from '@epicenter/ui/modal';
 	import { Button } from '@epicenter/ui/button';
 </script>
 
-<Dialog.Root bind:open={moreDetailsDialog.isOpen}>
-	<Dialog.Content class="sm:max-w-xl">
-		<Dialog.Header>
-			<Dialog.Title>{moreDetailsDialog.title}</Dialog.Title>
-			<Dialog.Description>{moreDetailsDialog.description}</Dialog.Description>
-		</Dialog.Header>
+<Modal.Root bind:open={moreDetailsDialog.isOpen}>
+	<Modal.Content class="sm:max-w-xl">
+		<Modal.Header>
+			<Modal.Title>{moreDetailsDialog.title}</Modal.Title>
+			<Modal.Description>{moreDetailsDialog.description}</Modal.Description>
+		</Modal.Header>
 		<pre
 			class="bg-muted relative whitespace-pre-wrap break-words rounded p-4 pr-12 font-mono text-sm overflow-x-auto">{moreDetailsDialog.content}</pre>
 		{#if moreDetailsDialog.buttons.length !== 0}
-			<Dialog.Footer>
+			<Modal.Footer>
 				{#each moreDetailsDialog.buttons as button}
 					<Button
 						variant={button.variant}
@@ -83,7 +83,7 @@
 						{button.label}
 					</Button>
 				{/each}
-			</Dialog.Footer>
+			</Modal.Footer>
 		{/if}
-	</Dialog.Content>
-</Dialog.Root>
+	</Modal.Content>
+</Modal.Root>

--- a/apps/whispering/src/lib/components/NotificationLog.svelte
+++ b/apps/whispering/src/lib/components/NotificationLog.svelte
@@ -26,7 +26,7 @@
 
 <script lang="ts">
 	import * as Alert from '@epicenter/ui/alert';
-	import * as Dialog from '@epicenter/ui/dialog';
+	import * as Modal from '@epicenter/ui/modal';
 	import * as Empty from '@epicenter/ui/empty';
 	import type { UnifiedNotificationOptions } from '$lib/services/isomorphic/notifications/types';
 	import { ScrollArea } from '@epicenter/ui/scroll-area';
@@ -39,12 +39,12 @@
 	import { mode } from 'mode-watcher';
 </script>
 
-<Dialog.Root bind:open={notificationLog.isOpen}>
-	<Dialog.Content class="max-w-md">
-		<Dialog.Header>
-			<Dialog.Title>Notification History</Dialog.Title>
-			<Dialog.Description>View past notifications</Dialog.Description>
-		</Dialog.Header>
+<Modal.Root bind:open={notificationLog.isOpen}>
+	<Modal.Content class="max-w-md">
+		<Modal.Header>
+			<Modal.Title>Notification History</Modal.Title>
+			<Modal.Description>View past notifications</Modal.Description>
+		</Modal.Header>
 
 		<ScrollArea
 			class="h-[60vh] overflow-y-auto rounded-md border bg-background p-4"
@@ -108,8 +108,8 @@
 				</Empty.Root>
 			{/if}
 		</ScrollArea>
-	</Dialog.Content>
-</Dialog.Root>
+	</Modal.Content>
+</Modal.Root>
 
 <style>
 	:global([data-slot='dialog-content'] [data-sonner-toast]) {

--- a/apps/whispering/src/lib/components/copyable/TextPreviewDialog.svelte
+++ b/apps/whispering/src/lib/components/copyable/TextPreviewDialog.svelte
@@ -2,7 +2,7 @@
 	import { createCopyFn } from '$lib/utils/createCopyFn';
 	import { Button } from '@epicenter/ui/button';
 	import { CopyButton } from '@epicenter/ui/copy-button';
-	import * as Dialog from '@epicenter/ui/dialog';
+	import * as Modal from '@epicenter/ui/modal';
 	import * as InputGroup from '@epicenter/ui/input-group';
 	import { Spinner } from '@epicenter/ui/spinner';
 	import { Textarea } from '@epicenter/ui/textarea';
@@ -64,9 +64,9 @@
 	let isDialogOpen = $state(false);
 </script>
 
-<Dialog.Root bind:open={isDialogOpen}>
+<Modal.Root bind:open={isDialogOpen}>
 	<InputGroup.Root data-disabled={disabled || loading}>
-		<Dialog.Trigger {id} disabled={disabled || loading} class="flex-1 min-w-0">
+		<Modal.Trigger {id} disabled={disabled || loading} class="flex-1 min-w-0">
 			{#snippet child({ props })}
 				<textarea
 					{...props}
@@ -80,7 +80,7 @@
 					aria-label="Click to view {label}"
 				></textarea>
 			{/snippet}
-		</Dialog.Trigger>
+		</Modal.Trigger>
 		<InputGroup.Addon align="inline-end">
 			{#if loading}
 				<Spinner />
@@ -94,10 +94,10 @@
 			{/if}
 		</InputGroup.Addon>
 	</InputGroup.Root>
-	<Dialog.Content class="max-w-4xl">
-		<Dialog.Title>{title}</Dialog.Title>
+	<Modal.Content class="max-w-4xl">
+		<Modal.Title>{title}</Modal.Title>
 		<Textarea readonly value={text} rows={20} />
-		<Dialog.Footer>
+		<Modal.Footer>
 			<Button variant="outline" onclick={() => (isDialogOpen = false)}>
 				Close
 			</Button>
@@ -112,6 +112,6 @@
 			>
 				Copy Text
 			</CopyButton>
-		</Dialog.Footer>
-	</Dialog.Content>
-</Dialog.Root>
+		</Modal.Footer>
+	</Modal.Content>
+</Modal.Root>

--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -9,7 +9,7 @@
 	import * as ButtonGroup from '@epicenter/ui/button-group';
 	import { Card } from '@epicenter/ui/card';
 	import { Checkbox } from '@epicenter/ui/checkbox';
-	import * as Dialog from '@epicenter/ui/dialog';
+	import * as Modal from '@epicenter/ui/modal';
 	import * as DropdownMenu from '@epicenter/ui/dropdown-menu';
 	import { Input } from '@epicenter/ui/input';
 	import { Label } from '@epicenter/ui/label';
@@ -449,11 +449,11 @@
 						{/if}
 					</Button>
 
-					<Dialog.Root
+					<Modal.Root
 						open={isDialogOpen}
 						onOpenChange={(v) => (isDialogOpen = v)}
 					>
-						<Dialog.Trigger>
+						<Modal.Trigger>
 							<Button
 								tooltip="Copy transcripts from selected recordings"
 								variant="outline"
@@ -461,15 +461,15 @@
 							>
 								<CopyIcon class="size-4" />
 							</Button>
-						</Dialog.Trigger>
-						<Dialog.Content>
-							<Dialog.Header>
-								<Dialog.Title>Copy Transcripts</Dialog.Title>
-								<Dialog.Description>
+						</Modal.Trigger>
+						<Modal.Content>
+							<Modal.Header>
+								<Modal.Title>Copy Transcripts</Modal.Title>
+								<Modal.Description>
 									Make changes to your profile here. Click save when you're
 									done.
-								</Dialog.Description>
-							</Dialog.Header>
+								</Modal.Description>
+							</Modal.Header>
 							<div class="grid gap-4 py-4">
 								<div class="grid grid-cols-4 items-center gap-4">
 									<Label for="template" class="text-right">Template</Label>
@@ -494,7 +494,7 @@
 								class="h-32"
 								value={joinedTranscriptionsText}
 							/>
-							<Dialog.Footer>
+							<Modal.Footer>
 								<CopyButton
 									text={joinedTranscriptionsText}
 									copyFn={createCopyFn('transcripts')}
@@ -505,9 +505,9 @@
 								>
 									Copy Transcriptions
 								</CopyButton>
-							</Dialog.Footer>
-						</Dialog.Content>
-					</Dialog.Root>
+							</Modal.Footer>
+						</Modal.Content>
+					</Modal.Root>
 
 					<Button
 						tooltip="Delete selected recordings"

--- a/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/ViewTransformationRunsDialog.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/ViewTransformationRunsDialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Runs } from '$lib/components/transformations-editor';
 	import { Button } from '@epicenter/ui/button';
-	import * as Dialog from '@epicenter/ui/dialog';
+	import * as Modal from '@epicenter/ui/modal';
 	import { rpc } from '$lib/query';
 	import { createQuery } from '@tanstack/svelte-query';
 	import HistoryIcon from '@lucide/svelte/icons/history';
@@ -15,8 +15,8 @@
 	let isOpen = $state(false);
 </script>
 
-<Dialog.Root bind:open={isOpen}>
-	<Dialog.Trigger>
+<Modal.Root bind:open={isOpen}>
+	<Modal.Trigger>
 		{#snippet child({ props })}
 			<Button
 				{...props}
@@ -27,14 +27,14 @@
 				<HistoryIcon class="size-4" />
 			</Button>
 		{/snippet}
-	</Dialog.Trigger>
-	<Dialog.Content class="sm:max-w-4xl">
-		<Dialog.Header>
-			<Dialog.Title>Transformation Runs</Dialog.Title>
-			<Dialog.Description>
+	</Modal.Trigger>
+	<Modal.Content class="sm:max-w-4xl">
+		<Modal.Header>
+			<Modal.Title>Transformation Runs</Modal.Title>
+			<Modal.Description>
 				View all transformation runs for this recording
-			</Dialog.Description>
-		</Dialog.Header>
+			</Modal.Description>
+		</Modal.Header>
 		<div class="max-h-[60vh] overflow-y-auto">
 			{#if transformationRunsByRecordingIdQuery.isPending}
 				<div class="text-muted-foreground text-sm">Loading runs...</div>
@@ -46,8 +46,8 @@
 				<Runs runs={transformationRunsByRecordingIdQuery.data} />
 			{/if}
 		</div>
-		<Dialog.Footer>
+		<Modal.Footer>
 			<Button variant="outline" onclick={() => (isOpen = false)}>Close</Button>
-		</Dialog.Footer>
-	</Dialog.Content>
-</Dialog.Root>
+		</Modal.Footer>
+	</Modal.Content>
+</Modal.Root>

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutFormatHelp.svelte
@@ -2,7 +2,7 @@
 	import * as Alert from '@epicenter/ui/alert';
 	import { Button } from '@epicenter/ui/button';
 	import * as Kbd from '@epicenter/ui/kbd';
-	import * as Dialog from '@epicenter/ui/dialog';
+	import * as Modal from '@epicenter/ui/modal';
 	import {
 		ACCELERATOR_SECTIONS,
 		CommandOrAlt,
@@ -54,18 +54,18 @@
 	<span class="sr-only">Shortcut format help</span>
 </Button>
 
-<Dialog.Root bind:open={dialogOpen}>
-	<Dialog.Content class="sm:max-w-3xl">
-		<Dialog.Header>
-			<Dialog.Title>
+<Modal.Root bind:open={dialogOpen}>
+	<Modal.Content class="sm:max-w-3xl">
+		<Modal.Header>
+			<Modal.Title>
 				{isLocal ? 'Local' : 'Global'} Shortcut Format Guide
-			</Dialog.Title>
-			<Dialog.Description>
+			</Modal.Title>
+			<Modal.Description>
 				Learn how to format keyboard shortcuts for {isLocal
 					? 'in-app'
 					: 'system-wide'} use.
-			</Dialog.Description>
-		</Dialog.Header>
+			</Modal.Description>
+		</Modal.Header>
 
 		<div class="flex flex-col gap-4">
 			<!-- Quick format summary -->
@@ -149,7 +149,7 @@
 			{/if}
 		</div>
 
-		<Dialog.Footer>
+		<Modal.Footer>
 			{#if !isLocal}
 				<Button
 					variant="outline"
@@ -162,6 +162,6 @@
 				</Button>
 			{/if}
 			<Button onclick={() => (dialogOpen = false)}>Close</Button>
-		</Dialog.Footer>
-	</Dialog.Content>
-</Dialog.Root>
+		</Modal.Footer>
+	</Modal.Content>
+</Modal.Root>

--- a/apps/whispering/src/routes/(app)/(config)/transformations/CreateTransformationButton.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/transformations/CreateTransformationButton.svelte
@@ -2,7 +2,7 @@
 	import { confirmationDialog } from '$lib/components/ConfirmationDialog.svelte';
 	import { Editor } from '$lib/components/transformations-editor';
 	import { Button } from '@epicenter/ui/button';
-	import * as Dialog from '@epicenter/ui/dialog';
+	import * as Modal from '@epicenter/ui/modal';
 	import { Separator } from '@epicenter/ui/separator';
 	import { rpc } from '$lib/query';
 	import { generateDefaultTransformation } from '$lib/services/isomorphic/db';
@@ -13,7 +13,7 @@
 		() => rpc.db.transformations.create.options,
 	);
 
-	let isDialogOpen = $state(false);
+	let isModalOpen = $state(false);
 	let transformation = $state(generateDefaultTransformation());
 
 	function promptUserConfirmLeave() {
@@ -22,46 +22,46 @@
 			description: 'You have unsaved changes. Are you sure you want to leave?',
 			confirm: { text: 'Leave' },
 			onConfirm: () => {
-				isDialogOpen = false;
+				isModalOpen = false;
 			},
 		});
 	}
 </script>
 
-<Dialog.Root bind:open={isDialogOpen}>
-	<Dialog.Trigger>
+<Modal.Root bind:open={isModalOpen}>
+	<Modal.Trigger>
 		{#snippet child({ props })}
 			<Button {...props}>
 				<PlusIcon class="size-4" />
 				Create Transformation
 			</Button>
 		{/snippet}
-	</Dialog.Trigger>
+	</Modal.Trigger>
 
-	<Dialog.Content
+	<Modal.Content
 		class="max-h-[80vh] sm:max-w-7xl"
 		onEscapeKeydown={(e) => {
 			e.preventDefault();
-			if (isDialogOpen) {
+			if (isModalOpen) {
 				promptUserConfirmLeave();
 			}
 		}}
 		onInteractOutside={(e) => {
 			e.preventDefault();
-			if (isDialogOpen) {
+			if (isModalOpen) {
 				promptUserConfirmLeave();
 			}
 		}}
 	>
-		<Dialog.Header>
-			<Dialog.Title>Create Transformation</Dialog.Title>
+		<Modal.Header>
+			<Modal.Title>Create Transformation</Modal.Title>
 			<Separator />
-		</Dialog.Header>
+		</Modal.Header>
 
 		<Editor bind:transformation />
 
-		<Dialog.Footer>
-			<Button variant="outline" onclick={() => (isDialogOpen = false)}>
+		<Modal.Footer>
+			<Button variant="outline" onclick={() => (isModalOpen = false)}>
 				Cancel
 			</Button>
 			<Button
@@ -69,7 +69,7 @@
 				onclick={() =>
 					createTransformation.mutate($state.snapshot(transformation), {
 						onSuccess: () => {
-							isDialogOpen = false;
+							isModalOpen = false;
 							transformation = generateDefaultTransformation();
 							rpc.notify.success.execute({
 								title: 'Created transformation!',
@@ -88,6 +88,6 @@
 			>
 				Create
 			</Button>
-		</Dialog.Footer>
-	</Dialog.Content>
-</Dialog.Root>
+		</Modal.Footer>
+	</Modal.Content>
+</Modal.Root>

--- a/bun.lock
+++ b/bun.lock
@@ -380,7 +380,7 @@
     "turbo": "^2.6.1",
     "typescript": "^5.9.3",
     "vite": "^7.2.4",
-    "wellcrafted": "^0.29.0",
+    "wellcrafted": "^0.29.1",
     "wrangler": "^4.51.0",
     "yargs": "^18.0.0",
   },
@@ -2825,7 +2825,7 @@
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
-    "wellcrafted": ["wellcrafted@0.29.0", "", {}, "sha512-A7RveTHJN1yyXBblJjlo4HHE7WTQ2EVi7JyH+uEb0fg8PJp+bv9dJXlnEva9TMhE/1m0ib7WGGuixpuCtNAC7A=="],
+    "wellcrafted": ["wellcrafted@0.29.1", "", {}, "sha512-NAqtmAdZffcmiQqjy9uE7g67hpjkpN7l5uvU6F/JSAd2OfiqjPTDsiJBBlLbGo9w+UfSnGMnvP5TkH/sGqONkQ=="],
 
     "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
 


### PR DESCRIPTION
Convert content-heavy dialogs to Modal component which renders as a drawer on mobile (<768px) and dialog on desktop for better UX.

Affected dialogs:
- Create Transformation form
- View Transformation Runs history
- Text preview (transcript/transformation output)
- Keyboard Shortcut Format Guide
- Notification History
- Error/Content Details ("More Details")
- Copy Transcripts dialog

### Before

<img width="421" height="927" alt="image" src="https://github.com/user-attachments/assets/e73e1408-4b6c-41c6-b33a-018609bd4240" />

### After

<img width="427" height="928" alt="image" src="https://github.com/user-attachments/assets/28ef767f-7669-48b4-a007-e645c50d1ca7" />


## Summary

Dialogs were broken/unusable on mobile devices. This PR converts content-heavy dialogs to use the Modal component, which renders as a drawer on mobile (<768px) and a dialog on desktop.

## Type of Change

- [x] `fix`: Bug fix

## Related Issue

Closes #

## Changes Made

Converted 7 files from `Dialog` to `Modal`:

- **CreateTransformationButton.svelte** - Create Transformation form
- **ViewTransformationRunsDialog.svelte** - View Transformation Runs history
- **TextPreviewDialog.svelte** - Text preview (transcript/transformation output)
- **ShortcutFormatHelp.svelte** - Keyboard Shortcut Format Guide
- **NotificationLog.svelte** - Notification History
- **MoreDetailsDialog.svelte** - Error/Content Details ("More Details")
- **recordings/+page.svelte** - Copy Transcripts dialog

## Testing

### Desktop App Testing
- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] Not applicable (web-only change)

### General Testing
- [ ] Tested with multiple API providers (if applicable)
- [ ] Verified no API keys are exposed in logs or storage
- [x] Checked for console errors
- [x] Tested on different screen sizes (if UI change)

## Checklist

- [x] My code follows the project's coding standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I've used `type` instead of `interface` in TypeScript
- [x] I've used absolute imports where applicable
- [x] I've tested my changes thoroughly
- [ ] I've added/updated tests for my changes (if applicable)
- [x] My changes don't break existing functionality
- [ ] I've updated documentation (if needed)

## Screenshots/Recordings

<!-- Before/after screenshots of mobile drawer vs dialog would be helpful -->

## Additional Notes

The Modal component (from `@epicenter/ui/modal`) uses a media query to detect screen size and renders:
- **Desktop (≥768px)**: Standard dialog
- **Mobile (<768px)**: Vaul drawer (slides up from bottom)
