### PR TITLE
refactor(ui): standardize tooltip provider defaults and fix tab-manager Tailwind issues

### DIFF
--- a/apps/tab-manager/src/lib/components/SavedTabList.svelte
+++ b/apps/tab-manager/src/lib/components/SavedTabList.svelte
@@ -38,7 +38,7 @@
 								<Item.Title>
 									<span class="truncate">{tab.title || 'Untitled'}</span>
 								</Item.Title>
-								<Item.Description class="flex items-center gap-2 truncate">
+								<Item.Description class="flex min-w-0 items-center gap-2 truncate">
 									<span class="truncate">{getDomain(tab.url)}</span>
 									<span>•</span>
 									<span class="shrink-0">{getRelativeTime(tab.savedAt)}</span>

--- a/apps/tab-manager/src/lib/components/SavedTabList.svelte
+++ b/apps/tab-manager/src/lib/components/SavedTabList.svelte
@@ -38,7 +38,9 @@
 								<Item.Title>
 									<span class="truncate">{tab.title || 'Untitled'}</span>
 								</Item.Title>
-								<Item.Description class="flex min-w-0 items-center gap-2 truncate">
+								<Item.Description
+									class="flex min-w-0 items-center gap-2 truncate"
+								>
 									<span class="truncate">{getDomain(tab.url)}</span>
 									<span>•</span>
 									<span class="shrink-0">{getRelativeTime(tab.savedAt)}</span>

--- a/apps/tab-manager/src/lib/components/TabItem.svelte
+++ b/apps/tab-manager/src/lib/components/TabItem.svelte
@@ -15,6 +15,7 @@
 	import { Button } from '@epicenter/ui/button';
 	import * as Item from '@epicenter/ui/item';
 	import * as Tooltip from '@epicenter/ui/tooltip';
+	import { cn } from '@epicenter/ui/utils';
 
 	let { tab }: { tab: Tab } = $props();
 
@@ -22,12 +23,17 @@
 	const domain = $derived(tab.url ? getDomain(tab.url) : '');
 </script>
 
-<Item.Root size="sm" class={tab.active ? 'bg-accent/50' : 'hover:bg-accent'}>
+<Item.Root
+	size="sm"
+	class={cn(
+		'w-full text-left',
+		tab.active ? 'bg-accent/50' : 'hover:bg-accent',
+	)}
+>
 	{#snippet child({ props }: { props: Record<string, unknown> })}
 		<button
 			type="button"
 			{...props}
-			class="{props.class} w-full text-left"
 			onclick={() => browserState.actions.activate(tabId)}
 		>
 			<Item.Media>


### PR DESCRIPTION
Every app using our `Tooltip.Provider` wrapper had to manually pass `delayDuration={300} skipDelayDuration={150}`, and some didn't bother — tab-manager was silently inheriting bits-ui's sluggish 700ms default. Worse, `pm-command` was wrapping a single tooltip in its own `Tooltip.Provider`, which created an isolated tooltip group where that tooltip could open simultaneously with others.

```
App Root
├── Tooltip.Provider (root)           ← one-at-a-time scope
│   ├── Button tooltip="Save"
│   ├── Button tooltip="Delete"
│   └── PmCommand
│       └── Tooltip.Provider (nested)  ← SEPARATE scope (bug)
│           └── Tooltip.Root            ← can open alongside "Save" or "Delete"
```

The fix moves opinionated defaults (300ms delay, 150ms skip) into the UI package's `tooltip-provider.svelte`, so apps get sensible timing for free. `pm-command` now uses `Tooltip.Root delayDuration={0}` instead of wrapping in its own provider, keeping it in the root's one-at-a-time scope:

```
App Root
├── Tooltip.Provider (root)           ← single one-at-a-time scope
│   ├── Button tooltip="Save"
│   ├── Button tooltip="Delete"
│   └── PmCommand
│       └── Tooltip.Root delayDuration={0}  ← overrides default, stays in root scope
```

This works because bits-ui resolves `delayDuration` via nullish coalescing — `Tooltip.Root` props win over the ancestor `Tooltip.Provider` defaults. So you only need a nested provider when you genuinely want an independent tooltip group (like the sidebar's instant icon tooltips).

```
┌──────────────────────────────────────────────────────────────────┐
│  Before                          │  After                        │
├──────────────────────────────────┼───────────────────────────────┤
│  Each app sets delay props       │  UI package provides defaults │
│  pm-command has own Provider     │  pm-command uses Root override │
│  tab-manager gets 700ms default  │  tab-manager gets 300ms free  │
│  Sidebar sets delayDuration={0}  │  Unchanged (intentional)      │
└──────────────────────────────────┴───────────────────────────────┘
```

While auditing the tab-manager, I also fixed two Tailwind issues. `SavedTabList`'s flex description container was missing `min-w-0`, so long domains would push the timestamp off-screen instead of truncating. And `TabItem` was appending `w-full text-left` to the child button via `{props.class}` string interpolation instead of using `cn()` on `Item.Root` — inconsistent with how every other component in the codebase handles class merging.

An article documenting the tooltip provider pattern is included at `docs/articles/` for future reference.