### PR TITLE
docs(contributing): add fork workflow for external contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,8 +105,7 @@ Currently, **Whispering** (`apps/whispering`) is the most mature application and
    ```
 
    Create a PR to merge your fork's branch into `EpicenterHQ/epicenter:main`:
-   - **GitHub CLI**: `gh pr create --repo EpicenterHQ/epicenter`
-   - **Web**: Go to [EpicenterHQ/epicenter](https://github.com/EpicenterHQ/epicenter) — GitHub usually shows a "Compare & pull request" banner for recent pushes
+   Go to [EpicenterHQ/epicenter](https://github.com/EpicenterHQ/epicenter) — GitHub usually shows a "Compare & pull request" banner for recent pushes.
 
 <details>
 <summary>Tips for new contributors</summary>
@@ -121,7 +120,7 @@ git checkout main
 git merge upstream/main
 ```
 
-> Note: `upstream` is set automatically if you used `gh repo fork`. Otherwise, add it:
+> Note: Add the upstream remote to sync with the main repo:
 >
 > ```bash
 > git remote add upstream https://github.com/EpicenterHQ/epicenter.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,32 +14,62 @@ Epicenter is a monorepo containing multiple applications. The main application r
 
 ### Quick Setup
 
-1. **Clone the repository**
+1. **Fork and clone the repository**
+
+   [Fork the repository](https://github.com/EpicenterHQ/epicenter/fork) and clone your fork:
+
    ```bash
-   git clone https://github.com/EpicenterHQ/epicenter.git
+   git clone https://github.com/<your-username>/epicenter.git
    cd epicenter
    ```
 
+   <details>
+   <summary>New to forking? Click here for detailed steps</summary>
+
+   **Option A: GitHub CLI (one command)**
+
+   ```bash
+   gh repo fork EpicenterHQ/epicenter --clone
+   cd epicenter
+   ```
+
+   Requires [GitHub CLI](https://cli.github.com/).
+
+   **Option B: Web + git**
+   1. Click [Fork](https://github.com/EpicenterHQ/epicenter/fork) on GitHub
+   2. Clone your fork:
+      ```bash
+      git clone https://github.com/<your-username>/epicenter.git
+      cd epicenter
+      ```
+
+   **Learn more**: [How to Contribute to Open Source](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github) (free video series)
+
+   </details>
+
 2. **Install dependencies**
+
    ```bash
    bun install
    ```
-   
+
    > **Note**: If you see a version warning, run `bun upgrade` to update to the required version. The repository uses Bun 1.2.19 to ensure consistency across all contributors.
-   
+
    > **Note**: Desktop app development requires external tools not installed by the command above. Install these manually.
    > (For example: [Rust](https://www.rust-lang.org/tools/install) and [CMake](https://cmake.org/download/))
 
 3. **Navigate to the Whispering app**
+
    ```bash
    cd apps/whispering
    ```
 
 4. **Start development**
+
    ```bash
    # Run both web and desktop mode
    bun dev
-   
+
    # Or run just the web version
    bun dev:web
    ```
@@ -70,6 +100,7 @@ Currently, **Whispering** (`apps/whispering`) is the most mature application and
 ## Development Workflow
 
 1. **Create a branch** for your feature or fix
+
    ```bash
    git checkout -b feat/your-feature-name
    ```
@@ -77,20 +108,57 @@ Currently, **Whispering** (`apps/whispering`) is the most mature application and
 2. **Make your changes** following our coding standards (see below)
 
 3. **Test your changes** thoroughly
+
    ```bash
    # Run tests if available
    bun test
    ```
 
 4. **Commit using conventional commits**
+
    ```bash
    git commit -m "feat(whispering): add new feature"
    ```
 
 5. **Push and create a pull request**
+
    ```bash
    git push origin feat/your-feature-name
    ```
+
+   Create a PR to merge your fork's branch into `EpicenterHQ/epicenter:main`:
+   - **GitHub CLI**: `gh pr create --repo EpicenterHQ/epicenter`
+   - **Web**: Go to [EpicenterHQ/epicenter](https://github.com/EpicenterHQ/epicenter) — GitHub usually shows a "Compare & pull request" banner for recent pushes
+
+<details>
+<summary>Tips for new contributors</summary>
+
+**Keeping your fork updated**
+
+Before starting new work, sync with the main repo:
+
+```bash
+git fetch upstream
+git checkout main
+git merge upstream/main
+```
+
+> Note: `upstream` is set automatically if you used `gh repo fork`. Otherwise, add it:
+>
+> ```bash
+> git remote add upstream https://github.com/EpicenterHQ/epicenter.git
+> ```
+
+**If your PR has conflicts**
+
+Rebase your branch on the latest main:
+
+```bash
+git fetch upstream
+git rebase upstream/main
+```
+
+</details>
 
 ## Local Development: Testing the CLI
 
@@ -132,6 +200,7 @@ bun cli.ts blog createPost --title "Test Post" --category tech
 ```
 
 This approach is useful for:
+
 - Learning how to create a CLI programmatically
 - Testing without global installation
 - Understanding the CLI creation API
@@ -148,17 +217,21 @@ bun unlink
 ## Coding Standards
 
 ### TypeScript
+
 - Use `type` instead of `interface`
 - Prefer absolute imports over relative imports
 - Use object method shorthand syntax when appropriate
 
 ### Svelte
+
 - We use Svelte 5 with the latest runes syntax
 - Follow shadcn-svelte patterns for UI components
 - Use Tailwind CSS for styling
 
 ### Commits
+
 We follow [Conventional Commits](https://www.conventionalcommits.org/):
+
 - `feat`: New features
 - `fix`: Bug fixes
 - `docs`: Documentation changes
@@ -167,6 +240,7 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/):
 - `chore`: Maintenance tasks
 
 Examples:
+
 - `feat(whispering): add model selection for OpenAI providers`
 - `fix(sound): resolve audio import paths`
 - `docs: update contribution guidelines`
@@ -174,7 +248,9 @@ Examples:
 ## Troubleshooting
 
 ### Version Mismatch Warning
+
 If you see a warning about Bun version mismatch:
+
 ```bash
 # Update to the latest Bun version
 bun upgrade
@@ -184,6 +260,7 @@ curl -fsSL https://bun.sh/install | bash -s "bun-v1.2.19"
 ```
 
 ### Installation Issues
+
 - Make sure you're in the repository root when running `bun install`
 - Clear the cache if you encounter issues: `bun pm cache rm`
 - On Windows, you may need to run your terminal as Administrator
@@ -197,6 +274,7 @@ curl -fsSL https://bun.sh/install | bash -s "bun-v1.2.19"
 ## Philosophy
 
 We believe in:
+
 - **Local-first**: Your data stays on your machine
 - **Open source**: Everything is transparent and auditable
 - **User ownership**: You own your data and choose your models
@@ -213,6 +291,7 @@ We believe in:
 ## Questions?
 
 Feel free to:
+
 - Open an issue for discussion
 - Join our Discord and DM me directly to get started
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,29 +23,7 @@ Epicenter is a monorepo containing multiple applications. The main application r
    cd epicenter
    ```
 
-   <details>
-   <summary>New to forking? Click here for detailed steps</summary>
-
-   **Option A: GitHub CLI (one command)**
-
-   ```bash
-   gh repo fork EpicenterHQ/epicenter --clone
-   cd epicenter
-   ```
-
-   Requires [GitHub CLI](https://cli.github.com/).
-
-   **Option B: Web + git**
-   1. Click [Fork](https://github.com/EpicenterHQ/epicenter/fork) on GitHub
-   2. Clone your fork:
-      ```bash
-      git clone https://github.com/<your-username>/epicenter.git
-      cd epicenter
-      ```
-
-   **Learn more**: [How to Contribute to Open Source](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github) (free video series)
-
-   </details>
+   > New to open source? Check out [How to Contribute to Open Source](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github) (free video series).
 
 2. **Install dependencies**
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 >
 > - Whispering's evolution beyond transcription required changes to the repository's structure and branding.
 > - Everything else remains the same—same tools, same philosophy, same team.
-> - The original app lives on as [*Epicenter Whispering*](https://github.com/EpicenterHQ/epicenter/tree/main/apps/whispering), keeping a tight focus on transcription.
-> - This makes room for standalone apps with complementary, but non-transcription-related features (like [*Epicenter Assistant*](https://github.com/EpicenterHQ/epicenter/tree/main/apps/sh)).
+> - The original app lives on as [_Epicenter Whispering_](https://github.com/EpicenterHQ/epicenter/tree/main/apps/whispering), keeping a tight focus on transcription.
+> - This makes room for standalone apps with complementary, but non-transcription-related features (like [_Epicenter Assistant_](https://github.com/EpicenterHQ/epicenter/tree/main/apps/sh)).
 > - The new [root](https://github.com/EpicenterHQ/epicenter/) of the Epicenter repository contains common files supporting all the apps in the ecosystem.
 > - Note: the old URL [github.com/braden-w/whispering](https://github.com/braden-w/whispering) is now just a thin placeholder redirecting to this rebranded repository.
 >
@@ -99,6 +99,7 @@ Our vision is to build a personal workspace where you own your data, choose your
 Our first app in the ecosystem. Choose your installation method:
 
 **macOS (Homebrew)**
+
 ```bash
 brew install --cask whispering
 ```
@@ -106,6 +107,7 @@ brew install --cask whispering
 **macOS, Windows, Linux (Direct Download)**
 
 Download the installer for your platform from [GitHub Releases](https://github.com/EpicenterHQ/epicenter/releases/latest):
+
 - macOS: `.dmg` (Apple Silicon or Intel)
 - Windows: `.msi` or `.exe`
 - Linux: `.AppImage`, `.deb`, or `.rpm`
@@ -127,6 +129,8 @@ bun install  # Will prompt to upgrade if your Bun version is too old
 cd apps/whispering
 bun dev
 ```
+
+> Want to contribute? See [CONTRIBUTING.md](CONTRIBUTING.md) for fork and PR instructions.
 
 ### Troubleshooting
 

--- a/apps/whispering/README.md
+++ b/apps/whispering/README.md
@@ -126,8 +126,8 @@ This automatically handles installation and updates.
 
 #### Download Options
 
-| Installer Type    | Download                                                                                                                                        | Description                            |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| Installer Type    | Download                                                                                                                                              | Description                            |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
 | **MSI Installer** | [Whispering_7.11.0_x64_en-US_windows.msi](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_x64_en-US_windows.msi) | Recommended Standard Windows installer |
 | **EXE Installer** | [Whispering_7.11.0_x64-setup_windows.exe](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_x64-setup_windows.exe) | Alternative installer option           |
 
@@ -147,8 +147,8 @@ Whispering will appear in your Start Menu when complete.
 
 #### Download Options
 
-| Package Format  | Download                                                                                                                                      | Compatible With          |
-| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| Package Format  | Download                                                                                                                                            | Compatible With          |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
 | **AppImage**    | [Whispering_7.11.0_amd64_linux.AppImage](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_amd64_linux.AppImage) | All Linux distributions  |
 | **DEB Package** | [Whispering_7.11.0_amd64_linux.deb](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_amd64_linux.deb)           | Debian, Ubuntu, Pop!\_OS |
 | **RPM Package** | [Whispering-7.11.0-1.x86_64_linux.rpm](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering-7.11.0-1.x86_64_linux.rpm)     | Fedora, RHEL, openSUSE   |
@@ -635,6 +635,8 @@ The architecture achieves extensive code reuse through build-time platform detec
 2. Change into the project directory: `cd epicenter`
 3. Install the necessary dependencies: `bun i`
 
+> Want to contribute? See [CONTRIBUTING.md](../../CONTRIBUTING.md) for fork and PR instructions.
+
 To run the desktop app and website:
 
 ```bash
@@ -786,47 +788,47 @@ Adding a new transcription service involves four main steps:
 
    // Add import for your models
    import {
-     YOUR_SERVICE_MODELS,
-     type YourServiceModel,
+   	YOUR_SERVICE_MODELS,
+   	type YourServiceModel,
    } from './cloud/your-service';
 
    // Add to the TranscriptionModel union type
    type TranscriptionModel =
-     | OpenAIModel
-     | GroqModel
-     | ElevenLabsModel
-     | DeepgramModel
-     | YourServiceModel;
+   	| OpenAIModel
+   	| GroqModel
+   	| ElevenLabsModel
+   	| DeepgramModel
+   	| YourServiceModel;
 
    // Add to TRANSCRIPTION_SERVICE_IDS array
    export const TRANSCRIPTION_SERVICE_IDS = [
-     'whispercpp',
-     'parakeet',
-     'Groq',
-     'OpenAI',
-     'ElevenLabs',
-     'Deepgram',
-     'speaches',
-     'YourService', // Add your service here
+   	'whispercpp',
+   	'parakeet',
+   	'Groq',
+   	'OpenAI',
+   	'ElevenLabs',
+   	'Deepgram',
+   	'speaches',
+   	'YourService', // Add your service here
    ] as const;
 
    // Add to TRANSCRIPTION_SERVICES array (in the appropriate section)
    export const TRANSCRIPTION_SERVICES = [
-     // ... existing services
-     // Add in the cloud services section:
-     {
-       id: 'YourService',
-       name: 'Your Service Name',
-       icon: yourServiceIcon,
-       invertInDarkMode: true, // or false, depending on your icon
-       description: 'Description of what makes your service special',
-       models: YOUR_SERVICE_MODELS,
-       defaultModel: YOUR_SERVICE_MODELS[0],
-       modelSettingKey: 'transcription.yourservice.model',
-       apiKeyField: 'apiKeys.yourservice',
-       location: 'cloud', // or 'local' or 'self-hosted'
-     },
-     // ... rest of services
+   	// ... existing services
+   	// Add in the cloud services section:
+   	{
+   		id: 'YourService',
+   		name: 'Your Service Name',
+   		icon: yourServiceIcon,
+   		invertInDarkMode: true, // or false, depending on your icon
+   		description: 'Description of what makes your service special',
+   		models: YOUR_SERVICE_MODELS,
+   		defaultModel: YOUR_SERVICE_MODELS[0],
+   		modelSettingKey: 'transcription.yourservice.model',
+   		apiKeyField: 'apiKeys.yourservice',
+   		location: 'cloud', // or 'local' or 'self-hosted'
+   	},
+   	// ... rest of services
    ] as const satisfies SatisfiedTranscriptionService[];
    ```
 


### PR DESCRIPTION
## Summary

New contributors were confused because they didn't know they needed to fork first (they lack push access to the main repo). This PR clarifies the fork workflow in CONTRIBUTING.md and links to it from README files.

## Type of Change

- [x] \`docs\`: Documentation update

## Related Issue

Closes #

## Changes Made

- **CONTRIBUTING.md**: Replace "clone" with "fork and clone" in Quick Setup
- **CONTRIBUTING.md**: Add link to egghead.io video series for beginners
- **CONTRIBUTING.md**: Clarify PR should target upstream repo, not fork
- **CONTRIBUTING.md**: Add details-summary with tips for syncing fork and handling conflicts
- **README.md** & **apps/whispering/README.md**: Add link to CONTRIBUTING.md for contributors

## Testing

### Desktop App Testing
- [x] Not applicable (web-only change)

### General Testing
- [x] Verified markdown renders correctly

## Checklist

- [x] My code follows the project's coding standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] My changes don't break existing functionality
- [x] I've updated documentation (if needed)

## Screenshots/Recordings

N/A - docs only

## Additional Notes

N/A
