### PR TITLE
fix(whispering): save text inputs on blur instead of every keystroke

### DIFF
--- a/apps/whispering/src/lib/components/settings/api-key-inputs/AnthropicApiKeyInput.svelte
+++ b/apps/whispering/src/lib/components/settings/api-key-inputs/AnthropicApiKeyInput.svelte
@@ -3,6 +3,9 @@
 	import { Input } from '@epicenter/ui/input';
 	import { Link } from '@epicenter/ui/link';
 	import { settings } from '$lib/stores/settings.svelte';
+
+	// Local state for text inputs to avoid saving on every keystroke
+	let apiKey = $state(settings.value['apiKeys.anthropic']);
 </script>
 
 <Field.Field>
@@ -12,10 +15,8 @@
 		type="password"
 		placeholder="Your Anthropic API Key"
 		autocomplete="off"
-		bind:value={
-			() => settings.value['apiKeys.anthropic'],
-			(value) => settings.updateKey('apiKeys.anthropic', value)
-		}
+		bind:value={apiKey}
+		onchange={() => settings.updateKey('apiKeys.anthropic', apiKey)}
 	/>
 	<Field.Description>
 		You can find your Anthropic API key in your <Link

--- a/apps/whispering/src/lib/components/settings/api-key-inputs/CustomEndpointInput.svelte
+++ b/apps/whispering/src/lib/components/settings/api-key-inputs/CustomEndpointInput.svelte
@@ -8,6 +8,10 @@
 	};
 
 	let { showBaseUrl = true }: Props = $props();
+
+	// Local state for text inputs to avoid saving on every keystroke
+	let baseUrl = $state(settings.value['completion.custom.baseUrl']);
+	let apiKey = $state(settings.value['apiKeys.custom']);
 </script>
 
 <div class="space-y-4">
@@ -20,10 +24,9 @@
 				id="custom-endpoint-base-url"
 				placeholder="e.g. http://localhost:11434/v1"
 				autocomplete="off"
-				bind:value={
-					() => settings.value['completion.custom.baseUrl'],
-					(value) => settings.updateKey('completion.custom.baseUrl', value)
-				}
+				bind:value={baseUrl}
+				onchange={() =>
+					settings.updateKey('completion.custom.baseUrl', baseUrl)}
 			/>
 			<Field.Description>
 				Global default URL for OpenAI-compatible endpoints (Ollama, LM Studio,
@@ -39,10 +42,8 @@
 			type="password"
 			placeholder="Leave empty if not required"
 			autocomplete="off"
-			bind:value={
-				() => settings.value['apiKeys.custom'],
-				(value) => settings.updateKey('apiKeys.custom', value)
-			}
+			bind:value={apiKey}
+			onchange={() => settings.updateKey('apiKeys.custom', apiKey)}
 		/>
 		<Field.Description>
 			Most local endpoints don't require authentication. Only enter a key if

--- a/apps/whispering/src/lib/components/settings/api-key-inputs/DeepgramApiKeyInput.svelte
+++ b/apps/whispering/src/lib/components/settings/api-key-inputs/DeepgramApiKeyInput.svelte
@@ -3,6 +3,9 @@
 	import { Input } from '@epicenter/ui/input';
 	import { Link } from '@epicenter/ui/link';
 	import { settings } from '$lib/stores/settings.svelte';
+
+	// Local state for text inputs to avoid saving on every keystroke
+	let apiKey = $state(settings.value['apiKeys.deepgram']);
 </script>
 
 <Field.Field>
@@ -12,10 +15,8 @@
 		type="password"
 		placeholder="Your Deepgram API Key"
 		autocomplete="off"
-		bind:value={
-			() => settings.value['apiKeys.deepgram'],
-			(value) => settings.updateKey('apiKeys.deepgram', value)
-		}
+		bind:value={apiKey}
+		onchange={() => settings.updateKey('apiKeys.deepgram', apiKey)}
 	/>
 	<Field.Description>
 		You can find your API key in your <Link

--- a/apps/whispering/src/lib/components/settings/api-key-inputs/ElevenLabsApiKeyInput.svelte
+++ b/apps/whispering/src/lib/components/settings/api-key-inputs/ElevenLabsApiKeyInput.svelte
@@ -3,6 +3,9 @@
 	import { Input } from '@epicenter/ui/input';
 	import { Link } from '@epicenter/ui/link';
 	import { settings } from '$lib/stores/settings.svelte';
+
+	// Local state for text inputs to avoid saving on every keystroke
+	let apiKey = $state(settings.value['apiKeys.elevenlabs']);
 </script>
 
 <Field.Field>
@@ -12,10 +15,8 @@
 		type="password"
 		placeholder="Your ElevenLabs API Key"
 		autocomplete="off"
-		bind:value={
-			() => settings.value['apiKeys.elevenlabs'],
-			(value) => settings.updateKey('apiKeys.elevenlabs', value)
-		}
+		bind:value={apiKey}
+		onchange={() => settings.updateKey('apiKeys.elevenlabs', apiKey)}
 	/>
 	<Field.Description>
 		You can find your ElevenLabs API key in your <Link

--- a/apps/whispering/src/lib/components/settings/api-key-inputs/GoogleApiKeyInput.svelte
+++ b/apps/whispering/src/lib/components/settings/api-key-inputs/GoogleApiKeyInput.svelte
@@ -3,6 +3,9 @@
 	import { Input } from '@epicenter/ui/input';
 	import { Link } from '@epicenter/ui/link';
 	import { settings } from '$lib/stores/settings.svelte';
+
+	// Local state for text inputs to avoid saving on every keystroke
+	let apiKey = $state(settings.value['apiKeys.google']);
 </script>
 
 <Field.Field>
@@ -12,10 +15,8 @@
 		type="password"
 		placeholder="Your Google API Key"
 		autocomplete="off"
-		bind:value={
-			() => settings.value['apiKeys.google'],
-			(value) => settings.updateKey('apiKeys.google', value)
-		}
+		bind:value={apiKey}
+		onchange={() => settings.updateKey('apiKeys.google', apiKey)}
 	/>
 	<Field.Description>
 		You can find your Google API key in your <Link

--- a/apps/whispering/src/lib/components/settings/api-key-inputs/GroqApiKeyInput.svelte
+++ b/apps/whispering/src/lib/components/settings/api-key-inputs/GroqApiKeyInput.svelte
@@ -3,6 +3,10 @@
 	import { Input } from '@epicenter/ui/input';
 	import { Link } from '@epicenter/ui/link';
 	import { settings } from '$lib/stores/settings.svelte';
+
+	// Local state for text inputs to avoid saving on every keystroke
+	let apiKey = $state(settings.value['apiKeys.groq']);
+	let baseUrl = $state(settings.value['apiEndpoints.groq']);
 </script>
 
 <Field.Group>
@@ -13,10 +17,8 @@
 			type="password"
 			placeholder="Your Groq API Key"
 			autocomplete="off"
-			bind:value={
-				() => settings.value['apiKeys.groq'],
-				(value) => settings.updateKey('apiKeys.groq', value)
-			}
+			bind:value={apiKey}
+			onchange={() => settings.updateKey('apiKeys.groq', apiKey)}
 		/>
 		<Field.Description>
 			You can find your Groq API key in your <Link
@@ -36,10 +38,8 @@
 			type="url"
 			placeholder="https://api.groq.com/openai/v1 (default)"
 			autocomplete="off"
-			bind:value={
-				() => settings.value['apiEndpoints.groq'],
-				(value) => settings.updateKey('apiEndpoints.groq', value)
-			}
+			bind:value={baseUrl}
+			onchange={() => settings.updateKey('apiEndpoints.groq', baseUrl)}
 		/>
 		<Field.Description>
 			Override the default Groq API endpoint. Useful for reverse proxies or

--- a/apps/whispering/src/lib/components/settings/api-key-inputs/MistralApiKeyInput.svelte
+++ b/apps/whispering/src/lib/components/settings/api-key-inputs/MistralApiKeyInput.svelte
@@ -3,6 +3,9 @@
 	import { Input } from '@epicenter/ui/input';
 	import { Link } from '@epicenter/ui/link';
 	import { settings } from '$lib/stores/settings.svelte';
+
+	// Local state for text inputs to avoid saving on every keystroke
+	let apiKey = $state(settings.value['apiKeys.mistral']);
 </script>
 
 <Field.Field>
@@ -12,10 +15,8 @@
 		type="password"
 		placeholder="Your Mistral AI API Key"
 		autocomplete="off"
-		bind:value={
-			() => settings.value['apiKeys.mistral'],
-			(value) => settings.updateKey('apiKeys.mistral', value)
-		}
+		bind:value={apiKey}
+		onchange={() => settings.updateKey('apiKeys.mistral', apiKey)}
 	/>
 	<Field.Description>
 		You can find your API key in your <Link

--- a/apps/whispering/src/lib/components/settings/api-key-inputs/OpenAiApiKeyInput.svelte
+++ b/apps/whispering/src/lib/components/settings/api-key-inputs/OpenAiApiKeyInput.svelte
@@ -3,6 +3,10 @@
 	import { Input } from '@epicenter/ui/input';
 	import { Link } from '@epicenter/ui/link';
 	import { settings } from '$lib/stores/settings.svelte';
+
+	// Local state for text inputs to avoid saving on every keystroke
+	let apiKey = $state(settings.value['apiKeys.openai']);
+	let baseUrl = $state(settings.value['apiEndpoints.openai']);
 </script>
 
 <Field.Group>
@@ -13,10 +17,8 @@
 			type="password"
 			placeholder="Your OpenAI API Key"
 			autocomplete="off"
-			bind:value={
-				() => settings.value['apiKeys.openai'],
-				(value) => settings.updateKey('apiKeys.openai', value)
-			}
+			bind:value={apiKey}
+			onchange={() => settings.updateKey('apiKeys.openai', apiKey)}
 		/>
 		<Field.Description>
 			You can find your API key in your <Link
@@ -43,10 +45,8 @@
 			type="url"
 			placeholder="https://api.openai.com/v1 (default)"
 			autocomplete="off"
-			bind:value={
-				() => settings.value['apiEndpoints.openai'],
-				(value) => settings.updateKey('apiEndpoints.openai', value)
-			}
+			bind:value={baseUrl}
+			onchange={() => settings.updateKey('apiEndpoints.openai', baseUrl)}
 		/>
 		<Field.Description>
 			Override the default OpenAI API endpoint. Useful for reverse proxies or

--- a/apps/whispering/src/lib/components/settings/api-key-inputs/OpenRouterApiKeyInput.svelte
+++ b/apps/whispering/src/lib/components/settings/api-key-inputs/OpenRouterApiKeyInput.svelte
@@ -3,6 +3,9 @@
 	import { Input } from '@epicenter/ui/input';
 	import { Link } from '@epicenter/ui/link';
 	import { settings } from '$lib/stores/settings.svelte';
+
+	// Local state for text inputs to avoid saving on every keystroke
+	let apiKey = $state(settings.value['apiKeys.openrouter']);
 </script>
 
 <Field.Field>
@@ -12,10 +15,8 @@
 		type="password"
 		placeholder="Your OpenRouter API Key"
 		autocomplete="off"
-		bind:value={
-			() => settings.value['apiKeys.openrouter'],
-			(value) => settings.updateKey('apiKeys.openrouter', value)
-		}
+		bind:value={apiKey}
+		onchange={() => settings.updateKey('apiKeys.openrouter', apiKey)}
 	/>
 	<Field.Description>
 		You can find your OpenRouter API key in your <Link

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/+page.svelte
@@ -25,6 +25,17 @@
 
 	const { data } = $props();
 
+	// Local state for FFmpeg options to avoid saving on every keystroke
+	let ffmpegGlobalOptions = $state(
+		settings.value['recording.ffmpeg.globalOptions'],
+	);
+	let ffmpegInputOptions = $state(
+		settings.value['recording.ffmpeg.inputOptions'],
+	);
+	let ffmpegOutputOptions = $state(
+		settings.value['recording.ffmpeg.outputOptions'],
+	);
+
 	// Derived labels for select triggers
 	const recordingModeLabel = $derived(
 		RECORDING_MODE_OPTIONS.find(
@@ -358,18 +369,16 @@
 				</div>
 
 				<FfmpegCommandBuilder
-					bind:globalOptions={
-						() => settings.value['recording.ffmpeg.globalOptions'],
-						(v) => settings.updateKey('recording.ffmpeg.globalOptions', v)
-					}
-					bind:inputOptions={
-						() => settings.value['recording.ffmpeg.inputOptions'],
-						(v) => settings.updateKey('recording.ffmpeg.inputOptions', v)
-					}
-					bind:outputOptions={
-						() => settings.value['recording.ffmpeg.outputOptions'],
-						(v) => settings.updateKey('recording.ffmpeg.outputOptions', v)
-					}
+					bind:globalOptions={ffmpegGlobalOptions}
+					bind:inputOptions={ffmpegInputOptions}
+					bind:outputOptions={ffmpegOutputOptions}
+					commitChanges={() => {
+						settings.update({
+							'recording.ffmpeg.globalOptions': ffmpegGlobalOptions,
+							'recording.ffmpeg.inputOptions': ffmpegInputOptions,
+							'recording.ffmpeg.outputOptions': ffmpegOutputOptions,
+						});
+					}}
 				/>
 			{:else}
 				<!-- CPAL method settings -->

--- a/apps/whispering/src/routes/(app)/(config)/settings/recording/FfmpegCommandBuilder.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/recording/FfmpegCommandBuilder.svelte
@@ -30,10 +30,12 @@
 		globalOptions = $bindable(),
 		inputOptions = $bindable(),
 		outputOptions = $bindable(),
+		commitChanges,
 	}: {
 		globalOptions: string;
 		inputOptions: string;
 		outputOptions: string;
+		commitChanges?: () => void;
 	} = $props();
 
 	const getDevicesQuery = createQuery(
@@ -226,6 +228,7 @@
 		] as const;
 
 		outputOptions = options.join(' ');
+		commitChanges?.();
 	}
 </script>
 
@@ -240,6 +243,7 @@
 					globalOptions = FFMPEG_DEFAULT_GLOBAL_OPTIONS;
 					inputOptions = FFMPEG_DEFAULT_INPUT_OPTIONS;
 					outputOptions = FFMPEG_DEFAULT_OUTPUT_OPTIONS;
+					commitChanges?.();
 				}}
 				class="text-xs text-muted-foreground hover:text-foreground transition-colors"
 			>
@@ -264,6 +268,7 @@
 						class="h-6 w-6"
 						onclick={() => {
 							outputOptions = FFMPEG_DEFAULT_OUTPUT_OPTIONS;
+							commitChanges?.();
 						}}
 					>
 						<RotateCcw class="h-3 w-3" />
@@ -410,6 +415,7 @@
 						<Input
 							id="ffmpeg-global"
 							bind:value={globalOptions}
+							onchange={() => commitChanges?.()}
 							placeholder="-hide_banner -loglevel warning"
 							class="font-mono text-xs h-8 flex-1"
 						/>
@@ -419,7 +425,10 @@
 								variant="ghost"
 								size="icon"
 								class="h-8 w-8"
-								onclick={() => (globalOptions = FFMPEG_DEFAULT_GLOBAL_OPTIONS)}
+								onclick={() => {
+									globalOptions = FFMPEG_DEFAULT_GLOBAL_OPTIONS;
+									commitChanges?.();
+								}}
 							>
 								<RotateCcw class="h-3 w-3" />
 							</Button>
@@ -437,6 +446,7 @@
 						<Input
 							id="ffmpeg-input"
 							bind:value={inputOptions}
+							onchange={() => commitChanges?.()}
 							placeholder={FFMPEG_DEFAULT_INPUT_OPTIONS || 'Auto-detect'}
 							class="font-mono text-xs h-8 flex-1"
 						/>
@@ -446,7 +456,10 @@
 								variant="ghost"
 								size="icon"
 								class="h-8 w-8"
-								onclick={() => (inputOptions = FFMPEG_DEFAULT_INPUT_OPTIONS)}
+								onclick={() => {
+									inputOptions = FFMPEG_DEFAULT_INPUT_OPTIONS;
+									commitChanges?.();
+								}}
 							>
 								<RotateCcw class="h-3 w-3" />
 							</Button>
@@ -479,6 +492,7 @@
 						<Input
 							id="ffmpeg-output"
 							bind:value={outputOptions}
+							onchange={() => commitChanges?.()}
 							placeholder="Raw output options"
 							class="font-mono text-xs h-8 flex-1"
 						/>
@@ -490,6 +504,7 @@
 								class="h-8 w-8"
 								onclick={() => {
 									outputOptions = FFMPEG_DEFAULT_OUTPUT_OPTIONS;
+									commitChanges?.();
 								}}
 							>
 								<RotateCcw class="h-3 w-3" />

--- a/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
@@ -37,6 +37,16 @@
 
 	const { data } = $props();
 
+	// Local state for text inputs to avoid saving on every keystroke
+	let speachesBaseUrl = $state(
+		settings.value['transcription.speaches.baseUrl'],
+	);
+	let speachesModelId = $state(
+		settings.value['transcription.speaches.modelId'],
+	);
+	let temperature = $state(settings.value['transcription.temperature']);
+	let transcriptionPrompt = $state(settings.value['transcription.prompt']);
+
 	/**
 	 * Feature capabilities for the currently selected transcription service.
 	 * Used to conditionally disable UI fields that aren't supported by the service.
@@ -403,11 +413,12 @@
 					id="speaches-base-url"
 					placeholder="http://localhost:8000"
 					autocomplete="off"
-					bind:value={
-						() => settings.value['transcription.speaches.baseUrl'],
-						(value) =>
-							settings.updateKey('transcription.speaches.baseUrl', value)
-					}
+					bind:value={speachesBaseUrl}
+					onchange={() =>
+						settings.updateKey(
+							'transcription.speaches.baseUrl',
+							speachesBaseUrl,
+						)}
 				/>
 				<Field.Description>
 					The URL where your Speaches server is running (<code>
@@ -431,11 +442,12 @@
 					id="speaches-model-id"
 					placeholder="Systran/faster-distil-whisper-small.en"
 					autocomplete="off"
-					bind:value={
-						() => settings.value['transcription.speaches.modelId'],
-						(value) =>
-							settings.updateKey('transcription.speaches.modelId', value)
-					}
+					bind:value={speachesModelId}
+					onchange={() =>
+						settings.updateKey(
+							'transcription.speaches.modelId',
+							speachesModelId,
+						)}
 				/>
 				<Field.Description>
 					The model you downloaded in step 3 (<code>MODEL_ID</code>), e.g.
@@ -829,11 +841,9 @@
 				placeholder="0"
 				autocomplete="off"
 				disabled={!currentServiceCapabilities.supportsTemperature}
-				bind:value={
-					() => settings.value['transcription.temperature'],
-					(value) =>
-						settings.updateKey('transcription.temperature', String(value))
-				}
+				bind:value={temperature}
+				onchange={() =>
+					settings.updateKey('transcription.temperature', String(temperature))}
 			/>
 			<Field.Description>
 				{currentServiceCapabilities.supportsTemperature
@@ -848,10 +858,9 @@
 				id="transcription-prompt"
 				placeholder="e.g., This is an academic lecture about quantum physics with technical terms like 'eigenvalue' and 'Schrödinger'"
 				disabled={!currentServiceCapabilities.supportsPrompt}
-				bind:value={
-					() => settings.value['transcription.prompt'],
-					(value) => settings.updateKey('transcription.prompt', value)
-				}
+				bind:value={transcriptionPrompt}
+				onchange={() =>
+					settings.updateKey('transcription.prompt', transcriptionPrompt)}
 			/>
 			<Field.Description>
 				{currentServiceCapabilities.supportsPrompt


### PR DESCRIPTION
## Summary

### Problem
Editing text inputs in settings (System Prompt, API keys, etc.) triggered a save on **every keystroke**, resulting in constant toast notifications.

### Solution
Changed text inputs to save **on blur** instead of on every keystroke:

- Use local `$state()` for input values
- Trigger `settings.updateKey()` on `onchange` (fires on blur/enter)
- For FFmpeg settings: added `commitChanges` callback prop so child component can signal when to save

### Result
Users can type freely without toast spam. A single toast appears when they leave the field.

---

## Type of Change

- [x] `fix`: Bug fix

---

## Related Issue

Closes #1214

---

## Testing Instructions

### System Prompt (main issue)
1. Navigate to **Settings &#x2192; Transcription**
2. Edit the **System Prompt** field
3. Confirm that:
   - No toasts while typing
   - Single toast appears when you click outside or press Tab

### API Keys
- Test any API key input (Settings &#x2192; API Keys or select a cloud transcription service)
- Same behavior: no toast while typing, single toast on blur

### FFmpeg Options

**Setup:**
1. Go to Settings &#x2192; Recording
2. Set Recording Mode to "Manual"
3. Set Recording Method to "FFmpeg"

**Test Cases:**

1. **Select dropdowns (Format, Sample Rate, Bitrate/Quality)**
   - Change format from WAV &#x2192; MP3
   - Verify: Toast appears once, preview updates, setting persists on page refresh

2. **Advanced text inputs (Global/Input/Output Options)**
   - Expand "Advanced Options"
   - Type multiple characters in Global Options field
   - Verify: No toast while typing
   - Click outside (blur) or press Tab
   - Verify: Single toast appears, setting persists on refresh

3. **Reset buttons**
   - Modify Global Options text
   - Click the reset button (&#x21ba;)
   - Verify: Single toast appears, value resets to default

4. **"Reset all" button**
   - Modify multiple fields
   - Click "Reset all" link
   - Verify: Single toast appears, all values reset

5. **Live preview**
   - Type in any text input
   - Verify: Command preview updates in real-time while typing (before blur)

---

## Comparison to #1234

| Approach | This PR (blur) | #1234 (debounce) |
|----------|----------------|------------------|
| When saves | On blur/enter | 500ms after typing stops |
| New dependencies | None | Debounce utility |
| Files changed | 12 | 4 |
| Scope | All text inputs | System prompt only |
