### PR TITLE
refactor(docs): add createWorkspaceClient helper for DRY workspace creation

### DIFF
--- a/apps/epicenter/src/lib/docs/README.md
+++ b/apps/epicenter/src/lib/docs/README.md
@@ -1,0 +1,120 @@
+# Three-Doc Architecture
+
+Epicenter uses a three-document architecture for storing and retrieving workspace data. Each document type has a specific responsibility and corresponding helper function.
+
+## Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         THREE-DOC ARCHITECTURE                              │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│   ┌──────────────┐      ┌──────────────┐      ┌──────────────────────┐     │
+│   │   REGISTRY   │ ──▶  │   HEAD DOC   │ ──▶  │    WORKSPACE DOC     │     │
+│   │              │      │              │      │                      │     │
+│   │  "Which      │      │  "What       │      │  "The actual         │     │
+│   │   workspaces │      │   epoch?"    │   │   definition & data" │     │
+│   │   exist?"    │      │              │      │                      │     │
+│   └──────────────┘      └──────────────┘      └──────────────────────┘     │
+│         │                     │                        │                    │
+│         ▼                     ▼                        ▼                    │
+│   registry.yjs          head.yjs              {epoch}.yjs                  │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Document Types
+
+| Doc Type      | Purpose                             | Storage Path                                    | Helper                                     |
+| ------------- | ----------------------------------- | ----------------------------------------------- | ------------------------------------------ |
+| **Registry**  | Tracks which workspace GUIDs exist  | `{appLocalDataDir}/registry.yjs`                | `registry` (module singleton)              |
+| **Head Doc**  | Stores current epoch per workspace  | `{appLocalDataDir}/workspaces/{id}/head.yjs`    | `createHead(workspaceId)`                  |
+| **Workspace** | Definition and data for a workspace | `{appLocalDataDir}/workspaces/{id}/{epoch}.yjs` | `createWorkspaceClient(definition, epoch)` |
+
+## Helper Functions
+
+### Registry (Module Singleton)
+
+```typescript
+import { registry } from '$lib/docs/registry';
+
+// Sync access works immediately
+registry.addWorkspace('abc123');
+registry.getWorkspaceIds();
+registry.hasWorkspace('abc123');
+
+// Await in UI render gate
+{#await registry.whenSynced}
+  <Loading />
+{:then}
+  {@render children()}
+{/await}
+```
+
+### Head Doc (Factory Function)
+
+```typescript
+import { createHead } from '$lib/docs/head';
+
+const head = createHead(workspaceId);
+await head.whenSynced;
+const epoch = head.getEpoch();
+```
+
+### Workspace Doc (Factory Function)
+
+```typescript
+import { createWorkspaceClient } from '$lib/docs/workspace';
+
+const client = createWorkspaceClient(definition, epoch);
+await client.whenSynced;
+
+// Use the client
+client.tables.myTable.insert({ ... });
+```
+
+## Typical Flow
+
+Loading an existing workspace:
+
+```typescript
+// 1. Check registry for workspace existence
+await registry.whenSynced;
+if (!registry.hasWorkspace(workspaceId)) {
+	throw new Error('Workspace not found');
+}
+
+// 2. Get epoch from head doc
+const head = createHead(workspaceId);
+await head.whenSynced;
+const epoch = head.getEpoch();
+
+// 3. Create workspace client with definition + epoch
+const client = createWorkspaceClient(definition, epoch);
+await client.whenSynced;
+```
+
+Creating a new workspace:
+
+```typescript
+// 1. Add to registry
+registry.addWorkspace(guid);
+
+// 2. Initialize head doc (epoch starts at 0)
+const head = createHead(guid);
+await head.whenSynced;
+
+// 3. Create workspace at epoch 0
+const client = createWorkspaceClient(definition, 0);
+await client.whenSynced;
+```
+
+## File Structure
+
+```
+$lib/docs/
+├── README.md       # This file
+├── registry.ts     # Module singleton for workspace registry
+├── head.ts         # Factory for head docs (epoch tracking)
+└── workspace.ts    # Factory for workspace clients
+```

--- a/apps/epicenter/src/lib/docs/workspace.ts
+++ b/apps/epicenter/src/lib/docs/workspace.ts
@@ -1,0 +1,49 @@
+import { defineWorkspace, type WorkspaceDefinition } from '@epicenter/hq';
+import * as Y from 'yjs';
+import { persistYDoc } from '$lib/providers/tauri-persistence';
+
+/**
+ * Create a workspace client with persistence for a given definition and epoch.
+ *
+ * This is the third step in the three-doc architecture:
+ * 1. Registry → tracks which workspace GUIDs exist
+ * 2. Head Doc → stores the current epoch for a workspace
+ * 3. Workspace Doc → the actual definition and data (this function)
+ *
+ * Combines `defineWorkspace()` and `.create()` into a single call with
+ * standardized capabilities. The workspace ID comes from `definition.id`.
+ *
+ * Persisted to `{appLocalDataDir}/workspaces/{workspaceId}/{epoch}.yjs`.
+ *
+ * @param definition - The workspace definition (id, slug, name, tables, kv)
+ * @param epoch - The epoch number from the head doc
+ * @returns A workspace client with persistence pre-configured
+ *
+ * @example
+ * ```typescript
+ * // Get epoch from head doc
+ * const head = createHead(workspaceId);
+ * await head.whenSynced;
+ * const epoch = head.getEpoch();
+ *
+ * // Create workspace client
+ * const client = createWorkspaceClient(definition, epoch);
+ * await client.whenSynced;
+ *
+ * // Use the client
+ * client.tables.myTable.insert({ ... });
+ * ```
+ */
+export function createWorkspaceClient(
+	definition: WorkspaceDefinition,
+	epoch: number,
+) {
+	const workspace = defineWorkspace(definition);
+	return workspace.create({
+		epoch,
+		capabilities: {
+			persistence: (ctx: { ydoc: Y.Doc }) =>
+				persistYDoc(ctx.ydoc, ['workspaces', definition.id, `${epoch}.yjs`]),
+		},
+	});
+}


### PR DESCRIPTION
Epicenter uses a three-document architecture for workspace data. Previously, every call site that created a workspace client had to repeat the same boilerplate: call `defineWorkspace()`, then `.create()` with capabilities wired up manually. This PR introduces a `createWorkspaceClient(definition, epoch)` helper that consolidates this pattern, matching the existing `createHead(workspaceId)` helper for head docs.

## Three-Doc Architecture

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                         THREE-DOC ARCHITECTURE                              │
├─────────────────────────────────────────────────────────────────────────────┤
│                                                                             │
│   ┌──────────────┐      ┌──────────────┐      ┌──────────────────────┐     │
│   │   REGISTRY   │ ──▶  │   HEAD DOC   │ ──▶  │    WORKSPACE DOC     │     │
│   │              │      │              │      │                      │     │
│   │  "Which      │      │  "What       │      │  "The actual         │     │
│   │   workspaces │      │   epoch?"    │      │   definition & data" │     │
│   │   exist?"    │      │              │      │                      │     │
│   └──────────────┘      └──────────────┘      └──────────────────────┘     │
│         │                     │                        │                    │
│         ▼                     ▼                        ▼                    │
│   registry.yjs          head.yjs              {epoch}.yjs                  │
│                                                                             │
└─────────────────────────────────────────────────────────────────────────────┘
```

## Helper Pattern

Each document type now has a corresponding helper:

```
┌────────────────┬─────────────────────────────────────────┬──────────────────┐
│ Doc Type       │ Helper                                  │ Input            │
├────────────────┼─────────────────────────────────────────┼──────────────────┤
│ Registry       │ registry (module singleton)             │ -                │
│ Head Doc       │ createHead(workspaceId)                 │ workspaceId      │
│ Workspace Doc  │ createWorkspaceClient(definition, epoch)│ definition+epoch │
└────────────────┴─────────────────────────────────────────┴──────────────────┘
```

## Before/After

**Before** (repeated at 3 call sites):
```typescript
const workspace = defineWorkspace({
  id: workspaceId,
  slug: workspaceId,
  name: '',
  tables: {},
  kv: {},
});

const client = workspace.create({
  epoch,
  capabilities: {
    persistence: (ctx: { ydoc: Y.Doc }) =>
      persistYDoc(ctx.ydoc, ['workspaces', workspaceId, `${epoch}.yjs`]),
  },
});
```

**After**:
```typescript
const client = createWorkspaceClient(
  { id: workspaceId, slug: workspaceId, name: '', tables: {}, kv: {} },
  epoch,
);
```

The helper standardizes the persistence path convention (`workspaces/{id}/{epoch}.yjs`) and ensures all workspace clients get the same capabilities.

## Verification

- [x] TypeScript compiles with no errors