### PR TITLE
feat(templates): add workspace templates with simplified docs API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 >
 > - Whispering's evolution beyond transcription required changes to the repository's structure and branding.
 > - Everything else remains the same—same tools, same philosophy, same team.
-> - The original app lives on as [*Epicenter Whispering*](https://github.com/EpicenterHQ/epicenter/tree/main/apps/whispering), keeping a tight focus on transcription.
-> - This makes room for standalone apps with complementary, but non-transcription-related features (like [*Epicenter Assistant*](https://github.com/EpicenterHQ/epicenter/tree/main/apps/sh)).
+> - The original app lives on as [_Epicenter Whispering_](https://github.com/EpicenterHQ/epicenter/tree/main/apps/whispering), keeping a tight focus on transcription.
+> - This makes room for standalone apps with complementary, but non-transcription-related features (like [_Epicenter Assistant_](https://github.com/EpicenterHQ/epicenter/tree/main/apps/sh)).
 > - The new [root](https://github.com/EpicenterHQ/epicenter/) of the Epicenter repository contains common files supporting all the apps in the ecosystem.
 > - Note: the old URL [github.com/braden-w/whispering](https://github.com/braden-w/whispering) is now just a thin placeholder redirecting to this rebranded repository.
 >
@@ -92,6 +92,17 @@ Epicenter is an ecosystem of open-source, local-first apps. Our eventual goal is
 
 Our vision is to build a personal workspace where you own your data, choose your models, and replace siloed apps with open, interoperable alternatives. All while preserving authenticity and being free and open source.
 
+## Shared Workspace ID Convention
+
+Epicenter uses stable, shared workspace IDs so multiple apps can collaborate on the same data.
+
+- **Format**: `epicenter.<app>` (for example, `epicenter.whispering`)
+- **Purpose**: Ensures the same workspace is discovered, synced, and shared across Epicenter apps
+- **Stability**: IDs must be globally unique and never change once published
+- **Usage**: The workspace ID is used for routing, persistence paths, Y.Doc IDs, and sharing
+
+When two apps declare the same workspace ID, they intentionally point to the same shared workspace and data.
+
 ## Quick Start
 
 ### Install Epicenter Whispering
@@ -99,6 +110,7 @@ Our vision is to build a personal workspace where you own your data, choose your
 Our first app in the ecosystem. Choose your installation method:
 
 **macOS (Homebrew)**
+
 ```bash
 brew install --cask whispering
 ```
@@ -106,6 +118,7 @@ brew install --cask whispering
 **macOS, Windows, Linux (Direct Download)**
 
 Download the installer for your platform from [GitHub Releases](https://github.com/EpicenterHQ/epicenter/releases/latest):
+
 - macOS: `.dmg` (Apple Silicon or Intel)
 - Windows: `.msi` or `.exe`
 - Linux: `.AppImage`, `.deb`, or `.rpm`

--- a/README.md
+++ b/README.md
@@ -92,17 +92,6 @@ Epicenter is an ecosystem of open-source, local-first apps. Our eventual goal is
 
 Our vision is to build a personal workspace where you own your data, choose your models, and replace siloed apps with open, interoperable alternatives. All while preserving authenticity and being free and open source.
 
-## Shared Workspace ID Convention
-
-Epicenter uses stable, shared workspace IDs so multiple apps can collaborate on the same data.
-
-- **Format**: `epicenter.<app>` (for example, `epicenter.whispering`)
-- **Purpose**: Ensures the same workspace is discovered, synced, and shared across Epicenter apps
-- **Stability**: IDs must be globally unique and never change once published
-- **Usage**: The workspace ID is used for routing, persistence paths, Y.Doc IDs, and sharing
-
-When two apps declare the same workspace ID, they intentionally point to the same shared workspace and data.
-
 ## Quick Start
 
 ### Install Epicenter Whispering

--- a/apps/epicenter/src/lib/components/CreateWorkspaceDialog.svelte
+++ b/apps/epicenter/src/lib/components/CreateWorkspaceDialog.svelte
@@ -241,13 +241,7 @@
 					<Label for="workspace-template">Template</Label>
 					<Select.Root
 						type="single"
-						value={createWorkspaceDialog.selectedTemplateId}
-						onValueChange={(value) => {
-							if (value !== undefined) {
-								createWorkspaceDialog.selectedTemplateId =
-									value as TemplateSelectionId;
-							}
-						}}
+						bind:value={createWorkspaceDialog.selectedTemplateId}
 					>
 						<Select.Trigger
 							id="workspace-template"

--- a/apps/epicenter/src/lib/components/CreateWorkspaceDialog.svelte
+++ b/apps/epicenter/src/lib/components/CreateWorkspaceDialog.svelte
@@ -193,7 +193,6 @@
 	import * as Select from '@epicenter/ui/select';
 	import { Input } from '@epicenter/ui/input';
 	import { Button } from '@epicenter/ui/button';
-	import { Label } from '@epicenter/ui/label';
 	import RotateCcwIcon from '@lucide/svelte/icons/rotate-ccw';
 	import FileTextIcon from '@lucide/svelte/icons/file-text';
 	import LayoutTemplateIcon from '@lucide/svelte/icons/layout-template';
@@ -236,9 +235,9 @@
 				</Dialog.Description>
 			</Dialog.Header>
 
-			<div class="grid gap-4">
+			<Field.Group>
 				<Field.Field>
-					<Label for="workspace-template">Template</Label>
+					<Field.Label for="workspace-template">Template</Field.Label>
 					<Select.Root
 						type="single"
 						bind:value={createWorkspaceDialog.selectedTemplateId}
@@ -276,7 +275,7 @@
 				</Field.Field>
 
 				<Field.Field>
-					<Label for="workspace-name">Workspace Name</Label>
+					<Field.Label for="workspace-name">Workspace Name</Field.Label>
 					<Input
 						id="workspace-name"
 						bind:value={createWorkspaceDialog.name}
@@ -285,22 +284,20 @@
 					/>
 				</Field.Field>
 
-				<Field.Field>
-					<div class="flex items-center justify-between">
-						<Label for="workspace-id">
-							Workspace ID
-							{#if !createWorkspaceDialog.isIdManuallyEdited && createWorkspaceDialog.id}
-								<span class="text-muted-foreground ml-2 text-xs font-normal"
-									>(auto-generated)</span
-								>
-							{/if}
-						</Label>
+				<Field.Field data-invalid={!!createWorkspaceDialog.error}>
+					<Field.Label for="workspace-id">
+						Workspace ID
+						{#if !createWorkspaceDialog.isIdManuallyEdited && createWorkspaceDialog.id}
+							<span class="text-muted-foreground ml-2 text-xs font-normal">
+								(auto-generated)
+							</span>
+						{/if}
 						{#if createWorkspaceDialog.isIdManuallyEdited}
 							<Button
 								type="button"
 								variant="ghost"
 								size="sm"
-								class="h-6 px-2 text-xs"
+								class="ml-auto h-5 px-1.5 text-xs"
 								onclick={() => createWorkspaceDialog.resetId()}
 								disabled={createWorkspaceDialog.isPending}
 							>
@@ -308,7 +305,7 @@
 								Reset
 							</Button>
 						{/if}
-					</div>
+					</Field.Label>
 					<Input
 						id="workspace-id"
 						bind:value={createWorkspaceDialog.id}
@@ -325,7 +322,7 @@
 						</Field.Description>
 					{/if}
 				</Field.Field>
-			</div>
+			</Field.Group>
 
 			<Dialog.Footer>
 				<Button

--- a/apps/epicenter/src/lib/docs/head.ts
+++ b/apps/epicenter/src/lib/docs/head.ts
@@ -44,9 +44,12 @@ import { tauriWorkspacePersistence } from './persistence/tauri-workspace-persist
  * ```
  */
 export function createHead(workspaceId: string) {
-	const baseHead = createHeadDoc({ workspaceId }).withProviders({
-		persistence: (ctx) =>
-			tauriPersistence(ctx.ydoc, ['workspaces', workspaceId, 'head']),
+	const baseHead = createHeadDoc({
+		workspaceId,
+		providers: {
+			persistence: ({ ydoc }) =>
+				tauriPersistence(ydoc, ['workspaces', workspaceId, 'head']),
+		},
 	});
 
 	return {

--- a/apps/epicenter/src/lib/docs/persistence/tauri-persistence.ts
+++ b/apps/epicenter/src/lib/docs/persistence/tauri-persistence.ts
@@ -1,4 +1,4 @@
-import type { ProviderExports } from '@epicenter/hq';
+import { defineExports, type ProviderExports } from '@epicenter/hq';
 import { appLocalDataDir, dirname, join } from '@tauri-apps/api/path';
 import { mkdir, readFile, writeFile } from '@tauri-apps/plugin-fs';
 import * as Y from 'yjs';
@@ -53,10 +53,12 @@ export type TauriPersistenceConfig = {
  * @example
  * ```typescript
  * // In a provider factory
- * export const registry = createRegistryDoc({ registryId: REGISTRY_ID })
- *   .withProviders({
- *     persistence: (ctx) => tauriPersistence(ctx.ydoc, ['registry']),
- *   });
+ * const registry = createRegistryDoc({
+ *   registryId: REGISTRY_ID,
+ *   providers: {
+ *     persistence: ({ ydoc }) => tauriPersistence(ydoc, ['registry']),
+ *   },
+ * });
  * ```
  */
 export function tauriPersistence(
@@ -140,7 +142,7 @@ export function tauriPersistence(
 	// Provider Exports
 	// =========================================================================
 
-	return {
+	return defineExports({
 		whenSynced: (async () => {
 			const { binaryPath, jsonPath } = await pathsPromise;
 
@@ -187,5 +189,5 @@ export function tauriPersistence(
 				saveJson();
 			}
 		},
-	};
+	});
 }

--- a/apps/epicenter/src/lib/docs/persistence/tauri-workspace-persistence.ts
+++ b/apps/epicenter/src/lib/docs/persistence/tauri-workspace-persistence.ts
@@ -1,4 +1,5 @@
 import {
+	defineExports,
 	getWorkspaceDocMaps,
 	type ProviderExports,
 	readDefinitionFromYDoc,
@@ -213,7 +214,7 @@ export function tauriWorkspacePersistence(
 	// Return Provider Exports
 	// =========================================================================
 
-	return {
+	return defineExports({
 		whenSynced: (async () => {
 			const { epochDir, workspaceYjsPath, snapshotsDir } = await pathsPromise;
 
@@ -262,5 +263,5 @@ export function tauriWorkspacePersistence(
 			definitionMap.unobserveDeep(definitionObserverHandler);
 			kvMap.unobserve(kvObserverHandler);
 		},
-	};
+	});
 }

--- a/apps/epicenter/src/lib/docs/reactive-head.svelte.ts
+++ b/apps/epicenter/src/lib/docs/reactive-head.svelte.ts
@@ -1,0 +1,71 @@
+import type { HeadDoc } from '@epicenter/hq';
+import { createSubscriber } from 'svelte/reactivity';
+
+/**
+ * Wrap a HeadDoc with Svelte 5 reactivity.
+ *
+ * All methods and properties pass through to the underlying HeadDoc.
+ * The only addition: `epoch` and `ownEpoch` become reactive getters that
+ * automatically update when the underlying Y.Doc changes.
+ *
+ * Uses `createSubscriber` for lazy subscription management:
+ * - Observer is only attached when `epoch` or `ownEpoch` is read in a reactive context
+ * - Observer is automatically detached when no more reactive consumers exist
+ *
+ * @example
+ * ```typescript
+ * import { createHeadDoc } from '@epicenter/hq';
+ * import { reactiveHeadDoc } from '$lib/docs/reactive-head.svelte';
+ *
+ * const head = reactiveHeadDoc(
+ *   createHeadDoc({
+ *     workspaceId: 'abc123',
+ *     providers: { persistence: ({ ydoc }) => tauriPersistence(ydoc, ['head']) },
+ *   })
+ * );
+ *
+ * // In Svelte component - automatically reactive
+ * $effect(() => {
+ *   console.log('Epoch changed:', head.epoch);
+ * });
+ *
+ * // Mutations work as expected
+ * head.bumpEpoch();  // Triggers the $effect above
+ * ```
+ */
+export function reactiveHeadDoc<T extends HeadDoc<any>>(headDoc: T) {
+	// Shadow state for reactive values
+	let epoch = $state(headDoc.getEpoch());
+	let ownEpoch = $state(headDoc.getOwnEpoch());
+
+	// Lazy subscription via createSubscriber
+	const subscribe = createSubscriber((update) => {
+		// Only attaches observer when someone reads epoch/ownEpoch in a reactive context
+		const unsubscribe = headDoc.observeEpoch((newEpoch) => {
+			epoch = newEpoch;
+			ownEpoch = headDoc.getOwnEpoch();
+			update(); // Signal Svelte that dependencies changed
+		});
+		return unsubscribe;
+	});
+
+	return {
+		// Pass through everything from the original headDoc
+		...headDoc,
+
+		// Reactive getters (shadow the method-based API)
+		get epoch() {
+			subscribe();
+			return epoch;
+		},
+		get ownEpoch() {
+			subscribe();
+			return ownEpoch;
+		},
+	};
+}
+
+/** Reactive HeadDoc wrapper type - inferred from factory function. */
+export type ReactiveHeadDoc<T extends HeadDoc<any>> = ReturnType<
+	typeof reactiveHeadDoc<T>
+>;

--- a/apps/epicenter/src/lib/docs/reactive-registry.svelte.ts
+++ b/apps/epicenter/src/lib/docs/reactive-registry.svelte.ts
@@ -1,0 +1,73 @@
+import type { RegistryDoc } from '@epicenter/hq';
+import { createSubscriber } from 'svelte/reactivity';
+
+/**
+ * Wrap a RegistryDoc with Svelte 5 reactivity.
+ *
+ * All methods and properties pass through to the underlying RegistryDoc.
+ * The only addition: `workspaceIds` and `count` become reactive getters that
+ * automatically update when the underlying Y.Doc changes.
+ *
+ * Uses `createSubscriber` for lazy subscription management:
+ * - Observer is only attached when `workspaceIds` or `count` is read in a reactive context
+ * - Observer is automatically detached when no more reactive consumers exist
+ *
+ * @example
+ * ```typescript
+ * import { createRegistryDoc } from '@epicenter/hq';
+ * import { reactiveRegistryDoc } from '$lib/docs/reactive-registry.svelte';
+ *
+ * const registry = reactiveRegistryDoc(
+ *   createRegistryDoc({
+ *     registryId: 'local',
+ *     providers: { persistence: ({ ydoc }) => tauriPersistence(ydoc, ['registry']) },
+ *   })
+ * );
+ *
+ * // In Svelte component - automatically reactive
+ * $effect(() => {
+ *   console.log('Workspaces:', registry.workspaceIds);
+ * });
+ *
+ * // Mutations work as expected
+ * registry.addWorkspace('new-workspace');  // Triggers the $effect above
+ * ```
+ */
+export function reactiveRegistryDoc<T extends RegistryDoc<any>>(
+	registryDoc: T,
+) {
+	// Shadow state for reactive values
+	let workspaceIds = $state(registryDoc.getWorkspaceIds());
+	let count = $state(registryDoc.count());
+
+	// Lazy subscription via createSubscriber
+	const subscribe = createSubscriber((update) => {
+		// Only attaches observer when someone reads workspaceIds/count in a reactive context
+		const unsubscribe = registryDoc.observe(() => {
+			workspaceIds = registryDoc.getWorkspaceIds();
+			count = registryDoc.count();
+			update(); // Signal Svelte that dependencies changed
+		});
+		return unsubscribe;
+	});
+
+	return {
+		// Pass through everything from the original registryDoc
+		...registryDoc,
+
+		// Reactive getters (shadow the method-based API)
+		get workspaceIds() {
+			subscribe();
+			return workspaceIds;
+		},
+		get count() {
+			subscribe();
+			return count;
+		},
+	};
+}
+
+/** Reactive RegistryDoc wrapper type - inferred from factory function. */
+export type ReactiveRegistryDoc<T extends RegistryDoc<any>> = ReturnType<
+	typeof reactiveRegistryDoc<T>
+>;

--- a/apps/epicenter/src/lib/docs/registry.ts
+++ b/apps/epicenter/src/lib/docs/registry.ts
@@ -9,8 +9,9 @@ const REGISTRY_ID = 'local';
  */
 const baseRegistry = createRegistryDoc({
 	registryId: REGISTRY_ID,
-}).withProviders({
-	persistence: (ctx) => tauriPersistence(ctx.ydoc, ['registry']),
+	providers: {
+		persistence: ({ ydoc }) => tauriPersistence(ydoc, ['registry']),
+	},
 });
 
 /**

--- a/apps/epicenter/src/lib/query/workspaces.ts
+++ b/apps/epicenter/src/lib/query/workspaces.ts
@@ -5,6 +5,7 @@ import { createTaggedError } from 'wellcrafted/error';
 import { Ok } from 'wellcrafted/result';
 import { registry } from '$lib/docs/registry';
 import { createWorkspaceClient } from '$lib/docs/workspace';
+import type { WorkspaceTemplate } from '$lib/templates';
 import { defineMutation, defineQuery, queryClient } from './client';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -114,16 +115,24 @@ export const workspaces = {
 	 *
 	 * Uses `createWorkspaceClient` (static schema mode) because we're seeding
 	 * a new workspace with a known definition.
+	 *
+	 * If a template is provided, the tables and kv from the template are used
+	 * instead of starting with empty collections.
 	 */
 	createWorkspace: defineMutation({
 		mutationKey: ['workspaces', 'create'],
-		mutationFn: async (input: { name: string; id: string }) => {
+		mutationFn: async (input: {
+			name: string;
+			id: string;
+			template: WorkspaceTemplate | null;
+		}) => {
 			// Create definition using the user-provided ID directly
+			// If a template is provided, use its tables and kv
 			const definition: WorkspaceDefinition = {
 				id: input.id,
 				name: input.name,
-				tables: {},
-				kv: {},
+				tables: input.template?.tables ?? {},
+				kv: input.template?.kv ?? {},
 			};
 
 			// Add to registry (persisted automatically via registryPersistence)

--- a/apps/epicenter/src/lib/templates/entries.ts
+++ b/apps/epicenter/src/lib/templates/entries.ts
@@ -1,0 +1,32 @@
+/**
+ * Entries workspace template.
+ *
+ * A general-purpose content management schema with:
+ * - id: unique identifier
+ * - title: entry title
+ * - content: entry body text
+ * - type: categorization tags
+ * - tags: additional tagging
+ */
+
+import { id, table, tags, text } from '@epicenter/hq';
+
+export const ENTRIES_TEMPLATE = {
+	id: 'epicenter.entries',
+	name: 'Entries',
+	tables: {
+		entries: table({
+			name: 'Entries',
+			icon: '📝',
+			description: 'General-purpose content entries',
+			fields: {
+				id: id(),
+				title: text({ name: 'Title', description: 'Entry title' }),
+				content: text({ name: 'Content', description: 'Entry body text' }),
+				type: tags({ name: 'Type', description: 'Entry type/category' }),
+				tags: tags({ name: 'Tags', description: 'Additional tags' }),
+			},
+		}),
+	},
+	kv: {},
+} as const;

--- a/apps/epicenter/src/lib/templates/index.ts
+++ b/apps/epicenter/src/lib/templates/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Workspace templates for pre-configured schemas.
+ *
+ * Templates provide ready-to-use workspace definitions that users can
+ * select when creating a new workspace instead of starting from scratch.
+ */
+
+import { ENTRIES_TEMPLATE } from './entries';
+
+/**
+ * Registry of available workspace templates.
+ *
+ * The 'blank' template is implicit and not listed here.
+ * Add new templates by importing them and adding to this array.
+ */
+export const WORKSPACE_TEMPLATES = [ENTRIES_TEMPLATE] as const;
+
+/**
+ * A workspace template definition.
+ *
+ * Templates are similar to WorkspaceDefinition but with predefined
+ * id, name, tables, and kv that get applied when the user creates
+ * a workspace from this template.
+ */
+export type WorkspaceTemplate = (typeof WORKSPACE_TEMPLATES)[number];

--- a/apps/epicenter/src/lib/templates/index.ts
+++ b/apps/epicenter/src/lib/templates/index.ts
@@ -10,8 +10,9 @@ import { ENTRIES_TEMPLATE } from './entries';
 /**
  * Registry of available workspace templates.
  *
- * The 'blank' template is implicit and not listed here.
  * Add new templates by importing them and adding to this array.
+ * Types are derived from this array, so adding a template automatically
+ * makes its ID available as a valid `WorkspaceTemplateId`.
  */
 export const WORKSPACE_TEMPLATES = [ENTRIES_TEMPLATE] as const;
 
@@ -23,3 +24,25 @@ export const WORKSPACE_TEMPLATES = [ENTRIES_TEMPLATE] as const;
  * a workspace from this template.
  */
 export type WorkspaceTemplate = (typeof WORKSPACE_TEMPLATES)[number];
+
+/**
+ * Valid template IDs derived from the registry.
+ *
+ * This is a string literal union of all template IDs, providing
+ * compile-time safety when referencing templates.
+ */
+export type WorkspaceTemplateId = WorkspaceTemplate['id'];
+
+/**
+ * O(1) lookup map for templates by ID.
+ *
+ * Use this instead of `.find()` for cleaner, more efficient lookups.
+ *
+ * @example
+ * ```typescript
+ * const template = WORKSPACE_TEMPLATE_BY_ID['epicenter.entries'];
+ * ```
+ */
+export const WORKSPACE_TEMPLATE_BY_ID = Object.fromEntries(
+	WORKSPACE_TEMPLATES.map((t) => [t.id, t]),
+) as Record<WorkspaceTemplateId, WorkspaceTemplate>;

--- a/apps/epicenter/src/lib/templates/index.ts
+++ b/apps/epicenter/src/lib/templates/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { ENTRIES_TEMPLATE } from './entries';
+import { WHISPERING_TEMPLATE } from './whispering';
 
 /**
  * Registry of available workspace templates.
@@ -14,7 +15,10 @@ import { ENTRIES_TEMPLATE } from './entries';
  * Types are derived from this array, so adding a template automatically
  * makes its ID available as a valid `WorkspaceTemplateId`.
  */
-export const WORKSPACE_TEMPLATES = [ENTRIES_TEMPLATE] as const;
+export const WORKSPACE_TEMPLATES = [
+	ENTRIES_TEMPLATE,
+	WHISPERING_TEMPLATE,
+] as const;
 
 /**
  * A workspace template definition.

--- a/apps/epicenter/src/lib/templates/whispering.ts
+++ b/apps/epicenter/src/lib/templates/whispering.ts
@@ -1,0 +1,35 @@
+/**
+ * Whispering workspace template.
+ *
+ * Mirrors the core recording schema used by Epicenter Whispering so that
+ * recordings and transcriptions can be shared across apps via a unified
+ * Epicenter workspace.
+ */
+
+import { id, select, table, text } from '@epicenter/hq';
+
+export const WHISPERING_TEMPLATE = {
+	id: 'epicenter.whispering',
+	name: 'Whispering',
+	tables: {
+		recordings: table({
+			name: 'Recordings',
+			icon: '🎙️',
+			description: 'Voice recordings and transcriptions',
+			fields: {
+				id: id(),
+				title: text({ name: 'Title' }),
+				subtitle: text({ name: 'Subtitle' }),
+				timestamp: text({ name: 'Timestamp' }),
+				createdAt: text({ name: 'Created At' }),
+				updatedAt: text({ name: 'Updated At' }),
+				transcribedText: text({ name: 'Transcribed Text' }),
+				transcriptionStatus: select({
+					name: 'Status',
+					options: ['UNPROCESSED', 'TRANSCRIBING', 'DONE', 'FAILED'],
+				}),
+			},
+		}),
+	},
+	kv: {},
+} as const;

--- a/apps/epicenter/src/routes/(home)/+page.svelte
+++ b/apps/epicenter/src/routes/(home)/+page.svelte
@@ -46,8 +46,8 @@
 			<Button
 				onclick={() =>
 					createWorkspaceDialog.open({
-						onConfirm: async ({ name, id }) => {
-							await createWorkspace.mutateAsync({ name, id });
+						onConfirm: async ({ name, id, template }) => {
+							await createWorkspace.mutateAsync({ name, id, template });
 						},
 					})}
 				disabled={createWorkspace.isPending}
@@ -97,8 +97,8 @@
 					<Button
 						onclick={() =>
 							createWorkspaceDialog.open({
-								onConfirm: async ({ name, id }) => {
-									await createWorkspace.mutateAsync({ name, id });
+								onConfirm: async ({ name, id, template }) => {
+									await createWorkspace.mutateAsync({ name, id, template });
 								},
 							})}
 					>

--- a/packages/epicenter/README.md
+++ b/packages/epicenter/README.md
@@ -107,6 +107,17 @@ Yjs supports multiple providers simultaneously. Phone can connect to desktop, la
 
 The architecture is **local-first**: everything works offline, syncs opportunistically, and your data lives in plain files (`.yjs`, SQLite, markdown) that you fully control.
 
+## Shared Workspace ID Convention
+
+Epicenter uses stable, shared workspace IDs so multiple apps can collaborate on the same data.
+
+- **Format**: `epicenter.<app>` (for example, `epicenter.whispering`)
+- **Purpose**: Ensures the same workspace is discovered, synced, and shared across Epicenter apps
+- **Stability**: IDs must be globally unique and never change once published
+- **Usage**: The workspace ID is used for routing, persistence paths, Y.Doc IDs, and sharing
+
+When two apps declare the same workspace ID, they intentionally point to the same shared workspace and data.
+
 ## Quick Start
 
 ### Installation

--- a/packages/epicenter/src/capabilities/persistence/web.ts
+++ b/packages/epicenter/src/capabilities/persistence/web.ts
@@ -1,7 +1,8 @@
 import { IndexeddbPersistence } from 'y-indexeddb';
-import type {
-	CapabilityContext,
-	CapabilityFactory,
+import {
+	type CapabilityContext,
+	type CapabilityFactory,
+	defineCapabilities,
 } from '../../core/capability';
 import type { KvDefinitionMap, TableDefinitionMap } from '../../core/schema';
 
@@ -110,10 +111,10 @@ export const persistence = (<
 
 	// Return exports with whenSynced for the y-indexeddb pattern
 	// This allows the workspace to know when data has been loaded from IndexedDB
-	return {
+	return defineCapabilities({
 		whenSynced: persistence.whenSynced.then(() => {
 			console.log(`[Persistence] IndexedDB synced for ${ydoc.guid}`);
 		}),
 		destroy: () => persistence.destroy(),
-	};
+	});
 }) satisfies CapabilityFactory<TableDefinitionMap, KvDefinitionMap>;

--- a/packages/epicenter/src/core/docs/provider-types.ts
+++ b/packages/epicenter/src/core/docs/provider-types.ts
@@ -93,9 +93,10 @@ export type InferProviderExports<T extends ProviderFactoryMap> = {
  * Helper to define provider exports with proper typing and lifecycle normalization.
  *
  * Automatically fills in missing `whenSynced` and `destroy` fields with defaults.
- * Use this at the return site of your provider factory for explicit lifecycle.
+ * Use this at the return site of your provider factory for explicit type safety.
  *
  * This is an alias for `defineExports()` for consistency with `defineCapabilities()`.
+ * Both can be used interchangeably; choose whichever reads better in your context.
  *
  * @example
  * ```typescript

--- a/packages/epicenter/src/core/lifecycle.ts
+++ b/packages/epicenter/src/core/lifecycle.ts
@@ -25,22 +25,33 @@
  *
  * ## Usage
  *
- * Authors can return plain objects; the framework normalizes at boundaries.
- * Use `defineExports()` when you want to be explicit about lifecycle:
+ * Factory functions are **always synchronous**. Async initialization is tracked
+ * via the returned `whenSynced` promise, not the factory itself.
+ *
+ * Use `defineExports()` for explicit type safety and lifecycle normalization:
  *
  * ```typescript
- * // Simple capability - framework adds defaults
+ * // Simple capability - explicit lifecycle with defaults
  * const simple: CapabilityFactory = ({ tables }) => {
  *   tables.posts.observe({ onAdd: console.log });
- *   // No return needed - framework normalizes to { whenSynced, destroy }
+ *   return defineExports(); // Framework fills in whenSynced and destroy
  * };
  *
- * // Explicit lifecycle - use defineExports for clarity
+ * // Capability with cleanup
  * const withCleanup: CapabilityFactory = ({ ydoc }) => {
  *   const db = new Database(':memory:');
  *   return defineExports({
  *     db,
  *     destroy: () => db.close(),
+ *   });
+ * };
+ *
+ * // Provider with async initialization
+ * const persistence: ProviderFactory = ({ ydoc }) => {
+ *   const provider = new IndexeddbPersistence(ydoc.guid, ydoc);
+ *   return defineExports({
+ *     whenSynced: provider.whenSynced,
+ *     destroy: () => provider.destroy(),
  *   });
  * };
  * ```

--- a/packages/ui/src/table/table-cell.svelte
+++ b/packages/ui/src/table/table-cell.svelte
@@ -6,8 +6,11 @@
 		ref = $bindable(null),
 		class: className,
 		children,
+		variant = 'default',
 		...restProps
-	}: WithElementRef<HTMLTdAttributes> = $props();
+	}: WithElementRef<HTMLTdAttributes> & {
+		variant?: 'default' | 'muted' | 'numeric';
+	} = $props();
 </script>
 
 <td
@@ -15,6 +18,8 @@
 	data-slot="table-cell"
 	class={cn(
 		'whitespace-nowrap bg-clip-padding p-2 align-middle [&:has([role=checkbox])]:pe-0',
+		variant === 'muted' && 'text-muted-foreground',
+		variant === 'numeric' && 'text-right font-mono',
 		className,
 	)}
 	{...restProps}


### PR DESCRIPTION
## Summary

This PR introduces workspace templates to the Epicenter app, allowing users to create new workspaces from predefined schemas (like Whispering's recordings schema). It also simplifies the HeadDoc and RegistryDoc APIs and makes provider/capability factories synchronous-only.

## Architecture

### Workspace Templates System

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                           TEMPLATE SYSTEM                                    │
├─────────────────────────────────────────────────────────────────────────────┤
│                                                                              │
│  templates/index.ts          templates/entries.ts     templates/whispering.ts│
│  ───────────────────         ─────────────────────    ────────────────────── │
│                                                                              │
│  ┌─────────────────┐        ┌─────────────────────┐  ┌────────────────────┐ │
│  │ TEMPLATES Map   │        │ entries schema      │  │ whispering schema  │ │
│  │                 │   ◄────│ • id                │  │ • recordings       │ │
│  │ 'entries'  ─────┼───     │ • title             │  │ • transformations  │ │
│  │ 'whispering' ───┼───     │ • content           │  │ • session settings │ │
│  │ ...             │   ◄────│ • date              │  └────────────────────┘ │
│  └─────────────────┘        └─────────────────────┘                          │
│                                                                              │
│  Usage: TEMPLATES.get(id) → WorkspaceDefinition                             │
│                                                                              │
└─────────────────────────────────────────────────────────────────────────────┘
```

### Simplified Docs API

The HeadDoc and RegistryDoc APIs have been streamlined:

```
BEFORE                              AFTER
──────                              ─────

headDoc.getEpoch()                  head.epoch (getter)
headDoc.bumpEpoch()                 head.bumpEpoch()
headDoc.observeEpoch(cb)            head.observeEpoch(cb)
headDoc.getOwnEpoch()               head.ownEpoch (getter)
headDoc.setOwnEpoch(n)              head.setOwnEpoch(n)
headDoc.getEpochProposals()         REMOVED (internal)
headDoc.ydoc                        head.ydoc

registryDoc.addWorkspace(id)        registry.add(id)
registryDoc.removeWorkspace(id)     registry.remove(id)
registryDoc.hasWorkspace(id)        registry.has(id)
registryDoc.getWorkspaceIds()       registry.ids (getter)
registryDoc.observeWorkspaces(cb)   registry.observe(cb)
registryDoc.ydoc                    registry.ydoc
```

### Synchronous-Only Factories

Provider and capability factories are now **always synchronous**. Async initialization is tracked via the returned `whenSynced` promise:

```typescript
// Factory is synchronous, returns immediately
const persistence: ProviderFactory = ({ ydoc }) => {
  const provider = new IndexeddbPersistence(ydoc.guid, ydoc);
  
  return defineExports({
    whenSynced: provider.whenSynced,  // Async tracked here
    destroy: () => provider.destroy(),
  });
};

// Framework calls factory synchronously, then awaits whenSynced
```

This simplifies the type system and makes initialization order predictable.

## Changes

### New Files
- `apps/epicenter/src/lib/templates/index.ts` - Template registry
- `apps/epicenter/src/lib/templates/entries.ts` - Generic entries schema
- `apps/epicenter/src/lib/templates/whispering.ts` - Whispering schema
- `apps/epicenter/src/lib/docs/reactive-head.svelte.ts` - Svelte 5 reactive head
- `apps/epicenter/src/lib/docs/reactive-registry.svelte.ts` - Svelte 5 reactive registry

### Modified Files
- Simplified `head-doc.ts` and `registry-doc.ts` APIs
- Updated `capability.ts` and `provider-types.ts` for sync-only factories
- Updated web persistence provider
- Added table cell variants in UI package

### Documentation
- Added shared workspace ID convention to epicenter package README

## Shared Workspace ID Convention

Epicenter uses stable, shared workspace IDs so multiple apps can collaborate:

```
Format: epicenter.<app>
Examples: epicenter.whispering, epicenter.crm

Purpose: Same ID → Same data across all Epicenter apps
```

When Whispering and the Epicenter app both use `epicenter.whispering`, they access the same transcriptions, settings, and history.