### PR TITLE
feat(static): move batch() to workspace-level client API

### DIFF
--- a/apps/tab-manager/src/entrypoints/background.ts
+++ b/apps/tab-manager/src/entrypoints/background.ts
@@ -904,11 +904,12 @@ export default defineBackground(() => {
 								const tabs = await browser.tabs.query({
 									groupId: parsed.groupId,
 								});
-								for (const tab of tabs) {
-									if (tab.id !== undefined) {
-										await browser.tabs.ungroup(tab.id);
-									}
-								}
+								const tabIds = tabs.flatMap((tab) =>
+									tab.id !== undefined ? [tab.id] : [],
+								);
+								await Promise.allSettled(
+									tabIds.map((id) => browser.tabs.ungroup(id)),
+								);
 							},
 							catch: (error) => {
 								console.log(

--- a/apps/tab-manager/src/entrypoints/background.ts
+++ b/apps/tab-manager/src/entrypoints/background.ts
@@ -136,7 +136,7 @@ export default defineBackground(() => {
 	// Action Helpers (extracted from workspace definition)
 	// ─────────────────────────────────────────────────────────────────────────
 
-	const { tables, ydoc } = client;
+	const { tables } = client;
 
 	const actions = {
 		/**
@@ -173,7 +173,7 @@ export default defineBackground(() => {
 			const tabIds = new Set(rows.map((r) => r.tabId));
 			const existingYDocTabs = tables.tabs.getAllValid();
 
-			ydoc.transact(() => {
+			client.batch(() => {
 				// Set all browser tabs (with device-scoped IDs)
 				for (const row of rows) {
 					tables.tabs.set(row);
@@ -213,7 +213,7 @@ export default defineBackground(() => {
 			const windowIds = new Set(rows.map((r) => r.windowId));
 			const existingYDocWindows = tables.windows.getAllValid();
 
-			ydoc.transact(() => {
+			client.batch(() => {
 				// Set all browser windows (with device-scoped IDs)
 				for (const row of rows) {
 					tables.windows.set(row);
@@ -253,7 +253,7 @@ export default defineBackground(() => {
 			const groupIds = new Set(browserGroups.map((g) => g.id));
 			const existingYDocGroups = tables.tabGroups.getAllValid();
 
-			ydoc.transact(() => {
+			client.batch(() => {
 				// Set all browser groups (with device-scoped IDs)
 				for (const group of browserGroups) {
 					tables.tabGroups.set(tabGroupToRow(deviceId, group));
@@ -312,9 +312,9 @@ export default defineBackground(() => {
 	};
 
 	// Debug: Listen for all Y.Doc updates to see if we're receiving them
-	ydoc.on('update', (update: Uint8Array, origin: unknown) => {
+	client.ydoc.on('update', (update: Uint8Array, origin: unknown) => {
 		// Get the ytables Y.Map to inspect structure
-		const ytables = ydoc.getMap('tables');
+		const ytables = client.ydoc.getMap('tables');
 		const tabsTable = ytables.get('tabs') as Map<string, unknown> | undefined;
 
 		// Get entries from tabs table if it's a Y.Map

--- a/apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts
@@ -136,7 +136,7 @@ function createSavedTabState() {
 
 				// Batch-delete from Y.Doc in a single transaction so the observer
 				// fires exactly once (not N times).
-				popupWorkspace.ydoc.transact(() => {
+				popupWorkspace.batch(() => {
 					for (const tab of all) {
 						popupWorkspace.tables.savedTabs.delete(tab.id);
 					}
@@ -162,7 +162,7 @@ function createSavedTabState() {
 				const all = popupWorkspace.tables.savedTabs.getAllValid();
 				if (!all.length) return;
 
-				popupWorkspace.ydoc.transact(() => {
+				popupWorkspace.batch(() => {
 					for (const tab of all) {
 						popupWorkspace.tables.savedTabs.delete(tab.id);
 					}

--- a/apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts
@@ -110,18 +110,41 @@ function createSavedTabState() {
 			},
 
 			/**
-			 * Restore all saved tabs at once. Opens each tab sequentially
-			 * to avoid overwhelming the browser, then removes each from Y.Doc.
+			 * Restore all saved tabs at once.
+			 *
+			 * Fires all `browser.tabs.create()` calls in parallel (no sequential
+			 * awaiting) and batch-deletes from Y.Doc in a single transaction.
+			 *
+			 * This avoids two problems with the naive sequential approach:
+			 * 1. **Popup teardown**: `browser.tabs.create()` shifts focus, which
+			 *    can cause Chrome to destroy the popup mid-loop — killing the
+			 *    async context and leaving remaining tabs un-restored.
+			 * 2. **Observer spam**: Each individual `delete()` fires the Y.Doc
+			 *    observer, triggering a full `readAll()`. Wrapping in `transact()`
+			 *    collapses N observer callbacks into one.
 			 */
 			async restoreAll() {
 				const all = popupWorkspace.tables.savedTabs.getAllValid();
-				for (const tab of all) {
-					await browser.tabs.create({
-						url: tab.url,
-						pinned: tab.pinned,
-					});
-					popupWorkspace.tables.savedTabs.delete(tab.id);
-				}
+				if (!all.length) return;
+
+				// Fire all tab creations without awaiting each one individually.
+				// browser.tabs.create() sends IPC to the browser process immediately —
+				// the tabs will be created even if the popup is torn down afterward.
+				const createPromises = all.map((tab) =>
+					browser.tabs.create({ url: tab.url, pinned: tab.pinned }),
+				);
+
+				// Batch-delete from Y.Doc in a single transaction so the observer
+				// fires exactly once (not N times).
+				popupWorkspace.ydoc.transact(() => {
+					for (const tab of all) {
+						popupWorkspace.tables.savedTabs.delete(tab.id);
+					}
+				});
+
+				// Best-effort await — popup may die before this resolves, which is
+				// fine because the browser process is already creating the tabs.
+				await Promise.allSettled(createPromises);
 			},
 
 			/** Delete a saved tab without restoring it. */
@@ -129,12 +152,21 @@ function createSavedTabState() {
 				popupWorkspace.tables.savedTabs.delete(id);
 			},
 
-			/** Delete all saved tabs without restoring them. */
+			/**
+			 * Delete all saved tabs without restoring them.
+			 *
+			 * Wrapped in a Y.Doc transaction so the observer fires once
+			 * (not N times for N tabs).
+			 */
 			removeAll() {
 				const all = popupWorkspace.tables.savedTabs.getAllValid();
-				for (const tab of all) {
-					popupWorkspace.tables.savedTabs.delete(tab.id);
-				}
+				if (!all.length) return;
+
+				popupWorkspace.ydoc.transact(() => {
+					for (const tab of all) {
+						popupWorkspace.tables.savedTabs.delete(tab.id);
+					}
+				});
 			},
 
 			/** Update a saved tab's metadata in Y.Doc. */

--- a/bun.lock
+++ b/bun.lock
@@ -93,22 +93,6 @@
         "@tailwindcss/typography": "^0.5.16",
       },
     },
-    "apps/marp-test": {
-      "name": "marp-test",
-      "version": "0.0.1",
-      "dependencies": {
-        "@marp-team/marp-core": "^4.2.0",
-      },
-      "devDependencies": {
-        "@sveltejs/adapter-auto": "^7.0.0",
-        "@sveltejs/kit": "^2.50.2",
-        "@sveltejs/vite-plugin-svelte": "^6.2.4",
-        "svelte": "^5.49.2",
-        "svelte-check": "^4.3.6",
-        "typescript": "^5.9.3",
-        "vite": "^7.3.1",
-      },
-    },
     "apps/posthog-reverse-proxy": {
       "name": "@epicenter/posthog-reverse-proxy",
       "version": "0.0.1",
@@ -576,12 +560,6 @@
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
-    "@csstools/postcss-is-pseudo-class": ["@csstools/postcss-is-pseudo-class@5.0.3", "", { "dependencies": { "@csstools/selector-specificity": "^5.0.0", "postcss-selector-parser": "^7.0.0" }, "peerDependencies": { "postcss": "^8.4" } }, "sha512-jS/TY4SpG4gszAtIg7Qnf3AS2pjcUM5SzxpApOrlndMeGhIbaTzWBzzP/IApXoNWEW7OhcjkRT48jnAUIFXhAQ=="],
-
-    "@csstools/selector-resolve-nested": ["@csstools/selector-resolve-nested@3.1.0", "", { "peerDependencies": { "postcss-selector-parser": "^7.0.0" } }, "sha512-mf1LEW0tJLKfWyvn5KdDrhpxHyuxpbNwTIwOYLIvsTffeyOf85j5oIzfG0yosxDgx/sswlqBnESYUcQH0vgZ0g=="],
-
-    "@csstools/selector-specificity": ["@csstools/selector-specificity@5.0.0", "", { "peerDependencies": { "postcss-selector-parser": "^7.0.0" } }, "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw=="],
-
     "@devicefarmer/adbkit": ["@devicefarmer/adbkit@3.3.8", "", { "dependencies": { "@devicefarmer/adbkit-logcat": "^2.1.2", "@devicefarmer/adbkit-monkey": "~1.2.1", "bluebird": "~3.7", "commander": "^9.1.0", "debug": "~4.3.1", "node-forge": "^1.3.1", "split": "~1.0.1" }, "bin": { "adbkit": "bin/adbkit" } }, "sha512-7rBLLzWQnBwutH2WZ0EWUkQdihqrnLYCUMaB44hSol9e0/cdIhuNFcqZO0xNheAU6qqHVA8sMiLofkYTgb+lmw=="],
 
     "@devicefarmer/adbkit-logcat": ["@devicefarmer/adbkit-logcat@2.1.3", "", {}, "sha512-yeaGFjNBc/6+svbDeul1tNHtNChw6h8pSHAt5D+JsedUrMTN7tla7B15WLDyekxsuS2XlZHRxpuC6m92wiwCNw=="],
@@ -836,12 +814,6 @@
 
     "@lucide/svelte": ["@lucide/svelte@0.555.0", "", { "peerDependencies": { "svelte": "^5" } }, "sha512-aqTOMjBjf/HNwrhggRdb83T0QslZdpJTyTwr/chtXTGw7u4Hcu4zQb/5uA+csF0KKawKWVnsNI1MdHEHeEXTcQ=="],
 
-    "@marp-team/marp-core": ["@marp-team/marp-core@4.2.0", "", { "dependencies": { "@marp-team/marpit": "^3.2.0", "@marp-team/marpit-svg-polyfill": "^2.1.0", "highlight.js": "^11.11.1", "katex": "^0.16.25", "mathjax-full": "^3.2.2", "postcss-selector-parser": "^7.1.0", "xss": "^1.0.15" } }, "sha512-AoqRk9g6kF44OhdgV2eUsc0ciyxkI3IM/S4ntV+aHy59NSTcwPEHrbtAzqe+q2PK/trmQX233/0plusNZPoF+Q=="],
-
-    "@marp-team/marpit": ["@marp-team/marpit@3.2.0", "", { "dependencies": { "@csstools/postcss-is-pseudo-class": "^5.0.3", "cssesc": "^3.0.0", "js-yaml": "^4.1.0", "lodash.kebabcase": "^4.1.1", "markdown-it": "^14.1.0", "markdown-it-front-matter": "^0.2.4", "postcss": "^8.5.6", "postcss-nesting": "^13.0.2" } }, "sha512-DNCbwkAKugzCtiHJg/7DciIRwnKwAI2QH3VWWC1cVxoBBQTPnH5D9HcWqpDdduUqnCuW2PY78afVo+QlaInDdQ=="],
-
-    "@marp-team/marpit-svg-polyfill": ["@marp-team/marpit-svg-polyfill@2.1.0", "", { "peerDependencies": { "@marp-team/marpit": ">=0.5.0" }, "optionalPeers": ["@marp-team/marpit"] }, "sha512-VqCoAKwv1HJdzZp36dDPxznz2JZgRjkVSSPHpCzk72G2N753F0HPKXjevdjxmzN6gir9bUGBgMD1SguWJIi11A=="],
-
     "@mistralai/mistralai": ["@mistralai/mistralai@1.14.0", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.24.1" } }, "sha512-6zaj2f2LCd37cRpBvCgctkDbXtYBlAC85p+u4uU/726zjtsI+sdVH34qRzkm9iE3tRb8BoaiI0/P7TD+uMvLLQ=="],
 
     "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
@@ -1048,7 +1020,7 @@
 
     "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.8", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA=="],
 
-    "@sveltejs/adapter-auto": ["@sveltejs/adapter-auto@7.0.1", "", { "peerDependencies": { "@sveltejs/kit": "^2.0.0" } }, "sha512-dvuPm1E7M9NI/+canIQ6KKQDU2AkEefEZ2Dp7cY6uKoPq9Z/PhOXABe526UdW2mN986gjVkuSLkOYIBnS/M2LQ=="],
+    "@sveltejs/adapter-auto": ["@sveltejs/adapter-auto@6.1.1", "", { "peerDependencies": { "@sveltejs/kit": "^2.0.0" } }, "sha512-cBNt4jgH4KuaNO5gRSB2CZKkGtz+OCZ8lPjRQGjhvVUD4akotnj2weUia6imLl2v07K3IgsQRyM36909miSwoQ=="],
 
     "@sveltejs/adapter-static": ["@sveltejs/adapter-static@3.0.10", "", { "peerDependencies": { "@sveltejs/kit": "^2.0.0" } }, "sha512-7D9lYFWJmB7zxZyTE/qxjksvMqzMuYrrsyh1f4AlZqeZeACPRySjbC3aFiY55wb1tWUaKOQG9PVbm74JcN2Iew=="],
 
@@ -1277,8 +1249,6 @@
     "@wxt-dev/module-svelte": ["@wxt-dev/module-svelte@2.0.4", "", { "dependencies": { "@sveltejs/vite-plugin-svelte": "^4.0.0 || ^5.0.0 || ^6.0.0" }, "peerDependencies": { "svelte": ">=5", "wxt": ">=0.18.6" } }, "sha512-zYrzhoaRZsudPDQE2Yb4AOLwZXD4fXCOf+/ud7tvFnAJJ71aFtvZ5OuW/U2oBBYXdAtm+S2erFN2L0Re79x6ZA=="],
 
     "@wxt-dev/storage": ["@wxt-dev/storage@1.2.6", "", { "dependencies": { "@wxt-dev/browser": "^0.1.4", "async-mutex": "^0.5.0", "dequal": "^2.0.3" } }, "sha512-f6AknnpJvhNHW4s0WqwSGCuZAj0fjP3EVNPBO5kB30pY+3Zt/nqZGqJN6FgBLCSkYjPJ8VL1hNX5LMVmvxQoDw=="],
-
-    "@xmldom/xmldom": ["@xmldom/xmldom@0.9.8", "", {}, "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
@@ -1518,8 +1488,6 @@
 
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
-    "cssfilter": ["cssfilter@0.0.10", "", {}, "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="],
-
     "csso": ["csso@5.0.5", "", { "dependencies": { "css-tree": "~2.2.0" } }, "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ=="],
 
     "cssom": ["cssom@0.5.0", "", {}, "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="],
@@ -1663,8 +1631,6 @@
     "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
 
     "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
-
-    "esm": ["esm@3.2.25", "", {}, "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="],
 
     "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
 
@@ -1858,8 +1824,6 @@
 
     "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
 
-    "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
-
     "hmac-drbg": ["hmac-drbg@1.0.1", "", { "dependencies": { "hash.js": "^1.0.3", "minimalistic-assert": "^1.0.0", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg=="],
 
     "hookable": ["hookable@6.0.1", "", {}, "sha512-uKGyY8BuzN/a5gvzvA+3FVWo0+wUjgtfSdnmjtrOVwQCZPHpHDH2WRO3VZSOeluYrHoDCiXFffZXs8Dj1ULWtw=="],
@@ -2004,8 +1968,6 @@
 
     "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
-    "katex": ["katex@0.16.28", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg=="],
-
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
@@ -2082,8 +2044,6 @@
 
     "lodash.isstring": ["lodash.isstring@4.0.1", "", {}, "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="],
 
-    "lodash.kebabcase": ["lodash.kebabcase@4.1.1", "", {}, "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g=="],
-
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
     "lodash.once": ["lodash.once@4.1.1", "", {}, "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="],
@@ -2110,19 +2070,13 @@
 
     "markdown-it": ["markdown-it@14.1.1", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.4.0", "linkify-it": "^5.0.0", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA=="],
 
-    "markdown-it-front-matter": ["markdown-it-front-matter@0.2.4", "", {}, "sha512-25GUs0yjS2hLl8zAemVndeEzThB1p42yxuDEKbd4JlL3jiz+jsm6e56Ya8B0VREOkNxLYB4TTwaoPJ3ElMmW+w=="],
-
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
     "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
 
     "marky": ["marky@1.3.0", "", {}, "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ=="],
 
-    "marp-test": ["marp-test@workspace:apps/marp-test"],
-
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
-
-    "mathjax-full": ["mathjax-full@3.2.2", "", { "dependencies": { "esm": "^3.2.25", "mhchemparser": "^4.1.0", "mj-context-menu": "^0.6.1", "speech-rule-engine": "^4.0.6" } }, "sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w=="],
 
     "md5.js": ["md5.js@1.3.5", "", { "dependencies": { "hash-base": "^3.0.0", "inherits": "^2.0.1", "safe-buffer": "^5.1.2" } }, "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg=="],
 
@@ -2161,8 +2115,6 @@
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
-
-    "mhchemparser": ["mhchemparser@4.2.1", "", {}, "sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ=="],
 
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
@@ -2245,8 +2197,6 @@
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
-
-    "mj-context-menu": ["mj-context-menu@0.6.1", "", {}, "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA=="],
 
     "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
 
@@ -2423,8 +2373,6 @@
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "postcss-load-config": ["postcss-load-config@3.1.4", "", { "dependencies": { "lilconfig": "^2.0.5", "yaml": "^1.10.2" }, "peerDependencies": { "postcss": ">=8.0.9", "ts-node": ">=9.0.0" }, "optionalPeers": ["postcss", "ts-node"] }, "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg=="],
-
-    "postcss-nesting": ["postcss-nesting@13.0.2", "", { "dependencies": { "@csstools/selector-resolve-nested": "^3.1.0", "@csstools/selector-specificity": "^5.0.0", "postcss-selector-parser": "^7.0.0" }, "peerDependencies": { "postcss": "^8.4" } }, "sha512-1YCI290TX+VP0U/K/aFxzHzQWHWURL+CtHMSbex1lCdpXD1SoR2sYuxDu5aNI9lPoXpKTCggFZiDJbwylU0LEQ=="],
 
     "postcss-safe-parser": ["postcss-safe-parser@7.0.1", "", { "peerDependencies": { "postcss": "^8.4.31" } }, "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A=="],
 
@@ -2665,8 +2613,6 @@
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
     "spawn-sync": ["spawn-sync@1.0.15", "", { "dependencies": { "concat-stream": "^1.4.7", "os-shim": "^0.1.2" } }, "sha512-9DWBgrgYZzNghseho0JOuh+5fg9u6QWhAWa51QC7+U5rCheZ/j1DrEZnyE0RBBRqZ9uEXGPgSSM0nky6burpVw=="],
-
-    "speech-rule-engine": ["speech-rule-engine@4.1.2", "", { "dependencies": { "@xmldom/xmldom": "0.9.8", "commander": "13.1.0", "wicked-good-xpath": "1.3.0" }, "bin": { "sre": "bin/sre" } }, "sha512-S6ji+flMEga+1QU79NDbwZ8Ivf0S/MpupQQiIC0rTpU/ZTKgcajijJJb1OcByBQDjrXCN1/DJtGz4ZJeBMPGJw=="],
 
     "split": ["split@1.0.1", "", { "dependencies": { "through": "2" } }, "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg=="],
 
@@ -2984,8 +2930,6 @@
 
     "which-typed-array": ["which-typed-array@1.1.20", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg=="],
 
-    "wicked-good-xpath": ["wicked-good-xpath@1.3.0", "", {}, "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw=="],
-
     "widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
 
     "winreg": ["winreg@0.0.12", "", {}, "sha512-typ/+JRmi7RqP1NanzFULK36vczznSNN8kWVA9vIqXyv8GhghUlwhGp1Xj3Nms1FsPcNnsQrJOR10N58/nQ9hQ=="],
@@ -3011,8 +2955,6 @@
     "xml2js": ["xml2js@0.6.2", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA=="],
 
     "xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
-
-    "xss": ["xss@1.0.15", "", { "dependencies": { "commander": "^2.20.3", "cssfilter": "0.0.10" }, "bin": { "xss": "bin/xss" } }, "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
@@ -3244,8 +3186,6 @@
 
     "jws/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
-    "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
-
     "libsql/detect-libc": ["detect-libc@2.0.2", "", {}, "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="],
 
     "local-pkg/quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
@@ -3332,8 +3272,6 @@
 
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
-    "speech-rule-engine/commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
-
     "stream-browserify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "stream-http/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
@@ -3364,8 +3302,6 @@
 
     "vaul-svelte/svelte-toolbelt": ["svelte-toolbelt@0.7.1", "", { "dependencies": { "clsx": "^2.1.1", "runed": "^0.23.2", "style-to-object": "^1.0.8" }, "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-HcBOcR17Vx9bjaOceUvxkY3nGmbBmCBBbuWLLEWO6jtmWH8f/QoWmbyUfQZrpDINH39en1b8mptfPQT9VKQ1xQ=="],
 
-    "vault-demo/@sveltejs/adapter-auto": ["@sveltejs/adapter-auto@6.1.1", "", { "peerDependencies": { "@sveltejs/kit": "^2.0.0" } }, "sha512-cBNt4jgH4KuaNO5gRSB2CZKkGtz+OCZ8lPjRQGjhvVUD4akotnj2weUia6imLl2v07K3IgsQRyM36909miSwoQ=="],
-
     "vite-node/es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
 
     "vscode-json-languageservice/jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
@@ -3375,8 +3311,6 @@
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "wxt/minimatch": ["minimatch@10.1.2", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.1" } }, "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw=="],
-
-    "xss/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "yaml-language-server/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 

--- a/packages/epicenter/src/static/benchmark.test.ts
+++ b/packages/epicenter/src/static/benchmark.test.ts
@@ -304,9 +304,13 @@ describe('table benchmarks', () => {
 		const tables2 = createTables(ydoc2, { posts: postDefinition });
 
 		const { durationMs: batchMs } = measureTime(() => {
-			tables2.posts.batch((tx) => {
+			ydoc2.transact(() => {
 				for (let i = 0; i < 1_000; i++) {
-					tx.set({ id: generateId(i), title: `Post ${i}`, views: i });
+					tables2.posts.set({
+						id: generateId(i),
+						title: `Post ${i}`,
+						views: i,
+					});
 				}
 			});
 		});

--- a/packages/epicenter/src/static/create-kv.ts
+++ b/packages/epicenter/src/static/create-kv.ts
@@ -37,7 +37,6 @@ import {
 import { KV_KEY } from '../shared/ydoc-keys.js';
 import type {
 	InferKvValue,
-	KvBatchTransaction,
 	KvDefinition,
 	KvDefinitions,
 	KvGetResult,
@@ -106,21 +105,6 @@ export function createKv<TKvDefinitions extends KvDefinitions>(
 		delete(key) {
 			if (!definitions[key]) throw new Error(`Unknown KV key: ${key}`);
 			ykv.delete(key);
-		},
-
-		batch(fn) {
-			ykv.doc.transact(() => {
-				fn({
-					set: (key, value) => {
-						if (!definitions[key]) throw new Error(`Unknown KV key: ${key}`);
-						ykv.set(key, value);
-					},
-					delete: (key) => {
-						if (!definitions[key]) throw new Error(`Unknown KV key: ${key}`);
-						ykv.delete(key);
-					},
-				} as KvBatchTransaction<TKvDefinitions>);
-			});
 		},
 
 		observe(key, callback) {

--- a/packages/epicenter/src/static/create-workspace.test.ts
+++ b/packages/epicenter/src/static/create-workspace.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, test } from 'bun:test';
+import { type } from 'arktype';
+import { createWorkspace } from './create-workspace.js';
+import { defineKv } from './define-kv.js';
+import { defineTable } from './define-table.js';
+import { defineWorkspace } from './define-workspace.js';
+
+/** Creates a workspace client with two tables and one KV for testing. */
+function setup() {
+	const postsTable = defineTable(type({ id: 'string', title: 'string' }));
+	const tagsTable = defineTable(type({ id: 'string', name: 'string' }));
+	const themeDef = defineKv(type({ mode: "'light' | 'dark'" }));
+
+	const definition = defineWorkspace({
+		id: 'test-workspace',
+		tables: { posts: postsTable, tags: tagsTable },
+		kv: { theme: themeDef },
+	});
+
+	const client = createWorkspace(definition);
+	return { client };
+}
+
+describe('createWorkspace', () => {
+	describe('batch()', () => {
+		describe('core behavior', () => {
+			test('batch() batches table operations', () => {
+				const { client } = setup();
+
+				const changes: Set<string>[] = [];
+				const unsubscribe = client.tables.posts.observe((changedIds) => {
+					changes.push(new Set(changedIds));
+				});
+
+				client.batch(() => {
+					client.tables.posts.set({ id: '1', title: 'First' });
+					client.tables.posts.set({ id: '2', title: 'Second' });
+					client.tables.posts.set({ id: '3', title: 'Third' });
+				});
+
+				expect(changes).toHaveLength(1);
+				expect(changes[0]!.has('1')).toBe(true);
+				expect(changes[0]!.has('2')).toBe(true);
+				expect(changes[0]!.has('3')).toBe(true);
+				expect(client.tables.posts.count()).toBe(3);
+
+				unsubscribe();
+			});
+
+			test('batch() batches table deletes', () => {
+				const { client } = setup();
+
+				client.tables.posts.set({ id: '1', title: 'A' });
+				client.tables.posts.set({ id: '2', title: 'B' });
+				client.tables.posts.set({ id: '3', title: 'C' });
+
+				const changes: Set<string>[] = [];
+				const unsubscribe = client.tables.posts.observe((changedIds) => {
+					changes.push(new Set(changedIds));
+				});
+
+				client.batch(() => {
+					client.tables.posts.delete('1');
+					client.tables.posts.delete('2');
+					client.tables.posts.delete('3');
+				});
+
+				expect(changes).toHaveLength(1);
+				expect(changes[0]!.has('1')).toBe(true);
+				expect(changes[0]!.has('2')).toBe(true);
+				expect(changes[0]!.has('3')).toBe(true);
+				expect(client.tables.posts.count()).toBe(0);
+
+				unsubscribe();
+			});
+
+			test('batch() batches mixed set + delete', () => {
+				const { client } = setup();
+
+				client.tables.posts.set({ id: '1', title: 'Existing' });
+
+				const changes: Set<string>[] = [];
+				const unsubscribe = client.tables.posts.observe((changedIds) => {
+					changes.push(new Set(changedIds));
+				});
+
+				client.batch(() => {
+					client.tables.posts.set({ id: '2', title: 'New' });
+					client.tables.posts.delete('1');
+				});
+
+				expect(changes).toHaveLength(1);
+				expect(changes[0]!.has('1')).toBe(true);
+				expect(changes[0]!.has('2')).toBe(true);
+				expect(client.tables.posts.count()).toBe(1);
+				expect(client.tables.posts.has('1')).toBe(false);
+				expect(client.tables.posts.has('2')).toBe(true);
+
+				unsubscribe();
+			});
+
+			test('batch() works across multiple tables', () => {
+				const { client } = setup();
+
+				const postChanges: Set<string>[] = [];
+				const tagChanges: Set<string>[] = [];
+
+				const unsubPosts = client.tables.posts.observe((changedIds) => {
+					postChanges.push(new Set(changedIds));
+				});
+				const unsubTags = client.tables.tags.observe((changedIds) => {
+					tagChanges.push(new Set(changedIds));
+				});
+
+				client.batch(() => {
+					client.tables.posts.set({ id: 'p1', title: 'Post' });
+					client.tables.tags.set({ id: 't1', name: 'Tag' });
+				});
+
+				expect(postChanges).toHaveLength(1);
+				expect(postChanges[0]!.has('p1')).toBe(true);
+				expect(tagChanges).toHaveLength(1);
+				expect(tagChanges[0]!.has('t1')).toBe(true);
+
+				unsubPosts();
+				unsubTags();
+			});
+
+			test('batch() works across tables and KV', () => {
+				const { client } = setup();
+
+				const postChanges: Set<string>[] = [];
+				const kvChanges: unknown[] = [];
+
+				const unsubPosts = client.tables.posts.observe((changedIds) => {
+					postChanges.push(new Set(changedIds));
+				});
+				const unsubKv = client.kv.observe('theme', (change) => {
+					kvChanges.push(change);
+				});
+
+				client.batch(() => {
+					client.tables.posts.set({ id: 'p1', title: 'Post' });
+					client.kv.set('theme', { mode: 'dark' });
+				});
+
+				expect(postChanges).toHaveLength(1);
+				expect(postChanges[0]!.has('p1')).toBe(true);
+				expect(kvChanges).toHaveLength(1);
+
+				unsubPosts();
+				unsubKv();
+			});
+
+			test('batch() with no operations is a no-op', () => {
+				const { client } = setup();
+
+				const changes: Set<string>[] = [];
+				const unsubscribe = client.tables.posts.observe((changedIds) => {
+					changes.push(new Set(changedIds));
+				});
+
+				client.batch(() => {
+					// intentionally empty
+				});
+
+				expect(changes).toHaveLength(0);
+
+				unsubscribe();
+			});
+
+			test('nested batch() calls work', () => {
+				const { client } = setup();
+
+				const changes: Set<string>[] = [];
+				const unsubscribe = client.tables.posts.observe((changedIds) => {
+					changes.push(new Set(changedIds));
+				});
+
+				client.batch(() => {
+					client.tables.posts.set({ id: '1', title: 'Outer' });
+					client.batch(() => {
+						client.tables.posts.set({ id: '2', title: 'Inner' });
+					});
+					client.tables.posts.set({ id: '3', title: 'After inner' });
+				});
+
+				// Inner batch absorbed by outer — single notification
+				expect(changes).toHaveLength(1);
+				expect(changes[0]!.has('1')).toBe(true);
+				expect(changes[0]!.has('2')).toBe(true);
+				expect(changes[0]!.has('3')).toBe(true);
+
+				unsubscribe();
+			});
+		});
+
+		describe('observer semantics', () => {
+			test('without batch(), each set() fires observer separately', () => {
+				const { client } = setup();
+
+				const changes: Set<string>[] = [];
+				const unsubscribe = client.tables.posts.observe((changedIds) => {
+					changes.push(new Set(changedIds));
+				});
+
+				client.tables.posts.set({ id: '1', title: 'First' });
+				client.tables.posts.set({ id: '2', title: 'Second' });
+				client.tables.posts.set({ id: '3', title: 'Third' });
+
+				expect(changes).toHaveLength(3);
+
+				unsubscribe();
+			});
+
+			test('with batch(), N calls = 1 notification', () => {
+				const { client } = setup();
+
+				const changes: Set<string>[] = [];
+				const unsubscribe = client.tables.posts.observe((changedIds) => {
+					changes.push(new Set(changedIds));
+				});
+
+				client.batch(() => {
+					for (let i = 0; i < 100; i++) {
+						client.tables.posts.set({ id: `${i}`, title: `Post ${i}` });
+					}
+				});
+
+				expect(changes).toHaveLength(1);
+				expect(changes[0]!.size).toBe(100);
+
+				unsubscribe();
+			});
+		});
+
+		describe('edge cases', () => {
+			test('error inside batch() still applies prior operations', () => {
+				const { client } = setup();
+
+				try {
+					client.batch(() => {
+						client.tables.posts.set({ id: '1', title: 'Before error' });
+						client.tables.posts.set({ id: '2', title: 'Also before' });
+						throw new Error('intentional');
+					});
+				} catch {
+					// expected
+				}
+
+				// Yjs transact doesn't roll back — prior mutations are applied
+				expect(client.tables.posts.has('1')).toBe(true);
+				expect(client.tables.posts.has('2')).toBe(true);
+				expect(client.tables.posts.count()).toBe(2);
+			});
+		});
+	});
+});

--- a/packages/epicenter/src/static/create-workspace.ts
+++ b/packages/epicenter/src/static/create-workspace.ts
@@ -135,6 +135,9 @@ export function createWorkspace<
 			kv,
 			awareness,
 			extensions,
+			batch(fn: () => void): void {
+				ydoc.transact(fn);
+			},
 			whenReady,
 			destroy,
 			[Symbol.asyncDispose]: destroy,

--- a/packages/epicenter/src/static/index.ts
+++ b/packages/epicenter/src/static/index.ts
@@ -141,7 +141,6 @@ export type {
 	InferKvValue,
 	InferTableRow,
 	InvalidRowResult,
-	KvBatchTransaction,
 	KvChange,
 	KvDefinition,
 	KvDefinitions,
@@ -150,7 +149,6 @@ export type {
 	NotFoundResult,
 	// Result types - composed
 	RowResult,
-	TableBatchTransaction,
 	// Definition types
 	TableDefinition,
 	// Map types

--- a/packages/epicenter/src/static/table-helper.ts
+++ b/packages/epicenter/src/static/table-helper.ts
@@ -16,7 +16,6 @@ import type {
 	InferTableRow,
 	InvalidRowResult,
 	RowResult,
-	TableBatchTransaction,
 	TableDefinition,
 	TableHelper,
 	UpdateResult,
@@ -165,19 +164,6 @@ export function createTableHelper<
 			for (const key of keys) {
 				ykv.delete(key);
 			}
-		},
-
-		// ═══════════════════════════════════════════════════════════════════════
-		// BATCH (Y.js transaction for atomicity)
-		// ═══════════════════════════════════════════════════════════════════════
-
-		batch(fn: (tx: TableBatchTransaction<TRow>) => void): void {
-			ykv.doc.transact(() => {
-				fn({
-					set: (row: TRow) => ykv.set(row.id, row),
-					delete: (id: string) => ykv.delete(id),
-				});
-			});
 		},
 
 		// ═══════════════════════════════════════════════════════════════════════

--- a/packages/epicenter/src/static/types.ts
+++ b/packages/epicenter/src/static/types.ts
@@ -801,6 +801,31 @@ export type WorkspaceClient<
 	 * });
 	 * // All three writes are one atomic transaction
 	 * ```
+	 *
+	 * ## Known Limitation: Stale reads after delete
+	 *
+	 * If you delete a pre-existing key inside `batch()` and then read it back
+	 * within the same callback, `has()` returns `true` and `get()` returns the
+	 * old value. This is because the underlying YKeyValue read cache (`map`) is
+	 * only updated by the Yjs observer, which doesn't fire until the transaction
+	 * ends. Writes via `set()` are not affected — they go through a `pending`
+	 * buffer that `get()`/`has()` check first.
+	 *
+	 * ```typescript
+	 * client.tables.posts.set({ id: '1', title: 'Hello' });
+	 *
+	 * client.batch(() => {
+	 *   client.tables.posts.delete('1');
+	 *   client.tables.posts.has('1');  // true  (stale — map not yet updated)
+	 *   client.tables.posts.get('1');  // valid (stale — returns old row)
+	 * });
+	 *
+	 * client.tables.posts.has('1');    // false (observer has now updated map)
+	 * ```
+	 *
+	 * This is a known consequence of the single-writer architecture in the
+	 * YKeyValue layer. If you need to check deletion status within a batch,
+	 * track deleted IDs yourself in a local `Set`.
 	 */
 	batch(fn: () => void): void;
 

--- a/specs/20260214T105600-workspace-level-batch.md
+++ b/specs/20260214T105600-workspace-level-batch.md
@@ -1,0 +1,174 @@
+# Workspace-Level `batch()` — Replace Per-Table/Per-KV Batch with `client.batch()`
+
+**Date**: 2026-02-14
+**Status**: Proposed
+
+## Overview
+
+Move the `batch()` API from individual table helpers and KV helpers up to the workspace client. All tables and KV in a workspace share a single `Y.Doc`, so the transaction boundary should reflect that — not pretend it's per-table.
+
+## Problem
+
+### Per-table `batch()` lies about scope
+
+Every table helper and KV helper has its own `batch()` method:
+
+```typescript
+tables.tabs.batch((tx) => {
+  tx.set({ id: '1', ... });
+  tx.set({ id: '2', ... });
+});
+```
+
+Under the hood, this calls `ydoc.transact()` on the shared workspace Y.Doc. But the API implies the transaction is scoped to that one table. Nothing stops you from doing this:
+
+```typescript
+tables.tabs.batch((tx) => {
+  tx.set({ id: '1', ... });
+  tables.windows.set({ ... }); // Also batched! Same ydoc.transact()
+});
+```
+
+That works because it's all one Y.Doc. The `tx` object's constrained surface (`set`/`delete` for one table) creates a false impression of isolation that doesn't exist.
+
+### The `tx` parameter is redundant
+
+`tx.set(row)` is identical to `tables.posts.set(row)` — both call through to the same `ykv.set()`. The transaction object adds no behavior beyond what the normal table methods already do inside a `ydoc.transact()` wrapper.
+
+### Cross-table batching requires escaping to raw Yjs
+
+When users need to batch across tables (common in sync code), they have to drop to `ydoc.transact()`:
+
+```typescript
+// From background.ts — user has to reach for raw Yjs
+ydoc.transact(() => {
+	for (const row of rows) {
+		tables.tabs.set(row);
+	}
+	for (const existing of stale) {
+		tables.tabs.delete(existing.id);
+	}
+});
+```
+
+This leaks the Yjs implementation detail. The workspace API exists to abstract over Yjs.
+
+## Solution
+
+### Add `client.batch(fn: () => void): void`
+
+```typescript
+// create-workspace.ts — in buildClient()
+batch(fn: () => void): void {
+  ydoc.transact(fn);
+}
+```
+
+No callback parameter. No `tx` object. The user already has `client.tables` and `client.kv` — calling their normal methods inside the callback automatically batches everything into one Y.js transaction.
+
+```typescript
+// Single table
+client.batch(() => {
+  tables.tabs.set({ id: '1', ... });
+  tables.tabs.set({ id: '2', ... });
+  tables.tabs.delete('3');
+});
+
+// Cross-table + KV — all one transaction
+client.batch(() => {
+  tables.tabs.set({ id: '1', ... });
+  tables.windows.set({ id: 'w1', ... });
+  kv.set('lastSync', new Date().toISOString());
+});
+```
+
+### Remove per-table and per-KV `batch()`
+
+Remove `batch()` from:
+
+- `TableHelper` type and implementation (`static/types.ts`, `static/table-helper.ts`)
+- `KvHelper` type and implementation (`static/types.ts`, `static/create-kv.ts`)
+- `TableBatchTransaction` type (`static/types.ts`)
+- `KvBatchTransaction` type (`static/types.ts`)
+
+### Why no callback parameter?
+
+The callback receives nothing because there's nothing special to pass:
+
+- `tables` and `kv` are the same objects whether you're inside `batch()` or not
+- Passing them back as `({ tables, kv }) => { ... }` would falsely imply they're transactional versions with special behavior
+- The entire point is that `ydoc.transact()` makes ALL operations on the shared doc atomic — no wrapper needed
+
+## Implementation Plan
+
+- [x] 1. Add `batch()` to `WorkspaceClient` type in `static/types.ts`
+- [x] 2. Add `batch()` implementation in `create-workspace.ts` `buildClient()`
+- [x] 3. Write tests for `client.batch()` (see Test Plan below)
+- [x] 4. Remove `batch()` from `TableHelper` type and `TableBatchTransaction` type in `static/types.ts`
+- [x] 5. Remove `batch()` from `KvHelper` type and `KvBatchTransaction` type in `static/types.ts`
+- [x] 6. Remove `batch()` implementation from `static/table-helper.ts`
+- [x] 7. Remove `batch()` implementation from `static/create-kv.ts`
+- [x] 8. Update all call sites that use `table.batch()` or `kv.batch()` to use `client.batch()` (or `ydoc.transact()` where client isn't available — tests, benchmarks, low-level code)
+- [x] 9. Run tests and fix any breakage
+- [x] 10. Update benchmark test that compares batch vs individual insert
+
+## Test Plan
+
+Tests go in a new file: `static/create-workspace.test.ts`
+
+### Core behavior
+
+1. **`batch()` batches table operations** — multiple `set()` calls, observer fires once
+2. **`batch()` batches table deletes** — multiple `delete()` calls, observer fires once
+3. **`batch()` batches mixed set + delete** — observer fires once with all changed IDs
+4. **`batch()` works across multiple tables** — set on table A + table B, both observers fire once each
+5. **`batch()` works across tables and KV** — set on table + KV, both observers fire once each
+6. **`batch()` with no operations is a no-op** — no observer fires
+7. **Nested `batch()` calls work** — inner batch is absorbed by outer (Yjs transact is reentrant)
+
+### Observer semantics
+
+8. **Without `batch()`, each `set()` fires observer separately** — baseline comparison showing N calls = N notifications
+9. **With `batch()`, N calls = 1 notification** — the whole point
+
+### Edge cases
+
+10. **Error inside `batch()` still applies prior operations** — Yjs transact doesn't roll back; verify this behavior is documented/expected
+
+## Files Changed
+
+| File                                                     | Change                                                                                                                                |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/epicenter/src/static/types.ts`                 | Add `batch` to `WorkspaceClient`; remove `batch` from `TableHelper`, `KvHelper`; remove `TableBatchTransaction`, `KvBatchTransaction` |
+| `packages/epicenter/src/static/create-workspace.ts`      | Add `batch()` implementation                                                                                                          |
+| `packages/epicenter/src/static/table-helper.ts`          | Remove `batch()` method                                                                                                               |
+| `packages/epicenter/src/static/create-kv.ts`             | Remove `batch()` method                                                                                                               |
+| `packages/epicenter/src/static/create-workspace.test.ts` | New test file                                                                                                                         |
+| `packages/epicenter/src/static/table-helper.test.ts`     | Update tests that use `helper.batch()`                                                                                                |
+| `packages/epicenter/src/static/benchmark.test.ts`        | Update batch benchmark to use workspace-level batch                                                                                   |
+| `packages/epicenter/src/ingest/reddit/index.ts`          | Update `batch()` call sites                                                                                                           |
+| External consumers (tab-manager background.ts etc.)      | Replace `ydoc.transact()` / `table.batch()` with `client.batch()`                                                                     |
+
+## Non-Goals
+
+- No changes to the **dynamic** table API (`packages/epicenter/src/dynamic/`). That's a separate system with its own `batch()` / `upsertMany()` / `deleteMany()`. It can be aligned later if desired.
+- No changes to the low-level `YKeyValue` or `YKeyValueLww` classes — they keep their internal `transact()` calls for their own atomicity guarantees.
+
+## Review
+
+Implemented in 4 atomic commits:
+
+1. **`feat(static): add batch() to WorkspaceClient`** — Added `batch(fn: () => void): void` to the `WorkspaceClient` type and implementation. The method wraps `ydoc.transact(fn)` directly. Detailed JSDoc explains semantics (no rollback, reentrant nesting, no tx object needed).
+
+2. **`test(static): add workspace-level batch tests`** — New `create-workspace.test.ts` with all 10 test cases from the test plan. All pass. Key tests: observer fires once for batched ops, cross-table+KV atomicity, nested batch absorption, error-doesn't-rollback behavior.
+
+3. **`refactor: migrate batch call sites`** — Updated 5 files:
+   - `tab-manager/background.ts`: 3× `ydoc.transact()` → `client.batch()`, removed `ydoc` destructuring (now uses `client.ydoc` for the remaining debug listener)
+   - `tab-manager/saved-tab-state.svelte.ts`: 2× `popupWorkspace.ydoc.transact()` → `popupWorkspace.batch()`
+   - `ingest/reddit/index.ts`: Refactored `importTableRows` to accept `{ set }` instead of `{ batch }`, wrapped entire import (all tables + KV) in a single `workspace.batch()` call
+   - `table-helper.test.ts`: 12× `helper.batch((tx) => ...)` → `ydoc.transact(() => ...)` with direct `helper.set()`/`helper.delete()` calls
+   - `benchmark.test.ts`: 1× `tables.batch((tx) => ...)` → `ydoc.transact(() => ...)`
+
+4. **`refactor(static): remove per-table and per-kv batch()`** — Removed `TableBatchTransaction`, `KvBatchTransaction` types, `batch()` from `TableHelper`/`KvHelper` types and implementations, cleaned up re-exports from `index.ts`.
+
+128 tests pass across 9 test files. No type errors. Dynamic API batch left untouched per spec.


### PR DESCRIPTION
This PR consolidates batch operations from scattered per-table and per-KV helpers into a single workspace-level `client.batch()` method. The motivation is simplicity: users shouldn't need to think about which helper owns the batch operation. Instead, all table and KV operations automatically participate in the transaction without requiring a transaction object to be passed around.

We chose a bare callback over a transaction object because Yjs `transact()` makes all doc operations atomic automatically — there's nothing a tx object would add.

## API Migration

The old API required passing a transaction object to each batch operation:

```typescript
// OLD: per-table batch with transaction object
await client.tables.posts.batch((tx) => {
  tx.set(postId, { title: 'Hello' });
  tx.delete(otherId);
});

// OLD: per-KV batch with transaction object
await client.kv.settings.batch((tx) => {
  tx.set('theme', 'dark');
  tx.delete('oldKey');
});
```

The new API is simpler — tables and KV work the same inside or outside a batch:

```typescript
// NEW: workspace-level batch, no transaction object
await client.batch(() => {
  client.tables.posts.set(postId, { title: 'Hello' });
  client.tables.posts.delete(otherId);
  client.kv.settings.set('theme', 'dark');
  client.kv.settings.delete('oldKey');
});
```

Notice that inside the batch callback, you use the exact same API as outside — no special transaction object, no cognitive overhead of "which helper do I call this on?"

## Architecture

`client.batch()` wraps `ydoc.transact()` at the workspace level. Yjs makes all operations on the shared doc atomic automatically, so there's no need for a transaction object to coordinate them:

```
┌──────────────────────────────────────────────────────────────┐
│  client.batch(fn)                                            │
│    ↓                                                          │
│  ydoc.transact(fn)  ← Yjs makes all doc ops atomic           │
│    ↓                                                          │
│  Inside fn:                                                  │
│    • client.tables.posts.set()  ──→ updates Y.Map            │
│    • client.tables.posts.delete()  ──→ updates Y.Map         │
│    • client.kv.settings.set()  ──→ updates Y.Map             │
│    ↓                                                          │
│  Transaction ends → all observers fire once                  │
└──────────────────────────────────────────────────────────────┘
```

All table and KV operations work identically inside or outside a batch. The only difference is that inside a batch, Yjs defers observer notifications until the transaction ends, coalescing multiple changes into a single update.

## Known Limitation

There's one edge case worth documenting: deleting a pre-existing key inside a batch and then reading it back returns stale data.

```typescript
await client.batch(() => {
  client.tables.posts.delete(postId);
  const post = client.tables.posts.get(postId);  // ← returns stale data
});
```

This happens because the YKeyValue read cache updates via observer, which is deferred until the transaction ends. The delete removes the key from the underlying Y.Map, but the in-memory cache doesn't update until the observer fires after the transaction completes. This is fixable at the YKeyValue layer by adding a `pendingDeletes` set (symmetric to the existing `pending` map for writes), but that's tracked separately.

## Test Coverage

All call sites across `tab-manager`, `reddit-ingest`, and static tests have been migrated to the new API. The old `TableBatchTransaction` and `KvBatchTransaction` types and their corresponding per-helper `batch()` methods have been removed entirely. Test coverage is comprehensive: 10 new workspace-level batch tests cover single-table operations, cross-table operations, cross-table+KV operations, nested batches, error behavior, and observer coalescing. All 128 tests pass with 0 type errors.