### PR TITLE
feat(actions): add action system for type-safe CLI and HTTP route generation

### DIFF
--- a/docs/articles/exhaustive-switch-pattern.md
+++ b/docs/articles/exhaustive-switch-pattern.md
@@ -1,0 +1,106 @@
+# The Exhaustive Switch Pattern
+
+You're switching on a discriminated union. You've got `query` and `mutation`. Two cases, two code paths. Done, right?
+
+What happens six months from now when someone adds `subscription`?
+
+Nothing. The code silently falls through. No compile error. No runtime warning. Just a bug waiting to surface in production.
+
+## The Pattern
+
+```typescript
+switch (action.type) {
+	case 'query':
+		router.get(routePath, handler, { query: action.input, detail });
+		break;
+	case 'mutation':
+		router.post(routePath, handler, { body: action.input, detail });
+		break;
+	default: {
+		// Gives type warning if not never
+		const _exhaustive: never = action.type;
+		// Gives runtime exception if invariant is violated
+		throw new Error(`Unknown action type: ${_exhaustive}`);
+	}
+}
+```
+
+Two lines in the default case. That's it.
+
+## Why It Works
+
+The `never` type in TypeScript represents values that should never exist. When you assign `action.type` to a variable typed as `never`, TypeScript checks: "Can this value actually reach this point?"
+
+If you've handled all cases, the answer is no. `action.type` is `'query' | 'mutation'`, both are handled, so the default is unreachable. TypeScript is happy.
+
+Now add a new type:
+
+```typescript
+type ActionType = 'query' | 'mutation' | 'subscription';
+```
+
+Suddenly `action.type` in the default case could be `'subscription'`. You can't assign `'subscription'` to `never`. TypeScript screams at you. You fix it before the code ever runs.
+
+## The Underscore Prefix
+
+The `_exhaustive` variable is intentionally unused. The underscore signals to linters and readers: "This exists for the type system, not for runtime logic."
+
+Some teams use `_` alone, some use `_never`, some use `_exhaustive`. Pick one and be consistent.
+
+## Defense in Depth
+
+The runtime `throw` might seem redundant. If TypeScript catches all missing cases at compile time, why throw?
+
+Because TypeScript isn't omniscient. Consider:
+
+- External data parsed with `as ActionType`
+- JSON from an API with a new type your code doesn't know about
+- Version mismatches between services
+- Tests that bypass type checking
+
+The throw is your last line of defense. If impossible happens, fail loudly and immediately. The error message includes the actual value (`${_exhaustive}`), making debugging trivial.
+
+## When to Use It
+
+Any switch on a discriminated union where:
+
+- New variants might be added over time
+- Missing a case would cause subtle bugs
+- You want compile-time + runtime guarantees
+
+Common scenarios:
+
+- Action types (query/mutation/subscription)
+- State machine states
+- Event types
+- Message kinds
+- API response discriminators
+
+## The Alternative (Don't Do This)
+
+```typescript
+switch (action.type) {
+	case 'query':
+		// ...
+		break;
+	case 'mutation':
+		// ...
+		break;
+	// No default - TypeScript won't warn you
+}
+```
+
+This compiles. It runs. It silently does nothing for new types. Months later someone files a bug report and you spend hours tracking down what should have been a compile error.
+
+## Summary
+
+Two lines. Compile-time exhaustiveness checking. Runtime safety net. Clear error messages.
+
+```typescript
+default: {
+    const _exhaustive: never = action.type;
+    throw new Error(`Unknown action type: ${_exhaustive}`);
+}
+```
+
+Add it to every switch on a discriminated union. Future you will be grateful.

--- a/docs/articles/exhaustive-switch-pattern.md
+++ b/docs/articles/exhaustive-switch-pattern.md
@@ -18,7 +18,7 @@ switch (action.type) {
 		break;
 	default: {
 		// Gives type warning if not never
-		const _exhaustive: never = action.type;
+		const _exhaustive: never = action;
 		// Gives runtime exception if invariant is violated
 		throw new Error(`Unknown action type: ${_exhaustive}`);
 	}
@@ -98,7 +98,7 @@ Two lines. Compile-time exhaustiveness checking. Runtime safety net. Clear error
 
 ```typescript
 default: {
-    const _exhaustive: never = action.type;
+    const _exhaustive: never = action;
     throw new Error(`Unknown action type: ${_exhaustive}`);
 }
 ```

--- a/docs/articles/generators-vs-callbacks-for-tree-traversal.md
+++ b/docs/articles/generators-vs-callbacks-for-tree-traversal.md
@@ -1,0 +1,210 @@
+# Generators vs Callbacks for Tree Traversal
+
+I was building the action system for Epicenter and needed to walk a nested object structure. The type looked like this:
+
+```typescript
+type Actions = {
+	[key: string]: Action<any, any> | Actions;
+};
+```
+
+Actions can be nested arbitrarily deep. A user might have `actions.users.getById` or `actions.billing.subscriptions.cancel`. I needed to visit every leaf action with its full path.
+
+My first instinct was the visitor pattern—the classic callback approach. It works, but something about it always felt clunky. This time I tried generators instead, and the difference was striking.
+
+## The Callback Approach
+
+Here's the visitor pattern implementation:
+
+```typescript
+function walkActions(
+	actions: Actions,
+	visitor: (action: Action, path: string[]) => void,
+	path: string[] = [],
+): void {
+	for (const [key, value] of Object.entries(actions)) {
+		const currentPath = [...path, key];
+		if (isAction(value)) {
+			visitor(value, currentPath);
+		} else {
+			walkActions(value, visitor, currentPath);
+		}
+	}
+}
+```
+
+To collect all the action paths:
+
+```typescript
+const paths: string[] = [];
+walkActions(actions, (_, path) => {
+	paths.push(path.join('/'));
+});
+```
+
+This works. But notice what happened: I had to create an external variable (`paths`), then mutate it inside the callback. The callback doesn't return anything—it's pure side effect. The relationship between "I want paths" and "here are paths" is spread across three lines with a mutable variable in between.
+
+Want to filter? More callback soup:
+
+```typescript
+const mutations: Action[] = [];
+walkActions(actions, (action, _) => {
+	if (action.type === 'mutation') {
+		mutations.push(action);
+	}
+});
+```
+
+Want to transform each action? Same pattern:
+
+```typescript
+const entries: [string, Action][] = [];
+walkActions(actions, (action, path) => {
+	entries.push([path.join('.'), action]);
+});
+```
+
+Every operation follows the same dance: declare a variable, mutate it in a callback, use it after. The actual logic is buried inside anonymous functions.
+
+## The Generator Approach
+
+Now here's the same traversal as a generator:
+
+```typescript
+function* iterateActions(
+	actions: Actions,
+	path: string[] = [],
+): Generator<[Action<any, any>, string[]]> {
+	for (const [key, value] of Object.entries(actions)) {
+		const currentPath = [...path, key];
+		if (isAction(value)) {
+			yield [value, currentPath];
+		} else {
+			yield* iterateActions(value, currentPath);
+		}
+	}
+}
+```
+
+The structure is nearly identical. Same recursion, same path tracking. But instead of calling a visitor, we `yield` the result. And instead of passing callbacks down, we use `yield*` to delegate to recursive calls.
+
+Now watch how the usage changes:
+
+```typescript
+// Collect paths - one line, no mutation
+const paths = [...iterateActions(actions)].map(([_, path]) => path.join('/'));
+
+// Filter mutations - standard array method
+const mutations = [...iterateActions(actions)]
+	.filter(([action]) => action.type === 'mutation')
+	.map(([action]) => action);
+
+// Transform to entries - just map
+const entries = [...iterateActions(actions)].map(([action, path]) => [
+	path.join('.'),
+	action,
+]);
+```
+
+No external variables. No mutation. Each operation reads left-to-right: spread the iterator, apply transformations, get result.
+
+## Direct Iteration
+
+Generators also let you iterate directly without collecting everything:
+
+```typescript
+for (const [action, path] of iterateActions(actions)) {
+	console.log(action.type, path.join('.'));
+}
+```
+
+This is lazy evaluation. If you break early, you don't traverse the entire tree. With the callback approach, you'd need to throw an exception or add a return flag:
+
+```typescript
+// Callback approach - awkward early exit
+let found: Action | null = null;
+walkActions(actions, (action, path) => {
+	if (action.id === targetId) {
+		found = action;
+		// How do I stop? I can't.
+	}
+});
+
+// Generator approach - natural early exit
+for (const [action] of iterateActions(actions)) {
+	if (action.id === targetId) {
+		found = action;
+		break; // Just works
+	}
+}
+```
+
+With callbacks, you'd need to add a return value to signal "stop traversing" and check it at every level. Generators give you `break` for free.
+
+## Why Generators Win Here
+
+The callback approach inverts control. You pass a function, and the walker calls it. Your code runs inside someone else's loop. This makes composition awkward because you can't use standard flow control.
+
+Generators restore normal control flow. The walker yields values, and your code decides what to do with them. You're back in charge of the loop.
+
+This matters most when you want to compose operations:
+
+```typescript
+// Find the first mutation that operates on users
+const userMutation = [...iterateActions(actions)]
+	.filter(([action]) => action.type === 'mutation')
+	.find(([_, path]) => path[0] === 'users');
+```
+
+With callbacks, this would require nested mutable state and early-exit flags. With generators, it's just method chaining.
+
+## The `yield*` Trick
+
+The recursive delegation (`yield*`) deserves attention. When you write:
+
+```typescript
+yield * iterateActions(value, currentPath);
+```
+
+You're saying "yield everything from this nested generator." It flattens the recursion automatically. The caller sees a single stream of `[action, path]` tuples, regardless of nesting depth.
+
+Without `yield*`, you'd need to manually loop:
+
+```typescript
+for (const item of iterateActions(value, currentPath)) {
+	yield item;
+}
+```
+
+Same result, more noise. `yield*` is syntax sugar that makes recursive generators clean.
+
+## When to Use Each
+
+Callbacks still make sense when:
+
+- You need to modify the tree during traversal (generators shouldn't have side effects)
+- You're integrating with callback-based APIs
+- The traversal itself has complex early-termination logic that affects siblings
+
+Generators shine when:
+
+- You want to collect, filter, or transform results
+- Early termination is a possibility
+- You're composing multiple operations on the results
+- You value readable, left-to-right code flow
+
+For tree traversal that produces a stream of values, generators are almost always cleaner. The code reads naturally, composes with standard array methods, and doesn't require mutable accumulator variables.
+
+## The Implementation Pattern
+
+If you're converting a callback-based traversal to a generator, the pattern is mechanical:
+
+1. Change the return type from `void` to `Generator<YourResultType>`
+2. Add `*` after `function` to make it a generator
+3. Replace `visitor(value)` with `yield value`
+4. Replace recursive calls with `yield* recursiveCall()`
+5. Remove the visitor parameter entirely
+
+The walker's structure stays the same. Only the interface changes—from "call this function" to "produce this value."
+
+That's the insight: generators let you separate the traversal logic from what you do with the results. The walker produces values. Your code consumes them. Clean boundaries, composable operations, readable flow.

--- a/docs/articles/generators-vs-callbacks-for-tree-traversal.md
+++ b/docs/articles/generators-vs-callbacks-for-tree-traversal.md
@@ -1,5 +1,23 @@
 # Generators vs Callbacks for Tree Traversal
 
+> **TL;DR**: Use generators (`function*` + `yield`) instead of callbacks for tree traversal when you need to collect, filter, or transform results. You get:
+>
+> - No mutable accumulator variables
+> - Natural `break` for early termination
+> - Composable with `.map()`, `.filter()`, `.find()`
+> - Left-to-right readable code flow
+>
+> ```typescript
+> // Instead of this (callback)
+> const paths: string[] = [];
+> walkActions(actions, (_, path) => paths.push(path.join('/')));
+>
+> // Do this (generator)
+> const paths = [...iterateActions(actions)].map(([_, path]) => path.join('/'));
+> ```
+
+---
+
 I was building the action system for Epicenter and needed to walk a nested object structure. The type looked like this:
 
 ```typescript

--- a/packages/epicenter/src/cli/cli.test.ts
+++ b/packages/epicenter/src/cli/cli.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from 'bun:test';
+import yargs from 'yargs';
+import { type } from 'arktype';
+import { defineAction, type Actions } from '../core/actions';
+import { buildActionCommands } from './command-builder';
+
+describe('CLI command registration', () => {
+	test('registers flat action commands with yargs', () => {
+		const actions: Actions = {
+			ping: defineAction({
+				type: 'query',
+				handler: () => 'pong',
+			}),
+			sync: defineAction({
+				type: 'mutation',
+				handler: () => {},
+			}),
+		};
+
+		const commands = buildActionCommands(actions);
+
+		let cli = yargs().scriptName('test');
+		for (const cmd of commands) {
+			cli = cli.command(cmd);
+		}
+
+		const commandInstance = cli.getInternalMethods().getCommandInstance();
+		const registeredCommands = commandInstance.getCommands();
+
+		expect(registeredCommands).toContain('ping');
+		expect(registeredCommands).toContain('sync');
+	});
+
+	test('registers nested commands with top-level parent', () => {
+		const actions: Actions = {
+			posts: {
+				list: defineAction({
+					type: 'query',
+					handler: () => [],
+				}),
+			},
+		};
+
+		const commands = buildActionCommands(actions);
+
+		let cli = yargs().scriptName('test');
+		for (const cmd of commands) {
+			cli = cli.command(cmd);
+		}
+
+		const commandInstance = cli.getInternalMethods().getCommandInstance();
+		const registeredCommands = commandInstance.getCommands();
+
+		expect(registeredCommands).toContain('posts');
+	});
+
+	test('command handlers are accessible', () => {
+		const actions: Actions = {
+			ping: defineAction({
+				type: 'query',
+				handler: () => 'pong',
+			}),
+		};
+
+		const commands = buildActionCommands(actions);
+
+		let cli = yargs().scriptName('test');
+		for (const cmd of commands) {
+			cli = cli.command(cmd);
+		}
+
+		const commandInstance = cli.getInternalMethods().getCommandInstance();
+		const handlers = commandInstance.getCommandHandlers();
+
+		expect(handlers).toHaveProperty('ping');
+		expect(typeof handlers.ping?.handler).toBe('function');
+	});
+
+	test('parses flat command options correctly', async () => {
+		let capturedArgs: Record<string, unknown> | null = null;
+
+		const actions: Actions = {
+			create: defineAction({
+				type: 'mutation',
+				input: type({ title: 'string', 'count?': 'number' }),
+				handler: ({ title, count }) => {
+					capturedArgs = { title, count };
+					return { id: '1', title };
+				},
+			}),
+		};
+
+		const commands = buildActionCommands(actions);
+
+		let cli = yargs()
+			.scriptName('test')
+			.fail(() => {});
+		for (const cmd of commands) {
+			cli = cli.command(cmd);
+		}
+
+		await cli.parseAsync(['create', '--title', 'Hello', '--count', '42']);
+
+		expect(capturedArgs).not.toBeNull();
+		expect(capturedArgs?.title).toBe('Hello');
+		expect(capturedArgs?.count).toBe(42);
+	});
+
+	test('buildActionCommands returns correct command paths', () => {
+		const actions: Actions = {
+			ping: defineAction({ type: 'query', handler: () => 'pong' }),
+			posts: {
+				list: defineAction({ type: 'query', handler: () => [] }),
+				create: defineAction({
+					type: 'mutation',
+					input: type({ title: 'string' }),
+					handler: ({ title }) => ({ title }),
+				}),
+			},
+		};
+
+		const commands = buildActionCommands(actions);
+		const commandPaths = commands.map((c) => c.command);
+
+		expect(commandPaths).toContain('ping');
+		expect(commandPaths).toContain('posts list');
+		expect(commandPaths).toContain('posts create');
+	});
+});

--- a/packages/epicenter/src/cli/cli.test.ts
+++ b/packages/epicenter/src/cli/cli.test.ts
@@ -1,18 +1,16 @@
 import { describe, expect, test } from 'bun:test';
 import yargs from 'yargs';
 import { type } from 'arktype';
-import { defineAction, type Actions } from '../core/actions';
+import { defineMutation, defineQuery, type Actions } from '../core/actions';
 import { buildActionCommands } from './command-builder';
 
 describe('CLI command registration', () => {
 	test('registers flat action commands with yargs', () => {
 		const actions: Actions = {
-			ping: defineAction({
-				type: 'query',
+			ping: defineQuery({
 				handler: () => 'pong',
 			}),
-			sync: defineAction({
-				type: 'mutation',
+			sync: defineMutation({
 				handler: () => {},
 			}),
 		};
@@ -34,8 +32,7 @@ describe('CLI command registration', () => {
 	test('registers nested commands with top-level parent', () => {
 		const actions: Actions = {
 			posts: {
-				list: defineAction({
-					type: 'query',
+				list: defineQuery({
 					handler: () => [],
 				}),
 			},
@@ -56,8 +53,7 @@ describe('CLI command registration', () => {
 
 	test('command handlers are accessible', () => {
 		const actions: Actions = {
-			ping: defineAction({
-				type: 'query',
+			ping: defineQuery({
 				handler: () => 'pong',
 			}),
 		};
@@ -80,8 +76,7 @@ describe('CLI command registration', () => {
 		let capturedArgs: Record<string, unknown> | null = null;
 
 		const actions: Actions = {
-			create: defineAction({
-				type: 'mutation',
+			create: defineMutation({
 				input: type({ title: 'string', 'count?': 'number' }),
 				handler: ({ title, count }) => {
 					capturedArgs = { title, count };
@@ -108,11 +103,10 @@ describe('CLI command registration', () => {
 
 	test('buildActionCommands returns correct command paths', () => {
 		const actions: Actions = {
-			ping: defineAction({ type: 'query', handler: () => 'pong' }),
+			ping: defineQuery({ handler: () => 'pong' }),
 			posts: {
-				list: defineAction({ type: 'query', handler: () => [] }),
-				create: defineAction({
-					type: 'mutation',
+				list: defineQuery({ handler: () => [] }),
+				create: defineMutation({
 					input: type({ title: 'string' }),
 					handler: ({ title }) => ({ title }),
 				}),

--- a/packages/epicenter/src/cli/cli.ts
+++ b/packages/epicenter/src/cli/cli.ts
@@ -1,15 +1,25 @@
-import yargs from 'yargs';
+import yargs, { type Argv } from 'yargs';
+import type { Actions } from '../core/actions';
+import { iterateActions } from '../core/actions';
+import { generateJsonSchema } from '../core/schema/standard/to-json-schema';
 import type { WorkspaceClient } from '../core/workspace/contract';
 import { createServer, DEFAULT_PORT } from '../server/server';
 
 type AnyWorkspaceClient = WorkspaceClient<string, any, any, any>;
 
-export function createCLI(clients: AnyWorkspaceClient | AnyWorkspaceClient[]) {
+type CLIOptions = {
+	actions?: Actions;
+};
+
+export function createCLI(
+	clients: AnyWorkspaceClient | AnyWorkspaceClient[],
+	options?: CLIOptions,
+) {
 	const clientArray = Array.isArray(clients) ? clients : [clients];
 
-	const cli = yargs()
+	const baseCli = yargs()
 		.scriptName('epicenter')
-		.usage('Usage: $0 [options]')
+		.usage('Usage: $0 <command> [options]')
 		.help()
 		.version()
 		.strict()
@@ -19,13 +29,20 @@ export function createCLI(clients: AnyWorkspaceClient | AnyWorkspaceClient[]) {
 			default: DEFAULT_PORT,
 		})
 		.command(
-			'$0',
+			'serve',
 			'Start HTTP server with REST and WebSocket sync endpoints',
 			() => {},
 			(argv) => {
-				createServer(clientArray, { port: argv.port }).start();
+				createServer(clientArray, {
+					port: argv.port,
+					actions: options?.actions,
+				}).start();
 			},
 		);
+
+	const cli = options?.actions
+		? registerActionCommands(baseCli, options.actions)
+		: baseCli;
 
 	return {
 		async run(argv: string[]) {
@@ -49,4 +66,137 @@ export function createCLI(clients: AnyWorkspaceClient | AnyWorkspaceClient[]) {
 			}
 		},
 	};
+}
+
+function registerActionCommands<T>(cli: Argv<T>, actions: Actions): Argv<T> {
+	let result = cli;
+
+	for (const [action, path] of iterateActions(actions)) {
+		const commandPath = path.join(' ');
+		const description =
+			action.description ??
+			`${action.type === 'query' ? 'Query' : 'Mutation'}: ${path.join('.')}`;
+
+		result = result.command(
+			commandPath,
+			description,
+			(yargs) => {
+				if (action.input) {
+					const jsonSchema = generateJsonSchema(action.input) as Record<
+						string,
+						unknown
+					>;
+					return addOptionsFromJsonSchema(yargs, jsonSchema);
+				}
+				return yargs;
+			},
+			async (argv) => {
+				const input = extractInputFromArgv(
+					argv as Record<string, unknown>,
+					action.input,
+				);
+
+				if (action.input) {
+					const result = await action.input['~standard'].validate(input);
+					if (result.issues) {
+						console.error('Validation failed:');
+						for (const issue of result.issues) {
+							console.error(
+								`  - ${issue.path?.join('.') ?? 'input'}: ${issue.message}`,
+							);
+						}
+						process.exit(1);
+					}
+					const output = await action.handler(result.value);
+					console.log(JSON.stringify(output, null, 2));
+				} else {
+					const output = await (action.handler as () => unknown)();
+					console.log(JSON.stringify(output, null, 2));
+				}
+			},
+		) as Argv<T>;
+	}
+
+	return result;
+}
+
+function addOptionsFromJsonSchema<T>(
+	yargs: Argv<T>,
+	schema: Record<string, unknown>,
+): Argv<T> {
+	if (schema.type !== 'object' || !schema.properties) {
+		return yargs;
+	}
+
+	const properties = schema.properties as Record<
+		string,
+		Record<string, unknown>
+	>;
+	const required = (schema.required as string[]) ?? [];
+
+	let result = yargs;
+
+	for (const [key, propSchema] of Object.entries(properties)) {
+		const isRequired = required.includes(key);
+		const yargsType = jsonSchemaTypeToYargsType(propSchema.type as string);
+
+		result = result.option(key, {
+			type: yargsType,
+			description: propSchema.description as string | undefined,
+			demandOption: isRequired,
+		}) as Argv<T>;
+	}
+
+	return result;
+}
+
+function jsonSchemaTypeToYargsType(
+	type: string,
+): 'string' | 'number' | 'boolean' | 'array' {
+	switch (type) {
+		case 'string':
+			return 'string';
+		case 'number':
+		case 'integer':
+			return 'number';
+		case 'boolean':
+			return 'boolean';
+		case 'array':
+			return 'array';
+		default:
+			return 'string';
+	}
+}
+
+function extractInputFromArgv(
+	argv: Record<string, unknown>,
+	inputSchema: unknown,
+): Record<string, unknown> {
+	if (!inputSchema) return {};
+
+	const schema = inputSchema as {
+		'~standard': {
+			jsonSchema: {
+				input: (opts: { target: string }) => Record<string, unknown>;
+			};
+		};
+	};
+	const jsonSchema = schema['~standard'].jsonSchema.input({
+		target: 'draft-2020-12',
+	});
+
+	if (jsonSchema.type !== 'object' || !jsonSchema.properties) {
+		return {};
+	}
+
+	const properties = jsonSchema.properties as Record<string, unknown>;
+	const input: Record<string, unknown> = {};
+
+	for (const key of Object.keys(properties)) {
+		if (key in argv && argv[key] !== undefined) {
+			input[key] = argv[key];
+		}
+	}
+
+	return input;
 }

--- a/packages/epicenter/src/cli/command-builder.test.ts
+++ b/packages/epicenter/src/cli/command-builder.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from 'bun:test';
+import { type } from 'arktype';
+import { defineAction, type Actions } from '../core/actions';
+import { buildActionCommands } from './command-builder';
+
+describe('buildActionCommands', () => {
+	test('builds command from simple action without input', () => {
+		const actions: Actions = {
+			getAll: defineAction({
+				type: 'query',
+				handler: () => [],
+			}),
+		};
+
+		const commands = buildActionCommands(actions);
+
+		expect(commands).toHaveLength(1);
+		expect(commands[0]?.command).toBe('getAll');
+		expect(commands[0]?.describe).toBe('Query: getAll');
+		expect(commands[0]?.builder).toEqual({});
+		expect(typeof commands[0]?.handler).toBe('function');
+	});
+
+	test('builds command from action with input schema', () => {
+		const actions: Actions = {
+			create: defineAction({
+				type: 'mutation',
+				input: type({ title: 'string' }),
+				handler: ({ title }) => ({ id: '1', title }),
+			}),
+		};
+
+		const commands = buildActionCommands(actions);
+
+		expect(commands).toHaveLength(1);
+		expect(commands[0]?.command).toBe('create');
+		expect(commands[0]?.describe).toBe('Mutation: create');
+		expect(commands[0]?.builder).toHaveProperty('title');
+	});
+
+	test('builds commands from nested actions', () => {
+		const actions: Actions = {
+			posts: {
+				getAll: defineAction({
+					type: 'query',
+					handler: () => [],
+				}),
+				create: defineAction({
+					type: 'mutation',
+					input: type({ title: 'string' }),
+					handler: ({ title }) => ({ id: '1', title }),
+				}),
+			},
+		};
+
+		const commands = buildActionCommands(actions);
+
+		expect(commands).toHaveLength(2);
+
+		const commandNames = commands.map((c) => c.command);
+		expect(commandNames).toContain('posts getAll');
+		expect(commandNames).toContain('posts create');
+	});
+
+	test('builds commands from deeply nested actions', () => {
+		const actions: Actions = {
+			api: {
+				v1: {
+					posts: {
+						list: defineAction({
+							type: 'query',
+							handler: () => [],
+						}),
+					},
+				},
+			},
+		};
+
+		const commands = buildActionCommands(actions);
+
+		expect(commands).toHaveLength(1);
+		expect(commands[0]?.command).toBe('api v1 posts list');
+	});
+
+	test('uses description from action when provided', () => {
+		const actions: Actions = {
+			sync: defineAction({
+				type: 'mutation',
+				description: 'Sync data from external source',
+				handler: () => {},
+			}),
+		};
+
+		const commands = buildActionCommands(actions);
+
+		expect(commands[0]?.describe).toBe('Sync data from external source');
+	});
+
+	test('builder contains yargs options for input schema', () => {
+		const actions: Actions = {
+			create: defineAction({
+				type: 'mutation',
+				input: type({
+					title: 'string',
+					'count?': 'number',
+				}),
+				handler: ({ title }) => ({ id: '1', title }),
+			}),
+		};
+
+		const commands = buildActionCommands(actions);
+		const builder = commands[0]?.builder as Record<string, unknown>;
+
+		expect(builder).toHaveProperty('title');
+		expect(builder).toHaveProperty('count');
+	});
+
+	test('returns empty array for empty actions', () => {
+		const commands = buildActionCommands({});
+		expect(commands).toEqual([]);
+	});
+
+	test('handles mixed flat and nested actions', () => {
+		const actions: Actions = {
+			ping: defineAction({
+				type: 'query',
+				handler: () => 'pong',
+			}),
+			users: {
+				list: defineAction({
+					type: 'query',
+					handler: () => [],
+				}),
+			},
+		};
+
+		const commands = buildActionCommands(actions);
+
+		expect(commands).toHaveLength(2);
+		const commandNames = commands.map((c) => c.command);
+		expect(commandNames).toContain('ping');
+		expect(commandNames).toContain('users list');
+	});
+});

--- a/packages/epicenter/src/cli/command-builder.test.ts
+++ b/packages/epicenter/src/cli/command-builder.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, test } from 'bun:test';
 import { type } from 'arktype';
-import { defineAction, type Actions } from '../core/actions';
+import { defineMutation, defineQuery, type Actions } from '../core/actions';
 import { buildActionCommands } from './command-builder';
 
 describe('buildActionCommands', () => {
 	test('builds command from simple action without input', () => {
 		const actions: Actions = {
-			getAll: defineAction({
-				type: 'query',
+			getAll: defineQuery({
 				handler: () => [],
 			}),
 		};
@@ -23,8 +22,7 @@ describe('buildActionCommands', () => {
 
 	test('builds command from action with input schema', () => {
 		const actions: Actions = {
-			create: defineAction({
-				type: 'mutation',
+			create: defineMutation({
 				input: type({ title: 'string' }),
 				handler: ({ title }) => ({ id: '1', title }),
 			}),
@@ -41,12 +39,10 @@ describe('buildActionCommands', () => {
 	test('builds commands from nested actions', () => {
 		const actions: Actions = {
 			posts: {
-				getAll: defineAction({
-					type: 'query',
+				getAll: defineQuery({
 					handler: () => [],
 				}),
-				create: defineAction({
-					type: 'mutation',
+				create: defineMutation({
 					input: type({ title: 'string' }),
 					handler: ({ title }) => ({ id: '1', title }),
 				}),
@@ -67,8 +63,7 @@ describe('buildActionCommands', () => {
 			api: {
 				v1: {
 					posts: {
-						list: defineAction({
-							type: 'query',
+						list: defineQuery({
 							handler: () => [],
 						}),
 					},
@@ -84,8 +79,7 @@ describe('buildActionCommands', () => {
 
 	test('uses description from action when provided', () => {
 		const actions: Actions = {
-			sync: defineAction({
-				type: 'mutation',
+			sync: defineMutation({
 				description: 'Sync data from external source',
 				handler: () => {},
 			}),
@@ -98,8 +92,7 @@ describe('buildActionCommands', () => {
 
 	test('builder contains yargs options for input schema', () => {
 		const actions: Actions = {
-			create: defineAction({
-				type: 'mutation',
+			create: defineMutation({
 				input: type({
 					title: 'string',
 					'count?': 'number',
@@ -122,13 +115,11 @@ describe('buildActionCommands', () => {
 
 	test('handles mixed flat and nested actions', () => {
 		const actions: Actions = {
-			ping: defineAction({
-				type: 'query',
+			ping: defineQuery({
 				handler: () => 'pong',
 			}),
 			users: {
-				list: defineAction({
-					type: 'query',
+				list: defineQuery({
 					handler: () => [],
 				}),
 			},

--- a/packages/epicenter/src/cli/command-builder.ts
+++ b/packages/epicenter/src/cli/command-builder.ts
@@ -1,0 +1,100 @@
+import type { CommandModule } from 'yargs';
+import type { Action, Actions } from '../core/actions';
+import { iterateActions } from '../core/actions';
+import { generateJsonSchema } from '../core/schema/standard/to-json-schema';
+import { jsonSchemaToYargsOptions } from './json-schema-to-yargs';
+
+function extractInputFromArgv(
+	argv: Record<string, unknown>,
+	inputSchema: unknown,
+): Record<string, unknown> {
+	if (!inputSchema) return {};
+
+	const schema = inputSchema as {
+		'~standard': {
+			jsonSchema: {
+				input: (opts: { target: string }) => Record<string, unknown>;
+			};
+		};
+	};
+	const jsonSchema = schema['~standard'].jsonSchema.input({
+		target: 'draft-2020-12',
+	});
+
+	if (jsonSchema.type !== 'object' || !jsonSchema.properties) {
+		return {};
+	}
+
+	const properties = jsonSchema.properties as Record<string, unknown>;
+	const input: Record<string, unknown> = {};
+
+	for (const key of Object.keys(properties)) {
+		if (key in argv && argv[key] !== undefined) {
+			input[key] = argv[key];
+		}
+	}
+
+	return input;
+}
+
+function createActionHandler(action: Action<any, any>) {
+	return async (argv: Record<string, unknown>) => {
+		const input = extractInputFromArgv(argv, action.input);
+
+		if (action.input) {
+			const result = await action.input['~standard'].validate(input);
+			if (result.issues) {
+				console.error('Validation failed:');
+				for (const issue of result.issues) {
+					console.error(
+						`  - ${issue.path?.join('.') ?? 'input'}: ${issue.message}`,
+					);
+				}
+				process.exit(1);
+			}
+			const output = await action.handler(result.value);
+			console.log(JSON.stringify(output, null, 2));
+		} else {
+			const output = await (action.handler as () => unknown)();
+			console.log(JSON.stringify(output, null, 2));
+		}
+	};
+}
+
+/**
+ * Build yargs command configurations from an actions tree.
+ *
+ * Iterates over all actions and creates CommandModule configs that can be
+ * registered with yargs. Separates the concern of building command configs
+ * from registering them, enabling cleaner CLI construction.
+ *
+ * @example
+ * ```typescript
+ * const actions = { posts: { create: defineAction({ ... }) } };
+ * const commands = buildActionCommands(actions);
+ * for (const cmd of commands) {
+ *   cli = cli.command(cmd);
+ * }
+ * ```
+ */
+export function buildActionCommands(actions: Actions): CommandModule[] {
+	return [...iterateActions(actions)].map(([action, path]) => {
+		const commandPath = path.join(' ');
+		const description =
+			action.description ??
+			`${action.type === 'query' ? 'Query' : 'Mutation'}: ${path.join('.')}`;
+
+		const builder = action.input
+			? jsonSchemaToYargsOptions(
+					generateJsonSchema(action.input) as Record<string, unknown>,
+				)
+			: {};
+
+		return {
+			command: commandPath,
+			describe: description,
+			builder,
+			handler: createActionHandler(action),
+		};
+	});
+}

--- a/packages/epicenter/src/cli/command-builder.ts
+++ b/packages/epicenter/src/cli/command-builder.ts
@@ -1,7 +1,7 @@
 import type { CommandModule } from 'yargs';
 import type { Actions } from '../core/actions';
 import { iterateActions } from '../core/actions';
-import { generateJsonSchema } from '../core/schema/standard/to-json-schema';
+import { standardSchemaToJsonSchema } from '../core/schema/standard/to-json-schema';
 import { jsonSchemaToYargsOptions } from './json-schema-to-yargs';
 
 /**
@@ -28,7 +28,7 @@ export function buildActionCommands(actions: Actions): CommandModule[] {
 			`${action.type === 'query' ? 'Query' : 'Mutation'}: ${path.join('.')}`;
 
 		const jsonSchema = action.input
-			? (generateJsonSchema(action.input) as Record<string, unknown>)
+			? (standardSchemaToJsonSchema(action.input) as Record<string, unknown>)
 			: undefined;
 
 		const builder = jsonSchema ? jsonSchemaToYargsOptions(jsonSchema) : {};

--- a/packages/epicenter/src/cli/command-builder.ts
+++ b/packages/epicenter/src/cli/command-builder.ts
@@ -1,5 +1,5 @@
 import type { CommandModule } from 'yargs';
-import type { Action, Actions } from '../core/actions';
+import type { Actions } from '../core/actions';
 import { iterateActions } from '../core/actions';
 import { generateJsonSchema } from '../core/schema/standard/to-json-schema';
 import { jsonSchemaToYargsOptions } from './json-schema-to-yargs';
@@ -37,30 +37,6 @@ function extractInputFromArgv(
 	return input;
 }
 
-function createActionHandler(action: Action<any, any>) {
-	return async (argv: Record<string, unknown>) => {
-		const input = extractInputFromArgv(argv, action.input);
-
-		if (action.input) {
-			const result = await action.input['~standard'].validate(input);
-			if (result.issues) {
-				console.error('Validation failed:');
-				for (const issue of result.issues) {
-					console.error(
-						`  - ${issue.path?.join('.') ?? 'input'}: ${issue.message}`,
-					);
-				}
-				process.exit(1);
-			}
-			const output = await action.handler(result.value);
-			console.log(JSON.stringify(output, null, 2));
-		} else {
-			const output = await (action.handler as () => unknown)();
-			console.log(JSON.stringify(output, null, 2));
-		}
-	};
-}
-
 /**
  * Build yargs command configurations from an actions tree.
  *
@@ -94,7 +70,27 @@ export function buildActionCommands(actions: Actions): CommandModule[] {
 			command: commandPath,
 			describe: description,
 			builder,
-			handler: createActionHandler(action),
+			handler: async (argv: Record<string, unknown>) => {
+				const input = extractInputFromArgv(argv, action.input);
+
+				if (action.input) {
+					const result = await action.input['~standard'].validate(input);
+					if (result.issues) {
+						console.error('Validation failed:');
+						for (const issue of result.issues) {
+							console.error(
+								`  - ${issue.path?.join('.') ?? 'input'}: ${issue.message}`,
+							);
+						}
+						process.exit(1);
+					}
+					const output = await action.handler(result.value);
+					console.log(JSON.stringify(output, null, 2));
+				} else {
+					const output = await (action.handler as () => unknown)();
+					console.log(JSON.stringify(output, null, 2));
+				}
+			},
 		};
 	});
 }

--- a/packages/epicenter/src/cli/command-builder.ts
+++ b/packages/epicenter/src/cli/command-builder.ts
@@ -4,26 +4,6 @@ import { iterateActions } from '../core/actions';
 import { generateJsonSchema } from '../core/schema/standard/to-json-schema';
 import { jsonSchemaToYargsOptions } from './json-schema-to-yargs';
 
-function extractInputFromArgv(
-	argv: Record<string, unknown>,
-	jsonSchema: Record<string, unknown> | undefined,
-): Record<string, unknown> {
-	if (!jsonSchema || jsonSchema.type !== 'object' || !jsonSchema.properties) {
-		return {};
-	}
-
-	const properties = jsonSchema.properties as Record<string, unknown>;
-	const input: Record<string, unknown> = {};
-
-	for (const key of Object.keys(properties)) {
-		if (key in argv && argv[key] !== undefined) {
-			input[key] = argv[key];
-		}
-	}
-
-	return input;
-}
-
 /**
  * Build yargs command configurations from an actions tree.
  *
@@ -33,7 +13,7 @@ function extractInputFromArgv(
  *
  * @example
  * ```typescript
- * const actions = { posts: { create: defineAction({ ... }) } };
+ * const actions = { posts: { create: defineMutation({ ... }) } };
  * const commands = buildActionCommands(actions);
  * for (const cmd of commands) {
  *   cli = cli.command(cmd);
@@ -80,4 +60,24 @@ export function buildActionCommands(actions: Actions): CommandModule[] {
 			},
 		};
 	});
+}
+
+function extractInputFromArgv(
+	argv: Record<string, unknown>,
+	jsonSchema: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+	if (!jsonSchema || jsonSchema.type !== 'object' || !jsonSchema.properties) {
+		return {};
+	}
+
+	const properties = jsonSchema.properties as Record<string, unknown>;
+	const input: Record<string, unknown> = {};
+
+	for (const key of Object.keys(properties)) {
+		if (key in argv && argv[key] !== undefined) {
+			input[key] = argv[key];
+		}
+	}
+
+	return input;
 }

--- a/packages/epicenter/src/cli/command-builder.ts
+++ b/packages/epicenter/src/cli/command-builder.ts
@@ -24,6 +24,22 @@ function extractInputFromArgv(
 	return input;
 }
 
+/**
+ * Build yargs command configurations from an actions tree.
+ *
+ * Iterates over all actions and creates CommandModule configs that can be
+ * registered with yargs. Separates the concern of building command configs
+ * from registering them, enabling cleaner CLI construction.
+ *
+ * @example
+ * ```typescript
+ * const actions = { posts: { create: defineAction({ ... }) } };
+ * const commands = buildActionCommands(actions);
+ * for (const cmd of commands) {
+ *   cli = cli.command(cmd);
+ * }
+ * ```
+ */
 export function buildActionCommands(actions: Actions): CommandModule[] {
 	return [...iterateActions(actions)].map(([action, path]) => {
 		const commandPath = path.join(' ');

--- a/packages/epicenter/src/cli/json-schema-to-yargs.test.ts
+++ b/packages/epicenter/src/cli/json-schema-to-yargs.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from 'bun:test';
+import { type } from 'arktype';
+import { generateJsonSchema } from '../core/schema/standard/to-json-schema';
+import { jsonSchemaToYargsOptions } from './json-schema-to-yargs';
+
+describe('jsonSchemaToYargsOptions', () => {
+	test('converts string field to string option', () => {
+		const schema = type({ title: 'string' });
+		const jsonSchema = generateJsonSchema(schema);
+		const options = jsonSchemaToYargsOptions(jsonSchema);
+
+		expect(options.title).toBeDefined();
+		expect(options.title?.type).toBe('string');
+		expect(options.title?.demandOption).toBe(true);
+	});
+
+	test('converts number field to number option', () => {
+		const schema = type({ count: 'number' });
+		const jsonSchema = generateJsonSchema(schema);
+		const options = jsonSchemaToYargsOptions(jsonSchema);
+
+		expect(options.count).toBeDefined();
+		expect(options.count?.type).toBe('number');
+		expect(options.count?.demandOption).toBe(true);
+	});
+
+	test('converts integer field to number option', () => {
+		const schema = type({ count: 'number.integer' });
+		const jsonSchema = generateJsonSchema(schema);
+		const options = jsonSchemaToYargsOptions(jsonSchema);
+
+		expect(options.count).toBeDefined();
+		expect(options.count?.type).toBe('number');
+	});
+
+	test('converts boolean field to boolean option', () => {
+		const schema = type({ published: 'boolean' });
+		const jsonSchema = generateJsonSchema(schema);
+		const options = jsonSchemaToYargsOptions(jsonSchema);
+
+		expect(options.published).toBeDefined();
+		expect(options.published?.type).toBe('boolean');
+		expect(options.published?.demandOption).toBe(true);
+	});
+
+	test('converts optional field to non-required option', () => {
+		const schema = type({ 'title?': 'string' });
+		const jsonSchema = generateJsonSchema(schema);
+		const options = jsonSchemaToYargsOptions(jsonSchema);
+
+		expect(options.title).toBeDefined();
+		expect(options.title?.type).toBe('string');
+		expect(options.title?.demandOption).toBe(false);
+	});
+
+	test('converts string literal union to choices', () => {
+		const schema = type({ status: "'draft' | 'published' | 'archived'" });
+		const jsonSchema = generateJsonSchema(schema);
+		const options = jsonSchemaToYargsOptions(jsonSchema);
+
+		expect(options.status).toBeDefined();
+		expect(options.status?.type).toBe('string');
+		expect(options.status?.choices).toContain('draft');
+		expect(options.status?.choices).toContain('published');
+		expect(options.status?.choices).toContain('archived');
+		expect(options.status?.choices).toHaveLength(3);
+	});
+
+	test('converts array field to array option', () => {
+		const schema = type({ tags: 'string[]' });
+		const jsonSchema = generateJsonSchema(schema);
+		const options = jsonSchemaToYargsOptions(jsonSchema);
+
+		expect(options.tags).toBeDefined();
+		expect(options.tags?.type).toBe('array');
+	});
+
+	test('handles multiple fields', () => {
+		const schema = type({
+			title: 'string',
+			count: 'number',
+			'published?': 'boolean',
+		});
+		const jsonSchema = generateJsonSchema(schema);
+		const options = jsonSchemaToYargsOptions(jsonSchema);
+
+		expect(Object.keys(options)).toHaveLength(3);
+		expect(options.title?.type).toBe('string');
+		expect(options.title?.demandOption).toBe(true);
+		expect(options.count?.type).toBe('number');
+		expect(options.count?.demandOption).toBe(true);
+		expect(options.published?.type).toBe('boolean');
+		expect(options.published?.demandOption).toBe(false);
+	});
+
+	test('returns empty object for non-object schema', () => {
+		const options = jsonSchemaToYargsOptions({ type: 'string' });
+		expect(options).toEqual({});
+	});
+
+	test('handles schema without descriptions gracefully', () => {
+		const schema = type({ title: 'string' });
+		const jsonSchema = generateJsonSchema(schema);
+		const options = jsonSchemaToYargsOptions(jsonSchema);
+
+		expect(options.title?.description).toBeUndefined();
+	});
+});

--- a/packages/epicenter/src/cli/json-schema-to-yargs.test.ts
+++ b/packages/epicenter/src/cli/json-schema-to-yargs.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from 'bun:test';
 import { type } from 'arktype';
-import { generateJsonSchema } from '../core/schema/standard/to-json-schema';
+import { standardSchemaToJsonSchema } from '../core/schema/standard/to-json-schema';
 import { jsonSchemaToYargsOptions } from './json-schema-to-yargs';
 
 describe('jsonSchemaToYargsOptions', () => {
 	test('converts string field to string option', () => {
 		const schema = type({ title: 'string' });
-		const jsonSchema = generateJsonSchema(schema);
+		const jsonSchema = standardSchemaToJsonSchema(schema);
 		const options = jsonSchemaToYargsOptions(jsonSchema);
 
 		expect(options.title).toBeDefined();
@@ -16,7 +16,7 @@ describe('jsonSchemaToYargsOptions', () => {
 
 	test('converts number field to number option', () => {
 		const schema = type({ count: 'number' });
-		const jsonSchema = generateJsonSchema(schema);
+		const jsonSchema = standardSchemaToJsonSchema(schema);
 		const options = jsonSchemaToYargsOptions(jsonSchema);
 
 		expect(options.count).toBeDefined();
@@ -26,7 +26,7 @@ describe('jsonSchemaToYargsOptions', () => {
 
 	test('converts integer field to number option', () => {
 		const schema = type({ count: 'number.integer' });
-		const jsonSchema = generateJsonSchema(schema);
+		const jsonSchema = standardSchemaToJsonSchema(schema);
 		const options = jsonSchemaToYargsOptions(jsonSchema);
 
 		expect(options.count).toBeDefined();
@@ -35,7 +35,7 @@ describe('jsonSchemaToYargsOptions', () => {
 
 	test('converts boolean field to boolean option', () => {
 		const schema = type({ published: 'boolean' });
-		const jsonSchema = generateJsonSchema(schema);
+		const jsonSchema = standardSchemaToJsonSchema(schema);
 		const options = jsonSchemaToYargsOptions(jsonSchema);
 
 		expect(options.published).toBeDefined();
@@ -45,7 +45,7 @@ describe('jsonSchemaToYargsOptions', () => {
 
 	test('converts optional field to non-required option', () => {
 		const schema = type({ 'title?': 'string' });
-		const jsonSchema = generateJsonSchema(schema);
+		const jsonSchema = standardSchemaToJsonSchema(schema);
 		const options = jsonSchemaToYargsOptions(jsonSchema);
 
 		expect(options.title).toBeDefined();
@@ -55,7 +55,7 @@ describe('jsonSchemaToYargsOptions', () => {
 
 	test('converts string literal union to choices', () => {
 		const schema = type({ status: "'draft' | 'published' | 'archived'" });
-		const jsonSchema = generateJsonSchema(schema);
+		const jsonSchema = standardSchemaToJsonSchema(schema);
 		const options = jsonSchemaToYargsOptions(jsonSchema);
 
 		expect(options.status).toBeDefined();
@@ -68,7 +68,7 @@ describe('jsonSchemaToYargsOptions', () => {
 
 	test('converts array field to array option', () => {
 		const schema = type({ tags: 'string[]' });
-		const jsonSchema = generateJsonSchema(schema);
+		const jsonSchema = standardSchemaToJsonSchema(schema);
 		const options = jsonSchemaToYargsOptions(jsonSchema);
 
 		expect(options.tags).toBeDefined();
@@ -81,7 +81,7 @@ describe('jsonSchemaToYargsOptions', () => {
 			count: 'number',
 			'published?': 'boolean',
 		});
-		const jsonSchema = generateJsonSchema(schema);
+		const jsonSchema = standardSchemaToJsonSchema(schema);
 		const options = jsonSchemaToYargsOptions(jsonSchema);
 
 		expect(Object.keys(options)).toHaveLength(3);
@@ -100,7 +100,7 @@ describe('jsonSchemaToYargsOptions', () => {
 
 	test('handles schema without descriptions gracefully', () => {
 		const schema = type({ title: 'string' });
-		const jsonSchema = generateJsonSchema(schema);
+		const jsonSchema = standardSchemaToJsonSchema(schema);
 		const options = jsonSchemaToYargsOptions(jsonSchema);
 
 		expect(options.title?.description).toBeUndefined();

--- a/packages/epicenter/src/cli/json-schema-to-yargs.ts
+++ b/packages/epicenter/src/cli/json-schema-to-yargs.ts
@@ -155,7 +155,7 @@ function fieldSchemaToYargsOption(
  * @example
  * ```typescript
  * const schema = type({ title: 'string', count: 'number?' });
- * const jsonSchema = generateJsonSchema(schema);
+ * const jsonSchema = standardSchemaToJsonSchema(schema);
  * const options = jsonSchemaToYargsOptions(jsonSchema);
  * // { title: { type: 'string', demandOption: true }, count: { type: 'number', demandOption: false } }
  * ```

--- a/packages/epicenter/src/cli/json-schema-to-yargs.ts
+++ b/packages/epicenter/src/cli/json-schema-to-yargs.ts
@@ -1,0 +1,178 @@
+import type { JsonSchema } from 'arktype';
+import type { Options } from 'yargs';
+
+function isObjectSchema(
+	schema: JsonSchema,
+): schema is JsonSchema.Object & { properties: Record<string, JsonSchema> } {
+	return (
+		'type' in schema &&
+		schema.type === 'object' &&
+		'properties' in schema &&
+		schema.properties !== undefined
+	);
+}
+
+function isEnumSchema(schema: JsonSchema): schema is JsonSchema.Enum {
+	return 'enum' in schema && schema.enum !== undefined;
+}
+
+function isUnionSchema(schema: JsonSchema): schema is JsonSchema.Union {
+	return 'anyOf' in schema && schema.anyOf !== undefined;
+}
+
+function isConstSchema(schema: JsonSchema): schema is JsonSchema.Const {
+	return 'const' in schema && schema.const !== undefined;
+}
+
+function hasType(schema: JsonSchema): schema is JsonSchema.Constrainable & {
+	type: JsonSchema.TypeName | JsonSchema.TypeName[];
+} {
+	return 'type' in schema && schema.type !== undefined;
+}
+
+type YargsType = 'string' | 'number' | 'boolean' | 'array' | 'count';
+
+function jsonSchemaTypeToYargsType(
+	type: JsonSchema.TypeName | undefined,
+): YargsType | undefined {
+	switch (type) {
+		case 'string':
+			return 'string';
+		case 'number':
+		case 'integer':
+			return 'number';
+		case 'boolean':
+			return 'boolean';
+		case 'array':
+			return 'array';
+		default:
+			return undefined;
+	}
+}
+
+function extractChoicesFromUnion(
+	variants: readonly JsonSchema[],
+): string[] | undefined {
+	const choices: string[] = [];
+
+	for (const variant of variants) {
+		if (hasType(variant) && variant.type === 'null') continue;
+
+		if (isConstSchema(variant) && typeof variant.const === 'string') {
+			choices.push(variant.const);
+		} else if (isEnumSchema(variant)) {
+			for (const val of variant.enum) {
+				if (typeof val === 'string') choices.push(val);
+			}
+		} else {
+			return undefined;
+		}
+	}
+
+	return choices.length > 0 ? choices : undefined;
+}
+
+function fieldSchemaToYargsOption(
+	fieldSchema: JsonSchema,
+	isRequired: boolean,
+): Options {
+	const description =
+		'description' in fieldSchema
+			? (fieldSchema.description as string | undefined)
+			: undefined;
+
+	const defaultValue =
+		'default' in fieldSchema ? fieldSchema.default : undefined;
+
+	const baseOption: Options = {
+		description,
+		demandOption: isRequired,
+		default: defaultValue,
+	};
+
+	if (isEnumSchema(fieldSchema)) {
+		const choices = fieldSchema.enum.filter(
+			(v): v is string | number =>
+				typeof v === 'string' || typeof v === 'number',
+		);
+		if (choices.length > 0) {
+			return {
+				...baseOption,
+				type: typeof choices[0] === 'number' ? 'number' : 'string',
+				choices,
+			};
+		}
+	}
+
+	if (isUnionSchema(fieldSchema)) {
+		const choices = extractChoicesFromUnion(fieldSchema.anyOf);
+		if (choices) {
+			return {
+				...baseOption,
+				type: 'string',
+				choices,
+			};
+		}
+		return baseOption;
+	}
+
+	if (isConstSchema(fieldSchema)) {
+		const constVal = fieldSchema.const;
+		if (typeof constVal === 'string' || typeof constVal === 'number') {
+			return {
+				...baseOption,
+				type: typeof constVal === 'number' ? 'number' : 'string',
+				choices: [constVal],
+			};
+		}
+	}
+
+	if (hasType(fieldSchema)) {
+		const type = Array.isArray(fieldSchema.type)
+			? fieldSchema.type.find((t) => t !== 'null')
+			: fieldSchema.type;
+
+		const yargsType = jsonSchemaTypeToYargsType(type);
+		if (yargsType) {
+			return {
+				...baseOption,
+				type: yargsType,
+			};
+		}
+	}
+
+	return baseOption;
+}
+
+/**
+ * Convert JSON Schema to yargs options record.
+ *
+ * Takes a JSON Schema (typically generated from a StandardSchema action input)
+ * and returns a record of yargs option configurations. Uses a permissive approach:
+ * if a schema type can't be cleanly mapped to yargs, the option is still created
+ * without a type constraint, letting action validation handle strict checking.
+ *
+ * @example
+ * ```typescript
+ * const schema = type({ title: 'string', count: 'number?' });
+ * const jsonSchema = generateJsonSchema(schema);
+ * const options = jsonSchemaToYargsOptions(jsonSchema);
+ * // { title: { type: 'string', demandOption: true }, count: { type: 'number', demandOption: false } }
+ * ```
+ */
+export function jsonSchemaToYargsOptions(
+	schema: JsonSchema,
+): Record<string, Options> {
+	if (!isObjectSchema(schema)) {
+		return {};
+	}
+
+	const required = new Set(schema.required ?? []);
+	const options: Record<string, Options> = {};
+
+	for (const [key, fieldSchema] of Object.entries(schema.properties)) {
+		options[key] = fieldSchemaToYargsOption(fieldSchema, required.has(key));
+	}
+
+	return options;
+}

--- a/packages/epicenter/src/core/actions.ts
+++ b/packages/epicenter/src/core/actions.ts
@@ -1,0 +1,271 @@
+/**
+ * Action System: Lightweight boundary layer for exposing workspace functionality.
+ *
+ * Actions are plain objects with handlers and metadata for cross-boundary invocation.
+ * They enable REST API endpoints, MCP tool definitions, CLI commands, and OpenAPI docs.
+ *
+ * Actions are defined AFTER client creation and passed to adapters (server, CLI) explicitly.
+ * This separates the internal runtime (capabilities) from external boundary contracts (actions).
+ *
+ * @example
+ * ```typescript
+ * // Define actions wrapping client methods
+ * const actions = {
+ *   posts: {
+ *     getAll: defineAction({
+ *       type: 'query',
+ *       handler: () => client.tables.posts.getAllValid(),
+ *     }),
+ *     create: defineAction({
+ *       type: 'mutation',
+ *       input: type({ title: 'string' }),
+ *       handler: ({ title }) => {
+ *         const id = generateId();
+ *         client.tables.posts.upsert({ id, title });
+ *         return { id };
+ *       },
+ *     }),
+ *   },
+ * };
+ *
+ * // Pass to server/CLI
+ * const server = createServer(client, { actions });
+ * ```
+ */
+
+import type {
+	StandardSchemaV1,
+	StandardSchemaWithJSONSchema,
+} from './schema/standard/types';
+
+/**
+ * Action: a plain object with handler and metadata for cross-boundary invocation.
+ *
+ * Actions enable:
+ * - REST API endpoints (GET for queries, POST for mutations)
+ * - MCP tool definitions
+ * - CLI commands
+ * - OpenAPI documentation
+ *
+ * The handler signature is conditional on whether `input` is defined:
+ * - With input: `(input: TInput) => TOutput | Promise<TOutput>`
+ * - Without input: `() => TOutput | Promise<TOutput>`
+ *
+ * @template TInput - Input schema (must support JSON Schema generation)
+ * @template TOutput - Handler return type (inferred if not specified)
+ *
+ * @example No input - handler has no arguments
+ * ```typescript
+ * const getAllPosts = defineAction({
+ *   type: 'query',
+ *   handler: () => client.tables.posts.getAllValid(),
+ * });
+ * ```
+ *
+ * @example With input - handler receives typed input
+ * ```typescript
+ * const createPost = defineAction({
+ *   type: 'mutation',
+ *   input: type({ title: 'string' }),
+ *   handler: ({ title }) => {
+ *     // TypeScript knows: title is string
+ *     client.tables.posts.upsert({ id: generateId(), title });
+ *   },
+ * });
+ * ```
+ */
+export type Action<
+	TInput extends StandardSchemaWithJSONSchema | undefined = undefined,
+	TOutput = unknown,
+> = {
+	/** 'query' for read operations (GET), 'mutation' for write operations (POST) */
+	type: 'query' | 'mutation';
+
+	/** Human-readable description for docs and MCP tool descriptions */
+	description?: string;
+
+	/** Input schema for validation and JSON Schema generation */
+	input?: TInput;
+
+	/** Output schema for documentation (optional, can be inferred) */
+	output?: StandardSchemaWithJSONSchema;
+
+	/** The handler function. Receives validated input if `input` is defined. */
+	handler: TInput extends StandardSchemaWithJSONSchema
+		? (
+				input: StandardSchemaV1.InferOutput<TInput>,
+			) => TOutput | Promise<TOutput>
+		: () => TOutput | Promise<TOutput>;
+};
+
+/**
+ * Actions can nest to any depth.
+ * Leaves must be Action objects (have `type` and `handler`).
+ *
+ * @example Flat structure
+ * ```typescript
+ * const actions = {
+ *   getUser: defineAction({ type: 'query', handler: ... }),
+ *   createUser: defineAction({ type: 'mutation', handler: ... }),
+ * };
+ * ```
+ *
+ * @example Nested structure
+ * ```typescript
+ * const actions = {
+ *   users: {
+ *     getAll: defineAction({ type: 'query', handler: ... }),
+ *     create: defineAction({ type: 'mutation', handler: ... }),
+ *   },
+ *   posts: {
+ *     getAll: defineAction({ type: 'query', handler: ... }),
+ *   },
+ * };
+ * ```
+ */
+export type Actions = {
+	[key: string]: Action<any, any> | Actions;
+};
+
+/**
+ * Define an action with full type inference.
+ *
+ * This is an identity function that provides type inference for:
+ * - TInput: Inferred from the `input` schema
+ * - TOutput: Inferred from the handler return type
+ * - Handler signature: Conditional based on whether `input` is defined
+ *
+ * Without this helper, you'd need `satisfies Action` and lose input type inference.
+ *
+ * @example No input - handler has no arguments
+ * ```typescript
+ * const getAllPosts = defineAction({
+ *   type: 'query',
+ *   handler: () => client.tables.posts.getAllValid(),
+ * });
+ * ```
+ *
+ * @example With input - handler receives typed input
+ * ```typescript
+ * const createPost = defineAction({
+ *   type: 'mutation',
+ *   input: type({ title: 'string' }),
+ *   handler: ({ title }) => {
+ *     // TypeScript knows: title is string
+ *     client.tables.posts.upsert({ id: generateId(), title });
+ *   },
+ * });
+ * ```
+ *
+ * @example With description for MCP/docs
+ * ```typescript
+ * const syncMarkdown = defineAction({
+ *   type: 'mutation',
+ *   description: 'Sync markdown files to YJS',
+ *   handler: () => client.capabilities.markdown.pullFromMarkdown(),
+ * });
+ * ```
+ */
+export function defineAction<
+	TInput extends StandardSchemaWithJSONSchema | undefined = undefined,
+	TOutput = unknown,
+>(action: Action<TInput, TOutput>): Action<TInput, TOutput> {
+	return action;
+}
+
+/**
+ * Type guard to check if a value is an Action (either query or mutation).
+ *
+ * Actions are identified by having both `type` ('query' | 'mutation') and `handler` properties.
+ * This distinguishes them from nested action groups (which are plain objects).
+ *
+ * @example
+ * ```typescript
+ * function walkActions(node: Action | Actions) {
+ *   if (isAction(node)) {
+ *     // node is Action
+ *     console.log(node.type, node.handler);
+ *   } else {
+ *     // node is Actions (nested structure)
+ *     for (const [key, child] of Object.entries(node)) {
+ *       walkActions(child);
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export function isAction(value: unknown): value is Action<any, any> {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		'type' in value &&
+		(value.type === 'query' || value.type === 'mutation') &&
+		'handler' in value &&
+		typeof value.handler === 'function'
+	);
+}
+
+/**
+ * Type guard to check if a value is a query action.
+ *
+ * Query actions represent read operations and map to HTTP GET requests.
+ *
+ * @example
+ * ```typescript
+ * if (isQuery(action)) {
+ *   // Use GET method for this action
+ * }
+ * ```
+ */
+export function isQuery(value: unknown): value is Action<any, any> {
+	return isAction(value) && value.type === 'query';
+}
+
+/**
+ * Type guard to check if a value is a mutation action.
+ *
+ * Mutation actions represent write operations and map to HTTP POST requests.
+ *
+ * @example
+ * ```typescript
+ * if (isMutation(action)) {
+ *   // Use POST method for this action
+ * }
+ * ```
+ */
+export function isMutation(value: unknown): value is Action<any, any> {
+	return isAction(value) && value.type === 'mutation';
+}
+
+/**
+ * Walk an action tree and call a visitor function for each action.
+ *
+ * The visitor receives:
+ * - `action`: The action object
+ * - `path`: Array of keys from root to this action (e.g., ['posts', 'create'])
+ *
+ * @example Generate routes from actions
+ * ```typescript
+ * walkActions(actions, (action, path) => {
+ *   const route = '/' + path.join('/');
+ *   const method = action.type === 'query' ? 'GET' : 'POST';
+ *   console.log(`${method} ${route}`);
+ * });
+ * // GET /posts/getAll
+ * // POST /posts/create
+ * ```
+ */
+export function walkActions(
+	actions: Actions,
+	visitor: (action: Action<any, any>, path: string[]) => void,
+	path: string[] = [],
+): void {
+	for (const [key, value] of Object.entries(actions)) {
+		const currentPath = [...path, key];
+		if (isAction(value)) {
+			visitor(value, currentPath);
+		} else {
+			walkActions(value, visitor, currentPath);
+		}
+	}
+}

--- a/packages/epicenter/src/core/schema/index.ts
+++ b/packages/epicenter/src/core/schema/index.ts
@@ -75,7 +75,7 @@ export type {
 	StandardTypedV1,
 } from './standard/types.js';
 
-export { generateJsonSchema } from './standard/to-json-schema.js';
+export { standardSchemaToJsonSchema } from './standard/to-json-schema.js';
 
 export type { DateIsoString, TimezoneId } from './fields/datetime.js';
 export { DateTimeString } from './fields/datetime.js';

--- a/packages/epicenter/src/core/schema/standard/index.ts
+++ b/packages/epicenter/src/core/schema/standard/index.ts
@@ -5,6 +5,6 @@ export type {
 	StandardTypedV1,
 } from './types.js';
 
-export { generateJsonSchema } from './to-json-schema.js';
+export { standardSchemaToJsonSchema } from './to-json-schema.js';
 
 export { ARKTYPE_JSON_SCHEMA_FALLBACK } from './arktype-fallback.js';

--- a/packages/epicenter/src/core/schema/standard/to-json-schema.ts
+++ b/packages/epicenter/src/core/schema/standard/to-json-schema.ts
@@ -33,7 +33,9 @@ import { ARKTYPE_JSON_SCHEMA_FALLBACK } from './arktype-fallback';
  * @param schema - Standard JSON Schema to convert
  * @returns JSON Schema representation, or permissive `{}` on error
  */
-export function generateJsonSchema(schema: StandardJSONSchemaV1): JsonSchema {
+export function standardSchemaToJsonSchema(
+	schema: StandardJSONSchemaV1,
+): JsonSchema {
 	const { data } = trySync({
 		try: () =>
 			schema['~standard'].jsonSchema.input({
@@ -48,7 +50,7 @@ export function generateJsonSchema(schema: StandardJSONSchemaV1): JsonSchema {
 		// permissive empty schema `{}` that accepts any input.
 		catch: (e) => {
 			console.warn(
-				'[generateJsonSchema] Conversion failure, using permissive fallback:',
+				'[standardSchemaToJsonSchema] Conversion failure, using permissive fallback:',
 				e,
 			);
 			return Ok({} satisfies JsonSchema);

--- a/packages/epicenter/src/index.ts
+++ b/packages/epicenter/src/index.ts
@@ -132,6 +132,15 @@ export type {
 	WorkspaceSchema,
 } from './core/workspace/contract';
 export { defineWorkspace } from './core/workspace/contract';
+// Action system
+export type { Action, Actions } from './core/actions';
+export {
+	defineAction,
+	isAction,
+	isMutation,
+	isQuery,
+	iterateActions,
+} from './core/actions';
 
 // Note: Capabilities (markdown, sqlite) are NOT re-exported here to avoid bundling
 // Node.js-only code in browser builds. Import them directly from subpaths:

--- a/packages/epicenter/src/index.ts
+++ b/packages/epicenter/src/index.ts
@@ -133,9 +133,10 @@ export type {
 } from './core/workspace/contract';
 export { defineWorkspace } from './core/workspace/contract';
 // Action system
-export type { Action, Actions } from './core/actions';
+export type { Action, Actions, Mutation, Query } from './core/actions';
 export {
-	defineAction,
+	defineMutation,
+	defineQuery,
 	isAction,
 	isMutation,
 	isQuery,

--- a/packages/epicenter/src/server/actions.test.ts
+++ b/packages/epicenter/src/server/actions.test.ts
@@ -102,7 +102,7 @@ describe('createActionsRouter', () => {
 		expect(body).toEqual({ data: { id: '123', title: 'Hello World' } });
 	});
 
-	test('validates input and returns error for invalid data', async () => {
+	test('validates input and returns 422 for invalid data', async () => {
 		const actions: Actions = {
 			create: defineMutation({
 				input: type({ title: 'string', count: 'number' }),
@@ -118,10 +118,8 @@ describe('createActionsRouter', () => {
 				body: JSON.stringify({ title: 'Hello', count: 'not-a-number' }),
 			}),
 		);
-		const body = await response.json();
 
-		expect(body).toHaveProperty('error');
-		expect(body.error.message).toBe('Validation failed');
+		expect(response.status).toBe(422);
 	});
 
 	test('async handlers work correctly', async () => {

--- a/packages/epicenter/src/server/actions.test.ts
+++ b/packages/epicenter/src/server/actions.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, test } from 'bun:test';
+import { type } from 'arktype';
+import { defineMutation, defineQuery, type Actions } from '../core/actions';
+import { collectActionPaths, createActionsRouter } from './actions';
+
+describe('createActionsRouter', () => {
+	test('creates routes for flat actions', async () => {
+		const actions: Actions = {
+			ping: defineQuery({
+				handler: () => 'pong',
+			}),
+		};
+
+		const app = createActionsRouter({ actions });
+		const response = await app.handle(new Request('http://test/actions/ping'));
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toEqual({ data: 'pong' });
+	});
+
+	test('creates routes for nested actions', async () => {
+		const actions: Actions = {
+			posts: {
+				list: defineQuery({
+					handler: () => ['post1', 'post2'],
+				}),
+			},
+		};
+
+		const app = createActionsRouter({ actions });
+		const response = await app.handle(
+			new Request('http://test/actions/posts/list'),
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toEqual({ data: ['post1', 'post2'] });
+	});
+
+	test('query actions respond to GET requests', async () => {
+		const actions: Actions = {
+			getStatus: defineQuery({
+				handler: () => ({ status: 'ok' }),
+			}),
+		};
+
+		const app = createActionsRouter({ actions });
+		const response = await app.handle(
+			new Request('http://test/actions/getStatus', { method: 'GET' }),
+		);
+
+		expect(response.status).toBe(200);
+	});
+
+	test('mutation actions respond to POST requests', async () => {
+		let called = false;
+		const actions: Actions = {
+			doSomething: defineMutation({
+				handler: () => {
+					called = true;
+					return { done: true };
+				},
+			}),
+		};
+
+		const app = createActionsRouter({ actions });
+		const response = await app.handle(
+			new Request('http://test/actions/doSomething', { method: 'POST' }),
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(called).toBe(true);
+		expect(body).toEqual({ data: { done: true } });
+	});
+
+	test('mutation actions accept JSON body input', async () => {
+		let capturedInput: { title: string } | null = null;
+		const actions: Actions = {
+			create: defineMutation({
+				input: type({ title: 'string' }),
+				handler: (input) => {
+					capturedInput = input;
+					return { id: '123', title: input.title };
+				},
+			}),
+		};
+
+		const app = createActionsRouter({ actions });
+		const response = await app.handle(
+			new Request('http://test/actions/create', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ title: 'Hello World' }),
+			}),
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(capturedInput).toEqual({ title: 'Hello World' });
+		expect(body).toEqual({ data: { id: '123', title: 'Hello World' } });
+	});
+
+	test('validates input and returns error for invalid data', async () => {
+		const actions: Actions = {
+			create: defineMutation({
+				input: type({ title: 'string', count: 'number' }),
+				handler: ({ title, count }) => ({ title, count }),
+			}),
+		};
+
+		const app = createActionsRouter({ actions });
+		const response = await app.handle(
+			new Request('http://test/actions/create', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ title: 'Hello', count: 'not-a-number' }),
+			}),
+		);
+		const body = await response.json();
+
+		expect(body).toHaveProperty('error');
+		expect(body.error.message).toBe('Validation failed');
+	});
+
+	test('async handlers work correctly', async () => {
+		const actions: Actions = {
+			asyncQuery: defineQuery({
+				handler: async () => {
+					await new Promise((resolve) => setTimeout(resolve, 10));
+					return { async: true };
+				},
+			}),
+		};
+
+		const app = createActionsRouter({ actions });
+		const response = await app.handle(
+			new Request('http://test/actions/asyncQuery'),
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toEqual({ data: { async: true } });
+	});
+
+	test('supports custom base path', async () => {
+		const actions: Actions = {
+			test: defineQuery({
+				handler: () => 'ok',
+			}),
+		};
+
+		const app = createActionsRouter({ actions, basePath: '/api' });
+		const response = await app.handle(new Request('http://test/api/test'));
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toEqual({ data: 'ok' });
+	});
+
+	test('deeply nested actions create correct routes', async () => {
+		const actions: Actions = {
+			api: {
+				v1: {
+					users: {
+						list: defineQuery({
+							handler: () => [],
+						}),
+					},
+				},
+			},
+		};
+
+		const app = createActionsRouter({ actions });
+		const response = await app.handle(
+			new Request('http://test/actions/api/v1/users/list'),
+		);
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toEqual({ data: [] });
+	});
+});
+
+describe('collectActionPaths', () => {
+	test('collects flat action paths', () => {
+		const actions: Actions = {
+			ping: defineQuery({ handler: () => 'pong' }),
+			sync: defineMutation({ handler: () => {} }),
+		};
+
+		const paths = collectActionPaths(actions);
+
+		expect(paths).toContain('ping');
+		expect(paths).toContain('sync');
+		expect(paths).toHaveLength(2);
+	});
+
+	test('collects nested action paths', () => {
+		const actions: Actions = {
+			posts: {
+				list: defineQuery({ handler: () => [] }),
+				create: defineMutation({ handler: () => {} }),
+			},
+			users: {
+				get: defineQuery({ handler: () => null }),
+			},
+		};
+
+		const paths = collectActionPaths(actions);
+
+		expect(paths).toContain('posts/list');
+		expect(paths).toContain('posts/create');
+		expect(paths).toContain('users/get');
+		expect(paths).toHaveLength(3);
+	});
+
+	test('handles deeply nested actions', () => {
+		const actions: Actions = {
+			api: {
+				v1: {
+					users: {
+						list: defineQuery({ handler: () => [] }),
+					},
+				},
+			},
+		};
+
+		const paths = collectActionPaths(actions);
+
+		expect(paths).toEqual(['api/v1/users/list']);
+	});
+
+	test('returns empty array for empty actions', () => {
+		const paths = collectActionPaths({});
+
+		expect(paths).toEqual([]);
+	});
+});

--- a/packages/epicenter/src/server/actions.ts
+++ b/packages/epicenter/src/server/actions.ts
@@ -70,7 +70,7 @@ export function createActionsRouter(options: ActionsRouterOptions) {
 				);
 				break;
 			default: {
-				const _exhaustive: never = action.type;
+				const _exhaustive: never = action;
 				throw new Error(`Unknown action type: ${_exhaustive}`);
 			}
 		}

--- a/packages/epicenter/src/server/actions.ts
+++ b/packages/epicenter/src/server/actions.ts
@@ -1,0 +1,125 @@
+import { Elysia, t, type TSchema } from 'elysia';
+import type { Action, Actions } from '../core/actions';
+import { iterateActions } from '../core/actions';
+import { generateJsonSchema } from '../core/schema/standard/to-json-schema';
+
+type ActionsPluginOptions = {
+	actions: Actions;
+	basePath?: string;
+};
+
+export function createActionsPlugin(options: ActionsPluginOptions) {
+	const { actions, basePath = '/actions' } = options;
+
+	const plugin = new Elysia({ prefix: basePath });
+
+	for (const [action, path] of iterateActions(actions)) {
+		const routePath = '/' + path.join('/');
+		const handler = createActionHandler(action);
+		const tags: string[] = path.length > 1 ? [path[0] as string] : [];
+
+		if (action.type === 'query') {
+			plugin.get(routePath, handler, {
+				detail: {
+					summary: path.join('.'),
+					description: action.description,
+					tags,
+				},
+			});
+		} else {
+			const bodySchema = action.input
+				? jsonSchemaToElysia(
+						generateJsonSchema(action.input) as Record<string, unknown>,
+					)
+				: t.Any();
+
+			plugin.post(routePath, handler, {
+				body: bodySchema,
+				detail: {
+					summary: path.join('.'),
+					description: action.description,
+					tags,
+				},
+			});
+		}
+	}
+
+	return plugin;
+}
+
+function createActionHandler(action: Action<any, any>) {
+	return async ({ body, query }: { body?: unknown; query?: unknown }) => {
+		const rawInput = action.type === 'query' ? query : body;
+
+		if (action.input) {
+			const result = await action.input['~standard'].validate(rawInput);
+			if (result.issues) {
+				return {
+					error: {
+						message: 'Validation failed',
+						issues: result.issues,
+					},
+				};
+			}
+			const output = await action.handler(result.value);
+			return { data: output };
+		}
+
+		const output = await (action.handler as () => unknown)();
+		return { data: output };
+	};
+}
+
+function jsonSchemaToElysia(schema: Record<string, unknown>): TSchema {
+	if (schema.type === 'object' && schema.properties) {
+		const properties = schema.properties as Record<
+			string,
+			Record<string, unknown>
+		>;
+		const required = (schema.required as string[]) ?? [];
+		const shape: Record<string, TSchema> = {};
+
+		for (const [key, propSchema] of Object.entries(properties)) {
+			const isRequired = required.includes(key);
+			shape[key] = jsonSchemaPropertyToElysia(propSchema, isRequired);
+		}
+
+		return t.Object(shape);
+	}
+
+	return t.Any();
+}
+
+function jsonSchemaPropertyToElysia(
+	schema: Record<string, unknown>,
+	isRequired: boolean,
+): TSchema {
+	let elysiaType: TSchema;
+
+	switch (schema.type) {
+		case 'string':
+			elysiaType = t.String();
+			break;
+		case 'number':
+		case 'integer':
+			elysiaType = t.Number();
+			break;
+		case 'boolean':
+			elysiaType = t.Boolean();
+			break;
+		case 'array':
+			elysiaType = t.Array(t.Any());
+			break;
+		case 'object':
+			elysiaType = jsonSchemaToElysia(schema);
+			break;
+		default:
+			elysiaType = t.Any();
+	}
+
+	return isRequired ? elysiaType : t.Optional(elysiaType);
+}
+
+export function collectActionPaths(actions: Actions): string[] {
+	return [...iterateActions(actions)].map(([_, path]) => path.join('/'));
+}

--- a/packages/epicenter/src/server/server.ts
+++ b/packages/epicenter/src/server/server.ts
@@ -2,7 +2,7 @@ import { openapi } from '@elysiajs/openapi';
 import { Elysia } from 'elysia';
 import type { Actions } from '../core/actions';
 import type { WorkspaceClient } from '../core/workspace/contract';
-import { collectActionPaths, createActionsPlugin } from './actions';
+import { collectActionPaths, createActionsRouter } from './actions';
 import { createSyncPlugin } from './sync';
 import { createTablesPlugin } from './tables';
 
@@ -91,7 +91,7 @@ function createServerInternal(
 		.use(createTablesPlugin(workspaces));
 
 	const appWithActions = options?.actions
-		? baseApp.use(createActionsPlugin({ actions: options.actions }))
+		? baseApp.use(createActionsRouter({ actions: options.actions }))
 		: baseApp;
 
 	const app = appWithActions.get('/', () => ({

--- a/skills/describe-pr/SKILL.md
+++ b/skills/describe-pr/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: describe-pr
+description: Generate comprehensive PR descriptions with code examples and diagrams. Use when creating or updating pull request descriptions.
+---
+
+# Generate PR Description
+
+Generate a comprehensive pull request description that explains WHY the change exists, shows HOW to use any new APIs, and includes diagrams for architecture changes.
+
+## Steps to Follow
+
+### 1. Identify the PR
+
+```bash
+# Check current branch's PR
+gh pr view --json url,number,title,state 2>/dev/null
+
+# If no PR, list open PRs
+gh pr list --limit 10 --json number,title,headRefName,author
+```
+
+### 2. Gather PR Information
+
+```bash
+gh pr diff {number}
+gh pr view {number} --json commits,baseRefName,url,title,number,state
+```
+
+### 3. Analyze Changes Thoroughly
+
+- Read the entire diff
+- Identify the PROBLEM being solved (the "why")
+- Identify new APIs, functions, types, CLI commands, or endpoints
+- Identify architecture changes (data flow, component interactions)
+
+### 4. Generate the Description
+
+**Structure (in order):**
+
+1. **Opening paragraph**: WHY this change exists. What problem does it solve? Link to previous PRs if this restores/continues prior work.
+
+2. **Diagram** (if architecture changed): ASCII flow diagram showing how components interact.
+
+   ```
+   ┌─────────────┐     ┌─────────────┐
+   │  Component  │ ──> │  Component  │
+   └─────────────┘     └─────────────┘
+   ```
+
+3. **Code examples** (MANDATORY for API changes): Show actual usage, not descriptions.
+
+   ````markdown
+   ```typescript
+   // Show the actual API call site
+   const result = newFunction({ param: 'value' });
+   ```
+   ````
+
+4. **Implementation notes**: Technical decisions, why certain approaches were chosen.
+
+5. **Verification section**: What was tested (automated and manual).
+
+### 5. Update the PR
+
+```bash
+gh pr edit {number} --body "$(cat <<'EOF'
+[Your generated description here]
+EOF
+)"
+```
+
+## Mandatory Requirements
+
+### Code Examples Are Required For:
+
+- New functions, types, or exports
+- Changes to function signatures
+- New CLI commands or flags
+- New HTTP endpoints
+- Configuration changes
+
+**Good** (shows usage):
+
+```typescript
+const actions = {
+	posts: {
+		create: defineMutation({
+			input: type({ title: 'string' }),
+			handler: ({ title }) => db.insert({ title }),
+		}),
+	},
+};
+
+const cli = createCLI(client, { actions });
+```
+
+**Bad** (only describes):
+
+> This PR adds an action system that generates CLI commands from action definitions.
+
+### Diagrams Are Required For:
+
+- Changes to data flow
+- New component interactions
+- Architecture refactors
+
+### The "Why" Must Come First
+
+Every PR description MUST start with the problem being solved. Not what files changed, not how it works—WHY.
+
+**Good opening**:
+
+> This PR restores the action system removed in #1209, but with a clearer understanding of where the boundary belongs. Actions are now a contract you pass to `createCLI()` and `createServer()`.
+
+**Bad opening**:
+
+> This PR adds defineQuery and defineMutation functions and updates the CLI and server adapters.
+
+## What to Avoid
+
+- Listing files changed (GitHub shows this)
+- Section headers like "## Summary" or "## Changes Made"
+- Bullet point lists for the main content
+- Marketing language ("revolutionary", "seamless", "powerful")
+- Walls of text without code examples
+- AI watermarks or attribution
+
+## Voice
+
+- Conversational but precise
+- Direct and honest
+- Show your thinking: "We considered X, but Y made more sense because..."

--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -116,6 +116,54 @@ Every PR description MUST start with WHY this change exists. Not what files chan
 
 The reader should understand the PROBLEM before they see the SOLUTION.
 
+### Code Examples Are Mandatory for API Changes
+
+If the PR introduces or modifies APIs, you MUST include code examples showing how to use them. No exceptions.
+
+**What requires code examples:**
+
+- New functions, types, or exports
+- Changes to function signatures
+- New CLI commands or flags
+- New HTTP endpoints
+- Configuration changes
+
+**Good API PR** (shows the actual usage):
+
+```typescript
+// Define actions once
+const actions = {
+	posts: {
+		create: defineMutation({
+			input: type({ title: 'string' }),
+			handler: ({ title }) => client.tables.posts.create({ title }),
+		}),
+	},
+};
+
+// Pass to adapters - they generate CLI commands and HTTP routes
+const cli = createCLI(client, { actions });
+const server = createServer(client, { actions });
+```
+
+**Bad API PR** (only describes without showing):
+
+> This PR adds an action system that generates CLI commands and HTTP routes from action definitions.
+
+The first version lets reviewers understand the API at a glance. The second forces them to dig through the code to understand the call sites.
+
+### Diagrams for Architecture Changes
+
+For PRs that change how components interact, include ASCII flow diagrams:
+
+```
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│   Actions   │ ──> │  Adapters   │ ──> │  CLI/HTTP   │
+└─────────────┘     └─────────────┘     └─────────────┘
+```
+
+This immediately communicates the data flow without walls of text.
+
 ### Other Guidelines
 
 - NEVER include Claude Code or opencode watermarks or attribution in PR titles/descriptions

--- a/specs/20260107T194104-action-system-redesign.md
+++ b/specs/20260107T194104-action-system-redesign.md
@@ -1,0 +1,426 @@
+# Action System Redesign
+
+**Status:** Draft  
+**Created:** 2026-01-07  
+**Author:** Braden Wong
+
+## Overview
+
+Reintroduce actions as a lightweight boundary layer for exposing workspace functionality via HTTP, MCP, and CLI. Actions are plain objects defined separately from capabilities, passed to `createServer` and `createCLI` as a second argument.
+
+This design avoids the complexity of the previous action system (8+ overloads, `ctx` object, unclear registration timing) while preserving the benefits of declarative contracts for cross-boundary invocation.
+
+## Background
+
+### Why Actions Were Removed (PR #1209)
+
+The previous action system was removed because:
+
+1. **8+ function overloads**: Tracking sync/async, `Result<T,E>` vs raw `T`, with/without input created combinatorial explosion
+2. **Redundant `ctx` object**: Handlers received `(input, ctx)` where `ctx` was essentially the workspace client
+3. **Unclear registration timing**: Should actions be registered at workspace definition, `.create()`, or server creation?
+4. **Contract/handler separation complexity**: Added ceremony without clear value
+
+### What We Learned
+
+The "just write functions" approach that replaced actions is simpler for internal logic, but we lose:
+
+- Automatic MCP tool generation
+- Automatic OpenAPI documentation
+- Automatic CLI command generation
+- Input validation at boundaries
+- Introspectable action metadata
+
+### The New Insight
+
+**Capabilities and actions serve different purposes:**
+
+- **Capabilities**: Internal runtime APIs (SQLite connections, file watchers, sync providers)
+- **Actions**: External boundary contracts (what can be invoked remotely, with validation)
+
+Actions should be defined **after** client creation, **separately** from capabilities, and passed to adapters (server, CLI) explicitly.
+
+## Proposed Design
+
+### The Flow
+
+```
+1. Define Workspace Schema
+        ↓
+2. Create Client with Capabilities
+        ↓
+3. Define Actions (wrapping client methods)
+        ↓
+4. Pass to Server/CLI
+```
+
+### Code Example
+
+```typescript
+import { defineWorkspace, defineAction } from '@epicenter/hq';
+import { type } from 'arktype';
+
+// Step 1: Define workspace
+const workspace = defineWorkspace({
+	id: 'blog',
+	guid: 'abc-123',
+	tables: { posts: { id: id(), title: text(), content: text() } },
+	kv: {},
+});
+
+// Step 2: Create client with capabilities
+const client = await workspace.create({ sqlite, persistence, markdown });
+
+// Step 3: Define actions (wrapping client methods)
+const actions = {
+	posts: {
+		getAll: defineAction({
+			type: 'query',
+			handler: () => client.tables.posts.getAllValid(),
+		}),
+		create: defineAction({
+			type: 'mutation',
+			input: type({ title: 'string', content: 'string' }),
+			handler: ({ title, content }) => {
+				const id = generateId();
+				client.tables.posts.upsert({ id, title, content });
+				return { id };
+			},
+		}),
+		get: defineAction({
+			type: 'query',
+			input: type({ id: 'string' }),
+			output: type({ id: 'string', title: 'string', content: 'string' }),
+			handler: ({ id }) => client.tables.posts.get({ id }),
+		}),
+	},
+	sync: {
+		markdown: defineAction({
+			type: 'mutation',
+			description: 'Sync markdown files to YJS',
+			handler: () => client.capabilities.markdown.pullFromMarkdown(),
+		}),
+	},
+};
+
+// Step 4: Pass to server and/or CLI
+const server = createServer(client, { actions });
+const cli = createCLI(client, { actions });
+```
+
+## Type Definitions
+
+### Action Type
+
+````typescript
+import type { StandardSchemaV1, StandardSchemaWithJSONSchema } from './schema';
+
+/**
+ * Action - a plain object with handler and metadata for cross-boundary invocation.
+ *
+ * Actions enable:
+ * - REST API endpoints (GET for queries, POST for mutations)
+ * - MCP tool definitions
+ * - CLI commands
+ * - OpenAPI documentation
+ *
+ * @template TInput - Input schema (must support JSON Schema generation)
+ * @template TOutput - Handler return type (inferred if not specified)
+ */
+export type Action<
+	TInput extends StandardSchemaWithJSONSchema | undefined = undefined,
+	TOutput = unknown,
+> = {
+	/** 'query' for read operations (GET), 'mutation' for write operations (POST) */
+	type: 'query' | 'mutation';
+
+	/** Human-readable description for docs and MCP tool descriptions */
+	description?: string;
+
+	/** Input schema for validation and JSON Schema generation */
+	input?: TInput;
+
+	/** Output schema for documentation (optional, can be inferred) */
+	output?: StandardSchemaWithJSONSchema;
+
+	/** The handler function. Receives validated input if `input` is defined. */
+	handler: TInput extends StandardSchemaWithJSONSchema
+		? (
+				input: StandardSchemaV1.InferOutput<TInput>,
+			) => TOutput | Promise<TOutput>
+		: () => TOutput | Promise<TOutput>;
+};
+
+/**
+ * Actions can nest to any depth.
+ * Leaves must be Action objects (have `type` and `handler`).
+ *
+ * @example Flat structure
+ * ```typescript
+ * const actions = {
+ *   getUser: { type: 'query', handler: ... },
+ *   createUser: { type: 'mutation', handler: ... },
+ * };
+ * ```
+ *
+ * @example Nested structure
+ * ```typescript
+ * const actions = {
+ *   users: {
+ *     getAll: { type: 'query', handler: ... },
+ *     create: { type: 'mutation', handler: ... },
+ *   },
+ * };
+ * ```
+ */
+export type Actions = {
+	[key: string]: Action<any, any> | Actions;
+};
+````
+
+### Helper Function
+
+````typescript
+/**
+ * Define an action with full type inference.
+ *
+ * This is an identity function that provides type inference for:
+ * - TInput: Inferred from the `input` schema
+ * - TOutput: Inferred from the handler return type
+ * - Handler signature: Conditional based on whether `input` is defined
+ *
+ * Without this helper, you'd need `satisfies Action` and lose input type inference.
+ *
+ * @example No input - handler has no arguments
+ * ```typescript
+ * const getAllPosts = defineAction({
+ *   type: 'query',
+ *   handler: () => client.tables.posts.getAllValid(),
+ * });
+ * ```
+ *
+ * @example With input - handler receives typed input
+ * ```typescript
+ * const createPost = defineAction({
+ *   type: 'mutation',
+ *   input: type({ title: 'string' }),
+ *   handler: ({ title }) => {
+ *     // TypeScript knows: title is string
+ *     client.tables.posts.upsert({ id: generateId(), title });
+ *   },
+ * });
+ * ```
+ */
+export function defineAction<
+	TInput extends StandardSchemaWithJSONSchema | undefined = undefined,
+	TOutput = unknown,
+>(action: Action<TInput, TOutput>): Action<TInput, TOutput> {
+	return action;
+}
+````
+
+### Why No `defineActions`?
+
+A `defineActions` helper is **not necessary** because:
+
+1. Each leaf action is already typed via `defineAction`
+2. TypeScript infers the nested structure automatically from the leaves
+3. It would just be an identity function with no type inference benefit
+
+```typescript
+// This works fine - TypeScript infers the full structure
+const actions = {
+  posts: {
+    create: defineAction({ ... }), // Already typed
+    getAll: defineAction({ ... }), // Already typed
+  },
+};
+// actions.posts.create is fully typed ✓
+```
+
+## Server and CLI Integration
+
+### createServer Signature
+
+```typescript
+/**
+ * Create an HTTP server from a workspace client and actions.
+ *
+ * @param client - The workspace client
+ * @param options - Server options including actions to expose
+ */
+function createServer(
+	client: WorkspaceClient,
+	options: {
+		actions: Actions;
+		port?: number;
+	},
+): Server;
+```
+
+### createCLI Signature
+
+```typescript
+/**
+ * Create a CLI from a workspace client and actions.
+ *
+ * @param client - The workspace client
+ * @param options - CLI options including actions to expose
+ */
+function createCLI(
+	client: WorkspaceClient,
+	options: {
+		actions: Actions;
+	},
+): CLI;
+```
+
+### Route/Command Generation
+
+From the action tree, adapters generate:
+
+| Adapter     | Action Path    | Generated                           |
+| ----------- | -------------- | ----------------------------------- |
+| **HTTP**    | `posts.create` | `POST /posts/create`                |
+| **HTTP**    | `posts.getAll` | `GET /posts/getAll`                 |
+| **MCP**     | `posts.create` | Tool `posts_create`                 |
+| **CLI**     | `posts.create` | `cli posts create --title "Hello"`  |
+| **OpenAPI** | `posts.create` | Operation with input/output schemas |
+
+## Design Decisions
+
+### Why Plain Objects Instead of Callable Functions?
+
+The old system made actions callable (`action(input)`). The new system uses plain objects because:
+
+1. **Simpler types**: No need for callable + properties hybrid
+2. **Easier introspection**: Just read `action.type`, `action.input`, etc.
+3. **No confusion**: Actions are data describing behavior, not the behavior itself
+4. **Adapters invoke**: The server/CLI adapter calls `action.handler(input)`, not user code
+
+### Why `StandardSchemaWithJSONSchema` for Input?
+
+Input schemas must support JSON Schema generation for:
+
+- MCP tool `inputSchema`
+- OpenAPI request body schemas
+- CLI flag generation
+
+`StandardSchemaWithJSONSchema` ensures the schema can be converted to JSON Schema. ArkType and Zod (v4.2+) both satisfy this constraint.
+
+### Why Output is Optional?
+
+1. TypeScript can infer the handler return type
+2. Output schema is only needed for explicit documentation
+3. Most actions don't need it
+4. Keeps the common case simple
+
+### Why No Overloads?
+
+The old system had 8 overloads per function to track:
+
+- With/without input (2x)
+- Sync/async handler (2x)
+- Returns `Result<T,E>` vs raw `T` (2x)
+
+The new system avoids this by:
+
+1. **Conditional handler type**: If `input` is defined, handler receives it; otherwise no args
+2. **Union return type**: Handler returns `T | Promise<T>` - runtime handles both
+3. **No Result tracking**: Handler can return `Result` or raw value - adapters handle both
+
+### Why Separate from Capabilities?
+
+Capabilities are internal runtime APIs that may:
+
+- Not be JSON-serializable
+- Have complex dependencies
+- Manage resources and lifecycle
+
+Actions are external boundary contracts that must:
+
+- Have JSON-serializable inputs/outputs
+- Be introspectable without runtime initialization
+- Be safe to expose publicly
+
+Mixing them creates confusion about what's internal vs external.
+
+## Implementation Plan
+
+- [ ] **Create `core/actions.ts`** with new types
+  - [ ] `Action` type with conditional handler signature
+  - [ ] `Actions` type for nested structure
+  - [ ] `defineAction()` helper function
+  - [ ] `isAction()`, `isQuery()`, `isMutation()` type guards
+- [ ] **Update `server/server.ts`**
+  - [ ] Accept `{ actions }` as second argument to `createServer`
+  - [ ] Walk action tree to generate routes
+  - [ ] Use `action.type` to determine HTTP method (GET vs POST)
+  - [ ] Validate input with `action.input` schema
+- [ ] **Update `cli/cli.ts`**
+  - [ ] Accept `{ actions }` as second argument to `createCLI`
+  - [ ] Walk action tree to generate commands
+  - [ ] Convert `action.input` to CLI flags via JSON Schema
+- [ ] **Update MCP integration**
+  - [ ] Walk action tree to generate tools
+  - [ ] Use `action.input` for tool `inputSchema`
+  - [ ] Use `action.description` for tool description
+- [ ] **Update exports in `index.ts`**
+  - [ ] Export `Action`, `Actions` types
+  - [ ] Export `defineAction` function
+  - [ ] Export type guards
+- [ ] **Update documentation**
+  - [ ] `packages/epicenter/README.md`
+  - [ ] `packages/epicenter/src/server/README.md`
+  - [ ] `packages/epicenter/src/cli/README.md`
+
+## Files to Change
+
+| File                                      | Changes                           |
+| ----------------------------------------- | --------------------------------- |
+| `packages/epicenter/src/core/actions.ts`  | New file with types and helpers   |
+| `packages/epicenter/src/server/server.ts` | Accept actions, generate routes   |
+| `packages/epicenter/src/cli/cli.ts`       | Accept actions, generate commands |
+| `packages/epicenter/src/index.ts`         | Export new types and functions    |
+| `packages/epicenter/README.md`            | Update documentation              |
+
+## Migration Notes
+
+This is a **new feature**, not a breaking change. The previous action system was already removed.
+
+Users can adopt actions incrementally:
+
+```typescript
+// Before: No actions, just functions
+const client = await workspace.create({ sqlite });
+function createPost(title: string) { ... }
+app.post('/posts', (req) => createPost(req.body.title));
+
+// After: With actions
+const client = await workspace.create({ sqlite });
+const actions = {
+  posts: {
+    create: defineAction({
+      type: 'mutation',
+      input: type({ title: 'string' }),
+      handler: ({ title }) => { ... },
+    }),
+  },
+};
+const server = createServer(client, { actions });
+```
+
+## Comparison with Old System
+
+| Aspect          | Old System              | New System                     |
+| --------------- | ----------------------- | ------------------------------ |
+| Overloads       | 8 per function          | 0                              |
+| Handler context | `(input, ctx)`          | `(input)` - closes over client |
+| Registration    | `.withActions()` chain  | Separate, passed to server/CLI |
+| Callable        | Yes, `action(input)`    | No, plain object               |
+| Type complexity | High (4 generic params) | Low (2 generic params)         |
+| Lines of code   | ~743                    | ~100 estimated                 |
+
+## Review
+
+_To be filled in after implementation_

--- a/specs/20260108T000000-cli-architecture-cleanup.md
+++ b/specs/20260108T000000-cli-architecture-cleanup.md
@@ -1,0 +1,197 @@
+# CLI Architecture Cleanup
+
+**Status:** In Progress  
+**Created:** 2026-01-08  
+**Author:** Braden Wong
+
+## Overview
+
+Refactor the CLI module to separate concerns: JSON Schema to yargs conversion, command building, and CLI registration. This addresses the "stilted" feel of the current implementation where conversion, building, and registration are tangled together.
+
+## Background
+
+### Current State
+
+The current `cli.ts` has several issues:
+
+1. **Tangled concerns**: JSON Schema → yargs conversion happens inline within the command registration loop
+2. **Mutation-heavy pattern**: `result = result.command(...) as Argv<T>` repeated in a loop
+3. **Type casting**: `as Argv<T>`, `as Record<string, unknown>` throughout
+4. **Duplicate validation**: Yargs validates options, then action validator re-validates
+
+### History
+
+- **PR #1199**: Contract/handler separation introduced complex action system
+- **PR #1209**: Removed action system entirely (~1,820 lines), including `standard-json-schema-to-yargs.ts` (430 lines)
+- **Current**: Simplified action system restored, but CLI registration logic is still awkward
+
+### Inspiration
+
+The **server** implementation (`server/actions.ts`) handles the same data much more elegantly with Elysia's route registration. The CLI should follow a similar pattern: build command configs first, then register.
+
+Cloudflare Wrangler's yargs pattern uses a `createRegisterYargsCommand` factory that separates definition from registration.
+
+## Proposed Architecture
+
+```
+cli/
+├── cli.ts                      # Main createCLI, clean registration loop
+├── json-schema-to-yargs.ts     # JSON Schema → yargs options conversion
+├── command-builder.ts          # Build command configs from actions
+├── bin.ts                      # Entry point (unchanged)
+└── index.ts                    # Exports
+```
+
+### Data Flow
+
+```
+Actions (nested tree)
+    ↓ iterateActions()
+[Action, path][] tuples
+    ↓ buildActionCommands()
+CommandConfig[] (pure data)
+    ↓ register loop
+yargs instance with commands
+```
+
+## Implementation
+
+### 1. `json-schema-to-yargs.ts`
+
+Clean conversion utility using arktype's `JsonSchema` type with proper type guards.
+
+**Key design decisions:**
+
+- Use arktype's `JsonSchema` type (already a dependency)
+- Proper type guards for discriminated union (`isObjectSchema`, `isEnumSchema`, etc.)
+- Returns `Record<string, Options>` not a mutated yargs instance
+- Permissive philosophy: if we can't represent a type, omit the type constraint and let action validation handle it
+
+### 2. `command-builder.ts`
+
+Builds command configurations from actions without registering them.
+
+**Key design decisions:**
+
+- Returns `CommandModule[]` (yargs' command config type)
+- Pure function: actions in, configs out
+- Handler creation separated into its own function
+- Input extraction logic isolated
+
+### 3. `cli.ts` (refactored)
+
+Now just orchestrates: create base CLI, build commands, register them.
+
+**Key design decisions:**
+
+- No inline schema conversion
+- Clean registration loop: `for (const cmd of commands) cli = cli.command(cmd)`
+- Cleanup logic remains the same
+
+## Files Changed
+
+| File                          | Change                                        |
+| ----------------------------- | --------------------------------------------- |
+| `cli/json-schema-to-yargs.ts` | NEW: JSON Schema → yargs options              |
+| `cli/command-builder.ts`      | NEW: Build command configs from actions       |
+| `cli/cli.ts`                  | REFACTOR: Use new modules, clean registration |
+| `cli/index.ts`                | UPDATE: Export new utilities if needed        |
+
+## Comparison
+
+### Before (tangled)
+
+```typescript
+function registerActionCommands<T>(cli: Argv<T>, actions: Actions): Argv<T> {
+	let result = cli;
+	for (const [action, path] of iterateActions(actions)) {
+		result = result.command(
+			path.join(' '),
+			description,
+			(yargs) => {
+				if (action.input) {
+					const jsonSchema = generateJsonSchema(action.input);
+					return addOptionsFromJsonSchema(yargs, jsonSchema); // inline conversion!
+				}
+				return yargs;
+			},
+			async (argv) => {
+				/* handler */
+			},
+		) as Argv<T>; // type casting!
+	}
+	return result;
+}
+```
+
+### After (separated)
+
+```typescript
+// json-schema-to-yargs.ts
+export function jsonSchemaToYargsOptions(schema: JsonSchema): Record<string, Options> { ... }
+
+// command-builder.ts
+export function buildActionCommands(actions: Actions): CommandModule[] {
+  return [...iterateActions(actions)].map(([action, path]) => ({
+    command: path.join(' '),
+    describe: action.description,
+    builder: action.input ? jsonSchemaToYargsOptions(generateJsonSchema(action.input)) : {},
+    handler: createActionHandler(action),
+  }));
+}
+
+// cli.ts
+const commands = options?.actions ? buildActionCommands(options.actions) : [];
+for (const cmd of commands) {
+  cli = cli.command(cmd);
+}
+```
+
+## Todo
+
+- [x] Create spec
+- [ ] Create `cli/json-schema-to-yargs.ts`
+- [ ] Create `cli/command-builder.ts`
+- [ ] Refactor `cli/cli.ts`
+- [ ] Update `cli/index.ts` exports
+- [ ] Run typecheck
+- [ ] Test manually
+
+## Review
+
+### Changes Made
+
+| File                          | Lines | Change                                                            |
+| ----------------------------- | ----- | ----------------------------------------------------------------- |
+| `cli/json-schema-to-yargs.ts` | 167   | NEW: Clean JSON Schema → yargs conversion with proper type guards |
+| `cli/command-builder.ts`      | 90    | NEW: Build command configs from actions tree                      |
+| `cli/cli.ts`                  | 68    | REFACTORED: Now uses new modules, clean registration loop         |
+
+### Before/After Comparison
+
+**Before (cli.ts):** 203 lines with tangled concerns
+
+- Inline JSON Schema conversion in `addOptionsFromJsonSchema`
+- Mutation loop with `result = result.command(...) as Argv<T>`
+- Type casting throughout
+- `extractInputFromArgv` mixed with registration logic
+
+**After:**
+
+- `cli.ts`: 68 lines, clean orchestration
+- `json-schema-to-yargs.ts`: 167 lines, focused conversion with arktype's `JsonSchema` type
+- `command-builder.ts`: 90 lines, pure function building command configs
+
+### Key Improvements
+
+1. **Separation of concerns**: Conversion, building, and registration are now separate
+2. **Type safety**: Uses arktype's `JsonSchema` discriminated union with proper type guards
+3. **Cleaner registration**: `for (const cmd of commands) cli = cli.command(cmd)`
+4. **Testability**: `buildActionCommands` returns pure data, easy to unit test
+5. **Reusability**: `jsonSchemaToYargsOptions` could be exported for custom CLI building
+
+### Verification
+
+- [x] `bun run typecheck` passes
+- [x] No type errors in new files
+- [x] Existing exports unchanged (`createCLI`, `findProjectDir`, `loadClients`)


### PR DESCRIPTION
This PR restores the action system that was removed in #1209, but with a clearer understanding of where the boundary belongs.

## Why This Exists

The previous action system was removed because we weren't sure where it fit. Now we understand: actions are a **contract** you pass deterministically to `createCLI()` and `createServer()`. They're not magic—they're just data structures that describe operations, and the adapters turn them into CLI commands or HTTP routes.

```
┌─────────────────────────────────────────────────────────────────┐
│                         Your App Code                           │
│                                                                 │
│   const actions = {                                             │
│     posts: {                                                    │
│       getAll: defineQuery({ handler: () => ... }),              │
│       create: defineMutation({ input: type({...}), ... }),      │
│     },                                                          │
│   };                                                            │
└─────────────────────────────┬───────────────────────────────────┘
                              │
                              ▼
          ┌───────────────────┴───────────────────┐
          │                                       │
          ▼                                       ▼
┌─────────────────────┐               ┌─────────────────────┐
│   createCLI(...)    │               │  createServer(...)  │
│                     │               │                     │
│ { actions }         │               │ { actions }         │
│      │              │               │      │              │
│      ▼              │               │      ▼              │
│ yargs commands      │               │ Elysia routes       │
│ --title, --count    │               │ GET /actions/posts  │
└─────────────────────┘               └─────────────────────┘
```

## The API

Define actions with `defineQuery` (read operations → GET) or `defineMutation` (write operations → POST):

```typescript
import { defineQuery, defineMutation, type Actions } from '@epicenter/hq';
import { type } from 'arktype';

const actions: Actions = {
  posts: {
    getAll: defineQuery({
      description: 'Get all posts',
      handler: () => client.tables.posts.getAllValid(),
    }),
    create: defineMutation({
      input: type({ title: 'string', 'published?': 'boolean' }),
      handler: ({ title, published }) => {
        const id = generateId();
        client.tables.posts.upsert({ id, title, published: published ?? false });
        return { id };
      },
    }),
  },
  sync: defineMutation({
    description: 'Sync from external source',
    handler: () => client.capabilities.sync.pull(),
  }),
};
```

Then pass them to the adapters:

```typescript
// CLI: epicenter posts create --title "Hello"
const cli = createCLI(client, { actions });
await cli.run(process.argv.slice(2));

// Server: POST /actions/posts/create { "title": "Hello" }
const server = createServer(client, { actions });
server.start();
```

## What the Adapters Do

The **CLI adapter** converts JSON Schema from your input types to yargs options. It walks the action tree and creates subcommands:

```bash
epicenter posts getAll           # Calls actions.posts.getAll.handler()
epicenter posts create --title "Hello"  # Validates, then calls handler
epicenter sync                   # Calls actions.sync.handler()
```

The **server adapter** creates REST routes with automatic OpenAPI documentation. Queries become GET with query params; mutations become POST with JSON body.

Both adapters use the same `iterateActions` generator to traverse nested action structures, ensuring consistency.

## Implementation Notes

We use `defineQuery`/`defineMutation` (separate functions) instead of `defineAction({ type: 'query' })` because it matches the industry convention from TanStack Query and tRPC. The type discriminator is attached internally.

The input schemas can be any Standard Schema (ArkType, Zod, Valibot). Elysia's native Standard Schema support means we don't need to manually convert to TypeBox—it just works for OpenAPI generation.

## Verification

**Automated:**
- [x] Tests pass: `bun test packages/epicenter` (300 pass, 0 fail)

**Manual testing needed:**
- [ ] CLI commands work correctly with input validation
- [ ] HTTP endpoints return proper OpenAPI docs