### PR TITLE
refactor(workspace): consolidate Y.Doc structure and clarify CRDT semantics

### DIFF
--- a/apps/epicenter/src/lib/docs/README.md
+++ b/apps/epicenter/src/lib/docs/README.md
@@ -12,24 +12,86 @@ Epicenter uses a three-document architecture for storing and retrieving workspac
 │   ┌──────────────┐      ┌──────────────┐      ┌──────────────────────┐     │
 │   │   REGISTRY   │ ──▶  │   HEAD DOC   │ ──▶  │    WORKSPACE DOC     │     │
 │   │              │      │              │      │                      │     │
-│   │  "Which      │      │  "What       │      │  "The actual         │     │
-│   │   workspaces │      │   epoch?"    │   │   definition & data" │     │
+│   │  "Which      │      │  "What       │      │  "The actual data"   │     │
+│   │   workspaces │      │   epoch?"    │      │                      │     │
 │   │   exist?"    │      │              │      │                      │     │
 │   └──────────────┘      └──────────────┘      └──────────────────────┘     │
-│         │                     │                        │                    │
-│         ▼                     ▼                        ▼                    │
+│         │                     │                        │                   │
+│         ▼                     ▼                        ▼                   │
 │   registry.yjs          head.yjs              {epoch}.yjs                  │
+│                                                                             │
+│   ┌──────────────────────────────────────────────────────────────────┐     │
+│   │   DEFINITION (static JSON, not Y.Doc)                            │     │
+│   │                                                                  │     │
+│   │   "What is the workspace schema?"                                │     │
+│   │                                                                  │     │
+│   │   → definition.json                                              │     │
+│   └──────────────────────────────────────────────────────────────────┘     │
 │                                                                             │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
+## Storage Layout
+
+```
+{appLocalDataDir}/
+├── registry.yjs                    # Index of all workspace IDs
+├── registry.json                   # Human-readable snapshot
+└── workspaces/
+    ├── epicenter.whispering/       # Whispering workspace
+    │   ├── definition.json
+    │   ├── head.yjs
+    │   ├── 0.yjs
+    │   └── 0.json
+    │
+    └── epicenter.crm/              # Example: CRM workspace
+        │
+        │   # Static definition (edited by UI or text editor)
+        ├── definition.json         # WorkspaceDefinition (name, tables, kv)
+        │
+        │   # Epoch management
+        ├── head.yjs                # Current epoch number
+        ├── head.json               # Snapshot
+        │
+        │   # Data storage (Y.Doc per epoch, DATA ONLY)
+        ├── 0.yjs                   # Epoch 0 data (rows + kv values)
+        ├── 0.json                  # Snapshot
+        ├── 1.yjs                   # Epoch 1 (after migration)
+        └── 1.json                  # Snapshot
+```
+
+### Workspace ID Format
+
+The `id` is a **locally-scoped identifier**, not a GUID:
+
+- **Local/Relay**: `epicenter.whispering`, `epicenter.crm`
+- **Y-Sweet (with auth)**: Server combines user ID with local ID for global uniqueness
+
 ## Document Types
 
-| Doc Type      | Purpose                             | Storage Path                                    | Helper                                     |
-| ------------- | ----------------------------------- | ----------------------------------------------- | ------------------------------------------ |
-| **Registry**  | Tracks which workspace GUIDs exist  | `{appLocalDataDir}/registry.yjs`                | `registry` (module singleton)              |
-| **Head Doc**  | Stores current epoch per workspace  | `{appLocalDataDir}/workspaces/{id}/head.yjs`    | `createHead(workspaceId)`                  |
-| **Workspace** | Definition and data for a workspace | `{appLocalDataDir}/workspaces/{id}/{epoch}.yjs` | `createWorkspaceClient(definition, epoch)` |
+| Doc Type       | Purpose                            | Storage Path                                    | Helper                                     |
+| -------------- | ---------------------------------- | ----------------------------------------------- | ------------------------------------------ |
+| **Registry**   | Tracks which workspace GUIDs exist | `{appLocalDataDir}/registry.yjs`                | `registry` (module singleton)              |
+| **Head Doc**   | Stores current epoch per workspace | `{appLocalDataDir}/workspaces/{id}/head.yjs`    | `createHead(workspaceId)`                  |
+| **Definition** | Static workspace schema/metadata   | `{appLocalDataDir}/workspaces/{id}/definition.json` | JSON read/write                        |
+| **Workspace**  | Data for a workspace (rows, kv)    | `{appLocalDataDir}/workspaces/{id}/{epoch}.yjs` | `createWorkspaceClient(definition, epoch)` |
+
+## Key Design Decision: Static Definitions
+
+The workspace definition (name, icon, table schemas) is stored as a **static JSON file**, not in the Y.Doc.
+
+**Why?**
+- Definition rarely changes (set once, maybe edited occasionally)
+- No need for CRDT overhead on metadata
+- File is human-readable and git-friendly
+- Simpler mental model: Y.Doc = data, JSON = schema
+
+**What goes where?**
+
+| File | Contents |
+|------|----------|
+| `definition.json` | `WorkspaceDefinition` (id, name, tables with metadata, kv schema) |
+| `{epoch}.yjs` | Table rows (`Y.Map<rowId, Y.Map<field, value>>`) and kv values |
 
 ## Helper Functions
 
@@ -118,3 +180,34 @@ $lib/docs/
 ├── head.ts         # Factory for head docs (epoch tracking)
 └── workspace.ts    # Factory for workspace clients
 ```
+
+## Definition File Format
+
+The `definition.json` file contains a `WorkspaceDefinition`:
+
+```json
+{
+  "id": "epicenter.whispering",
+  "name": "Whispering",
+  "tables": {
+    "recordings": {
+      "name": "Recordings",
+      "icon": { "type": "emoji", "value": "🎙️" },
+      "description": "Voice recordings and transcriptions",
+      "fields": {
+        "id": { "type": "id" },
+        "title": { "type": "text" },
+        "transcript": { "type": "text", "nullable": true }
+      }
+    }
+  },
+  "kv": {}
+}
+```
+
+When creating a workspace via the SDK with minimal input, the definition is normalized with defaults:
+
+- `name` defaults to humanized `id` (e.g., "content-hub" → "Content hub")
+- Table `name` defaults to humanized key (e.g., "blogPosts" → "Blog posts")
+- Table `icon` defaults to `{ "type": "emoji", "value": "📄" }`
+- Table `description` defaults to `""`

--- a/packages/epicenter/src/core/workspace/workspace.ts
+++ b/packages/epicenter/src/core/workspace/workspace.ts
@@ -306,23 +306,6 @@ export type WorkspaceClient<
 	 */
 	readonly slug: string;
 
-	/**
-	 * Workspace definition helper for reading/merging metadata.
-	 *
-	 * Provides explicit access to live CRDT state and merge operations.
-	 * The root-level `client.name` and `client.slug` are shortcuts to these values.
-	 *
-	 * @example
-	 * ```typescript
-	 * // Read (equivalent to client.name / client.slug)
-	 * client.definition.name
-	 * client.definition.slug
-	 *
-	 * // Merge updated config (idempotent)
-	 * client.definition.merge({ name, slug, tables, kv });
-	 * ```
-	 */
-	readonly definition: Definition;
 	/** Typed table helpers for CRUD operations. */
 	tables: Tables<TTableDefinitionMap>;
 	/** Key-value store for simple values. */
@@ -609,7 +592,6 @@ export function defineWorkspace<
 				get slug() {
 					return definition.slug;
 				},
-				definition,
 				ydoc,
 				tables,
 				kv,
@@ -634,12 +616,9 @@ type TableDefinitionYMap = Y.Map<
 >;
 
 /**
- * Helper for reading and merging workspace definition in Y.Doc.
- *
- * Similar to {@link Tables} and {@link Kv}, this provides a typed interface
- * over the underlying Y.Map storage.
+ * Internal helper for reading and merging workspace definition in Y.Doc.
  */
-export type Definition = {
+type Definition = {
 	/** Display name of the workspace. */
 	readonly name: string;
 	/** URL-friendly identifier. */


### PR DESCRIPTION
This PR consolidates Y.Doc storage and clarifies the relationship between input config and runtime state.

## The Mental Model

```
WorkspaceDefinition              Y.Doc                          WorkspaceClient
(what you pass in)               (CRDT storage)                 (what you use)
──────────────────               ───────────────                ───────────────

┌─────────────────┐                                            ┌─────────────────┐
│ id ─────────────────────▶ doc.guid ─────────────────────────▶│ id (static)     │
│                 │                                            │                 │
│ name ───────────────┐    ┌──────────────────┐    ┌──────────▶│ get name()      │
│ slug ───────────────┼───▶│ 'definition'     │────┤          │ get slug()      │
│ tables ─────────────┤    │   ├─ name        │    │          │                 │
│ kv ─────────────────┘    │   ├─ slug        │    │          │ tables: Tables  │
└─────────────────┘        │   ├─ tables ─────────────────────▶│ kv: Kv          │
                           │   └─ kv ─────────────────────────▶│                 │
       Initial values      └──────────────────┘    Live state  └─────────────────┘
       (merged once)              │
                                  │
                           ┌──────────────────┐
                           │ 'tables' (data)  │───▶ Row storage
                           │ 'kv' (data)      │───▶ KV storage
                           └──────────────────┘
```

## Y.Doc Structure Change

```
BEFORE                              AFTER
──────                              ─────
Y.Doc                               Y.Doc
├── 'meta'                          ├── 'definition'
│   ├── name                        │   ├── name
│   └── slug                        │   ├── slug
├── 'schema'                        │   ├── tables
│   ├── tables                      │   └── kv
│   └── kv                          ├── 'tables' (data)
├── 'tables' (data)                 └── 'kv' (data)
└── 'kv' (data)
```

The new `'definition'` key maps 1:1 with `Omit<WorkspaceDefinition, 'id'>`.

## The Key Insight

`WorkspaceDefinition` provides **initial values**. After `workspace.create()`, they become **live CRDT state**:

```
┌────────────────────────────────────────────────────────────────────┐
│                        Property Semantics                          │
├──────────┬─────────────────────────┬──────────────────────────────┤
│ Property │ In WorkspaceDefinition  │ In WorkspaceClient           │
├──────────┼─────────────────────────┼──────────────────────────────┤
│ id       │ Immutable identity      │ client.id (static)           │
│ name     │ Initial value           │ client.name (live getter)    │
│ slug     │ Initial value           │ client.slug (live getter)    │
│ tables   │ Initial definitions     │ client.tables (data helpers) │
│ kv       │ Initial definitions     │ client.kv (data helpers)     │
└──────────┴─────────────────────────┴──────────────────────────────┘
```

After creation, `client.name` and `client.slug` read from Y.Map on each access—reflecting real-time collaborative changes from other peers.

## API Changes

```
BEFORE                              AFTER
──────                              ─────
client.id           (static)        client.id           (static)
client.slug         (static) ──────▶ client.slug        (live getter)
                                    client.name         (live getter) ← NEW
client.definition   (helper) ──────▶ (removed from public API)
```

## Breaking Change

Existing Y.Docs have data in old keys (`'meta'`, `'schema'`). Migration required for existing data.