### PR TITLE
refactor(ui): standardize tooltip provider defaults and remove redundant nesting

### DIFF
--- a/apps/whispering/src/routes/+layout.svelte
+++ b/apps/whispering/src/routes/+layout.svelte
@@ -43,7 +43,8 @@
 </svelte:head>
 
 <QueryClientProvider client={queryClient}>
-	<Tooltip.Provider delayDuration={300} skipDelayDuration={150}>
+	<!-- Uses UI package defaults (300ms delay, 150ms skip) -->
+	<Tooltip.Provider>
 		{@render children()}
 	</Tooltip.Provider>
 </QueryClientProvider>

--- a/docs/articles/tooltip-provider-one-at-the-root.md
+++ b/docs/articles/tooltip-provider-one-at-the-root.md
@@ -1,0 +1,75 @@
+# Tooltip.Provider Goes at the Root, Not Around Every Tooltip
+
+bits-ui's `Tooltip.Provider` does two things: it sets default props (`delayDuration`, `skipDelayDuration`) for all descendant tooltips, and it enforces that only one tooltip within its scope can be open at a time. That second behavior is the one most people miss.
+
+When you wrap a component in its own `Tooltip.Provider`, you're creating an isolated tooltip group. Tooltips inside that provider don't know about tooltips outside it. Two tooltips from different providers can be open simultaneously, which is almost never what you want.
+
+```
+App Root
+├── Tooltip.Provider (root)          ← one-at-a-time scope
+│   ├── Button tooltip="Save"
+│   ├── Button tooltip="Delete"
+│   └── PmCommand
+│       └── Tooltip.Provider (nested) ← separate one-at-a-time scope
+│           └── Tooltip.Root           ← can be open ALONGSIDE "Save" or "Delete"
+```
+
+The fix: remove the nested provider and use `Tooltip.Root`'s own `delayDuration` prop to override the ancestor's default.
+
+```
+App Root
+├── Tooltip.Provider (root)          ← single one-at-a-time scope
+│   ├── Button tooltip="Save"
+│   ├── Button tooltip="Delete"
+│   └── PmCommand
+│       └── Tooltip.Root delayDuration={0}  ← overrides default, stays in root scope
+```
+
+## How the Override Works
+
+bits-ui's `TooltipRootState` resolves `delayDuration` with nullish coalescing:
+
+```js
+delayDuration = $derived.by(
+  () => this.opts.delayDuration.current ?? this.provider.opts.delayDuration.current
+);
+```
+
+If `Tooltip.Root` has a `delayDuration` prop, it wins. Otherwise it falls back to the closest ancestor `Tooltip.Provider`. The same pattern applies to `disableHoverableContent`, `disableCloseOnTriggerClick`, `disabled`, and `ignoreNonKeyboardFocus`.
+
+This means you only need a nested `Tooltip.Provider` when you genuinely want an independent tooltip group with its own "one at a time" behavior. The sidebar is a legitimate case: collapsed sidebar icon tooltips should open instantly and independently of the app's other tooltips. A copy button inside a code block is not.
+
+## What We Changed
+
+Our `Tooltip.Provider` wrapper in `packages/ui` was a pure pass-through with no defaults, inheriting bits-ui's 700ms delay. Every app had to configure its own values, and some forgot (tab-manager was using the sluggish 700ms default).
+
+We added opinionated defaults to the UI package's `tooltip-provider.svelte`:
+
+```svelte
+let {
+  delayDuration = 300,
+  skipDelayDuration = 150,
+  ...restProps
+}: TooltipPrimitive.ProviderProps = $props();
+```
+
+| Before | After |
+|--------|-------|
+| Each app sets `delayDuration={300} skipDelayDuration={150}` | UI package provides the defaults |
+| pm-command wraps one tooltip in its own `Tooltip.Provider` | pm-command uses `Tooltip.Root delayDuration={0}` |
+| tab-manager gets bits-ui's 700ms default | tab-manager gets 300ms for free |
+| Sidebar provider sets `delayDuration={0}` | Unchanged; intentional independent group |
+
+Apps that need different timing still override via props on `Tooltip.Provider`. Components that need a different delay for one specific tooltip set it on `Tooltip.Root` directly.
+
+## When to Use a Nested Provider
+
+Nest a `Tooltip.Provider` only when you need a genuinely separate tooltip group. The sidebar is the canonical example: when the sidebar collapses to icon-only mode, those tooltips should appear instantly and independently. That's a different UX context from the rest of the app, so a separate provider makes sense.
+
+For everything else, set `delayDuration` on the individual `Tooltip.Root`.
+
+## References
+
+- [bits-ui Tooltip docs](https://bits-ui.com/docs/components/tooltip): "It also ensures that only a single tooltip within the same provider can be open at a time."
+- [shadcn-svelte Tooltip docs](https://www.shadcn-svelte.com/docs/components/tooltip): "Tooltips use the closest ancestor provider."
+- bits-ui source (`tooltip.svelte.js` line 66): nullish coalescing for `delayDuration` resolution.

--- a/packages/ui/src/pm-command/pm-command.svelte
+++ b/packages/ui/src/pm-command/pm-command.svelte
@@ -71,24 +71,26 @@
 				</Tabs.List>
 			</Tabs.Root>
 		</div>
-		<Tooltip.Provider delayDuration={0}>
-			<Tooltip.Root>
-				<Tooltip.Trigger>
-					{#snippet child({ props })}
-						<CopyButton
-							{...props}
-							text={commandText}
-							class="size-6 [&_svg]:size-3"
-						>
-							{#snippet icon()}
-								<ClipboardIcon />
-							{/snippet}
-						</CopyButton>
+	<!-- delayDuration={0} overrides the ancestor provider's default for this tooltip.
+		 bits-ui Tooltip.Root props take precedence over Provider defaults via nullish coalescing.
+		 A Tooltip.Provider must exist somewhere above this component in the tree.
+		 See: https://bits-ui.com/docs/components/tooltip#delay-duration -->
+	<Tooltip.Root delayDuration={0}>
+		<Tooltip.Trigger>
+			{#snippet child({ props })}
+				<CopyButton
+					{...props}
+					text={commandText}
+					class="size-6 [&_svg]:size-3"
+				>
+					{#snippet icon()}
+						<ClipboardIcon />
 					{/snippet}
-				</Tooltip.Trigger>
-				<Tooltip.Content>Copy to Clipboard</Tooltip.Content>
-			</Tooltip.Root>
-		</Tooltip.Provider>
+				</CopyButton>
+			{/snippet}
+		</Tooltip.Trigger>
+		<Tooltip.Content>Copy to Clipboard</Tooltip.Content>
+	</Tooltip.Root>
 	</div>
 	<div class="no-scrollbar overflow-x-auto p-3">
 		<span

--- a/packages/ui/src/pm-command/pm-command.svelte
+++ b/packages/ui/src/pm-command/pm-command.svelte
@@ -71,26 +71,26 @@
 				</Tabs.List>
 			</Tabs.Root>
 		</div>
-	<!-- delayDuration={0} overrides the ancestor provider's default for this tooltip.
+		<!-- delayDuration={0} overrides the ancestor provider's default for this tooltip.
 		 bits-ui Tooltip.Root props take precedence over Provider defaults via nullish coalescing.
 		 A Tooltip.Provider must exist somewhere above this component in the tree.
 		 See: https://bits-ui.com/docs/components/tooltip#delay-duration -->
-	<Tooltip.Root delayDuration={0}>
-		<Tooltip.Trigger>
-			{#snippet child({ props })}
-				<CopyButton
-					{...props}
-					text={commandText}
-					class="size-6 [&_svg]:size-3"
-				>
-					{#snippet icon()}
-						<ClipboardIcon />
-					{/snippet}
-				</CopyButton>
-			{/snippet}
-		</Tooltip.Trigger>
-		<Tooltip.Content>Copy to Clipboard</Tooltip.Content>
-	</Tooltip.Root>
+		<Tooltip.Root delayDuration={0}>
+			<Tooltip.Trigger>
+				{#snippet child({ props })}
+					<CopyButton
+						{...props}
+						text={commandText}
+						class="size-6 [&_svg]:size-3"
+					>
+						{#snippet icon()}
+							<ClipboardIcon />
+						{/snippet}
+					</CopyButton>
+				{/snippet}
+			</Tooltip.Trigger>
+			<Tooltip.Content>Copy to Clipboard</Tooltip.Content>
+		</Tooltip.Root>
 	</div>
 	<div class="no-scrollbar overflow-x-auto p-3">
 		<span

--- a/packages/ui/src/tooltip/tooltip-provider.svelte
+++ b/packages/ui/src/tooltip/tooltip-provider.svelte
@@ -1,7 +1,18 @@
 <script lang="ts">
 	import { Tooltip as TooltipPrimitive } from 'bits-ui';
 
-	let { ...restProps }: TooltipPrimitive.ProviderProps = $props();
+	let {
+		delayDuration = 300,
+		skipDelayDuration = 150,
+		...restProps
+	}: TooltipPrimitive.ProviderProps = $props();
 </script>
 
-<TooltipPrimitive.Provider {...restProps} />
+<!--
+	Opinionated defaults: 300ms delay, 150ms skip delay.
+	bits-ui defaults to 700ms/300ms which feels sluggish for desktop apps.
+	Individual Tooltip.Root components can override delayDuration via props.
+	Nested providers (e.g. sidebar-provider with delayDuration={0}) override these defaults.
+	See: https://bits-ui.com/docs/components/tooltip#provider-component
+-->
+<TooltipPrimitive.Provider {delayDuration} {skipDelayDuration} {...restProps} />


### PR DESCRIPTION
bits-ui's `Tooltip.Provider` does two things: sets default props for descendant tooltips, and enforces that only one tooltip within its scope can be open at a time. That second behavior was causing a subtle problem: `pm-command` wrapped its copy button tooltip in its own `Tooltip.Provider`, which created an isolated group where that tooltip could open simultaneously with any other tooltip in the app. Not intentional, just a side effect of wanting `delayDuration={0}`.

Meanwhile, bits-ui defaults to 700ms delay which is sluggish for desktop apps. Each app was either setting its own `delayDuration={300}` or silently inheriting the slow default (tab-manager was getting 700ms).

The fix is two things: bake opinionated defaults into the UI package's provider, and remove the redundant nested provider from pm-command. bits-ui's `Tooltip.Root` already supports per-tooltip overrides via nullish coalescing in the source:

```js
// bits-ui tooltip.svelte.js (TooltipRootState)
delayDuration = $derived.by(
  () => this.opts.delayDuration.current ?? this.provider.opts.delayDuration.current
);
```

So setting `delayDuration` on an individual `Tooltip.Root` takes precedence over the ancestor provider, no nested provider needed.

Before, every app had to configure its own provider and pm-command created an isolated tooltip scope:

```svelte
<!-- apps/whispering/+layout.svelte -->
<Tooltip.Provider delayDuration={300} skipDelayDuration={150}>

<!-- apps/tab-manager/App.svelte — forgot to configure, got 700ms -->
<Tooltip.Provider>

<!-- packages/ui/pm-command.svelte — isolated tooltip group -->
<Tooltip.Provider delayDuration={0}>
  <Tooltip.Root>...</Tooltip.Root>
</Tooltip.Provider>
```

After, the UI package owns the defaults and pm-command stays in the app's global tooltip scope:

```svelte
<!-- packages/ui/tooltip-provider.svelte — owns the defaults -->
let { delayDuration = 300, skipDelayDuration = 150, ...restProps } = $props();

<!-- apps/whispering/+layout.svelte — just uses defaults -->
<Tooltip.Provider>

<!-- apps/tab-manager/App.svelte — gets 300ms for free -->
<Tooltip.Provider>

<!-- packages/ui/pm-command.svelte — per-tooltip override, no nested provider -->
<Tooltip.Root delayDuration={0}>...</Tooltip.Root>
```

The sidebar's nested `Tooltip.Provider delayDuration={0}` is intentionally left alone. That's a shadcn-svelte convention: collapsed sidebar icon tooltips should open instantly and independently of the app's other tooltips, so a separate provider scope is correct there.

Includes a `docs/articles/` write-up documenting the provider architecture, the override mechanism, and when nested providers are appropriate.