### PR TITLE
fix(groq): surface non-APIError fetch failures as WhisperingError

### DIFF
--- a/apps/whispering/src/lib/services/isomorphic/transcription/cloud/groq.ts
+++ b/apps/whispering/src/lib/services/isomorphic/transcription/cloud/groq.ts
@@ -1,5 +1,6 @@
 import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
 import Groq from 'groq-sdk';
+import { extractErrorMessage } from 'wellcrafted/error';
 import { Err, Ok, type Result, tryAsync, trySync } from 'wellcrafted/result';
 import { WhisperingErr, type WhisperingError } from '$lib/result';
 import { getAudioExtension } from '$lib/services/isomorphic/transcription/utils';
@@ -127,13 +128,15 @@ export const GroqTranscriptionServiceLive = {
 						: undefined,
 				}),
 			catch: (error) => {
-				// Check if it's NOT a Groq API error
-				if (!(error instanceof Groq.APIError)) {
-					// This is an unexpected error type
-					throw error;
+				if (error instanceof Groq.APIError) {
+					return Err(error);
 				}
-				// Return the error directly
-				return Err(error);
+				// Non-APIError (e.g. network error, tauriFetch failure) - wrap it
+				return WhisperingErr({
+					title: 'Transcription Request Failed',
+					description: extractErrorMessage(error),
+					action: { type: 'more-details', error },
+				});
 			},
 		});
 


### PR DESCRIPTION
## Summary

When a Groq transcription request fails with a non-`APIError` (e.g. a network error or `tauriFetch` failure), the previous code re-threw the error as an unhandled exception rather than returning a user-facing error.

This fix catches non-`APIError` exceptions and wraps them in a `WhisperingErr` with a descriptive title and message, consistent with how other errors are handled in this service.