### PR TITLE
fix(settings): remove success toast for routine updates

### DIFF
--- a/apps/whispering/src/lib/stores/settings.svelte.ts
+++ b/apps/whispering/src/lib/stores/settings.svelte.ts
@@ -51,12 +51,6 @@ export const settings = (() => {
 			// Fallback - should never reach here
 			return getDefaultSettings();
 		},
-		onUpdateSuccess: () => {
-			rpc.notify.success({
-				title: 'Settings updated!',
-				description: '',
-			});
-		},
 		onUpdateError: (err) => {
 			rpc.notify.error({
 				title: 'Error updating settings',


### PR DESCRIPTION
Removes the success toast/notification that fires on every settings update, which was causing toast spam when typing in text fields.

Instead of changing inputs to save on blur (#1236), this takes the simpler approach: just don't show success notifications for routine settings changes. Users expect settings to auto-save silently (like VS Code, Chrome settings, macOS preferences).

**What changed:**
- Removed `onUpdateSuccess` callback from settings store
- Error notifications remain intact
- Explicit success toasts for significant actions (like mode switching) are preserved

Related to #1236

Co-authored-by: John-Kim Murphy <Leftium@users.noreply.github.com>