### PR TITLE
fix(server): scope action routes per workspace instead of global mount

### DIFF
--- a/packages/server/src/actions.test.ts
+++ b/packages/server/src/actions.test.ts
@@ -3,9 +3,6 @@ import { defineMutation, defineQuery } from '@epicenter/hq';
 import { type } from 'arktype';
 import { collectActionPaths, createActionsRouter } from './actions';
 
-// Mock client for closure-based actions
-const mockClient = { id: 'test' };
-
 describe('createActionsRouter', () => {
 	test('creates routes for flat actions', async () => {
 		const actions = {
@@ -14,7 +11,7 @@ describe('createActionsRouter', () => {
 			}),
 		};
 
-		const app = createActionsRouter({ client: mockClient, actions });
+		const app = createActionsRouter({ actions });
 		const response = await app.handle(new Request('http://test/actions/ping'));
 		const body = await response.json();
 
@@ -31,7 +28,7 @@ describe('createActionsRouter', () => {
 			},
 		};
 
-		const app = createActionsRouter({ client: mockClient, actions });
+		const app = createActionsRouter({ actions });
 		const response = await app.handle(
 			new Request('http://test/actions/posts/list'),
 		);
@@ -48,7 +45,7 @@ describe('createActionsRouter', () => {
 			}),
 		};
 
-		const app = createActionsRouter({ client: mockClient, actions });
+		const app = createActionsRouter({ actions });
 		const response = await app.handle(
 			new Request('http://test/actions/getStatus', { method: 'GET' }),
 		);
@@ -67,7 +64,7 @@ describe('createActionsRouter', () => {
 			}),
 		};
 
-		const app = createActionsRouter({ client: mockClient, actions });
+		const app = createActionsRouter({ actions });
 		const response = await app.handle(
 			new Request('http://test/actions/doSomething', { method: 'POST' }),
 		);
@@ -90,7 +87,7 @@ describe('createActionsRouter', () => {
 			}),
 		};
 
-		const app = createActionsRouter({ client: mockClient, actions });
+		const app = createActionsRouter({ actions });
 		const response = await app.handle(
 			new Request('http://test/actions/create', {
 				method: 'POST',
@@ -113,7 +110,7 @@ describe('createActionsRouter', () => {
 			}),
 		};
 
-		const app = createActionsRouter({ client: mockClient, actions });
+		const app = createActionsRouter({ actions });
 		const response = await app.handle(
 			new Request('http://test/actions/create', {
 				method: 'POST',
@@ -135,7 +132,7 @@ describe('createActionsRouter', () => {
 			}),
 		};
 
-		const app = createActionsRouter({ client: mockClient, actions });
+		const app = createActionsRouter({ actions });
 		const response = await app.handle(
 			new Request('http://test/actions/asyncQuery'),
 		);
@@ -153,7 +150,6 @@ describe('createActionsRouter', () => {
 		};
 
 		const app = createActionsRouter({
-			client: mockClient,
 			actions,
 			basePath: '/api',
 		});
@@ -177,7 +173,7 @@ describe('createActionsRouter', () => {
 			},
 		};
 
-		const app = createActionsRouter({ client: mockClient, actions });
+		const app = createActionsRouter({ actions });
 		const response = await app.handle(
 			new Request('http://test/actions/api/v1/users/list'),
 		);

--- a/packages/server/src/actions.ts
+++ b/packages/server/src/actions.ts
@@ -3,7 +3,6 @@ import { iterateActions } from '@epicenter/hq';
 import { Elysia } from 'elysia';
 
 type ActionsRouterOptions = {
-	client: unknown;
 	actions: Actions;
 	basePath?: string;
 };


### PR DESCRIPTION
The server was only reading actions from the first workspace client and mounting them at a global `/actions/` path. With multiple workspaces, every workspace's actions would collide under the same route prefix — only the first client's actions were ever reachable.

This scopes action routes per workspace under `/workspaces/{id}/actions/`, matching how tables and sync are already mounted. Each client's actions get their own Elysia router instance with the correct base path. The root `/` endpoint now lists all action paths prefixed with their workspace ID so you can see what's available across all workspaces. The startup log also groups actions under each workspace alongside its tables and sync endpoint, instead of dumping them in a separate global section.

The `client` field on `ActionsRouterOptions` was never actually used inside `createActionsRouter` — the router only needs the actions and a base path — so it's been removed. Tests updated accordingly.

## Verification

- [x] All 13 action router tests pass (`bun test packages/server/src/actions.test.ts`)