### PR TITLE
refactor(static): use @standard-schema/spec from catalog instead of local type copies

### DIFF
--- a/apps/whispering/package.json
+++ b/apps/whispering/package.json
@@ -53,7 +53,7 @@
 		"@google/generative-ai": "^0.24.1",
 		"@mistralai/mistralai": "^1.9.18",
 		"@ricky0123/vad-web": "^0.0.24",
-		"@standard-schema/spec": "^1.0.0",
+		"@standard-schema/spec": "catalog:",
 		"@tanstack/svelte-query": "catalog:",
 		"@tanstack/svelte-query-devtools": "catalog:",
 		"@tanstack/svelte-table": "catalog:",

--- a/bun.lock
+++ b/bun.lock
@@ -181,7 +181,7 @@
         "@google/generative-ai": "^0.24.1",
         "@mistralai/mistralai": "^1.9.18",
         "@ricky0123/vad-web": "^0.0.24",
-        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/spec": "catalog:",
         "@tanstack/svelte-query": "catalog:",
         "@tanstack/svelte-query-devtools": "catalog:",
         "@tanstack/svelte-table": "catalog:",
@@ -293,6 +293,7 @@
         "@ark/json-schema": "^0.0.4",
         "@epicenter/sync": "workspace:*",
         "@sindresorhus/slugify": "^3.0.0",
+        "@standard-schema/spec": "catalog:",
         "@tursodatabase/database": "^0.3.2",
         "@types/bun": "catalog:",
         "arkregex": "catalog:",
@@ -384,7 +385,7 @@
         "wellcrafted": "catalog:",
       },
       "devDependencies": {
-        "@standard-schema/spec": "^1.0.0-beta.3",
+        "@standard-schema/spec": "catalog:",
         "@types/node": "catalog:",
         "svelte": "catalog:",
         "svelte-check": "catalog:",
@@ -449,7 +450,7 @@
         "yaml": "^2.8.1",
       },
       "devDependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/spec": "catalog:",
         "bun-types": "^1.3.0",
         "drizzle-kit": "catalog:",
         "tsx": "^4.20.6",
@@ -460,6 +461,7 @@
   "catalog": {
     "@biomejs/biome": "latest",
     "@lucide/svelte": "^0.555.0",
+    "@standard-schema/spec": "^1.1.0",
     "@sveltejs/kit": "^2.49.0",
     "@sveltejs/vite-plugin-svelte": "^6.2.1",
     "@tanstack/svelte-query": "^6.0.10",
@@ -545,23 +547,23 @@
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.3.14", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.14", "@biomejs/cli-darwin-x64": "2.3.14", "@biomejs/cli-linux-arm64": "2.3.14", "@biomejs/cli-linux-arm64-musl": "2.3.14", "@biomejs/cli-linux-x64": "2.3.14", "@biomejs/cli-linux-x64-musl": "2.3.14", "@biomejs/cli-win32-arm64": "2.3.14", "@biomejs/cli-win32-x64": "2.3.14" }, "bin": { "biome": "bin/biome" } }, "sha512-QMT6QviX0WqXJCaiqVMiBUCr5WRQ1iFSjvOLoTk6auKukJMvnMzWucXpwZB0e8F00/1/BsS9DzcKgWH+CLqVuA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.3.15", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.15", "@biomejs/cli-darwin-x64": "2.3.15", "@biomejs/cli-linux-arm64": "2.3.15", "@biomejs/cli-linux-arm64-musl": "2.3.15", "@biomejs/cli-linux-x64": "2.3.15", "@biomejs/cli-linux-x64-musl": "2.3.15", "@biomejs/cli-win32-arm64": "2.3.15", "@biomejs/cli-win32-x64": "2.3.15" }, "bin": { "biome": "bin/biome" } }, "sha512-u+jlPBAU2B45LDkjjNNYpc1PvqrM/co4loNommS9/sl9oSxsAQKsNZejYuUztvToB5oXi1tN/e62iNd6ESiY3g=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UJGPpvWJMkLxSRtpCAKfKh41Q4JJXisvxZL8ChN1eNW3m/WlPFJ6EFDCE7YfUb4XS8ZFi3C1dFpxUJ0Ety5n+A=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-SDCdrJ4COim1r8SNHg19oqT50JfkI/xGZHSyC6mGzMfKrpNe/217Eq6y98XhNTc0vGWDjznSDNXdUc6Kg24jbw=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-PNkLNQG6RLo8lG7QoWe/hhnMxJIt1tEimoXpGQjwS/dkdNiKBLPv4RpeQl8o3s1OKI3ZOR5XPiYtmbGGHAOnLA=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-RkyeSosBtn3C3Un8zQnl9upX0Qbq4E3QmBa0qjpOh1MebRbHhNlRC16jk8HdTe/9ym5zlfnpbb8cKXzW+vlTxw=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-KT67FKfzIw6DNnUNdYlBg+eU24Go3n75GWK6NwU4+yJmDYFe9i/MjiI+U/iEzKvo0g7G7MZqoyrhIYuND2w8QQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-FN83KxrdVWANOn5tDmW6UBC0grojchbGmcEz6JkRs2YY6DY63sTZhwkQ56x6YtKhDVV1Unz7FJexy8o7KwuIhg=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-LInRbXhYujtL3sH2TMCH/UBwJZsoGwfQjBrMfl84CD4hL/41C/EU5mldqf1yoFpsI0iPWuU83U+nB2TUUypWeg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-SSSIj2yMkFdSkXqASzIBdjySBXOe65RJlhKEDlri7MN19RC4cpez+C0kEwPrhXOTgJbwQR9QH1F4+VnHkC35pg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-ZsZzQsl9U+wxFrGGS4f6UxREUlgHwmEfu1IrXlgNFrNnd5Th6lIJr8KmSzu/+meSa9f4rzFrbEW9LBBA6ScoMA=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.15", "", { "os": "linux", "cpu": "x64" }, "sha512-T8n9p8aiIKOrAD7SwC7opiBM1LYGrE5G3OQRXWgbeo/merBk8m+uxJ1nOXMPzfYyFLfPlKF92QS06KN1UW+Zbg=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-KQU7EkbBBuHPW3/rAcoiVmhlPtDSGOGRPv9js7qJVpYTzjQmVR+C9Rfcz+ti8YCH+zT1J52tuBybtP4IodjxZQ=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.15", "", { "os": "linux", "cpu": "x64" }, "sha512-dbjPzTh+ijmmNwojFYbQNMFp332019ZDioBYAMMJj5Ux9d8MkM+u+J68SBJGVwVeSHMYj+T9504CoxEzQxrdNw=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-+IKYkj/pUBbnRf1G1+RlyA3LWiDgra1xpS7H2g4BuOzzRbRB+hmlw0yFsLprHhbbt7jUzbzAbAjK/Pn0FDnh1A=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-puMuenu/2brQdgqtQ7geNwQlNVxiABKEZJhMRX6AGWcmrMO8EObMXniFQywy2b81qmC+q+SDvlOpspNwz0WiOA=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-oizCjdyQ3WJEswpb3Chdngeat56rIdSYK12JI3iI11Mt5T5EXcZ7WLuowzEaFPNJ3zmOQFliMN8QY1Pi+qsfdQ=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.15", "", { "os": "win32", "cpu": "x64" }, "sha512-kDZr/hgg+igo5Emi0LcjlgfkoGZtgIpJKhnvKTRmMBv6FF/3SDyEV4khBwqNebZIyMZTzvpca9sQNSXJ39pI2A=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 			"concurrently": "latest",
 			"wrangler": "^4.51.0",
 			"yargs": "^18.0.0",
+			"@standard-schema/spec": "^1.1.0",
 			"hono": "^4.10.7",
 			"mime": "^4.0.6"
 		}

--- a/packages/epicenter/package.json
+++ b/packages/epicenter/package.json
@@ -29,6 +29,7 @@
 	},
 	"dependencies": {
 		"@ark/json-schema": "^0.0.4",
+		"@standard-schema/spec": "catalog:",
 		"@sindresorhus/slugify": "^3.0.0",
 		"@tursodatabase/database": "^0.3.2",
 		"@types/bun": "catalog:",

--- a/packages/epicenter/src/shared/standard-schema/types.ts
+++ b/packages/epicenter/src/shared/standard-schema/types.ts
@@ -1,196 +1,23 @@
 /**
- * Standard Schema type definitions.
+ * Standard Schema type re-exports and Epicenter extensions.
  *
- * These interfaces are copied from the Standard Schema specification
- * (https://standardschema.dev) to avoid external dependencies.
+ * Re-exports the official types from `@standard-schema/spec` and adds
+ * Epicenter's combined `StandardSchemaWithJSONSchema` type.
  *
+ * @see https://standardschema.dev
  * @see https://github.com/standard-schema/standard-schema
  */
 
-// #########################
-// ###   Standard Typed  ###
-// #########################
+export type {
+	StandardJSONSchemaV1,
+	StandardSchemaV1,
+	StandardTypedV1,
+} from '@standard-schema/spec';
 
-/**
- * The Standard Typed interface. This is a base type extended by other specs.
- */
-export type StandardTypedV1<Input = unknown, Output = Input> = {
-	/** The Standard properties. */
-	readonly '~standard': StandardTypedV1.Props<Input, Output>;
-};
-
-export declare namespace StandardTypedV1 {
-	/** The Standard Typed properties interface. */
-	type Props<Input = unknown, Output = Input> = {
-		/** The version number of the standard. */
-		readonly version: 1;
-		/** The vendor name of the schema library. */
-		readonly vendor: string;
-		/** Inferred types associated with the schema. */
-		readonly types?: Types<Input, Output> | undefined;
-	};
-
-	/** The Standard Typed types interface. */
-	type Types<Input = unknown, Output = Input> = {
-		/** The input type of the schema. */
-		readonly input: Input;
-		/** The output type of the schema. */
-		readonly output: Output;
-	};
-
-	/** Infers the input type of a Standard Typed. */
-	type InferInput<Schema extends StandardTypedV1> = NonNullable<
-		Schema['~standard']['types']
-	>['input'];
-
-	/** Infers the output type of a Standard Typed. */
-	type InferOutput<Schema extends StandardTypedV1> = NonNullable<
-		Schema['~standard']['types']
-	>['output'];
-}
-
-// ##########################
-// ###   Standard Schema  ###
-// ##########################
-
-/**
- * The Standard Schema interface.
- *
- * Extends StandardTypedV1 with a validate function for runtime validation.
- */
-export type StandardSchemaV1<Input = unknown, Output = Input> = {
-	/** The Standard Schema properties. */
-	readonly '~standard': StandardSchemaV1.Props<Input, Output>;
-};
-
-export declare namespace StandardSchemaV1 {
-	/** The Standard Schema properties interface. */
-	type Props<Input = unknown, Output = Input> = StandardTypedV1.Props<
-		Input,
-		Output
-	> & {
-		/** Validates unknown input values. */
-		readonly validate: (
-			value: unknown,
-			options?: StandardSchemaV1.Options | undefined,
-		) => Result<Output> | Promise<Result<Output>>;
-	};
-
-	/** The result interface of the validate function. */
-	type Result<Output> = SuccessResult<Output> | FailureResult;
-
-	/** The result interface if validation succeeds. */
-	type SuccessResult<Output> = {
-		/** The typed output value. */
-		readonly value: Output;
-		/** A falsy value for `issues` indicates success. */
-		readonly issues?: undefined;
-	};
-
-	/** Options for the validate function. */
-	type Options = {
-		/** Explicit support for additional vendor-specific parameters, if needed. */
-		readonly libraryOptions?: Record<string, unknown> | undefined;
-	};
-
-	/** The result interface if validation fails. */
-	type FailureResult = {
-		/** The issues of failed validation. */
-		readonly issues: ReadonlyArray<Issue>;
-	};
-
-	/** The issue interface of the failure output. */
-	type Issue = {
-		/** The error message of the issue. */
-		readonly message: string;
-		/** The path of the issue, if any. */
-		readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined;
-	};
-
-	/** The path segment interface of the issue. */
-	type PathSegment = {
-		/** The key representing a path segment. */
-		readonly key: PropertyKey;
-	};
-
-	/** Infers the input type of a Standard Schema. */
-	type InferInput<Schema extends StandardTypedV1> =
-		StandardTypedV1.InferInput<Schema>;
-
-	/** Infers the output type of a Standard Schema. */
-	type InferOutput<Schema extends StandardTypedV1> =
-		StandardTypedV1.InferOutput<Schema>;
-}
-
-// ###############################
-// ###   Standard JSON Schema  ###
-// ###############################
-
-/**
- * The Standard JSON Schema interface.
- *
- * Extends StandardTypedV1 with methods for generating JSON Schema.
- */
-export type StandardJSONSchemaV1<Input = unknown, Output = Input> = {
-	/** The Standard JSON Schema properties. */
-	readonly '~standard': StandardJSONSchemaV1.Props<Input, Output>;
-};
-
-export declare namespace StandardJSONSchemaV1 {
-	/** The Standard JSON Schema properties interface. */
-	type Props<Input = unknown, Output = Input> = StandardTypedV1.Props<
-		Input,
-		Output
-	> & {
-		/** Methods for generating the input/output JSON Schema. */
-		readonly jsonSchema: StandardJSONSchemaV1.Converter;
-	};
-
-	/** The Standard JSON Schema converter interface. */
-	type Converter = {
-		/** Converts the input type to JSON Schema. May throw if conversion is not supported. */
-		readonly input: (
-			options: StandardJSONSchemaV1.Options,
-		) => Record<string, unknown>;
-		/** Converts the output type to JSON Schema. May throw if conversion is not supported. */
-		readonly output: (
-			options: StandardJSONSchemaV1.Options,
-		) => Record<string, unknown>;
-	};
-
-	/**
-	 * The target version of the generated JSON Schema.
-	 *
-	 * It is *strongly recommended* that implementers support `"draft-2020-12"` and `"draft-07"`,
-	 * as they are both in wide use. All other targets can be implemented on a best-effort basis.
-	 * Libraries should throw if they don't support a specified target.
-	 *
-	 * The `"openapi-3.0"` target is intended as a standardized specifier for OpenAPI 3.0
-	 * which is a superset of JSON Schema `"draft-04"`.
-	 */
-	type Target =
-		| 'draft-2020-12'
-		| 'draft-07'
-		| 'openapi-3.0'
-		// Accepts any string for future targets while preserving autocomplete
-		| (string & {});
-
-	/** The options for the input/output methods. */
-	type Options = {
-		/** Specifies the target version of the generated JSON Schema. */
-		readonly target: Target;
-		/** Explicit support for additional vendor-specific parameters, if needed. */
-		readonly libraryOptions?: Record<string, unknown> | undefined;
-	};
-
-	/** Infers the input type of a Standard JSON Schema. */
-	type InferInput<Schema extends StandardTypedV1> =
-		StandardTypedV1.InferInput<Schema>;
-
-	/** Infers the output type of a Standard JSON Schema. */
-	type InferOutput<Schema extends StandardTypedV1> =
-		StandardTypedV1.InferOutput<Schema>;
-}
+import type {
+	StandardJSONSchemaV1,
+	StandardSchemaV1,
+} from '@standard-schema/spec';
 
 // ###############################
 // ###   Epicenter Extensions  ###

--- a/packages/svelte-utils/package.json
+++ b/packages/svelte-utils/package.json
@@ -12,7 +12,7 @@
 		"wellcrafted": "catalog:"
 	},
 	"devDependencies": {
-		"@standard-schema/spec": "^1.0.0-beta.3",
+		"@standard-schema/spec": "catalog:",
 		"svelte": "catalog:",
 		"svelte-check": "catalog:",
 		"@types/node": "catalog:",

--- a/packages/vault-core/package.json
+++ b/packages/vault-core/package.json
@@ -13,7 +13,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@standard-schema/spec": "^1.0.0",
+		"@standard-schema/spec": "catalog:",
 		"bun-types": "^1.3.0",
 		"drizzle-kit": "catalog:",
 		"tsx": "^4.20.6",


### PR DESCRIPTION
This PR eliminates ~180 lines of hand-copied Standard Schema type definitions by re-exporting them from the official @standard-schema/spec package. The change unifies all packages to use the catalog version instead of stale, pinned versions.

Previously, we maintained local copies of StandardTypedV1, StandardSchemaV1, and StandardJSONSchemaV1 in packages/epicenter/src/shared/standard-schema/types.ts. These were copied from the Standard Schema specification to avoid external dependencies, but this created maintenance burden: whenever the spec evolved, we had to manually update our copies. The file had grown to 196 lines of duplicated type definitions.

Now we import these types directly from @standard-schema/spec, which is the authoritative source. The types.ts file shrinks to 23 lines—just re-exports plus our Epicenter-specific CombinedStandardSchema extension. This keeps our custom types while eliminating the duplication.

The PR also adds @standard-schema/spec: ^1.1.0 to the bun workspace catalog (package.json), then updates all packages to reference it via catalog: instead of pinned versions. This gives us:

- Unified version management: One place to update the spec version
- Consistency: All packages use the same version
- Maintainability: No more stale version pins scattered across package.json files

Changes made:

1. Added @standard-schema/spec: ^1.1.0 to the root catalog in package.json
2. Updated packages/epicenter/src/shared/standard-schema/types.ts to re-export from @standard-schema/spec
3. Updated all package.json files to use catalog: instead of pinned versions:
   - apps/whispering: ^1.0.0 → catalog:
   - packages/epicenter: added catalog: dependency
   - packages/svelte-utils: ^1.0.0-beta.3 → catalog:
   - packages/vault-core: ^1.0.0 → catalog:
4. Updated bun.lock to reflect the new catalog entry and version changes

The refactor is purely internal—no API changes, no behavior changes. All type exports remain identical; we're just sourcing them from the official package instead of maintaining copies.