### PR TITLE
fix(whispering): update Svelte MCP server to use local bunx command

### DIFF
--- a/apps/whispering/.mcp.json
+++ b/apps/whispering/.mcp.json
@@ -1,8 +1,8 @@
 {
 	"mcpServers": {
-		"svelte-llm": {
-			"type": "sse",
-			"url": "https://svelte-llm.stanislav.garden/mcp/sse"
+		"svelte": {
+			"type": "local",
+			"command": ["bunx", "@sveltejs/mcp"]
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Fix broken Svelte MCP server config by switching from defunct remote SSE server to local bunx command
- Other devs with bun installed will automatically get the MCP server via `bunx @sveltejs/mcp`
