### PR TITLE
fix: improve global shortcut recording UX

### DIFF
--- a/apps/whispering/src/lib/services/isomorphic/local-shortcut-manager.ts
+++ b/apps/whispering/src/lib/services/isomorphic/local-shortcut-manager.ts
@@ -34,6 +34,21 @@ const shortcuts = new Map<
 >();
 
 /**
+ * Global flag to track if we're currently recording a keyboard shortcut.
+ * When true, all local shortcuts are disabled to prevent interference.
+ */
+let isRecordingShortcut = false;
+
+/**
+ * Set the recording mode state. When recording is enabled, local shortcuts
+ * will not fire, allowing users to record any key combination without
+ * triggering existing shortcuts.
+ */
+export function setRecordingMode(recording: boolean) {
+	isRecordingShortcut = recording;
+}
+
+/**
  * Type representing the local shortcut manager instance.
  * Provides methods to:
  * - Listen for keyboard events and trigger registered shortcuts
@@ -269,6 +284,9 @@ function arraysMatch(a: string[], b: string[]) {
  * This prevents keyboard shortcuts from interfering with text input.
  */
 function isTypingInInput(): boolean {
+	// Prevent shortcuts when recording
+	if (isRecordingShortcut) return true;
+
 	const activeElement = document.activeElement;
 	if (!activeElement) return false;
 

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/KeyboardShortcutRecorder.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/KeyboardShortcutRecorder.svelte
@@ -155,8 +155,13 @@
 								aria-live="polite"
 							>
 								<div class="flex flex-col items-center gap-1 px-4 py-2">
-									<p class="text-sm font-medium">Press key combination</p>
-									<p class="text-xs text-muted-foreground">Esc to cancel</p>
+									{#if keyRecorder.capturedKeys.length > 0}
+										<Kbd.Root>{keyRecorder.capturedKeys.map(k => getShortcutDisplayLabel(k)).join('+')}</Kbd.Root>
+										<p class="text-xs text-muted-foreground">Release all keys or wait...</p>
+									{:else}
+										<p class="text-sm font-medium">Press key combination</p>
+										<p class="text-xs text-muted-foreground">Esc to cancel</p>
+									{/if}
 								</div>
 							</div>
 						{/if}

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/create-key-recorder.svelte.ts
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/create-key-recorder.svelte.ts
@@ -1,7 +1,8 @@
 import type { KeyboardEventSupportedKey } from '$lib/constants/keyboard';
 import type { PressedKeys } from '$lib/utils/createPressedKeys.svelte';
+import { setRecordingMode } from '$lib/services/isomorphic/local-shortcut-manager';
 
-const CAPTURE_WINDOW_MS = 300; // Time to wait for additional keys in a combination
+const CAPTURE_WINDOW_MS = 600; // Increased from 300ms for complex shortcuts
 
 /**
  * Creates a keyboard shortcut recorder that captures key combinations
@@ -32,7 +33,17 @@ export function createKeyRecorder({
 	// State
 	let isListening = $state(false);
 	const capturedKeys = new Set<KeyboardEventSupportedKey>();
+	let capturedKeysArray = $state<KeyboardEventSupportedKey[]>([]); // For UI preview
 	let captureWindowTimer: NodeJS.Timeout | null = null;
+
+	// Sync array with set for reactive UI
+	$effect(() => {
+		if (isListening) {
+			capturedKeysArray = Array.from(capturedKeys);
+		} else {
+			capturedKeysArray = [];
+		}
+	});
 
 	// Helper: Clear the capture window timer
 	function clearCaptureTimer() {
@@ -48,6 +59,7 @@ export function createKeyRecorder({
 
 		clearCaptureTimer();
 		isListening = false;
+		setRecordingMode(false);
 
 		// Convert Set to Array for registration
 		const combination = Array.from(capturedKeys);
@@ -94,20 +106,26 @@ export function createKeyRecorder({
 		get isListening() {
 			return isListening;
 		},
+		get capturedKeys() {
+			return capturedKeysArray;
+		},
 		start() {
 			isListening = true;
 			capturedKeys.clear();
 			clearCaptureTimer();
+			setRecordingMode(true);
 		},
 		stop() {
 			isListening = false;
 			capturedKeys.clear();
 			clearCaptureTimer();
+			setRecordingMode(false);
 		},
 		clear() {
 			isListening = false;
 			capturedKeys.clear();
 			clearCaptureTimer();
+			setRecordingMode(false);
 			onClear();
 		},
 		register: onRegister,


### PR DESCRIPTION
## Fix Global Shortcut Entry Issues (#1264)

### Problem
Users couldn't enter complex shortcuts (like Ctrl+Option+Cmd+R) on macOS because:
1. Local shortcuts (e.g. 'R') triggered while recording
2. Capture window (300ms) was too short for 3 modifiers

### Solution
1. **Recording Mode:** Added flag to disable local shortcuts while recording (`isRecordingShortcut`)
2. **Better Capture:** Increased window to 600ms and added live preview of pressed keys

### Testing
- Validated via static analysis (TypeScript check passed)
- Manual testing required on macOS