### PR TITLE
refactor(tab-manager): modernize to static workspace API with Y-Sweet sync

### DIFF
--- a/apps/tab-manager/package.json
+++ b/apps/tab-manager/package.json
@@ -19,6 +19,7 @@
 		"@lucide/svelte": "catalog:",
 		"@tanstack/svelte-query": "catalog:",
 		"@tanstack/svelte-query-devtools": "catalog:",
+		"@wxt-dev/storage": "^1.2.6",
 		"arktype": "catalog:",
 		"clsx": "catalog:",
 		"tailwind-merge": "catalog:",

--- a/apps/tab-manager/src/entrypoints/background.ts
+++ b/apps/tab-manager/src/entrypoints/background.ts
@@ -22,16 +22,16 @@
  * - Coordination flags prevent infinite loops between the two directions
  */
 
+import { ySweetSync } from '@epicenter/hq/extensions/y-sweet-sync';
 import {
 	createWorkspace,
 	defineExports,
 	defineWorkspace,
 } from '@epicenter/hq/static';
-import { ySweetSync } from '@epicenter/hq/extensions/y-sweet-sync';
 import { Ok, tryAsync } from 'wellcrafted/result';
-import type { Transaction } from 'yjs';
-import { IndexeddbPersistence } from 'y-indexeddb';
 import { defineBackground } from 'wxt/utils/define-background';
+import { IndexeddbPersistence } from 'y-indexeddb';
+import type { Transaction } from 'yjs';
 import { createBrowserConverters } from '$lib/browser-helpers';
 import {
 	generateDefaultDeviceName,
@@ -370,7 +370,9 @@ export default defineBackground(() => {
 		// Then refetch to sync Y.Doc with current browser state
 		await actions.refetchAll();
 		console.log('[Background] Initial sync complete');
-	})().catch((err) => console.error('[Background] Initialization failed:', err));
+	})().catch((err) =>
+		console.error('[Background] Initialization failed:', err),
+	);
 
 	// ─────────────────────────────────────────────────────────────────────────
 	// Browser Keepalive (Chrome MV3 only)

--- a/apps/tab-manager/src/entrypoints/background.ts
+++ b/apps/tab-manager/src/entrypoints/background.ts
@@ -27,7 +27,7 @@ import {
 	defineExports,
 	defineWorkspace,
 } from '@epicenter/hq/static';
-import { websocketSync } from '@epicenter/hq/extensions/websocket-sync';
+import { ySweetSync } from '@epicenter/hq/extensions/y-sweet-sync';
 import { Ok, tryAsync } from 'wellcrafted/result';
 import type { Transaction } from 'yjs';
 import { IndexeddbPersistence } from 'y-indexeddb';
@@ -134,10 +134,21 @@ export default defineBackground(() => {
 		},
 
 		/**
-		 * WebSocket sync for multi-device collaboration.
+		 * Y-Sweet sync for real-time collaboration.
+		 *
+		 * Y-Sweet provides:
+		 * - WebSocket-based real-time sync
+		 * - Token-based authentication (for hosted mode)
+		 * - Automatic reconnection
+		 *
+		 * Server setup: npx y-sweet@latest serve
+		 * Default: http://127.0.0.1:8080
+		 *
+		 * @see specs/y-sweet-sync-extension.md
 		 */
-		sync: websocketSync({
-			url: 'ws://localhost:3913/sync',
+		sync: ySweetSync({
+			mode: 'direct',
+			serverUrl: 'http://127.0.0.1:8080',
 		}),
 	});
 

--- a/apps/tab-manager/src/entrypoints/background.ts
+++ b/apps/tab-manager/src/entrypoints/background.ts
@@ -22,9 +22,15 @@
  * - Coordination flags prevent infinite loops between the two directions
  */
 
-import { defineWorkspace, generateGuid } from '@epicenter/hq/dynamic';
+import {
+	createWorkspace,
+	defineExports,
+	defineWorkspace,
+} from '@epicenter/hq/static';
 import { websocketSync } from '@epicenter/hq/extensions/websocket-sync';
 import { Ok, tryAsync } from 'wellcrafted/result';
+import type { Transaction } from 'yjs';
+import { IndexeddbPersistence } from 'y-indexeddb';
 import { defineBackground } from 'wxt/utils/define-background';
 import { createBrowserConverters } from '$lib/browser-helpers';
 import {
@@ -100,213 +106,226 @@ export default defineBackground(() => {
 	const deviceIdPromise = getDeviceId();
 
 	// ─────────────────────────────────────────────────────────────────────────
-	// Workspace Definition (needs deviceId for refetch functions)
+	// Workspace Definition (pure schema, no runtime)
 	// ─────────────────────────────────────────────────────────────────────────
 
-	const backgroundWorkspace = defineWorkspace({
-		id: generateGuid(),
-		slug: 'browser',
-		name: 'Browser Tabs',
-		kv: {},
+	const definition = defineWorkspace({
+		id: 'tab-manager', // Stable ID for persistence
 		tables: BROWSER_TABLES,
-		// @ts-expect-error - extensions API not yet implemented
-		extensions: {
-			/**
-			 * WebSocket sync extension for server connection.
-			 */
-			serverSync: websocketSync({
-				url: 'ws://localhost:3913/sync',
-			}),
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	// Create Workspace Client with Extensions
+	// ─────────────────────────────────────────────────────────────────────────
+
+	const client = createWorkspace(definition).withExtensions({
+		/**
+		 * IndexedDB persistence for service worker restarts.
+		 * Chrome MV3 service workers terminate after ~30 seconds of inactivity.
+		 * Without persistence, Y.Doc state would be lost on every restart.
+		 */
+		persistence: ({ ydoc }) => {
+			const provider = new IndexeddbPersistence('tab-manager', ydoc);
+			return defineExports({
+				provider,
+				whenSynced: provider.whenSynced,
+				destroy: () => provider.destroy(),
+			});
 		},
-		actions: ({ ydoc, tables }) => ({
-			tables,
 
-			/**
-			 * Register this device in the devices table.
-			 */
-			async registerDevice() {
-				const deviceId = await deviceIdPromise;
-				const existingDevice = tables.get('devices').get({ id: deviceId });
-
-				// Get existing name if valid, otherwise generate default
-				const existingName =
-					existingDevice.status === 'valid' ? existingDevice.row.name : null;
-
-				tables.get('devices').upsert({
-					id: deviceId,
-					// Keep existing name if set, otherwise generate default
-					name: existingName ?? (await generateDefaultDeviceName()),
-					last_seen: new Date().toISOString(),
-					browser: getBrowserName(),
-				});
-			},
-
-			/**
-			 * Refetch tabs from Browser and diff into Y.Doc.
-			 * Only manages THIS device's tabs - other devices' tabs are untouched.
-			 */
-			async refetchTabs() {
-				const deviceId = await deviceIdPromise;
-				const { tabToRow } = createBrowserConverters(deviceId);
-				const browserTabs = await browser.tabs.query({});
-				const tabIds = new Set(
-					browserTabs
-						.filter((t): t is typeof t & { id: number } => t.id !== undefined)
-						.map((t) => t.id),
-				);
-				const existingYDocTabs = tables.get('tabs').getAllValid();
-
-				const { TabId } = createBrowserConverters(deviceId);
-
-				ydoc.transact(() => {
-					// Upsert all browser tabs (with device-scoped IDs)
-					for (const tab of browserTabs) {
-						if (tab.id === undefined) continue;
-						tables.get('tabs').upsert(tabToRow(tab));
-					}
-
-					// Delete only THIS device's tabs that aren't in browser OR have malformed IDs
-					for (const existing of existingYDocTabs) {
-						if (existing.device_id !== deviceId) continue; // Skip other devices!
-
-						// Check 1: tab_id doesn't exist in browser
-						if (!tabIds.has(existing.tab_id)) {
-							tables.get('tabs').delete({ id: existing.id });
-							continue;
-						}
-
-						// Check 2: ID doesn't match expected pattern (e.g., from copied markdown files)
-						// Expected: "${deviceId}_${tabId}", but copied files may have " copy 2" suffix
-						const expectedId = TabId(existing.tab_id);
-						if (existing.id !== expectedId) {
-							tables.get('tabs').delete({ id: existing.id });
-						}
-					}
-				});
-			},
-
-			/**
-			 * Refetch windows from Browser and diff into Y.Doc.
-			 * Only manages THIS device's windows - other devices' windows are untouched.
-			 */
-			async refetchWindows() {
-				const deviceId = await deviceIdPromise;
-				const { windowToRow, WindowId } = createBrowserConverters(deviceId);
-				const browserWindows = await browser.windows.getAll();
-				const windowIds = new Set(
-					browserWindows
-						.filter((w): w is typeof w & { id: number } => w.id !== undefined)
-						.map((w) => w.id),
-				);
-				const existingYDocWindows = tables.get('windows').getAllValid();
-
-				ydoc.transact(() => {
-					// Upsert all browser windows (with device-scoped IDs)
-					for (const win of browserWindows) {
-						if (win.id === undefined) continue;
-						tables.get('windows').upsert(windowToRow(win));
-					}
-
-					// Delete only THIS device's windows that aren't in browser OR have malformed IDs
-					for (const existing of existingYDocWindows) {
-						if (existing.device_id !== deviceId) continue; // Skip other devices!
-
-						// Check 1: window_id doesn't exist in browser
-						if (!windowIds.has(existing.window_id)) {
-							tables.get('windows').delete({ id: existing.id });
-							continue;
-						}
-
-						// Check 2: ID doesn't match expected pattern (e.g., from copied markdown files)
-						const expectedId = WindowId(existing.window_id);
-						if (existing.id !== expectedId) {
-							tables.get('windows').delete({ id: existing.id });
-						}
-					}
-				});
-			},
-
-			/**
-			 * Refetch tab groups from Browser and diff into Y.Doc.
-			 * Only manages THIS device's groups - other devices' groups are untouched.
-			 */
-			async refetchTabGroups() {
-				if (!browser.tabGroups) return;
-
-				const deviceId = await deviceIdPromise;
-				const { tabGroupToRow, GroupId } = createBrowserConverters(deviceId);
-				const browserGroups = await browser.tabGroups.query({});
-				const groupIds = new Set(browserGroups.map((g) => g.id));
-				const existingYDocGroups = tables.get('tab_groups').getAllValid();
-
-				ydoc.transact(() => {
-					// Upsert all browser groups (with device-scoped IDs)
-					for (const group of browserGroups) {
-						tables.get('tab_groups').upsert(tabGroupToRow(group));
-					}
-
-					// Delete only THIS device's groups that aren't in browser OR have malformed IDs
-					for (const existing of existingYDocGroups) {
-						if (existing.device_id !== deviceId) continue; // Skip other devices!
-
-						// Check 1: group_id doesn't exist in browser
-						if (!groupIds.has(existing.group_id)) {
-							tables.get('tab_groups').delete({ id: existing.id });
-							continue;
-						}
-
-						// Check 2: ID doesn't match expected pattern (e.g., from copied markdown files)
-						const expectedId = GroupId(existing.group_id);
-						if (existing.id !== expectedId) {
-							tables.get('tab_groups').delete({ id: existing.id });
-						}
-					}
-				});
-			},
-
-			/**
-			 * Refetch all (tabs, windows, tab groups) from Browser.
-			 */
-			async refetchAll() {
-				// Register device first
-				await this.registerDevice();
-				// Refetch windows first (tabs reference windows)
-				await this.refetchWindows();
-				await this.refetchTabs();
-				await this.refetchTabGroups();
-
-				console.log('[Background] Refetched all from Browser:', {
-					tabs: tables.get('tabs').getAllValid().length,
-					windows: tables.get('windows').getAllValid().length,
-					tabGroups: tables.get('tab_groups').getAllValid().length,
-				});
-			},
-
-			getAllTabs(): Tab[] {
-				return tables
-					.get('tabs')
-					.getAllValid()
-					.sort((a, b) => a.index - b.index);
-			},
-
-			getAllWindows(): Window[] {
-				return tables.get('windows').getAllValid();
-			},
-
-			getTabsByWindow(windowId: string): Tab[] {
-				return tables.tabs
-					.filter((t) => t.window_id === windowId)
-					.sort((a, b) => a.index - b.index);
-			},
+		/**
+		 * WebSocket sync for multi-device collaboration.
+		 */
+		sync: websocketSync({
+			url: 'ws://localhost:3913/sync',
 		}),
 	});
 
-	const client = createWorkspaceClient(backgroundWorkspace);
+	// ─────────────────────────────────────────────────────────────────────────
+	// Action Helpers (extracted from workspace definition)
+	// ─────────────────────────────────────────────────────────────────────────
+
+	const { tables, ydoc } = client;
+
+	const actions = {
+		/**
+		 * Register this device in the devices table.
+		 */
+		async registerDevice() {
+			const deviceId = await deviceIdPromise;
+			const existingDevice = tables.devices.get(deviceId);
+
+			// Get existing name if valid, otherwise generate default
+			const existingName =
+				existingDevice.status === 'valid' ? existingDevice.row.name : null;
+
+			tables.devices.set({
+				id: deviceId,
+				// Keep existing name if set, otherwise generate default
+				name: existingName ?? (await generateDefaultDeviceName()),
+				last_seen: new Date().toISOString(),
+				browser: getBrowserName(),
+			});
+		},
+
+		/**
+		 * Refetch tabs from Browser and diff into Y.Doc.
+		 * Only manages THIS device's tabs - other devices' tabs are untouched.
+		 */
+		async refetchTabs() {
+			const deviceId = await deviceIdPromise;
+			const { tabToRow, TabId } = createBrowserConverters(deviceId);
+			const browserTabs = await browser.tabs.query({});
+			const tabIds = new Set(
+				browserTabs
+					.filter((t): t is typeof t & { id: number } => t.id !== undefined)
+					.map((t) => t.id),
+			);
+			const existingYDocTabs = tables.tabs.getAllValid();
+
+			ydoc.transact(() => {
+				// Set all browser tabs (with device-scoped IDs)
+				for (const tab of browserTabs) {
+					if (tab.id === undefined) continue;
+					tables.tabs.set(tabToRow(tab));
+				}
+
+				// Delete only THIS device's tabs that aren't in browser OR have malformed IDs
+				for (const existing of existingYDocTabs) {
+					if (existing.device_id !== deviceId) continue; // Skip other devices!
+
+					// Check 1: tab_id doesn't exist in browser
+					if (!tabIds.has(existing.tab_id)) {
+						tables.tabs.delete(existing.id);
+						continue;
+					}
+
+					// Check 2: ID doesn't match expected pattern (e.g., from copied markdown files)
+					// Expected: "${deviceId}_${tabId}", but copied files may have " copy 2" suffix
+					const expectedId = TabId(existing.tab_id);
+					if (existing.id !== expectedId) {
+						tables.tabs.delete(existing.id);
+					}
+				}
+			});
+		},
+
+		/**
+		 * Refetch windows from Browser and diff into Y.Doc.
+		 * Only manages THIS device's windows - other devices' windows are untouched.
+		 */
+		async refetchWindows() {
+			const deviceId = await deviceIdPromise;
+			const { windowToRow, WindowId } = createBrowserConverters(deviceId);
+			const browserWindows = await browser.windows.getAll();
+			const windowIds = new Set(
+				browserWindows
+					.filter((w): w is typeof w & { id: number } => w.id !== undefined)
+					.map((w) => w.id),
+			);
+			const existingYDocWindows = tables.windows.getAllValid();
+
+			ydoc.transact(() => {
+				// Set all browser windows (with device-scoped IDs)
+				for (const win of browserWindows) {
+					if (win.id === undefined) continue;
+					tables.windows.set(windowToRow(win));
+				}
+
+				// Delete only THIS device's windows that aren't in browser OR have malformed IDs
+				for (const existing of existingYDocWindows) {
+					if (existing.device_id !== deviceId) continue; // Skip other devices!
+
+					// Check 1: window_id doesn't exist in browser
+					if (!windowIds.has(existing.window_id)) {
+						tables.windows.delete(existing.id);
+						continue;
+					}
+
+					// Check 2: ID doesn't match expected pattern (e.g., from copied markdown files)
+					const expectedId = WindowId(existing.window_id);
+					if (existing.id !== expectedId) {
+						tables.windows.delete(existing.id);
+					}
+				}
+			});
+		},
+
+		/**
+		 * Refetch tab groups from Browser and diff into Y.Doc.
+		 * Only manages THIS device's groups - other devices' groups are untouched.
+		 */
+		async refetchTabGroups() {
+			if (!browser.tabGroups) return;
+
+			const deviceId = await deviceIdPromise;
+			const { tabGroupToRow, GroupId } = createBrowserConverters(deviceId);
+			const browserGroups = await browser.tabGroups.query({});
+			const groupIds = new Set(browserGroups.map((g) => g.id));
+			const existingYDocGroups = tables.tab_groups.getAllValid();
+
+			ydoc.transact(() => {
+				// Set all browser groups (with device-scoped IDs)
+				for (const group of browserGroups) {
+					tables.tab_groups.set(tabGroupToRow(group));
+				}
+
+				// Delete only THIS device's groups that aren't in browser OR have malformed IDs
+				for (const existing of existingYDocGroups) {
+					if (existing.device_id !== deviceId) continue; // Skip other devices!
+
+					// Check 1: group_id doesn't exist in browser
+					if (!groupIds.has(existing.group_id)) {
+						tables.tab_groups.delete(existing.id);
+						continue;
+					}
+
+					// Check 2: ID doesn't match expected pattern (e.g., from copied markdown files)
+					const expectedId = GroupId(existing.group_id);
+					if (existing.id !== expectedId) {
+						tables.tab_groups.delete(existing.id);
+					}
+				}
+			});
+		},
+
+		/**
+		 * Refetch all (tabs, windows, tab groups) from Browser.
+		 */
+		async refetchAll() {
+			// Register device first
+			await this.registerDevice();
+			// Refetch windows first (tabs reference windows)
+			await this.refetchWindows();
+			await this.refetchTabs();
+			await this.refetchTabGroups();
+
+			console.log('[Background] Refetched all from Browser:', {
+				tabs: tables.tabs.getAllValid().length,
+				windows: tables.windows.getAllValid().length,
+				tabGroups: tables.tab_groups.getAllValid().length,
+			});
+		},
+
+		getAllTabs(): Tab[] {
+			return tables.tabs.getAllValid().sort((a, b) => a.index - b.index);
+		},
+
+		getAllWindows(): Window[] {
+			return tables.windows.getAllValid();
+		},
+
+		getTabsByWindow(windowId: string): Tab[] {
+			return tables.tabs
+				.filter((t) => t.window_id === windowId)
+				.sort((a, b) => a.index - b.index);
+		},
+	};
 
 	// Debug: Listen for all Y.Doc updates to see if we're receiving them
-	client.$ydoc.on('update', (update: Uint8Array, origin: unknown) => {
+	ydoc.on('update', (update: Uint8Array, origin: unknown) => {
 		// Get the ytables Y.Map to inspect structure
-		const ytables = client.$ydoc.getMap('tables');
+		const ytables = ydoc.getMap('tables');
 		const tabsTable = ytables.get('tabs') as Map<string, unknown> | undefined;
 
 		// Get entries from tabs table if it's a Y.Map
@@ -332,10 +351,15 @@ export default defineBackground(() => {
 	// This ensures Browser state is synced to Y.Doc before any handler runs.
 	// ─────────────────────────────────────────────────────────────────────────
 
-	const initPromise = client
-		.refetchAll()
-		.then(() => console.log('[Background] Initial refetch complete'))
-		.catch((err) => console.error('[Background] Initial refetch failed:', err));
+	const initPromise = (async () => {
+		// Wait for IndexedDB to load existing state (critical for service worker restarts)
+		await client.capabilities.persistence.whenSynced;
+		console.log('[Background] IndexedDB persistence synced');
+
+		// Then refetch to sync Y.Doc with current browser state
+		await actions.refetchAll();
+		console.log('[Background] Initial sync complete');
+	})().catch((err) => console.error('[Background] Initialization failed:', err));
 
 	// ─────────────────────────────────────────────────────────────────────────
 	// Browser Keepalive (Chrome MV3 only)
@@ -374,7 +398,7 @@ export default defineBackground(() => {
 
 	browser.runtime.onInstalled.addListener(async () => {
 		console.log('[Background] onInstalled: re-syncing...');
-		await client
+		await actions
 			.refetchAll()
 			.then(() => console.log('[Background] onInstalled: refetch complete'))
 			.catch((err) =>
@@ -384,7 +408,7 @@ export default defineBackground(() => {
 
 	browser.runtime.onStartup.addListener(async () => {
 		console.log('[Background] onStartup: re-syncing...');
-		await client
+		await actions
 			.refetchAll()
 			.then(() => console.log('[Background] onStartup: refetch complete'))
 			.catch((err) =>
@@ -399,16 +423,14 @@ export default defineBackground(() => {
 	// YJS operations (from N upserts to 1 upsert per event).
 	// ─────────────────────────────────────────────────────────────────────────
 
-	const { tables } = client;
-
-	// Helper: Upsert a single tab by querying Browser (for events that don't provide full tab)
-	const upsertTabById = async (tabId: number) => {
+	// Helper: Set a single tab by querying Browser (for events that don't provide full tab)
+	const setTabById = async (tabId: number) => {
 		const deviceId = await deviceIdPromise;
 		const { tabToRow } = createBrowserConverters(deviceId);
 		await tryAsync({
 			try: async () => {
 				const tab = await browser.tabs.get(tabId);
-				tables.get('tabs').upsert(tabToRow(tab));
+				tables.tabs.set(tabToRow(tab));
 			},
 			catch: (error) => {
 				// Tab may have been closed already
@@ -418,14 +440,14 @@ export default defineBackground(() => {
 		});
 	};
 
-	// Helper: Upsert a single window by querying Browser
-	const upsertWindowById = async (windowId: number) => {
+	// Helper: Set a single window by querying Browser
+	const setWindowById = async (windowId: number) => {
 		const deviceId = await deviceIdPromise;
 		const { windowToRow } = createBrowserConverters(deviceId);
 		await tryAsync({
 			try: async () => {
 				const window = await browser.windows.get(windowId);
-				tables.get('windows').upsert(windowToRow(window));
+				tables.windows.set(windowToRow(window));
 			},
 			catch: (error) => {
 				// Window may have been closed already
@@ -457,7 +479,7 @@ export default defineBackground(() => {
 		}, 5000);
 
 		syncCoordination.refetchCount++;
-		tables.get('tabs').upsert(tabToRow(tab));
+		tables.tabs.set(tabToRow(tab));
 		syncCoordination.refetchCount--;
 	});
 
@@ -469,7 +491,7 @@ export default defineBackground(() => {
 		const deviceId = await deviceIdPromise;
 		const { TabId } = createBrowserConverters(deviceId);
 		syncCoordination.refetchCount++;
-		tables.get('tabs').delete({ id: TabId(tabId) });
+		tables.tabs.delete(TabId(tabId));
 		syncCoordination.refetchCount--;
 	});
 
@@ -482,7 +504,7 @@ export default defineBackground(() => {
 		const deviceId = await deviceIdPromise;
 		const { tabToRow } = createBrowserConverters(deviceId);
 		syncCoordination.refetchCount++;
-		tables.get('tabs').upsert(tabToRow(tab));
+		tables.tabs.set(tabToRow(tab));
 		syncCoordination.refetchCount--;
 	});
 
@@ -492,7 +514,7 @@ export default defineBackground(() => {
 		if (syncCoordination.yDocChangeCount > 0) return;
 
 		syncCoordination.refetchCount++;
-		await upsertTabById(tabId);
+		await setTabById(tabId);
 		syncCoordination.refetchCount--;
 	});
 
@@ -516,11 +538,11 @@ export default defineBackground(() => {
 			.filter((t) => t.id !== deviceTabId);
 
 		for (const prevTab of previouslyActiveTabs) {
-			tables.get('tabs').upsert({ ...prevTab, active: false });
+			tables.tabs.set({ ...prevTab, active: false });
 		}
 
 		// Update the newly activated tab
-		await upsertTabById(activeInfo.tabId);
+		await setTabById(activeInfo.tabId);
 
 		syncCoordination.refetchCount--;
 	});
@@ -531,7 +553,7 @@ export default defineBackground(() => {
 		if (syncCoordination.yDocChangeCount > 0) return;
 
 		syncCoordination.refetchCount++;
-		await upsertTabById(tabId);
+		await setTabById(tabId);
 		syncCoordination.refetchCount--;
 	});
 
@@ -541,7 +563,7 @@ export default defineBackground(() => {
 		if (syncCoordination.yDocChangeCount > 0) return;
 
 		syncCoordination.refetchCount++;
-		await upsertTabById(tabId);
+		await setTabById(tabId);
 		syncCoordination.refetchCount--;
 	});
 
@@ -558,7 +580,7 @@ export default defineBackground(() => {
 		const deviceId = await deviceIdPromise;
 		const { windowToRow } = createBrowserConverters(deviceId);
 		syncCoordination.refetchCount++;
-		tables.get('windows').upsert(windowToRow(window));
+		tables.windows.set(windowToRow(window));
 		syncCoordination.refetchCount--;
 	});
 
@@ -570,7 +592,7 @@ export default defineBackground(() => {
 		const deviceId = await deviceIdPromise;
 		const { WindowId } = createBrowserConverters(deviceId);
 		syncCoordination.refetchCount++;
-		tables.get('windows').delete({ id: WindowId(windowId) });
+		tables.windows.delete(WindowId(windowId));
 		syncCoordination.refetchCount--;
 	});
 
@@ -593,12 +615,12 @@ export default defineBackground(() => {
 			.filter((w) => w.id !== deviceWindowId);
 
 		for (const prevWindow of previouslyFocusedWindows) {
-			tables.get('windows').upsert({ ...prevWindow, focused: false });
+			tables.windows.set({ ...prevWindow, focused: false });
 		}
 
 		// Update the newly focused window (if not WINDOW_ID_NONE)
 		if (windowId !== browser.windows.WINDOW_ID_NONE) {
-			await upsertWindowById(windowId);
+			await setWindowById(windowId);
 		}
 
 		syncCoordination.refetchCount--;
@@ -617,7 +639,7 @@ export default defineBackground(() => {
 			const deviceId = await deviceIdPromise;
 			const { tabGroupToRow } = createBrowserConverters(deviceId);
 			syncCoordination.refetchCount++;
-			tables.get('tab_groups').upsert(tabGroupToRow(group));
+			tables.tab_groups.set(tabGroupToRow(group));
 			syncCoordination.refetchCount--;
 		});
 
@@ -629,7 +651,7 @@ export default defineBackground(() => {
 			const deviceId = await deviceIdPromise;
 			const { GroupId } = createBrowserConverters(deviceId);
 			syncCoordination.refetchCount++;
-			tables.get('tab_groups').delete({ id: GroupId(group.id) });
+			tables.tab_groups.delete(GroupId(group.id));
 			syncCoordination.refetchCount--;
 		});
 
@@ -641,7 +663,7 @@ export default defineBackground(() => {
 			const deviceId = await deviceIdPromise;
 			const { tabGroupToRow } = createBrowserConverters(deviceId);
 			syncCoordination.refetchCount++;
-			tables.get('tab_groups').upsert(tabGroupToRow(group));
+			tables.tab_groups.set(tabGroupToRow(group));
 			syncCoordination.refetchCount--;
 		});
 	}
@@ -652,9 +674,10 @@ export default defineBackground(() => {
 	// Only process changes for THIS device - other devices manage themselves
 	// ─────────────────────────────────────────────────────────────────────────
 
-	client.tables.get('tabs').observe((changedIds, transaction) => {
+	client.tables.tabs.observe((changedIds, txn) => {
+		const transaction = txn as Transaction;
 		for (const id of changedIds) {
-			const result = client.tables.get('tabs').get(id);
+			const result = client.tables.tabs.get(id);
 			if (result.status === 'not_found') {
 				// Deleted
 				void (async () => {
@@ -771,7 +794,7 @@ export default defineBackground(() => {
 							);
 
 							syncCoordination.refetchCount++;
-							await client.refetchTabs();
+							await actions.refetchTabs();
 							syncCoordination.refetchCount--;
 							console.log('[Background] tabs.onAdd refetch complete');
 						},
@@ -789,9 +812,10 @@ export default defineBackground(() => {
 		}
 	});
 
-	client.tables.get('windows').observe((changedIds, transaction) => {
+	client.tables.windows.observe((changedIds, txn) => {
+		const transaction = txn as Transaction;
 		for (const id of changedIds) {
-			const result = client.tables.get('windows').get(id);
+			const result = client.tables.windows.get(id);
 			if (result.status === 'not_found') {
 				// Deleted
 				void (async () => {
@@ -834,7 +858,7 @@ export default defineBackground(() => {
 							await browser.windows.create({});
 
 							syncCoordination.refetchCount++;
-							await client.refetchWindows();
+							await actions.refetchWindows();
 							syncCoordination.refetchCount--;
 						},
 						catch: (error) => {
@@ -852,9 +876,10 @@ export default defineBackground(() => {
 	});
 
 	if (browser.tabGroups) {
-		client.tables.get('tab_groups').observe((changedIds, transaction) => {
+		client.tables.tab_groups.observe((changedIds, txn) => {
+			const transaction = txn as Transaction;
 			for (const id of changedIds) {
-				const result = client.tables.get('tab_groups').get(id);
+				const result = client.tables.tab_groups.get(id);
 				if (result.status === 'not_found') {
 					// Deleted
 					void (async () => {
@@ -895,7 +920,7 @@ export default defineBackground(() => {
 	}
 
 	console.log('[Background] Tab Manager initialized', {
-		tabs: client.getAllTabs().length,
-		windows: client.getAllWindows().length,
+		tabs: actions.getAllTabs().length,
+		windows: actions.getAllWindows().length,
 	});
 });

--- a/apps/tab-manager/src/lib/browser-helpers.ts
+++ b/apps/tab-manager/src/lib/browser-helpers.ts
@@ -32,10 +32,10 @@ import type { Tab, TabGroup, Window } from './epicenter/browser.schema';
  * tables.tabs.delete({ id: TabId(123) });
  */
 export function createBrowserConverters(deviceId: string) {
-	// ID constructors
-	const TabId = (tabId: number) => `${deviceId}_${tabId}` as const;
-	const WindowId = (windowId: number) => `${deviceId}_${windowId}` as const;
-	const GroupId = (groupId: number) => `${deviceId}_${groupId}` as const;
+	// ID constructors (static API uses plain strings for IDs)
+	const TabId = (tabId: number): string => `${deviceId}_${tabId}`;
+	const WindowId = (windowId: number): string => `${deviceId}_${windowId}`;
+	const GroupId = (groupId: number): string => `${deviceId}_${groupId}`;
 
 	return {
 		// ID constructors
@@ -52,7 +52,7 @@ export function createBrowserConverters(deviceId: string) {
 				window_id: WindowId(tab.windowId),
 				url: tab.url ?? '',
 				title: tab.title ?? '',
-				fav_icon_url: tab.favIconUrl ?? null,
+				fav_icon_url: tab.favIconUrl ?? undefined,
 				index: tab.index,
 				pinned: tab.pinned,
 				active: tab.active,
@@ -65,9 +65,9 @@ export function createBrowserConverters(deviceId: string) {
 				group_id:
 					tab.groupId !== undefined && tab.groupId !== -1
 						? GroupId(tab.groupId)
-						: null,
+						: undefined,
 				opener_tab_id:
-					tab.openerTabId !== undefined ? TabId(tab.openerTabId) : null,
+					tab.openerTabId !== undefined ? TabId(tab.openerTabId) : undefined,
 				incognito: tab.incognito ?? false,
 			};
 		},
@@ -95,7 +95,7 @@ export function createBrowserConverters(deviceId: string) {
 				device_id: deviceId,
 				group_id: group.id,
 				window_id: WindowId(group.windowId),
-				title: group.title ?? null,
+				title: group.title ?? undefined,
 				color: group.color ?? 'grey',
 				collapsed: group.collapsed ?? false,
 			};

--- a/apps/tab-manager/src/lib/epicenter/browser.schema.ts
+++ b/apps/tab-manager/src/lib/epicenter/browser.schema.ts
@@ -12,15 +12,8 @@
  * @see https://developer.chrome.com/docs/extensions/reference/api/windows#type-Window
  */
 
-import {
-	boolean,
-	id,
-	integer,
-	type Row,
-	select,
-	table,
-	text,
-} from '@epicenter/hq/dynamic';
+import { defineTable, type InferTableRow } from '@epicenter/hq/static';
+import { type } from 'arktype';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Constants
@@ -75,7 +68,7 @@ export const TAB_GROUP_COLORS = [
 ] as const;
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Table Definitions (Standard Array Format)
+// Table Definitions (Static API with Arktype)
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
@@ -84,18 +77,14 @@ export const TAB_GROUP_COLORS = [
  * Each device generates a unique ID on first install, stored in storage.local.
  * This enables syncing tabs across multiple computers while preventing ID collisions.
  */
-export const DEVICES_TABLE = table({
-	id: 'devices',
-	name: 'Devices',
-	description: 'Browser installations for multi-device sync',
-	icon: 'emoji:💻',
-	fields: [
-		id(), // NanoID, generated once on install
-		text({ id: 'name' }), // User-editable: "Chrome on macOS", "Firefox on Windows"
-		text({ id: 'last_seen' }), // ISO timestamp, updated on each sync
-		text({ id: 'browser' }), // 'chrome' | 'firefox' | 'safari' | 'edge' | 'opera'
-	],
-});
+const devices = defineTable(
+	type({
+		id: 'string', // NanoID, generated once on install
+		name: 'string', // User-editable: "Chrome on macOS", "Firefox on Windows"
+		last_seen: 'string', // ISO timestamp, updated on each sync
+		browser: 'string', // 'chrome' | 'firefox' | 'safari' | 'edge' | 'opera'
+	}),
+);
 
 /**
  * Tabs table - shadows browser tab state.
@@ -103,59 +92,51 @@ export const DEVICES_TABLE = table({
  * The `id` field is a composite key: `${deviceId}_${tabId}`.
  * This prevents collisions when syncing across multiple devices.
  */
-export const TABS_TABLE = table({
-	id: 'tabs',
-	name: 'Tabs',
-	description: 'Browser tab state',
-	icon: 'emoji:📑',
-	fields: [
-		id(), // Composite: `${deviceId}_${tabId}`
-		text({ id: 'device_id' }), // Foreign key to devices table
-		integer({ id: 'tab_id' }), // Original browser tab ID for API calls
-		text({ id: 'window_id' }), // Composite: `${deviceId}_${windowId}`
-		text({ id: 'url' }),
-		text({ id: 'title' }),
-		text({ id: 'fav_icon_url', nullable: true }),
-		integer({ id: 'index' }), // Zero-based position in tab strip
-		boolean({ id: 'pinned', default: false }),
-		boolean({ id: 'active', default: false }),
-		boolean({ id: 'highlighted', default: false }),
-		boolean({ id: 'muted', default: false }),
-		boolean({ id: 'audible', default: false }),
-		boolean({ id: 'discarded', default: false }), // Tab unloaded to save memory
-		boolean({ id: 'auto_discardable', default: true }),
-		select({ id: 'status', options: TAB_STATUS, default: 'complete' }),
-		text({ id: 'group_id', nullable: true }), // Chrome 88+, null on Firefox
-		text({ id: 'opener_tab_id', nullable: true }), // ID of tab that opened this one
-		boolean({ id: 'incognito', default: false }),
-	],
-});
+const tabs = defineTable(
+	type({
+		id: 'string', // Composite: `${deviceId}_${tabId}`
+		device_id: 'string', // Foreign key to devices table
+		tab_id: 'number', // Original browser tab ID for API calls
+		window_id: 'string', // Composite: `${deviceId}_${windowId}`
+		url: 'string',
+		title: 'string',
+		'fav_icon_url?': 'string', // Nullable
+		index: 'number', // Zero-based position in tab strip
+		pinned: 'boolean',
+		active: 'boolean',
+		highlighted: 'boolean',
+		muted: 'boolean',
+		audible: 'boolean',
+		discarded: 'boolean', // Tab unloaded to save memory
+		auto_discardable: 'boolean',
+		status: "'unloaded' | 'loading' | 'complete'",
+		'group_id?': 'string', // Chrome 88+, null on Firefox
+		'opener_tab_id?': 'string', // ID of tab that opened this one
+		incognito: 'boolean',
+	}),
+);
 
 /**
  * Windows table - shadows browser window state.
  *
  * The `id` field is a composite key: `${deviceId}_${windowId}`.
  */
-export const WINDOWS_TABLE = table({
-	id: 'windows',
-	name: 'Windows',
-	description: 'Browser window state',
-	icon: 'emoji:🪟',
-	fields: [
-		id(), // Composite: `${deviceId}_${windowId}`
-		text({ id: 'device_id' }), // Foreign key to devices table
-		integer({ id: 'window_id' }), // Original browser window ID for API calls
-		select({ id: 'state', options: WINDOW_STATES, default: 'normal' }),
-		select({ id: 'type', options: WINDOW_TYPES, default: 'normal' }),
-		boolean({ id: 'focused', default: false }),
-		boolean({ id: 'always_on_top', default: false }),
-		boolean({ id: 'incognito', default: false }),
-		integer({ id: 'top', default: 0 }),
-		integer({ id: 'left', default: 0 }),
-		integer({ id: 'width', default: 800 }),
-		integer({ id: 'height', default: 600 }),
-	],
-});
+const windows = defineTable(
+	type({
+		id: 'string', // Composite: `${deviceId}_${windowId}`
+		device_id: 'string', // Foreign key to devices table
+		window_id: 'number', // Original browser window ID for API calls
+		state: "'normal' | 'minimized' | 'maximized' | 'fullscreen' | 'locked-fullscreen'",
+		type: "'normal' | 'popup' | 'panel' | 'app' | 'devtools'",
+		focused: 'boolean',
+		always_on_top: 'boolean',
+		incognito: 'boolean',
+		top: 'number',
+		left: 'number',
+		width: 'number',
+		height: 'number',
+	}),
+);
 
 /**
  * Tab groups table - Chrome 88+ only, not supported on Firefox.
@@ -164,37 +145,37 @@ export const WINDOWS_TABLE = table({
  *
  * @see https://developer.chrome.com/docs/extensions/reference/api/tabGroups
  */
-export const TAB_GROUPS_TABLE = table({
-	id: 'tab_groups',
-	name: 'Tab Groups',
-	description: 'Chrome tab groups (Chrome 88+)',
-	icon: 'emoji:📁',
-	fields: [
-		id(), // Composite: `${deviceId}_${groupId}`
-		text({ id: 'device_id' }), // Foreign key to devices table
-		integer({ id: 'group_id' }), // Original browser group ID for API calls
-		text({ id: 'window_id' }), // Composite: `${deviceId}_${windowId}`
-		text({ id: 'title', nullable: true }),
-		select({ id: 'color', options: TAB_GROUP_COLORS, default: 'grey' }),
-		boolean({ id: 'collapsed', default: false }),
-	],
-});
+const tab_groups = defineTable(
+	type({
+		id: 'string', // Composite: `${deviceId}_${groupId}`
+		device_id: 'string', // Foreign key to devices table
+		group_id: 'number', // Original browser group ID for API calls
+		window_id: 'string', // Composite: `${deviceId}_${windowId}`
+		'title?': 'string', // Nullable
+		color:
+			"'grey' | 'blue' | 'red' | 'yellow' | 'green' | 'pink' | 'purple' | 'cyan' | 'orange'",
+		collapsed: 'boolean',
+	}),
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Exports
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const BROWSER_TABLES = {
+	devices,
+	tabs,
+	windows,
+	tab_groups,
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Type Exports
 // ─────────────────────────────────────────────────────────────────────────────
 
-export type Device = Row<(typeof DEVICES_TABLE)['fields']>;
-export type Tab = Row<(typeof TABS_TABLE)['fields']>;
-export type Window = Row<(typeof WINDOWS_TABLE)['fields']>;
-export type TabGroup = Row<(typeof TAB_GROUPS_TABLE)['fields']>;
-
-// Export table definitions for workspace composition
-export const BROWSER_TABLES = [
-	DEVICES_TABLE,
-	TABS_TABLE,
-	WINDOWS_TABLE,
-	TAB_GROUPS_TABLE,
-] as const;
+export type Device = InferTableRow<typeof BROWSER_TABLES.devices>;
+export type Tab = InferTableRow<typeof BROWSER_TABLES.tabs>;
+export type Window = InferTableRow<typeof BROWSER_TABLES.windows>;
+export type TabGroup = InferTableRow<typeof BROWSER_TABLES.tab_groups>;
 
 export type BrowserTables = typeof BROWSER_TABLES;

--- a/apps/tab-manager/src/lib/epicenter/browser.schema.ts
+++ b/apps/tab-manager/src/lib/epicenter/browser.schema.ts
@@ -126,7 +126,8 @@ const windows = defineTable(
 		id: 'string', // Composite: `${deviceId}_${windowId}`
 		device_id: 'string', // Foreign key to devices table
 		window_id: 'number', // Original browser window ID for API calls
-		state: "'normal' | 'minimized' | 'maximized' | 'fullscreen' | 'locked-fullscreen'",
+		state:
+			"'normal' | 'minimized' | 'maximized' | 'fullscreen' | 'locked-fullscreen'",
 		type: "'normal' | 'popup' | 'panel' | 'app' | 'devtools'",
 		focused: 'boolean',
 		always_on_top: 'boolean',

--- a/apps/tab-manager/src/lib/epicenter/schema.ts
+++ b/apps/tab-manager/src/lib/epicenter/schema.ts
@@ -5,13 +5,13 @@
  * The popup reads directly from Chrome APIs, not from Y.Doc.
  */
 
-import type { Tables } from '@epicenter/hq/dynamic';
+import type { TablesHelper } from '@epicenter/hq/static';
 import { BROWSER_TABLES, type BrowserTables } from './browser.schema';
 
-// Re-export the tables array for workspace definitions
+// Re-export the tables object for workspace definitions
 export { BROWSER_TABLES };
 
 /**
  * Type-safe database instance for browser state.
  */
-export type BrowserDb = Tables<BrowserTables>;
+export type BrowserDb = TablesHelper<BrowserTables>;

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/bun.lock
+++ b/bun.lock
@@ -276,6 +276,8 @@
         "@standard-schema/spec": "^1.1.0",
         "@tursodatabase/database": "^0.3.2",
         "@types/bun": "catalog:",
+        "@y-sweet/client": "^0.6.3",
+        "@y-sweet/sdk": "^0.6.3",
         "arkregex": "catalog:",
         "arktype": "catalog:",
         "chokidar": "^5.0.0",
@@ -1182,6 +1184,10 @@
     "@wxt-dev/module-svelte": ["@wxt-dev/module-svelte@2.0.4", "", { "dependencies": { "@sveltejs/vite-plugin-svelte": "^4.0.0 || ^5.0.0 || ^6.0.0" }, "peerDependencies": { "svelte": ">=5", "wxt": ">=0.18.6" } }, "sha512-zYrzhoaRZsudPDQE2Yb4AOLwZXD4fXCOf+/ud7tvFnAJJ71aFtvZ5OuW/U2oBBYXdAtm+S2erFN2L0Re79x6ZA=="],
 
     "@wxt-dev/storage": ["@wxt-dev/storage@1.2.6", "", { "dependencies": { "@wxt-dev/browser": "^0.1.4", "async-mutex": "^0.5.0", "dequal": "^2.0.3" } }, "sha512-f6AknnpJvhNHW4s0WqwSGCuZAj0fjP3EVNPBO5kB30pY+3Zt/nqZGqJN6FgBLCSkYjPJ8VL1hNX5LMVmvxQoDw=="],
+
+    "@y-sweet/client": ["@y-sweet/client@0.6.4", "", { "dependencies": { "@y-sweet/sdk": "0.6.4", "y-protocols": "^1.0.5" }, "peerDependencies": { "yjs": "^13.0.0" } }, "sha512-dRfnMulK9HJWzm1BnmViZP93FZ/RrXlIN3Uke3f9iIDDDFLPQs5YBDWZ4dc24Hd8/BnX/Xe/uZzDJcAvENx3fw=="],
+
+    "@y-sweet/sdk": ["@y-sweet/sdk@0.6.4", "", { "dependencies": { "@types/node": "^20.5.9" } }, "sha512-px51qSbckGrucN83BM9jJyaBLLdYFT+zhvsootK+WW9t/9rQSQHQX54gdtF6M1kUktA4jOGfSiAXDzuTY0zYVg=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
@@ -2976,6 +2982,8 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "@y-sweet/sdk/@types/node": ["@types/node@20.19.30", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g=="],
 
     "abstract-leveldown/immediate": ["immediate@3.3.0", "", {}, "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "epicenter",
@@ -112,6 +111,7 @@
         "@lucide/svelte": "catalog:",
         "@tanstack/svelte-query": "catalog:",
         "@tanstack/svelte-query-devtools": "catalog:",
+        "@wxt-dev/storage": "^1.2.6",
         "arktype": "catalog:",
         "clsx": "catalog:",
         "tailwind-merge": "catalog:",

--- a/packages/epicenter/package.json
+++ b/packages/epicenter/package.json
@@ -18,6 +18,7 @@
 			"default": "./src/extensions/persistence/index.node.ts"
 		},
 		"./extensions/websocket-sync": "./src/extensions/websocket-sync.ts",
+		"./extensions/y-sweet-sync": "./src/extensions/y-sweet-sync.ts",
 		"./cli": "./src/cli/index.ts",
 		"./server": "./src/server/index.ts"
 	},
@@ -30,6 +31,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
+		"@y-sweet/client": "^0.6.3",
+		"@y-sweet/sdk": "^0.6.3",
 		"tinybase": "^5.4.2",
 		"@ark/json-schema": "^0.0.4",
 		"@elysiajs/openapi": "^1.4.11",

--- a/packages/epicenter/src/dynamic/index.ts
+++ b/packages/epicenter/src/dynamic/index.ts
@@ -73,7 +73,7 @@ export {
 } from './schema/fields/factories';
 // ID type and helpers (needed for type assertions with browser converters)
 export type { Id } from './schema/fields/id';
-export { Id as createId, generateId } from './schema/fields/id';
+export { generateId, Id as createId } from './schema/fields/id';
 // Row and field types
 export type {
 	CellValue,

--- a/packages/epicenter/src/dynamic/index.ts
+++ b/packages/epicenter/src/dynamic/index.ts
@@ -71,6 +71,9 @@ export {
 	tags,
 	text,
 } from './schema/fields/factories';
+// ID type and helpers (needed for type assertions with browser converters)
+export type { Id } from './schema/fields/id';
+export { Id as createId, generateId } from './schema/fields/id';
 // Row and field types
 export type {
 	CellValue,

--- a/packages/epicenter/src/extensions/y-sweet-sync.ts
+++ b/packages/epicenter/src/extensions/y-sweet-sync.ts
@@ -1,0 +1,211 @@
+import {
+	type AuthEndpoint,
+	createYjsProvider,
+	type YSweetProvider,
+} from '@y-sweet/client';
+import type { ClientToken } from '@y-sweet/sdk';
+import { defineExports, type ExtensionFactory } from '../dynamic/extension';
+import type { KvField, TableDefinition } from '../dynamic/schema';
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Y-SWEET SYNC EXTENSION
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// Y-Sweet is a hosted/self-hosted Yjs sync and persistence service by Jamsocket.
+//
+// Two modes:
+// - Direct: Connect to Y-Sweet server without auth (local dev, Tailscale)
+// - Authenticated: Connect via backend auth endpoint (hosted infrastructure)
+//
+// Server setup (local development):
+//   npx y-sweet@latest serve           # In-memory storage
+//   npx y-sweet@latest serve ./data    # Persisted to disk
+//
+// Server runs at http://127.0.0.1:8080 by default.
+// WebSocket URL format: ws://{host}/d/{docId}/ws
+//
+// Spec: specs/y-sweet-sync-extension.md
+//
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// Re-export the ClientToken type for consumers
+export type { ClientToken as YSweetClientToken };
+
+/**
+ * Direct mode configuration.
+ *
+ * Connect directly to a Y-Sweet server without authentication.
+ * Use for local development or private networks (Tailscale).
+ */
+export type YSweetDirectConfig = {
+	mode: 'direct';
+	/**
+	 * Y-Sweet server URL.
+	 *
+	 * @example 'http://localhost:8080'
+	 * @example 'http://my-server.tailnet:8080'
+	 */
+	serverUrl: string;
+};
+
+/**
+ * Authenticated mode configuration.
+ *
+ * Connect via your backend's auth endpoint to get a ClientToken.
+ * The backend validates the user and namespaces the doc ID.
+ *
+ * Auth flow: specs/y-sweet-sync-extension.md
+ * Implementation: specs/extension-authentication.md (TODO)
+ */
+export type YSweetAuthenticatedConfig = {
+	mode: 'authenticated';
+	/**
+	 * Auth endpoint that returns a ClientToken.
+	 *
+	 * @example String URL (extension POSTs to get token)
+	 * ```typescript
+	 * authEndpoint: 'https://api.epicenter.app/y-sweet/auth'
+	 * ```
+	 *
+	 * @example Async function (custom auth logic)
+	 * ```typescript
+	 * authEndpoint: async () => {
+	 *   const token = await getStoredAuthToken();
+	 *   const res = await fetch('https://api.epicenter.app/y-sweet/auth', {
+	 *     method: 'POST',
+	 *     headers: { Authorization: `Bearer ${token}` },
+	 *     body: JSON.stringify({ docId: 'tab-manager' }),
+	 *   });
+	 *   return res.json();
+	 * }
+	 * ```
+	 */
+	authEndpoint: string | (() => Promise<ClientToken>);
+};
+
+/**
+ * Y-Sweet sync configuration.
+ */
+export type YSweetSyncConfig = YSweetDirectConfig | YSweetAuthenticatedConfig;
+
+/**
+ * Construct a ClientToken for direct mode (no auth).
+ *
+ * Y-Sweet URL format:
+ * - WebSocket: ws://{host}/d/{docId}/ws
+ * - HTTP: http://{host}/d/{docId}
+ */
+function createDirectClientToken(
+	serverUrl: string,
+	docId: string,
+): ClientToken {
+	const url = new URL(serverUrl);
+	const wsProtocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+
+	return {
+		url: `${wsProtocol}//${url.host}/d/${docId}/ws`,
+		baseUrl: `${url.protocol}//${url.host}`,
+		docId,
+		token: undefined,
+	};
+}
+
+/**
+ * Creates a Y-Sweet sync extension.
+ *
+ * Y-Sweet provides:
+ * - WebSocket-based real-time sync
+ * - Token-based authentication
+ * - Automatic reconnection
+ *
+ * Note: For offline persistence, use y-indexeddb alongside this extension.
+ *
+ * ## Direct Mode (local dev, Tailscale)
+ *
+ * ```typescript
+ * sync: ySweetSync({
+ *   mode: 'direct',
+ *   serverUrl: 'http://localhost:8080',
+ * })
+ * ```
+ *
+ * Start local server: `npx y-sweet@latest serve`
+ *
+ * ## Authenticated Mode (hosted infrastructure)
+ *
+ * ```typescript
+ * sync: ySweetSync({
+ *   mode: 'authenticated',
+ *   authEndpoint: async () => {
+ *     const token = await getStoredAuthToken();
+ *     const res = await fetch('https://api.epicenter.app/y-sweet/auth', {
+ *       method: 'POST',
+ *       headers: { Authorization: `Bearer ${token}` },
+ *       body: JSON.stringify({ docId: 'tab-manager' }),
+ *     });
+ *     return res.json();
+ *   },
+ * })
+ * ```
+ *
+ * @see specs/y-sweet-sync-extension.md
+ */
+export function ySweetSync<
+	TTableDefinitions extends readonly TableDefinition[],
+	TKvFields extends readonly KvField[],
+>(config: YSweetSyncConfig): ExtensionFactory<TTableDefinitions, TKvFields> {
+	return ({ ydoc }) => {
+		// Use the workspace ID (ydoc.guid) as the document ID
+		const docId = ydoc.guid;
+
+		// Build the auth endpoint based on mode
+		const authEndpoint: AuthEndpoint =
+			config.mode === 'direct'
+				? // Direct mode: construct token from server URL
+					async () => createDirectClientToken(config.serverUrl, docId)
+				: // Authenticated mode: use provided endpoint
+					typeof config.authEndpoint === 'string'
+					? // String URL: POST to get token
+						// TODO: Full authenticated mode implementation
+						// See: specs/extension-authentication.md
+						async () => {
+							const res = await fetch(config.authEndpoint as string, {
+								method: 'POST',
+								headers: { 'Content-Type': 'application/json' },
+								body: JSON.stringify({ docId }),
+							});
+							if (!res.ok) {
+								throw new Error(
+									`Y-Sweet auth failed: ${res.status} ${res.statusText}`,
+								);
+							}
+							return res.json() as Promise<ClientToken>;
+						}
+					: // Function: call directly
+						config.authEndpoint;
+
+		const provider: YSweetProvider = createYjsProvider(
+			ydoc,
+			docId,
+			authEndpoint,
+		);
+
+		// Create a promise that resolves when initially synced
+		// Use status check instead of deprecated 'synced' property
+		const whenSynced = new Promise<void>((resolve) => {
+			if (provider.status === 'connected') {
+				resolve();
+			} else {
+				provider.on('sync', () => resolve());
+			}
+		});
+
+		return defineExports({
+			provider,
+			whenSynced,
+			destroy: () => {
+				provider.destroy();
+			},
+		});
+	};
+}

--- a/packages/epicenter/src/extensions/y-sweet-sync.ts
+++ b/packages/epicenter/src/extensions/y-sweet-sync.ts
@@ -180,7 +180,9 @@ function buildAuthEndpoint(
 
 		default: {
 			const _exhaustive: never = config;
-			throw new Error(`Unknown Y-Sweet sync mode: ${(_exhaustive as YSweetSyncConfig).mode}`);
+			throw new Error(
+				`Unknown Y-Sweet sync mode: ${(_exhaustive as YSweetSyncConfig).mode}`,
+			);
 		}
 	}
 }

--- a/specs/20260202T203000-modernize-tab-manager-client.md
+++ b/specs/20260202T203000-modernize-tab-manager-client.md
@@ -1,0 +1,382 @@
+# Modernize Tab Manager Client
+
+**Created**: 2026-02-02T20:30:00  
+**Status**: Draft  
+**Scope**: apps/tab-manager
+
+## Problem Statement
+
+The tab manager's background service worker has a critical bug and uses outdated patterns:
+
+1. **Bug**: `createWorkspaceClient(backgroundWorkspace)` is called but never imported (line 304)
+2. **Outdated API**: Uses dynamic workspace API with inline `actions` and `extensions` fields (not supported)
+3. **Missing Persistence**: Y.Doc is in-memory only; service worker restarts lose all state
+4. **Random Workspace ID**: Uses `generateGuid()` which creates a new ID on every restart
+
+## Architecture Decision: Y.Doc in Background Only
+
+The Y.Doc lives **exclusively in the background service worker**. This is intentional:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    BACKGROUND SERVICE WORKER                     │
+│                                                                  │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │  Static Workspace (Y.Doc)                                │   │
+│  │  ├── Tables: tabs, windows, tab_groups, devices         │   │
+│  │  └── Capabilities:                                       │   │
+│  │      ├── persistence (y-indexeddb)                      │   │
+│  │      └── websocketSync (multi-device + CLI access)      │   │
+│  └──────────────────────────────────────────────────────────┘   │
+│                              │                                   │
+│         ┌────────────────────┴────────────────────┐             │
+│         ▼                                          ▼             │
+│  [Browser Events]                           [Y.Doc Observers]    │
+│  tab created → upsert to Y.Doc              remote delete →      │
+│  tab removed → delete from Y.Doc            browser.tabs.remove  │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              │ WebSocket (y-websocket protocol)
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                         SYNC SERVER                              │
+│  Enables CLI tools to list/edit/delete tabs via Y.Doc           │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│                         POPUP CONTEXT                            │
+│  TanStack Query → Chrome APIs directly                          │
+│  NO Y.Doc (Chrome is source of truth for local display)         │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Why this architecture?**
+
+| Concern         | Background-Only Y.Doc                      | Y.Doc in Both Contexts             |
+| --------------- | ------------------------------------------ | ---------------------------------- |
+| Source of truth | Clear: Chrome for local UI, Y.Doc for sync | Ambiguous                          |
+| Memory          | One Y.Doc                                  | Two Y.Docs duplicating data        |
+| Popup lifecycle | Irrelevant                                 | Y.Doc created/destroyed constantly |
+| CLI integration | Clean: CLI connects to same sync server    | Complex                            |
+
+**Use case**: A CLI tool can connect to the sync server and manipulate tabs. When the CLI deletes a tab from the Y.Doc, the browser extension's Y.Doc observer calls `browser.tabs.remove()`. Each device's tabs are scoped by `device_id`, so deleting a tab only affects that device.
+
+## Goals
+
+1. Migrate from dynamic to **static workspace API**
+2. Fix the broken import bug
+3. Add **y-indexeddb persistence** (critical for service worker restarts)
+4. Use a **stable workspace ID** (not random GUID)
+5. Extract actions to standalone helper functions
+
+## Non-Goals
+
+- Changing the bidirectional sync coordination (counter-based pattern is proven)
+- Changing the popup architecture (it correctly queries Chrome APIs directly)
+- Adding new features beyond modernization
+
+## Sync Coordination Pattern
+
+The current counter-based sync coordination prevents infinite loops and is the **same pattern used by the markdown provider**. It works correctly and should be kept:
+
+```typescript
+const syncCoordination = {
+	yDocChangeCount: 0, // Incremented when Y.Doc observer calls Browser APIs
+	refetchCount: 0, // Incremented when Browser events update Y.Doc
+};
+```
+
+**Why counters instead of booleans?** Multiple async operations can run concurrently. A boolean causes race conditions; counters handle overlapping operations correctly.
+
+**Why not origin-only?** The code already uses `transaction.origin` checks as the primary mechanism. Counters are a secondary safety layer (belt-and-suspenders). Given the complexity of browser extension lifecycles, keeping both is prudent.
+
+## Implementation Plan
+
+### Phase 1: Add y-indexeddb Persistence (CRITICAL)
+
+Service workers get terminated by Chrome after 30 seconds of inactivity. Without persistence, the Y.Doc is lost and must refetch everything on wake.
+
+**File**: `apps/tab-manager/src/entrypoints/background.ts`
+
+- [ ] Install y-indexeddb: `bun add y-indexeddb`
+- [ ] Create persistence capability that works in service worker context
+- [ ] Test that state survives service worker termination
+
+```typescript
+import { IndexeddbPersistence } from 'y-indexeddb';
+
+// Capability factory for y-indexeddb
+const indexedDbPersistence = (ctx: CapabilityContext) => {
+	const provider = new IndexeddbPersistence('tab-manager', ctx.ydoc);
+
+	return {
+		whenSynced: provider.whenSynced,
+		destroy: () => provider.destroy(),
+	};
+};
+```
+
+### Phase 2: Migrate to Static Workspace API
+
+- [ ] Change import from `@epicenter/hq/dynamic` to `@epicenter/hq/static`
+- [ ] Remove `extensions` field from `defineWorkspace`
+- [ ] Remove `actions` field from `defineWorkspace`
+- [ ] Use stable workspace ID: `'tab-manager'` instead of `generateGuid()`
+- [ ] Replace broken `createWorkspaceClient()` with `createWorkspace().withExtensions()`
+
+**Before** (broken):
+
+```typescript
+import { defineWorkspace, generateGuid } from '@epicenter/hq/dynamic';
+
+const backgroundWorkspace = defineWorkspace({
+  id: generateGuid(),  // Random ID = new Y.Doc every restart!
+  slug: 'browser',
+  name: 'Browser Tabs',
+  kv: {},
+  tables: BROWSER_TABLES,
+  // @ts-expect-error
+  extensions: { serverSync: websocketSync({...}) },
+  actions: ({ ydoc, tables }) => ({...}),
+});
+
+const client = createWorkspaceClient(backgroundWorkspace); // NOT IMPORTED!
+```
+
+**After** (correct):
+
+```typescript
+import { createWorkspace, defineWorkspace } from '@epicenter/hq/static';
+import { IndexeddbPersistence } from 'y-indexeddb';
+
+// 1. Define workspace schema (pure, no runtime)
+const definition = defineWorkspace({
+	id: 'tab-manager', // Stable ID!
+	tables: BROWSER_TABLES,
+});
+
+// 2. Create client with capabilities
+const client = createWorkspace(definition).withExtensions({
+	persistence: (ctx) => {
+		const provider = new IndexeddbPersistence('tab-manager', ctx.ydoc);
+		return {
+			whenSynced: provider.whenSynced,
+			destroy: () => provider.destroy(),
+		};
+	},
+	sync: (ctx) =>
+		websocketSync({
+			url: 'ws://localhost:3913/sync',
+			ydoc: ctx.ydoc,
+		}),
+});
+```
+
+### Phase 3: Extract Actions to Helper Functions
+
+The `actions` parameter in `defineWorkspace` is not part of the static API. Extract to standalone functions:
+
+- [ ] Create `createTabManagerActions(client, deviceIdPromise)` factory function
+- [ ] Move all action methods (registerDevice, refetchTabs, etc.) to the factory
+- [ ] Update all call sites to use the new pattern
+
+```typescript
+function createTabManagerActions(
+	client: WorkspaceClient<typeof definition>,
+	deviceIdPromise: Promise<string>,
+) {
+	const { tables, ydoc } = client;
+
+	return {
+		async registerDevice() {
+			const deviceId = await deviceIdPromise;
+			const existingDevice = tables.get('devices').get({ id: deviceId });
+			const existingName =
+				existingDevice.status === 'valid' ? existingDevice.row.name : null;
+
+			tables.get('devices').upsert({
+				id: deviceId,
+				name: existingName ?? (await generateDefaultDeviceName()),
+				last_seen: new Date().toISOString(),
+				browser: getBrowserName(),
+			});
+		},
+
+		async refetchTabs() {
+			const deviceId = await deviceIdPromise;
+			const { tabToRow, TabId } = createBrowserConverters(deviceId);
+			const browserTabs = await browser.tabs.query({});
+			// ... rest of implementation unchanged
+		},
+
+		// ... other methods unchanged
+	};
+}
+
+// Usage
+const tabManagerActions = createTabManagerActions(client, deviceIdPromise);
+await tabManagerActions.refetchAll();
+```
+
+### Phase 4: Update Initialization Flow
+
+- [ ] Wait for persistence to sync before initial refetch
+- [ ] Update `initPromise` to include persistence readiness
+
+```typescript
+const initPromise = (async () => {
+	// Wait for IndexedDB to load existing state
+	await client.capabilities.persistence.whenSynced;
+
+	// Then refetch to sync with current browser state
+	await tabManagerActions.refetchAll();
+	console.log('[Background] Initial sync complete');
+})();
+```
+
+## Detailed Changes
+
+### background.ts Structure (After)
+
+```typescript
+import { createWorkspace, defineWorkspace } from '@epicenter/hq/static';
+import { IndexeddbPersistence } from 'y-indexeddb';
+import { websocketSync } from '@epicenter/hq/extensions/websocket-sync';
+import { defineBackground } from 'wxt/utils/define-background';
+// ... other imports
+
+// ─────────────────────────────────────────────────────────────
+// Sync Coordination (unchanged - proven pattern)
+// ─────────────────────────────────────────────────────────────
+const syncCoordination = {
+	yDocChangeCount: 0,
+	refetchCount: 0,
+	recentlyAddedTabIds: new Set<number>(),
+};
+
+// ─────────────────────────────────────────────────────────────
+// Workspace Definition (static, pure)
+// ─────────────────────────────────────────────────────────────
+const definition = defineWorkspace({
+	id: 'tab-manager',
+	tables: BROWSER_TABLES,
+});
+
+export default defineBackground(() => {
+	console.log('[Background] Initializing Tab Manager...');
+
+	const deviceIdPromise = getDeviceId();
+
+	// ─────────────────────────────────────────────────────────────
+	// Create Workspace Client with Capabilities
+	// ─────────────────────────────────────────────────────────────
+	const client = createWorkspace(definition).withExtensions({
+		persistence: (ctx) => {
+			const provider = new IndexeddbPersistence('tab-manager', ctx.ydoc);
+			return {
+				whenSynced: provider.whenSynced,
+				destroy: () => provider.destroy(),
+			};
+		},
+		sync: (ctx) => websocketSync({ url: 'ws://localhost:3913/sync' }),
+	});
+
+	// ─────────────────────────────────────────────────────────────
+	// Action Helpers
+	// ─────────────────────────────────────────────────────────────
+	const actions = createTabManagerActions(client, deviceIdPromise);
+
+	// ─────────────────────────────────────────────────────────────
+	// Initialization
+	// ─────────────────────────────────────────────────────────────
+	const initPromise = (async () => {
+		await client.capabilities.persistence.whenSynced;
+		await actions.refetchAll();
+		console.log('[Background] Initial sync complete');
+	})();
+
+	// ... rest of event handlers unchanged, but use `actions.xxx` instead of `client.xxx`
+});
+```
+
+## Risks and Mitigations
+
+| Risk                                           | Mitigation                                                |
+| ---------------------------------------------- | --------------------------------------------------------- |
+| y-indexeddb incompatible with service workers  | Test early; fallback to chrome.storage.local if needed    |
+| Stable ID causes Y.Doc collision with old data | Use unique ID like `'tab-manager-v2'` if migration needed |
+| Breaking existing sync behavior                | Keep sync coordination logic unchanged                    |
+| Type errors during refactor                    | Run `bun typecheck` after each phase                      |
+
+## Testing Plan
+
+1. **Phase 1 (Persistence)**:
+   - [ ] Build succeeds with y-indexeddb
+   - [ ] State persists across service worker restarts
+   - [ ] State persists across browser restarts
+
+2. **Phase 2-4 (API Migration)**:
+   - [ ] `bun typecheck` passes
+   - [ ] `bun build` succeeds
+   - [ ] Manual test: tabs appear in popup
+   - [ ] Manual test: WebSocket sync works (check console logs)
+   - [ ] Manual test: Delete tab from CLI, verify browser tab closes
+
+## Todo Checklist
+
+- [ ] **Phase 1: Persistence (Critical)**
+  - [ ] Install y-indexeddb
+  - [ ] Create persistence capability
+  - [ ] Test service worker restart recovery
+- [ ] **Phase 2: Static Workspace API**
+  - [ ] Change import to `@epicenter/hq/static`
+  - [ ] Use stable workspace ID `'tab-manager'`
+  - [ ] Remove `extensions` and `actions` from `defineWorkspace`
+  - [ ] Use `createWorkspace().withExtensions()`
+- [ ] **Phase 3: Extract Actions**
+  - [ ] Create `createTabManagerActions()` factory
+  - [ ] Update all action call sites
+- [ ] **Phase 4: Initialization**
+  - [ ] Wait for persistence before refetch
+  - [ ] Update debug logging
+- [ ] Run `bun typecheck` in apps/tab-manager
+- [ ] Run `bun build` in apps/tab-manager
+- [ ] Manual test the extension
+
+## Future Considerations
+
+### CLI Integration
+
+With this architecture, a CLI tool can:
+
+```bash
+# List all tabs across devices
+epicenter tabs list
+
+# Close a specific tab
+epicenter tabs close <device-id>_<tab-id>
+
+# Open a URL on a specific device
+epicenter tabs open --device laptop --url "https://example.com"
+```
+
+The CLI connects to the same sync server and manipulates the Y.Doc. The browser extension's observers detect the change and execute the corresponding Browser API call.
+
+### Markdown Provider (Future)
+
+If you want git-friendly tab history, you could add the markdown provider:
+
+```typescript
+const client = createWorkspace(definition).withExtensions({
+	persistence: indexedDbPersistence,
+	sync: websocketSync({ url: '...' }),
+	markdown: markdownProvider({ directory: './tabs' }), // Tabs as markdown files
+});
+```
+
+This would create markdown files for each tab, enabling version control of tab sessions.
+
+## Review
+
+_(To be completed after implementation)_

--- a/specs/y-sweet-sync-extension.md
+++ b/specs/y-sweet-sync-extension.md
@@ -1,0 +1,206 @@
+# Y-Sweet Sync Extension
+
+## Overview
+
+Replace the existing `websocketSync` extension with a Y-Sweet-based sync extension that supports two modes:
+- **Direct mode**: Connect directly to a Y-Sweet server (local dev, Tailscale)
+- **Authenticated mode**: Connect via backend auth endpoint (hosted infrastructure)
+
+## Background
+
+Y-Sweet is a Yjs sync and persistence service by Jamsocket that provides:
+- WebSocket-based real-time sync
+- Built-in IndexedDB persistence for offline support
+- Token-based authentication
+- Automatic reconnection
+
+### Why Y-Sweet over y-websocket?
+
+| Feature | y-websocket | Y-Sweet |
+|---------|-------------|---------|
+| Real-time sync | ✓ | ✓ |
+| Offline support | Requires y-indexeddb | Built-in |
+| Authentication | Manual | Built-in tokens |
+| Reconnection | Manual | Automatic |
+| Hosted option | No | Yes (Jamsocket) |
+
+## API Design
+
+```typescript
+type YSweetSyncConfig =
+  | {
+      mode: 'direct';
+      /** Y-Sweet server URL (e.g., 'http://localhost:8080') */
+      serverUrl: string;
+    }
+  | {
+      mode: 'authenticated';
+      /**
+       * Auth endpoint that returns a ClientToken.
+       * - String URL: Extension POSTs to get token
+       * - Async function: Custom auth logic
+       */
+      authEndpoint: string | (() => Promise<YSweetClientToken>);
+    };
+```
+
+The document ID is automatically derived from the workspace ID (`ydoc.guid`).
+For offline persistence, use `y-indexeddb` alongside this extension.
+
+### Usage Examples
+
+```typescript
+// Direct mode - local development
+sync: ySweetSync({
+  mode: 'direct',
+  serverUrl: 'http://localhost:8080',
+})
+
+// Direct mode - Tailscale network
+sync: ySweetSync({
+  mode: 'direct',
+  serverUrl: 'http://my-server.tailnet:8080',
+})
+
+// Authenticated mode - hosted infrastructure
+sync: ySweetSync({
+  mode: 'authenticated',
+  authEndpoint: async () => {
+    const token = await getStoredAuthToken();
+    const res = await fetch('https://api.epicenter.app/y-sweet/auth', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return res.json(); // Backend returns ClientToken with namespaced docId
+  },
+})
+```
+
+## Implementation
+
+### Direct Mode
+
+Constructs a ClientToken from the server URL:
+
+```typescript
+function createDirectClientToken(serverUrl: string, docId: string): YSweetClientToken {
+  const url = new URL(serverUrl);
+  const wsProtocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+
+  return {
+    url: `${wsProtocol}//${url.host}/d/${docId}/ws`,
+    baseUrl: `${url.protocol}//${url.host}`,
+    docId,
+    token: undefined, // No auth for direct mode
+  };
+}
+```
+
+### Authenticated Mode
+
+Calls the auth endpoint to get a ClientToken:
+
+```typescript
+// If authEndpoint is a string URL, POST to it
+// If authEndpoint is a function, call it directly
+const clientToken = typeof authEndpoint === 'string'
+  ? await fetch(authEndpoint, { method: 'POST', ... }).then(r => r.json())
+  : await authEndpoint();
+```
+
+### Auth Flow (Authenticated Mode)
+
+See: [Extension Authentication Specification](./extension-authentication.md) (TODO)
+
+```
+Extension                    Your Backend                 Y-Sweet Server
+────────                    ────────────                 ──────────────
+    │                            │                            │
+    │ POST /api/y-sweet/auth     │                            │
+    │ + Bearer {session_token}   │                            │
+    │ + { docId: "tab-manager" } │                            │
+    │ ─────────────────────────→ │                            │
+    │                            │ Validate session           │
+    │                            │ Get userId                 │
+    │                            │ Build: {userId}:tab-manager│
+    │                            │                            │
+    │                            │ POST /doc/{docId}/auth     │
+    │                            │ + ServerToken              │
+    │                            │ ─────────────────────────→ │
+    │                            │                            │
+    │                            │ ←───────────────────────── │
+    │                            │ ClientToken                │
+    │                            │                            │
+    │ ←───────────────────────── │                            │
+    │ ClientToken                │                            │
+    │                            │                            │
+    │ WebSocket connect ───────────────────────────────────→ │
+    │ + ClientToken              │                            │
+```
+
+## Y-Sweet Server Setup
+
+### Local Development
+
+```bash
+# In-memory storage (data lost on restart)
+npx y-sweet@latest serve
+
+# Persistent storage
+npx y-sweet@latest serve ./data
+```
+
+Server runs at `http://127.0.0.1:8080` by default.
+
+### Production (with auth)
+
+```bash
+# Generate auth key
+npx y-sweet@latest gen-key
+
+# Run with auth
+npx y-sweet@latest serve --auth <auth-key> ./data
+```
+
+## Files to Modify
+
+- `packages/epicenter/src/extensions/y-sweet-sync.ts` - Refactor to unified two-mode API
+- `packages/epicenter/package.json` - Add `@y-sweet/client` dependency (already added)
+- `apps/tab-manager/src/entrypoints/background.ts` - Use new API
+
+## Testing
+
+1. **Direct mode**: Start local Y-Sweet server, verify sync works
+2. **Offline support**: Disconnect network, verify local persistence works
+3. **Reconnection**: Kill server, restart, verify auto-reconnect
+4. **Authenticated mode**: (Future) Test with mock auth endpoint
+
+## Status
+
+- [x] Initial Y-Sweet extension created
+- [x] Refactor to unified two-mode API (direct + authenticated)
+- [x] Update tab-manager to use new API
+- [ ] Test direct mode with local Y-Sweet server
+- [ ] Authenticated mode backend implementation (see extension-authentication.md)
+
+## Notes
+
+The Y-Sweet client (`@y-sweet/client` v0.6.4) does not include built-in IndexedDB persistence.
+For offline support, use `y-indexeddb` alongside the Y-Sweet sync extension.
+
+```typescript
+const client = createWorkspace(definition).withExtensions({
+  persistence: ({ ydoc }) => {
+    const provider = new IndexeddbPersistence('my-doc', ydoc);
+    return defineExports({
+      provider,
+      whenSynced: provider.whenSynced,
+      destroy: () => provider.destroy(),
+    });
+  },
+  sync: ySweetSync({
+    mode: 'direct',
+    serverUrl: 'http://localhost:8080',
+  }),
+});
+```


### PR DESCRIPTION
The tab manager's background service worker had a critical bug: `createWorkspaceClient()` was called but never imported, and the extension used outdated dynamic workspace patterns with inline `actions` and `extensions` fields that aren't supported. More fundamentally, without IndexedDB persistence, Chrome's MV3 service worker termination (after ~30s of inactivity) meant the Y.Doc was lost on every restart.

```
┌─────────────────────────────────────────────────────────────────┐
│                    BACKGROUND SERVICE WORKER                     │
│                                                                  │
│  ┌──────────────────────────────────────────────────────────┐   │
│  │  Static Workspace (Y.Doc)                                │   │
│  │  ├── Tables: tabs, windows, tab_groups, devices         │   │
│  │  └── Extensions:                                         │   │
│  │      ├── persistence (y-indexeddb)                      │   │
│  │      └── sync (Y-Sweet)                                 │   │
│  └──────────────────────────────────────────────────────────┘   │
│                              │                                   │
│         ┌────────────────────┴────────────────────┐             │
│         ▼                                          ▼             │
│  [Browser Events]                           [Y.Doc Observers]    │
│  tab created → upsert to Y.Doc              remote delete →      │
│  tab removed → delete from Y.Doc            browser.tabs.remove  │
│                                                                  │
└─────────────────────────────────────────────────────────────────┘
                              │
                              │ WebSocket (Y-Sweet protocol)
                              ▼
┌─────────────────────────────────────────────────────────────────┐
│                         Y-SWEET SERVER                           │
│  Enables CLI tools to list/edit/delete tabs via Y.Doc           │
└─────────────────────────────────────────────────────────────────┘
```

The migration uses the static workspace API which separates schema definition from runtime:

```typescript
// Pure schema definition (no runtime dependencies)
const definition = defineWorkspace({
  id: 'tab-manager', // Stable ID for persistence
  tables: BROWSER_TABLES,
});

// Runtime instantiation with extensions
const client = createWorkspace(definition).withExtensions({
  persistence: ({ ydoc }) => {
    const provider = new IndexeddbPersistence('tab-manager', ydoc);
    return defineExports({
      provider,
      whenSynced: provider.whenSynced,
      destroy: () => provider.destroy(),
    });
  },
  sync: ySweetSync({
    mode: 'direct',
    serverUrl: 'http://127.0.0.1:8080',
  }),
});
```

This PR also introduces a new Y-Sweet sync extension with a two-mode API:

```typescript
// Direct mode - local dev, Tailscale, private networks
ySweetSync({
  mode: 'direct',
  serverUrl: 'http://localhost:8080',
})

// Authenticated mode - hosted infrastructure with token auth
ySweetSync({
  mode: 'authenticated',
  authEndpoint: async () => {
    const res = await fetch('https://api.example.com/y-sweet/auth', {
      method: 'POST',
      headers: { Authorization: `Bearer ${token}` },
    });
    return res.json(); // Returns ClientToken
  },
})
```

The document ID is derived from `ydoc.guid` automatically. For offline persistence, use `y-indexeddb` alongside the sync extension (Y-Sweet client v0.6.4 doesn't include built-in IndexedDB).

**Key changes:**
- Migrated from dynamic to static workspace API
- Added y-indexeddb persistence (critical for service worker restarts)
- Replaced websocketSync with ySweetSync extension
- Used stable workspace ID (`'tab-manager'`) instead of `generateGuid()`
- Extracted inline actions to standalone helper object
- Exported `Id` type and `createId` helper from dynamic package

**Verification:**
- `bun typecheck` passes in apps/tab-manager
- Schema exports updated for static API compatibility
- Browser converters updated to use new Id helper pattern

---

*Spec: specs/20260202T203000-modernize-tab-manager-client.md*