### PR TITLE
refactor(services): inline factory functions for single-use services

### DIFF
--- a/apps/whispering/src/lib/services/desktop/autostart.ts
+++ b/apps/whispering/src/lib/services/desktop/autostart.ts
@@ -16,40 +16,36 @@ export type AutostartServiceError = ReturnType<typeof AutostartServiceError>;
  * - Windows: Adds registry entry to HKEY_CURRENT_USER\...\Run
  * - Linux: Creates .desktop file in ~/.config/autostart/
  */
-export function createAutostartServiceDesktop() {
-	return {
-		/** Check if autostart is currently enabled for Whispering. */
-		isEnabled: () =>
-			tryAsync({
-				try: () => isEnabled(),
-				catch: (error) =>
-					AutostartServiceErr({
-						message: `Failed to check autostart status: ${extractErrorMessage(error)}`,
-					}),
-			}),
+export const AutostartServiceLive = {
+	/** Check if autostart is currently enabled for Whispering. */
+	isEnabled: () =>
+		tryAsync({
+			try: () => isEnabled(),
+			catch: (error) =>
+				AutostartServiceErr({
+					message: `Failed to check autostart status: ${extractErrorMessage(error)}`,
+				}),
+		}),
 
-		/** Enable autostart so Whispering launches on system login. */
-		enable: () =>
-			tryAsync({
-				try: () => enable(),
-				catch: (error) =>
-					AutostartServiceErr({
-						message: `Failed to enable autostart: ${extractErrorMessage(error)}`,
-					}),
-			}),
+	/** Enable autostart so Whispering launches on system login. */
+	enable: () =>
+		tryAsync({
+			try: () => enable(),
+			catch: (error) =>
+				AutostartServiceErr({
+					message: `Failed to enable autostart: ${extractErrorMessage(error)}`,
+				}),
+		}),
 
-		/** Disable autostart so Whispering does not launch on system login. */
-		disable: () =>
-			tryAsync({
-				try: () => disable(),
-				catch: (error) =>
-					AutostartServiceErr({
-						message: `Failed to disable autostart: ${extractErrorMessage(error)}`,
-					}),
-			}),
-	};
-}
+	/** Disable autostart so Whispering does not launch on system login. */
+	disable: () =>
+		tryAsync({
+			try: () => disable(),
+			catch: (error) =>
+				AutostartServiceErr({
+					message: `Failed to disable autostart: ${extractErrorMessage(error)}`,
+				}),
+		}),
+};
 
-export type AutostartService = ReturnType<typeof createAutostartServiceDesktop>;
-
-export const AutostartServiceLive = createAutostartServiceDesktop();
+export type AutostartService = typeof AutostartServiceLive;

--- a/apps/whispering/src/lib/services/desktop/command.ts
+++ b/apps/whispering/src/lib/services/desktop/command.ts
@@ -4,7 +4,7 @@ import type { Brand } from 'wellcrafted/brand';
 import { createTaggedError, extractErrorMessage } from 'wellcrafted/error';
 import { Err, Ok, tryAsync } from 'wellcrafted/result';
 
-export const { CommandServiceError, CommandServiceErr } = createTaggedError(
+export const { CommandServiceError, CommandServiceErr} = createTaggedError(
 	'CommandServiceError',
 );
 export type CommandServiceError = ReturnType<typeof CommandServiceError>;
@@ -21,80 +21,76 @@ export function asShellCommand(str: string): ShellCommand {
 	return str as ShellCommand;
 }
 
-export function createCommandServiceDesktop() {
-	return {
-		/**
-		 * Execute a command and wait for it to complete.
-		 *
-		 * Commands are parsed and executed directly without shell wrappers on all platforms.
-		 * On Windows, uses CREATE_NO_WINDOW flag to prevent console window flash.
-		 *
-		 * @param command - The command to execute (e.g., "ffmpeg -version")
-		 * @returns The command output (stdout/stderr/exit code) or an error
-		 * @see https://github.com/EpicenterHQ/epicenter/issues/815
-		 */
-		async execute(command: ShellCommand) {
-			console.log('[TS] execute: starting command:', command);
-			const { data, error } = await tryAsync({
-				try: async () => {
-					// Rust returns CommandOutput which matches ChildProcess<string> structure
-					const result = await invoke<ChildProcess<string>>('execute_command', {
-						command,
-					});
-					console.log('[TS] execute: completed with code:', result.code);
-					return result;
-				},
-				catch: (error) => {
-					console.error('[TS] execute: error:', error);
-					return CommandServiceErr({
-						message: 'Failed to execute command',
-					});
-				},
-			});
+export const CommandServiceLive = {
+	/**
+	 * Execute a command and wait for it to complete.
+	 *
+	 * Commands are parsed and executed directly without shell wrappers on all platforms.
+	 * On Windows, uses CREATE_NO_WINDOW flag to prevent console window flash.
+	 *
+	 * @param command - The command to execute (e.g., "ffmpeg -version")
+	 * @returns The command output (stdout/stderr/exit code) or an error
+	 * @see https://github.com/EpicenterHQ/epicenter/issues/815
+	 */
+	async execute(command: ShellCommand) {
+		console.log('[TS] execute: starting command:', command);
+		const { data, error } = await tryAsync({
+			try: async () => {
+				// Rust returns CommandOutput which matches ChildProcess<string> structure
+				const result = await invoke<ChildProcess<string>>('execute_command', {
+					command,
+				});
+				console.log('[TS] execute: completed with code:', result.code);
+				return result;
+			},
+			catch: (error) => {
+				console.error('[TS] execute: error:', error);
+				return CommandServiceErr({
+					message: 'Failed to execute command',
+				});
+			},
+		});
 
-			if (error) return Err(error);
-			return Ok(data);
-		},
+		if (error) return Err(error);
+		return Ok(data);
+	},
 
-		/**
-		 * Spawn a child process without waiting for it to complete.
-		 *
-		 * Commands are parsed and executed directly without shell wrappers on all platforms.
-		 * On Windows, uses CREATE_NO_WINDOW flag to prevent console window flash.
-		 * Returns a Child instance that can be used to control the process.
-		 *
-		 * @param command - The command to spawn (e.g., "ffmpeg -f avfoundation -i :0 output.wav")
-		 * @returns A Child process handle or an error
-		 * @see https://github.com/EpicenterHQ/epicenter/issues/815
-		 */
-		async spawn(command: ShellCommand) {
-			console.log('[TS] spawn: starting command:', command);
-			const { data, error } = await tryAsync({
-				try: async () => {
-					// Rust returns just the PID (u32)
-					const pid = await invoke<number>('spawn_command', { command });
-					console.log('[TS] spawn: received PID:', pid);
+	/**
+	 * Spawn a child process without waiting for it to complete.
+	 *
+	 * Commands are parsed and executed directly without shell wrappers on all platforms.
+	 * On Windows, uses CREATE_NO_WINDOW flag to prevent console window flash.
+	 * Returns a Child instance that can be used to control the process.
+	 *
+	 * @param command - The command to spawn (e.g., "ffmpeg -f avfoundation -i :0 output.wav")
+	 * @returns A Child process handle or an error
+	 * @see https://github.com/EpicenterHQ/epicenter/issues/815
+	 */
+	async spawn(command: ShellCommand) {
+		console.log('[TS] spawn: starting command:', command);
+		const { data, error } = await tryAsync({
+			try: async () => {
+				// Rust returns just the PID (u32)
+				const pid = await invoke<number>('spawn_command', { command });
+				console.log('[TS] spawn: received PID:', pid);
 
-					// Wrap the PID in a Child instance for process control
-					const { Child } = await import('@tauri-apps/plugin-shell');
-					const child = new Child(pid);
-					console.log('[TS] spawn: wrapped PID in Child instance');
-					return child as Child;
-				},
-				catch: (error) => {
-					console.error('[TS] spawn: error:', error);
-					return CommandServiceErr({
-						message: `Failed to spawn command: ${extractErrorMessage(error)}`,
-					});
-				},
-			});
+				// Wrap the PID in a Child instance for process control
+				const { Child } = await import('@tauri-apps/plugin-shell');
+				const child = new Child(pid);
+				console.log('[TS] spawn: wrapped PID in Child instance');
+				return child as Child;
+			},
+			catch: (error) => {
+				console.error('[TS] spawn: error:', error);
+				return CommandServiceErr({
+					message: `Failed to spawn command: ${extractErrorMessage(error)}`,
+				});
+			},
+		});
 
-			if (error) return Err(error);
-			return Ok(data);
-		},
-	};
-}
+		if (error) return Err(error);
+		return Ok(data);
+	},
+};
 
-export type CommandService = ReturnType<typeof createCommandServiceDesktop>;
-
-export const CommandServiceLive = createCommandServiceDesktop();
+export type CommandService = typeof CommandServiceLive;

--- a/apps/whispering/src/lib/services/desktop/ffmpeg.ts
+++ b/apps/whispering/src/lib/services/desktop/ffmpeg.ts
@@ -12,140 +12,136 @@ export const { FfmpegServiceErr, FfmpegServiceError } =
 
 export type FfmpegServiceError = ReturnType<typeof FfmpegServiceError>;
 
-export function createFfmpegService() {
-	return {
-		/**
-		 * Checks if FFmpeg is installed on the system.
-		 * @returns Ok(true) if installed, Ok(false) if not installed.
-		 */
-		async checkInstalled() {
-			const { data: shellFfmpegProcess, error: shellFfmpegError } =
-				await tryAsync({
-					try: async () => {
-						const { data: result, error: commandError } =
-							await CommandServiceLive.execute(
-								asShellCommand('ffmpeg -version'),
-							);
-
-						if (commandError) throw commandError;
-						return result;
-					},
-					catch: (error) =>
-						FfmpegServiceErr({
-							message: `Unable to determine if FFmpeg is installed through shell. ${extractErrorMessage(error)}`,
-						}),
-				});
-
-			if (shellFfmpegError) return Err(shellFfmpegError);
-			return Ok(shellFfmpegProcess.code === 0);
-		},
-
-		/**
-		 * Compresses an audio blob using FFmpeg with the specified compression options.
-		 * Creates temporary files for processing and returns a compressed audio blob.
-		 *
-		 * @param blob - The input audio blob to compress
-		 * @param compressionOptions - FFmpeg compression options (e.g., "-c:a libopus -b:a 32k -ar 16000 -ac 1")
-		 * @returns A Result containing the compressed blob or an error
-		 */
-		async compressAudioBlob(blob: Blob, compressionOptions: string) {
-			return await tryAsync({
+export const FfmpegServiceLive = {
+	/**
+	 * Checks if FFmpeg is installed on the system.
+	 * @returns Ok(true) if installed, Ok(false) if not installed.
+	 */
+	async checkInstalled() {
+		const { data: shellFfmpegProcess, error: shellFfmpegError } =
+			await tryAsync({
 				try: async () => {
-					// Generate unique filenames for temporary files
-					const sessionId = nanoid();
-					const tempDir = await appDataDir();
-					const inputPath = await join(
-						tempDir,
-						`compression_input_${sessionId}.wav`,
-					);
+					const { data: result, error: commandError } =
+						await CommandServiceLive.execute(
+							asShellCommand('ffmpeg -version'),
+						);
 
-					// Determine output extension and path based on compression options
-					const outputExtension =
-						getFileExtensionFromFfmpegOptions(compressionOptions);
-					const outputPath = await join(
-						tempDir,
-						`compression_output_${sessionId}.${outputExtension}`,
-					);
-
-					try {
-						// Write input blob to temporary file
-						const inputContents = new Uint8Array(await blob.arrayBuffer());
-						await writeFile(inputPath, inputContents);
-
-						// Verify file is accessible (forces OS flush on Windows)
-						const { error: verifyError } = await tryAsync({
-							try: () => FsServiceLive.pathToBlob(inputPath),
-							catch: (error) =>
-								FfmpegServiceErr({
-									message: `Temp file not accessible: ${extractErrorMessage(error)}`,
-								}),
-						});
-						if (verifyError) throw new Error(verifyError.message);
-
-						// Build FFmpeg command for compression using the utility function
-						const command = buildCompressionCommand({
-							inputPath,
-							compressionOptions,
-							outputPath,
-						});
-
-						// Execute FFmpeg compression command
-						const { data: result, error: commandError } =
-							await CommandServiceLive.execute(asShellCommand(command));
-						if (commandError) {
-							throw new Error(
-								`FFmpeg compression failed: ${commandError.message}`,
-							);
-						}
-
-						// Check if FFmpeg command was successful
-						if (result.code !== 0) {
-							throw new Error(
-								`FFmpeg compression failed with exit code ${result.code}: ${result.stderr}`,
-							);
-						}
-
-						// Verify output file exists
-						const outputExists = await exists(outputPath);
-						if (!outputExists) {
-							throw new Error(
-								'FFmpeg compression completed but output file was not created',
-							);
-						}
-
-						// Read compressed file back as blob
-						const { data: compressedBlob, error: readError } =
-							await FsServiceLive.pathToBlob(outputPath);
-						if (readError) {
-							throw new Error(
-								`Failed to read compressed audio file: ${readError.message}`,
-							);
-						}
-
-						return compressedBlob;
-					} finally {
-						// Clean up temporary files
-						await tryAsync({
-							try: async () => {
-								if (await exists(inputPath)) await remove(inputPath);
-								if (await exists(outputPath)) await remove(outputPath);
-							},
-							catch: () => Ok(undefined), // Ignore cleanup errors
-						});
-					}
+					if (commandError) throw commandError;
+					return result;
 				},
 				catch: (error) =>
 					FfmpegServiceErr({
-						message: `Audio compression failed: ${extractErrorMessage(error)}`,
+						message: `Unable to determine if FFmpeg is installed through shell. ${extractErrorMessage(error)}`,
 					}),
 			});
-		},
-	};
-}
 
-export type FfmpegService = ReturnType<typeof createFfmpegService>;
+		if (shellFfmpegError) return Err(shellFfmpegError);
+		return Ok(shellFfmpegProcess.code === 0);
+	},
 
-export const FfmpegServiceLive = createFfmpegService();
+	/**
+	 * Compresses an audio blob using FFmpeg with the specified compression options.
+	 * Creates temporary files for processing and returns a compressed audio blob.
+	 *
+	 * @param blob - The input audio blob to compress
+	 * @param compressionOptions - FFmpeg compression options (e.g., "-c:a libopus -b:a 32k -ar 16000 -ac 1")
+	 * @returns A Result containing the compressed blob or an error
+	 */
+	async compressAudioBlob(blob: Blob, compressionOptions: string) {
+		return await tryAsync({
+			try: async () => {
+				// Generate unique filenames for temporary files
+				const sessionId = nanoid();
+				const tempDir = await appDataDir();
+				const inputPath = await join(
+					tempDir,
+					`compression_input_${sessionId}.wav`,
+				);
+
+				// Determine output extension and path based on compression options
+				const outputExtension =
+					getFileExtensionFromFfmpegOptions(compressionOptions);
+				const outputPath = await join(
+					tempDir,
+					`compression_output_${sessionId}.${outputExtension}`,
+				);
+
+				try {
+					// Write input blob to temporary file
+					const inputContents = new Uint8Array(await blob.arrayBuffer());
+					await writeFile(inputPath, inputContents);
+
+					// Verify file is accessible (forces OS flush on Windows)
+					const { error: verifyError } = await tryAsync({
+						try: () => FsServiceLive.pathToBlob(inputPath),
+						catch: (error) =>
+							FfmpegServiceErr({
+								message: `Temp file not accessible: ${extractErrorMessage(error)}`,
+							}),
+					});
+					if (verifyError) throw new Error(verifyError.message);
+
+					// Build FFmpeg command for compression using the utility function
+					const command = buildCompressionCommand({
+						inputPath,
+						compressionOptions,
+						outputPath,
+					});
+
+					// Execute FFmpeg compression command
+					const { data: result, error: commandError } =
+						await CommandServiceLive.execute(asShellCommand(command));
+					if (commandError) {
+						throw new Error(
+							`FFmpeg compression failed: ${commandError.message}`,
+						);
+					}
+
+					// Check if FFmpeg command was successful
+					if (result.code !== 0) {
+						throw new Error(
+							`FFmpeg compression failed with exit code ${result.code}: ${result.stderr}`,
+						);
+					}
+
+					// Verify output file exists
+					const outputExists = await exists(outputPath);
+					if (!outputExists) {
+						throw new Error(
+							'FFmpeg compression completed but output file was not created',
+						);
+					}
+
+					// Read compressed file back as blob
+					const { data: compressedBlob, error: readError } =
+						await FsServiceLive.pathToBlob(outputPath);
+					if (readError) {
+						throw new Error(
+							`Failed to read compressed audio file: ${readError.message}`,
+						);
+					}
+
+					return compressedBlob;
+				} finally {
+					// Clean up temporary files
+					await tryAsync({
+						try: async () => {
+							if (await exists(inputPath)) await remove(inputPath);
+							if (await exists(outputPath)) await remove(outputPath);
+						},
+						catch: () => Ok(undefined), // Ignore cleanup errors
+					});
+				}
+			},
+			catch: (error) =>
+				FfmpegServiceErr({
+					message: `Audio compression failed: ${extractErrorMessage(error)}`,
+				}),
+		});
+	},
+};
+
+export type FfmpegService = typeof FfmpegServiceLive;
 
 /**
  * Builds a complete FFmpeg compression command string.

--- a/apps/whispering/src/lib/services/desktop/fs.ts
+++ b/apps/whispering/src/lib/services/desktop/fs.ts
@@ -8,52 +8,48 @@ export const { FsServiceError, FsServiceErr } =
 	createTaggedError('FsServiceError');
 export type FsServiceError = ReturnType<typeof FsServiceError>;
 
-export function createFsServiceDesktop() {
-	return {
-		/**
-		 * Reads a file from disk and creates a Blob with the correct MIME type.
-		 * @param path - The file path to read
-		 */
-		pathToBlob: (path: string) =>
-			tryAsync({
-				try: () => createBlobFromPath(path),
-				catch: (error) =>
-					FsServiceErr({
-						message: `Failed to read file as Blob: ${path}: ${extractErrorMessage(error)}`,
-					}),
-			}),
+export const FsServiceLive = {
+	/**
+	 * Reads a file from disk and creates a Blob with the correct MIME type.
+	 * @param path - The file path to read
+	 */
+	pathToBlob: (path: string) =>
+		tryAsync({
+			try: () => createBlobFromPath(path),
+			catch: (error) =>
+				FsServiceErr({
+					message: `Failed to read file as Blob: ${path}: ${extractErrorMessage(error)}`,
+				}),
+		}),
 
-		/**
-		 * Reads a file from disk and creates a File object with the correct MIME type.
-		 * @param path - The file path to read
-		 */
-		pathToFile: (path: string) =>
-			tryAsync({
-				try: () => createFileFromPath(path),
-				catch: (error) =>
-					FsServiceErr({
-						message: `Failed to read file as File: ${path}: ${extractErrorMessage(error)}`,
-					}),
-			}),
+	/**
+	 * Reads a file from disk and creates a File object with the correct MIME type.
+	 * @param path - The file path to read
+	 */
+	pathToFile: (path: string) =>
+		tryAsync({
+			try: () => createFileFromPath(path),
+			catch: (error) =>
+				FsServiceErr({
+					message: `Failed to read file as File: ${path}: ${extractErrorMessage(error)}`,
+				}),
+		}),
 
-		/**
-		 * Reads multiple files from disk and creates File objects with correct MIME types.
-		 * @param paths - Array of file paths to read
-		 */
-		pathsToFiles: (paths: string[]) =>
-			tryAsync({
-				try: () => Promise.all(paths.map(createFileFromPath)),
-				catch: (error) =>
-					FsServiceErr({
-						message: `Failed to read files: ${paths.join(', ')}: ${extractErrorMessage(error)}`,
-					}),
-			}),
-	};
-}
+	/**
+	 * Reads multiple files from disk and creates File objects with correct MIME types.
+	 * @param paths - Array of file paths to read
+	 */
+	pathsToFiles: (paths: string[]) =>
+		tryAsync({
+			try: () => Promise.all(paths.map(createFileFromPath)),
+			catch: (error) =>
+				FsServiceErr({
+					message: `Failed to read files: ${paths.join(', ')}: ${extractErrorMessage(error)}`,
+				}),
+		}),
+};
 
-export type FsService = ReturnType<typeof createFsServiceDesktop>;
-
-export const FsServiceLive = createFsServiceDesktop();
+export type FsService = typeof FsServiceLive;
 
 /** Reads a file from disk and creates a Blob with the correct MIME type. */
 async function createBlobFromPath(path: string): Promise<Blob> {

--- a/apps/whispering/src/lib/services/desktop/permissions.ts
+++ b/apps/whispering/src/lib/services/desktop/permissions.ts
@@ -8,82 +8,78 @@ export type PermissionsServiceError = ReturnType<
 	typeof PermissionsServiceError
 >;
 
-export function createPermissionsService() {
-	return {
-		accessibility: {
-			async check() {
-				if (!IS_MACOS) return Ok(true);
+export const PermissionsServiceLive = {
+	accessibility: {
+		async check() {
+			if (!IS_MACOS) return Ok(true);
 
-				return tryAsync({
-					try: async () => {
-						const { checkAccessibilityPermission } = await import(
-							'tauri-plugin-macos-permissions-api'
-						);
-						return await checkAccessibilityPermission();
-					},
-					catch: (error) =>
-						PermissionsServiceErr({
-							message: `Failed to check accessibility permissions: ${extractErrorMessage(error)}`,
-						}),
-				});
-			},
-
-			async request() {
-				if (!IS_MACOS) return Ok(true);
-
-				return tryAsync({
-					try: async () => {
-						const { requestAccessibilityPermission } = await import(
-							'tauri-plugin-macos-permissions-api'
-						);
-						return await requestAccessibilityPermission();
-					},
-					catch: (error) =>
-						PermissionsServiceErr({
-							message: `Failed to request accessibility permissions: ${extractErrorMessage(error)}`,
-						}),
-				});
-			},
+			return tryAsync({
+				try: async () => {
+					const { checkAccessibilityPermission } = await import(
+						'tauri-plugin-macos-permissions-api'
+					);
+					return await checkAccessibilityPermission();
+				},
+				catch: (error) =>
+					PermissionsServiceErr({
+						message: `Failed to check accessibility permissions: ${extractErrorMessage(error)}`,
+					}),
+			});
 		},
 
-		microphone: {
-			async check() {
-				if (!IS_MACOS) return Ok(true);
+		async request() {
+			if (!IS_MACOS) return Ok(true);
 
-				return tryAsync({
-					try: async () => {
-						const { checkMicrophonePermission } = await import(
-							'tauri-plugin-macos-permissions-api'
-						);
-						return await checkMicrophonePermission();
-					},
-					catch: (error) =>
-						PermissionsServiceErr({
-							message: `Failed to check microphone permissions: ${extractErrorMessage(error)}`,
-						}),
-				});
-			},
-
-			async request() {
-				if (!IS_MACOS) return Ok(true);
-
-				return tryAsync({
-					try: async () => {
-						const { requestMicrophonePermission } = await import(
-							'tauri-plugin-macos-permissions-api'
-						);
-						return await requestMicrophonePermission();
-					},
-					catch: (error) =>
-						PermissionsServiceErr({
-							message: `Failed to request microphone permissions: ${extractErrorMessage(error)}`,
-						}),
-				});
-			},
+			return tryAsync({
+				try: async () => {
+					const { requestAccessibilityPermission } = await import(
+						'tauri-plugin-macos-permissions-api'
+					);
+					return await requestAccessibilityPermission();
+				},
+				catch: (error) =>
+					PermissionsServiceErr({
+						message: `Failed to request accessibility permissions: ${extractErrorMessage(error)}`,
+					}),
+			});
 		},
-	};
-}
+	},
 
-export type PermissionsService = ReturnType<typeof createPermissionsService>;
+	microphone: {
+		async check() {
+			if (!IS_MACOS) return Ok(true);
 
-export const PermissionsServiceLive = createPermissionsService();
+			return tryAsync({
+				try: async () => {
+					const { checkMicrophonePermission } = await import(
+						'tauri-plugin-macos-permissions-api'
+					);
+					return await checkMicrophonePermission();
+				},
+				catch: (error) =>
+					PermissionsServiceErr({
+						message: `Failed to check microphone permissions: ${extractErrorMessage(error)}`,
+					}),
+			});
+		},
+
+		async request() {
+			if (!IS_MACOS) return Ok(true);
+
+			return tryAsync({
+				try: async () => {
+					const { requestMicrophonePermission } = await import(
+						'tauri-plugin-macos-permissions-api'
+					);
+					return await requestMicrophonePermission();
+				},
+				catch: (error) =>
+					PermissionsServiceErr({
+						message: `Failed to request microphone permissions: ${extractErrorMessage(error)}`,
+					}),
+			});
+		},
+	},
+};
+
+export type PermissionsService = typeof PermissionsServiceLive;

--- a/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
+++ b/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
@@ -30,301 +30,293 @@ type AudioRecording = {
 };
 
 /**
- * Creates a CPAL recorder service that interfaces with Rust audio recording methods.
- * This service handles device enumeration, recording start/stop operations, and file management
- * for desktop audio recording using the CPAL library.
+ * Enumerates available recording devices from the system.
  */
-export function createCpalRecorderService(): RecorderService {
-	/**
-	 * Enumerates available recording devices from the system.
-	 */
-	const enumerateDevices = async (): Promise<
-		Result<Device[], RecorderServiceError>
-	> => {
-		const { data: deviceNames, error: enumerateRecordingDevicesError } =
-			await invoke<string[]>('enumerate_recording_devices');
-		if (enumerateRecordingDevicesError) {
-			return RecorderServiceErr({
-				message: 'Failed to enumerate recording devices',
-			});
-		}
-		// On desktop, device names serve as both ID and label
-		return Ok(
-			deviceNames.map((name) => ({
-				id: asDeviceIdentifier(name),
-				label: name,
-			})),
-		);
-	};
-
-	return {
-		/**
-		 * Gets the current state of the recorder.
-		 */
-		getRecorderState: async (): Promise<
-			Result<WhisperingRecordingState, RecorderServiceError>
-		> => {
-			const { data: recordingId, error: getRecorderStateError } = await invoke<
-				string | null
-			>('get_current_recording_id');
-			if (getRecorderStateError)
-				return RecorderServiceErr({
-					message:
-						'We encountered an issue while getting the recorder state. This could be because your microphone is being used by another app, your microphone permissions are denied, or the selected recording device is disconnected',
-				});
-
-			return Ok(recordingId ? 'RECORDING' : 'IDLE');
-		},
-
-		enumerateDevices,
-
-		/**
-		 * Starts a recording session with the specified parameters.
-		 * Handles device selection, fallback logic, and recording initialization.
-		 *
-		 * @param params - Recording parameters including device ID, recording ID, output folder, and sample rate
-		 * @param callbacks - Callback functions for status updates
-		 */
-		startRecording: async (
-			{
-				selectedDeviceId,
-				recordingId,
-				outputFolder,
-				sampleRate,
-			}: CpalRecordingParams,
-			{ sendStatus },
-		): Promise<Result<DeviceAcquisitionOutcome, RecorderServiceError>> => {
-			const { data: devices, error: enumerateError } = await enumerateDevices();
-			if (enumerateError) return Err(enumerateError);
-
-			/**
-			 * Acquires a recording device, either the selected one or a fallback.
-			 */
-			const acquireDevice = (): Result<
-				DeviceAcquisitionOutcome,
-				RecorderServiceError
-			> => {
-				const deviceIds = devices.map((d) => d.id);
-				const fallbackDeviceId = deviceIds.at(0);
-				if (!fallbackDeviceId) {
-					return RecorderServiceErr({
-						message: selectedDeviceId
-							? "We couldn't find the selected microphone. Make sure it's connected and try again!"
-							: "We couldn't find any microphones. Make sure they're connected and try again!",
-					});
-				}
-
-				if (!selectedDeviceId) {
-					sendStatus({
-						title: '🔍 No Device Selected',
-						description:
-							"No worries! We'll find the best microphone for you automatically...",
-					});
-					return Ok({
-						outcome: 'fallback',
-						reason: 'no-device-selected',
-						deviceId: fallbackDeviceId,
-					});
-				}
-
-				// Check if the selected device exists in the devices array
-				const deviceExists = deviceIds.includes(selectedDeviceId);
-
-				if (deviceExists)
-					return Ok({ outcome: 'success', deviceId: selectedDeviceId });
-
-				sendStatus({
-					title: '⚠️ Finding a New Microphone',
-					description:
-						"That microphone isn't available. Let's try finding another one...",
-				});
-
-				return Ok({
-					outcome: 'fallback',
-					reason: 'preferred-device-unavailable',
-					deviceId: fallbackDeviceId,
-				});
-			};
-
-			const { data: deviceOutcome, error: acquireDeviceError } =
-				acquireDevice();
-			if (acquireDeviceError) return Err(acquireDeviceError);
-
-			// Use the device from the outcome
-			const deviceIdentifier = deviceOutcome.deviceId;
-
-			// Now initialize recording with the chosen device
-			sendStatus({
-				title: '🎤 Setting Up',
-				description:
-					'Initializing your recording session and checking microphone access...',
-			});
-
-			// Convert sample rate string to number if provided
-			const sampleRateNum = sampleRate
-				? Number.parseInt(sampleRate, 10)
-				: undefined;
-
-			const { error: initRecordingSessionError } = await invoke(
-				'init_recording_session',
-				{
-					deviceIdentifier,
-					recordingId,
-					outputFolder,
-					sampleRate: sampleRateNum,
-				},
-			);
-			if (initRecordingSessionError)
-				return RecorderServiceErr({
-					message:
-						'We encountered an issue while setting up your recording session. This could be because your microphone is being used by another app, your microphone permissions are denied, or the selected recording device is disconnected',
-				});
-
-			sendStatus({
-				title: '🎙️ Starting Recording',
-				description:
-					'Recording session initialized, now starting to capture audio...',
-			});
-			const { error: startRecordingError } =
-				await invoke<void>('start_recording');
-			if (startRecordingError)
-				return RecorderServiceErr({
-					message:
-						'Unable to start recording. Please check your microphone and try again.',
-				});
-
-			return Ok(deviceOutcome);
-		},
-
-		/**
-		 * Stops the current recording session and returns the recorded audio as a Blob.
-		 * Handles file reading, session cleanup, and resource management.
-		 *
-		 * @param callbacks - Callback functions for status updates
-		 */
-		stopRecording: async ({
-			sendStatus,
-		}): Promise<Result<Blob, RecorderServiceError>> => {
-			const { data: audioRecording, error: stopRecordingError } =
-				await invoke<AudioRecording>('stop_recording');
-			if (stopRecordingError) {
-				return RecorderServiceErr({
-					message: 'Unable to save your recording. Please try again.',
-				});
-			}
-
-			const { filePath } = audioRecording;
-			// Desktop recorder should always write to a file
-			if (!filePath) {
-				return RecorderServiceErr({
-					message: 'Recording file path not provided by method.',
-				});
-			}
-			// audioRecording is now AudioRecordingWithFile
-
-			// Read the WAV file from disk
-			sendStatus({
-				title: '📁 Reading Recording',
-				description: 'Loading your recording from disk...',
-			});
-
-			const { data: blob, error: readRecordingFileError } =
-				await FsServiceLive.pathToBlob(filePath);
-			if (readRecordingFileError)
-				return RecorderServiceErr({
-					message: `Unable to read recording file: ${readRecordingFileError.message}`,
-				});
-			// Close the recording session after stopping
-			sendStatus({
-				title: '🔄 Closing Session',
-				description: 'Cleaning up recording resources...',
-			});
-			const { error: closeError } = await invoke<void>(
-				'close_recording_session',
-			);
-			if (closeError) {
-				// Log but don't fail the stop operation
-				console.error('Failed to close recording session:', closeError);
-			}
-
-			return Ok(blob);
-		},
-
-		/**
-		 * Cancels the current recording session and cleans up resources.
-		 * Deletes any temporary recording files and closes the recording session.
-		 *
-		 * @param callbacks - Callback functions for status updates
-		 */
-		cancelRecording: async ({
-			sendStatus,
-		}): Promise<Result<CancelRecordingResult, RecorderServiceError>> => {
-			// Check current state first
-			const { data: recordingId, error: getRecordingIdError } = await invoke<
-				string | null
-			>('get_current_recording_id');
-			if (getRecordingIdError) {
-				return RecorderServiceErr({
-					message:
-						'Unable to check recording state. Please try closing the app and starting again.',
-				});
-			}
-
-			if (!recordingId) {
-				return Ok({ status: 'no-recording' });
-			}
-
-			sendStatus({
-				title: '🛑 Cancelling',
-				description:
-					'Safely stopping your recording and cleaning up resources...',
-			});
-
-			// First get the recording data to know if there's a file to delete
-			const { data: audioRecording } =
-				await invoke<AudioRecording>('stop_recording');
-
-			// If there's a file path, delete the file using Tauri FS plugin
-			if (audioRecording?.filePath) {
-				const { filePath } = audioRecording;
-				const { error: removeError } = await tryAsync({
-					try: () => remove(filePath),
-					catch: (error) =>
-						RecorderServiceErr({
-							message: `Failed to delete recording file: ${extractErrorMessage(error)}`,
-						}),
-				});
-				if (removeError)
-					sendStatus({
-						title: '❌ Error Deleting Recording File',
-						description:
-							"We couldn't delete the recording file. Continuing with the cancellation process...",
-					});
-			}
-
-			// Close the recording session after cancelling
-			sendStatus({
-				title: '🔄 Closing Session',
-				description: 'Cleaning up recording resources...',
-			});
-			const { error: closeError } = await invoke<void>(
-				'close_recording_session',
-			);
-			if (closeError) {
-				// Log but don't fail the cancel operation
-				console.error('Failed to close recording session:', closeError);
-			}
-
-			return Ok({ status: 'cancelled' });
-		},
-	};
-}
+const enumerateDevices = async (): Promise<
+	Result<Device[], RecorderServiceError>
+> => {
+	const { data: deviceNames, error: enumerateRecordingDevicesError } =
+		await invoke<string[]>('enumerate_recording_devices');
+	if (enumerateRecordingDevicesError) {
+		return RecorderServiceErr({
+			message: 'Failed to enumerate recording devices',
+		});
+	}
+	// On desktop, device names serve as both ID and label
+	return Ok(
+		deviceNames.map((name) => ({
+			id: asDeviceIdentifier(name),
+			label: name,
+		})),
+	);
+};
 
 /**
  * CPAL recorder service that uses the Rust CPAL method.
- * This is the CPAL audio recorder for desktop environments.
+ * This service handles device enumeration, recording start/stop operations, and file management
+ * for desktop audio recording using the CPAL library.
  */
-export const CpalRecorderServiceLive = createCpalRecorderService();
+export const CpalRecorderServiceLive: RecorderService = {
+	/**
+	 * Gets the current state of the recorder.
+	 */
+	getRecorderState: async (): Promise<
+		Result<WhisperingRecordingState, RecorderServiceError>
+	> => {
+		const { data: recordingId, error: getRecorderStateError } = await invoke<
+			string | null
+		>('get_current_recording_id');
+		if (getRecorderStateError)
+			return RecorderServiceErr({
+				message:
+					'We encountered an issue while getting the recorder state. This could be because your microphone is being used by another app, your microphone permissions are denied, or the selected recording device is disconnected',
+			});
+
+		return Ok(recordingId ? 'RECORDING' : 'IDLE');
+	},
+
+	enumerateDevices,
+
+	/**
+	 * Starts a recording session with the specified parameters.
+	 * Handles device selection, fallback logic, and recording initialization.
+	 *
+	 * @param params - Recording parameters including device ID, recording ID, output folder, and sample rate
+	 * @param callbacks - Callback functions for status updates
+	 */
+	startRecording: async (
+		{
+			selectedDeviceId,
+			recordingId,
+			outputFolder,
+			sampleRate,
+		}: CpalRecordingParams,
+		{ sendStatus },
+	): Promise<Result<DeviceAcquisitionOutcome, RecorderServiceError>> => {
+		const { data: devices, error: enumerateError } = await enumerateDevices();
+		if (enumerateError) return Err(enumerateError);
+
+		/**
+		 * Acquires a recording device, either the selected one or a fallback.
+		 */
+		const acquireDevice = (): Result<
+			DeviceAcquisitionOutcome,
+			RecorderServiceError
+		> => {
+			const deviceIds = devices.map((d) => d.id);
+			const fallbackDeviceId = deviceIds.at(0);
+			if (!fallbackDeviceId) {
+				return RecorderServiceErr({
+					message: selectedDeviceId
+						? "We couldn't find the selected microphone. Make sure it's connected and try again!"
+						: "We couldn't find any microphones. Make sure they're connected and try again!",
+				});
+			}
+
+			if (!selectedDeviceId) {
+				sendStatus({
+					title: '🔍 No Device Selected',
+					description:
+						"No worries! We'll find the best microphone for you automatically...",
+				});
+				return Ok({
+					outcome: 'fallback',
+					reason: 'no-device-selected',
+					deviceId: fallbackDeviceId,
+				});
+			}
+
+			// Check if the selected device exists in the devices array
+			const deviceExists = deviceIds.includes(selectedDeviceId);
+
+			if (deviceExists)
+				return Ok({ outcome: 'success', deviceId: selectedDeviceId });
+
+			sendStatus({
+				title: '⚠️ Finding a New Microphone',
+				description:
+					"That microphone isn't available. Let's try finding another one...",
+			});
+
+			return Ok({
+				outcome: 'fallback',
+				reason: 'preferred-device-unavailable',
+				deviceId: fallbackDeviceId,
+			});
+		};
+
+		const { data: deviceOutcome, error: acquireDeviceError } =
+			acquireDevice();
+		if (acquireDeviceError) return Err(acquireDeviceError);
+
+		// Use the device from the outcome
+		const deviceIdentifier = deviceOutcome.deviceId;
+
+		// Now initialize recording with the chosen device
+		sendStatus({
+			title: '🎤 Setting Up',
+			description:
+				'Initializing your recording session and checking microphone access...',
+		});
+
+		// Convert sample rate string to number if provided
+		const sampleRateNum = sampleRate
+			? Number.parseInt(sampleRate, 10)
+			: undefined;
+
+		const { error: initRecordingSessionError } = await invoke(
+			'init_recording_session',
+			{
+				deviceIdentifier,
+				recordingId,
+				outputFolder,
+				sampleRate: sampleRateNum,
+			},
+		);
+		if (initRecordingSessionError)
+			return RecorderServiceErr({
+				message:
+					'We encountered an issue while setting up your recording session. This could be because your microphone is being used by another app, your microphone permissions are denied, or the selected recording device is disconnected',
+			});
+
+		sendStatus({
+			title: '🎙️ Starting Recording',
+			description:
+				'Recording session initialized, now starting to capture audio...',
+		});
+		const { error: startRecordingError } =
+			await invoke<void>('start_recording');
+		if (startRecordingError)
+			return RecorderServiceErr({
+				message:
+					'Unable to start recording. Please check your microphone and try again.',
+			});
+
+		return Ok(deviceOutcome);
+	},
+
+	/**
+	 * Stops the current recording session and returns the recorded audio as a Blob.
+	 * Handles file reading, session cleanup, and resource management.
+	 *
+	 * @param callbacks - Callback functions for status updates
+	 */
+	stopRecording: async ({
+		sendStatus,
+	}): Promise<Result<Blob, RecorderServiceError>> => {
+		const { data: audioRecording, error: stopRecordingError } =
+			await invoke<AudioRecording>('stop_recording');
+		if (stopRecordingError) {
+			return RecorderServiceErr({
+				message: 'Unable to save your recording. Please try again.',
+			});
+		}
+
+		const { filePath } = audioRecording;
+		// Desktop recorder should always write to a file
+		if (!filePath) {
+			return RecorderServiceErr({
+				message: 'Recording file path not provided by method.',
+			});
+		}
+		// audioRecording is now AudioRecordingWithFile
+
+		// Read the WAV file from disk
+		sendStatus({
+			title: '📁 Reading Recording',
+			description: 'Loading your recording from disk...',
+		});
+
+		const { data: blob, error: readRecordingFileError } =
+			await FsServiceLive.pathToBlob(filePath);
+		if (readRecordingFileError)
+			return RecorderServiceErr({
+				message: `Unable to read recording file: ${readRecordingFileError.message}`,
+			});
+		// Close the recording session after stopping
+		sendStatus({
+			title: '🔄 Closing Session',
+			description: 'Cleaning up recording resources...',
+		});
+		const { error: closeError } = await invoke<void>(
+			'close_recording_session',
+		);
+		if (closeError) {
+			// Log but don't fail the stop operation
+			console.error('Failed to close recording session:', closeError);
+		}
+
+		return Ok(blob);
+	},
+
+	/**
+	 * Cancels the current recording session and cleans up resources.
+	 * Deletes any temporary recording files and closes the recording session.
+	 *
+	 * @param callbacks - Callback functions for status updates
+	 */
+	cancelRecording: async ({
+		sendStatus,
+	}): Promise<Result<CancelRecordingResult, RecorderServiceError>> => {
+		// Check current state first
+		const { data: recordingId, error: getRecordingIdError } = await invoke<
+			string | null
+		>('get_current_recording_id');
+		if (getRecordingIdError) {
+			return RecorderServiceErr({
+				message:
+					'Unable to check recording state. Please try closing the app and starting again.',
+			});
+		}
+
+		if (!recordingId) {
+			return Ok({ status: 'no-recording' });
+		}
+
+		sendStatus({
+			title: '🛑 Cancelling',
+			description:
+				'Safely stopping your recording and cleaning up resources...',
+		});
+
+		// First get the recording data to know if there's a file to delete
+		const { data: audioRecording } =
+			await invoke<AudioRecording>('stop_recording');
+
+		// If there's a file path, delete the file using Tauri FS plugin
+		if (audioRecording?.filePath) {
+			const { filePath } = audioRecording;
+			const { error: removeError } = await tryAsync({
+				try: () => remove(filePath),
+				catch: (error) =>
+					RecorderServiceErr({
+						message: `Failed to delete recording file: ${extractErrorMessage(error)}`,
+					}),
+			});
+			if (removeError)
+				sendStatus({
+					title: '❌ Error Deleting Recording File',
+					description:
+						"We couldn't delete the recording file. Continuing with the cancellation process...",
+				});
+		}
+
+		// Close the recording session after cancelling
+		sendStatus({
+			title: '🔄 Closing Session',
+			description: 'Cleaning up recording resources...',
+		});
+		const { error: closeError } = await invoke<void>(
+			'close_recording_session',
+		);
+		if (closeError) {
+			// Log but don't fail the cancel operation
+			console.error('Failed to close recording session:', closeError);
+		}
+
+		return Ok({ status: 'cancelled' });
+	},
+};
 
 /**
  * Wrapper function for Tauri invoke calls that handles errors consistently.

--- a/apps/whispering/src/lib/services/desktop/tray.ts
+++ b/apps/whispering/src/lib/services/desktop/tray.ts
@@ -14,23 +14,24 @@ const TRAY_ID = 'whispering-tray';
 
 const { SetTrayIconServiceErr } = createTaggedError('SetTrayIconServiceError');
 
-export function createTrayIconDesktopService() {
-	const trayPromise = initTray();
-	return {
-		setTrayIcon: (recorderState: WhisperingRecordingState) =>
-			tryAsync({
-				try: async () => {
-					const iconPath = await getIconPath(recorderState);
-					const tray = await trayPromise;
-					return tray.setIcon(iconPath);
-				},
-				catch: (error) =>
-					SetTrayIconServiceErr({
-						message: `Failed to set tray icon: ${extractErrorMessage(error)}`,
-					}),
-			}),
-	};
-}
+const trayPromise = initTray();
+
+export const TrayIconServiceLive = {
+	setTrayIcon: (recorderState: WhisperingRecordingState) =>
+		tryAsync({
+			try: async () => {
+				const iconPath = await getIconPath(recorderState);
+				const tray = await trayPromise;
+				return tray.setIcon(iconPath);
+			},
+			catch: (error) =>
+				SetTrayIconServiceErr({
+					message: `Failed to set tray icon: ${extractErrorMessage(error)}`,
+				}),
+		}),
+};
+
+export type TrayIconService = typeof TrayIconServiceLive;
 
 async function initTray() {
 	const existingTray = await TrayIcon.getById(TRAY_ID);
@@ -90,10 +91,6 @@ async function initTray() {
 
 	return tray;
 }
-
-export type TrayIconService = ReturnType<typeof createTrayIconDesktopService>;
-
-export const TrayIconServiceLive = createTrayIconDesktopService();
 
 async function getIconPath(recorderState: WhisperingRecordingState) {
 	const iconPaths = {

--- a/apps/whispering/src/lib/services/isomorphic/completion/google.ts
+++ b/apps/whispering/src/lib/services/isomorphic/completion/google.ts
@@ -4,48 +4,42 @@ import { Err, Ok, tryAsync } from 'wellcrafted/result';
 import type { CompletionService } from './types';
 import { CompletionServiceErr } from './types';
 
-export function createGoogleCompletionService(): CompletionService {
-	return {
-		complete: async ({
-			apiKey,
-			model: modelName,
-			systemPrompt,
-			userPrompt,
-		}) => {
-			const combinedPrompt = `${systemPrompt}\n${userPrompt}`;
-			const { data: completion, error: completionError } = await tryAsync({
-				try: async () => {
-					const genAI = new GoogleGenerativeAI(apiKey);
+export const GoogleCompletionServiceLive: CompletionService = {
+	complete: async ({
+		apiKey,
+		model: modelName,
+		systemPrompt,
+		userPrompt,
+	}) => {
+		const combinedPrompt = `${systemPrompt}\n${userPrompt}`;
+		const { data: completion, error: completionError } = await tryAsync({
+			try: async () => {
+				const genAI = new GoogleGenerativeAI(apiKey);
 
-					const model = genAI.getGenerativeModel({
-						model: modelName,
-						// TODO: Add temperature to step settings
-						generationConfig: { temperature: 0 },
-					});
-					const { response } = await model.generateContent(combinedPrompt);
-					return response.text();
-				},
-				catch: (error) =>
-					CompletionServiceErr({
-						message: `Google API Error: ${extractErrorMessage(error)}`,
-					}),
-			});
-
-			if (completionError) return Err(completionError);
-
-			if (!completion) {
-				return CompletionServiceErr({
-					message: 'Google API returned an empty response',
+				const model = genAI.getGenerativeModel({
+					model: modelName,
+					// TODO: Add temperature to step settings
+					generationConfig: { temperature: 0 },
 				});
-			}
+				const { response } = await model.generateContent(combinedPrompt);
+				return response.text();
+			},
+			catch: (error) =>
+				CompletionServiceErr({
+					message: `Google API Error: ${extractErrorMessage(error)}`,
+				}),
+		});
 
-			return Ok(completion);
-		},
-	};
-}
+		if (completionError) return Err(completionError);
 
-export type GoogleCompletionService = ReturnType<
-	typeof createGoogleCompletionService
->;
+		if (!completion) {
+			return CompletionServiceErr({
+				message: 'Google API returned an empty response',
+			});
+		}
 
-export const GoogleCompletionServiceLive = createGoogleCompletionService();
+		return Ok(completion);
+	},
+};
+
+export type GoogleCompletionService = typeof GoogleCompletionServiceLive;

--- a/apps/whispering/src/lib/services/isomorphic/completion/groq.ts
+++ b/apps/whispering/src/lib/services/isomorphic/completion/groq.ts
@@ -5,130 +5,125 @@ import type { CompletionService } from './types';
 import { CompletionServiceErr } from './types';
 
 const customFetch = window.__TAURI_INTERNALS__ ? tauriFetch : undefined;
-export function createGroqCompletionService(): CompletionService {
-	return {
-		async complete({ apiKey, model, systemPrompt, userPrompt }) {
-			const client = new Groq({
-				apiKey,
-				dangerouslyAllowBrowser: true,
-				fetch: customFetch,
-			});
-			// Call Groq API
-			const { data: completion, error: groqApiError } = await tryAsync({
-				try: () =>
-					client.chat.completions.create({
-						model,
-						messages: [
-							{ role: 'system', content: systemPrompt },
-							{ role: 'user', content: userPrompt },
-						],
-					}),
-				catch: (error) => {
-					// Check if it's NOT a Groq API error
-					if (!(error instanceof Groq.APIError)) {
-						// This is an unexpected error type
-						throw error;
-					}
-					// Return the error directly
-					return Err(error);
-				},
-			});
 
-			if (groqApiError) {
-				// Error handling follows https://www.npmjs.com/package/groq-sdk#error-handling
-				const { status, name, message, error } = groqApiError;
-
-				// 400 - BadRequestError
-				if (status === 400) {
-					return CompletionServiceErr({
-						message:
-							message ??
-							`Invalid request to Groq API. ${error?.message ?? ''}`.trim(),
-					});
+export const GroqCompletionServiceLive: CompletionService = {
+	async complete({ apiKey, model, systemPrompt, userPrompt }) {
+		const client = new Groq({
+			apiKey,
+			dangerouslyAllowBrowser: true,
+			fetch: customFetch,
+		});
+		// Call Groq API
+		const { data: completion, error: groqApiError } = await tryAsync({
+			try: () =>
+				client.chat.completions.create({
+					model,
+					messages: [
+						{ role: 'system', content: systemPrompt },
+						{ role: 'user', content: userPrompt },
+					],
+				}),
+			catch: (error) => {
+				// Check if it's NOT a Groq API error
+				if (!(error instanceof Groq.APIError)) {
+					// This is an unexpected error type
+					throw error;
 				}
+				// Return the error directly
+				return Err(error);
+			},
+		});
 
-				// 401 - AuthenticationError
-				if (status === 401) {
-					return CompletionServiceErr({
-						message:
-							message ??
-							'Your API key appears to be invalid or expired. Please update your API key in settings.',
-					});
-				}
+		if (groqApiError) {
+			// Error handling follows https://www.npmjs.com/package/groq-sdk#error-handling
+			const { status, name, message, error } = groqApiError;
 
-				// 403 - PermissionDeniedError
-				if (status === 403) {
-					return CompletionServiceErr({
-						message:
-							message ??
-							"Your account doesn't have access to this model or feature.",
-					});
-				}
-
-				// 404 - NotFoundError
-				if (status === 404) {
-					return CompletionServiceErr({
-						message:
-							message ??
-							'The requested model was not found. Please check the model name.',
-					});
-				}
-
-				// 422 - UnprocessableEntityError
-				if (status === 422) {
-					return CompletionServiceErr({
-						message:
-							message ??
-							'The request was valid but the server cannot process it. Please check your parameters.',
-					});
-				}
-
-				// 429 - RateLimitError
-				if (status === 429) {
-					return CompletionServiceErr({
-						message: message ?? 'Too many requests. Please try again later.',
-					});
-				}
-
-				// >=500 - InternalServerError
-				if (status && status >= 500) {
-					return CompletionServiceErr({
-						message:
-							message ??
-							`The Groq service is temporarily unavailable (Error ${status}). Please try again in a few minutes.`,
-					});
-				}
-
-				// Handle APIConnectionError (no status code)
-				if (!status && name === 'APIConnectionError') {
-					return CompletionServiceErr({
-						message:
-							message ??
-							'Unable to connect to the Groq service. This could be a network issue or temporary service interruption.',
-					});
-				}
-
-				// Catch-all for unexpected errors
+			// 400 - BadRequestError
+			if (status === 400) {
 				return CompletionServiceErr({
-					message: message ?? 'An unexpected error occurred. Please try again.',
+					message:
+						message ??
+						`Invalid request to Groq API. ${error?.message ?? ''}`.trim(),
 				});
 			}
 
-			// Extract the response text
-			const responseText = completion.choices.at(0)?.message?.content;
-			if (!responseText) {
+			// 401 - AuthenticationError
+			if (status === 401) {
 				return CompletionServiceErr({
-					message: 'Groq API returned an empty response',
+					message:
+						message ??
+						'Your API key appears to be invalid or expired. Please update your API key in settings.',
 				});
 			}
 
-			return Ok(responseText);
-		},
-	};
-}
+			// 403 - PermissionDeniedError
+			if (status === 403) {
+				return CompletionServiceErr({
+					message:
+						message ??
+						"Your account doesn't have access to this model or feature.",
+				});
+			}
 
-export type GroqCompletionService = ReturnType<
-	typeof createGroqCompletionService
->;
+			// 404 - NotFoundError
+			if (status === 404) {
+				return CompletionServiceErr({
+					message:
+						message ??
+						'The requested model was not found. Please check the model name.',
+				});
+			}
 
-export const GroqCompletionServiceLive = createGroqCompletionService();
+			// 422 - UnprocessableEntityError
+			if (status === 422) {
+				return CompletionServiceErr({
+					message:
+						message ??
+						'The request was valid but the server cannot process it. Please check your parameters.',
+				});
+			}
+
+			// 429 - RateLimitError
+			if (status === 429) {
+				return CompletionServiceErr({
+					message: message ?? 'Too many requests. Please try again later.',
+				});
+			}
+
+			// >=500 - InternalServerError
+			if (status && status >= 500) {
+				return CompletionServiceErr({
+					message:
+						message ??
+						`The Groq service is temporarily unavailable (Error ${status}). Please try again in a few minutes.`,
+				});
+			}
+
+			// Handle APIConnectionError (no status code)
+			if (!status && name === 'APIConnectionError') {
+				return CompletionServiceErr({
+					message:
+						message ??
+						'Unable to connect to the Groq service. This could be a network issue or temporary service interruption.',
+				});
+			}
+
+			// Catch-all for unexpected errors
+			return CompletionServiceErr({
+				message: message ?? 'An unexpected error occurred. Please try again.',
+			});
+		}
+
+		// Extract the response text
+		const responseText = completion.choices.at(0)?.message?.content;
+		if (!responseText) {
+			return CompletionServiceErr({
+				message: 'Groq API returned an empty response',
+			});
+		}
+
+		return Ok(responseText);
+	},
+};
+
+export type GroqCompletionService = typeof GroqCompletionServiceLive;

--- a/apps/whispering/src/lib/services/isomorphic/local-shortcut-manager.ts
+++ b/apps/whispering/src/lib/services/isomorphic/local-shortcut-manager.ts
@@ -24,216 +24,14 @@ type LocalShortcutServiceError = ReturnType<typeof LocalShortcutServiceError>;
 
 export type CommandId = string & Brand<'CommandId'>;
 
-export function createLocalShortcutManager() {
-	const shortcuts = new Map<
-		CommandId,
-		{
-			on: ShortcutEventState[];
-			keyCombination: KeyboardEventSupportedKey[];
-			callback: (state: ShortcutEventState) => void;
-		}
-	>();
-
-	return {
-		/**
-		 * Sets up keyboard event listeners to detect and handle shortcut key combinations.
-		 *
-		 * - Tracks currently pressed keys in real-time
-		 * - Matches key combinations against registered shortcuts
-		 * - Handles both keydown and keyup events for flexible trigger options
-		 * - Provides special handling for modifier keys to prevent stuck keys
-		 * - Automatically cleans up state when window loses focus or visibility
-		 *
-		 * @returns Cleanup function that removes all event listeners when called
-		 */
-		listen() {
-			/**
-			 * Array tracking currently pressed keys in lowercase format.
-			 * Maintains real-time state of which keys are physically held down.
-			 * Updated on every keydown (adds key) and keyup (removes key) event.
-			 */
-			let pressedKeys: KeyboardEventSupportedKey[] = [];
-			/**
-			 * Set tracking which shortcuts have already been triggered and are currently active.
-			 * This prevents key repeat spam when holding down keys - without this, holding
-			 * spacebar would trigger the shortcut many times per second!
-			 *
-			 * When a shortcut is triggered:
-			 * 1. Its ID is added to this set, marking it as "already fired"
-			 * 2. Future keydown events with the same key combo are ignored
-			 * 3. The ID is only removed when all keys are released or focus is lost
-			 *
-			 * This ensures each key combination fires exactly once per physical press,
-			 * regardless of how long the user holds the keys down.
-			 */
-			const activeShortcuts = new Set<CommandId>();
-
-			/**
-			 * Handle keydown events - adds keys to pressed state and triggers 'Pressed' shortcuts.
-			 * Fires repeatedly while a key is held down (due to OS key repeat), but activeShortcuts
-			 * ensures callbacks only fire once per physical key press.
-			 */
-			const keydown = on(window, 'keydown', (e) => {
-				// Skip shortcut processing if user is typing in an input field
-				if (isTypingInInput()) return;
-
-				let key = e.key.toLowerCase() as KeyboardEventPossibleKey;
-
-				// macOS Option key normalization:
-				// On macOS, the Option key (Alt) triggers special character insertion.
-				// For example, Option+A produces "å" instead of registering as "alt+a".
-				// This breaks keyboard shortcut detection because we get the special
-				// character instead of the actual key that was pressed.
-				//
-				// To fix this, when Option is held on macOS, we normalize these special
-				// characters back to their base keys (e.g., "å" → "a", "ç" → "c").
-				// This ensures keyboard shortcuts work consistently across platforms.
-				if (IS_MACOS && pressedKeys.includes('alt')) {
-					key = normalizeOptionKeyCharacter(key);
-				}
-
-				// Ignore keys that are not supported
-				if (!isSupportedKey(key)) return;
-
-				// Add key to pressed state if not already present
-				if (!pressedKeys.includes(key)) pressedKeys.push(key);
-
-				// Check all registered shortcuts for matches
-				for (const [
-					id,
-					{ callback, keyCombination, on },
-				] of shortcuts.entries()) {
-					if (!arraysMatch(pressedKeys, keyCombination)) continue;
-
-					// Always prevent default for matching shortcuts
-					e.preventDefault();
-
-					// Only trigger callback if shortcut not already active
-					// This is the key anti-spam mechanism: if the shortcut ID is already
-					// in activeShortcuts, we know it's been triggered and should not fire again
-					if (!activeShortcuts.has(id) && on.includes('Pressed')) {
-						activeShortcuts.add(id); // Mark as active BEFORE calling callback
-						callback('Pressed');
-					}
-				}
-			});
-
-			/**
-			 * Handle keyup events - removes keys from pressed state and triggers 'Released' shortcuts.
-			 * Also responsible for clearing activeShortcuts to allow shortcuts to fire again
-			 * on the next key press.
-			 */
-			const keyup = on(window, 'keyup', (e) => {
-				// Skip shortcut processing if user is typing in an input field
-				if (isTypingInInput()) return;
-
-				const key = e.key.toLowerCase() as KeyboardEventPossibleKey;
-
-				// Ignore keys that are not supported
-				if (!isSupportedKey(key)) return;
-
-				/** Modifier keys that require special handling */
-				const modifierKeys = ['meta', 'control', 'alt', 'shift'];
-
-				if (modifierKeys.includes(key)) {
-					// Special handling for modifier keys (meta, control, alt, shift)
-					// This addresses issues with OS/browser intercepting certain key combinations
-					// where non-modifier keyup events might not fire properly
-					// When a modifier key is released, clear all non-modifier keys
-					// but keep other modifier keys that might still be pressed
-					// This prevents keys from getting "stuck" in the pressedKeys state
-					pressedKeys = pressedKeys.filter((k) => modifierKeys.includes(k));
-					activeShortcuts.clear();
-				}
-
-				// Check all registered shortcuts for matches on release BEFORE removing the key
-				for (const [
-					id,
-					{ callback, keyCombination, on },
-				] of shortcuts.entries()) {
-					if (!arraysMatch(pressedKeys, keyCombination)) continue;
-					if (activeShortcuts.has(id) && on.includes('Released')) {
-						e.preventDefault();
-						callback('Released');
-						activeShortcuts.delete(id);
-					}
-				}
-
-				// Regular key removal from pressed state
-				pressedKeys = pressedKeys.filter((k) => k !== key);
-
-				// Clear active shortcuts when no keys are pressed
-				if (pressedKeys.length === 0) {
-					activeShortcuts.clear();
-				}
-			});
-
-			/**
-			 * Handle window blur events (switching applications, clicking outside browser)
-			 * Reset all keys when user shifts focus away from the window
-			 */
-			const blur = on(window, 'blur', () => {
-				pressedKeys = [];
-				activeShortcuts.clear();
-			});
-
-			/**
-			 * Handle tab visibility changes (switching browser tabs)
-			 * This catches cases where the window doesn't lose focus but the tab is hidden
-			 */
-			const visibilityChange = on(document, 'visibilitychange', () => {
-				if (document.visibilityState === 'hidden') {
-					pressedKeys = [];
-					activeShortcuts.clear();
-				}
-			});
-
-			/** Cleanup function that removes all event listeners */
-			return () => {
-				keydown();
-				keyup();
-				blur();
-				visibilityChange();
-			};
-		},
-		async register({
-			id,
-			keyCombination,
-			callback,
-			on,
-		}: {
-			id: CommandId;
-			keyCombination: KeyboardEventSupportedKey[];
-			callback: (state: ShortcutEventState) => void;
-			on: ShortcutEventState[];
-		}): Promise<Result<void, LocalShortcutServiceError>> {
-			shortcuts.set(id, { keyCombination, callback, on });
-			return Ok(undefined);
-		},
-
-		/**
-		 * Unregisters a local shortcut by ID.
-		 * This function is idempotent - it can be safely called even if the shortcut
-		 * with the given ID doesn't exist or has already been unregistered.
-		 */
-		async unregister(
-			id: CommandId,
-		): Promise<Result<void, LocalShortcutServiceError>> {
-			shortcuts.delete(id);
-			return Ok(undefined);
-		},
-
-		/**
-		 * Unregisters all local shortcuts.
-		 * This function is idempotent - it can be safely called even if no shortcuts
-		 * are currently registered.
-		 */
-		async unregisterAll(): Promise<Result<void, LocalShortcutServiceError>> {
-			shortcuts.clear();
-			return Ok(undefined);
-		},
-	};
-}
+const shortcuts = new Map<
+	CommandId,
+	{
+		on: ShortcutEventState[];
+		keyCombination: KeyboardEventSupportedKey[];
+		callback: (state: ShortcutEventState) => void;
+	}
+>();
 
 /**
  * Type representing the local shortcut manager instance.
@@ -244,12 +42,208 @@ export function createLocalShortcutManager() {
  *
  * The manager handles the complexity of tracking pressed keys, matching
  * key combinations, and managing shortcut lifecycles.
- *
- * @see {@link createLocalShortcutManager} Factory function to create instances
  */
-export type LocalShortcutManager = ReturnType<
-	typeof createLocalShortcutManager
->;
+export type LocalShortcutManager = typeof LocalShortcutManagerLive;
+
+export const LocalShortcutManagerLive = {
+	/**
+	 * Sets up keyboard event listeners to detect and handle shortcut key combinations.
+	 *
+	 * - Tracks currently pressed keys in real-time
+	 * - Matches key combinations against registered shortcuts
+	 * - Handles both keydown and keyup events for flexible trigger options
+	 * - Provides special handling for modifier keys to prevent stuck keys
+	 * - Automatically cleans up state when window loses focus or visibility
+	 *
+	 * @returns Cleanup function that removes all event listeners when called
+	 */
+	listen() {
+		/**
+		 * Array tracking currently pressed keys in lowercase format.
+		 * Maintains real-time state of which keys are physically held down.
+		 * Updated on every keydown (adds key) and keyup (removes key) event.
+		 */
+		let pressedKeys: KeyboardEventSupportedKey[] = [];
+		/**
+		 * Set tracking which shortcuts have already been triggered and are currently active.
+		 * This prevents key repeat spam when holding down keys - without this, holding
+		 * spacebar would trigger the shortcut many times per second!
+		 *
+		 * When a shortcut is triggered:
+		 * 1. Its ID is added to this set, marking it as "already fired"
+		 * 2. Future keydown events with the same key combo are ignored
+		 * 3. The ID is only removed when all keys are released or focus is lost
+		 *
+		 * This ensures each key combination fires exactly once per physical press,
+		 * regardless of how long the user holds the keys down.
+		 */
+		const activeShortcuts = new Set<CommandId>();
+
+		/**
+		 * Handle keydown events - adds keys to pressed state and triggers 'Pressed' shortcuts.
+		 * Fires repeatedly while a key is held down (due to OS key repeat), but activeShortcuts
+		 * ensures callbacks only fire once per physical key press.
+		 */
+		const keydown = on(window, 'keydown', (e) => {
+			// Skip shortcut processing if user is typing in an input field
+			if (isTypingInInput()) return;
+
+			let key = e.key.toLowerCase() as KeyboardEventPossibleKey;
+
+			// macOS Option key normalization:
+			// On macOS, the Option key (Alt) triggers special character insertion.
+			// For example, Option+A produces "å" instead of registering as "alt+a".
+			// This breaks keyboard shortcut detection because we get the special
+			// character instead of the actual key that was pressed.
+			//
+			// To fix this, when Option is held on macOS, we normalize these special
+			// characters back to their base keys (e.g., "å" → "a", "ç" → "c").
+			// This ensures keyboard shortcuts work consistently across platforms.
+			if (IS_MACOS && pressedKeys.includes('alt')) {
+				key = normalizeOptionKeyCharacter(key);
+			}
+
+			// Ignore keys that are not supported
+			if (!isSupportedKey(key)) return;
+
+			// Add key to pressed state if not already present
+			if (!pressedKeys.includes(key)) pressedKeys.push(key);
+
+			// Check all registered shortcuts for matches
+			for (const [
+				id,
+				{ callback, keyCombination, on },
+			] of shortcuts.entries()) {
+				if (!arraysMatch(pressedKeys, keyCombination)) continue;
+
+				// Always prevent default for matching shortcuts
+				e.preventDefault();
+
+				// Only trigger callback if shortcut not already active
+				// This is the key anti-spam mechanism: if the shortcut ID is already
+				// in activeShortcuts, we know it's been triggered and should not fire again
+				if (!activeShortcuts.has(id) && on.includes('Pressed')) {
+					activeShortcuts.add(id); // Mark as active BEFORE calling callback
+					callback('Pressed');
+				}
+			}
+		});
+
+		/**
+		 * Handle keyup events - removes keys from pressed state and triggers 'Released' shortcuts.
+		 * Also responsible for clearing activeShortcuts to allow shortcuts to fire again
+		 * on the next key press.
+		 */
+		const keyup = on(window, 'keyup', (e) => {
+			// Skip shortcut processing if user is typing in an input field
+			if (isTypingInInput()) return;
+
+			const key = e.key.toLowerCase() as KeyboardEventPossibleKey;
+
+			// Ignore keys that are not supported
+			if (!isSupportedKey(key)) return;
+
+			/** Modifier keys that require special handling */
+			const modifierKeys = ['meta', 'control', 'alt', 'shift'];
+
+			if (modifierKeys.includes(key)) {
+				// Special handling for modifier keys (meta, control, alt, shift)
+				// This addresses issues with OS/browser intercepting certain key combinations
+				// where non-modifier keyup events might not fire properly
+				// When a modifier key is released, clear all non-modifier keys
+				// but keep other modifier keys that might still be pressed
+				// This prevents keys from getting "stuck" in the pressedKeys state
+				pressedKeys = pressedKeys.filter((k) => modifierKeys.includes(k));
+				activeShortcuts.clear();
+			}
+
+			// Check all registered shortcuts for matches on release BEFORE removing the key
+			for (const [
+				id,
+				{ callback, keyCombination, on },
+			] of shortcuts.entries()) {
+				if (!arraysMatch(pressedKeys, keyCombination)) continue;
+				if (activeShortcuts.has(id) && on.includes('Released')) {
+					e.preventDefault();
+					callback('Released');
+					activeShortcuts.delete(id);
+				}
+			}
+
+			// Regular key removal from pressed state
+			pressedKeys = pressedKeys.filter((k) => k !== key);
+
+			// Clear active shortcuts when no keys are pressed
+			if (pressedKeys.length === 0) {
+				activeShortcuts.clear();
+			}
+		});
+
+		/**
+		 * Handle window blur events (switching applications, clicking outside browser)
+		 * Reset all keys when user shifts focus away from the window
+		 */
+		const blur = on(window, 'blur', () => {
+			pressedKeys = [];
+			activeShortcuts.clear();
+		});
+
+		/**
+		 * Handle tab visibility changes (switching browser tabs)
+		 * This catches cases where the window doesn't lose focus but the tab is hidden
+		 */
+		const visibilityChange = on(document, 'visibilitychange', () => {
+			if (document.visibilityState === 'hidden') {
+				pressedKeys = [];
+				activeShortcuts.clear();
+			}
+		});
+
+		/** Cleanup function that removes all event listeners */
+		return () => {
+			keydown();
+			keyup();
+			blur();
+			visibilityChange();
+		};
+	},
+	async register({
+		id,
+		keyCombination,
+		callback,
+		on,
+	}: {
+		id: CommandId;
+		keyCombination: KeyboardEventSupportedKey[];
+		callback: (state: ShortcutEventState) => void;
+		on: ShortcutEventState[];
+	}): Promise<Result<void, LocalShortcutServiceError>> {
+		shortcuts.set(id, { keyCombination, callback, on });
+		return Ok(undefined);
+	},
+
+	/**
+	 * Unregisters a local shortcut by ID.
+	 * This function is idempotent - it can be safely called even if the shortcut
+	 * with the given ID doesn't exist or has already been unregistered.
+	 */
+	async unregister(
+		id: CommandId,
+	): Promise<Result<void, LocalShortcutServiceError>> {
+		shortcuts.delete(id);
+		return Ok(undefined);
+	},
+
+	/**
+	 * Unregisters all local shortcuts.
+	 * This function is idempotent - it can be safely called even if no shortcuts
+	 * are currently registered.
+	 */
+	async unregisterAll(): Promise<Result<void, LocalShortcutServiceError>> {
+		shortcuts.clear();
+		return Ok(undefined);
+	},
+};
 
 /**
  * Checks if two arrays contain the same elements, regardless of order.
@@ -331,5 +325,3 @@ export function arrayToShortcutString(
 ): string {
 	return keys.map((key) => key.toLowerCase()).join('+');
 }
-
-export const LocalShortcutManagerLive = createLocalShortcutManager();

--- a/apps/whispering/src/lib/services/isomorphic/recorder/navigator.ts
+++ b/apps/whispering/src/lib/services/isomorphic/recorder/navigator.ts
@@ -30,177 +30,175 @@ type ActiveRecording = {
 	recordedChunks: Blob[];
 };
 
-export function createNavigatorRecorderService(): RecorderService {
-	let activeRecording: ActiveRecording | null = null;
-
-	return {
-		getRecorderState: async (): Promise<
-			Result<WhisperingRecordingState, RecorderServiceError>
-		> => {
-			return Ok(activeRecording ? 'RECORDING' : 'IDLE');
-		},
-
-		enumerateDevices: async () => {
-			const { data: devices, error } = await enumerateDevices();
-			if (error) {
-				return RecorderServiceErr({
-					message: error.message,
-				});
-			}
-			return Ok(devices);
-		},
-
-		startRecording: async (
-			{ selectedDeviceId, recordingId, bitrateKbps }: NavigatorRecordingParams,
-			{ sendStatus },
-		): Promise<Result<DeviceAcquisitionOutcome, RecorderServiceError>> => {
-			// Ensure we're not already recording
-			if (activeRecording) {
-				return RecorderServiceErr({
-					message:
-						'A recording is already in progress. Please stop the current recording before starting a new one.',
-				});
-			}
-
-			sendStatus({
-				title: '🎙️ Starting Recording',
-				description: 'Setting up your microphone...',
-			});
-
-			// Get the recording stream
-			const { data: streamResult, error: acquireStreamError } =
-				await getRecordingStream({ selectedDeviceId, sendStatus });
-			if (acquireStreamError) {
-				return RecorderServiceErr({
-					message: acquireStreamError.message,
-				});
-			}
-
-			const { stream, deviceOutcome } = streamResult;
-
-			const { data: mediaRecorder, error: recorderError } = trySync({
-				try: () =>
-					new MediaRecorder(stream, {
-						bitsPerSecond: Number(bitrateKbps) * 1000,
-					}),
-				catch: (error) =>
-					RecorderServiceErr({
-						message: `Failed to initialize the audio recorder. This could be due to unsupported audio settings, microphone conflicts, or browser limitations. Please check your microphone is working and try adjusting your audio settings. ${extractErrorMessage(error)}`,
-					}),
-			});
-
-			if (recorderError) {
-				// Clean up stream if recorder creation fails
-				cleanupRecordingStream(stream);
-				return Err(recorderError);
-			}
-
-			// Set up recording state and event handlers
-			const recordedChunks: Blob[] = [];
-
-			// Store active recording state
-			activeRecording = {
-				recordingId,
-				selectedDeviceId,
-				bitrateKbps,
-				stream,
-				mediaRecorder,
-				recordedChunks,
-			};
-
-			// Set up event handlers
-			mediaRecorder.addEventListener('dataavailable', (event: BlobEvent) => {
-				if (event.data.size) recordedChunks.push(event.data);
-			});
-
-			// Start recording
-			mediaRecorder.start(TIMESLICE_MS);
-
-			// Return the device acquisition outcome
-			return Ok(deviceOutcome);
-		},
-
-		stopRecording: async ({
-			sendStatus,
-		}): Promise<Result<Blob, RecorderServiceError>> => {
-			if (!activeRecording) {
-				return RecorderServiceErr({
-					message:
-						'Cannot stop recording because no active recording session was found. Make sure you have started recording before attempting to stop it.',
-				});
-			}
-
-			const recording = activeRecording;
-			activeRecording = null; // Clear immediately to prevent race conditions
-
-			sendStatus({
-				title: '⏸️ Finishing Recording',
-				description: 'Saving your audio...',
-			});
-
-			// Stop the recorder and wait for the final data
-			const { data: blob, error: stopError } = await tryAsync({
-				try: () =>
-					new Promise<Blob>((resolve) => {
-						recording.mediaRecorder.addEventListener('stop', () => {
-							const audioBlob = new Blob(recording.recordedChunks, {
-								type: recording.mediaRecorder.mimeType,
-							});
-							resolve(audioBlob);
-						});
-						recording.mediaRecorder.stop();
-					}),
-				catch: (error) =>
-					RecorderServiceErr({
-						message: `Failed to properly stop and save the recording. This might be due to corrupted audio data, insufficient storage space, or a browser issue. Your recording data may be lost. ${extractErrorMessage(error)}`,
-					}),
-			});
-
-			// Always clean up the stream
-			cleanupRecordingStream(recording.stream);
-
-			if (stopError) return Err(stopError);
-
-			sendStatus({
-				title: '✅ Recording Saved',
-				description: 'Your recording is ready for transcription!',
-			});
-			return Ok(blob);
-		},
-
-		cancelRecording: async ({
-			sendStatus,
-		}): Promise<Result<CancelRecordingResult, RecorderServiceError>> => {
-			if (!activeRecording) {
-				return Ok({ status: 'no-recording' });
-			}
-
-			const recording = activeRecording;
-			activeRecording = null; // Clear immediately
-
-			sendStatus({
-				title: '🛑 Cancelling',
-				description: 'Discarding your recording...',
-			});
-
-			// Stop the recorder
-			recording.mediaRecorder.stop();
-
-			// Clean up the stream
-			cleanupRecordingStream(recording.stream);
-
-			sendStatus({
-				title: '✨ Cancelled',
-				description: 'Recording discarded successfully!',
-			});
-
-			return Ok({ status: 'cancelled' });
-		},
-	};
-}
+let activeRecording: ActiveRecording | null = null;
 
 /**
  * Navigator recorder service that uses the MediaRecorder API.
  * Available in both browser and desktop environments.
  */
-export const NavigatorRecorderServiceLive = createNavigatorRecorderService();
+export const NavigatorRecorderServiceLive: RecorderService = {
+	getRecorderState: async (): Promise<
+		Result<WhisperingRecordingState, RecorderServiceError>
+	> => {
+		return Ok(activeRecording ? 'RECORDING' : 'IDLE');
+	},
+
+	enumerateDevices: async () => {
+		const { data: devices, error } = await enumerateDevices();
+		if (error) {
+			return RecorderServiceErr({
+				message: error.message,
+			});
+		}
+		return Ok(devices);
+	},
+
+	startRecording: async (
+		{ selectedDeviceId, recordingId, bitrateKbps }: NavigatorRecordingParams,
+		{ sendStatus },
+	): Promise<Result<DeviceAcquisitionOutcome, RecorderServiceError>> => {
+		// Ensure we're not already recording
+		if (activeRecording) {
+			return RecorderServiceErr({
+				message:
+					'A recording is already in progress. Please stop the current recording before starting a new one.',
+			});
+		}
+
+		sendStatus({
+			title: '🎙️ Starting Recording',
+			description: 'Setting up your microphone...',
+		});
+
+		// Get the recording stream
+		const { data: streamResult, error: acquireStreamError } =
+			await getRecordingStream({ selectedDeviceId, sendStatus });
+		if (acquireStreamError) {
+			return RecorderServiceErr({
+				message: acquireStreamError.message,
+			});
+		}
+
+		const { stream, deviceOutcome } = streamResult;
+
+		const { data: mediaRecorder, error: recorderError } = trySync({
+			try: () =>
+				new MediaRecorder(stream, {
+					bitsPerSecond: Number(bitrateKbps) * 1000,
+				}),
+			catch: (error) =>
+				RecorderServiceErr({
+					message: `Failed to initialize the audio recorder. This could be due to unsupported audio settings, microphone conflicts, or browser limitations. Please check your microphone is working and try adjusting your audio settings. ${extractErrorMessage(error)}`,
+				}),
+		});
+
+		if (recorderError) {
+			// Clean up stream if recorder creation fails
+			cleanupRecordingStream(stream);
+			return Err(recorderError);
+		}
+
+		// Set up recording state and event handlers
+		const recordedChunks: Blob[] = [];
+
+		// Store active recording state
+		activeRecording = {
+			recordingId,
+			selectedDeviceId,
+			bitrateKbps,
+			stream,
+			mediaRecorder,
+			recordedChunks,
+		};
+
+		// Set up event handlers
+		mediaRecorder.addEventListener('dataavailable', (event: BlobEvent) => {
+			if (event.data.size) recordedChunks.push(event.data);
+		});
+
+		// Start recording
+		mediaRecorder.start(TIMESLICE_MS);
+
+		// Return the device acquisition outcome
+		return Ok(deviceOutcome);
+	},
+
+	stopRecording: async ({
+		sendStatus,
+	}): Promise<Result<Blob, RecorderServiceError>> => {
+		if (!activeRecording) {
+			return RecorderServiceErr({
+				message:
+					'Cannot stop recording because no active recording session was found. Make sure you have started recording before attempting to stop it.',
+			});
+		}
+
+		const recording = activeRecording;
+		activeRecording = null; // Clear immediately to prevent race conditions
+
+		sendStatus({
+			title: '⏸️ Finishing Recording',
+			description: 'Saving your audio...',
+		});
+
+		// Stop the recorder and wait for the final data
+		const { data: blob, error: stopError } = await tryAsync({
+			try: () =>
+				new Promise<Blob>((resolve) => {
+					recording.mediaRecorder.addEventListener('stop', () => {
+						const audioBlob = new Blob(recording.recordedChunks, {
+							type: recording.mediaRecorder.mimeType,
+						});
+						resolve(audioBlob);
+					});
+					recording.mediaRecorder.stop();
+				}),
+			catch: (error) =>
+				RecorderServiceErr({
+					message: `Failed to properly stop and save the recording. This might be due to corrupted audio data, insufficient storage space, or a browser issue. Your recording data may be lost. ${extractErrorMessage(error)}`,
+				}),
+		});
+
+		// Always clean up the stream
+		cleanupRecordingStream(recording.stream);
+
+		if (stopError) return Err(stopError);
+
+		sendStatus({
+			title: '✅ Recording Saved',
+			description: 'Your recording is ready for transcription!',
+		});
+		return Ok(blob);
+	},
+
+	cancelRecording: async ({
+		sendStatus,
+	}): Promise<Result<CancelRecordingResult, RecorderServiceError>> => {
+		if (!activeRecording) {
+			return Ok({ status: 'no-recording' });
+		}
+
+		const recording = activeRecording;
+		activeRecording = null; // Clear immediately
+
+		sendStatus({
+			title: '🛑 Cancelling',
+			description: 'Discarding your recording...',
+		});
+
+		// Stop the recorder
+		recording.mediaRecorder.stop();
+
+		// Clean up the stream
+		cleanupRecordingStream(recording.stream);
+
+		sendStatus({
+			title: '✨ Cancelled',
+			description: 'Recording discarded successfully!',
+		});
+
+		return Ok({ status: 'cancelled' });
+	},
+};
+
+export type NavigatorRecorderService = typeof NavigatorRecorderServiceLive;

--- a/apps/whispering/src/lib/services/isomorphic/transcription/cloud/deepgram.ts
+++ b/apps/whispering/src/lib/services/isomorphic/transcription/cloud/deepgram.ts
@@ -1,7 +1,6 @@
 import { type } from 'arktype';
 import { Ok, type Result } from 'wellcrafted/result';
 import { WhisperingErr, type WhisperingError } from '$lib/result';
-import type { HttpService } from '$lib/services/isomorphic/http';
 import { HttpServiceLive } from '$lib/services/isomorphic/http';
 import type { Settings } from '$lib/settings';
 
@@ -57,209 +56,196 @@ const DeepgramResponse = type({
 	},
 });
 
-export function createDeepgramTranscriptionService({
-	HttpService,
-}: {
-	HttpService: HttpService;
-}) {
-	return {
-		async transcribe(
-			audioBlob: Blob,
-			options: {
-				prompt: string;
-				temperature: string;
-				outputLanguage: Settings['transcription.outputLanguage'];
-				apiKey: string;
-				modelName: (string & {}) | DeepgramModel['name'];
-			},
-		): Promise<Result<string, WhisperingError>> {
-			// Pre-validation: Check API key
-			if (!options.apiKey) {
-				return WhisperingErr({
-					title: '🔑 API Key Required',
-					description:
-						'Please enter your Deepgram API key in settings to use Deepgram transcription.',
-					action: {
-						type: 'link',
-						label: 'Add API key',
-						href: '/settings/transcription',
-					},
-				});
-			}
+export const DeepgramTranscriptionServiceLive = {
+	async transcribe(
+		audioBlob: Blob,
+		options: {
+			prompt: string;
+			temperature: string;
+			outputLanguage: Settings['transcription.outputLanguage'];
+			apiKey: string;
+			modelName: (string & {}) | DeepgramModel['name'];
+		},
+	): Promise<Result<string, WhisperingError>> {
+		// Pre-validation: Check API key
+		if (!options.apiKey) {
+			return WhisperingErr({
+				title: '🔑 API Key Required',
+				description:
+					'Please enter your Deepgram API key in settings to use Deepgram transcription.',
+				action: {
+					type: 'link',
+					label: 'Add API key',
+					href: '/settings/transcription',
+				},
+			});
+		}
 
-			// Validate file size
-			const blobSizeInMb = audioBlob.size / (1024 * 1024);
-			if (blobSizeInMb > MAX_FILE_SIZE_MB) {
-				return WhisperingErr({
-					title: `The file size (${blobSizeInMb}MB) is too large`,
-					description: `Please upload a file smaller than ${MAX_FILE_SIZE_MB}MB.`,
-				});
-			}
+		// Validate file size
+		const blobSizeInMb = audioBlob.size / (1024 * 1024);
+		if (blobSizeInMb > MAX_FILE_SIZE_MB) {
+			return WhisperingErr({
+				title: `The file size (${blobSizeInMb}MB) is too large`,
+				description: `Please upload a file smaller than ${MAX_FILE_SIZE_MB}MB.`,
+			});
+		}
 
-			// Build query parameters
-			const params = new URLSearchParams({
-				model: options.modelName,
-				smart_format: 'true',
-				punctuate: 'true',
-				paragraphs: 'true',
+		// Build query parameters
+		const params = new URLSearchParams({
+			model: options.modelName,
+			smart_format: 'true',
+			punctuate: 'true',
+			paragraphs: 'true',
+		});
+
+		if (options.outputLanguage !== 'auto') {
+			params.append('language', options.outputLanguage);
+		}
+
+		if (options.prompt) {
+			const isNova3 = options.modelName.toLowerCase().includes('nova-3');
+			params.append(isNova3 ? 'keyterm' : 'keywords', options.prompt);
+		}
+
+		// Send raw audio data directly as recommended by Deepgram docs
+		const { data: deepgramResponse, error: postError } =
+			await HttpServiceLive.post({
+				url: `https://api.deepgram.com/v1/listen?${params.toString()}`,
+				body: audioBlob, // Send raw audio blob directly
+				headers: {
+					Authorization: `Token ${options.apiKey}`,
+					'Content-Type': audioBlob.type || 'audio/*', // Use the blob's mime type or fallback to audio/*
+				},
+				schema: DeepgramResponse,
 			});
 
-			if (options.outputLanguage !== 'auto') {
-				params.append('language', options.outputLanguage);
-			}
+		if (postError) {
+			switch (postError.name) {
+				case 'ConnectionError': {
+					return WhisperingErr({
+						title: '🌐 Connection Issue',
+						description:
+							'Unable to connect to Deepgram service. Please check your internet connection.',
+						action: { type: 'more-details', error: postError },
+					});
+				}
 
-			if (options.prompt) {
-				const isNova3 = options.modelName.toLowerCase().includes('nova-3');
-				params.append(isNova3 ? 'keyterm' : 'keywords', options.prompt);
-			}
+				case 'ResponseError': {
+					const {
+						context: { status },
+						message,
+					} = postError;
 
-			// Send raw audio data directly as recommended by Deepgram docs
-			const { data: deepgramResponse, error: postError } =
-				await HttpService.post({
-					url: `https://api.deepgram.com/v1/listen?${params.toString()}`,
-					body: audioBlob, // Send raw audio blob directly
-					headers: {
-						Authorization: `Token ${options.apiKey}`,
-						'Content-Type': audioBlob.type || 'audio/*', // Use the blob's mime type or fallback to audio/*
-					},
-					schema: DeepgramResponse,
-				});
-
-			if (postError) {
-				switch (postError.name) {
-					case 'ConnectionError': {
+					if (status === 400) {
 						return WhisperingErr({
-							title: '🌐 Connection Issue',
-							description:
-								'Unable to connect to Deepgram service. Please check your internet connection.',
-							action: { type: 'more-details', error: postError },
-						});
-					}
-
-					case 'ResponseError': {
-						const {
-							context: { status },
-							message,
-						} = postError;
-
-						if (status === 400) {
-							return WhisperingErr({
-								title: '❌ Bad Request',
-								description:
-									message ||
-									'Invalid request parameters. Please check your audio file and settings.',
-								action: { type: 'more-details', error: postError },
-							});
-						}
-
-						if (status === 401) {
-							return WhisperingErr({
-								title: '🔑 Authentication Failed',
-								description:
-									'Your Deepgram API key is invalid or expired. Please update your API key in settings.',
-								action: {
-									type: 'link',
-									label: 'Update API key',
-									href: '/settings/transcription',
-								},
-							});
-						}
-
-						if (status === 403) {
-							return WhisperingErr({
-								title: '⛔ Access Denied',
-								description:
-									message ||
-									'Your account does not have access to this feature or model.',
-								action: { type: 'more-details', error: postError },
-							});
-						}
-
-						if (status === 413) {
-							return WhisperingErr({
-								title: '📦 Audio File Too Large',
-								description:
-									'Your audio file exceeds the maximum size limit. Try splitting it into smaller segments.',
-								action: { type: 'more-details', error: postError },
-							});
-						}
-
-						if (status === 415) {
-							return WhisperingErr({
-								title: '🎵 Unsupported Format',
-								description:
-									"This audio format isn't supported. Please convert your file to a supported format.",
-								action: { type: 'more-details', error: postError },
-							});
-						}
-
-						if (status === 429) {
-							return WhisperingErr({
-								title: '⏱️ Rate Limit Reached',
-								description:
-									'Too many requests. Please wait before trying again.',
-								action: { type: 'more-details', error: postError },
-							});
-						}
-
-						if (status && status >= 500) {
-							return WhisperingErr({
-								title: '🔧 Service Unavailable',
-								description: `The Deepgram service is temporarily unavailable (Error ${status}). Please try again later.`,
-								action: { type: 'more-details', error: postError },
-							});
-						}
-
-						return WhisperingErr({
-							title: '❌ Transcription Failed',
+							title: '❌ Bad Request',
 							description:
 								message ||
-								'An unexpected error occurred during transcription. Please try again.',
+								'Invalid request parameters. Please check your audio file and settings.',
 							action: { type: 'more-details', error: postError },
 						});
 					}
 
-					case 'ParseError':
+					if (status === 401) {
 						return WhisperingErr({
-							title: '🔍 Response Error',
+							title: '🔑 Authentication Failed',
 							description:
-								'Received an unexpected response from Deepgram service. Please try again.',
-							action: { type: 'more-details', error: postError },
+								'Your Deepgram API key is invalid or expired. Please update your API key in settings.',
+							action: {
+								type: 'link',
+								label: 'Update API key',
+								href: '/settings/transcription',
+							},
 						});
+					}
 
-					default:
+					if (status === 403) {
 						return WhisperingErr({
-							title: '❓ Unexpected Error',
+							title: '⛔ Access Denied',
 							description:
-								'An unexpected error occurred during transcription. Please try again.',
+								message ||
+								'Your account does not have access to this feature or model.',
 							action: { type: 'more-details', error: postError },
 						});
+					}
+
+					if (status === 413) {
+						return WhisperingErr({
+							title: '📦 Audio File Too Large',
+							description:
+								'Your audio file exceeds the maximum size limit. Try splitting it into smaller segments.',
+							action: { type: 'more-details', error: postError },
+						});
+					}
+
+					if (status === 415) {
+						return WhisperingErr({
+							title: '🎵 Unsupported Format',
+							description:
+								"This audio format isn't supported. Please convert your file to a supported format.",
+							action: { type: 'more-details', error: postError },
+						});
+					}
+
+					if (status === 429) {
+						return WhisperingErr({
+							title: '⏱️ Rate Limit Reached',
+							description:
+								'Too many requests. Please wait before trying again.',
+							action: { type: 'more-details', error: postError },
+						});
+					}
+
+					if (status && status >= 500) {
+						return WhisperingErr({
+							title: '🔧 Service Unavailable',
+							description: `The Deepgram service is temporarily unavailable (Error ${status}). Please try again later.`,
+							action: { type: 'more-details', error: postError },
+						});
+					}
+
+					return WhisperingErr({
+						title: '❌ Transcription Failed',
+						description:
+							message ||
+							'An unexpected error occurred during transcription. Please try again.',
+						action: { type: 'more-details', error: postError },
+					});
 				}
+
+				case 'ParseError':
+					return WhisperingErr({
+						title: '🔍 Response Error',
+						description:
+							'Received an unexpected response from Deepgram service. Please try again.',
+						action: { type: 'more-details', error: postError },
+					});
+
+				default:
+					return WhisperingErr({
+						title: '❓ Unexpected Error',
+						description:
+							'An unexpected error occurred during transcription. Please try again.',
+						action: { type: 'more-details', error: postError },
+					});
 			}
+		}
 
-			// Extract transcription text
-			const transcript = deepgramResponse.results?.channels
-				?.at(0)
-				?.alternatives?.at(0)?.transcript;
+		// Extract transcription text
+		const transcript = deepgramResponse.results?.channels
+			?.at(0)
+			?.alternatives?.at(0)?.transcript;
 
-			if (!transcript) {
-				return WhisperingErr({
-					title: '📝 No Transcription Found',
-					description:
-						'No speech was detected in the audio file. Please check your audio and try again.',
-				});
-			}
+		if (!transcript) {
+			return WhisperingErr({
+				title: '📝 No Transcription Found',
+				description:
+					'No speech was detected in the audio file. Please check your audio and try again.',
+			});
+		}
 
-			return Ok(transcript.trim());
-		},
-	};
-}
+		return Ok(transcript.trim());
+	},
+};
 
-export type DeepgramTranscriptionService = ReturnType<
-	typeof createDeepgramTranscriptionService
->;
-
-export const DeepgramTranscriptionServiceLive =
-	createDeepgramTranscriptionService({
-		HttpService: HttpServiceLive,
-	});
+export type DeepgramTranscriptionService = typeof DeepgramTranscriptionServiceLive;

--- a/apps/whispering/src/lib/services/isomorphic/transcription/cloud/elevenlabs.ts
+++ b/apps/whispering/src/lib/services/isomorphic/transcription/cloud/elevenlabs.ts
@@ -20,77 +20,71 @@ export const ELEVENLABS_TRANSCRIPTION_MODELS = [
 
 export type ElevenLabsModel = (typeof ELEVENLABS_TRANSCRIPTION_MODELS)[number];
 
-export function createElevenLabsTranscriptionService() {
-	return {
-		transcribe: async (
-			audioBlob: Blob,
-			options: {
-				prompt: string;
-				temperature: string;
-				outputLanguage: Settings['transcription.outputLanguage'];
-				apiKey: string;
-				modelName: (string & {}) | ElevenLabsModel['name'];
-			},
-		): Promise<Result<string, WhisperingError>> => {
-			if (!options.apiKey) {
-				return WhisperingErr({
-					title: '🔑 API Key Required',
-					description:
-						'Please enter your ElevenLabs API key in settings to use speech-to-text transcription.',
-					action: {
-						type: 'link',
-						label: 'Add API key',
-						href: '/settings/transcription',
-					},
-				});
-			}
-
-			try {
-				const client = new ElevenLabsClient({
-					apiKey: options.apiKey,
-				});
-
-				// Check file size
-				const blobSizeInMb = audioBlob.size / (1024 * 1024);
-				const MAX_FILE_SIZE_MB = 1000; // ElevenLabs allows files up to 1GB
-
-				if (blobSizeInMb > MAX_FILE_SIZE_MB) {
-					return WhisperingErr({
-						title: '📁 File Size Too Large',
-						description: `Your audio file (${blobSizeInMb.toFixed(1)}MB) exceeds the ${MAX_FILE_SIZE_MB}MB limit. Please use a smaller file or compress the audio.`,
-					});
-				}
-
-				// Use the client's speechToText functionality
-				const transcription = await client.speechToText.convert({
-					file: audioBlob,
-					model_id: options.modelName,
-					// Map outputLanguage if not set to 'auto'
-					language_code:
-						options.outputLanguage !== 'auto'
-							? options.outputLanguage
-							: undefined,
-					tag_audio_events: false,
-					diarize: true,
-				});
-
-				// Return the transcribed text
-				return Ok(transcription.text.trim());
-			} catch (error) {
-				return WhisperingErr({
-					title: '🔧 Transcription Failed',
-					description:
-						'Unable to complete the transcription using ElevenLabs. This may be due to a service issue or unsupported audio format. Please try again.',
-					action: { type: 'more-details', error },
-				});
-			}
+export const ElevenlabsTranscriptionServiceLive = {
+	transcribe: async (
+		audioBlob: Blob,
+		options: {
+			prompt: string;
+			temperature: string;
+			outputLanguage: Settings['transcription.outputLanguage'];
+			apiKey: string;
+			modelName: (string & {}) | ElevenLabsModel['name'];
 		},
-	};
-}
+	): Promise<Result<string, WhisperingError>> => {
+		if (!options.apiKey) {
+			return WhisperingErr({
+				title: '🔑 API Key Required',
+				description:
+					'Please enter your ElevenLabs API key in settings to use speech-to-text transcription.',
+				action: {
+					type: 'link',
+					label: 'Add API key',
+					href: '/settings/transcription',
+				},
+			});
+		}
 
-export type ElevenLabsTranscriptionService = ReturnType<
-	typeof createElevenLabsTranscriptionService
->;
+		try {
+			const client = new ElevenLabsClient({
+				apiKey: options.apiKey,
+			});
 
-export const ElevenlabsTranscriptionServiceLive =
-	createElevenLabsTranscriptionService();
+			// Check file size
+			const blobSizeInMb = audioBlob.size / (1024 * 1024);
+			const MAX_FILE_SIZE_MB = 1000; // ElevenLabs allows files up to 1GB
+
+			if (blobSizeInMb > MAX_FILE_SIZE_MB) {
+				return WhisperingErr({
+					title: '📁 File Size Too Large',
+					description: `Your audio file (${blobSizeInMb.toFixed(1)}MB) exceeds the ${MAX_FILE_SIZE_MB}MB limit. Please use a smaller file or compress the audio.`,
+				});
+			}
+
+			// Use the client's speechToText functionality
+			const transcription = await client.speechToText.convert({
+				file: audioBlob,
+				model_id: options.modelName,
+				// Map outputLanguage if not set to 'auto'
+				language_code:
+					options.outputLanguage !== 'auto'
+						? options.outputLanguage
+						: undefined,
+				tag_audio_events: false,
+				diarize: true,
+			});
+
+			// Return the transcribed text
+			return Ok(transcription.text.trim());
+		} catch (error) {
+			return WhisperingErr({
+				title: '🔧 Transcription Failed',
+				description:
+					'Unable to complete the transcription using ElevenLabs. This may be due to a service issue or unsupported audio format. Please try again.',
+				action: { type: 'more-details', error },
+			});
+		}
+	},
+};
+
+export type ElevenLabsTranscriptionService =
+	typeof ElevenlabsTranscriptionServiceLive;

--- a/apps/whispering/src/lib/services/isomorphic/transcription/cloud/groq.ts
+++ b/apps/whispering/src/lib/services/isomorphic/transcription/cloud/groq.ts
@@ -25,9 +25,8 @@ export type GroqModel = (typeof GROQ_MODELS)[number];
 
 const MAX_FILE_SIZE_MB = 25 as const;
 
-export function createGroqTranscriptionService() {
-	return {
-		async transcribe(
+export const GroqTranscriptionServiceLive = {
+	async transcribe(
 			audioBlob: Blob,
 			options: {
 				prompt: string;
@@ -252,12 +251,7 @@ export function createGroqTranscriptionService() {
 			}
 
 			return Ok(transcription.text.trim());
-		},
-	};
-}
+	},
+};
 
-export type GroqTranscriptionService = ReturnType<
-	typeof createGroqTranscriptionService
->;
-
-export const GroqTranscriptionServiceLive = createGroqTranscriptionService();
+export type GroqTranscriptionService = typeof GroqTranscriptionServiceLive;

--- a/apps/whispering/src/lib/services/isomorphic/transcription/cloud/mistral.ts
+++ b/apps/whispering/src/lib/services/isomorphic/transcription/cloud/mistral.ts
@@ -22,152 +22,145 @@ export type MistralModel = (typeof MISTRAL_TRANSCRIPTION_MODELS)[number];
 
 const MAX_FILE_SIZE_MB = 25 as const;
 
-export function createMistralTranscriptionService() {
-	return {
-		async transcribe(
-			audioBlob: Blob,
-			options: {
-				prompt: string;
-				temperature: string;
-				outputLanguage: Settings['transcription.outputLanguage'];
-				apiKey: string;
-				modelName: (string & {}) | MistralModel['name'];
+export const MistralTranscriptionServiceLive = {
+	async transcribe(
+		audioBlob: Blob,
+		options: {
+			prompt: string;
+			temperature: string;
+			outputLanguage: Settings['transcription.outputLanguage'];
+			apiKey: string;
+			modelName: (string & {}) | MistralModel['name'];
+		},
+	): Promise<Result<string, WhisperingError>> {
+		// Pre-validate API key
+		if (!options.apiKey) {
+			return WhisperingErr({
+				title: '🔑 API Key Required',
+				description: 'Please enter your Mistral API key in settings.',
+				action: {
+					type: 'link',
+					label: 'Add API key',
+					href: '/settings/transcription',
+				},
+			});
+		}
+
+		// Check file size
+		const blobSizeInMb = audioBlob.size / (1024 * 1024);
+		if (blobSizeInMb > MAX_FILE_SIZE_MB) {
+			return WhisperingErr({
+				title: `The file size (${blobSizeInMb}MB) is too large`,
+				description: `Please upload a file smaller than ${MAX_FILE_SIZE_MB}MB.`,
+			});
+		}
+
+		// Create file from blob
+		const { data: file, error: fileError } = trySync({
+			try: () =>
+				new File(
+					[audioBlob],
+					`recording.${getAudioExtension(audioBlob.type)}`,
+					{ type: audioBlob.type },
+				),
+			catch: (error) =>
+				WhisperingErr({
+					title: '📄 File Creation Failed',
+					description:
+						'Failed to create audio file for transcription. Please try again.',
+					action: { type: 'more-details', error },
+				}),
+		});
+
+		if (fileError) return Err(fileError);
+
+		// Make the transcription request
+		const { data: transcription, error: mistralApiError } = await tryAsync({
+			try: () =>
+				new Mistral({
+					apiKey: options.apiKey,
+				}).audio.transcriptions.complete({
+					file,
+					model: options.modelName,
+					language:
+						options.outputLanguage !== 'auto'
+							? options.outputLanguage
+							: undefined,
+					temperature: options.temperature
+						? Number.parseFloat(options.temperature)
+						: undefined,
+				}),
+			catch: (error) => {
+				// Return the error directly for processing
+				return Err(error);
 			},
-		): Promise<Result<string, WhisperingError>> {
-			// Pre-validate API key
-			if (!options.apiKey) {
+		});
+
+		if (mistralApiError) {
+			// Handle Mistral API errors
+			const errorMessage =
+				mistralApiError instanceof Error
+					? mistralApiError.message
+					: 'Unknown error occurred';
+
+			// Check for common HTTP status codes
+			if (
+				errorMessage.includes('401') ||
+				errorMessage.includes('Unauthorized')
+			) {
 				return WhisperingErr({
-					title: '🔑 API Key Required',
-					description: 'Please enter your Mistral API key in settings.',
+					title: '🔑 Authentication Required',
+					description:
+						'Your API key appears to be invalid or expired. Please update your API key in settings.',
 					action: {
 						type: 'link',
-						label: 'Add API key',
+						label: 'Update API key',
 						href: '/settings/transcription',
 					},
 				});
 			}
 
-			// Check file size
-			const blobSizeInMb = audioBlob.size / (1024 * 1024);
-			if (blobSizeInMb > MAX_FILE_SIZE_MB) {
+			if (
+				errorMessage.includes('429') ||
+				errorMessage.includes('rate limit')
+			) {
 				return WhisperingErr({
-					title: `The file size (${blobSizeInMb}MB) is too large`,
-					description: `Please upload a file smaller than ${MAX_FILE_SIZE_MB}MB.`,
-				});
-			}
-
-			// Create file from blob
-			const { data: file, error: fileError } = trySync({
-				try: () =>
-					new File(
-						[audioBlob],
-						`recording.${getAudioExtension(audioBlob.type)}`,
-						{ type: audioBlob.type },
-					),
-				catch: (error) =>
-					WhisperingErr({
-						title: '📄 File Creation Failed',
-						description:
-							'Failed to create audio file for transcription. Please try again.',
-						action: { type: 'more-details', error },
-					}),
-			});
-
-			if (fileError) return Err(fileError);
-
-			// Make the transcription request
-			const { data: transcription, error: mistralApiError } = await tryAsync({
-				try: () =>
-					new Mistral({
-						apiKey: options.apiKey,
-					}).audio.transcriptions.complete({
-						file,
-						model: options.modelName,
-						language:
-							options.outputLanguage !== 'auto'
-								? options.outputLanguage
-								: undefined,
-						temperature: options.temperature
-							? Number.parseFloat(options.temperature)
-							: undefined,
-					}),
-				catch: (error) => {
-					// Return the error directly for processing
-					return Err(error);
-				},
-			});
-
-			if (mistralApiError) {
-				// Handle Mistral API errors
-				const errorMessage =
-					mistralApiError instanceof Error
-						? mistralApiError.message
-						: 'Unknown error occurred';
-
-				// Check for common HTTP status codes
-				if (
-					errorMessage.includes('401') ||
-					errorMessage.includes('Unauthorized')
-				) {
-					return WhisperingErr({
-						title: '🔑 Authentication Required',
-						description:
-							'Your API key appears to be invalid or expired. Please update your API key in settings.',
-						action: {
-							type: 'link',
-							label: 'Update API key',
-							href: '/settings/transcription',
-						},
-					});
-				}
-
-				if (
-					errorMessage.includes('429') ||
-					errorMessage.includes('rate limit')
-				) {
-					return WhisperingErr({
-						title: '⏱️ Rate Limit Reached',
-						description: 'Too many requests. Please try again later.',
-						action: { type: 'more-details', error: mistralApiError },
-					});
-				}
-
-				if (
-					errorMessage.includes('413') ||
-					errorMessage.includes('too large')
-				) {
-					return WhisperingErr({
-						title: '📦 Audio File Too Large',
-						description:
-							'Your audio file exceeds the maximum size limit. Try reducing the file size.',
-						action: { type: 'more-details', error: mistralApiError },
-					});
-				}
-
-				// Generic error fallback
-				return WhisperingErr({
-					title: '❌ Transcription Failed',
-					description: errorMessage,
+					title: '⏱️ Rate Limit Reached',
+					description: 'Too many requests. Please try again later.',
 					action: { type: 'more-details', error: mistralApiError },
 				});
 			}
 
-			// Check if transcription is valid
-			if (!transcription || typeof transcription.text !== 'string') {
+			if (
+				errorMessage.includes('413') ||
+				errorMessage.includes('too large')
+			) {
 				return WhisperingErr({
-					title: '❌ Invalid Transcription Response',
-					description: 'Mistral API returned an invalid response format.',
+					title: '📦 Audio File Too Large',
+					description:
+						'Your audio file exceeds the maximum size limit. Try reducing the file size.',
+					action: { type: 'more-details', error: mistralApiError },
 				});
 			}
 
-			return Ok(transcription.text.trim());
-		},
-	};
-}
+			// Generic error fallback
+			return WhisperingErr({
+				title: '❌ Transcription Failed',
+				description: errorMessage,
+				action: { type: 'more-details', error: mistralApiError },
+			});
+		}
 
-export type MistralTranscriptionService = ReturnType<
-	typeof createMistralTranscriptionService
->;
+		// Check if transcription is valid
+		if (!transcription || typeof transcription.text !== 'string') {
+			return WhisperingErr({
+				title: '❌ Invalid Transcription Response',
+				description: 'Mistral API returned an invalid response format.',
+			});
+		}
 
-export const MistralTranscriptionServiceLive =
-	createMistralTranscriptionService();
+		return Ok(transcription.text.trim());
+	},
+};
+
+export type MistralTranscriptionService = typeof MistralTranscriptionServiceLive;

--- a/apps/whispering/src/lib/services/isomorphic/transcription/cloud/openai.ts
+++ b/apps/whispering/src/lib/services/isomorphic/transcription/cloud/openai.ts
@@ -36,9 +36,8 @@ export type OpenAIModel = (typeof OPENAI_TRANSCRIPTION_MODELS)[number];
 
 const MAX_FILE_SIZE_MB = 25 as const;
 
-export function createOpenaiTranscriptionService() {
-	return {
-		async transcribe(
+export const OpenaiTranscriptionServiceLive = {
+	async transcribe(
 			audioBlob: Blob,
 			options: {
 				prompt: string;
@@ -279,12 +278,6 @@ export function createOpenaiTranscriptionService() {
 			// Success - return the transcription text
 			return Ok(transcription.text.trim());
 		},
-	};
-}
+};
 
-export type OpenaiTranscriptionService = ReturnType<
-	typeof createOpenaiTranscriptionService
->;
-
-export const OpenaiTranscriptionServiceLive =
-	createOpenaiTranscriptionService();
+export type OpenaiTranscriptionService = typeof OpenaiTranscriptionServiceLive;

--- a/apps/whispering/src/lib/services/isomorphic/transcription/local/parakeet.ts
+++ b/apps/whispering/src/lib/services/isomorphic/transcription/local/parakeet.ts
@@ -54,149 +54,142 @@ const ParakeetErrorType = type({
 	message: 'string',
 });
 
-export function createParakeetTranscriptionService() {
-	return {
-		async transcribe(
-			audioBlob: Blob,
-			options: { modelPath: string },
-		): Promise<Result<string, WhisperingError>> {
-			// Pre-validation
-			if (!options.modelPath) {
-				return WhisperingErr({
-					title: '📁 Model Directory Required',
-					description: 'Please select a Parakeet model directory in settings.',
-					action: {
-						type: 'link',
-						label: 'Configure model',
-						href: '/settings/transcription',
-					},
-				});
-			}
-
-			// Check if model directory exists
-			const { data: isExists } = await tryAsync({
-				try: () => exists(options.modelPath),
-				catch: () => Ok(false),
-			});
-
-			if (!isExists) {
-				return WhisperingErr({
-					title: '❌ Model Directory Not Found',
-					description: `The model directory "${options.modelPath}" does not exist.`,
-					action: {
-						type: 'link',
-						label: 'Select model',
-						href: '/settings/transcription',
-					},
-				});
-			}
-
-			// Check if it's actually a directory
-			const { data: stats } = await tryAsync({
-				try: () => stat(options.modelPath),
-				catch: () => Ok(null),
-			});
-
-			if (!stats || !stats.isDirectory) {
-				return WhisperingErr({
-					title: '❌ Invalid Model Path',
-					description:
-						'Parakeet models must be directories containing model files.',
-					action: {
-						type: 'link',
-						label: 'Select model directory',
-						href: '/settings/transcription',
-					},
-				});
-			}
-
-			// Convert audio blob to byte array
-			const arrayBuffer = await audioBlob.arrayBuffer();
-			const audioData = Array.from(new Uint8Array(arrayBuffer));
-
-			// Call Tauri command to transcribe with Parakeet
-			// Note: Parakeet doesn't support language selection, temperature, or prompt
-			const result = await tryAsync({
-				try: () =>
-					invoke<string>('transcribe_audio_parakeet', {
-						audioData: audioData,
-						modelPath: options.modelPath,
-					}),
-				catch: (unknownError) => {
-					const result = ParakeetErrorType(unknownError);
-					if (result instanceof type.errors) {
-						return WhisperingErr({
-							title: '❌ Unexpected Parakeet Error',
-							description: extractErrorMessage(unknownError),
-							action: { type: 'more-details', error: unknownError },
-						});
-					}
-					const error = result;
-
-					switch (error.name) {
-						case 'ModelLoadError':
-							return WhisperingErr({
-								title: '🤖 Model Loading Error',
-								description: error.message,
-								action: {
-									type: 'more-details',
-									error: new Error(error.message),
-								},
-							});
-
-						case 'FfmpegNotFoundError':
-							return WhisperingErr({
-								title: '🛠️ FFmpeg Not Installed',
-								description:
-									'Parakeet requires FFmpeg to convert audio formats. Please install FFmpeg or switch to CPAL recording at 16kHz.',
-								action: {
-									type: 'link',
-									label: 'Install FFmpeg',
-									href: '/install-ffmpeg',
-								},
-							});
-
-						case 'AudioReadError':
-							return WhisperingErr({
-								title: '🔊 Audio Read Error',
-								description: error.message,
-								action: {
-									type: 'more-details',
-									error: new Error(error.message),
-								},
-							});
-
-						case 'TranscriptionError':
-							return WhisperingErr({
-								title: '❌ Transcription Error',
-								description: error.message,
-								action: {
-									type: 'more-details',
-									error: new Error(error.message),
-								},
-							});
-
-						default:
-							return WhisperingErr({
-								title: '❌ Parakeet Error',
-								description: 'An unexpected error occurred.',
-								action: {
-									type: 'more-details',
-									error: new Error(String(error)),
-								},
-							});
-					}
+export const ParakeetTranscriptionServiceLive = {
+	async transcribe(
+		audioBlob: Blob,
+		options: { modelPath: string },
+	): Promise<Result<string, WhisperingError>> {
+		// Pre-validation
+		if (!options.modelPath) {
+			return WhisperingErr({
+				title: '📁 Model Directory Required',
+				description: 'Please select a Parakeet model directory in settings.',
+				action: {
+					type: 'link',
+					label: 'Configure model',
+					href: '/settings/transcription',
 				},
 			});
+		}
 
-			return result;
-		},
-	};
-}
+		// Check if model directory exists
+		const { data: isExists } = await tryAsync({
+			try: () => exists(options.modelPath),
+			catch: () => Ok(false),
+		});
 
-export type ParakeetTranscriptionService = ReturnType<
-	typeof createParakeetTranscriptionService
->;
+		if (!isExists) {
+			return WhisperingErr({
+				title: '❌ Model Directory Not Found',
+				description: `The model directory "${options.modelPath}" does not exist.`,
+				action: {
+					type: 'link',
+					label: 'Select model',
+					href: '/settings/transcription',
+				},
+			});
+		}
 
-export const ParakeetTranscriptionServiceLive =
-	createParakeetTranscriptionService();
+		// Check if it's actually a directory
+		const { data: stats } = await tryAsync({
+			try: () => stat(options.modelPath),
+			catch: () => Ok(null),
+		});
+
+		if (!stats || !stats.isDirectory) {
+			return WhisperingErr({
+				title: '❌ Invalid Model Path',
+				description:
+					'Parakeet models must be directories containing model files.',
+				action: {
+					type: 'link',
+					label: 'Select model directory',
+					href: '/settings/transcription',
+				},
+			});
+		}
+
+		// Convert audio blob to byte array
+		const arrayBuffer = await audioBlob.arrayBuffer();
+		const audioData = Array.from(new Uint8Array(arrayBuffer));
+
+		// Call Tauri command to transcribe with Parakeet
+		// Note: Parakeet doesn't support language selection, temperature, or prompt
+		const result = await tryAsync({
+			try: () =>
+				invoke<string>('transcribe_audio_parakeet', {
+					audioData: audioData,
+					modelPath: options.modelPath,
+				}),
+			catch: (unknownError) => {
+				const result = ParakeetErrorType(unknownError);
+				if (result instanceof type.errors) {
+					return WhisperingErr({
+						title: '❌ Unexpected Parakeet Error',
+						description: extractErrorMessage(unknownError),
+						action: { type: 'more-details', error: unknownError },
+					});
+				}
+				const error = result;
+
+				switch (error.name) {
+					case 'ModelLoadError':
+						return WhisperingErr({
+							title: '🤖 Model Loading Error',
+							description: error.message,
+							action: {
+								type: 'more-details',
+								error: new Error(error.message),
+							},
+						});
+
+					case 'FfmpegNotFoundError':
+						return WhisperingErr({
+							title: '🛠️ FFmpeg Not Installed',
+							description:
+								'Parakeet requires FFmpeg to convert audio formats. Please install FFmpeg or switch to CPAL recording at 16kHz.',
+							action: {
+								type: 'link',
+								label: 'Install FFmpeg',
+								href: '/install-ffmpeg',
+							},
+						});
+
+					case 'AudioReadError':
+						return WhisperingErr({
+							title: '🔊 Audio Read Error',
+							description: error.message,
+							action: {
+								type: 'more-details',
+								error: new Error(error.message),
+							},
+						});
+
+					case 'TranscriptionError':
+						return WhisperingErr({
+							title: '❌ Transcription Error',
+							description: error.message,
+							action: {
+								type: 'more-details',
+								error: new Error(error.message),
+							},
+						});
+
+					default:
+						return WhisperingErr({
+							title: '❌ Parakeet Error',
+							description: 'An unexpected error occurred.',
+							action: {
+								type: 'more-details',
+								error: new Error(String(error)),
+							},
+						});
+				}
+			},
+		});
+
+		return result;
+	},
+};
+
+export type ParakeetTranscriptionService = typeof ParakeetTranscriptionServiceLive;

--- a/apps/whispering/src/lib/services/isomorphic/transcription/local/whispercpp.ts
+++ b/apps/whispering/src/lib/services/isomorphic/transcription/local/whispercpp.ts
@@ -67,173 +67,166 @@ const WhisperCppErrorType = type({
 	message: 'string',
 });
 
-export function createWhisperCppTranscriptionService() {
-	return {
-		async transcribe(
-			audioBlob: Blob,
-			options: {
-				outputLanguage: Settings['transcription.outputLanguage'];
-				modelPath: string;
-				prompt: Settings['transcription.prompt'];
-			},
-		): Promise<Result<string, WhisperingError>> {
-			// Pre-validation
-			if (!options.modelPath) {
-				return WhisperingErr({
-					title: '📁 Model File Required',
-					description: 'Please select a Whisper model file in settings.',
-					action: {
-						type: 'link',
-						label: 'Configure model',
-						href: '/settings/transcription',
-					},
-				});
-			}
-
-			// Check if model file exists
-			const { data: isExists } = await tryAsync({
-				try: () => exists(options.modelPath),
-				catch: () => Ok(false),
-			});
-
-			if (!isExists) {
-				return WhisperingErr({
-					title: '❌ Model File Not Found',
-					description: `The model file "${options.modelPath}" does not exist.`,
-					action: {
-						type: 'link',
-						label: 'Select model',
-						href: '/settings/transcription',
-					},
-				});
-			}
-
-			// Check for corrupted/incomplete model files
-			const modelConfig = WHISPER_MODELS.find((m) =>
-				options.modelPath.endsWith(m.file.filename),
-			);
-			if (modelConfig) {
-				const { data: fileStats } = await tryAsync({
-					try: () => stat(options.modelPath),
-					catch: () => Ok(null),
-				});
-				if (
-					fileStats &&
-					!isModelFileSizeValid(fileStats.size, modelConfig.sizeBytes)
-				) {
-					return WhisperingErr({
-						title: '⚠️ Model File Appears Corrupted',
-						description: `The model file is ${Math.round(fileStats.size / 1000000)}MB but should be ~${Math.round(modelConfig.sizeBytes / 1000000)}MB. This usually happens when a download was interrupted. Please delete and re-download the model.`,
-						action: {
-							type: 'link',
-							label: 'Re-download model',
-							href: '/settings/transcription',
-						},
-					});
-				}
-			}
-
-			// Convert audio blob to byte array
-			const arrayBuffer = await audioBlob.arrayBuffer();
-			const audioData = Array.from(new Uint8Array(arrayBuffer));
-
-			// Call Tauri command to transcribe with whisper-cpp
-			// Note: temperature is not supported by local models (transcribe-rs)
-			const result = await tryAsync({
-				try: () =>
-					invoke<string>('transcribe_audio_whisper', {
-						audioData: audioData,
-						modelPath: options.modelPath,
-						language:
-							options.outputLanguage === 'auto' ? null : options.outputLanguage,
-						initialPrompt: options.prompt || null,
-					}),
-				catch: (unknownError) => {
-					const result = WhisperCppErrorType(unknownError);
-					if (result instanceof type.errors) {
-						return WhisperingErr({
-							title: '❌ Unexpected Whisper C++ Error',
-							description: extractErrorMessage(unknownError),
-							action: { type: 'more-details', error: unknownError },
-						});
-					}
-					const error = result;
-
-					switch (error.name) {
-						case 'ModelLoadError':
-							return WhisperingErr({
-								title: '🤖 Model Loading Error',
-								description: error.message,
-								action: {
-									type: 'more-details',
-									error: new Error(error.message),
-								},
-							});
-
-						case 'GpuError':
-							return WhisperingErr({
-								title: '🎮 GPU Error',
-								description: error.message,
-								action: {
-									type: 'link',
-									label: 'Configure settings',
-									href: '/settings/transcription',
-								},
-							});
-
-						case 'FfmpegNotFoundError':
-							return WhisperingErr({
-								title: '🛠️ FFmpeg Required for This Recording Format',
-								description:
-									'This recording is in a compressed format (webm/ogg/mp4) that requires FFmpeg. Install FFmpeg or switch to CPAL recording (which produces WAV files that work without FFmpeg).',
-								action: {
-									type: 'link',
-									label: 'Install FFmpeg',
-									href: '/install-ffmpeg',
-								},
-							});
-
-						case 'AudioReadError':
-							return WhisperingErr({
-								title: '🔊 Audio Read Error',
-								description: error.message,
-								action: {
-									type: 'more-details',
-									error: new Error(error.message),
-								},
-							});
-
-						case 'TranscriptionError':
-							return WhisperingErr({
-								title: '❌ Transcription Error',
-								description: error.message,
-								action: {
-									type: 'more-details',
-									error: new Error(error.message),
-								},
-							});
-
-						default:
-							return WhisperingErr({
-								title: '❌ Whisper C++ Error',
-								description: 'An unexpected error occurred.',
-								action: {
-									type: 'more-details',
-									error: new Error(String(error)),
-								},
-							});
-					}
+export const WhisperCppTranscriptionServiceLive = {
+	async transcribe(
+		audioBlob: Blob,
+		options: {
+			outputLanguage: Settings['transcription.outputLanguage'];
+			modelPath: string;
+			prompt: Settings['transcription.prompt'];
+		},
+	): Promise<Result<string, WhisperingError>> {
+		// Pre-validation
+		if (!options.modelPath) {
+			return WhisperingErr({
+				title: '📁 Model File Required',
+				description: 'Please select a Whisper model file in settings.',
+				action: {
+					type: 'link',
+					label: 'Configure model',
+					href: '/settings/transcription',
 				},
 			});
+		}
 
-			return result;
-		},
-	};
-}
+		// Check if model file exists
+		const { data: isExists } = await tryAsync({
+			try: () => exists(options.modelPath),
+			catch: () => Ok(false),
+		});
 
-export type WhisperCppTranscriptionService = ReturnType<
-	typeof createWhisperCppTranscriptionService
->;
+		if (!isExists) {
+			return WhisperingErr({
+				title: '❌ Model File Not Found',
+				description: `The model file "${options.modelPath}" does not exist.`,
+				action: {
+					type: 'link',
+					label: 'Select model',
+					href: '/settings/transcription',
+				},
+			});
+		}
 
-export const WhisperCppTranscriptionServiceLive =
-	createWhisperCppTranscriptionService();
+		// Check for corrupted/incomplete model files
+		const modelConfig = WHISPER_MODELS.find((m) =>
+			options.modelPath.endsWith(m.file.filename),
+		);
+		if (modelConfig) {
+			const { data: fileStats } = await tryAsync({
+				try: () => stat(options.modelPath),
+				catch: () => Ok(null),
+			});
+			if (
+				fileStats &&
+				!isModelFileSizeValid(fileStats.size, modelConfig.sizeBytes)
+			) {
+				return WhisperingErr({
+					title: '⚠️ Model File Appears Corrupted',
+					description: `The model file is ${Math.round(fileStats.size / 1000000)}MB but should be ~${Math.round(modelConfig.sizeBytes / 1000000)}MB. This usually happens when a download was interrupted. Please delete and re-download the model.`,
+					action: {
+						type: 'link',
+						label: 'Re-download model',
+						href: '/settings/transcription',
+					},
+				});
+			}
+		}
+
+		// Convert audio blob to byte array
+		const arrayBuffer = await audioBlob.arrayBuffer();
+		const audioData = Array.from(new Uint8Array(arrayBuffer));
+
+		// Call Tauri command to transcribe with whisper-cpp
+		// Note: temperature is not supported by local models (transcribe-rs)
+		const result = await tryAsync({
+			try: () =>
+				invoke<string>('transcribe_audio_whisper', {
+					audioData: audioData,
+					modelPath: options.modelPath,
+					language:
+						options.outputLanguage === 'auto' ? null : options.outputLanguage,
+					initialPrompt: options.prompt || null,
+				}),
+			catch: (unknownError) => {
+				const result = WhisperCppErrorType(unknownError);
+				if (result instanceof type.errors) {
+					return WhisperingErr({
+						title: '❌ Unexpected Whisper C++ Error',
+						description: extractErrorMessage(unknownError),
+						action: { type: 'more-details', error: unknownError },
+					});
+				}
+				const error = result;
+
+				switch (error.name) {
+					case 'ModelLoadError':
+						return WhisperingErr({
+							title: '🤖 Model Loading Error',
+							description: error.message,
+							action: {
+								type: 'more-details',
+								error: new Error(error.message),
+							},
+						});
+
+					case 'GpuError':
+						return WhisperingErr({
+							title: '🎮 GPU Error',
+							description: error.message,
+							action: {
+								type: 'link',
+								label: 'Configure settings',
+								href: '/settings/transcription',
+							},
+						});
+
+					case 'FfmpegNotFoundError':
+						return WhisperingErr({
+							title: '🛠️ FFmpeg Required for This Recording Format',
+							description:
+								'This recording is in a compressed format (webm/ogg/mp4) that requires FFmpeg. Install FFmpeg or switch to CPAL recording (which produces WAV files that work without FFmpeg).',
+							action: {
+								type: 'link',
+								label: 'Install FFmpeg',
+								href: '/install-ffmpeg',
+							},
+						});
+
+					case 'AudioReadError':
+						return WhisperingErr({
+							title: '🔊 Audio Read Error',
+							description: error.message,
+							action: {
+								type: 'more-details',
+								error: new Error(error.message),
+							},
+						});
+
+					case 'TranscriptionError':
+						return WhisperingErr({
+							title: '❌ Transcription Error',
+							description: error.message,
+							action: {
+								type: 'more-details',
+								error: new Error(error.message),
+							},
+						});
+
+					default:
+						return WhisperingErr({
+							title: '❌ Whisper C++ Error',
+							description: 'An unexpected error occurred.',
+							action: {
+								type: 'more-details',
+								error: new Error(String(error)),
+							},
+						});
+				}
+			},
+		});
+
+		return result;
+	},
+};
+
+export type WhisperCppTranscriptionService = typeof WhisperCppTranscriptionServiceLive;

--- a/apps/whispering/src/lib/services/isomorphic/transcription/self-hosted/speaches.ts
+++ b/apps/whispering/src/lib/services/isomorphic/transcription/self-hosted/speaches.ts
@@ -1,7 +1,7 @@
 import { type } from 'arktype';
 import { Ok, type Result } from 'wellcrafted/result';
 import { WhisperingErr, type WhisperingError } from '$lib/result';
-import type { HttpService } from '$lib/services/isomorphic/http';
+import { HttpServiceLive } from '$lib/services/isomorphic/http';
 import { getAudioExtension } from '$lib/services/isomorphic/transcription/utils';
 import type { Settings } from '$lib/settings';
 
@@ -9,168 +9,153 @@ const WhisperApiResponse = type({ text: 'string' }, '|', {
 	error: { message: 'string' },
 });
 
-export function createSpeachesTranscriptionService({
-	HttpService,
-}: {
-	HttpService: HttpService;
-}) {
-	return {
-		transcribe: async (
-			audioBlob: Blob,
-			options: {
-				prompt: string;
-				temperature: string;
-				outputLanguage: Settings['transcription.outputLanguage'];
-				modelId: string;
-				baseUrl: string;
-			},
-		): Promise<Result<string, WhisperingError>> => {
-			const formData = new FormData();
-			formData.append(
-				'file',
-				new File(
-					[audioBlob],
-					`recording.${getAudioExtension(audioBlob.type)}`,
-					{ type: audioBlob.type },
-				),
-			);
-			formData.append('model', options.modelId);
-			if (options.outputLanguage !== 'auto') {
-				formData.append('language', options.outputLanguage);
-			}
-			if (options.prompt) formData.append('prompt', options.prompt);
-			if (options.temperature)
-				formData.append('temperature', options.temperature);
-
-			const { data: whisperApiResponse, error: postError } =
-				await HttpService.post({
-					url: `${options.baseUrl}/v1/audio/transcriptions`,
-					body: formData,
-					schema: WhisperApiResponse,
-				});
-
-			if (postError) {
-				switch (postError.name) {
-					case 'ConnectionError': {
-						return WhisperingErr({
-							title: '🌐 Connection Issue',
-							description:
-								'Unable to connect to the transcription service. This could be a network issue or temporary service interruption. Please try again in a moment.',
-							action: { type: 'more-details', error: postError },
-						});
-					}
-
-					case 'ResponseError': {
-						const {
-							context: { status },
-							message,
-						} = postError;
-
-						if (status === 401) {
-							return WhisperingErr({
-								title: '🔑 Authentication Required',
-								description:
-									'Your API key appears to be invalid or expired. Please update your API key in settings to continue transcribing.',
-								action: {
-									type: 'link',
-									label: 'Update API key',
-									href: '/settings/transcription',
-								},
-							});
-						}
-
-						if (status === 403) {
-							return WhisperingErr({
-								title: '⛔ Access Restricted',
-								description:
-									"Your account doesn't have access to this feature. This may be due to plan limitations or account restrictions. Please check your account status.",
-								action: { type: 'more-details', error: postError },
-							});
-						}
-
-						if (status === 413) {
-							return WhisperingErr({
-								title: '📦 Audio File Too Large',
-								description:
-									'Your audio file exceeds the maximum size limit (typically 25MB). Try splitting it into smaller segments or reducing the audio quality.',
-								action: { type: 'more-details', error: postError },
-							});
-						}
-
-						if (status === 415) {
-							return WhisperingErr({
-								title: '🎵 Unsupported Format',
-								description:
-									"This audio format isn't supported. Please convert your file to MP3, WAV, M4A, or another common audio format.",
-								action: { type: 'more-details', error: postError },
-							});
-						}
-
-						// Rate limiting
-						if (status === 429) {
-							return WhisperingErr({
-								title: '⏱️ Rate Limit Reached',
-								description: message,
-								action: {
-									type: 'link',
-									label: 'Update API key',
-									href: '/settings/transcription',
-								},
-							});
-						}
-
-						if (status >= 500) {
-							return WhisperingErr({
-								title: '🔧 Service Unavailable',
-								description: `The transcription service is temporarily unavailable (Error ${status}). Please try again in a few minutes.`,
-								action: { type: 'more-details', error: postError },
-							});
-						}
-
-						return WhisperingErr({
-							title: '❌ Request Failed',
-							description: `The request failed with error ${status}. This may be temporary - please try again. If the problem persists, please contact support.`,
-							action: { type: 'more-details', error: postError },
-						});
-					}
-
-					case 'ParseError':
-						return WhisperingErr({
-							title: '🔍 Response Error',
-							description:
-								'Received an unexpected response from the transcription service. This is usually temporary - please try again.',
-							action: { type: 'more-details', error: postError },
-						});
-
-					default:
-						return WhisperingErr({
-							title: '❓ Unexpected Error',
-							description:
-								'An unexpected error occurred during transcription. Please try again, and contact support if the issue continues.',
-							action: { type: 'more-details', error: postError },
-						});
-				}
-			}
-
-			if ('error' in whisperApiResponse) {
-				return WhisperingErr({
-					title: '🔧 Speaches Connection Issue',
-					description: whisperApiResponse.error.message,
-				});
-			}
-
-			return Ok(whisperApiResponse.text.trim());
+export const SpeachesTranscriptionServiceLive = {
+	transcribe: async (
+		audioBlob: Blob,
+		options: {
+			prompt: string;
+			temperature: string;
+			outputLanguage: Settings['transcription.outputLanguage'];
+			modelId: string;
+			baseUrl: string;
 		},
-	};
-}
+	): Promise<Result<string, WhisperingError>> => {
+		const formData = new FormData();
+		formData.append(
+			'file',
+			new File(
+				[audioBlob],
+				`recording.${getAudioExtension(audioBlob.type)}`,
+				{ type: audioBlob.type },
+			),
+		);
+		formData.append('model', options.modelId);
+		if (options.outputLanguage !== 'auto') {
+			formData.append('language', options.outputLanguage);
+		}
+		if (options.prompt) formData.append('prompt', options.prompt);
+		if (options.temperature)
+			formData.append('temperature', options.temperature);
 
-export type SpeachesTranscriptionService = ReturnType<
-	typeof createSpeachesTranscriptionService
->;
+		const { data: whisperApiResponse, error: postError } =
+			await HttpServiceLive.post({
+				url: `${options.baseUrl}/v1/audio/transcriptions`,
+				body: formData,
+				schema: WhisperApiResponse,
+			});
 
-import { HttpServiceLive } from '$lib/services/isomorphic/http';
+		if (postError) {
+			switch (postError.name) {
+				case 'ConnectionError': {
+					return WhisperingErr({
+						title: '🌐 Connection Issue',
+						description:
+							'Unable to connect to the transcription service. This could be a network issue or temporary service interruption. Please try again in a moment.',
+						action: { type: 'more-details', error: postError },
+					});
+				}
 
-export const SpeachesTranscriptionServiceLive =
-	createSpeachesTranscriptionService({
-		HttpService: HttpServiceLive,
-	});
+				case 'ResponseError': {
+					const {
+						context: { status },
+						message,
+					} = postError;
+
+					if (status === 401) {
+						return WhisperingErr({
+							title: '🔑 Authentication Required',
+							description:
+								'Your API key appears to be invalid or expired. Please update your API key in settings to continue transcribing.',
+							action: {
+								type: 'link',
+								label: 'Update API key',
+								href: '/settings/transcription',
+							},
+						});
+					}
+
+					if (status === 403) {
+						return WhisperingErr({
+							title: '⛔ Access Restricted',
+							description:
+								"Your account doesn't have access to this feature. This may be due to plan limitations or account restrictions. Please check your account status.",
+							action: { type: 'more-details', error: postError },
+						});
+					}
+
+					if (status === 413) {
+						return WhisperingErr({
+							title: '📦 Audio File Too Large',
+							description:
+								'Your audio file exceeds the maximum size limit (typically 25MB). Try splitting it into smaller segments or reducing the audio quality.',
+							action: { type: 'more-details', error: postError },
+						});
+					}
+
+					if (status === 415) {
+						return WhisperingErr({
+							title: '🎵 Unsupported Format',
+							description:
+								"This audio format isn't supported. Please convert your file to MP3, WAV, M4A, or another common audio format.",
+							action: { type: 'more-details', error: postError },
+						});
+					}
+
+					// Rate limiting
+					if (status === 429) {
+						return WhisperingErr({
+							title: '⏱️ Rate Limit Reached',
+							description: message,
+							action: {
+								type: 'link',
+								label: 'Update API key',
+								href: '/settings/transcription',
+							},
+						});
+					}
+
+					if (status >= 500) {
+						return WhisperingErr({
+							title: '🔧 Service Unavailable',
+							description: `The transcription service is temporarily unavailable (Error ${status}). Please try again in a few minutes.`,
+							action: { type: 'more-details', error: postError },
+						});
+					}
+
+					return WhisperingErr({
+						title: '❌ Request Failed',
+						description: `The request failed with error ${status}. This may be temporary - please try again. If the problem persists, please contact support.`,
+						action: { type: 'more-details', error: postError },
+					});
+				}
+
+				case 'ParseError':
+					return WhisperingErr({
+						title: '🔍 Response Error',
+						description:
+							'Received an unexpected response from the transcription service. This is usually temporary - please try again.',
+						action: { type: 'more-details', error: postError },
+					});
+
+				default:
+					return WhisperingErr({
+						title: '❓ Unexpected Error',
+						description:
+							'An unexpected error occurred during transcription. Please try again, and contact support if the issue continues.',
+						action: { type: 'more-details', error: postError },
+					});
+			}
+		}
+
+		if ('error' in whisperApiResponse) {
+			return WhisperingErr({
+				title: '🔧 Speaches Connection Issue',
+				description: whisperApiResponse.error.message,
+			});
+		}
+
+		return Ok(whisperApiResponse.text.trim());
+	},
+};
+
+export type SpeachesTranscriptionService = typeof SpeachesTranscriptionServiceLive;

--- a/specs/20260104T220141-inline-service-factories.md
+++ b/specs/20260104T220141-inline-service-factories.md
@@ -1,0 +1,460 @@
+# Inline Service Factory Functions
+
+**Status:** Planning  
+**Created:** 2026-01-04  
+**Type:** Refactor
+
+## Problem
+
+We have 22 service files that use unnecessary factory function wrappers when the factory is only called once at export time. This adds unnecessary indirection without providing any benefit.
+
+### Current Pattern (Unnecessary Complexity)
+
+```typescript
+export function createSomethingService() {
+  return {
+    method1() { ... },
+    method2() { ... }
+  };
+}
+
+export const SomethingServiceLive = createSomethingService();
+export type SomethingService = ReturnType<typeof createSomethingService>;
+```
+
+**Problems:**
+- Factory function serves no purpose (called exactly once)
+- Extra type complexity with `ReturnType<typeof ...>`
+- More code to read and maintain
+- Not consistent with simpler patterns like `workspace-storage.ts` in epicenter
+
+### Desired Pattern (Simple and Direct)
+
+```typescript
+export const SomethingServiceLive = {
+  method1() { ... },
+  method2() { ... }
+};
+
+export type SomethingService = typeof SomethingServiceLive;
+```
+
+**Benefits:**
+- No unnecessary factory wrapper
+- Simpler type exports
+- Consistent with epicenter's workspace-storage pattern
+- Less code to maintain
+
+## Scope
+
+### Files to Refactor (22 total)
+
+**Transcription Services (15 files):**
+- `src/lib/services/isomorphic/transcription/cloud/openai.ts`
+- `src/lib/services/isomorphic/transcription/cloud/groq.ts`
+- `src/lib/services/isomorphic/transcription/cloud/deepgram.ts`
+- `src/lib/services/isomorphic/transcription/cloud/elevenlabs.ts`
+- `src/lib/services/isomorphic/transcription/cloud/mistral.ts`
+- `src/lib/services/isomorphic/transcription/local/whispercpp.ts`
+- `src/lib/services/isomorphic/transcription/local/parakeet.ts`
+- `src/lib/services/isomorphic/transcription/local/moonshine.ts`
+- `src/lib/services/isomorphic/transcription/self-hosted/speaches.ts`
+
+**Desktop Services (7 files):**
+- `src/lib/services/desktop/global-shortcut-manager.ts`
+- `src/lib/services/desktop/tray.ts`
+- `src/lib/services/desktop/autostart.ts`
+- `src/lib/services/desktop/permissions.ts`
+- `src/lib/services/desktop/fs.ts`
+- `src/lib/services/desktop/ffmpeg.ts`
+- `src/lib/services/desktop/command.ts`
+
+**Completion Services:**
+- `src/lib/services/isomorphic/completion/google.ts`
+- `src/lib/services/isomorphic/completion/groq.ts`
+
+**Recorder Services:**
+- `src/lib/services/isomorphic/recorder/navigator.ts`
+- `src/lib/services/desktop/recorder/cpal.ts`
+- `src/lib/services/desktop/recorder/ffmpeg.ts`
+
+**Other:**
+- `src/lib/services/isomorphic/local-shortcut-manager.ts`
+
+### Files to NOT Change
+
+**Platform-specific services with build-time injection:**
+- `src/lib/services/isomorphic/text/index.ts`
+- `src/lib/services/isomorphic/sound/index.ts`
+- `src/lib/services/isomorphic/notifications/index.ts`
+- `src/lib/services/isomorphic/os/index.ts`
+- `src/lib/services/isomorphic/http/index.ts`
+- `src/lib/services/isomorphic/analytics/index.ts`
+- `src/lib/services/isomorphic/download/index.ts`
+- `src/lib/services/isomorphic/db/index.ts`
+
+These use `window.__TAURI_INTERNALS__` to choose implementations at build time, so the factory pattern is legitimate.
+
+## Refactoring Steps
+
+For each of the 22 files:
+
+### 1. Remove the Factory Function
+
+**Before:**
+```typescript
+export function createOpenaiTranscriptionService() {
+  return {
+    async transcribe(blob, options) {
+      // implementation
+    }
+  };
+}
+```
+
+**After:**
+```typescript
+// Remove the function wrapper entirely
+```
+
+### 2. Inline the Service Object
+
+**Before:**
+```typescript
+export const OpenaiTranscriptionServiceLive = createOpenaiTranscriptionService();
+```
+
+**After:**
+```typescript
+export const OpenaiTranscriptionServiceLive = {
+  async transcribe(blob, options) {
+    // implementation (moved from factory return)
+  }
+};
+```
+
+### 3. Simplify the Type Export
+
+**Before:**
+```typescript
+export type OpenaiTranscriptionService = ReturnType<typeof createOpenaiTranscriptionService>;
+```
+
+**After:**
+```typescript
+export type OpenaiTranscriptionService = typeof OpenaiTranscriptionServiceLive;
+```
+
+### 4. Handle Closures/State (if any)
+
+Some services might have variables defined in the factory function scope. These should be moved to module-level constants or the service object itself:
+
+**Before:**
+```typescript
+function createSomethingService() {
+  const cache = new Map(); // closure variable
+  return {
+    method() { cache.get(...) }
+  };
+}
+```
+
+**After (Option A - Module-level):**
+```typescript
+const cache = new Map(); // module-level
+
+export const SomethingServiceLive = {
+  method() { cache.get(...) }
+};
+```
+
+**After (Option B - Service property):**
+```typescript
+export const SomethingServiceLive = {
+  _cache: new Map(), // private by convention
+  method() { this._cache.get(...) }
+};
+```
+
+## Example Refactor
+
+### Before: `src/lib/services/desktop/autostart.ts`
+
+```typescript
+import { enable, disable, isEnabled } from '@tauri-apps/plugin-autostart';
+import { tryAsync } from 'wellcrafted/result';
+
+export function createAutostartServiceDesktop() {
+  return {
+    isEnabled: () => tryAsync({
+      try: () => isEnabled(),
+      catch: (error) => AutostartServiceErr({ message: 'Failed to check autostart', cause: error })
+    }),
+    enable: () => tryAsync({
+      try: () => enable(),
+      catch: (error) => AutostartServiceErr({ message: 'Failed to enable autostart', cause: error })
+    }),
+    disable: () => tryAsync({
+      try: () => disable(),
+      catch: (error) => AutostartServiceErr({ message: 'Failed to disable autostart', cause: error })
+    })
+  };
+}
+
+export type AutostartService = ReturnType<typeof createAutostartServiceDesktop>;
+export const AutostartServiceLive = createAutostartServiceDesktop();
+```
+
+### After: `src/lib/services/desktop/autostart.ts`
+
+```typescript
+import { enable, disable, isEnabled } from '@tauri-apps/plugin-autostart';
+import { tryAsync } from 'wellcrafted/result';
+
+export const AutostartServiceLive = {
+  isEnabled: () => tryAsync({
+    try: () => isEnabled(),
+    catch: (error) => AutostartServiceErr({ message: 'Failed to check autostart', cause: error })
+  }),
+  enable: () => tryAsync({
+    try: () => enable(),
+    catch: (error) => AutostartServiceErr({ message: 'Failed to enable autostart', cause: error })
+  }),
+  disable: () => tryAsync({
+    try: () => disable(),
+    catch: (error) => AutostartServiceErr({ message: 'Failed to disable autostart', cause: error })
+  })
+};
+
+export type AutostartService = typeof AutostartServiceLive;
+```
+
+## Git Strategy
+
+### Option 1: Direct on Main (Recommended for this refactor)
+
+**Pros:**
+- Simple, straightforward workflow
+- No worktree complexity
+- Clean linear history
+- Fast to execute
+
+**Workflow:**
+```bash
+# From main branch
+git checkout main
+git pull origin main
+
+# Make all changes
+# ... refactor 22 files ...
+
+# Commit
+git add apps/whispering/src/lib/services
+git commit -m "refactor(services): inline factory functions for single-use services
+
+Simplified 22 service files by removing unnecessary factory function
+wrappers that were only called once at export time.
+
+- Removed createXxxService() functions
+- Inlined service object definitions
+- Simplified type exports from ReturnType<typeof createXxx> to typeof XxxLive
+- No functional changes, purely structural simplification
+
+Pattern change:
+Before: export const XLive = createX()
+After: export const XLive = { methods... }
+
+Affected services:
+- 15 transcription services (cloud/local/self-hosted)
+- 7 desktop services
+- 2 completion services  
+- 3 recorder services
+- 1 local shortcut manager"
+
+# Push
+git push origin main
+```
+
+**When to use:** Low-risk refactors that don't change functionality, purely structural
+
+### Option 2: Worktree (For more exploratory work)
+
+**Pros:**
+- Can test changes in isolation
+- Easy to abandon if issues arise
+- Can work on multiple things simultaneously
+
+**Workflow:**
+```bash
+# Create worktree
+git worktree add .conductor/inline-factories -b refactor/inline-service-factories
+
+# Work in the worktree
+cd .conductor/inline-factories
+# ... make changes ...
+git add .
+git commit -m "refactor: inline service factories"
+git push origin refactor/inline-service-factories
+
+# Create PR
+gh pr create --title "refactor(services): inline factory functions" --body "..."
+
+# Merge when ready
+gh pr merge --merge
+
+# Cleanup
+cd ../..
+git worktree remove .conductor/inline-factories
+git branch -d refactor/inline-service-factories
+```
+
+**When to use:** Exploratory work, risky changes, work you might abandon
+
+### Recommendation
+
+For this refactor, **use Option 1 (direct on main)**:
+- It's a low-risk structural change
+- No functionality changes
+- Easy to verify (imports stay the same)
+- Fast to execute
+- Clean history
+
+## Testing Strategy
+
+### Before Starting
+
+1. Ensure app builds: `bun run build`
+2. Ensure tests pass: `bun test` (if you have tests)
+3. Note the current app state
+
+### During Refactoring
+
+For each file:
+1. Make the change
+2. Verify TypeScript compilation: `bun run typecheck` (or let your editor show errors)
+3. Ensure no import errors
+
+### After Completing All Changes
+
+1. Build the app: `bun run build`
+2. Run the app: `bun run dev`
+3. Test key functionality:
+   - Transcription services (try different providers)
+   - Desktop services (tray, shortcuts, autostart)
+   - Completion services (transformations)
+4. Check for any runtime errors in console
+
+### Verification Checklist
+
+- [ ] All 22 files refactored
+- [ ] TypeScript compiles without errors
+- [ ] App builds successfully
+- [ ] App runs without runtime errors
+- [ ] Transcription still works
+- [ ] Shortcuts still work
+- [ ] Transformations still work
+- [ ] No broken imports
+
+## Execution Plan
+
+### Phase 1: Preparation (5 minutes)
+
+```bash
+cd /Users/braden/Code/whispering
+git checkout main
+git pull origin main
+bun run typecheck  # Verify starting state
+```
+
+### Phase 2: Refactoring (30-45 minutes)
+
+Process files in groups to maintain focus:
+
+**Group 1: Desktop Services (simplest, good warmup)**
+1. `desktop/autostart.ts`
+2. `desktop/command.ts`
+3. `desktop/ffmpeg.ts`
+4. `desktop/fs.ts`
+5. `desktop/permissions.ts`
+6. `desktop/tray.ts`
+7. `desktop/global-shortcut-manager.ts`
+
+**Group 2: Transcription Services (largest group)**
+1. Cloud: openai, groq, deepgram, elevenlabs, mistral
+2. Local: whispercpp, parakeet, moonshine
+3. Self-hosted: speaches
+
+**Group 3: Completion Services**
+1. `completion/google.ts`
+2. `completion/groq.ts`
+
+**Group 4: Recorder Services**
+1. `recorder/navigator.ts`
+2. `desktop/recorder/cpal.ts`
+3. `desktop/recorder/ffmpeg.ts`
+
+**Group 5: Other**
+1. `isomorphic/local-shortcut-manager.ts`
+
+### Phase 3: Verification (10 minutes)
+
+```bash
+bun run typecheck
+bun run build
+bun run dev
+# Test app functionality
+```
+
+### Phase 4: Commit and Push (5 minutes)
+
+```bash
+git add apps/whispering/src/lib/services
+git status  # Review changes
+git commit -m "refactor(services): inline factory functions for single-use services"
+git push origin main
+```
+
+## Rollback Plan
+
+If issues arise after pushing:
+
+```bash
+# Find the commit hash
+git log --oneline -5
+
+# Revert the commit
+git revert <commit-hash>
+git push origin main
+```
+
+Or if not pushed yet:
+
+```bash
+# Reset to previous commit
+git reset --hard HEAD~1
+```
+
+## Success Criteria
+
+- [ ] All 22 files refactored following the pattern
+- [ ] No TypeScript errors
+- [ ] App builds and runs successfully
+- [ ] All functionality works as before
+- [ ] Clean commit message following conventional commits
+- [ ] Changes pushed to main
+
+## Future Considerations
+
+After this refactor, we'll have two patterns in services:
+
+1. **Direct object export** (22 files after this refactor + toast.ts)
+2. **Platform-specific with build-time injection** (8 files with `window.__TAURI_INTERNALS__`)
+
+This is the correct distinction—factories are only needed when there's actual runtime dependency injection happening.
+
+## Notes
+
+- This refactor is purely structural—no functionality changes
+- All imports remain the same (same export names)
+- Type safety is maintained
+- Can be done incrementally (file by file) or all at once


### PR DESCRIPTION
This simplifies 22 service files by removing unnecessary factory function wrappers that were only called once at export time.

The codebase had a pattern where services were created like `export const XxxServiceLive = createXxxService()` with `export type XxxService = ReturnType<typeof createXxxService>`. This makes sense when you need to call the factory multiple times or inject dependencies, but none of the 22 files changed here did either of those things—each factory was called exactly once at module load.

The refactor inlines the object directly as `export const XxxServiceLive = { methods }` and simplifies the type to `typeof XxxServiceLive`. For services that had closure variables (like `trayPromise` in tray.ts or `shortcuts` Map in local-shortcut-manager.ts), those were moved to module level, which is functionally equivalent since the factory was only ever called once anyway.

This matches the simpler pattern already used in workspace-storage.ts in epicenter and reduces about 138 lines of boilerplate. No logic changes—purely structural cleanup.