### PR TITLE
fix(dev): change Svelte inspector shortcut to avoid conflicts

### DIFF
--- a/apps/whispering/svelte.config.js
+++ b/apps/whispering/svelte.config.js
@@ -29,7 +29,7 @@ const config = {
 			// src/routes/+layout.svelte move it to bottom-center to avoid
 			// conflicts with devtools (bottom-left) and toasts (bottom-right)
 			toggleButtonPos: 'bottom-left',
-			toggleKeyCombo: 'meta-shift',
+			toggleKeyCombo: 'alt-x',
 		},
 	},
 };


### PR DESCRIPTION
## Summary

Fix Svelte inspector triggering on every Whispering global shortcut (e.g., Cmd+Shift+;).

## Type of Change

- [x] `fix`: Bug fix

## Related Issue

Closes #

## Changes Made

Changed `toggleKeyCombo` in `svelte.config.js` from `'meta-shift'` to `'alt-x'` (the official default).

**Problem:** The `'meta-shift'` config captured ALL `Cmd+Shift+*` combinations, causing the inspector to trigger whenever any Whispering global shortcut was pressed.

**Solution:** Use a specific key combo (`alt-x` = Option+X on macOS, Alt+X on Windows/Linux) which only triggers on that exact combination.

## Testing

### Desktop App Testing
- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] Not applicable (web-only change)

### General Testing
- [x] Verified Cmd+Shift+; no longer triggers inspector
- [x] Verified Option+X still activates inspector
- [x] Checked for console errors

## Checklist

- [x] My code follows the project&#x27;s coding standards
- [x] I&#x27;ve tested my changes thoroughly
- [x] My changes don&#x27;t break existing functionality

## Additional Notes

The original `'meta-shift'` was intended for &#x22;hold Cmd+Shift and click to inspect&#x22;, but the inspector also fires on any keypress while those modifiers are held - not just clicks.
