### PR TITLE
fix: trim trailing newlines when reading recordings from database

### DIFF
--- a/apps/whispering/src/lib/services/isomorphic/db/file-system.ts
+++ b/apps/whispering/src/lib/services/isomorphic/db/file-system.ts
@@ -55,7 +55,7 @@ function markdownToRecording({
 }): Recording {
 	return {
 		...frontMatter,
-		transcribedText: body,
+		transcribedText: body.trimEnd(),
 	};
 }
 


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does and why it's needed -->

Recordings stored with gray-matter include trailing newlines. When
read back, these newlines were preserved, causing an extra trailing
newline when copying transcribed text to clipboard.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `refactor`: Code refactoring (no functional changes)
- [ ] `perf`: Performance improvement
- [ ] `test`: Test additions or changes
- [ ] `chore`: Maintenance tasks
- [ ] `style`: Code style changes

## Related Issue

<!-- Link to the issue this PR addresses, if applicable -->
n/a

## Changes Made

<!-- Describe your changes in detail. What did you change and how? -->

This patch trims trailing whitespace when reading from the database.

## Testing

<!-- Describe the tests you ran to verify your changes -->

### Desktop App Testing
- [ ] Tested on macOS
- [ ] Tested on Windows
- [x] Tested on Linux
- [ ] Not applicable (web-only change)

### General Testing
- [ ] Tested with multiple API providers (if applicable)
- [x] Verified no API keys are exposed in logs or storage
- [x] Checked for console errors
- [ ] Tested on different screen sizes (if UI change)

## Checklist

<!-- Make sure you've completed these steps -->

- [x] My code follows the project's coding standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I've used `type` instead of `interface` in TypeScript
- [x] I've used absolute imports where applicable
- [x] I've tested my changes thoroughly
- [ ] I've added/updated tests for my changes (if applicable)
- [x] My changes don't break existing functionality
- [x] I've updated documentation (if needed)

## Screenshots/Recordings

<!-- If this is a UI change, please include screenshots or recordings -->
n/a

## Additional Notes

<!-- Any additional context, considerations, or discussion points -->

<!-- Message of single commit: -->

fix: trim trailing newlines when reading recordings from database

Recordings stored with gray-matter include trailing newlines. When
read back, these newlines were preserved, causing issues when copying
transcribed text to clipboard.

This patch trims trailing whitespace when reading from the database.