### PR TITLE
Fix: Debounce system prompt saves to prevent toast spam

### DIFF
--- a/packages/svelte-utils/src/debounce.svelte.ts
+++ b/packages/svelte-utils/src/debounce.svelte.ts
@@ -1,0 +1,50 @@
+/**
+ * Creates a debounced version of a function that delays invoking `fn` until after `delay` milliseconds
+ * have elapsed since the last time the debounced function was invoked.
+ *
+ * @param fn - The function to debounce
+ * @param delay - The number of milliseconds to delay
+ * @returns A debounced version of the function with a `cancel` method to cancel pending invocations
+ *
+ * @example
+ * ```ts
+ * const debouncedSave = debounce((value: string) => {
+ *   settings.updateKey('prompt', value);
+ * }, 500);
+ *
+ * // In component
+ * $effect(() => {
+ *   debouncedSave(localValue);
+ * });
+ *
+ * // Cleanup
+ * onDestroy(() => {
+ *   debouncedSave.cancel();
+ * });
+ * ```
+ */
+export function debounce<TArgs extends unknown[]>(
+	fn: (...args: TArgs) => void,
+	delay: number,
+) {
+	let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+	const debounced = (...args: TArgs) => {
+		if (timeoutId !== null) {
+			clearTimeout(timeoutId);
+		}
+		timeoutId = setTimeout(() => {
+			fn(...args);
+			timeoutId = null;
+		}, delay);
+	};
+
+	debounced.cancel = () => {
+		if (timeoutId !== null) {
+			clearTimeout(timeoutId);
+			timeoutId = null;
+		}
+	};
+
+	return debounced;
+}

--- a/packages/svelte-utils/src/index.ts
+++ b/packages/svelte-utils/src/index.ts
@@ -1,1 +1,2 @@
 export { createPersistedState } from './createPersistedState.svelte.js';
+export { debounce } from './debounce.svelte.js';


### PR DESCRIPTION
## Summary

### Problem
Editing the System Prompt in transcription settings triggered a save on **every keystroke**, resulting in constant toast notifications and a poor user experience.

### Solution
Implemented **debouncing** for the save action:

- Added a reusable debounce utility via `@epicenter/svelte-utils`
  - Svelte 5–compatible
  - Simple API + cleanup method for proper teardown
- Applied debounce to the System Prompt field
  - Local state manages textarea value
  - Save is delayed **500ms after the last keystroke**
  - Cleanup is handled on component destroy

### Result
Users can type freely without toast spam. A single toast is shown only after typing stops for ~500ms.

---

## Type of Change

- [x] `fix`: Bug fix

---

## Related Issue

Closes #1214 

---

## Testing Instructions

1. Navigate to **Settings → Transcription**
2. Edit the **System Prompt** field
3. Confirm that:
   - Only one toast appears after you stop typing
   - No toasts are shown on every keystroke

---

## Screenshots / Recordings

https://github.com/user-attachments/assets/78178bde-6831-4d88-a3dd-5572947d96c9
