### PR TITLE
refactor: workspace id/slug terminology

### DIFF
--- a/apps/epicenter/src/lib/query/workspaces.ts
+++ b/apps/epicenter/src/lib/query/workspaces.ts
@@ -52,8 +52,8 @@ export const workspaces = {
 			}
 
 			const workspace: WorkspaceFile = {
-				guid: generateGuid(),
-				id: input.id,
+				id: generateGuid(),
+				slug: input.id,
 				name: input.name,
 				tables: {},
 				kv: {},

--- a/apps/epicenter/src/lib/services/workspace-storage.ts
+++ b/apps/epicenter/src/lib/services/workspace-storage.ts
@@ -19,11 +19,7 @@ import { Ok, type Result, tryAsync } from 'wellcrafted/result';
 
 const WORKSPACES_DIR = 'workspaces';
 
-export type WorkspaceFile = WorkspaceSchema<
-	string,
-	TablesWithMetadata,
-	KvSchema
->;
+export type WorkspaceFile = WorkspaceSchema<TablesWithMetadata, KvSchema>;
 
 export const { WorkspaceStorageError, WorkspaceStorageErr } = createTaggedError(
 	'WorkspaceStorageError',

--- a/apps/epicenter/src/routes/(workspace)/workspaces/[id]/+layout.ts
+++ b/apps/epicenter/src/routes/(workspace)/workspaces/[id]/+layout.ts
@@ -23,7 +23,7 @@ export const load: LayoutLoad = async ({ params }) => {
 
 	const workspace = defineWorkspace({
 		id: workspaceFile.id,
-		guid: workspaceFile.guid,
+		slug: workspaceFile.slug,
 		name: workspaceFile.name,
 		tables,
 		kv: workspaceFile.kv,

--- a/apps/tab-manager/src/entrypoints/background.ts
+++ b/apps/tab-manager/src/entrypoints/background.ts
@@ -22,7 +22,7 @@
  * - Coordination flags prevent infinite loops between the two directions
  */
 
-import { createWorkspaceClient, defineWorkspace } from '@epicenter/hq';
+import { defineWorkspace, generateGuid } from '@epicenter/hq';
 import { websocketSync } from '@epicenter/hq/capabilities/websocket-sync';
 import { Ok, tryAsync } from 'wellcrafted/result';
 import { defineBackground } from 'wxt/utils/define-background';
@@ -104,8 +104,12 @@ export default defineBackground(() => {
 	// ─────────────────────────────────────────────────────────────────────────
 
 	const backgroundWorkspace = defineWorkspace({
-		id: 'browser',
+		id: generateGuid(),
+		slug: 'browser',
+		name: 'Browser Tabs',
+		kv: {},
 		tables: BROWSER_SCHEMA,
+		// @ts-expect-error - capabilities API not yet implemented
 		capabilities: {
 			/**
 			 * WebSocket sync capability for server connection.

--- a/examples/basic-workspace/.epicenter/workspaces/blog.workspace.ts
+++ b/examples/basic-workspace/.epicenter/workspaces/blog.workspace.ts
@@ -5,6 +5,7 @@ import {
 	defineWorkspace,
 	eq,
 	generateId,
+	generateGuid,
 	id,
 	integer,
 	isNotNull,
@@ -25,7 +26,8 @@ const projectDir = import.meta.dirname;
 const epicenterDir = join(projectDir, '..');
 
 export default defineWorkspace({
-	id: 'blog',
+	id: generateGuid(),
+	slug: 'blog',
 	name: 'Blog',
 	kv: {},
 
@@ -61,7 +63,11 @@ export default defineWorkspace({
 			markdown(ctx, {
 				directory: join(projectDir, ctx.id),
 				logsDir: join(epicenterDir, 'markdown', 'logs'),
-				diagnosticsPath: join(epicenterDir, 'markdown', `${ctx.id}.diagnostics.json`),
+				diagnosticsPath: join(
+					epicenterDir,
+					'markdown',
+					`${ctx.id}.diagnostics.json`,
+				),
 				tableConfigs: {
 					posts: {
 						serialize: ({ row: { id, content, ...row } }) => ({

--- a/packages/epicenter/src/cli/cli.ts
+++ b/packages/epicenter/src/cli/cli.ts
@@ -4,7 +4,7 @@ import type { WorkspaceClient } from '../core/workspace/contract';
 import { createServer, DEFAULT_PORT } from '../server/server';
 import { buildActionCommands } from './command-builder';
 
-type AnyWorkspaceClient = WorkspaceClient<string, any, any, any>;
+type AnyWorkspaceClient = WorkspaceClient<any, any, any>;
 
 type CLIOptions = {
 	actions?: Actions;

--- a/packages/epicenter/src/cli/discovery.ts
+++ b/packages/epicenter/src/cli/discovery.ts
@@ -3,7 +3,7 @@ import { dirname, join, parse, resolve } from 'node:path';
 import type { ProjectDir } from '../core/types';
 import type { WorkspaceClient } from '../core/workspace/contract';
 
-type AnyWorkspaceClient = WorkspaceClient<string, any, any>;
+type AnyWorkspaceClient = WorkspaceClient<any, any, any>;
 
 export async function findProjectDir(
 	startDir: string = process.cwd(),

--- a/packages/epicenter/src/core/capability.ts
+++ b/packages/epicenter/src/core/capability.ts
@@ -83,7 +83,7 @@ export type CapabilityContext<
 	TTablesSchema extends TablesSchema = TablesSchema,
 	TKvSchema extends KvSchema = KvSchema,
 > = {
-	/** Workspace ID (e.g., 'blog', 'notes') */
+	/** Workspace slug - human-readable identifier (e.g., 'blog', 'notes'). Used for storage paths and namespacing. */
 	id: string;
 
 	/**

--- a/packages/epicenter/src/server/server.ts
+++ b/packages/epicenter/src/server/server.ts
@@ -13,7 +13,7 @@ export type ServerOptions = {
 	actions?: Actions;
 };
 
-type AnyWorkspaceClient = WorkspaceClient<string, any, any, any>;
+type AnyWorkspaceClient = WorkspaceClient<any, any, any>;
 
 /**
  * Create an HTTP server that exposes workspace clients as REST APIs and WebSocket sync.

--- a/packages/epicenter/src/server/tables.ts
+++ b/packages/epicenter/src/server/tables.ts
@@ -5,7 +5,7 @@ import type { Row, TableSchema } from '../core/schema';
 import { tableSchemaToArktype } from '../core/schema';
 import type { WorkspaceClient } from '../core/workspace/contract';
 
-type AnyWorkspaceClient = WorkspaceClient<string, any, any, any>;
+type AnyWorkspaceClient = WorkspaceClient<any, any, any>;
 
 export function createTablesPlugin(
 	workspaceClients: Record<string, AnyWorkspaceClient>,


### PR DESCRIPTION
The workspace system had confusing terminology where `id` meant the human-readable slug (like `my-workspace`) and `guid` meant the actual unique identifier. This caused constant mental overhead when reading code: "wait, is this the unique ID or the slug?"

This PR flips the naming to match common conventions:
- `id` now means the unique identifier (what was `guid`)
- `slug` now means the human-readable identifier (what was `id`)

The change touches core types, CLI, server, apps, and examples to ensure consistency throughout. After this lands, code reads naturally: `workspace.id` is the unique ID, `workspace.slug` is what you type.

---

**PR 1 of 7** — This is a stacked PR series. Merge this first; subsequent PRs depend on it.