### PR TITLE
fix(sound): release Audio elements after playback to prevent PipeWire node leaks

### DIFF
--- a/apps/whispering/src/lib/services/isomorphic/sound/assets/index.ts
+++ b/apps/whispering/src/lib/services/isomorphic/sound/assets/index.ts
@@ -10,13 +10,40 @@ import cancelSoundSrc from './zapsplat_multimedia_click_button_short_sharp_73510
 import transformationCompleteSoundSrc from './zapsplat_multimedia_notification_alert_ping_bright_chime_001_93276.mp3';
 import transcriptionCompleteSoundSrc from './zapsplat_multimedia_ui_notification_classic_bell_synth_success_107505.mp3';
 
-export const audioElements = {
-	'manual-start': new Audio(startManualSoundSrc),
-	'manual-cancel': new Audio(cancelSoundSrc),
-	'manual-stop': new Audio(stopManualSoundSrc),
-	'vad-start': new Audio(startVadSoundSrc),
-	'vad-capture': new Audio(captureVadSoundSrc),
-	'vad-stop': new Audio(stopVadSoundSrc),
-	transcriptionComplete: new Audio(transcriptionCompleteSoundSrc),
-	transformationComplete: new Audio(transformationCompleteSoundSrc),
-} satisfies Record<WhisperingSoundNames, HTMLAudioElement>;
+// Map each sound name to its source URL. Audio elements are created on demand
+// and released after playback so PipeWire nodes don't accumulate.
+const soundSources = {
+	'manual-start': startManualSoundSrc,
+	'manual-cancel': cancelSoundSrc,
+	'manual-stop': stopManualSoundSrc,
+	'vad-start': startVadSoundSrc,
+	'vad-capture': captureVadSoundSrc,
+	'vad-stop': stopVadSoundSrc,
+	transcriptionComplete: transcriptionCompleteSoundSrc,
+	transformationComplete: transformationCompleteSoundSrc,
+} satisfies Record<WhisperingSoundNames, string>;
+
+/**
+ * Play a sound effect and release the PipeWire node once playback finishes.
+ *
+ * Each HTMLAudioElement registers a PipeWire output node that persists as long
+ * as the element is reachable. To prevent nodes from accumulating we clear the
+ * src after the sound ends, which tears down the underlying media resource.
+ */
+export async function playSound(
+	soundName: WhisperingSoundNames,
+): Promise<void> {
+	const el = new Audio(soundSources[soundName]);
+	await el.play();
+	await new Promise<void>((resolve) => {
+		el.addEventListener(
+			'ended',
+			() => {
+				el.src = '';
+				el.load();
+				resolve();
+			},
+			{ once: true },
+		);
+	});
+}

--- a/apps/whispering/src/lib/services/isomorphic/sound/desktop.ts
+++ b/apps/whispering/src/lib/services/isomorphic/sound/desktop.ts
@@ -1,16 +1,13 @@
 import { extractErrorMessage } from 'wellcrafted/error';
 import { tryAsync } from 'wellcrafted/result';
 import type { PlaySoundService } from '.';
-import { audioElements } from './assets';
-import { PlaySoundServiceErr } from './types';
+import { playSound } from './assets';
 
 export function createPlaySoundServiceDesktop(): PlaySoundService {
 	return {
 		playSound: async (soundName) =>
 			tryAsync({
-				try: async () => {
-					await audioElements[soundName].play();
-				},
+				try: () => playSound(soundName),
 				catch: (error) =>
 					PlaySoundServiceErr({
 						message: `Failed to play sound: ${extractErrorMessage(error)}`,

--- a/apps/whispering/src/lib/services/isomorphic/sound/web.ts
+++ b/apps/whispering/src/lib/services/isomorphic/sound/web.ts
@@ -1,13 +1,13 @@
 import { Ok } from 'wellcrafted/result';
 // import { extension } from '@epicenter/extension';
 import type { PlaySoundService } from '.';
-import { audioElements } from './assets';
+import { playSound } from './assets';
 
 export function createPlaySoundServiceWeb(): PlaySoundService {
 	return {
 		playSound: async (soundName) => {
 			if (!document.hidden) {
-				await audioElements[soundName].play();
+				await playSound(soundName);
 				return Ok(undefined);
 			}
 			// const { error: playSoundError } = await extension.playSound({


### PR DESCRIPTION
Each `HTMLAudioElement` registers a PipeWire output node that persists as long as the element is reachable. Previously, `Audio` objects were created eagerly at module load time and cached indefinitely, so every sound that played left a permanent PipeWire node behind — accumulating as multiple Whispering entries in PipeWire audio managers:

```
┌──────────────────────────────────────────────────────────┐
│  Before: eager construction + indefinite caching         │
│                                                          │
│  Module load  ──→  new Audio() × N  ──→  PipeWire nodes │
│                    (cached forever)      (never released) │
│                                                          │
│  HMR reload   ──→  new Audio() × N  ──→  more nodes     │
│                    (old ones orphaned)                    │
└──────────────────────────────────────────────────────────┘

┌──────────────────────────────────────────────────────────┐
│  After: on-demand creation + release on ended            │
│                                                          │
│  playSound()  ──→  new Audio()  ──→  play  ──→  ended   │
│                                        │         │       │
│                                        │    el.src = ''  │
│                                        │    el.load()    │
│                                        │         │       │
│                                        ▼         ▼       │
│                                   PipeWire node removed  │
└──────────────────────────────────────────────────────────┘
```

The `playSound()` function creates a fresh `Audio` element per call, waits for the `ended` event, then clears the `src` and calls `load()` to tear down the underlying media resource and its PipeWire node.

Fixes #842