### PR TITLE
refactor(tab-manager): rename "suspended" to "saved" terminology

### DIFF
--- a/apps/tab-manager/src/entrypoints/popup/App.svelte
+++ b/apps/tab-manager/src/entrypoints/popup/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import TabList from '$lib/components/TabList.svelte';
-	import SuspendedTabList from '$lib/components/SuspendedTabList.svelte';
+	import SavedTabList from '$lib/components/SavedTabList.svelte';
 	import { ScrollArea } from '@epicenter/ui/scroll-area';
 	import { Separator } from '@epicenter/ui/separator';
 	import * as Tooltip from '@epicenter/ui/tooltip';
@@ -18,7 +18,7 @@
 		<ScrollArea class="h-[calc(600px-60px)]">
 			<TabList />
 			<Separator class="my-2" />
-			<SuspendedTabList />
+			<SavedTabList />
 		</ScrollArea>
 	</main>
 </Tooltip.Provider>

--- a/apps/tab-manager/src/lib/components/SavedTabList.svelte
+++ b/apps/tab-manager/src/lib/components/SavedTabList.svelte
@@ -51,7 +51,7 @@
 						<div class="flex items-center gap-2 text-xs text-muted-foreground">
 							<span class="truncate">{getDomain(tab.url)}</span>
 							<span>•</span>
-							<span class="shrink-0">{getRelativeTime(tab.suspendedAt)}</span>
+							<span class="shrink-0">{getRelativeTime(tab.savedAt)}</span>
 						</div>
 					</div>
 

--- a/apps/tab-manager/src/lib/components/SavedTabList.svelte
+++ b/apps/tab-manager/src/lib/components/SavedTabList.svelte
@@ -29,7 +29,8 @@
 				<BookmarkIcon class="size-8 text-muted-foreground" />
 			</Empty.Media>
 			<Empty.Title>No saved tabs</Empty.Title>
-			<Empty.Description>Save tabs to come back to them later</Empty.Description>
+			<Empty.Description>Save tabs to come back to them later</Empty.Description
+			>
 		</Empty.Root>
 	{:else}
 		<div class="flex flex-col gap-1">

--- a/apps/tab-manager/src/lib/components/SavedTabList.svelte
+++ b/apps/tab-manager/src/lib/components/SavedTabList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { suspendedTabState } from '$lib/state/suspended-tab-state.svelte';
+	import { savedTabState } from '$lib/state/saved-tab-state.svelte';
 	import { getDomain, getRelativeTime } from '$lib/utils/format';
 	import { Badge } from '@epicenter/ui/badge';
 	import { Button } from '@epicenter/ui/button';
@@ -8,32 +8,32 @@
 	import GlobeIcon from '@lucide/svelte/icons/globe';
 	import RotateCcwIcon from '@lucide/svelte/icons/rotate-ccw';
 	import Trash2Icon from '@lucide/svelte/icons/trash-2';
-	import PauseIcon from '@lucide/svelte/icons/pause';
+	import BookmarkIcon from '@lucide/svelte/icons/bookmark';
 </script>
 
 <section class="flex flex-col gap-2 p-4 pt-0">
 	<header class="flex items-center justify-between">
 		<h2 class="text-sm font-semibold text-muted-foreground">
-			Suspended Tabs
-			{#if suspendedTabState.tabs.length}
+			Saved Tabs
+			{#if savedTabState.tabs.length}
 				<Badge variant="secondary" class="ml-1">
-					{suspendedTabState.tabs.length}
+					{savedTabState.tabs.length}
 				</Badge>
 			{/if}
 		</h2>
 	</header>
 
-	{#if !suspendedTabState.tabs.length}
+	{#if !savedTabState.tabs.length}
 		<Empty.Root class="py-8">
 			<Empty.Media>
-				<PauseIcon class="size-8 text-muted-foreground" />
+				<BookmarkIcon class="size-8 text-muted-foreground" />
 			</Empty.Media>
-			<Empty.Title>No suspended tabs</Empty.Title>
-			<Empty.Description>Suspend tabs to save them for later</Empty.Description>
+			<Empty.Title>No saved tabs</Empty.Title>
+			<Empty.Description>Save tabs to come back to them later</Empty.Description>
 		</Empty.Root>
 	{:else}
 		<div class="flex flex-col gap-1">
-			{#each suspendedTabState.tabs as tab (tab.id)}
+			{#each savedTabState.tabs as tab (tab.id)}
 				<div
 					class="group flex items-center gap-3 rounded-md px-2 py-2 hover:bg-accent/50"
 				>
@@ -62,7 +62,7 @@
 							variant="ghost"
 							size="icon-xs"
 							tooltip="Restore"
-							onclick={() => suspendedTabState.actions.restore(tab)}
+							onclick={() => savedTabState.actions.restore(tab)}
 						>
 							<RotateCcwIcon />
 						</Button>
@@ -71,7 +71,7 @@
 							size="icon-xs"
 							class="text-destructive"
 							tooltip="Delete"
-							onclick={() => suspendedTabState.actions.remove(tab.id)}
+							onclick={() => savedTabState.actions.remove(tab.id)}
 						>
 							<Trash2Icon />
 						</Button>
@@ -84,14 +84,14 @@
 			<Button
 				variant="outline"
 				size="sm"
-				onclick={() => suspendedTabState.actions.restoreAll()}
+				onclick={() => savedTabState.actions.restoreAll()}
 			>
 				Restore All
 			</Button>
 			<Button
 				variant="destructive"
 				size="sm"
-				onclick={() => suspendedTabState.actions.removeAll()}
+				onclick={() => savedTabState.actions.removeAll()}
 			>
 				Delete All
 			</Button>

--- a/apps/tab-manager/src/lib/components/TabItem.svelte
+++ b/apps/tab-manager/src/lib/components/TabItem.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { browserState } from '$lib/state/browser-state.svelte';
-	import { suspendedTabState } from '$lib/state/suspended-tab-state.svelte';
+	import { savedTabState } from '$lib/state/saved-tab-state.svelte';
 	import type { Tab } from '$lib/workspace';
 	import { getDomain } from '$lib/utils/format';
 	import XIcon from '@lucide/svelte/icons/x';
@@ -11,7 +11,7 @@
 	import RefreshCwIcon from '@lucide/svelte/icons/refresh-cw';
 	import CopyIcon from '@lucide/svelte/icons/copy';
 	import GlobeIcon from '@lucide/svelte/icons/globe';
-	import PauseIcon from '@lucide/svelte/icons/pause';
+	import BookmarkIcon from '@lucide/svelte/icons/bookmark';
 	import { Button } from '@epicenter/ui/button';
 	import * as Avatar from '@epicenter/ui/avatar';
 	import { cn } from '@epicenter/ui/utils';
@@ -135,13 +135,13 @@
 		<Button
 			variant="ghost"
 			size="icon-xs"
-			tooltip="Suspend"
+			tooltip="Save for later"
 			onclick={(e: MouseEvent) => {
 				e.stopPropagation();
-				suspendedTabState.actions.suspend(tab);
+				savedTabState.actions.save(tab);
 			}}
 		>
-			<PauseIcon />
+			<BookmarkIcon />
 		</Button>
 
 		<Button

--- a/apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts
@@ -39,9 +39,9 @@ import { popupWorkspace } from '$lib/workspace-popup';
 function createSavedTabState() {
 	/** Read all valid saved tabs, most recently saved first. */
 	const readAll = () =>
-		popupWorkspace.tables.suspendedTabs
+		popupWorkspace.tables.savedTabs
 			.getAllValid()
-			.sort((a, b) => b.suspendedAt - a.suspendedAt);
+			.sort((a, b) => b.savedAt - a.savedAt);
 
 	/**
 	 * The full sorted list of saved tabs.
@@ -55,7 +55,7 @@ function createSavedTabState() {
 
 	// Re-read on every Y.Doc change — observer fires when persistence
 	// loads and on any subsequent remote/local modification.
-	popupWorkspace.tables.suspendedTabs.observe(() => {
+	popupWorkspace.tables.savedTabs.observe(() => {
 		tabs = readAll();
 	});
 
@@ -85,14 +85,14 @@ function createSavedTabState() {
 			async save(tab: Tab) {
 				if (!tab.url) return;
 				const deviceId = await getDeviceId();
-				popupWorkspace.tables.suspendedTabs.set({
+				popupWorkspace.tables.savedTabs.set({
 					id: generateId(),
 					url: tab.url,
 					title: tab.title || 'Untitled',
 					favIconUrl: tab.favIconUrl,
 					pinned: tab.pinned,
 					sourceDeviceId: deviceId,
-					suspendedAt: Date.now(),
+					savedAt: Date.now(),
 				});
 				await browser.tabs.remove(tab.tabId);
 			},
@@ -106,7 +106,7 @@ function createSavedTabState() {
 					url: savedTab.url,
 					pinned: savedTab.pinned,
 				});
-				popupWorkspace.tables.suspendedTabs.delete(savedTab.id);
+				popupWorkspace.tables.savedTabs.delete(savedTab.id);
 			},
 
 			/**
@@ -114,32 +114,32 @@ function createSavedTabState() {
 			 * to avoid overwhelming the browser, then removes each from Y.Doc.
 			 */
 			async restoreAll() {
-				const all = popupWorkspace.tables.suspendedTabs.getAllValid();
+				const all = popupWorkspace.tables.savedTabs.getAllValid();
 				for (const tab of all) {
 					await browser.tabs.create({
 						url: tab.url,
 						pinned: tab.pinned,
 					});
-					popupWorkspace.tables.suspendedTabs.delete(tab.id);
+					popupWorkspace.tables.savedTabs.delete(tab.id);
 				}
 			},
 
 			/** Delete a saved tab without restoring it. */
 			remove(id: string) {
-				popupWorkspace.tables.suspendedTabs.delete(id);
+				popupWorkspace.tables.savedTabs.delete(id);
 			},
 
 			/** Delete all saved tabs without restoring them. */
 			removeAll() {
-				const all = popupWorkspace.tables.suspendedTabs.getAllValid();
+				const all = popupWorkspace.tables.savedTabs.getAllValid();
 				for (const tab of all) {
-					popupWorkspace.tables.suspendedTabs.delete(tab.id);
+					popupWorkspace.tables.savedTabs.delete(tab.id);
 				}
 			},
 
 			/** Update a saved tab's metadata in Y.Doc. */
 			update(savedTab: SavedTab) {
-				popupWorkspace.tables.suspendedTabs.set(savedTab);
+				popupWorkspace.tables.savedTabs.set(savedTab);
 			},
 		},
 	};

--- a/apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts
@@ -1,10 +1,10 @@
 /**
- * Reactive suspended tab state for the popup.
+ * Reactive saved tab state for the popup.
  *
- * Backed by a Y.Doc CRDT table, so suspended tabs sync across devices and
+ * Backed by a Y.Doc CRDT table, so saved tabs sync across devices and
  * survive browser restarts. Unlike {@link browserState} which seeds from the
- * browser API and tracks ephemeral browser state, suspended tabs are
- * persistent user data — a tab suspended on your laptop appears on your
+ * browser API and tracks ephemeral browser state, saved tabs are
+ * persistent user data — a tab saved on your laptop appears on your
  * desktop automatically.
  *
  * Uses a plain `$state` array (not `SvelteMap`) because the access pattern is
@@ -18,14 +18,14 @@
  * @example
  * ```svelte
  * <script>
- *   import { suspendedTabState } from '$lib/state/suspended-tab-state.svelte';
+ *   import { savedTabState } from '$lib/state/saved-tab-state.svelte';
  * </script>
  *
- * {#each suspendedTabState.tabs as tab (tab.id)}
- *   <SuspendedTabItem {tab} />
+ * {#each savedTabState.tabs as tab (tab.id)}
+ *   <SavedTabItem {tab} />
  * {/each}
  *
- * <button onclick={() => suspendedTabState.actions.restoreAll()}>
+ * <button onclick={() => savedTabState.actions.restoreAll()}>
  *   Restore all
  * </button>
  * ```
@@ -33,25 +33,25 @@
 
 import { generateId } from '@epicenter/hq/dynamic';
 import { getDeviceId } from '$lib/device/device-id';
-import type { SuspendedTab, Tab } from '$lib/workspace';
+import type { SavedTab, Tab } from '$lib/workspace';
 import { popupWorkspace } from '$lib/workspace-popup';
 
-function createSuspendedTabState() {
-	/** Read all valid suspended tabs, most recently suspended first. */
+function createSavedTabState() {
+	/** Read all valid saved tabs, most recently saved first. */
 	const readAll = () =>
 		popupWorkspace.tables.suspendedTabs
 			.getAllValid()
 			.sort((a, b) => b.suspendedAt - a.suspendedAt);
 
 	/**
-	 * The full sorted list of suspended tabs.
+	 * The full sorted list of saved tabs.
 	 *
 	 * Wholesale-replaced on every Y.Doc change rather than surgically mutated.
 	 * This is intentional — the Y.Doc observer doesn't tell us *what* changed,
 	 * only *that* something changed, so a full re-read is the simplest correct
 	 * approach. The list is small enough that this is never a perf concern.
 	 */
-	let tabs = $state<SuspendedTab[]>(readAll());
+	let tabs = $state<SavedTab[]>(readAll());
 
 	// Re-read on every Y.Doc change — observer fires when persistence
 	// loads and on any subsequent remote/local modification.
@@ -60,13 +60,13 @@ function createSuspendedTabState() {
 	});
 
 	return {
-		/** All suspended tabs, sorted by most recently suspended first. */
+		/** All saved tabs, sorted by most recently saved first. */
 		get tabs() {
 			return tabs;
 		},
 
 		/**
-		 * Actions that mutate suspended tab state.
+		 * Actions that mutate saved tab state.
 		 *
 		 * All mutations go through the Y.Doc table, which fires the observer,
 		 * which re-reads the full list into `tabs`. This keeps the mutation path
@@ -76,13 +76,13 @@ function createSuspendedTabState() {
 		 */
 		actions: {
 			/**
-			 * Suspend a tab — snapshot its metadata to Y.Doc and close the
+			 * Save a tab — snapshot its metadata to Y.Doc and close the
 			 * browser tab. The tab can be restored later on any synced device.
 			 *
 			 * Silently no-ops for tabs without a URL (e.g. `chrome://` pages
 			 * that can't be re-opened via `browser.tabs.create`).
 			 */
-			async suspend(tab: Tab) {
+			async save(tab: Tab) {
 				if (!tab.url) return;
 				const deviceId = await getDeviceId();
 				popupWorkspace.tables.suspendedTabs.set({
@@ -98,19 +98,19 @@ function createSuspendedTabState() {
 			},
 
 			/**
-			 * Restore a suspended tab — re-open it in the browser and remove
+			 * Restore a saved tab — re-open it in the browser and remove
 			 * the record from Y.Doc. Preserves the tab's pinned state.
 			 */
-			async restore(suspendedTab: SuspendedTab) {
+			async restore(savedTab: SavedTab) {
 				await browser.tabs.create({
-					url: suspendedTab.url,
-					pinned: suspendedTab.pinned,
+					url: savedTab.url,
+					pinned: savedTab.pinned,
 				});
-				popupWorkspace.tables.suspendedTabs.delete(suspendedTab.id);
+				popupWorkspace.tables.suspendedTabs.delete(savedTab.id);
 			},
 
 			/**
-			 * Restore all suspended tabs at once. Opens each tab sequentially
+			 * Restore all saved tabs at once. Opens each tab sequentially
 			 * to avoid overwhelming the browser, then removes each from Y.Doc.
 			 */
 			async restoreAll() {
@@ -124,12 +124,12 @@ function createSuspendedTabState() {
 				}
 			},
 
-			/** Delete a suspended tab without restoring it. */
+			/** Delete a saved tab without restoring it. */
 			remove(id: string) {
 				popupWorkspace.tables.suspendedTabs.delete(id);
 			},
 
-			/** Delete all suspended tabs without restoring them. */
+			/** Delete all saved tabs without restoring them. */
 			removeAll() {
 				const all = popupWorkspace.tables.suspendedTabs.getAllValid();
 				for (const tab of all) {
@@ -137,12 +137,12 @@ function createSuspendedTabState() {
 				}
 			},
 
-			/** Update a suspended tab's metadata in Y.Doc. */
-			update(suspendedTab: SuspendedTab) {
-				popupWorkspace.tables.suspendedTabs.set(suspendedTab);
+			/** Update a saved tab's metadata in Y.Doc. */
+			update(savedTab: SavedTab) {
+				popupWorkspace.tables.suspendedTabs.set(savedTab);
 			},
 		},
 	};
 }
 
-export const suspendedTabState = createSuspendedTabState();
+export const savedTabState = createSavedTabState();

--- a/apps/tab-manager/src/lib/workspace-popup.ts
+++ b/apps/tab-manager/src/lib/workspace-popup.ts
@@ -1,7 +1,7 @@
 /**
  * Popup-side workspace client for accessing Y.Doc data.
  *
- * The popup needs direct access to the Y.Doc for the `suspendedTabs` table,
+ * The popup needs direct access to the Y.Doc for the saved tabs table,
  * which is shared across devices via Yjs (not available through Chrome APIs).
  *
  * This creates a lightweight workspace client with IndexedDB persistence
@@ -21,7 +21,7 @@ import { definition } from '$lib/workspace';
 /**
  * Popup workspace client.
  *
- * Provides typed access to all browser tables including `suspendedTabs`.
+ * Provides typed access to all browser tables including saved tabs.
  * Shares the same Y.Doc as the background service worker via IndexedDB
  * persistence and Y-Sweet sync.
  */

--- a/apps/tab-manager/src/lib/workspace.ts
+++ b/apps/tab-manager/src/lib/workspace.ts
@@ -153,10 +153,8 @@ export const definition = defineWorkspace({
 		 * Created when a user explicitly saves a tab (close + persist).
 		 * Deleted when a user restores the tab (opens URL locally + deletes row).
 		 *
-		 * NOTE: The key `suspendedTabs` and field `suspendedAt` are Y.Doc storage
-		 * keys — do not rename without a data migration.
 		 */
-		suspendedTabs: defineTable(
+		savedTabs: defineTable(
 			type({
 				id: 'string', // nanoid, generated on save
 				url: 'string', // The tab URL
@@ -164,7 +162,7 @@ export const definition = defineWorkspace({
 				'favIconUrl?': 'string', // Favicon URL (nullable)
 				pinned: 'boolean', // Whether tab was pinned
 				sourceDeviceId: 'string', // Device that saved this tab
-				suspendedAt: 'number', // Timestamp (ms since epoch)
+				savedAt: 'number', // Timestamp (ms since epoch)
 			}),
 		),
 	},
@@ -180,4 +178,4 @@ export type Device = InferTableRow<Tables['devices']>;
 export type Tab = InferTableRow<Tables['tabs']>;
 export type Window = InferTableRow<Tables['windows']>;
 export type TabGroup = InferTableRow<Tables['tabGroups']>;
-export type SavedTab = InferTableRow<Tables['suspendedTabs']>;
+export type SavedTab = InferTableRow<Tables['savedTabs']>;

--- a/apps/tab-manager/src/lib/workspace.ts
+++ b/apps/tab-manager/src/lib/workspace.ts
@@ -144,23 +144,26 @@ export const definition = defineWorkspace({
 		),
 
 		/**
-		 * Suspended tabs table — explicitly saved tabs that can be restored later.
+		 * Saved tabs table — explicitly saved tabs that can be restored later.
 		 *
 		 * Unlike the `tabs` table (which mirrors live browser state and is device-owned),
-		 * suspended tabs are shared across all devices. Any device can read, edit, or
-		 * restore a suspended tab.
+		 * saved tabs are shared across all devices. Any device can read, edit, or
+		 * restore a saved tab.
 		 *
-		 * Created when a user explicitly "suspends" a tab (close + save).
+		 * Created when a user explicitly saves a tab (close + persist).
 		 * Deleted when a user restores the tab (opens URL locally + deletes row).
+		 *
+		 * NOTE: The key `suspendedTabs` and field `suspendedAt` are Y.Doc storage
+		 * keys — do not rename without a data migration.
 		 */
 		suspendedTabs: defineTable(
 			type({
-				id: 'string', // nanoid, generated on suspend
+				id: 'string', // nanoid, generated on save
 				url: 'string', // The tab URL
-				title: 'string', // Tab title at time of suspend
+				title: 'string', // Tab title at time of save
 				'favIconUrl?': 'string', // Favicon URL (nullable)
 				pinned: 'boolean', // Whether tab was pinned
-				sourceDeviceId: 'string', // Device that suspended this tab
+				sourceDeviceId: 'string', // Device that saved this tab
 				suspendedAt: 'number', // Timestamp (ms since epoch)
 			}),
 		),
@@ -177,4 +180,4 @@ export type Device = InferTableRow<Tables['devices']>;
 export type Tab = InferTableRow<Tables['tabs']>;
 export type Window = InferTableRow<Tables['windows']>;
 export type TabGroup = InferTableRow<Tables['tabGroups']>;
-export type SuspendedTab = InferTableRow<Tables['suspendedTabs']>;
+export type SavedTab = InferTableRow<Tables['suspendedTabs']>;

--- a/docs/articles/migrating-tanstack-query-to-svelte-state-and-observers.md
+++ b/docs/articles/migrating-tanstack-query-to-svelte-state-and-observers.md
@@ -1,5 +1,7 @@
 # Nine Mutations Became One Import
 
+> **Note**: "Suspended" terminology was renamed to "saved" in the codebase. Code examples below use the original names. See `specs/20260213T014300-rename-suspended-to-saved.md`.
+
 ## Migrating Tanstack Query To Svelte State And Observers
 
 We had a browser extension popup with TanStack Query managing tab state. Every component that could close, pin, mute, reload, duplicate, or suspend a tab needed a `createMutation` call for each action—plus loading spinners, `isPending` checks, and `invalidateQueries` callbacks. A single `TabItem.svelte` component had nine mutation objects. [PR #1337](https://github.com/EpicenterHQ/epicenter/pull/1337) replaced all of them with one import line. Here's what the migration looked like and why the result is so much less code.

--- a/docs/articles/types-should-be-computed-not-declared.md
+++ b/docs/articles/types-should-be-computed-not-declared.md
@@ -2,6 +2,8 @@
 
 # Types Should Be Computed, Not Declared
 
+> **Note**: "Suspended" terminology was renamed to "saved" in the codebase. Code examples below use the original names. See `specs/20260213T014300-rename-suspended-to-saved.md`.
+
 ## `types.ts` is a code smell
 
 I've written before about [co-locating types with their implementations](./type-co-location-pattern.md) and [not using generic type buckets](./type-colocation-pattern.md). Both of those are about where types should live. This one is about whether they should exist at all.

--- a/docs/articles/when-tanstack-query-is-the-wrong-abstraction.md
+++ b/docs/articles/when-tanstack-query-is-the-wrong-abstraction.md
@@ -1,5 +1,7 @@
 # Stop Caching Data That Isn't Remote
 
+> **Note**: "Suspended" terminology was renamed to "saved" in the codebase. References below use the original names. See `specs/20260213T014300-rename-suspended-to-saved.md`.
+
 ## When TanStack Query is the wrong abstraction
 
 TanStack Query solves a real problem: fetching remote data, caching it locally, and keeping it fresh. But when the data isn't remote, you're paying for an abstraction that does nothing useful. Our browser extension popup was using TanStack Query to read `browser.tabs.query({})`—an API call that takes less than a millisecond, returns data that's already local, and has a built-in push notification system for changes. We were caching data that didn't need caching, then spending more code invalidating that cache than it would have taken to just read the value.

--- a/docs/specs/20260213T012108-browser-schema-camelcase-cleanup.md
+++ b/docs/specs/20260213T012108-browser-schema-camelcase-cleanup.md
@@ -1,5 +1,7 @@
 # Browser Schema camelCase Cleanup
 
+> **Note**: "Suspended" terminology was renamed to "saved" in the codebase. References below use the original names. See `specs/20260213T014300-rename-suspended-to-saved.md`.
+
 ## Goal
 
 Refactor `browser.schema.ts` and all consumers in `apps/tab-manager/` to use camelCase field names and table keys. Remove unused constants. Simplify where possible.

--- a/docs/specs/20260213T015500-popup-reactive-state.md
+++ b/docs/specs/20260213T015500-popup-reactive-state.md
@@ -3,7 +3,9 @@
 **Date**: 2026-02-13
 **Status**: Implemented
 **Author**: AI-assisted
-**Implementation notes**: All 5 phases completed. `browser-state.svelte.ts` created with `$state` reactive class, surgical browser event handlers, and direct action methods. Components (`TabList.svelte`, `TabItem.svelte`, `SuspendedTabList.svelte`) rewritten to use `browserState`. TanStack Query fully removed — `query/` directory deleted, `EpicenterProvider.svelte` deleted, no `@tanstack/svelte-query` imports remain.
+**Implementation notes**: All 5 phases completed. `browser-state.svelte.ts` created with `$state` reactive class, surgical browser event handlers, and direct action methods. Components (`TabList.svelte`, `TabItem.svelte`, `SavedTabList.svelte`) rewritten to use `browserState`. TanStack Query fully removed — `query/` directory deleted, `EpicenterProvider.svelte` deleted, no `@tanstack/svelte-query` imports remain.
+
+> **Note**: "Suspended" terminology was renamed to "saved" in the codebase. References below use the original names. See `specs/20260213T014300-rename-suspended-to-saved.md`.
 
 ## Overview
 

--- a/docs/specs/20260213T105705-tab-manager-src-reorganization.md
+++ b/docs/specs/20260213T105705-tab-manager-src-reorganization.md
@@ -1,5 +1,7 @@
 # Tab Manager `src/` Reorganization
 
+> **Note**: "Suspended" terminology was renamed to "saved" in the codebase. References below use the original names. See `specs/20260213T014300-rename-suspended-to-saved.md`.
+
 Reorganize `apps/tab-manager/src/lib/` from a flat/ad-hoc layout to domain-grouped modules.
 
 ## Problem

--- a/packages/epicenter/docs/architecture/action-dispatch.md
+++ b/packages/epicenter/docs/architecture/action-dispatch.md
@@ -1,5 +1,7 @@
 # Action Dispatch
 
+> **Note**: "Suspended" terminology was renamed to "saved" in the codebase. References below use the original names. See `specs/20260213T014300-rename-suspended-to-saved.md`.
+
 How to invoke actions across runtimes using YJS as the transport layer.
 
 ## The Problem

--- a/specs/20260212T132200-events-based-tab-management.md
+++ b/specs/20260212T132200-events-based-tab-management.md
@@ -1,7 +1,9 @@
 # Events-Based Tab Management
 
 **Date**: 2026-02-12
-**Status**: Superseded by `20260213T003200-suspended-tabs.md` (suspend/restore) and `20260213T103000-request-dispatch.md` (cross-runtime dispatch)
+**Status**: Superseded by `20260213T003200-suspended-tabs.md` (suspend/restore → now "save/saved") and `20260213T103000-request-dispatch.md` (cross-runtime dispatch)
+
+> **Note**: "Suspended" terminology was renamed to "saved" in the codebase. See `specs/20260213T014300-rename-suspended-to-saved.md`.
 **Author**: AI-assisted
 
 ## Overview

--- a/specs/20260213T003200-suspended-tabs.md
+++ b/specs/20260213T003200-suspended-tabs.md
@@ -1,8 +1,10 @@
 # Suspended Tabs
 
 **Date**: 2026-02-13
-**Status**: Draft
+**Status**: Complete (terminology renamed)
 **Supersedes**: `20260212T132200-events-based-tab-management.md`
+
+> **Note**: "Suspended" terminology was renamed to "saved" in the codebase. See `specs/20260213T014300-rename-suspended-to-saved.md`.
 
 ## Overview
 

--- a/specs/20260213T014300-rename-suspended-to-saved.md
+++ b/specs/20260213T014300-rename-suspended-to-saved.md
@@ -1,0 +1,148 @@
+# Rename "Suspended" to "Saved" Terminology
+
+**Date**: 2026-02-13
+**Status**: Draft
+
+## Overview
+
+Rename all "suspend/suspended" terminology to "save/saved" across the tab manager app. The user-facing label becomes **"Save for later"** and the code/data model uses **"saved"**.
+
+## Motivation
+
+"Suspend" is the wrong term for what this feature does. In browser land, "suspend" means freezing a tab in place to save memory (like The Great Suspender) — the tab stays in the tab bar but stops consuming resources. Our feature actually **closes the tab and persists it for later retrieval**, which is saving, not suspending.
+
+Evidence: the current helper text already says _"Suspend tabs to save them for later"_ — using a second phrase to explain what the first word means. If the verb needs explaining, it's the wrong verb.
+
+"Save for later" is universally understood (Slack uses this exact phrase), requires zero learning curve, and works for both developer and non-developer audiences.
+
+## Terminology Mapping
+
+| Before (Suspended)                    | After (Saved)                          | Where                         |
+| ------------------------------------- | -------------------------------------- | ----------------------------- |
+| "Suspended Tabs"                      | "Saved Tabs"                           | Section header                |
+| "No suspended tabs"                   | "No saved tabs"                        | Empty state                   |
+| "Suspend tabs to save them for later" | "Save tabs to come back to them later" | Empty state helper            |
+| "Suspend" (tooltip)                   | "Save for later" (tooltip)             | TabItem action button         |
+| "Error loading suspended tabs"        | "Error loading saved tabs"             | Error state                   |
+| "Restore"                             | "Restore"                              | **No change** — still correct |
+| "Delete"                              | "Delete"                               | **No change**                 |
+| "Restore All"                         | "Restore All"                          | **No change**                 |
+| "Delete All"                          | "Delete All"                           | **No change**                 |
+
+## Code Rename Mapping
+
+### Types & Schema (`browser.schema.ts`)
+
+| Before                         | After                      |
+| ------------------------------ | -------------------------- | ------------- |
+| `SuspendedTab` (type)          | `SavedTab`                 |
+| `suspendedTabs` (table const)  | `savedTabs`                |
+| `BROWSER_TABLES.suspendedTabs` | `BROWSER_TABLES.savedTabs` |
+| `suspendedAt` (field)          | `savedAt`                  |
+| `sourceDeviceId` (field)       | `sourceDeviceId`           | **No change** |
+| JSDoc: "Suspended tabs table"  | "Saved tabs table"         |
+
+### Helpers (`suspend-tab.ts` -> `save-tab.ts`)
+
+| Before                          | After               |
+| ------------------------------- | ------------------- | ------------- |
+| File: `suspend-tab.ts`          | File: `save-tab.ts` |
+| `suspendTab()`                  | `saveTab()`         |
+| `restoreTab()`                  | `restoreTab()`      | **No change** |
+| `deleteSuspendedTab()`          | `deleteSavedTab()`  |
+| `updateSuspendedTab()`          | `updateSavedTab()`  |
+| All JSDoc referencing "suspend" | Updated to "save"   |
+
+### Query Layer (`suspended-tabs.ts` -> `saved-tabs.ts`)
+
+| Before                                             | After                                  |
+| -------------------------------------------------- | -------------------------------------- |
+| File: `suspended-tabs.ts`                          | File: `saved-tabs.ts`                  |
+| `suspendedTabsKeys`                                | `savedTabsKeys`                        |
+| `suspendedTabsKeys.all` = `['suspended-tabs']`     | `savedTabsKeys.all` = `['saved-tabs']` |
+| `SuspendedTabsErr` / `'SuspendedTabsError'`        | `SavedTabsErr` / `'SavedTabsError'`    |
+| `suspendedTabs` (export)                           | `savedTabs`                            |
+| `suspendedTabs.suspend` mutation                   | `savedTabs.save`                       |
+| Mutation key `['suspended-tabs', 'suspend']`       | `['saved-tabs', 'save']`               |
+| All other mutation keys: `'suspended-tabs'` prefix | `'saved-tabs'` prefix                  |
+| Error messages: "Failed to suspend tab"            | "Failed to save tab"                   |
+
+### Component (`SuspendedTabList.svelte` -> `SavedTabList.svelte`)
+
+| Before                          | After                       |
+| ------------------------------- | --------------------------- |
+| File: `SuspendedTabList.svelte` | File: `SavedTabList.svelte` |
+| Imports from `suspended-tabs`   | Imports from `saved-tabs`   |
+| `type SuspendedTab`             | `type SavedTab`             |
+| `suspendedTabs.getAll`          | `savedTabs.getAll`          |
+| `suspendedTabs.restore`         | `savedTabs.restore`         |
+| `suspendedTabs.remove`          | `savedTabs.remove`          |
+| `suspendedTabs.restoreAll`      | `savedTabs.restoreAll`      |
+| `suspendedTabs.removeAll`       | `savedTabs.removeAll`       |
+| `suspendedTabsKeys`             | `savedTabsKeys`             |
+| `tab.suspendedAt`               | `tab.savedAt`               |
+
+### TabItem (`TabItem.svelte`)
+
+| Before                  | After                                          |
+| ----------------------- | ---------------------------------------------- |
+| `suspendMutation`       | `saveMutation`                                 |
+| `suspendedTabs.suspend` | `savedTabs.save`                               |
+| `suspendedTabsKeys`     | `savedTabsKeys`                                |
+| `tooltip="Suspend"`     | `tooltip="Save for later"`                     |
+| `PauseIcon`             | Consider `BookmarkIcon` or `ArchiveIcon` — TBD |
+
+### Other Files
+
+| File                         | Change                                               |
+| ---------------------------- | ---------------------------------------------------- |
+| `App.svelte`                 | Import `SavedTabList` instead of `SuspendedTabList`  |
+| `lib/epicenter/index.ts`     | Export `SavedTab` instead of `SuspendedTab`          |
+| `lib/epicenter/workspace.ts` | Update JSDoc referencing `suspendedTabs`             |
+| `lib/query/index.ts`         | Import/export `savedTabs` instead of `suspendedTabs` |
+
+## Icon Change
+
+Current: `PauseIcon` (pause symbol, fits "suspend" metaphor)
+
+Options for "save":
+
+- `BookmarkIcon` — universally means "save for later", strong precedent
+- `ArchiveIcon` (box with arrow) — feels too permanent
+- `InboxIcon` — implies a queue/inbox metaphor
+- `SaveIcon` (floppy disk) — dated, means "save file" not "save for later"
+
+**Recommendation**: `BookmarkIcon` — it's the standard "save for later" icon across Slack, browsers, and mobile apps.
+
+## Data Migration
+
+**Not required — but Y.Doc keys must stay unchanged.** The Yjs table key is derived from the JS object key name via `TableKey(name)` → `table:suspendedTabs`. Field names like `suspendedAt` are also Y.Map keys in the CRDT. Renaming either would orphan existing data. **Decision: keep internal Y.Doc keys (`suspendedTabs`, `suspendedAt`) unchanged, rename all code variables, types, file names, and user-facing strings.**
+
+## Implementation Plan
+
+- [ ] **1. Verify data migration** — Confirm `defineTable` key derivation doesn't depend on variable name
+- [ ] **2. Schema rename** — `browser.schema.ts`: rename type, table const, field `suspendedAt` -> `savedAt`, update JSDoc
+- [ ] **3. Helper rename** — Rename `suspend-tab.ts` -> `save-tab.ts`, rename all functions and update JSDoc
+- [ ] **4. Query layer rename** — Rename `suspended-tabs.ts` -> `saved-tabs.ts`, rename all exports, keys, error types
+- [ ] **5. SavedTabList component** — Rename `SuspendedTabList.svelte` -> `SavedTabList.svelte`, update all imports and labels
+- [ ] **6. TabItem component** — Rename mutation, update tooltip to "Save for later", change icon to `BookmarkIcon`
+- [ ] **7. Remaining imports** — Update `App.svelte`, `index.ts`, `workspace.ts`, `query/index.ts`
+- [ ] **8. Update original spec** — Add note to `20260213T003200-suspended-tabs.md` that terminology was renamed
+- [ ] **9. Verify** — `bun run check` passes, no stale references to "suspend" terminology
+
+## Edge Cases
+
+### Yjs Table Key
+
+If the table key in Y.Doc is derived from the variable name `suspendedTabs`, renaming to `savedTabs` would create a new empty table while orphaning existing data. **Must verify before proceeding.** If keys are positional or explicitly set, no migration needed.
+
+### Existing Suspended Tabs in User Data
+
+Users who already have suspended tabs should see them appear as "Saved Tabs" after the update. This works automatically if the underlying Y.Doc key doesn't change.
+
+## Success Criteria
+
+- [ ] Zero references to "suspend" terminology in user-facing text
+- [ ] Zero references to `suspended`/`Suspended`/`suspend` in code (except the background.ts WebSocket comment which is unrelated)
+- [ ] All existing saved tabs still appear after the rename
+- [ ] `bun run check` passes clean

--- a/specs/20260213T014300-rename-suspended-to-saved.md
+++ b/specs/20260213T014300-rename-suspended-to-saved.md
@@ -153,6 +153,24 @@ All "suspend/suspended" terminology renamed to "save/saved" across the tab manag
 | `App.svelte` | Import `SavedTabList` |
 | `workspace-popup.ts` | JSDoc updated |
 
-Done in two commits:
+### Docs & Specs Updated
+
+Added terminology rename notes to all historical specs and docs that reference "suspended":
+
+| File | Type |
+|------|------|
+| `specs/20260213T003200-suspended-tabs.md` | Note added, status → "Complete (terminology renamed)" |
+| `specs/20260213T103000-request-dispatch.md` | Note added |
+| `specs/20260212T132200-events-based-tab-management.md` | Note added |
+| `docs/specs/20260213T015500-popup-reactive-state.md` | Note added |
+| `docs/specs/20260213T105705-tab-manager-src-reorganization.md` | Note added |
+| `docs/specs/20260213T012108-browser-schema-camelcase-cleanup.md` | Note added |
+| `docs/articles/migrating-tanstack-query-to-svelte-state-and-observers.md` | Note added |
+| `docs/articles/when-tanstack-query-is-the-wrong-abstraction.md` | Note added |
+| `docs/articles/types-should-be-computed-not-declared.md` | Note added |
+| `packages/epicenter/docs/architecture/action-dispatch.md` | Note added |
+
+Done in three commits:
 1. `refactor(tab-manager): rename "suspended" to "saved" terminology` — user-facing + types + files (kept Y.Doc keys)
-2. `refactor(tab-manager): rename Y.Doc keys from suspended to saved` — breaking rename of storage keys
+2. `refactor(tab-manager)!: rename Y.Doc keys from suspended to saved` — breaking rename of storage keys
+3. `docs: add terminology rename notes to specs and articles` — notes on all historical docs

--- a/specs/20260213T103000-request-dispatch.md
+++ b/specs/20260213T103000-request-dispatch.md
@@ -4,6 +4,8 @@
 **Status**: Draft
 **Supersedes**: `20260212T132200-events-based-tab-management.md`
 
+> **Note**: "Suspended" terminology was renamed to "saved" in the codebase. See `specs/20260213T014300-rename-suspended-to-saved.md`.
+
 ## Overview
 
 Cross-runtime action dispatch via a per-workspace `requests` table. Any client connected to a workspace's Y.Doc can invoke actions on another online client by writing a request row. The target client observes, executes, writes the response, and the row is eventually purged.


### PR DESCRIPTION
"Suspend" is the wrong word for what this feature does. In browser land, "suspend" means freezing a tab in place to save memory (like The Great Suspender) — the tab stays in the tab bar but stops consuming resources. Our feature actually closes the tab and persists it for later retrieval, which is saving, not suspending. The current helper text already says _"Suspend tabs to save them for later"_ — using a second phrase to explain what the first word means. If the verb needs explaining, it's the wrong verb.

This renames all "suspend/suspended" terminology to "save/saved" across the tab manager app. "Save for later" is universally understood (Slack uses this exact phrase), requires zero learning curve, and works for both developer and non-developer audiences.

```
Before                              After
─────────────────────────────────── ───────────────────────────────────
"Suspended Tabs"                    "Saved Tabs"
"No suspended tabs"                 "No saved tabs"
"Suspend tabs to save them..."      "Save tabs to come back to them later"
tooltip: "Suspend"                  tooltip: "Save for later"
PauseIcon                           BookmarkIcon
SuspendedTabList.svelte             SavedTabList.svelte
suspended-tab-state.svelte.ts       saved-tab-state.svelte.ts
type SuspendedTab                   type SavedTab
suspendedTabs (table key)           savedTabs
suspendedAt (field)                 savedAt
```

The table key and field renames are a **breaking change** — the Y.Doc key changes from `table:suspendedTabs` to `table:savedTabs`, which means existing saved tabs won't carry over. This was accepted since the feature is brand new with minimal user data.

Historical specs and docs that reference the old terminology were annotated with notes pointing to the rename spec rather than rewritten, preserving the historical record.