### PR TITLE
refactor: replace Sleeper class with createSleeper function

### DIFF
--- a/docs/articles/promise-with-resolvers.md
+++ b/docs/articles/promise-with-resolvers.md
@@ -1,0 +1,38 @@
+# Promise.withResolvers() replaces the most common Promise anti-pattern
+
+Normally when you create a promise, `resolve` and `reject` are trapped inside the constructor callback:
+
+```typescript
+let resolve;
+const promise = new Promise<void>((r) => {
+  resolve = r; // have to "escape" it via an outer variable
+});
+```
+
+This is awkward. You declare a variable, leave it uninitialized, then assign it inside a callback just to use it outside. It's the closure escape hatch pattern, and it's everywhere — cancellable timeouts, deferred results, bridging event-based APIs to async/await.
+
+The pattern is so common it got its own built-in. `Promise.withResolvers<T>()` returns all three pieces as a plain object:
+
+```typescript
+const { promise, resolve, reject } = Promise.withResolvers<void>();
+```
+
+That's it. The `promise` is pending. `resolve(value)` fulfills it. `reject(reason)` rejects it. They're the same `resolve`/`reject` you'd get inside `new Promise((resolve, reject) => ...)`, just handed to you directly without the closure.
+
+## Where this shines
+
+Anywhere you need to resolve a promise from outside the constructor. A cancellable sleep:
+
+```typescript
+function createSleeper(timeout: number) {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  setTimeout(resolve, timeout);
+  return { promise, wake: resolve };
+}
+```
+
+`setTimeout` resolves it after the delay. But `wake` (which is just `resolve`) can resolve it early. Since `resolve` is idempotent — calling it a second time does nothing — both paths are safe. If the timeout fires after `wake()`, it's a no-op.
+
+## One thing to know
+
+`resolve` is idempotent. The first call wins. This matters when you have competing resolution paths (timeout vs manual wake, race conditions, etc.). You don't need guards or flags — just call `resolve` from wherever, and the first one to arrive settles the promise. Every subsequent call is silently ignored.

--- a/packages/y-sweet/src/provider.ts
+++ b/packages/y-sweet/src/provider.ts
@@ -4,7 +4,7 @@ import * as awarenessProtocol from 'y-protocols/awareness';
 import * as syncProtocol from 'y-protocols/sync';
 import * as Y from 'yjs';
 import { createIndexedDBProvider, type IndexedDBProvider } from './indexeddb';
-import { Sleeper } from './sleeper';
+import { createSleeper, type Sleeper } from './sleeper';
 import type { ClientToken } from './types';
 
 const MESSAGE_SYNC = 0;
@@ -342,8 +342,8 @@ export class YSweetProvider {
 						Math.pow(BACKOFF_BASE, this.retries),
 					);
 				this.retries += 1;
-				this.reconnectSleeper = new Sleeper(timeout);
-				await this.reconnectSleeper.sleep();
+				this.reconnectSleeper = createSleeper(timeout);
+				await this.reconnectSleeper.promise;
 				continue;
 			}
 
@@ -360,8 +360,8 @@ export class YSweetProvider {
 						Math.pow(BACKOFF_BASE, this.retries),
 					);
 				this.retries += 1;
-				this.reconnectSleeper = new Sleeper(timeout);
-				await this.reconnectSleeper.sleep();
+				this.reconnectSleeper = createSleeper(timeout);
+				await this.reconnectSleeper.promise;
 			}
 
 			// Delete the current client token to force a token refresh on the next attempt.

--- a/packages/y-sweet/src/sleeper.ts
+++ b/packages/y-sweet/src/sleeper.ts
@@ -1,33 +1,10 @@
 /**
- * A timeout that can be woken up prematurely by calling `wake()`.
+ * A cancellable timeout. Resolves after `timeout` ms, or immediately if `wake()` is called.
  */
-export class Sleeper {
-	resolve?: () => void;
-	reject?: () => void;
-	promise: Promise<void>;
-
-	constructor(timeout: number) {
-		this.promise = new Promise<void>((resolve, reject) => {
-			setTimeout(() => {
-				resolve();
-			}, timeout);
-
-			this.resolve = resolve;
-			this.reject = reject;
-		});
-	}
-
-	/**
-	 * Sleeps until the timeout has completed (or has been woken).
-	 */
-	async sleep() {
-		await this.promise;
-	}
-
-	/**
-	 * Wakes up the timeout if it has not completed yet.
-	 */
-	wake() {
-		this.resolve && this.resolve();
-	}
+export function createSleeper(timeout: number) {
+	const { promise, resolve } = Promise.withResolvers<void>();
+	setTimeout(resolve, timeout);
+	return { promise, wake: resolve };
 }
+
+export type Sleeper = ReturnType<typeof createSleeper>;

--- a/packages/y-sweet/src/sleeper.ts
+++ b/packages/y-sweet/src/sleeper.ts
@@ -1,10 +1,20 @@
 /**
- * A cancellable timeout. Resolves after `timeout` ms, or immediately if `wake()` is called.
+ * Creates a cancellable timeout that resolves after `timeout` ms,
+ * or immediately if {@link Sleeper.wake `wake()`} is called.
+ *
+ * @param timeout - Duration in milliseconds before the promise auto-resolves.
+ * @returns A {@link Sleeper} with a `promise` to await and a `wake` function to resolve early.
  */
 export function createSleeper(timeout: number) {
 	const { promise, resolve } = Promise.withResolvers<void>();
 	setTimeout(resolve, timeout);
-	return { promise, wake: resolve };
+	return {
+		/** Resolves when the timeout expires or `wake()` is called. */
+		promise,
+		/** Resolves the promise immediately, skipping the remaining timeout. */
+		wake: resolve,
+	};
 }
 
+/** A cancellable timeout returned by {@link createSleeper}. */
 export type Sleeper = ReturnType<typeof createSleeper>;

--- a/specs/20260212T200000-simplify-sleeper-to-function.md
+++ b/specs/20260212T200000-simplify-sleeper-to-function.md
@@ -1,0 +1,57 @@
+# Simplify Sleeper Class to Function
+
+## Status: In Progress
+
+## Problem
+
+`packages/y-sweet/src/sleeper.ts` exports a `Sleeper` class that wraps a cancellable timeout. It has three issues:
+
+1. **Dead code**: `reject` is stored but never called anywhere in the codebase.
+2. **Unnecessary wrapper**: `sleep()` method just does `await this.promise` — adds no value.
+3. **Over-abstraction**: A class with constructor + two methods for what is fundamentally `Promise.withResolvers()` + `setTimeout`.
+
+## Current Usage
+
+`provider.ts` uses `Sleeper` in two places for reconnection backoff:
+
+```ts
+// Line 115: stored as nullable property
+private reconnectSleeper: Sleeper | null = null;
+
+// Lines 345-346, 363-364: created and awaited
+this.reconnectSleeper = new Sleeper(timeout);
+await this.reconnectSleeper.sleep();
+
+// Lines 168-170: woken early when online event fires
+this.reconnectSleeper.wake();
+```
+
+## Changes
+
+### 1. Replace `Sleeper` class with `createSleeper` function
+
+Replace the class in `sleeper.ts` with:
+
+```ts
+export function createSleeper(timeout: number) {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  setTimeout(resolve, timeout);
+  return { promise, wake: resolve };
+}
+```
+
+Export the return type as `Sleeper` for use in the provider's type annotation.
+
+### 2. Update `provider.ts`
+
+- Change import from `Sleeper` class to `createSleeper` function and `Sleeper` type.
+- Change type annotation from `Sleeper | null` to `Sleeper | null` (no change needed — type alias keeps this stable).
+- Replace `new Sleeper(timeout)` with `createSleeper(timeout)`.
+- Replace `await this.reconnectSleeper.sleep()` with `await this.reconnectSleeper.promise`.
+- `this.reconnectSleeper.wake()` stays unchanged.
+
+## Tasks
+
+- [ ] Rewrite `sleeper.ts` — replace class with `createSleeper` function
+- [ ] Update `provider.ts` — swap to new API
+- [ ] Verify build passes

--- a/specs/20260212T200000-simplify-sleeper-to-function.md
+++ b/specs/20260212T200000-simplify-sleeper-to-function.md
@@ -1,6 +1,6 @@
 # Simplify Sleeper Class to Function
 
-## Status: In Progress
+## Status: Complete
 
 ## Problem
 
@@ -52,6 +52,6 @@ Export the return type as `Sleeper` for use in the provider's type annotation.
 
 ## Tasks
 
-- [ ] Rewrite `sleeper.ts` — replace class with `createSleeper` function
-- [ ] Update `provider.ts` — swap to new API
-- [ ] Verify build passes
+- [x] Rewrite `sleeper.ts` — replace class with `createSleeper` function
+- [x] Update `provider.ts` — swap to new API
+- [x] Verify build passes


### PR DESCRIPTION
The `Sleeper` class was a 33-line abstraction wrapping what is fundamentally `Promise.withResolvers()` + `setTimeout`. It had:

- A dead `reject` field — stored but never called anywhere in the codebase
- A redundant `sleep()` method — just `await this.promise`, adding zero value
- Class ceremony (constructor, two methods, three properties) for something that's naturally a plain object

Replaced with a `createSleeper` function that returns `{ promise, wake }` in 4 lines. The call sites in `provider.ts` read more naturally: `await sleeper.promise` instead of `await sleeper.sleep()`.

**Before** (33 lines):
```ts
class Sleeper {
  resolve?: () => void;
  reject?: () => void;    // dead code
  promise: Promise<void>;
  constructor(timeout) { ... }
  async sleep() { await this.promise; }  // unnecessary wrapper
  wake() { this.resolve && this.resolve(); }
}
```

**After** (4 lines):
```ts
function createSleeper(timeout: number) {
  const { promise, resolve } = Promise.withResolvers<void>();
  setTimeout(resolve, timeout);
  return { promise, wake: resolve };
}
```

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Verify reconnection backoff still works (connect → disconnect → observe exponential retry delays)
- [ ] Verify `online` event wakes the sleeper early (go offline → reconnect timer starts → go online → reconnects immediately)