### PR TITLE
feat(epicenter): add YCellStore and YRowStore for cell-level CRDT storage

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/packages/epicenter/src/shared/y-cell-store.test.ts
+++ b/packages/epicenter/src/shared/y-cell-store.test.ts
@@ -14,7 +14,7 @@
  */
 import { describe, expect, test } from 'bun:test';
 import * as Y from 'yjs';
-import { createCellStore, type CellChange } from './y-cell-store';
+import { type CellChange, createCellStore } from './y-cell-store';
 
 describe('YCellStore', () => {
 	describe('Cell CRUD', () => {
@@ -101,7 +101,7 @@ describe('YCellStore', () => {
 			const cells = createCellStore<string>(ydoc, 'cells');
 
 			expect(() => cells.setCell('row:1', 'title', 'Hello')).toThrow(
-				"rowId cannot contain ':': \"row:1\"",
+				'rowId cannot contain \':\': "row:1"',
 			);
 		});
 
@@ -278,7 +278,12 @@ describe('YCellStore', () => {
 			cells.deleteCell('row-1', 'title');
 
 			expect(changes).toEqual([
-				{ action: 'delete', rowId: 'row-1', columnId: 'title', oldValue: 'Hello' },
+				{
+					action: 'delete',
+					rowId: 'row-1',
+					columnId: 'title',
+					oldValue: 'Hello',
+				},
 			]);
 		});
 

--- a/packages/epicenter/src/shared/y-cell-store.test.ts
+++ b/packages/epicenter/src/shared/y-cell-store.test.ts
@@ -1,0 +1,526 @@
+/**
+ * YCellStore Tests - Schema-agnostic Sparse Grid Storage
+ *
+ * Tests cover:
+ * 1. Cell CRUD: setCell, getCell, hasCell, deleteCell
+ * 2. Key validation: rowId with ':' throws error
+ * 3. Batch operations: multiple cell operations atomically
+ * 4. Observer fires once per batch: not per operation
+ * 5. Change types: add, update, delete events with correct rowId/columnId
+ * 6. Iteration: cells() yields all cells with parsed components
+ * 7. Count accuracy: after various operations
+ * 8. Clear: removes all cells
+ * 9. Escape hatch: ykv and doc accessible
+ */
+import { describe, expect, test } from 'bun:test';
+import * as Y from 'yjs';
+import { createCellStore, type CellChange } from './y-cell-store';
+
+describe('YCellStore', () => {
+	describe('Cell CRUD', () => {
+		test('setCell and getCell work correctly', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			cells.setCell('row-1', 'title', 'Hello');
+			expect(cells.getCell('row-1', 'title')).toBe('Hello');
+		});
+
+		test('setCell overwrites existing value', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			cells.setCell('row-1', 'title', 'First');
+			cells.setCell('row-1', 'title', 'Second');
+			expect(cells.getCell('row-1', 'title')).toBe('Second');
+		});
+
+		test('getCell returns undefined for non-existent cell', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			expect(cells.getCell('row-1', 'title')).toBeUndefined();
+		});
+
+		test('hasCell returns true for existing cell', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			cells.setCell('row-1', 'title', 'Hello');
+			expect(cells.hasCell('row-1', 'title')).toBe(true);
+		});
+
+		test('hasCell returns false for non-existent cell', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			expect(cells.hasCell('row-1', 'title')).toBe(false);
+		});
+
+		test('deleteCell removes cell and returns true', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			cells.setCell('row-1', 'title', 'Hello');
+			const result = cells.deleteCell('row-1', 'title');
+
+			expect(result).toBe(true);
+			expect(cells.getCell('row-1', 'title')).toBeUndefined();
+			expect(cells.hasCell('row-1', 'title')).toBe(false);
+		});
+
+		test('deleteCell returns false for non-existent cell', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			const result = cells.deleteCell('row-1', 'title');
+			expect(result).toBe(false);
+		});
+
+		test('supports different value types', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<unknown>(ydoc, 'cells');
+
+			cells.setCell('row-1', 'string', 'hello');
+			cells.setCell('row-1', 'number', 42);
+			cells.setCell('row-1', 'boolean', true);
+			cells.setCell('row-1', 'object', { nested: 'value' });
+			cells.setCell('row-1', 'null', null);
+
+			expect(cells.getCell('row-1', 'string')).toBe('hello');
+			expect(cells.getCell('row-1', 'number')).toBe(42);
+			expect(cells.getCell('row-1', 'boolean')).toBe(true);
+			expect(cells.getCell('row-1', 'object')).toEqual({ nested: 'value' });
+			expect(cells.getCell('row-1', 'null')).toBeNull();
+		});
+	});
+
+	describe('Key Validation', () => {
+		test('rowId with colon throws error', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			expect(() => cells.setCell('row:1', 'title', 'Hello')).toThrow(
+				"rowId cannot contain ':': \"row:1\"",
+			);
+		});
+
+		test('columnId with colon is allowed', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			cells.setCell('row-1', 'nested:column:id', 'Hello');
+			expect(cells.getCell('row-1', 'nested:column:id')).toBe('Hello');
+		});
+
+		test('empty rowId is allowed', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			cells.setCell('', 'title', 'Hello');
+			expect(cells.getCell('', 'title')).toBe('Hello');
+		});
+
+		test('empty columnId is allowed', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			cells.setCell('row-1', '', 'Hello');
+			expect(cells.getCell('row-1', '')).toBe('Hello');
+		});
+	});
+
+	describe('Batch Operations', () => {
+		test('batch executes multiple operations atomically', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			cells.batch((tx) => {
+				tx.setCell('row-1', 'title', 'Hello');
+				tx.setCell('row-1', 'views', '42');
+				tx.setCell('row-2', 'title', 'World');
+			});
+
+			expect(cells.getCell('row-1', 'title')).toBe('Hello');
+			expect(cells.getCell('row-1', 'views')).toBe('42');
+			expect(cells.getCell('row-2', 'title')).toBe('World');
+		});
+
+		test('batch deleteCell removes cells', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			cells.setCell('row-1', 'title', 'Hello');
+			cells.setCell('row-1', 'views', '42');
+
+			cells.batch((tx) => {
+				tx.deleteCell('row-1', 'title');
+			});
+
+			expect(cells.hasCell('row-1', 'title')).toBe(false);
+			expect(cells.hasCell('row-1', 'views')).toBe(true);
+		});
+
+		test('values set in batch are readable within batch', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			let valueInBatch: string | undefined;
+
+			cells.batch((tx) => {
+				tx.setCell('row-1', 'title', 'Hello');
+				valueInBatch = cells.getCell('row-1', 'title');
+			});
+
+			expect(valueInBatch).toBe('Hello');
+		});
+	});
+
+	describe('Observer', () => {
+		test('observer fires once per batch, not per operation', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			let callCount = 0;
+			cells.observe(() => {
+				callCount++;
+			});
+
+			cells.batch((tx) => {
+				tx.setCell('row-1', 'a', '1');
+				tx.setCell('row-1', 'b', '2');
+				tx.setCell('row-2', 'a', '3');
+			});
+
+			expect(callCount).toBe(1);
+		});
+
+		test('observer receives all changes from batch', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			const changes: CellChange<string>[] = [];
+			cells.observe((c) => {
+				changes.push(...c);
+			});
+
+			cells.batch((tx) => {
+				tx.setCell('row-1', 'a', '1');
+				tx.setCell('row-2', 'b', '2');
+			});
+
+			expect(changes.length).toBe(2);
+			expect(changes[0]).toEqual({
+				action: 'add',
+				rowId: 'row-1',
+				columnId: 'a',
+				value: '1',
+			});
+			expect(changes[1]).toEqual({
+				action: 'add',
+				rowId: 'row-2',
+				columnId: 'b',
+				value: '2',
+			});
+		});
+
+		test('observer fires add event for new cell', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			const changes: CellChange<string>[] = [];
+			cells.observe((c) => {
+				changes.push(...c);
+			});
+
+			cells.setCell('row-1', 'title', 'Hello');
+
+			expect(changes).toEqual([
+				{ action: 'add', rowId: 'row-1', columnId: 'title', value: 'Hello' },
+			]);
+		});
+
+		test('observer fires update event when value changes', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			cells.setCell('row-1', 'title', 'First');
+
+			const changes: CellChange<string>[] = [];
+			cells.observe((c) => {
+				changes.push(...c);
+			});
+
+			cells.setCell('row-1', 'title', 'Second');
+
+			expect(changes).toEqual([
+				{
+					action: 'update',
+					rowId: 'row-1',
+					columnId: 'title',
+					oldValue: 'First',
+					value: 'Second',
+				},
+			]);
+		});
+
+		test('observer fires delete event when cell removed', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			cells.setCell('row-1', 'title', 'Hello');
+
+			const changes: CellChange<string>[] = [];
+			cells.observe((c) => {
+				changes.push(...c);
+			});
+
+			cells.deleteCell('row-1', 'title');
+
+			expect(changes).toEqual([
+				{ action: 'delete', rowId: 'row-1', columnId: 'title', oldValue: 'Hello' },
+			]);
+		});
+
+		test('unsubscribe stops receiving events', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			let callCount = 0;
+			const unsubscribe = cells.observe(() => {
+				callCount++;
+			});
+
+			cells.setCell('row-1', 'title', 'Hello');
+			expect(callCount).toBe(1);
+
+			unsubscribe();
+
+			cells.setCell('row-1', 'title', 'World');
+			expect(callCount).toBe(1); // Still 1, no new call
+		});
+	});
+
+	describe('Iteration', () => {
+		test('cells() yields all cells with parsed components', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			cells.setCell('row-1', 'title', 'Hello');
+			cells.setCell('row-1', 'views', '42');
+			cells.setCell('row-2', 'title', 'World');
+
+			const result = Array.from(cells.cells());
+
+			expect(result).toHaveLength(3);
+			expect(result).toContainEqual({
+				rowId: 'row-1',
+				columnId: 'title',
+				value: 'Hello',
+			});
+			expect(result).toContainEqual({
+				rowId: 'row-1',
+				columnId: 'views',
+				value: '42',
+			});
+			expect(result).toContainEqual({
+				rowId: 'row-2',
+				columnId: 'title',
+				value: 'World',
+			});
+		});
+
+		test('cells() returns empty iterator for empty store', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			const result = Array.from(cells.cells());
+			expect(result).toEqual([]);
+		});
+
+		test('cells() correctly parses columnId with colon', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			cells.setCell('row-1', 'nested:column:id', 'value');
+
+			const result = Array.from(cells.cells());
+			expect(result).toEqual([
+				{ rowId: 'row-1', columnId: 'nested:column:id', value: 'value' },
+			]);
+		});
+	});
+
+	describe('Count', () => {
+		test('count returns 0 for empty store', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			expect(cells.count()).toBe(0);
+		});
+
+		test('count returns correct number after adds', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			cells.setCell('row-1', 'a', '1');
+			cells.setCell('row-1', 'b', '2');
+			cells.setCell('row-2', 'a', '3');
+
+			expect(cells.count()).toBe(3);
+		});
+
+		test('count decreases after delete', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			cells.setCell('row-1', 'a', '1');
+			cells.setCell('row-1', 'b', '2');
+			cells.deleteCell('row-1', 'a');
+
+			expect(cells.count()).toBe(1);
+		});
+
+		test('count unchanged when updating existing cell', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			cells.setCell('row-1', 'a', '1');
+			cells.setCell('row-1', 'a', '2');
+
+			expect(cells.count()).toBe(1);
+		});
+	});
+
+	describe('Clear', () => {
+		test('clear removes all cells', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			cells.setCell('row-1', 'a', '1');
+			cells.setCell('row-1', 'b', '2');
+			cells.setCell('row-2', 'a', '3');
+
+			cells.clear();
+
+			expect(cells.count()).toBe(0);
+			expect(cells.hasCell('row-1', 'a')).toBe(false);
+			expect(cells.hasCell('row-1', 'b')).toBe(false);
+			expect(cells.hasCell('row-2', 'a')).toBe(false);
+		});
+
+		test('clear on empty store is no-op', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			cells.clear();
+			expect(cells.count()).toBe(0);
+		});
+
+		test('clear fires single observer notification', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			cells.setCell('row-1', 'a', '1');
+			cells.setCell('row-1', 'b', '2');
+
+			let callCount = 0;
+			cells.observe(() => {
+				callCount++;
+			});
+
+			cells.clear();
+
+			expect(callCount).toBe(1);
+		});
+	});
+
+	describe('Escape Hatch', () => {
+		test('ykv property is accessible', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			expect(cells.ykv).toBeDefined();
+			expect(cells.ykv.map).toBeInstanceOf(Map);
+		});
+
+		test('doc property is accessible', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			expect(cells.doc).toBe(ydoc);
+		});
+
+		test('can use ykv directly for advanced operations', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+
+			cells.setCell('row-1', 'title', 'Hello');
+
+			// Direct access to underlying map
+			expect(cells.ykv.map.size).toBe(1);
+			expect(cells.ykv.has('row-1:title')).toBe(true);
+		});
+	});
+
+	describe('CRDT Sync', () => {
+		test('changes sync between documents', () => {
+			const doc1 = new Y.Doc({ guid: 'shared' });
+			const doc2 = new Y.Doc({ guid: 'shared' });
+
+			const cells1 = createCellStore<string>(doc1, 'cells');
+			const cells2 = createCellStore<string>(doc2, 'cells');
+
+			cells1.setCell('row-1', 'title', 'Hello');
+
+			// Sync doc1 to doc2
+			Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1));
+
+			expect(cells2.getCell('row-1', 'title')).toBe('Hello');
+		});
+
+		test('concurrent edits to different cells merge correctly', () => {
+			const doc1 = new Y.Doc({ guid: 'shared' });
+			const doc2 = new Y.Doc({ guid: 'shared' });
+
+			const cells1 = createCellStore<string>(doc1, 'cells');
+			const cells2 = createCellStore<string>(doc2, 'cells');
+
+			// Both edit different cells offline
+			cells1.setCell('row-1', 'title', 'From doc1');
+			cells2.setCell('row-1', 'views', 'From doc2');
+
+			// Sync both directions
+			Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1));
+			Y.applyUpdate(doc1, Y.encodeStateAsUpdate(doc2));
+
+			// Both cells exist in both docs
+			expect(cells1.getCell('row-1', 'title')).toBe('From doc1');
+			expect(cells1.getCell('row-1', 'views')).toBe('From doc2');
+			expect(cells2.getCell('row-1', 'title')).toBe('From doc1');
+			expect(cells2.getCell('row-1', 'views')).toBe('From doc2');
+		});
+
+		test('concurrent edits to same cell use LWW resolution', () => {
+			const doc1 = new Y.Doc({ guid: 'shared' });
+			const doc2 = new Y.Doc({ guid: 'shared' });
+
+			const cells1 = createCellStore<string>(doc1, 'cells');
+			const cells2 = createCellStore<string>(doc2, 'cells');
+
+			// Both edit same cell offline
+			cells1.setCell('row-1', 'title', 'From doc1');
+			// Small delay to ensure different timestamps
+			cells2.setCell('row-1', 'title', 'From doc2');
+
+			// Sync both directions
+			Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1));
+			Y.applyUpdate(doc1, Y.encodeStateAsUpdate(doc2));
+
+			// Both should have same value (LWW winner)
+			expect(cells1.getCell('row-1', 'title')).toBe(
+				cells2.getCell('row-1', 'title'),
+			);
+		});
+	});
+});

--- a/packages/epicenter/src/shared/y-cell-store.ts
+++ b/packages/epicenter/src/shared/y-cell-store.ts
@@ -169,7 +169,10 @@ function parseCellKey(key: string): { rowId: string; columnId: string } {
  * @param ydoc - The Y.Doc to store data in
  * @param arrayKey - The key name for the Y.Array (e.g., 'table:posts')
  */
-export function createCellStore<T>(ydoc: Y.Doc, arrayKey: string): CellStore<T> {
+export function createCellStore<T>(
+	ydoc: Y.Doc,
+	arrayKey: string,
+): CellStore<T> {
 	const yarray = ydoc.getArray<YKeyValueLwwEntry<T>>(arrayKey);
 	const ykv = new YKeyValueLww<T>(yarray);
 
@@ -198,8 +201,7 @@ export function createCellStore<T>(ydoc: Y.Doc, arrayKey: string): CellStore<T> 
 				fn({
 					setCell: (rowId, columnId, value) =>
 						ykv.set(cellKey(rowId, columnId), value),
-					deleteCell: (rowId, columnId) =>
-						ykv.delete(cellKey(rowId, columnId)),
+					deleteCell: (rowId, columnId) => ykv.delete(cellKey(rowId, columnId)),
 				});
 			});
 		},

--- a/packages/epicenter/src/shared/y-cell-store.ts
+++ b/packages/epicenter/src/shared/y-cell-store.ts
@@ -1,0 +1,274 @@
+/**
+ * # YCellStore - Schema-agnostic Sparse Grid Storage
+ *
+ * A pure cell primitive that stores cells with compound keys `rowId:columnId`.
+ * Built on top of YKeyValueLww for CRDT conflict resolution.
+ *
+ * ## Key Format
+ *
+ * - Cell key: `rowId:columnId`
+ * - `rowId` MUST NOT contain `:` (throws error)
+ * - `columnId` MAY contain `:` (separator is first occurrence only)
+ *
+ * ## Design Principles
+ *
+ * - Schema decoupled: No validation, pure storage primitive
+ * - Single responsibility: Only handles cell operations
+ * - Escape hatches: Exposes `ykv` and `doc` for advanced use
+ *
+ * @example
+ * ```typescript
+ * import { createCellStore } from './y-cell-store.js';
+ *
+ * const cells = createCellStore<unknown>(ydoc, 'table:posts');
+ *
+ * cells.setCell('row-1', 'title', 'Hello');
+ * cells.setCell('row-1', 'views', 42);
+ * cells.getCell('row-1', 'title'); // 'Hello'
+ *
+ * // Batch operations (atomic, single observer notification)
+ * cells.batch((tx) => {
+ *   tx.setCell('row-1', 'title', 'Updated');
+ *   tx.setCell('row-2', 'title', 'New Row');
+ *   tx.deleteCell('row-1', 'views');
+ * });
+ * ```
+ */
+import type * as Y from 'yjs';
+import {
+	YKeyValueLww,
+	type YKeyValueLwwChange,
+	type YKeyValueLwwEntry,
+} from './y-keyvalue/y-keyvalue-lww.js';
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TYPES
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** A single cell's location and value. */
+export type Cell<T> = {
+	rowId: string;
+	columnId: string;
+	value: T;
+};
+
+/** Change event for a single cell. */
+export type CellChange<T> =
+	| { action: 'add'; rowId: string; columnId: string; value: T }
+	| {
+			action: 'update';
+			rowId: string;
+			columnId: string;
+			oldValue: T;
+			value: T;
+	  }
+	| { action: 'delete'; rowId: string; columnId: string; oldValue: T };
+
+/** Handler for cell change events. */
+export type CellChangeHandler<T> = (
+	changes: CellChange<T>[],
+	transaction: Y.Transaction,
+) => void;
+
+/** Operations available inside a batch transaction. */
+export type CellStoreBatchTransaction<T> = {
+	setCell(rowId: string, columnId: string, value: T): void;
+	deleteCell(rowId: string, columnId: string): void;
+};
+
+/** Pure cell-level storage primitive. */
+export type CellStore<T> = {
+	// ═══════════════════════════════════════════════════════════════════════
+	// CELL CRUD
+	// ═══════════════════════════════════════════════════════════════════════
+
+	/** Set a single cell value. */
+	setCell(rowId: string, columnId: string, value: T): void;
+
+	/** Get a single cell value. Returns undefined if not found. */
+	getCell(rowId: string, columnId: string): T | undefined;
+
+	/** Check if a cell exists. */
+	hasCell(rowId: string, columnId: string): boolean;
+
+	/** Delete a single cell. Returns true if existed. */
+	deleteCell(rowId: string, columnId: string): boolean;
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// BATCH
+	// ═══════════════════════════════════════════════════════════════════════
+
+	/**
+	 * Execute multiple operations atomically in a Y.js transaction.
+	 * - Single undo/redo step
+	 * - Observers fire once (not per-operation)
+	 * - All changes applied together
+	 */
+	batch(fn: (tx: CellStoreBatchTransaction<T>) => void): void;
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// ITERATION & METADATA
+	// ═══════════════════════════════════════════════════════════════════════
+
+	/** Iterate all cells with parsed components. */
+	cells(): IterableIterator<Cell<T>>;
+
+	/** Total number of cells. */
+	count(): number;
+
+	/** Delete all cells. */
+	clear(): void;
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// OBSERVE
+	// ═══════════════════════════════════════════════════════════════════════
+
+	/** Watch for cell changes. Returns unsubscribe function. */
+	observe(handler: CellChangeHandler<T>): () => void;
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// ESCAPE HATCH
+	// ═══════════════════════════════════════════════════════════════════════
+
+	/** The underlying YKeyValueLww for advanced use cases. */
+	readonly ykv: YKeyValueLww<T>;
+
+	/** The Y.Doc for transaction control. */
+	readonly doc: Y.Doc;
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// KEY UTILITIES (Private)
+// ═══════════════════════════════════════════════════════════════════════════
+
+const SEPARATOR = ':';
+
+function cellKey(rowId: string, columnId: string): string {
+	if (rowId.includes(SEPARATOR)) {
+		throw new Error(`rowId cannot contain '${SEPARATOR}': "${rowId}"`);
+	}
+	return `${rowId}${SEPARATOR}${columnId}`;
+}
+
+function parseCellKey(key: string): { rowId: string; columnId: string } {
+	const idx = key.indexOf(SEPARATOR);
+	if (idx === -1) throw new Error(`Invalid cell key: "${key}"`);
+	return {
+		rowId: key.slice(0, idx),
+		columnId: key.slice(idx + 1),
+	};
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// FACTORY FUNCTION
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Create a schema-agnostic cell store backed by YKeyValueLww.
+ *
+ * @param ydoc - The Y.Doc to store data in
+ * @param arrayKey - The key name for the Y.Array (e.g., 'table:posts')
+ */
+export function createCellStore<T>(ydoc: Y.Doc, arrayKey: string): CellStore<T> {
+	const yarray = ydoc.getArray<YKeyValueLwwEntry<T>>(arrayKey);
+	const ykv = new YKeyValueLww<T>(yarray);
+
+	return {
+		setCell(rowId, columnId, value) {
+			ykv.set(cellKey(rowId, columnId), value);
+		},
+
+		getCell(rowId, columnId) {
+			return ykv.get(cellKey(rowId, columnId));
+		},
+
+		hasCell(rowId, columnId) {
+			return ykv.has(cellKey(rowId, columnId));
+		},
+
+		deleteCell(rowId, columnId) {
+			const key = cellKey(rowId, columnId);
+			if (!ykv.has(key)) return false;
+			ykv.delete(key);
+			return true;
+		},
+
+		batch(fn) {
+			ydoc.transact(() => {
+				fn({
+					setCell: (rowId, columnId, value) =>
+						ykv.set(cellKey(rowId, columnId), value),
+					deleteCell: (rowId, columnId) =>
+						ykv.delete(cellKey(rowId, columnId)),
+				});
+			});
+		},
+
+		*cells() {
+			for (const [key, entry] of ykv.entries()) {
+				const { rowId, columnId } = parseCellKey(key);
+				yield { rowId, columnId, value: entry.val };
+			}
+		},
+
+		count() {
+			return ykv.map.size;
+		},
+
+		clear() {
+			const keys = Array.from(ykv.map.keys());
+			ydoc.transact(() => {
+				for (const key of keys) {
+					ykv.delete(key);
+				}
+			});
+		},
+
+		observe(handler) {
+			const ykvHandler = (
+				changes: Map<string, YKeyValueLwwChange<T>>,
+				transaction: Y.Transaction,
+			) => {
+				const cellChanges: CellChange<T>[] = [];
+
+				for (const [key, change] of changes) {
+					const { rowId, columnId } = parseCellKey(key);
+
+					if (change.action === 'add') {
+						cellChanges.push({
+							action: 'add',
+							rowId,
+							columnId,
+							value: change.newValue,
+						});
+					} else if (change.action === 'update') {
+						cellChanges.push({
+							action: 'update',
+							rowId,
+							columnId,
+							oldValue: change.oldValue,
+							value: change.newValue,
+						});
+					} else if (change.action === 'delete') {
+						cellChanges.push({
+							action: 'delete',
+							rowId,
+							columnId,
+							oldValue: change.oldValue,
+						});
+					}
+				}
+
+				if (cellChanges.length > 0) {
+					handler(cellChanges, transaction);
+				}
+			};
+
+			ykv.observe(ykvHandler);
+			return () => ykv.unobserve(ykvHandler);
+		},
+
+		ykv,
+		doc: ydoc,
+	};
+}

--- a/packages/epicenter/src/shared/y-row-store.test.ts
+++ b/packages/epicenter/src/shared/y-row-store.test.ts
@@ -1,0 +1,502 @@
+/**
+ * YRowStore Tests - Row Operations Wrapper over CellStore
+ *
+ * Tests cover:
+ * 1. Row reconstruction: get() assembles cells correctly
+ * 2. Row existence: has() returns true only if cells exist
+ * 3. Row IDs: ids() returns deduplicated list
+ * 4. Get all rows: getAll() reconstructs all rows
+ * 5. Row count: count() matches unique row count
+ * 6. Row deletion: delete() removes all cells for row
+ * 7. Observe dedupe: observe() fires with Set of changed row IDs
+ * 8. Underlying access: cells property gives CellStore
+ * 9. Empty row: get() returns undefined, has() returns false
+ * 10. Sparse rows: rows with different columns work correctly
+ */
+import { describe, expect, test } from 'bun:test';
+import * as Y from 'yjs';
+import { createCellStore } from './y-cell-store';
+import { createRowStore } from './y-row-store';
+
+describe('YRowStore', () => {
+	describe('Row Reconstruction', () => {
+		test('get() assembles cells into a row object', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<unknown>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			cells.batch((tx) => {
+				tx.setCell('row-1', 'title', 'Hello');
+				tx.setCell('row-1', 'views', 42);
+				tx.setCell('row-1', 'published', true);
+			});
+
+			const row = rows.get('row-1');
+			expect(row).toEqual({
+				title: 'Hello',
+				views: 42,
+				published: true,
+			});
+		});
+
+		test('get() returns undefined for non-existent row', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			expect(rows.get('non-existent')).toBeUndefined();
+		});
+
+		test('get() returns undefined after row is deleted', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			cells.setCell('row-1', 'title', 'Hello');
+			rows.delete('row-1');
+
+			expect(rows.get('row-1')).toBeUndefined();
+		});
+	});
+
+	describe('Row Existence', () => {
+		test('has() returns true when row has cells', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			cells.setCell('row-1', 'title', 'Hello');
+			expect(rows.has('row-1')).toBe(true);
+		});
+
+		test('has() returns false for non-existent row', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			expect(rows.has('non-existent')).toBe(false);
+		});
+
+		test('has() returns false after row is deleted', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			cells.setCell('row-1', 'title', 'Hello');
+			rows.delete('row-1');
+
+			expect(rows.has('row-1')).toBe(false);
+		});
+
+		test('has() early-exits on first cell found', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			// Add many cells for row-1
+			cells.batch((tx) => {
+				for (let i = 0; i < 100; i++) {
+					tx.setCell('row-1', `col-${i}`, `value-${i}`);
+				}
+			});
+
+			// has() should find the first cell and return true without scanning all
+			expect(rows.has('row-1')).toBe(true);
+		});
+
+		test('has() does not false-match on rowId prefix substring', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			// "ab" exists, but "a" does not - they are distinct rows
+			cells.setCell('ab', 'title', 'Hello');
+
+			expect(rows.has('ab')).toBe(true);
+			expect(rows.has('a')).toBe(false); // "a" is prefix of "ab" but not a match
+		});
+
+		test('get() does not include cells from prefix-matching rows', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			cells.setCell('a', 'col1', 'value-a');
+			cells.setCell('ab', 'col1', 'value-ab');
+
+			expect(rows.get('a')).toEqual({ col1: 'value-a' });
+			expect(rows.get('ab')).toEqual({ col1: 'value-ab' });
+
+			// Deleting 'a' should NOT affect 'ab'
+			rows.delete('a');
+			expect(rows.has('a')).toBe(false);
+			expect(rows.has('ab')).toBe(true);
+			expect(rows.get('ab')).toEqual({ col1: 'value-ab' });
+		});
+	});
+
+	describe('Row IDs', () => {
+		test('ids() returns all unique row IDs', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			cells.batch((tx) => {
+				tx.setCell('row-1', 'title', 'Hello');
+				tx.setCell('row-2', 'title', 'World');
+				tx.setCell('row-3', 'title', 'Test');
+			});
+
+			const ids = rows.ids();
+			expect(ids.sort()).toEqual(['row-1', 'row-2', 'row-3']);
+		});
+
+		test('ids() returns deduplicated list', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			// Multiple cells for same row
+			cells.batch((tx) => {
+				tx.setCell('row-1', 'a', '1');
+				tx.setCell('row-1', 'b', '2');
+				tx.setCell('row-1', 'c', '3');
+			});
+
+			const ids = rows.ids();
+			expect(ids).toEqual(['row-1']);
+		});
+
+		test('ids() returns empty array for empty store', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			expect(rows.ids()).toEqual([]);
+		});
+	});
+
+	describe('Get All Rows', () => {
+		test('getAll() reconstructs all rows', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<unknown>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			cells.batch((tx) => {
+				tx.setCell('row-1', 'title', 'First');
+				tx.setCell('row-1', 'views', 10);
+				tx.setCell('row-2', 'title', 'Second');
+				tx.setCell('row-2', 'views', 20);
+			});
+
+			const allRows = rows.getAll();
+
+			expect(allRows.size).toBe(2);
+			expect(allRows.get('row-1')).toEqual({ title: 'First', views: 10 });
+			expect(allRows.get('row-2')).toEqual({ title: 'Second', views: 20 });
+		});
+
+		test('getAll() returns empty Map for empty store', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			expect(rows.getAll().size).toBe(0);
+		});
+	});
+
+	describe('Row Count', () => {
+		test('count() returns number of unique rows', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			cells.batch((tx) => {
+				tx.setCell('row-1', 'a', '1');
+				tx.setCell('row-1', 'b', '2');
+				tx.setCell('row-2', 'a', '3');
+				tx.setCell('row-3', 'a', '4');
+			});
+
+			expect(rows.count()).toBe(3);
+		});
+
+		test('count() returns 0 for empty store', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			expect(rows.count()).toBe(0);
+		});
+
+		test('count() decreases after row deletion', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			cells.batch((tx) => {
+				tx.setCell('row-1', 'title', 'First');
+				tx.setCell('row-2', 'title', 'Second');
+			});
+
+			expect(rows.count()).toBe(2);
+
+			rows.delete('row-1');
+
+			expect(rows.count()).toBe(1);
+		});
+	});
+
+	describe('Row Deletion', () => {
+		test('delete() removes all cells for a row', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			cells.batch((tx) => {
+				tx.setCell('row-1', 'title', 'Hello');
+				tx.setCell('row-1', 'views', '42');
+				tx.setCell('row-1', 'published', 'true');
+			});
+
+			const result = rows.delete('row-1');
+
+			expect(result).toBe(true);
+			expect(rows.has('row-1')).toBe(false);
+			expect(cells.hasCell('row-1', 'title')).toBe(false);
+			expect(cells.hasCell('row-1', 'views')).toBe(false);
+			expect(cells.hasCell('row-1', 'published')).toBe(false);
+		});
+
+		test('delete() returns false for non-existent row', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			const result = rows.delete('non-existent');
+			expect(result).toBe(false);
+		});
+
+		test('delete() does not affect other rows', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			cells.batch((tx) => {
+				tx.setCell('row-1', 'title', 'First');
+				tx.setCell('row-2', 'title', 'Second');
+			});
+
+			rows.delete('row-1');
+
+			expect(rows.has('row-1')).toBe(false);
+			expect(rows.has('row-2')).toBe(true);
+			expect(rows.get('row-2')).toEqual({ title: 'Second' });
+		});
+
+		test('delete() fires single observer notification', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			cells.batch((tx) => {
+				tx.setCell('row-1', 'a', '1');
+				tx.setCell('row-1', 'b', '2');
+				tx.setCell('row-1', 'c', '3');
+			});
+
+			let callCount = 0;
+			rows.observe(() => {
+				callCount++;
+			});
+
+			rows.delete('row-1');
+
+			expect(callCount).toBe(1);
+		});
+	});
+
+	describe('Observe', () => {
+		test('observe() fires with Set of changed row IDs', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			const changedRows: string[][] = [];
+			rows.observe((rowIds) => {
+				changedRows.push(Array.from(rowIds).sort());
+			});
+
+			cells.batch((tx) => {
+				tx.setCell('row-1', 'a', '1');
+				tx.setCell('row-2', 'b', '2');
+			});
+
+			expect(changedRows).toEqual([['row-1', 'row-2']]);
+		});
+
+		test('observe() deduplicates changes to same row', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			const changedRows: string[][] = [];
+			rows.observe((rowIds) => {
+				changedRows.push(Array.from(rowIds));
+			});
+
+			// Multiple changes to same row
+			cells.batch((tx) => {
+				tx.setCell('row-1', 'a', '1');
+				tx.setCell('row-1', 'b', '2');
+				tx.setCell('row-1', 'c', '3');
+			});
+
+			// Should only have row-1 once
+			expect(changedRows).toEqual([['row-1']]);
+		});
+
+		test('unsubscribe stops receiving events', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			let callCount = 0;
+			const unsubscribe = rows.observe(() => {
+				callCount++;
+			});
+
+			cells.setCell('row-1', 'title', 'Hello');
+			expect(callCount).toBe(1);
+
+			unsubscribe();
+
+			cells.setCell('row-1', 'title', 'World');
+			expect(callCount).toBe(1); // Still 1
+		});
+	});
+
+	describe('Underlying Store Access', () => {
+		test('cells property gives access to CellStore', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			expect(rows.cells).toBe(cells);
+		});
+
+		test('can use cells for writes and rows for reads', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<unknown>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			// Write via cells
+			rows.cells.batch((tx) => {
+				tx.setCell('post-1', 'title', 'Hello World');
+				tx.setCell('post-1', 'views', 0);
+			});
+
+			// Read via rows
+			expect(rows.get('post-1')).toEqual({
+				title: 'Hello World',
+				views: 0,
+			});
+		});
+	});
+
+	describe('Sparse Rows', () => {
+		test('rows can have different columns', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<unknown>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			cells.batch((tx) => {
+				// row-1 has title and views
+				tx.setCell('row-1', 'title', 'First');
+				tx.setCell('row-1', 'views', 10);
+
+				// row-2 has title and author
+				tx.setCell('row-2', 'title', 'Second');
+				tx.setCell('row-2', 'author', 'Alice');
+			});
+
+			expect(rows.get('row-1')).toEqual({ title: 'First', views: 10 });
+			expect(rows.get('row-2')).toEqual({ title: 'Second', author: 'Alice' });
+		});
+
+		test('deleting some cells makes row sparse but still exists', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			cells.batch((tx) => {
+				tx.setCell('row-1', 'title', 'Hello');
+				tx.setCell('row-1', 'views', '42');
+			});
+
+			cells.deleteCell('row-1', 'views');
+
+			expect(rows.has('row-1')).toBe(true);
+			expect(rows.get('row-1')).toEqual({ title: 'Hello' });
+		});
+	});
+
+	describe('Column ID with Colons', () => {
+		test('handles column IDs containing colons', () => {
+			const ydoc = new Y.Doc({ guid: 'test' });
+			const cells = createCellStore<string>(ydoc, 'cells');
+			const rows = createRowStore(cells);
+
+			cells.setCell('row-1', 'nested:column:id', 'value');
+
+			const row = rows.get('row-1');
+			expect(row).toEqual({ 'nested:column:id': 'value' });
+		});
+	});
+
+	describe('CRDT Sync', () => {
+		test('changes sync between documents', () => {
+			const doc1 = new Y.Doc({ guid: 'shared' });
+			const doc2 = new Y.Doc({ guid: 'shared' });
+
+			const cells1 = createCellStore<string>(doc1, 'cells');
+			createRowStore(cells1); // Creates row view but we write via cells
+
+			const cells2 = createCellStore<string>(doc2, 'cells');
+			const rows2 = createRowStore(cells2);
+
+			cells1.batch((tx) => {
+				tx.setCell('row-1', 'title', 'Hello');
+				tx.setCell('row-1', 'views', '42');
+			});
+
+			// Sync doc1 to doc2
+			Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1));
+
+			expect(rows2.get('row-1')).toEqual({ title: 'Hello', views: '42' });
+		});
+
+		test('row deletion syncs', () => {
+			const doc1 = new Y.Doc({ guid: 'shared' });
+			const doc2 = new Y.Doc({ guid: 'shared' });
+
+			const cells1 = createCellStore<string>(doc1, 'cells');
+			const rows1 = createRowStore(cells1);
+
+			const cells2 = createCellStore<string>(doc2, 'cells');
+			const rows2 = createRowStore(cells2);
+
+			// Create row in doc1
+			cells1.setCell('row-1', 'title', 'Hello');
+			Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1));
+
+			expect(rows2.has('row-1')).toBe(true);
+
+			// Delete row in doc1
+			rows1.delete('row-1');
+			Y.applyUpdate(doc2, Y.encodeStateAsUpdate(doc1));
+
+			expect(rows2.has('row-1')).toBe(false);
+		});
+	});
+});

--- a/packages/epicenter/src/shared/y-row-store.ts
+++ b/packages/epicenter/src/shared/y-row-store.ts
@@ -1,0 +1,218 @@
+/**
+ * # YRowStore - Row Operations Wrapper over CellStore
+ *
+ * Provides row reconstruction, row deletion, and row-level observation.
+ * Does NOT store anything itself - delegates to the underlying CellStore.
+ *
+ * ## Design Principles
+ *
+ * - Composition over features: Takes a CellStore as its only argument
+ * - No setRow(): Write semantics are ambiguous (merge vs replace), use cells.batch()
+ * - Row operations use prefix scanning on the underlying ykv.map
+ *
+ * @example
+ * ```typescript
+ * import { createCellStore } from './y-cell-store.js';
+ * import { createRowStore } from './y-row-store.js';
+ *
+ * const cells = createCellStore<unknown>(ydoc, 'table:posts');
+ * const rows = createRowStore(cells);
+ *
+ * // Write via cells (cell-level granularity)
+ * cells.batch((tx) => {
+ *   tx.setCell('post-1', 'title', 'Hello World');
+ *   tx.setCell('post-1', 'views', 0);
+ * });
+ *
+ * // Read via rows (reconstructed)
+ * const post = rows.get('post-1');
+ * // { title: 'Hello World', views: 0 }
+ *
+ * // Delete entire row
+ * rows.delete('post-1');
+ * ```
+ */
+import type * as Y from 'yjs';
+import type { CellStore } from './y-cell-store.js';
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TYPES
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** Handler for row-level change notifications (deduplicated from cells). */
+export type RowsChangedHandler = (
+	changedRowIds: Set<string>,
+	transaction: Y.Transaction,
+) => void;
+
+/** Row operations wrapper over CellStore. */
+export type RowStore<T> = {
+	// ═══════════════════════════════════════════════════════════════════════
+	// ROW READ
+	// ═══════════════════════════════════════════════════════════════════════
+
+	/**
+	 * Reconstruct a row from its cells.
+	 * Returns undefined if no cells exist for this row.
+	 * O(n) where n = total cells in store.
+	 */
+	get(rowId: string): Record<string, T> | undefined;
+
+	/** Check if any cells exist for a row. O(n) worst case, early-exits. */
+	has(rowId: string): boolean;
+
+	/** Get all row IDs that have at least one cell. O(n) with deduplication. */
+	ids(): string[];
+
+	/** Get all rows reconstructed from cells. O(n) single pass. */
+	getAll(): Map<string, Record<string, T>>;
+
+	/** Number of unique rows. */
+	count(): number;
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// ROW DELETE
+	// ═══════════════════════════════════════════════════════════════════════
+
+	/**
+	 * Delete all cells for a row.
+	 * Returns true if any cells existed.
+	 * O(n) scan + k deletions where k = cells in row.
+	 */
+	delete(rowId: string): boolean;
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// OBSERVE
+	// ═══════════════════════════════════════════════════════════════════════
+
+	/**
+	 * Watch for row-level changes (deduplicated from cell changes).
+	 * Callback receives Set of row IDs that had any cell change.
+	 * Returns unsubscribe function.
+	 */
+	observe(handler: RowsChangedHandler): () => void;
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// UNDERLYING STORE
+	// ═══════════════════════════════════════════════════════════════════════
+
+	/** The underlying CellStore for cell-level operations. */
+	readonly cells: CellStore<T>;
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ROW UTILITIES (Private)
+// ═══════════════════════════════════════════════════════════════════════════
+
+const SEPARATOR = ':';
+
+function rowPrefix(rowId: string): string {
+	return `${rowId}${SEPARATOR}`;
+}
+
+function extractRowId(key: string): string {
+	const idx = key.indexOf(SEPARATOR);
+	return key.slice(0, idx);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// FACTORY FUNCTION
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Create a row operations wrapper over an existing CellStore.
+ *
+ * @param cellStore - The CellStore to wrap
+ */
+export function createRowStore<T>(cellStore: CellStore<T>): RowStore<T> {
+	const { ykv, doc } = cellStore;
+
+	return {
+		get(rowId) {
+			const prefix = rowPrefix(rowId);
+			const cells: Record<string, T> = {};
+			let found = false;
+
+			for (const [key, entry] of ykv.map) {
+				if (key.startsWith(prefix)) {
+					const columnId = key.slice(prefix.length);
+					cells[columnId] = entry.val;
+					found = true;
+				}
+			}
+
+			return found ? cells : undefined;
+		},
+
+		has(rowId) {
+			const prefix = rowPrefix(rowId);
+			for (const key of ykv.map.keys()) {
+				if (key.startsWith(prefix)) return true;
+			}
+			return false;
+		},
+
+		ids() {
+			const seen = new Set<string>();
+			for (const key of ykv.map.keys()) {
+				seen.add(extractRowId(key));
+			}
+			return Array.from(seen);
+		},
+
+		getAll() {
+			const rows = new Map<string, Record<string, T>>();
+
+			for (const [key, entry] of ykv.map) {
+				const rowId = extractRowId(key);
+				const columnId = key.slice(rowId.length + 1); // +1 for separator
+
+				const existing = rows.get(rowId) ?? {};
+				existing[columnId] = entry.val;
+				rows.set(rowId, existing);
+			}
+
+			return rows;
+		},
+
+		count() {
+			const seen = new Set<string>();
+			for (const key of ykv.map.keys()) {
+				seen.add(extractRowId(key));
+			}
+			return seen.size;
+		},
+
+		delete(rowId) {
+			const prefix = rowPrefix(rowId);
+			const keysToDelete: string[] = [];
+
+			for (const key of ykv.map.keys()) {
+				if (key.startsWith(prefix)) {
+					keysToDelete.push(key);
+				}
+			}
+
+			if (keysToDelete.length === 0) return false;
+
+			doc.transact(() => {
+				for (const key of keysToDelete) {
+					ykv.delete(key);
+				}
+			});
+
+			return true;
+		},
+
+		observe(handler) {
+			return cellStore.observe((changes, transaction) => {
+				const rowIds = new Set(changes.map((c) => c.rowId));
+				if (rowIds.size > 0) {
+					handler(rowIds, transaction);
+				}
+			});
+		},
+
+		cells: cellStore,
+	};
+}

--- a/specs/y-meta-stores.md
+++ b/specs/y-meta-stores.md
@@ -1,0 +1,817 @@
+# YKeyValue Meta Data Structures
+
+Intermediate storage abstractions between `YKeyValueLww` and higher-level APIs.
+
+## Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      Higher-Level APIs                          │
+│  ┌──────────────────────┐    ┌──────────────────────────────┐  │
+│  │  static/TableHelper  │    │   dynamic/TableHelper        │  │
+│  │  (schema validation, │    │  (schema validation,         │  │
+│  │   versioned rows)    │    │   field types, Notion-like)  │  │
+│  └──────────┬───────────┘    └────────────┬─────────────────┘  │
+└─────────────┼────────────────────────────┼──────────────────────┘
+              │                            │
+┌─────────────┼────────────────────────────┼──────────────────────┐
+│             │                            │                      │
+│             │              ┌─────────────┴─────────────┐        │
+│             │              │        YRowStore          │  NEW   │
+│             │              │   (wrapper over cells)    │  LAYER │
+│             │              │   Adds row operations     │        │
+│             │              └─────────────┬─────────────┘        │
+│             │                            │                      │
+│             │                            ▼                      │
+│             │              ┌─────────────────────────┐          │
+│             │              │       YCellStore        │   NEW    │
+│             │              │   (pure cell primitive) │   LAYER  │
+│             │              │   Schema-free storage   │          │
+│             │              └─────────────┬───────────┘          │
+│             │                            │                      │
+│             ▼                            ▼                      │
+│       ┌──────────────────────────────────────┐                  │
+│       │           YKeyValueLww               │                  │
+│       │     (Low-level CRDT primitive)       │                  │
+│       └──────────────────────────────────────┘                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Three Storage Patterns
+
+| Pattern | Storage Model | Use Case |
+|---------|---------------|----------|
+| **Direct YKeyValueLww** | Whole rows keyed by ID | `static/TableHelper` - fixed schemas, replace entire row |
+| **YCellStore** | Individual cells keyed by `rowId:columnId` | Cell-level granularity, concurrent field edits |
+| **YRowStore** | Wrapper over YCellStore | `dynamic/TableHelper` - row operations on cell storage |
+
+### When to Use Each
+
+- **Direct YKeyValueLww**: When you have a fixed schema and always write complete rows. Simpler, less overhead.
+- **YCellStore + YRowStore**: When you need cell-level conflict resolution (User A edits `title`, User B edits `views` → both merge).
+
+---
+
+## Design Principles
+
+### 1. Schema Decoupled
+
+Neither store does validation. They're pure storage primitives. Schema validation belongs in higher-level APIs (TableHelper).
+
+### 2. Single Responsibility
+
+- `YCellStore` - ONLY cells
+- `YRowStore` - ONLY row operations (wraps cells)
+- `TableHelper` - schema validation and business logic
+
+### 3. Composition Over Features
+
+`YRowStore` takes a `YCellStore` as its only argument. No duplicate storage, just a different view.
+
+### 4. No Bulk APIs
+
+No `setMany`, `deleteMany`, `updateMany`. Instead, a single `.batch()` method provides a type-safe transaction callback.
+
+### 5. Factory Functions
+
+Follow codebase pattern. Return plain objects, not classes.
+
+### 6. Escape Hatches
+
+Expose underlying primitives for advanced use cases.
+
+---
+
+## File Locations
+
+```
+packages/epicenter/src/shared/
+├── y-keyvalue/
+│   ├── y-keyvalue-lww.ts      # Existing - low-level CRDT
+│   └── y-keyvalue.ts          # Existing - simpler variant
+├── y-cell-store.ts            # NEW - pure cell primitive
+├── y-cell-store.test.ts       # NEW
+├── y-row-store.ts             # NEW - wrapper over CellStore
+└── y-row-store.test.ts        # NEW
+```
+
+---
+
+# YCellStore Specification
+
+**File:** `packages/epicenter/src/shared/y-cell-store.ts`
+
+**Purpose:** Schema-agnostic sparse grid storage. Cells stored with compound keys `rowId:columnId`. Pure cell primitive - no row operations.
+
+## Key Format
+
+```typescript
+const SEPARATOR = ':' as const;
+
+// Cell key: "rowId:columnId"
+// rowId MUST NOT contain ':'
+// columnId MAY contain ':' (separator is first occurrence only)
+```
+
+## Types
+
+```typescript
+import type * as Y from 'yjs';
+import type { YKeyValueLww } from './y-keyvalue/y-keyvalue-lww.js';
+
+/** A single cell's location and value. */
+export type Cell<T> = {
+  rowId: string;
+  columnId: string;
+  value: T;
+};
+
+/** Change event for a single cell. */
+export type CellChange<T> =
+  | { action: 'add'; rowId: string; columnId: string; value: T }
+  | { action: 'update'; rowId: string; columnId: string; oldValue: T; value: T }
+  | { action: 'delete'; rowId: string; columnId: string; oldValue: T };
+
+/** Handler for cell change events. */
+export type CellChangeHandler<T> = (
+  changes: CellChange<T>[],
+  transaction: Y.Transaction,
+) => void;
+
+/** Operations available inside a batch transaction. */
+export type CellStoreBatchTransaction<T> = {
+  setCell(rowId: string, columnId: string, value: T): void;
+  deleteCell(rowId: string, columnId: string): void;
+};
+
+/** Pure cell-level storage primitive. */
+export type CellStore<T> = {
+  // ═══════════════════════════════════════════════════════════════════
+  // CELL CRUD
+  // ═══════════════════════════════════════════════════════════════════
+
+  /** Set a single cell value. */
+  setCell(rowId: string, columnId: string, value: T): void;
+
+  /** Get a single cell value. Returns undefined if not found. */
+  getCell(rowId: string, columnId: string): T | undefined;
+
+  /** Check if a cell exists. */
+  hasCell(rowId: string, columnId: string): boolean;
+
+  /** Delete a single cell. Returns true if existed. */
+  deleteCell(rowId: string, columnId: string): boolean;
+
+  // ═══════════════════════════════════════════════════════════════════
+  // BATCH
+  // ═══════════════════════════════════════════════════════════════════
+
+  /**
+   * Execute multiple operations atomically in a Y.js transaction.
+   * - Single undo/redo step
+   * - Observers fire once (not per-operation)
+   * - All changes applied together
+   */
+  batch(fn: (tx: CellStoreBatchTransaction<T>) => void): void;
+
+  // ═══════════════════════════════════════════════════════════════════
+  // ITERATION & METADATA
+  // ═══════════════════════════════════════════════════════════════════
+
+  /** Iterate all cells with parsed components. */
+  cells(): IterableIterator<Cell<T>>;
+
+  /** Total number of cells. */
+  count(): number;
+
+  /** Delete all cells. */
+  clear(): void;
+
+  // ═══════════════════════════════════════════════════════════════════
+  // OBSERVE
+  // ═══════════════════════════════════════════════════════════════════
+
+  /** Watch for cell changes. Returns unsubscribe function. */
+  observe(handler: CellChangeHandler<T>): () => void;
+
+  // ═══════════════════════════════════════════════════════════════════
+  // ESCAPE HATCH
+  // ═══════════════════════════════════════════════════════════════════
+
+  /** The underlying YKeyValueLww for advanced use cases. */
+  readonly ykv: YKeyValueLww<T>;
+
+  /** The Y.Doc for transaction control. */
+  readonly doc: Y.Doc;
+};
+```
+
+## Factory Function
+
+```typescript
+/**
+ * Create a schema-agnostic cell store backed by YKeyValueLww.
+ *
+ * @param ydoc - The Y.Doc to store data in
+ * @param arrayKey - The key name for the Y.Array (e.g., 'table:posts')
+ */
+export function createCellStore<T>(
+  ydoc: Y.Doc,
+  arrayKey: string,
+): CellStore<T>;
+```
+
+## Implementation Notes
+
+### 1. Key Utilities (Private)
+
+```typescript
+const SEPARATOR = ':';
+
+function cellKey(rowId: string, columnId: string): string {
+  if (rowId.includes(SEPARATOR)) {
+    throw new Error(`rowId cannot contain '${SEPARATOR}': "${rowId}"`);
+  }
+  return `${rowId}${SEPARATOR}${columnId}`;
+}
+
+function parseCellKey(key: string): { rowId: string; columnId: string } {
+  const idx = key.indexOf(SEPARATOR);
+  if (idx === -1) throw new Error(`Invalid cell key: "${key}"`);
+  return {
+    rowId: key.slice(0, idx),
+    columnId: key.slice(idx + 1),
+  };
+}
+```
+
+### 2. Constructor Creates YKeyValueLww Internally
+
+```typescript
+export function createCellStore<T>(ydoc: Y.Doc, arrayKey: string): CellStore<T> {
+  const yarray = ydoc.getArray<YKeyValueLwwEntry<T>>(arrayKey);
+  const ykv = new YKeyValueLww<T>(yarray);
+
+  return {
+    setCell(rowId, columnId, value) {
+      ykv.set(cellKey(rowId, columnId), value);
+    },
+
+    getCell(rowId, columnId) {
+      return ykv.get(cellKey(rowId, columnId));
+    },
+
+    hasCell(rowId, columnId) {
+      return ykv.has(cellKey(rowId, columnId));
+    },
+
+    deleteCell(rowId, columnId) {
+      const key = cellKey(rowId, columnId);
+      if (!ykv.has(key)) return false;
+      ykv.delete(key);
+      return true;
+    },
+
+    batch(fn) {
+      ydoc.transact(() => {
+        fn({
+          setCell: (rowId, columnId, value) => ykv.set(cellKey(rowId, columnId), value),
+          deleteCell: (rowId, columnId) => ykv.delete(cellKey(rowId, columnId)),
+        });
+      });
+    },
+
+    *cells() {
+      for (const [key, entry] of ykv.entries()) {
+        const { rowId, columnId } = parseCellKey(key);
+        yield { rowId, columnId, value: entry.val };
+      }
+    },
+
+    count() {
+      return ykv.map.size;
+    },
+
+    clear() {
+      const keys = Array.from(ykv.map.keys());
+      ydoc.transact(() => {
+        for (const key of keys) {
+          ykv.delete(key);
+        }
+      });
+    },
+
+    observe(handler) {
+      const ykvHandler = (changes: Map<string, YKeyValueLwwChange<T>>, transaction: Y.Transaction) => {
+        const cellChanges: CellChange<T>[] = [];
+
+        for (const [key, change] of changes) {
+          const { rowId, columnId } = parseCellKey(key);
+
+          if (change.action === 'add') {
+            cellChanges.push({ action: 'add', rowId, columnId, value: change.newValue });
+          } else if (change.action === 'update') {
+            cellChanges.push({ action: 'update', rowId, columnId, oldValue: change.oldValue, value: change.newValue });
+          } else if (change.action === 'delete') {
+            cellChanges.push({ action: 'delete', rowId, columnId, oldValue: change.oldValue });
+          }
+        }
+
+        if (cellChanges.length > 0) {
+          handler(cellChanges, transaction);
+        }
+      };
+
+      ykv.observe(ykvHandler);
+      return () => ykv.unobserve(ykvHandler);
+    },
+
+    ykv,
+    doc: ydoc,
+  };
+}
+```
+
+---
+
+# YRowStore Specification
+
+**File:** `packages/epicenter/src/shared/y-row-store.ts`
+
+**Purpose:** Row operations wrapper over `CellStore`. Provides row reconstruction, row deletion, and row-level observation. Does NOT store anything itself - delegates to the underlying `CellStore`.
+
+## Types
+
+```typescript
+import type * as Y from 'yjs';
+import type { CellStore } from './y-cell-store.js';
+
+/** Handler for row-level change notifications (deduplicated from cells). */
+export type RowsChangedHandler = (
+  changedRowIds: Set<string>,
+  transaction: Y.Transaction,
+) => void;
+
+/** Row operations wrapper over CellStore. */
+export type RowStore<T> = {
+  // ═══════════════════════════════════════════════════════════════════
+  // ROW READ
+  // ═══════════════════════════════════════════════════════════════════
+
+  /**
+   * Reconstruct a row from its cells.
+   * Returns undefined if no cells exist for this row.
+   * O(n) where n = total cells in store.
+   */
+  get(rowId: string): Record<string, T> | undefined;
+
+  /** Check if any cells exist for a row. O(n) worst case, early-exits. */
+  has(rowId: string): boolean;
+
+  /** Get all row IDs that have at least one cell. O(n) with deduplication. */
+  ids(): string[];
+
+  /** Get all rows reconstructed from cells. O(n) single pass. */
+  getAll(): Map<string, Record<string, T>>;
+
+  /** Number of unique rows. */
+  count(): number;
+
+  // ═══════════════════════════════════════════════════════════════════
+  // ROW DELETE
+  // ═══════════════════════════════════════════════════════════════════
+
+  /**
+   * Delete all cells for a row.
+   * Returns true if any cells existed.
+   * O(n) scan + k deletions where k = cells in row.
+   */
+  delete(rowId: string): boolean;
+
+  // ═══════════════════════════════════════════════════════════════════
+  // OBSERVE
+  // ═══════════════════════════════════════════════════════════════════
+
+  /**
+   * Watch for row-level changes (deduplicated from cell changes).
+   * Callback receives Set of row IDs that had any cell change.
+   * Returns unsubscribe function.
+   */
+  observe(handler: RowsChangedHandler): () => void;
+
+  // ═══════════════════════════════════════════════════════════════════
+  // UNDERLYING STORE
+  // ═══════════════════════════════════════════════════════════════════
+
+  /** The underlying CellStore for cell-level operations. */
+  readonly cells: CellStore<T>;
+};
+```
+
+## Factory Function
+
+```typescript
+/**
+ * Create a row operations wrapper over an existing CellStore.
+ *
+ * @param cellStore - The CellStore to wrap
+ */
+export function createRowStore<T>(cellStore: CellStore<T>): RowStore<T>;
+```
+
+## Implementation Notes
+
+### 1. Row Prefix Utility (Private)
+
+```typescript
+const SEPARATOR = ':';
+
+function rowPrefix(rowId: string): string {
+  return `${rowId}${SEPARATOR}`;
+}
+
+function extractRowId(key: string): string {
+  const idx = key.indexOf(SEPARATOR);
+  return key.slice(0, idx);
+}
+```
+
+### 2. Full Implementation
+
+```typescript
+export function createRowStore<T>(cellStore: CellStore<T>): RowStore<T> {
+  const { ykv, doc } = cellStore;
+
+  return {
+    get(rowId) {
+      const prefix = rowPrefix(rowId);
+      const cells: Record<string, T> = {};
+      let found = false;
+
+      for (const [key, entry] of ykv.map) {
+        if (key.startsWith(prefix)) {
+          const columnId = key.slice(prefix.length);
+          cells[columnId] = entry.val;
+          found = true;
+        }
+      }
+
+      return found ? cells : undefined;
+    },
+
+    has(rowId) {
+      const prefix = rowPrefix(rowId);
+      for (const key of ykv.map.keys()) {
+        if (key.startsWith(prefix)) return true;
+      }
+      return false;
+    },
+
+    ids() {
+      const seen = new Set<string>();
+      for (const key of ykv.map.keys()) {
+        seen.add(extractRowId(key));
+      }
+      return Array.from(seen);
+    },
+
+    getAll() {
+      const rows = new Map<string, Record<string, T>>();
+
+      for (const [key, entry] of ykv.map) {
+        const rowId = extractRowId(key);
+        const columnId = key.slice(rowId.length + 1); // +1 for separator
+
+        const existing = rows.get(rowId) ?? {};
+        existing[columnId] = entry.val;
+        rows.set(rowId, existing);
+      }
+
+      return rows;
+    },
+
+    count() {
+      const seen = new Set<string>();
+      for (const key of ykv.map.keys()) {
+        seen.add(extractRowId(key));
+      }
+      return seen.size;
+    },
+
+    delete(rowId) {
+      const prefix = rowPrefix(rowId);
+      const keysToDelete: string[] = [];
+
+      for (const key of ykv.map.keys()) {
+        if (key.startsWith(prefix)) {
+          keysToDelete.push(key);
+        }
+      }
+
+      if (keysToDelete.length === 0) return false;
+
+      doc.transact(() => {
+        for (const key of keysToDelete) {
+          ykv.delete(key);
+        }
+      });
+
+      return true;
+    },
+
+    observe(handler) {
+      return cellStore.observe((changes, transaction) => {
+        const rowIds = new Set(changes.map(c => c.rowId));
+        if (rowIds.size > 0) {
+          handler(rowIds, transaction);
+        }
+      });
+    },
+
+    cells: cellStore,
+  };
+}
+```
+
+---
+
+# Usage Examples
+
+## Cell-Level Operations (YCellStore Only)
+
+```typescript
+import { createCellStore } from '../shared/y-cell-store.js';
+
+const cells = createCellStore<unknown>(ydoc, 'table:posts');
+
+// Single cell operations
+cells.setCell('row-1', 'title', 'Hello');
+cells.setCell('row-1', 'views', 42);
+cells.getCell('row-1', 'title'); // 'Hello'
+
+// Batch operations (atomic, single observer notification)
+cells.batch((tx) => {
+  tx.setCell('row-1', 'title', 'Updated');
+  tx.setCell('row-2', 'title', 'New Row');
+  tx.deleteCell('row-1', 'views');
+});
+
+// Observe cell changes
+const unsubscribe = cells.observe((changes, transaction) => {
+  for (const change of changes) {
+    console.log(change.action, change.rowId, change.columnId);
+  }
+});
+
+// Iterate all cells
+for (const { rowId, columnId, value } of cells.cells()) {
+  console.log(`${rowId}.${columnId} = ${value}`);
+}
+```
+
+## Row-Level Operations (YCellStore + YRowStore)
+
+```typescript
+import { createCellStore } from '../shared/y-cell-store.js';
+import { createRowStore } from '../shared/y-row-store.js';
+
+// Create both stores
+const cells = createCellStore<unknown>(ydoc, 'table:posts');
+const rows = createRowStore(cells);
+
+// Write via cells (cell-level granularity)
+cells.batch((tx) => {
+  tx.setCell('post-1', 'title', 'Hello World');
+  tx.setCell('post-1', 'views', 0);
+  tx.setCell('post-1', 'published', false);
+});
+
+// Read via rows (reconstructed)
+const post = rows.get('post-1');
+// { title: 'Hello World', views: 0, published: false }
+
+// Row existence check
+rows.has('post-1'); // true
+rows.has('post-999'); // false
+
+// All row IDs
+rows.ids(); // ['post-1']
+
+// Delete entire row (all cells)
+rows.delete('post-1'); // true
+
+// Observe at row level (deduplicated)
+const unsubscribe = rows.observe((changedRowIds, transaction) => {
+  for (const rowId of changedRowIds) {
+    const row = rows.get(rowId);
+    console.log('Changed:', rowId, row);
+  }
+});
+```
+
+## Static Pattern (Direct YKeyValueLww)
+
+The `static/TableHelper` continues to use `YKeyValueLww` directly for whole-row storage:
+
+```typescript
+// In packages/epicenter/src/static/table-helper.ts
+
+import { YKeyValueLww } from '../shared/y-keyvalue/y-keyvalue-lww.js';
+
+export function createTableHelper(ykv: YKeyValueLww<unknown>, definition) {
+  return {
+    set(row) {
+      ykv.set(row.id, row);  // Whole row, single key
+    },
+
+    get(id) {
+      const raw = ykv.get(id);  // Whole row returned
+      return parseRow(id, raw);
+    },
+
+    // ... validation, migration, etc.
+  };
+}
+```
+
+## Dynamic Pattern (YCellStore + YRowStore)
+
+```typescript
+// In packages/epicenter/src/dynamic/tables/table-helper.ts
+
+import { createCellStore } from '../../shared/y-cell-store.js';
+import { createRowStore } from '../../shared/y-row-store.js';
+
+export function createTableHelper({ ydoc, tableDefinition }) {
+  const cells = createCellStore<unknown>(ydoc, TableKey(tableDefinition.id));
+  const rows = createRowStore(cells);
+
+  return {
+    upsert(row) {
+      cells.batch((tx) => {
+        for (const [columnId, value] of Object.entries(row)) {
+          tx.setCell(row.id, columnId, value);
+        }
+      });
+    },
+
+    update(partialRow) {
+      if (!rows.has(partialRow.id)) {
+        return { status: 'not_found_locally' };
+      }
+      cells.batch((tx) => {
+        for (const [columnId, value] of Object.entries(partialRow)) {
+          tx.setCell(partialRow.id, columnId, value);
+        }
+      });
+      return { status: 'applied' };
+    },
+
+    get(id) {
+      const raw = rows.get(id);
+      if (!raw) return { status: 'not_found', id, row: undefined };
+      return validateRow(id, raw);
+    },
+
+    delete(id) {
+      return rows.delete(id)
+        ? { status: 'deleted' }
+        : { status: 'not_found_locally' };
+    },
+
+    observe(callback) {
+      return rows.observe(callback);
+    },
+
+    // Access underlying stores for advanced use
+    cells,
+    rows,
+  };
+}
+```
+
+---
+
+# Testing Requirements
+
+## y-cell-store.test.ts
+
+1. **Cell CRUD**: `setCell`, `getCell`, `hasCell`, `deleteCell`
+2. **Key validation**: `rowId` with `:` throws error
+3. **Batch operations**: multiple cell operations atomically
+4. **Observer fires once per batch**: not per operation
+5. **Change types**: `add`, `update`, `delete` events with correct `rowId`/`columnId`
+6. **Iteration**: `cells()` yields all cells with parsed components
+7. **Count accuracy**: after various operations
+8. **Clear**: removes all cells
+9. **Escape hatch**: `ykv` and `doc` accessible
+
+## y-row-store.test.ts
+
+1. **Row reconstruction**: `get()` assembles cells correctly
+2. **Row existence**: `has()` returns true only if cells exist
+3. **Row IDs**: `ids()` returns deduplicated list
+4. **Get all rows**: `getAll()` reconstructs all rows
+5. **Row count**: `count()` matches unique row count
+6. **Row deletion**: `delete()` removes all cells for row
+7. **Observe dedupe**: `observe()` fires with Set of changed row IDs
+8. **Underlying access**: `cells` property gives CellStore
+9. **Empty row**: `get()` returns undefined, `has()` returns false
+10. **Sparse rows**: rows with different columns work correctly
+
+---
+
+# Implementation Checklist
+
+- [ ] Create `packages/epicenter/src/shared/y-cell-store.ts`
+- [ ] Create `packages/epicenter/src/shared/y-cell-store.test.ts`
+- [ ] Create `packages/epicenter/src/shared/y-row-store.ts`
+- [ ] Create `packages/epicenter/src/shared/y-row-store.test.ts`
+- [ ] Run tests: `bun test y-cell-store && bun test y-row-store`
+- [ ] Export from index (if needed)
+- [ ] Update `dynamic/tables/table-helper.ts` to use new stores (future task)
+
+---
+
+# Design Decisions
+
+## Why No `setRow()` on YRowStore?
+
+The semantics are ambiguous:
+- Should it **merge** with existing cells? (What about columns not in the new row?)
+- Should it **replace** all cells? (Delete first, then set?)
+
+Explicit is better. Use `cells.batch()` for writes:
+
+```typescript
+// REPLACE row (delete old, add new)
+rows.delete(id);
+cells.batch((tx) => {
+  for (const [col, val] of Object.entries(newRow)) {
+    tx.setCell(id, col, val);
+  }
+});
+
+// MERGE row (only update specified cells)
+cells.batch((tx) => {
+  for (const [col, val] of Object.entries(partialRow)) {
+    tx.setCell(id, col, val);
+  }
+});
+```
+
+## Why Separate YCellStore and YRowStore?
+
+1. **Single responsibility**: CellStore handles cells, RowStore handles row patterns
+2. **Composition**: RowStore wraps CellStore, no duplicate storage
+3. **Flexibility**: Use CellStore alone for pure cell operations
+4. **Testing**: Each layer testable in isolation
+
+## Why Does Static Use YKeyValueLww Directly?
+
+For fixed schemas where you always write complete rows, cell-level storage adds unnecessary overhead:
+- More keys to manage
+- Row reconstruction on every read
+- No benefit if concurrent field edits aren't needed
+
+Direct `YKeyValueLww` with whole rows is simpler and faster for this use case.
+
+## Why Three Observer Layers?
+
+The observer API has three distinct levels with progressive information reduction:
+
+```
+YKeyValueLww.observe()  →  Map<"rowId:columnId", Change>  (full details)
+       ↓ transforms
+CellStore.observe()     →  CellChange[] with rowId, columnId, action, values
+       ↓ deduplicates
+RowStore.observe()      →  Set<string> of affected row IDs only
+```
+
+**This layered design:**
+
+1. **Lets consumers subscribe at the appropriate granularity**
+   - Need to highlight specific cells? Use `cellStore.observe()`
+   - Just need to invalidate rows? Use `rowStore.observe()`
+
+2. **Keeps each layer testable in isolation**
+   - CellStore tests don't need row semantics
+   - RowStore tests don't need cell-level assertions
+
+3. **Follows the escape hatch principle**
+   - `rowStore.cells` gives access to CellStore
+   - `cellStore.ykv` gives access to YKeyValueLww
+   - Advanced consumers can subscribe to multiple layers simultaneously
+
+4. **Matches Yjs conventions**
+   - Single observer fire per transaction (batched)
+   - Unsubscribe function returned
+   - Transaction object passed for origin checking
+
+**When to use each:**
+
+| Layer | Observer Returns | Use When |
+|-------|------------------|----------|
+| `ykv.observe()` | `Map<key, Change>` | Building custom abstractions, need raw CRDT access |
+| `cellStore.observe()` | `CellChange[]` | Need exact cell coordinates, action type, old/new values |
+| `rowStore.observe()` | `Set<rowId>` | Just need to know which rows changed (invalidation, re-render)


### PR DESCRIPTION
The existing `YKeyValueLww` stores whole rows keyed by ID, which works great for static schemas. But for Notion-like dynamic tables, concurrent edits to different fields of the same row should merge cleanly. If User A edits `title` while User B edits `views`, we want both changes preserved—not a last-write-wins at the row level.

This PR adds two intermediate storage abstractions that sit between `YKeyValueLww` and higher-level table APIs, enabling cell-level conflict resolution.

```
┌─────────────────────────────────────────────────────────────────┐
│                      Higher-Level APIs                          │
│  ┌──────────────────────┐    ┌──────────────────────────────┐  │
│  │  static/TableHelper  │    │   dynamic/TableHelper        │  │
│  │  (whole-row storage) │    │  (cell-level storage)        │  │
│  └──────────┬───────────┘    └────────────┬─────────────────┘  │
└─────────────┼────────────────────────────┼──────────────────────┘
              │                            │
              │              ┌─────────────┴─────────────┐  NEW
              │              │        YRowStore          │  ────
              │              │   (wrapper over cells)    │
              │              └─────────────┬─────────────┘
              │                            │
              │              ┌─────────────┴───────────┐  NEW
              │              │       YCellStore        │  ────
              │              │  (sparse grid storage)  │
              │              └─────────────┬───────────┘
              │                            │
              ▼                            ▼
        ┌──────────────────────────────────────┐
        │           YKeyValueLww               │
        │     (Low-level CRDT primitive)       │
        └──────────────────────────────────────┘
```

## API

**YCellStore** — schema-agnostic sparse grid with compound keys `rowId:columnId`:

```typescript
const cells = createCellStore<unknown>(ydoc, 'table:posts');

// Individual cell operations
cells.setCell('row-1', 'title', 'Hello');
cells.setCell('row-1', 'views', 42);
cells.getCell('row-1', 'title'); // 'Hello'

// Batch operations (atomic, single observer notification, single undo step)
cells.batch((tx) => {
  tx.setCell('row-1', 'title', 'Updated');
  tx.setCell('row-2', 'title', 'New Row');
  tx.deleteCell('row-1', 'views');
});

// Observe cell changes with full details
cells.observe((changes, transaction) => {
  // changes: CellChange[] with { action, rowId, columnId, value, oldValue }
});
```

**YRowStore** — row operations wrapper over CellStore:

```typescript
const rows = createRowStore(cells);

// Reconstruct row from its cells
const post = rows.get('post-1');
// { title: 'Hello World', views: 0 }

// Row-level operations
rows.has('post-1');  // true
rows.ids();          // ['post-1', 'post-2']
rows.delete('post-1'); // deletes all cells for this row

// Observe at row level (deduplicated from cells)
rows.observe((changedRowIds, transaction) => {
  // changedRowIds: Set<string> of affected row IDs
});
```

Note: YRowStore intentionally has **no `setRow()`** because the semantics are ambiguous (merge vs replace). Use `cells.batch()` for writes—explicit is better.

## Observer API Design

Each layer adds semantic meaning; consumers subscribe at appropriate granularity:

```
YKeyValueLww.observe()  →  Map<"rowId:columnId", Change>  (raw CRDT)
       ↓ transforms
CellStore.observe()     →  CellChange[] with rowId, columnId, action, values
       ↓ deduplicates
RowStore.observe()      →  Set<string> of affected row IDs only
```

## Verification

- 37 tests for YCellStore covering CRUD, batching, key validation, observer behavior
- 31 tests for YRowStore covering row reconstruction, deletion, deduped observation
- Prefix edge cases tested (e.g., row "a" vs "ab" don't collide due to separator)