### PR TITLE
fix(ui): suppress state_referenced_locally warnings with untrack()

### DIFF
--- a/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
@@ -20,6 +20,7 @@
 	import SettingsIcon from '@lucide/svelte/icons/settings';
 	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
 	import { SvelteSet } from 'svelte/reactivity';
+	import { untrack } from 'svelte';
 
 	let { class: className }: { class?: string } = $props();
 
@@ -41,7 +42,9 @@
 	);
 
 	const selfHostedServices = $derived(
-		TRANSCRIPTION_SERVICES.filter((service) => service.location === 'self-hosted'),
+		TRANSCRIPTION_SERVICES.filter(
+			(service) => service.location === 'self-hosted',
+		),
 	);
 
 	const localServices = $derived(
@@ -50,9 +53,9 @@
 
 	const combobox = useCombobox();
 
-	// Track which services are expanded
+	// Track which services are expanded (initial value only, user controls after)
 	let expandedServices = new SvelteSet(
-		selectedService ? [selectedService.id] : [],
+		untrack(() => (selectedService ? [selectedService.id] : [])),
 	);
 
 	function toggleServiceExpanded(serviceId: TranscriptionService['id']) {

--- a/packages/ui/src/copy-button/copy-button.svelte
+++ b/packages/ui/src/copy-button/copy-button.svelte
@@ -6,6 +6,7 @@
 	import CopyIcon from '@lucide/svelte/icons/copy';
 	import XIcon from '@lucide/svelte/icons/x';
 	import { scale } from 'svelte/transition';
+	import { untrack } from 'svelte';
 	import type { CopyButtonProps } from './types';
 
 	let {
@@ -23,12 +24,14 @@
 		...rest
 	}: CopyButtonProps = $props();
 
-	// this way if the user passes text then the button will be the default size
-	if (size === 'icon' && children) {
-		size = 'default';
-	}
+	untrack(() => {
+		if (size === 'icon' && children) {
+			size = 'default';
+		}
+	});
 
-	const clipboard = new UseClipboard({ copyFn });
+	// Clipboard instance created once - copyFn is static, intentionally non-reactive
+	const clipboard = untrack(() => new UseClipboard({ copyFn }));
 </script>
 
 <Button

--- a/packages/ui/src/file-drop-zone/file-drop-zone.svelte
+++ b/packages/ui/src/file-drop-zone/file-drop-zone.svelte
@@ -6,6 +6,7 @@
 	import { cn } from '#/utils/utils';
 	import UploadIcon from '@lucide/svelte/icons/upload';
 	import { useId } from 'bits-ui';
+	import { untrack } from 'svelte';
 
 	import type { FileDropZoneProps, FileRejectedReason } from './types';
 
@@ -25,11 +26,14 @@
 		...rest
 	}: FileDropZoneProps = $props();
 
-	if (maxFiles !== undefined && fileCount === undefined) {
-		console.warn(
-			'Make sure to provide FileDropZone with `fileCount` when using the `maxFiles` prompt',
-		);
-	}
+	// One-time dev warning on mount - intentionally non-reactive
+	untrack(() => {
+		if (maxFiles !== undefined && fileCount === undefined) {
+			console.warn(
+				'Make sure to provide FileDropZone with `fileCount` when using the `maxFiles` prompt',
+			);
+		}
+	});
 
 	let uploading = $state(false);
 

--- a/packages/ui/src/toggle-group/toggle-group.svelte
+++ b/packages/ui/src/toggle-group/toggle-group.svelte
@@ -13,6 +13,7 @@
 <script lang="ts">
 	import { ToggleGroup as ToggleGroupPrimitive } from 'bits-ui';
 	import { cn } from '#/utils/utils.js';
+	import { untrack } from 'svelte';
 
 	let {
 		ref = $bindable(null),
@@ -23,9 +24,12 @@
 		...restProps
 	}: ToggleGroupPrimitive.RootProps & ToggleVariants = $props();
 
-	setToggleGroupCtx({
-		variant,
-		size,
+	// setContext must run synchronously during init - intentionally non-reactive
+	untrack(() => {
+		setToggleGroupCtx({
+			variant,
+			size,
+		});
 	});
 </script>
 


### PR DESCRIPTION
## Summary

Silence Svelte 5 `state_referenced_locally` compiler warnings that were causing console noise and doubt from external devs. Confirmed these variables do not need to be reactive - behavior is correct as-is.

## Type of Change

- [x] `fix`: Bug fix

## Related Issue

Related to #1203

## Changes Made

Use Svelte's `untrack()` to explicitly mark intentionally non-reactive prop reads:

- `file-drop-zone.svelte`: wrap dev warning check (one-time mount validation)
- `toggle-group.svelte`: wrap setContext call (must run synchronously during init)
- `copy-button.svelte`: wrap size adjustment and clipboard instantiation
- `TranscriptionSelector.svelte`: wrap initial expanded state

## Testing

### Desktop App Testing
- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [x] Not applicable (web-only change)

### General Testing
- [ ] Tested with multiple API providers (if applicable)
- [ ] Verified no API keys are exposed in logs or storage
- [x] Checked for console errors
- [ ] Tested on different screen sizes (if UI change)

## Checklist

- [x] My code follows the project's coding standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I've used `type` instead of `interface` in TypeScript
- [x] I've used absolute imports where applicable
- [x] I've tested my changes thoroughly
- [ ] I've added/updated tests for my changes (if applicable)
- [x] My changes don't break existing functionality
- [ ] I've updated documentation (if needed)

## Screenshots/Recordings

N/A - no UI changes

## Additional Notes

The `state_referenced_locally` warning fires when reactive props are read outside reactive contexts. In these cases, capturing the initial value is intentional (setContext, one-time validation, static initialization).