### PR TITLE
Feat/1253 basic punctuation

### DIFF
--- a/apps/whispering/src/lib/constants/database/transformation-types.ts
+++ b/apps/whispering/src/lib/constants/database/transformation-types.ts
@@ -5,11 +5,13 @@
 export const TRANSFORMATION_STEP_TYPES = [
 	'prompt_transform',
 	'find_replace',
+	'simple_punctuation',
 ] as const;
 
 export const TRANSFORMATION_STEP_TYPES_TO_LABEL = {
 	prompt_transform: 'Prompt Transform',
 	find_replace: 'Find Replace',
+	simple_punctuation: 'Simple Punctuation',
 } as const satisfies Record<(typeof TRANSFORMATION_STEP_TYPES)[number], string>;
 
 export const TRANSFORMATION_STEP_TYPE_OPTIONS = TRANSFORMATION_STEP_TYPES.map(

--- a/apps/whispering/src/lib/query/isomorphic/transformation-logic.ts
+++ b/apps/whispering/src/lib/query/isomorphic/transformation-logic.ts
@@ -1,0 +1,21 @@
+export function applySimplePunctuation(input: string): string {
+	let output = input;
+	const replacements = [
+		{ pattern: /(?:\s+|^)(?:period|full stop)/gi, replacement: '.' },
+		{ pattern: /(?:\s+|^)comma/gi, replacement: ',' },
+		{ pattern: /(?:\s+|^)question mark/gi, replacement: '?' },
+		{
+			pattern: /(?:\s+|^)(?:exclamation mark|exclamation point)/gi,
+			replacement: '!',
+		},
+		{ pattern: /(?:\s+|^)colon/gi, replacement: ':' },
+		{ pattern: /(?:\s+|^)semicolon/gi, replacement: ';' },
+		{ pattern: /(?:\s+|^)(?:new line|newline)/gi, replacement: '\n' },
+		{ pattern: /(?:\s+|^)new paragraph/gi, replacement: '\n\n' },
+	];
+
+	for (const { pattern, replacement } of replacements) {
+		output = output.replace(pattern, replacement);
+	}
+	return output;
+}

--- a/apps/whispering/src/lib/query/isomorphic/transformation-logic.ts
+++ b/apps/whispering/src/lib/query/isomorphic/transformation-logic.ts
@@ -1,17 +1,17 @@
 export function applySimplePunctuation(input: string): string {
 	let output = input;
 	const replacements = [
-		{ pattern: /(?:\s+|^)(?:period|full stop)/gi, replacement: '.' },
-		{ pattern: /(?:\s+|^)comma/gi, replacement: ',' },
-		{ pattern: /(?:\s+|^)question mark/gi, replacement: '?' },
+		{ pattern: /(?:\s+|^)(?:period|full stop)\b/gi, replacement: '.' },
+		{ pattern: /(?:\s+|^)comma\b/gi, replacement: ',' },
+		{ pattern: /(?:\s+|^)question mark\b/gi, replacement: '?' },
 		{
-			pattern: /(?:\s+|^)(?:exclamation mark|exclamation point)/gi,
+			pattern: /(?:\s+|^)(?:exclamation mark|exclamation point)\b/gi,
 			replacement: '!',
 		},
-		{ pattern: /(?:\s+|^)colon/gi, replacement: ':' },
-		{ pattern: /(?:\s+|^)semicolon/gi, replacement: ';' },
-		{ pattern: /(?:\s+|^)(?:new line|newline)/gi, replacement: '\n' },
-		{ pattern: /(?:\s+|^)new paragraph/gi, replacement: '\n\n' },
+		{ pattern: /(?:\s+|^)colon\b/gi, replacement: ':' },
+		{ pattern: /(?:\s+|^)semicolon\b/gi, replacement: ';' },
+		{ pattern: /(?:\s+|^)(?:new line|newline)(?:\s+|$)/gi, replacement: '\n' },
+		{ pattern: /(?:\s+|^)new paragraph(?:\s+|$)/gi, replacement: '\n\n' },
 	];
 
 	for (const { pattern, replacement } of replacements) {

--- a/apps/whispering/src/lib/query/isomorphic/transformer.test.ts
+++ b/apps/whispering/src/lib/query/isomorphic/transformer.test.ts
@@ -16,10 +16,7 @@ describe('applySimplePunctuation', () => {
 				input: 'Question mark at start',
 				expected: '? at start',
 			},
-			{
-				input: 'Line one new line Line two',
-				expected: 'Line one\n Line two',
-			},
+
 			{
 				input: 'Capitalized Period works',
 				expected: 'Capitalized. works',
@@ -31,6 +28,14 @@ describe('applySimplePunctuation', () => {
 			{
 				input: 'No punctuation here',
 				expected: 'No punctuation here',
+			},
+			{
+				input: 'The commander gave a command',
+				expected: 'The commander gave a command',
+			},
+			{
+				input: 'Line one new line Line two',
+				expected: 'Line one\nLine two',
 			}
 		];
 

--- a/apps/whispering/src/lib/query/isomorphic/transformer.test.ts
+++ b/apps/whispering/src/lib/query/isomorphic/transformer.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'bun:test';
+import { applySimplePunctuation } from './transformation-logic';
+
+describe('applySimplePunctuation', () => {
+	it('should handle simple punctuation replacement', () => {
+		const inputs = [
+			{
+				input: 'Hello comma world',
+				expected: 'Hello, world',
+			},
+			{
+				input: 'This is a period',
+				expected: 'This is a.',
+			},
+			{
+				input: 'Question mark at start',
+				expected: '? at start',
+			},
+			{
+				input: 'Line one new line Line two',
+				expected: 'Line one\n Line two',
+			},
+			{
+				input: 'Capitalized Period works',
+				expected: 'Capitalized. works',
+			},
+			{
+				input: 'Multiple  spaces   comma handled',
+				expected: 'Multiple  spaces, handled',
+			},
+			{
+				input: 'No punctuation here',
+				expected: 'No punctuation here',
+			}
+		];
+
+		for (const { input, expected } of inputs) {
+			const result = applySimplePunctuation(input);
+			expect(result).toBe(expected);
+		}
+	});
+});

--- a/apps/whispering/src/lib/query/isomorphic/transformer.ts
+++ b/apps/whispering/src/lib/query/isomorphic/transformer.ts
@@ -18,6 +18,7 @@ import type {
 import { settings } from '$lib/stores/settings.svelte';
 import { asTemplateString, interpolateTemplate } from '$lib/utils/template';
 import { dbKeys } from './db';
+import { applySimplePunctuation } from './transformation-logic';
 
 const { TransformServiceError, TransformServiceErr } = createTaggedError(
 	'TransformServiceError',
@@ -139,7 +140,7 @@ export const transformer = {
 	}),
 };
 
-async function handleStep({
+export async function handleStep({
 	input,
 	step,
 }: {
@@ -293,6 +294,10 @@ async function handleStep({
 				default:
 					return Err(`Unsupported provider: ${provider}`);
 			}
+		}
+
+		case 'simple_punctuation': {
+			return Ok(applySimplePunctuation(input));
 		}
 
 		default:

--- a/apps/whispering/src/lib/services/isomorphic/db/models/transformation-steps.ts
+++ b/apps/whispering/src/lib/services/isomorphic/db/models/transformation-steps.ts
@@ -13,7 +13,7 @@ import {
  * The current version of the TransformationStep schema.
  * Increment this when adding new fields or making breaking changes.
  */
-const CURRENT_TRANSFORMATION_STEP_VERSION = 2 as const;
+const CURRENT_TRANSFORMATION_STEP_VERSION = 3 as const;
 
 // ============================================================================
 // VERSION 1 (FROZEN)
@@ -56,7 +56,7 @@ export const TransformationStepV1 = type({
 export type TransformationStepV1 = typeof TransformationStepV1.infer;
 
 // ============================================================================
-// VERSION 2 (CURRENT)
+// VERSION 2 (FROZEN)
 // ============================================================================
 
 /**
@@ -82,6 +82,20 @@ export const TransformationStepV2 = TransformationStepV1.merge({
 export type TransformationStepV2 = typeof TransformationStepV2.infer;
 
 // ============================================================================
+// VERSION 3 (CURRENT)
+// ============================================================================
+
+/**
+ * V3: Added 'simple_punctuation' type support.
+ * Structure is identical to V2, just bumped version number to track schema evolution.
+ */
+export const TransformationStepV3 = TransformationStepV2.merge({
+	version: '3',
+});
+
+export type TransformationStepV3 = typeof TransformationStepV3.infer;
+
+// ============================================================================
 // MIGRATING VALIDATOR
 // ============================================================================
 
@@ -89,21 +103,27 @@ export type TransformationStepV2 = typeof TransformationStepV2.infer;
  * TransformationStep validator with automatic migration.
  * Accepts V1 or V2 and always outputs V2.
  */
-export const TransformationStep = TransformationStepV1.or(
-	TransformationStepV2,
-).pipe((step): TransformationStepV2 => {
+export const TransformationStep = TransformationStepV1.or(TransformationStepV2)
+	.or(TransformationStepV3)
+	.pipe((step): TransformationStepV3 => {
 	if (step.version === 1) {
 		return {
 			...step,
-			version: 2,
+			version: 3,
 			'prompt_transform.inference.provider.Custom.model': '',
 			'prompt_transform.inference.provider.Custom.baseUrl': '',
+		};
+	}
+	if (step.version === 2) {
+		return {
+			...step,
+			version: 3,
 		};
 	}
 	return step;
 });
 
-export type TransformationStep = TransformationStepV2;
+export type TransformationStep = TransformationStepV3;
 
 // ============================================================================
 // FACTORY FUNCTION


### PR DESCRIPTION
This PR introduces the “Simple Punctuation” transformation step requested in issue #1253, enabling automatic conversion of spoken punctuation commands—such as “period,” “comma,” and “new line”—into their corresponding symbols during post-processing. The update adds a new simple_punctuation entry to the transformation registry and updates the database schema to version 3. The transformation logic, implemented in transformation-logic.ts, uses carefully designed regular expressions with word-boundary checks to avoid false positives (for example, ensuring that words like “commander” are not mistakenly altered). Special handling is included for the “new line” command to remove awkward leading spaces on the following line, resulting in clean formatting. To ensure correctness and robustness, comprehensive unit tests were added in transformer.test.ts, covering case insensitivity, spacing variations, and edge cases. Verification was performed by running bun test src/lib/query/isomorphic/transformer.test.ts locally, with successful results confirming basic replacements (e.g., “Hello comma world” → “Hello, world”), case-insensitive behavior (“Period” → “.”), safety checks (“The commander” remains unchanged), and proper newline handling (“Line one new line Line two” → “Line one\nLine two”). This change fully resolves and closes issue #1253 without omitting any requested functionality.