### PR TITLE
refactor: replace .withExtensions(map) with chainable .withExtension(key, factory), restore directly callable actions (no `.handler()` required)

### DIFF
--- a/apps/epicenter/src/lib/yjs/workspace-persistence.ts
+++ b/apps/epicenter/src/lib/yjs/workspace-persistence.ts
@@ -61,25 +61,23 @@ const FILE_NAMES = {
  * @example
  * ```typescript
  * const client = createWorkspace(definition)
- *   .withExtensions({
- *     persistence: (ctx) => workspacePersistence(ctx),
- *   });
+ *   .withExtension('persistence', (ctx) => workspacePersistence(ctx));
  * ```
  */
 export function workspacePersistence(
 	ctx: ExtensionContext,
 	config: WorkspacePersistenceConfig = {},
 ): Lifecycle {
-	const { ydoc, workspaceId, kv } = ctx;
+	const { ydoc, id, kv } = ctx;
 	const { jsonDebounceMs = 500 } = config;
 
 	// For logging
-	const logPath = `workspaces/${workspaceId}`;
+	const logPath = `workspaces/${id}`;
 
 	// Resolve paths once, cache the promise
 	const pathsPromise = (async () => {
 		const baseDir = await appLocalDataDir();
-		const workspaceDir = await join(baseDir, 'workspaces', workspaceId);
+		const workspaceDir = await join(baseDir, 'workspaces', id);
 		const workspaceYjsPath = await join(workspaceDir, FILE_NAMES.WORKSPACE_YJS);
 		const kvJsonPath = await join(workspaceDir, FILE_NAMES.KV_JSON);
 
@@ -122,7 +120,7 @@ export function workspacePersistence(
 			const kvData = kv.toJSON();
 			const json = JSON.stringify(kvData, null, '\t');
 			await writeFile(kvJsonPath, new TextEncoder().encode(json));
-			console.log(`[WorkspacePersistence] Saved kv.json for ${workspaceId}`);
+			console.log(`[WorkspacePersistence] Saved kv.json for ${id}`);
 		} catch (error) {
 			console.error(`[WorkspacePersistence] Failed to save kv.json:`, error);
 		}

--- a/apps/epicenter/src/lib/yjs/workspace.ts
+++ b/apps/epicenter/src/lib/yjs/workspace.ts
@@ -11,7 +11,7 @@ import { workspacePersistence } from './workspace-persistence';
  * @returns A workspace client with persistence pre-configured
  */
 export function createWorkspaceClient(definition: WorkspaceDefinition) {
-	return createWorkspace(definition).withExtensions({
-		persistence: (ctx) => workspacePersistence(ctx),
-	});
+	return createWorkspace(definition).withExtension('persistence', (ctx) =>
+		workspacePersistence(ctx),
+	);
 }

--- a/apps/tab-manager/src/entrypoints/background.ts
+++ b/apps/tab-manager/src/entrypoints/background.ts
@@ -115,7 +115,8 @@ export default defineBackground(() => {
 	// Create Workspace Client with Extensions
 	// ─────────────────────────────────────────────────────────────────────────
 
-	const client = createWorkspace(definition).withExtensions({
+	const client = createWorkspace(definition).withExtension(
+		'sync',
 		/**
 		 * Y-Sweet sync with IndexedDB persistence.
 		 *
@@ -126,11 +127,11 @@ export default defineBackground(() => {
 		 * Server setup: npx y-sweet@latest serve
 		 * Default: http://127.0.0.1:8080
 		 */
-		sync: ySweetPersistSync({
+		ySweetPersistSync({
 			auth: directAuth('http://127.0.0.1:8080'),
 			persistence: indexeddbPersistence,
 		}),
-	});
+	);
 
 	// ─────────────────────────────────────────────────────────────────────────
 	// Action Helpers (extracted from workspace definition)

--- a/apps/tab-manager/src/lib/workspace-popup.ts
+++ b/apps/tab-manager/src/lib/workspace-popup.ts
@@ -25,9 +25,10 @@ import { definition } from '$lib/workspace';
  * Shares the same Y.Doc as the background service worker via IndexedDB
  * persistence and Y-Sweet sync.
  */
-export const popupWorkspace = createWorkspace(definition).withExtensions({
-	sync: ySweetPersistSync({
+export const popupWorkspace = createWorkspace(definition).withExtension(
+	'sync',
+	ySweetPersistSync({
 		auth: directAuth('http://127.0.0.1:8080'),
 		persistence: indexeddbPersistence,
 	}),
-});
+);

--- a/docs/articles/remove-default-generics-for-pass-through-types.md
+++ b/docs/articles/remove-default-generics-for-pass-through-types.md
@@ -121,11 +121,9 @@ const workspace = defineWorkspace({
 });
 
 // Extension receives context with those schemas
-createWorkspace(workspace).withExtensions({
-	// The extension MUST receive the full schema types
-	// Defaults would silently lose type information
-	sqlite: (ctx) => sqlite(ctx, config),
-});
+createWorkspace(workspace).withExtension('sqlite', (ctx) =>
+	sqlite(ctx, config),
+);
 ```
 
 Without defaults on `ExtensionContext`, TypeScript ensures every extension properly declares and passes through both `TTableDefinitionMap` and `TKvSchema`.

--- a/docs/articles/types-should-be-computed-not-declared.md
+++ b/docs/articles/types-should-be-computed-not-declared.md
@@ -59,9 +59,7 @@ const definition = defineWorkspace({
 	id: 'tab-manager',
 	tables: BROWSER_TABLES,
 });
-export const popupWorkspace = createWorkspace(definition).withExtensions({
-	/* ... */
-});
+export const popupWorkspace = createWorkspace(definition);
 ```
 
 And `background.ts` had its own `defineWorkspace({ id: 'tab-manager', tables: BROWSER_TABLES })` call. Same definition, duplicated because the "schema" was in one place and the "workspace" was in another.

--- a/packages/epicenter/README.md
+++ b/packages/epicenter/README.md
@@ -105,7 +105,7 @@ Yjs supports multiple providers simultaneously. Phone can connect to desktop, la
 1. **Define workspace** with `defineWorkspace({ id, tables, kv })`
 2. **Create client builder** with `createClient(workspace.id)`
 3. **Chain definition** with `.withDefinition(workspace)`
-4. **Attach extensions** with `.withExtensions({ persistence, sqlite })`
+4. **Attach extensions** with `.withExtension('persistence', setupPersistence).withExtension('sqlite', sqliteProvider)`
 5. **Y.Doc created** with workspace ID + epoch as GUID
 6. **Extensions initialize** in parallel (persistence, SQLite, markdown, sync)
 7. **Tables API** wraps Y.Doc with type-safe CRUD
@@ -174,14 +174,9 @@ const blogWorkspace = defineWorkspace({
 // 2. Initialize the workspace client
 const client = createClient(blogWorkspace.id)
 	.withDefinition(blogWorkspace)
-	.withExtensions({
-		// Optional: Add YJS persistence (IndexedDB in browser, filesystem in Node.js)
-		persistence: setupPersistence,
-		// Optional: Add SQLite for SQL queries
-		sqlite: (c) => sqliteProvider(c),
-		// Optional: Add markdown for file-based persistence
-		markdown: (c) => markdownProvider(c),
-	});
+	.withExtension('persistence', setupPersistence)
+	.withExtension('sqlite', (c) => sqliteProvider(c))
+	.withExtension('markdown', (c) => markdownProvider(c));
 
 // 3. Define actions (exposed via REST/MCP)
 const blogActions = {
@@ -291,11 +286,9 @@ Extensions add capabilities to your workspace, such as persistence, sync, and ma
 ```typescript
 const client = createClient(definition.id)
 	.withDefinition(definition)
-	.withExtensions({
-		persistence: setupPersistence, // YJS persistence
-		sqlite: (c) => sqliteProvider(c), // SQL queries via Drizzle ORM
-		markdown: (c) => markdownProvider(c), // File-based persistence
-	});
+	.withExtension('persistence', setupPersistence) // YJS persistence
+	.withExtension('sqlite', (c) => sqliteProvider(c)) // SQL queries via Drizzle ORM
+	.withExtension('markdown', (c) => markdownProvider(c)); // File-based persistence
 ```
 
 Materializer extensions (sqlite, markdown) automatically sync with YJS:
@@ -321,15 +314,14 @@ Extension factory functions receive a context object with `{ id, extensionId, yd
 ```typescript
 const client = createClient(definition.id)
 	.withDefinition(definition)
-	.withExtensions({
-		persistence: setupPersistence,
-		sqlite: (c) => sqliteProvider(c),
-
-		// WebSocket sync (y-websocket protocol)
-		sync: createWebsocketSyncProvider({
+	.withExtension('persistence', setupPersistence)
+	.withExtension('sqlite', (c) => sqliteProvider(c))
+	.withExtension(
+		'sync',
+		createWebsocketSyncProvider({
 			url: 'ws://localhost:3913/sync',
 		}),
-	});
+	);
 ```
 
 ### Actions
@@ -725,9 +717,7 @@ import { createClient, sqliteProvider } from '@epicenter/hq';
 
 const client = createClient(definition.id)
 	.withDefinition(definition)
-	.withExtensions({
-		sqlite: (c) => sqliteProvider(c),
-	});
+	.withExtension('sqlite', (c) => sqliteProvider(c));
 ```
 
 **Storage:**
@@ -803,26 +793,25 @@ import { createClient, markdownProvider } from '@epicenter/hq';
 
 const client = createClient(definition.id)
 	.withDefinition(definition)
-	.withExtensions({
-		markdown: (c) =>
-			markdownProvider(c, {
-				directory: './data', // Optional: workspace-level directory
-				tableConfigs: {
-					posts: {
-						directory: './posts', // Optional: per-table directory
-						serialize: ({ row }) => ({
-							frontmatter: { title: row.title, published: row.published },
-							body: row.content,
-							filename: `${row.id}.md`,
-						}),
-						deserialize: ({ frontmatter, body, filename }) => {
-							const id = basename(filename, '.md');
-							return Ok({ id, content: body, ...frontmatter });
-						},
+	.withExtension('markdown', (c) =>
+		markdownProvider(c, {
+			directory: './data', // Optional: workspace-level directory
+			tableConfigs: {
+				posts: {
+					directory: './posts', // Optional: per-table directory
+					serialize: ({ row }) => ({
+						frontmatter: { title: row.title, published: row.published },
+						body: row.content,
+						filename: `${row.id}.md`,
+					}),
+					deserialize: ({ frontmatter, body, filename }) => {
+						const id = basename(filename, '.md');
+						return Ok({ id, content: body, ...frontmatter });
 					},
 				},
-			}),
-	});
+			},
+		}),
+	);
 ```
 
 **Storage:**
@@ -903,11 +892,12 @@ import { createWebsocketSyncProvider } from '@epicenter/hq/extensions/websocket-
 
 const client = createClient(definition.id)
 	.withDefinition(definition)
-	.withExtensions({
-		sync: createWebsocketSyncProvider({
+	.withExtension(
+		'sync',
+		createWebsocketSyncProvider({
 			url: 'ws://localhost:3913/sync',
 		}),
-	});
+	);
 ```
 
 **Server-side sync endpoint:**
@@ -974,11 +964,18 @@ export const SYNC_NODES = {
 // Phone connects to ALL available sync nodes
 const client = createClient(definition.id)
 	.withDefinition(definition)
-	.withExtensions({
-		syncDesktop: createWebsocketSyncProvider({ url: SYNC_NODES.desktop }),
-		syncLaptop: createWebsocketSyncProvider({ url: SYNC_NODES.laptop }),
-		syncCloud: createWebsocketSyncProvider({ url: SYNC_NODES.cloud }),
-	});
+	.withExtension(
+		'syncDesktop',
+		createWebsocketSyncProvider({ url: SYNC_NODES.desktop }),
+	)
+	.withExtension(
+		'syncLaptop',
+		createWebsocketSyncProvider({ url: SYNC_NODES.laptop }),
+	)
+	.withExtension(
+		'syncCloud',
+		createWebsocketSyncProvider({ url: SYNC_NODES.cloud }),
+	);
 ```
 
 **Server-to-server sync:**
@@ -987,10 +984,14 @@ const client = createClient(definition.id)
 // Desktop server connects to OTHER servers (not itself!)
 const client = createClient(definition.id)
 	.withDefinition(definition)
-	.withExtensions({
-		syncToLaptop: createWebsocketSyncProvider({ url: SYNC_NODES.laptop }),
-		syncToCloud: createWebsocketSyncProvider({ url: SYNC_NODES.cloud }),
-	});
+	.withExtension(
+		'syncToLaptop',
+		createWebsocketSyncProvider({ url: SYNC_NODES.laptop }),
+	)
+	.withExtension(
+		'syncToCloud',
+		createWebsocketSyncProvider({ url: SYNC_NODES.cloud }),
+	);
 ```
 
 Yjs supports multiple providers simultaneously. Changes merge automatically via CRDTs regardless of which provider delivers them first.
@@ -1253,7 +1254,7 @@ Create a workspace client using the builder pattern:
 // Create a client with extensions
 const blogClient = createClient(blogWorkspace.id)
 	.withDefinition(blogWorkspace)
-	.withExtensions({ sqlite: sqliteProvider });
+	.withExtension('sqlite', sqliteProvider);
 
 // Direct table access
 const posts = blogClient.tables.get('posts').getAllValid();
@@ -1265,7 +1266,7 @@ await blogClient.destroy();
 {
 	await using client = createClient(blogWorkspace.id)
 		.withDefinition(blogWorkspace)
-		.withExtensions({ sqlite: sqliteProvider });
+		.withExtension('sqlite', sqliteProvider);
 
 	client.tables.get('posts').upsert({ id: '1', title: 'Hello' });
 }
@@ -1277,7 +1278,7 @@ await blogClient.destroy();
 
 ### Client Initialization Lifecycle
 
-When you call `.withExtensions()`, here's what happens:
+When you call `.withExtension()`, here's what happens:
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -1405,7 +1406,7 @@ Create a client directly for standalone scripts. Use `await using` for automatic
 {
 	await using client = createClient(blogWorkspace.id)
 		.withDefinition(blogWorkspace)
-		.withExtensions({ sqlite: sqliteProvider });
+		.withExtension('sqlite', sqliteProvider);
 
 	client.tables.get('posts').upsert({ id: '1', title: 'Hello' });
 	// Automatic cleanup when block exits
@@ -1423,7 +1424,7 @@ import { createClient, createServer } from '@epicenter/hq';
 
 const client = createClient(blogWorkspace.id)
   .withDefinition(blogWorkspace)
-  .withExtensions({ sqlite: sqliteProvider });
+  .withExtension('sqlite', sqliteProvider);
 
 // Expose the client and custom actions via HTTP
 const server = createServer(client, {
@@ -1471,7 +1472,7 @@ const blogWorkspace = defineWorkspace({
 // Create client with extensions
 const client = createClient(blogWorkspace.id)
 	.withDefinition(blogWorkspace)
-	.withExtensions({ sqlite: sqliteProvider });
+	.withExtension('sqlite', sqliteProvider);
 
 // Use tables directly
 const id = generateId();
@@ -1780,11 +1781,11 @@ import { createClient, createServer } from '@epicenter/hq';
 // Create clients with extensions
 const blogClient = createClient(blogWorkspace.id)
 	.withDefinition(blogWorkspace)
-	.withExtensions({ sqlite: sqliteProvider });
+	.withExtension('sqlite', sqliteProvider);
 
 const authClient = createClient(authWorkspace.id)
 	.withDefinition(authWorkspace)
-	.withExtensions({ sqlite: sqliteProvider });
+	.withExtension('sqlite', sqliteProvider);
 
 // Create and start server
 const server = createServer([blogClient, authClient], { port: 3913 });

--- a/packages/epicenter/README.md
+++ b/packages/epicenter/README.md
@@ -309,7 +309,7 @@ const queryPosts = defineQuery({
 });
 ```
 
-Extension factory functions receive a context object with `{ id, extensionId, ydoc, tables, kv }` and can return exports. For example, sync extensions:
+Extension factory functions receive a context object with `{ id, ydoc, tables, kv, extensions }` (the "client-so-far") and can return exports. Each factory receives typed access to all previously added extensions. For example, sync extensions:
 
 ```typescript
 const client = createClient(definition.id)

--- a/packages/epicenter/src/cli/command-builder.ts
+++ b/packages/epicenter/src/cli/command-builder.ts
@@ -49,7 +49,6 @@ export function buildActionCommands(actions: Actions): CommandModule[] {
 			builder,
 			handler: async (argv: Record<string, unknown>) => {
 				const input = extractInputFromArgv(argv, jsonSchema);
-				let validatedInput: unknown;
 
 				if (action.input) {
 					const result = await action.input['~standard'].validate(input);
@@ -62,13 +61,12 @@ export function buildActionCommands(actions: Actions): CommandModule[] {
 						}
 						process.exit(1);
 					}
-					validatedInput = result.value;
+					const output = await action(result.value);
+					console.log(JSON.stringify(output, null, 2));
+				} else {
+					const output = await action();
+					console.log(JSON.stringify(output, null, 2));
 				}
-
-				const output = action.input
-					? await action.handler(validatedInput)
-					: await (action.handler as () => unknown)();
-				console.log(JSON.stringify(output, null, 2));
 			},
 		};
 	});

--- a/packages/epicenter/src/dynamic/YDOC-ARCHITECTURE.md
+++ b/packages/epicenter/src/dynamic/YDOC-ARCHITECTURE.md
@@ -227,7 +227,8 @@ const definition = defineWorkspace({
 
 const client = createClient(definition.id, { epoch })
 	.withDefinition(definition)
-	.withExtensions({ sqlite, persistence });
+	.withExtension('sqlite', sqlite)
+	.withExtension('persistence', persistence);
 
 // Now you have a fully typed client
 await client.whenSynced;
@@ -246,7 +247,7 @@ They're different Y.Docs with different GUIDs. You can't "upgrade" a Y.Doc in pl
 
 The Head Doc is the **stable pointer**. Its GUID never changes (`abc123`), but its `epoch` value can change. When you bump epochs:
 
-1. Create new client at epoch 3: `createClient(definition.id, { epoch: 3 }).withDefinition(definition).withExtensions({})`
+1. Create new client at epoch 3: `createClient(definition.id, { epoch: 3 }).withDefinition(definition)`
 2. Migrate data from old client to new client
 3. Bump Head Doc: `head.bumpEpoch()`
 4. All clients observing Head reconnect to the new Workspace Doc
@@ -293,9 +294,7 @@ const definition = defineWorkspace({
 });
 
 // createClient() uses definition for type safety but doesn't store it in Y.Doc
-const client = createClient(definition.id)
-	.withDefinition(definition)
-	.withExtensions({});
+const client = createClient(definition.id).withDefinition(definition);
 ```
 
 **Why static definitions?**
@@ -336,7 +335,7 @@ const definition = defineWorkspace({
 // Epoch defaults to 0
 const client = createClient(definition.id)
 	.withDefinition(definition)
-	.withExtensions({ sqlite });
+	.withExtension('sqlite', sqlite);
 ```
 
 ## Files
@@ -421,9 +420,9 @@ const definition = defineWorkspace({
 	kv: {},
 });
 
-const client = createClient(definition.id, { epoch })
-	.withDefinition(definition)
-	.withExtensions({});
+const client = createClient(definition.id, { epoch }).withDefinition(
+	definition,
+);
 // client.ydoc is the Workspace Doc at guid "workspace456-0"
 ```
 

--- a/packages/epicenter/src/dynamic/extension.ts
+++ b/packages/epicenter/src/dynamic/extension.ts
@@ -10,8 +10,8 @@
  *   (Head Doc, Registry Doc). Receive minimal context: `{ ydoc }`.
  *
  * - **Extensions** (workspace-level): Plugins that extend workspaces with features
- *   like SQLite queries, Markdown sync, revision history. Receive flattened context
- *   with all workspace data plus extensionId.
+ *   like SQLite queries, Markdown sync, revision history. Receive the client-so-far
+ *   as context, including previously added extensions.
  *
  * Use `defineExports()` to wrap your extension's return value for lifecycle normalization.
  */
@@ -34,6 +34,4 @@ export type ExtensionExports<
 export type {
 	ExtensionContext,
 	ExtensionFactory,
-	ExtensionFactoryMap,
-	InferExtensionExports,
 } from './workspace/types';

--- a/packages/epicenter/src/dynamic/index.ts
+++ b/packages/epicenter/src/dynamic/index.ts
@@ -27,8 +27,6 @@ export { createWorkspace } from './workspace/create-workspace';
 export type {
 	ExtensionContext,
 	ExtensionFactory,
-	ExtensionFactoryMap,
-	InferExtensionExports,
 	WorkspaceClient,
 	WorkspaceClientBuilder,
 } from './workspace/types';

--- a/packages/epicenter/src/dynamic/workspace/README.md
+++ b/packages/epicenter/src/dynamic/workspace/README.md
@@ -28,9 +28,10 @@ const definition = defineWorkspace({
 	kv: [],
 });
 
-const workspace = createWorkspace(definition).withExtensions({
-	persistence: (ctx) => myPersistence(ctx),
-});
+const workspace = createWorkspace(definition).withExtension(
+	'persistence',
+	(ctx) => myPersistence(ctx),
+);
 
 await workspace.whenSynced;
 workspace.tables.get('posts').upsert({ id: '1', title: 'Hello' });
@@ -64,10 +65,9 @@ const definition = defineWorkspace({
 Creates a workspace from a definition. Returns a builder for adding extensions.
 
 ```typescript
-const workspace = createWorkspace(definition).withExtensions({
-	sqlite: (ctx) => sqliteExtension(ctx),
-	persistence: (ctx) => persistenceExtension(ctx),
-});
+const workspace = createWorkspace(definition)
+	.withExtension('sqlite', (ctx) => sqliteExtension(ctx))
+	.withExtension('persistence', (ctx) => persistenceExtension(ctx));
 ```
 
 **Key details:**
@@ -110,7 +110,7 @@ await using workspace = ...;      // Auto-cleanup with dispose
 ### Basic CRUD
 
 ```typescript
-const workspace = createWorkspace(definition).withExtensions({});
+const workspace = createWorkspace(definition);
 
 // Create
 workspace.tables
@@ -132,11 +132,9 @@ workspace.tables.get('posts').delete({ id: '1' });
 
 ```typescript
 const workspace = createWorkspace(definition)
-  .withExtensions({
-    persistence: (ctx) => {
-      // Load from storage, sync changes back
-      return { save: () => {...}, load: () => {...} };
-    },
+  .withExtension('persistence', (ctx) => {
+    // Load from storage, sync changes back
+    return { save: () => {...}, load: () => {...} };
   });
 
 await workspace.whenSynced;
@@ -146,17 +144,19 @@ await workspace.whenSynced;
 
 ```typescript
 {
-	await using workspace = createWorkspace(definition).withExtensions({
+	await using workspace = createWorkspace(definition).withExtension(
+		'persistence',
 		persistence,
-	});
+	);
 	workspace.tables.get('posts').upsert({ id: '1', title: 'Hello' });
 	// Auto-disposed when block exits
 }
 
 {
-	await using workspace = createWorkspace(definition).withExtensions({
+	await using workspace = createWorkspace(definition).withExtension(
+		'persistence',
 		persistence,
-	});
+	);
 	const posts = workspace.tables.get('posts').getAllValid();
 	// Auto-disposed when block exits
 }

--- a/packages/epicenter/src/dynamic/workspace/README.md
+++ b/packages/epicenter/src/dynamic/workspace/README.md
@@ -77,16 +77,15 @@ const workspace = createWorkspace(definition)
 
 ### Extension Context
 
-Extensions receive an `ExtensionContext` with:
+Extensions receive an `ExtensionContext` — the "client-so-far":
 
 ```typescript
 interface ExtensionContext {
 	ydoc: Y.Doc; // The underlying Y.Doc
 	id: string; // Workspace ID
-	definition: WorkspaceDefinition;
 	tables: Tables; // Table operations
 	kv: KeyValueStore; // Key-value store
-	extensionId: string; // The extension's key name
+	extensions: Record<string, Lifecycle>; // Previously added extensions (typed)
 }
 ```
 

--- a/packages/epicenter/src/dynamic/workspace/node.ts
+++ b/packages/epicenter/src/dynamic/workspace/node.ts
@@ -18,7 +18,8 @@
  * });
  *
  * // Use createWorkspace to create workspace clients
- * const workspace = createWorkspace(definition).withExtensions({ persistence });
+ * const workspace = createWorkspace(definition)
+ *   .withExtension('persistence', (ctx) => persistence(ctx));
  * ```
  *
  * @module

--- a/packages/epicenter/src/dynamic/workspace/workspace.ts
+++ b/packages/epicenter/src/dynamic/workspace/workspace.ts
@@ -31,7 +31,8 @@
  * ```typescript
  * import { createWorkspace } from '@epicenter/hq/dynamic';
  *
- * const workspace = createWorkspace(definition).withExtensions({ persistence });
+ * const workspace = createWorkspace(definition)
+ *   .withExtension('persistence', (ctx) => persistence(ctx));
  * ```
  *
  * ## Related Modules

--- a/packages/epicenter/src/extensions/revision-history/index.ts
+++ b/packages/epicenter/src/extensions/revision-history/index.ts
@@ -10,12 +10,10 @@
  * import { localRevisionHistory } from '@epicenter/hq/extensions/revision-history';
  *
  * const workspace = createWorkspace({ name: 'Blog', tables: {...} })
- *   .withExtensions({
- *     revisions: (ctx) => localRevisionHistory(ctx, {
- *       directory: './workspaces',
- *       maxVersions: 50,
- *     }),
- *   });
+ *   .withExtension('revisions', (ctx) => localRevisionHistory(ctx, {
+ *     directory: './workspaces',
+ *     maxVersions: 50,
+ *   }));
  *
  * // Save manually (bypasses debounce)
  * workspace.extensions.revisions.save('Before refactor');

--- a/packages/epicenter/src/extensions/revision-history/local.ts
+++ b/packages/epicenter/src/extensions/revision-history/local.ts
@@ -72,13 +72,12 @@ export type LocalRevisionHistoryConfig = {
  * import { createWorkspace } from '@epicenter/hq/dynamic';
  * import { localRevisionHistory } from '@epicenter/hq/extensions/revision-history';
  *
- * const workspace = createWorkspace(definition).withExtensions({
- *   persistence,
- *   revisions: (ctx) => localRevisionHistory(ctx, {
+ * const workspace = createWorkspace(definition)
+ *   .withExtension('persistence', () => persistence)
+ *   .withExtension('revisions', (ctx) => localRevisionHistory(ctx, {
  *     directory: './workspaces',
  *     maxVersions: 50,
- *   }),
- * });
+ *   }));
  *
  * // Save a version manually (bypasses debounce)
  * workspace.extensions.revisions.save('Before refactor');
@@ -96,12 +95,11 @@ export type LocalRevisionHistoryConfig = {
  *
  * @example Custom debounce interval
  * ```typescript
- * const workspace = createWorkspace(definition).withExtensions({
- *   revisions: (ctx) => localRevisionHistory(ctx, {
+ * const workspace = createWorkspace(definition)
+ *   .withExtension('revisions', (ctx) => localRevisionHistory(ctx, {
  *     directory: './workspaces',
  *     debounceMs: 5000,  // Save 5 seconds after last change
- *   }),
- * });
+ *   }));
  * ```
  *
  * @example Google Docs-style slider UI

--- a/packages/epicenter/src/extensions/sqlite/sqlite.ts
+++ b/packages/epicenter/src/extensions/sqlite/sqlite.ts
@@ -67,12 +67,10 @@ export type SqliteConfig = {
  * const epicenterDir = join(projectDir, '.epicenter');
  *
  * const workspace = createWorkspace({ name: 'Blog', tables: {...} })
- *   .withExtensions({
- *     sqlite: (ctx) => sqlite(ctx, {
- *       dbPath: join(epicenterDir, 'sqlite', `${ctx.id}.db`),
- *       logsDir: join(epicenterDir, 'sqlite', 'logs'),
- *     }),
- *   });
+ *   .withExtension('sqlite', (ctx) => sqlite(ctx, {
+ *     dbPath: join(epicenterDir, 'sqlite', `${ctx.id}.db`),
+ *     logsDir: join(epicenterDir, 'sqlite', 'logs'),
+ *   }));
  *
  * // Query with Drizzle:
  * const posts = await workspace.extensions.sqlite.db

--- a/packages/epicenter/src/extensions/websocket-sync.ts
+++ b/packages/epicenter/src/extensions/websocket-sync.ts
@@ -1,6 +1,6 @@
 import { WebsocketProvider } from 'y-websocket';
-import type { ExtensionContext } from '../dynamic/extension';
-import { defineExports } from '../dynamic/extension';
+import { defineExports } from '../shared/lifecycle';
+import type { ExtensionContext } from '../static/types';
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // MULTI-DEVICE SYNC ARCHITECTURE

--- a/packages/epicenter/src/extensions/y-sweet-persist-sync.ts
+++ b/packages/epicenter/src/extensions/y-sweet-persist-sync.ts
@@ -1,8 +1,8 @@
 import type { ClientToken } from '@epicenter/y-sweet';
 import { createYjsProvider, type YSweetProvider } from '@epicenter/y-sweet';
 import type * as Y from 'yjs';
-import type { ExtensionFactory } from '../dynamic/extension';
 import type { Lifecycle, MaybePromise } from '../shared/lifecycle';
+import type { ExtensionFactory } from '../static/types';
 
 // Re-export the ClientToken type for consumers
 export type { ClientToken as YSweetClientToken };

--- a/packages/epicenter/src/extensions/y-sweet-persist-sync/desktop.ts
+++ b/packages/epicenter/src/extensions/y-sweet-persist-sync/desktop.ts
@@ -34,11 +34,9 @@ export type PersistenceConfig = {
  * const epicenterDir = join(projectDir, '.epicenter');
  *
  * const workspace = createWorkspace({ name: 'Blog', tables: {...} })
- *   .withExtensions({
- *     persistence: (ctx) => persistence(ctx, {
- *       filePath: join(epicenterDir, 'persistence', `${ctx.id}.yjs`),
- *     }),
- *   });
+ *   .withExtension('persistence', (ctx) => persistence(ctx, {
+ *     filePath: join(epicenterDir, 'persistence', `${ctx.id}.yjs`),
+ *   }));
  * ```
  */
 export const persistence = (

--- a/packages/epicenter/src/extensions/y-sweet-persist-sync/web.ts
+++ b/packages/epicenter/src/extensions/y-sweet-persist-sync/web.ts
@@ -17,17 +17,17 @@ import { defineExports } from '../../dynamic/extension';
  * import { indexeddbPersistence } from '@epicenter/hq/extensions/y-sweet-persist-sync/web';
  *
  * const workspace = createWorkspace({ name: 'Blog', tables: {...} })
- *   .withExtensions({ persistence: indexeddbPersistence });
+ *   .withExtension('persistence', () => indexeddbPersistence);
  * ```
  *
  * @example With Y-Sweet persist sync
  * ```typescript
  * import { indexeddbPersistence } from '@epicenter/hq/extensions/y-sweet-persist-sync/web';
  *
- * sync: ySweetPersistSync({
+ * .withExtension('sync', () => ySweetPersistSync({
  *   auth: directAuth('http://localhost:8080'),
  *   persistence: indexeddbPersistence,
- * })
+ * }))
  * ```
  */
 export function indexeddbPersistence({ ydoc }: { ydoc: Y.Doc }) {

--- a/packages/epicenter/src/server/actions.ts
+++ b/packages/epicenter/src/server/actions.ts
@@ -31,7 +31,6 @@ export function createActionsRouter(options: ActionsRouterOptions) {
 		};
 
 		const handleRequest = async (input: unknown) => {
-			let validatedInput: unknown;
 			if (action.input) {
 				const result = await action.input['~standard'].validate(input);
 				if (result.issues) {
@@ -39,13 +38,10 @@ export function createActionsRouter(options: ActionsRouterOptions) {
 						error: { message: 'Validation failed', issues: result.issues },
 					};
 				}
-				validatedInput = result.value;
-				// Call handler with validated input
-				const output = await action.handler(validatedInput);
+				const output = await action(result.value);
 				return { data: output };
 			}
-			// Call handler with no arguments for actions without input
-			const output = await (action.handler as () => unknown)();
+			const output = await action();
 			return { data: output };
 		};
 

--- a/packages/epicenter/src/server/server.ts
+++ b/packages/epicenter/src/server/server.ts
@@ -25,7 +25,9 @@ export type ServerOptions = {
  * ```typescript
  * import { createWorkspace } from '@epicenter/hq/static';
  *
- * const workspace = createWorkspace(definition).withExtensions({ ... });
+ * const workspace = createWorkspace(definition)
+ *   .withExtension('persistence', (ctx) => setupPersistence(ctx))
+ *   .withExtension('sqlite', (ctx) => sqliteProvider(ctx));
  *
  * const server = createServer(workspace, { port: 3913 });
  * server.start();

--- a/packages/epicenter/src/shared/actions.ts
+++ b/packages/epicenter/src/shared/actions.ts
@@ -293,16 +293,22 @@ export type Actions = {
  * getPost({ id: '1' }); // call directly
  * ```
  */
+/** No input — `TInput` is explicitly `undefined`. */
+export function defineQuery<TOutput = unknown>(
+	config: ActionConfig<undefined, TOutput>,
+): Query<undefined, TOutput>;
+/** With input — `TInput` inferred from the schema. */
 export function defineQuery<
-	TInput extends StandardSchemaWithJSONSchema | undefined = undefined,
+	TInput extends StandardSchemaWithJSONSchema,
 	TOutput = unknown,
->(config: ActionConfig<TInput, TOutput>): Query<TInput, TOutput> {
+>(config: ActionConfig<TInput, TOutput>): Query<TInput, TOutput>;
+export function defineQuery(config: ActionConfig<any, any>): Query<any, any> {
 	const fn = (...args: unknown[]) =>
 		(config.handler as (...args: unknown[]) => unknown)(...args);
 	return Object.assign(fn, {
 		type: 'query' as const,
 		...config,
-	}) as unknown as Query<TInput, TOutput>;
+	}) as unknown as Query<any, any>;
 }
 
 /**
@@ -336,16 +342,24 @@ export function defineQuery<
  * });
  * ```
  */
+/** No input — `TInput` is explicitly `undefined`. */
+export function defineMutation<TOutput = unknown>(
+	config: ActionConfig<undefined, TOutput>,
+): Mutation<undefined, TOutput>;
+/** With input — `TInput` inferred from the schema. */
 export function defineMutation<
-	TInput extends StandardSchemaWithJSONSchema | undefined = undefined,
+	TInput extends StandardSchemaWithJSONSchema,
 	TOutput = unknown,
->(config: ActionConfig<TInput, TOutput>): Mutation<TInput, TOutput> {
+>(config: ActionConfig<TInput, TOutput>): Mutation<TInput, TOutput>;
+export function defineMutation(
+	config: ActionConfig<any, any>,
+): Mutation<any, any> {
 	const fn = (...args: unknown[]) =>
 		(config.handler as (...args: unknown[]) => unknown)(...args);
 	return Object.assign(fn, {
 		type: 'mutation' as const,
 		...config,
-	}) as unknown as Mutation<TInput, TOutput>;
+	}) as unknown as Mutation<any, any>;
 }
 
 /**

--- a/packages/epicenter/src/shared/actions.ts
+++ b/packages/epicenter/src/shared/actions.ts
@@ -289,14 +289,15 @@ export function defineQuery<
 	TInput extends StandardSchemaWithJSONSchema,
 	TOutput = unknown,
 >(config: ActionConfig<TInput, TOutput>): Query<TInput, TOutput>;
-export function defineQuery(config: ActionConfig<any, any>): Query<any, any> {
+export function defineQuery({
+	handler,
+	...rest
+}: ActionConfig<any, any>): Query<any, any> {
 	const fn = (...args: unknown[]) =>
-		(config.handler as (...args: unknown[]) => unknown)(...args);
+		(handler as (...args: unknown[]) => unknown)(...args);
 	return Object.assign(fn, {
 		type: 'query' as const,
-		description: config.description,
-		input: config.input,
-		output: config.output,
+		...rest,
 	}) as unknown as Query<any, any>;
 }
 
@@ -340,16 +341,15 @@ export function defineMutation<
 	TInput extends StandardSchemaWithJSONSchema,
 	TOutput = unknown,
 >(config: ActionConfig<TInput, TOutput>): Mutation<TInput, TOutput>;
-export function defineMutation(
-	config: ActionConfig<any, any>,
-): Mutation<any, any> {
+export function defineMutation({
+	handler,
+	...rest
+}: ActionConfig<any, any>): Mutation<any, any> {
 	const fn = (...args: unknown[]) =>
-		(config.handler as (...args: unknown[]) => unknown)(...args);
+		(handler as (...args: unknown[]) => unknown)(...args);
 	return Object.assign(fn, {
 		type: 'mutation' as const,
-		description: config.description,
-		input: config.input,
-		output: config.output,
+		...rest,
 	}) as unknown as Mutation<any, any>;
 }
 

--- a/packages/epicenter/src/shared/actions.ts
+++ b/packages/epicenter/src/shared/actions.ts
@@ -74,15 +74,22 @@ import type {
 /**
  * The handler function type, conditional on whether input is provided.
  *
+ * Uses variadic tuple args instead of conditional function signatures so that
+ * when the type flows through `Action<any, any>` (via the `Actions` constraint),
+ * `any` distributes over both branches giving `[input: any] | []` — which
+ * correctly allows calling with 0 arguments for no-input actions.
+ *
  * When `TInput` extends `StandardSchemaWithJSONSchema`, the handler takes validated input.
  * When `TInput` is `undefined`, the handler takes no arguments.
  */
 type ActionHandler<
 	TInput extends StandardSchemaWithJSONSchema | undefined = undefined,
 	TOutput = unknown,
-> = TInput extends StandardSchemaWithJSONSchema
-	? (input: StandardSchemaV1.InferOutput<TInput>) => TOutput | Promise<TOutput>
-	: () => TOutput | Promise<TOutput>;
+> = (
+	...args: TInput extends StandardSchemaWithJSONSchema
+		? [input: StandardSchemaV1.InferOutput<TInput>]
+		: []
+) => TOutput | Promise<TOutput>;
 
 /**
  * Configuration for defining an action (query or mutation).

--- a/packages/epicenter/src/shared/actions.ts
+++ b/packages/epicenter/src/shared/actions.ts
@@ -293,9 +293,7 @@ export function defineQuery({
 	handler,
 	...rest
 }: ActionConfig<any, any>): Query<any, any> {
-	const fn = (...args: unknown[]) =>
-		(handler as (...args: unknown[]) => unknown)(...args);
-	return Object.assign(fn, {
+	return Object.assign(handler, {
 		type: 'query' as const,
 		...rest,
 	}) as unknown as Query<any, any>;
@@ -345,9 +343,7 @@ export function defineMutation({
 	handler,
 	...rest
 }: ActionConfig<any, any>): Mutation<any, any> {
-	const fn = (...args: unknown[]) =>
-		(handler as (...args: unknown[]) => unknown)(...args);
-	return Object.assign(fn, {
+	return Object.assign(handler, {
 		type: 'mutation' as const,
 		...rest,
 	}) as unknown as Mutation<any, any>;

--- a/packages/epicenter/src/static/README.md
+++ b/packages/epicenter/src/static/README.md
@@ -52,16 +52,16 @@ For most apps, just call `workspace.create()` and you're done. It's synchronous,
 When you need extensibility (persistence, sync, databases) without baking it into the core:
 
 ```typescript
-const client = createWorkspace({ id: 'my-app', tables: { posts } })
-	.withExtensions({
-		persistence: ({ ydoc }) => {
-			const provider = new IndexeddbPersistence(ydoc.guid, ydoc);
-			return defineExports({
-				provider,
-				destroy: () => provider.destroy(),
-			});
-		},
+const client = createWorkspace({
+	id: 'my-app',
+	tables: { posts },
+}).withExtension('persistence', ({ ydoc }) => {
+	const provider = new IndexeddbPersistence(ydoc.guid, ydoc);
+	return defineExports({
+		provider,
+		destroy: () => provider.destroy(),
 	});
+});
 
 await client.extensions.persistence.whenSynced;
 client.tables.posts.set({ id: '1', title: 'Hello' });

--- a/packages/epicenter/src/static/define-workspace.test.ts
+++ b/packages/epicenter/src/static/define-workspace.test.ts
@@ -295,10 +295,6 @@ describe('defineWorkspace', () => {
 		expect(client.actions.getAnalyticsCount()).toBe(5);
 		client.actions.addPost({ title: 'Hello' });
 
-		// .handler still works for backwards compatibility
-		expect(client.actions.getAnalyticsCount.handler()).toBe(5);
-		client.actions.addPost.handler({ title: 'Hello' });
-
 		// Extensions still accessible
 		expect(client.extensions.analytics.getCount()).toBe(5);
 

--- a/packages/epicenter/src/static/define-workspace.test.ts
+++ b/packages/epicenter/src/static/define-workspace.test.ts
@@ -63,7 +63,7 @@ describe('defineWorkspace', () => {
 		expect(themeResult.status).toBe('valid');
 	});
 
-	test('createWorkspace().withExtensions() adds extensions', () => {
+	test('createWorkspace().withExtension() adds extensions', () => {
 		// Mock extension with custom exports - uses defineExports for lifecycle
 		const mockExtension = (_context: {
 			ydoc: Y.Doc;
@@ -79,9 +79,7 @@ describe('defineWorkspace', () => {
 			tables: {
 				posts: defineTable(type({ id: 'string', title: 'string' })),
 			},
-		}).withExtensions({
-			mock: mockExtension,
-		});
+		}).withExtension('mock', mockExtension);
 
 		expect(client.extensions.mock).toBeDefined();
 		expect(client.extensions.mock.customMethod()).toBe('hello');
@@ -111,10 +109,9 @@ describe('defineWorkspace', () => {
 			tables: {
 				posts: defineTable(type({ id: 'string', title: 'string' })),
 			},
-		}).withExtensions({
-			persistence: persistenceExtension,
-			sync: syncExtension,
-		});
+		})
+			.withExtension('persistence', persistenceExtension)
+			.withExtension('sync', syncExtension);
 
 		// Test persistence extension exports are typed
 		const queryResult = client.extensions.persistence.db.query('SELECT');
@@ -156,9 +153,7 @@ describe('defineWorkspace', () => {
 			tables: {
 				posts: defineTable(type({ id: 'string', title: 'string' })),
 			},
-		}).withExtensions({
-			mock: mockExtension,
-		});
+		}).withExtension('mock', mockExtension);
 
 		await client.destroy();
 		expect(destroyed).toBe(true);
@@ -193,7 +188,7 @@ describe('defineWorkspace', () => {
 		expect(result.status).toBe('valid');
 	});
 
-	test('createWorkspace client is usable before withExtensions', () => {
+	test('createWorkspace client is usable before withExtension', () => {
 		const client = createWorkspace({
 			id: 'builder-app',
 			tables: {
@@ -204,10 +199,10 @@ describe('defineWorkspace', () => {
 		client.tables.posts.set({ id: '1', title: 'Before Extensions' });
 		const result = client.tables.posts.get('1');
 		expect(result.status).toBe('valid');
-		expect(typeof client.withExtensions).toBe('function');
+		expect(typeof client.withExtension).toBe('function');
 	});
 
-	test('withExtensions shares same ydoc', () => {
+	test('withExtension shares same ydoc', () => {
 		const baseClient = createWorkspace({
 			id: 'shared-doc-app',
 			tables: {
@@ -216,7 +211,7 @@ describe('defineWorkspace', () => {
 		});
 
 		baseClient.tables.posts.set({ id: '1', title: 'Original' });
-		const clientWithExt = baseClient.withExtensions({});
+		const clientWithExt = baseClient;
 
 		expect(clientWithExt.ydoc).toBe(baseClient.ydoc);
 

--- a/packages/epicenter/src/static/index.ts
+++ b/packages/epicenter/src/static/index.ts
@@ -50,7 +50,8 @@
  *
  * // Or add extensions
  * const clientWithExt = createWorkspace({ id: 'my-app', tables: { posts } })
- *   .withExtensions({ sqlite, persistence });
+ *   .withExtension('sqlite', sqlite)
+ *   .withExtension('persistence', persistence);
  *
  * // Cleanup
  * await client.destroy();
@@ -127,9 +128,7 @@ export type {
 	// Extension types
 	ExtensionContext,
 	ExtensionFactory,
-	ExtensionMap,
 	GetResult,
-	InferExtensionExports,
 	InferKvValue,
 	InferTableRow,
 	InvalidRowResult,

--- a/specs/20260201T000000-examples-and-scripts-fixes.md
+++ b/specs/20260201T000000-examples-and-scripts-fixes.md
@@ -10,6 +10,7 @@
 The examples and scripts used a completely non-existent API pattern. Rather than rewriting everything, the broken code was deleted.
 
 ### Deleted
+
 - `examples/basic-workspace/` - Entire directory
 - `examples/content-hub/` - Entire directory
 - `examples/stress-test/` - Entire directory
@@ -18,6 +19,7 @@ The examples and scripts used a completely non-existent API pattern. Rather than
 - `packages/epicenter/scripts/yjs-vs-sqlite-comparison.ts`
 
 ### Kept
+
 - `examples/yjs-size-benchmark/` - Pure Yjs benchmark, no `@epicenter/hq` dependencies
 - `packages/epicenter/scripts/yjs-data-structure-benchmark.ts` - Pure Yjs benchmark
 - `packages/epicenter/scripts/demo-yjs-nested-map-lww.ts` - Pure Yjs demonstration
@@ -26,7 +28,9 @@ The examples and scripts used a completely non-existent API pattern. Rather than
 - `packages/epicenter/scripts/ykeyvalue-write-benchmark.ts` - Uses internal `y-keyvalue-lww` utility
 
 ### Public API Status
+
 The following types were already exported from `@epicenter/hq`:
+
 - `DateTimeString` (with companion object methods `.parse()`, `.stringify()`, `.now()`)
 - `ExtensionContext`
 - `ProviderContext`
@@ -52,20 +56,33 @@ Neither the **static API** (`@epicenter/hq/static`) nor the **dynamic API** (`@e
 ### Actual Available APIs
 
 **Dynamic API** (`@epicenter/hq/dynamic`):
+
 ```typescript
 const definition = defineWorkspace({
-  id: 'my-app',
-  name: 'My App',
-  tables: [table({ id: 'posts', name: 'Posts', fields: [id(), text({ id: 'title' })] })],
-  kv: [],
+	id: 'my-app',
+	name: 'My App',
+	tables: [
+		table({
+			id: 'posts',
+			name: 'Posts',
+			fields: [id(), text({ id: 'title' })],
+		}),
+	],
+	kv: [],
 });
-const client = createWorkspace({ headDoc, definition }).withExtensions({ sqlite, persistence });
+const client = createWorkspace({ headDoc, definition })
+	.withExtension('sqlite', sqlite)
+	.withExtension('persistence', persistence);
 ```
 
 **Static API** (`@epicenter/hq/static`):
+
 ```typescript
 const posts = defineTable(type({ id: 'string', title: 'string' }));
-const client = createWorkspace({ id: 'my-app', tables: { posts } }).withExtensions({ sqlite });
+const client = createWorkspace({
+	id: 'my-app',
+	tables: { posts },
+}).withExtension('sqlite', sqlite);
 ```
 
 ### Additional Issues
@@ -78,42 +95,42 @@ const client = createWorkspace({ id: 'my-app', tables: { posts } }).withExtensio
 
 ### examples/content-hub/.epicenter/workspaces/
 
-| File | Severity | Issues |
-|------|----------|--------|
-| `browser.workspace.ts` | Medium | Outdated import paths, renamed functions |
-| `clippings.workspace.ts` | High | Removed exports (`DateWithTimezone*`), import paths, renamed functions |
-| `epicenter.workspace.ts` | Medium | Outdated import paths, renamed functions |
-| `gmail.workspace.ts` | High | Root-level imports of non-exported items, missing `type` import |
-| `journal.workspace.ts` | Medium | Outdated import paths, renamed functions |
-| `pages.workspace.ts` | High | Removed export (`DateWithTimezone`), import paths |
-| `posts.workspace.ts` | Medium | Outdated import paths, renamed functions |
-| `whispering.workspace.ts` | High | Removed export (`DateWithTimezone`), import paths |
-| `wiki.workspace.ts` | High | Removed exports (`DateWithTimezone*`, `SerializedRow`), import paths |
+| File                      | Severity | Issues                                                                 |
+| ------------------------- | -------- | ---------------------------------------------------------------------- |
+| `browser.workspace.ts`    | Medium   | Outdated import paths, renamed functions                               |
+| `clippings.workspace.ts`  | High     | Removed exports (`DateWithTimezone*`), import paths, renamed functions |
+| `epicenter.workspace.ts`  | Medium   | Outdated import paths, renamed functions                               |
+| `gmail.workspace.ts`      | High     | Root-level imports of non-exported items, missing `type` import        |
+| `journal.workspace.ts`    | Medium   | Outdated import paths, renamed functions                               |
+| `pages.workspace.ts`      | High     | Removed export (`DateWithTimezone`), import paths                      |
+| `posts.workspace.ts`      | Medium   | Outdated import paths, renamed functions                               |
+| `whispering.workspace.ts` | High     | Removed export (`DateWithTimezone`), import paths                      |
+| `wiki.workspace.ts`       | High     | Removed exports (`DateWithTimezone*`, `SerializedRow`), import paths   |
 
 ### examples/basic-workspace/.epicenter/workspaces/
 
-| File | Severity | Issues |
-|------|----------|--------|
+| File                | Severity | Issues                                                                                                                               |
+| ------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `blog.workspace.ts` | Critical | Uses non-existent `/capabilities/` path, old builder pattern (`.withCapabilities()`, `.withActions()`), removed `SerializedRow` type |
 
 ### examples/stress-test/.epicenter/workspaces/
 
-| File | Severity | Issues |
-|------|----------|--------|
-| `stress.workspace.ts` | Medium | Outdated import paths |
+| File                  | Severity | Issues                |
+| --------------------- | -------- | --------------------- |
+| `stress.workspace.ts` | Medium   | Outdated import paths |
 
 ### packages/epicenter/scripts/
 
-| File | Severity | Issues |
-|------|----------|--------|
-| `email-storage-simulation.ts` | Critical | Old workspace API (array tables with `id` in field options), old `createClient` builder pattern |
-| `email-minimal-simulation.ts` | Critical | Same as above |
-| `yjs-vs-sqlite-comparison.ts` | Critical | Same as above |
-| `ymap-vs-ykeyvalue-benchmark.ts` | Low | Uses internal `y-keyvalue` utility (may be fine) |
-| `yjs-data-structure-benchmark.ts` | None | Pure Yjs benchmark, no @epicenter/hq imports |
-| `demo-yjs-nested-map-lww.ts` | Unknown | Needs review |
-| `yjs-gc-benchmark.ts` | Unknown | Needs review |
-| `ykeyvalue-write-benchmark.ts` | Unknown | Needs review |
+| File                              | Severity | Issues                                                                                          |
+| --------------------------------- | -------- | ----------------------------------------------------------------------------------------------- |
+| `email-storage-simulation.ts`     | Critical | Old workspace API (array tables with `id` in field options), old `createClient` builder pattern |
+| `email-minimal-simulation.ts`     | Critical | Same as above                                                                                   |
+| `yjs-vs-sqlite-comparison.ts`     | Critical | Same as above                                                                                   |
+| `ymap-vs-ykeyvalue-benchmark.ts`  | Low      | Uses internal `y-keyvalue` utility (may be fine)                                                |
+| `yjs-data-structure-benchmark.ts` | None     | Pure Yjs benchmark, no @epicenter/hq imports                                                    |
+| `demo-yjs-nested-map-lww.ts`      | Unknown  | Needs review                                                                                    |
+| `yjs-gc-benchmark.ts`             | Unknown  | Needs review                                                                                    |
+| `ykeyvalue-write-benchmark.ts`    | Unknown  | Needs review                                                                                    |
 
 ## Error Categories
 
@@ -122,15 +139,17 @@ const client = createWorkspace({ id: 'my-app', tables: { posts } }).withExtensio
 **Problem**: Import paths use old `/providers/` or `/capabilities/` subdirectories.
 
 **Current package.json exports**:
+
 ```json
 {
-  "./extensions/persistence": "...",
-  "./extensions/markdown": "...",
-  "./extensions/sqlite": "..."
+	"./extensions/persistence": "...",
+	"./extensions/markdown": "...",
+	"./extensions/sqlite": "..."
 }
 ```
 
 **Affected patterns**:
+
 ```typescript
 // OLD (broken)
 import { ... } from '@epicenter/hq/providers/markdown';
@@ -150,12 +169,12 @@ import { ... } from '@epicenter/hq/extensions/sqlite';
 
 **Problem**: Extension factory functions were renamed for consistency.
 
-| Old Name | New Name | Export Path |
-|----------|----------|-------------|
-| `markdownProvider` | `markdown` | `@epicenter/hq/extensions/markdown` |
-| `sqliteProvider` | `sqlite` | `@epicenter/hq/extensions/sqlite` |
-| `setupPersistence` | `persistence` | `@epicenter/hq/extensions/persistence` |
-| `MarkdownProviderErr` | `MarkdownExtensionErr` | `@epicenter/hq/extensions/markdown` |
+| Old Name              | New Name               | Export Path                            |
+| --------------------- | ---------------------- | -------------------------------------- |
+| `markdownProvider`    | `markdown`             | `@epicenter/hq/extensions/markdown`    |
+| `sqliteProvider`      | `sqlite`               | `@epicenter/hq/extensions/sqlite`      |
+| `setupPersistence`    | `persistence`          | `@epicenter/hq/extensions/persistence` |
+| `MarkdownProviderErr` | `MarkdownExtensionErr` | `@epicenter/hq/extensions/markdown`    |
 
 **Files affected**: 11 files
 
@@ -163,14 +182,14 @@ import { ... } from '@epicenter/hq/extensions/sqlite';
 
 **Problem**: Certain types/utilities are no longer exported from `@epicenter/hq` root.
 
-| Missing Export | Status | Recommendation |
-|----------------|--------|----------------|
-| `DateWithTimezone` | Not exported | Use `Temporal.ZonedDateTime` or ISO strings with manual timezone handling |
-| `DateWithTimezoneFromString` | Not exported | Parse manually or add back as utility |
-| `DateWithTimezoneString` | Not exported (type) | Define locally or use string type |
-| `SerializedRow` | Not exported | Import from internal path or use `Row<T>` type |
-| `WorkspaceSchema` | Not exported | Use `WorkspaceDefinition` type |
-| `ProviderContext` | Not exported | Import from `@epicenter/hq/dynamic` subpath |
+| Missing Export               | Status              | Recommendation                                                            |
+| ---------------------------- | ------------------- | ------------------------------------------------------------------------- |
+| `DateWithTimezone`           | Not exported        | Use `Temporal.ZonedDateTime` or ISO strings with manual timezone handling |
+| `DateWithTimezoneFromString` | Not exported        | Parse manually or add back as utility                                     |
+| `DateWithTimezoneString`     | Not exported (type) | Define locally or use string type                                         |
+| `SerializedRow`              | Not exported        | Import from internal path or use `Row<T>` type                            |
+| `WorkspaceSchema`            | Not exported        | Use `WorkspaceDefinition` type                                            |
+| `ProviderContext`            | Not exported        | Import from `@epicenter/hq/dynamic` subpath                               |
 
 **Files affected**: 6 files
 
@@ -179,6 +198,7 @@ import { ... } from '@epicenter/hq/extensions/sqlite';
 **Problem**: The `basic-workspace/blog.workspace.ts` uses a completely different API pattern that no longer exists.
 
 **Old API (broken)**:
+
 ```typescript
 defineWorkspace({
   id: generateGuid(),
@@ -199,6 +219,7 @@ defineWorkspace({
 ```
 
 **Current API**:
+
 ```typescript
 defineWorkspace({
   id: 'blog',
@@ -217,6 +238,7 @@ defineWorkspace({
 ```
 
 **Note**: The current API uses:
+
 - Array-based `tables` with `table()` factory
 - Array-based `kv`
 - `id` option in field factories: `text({ id: 'title' })`
@@ -226,16 +248,17 @@ defineWorkspace({
 
 ### Category 5: Old Scripts API (createClient Builder Pattern)
 
-**Problem**: Scripts use `createClient(head).withDefinition().withExtensions()` builder pattern.
+**Problem**: Scripts use `createClient(head).withDefinition().withExtension()` builder pattern.
 
 **Old API (broken)**:
+
 ```typescript
 const head = createHeadDoc({ workspaceId: 'emails', providers: {} });
 await using client = await createClient(head)
-  .withDefinition(emailDefinition)
-  .withExtensions({
-    persistence: (ctx) => persistence(ctx, { filePath: YJS_PATH }),
-  });
+	.withDefinition(emailDefinition)
+	.withExtension('persistence', (ctx) =>
+		persistence(ctx, { filePath: YJS_PATH }),
+	);
 
 // Access via:
 client.tables.get('emails').upsertMany(emails);
@@ -248,6 +271,7 @@ client.tables.get('emails').upsertMany(emails);
 ### Option A: Delete Outdated Examples/Scripts
 
 **Candidates for deletion**:
+
 - `examples/basic-workspace/` - Uses completely different API, would require full rewrite
 - `packages/epicenter/scripts/email-*.ts` - Simulation scripts likely not actively used
 - `packages/epicenter/scripts/yjs-vs-sqlite-comparison.ts` - Benchmark script
@@ -268,16 +292,19 @@ For files that can be updated with find-and-replace style fixes:
 ### Option C: Hybrid Approach (Recommended)
 
 **Delete**:
+
 - `examples/basic-workspace/` - Fundamentally incompatible API
 - `packages/epicenter/scripts/email-storage-simulation.ts`
 - `packages/epicenter/scripts/email-minimal-simulation.ts`
 - `packages/epicenter/scripts/yjs-vs-sqlite-comparison.ts`
 
 **Update**:
+
 - All `examples/content-hub/` workspaces - Import paths and function names only
 - `examples/stress-test/` - Import paths only
 
 **Requires deeper analysis**:
+
 - Files using `DateWithTimezone` utilities - Decide if these should be re-exported
 - `packages/epicenter/scripts/ymap-vs-ykeyvalue-benchmark.ts` - Uses internal utility
 - Other benchmark scripts
@@ -298,11 +325,11 @@ Files: All 12 workspace files in examples/
 
 Rename function calls:
 
-| Find | Replace |
-|------|---------|
-| `markdownProvider` | `markdown` |
-| `sqliteProvider` | `sqlite` |
-| `setupPersistence` | `persistence` |
+| Find                  | Replace                |
+| --------------------- | ---------------------- |
+| `markdownProvider`    | `markdown`             |
+| `sqliteProvider`      | `sqlite`               |
+| `setupPersistence`    | `persistence`          |
 | `MarkdownProviderErr` | `MarkdownExtensionErr` |
 
 Files: Same 12 workspace files
@@ -321,12 +348,13 @@ Delete files that require complete rewrites:
 **Option 4A**: Re-export `DateWithTimezone` utilities from `@epicenter/hq`
 
 **Option 4B**: Replace with inline implementations:
+
 ```typescript
 // Instead of:
-DateWithTimezone({ date: new Date(), timezone: 'UTC' }).toJSON()
+DateWithTimezone({ date: new Date(), timezone: 'UTC' }).toJSON();
 
 // Use:
-new Date().toISOString() // For UTC
+new Date().toISOString(); // For UTC
 // Or define local helper
 ```
 
@@ -337,16 +365,18 @@ Files needing this: 5 workspace files
 ### Phase 5: gmail.workspace.ts Special Handling
 
 This file imports non-exported items from root:
+
 ```typescript
 import {
-  markdownProvider,      // Should come from extensions/markdown
-  sqliteProvider,        // Should come from extensions/sqlite
-  type ProviderContext,  // Not publicly exported
-  type WorkspaceSchema,  // Not publicly exported
+	markdownProvider, // Should come from extensions/markdown
+	sqliteProvider, // Should come from extensions/sqlite
+	type ProviderContext, // Not publicly exported
+	type WorkspaceSchema, // Not publicly exported
 } from '@epicenter/hq';
 ```
 
 Options:
+
 1. Export `ProviderContext` and `WorkspaceSchema` from public API
 2. Remove/rewrite the custom `gmailAuthProvider` that uses these types
 3. Import from internal subpaths (not recommended for examples)
@@ -377,19 +407,21 @@ After fixes are applied:
 ### examples/content-hub/.epicenter/workspaces/browser.workspace.ts
 
 **Lines 34-36**:
+
 ```typescript
 import {
-  domainTitleFilenameSerializer,
-  markdownProvider,
+	domainTitleFilenameSerializer,
+	markdownProvider,
 } from '@epicenter/hq/providers/markdown';
 import { sqliteProvider } from '@epicenter/hq/providers/sqlite';
 ```
 
 **Fix**:
+
 ```typescript
 import {
-  domainTitleFilenameSerializer,
-  markdown,
+	domainTitleFilenameSerializer,
+	markdown,
 } from '@epicenter/hq/extensions/markdown';
 import { sqlite } from '@epicenter/hq/extensions/sqlite';
 ```
@@ -401,19 +433,25 @@ Also update usages: `markdownProvider` → `markdown`, `sqliteProvider` → `sql
 ### examples/content-hub/.epicenter/workspaces/clippings.workspace.ts
 
 **Lines 3-21**:
+
 ```typescript
 import {
-  DateWithTimezone,
-  DateWithTimezoneFromString,
-  DateWithTimezoneString,
-  // ... other imports
+	DateWithTimezone,
+	DateWithTimezoneFromString,
+	DateWithTimezoneString,
+	// ... other imports
 } from '@epicenter/hq';
-import { bodyFieldSerializer, MarkdownProviderErr, markdownProvider } from '@epicenter/hq/providers/markdown';
+import {
+	bodyFieldSerializer,
+	MarkdownProviderErr,
+	markdownProvider,
+} from '@epicenter/hq/providers/markdown';
 import { setupPersistence } from '@epicenter/hq/providers/persistence';
 import { sqliteProvider } from '@epicenter/hq/providers/sqlite';
 ```
 
 **Issues**:
+
 - `DateWithTimezone`, `DateWithTimezoneFromString`, `DateWithTimezoneString` not exported
 - Wrong import paths
 - Wrong function names
@@ -433,21 +471,23 @@ import { sqliteProvider } from '@epicenter/hq/providers/sqlite';
 ### packages/epicenter/scripts/email-storage-simulation.ts
 
 **Lines 18-28**:
+
 ```typescript
 import { persistence } from '../src/extensions/persistence/desktop';
 import {
-  createClient,
-  createHeadDoc,
-  defineWorkspace,
-  generateId,
-  id,
-  integer,
-  table,
-  text,
+	createClient,
+	createHeadDoc,
+	defineWorkspace,
+	generateId,
+	id,
+	integer,
+	table,
+	text,
 } from '../src/index';
 ```
 
 **Lines 188-226** use old API:
+
 ```typescript
 const emailDefinition = defineWorkspace({
   name: 'Email Storage Simulation',
@@ -468,7 +508,7 @@ const emailDefinition = defineWorkspace({
 const head = createHeadDoc({ workspaceId: 'emails', providers: {} });
 await using client = await createClient(head)
   .withDefinition(emailDefinition)
-  .withExtensions({...});
+  .withExtension(...);
 ```
 
 **Recommendation**: DELETE - Uses non-existent builder pattern
@@ -484,6 +524,7 @@ await using client = await createClient(head)
 ### packages/epicenter/scripts/ymap-vs-ykeyvalue-benchmark.ts
 
 **Line 13**:
+
 ```typescript
 import { YKeyValue } from '../src/core/utils/y-keyvalue';
 ```

--- a/specs/20260201T000000-packages-epicenter-typecheck-fixes.md
+++ b/specs/20260201T000000-packages-epicenter-typecheck-fixes.md
@@ -10,29 +10,30 @@ The `packages/epicenter` package has 237 type errors across ~15 files. This spec
 
 ## Error Summary by File
 
-| File | Error Count | Category |
-|------|-------------|----------|
-| `src/dynamic/tables/create-tables.test.ts` | 68 | TRow type inference |
-| `src/dynamic/tables/create-tables.crdt-sync.test.ts` | 55 | TRow type inference |
-| `src/dynamic/tables/create-tables.offline-sync.test.ts` | 49 | TRow type inference |
-| `src/dynamic/tables/create-tables.types.test.ts` | 32 | TRow type inference |
-| `scripts/demo-yjs-nested-map-lww.ts` | 8 | Y.Map toJSON typing |
-| `src/cli/cli.test.ts` | 5 | Unknown (needs investigation) |
-| `scripts/yjs-vs-sqlite-comparison.ts` | 3 | Removed export + WorkspaceDefinition `id` |
-| `scripts/yjs-gc-benchmark.ts` | 3 | string \| undefined |
-| `scripts/email-storage-simulation.ts` | 3 | Removed export + WorkspaceDefinition `id` |
-| `scripts/email-minimal-simulation.ts` | 3 | Removed export + WorkspaceDefinition `id` |
-| `src/dynamic/tables/keys.ts` | 2 | string \| undefined handling |
-| `src/core/schema/workspace-definition-validator.ts` | 2 | Unused import |
-| `scripts/yjs-data-structure-benchmark.ts` | 2 | Unused variables |
-| `scripts/ymap-vs-ykeyvalue-benchmark.ts` | 1 | Missing module |
-| `scripts/ykeyvalue-write-benchmark.ts` | 1 | Missing module |
+| File                                                    | Error Count | Category                                  |
+| ------------------------------------------------------- | ----------- | ----------------------------------------- |
+| `src/dynamic/tables/create-tables.test.ts`              | 68          | TRow type inference                       |
+| `src/dynamic/tables/create-tables.crdt-sync.test.ts`    | 55          | TRow type inference                       |
+| `src/dynamic/tables/create-tables.offline-sync.test.ts` | 49          | TRow type inference                       |
+| `src/dynamic/tables/create-tables.types.test.ts`        | 32          | TRow type inference                       |
+| `scripts/demo-yjs-nested-map-lww.ts`                    | 8           | Y.Map toJSON typing                       |
+| `src/cli/cli.test.ts`                                   | 5           | Unknown (needs investigation)             |
+| `scripts/yjs-vs-sqlite-comparison.ts`                   | 3           | Removed export + WorkspaceDefinition `id` |
+| `scripts/yjs-gc-benchmark.ts`                           | 3           | string \| undefined                       |
+| `scripts/email-storage-simulation.ts`                   | 3           | Removed export + WorkspaceDefinition `id` |
+| `scripts/email-minimal-simulation.ts`                   | 3           | Removed export + WorkspaceDefinition `id` |
+| `src/dynamic/tables/keys.ts`                            | 2           | string \| undefined handling              |
+| `src/core/schema/workspace-definition-validator.ts`     | 2           | Unused import                             |
+| `scripts/yjs-data-structure-benchmark.ts`               | 2           | Unused variables                          |
+| `scripts/ymap-vs-ykeyvalue-benchmark.ts`                | 1           | Missing module                            |
+| `scripts/ykeyvalue-write-benchmark.ts`                  | 1           | Missing module                            |
 
 ## Error Categories
 
 ### Category 1: TRow Type Inference (204 errors)
 
 **Affected files**:
+
 - `src/dynamic/tables/create-tables.test.ts`
 - `src/dynamic/tables/create-tables.crdt-sync.test.ts`
 - `src/dynamic/tables/create-tables.offline-sync.test.ts`
@@ -41,6 +42,7 @@ The `packages/epicenter` package has 237 type errors across ~15 files. This spec
 **Error codes**: TS2353, TS2339, TS2345
 
 **Symptoms**:
+
 ```typescript
 // TS2353: Object literal may only specify known properties, and 'title' does not exist in type 'TRow'
 doc.get('posts').upsert({ id: '1', title: 'Test' });
@@ -62,6 +64,7 @@ expect(row.title).toBe('Test');
    - Less ideal because tests should verify type inference works
 
 **Investigation needed**:
+
 - Read `src/dynamic/tables/create-tables.ts` to understand generic structure
 - Read `src/core/schema/table.ts` to understand `TableDefinition` type
 - Check if there's a missing `as const` in the test files or the implementation
@@ -71,6 +74,7 @@ expect(row.title).toBe('Test');
 ### Category 2: Removed Exports (6 errors)
 
 **Affected files**:
+
 - `scripts/email-minimal-simulation.ts`
 - `scripts/email-storage-simulation.ts`
 - `scripts/yjs-vs-sqlite-comparison.ts`
@@ -78,6 +82,7 @@ expect(row.title).toBe('Test');
 **Error codes**: TS2305
 
 **Symptom**:
+
 ```typescript
 // Module '"../src/index"' has no exported member 'createClient'
 import { createClient } from '../src/index';
@@ -86,6 +91,7 @@ import { createClient } from '../src/index';
 **Root cause**: The `createClient` export was removed from the public API. These scripts use an outdated API.
 
 **Fix**: Update scripts to use the new API. Need to determine:
+
 - What replaced `createClient`?
 - Are these scripts still needed or can they be deleted?
 
@@ -94,6 +100,7 @@ import { createClient } from '../src/index';
 ### Category 3: Missing WorkspaceDefinition `id` (3 errors)
 
 **Affected files**:
+
 - `scripts/email-minimal-simulation.ts`
 - `scripts/email-storage-simulation.ts`
 - `scripts/yjs-vs-sqlite-comparison.ts`
@@ -101,6 +108,7 @@ import { createClient } from '../src/index';
 **Error codes**: TS2345
 
 **Symptom**:
+
 ```typescript
 // Property 'id' is missing in type '{ name: string; ... }' but required in type 'WorkspaceDefinition'
 ```
@@ -114,6 +122,7 @@ import { createClient } from '../src/index';
 ### Category 4: Implicit `any` on `ctx` parameter (3 errors)
 
 **Affected files**:
+
 - `scripts/email-minimal-simulation.ts:106`
 - `scripts/email-storage-simulation.ts:221`
 - `scripts/yjs-vs-sqlite-comparison.ts:193`
@@ -121,9 +130,10 @@ import { createClient } from '../src/index';
 **Error codes**: TS7006
 
 **Symptom**:
+
 ```typescript
 // Parameter 'ctx' implicitly has an 'any' type
-.withExtensions({ persistence: (ctx) => ... })
+.withExtension('persistence', (ctx) => ...)
 ```
 
 **Fix**: Add type annotation to `ctx` parameter, e.g., `(ctx: ExtensionContext) => ...`
@@ -137,16 +147,18 @@ import { createClient } from '../src/index';
 **Error codes**: TS2339
 
 **Symptom**:
+
 ```typescript
 // Property 'toJSON' does not exist on type '{}'
-doc1Nested.get('user').toJSON()
+doc1Nested.get('user').toJSON();
 ```
 
 **Root cause**: `Y.Map.get()` returns `T | undefined` where T defaults to `{}`. The type doesn't include Yjs methods.
 
 **Fix**: Cast to `Y.Map` or use type assertion, e.g.:
+
 ```typescript
-(doc1Nested.get('user') as Y.Map<unknown>).toJSON()
+(doc1Nested.get('user') as Y.Map<unknown>).toJSON();
 ```
 
 ---
@@ -154,12 +166,14 @@ doc1Nested.get('user').toJSON()
 ### Category 6: `string | undefined` not assignable to `string` (5 errors)
 
 **Affected files**:
+
 - `src/dynamic/tables/keys.ts:168-169`
 - `scripts/yjs-gc-benchmark.ts:93, 130, 134`
 
 **Error codes**: TS2345
 
 **Symptom**:
+
 ```typescript
 // In parseCellKey():
 const [rowIdStr, fieldIdStr] = parts; // parts[0] and parts[1] could be undefined
@@ -167,10 +181,11 @@ return { rowId: RowId(rowIdStr), fieldId: FieldId(fieldIdStr) }; // Error!
 ```
 
 **Fix for keys.ts**:
+
 ```typescript
 const [rowIdStr, fieldIdStr] = parts;
 if (!rowIdStr || !fieldIdStr) {
-  throw new Error(`Invalid cell key format: "${key}"`);
+	throw new Error(`Invalid cell key format: "${key}"`);
 }
 return { rowId: RowId(rowIdStr), fieldId: FieldId(fieldIdStr) };
 ```
@@ -186,6 +201,7 @@ return { rowId: RowId(rowIdStr), fieldId: FieldId(fieldIdStr) };
 **Error codes**: TS6133
 
 **Symptom**:
+
 ```typescript
 // 'COLUMNS' is declared but its value is never read
 // 'doc' is declared but its value is never read
@@ -202,6 +218,7 @@ return { rowId: RowId(rowIdStr), fieldId: FieldId(fieldIdStr) };
 **Error codes**: TS2614, TS6133
 
 **Symptom**:
+
 ```typescript
 // Module '"typebox/compile"' has no exported member 'TCompileReturn'
 import { Compile, type TCompileReturn } from 'typebox/compile';
@@ -210,6 +227,7 @@ import { Compile, type TCompileReturn } from 'typebox/compile';
 **Root cause**: `TCompileReturn` doesn't exist in this version of typebox, and it's not used anyway.
 
 **Fix**: Remove the unused import:
+
 ```typescript
 import { Compile } from 'typebox/compile';
 ```
@@ -219,12 +237,14 @@ import { Compile } from 'typebox/compile';
 ### Category 9: Missing Module (2 errors)
 
 **Affected files**:
+
 - `scripts/ymap-vs-ykeyvalue-benchmark.ts`
 - `scripts/ykeyvalue-write-benchmark.ts`
 
 **Error codes**: TS2307
 
 **Symptom**:
+
 ```typescript
 // Cannot find module '../src/core/utils/y-keyvalue'
 ```
@@ -232,6 +252,7 @@ import { Compile } from 'typebox/compile';
 **Root cause**: The `y-keyvalue` module was moved or deleted.
 
 **Fix options**:
+
 1. Update import path if module was moved
 2. Delete scripts if they're obsolete
 
@@ -281,6 +302,7 @@ This is the critical fix affecting 204 errors:
 ### Decision 1: Script Disposition
 
 For scripts using removed APIs, choose one:
+
 - **A) Update scripts** to use new API
 - **B) Delete scripts** if they're obsolete demo code
 - **C) Move to archive** folder for reference
@@ -290,6 +312,7 @@ For scripts using removed APIs, choose one:
 ### Decision 2: TRow Fix Location
 
 For the 204 type inference errors, choose one:
+
 - **A) Fix in createTables()** - Correct generic inference at source
 - **B) Fix in tests** - Add explicit type annotations as workaround
 

--- a/specs/20260201T120000-simple-definition-first-workspace-handoff.md
+++ b/specs/20260201T120000-simple-definition-first-workspace-handoff.md
@@ -131,9 +131,9 @@ import {
 import { workspacePersistence } from './workspace-persistence';
 
 export function createWorkspaceClient(definition: WorkspaceDefinition) {
-	return createWorkspace(definition).withExtensions({
-		persistence: (ctx) => workspacePersistence(ctx),
-	});
+	return createWorkspace(definition).withExtension('persistence', (ctx) =>
+		workspacePersistence(ctx),
+	);
 }
 ```
 

--- a/specs/20260201T120000-simple-definition-first-workspace.md
+++ b/specs/20260201T120000-simple-definition-first-workspace.md
@@ -58,10 +58,9 @@ For these simple cases, the HeadDoc is overhead. The `WorkspaceDefinition` alrea
 ```typescript
 import { createWorkspace } from '@epicenter/hq/dynamic';
 
-const workspace = createWorkspace(definition).withExtensions({
-	persistence,
-	sqlite,
-});
+const workspace = createWorkspace(definition)
+	.withExtension('persistence', (ctx) => workspacePersistence(ctx))
+	.withExtension('sqlite', sqlite);
 
 await workspace.whenSynced;
 ```
@@ -202,7 +201,7 @@ Add new overload that takes definition directly:
  * @example
  * ```typescript
  * const workspace = createWorkspace(definition)
- *   .withExtensions({ persistence });
+ *   .withExtension('persistence', persistence);
  *
  * workspace.tables.get('posts').upsert({ id: '1', title: 'Hello' });
  * ```
@@ -323,9 +322,9 @@ import { workspacePersistence } from './workspace-persistence';
  * Loads definition from JSON file if not provided.
  */
 export function createWorkspaceClient(definition: WorkspaceDefinition) {
-	return createWorkspace(definition).withExtensions({
-		persistence: (ctx) => workspacePersistence(ctx),
-	});
+	return createWorkspace(definition).withExtension('persistence', (ctx) =>
+		workspacePersistence(ctx),
+	);
 }
 ```
 

--- a/specs/20260203T100000-static-workspace-viewing.md
+++ b/specs/20260203T100000-static-workspace-viewing.md
@@ -31,14 +31,14 @@ const ydoc = new Y.Doc({ guid: workspaceId });
 // Discover all tables
 const tables: string[] = [];
 ydoc.share.forEach((type, key) => {
-  if (key.startsWith('table:') && type instanceof Y.Array) {
-    tables.push(key.slice(7)); // Remove 'table:' prefix
-  }
+	if (key.startsWith('table:') && type instanceof Y.Array) {
+		tables.push(key.slice(7)); // Remove 'table:' prefix
+	}
 });
 
 // Discover all KV keys
 const kvArray = ydoc.getArray<YKeyValueLwwEntry>('kv');
-const kvKeys = [...new Set(kvArray.toArray().map(entry => entry.key))];
+const kvKeys = [...new Set(kvArray.toArray().map((entry) => entry.key))];
 
 console.log({ tables, kvKeys });
 // { tables: ['posts', 'users'], kvKeys: ['theme', 'settings'] }
@@ -46,22 +46,22 @@ console.log({ tables, kvKeys });
 
 ### Storage Format (from `ydoc-keys.ts`)
 
-| Key Pattern | Type | Contents |
-|-------------|------|----------|
-| `table:{name}` | `Y.Array` | LWW entries: `{ key: id, val: row, ts: timestamp }` |
-| `kv` | `Y.Array` | LWW entries: `{ key: name, val: value, ts: timestamp }` |
+| Key Pattern    | Type      | Contents                                                |
+| -------------- | --------- | ------------------------------------------------------- |
+| `table:{name}` | `Y.Array` | LWW entries: `{ key: id, val: row, ts: timestamp }`     |
+| `kv`           | `Y.Array` | LWW entries: `{ key: name, val: value, ts: timestamp }` |
 
 ### What You Get Without TypeScript Runtime
 
-| Feature | Works? | Notes |
-|---------|--------|-------|
-| Read all rows | ✅ | Just iterate the Y.Array |
-| Read all KV values | ✅ | Filter by key in 'kv' array |
-| Observe changes | ✅ | `array.observe()` works |
-| Write raw data | ✅ | No validation, but works |
-| Schema validation | ❌ | Requires runtime |
-| Migrations | ❌ | Requires runtime |
-| Type inference | ❌ | Data is `unknown` |
+| Feature            | Works? | Notes                       |
+| ------------------ | ------ | --------------------------- |
+| Read all rows      | ✅     | Just iterate the Y.Array    |
+| Read all KV values | ✅     | Filter by key in 'kv' array |
+| Observe changes    | ✅     | `array.observe()` works     |
+| Write raw data     | ✅     | No validation, but works    |
+| Schema validation  | ❌     | Requires runtime            |
+| Migrations         | ❌     | Requires runtime            |
+| Type inference     | ❌     | Data is `unknown`           |
 
 ---
 
@@ -78,22 +78,23 @@ const ydoc = new Y.Doc({ guid: workspaceId });
 
 // Connect to local y-sweet server
 const provider = createYjsProvider(ydoc, workspaceId, async () => ({
-  url: `ws://127.0.0.1:8080/d/${workspaceId}/ws`,
-  baseUrl: 'http://127.0.0.1:8080',
-  docId: workspaceId,
-  token: undefined,
+	url: `ws://127.0.0.1:8080/d/${workspaceId}/ws`,
+	baseUrl: 'http://127.0.0.1:8080',
+	docId: workspaceId,
+	token: undefined,
 }));
 
 // Wait for initial sync
-await new Promise<void>(resolve => {
-  if (provider.status === 'connected') resolve();
-  else provider.on('sync', () => resolve());
+await new Promise<void>((resolve) => {
+	if (provider.status === 'connected') resolve();
+	else provider.on('sync', () => resolve());
 });
 
 // Now ydoc.share is populated with remote data
 ```
 
 **Start y-sweet locally:**
+
 ```bash
 npx y-sweet@latest serve        # In-memory
 npx y-sweet@latest serve ./data # Persisted to disk
@@ -108,9 +109,9 @@ import { WebsocketProvider } from 'y-websocket';
 
 const ydoc = new Y.Doc({ guid: workspaceId });
 const provider = new WebsocketProvider(
-  'ws://localhost:3913/sync',
-  workspaceId,
-  ydoc
+	'ws://localhost:3913/sync',
+	workspaceId,
+	ydoc,
 );
 
 await provider.synced;
@@ -134,34 +135,35 @@ await provider.synced;
    - Renders tables and KV in generic viewer
 
 2. **Generic table viewer component**
+
    ```svelte
    <script lang="ts">
-     import * as Y from 'yjs';
+   	import * as Y from 'yjs';
 
-     export let ydoc: Y.Doc;
-     export let tableName: string;
+   	export let ydoc: Y.Doc;
+   	export let tableName: string;
 
-     const array = ydoc.getArray(`table:${tableName}`);
+   	const array = ydoc.getArray(`table:${tableName}`);
 
-     // Reactive rows from Y.Array
-     let rows: unknown[] = [];
-     $: {
-       rows = array.toArray().map(entry => entry.val);
-     }
+   	// Reactive rows from Y.Array
+   	let rows: unknown[] = [];
+   	$: {
+   		rows = array.toArray().map((entry) => entry.val);
+   	}
 
-     array.observe(() => {
-       rows = array.toArray().map(entry => entry.val);
-     });
+   	array.observe(() => {
+   		rows = array.toArray().map((entry) => entry.val);
+   	});
    </script>
 
    <table>
-     <tbody>
-       {#each rows as row}
-         <tr>
-           <td><pre>{JSON.stringify(row, null, 2)}</pre></td>
-         </tr>
-       {/each}
-     </tbody>
+   	<tbody>
+   		{#each rows as row}
+   			<tr>
+   				<td><pre>{JSON.stringify(row, null, 2)}</pre></td>
+   			</tr>
+   		{/each}
+   	</tbody>
    </table>
    ```
 
@@ -185,47 +187,52 @@ await provider.synced;
 ```
 
 **Bun side** (runs TypeScript):
+
 ```typescript
 // packages/epicenter/examples/static-workspace-server.ts
 import { createWorkspace } from 'epicenter/static';
 import { ySweetSync } from 'epicenter/extensions';
 import { type } from 'arktype';
 
-const posts = defineTable(type({ id: 'string', title: 'string', views: 'number' }));
+const posts = defineTable(
+	type({ id: 'string', title: 'string', views: 'number' }),
+);
 
 const workspace = createWorkspace({
-  id: 'my-static-workspace',
-  tables: { posts },
-}).withExtensions({
-  sync: ySweetSync({ mode: 'direct', serverUrl: 'http://localhost:8080' }),
-});
+	id: 'my-static-workspace',
+	tables: { posts },
+}).withExtension(
+	'sync',
+	ySweetSync({ mode: 'direct', serverUrl: 'http://localhost:8080' }),
+);
 
-await workspace.capabilities.sync.whenSynced;
+await workspace.extensions.sync.whenSynced;
 
 // Now any changes sync to y-sweet
 workspace.tables.posts.set({ id: '1', title: 'Hello', views: 0 });
 ```
 
 **Tauri side** (no TypeScript runtime):
+
 ```typescript
 // apps/epicenter/src/routes/workspaces/static/[id]/+page.ts
 export async function load({ params }) {
-  const ydoc = new Y.Doc({ guid: params.id });
+	const ydoc = new Y.Doc({ guid: params.id });
 
-  // Connect to same y-sweet server
-  const provider = createYjsProvider(ydoc, params.id, async () => ({
-    url: `ws://127.0.0.1:8080/d/${params.id}/ws`,
-    baseUrl: 'http://127.0.0.1:8080',
-    docId: params.id,
-  }));
+	// Connect to same y-sweet server
+	const provider = createYjsProvider(ydoc, params.id, async () => ({
+		url: `ws://127.0.0.1:8080/d/${params.id}/ws`,
+		baseUrl: 'http://127.0.0.1:8080',
+		docId: params.id,
+	}));
 
-  await whenSynced(provider);
+	await whenSynced(provider);
 
-  // Discover structure
-  const tables = discoverTables(ydoc);
-  const kvKeys = discoverKvKeys(ydoc);
+	// Discover structure
+	const tables = discoverTables(ydoc);
+	const kvKeys = discoverKvKeys(ydoc);
 
-  return { ydoc, tables, kvKeys };
+	return { ydoc, tables, kvKeys };
 }
 ```
 
@@ -239,18 +246,18 @@ Create a registry file that lists known static workspaces:
 // apps/epicenter/src/lib/static-workspaces.ts
 
 export const STATIC_WORKSPACES = [
-  {
-    id: 'tab-manager',
-    name: 'Tab Manager',
-    description: 'Browser tab sync workspace',
-    icon: 'lucide:layout-grid',
-  },
-  {
-    id: 'whispering',
-    name: 'Whispering',
-    description: 'Voice transcription workspace',
-    icon: 'lucide:mic',
-  },
+	{
+		id: 'tab-manager',
+		name: 'Tab Manager',
+		description: 'Browser tab sync workspace',
+		icon: 'lucide:layout-grid',
+	},
+	{
+		id: 'whispering',
+		name: 'Whispering',
+		description: 'Voice transcription workspace',
+		icon: 'lucide:mic',
+	},
 ] as const;
 ```
 
@@ -262,21 +269,21 @@ This gives the UI friendly names and icons without needing TypeScript runtime.
 
 ### New Files
 
-| Path | Purpose |
-|------|---------|
-| `apps/epicenter/src/routes/(workspace)/workspaces/static/[id]/+page.svelte` | Static workspace viewer page |
-| `apps/epicenter/src/routes/(workspace)/workspaces/static/[id]/+layout.ts` | Load Y.Doc and discover structure |
-| `apps/epicenter/src/lib/static-workspaces.ts` | Registry of known static workspaces |
-| `apps/epicenter/src/lib/components/GenericTableViewer.svelte` | Render any Y.Array as a table |
-| `apps/epicenter/src/lib/components/GenericKvViewer.svelte` | Render KV entries |
-| `apps/epicenter/src/lib/docs/discover.ts` | `discoverTables()`, `discoverKvKeys()` utilities |
+| Path                                                                        | Purpose                                          |
+| --------------------------------------------------------------------------- | ------------------------------------------------ |
+| `apps/epicenter/src/routes/(workspace)/workspaces/static/[id]/+page.svelte` | Static workspace viewer page                     |
+| `apps/epicenter/src/routes/(workspace)/workspaces/static/[id]/+layout.ts`   | Load Y.Doc and discover structure                |
+| `apps/epicenter/src/lib/static-workspaces.ts`                               | Registry of known static workspaces              |
+| `apps/epicenter/src/lib/components/GenericTableViewer.svelte`               | Render any Y.Array as a table                    |
+| `apps/epicenter/src/lib/components/GenericKvViewer.svelte`                  | Render KV entries                                |
+| `apps/epicenter/src/lib/docs/discover.ts`                                   | `discoverTables()`, `discoverKvKeys()` utilities |
 
 ### Modified Files
 
-| Path | Change |
-|------|--------|
-| `apps/epicenter/src/routes/(home)/+page.svelte` | Add "Static Workspaces" section |
-| `apps/epicenter/src/lib/components/WorkspaceSidebar.svelte` | Show static workspaces |
+| Path                                                        | Change                          |
+| ----------------------------------------------------------- | ------------------------------- |
+| `apps/epicenter/src/routes/(home)/+page.svelte`             | Add "Static Workspaces" section |
+| `apps/epicenter/src/lib/components/WorkspaceSidebar.svelte` | Show static workspaces          |
 
 ---
 
@@ -291,59 +298,59 @@ import * as Y from 'yjs';
  * Discover all table names from a Y.Doc by scanning ydoc.share
  */
 export function discoverTables(ydoc: Y.Doc): string[] {
-  const tables: string[] = [];
+	const tables: string[] = [];
 
-  ydoc.share.forEach((type, key) => {
-    if (key.startsWith('table:') && type instanceof Y.Array) {
-      tables.push(key.slice(7)); // Remove 'table:' prefix
-    }
-  });
+	ydoc.share.forEach((type, key) => {
+		if (key.startsWith('table:') && type instanceof Y.Array) {
+			tables.push(key.slice(7)); // Remove 'table:' prefix
+		}
+	});
 
-  return tables.sort();
+	return tables.sort();
 }
 
 /**
  * Discover all KV keys from a Y.Doc
  */
 export function discoverKvKeys(ydoc: Y.Doc): string[] {
-  const kvArray = ydoc.getArray('kv');
-  const keys = new Set<string>();
+	const kvArray = ydoc.getArray('kv');
+	const keys = new Set<string>();
 
-  for (const entry of kvArray.toArray()) {
-    if (entry && typeof entry === 'object' && 'key' in entry) {
-      keys.add(entry.key as string);
-    }
-  }
+	for (const entry of kvArray.toArray()) {
+		if (entry && typeof entry === 'object' && 'key' in entry) {
+			keys.add(entry.key as string);
+		}
+	}
 
-  return [...keys].sort();
+	return [...keys].sort();
 }
 
 /**
  * Read all rows from a table (untyped)
  */
 export function readTableRows(ydoc: Y.Doc, tableName: string): unknown[] {
-  const array = ydoc.getArray(`table:${tableName}`);
-  return array.toArray().map((entry: any) => entry.val);
+	const array = ydoc.getArray(`table:${tableName}`);
+	return array.toArray().map((entry: any) => entry.val);
 }
 
 /**
  * Read a KV value by key (untyped)
  */
 export function readKvValue(ydoc: Y.Doc, key: string): unknown | undefined {
-  const kvArray = ydoc.getArray('kv');
+	const kvArray = ydoc.getArray('kv');
 
-  // Find entry with highest timestamp (LWW)
-  let latest: { val: unknown; ts: number } | undefined;
+	// Find entry with highest timestamp (LWW)
+	let latest: { val: unknown; ts: number } | undefined;
 
-  for (const entry of kvArray.toArray()) {
-    if (entry?.key === key) {
-      if (!latest || entry.ts > latest.ts) {
-        latest = entry;
-      }
-    }
-  }
+	for (const entry of kvArray.toArray()) {
+		if (entry?.key === key) {
+			if (!latest || entry.ts > latest.ts) {
+				latest = entry;
+			}
+		}
+	}
 
-  return latest?.val;
+	return latest?.val;
 }
 ```
 
@@ -430,7 +437,7 @@ Store in app settings (already exists):
 
 ```typescript
 // In settings store
-syncServerUrl: 'http://127.0.0.1:8080'
+syncServerUrl: 'http://127.0.0.1:8080';
 ```
 
 ### Local Development
@@ -453,6 +460,7 @@ bun run --filter @epicenter/app dev
 ### Empty Y.Doc (No Data Yet)
 
 If the static workspace hasn't synced any data:
+
 - `ydoc.share` will be empty
 - Show "No tables found" message
 - Keep connection open for real-time updates
@@ -460,12 +468,14 @@ If the static workspace hasn't synced any data:
 ### Workspace ID Doesn't Exist
 
 Y-Sweet will create a new empty document:
+
 - This is fine for development
 - For production, validate against registry first
 
 ### Offline Mode
 
 If y-sweet server is unreachable:
+
 - Show connection error
 - Retry with exponential backoff
 - Allow viewing cached data if using IndexedDB persistence
@@ -484,12 +494,12 @@ If y-sweet server is unreachable:
 
 ## Summary
 
-| What | How |
-|------|-----|
-| Minimum to view | Workspace ID only |
-| Structure discovery | `ydoc.share` Map |
-| Table names | Keys starting with `table:` |
-| KV keys | Entries in `'kv'` array |
-| Sync | Y-Sweet direct mode |
-| TypeScript runtime | Not needed |
-| Migrations | Not supported (view only) |
+| What                | How                         |
+| ------------------- | --------------------------- |
+| Minimum to view     | Workspace ID only           |
+| Structure discovery | `ydoc.share` Map            |
+| Table names         | Keys starting with `table:` |
+| KV keys             | Entries in `'kv'` array     |
+| Sync                | Y-Sweet direct mode         |
+| TypeScript runtime  | Not needed                  |
+| Migrations          | Not supported (view only)   |

--- a/specs/20260205T110000-unify-extension-naming.md
+++ b/specs/20260205T110000-unify-extension-naming.md
@@ -9,6 +9,7 @@
 The static and dynamic APIs use different terminology for the same concept:
 
 **Static API:**
+
 - Type: `CapabilityFactory`
 - Map type: `CapabilityMap`
 - Context: `CapabilityContext`
@@ -16,6 +17,7 @@ The static and dynamic APIs use different terminology for the same concept:
 - Client property: `client.capabilities`
 
 **Dynamic API:**
+
 - Type: `ExtensionFactory`
 - Map type: `ExtensionFactoryMap`
 - Context: `ExtensionContext`
@@ -23,6 +25,7 @@ The static and dynamic APIs use different terminology for the same concept:
 - Client property: `client.extensions`
 
 **The Inconsistency:**
+
 - The method is called `.withExtensions()` in BOTH APIs
 - But static stores them as "capabilities" while dynamic stores them as "extensions"
 - Users are confused: "Am I adding extensions or capabilities?"
@@ -32,6 +35,7 @@ The static and dynamic APIs use different terminology for the same concept:
 **Standardize on "extensions" terminology across the entire static API.**
 
 This aligns with:
+
 1. The method name `.withExtensions()`
 2. Common terminology (VSCode extensions, Chrome extensions)
 3. The dynamic API (for consistency if we ever need to reference both)
@@ -40,6 +44,7 @@ This aligns with:
 ## Scope
 
 **Files to change:**
+
 - `packages/epicenter/src/static/types.ts` - Type definitions
 - `packages/epicenter/src/static/create-workspace.ts` - Implementation
 - `packages/epicenter/src/static/index.ts` - Exports
@@ -55,64 +60,62 @@ This aligns with:
 
 **Find and replace (case-sensitive):**
 
-| Old Name | New Name | Occurrences |
-|----------|----------|-------------|
-| `CapabilityFactory` | `ExtensionFactory` | ~10 |
-| `CapabilityMap` | `ExtensionMap` | ~8 |
-| `CapabilityContext` | `ExtensionContext` | ~5 |
-| `InferCapabilityExports` | `InferExtensionExports` | ~6 |
+| Old Name                 | New Name                | Occurrences |
+| ------------------------ | ----------------------- | ----------- |
+| `CapabilityFactory`      | `ExtensionFactory`      | ~10         |
+| `CapabilityMap`          | `ExtensionMap`          | ~8          |
+| `CapabilityContext`      | `ExtensionContext`      | ~5          |
+| `InferCapabilityExports` | `InferExtensionExports` | ~6          |
 
 **Before:**
+
 ```typescript
 export type CapabilityFactory<
-  TTableDefinitions extends TableDefinitions,
-  TKvDefinitions extends KvDefinitions,
-  TExports extends Lifecycle,
-> = (
-  context: CapabilityContext<TTableDefinitions, TKvDefinitions>,
-) => TExports;
+	TTableDefinitions extends TableDefinitions,
+	TKvDefinitions extends KvDefinitions,
+	TExports extends Lifecycle,
+> = (context: CapabilityContext<TTableDefinitions, TKvDefinitions>) => TExports;
 
 export type CapabilityMap = Record<string, CapabilityFactory<any, any, any>>;
 
 export type CapabilityContext<
-  TTableDefinitions extends TableDefinitions,
-  TKvDefinitions extends KvDefinitions,
+	TTableDefinitions extends TableDefinitions,
+	TKvDefinitions extends KvDefinitions,
 > = {
-  id: string;
-  ydoc: Y.Doc;
-  tables: TablesHelper<TTableDefinitions>;
-  kv: KvHelper<TKvDefinitions>;
+	id: string;
+	ydoc: Y.Doc;
+	tables: TablesHelper<TTableDefinitions>;
+	kv: KvHelper<TKvDefinitions>;
 };
 
 export type InferCapabilityExports<TCapabilities extends CapabilityMap> = {
-  [K in keyof TCapabilities]: ReturnType<TCapabilities[K]>;
+	[K in keyof TCapabilities]: ReturnType<TCapabilities[K]>;
 };
 ```
 
 **After:**
+
 ```typescript
 export type ExtensionFactory<
-  TTableDefinitions extends TableDefinitions,
-  TKvDefinitions extends KvDefinitions,
-  TExports extends Lifecycle,
-> = (
-  context: ExtensionContext<TTableDefinitions, TKvDefinitions>,
-) => TExports;
+	TTableDefinitions extends TableDefinitions,
+	TKvDefinitions extends KvDefinitions,
+	TExports extends Lifecycle,
+> = (context: ExtensionContext<TTableDefinitions, TKvDefinitions>) => TExports;
 
 export type ExtensionMap = Record<string, ExtensionFactory<any, any, any>>;
 
 export type ExtensionContext<
-  TTableDefinitions extends TableDefinitions,
-  TKvDefinitions extends KvDefinitions,
+	TTableDefinitions extends TableDefinitions,
+	TKvDefinitions extends KvDefinitions,
 > = {
-  id: string;
-  ydoc: Y.Doc;
-  tables: TablesHelper<TTableDefinitions>;
-  kv: KvHelper<TKvDefinitions>;
+	id: string;
+	ydoc: Y.Doc;
+	tables: TablesHelper<TTableDefinitions>;
+	kv: KvHelper<TKvDefinitions>;
 };
 
 export type InferExtensionExports<TExtensions extends ExtensionMap> = {
-  [K in keyof TExtensions]: ReturnType<TExtensions[K]>;
+	[K in keyof TExtensions]: ReturnType<TExtensions[K]>;
 };
 ```
 
@@ -121,40 +124,42 @@ export type InferExtensionExports<TExtensions extends ExtensionMap> = {
 **File:** `packages/epicenter/src/static/types.ts`
 
 **Before:**
+
 ```typescript
 export type WorkspaceClient<
-  TId extends string,
-  TTableDefinitions extends TableDefinitions,
-  TKvDefinitions extends KvDefinitions,
-  TCapabilities extends CapabilityMap,
+	TId extends string,
+	TTableDefinitions extends TableDefinitions,
+	TKvDefinitions extends KvDefinitions,
+	TCapabilities extends CapabilityMap,
 > = {
-  id: TId;
-  ydoc: Y.Doc;
-  tables: TablesHelper<TTableDefinitions>;
-  kv: KvHelper<TKvDefinitions>;
-  capabilities: InferCapabilityExports<TCapabilities>;  // ← RENAME
+	id: TId;
+	ydoc: Y.Doc;
+	tables: TablesHelper<TTableDefinitions>;
+	kv: KvHelper<TKvDefinitions>;
+	capabilities: InferCapabilityExports<TCapabilities>; // ← RENAME
 
-  destroy(): Promise<void>;
-  [Symbol.asyncDispose](): Promise<void>;
+	destroy(): Promise<void>;
+	[Symbol.asyncDispose](): Promise<void>;
 };
 ```
 
 **After:**
+
 ```typescript
 export type WorkspaceClient<
-  TId extends string,
-  TTableDefinitions extends TableDefinitions,
-  TKvDefinitions extends KvDefinitions,
-  TExtensions extends ExtensionMap,  // ← Rename type param
+	TId extends string,
+	TTableDefinitions extends TableDefinitions,
+	TKvDefinitions extends KvDefinitions,
+	TExtensions extends ExtensionMap, // ← Rename type param
 > = {
-  id: TId;
-  ydoc: Y.Doc;
-  tables: TablesHelper<TTableDefinitions>;
-  kv: KvHelper<TKvDefinitions>;
-  extensions: InferExtensionExports<TExtensions>;  // ← RENAMED
+	id: TId;
+	ydoc: Y.Doc;
+	tables: TablesHelper<TTableDefinitions>;
+	kv: KvHelper<TKvDefinitions>;
+	extensions: InferExtensionExports<TExtensions>; // ← RENAMED
 
-  destroy(): Promise<void>;
-  [Symbol.asyncDispose](): Promise<void>;
+	destroy(): Promise<void>;
+	[Symbol.asyncDispose](): Promise<void>;
 };
 ```
 
@@ -163,10 +168,12 @@ export type WorkspaceClient<
 Throughout `types.ts`, rename the 4th type parameter from `TCapabilities` to `TExtensions`:
 
 **Find and replace:**
+
 - `TCapabilities extends CapabilityMap` → `TExtensions extends ExtensionMap`
 - References to `TCapabilities` → `TExtensions`
 
 **Affected types:**
+
 - `WorkspaceClient<TId, TTableDefs, TKvDefs, TCapabilities>` → `WorkspaceClient<TId, TTableDefs, TKvDefs, TExtensions>`
 - `WorkspaceClientBuilder<TId, TTableDefs, TKvDefs>` → (no change, it doesn't have extensions yet)
 - `WorkspaceClientWithActions<..., TCapabilities, ...>` → `WorkspaceClientWithActions<..., TExtensions, ...>`
@@ -179,6 +186,7 @@ Throughout `types.ts`, rename the 4th type parameter from `TCapabilities` to `TE
 **Changes:**
 
 1. Rename `.withExtensions()` parameter type:
+
 ```typescript
 // Before
 withExtensions<TCapabilities extends CapabilityMap>(
@@ -192,38 +200,34 @@ withExtensions<TExtensions extends ExtensionMap>(
 ```
 
 2. Rename internal variable:
+
 ```typescript
 // Before
 const capabilities = Object.fromEntries(
-  Object.entries(extensions).map(([key, factory]) => [
-    key,
-    factory(context),
-  ])
+	Object.entries(extensions).map(([key, factory]) => [key, factory(context)]),
 ) as InferCapabilityExports<TCapabilities>;
 
 // After
 const extensionExports = Object.fromEntries(
-  Object.entries(extensions).map(([key, factory]) => [
-    key,
-    factory(context),
-  ])
+	Object.entries(extensions).map(([key, factory]) => [key, factory(context)]),
 ) as InferExtensionExports<TExtensions>;
 ```
 
 3. Update return object:
+
 ```typescript
 // Before
 return {
-  ...baseClient,
-  capabilities,
-  // ...
+	...baseClient,
+	capabilities,
+	// ...
 };
 
 // After
 return {
-  ...baseClient,
-  extensions: extensionExports,
-  // ...
+	...baseClient,
+	extensions: extensionExports,
+	// ...
 };
 ```
 
@@ -236,22 +240,22 @@ return {
 ```typescript
 // Before
 export type {
-  // ...
-  CapabilityContext,
-  CapabilityFactory,
-  CapabilityMap,
-  InferCapabilityExports,
-  // ...
+	// ...
+	CapabilityContext,
+	CapabilityFactory,
+	CapabilityMap,
+	InferCapabilityExports,
+	// ...
 } from './types.js';
 
 // After
 export type {
-  // ...
-  ExtensionContext,
-  ExtensionFactory,
-  ExtensionMap,
-  InferExtensionExports,
-  // ...
+	// ...
+	ExtensionContext,
+	ExtensionFactory,
+	ExtensionMap,
+	InferExtensionExports,
+	// ...
 } from './types.js';
 ```
 
@@ -260,11 +264,13 @@ export type {
 **Files:** `/packages/epicenter/src/extensions/**/*.ts`
 
 These files currently import from dynamic:
+
 ```typescript
 import { ExtensionFactory } from '../../dynamic';
 ```
 
 After this refactor, they can import from static:
+
 ```typescript
 import { ExtensionFactory } from '../../static/types';
 ```
@@ -289,6 +295,7 @@ Search for mentions of "capability" in comments and documentation, update to "ex
 If you're using the static API, you'll need to update your code:
 
 ### Type Imports
+
 ```typescript
 // Before
 import type { CapabilityFactory, CapabilityMap } from '@epicenter/hq/static';
@@ -298,9 +305,9 @@ import type { ExtensionFactory, ExtensionMap } from '@epicenter/hq/static';
 ```
 
 ### Client Property Access
+
 ```typescript
-const client = createWorkspace(def)
-  .withExtensions({ persistence });
+const client = createWorkspace(def).withExtension('persistence', persistence);
 
 // Before
 client.capabilities.persistence.save();
@@ -310,6 +317,7 @@ client.extensions.persistence.save();
 ```
 
 ### Extension Definitions
+
 ```typescript
 // Before
 export const myExtension: CapabilityFactory<TTableDefs, TKvDefs, MyExports> = (context) => {
@@ -323,6 +331,7 @@ export const myExtension: ExtensionFactory<TTableDefs, TKvDefs, MyExports> = (co
 ```
 
 ### Generic Type Parameters
+
 ```typescript
 // Before
 function useWorkspace<TCapabilities extends CapabilityMap>(
@@ -338,21 +347,25 @@ function useWorkspace<TExtensions extends ExtensionMap>(
 ## Testing Strategy
 
 ### 1. Type Tests
+
 - Verify all type exports are renamed correctly
 - Check that `WorkspaceClient` type has `extensions` property
 - Ensure generic type parameters work with new names
 
 ### 2. Runtime Tests
+
 - Run existing test suite - should pass with no changes
 - Add test that accesses `client.extensions` property
 - Verify `.withExtensions()` method still works
 
 ### 3. Integration Tests
+
 - Build a workspace with extensions
 - Access extension exports via `client.extensions`
 - Verify `whenSynced` and `destroy` work on extensions
 
 ### 4. Example Apps
+
 - Update tab-manager app if it uses static API with extensions
 - Test that apps compile and run
 - Verify no runtime errors
@@ -394,6 +407,7 @@ function useWorkspace<TExtensions extends ExtensionMap>(
 ## Rollback Plan
 
 If this breaks too much:
+
 1. Revert all commits from this change
 2. Consider adding type aliases for backwards compatibility:
    ```typescript
@@ -425,15 +439,17 @@ If this breaks too much:
 **Consistency:** Method is `.withExtensions()` but you access `.capabilities`? Confusing!
 
 **Before:**
+
 ```typescript
-.withExtensions({ persistence })  // Adding extensions...
-client.capabilities.persistence   // ...but they're called capabilities?
+.withExtension('persistence', persistence)  // Adding extensions...
+client.capabilities.persistence             // ...but they're called capabilities?
 ```
 
 **After:**
+
 ```typescript
-.withExtensions({ persistence })  // Adding extensions...
-client.extensions.persistence     // ...and they're called extensions! ✓
+.withExtension('persistence', persistence)  // Adding extensions...
+client.extensions.persistence               // ...and they're called extensions! ✓
 ```
 
 **User Experience:** Reduces cognitive load, aligns with ecosystem norms, makes API more intuitive.

--- a/specs/20260213T003800-y-sweet-sync-reconnect.md
+++ b/specs/20260213T003800-y-sweet-sync-reconnect.md
@@ -45,14 +45,12 @@ export function ySweetSync(config: YSweetSyncConfig): ExtensionFactory {
 }
 ```
 
-And `withExtensions()` runs factories once at construction with no re-registration path:
+And `.withExtension()` runs factories once at construction with no re-registration path:
 
 ```typescript
 // packages/epicenter/src/dynamic/workspace/create-workspace.ts (line 122)
-for (const [extensionId, factory] of Object.entries(extensionFactories)) {
-	const result = factory(context);
-	extensions[extensionId] = defineExports(result); // written once, never reassigned
-}
+// Each .withExtension() call creates a new client with the extension added
+// The extension is written once, never reassigned
 ```
 
 This creates two problems:
@@ -84,12 +82,13 @@ If the provider is destroyed but the Y.Doc lives on (which is exactly what `reco
 ### Desired State
 
 ```typescript
-const workspace = createWorkspace(definition).withExtensions({
-	sync: ySweetSync({
+const workspace = createWorkspace(definition).withExtension(
+	'sync',
+	ySweetSync({
 		auth: directAuth('http://localhost:8080'),
 		persistence: indexeddbPersistence,
 	}),
-});
+);
 
 await workspace.whenSynced;
 

--- a/specs/20260213T102800-chainable-extension-api.md
+++ b/specs/20260213T102800-chainable-extension-api.md
@@ -1,0 +1,810 @@
+# Chainable Extension API
+
+**Date**: 2026-02-13
+**Status**: Draft
+
+## Overview
+
+Replace `.withExtensions(map)` with a chainable `.withExtension(key, factory)` API on the workspace builder. Each call adds one extension and returns a new builder with the accumulated type information. Later extensions receive the client-so-far as their context, enabling progressive access to previously-declared extensions.
+
+## Motivation
+
+### The Map Pattern Obscures Dependencies
+
+The current API passes all extensions as a flat object:
+
+```typescript
+createWorkspace(definition).withExtensions({
+	persistence: indexeddbPersistence,
+	sync: ySweetSync({
+		auth: directAuth('...'),
+		persistence: indexeddbPersistence,
+	}),
+	sqlite: sqliteExtension,
+});
+```
+
+All extensions are initialized in iteration order, but the type system can't express that `sync` might depend on `persistence`. Dependencies are invisible — `ySweetSync` takes `persistence` as a config option and handles composition internally. This works but creates parallel composition mechanisms (extension map + internal config) when one would do.
+
+### The Singular Pattern Mirrors How Builders Work
+
+Every other builder method in the codebase is singular and chainable (`.withActions()`). Extensions should follow the same pattern:
+
+```typescript
+createWorkspace(definition)
+	.withExtension('persistence', indexeddbPersistence)
+	.withExtension('sync', ySweetSync({ auth: directAuth('...') }))
+	.withExtension('sqlite', sqliteExtension);
+```
+
+Each call returns a usable client with progressive type narrowing. The chain reads top-to-bottom, dependencies are explicit, and TypeScript can enforce that a factory can only access extensions that precede it.
+
+## Design Decisions
+
+| Decision               | Choice                                  | Rationale                                              |
+| ---------------------- | --------------------------------------- | ------------------------------------------------------ |
+| API shape              | `.withExtension(key, factory)` singular | Matches builder convention, enables chaining           |
+| Backward compat        | Clean break, remove `.withExtensions()` | Avoids two ways to do the same thing                   |
+| Extension context      | Client-so-far (minus lifecycle)         | Simpler mental model, fewer special types              |
+| `.withActions()`       | Available at every point, terminal      | Actions are always last, never followed by extensions  |
+| Both APIs              | Static + Dynamic updated                | They share the same builder concept                    |
+| ySweetSync composition | Keep internal persistence option        | Orchestration order (persistence-first) is intentional |
+
+## Current API (Before)
+
+### Static API
+
+```typescript
+// packages/epicenter/src/static/create-workspace.ts
+const client = createWorkspace(definition).withExtensions({
+	persistence: indexeddbPersistence,
+	sync: ySweetSync({
+		auth: directAuth('...'),
+		persistence: indexeddbPersistence,
+	}),
+});
+
+client.extensions.persistence.whenSynced;
+client.extensions.sync.provider;
+```
+
+**Types:**
+
+```typescript
+type ExtensionMap = Record<string, (...args: any[]) => Lifecycle>;
+
+type WorkspaceClientBuilder<TId, TTableDefs, TKvDefs> =
+  WorkspaceClient<TId, TTableDefs, TKvDefs, Record<string, never>> & {
+    withExtensions<TExtensions extends ExtensionMap>(
+      extensions: TExtensions,
+    ): WorkspaceClient<TId, TTableDefs, TKvDefs, TExtensions> & {
+      withActions<TActions extends Actions>(
+        factory: (client: WorkspaceClient<...>) => TActions,
+      ): WorkspaceClientWithActions<...>;
+    };
+    withActions<TActions extends Actions>(...): WorkspaceClientWithActions<...>;
+  };
+```
+
+### Dynamic API
+
+```typescript
+// packages/epicenter/src/dynamic/workspace/create-workspace.ts
+const workspace = createWorkspace(definition).withExtensions({
+	persistence: (ctx) => workspacePersistence(ctx),
+});
+
+await workspace.whenSynced;
+```
+
+**Types:**
+
+```typescript
+type ExtensionFactoryMap = Record<string, (...args: any[]) => Lifecycle>;
+
+type WorkspaceClientBuilder<TTableDefs, TKvFields> = WorkspaceClient<
+	TTableDefs,
+	TKvFields,
+	Record<string, never>
+> & {
+	withExtensions<TExtensions extends ExtensionFactoryMap>(
+		extensions: TExtensions,
+	): WorkspaceClient<TTableDefs, TKvFields, TExtensions>;
+};
+```
+
+## New API (After)
+
+### Usage
+
+```typescript
+// No extensions — works immediately
+const client = createWorkspace(definition);
+client.tables.posts.set({ id: '1', title: 'Hello' });
+
+// Single extension
+const client = createWorkspace(definition)
+  .withExtension('persistence', indexeddbPersistence);
+
+// Multiple extensions (chained)
+const client = createWorkspace(definition)
+  .withExtension('persistence', indexeddbPersistence)
+  .withExtension('sync', ySweetSync({ auth: directAuth('...') }))
+  .withExtension('sqlite', sqliteExtension);
+
+// With actions (terminal)
+const client = createWorkspace(definition)
+  .withExtension('persistence', indexeddbPersistence)
+  .withActions((client) => ({
+    createPost: defineMutation({ ... }),
+  }));
+```
+
+### Type Signatures — Static API
+
+```typescript
+/**
+ * The base workspace client. Always usable.
+ */
+type WorkspaceClient<
+	TId extends string,
+	TTableDefs extends TableDefinitions,
+	TKvDefs extends KvDefinitions,
+	TExtensions extends Record<string, Lifecycle>,
+> = {
+	id: TId;
+	ydoc: Y.Doc;
+	tables: TablesHelper<TTableDefs>;
+	kv: KvHelper<TKvDefs>;
+	definitions: { tables: TTableDefs; kv: TKvDefs };
+	extensions: TExtensions;
+	destroy(): Promise<void>;
+	[Symbol.asyncDispose](): Promise<void>;
+};
+
+/**
+ * Context passed to extension factories.
+ * This IS the client-so-far, minus lifecycle methods.
+ */
+type ExtensionContext<
+	TId extends string,
+	TTableDefs extends TableDefinitions,
+	TKvDefs extends KvDefinitions,
+	TExtensions extends Record<string, Lifecycle>,
+> = {
+	id: TId;
+	ydoc: Y.Doc;
+	tables: TablesHelper<TTableDefs>;
+	kv: KvHelper<TKvDefs>;
+	extensions: TExtensions;
+};
+
+/**
+ * Builder returned by createWorkspace() and by each .withExtension() call.
+ * IS a usable client AND has .withExtension() + .withActions().
+ */
+type WorkspaceClientBuilder<
+	TId extends string,
+	TTableDefs extends TableDefinitions,
+	TKvDefs extends KvDefinitions,
+	TExtensions extends Record<string, Lifecycle>,
+> = WorkspaceClient<TId, TTableDefs, TKvDefs, TExtensions> & {
+	/**
+	 * Add a single extension. Returns a new builder with the extension's
+	 * exports accumulated into the extensions type.
+	 */
+	withExtension<TKey extends string, TExports extends Lifecycle>(
+		key: TKey,
+		factory: (
+			context: ExtensionContext<TId, TTableDefs, TKvDefs, TExtensions>,
+		) => TExports,
+	): WorkspaceClientBuilder<
+		TId,
+		TTableDefs,
+		TKvDefs,
+		TExtensions & Record<TKey, TExports>
+	>;
+
+	/**
+	 * Attach actions. Terminal — no more chaining after this.
+	 */
+	withActions<TActions extends Actions>(
+		factory: (
+			client: WorkspaceClient<TId, TTableDefs, TKvDefs, TExtensions>,
+		) => TActions,
+	): WorkspaceClientWithActions<
+		TId,
+		TTableDefs,
+		TKvDefs,
+		TExtensions,
+		TActions
+	>;
+};
+```
+
+**Key type mechanic**: Each `.withExtension()` call returns `WorkspaceClientBuilder<..., TExtensions & Record<TKey, TExports>>`. TypeScript intersects the previous extensions with the new one. The next factory's context sees all accumulated extensions.
+
+### Type Signatures — Dynamic API
+
+```typescript
+type WorkspaceClient<
+	TTableDefs extends readonly TableDefinition[],
+	TKvFields extends readonly KvField[],
+	TExtensions extends Record<string, Lifecycle>,
+> = {
+	id: string;
+	ydoc: Y.Doc;
+	tables: Tables<TTableDefs>;
+	kv: Kv<TKvFields>;
+	extensions: TExtensions;
+	whenSynced: Promise<void>;
+	destroy(): Promise<void>;
+	[Symbol.asyncDispose](): Promise<void>;
+};
+
+type ExtensionContext<
+	TTableDefs extends readonly TableDefinition[],
+	TKvFields extends readonly KvField[],
+	TExtensions extends Record<string, Lifecycle>,
+> = {
+	id: string;
+	ydoc: Y.Doc;
+	tables: Tables<TTableDefs>;
+	kv: Kv<TKvFields>;
+	extensions: TExtensions;
+};
+
+type WorkspaceClientBuilder<
+	TTableDefs extends readonly TableDefinition[],
+	TKvFields extends readonly KvField[],
+	TExtensions extends Record<string, Lifecycle>,
+> = WorkspaceClient<TTableDefs, TKvFields, TExtensions> & {
+	withExtension<TKey extends string, TExports extends Lifecycle>(
+		key: TKey,
+		factory: (
+			context: ExtensionContext<TTableDefs, TKvFields, TExtensions>,
+		) => TExports,
+	): WorkspaceClientBuilder<
+		TTableDefs,
+		TKvFields,
+		TExtensions & Record<TKey, TExports>
+	>;
+};
+```
+
+Note: The dynamic API currently has no `.withActions()`. Adding it is out of scope for this refactor but the builder pattern makes it trivial to add later.
+
+## Context Simplification
+
+### Before (two different shapes)
+
+**Static ExtensionContext:**
+
+```typescript
+{
+	(ydoc, id, tables, kv);
+}
+```
+
+**Dynamic ExtensionContext:**
+
+```typescript
+{
+	(ydoc, id, definition, tables, kv, extensionId);
+}
+```
+
+### After (client-so-far, unified shape)
+
+**Both APIs:**
+
+```typescript
+{
+	(id, ydoc, tables, kv, extensions);
+}
+```
+
+**What's dropped and why:**
+
+| Dropped field | API     | Reason                                                                                                                                      |
+| ------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `extensionId` | Dynamic | Now the first argument to `.withExtension(key, ...)` — the factory knows its key from the call site                                         |
+| `definition`  | Dynamic | Workspace definitions are available via the client. For extensions that need the full definition, they can close over it from the call site |
+| `definitions` | Static  | Omitted from context to keep it lean. Available on the returned client. If an extension needs it, pass via closure                          |
+
+**Tradeoff acknowledged:** Extensions that currently destructure `extensionId` or `definition` from context will need minor refactoring. `extensionId` is trivially replaced (it's the key string). `definition` requires either closing over it or adding it to the dynamic client type.
+
+For the dynamic API, if extensions commonly need `definition`, it can be added to the context type:
+
+```typescript
+// Dynamic-only: include definition if extensions need it
+type ExtensionContext<TTableDefs, TKvFields, TExtensions> = {
+	id: string;
+	ydoc: Y.Doc;
+	definition: WorkspaceDefinition<TTableDefs, TKvFields>;
+	tables: Tables<TTableDefs>;
+	kv: Kv<TKvFields>;
+	extensions: TExtensions;
+};
+```
+
+This is an implementation decision — the implementer should check how many extensions actually use `definition` and decide.
+
+## Progressive Type Safety — Worked Example
+
+```typescript
+const client = createWorkspace(definition)
+	// Factory receives: { id, ydoc, tables, kv, extensions: {} }
+	.withExtension('persistence', ({ ydoc }) => {
+		const idb = new IndexeddbPersistence(ydoc.guid, ydoc);
+		return defineExports({
+			whenSynced: idb.whenSynced,
+			destroy: () => idb.destroy(),
+			clearData: () => idb.clearData(),
+		});
+	})
+	// Factory receives: { id, ydoc, tables, kv, extensions: { persistence: { clearData, ... } } }
+	.withExtension('sync', ({ ydoc, extensions }) => {
+		// extensions.persistence is fully typed here!
+		// Could access extensions.persistence.clearData if needed
+		const provider = createYjsProvider(ydoc, ydoc.guid, authEndpoint);
+		return defineExports({
+			provider,
+			whenSynced: waitForFirstSync(provider),
+			destroy: () => provider.destroy(),
+		});
+	});
+
+// client.extensions.persistence.clearData — typed
+// client.extensions.sync.provider — typed
+```
+
+## Implementation — Static `createWorkspace.ts`
+
+The core change is replacing the single `withExtensions(map)` method with a recursive `buildClient` that returns a new builder each time.
+
+```typescript
+export function createWorkspace<
+	TId extends string,
+	TTableDefs extends TableDefinitions = Record<string, never>,
+	TKvDefs extends KvDefinitions = Record<string, never>,
+>(
+	config: WorkspaceDefinition<TId, TTableDefs, TKvDefs>,
+): WorkspaceClientBuilder<TId, TTableDefs, TKvDefs, Record<string, never>> {
+	const { id } = config;
+	const ydoc = new Y.Doc({ guid: id });
+	const tableDefs = (config.tables ?? {}) as TTableDefs;
+	const kvDefs = (config.kv ?? {}) as TKvDefs;
+	const tables = createTables(ydoc, tableDefs);
+	const kv = createKv(ydoc, kvDefs);
+	const definitions = { tables: tableDefs, kv: kvDefs };
+
+	// Internal state: accumulated cleanup functions
+	// Shared across the builder chain (same ydoc)
+	const extensionCleanups: (() => MaybePromise<void>)[] = [];
+
+	function buildClient<TExtensions extends Record<string, Lifecycle>>(
+		extensions: TExtensions,
+	): WorkspaceClientBuilder<TId, TTableDefs, TKvDefs, TExtensions> {
+		const destroy = async (): Promise<void> => {
+			// Destroy extensions in reverse order (last added = first destroyed)
+			for (let i = extensionCleanups.length - 1; i >= 0; i--) {
+				await extensionCleanups[i]!();
+			}
+			ydoc.destroy();
+		};
+
+		const client = {
+			id,
+			ydoc,
+			tables,
+			kv,
+			definitions,
+			extensions,
+			destroy,
+			[Symbol.asyncDispose]: destroy,
+		};
+
+		return Object.assign(client, {
+			withExtension<TKey extends string, TExports extends Lifecycle>(
+				key: TKey,
+				factory: (
+					context: ExtensionContext<TId, TTableDefs, TKvDefs, TExtensions>,
+				) => TExports,
+			) {
+				const exports = factory({ id, ydoc, tables, kv, extensions });
+				extensionCleanups.push(() => exports.destroy());
+
+				const newExtensions = {
+					...extensions,
+					[key]: exports,
+				} as TExtensions & Record<TKey, TExports>;
+
+				return buildClient(newExtensions);
+			},
+
+			withActions<TActions extends Actions>(
+				factory: (
+					client: WorkspaceClient<TId, TTableDefs, TKvDefs, TExtensions>,
+				) => TActions,
+			) {
+				const actions = factory(
+					client as WorkspaceClient<TId, TTableDefs, TKvDefs, TExtensions>,
+				);
+				return { ...client, actions } as WorkspaceClientWithActions<
+					TId,
+					TTableDefs,
+					TKvDefs,
+					TExtensions,
+					TActions
+				>;
+			},
+		});
+	}
+
+	return buildClient({} as Record<string, never>);
+}
+```
+
+**Key details:**
+
+- `extensionCleanups` is shared mutable state across the chain. Each `.withExtension()` call pushes to it and returns a new typed view.
+- Destroy runs cleanups in **reverse order** (LIFO). Extensions added last depend on earlier ones, so they should be torn down first.
+- The `extensions` parameter to `buildClient` is the typed view used for the return type and context.
+
+## Implementation — Dynamic `createWorkspace.ts`
+
+Same pattern as static, but with the dynamic API's type parameters and `whenSynced` aggregation:
+
+```typescript
+export function createWorkspace<
+	const TTableDefs extends readonly TableDefinition[],
+	const TKvFields extends readonly KvField[],
+>(
+	definition: WorkspaceDefinition<TTableDefs, TKvFields>,
+): WorkspaceClientBuilder<TTableDefs, TKvFields, Record<string, never>> {
+	const id = definition.id;
+	const ydoc = new Y.Doc({ guid: id, gc: true });
+	const tables = createTables(ydoc, definition.tables ?? []);
+	const kv = createKv(ydoc, definition.kv ?? []);
+
+	const extensionCleanups: (() => MaybePromise<void>)[] = [];
+	const whenSyncedPromises: Promise<unknown>[] = [];
+
+	function buildClient<TExtensions extends Record<string, Lifecycle>>(
+		extensions: TExtensions,
+	): WorkspaceClientBuilder<TTableDefs, TKvFields, TExtensions> {
+		const whenSynced = Promise.all(whenSyncedPromises).then(() => {});
+
+		const destroy = async (): Promise<void> => {
+			for (let i = extensionCleanups.length - 1; i >= 0; i--) {
+				await extensionCleanups[i]!();
+			}
+			ydoc.destroy();
+		};
+
+		const client = {
+			id,
+			ydoc,
+			tables,
+			kv,
+			extensions,
+			whenSynced,
+			destroy,
+			[Symbol.asyncDispose]: destroy,
+		};
+
+		return Object.assign(client, {
+			withExtension<TKey extends string, TExports extends Lifecycle>(
+				key: TKey,
+				factory: (
+					context: ExtensionContext<TTableDefs, TKvFields, TExtensions>,
+				) => TExports,
+			) {
+				const result = factory({ id, ydoc, tables, kv, extensions });
+				const exports = defineExports(
+					result as Record<string, unknown>,
+				) as unknown as TExports;
+				extensionCleanups.push(() => exports.destroy());
+				whenSyncedPromises.push(exports.whenSynced);
+
+				const newExtensions = {
+					...extensions,
+					[key]: exports,
+				} as TExtensions & Record<TKey, TExports>;
+
+				return buildClient(newExtensions);
+			},
+		});
+	}
+
+	return buildClient({} as Record<string, never>);
+}
+```
+
+**Dynamic-specific notes:**
+
+- `whenSynced` is recomputed at each builder step from the accumulated promises list.
+- `defineExports()` normalization is preserved — factories can return bare objects and lifecycle defaults are filled in.
+
+## How Existing Extensions Adapt
+
+### `indexeddbPersistence` — No change needed
+
+```typescript
+// Before
+export function indexeddbPersistence({ ydoc }: { ydoc: Y.Doc }) { ... }
+
+// After — same signature, works as-is
+.withExtension('persistence', indexeddbPersistence)
+```
+
+The function destructures `{ ydoc }` from the context. Since the new context is a superset (`{ id, ydoc, tables, kv, extensions }`), destructuring `{ ydoc }` still works.
+
+### `ySweetSync` — No change needed
+
+```typescript
+// Before
+createWorkspace(def).withExtensions({
+	sync: ySweetSync({
+		auth: directAuth('...'),
+		persistence: indexeddbPersistence,
+	}),
+});
+
+// After
+createWorkspace(def).withExtension(
+	'sync',
+	ySweetSync({
+		auth: directAuth('...'),
+		persistence: indexeddbPersistence,
+	}),
+);
+```
+
+`ySweetSync(config)` returns a factory function `({ ydoc }) => Lifecycle`. The returned factory destructures `{ ydoc }` from context — works unchanged.
+
+### `persistence` (desktop) — No change needed
+
+```typescript
+// Before
+.withExtensions({
+  persistence: (ctx) => persistence(ctx, { filePath: '...' }),
+})
+
+// After
+.withExtension('persistence', (ctx) => persistence(ctx, { filePath: '...' }))
+```
+
+### `workspacePersistence` (Tauri app) — Minor fix
+
+```typescript
+// Before (has a bug: uses ctx.workspaceId but type has ctx.id)
+// After — fix the bug, use ctx.id
+.withExtension('persistence', (ctx) => workspacePersistence(ctx))
+```
+
+The `workspacePersistence` function currently destructures `{ ydoc, workspaceId, kv }` from `ExtensionContext`. The field is `id` not `workspaceId` (pre-existing bug). Fix by changing the destructure to `{ ydoc, id, kv }`.
+
+### Extensions that use `extensionId` — Minor change
+
+Any extension that uses `extensionId` from the dynamic context would need to get it from the key argument at the call site instead. In practice, `extensionId` is rarely used. Grep for it and update any occurrences.
+
+## Migration Guide — Call Sites
+
+### `apps/tab-manager/src/lib/workspace.ts`
+
+```typescript
+// Before
+export const popupWorkspace = createWorkspace(definition).withExtensions({
+	sync: ySweetSync({
+		auth: directAuth('http://127.0.0.1:8080'),
+		persistence: indexeddbPersistence,
+	}),
+});
+
+// After
+export const popupWorkspace = createWorkspace(definition).withExtension(
+	'sync',
+	ySweetSync({
+		auth: directAuth('http://127.0.0.1:8080'),
+		persistence: indexeddbPersistence,
+	}),
+);
+```
+
+### `apps/tab-manager/src/entrypoints/background.ts`
+
+```typescript
+// Before
+const client = createWorkspace(definition).withExtensions({
+	sync: ySweetSync({
+		auth: directAuth('http://127.0.0.1:8080'),
+		persistence: indexeddbPersistence,
+	}),
+});
+
+// After
+const client = createWorkspace(definition).withExtension(
+	'sync',
+	ySweetSync({
+		auth: directAuth('http://127.0.0.1:8080'),
+		persistence: indexeddbPersistence,
+	}),
+);
+```
+
+### `apps/epicenter/src/lib/yjs/workspace.ts`
+
+```typescript
+// Before
+return createWorkspace(definition).withExtensions({
+	persistence: (ctx) => workspacePersistence(ctx),
+});
+
+// After
+return createWorkspace(definition).withExtension('persistence', (ctx) =>
+	workspacePersistence(ctx),
+);
+```
+
+### Test files
+
+All test files that use `.withExtensions({...})` need mechanical conversion:
+
+```typescript
+// Before
+const client = createWorkspace({...}).withExtensions({
+  mock: mockExtension,
+  sync: syncExtension,
+});
+
+// After
+const client = createWorkspace({...})
+  .withExtension('mock', mockExtension)
+  .withExtension('sync', syncExtension);
+```
+
+## Type Changes Summary
+
+### Removed types
+
+| Type                       | Location                     | Replacement                                               |
+| -------------------------- | ---------------------------- | --------------------------------------------------------- |
+| `ExtensionMap`             | `static/types.ts`            | No longer needed — extensions are added one at a time     |
+| `ExtensionFactoryMap`      | `dynamic/workspace/types.ts` | No longer needed                                          |
+| `InferExtensionExports<T>` | Both                         | No longer needed — extensions accumulate via intersection |
+
+### Changed types
+
+| Type                     | Change                                                                                              |
+| ------------------------ | --------------------------------------------------------------------------------------------------- |
+| `WorkspaceClient`        | `TExtensions` constraint changes from `extends ExtensionMap` to `extends Record<string, Lifecycle>` |
+| `WorkspaceClientBuilder` | Adds `TExtensions` generic param, replaces `withExtensions` with `withExtension`                    |
+| `ExtensionContext`       | Simplified to client-so-far shape, gains `extensions` field, parameterized by `TExtensions`         |
+| `ExtensionFactory`       | Removed as standalone type. Factory signature is inline in `withExtension`'s parameter              |
+
+### New types
+
+None. The refactor simplifies by removing types, not adding them.
+
+## Related: ySweetSync Naming
+
+The `ySweetSync` extension composes both persistence and sync into a single lifecycle. It's not purely "sync" — it orchestrates:
+
+1. Load from persistence (IndexedDB/filesystem)
+2. Connect WebSocket in background
+3. Coordinate `whenSynced` to resolve on persistence load (not network)
+4. Destroy both on cleanup
+
+The name `ySweetSync` undersells what it does. Consider renaming to something that reflects the composed nature:
+
+- `ySweetProvider` — mirrors Yjs terminology ("provider" = thing that connects a Y.Doc to something)
+- `ySweetConnection` — describes the full connection lifecycle
+- `ySweet` — simplest, since it IS the Y-Sweet integration
+
+Additionally, `persistence` being optional in `YSweetSyncConfig` is questionable. The entire design assumes a local-first pattern where persistence loads first. Without persistence, it degrades to a simple WebSocket provider — which `websocket-sync.ts` already covers.
+
+**Recommendation for future work (out of scope for this spec):**
+
+1. Rename `ySweetSync` to `ySweet` (or `ySweetProvider`)
+2. Make `persistence` required in the config
+3. For "sync only, no persistence" use cases, point users to `websocket-sync.ts`
+
+## Implementation Plan
+
+### Phase 1: Type changes
+
+- [ ] Update `WorkspaceClient` type to use `TExtensions extends Record<string, Lifecycle>` in both APIs
+- [ ] Replace `WorkspaceClientBuilder` type with `withExtension(key, factory)` signature in both APIs
+- [ ] Simplify `ExtensionContext` to client-so-far shape in both APIs
+- [ ] Remove `ExtensionMap`, `ExtensionFactoryMap`, `InferExtensionExports` types
+- [ ] Update `ExtensionFactory` type or remove it (check if extension authors import it)
+
+### Phase 2: Implementation — Static API
+
+- [ ] Rewrite `createWorkspace()` in `packages/epicenter/src/static/create-workspace.ts` with the recursive `buildClient` pattern
+- [ ] Ensure `withActions()` is available on every builder step
+- [ ] Ensure `destroy()` runs cleanups in reverse order
+
+### Phase 3: Implementation — Dynamic API
+
+- [ ] Rewrite `createWorkspace()` in `packages/epicenter/src/dynamic/workspace/create-workspace.ts` with the recursive `buildClient` pattern
+- [ ] Ensure `whenSynced` is correctly aggregated across the chain
+- [ ] Ensure `destroy()` runs cleanups in reverse order
+
+### Phase 4: Update extension re-exports
+
+- [ ] Update `packages/epicenter/src/dynamic/extension.ts` — remove/update re-exported types
+- [ ] Update `packages/epicenter/src/static/index.ts` — update exports
+- [ ] Update any barrel files that re-export `ExtensionMap`, `ExtensionFactoryMap`, etc.
+
+### Phase 5: Migrate call sites
+
+- [ ] `apps/tab-manager/src/lib/workspace.ts`
+- [ ] `apps/tab-manager/src/entrypoints/background.ts`
+- [ ] `apps/epicenter/src/lib/yjs/workspace.ts`
+- [ ] Fix `apps/epicenter/src/lib/yjs/workspace-persistence.ts` — `workspaceId` to `id` (pre-existing bug)
+
+### Phase 6: Migrate tests
+
+- [ ] `packages/epicenter/src/static/define-workspace.test.ts` — update all `.withExtensions()` calls
+- [ ] `packages/epicenter/src/dynamic/workspace/create-workspace.test.ts` — update all `.withExtensions()` calls
+- [ ] `packages/epicenter/src/extensions/y-sweet-sync.test.ts` — verify factory still works with new context shape
+- [ ] Add new test: progressive type access (extension N+1 can access extension N's exports)
+- [ ] Add new test: `.withActions()` works after `.withExtension()` chain (static API)
+- [ ] Add new test: destroy runs in reverse order
+
+### Phase 7: Verify
+
+- [ ] Run `bun test` across affected packages
+- [ ] Run `bun run typecheck` to verify no type errors
+- [ ] Grep for any remaining `.withExtensions(` references and update them
+
+## Files Changed
+
+| File                                                                | Change                                                                                                                                            |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/epicenter/src/static/types.ts`                            | Remove `ExtensionMap`, `InferExtensionExports`; update `WorkspaceClient`, `WorkspaceClientBuilder`, `ExtensionContext`, `ExtensionFactory`        |
+| `packages/epicenter/src/static/create-workspace.ts`                 | Rewrite builder with recursive `buildClient` + `withExtension`                                                                                    |
+| `packages/epicenter/src/dynamic/workspace/types.ts`                 | Remove `ExtensionFactoryMap`, `InferExtensionExports`; update `WorkspaceClient`, `WorkspaceClientBuilder`, `ExtensionContext`, `ExtensionFactory` |
+| `packages/epicenter/src/dynamic/workspace/create-workspace.ts`      | Rewrite builder with recursive `buildClient` + `withExtension`                                                                                    |
+| `packages/epicenter/src/dynamic/extension.ts`                       | Update re-exports                                                                                                                                 |
+| `packages/epicenter/src/static/index.ts`                            | Update exports                                                                                                                                    |
+| `packages/epicenter/src/extensions/y-sweet-sync.ts`                 | No change (factory signature compatible)                                                                                                          |
+| `packages/epicenter/src/extensions/persistence/web.ts`              | No change                                                                                                                                         |
+| `packages/epicenter/src/extensions/persistence/desktop.ts`          | No change                                                                                                                                         |
+| `apps/tab-manager/src/lib/workspace.ts`                             | Migrate call site                                                                                                                                 |
+| `apps/tab-manager/src/entrypoints/background.ts`                    | Migrate call site                                                                                                                                 |
+| `apps/epicenter/src/lib/yjs/workspace.ts`                           | Migrate call site                                                                                                                                 |
+| `apps/epicenter/src/lib/yjs/workspace-persistence.ts`               | Fix `workspaceId` to `id` bug                                                                                                                     |
+| `packages/epicenter/src/static/define-workspace.test.ts`            | Migrate tests                                                                                                                                     |
+| `packages/epicenter/src/dynamic/workspace/create-workspace.test.ts` | Migrate tests                                                                                                                                     |
+| `packages/epicenter/src/extensions/y-sweet-sync.test.ts`            | Verify compatibility                                                                                                                              |
+
+## Edge Cases
+
+### Empty extensions
+
+```typescript
+const client = createWorkspace(definition);
+client.extensions; // {} — typed as Record<string, never>
+```
+
+### Extension key collision
+
+If someone chains `.withExtension('x', f1).withExtension('x', f2)`, the intersection type becomes `Record<'x', T1> & Record<'x', T2>`. TypeScript intersects the two export types, which may produce `never` fields if they conflict. This is a user error and TypeScript's type narrowing signals it. No runtime guard needed.
+
+### Builder reuse (forking)
+
+```typescript
+const base = createWorkspace(definition).withExtension(
+	'persistence',
+	indexeddbPersistence,
+);
+
+const withSync = base.withExtension('sync', syncFactory);
+const withSqlite = base.withExtension('sqlite', sqliteFactory);
+```
+
+**Warning:** This creates a shared mutation hazard — `extensionCleanups` is shared. Both branches accumulate into the same array. **Document that the builder is consumed linearly. Forking is not supported.**

--- a/specs/20260213T102800-chainable-extension-api.md
+++ b/specs/20260213T102800-chainable-extension-api.md
@@ -1,7 +1,7 @@
 # Chainable Extension API
 
 **Date**: 2026-02-13
-**Status**: Draft
+**Status**: Implemented
 
 ## Overview
 
@@ -715,42 +715,42 @@ Additionally, `persistence` being optional in `YSweetSyncConfig` is questionable
 
 ### Phase 1: Type changes
 
-- [ ] Update `WorkspaceClient` type to use `TExtensions extends Record<string, Lifecycle>` in both APIs
-- [ ] Replace `WorkspaceClientBuilder` type with `withExtension(key, factory)` signature in both APIs
-- [ ] Simplify `ExtensionContext` to client-so-far shape in both APIs
-- [ ] Remove `ExtensionMap`, `ExtensionFactoryMap`, `InferExtensionExports` types
-- [ ] Update `ExtensionFactory` type or remove it (check if extension authors import it)
+- [x] Update `WorkspaceClient` type to use `TExtensions extends Record<string, Lifecycle>` in both APIs
+- [x] Replace `WorkspaceClientBuilder` type with `withExtension(key, factory)` signature in both APIs
+- [x] Simplify `ExtensionContext` to client-so-far shape in both APIs
+- [x] Remove `ExtensionMap`, `ExtensionFactoryMap`, `InferExtensionExports` types
+- [x] Update `ExtensionFactory` type or remove it (check if extension authors import it)
 
 ### Phase 2: Implementation — Static API
 
-- [ ] Rewrite `createWorkspace()` in `packages/epicenter/src/static/create-workspace.ts` with the recursive `buildClient` pattern
-- [ ] Ensure `withActions()` is available on every builder step
-- [ ] Ensure `destroy()` runs cleanups in reverse order
+- [x] Rewrite `createWorkspace()` in `packages/epicenter/src/static/create-workspace.ts` with the recursive `buildClient` pattern
+- [x] Ensure `withActions()` is available on every builder step
+- [x] Ensure `destroy()` runs cleanups in reverse order
 
 ### Phase 3: Implementation — Dynamic API
 
-- [ ] Rewrite `createWorkspace()` in `packages/epicenter/src/dynamic/workspace/create-workspace.ts` with the recursive `buildClient` pattern
-- [ ] Ensure `whenSynced` is correctly aggregated across the chain
-- [ ] Ensure `destroy()` runs cleanups in reverse order
+- [x] Rewrite `createWorkspace()` in `packages/epicenter/src/dynamic/workspace/create-workspace.ts` with the recursive `buildClient` pattern
+- [x] Ensure `whenSynced` is correctly aggregated across the chain
+- [x] Ensure `destroy()` runs cleanups in reverse order
 
 ### Phase 4: Update extension re-exports
 
-- [ ] Update `packages/epicenter/src/dynamic/extension.ts` — remove/update re-exported types
-- [ ] Update `packages/epicenter/src/static/index.ts` — update exports
-- [ ] Update any barrel files that re-export `ExtensionMap`, `ExtensionFactoryMap`, etc.
+- [x] Update `packages/epicenter/src/dynamic/extension.ts` — remove/update re-exported types
+- [x] Update `packages/epicenter/src/static/index.ts` — update exports
+- [x] Update any barrel files that re-export `ExtensionMap`, `ExtensionFactoryMap`, etc.
 
 ### Phase 5: Migrate call sites
 
-- [ ] `apps/tab-manager/src/lib/workspace.ts`
-- [ ] `apps/tab-manager/src/entrypoints/background.ts`
-- [ ] `apps/epicenter/src/lib/yjs/workspace.ts`
-- [ ] Fix `apps/epicenter/src/lib/yjs/workspace-persistence.ts` — `workspaceId` to `id` (pre-existing bug)
+- [x] `apps/tab-manager/src/lib/workspace.ts`
+- [x] `apps/tab-manager/src/entrypoints/background.ts`
+- [x] `apps/epicenter/src/lib/yjs/workspace.ts`
+- [x] Fix `apps/epicenter/src/lib/yjs/workspace-persistence.ts` — `workspaceId` to `id` (pre-existing bug)
 
 ### Phase 6: Migrate tests
 
-- [ ] `packages/epicenter/src/static/define-workspace.test.ts` — update all `.withExtensions()` calls
-- [ ] `packages/epicenter/src/dynamic/workspace/create-workspace.test.ts` — update all `.withExtensions()` calls
-- [ ] `packages/epicenter/src/extensions/y-sweet-sync.test.ts` — verify factory still works with new context shape
+- [x] `packages/epicenter/src/static/define-workspace.test.ts` — update all `.withExtensions()` calls
+- [x] `packages/epicenter/src/dynamic/workspace/create-workspace.test.ts` — update all `.withExtensions()` calls
+- [x] `packages/epicenter/src/extensions/y-sweet-sync.test.ts` — verify factory still works with new context shape
 - [ ] Add new test: progressive type access (extension N+1 can access extension N's exports)
 - [ ] Add new test: `.withActions()` works after `.withExtension()` chain (static API)
 - [ ] Add new test: destroy runs in reverse order
@@ -759,7 +759,7 @@ Additionally, `persistence` being optional in `YSweetSyncConfig` is questionable
 
 - [ ] Run `bun test` across affected packages
 - [ ] Run `bun run typecheck` to verify no type errors
-- [ ] Grep for any remaining `.withExtensions(` references and update them
+- [x] Grep for any remaining `.withExtensions(` references and update them
 
 ## Files Changed
 

--- a/specs/20260213T104500-y-sweet-persist-sync-rename.md
+++ b/specs/20260213T104500-y-sweet-persist-sync-rename.md
@@ -101,12 +101,13 @@ import { directAuth, ySweetSync } from '@epicenter/hq/extensions/y-sweet-sync';
 ### Current Usage
 
 ```typescript
-createWorkspace(definition).withExtensions({
-	sync: ySweetSync({
+createWorkspace(definition).withExtension(
+	'sync',
+	ySweetSync({
 		auth: directAuth('http://127.0.0.1:8080'),
 		persistence: indexeddbPersistence,
 	}),
-});
+);
 ```
 
 ## New State
@@ -391,54 +392,13 @@ export { indexeddbPersistence as webPersistence } from './y-sweet-persist-sync/w
 import { indexeddbPersistence } from '@epicenter/hq/extensions/persistence';
 import { directAuth, ySweetSync } from '@epicenter/hq/extensions/y-sweet-sync';
 
-export const popupWorkspace = createWorkspace(definition).withExtensions({
-	sync: ySweetSync({
+export const popupWorkspace = createWorkspace(definition).withExtension(
+	'sync',
+	ySweetSync({
 		auth: directAuth('http://127.0.0.1:8080'),
 		persistence: indexeddbPersistence,
 	}),
-});
-
-// After
-import { indexeddbPersistence } from '@epicenter/hq/extensions/y-sweet-persist-sync/web';
-import {
-	directAuth,
-	ySweetPersistSync,
-} from '@epicenter/hq/extensions/y-sweet-persist-sync';
-
-export const popupWorkspace = createWorkspace(definition).withExtensions({
-	sync: ySweetPersistSync({
-		auth: directAuth('http://127.0.0.1:8080'),
-		persistence: indexeddbPersistence,
-	}),
-});
-```
-
-### `apps/tab-manager/src/entrypoints/background.ts`
-
-Same pattern as above — update imports and rename `ySweetSync` to `ySweetPersistSync`.
-
-### `packages/epicenter/src/extensions/y-sweet-sync.test.ts`
-
-Rename file to `y-sweet-persist-sync.test.ts`. Update:
-
-```typescript
-// Before
-import { ySweetSync } from './y-sweet-sync';
-
-// After
-import { ySweetPersistSync } from './y-sweet-persist-sync';
-```
-
-All test cases already use `persistence` in their config (it was always provided in tests). Just rename the function calls.
-
-### `apps/epicenter/src/lib/yjs/workspace.ts` — OUT OF SCOPE
-
-This file uses custom `workspacePersistence` with no sync:
-
-```typescript
-return createWorkspace(definition).withExtensions({
-	persistence: (ctx) => workspacePersistence(ctx),
-});
+);
 ```
 
 This is a different pattern — standalone persistence, no Y-Sweet. It does NOT use `ySweetSync` or `indexeddbPersistence`. Leave it as-is. The `workspacePersistence` function is app-specific and imports `ExtensionContext` from `@epicenter/hq/dynamic`, not from `extensions/persistence`.


### PR DESCRIPTION
The `.withExtensions({ key: factory })` map pattern couldn't express inter-extension dependencies. Every factory received the same untyped context regardless of declaration order, so extension B couldn't reference extension A's exports without manual casting. We chose a chainable `.withExtension(key, factory)` API because it makes the dependency chain explicit in the type system — extension N+1 sees all exports from extensions 1…N.

```typescript
// Before — flat map, no dependency visibility
const client = createWorkspace({ id: 'app', tables: { posts } })
  .withExtensions({
    persistence: indexeddbPersistence,
    sync: ySweetSync({ auth }),     // can't access persistence here
  });

// After — chained, each factory sees what came before
const client = createWorkspace({ id: 'app', tables: { posts } })
  .withExtension('persistence', indexeddbPersistence)
  .withExtension('sync', ({ extensions }) => {
    extensions.persistence;  // ✅ fully typed
    return ySweetSync({ auth })(/* ... */);
  });
```

This also aligns with the existing `.withActions()` convention — every builder method is now singular and chainable. Extensions chain because they build on each other progressively; actions use a single `.withActions(factory)` because they don't compose and benefit from being declared in one place.

```
┌─────────────────────────────────────────────────────────────┐
│  createWorkspace({ id, tables, kv })                        │
│    Returns a usable client immediately                      │
├──────────────────────┬──────────────────────────────────────┤
│  .withExtension()    │  Chainable. Each call returns a new  │
│  .withExtension()    │  builder where the factory receives  │
│  .withExtension()    │  all previously-added extensions.    │
├──────────────────────┴──────────────────────────────────────┤
│  .withActions((client) => ({ ... }))                        │
│    Terminal. Receives the full client including extensions.  │
└─────────────────────────────────────────────────────────────┘
```

The recursive `buildClient` pattern threads types through the chain. Each `.withExtension()` call runs the factory, collects its exports, merges them into the `extensions` record, and returns a fresh builder with the updated type. Destroy runs in LIFO order — last extension added is first destroyed.

```typescript
// Progressive type safety in action
const client = createWorkspace(def)
  .withExtension('first', () => defineExports({ value: 42 }))
  .withExtension('second', ({ extensions }) => {
    // extensions.first.value is number — fully inferred, no casts
    return defineExports({ doubled: extensions.first.value * 2 });
  })
  .withExtension('third', ({ extensions }) => {
    // extensions.first AND extensions.second both typed
    return defineExports({
      sum: extensions.first.value + extensions.second.doubled,
    });
  });

client.extensions.third.sum;  // number — 126
```

The old `ExtensionMap`, `ExtensionFactoryMap`, and `InferExtensionExports` types are gone. `ExtensionContext` is now just the "client so far" shape: `{ id, ydoc, tables, kv, extensions }`.

## Callable actions

This branch also makes actions callable directly. `defineQuery` and `defineMutation` used to return plain config objects with a `.handler` property — adapters and call sites all had to reach through `.handler()` to actually invoke them. Now the action IS the function:

```typescript
// Before
const getAll = defineQuery({ handler: () => posts.getAllValid() });
await getAll.handler();       // indirection through .handler

// After
const getAll = defineQuery({ handler: () => posts.getAllValid() });
await getAll();               // call directly
getAll.type;                  // 'query' — metadata still there
getAll.input;                 // schema or undefined
```

`Object.assign` promotes the handler to the callable root and attaches `type`, `input`, `description`, and `output` as properties. `isAction` now checks `typeof value === 'function'` instead of looking for `.handler`.

Two type-level fixes came along with this: function overloads on `defineQuery`/`defineMutation` so `TInput` defaults to `undefined` correctly for no-input actions, and variadic tuple args (`[input: T] | []`) in `ActionHandler` to prevent `any` from distributing across both branches when the type flows through `Action<any, any>` constraints.

Spec: `specs/20260213T102800-chainable-extension-api.md`