### PR TITLE
feat(tab-manager): collapsible window groups, overlay hover actions, and URL tooltips

### DIFF
--- a/apps/tab-manager/src/lib/components/FlatTabList.svelte
+++ b/apps/tab-manager/src/lib/components/FlatTabList.svelte
@@ -59,12 +59,12 @@
 			<button
 				type="button"
 				onclick={() => toggleWindow(item.window.id)}
-				class="sticky top-0 z-10 flex w-full cursor-pointer items-center gap-2 border-b bg-muted/50 px-4 py-2 text-xs text-muted-foreground backdrop-blur transition hover:bg-muted/80"
+				class="sticky top-0 z-10 flex w-full cursor-pointer items-center gap-2 border-b bg-muted/50 px-4 py-2 text-sm text-muted-foreground backdrop-blur transition hover:bg-muted/80"
 			>
 				<ChevronRightIcon
-					class={cn('size-3 shrink-0 transition', isExpanded && 'rotate-90')}
+					class={cn('size-4 shrink-0 transition', isExpanded && 'rotate-90')}
 				/>
-				<AppWindowIcon class="size-3 shrink-0" />
+				<AppWindowIcon class="size-4 shrink-0" />
 				<span class="truncate">
 					{#if displayTab?.title}
 						{displayTab.title}
@@ -73,11 +73,9 @@
 					{/if}
 				</span>
 				{#if item.window.focused}
-					<Badge variant="secondary" class="ml-auto shrink-0 px-1.5 py-0 text-[10px]">
-						focused
-					</Badge>
+					<Badge variant="secondary" class="ml-auto shrink-0">focused</Badge>
 				{/if}
-				<Badge variant="outline" class="shrink-0 px-1.5 py-0 text-[10px]">
+				<Badge variant="outline" class="shrink-0">
 					{windowTabs.length}
 				</Badge>
 			</button>

--- a/apps/tab-manager/src/lib/components/FlatTabList.svelte
+++ b/apps/tab-manager/src/lib/components/FlatTabList.svelte
@@ -50,35 +50,35 @@
 				: `tab-${item.tab.id}`}
 	>
 		{#snippet children(item)}
-		{#if item.kind === 'window'}
-			{@const windowTabs = browserState.tabsByWindow(item.window.id)}
-			{@const activeTab = windowTabs.find((t) => t.active)}
-			{@const firstTab = windowTabs[0]}
-			{@const displayTab = activeTab || firstTab}
-			{@const isExpanded = expandedWindows.has(item.window.id)}
-			<button
-				type="button"
-				onclick={() => toggleWindow(item.window.id)}
-				class="sticky top-0 z-10 flex w-full cursor-pointer items-center gap-2 border-b bg-muted/50 px-4 py-2 text-sm text-muted-foreground backdrop-blur transition hover:bg-muted/80"
-			>
-				<ChevronRightIcon
-					class={cn('size-4 shrink-0 transition', isExpanded && 'rotate-90')}
-				/>
-				<AppWindowIcon class="size-4 shrink-0" />
-				<span class="truncate">
-					{#if displayTab?.title}
-						{displayTab.title}
-					{:else}
-						Window
+			{#if item.kind === 'window'}
+				{@const windowTabs = browserState.tabsByWindow(item.window.id)}
+				{@const activeTab = windowTabs.find((t) => t.active)}
+				{@const firstTab = windowTabs[0]}
+				{@const displayTab = activeTab || firstTab}
+				{@const isExpanded = expandedWindows.has(item.window.id)}
+				<button
+					type="button"
+					onclick={() => toggleWindow(item.window.id)}
+					class="sticky top-0 z-10 flex w-full cursor-pointer items-center gap-2 border-b bg-muted/50 px-4 py-2 text-sm text-muted-foreground backdrop-blur transition hover:bg-muted/80"
+				>
+					<ChevronRightIcon
+						class={cn('size-4 shrink-0 transition', isExpanded && 'rotate-90')}
+					/>
+					<AppWindowIcon class="size-4 shrink-0" />
+					<span class="truncate">
+						{#if displayTab?.title}
+							{displayTab.title}
+						{:else}
+							Window
+						{/if}
+					</span>
+					{#if item.window.focused}
+						<Badge variant="secondary" class="ml-auto shrink-0">focused</Badge>
 					{/if}
-				</span>
-				{#if item.window.focused}
-					<Badge variant="secondary" class="ml-auto shrink-0">focused</Badge>
-				{/if}
-				<Badge variant="outline" class="shrink-0">
-					{windowTabs.length}
-				</Badge>
-			</button>
+					<Badge variant="outline" class="shrink-0">
+						{windowTabs.length}
+					</Badge>
+				</button>
 			{:else}
 				<div class="border-b border-border">
 					<TabItem tab={item.tab} />

--- a/apps/tab-manager/src/lib/components/FlatTabList.svelte
+++ b/apps/tab-manager/src/lib/components/FlatTabList.svelte
@@ -53,8 +53,7 @@
 			{#if item.kind === 'window'}
 				{@const windowTabs = browserState.tabsByWindow(item.window.id)}
 				{@const activeTab = windowTabs.find((t) => t.active)}
-				{@const firstTab = windowTabs[0]}
-				{@const displayTab = activeTab || firstTab}
+				{@const firstTab = windowTabs.at(0)}
 				{@const isExpanded = expandedWindows.has(item.window.id)}
 				<button
 					type="button"
@@ -66,11 +65,7 @@
 					/>
 					<AppWindowIcon class="size-4 shrink-0" />
 					<span class="truncate">
-						{#if displayTab?.title}
-							{displayTab.title}
-						{:else}
-							Window
-						{/if}
+						{(activeTab ?? firstTab)?.title ?? 'Window'}
 					</span>
 					{#if item.window.focused}
 						<Badge variant="secondary" class="ml-auto shrink-0">focused</Badge>

--- a/apps/tab-manager/src/lib/components/FlatTabList.svelte
+++ b/apps/tab-manager/src/lib/components/FlatTabList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { VList } from 'virtua/svelte';
 	import { SvelteSet } from 'svelte/reactivity';
+	import { cn } from '@epicenter/ui/utils';
 	import { browserState } from '$lib/state/browser-state.svelte';
 	import type { WindowCompositeId } from '$lib/device/composite-id';
 	import TabItem from './TabItem.svelte';
@@ -58,15 +59,13 @@
 			<button
 				type="button"
 				onclick={() => toggleWindow(item.window.id)}
-				class="sticky top-0 z-10 flex w-full cursor-pointer items-center gap-2 border-b bg-muted/50 px-4 py-2 text-xs backdrop-blur transition-colors hover:bg-muted/80"
+				class="sticky top-0 z-10 flex w-full cursor-pointer items-center gap-2 border-b bg-muted/50 px-4 py-2 text-xs text-muted-foreground backdrop-blur transition hover:bg-muted/80"
 			>
 				<ChevronRightIcon
-					class="size-3 shrink-0 text-muted-foreground transition-transform {isExpanded
-						? 'rotate-90'
-						: ''}"
+					class={cn('size-3 shrink-0 transition', isExpanded && 'rotate-90')}
 				/>
-				<AppWindowIcon class="size-3 text-muted-foreground shrink-0" />
-				<span class="truncate text-muted-foreground">
+				<AppWindowIcon class="size-3 shrink-0" />
+				<span class="truncate">
 					{#if displayTab?.title}
 						{displayTab.title}
 					{:else}
@@ -74,9 +73,11 @@
 					{/if}
 				</span>
 				{#if item.window.focused}
-					<Badge variant="secondary" class="ml-auto shrink-0">focused</Badge>
+					<Badge variant="secondary" class="ml-auto shrink-0 px-1.5 py-0 text-[10px]">
+						focused
+					</Badge>
 				{/if}
-				<Badge variant="outline" class="shrink-0">
+				<Badge variant="outline" class="shrink-0 px-1.5 py-0 text-[10px]">
 					{windowTabs.length}
 				</Badge>
 			</button>

--- a/apps/tab-manager/src/lib/components/FlatTabList.svelte
+++ b/apps/tab-manager/src/lib/components/FlatTabList.svelte
@@ -1,20 +1,32 @@
 <script lang="ts">
 	import { VList } from 'virtua/svelte';
+	import { SvelteSet } from 'svelte/reactivity';
 	import { browserState } from '$lib/state/browser-state.svelte';
+	import type { WindowCompositeId } from '$lib/device/composite-id';
 	import TabItem from './TabItem.svelte';
 	import * as Empty from '@epicenter/ui/empty';
 	import { Badge } from '@epicenter/ui/badge';
 	import FolderOpenIcon from '@lucide/svelte/icons/folder-open';
 	import AppWindowIcon from '@lucide/svelte/icons/app-window';
+	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
 
-	// Flatten windows and tabs into a single list for virtualization
+	// Track which windows are expanded — seed with focused window
+	const expandedWindows = new SvelteSet<WindowCompositeId>(
+		browserState.windows.filter((w) => w.focused).map((w) => w.id),
+	);
+
+	function toggleWindow(id: WindowCompositeId) {
+		if (expandedWindows.has(id)) expandedWindows.delete(id);
+		else expandedWindows.add(id);
+	}
+
+	// Flatten windows and tabs, respecting collapsed state
 	const flatItems = $derived(
 		browserState.windows.flatMap((window) => {
+			const header = { kind: 'window' as const, window };
+			if (!expandedWindows.has(window.id)) return [header];
 			const tabs = browserState.tabsByWindow(window.id);
-			return [
-				{ kind: 'window' as const, window },
-				...tabs.map((tab) => ({ kind: 'tab' as const, tab })),
-			];
+			return [header, ...tabs.map((tab) => ({ kind: 'tab' as const, tab }))];
 		}),
 	);
 </script>
@@ -37,29 +49,37 @@
 				: `tab-${item.tab.id}`}
 	>
 		{#snippet children(item)}
-			{#if item.kind === 'window'}
-				{@const windowTabs = browserState.tabsByWindow(item.window.id)}
-				{@const activeTab = windowTabs.find((t) => t.active)}
-				{@const firstTab = windowTabs[0]}
-				{@const displayTab = activeTab || firstTab}
-				<div
-					class="sticky top-0 z-10 flex items-center gap-2 bg-muted/50 px-4 py-2 text-xs backdrop-blur border-b"
-				>
-					<AppWindowIcon class="size-3 text-muted-foreground shrink-0" />
-					<span class="truncate text-muted-foreground">
-						{#if displayTab?.title}
-							{displayTab.title}
-						{:else}
-							Window
-						{/if}
-					</span>
-					{#if item.window.focused}
-						<Badge variant="secondary" class="ml-auto shrink-0">focused</Badge>
+		{#if item.kind === 'window'}
+			{@const windowTabs = browserState.tabsByWindow(item.window.id)}
+			{@const activeTab = windowTabs.find((t) => t.active)}
+			{@const firstTab = windowTabs[0]}
+			{@const displayTab = activeTab || firstTab}
+			{@const isExpanded = expandedWindows.has(item.window.id)}
+			<button
+				type="button"
+				onclick={() => toggleWindow(item.window.id)}
+				class="sticky top-0 z-10 flex w-full items-center gap-2 bg-muted/50 px-4 py-2 text-xs backdrop-blur border-b cursor-pointer hover:bg-muted/80 transition-colors"
+			>
+				<ChevronRightIcon
+					class="size-3 text-muted-foreground shrink-0 transition-transform duration-200 {isExpanded
+						? 'rotate-90'
+						: ''}"
+				/>
+				<AppWindowIcon class="size-3 text-muted-foreground shrink-0" />
+				<span class="truncate text-muted-foreground">
+					{#if displayTab?.title}
+						{displayTab.title}
+					{:else}
+						Window
 					{/if}
-					<Badge variant="outline" class="shrink-0">
-						{windowTabs.length}
-					</Badge>
-				</div>
+				</span>
+				{#if item.window.focused}
+					<Badge variant="secondary" class="ml-auto shrink-0">focused</Badge>
+				{/if}
+				<Badge variant="outline" class="shrink-0">
+					{windowTabs.length}
+				</Badge>
+			</button>
 			{:else}
 				<div class="border-b border-border">
 					<TabItem tab={item.tab} />

--- a/apps/tab-manager/src/lib/components/FlatTabList.svelte
+++ b/apps/tab-manager/src/lib/components/FlatTabList.svelte
@@ -58,10 +58,10 @@
 			<button
 				type="button"
 				onclick={() => toggleWindow(item.window.id)}
-				class="sticky top-0 z-10 flex w-full items-center gap-2 bg-muted/50 px-4 py-2 text-xs backdrop-blur border-b cursor-pointer hover:bg-muted/80 transition-colors"
+				class="sticky top-0 z-10 flex w-full cursor-pointer items-center gap-2 border-b bg-muted/50 px-4 py-2 text-xs backdrop-blur transition-colors hover:bg-muted/80"
 			>
 				<ChevronRightIcon
-					class="size-3 text-muted-foreground shrink-0 transition-transform duration-200 {isExpanded
+					class="size-3 shrink-0 text-muted-foreground transition-transform {isExpanded
 						? 'rotate-90'
 						: ''}"
 				/>

--- a/apps/tab-manager/src/lib/components/TabFavicon.svelte
+++ b/apps/tab-manager/src/lib/components/TabFavicon.svelte
@@ -5,7 +5,7 @@
 	let { src }: { src: string | undefined } = $props();
 </script>
 
-<Avatar.Root class="size-4 shrink-0 rounded-sm">
+<Avatar.Root class="size-6 shrink-0 rounded-sm">
 	<Avatar.Image {src} alt="" />
 	<Avatar.Fallback class="rounded-sm">
 		<GlobeIcon class="size-3 text-muted-foreground" />

--- a/apps/tab-manager/src/lib/components/TabItem.svelte
+++ b/apps/tab-manager/src/lib/components/TabItem.svelte
@@ -14,6 +14,7 @@
 	import BookmarkIcon from '@lucide/svelte/icons/bookmark';
 	import { Button } from '@epicenter/ui/button';
 	import * as Item from '@epicenter/ui/item';
+	import * as Tooltip from '@epicenter/ui/tooltip';
 
 	let { tab }: { tab: Tab } = $props();
 
@@ -22,7 +23,7 @@
 </script>
 
 <Item.Root size="sm" class={tab.active ? 'bg-accent/50' : 'hover:bg-accent'}>
-	{#snippet child({ props })}
+	{#snippet child({ props }: { props: Record<string, unknown> })}
 		<button
 			type="button"
 			{...props}
@@ -46,9 +47,24 @@
 					{/if}
 					<span class="truncate">{tab.title || 'Untitled'}</span>
 				</Item.Title>
-				<Item.Description class="truncate">
-					{domain}
-				</Item.Description>
+				{#if tab.url}
+					<Tooltip.Root>
+						<Tooltip.Trigger>
+							{#snippet child({ props }: { props: Record<string, unknown> })}
+								<Item.Description {...props} class="w-fit truncate">
+									{domain}
+								</Item.Description>
+							{/snippet}
+						</Tooltip.Trigger>
+						<Tooltip.Content side="bottom">
+							{tab.url}
+						</Tooltip.Content>
+					</Tooltip.Root>
+				{:else}
+					<Item.Description class="truncate">
+						{domain}
+					</Item.Description>
+				{/if}
 			</Item.Content>
 
 			<Item.Actions showOnHover class="gap-1">

--- a/apps/tab-manager/src/lib/components/TabItem.svelte
+++ b/apps/tab-manager/src/lib/components/TabItem.svelte
@@ -56,7 +56,7 @@
 								</Item.Description>
 							{/snippet}
 						</Tooltip.Trigger>
-						<Tooltip.Content side="bottom">
+						<Tooltip.Content side="bottom" class="max-w-sm break-all">
 							{tab.url}
 						</Tooltip.Content>
 					</Tooltip.Root>

--- a/apps/tab-manager/src/lib/components/TabItem.svelte
+++ b/apps/tab-manager/src/lib/components/TabItem.svelte
@@ -56,7 +56,11 @@
 								</Item.Description>
 							{/snippet}
 						</Tooltip.Trigger>
-						<Tooltip.Content side="bottom" class="max-w-sm break-all">
+						<Tooltip.Content
+							side="bottom"
+							collisionPadding={8}
+							class="max-w-[calc(100vw-2rem)] break-all"
+						>
 							{tab.url}
 						</Tooltip.Content>
 					</Tooltip.Root>

--- a/apps/tab-manager/src/lib/utils/format.ts
+++ b/apps/tab-manager/src/lib/utils/format.ts
@@ -17,7 +17,7 @@ import { Ok, trySync } from 'wellcrafted/result';
  */
 export function getDomain(url: string): string {
 	const { data } = trySync({
-		try: () => new URL(url).hostname,
+		try: () => new URL(url).hostname.replace(/^www\./, ''),
 		catch: () => Ok(url),
 	});
 	return data;

--- a/docs/articles/tooltip-overflow-in-constrained-viewports.md
+++ b/docs/articles/tooltip-overflow-in-constrained-viewports.md
@@ -1,0 +1,62 @@
+# Tooltip Overflow in Constrained Viewports: Two Props That Work Together
+
+We added a tooltip to the tab manager extension that shows the full URL when you hover a tab's domain. Most URLs fit fine. Then we hovered a GitHub diff link:
+
+```
+https://github.com/EpicenterHQ/epicenter/pull/1155/changes#diff-ba2c48ee61d8c9f062cc1dbcb7c36f916294aae8ddef183c96200ed8cd6cdddc
+```
+
+120+ characters, no natural break points. It blew right past the edge of the popup.
+
+## Problem
+
+The [shadcn-svelte](https://next.shadcn-svelte.com/) `Tooltip.Content` component renders fine on a normal page. But in a browser extension sidepanel, the viewport is narrow and user-controlled. A long tooltip has nowhere to go, and the default positioning can push it flush against the viewport edge.
+
+Here's what the component looked like before the fix:
+
+```svelte
+<Tooltip.Content side="bottom">
+  {tab.url}
+</Tooltip.Content>
+```
+
+Two issues: the tooltip element itself can be wider than the viewport, and even when it fits, it can be positioned right up against the edge with no breathing room.
+
+## Solution
+
+The fix is twofold:
+
+```svelte
+<Tooltip.Content
+  side="bottom"
+  collisionPadding={8}
+  class="max-w-[calc(100vw-2rem)] break-all"
+>
+  {tab.url}
+</Tooltip.Content>
+```
+
+**`max-w-[calc(100vw-2rem)]`** constrains how wide the tooltip element can be. `100vw` in an extension popup is the popup itself; subtracting `2rem` reserves 1rem of space on each side. The tooltip's max width tracks the viewport whether it's 300px or 500px wide. A fixed value like `max-w-sm` (384px) breaks the moment the sidepanel is narrower than that.
+
+`break-all` is necessary alongside it because URLs are a single unbroken string. `break-words` only breaks at word boundaries, and a URL has none. Without `break-all`, the browser treats the entire URL as one "word" and lets it overflow.
+
+**`collisionPadding={8}`** constrains where the tooltip is placed. [bits-ui](https://bits-ui.com/docs/components/tooltip) exposes this prop on all its floating content components: [Tooltip.Content](https://bits-ui.com/docs/components/tooltip), [Popover.Content](https://bits-ui.com/docs/components/popover), [Select.Content](https://bits-ui.com/docs/components/select), and others. Under the hood, bits-ui passes it to [Floating UI](https://floating-ui.com/)'s [`shift()` middleware](https://floating-ui.com/docs/shift#padding) as the `padding` option in [`detectOverflow`](https://floating-ui.com/docs/detectoverflow#padding). This adds virtual padding around the viewport edges when calculating position: with `collisionPadding={8}`, Floating UI's shift middleware repositions the tooltip to stay at least 8px from any viewport edge.
+
+| What | Controls | Layer |
+|------|----------|-------|
+| `max-w-[calc(100vw-2rem)]` | How wide the tooltip can be | CSS |
+| `break-all` | Whether long strings wrap | CSS |
+| `collisionPadding={8}` | How close it can get to viewport edges | [Floating UI](https://floating-ui.com/docs/shift) positioning |
+
+These solve different problems and you need both. A tooltip can be narrow enough to fit but still positioned flush against the left wall. And a tooltip can be perfectly centered but too wide for the viewport.
+
+```
+Without collisionPadding:        With collisionPadding={8}:
+
+|tooltip text here    |          |  tooltip text here  |
+|                     |          |                     |
+├─────────────────────┤          ├─────────────────────┤
+ ^ flush against edge             ^ 8px gap
+```
+
+This applies to any bits-ui floating content in a constrained viewport, not just tooltips.

--- a/docs/articles/you-dont-need-an-accordion-inside-a-virtual-list.md
+++ b/docs/articles/you-dont-need-an-accordion-inside-a-virtual-list.md
@@ -1,0 +1,84 @@
+# You Don't Need an Accordion Inside a Virtual List
+
+I tried to put a shadcn Accordion component inside a virtua `VList` in Svelte. The Accordion needs a context provider wrapping all its items, its CSS animations assume nested DOM (parent `Item` containing child `Content`), and the virtual list mounts and unmounts DOM nodes as you scroll. The two models are fundamentally incompatible.
+
+Then I realized: accordion behavior is just conditional rendering with a Set.
+
+## The Pattern
+
+An accordion does two things: tracks which groups are open, and shows or hides children accordingly. You don't need a component for that. A reactive Set and a derived flat list do the same job, and they work perfectly inside a virtual list.
+
+```svelte
+<script lang="ts">
+  import { SvelteSet } from 'svelte/reactivity';
+  import { VList } from 'virtua/svelte';
+
+  const expandedGroups = new SvelteSet<string>(['focused-group']);
+
+  const flatItems = $derived(
+    groups.flatMap((group) => {
+      const header = { kind: 'header' as const, group };
+      if (!expandedGroups.has(group.id)) return [header];
+      return [
+        header,
+        ...group.children.map((child) => ({ kind: 'item' as const, child })),
+      ];
+    }),
+  );
+
+  function toggle(id: string) {
+    if (expandedGroups.has(id)) expandedGroups.delete(id);
+    else expandedGroups.add(id);
+  }
+</script>
+
+<VList data={flatItems} style="height: 100%;">
+  {#snippet children(item)}
+    {#if item.kind === 'header'}
+      <button onclick={() => toggle(item.group.id)}>
+        {item.group.name}
+      </button>
+    {:else}
+      <div>{item.child.title}</div>
+    {/if}
+  {/snippet}
+</VList>
+```
+
+When you click a header, the Set changes, `$derived` recomputes, and the flat list grows or shrinks. The virtual list sees a new array with more or fewer items. It renders the visible ones. That's it.
+
+```
+expandedGroups (Set)        flatItems ($derived)          VList
+      |                           |                         |
+      |  .add() / .delete()      |  recomputes when        |
+      |------------------------->|  Set changes             |
+      |                           |                         |
+      |                           |  [header, item, item,   |  renders only
+      |                           |   header,               |  visible items
+      |                           |   header, item, item]   |------------->
+```
+
+## Why Real Accordions Don't Work Here
+
+| Approach | Works in virtual list? | Why |
+|----------|----------------------|-----|
+| Accordion component | No | Needs parent context provider; CSS animations assume nested DOM |
+| Conditional rendering + Set | Yes | Flat data; virtual list just sees items appear and disappear |
+
+Accordion components like shadcn's (built on bits-ui) manage their own DOM hierarchy. `Accordion.Root` provides context, `Accordion.Item` wraps a trigger and content panel together, and `Accordion.Content` uses `data-[state=open/closed]` for CSS transitions. All of that assumes a stable, nested DOM tree.
+
+Virtual lists destroy that assumption. They mount and unmount items as you scroll. An `Accordion.Item` that scrolls out of view gets removed from the DOM entirely, and its open/closed state disappears with it. Even if you could keep the state, the context provider relationship between Root and Item breaks when they aren't in the same DOM subtree.
+
+## Not Svelte-Specific
+
+The principle generalizes across frameworks. Accordion components couple state to DOM structure. Virtual lists need flat data with externalized state.
+
+In React: `useState(new Set())` with a derived flat array. In Vue: `reactive(new Set())` with a computed property. In Solid: `createSignal(new Set())` with a memo. The framework-specific reactive primitive changes; the pattern stays the same.
+
+Svelte's `SvelteSet` from `svelte/reactivity` happens to be especially clean here because `.has()`, `.add()`, and `.delete()` all participate in the reactivity system. Call `.has()` inside `$derived` and Svelte tracks the dependency automatically. Mutate the Set elsewhere and the derived value recomputes.
+
+## Heights Handle Themselves
+
+Most virtual list libraries (virtua, tanstack-virtual, react-virtuoso) use `ResizeObserver` to measure item heights automatically. When a group expands and new items appear in the flat list, the library measures them, updates its internal layout cache, and adjusts scroll position. When a group collapses, items vanish and the layout shrinks.
+
+No animation library, no DOM nesting, no context provider headaches. The items appear and disappear, and the virtual list handles the rest.

--- a/docs/articles/you-dont-need-an-accordion-inside-a-virtual-list.md
+++ b/docs/articles/you-dont-need-an-accordion-inside-a-virtual-list.md
@@ -1,8 +1,8 @@
 # You Don't Need an Accordion Inside a Virtual List
 
-I tried to put a shadcn Accordion component inside a virtua `VList` in Svelte. The Accordion needs a context provider wrapping all its items, its CSS animations assume nested DOM (parent `Item` containing child `Content`), and the virtual list mounts and unmounts DOM nodes as you scroll. The two models are fundamentally incompatible.
+I tried to put a shadcn Accordion component inside a virtua `VList` in Svelte. Virtual lists expect flat, predictable-height items. Accordions give you nested DOM with variable-height content that expands and collapses. The virtual list needs to measure and position every item; the accordion wants to animate its own height transitions independently. The two models don't compose.
 
-Then I realized: accordion behavior is just conditional rendering with a Set.
+At first I was bummed-it seemed like I had to choose between collapsible groups and virtualization. Then it clicked: I don't need an accordion component. I can accomplish the same thing with headers with arrows that conditionally render their children in the virtual list. A reactive Set, a derived flat list, done.
 
 ## The Pattern
 

--- a/packages/ui/src/item/item-actions.svelte
+++ b/packages/ui/src/item/item-actions.svelte
@@ -19,7 +19,17 @@
 	data-slot="item-actions"
 	class={cn(
 		'flex items-center gap-2',
-		showOnHover && 'opacity-0 transition-opacity group-hover/item:opacity-100',
+		showOnHover && [
+			// Overlay the right side of the item instead of taking flex space, so the
+			// title gets full width when actions are hidden. Solid bg-accent masks the
+			// text underneath — matches the item's hover background.
+			'absolute inset-y-0 right-0 bg-accent pl-2 pr-4',
+			// Fade in/out on hover of the parent group/item.
+			'opacity-0 transition-opacity group-hover/item:opacity-100',
+			// Pseudo-element gradient on the left edge so text fades out smoothly
+			// rather than hard-clipping against the solid background.
+			'before:pointer-events-none before:absolute before:inset-y-0 before:-left-4 before:w-4 before:bg-linear-to-r before:from-transparent before:to-accent',
+		],
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/item/item-content.svelte
+++ b/packages/ui/src/item/item-content.svelte
@@ -14,7 +14,9 @@
 	bind:this={ref}
 	data-slot="item-content"
 	class={cn(
-		'flex min-w-0 flex-1 flex-col gap-1 [&+[data-slot=item-content]]:flex-none',
+		'flex flex-1 flex-col gap-1 [&+[data-slot=item-content]]:flex-none',
+		// Custom override: enables text truncation inside flex containers
+		'min-w-0',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/item/item-title.svelte
+++ b/packages/ui/src/item/item-title.svelte
@@ -14,7 +14,10 @@
 	bind:this={ref}
 	data-slot="item-title"
 	class={cn(
-		'flex min-w-0 items-center gap-2 text-sm leading-snug font-medium',
+		'flex items-center gap-2 text-sm leading-snug font-medium',
+		// Custom override: upstream uses `w-fit` here. We use `min-w-0` instead
+		// to enable text truncation inside flex containers.
+		'min-w-0',
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/item/item.svelte
+++ b/packages/ui/src/item/item.svelte
@@ -2,7 +2,8 @@
 	import { tv, type VariantProps } from 'tailwind-variants';
 
 	export const itemVariants = tv({
-		base: 'group/item relative [a]:hover:bg-accent/50 focus-visible:border-ring focus-visible:ring-ring/50 flex items-center rounded-md border border-transparent text-sm transition-colors duration-100 outline-none focus-visible:ring-[3px] [a]:transition-colors',
+		// Custom override: `relative` needed for absolute-positioned showOnHover Actions
+		base: 'group/item relative [a]:hover:bg-accent/50 focus-visible:border-ring focus-visible:ring-ring/50 flex flex-wrap items-center rounded-md border border-transparent text-sm transition-colors duration-100 outline-none focus-visible:ring-[3px] [a]:transition-colors',
 		variants: {
 			variant: {
 				default: 'bg-transparent',

--- a/packages/ui/src/item/item.svelte
+++ b/packages/ui/src/item/item.svelte
@@ -2,7 +2,7 @@
 	import { tv, type VariantProps } from 'tailwind-variants';
 
 	export const itemVariants = tv({
-		base: 'group/item [a]:hover:bg-accent/50 focus-visible:border-ring focus-visible:ring-ring/50 flex items-center rounded-md border border-transparent text-sm transition-colors duration-100 outline-none focus-visible:ring-[3px] [a]:transition-colors',
+		base: 'group/item relative [a]:hover:bg-accent/50 focus-visible:border-ring focus-visible:ring-ring/50 flex items-center rounded-md border border-transparent text-sm transition-colors duration-100 outline-none focus-visible:ring-[3px] [a]:transition-colors',
 		variants: {
 			variant: {
 				default: 'bg-transparent',


### PR DESCRIPTION
The tab manager extension was shipping with flat, non-collapsible window lists and action buttons that stole horizontal space from tab titles even when hidden. This rounds out the UI with three improvements: collapsible window groups, overlay-based hover actions, and domain tooltips with full URLs.

## Collapsible window groups

Window headers in FlatTabList are now clickable and toggle their child tabs. A `SvelteSet<WindowCompositeId>` tracks expanded state, seeded with the focused window. The `$derived` flat list conditionally includes child tabs based on membership in the set — the virtual list just sees items appear and disappear, no accordion component needed.

```svelte
const expandedWindows = new SvelteSet<WindowCompositeId>(
  browserState.windows.filter((w) => w.focused).map((w) => w.id),
);

const flatItems = $derived(
  browserState.windows.flatMap((window) => {
    const header = { kind: 'window' as const, window };
    if (!expandedWindows.has(window.id)) return [header];
    const tabs = browserState.tabsByWindow(window.id);
    return [header, ...tabs.map((tab) => ({ kind: 'tab' as const, tab }))];
  }),
);
```

```
expandedWindows (SvelteSet)     flatItems ($derived)          VList
       |                              |                         |
       |  .add() / .delete()          |  recomputes when        |
       |----------------------------->|  Set changes             |
       |                              |                         |
       |                              |  [header, tab, tab,     |  renders only
       |                              |   header,               |  visible items
       |                              |   header, tab, tab]     |------------->
```

Window headers were also scaled up from `text-xs` to `text-sm` to match the default badge sizing, and the selection logic was simplified using `at(0)` instead of bracket indexing.

## Overlay hover actions

The Item component's action buttons previously occupied flex space even when invisible (`opacity-0`), which truncated titles prematurely. Now they overlay the right edge of the item with absolute positioning, a solid `bg-accent` background, and a pseudo-element gradient that fades out the text underneath.

```
Before (flex space reserved):
┌──────────────────────────────────────────────────┐
│ 🌐 Tab title gets truncated here...  [🔖] [📌]  │
│                                      ↑ always    │
│                                        occupies  │
│                                        space     │
└──────────────────────────────────────────────────┘

After (absolute overlay on hover):
┌──────────────────────────────────────────────────┐
│ 🌐 Tab title uses full width of the row          │
│                                 ░░░░░[🔖] [📌]  │
│                                 ↑ gradient fade  │
│                                   only on hover  │
└──────────────────────────────────────────────────┘
```

This required adding `relative` to the Item base variant so absolute children position correctly, and swapping `min-w-0` placement in `item-title` and `item-content` to preserve truncation in the new flex layout.

## URL tooltips

Tab domains now strip the `www.` prefix for cleaner display, and hovering shows the full URL in a tooltip. The tooltip uses `collisionPadding={8}` and `max-w-[calc(100vw-2rem)]` to stay within the narrow sidepanel viewport — without both, long URLs (GitHub diff links, etc.) overflow the popup edges.

Two articles were added documenting the patterns discovered during this work: one on using a reactive Set instead of an accordion component inside virtual lists, and one on constraining tooltip overflow in narrow viewports with `collisionPadding` and viewport-relative `max-w`.