### PR TITLE
feat(epicenter): restore YKeyValue utility for stable ID schema pattern

### DIFF
--- a/docs/articles/api-design-decisions-definetable-definekv.md
+++ b/docs/articles/api-design-decisions-definetable-definekv.md
@@ -1,0 +1,215 @@
+# API Design Decisions: defineTable and defineKV
+
+Designing an API is about trade-offs. Every choice closes some doors and opens others. Here's the reasoning behind Epicenter's versioned schema API.
+
+## The Final API
+
+```typescript
+const posts = defineTable('posts')
+  .version(schema1)
+  .version(schema2)
+  .version(schema3)
+  .migrate((row) => { ... });
+
+const tables = createTables(ydoc, { posts });
+```
+
+This didn't emerge fully formed. We considered many alternatives.
+
+## Naming: `defineTable` vs Alternatives
+
+**Options considered:**
+
+| Name | Feel | Problem |
+|------|------|---------|
+| `table('posts')` | Clean, short | Ambiguous - is it getting or creating a table? |
+| `createTable('posts')` | Clear it creates | Conflicts with `createTables()` binding function |
+| `defineTable('posts')` | Clear it defines | Slightly verbose |
+| `schema('posts')` | Generic | Doesn't convey it's for tables |
+
+**We chose `defineTable` because:**
+- The `define` prefix signals "this is a definition, not a runtime instance"
+- Clear distinction from `createTables()` which binds definitions to storage
+- Familiar pattern from other libraries (Drizzle's `defineRelations`, etc.)
+
+## Naming: `defineKV` vs `defineKVKey`
+
+Early versions used `defineKVKey`:
+
+```typescript
+const theme = defineKVKey('theme')
+  .version(...)
+  .migrate(...);
+```
+
+**We shortened to `defineKV` because:**
+- "KVKey" is redundant - "KV" already implies key-value
+- The first argument IS the key
+- Saying it aloud: "define KV key theme" vs "define KV theme" - the latter is cleaner
+
+## Method Chaining: `.version().migrate()`
+
+**Alternative A: Explicit version numbers**
+```typescript
+defineTable('posts')
+  .v1(schema1)
+  .v2(schema2)
+  .v3(schema3)
+  .migrate(fn);
+```
+
+Rejected because:
+- Limits versions to whatever we pre-define (v1-v10?)
+- Verbose for no benefit
+- Version numbers are implicit in call order anyway
+
+**Alternative B: Migration per version**
+```typescript
+defineTable('posts')
+  .version(schema1)
+  .version(schema2, (v1) => ({ ...v1, views: 0 }))
+  .version(schema3, (v2) => ({ ...v2, author: null }));
+```
+
+This has appeal - each version is co-located with its migration. We almost chose this.
+
+Rejected because:
+- Can't do direct jumps (v1→v3) without intermediate steps
+- Type inference is trickier (each migration is `(prev) => next`)
+- Harder to refactor - migration logic spread across multiple calls
+
+**Chosen: `.version().migrate()`**
+```typescript
+defineTable('posts')
+  .version(schema1)
+  .version(schema2)
+  .version(schema3)
+  .migrate((row) => { ... });
+```
+
+Benefits:
+- Clean separation of schema definitions and migration logic
+- Full control over migration strategy (incremental or direct)
+- Single place for all migration logic
+- Simpler types: `(V1 | V2 | V3) => V3`
+
+## User-Defined vs Library-Managed Discriminator
+
+**Option A: Library injects `__v`**
+```typescript
+// Library automatically adds __v: 1, __v: 2, etc.
+.version(schema1)
+.version(schema2)
+```
+
+**Option B: User defines discriminator**
+```typescript
+// User explicitly adds _v (or whatever they want)
+.version(z.object({ ..., _v: z.literal('1') }))
+.version(z.object({ ..., _v: z.literal('2') }))
+```
+
+**We chose Option B because:**
+
+1. **No magic** - What you see in your schema is what's in your data
+2. **Flexibility** - Use `_v`, `version`, `schemaVersion`, `type`, whatever
+3. **Value flexibility** - Numbers, strings, enums, your choice
+4. **Simpler implementation** - Library doesn't inject/strip fields
+5. **Debugging** - Raw data inspection shows exactly what you defined
+
+The trade-off is users might forget the discriminator. We mitigate with documentation and the fact that TypeScript will complain if your migration function can't discriminate.
+
+## Definition/Binding Separation
+
+**Option A: All-in-one**
+```typescript
+const tables = createTables(ydoc, {
+  posts: defineTable('posts').version(...).migrate(...)
+});
+```
+
+**Option B: Separate definition from binding**
+```typescript
+// Define (pure, no side effects)
+const postsDefinition = defineTable('posts')
+  .version(...)
+  .migrate(...);
+
+// Bind (connects to Y.Doc)
+const tables = createTables(ydoc, { posts: postsDefinition });
+```
+
+**We chose Option B because:**
+
+1. **Definitions are reusable** - Same definition, different Y.Docs (great for testing)
+2. **Clear phases** - Definition is pure, binding has side effects
+3. **Testability** - Test definitions in isolation
+4. **Organizational flexibility** - Define in one file, bind in another
+
+## Single `.migrate()` vs Multiple
+
+With multiple versions, you need migration logic. The question is how to structure it.
+
+**Incremental (each version migrates to next):**
+```typescript
+v1 → v2 → v3
+```
+
+**Direct (any version migrates to latest):**
+```typescript
+v1 → v3
+v2 → v3
+```
+
+We don't enforce either. The single `.migrate()` function receives any version and must return the latest. How you structure that is up to you:
+
+```typescript
+// Incremental style
+.migrate((row) => {
+  let current = row;
+  if (current._v === '1') current = migrateV1toV2(current);
+  if (current._v === '2') current = migrateV2toV3(current);
+  return current;
+})
+
+// Direct style
+.migrate((row) => {
+  switch (row._v) {
+    case '1': return { ...row, views: 0, author: null, _v: '3' };
+    case '2': return { ...row, author: null, _v: '3' };
+    case '3': return row;
+  }
+})
+```
+
+Both work. We give you the flexibility to choose.
+
+## Symmetry: Tables and KV
+
+We deliberately made Tables and KV APIs symmetric:
+
+```typescript
+// Tables
+defineTable('posts').version(...).migrate(...)
+createTables(ydoc, { posts })
+tables.posts.get()
+
+// KV
+defineKV('theme').version(...).migrate(...)
+createKV(ydoc, { theme })
+kv.theme.get()
+```
+
+Same pattern, same mental model. Learn one, use both.
+
+## Summary
+
+Good API design is about:
+- **Clarity** - Names that say what they do
+- **Consistency** - Similar things work similarly
+- **Flexibility** - Don't over-constrain users
+- **Simplicity** - Fewer concepts to learn
+
+We made trade-offs. Someone who wants per-version migrations might disagree with our choice. Someone who likes library-managed version fields might find ours verbose.
+
+But we optimized for clarity and flexibility over magic and brevity. For a foundational API that developers build on, we think that's the right call.

--- a/docs/articles/cell-level-crdt-vs-row-level-lww.md
+++ b/docs/articles/cell-level-crdt-vs-row-level-lww.md
@@ -1,0 +1,180 @@
+# The Trade-off: Cell-Level CRDT vs Row-Level LWW
+
+Most CRDT-based databases let you edit individual fields of a record independently. Epicenter doesn't. We use row-level last-write-wins.
+
+This is a deliberate trade-off, and it's not right for every app. Here's how to think about it.
+
+## Cell-Level CRDT: The Default Approach
+
+In a typical CRDT database, each field is an independent data structure:
+
+```
+Record: users/alice
+├── name: LWW("Alice")        ← Independent CRDT
+├── email: LWW("a@b.com")     ← Independent CRDT
+└── bio: Y.Text("Hello...")   ← Independent CRDT
+```
+
+When Alice updates her name while Bob updates her email, both changes merge:
+
+```
+Alice: { name: "Alicia" }     → merged
+Bob:   { email: "new@b.com" } → merged
+Result: { name: "Alicia", email: "new@b.com", bio: "Hello..." }
+```
+
+No conflicts. No data loss. This is the CRDT promise.
+
+## Row-Level LWW: Epicenter's Approach
+
+In Epicenter, the entire row is one atomic blob:
+
+```
+Record: users/alice = { name: "Alice", email: "a@b.com", bio: "Hello...", _v: "2" }
+                      ↑ One atomic value
+```
+
+When Alice and Bob edit simultaneously:
+
+```
+Alice: { name: "Alicia", email: "a@b.com", bio: "Hello...", _v: "2" }
+Bob:   { name: "Alice", email: "new@b.com", bio: "Hello...", _v: "2" }
+```
+
+Last write wins. One of their changes is lost.
+
+## Why Would Anyone Choose Row-Level LWW?
+
+Because it enables something cell-level CRDTs can't: **coherent schema versioning**.
+
+### The Schema Version Problem
+
+With cell-level CRDTs, imagine this scenario:
+
+1. You ship v1 of your app with schema `{ name, email }`
+2. You ship v2 with schema `{ name, email, bio }`
+3. Alice (on v2) adds a bio
+4. Bob (on v1) updates the name
+5. After sync, the record has cells from both versions
+
+What schema version is this record? It's neither v1 nor v2. It's a Frankenstein mix.
+
+Your migration function can't handle this:
+
+```typescript
+.migrate((row) => {
+  // Is this v1 or v2? It has 'bio' (v2) but was partially
+  // written by a v1 client. The _v field might say "1"
+  // but the data has v2 fields. Or vice versa.
+  // There's no coherent answer.
+})
+```
+
+### Row-Level Solves This
+
+With row-level LWW, the entire row comes from a single write:
+
+```typescript
+// Alice writes (v2 client):
+{ name: "Alice", email: "a@b.com", bio: "Hello", _v: "2" }
+
+// Bob writes (v1 client):
+{ name: "Bobby", email: "b@b.com", _v: "1" }
+
+// After sync, it's one or the other - not a mix
+// Migration knows exactly what it's dealing with
+```
+
+Every row has a coherent schema version because every row is from a single atomic write.
+
+## The Trade-off Matrix
+
+| Aspect | Cell-Level CRDT | Row-Level LWW |
+|--------|----------------|---------------|
+| Concurrent field edits | Merge perfectly | Last writer wins |
+| Schema versioning | Broken (mixed versions) | Works cleanly |
+| Conflict resolution | Per-field | Per-row |
+| Storage efficiency | More metadata | Less metadata |
+| Migration complexity | Very hard | Straightforward |
+
+## When to Use Cell-Level CRDT
+
+**Good fit for:**
+- Real-time collaborative editing (Google Docs-style)
+- Apps where multiple users edit the same record simultaneously
+- Data with stable schemas that rarely change
+- Records with independent fields (editing one shouldn't affect others)
+
+**Examples:**
+- Collaborative document editors
+- Shared whiteboards
+- Real-time multiplayer game state
+
+## When to Use Row-Level LWW
+
+**Good fit for:**
+- Document-style data (one author at a time)
+- Apps that need schema evolution
+- Records that are conceptually atomic
+- Apps where "last edit wins" is acceptable
+
+**Examples:**
+- Note-taking apps (one person writes a note)
+- Task managers (tasks have an owner)
+- CMS systems (articles have an author)
+- Settings/preferences (user updates their own settings)
+
+## The Honest Assessment
+
+Row-level LWW is a constraint. You lose the CRDT magic of conflict-free field merging.
+
+But schema evolution is also a constraint. Most apps need to evolve their data model, and "CRDT migration hell" is a real problem that has sunk local-first projects.
+
+Epicenter chooses row-level LWW because:
+
+1. **Most apps don't need concurrent field editing** - One person edits a document at a time
+2. **Most apps do need schema evolution** - Requirements change, data models change
+3. **Last-write-wins is often acceptable** - For non-collaborative data, it's fine
+4. **Simpler mental model** - Easier to reason about than per-field merging
+
+## Hybrid Approaches
+
+You don't have to choose one approach for everything.
+
+**Use row-level for structured data:**
+```typescript
+// Settings, preferences, records with schemas
+const settings = defineKV('settings')
+  .version(schema1)
+  .version(schema2)
+  .migrate(...);
+```
+
+**Use cell-level for collaborative content:**
+```typescript
+// Store rich text as Y.Text in a separate structure
+const content = doc.getText('content');  // Full CRDT merging
+```
+
+**Reference between them:**
+```typescript
+// Row references the collaborative content
+const post = {
+  id: 'post-1',
+  title: 'My Post',          // Row-level LWW
+  contentId: 'content-123',  // Points to Y.Text
+  _v: '2'
+};
+```
+
+This gives you schema versioning for metadata and CRDT merging for content.
+
+## Conclusion
+
+There's no universally correct answer. Cell-level CRDTs and row-level LWW solve different problems.
+
+Epicenter bets that for most apps, schema evolution matters more than concurrent field editing. If your app is highly collaborative with multiple users editing the same record simultaneously, Epicenter's approach might not be right for you.
+
+But if you're building a local-first app where data has an "owner" and schemas need to evolve, row-level LWW with migrate-on-read is a powerful pattern that sidesteps the hardest problems in CRDT-land.
+
+Know your requirements. Choose accordingly.

--- a/docs/articles/schema-granularity-matches-write-granularity.md
+++ b/docs/articles/schema-granularity-matches-write-granularity.md
@@ -1,0 +1,115 @@
+# Why Versioned Schemas Work in Epicenter
+
+The key insight that makes schema versioning possible in Epicenter is deceptively simple: **the granularity of the schema matches the granularity of the writes**.
+
+## The Problem with Cell-Level CRDTs
+
+Most CRDT-based databases use cell-level merging. Each field in a row is an independent CRDT that can be edited concurrently:
+
+```
+Row: posts/row-1
+├── title: Y.Text("Hello")      ← Can be edited independently
+├── views: LWW(42)              ← Can be edited independently
+└── author: LWW("alice")        ← Can be edited independently
+```
+
+This is great for concurrent editing. Alice can update `title` while Bob updates `views`, and both changes merge cleanly.
+
+But it creates a fundamental problem for schema evolution: **after concurrent edits, different cells could be at different schema versions**.
+
+Imagine you ship v2 of your schema that adds a `views` field. Alice's client (on v2) writes `{ title: "Hello", views: 0 }`. Bob's client (still on v1) writes `{ title: "World" }`. After sync, you have:
+
+```
+Row: posts/row-1
+├── title: "World"    ← From Bob (v1 client)
+├── views: 0          ← From Alice (v2 client)
+```
+
+What schema version is this row? It's... neither? It's a Frankenstein mix of v1 and v2 data. Your migration function can't handle this because the row isn't coherent.
+
+## Epicenter's Solution: Row-Level Atomicity
+
+Epicenter takes a different approach. Instead of cell-level CRDTs, we use **row-level last-write-wins**:
+
+```
+Row: posts/row-1 = { id: "row-1", title: "Hello", views: 42, _v: "2" }
+                   ↑ Entire row is one atomic blob
+```
+
+When you update a row, you replace the entire thing. This means:
+
+1. **The entire row has a coherent schema version** - all fields come from the same write
+2. **Migration is straightforward** - check the version, transform the whole row
+3. **No Frankenstein rows** - impossible to have mixed-version cells
+
+## The Trade-off
+
+This is a deliberate trade-off:
+
+| Approach | Concurrent Field Edits | Schema Versioning |
+|----------|------------------------|-------------------|
+| Cell-level CRDT | Merge cleanly | Broken (mixed versions) |
+| Row-level LWW | Last write wins | Works perfectly |
+
+If Alice edits `title` and Bob edits `views` at the same time, one of their changes will be lost. The last writer wins for the entire row.
+
+**When this trade-off makes sense:**
+- Document-style data edited by one user at a time
+- Apps where schema evolution is more important than concurrent field editing
+- Data with frequent schema changes during development
+
+**When to use cell-level CRDTs instead:**
+- Highly collaborative apps (multiple users editing same row simultaneously)
+- Apps with stable schemas that rarely change
+
+## The API
+
+Here's how it looks in practice:
+
+```typescript
+const posts = defineTable('posts')
+  .version(type({ id: 'string', title: 'string', _v: '"1"' }))
+  .version(type({ id: 'string', title: 'string', views: 'number', _v: '"2"' }))
+  .version(type({ id: 'string', title: 'string', views: 'number', tags: 'string[]', _v: '"3"' }))
+  .migrate((row) => {
+    switch (row._v) {
+      case '1':
+        return { ...row, views: 0, tags: [], _v: '3' as const };
+      case '2':
+        return { ...row, tags: [], _v: '3' as const };
+      case '3':
+        return row;
+    }
+  });
+```
+
+The `.version()` calls register schema versions. The `.migrate()` function receives any version and normalizes to the latest.
+
+Because the entire row is atomic, you're guaranteed that `row._v` tells you the exact schema of every field in that row. No ambiguity, no mixed versions.
+
+## Same Pattern for KV
+
+The same principle applies to key-value storage:
+
+```typescript
+const theme = defineKV('theme')
+  .version(type({ mode: "'light' | 'dark'", _v: '"1"' }))
+  .version(type({ mode: "'light' | 'dark' | 'system'", accentColor: 'string', _v: '"2"' }))
+  .migrate((v) => {
+    if (v._v === '1') return { ...v, accentColor: '#3b82f6', _v: '2' as const };
+    return v;
+  });
+```
+
+Each KV value is an atomic blob, so each value has a coherent schema version.
+
+## The Key Insight
+
+**Granularity match is what makes versioned schemas possible.**
+
+- Tables: Row-level writes → Row-level schema versions
+- KV: Value-level writes → Value-level schema versions
+
+If your writes are atomic at some boundary, your schemas can be versioned at that same boundary. Epicenter chooses row/value boundaries, which enables clean schema evolution at the cost of concurrent field editing.
+
+This isn't the right choice for every app. But for apps that need to evolve their schemas over time (which is most apps), it's a powerful pattern that eliminates the "CRDT migration hell" that plagues many local-first applications.

--- a/docs/articles/standard-schema-library-agnostic-validation.md
+++ b/docs/articles/standard-schema-library-agnostic-validation.md
@@ -1,0 +1,181 @@
+# Standard Schema for Library-Agnostic Validation
+
+When building a library that needs validation, you face a choice: which validation library do you depend on? Zod? ArkType? TypeBox? Each has fans who won't switch.
+
+Standard Schema offers an escape: a common interface that validation libraries implement, allowing you to build tools that work with any of them.
+
+## What is Standard Schema?
+
+Standard Schema is a specification (not a library) that defines a common interface for schema validation:
+
+```typescript
+type StandardSchemaV1<Input = unknown, Output = Input> = {
+  readonly '~standard': {
+    readonly version: 1;
+    readonly vendor: string;
+    readonly validate: (value: unknown) => Result<Output>;
+  };
+};
+
+type Result<Output> =
+  | { value: Output; issues?: undefined }  // Success
+  | { issues: Issue[] };                    // Failure
+```
+
+That's it. Any object with a `~standard` property containing a `validate` function is a Standard Schema.
+
+## Who Implements It?
+
+As of 2025, these libraries implement Standard Schema:
+
+- **ArkType** - Built-in support
+- **Zod** (v4.2+) - Built-in support
+- **Valibot** - Built-in support
+- **TypeBox** - Via adapter
+
+This means you can write code that accepts any of these:
+
+```typescript
+function validateData<T>(schema: StandardSchemaV1<unknown, T>, data: unknown): T {
+  const result = schema['~standard'].validate(data);
+  if (result.issues) {
+    throw new Error(result.issues[0].message);
+  }
+  return result.value;
+}
+
+// Works with any library:
+validateData(z.string(), "hello");           // Zod
+validateData(type("string"), "hello");       // ArkType
+validateData(v.string(), "hello");           // Valibot
+```
+
+## Building a Union Schema
+
+Standard Schema doesn't provide composition primitives. You can't do `schema1.or(schema2)` at the Standard Schema level because that's library-specific.
+
+But you can build your own union wrapper:
+
+```typescript
+function createUnionSchema<T extends StandardSchemaV1[]>(
+  schemas: T
+): StandardSchemaV1<
+  StandardSchemaV1.InferInput<T[number]>,
+  StandardSchemaV1.InferOutput<T[number]>
+> {
+  return {
+    '~standard': {
+      version: 1,
+      vendor: 'my-library',
+      validate: (value) => {
+        // Try each schema until one succeeds
+        for (const schema of schemas) {
+          const result = schema['~standard'].validate(value);
+          if (!result.issues) return result;
+        }
+        return {
+          issues: [{ message: 'Value did not match any schema' }]
+        };
+      }
+    }
+  };
+}
+```
+
+This is O(n) - it tries each schema sequentially. For most use cases with a small number of schemas, this is fine.
+
+## Performance Considerations
+
+Different libraries have different performance characteristics:
+
+| Library | Union Approach | Performance |
+|---------|---------------|-------------|
+| ArkType | Auto-discriminates | O(1) |
+| Zod | `z.discriminatedUnion()` | O(1) with discriminator |
+| Zod | `z.union()` | O(n) tries each |
+| TypeBox | JIT compiled | Very fast |
+
+If you know all your schemas are from the same library, you could optimize:
+
+```typescript
+function createOptimizedUnion(schemas: StandardSchemaV1[]) {
+  const vendors = new Set(schemas.map(s => s['~standard'].vendor));
+
+  if (vendors.size === 1 && vendors.has('arktype')) {
+    // All ArkType - use native union for auto-discrimination
+    return (schemas as Type[]).reduce((acc, s) => acc.or(s));
+  }
+
+  // Mixed libraries - use generic approach
+  return createUnionSchema(schemas);
+}
+```
+
+But in practice, the generic approach is fast enough for most cases.
+
+## How Epicenter Uses Standard Schema
+
+Epicenter's versioned schemas use Standard Schema unions:
+
+```typescript
+const posts = defineTable('posts')
+  .version(arktypeSchema)   // ArkType schema
+  .version(zodSchema)       // Could even be Zod!
+  .migrate((row) => { ... });
+```
+
+Internally:
+1. Collect all version schemas
+2. Create a Standard Schema union
+3. On read, validate against the union
+4. Run migration function
+
+This means Epicenter works with whatever validation library you prefer. Use ArkType for its speed, Zod for its ecosystem, or TypeBox for JSON Schema compatibility.
+
+## Type Inference
+
+Standard Schema includes type inference helpers:
+
+```typescript
+type StandardSchemaV1 {
+  // ...
+}
+
+namespace StandardSchemaV1 {
+  type InferInput<Schema> = Schema['~standard']['types']['input'];
+  type InferOutput<Schema> = Schema['~standard']['types']['output'];
+}
+```
+
+This lets you extract the TypeScript type from any Standard Schema:
+
+```typescript
+function process<T extends StandardSchemaV1>(
+  schema: T,
+  data: StandardSchemaV1.InferInput<T>
+): StandardSchemaV1.InferOutput<T> {
+  const result = schema['~standard'].validate(data);
+  if (result.issues) throw new Error('Validation failed');
+  return result.value;
+}
+```
+
+## When to Use Standard Schema
+
+**Use it when:**
+- Building a library that needs validation but shouldn't force a specific library
+- You want to support multiple validation libraries
+- You're composing schemas from different sources
+
+**Don't bother when:**
+- You control the whole stack and can pick one library
+- You need library-specific features (transforms, refinements, etc.)
+- Performance is critical and you need library-specific optimizations
+
+## Conclusion
+
+Standard Schema is a simple but powerful abstraction. By programming against the interface rather than a specific library, you build tools that work for everyone.
+
+The ecosystem is still young, but adoption is growing. As more libraries implement it, Standard Schema becomes increasingly valuable for library authors who want to stay agnostic.
+
+For Epicenter, it means users can bring their preferred validation library. That flexibility is worth the small overhead of the generic union approach.

--- a/docs/articles/versioned-schemas-migrate-on-read.md
+++ b/docs/articles/versioned-schemas-migrate-on-read.md
@@ -1,0 +1,202 @@
+# Versioned Schemas with Migrate-on-Read
+
+Most developers struggle with migrations in local-first apps. The core issue: how do you rename columns, change field types, or restructure data when that data is replicated across many clients with different app versions?
+
+Epicenter solves this with a pattern we call **migrate-on-read**: store data in its original schema version, validate and migrate when reading.
+
+## The Problem with Traditional Migrations
+
+In a traditional database, migrations are applied once to all data:
+
+```sql
+ALTER TABLE posts ADD COLUMN views INTEGER DEFAULT 0;
+```
+
+Every row gets the new column. Done.
+
+But in a local-first app:
+- Data lives on many devices
+- Devices might be offline for weeks
+- Old app versions might still be writing data
+- You can't run a migration "on the database" because there are thousands of databases
+
+Running migrations on sync is fragile. What if the migration fails halfway? What if two clients sync different versions simultaneously?
+
+## Migrate-on-Read
+
+Instead of migrating data in place, Epicenter migrates when you read:
+
+```typescript
+// Storage contains original data:
+{ id: "row-1", title: "Hello", _v: "1" }  // v1 schema (no views field)
+
+// When you read:
+const post = tables.posts.get("row-1");
+// → { id: "row-1", title: "Hello", views: 0, _v: "3" }  // Migrated to v3
+```
+
+The migration function transforms old data to the latest schema on-the-fly. The original data stays untouched in storage.
+
+**Key benefits:**
+- No migrations to run
+- Old and new clients can coexist
+- Data is always valid when you use it
+- Failed migrations don't corrupt storage
+
+## Defining Versioned Schemas
+
+You define schemas with `.version()` and provide a migration function with `.migrate()`:
+
+```typescript
+const posts = defineTable('posts')
+  // V1: Original schema
+  .version(type({
+    id: 'string',
+    title: 'string',
+    _v: '"1"'
+  }))
+  // V2: Added views counter
+  .version(type({
+    id: 'string',
+    title: 'string',
+    views: 'number',
+    _v: '"2"'
+  }))
+  // V3: Added tags
+  .version(type({
+    id: 'string',
+    title: 'string',
+    views: 'number',
+    tags: 'string[]',
+    _v: '"3"'
+  }))
+  .migrate((row) => {
+    // row is V1 | V2 | V3, must return V3
+    switch (row._v) {
+      case '1':
+        return { ...row, views: 0, tags: [], _v: '3' as const };
+      case '2':
+        return { ...row, tags: [], _v: '3' as const };
+      case '3':
+        return row;
+    }
+  });
+```
+
+## How Validation Works
+
+Internally, Epicenter creates a union of all your schemas:
+
+```typescript
+// Conceptually:
+const unionSchema = schema1 | schema2 | schema3;
+```
+
+When you read data:
+1. Validate against the union (any version is valid)
+2. Run the migration function to normalize to latest
+3. Return strongly-typed latest version
+
+This uses Standard Schema, so you can use any validation library: ArkType, Zod, TypeBox, Valibot.
+
+## The Discriminator Pattern
+
+While not required, we **highly recommend** including a version field in your schemas:
+
+```typescript
+// Recommended: Explicit version field
+.version(type({ id: 'string', title: 'string', _v: '"1"' }))
+.version(type({ id: 'string', title: 'string', views: 'number', _v: '"2"' }))
+```
+
+This makes migrations trivial:
+
+```typescript
+.migrate((row) => {
+  switch (row._v) {
+    case '1': return { ...row, views: 0, _v: '2' as const };
+    case '2': return row;
+  }
+})
+```
+
+Without a discriminator, you have to check for field presence, which is fragile:
+
+```typescript
+// Works but not recommended
+.migrate((row) => {
+  if (!('views' in row)) return { ...row, views: 0 };
+  return row;
+})
+```
+
+## KV Storage
+
+The same pattern works for key-value storage:
+
+```typescript
+const theme = defineKV('theme')
+  .version(type({ mode: "'light' | 'dark'", _v: '"1"' }))
+  .version(type({ mode: "'light' | 'dark' | 'system'", fontSize: 'number', _v: '"2"' }))
+  .migrate((v) => {
+    if (v._v === '1') return { ...v, fontSize: 14, _v: '2' as const };
+    return v;
+  });
+
+// Usage
+kv.theme.set({ mode: 'dark', fontSize: 16, _v: '2' });
+const theme = kv.theme.get();  // Always returns v2 shape
+```
+
+## Reads Are Pure
+
+An important design decision: **reads don't write back migrated data**.
+
+When you read a v1 row and get a v3 result, the storage still contains v1. We don't automatically persist the migration because:
+
+- Reads causing writes is unexpected
+- It would increase sync traffic
+- It could cause conflicts if multiple clients read simultaneously
+
+If you want to persist migrated data, do it explicitly:
+
+```typescript
+const result = tables.posts.get('post-1');
+if (result.status === 'valid') {
+  tables.posts.upsert(result.row);  // Explicitly write back
+}
+```
+
+## Storage: YKeyValue for Bounded Memory
+
+Both tables and KV use YKeyValue (not Y.Map) for storage. Benchmarks show Y.Map has unbounded memory growth with frequent updates:
+
+| Updates/Key | Y.Map | YKeyValue |
+|-------------|-------|-----------|
+| 10 | 562 B | 241 B |
+| 100 | 4.43 KB | 254 B |
+| 1000 | 44 KB | 259 B |
+
+YKeyValue uses an append-and-cleanup pattern that keeps memory bounded regardless of update frequency.
+
+## When to Use This Pattern
+
+**Good fit:**
+- Apps with evolving schemas (most apps)
+- Document-style data edited by one user at a time
+- Apps where data integrity matters more than concurrent field editing
+
+**Consider alternatives if:**
+- You need concurrent editing of individual fields
+- Your schema is completely stable
+- You're building a highly collaborative real-time editor
+
+## Summary
+
+1. Define schemas with `.version()` for each schema evolution
+2. Provide a `.migrate()` function that normalizes any version to latest
+3. Use a `_v` discriminator field (recommended) for clean migrations
+4. Data is validated and migrated on read, not in storage
+5. Both tables and KV use the same pattern
+
+This approach eliminates "CRDT migration hell" by embracing row-level atomicity and lazy migration. Your app always sees the latest schema shape, regardless of when the underlying data was written.

--- a/docs/articles/why-reads-should-be-pure.md
+++ b/docs/articles/why-reads-should-be-pure.md
@@ -1,0 +1,153 @@
+# Why Reads Should Be Pure
+
+When designing Epicenter's migrate-on-read pattern, we faced a question: after reading and migrating old data, should we automatically write the migrated version back to storage?
+
+We decided no. Reads should be pure.
+
+## The Temptation
+
+The argument for auto write-back seems compelling:
+
+```typescript
+// User reads v1 data
+const post = tables.posts.get('post-1');
+// Internally: read v1 → migrate to v3 → return v3
+
+// If we wrote back automatically:
+// Storage now contains v3, future reads are faster
+```
+
+Data gets "upgraded" over time. Future reads skip the migration. Seems efficient.
+
+## Why We Didn't Do It
+
+### 1. Reads Causing Writes Is Unexpected
+
+The principle of least surprise matters. When you call `get()`, you expect to... get something. Not modify storage.
+
+```typescript
+// This looks like a read-only operation
+const post = tables.posts.get('post-1');
+
+// But with auto write-back, it's actually:
+// 1. Read from storage
+// 2. Validate
+// 3. Migrate
+// 4. Write back to storage  ← SURPRISE!
+// 5. Return value
+```
+
+Debugging becomes harder when "read" operations have side effects.
+
+### 2. Increased Sync Traffic
+
+In a local-first app, writes sync to other devices and the server. Auto write-back means:
+
+```
+User opens app
+→ Reads 100 old records
+→ Triggers 100 writes
+→ Syncs 100 changes to server
+→ Syncs to user's other devices
+```
+
+The user did nothing, but their app is churning through bandwidth. On mobile with metered connections, this is hostile.
+
+### 3. Concurrent Read Conflicts
+
+What if two clients read the same v1 record simultaneously?
+
+```
+Client A: read v1 → migrate to v3 → write v3
+Client B: read v1 → migrate to v3 → write v3
+```
+
+Both write the same data, but they're still two writes that need to merge. In Yjs, this creates unnecessary history. With some CRDTs, it could cause conflicts.
+
+### 4. Testing Becomes Harder
+
+Pure reads are easy to test:
+
+```typescript
+// Setup
+storage.write({ id: '1', title: 'Test', _v: '1' });
+
+// Test
+const result = table.get('1');
+expect(result._v).toBe('3');  // Migrated
+
+// Verify storage unchanged
+expect(storage.read('1')._v).toBe('1');  // Still v1
+```
+
+With auto write-back, the same test modifies storage, making assertions about "before and after" states complicated.
+
+### 5. Intentionality Matters
+
+Sometimes you want old data to stay old. Maybe you're debugging, analyzing migration behavior, or intentionally preserving history. Auto write-back removes that choice.
+
+## The Alternative: Explicit Write-Back
+
+If users want to persist migrations, they can do it explicitly:
+
+```typescript
+const result = tables.posts.get('post-1');
+if (result.status === 'valid') {
+  // Explicitly persist the migrated version
+  tables.posts.upsert(result.row);
+}
+```
+
+Or batch it:
+
+```typescript
+// Migrate all old data explicitly
+const allPosts = tables.posts.getAllValid();
+for (const post of allPosts) {
+  tables.posts.upsert(post);
+}
+```
+
+This is intentional. The user knows they're writing. Sync traffic is expected.
+
+## When Auto Write-Back Makes Sense
+
+To be fair, auto write-back isn't always wrong:
+
+**Consider it when:**
+- Migration is computationally expensive (rare)
+- You control the network layer and can batch/debounce
+- Users expect writes (e.g., "upgrade all my data" button)
+
+**Avoid it when:**
+- Reads should be predictable
+- Bandwidth matters
+- You want simple, testable code
+
+For Epicenter's general-purpose API, predictability wins.
+
+## Implementation
+
+Our implementation is simple because we don't write back:
+
+```typescript
+function get(id: string): GetResult<TRow> {
+  const raw = storage.read(id);
+  if (!raw) return { status: 'not_found', id };
+
+  const validated = unionSchema.validate(raw);
+  if (validated.issues) return { status: 'invalid', ... };
+
+  const migrated = migrate(validated.value);
+  return { status: 'valid', row: migrated };
+  // Note: no write!
+}
+```
+
+Clean, predictable, testable.
+
+## Conclusion
+
+"Reads should be pure" isn't a universal law, but it's a good default. Side effects in unexpected places create surprising behavior, debugging nightmares, and architectural complexity.
+
+For Epicenter, we chose purity. If you need to persist migrations, do it explicitly. Your future self debugging a sync issue will thank you.

--- a/docs/articles/yjs-memory-management-ymap-vs-ykeyvalue.md
+++ b/docs/articles/yjs-memory-management-ymap-vs-ykeyvalue.md
@@ -1,0 +1,127 @@
+# Memory Management in Yjs: Y.Map vs YKeyValue
+
+Yjs is a CRDT library that enables real-time collaboration. But there's a subtle issue that can cause your app to consume unbounded memory over time: Y.Map retains all historical values for each key.
+
+## The Problem: Y.Map's Unbounded Growth
+
+When you update a key in Y.Map, Yjs doesn't just overwrite the old value. It needs to remember what was there so it can merge correctly when syncing with other clients.
+
+```typescript
+const map = doc.getMap('settings');
+
+map.set('theme', 'light');  // 1 item stored
+map.set('theme', 'dark');   // 2 items stored (old value retained!)
+map.set('theme', 'light');  // 3 items stored
+map.set('theme', 'dark');   // 4 items stored
+// ... after 1000 updates: 1000 items stored
+```
+
+For key-value patterns where the same keys are updated repeatedly, this causes unbounded memory growth.
+
+## Benchmark Results
+
+We benchmarked Y.Map vs YKeyValue (an alternative data structure) for typical KV patterns:
+
+| Scenario | Y.Map Size | YKeyValue Size | Ratio |
+|----------|------------|----------------|-------|
+| 5 keys, 1 update each | 194 B | 225 B | Similar |
+| 5 keys, 10 updates each | 562 B | 241 B | **Y.Map 2.3x larger** |
+| 5 keys, 100 updates each | 4.43 KB | 254 B | **Y.Map 18x larger** |
+| 5 keys, 1000 updates each | 44 KB | 259 B | **Y.Map 174x larger** |
+| 10 keys, 10000 updates each | 961 KB | 507 B | **Y.Map 1940x larger** |
+
+The pattern is clear: YKeyValue stays bounded while Y.Map grows linearly with update count.
+
+## How YKeyValue Works
+
+YKeyValue uses Y.Array with an append-and-cleanup strategy:
+
+1. **Append new entries to the right**: When you set a key, push `{key, val}` to the end
+2. **Remove old duplicates**: Delete any previous entry with the same key
+3. **Right-side precedence**: If concurrent edits add the same key, rightmost wins
+
+```typescript
+// Same operations, constant size:
+array: [{key:'theme', val:'light'}]                    // 1 item
+array: [{key:'theme', val:'dark'}]                     // still 1 item!
+array: [{key:'theme', val:'light'}]                    // still 1 item!
+```
+
+**Why Y.Array doesn't have the same problem**: When you delete from Y.Array, Yjs marks the item as a "tombstone" but doesn't retain the full value—just enough metadata to know it was deleted.
+
+## The Trade-off
+
+| Aspect | Y.Map | YKeyValue |
+|--------|-------|-----------|
+| Memory | Unbounded growth | Bounded |
+| Set performance | O(1) | O(n) worst case* |
+| Get performance | O(1) | O(1) |
+| Built-in | Yes | No (custom) |
+
+*YKeyValue scans to find and delete the old entry. In practice, this is fast for small maps.
+
+## When to Use Each
+
+**Use Y.Map when:**
+- Keys are set once and rarely updated
+- You need maximum write performance
+- Memory growth is acceptable for your use case
+
+**Use YKeyValue when:**
+- Keys are updated frequently
+- Your app runs indefinitely (memory growth matters)
+- You're storing table rows or settings that change over time
+
+## Epicenter's Choice
+
+Epicenter uses YKeyValue for both tables and KV storage:
+
+```
+Y.Doc
+├── tables (Y.Map<tableName, YKeyValue>)
+│    └── posts (YKeyValue) ← bounded memory
+│
+└── kv (YKeyValue) ← bounded memory
+```
+
+Local-first apps run indefinitely. Users don't restart them like web pages. Unbounded memory growth will eventually cause problems, so we chose bounded memory even with the slight performance trade-off.
+
+## Implementation
+
+Here's the core of YKeyValue:
+
+```typescript
+class YKeyValue<T> {
+  private yarray: Y.Array<{ key: string; val: T }>;
+  private map: Map<string, { key: string; val: T }>;  // In-memory index
+
+  set(key: string, val: T): void {
+    const entry = { key, val };
+    const existing = this.map.get(key);
+
+    this.doc.transact(() => {
+      // Delete old entry if exists
+      if (existing) {
+        const index = this.findIndex(key);
+        if (index !== -1) this.yarray.delete(index);
+      }
+      // Append new entry
+      this.yarray.push([entry]);
+    });
+
+    this.map.set(key, entry);
+  }
+
+  get(key: string): T | undefined {
+    return this.map.get(key)?.val;  // O(1) via in-memory index
+  }
+}
+```
+
+The in-memory Map provides O(1) reads while Y.Array provides bounded storage.
+
+## Conclusion
+
+Y.Map is great for many use cases, but its unbounded memory growth is a hidden trap for key-value patterns with frequent updates. YKeyValue solves this with a simple append-and-cleanup strategy.
+
+If you're building a local-first app that runs for extended periods, consider your memory characteristics carefully. The difference between 507 bytes and 961 KB might not matter at first, but it compounds over time.

--- a/docs/articles/ykeyvalue-meta-data-structure.md
+++ b/docs/articles/ykeyvalue-meta-data-structure.md
@@ -1,9 +1,9 @@
 # YKeyValue: The Most Interesting Meta Data Structure in Yjs
 
-> **Deprecated (2026-01-08)**: We reverted YKeyValue in favor of native Y.Map of Y.Maps.
-> The storage gains were dubious in practice (~6% difference with epoch compaction, not 1935x),
-> and the unpredictable LWW conflict resolution was a footgun. Native Y.Map is simpler and
-> more battle-tested. See [PR #1226](https://github.com/EpicenterHQ/epicenter/pull/1226) for details.
+> **Note**: YKeyValue uses the same clientID-based conflict resolution as Y.Map under the hood.
+> The original deprecation claimed "unpredictable LWW" behavior, but this was misleading—both
+> Y.Map and YKeyValue resolve conflicts using Yjs's deterministic clientID ordering.
+> YKeyValue remains useful for long-lived collaborative documents without epoch compaction.
 
 YKeyValue is one of the most interesting meta Yjs data structures I've encountered.
 

--- a/packages/epicenter/scripts/yjs-data-structure-benchmark.ts
+++ b/packages/epicenter/scripts/yjs-data-structure-benchmark.ts
@@ -1,0 +1,720 @@
+/**
+ * ============================================================================
+ * YJS Data Structure Benchmark: Arrays vs Maps, Plain Objects vs Nested Y.Maps
+ * ============================================================================
+ *
+ * This benchmark compares four approaches for modeling a data table in YJS:
+ *
+ *   1. Y.Map<id, PlainObject>  - Map with row IDs as keys, plain JS objects as values
+ *   2. Y.Array<PlainObject>    - Array of plain JS objects
+ *   3. Y.Map<id, Y.Map>        - Map with row IDs as keys, nested Y.Maps as values
+ *   4. Y.Array<Y.Map>          - Array of nested Y.Maps
+ *
+ * We test three update scenarios:
+ *
+ *   A. SINGLE COLUMN UPDATES  - Update one property per row (e.g., increment age)
+ *   B. FULL ROW REPLACEMENTS  - Replace entire row with new data
+ *   C. MIXED UPDATES          - 70% single column, 30% full row (realistic usage)
+ *
+ * Key questions answered:
+ *
+ *   - How does storage grow with each approach?
+ *   - How much does GC help for each approach?
+ *   - When are plain objects actually better than nested Y.Maps?
+ *   - What are the performance differences?
+ *
+ * ============================================================================
+ * TL;DR RECOMMENDATIONS
+ * ============================================================================
+ *
+ * | Scenario                          | Best Choice              | Why                           |
+ * |-----------------------------------|--------------------------|-------------------------------|
+ * | Frequent single-column updates    | Y.Map<id, Y.Map>         | Minimal tombstones per update |
+ * | Real-time collaboration           | Y.Map<id, Y.Map>         | Concurrent edits merge        |
+ * | Write-once / read-many data       | Y.Map<id, PlainObject>   | Simpler, smaller initial size |
+ * | Full row replacements only        | Y.Map<id, PlainObject>   | Less overhead per row         |
+ * | Need ordering + frequent updates  | Y.Array<Y.Map>           | Maintains order, granular     |
+ * | Append-only logs                  | Y.Array<PlainObject>     | Efficient batching            |
+ *
+ * ============================================================================
+ */
+
+import * as Y from 'yjs';
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+const CONFIG = {
+	NUM_ROWS: 1000,
+	NUM_COLUMNS: 5, // id, name, age, email, active
+	UPDATES_PER_ROW: 10,
+	NUM_DELETIONS: 200,
+	NUM_RECREATIONS: 100,
+};
+
+// ============================================================================
+// Data Helpers
+// ============================================================================
+
+type PlainRow = {
+	id: string;
+	name: string;
+	age: number;
+	email: string;
+	active: boolean;
+};
+
+const COLUMNS = ['id', 'name', 'age', 'email', 'active'] as const;
+
+function createPlainRow(id: string, suffix = ''): PlainRow {
+	return {
+		id,
+		name: `User ${id}${suffix}`,
+		age: Math.floor(Math.random() * 50) + 20,
+		email: `user${id}${suffix}@example.com`,
+		active: true,
+	};
+}
+
+function createYMapRow(doc: Y.Doc, id: string, suffix = ''): Y.Map<unknown> {
+	const row = new Y.Map<unknown>();
+	row.set('id', id);
+	row.set('name', `User ${id}${suffix}`);
+	row.set('age', Math.floor(Math.random() * 50) + 20);
+	row.set('email', `user${id}${suffix}@example.com`);
+	row.set('active', true);
+	return row;
+}
+
+// ============================================================================
+// Measurement Utilities
+// ============================================================================
+
+function getDocSize(doc: Y.Doc): number {
+	return Y.encodeStateAsUpdate(doc).byteLength;
+}
+
+function countStructs(doc: Y.Doc): { total: number; deleted: number; gc: number } {
+	let total = 0;
+	let deleted = 0;
+	let gc = 0;
+
+	// Access internal store structure
+	const store = (doc as any).store;
+	for (const structs of store.clients.values()) {
+		for (const struct of structs) {
+			total++;
+			if ((struct as any).deleted) {
+				deleted++;
+			}
+			if (struct.constructor.name === 'GC') {
+				gc++;
+			}
+		}
+	}
+
+	return { total, deleted, gc };
+}
+
+// ============================================================================
+// Update Strategies
+// ============================================================================
+
+type UpdateStrategy = 'single-column' | 'full-row' | 'mixed';
+
+/**
+ * Single Column Update: Only update one property (age)
+ * - Best case for nested Y.Maps (minimal tombstone)
+ * - Worst case for plain objects (whole object replaced for one change)
+ */
+function singleColumnUpdate(row: PlainRow): PlainRow {
+	return { ...row, age: row.age + 1 };
+}
+
+/**
+ * Full Row Replacement: Update all properties
+ * - Similar cost for both approaches
+ * - Plain objects may have slight edge (less overhead)
+ */
+function fullRowUpdate(row: PlainRow): PlainRow {
+	return {
+		id: row.id,
+		name: row.name + '!',
+		age: row.age + 1,
+		email: row.email.replace('@', '+updated@'),
+		active: !row.active,
+	};
+}
+
+// ============================================================================
+// Benchmark Implementations
+// ============================================================================
+
+interface BenchmarkResult {
+	name: string;
+	gcEnabled: boolean;
+	updateStrategy: UpdateStrategy;
+	timings: {
+		insert: number;
+		update: number;
+		delete: number;
+		recreate: number;
+	};
+	sizes: {
+		afterInsert: number;
+		afterUpdate: number;
+		afterDelete: number;
+		afterRecreate: number;
+	};
+	structs: {
+		total: number;
+		deleted: number;
+		gc: number;
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Y.Map<id, PlainObject>
+// ---------------------------------------------------------------------------
+
+function benchmarkMapPlain(gcEnabled: boolean, strategy: UpdateStrategy): BenchmarkResult {
+	const doc = new Y.Doc({ gc: gcEnabled });
+	const ymap = doc.getMap<PlainRow>('data');
+
+	const result: BenchmarkResult = {
+		name: 'Y.Map<id, PlainObject>',
+		gcEnabled,
+		updateStrategy: strategy,
+		timings: { insert: 0, update: 0, delete: 0, recreate: 0 },
+		sizes: { afterInsert: 0, afterUpdate: 0, afterDelete: 0, afterRecreate: 0 },
+		structs: { total: 0, deleted: 0, gc: 0 },
+	};
+
+	// INSERT
+	let start = performance.now();
+	doc.transact(() => {
+		for (let i = 0; i < CONFIG.NUM_ROWS; i++) {
+			ymap.set(`row-${i}`, createPlainRow(`${i}`));
+		}
+	});
+	result.timings.insert = performance.now() - start;
+	result.sizes.afterInsert = getDocSize(doc);
+
+	// UPDATE
+	start = performance.now();
+	for (let u = 0; u < CONFIG.UPDATES_PER_ROW; u++) {
+		doc.transact(() => {
+			for (let i = 0; i < CONFIG.NUM_ROWS; i++) {
+				const existing = ymap.get(`row-${i}`)!;
+				if (strategy === 'single-column') {
+					ymap.set(`row-${i}`, singleColumnUpdate(existing));
+				} else if (strategy === 'full-row') {
+					ymap.set(`row-${i}`, fullRowUpdate(existing));
+				} else {
+					// mixed: 70% single, 30% full
+					const updateFn = Math.random() < 0.7 ? singleColumnUpdate : fullRowUpdate;
+					ymap.set(`row-${i}`, updateFn(existing));
+				}
+			}
+		});
+	}
+	result.timings.update = performance.now() - start;
+	result.sizes.afterUpdate = getDocSize(doc);
+
+	// DELETE
+	start = performance.now();
+	doc.transact(() => {
+		for (let i = 0; i < CONFIG.NUM_DELETIONS; i++) {
+			ymap.delete(`row-${i}`);
+		}
+	});
+	result.timings.delete = performance.now() - start;
+	result.sizes.afterDelete = getDocSize(doc);
+
+	// RECREATE
+	start = performance.now();
+	doc.transact(() => {
+		for (let i = 0; i < CONFIG.NUM_RECREATIONS; i++) {
+			ymap.set(`row-${i}`, createPlainRow(`${i}`, '-v2'));
+		}
+	});
+	result.timings.recreate = performance.now() - start;
+	result.sizes.afterRecreate = getDocSize(doc);
+
+	result.structs = countStructs(doc);
+	return result;
+}
+
+// ---------------------------------------------------------------------------
+// Y.Array<PlainObject>
+// ---------------------------------------------------------------------------
+
+function benchmarkArrayPlain(gcEnabled: boolean, strategy: UpdateStrategy): BenchmarkResult {
+	const doc = new Y.Doc({ gc: gcEnabled });
+	const yarray = doc.getArray<PlainRow>('data');
+
+	const result: BenchmarkResult = {
+		name: 'Y.Array<PlainObject>',
+		gcEnabled,
+		updateStrategy: strategy,
+		timings: { insert: 0, update: 0, delete: 0, recreate: 0 },
+		sizes: { afterInsert: 0, afterUpdate: 0, afterDelete: 0, afterRecreate: 0 },
+		structs: { total: 0, deleted: 0, gc: 0 },
+	};
+
+	// INSERT
+	let start = performance.now();
+	doc.transact(() => {
+		for (let i = 0; i < CONFIG.NUM_ROWS; i++) {
+			yarray.push([createPlainRow(`${i}`)]);
+		}
+	});
+	result.timings.insert = performance.now() - start;
+	result.sizes.afterInsert = getDocSize(doc);
+
+	// UPDATE (must delete + reinsert for arrays)
+	start = performance.now();
+	for (let u = 0; u < CONFIG.UPDATES_PER_ROW; u++) {
+		doc.transact(() => {
+			for (let i = 0; i < CONFIG.NUM_ROWS; i++) {
+				const existing = yarray.get(i);
+				yarray.delete(i, 1);
+				if (strategy === 'single-column') {
+					yarray.insert(i, [singleColumnUpdate(existing)]);
+				} else if (strategy === 'full-row') {
+					yarray.insert(i, [fullRowUpdate(existing)]);
+				} else {
+					const updateFn = Math.random() < 0.7 ? singleColumnUpdate : fullRowUpdate;
+					yarray.insert(i, [updateFn(existing)]);
+				}
+			}
+		});
+	}
+	result.timings.update = performance.now() - start;
+	result.sizes.afterUpdate = getDocSize(doc);
+
+	// DELETE
+	start = performance.now();
+	doc.transact(() => {
+		yarray.delete(CONFIG.NUM_ROWS - CONFIG.NUM_DELETIONS, CONFIG.NUM_DELETIONS);
+	});
+	result.timings.delete = performance.now() - start;
+	result.sizes.afterDelete = getDocSize(doc);
+
+	// RECREATE
+	start = performance.now();
+	doc.transact(() => {
+		for (let i = 0; i < CONFIG.NUM_RECREATIONS; i++) {
+			yarray.push([createPlainRow(`${CONFIG.NUM_ROWS - CONFIG.NUM_DELETIONS + i}`, '-v2')]);
+		}
+	});
+	result.timings.recreate = performance.now() - start;
+	result.sizes.afterRecreate = getDocSize(doc);
+
+	result.structs = countStructs(doc);
+	return result;
+}
+
+// ---------------------------------------------------------------------------
+// Y.Map<id, Y.Map>
+// ---------------------------------------------------------------------------
+
+function benchmarkMapYMap(gcEnabled: boolean, strategy: UpdateStrategy): BenchmarkResult {
+	const doc = new Y.Doc({ gc: gcEnabled });
+	const ymap = doc.getMap<Y.Map<unknown>>('data');
+
+	const result: BenchmarkResult = {
+		name: 'Y.Map<id, Y.Map>',
+		gcEnabled,
+		updateStrategy: strategy,
+		timings: { insert: 0, update: 0, delete: 0, recreate: 0 },
+		sizes: { afterInsert: 0, afterUpdate: 0, afterDelete: 0, afterRecreate: 0 },
+		structs: { total: 0, deleted: 0, gc: 0 },
+	};
+
+	// INSERT
+	let start = performance.now();
+	doc.transact(() => {
+		for (let i = 0; i < CONFIG.NUM_ROWS; i++) {
+			ymap.set(`row-${i}`, createYMapRow(doc, `${i}`));
+		}
+	});
+	result.timings.insert = performance.now() - start;
+	result.sizes.afterInsert = getDocSize(doc);
+
+	// UPDATE
+	start = performance.now();
+	for (let u = 0; u < CONFIG.UPDATES_PER_ROW; u++) {
+		doc.transact(() => {
+			for (let i = 0; i < CONFIG.NUM_ROWS; i++) {
+				const row = ymap.get(`row-${i}`)!;
+				if (strategy === 'single-column') {
+					// Only update age - creates 1 tombstone
+					row.set('age', (row.get('age') as number) + 1);
+				} else if (strategy === 'full-row') {
+					// Update all columns - creates 5 tombstones (one per column)
+					row.set('name', (row.get('name') as string) + '!');
+					row.set('age', (row.get('age') as number) + 1);
+					row.set('email', (row.get('email') as string).replace('@', '+updated@'));
+					row.set('active', !(row.get('active') as boolean));
+				} else {
+					// mixed
+					if (Math.random() < 0.7) {
+						row.set('age', (row.get('age') as number) + 1);
+					} else {
+						row.set('name', (row.get('name') as string) + '!');
+						row.set('age', (row.get('age') as number) + 1);
+						row.set('email', (row.get('email') as string).replace('@', '+updated@'));
+						row.set('active', !(row.get('active') as boolean));
+					}
+				}
+			}
+		});
+	}
+	result.timings.update = performance.now() - start;
+	result.sizes.afterUpdate = getDocSize(doc);
+
+	// DELETE
+	start = performance.now();
+	doc.transact(() => {
+		for (let i = 0; i < CONFIG.NUM_DELETIONS; i++) {
+			ymap.delete(`row-${i}`);
+		}
+	});
+	result.timings.delete = performance.now() - start;
+	result.sizes.afterDelete = getDocSize(doc);
+
+	// RECREATE
+	start = performance.now();
+	doc.transact(() => {
+		for (let i = 0; i < CONFIG.NUM_RECREATIONS; i++) {
+			ymap.set(`row-${i}`, createYMapRow(doc, `${i}`, '-v2'));
+		}
+	});
+	result.timings.recreate = performance.now() - start;
+	result.sizes.afterRecreate = getDocSize(doc);
+
+	result.structs = countStructs(doc);
+	return result;
+}
+
+// ---------------------------------------------------------------------------
+// Y.Array<Y.Map>
+// ---------------------------------------------------------------------------
+
+function benchmarkArrayYMap(gcEnabled: boolean, strategy: UpdateStrategy): BenchmarkResult {
+	const doc = new Y.Doc({ gc: gcEnabled });
+	const yarray = doc.getArray<Y.Map<unknown>>('data');
+
+	const result: BenchmarkResult = {
+		name: 'Y.Array<Y.Map>',
+		gcEnabled,
+		updateStrategy: strategy,
+		timings: { insert: 0, update: 0, delete: 0, recreate: 0 },
+		sizes: { afterInsert: 0, afterUpdate: 0, afterDelete: 0, afterRecreate: 0 },
+		structs: { total: 0, deleted: 0, gc: 0 },
+	};
+
+	// INSERT
+	let start = performance.now();
+	doc.transact(() => {
+		for (let i = 0; i < CONFIG.NUM_ROWS; i++) {
+			yarray.push([createYMapRow(doc, `${i}`)]);
+		}
+	});
+	result.timings.insert = performance.now() - start;
+	result.sizes.afterInsert = getDocSize(doc);
+
+	// UPDATE (can update in-place since Y.Map is mutable)
+	start = performance.now();
+	for (let u = 0; u < CONFIG.UPDATES_PER_ROW; u++) {
+		doc.transact(() => {
+			for (let i = 0; i < CONFIG.NUM_ROWS; i++) {
+				const row = yarray.get(i);
+				if (strategy === 'single-column') {
+					row.set('age', (row.get('age') as number) + 1);
+				} else if (strategy === 'full-row') {
+					row.set('name', (row.get('name') as string) + '!');
+					row.set('age', (row.get('age') as number) + 1);
+					row.set('email', (row.get('email') as string).replace('@', '+updated@'));
+					row.set('active', !(row.get('active') as boolean));
+				} else {
+					if (Math.random() < 0.7) {
+						row.set('age', (row.get('age') as number) + 1);
+					} else {
+						row.set('name', (row.get('name') as string) + '!');
+						row.set('age', (row.get('age') as number) + 1);
+						row.set('email', (row.get('email') as string).replace('@', '+updated@'));
+						row.set('active', !(row.get('active') as boolean));
+					}
+				}
+			}
+		});
+	}
+	result.timings.update = performance.now() - start;
+	result.sizes.afterUpdate = getDocSize(doc);
+
+	// DELETE
+	start = performance.now();
+	doc.transact(() => {
+		yarray.delete(CONFIG.NUM_ROWS - CONFIG.NUM_DELETIONS, CONFIG.NUM_DELETIONS);
+	});
+	result.timings.delete = performance.now() - start;
+	result.sizes.afterDelete = getDocSize(doc);
+
+	// RECREATE
+	start = performance.now();
+	doc.transact(() => {
+		for (let i = 0; i < CONFIG.NUM_RECREATIONS; i++) {
+			yarray.push([createYMapRow(doc, `${CONFIG.NUM_ROWS - CONFIG.NUM_DELETIONS + i}`, '-v2')]);
+		}
+	});
+	result.timings.recreate = performance.now() - start;
+	result.sizes.afterRecreate = getDocSize(doc);
+
+	result.structs = countStructs(doc);
+	return result;
+}
+
+// ============================================================================
+// Reporting
+// ============================================================================
+
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function formatTime(ms: number): string {
+	if (ms < 1) return `${(ms * 1000).toFixed(0)} µs`;
+	if (ms < 1000) return `${ms.toFixed(1)} ms`;
+	return `${(ms / 1000).toFixed(2)} s`;
+}
+
+function formatPercent(ratio: number): string {
+	return `${(ratio * 100).toFixed(1)}%`;
+}
+
+function printStrategyResults(results: BenchmarkResult[], strategy: UpdateStrategy) {
+	const strategyLabel =
+		strategy === 'single-column'
+			? 'SINGLE COLUMN UPDATES (best case for Y.Map nested)'
+			: strategy === 'full-row'
+				? 'FULL ROW REPLACEMENTS (when plain objects may win)'
+				: 'MIXED UPDATES (70% single column, 30% full row)';
+
+	console.log(`\n${'═'.repeat(100)}`);
+	console.log(`  ${strategyLabel}`);
+	console.log(`${'═'.repeat(100)}`);
+
+	const withGC = results.filter((r) => r.gcEnabled);
+	const withoutGC = results.filter((r) => !r.gcEnabled);
+
+	for (const [label, group] of [
+		['GC ENABLED', withGC],
+		['GC DISABLED', withoutGC],
+	] as const) {
+		console.log(`\n  ${label}`);
+		console.log(`  ${'─'.repeat(96)}`);
+
+		// Performance table
+		console.log(
+			'\n  ' +
+				'Structure'.padEnd(24) +
+				'Insert'.padStart(10) +
+				'Update'.padStart(10) +
+				'Delete'.padStart(10) +
+				'Recreate'.padStart(10) +
+				'│' +
+				'Final Size'.padStart(12) +
+				'Growth'.padStart(10),
+		);
+		console.log('  ' + '─'.repeat(96));
+
+		for (const r of group) {
+			const growth = r.sizes.afterRecreate / r.sizes.afterInsert - 1;
+			console.log(
+				'  ' +
+					r.name.padEnd(24) +
+					formatTime(r.timings.insert).padStart(10) +
+					formatTime(r.timings.update).padStart(10) +
+					formatTime(r.timings.delete).padStart(10) +
+					formatTime(r.timings.recreate).padStart(10) +
+					'│' +
+					formatBytes(r.sizes.afterRecreate).padStart(12) +
+					formatPercent(growth).padStart(10),
+			);
+		}
+
+		// Struct counts
+		console.log(
+			'\n  ' + 'Structure'.padEnd(24) + 'Total Structs'.padStart(14) + 'Deleted'.padStart(10) + 'GC'.padStart(8) + 'Tombstone %'.padStart(14),
+		);
+		console.log('  ' + '─'.repeat(70));
+
+		for (const r of group) {
+			const tombstoneRatio = r.structs.total > 0 ? r.structs.deleted / r.structs.total : 0;
+			console.log(
+				'  ' +
+					r.name.padEnd(24) +
+					r.structs.total.toString().padStart(14) +
+					r.structs.deleted.toString().padStart(10) +
+					r.structs.gc.toString().padStart(8) +
+					formatPercent(tombstoneRatio).padStart(14),
+			);
+		}
+	}
+}
+
+function printAnalysis(allResults: BenchmarkResult[]) {
+	console.log(`\n${'═'.repeat(100)}`);
+	console.log('  ANALYSIS & RECOMMENDATIONS');
+	console.log(`${'═'.repeat(100)}`);
+
+	// Group by strategy
+	const singleCol = allResults.filter((r) => r.updateStrategy === 'single-column' && r.gcEnabled);
+	const fullRow = allResults.filter((r) => r.updateStrategy === 'full-row' && r.gcEnabled);
+
+	// Find winners
+	const singleColBySize = [...singleCol].sort((a, b) => a.sizes.afterRecreate - b.sizes.afterRecreate);
+	const fullRowBySize = [...fullRow].sort((a, b) => a.sizes.afterRecreate - b.sizes.afterRecreate);
+
+	console.log('\n  STORAGE EFFICIENCY (with GC enabled)');
+	console.log('  ' + '─'.repeat(70));
+
+	console.log('\n  Single Column Updates - Final Size Ranking:');
+	singleColBySize.forEach((r, i) => {
+		const marker = i === 0 ? ' ★ BEST' : '';
+		console.log(`    ${i + 1}. ${r.name.padEnd(24)} ${formatBytes(r.sizes.afterRecreate).padStart(10)}${marker}`);
+	});
+
+	console.log('\n  Full Row Replacements - Final Size Ranking:');
+	fullRowBySize.forEach((r, i) => {
+		const marker = i === 0 ? ' ★ BEST' : '';
+		console.log(`    ${i + 1}. ${r.name.padEnd(24)} ${formatBytes(r.sizes.afterRecreate).padStart(10)}${marker}`);
+	});
+
+	// Compare plain vs nested for each strategy
+	console.log('\n  PLAIN OBJECTS vs NESTED Y.MAPS');
+	console.log('  ' + '─'.repeat(70));
+
+	const mapPlainSingle = singleCol.find((r) => r.name.includes('Map<id, Plain'))!;
+	const mapYMapSingle = singleCol.find((r) => r.name.includes('Map<id, Y.Map'))!;
+	const mapPlainFull = fullRow.find((r) => r.name.includes('Map<id, Plain'))!;
+	const mapYMapFull = fullRow.find((r) => r.name.includes('Map<id, Y.Map'))!;
+
+	console.log('\n  Single Column Updates:');
+	console.log(`    Plain objects: ${formatBytes(mapPlainSingle.sizes.afterRecreate)}`);
+	console.log(`    Nested Y.Maps: ${formatBytes(mapYMapSingle.sizes.afterRecreate)}`);
+	const singleDiff = mapPlainSingle.sizes.afterRecreate - mapYMapSingle.sizes.afterRecreate;
+	if (singleDiff > 0) {
+		console.log(`    → Nested Y.Maps saves ${formatBytes(singleDiff)} (${formatPercent(singleDiff / mapPlainSingle.sizes.afterRecreate)})`);
+	} else {
+		console.log(`    → Plain objects saves ${formatBytes(-singleDiff)} (${formatPercent(-singleDiff / mapYMapSingle.sizes.afterRecreate)})`);
+	}
+
+	console.log('\n  Full Row Replacements:');
+	console.log(`    Plain objects: ${formatBytes(mapPlainFull.sizes.afterRecreate)}`);
+	console.log(`    Nested Y.Maps: ${formatBytes(mapYMapFull.sizes.afterRecreate)}`);
+	const fullDiff = mapPlainFull.sizes.afterRecreate - mapYMapFull.sizes.afterRecreate;
+	if (fullDiff > 0) {
+		console.log(`    → Nested Y.Maps saves ${formatBytes(fullDiff)} (${formatPercent(fullDiff / mapPlainFull.sizes.afterRecreate)})`);
+	} else {
+		console.log(`    → Plain objects saves ${formatBytes(-fullDiff)} (${formatPercent(-fullDiff / mapYMapFull.sizes.afterRecreate)})`);
+	}
+
+	// GC impact analysis
+	console.log('\n  GC IMPACT');
+	console.log('  ' + '─'.repeat(70));
+
+	const strategies: UpdateStrategy[] = ['single-column', 'full-row'];
+	for (const strategy of strategies) {
+		const label = strategy === 'single-column' ? 'Single Column' : 'Full Row';
+		console.log(`\n  ${label} Updates:`);
+
+		const gcOn = allResults.filter((r) => r.updateStrategy === strategy && r.gcEnabled);
+		const gcOff = allResults.filter((r) => r.updateStrategy === strategy && !r.gcEnabled);
+
+		for (const on of gcOn) {
+			const off = gcOff.find((r) => r.name === on.name)!;
+			const reduction = 1 - on.sizes.afterRecreate / off.sizes.afterRecreate;
+			console.log(`    ${on.name.padEnd(24)} ${formatBytes(off.sizes.afterRecreate)} → ${formatBytes(on.sizes.afterRecreate)} (${formatPercent(reduction)} reduction)`);
+		}
+	}
+
+	// Decision guide
+	console.log(`\n${'═'.repeat(100)}`);
+	console.log('  DECISION GUIDE');
+	console.log(`${'═'.repeat(100)}`);
+
+	console.log(`
+  Use Y.Map<id, PlainObject> when:
+    ✓ Data is write-once or rarely updated
+    ✓ Updates always replace the entire row (form submissions)
+    ✓ You don't need concurrent edit merging (single user)
+    ✓ Simpler mental model is worth the tradeoff
+    ✓ GC is enabled (critical for managing tombstone growth)
+
+  Use Y.Map<id, Y.Map> when:
+    ✓ Individual columns update frequently (cell edits)
+    ✓ Multiple users may edit the same row concurrently
+    ✓ You need per-field conflict resolution
+    ✓ Undo/redo needs to track individual field changes
+    ✓ Your API exposes granular cell-level updates
+
+  Use Y.Array<*> variants when:
+    ✓ Row ordering matters and changes
+    ✓ You need to insert rows at specific positions
+    ✓ Append-only patterns (logs, feeds)
+    ✗ Avoid if you need fast lookup by ID (O(n) scan required)
+
+  GC Considerations:
+    • GC enabled:  Plain objects get ~80% size reduction (content discarded)
+    • GC enabled:  Nested Y.Maps get ~20-30% reduction (small values)
+    • GC disabled: Plain objects grow ~10x with frequent updates (content kept)
+    • GC disabled: Nested Y.Maps grow ~2x (only primitive tombstones)
+`);
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+async function main() {
+	console.log(`${'═'.repeat(100)}`);
+	console.log('  YJS DATA STRUCTURE BENCHMARK');
+	console.log(`${'═'.repeat(100)}`);
+	console.log(`
+  Configuration:
+    Rows: ${CONFIG.NUM_ROWS}
+    Columns per row: ${CONFIG.NUM_COLUMNS}
+    Updates per row: ${CONFIG.UPDATES_PER_ROW}
+    Deletions: ${CONFIG.NUM_DELETIONS}
+    Recreations: ${CONFIG.NUM_RECREATIONS}
+`);
+
+	const allResults: BenchmarkResult[] = [];
+	const strategies: UpdateStrategy[] = ['single-column', 'full-row', 'mixed'];
+	const benchmarks = [benchmarkMapPlain, benchmarkArrayPlain, benchmarkMapYMap, benchmarkArrayYMap];
+
+	for (const strategy of strategies) {
+		console.log(`Running ${strategy} benchmarks...`);
+		const strategyResults: BenchmarkResult[] = [];
+
+		for (const gcEnabled of [true, false]) {
+			for (const benchmark of benchmarks) {
+				const result = benchmark(gcEnabled, strategy);
+				strategyResults.push(result);
+				allResults.push(result);
+			}
+		}
+
+		printStrategyResults(strategyResults, strategy);
+	}
+
+	printAnalysis(allResults);
+}
+
+main().catch(console.error);

--- a/packages/epicenter/scripts/yjs-gc-benchmark.ts
+++ b/packages/epicenter/scripts/yjs-gc-benchmark.ts
@@ -1,0 +1,291 @@
+import * as Y from 'yjs';
+import { mkdir } from 'node:fs/promises';
+
+type BenchmarkResult = {
+	name: string;
+	gcEnabled: boolean;
+	sizeBytes: number;
+	operations: number;
+};
+
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(2)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function createDoc(gc: boolean): Y.Doc {
+	return new Y.Doc({ gc });
+}
+
+/**
+ * Benchmark 1: Y.Text Heavy Editing
+ * Simulates Google Docs-like typing and deleting
+ */
+function benchmarkTextEditing(gc: boolean, operations: number): BenchmarkResult {
+	const doc = createDoc(gc);
+	const text = doc.getText('content');
+
+	for (let i = 0; i < operations; i++) {
+		const action = Math.random();
+
+		if (action < 0.6) {
+			// 60% - Insert character at random position
+			const pos = Math.floor(Math.random() * (text.length + 1));
+			const char = String.fromCharCode(97 + Math.floor(Math.random() * 26));
+			text.insert(pos, char);
+		} else if (action < 0.9 && text.length > 0) {
+			// 30% - Delete character at random position
+			const pos = Math.floor(Math.random() * text.length);
+			text.delete(pos, 1);
+		} else if (text.length > 0) {
+			// 10% - Delete a range
+			const pos = Math.floor(Math.random() * text.length);
+			const len = Math.min(Math.floor(Math.random() * 10) + 1, text.length - pos);
+			text.delete(pos, len);
+		}
+	}
+
+	const encoded = Y.encodeStateAsUpdate(doc);
+	return {
+		name: 'Y.Text Heavy Editing',
+		gcEnabled: gc,
+		sizeBytes: encoded.byteLength,
+		operations,
+	};
+}
+
+/**
+ * Benchmark 2a: BAD PATTERN - Replace entire Y.Maps
+ *
+ * Structure:
+ *   root (Y.Map)
+ *     └── "record-0" -> Y.Map { id, name, data }
+ *     └── "record-1" -> Y.Map { id, name, data }
+ *     └── ...
+ *
+ * Each "update" creates a NEW Y.Map and sets it at the key,
+ * orphaning the old Y.Map (which becomes a tombstone).
+ */
+function benchmarkBadPattern(gc: boolean, operations: number): BenchmarkResult {
+	const doc = createDoc(gc);
+	const root = doc.getMap('workspace');
+
+	const recordIds = Array.from({ length: 100 }, (_, i) => `record-${i}`);
+
+	for (let i = 0; i < operations; i++) {
+		const recordId = recordIds[Math.floor(Math.random() * recordIds.length)];
+
+		// BAD: Create a brand new Y.Map every time we "update" a record
+		const newRecord = new Y.Map();
+		newRecord.set('id', recordId);
+		newRecord.set('name', `Name ${i}`);
+		newRecord.set('data', `data-${Math.random().toString(36).slice(2)}`);
+		newRecord.set('updatedAt', i);
+
+		// This orphans the previous Y.Map at this key!
+		root.set(recordId, newRecord);
+	}
+
+	const encoded = Y.encodeStateAsUpdate(doc);
+	return {
+		name: 'BAD: Replace Y.Maps',
+		gcEnabled: gc,
+		sizeBytes: encoded.byteLength,
+		operations,
+	};
+}
+
+/**
+ * Benchmark 2b: GOOD PATTERN - Reuse Y.Maps, update fields
+ *
+ * Structure:
+ *   root (Y.Map)
+ *     └── "record-0" -> Y.Map { id, name, data }  <- same Y.Map instance, fields updated
+ *     └── "record-1" -> Y.Map { id, name, data }
+ *     └── ...
+ *
+ * Each "update" reuses the existing Y.Map and only updates fields.
+ * No orphaned Y.Maps = minimal tombstones.
+ */
+function benchmarkGoodPattern(gc: boolean, operations: number): BenchmarkResult {
+	const doc = createDoc(gc);
+	const root = doc.getMap('workspace');
+
+	const recordIds = Array.from({ length: 100 }, (_, i) => `record-${i}`);
+
+	for (let i = 0; i < operations; i++) {
+		const recordId = recordIds[Math.floor(Math.random() * recordIds.length)];
+
+		// GOOD: Get existing Y.Map or create once, then update fields
+		let record = root.get(recordId) as Y.Map<unknown> | undefined;
+		if (!record) {
+			record = new Y.Map();
+			record.set('id', recordId);
+			root.set(recordId, record);
+		}
+
+		// Update fields in-place - no new Y.Map created
+		record.set('name', `Name ${i}`);
+		record.set('data', `data-${Math.random().toString(36).slice(2)}`);
+		record.set('updatedAt', i);
+	}
+
+	const encoded = Y.encodeStateAsUpdate(doc);
+	return {
+		name: 'GOOD: Reuse Y.Maps',
+		gcEnabled: gc,
+		sizeBytes: encoded.byteLength,
+		operations,
+	};
+}
+
+/**
+ * Benchmark 3: FLAT PATTERN - Single Y.Map with composite keys
+ *
+ * Structure:
+ *   root (Y.Map)
+ *     └── "record-0:name" -> "Name 123"
+ *     └── "record-0:data" -> "xyz..."
+ *     └── "record-1:name" -> "Name 456"
+ *     └── ...
+ *
+ * No nesting at all. Each field is a top-level key.
+ */
+function benchmarkFlatPattern(gc: boolean, operations: number): BenchmarkResult {
+	const doc = createDoc(gc);
+	const root = doc.getMap('workspace');
+
+	const recordIds = Array.from({ length: 100 }, (_, i) => `record-${i}`);
+
+	for (let i = 0; i < operations; i++) {
+		const recordId = recordIds[Math.floor(Math.random() * recordIds.length)];
+
+		// FLAT: Use composite keys instead of nested Y.Maps
+		root.set(`${recordId}:name`, `Name ${i}`);
+		root.set(`${recordId}:data`, `data-${Math.random().toString(36).slice(2)}`);
+		root.set(`${recordId}:updatedAt`, i);
+	}
+
+	const encoded = Y.encodeStateAsUpdate(doc);
+	return {
+		name: 'FLAT: Composite Keys',
+		gcEnabled: gc,
+		sizeBytes: encoded.byteLength,
+		operations,
+	};
+}
+
+/**
+ * Benchmark 4: Append-Only
+ * Baseline comparison with no deletions
+ */
+function benchmarkAppendOnly(gc: boolean, operations: number): BenchmarkResult {
+	const doc = createDoc(gc);
+	const text = doc.getText('log');
+
+	for (let i = 0; i < operations; i++) {
+		text.insert(text.length, `Entry ${i}: ${Math.random().toString(36).slice(2)}\n`);
+	}
+
+	const encoded = Y.encodeStateAsUpdate(doc);
+	return {
+		name: 'Append-Only (Baseline)',
+		gcEnabled: gc,
+		sizeBytes: encoded.byteLength,
+		operations,
+	};
+}
+
+async function runBenchmarks() {
+	console.log('='.repeat(70));
+	console.log('Yjs Garbage Collection Benchmark');
+	console.log('='.repeat(70));
+	console.log();
+
+	const results: BenchmarkResult[] = [];
+
+	// Benchmark 1: Text Editing
+	console.log('Running: Y.Text Heavy Editing (100k operations)...');
+	const textOps = 100_000;
+	results.push(benchmarkTextEditing(false, textOps));
+	results.push(benchmarkTextEditing(true, textOps));
+
+	// Benchmark 2: Bad Pattern (Replace Y.Maps)
+	console.log('Running: BAD Pattern - Replace Y.Maps (50k operations)...');
+	const mapOps = 50_000;
+	results.push(benchmarkBadPattern(false, mapOps));
+	results.push(benchmarkBadPattern(true, mapOps));
+
+	// Benchmark 3: Good Pattern (Reuse Y.Maps)
+	console.log('Running: GOOD Pattern - Reuse Y.Maps (50k operations)...');
+	results.push(benchmarkGoodPattern(false, mapOps));
+	results.push(benchmarkGoodPattern(true, mapOps));
+
+	// Benchmark 4: Flat Pattern (Composite Keys)
+	console.log('Running: FLAT Pattern - Composite Keys (50k operations)...');
+	results.push(benchmarkFlatPattern(false, mapOps));
+	results.push(benchmarkFlatPattern(true, mapOps));
+
+	// Benchmark 5: Append-Only
+	console.log('Running: Append-Only Baseline (10k operations)...');
+	const appendOps = 10_000;
+	results.push(benchmarkAppendOnly(false, appendOps));
+	results.push(benchmarkAppendOnly(true, appendOps));
+
+	console.log();
+	console.log('='.repeat(70));
+	console.log('Results');
+	console.log('='.repeat(70));
+	console.log();
+
+	// Group results by benchmark name
+	const grouped = new Map<string, BenchmarkResult[]>();
+	for (const result of results) {
+		const existing = grouped.get(result.name) || [];
+		existing.push(result);
+		grouped.set(result.name, existing);
+	}
+
+	for (const [name, benchResults] of grouped) {
+		const gcOff = benchResults.find((r) => !r.gcEnabled)!;
+		const gcOn = benchResults.find((r) => r.gcEnabled)!;
+		const reduction = ((gcOff.sizeBytes - gcOn.sizeBytes) / gcOff.sizeBytes) * 100;
+		const ratio = gcOff.sizeBytes / gcOn.sizeBytes;
+
+		console.log(`${name}`);
+		console.log(`  Operations: ${gcOff.operations.toLocaleString()}`);
+		console.log(`  GC OFF: ${formatBytes(gcOff.sizeBytes)}`);
+		console.log(`  GC ON:  ${formatBytes(gcOn.sizeBytes)}`);
+		console.log(`  Reduction: ${reduction.toFixed(1)}% (${ratio.toFixed(2)}x smaller)`);
+		console.log();
+	}
+
+	// Save encoded documents for inspection
+	const outputDir = new URL('./benchmark-output/', import.meta.url).pathname;
+	await mkdir(outputDir, { recursive: true });
+
+	for (const result of results) {
+		const doc = createDoc(result.gcEnabled);
+
+		// Re-run the benchmark to get the actual doc (bit wasteful but keeps code simple)
+		if (result.name.includes('Text')) {
+			const text = doc.getText('content');
+			for (let i = 0; i < 1000; i++) {
+				// Small sample
+				text.insert(Math.floor(Math.random() * (text.length + 1)), 'x');
+				if (text.length > 0 && Math.random() > 0.5) {
+					text.delete(Math.floor(Math.random() * text.length), 1);
+				}
+			}
+		}
+
+		const encoded = Y.encodeStateAsUpdate(doc);
+		const filename = `${result.name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-gc-${result.gcEnabled ? 'on' : 'off'}.bin`;
+		await Bun.write(`${outputDir}${filename}`, encoded);
+	}
+
+	console.log(`Sample documents saved to: ${outputDir}`);
+}
+
+runBenchmarks().catch(console.error);

--- a/packages/epicenter/scripts/ykeyvalue-write-benchmark.ts
+++ b/packages/epicenter/scripts/ykeyvalue-write-benchmark.ts
@@ -1,0 +1,139 @@
+/**
+ * Benchmark: Is YKeyValue's O(n) write fast enough for 100k rows?
+ *
+ * Run: bun packages/epicenter/scripts/ykeyvalue-write-benchmark.ts
+ */
+import * as Y from 'yjs';
+import { YKeyValue } from '../src/core/utils/y-keyvalue';
+
+type Row = { id: string; name: string; value: number };
+
+function benchmarkYKeyValue(rowCount: number, updateCount: number) {
+	const doc = new Y.Doc();
+	const yarray = doc.getArray<{ key: string; val: Row }>('table');
+	const kv = new YKeyValue(yarray);
+
+	// Seed with rows
+	console.log(`\nSeeding ${rowCount.toLocaleString()} rows...`);
+	const seedStart = performance.now();
+	doc.transact(() => {
+		for (let i = 0; i < rowCount; i++) {
+			kv.set(`row-${i}`, { id: `row-${i}`, name: `Name ${i}`, value: i });
+		}
+	});
+	const seedTime = performance.now() - seedStart;
+	console.log(`  Seed time: ${seedTime.toFixed(2)}ms`);
+
+	// Measure single update times
+	const updateTimes: number[] = [];
+	for (let i = 0; i < updateCount; i++) {
+		const randomKey = `row-${Math.floor(Math.random() * rowCount)}`;
+		const start = performance.now();
+		kv.set(randomKey, { id: randomKey, name: `Updated ${i}`, value: i * 100 });
+		updateTimes.push(performance.now() - start);
+	}
+
+	const avg = updateTimes.reduce((a, b) => a + b, 0) / updateTimes.length;
+	const max = Math.max(...updateTimes);
+	const min = Math.min(...updateTimes);
+
+	console.log(`  Single update (${updateCount} samples):`);
+	console.log(`    Avg: ${avg.toFixed(3)}ms`);
+	console.log(`    Min: ${min.toFixed(3)}ms`);
+	console.log(`    Max: ${max.toFixed(3)}ms`);
+
+	// Measure read time for comparison
+	const readTimes: number[] = [];
+	for (let i = 0; i < updateCount; i++) {
+		const randomKey = `row-${Math.floor(Math.random() * rowCount)}`;
+		const start = performance.now();
+		kv.get(randomKey);
+		readTimes.push(performance.now() - start);
+	}
+	const readAvg = readTimes.reduce((a, b) => a + b, 0) / readTimes.length;
+	console.log(`  Single read avg: ${readAvg.toFixed(4)}ms`);
+
+	return { seedTime, avgUpdate: avg, maxUpdate: max };
+}
+
+function benchmarkYMap(rowCount: number, updateCount: number) {
+	const doc = new Y.Doc();
+	const ymap = doc.getMap<Row>('table');
+
+	// Seed with rows
+	console.log(`\nSeeding ${rowCount.toLocaleString()} rows (Y.Map)...`);
+	const seedStart = performance.now();
+	doc.transact(() => {
+		for (let i = 0; i < rowCount; i++) {
+			ymap.set(`row-${i}`, { id: `row-${i}`, name: `Name ${i}`, value: i });
+		}
+	});
+	const seedTime = performance.now() - seedStart;
+	console.log(`  Seed time: ${seedTime.toFixed(2)}ms`);
+
+	// Measure single update times
+	const updateTimes: number[] = [];
+	for (let i = 0; i < updateCount; i++) {
+		const randomKey = `row-${Math.floor(Math.random() * rowCount)}`;
+		const start = performance.now();
+		ymap.set(randomKey, { id: randomKey, name: `Updated ${i}`, value: i * 100 });
+		updateTimes.push(performance.now() - start);
+	}
+
+	const avg = updateTimes.reduce((a, b) => a + b, 0) / updateTimes.length;
+	const max = Math.max(...updateTimes);
+
+	console.log(`  Single update (${updateCount} samples):`);
+	console.log(`    Avg: ${avg.toFixed(3)}ms`);
+	console.log(`    Max: ${max.toFixed(3)}ms`);
+
+	return { seedTime, avgUpdate: avg, maxUpdate: max };
+}
+
+console.log('═'.repeat(60));
+console.log('YKeyValue O(n) Write Performance Benchmark');
+console.log('═'.repeat(60));
+
+const rowCounts = [1_000, 10_000, 100_000];
+const updateSamples = 100;
+
+console.log('\n── YKeyValue ──');
+const ykvResults: Record<number, { avgUpdate: number }> = {};
+for (const count of rowCounts) {
+	ykvResults[count] = benchmarkYKeyValue(count, updateSamples);
+}
+
+console.log('\n── Y.Map (for comparison) ──');
+const ymapResults: Record<number, { avgUpdate: number }> = {};
+for (const count of rowCounts) {
+	ymapResults[count] = benchmarkYMap(count, updateSamples);
+}
+
+console.log('\n' + '═'.repeat(60));
+console.log('Summary: Single Update Latency');
+console.log('═'.repeat(60));
+console.log('\nRows       | YKeyValue  | Y.Map      | Ratio');
+console.log('-----------|------------|------------|-------');
+for (const count of rowCounts) {
+	const ykv = ykvResults[count]!.avgUpdate;
+	const ym = ymapResults[count]!.avgUpdate;
+	const ratio = (ykv / ym).toFixed(1);
+	console.log(
+		`${count.toLocaleString().padEnd(10)} | ${ykv.toFixed(3).padEnd(10)}ms | ${ym.toFixed(3).padEnd(10)}ms | ${ratio}x`,
+	);
+}
+
+console.log('\n' + '═'.repeat(60));
+console.log('Verdict');
+console.log('═'.repeat(60));
+const verdict100k = ykvResults[100_000]!.avgUpdate;
+if (verdict100k < 1) {
+	console.log(`\n✓ At 100k rows, updates take ~${verdict100k.toFixed(2)}ms`);
+	console.log('  This is sub-millisecond and totally fine for most UIs.');
+} else if (verdict100k < 16) {
+	console.log(`\n~ At 100k rows, updates take ~${verdict100k.toFixed(2)}ms`);
+	console.log('  This is under one frame (16ms) - acceptable for most cases.');
+} else {
+	console.log(`\n⚠ At 100k rows, updates take ~${verdict100k.toFixed(2)}ms`);
+	console.log('  This exceeds one frame - may cause jank in rapid updates.');
+}

--- a/packages/epicenter/scripts/ymap-vs-ykeyvalue-benchmark.ts
+++ b/packages/epicenter/scripts/ymap-vs-ykeyvalue-benchmark.ts
@@ -1,0 +1,187 @@
+/**
+ * Benchmark: Y.Map vs YKeyValue for KV-style storage
+ *
+ * Tests typical KV patterns:
+ * 1. Few keys, frequent updates (e.g., settings that change often)
+ * 2. Few keys, infrequent updates (e.g., user preferences)
+ * 3. Many keys, moderate updates (e.g., feature flags, cache)
+ *
+ * Run: bun packages/epicenter/scripts/ymap-vs-ykeyvalue-benchmark.ts
+ */
+
+import * as Y from 'yjs';
+import { YKeyValue } from '../src/core/utils/y-keyvalue';
+
+type BenchmarkResult = {
+	name: string;
+	ymapBytes: number;
+	ykvBytes: number;
+	ymapTimeMs: number;
+	ykvTimeMs: number;
+	ratio: string;
+};
+
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(2)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function benchmarkScenario(
+	name: string,
+	numKeys: number,
+	updatesPerKey: number,
+): BenchmarkResult {
+	// Y.Map benchmark
+	const ymapDoc = new Y.Doc();
+	const ymap = ymapDoc.getMap<{ value: string; count: number }>('kv');
+
+	const ymapStart = performance.now();
+	for (let update = 0; update < updatesPerKey; update++) {
+		for (let key = 0; key < numKeys; key++) {
+			ymap.set(`key-${key}`, {
+				value: `value-${update}`,
+				count: update,
+			});
+		}
+	}
+	const ymapTime = performance.now() - ymapStart;
+	const ymapBytes = Y.encodeStateAsUpdate(ymapDoc).byteLength;
+
+	// YKeyValue benchmark
+	const ykvDoc = new Y.Doc();
+	const yarray = ykvDoc.getArray<{
+		key: string;
+		val: { value: string; count: number };
+	}>('kv');
+	const ykv = new YKeyValue(yarray);
+
+	const ykvStart = performance.now();
+	for (let update = 0; update < updatesPerKey; update++) {
+		for (let key = 0; key < numKeys; key++) {
+			ykv.set(`key-${key}`, {
+				value: `value-${update}`,
+				count: update,
+			});
+		}
+	}
+	const ykvTime = performance.now() - ykvStart;
+	const ykvBytes = Y.encodeStateAsUpdate(ykvDoc).byteLength;
+
+	const ratio =
+		ymapBytes > ykvBytes
+			? `Y.Map is ${(ymapBytes / ykvBytes).toFixed(1)}x larger`
+			: `YKeyValue is ${(ykvBytes / ymapBytes).toFixed(1)}x larger`;
+
+	return {
+		name,
+		ymapBytes,
+		ykvBytes,
+		ymapTimeMs: ymapTime,
+		ykvTimeMs: ykvTime,
+		ratio,
+	};
+}
+
+console.log('═══════════════════════════════════════════════════════════════');
+console.log('Y.Map vs YKeyValue Benchmark for KV Storage');
+console.log('═══════════════════════════════════════════════════════════════\n');
+
+const scenarios = [
+	// Typical KV: few keys, rare updates
+	{ name: '5 keys, 1 update each (initial set)', numKeys: 5, updatesPerKey: 1 },
+	{
+		name: '10 keys, 1 update each (initial set)',
+		numKeys: 10,
+		updatesPerKey: 1,
+	},
+
+	// Settings that change occasionally
+	{
+		name: '5 keys, 10 updates each (occasional changes)',
+		numKeys: 5,
+		updatesPerKey: 10,
+	},
+	{
+		name: '10 keys, 10 updates each (occasional changes)',
+		numKeys: 10,
+		updatesPerKey: 10,
+	},
+
+	// Frequently changing values (e.g., cursor position, live data)
+	{
+		name: '5 keys, 100 updates each (frequent changes)',
+		numKeys: 5,
+		updatesPerKey: 100,
+	},
+	{
+		name: '5 keys, 1000 updates each (very frequent)',
+		numKeys: 5,
+		updatesPerKey: 1000,
+	},
+
+	// Many keys (e.g., feature flags, cache entries)
+	{
+		name: '50 keys, 10 updates each (many keys)',
+		numKeys: 50,
+		updatesPerKey: 10,
+	},
+	{
+		name: '100 keys, 10 updates each (lots of keys)',
+		numKeys: 100,
+		updatesPerKey: 10,
+	},
+
+	// Stress test
+	{
+		name: '10 keys, 10000 updates each (stress test)',
+		numKeys: 10,
+		updatesPerKey: 10000,
+	},
+];
+
+const results: BenchmarkResult[] = [];
+
+for (const scenario of scenarios) {
+	const result = benchmarkScenario(
+		scenario.name,
+		scenario.numKeys,
+		scenario.updatesPerKey,
+	);
+	results.push(result);
+
+	console.log(`📊 ${result.name}`);
+	console.log(`   Y.Map:     ${formatBytes(result.ymapBytes).padStart(12)} | ${result.ymapTimeMs.toFixed(2).padStart(8)} ms`);
+	console.log(`   YKeyValue: ${formatBytes(result.ykvBytes).padStart(12)} | ${result.ykvTimeMs.toFixed(2).padStart(8)} ms`);
+	console.log(`   → ${result.ratio}`);
+	console.log();
+}
+
+console.log('═══════════════════════════════════════════════════════════════');
+console.log('Summary');
+console.log('═══════════════════════════════════════════════════════════════\n');
+
+console.log('| Scenario | Y.Map Size | YKV Size | Y.Map Time | YKV Time | Winner |');
+console.log('|----------|------------|----------|------------|----------|--------|');
+
+for (const r of results) {
+	const sizeWinner = r.ymapBytes <= r.ykvBytes ? 'Y.Map' : 'YKV';
+	const timeWinner = r.ymapTimeMs <= r.ykvTimeMs ? 'Y.Map' : 'YKV';
+	const winner = sizeWinner === timeWinner ? sizeWinner : 'Mixed';
+
+	console.log(
+		`| ${r.name.slice(0, 40).padEnd(40)} | ${formatBytes(r.ymapBytes).padStart(10)} | ${formatBytes(r.ykvBytes).padStart(8)} | ${r.ymapTimeMs.toFixed(2).padStart(10)} ms | ${r.ykvTimeMs.toFixed(2).padStart(8)} ms | ${winner.padStart(6)} |`,
+	);
+}
+
+console.log('\n');
+console.log('Key Insights:');
+console.log('- For few updates: Y.Map and YKeyValue are similar in size');
+console.log('- For many updates to same keys: YKeyValue stays bounded, Y.Map grows');
+console.log('- YKeyValue has slightly more overhead per operation (cleanup scan)');
+console.log(
+	'- For typical KV (few keys, occasional updates): either works fine',
+);
+console.log(
+	'- For high-frequency updates: YKeyValue prevents unbounded growth',
+);

--- a/packages/epicenter/src/core/utils/y-keyvalue.test.ts
+++ b/packages/epicenter/src/core/utils/y-keyvalue.test.ts
@@ -1,0 +1,371 @@
+/**
+ * YKeyValue Conflict Resolution Tests
+ *
+ * These tests verify the conflict resolution behavior of YKeyValue,
+ * particularly in offline sync scenarios where multiple clients
+ * update the same key concurrently.
+ *
+ * Key finding: YKeyValue uses POSITIONAL conflict resolution (rightmost wins),
+ * built on top of Yjs's clientID-based ordering. The "winner" is deterministic
+ * based on clientIDs, just like Y.Map.
+ */
+import { describe, expect, test } from 'bun:test';
+import * as Y from 'yjs';
+import { YKeyValue } from './y-keyvalue';
+
+describe('YKeyValue', () => {
+	describe('Basic Operations', () => {
+		test('set and get work correctly', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const yarray = ydoc.getArray<{ key: string; val: string }>('data');
+			const kv = new YKeyValue(yarray);
+
+			kv.set('foo', 'bar');
+			expect(kv.get('foo')).toBe('bar');
+		});
+
+		test('set overwrites existing value', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const yarray = ydoc.getArray<{ key: string; val: string }>('data');
+			const kv = new YKeyValue(yarray);
+
+			kv.set('foo', 'first');
+			kv.set('foo', 'second');
+			expect(kv.get('foo')).toBe('second');
+		});
+
+		test('delete removes value', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const yarray = ydoc.getArray<{ key: string; val: string }>('data');
+			const kv = new YKeyValue(yarray);
+
+			kv.set('foo', 'bar');
+			kv.delete('foo');
+			expect(kv.get('foo')).toBeUndefined();
+			expect(kv.has('foo')).toBe(false);
+		});
+
+		test('has returns correct boolean', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const yarray = ydoc.getArray<{ key: string; val: string }>('data');
+			const kv = new YKeyValue(yarray);
+
+			expect(kv.has('foo')).toBe(false);
+			kv.set('foo', 'bar');
+			expect(kv.has('foo')).toBe(true);
+		});
+	});
+
+	describe('Change Events', () => {
+		test('fires add event when new key is set', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const yarray = ydoc.getArray<{ key: string; val: string }>('data');
+			const kv = new YKeyValue(yarray);
+
+			const events: Array<{ key: string; action: string }> = [];
+			kv.on('change', (changes) => {
+				for (const [key, change] of changes) {
+					events.push({ key, action: change.action });
+				}
+			});
+
+			kv.set('foo', 'bar');
+			expect(events).toEqual([{ key: 'foo', action: 'add' }]);
+		});
+
+		test('fires update event when existing key is changed', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const yarray = ydoc.getArray<{ key: string; val: string }>('data');
+			const kv = new YKeyValue(yarray);
+
+			kv.set('foo', 'first');
+
+			const events: Array<{
+				key: string;
+				action: string;
+				oldValue?: string;
+				newValue?: string;
+			}> = [];
+			kv.on('change', (changes) => {
+				for (const [key, change] of changes) {
+					events.push({
+						key,
+						action: change.action,
+						oldValue: 'oldValue' in change ? change.oldValue : undefined,
+						newValue: 'newValue' in change ? change.newValue : undefined,
+					});
+				}
+			});
+
+			kv.set('foo', 'second');
+			expect(events).toEqual([
+				{ key: 'foo', action: 'update', oldValue: 'first', newValue: 'second' },
+			]);
+		});
+
+		test('fires delete event when key is removed', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const yarray = ydoc.getArray<{ key: string; val: string }>('data');
+			const kv = new YKeyValue(yarray);
+
+			kv.set('foo', 'bar');
+
+			const events: Array<{ key: string; action: string }> = [];
+			kv.on('change', (changes) => {
+				for (const [key, change] of changes) {
+					events.push({ key, action: change.action });
+				}
+			});
+
+			kv.delete('foo');
+			expect(events).toEqual([{ key: 'foo', action: 'delete' }]);
+		});
+	});
+
+	describe('Sync Behavior - Two Document Simulation', () => {
+		/**
+		 * Simulates two clients editing the same key while offline,
+		 * then syncing their changes.
+		 *
+		 * This test demonstrates that YKeyValue conflict resolution is
+		 * deterministic based on Yjs's clientID ordering.
+		 */
+		test('concurrent updates: winner is determined by clientID ordering', () => {
+			// Create two separate Y.Docs (simulating two offline clients)
+			const doc1 = new Y.Doc({ guid: 'shared' });
+			const doc2 = new Y.Doc({ guid: 'shared' });
+
+			const array1 = doc1.getArray<{ key: string; val: string }>('data');
+			const array2 = doc2.getArray<{ key: string; val: string }>('data');
+
+			const kv1 = new YKeyValue(array1);
+			const kv2 = new YKeyValue(array2);
+
+			// Client 1 sets value (imagine this is at 10:00am)
+			kv1.set('doc', 'from-client-1');
+
+			// Client 2 sets value (imagine this is at 10:05am - LATER)
+			kv2.set('doc', 'from-client-2');
+
+			// Now sync: Apply doc1's changes to doc2, then doc2's changes to doc1
+			const state1 = Y.encodeStateAsUpdate(doc1);
+			const state2 = Y.encodeStateAsUpdate(doc2);
+
+			// Apply in order: doc1 → doc2, doc2 → doc1
+			Y.applyUpdate(doc2, state1);
+			Y.applyUpdate(doc1, state2);
+
+			// Both docs should now have the same value
+			// The winner is determined by Yjs's clientID-based ordering
+			const value1 = kv1.get('doc');
+			const value2 = kv2.get('doc');
+
+			// Both clients should see the same value (convergence)
+			expect(value1).toBe(value2);
+
+			// The key insight: the winner is deterministic based on clientIDs
+			console.log(`Winner: ${value1}`);
+		});
+
+		test('concurrent updates converge to same value across all clients', () => {
+			// Run the sync test multiple times to observe if outcome varies
+			const results: string[] = [];
+
+			for (let i = 0; i < 10; i++) {
+				const doc1 = new Y.Doc({ guid: `shared-${i}` });
+				const doc2 = new Y.Doc({ guid: `shared-${i}` });
+
+				const array1 = doc1.getArray<{ key: string; val: string }>('data');
+				const array2 = doc2.getArray<{ key: string; val: string }>('data');
+
+				const kv1 = new YKeyValue(array1);
+				const kv2 = new YKeyValue(array2);
+
+				kv1.set('key', `value-from-1-iteration-${i}`);
+				kv2.set('key', `value-from-2-iteration-${i}`);
+
+				const state1 = Y.encodeStateAsUpdate(doc1);
+				const state2 = Y.encodeStateAsUpdate(doc2);
+
+				Y.applyUpdate(doc2, state1);
+				Y.applyUpdate(doc1, state2);
+
+				// Convergence check: both should have same value
+				expect(kv1.get('key')).toBe(kv2.get('key'));
+
+				results.push(kv1.get('key')!);
+			}
+
+			// Log results to observe pattern
+			console.log('Concurrent update winners:', results);
+		});
+
+		test('delete vs update race condition', () => {
+			// Client 1 deletes a key
+			// Client 2 updates the same key
+			// Who wins after sync?
+
+			const doc1 = new Y.Doc({ guid: 'shared-delete-test' });
+			const doc2 = new Y.Doc({ guid: 'shared-delete-test' });
+
+			const array1 = doc1.getArray<{ key: string; val: string }>('data');
+			const array2 = doc2.getArray<{ key: string; val: string }>('data');
+
+			// First, establish initial state in both docs
+			const kv1 = new YKeyValue(array1);
+			kv1.set('doc', 'initial');
+
+			// Sync initial state to doc2
+			Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1));
+			const kv2 = new YKeyValue(array2);
+
+			expect(kv2.get('doc')).toBe('initial');
+
+			// Now, while offline:
+			// Client 1 DELETES the key
+			kv1.delete('doc');
+
+			// Client 2 UPDATES the key (doesn't know about the delete)
+			kv2.set('doc', 'updated-value');
+
+			// Sync both ways
+			const state1 = Y.encodeStateAsUpdate(doc1);
+			const state2 = Y.encodeStateAsUpdate(doc2);
+
+			Y.applyUpdate(doc2, state1);
+			Y.applyUpdate(doc1, state2);
+
+			// What's the result?
+			const value1 = kv1.get('doc');
+			const value2 = kv2.get('doc');
+
+			// Both should converge
+			expect(value1).toBe(value2);
+
+			// Log the outcome
+			console.log(`Delete vs Update result: ${value1 ?? 'DELETED'}`);
+		});
+	});
+
+	describe('Array Cleanup Behavior', () => {
+		test('duplicate keys are cleaned up on construction', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const yarray = ydoc.getArray<{ key: string; val: string }>('data');
+
+			// Manually push duplicate keys (simulating sync artifacts)
+			yarray.push([{ key: 'foo', val: 'first' }]);
+			yarray.push([{ key: 'bar', val: 'only' }]);
+			yarray.push([{ key: 'foo', val: 'second' }]); // duplicate
+
+			expect(yarray.length).toBe(3);
+
+			// Creating YKeyValue should clean up duplicates
+			const kv = new YKeyValue(yarray);
+
+			// Rightmost 'foo' should win
+			expect(kv.get('foo')).toBe('second');
+			expect(kv.get('bar')).toBe('only');
+
+			// Array should be cleaned (duplicates removed)
+			expect(yarray.length).toBe(2);
+		});
+
+		test('rightmost entry wins during cleanup', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const yarray = ydoc.getArray<{ key: string; val: string }>('data');
+
+			// Push same key multiple times
+			yarray.push([{ key: 'x', val: 'A' }]);
+			yarray.push([{ key: 'x', val: 'B' }]);
+			yarray.push([{ key: 'x', val: 'C' }]);
+
+			const kv = new YKeyValue(yarray);
+
+			// Rightmost ('C') should win
+			expect(kv.get('x')).toBe('C');
+			expect(yarray.length).toBe(1);
+		});
+	});
+
+	describe('Storage Efficiency', () => {
+		test('maintains constant size regardless of update count', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const yarray = ydoc.getArray<{ key: string; val: number }>('data');
+			const kv = new YKeyValue(yarray);
+
+			for (let i = 0; i < 100; i++) {
+				kv.set('counter', i);
+			}
+
+			expect(yarray.length).toBe(1);
+			expect(kv.get('counter')).toBe(99);
+		});
+
+		test('size scales with unique keys, not operations', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const yarray = ydoc.getArray<{ key: string; val: string }>('data');
+			const kv = new YKeyValue(yarray);
+
+			for (let i = 0; i < 10; i++) {
+				kv.set(`key-${i}`, `value-${i}`);
+			}
+
+			for (let round = 0; round < 10; round++) {
+				for (let i = 0; i < 10; i++) {
+					kv.set(`key-${i}`, `value-${i}-round-${round}`);
+				}
+			}
+
+			expect(yarray.length).toBe(10);
+		});
+	});
+
+	describe('Documentation of Conflict Resolution Behavior', () => {
+		/**
+		 * This test documents the EXACT conflict resolution mechanism.
+		 *
+		 * YKeyValue uses "rightmost wins" - when the cleanup logic runs
+		 * (either on construction or via observer), it iterates right-to-left
+		 * and keeps only the first occurrence of each key.
+		 *
+		 * This is DETERMINISTIC given a specific array state, and the array
+		 * state after CRDT merge is also deterministic based on Yjs's
+		 * clientID-based ordering algorithm.
+		 */
+		test('conflict resolution is positional (rightmost wins)', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const yarray = ydoc.getArray<{ key: string; val: string }>('data');
+
+			// Manually construct a conflicted state
+			yarray.push([{ key: 'x', val: 'leftmost' }]);
+			yarray.push([{ key: 'y', val: 'middle-y' }]);
+			yarray.push([{ key: 'x', val: 'rightmost' }]); // This should win
+
+			const kv = new YKeyValue(yarray);
+
+			expect(kv.get('x')).toBe('rightmost');
+			expect(kv.get('y')).toBe('middle-y');
+		});
+
+		/**
+		 * This test shows that there are NO TIMESTAMPS in the current implementation.
+		 * The entry structure is just { key, val } - no temporal information.
+		 */
+		test('entries have no timestamp field', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const yarray = ydoc.getArray<{ key: string; val: string }>('data');
+			const kv = new YKeyValue(yarray);
+
+			kv.set('foo', 'bar');
+
+			// Inspect the raw array entry
+			const entry = yarray.get(0);
+			expect(entry).toEqual({ key: 'foo', val: 'bar' });
+
+			// No timestamp field exists
+			expect('timestamp' in entry).toBe(false);
+			expect('time' in entry).toBe(false);
+			expect('updatedAt' in entry).toBe(false);
+		});
+	});
+});

--- a/packages/epicenter/src/core/utils/y-keyvalue.ts
+++ b/packages/epicenter/src/core/utils/y-keyvalue.ts
@@ -1,0 +1,374 @@
+/**
+ * # YKeyValue - Efficient Key-Value Store for Yjs
+ *
+ * Based on [y-utility](https://github.com/yjs/y-utility) (MIT License).
+ *
+ * ## The Problem: Y.Map's Unbounded Growth
+ *
+ * Yjs is a CRDT (Conflict-free Replicated Data Type) library that enables real-time
+ * collaboration. CRDTs solve a hard problem: when two users edit the same data
+ * simultaneously without coordination, how do you merge their changes?
+ *
+ * Y.Map solves this by keeping historical context. When you update a key, Yjs doesn't
+ * just overwrite the old value—it needs to remember what was there so it can merge
+ * correctly when syncing with other clients.
+ *
+ * **The catch**: Y.Map retains ALL historical values for EACH key. If you update
+ * `key1` 1000 times, Y.Map stores all 1000 values internally. For a key-value store
+ * pattern (like storing table rows), this causes unbounded memory growth:
+ *
+ * ```
+ * // Alternating updates cause worst-case growth:
+ * map.set('row1', data1)  // 1 item stored
+ * map.set('row2', data2)  // 2 items stored
+ * map.set('row1', data3)  // 3 items stored (old row1 value retained!)
+ * map.set('row2', data4)  // 4 items stored (old row2 value retained!)
+ * // ... after 100k operations on 10 keys: 524,985 bytes
+ * ```
+ *
+ * ## The Solution: Append-and-Cleanup with Y.Array
+ *
+ * YKeyValue uses Y.Array instead of Y.Map with a clever strategy:
+ *
+ * 1. **Append new entries to the right**: When you set a key, push `{key, val}` to
+ *    the end of the array
+ * 2. **Remove old duplicates**: Delete any previous entry with the same key
+ * 3. **Right-side precedence**: If two clients add the same key simultaneously,
+ *    the rightmost entry wins (this is the CRDT merge rule)
+ *
+ * ```
+ * // Same operations, constant size:
+ * array: [{key:'row1', val:data1}]                           // 1 item
+ * array: [{key:'row1', val:data1}, {key:'row2', val:data2}]  // 2 items
+ * array: [{key:'row2', val:data2}, {key:'row1', val:data3}]  // still 2 items!
+ * // ... after 100k operations on 10 keys: 271 bytes
+ * ```
+ *
+ * **Why Y.Array doesn't have the same problem**: When you delete from Y.Array,
+ * Yjs marks the item as a "tombstone" but doesn't retain the full value—just
+ * enough metadata to know it was deleted. The actual data is garbage collected.
+ *
+ * ## How the In-Memory Map Works
+ *
+ * Scanning an array for a key is O(n). To get O(1) lookups, YKeyValue maintains
+ * an in-memory `Map<string, {key, val}>` that mirrors the Y.Array:
+ *
+ * ```
+ * Y.Array (source of truth, synced across clients):
+ *   [{key:'a', val:1}, {key:'b', val:2}, {key:'c', val:3}]
+ *
+ * In-memory Map (local cache for fast lookups):
+ *   'a' → {key:'a', val:1}
+ *   'b' → {key:'b', val:2}
+ *   'c' → {key:'c', val:3}
+ * ```
+ *
+ * The Map is rebuilt on initialization and updated incrementally via Y.Array's
+ * observer. It's never persisted—just derived state.
+ *
+ * ## Conflict Resolution: ClientID-Based Ordering
+ *
+ * When two clients simultaneously set the same key, both entries end up in the
+ * array. The final order depends on Yjs's CRDT merge algorithm, which uses
+ * **clientID ordering** (lower clientID wins ties). This is the SAME ordering
+ * mechanism that Y.Map uses internally.
+ *
+ * ```
+ * Client A (clientID: 100): array.push({key:'x', val:'A'})
+ * Client B (clientID: 200): array.push({key:'x', val:'B'})
+ *
+ * After sync, array is deterministically ordered based on clientIDs.
+ * YKeyValue's cleanup keeps only the rightmost 'x'.
+ * ```
+ *
+ * The key insight: YKeyValue's "rightmost wins" cleanup on top of Yjs's
+ * clientID-ordered array produces deterministic conflict resolution—the same
+ * mechanism that powers Y.Map.
+ *
+ * ## Performance
+ *
+ * Benchmark (100k operations on 10 keys):
+ * - **YKeyValue**: 271 bytes (constant, ~27 bytes per key)
+ * - **Y.Map**: 524,985 bytes (grows with operation count)
+ * - **Improvement**: 1935x smaller
+ *
+ * Time complexity:
+ * - `get()`: O(1) via in-memory Map
+ * - `set()`: O(n) worst case (scan to find old entry), typically O(1) amortized
+ * - `delete()`: O(n) worst case (scan to find entry)
+ * - Iteration: O(n)
+ *
+ * ## Limitations
+ *
+ * - **No nested Yjs types**: Values must be JSON-serializable (no Y.Text, Y.Map, etc.)
+ * - **No partial updates**: Setting a key replaces the entire value
+ * - **Order not preserved**: Iteration order depends on insertion/update history
+ *
+ * For collaborative text editing within a value, store the text in a separate
+ * Y.Text and reference it by ID.
+ *
+ * @example
+ * ```typescript
+ * import * as Y from 'yjs';
+ * import { YKeyValue } from './y-keyvalue';
+ *
+ * const doc = new Y.Doc();
+ * const yarray = doc.getArray<{ key: string; val: { name: string; age: number } }>('users');
+ * const kv = new YKeyValue(yarray);
+ *
+ * // Basic operations
+ * kv.set('user1', { name: 'Alice', age: 30 });
+ * kv.set('user2', { name: 'Bob', age: 25 });
+ *
+ * console.log(kv.get('user1')); // { name: 'Alice', age: 30 }
+ * console.log(kv.has('user2')); // true
+ *
+ * // Update (replaces entire value)
+ * kv.set('user1', { name: 'Alice', age: 31 });
+ *
+ * // Delete
+ * kv.delete('user2');
+ *
+ * // Observe changes
+ * kv.on('change', (changes, transaction) => {
+ *   for (const [key, change] of changes) {
+ *     if (change.action === 'add') {
+ *       console.log(`Added ${key}:`, change.newValue);
+ *     } else if (change.action === 'update') {
+ *       console.log(`Updated ${key}:`, change.oldValue, '→', change.newValue);
+ *     } else if (change.action === 'delete') {
+ *       console.log(`Deleted ${key}:`, change.oldValue);
+ *     }
+ *   }
+ * });
+ * ```
+ */
+import type * as Y from 'yjs';
+
+export type YKeyValueChange<T> =
+	| { action: 'add'; newValue: T }
+	| { action: 'update'; oldValue: T; newValue: T }
+	| { action: 'delete'; oldValue: T };
+
+export type YKeyValueChangeHandler<T> = (
+	changes: Map<string, YKeyValueChange<T>>,
+	transaction: Y.Transaction,
+) => void;
+
+export class YKeyValue<T> {
+	/** The underlying Y.Array that stores `{key, val}` entries. This is the CRDT source of truth. */
+	readonly yarray: Y.Array<{ key: string; val: T }>;
+
+	/** The Y.Doc that owns this array. Required for transactions. */
+	readonly doc: Y.Doc;
+
+	/**
+	 * In-memory index for O(1) key lookups. Maps key → entry object.
+	 *
+	 * This is derived state rebuilt from yarray on init. It stores references to
+	 * the actual entry objects in yarray, so `map.get(key) === yarray.get(i)` for
+	 * the corresponding index.
+	 */
+	readonly map: Map<string, { key: string; val: T }>;
+
+	/**
+	 * Registered change handlers for the `.on('change', handler)` API.
+	 *
+	 * ## Why not use Y.Array.observe() directly?
+	 *
+	 * YKeyValue is a meta data structure: it wraps Y.Array but presents a map-like
+	 * interface. The raw Y.Array events don't map cleanly to "key-value" semantics:
+	 *
+	 * - Y.Array fires on positional changes (insert at index 5, delete range 2-4)
+	 * - YKeyValue needs semantic changes (key 'foo' was added/updated/deleted)
+	 *
+	 * We already observe Y.Array internally to maintain `this.map`. This handler set
+	 * lets us expose higher-level change events that make sense for key-value usage:
+	 *
+	 * ```typescript
+	 * // Raw Y.Array event (low-level, positional):
+	 * yarray.observe((event) => {
+	 *   // event.changes.added: Set<Item> - items added at various positions
+	 *   // event.changes.deleted: Set<Item> - items removed from various positions
+	 * });
+	 *
+	 * // YKeyValue event (high-level, semantic):
+	 * kv.on('change', (changes) => {
+	 *   // changes: Map<key, { action: 'add'|'update'|'delete', oldValue?, newValue? }>
+	 * });
+	 * ```
+	 *
+	 * The internal observer translates positional changes to semantic changes,
+	 * then dispatches to all registered handlers.
+	 */
+	private changeHandlers: Set<YKeyValueChangeHandler<T>> = new Set();
+
+	/**
+	 * Create a YKeyValue wrapper around an existing Y.Array.
+	 *
+	 * On construction:
+	 * 1. Scans the array right-to-left to build the in-memory Map
+	 * 2. Removes any duplicate keys (keeps rightmost, per CRDT rules)
+	 * 3. Sets up an observer to keep the Map in sync with future changes
+	 *
+	 * @param yarray - A Y.Array storing `{key: string, val: T}` entries
+	 */
+	constructor(yarray: Y.Array<{ key: string; val: T }>) {
+		this.yarray = yarray;
+		this.doc = yarray.doc as Y.Doc;
+		this.map = new Map();
+
+		const arr = yarray.toArray();
+		this.doc.transact(() => {
+			for (let i = arr.length - 1; i >= 0; i--) {
+				const v = arr[i]!;
+				if (this.map.has(v.key)) {
+					yarray.delete(i);
+				} else {
+					this.map.set(v.key, v);
+				}
+			}
+		});
+
+		yarray.observe((event, tr) => {
+			const changes = new Map<string, YKeyValueChange<T>>();
+			const addedItems: Y.Item[] = Array.from(event.changes.added);
+
+			event.changes.deleted.forEach((ditem) => {
+				ditem.content.getContent().forEach((c: { key: string; val: T }) => {
+					if (this.map.get(c.key) === c) {
+						this.map.delete(c.key);
+						changes.set(c.key, { action: 'delete', oldValue: c.val });
+					}
+				});
+			});
+
+			const addedVals = new Map<string, { key: string; val: T }>();
+			addedItems
+				.flatMap((item) => item.content.getContent())
+				.forEach((v: { key: string; val: T }) => {
+					addedVals.set(v.key, v);
+				});
+
+			const itemsToRemove = new Set<string>();
+			const vals = yarray.toArray();
+
+			this.doc.transact(() => {
+				for (
+					let i = vals.length - 1;
+					i >= 0 && (addedVals.size > 0 || itemsToRemove.size > 0);
+					i--
+				) {
+					const currVal = vals[i]!;
+
+					if (itemsToRemove.has(currVal.key)) {
+						itemsToRemove.delete(currVal.key);
+						yarray.delete(i, 1);
+					} else if (addedVals.get(currVal.key) === currVal) {
+						const prevValue = this.map.get(currVal.key);
+						if (prevValue) {
+							itemsToRemove.add(currVal.key);
+							changes.set(currVal.key, {
+								action: 'update',
+								oldValue: prevValue.val,
+								newValue: currVal.val,
+							});
+						} else {
+							const delEvent = changes.get(currVal.key);
+							if (delEvent && delEvent.action === 'delete') {
+								changes.set(currVal.key, {
+									action: 'update',
+									newValue: currVal.val,
+									oldValue: delEvent.oldValue,
+								});
+							} else {
+								changes.set(currVal.key, {
+									action: 'add',
+									newValue: currVal.val,
+								});
+							}
+						}
+						addedVals.delete(currVal.key);
+						this.map.set(currVal.key, currVal);
+					} else if (addedVals.has(currVal.key)) {
+						itemsToRemove.add(currVal.key);
+						addedVals.delete(currVal.key);
+					}
+				}
+			});
+
+			if (changes.size > 0) {
+				for (const handler of this.changeHandlers) {
+					handler(changes, tr);
+				}
+			}
+		});
+	}
+
+	/**
+	 * Set a key-value pair. Creates or replaces the entire value.
+	 *
+	 * Algorithm: Delete old entry (if exists) + append new entry to right.
+	 * The in-memory Map is updated synchronously before the transaction
+	 * commits, ensuring `get()` returns the new value immediately.
+	 */
+	set(key: string, val: T): void {
+		const entry = { key, val };
+		const existing = this.map.get(key);
+
+		this.doc.transact(() => {
+			if (existing) {
+				let i = 0;
+				for (const v of this.yarray) {
+					if (v.key === key) {
+						this.yarray.delete(i);
+						break;
+					}
+					i++;
+				}
+			}
+			this.yarray.push([entry]);
+		});
+
+		this.map.set(key, entry);
+	}
+
+	/** Delete a key. No-op if key doesn't exist. O(n) scan to find entry. */
+	delete(key: string): void {
+		if (!this.map.has(key)) return;
+
+		let i = 0;
+		for (const val of this.yarray) {
+			if (val.key === key) {
+				this.yarray.delete(i);
+				break;
+			}
+			i++;
+		}
+		this.map.delete(key);
+	}
+
+	/** Get value by key. O(1) via in-memory Map. Returns undefined if not found. */
+	get(key: string): T | undefined {
+		return this.map.get(key)?.val;
+	}
+
+	/** Check if key exists. O(1) via in-memory Map. */
+	has(key: string): boolean {
+		return this.map.has(key);
+	}
+
+	/** Subscribe to changes. Handler receives a Map of key → change info. */
+	on(event: 'change', handler: YKeyValueChangeHandler<T>): void {
+		if (event === 'change') {
+			this.changeHandlers.add(handler);
+		}
+	}
+
+	/** Unsubscribe from changes. */
+	off(event: 'change', handler: YKeyValueChangeHandler<T>): void {
+		if (event === 'change') {
+			this.changeHandlers.delete(handler);
+		}
+	}
+}

--- a/specs/20260124T004528-versioned-table-api-design.md
+++ b/specs/20260124T004528-versioned-table-api-design.md
@@ -1,0 +1,879 @@
+# Versioned Table API Design for YJS Local-First Apps
+
+> **⚠️ PARTIALLY SUPERSEDED**
+>
+> This spec has been partially superseded by [`specs/20260124T162638-stable-id-schema-pattern.md`](./20260124T162638-stable-id-schema-pattern.md).
+>
+> **What changed**: The Stable ID pattern sidesteps the entire versioning problem. Instead of tracking `_v` per row and running migrations, each field has a stable internal ID that never changes. The developer-facing key can be renamed freely; the data is untouched.
+>
+> **What's still valuable here**:
+> - The analysis of YJS Y.Map LWW conflicts (the "Migration Disaster Scenario")
+> - The comparison of Full Row Transform vs Patch-Based approaches
+> - The "Deep Dive" section (line 650+) which correctly concludes per-row `_v` is overkill
+> - The recommendation to use epochs for breaking changes
+>
+> **What's obsolete**:
+> - The `versionedTable` API with `_v` tracking
+> - The `addFields` migration pattern
+> - Legacy key fallback approaches (mentioned but not recommended)
+>
+> **Read this spec for**: Understanding why CRDT migrations are dangerous. **Read the Stable ID spec for**: How to avoid migrations entirely.
+
+---
+
+**Status**: Research & Design (Partially Superseded)
+**Date**: 2026-01-24
+**Context**: Designing a `versionedTable` abstraction for schema migrations in YJS-backed local-first applications
+
+---
+
+## Problem Statement
+
+Local-first apps using YJS need to evolve their data schemas over time. Unlike traditional databases:
+
+- Data can arrive from any peer at any schema version
+- YJS uses last-write-wins (LWW) at the **field level**, not row level
+- Old clients may sync with new clients indefinitely
+- There's no single "migration window" — migrations must be safe to run anytime
+
+We need an API that:
+
+1. Makes common schema changes easy (add field, rename, etc.)
+2. Preserves type safety through the migration chain
+3. Works correctly with YJS's conflict resolution
+4. Follows the 80/20 rule — easy for common cases, possible for rare cases
+
+---
+
+## Schema Change Frequency (From Developer Simulations)
+
+We simulated realistic schema evolution for TODO and voice recording apps:
+
+| Change Type            | Frequency | YJS Safety               |
+| ---------------------- | --------- | ------------------------ |
+| Add nullable field     | ~25%      | Safe                     |
+| Add field with default | ~25%      | Safe                     |
+| Rename field           | ~15%      | **Unsafe**               |
+| Change field type      | ~15%      | **Unsafe**               |
+| Remove field           | ~10%      | **Unsafe** (hard remove) |
+| Extract to new table   | ~10%      | Complex                  |
+
+**Key insight**: ~50% of migrations are "add field" which is safe. The other 50% involve touching existing fields, which conflicts with YJS LWW.
+
+---
+
+## The YJS Conflict Problem
+
+### Scenario: Migration vs Concurrent Edit
+
+```
+Device A (offline): Reads row v1, migrates to v2, writes entire row back
+Device B (offline): Edits just the "title" field on v1
+Both sync...
+```
+
+**Result**: If A's migration wrote the `title` field (even with its old value), A and B both wrote to the same key. YJS picks one — B's edit may be lost.
+
+### Root Cause
+
+YJS Y.Maps resolve conflicts **per field**. When you do:
+
+```typescript
+// This writes EVERY field, creating conflicts on ALL of them
+rowMap.set('title', row.title);
+rowMap.set('status', row.status);
+rowMap.set('_v', 2);
+```
+
+You're competing with any concurrent edits to those fields.
+
+---
+
+## Two API Approaches
+
+We present two approaches with different trade-offs:
+
+| Aspect             | Approach A: Full Row Transform | Approach B: Patch-Based |
+| ------------------ | ------------------------------ | ----------------------- |
+| Ergonomics         | Excellent                      | Good                    |
+| Type Safety        | Excellent                      | Moderate                |
+| YJS Safety         | **Poor**                       | Excellent               |
+| Rename/Type Change | Supported                      | Not supported           |
+| Complexity         | Simple                         | More complex            |
+
+---
+
+## Approach A: Full Row Transform (Simpler, Less YJS-Safe)
+
+### Philosophy
+
+Treat migrations like pure functions: `(oldRow) => newRow`. Simple, type-safe, easy to understand.
+
+### API Design
+
+```typescript
+import { type } from 'arktype';
+
+const TodoV1 = type({
+	_v: '1',
+	id: 'string',
+	text: 'string',
+	done: 'boolean',
+});
+
+const TodoV2 = type({
+	_v: '2',
+	id: 'string',
+	title: 'string', // renamed from 'text'
+	done: 'boolean',
+	status: "'active' | 'completed'", // new field
+});
+
+const TodoV3 = type({
+	_v: '3',
+	id: 'string',
+	title: 'string',
+	status: "'active' | 'completed' | 'archived'", // type changed
+	priority: '1 | 2 | 3', // new field
+});
+
+const todosTable = versionedTable('todos')
+	.v(1, TodoV1)
+	.v(2, TodoV2, (row) => ({
+		_v: 2 as const,
+		id: row.id,
+		title: row.text, // rename
+		done: row.done,
+		status: row.done ? 'completed' : 'active',
+	}))
+	.v(3, TodoV3, (row) => ({
+		_v: 3 as const,
+		id: row.id,
+		title: row.title,
+		status: row.status,
+		priority: 2, // default to medium
+	}))
+	.build();
+```
+
+### Type Signatures
+
+```typescript
+type Migrator<From, To> = (row: From) => To;
+
+type VersionedTableBuilder<Name, Prev, Latest> = {
+	v<V extends number, Next>(
+		version: V,
+		schema: Type<Next>,
+		migrate?: Migrator<Prev, Next>,
+	): VersionedTableBuilder<Name, Next, Next>;
+
+	build(): VersionedTable<Name, Latest>;
+};
+
+type VersionedTable<Name, Latest> = {
+	name: Name;
+	latestVersion: number;
+
+	// Runtime: detect version, apply migrations, return latest
+	upgrade(raw: unknown): Latest;
+
+	// For inspection/debugging
+	versions: Record<number, { schema: Type<any> }>;
+};
+```
+
+### Usage with YJS
+
+```typescript
+// Reading
+function getRow(id: string): Todo {
+	const raw = rowsMap.get(id)?.toJSON();
+	return todosTable.upgrade(raw); // Always returns TodoV3
+}
+
+// Writing (DANGER: overwrites concurrent edits)
+function saveRow(id: string, row: Todo): void {
+	const rowMap = rowsMap.get(id) ?? new Y.Map();
+	for (const [key, value] of Object.entries(row)) {
+		rowMap.set(key, value); // Writes ALL fields
+	}
+	rowsMap.set(id, rowMap);
+}
+```
+
+### Pros
+
+- **Excellent ergonomics**: Migration is just a function
+- **Full type safety**: `(TodoV1) => TodoV2` is fully typed
+- **Supports all operations**: Rename, type change, restructure — anything goes
+- **Easy to understand**: No special rules, just transform data
+
+### Cons
+
+- **YJS unsafe**: Writing entire rows creates conflicts on all fields
+- **Can lose concurrent edits**: If peer A migrates while peer B edits, B's edit may be lost
+- **Encourages bad patterns**: Developers might not realize the conflict danger
+
+### When to Use
+
+- **Non-collaborative apps**: Single user, no sync — conflicts impossible
+- **Epoch-based migrations**: Bumping epoch means new Y.Doc, no concurrent edits
+- **Infrequent migrations**: If migrations are rare, conflict window is small
+
+---
+
+## Approach B: Patch-Based (YJS-Safe, More Restrictive)
+
+### Philosophy
+
+Migrations should only **add new fields**, never touch existing ones. This guarantees no conflicts with concurrent edits.
+
+### API Design
+
+```typescript
+import { type } from 'arktype';
+
+const TodoV1 = type({
+	_v: '1',
+	id: 'string',
+	text: 'string',
+	done: 'boolean',
+});
+
+const TodoV2 = type({
+	_v: '2',
+	id: 'string',
+	text: 'string', // can't rename in this approach
+	done: 'boolean',
+	status: "'active' | 'completed'", // new field
+});
+
+const TodoV3 = type({
+	_v: '3',
+	id: 'string',
+	text: 'string',
+	done: 'boolean',
+	status: "'active' | 'completed' | 'archived'",
+	priority: '1 | 2 | 3', // new field
+});
+
+const todosTable = versionedTable('todos')
+	.v(1, TodoV1)
+	.v(2, TodoV2, {
+		// Only specify NEW fields to add
+		addFields: (row) => ({
+			status: row.done ? ('completed' as const) : ('active' as const),
+		}),
+	})
+	.v(3, TodoV3, {
+		addFields: () => ({
+			priority: 2 as const,
+		}),
+	})
+	.build();
+```
+
+### Type Signatures
+
+```typescript
+type PatchMigration<From, Added> = {
+	// Returns only the NEW fields to add
+	addFields: (row: From) => Added;
+};
+
+type VersionedTableBuilder<Name, Prev, Latest> = {
+	v<V extends number, Next, Added>(
+		version: V,
+		schema: Type<Next>,
+		migration?: PatchMigration<Prev, Added>,
+	): VersionedTableBuilder<Name, Next, Next>;
+
+	build(): VersionedTable<Name, Latest>;
+};
+```
+
+### Usage with YJS (Safe Pattern)
+
+```typescript
+// Reading: migrate in-memory only
+function getRow(id: string): Todo {
+	const raw = rowsMap.get(id)?.toJSON();
+	return todosTable.upgrade(raw);
+}
+
+// Writing: patch only new fields + version
+function ensureMigrated(rowMap: Y.Map<any>): void {
+	const currentVersion = rowMap.get('_v') ?? 1;
+
+	if (currentVersion < 2) {
+		// Only set NEW fields, don't touch existing ones
+		if (!rowMap.has('status')) {
+			const done = rowMap.get('done');
+			rowMap.set('status', done ? 'completed' : 'active');
+		}
+		rowMap.set('_v', 2);
+	}
+
+	if (currentVersion < 3) {
+		if (!rowMap.has('priority')) {
+			rowMap.set('priority', 2);
+		}
+		rowMap.set('_v', 3);
+	}
+}
+
+// User edit: migrate + apply changes in same transaction
+function updateRow(id: string, changes: Partial<Todo>): void {
+	ydoc.transact(() => {
+		const rowMap = rowsMap.get(id);
+		ensureMigrated(rowMap); // Safe: only adds new fields
+
+		for (const [key, value] of Object.entries(changes)) {
+			rowMap.set(key, value); // User's actual edit
+		}
+	});
+}
+```
+
+### Pros
+
+- **YJS safe**: Only writes new fields, never conflicts with existing data
+- **Concurrent edit safe**: Peer A migrating won't clobber peer B's edit
+- **Idempotent**: Running migration twice is safe
+- **No "ping-pong"**: Devices don't keep re-migrating each other's data
+
+### Cons
+
+- **Cannot rename fields**: `text` stays `text` forever (or use both names)
+- **Cannot change field types**: Must keep backward-compatible types
+- **Cannot remove fields**: Old fields persist (soft delete only)
+- **More verbose**: Migration specifies patches, not full transforms
+- **Type safety is harder**: Ensuring `addFields` returns exactly the new fields is tricky
+
+### When to Use
+
+- **Collaborative apps**: Multiple peers editing simultaneously
+- **Long-lived data**: Data may exist for years across many app versions
+- **Strict consistency requirements**: Can't afford to lose any edits
+
+---
+
+## Operations Comparison
+
+| Operation              | Approach A                                                | Approach B                                      |
+| ---------------------- | --------------------------------------------------------- | ----------------------------------------------- |
+| Add nullable field     | `(row) => ({ ...row, field: null })`                      | `addFields: () => ({ field: null })`            |
+| Add field with default | `(row) => ({ ...row, field: 'default' })`                 | `addFields: () => ({ field: 'default' })`       |
+| Add computed field     | `(row) => ({ ...row, field: compute(row) })`              | `addFields: (row) => ({ field: compute(row) })` |
+| Rename field           | `(row) => ({ ...row, newName: row.oldName })`             | **Not supported** — use alias or epoch          |
+| Change field type      | `(row) => ({ ...row, field: convert(row.field) })`        | **Not supported** — use epoch                   |
+| Remove field           | `(row) => { const {field, ...rest} = row; return rest; }` | **Not supported** — soft delete only            |
+
+---
+
+## Hybrid Approach: Patch by Default, Epoch for Breaking Changes
+
+### Recommended Strategy
+
+1. **Use Approach B (patch-based)** for additive changes:
+   - Add nullable field
+   - Add field with default
+   - Add computed field
+
+2. **Use epoch bump** for breaking changes:
+   - Rename field
+   - Change field type
+   - Remove field
+   - Restructure data
+
+### Epoch-Based Migration
+
+When you need breaking changes, bump the epoch (create new Y.Doc):
+
+```typescript
+// Migration script (runs once, coordinated)
+async function migrateToEpoch2() {
+	const head = createHeadDoc({ workspaceId });
+	const oldEpoch = head.getEpoch();
+	const newEpoch = oldEpoch + 1;
+
+	const oldClient = await workspace.create({ epoch: oldEpoch });
+	const newClient = await workspaceV2.create({ epoch: newEpoch });
+
+	// Full transform is safe here — new doc, no concurrent edits
+	for (const todo of oldClient.tables.todos.getAll()) {
+		newClient.tables.todos.upsert({
+			...todo,
+			title: todo.text, // rename is safe
+			// text field doesn't exist in new schema
+		});
+	}
+
+	head.bumpEpoch();
+}
+```
+
+---
+
+## Version Field Design
+
+### Should every row store `_v`?
+
+**Yes, recommended.** Explicit version makes detection O(1):
+
+```typescript
+const row = rowMap.toJSON();
+const version = row._v ?? 1; // Default to 1 for legacy data
+```
+
+### Should developers write version numbers explicitly?
+
+**Yes.** Explicit is clearer:
+
+```typescript
+.v(1, TodoV1)
+.v(2, TodoV2, migrate)
+.v(3, TodoV3, migrate)
+```
+
+The builder can validate:
+
+- Versions must be positive integers
+- Versions must be ascending
+- First version has no migration
+- Subsequent versions require migration
+
+### Version field rules
+
+- `_v` is **monotonic**: only ever increases
+- `_v` is **deterministic**: same input always produces same version
+- Old clients should **never downgrade** `_v`
+
+---
+
+## Forward Compatibility
+
+### Scenario: New Client Creates v3 Row, Old Client Edits It
+
+```
+Device A (app v2.0): Creates row with _v: 3, has 'priority' field
+Device B (app v1.0): Syncs row, doesn't understand 'priority'
+Device B: Edits 'title' field
+Sync back to A...
+```
+
+**This works IF** Device B only patches fields it knows about:
+
+```typescript
+// Good: only touch known fields
+rowMap.set('title', newTitle);
+
+// Bad: rewrite entire row as understood schema
+const myRow = { _v: 1, id, title, done }; // loses 'priority'!
+for (const [k, v] of Object.entries(myRow)) {
+	rowMap.set(k, v);
+}
+```
+
+### Rule: Old clients must only patch known fields
+
+This is an application-level concern. The `versionedTable` API can't enforce it, but documentation should emphasize it.
+
+---
+
+## Implementation Sketch
+
+### Approach A: Full Row Transform
+
+```typescript
+export function versionedTable<Name extends string>(name: Name) {
+	const versions: Map<number, { schema: Type<any>; migrate?: Function }> =
+		new Map();
+	let latestVersion = 0;
+
+	const builder = {
+		v<V extends number, T>(
+			version: V,
+			schema: Type<T>,
+			migrate?: (prev: any) => T,
+		) {
+			if (version <= latestVersion) {
+				throw new Error(
+					`Version ${version} must be greater than ${latestVersion}`,
+				);
+			}
+			if (latestVersion > 0 && !migrate) {
+				throw new Error(`Version ${version} requires a migration function`);
+			}
+			versions.set(version, { schema, migrate });
+			latestVersion = version;
+			return builder;
+		},
+
+		build() {
+			return {
+				name,
+				latestVersion,
+				versions: Object.fromEntries(versions),
+
+				upgrade(raw: unknown) {
+					let current = raw as any;
+					let currentVersion = current._v ?? 1;
+
+					// Apply migrations sequentially
+					for (let v = currentVersion + 1; v <= latestVersion; v++) {
+						const { migrate } = versions.get(v)!;
+						if (migrate) {
+							current = migrate(current);
+						}
+					}
+
+					// Validate against latest schema
+					const result = versions.get(latestVersion)!.schema(current);
+					if (result instanceof type.errors) {
+						throw new Error(`Invalid data after migration: ${result.summary}`);
+					}
+
+					return current;
+				},
+			};
+		},
+	};
+
+	return builder;
+}
+```
+
+### Approach B: Patch-Based
+
+```typescript
+export function versionedTable<Name extends string>(name: Name) {
+	const versions: Map<
+		number,
+		{
+			schema: Type<any>;
+			addFields?: (row: any) => Record<string, any>;
+		}
+	> = new Map();
+	let latestVersion = 0;
+
+	const builder = {
+		v<V extends number, T>(
+			version: V,
+			schema: Type<T>,
+			migration?: { addFields: (prev: any) => Record<string, any> },
+		) {
+			versions.set(version, { schema, addFields: migration?.addFields });
+			latestVersion = version;
+			return builder;
+		},
+
+		build() {
+			return {
+				name,
+				latestVersion,
+				versions: Object.fromEntries(versions),
+
+				// In-memory upgrade (for reading)
+				upgrade(raw: unknown) {
+					let current = { ...(raw as any) };
+					let currentVersion = current._v ?? 1;
+
+					for (let v = currentVersion + 1; v <= latestVersion; v++) {
+						const { addFields } = versions.get(v)!;
+						if (addFields) {
+							const newFields = addFields(current);
+							current = { ...current, ...newFields, _v: v };
+						} else {
+							current._v = v;
+						}
+					}
+
+					return current;
+				},
+
+				// YJS-safe patch (for writing)
+				ensureMigrated(rowMap: Y.Map<any>) {
+					const currentVersion = rowMap.get('_v') ?? 1;
+
+					for (let v = currentVersion + 1; v <= latestVersion; v++) {
+						const { addFields } = versions.get(v)!;
+						if (addFields) {
+							const row = rowMap.toJSON();
+							const newFields = addFields(row);
+							for (const [key, value] of Object.entries(newFields)) {
+								if (!rowMap.has(key)) {
+									rowMap.set(key, value);
+								}
+							}
+						}
+						rowMap.set('_v', v);
+					}
+				},
+			};
+		},
+	};
+
+	return builder;
+}
+```
+
+---
+
+## Recommendations
+
+### For Epicenter HQ
+
+1. **Start with Approach B (patch-based)** for the core `versionedTable` API
+2. **Document clearly** that rename/type-change require epoch bumps
+3. **Provide migration helpers** for epoch-based migrations separately
+4. **Consider Approach A as opt-in** for single-user or epoch-migration contexts
+
+### Decision Matrix
+
+| Your Situation              | Recommended Approach      |
+| --------------------------- | ------------------------- |
+| Building collaborative app  | Approach B (patch)        |
+| Building single-user app    | Either works              |
+| Mostly adding fields        | Approach B (patch)        |
+| Need to rename fields often | Approach A + epoch bumps  |
+| Migrating between epochs    | Approach A (safe context) |
+
+---
+
+## Open Questions
+
+1. **Should `upgrade()` write back to YJS?**
+   - Current recommendation: No, keep reads pure. Write-back on user edit only.
+
+2. **How to handle unknown fields from future versions?**
+   - Preserve them. Don't delete fields you don't recognize.
+
+3. **Should defaults be functions or values?**
+   - Functions allow computed defaults: `addFields: (row) => ({ computed: derive(row) })`
+   - Values are simpler: `addFields: { status: 'active' }`
+   - Probably support both.
+
+4. **Cross-table migrations (extract/normalize)?**
+   - Out of scope for `versionedTable`. Handle in epoch migration scripts.
+
+---
+
+## Related Documents
+
+- `specs/20260116T082500-schema-migration-patterns.md` - Broader migration strategy
+- `docs/specs/20250528T000000-transformation-schema-versioning.md` - Whispering's current approach
+- `apps/whispering/src/lib/services/isomorphic/db/models/transformation-steps.ts` - Real implementation
+
+---
+
+## Deep Dive Analysis: Do Local-First Apps Actually Need Per-Row Versioning?
+
+**Date**: 2026-01-24  
+**Status**: Research Complete
+
+### Executive Summary
+
+After extensive analysis consulting multiple perspectives (app developer use cases, YJS CRDT internals, industry practices), the recommendation is:
+
+**Per-row `_v` versioning is OVERKILL for most local-first apps.** The 80/20 solution is:
+
+1. **App-level schema version** (stored once, not per-row)
+2. **Lazy migration on read/write** with Arktype pipes (Whispering's current pattern)
+3. **Additive-only field changes** with deprecation layers
+4. **Epoch bumps** for breaking changes (Epicenter's existing pattern)
+
+### Research Sources
+
+1. **Oracle analysis**: Local-first app versioning use cases across 7 app types
+2. **Oracle analysis**: YJS Y.Map LWW conflict edge cases and mitigation
+3. **YJS Community**: Real developer discussions on migration pain points
+4. **Codebase exploration**: Whispering's existing patterns (Arktype pipes, epoch system)
+
+---
+
+### Analysis by App Type
+
+| App Type                       | Realistic Schema Changes (2-3 years)                   | Per-Row `_v` Needed?                                  |
+| ------------------------------ | ------------------------------------------------------ | ----------------------------------------------------- |
+| **Whispering** (transcription) | Add fields (language, model, timestamps), rare renames | No - lazy migration on open works                     |
+| **Notes app** (Notion-like)    | Add block types, block attributes                      | No - typed blocks + tolerant decoding                 |
+| **Todo app**                   | Add fields (due, tags, priority), recurrence changes   | No - add-only, dual fields for transitions            |
+| **Personal CRM**               | Add social profiles, custom fields                     | No - property bag model handles it                    |
+| **Habit tracker**              | Add metrics, schedule rules                            | No - streaks can be recomputed                        |
+| **Bookmark manager**           | Add tags, metadata, annotations                        | No - optional fields pattern                          |
+| **Calendar**                   | Recurrence rule evolution                              | _Maybe_ - but dual fields + invariant tests preferred |
+
+**Key insight**: ~50% of schema changes are "add field" (safe). The problematic 50% (rename, type change, delete) should use **epoch bumps**, not per-row versioning.
+
+---
+
+### YJS Y.Map LWW: The Core Problem
+
+#### How Y.Map Conflict Resolution Actually Works
+
+1. **"Last" is NOT wall-clock time** — it's deterministic order from Yjs internal operation IDs
+2. **Any `set(key, value)` creates a new operation**, even if value is identical
+3. **Concurrent writes to same key**: higher `clientID` tends to win (deterministic but arbitrary)
+4. **No "read without touching"** — the only way to not write is to not call `set()`
+
+#### The Migration Disaster Scenario
+
+```
+Device A (offline): Reads row v1, migrates to v2, writes ENTIRE row back
+Device B (offline): Edits just the "title" field on v1
+Both sync...
+
+Result: A wrote `title = oldTitle` even though unchanged.
+        B wrote `title = newTitle` (user's actual edit).
+        Higher clientID wins. B's edit MAY BE LOST.
+```
+
+**This is why the "Full Row Transform" approach (Approach A) is DANGEROUS.**
+
+#### Evidence from YJS Community
+
+From [discuss.yjs.dev](https://discuss.yjs.dev/t/what-is-the-correct-way-to-apply-document-migrations/2321):
+
+> "Migrations are a huge pain... pretty much the biggest glaring flaw with Yjs. I've lost many days designing around the migration problem—supporting local-first back compat probably makes dev take 50% longer."
+
+> "A migration can randomly erase data... we wait until server is synced before applying any migration, but then we lose offline-first."
+
+**Kevin Jahns (YJS author) warning on clientID hacks:**
+
+> "THIS CODE IS DISCOURAGED AND WILL LIKELY BREAK YOUR Yjs DOCUMENTS... once a client initializes state slightly differently, you will break all documents."
+
+---
+
+### What Actually Works (Safe Patterns)
+
+#### Pattern 1: Patch-Based Migration (Only Write What Changes)
+
+```typescript
+// SAFE: Only writes NEW fields
+doc.transact(() => {
+	const row = table.get(id) as Y.Map<any>;
+	const v = row.get('_v') ?? 1;
+	if (v >= 2) return;
+
+	// Only add if missing
+	if (!row.has('foo')) row.set('foo', 'default');
+
+	// Only rewrite if value actually differs
+	const curTitle = row.get('title');
+	const nextTitle = transform(curTitle);
+	if (nextTitle !== curTitle) row.set('title', nextTitle);
+
+	row.set('_v', 2);
+});
+```
+
+#### Pattern 2: Lazy Migration on Read (Whispering's Current Approach)
+
+```typescript
+// transformation-steps.ts - ALREADY DOING THIS RIGHT
+export const TransformationStep = TransformationStepV1.or(
+	TransformationStepV2,
+).pipe((step): TransformationStepV2 => {
+	if (step.version === 1) {
+		return { ...step, version: 2 /* add new fields */ };
+	}
+	return step;
+});
+```
+
+This is **in-memory only**. Old data stays in old format until explicitly saved.
+
+#### Pattern 3: Epoch System for Breaking Changes (Epicenter's Approach)
+
+```typescript
+// head-doc.ts - Full transform is SAFE in new Y.Doc
+async function migrateToEpoch2() {
+	const newClient = await workspace.create({ epoch: newEpoch });
+
+	// Safe: new doc, no concurrent edits possible
+	for (const todo of oldClient.tables.todos.getAll()) {
+		newClient.tables.todos.upsert({
+			...todo,
+			title: todo.text, // rename is safe here
+		});
+	}
+
+	head.bumpEpoch();
+}
+```
+
+---
+
+### What Whispering/Epicenter Already Has
+
+| Layer               | Pattern                              | Where                     |
+| ------------------- | ------------------------------------ | ------------------------- |
+| **Record-level**    | Arktype `.pipe()` for lazy migration | `transformation-steps.ts` |
+| **Workspace-level** | Epoch bump system                    | `head-doc.ts`             |
+| **Storage-level**   | Dexie IndexedDB versioning           | `web.ts`, `desktop.ts`    |
+| **Settings**        | Key renaming migration               | `settings.ts`             |
+
+**This is already the right architecture.** Per-row `_v` would add complexity without proportional benefit.
+
+---
+
+### Revised Recommendations
+
+#### For Epicenter Framework
+
+1. **DO NOT mandate per-row `_v`** as a core primitive
+2. **DO provide:**
+   - App-level schema version (root metadata)
+   - Migration pipeline (`migrate(fromVersion, toVersion)`)
+   - Lazy entity migration hooks (Arktype pipes pattern)
+   - Documentation: "add-only, dual-field transitions, tolerant readers"
+3. **Keep epoch system** for breaking changes
+4. **Make per-row `_v` an opt-in advanced pattern** for rare cases
+
+#### When Per-Row Versioning IS Justified
+
+Only if you can say "yes" to MOST of these:
+
+- Shared docs with many concurrent collaborators
+- Long periods where old and new app versions co-edit same data
+- Partial replication (can't migrate everything deterministically)
+- Very large datasets where full migration is expensive
+- Frequent deep restructures of same entity types
+
+For Whispering (mostly single-user, recordings are immutable-ish), **none of these apply**.
+
+---
+
+### Danger Patterns to Avoid
+
+| Pattern                               | Why It's Dangerous                                       |
+| ------------------------------------- | -------------------------------------------------------- |
+| Full-row rewrites during migration    | Creates conflicts on EVERY field                         |
+| Setting defaults blindly (`foo = ""`) | Can erase real data from concurrent peers                |
+| Rename/delete migrations              | Concurrent edits can resurrect deleted keys              |
+| `clientID = 0` hacks                  | Can corrupt documents if any divergence                  |
+| Bumping `_v` early                    | Advertises completion even if some fields lost conflicts |
+
+---
+
+### Final Verdict
+
+**The `versionedTable` API as designed (Approach A) should NOT be the default.**
+
+The spec's own Approach B (patch-based) combined with Epicenter's existing epoch system is the correct architecture. The framework should:
+
+1. Embrace the patterns Whispering already uses (Arktype pipes for lazy migration)
+2. Keep epoch bumps for breaking changes (already implemented)
+3. NOT add per-row `_v` complexity to every table
+4. Document the "add-only + deprecation layer" pattern as the recommended approach
+
+**Effort to implement "right" approach: Already done.** Whispering and Epicenter have the correct architecture. This spec should be updated to recommend _against_ per-row versioning as a default and instead document the existing patterns as best practices.
+
+---
+
+## Changelog
+
+- 2026-01-24: Initial draft with both approaches documented
+- 2026-01-24: Added deep dive analysis with Oracle research, YJS community evidence, and revised recommendations

--- a/specs/20260124T125300-workspace-schema-versioning.md
+++ b/specs/20260124T125300-workspace-schema-versioning.md
@@ -1,0 +1,759 @@
+# Workspace-Level Schema Versioning for YJS Local-First Apps
+
+> **⚠️ PARTIALLY SUPERSEDED**
+>
+> This spec has been partially superseded by [`specs/20260124T162638-stable-id-schema-pattern.md`](./20260124T162638-stable-id-schema-pattern.md).
+>
+> **What changed**: The Stable ID pattern eliminates the need for per-row `_v` versioning entirely. Instead of tracking versions and running migrations, each field has a stable internal ID that never changes. Renaming is free (just change the schema key), and invalid/missing data simply returns the default value.
+>
+> **What's still valuable here**: The analysis of the problem space (why CRDT migrations are hard, the epoch system for breaking changes, the YJS conflict problem) remains accurate. The two-tier model (epochs for breaking changes, additive changes within epochs) is still correct—but "additive changes" no longer need version tracking.
+>
+> **Read this spec for**: Understanding the problem. **Read the Stable ID spec for**: The solution.
+
+---
+
+**Status**: Design Proposal (Partially Superseded)
+**Date**: 2026-01-24
+**Builds On**: `specs/20260124T004528-versioned-table-api-design.md` (table-level research)
+**Context**: Designing a unified schema versioning system at the workspace level
+
+---
+
+## Executive Summary
+
+This spec proposes **workspace-level schema versioning** as an alternative to per-table or per-row versioning. The key insight is that schema changes often affect multiple tables simultaneously, and versioning at the workspace level provides:
+
+1. **Atomic schema changes** — Add fields to multiple tables in one version bump
+2. **Simpler mental model** — "The workspace is at version 3" vs "Table A is v2, Table B is v4"
+3. **Better type safety** — One version number → one complete TypeScript type
+4. **Natural callback API** — Previous schema flows into next, enabling spreads and transforms
+
+---
+
+## Problem Recap
+
+Local-first apps using YJS need to evolve schemas over time. The challenges:
+
+| Challenge               | Description                                         |
+| ----------------------- | --------------------------------------------------- |
+| **Multi-peer sync**     | Data can arrive from any peer at any schema version |
+| **Field-level LWW**     | YJS uses last-write-wins per field, not per row     |
+| **No migration window** | Old and new clients may sync indefinitely           |
+| **Coordinated changes** | Features often touch multiple tables at once        |
+
+The previous spec explored **table-level versioning** (`versionedTable`), but this creates complexity when tables need coordinated changes.
+
+---
+
+## Proposed Solution: Workspace-Level Schema Versioning
+
+### Core API
+
+```typescript
+import {
+	workspace,
+	id,
+	text,
+	select,
+	integer,
+	boolean,
+	setting,
+} from '@epicenter/hq';
+
+const whispering = workspace('epicenter.whispering')
+	// Version 1: Initial schema (no callback - this IS the base)
+	.v(1, {
+		tables: {
+			recordings: {
+				id: id(),
+				title: text(),
+				transcript: text({ nullable: true }),
+			},
+			transformations: {
+				id: id(),
+				name: text(),
+				prompt: text(),
+			},
+		},
+		kv: {
+			theme: setting(select(['light', 'dark']), { default: 'light' }),
+		},
+	})
+
+	// Version 2: Add status to recordings, add language to KV
+	.v(2, (prev) => ({
+		tables: {
+			recordings: {
+				...prev.tables.recordings,
+				status: select(['pending', 'completed'], { default: 'completed' }),
+			},
+			transformations: prev.tables.transformations,
+		},
+		kv: {
+			...prev.kv,
+			language: setting(select(['en', 'es', 'fr']), { default: 'en' }),
+		},
+	}))
+
+	// Version 3: Add priority with computed default, add enabled to transformations
+	.v(3, (prev) => ({
+		tables: {
+			recordings: {
+				...prev.tables.recordings,
+				priority: integer({
+					default: 0,
+					migrateFrom: (row) => (row.transcript ? 1 : 0),
+				}),
+			},
+			transformations: {
+				...prev.tables.transformations,
+				enabled: boolean({ default: true }),
+			},
+		},
+		kv: prev.kv,
+	}))
+
+	.build();
+```
+
+### Key Design Decisions
+
+#### 1. Callback Receives Previous Schema, Returns New Schema
+
+The migration callback receives the **fully typed previous schema** and must return the **next schema**:
+
+```typescript
+.v(2, (prev) => {
+  // prev is typed as Schema_V1
+  // return type must be Schema_V2
+  return {
+    tables: {
+      recordings: {
+        ...prev.tables.recordings,  // Spread existing fields
+        newField: text(),            // Add new field
+      },
+    },
+    kv: prev.kv,
+  };
+})
+```
+
+**Why this is better than `addFields`**:
+
+- Full type safety end-to-end
+- Explicit about what changed
+- Flexible — spread, modify, restructure as needed
+- No magic APIs to learn
+
+#### 2. Defaults Drive Data Migration
+
+New fields **must have a `default`**. This default is used when reading rows at older versions:
+
+```typescript
+status: select(['pending', 'completed'], { default: 'completed' });
+```
+
+For computed defaults based on existing row data, use `migrateFrom`:
+
+```typescript
+priority: integer({
+	default: 0, // Fallback default
+	migrateFrom: (row) => (row.transcript ? 1 : 0), // Computed from row
+});
+```
+
+**Migration execution**:
+
+- `migrateFrom` is called lazily when reading old rows
+- If `migrateFrom` is not provided, `default` is used
+- This keeps reads pure (no YJS writes during read)
+
+#### 3. Version Stored Per-Row as `_v`
+
+Each row stores its schema version:
+
+```typescript
+{ id: 'abc', title: 'Hello', transcript: '...', _v: 2 }
+```
+
+**Why per-row instead of per-workspace**:
+
+- Allows gradual migration (rows upgrade when touched)
+- Handles offline scenarios (device A at v2, device B at v3)
+- Simpler than coordinating workspace-wide migration
+
+**Version field rules**:
+
+- `_v` is monotonic (only increases)
+- `_v` defaults to `1` for rows without it (legacy data)
+- Old clients should never downgrade `_v`
+
+#### 4. Breaking Changes Require Epoch Bumps
+
+This system handles **additive changes** (the common 50%):
+
+- Add nullable field ✓
+- Add field with default ✓
+- Add computed field ✓
+- Add new table ✓
+- Add new KV setting ✓
+
+**Breaking changes** still require epoch bumps (new Y.Doc):
+
+- Rename field → Epoch bump
+- Change field type → Epoch bump
+- Remove field → Epoch bump (or soft-delete)
+- Restructure data → Epoch bump
+
+---
+
+## Type System Design
+
+### Builder Type Flow
+
+```typescript
+type WorkspaceBuilder<TLatest extends WorkspaceSchema> = {
+	v<TNext extends WorkspaceSchema>(
+		version: number,
+		schema: TNext | ((prev: TLatest) => TNext),
+	): WorkspaceBuilder<TNext>;
+
+	build(): VersionedWorkspace<TLatest>;
+};
+```
+
+The builder accumulates types through the chain:
+
+```
+workspace('id')           // WorkspaceBuilder<{}>
+  .v(1, schema1)          // WorkspaceBuilder<Schema1>
+  .v(2, prev => schema2)  // WorkspaceBuilder<Schema2>  (prev: Schema1)
+  .v(3, prev => schema3)  // WorkspaceBuilder<Schema3>  (prev: Schema2)
+  .build()                // VersionedWorkspace<Schema3>
+```
+
+### Schema Types
+
+```typescript
+type WorkspaceSchema = {
+	tables: TableDefinitionMap;
+	kv: KvDefinitionMap;
+};
+
+type TableDefinitionMap = Record<string, FieldMap>;
+type FieldMap = Record<string, FieldSchema>;
+
+type KvDefinitionMap = Record<string, KvDefinition>;
+type KvDefinition = { field: FieldSchema; default?: unknown };
+```
+
+### Field Schema with Migration
+
+```typescript
+type FieldSchema = {
+  type: 'text' | 'integer' | 'boolean' | 'select' | /* ... */;
+  nullable?: boolean;
+  default?: unknown;
+  migrateFrom?: (row: Record<string, unknown>) => unknown;
+};
+```
+
+### Inferred Row Types
+
+The final `build()` returns a workspace where tables are typed to the **latest schema**:
+
+```typescript
+const ws = workspace('id').v(1, s1).v(2, s2).v(3, s3).build();
+
+// ws.tables.recordings returns rows typed as:
+type Recording = {
+	id: string;
+	title: string;
+	transcript: string | null;
+	status: 'pending' | 'completed';
+	priority: number;
+	_v: number;
+};
+```
+
+---
+
+## Runtime Behavior
+
+### Reading Rows (Lazy Migration)
+
+When reading a row, the system:
+
+1. Reads raw data from Y.Map
+2. Checks `_v` field (defaults to 1)
+3. If `_v < latestVersion`, applies migrations **in memory**
+4. Returns the upgraded row (does NOT write back to YJS)
+
+```typescript
+function getRow(id: string): Recording {
+	const raw = rowMap.get(id)?.toJSON();
+	const version = raw._v ?? 1;
+
+	if (version < 3) {
+		// Apply migrations in memory
+		return workspace.upgrade(raw);
+	}
+
+	return raw as Recording;
+}
+```
+
+### Writing Rows (YJS-Safe Patching)
+
+When writing a row, the system:
+
+1. Checks if row exists and its current `_v`
+2. If upgrading, **only writes new fields** (patch-based)
+3. Updates `_v` to latest version
+4. Writes user's actual changes
+
+```typescript
+function upsertRow(row: Recording): void {
+	ydoc.transact(() => {
+		const existing = rowsMap.get(row.id);
+
+		if (existing) {
+			const currentV = existing.get('_v') ?? 1;
+
+			// Patch new fields from migrations (YJS-safe)
+			if (currentV < 2) {
+				if (!existing.has('status')) {
+					existing.set('status', row.status ?? 'completed');
+				}
+			}
+			if (currentV < 3) {
+				if (!existing.has('priority')) {
+					existing.set('priority', row.priority ?? 0);
+				}
+			}
+
+			// Update version
+			existing.set('_v', 3);
+
+			// Apply user's changes
+			for (const [key, value] of Object.entries(row)) {
+				if (key !== '_v') {
+					existing.set(key, value);
+				}
+			}
+		} else {
+			// New row - write all fields at latest version
+			const newRow = new Y.Map();
+			for (const [key, value] of Object.entries(row)) {
+				newRow.set(key, value);
+			}
+			newRow.set('_v', 3);
+			rowsMap.set(row.id, newRow);
+		}
+	});
+}
+```
+
+### Batch Migration (Optional)
+
+For eager migration of all rows:
+
+```typescript
+async function migrateAllRows(tableName: string): Promise<void> {
+	const table = workspace.tables[tableName];
+
+	ydoc.transact(() => {
+		for (const [id, rowMap] of tableMap.entries()) {
+			table.ensureMigrated(rowMap);
+		}
+	});
+}
+```
+
+---
+
+## Integration with Existing Architecture
+
+### Relationship to Epochs
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  EPOCH LEVEL (Breaking Changes)                                  │
+│  ───────────────────────────────                                 │
+│                                                                  │
+│  Epoch 0 ─────────────────────────────> Epoch 1                  │
+│  (Y.Doc "abc-0")                        (Y.Doc "abc-1")          │
+│                                                                  │
+│  • Field renames                                                 │
+│  • Type changes                                                  │
+│  • Field deletions                                               │
+│  • Data restructuring                                            │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              │ Within each epoch...
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  SCHEMA VERSION LEVEL (Additive Changes)                         │
+│  ───────────────────────────────────────                         │
+│                                                                  │
+│  v1 ──────> v2 ──────> v3 ──────> v4                             │
+│  (same Y.Doc, per-row _v field)                                  │
+│                                                                  │
+│  • Add nullable field                                            │
+│  • Add field with default                                        │
+│  • Add computed field                                            │
+│  • Add new table                                                 │
+│  • Add new KV setting                                            │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Relationship to Head Doc
+
+The Head Doc continues to manage epochs. Schema versions are orthogonal:
+
+```typescript
+// Head Doc: manages epoch (which Y.Doc to use)
+const head = createHeadDoc({ workspaceId: 'abc' });
+const epoch = head.getEpoch(); // 0
+
+// Workspace: manages schema versions (within that Y.Doc)
+const ws = workspace('abc').v(1, s1).v(2, s2).v(3, s3).build();
+const schemaVersion = ws.latestVersion; // 3
+
+// Client: combines both
+const client = createClient(head)
+	.withDefinition(ws)
+	.withExtensions({ persistence, sqlite });
+```
+
+### Relationship to createClient Builder
+
+The existing builder pattern is preserved:
+
+```typescript
+// Before (current API)
+const definition = defineWorkspace({
+	id: 'abc',
+	tables: { posts: { id: id(), title: text() } },
+	kv: {},
+});
+
+const client = createClient(head)
+	.withDefinition(definition)
+	.withExtensions({ persistence });
+
+// After (versioned API)
+const definition = workspace('abc')
+	.v(1, { tables: { posts: { id: id(), title: text() } }, kv: {} })
+	.v(2, (prev) => ({ ...prev /* changes */ }))
+	.build();
+
+const client = createClient(head)
+	.withDefinition(definition) // Same API!
+	.withExtensions({ persistence });
+```
+
+---
+
+## KV Store Versioning
+
+KV settings are singletons, but they also evolve:
+
+```typescript
+.v(1, {
+  tables: { /* ... */ },
+  kv: {
+    theme: setting(select(['light', 'dark']), { default: 'light' }),
+  },
+})
+.v(2, (prev) => ({
+  tables: { /* ... */ },
+  kv: {
+    ...prev.kv,
+    language: setting(select(['en', 'es', 'fr']), { default: 'en' }),
+  },
+}))
+```
+
+### KV Migration Behavior
+
+- New KV keys return their default until explicitly set
+- No `_v` field needed for KV (presence/absence is sufficient)
+- KV changes don't conflict with row migrations
+
+---
+
+## Forward Compatibility
+
+### Scenario: New Client (v3) Creates Row, Old Client (v1) Edits It
+
+```
+Device A (v3): Creates row with status, priority fields
+Device B (v1): Syncs row, doesn't understand status/priority
+Device B: Edits title field
+Sync back to A...
+```
+
+**This works IF** Device B only patches fields it knows:
+
+```typescript
+// Good: only touch known fields
+rowMap.set('title', newTitle);
+
+// Bad: rewrite entire row
+const myRow = { id, title, transcript }; // Missing status, priority!
+for (const [k, v] of Object.entries(myRow)) {
+	rowMap.set(k, v);
+}
+```
+
+**Rule**: Old clients must use patch-based updates, not full row rewrites.
+
+### Unknown Field Preservation
+
+When reading, preserve fields you don't recognize:
+
+```typescript
+function upgradeRow(raw: any): Recording {
+	// Apply known migrations
+	const upgraded = { ...raw };
+
+	// Don't strip unknown fields
+	// Future versions may have added fields we don't know about
+
+	return upgraded;
+}
+```
+
+---
+
+## Implementation Sketch
+
+### workspace() Builder
+
+```typescript
+type VersionEntry<T> = {
+	version: number;
+	schema: T;
+	migrations: Map<string, FieldMigration>; // tableName.fieldName -> migrator
+};
+
+export function workspace<Id extends string>(id: Id) {
+	const versions: VersionEntry<any>[] = [];
+
+	const builder = {
+		v<TSchema extends WorkspaceSchema>(
+			version: number,
+			schemaOrCallback: TSchema | ((prev: any) => TSchema),
+		) {
+			const prevSchema =
+				versions.length > 0 ? versions[versions.length - 1].schema : {};
+
+			const schema =
+				typeof schemaOrCallback === 'function'
+					? schemaOrCallback(prevSchema)
+					: schemaOrCallback;
+
+			// Extract migrations from fields with migrateFrom
+			const migrations = extractMigrations(prevSchema, schema);
+
+			versions.push({ version, schema, migrations });
+
+			return builder as WorkspaceBuilder<TSchema>;
+		},
+
+		build(): VersionedWorkspace<TLatest> {
+			const latest = versions[versions.length - 1];
+
+			return {
+				id,
+				latestVersion: latest.version,
+				schema: latest.schema,
+				versions,
+
+				upgrade(tableName: string, raw: unknown) {
+					let current = { ...(raw as any) };
+					let currentVersion = current._v ?? 1;
+
+					for (const entry of versions) {
+						if (entry.version <= currentVersion) continue;
+
+						// Apply field migrations for this table
+						const tableKey = tableName;
+						for (const [fieldPath, migrator] of entry.migrations) {
+							if (fieldPath.startsWith(tableKey + '.')) {
+								const fieldName = fieldPath.split('.')[1];
+								if (!(fieldName in current)) {
+									current[fieldName] = migrator(current);
+								}
+							}
+						}
+
+						current._v = entry.version;
+					}
+
+					return current;
+				},
+
+				ensureMigrated(tableName: string, rowMap: Y.Map<any>) {
+					const currentVersion = rowMap.get('_v') ?? 1;
+
+					for (const entry of versions) {
+						if (entry.version <= currentVersion) continue;
+
+						const tableKey = tableName;
+						for (const [fieldPath, migrator] of entry.migrations) {
+							if (fieldPath.startsWith(tableKey + '.')) {
+								const fieldName = fieldPath.split('.')[1];
+								if (!rowMap.has(fieldName)) {
+									const value = migrator(rowMap.toJSON());
+									rowMap.set(fieldName, value);
+								}
+							}
+						}
+
+						rowMap.set('_v', entry.version);
+					}
+				},
+			};
+		},
+	};
+
+	return builder;
+}
+
+function extractMigrations(prev: any, next: any): Map<string, FieldMigration> {
+	const migrations = new Map();
+
+	// Compare tables
+	for (const [tableName, tableSchema] of Object.entries(next.tables ?? {})) {
+		const prevTable = prev.tables?.[tableName] ?? {};
+
+		for (const [fieldName, fieldSchema] of Object.entries(tableSchema as any)) {
+			if (!(fieldName in prevTable)) {
+				// New field - extract migrator
+				const schema = fieldSchema as FieldSchema;
+				const migrator = schema.migrateFrom ?? (() => schema.default);
+				migrations.set(`${tableName}.${fieldName}`, migrator);
+			}
+		}
+	}
+
+	return migrations;
+}
+```
+
+---
+
+## Comparison with Previous Approaches
+
+| Aspect                  | Per-Row \_v (Table-Level)          | Workspace-Level                     |
+| ----------------------- | ---------------------------------- | ----------------------------------- |
+| **Granularity**         | Each table versioned independently | All tables share version chain      |
+| **Coordinated changes** | Must manually sync versions        | Atomic across tables                |
+| **Type safety**         | Per-table, harder to compose       | Full workspace type at each version |
+| **Mental model**        | "Table A is v2, Table B is v4"     | "Workspace is v3"                   |
+| **API complexity**      | Multiple `versionedTable()` calls  | Single `workspace()` chain          |
+| **Migration callback**  | `addFields` or per-table transform | Full schema callback                |
+
+---
+
+## The YJS Conflict Problem (Reference)
+
+### Why Full Row Transforms Are Dangerous
+
+```
+Device A (offline): Reads row v1, migrates to v2, writes entire row back
+Device B (offline): Edits just the "title" field on v1
+Both sync...
+```
+
+**Result**: If A's migration wrote the `title` field (even with its old value), A and B both wrote to the same key. YJS picks one — B's edit may be lost.
+
+### Why Patch-Based Is Safe
+
+This design only writes **new fields** during migration:
+
+```typescript
+// Safe: only add fields that don't exist
+if (!rowMap.has('status')) {
+	rowMap.set('status', 'completed');
+}
+rowMap.set('_v', 2);
+```
+
+Existing fields are never touched during migration, so concurrent edits to those fields are preserved.
+
+---
+
+## Open Questions
+
+1. **Should v(1) accept a callback?**
+   - Current proposal: No, v(1) is the base schema (no "previous")
+   - Alternative: Allow callback that receives `{}` for consistency
+
+2. **How to handle table additions?**
+   - New tables added in v2+ start empty
+   - Should there be a way to "seed" initial data for new tables?
+
+3. **Validation of version chain?**
+   - Should the builder validate that versions are sequential?
+   - Should it validate that new fields have defaults?
+
+4. **Runtime version storage location?**
+   - Per-row `_v` field (current proposal)
+   - Alternative: Single version in workspace metadata (all-or-nothing)
+
+5. **Extension integration?**
+   - How do SQLite/markdown extensions handle schema versions?
+   - Should they auto-migrate their schemas too?
+
+---
+
+## Migration Path from Current API
+
+For existing apps using `defineWorkspace`:
+
+```typescript
+// Before
+const definition = defineWorkspace({
+	id: 'blog',
+	tables: { posts: { id: id(), title: text() } },
+	kv: {},
+});
+
+// After (minimal change)
+const definition = workspace('blog')
+	.v(1, {
+		tables: { posts: { id: id(), title: text() } },
+		kv: {},
+	})
+	.build();
+
+// The build() result is compatible with createClient().withDefinition()
+```
+
+---
+
+## Recommendations
+
+1. **Implement workspace-level versioning** as the primary API
+2. **Keep `defineWorkspace` as sugar** for v1-only definitions
+3. **Require defaults for new fields** (enforced by types)
+4. **Use per-row `_v`** for gradual migration support
+5. **Keep epoch bumps** for breaking changes
+6. **Document the "additive only within epoch" rule** clearly
+
+---
+
+## Related Documents
+
+- `specs/20260124T004528-versioned-table-api-design.md` — Previous table-level research and YJS conflict analysis
+- `packages/epicenter/src/core/docs/README.md` — Three-document architecture (Registry, Head, Workspace)
+- `packages/epicenter/src/core/workspace/README.md` — Current workspace API and epoch system
+
+---
+
+## Changelog
+
+- 2026-01-24: Initial proposal for workspace-level schema versioning

--- a/specs/20260124T160000-developer-experience-schema-api.md
+++ b/specs/20260124T160000-developer-experience-schema-api.md
@@ -1,0 +1,829 @@
+# Developer Experience for YJS-Backed Tables and KV
+
+> **⚠️ PARTIALLY SUPERSEDED**
+>
+> The migration strategy in this spec has been superseded by [`specs/20260124T162638-stable-id-schema-pattern.md`](./20260124T162638-stable-id-schema-pattern.md).
+>
+> **What's still valuable here**:
+> - Part 1: Schema Definition DX (field factories like `text()`, `select()`)
+> - Part 2: Cell-Level vs Row-Level LWW analysis
+> - The patch-based update pattern
+>
+> **What's obsolete**:
+> - Part 3-4: The `_v` versioning and migration strategy
+> - The `since` and `migrateFrom` field options
+> - Lazy migration on read/write
+>
+> **The new approach**: Each field has a stable `id` that never changes. Renaming is free. Invalid data returns the default. No migrations needed.
+
+---
+
+**Status**: Draft (Partially Superseded)
+**Date**: 2026-01-24
+**Context**: Designing the ideal developer experience for defining schemas, tables, and KV stores with YJS, focusing on migrations and conflict handling
+**Builds on**: `specs/20260124T004528-versioned-table-api-design.md`, `specs/20260124T125300-workspace-schema-versioning.md`, `specs/20260116T082500-schema-migration-patterns.md`
+
+---
+
+## Executive Summary
+
+This spec focuses on **developer experience** (DX): What do developers actually type? How do they define schemas, handle migrations, and avoid data loss from concurrent edits?
+
+**Key decisions proposed**:
+
+1. **Standard Schema for field definitions** (not proprietary syntax)
+2. **Cell-level LWW** as the default (not row-level)
+3. **Additive-only migrations** within epochs (breaking changes = epoch bump)
+4. **Lazy migration on read**, explicit migration on write
+5. **Simple versioned workspace API** with callback-based schema evolution
+
+---
+
+## Part 1: Schema Definition DX
+
+### The Question
+
+Should we use proprietary field syntax (`text()`, `select()`) or standard schemas (ArkType, Standard Schema, TypeBox)?
+
+### Analysis: Proprietary vs Standard
+
+| Aspect | Proprietary (`text()`, `select()`) | Standard Schema (ArkType, TypeBox) |
+|--------|-------------------------------------|-------------------------------------|
+| **Learning curve** | New API to learn | Use existing knowledge |
+| **Type inference** | Custom inference | Built-in inference |
+| **Validation** | Custom validators | Well-tested validators |
+| **Ecosystem** | Isolated | Integrates with tRPC, Hono, etc. |
+| **Flexibility** | Limited to our types | Full schema power |
+| **UI metadata** | Native (`name`, `icon`) | Needs extension |
+
+### Recommendation: Hybrid Approach
+
+Use **Standard Schema-compatible types** with **metadata extensions** for UI:
+
+```typescript
+import { type } from 'arktype';
+
+// Option A: ArkType with metadata decorators (proposed)
+const Recording = type({
+  id: 'string',
+  title: 'string',
+  transcript: 'string | null',
+  status: "'pending' | 'transcribing' | 'completed'",
+  duration: 'number',
+  createdAt: 'string', // ISO timestamp
+});
+
+// Metadata separate (keeps schema portable)
+const recordingsTable = defineTable({
+  name: 'Recordings',
+  icon: 'emoji:🎙️',
+  schema: Recording,
+  primaryKey: 'id',
+});
+```
+
+```typescript
+// Option B: Keep current factory syntax (familiar, metadata inline)
+import { table, id, text, select, integer } from '@epicenter/hq';
+
+const recordingsTable = table({
+  name: 'Recordings',
+  icon: '🎙️',
+  fields: {
+    id: id(),
+    title: text(),
+    transcript: text({ nullable: true }),
+    status: select({ options: ['pending', 'transcribing', 'completed'] }),
+    duration: integer(),
+    createdAt: text(),
+  },
+});
+```
+
+**Verdict**: Keep **Option B (current syntax)** for several reasons:
+
+1. **Metadata co-location**: Name, icon, description live with the field
+2. **Type inference**: Factory functions provide excellent inference
+3. **Simplicity**: No need to learn ArkType syntax
+4. **YJS-aware**: Fields know their CRDT implications (e.g., `richtext` creates separate Y.Doc)
+5. **Conversion available**: Can still export to ArkType/TypeBox/JSON Schema via converters
+
+The current `text()`, `select()`, `integer()` factories are good DX. The spec should focus on **versioning** and **migrations**, not replacing the field system.
+
+---
+
+## Part 2: Cell-Level vs Row-Level LWW
+
+### The Core Problem
+
+YJS Y.Map uses **last-write-wins per key (cell)**. This creates problems:
+
+```
+Device A: Sets row { id: '1', title: 'Hello', status: 'draft' }
+Device B: Sets row { id: '1', title: 'World', status: 'draft' }
+Sync...
+
+Result: { id: '1', title: ??? (one wins), status: 'draft' }
+```
+
+If both devices set the entire row, they compete on EVERY field. YJS picks one writer per field based on client ID ordering.
+
+### Two Approaches
+
+#### Row-Level: Full Row Operations
+
+```typescript
+// Every write sets all fields
+table.upsert({ id: '1', title: 'Hello', status: 'draft' });
+
+// Internally:
+ymap.set('1/id', '1');
+ymap.set('1/title', 'Hello');
+ymap.set('1/status', 'draft');
+```
+
+**Problem**: Writing `title` also writes `status`. If another device changed `status`, your write to `title` clobbers it.
+
+#### Cell-Level: Patch Operations
+
+```typescript
+// Only write fields that changed
+table.update({ id: '1', title: 'Hello' }); // Only touches 'title'
+
+// Internally:
+ymap.set('1/title', 'Hello'); // Only this field
+```
+
+**Benefit**: Concurrent edits to different fields merge correctly.
+
+### Recommendation: Cell-Level by Default
+
+For most apps (like Whispering), **cell-level editing** is correct:
+
+1. **Concurrent safety**: Two devices editing different fields don't conflict
+2. **Minimal writes**: Only changed data hits the network
+3. **Natural model**: Matches how users think about edits
+
+**API implication**: The `update()` method should be patch-based, not full-row:
+
+```typescript
+// GOOD: Only writes 'title'
+table.update({ id: '1', title: 'New Title' });
+
+// BAD: Writes ALL fields, clobbering concurrent edits to other fields
+table.upsert(table.get('1').merge({ title: 'New Title' }));
+```
+
+### When Row-Level Makes Sense
+
+Row-level is appropriate for:
+
+1. **Immutable records**: Append-only data (logs, events)
+2. **User-initiated saves**: Explicit "save" button, no concurrent editing
+3. **Transactional integrity**: All fields must be consistent (financial records)
+
+For Whispering's recordings table: **cell-level** is correct. Recordings are mostly immutable after creation, but metadata (title, tags) can be edited independently.
+
+---
+
+## Part 3: Migration Strategy
+
+### The Migration Problem
+
+Local-first apps face unique migration challenges:
+
+1. **No migration window**: Old and new app versions coexist indefinitely
+2. **Offline devices**: Devices may sync months later
+3. **No central coordinator**: Can't run migrations "at deploy time"
+4. **Data arrives from anywhere**: Any peer can send any version
+
+### The Two-Tier Strategy (Already Established)
+
+Your existing specs establish the right pattern:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  EPOCH (Breaking Changes)                                        │
+│  ─────────────────────────                                       │
+│  • Field renames: text → title                                  │
+│  • Type changes: string → number                                │
+│  • Field deletions                                              │
+│  • Major restructuring                                          │
+│                                                                  │
+│  Action: Bump epoch, migrate to new Y.Doc                       │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              │ Within each epoch...
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  SCHEMA VERSION (Additive Changes)                               │
+│  ─────────────────────────────────                               │
+│  • Add nullable field                                           │
+│  • Add field with default                                       │
+│  • Add computed field                                           │
+│  • Add new table                                                │
+│                                                                  │
+│  Action: Lazy migrate on read, explicit migrate on write        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### What Developers Actually Type
+
+#### Defining a Versioned Workspace
+
+```typescript
+import { defineWorkspace, table, id, text, select, integer, setting } from '@epicenter/hq';
+
+// Version 1: Initial schema
+const whisperingV1 = {
+  tables: {
+    recordings: table({
+      name: 'Recordings',
+      icon: '🎙️',
+      fields: {
+        id: id(),
+        title: text(),
+        transcript: text({ nullable: true }),
+      },
+    }),
+    transformations: table({
+      name: 'Transformations',
+      icon: '✨',
+      fields: {
+        id: id(),
+        name: text(),
+        prompt: text(),
+      },
+    }),
+  },
+  kv: {
+    theme: setting({ name: 'Theme', field: select({ options: ['light', 'dark'], default: 'light' }) }),
+  },
+};
+
+// Version 2: Add status to recordings, add language setting
+const whisperingV2 = {
+  tables: {
+    recordings: table({
+      name: 'Recordings',
+      icon: '🎙️',
+      fields: {
+        id: id(),
+        title: text(),
+        transcript: text({ nullable: true }),
+        // NEW: status field with default
+        status: select({ options: ['pending', 'completed'], default: 'completed' }),
+      },
+    }),
+    transformations: table({
+      name: 'Transformations',
+      icon: '✨',
+      fields: {
+        id: id(),
+        name: text(),
+        prompt: text(),
+        // NEW: enabled toggle
+        enabled: boolean({ default: true }),
+      },
+    }),
+  },
+  kv: {
+    theme: setting({ name: 'Theme', field: select({ options: ['light', 'dark'], default: 'light' }) }),
+    // NEW: language setting
+    language: setting({ name: 'Language', field: select({ options: ['en', 'es', 'fr'], default: 'en' }) }),
+  },
+};
+
+export const whisperingWorkspace = defineWorkspace({
+  id: 'epicenter.whispering',
+  versions: [
+    { version: 1, schema: whisperingV1 },
+    { version: 2, schema: whisperingV2 },
+  ],
+});
+```
+
+**Key points**:
+- Each version is a complete schema snapshot
+- New fields MUST have defaults (for migration)
+- No explicit migration functions for additive changes—defaults are sufficient
+
+#### Alternative: Callback-Based Evolution (More Explicit)
+
+```typescript
+export const whisperingWorkspace = workspace('epicenter.whispering')
+  .v(1, whisperingV1)
+  .v(2, (prev) => ({
+    tables: {
+      recordings: table({
+        ...prev.tables.recordings,
+        fields: {
+          ...prev.tables.recordings.fields,
+          status: select({
+            options: ['pending', 'completed'],
+            default: 'completed',
+            // Optional: compute from existing data
+            migrateFrom: (row) => row.transcript ? 'completed' : 'pending',
+          }),
+        },
+      }),
+      transformations: table({
+        ...prev.tables.transformations,
+        fields: {
+          ...prev.tables.transformations.fields,
+          enabled: boolean({ default: true }),
+        },
+      }),
+    },
+    kv: {
+      ...prev.kv,
+      language: setting({
+        name: 'Language',
+        field: select({ options: ['en', 'es', 'fr'], default: 'en' })
+      }),
+    },
+  }))
+  .build();
+```
+
+**This approach** (from your `20260124T125300` spec) is powerful but verbose.
+
+### Recommended API: Declarative with Computed Defaults
+
+```typescript
+export const whisperingWorkspace = defineWorkspace({
+  id: 'epicenter.whispering',
+  currentVersion: 2,
+
+  tables: {
+    recordings: table({
+      name: 'Recordings',
+      icon: '🎙️',
+      fields: {
+        id: id(),
+        title: text(),
+        transcript: text({ nullable: true }),
+        // Added in v2
+        status: select({
+          options: ['pending', 'completed'],
+          // Simple default
+          default: 'completed',
+          // OR: Computed migration (optional)
+          migrateFrom: (row) => row.transcript ? 'completed' : 'pending',
+          // When was this field added?
+          since: 2,
+        }),
+      },
+    }),
+    transformations: table({
+      name: 'Transformations',
+      icon: '✨',
+      fields: {
+        id: id(),
+        name: text(),
+        prompt: text(),
+        enabled: boolean({ default: true, since: 2 }),
+      },
+    }),
+  },
+
+  kv: {
+    theme: setting({
+      name: 'Theme',
+      field: select({ options: ['light', 'dark'], default: 'light' })
+    }),
+    language: setting({
+      name: 'Language',
+      field: select({ options: ['en', 'es', 'fr'], default: 'en' }),
+      since: 2,
+    }),
+  },
+});
+```
+
+**This API**:
+1. Keeps the schema in one place (not scattered across version callbacks)
+2. Uses `since` to track when fields were added
+3. Uses `default` for simple migrations, `migrateFrom` for computed
+4. Is closer to how developers think: "what's the current schema?"
+
+---
+
+## Part 4: Runtime Behavior
+
+### Reading Rows (Lazy Migration)
+
+```typescript
+function get(id: string): Recording | null {
+  const raw = ymap.get(id)?.toJSON();
+  if (!raw) return null;
+
+  // Apply in-memory migration (does NOT write back)
+  const version = raw._v ?? 1;
+  if (version < currentVersion) {
+    return migrate(raw, version, currentVersion);
+  }
+
+  return raw as Recording;
+}
+
+function migrate(row: any, fromVersion: number, toVersion: number): Recording {
+  let current = { ...row };
+
+  for (const [fieldName, fieldDef] of Object.entries(schema.fields)) {
+    if (fieldDef.since && fieldDef.since > fromVersion && !(fieldName in current)) {
+      // Apply default or computed value
+      current[fieldName] = fieldDef.migrateFrom
+        ? fieldDef.migrateFrom(current)
+        : fieldDef.default;
+    }
+  }
+
+  current._v = toVersion;
+  return current;
+}
+```
+
+### Writing Rows (YJS-Safe Patching)
+
+```typescript
+function update(partial: Partial<Recording> & { id: string }): void {
+  ydoc.transact(() => {
+    const rowMap = getOrCreateRowMap(partial.id);
+    const currentVersion = rowMap.get('_v') ?? 1;
+
+    // 1. Migrate new fields if needed (YJS-safe: only add missing fields)
+    if (currentVersion < schemaVersion) {
+      for (const [fieldName, fieldDef] of Object.entries(schema.fields)) {
+        if (fieldDef.since && fieldDef.since > currentVersion && !rowMap.has(fieldName)) {
+          const value = fieldDef.migrateFrom
+            ? fieldDef.migrateFrom(rowMap.toJSON())
+            : fieldDef.default;
+          rowMap.set(fieldName, value);
+        }
+      }
+      rowMap.set('_v', schemaVersion);
+    }
+
+    // 2. Apply user's changes (only the fields they provided)
+    for (const [key, value] of Object.entries(partial)) {
+      if (key !== 'id' && key !== '_v') {
+        rowMap.set(key, value);
+      }
+    }
+  });
+}
+```
+
+### Creating New Rows
+
+```typescript
+function insert(row: Omit<Recording, 'id'> & { id?: string }): Recording {
+  const id = row.id ?? generateId();
+
+  ydoc.transact(() => {
+    const rowMap = new Y.Map();
+
+    // Set all fields at current version
+    rowMap.set('id', id);
+    for (const [fieldName, value] of Object.entries(row)) {
+      if (fieldName !== 'id') {
+        rowMap.set(fieldName, value);
+      }
+    }
+    rowMap.set('_v', schemaVersion);
+
+    tableMap.set(id, rowMap);
+  });
+
+  return { ...row, id, _v: schemaVersion } as Recording;
+}
+```
+
+---
+
+## Part 5: Handling Concurrent Conflicts
+
+### The Danger Zone: Migration + Concurrent Edit
+
+```
+Device A (offline): Reads row v1, app migrates to v2 in memory
+                   User edits title
+                   App writes row with ALL fields (bad pattern)
+
+Device B (offline): User edits status on v1
+
+Sync... → Title OR status may be lost (YJS picks per-field winner)
+```
+
+### The Safe Pattern
+
+**Never write fields you didn't change.**
+
+```typescript
+// GOOD: Only write what the user changed
+function updateTitle(id: string, newTitle: string) {
+  ydoc.transact(() => {
+    const rowMap = tableMap.get(id);
+
+    // Migrate if needed (adds NEW fields only)
+    ensureMigrated(rowMap);
+
+    // Only write the title
+    rowMap.set('title', newTitle);
+  });
+}
+
+// BAD: Write entire row
+function updateTitle(id: string, newTitle: string) {
+  const row = get(id); // Returns migrated row
+  row.title = newTitle;
+
+  // This writes EVERY field, competing with concurrent edits
+  upsert(row);
+}
+```
+
+### API Design Implications
+
+The table API should encourage patch-based updates:
+
+```typescript
+// Primary API: patch-based update
+table.update({ id: '1', title: 'New Title' }); // Only touches 'title'
+
+// Secondary API: full row (use with caution)
+table.upsert(fullRow); // Writes all fields - documented as "clobbers concurrent edits"
+
+// Read API: returns migrated row (in-memory, no write)
+const row = table.get('1'); // Always at current schema version
+```
+
+---
+
+## Part 6: Forward Compatibility
+
+### Old Client Reads New Data
+
+Device A (v2) creates a row with `status` field.
+Device B (v1) syncs and reads it.
+
+```typescript
+// Device B's code (v1 schema, doesn't know about 'status')
+const row = table.get('1');
+// row = { id: '1', title: 'Hello', status: 'completed', _v: 2 }
+
+// Device B's validator only knows v1 fields
+// BUT: we must preserve unknown fields!
+```
+
+**Rule**: Old clients must preserve unknown fields when writing:
+
+```typescript
+function update(partial: Partial<Row> & { id: string }) {
+  ydoc.transact(() => {
+    const rowMap = tableMap.get(partial.id);
+
+    // Only update fields we're changing
+    // Unknown fields (like 'status' for v1 client) remain untouched
+    for (const [key, value] of Object.entries(partial)) {
+      if (key !== 'id') {
+        rowMap.set(key, value);
+      }
+    }
+    // Don't downgrade _v - old client doesn't touch it
+  });
+}
+```
+
+### New Client Reads Old Data
+
+Device A (v1) has a row without `status`.
+Device B (v2) reads it.
+
+```typescript
+// Device B's code
+const row = table.get('1');
+// In-memory migration applies: row.status = 'completed' (default)
+// BUT: this is NOT written back to YJS unless user edits
+```
+
+**Decision**: Do NOT eagerly write migrations back. Wait for user edit.
+
+---
+
+## Part 7: Breaking Changes (Epoch Bumps)
+
+### When Epochs Are Required
+
+1. **Field rename**: `text` → `title`
+2. **Type change**: `views: string` → `views: number`
+3. **Field deletion**: Remove `deprecated_field`
+4. **Incompatible schema change**: Split one field into multiple
+
+### Epoch Migration Script
+
+```typescript
+// Migration from epoch 0 to epoch 1
+// This runs ONCE, coordinated (e.g., on first launch after update)
+
+async function migrateEpoch0ToEpoch1() {
+  const head = await getHeadDoc('epicenter.whispering');
+  const currentEpoch = head.getEpoch(); // 0
+
+  if (currentEpoch !== 0) {
+    console.log('Already migrated');
+    return;
+  }
+
+  // Create clients at both epochs
+  const oldClient = await createClient({ epoch: 0 });
+  const newClient = await createClient({ epoch: 1 });
+
+  // Migrate recordings table
+  for (const recording of oldClient.tables.recordings.getAll()) {
+    newClient.tables.recordings.upsert({
+      ...recording,
+      // Apply breaking changes
+      title: recording.text,  // Rename: text → title
+      // text field no longer exists in v1 schema
+    });
+  }
+
+  // Copy other tables...
+
+  // Bump epoch (atomic switch)
+  head.bumpEpoch();
+
+  // Cleanup
+  await oldClient.destroy();
+  await newClient.destroy();
+}
+```
+
+### Key Points
+
+1. **New Y.Doc**: Epoch 1 is a completely new document
+2. **Full transform safe**: No concurrent edits to new doc yet
+3. **Old data preserved**: Epoch 0 doc still exists for rollback
+4. **Coordinated**: Only one device runs migration, others see epoch bump
+
+---
+
+## Part 8: Decision Summary
+
+| Question | Decision | Rationale |
+|----------|----------|-----------|
+| **Field definition syntax** | Keep `text()`, `select()` factories | Good DX, type inference, metadata co-location |
+| **Schema standard** | Internal format with converters | Can export to ArkType/TypeBox/JSON Schema on demand |
+| **Cell vs Row LWW** | Cell-level by default | Preserves concurrent edits to different fields |
+| **Primary update API** | Patch-based `update()` | Only touches changed fields |
+| **Migration timing** | Lazy on read, explicit on write | Minimal YJS writes, preserves concurrent edits |
+| **Version storage** | Per-row `_v` field | Gradual migration, handles mixed versions |
+| **Breaking changes** | Epoch bump | Clean slate, no conflict with old data |
+| **Forward compat** | Preserve unknown fields | Old clients don't clobber new fields |
+
+---
+
+## Part 9: API Reference (Proposed)
+
+### Workspace Definition
+
+```typescript
+import {
+  defineWorkspace,
+  table,
+  setting,
+  id, text, select, integer, boolean, date, tags, richtext
+} from '@epicenter/hq';
+
+export const myWorkspace = defineWorkspace({
+  id: 'my.workspace',
+  version: 2, // Current schema version
+
+  tables: {
+    items: table({
+      name: 'Items',
+      icon: '📦',
+      description: 'All items in the system',
+      fields: {
+        id: id(),
+        title: text(),
+        description: text({ nullable: true }),
+        status: select({
+          options: ['draft', 'active', 'archived'],
+          default: 'draft',
+        }),
+        priority: integer({
+          default: 0,
+          since: 2, // Added in version 2
+        }),
+        tags: tags({ default: [] }),
+        createdAt: date(),
+        notes: richtext(), // Separate Y.Doc for rich content
+      },
+    }),
+  },
+
+  kv: {
+    theme: setting({
+      name: 'Theme',
+      field: select({ options: ['light', 'dark'], default: 'light' }),
+    }),
+    autoSave: setting({
+      name: 'Auto-save',
+      field: boolean({ default: true }),
+      since: 2,
+    }),
+  },
+});
+```
+
+### Table Operations
+
+```typescript
+const client = await createClient(myWorkspace);
+const { items } = client.tables;
+
+// Create (all fields at current version)
+const item = items.insert({
+  title: 'New Item',
+  status: 'draft',
+  priority: 1,
+  tags: ['important'],
+  createdAt: new Date().toISOString(),
+});
+
+// Read (automatically migrated to current version)
+const existing = items.get({ id: 'abc' });
+if (existing.status === 'valid') {
+  console.log(existing.row.priority); // Works even if row was created at v1
+}
+
+// Update (patch-based, only touches specified fields)
+items.update({ id: 'abc', title: 'Updated Title' });
+
+// Upsert (full row, use with caution in concurrent scenarios)
+items.upsert({ id: 'abc', ...fullRow });
+
+// Delete
+items.delete({ id: 'abc' });
+
+// List
+const all = items.getAll(); // Returns array of migrated rows
+```
+
+### KV Operations
+
+```typescript
+const { kv } = client;
+
+// Get (returns default if not set)
+const theme = kv.get('theme'); // 'light' | 'dark'
+
+// Set
+kv.set('theme', 'dark');
+
+// Subscribe
+kv.subscribe('theme', (value) => {
+  console.log('Theme changed:', value);
+});
+```
+
+---
+
+## Open Questions for Discussion
+
+1. **Should `since` be required for new fields?**
+   - Pro: Explicit about migration needs
+   - Con: Verbose for simple schemas
+
+2. **Should computed migrations (`migrateFrom`) write back immediately?**
+   - Current proposal: No, only on user edit
+   - Alternative: Write back in background after sync
+
+3. **How to handle `richtext` field migrations?**
+   - Rich text is a separate Y.Doc
+   - Might need special handling for content migrations
+
+4. **Should we expose version history in the API?**
+   - `table.getVersionHistory(id)` — useful for debugging?
+
+5. **How to handle schema validation errors?**
+   - Current: Return `{ status: 'invalid', errors }` from `get()`
+   - Should invalid rows be auto-repaired? Hidden? Surfaced to user?
+
+---
+
+## Related Documents
+
+- `specs/20260124T004528-versioned-table-api-design.md` — Deep dive on row versioning
+- `specs/20260124T125300-workspace-schema-versioning.md` — Workspace-level versioning
+- `specs/20260116T082500-schema-migration-patterns.md` — Migration strategy overview
+- `apps/whispering/src/lib/services/isomorphic/db/models/transformation-steps.ts` — Real example of ArkType versioned schema
+
+---
+
+## Changelog
+
+- 2026-01-24: Initial draft focusing on developer experience

--- a/specs/20260124T162638-stable-id-schema-pattern.md
+++ b/specs/20260124T162638-stable-id-schema-pattern.md
@@ -1,0 +1,490 @@
+# Stable ID Schema Pattern
+
+## Summary
+
+This spec describes a schema definition pattern for Epicenter's KV and Table systems where every field has a **stable internal ID** that's decoupled from its developer-facing name. This enables free renaming without data migration.
+
+## The Pattern
+
+Every field in a KV or Table schema is defined with three components:
+
+1. **Internal ID** (`id`): A stable string key used for storage in the Y.Map. Never changes.
+2. **Type** (`type`): A Zod (or standard schema) validator for runtime type checking.
+3. **Default** (`default`): Optional fallback value when data is missing or invalid.
+
+```typescript
+import { z } from 'zod';
+import { defineKv, defineTable, field } from 'epicenter';
+
+// KV Definition (id defaults to key name when not specified)
+const settings = defineKv({
+  'app.theme': field({
+    type: z.enum(['light', 'dark', 'system']),
+    default: 'system',
+  }),  // id defaults to 'app.theme'
+  'editor.fontSize': field({
+    type: z.number().int().min(8).max(72),
+    default: 14,
+  }),  // id defaults to 'editor.fontSize'
+});
+
+// Table Definition
+const recordings = defineTable({
+  id: 'recordings',
+  name: 'Recordings',
+  fields: {
+    id: id(),  // Special helper for primary key
+    title: field({ type: z.string(), default: 'Untitled' }),  // id defaults to 'title'
+    transcript: field({ type: z.string(), default: '' }),
+    status: field({
+      type: z.enum(['pending', 'transcribing', 'done', 'failed']),
+      default: 'pending',
+    }),
+    createdAt: field({
+      type: z.string().datetime(),
+      default: () => new Date().toISOString(),  // Dynamic default
+    }),
+  },
+});
+```
+
+## How It Works
+
+The developer-facing key (e.g., `'app.theme'`, `'transcript'`) is separate from the storage key (`id`).
+
+**What the Y.Doc stores:**
+
+By default, storage keys match developer-facing keys (since `id` defaults to the key name):
+
+```typescript
+// KV Y.Map internally:
+{ "app.theme": "dark", "editor.fontSize": 16 }
+
+// Table row Y.Map internally:
+{ "id": "rec_abc", "title": "Meeting", "transcript": "...", "status": "done", "createdAt": "2024-01-15T10:30:00Z" }
+```
+
+If you've renamed a field (explicitly setting `id`), the storage key differs from the developer key:
+
+```typescript
+// After renaming 'app.theme' → 'appearance.colorScheme' with id: 'app.theme'
+{ "app.theme": "dark", "editor.fontSize": 16 }
+// Developer sees: settings.get('appearance.colorScheme') → 'dark'
+```
+
+**What the developer sees:**
+
+```typescript
+settings.get('app.theme');           // Returns 'dark'
+recordings.get('rec_abc').transcript; // Returns '...'
+```
+
+The mapping is transparent. Developers work with readable names; storage uses stable IDs.
+
+## Renaming Is Free
+
+To rename a field, change the developer-facing key and explicitly set `id` to preserve the old storage key:
+
+```typescript
+// Before (id defaults to 'transcript')
+const recordings = defineTable({
+  fields: {
+    id: id(),
+    transcript: field({ type: z.string(), default: '' }),
+  },
+});
+
+// After: rename transcript → transcription
+const recordings = defineTable({
+  fields: {
+    id: id(),
+    transcription: field({  // ← New developer-facing name
+      id: 'transcript',      // ← Explicitly set to old key, data untouched
+      type: z.string(),
+      default: '',
+    }),
+  },
+});
+```
+
+No migration. No data changes. No `legacyKeys` fallback logic. The rename is purely a code change.
+
+**Key insight**: You only need to specify `id` when renaming. For new fields, let it default to the key name.
+
+## What This Eliminates
+
+By making internal keys stable (either explicitly via `id` or implicitly via key name), we eliminate an entire category of CRDT bugs:
+
+| Bug Category | Why It's Eliminated |
+|--------------|---------------------|
+| **Data resurrection** | Old client writes to "deleted" key? Can't happen. Keys are never deleted. |
+| **Split-brain data** | Data in both old and new keys? Can't happen. There's only one key per field. |
+| **Legacy key accumulation** | Read logic checking five fallback keys? Gone. One key, one read. |
+| **Migration race conditions** | Two clients migrating simultaneously? Not a thing. Nothing to migrate. |
+| **Version coordination** | Tracking who's migrated? Unnecessary. Schema handles interpretation. |
+
+The pattern doesn't just make renaming easier—it makes renaming a **non-operation** at the data layer. You're not "handling" renames; you're making them structurally impossible to get wrong.
+
+## The `field()` Helper
+
+```typescript
+import { z, ZodType } from 'zod';
+
+type FieldDefinition<T extends ZodType> = {
+  id?: string;                            // Internal storage key (defaults to the developer-facing key name)
+  type: T;                                // Zod schema for validation
+  default?: z.infer<T> | (() => z.infer<T>); // Default value or factory function (makes field optional)
+  required?: boolean;                     // If true, missing value is an error (no default allowed)
+};
+
+function field<T extends ZodType>(def: FieldDefinition<T>): FieldDefinition<T> {
+  return def;
+}
+
+// Special helper for table primary key
+function id(): FieldDefinition<z.ZodString> {
+  return { id: 'id', type: z.string(), required: true };
+}
+```
+
+**Rules:**
+- `id` defaults to the developer-facing key name if not specified
+- `id` must be unique within the KV or Table (validated at definition time)
+- `default` makes a field optional; missing/invalid data returns the default
+- `default` can be a static value or a factory function (e.g., `() => Date.now()`)
+- `required: true` makes a field mandatory; missing data is an error
+- `required` and `default` are mutually exclusive (a field cannot be both required and have a default)
+- `type` uses Zod (or any standard schema compatible validator)
+
+## Read Behavior
+
+When reading a field:
+
+1. Get the raw value from Y.Map using the internal `id`
+2. If undefined and has `default`: return default
+3. If undefined and `required`: return error status
+4. Validate against `type`
+5. If invalid and has `default`: return default
+6. If invalid and `required`: return error status
+7. Return validated value
+
+```typescript
+function getDefault(fieldDef: FieldDefinition) {
+  if (fieldDef.default === undefined) return undefined;
+  // Support both static values and factory functions
+  return typeof fieldDef.default === 'function' ? fieldDef.default() : fieldDef.default;
+}
+
+function readField(ymap: Y.Map, fieldDef: FieldDefinition, devKey: string) {
+  // id defaults to the developer-facing key name
+  const storageKey = fieldDef.id ?? devKey;
+  const raw = ymap.get(storageKey);
+
+  if (raw === undefined) {
+    if (fieldDef.default !== undefined) return { status: 'valid', value: getDefault(fieldDef) };
+    if (fieldDef.required) return { status: 'missing' };
+    return { status: 'valid', value: undefined };
+  }
+
+  const result = fieldDef.type.safeParse(raw);
+  if (!result.success) {
+    if (fieldDef.default !== undefined) return { status: 'valid', value: getDefault(fieldDef) };
+    return { status: 'invalid', error: result.error };
+  }
+
+  return { status: 'valid', value: result.data };
+}
+```
+
+## Write Behavior
+
+Writes always use the internal `id`:
+
+```typescript
+function writeField(ymap: Y.Map, fieldDef: FieldDefinition, devKey: string, value: unknown) {
+  const storageKey = fieldDef.id ?? devKey;
+  const result = fieldDef.type.safeParse(value);
+  if (!result.success) {
+    throw new Error(`Invalid value for field '${devKey}': ${result.error}`);
+  }
+  ymap.set(storageKey, result.data);
+}
+```
+
+## Schema Evolution
+
+| Change | How to Handle |
+|--------|---------------|
+| Add field | Add to schema with `default`. Old data gets the default. |
+| Remove field | Remove from schema. Data stays in Y.Doc but isn't read. |
+| Rename field | Change developer-facing key, keep same `id`. |
+| Change type | If old values fail new validation, they return `default`. |
+
+No migrations. No coordination. Schema is the source of truth.
+
+---
+
+## Why This Pattern?
+
+### The Problem: Renaming in CRDTs
+
+In a CRDT system, renaming a key is surprisingly hard:
+
+1. **Copy approach**: Set new key, delete old key. But if an old client writes to the old key after you delete it, that write "resurrects" the old key.
+
+2. **Legacy keys approach**: Read from new key, fall back to old key. Works but requires maintaining fallback logic forever.
+
+3. **Migration scripts**: Don't work in CRDTs. No central authority to run them. Peers can be offline indefinitely.
+
+### Alternatives Considered
+
+**Option A: Direct Key Names (No Indirection)**
+
+```typescript
+const settings = defineKv({
+  'app.theme': field({
+    type: z.enum(['light', 'dark']),
+    default: 'light',
+  }),
+});
+// Y.Map stores: { "app.theme": "dark" }
+```
+
+Pros:
+- Simple, what you see is what you get
+- Easy to debug Y.Doc contents
+
+Cons:
+- Renaming requires `legacyKeys` fallback logic
+- Legacy keys accumulate forever
+- Risk of data loss during concurrent rename operations
+
+**Option B: Auto-Generated IDs**
+
+```typescript
+const settings = defineKv({
+  'app.theme': field({
+    id: generateId(),  // Auto-generate stable ID
+    type: z.enum(['light', 'dark']),
+  }),
+});
+```
+
+Cons:
+- How do you generate stable IDs? Hash of key name? Then renaming breaks it.
+- Random IDs? They change on every code run unless persisted somewhere.
+- Adds hidden complexity.
+
+**Option C: Default ID = Key Name, Override When Needed (This Spec) ✅**
+
+```typescript
+// ID defaults to 'app.theme' - no need to specify
+'app.theme': field({ type: z.enum(['light', 'dark']) }),
+
+// When renaming, explicitly set id to preserve old storage key
+'app.colorTheme': field({ id: 'app.theme', type: z.enum(['light', 'dark']) }),
+```
+
+Pros:
+- Zero boilerplate for the 90% case where you never rename
+- Renaming is still trivial: change key, add explicit `id`
+- No legacy key fallback logic needed
+- No magic or auto-generation
+- Duplicates caught at build time
+- Y.Doc data is readable (uses same keys as code by default)
+
+Cons:
+- If you forget to set `id` when renaming, you get a new storage key (data appears "lost")
+- Could be mitigated with a linter rule that detects removed keys without corresponding `id` references
+
+### Why Default-to-Key-Name Wins
+
+This approach gives you the best of both worlds:
+
+1. **Simple case (no renames)**: Just write `field({ type, default })`. No extra thought needed.
+2. **Rename case**: Add explicit `id` to preserve the old storage key. Clear and intentional.
+
+The "silent data loss" concern is real but manageable:
+- Renames are relatively rare
+- A linter can catch removed keys and suggest adding `id`
+- Code review should catch renames without `id`
+
+**Option D: Always Explicit IDs**
+
+```typescript
+'app.theme': field({
+  id: 'theme',
+  type: z.enum(['light', 'dark']),
+  default: 'light',
+}),
+```
+
+Pros:
+- Never any ambiguity about what's stored
+- Grep-friendly
+
+Cons:
+- Boilerplate for every single field
+- Developers must invent two names for everything
+- Most fields are never renamed, so the overhead is wasted
+
+We chose Option C because reducing boilerplate for the common case outweighs the risk of the rare rename case.
+
+---
+
+## Implementation Notes
+
+### Uniqueness Validation
+
+At definition time, validate that all storage IDs (explicit or defaulted) are unique:
+
+```typescript
+function defineKv(fields: Record<string, FieldDefinition>) {
+  const ids = new Set<string>();
+  for (const [devKey, field] of Object.entries(fields)) {
+    const storageId = field.id ?? devKey;  // id defaults to devKey
+    if (ids.has(storageId)) {
+      throw new Error(`Duplicate storage id '${storageId}' in KV definition (used by '${devKey}')`);
+    }
+    ids.add(storageId);
+  }
+  // ... create KV accessor
+}
+```
+
+This catches cases where two fields accidentally map to the same storage key:
+
+```typescript
+// This would throw an error:
+defineKv({
+  'theme': field({ type: z.string() }),              // storageId: 'theme'
+  'colorScheme': field({ id: 'theme', type: z.string() }),  // storageId: 'theme' - DUPLICATE!
+});
+```
+
+### TypeScript Inference
+
+The developer-facing key becomes the TypeScript property name:
+
+```typescript
+type SettingsKv = {
+  get(key: 'app.theme'): 'light' | 'dark' | 'system';
+  get(key: 'editor.fontSize'): number;
+  set(key: 'app.theme', value: 'light' | 'dark' | 'system'): void;
+  // ...
+};
+```
+
+The internal `id` is an implementation detail hidden from the type system.
+
+### Debugging and Serialization
+
+Two methods for inspecting data:
+
+**`toJSON()`** - Human-readable keys (for application use, debugging):
+
+```typescript
+settings.toJSON()
+// { "app.theme": "dark", "editor.fontSize": 16 }
+
+recordings.get('rec_abc').toJSON()
+// { "id": "rec_abc", "title": "Meeting", "transcript": "...", "status": "done", "createdAt": "2024-01-15T10:30:00Z" }
+```
+
+**`toRaw()`** - Internal storage keys (for low-level debugging, sync inspection):
+
+```typescript
+settings.toRaw()
+// { "app.theme": "dark", "editor.fontSize": 16 }
+// (Same as toJSON when id defaults to key name)
+
+// But if you've renamed a field:
+// 'appearance.colorScheme': field({ id: 'app.theme', ... })
+settings.toRaw()
+// { "app.theme": "dark", ... }  // Shows actual storage key
+
+settings.toJSON()
+// { "appearance.colorScheme": "dark", ... }  // Shows developer-facing key
+```
+
+You can also get a mapping from internal IDs to developer names:
+
+```typescript
+settings.getFieldMapping()
+// { "app.theme": "appearance.colorScheme", "editor.fontSize": "editor.fontSize" }
+```
+
+---
+
+## Workspace-Level Definition
+
+KV and tables are typically grouped into a workspace:
+
+```typescript
+import { z } from 'zod';
+import { defineWorkspace, defineKv, defineTable, field, id } from 'epicenter';
+
+export const whispering = defineWorkspace({
+  name: 'whispering',
+
+  kv: defineKv({
+    'app.theme': field({
+      type: z.enum(['light', 'dark', 'system']),
+      default: 'system',
+    }),
+    'recording.autoStart': field({
+      type: z.boolean(),
+      default: false,
+    }),
+  }),
+
+  tables: {
+    recordings: defineTable({
+      id: 'recordings',
+      name: 'Recordings',
+      fields: {
+        id: id(),
+        title: field({ type: z.string(), default: 'Untitled' }),
+        transcript: field({ type: z.string(), default: '' }),
+        status: field({
+          type: z.enum(['pending', 'transcribing', 'done', 'failed']),
+          default: 'pending',
+        }),
+      },
+    }),
+
+    transformations: defineTable({
+      id: 'transformations',
+      name: 'Transformations',
+      fields: {
+        id: id(),
+        name: field({ type: z.string(), default: 'Untitled' }),
+        steps: field({ type: z.array(TransformationStepSchema), default: [] }),
+      },
+    }),
+  },
+});
+```
+
+---
+
+## Summary
+
+The Stable ID Schema Pattern separates developer-facing names from internal storage keys. By default, the internal `id` matches the developer-facing key name, keeping things simple. When you need to rename a field, you explicitly set `id` to preserve the old storage key.
+
+This pattern provides:
+- **Zero boilerplate** for the common case (no renames)
+- **Free renames** when needed (just add explicit `id`)
+- **No migration scripts** - schema is the source of truth
+- **No legacy key fallback logic** - the mapping is handled by the framework
+- **No CRDT coordination issues** - renaming is a code change, not a data change
+
+For CRDT-based systems where traditional migrations don't work, this is the pragmatic choice.
+
+---
+
+## Related
+
+- [CRDT Schema Evolution Without Migrations](../docs/articles/crdt-schema-evolution-without-migrations.md) - Why this pattern exists
+- [Flat Y.Map with Dot-Notation Keys](../docs/articles/flat-ymap-dot-notation-pattern.md) - The underlying storage pattern
+- [Nested Y.Map Replacement Danger](../docs/articles/nested-ymap-replacement-danger.md) - Why we use flat maps

--- a/specs/20260124T163000-developer-experience-schema-api.md
+++ b/specs/20260124T163000-developer-experience-schema-api.md
@@ -1,0 +1,1652 @@
+# Developer Experience: Schema Definition and Migration API
+
+> **⚠️ PARTIALLY SUPERSEDED**
+>
+> The migration approach in this spec has been superseded by [`specs/20260124T162638-stable-id-schema-pattern.md`](./20260124T162638-stable-id-schema-pattern.md).
+>
+> **What's still valuable here**:
+> - Challenge 1: Multi-Peer Writes analysis
+> - Cell-level vs Row-level LWW discussion
+> - The problem framing for schema evolution
+>
+> **What's obsolete**:
+> - The versioning and migration strategies (Challenges 2-3)
+> - Per-row `_v` tracking
+> - Migration race condition handling
+>
+> **The new approach**: Stable internal IDs that never change. Renaming = change schema key, keep same ID. Invalid data returns default. No migrations.
+
+---
+
+**Status**: Draft - Iterating (Partially Superseded)
+**Date**: 2026-01-24
+**Context**: Designing the developer-facing API for defining schemas, tables, and KV stores with YJS synchronization
+**Builds On**: `specs/20260124T125300-workspace-schema-versioning.md`, `specs/20260124T004528-versioned-table-api-design.md`
+
+---
+
+## Executive Summary
+
+This spec focuses on **developer experience (DX)** for Epicenter's data layer. The goal: make it feel like working with a modern ORM, not a CRDT framework.
+
+**Key Principles:**
+1. Use existing schema libraries (ArkType, Standard Schema) — no proprietary field syntax
+2. Strong opinions on migrations — one obvious way to do things
+3. Cell-level editing by default — YJS handles conflicts naturally
+4. Minimize footguns — make the safe thing the easy thing
+
+---
+
+## The Core Problem
+
+You want to build local-first apps with sync. Conceptually simple:
+
+```
+User has data → Data syncs across devices → Everyone sees the same thing
+```
+
+But local-first sync introduces hard problems that traditional databases don't have.
+
+---
+
+## Challenge 1: Multi-Peer Writes Without a Server
+
+**Traditional database:**
+```
+Client → Server → Database
+         ↑
+         Server decides order, rejects conflicts
+```
+
+**Local-first:**
+```
+Device A ←→ Device B ←→ Device C
+     ↑           ↑           ↑
+     All can write offline, all sync later
+```
+
+**The problem**: No central authority. When Device A and Device B both edit offline, who wins?
+
+**YJS's answer**: Last-Write-Wins (LWW) at the Y.Map key level. Deterministic ordering based on internal operation IDs.
+
+**Our question**: At what granularity? Entire rows? Individual fields?
+
+---
+
+## Challenge 2: Schema Evolution Over Time
+
+Apps evolve. You ship v1 with:
+```typescript
+{ id: string, title: string }
+```
+
+Later you need:
+```typescript
+{ id: string, title: string, status: 'pending' | 'done', priority: number }
+```
+
+**Traditional database**: Run a migration script once, coordinated.
+
+**Local-first**:
+- Device A might have app v2 (new schema)
+- Device B might still run app v1 (old schema)
+- They sync the same data
+- Old data and new data coexist
+
+**The questions**:
+- Where do we store "what version is this workspace"?
+- When do we migrate data?
+- Who triggers migration?
+- What if two devices both try to migrate simultaneously?
+
+---
+
+## Challenge 3: Concurrent Migration Race Conditions
+
+```
+Device A (offline): Runs app v2, sees workspace at v1
+                    Starts migrating all rows...
+
+Device B (offline): Runs app v2, sees workspace at v1
+                    Also starts migrating all rows...
+
+Both sync...
+```
+
+**Scenario A**: Deterministic migration
+```typescript
+// Both devices compute the same result
+{ id: 'abc', status: 'pending' }  // Device A
+{ id: 'abc', status: 'pending' }  // Device B (identical)
+
+// YJS picks one. Doesn't matter which. Same data.
+```
+
+**Scenario B**: Non-deterministic migration
+```typescript
+// Devices compute different results
+{ id: 'abc', migratedAt: '2024-01-24T10:00:00Z' }  // Device A
+{ id: 'abc', migratedAt: '2024-01-24T10:05:00Z' }  // Device B (different!)
+
+// YJS picks one. The other is lost. Data inconsistency.
+```
+
+**The constraint**: Migrations must be deterministic, or we need coordination.
+
+---
+
+## Challenge 4: Forward and Backward Compatibility
+
+**Forward compatibility**: Old code reading new data
+```
+Device B (app v1) reads row created by Device A (app v2)
+Row has fields Device B doesn't know about
+```
+
+What should happen? Crash? Ignore unknown fields? Block until update?
+
+**Backward compatibility**: New code reading old data
+```
+Device A (app v2) reads row created months ago at v1
+Row is missing fields that v2 expects
+```
+
+What should happen? Apply defaults? Error? Migrate in place?
+
+---
+
+## Challenge 5: Developer Experience
+
+On top of all this, we want developers to not have to think about any of it.
+
+**Current pain points:**
+
+| Pain Point | Example |
+|------------|---------|
+| **Proprietary field syntax** | `text({ nullable: true })` instead of standard types |
+| **Migration uncertainty** | "Should I bump epoch or add a field?" |
+| **CRDT complexity leaks** | Developers need to understand Y.Map internals |
+| **Type inference friction** | Multiple type definition layers |
+
+**Goal**: A developer should be able to define their data model in 5 minutes and never think about CRDTs again (unless they want to).
+
+---
+
+## Summary: What We Need to Decide
+
+| Question | Options |
+|----------|---------|
+| **LWW granularity** | Row-level (simpler) vs Cell-level (better merging) |
+| **Version storage** | Per-workspace vs Per-row |
+| **Migration trigger** | Eager (on startup) vs Lazy (on access) |
+| **Migration coordination** | Any peer vs Designated migrator |
+| **Schema definition** | Proprietary syntax vs Standard Schema (ArkType/Zod) |
+| **Forward compat** | Ignore unknown vs Block until update |
+| **Backward compat** | Defaults vs Explicit migration |
+
+---
+
+## Deep Dive: The Versioning Question
+
+### Do We Even Need Framework-Level Versioning?
+
+Let's think about this from first principles.
+
+**What versioning buys you:**
+- Automatic detection of "old" data
+- Framework runs migrations for you
+- Developers don't think about it
+
+**What versioning costs you:**
+- Complex coordination logic
+- Race condition footguns
+- Magic that's hard to debug
+- Framework complexity
+
+**Alternative: Invert control to the developer**
+
+Instead of:
+```typescript
+// Framework magic
+const store = defineStore('app')
+  .v(1, schema1)
+  .v(2, schema2, migrate)  // Framework handles when/how
+  .build();
+```
+
+Maybe:
+```typescript
+// Developer controls migration
+const store = defineStore('app', {
+  tables: { recordings: RecordingSchema },
+  kv: { theme: ThemeSchema },
+});
+
+// Developer decides when to migrate
+if (needsMigration(workspace)) {
+  await migrateRecordings(workspace);
+}
+```
+
+### Let's Walk Through the Hard Cases
+
+#### Case 1: Rename a Field (`text` → `title`)
+
+```
+BEFORE                          AFTER
+┌─────────────────────┐        ┌─────────────────────┐
+│ recordings          │        │ recordings          │
+├─────────────────────┤        ├─────────────────────┤
+│ abc: {              │   →    │ abc: {              │
+│   id: "abc",        │        │   id: "abc",        │
+│   text: "Hello"     │        │   title: "Hello"    │  ← renamed
+│ }                   │        │ }                   │
+└─────────────────────┘        └─────────────────────┘
+```
+
+**Migration code:**
+```typescript
+function migrateTextToTitle(workspace) {
+  const table = workspace.doc.getMap('tables').get('recordings');
+
+  for (const [id, rowJson] of table.entries()) {
+    const row = JSON.parse(rowJson);
+    if ('text' in row && !('title' in row)) {
+      const migrated = { ...row, title: row.text };
+      delete migrated.text;
+      table.set(id, JSON.stringify(migrated));
+    }
+  }
+}
+```
+
+**What if two peers migrate simultaneously?**
+
+```
+Timeline:
+─────────────────────────────────────────────────────────────────
+Device A (offline)     Device B (offline)     After Sync
+─────────────────────────────────────────────────────────────────
+
+Both start with:
+{ id: "abc", text: "Hello" }
+
+A reads row          B reads row
+A transforms         B transforms
+A writes:            B writes:
+{                    {
+  id: "abc",           id: "abc",
+  title: "Hello"       title: "Hello"    ← SAME DATA
+}                    }
+
+                     SYNC
+                       ↓
+
+Result: { id: "abc", title: "Hello" }
+
+YJS picks one write. Doesn't matter which.
+Both wrote identical data. ✓ SAFE
+```
+
+**Key insight**: Deterministic transforms converge, even with concurrent execution.
+
+#### Case 2: Rename a Table (`posts` → `articles`)
+
+```
+BEFORE                          AFTER
+┌─────────────────────┐        ┌─────────────────────┐
+│ tables              │        │ tables              │
+├─────────────────────┤        ├─────────────────────┤
+│ posts: Y.Map {      │        │ articles: Y.Map {   │  ← new name
+│   abc: {...}        │   →    │   abc: {...}        │
+│   def: {...}        │        │   def: {...}        │
+│ }                   │        │ }                   │
+│                     │        │ posts: Y.Map {}     │  ← old empty
+└─────────────────────┘        └─────────────────────┘
+```
+
+**Migration code:**
+```typescript
+function migratePostsToArticles(workspace) {
+  const tables = workspace.doc.getMap('tables');
+  const oldTable = tables.get('posts');
+
+  if (!oldTable || oldTable.size === 0) return; // Already migrated
+
+  // Create new table if needed
+  if (!tables.has('articles')) {
+    tables.set('articles', new Y.Map());
+  }
+  const newTable = tables.get('articles');
+
+  // Copy all rows
+  for (const [id, rowJson] of oldTable.entries()) {
+    if (!newTable.has(id)) {
+      newTable.set(id, rowJson);
+    }
+  }
+
+  // Clear old table (don't delete - other peers might still write to it)
+  // Or: leave it, new code ignores it
+}
+```
+
+**The concurrent migration scenario:**
+
+```
+Timeline:
+─────────────────────────────────────────────────────────────────
+Device A (offline)     Device B (offline)     After Sync
+─────────────────────────────────────────────────────────────────
+
+Both see posts with 2 rows, articles empty
+
+A copies abc→articles  B copies abc→articles
+A copies def→articles  B copies def→articles
+
+                     SYNC
+                       ↓
+
+articles: { abc: {...}, def: {...} }
+
+Both wrote same rows to same keys.
+YJS merges. ✓ SAFE (if row content is identical)
+```
+
+#### Case 3: The Dangerous One - Non-Deterministic Transform
+
+```typescript
+// DANGEROUS: Each device computes different value
+function migrateBad(workspace) {
+  for (const [id, rowJson] of table.entries()) {
+    const row = JSON.parse(rowJson);
+    const migrated = {
+      ...row,
+      migratedAt: new Date().toISOString(),  // DIFFERENT ON EACH DEVICE
+      migrationId: crypto.randomUUID(),       // DIFFERENT ON EACH DEVICE
+    };
+    table.set(id, JSON.stringify(migrated));
+  }
+}
+```
+
+```
+Timeline:
+─────────────────────────────────────────────────────────────────
+Device A (offline)     Device B (offline)     After Sync
+─────────────────────────────────────────────────────────────────
+
+A writes:              B writes:
+{                      {
+  id: "abc",             id: "abc",
+  migratedAt: "10:00",   migratedAt: "10:05",  ← DIFFERENT
+  migrationId: "xxx"     migrationId: "yyy"    ← DIFFERENT
+}                      }
+
+                     SYNC
+                       ↓
+
+YJS picks ONE. Based on clientID ordering.
+Could be A's version. Could be B's.
+The other is LOST. ✗ DATA DIVERGENCE
+```
+
+### The ClientID Problem
+
+YJS doesn't use wall-clock time for LWW. It uses internal operation ordering.
+
+```
+How YJS decides "last":
+─────────────────────────────────────────────────────────────────
+
+1. Each client has a unique clientID (random number)
+2. Each operation gets a clock value (increments locally)
+3. When two operations conflict, YJS compares:
+   - First by clock value
+   - Then by clientID (higher wins)
+
+This means:
+- "Last" is NOT chronological
+- Device with higher clientID tends to win ties
+- This is DETERMINISTIC (same result on all devices)
+- But NOT intuitive (newer edit might lose)
+```
+
+**Why this matters for migrations:**
+
+If Device A and B both write the SAME value:
+- One wins, one loses
+- Result is correct (values are identical)
+
+If Device A and B write DIFFERENT values:
+- One wins, one loses
+- Result might not be what you expect
+- The "older" edit (by wall clock) might win
+
+### So... Do We Need Epochs?
+
+Epochs (new Y.Doc for breaking changes) solve a different problem:
+
+```
+WITH EPOCHS:
+─────────────────────────────────────────────────────────────────
+Epoch 0 (Y.Doc)              Epoch 1 (Y.Doc)
+┌──────────────────┐         ┌──────────────────┐
+│ posts: {         │         │ articles: {      │
+│   abc: {...}     │    →    │   abc: {...}     │
+│ }                │  copy   │ }                │
+└──────────────────┘         └──────────────────┘
+
+- Old doc is frozen (read-only)
+- New doc is fresh start
+- No race conditions (migration runs once, copies data)
+- Old clients stay on old epoch until they upgrade
+
+WITHOUT EPOCHS (in-place migration):
+─────────────────────────────────────────────────────────────────
+Same Y.Doc
+┌──────────────────┐         ┌──────────────────┐
+│ posts: {         │         │ posts: {}        │
+│   abc: {...}     │    →    │ articles: {      │
+│ }                │ migrate │   abc: {...}     │
+│                  │         │ }                │
+└──────────────────┘         └──────────────────┘
+
+- Same doc, modified in place
+- Multiple peers can trigger migration
+- Race conditions if transforms are non-deterministic
+- Old clients see new data immediately (might break)
+```
+
+**When you need epochs:**
+- Non-deterministic transforms
+- Want old clients to stay isolated
+- Clean break between schema versions
+
+**When in-place migration is fine:**
+- Deterministic transforms
+- All clients will upgrade soon
+- Additive changes (new fields, new tables)
+
+### A Simpler Mental Model
+
+What if we just accept:
+
+1. **Additive changes** (add field, add table): Just do it. Old code ignores new stuff.
+
+2. **Renames and restructures**: Developer writes migration function. It runs on each device. As long as it's deterministic, concurrent execution converges.
+
+3. **Non-deterministic transforms**: Use epochs (new Y.Doc). Framework helps copy data.
+
+```typescript
+// The simple API
+const store = defineStore('app', {
+  tables: {
+    recordings: RecordingSchema,
+  },
+});
+
+// Additive: just add to schema, old data gets defaults on read
+const storeV2 = defineStore('app', {
+  tables: {
+    recordings: RecordingSchemaV2, // Has new optional field
+  },
+});
+
+// Restructure: developer runs migration explicitly
+await store.migrate(async (doc) => {
+  // Deterministic transform
+  renameField(doc, 'recordings', 'text', 'title');
+});
+
+// Breaking: developer bumps epoch
+await store.newEpoch(async (oldDoc, newDoc) => {
+  // Can do non-deterministic stuff here
+  // Runs on ONE device, new doc syncs to others
+});
+```
+
+### The Real Question
+
+Should the framework:
+
+**Option A: Be smart (manage versions internally)**
+- Track version in metadata
+- Auto-run migrations
+- Handle coordination
+- Complex, magic, potential footguns
+
+**Option B: Be simple (give developer control)**
+- No version tracking
+- Developer decides when to migrate
+- Provide helpers, not magic
+- Simple, explicit, developer owns the problem
+
+**Option C: Hybrid**
+- Track version for informational purposes
+- Warn developer "workspace is at v1, code expects v2"
+- Developer explicitly runs migration
+- Best of both? Or worst of both?
+
+---
+
+## Design Philosophy
+
+### 1. Schema-First, Not CRDT-First
+
+Developers think in terms of their domain:
+
+```typescript
+// What developers WANT to write
+type Recording = {
+  id: string;
+  title: string;
+  transcript: string | null;
+  duration: number;
+  status: 'pending' | 'transcribed' | 'failed';
+  createdAt: Date;
+};
+```
+
+Not:
+
+```typescript
+// What they DON'T want to think about
+const recording = Y.Map<{
+  id: Y.Text,
+  title: Y.Text,
+  // ...
+}>();
+```
+
+### 2. One Schema Definition, Multiple Uses
+
+A single schema definition should power:
+- TypeScript types (inference)
+- Runtime validation
+- YJS storage structure
+- SQLite mirror (for queries)
+- API contracts
+
+### 3. Migrations Should Be Boring
+
+The best migration system is one where:
+- 90% of changes need no migration code
+- The remaining 10% have one obvious path
+- Breaking changes are rare and explicit
+
+---
+
+## Proposed API: ArkType-Native Schemas
+
+### Basic Table Definition
+
+```typescript
+import { type } from 'arktype';
+import { defineStore } from '@epicenter/hq';
+
+// Define your types using ArkType
+const Recording = type({
+  id: 'string',
+  title: 'string',
+  transcript: 'string | null',
+  duration: 'number >= 0',
+  status: "'pending' | 'transcribed' | 'failed'",
+  createdAt: 'Date',
+});
+
+const Transformation = type({
+  id: 'string',
+  name: 'string',
+  prompt: 'string',
+  enabled: 'boolean',
+});
+
+// Define the store
+const store = defineStore('whispering', {
+  tables: {
+    recordings: Recording,
+    transformations: Transformation,
+  },
+  kv: {
+    theme: type("'light' | 'dark'"),
+    language: type("'en' | 'es' | 'fr' | 'de'"),
+    autoSave: type('boolean'),
+  },
+});
+
+// TypeScript infers everything
+type RecordingRow = typeof store.tables.recordings.Row;
+// { id: string; title: string; transcript: string | null; ... }
+```
+
+### Why ArkType?
+
+| Feature | ArkType | Zod | TypeBox |
+|---------|---------|-----|---------|
+| **Type inference** | Excellent | Good | Good |
+| **Runtime validation** | Fast | Moderate | Fast |
+| **Syntax** | `'string | null'` | `z.string().nullable()` | `Type.Union(...)` |
+| **Standard Schema** | Yes | Coming | No |
+| **Bundle size** | Small | Moderate | Small |
+
+ArkType's string-based syntax is closer to TypeScript itself, reducing cognitive load.
+
+### Standard Schema Compatibility
+
+If developers prefer Zod, Valibot, or other libraries:
+
+```typescript
+import { z } from 'zod';
+import { defineStore, fromStandardSchema } from '@epicenter/hq';
+
+const Recording = z.object({
+  id: z.string(),
+  title: z.string(),
+  transcript: z.string().nullable(),
+  duration: z.number().min(0),
+  status: z.enum(['pending', 'transcribed', 'failed']),
+  createdAt: z.date(),
+});
+
+const store = defineStore('whispering', {
+  tables: {
+    // fromStandardSchema adapts any Standard Schema-compliant library
+    recordings: fromStandardSchema(Recording),
+  },
+  kv: {},
+});
+```
+
+---
+
+## Storage Structure: Row-Level LWW
+
+### Design Decision: Simplicity Over Granularity
+
+We use **row-level last-write-wins** with a simple two-level structure:
+
+```
+Y.Map('tables')
+  └── 'recordings': Y.Map<rowId, JSON string>
+      ├── 'abc123': '{"id":"abc123","title":"Hello","status":"pending"}'
+      └── 'def456': '{"id":"def456","title":"World","status":"done"}'
+
+Y.Map('kv')
+  ├── 'theme': '"dark"'
+  └── 'language': '"en"'
+```
+
+**Why row-level, not cell-level?**
+
+| Aspect | Row-Level LWW | Cell-Level LWW |
+|--------|---------------|----------------|
+| **Storage depth** | 2 levels | 3 levels |
+| **Complexity** | Simple | Complex |
+| **Serialization** | JSON.stringify | Field-by-field |
+| **Conflict granularity** | Entire row | Per field |
+| **Use case fit** | Single-user, low-collab | High-collaboration |
+
+For most Epicenter apps (personal tools, single-user or family), row-level is the right trade-off. The simplicity wins.
+
+### What This Means for Conflicts
+
+```
+Device A (offline): Edits title to "Hello"
+Device B (offline): Edits status to "completed"
+Both sync...
+
+Result: ONE device's entire row wins.
+        The other device's edit is lost.
+```
+
+**Mitigations:**
+
+1. **Timestamps**: Store `updatedAt` in rows, surface "last editor" in UI
+2. **Conflict detection**: Compare local vs synced, show indicator if different
+3. **For high-collab needs**: Use a different storage mode (cell-level opt-in)
+
+### Implementation
+
+```typescript
+// Writing a row
+function upsert(row: Recording) {
+  const tableMap = doc.getMap('tables').get('recordings') as Y.Map<string>;
+  tableMap.set(row.id, JSON.stringify(row));
+}
+
+// Reading a row
+function get(id: string): Recording | undefined {
+  const tableMap = doc.getMap('tables').get('recordings') as Y.Map<string>;
+  const json = tableMap.get(id);
+  return json ? JSON.parse(json) : undefined;
+}
+```
+
+This is deliberately simple. No nested Y.Maps, no field-level tracking.
+
+---
+
+## Migration Strategy: Strong Opinions
+
+### The Golden Rule
+
+> **Additive changes are free. Breaking changes cost an epoch.**
+
+### What's "Additive"?
+
+| Change Type | Additive? | Action Required |
+|-------------|-----------|-----------------|
+| Add nullable field | Yes | Nothing |
+| Add field with default | Yes | Specify default |
+| Add new table | Yes | Nothing |
+| Add new KV key | Yes | Specify default |
+| Rename field | **No** | Epoch bump |
+| Change field type | **No** | Epoch bump |
+| Remove field | **No** | Epoch bump (or soft deprecate) |
+| Make nullable → required | **No** | Epoch bump |
+
+### API for Schema Evolution
+
+```typescript
+const store = defineStore('whispering')
+  // Version 1: Initial schema
+  .schema({
+    tables: {
+      recordings: type({
+        id: 'string',
+        title: 'string',
+        transcript: 'string | null',
+      }),
+    },
+    kv: {
+      theme: type("'light' | 'dark'"),
+    },
+  })
+
+  // Version 2: Add fields (additive — no migration code!)
+  .evolve({
+    tables: {
+      recordings: {
+        // New fields with defaults
+        status: { type: type("'pending' | 'transcribed'"), default: 'pending' },
+        duration: { type: type('number'), default: 0 },
+      },
+    },
+    kv: {
+      // New KV with default
+      language: { type: type("'en' | 'es' | 'fr'"), default: 'en' },
+    },
+  })
+
+  // Version 3: Add computed field
+  .evolve({
+    tables: {
+      recordings: {
+        priority: {
+          type: type('number'),
+          // Compute from existing data when missing
+          default: (row) => row.transcript ? 1 : 0,
+        },
+      },
+    },
+  })
+
+  .build();
+```
+
+### What `.evolve()` Does
+
+1. **Adds new fields** to the schema definition
+2. **Stores defaults** for lazy migration
+3. **Validates** that changes are additive
+4. **Errors** if you try to do something breaking
+
+```typescript
+// This would ERROR at build time:
+.evolve({
+  tables: {
+    recordings: {
+      // ERROR: Cannot change type of existing field 'title'
+      title: { type: type('number') },
+    },
+  },
+})
+```
+
+### Breaking Changes: The Epoch Path
+
+When you need to rename, retype, or restructure:
+
+```typescript
+import { createMigration } from '@epicenter/hq';
+
+// Step 1: Define migration
+const migrationV2 = createMigration({
+  from: store.v1,
+  to: store.v2,
+
+  tables: {
+    recordings: (old) => ({
+      ...old,
+      // Rename: text → title
+      title: old.text,
+      // Type change: string → enum
+      status: old.completed ? 'transcribed' : 'pending',
+    }),
+  },
+});
+
+// Step 2: Run migration (creates new epoch)
+await workspace.migrateToEpoch(migrationV2);
+```
+
+**Important**: Breaking changes create a new Y.Doc. Old clients on old epochs can still read their data. They just won't see new data until they upgrade.
+
+---
+
+## Migration Coordination: The Hard Problem
+
+### The Core Question
+
+> If any peer can trigger a migration, how do we prevent chaos?
+
+Consider this scenario:
+
+```
+Device A: Opens app (code expects v2), sees workspace at v1
+Device A: Starts migrating all rows to v2...
+
+Device B: Opens app (code expects v2), sees workspace at v1
+Device B: Also starts migrating all rows to v2...
+
+Both sync...
+
+What happens?
+```
+
+### Where Is Version Stored?
+
+**Option 1: Workspace Metadata (Single Source of Truth)**
+
+```typescript
+Y.Map('meta')
+  ├── 'name': 'My Workspace'
+  ├── 'schemaVersion': 2        // ← Single version for entire workspace
+  └── 'migratedAt': '2024-01-24T16:30:00Z'
+```
+
+Pros:
+- Clear, single source of truth
+- Easy to check: `if (meta.get('schemaVersion') < targetVersion)`
+
+Cons:
+- Any peer can bump it
+- Race condition window between "check version" and "write data"
+
+**Option 2: Per-Row Version (Distributed)**
+
+```typescript
+// Each row has its own version
+{ "id": "abc", "title": "Hello", "_v": 2 }
+{ "id": "def", "title": "World", "_v": 1 }  // Not yet migrated
+```
+
+Pros:
+- Gradual migration (rows upgrade when touched)
+- No single point of contention
+
+Cons:
+- More complex to reason about
+- "What version is my workspace?" has no clear answer
+- Rows at different versions in same table
+
+**Recommendation**: Workspace-level version in metadata, BUT with safe migration patterns.
+
+### The Dexie Pattern: Read-Transform-Write
+
+Dexie's IndexedDB migration works because:
+1. Only ONE client opens the database at a time
+2. Migrations run before the app starts
+3. Version is stored in IndexedDB metadata
+
+We can't have #1 (multiple peers), but we CAN adapt the pattern:
+
+```typescript
+// On client startup
+async function initWorkspace(store: Store) {
+  const meta = doc.getMap('meta');
+  const currentVersion = meta.get('schemaVersion') ?? 1;
+  const targetVersion = store.version;
+
+  if (currentVersion >= targetVersion) {
+    // Already migrated (by us or another peer)
+    return;
+  }
+
+  // Run migration
+  await runMigration(currentVersion, targetVersion);
+}
+```
+
+### Safe Migration Protocol
+
+**Key insight**: Migrations must be **idempotent** and **deterministic**.
+
+```typescript
+async function runMigration(from: number, to: number) {
+  doc.transact(() => {
+    const meta = doc.getMap('meta');
+    const currentVersion = meta.get('schemaVersion') ?? 1;
+
+    // Double-check inside transaction (another peer might have migrated)
+    if (currentVersion >= to) {
+      return; // Already done
+    }
+
+    // Migrate each table
+    for (const [tableName, tableMap] of doc.getMap('tables').entries()) {
+      for (const [rowId, rowJson] of (tableMap as Y.Map<string>).entries()) {
+        const oldRow = JSON.parse(rowJson);
+        const newRow = migrateRow(tableName, oldRow, from, to);
+
+        // Only write if changed (idempotent)
+        if (JSON.stringify(oldRow) !== JSON.stringify(newRow)) {
+          tableMap.set(rowId, JSON.stringify(newRow));
+        }
+      }
+    }
+
+    // Bump version LAST (after all data migrated)
+    meta.set('schemaVersion', to);
+    meta.set('migratedAt', new Date().toISOString());
+  });
+}
+```
+
+**Why this is safe:**
+
+1. **Check before migrate**: Skip if already at target version
+2. **Transact**: All changes are atomic
+3. **Idempotent transforms**: Same input → same output
+4. **Deterministic**: No random values, no timestamps in data
+5. **Version bumped last**: If migration fails, version stays old
+
+### Race Condition Analysis
+
+```
+Device A: Reads version = 1
+Device B: Reads version = 1
+Device A: Starts migrating row "abc"
+Device B: Starts migrating row "abc"
+Both write: {"id":"abc","title":"Hello","status":"pending","_newField":"default"}
+```
+
+**Result**: Both devices write **identical data** (because migration is deterministic).
+YJS picks one (doesn't matter which). No data corruption.
+
+**The only danger**: Non-deterministic transforms.
+
+```typescript
+// DANGEROUS: Non-deterministic migration
+const newRow = {
+  ...oldRow,
+  migratedAt: new Date(), // Different on each device!
+  randomId: crypto.randomUUID(), // Different on each device!
+};
+
+// SAFE: Deterministic migration
+const newRow = {
+  ...oldRow,
+  status: oldRow.completed ? 'done' : 'pending', // Same logic everywhere
+  priority: 0, // Static default
+};
+```
+
+### When Migrations MUST Be Coordinated
+
+If you need non-deterministic transforms (rare), use **epoch bumps**:
+
+```typescript
+// Epoch migration: Creates entirely new Y.Doc
+// Only the initiating device runs the transform
+// Other devices just switch to the new epoch
+
+await workspace.bumpEpoch({
+  migrate: async (oldDoc, newDoc) => {
+    // This runs on ONE device only
+    for (const row of oldDoc.tables.recordings.getAll()) {
+      newDoc.tables.recordings.upsert({
+        ...row,
+        // Safe to use non-deterministic values here
+        migratedAt: new Date(),
+      });
+    }
+  },
+});
+```
+
+### Migration Timing Options
+
+**Option A: Eager (On App Start)**
+
+```typescript
+// App startup
+await client.ensureMigrated();
+await client.whenReady;
+
+// Now safe to use
+```
+
+Pros: Simple mental model
+Cons: Startup delay, might migrate data user never touches
+
+**Option B: Lazy (On First Access)**
+
+```typescript
+// Migration happens when you first read/write a table
+const recordings = client.tables.recordings; // Triggers migration if needed
+```
+
+Pros: Faster startup, only migrate what's used
+Cons: First operation is slow, harder to predict
+
+**Option C: Hybrid (Metadata Eager, Data Lazy)**
+
+```typescript
+// On startup: Check version, prepare migration plan
+await client.prepareMigration();
+
+// On first table access: Run migration for that table
+const recordings = client.tables.recordings;
+```
+
+**Recommendation**: Option A (Eager) for simplicity. Most apps have small datasets where migration is instant.
+
+### What If Two Peers Have Different Code Versions?
+
+```
+Device A: Running app v2.0 (schema v3)
+Device B: Running app v1.0 (schema v1)
+
+Device A migrates workspace to v3.
+Device B syncs, sees v3 data, but only understands v1 schema.
+```
+
+**Two strategies:**
+
+**Strategy 1: Forward-Compatible Reads (Recommended)**
+
+Device B ignores fields it doesn't understand:
+
+```typescript
+function parseRow(json: string, knownFields: string[]) {
+  const row = JSON.parse(json);
+  // Only extract fields this version knows about
+  return Object.fromEntries(
+    Object.entries(row).filter(([k]) => knownFields.includes(k))
+  );
+}
+```
+
+Device B can still read `id`, `title`. It ignores `newFieldFromV3`.
+
+**Strategy 2: Schema Version Enforcement**
+
+Device B refuses to operate on data newer than it understands:
+
+```typescript
+if (workspaceVersion > MY_MAX_VERSION) {
+  throw new Error('Please update your app to access this workspace');
+}
+```
+
+**Recommendation**: Strategy 1 by default (graceful degradation), Strategy 2 opt-in for critical apps.
+
+### Summary: Migration Safety Rules
+
+| Rule | Why |
+|------|-----|
+| **Migrations must be deterministic** | Same input → same output, regardless of which peer runs it |
+| **Migrations must be idempotent** | Running twice produces same result as running once |
+| **Check version before migrating** | Skip if already done |
+| **Bump version after data** | Failed migration doesn't leave version in bad state |
+| **No timestamps/random in transforms** | Use epoch bump if you need these |
+| **Forward-compatible reads** | Old code ignores new fields |
+
+---
+
+## KV Store: Settings and Singletons
+
+### Use Cases
+
+- User preferences (theme, language)
+- Feature flags
+- App state that isn't per-record
+
+### API
+
+```typescript
+const store = defineStore('whispering', {
+  tables: { /* ... */ },
+  kv: {
+    theme: type("'light' | 'dark'"),
+    language: type("'en' | 'es' | 'fr'"),
+    lastSyncedAt: type('Date | null'),
+    featureFlags: type({
+      newEditor: 'boolean',
+      betaFeatures: 'boolean',
+    }),
+  },
+});
+
+// Usage
+const theme = store.kv.get('theme'); // 'light' | 'dark' | undefined
+store.kv.set('theme', 'dark');
+
+// With defaults
+const themeWithDefault = store.kv.get('theme') ?? 'light';
+
+// Observe changes
+store.kv.observe('theme', (value) => {
+  document.body.classList.toggle('dark', value === 'dark');
+});
+```
+
+### KV vs Tables: When to Use What
+
+| Use Case | KV | Table |
+|----------|----|----|
+| Single value (theme) | Yes | No |
+| User preferences | Yes | No |
+| List of items | No | Yes |
+| Needs querying | No | Yes |
+| Has relationships | No | Yes |
+
+---
+
+## Complete Example: Whispering App
+
+```typescript
+import { type } from 'arktype';
+import { defineStore, createClient } from '@epicenter/hq';
+
+// ============================================
+// SCHEMA DEFINITION
+// ============================================
+
+const Recording = type({
+  id: 'string',
+  title: 'string',
+  transcript: 'string | null',
+  duration: 'number >= 0',
+  status: "'pending' | 'transcribed' | 'failed'",
+  audioPath: 'string | null',
+  createdAt: 'Date',
+  updatedAt: 'Date',
+});
+
+const Transformation = type({
+  id: 'string',
+  name: 'string',
+  prompt: 'string',
+  enabled: 'boolean',
+  order: 'number',
+});
+
+const store = defineStore('whispering')
+  .schema({
+    tables: {
+      recordings: Recording,
+      transformations: Transformation,
+    },
+    kv: {
+      theme: type("'light' | 'dark' | 'system'"),
+      transcriptionModel: type("'whisper-1' | 'whisper-large-v3'"),
+      language: type("'en' | 'es' | 'fr' | 'de' | 'auto'"),
+      autoTranscribe: type('boolean'),
+    },
+  })
+
+  // Evolution: Add recording language detection
+  .evolve({
+    tables: {
+      recordings: {
+        detectedLanguage: { type: type('string | null'), default: null },
+      },
+    },
+  })
+
+  // Evolution: Add transformation categories
+  .evolve({
+    tables: {
+      transformations: {
+        category: { type: type("'formatting' | 'translation' | 'custom'"), default: 'custom' },
+      },
+    },
+    kv: {
+      showCategories: { type: type('boolean'), default: false },
+    },
+  })
+
+  .build();
+
+// ============================================
+// USAGE
+// ============================================
+
+// Create client
+const client = createClient(store, {
+  providers: {
+    indexeddb: true,
+    // sync: 'wss://sync.epicenter.so/whispering',
+  },
+});
+
+// Wait for local data to load
+await client.whenReady;
+
+// Tables API
+const recordings = client.tables.recordings;
+
+// Create
+recordings.create({
+  id: crypto.randomUUID(),
+  title: 'Meeting Notes',
+  transcript: null,
+  duration: 0,
+  status: 'pending',
+  audioPath: '/recordings/meeting.webm',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  detectedLanguage: null, // From evolution
+});
+
+// Read
+const recording = recordings.get({ id: 'abc123' });
+if (recording.status === 'valid') {
+  console.log(recording.row.title);
+}
+
+// Update (patches only changed fields — cell-level LWW safe)
+recordings.update({
+  id: 'abc123',
+  status: 'transcribed',
+  transcript: 'Hello, world...',
+  updatedAt: new Date(),
+});
+
+// Query all
+const allRecordings = recordings.getAll();
+const pendingCount = allRecordings.filter(r => r.status === 'pending').length;
+
+// Observe changes
+recordings.observe((changedIds) => {
+  console.log('Recordings changed:', changedIds);
+});
+
+// KV API
+const theme = client.kv.get('theme') ?? 'system';
+client.kv.set('autoTranscribe', true);
+
+client.kv.observe('theme', (newTheme) => {
+  applyTheme(newTheme);
+});
+```
+
+---
+
+## Type Inference Deep Dive
+
+### From Schema to TypeScript Types
+
+```typescript
+const store = defineStore('app', {
+  tables: {
+    recordings: type({
+      id: 'string',
+      title: 'string',
+      duration: 'number',
+    }),
+  },
+  kv: {
+    theme: type("'light' | 'dark'"),
+  },
+});
+
+// Inferred types
+type Store = typeof store;
+
+// Table row type
+type RecordingRow = Store['tables']['recordings']['Row'];
+// { id: string; title: string; duration: number }
+
+// KV value types
+type Theme = Store['kv']['theme']['Value'];
+// 'light' | 'dark'
+
+// Full store type (for passing around)
+type AppStore = typeof store;
+```
+
+### Why This Matters
+
+1. **No duplicate type definitions** — the schema IS the type
+2. **Autocomplete everywhere** — IDE knows your fields
+3. **Refactor safety** — rename a field, see all usages
+
+---
+
+## Migration Internals (Implementation Notes)
+
+### How Read-Time Migration Works
+
+When reading a row, we apply schema defaults **in memory only**:
+
+```typescript
+// Internal: what happens on read
+function getRow(id: string): Recording {
+  const tableMap = doc.getMap('tables').get('recordings') as Y.Map<string>;
+  const json = tableMap.get(id);
+  if (!json) return undefined;
+
+  const raw = JSON.parse(json);
+
+  // Apply defaults for missing fields (from .evolve() definitions)
+  for (const [field, config] of store.evolutions) {
+    if (!(field in raw)) {
+      raw[field] = typeof config.default === 'function'
+        ? config.default(raw)
+        : config.default;
+    }
+  }
+
+  // Validate against current schema
+  const validated = store.schema.recordings(raw);
+  if (validated instanceof type.errors) {
+    return { status: 'invalid', errors: validated };
+  }
+
+  return { status: 'valid', row: validated };
+}
+```
+
+**Key point**: The Y.Doc is NOT modified during reads. Old data stays old until explicitly written.
+
+### When Data Gets Persisted with New Fields
+
+**Option A: On User Edit**
+
+When a user edits any field, we persist the full migrated row:
+
+```typescript
+function update(id: string, changes: Partial<Recording>) {
+  doc.transact(() => {
+    const tableMap = doc.getMap('tables').get('recordings') as Y.Map<string>;
+
+    // Read current row (with in-memory defaults applied)
+    const current = getRow(id);
+    if (current.status !== 'valid') {
+      throw new Error('Cannot update invalid row');
+    }
+
+    // Merge changes
+    const updated = { ...current.row, ...changes };
+
+    // Write full row (now includes any new fields)
+    tableMap.set(id, JSON.stringify(updated));
+  });
+}
+```
+
+**Option B: Explicit Migration (Batch)**
+
+Developer explicitly migrates all data:
+
+```typescript
+await client.migrateAllRows();
+
+// Internal implementation
+function migrateAllRows() {
+  doc.transact(() => {
+    for (const [tableName, tableMap] of doc.getMap('tables').entries()) {
+      for (const [rowId, rowJson] of (tableMap as Y.Map<string>).entries()) {
+        const migrated = applyMigrations(tableName, JSON.parse(rowJson));
+        const newJson = JSON.stringify(migrated);
+
+        // Only write if actually changed
+        if (rowJson !== newJson) {
+          tableMap.set(rowId, newJson);
+        }
+      }
+    }
+  });
+}
+```
+
+### Preventing Double-Migration Data Corruption
+
+**The Danger:**
+
+```
+Device A: Sees old data, runs migration, writes transformed rows
+Device B: Sees old data, runs migration, writes transformed rows
+Both sync...
+
+If transforms are deterministic: Both write same data. Safe.
+If transforms are NOT deterministic: Data diverges. One version lost.
+```
+
+**Protection Layer 1: Workspace Version Check**
+
+```typescript
+function migrateIfNeeded() {
+  const meta = doc.getMap('meta');
+  const currentVersion = meta.get('schemaVersion') ?? 1;
+
+  if (currentVersion >= store.targetVersion) {
+    // Another peer already migrated. Nothing to do.
+    return;
+  }
+
+  // Proceed with migration...
+}
+```
+
+**Protection Layer 2: Content-Based Skip**
+
+```typescript
+function migrateRow(tableName: string, oldRow: any): any {
+  const newRow = applyTransforms(oldRow);
+
+  // If nothing changed, return original (won't trigger write)
+  if (JSON.stringify(oldRow) === JSON.stringify(newRow)) {
+    return oldRow;
+  }
+
+  return newRow;
+}
+```
+
+**Protection Layer 3: Deterministic-Only Transforms**
+
+The `.evolve()` API only allows defaults, not arbitrary transforms:
+
+```typescript
+// This is ALLOWED (deterministic)
+.evolve({
+  tables: {
+    recordings: {
+      status: { type: type("'pending' | 'done'"), default: 'pending' },
+    },
+  },
+})
+
+// This would be REJECTED (non-deterministic)
+.evolve({
+  tables: {
+    recordings: {
+      migratedAt: { type: type('Date'), default: () => new Date() }, // ERROR!
+    },
+  },
+})
+```
+
+For non-deterministic transforms, use epoch bumps (separate Y.Doc, no race condition).
+
+---
+
+## Decisions Made
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| **LWW granularity** | Row-level | Simpler (2 levels), good enough for single-user/low-collab |
+| **Storage format** | JSON string per row | Easy serialize/deserialize, schema-agnostic |
+| **Schema library** | ArkType (Standard Schema compat) | Clean syntax, good inference, industry standard |
+| **Version storage** | Workspace metadata | Single source of truth, easy to check |
+| **Migration trigger** | Any peer can initiate | Must be deterministic to be safe |
+
+---
+
+## Open Questions
+
+### 1. Should computed defaults be allowed?
+
+```typescript
+.evolve({
+  tables: {
+    recordings: {
+      // Is this okay? It's deterministic (same row → same result)
+      priority: { type: type('number'), default: (row) => row.transcript ? 1 : 0 },
+    },
+  },
+})
+```
+
+**Concern**: Even deterministic computed defaults could cause issues if the input row is in an unexpected state.
+
+**Leaning**: Allow, but document that function must be pure (no side effects, no external state).
+
+### 2. How to handle failed partial migrations?
+
+```
+Device A starts migrating 1000 rows.
+After 500 rows, connection drops.
+Device A comes back online.
+```
+
+**Options**:
+- A: Re-run migration from scratch (idempotent, so safe)
+- B: Track progress per-row with `_migrated` flag
+- C: Use version per-row instead of per-workspace
+
+**Leaning**: Option A. For most apps, re-running is instant. For huge datasets, we can add progress tracking later.
+
+### 3. Should old app versions be blocked or degraded?
+
+When Device B (old code) encounters data from Device A (new code):
+
+**Option A: Graceful degradation**
+```typescript
+// Old code just ignores fields it doesn't know
+const { id, title } = JSON.parse(rowJson);
+// `newFieldFromV3` is silently dropped
+```
+
+**Option B: Block with upgrade prompt**
+```typescript
+if (workspaceVersion > MAX_SUPPORTED_VERSION) {
+  throw new Error('Please update to continue');
+}
+```
+
+**Leaning**: Option A by default. Let developers opt into Option B.
+
+### 4. What about arrays in rows?
+
+```typescript
+const Playlist = type({
+  id: 'string',
+  name: 'string',
+  trackIds: 'string[]', // Row-level LWW means concurrent edits to array are lost
+});
+```
+
+**Options**:
+- A: Accept it (arrays are LWW, last write wins)
+- B: Normalize to separate table (`playlist_tracks` with `playlistId`, `trackId`, `order`)
+- C: Expose Y.Array for this field (leaks CRDT complexity)
+
+**Leaning**: Option A for simple cases, document Option B as best practice for frequently-edited lists.
+
+### 5. Should there be a cell-level mode for high-collaboration?
+
+```typescript
+// Opt-in per table?
+const store = defineStore('collab-notes', {
+  tables: {
+    notes: {
+      schema: NoteSchema,
+      conflictMode: 'cell', // Use Y.Map per field instead of JSON string
+    },
+  },
+});
+```
+
+**Concern**: Two storage modes = two code paths = complexity.
+
+**Leaning**: Defer. Start with row-level only. Add cell-level if users request it.
+
+### 6. Rich text handling?
+
+Current approach: Separate Y.Doc per rich text field, referenced by ID.
+
+**Question**: Should this be exposed in the schema API?
+
+```typescript
+const Note = type({
+  id: 'string',
+  title: 'string',
+  content: 'richtext', // Magic type that creates separate Y.Doc
+});
+
+// Usage
+const content = client.richtext.get(note.content); // Returns Y.XmlFragment
+```
+
+**Leaning**: Yes, but as a separate API. Rich text is fundamentally different (collaborative editing within a field).
+
+---
+
+## Success Criteria
+
+- [ ] Developer can define a schema in < 5 minutes
+- [ ] Schema changes for 90% of use cases require no migration code
+- [ ] Breaking changes have a clear, documented path
+- [ ] TypeScript autocomplete works everywhere
+- [ ] No CRDT concepts leak into the API (unless developer opts in)
+- [ ] Existing ArkType/Zod users feel at home
+
+---
+
+## Next Steps
+
+1. **Prototype** the `defineStore` API with ArkType
+2. **Test** type inference with complex schemas
+3. **Benchmark** validation performance
+4. **Document** the migration decision tree
+5. **Implement** Standard Schema adapter
+
+---
+
+## Related Documents
+
+- `specs/20260124T125300-workspace-schema-versioning.md` — Workspace-level versioning details
+- `specs/20260124T004528-versioned-table-api-design.md` — YJS conflict analysis
+- `packages/epicenter/src/core/schema/fields/types.ts` — Current field system
+
+---
+
+## Changelog
+
+- 2026-01-24: Initial draft focusing on DX with ArkType-native schemas

--- a/specs/20260124T180000-static-schema-library-architecture.md
+++ b/specs/20260124T180000-static-schema-library-architecture.md
@@ -1,0 +1,521 @@
+# Static Schema Library Architecture
+
+> **📝 NOTE**: This spec should be read alongside [`specs/20260124T162638-stable-id-schema-pattern.md`](./20260124T162638-stable-id-schema-pattern.md) which introduces stable internal IDs for fields. The stable ID pattern simplifies the migration story further: instead of lazy ArkType pipe migrations, fields have permanent internal IDs and invalid data simply returns defaults.
+
+---
+
+**Date**: 2026-01-24
+**Status**: Draft
+**Author**: Braden + Claude
+
+## Overview
+
+This spec describes the architecture for `@epicenter/static`, a developer-focused library for building local-first apps with statically-defined TypeScript schemas. This is a separate package from the dynamic/user-editable schema system.
+
+## Goals
+
+1. **TypeScript-first DX**: Schemas defined in code, full type inference
+2. **Lazy migrations**: Schema changes migrate data transparently on read
+3. **Row-level sync**: YJS-backed synchronization at the row level
+4. **Simplicity**: No Y.Doc definition storage, no epoch system for most use cases
+5. **GC-enabled**: Smaller docs, no revision history requirement
+
+## Non-Goals
+
+- User-editable schemas at runtime (that's the dynamic library)
+- Full revision/undo history (requires GC disabled)
+- Epoch-based data compaction (may add later as opt-in)
+
+---
+
+## Architecture Comparison
+
+| Aspect | Current Epicenter | @epicenter/static |
+|--------|-------------------|-------------------|
+| Schema storage | In Y.Doc `definition` map | TypeScript only (no Y.Doc) |
+| Schema introspection | Runtime via Y.Doc | Compile-time via types |
+| Migration strategy | Hybrid (lazy + epoch) | Lazy only (ArkType pipes) |
+| Y.Doc structure | `definition`, `kv`, `tables` | `kv`, `tables` only |
+| Garbage collection | Disabled (revision history) | Enabled (smaller docs) |
+| Epoch system | Required for breaking changes | Not needed |
+
+---
+
+## Schema Definition API
+
+### Table Definition
+
+```typescript
+import { defineTable, text, select, integer, timestamp } from '@epicenter/static';
+
+const recordings = defineTable('recordings', {
+  // Required fields (non-nullable by default)
+  id: text(),
+  title: text(),
+
+  // Optional fields
+  subtitle: text({ nullable: true }),
+
+  // Fields with defaults
+  status: select(['pending', 'completed'], { default: 'pending' }),
+  views: integer({ default: 0 }),
+
+  // Timestamps
+  createdAt: timestamp({ default: 'now' }),
+  updatedAt: timestamp({ default: 'now' }),
+});
+
+// Inferred type:
+type Recording = {
+  id: string;
+  title: string;
+  subtitle: string | null;
+  status: 'pending' | 'completed';
+  views: number;
+  createdAt: string;
+  updatedAt: string;
+};
+```
+
+### Workspace Definition
+
+```typescript
+import { defineWorkspace } from '@epicenter/static';
+import { recordings, transformations } from './tables';
+
+const workspace = defineWorkspace({
+  id: 'epicenter.whispering',
+  tables: { recordings, transformations },
+  kv: {
+    theme: { type: 'select', options: ['light', 'dark'], default: 'dark' },
+    autoSave: { type: 'boolean', default: true },
+  },
+});
+
+export type Workspace = typeof workspace;
+```
+
+---
+
+## Migration Strategy: Lazy On-Read
+
+### Core Principle
+
+Schema changes are **code changes**. When you add a field with a default, old rows automatically get that default when read. No migration scripts, no epoch bumps, no coordination.
+
+### How It Works
+
+```typescript
+// Version 1: Initial schema
+const recordings = defineTable('recordings', {
+  id: text(),
+  title: text(),
+});
+
+// Version 2: Add field with default
+const recordings = defineTable('recordings', {
+  id: text(),
+  title: text(),
+  status: select(['pending', 'completed'], { default: 'pending' }), // NEW
+});
+
+// Old row in Y.Doc: { id: '123', title: 'Hello' }
+// When read: { id: '123', title: 'Hello', status: 'pending' }  ← default applied
+```
+
+### Migration With Computed Defaults
+
+For migrations that need to compute values from existing data:
+
+```typescript
+const recordings = defineTable('recordings', {
+  id: text(),
+  title: text(),
+  transcript: text({ nullable: true }),
+
+  // NEW: Computed from existing data
+  hasTranscript: boolean({
+    default: false,
+    migrateFrom: (row) => row.transcript !== null,
+  }),
+});
+```
+
+**Behavior:**
+1. Read row from Y.Doc
+2. If `hasTranscript` missing, run `migrateFrom(row)`
+3. Return row with computed value
+4. Optionally persist on next write
+
+### What's Supported (Lazy)
+
+| Change | Supported | Notes |
+|--------|-----------|-------|
+| Add nullable field | ✅ | Returns `null` for old rows |
+| Add field with default | ✅ | Returns default for old rows |
+| Add field with migrateFrom | ✅ | Computes from row data |
+| Change default value | ✅ | Only affects new rows |
+| Add select option | ✅ | Non-breaking |
+
+### What Requires Manual Migration
+
+| Change | Reason | Solution |
+|--------|--------|----------|
+| Rename field | Can't auto-detect | Migration script |
+| Change field type | Type mismatch | Migration script |
+| Remove field | Data loss | Migration script (opt-in) |
+| Remove select option | Invalid values | Requires validation |
+
+---
+
+## Y.Doc Structure
+
+### Current Epicenter
+
+```
+Y.Doc
+├── Y.Map('definition')  ← Schema storage
+├── Y.Map('kv')          ← Settings
+└── Y.Map('tables')      ← Data
+    └── {tableName}: Y.Map
+        └── {rowId}: Y.Map
+            └── {column}: value
+```
+
+### @epicenter/static
+
+```
+Y.Doc
+├── Y.Map('kv')          ← Settings
+└── Y.Map('tables')      ← Data
+    └── {tableName}: Y.Map
+        └── {rowId}: Y.Map
+            └── {column}: value
+```
+
+**Key difference**: No `definition` map. Schema lives in TypeScript code.
+
+---
+
+## Read/Write Patterns
+
+### Reading Data
+
+```typescript
+const client = await workspace.create();
+
+// Get all recordings (lazy migration applied)
+const recordings = client.tables.recordings.getAll();
+
+// Get by ID
+const recording = client.tables.recordings.get('123');
+
+// Query (if supported)
+const pending = client.tables.recordings.where({ status: 'pending' });
+```
+
+### Writing Data
+
+```typescript
+// Insert
+client.tables.recordings.insert({
+  id: '123',
+  title: 'New Recording',
+  // status defaults to 'pending'
+});
+
+// Update (patch-based, safe for concurrent edits)
+client.tables.recordings.update('123', {
+  title: 'Updated Title',
+  // Only touches 'title' cell, not entire row
+});
+
+// Upsert
+client.tables.recordings.upsert({
+  id: '123',
+  title: 'Upserted',
+});
+
+// Delete
+client.tables.recordings.delete('123');
+```
+
+### Observing Changes
+
+```typescript
+// Subscribe to table changes
+client.tables.recordings.observe((event) => {
+  console.log('Changed rows:', event.changes);
+});
+
+// Subscribe to specific row
+client.tables.recordings.observeRow('123', (row) => {
+  console.log('Row updated:', row);
+});
+```
+
+---
+
+## Synchronization
+
+### Provider-Agnostic
+
+The library works with any YJS sync provider:
+
+```typescript
+import { WebsocketProvider } from 'y-websocket';
+import { IndexeddbPersistence } from 'y-indexeddb';
+
+const client = await workspace.create({
+  extensions: {
+    websocket: (ctx) => new WebsocketProvider(url, ctx.ydoc.guid, ctx.ydoc),
+    persistence: (ctx) => new IndexeddbPersistence(ctx.ydoc.guid, ctx.ydoc),
+  },
+});
+```
+
+### Doc ID Format
+
+Simple workspace-based IDs (no epoch):
+
+```
+Local: {workspaceId}
+Cloud: {orgId}:{workspaceId}
+```
+
+Examples:
+- `epicenter.whispering` (local)
+- `org_abc123:epicenter.whispering` (cloud)
+
+### Garbage Collection
+
+**GC Enabled by Default**
+
+```typescript
+const ydoc = new Y.Doc({ guid: docId, gc: true });
+```
+
+This means:
+- Smaller doc sizes (tombstones cleaned up)
+- No revision history (can't snapshot past states)
+- Simpler mental model
+
+---
+
+## KV Store
+
+For app-level settings that aren't row-based:
+
+```typescript
+// Read
+const theme = client.kv.theme.get(); // 'light' | 'dark'
+
+// Write
+client.kv.theme.set('dark');
+
+// Observe
+client.kv.theme.observe((value) => {
+  console.log('Theme changed:', value);
+});
+```
+
+### KV Migrations
+
+```typescript
+const workspace = defineWorkspace({
+  kv: {
+    // V1: Simple theme
+    theme: { type: 'select', options: ['light', 'dark'], default: 'dark' },
+
+    // V2: Add new setting with since version
+    fontSize: {
+      type: 'integer',
+      default: 14,
+      since: 2,  // Only read from version 2+
+    },
+  },
+});
+```
+
+---
+
+## Validation
+
+### Read-Time Validation
+
+Validation happens when reading from Y.Doc:
+
+```typescript
+const recordings = client.tables.recordings.getAll();
+// Returns Recording[] (validated)
+
+const recording = client.tables.recordings.get('123');
+// Returns Recording | null (validated or null if invalid)
+
+// Access raw (unvalidated) data
+const raw = client.tables.recordings.getRaw('123');
+// Returns unknown (no validation)
+```
+
+### Write-Time Validation
+
+Validation happens before writing:
+
+```typescript
+client.tables.recordings.insert({
+  id: '123',
+  title: 'Hello',
+  status: 'invalid', // TypeScript error + runtime validation error
+});
+```
+
+### Handling Invalid Data
+
+```typescript
+// Skip invalid rows (default)
+const valid = client.tables.recordings.getAllValid();
+
+// Get all with validation results
+const results = client.tables.recordings.getAllWithErrors();
+// [{ data: Recording, error: null }, { data: null, error: ValidationError }]
+```
+
+---
+
+## TODO: Open Questions
+
+### 1. Version Tracking
+
+Do we need to track schema version anywhere?
+
+**Option A**: No version tracking
+- Schema is always "latest" (code is source of truth)
+- Old data just gets defaults applied
+- Simplest approach
+
+**Option B**: Version in Y.Doc metadata
+- Store `{ schemaVersion: 2 }` in a metadata map
+- Enables detecting "this data is from a future version"
+- Useful for forward compatibility warnings
+
+**Recommendation**: Start with Option A, add version tracking if needed.
+
+### 2. Breaking Changes
+
+How do we handle truly breaking changes (field rename, type change)?
+
+**Option A**: Manual migration scripts
+- Developer writes a one-time script
+- Reads old data, writes new data
+- Simple but requires coordination
+
+**Option B**: Declarative migrations
+- Define renames in schema: `title: text({ renamedFrom: 'name' })`
+- Library handles the migration
+- More magic but less boilerplate
+
+**Recommendation**: Start with Option A (manual scripts), consider Option B later.
+
+### 3. Schema Diffing
+
+Should the library detect schema changes?
+
+**Option A**: No detection
+- Developer knows what changed
+- No runtime overhead
+
+**Option B**: Runtime diffing
+- Compare schema to last-known schema
+- Warn on breaking changes
+- Store schema hash in localStorage
+
+**Recommendation**: Start with Option A, add diffing as debug tool.
+
+### 4. Multi-Device Schema Mismatch
+
+What happens when Device A has schema v2 and Device B has schema v1?
+
+**Scenario**:
+1. Device A adds field `priority: integer({ default: 0 })`
+2. Device A creates row with `priority: 5`
+3. Device B (still v1) syncs the row
+4. Device B doesn't know about `priority` field
+
+**Option A**: Forward-compatible by default
+- Device B preserves unknown fields in Y.Doc
+- Device B's reads just don't see `priority`
+- When Device B updates, only touch known fields (patch-based)
+- `priority: 5` survives the round-trip
+
+**Option B**: Strict mode
+- Device B rejects unknown fields
+- Forces all devices to upgrade together
+- Safer but less flexible
+
+**Recommendation**: Option A (forward-compatible) with opt-in strict mode.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Core Schema System
+- [ ] Field factory functions (`text()`, `select()`, `integer()`, etc.)
+- [ ] `defineTable()` with type inference
+- [ ] `defineWorkspace()` with tables and KV
+- [ ] ArkType integration for validation
+
+### Phase 2: Y.Doc Integration
+- [ ] `workspace.create()` factory
+- [ ] Table CRUD operations (insert, update, delete, get, getAll)
+- [ ] KV operations (get, set)
+- [ ] Observation (observe table, observe row, observe KV)
+
+### Phase 3: Migration System
+- [ ] Lazy defaults (apply on read)
+- [ ] `migrateFrom` computed defaults
+- [ ] Patch-based writes (forward-compatible)
+- [ ] Unknown field preservation
+
+### Phase 4: Sync Integration
+- [ ] Extension system for providers
+- [ ] GC-enabled docs
+- [ ] Doc ID format (local vs cloud)
+- [ ] Multi-device testing
+
+### Phase 5: Developer Experience
+- [ ] Error messages for schema mismatches
+- [ ] Debug mode for migration tracking
+- [ ] Typed client generation (if needed)
+
+---
+
+## Relationship to Existing Code
+
+### What to Keep
+
+- Field type definitions (`/packages/epicenter/src/core/schema/fields/types.ts`)
+- ArkType converters (`/packages/epicenter/src/core/schema/converters/`)
+- Table helper patterns (`/packages/epicenter/src/core/tables/`)
+- Extension system concept
+
+### What to Change
+
+- Remove `definition` Y.Map storage
+- Remove epoch system (for this library)
+- Enable GC by default
+- Simplify doc ID format
+
+### What to Add
+
+- `migrateFrom` computed defaults
+- Forward-compatible unknown field handling
+- Simpler `workspace.create()` API
+
+---
+
+## References
+
+- `/specs/20260124T125300-workspace-schema-versioning.md` - Previous versioning proposal
+- `/specs/20260116T082500-schema-migration-patterns.md` - Migration strategy research
+- `/docs/articles/yjs-ymap-is-not-a-hashmap.md` - YJS internals
+- `/packages/epicenter/src/core/schema/README.md` - Current schema docs

--- a/specs/20260125T120000-versioned-table-kv-specification.md
+++ b/specs/20260125T120000-versioned-table-kv-specification.md
@@ -1,0 +1,652 @@
+# Versioned Table and KV Specification
+
+## Overview
+
+This specification defines APIs for versioned data storage in local-first applications, enabling schema evolution without traditional migrations. Data is validated against a union of all schema versions on read, then migrated to the latest version.
+
+---
+
+## Core Concepts
+
+### Why This Works: Granularity Match
+
+This versioning pattern is possible because **the granularity of the schema matches the granularity of writes**:
+
+- **Tables**: We do row-level edits, not cell-level edits. The entire row is written atomically, so the entire row can have a coherent schema version.
+- **KV**: Each value is written atomically, so each value can have its own schema version.
+
+If we had cell-level edits (like the current `table-helper.ts`), versioned schemas wouldn't work because different cells could be at different versions after concurrent edits.
+
+### Migrate-on-Read Pattern
+
+1. Store data as atomic JSON blobs (last-write-wins)
+2. On read, validate against union of all registered schemas
+3. Run user-provided migration function to normalize to latest version
+4. Return strongly-typed latest version to caller
+5. **Reads are pure** - we do NOT write migrated data back automatically
+
+### User-Defined Discriminator (Highly Recommended)
+
+While the library does NOT require a version field, **it is highly recommended** that users include one. Both patterns work, but explicit versioning is cleaner and less error-prone.
+
+#### Pattern 1: With Discriminator (Recommended)
+
+```typescript
+const posts = defineTable('posts')
+  .version(type({ id: 'string', title: 'string', _v: '"1"' }))
+  .version(type({ id: 'string', title: 'string', views: 'number', _v: '"2"' }))
+  .version(type({ id: 'string', title: 'string', views: 'number', author: 'string | null', _v: '"3"' }))
+  .migrate((row) => {
+    // Clean switch statement - easy to read and maintain
+    switch (row._v) {
+      case '1':
+        return { ...row, views: 0, author: null, _v: '3' as const };
+      case '2':
+        return { ...row, author: null, _v: '3' as const };
+      case '3':
+        return row;
+    }
+  });
+```
+
+**Why this is preferred:**
+- Clear and explicit versioning
+- Simple switch/if statements in migration
+- Easy to understand which version you're dealing with
+- Works well with TypeScript discriminated unions
+- Less fragile than checking field presence
+
+#### Pattern 2: Without Discriminator (Works but Not Recommended)
+
+```typescript
+const posts = defineTable('posts')
+  .version(type({ id: 'string', title: 'string' }))
+  .version(type({ id: 'string', title: 'string', views: 'number' }))
+  .version(type({ id: 'string', title: 'string', views: 'number', author: 'string | null' }))
+  .migrate((row) => {
+    // Check for field presence - works but can be fragile
+    let current = row;
+
+    if (!('views' in current)) {
+      current = { ...current, views: 0 };
+    }
+    if (!('author' in current)) {
+      current = { ...current, author: null };
+    }
+
+    return current;
+  });
+```
+
+**Why this is less ideal:**
+- Fragile if fields are optional or can be undefined
+- Harder to reason about which version you're handling
+- No TypeScript discriminated union support
+- Can break if you remove a field in a later version
+
+**Both patterns are fully supported**, but Pattern 1 is the recommended approach for production use.
+
+### Standard Schema Union
+
+Internally, schemas are combined into a Standard Schema union:
+
+```typescript
+function createUnionStandardSchema<TSchemas extends StandardSchemaV1[]>(
+  schemas: TSchemas
+): StandardSchemaV1 {
+  return {
+    '~standard': {
+      version: 1,
+      vendor: 'epicenter',
+      validate: (value) => {
+        for (const schema of schemas) {
+          const result = schema['~standard'].validate(value);
+          if (!result.issues) return result;
+        }
+        return { issues: [{ message: 'No schema version matched' }] };
+      }
+    }
+  };
+}
+```
+
+This works with any Standard Schema-compatible library (Zod, ArkType, TypeBox, Valibot).
+
+---
+
+## Table API
+
+### Storage Architecture
+
+```
+Y.Doc (gc: true)
+└── tables (Y.Map<tableName, YKeyValue>)
+     └── posts (YKeyValue<{ key: string, val: Row }>)
+          ├── { key: "row-1", val: { id: "row-1", title: "Hello", views: 42 } }
+          └── { key: "row-2", val: { id: "row-2", title: "World", views: 100 } }
+```
+
+- **YKeyValue** provides bounded memory (vs Y.Map's unbounded growth)
+- Rows are atomic JSON blobs (last-write-wins on entire row)
+- Enables schema evolution since entire row is replaced together
+
+See benchmark: `packages/epicenter/scripts/ymap-vs-ykeyvalue-benchmark.ts`
+
+### API: defineTable
+
+```typescript
+import { defineTable, createTables } from 'epicenter';
+import { type } from 'arktype';  // or zod, typebox, valibot
+
+// Define table with schema versions
+const postsDefinition = defineTable('posts')
+  .version(type({ id: 'string', title: 'string' }))
+  .version(type({ id: 'string', title: 'string', views: 'number' }))
+  .version(type({ id: 'string', title: 'string', views: 'number', author: 'string | null' }))
+  .migrate((row) => {
+    // row is V1 | V2 | V3, must return V3
+    if (!('views' in row)) {
+      return { ...row, views: 0, author: null };
+    }
+    if (!('author' in row)) {
+      return { ...row, author: null };
+    }
+    return row;
+  });
+
+// Bind to Y.Doc
+const tables = createTables(ydoc, {
+  posts: postsDefinition,
+  users: usersDefinition,
+});
+
+// Usage
+tables.posts.upsert({ id: 'post-1', title: 'Hello', views: 0, author: null });
+const post = tables.posts.get('post-1');  // Validated + migrated
+```
+
+### Type Signature
+
+```typescript
+function defineTable(name: string): TableBuilder<[], never>;
+
+type TableBuilder<TVersions extends StandardSchemaV1[], TLatest> = {
+  version<TSchema extends StandardSchemaV1>(
+    schema: TSchema
+  ): TableBuilder<[...TVersions, TSchema], StandardSchemaV1.InferOutput<TSchema>>;
+
+  migrate(
+    fn: (row: StandardSchemaV1.InferOutput<TVersions[number]>) => TLatest
+  ): TableDefinition<TLatest>;
+};
+
+type TableDefinition<TRow> = {
+  readonly name: string;
+  readonly versions: readonly StandardSchemaV1[];
+  readonly unionSchema: StandardSchemaV1;
+  readonly migrate: (row: unknown) => TRow;
+};
+```
+
+### Single Version (No Migration Needed)
+
+```typescript
+// When there's only one version, migrate just returns the row
+const simpleTable = defineTable('simple')
+  .version(type({ id: 'string', name: 'string' }))
+  .migrate((row) => row);
+```
+
+### Table Helper Methods
+
+```typescript
+type TableHelper<TRow> = {
+  // Read (validates + migrates)
+  get(id: string): GetResult<TRow>;
+  getAll(): RowResult<TRow>[];
+  getAllValid(): TRow[];
+  filter(predicate: (row: TRow) => boolean): TRow[];
+  find(predicate: (row: TRow) => boolean): TRow | null;
+
+  // Write (always writes latest schema shape)
+  upsert(row: TRow): void;
+  upsertMany(rows: TRow[]): void;
+
+  // Delete
+  delete(id: string): DeleteResult;
+  deleteMany(ids: string[]): DeleteManyResult;
+  clear(): void;
+
+  // Observe
+  observe(callback: (changedIds: Set<string>, transaction: Y.Transaction) => void): () => void;
+
+  // Metadata
+  count(): number;
+  has(id: string): boolean;
+};
+```
+
+---
+
+## KV API
+
+### Storage Architecture
+
+```
+Y.Doc (gc: true)
+└── kv (YKeyValue<{ key: string, val: JSON }>)
+     ├── { key: "theme", val: { value: "dark", fontSize: 14 } }
+     ├── { key: "sidebar", val: { collapsed: false, width: 250 } }
+     └── { key: "user", val: { name: "Alice", avatar: null } }
+```
+
+- **YKeyValue** for KV (consistent with tables, bounded memory)
+- Each key's value is an atomic JSON blob
+- Different keys can have different schema evolution paths
+
+#### Why YKeyValue over Y.Map?
+
+Benchmarks show Y.Map has unbounded memory growth with frequent updates:
+
+| Updates/Key | Y.Map Size | YKeyValue Size | Ratio |
+|-------------|------------|----------------|-------|
+| 1 | 194 B | 225 B | Similar |
+| 10 | 562 B | 241 B | Y.Map 2.3x larger |
+| 100 | 4.43 KB | 254 B | Y.Map 18x larger |
+| 1000 | 44 KB | 259 B | Y.Map 174x larger |
+
+For consistency with tables and bounded memory, we use YKeyValue for both.
+
+### API: defineKV
+
+```typescript
+import { defineKV, createKV } from 'epicenter';
+import { type } from 'arktype';
+
+// Define KV keys with schema versions
+const themeDefinition = defineKV('theme')
+  .version(type({ value: "'light' | 'dark'" }))
+  .version(type({ value: "'light' | 'dark' | 'system'", fontSize: 'number' }))
+  .migrate((v) => {
+    if (!('fontSize' in v)) {
+      return { ...v, fontSize: 14 };
+    }
+    return v;
+  });
+
+const sidebarDefinition = defineKV('sidebar')
+  .version(type({ collapsed: 'boolean' }))
+  .version(type({ collapsed: 'boolean', width: 'number' }))
+  .migrate((v) => {
+    if (!('width' in v)) {
+      return { ...v, width: 250 };
+    }
+    return v;
+  });
+
+// Bind to Y.Doc
+const kv = createKV(ydoc, {
+  theme: themeDefinition,
+  sidebar: sidebarDefinition,
+});
+
+// Usage
+kv.theme.set({ value: 'dark', fontSize: 16 });
+const theme = kv.theme.get();  // Validated + migrated
+```
+
+### Type Signature
+
+```typescript
+function defineKV(key: string): KVBuilder<[], never>;
+
+type KVBuilder<TVersions extends StandardSchemaV1[], TLatest> = {
+  version<TSchema extends StandardSchemaV1>(
+    schema: TSchema
+  ): KVBuilder<[...TVersions, TSchema], StandardSchemaV1.InferOutput<TSchema>>;
+
+  migrate(
+    fn: (value: StandardSchemaV1.InferOutput<TVersions[number]>) => TLatest
+  ): KVDefinition<TLatest>;
+};
+
+type KVDefinition<TValue> = {
+  readonly key: string;
+  readonly versions: readonly StandardSchemaV1[];
+  readonly unionSchema: StandardSchemaV1;
+  readonly migrate: (value: unknown) => TValue;
+};
+```
+
+### KV Helper Methods
+
+```typescript
+type KVHelper<TValue> = {
+  // Read (validates + migrates)
+  get(): KVGetResult<TValue>;
+
+  // Write (always writes latest schema shape)
+  set(value: TValue): void;
+
+  // Reset to default (if defined) or delete
+  reset(): void;
+
+  // Observe
+  observe(callback: (change: KVChange<TValue>, transaction: Y.Transaction) => void): () => void;
+};
+
+type KVGetResult<TValue> =
+  | { status: 'valid'; value: TValue }
+  | { status: 'invalid'; key: string; error: KVValidationError }
+  | { status: 'not_found'; key: string };
+```
+
+---
+
+## Internal Implementation
+
+### TableDefinition Structure
+
+```typescript
+const postsDefinition = defineTable('posts')
+  .version(v1Schema)
+  .version(v2Schema)
+  .version(v3Schema)
+  .migrate(migrateFn);
+
+// Internal structure:
+{
+  name: 'posts',
+  versions: [v1Schema, v2Schema, v3Schema],
+  unionSchema: createUnionStandardSchema([v1Schema, v2Schema, v3Schema]),
+  migrate: migrateFn,
+}
+```
+
+### Validation + Migration Flow
+
+```typescript
+function parseRow<TRow>(
+  definition: TableDefinition<TRow>,
+  rawRow: unknown
+): RowResult<TRow> {
+  // 1. Validate against union of all versions
+  const result = definition.unionSchema['~standard'].validate(rawRow);
+
+  if (result.issues) {
+    return {
+      status: 'invalid',
+      id: (rawRow as any)?.id ?? 'unknown',
+      tableName: definition.name,
+      errors: result.issues,
+      row: rawRow,
+    };
+  }
+
+  // 2. Run migration to normalize to latest
+  const migrated = definition.migrate(result.value);
+
+  return { status: 'valid', row: migrated };
+}
+```
+
+### createTables Implementation
+
+```typescript
+function createTables<TDefs extends Record<string, TableDefinition<any>>>(
+  ydoc: Y.Doc,
+  definitions: TDefs
+): { [K in keyof TDefs]: TableHelper<TDefs[K] extends TableDefinition<infer R> ? R : never> } {
+  const ytables = ydoc.getMap<YKeyValue<any>>('tables');
+
+  return Object.fromEntries(
+    Object.entries(definitions).map(([name, definition]) => {
+      // Get or create YKeyValue for this table
+      let yarray = ytables.get(name);
+      if (!yarray) {
+        yarray = ydoc.getArray(`table:${name}`);
+        ytables.set(name, yarray);
+      }
+      const ykv = new YKeyValue(yarray);
+
+      return [name, createTableHelper(ykv, definition)];
+    })
+  ) as any;
+}
+```
+
+### createKV Implementation
+
+```typescript
+function createKV<TDefs extends Record<string, KVDefinition<any>>>(
+  ydoc: Y.Doc,
+  definitions: TDefs
+): { [K in keyof TDefs]: KVHelper<TDefs[K] extends KVDefinition<infer V> ? V : never> } {
+  // Use YKeyValue for bounded memory (consistent with tables)
+  const yarray = ydoc.getArray<{ key: string; val: unknown }>('kv');
+  const ykv = new YKeyValue(yarray);
+
+  return Object.fromEntries(
+    Object.entries(definitions).map(([name, definition]) => {
+      return [name, createKVHelper(ykv, definition)];
+    })
+  ) as any;
+}
+```
+
+---
+
+## Complete Example
+
+```typescript
+import * as Y from 'yjs';
+import { defineTable, defineKV, createTables, createKV } from 'epicenter';
+import { type } from 'arktype';
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCHEMA DEFINITIONS
+// ═══════════════════════════════════════════════════════════════════════════
+
+// Table: posts (3 versions)
+const posts = defineTable('posts')
+  .version(type({
+    id: 'string',
+    title: 'string',
+    content: 'string',
+  }))
+  .version(type({
+    id: 'string',
+    title: 'string',
+    content: 'string',
+    views: 'number',
+    publishedAt: 'string | null',
+  }))
+  .version(type({
+    id: 'string',
+    title: 'string',
+    content: 'string',
+    views: 'number',
+    publishedAt: 'string | null',
+    tags: 'string[]',
+  }))
+  .migrate((row) => {
+    // V1 → V3
+    if (!('views' in row)) {
+      return { ...row, views: 0, publishedAt: null, tags: [] };
+    }
+    // V2 → V3
+    if (!('tags' in row)) {
+      return { ...row, tags: [] };
+    }
+    // V3 → V3
+    return row;
+  });
+
+// Table: users (1 version - no migration needed)
+const users = defineTable('users')
+  .version(type({
+    id: 'string',
+    email: 'string',
+    name: 'string',
+  }))
+  .migrate((row) => row);
+
+// KV: theme (2 versions)
+const theme = defineKV('theme')
+  .version(type({ mode: "'light' | 'dark'" }))
+  .version(type({ mode: "'light' | 'dark' | 'system'", accentColor: 'string' }))
+  .migrate((v) => {
+    if (!('accentColor' in v)) {
+      return { ...v, accentColor: '#3b82f6' };
+    }
+    return v;
+  });
+
+// KV: sidebar (1 version)
+const sidebar = defineKV('sidebar')
+  .version(type({ collapsed: 'boolean', width: 'number' }))
+  .migrate((v) => v);
+
+// ═══════════════════════════════════════════════════════════════════════════
+// BIND TO Y.DOC
+// ═══════════════════════════════════════════════════════════════════════════
+
+const ydoc = new Y.Doc({ gc: true });
+
+const tables = createTables(ydoc, { posts, users });
+const kv = createKV(ydoc, { theme, sidebar });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// USAGE
+// ═══════════════════════════════════════════════════════════════════════════
+
+// Write (always latest version)
+tables.posts.upsert({
+  id: 'post-1',
+  title: 'Hello World',
+  content: 'My first post',
+  views: 0,
+  publishedAt: null,
+  tags: ['intro'],
+});
+
+// Read (validates + migrates)
+const post = tables.posts.get('post-1');
+if (post.status === 'valid') {
+  console.log(post.row.tags);  // ['intro']
+}
+
+// KV
+kv.theme.set({ mode: 'dark', accentColor: '#10b981' });
+const themeValue = kv.theme.get();
+if (themeValue.status === 'valid') {
+  console.log(themeValue.value.mode);  // 'dark'
+}
+
+// Observe changes
+tables.posts.observe((changedIds) => {
+  for (const id of changedIds) {
+    const result = tables.posts.get(id);
+    if (result.status === 'not_found') {
+      console.log('Deleted:', id);
+    } else if (result.status === 'valid') {
+      console.log('Changed:', result.row);
+    }
+  }
+});
+```
+
+---
+
+## Design Decision: No Automatic Write-Back
+
+**Question**: After reading and migrating old data, should we automatically write the migrated version back?
+
+**Answer**: No. Reads should be pure and not cause writes.
+
+**Rationale:**
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **Auto write-back** | Data upgrades over time; future reads faster | Reads cause writes (unexpected); increases sync traffic; potential conflicts if multiple clients read simultaneously |
+| **Read-only migration (chosen)** | Reads are pure and predictable; no surprise sync traffic; no conflicts from reads | Old data stays old until explicitly updated |
+
+**If users want to persist migrations**, they can explicitly write after reading:
+
+```typescript
+const result = tables.posts.get('post-1');
+if (result.status === 'valid') {
+  // Optionally persist the migrated version
+  tables.posts.upsert(result.row);
+}
+```
+
+**Future consideration**: Could add opt-in `writeback: true` option if needed.
+
+---
+
+## Migration Best Practices
+
+### 1. Check for Field Presence (Recommended)
+
+```typescript
+.migrate((row) => {
+  if (!('views' in row)) {
+    return { ...row, views: 0 };
+  }
+  return row;
+})
+```
+
+### 2. Use a Version Field (Optional)
+
+```typescript
+// If you want explicit version tracking, add it to your schema:
+.version(type({ id: 'string', title: 'string', _v: '1' }))
+.version(type({ id: 'string', title: 'string', views: 'number', _v: '2' }))
+.migrate((row) => {
+  if (row._v === '1') {
+    return { ...row, views: 0, _v: '2' as const };
+  }
+  return row;
+})
+```
+
+### 3. Handle Multiple Versions Cleanly
+
+```typescript
+.migrate((row) => {
+  let current = row;
+
+  // V1 → V2: Add views
+  if (!('views' in current)) {
+    current = { ...current, views: 0 };
+  }
+
+  // V2 → V3: Add author
+  if (!('author' in current)) {
+    current = { ...current, author: null };
+  }
+
+  // V3 → V4: Add tags
+  if (!('tags' in current)) {
+    current = { ...current, tags: [] };
+  }
+
+  return current as LatestRow;
+})
+```
+
+---
+
+## TODO
+
+- [ ] Implement `defineTable` builder with TypeScript inference
+- [ ] Implement `defineKV` builder with TypeScript inference
+- [ ] Implement `createUnionStandardSchema` for library-agnostic validation
+- [ ] Implement `createTables` binding function
+- [ ] Implement `createKV` binding function
+- [ ] Add tests for migration scenarios
+- [ ] Add tests for validation error handling
+- [ ] Benchmark union validation performance
+- [ ] Consider write-back optimization (persist migrated data)


### PR DESCRIPTION
## Summary

Restores YKeyValue that was removed in #1226. After further analysis, the reasoning for removal was partially flawed.

## The Journey

```
┌─────────────────────────────────────────────────────────────────────────┐
│  PR #1217 (Jan 7)                                                       │
│  "Add YKeyValue for 1935x storage improvement"                          │
│                                                                         │
│       Y.Map (524,985 bytes) ──→ YKeyValue (271 bytes)                   │
│                                                                         │
└───────────────────────────────────┬─────────────────────────────────────┘
                                    │
                                    ▼
┌─────────────────────────────────────────────────────────────────────────┐
│  PR #1226 (Jan 8)                                                       │
│  "Remove YKeyValue, use native Y.Map + epoch compaction"                │
│                                                                         │
│  Reasoning:                                                             │
│  • "Storage gains were dubious" (only worst-case benchmarks)            │
│  • "Unpredictable LWW behavior" (rightmost wins, not timestamps)  ← ⚠️  │
│  • Epoch compaction makes Y.Map tombstones a non-issue                  │
│                                                                         │
└───────────────────────────────────┬─────────────────────────────────────┘
                                    │
                                    ▼
┌─────────────────────────────────────────────────────────────────────────┐
│  This PR (Jan 24)                                                       │
│  "Restore YKeyValue for stable ID schema pattern"                       │
│                                                                         │
│  Why:                                                                   │
│  • The "unpredictable LWW" claim was MISLEADING                         │
│  • Both YKeyValue AND Y.Map use clientID-based ordering                 │
│  • For long-lived docs without epoch compaction, YKeyValue wins         │
│                                                                         │
└─────────────────────────────────────────────────────────────────────────┘
```

## The Misleading "Unpredictable LWW" Claim

PR #1226 stated:

> "YKeyValue uses positional conflict resolution (rightmost array entry wins). This means earlier edits can overwrite later ones, with winners determined by Yjs client IDs rather than timestamps."

This is technically true but **equally true for Y.Map**. Both data structures use the same Yjs CRDT merge algorithm under the hood:

```
┌────────────────────────────────────────────────────────────────┐
│                     Conflict Resolution                        │
├────────────────────────────────────────────────────────────────┤
│                                                                │
│  Client A (ID: 100)  ──┐                                       │
│                        │──→  Yjs CRDT merge                    │
│  Client B (ID: 200)  ──┘     (clientID ordering)               │
│                                    │                           │
│                   ┌────────────────┴────────────────┐          │
│                   ▼                                 ▼          │
│              Y.Map                            YKeyValue        │
│         (clientID wins)                   (clientID wins)      │
│                                                                │
│  Neither uses timestamps. Both use clientID ordering.          │
│  The "unpredictability" is identical.                          │
│                                                                │
└────────────────────────────────────────────────────────────────┘
```

## When to Use Which

```
┌────────────────────────────────────────────────────────────────┐
│  Use Case                         │  Recommendation            │
├───────────────────────────────────┼────────────────────────────┤
│  Short-lived docs with epochs     │  Y.Map (simpler)           │
│  Long-lived docs, no compaction   │  YKeyValue (constant mem)  │
│  Stable ID schema pattern         │  YKeyValue ✅              │
└────────────────────────────────────────────────────────────────┘
```

The **stable ID schema pattern** (see `specs/20260124T162638-stable-id-schema-pattern.md`) uses long-lived documents where:
- Keys are stable IDs that never change
- No epoch compaction needed (document grows only with unique keys, not operations)
- YKeyValue's constant memory footprint is ideal

## The Storage Reality

```
┌─────────────────────────────────────────────────────────────────┐
│  Y.Map: Grows with OPERATIONS                                   │
│                                                                 │
│  set('a', 1) → set('a', 2) → set('a', 3) → ... → set('a', 100) │
│                                                                 │
│  Internal items: 100 (every update retained)                    │
│  Need epoch compaction to reset                                 │
└─────────────────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────────────────┐
│  YKeyValue: Grows with UNIQUE KEYS                              │
│                                                                 │
│  set('a', 1) → set('a', 2) → set('a', 3) → ... → set('a', 100) │
│                                                                 │
│  Internal items: 1 (old entries cleaned up)                     │
│  No compaction needed                                           │
└─────────────────────────────────────────────────────────────────┘
```