### PR TITLE
feat: 3-doc Y.Doc architecture + TypeBox serialization

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -281,6 +281,7 @@
         "epicenter": "./src/cli/bin.ts",
       },
       "dependencies": {
+        "@ark/json-schema": "^0.0.4",
         "@elysiajs/openapi": "^1.4.11",
         "@sindresorhus/slugify": "^3.0.0",
         "@standard-schema/spec": "^1.1.0",
@@ -436,6 +437,10 @@
     "@aptabase/tauri": ["@aptabase/tauri@0.4.1", "", { "dependencies": { "@tauri-apps/api": "^1.0.0" } }, "sha512-ZjCtPN1Tw0y90nxMLR64UqFjgikxfc9NZouxqXlqZFkfpF8D/tPf1xUn0Anu8nvERGND/hAkO3x7ZLyLGI1HRg=="],
 
     "@aptabase/web": ["@aptabase/web@0.4.3", "", {}, "sha512-IcFGvgEcc26chrRDmnOxzH/HLeNexrAoDx2DjNFAoTjfZCSJmxrABqseVLlTI7JeGKfDdIVI+IC3AWj5v+2J0A=="],
+
+    "@ark/json-schema": ["@ark/json-schema@0.0.4", "", { "dependencies": { "@ark/schema": "0.50.0", "@ark/util": "0.50.0", "arktype": "2.1.23" } }, "sha512-JlOzX8E2BpNPLv6Ue8CXV3BTfY/iFVLxxAVdYDY1BRqe4EEljfPaKlXmYo9IC+fgT9HCTkc9U87lP7E5w8BUnQ=="],
+
+    "@ark/regex": ["@ark/regex@0.0.0", "", { "dependencies": { "@ark/util": "0.50.0" } }, "sha512-p4vsWnd/LRGOdGQglbwOguIVhPmCAf5UzquvnDoxqhhPWTP84wWgi1INea8MgJ4SnI2gp37f13oA4Waz9vwNYg=="],
 
     "@ark/schema": ["@ark/schema@0.56.0", "", { "dependencies": { "@ark/util": "0.56.0" } }, "sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA=="],
 
@@ -2980,6 +2985,14 @@
     "@aklinker1/rollup-plugin-visualizer/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
     "@aptabase/tauri/@tauri-apps/api": ["@tauri-apps/api@1.6.0", "", {}, "sha512-rqI++FWClU5I2UBp4HXFvl+sBWkdigBkxnpJDQUWttNyG7IZP4FwQGhTNL5EOw0vI8i6eSAJ5frLqO7n7jbJdg=="],
+
+    "@ark/json-schema/@ark/schema": ["@ark/schema@0.50.0", "", { "dependencies": { "@ark/util": "0.50.0" } }, "sha512-hfmP82GltBZDadIOeR3argKNlYYyB2wyzHp0eeAqAOFBQguglMV/S7Ip2q007bRtKxIMLDqFY6tfPie1dtssaQ=="],
+
+    "@ark/json-schema/@ark/util": ["@ark/util@0.50.0", "", {}, "sha512-tIkgIMVRpkfXRQIEf0G2CJryZVtHVrqcWHMDa5QKo0OEEBu0tHkRSIMm4Ln8cd8Bn9TPZtvc/kE2Gma8RESPSg=="],
+
+    "@ark/json-schema/arktype": ["arktype@2.1.23", "", { "dependencies": { "@ark/regex": "0.0.0", "@ark/schema": "0.50.0", "@ark/util": "0.50.0" } }, "sha512-tyxNWX6xJVMb2EPJJ3OjgQS1G/vIeQRrZuY4DeBNQmh8n7geS+czgbauQWB6Pr+RXiOO8ChEey44XdmxsqGmfQ=="],
+
+    "@ark/regex/@ark/util": ["@ark/util@0.50.0", "", {}, "sha512-tIkgIMVRpkfXRQIEf0G2CJryZVtHVrqcWHMDa5QKo0OEEBu0tHkRSIMm4Ln8cd8Bn9TPZtvc/kE2Gma8RESPSg=="],
 
     "@asamuzakjp/css-color/lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
 

--- a/packages/epicenter/package.json
+++ b/packages/epicenter/package.json
@@ -33,6 +33,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
+		"@ark/json-schema": "^0.0.4",
 		"@elysiajs/openapi": "^1.4.11",
 		"@sindresorhus/slugify": "^3.0.0",
 		"@standard-schema/spec": "^1.1.0",

--- a/packages/epicenter/src/core/docs/README.md
+++ b/packages/epicenter/src/core/docs/README.md
@@ -1,0 +1,178 @@
+# Y.Doc Wrappers: 3-Document Architecture
+
+This module provides typed wrappers for the three Y.Doc types that power collaborative workspaces.
+
+## Why Three Documents?
+
+A single Y.Doc per workspace seems simpler, but creates problems:
+
+1. **Different sync scopes**: Registry syncs only to YOUR devices; workspace data syncs to ALL collaborators
+2. **Epoch migrations**: Bumping epochs requires a stable pointer (Head) separate from data (Data)
+3. **Discovery**: Users need to know which workspaces they have access to before loading them
+
+## Document Types
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  REGISTRY Y.Doc                                                  │
+│  ID: {registryId}                                                │
+│  Scope: Personal (syncs across user's own devices only)          │
+│                                                                  │
+│  Y.Map('workspaces')                                             │
+│    └── {workspaceId}: true                                       │
+│                                                                  │
+│  Purpose: "Which workspaces do I have access to?"                │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              │ User picks a workspace
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  HEAD Y.Doc                                                      │
+│  ID: {workspaceId}                                               │
+│  Scope: Shared (syncs with all workspace collaborators)          │
+│                                                                  │
+│  Y.Map('head')                                                   │
+│    └── epoch: 0                                                  │
+│                                                                  │
+│  Purpose: "What's the current data epoch?"                       │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              │ Read epoch, compute Data doc ID
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  DATA Y.Doc                                                      │
+│  ID: {workspaceId}-{epoch}                                       │
+│  Scope: Shared (syncs with all workspace collaborators)          │
+│                                                                  │
+│  Y.Map('meta')                                                   │
+│    └── name: "My Workspace"                                      │
+│                                                                  │
+│  Y.Map('schema')                                                 │
+│    ├── tables: Y.Map<tableName, Y.Map<fieldName, FieldSchema>>   │
+│    └── kv: Y.Map<keyName, FieldSchema>                           │
+│                                                                  │
+│  Y.Map('tables')                                                 │
+│    └── {tableName}: Y.Map<rowId, Y.Map<fieldName, value>>        │
+│                                                                  │
+│  Y.Map('kv')                                                     │
+│    └── {keyName}: value                                          │
+│                                                                  │
+│  Purpose: "All the actual workspace data"                        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Boot Flow
+
+```typescript
+// 1. Get registryId from auth server
+const registryId = authServer.getRegistryId(userId);
+
+// 2. Connect to Registry to discover workspaces
+const registry = createRegistryDoc({ registryId });
+const workspaceIds = registry.getWorkspaceIds();
+
+// 3. User selects a workspace, connect to Head
+const head = createHeadDoc({ workspaceId });
+const epoch = head.getEpoch();
+
+// 4. Connect to Data doc at current epoch
+const data = createDataDoc({ workspaceId, epoch });
+
+// 5. Subscribe to epoch changes for reconnection
+head.observeEpoch((newEpoch) => {
+	// Reconnect to new Data doc
+	const newData = createDataDoc({ workspaceId, epoch: newEpoch });
+});
+```
+
+## Epoch System
+
+Epochs enable atomic migrations and compaction:
+
+```
+Epoch 0: Initial data
+    │
+    │ Schema migration needed
+    ▼
+Epoch 1: Migrated data (new schema)
+    │
+    │ Compaction needed
+    ▼
+Epoch 2: Compacted data (fresh Y.Doc)
+```
+
+**To bump epochs:**
+
+1. Create new Data doc at `{workspaceId}-{epoch+1}`
+2. Migrate/transform data from old epoch
+3. Call `head.setEpoch(epoch + 1)`
+4. All clients observing Head reconnect to new Data doc
+
+## Schema Merge Semantics
+
+When `workspace.create()` is called, the code-defined schema is merged into the Y.Doc:
+
+```typescript
+// Code defines schema
+const workspace = defineWorkspace({
+	tables: {
+		posts: { id: id(), title: text(), published: boolean() },
+	},
+});
+
+// On create(), schema is merged into Y.Doc
+const client = await workspace.create();
+// Internally: dataDoc.mergeSchema(tables, kv)
+```
+
+**Merge rules:**
+
+- Field doesn't exist → add it
+- Field exists with different value → update it
+- Field exists with same value → no-op (CRDT handles)
+
+This is idempotent and safe for concurrent calls.
+
+## Files
+
+| File              | Factory               | Purpose                  |
+| ----------------- | --------------------- | ------------------------ |
+| `registry-doc.ts` | `createRegistryDoc()` | Personal workspace index |
+| `head-doc.ts`     | `createHeadDoc()`     | Epoch pointer            |
+| `data-doc.ts`     | `createDataDoc()`     | Schema + data storage    |
+
+## SerializedFieldSchema
+
+The Y.Doc stores a subset of `FieldSchema` to save space:
+
+```typescript
+// Full FieldSchema (from factories)
+{ type: 'text', name: '', description: '', icon: null, nullable: true }
+
+// SerializedFieldSchema (stored in Y.Doc)
+{ type: 'text', nullable: true }
+```
+
+`FieldMetadata` (name, description, icon) is stripped because:
+
+1. Nobody actually uses it (all call sites pass empty/null)
+2. It would bloat every field in the Y.Doc
+3. TypeScript types come from code schema anyway
+
+## Usage
+
+```typescript
+import { createRegistryDoc, createHeadDoc, createDataDoc } from './docs';
+
+// Registry (user's workspace list)
+const registry = createRegistryDoc({ registryId: 'user123' });
+registry.addWorkspace('workspace456');
+
+// Head (epoch pointer)
+const head = createHeadDoc({ workspaceId: 'workspace456' });
+console.log(head.getEpoch()); // 0
+
+// Data (schema + data)
+const data = createDataDoc({ workspaceId: 'workspace456', epoch: 0 });
+data.mergeSchema(tables, kv);
+```

--- a/packages/epicenter/src/core/docs/README.md
+++ b/packages/epicenter/src/core/docs/README.md
@@ -48,8 +48,8 @@ A single Y.Doc per workspace seems simpler, but creates problems:
 │    └── name: "My Workspace"                                      │
 │                                                                  │
 │  Y.Map('schema')                                                 │
-│    ├── tables: Y.Map<tableName, Y.Map<fieldName, FieldSchema>>   │
-│    └── kv: Y.Map<keyName, FieldSchema>                           │
+│    ├── tables: Y.Map<tableName, Y.Map<fieldName, StoredFieldSchema>>│
+│    └── kv: Y.Map<keyName, StoredFieldSchema>                     │
 │                                                                  │
 │  Y.Map('tables')                                                 │
 │    └── {tableName}: Y.Map<rowId, Y.Map<fieldName, value>>        │
@@ -141,23 +141,35 @@ This is idempotent and safe for concurrent calls.
 | `head-doc.ts`     | `createHeadDoc()`     | Epoch pointer            |
 | `data-doc.ts`     | `createDataDoc()`     | Schema + data storage    |
 
-## SerializedFieldSchema
+## StoredFieldSchema
 
-The Y.Doc stores a subset of `FieldSchema` to save space:
+The Y.Doc stores the full `FieldSchema` to enable collaborative schema editing:
 
 ```typescript
-// Full FieldSchema (from factories)
-{ type: 'text', name: '', description: '', icon: null, nullable: true }
+// FieldSchema (from factories)
+{ type: 'text', name: 'Title', description: 'Post title', icon: { type: 'emoji', value: '📝' }, nullable: true }
 
-// SerializedFieldSchema (stored in Y.Doc)
-{ type: 'text', nullable: true }
+// StoredFieldSchema (stored in Y.Doc) - same structure, preserved for collaboration
+{ type: 'text', name: 'Title', description: 'Post title', icon: { type: 'emoji', value: '📝' }, nullable: true }
 ```
 
-`FieldMetadata` (name, description, icon) is stripped because:
+**Why store full metadata?**
 
-1. Nobody actually uses it (all call sites pass empty/null)
-2. It would bloat every field in the Y.Doc
-3. TypeScript types come from code schema anyway
+1. Enables Notion-like collaborative schema editing (rename fields, add descriptions, set icons)
+2. Changes sync via CRDT to all collaborators
+3. TypeScript types still come from code schema (compile-time safety)
+
+**Special handling for `json` fields:**
+
+For `json` fields, the `StandardSchema` (arktype/zod) is converted to JSON Schema before storage:
+
+```typescript
+// Code definition
+{ type: 'json', schema: type({ theme: 'string' }) }
+
+// Stored in Y.Doc (StandardSchema → JSON Schema)
+{ type: 'json', schema: { type: 'object', properties: { theme: { type: 'string' } } } }
+```
 
 ## Usage
 

--- a/packages/epicenter/src/core/docs/data-doc.ts
+++ b/packages/epicenter/src/core/docs/data-doc.ts
@@ -1,0 +1,487 @@
+import * as Y from 'yjs';
+
+import type { KvSchema, TablesSchema } from '../schema';
+import type { FieldSchema } from '../schema/fields/types';
+
+/**
+ * Serialized field schema for Y.Doc storage.
+ *
+ * This is the JSON representation of a field definition stored in the Y.Doc.
+ * It mirrors the FieldSchema type but is guaranteed to be JSON-serializable.
+ */
+export type SerializedFieldSchema = {
+	type: FieldSchema['type'];
+	nullable?: boolean;
+	default?: unknown;
+	options?: readonly string[];
+	schema?: unknown; // JSON schema for json fields
+};
+
+/**
+ * Schema change event for observeSchemaChanges callback.
+ */
+export type SchemaChangeEvent = {
+	tablesAdded: string[];
+	tablesRemoved: string[];
+	fieldsChanged: Array<{
+		table: string;
+		field: string;
+		action: 'add' | 'update' | 'delete';
+	}>;
+};
+
+/**
+ * Data Y.Doc wrapper - Contains all workspace data and schema for a specific epoch.
+ *
+ * Each workspace+epoch combination has one Data Y.Doc that syncs with all collaborators.
+ * It stores:
+ * - Schema definitions (tables, fields, kv)
+ * - Metadata (workspace name)
+ * - Table data
+ * - KV data
+ *
+ * Y.Doc ID: `{workspaceId}-{epoch}`
+ *
+ * Structure:
+ * ```
+ * Y.Map('meta')
+ *   └── name: string
+ *
+ * Y.Map('schema')
+ *   ├── tables: Y.Map<tableName, Y.Map<fieldName, SerializedFieldSchema>>
+ *   └── kv: Y.Map<keyName, SerializedFieldSchema>
+ *
+ * Y.Map('tables')
+ *   └── {tableName}: Y.Map<rowId, Y.Map<fieldName, value>>
+ *
+ * Y.Map('kv')
+ *   └── {keyName}: value
+ * ```
+ */
+export type DataDoc = {
+	/** The underlying Y.Doc instance. */
+	ydoc: Y.Doc;
+	/** The workspace ID. */
+	workspaceId: string;
+	/** The epoch number. */
+	epoch: number;
+	/** The full doc ID (`{workspaceId}-{epoch}`). */
+	docId: string;
+
+	// ─────────────────────────────────────────────────────────────────────────
+	// Metadata
+	// ─────────────────────────────────────────────────────────────────────────
+
+	/** Get the workspace display name. */
+	getName(): string | undefined;
+	/** Set the workspace display name. */
+	setName(name: string): void;
+
+	// ─────────────────────────────────────────────────────────────────────────
+	// Schema Management
+	// ─────────────────────────────────────────────────────────────────────────
+
+	/**
+	 * Check if schema has been seeded.
+	 *
+	 * Returns true if at least one table or kv field is defined in the Y.Doc.
+	 */
+	hasSchema(): boolean;
+
+	/**
+	 * Check if schema has been marked as seeded.
+	 *
+	 * This is a more reliable check than hasSchema() since it uses an explicit marker.
+	 */
+	isSchemaSeeded(): boolean;
+
+	/**
+	 * Seed the Y.Doc schema from code-defined schema.
+	 *
+	 * This should be called once when first creating a workspace.
+	 * If the Y.Doc already has schema, this is a no-op.
+	 *
+	 * The code schema is the source of truth for TypeScript types,
+	 * while the Y.Doc schema enables runtime validation and collaborative editing.
+	 */
+	seedSchema(
+		tables: TablesSchema,
+		kv: KvSchema,
+		options?: { force?: boolean },
+	): void;
+
+	/** Get the schema for a specific table. */
+	getTableSchema(
+		tableName: string,
+	): Map<string, SerializedFieldSchema> | undefined;
+
+	/** Get all table names that have schema defined. */
+	getTableNames(): string[];
+
+	/** Get the schema for a specific KV key. */
+	getKvSchema(keyName: string): SerializedFieldSchema | undefined;
+
+	/** Get all KV key names that have schema defined. */
+	getKvNames(): string[];
+
+	/**
+	 * Add a new field to a table schema.
+	 *
+	 * This enables collaborative schema editing - multiple users can add fields
+	 * and CRDT will merge them automatically.
+	 */
+	addTableField(
+		tableName: string,
+		fieldName: string,
+		fieldSchema: FieldSchema,
+	): void;
+
+	/** Remove a field from a table schema. */
+	removeTableField(tableName: string, fieldName: string): void;
+
+	/** Add a new KV field schema. */
+	addKvField(keyName: string, fieldSchema: FieldSchema): void;
+
+	/** Remove a KV field schema. */
+	removeKvField(keyName: string): void;
+
+	// ─────────────────────────────────────────────────────────────────────────
+	// Raw Y.Map Access (for table operations)
+	// ─────────────────────────────────────────────────────────────────────────
+
+	/**
+	 * Get the raw tables Y.Map.
+	 *
+	 * Structure: `{tableName}: Y.Map<rowId, Y.Map<fieldName, value>>`
+	 */
+	getTablesMap(): Y.Map<Y.Map<Y.Map<unknown>>>;
+
+	/**
+	 * Get the raw KV Y.Map.
+	 *
+	 * Structure: `{keyName}: value`
+	 */
+	getKvMap(): Y.Map<unknown>;
+
+	/** Get the raw schema Y.Map. */
+	getSchemaMap(): Y.Map<Y.Map<unknown>>;
+
+	// ─────────────────────────────────────────────────────────────────────────
+	// Schema Observation
+	// ─────────────────────────────────────────────────────────────────────────
+
+	/**
+	 * Observe changes to table schemas.
+	 *
+	 * Fires when tables are added/removed or fields within tables change.
+	 *
+	 * @returns Unsubscribe function
+	 */
+	observeSchemaChanges(
+		callback: (event: SchemaChangeEvent) => void,
+	): () => void;
+
+	/** Destroy the data doc and clean up resources. */
+	destroy(): void;
+};
+
+/**
+ * Serialize a FieldSchema to a JSON-safe format for Y.Doc storage.
+ */
+function serializeFieldSchema(schema: FieldSchema): SerializedFieldSchema {
+	const serialized: SerializedFieldSchema = {
+		type: schema.type,
+	};
+
+	// Check for nullable (not present on IdFieldSchema, RichtextFieldSchema)
+	if ('nullable' in schema && schema.nullable !== undefined) {
+		serialized.nullable = schema.nullable;
+	}
+
+	// Check for default (not present on IdFieldSchema, RichtextFieldSchema)
+	if ('default' in schema && schema.default !== undefined) {
+		// Functions can't be serialized, so we evaluate them
+		const defaultValue = schema.default;
+		serialized.default =
+			typeof defaultValue === 'function' ? defaultValue() : defaultValue;
+	}
+
+	if ('options' in schema && schema.options !== undefined) {
+		serialized.options = schema.options as readonly string[];
+	}
+
+	if ('schema' in schema && schema.schema !== undefined) {
+		// For JSON fields, store the schema definition
+		// This would need proper JSON Schema conversion in production
+		serialized.schema = schema.schema;
+	}
+
+	return serialized;
+}
+
+/**
+ * Create a Data Y.Doc wrapper for managing workspace data and schema.
+ *
+ * @example
+ * ```typescript
+ * const data = createDataDoc({
+ *   workspaceId: 'abc123xyz789012',
+ *   epoch: 0,
+ * });
+ *
+ * // Seed schema from code definition
+ * data.seedSchema(workspaceSchema.tables, workspaceSchema.kv);
+ *
+ * // Check if schema is already seeded
+ * const hasSchema = data.hasSchema();
+ *
+ * // Get schema for a table
+ * const postsSchema = data.getTableSchema('posts');
+ *
+ * // Access raw Y.Maps for table operations
+ * const tablesMap = data.getTablesMap();
+ * const kvMap = data.getKvMap();
+ * ```
+ */
+export function createDataDoc(options: {
+	workspaceId: string;
+	epoch: number;
+	ydoc?: Y.Doc;
+}): DataDoc {
+	const { workspaceId, epoch } = options;
+	const docId = `${workspaceId}-${epoch}`;
+	const ydoc = options.ydoc ?? new Y.Doc({ guid: docId });
+
+	const metaMap = ydoc.getMap<string>('meta');
+	const schemaMap = ydoc.getMap<Y.Map<unknown>>('schema');
+	const tablesMap = ydoc.getMap<Y.Map<Y.Map<unknown>>>('tables');
+	const kvMap = ydoc.getMap<unknown>('kv');
+
+	// Initialize schema submaps if not present
+	if (!schemaMap.has('tables')) {
+		schemaMap.set('tables', new Y.Map());
+	}
+	if (!schemaMap.has('kv')) {
+		schemaMap.set('kv', new Y.Map());
+	}
+
+	function getTablesSchemaMap(): Y.Map<Y.Map<SerializedFieldSchema>> {
+		return schemaMap.get('tables') as Y.Map<Y.Map<SerializedFieldSchema>>;
+	}
+
+	function getKvSchemaMap(): Y.Map<SerializedFieldSchema> {
+		return schemaMap.get('kv') as Y.Map<SerializedFieldSchema>;
+	}
+
+	return {
+		ydoc,
+		workspaceId,
+		epoch,
+		docId,
+
+		// ─────────────────────────────────────────────────────────────────────
+		// Metadata
+		// ─────────────────────────────────────────────────────────────────────
+
+		getName() {
+			return metaMap.get('name');
+		},
+
+		setName(name) {
+			metaMap.set('name', name);
+		},
+
+		// ─────────────────────────────────────────────────────────────────────
+		// Schema Management
+		// ─────────────────────────────────────────────────────────────────────
+
+		hasSchema() {
+			return getTablesSchemaMap().size > 0 || getKvSchemaMap().size > 0;
+		},
+
+		isSchemaSeeded() {
+			return metaMap.get('schemaSeeded') === 'true';
+		},
+
+		seedSchema(tables, kv, seedOptions = {}) {
+			// Skip if already seeded (unless force)
+			if (metaMap.get('schemaSeeded') === 'true' && !seedOptions.force) {
+				return;
+			}
+
+			ydoc.transact(() => {
+				const tablesSchemaMap = getTablesSchemaMap();
+				const kvSchemaMap = getKvSchemaMap();
+
+				// Seed table schemas
+				for (const [tableName, tableSchema] of Object.entries(tables)) {
+					let tableMap = tablesSchemaMap.get(tableName);
+					if (!tableMap) {
+						tableMap = new Y.Map();
+						tablesSchemaMap.set(tableName, tableMap);
+					}
+
+					for (const [fieldName, fieldSchema] of Object.entries(tableSchema)) {
+						if (!tableMap.has(fieldName) || seedOptions.force) {
+							tableMap.set(fieldName, serializeFieldSchema(fieldSchema));
+						}
+					}
+				}
+
+				// Seed KV schemas
+				for (const [keyName, fieldSchema] of Object.entries(kv)) {
+					if (!kvSchemaMap.has(keyName) || seedOptions.force) {
+						kvSchemaMap.set(keyName, serializeFieldSchema(fieldSchema));
+					}
+				}
+
+				// Mark as seeded
+				metaMap.set('schemaSeeded', 'true');
+			});
+		},
+
+		getTableSchema(tableName) {
+			const tableMap = getTablesSchemaMap().get(tableName);
+			if (!tableMap) return undefined;
+
+			const result = new Map<string, SerializedFieldSchema>();
+			tableMap.forEach((value, key) => {
+				result.set(key, value);
+			});
+			return result;
+		},
+
+		getTableNames() {
+			return Array.from(getTablesSchemaMap().keys());
+		},
+
+		getKvSchema(keyName) {
+			return getKvSchemaMap().get(keyName);
+		},
+
+		getKvNames() {
+			return Array.from(getKvSchemaMap().keys());
+		},
+
+		addTableField(tableName, fieldName, fieldSchema) {
+			const tablesSchemaMap = getTablesSchemaMap();
+
+			let tableMap = tablesSchemaMap.get(tableName);
+			if (!tableMap) {
+				tableMap = new Y.Map();
+				tablesSchemaMap.set(tableName, tableMap);
+			}
+
+			tableMap.set(fieldName, serializeFieldSchema(fieldSchema));
+		},
+
+		removeTableField(tableName, fieldName) {
+			const tableMap = getTablesSchemaMap().get(tableName);
+			if (tableMap) {
+				tableMap.delete(fieldName);
+			}
+		},
+
+		addKvField(keyName, fieldSchema) {
+			getKvSchemaMap().set(keyName, serializeFieldSchema(fieldSchema));
+		},
+
+		removeKvField(keyName) {
+			getKvSchemaMap().delete(keyName);
+		},
+
+		// ─────────────────────────────────────────────────────────────────────
+		// Raw Y.Map Access
+		// ─────────────────────────────────────────────────────────────────────
+
+		getTablesMap() {
+			return tablesMap;
+		},
+
+		getKvMap() {
+			return kvMap;
+		},
+
+		getSchemaMap() {
+			return schemaMap;
+		},
+
+		// ─────────────────────────────────────────────────────────────────────
+		// Schema Observation
+		// ─────────────────────────────────────────────────────────────────────
+
+		observeSchemaChanges(callback) {
+			const tablesSchemaMap = getTablesSchemaMap();
+			const fieldHandlers = new Map<
+				string,
+				(event: Y.YMapEvent<SerializedFieldSchema>) => void
+			>();
+
+			const setupFieldObserver = (
+				tableName: string,
+				tableMap: Y.Map<SerializedFieldSchema>,
+			) => {
+				const fieldHandler = (event: Y.YMapEvent<SerializedFieldSchema>) => {
+					const fieldsChanged: SchemaChangeEvent['fieldsChanged'] = [];
+
+					event.changes.keys.forEach((change, key) => {
+						fieldsChanged.push({
+							table: tableName,
+							field: key,
+							action: change.action as 'add' | 'update' | 'delete',
+						});
+					});
+
+					if (fieldsChanged.length > 0) {
+						callback({ tablesAdded: [], tablesRemoved: [], fieldsChanged });
+					}
+				};
+
+				tableMap.observe(fieldHandler);
+				fieldHandlers.set(tableName, fieldHandler);
+			};
+
+			// Track table-level changes
+			const tableHandler = (
+				event: Y.YMapEvent<Y.Map<SerializedFieldSchema>>,
+			) => {
+				const tablesAdded: string[] = [];
+				const tablesRemoved: string[] = [];
+
+				event.changes.keys.forEach((change, key) => {
+					if (change.action === 'add') {
+						tablesAdded.push(key);
+						// Setup observer for new table
+						const tableMap = tablesSchemaMap.get(key);
+						if (tableMap) {
+							setupFieldObserver(key, tableMap);
+						}
+					} else if (change.action === 'delete') {
+						tablesRemoved.push(key);
+						fieldHandlers.delete(key);
+					}
+				});
+
+				if (tablesAdded.length > 0 || tablesRemoved.length > 0) {
+					callback({ tablesAdded, tablesRemoved, fieldsChanged: [] });
+				}
+			};
+
+			// Setup observers for existing tables
+			tablesSchemaMap.forEach((tableMap, tableName) => {
+				setupFieldObserver(tableName, tableMap);
+			});
+
+			tablesSchemaMap.observe(tableHandler);
+
+			return () => {
+				tablesSchemaMap.unobserve(tableHandler);
+				// Field handlers are implicitly cleaned up when their Y.Maps are garbage collected
+			};
+		},
+
+		destroy() {
+			ydoc.destroy();
+		},
+	};
+}

--- a/packages/epicenter/src/core/docs/data-doc.ts
+++ b/packages/epicenter/src/core/docs/data-doc.ts
@@ -5,15 +5,13 @@ import type {
 	FieldSchema,
 	FieldType,
 	IconDefinition,
-	JsonFieldSchema,
 } from '../schema/fields/types';
-import { standardSchemaToJsonSchema } from '../schema/standard/to-json-schema';
 
 /**
  * Stored field schema in Y.Doc.
  *
- * Contains all FieldSchema properties, with json fields having their
- * StandardSchema converted to JSON Schema for serialization.
+ * Contains all FieldSchema properties. TypeBox schemas (for json fields)
+ * are already JSON Schema, so no conversion is needed.
  *
  * This enables collaborative schema editing - users can modify field names,
  * descriptions, and icons, and changes sync via CRDT.
@@ -33,24 +31,17 @@ export type StoredFieldSchema = {
 	default?: unknown;
 	/** Options for select/tags fields */
 	options?: readonly string[];
-	/** JSON Schema for json fields (converted from StandardSchema) */
+	/** TypeBox schema for json fields (already JSON Schema, no conversion needed) */
 	schema?: unknown;
 };
 
 /**
  * Prepare a FieldSchema for Y.Doc storage.
  *
- * For json fields, converts the StandardSchema to JSON Schema.
- * All other fields are stored as-is, preserving metadata (name, description, icon).
+ * Since TypeBox schemas are already JSON Schema, no conversion is needed.
+ * This function just performs a type cast.
  */
 function prepareForStorage(schema: FieldSchema): StoredFieldSchema {
-	if (schema.type === 'json') {
-		const jsonField = schema as JsonFieldSchema;
-		return {
-			...jsonField,
-			schema: standardSchemaToJsonSchema(jsonField.schema),
-		} as StoredFieldSchema;
-	}
 	return schema as StoredFieldSchema;
 }
 

--- a/packages/epicenter/src/core/docs/head-doc.ts
+++ b/packages/epicenter/src/core/docs/head-doc.ts
@@ -1,7 +1,7 @@
 import * as Y from 'yjs';
 
 /**
- * Head Y.Doc wrapper - Pointer to the current data epoch for a workspace.
+ * Create a Head Y.Doc wrapper for managing workspace epoch state.
  *
  * Each workspace has one Head Y.Doc that syncs with all collaborators.
  * It stores the current epoch number, which determines which Data Y.Doc to use.
@@ -11,84 +11,8 @@ import * as Y from 'yjs';
  * Structure:
  * ```
  * Y.Map('head')
- *   ├── epoch: number (currently always 0)
- *   └── isMigrating: boolean (optional, for epoch bump coordination)
+ *   └── epoch: number
  * ```
- */
-export type HeadDoc = {
-	/** The underlying Y.Doc instance. */
-	ydoc: Y.Doc;
-	/** The workspace ID (Y.Doc guid). */
-	workspaceId: string;
-
-	/**
-	 * Get the current epoch number.
-	 *
-	 * Epoch 0 is the initial epoch. Higher epochs indicate migrations.
-	 */
-	getEpoch(): number;
-
-	/**
-	 * Get the Y.Doc ID for the current data document.
-	 *
-	 * Format: `{workspaceId}-{epoch}`
-	 */
-	getDataDocId(): string;
-
-	/**
-	 * Check if a migration is currently in progress.
-	 *
-	 * When true, clients should avoid writes until migration completes.
-	 */
-	isMigrating(): boolean;
-
-	/**
-	 * Start a migration to a new epoch.
-	 *
-	 * This sets `isMigrating = true` to signal other clients.
-	 * Call `completeEpochBump()` after migration is done.
-	 *
-	 * @returns The new epoch number
-	 */
-	startEpochBump(): number;
-
-	/**
-	 * Complete an epoch bump and update to the new epoch.
-	 *
-	 * Call this after data has been migrated to the new Data Y.Doc.
-	 */
-	completeEpochBump(newEpoch: number): void;
-
-	/**
-	 * Cancel an in-progress epoch bump.
-	 *
-	 * Use this if migration fails and you need to abort.
-	 */
-	cancelEpochBump(): void;
-
-	/**
-	 * Observe epoch changes.
-	 *
-	 * This fires when the epoch number changes, indicating clients
-	 * should reconnect to a new Data Y.Doc.
-	 *
-	 * @returns Unsubscribe function
-	 */
-	observeEpoch(callback: (epoch: number) => void): () => void;
-
-	/**
-	 * Observe migration status changes.
-	 *
-	 * @returns Unsubscribe function
-	 */
-	observeMigrating(callback: (isMigrating: boolean) => void): () => void;
-
-	/** Destroy the head doc and clean up resources. */
-	destroy(): void;
-};
-
-/**
- * Create a Head Y.Doc wrapper for managing workspace epoch state.
  *
  * @example
  * ```typescript
@@ -97,23 +21,20 @@ export type HeadDoc = {
  * // Get current epoch
  * const epoch = head.getEpoch(); // 0
  *
- * // Get data doc ID
- * const dataDocId = head.getDataDocId(); // 'abc123xyz789012-0'
+ * // Set epoch (for migrations)
+ * head.setEpoch(1);
  *
  * // Observe epoch changes (for reconnecting to new data doc)
  * const unsubscribe = head.observeEpoch((newEpoch) => {
- *   console.log('Epoch changed to:', newEpoch);
+ *   const dataDocId = `${head.workspaceId}-${newEpoch}`;
  *   // Reconnect to new data doc
  * });
  * ```
  */
-export function createHeadDoc(options: {
-	workspaceId: string;
-	ydoc?: Y.Doc;
-}): HeadDoc {
+export function createHeadDoc(options: { workspaceId: string; ydoc?: Y.Doc }) {
 	const { workspaceId } = options;
 	const ydoc = options.ydoc ?? new Y.Doc({ guid: workspaceId });
-	const headMap = ydoc.getMap<number | boolean>('head');
+	const headMap = ydoc.getMap<number>('head');
 
 	// Initialize epoch to 0 if not set
 	if (!headMap.has('epoch')) {
@@ -121,50 +42,44 @@ export function createHeadDoc(options: {
 	}
 
 	function getEpoch(): number {
-		return (headMap.get('epoch') as number) ?? 0;
-	}
-
-	function isMigrating(): boolean {
-		return (headMap.get('isMigrating') as boolean) ?? false;
+		return headMap.get('epoch') ?? 0;
 	}
 
 	return {
+		/** The underlying Y.Doc instance. */
 		ydoc,
+
+		/** The workspace ID (Y.Doc guid). */
 		workspaceId,
 
+		/**
+		 * Get the current epoch number.
+		 *
+		 * Epoch 0 is the initial epoch. Higher epochs indicate migrations.
+		 */
 		getEpoch,
 
-		getDataDocId() {
-			return `${workspaceId}-${getEpoch()}`;
+		/**
+		 * Set the epoch number.
+		 *
+		 * Use this to bump epochs or restore from a specific point.
+		 * Clients observing epoch changes will be notified.
+		 */
+		setEpoch(epoch: number) {
+			headMap.set('epoch', epoch);
 		},
 
-		isMigrating,
-
-		startEpochBump() {
-			const currentEpoch = getEpoch();
-			const newEpoch = currentEpoch + 1;
-
-			ydoc.transact(() => {
-				headMap.set('isMigrating', true);
-			});
-
-			return newEpoch;
-		},
-
-		completeEpochBump(newEpoch) {
-			ydoc.transact(() => {
-				headMap.set('epoch', newEpoch);
-				headMap.delete('isMigrating');
-			});
-		},
-
-		cancelEpochBump() {
-			headMap.delete('isMigrating');
-		},
-
-		observeEpoch(callback) {
+		/**
+		 * Observe epoch changes.
+		 *
+		 * Fires when the epoch number changes, indicating clients
+		 * should reconnect to a new Data Y.Doc at `{workspaceId}-{newEpoch}`.
+		 *
+		 * @returns Unsubscribe function
+		 */
+		observeEpoch(callback: (epoch: number) => void) {
 			const handler = (
-				event: Y.YMapEvent<number | boolean>,
+				event: Y.YMapEvent<number>,
 				_transaction: Y.Transaction,
 			) => {
 				if (event.keysChanged.has('epoch')) {
@@ -176,22 +91,12 @@ export function createHeadDoc(options: {
 			return () => headMap.unobserve(handler);
 		},
 
-		observeMigrating(callback) {
-			const handler = (
-				event: Y.YMapEvent<number | boolean>,
-				_transaction: Y.Transaction,
-			) => {
-				if (event.keysChanged.has('isMigrating')) {
-					callback(isMigrating());
-				}
-			};
-
-			headMap.observe(handler);
-			return () => headMap.unobserve(handler);
-		},
-
+		/** Destroy the head doc and clean up resources. */
 		destroy() {
 			ydoc.destroy();
 		},
 	};
 }
+
+/** Head Y.Doc wrapper type - inferred from factory function. */
+export type HeadDoc = ReturnType<typeof createHeadDoc>;

--- a/packages/epicenter/src/core/docs/head-doc.ts
+++ b/packages/epicenter/src/core/docs/head-doc.ts
@@ -1,0 +1,197 @@
+import * as Y from 'yjs';
+
+/**
+ * Head Y.Doc wrapper - Pointer to the current data epoch for a workspace.
+ *
+ * Each workspace has one Head Y.Doc that syncs with all collaborators.
+ * It stores the current epoch number, which determines which Data Y.Doc to use.
+ *
+ * Y.Doc ID: `{workspaceId}` (no epoch suffix)
+ *
+ * Structure:
+ * ```
+ * Y.Map('head')
+ *   ├── epoch: number (currently always 0)
+ *   └── isMigrating: boolean (optional, for epoch bump coordination)
+ * ```
+ */
+export type HeadDoc = {
+	/** The underlying Y.Doc instance. */
+	ydoc: Y.Doc;
+	/** The workspace ID (Y.Doc guid). */
+	workspaceId: string;
+
+	/**
+	 * Get the current epoch number.
+	 *
+	 * Epoch 0 is the initial epoch. Higher epochs indicate migrations.
+	 */
+	getEpoch(): number;
+
+	/**
+	 * Get the Y.Doc ID for the current data document.
+	 *
+	 * Format: `{workspaceId}-{epoch}`
+	 */
+	getDataDocId(): string;
+
+	/**
+	 * Check if a migration is currently in progress.
+	 *
+	 * When true, clients should avoid writes until migration completes.
+	 */
+	isMigrating(): boolean;
+
+	/**
+	 * Start a migration to a new epoch.
+	 *
+	 * This sets `isMigrating = true` to signal other clients.
+	 * Call `completeEpochBump()` after migration is done.
+	 *
+	 * @returns The new epoch number
+	 */
+	startEpochBump(): number;
+
+	/**
+	 * Complete an epoch bump and update to the new epoch.
+	 *
+	 * Call this after data has been migrated to the new Data Y.Doc.
+	 */
+	completeEpochBump(newEpoch: number): void;
+
+	/**
+	 * Cancel an in-progress epoch bump.
+	 *
+	 * Use this if migration fails and you need to abort.
+	 */
+	cancelEpochBump(): void;
+
+	/**
+	 * Observe epoch changes.
+	 *
+	 * This fires when the epoch number changes, indicating clients
+	 * should reconnect to a new Data Y.Doc.
+	 *
+	 * @returns Unsubscribe function
+	 */
+	observeEpoch(callback: (epoch: number) => void): () => void;
+
+	/**
+	 * Observe migration status changes.
+	 *
+	 * @returns Unsubscribe function
+	 */
+	observeMigrating(callback: (isMigrating: boolean) => void): () => void;
+
+	/** Destroy the head doc and clean up resources. */
+	destroy(): void;
+};
+
+/**
+ * Create a Head Y.Doc wrapper for managing workspace epoch state.
+ *
+ * @example
+ * ```typescript
+ * const head = createHeadDoc({ workspaceId: 'abc123xyz789012' });
+ *
+ * // Get current epoch
+ * const epoch = head.getEpoch(); // 0
+ *
+ * // Get data doc ID
+ * const dataDocId = head.getDataDocId(); // 'abc123xyz789012-0'
+ *
+ * // Observe epoch changes (for reconnecting to new data doc)
+ * const unsubscribe = head.observeEpoch((newEpoch) => {
+ *   console.log('Epoch changed to:', newEpoch);
+ *   // Reconnect to new data doc
+ * });
+ * ```
+ */
+export function createHeadDoc(options: {
+	workspaceId: string;
+	ydoc?: Y.Doc;
+}): HeadDoc {
+	const { workspaceId } = options;
+	const ydoc = options.ydoc ?? new Y.Doc({ guid: workspaceId });
+	const headMap = ydoc.getMap<number | boolean>('head');
+
+	// Initialize epoch to 0 if not set
+	if (!headMap.has('epoch')) {
+		headMap.set('epoch', 0);
+	}
+
+	function getEpoch(): number {
+		return (headMap.get('epoch') as number) ?? 0;
+	}
+
+	function isMigrating(): boolean {
+		return (headMap.get('isMigrating') as boolean) ?? false;
+	}
+
+	return {
+		ydoc,
+		workspaceId,
+
+		getEpoch,
+
+		getDataDocId() {
+			return `${workspaceId}-${getEpoch()}`;
+		},
+
+		isMigrating,
+
+		startEpochBump() {
+			const currentEpoch = getEpoch();
+			const newEpoch = currentEpoch + 1;
+
+			ydoc.transact(() => {
+				headMap.set('isMigrating', true);
+			});
+
+			return newEpoch;
+		},
+
+		completeEpochBump(newEpoch) {
+			ydoc.transact(() => {
+				headMap.set('epoch', newEpoch);
+				headMap.delete('isMigrating');
+			});
+		},
+
+		cancelEpochBump() {
+			headMap.delete('isMigrating');
+		},
+
+		observeEpoch(callback) {
+			const handler = (
+				event: Y.YMapEvent<number | boolean>,
+				_transaction: Y.Transaction,
+			) => {
+				if (event.keysChanged.has('epoch')) {
+					callback(getEpoch());
+				}
+			};
+
+			headMap.observe(handler);
+			return () => headMap.unobserve(handler);
+		},
+
+		observeMigrating(callback) {
+			const handler = (
+				event: Y.YMapEvent<number | boolean>,
+				_transaction: Y.Transaction,
+			) => {
+				if (event.keysChanged.has('isMigrating')) {
+					callback(isMigrating());
+				}
+			};
+
+			headMap.observe(handler);
+			return () => headMap.unobserve(handler);
+		},
+
+		destroy() {
+			ydoc.destroy();
+		},
+	};
+}

--- a/packages/epicenter/src/core/docs/index.ts
+++ b/packages/epicenter/src/core/docs/index.ts
@@ -3,6 +3,5 @@ export { createHeadDoc, type HeadDoc } from './head-doc';
 export {
 	createDataDoc,
 	type DataDoc,
-	type StoredFieldSchema,
 	type SchemaChangeEvent,
 } from './data-doc';

--- a/packages/epicenter/src/core/docs/index.ts
+++ b/packages/epicenter/src/core/docs/index.ts
@@ -3,6 +3,6 @@ export { createHeadDoc, type HeadDoc } from './head-doc';
 export {
 	createDataDoc,
 	type DataDoc,
-	type SerializedFieldSchema,
+	type StoredFieldSchema,
 	type SchemaChangeEvent,
 } from './data-doc';

--- a/packages/epicenter/src/core/docs/index.ts
+++ b/packages/epicenter/src/core/docs/index.ts
@@ -1,0 +1,8 @@
+export { createRegistryDoc, type RegistryDoc } from './registry-doc';
+export { createHeadDoc, type HeadDoc } from './head-doc';
+export {
+	createDataDoc,
+	type DataDoc,
+	type SerializedFieldSchema,
+	type SchemaChangeEvent,
+} from './data-doc';

--- a/packages/epicenter/src/core/docs/registry-doc.ts
+++ b/packages/epicenter/src/core/docs/registry-doc.ts
@@ -1,0 +1,150 @@
+import * as Y from 'yjs';
+
+/**
+ * Registry Y.Doc wrapper - Personal index of workspaces the user has access to.
+ *
+ * Each user has one Registry Y.Doc that syncs only across their own devices.
+ * It stores a set of workspace IDs (not the workspace data itself).
+ *
+ * Y.Doc ID: `{registryId}` (from auth server)
+ *
+ * Structure:
+ * ```
+ * Y.Map('workspaces')
+ *   └── {workspaceId}: true
+ * ```
+ */
+export type RegistryDoc = {
+	/** The underlying Y.Doc instance. */
+	ydoc: Y.Doc;
+	/** The registry ID (Y.Doc guid). */
+	registryId: string;
+
+	/**
+	 * Add a workspace to the registry.
+	 *
+	 * This marks that the user has access to this workspace.
+	 * The workspace data itself lives in separate Head and Data Y.Docs.
+	 */
+	addWorkspace(workspaceId: string): void;
+
+	/**
+	 * Remove a workspace from the registry.
+	 *
+	 * This removes the user's local reference to the workspace.
+	 * It does NOT delete the workspace data (that requires auth server action).
+	 */
+	removeWorkspace(workspaceId: string): void;
+
+	/** Check if a workspace is in the registry. */
+	hasWorkspace(workspaceId: string): boolean;
+
+	/** Get all workspace IDs in the registry. */
+	getWorkspaceIds(): string[];
+
+	/** Get the count of workspaces in the registry. */
+	count(): number;
+
+	/**
+	 * Observe changes to the workspace registry.
+	 *
+	 * Fires when workspaces are added or removed.
+	 *
+	 * @returns Unsubscribe function
+	 */
+	observe(
+		callback: (event: { added: string[]; removed: string[] }) => void,
+	): () => void;
+
+	/** Destroy the registry doc and clean up resources. */
+	destroy(): void;
+};
+
+/**
+ * Create a Registry Y.Doc wrapper for managing a user's workspace list.
+ *
+ * @example
+ * ```typescript
+ * const registry = createRegistryDoc({ registryId: 'xyz789012345abc' });
+ *
+ * // Add workspace to registry
+ * registry.addWorkspace('abc123xyz789012');
+ *
+ * // Get all workspace IDs
+ * const workspaceIds = registry.getWorkspaceIds();
+ *
+ * // Check if workspace exists
+ * const exists = registry.hasWorkspace('abc123xyz789012');
+ *
+ * // Remove workspace from registry
+ * registry.removeWorkspace('abc123xyz789012');
+ *
+ * // Observe changes
+ * const unsubscribe = registry.observe((event) => {
+ *   console.log('Added:', event.added);
+ *   console.log('Removed:', event.removed);
+ * });
+ * ```
+ */
+export function createRegistryDoc(options: {
+	registryId: string;
+	ydoc?: Y.Doc;
+}): RegistryDoc {
+	const { registryId } = options;
+	const ydoc = options.ydoc ?? new Y.Doc({ guid: registryId });
+	const workspacesMap = ydoc.getMap<true>('workspaces');
+
+	return {
+		ydoc,
+		registryId,
+
+		addWorkspace(workspaceId) {
+			workspacesMap.set(workspaceId, true);
+		},
+
+		removeWorkspace(workspaceId) {
+			workspacesMap.delete(workspaceId);
+		},
+
+		hasWorkspace(workspaceId) {
+			return workspacesMap.has(workspaceId);
+		},
+
+		getWorkspaceIds() {
+			return Array.from(workspacesMap.keys());
+		},
+
+		count() {
+			return workspacesMap.size;
+		},
+
+		observe(callback) {
+			const handler = (
+				event: Y.YMapEvent<true>,
+				_transaction: Y.Transaction,
+			) => {
+				const added: string[] = [];
+				const removed: string[] = [];
+
+				event.changes.keys.forEach((change, key) => {
+					if (change.action === 'add') {
+						added.push(key);
+					} else if (change.action === 'delete') {
+						removed.push(key);
+					}
+				});
+
+				if (added.length > 0 || removed.length > 0) {
+					callback({ added, removed });
+				}
+			};
+
+			workspacesMap.observe(handler);
+			return () => workspacesMap.unobserve(handler);
+		},
+
+		destroy() {
+			ydoc.destroy();
+		},
+	};
+}

--- a/packages/epicenter/src/core/schema/converters/to-arktype-yjs.ts
+++ b/packages/epicenter/src/core/schema/converters/to-arktype-yjs.ts
@@ -5,8 +5,8 @@
  * where fields may contain YJS types.
  */
 
-import type { StandardSchemaV1 } from '../standard/types';
 import { type Type, type } from 'arktype';
+import type { TSchema, Static } from 'typebox';
 import type { ObjectType } from 'arktype/internal/variants/object.ts';
 import type {
 	BooleanFieldSchema,
@@ -72,10 +72,13 @@ export type FieldSchemaToYjsArktype<C extends FieldSchema> =
 										? TNullable extends true
 											? Type<TOptions[number][] | null>
 											: Type<TOptions[number][]>
-										: C extends JsonFieldSchema<infer TSchema, infer TNullable>
+										: C extends JsonFieldSchema<
+													infer T extends TSchema,
+													infer TNullable
+												>
 											? TNullable extends true
-												? Type<StandardSchemaV1.InferOutput<TSchema> | null>
-												: Type<StandardSchemaV1.InferOutput<TSchema>>
+												? Type<Static<T> | null>
+												: Type<Static<T>>
 											: never;
 
 /**

--- a/packages/epicenter/src/core/schema/converters/to-arktype-yjs.ts
+++ b/packages/epicenter/src/core/schema/converters/to-arktype-yjs.ts
@@ -6,6 +6,7 @@
  */
 
 import { type Type, type } from 'arktype';
+import { jsonSchemaToType } from '@ark/json-schema';
 import type { TSchema, Static } from 'typebox';
 import type { ObjectType } from 'arktype/internal/variants/object.ts';
 import type {
@@ -183,7 +184,11 @@ export function fieldSchemaToYjsArktype<C extends FieldSchema>(
 				: type.string.array();
 			break;
 		case 'json':
-			baseType = fieldSchema.schema as unknown as Type<unknown, {}>;
+			// TypeBox schemas ARE JSON Schema - convert to ArkType at runtime.
+			// TODO: Remove cast when @ark/json-schema updates to arktype >=2.1.29
+			// Type cast needed due to @ark/json-schema using older arktype version (2.1.23 vs 2.1.29).
+			// Runtime behavior is correct; only TS types differ.
+			baseType = jsonSchemaToType(fieldSchema.schema) as unknown as Type;
 			break;
 	}
 

--- a/packages/epicenter/src/core/schema/converters/to-arktype.test.ts
+++ b/packages/epicenter/src/core/schema/converters/to-arktype.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { type } from 'arktype';
+import { Type } from 'typebox';
 import { id, integer, json, select, text } from '../../schema';
 import { tableSchemaToArktype } from './to-arktype';
 
@@ -113,9 +114,9 @@ describe('tableSchemaToArktype', () => {
 			id: id(),
 			title: text(),
 			metadata: json({
-				schema: type({
-					author: 'string',
-					tags: type.string.array(),
+				schema: Type.Object({
+					author: Type.String(),
+					tags: Type.Array(Type.String()),
 				}),
 			}),
 			status: select({ options: ['draft', 'published'] }),

--- a/packages/epicenter/src/core/schema/converters/to-arktype.ts
+++ b/packages/epicenter/src/core/schema/converters/to-arktype.ts
@@ -5,8 +5,8 @@
  * object methods like .partial() and .merge().
  */
 
-import type { StandardSchemaV1 } from '../standard/types';
 import { type Type, type } from 'arktype';
+import type { TSchema, Static } from 'typebox';
 import type { ObjectType } from 'arktype/internal/variants/object.ts';
 import type {
 	BooleanFieldSchema,
@@ -72,10 +72,13 @@ export type FieldSchemaToArktype<C extends FieldSchema> =
 										? TNullable extends true
 											? Type<TOptions[number][] | null>
 											: Type<TOptions[number][]>
-										: C extends JsonFieldSchema<infer TSchema, infer TNullable>
+										: C extends JsonFieldSchema<
+													infer T extends TSchema,
+													infer TNullable
+												>
 											? TNullable extends true
-												? Type<StandardSchemaV1.InferOutput<TSchema> | null>
-												: Type<StandardSchemaV1.InferOutput<TSchema>>
+												? Type<Static<T> | null>
+												: Type<Static<T>>
 											: never;
 
 /**

--- a/packages/epicenter/src/core/schema/converters/to-arktype.ts
+++ b/packages/epicenter/src/core/schema/converters/to-arktype.ts
@@ -6,6 +6,7 @@
  */
 
 import { type Type, type } from 'arktype';
+import { jsonSchemaToType } from '@ark/json-schema';
 import type { TSchema, Static } from 'typebox';
 import type { ObjectType } from 'arktype/internal/variants/object.ts';
 import type {
@@ -194,7 +195,11 @@ export function fieldSchemaToArktype<C extends FieldSchema>(
 				: type.string.array();
 			break;
 		case 'json':
-			baseType = fieldSchema.schema as unknown as Type<unknown, {}>;
+			// TypeBox schemas ARE JSON Schema - convert to ArkType at runtime.
+			// TODO: Remove cast when @ark/json-schema updates to arktype >=2.1.29
+			// Type cast needed due to @ark/json-schema using older arktype version (2.1.23 vs 2.1.29).
+			// Runtime behavior is correct; only TS types differ.
+			baseType = jsonSchemaToType(fieldSchema.schema) as unknown as Type;
 			break;
 	}
 

--- a/packages/epicenter/src/core/schema/converters/to-drizzle.ts
+++ b/packages/epicenter/src/core/schema/converters/to-drizzle.ts
@@ -1,5 +1,5 @@
 import slugify from '@sindresorhus/slugify';
-import type { StandardSchemaV1 } from '../standard/types';
+import type { TSchema, Static } from 'typebox';
 import type { $Type, IsPrimaryKey, NotNull } from 'drizzle-orm';
 import {
 	integer,
@@ -235,13 +235,16 @@ type FieldToDrizzle<C extends FieldSchema> = C extends IdFieldSchema
 													enumValues: undefined;
 												}>
 											>
-									: C extends JsonFieldSchema<infer TSchema, infer TNullable>
+									: C extends JsonFieldSchema<
+												infer T extends TSchema,
+												infer TNullable
+											>
 										? TNullable extends true
 											? SQLiteCustomColumnBuilder<{
 													name: '';
 													dataType: 'custom';
 													columnType: 'SQLiteCustomColumn';
-													data: StandardSchemaV1.InferOutput<TSchema>;
+													data: Static<T>;
 													driverParam: string;
 													enumValues: undefined;
 												}>
@@ -250,7 +253,7 @@ type FieldToDrizzle<C extends FieldSchema> = C extends IdFieldSchema
 														name: '';
 														dataType: 'custom';
 														columnType: 'SQLiteCustomColumn';
-														data: StandardSchemaV1.InferOutput<TSchema>;
+														data: Static<T>;
 														driverParam: string;
 														enumValues: undefined;
 													}>

--- a/packages/epicenter/src/core/schema/converters/to-typebox.ts
+++ b/packages/epicenter/src/core/schema/converters/to-typebox.ts
@@ -32,7 +32,6 @@ import type {
 } from '../fields/types';
 import { isNullableFieldSchema } from '../fields/helpers';
 import { DATE_TIME_STRING_REGEX } from '../fields/regex';
-import { ARKTYPE_JSON_SCHEMA_FALLBACK } from '../standard/arktype-fallback';
 
 /**
  * Maps a FieldSchema to its corresponding TypeBox TSchema type.
@@ -208,14 +207,8 @@ export function fieldSchemaToTypebox<C extends FieldSchema>(
 		}
 
 		case 'json': {
-			const standardSchema = fieldSchema.schema;
-			const jsonSchema = standardSchema['~standard'].jsonSchema.input({
-				target: 'draft-2020-12',
-				libraryOptions: {
-					fallback: ARKTYPE_JSON_SCHEMA_FALLBACK,
-				},
-			});
-			baseType = jsonSchema as TSchema;
+			// TypeBox schemas ARE JSON Schema - use directly
+			baseType = fieldSchema.schema;
 			break;
 		}
 	}

--- a/packages/epicenter/src/core/schema/fields/factories.ts
+++ b/packages/epicenter/src/core/schema/fields/factories.ts
@@ -6,11 +6,8 @@
  */
 
 import type { Temporal } from 'temporal-polyfill';
+import type { TSchema, Static } from 'typebox';
 import { DateTimeString } from './datetime';
-import type {
-	StandardSchemaV1,
-	StandardSchemaWithJSONSchema,
-} from '../standard/types';
 import type {
 	BooleanFieldSchema,
 	DateFieldSchema,
@@ -297,21 +294,21 @@ export function tags<const TOptions extends readonly [string, ...string[]]>({
 	};
 }
 
-export function json<const TSchema extends StandardSchemaWithJSONSchema>(
+export function json<const T extends TSchema>(
 	opts: FieldOptions & {
-		schema: TSchema;
+		schema: T;
 		nullable: true;
-		default?: StandardSchemaV1.InferOutput<TSchema>;
+		default?: Static<T>;
 	},
-): JsonFieldSchema<TSchema, true>;
-export function json<const TSchema extends StandardSchemaWithJSONSchema>(
+): JsonFieldSchema<T, true>;
+export function json<const T extends TSchema>(
 	opts: FieldOptions & {
-		schema: TSchema;
+		schema: T;
 		nullable?: false;
-		default?: StandardSchemaV1.InferOutput<TSchema>;
+		default?: Static<T>;
 	},
-): JsonFieldSchema<TSchema, false>;
-export function json<const TSchema extends StandardSchemaWithJSONSchema>({
+): JsonFieldSchema<T, false>;
+export function json<const T extends TSchema>({
 	schema,
 	nullable = false,
 	default: defaultValue,
@@ -319,10 +316,10 @@ export function json<const TSchema extends StandardSchemaWithJSONSchema>({
 	description = '',
 	icon = null,
 }: FieldOptions & {
-	schema: TSchema;
+	schema: T;
 	nullable?: boolean;
-	default?: StandardSchemaV1.InferOutput<TSchema>;
-}): JsonFieldSchema<TSchema, boolean> {
+	default?: Static<T>;
+}): JsonFieldSchema<T, boolean> {
 	return {
 		type: 'json',
 		name,

--- a/packages/epicenter/src/core/workspace/contract.ts
+++ b/packages/epicenter/src/core/workspace/contract.ts
@@ -227,14 +227,14 @@ async function initializeWorkspace<
 		epoch: 0,
 	});
 
-	// Seed workspace name
+	// Set workspace name (only if not already set)
 	if (!dataDoc.getName()) {
 		dataDoc.setName(config.name);
 	}
 
-	// Seed schema from code definition (no-op if already seeded)
+	// Merge code schema into Y.Doc schema (idempotent, CRDT handles conflicts)
 	const normalizedTables = normalizeTablesForSeeding(config.tables);
-	dataDoc.seedSchema(normalizedTables, config.kv);
+	dataDoc.mergeSchema(normalizedTables, config.kv);
 
 	// Create table and kv helpers using the Data Y.Doc
 	const tables = createTables(dataDoc.ydoc, config.tables);

--- a/packages/epicenter/src/index.ts
+++ b/packages/epicenter/src/index.ts
@@ -133,6 +133,16 @@ export type {
 	WorkspaceSchema,
 } from './core/workspace/contract';
 export { defineWorkspace } from './core/workspace/contract';
+
+// Y.Doc wrappers for collaborative workspace architecture
+export type {
+	RegistryDoc,
+	HeadDoc,
+	DataDoc,
+	SerializedFieldSchema,
+	SchemaChangeEvent,
+} from './core/docs';
+export { createRegistryDoc, createHeadDoc, createDataDoc } from './core/docs';
 // Action system
 export type { Action, Actions, Mutation, Query } from './core/actions';
 export {

--- a/packages/epicenter/src/index.ts
+++ b/packages/epicenter/src/index.ts
@@ -139,7 +139,6 @@ export type {
 	RegistryDoc,
 	HeadDoc,
 	DataDoc,
-	StoredFieldSchema,
 	SchemaChangeEvent,
 } from './core/docs';
 export { createRegistryDoc, createHeadDoc, createDataDoc } from './core/docs';

--- a/packages/epicenter/src/index.ts
+++ b/packages/epicenter/src/index.ts
@@ -139,7 +139,7 @@ export type {
 	RegistryDoc,
 	HeadDoc,
 	DataDoc,
-	SerializedFieldSchema,
+	StoredFieldSchema,
 	SchemaChangeEvent,
 } from './core/docs';
 export { createRegistryDoc, createHeadDoc, createDataDoc } from './core/docs';

--- a/specs/20250107T123500-minimal-field-schema-refactor.md
+++ b/specs/20250107T123500-minimal-field-schema-refactor.md
@@ -3,6 +3,8 @@
 **Created**: 2025-01-07T12:35:00
 **Status**: Complete
 
+> **Note (2026-01-08)**: The `json()` field API in this spec uses `StandardSchemaWithJSONSchema` (arktype/zod). This has been superseded by TypeBox. See `20260108T133200-collaborative-workspace-config-ydoc-handoff.md` Phase 4 for the current API using `Type.Object()` from TypeBox.
+
 ## Summary
 
 Refactor field schemas from JSON Schema hybrid format to a minimal, Notion-like format. Remove redundant `type` field, rename `x-component` to `type`, and add table/workspace metadata (emoji, name, description, order).

--- a/specs/20260108T133200-collaborative-workspace-config-ydoc-handoff.md
+++ b/specs/20260108T133200-collaborative-workspace-config-ydoc-handoff.md
@@ -5,24 +5,52 @@
 
 ## Implementation Status
 
-### Phase 4: Schema Type Unification ✅ COMPLETE
+### Phase 5: Remove StoredFieldSchema ✅ COMPLETE
 
-Unified schema storage to enable collaborative schema editing:
+Simplified by eliminating the intermediate type entirely:
 
-| Before                                      | After                                         | Rationale                                                         |
-| ------------------------------------------- | --------------------------------------------- | ----------------------------------------------------------------- |
-| `SerializedFieldSchema` (stripped metadata) | `StoredFieldSchema` (full FieldSchema)        | Enables collaborative editing of field names, descriptions, icons |
-| Metadata stripped before storage            | Metadata preserved in Y.Doc                   | Users can rename fields, add descriptions, set icons              |
-| No JSON Schema conversion                   | `json` field schemas converted to JSON Schema | StandardSchema objects aren't serializable                        |
+| Before                                                              | After                 | Rationale                   |
+| ------------------------------------------------------------------- | --------------------- | --------------------------- |
+| `FieldSchema` → `prepareForStorage()` → `StoredFieldSchema` → Y.Doc | `FieldSchema` → Y.Doc | No conversion needed        |
+| `StoredFieldSchema` type definition                                 | Removed               | Redundant intermediate type |
+| `prepareForStorage()` function                                      | Removed               | Was just a type cast        |
 
-**Key insight**: The original design stripped `FieldMetadata` (name, description, icon) because "nobody uses it" — but that was circular reasoning. For Notion-like collaborative schema editing, metadata must be stored in Y.Doc.
+**Key insight**: Since TypeBox schemas ARE JSON Schema, `FieldSchema` is directly serializable. No intermediate type or conversion function is needed.
 
-**Changes made:**
+### Phase 4: TypeBox for JSON Fields ✅ COMPLETE
 
-- Renamed `SerializedFieldSchema` → `StoredFieldSchema`
-- `StoredFieldSchema` now includes all `FieldSchema` properties (type, nullable, default, options, name, description, icon)
-- For `json` fields: `StandardSchema` is converted to JSON Schema via `standardSchemaToJsonSchema()` before storage
-- Updated `deepEqual()` to compare all properties including metadata
+Replaced arktype/zod `StandardSchema` with TypeBox `TSchema`:
+
+| Before                                                          | After                                                     | Rationale               |
+| --------------------------------------------------------------- | --------------------------------------------------------- | ----------------------- |
+| `json({ schema: type({ foo: 'string' }) })`                     | `json({ schema: Type.Object({ foo: Type.String() }) })`   | TypeBox IS JSON Schema  |
+| `StandardSchema` → `standardSchemaToJsonSchema()` → JSON Schema | `TSchema` (already JSON Schema)                           | No conversion needed    |
+| Runtime validation via StandardSchema                           | Runtime validation via `Compile()` from `typebox/compile` | JIT-compiled validation |
+
+**API Change:**
+
+```typescript
+// Before (arktype)
+import { type } from 'arktype';
+json({ schema: type({ theme: 'string', darkMode: 'boolean' }) });
+
+// After (TypeBox)
+import { Type } from 'typebox';
+json({
+	schema: Type.Object({ theme: Type.String(), darkMode: Type.Boolean() }),
+});
+```
+
+### Phase 3: Unified FieldSchema Storage ✅ COMPLETE
+
+`FieldSchema` now stores full metadata for Notion-like collaborative editing:
+
+| Before                                      | After                         | Rationale                                            |
+| ------------------------------------------- | ----------------------------- | ---------------------------------------------------- |
+| `SerializedFieldSchema` (stripped metadata) | `FieldSchema` (full metadata) | Enables collaborative editing                        |
+| `name`, `description`, `icon` stripped      | Preserved in Y.Doc            | Users can rename fields, add descriptions, set icons |
+
+**Key insight**: The original design stripped metadata because "nobody uses it" — but that was circular reasoning. For Notion-like collaborative schema editing, metadata must be stored in Y.Doc.
 
 ### Phase 1: Terminology Refactor ✅ COMPLETE
 
@@ -75,6 +103,9 @@ packages/epicenter/src/index.ts                    # Exports new doc types
 ### Commits (on branch `feat/workspace-id-slug-terminology`)
 
 ```
+748371a refactor(schema): remove StoredFieldSchema, use FieldSchema directly
+62db83c refactor(schema): use TypeBox for json field schemas
+1e4228e refactor(schema): unify FieldSchema storage in Y.Doc for collaborative editing
 2f7df8c feat(epicenter): integrate DataDoc with schema seeding into workspace
 d36d4cd feat(epicenter): add collaborative Y.Doc wrappers for 3-document architecture
 e756241 docs(spec): add collaborative workspace config spec and handoff
@@ -228,9 +259,9 @@ data.setName('My Workspace');
 // Schema (merge semantics - idempotent, call on every create)
 data.hasSchema();                      // boolean
 data.mergeSchema(tables, kv);          // Merge code schema into Y.Doc (preserves metadata)
-data.getTableSchema('posts');          // Map<fieldName, StoredFieldSchema>
+data.getTableSchema('posts');          // Map<fieldName, FieldSchema>
 data.getTableNames();                  // string[]
-data.getKvSchema('theme');             // StoredFieldSchema
+data.getKvSchema('theme');             // FieldSchema
 data.getKvNames();                     // string[]
 data.addTableField('posts', 'newField', text());
 data.removeTableField('posts', 'oldField');

--- a/specs/20260108T133200-collaborative-workspace-config-ydoc-handoff.md
+++ b/specs/20260108T133200-collaborative-workspace-config-ydoc-handoff.md
@@ -209,14 +209,12 @@ const head = createHeadDoc({ workspaceId: 'abc123xyz789012' });
 
 head.getEpoch();           // number (currently 0)
 head.getDataDocId();       // 'abc123xyz789012-0'
-head.isMigrating();        // boolean
-head.startEpochBump();     // returns new epoch number
-head.completeEpochBump(1); // sets epoch to 1, clears isMigrating
-head.cancelEpochBump();    // clears isMigrating without changing epoch
+head.bumpEpoch();          // atomically sets epoch = max(current, current+1), returns new epoch
 head.observeEpoch((epoch) => { ... });
-head.observeMigrating((isMigrating) => { ... });
 head.destroy();
 ```
+
+**Note**: The Head Doc is minimal—just stores `epoch: number`. No `isMigrating` flag needed; epoch bump is an atomic pointer flip. Old epochs remain accessible for historical viewing.
 
 ### createDataDoc
 

--- a/specs/20260108T133200-collaborative-workspace-config-ydoc-handoff.md
+++ b/specs/20260108T133200-collaborative-workspace-config-ydoc-handoff.md
@@ -1,0 +1,242 @@
+# Handoff: Collaborative Workspace Config Y.Doc
+
+**Date**: 2026-01-08
+**Parent Spec**: `20260108T133200-collaborative-workspace-config-ydoc.md`
+
+## What Was Implemented
+
+### Terminology Refactor (Complete)
+
+The workspace identifier terminology has been standardized:
+
+```typescript
+// OLD API
+const workspace = defineWorkspace({
+  guid: generateGuid(),  // 15-char globally unique
+  id: 'blog',            // human-readable slug
+  name: 'Blog',
+  tables: { ... },
+  kv: {},
+});
+
+// NEW API
+const workspace = defineWorkspace({
+  id: generateWorkspaceId(),  // 15-char globally unique
+  slug: 'blog',               // human-readable slug
+  name: 'Blog',
+  tables: { ... },
+  kv: {},
+});
+```
+
+**Deprecation aliases provided:**
+
+- `Guid` type → Use `WorkspaceId`
+- `generateGuid()` → Use `generateWorkspaceId()`
+
+**Y.Doc GUID format:**
+
+- Already uses `{id}-0` (workspace ID + hyphen + epoch)
+- Hyphen delimiter is y-sweet compatible (colons not allowed)
+
+### Files Changed
+
+```
+packages/epicenter/src/core/schema/fields/id.ts    # New types + deprecation aliases
+packages/epicenter/src/core/schema/index.ts        # Export new types
+packages/epicenter/src/index.ts                    # Export new types
+packages/epicenter/src/core/workspace/contract.ts  # Core type changes
+packages/epicenter/src/core/capability.ts          # JSDoc clarification
+packages/epicenter/src/cli/cli.ts                  # Generic param update
+packages/epicenter/src/cli/discovery.ts            # Generic param update
+packages/epicenter/src/server/server.ts            # Generic param update
+packages/epicenter/src/server/tables.ts            # Generic param update
+packages/epicenter/scripts/*.ts                    # Use new API
+apps/epicenter/src/**/*.ts                         # Use new API
+apps/tab-manager/src/**/*.ts                       # Use new API
+examples/basic-workspace/epicenter.config.ts       # Use new API
+```
+
+## What Remains to Implement
+
+### 1. Registry Y.Doc (Per User)
+
+**Purpose:** Personal index of workspaces the user has access to.
+
+**Implementation tasks:**
+
+- [ ] Create `RegistryDoc` class to manage user's workspace list
+- [ ] Store as `Y.Map('workspaces')` where keys are workspace IDs, values are `true`
+- [ ] Sync only across user's own devices (not with other users)
+- [ ] Integrate with auth server to get `registryId`
+
+**Data structure:**
+
+```typescript
+// Y.Doc ID: {registryId}
+Y.Map('workspaces')
+  └── {workspaceId}: true
+```
+
+### 2. Head Y.Doc (Per Workspace)
+
+**Purpose:** Pointer to current data epoch, shared among collaborators.
+
+**Implementation tasks:**
+
+- [ ] Create `HeadDoc` class with epoch pointer
+- [ ] Store as `Y.Map('head')` with `epoch` key
+- [ ] Add `isMigrating` flag for epoch bump coordination
+- [ ] Sync with all workspace collaborators
+
+**Data structure:**
+
+```typescript
+// Y.Doc ID: {workspaceId}
+Y.Map('head')
+  └── epoch: number (currently always 0)
+```
+
+### 3. Separate Data Y.Doc from Head
+
+**Current state:** Single Y.Doc at `{id}-0` contains all data.
+
+**Target state:**
+
+- Head doc at `{workspaceId}` (no epoch suffix)
+- Data doc at `{workspaceId}-{epoch}`
+
+**Implementation tasks:**
+
+- [ ] On workspace create, first connect to Head doc
+- [ ] Read current epoch from head
+- [ ] Then connect to Data doc at `{workspaceId}-{epoch}`
+- [ ] Subscribe to head changes for epoch bumps
+
+### 4. Schema Storage in Y.Doc
+
+**Purpose:** Enable collaborative schema editing.
+
+**Implementation tasks:**
+
+- [ ] Add `Y.Map('schema')` to Data Y.Doc structure
+- [ ] Nested structure: `schema.tables.{tableName}.{fieldName}` → JSON field definition
+- [ ] On `workspace.create()`:
+  - If Y.Doc schema empty → seed from code schema
+  - If Y.Doc schema exists → use it for runtime validation
+- [ ] TypeScript types always from code schema (compile-time)
+- [ ] Runtime validation uses Y.Doc schema
+
+**Data structure:**
+
+```typescript
+// Y.Doc ID: {workspaceId}-{epoch}
+Y.Map('schema')
+  ├── tables: Y.Map
+  │   └── {tableName}: Y.Map
+  │       └── {fieldName}: { type: 'text', nullable: false, ... }
+  └── kv: Y.Map
+      └── {keyName}: { type: 'text', ... }
+```
+
+### 5. Epoch Bump Flow
+
+**Purpose:** Atomic schema migrations and compaction.
+
+**Implementation tasks:**
+
+- [ ] Implement `bumpEpoch()` function:
+  1. Set `head.isMigrating = true`
+  2. Create new Data Y.Doc at `{workspaceId}-{epoch+1}`
+  3. Migrate data from old epoch
+  4. Update `head.epoch = epoch + 1`
+  5. Clear `head.isMigrating`
+- [ ] All clients observe head changes and reconnect on epoch bump
+- [ ] Consider epoch coordination (single writer vs distributed)
+
+### 6. Auth Server Integration
+
+**Purpose:** Permission management for workspace access.
+
+**Implementation tasks:**
+
+- [ ] Add `permissions` table to auth server
+- [ ] Add `shareLinks` table for invitation tokens
+- [ ] Sync server checks permissions before allowing room join
+- [ ] Store `bootstrapSyncNodes` in user record
+
+## Migration Considerations
+
+### Existing Data
+
+Workspaces created with old API have:
+
+- `guid` field in stored JSON
+- `id` field (slug) in stored JSON
+
+When loading old workspace files:
+
+```typescript
+// Migration layer
+const workspace = defineWorkspace({
+  id: oldData.guid ?? generateWorkspaceId(),  // guid → id
+  slug: oldData.id,                            // id → slug
+  ...
+});
+```
+
+### Y.Doc Persistence
+
+Existing `.yjs` files are named using `{guid}-0` format. This is compatible with new `{id}-0` format since the value hasn't changed, just the property name.
+
+## Testing Checklist
+
+- [ ] Create workspace with new API
+- [ ] Load workspace with deprecation aliases (backward compat)
+- [ ] Verify Y.Doc GUID is `{id}-0` format
+- [ ] Verify capabilities receive `slug` as their `id` context
+- [ ] Multi-device sync still works (same room names)
+- [ ] IndexedDB persistence still works (same DB names)
+
+## Architecture Diagram
+
+```
+                                    AUTH SERVER
+                                        │
+                            ┌───────────┴───────────┐
+                            │  registryId           │
+                            │  bootstrapSyncNodes   │
+                            │  permissions          │
+                            └───────────┬───────────┘
+                                        │
+                    ┌───────────────────┼───────────────────┐
+                    │                   │                   │
+              DEVICE A              DEVICE B            DEVICE C
+                    │                   │                   │
+        ┌───────────┴───────────┐       │                   │
+        │                       │       │                   │
+   REGISTRY Y.Doc          REGISTRY Y.Doc              REGISTRY Y.Doc
+   {registryId}            {registryId}                {registryId}
+   (personal, syncs        (syncs across               (syncs across
+    across A's devices)     B's devices)               C's devices)
+        │                       │                           │
+        └───────────────────────┼───────────────────────────┘
+                                │
+                    ┌───────────┴───────────┐
+                    │   HEAD Y.Doc          │
+                    │   {workspaceId}       │  ← Shared among
+                    │   epoch: 0            │     all collaborators
+                    └───────────┬───────────┘
+                                │
+                    ┌───────────┴───────────┐
+                    │   DATA Y.Doc          │
+                    │   {workspaceId}-0     │  ← Shared among
+                    │   schema + data       │     all collaborators
+                    └───────────────────────┘
+```
+
+## References
+
+- Parent spec: `20260108T133200-collaborative-workspace-config-ydoc.md`
+- Local-first discovery: `20260108T062000-local-first-workspace-discovery.md`
+- Workspace GUID epochs: `20260107T005800-workspace-guid-and-epochs.md`

--- a/specs/20260108T133200-collaborative-workspace-config-ydoc.md
+++ b/specs/20260108T133200-collaborative-workspace-config-ydoc.md
@@ -1,0 +1,593 @@
+# Collaborative Workspace Configuration via YJS
+
+**Date**: 2026-01-08
+**Status**: DRAFT
+**Depends on**: `20260108T062000-local-first-workspace-discovery.md`
+
+## Overview
+
+This specification describes how to store workspace configurations (schema, metadata) in YJS documents instead of local JSON files, enabling real-time collaborative schema editing across users and devices.
+
+## Problem Statement
+
+The current architecture stores workspace configs as JSON files:
+
+- `workspaces/blog.json` → `{ id, slug, name, tables, kv, sync }`
+
+This creates issues:
+
+1. **Multi-device drift**: Edit schema on Device A, Device B doesn't see it
+2. **No collaboration**: Can't share schema editing with other users
+3. **Manual sync**: Must export/import JSON to share configs
+
+## Solution: 3-Document Architecture
+
+Store workspace configuration in YJS documents that sync via CRDT.
+
+```
+╔═══════════════════════════════════════════════════════════════════════════════╗
+║  DOC TYPE 1: Registry Y.Doc (per user)                                        ║
+║  ID: {registryId} (from auth server)                                          ║
+╠═══════════════════════════════════════════════════════════════════════════════╣
+║                                                                               ║
+║  Y.Map('workspaces')                                                          ║
+║      └── {workspaceId} → true      ◄── Just a SET of workspace IDs            ║
+║                                                                               ║
+║  Purpose: Personal index of "which workspaces do I have access to?"           ║
+║  Syncs: Only across user's own devices (not with other users)                 ║
+║                                                                               ║
+╚═══════════════════════════════════════════════════════════════════════════════╝
+
+╔═══════════════════════════════════════════════════════════════════════════════╗
+║  DOC TYPE 2: Head Y.Doc (per workspace, shared)                               ║
+║  ID: {workspaceId}                                                            ║
+╠═══════════════════════════════════════════════════════════════════════════════╣
+║                                                                               ║
+║  Y.Map('head')                                                                ║
+║      └── epoch: 0                  ◄── Current data doc epoch                 ║
+║                                                                               ║
+║  Purpose: Pointer to current data epoch (enables atomic epoch switching)      ║
+║  Syncs: With all collaborators on this workspace                              ║
+║                                                                               ║
+╚═══════════════════════════════════════════════════════════════════════════════╝
+
+╔═══════════════════════════════════════════════════════════════════════════════╗
+║  DOC TYPE 3: Data Y.Doc (per workspace per epoch, shared)                     ║
+║  ID: {workspaceId}-{epoch}                                                    ║
+╠═══════════════════════════════════════════════════════════════════════════════╣
+║                                                                               ║
+║  Y.Map('meta')                                                                ║
+║      └── name: "My Blog"                                                      ║
+║                                                                               ║
+║  Y.Map('schema')                                                              ║
+║      ├── tables: Y.Map<tableName, Y.Map<fieldName, FieldSchema>>              ║
+║      └── kv: Y.Map<keyName, KvSchema>                                         ║
+║                                                                               ║
+║  Y.Map('tables')                                                              ║
+║      └── {tableName}: Y.Map<rowId, Y.Map<fieldName, value>>                   ║
+║                                                                               ║
+║  Y.Map('kv')                                                                  ║
+║      └── {keyName}: value                                                     ║
+║                                                                               ║
+║  Purpose: All shared workspace state (schema + data)                          ║
+║  Syncs: With all collaborators on this workspace                              ║
+║                                                                               ║
+╚═══════════════════════════════════════════════════════════════════════════════╝
+```
+
+## Schema Storage Granularity
+
+### Decision: Nested Y.Maps for Schema
+
+Store schema as nested Y.Maps down to the **field level**, but field definitions themselves are plain JSON objects (not Y.Maps).
+
+```typescript
+// Structure
+schema/tables/{tableName}/{fieldName} → { type: 'text', nullable: false, ... }
+
+// Example
+schema.tables.get('posts')  // → Y.Map
+  .get('title')             // → { type: 'text', nullable: false }
+  .get('category')          // → { type: 'select', options: ['tech', 'personal'] }
+```
+
+### Why This Granularity?
+
+**Scenario: Alice and Bob both add columns**
+
+```
+Alice: schema.tables.posts.set('category', { type: 'select', options: [...] })
+Bob:   schema.tables.posts.set('author', { type: 'text' })
+
+CRDT merge: Both columns exist! ✅
+```
+
+**If we used JSON blob for entire table schema:**
+
+```
+Alice: schema.tables.set('posts', { id: {...}, title: {...}, category: {...} })
+Bob:   schema.tables.set('posts', { id: {...}, title: {...}, author: {...} })
+
+CRDT merge: Last-writer-wins at table level. One column lost! ❌
+```
+
+### Granularity Levels
+
+| Level           | Structure                                        | When to Use              |
+| --------------- | ------------------------------------------------ | ------------------------ |
+| **Table level** | `schema.tables.{tableName}` → Y.Map              | Add/remove tables        |
+| **Field level** | `schema.tables.{tableName}.{fieldName}` → JSON   | Add/remove/update fields |
+| **Row level**   | `tables.{tableName}.{rowId}` → Y.Map             | Add/remove/update rows   |
+| **Cell level**  | `tables.{tableName}.{rowId}.{fieldName}` → value | Update cell values       |
+
+## Schema Merging Strategy
+
+### Default Behavior: Merge at Field Level
+
+When multiple collaborators edit schema:
+
+- **Adding fields**: Merges automatically (different keys)
+- **Same field edited**: Last-writer-wins on that field's definition
+- **Removing fields**: Removes (but consider tombstones for undo)
+
+### No Schema Compatibility Checking (MVP)
+
+For MVP, do NOT check if schema changes are "compatible". Just merge/overwrite.
+
+Rationale:
+
+- Schema validation happens at data write time (existing behavior)
+- Incompatible schema changes are rare
+- Checking compatibility adds complexity
+- Users can see schema in UI and coordinate
+
+### Future: Schema Validation Mode
+
+Could add optional validation:
+
+```typescript
+const client = await workspace.create({
+	schemaValidation: 'none' | 'warn' | 'error',
+});
+```
+
+## Auth Server Integration
+
+The auth server stores minimal metadata (not user data):
+
+```
+╔═══════════════════════════════════════════════════════════════════════════════╗
+║  AUTH SERVER (Postgres/SQLite)                                                ║
+╠═══════════════════════════════════════════════════════════════════════════════╣
+║                                                                               ║
+║  users:                                                                       ║
+║      userId → {                                                               ║
+║          registryId: "xyz789012345abc",                                       ║
+║          bootstrapSyncNodes: ["wss://cloud.epicenter.so"],                    ║
+║      }                                                                        ║
+║                                                                               ║
+║  permissions:                                                                 ║
+║      workspaceId → [{ userId, role: 'owner' | 'editor' | 'viewer' }]          ║
+║                                                                               ║
+║  shareLinks:                                                                  ║
+║      token → { workspaceId, role, expiresAt, maxUses }                        ║
+║                                                                               ║
+╚═══════════════════════════════════════════════════════════════════════════════╝
+```
+
+### Sync Server Permission Check
+
+When connecting to a Y.Doc room:
+
+1. Validate JWT → get userId
+2. Query auth server for permissions
+3. Allow/deny connection based on role
+
+## Client Boot Flow
+
+```
+1. Authenticate → get registryId + bootstrapSyncNodes from auth server
+
+2. Connect to Registry Y.Doc ({registryId})
+   → Get set of workspaceIds
+
+3. To open a workspace:
+   a. Connect to Head Y.Doc ({workspaceId})
+   b. Read epoch from head.epoch
+   c. Connect to Data Y.Doc ({workspaceId}-{epoch})
+   d. Subscribe to head changes (for epoch bumps)
+
+4. Use typed client for tables/kv operations
+```
+
+## Epoch System
+
+### Purpose
+
+Epochs enable atomic schema migrations and compaction.
+
+### When to Bump Epoch
+
+- Breaking schema changes (type changes, removed fields)
+- Compaction (resetting Y.Doc to current state)
+- Recovery from corruption
+
+### Epoch Bump Flow
+
+```
+1. Set head.isMigrating = true (optional: pause writes)
+2. Create new Data Y.Doc: {workspaceId}-{epoch+1}
+3. Migrate data from old → new epoch
+4. Update head.epoch = epoch + 1
+5. Clear head.isMigrating
+6. All clients see epoch change → reconnect to new data doc
+7. (Optional) Delete old epoch doc
+```
+
+## Code-Defined Schema Integration
+
+### How It Works
+
+1. User defines schema in code (TypeScript types)
+2. On `workspace.create()`:
+   - If Y.Doc schema is empty: serialize code schema → write to Y.Doc
+   - If Y.Doc schema exists: use it (schema in Y.Doc is authoritative)
+3. TypeScript types come from code schema (compile-time)
+4. Runtime data uses Y.Doc schema (runtime)
+
+### Seed vs Sync
+
+```typescript
+const workspace = defineWorkspace({
+	id: 'abc123xyz789012',
+	slug: 'blog',
+	name: 'My Blog',
+	tables: {
+		posts: {
+			id: id(),
+			title: text(),
+			published: boolean({ default: false }),
+		},
+	},
+	kv: {},
+});
+
+const client = await workspace.create();
+// If Y.Doc empty: writes code schema to Y.Doc
+// If Y.Doc has schema: uses Y.Doc schema for runtime
+// TypeScript types always from code schema
+```
+
+### Handling Extra Fields
+
+If Y.Doc has fields not in code schema:
+
+- They exist at runtime
+- Not accessible via typed `client.tables.posts.extraField`
+- Accessible via dynamic API: `client.runtime.getField('posts', 'extraField')`
+
+## Implementation Notes
+
+### Terminology
+
+| Old Term | New Term | Description                  |
+| -------- | -------- | ---------------------------- |
+| `guid`   | `id`     | 15-char nanoid, used as keys |
+| `id`     | `slug`   | Human-readable name          |
+
+### Y.Doc GUID Patterns
+
+| Doc Type | GUID Pattern            | Example             |
+| -------- | ----------------------- | ------------------- |
+| Registry | `{registryId}`          | `xyz789012345abc`   |
+| Head     | `{workspaceId}`         | `abc123xyz789012`   |
+| Data     | `{workspaceId}-{epoch}` | `abc123xyz789012-0` |
+
+**Note**: Hyphen (`-`) is used as the epoch delimiter because y-sweet only allows alphanumeric characters, hyphens, and underscores in document IDs. Colons are NOT allowed.
+
+### What We Removed
+
+| Field                    | Why Removed                                                |
+| ------------------------ | ---------------------------------------------------------- |
+| `schemaVersion`          | Epoch handles migrations; CRDT handles incremental changes |
+| `slug` in registry       | Use workspace's `meta.name`                                |
+| `syncNodes` in registry  | Get from auth server                                       |
+| `lastOpenedAt`, `pinned` | Add later as needed                                        |
+| `deletedAt` tombstone    | Just delete + revoke access on auth server                 |
+| `createdAt`              | Add later as needed                                        |
+
+## Migration from File-Based System
+
+### One-Time Migration
+
+1. Scan existing `workspaces/*.json` files
+2. For each workspace:
+   - Create Head Y.Doc with epoch: 0
+   - Create Data Y.Doc with schema + empty tables
+   - Add to user's Registry Y.Doc
+3. Import existing Y.Doc data files (if any)
+
+### Coexistence Period (Optional)
+
+Could support both file-based and Y.Doc-based during transition:
+
+- Read from Y.Doc if exists
+- Fall back to JSON file
+- Eventually remove file support
+
+## Critical YJS Semantics (Must Understand)
+
+### Y.Map Same-Key Conflict Resolution
+
+When two peers concurrently `set()` the same key, Yjs picks the winner by **operation ID ordering** (`{clientID, clock}`), NOT by timestamp or "who saved last".
+
+```
+Alice: postsMap.set('title', { type: 'text', nullable: true })
+Bob:   postsMap.set('title', { type: 'text', nullable: false })
+
+Result: ONE wins deterministically (by clientID/clock), other is lost entirely
+```
+
+**Implication**: Field-level schema conflicts are all-or-nothing for that field's JSON definition.
+
+### Delete Parent vs Update Child
+
+If Alice deletes `schema.tables.posts` while Bob adds `schema.tables.posts.newColumn`:
+
+- Delete parent removes entire nested Y.Map
+- Child updates can become orphaned
+- **Solution**: Use tombstones instead of hard deletes
+
+### Epoch Monotonicity Warning
+
+⚠️ **Y.Map `set()` for epoch can go backwards!**
+
+If two clients race:
+
+- Client A writes `epoch = 3`
+- Client B writes `epoch = 2`
+- Winner is determined by `{clientID, clock}`, NOT by numeric value
+- Final epoch could be `2` even though `3` was written later
+
+**Solution**: Store epoch as monotonic-max register:
+
+```typescript
+// Option A: Track per-client epochs, compute max
+head.epochs: Y.Map<clientId, number>
+currentEpoch = Math.max(...head.epochs.values())
+
+// Option B: Epoch bump requires coordination (single writer)
+```
+
+## Edge Cases and Failure Modes
+
+### 1. Concurrent Same-Field Edits
+
+- **Scenario**: Alice and Bob both edit `posts.title` field definition
+- **Result**: One JSON definition wins entirely (LWW by clientID/clock)
+- **Handling**: Acceptable for MVP; document behavior
+
+### 2. Delete Table vs Add Column Race
+
+- **Scenario**: Alice deletes `posts` table, Bob adds column to `posts`
+- **Result**: With hard delete, Bob's column is orphaned/lost
+- **Handling**: Use tombstones for table/field deletion
+
+```typescript
+// Instead of: schema.tables.delete('posts')
+// Use: schema.deletedTables.set('posts', { deletedAt, deletedBy })
+```
+
+### 3. Schema Edit During Epoch Bump
+
+- **Scenario**: User editing schema when epoch changes
+- **Result**: Edits go to old epoch doc, not migrated
+- **Handling**: Add `head.isMigrating` flag; block schema writes during migration
+
+### 4. Race Condition on Schema Seeding
+
+- **Scenario**: Two clients both see empty schema, both seed
+- **Result**: If seeding includes non-deterministic data, conflicts occur
+- **Handling**: Make seeding deterministic; add `meta.schemaSeeded = true` marker
+
+### 5. Corrupted Schema Recovery
+
+- **Scenario**: Schema values are malformed JSON
+- **Handling**:
+  - Validate schema on load
+  - Quarantine invalid entries
+  - Option to reset from code schema via epoch bump
+
+## Multi-Document Architecture Patterns
+
+### Provider Management
+
+**Critical: One provider per Y.Doc. Never share providers.**
+
+```typescript
+// CORRECT: Separate providers
+const registryProvider = new WebsocketProvider(
+	url,
+	`${registryId}`,
+	registryDoc,
+);
+const headProvider = new WebsocketProvider(url, `${workspaceId}`, headDoc);
+const dataProvider = new WebsocketProvider(
+	url,
+	`${workspaceId}-${epoch}`,
+	dataDoc,
+);
+
+// WRONG: Reusing providers across docs
+```
+
+### Connection Lifecycle
+
+**Always disconnect before destroy. Order matters.**
+
+```typescript
+async function cleanup() {
+	// 1. Disconnect providers FIRST
+	for (const provider of providers) {
+		provider.shouldConnect = false;
+		provider.disconnect();
+		provider.destroy();
+	}
+
+	// 2. THEN destroy Y.Docs
+	for (const doc of docs) {
+		doc.destroy();
+	}
+}
+```
+
+### Awareness Scope
+
+**Awareness is per-document, NOT cross-document.**
+
+Each Y.Doc has its own awareness instance. If you need presence across multiple docs, implement manually.
+
+### Transactions Don't Span Docs
+
+```typescript
+// WRONG: Can't do cross-doc transactions
+doc1.transact(() => {
+	doc2.getMap().set('key', 'value'); // ERROR: different doc
+});
+
+// CORRECT: Separate transactions
+doc1.transact(() => doc1.getMap().set('key1', 'value1'));
+doc2.transact(() => doc2.getMap().set('key2', 'value2'));
+```
+
+### Persistence Per Doc
+
+```typescript
+// CORRECT: Separate persistence per doc
+new IndexeddbPersistence(`${workspaceId}-registry`, registryDoc);
+new IndexeddbPersistence(`${workspaceId}-head`, headDoc);
+new IndexeddbPersistence(`${workspaceId}-data-${epoch}`, dataDoc);
+```
+
+## Existing Codebase Patterns to Follow
+
+### Current Y.Doc Structure
+
+The codebase currently uses two root Y.Maps:
+
+- `ydoc.getMap('tables')` → `Y.Map<tableName, Y.Map<rowId, Y.Map<fieldName, value>>>`
+- `ydoc.getMap('kv')` → `Y.Map<keyName, value>`
+
+Schema is NOT currently stored in Y.Doc; it's passed as config. This spec changes that.
+
+### Capability Context Pattern
+
+Capabilities receive `{ id, capabilityId, ydoc, tables, kv }`. The new architecture will need to update this to handle multiple docs.
+
+### Error Handling Pattern
+
+Use `wellcrafted/result` with tagged errors:
+
+```typescript
+import { Ok, Err, tryAsync } from 'wellcrafted/result';
+
+const result = await tryAsync({
+	try: () => loadSchema(),
+	catch: (e) => SchemaLoadErr({ message: 'Failed to load schema', cause: e }),
+});
+```
+
+### Sync Coordination Pattern
+
+Prevent infinite loops with coordination counters:
+
+```typescript
+const syncCoordination = {
+	yDocChangeCount: 0, // Use counters, not booleans (for async)
+	refetchCount: 0,
+};
+
+// Skip if other direction is updating
+if (syncCoordination.yDocChangeCount > 0) return;
+```
+
+## Open Questions for Implementation
+
+1. **Schema sync on startup**: Should we always sync Y.Doc schema with code schema, or only on first run?
+
+2. **Schema conflict UI**: How should the app surface schema conflicts to users?
+
+3. **Offline schema changes**: If offline edits to schema conflict with online changes, how to resolve?
+
+4. **Schema rollback**: If a schema change breaks things, how to roll back?
+
+5. **Epoch coordination**: Who can bump epochs? Single leader? Any client?
+
+## Todo
+
+- [ ] Implement Registry Y.Doc persistence
+- [ ] Implement Head Y.Doc with epoch pointer
+- [ ] Move schema storage to Data Y.Doc
+- [ ] Update `defineWorkspace()` to seed schema on first run
+- [ ] Add auth server permission tables
+- [ ] Add sync server permission checking
+- [ ] Test multi-user schema editing
+- [ ] Test epoch bump flow
+- [ ] Document migration path for existing users
+
+## Implementation Review (2026-01-08)
+
+### Completed: Terminology Refactor
+
+The terminology changes from this spec have been implemented:
+
+| Old Term | New Term | Notes                                                |
+| -------- | -------- | ---------------------------------------------------- |
+| `guid`   | `id`     | 15-char nanoid, globally unique workspace identifier |
+| `id`     | `slug`   | Human-readable name for URLs, paths, CLI             |
+
+**Changes made:**
+
+1. **Type definitions** (`packages/epicenter/src/core/schema/fields/id.ts`):
+   - Added `WorkspaceId` type (branded string)
+   - Added `generateWorkspaceId()` function
+   - Kept `Guid` and `generateGuid()` as deprecated aliases for backward compatibility
+
+2. **Workspace types** (`packages/epicenter/src/core/workspace/contract.ts`):
+   - `WorkspaceSchema.guid` → `WorkspaceSchema.id`
+   - `WorkspaceSchema.id` → `WorkspaceSchema.slug`
+   - `WorkspaceClient.guid` → `WorkspaceClient.id`
+   - `WorkspaceClient.id` → `WorkspaceClient.slug`
+   - Removed `TId` generic parameter (analysis showed no consumers used literal type inference)
+
+3. **Y.Doc GUID construction** (already correct):
+   - Uses `{id}-0` format where `-0` is epoch 0
+   - Hyphen delimiter compatible with y-sweet
+
+4. **Capability context**:
+   - `CapabilityContext.id` remains as `slug` (for storage path namespacing)
+   - Updated JSDoc to clarify this is the slug
+
+5. **Consumer updates**:
+   - `apps/epicenter` - Updated to use new terminology
+   - `apps/tab-manager` - Updated (has pre-existing API issues unrelated)
+   - `examples/basic-workspace` - Updated
+   - `packages/epicenter/scripts/*` - Updated
+
+### Not Yet Implemented
+
+The following spec components are deferred to follow-up work:
+
+- **Registry Y.Doc**: Personal workspace index per user
+- **Head Y.Doc**: Epoch pointer separation from data doc
+- **Schema storage in Y.Doc**: Currently schema is code-defined only
+- **Schema seeding**: Auto-populate Y.Doc schema from code on first run
+- **Auth server integration**: Permission tables and checks
+
+See `specs/20260108T133200-collaborative-workspace-config-ydoc-handoff.md` for detailed handoff.
+
+## References
+
+- `20260108T062000-local-first-workspace-discovery.md` - Original file-based discovery spec
+- `/packages/epicenter/src/core/workspace/contract.ts` - Current implementation
+- `/packages/epicenter/src/core/schema/fields/factories.ts` - Schema factory functions


### PR DESCRIPTION
Epicenter workspaces need to support real-time collaboration, but storing everything in a single Y.Doc creates problems: schema changes during collaboration can corrupt data, and there is no clean separation between "what tables exist" vs "what data is in them."

This PR introduces a 3-document architecture that separates concerns:

```
┌─────────────┐     ┌─────────────┐     ┌─────────────┐
│  ConfigDoc  │     │  SchemaDoc  │     │   DataDoc   │
├─────────────┤     ├─────────────┤     ├─────────────┤
│ name        │     │ tables      │     │ rows        │
│ settings    │     │ fields      │     │ values      │
│ metadata    │     │ types       │     │ references  │
└─────────────┘     └─────────────┘     └─────────────┘
     ↓                    ↓                    ↓
  Rarely changes    Changes on schema     Changes constantly
                    migrations only       during normal use
```

ConfigDoc holds workspace metadata. SchemaDoc holds table/field definitions as TypeBox JSON schemas (chosen over ArkType because TypeBox serializes cleanly to JSON for Y.Doc storage). DataDoc holds actual row data.

This separation means schema migrations do not risk corrupting live data, and different sync strategies can be applied to each document based on its change frequency.

---

**PR 2 of 7** — Depends on PR #1227 (workspace terminology). After PR1 merges, rebase this onto `feat/epicenter-app`.