### PR TITLE
fix(ui): properly fix state_referenced_locally warnings

### DIFF
--- a/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/TranscriptionSelector.svelte
@@ -41,7 +41,9 @@
 	);
 
 	const selfHostedServices = $derived(
-		TRANSCRIPTION_SERVICES.filter((service) => service.location === 'self-hosted'),
+		TRANSCRIPTION_SERVICES.filter(
+			(service) => service.location === 'self-hosted',
+		),
 	);
 
 	const localServices = $derived(
@@ -51,6 +53,7 @@
 	const combobox = useCombobox();
 
 	// Track which services are expanded
+	// svelte-ignore state_referenced_locally - intentional one-time init to expand the currently selected service
 	let expandedServices = new SvelteSet(
 		selectedService ? [selectedService.id] : [],
 	);

--- a/packages/ui/src/copy-button/copy-button.svelte
+++ b/packages/ui/src/copy-button/copy-button.svelte
@@ -23,11 +23,12 @@
 		...rest
 	}: CopyButtonProps = $props();
 
-	// this way if the user passes text then the button will be the default size
+	// svelte-ignore state_referenced_locally - intentional one-time size adjustment based on initial children
 	if (size === 'icon' && children) {
 		size = 'default';
 	}
 
+	// svelte-ignore state_referenced_locally - clipboard instance created once with initial copyFn
 	const clipboard = new UseClipboard({ copyFn });
 </script>
 

--- a/packages/ui/src/file-drop-zone/file-drop-zone.svelte
+++ b/packages/ui/src/file-drop-zone/file-drop-zone.svelte
@@ -25,6 +25,7 @@
 		...rest
 	}: FileDropZoneProps = $props();
 
+	// svelte-ignore state_referenced_locally - one-time dev warning at component init
 	if (maxFiles !== undefined && fileCount === undefined) {
 		console.warn(
 			'Make sure to provide FileDropZone with `fileCount` when using the `maxFiles` prompt',

--- a/packages/ui/src/toggle-group/toggle-group.svelte
+++ b/packages/ui/src/toggle-group/toggle-group.svelte
@@ -23,9 +23,14 @@
 		...restProps
 	}: ToggleGroupPrimitive.RootProps & ToggleVariants = $props();
 
+	// Use getters so child components receive reactive values when props change
 	setToggleGroupCtx({
-		variant,
-		size,
+		get variant() {
+			return variant;
+		},
+		get size() {
+			return size;
+		},
 	});
 </script>
 


### PR DESCRIPTION
Fixes Svelte 5 `state_referenced_locally` warnings using the correct patterns instead of `untrack()` (which has no effect at top-level script).

**Fixes applied:**

| File | Fix | Reasoning |
|------|-----|-----------|
| TranscriptionSelector.svelte | `svelte-ignore` | One-time init to expand selected service; re-tracking would reset user's expand/collapse |
| copy-button.svelte | `svelte-ignore` (2x) | Size adjustment and clipboard instance are intentionally static |
| file-drop-zone.svelte | `svelte-ignore` | Dev warning should only fire once at init |
| toggle-group.svelte | **Getters** | Context must stay reactive for child components |

The key insight: `untrack()` only works inside `$effect` or `$derived` blocks. At top-level, it does nothing. For intentional one-time initialization, `svelte-ignore` is the honest approach. For context that needs to stay reactive, use getters.

Related to #1248

Co-authored-by: John-Kim Murphy <Leftium@users.noreply.github.com>