### PR TITLE
fix(ci): correct README download link filenames to match Tauri assets

### DIFF
--- a/.github/workflows/update-readme-version.yml
+++ b/.github/workflows/update-readme-version.yml
@@ -1,7 +1,7 @@
 name: 'Update README Download Links'
 
 # Purpose: Automatically update version numbers in README.md download links
-# 
+#
 # Why this exists:
 # - We want one-click download buttons in the README for the best user experience
 # - GitHub releases include version numbers in filenames (e.g., Whispering_7.0.0_aarch64.dmg)
@@ -21,8 +21,8 @@ name: 'Update README Download Links'
 
 on:
   release:
-    types: [published]  # Only runs when draft releases are published
-  workflow_dispatch:    # Manual trigger option
+    types: [published] # Only runs when draft releases are published
+  workflow_dispatch: # Manual trigger option
     inputs:
       version:
         description: 'Version to update (without v prefix, e.g., 7.0.0)'
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -60,13 +60,13 @@ jobs:
       - name: Update README download links
         run: |
           VERSION=${{ steps.get_version.outputs.VERSION }}
-          
+
           # Update the Whispering app README
           README_PATH="apps/whispering/README.md"
-          
+
           # Create backup for safety
           cp "$README_PATH" "${README_PATH}.bak"
-          
+
           # Update download links using regex to match semantic version patterns
           # The regex [0-9]\+\.[0-9]\+\.[0-9]\+ matches version numbers like 7.0.0, 10.2.1, etc.
 
@@ -75,24 +75,31 @@ jobs:
           # Example: /releases/download/v7.2.0/ → /releases/download/v7.2.1/
           sed -i "s|/releases/download/v[0-9]\+\.[0-9]\+\.[0-9]\+/|/releases/download/v${VERSION}/|g" "$README_PATH"
 
-          # SECOND: Update filenames with platform-suffixed format (Tauri v2)
-          # macOS downloads (include _darwin suffix)
-          # Example: Whispering_7.2.0_aarch64_darwin.dmg → Whispering_7.2.1_aarch64_darwin.dmg
-          sed -i "s/Whispering_[0-9]\+\.[0-9]\+\.[0-9]\+_aarch64_darwin\.dmg/Whispering_${VERSION}_aarch64_darwin.dmg/g" "$README_PATH"
-          sed -i "s/Whispering_[0-9]\+\.[0-9]\+\.[0-9]\+_x64_darwin\.dmg/Whispering_${VERSION}_x64_darwin.dmg/g" "$README_PATH"
+          # SECOND: Update filenames to match actual Tauri-generated asset names
+          # Note: Tauri does NOT add platform suffixes (_darwin, _windows, _linux) to filenames
+          # 
+          # Actual asset naming from Tauri build:
+          #   macOS:   Whispering_X.Y.Z_aarch64.dmg, Whispering_X.Y.Z_x64.dmg
+          #   Windows: Whispering_X.Y.Z_x64_en-US.msi, Whispering_X.Y.Z_x64-setup.exe
+          #   Linux:   Whispering_X.Y.Z_amd64.AppImage, Whispering_X.Y.Z_amd64.deb, Whispering-X.Y.Z-1.x86_64.rpm
 
-          # Windows downloads (include _windows suffix)
-          # Example: Whispering_7.2.0_x64_en-US_windows.msi → Whispering_7.2.1_x64_en-US_windows.msi
-          sed -i "s/Whispering_[0-9]\+\.[0-9]\+\.[0-9]\+_x64_en-US_windows\.msi/Whispering_${VERSION}_x64_en-US_windows.msi/g" "$README_PATH"
-          sed -i "s/Whispering_[0-9]\+\.[0-9]\+\.[0-9]\+_x64-setup_windows\.exe/Whispering_${VERSION}_x64-setup_windows.exe/g" "$README_PATH"
+          # macOS downloads (no _darwin suffix in actual assets)
+          # Example: Whispering_7.2.0_aarch64.dmg → Whispering_7.2.1_aarch64.dmg
+          sed -i "s/Whispering_[0-9]\+\.[0-9]\+\.[0-9]\+_aarch64\.dmg/Whispering_${VERSION}_aarch64.dmg/g" "$README_PATH"
+          sed -i "s/Whispering_[0-9]\+\.[0-9]\+\.[0-9]\+_x64\.dmg/Whispering_${VERSION}_x64.dmg/g" "$README_PATH"
 
-          # Linux downloads (include _linux suffix)
-          # Example: Whispering_7.2.0_amd64_linux.AppImage → Whispering_7.2.1_amd64_linux.AppImage
-          sed -i "s/Whispering_[0-9]\+\.[0-9]\+\.[0-9]\+_amd64_linux\.AppImage/Whispering_${VERSION}_amd64_linux.AppImage/g" "$README_PATH"
-          sed -i "s/Whispering_[0-9]\+\.[0-9]\+\.[0-9]\+_amd64_linux\.deb/Whispering_${VERSION}_amd64_linux.deb/g" "$README_PATH"
-          # RPM has a special format with -1 suffix and _linux suffix
-          sed -i "s/Whispering-[0-9]\+\.[0-9]\+\.[0-9]\+-1\.x86_64_linux\.rpm/Whispering-${VERSION}-1.x86_64_linux.rpm/g" "$README_PATH"
-          
+          # Windows downloads (no _windows suffix in actual assets)
+          # Example: Whispering_7.2.0_x64_en-US.msi → Whispering_7.2.1_x64_en-US.msi
+          sed -i "s/Whispering_[0-9]\+\.[0-9]\+\.[0-9]\+_x64_en-US\.msi/Whispering_${VERSION}_x64_en-US.msi/g" "$README_PATH"
+          sed -i "s/Whispering_[0-9]\+\.[0-9]\+\.[0-9]\+_x64-setup\.exe/Whispering_${VERSION}_x64-setup.exe/g" "$README_PATH"
+
+          # Linux downloads (no _linux suffix in actual assets)
+          # Example: Whispering_7.2.0_amd64.AppImage → Whispering_7.2.1_amd64.AppImage
+          sed -i "s/Whispering_[0-9]\+\.[0-9]\+\.[0-9]\+_amd64\.AppImage/Whispering_${VERSION}_amd64.AppImage/g" "$README_PATH"
+          sed -i "s/Whispering_[0-9]\+\.[0-9]\+\.[0-9]\+_amd64\.deb/Whispering_${VERSION}_amd64.deb/g" "$README_PATH"
+          # RPM has a special format with -1 suffix (no _linux suffix)
+          sed -i "s/Whispering-[0-9]\+\.[0-9]\+\.[0-9]\+-1\.x86_64\.rpm/Whispering-${VERSION}-1.x86_64.rpm/g" "$README_PATH"
+
           # Show what changed for transparency
           echo "Changes made:"
           diff "${README_PATH}.bak" "$README_PATH" || true

--- a/apps/whispering/README.md
+++ b/apps/whispering/README.md
@@ -97,10 +97,10 @@ This automatically handles installation and updates.
 
 #### Option 2: Direct Download
 
-| Architecture      | Download                                                                                                                                        | Requirements     |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| **Apple Silicon** | [Whispering_7.11.0_aarch64_darwin.dmg](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_aarch64_darwin.dmg) | M1/M2/M3/M4 Macs |
-| **Intel**         | [Whispering_7.11.0_x64_darwin.dmg](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_x64_darwin.dmg)         | Intel-based Macs |
+| Architecture      | Download                                                                                                                          | Requirements     |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| **Apple Silicon** | [Whispering_7.11.0_aarch64.dmg](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_aarch64.dmg) | M1/M2/M3/M4 Macs |
+| **Intel**         | [Whispering_7.11.0_x64.dmg](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_x64.dmg)         | Intel-based Macs |
 
 > **💡 Tip:** Not sure which Mac you have? Click the Apple menu → About This Mac. Look for "Chip" or "Processor":
 >
@@ -126,10 +126,10 @@ This automatically handles installation and updates.
 
 #### Download Options
 
-| Installer Type    | Download                                                                                                                                              | Description                            |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
-| **MSI Installer** | [Whispering_7.11.0_x64_en-US_windows.msi](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_x64_en-US_windows.msi) | Recommended Standard Windows installer |
-| **EXE Installer** | [Whispering_7.11.0_x64-setup_windows.exe](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_x64-setup_windows.exe) | Alternative installer option           |
+| Installer Type    | Download                                                                                                                              | Description                            |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| **MSI Installer** | [Whispering_7.11.0_x64_en-US.msi](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_x64_en-US.msi) | Recommended Standard Windows installer |
+| **EXE Installer** | [Whispering_7.11.0_x64-setup.exe](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_x64-setup.exe) | Alternative installer option           |
 
 #### Installation
 
@@ -147,34 +147,34 @@ Whispering will appear in your Start Menu when complete.
 
 #### Download Options
 
-| Package Format  | Download                                                                                                                                            | Compatible With          |
-| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| **AppImage**    | [Whispering_7.11.0_amd64_linux.AppImage](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_amd64_linux.AppImage) | All Linux distributions  |
-| **DEB Package** | [Whispering_7.11.0_amd64_linux.deb](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_amd64_linux.deb)           | Debian, Ubuntu, Pop!\_OS |
-| **RPM Package** | [Whispering-7.11.0-1.x86_64_linux.rpm](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering-7.11.0-1.x86_64_linux.rpm)     | Fedora, RHEL, openSUSE   |
+| Package Format  | Download                                                                                                                                | Compatible With          |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| **AppImage**    | [Whispering_7.11.0_amd64.AppImage](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_amd64.AppImage) | All Linux distributions  |
+| **DEB Package** | [Whispering_7.11.0_amd64.deb](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_amd64.deb)           | Debian, Ubuntu, Pop!\_OS |
+| **RPM Package** | [Whispering-7.11.0-1.x86_64.rpm](https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering-7.11.0-1.x86_64.rpm)     | Fedora, RHEL, openSUSE   |
 
 #### Quick Install Commands
 
 **AppImage (Universal)**
 
 ```bash
-wget https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_amd64_linux.AppImage
-chmod +x Whispering_7.11.0_amd64_linux.AppImage
-./Whispering_7.11.0_amd64_linux.AppImage
+wget https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_amd64.AppImage
+chmod +x Whispering_7.11.0_amd64.AppImage
+./Whispering_7.11.0_amd64.AppImage
 ```
 
 **Debian/Ubuntu**
 
 ```bash
-wget https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_amd64_linux.deb
-sudo dpkg -i Whispering_7.11.0_amd64_linux.deb
+wget https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering_7.11.0_amd64.deb
+sudo dpkg -i Whispering_7.11.0_amd64.deb
 ```
 
 **Fedora/RHEL**
 
 ```bash
-wget https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering-7.11.0-1.x86_64_linux.rpm
-sudo rpm -i Whispering-7.11.0-1.x86_64_linux.rpm
+wget https://github.com/EpicenterHQ/epicenter/releases/download/v7.11.0/Whispering-7.11.0-1.x86_64.rpm
+sudo rpm -i Whispering-7.11.0-1.x86_64.rpm
 ```
 
 </details>


### PR DESCRIPTION
The `update-readme-version.yml` workflow was adding platform suffixes (`_windows`, `_linux`, `_darwin`) to download filenames, but Tauri's build action doesn't include these suffixes in actual release assets. This caused all Windows and Linux download links to return 404 errors.

**Root cause**: The CI workflow assumed Tauri would name files like `Whispering_7.11.0_x64_en-US_windows.msi`, but Tauri actually produces `Whispering_7.11.0_x64_en-US.msi`.

**Changes**:
- Updated CI regex patterns to match actual Tauri asset naming
- Fixed current README links for v7.11.0
- Added documentation explaining the correct naming convention

This supersedes #991 by @renesq, who originally reported the broken Windows links. The issue has persisted because the CI kept regenerating incorrect links on each release.

Co-authored-by: renesq <35303112+renesq@users.noreply.github.com>