### PR TITLE
fix(settings): remove success toast for routine updates

### DIFF
--- a/apps/whispering/src/lib/stores/settings.svelte.ts
+++ b/apps/whispering/src/lib/stores/settings.svelte.ts
@@ -51,12 +51,6 @@ export const settings = (() => {
 			// Fallback - should never reach here
 			return getDefaultSettings();
 		},
-		onUpdateSuccess: () => {
-			rpc.notify.success({
-				title: 'Settings updated!',
-				description: '',
-			});
-		},
 		onUpdateError: (err) => {
 			rpc.notify.error({
 				title: 'Error updating settings',


### PR DESCRIPTION
Every settings change was triggering a toast AND OS notification, causing spam when typing in settings fields. This removes the `onUpdateSuccess` callback that fired on every settings update.

The change is minimal: just removing the success notification callback from `createPersistedState` in `settings.svelte.ts:54-59`. Error notifications remain intact for actual failures, and the explicit success toast for `switchRecordingMode` is preserved since mode switching is a significant user action (not routine typing).

Related to #1236