### PR TITLE
feat(lifecycle)!: replace defineExports with defineExtension — separate lifecycle from exports

### DIFF
--- a/apps/epicenter/src/lib/yjs/workspace-persistence.ts
+++ b/apps/epicenter/src/lib/yjs/workspace-persistence.ts
@@ -1,7 +1,7 @@
 import {
 	defineExtension,
+	type Extension,
 	type ExtensionContext,
-	type ExtensionResult,
 } from '@epicenter/hq/dynamic';
 import { appLocalDataDir, join } from '@tauri-apps/api/path';
 import { mkdir, readFile, writeFile } from '@tauri-apps/plugin-fs';
@@ -67,7 +67,7 @@ const FILE_NAMES = {
 export function workspacePersistence(
 	ctx: ExtensionContext,
 	config: WorkspacePersistenceConfig = {},
-): ExtensionResult {
+): Extension {
 	const { ydoc, id, kv } = ctx;
 	const { jsonDebounceMs = 500 } = config;
 

--- a/apps/epicenter/src/lib/yjs/workspace-persistence.ts
+++ b/apps/epicenter/src/lib/yjs/workspace-persistence.ts
@@ -1,7 +1,7 @@
 import {
-	defineExports,
+	defineExtension,
 	type ExtensionContext,
-	type Lifecycle,
+	type ExtensionResult,
 } from '@epicenter/hq/dynamic';
 import { appLocalDataDir, join } from '@tauri-apps/api/path';
 import { mkdir, readFile, writeFile } from '@tauri-apps/plugin-fs';
@@ -67,7 +67,7 @@ const FILE_NAMES = {
 export function workspacePersistence(
 	ctx: ExtensionContext,
 	config: WorkspacePersistenceConfig = {},
-): Lifecycle {
+): ExtensionResult {
 	const { ydoc, id, kv } = ctx;
 	const { jsonDebounceMs = 500 } = config;
 
@@ -141,7 +141,7 @@ export function workspacePersistence(
 	// Return Lifecycle
 	// =========================================================================
 
-	return defineExports({
+	return defineExtension({
 		whenReady: (async () => {
 			const { workspaceDir, workspaceYjsPath } = await pathsPromise;
 

--- a/apps/tab-manager/src/entrypoints/background.ts
+++ b/apps/tab-manager/src/entrypoints/background.ts
@@ -343,7 +343,7 @@ export default defineBackground(() => {
 
 	const initPromise = (async () => {
 		// Wait for local data to load (WebSocket connects in background)
-		await client.extensions.sync.whenReady;
+		await client.whenReady;
 		console.log('[Background] Persistence loaded');
 
 		// Then refetch to sync Y.Doc with current browser state

--- a/packages/epicenter/src/dynamic/extension.ts
+++ b/packages/epicenter/src/dynamic/extension.ts
@@ -13,22 +13,16 @@
  *   like SQLite queries, Markdown sync, revision history. Receive the client-so-far
  *   as context, including previously added extensions.
  *
- * Use `defineExports()` to wrap your extension's return value for lifecycle normalization.
+ * Use `defineExtension()` to wrap your extension's return value, separating lifecycle from exports.
  */
 
 // Re-export lifecycle utilities for extension authors
-import { defineExports, type Lifecycle } from '../shared/lifecycle';
-export { defineExports, type Lifecycle };
-
-/**
- * Extension exports combining lifecycle protocol with custom exports.
- *
- * The framework guarantees `whenReady` and `destroy` exist on all extensions.
- * Use `defineExports()` to easily create compliant extension returns.
- */
-export type ExtensionExports<
-	T extends Record<string, unknown> = Record<string, unknown>,
-> = Lifecycle & T;
+import {
+	defineExtension,
+	type ExtensionResult,
+	type Lifecycle,
+} from '../shared/lifecycle';
+export { defineExtension, type ExtensionResult, type Lifecycle };
 
 // Re-export all extension types from workspace/types.ts (the canonical location)
 export type {

--- a/packages/epicenter/src/dynamic/extension.ts
+++ b/packages/epicenter/src/dynamic/extension.ts
@@ -19,10 +19,10 @@
 // Re-export lifecycle utilities for extension authors
 import {
 	defineExtension,
-	type ExtensionResult,
+	type Extension,
 	type Lifecycle,
 } from '../shared/lifecycle';
-export { defineExtension, type ExtensionResult, type Lifecycle };
+export { defineExtension, type Extension, type Lifecycle };
 
 // Re-export all extension types from workspace/types.ts (the canonical location)
 export type {

--- a/packages/epicenter/src/dynamic/index.ts
+++ b/packages/epicenter/src/dynamic/index.ts
@@ -25,9 +25,9 @@ export type { WorkspaceDefinition } from './schema/workspace-definition';
 // The builder pattern API
 export { createWorkspace } from './workspace/create-workspace';
 export type {
+	Extension,
 	ExtensionContext,
 	ExtensionFactory,
-	ExtensionResult,
 	WorkspaceClient,
 	WorkspaceClientBuilder,
 } from './workspace/types';
@@ -57,7 +57,7 @@ export { generateId, Id as createId } from '../shared/id';
 // Lifecycle utilities (re-exported for extension authors)
 export {
 	defineExtension,
-	type ExtensionResult,
+	type Extension,
 	type Lifecycle,
 	type MaybePromise,
 } from '../shared/lifecycle';
@@ -106,8 +106,8 @@ export { KV_KEY, TableKey } from '../shared/ydoc-keys';
 // ════════════════════════════════════════════════════════════════════════════
 
 export type {
+	Provider,
 	ProviderContext,
-	ProviderExports,
 	ProviderFactory,
 	ProviderFactoryMap,
 } from './provider-types';

--- a/packages/epicenter/src/dynamic/index.ts
+++ b/packages/epicenter/src/dynamic/index.ts
@@ -27,6 +27,7 @@ export { createWorkspace } from './workspace/create-workspace';
 export type {
 	ExtensionContext,
 	ExtensionFactory,
+	ExtensionResult,
 	WorkspaceClient,
 	WorkspaceClientBuilder,
 } from './workspace/types';
@@ -55,7 +56,8 @@ export type { Id } from '../shared/id';
 export { generateId, Id as createId } from '../shared/id';
 // Lifecycle utilities (re-exported for extension authors)
 export {
-	defineExports,
+	defineExtension,
+	type ExtensionResult,
 	type Lifecycle,
 	type MaybePromise,
 } from '../shared/lifecycle';

--- a/packages/epicenter/src/dynamic/provider-types.ts
+++ b/packages/epicenter/src/dynamic/provider-types.ts
@@ -28,9 +28,9 @@ export type ProviderContext = {
 };
 
 /**
- * Provider exports - returned values accessible via `doc.providers.{name}`.
+ * The return type of a `ProviderFactory` — accessible via `doc.providers.{name}`.
  *
- * This type combines the lifecycle protocol with custom exports.
+ * Combines the lifecycle protocol with custom exports.
  * The framework guarantees `whenReady` and `destroy` exist on all providers.
  *
  * @typeParam T - Additional exports beyond lifecycle fields
@@ -38,16 +38,15 @@ export type ProviderContext = {
  * @example
  * ```typescript
  * // Type for a provider that exports a connection
- * type SyncProviderExports = ProviderExports<{ connection: WebSocket }>;
+ * type SyncProvider = Provider<{ connection: WebSocket }>;
  * // → { whenReady, destroy, connection }
  *
  * // Type for a provider with no custom exports
- * type SimpleProviderExports = ProviderExports;
+ * type SimpleProvider = Provider;
  * // → { whenReady, destroy }
  * ```
  */
-export type ProviderExports<T extends Record<string, unknown> = {}> =
-	Lifecycle & T;
+export type Provider<T extends Record<string, unknown> = {}> = Lifecycle & T;
 
 /**
  * A doc-level provider factory function.
@@ -83,9 +82,9 @@ export type ProviderExports<T extends Record<string, unknown> = {}> =
  * };
  * ```
  */
-export type ProviderFactory<
-	TExports extends ProviderExports = ProviderExports,
-> = (context: ProviderContext) => TExports;
+export type ProviderFactory<TExports extends Provider = Provider> = (
+	context: ProviderContext,
+) => TExports;
 
 /**
  * Map of provider factories keyed by provider ID.
@@ -93,8 +92,8 @@ export type ProviderFactory<
 export type ProviderFactoryMap = Record<string, ProviderFactory>;
 
 /**
- * Infer exports from provider factories.
+ * Infer the return type of provider factories.
  */
-export type InferProviderExports<T extends ProviderFactoryMap> = {
+export type InferProviderReturn<T extends ProviderFactoryMap> = {
 	[K in keyof T]: ReturnType<T[K]>;
 };

--- a/packages/epicenter/src/dynamic/provider-types.ts
+++ b/packages/epicenter/src/dynamic/provider-types.ts
@@ -2,7 +2,7 @@ import type * as Y from 'yjs';
 import type { Lifecycle } from '../shared/lifecycle';
 
 // Re-export lifecycle utilities for provider authors
-export { defineExports, type Lifecycle } from '../shared/lifecycle';
+export type { Lifecycle } from '../shared/lifecycle';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Doc-Level Provider Types
@@ -55,8 +55,8 @@ export type ProviderExports<T extends Record<string, unknown> = {}> =
  * Factories are **always synchronous**. Async initialization is tracked via
  * the returned `whenReady` promise, not the factory itself.
  *
- * Use `defineExports()` to wrap your return for explicit type safety and
- * lifecycle normalization. The framework fills in defaults for missing fields:
+ * Return an object satisfying the `Lifecycle` protocol directly.
+ * The framework fills in defaults for missing fields:
  * - `whenReady`: defaults to `Promise.resolve()`
  * - `destroy`: defaults to no-op `() => {}`
  *
@@ -64,10 +64,10 @@ export type ProviderExports<T extends Record<string, unknown> = {}> =
  * ```typescript
  * const persistence: ProviderFactory = ({ ydoc }) => {
  *   const provider = new IndexeddbPersistence(ydoc.guid, ydoc);
- *   return defineExports({
+ *   return {
  *     whenReady: provider.whenReady,
  *     destroy: () => provider.destroy(),
- *   });
+ *   };
  * };
  * ```
  *
@@ -75,11 +75,11 @@ export type ProviderExports<T extends Record<string, unknown> = {}> =
  * ```typescript
  * const websocket: ProviderFactory = ({ ydoc }) => {
  *   const ws = new WebsocketProvider(url, ydoc.guid, ydoc);
- *   return defineExports({
+ *   return {
  *     ws,
  *     whenReady: new Promise(r => ws.on('sync', r)),
  *     destroy: () => ws.destroy(),
- *   });
+ *   };
  * };
  * ```
  */

--- a/packages/epicenter/src/dynamic/workspace/create-workspace.test.ts
+++ b/packages/epicenter/src/dynamic/workspace/create-workspace.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import * as Y from 'yjs';
-import { defineExports } from '../../shared/lifecycle';
+import { defineExtension } from '../../shared/lifecycle';
 import { boolean, Id, id, integer, select, table, text } from '../schema';
 import { defineWorkspace } from '../schema/workspace-definition';
 import { createWorkspace } from './create-workspace';
@@ -113,8 +113,10 @@ describe('createWorkspace', () => {
 
 			// Use inline factory for better type inference
 			const workspace = baseWorkspace.withExtension('mock', ({ id }) =>
-				defineExports({
-					greeting: `Hello from ${id}`,
+				defineExtension({
+					exports: {
+						greeting: `Hello from ${id}`,
+					},
 				}),
 			);
 
@@ -136,7 +138,7 @@ describe('createWorkspace', () => {
 					hasTables: typeof ctx.tables.get === 'function',
 					hasKv: typeof ctx.kv.get === 'function',
 				};
-				return defineExports();
+				return defineExtension();
 			});
 
 			expect(receivedContext).toBeDefined();
@@ -154,7 +156,7 @@ describe('createWorkspace', () => {
 
 			const workspace = baseWorkspace
 				.withExtension('ext1', () =>
-					defineExports({
+					defineExtension({
 						whenReady: new Promise<void>((resolve) => {
 							setTimeout(() => {
 								resolved1 = true;
@@ -164,7 +166,7 @@ describe('createWorkspace', () => {
 					}),
 				)
 				.withExtension('ext2', () =>
-					defineExports({
+					defineExtension({
 						whenReady: new Promise<void>((resolve) => {
 							setTimeout(() => {
 								resolved2 = true;
@@ -188,7 +190,7 @@ describe('createWorkspace', () => {
 			const baseWorkspace = createWorkspace(testDefinition);
 
 			const chainedWorkspace = baseWorkspace.withExtension('mock', () =>
-				defineExports({ data: 'test' }),
+				defineExtension({ exports: { data: 'test' } }),
 			);
 
 			// Base should still have empty extensions
@@ -224,14 +226,14 @@ describe('createWorkspace', () => {
 
 			const workspace = baseWorkspace
 				.withExtension('ext1', () =>
-					defineExports({
+					defineExtension({
 						destroy: () => {
 							destroyed1 = true;
 						},
 					}),
 				)
 				.withExtension('ext2', () =>
-					defineExports({
+					defineExtension({
 						destroy: () => {
 							destroyed2 = true;
 						},
@@ -254,7 +256,7 @@ describe('createWorkspace', () => {
 			const workspace = createWorkspace(testDefinition).withExtension(
 				'tracker',
 				() =>
-					defineExports({
+					defineExtension({
 						destroy: () => {
 							destroyed = true;
 						},
@@ -293,9 +295,11 @@ describe('createWorkspace', () => {
 			const workspace = createWorkspace(testDefinition).withExtension(
 				'myExt',
 				() =>
-					defineExports({
-						version: 1,
-						getName: () => 'my-extension',
+					defineExtension({
+						exports: {
+							version: 1,
+							getName: () => 'my-extension',
+						},
 					}),
 			);
 
@@ -309,22 +313,24 @@ describe('createWorkspace', () => {
 		test('extension N+1 can access extension N exports via context', () => {
 			const workspace = createWorkspace(testDefinition)
 				.withExtension('first', () =>
-					defineExports({
-						value: 42,
-						helper: () => 'from-first',
+					defineExtension({
+						exports: {
+							value: 42,
+							helper: () => 'from-first',
+						},
 					}),
 				)
 				.withExtension('second', ({ extensions }) => {
 					// extensions.first is fully typed — no casts needed
 					const doubled = extensions.first.value * 2;
 					const msg = extensions.first.helper();
-					return defineExports({ doubled, msg });
+					return defineExtension({ exports: { doubled, msg } });
 				})
 				.withExtension('third', ({ extensions }) => {
 					// extensions.first AND extensions.second are both fully typed
 					const tripled = extensions.first.value * 3;
 					const fromSecond = extensions.second.doubled;
-					return defineExports({ tripled, fromSecond });
+					return defineExtension({ exports: { tripled, fromSecond } });
 				});
 
 			// All extensions accessible and typed on the final client
@@ -350,21 +356,21 @@ describe('createWorkspace', () => {
 
 			const workspace = createWorkspace(testDefinition)
 				.withExtension('a', () =>
-					defineExports({
+					defineExtension({
 						destroy: () => {
 							order.push('a');
 						},
 					}),
 				)
 				.withExtension('b', () =>
-					defineExports({
+					defineExtension({
 						destroy: () => {
 							order.push('b');
 						},
 					}),
 				)
 				.withExtension('c', () =>
-					defineExports({
+					defineExtension({
 						destroy: () => {
 							order.push('c');
 						},

--- a/packages/epicenter/src/dynamic/workspace/create-workspace.ts
+++ b/packages/epicenter/src/dynamic/workspace/create-workspace.ts
@@ -26,7 +26,7 @@
  */
 
 import * as Y from 'yjs';
-import type { ExtensionResult, MaybePromise } from '../../shared/lifecycle';
+import type { Extension, MaybePromise } from '../../shared/lifecycle';
 import { createKv } from '../kv/create-kv';
 import type { KvField, TableDefinition } from '../schema/fields/types';
 import type { WorkspaceDefinition } from '../schema/workspace-definition';
@@ -124,7 +124,7 @@ export function createWorkspace<
 				key: TKey,
 				factory: (
 					context: ExtensionContext<TTableDefinitions, TKvFields, TExtensions>,
-				) => ExtensionResult<TExports>,
+				) => Extension<TExports>,
 			) {
 				const result = factory({ id, ydoc, tables, kv, extensions });
 				extensionCleanups.push(() => result.lifecycle.destroy());

--- a/packages/epicenter/src/dynamic/workspace/create-workspace.ts
+++ b/packages/epicenter/src/dynamic/workspace/create-workspace.ts
@@ -26,11 +26,7 @@
  */
 
 import * as Y from 'yjs';
-import {
-	defineExports,
-	type Lifecycle,
-	type MaybePromise,
-} from '../../shared/lifecycle';
+import type { ExtensionResult, MaybePromise } from '../../shared/lifecycle';
 import { createKv } from '../kv/create-kv';
 import type { KvField, TableDefinition } from '../schema/fields/types';
 import type { WorkspaceDefinition } from '../schema/workspace-definition';
@@ -96,7 +92,7 @@ export function createWorkspace<
 	const extensionCleanups: (() => MaybePromise<void>)[] = [];
 	const whenReadyPromises: Promise<unknown>[] = [];
 
-	function buildClient<TExtensions extends Record<string, Lifecycle>>(
+	function buildClient<TExtensions extends Record<string, unknown>>(
 		extensions: TExtensions,
 	): WorkspaceClientBuilder<TTableDefinitions, TKvFields, TExtensions> {
 		const whenReady = Promise.all(whenReadyPromises).then(() => {});
@@ -121,22 +117,22 @@ export function createWorkspace<
 		};
 
 		return Object.assign(client, {
-			withExtension<TKey extends string, TExports extends Lifecycle>(
+			withExtension<
+				TKey extends string,
+				TExports extends Record<string, unknown>,
+			>(
 				key: TKey,
 				factory: (
 					context: ExtensionContext<TTableDefinitions, TKvFields, TExtensions>,
-				) => TExports,
+				) => ExtensionResult<TExports>,
 			) {
 				const result = factory({ id, ydoc, tables, kv, extensions });
-				const exports = defineExports(
-					result as Record<string, unknown>,
-				) as unknown as TExports;
-				extensionCleanups.push(() => exports.destroy());
-				whenReadyPromises.push(exports.whenReady);
+				extensionCleanups.push(() => result.lifecycle.destroy());
+				whenReadyPromises.push(result.lifecycle.whenReady);
 
 				const newExtensions = {
 					...extensions,
-					[key]: exports,
+					[key]: result.exports,
 				} as TExtensions & Record<TKey, TExports>;
 
 				return buildClient(newExtensions);

--- a/packages/epicenter/src/dynamic/workspace/types.ts
+++ b/packages/epicenter/src/dynamic/workspace/types.ts
@@ -32,7 +32,7 @@
  */
 
 import type * as Y from 'yjs';
-import type { ExtensionResult } from '../../shared/lifecycle';
+import type { Extension } from '../../shared/lifecycle';
 import type { Kv } from '../kv/create-kv';
 import type { KvField, TableDefinition } from '../schema/fields/types';
 import type { Tables } from '../tables/create-tables';
@@ -85,7 +85,7 @@ export type ExtensionContext<
 /**
  * Factory function that creates an extension with lifecycle hooks.
  *
- * All extensions MUST return an `ExtensionResult` (from `defineExtension()`).
+ * All extensions MUST return an `Extension` (from `defineExtension()`).
  * The framework plucks `lifecycle` for internal management and stores
  * `exports` by reference — getters and object identity are preserved.
  *
@@ -107,7 +107,7 @@ export type ExtensionContext<
  */
 export type ExtensionFactory<
 	TExports extends Record<string, unknown> = Record<string, unknown>,
-> = (context: ExtensionContext) => ExtensionResult<TExports>;
+> = (context: ExtensionContext) => Extension<TExports>;
 
 // ════════════════════════════════════════════════════════════════════════════
 // WORKSPACE CLIENT TYPES
@@ -167,12 +167,12 @@ export type WorkspaceClientBuilder<
 	 * Add a single extension. Returns a new builder with the extension's
 	 * exports accumulated into the extensions type.
 	 *
-	 * The factory must return an `ExtensionResult` (from `defineExtension()`).
+	 * The factory must return an `Extension` (from `defineExtension()`).
 	 * The framework plucks `lifecycle` for internal management and stores
 	 * `exports` by reference — getters and object identity are preserved.
 	 *
 	 * @param key - Unique name for this extension (used as the key in `.extensions`)
-	 * @param factory - Factory function receiving the client-so-far context, returns ExtensionResult
+	 * @param factory - Factory function receiving the client-so-far context, returns Extension
 	 * @returns A new builder with the extension's exports added to the type
 	 *
 	 * @example
@@ -191,7 +191,7 @@ export type WorkspaceClientBuilder<
 		key: TKey,
 		factory: (
 			context: ExtensionContext<TTableDefinitions, TKvFields, TExtensions>,
-		) => ExtensionResult<TExports>,
+		) => Extension<TExports>,
 	): WorkspaceClientBuilder<
 		TTableDefinitions,
 		TKvFields,
@@ -199,5 +199,5 @@ export type WorkspaceClientBuilder<
 	>;
 };
 
-// Re-export ExtensionResult for convenience
-export type { ExtensionResult } from '../../shared/lifecycle';
+// Re-export Extension for convenience
+export type { Extension } from '../../shared/lifecycle';

--- a/packages/epicenter/src/extensions/markdown/markdown.ts
+++ b/packages/epicenter/src/extensions/markdown/markdown.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import chokidar, { type FSWatcher } from 'chokidar';
 import { createTaggedError, extractErrorMessage } from 'wellcrafted/error';
 import { tryAsync, trySync } from 'wellcrafted/result';
-import { defineExports, type ExtensionContext } from '../../dynamic/extension';
+import type { ExtensionContext } from '../../dynamic/extension';
 import type {
 	Field,
 	Id,
@@ -16,6 +16,7 @@ import type { TableById } from '../../dynamic/schema/fields/types';
 import { getTableById } from '../../dynamic/schema/schema-file';
 import type { TableHelper } from '../../dynamic/tables/create-tables';
 import { ExtensionErr, ExtensionError } from '../../shared/errors';
+import { defineExtension } from '../../shared/lifecycle';
 import type { AbsolutePath } from '../../shared/types';
 import { createIndexLogger } from '../error-logger';
 import {
@@ -1124,7 +1125,415 @@ export const markdown = async <
 		console.error('[MarkdownProvider] Background validation failed:', err);
 	});
 
-	return defineExports({
+	return defineExtension({
+		exports: {
+			/**
+			 * Pull: Sync from YJS to Markdown using diff-based synchronization.
+			 *
+			 * Computes the diff between YJS and markdown files, then applies only the changes:
+			 * - Files in markdown but not in YJS → deleted
+			 * - Rows in YJS but not in markdown → file created
+			 * - Rows in both → file updated only if content differs
+			 */
+			async pullToMarkdown() {
+				return tryAsync({
+					try: async () => {
+						syncCoordination.yjsWriteCount++;
+
+						await Promise.all(
+							Object.entries(resolvedConfigs).map(
+								async ([tableName, tableConfig]) => {
+									const table = tables.get(tableName);
+									const tableDefinition = getTableById(
+										tables.definitions,
+										tableName,
+									);
+									const fields = tableDefinition!.fields;
+									const tableTracking = tracking[tableName];
+									const filePaths = await listMarkdownFiles(
+										tableConfig.directory,
+									);
+
+									const markdownIds = new Map(
+										filePaths
+											.map((filePath) => {
+												const filename = path.basename(filePath);
+												const parsed = tableConfig.parseFilename(filename);
+												return parsed?.id
+													? ([parsed.id, filePath as AbsolutePath] as const)
+													: null;
+											})
+											.filter(
+												(entry): entry is [string, AbsolutePath] =>
+													entry !== null,
+											),
+									);
+
+									const yjsRows = table.getAllValid();
+									const yjsIds = new Set(yjsRows.map((row) => String(row.id)));
+
+									const idsToDelete = [...markdownIds.entries()].filter(
+										([id]) => !yjsIds.has(id),
+									);
+									await Promise.all(
+										idsToDelete.map(async ([id, filePath]) => {
+											const { error } = await deleteMarkdownFile({ filePath });
+											if (error) {
+												logger.log(
+													ExtensionError({
+														message: `pullToMarkdown: failed to delete ${filePath}`,
+														context: { filePath, tableName },
+													}),
+												);
+											}
+											if (tableTracking) {
+												delete tableTracking[id];
+											}
+										}),
+									);
+
+									await Promise.all(
+										yjsRows.map(async (row) => {
+											const { frontmatter, body, filename } =
+												tableConfig.serialize({
+													row,
+													fields,
+												});
+
+											const filePath = path.join(
+												tableConfig.directory,
+												filename,
+											) as AbsolutePath;
+
+											const existingFilePath = markdownIds.get(String(row.id));
+											const isNewFile = !existingFilePath;
+											const filenameChanged =
+												existingFilePath &&
+												path.basename(existingFilePath) !== filename;
+
+											if (filenameChanged && existingFilePath) {
+												await deleteMarkdownFile({
+													filePath: existingFilePath,
+												});
+											}
+
+											let shouldWrite = isNewFile || filenameChanged;
+
+											if (!shouldWrite && existingFilePath) {
+												const { data: existingContent, error: readError } =
+													await readMarkdownFile(existingFilePath);
+												if (readError) {
+													shouldWrite = true;
+												} else {
+													const {
+														data: existingFrontmatter,
+														body: existingBody,
+													} = existingContent;
+													const frontmatterChanged =
+														JSON.stringify(frontmatter) !==
+														JSON.stringify(existingFrontmatter);
+													const bodyChanged = body !== existingBody;
+													shouldWrite = frontmatterChanged || bodyChanged;
+												}
+											}
+
+											if (shouldWrite) {
+												const { error } = await writeMarkdownFile({
+													filePath,
+													frontmatter,
+													body,
+												});
+												if (error) {
+													logger.log(
+														ExtensionError({
+															message: `pullToMarkdown: failed to write ${filePath}`,
+															context: {
+																filePath,
+																tableName,
+																rowId: row.id,
+															},
+														}),
+													);
+												}
+											}
+
+											if (tableTracking) {
+												tableTracking[String(row.id)] = filename;
+											}
+										}),
+									);
+								},
+							),
+						);
+
+						syncCoordination.yjsWriteCount--;
+					},
+					catch: (error) => {
+						syncCoordination.yjsWriteCount--;
+						return ExtensionErr({
+							message: `Markdown extension pull failed: ${extractErrorMessage(error)}`,
+							context: { operation: 'pull' },
+						});
+					},
+				});
+			},
+
+			/**
+			 * Push: Sync from Markdown to YJS using diff-based synchronization.
+			 *
+			 * Computes the diff between markdown files and YJS, then applies only the changes:
+			 * - Rows in markdown but not in YJS → added
+			 * - Rows in YJS but not in markdown → deleted
+			 * - Rows in both → updated (no-op if content unchanged)
+			 *
+			 * **Deletion safety**: A YJS row is only deleted if no file exists with that ID.
+			 * If a file exists but fails to read or deserialize, the row is preserved and
+			 * a diagnostic is recorded. This prevents data loss when files have temporary
+			 * I/O errors or invalid content that the user can fix.
+			 *
+			 * The distinction:
+			 * - Can't parse ID from filename → file is unidentifiable → row deleted (can't protect what we can't identify)
+			 * - Can parse ID but can't read/deserialize → file exists → row preserved (user can fix the file)
+			 *
+			 * All YJS operations are wrapped in a single transaction for atomicity.
+			 */
+			async pushFromMarkdown() {
+				return tryAsync({
+					try: async () => {
+						syncCoordination.fileChangeCount++;
+
+						diagnostics.clear();
+
+						type TableSyncData = {
+							tableName: string;
+							table: TableHelper<string, TTableDefinitions[number]['fields']>;
+							yjsIds: Set<Id>;
+							fileExistsIds: Set<Id>;
+							markdownRows: Map<
+								Id,
+								RowWithId<TTableDefinitions[number]['fields']>
+							>;
+							markdownFilenames: Map<Id, string>;
+						};
+
+						const allTableData = await Promise.all(
+							Object.entries(resolvedConfigs).map(
+								async ([tableName, tableConfig]): Promise<TableSyncData> => {
+									const table = tables.get(tableName);
+									const tableDefinition = getTableById(
+										tables.definitions,
+										tableName,
+									);
+									const fields = tableDefinition!.fields;
+									const yjsIds = new Set(
+										table
+											.getAll()
+											.map((result) =>
+												result.status === 'valid' ? result.row.id : result.id,
+											),
+									);
+
+									const filePaths = await listMarkdownFiles(
+										tableConfig.directory,
+									);
+
+									const fileExistsIds = new Set(
+										filePaths
+											.map((filePath) => {
+												const parsed = tableConfig.parseFilename(
+													path.basename(filePath),
+												);
+												return parsed?.id ? createId(parsed.id) : undefined;
+											})
+											.filter((id): id is Id => Boolean(id)),
+									);
+
+									const markdownRows = new Map<
+										Id,
+										RowWithId<TTableDefinitions[number]['fields']>
+									>();
+									const markdownFilenames = new Map<Id, string>();
+
+									await Promise.all(
+										filePaths.map(async (filePath) => {
+											const filename = path.basename(filePath);
+
+											const parsed = tableConfig.parseFilename(filename);
+											if (!parsed) {
+												diagnostics.add({
+													filePath,
+													tableName,
+													filename,
+													error: MarkdownExtensionError({
+														message: `Failed to parse filename: ${filename}`,
+													}),
+												});
+												logger.log(
+													ExtensionError({
+														message: `pushFromMarkdown: failed to parse filename ${tableName}/${filename}`,
+														context: {
+															filePath,
+															tableName,
+															filename,
+														},
+													}),
+												);
+												return;
+											}
+
+											const { data: fileContent, error: readError } =
+												await readMarkdownFile(filePath);
+
+											if (readError) {
+												diagnostics.add({
+													filePath,
+													tableName,
+													filename,
+													error: MarkdownExtensionError({
+														message: `Failed to read markdown file at ${filePath}: ${readError.message}`,
+													}),
+												});
+												logger.log(
+													ExtensionError({
+														message: `pushFromMarkdown: failed to read ${tableName}/${filename}`,
+														context: {
+															filePath,
+															tableName,
+															filename,
+														},
+													}),
+												);
+												return;
+											}
+
+											const { data: frontmatter, body } = fileContent;
+
+											const { data: row, error: deserializeError } =
+												tableConfig.deserialize({
+													frontmatter,
+													body,
+													filename,
+													parsed,
+													fields,
+												});
+
+											if (deserializeError) {
+												diagnostics.add({
+													filePath,
+													tableName,
+													filename,
+													error: deserializeError,
+												});
+												logger.log(
+													ExtensionError({
+														message: `pushFromMarkdown: validation failed for ${tableName}/${filename}`,
+														context: {
+															filePath,
+															tableName,
+															filename,
+														},
+													}),
+												);
+												return;
+											}
+
+											// Convert row.id from string to branded Id
+											const rowWithBrandedId = {
+												...row,
+												id: createId((row as { id: string }).id),
+											} as RowWithId<TTableDefinitions[number]['fields']>;
+											markdownRows.set(rowWithBrandedId.id, rowWithBrandedId);
+											markdownFilenames.set(rowWithBrandedId.id, filename);
+										}),
+									);
+
+									return {
+										tableName,
+										table,
+										yjsIds,
+										fileExistsIds,
+										markdownRows,
+										markdownFilenames,
+									};
+								},
+							),
+						);
+
+						ydoc.transact(() => {
+							allTableData.forEach(
+								({
+									tableName,
+									table,
+									yjsIds,
+									fileExistsIds,
+									markdownRows,
+									markdownFilenames,
+								}) => {
+									const tableTracking = tracking[tableName];
+									const idsToDelete = [...yjsIds].filter(
+										(id) => !fileExistsIds.has(id),
+									);
+									idsToDelete.forEach((id) => {
+										table.delete(id);
+										if (tableTracking) {
+											delete tableTracking[id];
+										}
+									});
+
+									[...markdownRows.entries()].forEach(([id, row]) => {
+										table.upsert(row);
+										if (tableTracking) {
+											tableTracking[id] = markdownFilenames.get(id) ?? '';
+										}
+									});
+								},
+							);
+						});
+
+						syncCoordination.fileChangeCount--;
+					},
+					catch: (error) => {
+						syncCoordination.fileChangeCount--;
+						return ExtensionErr({
+							message: `Markdown extension push failed: ${extractErrorMessage(error)}`,
+							context: { operation: 'push' },
+						});
+					},
+				});
+			},
+
+			/**
+			 * Scan all markdown files and rebuild diagnostics
+			 *
+			 * Validates every markdown file against its table definition and updates the diagnostics
+			 * to reflect the current state. This is useful for:
+			 * - On-demand validation after bulk file edits
+			 * - Scheduled validation jobs (e.g., nightly scans)
+			 * - Manual verification that diagnostics are accurate
+			 *
+			 * Note: The initial scan on startup serves the same purpose, but this method
+			 * allows re-scanning at any time without restarting the server.
+			 */
+			async scanForErrors() {
+				return tryAsync({
+					try: async () => {
+						await validateAllMarkdownFiles({ operation: 'scanForErrors' });
+
+						// Return count of errors found
+						const errorCount = diagnostics.count();
+						console.log(
+							`Scan complete: ${errorCount} markdown file${errorCount === 1 ? '' : 's'} with validation errors`,
+						);
+					},
+					catch: (error) => {
+						return ExtensionErr({
+							message: `Markdown extension scan failed: ${extractErrorMessage(error)}`,
+							context: { operation: 'scan' },
+						});
+					},
+				});
+			},
+		},
 		async destroy() {
 			for (const unsub of unsubscribers) {
 				unsub();
@@ -1133,413 +1542,6 @@ export const markdown = async <
 			await Promise.all(watchers.map((watcher) => watcher.close()));
 			// Flush and close logger to ensure all pending logs are written
 			await logger.close();
-		},
-
-		/**
-		 * Pull: Sync from YJS to Markdown using diff-based synchronization.
-		 *
-		 * Computes the diff between YJS and markdown files, then applies only the changes:
-		 * - Files in markdown but not in YJS → deleted
-		 * - Rows in YJS but not in markdown → file created
-		 * - Rows in both → file updated only if content differs
-		 */
-		async pullToMarkdown() {
-			return tryAsync({
-				try: async () => {
-					syncCoordination.yjsWriteCount++;
-
-					await Promise.all(
-						Object.entries(resolvedConfigs).map(
-							async ([tableName, tableConfig]) => {
-								const table = tables.get(tableName);
-								const tableDefinition = getTableById(
-									tables.definitions,
-									tableName,
-								);
-								const fields = tableDefinition!.fields;
-								const tableTracking = tracking[tableName];
-								const filePaths = await listMarkdownFiles(
-									tableConfig.directory,
-								);
-
-								const markdownIds = new Map(
-									filePaths
-										.map((filePath) => {
-											const filename = path.basename(filePath);
-											const parsed = tableConfig.parseFilename(filename);
-											return parsed?.id
-												? ([parsed.id, filePath as AbsolutePath] as const)
-												: null;
-										})
-										.filter(
-											(entry): entry is [string, AbsolutePath] =>
-												entry !== null,
-										),
-								);
-
-								const yjsRows = table.getAllValid();
-								const yjsIds = new Set(yjsRows.map((row) => String(row.id)));
-
-								const idsToDelete = [...markdownIds.entries()].filter(
-									([id]) => !yjsIds.has(id),
-								);
-								await Promise.all(
-									idsToDelete.map(async ([id, filePath]) => {
-										const { error } = await deleteMarkdownFile({ filePath });
-										if (error) {
-											logger.log(
-												ExtensionError({
-													message: `pullToMarkdown: failed to delete ${filePath}`,
-													context: { filePath, tableName },
-												}),
-											);
-										}
-										if (tableTracking) {
-											delete tableTracking[id];
-										}
-									}),
-								);
-
-								await Promise.all(
-									yjsRows.map(async (row) => {
-										const { frontmatter, body, filename } =
-											tableConfig.serialize({
-												row,
-												fields,
-											});
-
-										const filePath = path.join(
-											tableConfig.directory,
-											filename,
-										) as AbsolutePath;
-
-										const existingFilePath = markdownIds.get(String(row.id));
-										const isNewFile = !existingFilePath;
-										const filenameChanged =
-											existingFilePath &&
-											path.basename(existingFilePath) !== filename;
-
-										if (filenameChanged && existingFilePath) {
-											await deleteMarkdownFile({
-												filePath: existingFilePath,
-											});
-										}
-
-										let shouldWrite = isNewFile || filenameChanged;
-
-										if (!shouldWrite && existingFilePath) {
-											const { data: existingContent, error: readError } =
-												await readMarkdownFile(existingFilePath);
-											if (readError) {
-												shouldWrite = true;
-											} else {
-												const {
-													data: existingFrontmatter,
-													body: existingBody,
-												} = existingContent;
-												const frontmatterChanged =
-													JSON.stringify(frontmatter) !==
-													JSON.stringify(existingFrontmatter);
-												const bodyChanged = body !== existingBody;
-												shouldWrite = frontmatterChanged || bodyChanged;
-											}
-										}
-
-										if (shouldWrite) {
-											const { error } = await writeMarkdownFile({
-												filePath,
-												frontmatter,
-												body,
-											});
-											if (error) {
-												logger.log(
-													ExtensionError({
-														message: `pullToMarkdown: failed to write ${filePath}`,
-														context: {
-															filePath,
-															tableName,
-															rowId: row.id,
-														},
-													}),
-												);
-											}
-										}
-
-										if (tableTracking) {
-											tableTracking[String(row.id)] = filename;
-										}
-									}),
-								);
-							},
-						),
-					);
-
-					syncCoordination.yjsWriteCount--;
-				},
-				catch: (error) => {
-					syncCoordination.yjsWriteCount--;
-					return ExtensionErr({
-						message: `Markdown extension pull failed: ${extractErrorMessage(error)}`,
-						context: { operation: 'pull' },
-					});
-				},
-			});
-		},
-
-		/**
-		 * Push: Sync from Markdown to YJS using diff-based synchronization.
-		 *
-		 * Computes the diff between markdown files and YJS, then applies only the changes:
-		 * - Rows in markdown but not in YJS → added
-		 * - Rows in YJS but not in markdown → deleted
-		 * - Rows in both → updated (no-op if content unchanged)
-		 *
-		 * **Deletion safety**: A YJS row is only deleted if no file exists with that ID.
-		 * If a file exists but fails to read or deserialize, the row is preserved and
-		 * a diagnostic is recorded. This prevents data loss when files have temporary
-		 * I/O errors or invalid content that the user can fix.
-		 *
-		 * The distinction:
-		 * - Can't parse ID from filename → file is unidentifiable → row deleted (can't protect what we can't identify)
-		 * - Can parse ID but can't read/deserialize → file exists → row preserved (user can fix the file)
-		 *
-		 * All YJS operations are wrapped in a single transaction for atomicity.
-		 */
-		async pushFromMarkdown() {
-			return tryAsync({
-				try: async () => {
-					syncCoordination.fileChangeCount++;
-
-					diagnostics.clear();
-
-					type TableSyncData = {
-						tableName: string;
-						table: TableHelper<string, TTableDefinitions[number]['fields']>;
-						yjsIds: Set<Id>;
-						fileExistsIds: Set<Id>;
-						markdownRows: Map<
-							Id,
-							RowWithId<TTableDefinitions[number]['fields']>
-						>;
-						markdownFilenames: Map<Id, string>;
-					};
-
-					const allTableData = await Promise.all(
-						Object.entries(resolvedConfigs).map(
-							async ([tableName, tableConfig]): Promise<TableSyncData> => {
-								const table = tables.get(tableName);
-								const tableDefinition = getTableById(
-									tables.definitions,
-									tableName,
-								);
-								const fields = tableDefinition!.fields;
-								const yjsIds = new Set(
-									table
-										.getAll()
-										.map((result) =>
-											result.status === 'valid' ? result.row.id : result.id,
-										),
-								);
-
-								const filePaths = await listMarkdownFiles(
-									tableConfig.directory,
-								);
-
-								const fileExistsIds = new Set(
-									filePaths
-										.map((filePath) => {
-											const parsed = tableConfig.parseFilename(
-												path.basename(filePath),
-											);
-											return parsed?.id ? createId(parsed.id) : undefined;
-										})
-										.filter((id): id is Id => Boolean(id)),
-								);
-
-								const markdownRows = new Map<
-									Id,
-									RowWithId<TTableDefinitions[number]['fields']>
-								>();
-								const markdownFilenames = new Map<Id, string>();
-
-								await Promise.all(
-									filePaths.map(async (filePath) => {
-										const filename = path.basename(filePath);
-
-										const parsed = tableConfig.parseFilename(filename);
-										if (!parsed) {
-											diagnostics.add({
-												filePath,
-												tableName,
-												filename,
-												error: MarkdownExtensionError({
-													message: `Failed to parse filename: ${filename}`,
-												}),
-											});
-											logger.log(
-												ExtensionError({
-													message: `pushFromMarkdown: failed to parse filename ${tableName}/${filename}`,
-													context: {
-														filePath,
-														tableName,
-														filename,
-													},
-												}),
-											);
-											return;
-										}
-
-										const { data: fileContent, error: readError } =
-											await readMarkdownFile(filePath);
-
-										if (readError) {
-											diagnostics.add({
-												filePath,
-												tableName,
-												filename,
-												error: MarkdownExtensionError({
-													message: `Failed to read markdown file at ${filePath}: ${readError.message}`,
-												}),
-											});
-											logger.log(
-												ExtensionError({
-													message: `pushFromMarkdown: failed to read ${tableName}/${filename}`,
-													context: {
-														filePath,
-														tableName,
-														filename,
-													},
-												}),
-											);
-											return;
-										}
-
-										const { data: frontmatter, body } = fileContent;
-
-										const { data: row, error: deserializeError } =
-											tableConfig.deserialize({
-												frontmatter,
-												body,
-												filename,
-												parsed,
-												fields,
-											});
-
-										if (deserializeError) {
-											diagnostics.add({
-												filePath,
-												tableName,
-												filename,
-												error: deserializeError,
-											});
-											logger.log(
-												ExtensionError({
-													message: `pushFromMarkdown: validation failed for ${tableName}/${filename}`,
-													context: {
-														filePath,
-														tableName,
-														filename,
-													},
-												}),
-											);
-											return;
-										}
-
-										// Convert row.id from string to branded Id
-										const rowWithBrandedId = {
-											...row,
-											id: createId((row as { id: string }).id),
-										} as RowWithId<TTableDefinitions[number]['fields']>;
-										markdownRows.set(rowWithBrandedId.id, rowWithBrandedId);
-										markdownFilenames.set(rowWithBrandedId.id, filename);
-									}),
-								);
-
-								return {
-									tableName,
-									table,
-									yjsIds,
-									fileExistsIds,
-									markdownRows,
-									markdownFilenames,
-								};
-							},
-						),
-					);
-
-					ydoc.transact(() => {
-						allTableData.forEach(
-							({
-								tableName,
-								table,
-								yjsIds,
-								fileExistsIds,
-								markdownRows,
-								markdownFilenames,
-							}) => {
-								const tableTracking = tracking[tableName];
-								const idsToDelete = [...yjsIds].filter(
-									(id) => !fileExistsIds.has(id),
-								);
-								idsToDelete.forEach((id) => {
-									table.delete(id);
-									if (tableTracking) {
-										delete tableTracking[id];
-									}
-								});
-
-								[...markdownRows.entries()].forEach(([id, row]) => {
-									table.upsert(row);
-									if (tableTracking) {
-										tableTracking[id] = markdownFilenames.get(id) ?? '';
-									}
-								});
-							},
-						);
-					});
-
-					syncCoordination.fileChangeCount--;
-				},
-				catch: (error) => {
-					syncCoordination.fileChangeCount--;
-					return ExtensionErr({
-						message: `Markdown extension push failed: ${extractErrorMessage(error)}`,
-						context: { operation: 'push' },
-					});
-				},
-			});
-		},
-
-		/**
-		 * Scan all markdown files and rebuild diagnostics
-		 *
-		 * Validates every markdown file against its table definition and updates the diagnostics
-		 * to reflect the current state. This is useful for:
-		 * - On-demand validation after bulk file edits
-		 * - Scheduled validation jobs (e.g., nightly scans)
-		 * - Manual verification that diagnostics are accurate
-		 *
-		 * Note: The initial scan on startup serves the same purpose, but this method
-		 * allows re-scanning at any time without restarting the server.
-		 */
-		async scanForErrors() {
-			return tryAsync({
-				try: async () => {
-					await validateAllMarkdownFiles({ operation: 'scanForErrors' });
-
-					// Return count of errors found
-					const errorCount = diagnostics.count();
-					console.log(
-						`Scan complete: ${errorCount} markdown file${errorCount === 1 ? '' : 's'} with validation errors`,
-					);
-				},
-				catch: (error) => {
-					return ExtensionErr({
-						message: `Markdown extension scan failed: ${extractErrorMessage(error)}`,
-						context: { operation: 'scan' },
-					});
-				},
-			});
 		},
 	});
 };

--- a/packages/epicenter/src/extensions/sqlite/sqlite.ts
+++ b/packages/epicenter/src/extensions/sqlite/sqlite.ts
@@ -6,11 +6,12 @@ import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { getTableConfig, type SQLiteTable } from 'drizzle-orm/sqlite-core';
 import { extractErrorMessage } from 'wellcrafted/error';
 import { tryAsync } from 'wellcrafted/result';
-import { defineExports, type ExtensionContext } from '../../dynamic/extension';
+import type { ExtensionContext } from '../../dynamic/extension';
 import type { Id, KvField, Row, TableDefinition } from '../../dynamic/schema';
 import { Id as createId } from '../../dynamic/schema';
 import { convertTableDefinitionsToDrizzle } from '../../dynamic/schema/converters/to-drizzle';
 import { ExtensionErr, ExtensionError } from '../../shared/errors';
+import { defineExtension } from '../../shared/lifecycle';
 import { createIndexLogger } from '../error-logger';
 
 const DEFAULT_DEBOUNCE_MS = 100;
@@ -41,7 +42,7 @@ export type SqliteConfig = {
  * SQLite extension: syncs YJS changes to SQLite and exposes Drizzle query interface.
  *
  * This extension creates internal resources (sqliteDb, drizzleTables) and exports them
- * via defineExports(). All exported resources become available in your workspace
+ * via defineExtension(). All exported resources become available in your workspace
  * via `client.extensions.sqlite`.
  *
  * **Sync Strategy**:
@@ -259,7 +260,56 @@ export const sqlite = async <
 	}
 
 	// Return destroy function alongside exported resources (flattened structure)
-	return defineExports({
+	return defineExtension({
+		exports: {
+			async pullToSqlite() {
+				return tryAsync({
+					try: () => rebuildSqlite(),
+					catch: (error) =>
+						ExtensionErr({
+							message: `SQLite extension pull operation failed: ${extractErrorMessage(error)}`,
+						}),
+				});
+			},
+
+			async pushFromSqlite() {
+				return tryAsync({
+					try: async () => {
+						isPushingFromSqlite = true;
+						tables.clear();
+
+						for (const [tableName, drizzleTable] of Object.entries(
+							drizzleTables,
+						) as [string, SQLiteTable][]) {
+							const table = tables.get(tableName);
+							const rows = await sqliteDb.select().from(drizzleTable);
+							for (const row of rows) {
+								// Cast is safe: Drizzle schema is derived from workspace definition
+								// Convert string id to branded Id type
+								const rowWithBrandedId = {
+									...row,
+									id: createId((row as { id: string }).id),
+								} as Row<TTableDefinitions[number]['fields']> & {
+									id: Id;
+								};
+								table.upsert(rowWithBrandedId);
+							}
+						}
+
+						isPushingFromSqlite = false;
+					},
+					catch: (error) => {
+						isPushingFromSqlite = false;
+						return ExtensionErr({
+							message: `SQLite extension push operation failed: ${extractErrorMessage(error)}`,
+						});
+					},
+				});
+			},
+
+			db: sqliteDb,
+			...drizzleTables,
+		},
 		async destroy() {
 			// Clear any pending sync timeout
 			if (syncTimeout) {
@@ -275,53 +325,5 @@ export const sqlite = async <
 			// Close the database connection to ensure WAL files are properly checkpointed
 			client.close();
 		},
-
-		async pullToSqlite() {
-			return tryAsync({
-				try: () => rebuildSqlite(),
-				catch: (error) =>
-					ExtensionErr({
-						message: `SQLite extension pull operation failed: ${extractErrorMessage(error)}`,
-					}),
-			});
-		},
-
-		async pushFromSqlite() {
-			return tryAsync({
-				try: async () => {
-					isPushingFromSqlite = true;
-					tables.clear();
-
-					for (const [tableName, drizzleTable] of Object.entries(
-						drizzleTables,
-					) as [string, SQLiteTable][]) {
-						const table = tables.get(tableName);
-						const rows = await sqliteDb.select().from(drizzleTable);
-						for (const row of rows) {
-							// Cast is safe: Drizzle schema is derived from workspace definition
-							// Convert string id to branded Id type
-							const rowWithBrandedId = {
-								...row,
-								id: createId((row as { id: string }).id),
-							} as Row<TTableDefinitions[number]['fields']> & {
-								id: Id;
-							};
-							table.upsert(rowWithBrandedId);
-						}
-					}
-
-					isPushingFromSqlite = false;
-				},
-				catch: (error) => {
-					isPushingFromSqlite = false;
-					return ExtensionErr({
-						message: `SQLite extension push operation failed: ${extractErrorMessage(error)}`,
-					});
-				},
-			});
-		},
-
-		db: sqliteDb,
-		...drizzleTables,
 	});
 };

--- a/packages/epicenter/src/extensions/websocket-sync.ts
+++ b/packages/epicenter/src/extensions/websocket-sync.ts
@@ -1,5 +1,5 @@
 import { WebsocketProvider } from 'y-websocket';
-import { defineExports } from '../shared/lifecycle';
+import { defineExtension } from '../shared/lifecycle';
 import type { ExtensionContext } from '../static/types';
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -206,7 +206,7 @@ export function websocketSync(config: WebsocketSyncConfig) {
 			ydoc,
 		);
 
-		return defineExports({
+		return defineExtension({
 			destroy: () => {
 				provider.destroy();
 			},

--- a/packages/epicenter/src/extensions/y-sweet-persist-sync/desktop.ts
+++ b/packages/epicenter/src/extensions/y-sweet-persist-sync/desktop.ts
@@ -2,8 +2,8 @@ import { writeFileSync } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import * as Y from 'yjs';
-import { defineExports, type ExtensionContext } from '../../dynamic/extension';
-import type { Lifecycle } from '../../shared/lifecycle';
+import type { ExtensionContext } from '../../dynamic/extension';
+import { defineExtension, type Lifecycle } from '../../shared/lifecycle';
 
 /**
  * Configuration for the persistence extension.
@@ -70,7 +70,7 @@ export const persistence = (
 		});
 	})();
 
-	return defineExports({ whenReady });
+	return defineExtension({ whenReady });
 };
 
 /**

--- a/packages/epicenter/src/extensions/y-sweet-persist-sync/web.ts
+++ b/packages/epicenter/src/extensions/y-sweet-persist-sync/web.ts
@@ -1,6 +1,6 @@
 import { IndexeddbPersistence } from 'y-indexeddb';
 import type * as Y from 'yjs';
-import { defineExports } from '../../dynamic/extension';
+import { defineExtension } from '../../shared/lifecycle';
 
 /**
  * IndexedDB persistence for a Yjs document.
@@ -32,10 +32,12 @@ import { defineExports } from '../../dynamic/extension';
  */
 export function indexeddbPersistence({ ydoc }: { ydoc: Y.Doc }) {
 	const idb = new IndexeddbPersistence(ydoc.guid, ydoc);
-	return defineExports({
+	return defineExtension({
+		exports: {
+			clearData: () => idb.clearData(),
+		},
 		// y-indexeddb's whenSynced = "data loaded from IndexedDB"
 		whenReady: idb.whenSynced,
 		destroy: () => idb.destroy(),
-		clearData: () => idb.clearData(),
 	});
 }

--- a/packages/epicenter/src/index.ts
+++ b/packages/epicenter/src/index.ts
@@ -42,7 +42,7 @@ export {
 
 export {
 	defineExtension,
-	type ExtensionResult,
+	type Extension,
 	type Lifecycle,
 	type MaybePromise,
 } from './shared/lifecycle';

--- a/packages/epicenter/src/index.ts
+++ b/packages/epicenter/src/index.ts
@@ -41,7 +41,8 @@ export {
 // ════════════════════════════════════════════════════════════════════════════
 
 export {
-	defineExports,
+	defineExtension,
+	type ExtensionResult,
 	type Lifecycle,
 	type MaybePromise,
 } from './shared/lifecycle';

--- a/packages/epicenter/src/shared/lifecycle.ts
+++ b/packages/epicenter/src/shared/lifecycle.ts
@@ -18,7 +18,7 @@
  *          ▼                                    ▼
  * ┌──────────────────────────┐    ┌──────────────────────────────┐
  * │  Providers (doc-level)   │    │  Extensions (workspace-level) │
- * │  return Lifecycle & T    │    │  return ExtensionResult<T>    │
+ * │  return Lifecycle & T    │    │  return Extension<T>    │
  * │  directly                │    │  via defineExtension()        │
  * └──────────────────────────┘    └──────────────────────────────┘
  * ```
@@ -155,7 +155,7 @@ export type Lifecycle = {
  * allExtensions[key] = exports; // by reference — getters survive
  * ```
  */
-export type ExtensionResult<T = Record<string, never>> = {
+export type Extension<T = Record<string, never>> = {
 	/** Consumer-facing exports stored by reference in `workspace.extensions[key]` */
 	exports: T;
 	/** Framework-managed lifecycle hooks (cleanup + readiness tracking) */
@@ -191,7 +191,7 @@ export type ExtensionResult<T = Record<string, never>> = {
  * | `destroy` | `() => {}` (no-op cleanup) |
  *
  * @param options - Optional configuration with exports and/or lifecycle hooks
- * @returns `ExtensionResult<T>` with exports stored by reference and lifecycle normalized
+ * @returns `Extension<T>` with exports stored by reference and lifecycle normalized
  *
  * @example Lifecycle-only extension (no consumer exports)
  * ```typescript
@@ -240,7 +240,7 @@ export function defineExtension<
 		whenReady?: Promise<unknown>;
 		destroy?: () => MaybePromise<void>;
 	} | void | null,
-): ExtensionResult<T> {
+): Extension<T> {
 	return {
 		exports: (options?.exports ?? {}) as T,
 		lifecycle: {

--- a/packages/epicenter/src/shared/lifecycle.ts
+++ b/packages/epicenter/src/shared/lifecycle.ts
@@ -14,13 +14,13 @@
  * │  Lifecycle (base protocol)                                      │
  * │    { whenReady, destroy }                                       │
  * └─────────────────────────────────────────────────────────────────┘
- *                    │                              │
- *                    ▼                              ▼
- * ┌─────────────────────────────┐    ┌─────────────────────────────┐
- * │  ProviderExports<T>         │    │  ExtensionExports<T>        │
- * │  Lifecycle & T              │    │  Lifecycle & T              │
- * │  (doc-level: head, registry)│    │  (workspace-level)          │
- * └─────────────────────────────┘    └─────────────────────────────┘
+ *          │                                    │
+ *          ▼                                    ▼
+ * ┌──────────────────────────┐    ┌──────────────────────────────┐
+ * │  Providers (doc-level)   │    │  Extensions (workspace-level) │
+ * │  return Lifecycle & T    │    │  return ExtensionResult<T>    │
+ * │  directly                │    │  via defineExtension()        │
+ * └──────────────────────────┘    └──────────────────────────────┘
  * ```
  *
  * ## Usage
@@ -28,31 +28,29 @@
  * Factory functions are **always synchronous**. Async initialization is tracked
  * via the returned `whenReady` promise, not the factory itself.
  *
- * Use `defineExports()` for explicit type safety and lifecycle normalization:
+ * **Extensions** use `defineExtension()` to separate lifecycle from consumer exports:
  *
  * ```typescript
- * // Simple extension - explicit lifecycle with defaults
- * const simple: ExtensionFactory = ({ tables }) => {
- *   tables.get('posts').observe({ onAdd: console.log });
- *   return defineExports(); // Framework fills in whenReady and destroy
- * };
- *
- * // Extension with cleanup
+ * // Extension with cleanup — lifecycle separated from exports
  * const withCleanup: ExtensionFactory = ({ ydoc }) => {
  *   const db = new Database(':memory:');
- *   return defineExports({
- *     db,
+ *   return defineExtension({
+ *     exports: { db },
  *     destroy: () => db.close(),
  *   });
  * };
+ * ```
  *
+ * **Providers** return `Lifecycle` (or `Lifecycle & T`) directly:
+ *
+ * ```typescript
  * // Provider with async initialization
  * const persistence: ProviderFactory = ({ ydoc }) => {
  *   const provider = new IndexeddbPersistence(ydoc.guid, ydoc);
- *   return defineExports({
+ *   return {
  *     whenReady: provider.whenReady,
  *     destroy: () => provider.destroy(),
- *   });
+ *   };
  * };
  * ```
  */
@@ -135,91 +133,119 @@ export type Lifecycle = {
 	destroy: () => MaybePromise<void>;
 };
 
+// ════════════════════════════════════════════════════════════════════════════
+// EXTENSION RESULT — Separated lifecycle from consumer exports
+// ════════════════════════════════════════════════════════════════════════════
+
 /**
- * Normalize any return value into a valid Lifecycle.
+ * The result of `defineExtension()` — separates lifecycle from consumer exports.
  *
- * This is the shared helper for both providers and extensions.
- * It fills in defaults for missing lifecycle fields:
+ * The framework plucks `lifecycle` for internal management (cleanup, readiness)
+ * and stores `exports` by reference as `workspace.extensions[key]`. Consumers
+ * never see lifecycle hooks — only the extension's public API.
  *
- * - `whenReady`: defaults to `Promise.resolve()`
- * - `destroy`: defaults to no-op `() => {}`
+ * @typeParam T - The exports object type (what consumers access via `workspace.extensions[key]`)
+ *
+ * @example
+ * ```typescript
+ * // Framework usage (internal)
+ * const { exports, lifecycle } = factory(context);
+ * extensionCleanups.push(lifecycle.destroy);
+ * whenReadyPromises.push(lifecycle.whenReady);
+ * allExtensions[key] = exports; // by reference — getters survive
+ * ```
+ */
+export type ExtensionResult<T = Record<string, never>> = {
+	/** Consumer-facing exports stored by reference in `workspace.extensions[key]` */
+	exports: T;
+	/** Framework-managed lifecycle hooks (cleanup + readiness tracking) */
+	lifecycle: Lifecycle;
+};
+
+/**
+ * Define an extension's exports and lifecycle hooks as separate concerns.
+ *
+ * Separates lifecycle hooks from consumer exports. The `exports` object is stored
+ * **by reference** — getters, proxies, and object identity are preserved.
  *
  * ## When to use
  *
- * Use `defineExports()` when you want to be explicit about lifecycle,
- * especially when your extension/provider has cleanup requirements:
+ * Use in any extension factory that is passed to `withExtension()`:
  *
  * ```typescript
- * // Makes cleanup visible in the return statement
- * return defineExports({
- *   db: sqliteDb,
- *   destroy: () => db.close(),
+ * .withExtension('sqlite', ({ ydoc }) => {
+ *   const db = new Database(':memory:');
+ *   return defineExtension({
+ *     exports: { db, query: (sql) => db.exec(sql) },
+ *     destroy: () => db.close(),
+ *   });
+ * })
+ * ```
+ *
+ * ## Defaults
+ *
+ * | Field | Default when omitted |
+ * |-------|---------------------|
+ * | `exports` | `{}` (empty object — valid for lifecycle-only extensions) |
+ * | `whenReady` | `Promise.resolve()` (instantly ready) |
+ * | `destroy` | `() => {}` (no-op cleanup) |
+ *
+ * @param options - Optional configuration with exports and/or lifecycle hooks
+ * @returns `ExtensionResult<T>` with exports stored by reference and lifecycle normalized
+ *
+ * @example Lifecycle-only extension (no consumer exports)
+ * ```typescript
+ * return defineExtension({
+ *   whenReady: loadPromise,
+ *   destroy: cleanup,
  * });
+ * // → exports: {}, lifecycle: { whenReady: loadPromise, destroy: cleanup }
  * ```
  *
- * For simple extensions with no cleanup, you can return void or a plain
- * object; the framework normalizes at the boundary anyway.
- *
- * ## Framework usage
- *
- * The framework calls this internally to normalize all returns:
- *
+ * @example Exports-only extension (no lifecycle)
  * ```typescript
- * // In contract.ts, workspace/create-workspace.ts
- * const exports = defineExports(factoryResult);
+ * return defineExtension({
+ *   exports: { compute: (x) => x * 2 },
+ * });
+ * // → exports: { compute }, lifecycle: { whenReady: resolved, destroy: noop }
  * ```
  *
- * @param exports - Optional exports object (may include lifecycle fields)
- * @returns Normalized object with guaranteed `whenReady` and `destroy`
- *
- * @example Simple extension (no async, no cleanup)
+ * @example Getter-based extension (preserves getters)
  * ```typescript
- * return defineExports({ helper: myHelper });
- * // → { helper, whenReady: Promise.resolve(), destroy: () => {} }
+ * return defineExtension({
+ *   exports: {
+ *     get provider() { return currentProvider; },
+ *     reconnect(newAuth) { ... },
+ *   },
+ *   whenReady,
+ *   destroy() { provider.destroy(); },
+ * });
+ * // → exports stored by reference — getter survives
  * ```
  *
- * @example With async initialization
+ * @example Full extension with exports + lifecycle
  * ```typescript
- * return defineExports({
- *   db: sqliteDb,
+ * return defineExtension({
+ *   exports: { db, pullToSqlite, pushFromSqlite },
  *   whenReady: db.initialize(),
- * });
- * // → { db, whenReady: initPromise, destroy: () => {} }
- * ```
- *
- * @example With cleanup
- * ```typescript
- * return defineExports({
- *   db: sqliteDb,
  *   destroy: () => db.close(),
- * });
- * // → { db, whenReady: Promise.resolve(), destroy: closeDb }
- * ```
- *
- * @example Full lifecycle
- * ```typescript
- * return defineExports({
- *   provider,
- *   whenReady: provider.connected,
- *   destroy: () => provider.disconnect(),
  * });
  * ```
  */
-export function defineExports<T extends Record<string, unknown> = {}>(
-	exports?: T | void | null,
-): Lifecycle & T {
-	if (!exports) {
-		return {
-			whenReady: Promise.resolve(),
-			destroy: () => {},
-		} as Lifecycle & T;
-	}
-
-	const { whenReady, destroy, ...rest } = exports as T & Partial<Lifecycle>;
-
+export function defineExtension<
+	T extends Record<string, unknown> = Record<string, never>,
+>(
+	options?: {
+		exports?: T;
+		whenReady?: Promise<unknown>;
+		destroy?: () => MaybePromise<void>;
+	} | void | null,
+): ExtensionResult<T> {
 	return {
-		...rest,
-		whenReady: whenReady ?? Promise.resolve(),
-		destroy: destroy ?? (() => {}),
-	} as Lifecycle & T;
+		exports: (options?.exports ?? {}) as T,
+		lifecycle: {
+			whenReady: options?.whenReady ?? Promise.resolve(),
+			destroy: options?.destroy ?? (() => {}),
+		},
+	};
 }

--- a/packages/epicenter/src/static/create-workspace.ts
+++ b/packages/epicenter/src/static/create-workspace.ts
@@ -38,7 +38,7 @@
 
 import * as Y from 'yjs';
 import type { Actions } from '../shared/actions.js';
-import type { ExtensionResult, MaybePromise } from '../shared/lifecycle.js';
+import type { Extension, MaybePromise } from '../shared/lifecycle.js';
 import { createKv } from './create-kv.js';
 import { createTables } from './create-tables.js';
 import type {
@@ -124,7 +124,7 @@ export function createWorkspace<
 						TKvDefinitions,
 						TExtensions
 					>,
-				) => ExtensionResult<TExports>,
+				) => Extension<TExports>,
 			) {
 				const result = factory({ id, ydoc, tables, kv, extensions });
 				extensionCleanups.push(() => result.lifecycle.destroy());

--- a/packages/epicenter/src/static/index.ts
+++ b/packages/epicenter/src/static/index.ts
@@ -79,7 +79,8 @@ export type { ExtensionError } from '../shared/errors.js';
 export { ExtensionErr } from '../shared/errors.js';
 // Lifecycle protocol
 export {
-	defineExports,
+	defineExtension,
+	type ExtensionResult,
 	type Lifecycle,
 	type MaybePromise,
 } from '../shared/lifecycle.js';
@@ -128,6 +129,7 @@ export type {
 	// Extension types
 	ExtensionContext,
 	ExtensionFactory,
+	ExtensionResult,
 	GetResult,
 	InferKvValue,
 	InferTableRow,

--- a/packages/epicenter/src/static/index.ts
+++ b/packages/epicenter/src/static/index.ts
@@ -80,7 +80,7 @@ export { ExtensionErr } from '../shared/errors.js';
 // Lifecycle protocol
 export {
 	defineExtension,
-	type ExtensionResult,
+	type Extension,
 	type Lifecycle,
 	type MaybePromise,
 } from '../shared/lifecycle.js';
@@ -126,10 +126,10 @@ export { createUnionSchema } from './schema-union.js';
 
 export type {
 	DeleteResult,
+	Extension,
 	// Extension types
 	ExtensionContext,
 	ExtensionFactory,
-	ExtensionResult,
 	GetResult,
 	InferKvValue,
 	InferTableRow,

--- a/packages/epicenter/src/static/types.ts
+++ b/packages/epicenter/src/static/types.ts
@@ -7,7 +7,7 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 import type * as Y from 'yjs';
 import type { Actions } from '../shared/actions.js';
-import type { ExtensionResult } from '../shared/lifecycle.js';
+import type { Extension } from '../shared/lifecycle.js';
 
 // ════════════════════════════════════════════════════════════════════════════
 // TABLE RESULT TYPES - Building Blocks
@@ -390,12 +390,12 @@ export type WorkspaceClientBuilder<
 	 * each factory receives the client-so-far (including all previously added extensions)
 	 * as typed context. This enables extension N+1 to access extension N's exports.
 	 *
-	 * The factory must return an `ExtensionResult` (from `defineExtension()`).
+	 * The factory must return an `Extension` (from `defineExtension()`).
 	 * The framework plucks `lifecycle` for internal management and stores
 	 * `exports` by reference — getters and object identity are preserved.
 	 *
 	 * @param key - Unique name for this extension (used as the key in `.extensions`)
-	 * @param factory - Factory function receiving the client-so-far context, returns ExtensionResult
+	 * @param factory - Factory function receiving the client-so-far context, returns Extension
 	 * @returns A new builder with the extension's exports added to the type
 	 *
 	 * @example
@@ -420,7 +420,7 @@ export type WorkspaceClientBuilder<
 				TKvDefinitions,
 				TExtensions
 			>,
-		) => ExtensionResult<TExports>,
+		) => Extension<TExports>,
 	): WorkspaceClientBuilder<
 		TId,
 		TTableDefinitions,
@@ -456,8 +456,8 @@ export type WorkspaceClientBuilder<
 	>;
 };
 
-// Re-export ExtensionResult for convenience
-export type { ExtensionResult } from '../shared/lifecycle.js';
+// Re-export Extension for convenience
+export type { Extension } from '../shared/lifecycle.js';
 
 // ════════════════════════════════════════════════════════════════════════════
 // EXTENSION TYPES
@@ -508,7 +508,7 @@ export type ExtensionContext<
 /**
  * Factory function that creates an extension with lifecycle hooks.
  *
- * All extensions MUST return an `ExtensionResult` (from `defineExtension()`).
+ * All extensions MUST return an `Extension` (from `defineExtension()`).
  * The framework plucks `lifecycle` for internal management and stores
  * `exports` by reference — getters and object identity are preserved.
  *
@@ -530,7 +530,7 @@ export type ExtensionContext<
  */
 export type ExtensionFactory<
 	TExports extends Record<string, unknown> = Record<string, unknown>,
-> = (context: ExtensionContext) => ExtensionResult<TExports>;
+> = (context: ExtensionContext) => Extension<TExports>;
 
 /** The workspace client returned by createWorkspace() */
 export type WorkspaceClient<

--- a/packages/epicenter/src/static/types.ts
+++ b/packages/epicenter/src/static/types.ts
@@ -7,7 +7,7 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 import type * as Y from 'yjs';
 import type { Actions } from '../shared/actions.js';
-import type { Lifecycle } from '../shared/lifecycle.js';
+import type { ExtensionResult } from '../shared/lifecycle.js';
 
 // ════════════════════════════════════════════════════════════════════════════
 // TABLE RESULT TYPES - Building Blocks
@@ -340,7 +340,7 @@ export type WorkspaceClientWithActions<
 	TId extends string,
 	TTableDefs extends TableDefinitions,
 	TKvDefs extends KvDefinitions,
-	TExtensions extends Record<string, Lifecycle>,
+	TExtensions extends Record<string, unknown>,
 	TActions extends Actions,
 > = WorkspaceClient<TId, TTableDefs, TKvDefs, TExtensions> & {
 	actions: TActions;
@@ -380,7 +380,7 @@ export type WorkspaceClientBuilder<
 	TId extends string,
 	TTableDefinitions extends TableDefinitions,
 	TKvDefinitions extends KvDefinitions,
-	TExtensions extends Record<string, Lifecycle> = Record<string, never>,
+	TExtensions extends Record<string, unknown> = Record<string, never>,
 > = WorkspaceClient<TId, TTableDefinitions, TKvDefinitions, TExtensions> & {
 	/**
 	 * Add a single extension. Returns a new builder with the extension's
@@ -390,24 +390,28 @@ export type WorkspaceClientBuilder<
 	 * each factory receives the client-so-far (including all previously added extensions)
 	 * as typed context. This enables extension N+1 to access extension N's exports.
 	 *
+	 * The factory must return an `ExtensionResult` (from `defineExtension()`).
+	 * The framework plucks `lifecycle` for internal management and stores
+	 * `exports` by reference — getters and object identity are preserved.
+	 *
 	 * @param key - Unique name for this extension (used as the key in `.extensions`)
-	 * @param factory - Factory function receiving the client-so-far context, returns exports
-	 * @returns A new builder with the extension added to the type
+	 * @param factory - Factory function receiving the client-so-far context, returns ExtensionResult
+	 * @returns A new builder with the extension's exports added to the type
 	 *
 	 * @example
 	 * ```typescript
 	 * const client = createWorkspace(definition)
 	 *   .withExtension('persistence', ({ ydoc }) => {
 	 *     const idb = new IndexeddbPersistence(ydoc.guid, ydoc);
-	 *     return defineExports({ whenReady: idb.whenReady, destroy: () => idb.destroy() });
+	 *     return defineExtension({ whenReady: idb.whenReady, destroy: () => idb.destroy() });
 	 *   })
 	 *   .withExtension('sync', ({ extensions }) => {
 	 *     // extensions.persistence is fully typed here!
-	 *     return defineExports({ ... });
+	 *     return defineExtension({ ... });
 	 *   });
 	 * ```
 	 */
-	withExtension<TKey extends string, TExports extends Lifecycle>(
+	withExtension<TKey extends string, TExports extends Record<string, unknown>>(
 		key: TKey,
 		factory: (
 			context: ExtensionContext<
@@ -416,7 +420,7 @@ export type WorkspaceClientBuilder<
 				TKvDefinitions,
 				TExtensions
 			>,
-		) => TExports,
+		) => ExtensionResult<TExports>,
 	): WorkspaceClientBuilder<
 		TId,
 		TTableDefinitions,
@@ -452,6 +456,9 @@ export type WorkspaceClientBuilder<
 	>;
 };
 
+// Re-export ExtensionResult for convenience
+export type { ExtensionResult } from '../shared/lifecycle.js';
+
 // ════════════════════════════════════════════════════════════════════════════
 // EXTENSION TYPES
 // ════════════════════════════════════════════════════════════════════════════
@@ -476,7 +483,7 @@ export type WorkspaceClientBuilder<
  * .withExtension('sync', ({ ydoc, extensions }) => {
  *   // extensions.persistence is typed if persistence was added before this
  *   const provider = createProvider(ydoc);
- *   return defineExports({ provider, destroy: () => provider.destroy() });
+ *   return defineExtension({ exports: { provider }, destroy: () => provider.destroy() });
  * })
  * ```
  */
@@ -484,7 +491,7 @@ export type ExtensionContext<
 	TId extends string = string,
 	TTableDefinitions extends TableDefinitions = TableDefinitions,
 	TKvDefinitions extends KvDefinitions = KvDefinitions,
-	TExtensions extends Record<string, Lifecycle> = Record<string, Lifecycle>,
+	TExtensions extends Record<string, unknown> = Record<string, unknown>,
 > = {
 	/** Workspace identifier */
 	id: TId;
@@ -501,36 +508,36 @@ export type ExtensionContext<
 /**
  * Factory function that creates an extension with lifecycle hooks.
  *
- * All extensions MUST return an object that satisfies the {@link Lifecycle} protocol:
- * - `whenReady`: Promise that resolves when the extension is ready
- * - `destroy`: Cleanup function called when the workspace is destroyed
+ * All extensions MUST return an `ExtensionResult` (from `defineExtension()`).
+ * The framework plucks `lifecycle` for internal management and stores
+ * `exports` by reference — getters and object identity are preserved.
  *
- * Use {@link defineExports} from `shared/lifecycle.ts` to easily create compliant exports.
+ * Use `defineExtension()` from `shared/lifecycle.ts` to create the result:
  *
  * @example Simple extension (works with any workspace)
  * ```typescript
  * const persistence: ExtensionFactory = ({ ydoc }) => {
  *   const provider = new IndexeddbPersistence(ydoc.guid, ydoc);
- *   return defineExports({
- *     provider,
+ *   return defineExtension({
+ *     exports: { provider },
  *     whenReady: provider.whenReady,
  *     destroy: () => provider.destroy(),
  *   });
  * };
  * ```
  *
- * @typeParam TExports - The exports returned by this extension (must extend Lifecycle)
+ * @typeParam TExports - The consumer-facing exports object type
  */
-export type ExtensionFactory<TExports extends Lifecycle = Lifecycle> = (
-	context: ExtensionContext,
-) => TExports;
+export type ExtensionFactory<
+	TExports extends Record<string, unknown> = Record<string, unknown>,
+> = (context: ExtensionContext) => ExtensionResult<TExports>;
 
 /** The workspace client returned by createWorkspace() */
 export type WorkspaceClient<
 	TId extends string,
 	TTableDefinitions extends TableDefinitions,
 	TKvDefinitions extends KvDefinitions,
-	TExtensions extends Record<string, Lifecycle>,
+	TExtensions extends Record<string, unknown>,
 > = {
 	/** Workspace identifier */
 	id: TId;
@@ -544,6 +551,9 @@ export type WorkspaceClient<
 	definitions: { tables: TTableDefinitions; kv: TKvDefinitions };
 	/** Extension exports (accumulated via `.withExtension()` calls) */
 	extensions: TExtensions;
+
+	/** Promise resolving when all extensions are ready */
+	whenReady: Promise<void>;
 
 	/** Cleanup all resources */
 	destroy(): Promise<void>;

--- a/specs/20260213T120800-separate-extension-lifecycle-from-exports.md
+++ b/specs/20260213T120800-separate-extension-lifecycle-from-exports.md
@@ -1,0 +1,366 @@
+# Separate Extension Lifecycle from Exports
+
+**Date**: 2026-02-13
+**Status**: Complete
+**Author**: AI-assisted
+
+## Overview
+
+Introduce `defineExtension()` to separate lifecycle hooks (`destroy`, `whenReady`) from custom exports, so the framework manages lifecycle internally and `workspace.extensions[key]` only exposes what consumers actually need.
+
+## Motivation
+
+### Current State
+
+Extensions return a flat object mixing lifecycle hooks with custom exports:
+
+```typescript
+// packages/epicenter/src/extensions/sqlite/sqlite.ts
+return defineExports({
+  db: client,              // custom export
+  pullToSqlite,            // custom export
+  pushFromSqlite,          // custom export
+  async destroy() { ... }, // lifecycle hook
+});
+```
+
+The framework then treats the whole object as both "lifecycle container" and "consumer API":
+
+```typescript
+// In withExtension() — dynamic create-workspace.ts:131
+const exports = defineExports(result as Record<string, unknown>);
+extensionCleanups.push(() => exports.destroy());
+whenReadyPromises.push(exports.whenReady);
+// ...
+const newExtensions = { ...extensions, [key]: exports };
+```
+
+This creates problems:
+
+1. **Lifecycle leaks to consumers.** `workspace.extensions.sqlite.destroy()` shows up in autocomplete and is callable. Consumers shouldn't be destroying individual extensions — that's the framework's job.
+
+2. **`defineExports` destructure+spread kills getters.** `ySweetPersistSync` had to opt out of `defineExports()` entirely because `{ ...rest }` strips its `provider` getter. The comment in the code:
+
+   ```typescript
+   // Build exports manually instead of using defineExports() because
+   // defineExports() destructures + spreads, which strips the provider getter.
+   ```
+
+3. **Static workspace doesn't aggregate `whenReady`.** The static `create-workspace.ts` pushes `exports.destroy()` but never collects `whenReady` into a top-level promise. The dynamic version does. Inconsistency.
+
+4. **No type distinction between "framework hooks" and "your stuff."** Both are `Lifecycle & T` — a flat intersection. There's no way for the type system to say "these two fields are special."
+
+### Desired State
+
+```typescript
+// Extension authoring
+return defineExtension({
+  exports: { db, pullToSqlite, pushFromSqlite },
+  destroy: () => db.close(),
+});
+
+// Consumer access — clean, no lifecycle pollution
+workspace.extensions.sqlite.db           // ✅ visible
+workspace.extensions.sqlite.destroy      // ❌ doesn't exist
+workspace.extensions.sqlite.whenReady   // ❌ doesn't exist
+
+// Getter-based extensions just work
+return defineExtension({
+  exports: {
+    get provider() { return provider; },
+    reconnect(newAuth) { ... },
+  },
+  whenReady,
+  destroy() { persistenceCleanup?.(); provider.destroy(); },
+});
+```
+
+## Research Findings
+
+### Extension Authoring Inventory (8 extensions)
+
+| Extension             | Current Pattern   | Custom Exports                         | Lifecycle Hooks | Getter? |
+| --------------------- | ----------------- | -------------------------------------- | --------------- | ------- |
+| websocketSync         | `defineExports()` | none                                   | `destroy`       | No      |
+| sqliteProvider        | `defineExports()` | `db`, tables, pull/push                | `destroy`       | No      |
+| markdownProvider      | `defineExports()` | pull/push/scan                         | `destroy`       | No      |
+| indexeddbPersistence  | `defineExports()` | `clearData`                            | both            | No      |
+| persistence (desktop) | `defineExports()` | none                                   | `whenReady`     | No      |
+| workspace-persistence | `defineExports()` | none                                   | both            | No      |
+| ySweetPersistSync     | **manual object** | `provider`, `reconnect`                | both            | **Yes** |
+| localRevisionHistory  | **manual object** | save/list/view/restore/count/directory | `destroy` only  | No      |
+
+**Key finding**: 6/8 extensions use `defineExports()`. The 2 that don't have legitimate reasons — getters and missing `whenReady`. Option A naturally handles both cases.
+
+### Extension Consumption Inventory
+
+| Access Pattern            | Count                 | Location                                             |
+| ------------------------- | --------------------- | ---------------------------------------------------- |
+| `extensions.X.customProp` | Many                  | Throughout apps and tests                            |
+| `extensions.X.whenReady`  | **1**                 | `apps/tab-manager/src/entrypoints/background.ts:346` |
+| `extensions.X.destroy()`  | **0** (consumer code) | Only framework-internal (2 sites)                    |
+| Spread/iterate extensions | **0** (consumer code) | Only framework-internal builder                      |
+
+**Key finding**: Separating lifecycle from exports breaks exactly 1 line of real consumer code. The refactor is essentially free from a migration standpoint.
+
+## Design Decisions
+
+| Decision               | Choice                                                            | Rationale                                                              |
+| ---------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Separation approach    | Structured return object with `exports` key + top-level lifecycle | Cleanest type boundary; framework never exposes lifecycle to consumers |
+| Helper name            | `defineExtension()` replaces `defineExports()`                    | Clean break; clear naming distinction                                  |
+| Exports storage        | Store by reference (no spread)                                    | Preserves getters, proxies, and object identity                        |
+| `defineExports()` fate | Remove entirely                                                   | Breaking change — no compat shim, no deprecation period                |
+| Static/dynamic parity  | Both workspaces share same normalization                          | Fixes the `whenReady` aggregation inconsistency                        |
+| `whenReady` default    | `Promise.resolve()` when omitted                                  | Same as today — extension with no async init is ready immediately      |
+| `destroy` default      | `() => {}` when omitted                                           | Same as today — extension with no cleanup is a no-op                   |
+
+## Architecture
+
+### New Return Shape
+
+```
+defineExtension() input                    defineExtension() output
+┌──────────────────────────┐               ┌──────────────────────────┐
+│  exports?: { ... }       │               │  exports: T              │  ← stored by reference
+│  whenReady?: Promise    │  ──────────►  │  lifecycle: {            │
+│  destroy?: () => void    │               │    whenReady: Promise   │  ← framework-managed
+│                          │               │    destroy: () => void   │  ← framework-managed
+└──────────────────────────┘               │  }                       │
+                                           └──────────────────────────┘
+```
+
+### Framework Consumption
+
+```
+withExtension(key, factory)
+─────────────────────────────
+
+STEP 1: Call factory (must return ExtensionResult from defineExtension())
+─────────────────────────────────────────────────────────────────────────
+const { exports, lifecycle } = factory(context);
+
+STEP 2: Register lifecycle
+──────────────────────────
+extensionCleanups.push(lifecycle.destroy);
+whenReadyPromises.push(lifecycle.whenReady);
+
+STEP 3: Store exports by reference
+───────────────────────────────────
+allExtensions[key] = exports;  // NO spread — getters survive
+```
+
+### Type Flow
+
+```typescript
+// What the extension author writes
+defineExtension({
+	exports: { db, helper },
+	destroy: () => db.close(),
+});
+
+// What defineExtension() returns (internal)
+type ExtensionResult<T> = {
+	exports: T;
+	lifecycle: Lifecycle;
+};
+
+// What workspace.extensions[key] exposes (consumer-facing)
+workspace.extensions.sqlite; // type: { db: Database; helper: () => void }
+//                              no .destroy, no .whenReady
+```
+
+## Implementation Plan
+
+### Phase 1: Core — `defineExtension()` replaces `defineExports()`
+
+- [x] **1.1** Create `defineExtension()` in `shared/lifecycle.ts`
+  - Accepts `{ exports?, whenReady?, destroy? }`
+  - Returns `{ exports: T, lifecycle: Lifecycle }` with defaults filled in
+  - Stores `exports` by reference (no spread/copy)
+- [x] **1.2** Remove `defineExports()` entirely from `shared/lifecycle.ts`
+- [x] **1.3** Add `ExtensionResult<T>` type to `shared/lifecycle.ts`
+- [x] **1.4** Update `ExtensionExports` type (or remove if no longer needed)
+- [x] **1.5** Tests: `defineExtension()` basic behavior, getter preservation, default filling
+
+### Phase 2: Framework integration — both workspace systems
+
+- [x] **2.1** Update `static/create-workspace.ts` `withExtension()`
+  - Factory return type: `ExtensionResult<T>` (from `defineExtension()`)
+  - Pluck `result.lifecycle` into internal arrays
+  - Store only `result.exports` in `extensions[key]` by reference
+  - **Add `whenReady` aggregation** (currently missing in static)
+- [x] **2.2** Update `dynamic/workspace/create-workspace.ts` `withExtension()` with same pattern
+- [x] **2.3** Update `WorkspaceClient` types in both `static/types.ts` and `dynamic/workspace/types.ts`
+  - `extensions: TExtensions` maps to exports-only types (no `Lifecycle` in the type)
+  - `withExtension` factory return type constraint: `ExtensionResult<T>` instead of `TExports extends Lifecycle`
+- [x] **2.4** Add `whenReady` to static `WorkspaceClient` type (parity with dynamic)
+- [x] **2.5** Tests: verify `workspace.extensions` doesn't expose destroy/whenReady, verify lifecycle still runs
+
+### Phase 3: Migrate extensions
+
+- [x] **3.1** `websocketSync` → `defineExtension()`
+- [x] **3.2** `sqliteProvider` → `defineExtension()`
+- [x] **3.3** `markdownProvider` → `defineExtension()`
+- [x] **3.4** `indexeddbPersistence` → `defineExtension()` (via y-sweet-persist-sync/web.ts)
+- [x] **3.5** `persistence` (desktop) → `defineExtension()` (via y-sweet-persist-sync/desktop.ts)
+- [x] **3.6** `workspace-persistence` (app) → `defineExtension()`
+- [x] **3.7** `ySweetPersistSync` → `defineExtension()` (getter-based — validates the design)
+- [x] **3.8** `localRevisionHistory` → `defineExtension()` (no whenReady — validates defaults)
+
+### Phase 4: Update consumers, exports, and cleanup
+
+- [x] **4.1** Fix the 1 consumer site: `apps/tab-manager/src/entrypoints/background.ts:346`
+  - `await client.extensions.sync.whenReady` → `await client.whenReady` (use workspace-level aggregated promise)
+- [x] **4.2** Update re-exports: replace `defineExports` with `defineExtension` in `dynamic/extension.ts`, `dynamic/index.ts`, `static/index.ts`, `packages/epicenter/src/index.ts`
+- [x] **4.3** Update `dynamic/provider-types.ts` re-exports
+- [x] **4.4** Remove all remaining `defineExports` imports and references across the codebase
+- [x] **4.5** Update tests that used `defineExports()` to use `defineExtension()`
+- [x] **4.6** Run full test suite, fix any type errors — 868 pass, 2 skip, 0 fail
+
+## Edge Cases
+
+### Extension with no exports (lifecycle-only)
+
+```typescript
+// E.g., persistence that just syncs Y.Doc
+return defineExtension({
+	whenReady: loadPromise,
+	destroy: cleanup,
+});
+// → exports: {} (empty object), lifecycle filled in
+// → workspace.extensions.persistence is {} — valid, just empty
+```
+
+### Extension with no lifecycle (exports-only)
+
+```typescript
+// E.g., a pure computation helper
+return defineExtension({
+	exports: { compute: (x) => x * 2 },
+});
+// → lifecycle: { whenReady: Promise.resolve(), destroy: () => {} }
+```
+
+### Extension returning nothing
+
+```typescript
+// Side-effect-only extension (e.g., logging observer)
+return defineExtension();
+// → exports: {}, lifecycle: { whenReady: Promise.resolve(), destroy: () => {} }
+```
+
+### Getter on exports
+
+```typescript
+return defineExtension({
+	exports: {
+		get provider() {
+			return currentProvider;
+		},
+	},
+	destroy() {
+		currentProvider.destroy();
+	},
+});
+// → exports stored by reference, getter preserved
+```
+
+### Extension that needs both exports AND whenReady/destroy
+
+```typescript
+return defineExtension({
+	exports: { db, pullToSqlite, pushFromSqlite },
+	whenReady: db.initialize(),
+	destroy: () => db.close(),
+});
+```
+
+## Open Questions
+
+1. **Should `workspace.extensions.X.whenReady` be available as an escape hatch?**
+   - The tab-manager currently uses it. After migration it should use `workspace.whenReady` instead.
+   - But some advanced use case might want per-extension readiness.
+   - **Recommendation**: Don't expose it. If a real need arises later, extensions can explicitly include a readiness signal in their `exports`.
+
+2. **Name: `defineExtension` vs `extension` vs `createExtension`?**
+   - `defineExtension` matches `defineWorkspace`, `defineTable` naming.
+   - `createExtension` implies instantiation (but this is a return-shape wrapper, not a factory).
+   - **Recommendation**: `defineExtension` — consistent with codebase conventions.
+
+## Success Criteria
+
+- [x] `defineExtension()` exists and is exported from `@epicenter/hq`
+- [x] `workspace.extensions.sqlite` does NOT have `.destroy` or `.whenReady` in its type
+- [x] `workspace.whenReady` works on both static and dynamic workspaces
+- [x] `workspace.destroy()` still calls all extension cleanup in reverse order
+- [x] Getter-based extensions (ySweetPersistSync) use `defineExtension()` and getter survives
+- [x] `defineExports()` is fully removed — no references remain
+- [x] All existing tests pass (updated to use `defineExtension()`) — 868 pass, 2 skip, 0 fail
+- [x] No `as any` or `@ts-ignore` introduced
+
+## References
+
+- `packages/epicenter/src/shared/lifecycle.ts` — Current `defineExports()` and `Lifecycle` type
+- `packages/epicenter/src/static/create-workspace.ts` — Static workspace `withExtension()` (missing `whenReady` aggregation)
+- `packages/epicenter/src/dynamic/workspace/create-workspace.ts` — Dynamic workspace `withExtension()` (has `whenReady` aggregation)
+- `packages/epicenter/src/static/types.ts` — Static `ExtensionContext`, `ExtensionFactory`, `WorkspaceClientBuilder`
+- `packages/epicenter/src/dynamic/workspace/types.ts` — Dynamic `ExtensionContext`, `ExtensionFactory`, `WorkspaceClientBuilder`
+- `packages/epicenter/src/dynamic/extension.ts` — Re-exports lifecycle utilities
+- `packages/epicenter/src/extensions/y-sweet-persist-sync.ts` — Getter-based manual object (prime migration candidate)
+- `packages/epicenter/src/extensions/revision-history/local.ts` — No `whenReady`, manual object
+- `apps/tab-manager/src/entrypoints/background.ts:346` — Only consumer accessing `.whenReady` on an extension
+
+## Review
+
+### Summary
+
+Replaced `defineExports()` with `defineExtension()` across the entire codebase. This is a **breaking change** — there is no backwards compatibility shim. All extension factories now return `ExtensionResult<T>` with separated `exports` and `lifecycle` instead of the old flat `Lifecycle & T`.
+
+### What Changed
+
+**Core API** (`shared/lifecycle.ts`):
+
+- `defineExports()` removed entirely
+- `defineExtension()` added — accepts `{ exports?, whenReady?, destroy? }`, returns `{ exports: T, lifecycle: Lifecycle }`
+- `ExtensionResult<T>` type added
+- `ExtensionExports<T>` type alias removed
+
+**Type system** (`static/types.ts`, `dynamic/workspace/types.ts`):
+
+- `TExtensions` constraint relaxed from `Record<string, Lifecycle>` to `Record<string, unknown>`
+- `ExtensionFactory` return type changed from `Lifecycle & T` to `ExtensionResult<T>`
+- `withExtension` factory parameter updated to match
+- `whenReady` added to static `WorkspaceClient` type (was missing — parity with dynamic)
+
+**Framework** (`static/create-workspace.ts`, `dynamic/workspace/create-workspace.ts`):
+
+- `withExtension()` now plucks `result.lifecycle` for internal management
+- Stores `result.exports` by reference (no spread — getters survive)
+- Static workspace now aggregates `whenReady` promises (previously missing)
+
+**Extensions** (7 files):
+
+- All migrated from `defineExports()` to `defineExtension()`
+- `ySweetPersistSync` no longer needs a manual object workaround — `defineExtension()` stores exports by reference, preserving the `provider` getter
+
+**Consumers** (3 files):
+
+- `workspace-persistence` returns `ExtensionResult` via `defineExtension()`
+- `tab-manager` uses `client.whenReady` instead of `extensions.sync.whenReady`
+- `content-doc-store` tests use inline `Lifecycle` objects
+
+### Commit History (8 waves, dependency-ordered)
+
+1. `feat(lifecycle)!: replace defineExports with defineExtension` — foundation
+2. `feat(types)!: update extension types to use ExtensionResult` — type definitions
+3. `feat(workspace)!: pluck lifecycle from ExtensionResult in withExtension` — framework
+4. `refactor(extensions): migrate all extensions to defineExtension` — 7 extension files
+5. `refactor: update re-exports from defineExports to defineExtension` — package exports
+6. `refactor: migrate consumers to defineExtension API` — apps and packages
+7. `test: update tests for defineExtension API` — test migrations
+8. `docs(spec): mark separate-extension-lifecycle spec complete` — this file
+
+### Test Results
+
+868 pass, 2 skip, 0 fail across 54 test files. Zero `defineExports` references remain in the codebase.


### PR DESCRIPTION
**BREAKING CHANGE**: `defineExports()` is removed. All extension factories must use `defineExtension()`.

Extensions were leaking lifecycle hooks (`destroy`, `whenReady`) into `workspace.extensions[key]`, polluting autocomplete and making it possible for consumers to call `workspace.extensions.sqlite.destroy()` directly — that's the framework's job. On top of that, `defineExports()` used destructure+spread internally, which stripped getters. The `ySweetPersistSync` extension had to opt out entirely with a manual object and a comment explaining why.

We chose a structured return (`{ exports, lifecycle }`) over a symbol-based or subclass approach because it gives the cleanest type boundary with zero runtime overhead.

## API Migration

```typescript
// BEFORE: lifecycle mixed into consumer exports
return defineExports({
  db: client,
  pullToSqlite,
  pushFromSqlite,
  async destroy() { await client.close(); },
});

// workspace.extensions.sqlite.destroy  ← visible to consumers ❌
// workspace.extensions.sqlite.whenReady ← visible to consumers ❌
```

```typescript
// AFTER: lifecycle separated from exports
return defineExtension({
  exports: { db: client, pullToSqlite, pushFromSqlite },
  destroy: async () => { await client.close(); },
});

// workspace.extensions.sqlite.db           ← visible ✅
// workspace.extensions.sqlite.destroy      ← doesn't exist ✅
// workspace.extensions.sqlite.whenReady    ← doesn't exist ✅
```

Getter-based extensions (like `ySweetPersistSync`) now work naturally — no more manual workarounds:

```typescript
// BEFORE: manual object because defineExports() stripped getters
return {
  get provider() { return provider; },
  reconnect(newAuth) { ... },
  whenReady,
  destroy() { ... },
};

// AFTER: defineExtension() stores exports by reference
return defineExtension({
  exports: {
    get provider() { return provider; },
    reconnect(newAuth) { ... },
  },
  whenReady,
  destroy() { provider.destroy(); },
});
```

## Architecture

```
defineExtension() input                    defineExtension() output
┌──────────────────────────┐               ┌──────────────────────────┐
│  exports?: { ... }       │               │  exports: T              │  ← stored by reference
│  whenReady?: Promise     │  ──────────►  │  lifecycle: {            │
│  destroy?: () => void    │               │    whenReady: Promise    │  ← framework-managed
│                          │               │    destroy: () => void   │  ← framework-managed
└──────────────────────────┘               │  }                       │
                                           └──────────────────────────┘
```

The framework plucks `lifecycle` for internal management and stores `exports` by reference — no spread, so getters survive:

```
withExtension(key, factory)
────────────────────────────
const { exports, lifecycle } = factory(context);
extensionCleanups.push(lifecycle.destroy);      // framework-managed
whenReadyPromises.push(lifecycle.whenReady);    // framework-managed
allExtensions[key] = exports;                   // by reference — getters survive
```

## Technical Details

The `ExtensionResult<T>` type and `ExtensionFactory` constraint changed:

```typescript
// New type
type ExtensionResult<T = Record<string, never>> = {
  exports: T;
  lifecycle: Lifecycle;
};

// ExtensionFactory now returns ExtensionResult instead of Lifecycle & T
type ExtensionFactory<TExports extends Record<string, unknown>> =
  (context: ExtensionContext) => ExtensionResult<TExports>;

// TExtensions constraint relaxed
type WorkspaceClient<..., TExtensions extends Record<string, unknown>> = { ... };
```

This also fixes the static/dynamic parity gap — static `create-workspace.ts` was missing `whenReady` aggregation. Both workspace systems now expose `workspace.whenReady`:

```typescript
// Previously only worked on dynamic workspaces
await workspace.whenReady; // now works on both static and dynamic ✅
```

## Rationale

The old `defineExports()` was designed as a simple normalizer — spread the input, fill in defaults for `whenReady` and `destroy`. This worked fine when extensions were simple, but as extensions grew more complex (getters, reconnect methods, provider swapping), the spread-based approach became a liability. The `ySweetPersistSync` extension already had to bypass it entirely.

Rather than patch `defineExports()` to handle getters (e.g., using `Object.defineProperties`), we took the opportunity to fix the deeper design issue: lifecycle hooks shouldn't be in the consumer-facing type at all. The structured return makes this separation explicit in the type system.

## Future Work

Per-extension readiness (`workspace.extensions.sqlite.whenReady`) is intentionally not exposed. If a real need arises, extensions can include a readiness signal in their `exports` explicitly — but the default is clean consumer types with no framework internals leaking through.