### PR TITLE
feat(epicenter): unify observation patterns across all YJS helpers

### DIFF
--- a/apps/epicenter/src/lib/docs/workspace-persistence.ts
+++ b/apps/epicenter/src/lib/docs/workspace-persistence.ts
@@ -8,10 +8,6 @@ import { appLocalDataDir, dirname, join } from '@tauri-apps/api/path';
 import { mkdir, readFile, writeFile } from '@tauri-apps/plugin-fs';
 import * as Y from 'yjs';
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Types
-// ─────────────────────────────────────────────────────────────────────────────
-
 /**
  * Configuration for the workspace persistence extension.
  */
@@ -93,15 +89,11 @@ export function workspacePersistence<
 	ctx: ExtensionContext<TTableDefinitionMap, TKvDefinitionMap>,
 	config: WorkspacePersistenceConfig = {},
 ): ProviderExports {
-	const { ydoc, workspaceId, epoch, schema } = ctx;
+	const { ydoc, workspaceId, epoch, schema, kv } = ctx;
 	const { jsonDebounceMs = 500 } = config;
 
 	// For logging
 	const logPath = `workspaces/${workspaceId}/${epoch}`;
-
-	// Get the top-level Y.Maps directly from ydoc (stable references)
-	const schemaMap = ydoc.getMap('schema');
-	const kvMap = ydoc.getMap('kv');
 
 	// Resolve paths once, cache the promise
 	const pathsPromise = (async () => {
@@ -177,11 +169,8 @@ export function workspacePersistence<
 		}, jsonDebounceMs);
 	};
 
-	// Observe schema map changes
-	const schemaObserverHandler = () => {
-		scheduleSchemaSave();
-	};
-	schemaMap.observeDeep(schemaObserverHandler);
+	// Observe schema changes using the schema helper's observe method
+	const unsubscribeSchema = schema.observe(scheduleSchemaSave);
 
 	// =========================================================================
 	// 3. KV JSON Persistence (kv.json)
@@ -192,7 +181,7 @@ export function workspacePersistence<
 	const saveKvJson = async () => {
 		const { kvJsonPath } = await pathsPromise;
 		try {
-			const kvData = kvMap.toJSON();
+			const kvData = kv.toJSON();
 			const json = JSON.stringify(kvData, null, '\t');
 			await writeFile(kvJsonPath, new TextEncoder().encode(json));
 			console.log(`[WorkspacePersistence] Saved kv.json for ${workspaceId}`);
@@ -209,11 +198,8 @@ export function workspacePersistence<
 		}, jsonDebounceMs);
 	};
 
-	// Observe KV map changes
-	const kvObserverHandler = () => {
-		scheduleKvSave();
-	};
-	kvMap.observe(kvObserverHandler);
+	// Observe KV changes using the kv helper's observe method
+	const unsubscribeKv = kv.observe(scheduleKvSave);
 
 	// =========================================================================
 	// Return Provider Exports
@@ -266,9 +252,9 @@ export function workspacePersistence<
 			// Remove Y.Doc observer
 			ydoc.off('update', saveYDoc);
 
-			// Remove map observers
-			schemaMap.unobserveDeep(schemaObserverHandler);
-			kvMap.unobserve(kvObserverHandler);
+			// Remove map observers via unsubscribe functions
+			unsubscribeSchema();
+			unsubscribeKv();
 		},
 	});
 }

--- a/apps/epicenter/src/lib/docs/workspace-persistence.ts
+++ b/apps/epicenter/src/lib/docs/workspace-persistence.ts
@@ -93,15 +93,15 @@ export function workspacePersistence<
 	ctx: ExtensionContext<TTableDefinitionMap, TKvDefinitionMap>,
 	config: WorkspacePersistenceConfig = {},
 ): ProviderExports {
-	const { workspaceDoc } = ctx;
-	const { ydoc, workspaceId, epoch } = workspaceDoc;
+	const { ydoc, workspaceId, epoch, schema } = ctx;
 	const { jsonDebounceMs = 500 } = config;
 
 	// For logging
 	const logPath = `workspaces/${workspaceId}/${epoch}`;
 
-	// Get the top-level Y.Maps from the workspace doc wrapper (stable references)
-	const { schemaMap, kvMap } = workspaceDoc;
+	// Get the top-level Y.Maps directly from ydoc (stable references)
+	const schemaMap = ydoc.getMap('schema');
+	const kvMap = ydoc.getMap('kv');
 
 	// Resolve paths once, cache the promise
 	const pathsPromise = (async () => {
@@ -155,8 +155,8 @@ export function workspacePersistence<
 	const saveSchemaJson = async () => {
 		const { schemaJsonPath } = await pathsPromise;
 		try {
-			const schema = workspaceDoc.schema.get();
-			const json = JSON.stringify(schema, null, '\t');
+			const schemaSnapshot = schema.get();
+			const json = JSON.stringify(schemaSnapshot, null, '\t');
 			await writeFile(schemaJsonPath, new TextEncoder().encode(json));
 			console.log(
 				`[WorkspacePersistence] Saved schema.json for ${workspaceId}`,

--- a/packages/epicenter/docs/articles/observation-patterns.md
+++ b/packages/epicenter/docs/articles/observation-patterns.md
@@ -1,0 +1,102 @@
+# Observation Patterns
+
+## Philosophy
+
+All observers in Epicenter follow a simple principle: **notify at the Y.Map boundary, let the consumer fetch the data**.
+
+Observers don't reconstruct or validate data—they just tell you what changed. You call the appropriate getter to fetch current state when you need it.
+
+## Why This Design
+
+1. **Efficiency**: No wasted work reconstructing data the consumer might not need
+2. **Simplicity**: Observer implementation is trivial (just watch Y.Map events)
+3. **Consistency**: Same pattern across all data structures
+4. **Flexibility**: Consumer decides when and how to fetch data
+
+## Pattern by Structure Type
+
+### Single Y.Map (schema, KV top-level)
+
+For structures backed by a single Y.Map, the observer just notifies that something changed:
+
+```typescript
+// Observer signature
+observe(callback: () => void): () => void
+
+// Usage
+const unsub = kv.observe(() => {
+  // Something changed - fetch if needed
+  const snapshot = kv.toJSON();
+  saveToFile(snapshot);
+});
+
+const unsub = schema.observe(() => {
+  const snapshot = schema.get();
+  rebuildValidators(snapshot);
+});
+```
+
+### Nested Y.Map with known keys (schema.tables, schema.kv)
+
+For Y.Maps where children are also Y.Maps, notify which keys changed:
+
+```typescript
+// Observer signature
+observe(callback: (changes: Map<string, 'add' | 'delete'>) => void): () => void
+
+// Usage
+schema.tables.observe((changes) => {
+  for (const [tableName, action] of changes) {
+    if (action === 'add') {
+      const tableSchema = schema.tables.get(tableName);
+      registerTable(tableName, tableSchema);
+    } else {
+      unregisterTable(tableName);
+    }
+  }
+});
+```
+
+### Deeply nested Y.Map (tables = rows)
+
+For tables where each row is a Y.Map, notify which row IDs changed:
+
+```typescript
+// Observer signature
+observe(callback: (changes: Map<string, 'add' | 'update' | 'delete'>, transaction: Y.Transaction) => void): () => void
+
+// Usage
+tables.posts.observe((changes, transaction) => {
+  for (const [id, action] of changes) {
+    if (action === 'delete') {
+      removeFromCache(id);
+    } else {
+      // Fetch row data only when needed
+      const result = tables.posts.get(id);
+      if (result.status === 'valid') {
+        updateCache(id, result.row);
+      }
+    }
+  }
+});
+```
+
+## Summary Table
+
+| Structure        | Observer Callback Receives               | Consumer Fetches With     |
+| ---------------- | ---------------------------------------- | ------------------------- |
+| `kv` (top-level) | `() => void`                             | `kv.toJSON()`             |
+| `kv('key')`      | `(change: KvChange) => void`             | (change has the value)    |
+| `schema`         | `() => void`                             | `schema.get()`            |
+| `schema.tables`  | `Map<string, 'add'\|'delete'>`           | `schema.tables.get(name)` |
+| `schema.kv`      | `Map<string, 'add'\|'delete'>`           | `schema.kv.get(name)`     |
+| `tables.{name}`  | `Map<string, 'add'\|'update'\|'delete'>` | `tables.{name}.get(id)`   |
+
+## The Y.Map Boundary Rule
+
+The observer tells you **which Y.Map changed**. You read that Y.Map yourself.
+
+- Single Y.Map: "it changed" (no args)
+- Parent of Y.Maps: "these children changed" (Map of keys to actions)
+
+This keeps observers simple and puts the consumer in control of when to fetch data.

--- a/packages/epicenter/src/core/kv/core.ts
+++ b/packages/epicenter/src/core/kv/core.ts
@@ -78,6 +78,15 @@ export type KvFunction<TKvDefinitionMap extends KvDefinitionMap> = {
 	definitions: TKvDefinitionMap;
 
 	// ════════════════════════════════════════════════════════════════════
+	// OBSERVATION
+	// ════════════════════════════════════════════════════════════════════
+
+	/**
+	 * Observe any KV changes. Callback is notified when any key changes.
+	 */
+	observe(callback: () => void): () => void;
+
+	// ════════════════════════════════════════════════════════════════════
 	// UTILITIES
 	// ════════════════════════════════════════════════════════════════════
 
@@ -285,6 +294,35 @@ export function createKv<TKvDefinitionMap extends KvDefinitionMap>(
 		 * ```
 		 */
 		definitions,
+
+		// ════════════════════════════════════════════════════════════════════
+		// OBSERVATION
+		// ════════════════════════════════════════════════════════════════════
+
+		/**
+		 * Observe any KV changes. Callback is notified when any key changes.
+		 *
+		 * The observer just notifies that something changed. To get the current
+		 * state, call `toJSON()` inside your callback or use individual key getters.
+		 *
+		 * @returns Unsubscribe function to stop observing
+		 *
+		 * @example
+		 * ```typescript
+		 * const unsubscribe = kv.observe(() => {
+		 *   // Something changed - fetch current state if needed
+		 *   const snapshot = kv.toJSON();
+		 *   saveToFile(snapshot);
+		 * });
+		 *
+		 * // Later, stop observing
+		 * unsubscribe();
+		 * ```
+		 */
+		observe(callback: () => void): () => void {
+			ykvMap.observeDeep(callback);
+			return () => ykvMap.unobserveDeep(callback);
+		},
 
 		// ════════════════════════════════════════════════════════════════════
 		// UTILITIES

--- a/packages/epicenter/src/core/kv/kv-helper.test.ts
+++ b/packages/epicenter/src/core/kv/kv-helper.test.ts
@@ -526,7 +526,7 @@ describe('KV Helpers', () => {
 			});
 
 			const values: string[] = [];
-			kv('theme').observeChanges((change) => {
+			kv('theme').observe((change) => {
 				if (change.action !== 'delete') {
 					values.push(change.newValue);
 				}
@@ -549,14 +549,14 @@ describe('KV Helpers', () => {
 			});
 
 			const themeValues: string[] = [];
-			kv('theme').observeChanges((change) => {
+			kv('theme').observe((change) => {
 				if (change.action !== 'delete') {
 					themeValues.push(change.newValue);
 				}
 			});
 
 			const countValues: number[] = [];
-			kv('count').observeChanges((change) => {
+			kv('count').observe((change) => {
 				if (change.action !== 'delete') {
 					countValues.push(change.newValue);
 				}
@@ -577,7 +577,7 @@ describe('KV Helpers', () => {
 			});
 
 			const values: number[] = [];
-			const unsubscribe = kv('count').observeChanges((change) => {
+			const unsubscribe = kv('count').observe((change) => {
 				if (change.action !== 'delete') {
 					values.push(change.newValue);
 				}
@@ -598,7 +598,7 @@ describe('KV Helpers', () => {
 			});
 
 			let callCount = 0;
-			kv('notes').observeChanges(() => {
+			kv('notes').observe(() => {
 				callCount++;
 			});
 
@@ -613,7 +613,7 @@ describe('KV Helpers', () => {
 			});
 
 			let callCount = 0;
-			kv('tags').observeChanges(() => {
+			kv('tags').observe(() => {
 				callCount++;
 			});
 
@@ -650,7 +650,7 @@ describe('KV Helpers', () => {
 			});
 
 			const values: string[] = [];
-			kv('theme').observeChanges((change) => {
+			kv('theme').observe((change) => {
 				if (change.action !== 'delete') {
 					values.push(change.newValue);
 				}
@@ -902,7 +902,7 @@ describe('KV Helpers', () => {
 			});
 
 			let receivedValue: unknown = null;
-			kv('count').observeChanges((change) => {
+			kv('count').observe((change) => {
 				if (change.action !== 'delete') {
 					receivedValue = change.newValue;
 				}

--- a/packages/epicenter/src/core/kv/kv-helper.ts
+++ b/packages/epicenter/src/core/kv/kv-helper.ts
@@ -185,7 +185,7 @@ export function createKvHelper<TFieldSchema extends KvFieldSchema>({
 		 *
 		 * @example
 		 * ```typescript
-		 * const unsubscribe = kv.theme.observeChanges((change, transaction) => {
+		 * const unsubscribe = kv('theme').observe((change, transaction) => {
 		 *   switch (change.action) {
 		 *     case 'add':
 		 *     case 'update':
@@ -199,7 +199,7 @@ export function createKvHelper<TFieldSchema extends KvFieldSchema>({
 		 * unsubscribe(); // Stop watching
 		 * ```
 		 */
-		observeChanges(
+		observe(
 			callback: (change: KvChange<TValue>, transaction: Y.Transaction) => void,
 		): () => void {
 			const handler = (

--- a/packages/epicenter/src/core/schema-helper/index.ts
+++ b/packages/epicenter/src/core/schema-helper/index.ts
@@ -1,11 +1,12 @@
 export {
+	type ChangeAction,
 	createSchema,
+	type FieldChangeAction,
 	type FieldsMap,
 	type KvSchemaHelper,
 	type KvSchemaInput,
 	type KvSchemaMap,
 	type Schema,
-	type SchemaChange,
 	type StoredKvSchema,
 	type StoredTableSchema,
 	type TableMetadata,

--- a/packages/epicenter/src/core/schema-helper/schema-helper.test.ts
+++ b/packages/epicenter/src/core/schema-helper/schema-helper.test.ts
@@ -351,35 +351,33 @@ describe('createSchema', () => {
 			const schemaMap = ydoc.getMap('schema');
 			const schema = createSchema(schemaMap);
 
-			const changes: unknown[] = [];
-			const unsub = schema.tables.observe((c) => {
-				changes.push(...c);
+			const allChanges: Map<string, 'add' | 'delete'>[] = [];
+			const unsub = schema.tables.observe((changes) => {
+				allChanges.push(changes);
 			});
 
 			schema.tables.set('posts', { name: 'Posts', fields: { id: id() } });
-			expect(
-				changes.some((c: any) => c.action === 'add' && c.key === 'posts'),
-			).toBe(true);
+			expect(allChanges.length).toBeGreaterThan(0);
+			expect(allChanges.some((m) => m.get('posts') === 'add')).toBe(true);
 
 			unsub();
 		});
 
-		test('fields.observe() fires on field add/delete', () => {
+		test('fields.observe() fires on field add/update/delete', () => {
 			const ydoc = new Y.Doc();
 			const schemaMap = ydoc.getMap('schema');
 			const schema = createSchema(schemaMap);
 
 			schema.tables.set('posts', { name: 'Posts', fields: { id: id() } });
 
-			const changes: unknown[] = [];
-			const unsub = schema.tables('posts')!.fields.observe((c) => {
-				changes.push(...c);
+			const allChanges: Map<string, 'add' | 'update' | 'delete'>[] = [];
+			const unsub = schema.tables('posts')!.fields.observe((changes) => {
+				allChanges.push(changes);
 			});
 
 			schema.tables('posts')!.fields.set('title', text());
-			expect(
-				changes.some((c: any) => c.action === 'add' && c.key === 'title'),
-			).toBe(true);
+			expect(allChanges.length).toBeGreaterThan(0);
+			expect(allChanges.some((m) => m.get('title') === 'add')).toBe(true);
 
 			unsub();
 		});

--- a/packages/epicenter/src/core/tables/create-tables.crdt-sync.test.ts
+++ b/packages/epicenter/src/core/tables/create-tables.crdt-sync.test.ts
@@ -480,9 +480,9 @@ describe('Cell-Level CRDT Merging', () => {
 
 		// Set up observer on doc2 BEFORE any sync
 		const addedIds: string[] = [];
-		tables2('posts').observeChanges((changes) => {
-			for (const [id, change] of changes) {
-				if (change.action === 'add') {
+		tables2('posts').observe((changes) => {
+			for (const [id, action] of changes) {
+				if (action === 'add') {
 					addedIds.push(id);
 				}
 			}
@@ -519,9 +519,9 @@ describe('Cell-Level CRDT Merging', () => {
 
 		// Set up observer on doc2
 		const updatedIds: string[] = [];
-		tables2('posts').observeChanges((changes) => {
-			for (const [id, change] of changes) {
-				if (change.action === 'update') {
+		tables2('posts').observe((changes) => {
+			for (const [id, action] of changes) {
+				if (action === 'update') {
 					updatedIds.push(id);
 				}
 			}
@@ -555,9 +555,9 @@ describe('Cell-Level CRDT Merging', () => {
 
 		// Set up observer on doc2
 		const deletedIds: string[] = [];
-		tables2('posts').observeChanges((changes) => {
-			for (const [id, change] of changes) {
-				if (change.action === 'delete') {
+		tables2('posts').observe((changes) => {
+			for (const [id, action] of changes) {
+				if (action === 'delete') {
 					deletedIds.push(id);
 				}
 			}
@@ -747,9 +747,9 @@ describe('Cell-Level CRDT Merging', () => {
 		Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1));
 
 		const changes: Array<{ action: string; id: string }> = [];
-		tables2('posts').observeChanges((changeMap) => {
-			for (const [id, change] of changeMap) {
-				changes.push({ action: change.action, id });
+		tables2('posts').observe((changeMap) => {
+			for (const [id, action] of changeMap) {
+				changes.push({ action, id });
 			}
 		});
 
@@ -791,9 +791,9 @@ describe('Cell-Level CRDT Merging', () => {
 		Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1));
 
 		const changes: Array<{ action: string; id: string }> = [];
-		tables2('posts').observeChanges((changeMap) => {
-			for (const [id, change] of changeMap) {
-				changes.push({ action: change.action, id });
+		tables2('posts').observe((changeMap) => {
+			for (const [id, action] of changeMap) {
+				changes.push({ action, id });
 			}
 		});
 
@@ -827,9 +827,9 @@ describe('Cell-Level CRDT Merging', () => {
 		]);
 
 		const changes: Array<{ action: string; id: string }> = [];
-		tables('posts').observeChanges((changeMap) => {
-			for (const [rowId, change] of changeMap) {
-				changes.push({ action: change.action, id: rowId });
+		tables('posts').observe((changeMap) => {
+			for (const [rowId, action] of changeMap) {
+				changes.push({ action, id: rowId });
 			}
 		});
 
@@ -866,14 +866,17 @@ describe('Cell-Level CRDT Merging', () => {
 		tables('posts').upsert({ id: 'post-1', title: 'Original' });
 
 		const changes: Array<{ action: string; id: string; title?: string }> = [];
-		tables('posts').observeChanges((changeMap) => {
-			for (const [rowId, change] of changeMap) {
+		tables('posts').observe((changeMap) => {
+			for (const [rowId, action] of changeMap) {
 				const entry: { action: string; id: string; title?: string } = {
-					action: change.action,
+					action,
 					id: rowId,
 				};
-				if (change.action !== 'delete' && change.result.status === 'valid') {
-					entry.title = change.result.row.title;
+				if (action !== 'delete') {
+					const result = tables('posts').get(rowId);
+					if (result.status === 'valid') {
+						entry.title = result.row.title;
+					}
 				}
 				changes.push(entry);
 			}
@@ -913,9 +916,9 @@ describe('Cell-Level CRDT Merging', () => {
 		});
 
 		const changes: Array<{ action: string; id: string }> = [];
-		tables('posts').observeChanges((changeMap) => {
-			for (const [rowId, change] of changeMap) {
-				changes.push({ action: change.action, id: rowId });
+		tables('posts').observe((changeMap) => {
+			for (const [rowId, action] of changeMap) {
+				changes.push({ action, id: rowId });
 			}
 		});
 

--- a/packages/epicenter/src/core/tables/create-tables.crdt-sync.test.ts
+++ b/packages/epicenter/src/core/tables/create-tables.crdt-sync.test.ts
@@ -480,9 +480,12 @@ describe('Cell-Level CRDT Merging', () => {
 
 		// Set up observer on doc2 BEFORE any sync
 		const addedIds: string[] = [];
-		tables2('posts').observe((changes) => {
-			for (const [id, action] of changes) {
-				if (action === 'add') {
+		tables2('posts').observe((changedIds) => {
+			for (const id of changedIds) {
+				const result = tables2('posts').get(id);
+				if (result.status !== 'not_found') {
+					// Could be add or update - we only care about new rows here
+					// Since we're tracking before any sync, these are all adds
 					addedIds.push(id);
 				}
 			}
@@ -519,9 +522,11 @@ describe('Cell-Level CRDT Merging', () => {
 
 		// Set up observer on doc2
 		const updatedIds: string[] = [];
-		tables2('posts').observe((changes) => {
-			for (const [id, action] of changes) {
-				if (action === 'update') {
+		tables2('posts').observe((changedIds) => {
+			for (const id of changedIds) {
+				const result = tables2('posts').get(id);
+				if (result.status !== 'not_found') {
+					// Row exists, so it was added or updated
 					updatedIds.push(id);
 				}
 			}
@@ -555,9 +560,11 @@ describe('Cell-Level CRDT Merging', () => {
 
 		// Set up observer on doc2
 		const deletedIds: string[] = [];
-		tables2('posts').observe((changes) => {
-			for (const [id, action] of changes) {
-				if (action === 'delete') {
+		tables2('posts').observe((changedIds) => {
+			for (const id of changedIds) {
+				const result = tables2('posts').get(id);
+				if (result.status === 'not_found') {
+					// Row was deleted
 					deletedIds.push(id);
 				}
 			}
@@ -730,7 +737,10 @@ describe('Cell-Level CRDT Merging', () => {
 		expect(tables2('posts').count()).toBe(3);
 	});
 
-	test('observer continues working after table deletion', () => {
+	test('observer continues working after clear() and detects new rows', () => {
+		// Tables are permanent structures; they can be emptied but never deleted.
+		// This test verifies that clear() properly notifies observers and the
+		// observer continues working for new rows.
 		const doc1 = new Y.Doc();
 		const doc2 = new Y.Doc();
 		doc1.clientID = 1;
@@ -747,26 +757,24 @@ describe('Cell-Level CRDT Merging', () => {
 		Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1));
 
 		const changes: Array<{ action: string; id: string }> = [];
-		tables2('posts').observe((changeMap) => {
-			for (const [id, action] of changeMap) {
-				changes.push({ action, id });
+		tables2('posts').observe((changedIds) => {
+			for (const id of changedIds) {
+				const result = tables2('posts').get(id);
+				if (result.status === 'not_found') {
+					changes.push({ action: 'delete', id });
+				} else {
+					changes.push({ action: 'add', id });
+				}
 			}
 		});
 
-		const ytables2 = doc2.getMap('tables') as Y.Map<Y.Map<Y.Map<unknown>>>;
-		ytables2.delete('posts');
+		// Use clear() instead of deleting the table Y.Map directly
+		tables2('posts').clear();
 
 		expect(changes).toContainEqual({ action: 'delete', id: 'post-1' });
 
-		const postsTable = new Y.Map() as Y.Map<Y.Map<unknown>>;
-		ytables2.set('posts', postsTable);
-
-		const rowMap = new Y.Map() as Y.Map<unknown>;
-		postsTable.set('post-new', rowMap);
-		doc2.transact(() => {
-			rowMap.set('id', 'post-new');
-			rowMap.set('title', 'New Post');
-		});
+		// Add a new row; observer should still be working
+		tables2('posts').upsert({ id: 'post-new', title: 'New Post' });
 
 		expect(changes).toContainEqual({ action: 'add', id: 'post-new' });
 	});
@@ -791,9 +799,14 @@ describe('Cell-Level CRDT Merging', () => {
 		Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1));
 
 		const changes: Array<{ action: string; id: string }> = [];
-		tables2('posts').observe((changeMap) => {
-			for (const [id, action] of changeMap) {
-				changes.push({ action, id });
+		tables2('posts').observe((changedIds) => {
+			for (const id of changedIds) {
+				const result = tables2('posts').get(id);
+				if (result.status === 'not_found') {
+					changes.push({ action: 'delete', id });
+				} else {
+					changes.push({ action: 'update', id });
+				}
 			}
 		});
 
@@ -809,13 +822,11 @@ describe('Cell-Level CRDT Merging', () => {
 		}
 	});
 
-	test('table replacement emits delete for old rows and add for new rows', () => {
+	test('clear then upsertMany emits delete for old rows and add for new rows', () => {
+		// Tables are permanent structures; to "replace" a table's contents,
+		// use clear() followed by upsertMany(). This test verifies that
+		// observers see deletions for old rows and additions for new rows.
 		const ydoc = new Y.Doc({ guid: 'test-table-replacement' });
-		type RowMap = Y.Map<unknown>;
-		type TableMap = Y.Map<RowMap>;
-		type TablesMap = Y.Map<TableMap>;
-
-		const ytables: TablesMap = ydoc.getMap('tables');
 
 		const tables = createTables(ydoc, {
 			posts: table({ name: '', fields: { id: id(), title: text() } }),
@@ -827,23 +838,23 @@ describe('Cell-Level CRDT Merging', () => {
 		]);
 
 		const changes: Array<{ action: string; id: string }> = [];
-		tables('posts').observe((changeMap) => {
-			for (const [rowId, action] of changeMap) {
-				changes.push({ action, id: rowId });
+		tables('posts').observe((changedIds) => {
+			for (const rowId of changedIds) {
+				const result = tables('posts').get(rowId);
+				if (result.status === 'not_found') {
+					changes.push({ action: 'delete', id: rowId });
+				} else {
+					changes.push({ action: 'add', id: rowId });
+				}
 			}
 		});
 
-		const newPostsTable = new Y.Map() as TableMap;
-		const newRow1 = new Y.Map() as RowMap;
-		const newRow2 = new Y.Map() as RowMap;
-		newRow1.set('id', 'new-1');
-		newRow1.set('title', 'New Post 1');
-		newRow2.set('id', 'new-2');
-		newRow2.set('title', 'New Post 2');
-		newPostsTable.set('new-1', newRow1);
-		newPostsTable.set('new-2', newRow2);
-
-		ytables.set('posts', newPostsTable);
+		// Clear and add new rows (simulates "table replacement")
+		tables('posts').clear();
+		tables('posts').upsertMany([
+			{ id: 'new-1', title: 'New Post 1' },
+			{ id: 'new-2', title: 'New Post 2' },
+		]);
 
 		expect(changes).toContainEqual({ action: 'delete', id: 'old-1' });
 		expect(changes).toContainEqual({ action: 'delete', id: 'old-2' });
@@ -866,19 +877,21 @@ describe('Cell-Level CRDT Merging', () => {
 		tables('posts').upsert({ id: 'post-1', title: 'Original' });
 
 		const changes: Array<{ action: string; id: string; title?: string }> = [];
-		tables('posts').observe((changeMap) => {
-			for (const [rowId, action] of changeMap) {
-				const entry: { action: string; id: string; title?: string } = {
-					action,
-					id: rowId,
-				};
-				if (action !== 'delete') {
-					const result = tables('posts').get(rowId);
+		tables('posts').observe((changedIds) => {
+			for (const rowId of changedIds) {
+				const result = tables('posts').get(rowId);
+				if (result.status === 'not_found') {
+					changes.push({ action: 'delete', id: rowId });
+				} else {
+					const entry: { action: string; id: string; title?: string } = {
+						action: 'update',
+						id: rowId,
+					};
 					if (result.status === 'valid') {
 						entry.title = result.row.title;
 					}
+					changes.push(entry);
 				}
-				changes.push(entry);
 			}
 		});
 
@@ -916,9 +929,14 @@ describe('Cell-Level CRDT Merging', () => {
 		});
 
 		const changes: Array<{ action: string; id: string }> = [];
-		tables('posts').observe((changeMap) => {
-			for (const [rowId, action] of changeMap) {
-				changes.push({ action, id: rowId });
+		tables('posts').observe((changedIds) => {
+			for (const rowId of changedIds) {
+				const result = tables('posts').get(rowId);
+				if (result.status === 'not_found') {
+					changes.push({ action: 'delete', id: rowId });
+				} else {
+					changes.push({ action: 'add', id: rowId });
+				}
 			}
 		});
 

--- a/packages/epicenter/src/core/tables/create-tables.ts
+++ b/packages/epicenter/src/core/tables/create-tables.ts
@@ -53,11 +53,12 @@ const COLUMN_NAME_PATTERN = regex('^[a-z][a-zA-Z0-9_]*$');
 export type {
 	GetResult,
 	InvalidRowResult,
+	RowAction,
+	RowChanges,
 	RowMap,
 	RowResult,
 	TableHelper,
 	TableMap,
-	TableRowChange,
 	TablesMap,
 	UntypedTableHelper,
 	ValidRowResult,

--- a/packages/epicenter/src/core/tables/create-tables.types.test.ts
+++ b/packages/epicenter/src/core/tables/create-tables.types.test.ts
@@ -158,13 +158,11 @@ describe('YjsDoc Type Inference', () => {
 			read: boolean;
 		}> = [];
 
-		const unsubscribe = doc('notifications').observe((changes) => {
-			for (const [id, action] of changes) {
-				if (action === 'add') {
-					const result = doc('notifications').get(id);
-					if (result.status === 'valid') {
-						addedNotifications.push(result.row);
-					}
+		const unsubscribe = doc('notifications').observe((changedIds) => {
+			for (const id of changedIds) {
+				const result = doc('notifications').get(id);
+				if (result.status === 'valid') {
+					addedNotifications.push(result.row);
 				}
 			}
 		});

--- a/packages/epicenter/src/core/tables/create-tables.types.test.ts
+++ b/packages/epicenter/src/core/tables/create-tables.types.test.ts
@@ -158,10 +158,13 @@ describe('YjsDoc Type Inference', () => {
 			read: boolean;
 		}> = [];
 
-		const unsubscribe = doc('notifications').observeChanges((changes) => {
-			for (const [_id, change] of changes) {
-				if (change.action === 'add' && change.result.status === 'valid') {
-					addedNotifications.push(change.result.row);
+		const unsubscribe = doc('notifications').observe((changes) => {
+			for (const [id, action] of changes) {
+				if (action === 'add') {
+					const result = doc('notifications').get(id);
+					if (result.status === 'valid') {
+						addedNotifications.push(result.row);
+					}
 				}
 			}
 		});

--- a/packages/epicenter/src/extensions/markdown/markdown.ts
+++ b/packages/epicenter/src/extensions/markdown/markdown.ts
@@ -442,11 +442,15 @@ export const markdown = async <
 				});
 			}
 
-			const unsub = table.observe((changes) => {
+			const unsub = table.observe((changedIds) => {
 				if (syncCoordination.fileChangeCount > 0) return;
 
-				for (const [id, action] of changes) {
-					if (action === 'delete') {
+				for (const id of changedIds) {
+					// Fetch the row data to determine if it was added/updated or deleted
+					const result = table.get(id);
+
+					if (result.status === 'not_found') {
+						// Row was deleted
 						void (async () => {
 							syncCoordination.yjsWriteCount++;
 
@@ -480,12 +484,6 @@ export const markdown = async <
 						continue;
 					}
 
-					// For add/update, fetch the row data
-					const result = table.get(id);
-					if (result.status === 'not_found') {
-						// Row was deleted between action and fetch, skip
-						continue;
-					}
 					if (result.status === 'invalid') {
 						const errorMessages = result.errors
 							.map(
@@ -494,7 +492,7 @@ export const markdown = async <
 							.join(', ');
 						logger.log(
 							ExtensionError({
-								message: `YJS observer ${action}: validation failed for ${table.name}/${id}: ${errorMessages}`,
+								message: `YJS observer: validation failed for ${table.name}/${id}: ${errorMessages}`,
 								context: {
 									tableName: result.tableName,
 									rowId: id,
@@ -504,6 +502,7 @@ export const markdown = async <
 						continue;
 					}
 
+					// Row was added or updated
 					const row = result.row;
 					void (async () => {
 						syncCoordination.yjsWriteCount++;
@@ -513,7 +512,7 @@ export const markdown = async <
 						if (error) {
 							logger.log(
 								ExtensionError({
-									message: `YJS observer ${action}: failed to write ${table.name}/${row.id}`,
+									message: `YJS observer: failed to write ${table.name}/${row.id}`,
 									context: { tableName: table.name, rowId: row.id },
 								}),
 							);

--- a/packages/epicenter/src/extensions/sqlite/sqlite.ts
+++ b/packages/epicenter/src/extensions/sqlite/sqlite.ts
@@ -213,19 +213,23 @@ export const sqlite = async <
 	const unsubscribers: Array<() => void> = [];
 
 	for (const { table } of tables.zip(drizzleTables)) {
-		const unsub = table.observe((changes) => {
+		const unsub = table.observe((changedIds) => {
 			if (isPushingFromSqlite) return;
 
-			for (const [id, action] of changes) {
-				if (action === 'delete') continue;
+			for (const id of changedIds) {
 				const result = table.get(id);
+				if (result.status === 'not_found') {
+					// Row was deleted - no validation needed
+					continue;
+				}
 				if (result.status === 'invalid') {
 					logger.log(
 						ExtensionError({
-							message: `SQLite extension ${action}: validation failed for ${table.name}`,
+							message: `SQLite extension: validation failed for ${table.name}`,
 						}),
 					);
 				}
+				// result.status === 'valid' means row was added or updated - sync will handle it
 			}
 
 			scheduleSync();

--- a/packages/epicenter/src/extensions/sqlite/sqlite.ts
+++ b/packages/epicenter/src/extensions/sqlite/sqlite.ts
@@ -213,15 +213,16 @@ export const sqlite = async <
 	const unsubscribers: Array<() => void> = [];
 
 	for (const { table } of tables.zip(drizzleTables)) {
-		const unsub = table.observeChanges((changes) => {
+		const unsub = table.observe((changes) => {
 			if (isPushingFromSqlite) return;
 
-			for (const [_id, change] of changes) {
-				if (change.action === 'delete') continue;
-				if (change.result.status === 'invalid') {
+			for (const [id, action] of changes) {
+				if (action === 'delete') continue;
+				const result = table.get(id);
+				if (result.status === 'invalid') {
 					logger.log(
 						ExtensionError({
-							message: `SQLite extension ${change.action}: validation failed for ${table.name}`,
+							message: `SQLite extension ${action}: validation failed for ${table.name}`,
 						}),
 					);
 				}

--- a/packages/epicenter/src/index.ts
+++ b/packages/epicenter/src/index.ts
@@ -151,6 +151,8 @@ export type {
 	GetResult,
 	InvalidRowResult,
 	NotFoundResult,
+	RowAction,
+	RowChanges,
 	RowResult,
 	UpdateManyResult,
 	UpdateResult,

--- a/specs/20260122T105410-unified-observation-patterns.md
+++ b/specs/20260122T105410-unified-observation-patterns.md
@@ -1,0 +1,434 @@
+# Unified Observation Patterns
+
+## Status: Complete
+
+## Problem Statement
+
+The current observation APIs across schema, KV, and tables are inconsistent:
+
+| Helper           | Current API         | Callback Receives                    | Validation                          |
+| ---------------- | ------------------- | ------------------------------------ | ----------------------------------- |
+| `schema`         | `.observe()`        | Full snapshot (`WorkspaceSchemaMap`) | N/A                                 |
+| `schema.tables`  | `.observe()`        | Granular changes (`SchemaChange[]`)  | N/A                                 |
+| `kv.{key}`       | `.observeChanges()` | Single key change (`KvChange`)       | None (raw values)                   |
+| `kv` (top-level) | None                | N/A                                  | N/A                                 |
+| `tables.{name}`  | `.observeChanges()` | `Map<string, TableRowChange>`        | Yes (RowResult discriminated union) |
+
+**Issues:**
+
+1. No top-level `kv.observe()` for watching all KV changes
+2. Table observation includes validation logic and row reconstruction that consumers may not need
+3. Inconsistent naming (`.observe()` vs `.observeChanges()`)
+4. Table changes wrapped in complex `RowResult` discriminated union
+5. Table observer reconstructs rows even when consumer only needs to know which IDs changed
+
+## Goals
+
+1. **Simplify**: One observer type per structure, minimal data in callbacks
+2. **Unify**: Consistent `.observe()` naming across all structures
+3. **Right tool for the job**: Snapshot for small/cold data (schema, KV), ID + action for large/hot data (tables)
+4. **Zero waste**: Don't reconstruct rows in observer - let consumer fetch if needed
+5. **SvelteMap-ready**: Design for future reactive Map integration (Svelte 5's `SvelteMap`)
+
+## Design
+
+### One Observer Per Structure
+
+Each data structure gets exactly ONE observer type, chosen based on its characteristics:
+
+| Structure  | Observer Type | Callback Receives                    | Rationale                                                                       |
+| ---------- | ------------- | ------------------------------------ | ------------------------------------------------------------------------------- |
+| **Schema** | Snapshot      | Full `WorkspaceSchemaMap`            | Small (~100 tables), changes rarely, triggers global rebuilds anyway            |
+| **KV**     | Snapshot      | Full `KvSnapshot`                    | Tiny (~50 keys), changes occasionally                                           |
+| **Tables** | ID + Action   | `Map<id, 'add'\|'update'\|'delete'>` | Large (1000s of rows), changes frequently, consumer decides if/how to fetch row |
+
+### Schema: Snapshot Observer
+
+```typescript
+// Full schema snapshot on any change
+schema.observe((snapshot: WorkspaceSchemaMap) => {
+	// snapshot = { tables: {...}, kv: {...} }
+	console.log('Schema changed:', snapshot);
+});
+```
+
+**Already exists** - no changes needed.
+
+### KV: Snapshot Observer (NEW)
+
+```typescript
+// Full KV snapshot on any change
+kv.observe((snapshot: KvSnapshot) => {
+	// snapshot = { theme: 'dark', fontSize: 14, ... }
+	console.log('Settings changed:', snapshot);
+});
+```
+
+**Use cases:**
+
+- Persistence (stringify and save the whole settings object)
+- Settings provider (React/Svelte context that holds all settings)
+- Debugging/logging
+
+### Tables: ID + Action Observer (SIMPLIFIED)
+
+```typescript
+// Just IDs and actions - no row data, no reconstruction, no validation
+tables.posts.observe(
+	(
+		changes: Map<string, 'add' | 'update' | 'delete'>,
+		transaction: Y.Transaction,
+	) => {
+		for (const [id, action] of changes) {
+			if (action === 'delete') {
+				removeFromCache(id);
+			} else {
+				// Consumer fetches row only if needed
+				const result = tables.posts.get(id);
+				if (result.status === 'valid') {
+					updateCache(id, result.row);
+				}
+			}
+		}
+	},
+);
+```
+
+**Key simplifications from current:**
+
+1. No row reconstruction in observer - consumer calls `table.get(id)` if needed
+2. No validation in observer - consumer validates if needed
+3. Action is just a string, not a wrapper object
+4. Map value is the action directly: `Map<string, 'add' | 'update' | 'delete'>`
+
+**Use cases:**
+
+- Persistence: Know which IDs changed, fetch and write only those
+- UI updates: Know which rows to re-render, fetch fresh data
+- Sync: Know which IDs to send, fetch current state
+- Cache invalidation: Just need IDs, don't need row data at all
+
+## Type Definitions
+
+### Schema Types (Existing)
+
+```typescript
+/**
+ * Full schema snapshot.
+ */
+type WorkspaceSchemaMap = {
+	tables: Record<string, StoredTableSchema>;
+	kv: Record<string, StoredKvSchema>;
+};
+```
+
+### KV Types (New)
+
+```typescript
+/**
+ * Full KV snapshot - all keys and their current values.
+ *
+ * This is the return type of kv.toJSON(), representing the
+ * current state of all KV entries.
+ */
+type KvSnapshot<TKvDefinitionMap extends KvDefinitionMap> = {
+	[K in keyof TKvDefinitionMap]?: KvValue<TKvDefinitionMap[K]['field']>;
+};
+```
+
+### Table Types (Simplified)
+
+```typescript
+/**
+ * Action that occurred on a row.
+ */
+type RowAction = 'add' | 'update' | 'delete';
+
+/**
+ * Map of row IDs to the action that occurred.
+ *
+ * The observer only tells you WHAT changed (IDs) and HOW (action).
+ * To get the actual row data, call table.get(id).
+ */
+type RowChanges = Map<string, RowAction>;
+```
+
+**Key change from current `TableRowChange`:**
+
+- Before: `Map<string, { action: 'add'; result: RowResult<TRow> } | ...>`
+- After: `Map<string, 'add' | 'update' | 'delete'>` - just ID → action
+
+### Why No Row Data in Observer?
+
+1. **Zero waste**: Observer doesn't reconstruct rows that consumer might not need
+2. **Consumer decides**: Fetch with validation (`get`), without validation (future `getRaw`), or not at all
+3. **Simpler implementation**: No `reconstructRow()` calls in observer hot path
+4. **Simpler types**: No generics needed for the change type itself
+
+**Consumers who need row data:**
+
+```typescript
+tables.posts.observe((changes) => {
+	for (const [id, action] of changes) {
+		if (action === 'delete') continue;
+
+		// Fetch row when needed
+		const result = tables.posts.get(id);
+		if (result.status === 'valid') {
+			// use result.row
+		}
+	}
+});
+```
+
+## API Summary
+
+### Schema
+
+````typescript
+/**
+ * Observe schema changes. Callback receives full snapshot on any change.
+ *
+ * @example
+ * ```typescript
+ * const unsub = schema.observe((snapshot) => {
+ *   console.log('Tables:', Object.keys(snapshot.tables));
+ *   rebuildValidators(snapshot);
+ * });
+ * ```
+ */
+schema.observe(callback: (snapshot: WorkspaceSchemaMap) => void): () => void
+````
+
+### KV
+
+````typescript
+/**
+ * Observe KV changes. Callback receives full snapshot on any change.
+ *
+ * @example
+ * ```typescript
+ * const unsub = kv.observe((snapshot) => {
+ *   console.log('Current theme:', snapshot.theme);
+ *   saveSettingsToFile(snapshot);
+ * });
+ * ```
+ */
+kv.observe(callback: (snapshot: KvSnapshot) => void): () => void
+````
+
+### Tables
+
+````typescript
+/**
+ * Observe table changes. Callback receives Map of row IDs to actions.
+ *
+ * Changes are batched per Y.Transaction - bulk operations fire one callback.
+ * The transaction object enables origin checks (local vs remote).
+ *
+ * To get row data, call table.get(id) - the observer intentionally
+ * does not include row data to avoid unnecessary reconstruction.
+ *
+ * @example
+ * ```typescript
+ * const unsub = tables.posts.observe((changes, transaction) => {
+ *   // Skip our own changes (echo prevention)
+ *   if (transaction.origin === 'local') return;
+ *
+ *   for (const [id, action] of changes) {
+ *     if (action === 'delete') {
+ *       removeFromUI(id);
+ *     } else {
+ *       // Fetch row data only when needed
+ *       const result = tables.posts.get(id);
+ *       if (result.status === 'valid') {
+ *         updateUI(id, result.row);
+ *       }
+ *     }
+ *   }
+ * });
+ * ```
+ */
+tables.posts.observe(
+  callback: (changes: Map<string, 'add' | 'update' | 'delete'>, transaction: Y.Transaction) => void
+): () => void
+````
+
+## Implementation Plan
+
+### Phase 1: Add KV Observer (Non-breaking)
+
+Add `kv.observe()` method that emits full snapshot on any change.
+
+**Files to modify:**
+
+- `packages/epicenter/src/core/kv/core.ts` - Add `observe()` method
+
+**Implementation:**
+
+```typescript
+observe(callback: (snapshot: KvSnapshot) => void): () => void {
+  const handler = () => {
+    callback(this.toJSON());
+  };
+  ykvMap.observeDeep(handler);
+  return () => ykvMap.unobserveDeep(handler);
+}
+```
+
+### Phase 2: Simplify Table Observer (Breaking)
+
+1. Remove `TableRowChange` type entirely
+2. Change callback signature from `Map<string, TableRowChange>` to `Map<string, 'add' | 'update' | 'delete'>`
+3. Remove `reconstructRow()` calls from observer implementation
+4. Remove validation from observer implementation
+5. Rename `observeChanges` to `observe` for consistency
+6. Update all consumers
+
+**Files to modify:**
+
+- `packages/epicenter/src/core/tables/table-helper.ts`
+  - Remove `TableRowChange` type (lines 133-136)
+  - Simplify `observeChanges` implementation - just queue `{ id, action }`, no row reconstruction
+  - Rename to `observe`
+- `packages/epicenter/src/extensions/sqlite/sqlite.ts` - Update consumer
+- `packages/epicenter/src/extensions/markdown/markdown.ts` - Update consumer
+- `apps/tab-manager/src/entrypoints/background.ts` - Update consumer
+- All test files using `observeChanges`
+
+**Simplified observer implementation:**
+
+```typescript
+observe(
+  callback: (changes: Map<string, 'add' | 'update' | 'delete'>, transaction: Y.Transaction) => void
+): () => void {
+  let pendingChanges = new Map<string, 'add' | 'update' | 'delete'>();
+  let pendingTransaction: Y.Transaction | null = null;
+
+  const afterTransactionHandler = () => {
+    if (pendingChanges.size > 0 && pendingTransaction) {
+      callback(pendingChanges, pendingTransaction);
+      pendingChanges = new Map();
+      pendingTransaction = null;
+    }
+  };
+
+  ydoc.on('afterTransaction', afterTransactionHandler);
+
+  const queueChange = (id: string, action: 'add' | 'update' | 'delete', transaction: Y.Transaction) => {
+    pendingTransaction = transaction;
+    pendingChanges.set(id, action);
+  };
+
+  // ... rest of observer setup (table-level and row-level observers)
+  // but WITHOUT reconstructRow() or validation calls
+}
+```
+
+### Phase 3: Update Persistence Extension
+
+Update `workspace-persistence.ts` to use the new APIs:
+
+```typescript
+// Before
+const schemaMap = ydoc.getMap('schema');
+schemaMap.observeDeep(handler);
+
+// After
+const unsubSchema = schema.observe((snapshot) => {
+	scheduleSchemaJsonSave(snapshot);
+});
+
+const unsubKv = kv.observe((snapshot) => {
+	scheduleKvJsonSave(snapshot);
+});
+```
+
+## Migration Guide
+
+### For Table Observers
+
+**Before (current):**
+
+```typescript
+tables.posts.observeChanges((changes) => {
+	for (const [id, change] of changes) {
+		if (change.action === 'delete') continue;
+
+		// Row data was included in change
+		if (change.result.status === 'valid') {
+			console.log('Row:', change.result.row);
+		}
+	}
+});
+```
+
+**After (simplified):**
+
+```typescript
+tables.posts.observe((changes) => {
+	for (const [id, action] of changes) {
+		if (action === 'delete') continue;
+
+		// Fetch row data explicitly
+		const result = tables.posts.get(id);
+		if (result.status === 'valid') {
+			console.log('Row:', result.row);
+		}
+	}
+});
+```
+
+### For Consumers That Only Need IDs
+
+Some consumers (like cache invalidation) only need to know which IDs changed:
+
+```typescript
+// Before: had to ignore the row data
+tables.posts.observeChanges((changes) => {
+	for (const [id, change] of changes) {
+		invalidateCache(id);
+	}
+});
+
+// After: cleaner - no unused data
+tables.posts.observe((changes) => {
+	for (const [id, action] of changes) {
+		invalidateCache(id);
+	}
+});
+```
+
+## Batching Behavior
+
+All observers are batched per Y.Transaction:
+
+| Structure | Batching        | Rationale                                              |
+| --------- | --------------- | ------------------------------------------------------ |
+| Schema    | Per-transaction | Ensures consistent state (all schema changes together) |
+| KV        | Per-transaction | Ensures consistent state (all KV changes together)     |
+| Tables    | Per-transaction | Already implemented; bulk ops fire once                |
+
+This is achieved using `ydoc.on('afterTransaction', handler)` pattern.
+
+## Future: SvelteMap Integration
+
+The simplified observer enables clean SvelteMap integration:
+
+```typescript
+// Future API concept
+const postsMap: SvelteMap<string, TRow> = tables.posts.toSvelteMap();
+
+// Internally:
+// 1. Initial population from table.getAll()
+// 2. observe() to track changes
+// 3. On add/update: fetch row with table.get(id), update SvelteMap
+// 4. On delete: remove from SvelteMap
+```
+
+## References
+
+- [Svelte 5 SvelteMap](https://svelte.dev/docs/svelte/svelte-reactivity) - Reactive Map implementation
+- Current table observation: `packages/epicenter/src/core/tables/table-helper.ts:538`
+- Current schema observation: `packages/epicenter/src/core/schema-helper/schema-helper.ts:929`
+- Current KV per-key observation: `packages/epicenter/src/core/kv/kv-helper.ts:202`


### PR DESCRIPTION
The core philosophy is **"notify at the Y.Map boundary, let the consumer fetch the data"**.

Observers don't reconstruct or validate data; they just tell you what changed. You call the appropriate getter when you need the data.

```
┌─────────────────────────────────────────────────────────────────┐
│                      OBSERVATION PATTERNS                        │
├─────────────────────────────────────────────────────────────────┤
│                                                                  │
│  Single Y.Map (schema, kv top-level)                            │
│  ─────────────────────────────────────                          │
│  Observer: () => void                                           │
│  Consumer: calls .get() or .toJSON()                            │
│                                                                  │
│      schema.observe(() => {                                     │
│        const snapshot = schema.get();                           │
│      });                                                        │
│                                                                  │
├─────────────────────────────────────────────────────────────────┤
│                                                                  │
│  Nested Y.Maps (schema.tables, schema.kv)                       │
│  ─────────────────────────────────────────                      │
│  Observer: Map<key, 'add'|'delete'>                             │
│  Consumer: calls .get(key)                                      │
│                                                                  │
│      schema.tables.observe((changes) => {                       │
│        for (const [name, action] of changes) {                  │
│          if (action === 'add') registerTable(name);             │
│        }                                                        │
│      });                                                        │
│                                                                  │
├─────────────────────────────────────────────────────────────────┤
│                                                                  │
│  Table Rows (tables.{name})                                     │
│  ──────────────────────────                                     │
│  Observer: Set<id>                                              │
│  Consumer: calls table.get(id) to check existence               │
│                                                                  │
│      tables.posts.observe((changedIds) => {                     │
│        for (const id of changedIds) {                           │
│          const result = tables.posts.get(id);                   │
│          if (result.status === 'not_found') handleDelete(id);   │
│          else if (result.status === 'valid') update(result.row);│
│        }                                                        │
│      });                                                        │
│                                                                  │
└─────────────────────────────────────────────────────────────────┘
```

**Why no 'update' action for schema.tables/schema.kv?**

This is Y.js behavior: nested Y.Maps don't fire 'update' on the parent. Changes to children fire on the child's observer instead.