### PR TITLE
refactor(tab-manager): rename snake_case fields and table keys to camelCase

### DIFF
--- a/apps/tab-manager/src/lib/browser-helpers.ts
+++ b/apps/tab-manager/src/lib/browser-helpers.ts
@@ -47,12 +47,12 @@ export function createBrowserConverters(deviceId: string) {
 		tabToRow(tab: Browser.tabs.Tab & { id: number; windowId: number }): Tab {
 			return {
 				id: TabId(tab.id),
-				device_id: deviceId,
-				tab_id: tab.id,
-				window_id: WindowId(tab.windowId),
+				deviceId: deviceId,
+				tabId: tab.id,
+				windowId: WindowId(tab.windowId),
 				url: tab.url ?? '',
 				title: tab.title ?? '',
-				fav_icon_url: tab.favIconUrl ?? undefined,
+				favIconUrl: tab.favIconUrl ?? undefined,
 				index: tab.index,
 				pinned: tab.pinned,
 				active: tab.active,
@@ -60,13 +60,13 @@ export function createBrowserConverters(deviceId: string) {
 				muted: tab.mutedInfo?.muted ?? false,
 				audible: tab.audible ?? false,
 				discarded: tab.discarded,
-				auto_discardable: tab.autoDiscardable ?? true,
+				autoDiscardable: tab.autoDiscardable ?? true,
 				status: tab.status ?? 'complete',
-				group_id:
+				groupId:
 					tab.groupId !== undefined && tab.groupId !== -1
 						? GroupId(tab.groupId)
 						: undefined,
-				opener_tab_id:
+				openerTabId:
 					tab.openerTabId !== undefined ? TabId(tab.openerTabId) : undefined,
 				incognito: tab.incognito ?? false,
 			};
@@ -75,12 +75,12 @@ export function createBrowserConverters(deviceId: string) {
 		windowToRow(window: Browser.windows.Window & { id: number }): Window {
 			return {
 				id: WindowId(window.id),
-				device_id: deviceId,
-				window_id: window.id,
+				deviceId: deviceId,
+				windowId: window.id,
 				state: window.state ?? 'normal',
 				type: window.type ?? 'normal',
 				focused: window.focused ?? false,
-				always_on_top: window.alwaysOnTop ?? false,
+				alwaysOnTop: window.alwaysOnTop ?? false,
 				incognito: window.incognito ?? false,
 				top: window.top ?? 0,
 				left: window.left ?? 0,
@@ -92,9 +92,9 @@ export function createBrowserConverters(deviceId: string) {
 		tabGroupToRow(group: Browser.tabGroups.TabGroup): TabGroup {
 			return {
 				id: GroupId(group.id),
-				device_id: deviceId,
-				group_id: group.id,
-				window_id: WindowId(group.windowId),
+				deviceId: deviceId,
+				groupId: group.id,
+				windowId: WindowId(group.windowId),
 				title: group.title ?? undefined,
 				color: group.color ?? 'grey',
 				collapsed: group.collapsed ?? false,

--- a/apps/tab-manager/src/lib/components/SuspendedTabList.svelte
+++ b/apps/tab-manager/src/lib/components/SuspendedTabList.svelte
@@ -105,7 +105,7 @@
 					class="group flex items-center gap-3 rounded-md px-2 py-2 hover:bg-accent/50"
 				>
 					<Avatar.Root class="size-4 shrink-0 rounded-sm">
-						<Avatar.Image src={tab.fav_icon_url} alt="" />
+						<Avatar.Image src={tab.favIconUrl} alt="" />
 						<Avatar.Fallback class="rounded-sm">
 							<GlobeIcon class="size-3 text-muted-foreground" />
 						</Avatar.Fallback>
@@ -118,7 +118,7 @@
 						<div class="flex items-center gap-2 text-xs text-muted-foreground">
 							<span class="truncate">{getDomain(tab.url)}</span>
 							<span>•</span>
-							<span class="shrink-0">{getRelativeTime(tab.suspended_at)}</span>
+							<span class="shrink-0">{getRelativeTime(tab.suspendedAt)}</span>
 						</div>
 					</div>
 

--- a/apps/tab-manager/src/lib/components/TabItem.svelte
+++ b/apps/tab-manager/src/lib/components/TabItem.svelte
@@ -21,8 +21,8 @@
 
 	let { tab }: { tab: Tab } = $props();
 
-	// Use tab_id for browser API calls (native browser tab ID)
-	const tabId = $derived(tab.tab_id);
+	// Use tabId for browser API calls (native browser tab ID)
+	const tabId = $derived(tab.tabId);
 
 	const closeMutation = createMutation(() => rpc.tabs.close.options);
 	const activateMutation = createMutation(() => rpc.tabs.activate.options);
@@ -69,7 +69,7 @@
 >
 	<!-- Favicon -->
 	<Avatar.Root class="size-4 shrink-0 rounded-sm">
-		<Avatar.Image src={tab.fav_icon_url} alt="" />
+		<Avatar.Image src={tab.favIconUrl} alt="" />
 		<Avatar.Fallback class="rounded-sm">
 			<GlobeIcon class="size-3 text-muted-foreground" />
 		</Avatar.Fallback>

--- a/apps/tab-manager/src/lib/components/TabList.svelte
+++ b/apps/tab-manager/src/lib/components/TabList.svelte
@@ -22,9 +22,7 @@
 
 		const grouped = new Map<string, Tab[]>();
 		for (const window of windowsQuery.data) {
-			const windowTabs = tabsQuery.data.filter(
-				(t) => t.window_id === window.id,
-			);
+			const windowTabs = tabsQuery.data.filter((t) => t.windowId === window.id);
 			// Already sorted by index from query
 			grouped.set(window.id, windowTabs);
 		}

--- a/apps/tab-manager/src/lib/epicenter/browser.schema.ts
+++ b/apps/tab-manager/src/lib/epicenter/browser.schema.ts
@@ -16,58 +16,6 @@ import { defineTable, type InferTableRow } from '@epicenter/hq/static';
 import { type } from 'arktype';
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Constants
-// ─────────────────────────────────────────────────────────────────────────────
-
-/**
- * Chrome window states
- * @see Browser.windows.WindowState
- * Note: 'locked-fullscreen' is ChromeOS only and requires allowlisted extensions
- */
-export const WINDOW_STATES = [
-	'normal',
-	'minimized',
-	'maximized',
-	'fullscreen',
-	'locked-fullscreen',
-] as const;
-
-/**
- * Chrome window types
- * @see Browser.windows.WindowType
- * Note: 'panel' and 'app' are deprecated Chrome App types
- */
-export const WINDOW_TYPES = [
-	'normal',
-	'popup',
-	'panel',
-	'app',
-	'devtools',
-] as const;
-
-/**
- * Chrome tab loading status
- * @see Browser.tabs.TabStatus
- */
-export const TAB_STATUS = ['unloaded', 'loading', 'complete'] as const;
-
-/**
- * Chrome tab group colors
- * @see https://developer.chrome.com/docs/extensions/reference/api/tabGroups#type-Color
- */
-export const TAB_GROUP_COLORS = [
-	'grey',
-	'blue',
-	'red',
-	'yellow',
-	'green',
-	'pink',
-	'purple',
-	'cyan',
-	'orange',
-] as const;
-
-// ─────────────────────────────────────────────────────────────────────────────
 // Table Definitions (Static API with Arktype)
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -81,7 +29,7 @@ const devices = defineTable(
 	type({
 		id: 'string', // NanoID, generated once on install
 		name: 'string', // User-editable: "Chrome on macOS", "Firefox on Windows"
-		last_seen: 'string', // ISO timestamp, updated on each sync
+		lastSeen: 'string', // ISO timestamp, updated on each sync
 		browser: 'string', // 'chrome' | 'firefox' | 'safari' | 'edge' | 'opera'
 	}),
 );
@@ -95,12 +43,12 @@ const devices = defineTable(
 const tabs = defineTable(
 	type({
 		id: 'string', // Composite: `${deviceId}_${tabId}`
-		device_id: 'string', // Foreign key to devices table
-		tab_id: 'number', // Original browser tab ID for API calls
-		window_id: 'string', // Composite: `${deviceId}_${windowId}`
+		deviceId: 'string', // Foreign key to devices table
+		tabId: 'number', // Original browser tab ID for API calls
+		windowId: 'string', // Composite: `${deviceId}_${windowId}`
 		url: 'string',
 		title: 'string',
-		'fav_icon_url?': 'string', // Nullable
+		'favIconUrl?': 'string', // Nullable
 		index: 'number', // Zero-based position in tab strip
 		pinned: 'boolean',
 		active: 'boolean',
@@ -108,10 +56,10 @@ const tabs = defineTable(
 		muted: 'boolean',
 		audible: 'boolean',
 		discarded: 'boolean', // Tab unloaded to save memory
-		auto_discardable: 'boolean',
+		autoDiscardable: 'boolean',
 		status: "'unloaded' | 'loading' | 'complete'",
-		'group_id?': 'string', // Chrome 88+, null on Firefox
-		'opener_tab_id?': 'string', // ID of tab that opened this one
+		'groupId?': 'string', // Chrome 88+, null on Firefox
+		'openerTabId?': 'string', // ID of tab that opened this one
 		incognito: 'boolean',
 	}),
 );
@@ -124,13 +72,13 @@ const tabs = defineTable(
 const windows = defineTable(
 	type({
 		id: 'string', // Composite: `${deviceId}_${windowId}`
-		device_id: 'string', // Foreign key to devices table
-		window_id: 'number', // Original browser window ID for API calls
+		deviceId: 'string', // Foreign key to devices table
+		windowId: 'number', // Original browser window ID for API calls
 		state:
 			"'normal' | 'minimized' | 'maximized' | 'fullscreen' | 'locked-fullscreen'",
 		type: "'normal' | 'popup' | 'panel' | 'app' | 'devtools'",
 		focused: 'boolean',
-		always_on_top: 'boolean',
+		alwaysOnTop: 'boolean',
 		incognito: 'boolean',
 		top: 'number',
 		left: 'number',
@@ -146,12 +94,12 @@ const windows = defineTable(
  *
  * @see https://developer.chrome.com/docs/extensions/reference/api/tabGroups
  */
-const tab_groups = defineTable(
+const tabGroups = defineTable(
 	type({
 		id: 'string', // Composite: `${deviceId}_${groupId}`
-		device_id: 'string', // Foreign key to devices table
-		group_id: 'number', // Original browser group ID for API calls
-		window_id: 'string', // Composite: `${deviceId}_${windowId}`
+		deviceId: 'string', // Foreign key to devices table
+		groupId: 'number', // Original browser group ID for API calls
+		windowId: 'string', // Composite: `${deviceId}_${windowId}`
 		'title?': 'string', // Nullable
 		color:
 			"'grey' | 'blue' | 'red' | 'yellow' | 'green' | 'pink' | 'purple' | 'cyan' | 'orange'",
@@ -169,15 +117,15 @@ const tab_groups = defineTable(
  * Created when a user explicitly "suspends" a tab (close + save).
  * Deleted when a user restores the tab (opens URL locally + deletes row).
  */
-const suspended_tabs = defineTable(
+const suspendedTabs = defineTable(
 	type({
 		id: 'string', // nanoid, generated on suspend
 		url: 'string', // The tab URL
 		title: 'string', // Tab title at time of suspend
-		'fav_icon_url?': 'string', // Favicon URL (nullable)
+		'favIconUrl?': 'string', // Favicon URL (nullable)
 		pinned: 'boolean', // Whether tab was pinned
-		source_device_id: 'string', // Device that suspended this tab
-		suspended_at: 'number', // Timestamp (ms since epoch)
+		sourceDeviceId: 'string', // Device that suspended this tab
+		suspendedAt: 'number', // Timestamp (ms since epoch)
 	}),
 );
 
@@ -189,8 +137,8 @@ export const BROWSER_TABLES = {
 	devices,
 	tabs,
 	windows,
-	tab_groups,
-	suspended_tabs,
+	tabGroups,
+	suspendedTabs,
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -200,7 +148,7 @@ export const BROWSER_TABLES = {
 export type Device = InferTableRow<typeof BROWSER_TABLES.devices>;
 export type Tab = InferTableRow<typeof BROWSER_TABLES.tabs>;
 export type Window = InferTableRow<typeof BROWSER_TABLES.windows>;
-export type TabGroup = InferTableRow<typeof BROWSER_TABLES.tab_groups>;
-export type SuspendedTab = InferTableRow<typeof BROWSER_TABLES.suspended_tabs>;
+export type TabGroup = InferTableRow<typeof BROWSER_TABLES.tabGroups>;
+export type SuspendedTab = InferTableRow<typeof BROWSER_TABLES.suspendedTabs>;
 
 export type BrowserTables = typeof BROWSER_TABLES;

--- a/apps/tab-manager/src/lib/epicenter/suspend-tab.ts
+++ b/apps/tab-manager/src/lib/epicenter/suspend-tab.ts
@@ -1,7 +1,7 @@
 /**
  * Suspend and restore tab helpers.
  *
- * These operate on the shared `suspended_tabs` table and the browser tabs API.
+ * These operate on the shared `suspendedTabs` table and the browser tabs API.
  * Suspending saves a tab's essential data to Yjs and closes the browser tab.
  * Restoring opens the URL locally and removes the row from Yjs.
  *
@@ -13,10 +13,10 @@ import type { SuspendedTab, Tab } from './browser.schema';
 import type { BrowserDb } from './schema';
 
 /**
- * Suspend a browser tab — save it to the `suspended_tabs` table and close it.
+ * Suspend a browser tab — save it to the `suspendedTabs` table and close it.
  *
  * Reads the tab's essential data (url, title, favicon, pinned state),
- * writes a row to `suspended_tabs`, then closes the browser tab.
+ * writes a row to `suspendedTabs`, then closes the browser tab.
  * The existing `onRemoved` handler in background.ts handles cleanup
  * of the live `tabs` table row automatically.
  *
@@ -30,24 +30,24 @@ export async function suspendTab(
 	deviceId: string,
 	tab: Tab,
 ): Promise<void> {
-	tables.suspended_tabs.set({
+	tables.suspendedTabs.set({
 		id: generateId(),
 		url: tab.url,
 		title: tab.title || 'Untitled',
-		fav_icon_url: tab.fav_icon_url,
+		favIconUrl: tab.favIconUrl,
 		pinned: tab.pinned,
-		source_device_id: deviceId,
-		suspended_at: Date.now(),
+		sourceDeviceId: deviceId,
+		suspendedAt: Date.now(),
 	});
 
-	await browser.tabs.remove(tab.tab_id);
+	await browser.tabs.remove(tab.tabId);
 }
 
 /**
  * Restore a suspended tab — open it in the browser and delete the saved row.
  *
  * Creates a new browser tab with the suspended tab's URL and pinned state,
- * then removes the row from `suspended_tabs`. The existing `onCreated`
+ * then removes the row from `suspendedTabs`. The existing `onCreated`
  * handler in background.ts adds the new tab to the live `tabs` table
  * automatically.
  *
@@ -65,13 +65,13 @@ export async function restoreTab(
 		pinned: suspendedTab.pinned,
 	});
 
-	tables.suspended_tabs.delete(suspendedTab.id);
+	tables.suspendedTabs.delete(suspendedTab.id);
 }
 
 /**
  * Delete a suspended tab without restoring it.
  *
- * Simply removes the row from the `suspended_tabs` table.
+ * Simply removes the row from the `suspendedTabs` table.
  * The tab is permanently discarded.
  *
  * @example
@@ -80,7 +80,7 @@ export async function restoreTab(
  * ```
  */
 export function deleteSuspendedTab(tables: BrowserDb, id: string): void {
-	tables.suspended_tabs.delete(id);
+	tables.suspendedTabs.delete(id);
 }
 
 /**
@@ -98,5 +98,5 @@ export function updateSuspendedTab(
 	tables: BrowserDb,
 	suspendedTab: SuspendedTab,
 ): void {
-	tables.suspended_tabs.set(suspendedTab);
+	tables.suspendedTabs.set(suspendedTab);
 }

--- a/apps/tab-manager/src/lib/epicenter/workspace.ts
+++ b/apps/tab-manager/src/lib/epicenter/workspace.ts
@@ -1,7 +1,7 @@
 /**
  * Popup-side workspace client for accessing Y.Doc data.
  *
- * The popup needs direct access to the Y.Doc for the `suspended_tabs` table,
+ * The popup needs direct access to the Y.Doc for the `suspendedTabs` table,
  * which is shared across devices via Yjs (not available through Chrome APIs).
  *
  * This creates a lightweight workspace client with IndexedDB persistence
@@ -23,7 +23,7 @@ const definition = defineWorkspace({
 /**
  * Popup workspace client.
  *
- * Provides typed access to all browser tables including `suspended_tabs`.
+ * Provides typed access to all browser tables including `suspendedTabs`.
  * Shares the same Y.Doc as the background service worker via IndexedDB
  * persistence and Y-Sweet sync.
  */

--- a/apps/tab-manager/src/lib/query/suspended-tabs.ts
+++ b/apps/tab-manager/src/lib/query/suspended-tabs.ts
@@ -54,9 +54,9 @@ export const suspendedTabs = {
 	getAll: defineQuery({
 		queryKey: suspendedTabsKeys.all,
 		queryFn: () => {
-			const rows = popupWorkspace.tables.suspended_tabs
+			const rows = popupWorkspace.tables.suspendedTabs
 				.getAllValid()
-				.sort((a, b) => b.suspended_at - a.suspended_at);
+				.sort((a, b) => b.suspendedAt - a.suspendedAt);
 			return Ok(rows);
 		},
 	}),
@@ -95,7 +95,7 @@ export const suspendedTabs = {
 		mutationFn: () =>
 			tryAsync({
 				try: async () => {
-					const all = popupWorkspace.tables.suspended_tabs.getAllValid();
+					const all = popupWorkspace.tables.suspendedTabs.getAllValid();
 					for (const tab of all) {
 						await restoreTab(popupWorkspace.tables, tab);
 					}
@@ -126,7 +126,7 @@ export const suspendedTabs = {
 		mutationFn: async () =>
 			trySync({
 				try: () => {
-					const all = popupWorkspace.tables.suspended_tabs.getAllValid();
+					const all = popupWorkspace.tables.suspendedTabs.getAllValid();
 					for (const tab of all) {
 						deleteSuspendedTab(popupWorkspace.tables, tab.id);
 					}

--- a/docs/specs/20260213T012108-browser-schema-camelcase-cleanup.md
+++ b/docs/specs/20260213T012108-browser-schema-camelcase-cleanup.md
@@ -1,0 +1,142 @@
+# Browser Schema camelCase Cleanup
+
+## Goal
+
+Refactor `browser.schema.ts` and all consumers in `apps/tab-manager/` to use camelCase field names and table keys. Remove unused constants. Simplify where possible.
+
+**Data migration**: Nuke existing IndexedDB data. No versioned migration needed.
+
+## Changes
+
+### 1. `browser.schema.ts` — Schema source of truth
+
+**Table key renames** (in `BROWSER_TABLES` export object):
+
+- `tab_groups` → `tabGroups`
+- `suspended_tabs` → `suspendedTabs`
+- `devices`, `tabs`, `windows` — already camelCase, no change
+
+**Field renames** (snake_case → camelCase):
+
+| Table          | Old Field          | New Field         |
+| -------------- | ------------------ | ----------------- |
+| devices        | `last_seen`        | `lastSeen`        |
+| tabs           | `device_id`        | `deviceId`        |
+| tabs           | `tab_id`           | `tabId`           |
+| tabs           | `window_id`        | `windowId`        |
+| tabs           | `fav_icon_url?`    | `favIconUrl?`     |
+| tabs           | `auto_discardable` | `autoDiscardable` |
+| tabs           | `group_id?`        | `groupId?`        |
+| tabs           | `opener_tab_id?`   | `openerTabId?`    |
+| windows        | `device_id`        | `deviceId`        |
+| windows        | `window_id`        | `windowId`        |
+| windows        | `always_on_top`    | `alwaysOnTop`     |
+| tab_groups     | `device_id`        | `deviceId`        |
+| tab_groups     | `group_id`         | `groupId`         |
+| tab_groups     | `window_id`        | `windowId`        |
+| suspended_tabs | `fav_icon_url?`    | `favIconUrl?`     |
+| suspended_tabs | `source_device_id` | `sourceDeviceId`  |
+| suspended_tabs | `suspended_at`     | `suspendedAt`     |
+
+**Remove unused constants**: `WINDOW_STATES`, `WINDOW_TYPES`, `TAB_STATUS`, `TAB_GROUP_COLORS`
+
+**Update type exports**: `BrowserTables` type stays, individual row types stay (`Device`, `Tab`, `Window`, `TabGroup`, `SuspendedTab`) — field shapes change automatically via `InferTableRow`.
+
+### 2. `browser-helpers.ts` — Row converters
+
+Update `tabToRow()`, `windowToRow()`, `tabGroupToRow()` return object keys from snake_case to camelCase. The Chrome API input side stays the same (Chrome uses its own naming).
+
+### 3. `schema.ts` — Re-exports
+
+Minimal: just re-exports `BROWSER_TABLES`. No changes needed unless we rename the export itself (we won't).
+
+Update `BrowserDb` type — table access changes from `tables.suspended_tabs` to `tables.suspendedTabs` etc.
+
+### 4. `index.ts` — Public type re-exports
+
+No changes needed. Type names stay the same, field shapes change automatically.
+
+### 5. `suspend-tab.ts` — Suspend/restore helpers
+
+Update all field accesses:
+
+- `tab.fav_icon_url` → `tab.favIconUrl`
+- `tab.tab_id` → `tab.tabId`
+- `tables.suspended_tabs` → `tables.suspendedTabs`
+- `source_device_id` → `sourceDeviceId`
+- `suspended_at` → `suspendedAt`
+- `fav_icon_url` → `favIconUrl`
+
+### 6. `background.ts` — Background service worker (biggest file, ~930 lines)
+
+Table accessor renames:
+
+- `tables.tab_groups` → `tables.tabGroups`
+- `tables.suspended_tabs` → `tables.suspendedTabs` (if referenced)
+- `client.tables.tab_groups.observe` → `client.tables.tabGroups.observe`
+
+Field access renames throughout:
+
+- `existing.device_id` → `existing.deviceId`
+- `existing.tab_id` → `existing.tabId`
+- `existing.window_id` → `existing.windowId`
+- `row.device_id` → `row.deviceId`
+- `row.tab_id` → `row.tabId`
+- `row.window_id` → `row.windowId`
+- `last_seen` → `lastSeen`
+
+Also: the debug `ytables.get('tabs')` string reference on line ~319 stays as-is (that's a Y.Doc internal key, not a schema field).
+
+### 7. `query/suspended-tabs.ts` — Suspended tab queries
+
+- `popupWorkspace.tables.suspended_tabs` → `popupWorkspace.tables.suspendedTabs`
+- `b.suspended_at` → `b.suspendedAt`
+
+### 8. `query/tabs.ts` — Tab queries
+
+No table access changes (reads from Chrome APIs directly). The `tabToRow` / `windowToRow` / `tabGroupToRow` calls produce new camelCase field shapes, but the query layer just returns them.
+
+### 9. Svelte components
+
+**`TabItem.svelte`**:
+
+- `tab.fav_icon_url` → `tab.favIconUrl`
+- `tab.tab_id` → `tab.tabId`
+
+**`TabList.svelte`**:
+
+- `t.window_id` → `t.windowId`
+
+**`SuspendedTabList.svelte`**:
+
+- `tab.fav_icon_url` → `tab.favIconUrl`
+- `tab.suspended_at` → `tab.suspendedAt`
+
+## TODO
+
+- [x] Update `browser.schema.ts` — camelCase fields, camelCase table keys, remove unused constants
+- [x] Update `browser-helpers.ts` — camelCase return object keys
+- [x] Update `schema.ts` — if needed for table key renames
+- [x] Update `suspend-tab.ts` — camelCase field accesses and table accessors
+- [x] Update `background.ts` — camelCase table accessors and field accesses
+- [x] Update `query/suspended-tabs.ts` — camelCase table accessor and field accesses
+- [x] Update `TabItem.svelte` — camelCase field accesses
+- [x] Update `TabList.svelte` — camelCase field accesses
+- [x] Update `SuspendedTabList.svelte` — camelCase field accesses
+- [x] Run type check to verify no field name mismatches remain
+
+## Review
+
+All spec items completed. Changes across 9 files:
+
+- **browser.schema.ts**: Removed 4 unused constants (`WINDOW_STATES`, `WINDOW_TYPES`, `TAB_STATUS`, `TAB_GROUP_COLORS`). Renamed all snake_case fields to camelCase. Renamed table keys `tab_groups` → `tabGroups`, `suspended_tabs` → `suspendedTabs`. Renamed local variables to match (`tab_groups` → `tabGroups`, `suspended_tabs` → `suspendedTabs`).
+- **browser-helpers.ts**: Updated all return object keys in `tabToRow`, `windowToRow`, `tabGroupToRow`.
+- **suspend-tab.ts**: Updated table accessor (`tables.suspendedTabs`) and all field accesses (`favIconUrl`, `tabId`, `sourceDeviceId`, `suspendedAt`). Updated JSDoc comments.
+- **background.ts**: Updated all `tables.tabGroups` accessors, all field accesses (`deviceId`, `tabId`, `windowId`, `groupId`, `lastSeen`), and JSDoc comments.
+- **query/suspended-tabs.ts**: Updated `popupWorkspace.tables.suspendedTabs` and `suspendedAt` sort.
+- **workspace.ts**: Updated JSDoc comments only.
+- **TabItem.svelte**: `tab.fav_icon_url` → `tab.favIconUrl`, `tab.tab_id` → `tab.tabId`.
+- **TabList.svelte**: `t.window_id` → `t.windowId`.
+- **SuspendedTabList.svelte**: `tab.fav_icon_url` → `tab.favIconUrl`, `tab.suspended_at` → `tab.suspendedAt`.
+
+**Type check**: 9 pre-existing errors (all `Browser.tabs.Tab` intersection type mismatches), zero new errors introduced.


### PR DESCRIPTION
Browser schema used snake_case for field names and table keys (`tab_groups`, `suspended_tabs`, `device_id`, `tab_id`, etc.), which clashed with TypeScript conventions and Chrome API naming that already uses camelCase. This normalizes everything to camelCase so the schema matches both the language conventions and the Chrome API surface it mirrors.

```
browser.schema.ts   BROWSER_TABLES keys + all field definitions
                    ├── tab_groups     → tabGroups
                    ├── suspended_tabs → suspendedTabs
                    └── 20 field renames (device_id → deviceId, etc.)

browser-helpers.ts  tabToRow / windowToRow / tabGroupToRow return keys
suspend-tab.ts      tables.suspendedTabs + field accesses
background.ts       tables.tabGroups + all row field accesses
query/suspended-tabs.ts  tables.suspendedTabs + sort field
TabItem.svelte      tab.favIconUrl, tab.tabId
TabList.svelte      t.windowId
SuspendedTabList.svelte  tab.favIconUrl, tab.suspendedAt
```

Also removes four unused constants that were never referenced outside the schema file: `WINDOW_STATES`, `WINDOW_TYPES`, `TAB_STATUS`, `TAB_GROUP_COLORS`. The inline union string types in arktype already encode the same values.

Data migration: existing IndexedDB data should be nuked (the field names stored in Y.Doc will mismatch). No versioned migration needed since this is pre-release.

Type check confirms zero new errors — the 9 existing `Browser.tabs.Tab` intersection type mismatches are pre-existing and unrelated.