### PR TITLE
feat(filesystem): add sheet timeline entry with CSV serialization

### DIFF
--- a/packages/filesystem/src/index.ts
+++ b/packages/filesystem/src/index.ts
@@ -26,12 +26,23 @@ export {
 } from './markdown-helpers.js';
 // Path utilities
 export { posixResolve } from './path-utils.js';
+// Sheet helpers
+export {
+	parseSheetFromCsv,
+	reorderColumn,
+	reorderRow,
+	serializeSheetToCsv,
+} from './sheet-helpers.js';
 export type {
+	ColumnDefinition,
+	ColumnId,
 	ContentDocStore,
 	FileId,
 	FileRow,
+	RowId,
+	SheetEntry,
 } from './types.js';
-export { generateFileId } from './types.js';
+export { generateColumnId, generateFileId, generateRowId } from './types.js';
 // Validation
 export {
 	assertUniqueName,

--- a/packages/filesystem/src/sheet-helpers.test.ts
+++ b/packages/filesystem/src/sheet-helpers.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, test } from 'bun:test';
+import * as Y from 'yjs';
+import {
+	computeMidpoint,
+	generateInitialOrders,
+	parseSheetFromCsv,
+	reorderColumn,
+	reorderRow,
+	serializeSheetToCsv,
+} from './sheet-helpers.js';
+
+function createSheetMaps() {
+	const ydoc = new Y.Doc();
+	const columns = ydoc.getMap('columns') as Y.Map<Y.Map<string>>;
+	const rows = ydoc.getMap('rows') as Y.Map<Y.Map<string>>;
+	return { ydoc, columns, rows };
+}
+
+describe('serializeSheetToCsv', () => {
+	test('empty sheet returns empty string', () => {
+		const { columns, rows } = createSheetMaps();
+		expect(serializeSheetToCsv(columns, rows)).toBe('');
+	});
+
+	test('single column, single row', () => {
+		const { columns, rows } = createSheetMaps();
+		const col = new Y.Map<string>();
+		col.set('name', 'Name');
+		col.set('order', '0.5');
+		columns.set('col1', col);
+
+		const row = new Y.Map<string>();
+		row.set('order', '0.5');
+		row.set('col1', 'Alice');
+		rows.set('row1', row);
+
+		expect(serializeSheetToCsv(columns, rows)).toBe('Name\nAlice\n');
+	});
+
+	test('columns sorted by order property', () => {
+		const { columns, rows } = createSheetMaps();
+		const colA = new Y.Map<string>();
+		colA.set('name', 'A');
+		colA.set('order', '0.7');
+		columns.set('colA', colA);
+
+		const colB = new Y.Map<string>();
+		colB.set('name', 'B');
+		colB.set('order', '0.3');
+		columns.set('colB', colB);
+
+		const row = new Y.Map<string>();
+		row.set('order', '0.5');
+		row.set('colA', 'a1');
+		row.set('colB', 'b1');
+		rows.set('row1', row);
+
+		expect(serializeSheetToCsv(columns, rows)).toBe('B,A\nb1,a1\n');
+	});
+
+	test('missing cell values become empty fields', () => {
+		const { columns, rows } = createSheetMaps();
+		const colA = new Y.Map<string>();
+		colA.set('name', 'A');
+		colA.set('order', '0.3');
+		columns.set('colA', colA);
+
+		const colB = new Y.Map<string>();
+		colB.set('name', 'B');
+		colB.set('order', '0.7');
+		columns.set('colB', colB);
+
+		const row = new Y.Map<string>();
+		row.set('order', '0.5');
+		row.set('colA', 'a1');
+		// colB is missing
+		rows.set('row1', row);
+
+		expect(serializeSheetToCsv(columns, rows)).toBe('A,B\na1,\n');
+	});
+
+	test('escapes commas in cell values', () => {
+		const { columns, rows } = createSheetMaps();
+		const col = new Y.Map<string>();
+		col.set('name', 'Name');
+		col.set('order', '0.5');
+		columns.set('col1', col);
+
+		const row = new Y.Map<string>();
+		row.set('order', '0.5');
+		row.set('col1', 'Smith, John');
+		rows.set('row1', row);
+
+		expect(serializeSheetToCsv(columns, rows)).toBe('Name\n"Smith, John"\n');
+	});
+
+	test('escapes double quotes in cell values', () => {
+		const { columns, rows } = createSheetMaps();
+		const col = new Y.Map<string>();
+		col.set('name', 'Name');
+		col.set('order', '0.5');
+		columns.set('col1', col);
+
+		const row = new Y.Map<string>();
+		row.set('order', '0.5');
+		row.set('col1', 'Say "hello"');
+		rows.set('row1', row);
+
+		expect(serializeSheetToCsv(columns, rows)).toBe('Name\n"Say ""hello"""\n');
+	});
+
+	test('escapes newlines in cell values', () => {
+		const { columns, rows } = createSheetMaps();
+		const col = new Y.Map<string>();
+		col.set('name', 'Text');
+		col.set('order', '0.5');
+		columns.set('col1', col);
+
+		const row = new Y.Map<string>();
+		row.set('order', '0.5');
+		row.set('col1', 'Line 1\nLine 2');
+		rows.set('row1', row);
+
+		expect(serializeSheetToCsv(columns, rows)).toBe('Text\n"Line 1\nLine 2"\n');
+	});
+
+	test('header-only (columns but no rows) returns just header line', () => {
+		const { columns, rows } = createSheetMaps();
+		const col = new Y.Map<string>();
+		col.set('name', 'Name');
+		col.set('order', '0.5');
+		columns.set('col1', col);
+
+		expect(serializeSheetToCsv(columns, rows)).toBe('Name\n');
+	});
+});
+
+describe('parseSheetFromCsv', () => {
+	test('basic CSV (3 cols, 2 rows)', () => {
+		const { columns, rows } = createSheetMaps();
+		parseSheetFromCsv('A,B,C\n1,2,3\n4,5,6\n', columns, rows);
+
+		expect(columns.size).toBe(3);
+		expect(rows.size).toBe(2);
+
+		const colEntries = Array.from(columns.entries());
+		expect(colEntries[0][1].get('name')).toBe('A');
+		expect(colEntries[1][1].get('name')).toBe('B');
+		expect(colEntries[2][1].get('name')).toBe('C');
+	});
+
+	test('empty CSV leaves maps empty', () => {
+		const { columns, rows } = createSheetMaps();
+		parseSheetFromCsv('', columns, rows);
+		expect(columns.size).toBe(0);
+		expect(rows.size).toBe(0);
+	});
+
+	test('quoted fields with commas', () => {
+		const { columns, rows } = createSheetMaps();
+		parseSheetFromCsv('Name\n"Smith, John"\n', columns, rows);
+
+		const rowEntries = Array.from(rows.entries());
+		const colEntries = Array.from(columns.entries());
+		const colId = colEntries[0][0];
+		expect(rowEntries[0][1].get(colId)).toBe('Smith, John');
+	});
+
+	test('quoted fields with escaped quotes', () => {
+		const { columns, rows } = createSheetMaps();
+		parseSheetFromCsv('Text\n"Say ""hello"""\n', columns, rows);
+
+		const rowEntries = Array.from(rows.entries());
+		const colEntries = Array.from(columns.entries());
+		const colId = colEntries[0][0];
+		expect(rowEntries[0][1].get(colId)).toBe('Say "hello"');
+	});
+
+	test('quoted fields with newlines', () => {
+		const { columns, rows } = createSheetMaps();
+		parseSheetFromCsv('Text\n"Line 1\nLine 2"\n', columns, rows);
+
+		const rowEntries = Array.from(rows.entries());
+		const colEntries = Array.from(columns.entries());
+		const colId = colEntries[0][0];
+		expect(rowEntries[0][1].get(colId)).toBe('Line 1\nLine 2');
+	});
+
+	test('empty cells in CSV', () => {
+		const { columns, rows } = createSheetMaps();
+		parseSheetFromCsv('A,B,C\n1,,3\n', columns, rows);
+
+		const rowEntries = Array.from(rows.entries());
+		const colEntries = Array.from(columns.entries());
+		const row = rowEntries[0][1];
+		const colIdA = colEntries[0][0];
+		const colIdB = colEntries[1][0];
+		const colIdC = colEntries[2][0];
+
+		expect(row.get(colIdA)).toBe('1');
+		expect(row.has(colIdB)).toBe(false); // Empty cell not stored
+		expect(row.get(colIdC)).toBe('3');
+	});
+
+	test('header-only CSV creates columns, no rows', () => {
+		const { columns, rows } = createSheetMaps();
+		parseSheetFromCsv('A,B,C\n', columns, rows);
+
+		expect(columns.size).toBe(3);
+		expect(rows.size).toBe(0);
+	});
+});
+
+describe('round-trip', () => {
+	test('CSV → parseSheetFromCsv → serializeSheetToCsv → same CSV', () => {
+		const { columns, rows } = createSheetMaps();
+		const originalCsv = 'Name,Age,City\nAlice,30,NYC\nBob,25,LA\n';
+		parseSheetFromCsv(originalCsv, columns, rows);
+		const serialized = serializeSheetToCsv(columns, rows);
+		expect(serialized).toBe(originalCsv);
+	});
+
+	test('CSV with special characters survives round-trip', () => {
+		const { columns, rows } = createSheetMaps();
+		const originalCsv = 'Text\n"Line 1\nLine 2"\n"Say ""hi"""\n"Smith, John"\n';
+		parseSheetFromCsv(originalCsv, columns, rows);
+		const serialized = serializeSheetToCsv(columns, rows);
+		expect(serialized).toBe(originalCsv);
+	});
+});
+
+describe('fractional indexing', () => {
+	test('computeMidpoint returns value between bounds', () => {
+		const mid = computeMidpoint(0, 1);
+		expect(mid).toBeGreaterThan(0);
+		expect(mid).toBeLessThan(1);
+	});
+
+	test('computeMidpoint(0.25, 0.75) returns value in range', () => {
+		const mid = computeMidpoint(0.25, 0.75);
+		expect(mid).toBeGreaterThan(0.25);
+		expect(mid).toBeLessThan(0.75);
+	});
+
+	test('generateInitialOrders returns ascending values between 0 and 1', () => {
+		const orders = generateInitialOrders(5);
+		expect(orders.length).toBe(5);
+		for (let i = 0; i < orders.length; i++) {
+			expect(orders[i]).toBeGreaterThan(0);
+			expect(orders[i]).toBeLessThan(1);
+			if (i > 0) {
+				expect(orders[i]).toBeGreaterThan(orders[i - 1]);
+			}
+		}
+	});
+
+	test('generateInitialOrders(0) returns empty array', () => {
+		expect(generateInitialOrders(0)).toEqual([]);
+	});
+
+	test('reorderRow updates order to midpoint between neighbors', () => {
+		const { rows } = createSheetMaps();
+		const row = new Y.Map<string>();
+		row.set('order', '0.5');
+		rows.set('row1', row);
+
+		reorderRow(rows, 'row1', 0.25, 0.75);
+		const newOrder = Number.parseFloat(row.get('order') ?? '0');
+		expect(newOrder).toBeGreaterThan(0.25);
+		expect(newOrder).toBeLessThan(0.75);
+	});
+
+	test('reorderColumn updates order to midpoint between neighbors', () => {
+		const { columns } = createSheetMaps();
+		const col = new Y.Map<string>();
+		col.set('order', '0.5');
+		columns.set('col1', col);
+
+		reorderColumn(columns, 'col1', 0.1, 0.9);
+		const newOrder = Number.parseFloat(col.get('order') ?? '0');
+		expect(newOrder).toBeGreaterThan(0.1);
+		expect(newOrder).toBeLessThan(0.9);
+	});
+});

--- a/packages/filesystem/src/sheet-helpers.ts
+++ b/packages/filesystem/src/sheet-helpers.ts
@@ -1,0 +1,285 @@
+/**
+ * Compute a fractional index between two bounds.
+ * Adds small jitter to prevent collisions on concurrent reorders.
+ *
+ * @param start - Lower bound (exclusive)
+ * @param end - Upper bound (exclusive)
+ * @returns A number strictly between start and end
+ */
+export function computeMidpoint(start: number, end: number): number {
+	const mid = (start + end) / 2;
+	const range = (end - start) * 1e-10;
+	const jitter = -range / 2 + Math.random() * range;
+	return mid + jitter;
+}
+
+/**
+ * Generate evenly-spaced initial order values for n items.
+ * Values are between 0 (exclusive) and 1 (exclusive).
+ *
+ * @example
+ * ```typescript
+ * generateInitialOrders(3) // [0.25, 0.5, 0.75]
+ * ```
+ */
+export function generateInitialOrders(count: number): number[] {
+	return Array.from({ length: count }, (_, i) => (i + 1) / (count + 1));
+}
+
+import * as Y from 'yjs';
+import { generateColumnId, generateRowId } from './types.js';
+
+/**
+ * Escape a CSV field value per RFC 4180.
+ * Fields containing commas, quotes, or newlines are wrapped in quotes.
+ * Internal quotes are escaped as "".
+ */
+function escapeCsvField(value: string): string {
+	if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+		return `"${value.replace(/"/g, '""')}"`;
+	}
+	return value;
+}
+
+/**
+ * Parse CSV string into 2D array per RFC 4180.
+ * Handles quoted fields, escaped quotes, and newlines within fields.
+ */
+function parseCsvRows(csv: string): string[][] {
+	const rows: string[][] = [];
+	let currentRow: string[] = [];
+	let currentField = '';
+	let inQuotes = false;
+	let i = 0;
+
+	while (i < csv.length) {
+		const char = csv[i];
+		const nextChar = csv[i + 1];
+
+		if (inQuotes) {
+			if (char === '"' && nextChar === '"') {
+				// Escaped quote within quoted field
+				currentField += '"';
+				i += 2;
+			} else if (char === '"') {
+				// End of quoted field
+				inQuotes = false;
+				i++;
+			} else {
+				// Regular character within quoted field
+				currentField += char;
+				i++;
+			}
+		} else {
+			if (char === '"') {
+				// Start of quoted field
+				inQuotes = true;
+				i++;
+			} else if (char === ',') {
+				// Field delimiter
+				currentRow.push(currentField);
+				currentField = '';
+				i++;
+			} else if (char === '\n') {
+				// Row delimiter
+				currentRow.push(currentField);
+				if (currentRow.length > 0) {
+					rows.push(currentRow);
+				}
+				currentRow = [];
+				currentField = '';
+				i++;
+			} else if (char === '\r' && nextChar === '\n') {
+				// CRLF row delimiter
+				currentRow.push(currentField);
+				if (currentRow.length > 0) {
+					rows.push(currentRow);
+				}
+				currentRow = [];
+				currentField = '';
+				i += 2;
+			} else {
+				// Regular character
+				currentField += char;
+				i++;
+			}
+		}
+	}
+
+	// Handle final field and row
+	if (currentField || currentRow.length > 0) {
+		currentRow.push(currentField);
+		if (currentRow.length > 0) {
+			rows.push(currentRow);
+		}
+	}
+
+	return rows;
+}
+
+/**
+ * Serialize a sheet's columns and rows Y.Maps to a CSV string.
+ *
+ * 1. Sort columns by fractional `order`
+ * 2. Write header row (column names)
+ * 3. Sort rows by fractional `order`
+ * 4. For each row, read cell values by column ID (empty string for missing)
+ * 5. Escape values containing commas, quotes, or newlines (RFC 4180)
+ */
+export function serializeSheetToCsv(
+	columns: Y.Map<Y.Map<string>>,
+	rows: Y.Map<Y.Map<string>>,
+): string {
+	// Collect and sort columns by order
+	const columnEntries: Array<{
+		id: string;
+		colMap: Y.Map<string>;
+		order: number;
+	}> = [];
+	columns.forEach((colMap, colId) => {
+		const orderStr = colMap.get('order') ?? '0';
+		columnEntries.push({
+			id: colId,
+			colMap,
+			order: Number.parseFloat(orderStr),
+		});
+	});
+	columnEntries.sort((a, b) => a.order - b.order);
+
+	// If no columns, return empty string
+	if (columnEntries.length === 0) {
+		return '';
+	}
+
+	// Write header row
+	const headerRow = columnEntries
+		.map((col) => escapeCsvField(col.colMap.get('name') ?? ''))
+		.join(',');
+	const lines: string[] = [headerRow];
+
+	// Collect and sort rows by order
+	const rowEntries: Array<{
+		id: string;
+		rowMap: Y.Map<string>;
+		order: number;
+	}> = [];
+	rows.forEach((rowMap, rowId) => {
+		const orderStr = rowMap.get('order') ?? '0';
+		rowEntries.push({
+			id: rowId,
+			rowMap,
+			order: Number.parseFloat(orderStr),
+		});
+	});
+	rowEntries.sort((a, b) => a.order - b.order);
+
+	// Write data rows
+	for (const row of rowEntries) {
+		const cellValues = columnEntries.map((col) => {
+			const cellValue = row.rowMap.get(col.id) ?? '';
+			return escapeCsvField(cellValue);
+		});
+		lines.push(cellValues.join(','));
+	}
+
+	return `${lines.join('\n')}\n`;
+}
+
+/**
+ * Parse a CSV string and populate columns and rows Y.Maps.
+ *
+ * 1. Parse CSV (handle quoted fields per RFC 4180)
+ * 2. First row = column headers → create column Y.Maps with generated IDs
+ * 3. Subsequent rows → create row Y.Maps with generated IDs
+ * 4. Assign fractional order strings to columns and rows (sequential)
+ */
+export function parseSheetFromCsv(
+	csv: string,
+	columns: Y.Map<Y.Map<string>>,
+	rows: Y.Map<Y.Map<string>>,
+): void {
+	// Handle empty input
+	if (!csv || csv.trim() === '') {
+		return;
+	}
+
+	const parsed = parseCsvRows(csv);
+	if (parsed.length === 0) {
+		return;
+	}
+
+	// First row is headers
+	const headers = parsed[0];
+	if (!headers || headers.length === 0) {
+		return;
+	}
+
+	// Generate column IDs and orders
+	const columnIds = headers.map(() => generateColumnId());
+	const columnOrders = generateInitialOrders(headers.length);
+
+	// Create column Y.Maps
+	for (let i = 0; i < headers.length; i++) {
+		const colMap = new Y.Map<string>();
+		colMap.set('name', headers[i] ?? '');
+		colMap.set('kind', 'text');
+		colMap.set('width', '120');
+		colMap.set('order', String(columnOrders[i]));
+		columns.set(columnIds[i], colMap);
+	}
+
+	// Remaining rows are data
+	const dataRows = parsed.slice(1);
+	if (dataRows.length === 0) {
+		return;
+	}
+
+	const rowOrders = generateInitialOrders(dataRows.length);
+
+	// Create row Y.Maps
+	for (let i = 0; i < dataRows.length; i++) {
+		const rowMap = new Y.Map<string>();
+		rowMap.set('order', String(rowOrders[i]));
+
+		// Set cell values for each column
+		const dataRow = dataRows[i];
+		if (dataRow) {
+			for (let j = 0; j < columnIds.length; j++) {
+				const cellValue = dataRow[j] ?? '';
+				if (cellValue) {
+					rowMap.set(columnIds[j], cellValue);
+				}
+			}
+		}
+
+		rows.set(generateRowId(), rowMap);
+	}
+}
+
+/**
+ * Reorder a row by updating its fractional order property.
+ */
+export function reorderRow(
+	rows: Y.Map<Y.Map<string>>,
+	rowId: string,
+	beforeOrder: number,
+	afterOrder: number,
+): void {
+	const rowMap = rows.get(rowId);
+	if (!rowMap) return;
+	rowMap.set('order', String(computeMidpoint(beforeOrder, afterOrder)));
+}
+
+/**
+ * Reorder a column by updating its fractional order property.
+ */
+export function reorderColumn(
+	columns: Y.Map<Y.Map<string>>,
+	colId: string,
+	beforeOrder: number,
+	afterOrder: number,
+): void {
+	const colMap = columns.get(colId);
+	if (!colMap) return;
+	colMap.set('order', String(computeMidpoint(beforeOrder, afterOrder)));
+}

--- a/packages/filesystem/src/timeline-helpers.test.ts
+++ b/packages/filesystem/src/timeline-helpers.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from 'bun:test';
+import * as Y from 'yjs';
+import { createTimeline } from './timeline-helpers.js';
+
+function setup() {
+	const ydoc = new Y.Doc();
+	return { ydoc, tl: createTimeline(ydoc) };
+}
+
+describe('createTimeline - sheet entries', () => {
+	test('pushSheet creates entry with type sheet', () => {
+		const { tl } = setup();
+		const entry = tl.pushSheet();
+		expect(entry.get('type')).toBe('sheet');
+	});
+
+	test('pushSheet creates empty columns and rows Y.Maps', () => {
+		const { tl } = setup();
+		const entry = tl.pushSheet();
+		const columns = entry.get('columns') as Y.Map<Y.Map<string>>;
+		const rows = entry.get('rows') as Y.Map<Y.Map<string>>;
+		expect(columns).toBeInstanceOf(Y.Map);
+		expect(rows).toBeInstanceOf(Y.Map);
+		expect(columns.size).toBe(0);
+		expect(rows.size).toBe(0);
+	});
+
+	test('pushSheet increments timeline length', () => {
+		const { tl } = setup();
+		expect(tl.length).toBe(0);
+		tl.pushSheet();
+		expect(tl.length).toBe(1);
+	});
+
+	test('currentMode returns sheet after pushSheet', () => {
+		const { tl } = setup();
+		tl.pushSheet();
+		expect(tl.currentMode).toBe('sheet');
+	});
+
+	test('pushSheetFromCsv populates columns from header', () => {
+		const { tl } = setup();
+		tl.pushSheetFromCsv('Name,Age\nAlice,30\n');
+		const entry = tl.currentEntry!;
+		const columns = entry.get('columns') as Y.Map<Y.Map<string>>;
+		expect(columns.size).toBe(2);
+
+		const colArray = Array.from(columns.values());
+		const names = colArray.map((col) => col.get('name')).sort();
+		expect(names).toEqual(['Age', 'Name']);
+	});
+
+	test('pushSheetFromCsv populates rows from data', () => {
+		const { tl } = setup();
+		tl.pushSheetFromCsv('Name,Age\nAlice,30\nBob,25\n');
+		const entry = tl.currentEntry!;
+		const rows = entry.get('rows') as Y.Map<Y.Map<string>>;
+		expect(rows.size).toBe(2);
+	});
+
+	test('readAsString returns CSV for sheet entry', () => {
+		const { tl } = setup();
+		const csv = 'Name,Age\nAlice,30\n';
+		tl.pushSheetFromCsv(csv);
+		expect(tl.readAsString()).toBe(csv);
+	});
+
+	test('readAsBuffer returns encoded CSV for sheet entry', () => {
+		const { tl } = setup();
+		const csv = 'Name,Age\nAlice,30\n';
+		tl.pushSheetFromCsv(csv);
+		const buffer = tl.readAsBuffer();
+		expect(new TextDecoder().decode(buffer)).toBe(csv);
+	});
+
+	test('round-trip: pushSheetFromCsv → readAsString matches original', () => {
+		const { tl } = setup();
+		const originalCsv =
+			'Product,Price,Stock\nWidget,9.99,100\nGadget,24.99,50\n';
+		tl.pushSheetFromCsv(originalCsv);
+		expect(tl.readAsString()).toBe(originalCsv);
+	});
+
+	test('multiple entries: text then sheet then text', () => {
+		const { tl } = setup();
+		tl.pushText('First entry');
+		expect(tl.currentMode).toBe('text');
+		expect(tl.length).toBe(1);
+
+		tl.pushSheet();
+		expect(tl.currentMode).toBe('sheet');
+		expect(tl.length).toBe(2);
+
+		tl.pushText('Third entry');
+		expect(tl.currentMode).toBe('text');
+		expect(tl.length).toBe(3);
+		expect(tl.readAsString()).toBe('Third entry');
+	});
+
+	test('empty sheet returns empty string', () => {
+		const { tl } = setup();
+		tl.pushSheet();
+		expect(tl.readAsString()).toBe('');
+	});
+
+	test('sheet with columns but no rows returns header only', () => {
+		const { tl } = setup();
+		tl.pushSheetFromCsv('A,B,C\n');
+		expect(tl.readAsString()).toBe('A,B,C\n');
+	});
+});

--- a/packages/filesystem/src/types.ts
+++ b/packages/filesystem/src/types.ts
@@ -1,4 +1,4 @@
-import { type Guid, generateGuid } from '@epicenter/hq';
+import { type Guid, generateGuid, generateId, type Id } from '@epicenter/hq';
 import { type } from 'arktype';
 import type { Brand } from 'wellcrafted/brand';
 import type * as Y from 'yjs';
@@ -15,7 +15,16 @@ export type RichTextEntry = {
 	frontmatter: Y.Map<unknown>;
 };
 export type BinaryEntry = { type: 'binary'; content: Uint8Array };
-export type TimelineEntry = TextEntry | RichTextEntry | BinaryEntry;
+export type SheetEntry = {
+	type: 'sheet';
+	columns: Y.Map<Y.Map<string>>;
+	rows: Y.Map<Y.Map<string>>;
+};
+export type TimelineEntry =
+	| TextEntry
+	| RichTextEntry
+	| BinaryEntry
+	| SheetEntry;
 
 /** Content modes supported by timeline entries */
 export type ContentMode = TimelineEntry['type'];
@@ -31,6 +40,40 @@ export const FileId = type('string').pipe((s): FileId => s as FileId);
 export function generateFileId(): FileId {
 	return generateGuid() as FileId;
 }
+
+/** Branded row identifier — a 10-char nanoid that is specifically a row ID */
+export type RowId = Id & Brand<'RowId'>;
+
+/** Generate a new unique row identifier */
+export function generateRowId(): RowId {
+	return generateId() as RowId;
+}
+
+/** Branded column identifier — a 10-char nanoid that is specifically a column ID */
+export type ColumnId = Id & Brand<'ColumnId'>;
+
+/** Generate a new unique column identifier */
+export function generateColumnId(): ColumnId {
+	return generateId() as ColumnId;
+}
+
+/**
+ * Column definition stored in a column Y.Map.
+ *
+ * This type documents the expected shape but cannot be enforced at runtime
+ * since Y.Maps are dynamic key-value stores. Use defensive reading with
+ * defaults when accessing column properties.
+ */
+export type ColumnDefinition = {
+	/** Display name of the column */
+	name: string;
+	/** Column kind determines cell value interpretation */
+	kind: 'text' | 'number' | 'date' | 'select' | 'boolean';
+	/** Display width in pixels (stored as string) */
+	width: string;
+	/** Fractional index for column ordering */
+	order: string;
+};
 
 /** File metadata row derived from the files table definition */
 export type FileRow = InferTableRow<typeof filesTable>;

--- a/specs/20260214T174800-sheet-timeline-entry.md
+++ b/specs/20260214T174800-sheet-timeline-entry.md
@@ -1,0 +1,599 @@
+# Sheet Timeline Entry
+
+**Date**: 2026-02-14
+**Status**: Draft
+**Extends**: `specs/20260211T230000-timeline-content-storage-implementation.md`
+
+---
+
+## Overview
+
+Add a `sheet` content mode to the per-file Y.Doc timeline. A sheet entry stores tabular data as nested Y.Maps — columns for definitions, rows for cell values — with all values as strings. Row and column ordering uses fractional indexing (property updates, not Y.Array position). Serializes to/from CSV for the filesystem `readFile`/`writeFile` interface.
+
+---
+
+## Motivation
+
+### Current State
+
+The timeline supports three content modes:
+
+```typescript
+type TextEntry    = { type: 'text';     content: Y.Text };
+type RichTextEntry = { type: 'richtext'; content: Y.XmlFragment; frontmatter: Y.Map<unknown> };
+type BinaryEntry  = { type: 'binary';   content: Uint8Array };
+```
+
+These handle text files and rich documents, but there's no structured tabular format. A user wanting spreadsheet-like data must either:
+
+1. Store CSV as a plain text entry (no cell-level collaboration, no column metadata)
+2. Store JSON as a plain text entry (same problems)
+
+### Problems
+
+1. **No cell-level collaboration**: Two users editing the same CSV string causes full-text conflicts. There's no way to merge concurrent cell edits.
+2. **No column semantics**: A text entry doesn't know that column 3 is "Price" and should display as a number. Metadata lives nowhere.
+3. **No structured reordering**: Reordering rows in a text file means rewriting the entire string.
+
+### Desired State
+
+A file with content mode `sheet` stores tabular data with:
+- Cell-level CRDT collaboration (concurrent edits to different cells merge cleanly)
+- Column definitions (name, kind, width, order)
+- Row ordering via fractional indexing (drag-and-drop reorder = single property update)
+- Transparent CSV serialization for the POSIX filesystem interface
+
+---
+
+## Research Findings
+
+### How Production Yjs Apps Store Tabular Data
+
+| Project | Cell Storage | Row Ordering | Cell Values |
+|---------|-------------|--------------|-------------|
+| **BlockSuite / AFFiNE** | Flat Y.Map, compound keys `rowId:colId` | Separate order property | Y.Text per cell |
+| **AppFlowy** | Per-row Y.Doc, nested `Y.Map<fieldId, Y.Map>` | Y.Array + delete/insert (antipattern) | Mixed types per cell |
+| **Univer** | Nested `Record<row, Record<col, ICellData>>` | Positional indices | Object per cell |
+
+### Yjs Maintainer Recommendations
+
+Source: [Yjs DeepWiki](https://deepwiki.com/yjs/yjs), maintainer guidance.
+
+| Pattern | Recommendation | Rationale |
+|---------|---------------|-----------|
+| `Y.Map<rowId, Y.Map<colId, value>>` | **Recommended** | `observeDeep` gives structured paths. Row deletion cascades. |
+| `Y.Array<Y.Map>` | For append-only | Good when order is creation order. Bad for reordering (delete+insert). |
+| Flat `Y.Map` with compound keys | **Not recommended** | Re-keying on positional row insert. (Not applicable with UUID keys.) |
+| Row/column reordering | **Fractional indexing** | Y.Array move = delete+insert = lost updates + duplicates. Property update = clean merge. |
+
+**Key finding**: Nested Y.Maps with fractional indexing is the consensus approach. AppFlowy's Y.Array reorder is the known antipattern — their `reorderRow` does `rows.delete(sourceIndex)` then `rows.insert(adjustedTargetIndex)`, exactly what the [fractional ordering article](../docs/articles/fractional-ordering-meta-data-structure.md) warns against.
+
+**Implication**: Use `Y.Map<rowId, Y.Map>` for rows, fractional index as a string property on each row/column Y.Map.
+
+---
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Cell value type | Always `string` | Simplest CRDT layer. Interpretation (number, date, boolean) is a column `kind` hint. Parse on read, stringify on write. Google Sheets does the same. |
+| Row ordering | Fractional indexing (string property `order`) | Y.Array reorder = delete+insert = lost updates + duplicates. Property update is atomic. Already documented in `docs/articles/fractional-ordering-meta-data-structure.md`. |
+| Column ordering | Fractional indexing (string property `order`) | Same rationale as row ordering. |
+| Row/column IDs | 10-char nanoid via `generateId()` | Stable across concurrent edits. No positional re-keying. Uses existing `generateId()` from `@epicenter/hq` (10-char alphanumeric, safe for millions of rows). Branded types `RowId` and `ColumnId`. No prefixes (raw nanoid strings). |
+| Column definition versioning | No `_v` field | Y.Maps allow atomic field updates, making object-level versioning misleading. Use defensive reading (provide defaults for missing fields) + strict writing (always set all current schema fields). Additive changes (new optional fields) are safe without versioning. |
+| Column defs location | Nested Y.Map on the timeline entry | Co-located with data. No external schema reference needed. |
+| `order` as reserved key | Yes, on row Y.Map | Column IDs are nanoid-generated (e.g., `k7x9m2p4q8`), never the literal string `"order"`. No collision possible. |
+| Column kind key name | `kind` (not `type`) | Avoids collision with the timeline entry's `type` discriminant. |
+| Column kind values | Plain strings without version suffixes | `'text'`, `'number'`, `'date'`, `'select'`, `'boolean'`. New kinds can be added later non-breaking. |
+| Nesting strategy | `Y.Map<rowId, Y.Map>` | Yjs-recommended. `observeDeep` gives `[rowId, colId]` paths. Row delete = one `rows.delete(rowId)` call. |
+| CSV as filesystem serialization | Yes | Natural plain-text representation. `readFile` returns CSV string. `writeFile` with CSV string populates cells. |
+| CSV parsing implementation | Hand-rolled RFC 4180 parser | ~100 lines, full control, no external dependency. Handles quoted fields, escaping, newlines. |
+| Malformed CSV handling | Refuse to parse OR fall back to text mode | If CSV parsing fails, either leave columns/rows empty (caller can detect) or push a new text entry instead. Never silently corrupt data. |
+| Entry placement | On the timeline Y.Array, like all other modes | Consistent with existing architecture. Mode switching (text → sheet → text) works via timeline append. |
+
+---
+
+## Architecture
+
+### Y.Doc Structure (per file)
+
+```
+Y.Doc (guid = fileId, gc: false)
+└── Y.Array('timeline')
+    └── Y.Map (sheet entry)                    ← last entry = current version
+        │
+        ├── 'type': 'sheet'                    ← discriminant (string)
+        │
+        ├── 'columns': Y.Map                   ← column definitions
+        │     └── <colId>: Y.Map               ← one per column
+        │           ├── 'name':  string        ← display name ("Price")
+        │           ├── 'kind':  string        ← interpretation ("text"|"number"|"date"|"select"|"boolean")
+        │           ├── 'width': string        ← display width in px ("120")
+        │           └── 'order': string        ← fractional index for ordering ("a1")
+        │
+        └── 'rows': Y.Map                      ← row data
+              └── <rowId>: Y.Map               ← one per row
+                    ├── 'order':    string      ← RESERVED: fractional index ("a0V")
+                    ├── <colId_1>:  string      ← cell value ("42.50")
+                    ├── <colId_2>:  string      ← cell value ("In Stock")
+                    └── ...                     ← sparse: missing key = empty cell
+```
+
+### How It Fits in the Timeline
+
+```
+Timeline Y.Array (existing)
+│
+├── Y.Map { type: 'text',     content: Y.Text }                    ← existing
+├── Y.Map { type: 'richtext', content: Y.XmlFragment, frontmatter: Y.Map }  ← existing
+├── Y.Map { type: 'binary',   content: Uint8Array }                ← existing
+└── Y.Map { type: 'sheet',    columns: Y.Map, rows: Y.Map }       ← NEW
+```
+
+Mode switching works identically to existing modes. Converting a text file to a sheet appends a new sheet entry. Converting back appends a new text entry. The timeline grows; previous entries are preserved (revision history with `gc: false`).
+
+### Key Architectural Insights
+
+These design choices enable efficient collaborative editing and demonstrate fundamental CRDT patterns:
+
+#### 1. Two-Map Efficiency: No Separate Cells Map Needed
+
+The architecture uses only two top-level Y.Maps (`columns` and `rows`), yet supports full spreadsheet functionality:
+
+- **Column definitions** live in `columns` Y.Map (metadata: name, kind, width, order)
+- **Cell values** are nested properties within each row's Y.Map, keyed by column ID
+- No separate "cells" map needed—sparse storage works naturally (missing keys = empty cells)
+- Row deletion cascades automatically: `rows.delete(rowId)` removes all cells in that row
+
+This sparse nested structure is more efficient than a flat `cells` Y.Map with compound keys like `rowId:colId` because:
+- Row operations (delete, reorder) touch one Y.Map entry, not N cells
+- Empty cells cost zero bytes (no keys stored)
+- `observeDeep` gives structured paths (see insight #5)
+
+#### 2. Stable IDs Prevent Re-keying Hell
+
+Row and column IDs are generated via `generateId()` (10-char nanoid) and never change:
+
+- When columns reorder, IDs stay stable → cell keys in rows remain valid
+- When rows reorder, IDs stay stable → no cascading updates
+- Concurrent column addition = different UUIDs = no conflicts
+- No positional re-keying like flat maps with numeric indices
+
+**Example**: Reordering column B between A and C only changes column B's `order` property. All row Y.Maps still reference cells via the same column IDs. Zero re-keying.
+
+#### 3. Fractional Ordering Eliminates Y.Array Antipatterns
+
+Using an `order` property (not Y.Array position) for row/column ordering avoids the delete+insert antipattern documented in `docs/articles/fractional-ordering-meta-data-structure.md`:
+
+**Y.Array move pattern (WRONG)**:
+```typescript
+rows.delete(sourceIndex);        // Deletes the row Y.Map
+rows.insert(targetIndex, row);   // Inserts a new Y.Map
+// Result: Lost updates (concurrent edits to deleted row vanish)
+//         Duplicates (concurrent moves = multiple inserts)
+```
+
+**Fractional order pattern (CORRECT)**:
+```typescript
+row.set('order', computeMidpoint(beforeRow, afterRow));
+// Result: Single property update, clean CRDT merge
+```
+
+The `order` property is the ONLY positional data. The underlying Y.Map key order is irrelevant. This applies to both row AND column reordering.
+
+#### 4. Reserved Key Safety: `order` Never Collides
+
+The `order` key in row Y.Maps is safe because column IDs are nanoid-generated:
+
+- Column IDs look like: `k7x9m2p4q8`, `abc123xyz7`, `p2q4r6s8t0`
+- The literal string `"order"` will never be generated by nanoid with the `[a-z0-9]` alphabet
+- No collision possible, no need for namespacing like `_order` or `meta:order`
+
+#### 5. observeDeep Structured Paths Enable Cell-Level Tracking
+
+The nested `Y.Map<rowId, Y.Map<colId, value>>` structure gives structured paths in `observeDeep` events:
+
+```typescript
+sheetEntry.observeDeep((events) => {
+  for (const event of events) {
+    console.log(event.path);
+    // ['rows', 'k7x9m2p4q8', 'abc123xyz7']  → Cell (row k7x9..., col abc1...)
+    // ['rows', 'k7x9m2p4q8', 'order']       → Row reorder
+    // ['columns', 'abc123xyz7', 'name']     → Column rename
+    // ['columns', 'abc123xyz7', 'order']    → Column reorder
+  }
+});
+```
+
+This enables:
+- Listening to specific cells without iterating all changes
+- Filtering for row-level vs column-level events
+- Building efficient UI update logic (only re-render affected cells)
+
+Contrast with a flat `cells` Y.Map with compound keys (`rowId:colId`): `observeDeep` paths would be `['cells', 'k7x9m2p4q8:abc123xyz7']`, requiring string parsing to extract row/column IDs.
+
+### Example: 3-Column, 2-Row Sheet
+
+```
+Y.Map (entry)
+├── type: 'sheet'
+├── columns: Y.Map
+│     ├── 'k7x9m2p4q8': Y.Map { name: 'Product',  kind: 'text',    width: '200', order: 'a0' }
+│     ├── 'abc123xyz7': Y.Map { name: 'Price',    kind: 'number',  width: '100', order: 'a1' }
+│     └── 'p2q4r6s8t0': Y.Map { name: 'In Stock', kind: 'boolean', width: '80',  order: 'a2' }
+├── rows: Y.Map
+│     ├── 'm3n5p7q9r1': Y.Map { order: 'a0', k7x9m2p4q8: 'Widget',  abc123xyz7: '9.99',  p2q4r6s8t0: 'true' }
+│     └── 's1t3u5v7w9': Y.Map { order: 'a1', k7x9m2p4q8: 'Gadget',  abc123xyz7: '24.99', p2q4r6s8t0: 'false' }
+```
+
+Serialized as CSV via `readFile`:
+
+```csv
+Product,Price,In Stock
+Widget,9.99,true
+Gadget,24.99,false
+```
+
+---
+
+## TypeScript Types
+
+### Row and Column IDs
+
+Added to `packages/filesystem/src/types.ts`:
+
+```typescript
+import { type Id, generateId } from '@epicenter/hq';
+import type { Brand } from 'wellcrafted/brand';
+
+/** Branded row identifier — a 10-char nanoid that is specifically a row ID */
+export type RowId = Id & Brand<'RowId'>;
+
+/** Generate a new unique row identifier */
+export function generateRowId(): RowId {
+  return generateId() as RowId;
+}
+
+/** Branded column identifier — a 10-char nanoid that is specifically a column ID */
+export type ColumnId = Id & Brand<'ColumnId'>;
+
+/** Generate a new unique column identifier */
+export function generateColumnId(): ColumnId {
+  return generateId() as ColumnId;
+}
+```
+
+**Why 10-char IDs?** `generateId()` from `@epicenter/hq` produces 10-character alphanumeric strings (alphabet: `a-z0-9`), safe for ~85 million entities with 1-in-a-million collision chance. Both rows and columns are table-scoped, not globally unique, so 10 chars is sufficient.
+
+**Why branded types?** Prevents accidentally using a `RowId` where a `ColumnId` is expected at compile time. Follows the existing `FileId` pattern in the codebase.
+
+**Why no prefixes?** Raw nanoid strings (e.g., `k7x9m2p4q8`) are sufficient. Prefixes like `row_` or `col_` add visual clutter without functional benefit since TypeScript enforces type safety.
+
+### Sheet Entry
+
+Added to `packages/filesystem/src/types.ts`:
+
+```typescript
+export type SheetEntry = {
+  type: 'sheet';
+  columns: Y.Map<Y.Map<string>>;
+  rows: Y.Map<Y.Map<string>>;
+};
+
+export type TimelineEntry = TextEntry | RichTextEntry | BinaryEntry | SheetEntry;
+```
+
+Updated `ContentMode`:
+
+```typescript
+export type ContentMode = TimelineEntry['type']; // 'text' | 'richtext' | 'binary' | 'sheet'
+```
+
+### Column Definition (Type-Level Documentation)
+
+The column definition shape stored in each column Y.Map:
+
+```typescript
+/**
+ * Column definition stored in a column Y.Map.
+ * 
+ * This type documents the expected shape but cannot be enforced at runtime
+ * since Y.Maps are dynamic key-value stores. Use defensive reading with
+ * defaults when accessing column properties.
+ */
+export type ColumnDefinition = {
+  /** Display name of the column */
+  name: string;
+  
+  /** Column kind determines cell value interpretation */
+  kind: 'text' | 'number' | 'date' | 'select' | 'boolean';
+  
+  /** Display width in pixels (stored as string) */
+  width: string;
+  
+  /** Fractional index for column ordering (e.g., "a0", "a1", "a0V") */
+  order: string;
+};
+```
+
+**No `_v` version field**: Column definitions do not include a version field. Use defensive reading (provide defaults for missing fields) and strict writing (always set all current schema fields). Additive changes (new optional fields) are safe without versioning. See Design Decisions for rationale.
+
+---
+
+## Timeline Helper Additions
+
+New functions in `packages/filesystem/src/timeline-helpers.ts`:
+
+### pushSheet
+
+```typescript
+/** Create and append a new empty sheet entry. Returns the Y.Map. */
+pushSheet(): Y.Map<any> {
+  const entry = new Y.Map();
+  entry.set('type', 'sheet');
+  entry.set('columns', new Y.Map());
+  entry.set('rows', new Y.Map());
+  timeline.push([entry]);
+  return entry;
+}
+```
+
+### pushSheetFromCsv
+
+```typescript
+/**
+ * Create a sheet entry from a CSV string.
+ * First row is treated as column headers. Column IDs are generated.
+ * All cell values are stored as strings.
+ */
+pushSheetFromCsv(csv: string): Y.Map<any>
+```
+
+### readAsString (updated switch)
+
+```typescript
+case 'sheet':
+  return serializeSheetToCsv(
+    entry.get('columns') as Y.Map<Y.Map<string>>,
+    entry.get('rows') as Y.Map<Y.Map<string>>,
+  );
+```
+
+### readAsBuffer (updated switch)
+
+```typescript
+case 'sheet':
+  return new TextEncoder().encode(
+    serializeSheetToCsv(
+      entry.get('columns') as Y.Map<Y.Map<string>>,
+      entry.get('rows') as Y.Map<Y.Map<string>>,
+    ),
+  );
+```
+
+---
+
+## Sheet Helpers
+
+New file: `packages/filesystem/src/sheet-helpers.ts`
+
+### serializeSheetToCsv
+
+```typescript
+/**
+ * Serialize a sheet's columns and rows Y.Maps to a CSV string.
+ *
+ * 1. Sort columns by fractional `order`
+ * 2. Write header row (column names)
+ * 3. Sort rows by fractional `order`
+ * 4. For each row, read cell values by column ID (empty string for missing)
+ * 5. Escape values containing commas, quotes, or newlines (RFC 4180)
+ */
+export function serializeSheetToCsv(
+  columns: Y.Map<Y.Map<string>>,
+  rows: Y.Map<Y.Map<string>>,
+): string
+```
+
+### parseSheetFromCsv
+
+```typescript
+/**
+ * Parse a CSV string and populate columns and rows Y.Maps.
+ *
+ * 1. Parse CSV (handle quoted fields per RFC 4180)
+ * 2. First row = column headers → create column Y.Maps with generated IDs
+ * 3. Subsequent rows → create row Y.Maps with generated IDs
+ * 4. Assign fractional order strings to columns and rows (sequential)
+ */
+export function parseSheetFromCsv(
+  csv: string,
+  columns: Y.Map<Y.Map<string>>,
+  rows: Y.Map<Y.Map<string>>,
+): void
+```
+
+### RFC 4180 CSV Compliance
+
+- Fields containing `,`, `"`, or `\n` are enclosed in double quotes
+- Double quotes inside fields are escaped as `""`
+- Newline is `\n` (Unix)
+- Empty trailing fields are preserved
+
+---
+
+## ContentOps Changes
+
+In `packages/filesystem/src/content-ops.ts`:
+
+### write (updated)
+
+```typescript
+// After existing text/binary handling:
+if (typeof data === 'string' && tl.currentMode === 'sheet') {
+  // Writing a string to a sheet file: parse as CSV, update in place
+  const columns = tl.currentEntry!.get('columns') as Y.Map<Y.Map<string>>;
+  const rows = tl.currentEntry!.get('rows') as Y.Map<Y.Map<string>>;
+  ydoc.transact(() => {
+    // Clear existing data
+    columns.forEach((_, key) => columns.delete(key));
+    rows.forEach((_, key) => rows.delete(key));
+    parseSheetFromCsv(data, columns, rows);
+  });
+  return new TextEncoder().encode(data).byteLength;
+}
+```
+
+Writing a string to a sheet mode file re-parses the CSV and updates cells in place (same-mode write, timeline doesn't grow). Writing a `Uint8Array` to a sheet file mode-switches to binary (pushes new entry, timeline grows).
+
+---
+
+## Edge Cases
+
+### Empty Sheet
+
+A sheet with zero columns and zero rows serializes to an empty string `""`. This is consistent with `readFile` returning `""` for empty text entries.
+
+### CSV with No Data Rows
+
+A CSV with only a header row creates column definitions but zero rows. `readFile` returns just the header: `"Product,Price,In Stock\n"`.
+
+### Cells Referencing Deleted Columns
+
+If a column is deleted (`columns.delete(colId)`), row Y.Maps may still contain keys for that column ID. These orphaned cell values are:
+- Ignored during CSV serialization (only columns in `columns` Y.Map are iterated)
+- Harmless with `gc: false` (no cleanup needed, they're just unused keys)
+- Automatically excluded from any column-aware UI
+
+### Concurrent Row Reorder
+
+Two users move different rows to the same position simultaneously. Both compute the same fractional index midpoint, but with jitter (per the fractional indexing pattern), they get slightly different `order` values. Both rows appear near the target position. No duplicates, no lost data.
+
+### Concurrent Column Addition
+
+Two users add a column at the same time. Both create a new entry in the `columns` Y.Map with different UUIDs. Both columns appear. Y.Map handles concurrent `set` on different keys cleanly.
+
+### Mode Switching: Text → Sheet
+
+`writeFile("file.csv", csvString)` when the current mode is `text`:
+- Since the current mode is text and data is a string, this edits the existing Y.Text (existing behavior)
+- To create a sheet entry, the UI layer must explicitly push a sheet entry onto the timeline
+- The filesystem `writeFile` does NOT auto-detect CSV and switch modes
+
+### Mode Switching: Sheet → Text
+
+If a sheet entry is current and the user wants plain text, the UI pushes a new text entry. The sheet entry is preserved in the timeline for history.
+
+---
+
+## Resolved Questions
+
+All open questions have been resolved through implementation discussion.
+
+1. **Should `writeFile` with a CSV-like string auto-detect and create a sheet entry?**
+   - **Decision**: Explicit API only (option c). The UI layer calls `pushSheet` or `pushSheetFromCsv` directly. `writeFile` on a sheet-mode file re-parses CSV in place.
+
+2. **Should column `kind` support a fixed set of values or be freeform?**
+   - **Decision**: Fixed set, extensible later (option c). Column kinds are plain strings: `'text'`, `'number'`, `'date'`, `'select'`, `'boolean'`. No version suffixes on kind values. New kinds can be added non-breaking since they're stored as strings.
+
+3. **Should we use the `fractional-indexing` library or simple numeric midpoints?**
+   - **Decision**: Simple numeric midpoints with randomness (option b) for initial implementation. Uses the pattern from `docs/articles/fractional-ordering-meta-data-structure.md`. Migration path to library exists if precision becomes an issue (unlikely for typical usage).
+
+4. **CSV header row: column names or column IDs?**
+   - **Decision**: Column names (option a). CSV is for human consumption via the POSIX filesystem. Round-trip fidelity for programmatic use goes through the Y.Doc directly.
+
+5. **Should the sheet entry support a `meta` Y.Map for sheet-level properties?**
+   - **Decision**: Omit entirely for now. Do not add the key, do not reserve it in types. Add later when needed.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Types and Sheet Helpers
+
+- [ ] **1.1** Add `RowId`, `ColumnId` branded types and generator functions to `types.ts`
+- [ ] **1.2** Add `SheetEntry` type to `types.ts`, update `TimelineEntry` union and `ContentMode`
+- [ ] **1.3** Add `ColumnDefinition` type (type-level documentation, not enforced at runtime)
+- [ ] **1.4** Create `sheet-helpers.ts` with `serializeSheetToCsv` and `parseSheetFromCsv`
+- [ ] **1.5** Add CSV escaping/parsing per RFC 4180 (hand-rolled, handle commas, quotes, newlines in cell values)
+- [ ] **1.6** Unit tests for `serializeSheetToCsv` (empty sheet, single row, special characters, column ordering)
+- [ ] **1.7** Unit tests for `parseSheetFromCsv` (basic CSV, quoted fields, empty cells, round-trip, malformed CSV handling)
+
+### Phase 2: Timeline Integration
+
+- [ ] **2.1** Add `pushSheet()` and `pushSheetFromCsv(csv)` to `createTimeline()` in `timeline-helpers.ts`
+- [ ] **2.2** Update `readAsString()` switch to handle `'sheet'` → CSV serialization
+- [ ] **2.3** Update `readAsBuffer()` switch to handle `'sheet'` → CSV encoded as Uint8Array
+- [ ] **2.4** Unit tests for timeline push/read round-trip
+
+### Phase 3: ContentOps Integration
+
+- [ ] **3.1** Update `ContentOps.write()` to handle string writes to sheet-mode files (re-parse CSV in place)
+- [ ] **3.2** Update `ContentOps.read()` to return CSV string for sheet-mode files
+- [ ] **3.3** Integration tests via `YjsFileSystem`: write CSV → read back, verify cell-level storage
+
+### Phase 4: Fractional Indexing
+
+- [ ] **4.1** Implement simple numeric midpoints with randomness (pattern from `docs/articles/fractional-ordering-meta-data-structure.md`)
+- [ ] **4.2** Wire fractional index generation into `parseSheetFromCsv` (initial order assignment for columns and rows)
+- [ ] **4.3** Expose reorder helpers: `reorderRow(rowId, beforeRowId)`, `reorderColumn(colId, beforeColId)`
+- [ ] **4.4** Unit tests for concurrent reorder scenarios (verify no duplicates, no lost updates)
+
+### Phase 5: Sheet Editor UI (future, out of scope)
+
+- [ ] **5.1** Sheet component that binds to the `columns` and `rows` Y.Maps
+- [ ] **5.2** Cell editing with `observeDeep` for real-time collaboration
+- [ ] **5.3** Column/row add, delete, reorder via UI
+
+---
+
+## Success Criteria
+
+- [ ] `SheetEntry` type exists and is part of `TimelineEntry` union
+- [ ] `serializeSheetToCsv` produces RFC 4180-compliant CSV
+- [ ] `parseSheetFromCsv` correctly populates Y.Maps from CSV input
+- [ ] `createTimeline().pushSheet()` creates a valid sheet entry on the timeline
+- [ ] `createTimeline().pushSheetFromCsv(csv)` creates a populated sheet entry
+- [ ] `readAsString()` on a sheet entry returns CSV
+- [ ] Round-trip: CSV → pushSheetFromCsv → readAsString → original CSV (modulo column ID generation)
+- [ ] All existing timeline tests pass unchanged
+- [ ] `bun test packages/filesystem/` passes
+
+---
+
+## v14 Forward Compatibility
+
+Same structural mapping as the existing timeline spec:
+
+```
+v13 (this spec)                            v14 (future)
+──────────────────────────────────         ──────────────────────────────────
+Y.Map (sheet entry)                        Y.Type (sheet entry)
+├── .get('type')       → 'sheet'           ├── .getAttr('type')       → 'sheet'
+├── .get('columns')    → Y.Map             ├── .getAttr('columns')    → Y.Type
+│     └── Y.Map (col def)                  │     └── Y.Type (col def)
+└── .get('rows')       → Y.Map             └── .getAttr('rows')       → Y.Type
+      └── Y.Map (row data)                       └── Y.Type (row data)
+```
+
+Migration is confined to `timeline-helpers.ts` and `sheet-helpers.ts`. Consumer code is insulated.
+
+---
+
+## References
+
+- `packages/filesystem/src/types.ts` — TimelineEntry union (add SheetEntry here)
+- `packages/filesystem/src/timeline-helpers.ts` — Timeline factory (add pushSheet, update read switches)
+- `packages/filesystem/src/content-ops.ts` — Content I/O (update write for sheet mode)
+- `specs/20260211T230000-timeline-content-storage-implementation.md` — Parent spec (this extends it)
+- `docs/articles/fractional-ordering-meta-data-structure.md` — Fractional indexing pattern (use for row/column order)
+
+---
+
+## Spec Lineage
+
+| Spec | Relationship |
+|------|-------------|
+| `specs/20260211T230000-timeline-content-storage-implementation.md` | **Parent** — this spec adds a new entry type to that timeline |
+| `specs/20260211T220000-yjs-content-doc-multi-mode-research.md` | **Context** — decision record for the timeline approach |
+| `docs/articles/fractional-ordering-meta-data-structure.md` | **Pattern** — fractional indexing used for row/column ordering |


### PR DESCRIPTION
The timeline currently supports text, richtext, and binary content modes. If you want spreadsheet-like data, your only option is storing CSV as a plain text entry — which means two users editing different cells cause full-text merge conflicts, there's no column metadata, and reordering rows means rewriting the entire string. This PR adds a `sheet` content mode that stores tabular data as nested Y.Maps, giving cell-level CRDT collaboration out of the box.

We chose nested `Y.Map<rowId, Y.Map<colId, value>>` over flat compound keys or Y.Array — this is the Yjs-recommended pattern. Row/column ordering uses fractional indexing (property updates) instead of Y.Array position to avoid the delete+insert antipattern that causes lost updates and duplicates during concurrent reorders.

### Storage Structure

```
Y.Doc (per file)
└── Y.Array('timeline')
    └── Y.Map (sheet entry)
        ├── 'type': 'sheet'
        ├── 'columns': Y.Map
        │     └── <colId>: Y.Map { name, kind, width, order }
        └── 'rows': Y.Map
              └── <rowId>: Y.Map { order, <colId>: cellValue, ... }
```

The `order` key on row Y.Maps is safe as a reserved key because column IDs are nanoid-generated (`k7x9m2p4q8`) — the literal string `"order"` can never collide. Empty cells cost zero bytes (sparse storage, missing keys = empty).

### API

Creating and reading sheets on the timeline:

```typescript
const tl = createTimeline(ydoc);

// Create from CSV
tl.pushSheetFromCsv('Product,Price\nWidget,9.99\nGadget,24.99\n');

// Read back as CSV
tl.readAsString(); // "Product,Price\nWidget,9.99\nGadget,24.99\n"

// Create empty, populate programmatically
const entry = tl.pushSheet();
const columns = entry.get('columns');
const rows = entry.get('rows');
```

Reordering is a single property update instead of delete+insert:

```typescript
// WRONG: Y.Array move = delete+insert = lost updates + duplicates
rows.delete(sourceIndex);
rows.insert(targetIndex, row);

// CORRECT: fractional order update = clean CRDT merge
reorderRow(rows, rowId, beforeOrder, afterOrder);
```

Writing a CSV string to a sheet-mode file re-parses in place (the timeline doesn't grow). Writing binary data triggers a mode switch to binary (the timeline grows):

```typescript
const content = new ContentOps();
await content.write(fileId, 'X,Y\n3,4\n');  // sheet stays sheet, re-parses CSV
await content.write(fileId, new Uint8Array([0xff]));  // mode-switches to binary
```

### New Types

```typescript
type SheetEntry = { type: 'sheet'; columns: Y.Map<Y.Map<string>>; rows: Y.Map<Y.Map<string>> };
type RowId = Id & Brand<'RowId'>;       // 10-char nanoid
type ColumnId = Id & Brand<'ColumnId'>; // 10-char nanoid
type ColumnDefinition = { name: string; kind: 'text'|'number'|'date'|'select'|'boolean'; width: string; order: string };
```

`RowId` and `ColumnId` are branded types following the existing `FileId` pattern — prevents accidentally swapping row and column IDs at compile time.

### CSV Implementation

Hand-rolled RFC 4180 parser (~100 lines, no dependency). Handles quoted fields, escaped double quotes, and newlines within cell values. Round-trips cleanly: `CSV → parseSheetFromCsv → serializeSheetToCsv → identical CSV`.

Spec: `specs/20260214T174800-sheet-timeline-entry.md`