### PR TITLE
refactor(svelte-utils): remove unnecessary createSubscriber from createPersistedState

### DIFF
--- a/docs/articles/how-createsubscriber-works.md
+++ b/docs/articles/how-createsubscriber-works.md
@@ -1,0 +1,186 @@
+# How `createSubscriber` Works
+
+`createSubscriber` shipped in Svelte 5.7.0 and it's one of the most underappreciated tools in the reactivity system. It solves a specific problem: connecting external event sources to Svelte's reactive graph without `$state` as an intermediary. To use it well, you need to understand what it's actually doing.
+
+## The Problem It Solves
+
+Svelte's reactivity is pull-based. When you write `$state(0)` and read it in a template, Svelte tracks the read and knows to re-render when the value changes. But what about a value that lives outside Svelte entirely? A `window.matchMedia` result. A Yjs CRDT. A database cursor. These systems have their own change notification mechanisms (`addEventListener`, `observe`, `subscribe`) that Svelte knows nothing about.
+
+You need a bridge: something that says "Svelte, this external thing changed—please re-read my getter."
+
+That bridge is `createSubscriber`.
+
+## The API
+
+```typescript
+import { createSubscriber } from 'svelte/reactivity';
+
+const subscribe = createSubscriber((update) => {
+	// Called when first reactive consumer appears.
+	// Set up your external listener here.
+	// Call update() whenever the external source changes.
+
+	return () => {
+		// Called when last reactive consumer disappears.
+		// Clean up your external listener here.
+	};
+});
+```
+
+`createSubscriber` returns a function. Call that function inside a getter to make the getter reactive. The `start` callback runs lazily—only when at least one reactive context is reading the value.
+
+## What Happens Under the Hood
+
+The implementation is ~30 lines. Here's the mental model:
+
+```
+createSubscriber(start)
+  │
+  ├── version = source(0)     ← invisible signal, starts at 0
+  ├── subscribers = 0          ← reference counter
+  ├── stop = undefined         ← cleanup function from start()
+  │
+  └── returns subscribe()
+        │
+        ├── if not in reactive context → do nothing
+        │
+        └── if in reactive context:
+              ├── get(version)           ← register dependency
+              ├── create render_effect:
+              │     ├── if subscribers === 0 → call start(update)
+              │     ├── subscribers++
+              │     └── teardown:
+              │           ├── subscribers--
+              │           └── if subscribers === 0 → call stop()
+              └── done
+```
+
+Three moving parts: a version signal, a subscriber count, and a start/stop lifecycle.
+
+## The Version Signal
+
+`createSubscriber` allocates a single Svelte `source` initialized to `0`. This is the invisible reactive signal that makes everything work. Two things interact with it:
+
+When a getter calls `subscribe()`, it runs `get(version)`. This registers the current reactive context (an `$effect`, `$derived`, or template expression) as a dependency of `version`. Svelte now knows: "if version changes, re-run this effect."
+
+When the external system fires and your code calls `update()`, it runs `increment(version)`. This bumps the signal from 0 to 1, then 1 to 2, and so on. Every dependent effect re-runs, which means every getter that called `subscribe()` gets re-read.
+
+The version number itself is meaningless. It's just a counter that increments to trigger invalidation. Svelte doesn't care that version went from 7 to 8; it only cares that it changed.
+
+## Lazy Start, Lazy Stop
+
+The `start` callback doesn't run when you call `createSubscriber`. It runs when the first reactive consumer appears—specifically, when `subscribers` goes from 0 to 1. This is the "lazy" part.
+
+```typescript
+const mq = new MediaQuery('(prefers-color-scheme: dark)');
+// At this point, NO event listener is registered on matchMedia.
+// start() hasn't run. Nothing is subscribed.
+
+// Later, in a component template:
+// <p>{mq.current ? 'dark' : 'light'}</p>
+// NOW start() runs, because a template expression read mq.current,
+// which called subscribe(), which saw subscribers === 0.
+```
+
+The cleanup function (returned by `start`) runs when the last consumer disappears—when `subscribers` goes from 1 to 0. If a component using the `MediaQuery` unmounts, and no other component reads `.current`, the `change` listener is removed from `matchMedia`. If a new component later reads `.current`, `start` runs again.
+
+This is reference counting. Multiple effects can depend on the same `createSubscriber` instance. The external subscription stays alive as long as at least one consumer exists.
+
+## The render_effect
+
+Each consumer gets its own `render_effect` inside `subscribe()`. This effect does two things: increment the subscriber count on creation, and decrement it on teardown. The teardown uses `queue_micro_task` to avoid tearing down and immediately re-subscribing during synchronous component re-renders.
+
+The `start` callback itself runs inside `untrack()`. This prevents any reactive reads inside `start` from becoming dependencies of the `render_effect`. Your setup code can read whatever it needs without accidentally creating circular dependencies.
+
+## How Svelte Uses It Internally
+
+Svelte's own codebase has two uses that demonstrate the pattern perfectly.
+
+`MediaQuery` bridges `window.matchMedia`:
+
+```typescript
+class MediaQuery {
+	#query;
+	#subscribe;
+
+	constructor(query) {
+		this.#query = window.matchMedia(query);
+
+		this.#subscribe = createSubscriber((update) => {
+			this.#query.addEventListener('change', update);
+			return () => this.#query.removeEventListener('change', update);
+		});
+	}
+
+	get current() {
+		this.#subscribe();
+		return this.#query.matches; // read directly from matchMedia, no $state
+	}
+}
+```
+
+No `$state` anywhere. The value (`this.#query.matches`) is read directly from the browser API on every access. `createSubscriber` just tells Svelte when to re-read it. This is the purest form of the pattern: external state, no shadow copy, event-driven invalidation.
+
+`fromStore` adapts Svelte 4 stores to Svelte 5 runes:
+
+```typescript
+function fromStore(store) {
+	let value = store_get(store);
+
+	const subscribe = createSubscriber((update) => {
+		return store.subscribe((v) => {
+			value = v;
+			update();
+		});
+	});
+
+	return {
+		get current() {
+			subscribe();
+			return value;
+		},
+	};
+}
+```
+
+This one does use a local `value` variable (not `$state`, just a plain `let`) as a shadow copy, updated inside the store's subscription callback. `update()` tells Svelte to re-read the getter, which returns the now-updated `value`.
+
+Both follow the same shape: set up a listener in `start`, call `update` when something changes, clean up in the returned function, expose a getter that calls `subscribe()`.
+
+## Best Practices
+
+**Always call `subscribe()` inside a getter, not in the constructor.** The getter is what components read. If you call `subscribe()` during construction, you're subscribing before any reactive context exists—`effect_tracking()` returns `false`, and `subscribe()` silently does nothing.
+
+```typescript
+// Wrong: subscribe() in constructor does nothing
+class Bad {
+	constructor() {
+		this.#subscribe = createSubscriber(/* ... */);
+		this.#subscribe(); // effect_tracking() is false here. No-op.
+	}
+}
+
+// Right: subscribe() in getter, called during render
+class Good {
+	get value() {
+		this.#subscribe(); // effect_tracking() is true during render
+		return this.#computeValue();
+	}
+}
+```
+
+**Return a cleanup function from `start`.** If you don't, the external listener leaks when all consumers disappear. The whole point of `createSubscriber` managing the lifecycle is that it can clean up for you. If you skip the cleanup, you lose the main benefit over just registering listeners manually.
+
+**Don't call `update()` if you also mutate `$state`.** If your `start` callback mutates a `$state` variable and also calls `update()`, you're signaling the change twice. `$state` mutation already triggers re-renders for its consumers. `update()` would additionally invalidate anything depending on the version signal. Pick one owner for the reactivity. If you're using `$state` as a shadow copy, the `$state` mutation is sufficient and `update()` is redundant. If you're reading directly from the external source (like `MediaQuery` does), `update()` is the only signal mechanism.
+
+**Use it for expensive subscriptions that should be lazy.** If subscribing costs nothing (like adding a DOM event listener), you might not need `createSubscriber` at all. Just register the listener and mutate `$state` directly. `createSubscriber` shines when the act of subscribing is expensive: opening a WebSocket, starting a polling interval, connecting to a database. The lazy start/stop lifecycle means you only pay that cost when someone is actually reading the value.
+
+**On the server, `createSubscriber` is a no-op.** The returned `subscribe` function does nothing during SSR. There are no reactive contexts, no effects, no consumers. If you're reading from an external source during SSR, you'll get the initial value from your getter but no reactivity. Plan accordingly.
+
+## When You Don't Need It
+
+If your external events mutate `$state` directly, skip `createSubscriber`. The `$state` proxy already handles reactivity. You'd be adding a lifecycle manager for a subscription that doesn't need lifecycle management. Browser event listeners, cheap callbacks, module-level subscriptions that should always be active—these don't benefit from lazy start/stop semantics.
+
+## Further Reading
+
+For a consumer-focused guide with practical examples (BroadcastChannel, IntersectionObserver, and more), see [Using createSubscriber](./using-createsubscriber.md). For choosing between `$state` and `createSubscriber` when both could work, see [`$state` vs `createSubscriber`: Who Owns the Reactivity?](./state-vs-createsubscriber-who-owns-reactivity.md). For a Yjs-specific example with shadow state and bidirectional sync, see [Syncing External State with createSubscriber](./svelte-5-createsubscriber-pattern.md).

--- a/docs/articles/state-vs-createsubscriber-who-owns-reactivity.md
+++ b/docs/articles/state-vs-createsubscriber-who-owns-reactivity.md
@@ -1,0 +1,180 @@
+# `$state` vs `createSubscriber`: Who Owns the Reactivity?
+
+Svelte 5 gives you two ways to tell the framework "something changed, re-render." Most of the time you only need one. Picking the wrong one adds complexity for no benefit; picking the right one makes external integrations trivially simple. The distinction comes down to a single question: who owns the reactivity?
+
+## The Core Question
+
+`$state` and `createSubscriber` are both mechanisms for signaling change. They serve different purposes:
+
+| Mechanism          | What it does                                        |
+| ------------------ | --------------------------------------------------- |
+| `$state`           | "This value changed. Re-render whoever reads it."   |
+| `createSubscriber` | "Is anyone listening? Should I bother subscribing?" |
+
+If your external events directly mutate `$state`, the reactivity is already handled. Adding `createSubscriber` on top is redundant. If your value is computed on-read from an external source with no `$state` involved, `createSubscriber` is the only way Svelte knows to re-read the getter.
+
+## Pattern A: `$state` Owns Reactivity
+
+When external events mutate stored state, `$state` handles everything:
+
+```typescript
+class TabStore {
+	#tabs = $state<Tab[]>([]);
+
+	constructor() {
+		this.#seed();
+
+		browser.tabs.onCreated.addListener((tab) => {
+			this.#tabs.push(tab); // $state proxy intercepts this. Svelte knows.
+		});
+
+		browser.tabs.onRemoved.addListener((tabId) => {
+			this.#tabs = this.#tabs.filter((t) => t.id !== tabId); // Reassignment. Svelte knows.
+		});
+	}
+
+	async #seed() {
+		const windows = await browser.windows.getAll({ populate: true });
+		this.#tabs = windows.flatMap((w) => w.tabs ?? []);
+	}
+
+	get tabs() {
+		return this.#tabs; // Reactive because #tabs is $state
+	}
+}
+```
+
+The browser event listener is just a plain callback that happens to mutate reactive state. `$state` is a proxy—it intercepts `.push()`, index assignment, property mutation, reassignment. Every component reading `this.#tabs` already gets re-rendered when it changes. No `createSubscriber` needed.
+
+## Pattern B: No `$state`, Only `createSubscriber`
+
+When the value is computed fresh on every read and nothing is stored:
+
+```typescript
+class Clock {
+	#subscribe;
+
+	constructor() {
+		this.#subscribe = createSubscriber((update) => {
+			const interval = setInterval(update, 1000);
+			return () => clearInterval(interval);
+		});
+	}
+
+	get now() {
+		this.#subscribe(); // Registers this getter as a reactive dependency
+		return new Date(); // Computed fresh. Not stored in $state.
+	}
+}
+```
+
+There is no `$state` here. `new Date()` is computed on read. Without `createSubscriber`, Svelte would read `now` once and never again because there's no tracked signal to invalidate. `createSubscriber` creates an invisible version signal internally (`source(0)` that increments on each `update()` call). Reading `this.#subscribe()` in the getter tells Svelte "track this." Calling `update()` from the interval tells Svelte "re-read the getter."
+
+## Pattern C: External State You Can't Wrap
+
+The more realistic use case for `createSubscriber` alone: a third-party library managing its own state.
+
+```typescript
+import { externalDB } from 'some-library';
+
+class DBView {
+	#subscribe;
+
+	constructor() {
+		this.#subscribe = createSubscriber((update) => {
+			const unsub = externalDB.onChange(() => update());
+			return unsub;
+		});
+	}
+
+	get records() {
+		this.#subscribe();
+		return externalDB.getAll(); // Reads from EXTERNAL state, not $state
+	}
+}
+```
+
+You can't make `externalDB` use `$state`—it's not your code. `createSubscriber` bridges the gap: when the DB emits a change event, Svelte re-reads the getter.
+
+## Pattern D: Both, For Lazy Lifecycle
+
+This is the subtle case. You use `$state` for reactivity and `createSubscriber` for subscription lifecycle management:
+
+```typescript
+class LivePrices {
+	#prices = $state<Map<string, number>>(new Map());
+	#subscribe;
+
+	constructor() {
+		this.#subscribe = createSubscriber((update) => {
+			// WebSocket ONLY opens when a component reads .prices
+			const ws = new WebSocket('wss://prices.example.com/stream');
+
+			ws.onmessage = (e) => {
+				const { symbol, price } = JSON.parse(e.data);
+				this.#prices.set(symbol, price); // $state handles reactivity
+				// update() not needed here—$state already triggers re-render
+			};
+
+			// WebSocket CLOSES when no components read .prices
+			return () => ws.close();
+		});
+	}
+
+	get prices() {
+		this.#subscribe(); // Controls WebSocket lifecycle, not reactivity
+		return this.#prices;
+	}
+}
+```
+
+`createSubscriber`'s `start` function is lazy—it only fires when subscribers go from 0 to 1. The cleanup fires when the last consumer stops reading. So if a component conditionally shows a price widget, the WebSocket opens when it appears and closes when it disappears.
+
+The `$state` mutation handles all the reactivity. `createSubscriber` answers a different question entirely: "should this expensive resource even be active right now?"
+
+## When You Don't Need `createSubscriber`
+
+Browser extension event listeners are cheap to register—no network connections, no resources to manage. They're always wanted while the popup is open, and they're automatically cleaned up when the popup closes (the entire JS context dies). There's no expensive subscription to lazily manage.
+
+For a browser tab manager, the answer is Pattern A:
+
+```typescript
+class BrowserTabStore {
+	#tabs = $state<Tab[]>([]);
+
+	constructor() {
+		this.#seed();
+		browser.tabs.onCreated.addListener((tab) => {
+			/* mutate $state */
+		});
+		browser.tabs.onRemoved.addListener((tabId) => {
+			/* mutate $state */
+		});
+		browser.tabs.onUpdated.addListener((_id, _info, tab) => {
+			/* mutate $state */
+		});
+	}
+
+	get tabs() {
+		return this.#tabs;
+	}
+}
+```
+
+Register on construction. Let popup destruction handle cleanup. `$state` handles the rest.
+
+## The Decision Table
+
+| Scenario                                      |    `$state`     | `createSubscriber` |
+| --------------------------------------------- | :-------------: | :----------------: |
+| Events mutate stored state                    |       ✅        |         —          |
+| Value computed on-read, no storage            |        —        |         ✅         |
+| External library state you can't proxy        |        —        |         ✅         |
+| Expensive subscription, lazy lifecycle needed | ✅ (reactivity) |   ✅ (lifecycle)   |
+| Cheap event listeners, always wanted          |       ✅        |         —          |
+
+`$state` answers "this value changed." `createSubscriber` answers "is anyone listening, and should I bother subscribing?" Most of the time you need one or the other. When you need both, they serve distinct roles that don't overlap.
+
+## Further Reading
+
+For a practical guide on using `createSubscriber` with real browser APIs, see [Using createSubscriber](./using-createsubscriber.md). For the version signal, reference counting, and `render_effect` internals, see [How createSubscriber Works](./how-createsubscriber-works.md). For a Yjs-specific example with shadow state and bidirectional sync, see [Syncing External State with createSubscriber](./svelte-5-createsubscriber-pattern.md).

--- a/docs/articles/svelte-5-createsubscriber-pattern.md
+++ b/docs/articles/svelte-5-createsubscriber-pattern.md
@@ -159,3 +159,7 @@ Svelte re-renders components reading `rows`
 ---
 
 This pattern has been solid for syncing Yjs CRDTs in a local-first app. Works great for any external store with an observe/subscribe API.
+
+## Further Reading
+
+For a consumer-focused guide with more examples (BroadcastChannel, IntersectionObserver, and more), see [Using createSubscriber](./using-createsubscriber.md). For the version signal, reference counting, and `render_effect` internals, see [How createSubscriber Works](./how-createsubscriber-works.md). For choosing between `$state` and `createSubscriber`, see [`$state` vs `createSubscriber`: Who Owns the Reactivity?](./state-vs-createsubscriber-who-owns-reactivity.md).

--- a/docs/articles/using-createsubscriber.md
+++ b/docs/articles/using-createsubscriber.md
@@ -1,0 +1,238 @@
+# Using `createSubscriber`
+
+If something already knows how to notify you when it changes—`addEventListener`, `.observe()`, `.subscribe()`, `.on('change')`—then `createSubscriber` makes it reactive in Svelte with almost no code. You don't need `$state`. You don't need a shadow copy. You just need a getter that reads from the source and a bridge that tells Svelte when to re-read it.
+
+## The Shape of the Problem
+
+You have some external thing. It has a value. It has a way to tell you when that value changes. You want a Svelte component to re-render when it does.
+
+```
+External source        Your code           Svelte
+─────────────────      ──────────────      ──────────
+has a value        →   getter reads it  →  component renders it
+fires change event →   ???              →  component re-renders
+```
+
+That `???` is `createSubscriber`. It fills in the missing link: "the external thing changed, Svelte should re-read my getter."
+
+## The Recipe
+
+Every use of `createSubscriber` follows the same three steps:
+
+```typescript
+import { createSubscriber } from 'svelte/reactivity';
+
+// 1. Create the subscriber by telling it how to listen and how to stop
+const subscribe = createSubscriber((update) => {
+	source.addEventListener('change', update);
+	return () => source.removeEventListener('change', update);
+});
+
+// 2. Build a getter that calls subscribe() then reads from the source
+// 3. That's it. No $state needed.
+```
+
+The `update` function is a callback you receive from `createSubscriber`. Call it whenever the external source changes. Svelte will re-read any getter that called `subscribe()`.
+
+The returned function from `start` is cleanup. It runs when no component is reading your getter anymore.
+
+## You Don't Need `$state`
+
+This is the most important thing to internalize. When you use `createSubscriber`, the external source is your state. You don't need to copy it into a `$state` variable and keep it in sync. You read directly from the source every time.
+
+Svelte's own `MediaQuery` class demonstrates this:
+
+```typescript
+class MediaQuery {
+	#query;
+	#subscribe;
+
+	constructor(query) {
+		this.#query = window.matchMedia(query);
+
+		this.#subscribe = createSubscriber((update) => {
+			this.#query.addEventListener('change', update);
+			return () => this.#query.removeEventListener('change', update);
+		});
+	}
+
+	get current() {
+		this.#subscribe();
+		return this.#query.matches; // Read directly. No copy. No $state.
+	}
+}
+```
+
+`this.#query.matches` is the value. It lives on the `MediaQueryList` object, managed by the browser. The getter reads it fresh every time a component needs it. `createSubscriber` just tells Svelte when "every time" should happen: whenever the `change` event fires.
+
+There is no `let matches = $state(false)` being kept in sync. No shadow copy that could drift. The source of truth is the source.
+
+## When to Reach for It
+
+The pattern fits whenever you're adopting an existing subscription API into Svelte's reactive graph. The external system already does the hard work of tracking changes and notifying listeners. You're just connecting that notification channel to Svelte's re-render cycle.
+
+Concrete examples of things that already have their own change notification:
+
+| External Source         | Notification Mechanism                 |
+| ----------------------- | -------------------------------------- |
+| `window.matchMedia`     | `change` event                         |
+| `IntersectionObserver`  | callback on observe                    |
+| `BroadcastChannel`      | `message` event                        |
+| `EventSource` (SSE)     | `message` event                        |
+| Yjs Y.Map / Y.Array     | `.observe()` callback                  |
+| Firebase Realtime DB    | `.on('value')`                         |
+| Svelte 4 stores         | `.subscribe()`                         |
+| IndexedDB (via wrapper) | transaction callbacks                  |
+| `navigator.connection`  | `change` event on `NetworkInformation` |
+
+All of these already know when their data changes. They just don't speak Svelte. `createSubscriber` is the translator.
+
+## Wrapping a BroadcastChannel
+
+A `BroadcastChannel` lets browser tabs communicate. It has a `message` event. Wrapping it:
+
+```typescript
+// cross-tab-state.svelte.ts
+import { createSubscriber } from 'svelte/reactivity';
+
+export function crossTabValue<T>(channelName: string, initial: T) {
+	const channel = new BroadcastChannel(channelName);
+	let latest = initial;
+
+	const subscribe = createSubscriber((update) => {
+		const onMessage = (e: MessageEvent<T>) => {
+			latest = e.data;
+			update();
+		};
+		channel.addEventListener('message', onMessage);
+		return () => channel.removeEventListener('message', onMessage);
+	});
+
+	return {
+		get current() {
+			subscribe();
+			return latest;
+		},
+		send(value: T) {
+			latest = value;
+			channel.postMessage(value);
+		},
+	};
+}
+```
+
+```svelte
+<script>
+	import { crossTabValue } from './cross-tab-state.svelte';
+	const theme = crossTabValue('theme', 'light');
+</script>
+
+<p>Theme: {theme.current}</p>
+<button onclick={() => theme.send('dark')}>Switch to dark</button>
+```
+
+Here `latest` is a plain `let`, not `$state`. It holds the most recent message. The getter reads it, `subscribe()` tells Svelte when to re-read. When another tab sends a message, the `message` event fires, `latest` updates, `update()` tells Svelte, the component re-renders.
+
+## Wrapping an IntersectionObserver
+
+An `IntersectionObserver` fires a callback when an element enters or leaves the viewport:
+
+```typescript
+// visible.svelte.ts
+import { createSubscriber } from 'svelte/reactivity';
+
+export function trackVisibility(element: Element) {
+	let isVisible = false;
+
+	const subscribe = createSubscriber((update) => {
+		const observer = new IntersectionObserver(([entry]) => {
+			isVisible = entry.isIntersecting;
+			update();
+		});
+		observer.observe(element);
+		return () => observer.disconnect();
+	});
+
+	return {
+		get visible() {
+			subscribe();
+			return isVisible;
+		},
+	};
+}
+```
+
+Same recipe. Plain `let` for the value, `createSubscriber` for the bridge, getter that calls `subscribe()`.
+
+## The Getter Is Everything
+
+The getter is where the contract lives. Three things must happen inside it, in this order:
+
+```typescript
+get value() {
+  this.#subscribe();     // 1. Tell Svelte to track this read
+  return this.#source;   // 2. Return the current value from the external source
+}
+```
+
+If you forget `subscribe()`, Svelte reads the value once and never again. If you put `subscribe()` outside the getter (in the constructor, in a method), it runs outside a reactive context and silently does nothing—`effect_tracking()` returns `false`, so `subscribe()` becomes a no-op.
+
+The getter runs during render, which is a reactive context. That's why it works there and nowhere else.
+
+## When You DO Need `$state`
+
+Sometimes the external notification doesn't carry the new value. It just says "something changed, go check." If checking is expensive, you might want to cache the result:
+
+```typescript
+export function reactiveQuery(db: Database, sql: string) {
+	let cached = $state(db.execute(sql)); // expensive query, cache result
+
+	const subscribe = createSubscriber((update) => {
+		return db.onTableChange(() => {
+			cached = db.execute(sql); // re-query only when notified
+			update();
+		});
+	});
+
+	return {
+		get rows() {
+			subscribe();
+			return cached;
+		},
+	};
+}
+```
+
+Here `$state` serves a different purpose: caching an expensive computation. The external source (the database) doesn't have a `.getCurrentResult()` you can call cheaply in the getter. So you compute once, store in `$state`, and re-compute only when the change notification fires.
+
+But notice: `$state` is doing caching here, not reactivity. The `update()` call is still what tells Svelte to re-read. `$state` just ensures the re-read returns a fresh cached result rather than re-executing the query on every component render.
+
+## Cleanup Matters
+
+The function you return from `start` runs when the last reactive consumer disappears. If you skip it, your listener leaks:
+
+```typescript
+// Leaky: no cleanup
+const subscribe = createSubscriber((update) => {
+	source.addEventListener('change', update);
+	// Forgot to return cleanup. Listener lives forever.
+});
+
+// Correct: cleanup returned
+const subscribe = createSubscriber((update) => {
+	source.addEventListener('change', update);
+	return () => source.removeEventListener('change', update);
+});
+```
+
+`createSubscriber` manages the lifecycle for you—`start` runs when consumers appear, cleanup runs when they disappear. But it can only call your cleanup if you provide one.
+
+## Summary
+
+`createSubscriber` is an adapter. You have an external system that already has a subscription mechanism. You want Svelte components to react to it. You write a getter that reads from the source, call `subscribe()` at the top, and pass `update` to the external system's change listener. No `$state` required unless you need to cache an expensive computation.
+
+The external source is the state. `createSubscriber` is the notification channel. The getter is the read path. That's the whole thing.
+
+## Further Reading
+
+For a Yjs-specific example with shadow `SvelteMap` state and bidirectional mutations, see [Syncing External State with createSubscriber](./svelte-5-createsubscriber-pattern.md). For the version signal, reference counting, and `render_effect` internals, see [How createSubscriber Works](./how-createsubscriber-works.md). For choosing between `$state` and `createSubscriber` when both could work, see [`$state` vs `createSubscriber`: Who Owns the Reactivity?](./state-vs-createsubscriber-who-owns-reactivity.md).

--- a/packages/epicenter/src/dynamic/index.ts
+++ b/packages/epicenter/src/dynamic/index.ts
@@ -52,6 +52,9 @@ export {
 // Error types
 export type { ExtensionError } from '../shared/errors';
 export { ExtensionErr } from '../shared/errors';
+// ID type and helpers (needed for type assertions with browser converters)
+export type { Id } from '../shared/id';
+export { generateId, Id as createId } from '../shared/id';
 // Lifecycle utilities (re-exported for extension authors)
 export {
 	defineExports,
@@ -72,9 +75,6 @@ export {
 	text,
 } from './schema/fields/factories';
 export { isNullableField } from './schema/fields/helpers';
-// ID type and helpers (needed for type assertions with browser converters)
-export type { Id } from './schema/fields/id';
-export { generateId, Id as createId } from './schema/fields/id';
 // Row and field types
 export type {
 	CellValue,

--- a/packages/epicenter/src/dynamic/schema/fields/types.ts
+++ b/packages/epicenter/src/dynamic/schema/fields/types.ts
@@ -33,8 +33,8 @@
  */
 
 import type { Static, TSchema } from 'typebox';
+import type { Id } from '../../../shared/id';
 import type { DateTimeString } from './datetime';
-import type { Id } from './id';
 
 // ============================================================================
 // Icon Type (Tagged String)

--- a/packages/epicenter/src/dynamic/schema/index.ts
+++ b/packages/epicenter/src/dynamic/schema/index.ts
@@ -1,3 +1,5 @@
+export type { Guid } from '../../shared/id.js';
+export { generateGuid, generateId, Id } from '../../shared/id.js';
 export { standardSchemaToJsonSchema } from '../../shared/standard-schema/to-json-schema.js';
 export type {
 	StandardJSONSchemaV1,
@@ -40,8 +42,6 @@ export {
 	text,
 } from './fields/factories.js';
 export { isNullableField } from './fields/helpers.js';
-export type { Guid } from './fields/id.js';
-export { generateGuid, generateId, Id } from './fields/id.js';
 export {
 	DATE_TIME_STRING_REGEX,
 	ISO_DATETIME_REGEX,

--- a/packages/epicenter/src/dynamic/tables/table-helper.ts
+++ b/packages/epicenter/src/dynamic/tables/table-helper.ts
@@ -31,10 +31,10 @@
 import { Compile } from 'typebox/compile';
 import type { TLocalizedValidationError } from 'typebox/error';
 import type * as Y from 'yjs';
+import { Id } from '../../shared/id.js';
 import { TableKey } from '../../shared/ydoc-keys';
 import type { Field, PartialRow, Row, TableDefinition } from '../schema';
 import { fieldsToTypebox } from '../schema';
-import { Id } from '../schema/fields/id.js';
 import { createCellStore } from './y-cell-store.js';
 import { createRowStore } from './y-row-store.js';
 

--- a/packages/epicenter/src/filesystem/types.ts
+++ b/packages/epicenter/src/filesystem/types.ts
@@ -1,7 +1,7 @@
 import { type } from 'arktype';
 import type { Brand } from 'wellcrafted/brand';
 import type * as Y from 'yjs';
-import { type Guid, generateGuid } from '../dynamic/schema/fields/id.js';
+import { type Guid, generateGuid } from '../shared/id.js';
 
 /**
  * Timeline entry shapes — a discriminated union on 'type'.

--- a/packages/epicenter/src/shared/id.ts
+++ b/packages/epicenter/src/shared/id.ts
@@ -12,6 +12,9 @@ import type { Brand } from 'wellcrafted/brand';
 
 const ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789';
 
+const nanoid10 = customAlphabet(ALPHABET, 10);
+const nanoid15 = customAlphabet(ALPHABET, 15);
+
 /**
  * ID type - branded string for table row identifiers.
  *
@@ -58,8 +61,7 @@ export function Id(value: string): Id {
  * ```
  */
 export function generateId(): Id {
-	const nanoid = customAlphabet(ALPHABET, 10);
-	return nanoid() as Id;
+	return nanoid10() as Id;
 }
 
 /**
@@ -85,6 +87,5 @@ export type Guid = string & Brand<'Guid'>;
  * ```
  */
 export function generateGuid(): Guid {
-	const nanoid = customAlphabet(ALPHABET, 15);
-	return nanoid() as Guid;
+	return nanoid15() as Guid;
 }


### PR DESCRIPTION
`createPersistedState` was using both `$state` and `createSubscriber`, but `$state` already handles reactivity when event listeners mutate the value directly. The `createSubscriber` was doing two things, both unnecessary:

The `update()` calls were redundant — `value = parseValueFromStorage(...)` mutates `$state`, which already triggers re-renders. Actually slightly worse than redundant: if another tab writes the same value, `$state` correctly skips the re-render (value unchanged), but `update()` forces one anyway.

The lazy lifecycle for the listeners solved a problem that doesn't exist. `addEventListener('storage')` and `addEventListener('focus')` are cheap browser events, always wanted while the app is running. The lazy attach/detach from `createSubscriber` adds complexity for zero benefit.

```typescript
// BEFORE: createSubscriber wrapping $state (Pattern D where Pattern A suffices)
const subscribe = createSubscriber((update) => {
    const storage = on(window, 'storage', (e) => {
        value = parseValueFromStorage(e.newValue);
        update(); // redundant — $state already triggers
    });
    const focus = on(window, 'focus', () => {
        value = parseValueFromStorage(window.localStorage.getItem(key));
        update(); // redundant — $state already triggers
    });
    return () => { storage(); focus(); };
});

// AFTER: just $state + addEventListener
window.addEventListener('storage', (e) => {
    if (e.key !== key) return;
    value = parseValueFromStorage(e.newValue);
});
window.addEventListener('focus', () => {
    value = parseValueFromStorage(window.localStorage.getItem(key));
});
```

Removes the `createSubscriber` and `on` (from `svelte/events`) imports entirely.