### PR TITLE
feat(docs): move workspace identity to Head Doc, rename definition to schema

### DIFF
--- a/apps/epicenter/src/lib/docs/persistence/tauri-workspace-persistence.ts
+++ b/apps/epicenter/src/lib/docs/persistence/tauri-workspace-persistence.ts
@@ -58,18 +58,21 @@ const FILE_NAMES = {
  *
  * Persists a workspace Y.Doc with multiple outputs:
  * - `workspace.yjs` - Full Y.Doc binary for sync
- * - `definition.json` - Human-readable schema (git-friendly)
+ * - `schema.json` - Human-readable table/KV schemas (git-friendly)
  * - `kv.json` - Human-readable settings
  *
  * **Storage Layout:**
  * ```
  * {appLocalDataDir}/workspaces/{workspaceId}/{epoch}/
  * ├── workspace.yjs
- * ├── definition.json
+ * ├── schema.json
  * ├── kv.json
  * └── snapshots/
  *     └── {unix-ms}.ysnap
  * ```
+ *
+ * Note: Workspace identity (name, icon, description) lives in Head Doc's
+ * Y.Map('meta'), not in the Workspace Doc.
  *
  * Note: Unlike the Node.js version, this does NOT include SQLite persistence
  * since Tauri apps use a different approach for database access.

--- a/apps/epicenter/src/lib/docs/workspace.ts
+++ b/apps/epicenter/src/lib/docs/workspace.ts
@@ -5,9 +5,10 @@ import { tauriWorkspacePersistence } from './persistence/tauri-workspace-persist
 /**
  * Create a workspace client with persistence (static schema mode).
  *
- * **Use this for creating NEW workspaces** where you have a known definition
- * to seed into the Y.Doc. The definition is merged into Y.Map('definition')
- * after persistence loads.
+ * **Use this for creating NEW workspaces** where you have a known schema
+ * to seed into the Y.Doc. The schema is merged into Y.Map('schema')
+ * after persistence loads. Workspace identity (name, icon) should be
+ * set separately via Head Doc's setMeta().
  *
  * **For loading EXISTING workspaces**, use the fluent API instead:
  * ```typescript
@@ -27,11 +28,14 @@ import { tauriWorkspacePersistence } from './persistence/tauri-workspace-persist
  * ```
  * {appLocalDataDir}/workspaces/{workspaceId}/{epoch}/
  * ├── workspace.yjs      # Full Y.Doc binary (sync source of truth)
- * ├── definition.json    # Schema from Y.Map('definition')
+ * ├── schema.json        # Table/KV schemas from Y.Map('schema')
  * └── kv.json            # Settings from Y.Map('kv')
  * ```
  *
- * @param definition - The workspace definition (id, name, tables, kv) to seed
+ * Note: Workspace identity (name, icon, description) lives in Head Doc's
+ * Y.Map('meta'), not in the Workspace Doc.
+ *
+ * @param definition - The workspace definition (id, tables, kv) to seed
  * @param epoch - The epoch number (usually 0 for new workspaces)
  * @returns A workspace client with persistence pre-configured
  *
@@ -39,12 +43,16 @@ import { tauriWorkspacePersistence } from './persistence/tauri-workspace-persist
  * ```typescript
  * const definition: WorkspaceDefinition = {
  *   id: 'my-workspace',
- *   name: 'My Workspace',
  *   tables: {},
  *   kv: {},
  * };
  *
  * registry.addWorkspace(definition.id);
+ * // Set identity in Head Doc
+ * const head = registry.head(definition.id);
+ * await head.whenSynced;
+ * head.setMeta({ name: 'My Workspace', icon: null, description: '' });
+ * // Create client with schema
  * const client = createWorkspaceClient(definition, 0);
  * await client.whenSynced;
  * ```

--- a/apps/epicenter/src/routes/(workspace)/workspaces/[id]/+layout.ts
+++ b/apps/epicenter/src/routes/(workspace)/workspaces/[id]/+layout.ts
@@ -10,8 +10,9 @@ import type { LayoutLoad } from './$types';
  * 2. Create client via fluent chain: registry.head(id).client()
  * 3. Client loads schema from Y.Doc (dynamic schema mode)
  *
- * This eliminates the need to read definition.json from disk.
- * The schema lives in Y.Map('definition') inside the Y.Doc itself.
+ * This eliminates the need to read schema.json from disk.
+ * The schema lives in Y.Map('schema') inside the Y.Doc itself.
+ * Workspace identity (name, icon) comes from Head Doc's Y.Map('meta').
  */
 export const load: LayoutLoad = async ({ params }) => {
 	const workspaceId = params.id;
@@ -31,11 +32,13 @@ export const load: LayoutLoad = async ({ params }) => {
 	console.log(`[Layout] Workspace epoch: ${epoch}`);
 
 	// Step 3: Create client via fluent API (dynamic schema mode)
-	// Schema comes from Y.Doc, not from definition.json file
+	// Schema comes from Y.Doc, not from schema.json file
 	const client = head.client();
 	await client.whenSynced;
 
-	console.log(`[Layout] Loaded workspace: ${client.name} (${client.id})`);
+	// Get workspace name from Head Doc's meta (not from client)
+	const meta = head.getMeta();
+	console.log(`[Layout] Loaded workspace: ${meta.name} (${client.id})`);
 
 	return {
 		/** The live workspace client for CRUD operations. */

--- a/packages/epicenter/src/core/docs/README.md
+++ b/packages/epicenter/src/core/docs/README.md
@@ -67,12 +67,18 @@ A single Y.Doc per workspace seems simpler, but creates problems:
 │  ID: {workspaceId}                                               │
 │  Scope: Shared (syncs with all workspace collaborators)          │
 │                                                                  │
+│  Y.Map('meta')                                                   │
+│    ├── name: string         // "My Workspace"                    │
+│    ├── icon: IconDefinition | null                               │
+│    └── description: string                                       │
+│                                                                  │
 │  Y.Map('epochs')                                                 │
 │    └── {clientId}: number   // Per-client epoch proposals        │
 │                                                                  │
-│  getEpoch() → max(all values)                                    │
+│  getMeta() → { name, icon, description }                         │
+│  getEpoch() → max(all epoch values)                              │
 │                                                                  │
-│  Purpose: "What's the current data epoch?"                       │
+│  Purpose: "What is this workspace? What's the current epoch?"    │
 └─────────────────────────────────────────────────────────────────┘
                               │
                               │ Read epoch, compute Workspace Doc ID
@@ -82,19 +88,19 @@ A single Y.Doc per workspace seems simpler, but creates problems:
 │  ID: {workspaceId}-{epoch}                                       │
 │  Scope: Shared (syncs with all workspace collaborators)          │
 │                                                                  │
-│  Y.Map('meta')                                                   │
-│    ├── name: "My Workspace"                                      │
-│    └── slug: "my-workspace"                                      │
-│                                                                  │
 │  Y.Map('schema')                                                 │
-│    ├── tables: Y.Map<tableName, {                                │
+│    ├── tables: { [tableName]: {                                  │
 │    │     name: string,                                           │
 │    │     icon: IconDefinition | null,                            │
-│    │     cover: CoverDefinition | null,                          │
 │    │     description: string,                                    │
-│    │     fields: Y.Map<fieldName, FieldSchema>                   │
-│    │   }>                                                        │
-│    └── kv: Y.Map<keyName, FieldSchema>                           │
+│    │     fields: { [fieldName]: FieldSchema }                    │
+│    │   }}                                                        │
+│    └── kv: { [keyName]: {                                        │
+│          name: string,                                           │
+│          icon: IconDefinition | null,                            │
+│          description: string,                                    │
+│          field: FieldSchema                                      │
+│        }}                                                        │
 │                                                                  │
 │  Y.Map('tables')                                                 │
 │    └── {tableName}: Y.Map<rowId, Y.Map<fieldName, value>>        │
@@ -102,7 +108,7 @@ A single Y.Doc per workspace seems simpler, but creates problems:
 │  Y.Map('kv')                                                     │
 │    └── {keyName}: value                                          │
 │                                                                  │
-│  Purpose: "All the actual workspace data"                        │
+│  Purpose: "Schema + data for this epoch"                         │
 └─────────────────────────────────────────────────────────────────┘
 ```
 

--- a/packages/epicenter/src/core/docs/head-doc.ts
+++ b/packages/epicenter/src/core/docs/head-doc.ts
@@ -5,6 +5,26 @@ import type {
 	Lifecycle,
 	ProviderFactoryMap,
 } from './provider-types.js';
+import type { IconDefinition } from './workspace-doc.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Workspace Meta Type
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Workspace identity metadata stored in the Head Doc.
+ *
+ * This is separate from the schema/data (which lives in Workspace Docs)
+ * because renaming a workspace should apply to all epochs immediately.
+ */
+export type WorkspaceMeta = {
+	/** Display name of the workspace */
+	name: string;
+	/** Optional icon (emoji, Lucide icon name, or URL) */
+	icon: IconDefinition | null;
+	/** Optional description */
+	description: string;
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Head Doc
@@ -101,6 +121,7 @@ export function createHeadDoc<T extends ProviderFactoryMap>(options: {
 	const { workspaceId, providers: providerFactories } = options;
 	const ydoc = options.ydoc ?? new Y.Doc({ guid: workspaceId });
 	const epochsMap = ydoc.getMap<number>('epochs');
+	const metaMap = ydoc.getMap<string | IconDefinition | null>('meta');
 
 	// Initialize providers synchronously — async work is in their whenSynced
 	const providers = {} as InferProviderExports<T>;
@@ -334,6 +355,121 @@ export function createHeadDoc<T extends ProviderFactoryMap>(options: {
 
 			epochsMap.observeDeep(handler);
 			return () => epochsMap.unobserveDeep(handler);
+		},
+
+		// ─────────────────────────────────────────────────────────────────────────
+		// Meta (Workspace Identity)
+		// ─────────────────────────────────────────────────────────────────────────
+
+		/**
+		 * Get the workspace metadata (name, icon, description).
+		 *
+		 * These values are shared across all epochs and collaborators.
+		 * Renaming a workspace applies immediately to everyone.
+		 *
+		 * @returns The workspace meta object
+		 *
+		 * @example
+		 * ```typescript
+		 * const meta = head.getMeta();
+		 * console.log(meta.name);        // "Whispering"
+		 * console.log(meta.icon);        // { type: 'emoji', value: '🎙️' }
+		 * console.log(meta.description); // "Voice recordings"
+		 * ```
+		 */
+		getMeta(): WorkspaceMeta {
+			return {
+				name: (metaMap.get('name') as string) ?? '',
+				icon: (metaMap.get('icon') as IconDefinition | null) ?? null,
+				description: (metaMap.get('description') as string) ?? '',
+			};
+		},
+
+		/**
+		 * Set the workspace metadata.
+		 *
+		 * Only the provided fields are updated; others are left unchanged.
+		 * Changes sync to all collaborators via CRDT.
+		 *
+		 * @param meta - Partial meta object with fields to update
+		 *
+		 * @example
+		 * ```typescript
+		 * // Update just the name
+		 * head.setMeta({ name: 'My Workspace' });
+		 *
+		 * // Update multiple fields
+		 * head.setMeta({
+		 *   name: 'Whispering',
+		 *   icon: { type: 'emoji', value: '🎙️' },
+		 *   description: 'Voice recordings and transcriptions',
+		 * });
+		 * ```
+		 */
+		setMeta(meta: Partial<WorkspaceMeta>): void {
+			if (meta.name !== undefined) {
+				metaMap.set('name', meta.name);
+			}
+			if (meta.icon !== undefined) {
+				metaMap.set('icon', meta.icon);
+			}
+			if (meta.description !== undefined) {
+				metaMap.set('description', meta.description);
+			}
+		},
+
+		/**
+		 * Observe workspace metadata changes.
+		 *
+		 * Fires when any meta field (name, icon, description) changes.
+		 * The callback receives the full meta object.
+		 *
+		 * @param callback - Function called with the new meta when it changes
+		 * @returns Unsubscribe function
+		 *
+		 * @example
+		 * ```typescript
+		 * const unsubscribe = head.observeMeta((meta) => {
+		 *   console.log(`Workspace renamed to: ${meta.name}`);
+		 *   // Update UI, document title, etc.
+		 * });
+		 *
+		 * // Later: stop observing
+		 * unsubscribe();
+		 * ```
+		 */
+		observeMeta(callback: (meta: WorkspaceMeta) => void) {
+			const handler = () => {
+				callback(this.getMeta());
+			};
+
+			metaMap.observeDeep(handler);
+			return () => metaMap.unobserveDeep(handler);
+		},
+
+		/**
+		 * Check if workspace metadata has been initialized.
+		 *
+		 * Useful for migration: if meta is empty, you may need to
+		 * copy name/icon/description from an older Workspace Doc.
+		 *
+		 * @returns true if meta has at least a name set
+		 *
+		 * @example
+		 * ```typescript
+		 * if (!head.hasMeta()) {
+		 *   // Migrate from old Workspace Doc
+		 *   const oldMeta = workspaceDoc.getDefinition();
+		 *   head.setMeta({
+		 *     name: oldMeta.name,
+		 *     icon: oldMeta.icon,
+		 *     description: oldMeta.description,
+		 *   });
+		 * }
+		 * ```
+		 */
+		hasMeta(): boolean {
+			return metaMap.has('name') && (metaMap.get('name') as string) !== '';
 		},
 
 		/**

--- a/packages/epicenter/src/core/docs/head-doc.ts
+++ b/packages/epicenter/src/core/docs/head-doc.ts
@@ -458,12 +458,11 @@ export function createHeadDoc<T extends ProviderFactoryMap>(options: {
 		 * @example
 		 * ```typescript
 		 * if (!head.hasMeta()) {
-		 *   // Migrate from old Workspace Doc
-		 *   const oldMeta = workspaceDoc.getDefinition();
+		 *   // Set initial identity for new workspace
 		 *   head.setMeta({
-		 *     name: oldMeta.name,
-		 *     icon: oldMeta.icon,
-		 *     description: oldMeta.description,
+		 *     name: 'My Workspace',
+		 *     icon: null,
+		 *     description: '',
 		 *   });
 		 * }
 		 * ```

--- a/packages/epicenter/src/core/docs/index.ts
+++ b/packages/epicenter/src/core/docs/index.ts
@@ -1,4 +1,4 @@
-export { createHeadDoc, type HeadDoc } from './head-doc';
+export { createHeadDoc, type HeadDoc, type WorkspaceMeta } from './head-doc';
 export {
 	defineExports,
 	type InferProviderExports,
@@ -9,15 +9,15 @@ export {
 	type ProviderFactoryMap,
 } from './provider-types';
 export {
-	type DefinitionMap,
 	getWorkspaceDocMaps,
 	type IconDefinition,
 	type KvMap,
-	mergeDefinitionIntoYDoc,
+	mergeSchemaIntoYDoc,
 	type RowMap,
-	readDefinitionFromYDoc,
+	readSchemaFromYDoc,
+	type SchemaMap,
 	type TableMap,
 	type TablesMap,
 	WORKSPACE_DOC_MAPS,
-	type WorkspaceDefinitionMap,
+	type WorkspaceSchemaMap,
 } from './workspace-doc';

--- a/packages/epicenter/src/index.ts
+++ b/packages/epicenter/src/index.ts
@@ -46,8 +46,6 @@ export {
 } from './core/actions';
 // Y.Doc wrappers for collaborative workspace architecture
 export type {
-	// Workspace doc structure types
-	DefinitionMap,
 	HeadDoc,
 	InferProviderExports,
 	KvMap,
@@ -56,16 +54,17 @@ export type {
 	ProviderFactory,
 	ProviderFactoryMap,
 	RowMap,
+	SchemaMap,
 	TableMap,
 	TablesMap,
-	WorkspaceDefinitionMap,
+	WorkspaceMeta,
+	WorkspaceSchemaMap,
 } from './core/docs';
 export {
 	createHeadDoc,
 	getWorkspaceDocMaps,
-	mergeDefinitionIntoYDoc,
-	readDefinitionFromYDoc,
-	// Workspace doc helpers
+	mergeSchemaIntoYDoc,
+	readSchemaFromYDoc,
 	WORKSPACE_DOC_MAPS,
 } from './core/docs';
 export type { ExtensionError } from './core/errors';

--- a/specs/20260121T231500-doc-architecture-v2.md
+++ b/specs/20260121T231500-doc-architecture-v2.md
@@ -1,0 +1,694 @@
+# Document Architecture v2
+
+**Status**: Design In Progress  
+**Created**: 2026-01-21  
+**Updated**: 2026-01-21  
+**Purpose**: Define the three-doc architecture for local, relay, and cloud modes  
+**Related**:
+
+- [specs/20260121T170000-sync-architecture.md](./20260121T170000-sync-architecture.md)
+- [specs/20260121T222800-registry-and-sync-ux.md](./20260121T222800-registry-and-sync-ux.md)
+
+---
+
+## Executive Summary
+
+Epicenter uses a **three-document architecture** where each document type has a specific scope and sync behavior:
+
+| Document          | Scope         | Contains                     | Syncs Via         |
+| ----------------- | ------------- | ---------------------------- | ----------------- |
+| **Registry Doc**  | Per user      | Workspace list + preferences | Local/Relay only  |
+| **Head Doc**      | Per workspace | Identity + epoch             | Local/Relay/Cloud |
+| **Workspace Doc** | Per epoch     | Schema + data                | Local/Relay/Cloud |
+
+### Key Changes from v1
+
+1. **Name/icon moved to Head Doc** — Workspace identity is now separate from per-epoch schema
+2. **Cloud uses NanoID doc IDs** — Simpler, globally unique without encoding org
+3. **Registry is local-only in cloud mode** — Cloud workspaces come from server API
+4. **Schema stays per-epoch** — Epochs exist for schema migrations
+
+---
+
+## Document Hierarchy
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         THREE-DOC HIERARCHY                                  │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  REGISTRY DOC                                                                │
+│  "Which workspaces do I have?"                                              │
+│  ────────────────────────────────────────────────────────────────────────   │
+│  Scope: Per user                                                             │
+│  Syncs: Local/Relay only (NOT in cloud mode)                                │
+│                                                                              │
+│       │                                                                      │
+│       │ lists                                                                │
+│       ▼                                                                      │
+│                                                                              │
+│  HEAD DOC (one per workspace)                                               │
+│  "What is this workspace? What epoch?"                                      │
+│  ────────────────────────────────────────────────────────────────────────   │
+│  Scope: Per workspace (shared with collaborators)                           │
+│  Syncs: Local/Relay/Cloud                                                   │
+│                                                                              │
+│       │                                                                      │
+│       │ points to                                                            │
+│       ▼                                                                      │
+│                                                                              │
+│  WORKSPACE DOC (one per epoch)                                              │
+│  "What's the schema? What's the data?"                                      │
+│  ────────────────────────────────────────────────────────────────────────   │
+│  Scope: Per epoch (shared with collaborators)                               │
+│  Syncs: Local/Relay/Cloud                                                   │
+│                                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Document Structures
+
+### Registry Doc
+
+**Purpose**: Track which workspaces the user has access to, plus UI preferences.
+
+**Scope**: Per user. In local/relay mode, syncs across user's devices. In cloud mode, not used (server API provides workspace list).
+
+```typescript
+// Registry Doc Structure
+Y.Doc {
+  guid: 'local:registry'  // or 'registry' for simplicity
+
+  Y.Map('workspaces')
+  └── workspaceId: true   // Set of workspace IDs
+
+  Y.Map('preferences')
+  └── workspaceId: {
+        pinned: boolean,
+        order: number,
+        hidden: boolean,
+      }
+}
+```
+
+**Example:**
+
+```
+Y.Map('workspaces')
+├── "epicenter.whispering": true
+└── "my-notes": true
+
+Y.Map('preferences')
+├── "epicenter.whispering": { pinned: true, order: 0, hidden: false }
+└── "my-notes": { pinned: false, order: 1, hidden: false }
+```
+
+---
+
+### Head Doc
+
+**Purpose**: Store workspace identity (name, icon) and current epoch pointer.
+
+**Scope**: Per workspace. Shared with all collaborators. Changes apply to all epochs.
+
+```typescript
+// Head Doc Structure
+Y.Doc {
+  guid: '{workspaceId}'           // Local/Relay: "epicenter.whispering"
+     // or '{nanoId}'              // Cloud: "abc123xyz789qwe"
+
+  Y.Map('meta')
+  ├── name: string                // "Whispering"
+  ├── icon: IconDefinition | null // { type: 'emoji', value: '🎙️' }
+  └── description: string         // "Voice recordings and transcriptions"
+
+  Y.Map('epochs')
+  └── clientId: number            // Per-client epoch proposals (CRDT pattern)
+}
+```
+
+**Example:**
+
+```
+Y.Map('meta')
+├── name: "Whispering"
+├── icon: { type: "emoji", value: "🎙️" }
+└── description: "Voice recordings and transcriptions"
+
+Y.Map('epochs')
+├── "1090160253": 2
+├── "2847291038": 2
+└── "9182736450": 2
+
+getEpoch() → max(2, 2, 2) → 2
+```
+
+**Why name/icon are in Head Doc:**
+
+- Renaming applies to all epochs immediately
+- No duplication across epochs
+- Can list workspaces without loading every Workspace Doc
+
+---
+
+### Workspace Doc
+
+**Purpose**: Store schema and data for a specific epoch.
+
+**Scope**: Per epoch. Shared with all collaborators. Frozen when epoch bumps.
+
+```typescript
+// Workspace Doc Structure
+Y.Doc {
+  guid: '{workspaceId}-{epoch}'   // Local/Relay: "epicenter.whispering-0"
+     // or '{nanoId}-{epoch}'      // Cloud: "abc123xyz789qwe-0"
+
+  Y.Map('schema')
+  ├── tables: {
+  │     [tableName]: {
+  │       name: string,
+  │       description: string,
+  │       fields: { [fieldName]: FieldSchema }
+  │     }
+  │   }
+  └── kv: {
+        [keyName]: {
+          name: string,
+          description: string,
+          field: FieldSchema
+        }
+      }
+
+  Y.Map('tables')
+  └── [tableName]: Y.Map<rowId, Y.Map<fieldName, value>>
+
+  Y.Map('kv')
+  └── [keyName]: value
+}
+```
+
+**Example:**
+
+```
+Y.Map('schema')
+└── tables:
+    └── recordings:
+        ├── name: "Recordings"
+        ├── description: "Voice recordings"
+        └── fields:
+            ├── id: { type: "id" }
+            ├── title: { type: "text" }
+            ├── audio: { type: "text" }  // file path
+            └── createdAt: { type: "date" }
+
+Y.Map('tables')
+└── recordings:
+    ├── "rec_001": { id: "rec_001", title: "Meeting notes", ... }
+    └── "rec_002": { id: "rec_002", title: "Voice memo", ... }
+
+Y.Map('kv')
+├── theme: "dark"
+└── language: "en"
+```
+
+**Why schema is per-epoch:**
+
+- Epochs exist for schema migrations
+- Breaking schema changes require new epoch
+- Old epochs are frozen with their original schema
+- Can view historical data as it was structured
+
+---
+
+## Doc ID Conventions
+
+### Local/Relay Mode (Human-Readable)
+
+| Document  | ID Pattern              | Example                  |
+| --------- | ----------------------- | ------------------------ |
+| Registry  | `registry`              | `registry`               |
+| Head      | `{workspaceId}`         | `epicenter.whispering`   |
+| Workspace | `{workspaceId}-{epoch}` | `epicenter.whispering-0` |
+
+### Cloud Mode (NanoID)
+
+| Document  | ID Pattern         | Example                |
+| --------- | ------------------ | ---------------------- |
+| Registry  | N/A (not used)     | N/A                    |
+| Head      | `{nanoId}`         | `abc123xyz789qwerty`   |
+| Workspace | `{nanoId}-{epoch}` | `abc123xyz789qwerty-0` |
+
+**Why NanoID for cloud:**
+
+- Globally unique without encoding org
+- Simpler (no colons or special characters)
+- Server maps human-readable ID to NanoID
+- 21 characters = ~149 years of unique IDs at 1000/second
+
+---
+
+## Data Flows
+
+### Local/Relay Mode
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         LOCAL/RELAY MODE DATA FLOW                           │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  STEP 1: Load Registry Doc                                                   │
+│  ─────────────────────────                                                   │
+│  Source: Local storage (+ relay sync if connected)                          │
+│  Doc ID: "registry"                                                          │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────┐    │
+│  │  Registry Doc                                                        │    │
+│  │  └── workspaces: ["epicenter.whispering", "my-notes"]               │    │
+│  └─────────────────────────────────────────────────────────────────────┘    │
+│                                                                              │
+│  → Output: ['epicenter.whispering', 'my-notes']                             │
+│                                                                              │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  STEP 2: Load Head Doc (per workspace)                                       │
+│  ─────────────────────────────────────                                       │
+│  Source: Local storage (+ relay sync if connected)                          │
+│  Doc ID: "{workspaceId}"                                                    │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────┐    │
+│  │  Head Doc (epicenter.whispering)                                     │    │
+│  │  ├── meta: { name: "Whispering", icon: {...} }                      │    │
+│  │  └── epochs: { clientId: 0 }                                        │    │
+│  └─────────────────────────────────────────────────────────────────────┘    │
+│                                                                              │
+│  → Output: { name: "Whispering", epoch: 0 }                                 │
+│                                                                              │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  STEP 3: Load Workspace Doc                                                  │
+│  ─────────────────────────────                                               │
+│  Source: Local storage (+ relay sync if connected)                          │
+│  Doc ID: "{workspaceId}-{epoch}"                                            │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────┐    │
+│  │  Workspace Doc (epicenter.whispering-0)                              │    │
+│  │  ├── schema: { tables: {...}, kv: {...} }                           │    │
+│  │  ├── tables: { recordings: {...} }                                  │    │
+│  │  └── kv: { theme: "dark" }                                          │    │
+│  └─────────────────────────────────────────────────────────────────────┘    │
+│                                                                              │
+│  → Output: Ready to use workspace client                                    │
+│                                                                              │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  SYNC BEHAVIOR                                                               │
+│  ─────────────                                                               │
+│  All three docs sync via Y-Sweet to self-hosted relay (if connected)       │
+│                                                                              │
+│  ┌──────────┐     ┌──────────┐     ┌──────────┐                            │
+│  │ Device A │ ←──→│  Relay   │←──→ │ Device B │                            │
+│  │          │     │ (Y-Sweet)│     │          │                            │
+│  └──────────┘     └──────────┘     └──────────┘                            │
+│                                                                              │
+│  Registry, Head, and Workspace docs all sync                                │
+│                                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Cloud Mode
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         CLOUD MODE DATA FLOW                                 │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  STEP 1: Fetch Workspace List from Server                                    │
+│  ────────────────────────────────────────                                    │
+│  Source: Server API (authenticated)                                         │
+│  Endpoint: GET /api/orgs/{orgId}/workspaces                                 │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────┐    │
+│  │  Server Response                                                     │    │
+│  │  {                                                                   │    │
+│  │    workspaces: [                                                     │    │
+│  │      {                                                               │    │
+│  │        workspaceId: "epicenter.whispering",  // Human-readable      │    │
+│  │        docId: "abc123xyz789qwerty",          // NanoID for Y-Sweet  │    │
+│  │        name: "Whispering",                   // Cached from Head    │    │
+│  │        icon: { type: "emoji", value: "🎙️" } // Cached from Head    │    │
+│  │      }                                                               │    │
+│  │    ]                                                                 │    │
+│  │  }                                                                   │    │
+│  └─────────────────────────────────────────────────────────────────────┘    │
+│                                                                              │
+│  → Output: Workspace list with doc IDs                                      │
+│                                                                              │
+│  NOTE: No Registry Doc in cloud mode! Server is the source of truth.        │
+│                                                                              │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  STEP 2: Load Head Doc via Y-Sweet                                          │
+│  ─────────────────────────────────                                           │
+│  Source: Y-Sweet (Epicenter Cloud)                                          │
+│  Doc ID: "{nanoId}" (from server response)                                  │
+│                                                                              │
+│  2a. Request Y-Sweet token from server                                      │
+│      POST /api/y-sweet/token { docId: "abc123xyz789qwerty" }               │
+│                                                                              │
+│  2b. Connect to Y-Sweet with token                                          │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────┐    │
+│  │  Head Doc (abc123xyz789qwerty)                                       │    │
+│  │  ├── meta: { name: "Whispering", icon: {...} }                      │    │
+│  │  └── epochs: { clientId: 0 }                                        │    │
+│  └─────────────────────────────────────────────────────────────────────┘    │
+│                                                                              │
+│  → Output: { name: "Whispering", epoch: 0 }                                 │
+│                                                                              │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  STEP 3: Load Workspace Doc via Y-Sweet                                     │
+│  ──────────────────────────────────────                                      │
+│  Source: Y-Sweet (Epicenter Cloud)                                          │
+│  Doc ID: "{nanoId}-{epoch}"                                                 │
+│                                                                              │
+│  3a. Request Y-Sweet token from server                                      │
+│      POST /api/y-sweet/token { docId: "abc123xyz789qwerty-0" }             │
+│                                                                              │
+│  3b. Connect to Y-Sweet with token                                          │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────┐    │
+│  │  Workspace Doc (abc123xyz789qwerty-0)                                │    │
+│  │  ├── schema: { tables: {...}, kv: {...} }                           │    │
+│  │  ├── tables: { recordings: {...} }                                  │    │
+│  │  └── kv: { theme: "dark" }                                          │    │
+│  └─────────────────────────────────────────────────────────────────────┘    │
+│                                                                              │
+│  → Output: Ready to use workspace client                                    │
+│                                                                              │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  SYNC BEHAVIOR                                                               │
+│  ─────────────                                                               │
+│  Head and Workspace docs sync via Y-Sweet (Epicenter Cloud)                 │
+│                                                                              │
+│  ┌──────────┐     ┌──────────────────┐     ┌──────────┐                    │
+│  │ Device A │ ←──→│  Epicenter Cloud │←──→ │ Device B │                    │
+│  │          │     │  (Y-Sweet + S3)  │     │          │                    │
+│  └──────────┘     └──────────────────┘     └──────────┘                    │
+│                                                                              │
+│  Registry is NOT synced; workspace list comes from server API              │
+│                                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Side-by-Side Comparison
+
+| Aspect                    | Local/Relay Mode         | Cloud Mode             |
+| ------------------------- | ------------------------ | ---------------------- |
+| **Workspace list source** | Local Registry Doc       | Server API             |
+| **Registry Doc syncs?**   | Yes (via relay)          | No (not used)          |
+| **Head Doc syncs?**       | Yes (via relay)          | Yes (via Y-Sweet)      |
+| **Workspace Doc syncs?**  | Yes (via relay)          | Yes (via Y-Sweet)      |
+| **Doc ID format**         | Human-readable           | NanoID                 |
+| **Head Doc ID**           | `epicenter.whispering`   | `abc123xyz789qwerty`   |
+| **Workspace Doc ID**      | `epicenter.whispering-0` | `abc123xyz789qwerty-0` |
+| **Auth required?**        | No                       | Yes (Better Auth)      |
+| **Multi-org support?**    | No                       | Yes                    |
+
+---
+
+## Server Database Schema (Cloud Mode)
+
+```sql
+-- Workspace registry: maps human-readable IDs to NanoIDs
+CREATE TABLE workspace_registry (
+  doc_id TEXT PRIMARY KEY,              -- NanoID: "abc123xyz789qwerty"
+  workspace_id TEXT NOT NULL,           -- Human-readable: "epicenter.whispering"
+  organization_id TEXT NOT NULL,        -- Org: "org_alice_personal"
+
+  -- Cached from Head Doc (denormalized for fast listing)
+  name TEXT,                            -- "Whispering"
+  icon JSONB,                           -- { type: "emoji", value: "🎙️" }
+  description TEXT,                     -- "Voice recordings"
+
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW(),
+
+  UNIQUE(organization_id, workspace_id) -- One workspace ID per org
+);
+
+-- Index for listing workspaces by org
+CREATE INDEX idx_workspace_registry_org ON workspace_registry(organization_id);
+```
+
+**Note**: `name`, `icon`, `description` are cached copies of what's in the Head Doc. They're denormalized for fast workspace listing without loading every Head Doc.
+
+When a Head Doc changes, the server should update the cache (via Y-Sweet webhook or periodic sync).
+
+---
+
+## Static vs Dynamic Workspaces
+
+### Static Workspaces
+
+Defined in code (e.g., Whispering):
+
+```typescript
+// apps/whispering/src/lib/workspace.ts
+export const whisperingWorkspace = defineWorkspace({
+	id: 'epicenter.whispering',
+	tables: {
+		recordings: { id: id(), title: text(), audio: text() },
+	},
+	kv: {},
+});
+```
+
+**Characteristics:**
+
+- Schema comes from code
+- Always available (app knows about it)
+- In local mode: auto-created on first run
+- In cloud mode: created when user first uses the app
+
+### Dynamic Workspaces
+
+Created by users at runtime:
+
+```typescript
+// User clicks "Create Workspace" in UI
+const newWorkspace = await createDynamicWorkspace({
+	name: 'My Notes',
+	tables: { notes: { id: id(), content: text() } },
+});
+```
+
+**Characteristics:**
+
+- Schema defined by user (or from template)
+- Must be registered to be discovered
+- In local mode: added to Registry Doc
+- In cloud mode: added to server DB
+
+---
+
+## Epoch Mechanics
+
+### What Triggers an Epoch Bump?
+
+| Trigger             | Epoch Bump Needed? | Why?                |
+| ------------------- | ------------------ | ------------------- |
+| Add optional column | No                 | Backward compatible |
+| Add required column | Yes                | Breaking change     |
+| Remove column       | Yes                | Data loss           |
+| Rename column       | Yes                | Schema mismatch     |
+| Compact Y.Doc       | Yes                | Fresh document      |
+| Corruption recovery | Yes                | Start fresh         |
+
+### Epoch Bump Flow
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         EPOCH BUMP FLOW                                      │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  1. Create new Workspace Doc at epoch N+1                                   │
+│     Doc ID: "epicenter.whispering-1"                                        │
+│                                                                              │
+│  2. Migrate data from epoch N to epoch N+1                                  │
+│     (Apply schema transformations)                                          │
+│                                                                              │
+│  3. Bump epoch in Head Doc                                                  │
+│     head.bumpEpoch() → writes to Y.Map('epochs')                           │
+│                                                                              │
+│  4. All clients observe epoch change                                        │
+│     head.observeEpoch((newEpoch) => reconnect())                           │
+│                                                                              │
+│  5. Clients reconnect to new Workspace Doc                                  │
+│                                                                              │
+│  Result:                                                                     │
+│  - Old epoch (N) is frozen, read-only                                       │
+│  - New epoch (N+1) is active                                                │
+│  - All clients converge to new epoch                                        │
+│                                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Concurrent Epoch Bumps (CRDT Safety)
+
+The Head Doc uses a per-client MAX pattern:
+
+```typescript
+Y.Map('epochs')
+├── "client_a": 2  // Client A proposed epoch 2
+├── "client_b": 2  // Client B also proposed epoch 2
+└── "client_c": 1  // Client C still on epoch 1
+
+getEpoch() → max(2, 2, 1) → 2
+```
+
+If two clients bump simultaneously:
+
+- Both write their proposed epoch
+- After sync, both see the same MAX
+- No epochs skipped, no conflicts
+
+---
+
+## Migration Path from v1
+
+### Changes Required
+
+1. **Move `name`, `icon`, `description` from Workspace Doc to Head Doc**
+   - Update `createHeadDoc()` to include `Y.Map('meta')`
+   - Update `createClient()` to read name from Head Doc, not Workspace Doc
+   - Migration: copy values from latest Workspace Doc to Head Doc
+
+2. **Rename `definition` to `schema` in Workspace Doc**
+   - Update `Y.Map('definition')` to `Y.Map('schema')`
+   - Remove `name`, `icon`, `description` from schema
+   - Keep `tables` and `kv` definitions
+
+3. **Add `preferences` map to Registry Doc**
+   - Update `createRegistryDoc()` to include `Y.Map('preferences')`
+
+4. **Update cloud API to return `docId` (NanoID)**
+   - Generate NanoID when workspace is created
+   - Return both `workspaceId` and `docId` in API responses
+
+### Backward Compatibility
+
+For existing local workspaces:
+
+1. On load, check if Head Doc has `meta` map
+2. If not, migrate from Workspace Doc's `definition`
+3. Write to Head Doc (one-time migration)
+
+---
+
+## Design Decisions (Resolved)
+
+### Q: Should `description` be Y.Text or plain string?
+
+**Decision: Plain string.**
+
+Y.Text is for character-level collaborative editing (real-time cursors, concurrent typing). Workspace descriptions are short metadata, not collaborative documents. Last-write-wins semantics are actually better here—if two users edit the description simultaneously, you want one coherent result, not a merged mess. The overhead of Y.Text isn't justified.
+
+Same logic applies to `name`—it's short metadata, not a document.
+
+### Q: What should the container map be named?
+
+**Decision: `meta`.**
+
+| Name       | Problem                                           |
+| ---------- | ------------------------------------------------- |
+| `identity` | Too specific—doesn't cover all metadata           |
+| `info`     | Too generic                                       |
+| `header`   | Implies a UI concept                              |
+| `metadata` | Verbose                                           |
+| **`meta`** | **Concise, universally understood, clear intent** |
+
+### Q: Why Y.Map('meta') vs top-level fields?
+
+**Decision: Use Y.Map('meta').**
+
+1. **Namespace isolation**: `meta.name` can't conflict with a future top-level `name` field
+2. **Atomic observation**: `meta.observeDeep()` catches all identity changes
+3. **Cleaner API**: `headDoc.getMeta()` vs tracking three separate getters
+4. **Extensibility**: Easy to add `createdAt`, `color`, `coverImage` later
+
+---
+
+## Open Questions
+
+### Q1: Should server cache name/icon from Head Doc?
+
+**Proposed**: Yes, denormalize into `workspace_registry` table for fast listing.
+
+**Alternative**: Always fetch from Head Doc (slower but no sync issues).
+
+### Q2: How does server know when Head Doc changes?
+
+**Options:**
+
+- Y-Sweet webhook (if supported)
+- Periodic polling
+- Client notifies server after changes
+
+### Q3: What happens if cached name differs from Head Doc?
+
+**Proposed**: Head Doc is authoritative. Cache is eventually consistent. Client always reads from Head Doc for display.
+
+---
+
+## Implementation Progress
+
+- [x] Update `packages/epicenter/src/core/docs/head-doc.ts` to include `Y.Map('meta')`
+  - Added `WorkspaceMeta` type with name, icon, description
+  - Added `getMeta()`, `setMeta()`, `observeMeta()`, `hasMeta()` methods
+- [x] Rename `definition` to `schema` in Workspace Doc
+  - Changed `WORKSPACE_DOC_MAPS.DEFINITION` → `WORKSPACE_DOC_MAPS.SCHEMA`
+  - Renamed `mergeDefinitionIntoYDoc` → `mergeSchemaIntoYDoc`
+  - Renamed `readDefinitionFromYDoc` → `readSchemaFromYDoc`
+  - Renamed `WorkspaceDefinitionMap` → `WorkspaceSchemaMap`
+  - Renamed `DefinitionMap` → `SchemaMap`
+  - Added deprecated aliases for backward compatibility
+- [x] Remove `name`, `icon` from Workspace schema (they live in Head Doc now)
+  - `WorkspaceSchemaMap` no longer includes `name` or `icon`
+  - Legacy `readDefinitionFromYDoc` still reads them for migration
+- [x] Update `createClient()` to use new schema functions
+  - Uses `mergeSchemaIntoYDoc` instead of `mergeDefinitionIntoYDoc`
+  - Uses `readSchemaFromYDoc` internally
+  - `getDefinition()` still returns legacy format for backward compatibility
+- [x] Update exports and types in index.ts
+  - Exports new types: `WorkspaceMeta`, `WorkspaceSchemaMap`, `SchemaMap`
+  - Exports new functions: `mergeSchemaIntoYDoc`, `readSchemaFromYDoc`
+  - Maintains deprecated exports for backward compatibility
+- [x] Run typecheck - no new type errors introduced
+- [x] Update README docs to reflect new architecture
+  - Updated `apps/epicenter/src/lib/docs/README.md` with:
+    - Head Doc now shows `Y.Map('meta')` + `Y.Map('epochs')`
+    - Workspace Doc shows `Y.Map('schema')` instead of `Y.Map('definition')`
+    - `definition.json` → `schema.json` in storage layout
+    - Updated helper function examples
+
+### Migration Notes
+
+The `readDefinitionFromYDoc` function still reads `name` and `icon` from the Workspace Doc
+for migration purposes. New code should:
+
+1. Use `HeadDoc.getMeta()` to read workspace identity
+2. Use `HeadDoc.setMeta()` to set workspace identity
+3. Use `readSchemaFromYDoc()` to read only the table/kv schema
+
+### Future Work (Not in This PR)
+
+- [ ] Update `packages/epicenter/src/core/docs/registry-doc.ts` to include `Y.Map('preferences')`
+- [ ] Design cloud API endpoints
+- [ ] Implement NanoID generation for cloud doc IDs
+- [ ] Add actual migration code in apps to copy name/icon from Workspace Doc to Head Doc


### PR DESCRIPTION
## Summary

Moves workspace identity (name, icon, description) from Workspace Doc to Head Doc, and renames `Y.Map('definition')` to `Y.Map('schema')` since it now only contains table/KV schemas without identity.

## Why This Change?

**Problem**: Workspace name/icon were stored per-epoch in the Workspace Doc. This meant:
- Renaming a workspace required touching epoch-specific data
- Restoring from a snapshot could revert the workspace name
- Name/icon were duplicated across epochs

**Solution**: Workspace identity now lives in the Head Doc, which is shared across all epochs.

## Architecture Change

### Before
```
HEAD DOC (per workspace)
└── Y.Map('epochs')
    └── clientId: epochNumber

WORKSPACE DOC (per epoch)
└── Y.Map('definition')              ← Name/icon lived here
    ├── name: "Whispering"
    ├── icon: { type: 'emoji', ... }
    ├── tables: { ... }
    └── kv: { ... }
```

### After
```
┌─────────────────────────────────────────────────────────────────────────────┐
│                         HEAD DOC (Per Workspace)                             │
│                         Syncs: Local/Relay/Cloud                             │
├─────────────────────────────────────────────────────────────────────────────┤
│                                                                              │
│  Y.Map('meta')                          // NEW: Workspace identity           │
│  ├── name: "Whispering"                                                      │
│  ├── icon: { type: 'emoji', value: '🎙️' }                                   │
│  └── description: "Voice recordings"                                         │
│                                                                              │
│  Y.Map('epochs')                        // Existing: CRDT epoch tracking     │
│  └── clientId: epochNumber                                                   │
│                                                                              │
└─────────────────────────────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────────────────────────────┐
│                         WORKSPACE DOC (Per Epoch)                            │
│                         Syncs: Local/Relay/Cloud                             │
├─────────────────────────────────────────────────────────────────────────────┤
│                                                                              │
│  Y.Map('schema')                        // Renamed from 'definition'         │
│  ├── tables: { tableName: { fields: { ... } } }                              │
│  └── kv: { keyName: { field: { ... } } }                                     │
│                                                                              │
│  Y.Map('tables')                        // Existing: Row data                │
│  └── tableName: Y.Map<rowId, Y.Map<field, value>>                            │
│                                                                              │
│  Y.Map('kv')                            // Existing: Settings values         │
│  └── keyName: value                                                          │
│                                                                              │
└─────────────────────────────────────────────────────────────────────────────┘
```

## Key Benefits

1. **Rename survives epoch resets**: Workspace name/icon persist even when restoring from snapshot
2. **No duplication**: Identity stored once, not per-epoch  
3. **Faster listing**: Can list workspaces without loading every Workspace Doc
4. **Cleaner separation**: Identity vs schema vs data

## Changes

### Head Doc (`packages/epicenter/src/core/docs/head-doc.ts`)
- Added `WorkspaceMeta` type with `name`, `icon`, `description`
- Added `Y.Map('meta')` alongside existing `Y.Map('epochs')`
- New methods: `getMeta()`, `setMeta()`, `observeMeta()`, `hasMeta()`

### Workspace Doc (`packages/epicenter/src/core/docs/workspace-doc.ts`)
- Renamed `WORKSPACE_DOC_MAPS.DEFINITION` → `WORKSPACE_DOC_MAPS.SCHEMA`
- Renamed `WorkspaceDefinitionMap` → `WorkspaceSchemaMap` (no longer includes name/icon)
- Renamed `mergeDefinitionIntoYDoc` → `mergeSchemaIntoYDoc`
- Renamed `readDefinitionFromYDoc` → `readSchemaFromYDoc`
- Removed all deprecated aliases

### Workspace Client (`packages/epicenter/src/core/workspace/workspace.ts`)
- `getDefinition()` → `getSchema()` returning `WorkspaceSchemaMap`
- `client.name` still exists as a legacy fallback during migration

### App Layer (`apps/epicenter/`)
- `tauri-workspace-persistence.ts`: Uses `Y.Map('schema')`, writes `schema.json` instead of `definition.json`
- `workspaces.ts`: Reads/writes identity via `head.getMeta()` / `head.setMeta()`
- `+layout.ts`: Reads workspace name from `head.getMeta()` instead of `client.name`

### Documentation
- Updated `apps/epicenter/src/lib/docs/README.md` with new architecture diagrams
- Updated `packages/epicenter/src/core/docs/README.md` with new Y.Doc structures

## Migration Notes

The `client.name` getter still exists as a fallback that reads from the legacy location in the schema map. New code should use `head.getMeta().name` for workspace identity.

## Not in This PR (Future Work)

- Migration code to copy existing name/icon from old Workspace Docs to Head Doc
- Registry Doc `Y.Map('preferences')` for pinned/hidden workspaces
- Cloud API endpoints with NanoID doc IDs