### PR TITLE
refactor: move workspace definition inside folder as definition.json

### DIFF
--- a/apps/epicenter/src/lib/components/HomeSidebar.svelte
+++ b/apps/epicenter/src/lib/components/HomeSidebar.svelte
@@ -46,7 +46,11 @@
 				onclick={() =>
 					createWorkspaceDialog.open({
 						onConfirm: async ({ name, id }) => {
-							const result = await createWorkspace.mutateAsync({ name, id, template: null });
+							const result = await createWorkspace.mutateAsync({
+								name,
+								id,
+								template: null,
+							});
 							await invalidateAll();
 							// Navigate using the workspace ID
 							goto(`/workspaces/${result.id}`);

--- a/apps/epicenter/src/lib/docs/workspace-persistence.ts
+++ b/apps/epicenter/src/lib/docs/workspace-persistence.ts
@@ -49,12 +49,10 @@ const FILE_NAMES = {
  * **Storage Layout:**
  * ```
  * {appLocalDataDir}/workspaces/{workspaceId}/
- * ├── workspace.yjs   # Y.Doc binary (source of truth)
- * └── kv.json         # KV values mirror
+ * ├── definition.json   # Workspace definition (schema + metadata)
+ * ├── workspace.yjs     # Y.Doc binary (source of truth)
+ * └── kv.json           # KV values mirror
  * ```
- *
- * Note: Workspace definition is stored separately at the parent level
- * as `{workspaceId}.json`.
  *
  * @param ctx - The extension context
  * @param config - Optional configuration for debounce timing

--- a/apps/epicenter/src/lib/docs/workspace.ts
+++ b/apps/epicenter/src/lib/docs/workspace.ts
@@ -1,4 +1,7 @@
-import { createWorkspace, type WorkspaceDefinition } from '@epicenter/hq/dynamic';
+import {
+	createWorkspace,
+	type WorkspaceDefinition,
+} from '@epicenter/hq/dynamic';
 import { workspacePersistence } from './workspace-persistence';
 
 /**

--- a/apps/epicenter/src/lib/templates/entries.ts
+++ b/apps/epicenter/src/lib/templates/entries.ts
@@ -25,7 +25,11 @@ export const ENTRIES_TEMPLATE = {
 			fields: [
 				id(),
 				text({ id: 'title', name: 'Title', description: 'Entry title' }),
-				text({ id: 'content', name: 'Content', description: 'Entry body text' }),
+				text({
+					id: 'content',
+					name: 'Content',
+					description: 'Entry body text',
+				}),
 				tags({ id: 'type', name: 'Type', description: 'Entry type/category' }),
 				tags({ id: 'tags', name: 'Tags', description: 'Additional tags' }),
 			],

--- a/apps/epicenter/src/lib/templates/whispering.ts
+++ b/apps/epicenter/src/lib/templates/whispering.ts
@@ -6,7 +6,13 @@
  * Epicenter workspace.
  */
 
-import { id, select, table, text, type WorkspaceDefinition } from '@epicenter/hq';
+import {
+	id,
+	select,
+	table,
+	text,
+	type WorkspaceDefinition,
+} from '@epicenter/hq';
 
 export const WHISPERING_TEMPLATE = {
 	id: 'epicenter.whispering',

--- a/apps/epicenter/src/routes/(workspace)/workspaces/[id]/+layout.ts
+++ b/apps/epicenter/src/routes/(workspace)/workspaces/[id]/+layout.ts
@@ -1,6 +1,6 @@
 import { error } from '@sveltejs/kit';
-import { getWorkspace } from '$lib/services/workspaces';
 import { createWorkspaceClient } from '$lib/docs/workspace';
+import { getWorkspace } from '$lib/services/workspaces';
 import type { LayoutLoad } from './$types';
 
 /**
@@ -26,7 +26,9 @@ export const load: LayoutLoad = async ({ params }) => {
 	const client = createWorkspaceClient(definition);
 	await client.whenSynced;
 
-	console.log(`[Layout] Loaded workspace: ${definition.name} (${definition.id})`);
+	console.log(
+		`[Layout] Loaded workspace: ${definition.name} (${definition.id})`,
+	);
 
 	return {
 		/** The workspace definition. */

--- a/apps/epicenter/src/routes/(workspace)/workspaces/[id]/tables/[tableId]/+page.svelte
+++ b/apps/epicenter/src/routes/(workspace)/workspaces/[id]/tables/[tableId]/+page.svelte
@@ -33,14 +33,14 @@
 
 	// Fields is now an array - map to [id, field] pairs for backwards compat with template
 	const columns = $derived(
-		tableFields
-			? (tableFields.map((f) => [f.id, f]) as [string, Field][])
-			: [],
+		tableFields ? (tableFields.map((f) => [f.id, f]) as [string, Field][]) : [],
 	);
 
 	// Get actual table data from the YJS-backed client
 	const tableHelper = $derived(
-		tableId && data.client?.tables ? data.client.tables.get(tableId) : undefined,
+		tableId && data.client?.tables
+			? data.client.tables.get(tableId)
+			: undefined,
 	);
 
 	const rows = $derived.by(() => {

--- a/packages/epicenter/src/core/schema/schema-file.ts
+++ b/packages/epicenter/src/core/schema/schema-file.ts
@@ -8,7 +8,7 @@
  *
  * File structure:
  * ```
- * {workspaceId}.json        # Schema definitions (local only)
+ * {workspaceId}/definition.json   # Schema definitions (local only)
  * {workspaceId}/
  *   workspace.yjs           # CRDT data (synced)
  * ```

--- a/specs/20260108T133200-collaborative-workspace-config-ydoc.md
+++ b/specs/20260108T133200-collaborative-workspace-config-ydoc.md
@@ -12,7 +12,7 @@ This specification describes how to store workspace configurations (schema, meta
 
 The current architecture stores workspace configs as JSON files:
 
-- `workspaces/blog.json` → `{ id, slug, name, tables, kv, sync }`
+- `workspaces/blog/definition.json` → `{ id, name, tables, kv, ... }`
 
 This creates issues:
 
@@ -308,20 +308,12 @@ If Y.Doc has fields not in code schema:
 
 ### One-Time Migration
 
-1. Scan existing `workspaces/*.json` files
-2. For each workspace:
+1. Scan existing workspace directories in `workspaces/`
+2. For each workspace with `definition.json`:
    - Create Head Y.Doc with epoch: 0
    - Create Data Y.Doc with schema + empty tables
    - Add to user's Registry Y.Doc
 3. Import existing Y.Doc data files (if any)
-
-### Coexistence Period (Optional)
-
-Could support both file-based and Y.Doc-based during transition:
-
-- Read from Y.Doc if exists
-- Fall back to JSON file
-- Eventually remove file support
 
 ## Critical YJS Semantics (Must Understand)
 

--- a/specs/20260109T174900-epicenter-app-three-fetch-migration.md
+++ b/specs/20260109T174900-epicenter-app-three-fetch-migration.md
@@ -6,7 +6,7 @@
 
 ## Problem
 
-The `apps/epicenter` app stores workspace schemas as JSON files (`AppLocalData/workspaces/{id}.json`) and creates clients directly without following the three-fetch protocol documented in `packages/epicenter/src/core/docs/README.md`.
+The `apps/epicenter` app stores workspace schemas as JSON files (`AppLocalData/workspaces/{id}/definition.json`) and creates clients directly without following the three-fetch protocol documented in `packages/epicenter/src/core/docs/README.md`.
 
 Current flow (broken):
 

--- a/specs/20260202T145245-consolidate-workspace-definition-inside-folder.md
+++ b/specs/20260202T145245-consolidate-workspace-definition-inside-folder.md
@@ -1,0 +1,190 @@
+# Consolidate Workspace Definition Inside Folder
+
+## Problem
+
+Current workspace storage has redundancy:
+
+```
+workspaces/
+├── {workspaceId}.json          # Definition file (OUTSIDE folder)
+└── {workspaceId}/              # Data folder
+    ├── workspace.yjs
+    └── kv.json
+```
+
+The workspace ID appears twice: once as the JSON filename, once as the folder name. This diverges from the original architecture planned in `specs/20260117T004421-workspace-input-normalization.md`.
+
+## Solution
+
+Move the definition file inside the workspace folder and rename to `definition.json`:
+
+```
+workspaces/
+└── {workspaceId}/
+    ├── definition.json         # Definition file (INSIDE folder, renamed)
+    ├── workspace.yjs
+    └── kv.json
+```
+
+### Benefits
+
+1. **Less redundancy**: Workspace ID only appears once (folder name)
+2. **Self-contained**: Each workspace is a complete, portable folder
+3. **Aligns with original spec**: Matches the architecture in `20260117T004421`
+4. **Cleaner discovery**: List directories instead of globbing JSON files
+
+## Files to Update
+
+### Code Changes (TypeScript)
+
+| File                                                   | Change                                                                                               |
+| ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `apps/epicenter/src/lib/services/workspaces.ts`        | Update `getDefinitionPath()`, `listWorkspaces()`, `createWorkspaceDefinition()`, `deleteWorkspace()` |
+| `apps/epicenter/src/lib/docs/workspace-persistence.ts` | Update comment on line 56-57                                                                         |
+
+### Documentation Changes (Markdown)
+
+| File                                                                 | Change                                     |
+| -------------------------------------------------------------------- | ------------------------------------------ |
+| `apps/epicenter/src/lib/docs/README.md`                              | Update storage layout diagram and examples |
+| `specs/20260201T120000-simple-definition-first-workspace.md`         | Update storage layout                      |
+| `specs/20260201T120000-simple-definition-first-workspace-handoff.md` | Update storage references                  |
+| `specs/20260109T174900-epicenter-app-three-fetch-migration.md`       | Update path reference                      |
+| `packages/epicenter/src/core/schema/schema-file.ts`                  | Update JSDoc comment                       |
+
+### Files Already Correct (no changes needed)
+
+These files already reference `definition.json` inside the folder:
+
+- `specs/20260117T004421-workspace-input-normalization.md` (original spec - correct)
+- `specs/20260119T150426-workspace-storage-architecture.md`
+- `docs/specs/20260123T102500-single-workspace-architecture.md`
+- `docs/specs/20260122T225052-subdoc-architecture.md`
+
+## Implementation Plan
+
+### Part 1: Update Core Service (`workspaces.ts`)
+
+- [ ] Change `getDefinitionPath()` to return `join(workspacesDir, id, 'definition.json')`
+- [ ] Update `listWorkspaces()` to:
+  1. Read directories (not JSON files)
+  2. For each directory, read `definition.json` inside it
+- [ ] Update `createWorkspaceDefinition()` to:
+  1. Create workspace folder first
+  2. Write `definition.json` inside the folder
+- [ ] Update `deleteWorkspace()` to only delete the folder (definition is inside)
+
+### Part 2: Update Documentation
+
+- [ ] Update `apps/epicenter/src/lib/docs/README.md` storage layout
+- [ ] Update `apps/epicenter/src/lib/docs/workspace-persistence.ts` comment
+- [ ] Update `specs/20260201T120000-simple-definition-first-workspace.md`
+- [ ] Update `specs/20260201T120000-simple-definition-first-workspace-handoff.md`
+- [ ] Update `specs/20260109T174900-epicenter-app-three-fetch-migration.md`
+- [ ] Update `packages/epicenter/src/core/schema/schema-file.ts` JSDoc
+
+## Code Changes
+
+### `workspaces.ts` - Before
+
+```typescript
+async function getDefinitionPath(id: string): Promise<string> {
+	const workspacesDir = await getWorkspacesDir();
+	return join(workspacesDir, `${id}.json`);
+}
+
+export async function listWorkspaces(): Promise<WorkspaceDefinition[]> {
+	const workspacesDir = await getWorkspacesDir();
+	// ... reads *.json files
+	for (const entry of entries) {
+		if (!entry.name.endsWith('.json')) continue;
+		// ...
+	}
+}
+```
+
+### `workspaces.ts` - After
+
+```typescript
+async function getDefinitionPath(id: string): Promise<string> {
+	const workspacesDir = await getWorkspacesDir();
+	return join(workspacesDir, id, 'definition.json');
+}
+
+export async function listWorkspaces(): Promise<WorkspaceDefinition[]> {
+	const workspacesDir = await getWorkspacesDir();
+	// ... reads directories, then definition.json inside each
+	for (const entry of entries) {
+		if (!entry.isDirectory) continue;
+		const definitionPath = await join(
+			workspacesDir,
+			entry.name,
+			'definition.json',
+		);
+		// ...
+	}
+}
+```
+
+## Migration Consideration
+
+Existing workspaces will need migration. Options:
+
+1. **Manual migration**: User moves files manually (not recommended)
+2. **Automatic migration on startup**: App detects old format and migrates
+3. **Breaking change**: Since this is pre-release, just document the change
+
+**Recommendation**: Option 3 (breaking change) since Epicenter is pre-release. Document in changelog that users should manually move `{id}.json` to `{id}/definition.json`.
+
+## Testing
+
+1. Create a new workspace - verify `{id}/definition.json` is created
+2. List workspaces - verify discovery works
+3. Get workspace by ID - verify loading works
+4. Delete workspace - verify cleanup works
+5. Verify existing workspace data (`workspace.yjs`, `kv.json`) is unaffected
+
+---
+
+## Review
+
+### Summary
+
+Implemented the consolidation of workspace definition files from `{workspaceId}.json` (outside) to `{workspaceId}/definition.json` (inside the workspace folder).
+
+### Files Changed
+
+| File                                                                 | Change                                                                                                                    |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `apps/epicenter/src/lib/services/workspaces.ts`                      | Core CRUD service - updated `getDefinitionPath()`, `listWorkspaces()`, `createWorkspaceDefinition()`, `deleteWorkspace()` |
+| `apps/epicenter/src/lib/docs/workspace-persistence.ts`               | Updated JSDoc comment to reflect new storage layout                                                                       |
+| `apps/epicenter/src/lib/docs/README.md`                              | Updated storage layout diagram, examples, and discovery description                                                       |
+| `packages/epicenter/src/core/schema/schema-file.ts`                  | Updated JSDoc comment                                                                                                     |
+| `specs/20260201T120000-simple-definition-first-workspace.md`         | Updated storage layout and code examples                                                                                  |
+| `specs/20260201T120000-simple-definition-first-workspace-handoff.md` | Updated storage layout and references                                                                                     |
+| `specs/20260109T174900-epicenter-app-three-fetch-migration.md`       | Updated path reference                                                                                                    |
+
+### Key Implementation Details
+
+1. **`getDefinitionPath()`**: Now returns `join(workspacesDir, id, 'definition.json')` instead of `join(workspacesDir, `${id}.json`)`
+
+2. **`listWorkspaces()`**: Now lists directories (via `entry.isDirectory`) and reads `definition.json` from each, instead of globbing `*.json` files
+
+3. **`createWorkspaceDefinition()`**: Creates workspace folder first, then writes `definition.json` inside
+
+4. **`deleteWorkspace()`**: Simplified to just delete the folder recursively (definition is inside)
+
+### Migration Note
+
+This is a **breaking change** for existing workspaces. Users with existing workspaces need to manually migrate:
+
+```bash
+# For each workspace:
+mv {appLocalDataDir}/workspaces/{id}.json {appLocalDataDir}/workspaces/{id}/definition.json
+```
+
+### Verification
+
+- [x] All LSP diagnostics clean
+- [x] TypeScript compilation passes
+- [x] Code changes match the original spec architecture from `20260117T004421`


### PR DESCRIPTION
This consolidates workspace storage structure by moving the definition file inside the workspace folder, eliminating redundancy where the workspace ID appeared both as a JSON filename and as the folder name. This is a **breaking change** for existing workspaces.

The original architecture spec (`specs/20260117T004421-workspace-input-normalization.md`) had `definition.json` inside the workspace folder, but the implementation diverged from it. This PR realigns with that original design.

## Storage Layout

```
Before:
workspaces/
├── blog-workspace.json              ← Definition outside
├── blog-workspace/
│   ├── workspace.yjs
│   └── kv.json

After:
workspaces/
└── blog-workspace/
    ├── definition.json              ← Definition inside, self-contained
    ├── workspace.yjs
    └── kv.json
```

The key changes are in `workspaces.ts`:

- `getDefinitionPath()`: Returns `join(workspacesDir, id, 'definition.json')` instead of `join(workspacesDir, \`${id}.json\`)`
- `listWorkspaces()`: Lists directories and reads `definition.json` from each, instead of globbing `*.json` files
- `createWorkspaceDefinition()`: Creates folder first, then writes `definition.json` inside
- `deleteWorkspace()`: Simplified to just delete the folder recursively

This makes each workspace a self-contained, portable folder. The workspace ID only appears once (as the folder name), and discovery is cleaner (list directories vs glob JSON files).

## Migration

Users with existing workspaces need to manually move their definition files:

```bash
mv {appLocalDataDir}/workspaces/{id}.json {appLocalDataDir}/workspaces/{id}/definition.json
```

Spec: `specs/20260202T145245-consolidate-workspace-definition-inside-folder.md`