### PR TITLE
fix(ci): rename workflow to autofix.ci

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,4 +1,4 @@
-name: Autofix
+name: autofix.ci
 
 on:
   push:


### PR DESCRIPTION
The autofix-ci/action requires the workflow to be named exactly `autofix.ci` for security reasons. This was causing all autofix runs to fail with:

> For security reasons, the workflow in which the autofix.ci action is used must be named "autofix.ci".