### PR TITLE
feat(docs): add articles on updatedAt sentinel pattern for external Yjs docs

### DIFF
--- a/docs/articles/updated-at-sentinel-for-external-yjs-docs.md
+++ b/docs/articles/updated-at-sentinel-for-external-yjs-docs.md
@@ -1,0 +1,128 @@
+# Touch `updatedAt` When Content in a Separate Yjs Doc Changes
+
+Think of Google Drive's file list. It's always loaded, renders instantly, and each row is metadata plus a pointer to a document stored elsewhere. In our [split-doc architecture](./only-the-leaves-need-revision-history.md), the files table works the same way: each row stores a name, size, and timestamps, and the row's `id` doubles as the GUID of a separate Yjs content document that loads on demand.
+
+That separation creates a blind spot. When someone edits a content doc, nothing in the metadata row changes, so everything watching the files table (persistence, the file tree UI, "recently modified" sorting) sees no event. The fix: touch `updatedAt` on the metadata row every time the referenced content changes. One cheap metadata write makes content edits visible to every observer without loading all content docs.
+
+## The blind spot
+
+```
+Metadata Y.Doc (gc: true, always loaded)
+├── files table
+│   ├── { id: 'abc', name: 'api.md', size: 2048, updatedAt: ... }
+│   └── { id: 'def', name: 'index.ts', size: 512, updatedAt: ... }
+
+Content Y.Doc 'abc' (gc: false, loaded on demand)
+└── Y.Text('content')  →  "# API Reference\n..."
+
+Content Y.Doc 'def' (gc: false, loaded on demand)
+└── Y.Text('content')  →  "export function main() {..."
+```
+
+A user opens `api.md` and starts typing. Content doc `abc` gets updated, but the files table row still has the same name, same size, same `updatedAt`. No observer fires. Persistence doesn't save. The UI doesn't reflect the edit. The reference doesn't propagate change events.
+
+You could observe each content doc individually, but that defeats lazy loading. You'd have to load every content doc in the workspace just to watch for changes.
+
+## The fix
+
+On every content write, also write `updatedAt` (and `size`) back to the metadata row. This is the "touch": a tiny metadata update whose only purpose is to make content changes visible to observers.
+
+```typescript
+// file-table.ts
+export const filesTable = defineTable(
+  type({
+    id: FileId,
+    name: 'string',
+    parentId: FileId.or(type.null),
+    type: "'file' | 'folder'",
+    size: 'number',
+    createdAt: 'number',
+    updatedAt: 'number',       // ← touched on every content write
+    trashedAt: 'number | null',
+  }),
+);
+```
+
+The write path touches both docs in sequence:
+
+```typescript
+// yjs-file-system.ts
+async writeFile(path, data) {
+  // ... resolve path, get file ID ...
+  const size = await this.content.write(id, data);  // 1. write content doc
+  this.tree.touch(id, size);                         // 2. touch metadata row
+}
+
+// file-tree.ts
+touch(id: FileId, size: number): void {
+  this.filesTable.update(id, { size, updatedAt: Date.now() });
+}
+```
+
+From the metadata layer's perspective, this looks like any other table update:
+
+```
+User types in editor
+       │
+       ▼
+Content Y.Doc 'abc'          Metadata Y.Doc
+  Y.Text updated       →      filesTable.update('abc', {
+                                 size: 2150,
+                                 updatedAt: 1739612345678
+                               })
+                                      │
+                              ┌───────┴────────┐
+                              ▼                ▼
+                        Persistence       File tree UI
+                        re-saves doc      shows modified indicator
+```
+
+Every system already watching the metadata table now reacts to content changes for free.
+
+## Routing: which rows get touched?
+
+When each row points to exactly one content doc (1:1), a single `updatedAt` field is enough. This is how the filesystem package works: file `abc` has metadata row `abc` and content doc with guid `abc`. The `updatedAt` value does double duty as both an observer trigger and the mtime shown in the file tree (via `stat()` reading `new Date(row.updatedAt)`).
+
+When a row references multiple content docs (1:N), one `updatedAt` can't tell you which content changed. An article might have a `code` doc and a `preview` doc; a cell might have a `formula` doc and a `result` doc. Use per-reference timestamps instead:
+
+```typescript
+const articlesTable = defineTable(
+  type({
+    id: ArticleId,
+    title: 'string',
+    code: ContentDocId,            // references the code content doc
+    preview: ContentDocId,         // references the preview content doc
+    codeUpdatedAt: 'number',      // touched when code doc changes
+    previewUpdatedAt: 'number',   // touched when preview doc changes
+  }),
+);
+```
+
+Each timestamp moves independently. A consumer that only cares about code changes watches `codeUpdatedAt` and ignores preview updates. The naming convention follows the reference column: `code` → `codeUpdatedAt`, `preview` → `previewUpdatedAt`. For 1:1 where the row ID is the only reference, plain `updatedAt` works.
+
+## Implementation notes
+
+The metadata doc uses `gc: true`, so old timestamp values get tombstoned and compacted. Frequent touches don't grow storage.
+
+Conflict resolution is a non-issue. The timestamp's job is to be different from its previous value, not to be a globally accurate clock. Two users touching `updatedAt` concurrently resolve via LWW; either value triggers observers, so the exact winner doesn't matter.
+
+The content write and the metadata touch can't share a Yjs transaction because they're different Y.Docs. Both happen in the same synchronous call chain, so the gap is negligible in practice.
+
+## What this enables
+
+| Consumer | Mechanism |
+|---|---|
+| Persistence | Compare `updatedAt > lastPersistedAt` to decide which docs need saving |
+| File tree UI | Metadata table observer fires; re-render with new mtime |
+| Cache invalidation | Skip re-processing files whose timestamp hasn't moved |
+| Selective sync | Only transfer content docs whose timestamp advanced |
+
+Instead of watching N content docs, you watch one metadata table.
+
+---
+
+Related:
+
+- [Only the Leaves Need Revision History](./only-the-leaves-need-revision-history.md): The split-doc architecture this pattern builds on
+- [YKeyValue Conflict Resolution](./ykeyvalue-timestamp-expansion.md): Timestamp semantics in YKeyValueLww
+- [Debouncing Doesn't Lose Data When the Source is Separate](./debouncing-with-separate-source-of-truth.md): Persistence patterns that pair well with this approach

--- a/docs/specs/20260215T172007-updated-at-sentinel-pattern-article.md
+++ b/docs/specs/20260215T172007-updated-at-sentinel-pattern-article.md
@@ -1,0 +1,126 @@
+# The `updatedAt` Sentinel Pattern for External Yjs Docs
+
+## problem
+
+in the split-doc architecture ("only the leaves need revision history"), metadata and content live in separate yjs documents. the metadata doc is always loaded and observed; content docs load on demand. but when a content doc changes, the metadata doc's observers don't fire. downstream systems (persistence, ui, indexes) have no signal that something happened.
+
+## pattern
+
+store an `updatedat` timestamp in the metadata row for each external content doc. bump it whenever the content doc is written to. this causes the metadata table's `.observe()` to fire, bridging the observation gap between the two layers.
+
+```
+metadata y.doc (gc: true, always loaded)
+├── files table
+│   ├── { id: 'abc', name: 'api.md', updatedat: 1739... }  ← bumped on content write
+│   └── { id: 'def', name: 'index.ts', updatedat: 1739... }
+│
+content y.doc (gc: false, loaded on demand)     ← one per file
+└── y.text('content')
+
+write flow:
+  1. user edits content doc 'abc'
+  2. contentops.write('abc', data) writes to content y.doc
+  3. filetree.touch('abc', size) bumps updatedat in metadata row
+  4. metadata table observers fire → persistence, indexes, ui react
+```
+
+## Implementation (existing)
+
+The filesystem package already implements this pattern:
+
+### Schema
+
+```typescript
+// file-table.ts
+export const filesTable = defineTable(
+  type({
+    id: FileId,
+    name: 'string',
+    parentId: FileId.or(type.null),
+    type: "'file' | 'folder'",
+    size: 'number',
+    createdAt: 'number',
+    updatedAt: 'number',       // ← the sentinel
+    trashedAt: 'number | null',
+  }),
+);
+```
+
+### Write path
+
+```typescript
+// yjs-file-system.ts — writeFile calls content write, then touches metadata
+async writeFile(path, data) {
+  // ... resolve path, create row if needed ...
+  const size = await this.content.write(id, data);  // write to content Y.Doc
+  this.tree.touch(id, size);                         // bump updatedAt in metadata
+}
+
+// file-tree.ts — touch updates the sentinel
+touch(id: FileId, size: number): void {
+  this.filesTable.update(id, { size, updatedAt: Date.now() });
+}
+```
+
+### Observer chain
+
+```typescript
+// file-system-index.ts — observes metadata table, rebuilds indexes
+const unobserve = filesTable.observe(() => {
+  rebuild();  // fires when updatedAt changes, among other things
+});
+
+// desktop.ts — persistence observes the Y.Doc for any update
+ydoc.on('update', () => {
+  const state = Y.encodeStateAsUpdate(ydoc);
+  writeFileSync(filePath, state);
+});
+```
+
+## 1:1 case (one content doc per row)
+
+When each row maps to exactly one external doc, a single `updatedAt` field is enough. The row's `id` doubles as the content doc's GUID. This is the filesystem's approach.
+
+## 1:N case (multiple content docs per row)
+
+When a row references multiple external docs (e.g., a `code` doc and a `preview` doc stored in separate columns), use per-column sentinels:
+
+```typescript
+const articlesTable = defineTable(
+  type({
+    id: ArticleId,
+    title: 'string',
+    // ... other fields ...
+    codeUpdatedAt: 'number',     // ← tracks code content doc
+    previewUpdatedAt: 'number',  // ← tracks preview content doc
+  }),
+);
+```
+
+Each sentinel gets bumped independently when its corresponding content doc changes. Consumers can watch specific sentinel columns for fine-grained reactivity rather than reacting to every content change on the row.
+
+## What this enables
+
+| Consumer | How it uses the sentinel |
+|---|---|
+| Persistence | "Has this file changed since I last saved?" Compare `updatedAt` > `lastPersistedAt` |
+| UI (file tree) | Metadata table observer fires → re-render file list with updated mtime |
+| Cache invalidation | Skip re-processing files whose `updatedAt` hasn't moved |
+| Selective sync | Only persist content docs whose sentinel advanced |
+
+## Implementation considerations
+
+- Use `Date.now()` for the timestamp. Lamport-like timestamps (as in YKeyValueLww) are overkill here since the sentinel doesn't need conflict resolution semantics; it just needs to be "different from before."
+- The touch must happen immediately after the content write, not inside the content doc's transaction (they're separate Y.Docs, so they can't share a Yjs transaction).
+- The metadata doc has `gc: true`, so old sentinel values compact away. No storage bloat from frequent updates.
+
+## Deliverables
+
+- [x] Spec at `docs/specs/20260215T172007-updated-at-sentinel-pattern-article.md`
+- [x] Article at `docs/articles/updated-at-sentinel-for-external-yjs-docs.md`
+
+## Related
+
+- [Only the Leaves Need Revision History](../articles/only-the-leaves-need-revision-history.md)
+- [YKeyValue Timestamp Expansion](../articles/ykeyvalue-timestamp-expansion.md)
+- [Debouncing Doesn't Lose Data When the Source is Separate](../articles/debouncing-with-separate-source-of-truth.md)


### PR DESCRIPTION
## Summary
- Adds documentation articles covering the updatedAt sentinel pattern for external Yjs docs
- Includes both an article and a spec/planning document