### PR TITLE
refactor: rename StandardSchemaWithJSONSchema to CombinedStandardSchema

### DIFF
--- a/packages/epicenter/src/dynamic/schema/index.ts
+++ b/packages/epicenter/src/dynamic/schema/index.ts
@@ -2,9 +2,9 @@ export type { Guid } from '../../shared/id.js';
 export { generateGuid, generateId, Id } from '../../shared/id.js';
 export { standardSchemaToJsonSchema } from '../../shared/standard-schema/to-json-schema.js';
 export type {
+	CombinedStandardSchema,
 	StandardJSONSchemaV1,
 	StandardSchemaV1,
-	StandardSchemaWithJSONSchema,
 	StandardTypedV1,
 } from '../../shared/standard-schema/types.js';
 export type { FieldToArktype } from './converters/to-arktype.js';

--- a/packages/epicenter/src/shared/actions.ts
+++ b/packages/epicenter/src/shared/actions.ts
@@ -63,8 +63,8 @@
  */
 
 import type {
+	CombinedStandardSchema,
 	StandardSchemaV1,
-	StandardSchemaWithJSONSchema,
 } from '../shared/standard-schema/types';
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -79,14 +79,14 @@ import type {
  * `any` distributes over both branches giving `[input: any] | []` — which
  * correctly allows calling with 0 arguments for no-input actions.
  *
- * When `TInput` extends `StandardSchemaWithJSONSchema`, the handler takes validated input.
+ * When `TInput` extends `CombinedStandardSchema`, the handler takes validated input.
  * When `TInput` is `undefined`, the handler takes no arguments.
  */
 type ActionHandler<
-	TInput extends StandardSchemaWithJSONSchema | undefined = undefined,
+	TInput extends CombinedStandardSchema | undefined = undefined,
 	TOutput = unknown,
 > = (
-	...args: TInput extends StandardSchemaWithJSONSchema
+	...args: TInput extends CombinedStandardSchema
 		? [input: StandardSchemaV1.InferOutput<TInput>]
 		: []
 ) => TOutput | Promise<TOutput>;
@@ -128,7 +128,7 @@ type ActionHandler<
  * ```
  */
 type ActionConfig<
-	TInput extends StandardSchemaWithJSONSchema | undefined = undefined,
+	TInput extends CombinedStandardSchema | undefined = undefined,
 	TOutput = unknown,
 > = {
 	description?: string;
@@ -143,13 +143,12 @@ type ActionConfig<
  * (via `Object.assign`). The handler is NOT included — the action function IS
  * the handler. Call the action directly instead of accessing `.handler`.
  */
-type ActionMeta<
-	TInput extends StandardSchemaWithJSONSchema | undefined = undefined,
-> = {
-	type: 'query' | 'mutation';
-	description?: string;
-	input?: TInput;
-};
+type ActionMeta<TInput extends CombinedStandardSchema | undefined = undefined> =
+	{
+		type: 'query' | 'mutation';
+		description?: string;
+		input?: TInput;
+	};
 
 /**
  * A query action definition (read operation).
@@ -172,7 +171,7 @@ type ActionMeta<
  * @see {@link defineQuery} for creating query definitions
  */
 export type Query<
-	TInput extends StandardSchemaWithJSONSchema | undefined = undefined,
+	TInput extends CombinedStandardSchema | undefined = undefined,
 	TOutput = unknown,
 > = ActionHandler<TInput, TOutput> & ActionMeta<TInput> & { type: 'query' };
 
@@ -199,7 +198,7 @@ export type Query<
  * @see {@link defineMutation} for creating mutation definitions
  */
 export type Mutation<
-	TInput extends StandardSchemaWithJSONSchema | undefined = undefined,
+	TInput extends CombinedStandardSchema | undefined = undefined,
 	TOutput = unknown,
 > = ActionHandler<TInput, TOutput> & ActionMeta<TInput> & { type: 'mutation' };
 
@@ -212,7 +211,7 @@ export type Mutation<
  * @typeParam TOutput - The return type of the handler
  */
 export type Action<
-	TInput extends StandardSchemaWithJSONSchema | undefined = undefined,
+	TInput extends CombinedStandardSchema | undefined = undefined,
 	TOutput = unknown,
 > = Query<TInput, TOutput> | Mutation<TInput, TOutput>;
 
@@ -283,7 +282,7 @@ export function defineQuery<TOutput = unknown>(
 ): Query<undefined, TOutput>;
 /** With input — `TInput` inferred from the schema. */
 export function defineQuery<
-	TInput extends StandardSchemaWithJSONSchema,
+	TInput extends CombinedStandardSchema,
 	TOutput = unknown,
 >(config: ActionConfig<TInput, TOutput>): Query<TInput, TOutput>;
 export function defineQuery({
@@ -333,7 +332,7 @@ export function defineMutation<TOutput = unknown>(
 ): Mutation<undefined, TOutput>;
 /** With input — `TInput` inferred from the schema. */
 export function defineMutation<
-	TInput extends StandardSchemaWithJSONSchema,
+	TInput extends CombinedStandardSchema,
 	TOutput = unknown,
 >(config: ActionConfig<TInput, TOutput>): Mutation<TInput, TOutput>;
 export function defineMutation({

--- a/packages/epicenter/src/shared/standard-schema/index.ts
+++ b/packages/epicenter/src/shared/standard-schema/index.ts
@@ -2,8 +2,8 @@ export { ARKTYPE_JSON_SCHEMA_FALLBACK } from './arktype-fallback.js';
 
 export { standardSchemaToJsonSchema } from './to-json-schema.js';
 export type {
+	CombinedStandardSchema,
 	StandardJSONSchemaV1,
 	StandardSchemaV1,
-	StandardSchemaWithJSONSchema,
 	StandardTypedV1,
 } from './types.js';

--- a/packages/epicenter/src/shared/standard-schema/types.ts
+++ b/packages/epicenter/src/shared/standard-schema/types.ts
@@ -209,14 +209,14 @@ export declare namespace StandardJSONSchemaV1 {
  * ```typescript
  * // ArkType
  * import { type } from 'arktype';
- * type('string') satisfies StandardSchemaWithJSONSchema; // ✅
+ * type('string') satisfies CombinedStandardSchema; // ✅
  *
  * // Zod (v4.2+)
  * import * as z from 'zod';
- * z.string() satisfies StandardSchemaWithJSONSchema; // ✅
+ * z.string() satisfies CombinedStandardSchema; // ✅
  * ```
  */
-export type StandardSchemaWithJSONSchema<TInput = unknown, TOutput = TInput> = {
+export type CombinedStandardSchema<TInput = unknown, TOutput = TInput> = {
 	'~standard': StandardSchemaV1.Props<TInput, TOutput> &
 		StandardJSONSchemaV1.Props<TInput, TOutput>;
 };

--- a/packages/epicenter/src/static/create-kv.ts
+++ b/packages/epicenter/src/static/create-kv.ts
@@ -28,7 +28,7 @@
  */
 
 import type * as Y from 'yjs';
-import type { StandardSchemaWithJSONSchema } from '../shared/standard-schema/types.js';
+import type { CombinedStandardSchema } from '../shared/standard-schema/types.js';
 import {
 	YKeyValueLww,
 	type YKeyValueLwwChange,
@@ -66,7 +66,7 @@ export function createKv<TKvDefinitions extends KvDefinitions>(
 	 */
 	function parseValue<TValue>(
 		raw: unknown,
-		definition: KvDefinition<readonly StandardSchemaWithJSONSchema[]>,
+		definition: KvDefinition<readonly CombinedStandardSchema[]>,
 	): KvGetResult<TValue> {
 		const result = definition.schema['~standard'].validate(raw);
 		if (result instanceof Promise)

--- a/packages/epicenter/src/static/define-kv.ts
+++ b/packages/epicenter/src/static/define-kv.ts
@@ -44,8 +44,8 @@
  */
 
 import type {
+	CombinedStandardSchema,
 	StandardSchemaV1,
-	StandardSchemaWithJSONSchema,
 } from '../shared/standard-schema/types.js';
 import { createUnionSchema } from './schema-union.js';
 import type { KvDefinition, LastSchema } from './types.js';
@@ -55,12 +55,12 @@ import type { KvDefinition, LastSchema } from './types.js';
  *
  * @typeParam TVersions - Tuple of schema types added via .version() (single source of truth)
  */
-type KvBuilder<TVersions extends StandardSchemaWithJSONSchema[]> = {
+type KvBuilder<TVersions extends CombinedStandardSchema[]> = {
 	/**
 	 * Add a schema version.
 	 * The last version added becomes the "latest" schema shape.
 	 */
-	version<TSchema extends StandardSchemaWithJSONSchema>(
+	version<TSchema extends CombinedStandardSchema>(
 		schema: TSchema,
 	): KvBuilder<[...TVersions, TSchema]>;
 
@@ -87,7 +87,7 @@ type KvBuilder<TVersions extends StandardSchemaWithJSONSchema[]> = {
  * const sidebar = defineKv(type({ collapsed: 'boolean', width: 'number' }));
  * ```
  */
-export function defineKv<TSchema extends StandardSchemaWithJSONSchema>(
+export function defineKv<TSchema extends CombinedStandardSchema>(
 	schema: TSchema,
 ): KvDefinition<[TSchema]>;
 
@@ -130,7 +130,7 @@ export function defineKv<TSchema extends StandardSchemaWithJSONSchema>(
  */
 export function defineKv(): KvBuilder<[]>;
 
-export function defineKv<TSchema extends StandardSchemaWithJSONSchema>(
+export function defineKv<TSchema extends CombinedStandardSchema>(
 	schema?: TSchema,
 ): KvDefinition<[TSchema]> | KvBuilder<[]> {
 	if (schema) {
@@ -140,10 +140,10 @@ export function defineKv<TSchema extends StandardSchemaWithJSONSchema>(
 		} as KvDefinition<[TSchema]>;
 	}
 
-	const versions: StandardSchemaWithJSONSchema[] = [];
+	const versions: CombinedStandardSchema[] = [];
 
 	const builder = {
-		version(versionSchema: StandardSchemaWithJSONSchema) {
+		version(versionSchema: CombinedStandardSchema) {
 			versions.push(versionSchema);
 			return builder;
 		},

--- a/packages/epicenter/src/static/describe-workspace.ts
+++ b/packages/epicenter/src/static/describe-workspace.ts
@@ -61,7 +61,7 @@ export type ActionDescriptor = {
  * A portable, JSON-serializable descriptor of a workspace.
  *
  * Every schema field is guaranteed to be a `JsonSchema` (never undefined) —
- * the `StandardSchemaWithJSONSchema` type constraint on definitions ensures this.
+ * the `CombinedStandardSchema` type constraint on definitions ensures this.
  * Action inputs are optional since some actions have no input.
  */
 export type WorkspaceDescriptor = {

--- a/packages/epicenter/src/static/schema-union.test.ts
+++ b/packages/epicenter/src/static/schema-union.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { type } from 'arktype';
-import type { StandardSchemaWithJSONSchema } from '../shared/standard-schema/types.js';
+import type { CombinedStandardSchema } from '../shared/standard-schema/types.js';
 import { createUnionSchema } from './schema-union.js';
 
 describe('createUnionSchema', () => {
@@ -51,7 +51,7 @@ describe('createUnionSchema', () => {
 					output: () => ({}),
 				},
 			},
-		} satisfies StandardSchemaWithJSONSchema;
+		} satisfies CombinedStandardSchema;
 
 		const union = createUnionSchema([asyncSchema]);
 

--- a/packages/epicenter/src/static/schema-union.ts
+++ b/packages/epicenter/src/static/schema-union.ts
@@ -6,8 +6,8 @@
  */
 
 import type {
+	CombinedStandardSchema,
 	StandardSchemaV1,
-	StandardSchemaWithJSONSchema,
 } from '../shared/standard-schema/types.js';
 
 /**
@@ -36,7 +36,7 @@ import type {
  * ```
  */
 export function createUnionSchema<
-	const TSchemas extends readonly StandardSchemaWithJSONSchema[],
+	const TSchemas extends readonly CombinedStandardSchema[],
 >(schemas: TSchemas) {
 	return {
 		'~standard': {
@@ -80,7 +80,7 @@ export function createUnionSchema<
 				}),
 			},
 		},
-	} as const satisfies StandardSchemaWithJSONSchema<
+	} as const satisfies CombinedStandardSchema<
 		StandardSchemaV1.InferInput<TSchemas[number]>,
 		StandardSchemaV1.InferOutput<TSchemas[number]>
 	>;

--- a/packages/epicenter/src/static/table-helper.ts
+++ b/packages/epicenter/src/static/table-helper.ts
@@ -5,7 +5,7 @@
  */
 
 import type * as Y from 'yjs';
-import type { StandardSchemaWithJSONSchema } from '../shared/standard-schema/types.js';
+import type { CombinedStandardSchema } from '../shared/standard-schema/types.js';
 import type {
 	YKeyValueLww,
 	YKeyValueLwwChange,
@@ -25,7 +25,7 @@ import type {
  * Creates a TableHelper for a single table bound to a YKeyValue store.
  */
 export function createTableHelper<
-	TVersions extends readonly StandardSchemaWithJSONSchema<{ id: string }>[],
+	TVersions extends readonly CombinedStandardSchema<{ id: string }>[],
 >(
 	ykv: YKeyValueLww<unknown>,
 	definition: TableDefinition<TVersions>,

--- a/packages/epicenter/src/static/types.ts
+++ b/packages/epicenter/src/static/types.ts
@@ -9,8 +9,8 @@ import type * as Y from 'yjs';
 import type { Actions } from '../shared/actions.js';
 import type { Extension } from '../shared/lifecycle.js';
 import type {
+	CombinedStandardSchema,
 	StandardSchemaV1,
-	StandardSchemaWithJSONSchema,
 } from '../shared/standard-schema/types.js';
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -89,10 +89,10 @@ export type KvChange<TValue> =
 // ════════════════════════════════════════════════════════════════════════════
 
 /** Extract the last element from a tuple of schemas. */
-export type LastSchema<T extends readonly StandardSchemaWithJSONSchema[]> =
+export type LastSchema<T extends readonly CombinedStandardSchema[]> =
 	T extends readonly [
-		...StandardSchemaWithJSONSchema[],
-		infer L extends StandardSchemaWithJSONSchema,
+		...CombinedStandardSchema[],
+		infer L extends CombinedStandardSchema,
 	]
 		? L
 		: T[number];
@@ -103,9 +103,9 @@ export type LastSchema<T extends readonly StandardSchemaWithJSONSchema[]> =
  * @typeParam TVersions - Tuple of schema versions (each must include `{ id: string }`)
  */
 export type TableDefinition<
-	TVersions extends readonly StandardSchemaWithJSONSchema<{ id: string }>[],
+	TVersions extends readonly CombinedStandardSchema<{ id: string }>[],
 > = {
-	schema: StandardSchemaWithJSONSchema<
+	schema: CombinedStandardSchema<
 		unknown,
 		StandardSchemaV1.InferOutput<TVersions[number]>
 	>;
@@ -135,17 +135,16 @@ export type InferTableVersionUnion<T> =
  *
  * @typeParam TVersions - Tuple of schema versions
  */
-export type KvDefinition<
-	TVersions extends readonly StandardSchemaWithJSONSchema[],
-> = {
-	schema: StandardSchemaWithJSONSchema<
-		unknown,
-		StandardSchemaV1.InferOutput<TVersions[number]>
-	>;
-	migrate: (
-		value: StandardSchemaV1.InferOutput<TVersions[number]>,
-	) => StandardSchemaV1.InferOutput<LastSchema<TVersions>>;
-};
+export type KvDefinition<TVersions extends readonly CombinedStandardSchema[]> =
+	{
+		schema: CombinedStandardSchema<
+			unknown,
+			StandardSchemaV1.InferOutput<TVersions[number]>
+		>;
+		migrate: (
+			value: StandardSchemaV1.InferOutput<TVersions[number]>,
+		) => StandardSchemaV1.InferOutput<LastSchema<TVersions>>;
+	};
 
 /** Extract the value type from a KvDefinition */
 export type InferKvValue<T> =
@@ -361,8 +360,8 @@ export type TableHelper<TRow extends { id: string }> = {
 // AWARENESS TYPES
 // ════════════════════════════════════════════════════════════════════════════
 
-/** Map of awareness field definitions. Each field has its own StandardSchemaWithJSONSchema schema. */
-export type AwarenessDefinitions = Record<string, StandardSchemaWithJSONSchema>;
+/** Map of awareness field definitions. Each field has its own CombinedStandardSchema schema. */
+export type AwarenessDefinitions = Record<string, CombinedStandardSchema>;
 
 /** Extract the output type of an awareness field's schema. */
 export type InferAwarenessValue<T> = T extends StandardSchemaV1

--- a/specs/20250103T002300-schema-naming-and-provider-context-refactor.md
+++ b/specs/20250103T002300-schema-naming-and-provider-context-refactor.md
@@ -25,7 +25,7 @@ Refactor the schema type system and `ProviderContext` to:
 3. **Ambiguous `TSchema` generic**: Used for three different things:
    - `WorkspaceSchema` (all tables)
    - `TableSchema` (single table)
-   - `StandardSchemaWithJSONSchema` (JSON field validation)
+   - `CombinedStandardSchema` (JSON field validation)
 
 4. **No KV in providers**: KV storage exists but isn't passed to providers.
 

--- a/specs/20250107T123500-minimal-field-schema-refactor.md
+++ b/specs/20250107T123500-minimal-field-schema-refactor.md
@@ -3,7 +3,7 @@
 **Created**: 2025-01-07T12:35:00
 **Status**: Complete
 
-> **Note (2026-01-08)**: The `json()` field API in this spec uses `StandardSchemaWithJSONSchema` (arktype/zod). This has been superseded by TypeBox. See `20260108T133200-collaborative-workspace-config-ydoc-handoff.md` Phase 4 for the current API using `Type.Object()` from TypeBox.
+> **Note (2026-01-08)**: The `json()` field API in this spec uses `CombinedStandardSchema` (arktype/zod). This has been superseded by TypeBox. See `20260108T133200-collaborative-workspace-config-ydoc-handoff.md` Phase 4 for the current API using `Type.Object()` from TypeBox.
 
 ## Summary
 
@@ -61,7 +61,7 @@ type FieldDefinition =
 	  }
 	| {
 			type: 'json';
-			schema: StandardSchemaWithJSONSchema;
+			schema: CombinedStandardSchema;
 			nullable?: boolean;
 			default?: unknown;
 	  };
@@ -138,7 +138,7 @@ export type TagsFieldSchema<
 };
 
 export type JsonFieldSchema<
-	TSchema extends StandardSchemaWithJSONSchema = StandardSchemaWithJSONSchema,
+	TSchema extends CombinedStandardSchema = CombinedStandardSchema,
 	TNullable extends boolean = boolean,
 > = {
 	type: 'json';
@@ -332,7 +332,7 @@ export function tags<
 	};
 }
 
-export function json<const TSchema extends StandardSchemaWithJSONSchema>(opts: {
+export function json<const TSchema extends CombinedStandardSchema>(opts: {
 	schema: TSchema;
 	nullable?: boolean;
 	default?: StandardSchemaV1.InferOutput<TSchema>;

--- a/specs/20250203T150000-closure-based-actions.md
+++ b/specs/20250203T150000-closure-based-actions.md
@@ -90,26 +90,26 @@ const actions = {
 ```typescript
 // BEFORE: Handler receives ctx
 type ActionConfig<
-  TInput extends StandardSchemaWithJSONSchema | undefined = undefined,
+  TInput extends CombinedStandardSchema | undefined = undefined,
   TOutput = unknown,
 > = {
   description?: string;
   input?: TInput;
-  output?: StandardSchemaWithJSONSchema;
-  handler: TInput extends StandardSchemaWithJSONSchema
+  output?: CombinedStandardSchema;
+  handler: TInput extends CombinedStandardSchema
     ? (ctx: unknown, input: StandardSchemaV1.InferOutput<TInput>) => TOutput | Promise<TOutput>
     : (ctx: unknown) => TOutput | Promise<TOutput>;
 };
 
 // AFTER: Handler just receives input (or nothing)
 type ActionConfig<
-  TInput extends StandardSchemaWithJSONSchema | undefined = undefined,
+  TInput extends CombinedStandardSchema | undefined = undefined,
   TOutput = unknown,
 > = {
   description?: string;
   input?: TInput;
-  output?: StandardSchemaWithJSONSchema;
-  handler: TInput extends StandardSchemaWithJSONSchema
+  output?: CombinedStandardSchema;
+  handler: TInput extends CombinedStandardSchema
     ? (input: StandardSchemaV1.InferOutput<TInput>) => TOutput | Promise<TOutput>
     : () => TOutput | Promise<TOutput>;
 };

--- a/specs/20251231T153000-static-defaults-constraint.md
+++ b/specs/20251231T153000-static-defaults-constraint.md
@@ -63,7 +63,7 @@ tables.posts.upsert({
 
 ### What Changed
 
-`JsonColumnSchema` now uses `StandardSchemaWithJSONSchema` instead of arktype's `Type`:
+`JsonColumnSchema` now uses `CombinedStandardSchema` instead of arktype's `Type`:
 
 ```typescript
 // Before (arktype-specific)
@@ -73,7 +73,7 @@ type JsonColumnSchema<TSchema extends Type> = {
 };
 
 // After (any Standard Schema library)
-type JsonColumnSchema<TSchema extends StandardSchemaWithJSONSchema> = {
+type JsonColumnSchema<TSchema extends CombinedStandardSchema> = {
 	schema: TSchema;
 	// ...
 };
@@ -83,12 +83,12 @@ type JsonColumnSchema<TSchema extends StandardSchemaWithJSONSchema> = {
 
 Allows using Zod, Valibot, or any Standard Schema-compliant library for JSON column validation, not just arktype.
 
-### StandardSchemaWithJSONSchema
+### CombinedStandardSchema
 
 A schema that implements both validation and JSON Schema conversion:
 
 ```typescript
-type StandardSchemaWithJSONSchema = {
+type CombinedStandardSchema = {
 	'~standard': StandardSchemaV1.Props & StandardJSONSchemaV1.Props;
 };
 ```
@@ -114,7 +114,7 @@ Contains:
 - `StandardTypedV1` — Base type
 - `StandardSchemaV1` — Validation interface
 - `StandardJSONSchemaV1` — JSON Schema conversion interface
-- `StandardSchemaWithJSONSchema` — Combined type (our extension)
+- `CombinedStandardSchema` — Combined type (our extension)
 
 ### Why
 

--- a/specs/20251231T160000-json-column-standard-schema.md
+++ b/specs/20251231T160000-json-column-standard-schema.md
@@ -23,11 +23,11 @@ This couples the schema system to ArkType. We want library-agnostic schemas that
 
 ## Solution
 
-Change `JsonColumnSchema` to use `StandardSchemaWithJSONSchema` (combined interface that provides both validation and JSON Schema generation):
+Change `JsonColumnSchema` to use `CombinedStandardSchema` (combined interface that provides both validation and JSON Schema generation):
 
 ```typescript
 export type JsonColumnSchema<
-	TSchema extends StandardSchemaWithJSONSchema = StandardSchemaWithJSONSchema,
+	TSchema extends CombinedStandardSchema = CombinedStandardSchema,
 	TNullable extends boolean = boolean,
 > = {
 	type: 'json';
@@ -41,13 +41,13 @@ export type JsonColumnSchema<
 
 ### 1. Create shared type (schema/standard-schema.ts)
 
-- [ ] Move `StandardSchemaWithJSONSchema` from `actions.ts` to schema module
+- [ ] Move `CombinedStandardSchema` from `actions.ts` to schema module
 - [ ] Export from schema index
 
 ### 2. Update types.ts
 
-- [ ] Import `StandardSchemaWithJSONSchema` and `StandardSchemaV1`
-- [ ] Change `TSchema extends Type` to `TSchema extends StandardSchemaWithJSONSchema`
+- [ ] Import `CombinedStandardSchema` and `StandardSchemaV1`
+- [ ] Change `TSchema extends Type` to `TSchema extends CombinedStandardSchema`
 - [ ] Change `TSchema['infer']` to `StandardSchemaV1.InferOutput<TSchema>`
 
 ### 3. Update columns.ts
@@ -64,13 +64,13 @@ export type JsonColumnSchema<
 ### 5. Validation pattern
 
 - [ ] `arktype.ts` line 179: `columnSchema.schema` is used as arktype Type directly
-  - This still works because ArkType's Type satisfies StandardSchemaWithJSONSchema
+  - This still works because ArkType's Type satisfies CombinedStandardSchema
   - The validation uses it as a callable, which is ArkType-specific
   - For now, keep using the schema directly since ArkType is the implementation
 
 ## Success Criteria
 
-- [ ] `JsonColumnSchema` accepts any `StandardSchemaWithJSONSchema` compliant schema
+- [ ] `JsonColumnSchema` accepts any `CombinedStandardSchema` compliant schema
 - [ ] Type inference works via `StandardSchemaV1.InferOutput`
 - [ ] Existing ArkType usage continues to work (ArkType implements the spec)
 - [ ] TypeScript compiles without errors

--- a/specs/20260107T194104-action-system-redesign.md
+++ b/specs/20260107T194104-action-system-redesign.md
@@ -109,13 +109,13 @@ const cli = createCLI(client, { actions });
 ### Action Types
 
 ````typescript
-import type { StandardSchemaV1, StandardSchemaWithJSONSchema } from './schema';
+import type { StandardSchemaV1, CombinedStandardSchema } from './schema';
 
 /**
  * Base configuration shared by queries and mutations.
  */
 type ActionConfig<
-	TInput extends StandardSchemaWithJSONSchema | undefined = undefined,
+	TInput extends CombinedStandardSchema | undefined = undefined,
 	TOutput = unknown,
 > = {
 	/** Human-readable description for docs and MCP tool descriptions */
@@ -125,10 +125,10 @@ type ActionConfig<
 	input?: TInput;
 
 	/** Output schema for documentation (optional, can be inferred) */
-	output?: StandardSchemaWithJSONSchema;
+	output?: CombinedStandardSchema;
 
 	/** The handler function. Receives validated input if `input` is defined. */
-	handler: TInput extends StandardSchemaWithJSONSchema
+	handler: TInput extends CombinedStandardSchema
 		? (
 				input: StandardSchemaV1.InferOutput<TInput>,
 			) => TOutput | Promise<TOutput>
@@ -145,7 +145,7 @@ type ActionConfig<
  * - OpenAPI documentation
  */
 export type Query<
-	TInput extends StandardSchemaWithJSONSchema | undefined = undefined,
+	TInput extends CombinedStandardSchema | undefined = undefined,
 	TOutput = unknown,
 > = ActionConfig<TInput, TOutput> & {
 	/** Discriminator for runtime type checking */
@@ -162,7 +162,7 @@ export type Query<
  * - OpenAPI documentation
  */
 export type Mutation<
-	TInput extends StandardSchemaWithJSONSchema | undefined = undefined,
+	TInput extends CombinedStandardSchema | undefined = undefined,
 	TOutput = unknown,
 > = ActionConfig<TInput, TOutput> & {
 	/** Discriminator for runtime type checking */
@@ -171,7 +171,7 @@ export type Mutation<
 
 /** Union type for any action (query or mutation) */
 export type Action<
-	TInput extends StandardSchemaWithJSONSchema | undefined = undefined,
+	TInput extends CombinedStandardSchema | undefined = undefined,
 	TOutput = unknown,
 > = Query<TInput, TOutput> | Mutation<TInput, TOutput>;
 
@@ -226,7 +226,7 @@ export type Actions = {
  * ```
  */
 export function defineQuery<
-	TInput extends StandardSchemaWithJSONSchema | undefined = undefined,
+	TInput extends CombinedStandardSchema | undefined = undefined,
 	TOutput = unknown,
 >(config: Omit<Query<TInput, TOutput>, 'type'>): Query<TInput, TOutput> {
 	return { type: 'query', ...config };
@@ -256,7 +256,7 @@ export function defineQuery<
  * ```
  */
 export function defineMutation<
-	TInput extends StandardSchemaWithJSONSchema | undefined = undefined,
+	TInput extends CombinedStandardSchema | undefined = undefined,
 	TOutput = unknown,
 >(config: Omit<Mutation<TInput, TOutput>, 'type'>): Mutation<TInput, TOutput> {
 	return { type: 'mutation', ...config };
@@ -369,7 +369,7 @@ The old system made actions callable (`action(input)`). The new system uses plai
 3. **No confusion**: Actions are data describing behavior, not the behavior itself
 4. **Adapters invoke**: The server/CLI adapter calls `action.handler(input)`, not user code
 
-### Why `StandardSchemaWithJSONSchema` for Input?
+### Why `CombinedStandardSchema` for Input?
 
 Input schemas must support JSON Schema generation for:
 
@@ -377,7 +377,7 @@ Input schemas must support JSON Schema generation for:
 - OpenAPI request body schemas
 - CLI flag generation
 
-`StandardSchemaWithJSONSchema` ensures the schema can be converted to JSON Schema. ArkType and Zod (v4.2+) both satisfy this constraint.
+`CombinedStandardSchema` ensures the schema can be converted to JSON Schema. ArkType and Zod (v4.2+) both satisfy this constraint.
 
 ### Why Output is Optional?
 

--- a/specs/20260203T000000-action-system-v2-context-passing.md
+++ b/specs/20260203T000000-action-system-v2-context-passing.md
@@ -141,13 +141,13 @@ const cli = createCLI(client, { actions: customActions });
 
 ```typescript
 type ActionConfig<
-	TInput extends StandardSchemaWithJSONSchema | undefined = undefined,
+	TInput extends CombinedStandardSchema | undefined = undefined,
 	TOutput = unknown,
 > = {
 	description?: string;
 	input?: TInput;
-	output?: StandardSchemaWithJSONSchema;
-	handler: TInput extends StandardSchemaWithJSONSchema
+	output?: CombinedStandardSchema;
+	handler: TInput extends CombinedStandardSchema
 		? (
 				ctx: WorkspaceClient,
 				input: InferOutput<TInput>,
@@ -196,8 +196,8 @@ After `.withActions()`, actions are "attached" - calling them executes the handl
 type AttachedAction<TInput, TOutput> = {
 	type: 'query' | 'mutation';
 	description?: string;
-	input?: StandardSchemaWithJSONSchema;
-	output?: StandardSchemaWithJSONSchema;
+	input?: CombinedStandardSchema;
+	output?: CombinedStandardSchema;
 	/** Executes the handler with the attached client context */
 	(input?: TInput): TOutput | Promise<TOutput>;
 };


### PR DESCRIPTION
The old name `StandardSchemaWithJSONSchema` was overly verbose and didn't clearly communicate that the type combines Standard Schema with JSON Schema metadata. This PR renames it to `CombinedStandardSchema` across the entire codebase (89 occurrences in 19 files) for better clarity and conciseness.

The rename is purely mechanical—zero logic changes. All TypeScript source files (12) and spec markdown files (7) have been updated. The rename is complete: `grep -r "StandardSchemaWithJSONSchema"` returns 0 matches, and `tsc --noEmit` passes with no new errors.