### PR TITLE
fix(sound): suppress redundant notification toasts during recording flow

### DIFF
--- a/apps/whispering/src/lib/query/isomorphic/actions.ts
+++ b/apps/whispering/src/lib/query/isomorphic/actions.ts
@@ -75,11 +75,11 @@ const startManualRecording = defineMutation({
 
 		switch (deviceAcquisitionOutcome.outcome) {
 			case 'success': {
-				notify.success({
-					id: toastId,
-					title: '🎙️ Whispering is recording...',
-					description: 'Speak now and stop recording when done',
-				});
+				// notify.success({
+				// 	id: toastId,
+				// 	title: '🎙️ Whispering is recording...',
+				// 	description: 'Speak now and stop recording when done',
+				// });
 				break;
 			}
 			case 'fallback': {
@@ -160,11 +160,11 @@ const stopManualRecording = defineMutation({
 
 		const { blob, recordingId } = data;
 
-		notify.success({
-			id: toastId,
-			title: '🎙️ Recording stopped',
-			description: 'Your recording has been saved',
-		});
+		// notify.success({
+		// 	id: toastId,
+		// 	title: '🎙️ Recording stopped',
+		// 	description: 'Your recording has been saved',
+		// });
 		console.info('Recording stopped');
 		sound.playSoundIfEnabled('manual-stop');
 
@@ -630,11 +630,11 @@ async function processRecordingPipeline({
 
 	// Show transcribing toast immediately
 	const transcribeToastId = nanoid();
-	notify.loading({
-		id: transcribeToastId,
-		title: '📋 Transcribing...',
-		description: 'Your recording is being transcribed...',
-	});
+	// notify.loading({
+	// 	id: transcribeToastId,
+	// 	title: '📋 Transcribing...',
+	// 	description: 'Your recording is being transcribed...',
+	// });
 
 	// Start both operations in parallel
 	const savePromise = db.recordings.create({ recording, audio: blob });
@@ -688,11 +688,11 @@ async function processRecordingPipeline({
 	}
 
 	// Save succeeded - show completion toast and update recording
-	notify.success({
-		id: toastId,
-		title: completionTitle,
-		description: completionDescription,
-	});
+	// notify.success({
+	// 	id: toastId,
+	// 	title: completionTitle,
+	// 	description: completionDescription,
+	// });
 
 	const { error: updateError } = await db.recordings.update({
 		...recording,

--- a/apps/whispering/src/lib/query/isomorphic/transcription.ts
+++ b/apps/whispering/src/lib/query/isomorphic/transcription.ts
@@ -163,10 +163,10 @@ export async function transcribeBlob(
 			const compressionRatio = Math.round(
 				(1 - compressedBlob.size / blob.size) * 100,
 			);
-			notify.info({
-				title: 'Audio compressed',
-				description: `Reduced file size by ${compressionRatio}%`,
-			});
+			// notify.info({
+			// 	title: 'Audio compressed',
+			// 	description: `Reduced file size by ${compressionRatio}%`,
+			// });
 			rpc.analytics.logEvent({
 				type: 'compression_completed',
 				provider: selectedService,


### PR DESCRIPTION
A single push-to-talk transcription currently fires up to five separate toasts:

```
Press shortcut ──→ "🎙️ Whispering is recording..."
Release shortcut ──→ "🎙️ Recording stopped"
                 ──→ "📋 Transcribing..."
                 ──→ "Audio compressed" (if compression enabled)
                 ──→ "✨ Recording Complete!"
```

For frequent use this is visual noise that competes with the actual transcribed text the user cares about. Each toast demands attention for something that works fine and needs no acknowledgment.

This comments out the five happy-path toasts so notifications only appear when something goes wrong (errors, warnings, device fallback). The recording start/stop/transcription lifecycle is already communicated through the microphone icon state and sound effects.

Fixes #1373