### PR TITLE
refactor: tab manager UI overhaul and component cleanup

### DIFF
--- a/apps/tab-manager/src/entrypoints/popup/App.svelte
+++ b/apps/tab-manager/src/entrypoints/popup/App.svelte
@@ -1,24 +1,53 @@
 <script lang="ts">
 	import TabList from '$lib/components/TabList.svelte';
 	import SavedTabList from '$lib/components/SavedTabList.svelte';
+	import { browserState } from '$lib/state/browser-state.svelte';
+	import { savedTabState } from '$lib/state/saved-tab-state.svelte';
 	import { ScrollArea } from '@epicenter/ui/scroll-area';
-	import { Separator } from '@epicenter/ui/separator';
+	import { Badge } from '@epicenter/ui/badge';
+	import * as Tabs from '@epicenter/ui/tabs';
 	import * as Tooltip from '@epicenter/ui/tooltip';
+
+	const totalTabs = $derived(
+		browserState.windows.reduce(
+			(sum, w) => sum + browserState.tabsByWindow(w.id).length,
+			0,
+		),
+	);
 </script>
 
 <Tooltip.Provider>
 	<main
 		class="w-[400px] min-h-[300px] max-h-[600px] overflow-hidden bg-background text-foreground"
 	>
-		<header
-			class="sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60 px-4 py-3"
-		>
-			<h1 class="text-lg font-semibold">Tab Manager</h1>
-		</header>
-		<ScrollArea class="h-[calc(600px-60px)]">
-			<TabList />
-			<Separator class="my-2" />
-			<SavedTabList />
-		</ScrollArea>
+		<Tabs.Root value="windows" class="flex h-full flex-col">
+			<header
+				class="sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60 px-3 pt-3 pb-0"
+			>
+				<h1 class="px-1 text-lg font-semibold">Tab Manager</h1>
+				<Tabs.List class="mt-2 w-full">
+					<Tabs.Trigger value="windows" class="flex-1 gap-1.5">
+						Windows
+						<Badge variant="outline" class="ml-0.5">{totalTabs}</Badge>
+					</Tabs.Trigger>
+					<Tabs.Trigger value="saved" class="flex-1 gap-1.5">
+						Saved
+						{#if savedTabState.tabs.length}
+							<Badge variant="outline" class="ml-0.5">
+								{savedTabState.tabs.length}
+							</Badge>
+						{/if}
+					</Tabs.Trigger>
+				</Tabs.List>
+			</header>
+			<ScrollArea class="flex-1">
+				<Tabs.Content value="windows">
+					<TabList />
+				</Tabs.Content>
+				<Tabs.Content value="saved">
+					<SavedTabList />
+				</Tabs.Content>
+			</ScrollArea>
+		</Tabs.Root>
 	</main>
 </Tooltip.Provider>

--- a/apps/tab-manager/src/lib/components/SavedTabList.svelte
+++ b/apps/tab-manager/src/lib/components/SavedTabList.svelte
@@ -4,6 +4,7 @@
 	import TabFavicon from './TabFavicon.svelte';
 	import { Button } from '@epicenter/ui/button';
 	import * as Empty from '@epicenter/ui/empty';
+	import * as Item from '@epicenter/ui/item';
 	import RotateCcwIcon from '@lucide/svelte/icons/rotate-ccw';
 	import Trash2Icon from '@lucide/svelte/icons/trash-2';
 	import BookmarkIcon from '@lucide/svelte/icons/bookmark';
@@ -20,26 +21,26 @@
 			>
 		</Empty.Root>
 	{:else}
-		<div class="flex flex-col gap-1">
+		<Item.Group>
 			{#each savedTabState.tabs as tab (tab.id)}
-				<div
-					class="group flex items-center gap-3 rounded-md px-2 py-2 hover:bg-accent/50"
-				>
-					<TabFavicon src={tab.favIconUrl} />
+				<Item.Root size="sm" class="hover:bg-accent/50">
+					<Item.Media>
+						<TabFavicon src={tab.favIconUrl} />
+					</Item.Media>
 
-					<div class="min-w-0 flex-1">
-						<div class="truncate text-sm font-medium">
-							{tab.title || 'Untitled'}
-						</div>
-						<div class="flex items-center gap-2 text-xs text-muted-foreground">
+					<Item.Content>
+						<Item.Title>
+							<span class="truncate">{tab.title || 'Untitled'}</span>
+						</Item.Title>
+						<Item.Description class="flex items-center gap-2 truncate">
 							<span class="truncate">{getDomain(tab.url)}</span>
 							<span>•</span>
 							<span class="shrink-0">{getRelativeTime(tab.savedAt)}</span>
-						</div>
-					</div>
+						</Item.Description>
+					</Item.Content>
 
-					<div
-						class="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100"
+					<Item.Actions
+						class="gap-1 opacity-0 transition-opacity group-hover/item:opacity-100"
 					>
 						<Button
 							variant="ghost"
@@ -58,10 +59,10 @@
 						>
 							<Trash2Icon />
 						</Button>
-					</div>
-				</div>
+					</Item.Actions>
+				</Item.Root>
 			{/each}
-		</div>
+		</Item.Group>
 
 		<div class="mt-2 flex justify-end gap-2 border-t pt-2">
 			<Button

--- a/apps/tab-manager/src/lib/components/SavedTabList.svelte
+++ b/apps/tab-manager/src/lib/components/SavedTabList.svelte
@@ -39,9 +39,7 @@
 						</Item.Description>
 					</Item.Content>
 
-					<Item.Actions
-						class="gap-1 opacity-0 transition-opacity group-hover/item:opacity-100"
-					>
+					<Item.Actions showOnHover class="gap-1">
 						<Button
 							variant="ghost"
 							size="icon-xs"

--- a/apps/tab-manager/src/lib/components/SavedTabList.svelte
+++ b/apps/tab-manager/src/lib/components/SavedTabList.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { savedTabState } from '$lib/state/saved-tab-state.svelte';
 	import { getDomain, getRelativeTime } from '$lib/utils/format';
-	import { Badge } from '@epicenter/ui/badge';
 	import { Button } from '@epicenter/ui/button';
 	import * as Avatar from '@epicenter/ui/avatar';
 	import * as Empty from '@epicenter/ui/empty';
@@ -11,18 +10,7 @@
 	import BookmarkIcon from '@lucide/svelte/icons/bookmark';
 </script>
 
-<section class="flex flex-col gap-2 p-4 pt-0">
-	<header class="flex items-center justify-between">
-		<h2 class="text-sm font-semibold text-muted-foreground">
-			Saved Tabs
-			{#if savedTabState.tabs.length}
-				<Badge variant="secondary" class="ml-1">
-					{savedTabState.tabs.length}
-				</Badge>
-			{/if}
-		</h2>
-	</header>
-
+<section class="flex flex-col gap-2 p-4">
 	{#if !savedTabState.tabs.length}
 		<Empty.Root class="py-8">
 			<Empty.Media>

--- a/apps/tab-manager/src/lib/components/SavedTabList.svelte
+++ b/apps/tab-manager/src/lib/components/SavedTabList.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
 	import { savedTabState } from '$lib/state/saved-tab-state.svelte';
 	import { getDomain, getRelativeTime } from '$lib/utils/format';
+	import TabFavicon from './TabFavicon.svelte';
 	import { Button } from '@epicenter/ui/button';
-	import * as Avatar from '@epicenter/ui/avatar';
 	import * as Empty from '@epicenter/ui/empty';
-	import GlobeIcon from '@lucide/svelte/icons/globe';
 	import RotateCcwIcon from '@lucide/svelte/icons/rotate-ccw';
 	import Trash2Icon from '@lucide/svelte/icons/trash-2';
 	import BookmarkIcon from '@lucide/svelte/icons/bookmark';
@@ -26,12 +25,7 @@
 				<div
 					class="group flex items-center gap-3 rounded-md px-2 py-2 hover:bg-accent/50"
 				>
-					<Avatar.Root class="size-4 shrink-0 rounded-sm">
-						<Avatar.Image src={tab.favIconUrl} alt="" />
-						<Avatar.Fallback class="rounded-sm">
-							<GlobeIcon class="size-3 text-muted-foreground" />
-						</Avatar.Fallback>
-					</Avatar.Root>
+					<TabFavicon src={tab.favIconUrl} />
 
 					<div class="min-w-0 flex-1">
 						<div class="truncate text-sm font-medium">

--- a/apps/tab-manager/src/lib/components/TabFavicon.svelte
+++ b/apps/tab-manager/src/lib/components/TabFavicon.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import * as Avatar from '@epicenter/ui/avatar';
+	import GlobeIcon from '@lucide/svelte/icons/globe';
+
+	let { src }: { src: string | undefined } = $props();
+</script>
+
+<Avatar.Root class="size-4 shrink-0 rounded-sm">
+	<Avatar.Image {src} alt="" />
+	<Avatar.Fallback class="rounded-sm">
+		<GlobeIcon class="size-3 text-muted-foreground" />
+	</Avatar.Fallback>
+</Avatar.Root>

--- a/apps/tab-manager/src/lib/components/TabItem.svelte
+++ b/apps/tab-manager/src/lib/components/TabItem.svelte
@@ -51,9 +51,7 @@
 				</Item.Description>
 			</Item.Content>
 
-			<Item.Actions
-				class="gap-1 opacity-0 transition-opacity group-hover/item:opacity-100"
-			>
+			<Item.Actions showOnHover class="gap-1">
 				<Button
 					variant="ghost"
 					size="icon-xs"

--- a/apps/tab-manager/src/lib/components/TabItem.svelte
+++ b/apps/tab-manager/src/lib/components/TabItem.svelte
@@ -3,6 +3,7 @@
 	import { savedTabState } from '$lib/state/saved-tab-state.svelte';
 	import type { Tab } from '$lib/workspace';
 	import { getDomain } from '$lib/utils/format';
+	import TabFavicon from './TabFavicon.svelte';
 	import XIcon from '@lucide/svelte/icons/x';
 	import PinIcon from '@lucide/svelte/icons/pin';
 	import PinOffIcon from '@lucide/svelte/icons/pin-off';
@@ -10,10 +11,8 @@
 	import VolumeXIcon from '@lucide/svelte/icons/volume-x';
 	import RefreshCwIcon from '@lucide/svelte/icons/refresh-cw';
 	import CopyIcon from '@lucide/svelte/icons/copy';
-	import GlobeIcon from '@lucide/svelte/icons/globe';
 	import BookmarkIcon from '@lucide/svelte/icons/bookmark';
 	import { Button } from '@epicenter/ui/button';
-	import * as Avatar from '@epicenter/ui/avatar';
 	import { cn } from '@epicenter/ui/utils';
 
 	let { tab }: { tab: Tab } = $props();
@@ -33,13 +32,7 @@
 	)}
 	onclick={() => browserState.actions.activate(tabId)}
 >
-	<!-- Favicon -->
-	<Avatar.Root class="size-4 shrink-0 rounded-sm">
-		<Avatar.Image src={tab.favIconUrl} alt="" />
-		<Avatar.Fallback class="rounded-sm">
-			<GlobeIcon class="size-3 text-muted-foreground" />
-		</Avatar.Fallback>
-	</Avatar.Root>
+	<TabFavicon src={tab.favIconUrl} />
 
 	<!-- Title and URL -->
 	<div class="min-w-0 flex-1">

--- a/apps/tab-manager/src/lib/components/TabItem.svelte
+++ b/apps/tab-manager/src/lib/components/TabItem.svelte
@@ -13,141 +13,138 @@
 	import CopyIcon from '@lucide/svelte/icons/copy';
 	import BookmarkIcon from '@lucide/svelte/icons/bookmark';
 	import { Button } from '@epicenter/ui/button';
-	import { cn } from '@epicenter/ui/utils';
+	import * as Item from '@epicenter/ui/item';
 
 	let { tab }: { tab: Tab } = $props();
 
-	// Use tabId for browser API calls (native browser tab ID)
 	const tabId = $derived(tab.tabId);
-
-	// Extract domain from URL for display
 	const domain = $derived(tab.url ? getDomain(tab.url) : '');
 </script>
 
-<button
-	type="button"
-	class={cn(
-		'group flex w-full items-center gap-3 px-4 py-2 text-left transition-colors hover:bg-accent',
-		tab.active && 'bg-accent/50',
-	)}
-	onclick={() => browserState.actions.activate(tabId)}
->
-	<TabFavicon src={tab.favIconUrl} />
-
-	<!-- Title and URL -->
-	<div class="min-w-0 flex-1">
-		<div class="flex items-center gap-1">
-			{#if tab.pinned}
-				<PinIcon class="size-3 shrink-0 text-muted-foreground" />
-			{/if}
-			{#if tab.audible && !tab.mutedInfo?.muted}
-				<Volume2Icon class="size-3 shrink-0 text-muted-foreground" />
-			{/if}
-			{#if tab.mutedInfo?.muted}
-				<VolumeXIcon class="size-3 shrink-0 text-muted-foreground" />
-			{/if}
-			<span class="truncate text-sm font-medium">
-				{tab.title || 'Untitled'}
-			</span>
-		</div>
-		<div class="truncate text-xs text-muted-foreground">
-			{domain}
-		</div>
-	</div>
-
-	<!-- Actions (visible on hover) -->
-	<div
-		class="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100"
-	>
-		<Button
-			variant="ghost"
-			size="icon-xs"
-			tooltip={tab.pinned ? 'Unpin' : 'Pin'}
-			onclick={(e: MouseEvent) => {
-				e.stopPropagation();
-				if (tab.pinned) {
-					browserState.actions.unpin(tabId);
-				} else {
-					browserState.actions.pin(tabId);
-				}
-			}}
+<Item.Root size="sm" class={tab.active ? 'bg-accent/50' : 'hover:bg-accent'}>
+	{#snippet child({ props })}
+		<button
+			type="button"
+			{...props}
+			class="{props.class} w-full text-left"
+			onclick={() => browserState.actions.activate(tabId)}
 		>
-			{#if tab.pinned}
-				<PinOffIcon />
-			{:else}
-				<PinIcon />
-			{/if}
-		</Button>
+			<Item.Media>
+				<TabFavicon src={tab.favIconUrl} />
+			</Item.Media>
 
-		{#if tab.audible || tab.mutedInfo?.muted}
-			<Button
-				variant="ghost"
-				size="icon-xs"
-				tooltip={tab.mutedInfo?.muted ? 'Unmute' : 'Mute'}
-				onclick={(e: MouseEvent) => {
-					e.stopPropagation();
-					if (tab.mutedInfo?.muted) {
-						browserState.actions.unmute(tabId);
-					} else {
-						browserState.actions.mute(tabId);
-					}
-				}}
+			<Item.Content>
+				<Item.Title>
+					{#if tab.pinned}
+						<PinIcon class="size-3 shrink-0 text-muted-foreground" />
+					{/if}
+					{#if tab.audible && !tab.mutedInfo?.muted}
+						<Volume2Icon class="size-3 shrink-0 text-muted-foreground" />
+					{/if}
+					{#if tab.mutedInfo?.muted}
+						<VolumeXIcon class="size-3 shrink-0 text-muted-foreground" />
+					{/if}
+					<span class="truncate">{tab.title || 'Untitled'}</span>
+				</Item.Title>
+				<Item.Description class="truncate">
+					{domain}
+				</Item.Description>
+			</Item.Content>
+
+			<Item.Actions
+				class="gap-1 opacity-0 transition-opacity group-hover/item:opacity-100"
 			>
-				{#if tab.mutedInfo?.muted}
-					<Volume2Icon />
-				{:else}
-					<VolumeXIcon />
+				<Button
+					variant="ghost"
+					size="icon-xs"
+					tooltip={tab.pinned ? 'Unpin' : 'Pin'}
+					onclick={(e: MouseEvent) => {
+						e.stopPropagation();
+						if (tab.pinned) {
+							browserState.actions.unpin(tabId);
+						} else {
+							browserState.actions.pin(tabId);
+						}
+					}}
+				>
+					{#if tab.pinned}
+						<PinOffIcon />
+					{:else}
+						<PinIcon />
+					{/if}
+				</Button>
+
+				{#if tab.audible || tab.mutedInfo?.muted}
+					<Button
+						variant="ghost"
+						size="icon-xs"
+						tooltip={tab.mutedInfo?.muted ? 'Unmute' : 'Mute'}
+						onclick={(e: MouseEvent) => {
+							e.stopPropagation();
+							if (tab.mutedInfo?.muted) {
+								browserState.actions.unmute(tabId);
+							} else {
+								browserState.actions.mute(tabId);
+							}
+						}}
+					>
+						{#if tab.mutedInfo?.muted}
+							<Volume2Icon />
+						{:else}
+							<VolumeXIcon />
+						{/if}
+					</Button>
 				{/if}
-			</Button>
-		{/if}
 
-		<Button
-			variant="ghost"
-			size="icon-xs"
-			tooltip="Reload"
-			onclick={(e: MouseEvent) => {
-				e.stopPropagation();
-				browserState.actions.reload(tabId);
-			}}
-		>
-			<RefreshCwIcon />
-		</Button>
+				<Button
+					variant="ghost"
+					size="icon-xs"
+					tooltip="Reload"
+					onclick={(e: MouseEvent) => {
+						e.stopPropagation();
+						browserState.actions.reload(tabId);
+					}}
+				>
+					<RefreshCwIcon />
+				</Button>
 
-		<Button
-			variant="ghost"
-			size="icon-xs"
-			tooltip="Duplicate"
-			onclick={(e: MouseEvent) => {
-				e.stopPropagation();
-				browserState.actions.duplicate(tabId);
-			}}
-		>
-			<CopyIcon />
-		</Button>
+				<Button
+					variant="ghost"
+					size="icon-xs"
+					tooltip="Duplicate"
+					onclick={(e: MouseEvent) => {
+						e.stopPropagation();
+						browserState.actions.duplicate(tabId);
+					}}
+				>
+					<CopyIcon />
+				</Button>
 
-		<Button
-			variant="ghost"
-			size="icon-xs"
-			tooltip="Save for later"
-			onclick={(e: MouseEvent) => {
-				e.stopPropagation();
-				savedTabState.actions.save(tab);
-			}}
-		>
-			<BookmarkIcon />
-		</Button>
+				<Button
+					variant="ghost"
+					size="icon-xs"
+					tooltip="Save for later"
+					onclick={(e: MouseEvent) => {
+						e.stopPropagation();
+						savedTabState.actions.save(tab);
+					}}
+				>
+					<BookmarkIcon />
+				</Button>
 
-		<Button
-			variant="ghost"
-			size="icon-xs"
-			class="text-destructive"
-			tooltip="Close"
-			onclick={(e: MouseEvent) => {
-				e.stopPropagation();
-				browserState.actions.close(tabId);
-			}}
-		>
-			<XIcon />
-		</Button>
-	</div>
-</button>
+				<Button
+					variant="ghost"
+					size="icon-xs"
+					class="text-destructive"
+					tooltip="Close"
+					onclick={(e: MouseEvent) => {
+						e.stopPropagation();
+						browserState.actions.close(tabId);
+					}}
+				>
+					<XIcon />
+				</Button>
+			</Item.Actions>
+		</button>
+	{/snippet}
+</Item.Root>

--- a/apps/tab-manager/src/lib/components/TabList.svelte
+++ b/apps/tab-manager/src/lib/components/TabList.svelte
@@ -24,19 +24,19 @@
 		{#each browserState.windows as window (window.id)}
 			{@const windowTabs = browserState.tabsByWindow(window.id)}
 			<Accordion.Item value={window.id}>
-				<Accordion.Trigger class="px-2 py-2 hover:no-underline">
-					<div class="flex items-center gap-2">
-						<AppWindowIcon class="size-4 text-muted-foreground" />
-						<span class="text-sm font-medium">
-							Window
-							{#if window.focused}
-								<Badge variant="secondary" class="ml-1">focused</Badge>
-							{/if}
-						</span>
-						<Badge variant="outline" class="ml-auto">
-							{windowTabs.length}
-						</Badge>
-					</div>
+				<Accordion.Trigger
+					class="items-center gap-2 px-2 py-2 hover:no-underline"
+				>
+					<AppWindowIcon class="size-4 text-muted-foreground" />
+					<span class="text-sm font-medium">
+						Window
+						{#if window.focused}
+							<Badge variant="secondary" class="ml-1">focused</Badge>
+						{/if}
+					</span>
+					<Badge variant="outline" class="ml-auto">
+						{windowTabs.length}
+					</Badge>
 				</Accordion.Trigger>
 				<Accordion.Content class="pb-0 divide-y">
 					{#each windowTabs as tab (tab.id)}

--- a/packages/ui/src/item/item-actions.svelte
+++ b/packages/ui/src/item/item-actions.svelte
@@ -4,16 +4,24 @@
 
 	let {
 		ref = $bindable(null),
+		showOnHover = false,
 		class: className,
 		children,
 		...restProps
-	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		/** When true, actions are hidden by default and shown on hover of the parent `group/item`. */
+		showOnHover?: boolean;
+	} = $props();
 </script>
 
 <div
 	bind:this={ref}
 	data-slot="item-actions"
-	class={cn('flex items-center gap-2', className)}
+	class={cn(
+		'flex items-center gap-2',
+		showOnHover && 'opacity-0 transition-opacity group-hover/item:opacity-100',
+		className,
+	)}
 	{...restProps}
 >
 	{@render children?.()}


### PR DESCRIPTION
The tab manager popup was a vertically stacked layout with hand-rolled Tailwind for each row. This overhaul switches it to a proper Tabs component with badge counts, migrates tab rows to the existing `Item.*` component system, and cleans up repeated patterns along the way.

The progression was: layout → shared components → component system → component refinements → variant prop.

**Tabs layout** replaces the stacked Windows + Saved Tabs sections with a switchable tab UI. Each section gets the full scroll area, with badge counts on the triggers for at-a-glance state.

**TabFavicon** extracts the identical Avatar + GlobeIcon fallback pattern from both `TabItem` and `SavedTabList` into one shared component.

**Item.\* component system** replaces the hand-rolled flex/gap/padding layouts in `TabItem` and `SavedTabList` with `Item.Root`/`Media`/`Content`/`Title`/`Description`/`Actions`. This also gets hover-reveal actions via `group-hover/item` for free.

**Accordion.Trigger cleanup** removes a wrapper div — `Accordion.Trigger` already uses `cn()` to merge classes, so `items-center` and `gap-2` can override its defaults directly.

**`showOnHover` prop on `Item.Actions`** — two of three usages duplicated the same hover-reveal class string. This extracts that into a declarative boolean:

```svelte
<!-- Before: repeated class string you have to remember -->
<Item.Actions class="gap-1 opacity-0 transition-opacity group-hover/item:opacity-100">

<!-- After: single boolean prop -->
<Item.Actions showOnHover class="gap-1">
```

The prop defaults to `false`, so the epicenter `+page.svelte` usage (always-visible actions) continues working unchanged. When `true`, the component applies the opacity transition internally via `cn()`, keeping the hover-reveal classes as a separate override argument for easy maintenance after shadcn updates.

Also includes: renaming `StandardSchemaWithJSONSchema` → `CombinedStandardSchema` across the codebase, using `@standard-schema/spec` from catalog instead of local type copies, and docs updates for the `_v` convention.