### PR TITLE
feat(epicenter-cli): add CRUD commands with single workspace mode

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/packages/epicenter/src/cli/README.md
+++ b/packages/epicenter/src/cli/README.md
@@ -67,6 +67,30 @@ epicenter serve --port 8080  # custom port
 
 Exposes REST API and WebSocket sync.
 
+## Working Directory
+
+By default, Epicenter looks for `epicenter.config.ts` in the current directory.
+
+Use `-C` or `--dir` to run from a different directory:
+
+```bash
+epicenter -C apps/blog posts list
+epicenter --dir apps/shop products get abc123
+```
+
+If no config is found in the current directory but configs exist in subdirectories, Epicenter shows a helpful message:
+
+```
+No epicenter.config.ts found in current directory.
+
+Found configs in subdirectories:
+  - apps/blog/epicenter.config.ts
+  - apps/shop/epicenter.config.ts
+
+Use -C <dir> to specify which project:
+  epicenter -C apps/blog <command>
+```
+
 ## Multiple Workspaces
 
 For multiple workspaces, use separate directories with their own `epicenter.config.ts` files.

--- a/packages/epicenter/src/cli/README.md
+++ b/packages/epicenter/src/cli/README.md
@@ -5,24 +5,23 @@ Manage workspace data and start the sync server.
 ## Command Structure
 
 ```bash
-epicenter table <name> <action>   # table operations
-epicenter kv <action>             # key-value operations
-epicenter tables                  # list table names
-epicenter workspaces              # list workspace names
-epicenter serve                   # start HTTP/WebSocket server
+epicenter <table> <action>  # table operations (e.g., posts list)
+epicenter kv <action>       # key-value operations
+epicenter tables            # list table names
+epicenter serve             # start HTTP/WebSocket server
 ```
 
 ## Table Commands
 
 ```bash
-epicenter table users list              # list all rows
-epicenter table users list --all        # include invalid rows
-epicenter table users get <id>          # get row by id
-epicenter table users set '<json>'      # create/replace row
-epicenter table users update <id> --name "New"  # partial update
-epicenter table users delete <id>       # delete row
-epicenter table users clear             # delete all rows
-epicenter table users count             # count rows
+epicenter users list              # list all rows
+epicenter users list --all        # include invalid rows
+epicenter users get <id>          # get row by id
+epicenter users set '<json>'      # create/replace row
+epicenter users update <id> --name "New"  # partial update
+epicenter users delete <id>       # delete row
+epicenter users clear             # delete all rows
+epicenter users count             # count rows
 ```
 
 ## KV Commands
@@ -33,40 +32,30 @@ epicenter kv set <key> <value>    # set value
 epicenter kv delete <key>         # delete key
 ```
 
-## Multi-Workspace Mode
-
-With multiple workspaces, prefix commands with the workspace name:
-
-```bash
-epicenter blog table posts list
-epicenter blog kv get theme
-epicenter shop table products get abc123
-```
-
 ## Input Methods
 
 ```bash
 # Inline JSON
-epicenter table users set '{"id":"1","name":"Alice"}'
+epicenter users set '{"id":"1","name":"Alice"}'
 
 # From file
-epicenter table users set --file user.json
-epicenter table users set @user.json
+epicenter users set --file user.json
+epicenter users set @user.json
 
 # From stdin
-cat user.json | epicenter table users set
+cat user.json | epicenter users set
 
 # Flag-based update
-epicenter table users update abc123 --name "Bob" --active true
+epicenter users update abc123 --name "Bob" --active true
 ```
 
 ## Output Formats
 
 ```bash
-epicenter table users list                  # pretty JSON (TTY)
-epicenter table users list | jq             # compact JSON (pipe)
-epicenter table users list --format json    # force JSON
-epicenter table users list --format jsonl   # JSON lines
+epicenter users list                  # pretty JSON (TTY)
+epicenter users list | jq             # compact JSON (pipe)
+epicenter users list --format json    # force JSON
+epicenter users list --format jsonl   # JSON lines
 ```
 
 ## Server
@@ -76,10 +65,14 @@ epicenter serve              # default port 3913
 epicenter serve --port 8080  # custom port
 ```
 
-Exposes REST API and WebSocket sync for all workspaces.
+Exposes REST API and WebSocket sync.
 
 ## Reserved Names
 
-Table names have no restrictions.
+Table names cannot match reserved commands: `serve`, `tables`, `kv`, `help`, `version`, `init`.
 
-Workspace names cannot be: `table`, `tables`, `kv`, `workspaces`, `serve`, `help`, `version`.
+If a table name conflicts, the CLI will log a warning but still work.
+
+## Multiple Workspaces
+
+For multiple workspaces, use separate directories with their own `epicenter.config.ts` files.

--- a/packages/epicenter/src/cli/README.md
+++ b/packages/epicenter/src/cli/README.md
@@ -67,12 +67,6 @@ epicenter serve --port 8080  # custom port
 
 Exposes REST API and WebSocket sync.
 
-## Reserved Names
-
-Table names cannot match reserved commands: `serve`, `tables`, `kv`, `help`, `version`, `init`.
-
-If a table name conflicts, the CLI will log a warning but still work.
-
 ## Multiple Workspaces
 
 For multiple workspaces, use separate directories with their own `epicenter.config.ts` files.

--- a/packages/epicenter/src/cli/bin.ts
+++ b/packages/epicenter/src/cli/bin.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { Ok, tryAsync } from 'wellcrafted/result';
+import { tryAsync } from 'wellcrafted/result';
 import { hideBin } from 'yargs/helpers';
 import { createCLI } from './cli';
 import { findProjectDir, loadClients } from './discovery';
@@ -13,7 +13,9 @@ async function main() {
 			const projectDir = await findProjectDir();
 			if (!projectDir) {
 				console.error('No epicenter.config.ts found.');
-				console.error('Create one that exports an array of workspace clients.');
+				console.error(
+					'Create one with named exports: export const myClient = createWorkspaceClient({...})',
+				);
 				process.exit(1);
 			}
 
@@ -27,7 +29,6 @@ async function main() {
 				console.error('Unknown error:', error);
 			}
 			process.exit(1);
-			return Ok(undefined);
 		},
 	});
 }

--- a/packages/epicenter/src/cli/bin.ts
+++ b/packages/epicenter/src/cli/bin.ts
@@ -1,17 +1,84 @@
 #!/usr/bin/env bun
 
+import { resolve } from 'node:path';
 import { tryAsync } from 'wellcrafted/result';
 import { hideBin } from 'yargs/helpers';
 import { createCLI } from './cli';
-import { findProjectDir, loadClients } from './discovery';
+import { findConfigsInSubdirs, findProjectDir, loadClient } from './discovery';
+
+/**
+ * Parse -C/--dir flag from argv BEFORE yargs processes subcommands.
+ * Returns the base directory and remaining args.
+ */
+function parseDirectoryFlag(argv: string[]): { baseDir: string; remainingArgs: string[] } {
+	const args = [...argv];
+	let baseDir = process.cwd();
+
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i]!;
+
+		// Handle -C <dir> or --dir <dir>
+		if (arg === '-C' || arg === '--dir') {
+			const nextArg = args[i + 1];
+			if (!nextArg || nextArg.startsWith('-')) {
+				console.error(`Error: ${arg} requires a directory argument`);
+				process.exit(1);
+			}
+			baseDir = resolve(nextArg);
+			args.splice(i, 2);
+			i--; // Adjust index after removal
+			continue;
+		}
+
+		// Handle -C=<dir> or --dir=<dir>
+		if (arg.startsWith('-C=')) {
+			baseDir = resolve(arg.slice(3));
+			args.splice(i, 1);
+			i--;
+			continue;
+		}
+		if (arg.startsWith('--dir=')) {
+			baseDir = resolve(arg.slice(6));
+			args.splice(i, 1);
+			i--;
+			continue;
+		}
+	}
+
+	return { baseDir, remainingArgs: args };
+}
 
 async function main() {
 	await tryAsync({
 		try: async () => {
 			await enableWatchMode();
 
-			const projectDir = await findProjectDir();
+			// Parse -C/--dir before anything else
+			const { baseDir, remainingArgs } = parseDirectoryFlag(hideBin(process.argv));
+
+			// Try to find config in the specified directory
+			const projectDir = await findProjectDir(baseDir);
+
 			if (!projectDir) {
+				// No config in CWD/specified dir - check for ambiguity in subdirs
+				const subdirConfigs = await findConfigsInSubdirs(baseDir);
+
+				if (subdirConfigs.length > 0) {
+					// Ambiguous: multiple configs in subdirectories
+					console.error('No epicenter.config.ts found in current directory.');
+					console.error('');
+					console.error('Found configs in subdirectories:');
+					for (const config of subdirConfigs) {
+						console.error(`  - ${config}`);
+					}
+					console.error('');
+					console.error('Use -C <dir> to specify which project:');
+					const exampleDir = subdirConfigs[0]!.replace('/epicenter.config.ts', '');
+					console.error(`  epicenter -C ${exampleDir} <command>`);
+					process.exit(1);
+				}
+
+				// No configs found anywhere
 				console.error('No epicenter.config.ts found.');
 				console.error(
 					'Create one with named exports: export const myClient = createWorkspaceClient({...})',
@@ -19,8 +86,8 @@ async function main() {
 				process.exit(1);
 			}
 
-			const clients = await loadClients(projectDir);
-			await createCLI(clients).run(hideBin(process.argv));
+			const client = await loadClient(projectDir);
+			await createCLI(client).run(remainingArgs);
 		},
 		catch: (error) => {
 			if (error instanceof Error) {

--- a/packages/epicenter/src/cli/bin.ts
+++ b/packages/epicenter/src/cli/bin.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { tryAsync } from 'wellcrafted/result';
 import { hideBin } from 'yargs/helpers';
 import { createCLI } from './cli';
@@ -73,7 +73,7 @@ async function main() {
 					}
 					console.error('');
 					console.error('Use -C <dir> to specify which project:');
-					const exampleDir = subdirConfigs[0]!.replace('/epicenter.config.ts', '');
+					const exampleDir = dirname(subdirConfigs[0]!);
 					console.error(`  epicenter -C ${exampleDir} <command>`);
 					process.exit(1);
 				}

--- a/packages/epicenter/src/cli/cli.ts
+++ b/packages/epicenter/src/cli/cli.ts
@@ -1,51 +1,36 @@
 import yargs from 'yargs';
 import { createServer, DEFAULT_PORT } from '../server/server';
 import type { Actions } from '../shared/actions';
-import type { WorkspaceClient } from '../static/types';
 import { buildActionCommands } from './command-builder';
 import { buildKvCommands } from './commands/kv-commands';
-import {
-	buildMetaCommands,
-	isReservedCommand,
-	RESERVED_COMMANDS,
-} from './commands/meta-commands';
+import { buildMetaCommands } from './commands/meta-commands';
 import { buildTableCommands } from './commands/table-commands';
-import { createCommandConfig, type CommandConfig } from './discovery';
-
-// biome-ignore lint/suspicious/noExplicitAny: WorkspaceClient is generic over tables/kv/capabilities
-type AnyWorkspaceClient = WorkspaceClient<any, any, any, any>;
+import type { AnyWorkspaceClient } from './discovery';
 
 type CLIOptions = {
 	actions?: Actions;
 };
 
-export function createCLI(
-	clients: AnyWorkspaceClient | AnyWorkspaceClient[],
-	options?: CLIOptions,
-) {
-	const clientArray = Array.isArray(clients) ? clients : [clients];
-	const config = createCommandConfig(clientArray);
-
-	// Validate workspace and table names don't conflict with reserved commands
-	validateNames(config);
-
+export function createCLI(client: AnyWorkspaceClient, options?: CLIOptions) {
 	let cli = yargs()
 		.scriptName('epicenter')
 		.usage('Usage: $0 <command> [options]')
 		.help()
 		.version()
 		.strict()
-		.option('port', {
-			type: 'number',
-			description: 'Port to run the server on',
-			default: DEFAULT_PORT,
-		})
 		.command(
 			'serve',
 			'Start HTTP server with REST and WebSocket sync endpoints',
-			() => {},
+			(yargs) =>
+				yargs.option('port', {
+					type: 'number',
+					description: 'Port to run the server on',
+					default: DEFAULT_PORT,
+				}),
 			(argv) => {
-				createServer(clientArray, {
+				// Cast needed: CLI uses static WorkspaceClient type, server uses dynamic type
+				// Both are structurally compatible at runtime
+				createServer(client as any, {
 					port: argv.port,
 					actions: options?.actions,
 				}).start();
@@ -53,19 +38,19 @@ export function createCLI(
 		);
 
 	// Add meta commands (tables, workspaces)
-	const metaCommands = buildMetaCommands(config);
+	const metaCommands = buildMetaCommands(client);
 	for (const cmd of metaCommands) {
 		cli = cli.command(cmd);
 	}
 
 	// Add table commands for each table in each workspace
-	const tableCommands = buildTableCommands(config);
+	const tableCommands = buildTableCommands(client);
 	for (const cmd of tableCommands) {
 		cli = cli.command(cmd);
 	}
 
 	// Add KV commands
-	const kvCommands = buildKvCommands(config);
+	const kvCommands = buildKvCommands(client);
 	for (const cmd of kvCommands) {
 		cli = cli.command(cmd);
 	}
@@ -81,9 +66,7 @@ export function createCLI(
 	return {
 		async run(argv: string[]) {
 			const cleanup = async () => {
-				for (const client of clientArray) {
-					await client.destroy();
-				}
+				await client.destroy();
 				process.exit(0);
 			};
 			process.on('SIGINT', cleanup);
@@ -94,40 +77,8 @@ export function createCLI(
 			} finally {
 				process.off('SIGINT', cleanup);
 				process.off('SIGTERM', cleanup);
-				for (const client of clientArray) {
-					await client.destroy();
-				}
+				await client.destroy();
 			}
 		},
 	};
-}
-
-/**
- * Validate that workspace and table names don't conflict with reserved commands.
- * Logs warnings for conflicts but doesn't fail.
- */
-function validateNames(config: CommandConfig): void {
-	const isSingleClient = config.mode === 'single';
-
-	for (const client of config.clients) {
-		// With multiple clients, check workspace names (they become commands)
-		if (!isSingleClient && isReservedCommand(client.id)) {
-			console.warn(
-				`Warning: Workspace "${client.id}" conflicts with reserved command. ` +
-					`Reserved commands: ${RESERVED_COMMANDS.join(', ')}`,
-			);
-		}
-
-		// With single client, check table names (they become top-level commands)
-		if (isSingleClient) {
-			for (const tableName of Object.keys(client.tables)) {
-				if (isReservedCommand(tableName)) {
-					console.warn(
-						`Warning: Table "${tableName}" conflicts with reserved command. ` +
-							`Reserved commands: ${RESERVED_COMMANDS.join(', ')}`,
-					);
-				}
-			}
-		}
-	}
 }

--- a/packages/epicenter/src/cli/commands/index.ts
+++ b/packages/epicenter/src/cli/commands/index.ts
@@ -1,0 +1,3 @@
+export * from './table-commands.js';
+export * from './kv-commands.js';
+export * from './meta-commands.js';

--- a/packages/epicenter/src/cli/commands/index.ts
+++ b/packages/epicenter/src/cli/commands/index.ts
@@ -1,3 +1,3 @@
-export * from './table-commands.js';
 export * from './kv-commands.js';
 export * from './meta-commands.js';
+export * from './table-commands.js';

--- a/packages/epicenter/src/cli/commands/kv-commands.ts
+++ b/packages/epicenter/src/cli/commands/kv-commands.ts
@@ -1,7 +1,7 @@
 import type { CommandModule } from 'yargs';
 import type { AnyWorkspaceClient } from '../discovery.js';
-import { parseJsonInput, readStdinSync } from '../parse-input.js';
 import { formatYargsOptions, output, outputError } from '../format-output.js';
+import { parseJsonInput, readStdinSync } from '../parse-input.js';
 
 /**
  * Build yargs commands for KV operations.

--- a/packages/epicenter/src/cli/commands/kv-commands.ts
+++ b/packages/epicenter/src/cli/commands/kv-commands.ts
@@ -1,31 +1,18 @@
 import type { CommandModule } from 'yargs';
-import type { AnyWorkspaceClient, CommandConfig } from '../discovery.js';
+import type { AnyWorkspaceClient } from '../discovery.js';
 import { parseJsonInput, readStdinSync } from '../parse-input.js';
 import { formatYargsOptions, output, outputError } from '../format-output.js';
 
 /**
  * Build yargs commands for KV operations.
- *
- * Single client: `kv <command>` (e.g., `kv get theme`)
- * Multiple clients: `<workspace> kv <command>` (e.g., `blog kv get theme`)
  */
-export function buildKvCommands(config: CommandConfig): CommandModule[] {
-	const commands: CommandModule[] = [];
-
-	for (const client of config.clients) {
-		const commandPath = config.mode === 'single' ? 'kv' : `${client.id} kv`;
-		commands.push(buildKvCommand(commandPath, client));
-	}
-
-	return commands;
+export function buildKvCommands(client: AnyWorkspaceClient): CommandModule[] {
+	return [buildKvCommand(client)];
 }
 
-function buildKvCommand(
-	commandPath: string,
-	client: AnyWorkspaceClient,
-): CommandModule {
+function buildKvCommand(client: AnyWorkspaceClient): CommandModule {
 	return {
-		command: `${commandPath} <action>`,
+		command: 'kv <action>',
 		describe: 'Manage key-value store',
 		builder: (yargs) => {
 			return yargs

--- a/packages/epicenter/src/cli/commands/kv-commands.ts
+++ b/packages/epicenter/src/cli/commands/kv-commands.ts
@@ -1,0 +1,162 @@
+import type { CommandModule } from 'yargs';
+import type { AnyWorkspaceClient, CommandConfig } from '../discovery.js';
+import { parseJsonInput, readStdinSync } from '../parse-input.js';
+import { formatYargsOptions, output, outputError } from '../format-output.js';
+
+/**
+ * Build yargs commands for KV operations.
+ *
+ * Single client: `kv <command>` (e.g., `kv get theme`)
+ * Multiple clients: `<workspace> kv <command>` (e.g., `blog kv get theme`)
+ */
+export function buildKvCommands(config: CommandConfig): CommandModule[] {
+	const commands: CommandModule[] = [];
+
+	for (const client of config.clients) {
+		const commandPath = config.mode === 'single' ? 'kv' : `${client.id} kv`;
+		commands.push(buildKvCommand(commandPath, client));
+	}
+
+	return commands;
+}
+
+function buildKvCommand(
+	commandPath: string,
+	client: AnyWorkspaceClient,
+): CommandModule {
+	return {
+		command: `${commandPath} <action>`,
+		describe: 'Manage key-value store',
+		builder: (yargs) => {
+			return yargs
+				.command({
+					command: 'list',
+					describe: 'List all KV entries',
+					builder: (y) => y.options(formatYargsOptions()),
+					handler: () => {
+						// KV doesn't have a built-in list method, so we need to iterate known keys
+						// For now, output a message indicating this limitation
+						// In a real implementation, you'd need access to the KV definition keys
+						outputError(
+							'KV list requires knowledge of defined keys. Use specific get commands.',
+						);
+						process.exitCode = 1;
+					},
+				})
+				.command({
+					command: 'get <key>',
+					describe: 'Get a value by key',
+					builder: (y) =>
+						y
+							.positional('key', { type: 'string', demandOption: true })
+							.options(formatYargsOptions()),
+					handler: (argv) => {
+						const key = argv.key as string;
+						try {
+							const result = client.kv.get(key);
+							if (result.status === 'not_found') {
+								outputError(`Key not found: ${key}`);
+								process.exitCode = 1;
+								return;
+							}
+							output(result, { format: argv.format as 'json' | 'jsonl' });
+						} catch (error) {
+							outputError(
+								`Error getting key "${key}": ${error instanceof Error ? error.message : String(error)}`,
+							);
+							process.exitCode = 1;
+						}
+					},
+				})
+				.command({
+					command: 'set <key> [value]',
+					describe: 'Set a value by key',
+					builder: (y) =>
+						y
+							.positional('key', { type: 'string', demandOption: true })
+							.positional('value', {
+								type: 'string',
+								description: 'JSON value or @file',
+							})
+							.option('file', {
+								type: 'string',
+								description: 'Read value from file',
+							})
+							.options(formatYargsOptions()),
+					handler: (argv) => {
+						const key = argv.key as string;
+
+						// Try to parse the value
+						const stdinContent = readStdinSync();
+						const valueStr = argv.value as string | undefined;
+
+						// For simple string values, allow non-JSON input
+						let value: unknown;
+						if (
+							valueStr &&
+							!valueStr.startsWith('{') &&
+							!valueStr.startsWith('[') &&
+							!valueStr.startsWith('"') &&
+							!valueStr.startsWith('@')
+						) {
+							// Treat as raw string value
+							value = valueStr;
+						} else {
+							const result = parseJsonInput({
+								positional: valueStr,
+								file: argv.file as string | undefined,
+								hasStdin: stdinContent !== undefined,
+								stdinContent,
+							});
+
+							if (!result.ok) {
+								outputError(result.error);
+								process.exitCode = 1;
+								return;
+							}
+							value = result.data;
+						}
+
+						try {
+							client.kv.set(key, value as never);
+							output(
+								{ status: 'set', key, value },
+								{ format: argv.format as 'json' | 'jsonl' },
+							);
+						} catch (error) {
+							outputError(
+								`Error setting key "${key}": ${error instanceof Error ? error.message : String(error)}`,
+							);
+							process.exitCode = 1;
+						}
+					},
+				})
+				.command({
+					command: 'delete <key>',
+					aliases: ['reset'],
+					describe: 'Delete a value by key (reset to undefined)',
+					builder: (y) =>
+						y
+							.positional('key', { type: 'string', demandOption: true })
+							.options(formatYargsOptions()),
+					handler: (argv) => {
+						const key = argv.key as string;
+						try {
+							client.kv.delete(key as never);
+							output(
+								{ status: 'deleted', key },
+								{ format: argv.format as 'json' | 'jsonl' },
+							);
+						} catch (error) {
+							outputError(
+								`Error deleting key "${key}": ${error instanceof Error ? error.message : String(error)}`,
+							);
+							process.exitCode = 1;
+						}
+					},
+				})
+				.demandCommand(1, 'Specify an action: list, get, set, delete');
+		},
+		handler: () => {},
+	};
+}

--- a/packages/epicenter/src/cli/commands/meta-commands.ts
+++ b/packages/epicenter/src/cli/commands/meta-commands.ts
@@ -1,6 +1,6 @@
 import type { CommandModule } from 'yargs';
 import type { AnyWorkspaceClient } from '../discovery.js';
-import { output, formatYargsOptions } from '../format-output.js';
+import { formatYargsOptions, output } from '../format-output.js';
 
 /**
  * Build meta commands (tables).

--- a/packages/epicenter/src/cli/commands/meta-commands.ts
+++ b/packages/epicenter/src/cli/commands/meta-commands.ts
@@ -1,0 +1,64 @@
+import type { CommandModule } from 'yargs';
+import type { CommandConfig } from '../discovery.js';
+import { output, formatYargsOptions } from '../format-output.js';
+
+/**
+ * Build meta commands (tables, workspaces).
+ */
+export function buildMetaCommands(config: CommandConfig): CommandModule[] {
+	const commands: CommandModule[] = [];
+
+	// 'tables' command - list all table names
+	commands.push({
+		command: 'tables',
+		describe: 'List all table names',
+		builder: (yargs) => yargs.options(formatYargsOptions()),
+		handler: (argv) => {
+			if (config.mode === 'single') {
+				// Single workspace: just list table names
+				const tableNames = Object.keys(config.clients[0]!.tables);
+				output(tableNames, { format: argv.format as any });
+			} else {
+				// Multi workspace: list tables per workspace
+				const result: Record<string, string[]> = {};
+				for (const client of config.clients) {
+					result[client.id] = Object.keys(client.tables);
+				}
+				output(result, { format: argv.format as any });
+			}
+		},
+	});
+
+	// 'workspaces' command - list all workspaces
+	commands.push({
+		command: 'workspaces',
+		describe: 'List all workspaces',
+		builder: (yargs) => yargs.options(formatYargsOptions()),
+		handler: (argv) => {
+			const ids = config.clients.map((c) => c.id);
+			output(ids, { format: argv.format as any });
+		},
+	});
+
+	return commands;
+}
+
+/** Reserved command names that cannot be used as workspace or table names */
+export const RESERVED_COMMANDS = [
+	'serve',
+	'tables',
+	'workspaces',
+	'kv',
+	'help',
+	'version',
+	'init',
+] as const;
+
+export type ReservedCommand = (typeof RESERVED_COMMANDS)[number];
+
+/**
+ * Check if a name is a reserved command.
+ */
+export function isReservedCommand(name: string): name is ReservedCommand {
+	return RESERVED_COMMANDS.includes(name as ReservedCommand);
+}

--- a/packages/epicenter/src/cli/commands/meta-commands.ts
+++ b/packages/epicenter/src/cli/commands/meta-commands.ts
@@ -1,53 +1,28 @@
 import type { CommandModule } from 'yargs';
-import type { CommandConfig } from '../discovery.js';
+import type { AnyWorkspaceClient } from '../discovery.js';
 import { output, formatYargsOptions } from '../format-output.js';
 
 /**
- * Build meta commands (tables, workspaces).
+ * Build meta commands (tables).
  */
-export function buildMetaCommands(config: CommandConfig): CommandModule[] {
-	const commands: CommandModule[] = [];
-
-	// 'tables' command - list all table names
-	commands.push({
-		command: 'tables',
-		describe: 'List all table names',
-		builder: (yargs) => yargs.options(formatYargsOptions()),
-		handler: (argv) => {
-			if (config.mode === 'single') {
-				// Single workspace: just list table names
-				const tableNames = Object.keys(config.clients[0]!.tables);
+export function buildMetaCommands(client: AnyWorkspaceClient): CommandModule[] {
+	return [
+		{
+			command: 'tables',
+			describe: 'List all table names',
+			builder: (yargs) => yargs.options(formatYargsOptions()),
+			handler: (argv) => {
+				const tableNames = Object.keys(client.tables);
 				output(tableNames, { format: argv.format as any });
-			} else {
-				// Multi workspace: list tables per workspace
-				const result: Record<string, string[]> = {};
-				for (const client of config.clients) {
-					result[client.id] = Object.keys(client.tables);
-				}
-				output(result, { format: argv.format as any });
-			}
+			},
 		},
-	});
-
-	// 'workspaces' command - list all workspaces
-	commands.push({
-		command: 'workspaces',
-		describe: 'List all workspaces',
-		builder: (yargs) => yargs.options(formatYargsOptions()),
-		handler: (argv) => {
-			const ids = config.clients.map((c) => c.id);
-			output(ids, { format: argv.format as any });
-		},
-	});
-
-	return commands;
+	];
 }
 
 /** Reserved command names that cannot be used as workspace or table names */
 export const RESERVED_COMMANDS = [
 	'serve',
 	'tables',
-	'workspaces',
 	'kv',
 	'help',
 	'version',

--- a/packages/epicenter/src/cli/commands/meta-commands.ts
+++ b/packages/epicenter/src/cli/commands/meta-commands.ts
@@ -18,22 +18,3 @@ export function buildMetaCommands(client: AnyWorkspaceClient): CommandModule[] {
 		},
 	];
 }
-
-/** Reserved command names that cannot be used as workspace or table names */
-export const RESERVED_COMMANDS = [
-	'serve',
-	'tables',
-	'kv',
-	'help',
-	'version',
-	'init',
-] as const;
-
-export type ReservedCommand = (typeof RESERVED_COMMANDS)[number];
-
-/**
- * Check if a name is a reserved command.
- */
-export function isReservedCommand(name: string): name is ReservedCommand {
-	return RESERVED_COMMANDS.includes(name as ReservedCommand);
-}

--- a/packages/epicenter/src/cli/commands/table-commands.ts
+++ b/packages/epicenter/src/cli/commands/table-commands.ts
@@ -1,0 +1,211 @@
+import type { CommandModule } from 'yargs';
+import type { CommandConfig } from '../discovery.js';
+import { parseJsonInput, readStdinSync } from '../parse-input.js';
+import { output, outputError, formatYargsOptions } from '../format-output.js';
+
+/**
+ * Build yargs commands for all tables in a workspace.
+ *
+ * Single client: `<table> <command>` (e.g., `posts list`)
+ * Multiple clients: `<workspace> <table> <command>` (e.g., `blog posts list`)
+ */
+export function buildTableCommands(config: CommandConfig): CommandModule[] {
+	const commands: CommandModule[] = [];
+
+	for (const client of config.clients) {
+		const tableNames = Object.keys(client.tables);
+
+		for (const tableName of tableNames) {
+			const tableHelper = (client.tables as Record<string, unknown>)[tableName];
+
+			const commandPath =
+				config.mode === 'single'
+					? tableName
+					: `${client.id} ${tableName}`;
+
+			commands.push(buildTableCommand(commandPath, tableName, tableHelper));
+		}
+	}
+
+	return commands;
+}
+
+function buildTableCommand(
+	commandPath: string,
+	tableName: string,
+	tableHelper: any, // TableHelper<any>
+): CommandModule {
+	return {
+		command: `${commandPath} <action>`,
+		describe: `Manage ${tableName} table`,
+		builder: (yargs) => {
+			return yargs
+				.command({
+					command: 'list',
+					describe: 'List all valid rows',
+					builder: (y) =>
+						y
+							.option('all', {
+								type: 'boolean',
+								description: 'Include invalid rows',
+							})
+							.options(formatYargsOptions()),
+					handler: (argv) => {
+						const rows = argv.all
+							? tableHelper.getAll()
+							: tableHelper.getAllValid();
+						output(rows, { format: argv.format as any });
+					},
+				})
+				.command({
+					command: 'get <id>',
+					describe: 'Get a row by ID',
+					builder: (y) =>
+						y
+							.positional('id', { type: 'string', demandOption: true })
+							.options(formatYargsOptions()),
+					handler: (argv) => {
+						const result = tableHelper.get(argv.id as string);
+						if (result.status === 'not_found') {
+							outputError(`Row not found: ${argv.id}`);
+							process.exitCode = 1;
+							return;
+						}
+						output(result, { format: argv.format as any });
+					},
+				})
+				.command({
+					command: 'set [json]',
+					describe: 'Create or replace a row (requires full row with id)',
+					builder: (y) =>
+						y
+							.positional('json', {
+								type: 'string',
+								description: 'JSON row data or @file',
+							})
+							.option('file', { type: 'string', description: 'Read from file' })
+							.options(formatYargsOptions()),
+					handler: (argv) => {
+						const stdinContent = readStdinSync();
+						const result = parseJsonInput({
+							positional: argv.json as string | undefined,
+							file: argv.file as string | undefined,
+							hasStdin: stdinContent !== undefined,
+							stdinContent,
+						});
+
+						if (result.ok === false) {
+							outputError(result.error);
+							process.exitCode = 1;
+							return;
+						}
+
+						const row = result.data as { id: string };
+						if (!row.id) {
+							outputError('Row must have an id field');
+							process.exitCode = 1;
+							return;
+						}
+
+						tableHelper.set(row);
+						output(row, { format: argv.format as any });
+					},
+				})
+				.command({
+					command: 'update <id>',
+					describe: 'Partial update a row using flags (e.g., --title "New Title")',
+					builder: (y) =>
+						y
+							.positional('id', { type: 'string', demandOption: true })
+							.options(formatYargsOptions())
+							.strict(false), // Allow unknown flags as field updates
+					handler: (argv) => {
+						const id = argv.id as string;
+
+						// Collect field updates from flags (exclude yargs internals)
+						const reservedKeys = new Set([
+							'_',
+							'$0',
+							'id',
+							'format',
+							'help',
+							'version',
+						]);
+						const partial: Record<string, unknown> = {};
+
+						for (const [key, value] of Object.entries(argv)) {
+							if (!reservedKeys.has(key) && !key.includes('-')) {
+								// Parse JSON values for objects/arrays, keep primitives as-is
+								if (
+									typeof value === 'string' &&
+									(value.startsWith('{') || value.startsWith('['))
+								) {
+									try {
+										partial[key] = JSON.parse(value);
+									} catch {
+										partial[key] = value;
+									}
+								} else {
+									partial[key] = value;
+								}
+							}
+						}
+
+						if (Object.keys(partial).length === 0) {
+							outputError(
+								'No fields to update. Use flags like --title "New Title"',
+							);
+							process.exitCode = 1;
+							return;
+						}
+
+						const updateResult = tableHelper.update(id, partial);
+						if (updateResult.status === 'not_found') {
+							outputError(`Row not found: ${id}`);
+							process.exitCode = 1;
+							return;
+						}
+						if (updateResult.status === 'invalid') {
+							outputError(`Row is invalid and cannot be updated`);
+							output(updateResult, { format: argv.format as any });
+							process.exitCode = 1;
+							return;
+						}
+						output(updateResult.row, { format: argv.format as any });
+					},
+				})
+				.command({
+					command: 'delete <id>',
+					describe: 'Delete a row by ID',
+					builder: (y) =>
+						y
+							.positional('id', { type: 'string', demandOption: true })
+							.options(formatYargsOptions()),
+					handler: (argv) => {
+						const result = tableHelper.delete(argv.id as string);
+						output(result, { format: argv.format as any });
+					},
+				})
+				.command({
+					command: 'clear',
+					describe: 'Delete all rows',
+					handler: () => {
+						tableHelper.clear();
+						output({ status: 'cleared' });
+					},
+				})
+				.command({
+					command: 'count',
+					describe: 'Count rows',
+					handler: () => {
+						output({ count: tableHelper.count() });
+					},
+				})
+				.demandCommand(
+					1,
+					'Specify an action: list, get, set, update, delete, clear, count',
+				);
+		},
+		handler: () => {},
+	};
+}

--- a/packages/epicenter/src/cli/commands/table-commands.ts
+++ b/packages/epicenter/src/cli/commands/table-commands.ts
@@ -1,12 +1,14 @@
 import type { CommandModule } from 'yargs';
 import type { AnyWorkspaceClient } from '../discovery.js';
+import { formatYargsOptions, output, outputError } from '../format-output.js';
 import { parseJsonInput, readStdinSync } from '../parse-input.js';
-import { output, outputError, formatYargsOptions } from '../format-output.js';
 
 /**
  * Build yargs commands for all tables in a workspace.
  */
-export function buildTableCommands(client: AnyWorkspaceClient): CommandModule[] {
+export function buildTableCommands(
+	client: AnyWorkspaceClient,
+): CommandModule[] {
 	const commands: CommandModule[] = [];
 	const tableNames = Object.keys(client.tables);
 
@@ -100,7 +102,8 @@ function buildTableCommand(
 				})
 				.command({
 					command: 'update <id>',
-					describe: 'Partial update a row using flags (e.g., --title "New Title")',
+					describe:
+						'Partial update a row using flags (e.g., --title "New Title")',
 					builder: (y) =>
 						y
 							.positional('id', { type: 'string', demandOption: true })

--- a/packages/epicenter/src/cli/discovery.ts
+++ b/packages/epicenter/src/cli/discovery.ts
@@ -1,6 +1,6 @@
-import { join, resolve } from 'node:path';
-import type { WorkspaceClient } from '../static/types';
+import { dirname, join, resolve } from 'node:path';
 import type { ProjectDir } from '../shared/types';
+import type { WorkspaceClient } from '../static/types';
 
 // biome-ignore lint/suspicious/noExplicitAny: WorkspaceClient is generic over tables/kv/capabilities
 export type AnyWorkspaceClient = WorkspaceClient<any, any, any, any>;
@@ -39,7 +39,7 @@ export async function findConfigsInSubdirs(dir: string): Promise<string[]> {
 		absolute: false,
 	})) {
 		// Get the directory containing the config (relative to search dir)
-		const configDir = path.replace(`/${CONFIG_FILENAME}`, '').replace(CONFIG_FILENAME, '.');
+		const configDir = dirname(path) || '.';
 		if (configDir !== '.') {
 			// Only include subdirectory configs, not the root
 			configs.push(path);

--- a/packages/epicenter/src/cli/discovery.ts
+++ b/packages/epicenter/src/cli/discovery.ts
@@ -1,4 +1,4 @@
-import { dirname, join, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import type { ProjectDir } from '../shared/types';
 import type { WorkspaceClient } from '../static/types';
 
@@ -7,79 +7,87 @@ export type AnyWorkspaceClient = WorkspaceClient<any, any, any, any>;
 
 const CONFIG_FILENAME = 'epicenter.config.ts';
 
+// ═══════════════════════════════════════════════════════════════════════════
+// RESULT TYPES
+// ═══════════════════════════════════════════════════════════════════════════
+
+export type WorkspaceResolution =
+	| { status: 'found'; projectDir: ProjectDir; client: AnyWorkspaceClient }
+	| { status: 'ambiguous'; configs: string[] }
+	| { status: 'not_found' };
+
+// ═══════════════════════════════════════════════════════════════════════════
+// MAIN ENTRY POINT
+// ═══════════════════════════════════════════════════════════════════════════
+
 /**
- * Check if a config file exists in the given directory (no upward traversal).
+ * Resolve and load a workspace from a directory.
+ *
+ * 1. Checks for config in the given directory
+ * 2. If not found, checks subdirectories for ambiguity detection
+ * 3. Loads and validates the client if found
  */
-export async function findProjectDir(
+export async function resolveWorkspace(
 	dir: string = process.cwd(),
-): Promise<ProjectDir | null> {
-	const resolved = resolve(dir);
-	const configPath = join(resolved, CONFIG_FILENAME);
+): Promise<WorkspaceResolution> {
+	const baseDir = resolve(dir);
+	const configPath = join(baseDir, CONFIG_FILENAME);
 
-	if (await fileExists(configPath)) {
-		return resolved as ProjectDir;
+	// Check for config in the specified directory
+	if (await Bun.file(configPath).exists()) {
+		const client = await loadClientFromPath(configPath);
+		return { status: 'found', projectDir: baseDir as ProjectDir, client };
 	}
 
-	return null;
-}
-
-/**
- * Find all epicenter.config.ts files in subdirectories of the given directory.
- * Uses Bun.Glob for efficient filesystem traversal.
- */
-export async function findConfigsInSubdirs(dir: string): Promise<string[]> {
-	const resolved = resolve(dir);
-	const glob = new Bun.Glob(`**/${CONFIG_FILENAME}`);
-
-	const configs: string[] = [];
-
-	for await (const path of glob.scan({
-		cwd: resolved,
-		onlyFiles: true,
-		absolute: false,
-	})) {
-		// Get the directory containing the config (relative to search dir)
-		const configDir = dirname(path) || '.';
-		if (configDir !== '.') {
-			// Only include subdirectory configs, not the root
-			configs.push(path);
-		}
+	// No config in target dir - check subdirs for helpful error message
+	const subdirConfigs = await findSubdirConfigs(baseDir);
+	if (subdirConfigs.length > 0) {
+		return { status: 'ambiguous', configs: subdirConfigs };
 	}
 
-	return configs.sort();
+	return { status: 'not_found' };
 }
 
-async function fileExists(path: string): Promise<boolean> {
-	return Bun.file(path).exists();
-}
+// ═══════════════════════════════════════════════════════════════════════════
+// INTERNAL HELPERS
+// ═══════════════════════════════════════════════════════════════════════════
 
-export async function loadClient(
-	projectDir: ProjectDir,
+async function loadClientFromPath(
+	configPath: string,
 ): Promise<AnyWorkspaceClient> {
-	const configPath = join(projectDir, CONFIG_FILENAME);
-
-	if (!(await fileExists(configPath))) {
-		throw new Error(`No ${CONFIG_FILENAME} found at ${configPath}`);
-	}
-
-	const module = await import(configPath);
-	const clients = Object.values(module).filter(isWorkspaceClient);
+	// Use Bun.pathToFileURL for correct handling of special characters in paths
+	const module = await import(Bun.pathToFileURL(configPath).href);
+	const exports = Object.entries(module);
+	const clients = exports.filter(([, value]) => isWorkspaceClient(value));
 
 	if (clients.length === 0) {
 		throw new Error(
-			`No WorkspaceClient exports found in ${CONFIG_FILENAME}.\n` +
-				`Export a client as: export const workspace = createWorkspaceClient({...})`,
+			`No WorkspaceClient found in ${CONFIG_FILENAME}.\n` +
+				`Export a client: export const workspace = createWorkspaceClient({...})`,
 		);
 	}
 
 	if (clients.length > 1) {
+		const names = clients.map(([name]) => name).join(', ');
 		throw new Error(
-			`Found ${clients.length} WorkspaceClient exports. Epicenter supports one workspace per config file.\n` +
-				`Use separate directories for multiple workspaces.`,
+			`Multiple WorkspaceClient exports found: ${names}\n` +
+				`Epicenter supports one workspace per config. Use separate directories for multiple workspaces.`,
 		);
 	}
 
-	return clients[0]!;
+	return clients[0]![1] as AnyWorkspaceClient;
+}
+
+async function findSubdirConfigs(baseDir: string): Promise<string[]> {
+	// */** pattern naturally excludes root-level matches
+	const glob = new Bun.Glob(`*/**/${CONFIG_FILENAME}`);
+	const configs: string[] = [];
+
+	for await (const path of glob.scan({ cwd: baseDir, onlyFiles: true })) {
+		configs.push(path);
+	}
+
+	return configs.sort();
 }
 
 function isWorkspaceClient(value: unknown): value is AnyWorkspaceClient {
@@ -90,4 +98,41 @@ function isWorkspaceClient(value: unknown): value is AnyWorkspaceClient {
 		'tables' in value &&
 		typeof (value as Record<string, unknown>).id === 'string'
 	);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// EXPORTED UTILITIES (for special cases / backwards compat)
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Check if a directory contains an epicenter config.
+ * Prefer resolveWorkspace() for normal CLI flows.
+ */
+export async function hasConfig(dir: string): Promise<boolean> {
+	return Bun.file(join(resolve(dir), CONFIG_FILENAME)).exists();
+}
+
+/**
+ * Get the project directory if config exists, null otherwise.
+ * @deprecated Use resolveWorkspace() for full resolution with ambiguity detection.
+ */
+export async function findProjectDir(
+	dir: string = process.cwd(),
+): Promise<ProjectDir | null> {
+	const resolved = resolve(dir);
+	if (await Bun.file(join(resolved, CONFIG_FILENAME)).exists()) {
+		return resolved as ProjectDir;
+	}
+	return null;
+}
+
+/**
+ * Load a client from a known project directory.
+ * @deprecated Use resolveWorkspace() which combines discovery and loading.
+ */
+export async function loadClient(
+	projectDir: ProjectDir,
+): Promise<AnyWorkspaceClient> {
+	const configPath = join(projectDir, CONFIG_FILENAME);
+	return loadClientFromPath(configPath);
 }

--- a/packages/epicenter/src/cli/discovery.ts
+++ b/packages/epicenter/src/cli/discovery.ts
@@ -120,30 +120,3 @@ function isWorkspaceClient(value: unknown): value is AnyWorkspaceClient {
 		typeof (value as Record<string, unknown>).id === 'string'
 	);
 }
-
-// ═══════════════════════════════════════════════════════════════════════════
-// DEPRECATED EXPORTS (for backwards compatibility)
-// ═══════════════════════════════════════════════════════════════════════════
-
-/**
- * @deprecated Use resolveWorkspace() for full resolution with ambiguity detection.
- */
-export async function findProjectDir(
-	dir: string = process.cwd(),
-): Promise<ProjectDir | null> {
-	const resolved = resolve(dir);
-	if (await Bun.file(join(resolved, CONFIG_FILENAME)).exists()) {
-		return resolved as ProjectDir;
-	}
-	return null;
-}
-
-/**
- * @deprecated Use resolveWorkspace() which combines discovery and loading.
- */
-export async function loadClient(
-	projectDir: ProjectDir,
-): Promise<AnyWorkspaceClient> {
-	const configPath = join(projectDir, CONFIG_FILENAME);
-	return loadClientFromPath(configPath);
-}

--- a/packages/epicenter/src/cli/format-output.test.ts
+++ b/packages/epicenter/src/cli/format-output.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { formatJson, formatJsonl, output } from './format-output.js';
+
+describe('formatJson', () => {
+	const originalIsTTY = process.stdout.isTTY;
+
+	afterEach(() => {
+		Object.defineProperty(process.stdout, 'isTTY', {
+			value: originalIsTTY,
+			writable: true,
+			configurable: true,
+		});
+	});
+
+	test('pretty-prints when TTY', () => {
+		Object.defineProperty(process.stdout, 'isTTY', {
+			value: true,
+			writable: true,
+			configurable: true,
+		});
+		const data = { name: 'test', value: 42 };
+		const result = formatJson(data);
+		expect(result).toBe('{\n  "name": "test",\n  "value": 42\n}');
+	});
+
+	test('compacts when not TTY', () => {
+		Object.defineProperty(process.stdout, 'isTTY', {
+			value: false,
+			writable: true,
+			configurable: true,
+		});
+		const data = { name: 'test', value: 42 };
+		const result = formatJson(data);
+		expect(result).toBe('{"name":"test","value":42}');
+	});
+
+	test('compacts when format is jsonl regardless of TTY', () => {
+		Object.defineProperty(process.stdout, 'isTTY', {
+			value: true,
+			writable: true,
+			configurable: true,
+		});
+		const data = { name: 'test' };
+		const result = formatJson(data, { format: 'jsonl' });
+		expect(result).toBe('{"name":"test"}');
+	});
+});
+
+describe('formatJsonl', () => {
+	test('outputs one object per line', () => {
+		const values = [
+			{ id: 1, name: 'first' },
+			{ id: 2, name: 'second' },
+			{ id: 3, name: 'third' },
+		];
+		const result = formatJsonl(values);
+		expect(result).toBe(
+			'{"id":1,"name":"first"}\n{"id":2,"name":"second"}\n{"id":3,"name":"third"}',
+		);
+	});
+
+	test('handles empty array', () => {
+		const result = formatJsonl([]);
+		expect(result).toBe('');
+	});
+
+	test('handles single item', () => {
+		const result = formatJsonl([{ value: 'single' }]);
+		expect(result).toBe('{"value":"single"}');
+	});
+
+	test('handles mixed types', () => {
+		const values = [{ a: 1 }, 'string', 42, null, [1, 2, 3]];
+		const result = formatJsonl(values);
+		expect(result).toBe('{"a":1}\n"string"\n42\nnull\n[1,2,3]');
+	});
+});
+
+describe('output', () => {
+	test('throws error when format is jsonl but value is not array', () => {
+		expect(() => output({ notAnArray: true }, { format: 'jsonl' })).toThrow(
+			'JSONL format requires an array value',
+		);
+	});
+});

--- a/packages/epicenter/src/cli/format-output.ts
+++ b/packages/epicenter/src/cli/format-output.ts
@@ -6,8 +6,12 @@ export type FormatOptions = {
 /**
  * Format a single value as JSON
  */
-export function formatJson(value: unknown, options: FormatOptions = {}): string {
-	const shouldPretty = options.format !== 'jsonl' && (process.stdout.isTTY ?? false);
+export function formatJson(
+	value: unknown,
+	options: FormatOptions = {},
+): string {
+	const shouldPretty =
+		options.format !== 'jsonl' && (process.stdout.isTTY ?? false);
 	return JSON.stringify(value, null, shouldPretty ? 2 : undefined);
 }
 

--- a/packages/epicenter/src/cli/format-output.ts
+++ b/packages/epicenter/src/cli/format-output.ts
@@ -1,0 +1,53 @@
+export type FormatOptions = {
+	/** Override format (default: json, auto-pretty for TTY) */
+	format?: 'json' | 'jsonl';
+};
+
+/**
+ * Format a single value as JSON
+ */
+export function formatJson(value: unknown, options: FormatOptions = {}): string {
+	const shouldPretty = options.format !== 'jsonl' && (process.stdout.isTTY ?? false);
+	return JSON.stringify(value, null, shouldPretty ? 2 : undefined);
+}
+
+/**
+ * Format an array as JSONL (one JSON object per line)
+ */
+export function formatJsonl(values: unknown[]): string {
+	return values.map((v) => JSON.stringify(v)).join('\n');
+}
+
+/**
+ * Output data to stdout with appropriate formatting
+ */
+export function output(value: unknown, options: FormatOptions = {}): void {
+	if (options.format === 'jsonl') {
+		if (!Array.isArray(value)) {
+			throw new Error('JSONL format requires an array value');
+		}
+		console.log(formatJsonl(value));
+	} else {
+		console.log(formatJson(value, options));
+	}
+}
+
+/**
+ * Output an error message to stderr
+ */
+export function outputError(message: string): void {
+	console.error(message);
+}
+
+/**
+ * Create yargs options for format flag
+ */
+export function formatYargsOptions() {
+	return {
+		format: {
+			type: 'string' as const,
+			choices: ['json', 'jsonl'] as const,
+			description: 'Output format (default: json, auto-pretty for TTY)',
+		},
+	};
+}

--- a/packages/epicenter/src/cli/index.ts
+++ b/packages/epicenter/src/cli/index.ts
@@ -1,10 +1,10 @@
 export { createCLI } from './cli';
-export {
-	resolveWorkspace,
-	hasConfig,
-	type AnyWorkspaceClient,
-	type WorkspaceResolution,
-} from './discovery';
-export { buildTableCommands } from './commands/table-commands';
 export { buildKvCommands } from './commands/kv-commands';
 export { buildMetaCommands } from './commands/meta-commands';
+export { buildTableCommands } from './commands/table-commands';
+export {
+	type AnyWorkspaceClient,
+	hasConfig,
+	resolveWorkspace,
+	type WorkspaceResolution,
+} from './discovery';

--- a/packages/epicenter/src/cli/index.ts
+++ b/packages/epicenter/src/cli/index.ts
@@ -1,12 +1,8 @@
 export { createCLI } from './cli';
 export {
-	createCommandConfig,
 	findProjectDir,
-	loadClients,
+	loadClient,
 	type AnyWorkspaceClient,
-	type CommandConfig,
-	type MultiClientConfig,
-	type SingleClientConfig,
 } from './discovery';
 export { buildTableCommands } from './commands/table-commands';
 export { buildKvCommands } from './commands/kv-commands';

--- a/packages/epicenter/src/cli/index.ts
+++ b/packages/epicenter/src/cli/index.ts
@@ -2,8 +2,6 @@ export { createCLI } from './cli';
 export {
 	resolveWorkspace,
 	hasConfig,
-	findProjectDir,
-	loadClient,
 	type AnyWorkspaceClient,
 	type WorkspaceResolution,
 } from './discovery';

--- a/packages/epicenter/src/cli/index.ts
+++ b/packages/epicenter/src/cli/index.ts
@@ -1,2 +1,18 @@
 export { createCLI } from './cli';
-export { findProjectDir, loadClients } from './discovery';
+export {
+	createCommandConfig,
+	findProjectDir,
+	loadClients,
+	type AnyWorkspaceClient,
+	type CommandConfig,
+	type MultiClientConfig,
+	type SingleClientConfig,
+} from './discovery';
+export { buildTableCommands } from './commands/table-commands';
+export { buildKvCommands } from './commands/kv-commands';
+export {
+	buildMetaCommands,
+	RESERVED_COMMANDS,
+	type ReservedCommand,
+	isReservedCommand,
+} from './commands/meta-commands';

--- a/packages/epicenter/src/cli/index.ts
+++ b/packages/epicenter/src/cli/index.ts
@@ -1,8 +1,11 @@
 export { createCLI } from './cli';
 export {
+	resolveWorkspace,
+	hasConfig,
 	findProjectDir,
 	loadClient,
 	type AnyWorkspaceClient,
+	type WorkspaceResolution,
 } from './discovery';
 export { buildTableCommands } from './commands/table-commands';
 export { buildKvCommands } from './commands/kv-commands';

--- a/packages/epicenter/src/cli/index.ts
+++ b/packages/epicenter/src/cli/index.ts
@@ -6,9 +6,4 @@ export {
 } from './discovery';
 export { buildTableCommands } from './commands/table-commands';
 export { buildKvCommands } from './commands/kv-commands';
-export {
-	buildMetaCommands,
-	RESERVED_COMMANDS,
-	type ReservedCommand,
-	isReservedCommand,
-} from './commands/meta-commands';
+export { buildMetaCommands } from './commands/meta-commands';

--- a/packages/epicenter/src/cli/parse-input.test.ts
+++ b/packages/epicenter/src/cli/parse-input.test.ts
@@ -1,0 +1,148 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { type ParseInputOptions, parseJsonInput } from './parse-input.js';
+
+describe('parseJsonInput', () => {
+	let tempDir: string;
+
+	beforeAll(() => {
+		tempDir = mkdtempSync(join(tmpdir(), 'parse-input-test-'));
+	});
+
+	afterAll(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it('parses inline JSON', () => {
+		const options: ParseInputOptions = {
+			positional: '{"id":"1","name":"test"}',
+		};
+
+		const result = parseJsonInput<{ id: string; name: string }>(options);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data).toEqual({ id: '1', name: 'test' });
+		}
+	});
+
+	it('reads @file shorthand', () => {
+		const filePath = join(tempDir, 'test.json');
+		writeFileSync(filePath, '{"id":"2","value":42}');
+
+		const options: ParseInputOptions = {
+			positional: `@${filePath}`,
+		};
+
+		const result = parseJsonInput<{ id: string; value: number }>(options);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data).toEqual({ id: '2', value: 42 });
+		}
+	});
+
+	it('reads --file flag', () => {
+		const filePath = join(tempDir, 'file-flag.json');
+		writeFileSync(filePath, '{"source":"file-flag"}');
+
+		const options: ParseInputOptions = {
+			file: filePath,
+		};
+
+		const result = parseJsonInput<{ source: string }>(options);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data).toEqual({ source: 'file-flag' });
+		}
+	});
+
+	it('reads stdin content', () => {
+		const options: ParseInputOptions = {
+			hasStdin: true,
+			stdinContent: '{"from":"stdin"}',
+		};
+
+		const result = parseJsonInput<{ from: string }>(options);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data).toEqual({ from: 'stdin' });
+		}
+	});
+
+	it('returns error for invalid JSON', () => {
+		const options: ParseInputOptions = {
+			positional: '{invalid json}',
+		};
+
+		const result = parseJsonInput(options);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('Invalid JSON');
+		}
+	});
+
+	it('returns error for missing file', () => {
+		const options: ParseInputOptions = {
+			positional: '@/nonexistent/path/file.json',
+		};
+
+		const result = parseJsonInput(options);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('File not found');
+		}
+	});
+
+	it('returns error when no input provided', () => {
+		const options: ParseInputOptions = {};
+
+		const result = parseJsonInput(options);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain('No input provided');
+		}
+	});
+
+	it('prioritizes positional over --file', () => {
+		const filePath = join(tempDir, 'should-not-read.json');
+		writeFileSync(filePath, '{"source":"file"}');
+
+		const options: ParseInputOptions = {
+			positional: '{"source":"positional"}',
+			file: filePath,
+		};
+
+		const result = parseJsonInput<{ source: string }>(options);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data.source).toBe('positional');
+		}
+	});
+
+	it('prioritizes --file over stdin', () => {
+		const filePath = join(tempDir, 'file-priority.json');
+		writeFileSync(filePath, '{"source":"file"}');
+
+		const options: ParseInputOptions = {
+			file: filePath,
+			hasStdin: true,
+			stdinContent: '{"source":"stdin"}',
+		};
+
+		const result = parseJsonInput<{ source: string }>(options);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.data.source).toBe('file');
+		}
+	});
+});

--- a/packages/epicenter/src/cli/parse-input.ts
+++ b/packages/epicenter/src/cli/parse-input.ts
@@ -1,0 +1,99 @@
+import { readFileSync, readSync } from 'node:fs';
+
+export type ParseInputOptions = {
+	/** Positional argument (inline JSON or @file) */
+	positional?: string;
+	/** --file flag value */
+	file?: string;
+	/** Whether stdin has data (process.stdin.isTTY === false) */
+	hasStdin?: boolean;
+	/** Stdin content (if hasStdin) */
+	stdinContent?: string;
+};
+
+export type ParseInputResult<T> =
+	| { ok: true; data: T }
+	| { ok: false; error: string };
+
+function parseJson<T>(input: string): ParseInputResult<T> {
+	try {
+		const data = JSON.parse(input) as T;
+		return { ok: true, data };
+	} catch (e) {
+		return {
+			ok: false,
+			error: `Invalid JSON: ${e instanceof Error ? e.message : String(e)}`,
+		};
+	}
+}
+
+function readJsonFile<T>(filePath: string): ParseInputResult<T> {
+	try {
+		const content = readFileSync(filePath, 'utf-8');
+		return parseJson<T>(content);
+	} catch (e) {
+		if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+			return { ok: false, error: `File not found: ${filePath}` };
+		}
+		return {
+			ok: false,
+			error: `Error reading file: ${e instanceof Error ? e.message : String(e)}`,
+		};
+	}
+}
+
+/**
+ * Parse JSON input from various sources.
+ * Priority: positional > --file > stdin
+ */
+export function parseJsonInput<T = unknown>(
+	options: ParseInputOptions,
+): ParseInputResult<T> {
+	// 1. Check positional (could be inline JSON or @file)
+	if (options.positional) {
+		if (options.positional.startsWith('@')) {
+			const filePath = options.positional.slice(1);
+			return readJsonFile<T>(filePath);
+		}
+		return parseJson<T>(options.positional);
+	}
+
+	// 2. Check --file flag
+	if (options.file) {
+		return readJsonFile<T>(options.file);
+	}
+
+	// 3. Check stdin
+	if (options.hasStdin && options.stdinContent) {
+		return parseJson<T>(options.stdinContent);
+	}
+
+	return {
+		ok: false,
+		error:
+			'No input provided. Use inline JSON, --file, @file, or pipe via stdin.',
+	};
+}
+
+/**
+ * Read stdin content synchronously (for CLI use).
+ * Returns undefined if stdin is a TTY (interactive).
+ */
+export function readStdinSync(): string | undefined {
+	if (process.stdin.isTTY) return undefined;
+
+	try {
+		const chunks: Buffer[] = [];
+		const fd = 0; // stdin file descriptor
+		const buf = Buffer.alloc(1024);
+		let bytesRead: number;
+
+		while ((bytesRead = readSync(fd, buf, 0, buf.length, null)) > 0) {
+			chunks.push(buf.subarray(0, bytesRead));
+		}
+
+		return Buffer.concat(chunks).toString('utf-8').trim() || undefined;
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/epicenter/src/dynamic/workspace/README.md
+++ b/packages/epicenter/src/dynamic/workspace/README.md
@@ -82,7 +82,7 @@ Extensions receive an `ExtensionContext` with:
 ```typescript
 interface ExtensionContext {
 	ydoc: Y.Doc; // The underlying Y.Doc
-	workspaceId: string; // Workspace ID
+	id: string; // Workspace ID
 	definition: WorkspaceDefinition;
 	tables: Tables; // Table operations
 	kv: KeyValueStore; // Key-value store

--- a/packages/epicenter/src/dynamic/workspace/create-workspace.test.ts
+++ b/packages/epicenter/src/dynamic/workspace/create-workspace.test.ts
@@ -46,7 +46,7 @@ describe('createWorkspace', () => {
 			const workspace = createWorkspace(testDefinition);
 
 			// Should be usable immediately
-			expect(workspace.workspaceId).toBe('test-workspace');
+			expect(workspace.id).toBe('test-workspace');
 			expect(workspace.ydoc).toBeInstanceOf(Y.Doc);
 			expect(workspace.tables).toBeDefined();
 			expect(workspace.kv).toBeDefined();
@@ -113,9 +113,9 @@ describe('createWorkspace', () => {
 
 			// Use inline factory for better type inference
 			const workspace = baseWorkspace.withExtensions({
-				mock: ({ workspaceId }) =>
+				mock: ({ id }) =>
 					defineExports({
-						greeting: `Hello from ${workspaceId}`,
+						greeting: `Hello from ${id}`,
 					}),
 			});
 
@@ -133,7 +133,7 @@ describe('createWorkspace', () => {
 			baseWorkspace.withExtensions({
 				capture: (ctx) => {
 					receivedContext = {
-						workspaceId: ctx.workspaceId,
+						id: ctx.id,
 						extensionId: ctx.extensionId,
 						hasYdoc: ctx.ydoc instanceof Y.Doc,
 						hasTables: typeof ctx.tables.get === 'function',
@@ -145,7 +145,7 @@ describe('createWorkspace', () => {
 			});
 
 			expect(receivedContext).toBeDefined();
-			expect(receivedContext?.workspaceId).toBe('test-workspace');
+			expect(receivedContext?.id).toBe('test-workspace');
 			expect(receivedContext?.extensionId).toBe('capture');
 			expect(receivedContext?.hasYdoc).toBe(true);
 			expect(receivedContext?.hasTables).toBe(true);

--- a/packages/epicenter/src/dynamic/workspace/create-workspace.ts
+++ b/packages/epicenter/src/dynamic/workspace/create-workspace.ts
@@ -74,11 +74,11 @@ export function createWorkspace<
 >(
 	definition: WorkspaceDefinition<TTableDefinitions, TKvFields>,
 ): WorkspaceClientBuilder<TTableDefinitions, TKvFields> {
-	const workspaceId = definition.id;
+	const id = definition.id;
 
 	// Create Y.Doc with guid = definition.id
 	// gc: true enables garbage collection for efficient YKeyValueLww storage
-	const ydoc = new Y.Doc({ guid: workspaceId, gc: true });
+	const ydoc = new Y.Doc({ guid: id, gc: true });
 
 	// Create table and KV helpers bound to Y.Doc
 	const tables = createTables(ydoc, definition.tables ?? []);
@@ -95,7 +95,7 @@ export function createWorkspace<
 		TKvFields,
 		Record<string, never>
 	> = {
-		workspaceId,
+		id,
 		ydoc,
 		tables,
 		kv,
@@ -123,7 +123,7 @@ export function createWorkspace<
 				// Build context for this extension
 				const context: ExtensionContext<TTableDefinitions, TKvFields> = {
 					ydoc,
-					workspaceId,
+					id,
 					definition,
 					tables,
 					kv,
@@ -151,7 +151,7 @@ export function createWorkspace<
 			};
 
 			return {
-				workspaceId,
+				id,
 				ydoc,
 				tables,
 				kv,

--- a/packages/epicenter/src/dynamic/workspace/types.ts
+++ b/packages/epicenter/src/dynamic/workspace/types.ts
@@ -45,8 +45,8 @@ import type { Tables } from '../tables/create-tables';
  * ```typescript
  * // Destructure only what you need
  * const persistence: ExtensionFactory = ({ ydoc }) => { ... };
- * const sqlite: ExtensionFactory = ({ workspaceId, tables }) => { ... };
- * const markdown: ExtensionFactory = ({ ydoc, tables, workspaceId }) => { ... };
+ * const sqlite: ExtensionFactory = ({ id, tables }) => { ... };
+ * const markdown: ExtensionFactory = ({ ydoc, tables, id }) => { ... };
  * ```
  */
 export type ExtensionContext<
@@ -57,7 +57,7 @@ export type ExtensionContext<
 	/** The underlying Y.Doc instance */
 	ydoc: Y.Doc;
 	/** Workspace identifier (from definition.id) */
-	workspaceId: string;
+	id: string;
 	/** The workspace definition with typed tables and kv fields */
 	definition: WorkspaceDefinition<TTableDefinitions, TKvFields>;
 	/** Typed table helpers */
@@ -143,7 +143,7 @@ export type WorkspaceClient<
 	TExtensions extends ExtensionFactoryMap = Record<string, never>,
 > = {
 	/** Workspace identifier */
-	workspaceId: string;
+	id: string;
 	/** The underlying Y.Doc instance */
 	ydoc: Y.Doc;
 	/** Typed table helpers */

--- a/packages/epicenter/src/extensions/markdown/markdown.ts
+++ b/packages/epicenter/src/extensions/markdown/markdown.ts
@@ -293,7 +293,7 @@ export const markdown = async <
 	context: ExtensionContext<TTableDefinitions, TKvFields>,
 	config: MarkdownExtensionConfig<TTableDefinitions>,
 ) => {
-	const { workspaceId: id, tables, ydoc } = context;
+	const { id, tables, ydoc } = context;
 	const {
 		directory,
 		logsDir,

--- a/packages/epicenter/src/extensions/persistence/desktop.ts
+++ b/packages/epicenter/src/extensions/persistence/desktop.ts
@@ -36,7 +36,7 @@ export type PersistenceConfig = {
  * const workspace = createWorkspace({ name: 'Blog', tables: {...} })
  *   .withExtensions({
  *     persistence: (ctx) => persistence(ctx, {
- *       filePath: join(epicenterDir, 'persistence', `${ctx.workspaceId}.yjs`),
+ *       filePath: join(epicenterDir, 'persistence', `${ctx.id}.yjs`),
  *     }),
  *   });
  * ```

--- a/packages/epicenter/src/extensions/revision-history/local.ts
+++ b/packages/epicenter/src/extensions/revision-history/local.ts
@@ -124,7 +124,7 @@ export async function localRevisionHistory<
 	TTableDefinitions extends readonly TableDefinition[],
 	TKvFields extends readonly KvField[],
 >(
-	{ ydoc, workspaceId: id }: ExtensionContext<TTableDefinitions, TKvFields>,
+	{ ydoc, id }: ExtensionContext<TTableDefinitions, TKvFields>,
 	{ directory, debounceMs = 1000, maxVersions }: LocalRevisionHistoryConfig,
 ) {
 	// CRITICAL: Snapshots require gc: false

--- a/packages/epicenter/src/extensions/sqlite/sqlite.ts
+++ b/packages/epicenter/src/extensions/sqlite/sqlite.ts
@@ -69,7 +69,7 @@ export type SqliteConfig = {
  * const workspace = createWorkspace({ name: 'Blog', tables: {...} })
  *   .withExtensions({
  *     sqlite: (ctx) => sqlite(ctx, {
- *       dbPath: join(epicenterDir, 'sqlite', `${ctx.workspaceId}.db`),
+ *       dbPath: join(epicenterDir, 'sqlite', `${ctx.id}.db`),
  *       logsDir: join(epicenterDir, 'sqlite', 'logs'),
  *     }),
  *   });
@@ -84,7 +84,7 @@ export const sqlite = async <
 	TTableDefinitions extends readonly TableDefinition[],
 	TKvFields extends readonly KvField[],
 >(
-	{ workspaceId: id, tables }: ExtensionContext<TTableDefinitions, TKvFields>,
+	{ id, tables }: ExtensionContext<TTableDefinitions, TKvFields>,
 	config: SqliteConfig,
 ) => {
 	const { dbPath, logsDir, debounceMs = DEFAULT_DEBOUNCE_MS } = config;

--- a/packages/epicenter/src/server/server.ts
+++ b/packages/epicenter/src/server/server.ts
@@ -66,7 +66,7 @@ function createServerInternal(
 	const workspaces: Record<string, AnyWorkspaceClient> = {};
 
 	for (const client of clients) {
-		workspaces[client.workspaceId] = client;
+		workspaces[client.id] = client;
 	}
 
 	const actionPaths = options?.actions

--- a/packages/epicenter/src/static/create-workspace.ts
+++ b/packages/epicenter/src/static/create-workspace.ts
@@ -71,7 +71,7 @@ export function createWorkspace<
 		/**
 		 * Attach capabilities (persistence, SQLite, sync, etc.) to the workspace.
 		 *
-		 * Each capability factory receives { ydoc, workspaceId, tables, kv } and
+		 * Each capability factory receives { ydoc, id, tables, kv } and
 		 * returns a Lifecycle object with exports. The returned client includes
 		 * all capability exports under `.capabilities`.
 		 */
@@ -84,7 +84,7 @@ export function createWorkspace<
 					name,
 					(factory as CapabilityFactory<TTableDefinitions, TKvDefinitions>)({
 						ydoc,
-						workspaceId: id,
+						id,
 						tables,
 						kv,
 					}),

--- a/packages/epicenter/src/static/index.ts
+++ b/packages/epicenter/src/static/index.ts
@@ -146,6 +146,7 @@ export type {
 	// Helper types
 	TableHelper,
 	TablesHelper,
+	UpdateResult,
 	// Result types - building blocks
 	ValidRowResult,
 	WorkspaceClient,

--- a/packages/epicenter/src/static/table-helper.test.ts
+++ b/packages/epicenter/src/static/table-helper.test.ts
@@ -224,7 +224,9 @@ describe('createTableHelper', () => {
 	describe('update operations', () => {
 		test('update merges partial data correctly', () => {
 			const { ykv } = setup();
-			const definition = defineTable(type({ id: 'string', name: 'string', age: 'number' }));
+			const definition = defineTable(
+				type({ id: 'string', name: 'string', age: 'number' }),
+			);
 			const helper = createTableHelper(ykv, definition);
 
 			helper.set({ id: '1', name: 'Alice', age: 25 });
@@ -283,7 +285,9 @@ describe('createTableHelper', () => {
 
 			// TypeScript prevents passing `id` in partial due to Omit<TRow, 'id'>
 			// But we can test that even if someone bypasses TypeScript, the id is preserved
-			const result = helper.update('1', { name: 'Bob' } as Partial<Omit<{ id: string; name: string }, 'id'>>);
+			const result = helper.update('1', { name: 'Bob' } as Partial<
+				Omit<{ id: string; name: string }, 'id'>
+			>);
 
 			expect(result.status).toBe('updated');
 			if (result.status === 'updated') {

--- a/packages/epicenter/src/static/table-helper.ts
+++ b/packages/epicenter/src/static/table-helper.ts
@@ -73,7 +73,12 @@ export function createTableHelper<
 				return { status: 'not_found', id };
 			}
 			if (current.status === 'invalid') {
-				return { status: 'invalid', id, errors: current.errors, row: current.row };
+				return {
+					status: 'invalid',
+					id,
+					errors: current.errors,
+					row: current.row,
+				};
 			}
 			const merged = { ...current.row, ...partial } as TRow;
 			this.set(merged);

--- a/packages/epicenter/src/static/table-helper.ts
+++ b/packages/epicenter/src/static/table-helper.ts
@@ -19,6 +19,7 @@ import type {
 	TableBatchTransaction,
 	TableDefinition,
 	TableHelper,
+	UpdateResult,
 } from './types.js';
 
 /**
@@ -60,6 +61,23 @@ export function createTableHelper<
 
 		set(row: TRow): void {
 			ykv.set(row.id, row);
+		},
+
+		// ═══════════════════════════════════════════════════════════════════════
+		// UPDATE
+		// ═══════════════════════════════════════════════════════════════════════
+
+		update(id: string, partial: Partial<Omit<TRow, 'id'>>): UpdateResult<TRow> {
+			const current = this.get(id);
+			if (current.status === 'not_found') {
+				return { status: 'not_found', id };
+			}
+			if (current.status === 'invalid') {
+				return { status: 'invalid', id, errors: current.errors, row: current.row };
+			}
+			const merged = { ...current.row, ...partial } as TRow;
+			this.set(merged);
+			return { status: 'updated', row: merged };
 		},
 
 		// ═══════════════════════════════════════════════════════════════════════

--- a/packages/epicenter/src/static/types.ts
+++ b/packages/epicenter/src/static/types.ts
@@ -54,6 +54,12 @@ export type DeleteResult =
 	| { status: 'deleted' }
 	| { status: 'not_found_locally' };
 
+/** Result of updating a single row */
+export type UpdateResult<TRow> =
+	| { status: 'updated'; row: TRow }
+	| { status: 'not_found'; id: string }
+	| { status: 'invalid'; id: string; errors: readonly StandardSchemaV1.Issue[]; row: unknown };
+
 // ════════════════════════════════════════════════════════════════════════════
 // KV RESULT TYPES
 // ════════════════════════════════════════════════════════════════════════════
@@ -185,6 +191,13 @@ export type TableHelper<TRow extends { id: string }> = {
 
 	/** Find first row matching predicate (only valid rows). */
 	find(predicate: (row: TRow) => boolean): TRow | undefined;
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// UPDATE
+	// ═══════════════════════════════════════════════════════════════════════
+
+	/** Partial update a row by ID. Fetches current, merges partial, and saves. */
+	update(id: string, partial: Partial<Omit<TRow, 'id'>>): UpdateResult<TRow>;
 
 	// ═══════════════════════════════════════════════════════════════════════
 	// DELETE

--- a/packages/epicenter/src/static/types.ts
+++ b/packages/epicenter/src/static/types.ts
@@ -378,7 +378,7 @@ export type CapabilityContext<
 	/** The underlying Y.Doc instance */
 	ydoc: Y.Doc;
 	/** Workspace identifier */
-	workspaceId: string;
+	id: string;
 	/** Typed table helpers for the workspace */
 	tables: TablesHelper<TTableDefinitions>;
 	/** Typed KV helper for the workspace */

--- a/packages/epicenter/src/static/types.ts
+++ b/packages/epicenter/src/static/types.ts
@@ -58,7 +58,12 @@ export type DeleteResult =
 export type UpdateResult<TRow> =
 	| { status: 'updated'; row: TRow }
 	| { status: 'not_found'; id: string }
-	| { status: 'invalid'; id: string; errors: readonly StandardSchemaV1.Issue[]; row: unknown };
+	| {
+			status: 'invalid';
+			id: string;
+			errors: readonly StandardSchemaV1.Issue[];
+			row: unknown;
+	  };
 
 // ════════════════════════════════════════════════════════════════════════════
 // KV RESULT TYPES

--- a/specs/20260202T000000-epicenter-cli-crud-commands.md
+++ b/specs/20260202T000000-epicenter-cli-crud-commands.md
@@ -1,0 +1,305 @@
+# Epicenter CLI Architecture Plan
+
+**Date**: 2026-02-02
+**Status**: 🚧 Partially Implemented
+**Related**: `20260202T100000-single-workspace-simplification.md`
+
+## Implementation Status
+
+### ✅ Completed
+
+1. **Static TableHelper `update()` method** - Added fetch-merge-set logic to `table-helper.ts`
+2. **Command factories** - Implemented `buildTableCommands()`, `buildKvCommands()`, and `buildMetaCommands()`
+3. **Input parsing** - Added `parse-input.ts` with JSON/file/stdin support
+4. **Output formatting** - Added `format-output.ts` with TTY detection
+5. **CLI integration** - Commands registered in `cli.ts`
+6. **Single workspace mode** - Simplified to single client architecture (see related spec)
+
+### 🚧 In Progress / Future Work
+
+1. **Dynamic table support** - Currently only static tables implemented
+2. **Batch operations** - `set-many`, `delete-many` not yet implemented
+3. **Advanced update features** - `--patch` flag for complex nested updates
+4. **Table output formatting** - Using JSON, could add `cli-table3` for better display
+5. **Testing** - Unit tests for command handlers
+
+### 📝 Architecture Changes
+
+The original plan assumed multi-workspace support. The actual implementation uses:
+- Single workspace per config (see `20260202T100000-single-workspace-simplification.md`)
+- `-C`/`--dir` flag for multiple workspaces in subdirectories
+- Default export convention: `export default createWorkspaceClient({...})`
+
+## Overview
+
+Transform the Epicenter CLI from a simple server launcher into a comprehensive workspace management tool with:
+- ~~Automatic single/multi workspace detection~~ → Single workspace per config with `-C` flag
+- CRUD commands for tables and KV stores ✅
+- Multiple input methods (inline JSON, files, stdin, property flags) ✅
+- TTY-aware output formatting ✅
+
+**Scope**: Start with static tables, then extend to dynamic tables.
+
+## Design Decisions
+
+### 1. Config File: Keep `epicenter.config.ts`
+Matches ecosystem conventions (vite.config.ts, drizzle.config.ts). Clear intent.
+
+### 2. Export Pattern: Named Exports Only
+```typescript
+// Single workspace
+export const blog = createWorkspaceClient({...});
+
+// Multiple workspaces
+export const blog = createWorkspaceClient({...});
+export const shop = createWorkspaceClient({...});
+```
+
+Auto-detect mode based on number of WorkspaceClient exports found.
+
+### 3. Command Structure: Automatic Mode Detection
+
+**Single workspace mode:**
+```bash
+epicenter posts list
+epicenter posts get abc123
+epicenter posts set '{"id":"1","title":"Hello"}'
+epicenter posts update abc123 --title "New"
+epicenter kv set theme dark
+epicenter serve
+```
+
+**Multiple workspace mode:**
+```bash
+epicenter blog posts list
+epicenter blog posts get abc123
+epicenter shop products set @product.json
+epicenter serve
+```
+
+### 4. Reserved Commands
+Cannot be workspace names: `serve`, `tables`, `workspaces`, `kv`, `help`, `version`, `init`
+
+**Table name collisions**: If a table is named `tables` or `kv`, the reserved command wins. Document this limitation. Users should avoid naming tables after reserved commands.
+
+### 5. Table Commands
+
+| Command | Description | Static | Dynamic |
+|---------|-------------|--------|---------|
+| `list` | List valid rows | `getAllValid()` | `getAllValid()` |
+| `list --all` | Include invalid | `getAll()` | `getAll()` |
+| `get <id>` | Get by ID | `get(id)` | `get(id)` |
+| `set <json>` | Upsert full row | `set(row)` | `upsert(row)` |
+| `set-many <json>` | Bulk upsert | batch | `upsertMany()` |
+| `update <id> --flags` | Partial update | `update()` (new) | `update()` |
+| `delete <id>` | Delete row | `delete(id)` | `delete(id)` |
+| `delete-many <ids>` | Bulk delete | batch | `deleteMany()` |
+| `clear` | Clear table | `clear()` | `clear()` |
+| `count` | Count rows | `count()` | `count()` |
+
+### 6. Update Command Design (Flag-Based)
+
+Following [gh CLI patterns](https://cli.github.com/manual/gh_issue_edit) and [CLIG best practices](https://clig.dev/):
+
+```bash
+# Single field update
+epicenter posts update abc123 --title "New Title"
+
+# Multiple field update
+epicenter posts update abc123 --title "New" --status published
+
+# JSON fallback for complex nested data
+epicenter posts update abc123 --patch '{"tags":["a","b"]}'
+```
+
+**Why flags over positionals:**
+- Discoverable via `--help`
+- Order-independent
+- Scriptable
+- Industry standard (gh, Heroku, kubectl)
+
+### 7. Static Table `update()` Method (NEW)
+
+Add `update(id, partial)` to static TableHelper:
+
+```typescript
+update(id: string, partial: Partial<Omit<TRow, 'id'>>): UpdateResult<TRow> {
+  const current = this.get(id);
+  if (current.status !== 'valid') {
+    return { status: current.status };
+  }
+  const merged = { ...current.row, ...partial };
+  this.set(merged);
+  return { status: 'updated', row: merged };
+}
+```
+
+**Rationale**: Fetch-merge-set is a common pattern that belongs in the library, not CLI.
+
+### 8. KV Commands
+```bash
+epicenter kv list
+epicenter kv get <key>
+epicenter kv set <key> <value>
+epicenter kv reset <key>
+```
+
+### 9. JSON Input Methods
+1. **Inline**: `epicenter posts set '{"id":"1"}'`
+2. **File**: `epicenter posts set --file row.json` or `epicenter posts set @row.json`
+3. **Stdin**: `cat row.json | epicenter posts set`
+4. **Property flags** (update): `epicenter posts update abc123 --title "New"`
+
+### 10. Output Formats
+- **TTY (interactive)**: JSON pretty-print (simplest)
+- **Pipe (non-TTY)**: JSON compact
+- **Override**: `--format json|jsonl`
+
+Keep it simple for now. Can add `cli-table3` for table formatting later if needed.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Static TableHelper `update()` Method
+**File:** `packages/epicenter/src/static/table-helper.ts`
+
+1. Add `update(id, partial)` method with fetch-merge-set logic
+2. Add `UpdateResult` type to `types.ts`
+3. Add `count()` method if not present
+4. Add tests for new methods
+
+### Phase 2: Discovery Mode Detection
+**File:** `packages/epicenter/src/cli/discovery.ts`
+
+1. Modify `loadClients()` to return `{ clients, mode: 'single' | 'multi' }`
+2. Accept single client export (not just array)
+3. Determine mode: single if 1 client, multi if >1
+
+### Phase 3: CLI Command Structure
+**File:** `packages/epicenter/src/cli/cli.ts`
+
+1. Pass mode to command builder
+2. Single mode: `<table> <command>` structure
+3. Multi mode: `<workspace> <table> <command>` structure
+4. Add reserved command detection
+
+### Phase 4: Table Commands Factory
+**New file:** `packages/epicenter/src/cli/commands/table-commands.ts`
+
+1. Create `buildTableCommands(client, mode)` function
+2. Generate commands for each table in workspace
+3. Commands: `list`, `get`, `set`, `update`, `delete`, `clear`, `count`
+4. Generate `--field` flags from table schema for `update` command
+5. Support `--patch` JSON fallback for complex updates
+
+### Phase 5: KV Commands Factory
+**New file:** `packages/epicenter/src/cli/commands/kv-commands.ts`
+
+1. Create `buildKvCommands(client, mode)` function
+2. Commands: `list`, `get`, `set`, `reset`
+
+### Phase 6: Input Parsing
+**New file:** `packages/epicenter/src/cli/input/parse-input.ts`
+
+1. Priority: positional JSON > `--file` > `@file` > stdin
+2. Property flag extraction for `update` command
+3. JSON parsing with helpful error messages
+
+### Phase 7: Output Formatting
+**New file:** `packages/epicenter/src/cli/output/format.ts`
+
+1. TTY detection for pretty vs compact JSON
+2. JSON/JSONL formatters
+3. `--format` flag handler
+4. (Future: add cli-table3 for table formatting)
+
+### Phase 8: Meta Commands
+1. `epicenter tables` - list table names
+2. `epicenter workspaces` - list workspaces (multi mode only)
+
+---
+
+## File Structure
+
+```
+packages/epicenter/src/cli/
+├── bin.ts                      # Entry point (existing)
+├── cli.ts                      # CLI factory (modify)
+├── discovery.ts                # Config loading (modify)
+├── command-builder.ts          # Action commands (existing)
+├── commands/
+│   ├── serve.ts                # Server command (extract)
+│   ├── table-commands.ts       # Table CRUD factory (new)
+│   ├── kv-commands.ts          # KV CRUD factory (new)
+│   └── meta-commands.ts        # tables, workspaces (new)
+├── input/
+│   └── parse-input.ts          # JSON/file/stdin parsing (new)
+├── output/
+│   └── format.ts               # JSON formatting (new)
+└── index.ts                    # Public exports
+```
+
+---
+
+## Critical Files to Modify
+
+1. **`packages/epicenter/src/static/table-helper.ts`** - Add `update()` and `count()` methods
+2. **`packages/epicenter/src/static/types.ts`** - Add `UpdateResult` type
+3. **`packages/epicenter/src/cli/discovery.ts`** - Add mode detection, support single export
+4. **`packages/epicenter/src/cli/cli.ts`** - Restructure for table/KV commands
+
+---
+
+## Verification Plan
+
+1. **Unit tests for static TableHelper**:
+   - `update()` merges partial data correctly
+   - `update()` returns `not_found` for missing rows
+   - `count()` returns correct count
+
+2. **CLI integration tests**:
+   - `epicenter tables` lists all table names
+   - `epicenter <table> list` returns rows as JSON
+   - `epicenter <table> set '{"id":"1",...}'` creates row
+   - `epicenter <table> get <id>` retrieves row
+   - `epicenter <table> update <id> --field value` updates row
+   - `epicenter <table> delete <id>` removes row
+   - `epicenter kv list/get/set` works
+
+3. **Multi-workspace test**:
+   - Config with 2 workspaces
+   - `epicenter blog posts list` vs `epicenter shop products list`
+
+---
+
+## Example Usage
+
+```bash
+# List all tables
+epicenter tables
+# Output: posts, comments, users
+
+# List rows in posts table
+epicenter posts list
+# Output: [{"id":"1","title":"Hello"},{"id":"2","title":"World"}]
+
+# Get specific row
+epicenter posts get 1
+# Output: {"id":"1","title":"Hello","body":"..."}
+
+# Create/replace row (full row required)
+epicenter posts set '{"id":"3","title":"New Post","body":"Content"}'
+
+# Partial update (only specified fields changed)
+epicenter posts update 1 --title "Updated Title"
+epicenter posts update 1 --title "New" --status published
+
+# Delete row
+epicenter posts delete 1
+
+# KV operations
+epicenter kv list
+epicenter kv get theme
+epicenter kv set theme dark
+```

--- a/specs/20260202T100000-single-workspace-simplification.md
+++ b/specs/20260202T100000-single-workspace-simplification.md
@@ -1,0 +1,1067 @@
+# Single Workspace Simplification
+
+**Date**: 2026-02-02
+**Status**: ✅ Implemented
+**Author**: CLI Team
+
+## Implementation Summary
+
+The single workspace simplification has been completed with several enhancements beyond the original plan:
+
+### What Was Implemented
+
+1. **Single client architecture**: `createCLI()` now takes a single `AnyWorkspaceClient` instead of arrays
+2. **Default export convention**: `export default createWorkspaceClient({...})` is the new standard
+3. **Backward compatibility**: Named exports still work with validation (only one allowed)
+4. **Smart discovery**: New `resolveWorkspace()` function with discriminated union return type
+5. **Ambiguity detection**: Helpful messages when configs exist in subdirectories
+6. **`-C`/`--dir` flag**: Run commands from parent directories without `cd`
+7. **Robust error handling**: Using `tryAsync` from wellcrafted throughout
+8. **Path normalization**: Cross-platform path handling improvements
+
+### Key Files Modified
+
+- `discovery.ts`: New `resolveWorkspace()` API, default export support, ambiguity detection
+- `cli.ts`: Single client signature, removed array handling
+- `bin.ts`: `-C`/`--dir` flag parsing, `tryAsync` integration
+- `index.ts`: Updated exports
+- `README.md`: Updated documentation
+- All command builders: Simplified to single client
+
+### User Experience Improvements
+
+**Before (multi-workspace mode):**
+```bash
+epicenter blog posts list
+epicenter shop products list
+```
+
+**After (single workspace with `-C` flag):**
+```bash
+cd blog && epicenter posts list
+# or
+epicenter -C blog posts list
+epicenter -C shop products list
+```
+
+With smart error messages when running from wrong directory:
+```
+No epicenter.config.ts found in current directory.
+
+Found configs in subdirectories:
+  - blog/epicenter.config.ts
+  - shop/epicenter.config.ts
+
+Use -C <dir> to specify which project:
+  epicenter -C blog posts list
+```
+
+---
+
+## Original Plan Overview
+
+The Epicenter CLI originally supported both single and multi-workspace modes via auto-detection:
+- 1 `WorkspaceClient` export = single mode: `epicenter posts list`
+- N `WorkspaceClient` exports = multi mode: `epicenter blog posts list`
+
+We removed multi-workspace support entirely. **One config file = one workspace.**
+
+### Rationale
+
+1. **Complexity reduction**: The discriminated union (`SingleClientConfig | MultiClientConfig`) adds conditional logic throughout the codebase
+2. **Simpler mental model**: Users don't need to understand when commands get prefixed
+3. **Clearer error messages**: No ambiguity about command structure
+4. **Multiple workspaces still possible**: Use separate directories with separate config files or `-C` flag
+
+## Files Affected
+
+| File | Changes |
+|------|---------|
+| `discovery.ts` | Remove `MultiClientConfig`, simplify `loadClients` to `loadClient` |
+| `cli.ts` | Take single client, remove array iteration |
+| `table-commands.ts` | Remove conditional command path |
+| `kv-commands.ts` | Remove conditional command path |
+| `meta-commands.ts` | Remove `workspaces` command, simplify `tables` handler |
+| `index.ts` | Update exports |
+| `README.md` | Remove multi-workspace documentation |
+
+---
+
+## 1. Code Deletions
+
+### 1.1 Type Definitions (discovery.ts)
+
+**Delete entirely:**
+
+```ts
+// DELETE: Multi client mode type
+export type MultiClientConfig = {
+  mode: 'multi';
+  clients: AnyWorkspaceClient[];
+};
+
+// DELETE: Discriminated union
+export type CommandConfig = SingleClientConfig | MultiClientConfig;
+```
+
+### 1.2 Mode Detection Logic (discovery.ts)
+
+**Delete:**
+
+```ts
+// DELETE: createCommandConfig function
+export function createCommandConfig(clients: AnyWorkspaceClient[]): CommandConfig {
+  if (clients.length === 0) {
+    throw new Error('At least one client required');
+  }
+  if (clients.length === 1) {
+    return { mode: 'single', clients: [clients[0]!] as const };
+  }
+  return { mode: 'multi', clients };
+}
+```
+
+### 1.3 Multi-Client Conditionals (throughout)
+
+**Delete all `config.mode === 'single'` / `config.mode === 'multi'` checks:**
+
+```ts
+// DELETE: In meta-commands.ts tables handler
+if (config.mode === 'single') {
+  const tableNames = Object.keys(config.clients[0]!.tables);
+  output(tableNames, { format: argv.format as any });
+} else {
+  const result: Record<string, string[]> = {};
+  for (const client of config.clients) {
+    result[client.id] = Object.keys(client.tables);
+  }
+  output(result, { format: argv.format as any });
+}
+
+// DELETE: In table-commands.ts
+const commandPath =
+  config.mode === 'single'
+    ? tableName
+    : `${client.id} ${tableName}`;
+
+// DELETE: In kv-commands.ts
+const commandPath = config.mode === 'single' ? 'kv' : `${client.id} kv`;
+```
+
+### 1.4 Workspaces Command (meta-commands.ts)
+
+**Delete entirely:**
+
+```ts
+// DELETE: workspaces command
+commands.push({
+  command: 'workspaces',
+  describe: 'List all workspaces',
+  builder: (yargs) => yargs.options(formatYargsOptions()),
+  handler: (argv) => {
+    const ids = config.clients.map((c) => c.id);
+    output(ids, { format: argv.format as any });
+  },
+});
+```
+
+### 1.5 Workspace Name Validation (cli.ts)
+
+**Delete:**
+
+```ts
+// DELETE: Multi-client workspace name validation
+if (!isSingleClient && isReservedCommand(client.id)) {
+  console.warn(
+    `Warning: Workspace "${client.id}" conflicts with reserved command. ` +
+      `Reserved commands: ${RESERVED_COMMANDS.join(', ')}`,
+  );
+}
+```
+
+### 1.6 Client Array Iteration (cli.ts)
+
+**Delete:**
+
+```ts
+// DELETE: Array normalization
+const clientArray = Array.isArray(clients) ? clients : [clients];
+
+// DELETE: Loops over clientArray
+for (const client of clientArray) {
+  await client.destroy();
+}
+```
+
+### 1.7 Reserved Command (meta-commands.ts)
+
+**Delete from RESERVED_COMMANDS:**
+
+```ts
+// BEFORE
+export const RESERVED_COMMANDS = [
+  'serve',
+  'tables',
+  'workspaces',  // <-- DELETE THIS
+  'kv',
+  'help',
+  'version',
+  'init',
+] as const;
+
+// AFTER
+export const RESERVED_COMMANDS = [
+  'serve',
+  'tables',
+  'kv',
+  'help',
+  'version',
+  'init',
+] as const;
+```
+
+### 1.8 Exports (index.ts)
+
+**Delete:**
+
+```ts
+// DELETE from exports
+type MultiClientConfig,
+type SingleClientConfig,
+type CommandConfig,
+createCommandConfig,
+loadClients,  // renamed to loadClient
+```
+
+---
+
+## 2. Actual Implementation
+
+### 2.1 discovery.ts - New Resolution Pattern
+
+The actual implementation introduced a more sophisticated discovery pattern:
+
+```ts
+export type WorkspaceResolution =
+  | { status: 'found'; projectDir: ProjectDir; client: AnyWorkspaceClient }
+  | { status: 'ambiguous'; configs: string[] }
+  | { status: 'not_found' };
+
+/**
+ * Resolve and load a workspace from a directory.
+ *
+ * 1. Checks for config in the given directory
+ * 2. If not found, checks subdirectories for ambiguity detection
+ * 3. Loads and validates the client if found
+ */
+export async function resolveWorkspace(
+  dir: string = process.cwd(),
+): Promise<WorkspaceResolution> {
+  const baseDir = resolve(dir);
+  const configPath = join(baseDir, CONFIG_FILENAME);
+
+  // Check for config in the specified directory
+  if (await Bun.file(configPath).exists()) {
+    const client = await loadClientFromPath(configPath);
+    return { status: 'found', projectDir: baseDir as ProjectDir, client };
+  }
+
+  // No config in target dir - check subdirs for helpful error message
+  const subdirConfigs = await findSubdirConfigs(baseDir);
+  if (subdirConfigs.length > 0) {
+    return { status: 'ambiguous', configs: subdirConfigs };
+  }
+
+  return { status: 'not_found' };
+}
+```
+
+**Key improvements:**
+- Discriminated union return type for type-safe error handling
+- Automatic subdirectory scanning for helpful error messages
+- Single function that combines discovery and loading
+- Better error context with `tryAsync` integration
+
+### 2.2 discovery.ts - Default Export Convention
+
+The implementation introduced a new default export convention:
+
+```ts
+async function loadClientFromPath(configPath: string): Promise<AnyWorkspaceClient> {
+  const module = await import(Bun.pathToFileURL(configPath).href);
+
+  // New convention: export default createWorkspaceClient({...})
+  if (module.default !== undefined) {
+    const client = module.default;
+    if (isWorkspaceClient(client)) {
+      return client;
+    }
+    throw new Error(
+      `Default export in ${CONFIG_FILENAME} is not a WorkspaceClient.\n` +
+        `Expected: export default createWorkspaceClient({...})\n` +
+        `Got: ${typeof client}`,
+    );
+  }
+
+  // Fallback: support old convention of named exports (for migration)
+  const exports = Object.entries(module);
+  const clients = exports.filter(([, value]) => isWorkspaceClient(value));
+
+  if (clients.length === 0) {
+    throw new Error(
+      `No WorkspaceClient found in ${CONFIG_FILENAME}.\n` +
+        `Expected: export default createWorkspaceClient({...})`,
+    );
+  }
+
+  if (clients.length > 1) {
+    const names = clients.map(([name]) => name).join(', ');
+    throw new Error(
+      `Multiple WorkspaceClient exports found: ${names}\n` +
+        `Epicenter supports one workspace per config. Use: export default createWorkspaceClient({...})`,
+    );
+  }
+
+  return clients[0]![1] as AnyWorkspaceClient;
+}
+```
+
+**Benefits:**
+- Clearer intent with default export
+- Backward compatible with named exports
+- Better error messages listing export names
+- Migration path for existing configs
+
+### 2.3 bin.ts - Directory Flag Support
+
+Added `-C` and `--dir` flag parsing before yargs processes subcommands:
+
+```ts
+export function parseDirectoryFlag(argv: string[]): DirectoryParseResult {
+  let baseDir = process.cwd();
+  const remainingArgs: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+
+    // Handle -C <dir> or --dir <dir>
+    if (arg === '-C' || arg === '--dir') {
+      const nextArg = argv[i + 1];
+      if (!nextArg || nextArg.startsWith('-')) {
+        return { ok: false, error: `${arg} requires a directory argument` };
+      }
+      baseDir = resolve(nextArg);
+      i++;
+      continue;
+    }
+
+    // Handle -C=<dir> or --dir=<dir>
+    if (arg.startsWith('-C=')) {
+      baseDir = resolve(arg.slice(3));
+      continue;
+    }
+    if (arg.startsWith('--dir=')) {
+      baseDir = resolve(arg.slice(6));
+      continue;
+    }
+
+    remainingArgs.push(arg);
+  }
+
+  return { ok: true, baseDir, remainingArgs };
+}
+```
+
+This allows running commands like:
+```bash
+epicenter -C blog posts list
+epicenter --dir=shop products get abc123
+```
+
+### 2.4 Error Handling with tryAsync
+
+Used `wellcrafted/result` for robust error handling:
+
+```ts
+const resolutionResult = await tryAsync(() => resolveWorkspace(baseDir));
+
+if (!resolutionResult.ok) {
+  console.error('Failed to load workspace:', resolutionResult.error.message);
+  process.exit(1);
+}
+
+const resolution = resolutionResult.value;
+
+if (resolution.status === 'not_found') {
+  console.error('No epicenter.config.ts found in', baseDir);
+  process.exit(1);
+}
+
+if (resolution.status === 'ambiguous') {
+  console.error('No epicenter.config.ts found in current directory.\n');
+  console.error('Found configs in subdirectories:');
+  for (const config of resolution.configs) {
+    console.error(`  - ${config}`);
+  }
+  console.error('\nUse -C <dir> to specify which project:');
+  console.error('  epicenter -C <dir> <command>');
+  process.exit(1);
+}
+```
+
+### Original Plan: discovery.ts (for reference)
+
+**Original simplified approach:**
+
+```ts
+export async function loadClient(
+  projectDir: ProjectDir,
+): Promise<AnyWorkspaceClient> {
+  const configPath = join(projectDir, 'epicenter.config.ts');
+
+  if (!(await fileExists(configPath))) {
+    throw new Error(`No epicenter.config.ts found at ${configPath}`);
+  }
+
+  const module = await import(configPath);
+  const clients = Object.values(module).filter(isWorkspaceClient);
+
+  if (clients.length === 0) {
+    throw new Error(
+      `No WorkspaceClient exports found in epicenter.config.ts.\n` +
+        `Export a client as: export const workspace = createWorkspaceClient({...})`,
+    );
+  }
+
+  if (clients.length > 1) {
+    throw new Error(
+      `Found ${clients.length} WorkspaceClient exports. ` +
+        `Epicenter supports one workspace per config file.\n` +
+        `Use separate directories for multiple workspaces.`,
+    );
+  }
+
+  return clients[0]!;
+}
+```
+
+### 2.5 cli.ts - Actual Implementation
+
+The actual implementation is clean and minimal:
+
+```ts
+export function createCLI(client: AnyWorkspaceClient, options?: CLIOptions) {
+  let cli = yargs()
+    .scriptName('epicenter')
+    .usage('Usage: $0 <command> [options]')
+    .help()
+    .version()
+    .strict()
+    .command(
+      'serve',
+      'Start HTTP server with REST and WebSocket sync endpoints',
+      (yargs) =>
+        yargs.option('port', {
+          type: 'number',
+          description: 'Port to run the server on',
+          default: DEFAULT_PORT,
+        }),
+      (argv) => {
+        createServer(client as any, {
+          port: argv.port,
+          actions: options?.actions,
+        }).start();
+      },
+    );
+
+  // Add meta commands (tables)
+  const metaCommands = buildMetaCommands(client);
+  for (const cmd of metaCommands) {
+    cli = cli.command(cmd);
+  }
+
+  // Add table commands for each table
+  const tableCommands = buildTableCommands(client);
+  for (const cmd of tableCommands) {
+    cli = cli.command(cmd);
+  }
+
+  // Add KV commands
+  const kvCommands = buildKvCommands(client);
+  for (const cmd of kvCommands) {
+    cli = cli.command(cmd);
+  }
+
+  // Add action commands if provided
+  if (options?.actions) {
+    const commands = buildActionCommands(options.actions);
+    for (const cmd of commands) {
+      cli = cli.command(cmd);
+    }
+  }
+
+  return {
+    async run(argv: string[]) {
+      const cleanup = async () => {
+        await client.destroy();
+        process.exit(0);
+      };
+      process.on('SIGINT', cleanup);
+      process.on('SIGTERM', cleanup);
+
+      try {
+        await cli.parse(argv);
+      } finally {
+        process.off('SIGINT', cleanup);
+        process.off('SIGTERM', cleanup);
+        await client.destroy();
+      }
+    },
+  };
+}
+```
+
+**Notable changes:**
+- No array handling at all
+- No mode configuration types
+- No validation warnings (removed as dead code)
+- Clean signal handling with cleanup
+- Type cast for server compatibility (static vs dynamic types)
+
+### 2.6 Command Builders - Simplified Signatures
+
+All command builders were simplified to take a single client:
+
+**table-commands.ts:**
+```ts
+export function buildTableCommands(client: AnyWorkspaceClient): CommandModule[] {
+  const commands: CommandModule[] = [];
+  const tableNames = Object.keys(client.tables);
+
+  for (const tableName of tableNames) {
+    const tableHelper = (client.tables as Record<string, unknown>)[tableName];
+    commands.push(buildTableCommand(tableName, tableHelper));
+  }
+
+  return commands;
+}
+```
+
+**kv-commands.ts:**
+```ts
+export function buildKvCommands(client: AnyWorkspaceClient): CommandModule[] {
+  return [buildKvCommand(client)];
+}
+```
+
+**meta-commands.ts:**
+```ts
+export function buildMetaCommands(client: AnyWorkspaceClient): CommandModule[] {
+  return [
+    {
+      command: 'tables',
+      describe: 'List all table names',
+      builder: (yargs) => yargs.options(formatYargsOptions()),
+      handler: (argv) => {
+        const tableNames = Object.keys(client.tables);
+        output(tableNames, { format: argv.format as any });
+      },
+    },
+  ];
+}
+
+export const RESERVED_COMMANDS = [
+  'serve',
+  'tables',
+  'kv',
+  'help',
+  'version',
+  'init',
+] as const; // 'workspaces' removed
+```
+
+### 2.4 kv-commands.ts
+
+**Before:**
+
+```ts
+export function buildKvCommands(config: CommandConfig): CommandModule[] {
+  const commands: CommandModule[] = [];
+
+  for (const client of config.clients) {
+    const commandPath = config.mode === 'single' ? 'kv' : `${client.id} kv`;
+    commands.push(buildKvCommand(commandPath, client));
+  }
+
+  return commands;
+}
+```
+
+**After:**
+
+```ts
+export function buildKvCommands(client: AnyWorkspaceClient): CommandModule[] {
+  return [buildKvCommand(client)];
+}
+
+function buildKvCommand(client: AnyWorkspaceClient): CommandModule {
+  return {
+    command: 'kv <action>',
+    // ... rest unchanged
+  };
+}
+```
+
+### 2.5 meta-commands.ts
+
+**Before:**
+
+```ts
+export function buildMetaCommands(config: CommandConfig): CommandModule[] {
+  const commands: CommandModule[] = [];
+
+  // 'tables' command
+  commands.push({
+    command: 'tables',
+    describe: 'List all table names',
+    builder: (yargs) => yargs.options(formatYargsOptions()),
+    handler: (argv) => {
+      if (config.mode === 'single') {
+        const tableNames = Object.keys(config.clients[0]!.tables);
+        output(tableNames, { format: argv.format as any });
+      } else {
+        const result: Record<string, string[]> = {};
+        for (const client of config.clients) {
+          result[client.id] = Object.keys(client.tables);
+        }
+        output(result, { format: argv.format as any });
+      }
+    },
+  });
+
+  // 'workspaces' command
+  commands.push({
+    command: 'workspaces',
+    describe: 'List all workspaces',
+    // ...
+  });
+
+  return commands;
+}
+
+export const RESERVED_COMMANDS = [
+  'serve',
+  'tables',
+  'workspaces',
+  'kv',
+  'help',
+  'version',
+  'init',
+] as const;
+```
+
+**After:**
+
+```ts
+export function buildMetaCommands(client: AnyWorkspaceClient): CommandModule[] {
+  return [
+    {
+      command: 'tables',
+      describe: 'List all table names',
+      builder: (yargs) => yargs.options(formatYargsOptions()),
+      handler: (argv) => {
+        const tableNames = Object.keys(client.tables);
+        output(tableNames, { format: argv.format as any });
+      },
+    },
+  ];
+}
+
+export const RESERVED_COMMANDS = [
+  'serve',
+  'tables',
+  'kv',
+  'help',
+  'version',
+  'init',
+] as const;
+```
+
+### 2.6 index.ts
+
+**Before:**
+
+```ts
+export { createCLI } from './cli';
+export {
+  createCommandConfig,
+  findProjectDir,
+  loadClients,
+  type AnyWorkspaceClient,
+  type CommandConfig,
+  type MultiClientConfig,
+  type SingleClientConfig,
+} from './discovery';
+export { buildTableCommands } from './commands/table-commands';
+export { buildKvCommands } from './commands/kv-commands';
+export {
+  buildMetaCommands,
+  RESERVED_COMMANDS,
+  type ReservedCommand,
+  isReservedCommand,
+} from './commands/meta-commands';
+```
+
+**After:**
+
+```ts
+export { createCLI } from './cli';
+export {
+  findProjectDir,
+  loadClient,
+  type AnyWorkspaceClient,
+} from './discovery';
+export { buildTableCommands } from './commands/table-commands';
+export { buildKvCommands } from './commands/kv-commands';
+export {
+  buildMetaCommands,
+  RESERVED_COMMANDS,
+  type ReservedCommand,
+  isReservedCommand,
+} from './commands/meta-commands';
+```
+
+---
+
+## 3. Error Handling
+
+### 3.1 Multiple Exports Error
+
+When `loadClient()` finds multiple `WorkspaceClient` exports, throw a clear error:
+
+```ts
+if (clients.length > 1) {
+  throw new Error(
+    `Found ${clients.length} WorkspaceClient exports. ` +
+      `Epicenter supports one workspace per config file.\n` +
+      `Use separate directories for multiple workspaces.`,
+  );
+}
+```
+
+Example output:
+
+```
+Error: Found 3 WorkspaceClient exports. Epicenter supports one workspace per config file.
+Use separate directories for multiple workspaces.
+```
+
+### 3.2 No Exports Error (unchanged)
+
+```ts
+if (clients.length === 0) {
+  throw new Error(
+    `No WorkspaceClient exports found in epicenter.config.ts.\n` +
+      `Export a client as: export const workspace = createWorkspaceClient({...})`,
+  );
+}
+```
+
+---
+
+## 4. Documentation Update (README.md)
+
+### 4.1 Remove Multi-Workspace Section
+
+**Delete:**
+
+```markdown
+## Multi-Workspace Mode
+
+With multiple workspaces, prefix commands with the workspace name:
+
+\`\`\`bash
+epicenter blog table posts list
+epicenter blog kv get theme
+epicenter shop table products get abc123
+\`\`\`
+```
+
+### 4.2 Remove Reserved Workspace Names
+
+**Delete:**
+
+```markdown
+## Reserved Names
+
+Table names have no restrictions.
+
+Workspace names cannot be: `table`, `tables`, `kv`, `workspaces`, `serve`, `help`, `version`.
+```
+
+**Replace with:**
+
+```markdown
+## Reserved Names
+
+Table names cannot match reserved commands: `serve`, `tables`, `kv`, `help`, `version`, `init`.
+
+If a table name conflicts, the CLI will log a warning but still work.
+```
+
+### 4.3 Update Command Structure
+
+**Before:**
+
+```markdown
+## Command Structure
+
+\`\`\`bash
+epicenter table <name> <action>   # table operations
+epicenter kv <action>             # key-value operations
+epicenter tables                  # list table names
+epicenter workspaces              # list workspace names
+epicenter serve                   # start HTTP/WebSocket server
+\`\`\`
+```
+
+**After:**
+
+```markdown
+## Command Structure
+
+\`\`\`bash
+epicenter <table> <action>  # table operations (e.g., posts list)
+epicenter kv <action>       # key-value operations
+epicenter tables            # list table names
+epicenter serve             # start HTTP/WebSocket server
+\`\`\`
+```
+
+### 4.4 Updated README.md
+
+```markdown
+# Epicenter CLI
+
+Manage workspace data and start the sync server.
+
+## Command Structure
+
+\`\`\`bash
+epicenter <table> <action>  # table operations
+epicenter kv <action>       # key-value operations
+epicenter tables            # list table names
+epicenter serve             # start HTTP/WebSocket server
+\`\`\`
+
+## Table Commands
+
+\`\`\`bash
+epicenter users list              # list all rows
+epicenter users list --all        # include invalid rows
+epicenter users get <id>          # get row by id
+epicenter users set '<json>'      # create/replace row
+epicenter users update <id> --name "New"  # partial update
+epicenter users delete <id>       # delete row
+epicenter users clear             # delete all rows
+epicenter users count             # count rows
+\`\`\`
+
+## KV Commands
+
+\`\`\`bash
+epicenter kv get <key>            # get value
+epicenter kv set <key> <value>    # set value
+epicenter kv delete <key>         # delete key
+\`\`\`
+
+## Input Methods
+
+\`\`\`bash
+# Inline JSON
+epicenter users set '{"id":"1","name":"Alice"}'
+
+# From file
+epicenter users set --file user.json
+epicenter users set @user.json
+
+# From stdin
+cat user.json | epicenter users set
+
+# Flag-based update
+epicenter users update abc123 --name "Bob" --active true
+\`\`\`
+
+## Output Formats
+
+\`\`\`bash
+epicenter users list                  # pretty JSON (TTY)
+epicenter users list | jq             # compact JSON (pipe)
+epicenter users list --format json    # force JSON
+epicenter users list --format jsonl   # JSON lines
+\`\`\`
+
+## Server
+
+\`\`\`bash
+epicenter serve              # default port 3913
+epicenter serve --port 8080  # custom port
+\`\`\`
+
+Exposes REST API and WebSocket sync.
+
+## Reserved Names
+
+Table names cannot match reserved commands: `serve`, `tables`, `kv`, `help`, `version`, `init`.
+
+If a table name conflicts, the CLI will log a warning but still work.
+
+## Multiple Workspaces
+
+For multiple workspaces, use separate directories with their own `epicenter.config.ts` files.
+\`\`\`
+```
+
+---
+
+## 5. Test Updates
+
+### 5.1 Tests to Remove
+
+Remove any test scenarios for multi-workspace mode:
+
+- Tests with multiple `WorkspaceClient` exports
+- Tests verifying `config.mode === 'multi'` behavior
+- Tests for the `workspaces` command
+- Tests for workspace name collision validation
+
+### 5.2 New Test: Multiple Exports Error
+
+```ts
+import { test, expect } from 'bun:test';
+import { loadClient } from './discovery';
+
+test('loadClient throws on multiple exports', async () => {
+  // Setup: create temp config with multiple exports
+  const tempDir = await setupTempConfig(`
+    export const blog = createWorkspaceClient({ id: 'blog', ... });
+    export const shop = createWorkspaceClient({ id: 'shop', ... });
+  `);
+
+  await expect(loadClient(tempDir)).rejects.toThrow(
+    /Found 2 WorkspaceClient exports/
+  );
+  await expect(loadClient(tempDir)).rejects.toThrow(
+    /Epicenter supports one workspace per config file/
+  );
+});
+```
+
+### 5.3 Updated Single-Workspace Tests
+
+Ensure existing tests work with simplified API:
+
+```ts
+test('createCLI works with single client', () => {
+  const client = createMockClient();
+  const cli = createCLI(client);
+
+  // Should work without array wrapping
+  expect(cli).toBeDefined();
+});
+
+test('buildTableCommands generates top-level commands', () => {
+  const client = createMockClient({ tables: { posts: {}, users: {} } });
+  const commands = buildTableCommands(client);
+
+  expect(commands).toHaveLength(2);
+  expect(commands[0].command).toBe('posts <action>');
+  expect(commands[1].command).toBe('users <action>');
+});
+```
+
+---
+
+## 6. Implementation Status
+
+### Code Changes ✅
+
+- [x] Delete `MultiClientConfig` type from `discovery.ts`
+- [x] Delete `SingleClientConfig` type from `discovery.ts`
+- [x] Delete `CommandConfig` type from `discovery.ts`
+- [x] Delete `createCommandConfig` function from `discovery.ts`
+- [x] **IMPROVED**: Add `resolveWorkspace()` with discriminated union (better than planned `loadClient`)
+- [x] **NEW**: Add default export convention with backward compatibility
+- [x] **NEW**: Add subdirectory ambiguity detection
+- [x] Update `createCLI` signature to take single client
+- [x] Remove `clientArray` normalization in `cli.ts`
+- [x] Remove client array loops in `cli.ts`
+- [x] Remove `validateNames` function (was dead code)
+- [x] Update `buildTableCommands` to take single client
+- [x] Remove conditional command path in `buildTableCommands`
+- [x] Update `buildKvCommands` to take single client
+- [x] Remove conditional command path in `buildKvCommands`
+- [x] Update `buildMetaCommands` to take single client
+- [x] Remove `workspaces` command from `buildMetaCommands`
+- [x] Remove mode conditional in `tables` handler
+- [x] Remove `workspaces` from `RESERVED_COMMANDS`
+- [x] Update exports in `index.ts`
+- [x] **NEW**: Add `-C`/`--dir` flag parsing in `bin.ts`
+- [x] **NEW**: Integrate `tryAsync` error handling throughout
+- [x] **NEW**: Improve path handling for cross-platform compatibility
+
+### Documentation ✅
+
+- [x] Remove multi-workspace section from README
+- [x] Update command examples to show direct table names
+- [x] Update reserved names section
+- [x] Add "Working Directory" section explaining `-C` flag
+- [x] Add helpful error message examples
+- [x] Add "Multiple Workspaces" section
+
+### Additional Improvements
+
+- [x] Used `tryAsync` from wellcrafted for robust error handling
+- [x] Added `Bun.pathToFileURL()` for proper module loading
+- [x] Improved error messages with context
+- [x] Added helpful suggestions in error output
+- [x] Cross-platform path normalization
+- [x] Support for both `-C dir` and `-C=dir` syntax
+
+---
+
+## 7. Migration Notes
+
+### For Users
+
+If you have a config with multiple workspaces:
+
+**Before:**
+```ts
+// epicenter.config.ts
+export const blog = createWorkspaceClient({ id: 'blog', ... });
+export const shop = createWorkspaceClient({ id: 'shop', ... });
+```
+
+**After:**
+```
+my-project/
+├── blog/
+│   └── epicenter.config.ts  // export const blog = ...
+└── shop/
+    └── epicenter.config.ts  // export const shop = ...
+```
+
+Run CLI from the appropriate directory:
+```bash
+cd blog && epicenter posts list
+cd shop && epicenter products list
+```
+
+### Breaking Changes
+
+1. Multiple `WorkspaceClient` exports now throw an error
+2. `workspaces` command removed
+3. `loadClients()` renamed to `loadClient()`
+4. `createCLI()` no longer accepts arrays
+5. `CommandConfig`, `SingleClientConfig`, `MultiClientConfig` types removed


### PR DESCRIPTION
The Epicenter CLI was a server launcher. Now it's a workspace management tool with full CRUD operations for tables and KV stores.

The original multi-workspace design (`epicenter blog posts list` vs `epicenter posts list` based on export count) added complexity without much benefit. We simplified to one workspace per config, with `-C/--dir` for managing multiple projects:

```
┌──────────────────────────────────────────────────────────────────────────┐
│ epicenter -C blog posts list                                             │
└──────────────────────────────────────────────────────────────────────────┘
                    │
                    ▼
┌──────────────────────────────────────────────────────────────────────────┐
│ parseDirectoryFlag()        Extract -C flag before yargs                 │
│ ──────────────────────────────────────────────────────────────────────── │
│ resolveWorkspace()          Find config, detect ambiguity                │
│ ──────────────────────────────────────────────────────────────────────── │
│ createCLI(client)           Build yargs with table/kv/meta commands      │
└──────────────────────────────────────────────────────────────────────────┘
```

**Config convention** changed to default exports:

```typescript
// epicenter.config.ts
export default createWorkspaceClient({
  id: 'blog',
  tables: { posts },
  kv: { settings },
});
```

Named exports still work (for migration), but only one is allowed. Multiple exports error with a clear message.

**Table commands** work on static tables via TableHelper:

```bash
epicenter posts list              # getAllValid()
epicenter posts list --all        # getAll() - includes invalid rows
epicenter posts get abc123        # get(id)
epicenter posts set '{"id":"1","title":"Hello"}'  # set(row)
epicenter posts update abc123 --title "New Title" # update(id, partial)
epicenter posts delete abc123     # delete(id)
epicenter posts count             # count()
epicenter posts clear             # clear()
```

**Input methods** for `set`:

```bash
epicenter posts set '{"id":"1"}'       # inline JSON
epicenter posts set @data.json         # file reference
epicenter posts set --file data.json   # explicit file flag
cat data.json | epicenter posts set    # stdin
```

**KV commands** mirror the pattern:

```bash
epicenter kv get theme
epicenter kv set theme dark
epicenter kv delete theme
epicenter kv list
```

**Ambiguity detection** helps when running from wrong directory:

```
No epicenter.config.ts found in current directory.

Found configs in subdirectories:
  - blog/epicenter.config.ts
  - shop/epicenter.config.ts

Use -C <dir> to specify which project:
  epicenter -C blog posts list
```

**Implementation notes:**

- `resolveWorkspace()` returns a discriminated union (`found | ambiguous | not_found`) making error handling explicit
- `-C/--dir` parsing happens before yargs to avoid subcommand conflicts
- Output adapts to TTY: pretty JSON for terminals, compact for pipes
- Used `tryAsync` from wellcrafted throughout for consistent error handling
- Added `update()` to static TableHelper (fetch-merge-set pattern)
- Workspace ID field unified to `.id` across all APIs (was inconsistent)

**Testing:**

- Unit tests for `parse-input.ts` and `format-output.ts`
- Manual testing of all table commands against local workspace
- Tested ambiguity detection with multiple subdirectory configs
- Verified stdin/file/inline input methods