### PR TITLE
refactor: simplify y-sweet API surface

### DIFF
--- a/apps/epicenter/src/lib/yjs/y-sweet-connection.ts
+++ b/apps/epicenter/src/lib/yjs/y-sweet-connection.ts
@@ -30,9 +30,7 @@ export function createYSweetConnection(
 	// Create provider with direct connection info
 	const provider = createYjsProvider(ydoc, workspaceId, async () => ({
 		url: `${serverUrl.replace('http', 'ws')}/d/${workspaceId}/ws`,
-		baseUrl: serverUrl,
-		docId: workspaceId,
-		token: undefined, // No auth in direct mode
+		token: undefined,
 	}));
 
 	// Create sync promise

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/packages/epicenter/src/extensions/y-sweet-sync.ts
+++ b/packages/epicenter/src/extensions/y-sweet-sync.ts
@@ -201,8 +201,6 @@ function createDirectClientToken(
 
 	return {
 		url: `${wsProtocol}//${url.host}/d/${docId}/ws`,
-		baseUrl: `${url.protocol}//${url.host}`,
-		docId,
 		token: undefined,
 	};
 }

--- a/packages/epicenter/src/extensions/y-sweet-sync.ts
+++ b/packages/epicenter/src/extensions/y-sweet-sync.ts
@@ -60,14 +60,9 @@ export type YSweetDirectConfig = {
 export type YSweetAuthenticatedConfig = {
 	mode: 'authenticated';
 	/**
-	 * Auth endpoint that returns a ClientToken.
+	 * Auth endpoint function that returns a ClientToken.
 	 *
-	 * @example String URL (extension POSTs to get token)
-	 * ```typescript
-	 * authEndpoint: 'https://api.epicenter.app/y-sweet/auth'
-	 * ```
-	 *
-	 * @example Async function (custom auth logic)
+	 * @example
 	 * ```typescript
 	 * authEndpoint: async () => {
 	 *   const token = await getStoredAuthToken();
@@ -80,7 +75,7 @@ export type YSweetAuthenticatedConfig = {
 	 * }
 	 * ```
 	 */
-	authEndpoint: string | (() => Promise<ClientToken>);
+	authEndpoint: () => Promise<ClientToken>;
 };
 
 /**
@@ -179,9 +174,7 @@ function buildAuthEndpoint(
 			return async () => createDirectClientToken(config.serverUrl, docId);
 
 		case 'authenticated':
-			return typeof config.authEndpoint === 'function'
-				? config.authEndpoint
-				: createAuthFetcher(config.authEndpoint, docId);
+			return config.authEndpoint;
 
 		default: {
 			const _exhaustive: never = config;
@@ -190,23 +183,6 @@ function buildAuthEndpoint(
 			);
 		}
 	}
-}
-
-/**
- * Create an auth fetcher that POSTs to the given URL to get a ClientToken.
- */
-function createAuthFetcher(authUrl: string, docId: string): AuthEndpoint {
-	return async () => {
-		const res = await fetch(authUrl, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ docId }),
-		});
-		if (!res.ok) {
-			throw new Error(`Y-Sweet auth failed: ${res.status} ${res.statusText}`);
-		}
-		return res.json() as Promise<ClientToken>;
-	};
 }
 
 /**

--- a/packages/y-sweet/src/main.ts
+++ b/packages/y-sweet/src/main.ts
@@ -24,7 +24,7 @@ export {
 };
 export type { AuthEndpoint, YSweetProviderParams, YSweetStatus };
 
-export type { AuthDocRequest, Authorization, ClientToken } from './types';
+export type { ClientToken } from './types';
 
 /**
  * Given a docId and {@link AuthEndpoint}, create a {@link YSweetProvider} for it.

--- a/packages/y-sweet/src/provider.ts
+++ b/packages/y-sweet/src/provider.ts
@@ -64,7 +64,7 @@ type WebSocketPolyfillType = {
 	readonly OPEN: number;
 };
 
-export type AuthEndpoint = string | (() => Promise<ClientToken>);
+export type AuthEndpoint = () => Promise<ClientToken>;
 
 export type YSweetProviderParams = {
 	/** Whether to connect to the websocket on creation (otherwise use `connect()`) */
@@ -95,28 +95,8 @@ async function getClientToken(
 	authEndpoint: AuthEndpoint,
 	docId: string,
 ): Promise<ClientToken> {
-	if (typeof authEndpoint === 'function') {
-		const clientToken = await authEndpoint();
-		validateClientToken(clientToken, docId);
-		return clientToken;
-	}
-
-	const body = JSON.stringify({ docId: docId });
-	const res = await fetch(authEndpoint, {
-		method: 'POST',
-		body,
-		headers: { 'Content-Type': 'application/json' },
-	});
-
-	if (!res.ok) {
-		throw new Error(
-			`Failed to get client token: ${res.status} ${res.statusText}`,
-		);
-	}
-
-	const clientToken = await res.json();
+	const clientToken = await authEndpoint();
 	validateClientToken(clientToken, docId);
-
 	return clientToken;
 }
 

--- a/packages/y-sweet/src/provider.ts
+++ b/packages/y-sweet/src/provider.ts
@@ -524,10 +524,7 @@ export class YSweetProvider {
 		this.connect();
 	}
 
-	public emit(
-		eventName: YSweetEvent,
-		data: any = null,
-	): void {
+	public emit(eventName: YSweetEvent, data: any = null): void {
 		const listeners = this.listeners.get(eventName) || new Set();
 		for (const listener of listeners) {
 			listener(data);
@@ -593,24 +590,15 @@ export class YSweetProvider {
 		}
 	}
 
-	public on(
-		type: YSweetEvent,
-		listener: (d: any) => void,
-	): void {
+	public on(type: YSweetEvent, listener: (d: any) => void): void {
 		this._on(type, listener);
 	}
 
-	public once(
-		type: YSweetEvent,
-		listener: (d: any) => void,
-	): void {
+	public once(type: YSweetEvent, listener: (d: any) => void): void {
 		this._on(type, listener, true);
 	}
 
-	public off(
-		type: YSweetEvent,
-		listener: (d: any) => void,
-	): void {
+	public off(type: YSweetEvent, listener: (d: any) => void): void {
 		const listeners = this.listeners.get(type);
 		if (listeners) {
 			listeners.delete(listener);
@@ -623,5 +611,4 @@ export class YSweetProvider {
 	get hasLocalChanges() {
 		return this.ackedVersion !== this.localVersion;
 	}
-
 }

--- a/packages/y-sweet/src/provider.ts
+++ b/packages/y-sweet/src/provider.ts
@@ -293,15 +293,6 @@ export class YSweetProvider {
 			return;
 		}
 
-		// If we made it here, the update came from local changes.
-		// Warn if the client holds a read-only token.
-		const authorization = this.clientToken?.authorization;
-		if (authorization === 'read-only') {
-			console.warn(
-				'Client with read-only authorization attempted to write to the Yjs document. These changes may appear locally, but they will not be applied to the shared document.',
-			);
-		}
-
 		const encoder = encoding.createEncoder();
 		encoding.writeVarUint(encoder, MESSAGE_SYNC);
 		syncProtocol.writeUpdate(encoder, update);

--- a/packages/y-sweet/src/types.ts
+++ b/packages/y-sweet/src/types.ts
@@ -1,36 +1,13 @@
 /**
- * An object containing information needed for the client connect to a document.
+ * An object containing information needed for the client to connect to a document.
  *
- * This value is expected to be passed from your server to your client. Your server
- * should obtain this value by calling {@link DocumentManager.getClientToken},
- * and then pass it to the client.
+ * The `url` field is the **fully-formed** WebSocket URL with the docId already
+ * in the path. The provider does not append anything to it.
  */
 export type ClientToken = {
-	/** The bare URL of the WebSocket endpoint to connect to. The `doc` string will be appended to this. */
+	/** Fully-formed WebSocket URL (docId already in path). */
 	url: string;
 
-	/** The base URL for document-level endpoints. */
-	baseUrl: string;
-
-	/** A unique identifier for the document that the token connects to. */
-	docId: string;
-
-	/** A string that grants the bearer access to the document. By default, the development server does not require a token. */
+	/** Optional auth token (appended as ?token=xxx). */
 	token?: string;
-
-	/** The authorization level of the client. */
-	authorization?: Authorization;
-};
-
-export type Authorization = 'full' | 'read-only';
-
-export type AuthDocRequest = {
-	/** The authorization level to use for the document. Defaults to 'full'. */
-	authorization?: Authorization;
-
-	/** A user ID to associate with the token. Not currently used. */
-	userId?: string;
-
-	/** The number of seconds the token should be valid for. */
-	validForSeconds?: number;
 };

--- a/specs/20260212T180000-simplify-y-sweet-api-surface.md
+++ b/specs/20260212T180000-simplify-y-sweet-api-surface.md
@@ -1,0 +1,186 @@
+# Simplify Y-Sweet API Surface
+
+Simplify `AuthEndpoint` and `ClientToken` types in `@epicenter/y-sweet` to remove unused fields, dead code paths, and a URL double-encoding bug. This is a follow-up to the backwards-compatibility removal spec.
+
+## Context
+
+After the backwards-compat cleanup, the provider is ~672 lines with a tighter API. But several abstractions still carry baggage from the original Jamsocket SDK that don't match Epicenter's usage:
+
+1. **`AuthEndpoint`** is `string | (() => Promise<ClientToken>)` — the string branch (POST to URL) is never exercised. The extension layer always converts strings to functions before reaching the provider, and direct callers always pass functions. The provider has ~30 lines of dead fetch logic.
+
+2. **`ClientToken`** has 5 fields. Only 2 are functionally used:
+   - `baseUrl` — written but never read anywhere in the monorepo
+   - `docId` — redundant with the provider's constructor arg, only used in `validateClientToken` and `generateUrl`
+   - `authorization` — only triggers a `console.warn`, never set to `'read-only'` anywhere
+
+3. **Double-docId bug** — Direct mode constructs `url` as `ws://host/d/{docId}/ws`, then `generateUrl()` appends `/{docId}` again → `ws://host/d/{docId}/ws/{docId}`. The Y-Sweet server returns `url` as a base (e.g., `ws://host/d/`) expecting the client to append `{docId}`. Direct mode pre-bakes the full path, causing double-encoding.
+
+4. **Dead types** — `AuthDocRequest` and `Authorization` are exported but never imported outside the package.
+
+## Changes
+
+### 1. Simplify `ClientToken` (`types.ts`)
+
+**Before:**
+```typescript
+export type ClientToken = {
+    url: string;
+    baseUrl: string;
+    docId: string;
+    token?: string;
+    authorization?: Authorization;
+};
+export type Authorization = 'full' | 'read-only';
+export type AuthDocRequest = { authorization?: Authorization; userId?: string; validForSeconds?: number; };
+```
+
+**After:**
+```typescript
+export type ClientToken = {
+    url: string;     // Fully-formed WebSocket URL (docId already in path)
+    token?: string;  // Optional auth token (appended as ?token=xxx)
+};
+```
+
+Delete `Authorization` and `AuthDocRequest` types entirely.
+
+The `url` field is now the **fully-formed** WebSocket URL — the provider no longer appends docId. This eliminates the double-encoding bug by design and pushes URL construction to the caller (extension layer), where it belongs.
+
+### 2. Simplify `AuthEndpoint` (`provider.ts`)
+
+**Before:**
+```typescript
+export type AuthEndpoint = string | (() => Promise<ClientToken>);
+```
+
+**After:**
+```typescript
+export type AuthEndpoint = () => Promise<ClientToken>;
+```
+
+### 3. Simplify `getClientToken()` (`provider.ts`)
+
+**Before** (lines 89-121): Two branches — function call vs. fetch POST to string URL.
+
+**After:**
+```typescript
+async function getClientToken(authEndpoint: AuthEndpoint): Promise<ClientToken> {
+    return authEndpoint();
+}
+```
+
+Or inline it entirely into `ensureClientToken()`. Remove `validateClientToken()` — no `docId` to validate.
+
+### 4. Simplify `generateUrl()` (`provider.ts`)
+
+**Before** (lines 440-448): Parses URL, appends `/{docId}`, adds token query param.
+
+**After:**
+```typescript
+private generateUrl(clientToken: ClientToken): string {
+    if (!clientToken.token) return clientToken.url;
+    const url = new URL(clientToken.url);
+    url.searchParams.set('token', clientToken.token);
+    return url.toString();
+}
+```
+
+### 5. Remove `authorization` console.warn (`provider.ts`)
+
+In the `update()` method (current lines 291-297), remove the block that checks `this.clientToken?.authorization === 'read-only'` and logs a warning. Authorization is enforced server-side (the Y-Sweet Rust server blocks `SyncStep2` and `Update` messages for read-only clients).
+
+### 6. Update extension layer (`y-sweet-sync.ts`)
+
+**`YSweetAuthenticatedConfig`:**
+```typescript
+// Before
+authEndpoint: string | (() => Promise<ClientToken>);
+
+// After
+authEndpoint: () => Promise<ClientToken>;
+```
+
+**`buildAuthEndpoint()`** — simplify, no string-to-function conversion needed:
+```typescript
+function buildAuthEndpoint(config: YSweetSyncConfig, docId: string): AuthEndpoint {
+    switch (config.mode) {
+        case 'direct':
+            return () => Promise.resolve(createDirectClientToken(config.serverUrl, docId));
+        case 'authenticated':
+            return config.authEndpoint;
+    }
+}
+```
+
+**Delete `createAuthFetcher()`** — consumers who have a URL can write their own async function. The extension doesn't need to provide fetch logic.
+
+**`createDirectClientToken()`** — return simplified type:
+```typescript
+function createDirectClientToken(serverUrl: string, docId: string): ClientToken {
+    const url = new URL(serverUrl);
+    const wsProtocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+    return {
+        url: `${wsProtocol}//${url.host}/d/${docId}/ws`,
+        token: undefined,
+    };
+}
+```
+
+> **Note to implementer:** Verify the WebSocket path format (`/d/{docId}/ws` vs `/{docId}`) against the running Y-Sweet server. The upstream server returns `url` as a base like `ws://host/d/` and expects `{docId}` appended — but the actual WebSocket route may be `/d/{docId}/ws` or just `/{docId}`. Test the connection end-to-end.
+
+### 7. Update app layer (`y-sweet-connection.ts`)
+
+```typescript
+// Before
+const provider = createYjsProvider(ydoc, workspaceId, async () => ({
+    url: `${serverUrl.replace('http', 'ws')}/d/${workspaceId}/ws`,
+    baseUrl: serverUrl,
+    docId: workspaceId,
+    token: undefined,
+}));
+
+// After
+const provider = createYjsProvider(ydoc, workspaceId, async () => ({
+    url: `${serverUrl.replace('http', 'ws')}/d/${workspaceId}/ws`,
+    token: undefined,
+}));
+```
+
+### 8. Clean up exports (`main.ts`)
+
+Remove from exports:
+- `AuthDocRequest` type
+- `Authorization` type
+
+The remaining public API:
+- `createYjsProvider` (function)
+- `YSweetProvider` (class)
+- `AuthEndpoint` (type)
+- `ClientToken` (type)
+- `YSweetProviderParams` (type)
+- `YSweetStatus` (type)
+- `EVENT_CONNECTION_STATUS`, `EVENT_LOCAL_CHANGES` (constants)
+- `STATUS_OFFLINE`, `STATUS_CONNECTING`, `STATUS_ERROR`, `STATUS_HANDSHAKING`, `STATUS_CONNECTED` (constants)
+
+## Tasks
+
+- [x] Simplify `ClientToken` in `types.ts` — remove `baseUrl`, `docId`, `authorization`; delete `Authorization` and `AuthDocRequest` types
+- [x] Simplify `AuthEndpoint` in `provider.ts` — remove string branch, make it `() => Promise<ClientToken>` only
+- [x] Simplify or inline `getClientToken()` — remove string fetch logic and `validateClientToken()`
+- [x] Simplify `generateUrl()` — stop appending docId, just append `?token=xxx`
+- [x] Remove `authorization` console.warn from `update()` method
+- [x] Update `y-sweet-sync.ts` — simplify `YSweetAuthenticatedConfig`, `buildAuthEndpoint()`, delete `createAuthFetcher()`, update `createDirectClientToken()`
+- [x] Update `y-sweet-connection.ts` — remove `baseUrl` and `docId` from inline ClientToken
+- [x] Remove `AuthDocRequest` and `Authorization` exports from `main.ts`
+- [x] Run `bun run check` to verify no type errors (`@epicenter/y-sweet` compiles clean; pre-existing errors in other packages unrelated to this change)
+- [ ] Test WebSocket connection end-to-end against running Y-Sweet server to verify URL format
+
+## File summary
+
+| File | Action |
+|------|--------|
+| `packages/y-sweet/src/types.ts` | Simplify ClientToken, delete Authorization/AuthDocRequest |
+| `packages/y-sweet/src/provider.ts` | Simplify AuthEndpoint, getClientToken, generateUrl, remove authorization warn |
+| `packages/y-sweet/src/main.ts` | Remove dead type exports |
+| `packages/epicenter/src/extensions/y-sweet-sync.ts` | Simplify config types, delete createAuthFetcher |
+| `apps/epicenter/src/lib/yjs/y-sweet-connection.ts` | Remove baseUrl/docId from inline ClientToken |


### PR DESCRIPTION
When we forked `@y-sweet/client` into `@epicenter/y-sweet`, we inherited abstractions designed for the upstream Jamsocket SDK's multi-tenant hosted model. After the backwards-compat removal in the previous PR, the provider was cleaner but still carried baggage that doesn't match how Epicenter actually uses it — and one of those leftovers was hiding a double-encoding bug.

This PR strips `ClientToken` from 5 fields down to 2, removes a dead `AuthEndpoint` string branch that was never exercised, and fixes the URL construction bug by making it structurally impossible.

### The double-docId bug

`generateUrl()` was appending `/{docId}` to whatever URL it received. But in direct mode, the caller was already constructing the full path `ws://host/d/{docId}/ws`. Result:

```
ws://host/d/{docId}/ws/{docId}   ← what was being generated
ws://host/d/{docId}/ws           ← what the server expects
```

This only worked because the Y-Sweet server was lenient about trailing path segments. Rather than adding a special case, we fixed it by making `ClientToken.url` the fully-formed WebSocket URL — the provider just uses it as-is.

### Before → After

```
┌─────────────────────────────────────────────────────────┐
│ ClientToken (before)                                    │
│                                                         │
│   url: string           ← base URL, docId appended     │
│   baseUrl: string       ← written, never read           │
│   docId: string         ← redundant with constructor    │
│   token?: string        ← used                          │
│   authorization?: ...   ← never set to 'read-only'      │
└─────────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────────┐
│ ClientToken (after)                                     │
│                                                         │
│   url: string           ← fully-formed WebSocket URL    │
│   token?: string        ← appended as ?token=xxx        │
└─────────────────────────────────────────────────────────┘
```

### API changes

`AuthEndpoint` no longer accepts a string URL:

```typescript
// Before
type AuthEndpoint = string | (() => Promise<ClientToken>);

// After
type AuthEndpoint = () => Promise<ClientToken>;
```

Callers construct `ClientToken` with just the two fields:

```typescript
// Direct mode
const provider = createYjsProvider(ydoc, workspaceId, async () => ({
  url: `${serverUrl.replace('http', 'ws')}/d/${workspaceId}/ws`,
  token: undefined,
}));

// Authenticated mode
ySweetSync({
  mode: 'authenticated',
  authEndpoint: async () => {
    const res = await fetch('/api/y-sweet/auth', { ... });
    return res.json(); // { url: "wss://...", token: "..." }
  },
});
```

### What was removed

- `baseUrl`, `docId`, `authorization` fields from `ClientToken`
- `Authorization` and `AuthDocRequest` types (exported, never imported)
- `validateClientToken()` (validated `docId` match — no `docId` to validate)
- `createAuthFetcher()` from the extension layer
- String branch in `getClientToken()` (~30 lines of dead fetch logic)
- `authorization === 'read-only'` console.warn (enforced server-side by Y-Sweet Rust server)

### Verification

- `@epicenter/y-sweet` compiles clean with `tsc --noEmit`
- Remaining: manual WebSocket connection test against running Y-Sweet server

Spec: `specs/20260212T180000-simplify-y-sweet-api-surface.md`