### PR TITLE
fix(ci): add permissions for cleanup-preview workflow

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -8,6 +8,9 @@ jobs:
   cleanup-preview:
     name: Delete Preview Worker
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -15,7 +18,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version-file: "package.json"
+          bun-version-file: 'package.json'
 
       - name: Delete preview worker
         run: |


### PR DESCRIPTION
The cleanup-preview workflow was failing with "Resource not accessible by integration" (403 error) when trying to comment on PRs after deleting preview deployments.

This was caused by the workflow lacking the necessary permissions to write comments. GitHub Actions workflows use read-only permissions by default, so the `actions/github-script` step couldn't create issue comments.

Added a `permissions` block at the job level with:
- `contents: read` for repository checkout
- `pull-requests: write` for commenting on PRs