### PR TITLE
refactor: replace dynamic imports with static, codify testing conventions

### DIFF
--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -1,0 +1,423 @@
+---
+name: testing
+description: Test file conventions for setup functions, factory patterns, test organization, type testing, and naming. Use when writing or modifying *.test.ts files, creating test setup functions, or reviewing test structure.
+---
+
+# Test File Conventions
+
+## File-Level Doc Comments
+
+Every `.test.ts` file MUST start with a JSDoc block explaining what is being tested and the key behaviors verified. This serves as documentation for the module's contract.
+
+### Structure
+
+```typescript
+/**
+ * [Module Name] Tests
+ *
+ * [1-3 sentences explaining what this file tests and why these tests matter.]
+ *
+ * Key behaviors:
+ * - [Behavior 1]
+ * - [Behavior 2]
+ * - [Behavior 3]
+ *
+ * See also:
+ * - `related-file.test.ts` for [related aspect]
+ */
+```
+
+### Good Example
+
+```typescript
+/**
+ * Cell-Level LWW CRDT Sync Tests
+ *
+ * Verifies cell-level LWW conflict resolution where each field
+ * has its own timestamp. Unlike row-level LWW, concurrent edits to
+ * DIFFERENT fields merge independently.
+ *
+ * Key behaviors:
+ * - Concurrent edits to SAME field: latest timestamp wins
+ * - Concurrent edits to DIFFERENT fields: BOTH preserved (merge)
+ * - Delete removes all cells for a row
+ */
+```
+
+### Bad Example (Too Minimal)
+
+```typescript
+// Tests for create-tables
+```
+
+### Section Headers
+
+For long test files (100+ lines), use comment headers to separate logical sections:
+
+```typescript
+// ============================================================================
+// MESSAGE_SYNC Tests
+// ============================================================================
+```
+
+## Multi-Aspect Test File Splitting
+
+When a module has distinct behavioral aspects, split into focused test files rather than one monolithic file:
+
+| Pattern                       | Use Case                                             |
+| ----------------------------- | ---------------------------------------------------- |
+| `{module}.test.ts`            | Core CRUD behavior, happy paths, edge cases          |
+| `{module}.types.test.ts`      | Type inference verification, negative type tests     |
+| `{module}.{scenario}.test.ts` | Specific scenarios (CRDT sync, offline, integration) |
+
+### When to Split
+
+- File exceeds ~500 lines
+- Tests cover genuinely distinct concerns (CRUD vs sync vs types)
+- Different setup requirements per concern
+
+### When NOT to Split
+
+- Splitting would create files with fewer than 3 tests
+- All tests share the same setup and concern
+
+## Test Naming
+
+Test descriptions MUST be behavior assertions, not vague descriptions. The name should tell you what broke when the test fails.
+
+### Rules
+
+1. **State what happens**, not "should work" or "handles correctly"
+2. **Include the condition** when testing edge cases
+3. **No filler words**: "should", "correctly", "properly" add nothing
+
+### Good Names
+
+```typescript
+test('upsert stores row and get retrieves it', () => { ... });
+test('filter returns only published posts', () => { ... });
+test('concurrent edits to different fields: both preserved', () => { ... });
+test('delete vs update race: update wins (rightmost entry)', () => { ... });
+test('observer fires once per transaction, not per operation', () => { ... });
+test('get() throws for undefined tables with helpful message', () => { ... });
+```
+
+### Bad Names
+
+```typescript
+test('should work correctly', () => { ... });         // What works? What's correct?
+test('should handle batch operations', () => { ... }); // Handle how?
+test('basic test', () => { ... });                     // Says nothing
+test('should create and retrieve rows correctly', () => { ... }); // Vague "correctly"
+```
+
+### Pattern: `{action} {outcome} [condition]`
+
+```
+"upsert stores row and get retrieves it"
+ ^^^^^^ ^^^^^^^^^^   ^^^ ^^^^^^^^^^^^^
+ action  outcome    action  outcome
+
+"observer fires once per transaction, not per operation"
+ ^^^^^^^^ ^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ subject   outcome              condition
+
+"get() returns not_found for non-existent rows"
+ ^^^^^ ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^
+ action     outcome            condition
+```
+
+## Negative Type Tests
+
+For library code, test that incorrect types are rejected. Use `@ts-expect-error` to verify the compiler catches type errors.
+
+### When to Use
+
+- `.types.test.ts` files testing type inference
+- Any test verifying a public API's type constraints
+- Especially important for generic APIs where incorrect input should fail at compile time
+
+### Pattern
+
+```typescript
+test('rejects invalid row data at compile time', () => {
+	const doc = createTables(new Y.Doc(), [
+		table({
+			id: 'posts',
+			name: '',
+			fields: [id(), text({ id: 'title' })] as const,
+		}),
+	]);
+
+	// @ts-expect-error — missing required field 'title'
+	doc.get('posts').upsert({ id: Id('1') });
+
+	// @ts-expect-error — wrong type for 'title' (number instead of string)
+	doc.get('posts').upsert({ id: Id('1'), title: 42 });
+
+	// @ts-expect-error — unknown table name
+	doc.get('nonexistent');
+});
+```
+
+### Rules
+
+1. ALWAYS include a comment explaining what error is expected: `// @ts-expect-error — [reason]`
+2. One `@ts-expect-error` per assertion — don't stack them
+3. Group negative type tests in their own `describe('type errors', () => { ... })` block
+4. These tests verify the compiler catches errors — they don't need runtime assertions
+
+### In `bun:test` (No `expectTypeOf`)
+
+Since we use `bun:test` (not Vitest), we don't have `expectTypeOf`. Use these alternatives:
+
+- **Positive type tests**: Let TypeScript check the types — if it compiles, the types work. Add comments like `// Type: { id: string; title: string }` for documentation.
+- **Negative type tests**: `@ts-expect-error` to verify rejection
+- **CI enforcement**: `bun typecheck` (runs `tsc --noEmit`) catches type regressions
+
+## No `as any` in Tests
+
+Tests MUST NOT use `as any` to bypass type checking. Tests should prove the types work, not circumvent them.
+
+### Alternatives
+
+| Instead of                          | Use                                                                                                     |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `(obj as any).privateMethod()`      | Test through the public API                                                                             |
+| `tables.get('bad' as any)`          | Keep `as any` ONLY when testing runtime error handling for invalid input — add a comment explaining why |
+| `createMock() as any`               | Create a properly typed mock or use a minimal type                                                      |
+| `(content as any).store.ensure(id)` | Expose a test-only accessor or test through public API                                                  |
+
+### Acceptable `as any` (With Comment)
+
+```typescript
+// Testing runtime error for invalid table name — bypasses TypeScript intentionally
+expect(() => tables.get('nonexistent' as any)).toThrow(
+	/Table 'nonexistent' not found/,
+);
+```
+
+### Never Acceptable
+
+```typescript
+// Bad — hiding a real type problem
+const result = someFunction(data as any);
+expect(result).toBe('expected');
+```
+
+## The `setup()` Pattern
+
+Every test file that needs shared infrastructure MUST have a `setup()` function. This replaces `beforeEach` for code reuse, following Kent C. Dodds' principle: "We have functions for that."
+
+### Rules
+
+1. `setup()` ALWAYS returns a destructured object, even for single values
+2. Tests ALWAYS destructure the return: `const { thing } = setup()`
+3. `setup()` is a plain function, not a hook — each test calls it independently
+4. No mutable `let` variables at describe scope — setup returns fresh state per test
+
+### Why Always an Object (Even for One Value)
+
+- **Extensibility**: Adding a second value later doesn't require changing any existing callsites
+- **Self-documenting**: `const { files } = setup()` tells you what you're getting by name
+- **Consistency**: Every test file follows the same pattern — no guessing
+
+### Single Value
+
+```typescript
+// Good — always an object, even for one thing
+function setup() {
+	const ws = createWorkspace({ id: 'test', tables: { files: filesTable } });
+	return { files: ws.tables.files };
+}
+
+test('creates a file', () => {
+	const { files } = setup();
+	files.set({ id: '1', name: 'test.txt', _v: 1 });
+	expect(files.has('1')).toBe(true);
+});
+```
+
+```typescript
+// Bad — returns value directly
+function setup() {
+	const ws = createWorkspace({ id: 'test', tables: { files: filesTable } });
+	return ws.tables.files; // No destructuring = breaks convention
+}
+```
+
+### Multiple Values
+
+```typescript
+function setup() {
+	const ydoc = new Y.Doc();
+	const yarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>('test-table');
+	const ykv = new YKeyValueLww(yarray);
+	return { ydoc, yarray, ykv };
+}
+
+test('stores a row', () => {
+	const { ykv } = setup(); // Take only what you need
+	// ...
+});
+
+test('atomic transactions', () => {
+	const { ydoc, ykv } = setup(); // Take multiple when needed
+	ydoc.transact(() => {
+		ykv.set('1', { name: 'Alice' });
+	});
+});
+```
+
+### Composable Setup Functions
+
+When tests need additional setup beyond the base, create composable setup variants that build on `setup()`:
+
+```typescript
+function setup() {
+	const tableDef = defineTable(fileSchema);
+	const ydoc = new Y.Doc({ guid: 'test-workspace' });
+	const tables = createTables(ydoc, { files: tableDef });
+	return { ydoc, tables };
+}
+
+function setupWithBinding(
+	overrides?: Partial<Parameters<typeof createDocumentBinding>[0]>,
+) {
+	const { ydoc, tables } = setup();
+	const binding = createDocumentBinding({
+		guidKey: 'id',
+		tableHelper: tables.files,
+		ydoc,
+		...overrides,
+	});
+	return { ydoc, tables, binding };
+}
+```
+
+### When `setup()` Is NOT Needed
+
+- Pure function tests with no shared infrastructure (e.g., `parseFrontmatter('# Hello')`)
+- Tests where each case has completely different inputs with no overlap
+- Type-only test files (`*.test-d.ts`)
+
+## Avoid `beforeEach` for Setup
+
+Use `beforeEach`/`afterEach` ONLY for cleanup that must run even if a test fails (server shutdown, spy restoration). Never use them for data setup.
+
+```typescript
+// Bad — mutable state, hidden setup
+let files: TableHelper;
+beforeEach(() => {
+	const ws = createWorkspace({ id: 'test', tables: { files: filesTable } });
+	files = ws.tables.files;
+});
+
+// Good — setup function, immutable per-test
+function setup() {
+	const ws = createWorkspace({ id: 'test', tables: { files: filesTable } });
+	return { files: ws.tables.files };
+}
+```
+
+## Shared Schemas at Module Level
+
+Schemas and table definitions used across multiple tests should be defined at module level, outside `setup()`:
+
+```typescript
+const fileSchema = type({
+	id: 'string',
+	name: 'string',
+	updatedAt: 'number',
+	_v: '1',
+});
+
+const filesTable = defineTable(fileSchema);
+
+function setup() {
+	const ws = createWorkspace({ id: 'test', tables: { files: filesTable } });
+	return { files: ws.tables.files };
+}
+```
+
+These are stateless definitions — safe to share. Stateful objects (Y.Doc, workspace instances) go in `setup()`.
+
+## Don't Return Dead Weight
+
+Every property in the setup return should be used by at least one test. If no test uses `ydoc`, don't return it:
+
+```typescript
+// Bad — ydoc is never destructured by any test
+function setup() {
+	const ydoc = new Y.Doc();
+	return { ydoc, tl: createTimeline(ydoc) };
+}
+
+// Good — only return what tests actually use
+function setup() {
+	return { tl: createTimeline(new Y.Doc()) };
+}
+```
+
+Exception: if a value is needed for cleanup or might be needed by future tests in the same file, keeping it is fine.
+
+## Test Structure
+
+### Flat Over Nested
+
+Prefer flat `test()` calls. Use `describe()` only to group genuinely distinct behavioral categories of the same unit:
+
+```typescript
+// Good — describe groups behaviors, tests are flat within
+describe('FileTree', () => {
+	describe('create', () => {
+		test('creates file at root', () => { ... });
+		test('rejects invalid names', () => { ... });
+	});
+
+	describe('move', () => {
+		test('renames file', () => { ... });
+		test('moves to different parent', () => { ... });
+	});
+});
+```
+
+```typescript
+// Bad — unnecessary nesting
+describe('FileTree', () => {
+	describe('create', () => {
+		describe('when the name is valid', () => {
+			describe('and the parent exists', () => {
+				test('creates the file', () => { ... });
+			});
+		});
+	});
+});
+```
+
+### Helper Functions Over Nesting
+
+When tests need different setup scenarios, use named setup variants (not nested `describe` + `beforeEach`):
+
+```typescript
+// Good — composable setup functions
+function setupWithFiles() {
+	const { files } = setup();
+	files.set(makeRow('f1', 'test.txt'));
+	files.set(makeRow('f2', 'other.txt'));
+	return { files };
+}
+
+test('lists all files', () => {
+	const { files } = setupWithFiles();
+	expect(files.count()).toBe(2);
+});
+```
+
+## References
+
+- Kent C. Dodds, ["Avoid Nesting When You're Testing"](https://kentcdodds.com/blog/avoid-nesting-when-youre-testing) — setup functions over beforeEach, flat tests
+- Kent C. Dodds, ["AHA Testing"](https://kentcdodds.com/blog/aha-testing) — avoid hasty abstractions in tests
+- Kent C. Dodds, [Testing JavaScript](https://testingjavascript.com) — Test Object Factory Pattern
+- Matt Pocock, ["How to test your types"](https://www.totaltypescript.com/how-to-test-your-types) — vitest `expectTypeOf` for type testing
+- Matt Pocock, [`shoehorn`](https://github.com/total-typescript/shoehorn) — partial mocks for test ergonomics

--- a/packages/epicenter/scripts/stress-test-static.ts
+++ b/packages/epicenter/scripts/stress-test-static.ts
@@ -8,6 +8,7 @@
  * Run: bun packages/epicenter/scripts/stress-test-static.ts
  */
 
+import { unlinkSync } from 'node:fs';
 import { type } from 'arktype';
 import * as Y from 'yjs';
 import { createTables, defineTable } from '../src/static/index.js';
@@ -158,7 +159,6 @@ async function main() {
 	ydoc2.destroy();
 
 	// Cleanup output file
-	const { unlinkSync } = await import('node:fs');
 	unlinkSync(OUTPUT_PATH);
 	console.log(`\nCleaned up ${OUTPUT_PATH}`);
 }

--- a/packages/epicenter/src/cli/command-builder.test.ts
+++ b/packages/epicenter/src/cli/command-builder.test.ts
@@ -1,3 +1,14 @@
+/**
+ * Command Builder Tests
+ *
+ * These tests verify that action trees are converted into executable yargs command
+ * definitions with stable command paths, descriptions, and builders. They ensure the
+ * CLI can expose both flat and nested contracts consistently.
+ *
+ * Key behaviors:
+ * - Flattens nested action objects into space-delimited command paths
+ * - Builds per-command yargs option builders from input schemas
+ */
 import { describe, expect, test } from 'bun:test';
 import { type } from 'arktype';
 import { defineMutation, defineQuery } from '../shared/actions';
@@ -113,7 +124,7 @@ describe('buildActionCommands', () => {
 		expect(commands).toEqual([]);
 	});
 
-	test('handles mixed flat and nested actions', () => {
+	test('builds commands for mixed flat and nested action trees', () => {
 		const actions = {
 			ping: defineQuery({
 				handler: () => 'pong',

--- a/packages/epicenter/src/cli/format-output.test.ts
+++ b/packages/epicenter/src/cli/format-output.test.ts
@@ -1,3 +1,14 @@
+/**
+ * Format Output Tests
+ *
+ * These tests verify CLI JSON output formatting for interactive terminals and
+ * pipeline-friendly non-interactive usage. They ensure helpers produce deterministic
+ * pretty, compact, and JSONL output shapes.
+ *
+ * Key behaviors:
+ * - Switches between pretty and compact JSON based on TTY/format options
+ * - Serializes arrays into newline-delimited JSON for JSONL output
+ */
 import { afterEach, describe, expect, test } from 'bun:test';
 import { formatJson, formatJsonl, output } from './format-output.js';
 
@@ -69,7 +80,7 @@ describe('formatJsonl', () => {
 		expect(result).toBe('{"value":"single"}');
 	});
 
-	test('handles mixed types', () => {
+	test('serializes mixed JSON-compatible values as one JSON value per line', () => {
 		const values = [{ a: 1 }, 'string', 42, null, [1, 2, 3]];
 		const result = formatJsonl(values);
 		expect(result).toBe('{"a":1}\n"string"\n42\nnull\n[1,2,3]');

--- a/packages/epicenter/src/cli/integration.test.ts
+++ b/packages/epicenter/src/cli/integration.test.ts
@@ -1,3 +1,14 @@
+/**
+ * CLI Integration Tests
+ *
+ * These skipped tests cover end-to-end CLI integration behavior once contract-handler
+ * separation is complete. They remain as placeholders to document intended coverage
+ * and prevent regressions when `.withHandlers()` lands.
+ *
+ * Key behaviors:
+ * - Creates a CLI instance from workspace contracts
+ * - Executes workspace commands through the CLI runtime
+ */
 import { describe, test } from 'bun:test';
 
 /**

--- a/packages/epicenter/src/cli/json-schema-to-yargs.test.ts
+++ b/packages/epicenter/src/cli/json-schema-to-yargs.test.ts
@@ -1,3 +1,14 @@
+/**
+ * JSON Schema To Yargs Tests
+ *
+ * These tests verify conversion from JSON Schema field metadata into yargs option
+ * definitions used by CLI command builders. They ensure requiredness, option types,
+ * and enum choices are preserved during translation.
+ *
+ * Key behaviors:
+ * - Maps schema property types and required flags to yargs options
+ * - Handles optional fields, literal unions, arrays, and non-object schemas
+ */
 import { describe, expect, test } from 'bun:test';
 import { type } from 'arktype';
 import { standardSchemaToJsonSchema } from '../shared/standard-schema/to-json-schema';
@@ -75,7 +86,7 @@ describe('jsonSchemaToYargsOptions', () => {
 		expect(options.tags?.type).toBe('array');
 	});
 
-	test('handles multiple fields', () => {
+	test('converts required and optional fields in one schema object', () => {
 		const schema = type({
 			title: 'string',
 			count: 'number',
@@ -98,7 +109,7 @@ describe('jsonSchemaToYargsOptions', () => {
 		expect(options).toEqual({});
 	});
 
-	test('handles schema without descriptions gracefully', () => {
+	test('leaves yargs description undefined when schema has no descriptions', () => {
 		const schema = type({ title: 'string' });
 		const jsonSchema = standardSchemaToJsonSchema(schema);
 		const options = jsonSchemaToYargsOptions(jsonSchema);

--- a/packages/epicenter/src/cli/parse-input.test.ts
+++ b/packages/epicenter/src/cli/parse-input.test.ts
@@ -1,3 +1,14 @@
+/**
+ * Parse Input Tests
+ *
+ * These tests verify how CLI JSON input is sourced and parsed across positional values,
+ * file paths, and stdin. They protect input precedence and error messaging so command
+ * handlers receive the intended payload.
+ *
+ * Key behaviors:
+ * - Accepts JSON from positional input, --file, and stdin
+ * - Applies source precedence and returns clear errors for invalid input
+ */
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/packages/epicenter/src/dynamic/kv/kv-helper.test.ts
+++ b/packages/epicenter/src/dynamic/kv/kv-helper.test.ts
@@ -1,3 +1,15 @@
+/**
+ * KV Helper Tests
+ *
+ * This file verifies dynamic key-value helpers for all supported field types,
+ * including defaults, nullability, resets, observation, and validation failures.
+ * These tests ensure KV behavior stays predictable for both direct writes and
+ * replicated Yjs data.
+ *
+ * Key behaviors:
+ * - Returns validated values and schema-aware defaults across field types
+ * - Emits key-scoped change events and surfaces invalid replicated data safely
+ */
 import { describe, expect, test } from 'bun:test';
 import { Temporal } from 'temporal-polyfill';
 import * as Y from 'yjs';
@@ -518,7 +530,7 @@ describe('KV Helpers', () => {
 	});
 
 	describe('Edge Cases', () => {
-		test('multiple sets in sequence', () => {
+		test('keeps the last value after multiple sequential sets', () => {
 			const ydoc = new Y.Doc({ guid: 'test-kv' });
 			const kv = createKv(ydoc, [integer({ id: 'count', default: 0 })]);
 
@@ -533,7 +545,7 @@ describe('KV Helpers', () => {
 			}
 		});
 
-		test('setting same value twice', () => {
+		test('emits change notifications when setting the same value repeatedly', () => {
 			const ydoc = new Y.Doc({ guid: 'test-kv' });
 			const kv = createKv(ydoc, [
 				select({
@@ -557,7 +569,7 @@ describe('KV Helpers', () => {
 			expect(values).toEqual(['dark', 'dark', 'dark']);
 		});
 
-		test('interaction between multiple KV fields', () => {
+		test('isolates updates across multiple KV fields', () => {
 			const ydoc = new Y.Doc({ guid: 'test-kv' });
 			const kv = createKv(ydoc, [
 				select({

--- a/packages/epicenter/src/dynamic/schema/converters/to-arktype.test.ts
+++ b/packages/epicenter/src/dynamic/schema/converters/to-arktype.test.ts
@@ -1,3 +1,15 @@
+/**
+ * To Arktype Converter Tests
+ *
+ * This file verifies `tableToArktype` produces ArkType validators that enforce
+ * dynamic table field constraints at runtime.
+ * The suite also confirms composed validators (`partial`, `array`, `merge`) stay
+ * usable with generated table schemas.
+ *
+ * Key behaviors:
+ * - Validates rows against generated ArkType schemas
+ * - Supports ArkType composition on generated validators
+ */
 import { describe, expect, test } from 'bun:test';
 import { type } from 'arktype';
 import { Type } from 'typebox';
@@ -103,7 +115,7 @@ describe('tableToArktype', () => {
 		expect(valid).not.toBeInstanceOf(type.errors);
 	});
 
-	test('handles complex nested schema', () => {
+	test('validates nested json fields and rejects invalid nested data', () => {
 		const fields = [
 			id(),
 			text({ id: 'title' }),

--- a/packages/epicenter/src/dynamic/schema/converters/to-typebox.test.ts
+++ b/packages/epicenter/src/dynamic/schema/converters/to-typebox.test.ts
@@ -1,3 +1,15 @@
+/**
+ * To Typebox Converter Tests
+ *
+ * This file verifies `fieldToTypebox` and `fieldsToTypebox` convert dynamic
+ * schema field definitions into valid TypeBox JSON Schema structures.
+ * It protects compatibility for both runtime validation and compiled TypeBox
+ * validators used downstream.
+ *
+ * Key behaviors:
+ * - Maps each field type to the expected TypeBox validation shape
+ * - Preserves JSON-schema compatibility for nested json fields and compiled checks
+ */
 import { describe, expect, test } from 'bun:test';
 import { Type } from 'typebox';
 import { Compile } from 'typebox/compile';
@@ -87,7 +99,7 @@ describe('fieldToTypebox', () => {
 			const schema = fieldToTypebox(real({ id: 'price' }));
 			expect(Value.Check(schema, 0)).toBe(true);
 			expect(Value.Check(schema, 42)).toBe(true);
-			expect(Value.Check(schema, 3.14159)).toBe(true);
+			expect(Value.Check(schema, Math.PI)).toBe(true);
 			expect(Value.Check(schema, -99.99)).toBe(true);
 		});
 

--- a/packages/epicenter/src/dynamic/schema/fields/regex.test.ts
+++ b/packages/epicenter/src/dynamic/schema/fields/regex.test.ts
@@ -1,15 +1,13 @@
 /**
- * @fileoverview Test suite for datetime and timezone validation regex patterns.
+ * Regex Field Validators Tests
  *
- * Tests three regex patterns used in the schema system:
- * - ISO_DATETIME_REGEX: Validates ISO 8601 datetime strings
- * - TIMEZONE_ID_REGEX: Validates IANA timezone identifiers
- * - DATE_TIME_STRING_REGEX: Validates DateTimeString format (ISO datetime + IANA timezone)
+ * This file verifies datetime and timezone regex patterns used by dynamic schema
+ * validation. It covers both accepted formats and known limitations so date
+ * parsing behavior remains explicit and stable.
  *
- * References:
- * - ISO 8601: https://en.wikipedia.org/wiki/ISO_8601
- * - IANA Time Zones: https://www.iana.org/time-zones
- * - Date.toISOString(): https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
+ * Key behaviors:
+ * - Matches supported ISO datetime and DateTimeString storage formats
+ * - Rejects malformed timezone and datetime strings outside supported patterns
  */
 import { describe, expect, test } from 'bun:test';
 import {
@@ -153,31 +151,31 @@ describe('TIMEZONE_ID_REGEX', () => {
 	 * These are real timezone identifiers from the IANA Time Zone Database.
 	 */
 	describe('matches valid IANA timezone identifiers', () => {
-		test('UTC', () => {
+		test('matches standalone UTC identifier', () => {
 			expect(TIMEZONE_ID_REGEX.test('UTC')).toBe(true);
 		});
 
-		test('America/New_York', () => {
+		test('matches region/city timezone identifier', () => {
 			expect(TIMEZONE_ID_REGEX.test('America/New_York')).toBe(true);
 		});
 
-		test('Europe/London', () => {
+		test('matches Europe timezone identifier', () => {
 			expect(TIMEZONE_ID_REGEX.test('Europe/London')).toBe(true);
 		});
 
-		test('Asia/Tokyo', () => {
+		test('matches Asia timezone identifier', () => {
 			expect(TIMEZONE_ID_REGEX.test('Asia/Tokyo')).toBe(true);
 		});
 
-		test('Etc/GMT+5', () => {
+		test('matches positive GMT offset identifier', () => {
 			expect(TIMEZONE_ID_REGEX.test('Etc/GMT+5')).toBe(true);
 		});
 
-		test('Etc/GMT-5', () => {
+		test('matches negative GMT offset identifier', () => {
 			expect(TIMEZONE_ID_REGEX.test('Etc/GMT-5')).toBe(true);
 		});
 
-		test('US/Pacific', () => {
+		test('matches legacy alias timezone identifier', () => {
 			expect(TIMEZONE_ID_REGEX.test('US/Pacific')).toBe(true);
 		});
 
@@ -339,7 +337,7 @@ describe('DATE_TIME_STRING_REGEX', () => {
 	 * Verifies the regex works with commonly used timezone identifiers and realistic datetime values.
 	 */
 	describe('validates real-world timezone examples', () => {
-		test('New York Eastern Time', () => {
+		test('matches DateTimeString using America/New_York timezone', () => {
 			expect(
 				DATE_TIME_STRING_REGEX.test(
 					'2024-01-01T15:30:00.000Z|America/New_York',
@@ -347,19 +345,19 @@ describe('DATE_TIME_STRING_REGEX', () => {
 			).toBe(true);
 		});
 
-		test('Tokyo time', () => {
+		test('matches DateTimeString using Asia/Tokyo timezone', () => {
 			expect(
 				DATE_TIME_STRING_REGEX.test('2024-01-01T09:00:00.000Z|Asia/Tokyo'),
 			).toBe(true);
 		});
 
-		test('London time', () => {
+		test('matches DateTimeString using Europe/London timezone', () => {
 			expect(
 				DATE_TIME_STRING_REGEX.test('2024-07-15T14:22:33.123Z|Europe/London'),
 			).toBe(true);
 		});
 
-		test('UTC time', () => {
+		test('matches DateTimeString using UTC timezone', () => {
 			expect(DATE_TIME_STRING_REGEX.test('2024-12-31T23:59:59.999Z|UTC')).toBe(
 				true,
 			);

--- a/packages/epicenter/src/dynamic/tables/create-tables.offline-sync.test.ts
+++ b/packages/epicenter/src/dynamic/tables/create-tables.offline-sync.test.ts
@@ -1,5 +1,5 @@
 /**
- * Offline Sync Conflict Resolution Tests
+ * createTables Offline Sync Tests
  *
  * These tests verify YKeyValue's conflict resolution behavior in realistic
  * offline-first scenarios where clients edit data without seeing each other's
@@ -11,9 +11,9 @@
  *   see each other's changes before making their own.
  * - It does NOT mean "same millisecond" - it means "no causal relationship"
  *
- * KEY QUESTION: Does sync ORDER affect which value wins?
- * - If A syncs to B first, then B syncs to A - does A always win? Or B?
- * - If B syncs to A first, then A syncs to B - does the winner change?
+ * Key behaviors:
+ * - causally concurrent offline edits converge to a deterministic shared state
+ * - sync order, multi-client merges, and delayed edits do not break convergence
  */
 import { describe, expect, test } from 'bun:test';
 import * as Y from 'yjs';

--- a/packages/epicenter/src/dynamic/tables/create-tables.test.ts
+++ b/packages/epicenter/src/dynamic/tables/create-tables.test.ts
@@ -1,10 +1,21 @@
+/**
+ * createTables Tests
+ *
+ * These tests verify runtime table behavior for CRUD operations, observers,
+ * dynamic table access, and iteration helpers backed by Yjs storage.
+ * They protect API behavior for valid and invalid data paths.
+ *
+ * Key behaviors:
+ * - CRUD and query helpers return expected row results
+ * - observers emit changed row IDs across single and batched transactions
+ */
 import { describe, expect, test } from 'bun:test';
 import * as Y from 'yjs';
 import { boolean, Id, id, integer, table, tags, text } from '../schema';
 import { createTables } from './create-tables';
 
 describe('createTables', () => {
-	test('should create and retrieve rows correctly', () => {
+	test('upsert stores row and get retrieves it', () => {
 		const ydoc = new Y.Doc({ guid: 'test-workspace' });
 		const doc = createTables(ydoc, [
 			table({
@@ -37,7 +48,7 @@ describe('createTables', () => {
 		}
 	});
 
-	test('should handle batch operations', () => {
+	test('upsertMany creates multiple rows retrieved by get', () => {
 		const ydoc = new Y.Doc({ guid: 'test-workspace' });
 		const doc = createTables(ydoc, [
 			table({
@@ -71,7 +82,7 @@ describe('createTables', () => {
 		}
 	});
 
-	test('should filter and find rows correctly', () => {
+	test('filter returns matching rows and find returns first match', () => {
 		const ydoc = new Y.Doc({ guid: 'test-workspace' });
 		const doc = createTables(ydoc, [
 			table({
@@ -104,7 +115,7 @@ describe('createTables', () => {
 		}
 	});
 
-	test('should return not_found status for non-existent rows', () => {
+	test('get returns not_found for non-existent rows', () => {
 		const ydoc = new Y.Doc({ guid: 'test-workspace' });
 		const doc = createTables(ydoc, [
 			table({
@@ -133,7 +144,7 @@ describe('createTables', () => {
 		expect(findResult).toBeNull();
 	});
 
-	test('should store and retrieve richtext and tags correctly', () => {
+	test('upsert stores tags array and get returns plain array', () => {
 		const ydoc = new Y.Doc({ guid: 'test-workspace' });
 		const doc = createTables(ydoc, [
 			table({
@@ -784,7 +795,7 @@ describe('createTables', () => {
 			]);
 
 			// Accessing a table not in definition should throw
-			// Use `as any` to bypass TypeScript - we're testing runtime error handling
+			// Testing runtime error for invalid table name — bypasses TypeScript intentionally
 			expect(() => tables.get('custom_data' as any)).toThrow(
 				/Table 'custom_data' not found/,
 			);

--- a/packages/epicenter/src/dynamic/tables/y-cell-store.test.ts
+++ b/packages/epicenter/src/dynamic/tables/y-cell-store.test.ts
@@ -1,16 +1,13 @@
 /**
- * YCellStore Tests - Schema-agnostic Sparse Grid Storage
+ * YCellStore Tests
  *
- * Tests cover:
- * 1. Cell CRUD: setCell, getCell, hasCell, deleteCell
- * 2. Key validation: rowId with ':' throws error
- * 3. Batch operations: multiple cell operations atomically
- * 4. Observer fires once per batch: not per operation
- * 5. Change types: add, update, delete events with correct rowId/columnId
- * 6. Iteration: cells() yields all cells with parsed components
- * 7. Count accuracy: after various operations
- * 8. Clear: removes all cells
- * 9. Escape hatch: ykv and doc accessible
+ * These tests verify the schema-agnostic cell store used as the dynamic table
+ * storage primitive, including CRUD behavior, transactions, observation, and
+ * low-level escape hatches.
+ *
+ * Key behaviors:
+ * - cell operations preserve key semantics and emit correct change events
+ * - batching, iteration, clear, and CRDT sync remain internally consistent
  */
 import { describe, expect, test } from 'bun:test';
 import * as Y from 'yjs';
@@ -18,7 +15,7 @@ import { type CellChange, createCellStore } from './y-cell-store';
 
 describe('YCellStore', () => {
 	describe('Cell CRUD', () => {
-		test('setCell and getCell work correctly', () => {
+		test('setCell stores value and getCell retrieves it', () => {
 			const ydoc = new Y.Doc({ guid: 'test' });
 			const cells = createCellStore<string>(ydoc, 'cells');
 

--- a/packages/epicenter/src/dynamic/tables/y-row-store.test.ts
+++ b/packages/epicenter/src/dynamic/tables/y-row-store.test.ts
@@ -1,20 +1,13 @@
 /**
- * YRowStore Tests - Row Operations Wrapper over CellStore
+ * YRowStore Tests
  *
- * Tests cover:
- * 1. Row reconstruction: get() assembles cells correctly
- * 2. Row existence: has() returns true only if cells exist
- * 3. Row IDs: ids() returns deduplicated list
- * 4. Get all rows: getAll() reconstructs all rows
- * 5. Row count: count() matches unique row count
- * 6. Row deletion: delete() removes all cells for row
- * 7. Merge: merge() sets multiple cells, creates rows, preserves unmentioned columns
- * 8. Batch operations: batch() executes merge + delete atomically
- * 9. Atomic operations via doc.transact(): mixed cell/row ops in single transaction
- * 10. Observe dedupe: observe() fires with Set of changed row IDs
- * 11. Sparse rows: rows with different columns work correctly
- * 12. Column IDs with colons
- * 13. CRDT sync between documents
+ * These tests verify row-level behavior built on top of the cell store,
+ * including reconstruction, indexing, batch semantics, and observer behavior.
+ * They also validate consistency under sparse data and CRDT synchronization.
+ *
+ * Key behaviors:
+ * - row helpers reconstruct and mutate row state from underlying cells
+ * - observers and row indexes remain consistent across transactions and sync
  */
 import { describe, expect, test } from 'bun:test';
 import * as Y from 'yjs';

--- a/packages/epicenter/src/dynamic/workspace/normalize.test.ts
+++ b/packages/epicenter/src/dynamic/workspace/normalize.test.ts
@@ -1,8 +1,14 @@
 /**
- * Tests for icon and KV normalization functions.
+ * Normalize Workspace Inputs Tests
  *
- * Note: Table normalization is now handled by the `table()` factory function
- * in fields/factories.ts. See fields/factories.test.ts for table tests.
+ * This file verifies `normalizeIcon` normalizes plain emoji values into the
+ * tagged icon format while preserving already-tagged icon strings.
+ * These checks ensure workspace definitions accept common icon inputs without
+ * losing canonical storage format guarantees.
+ *
+ * Key behaviors:
+ * - Converts plain emoji strings to `emoji:`-prefixed icon values
+ * - Returns tagged icon strings and nullish inputs unchanged or normalized
  */
 
 import { describe, expect, test } from 'bun:test';

--- a/packages/epicenter/src/shared/cell-keys.test.ts
+++ b/packages/epicenter/src/shared/cell-keys.test.ts
@@ -1,3 +1,14 @@
+/**
+ * Cell Keys Utility Tests
+ *
+ * These tests verify the key format helpers that compose and parse row/column
+ * addressing strings. They protect separator rules so row identifiers remain
+ * unambiguous even when column identifiers contain colons.
+ *
+ * Key behaviors:
+ * - Key construction and parsing round-trip valid row/column combinations.
+ * - Invalid keys without separators or with invalid row ids fail fast.
+ */
 import { describe, expect, test } from 'bun:test';
 import { CellKey, extractRowId, parseCellKey, RowPrefix } from './cell-keys';
 
@@ -7,7 +18,7 @@ describe('cell-keys', () => {
 			expect(CellKey('row-1', 'title')).toBe('row-1:title');
 		});
 
-		test('roundtrips with parseCellKey', () => {
+		test('CellKey output parses back to original rowId and columnId', () => {
 			const key = CellKey('row-1', 'col-a');
 			const parsed = parseCellKey(key);
 			expect(parsed).toEqual({ rowId: 'row-1', columnId: 'col-a' });

--- a/packages/epicenter/src/shared/y-doc-sync.test.ts
+++ b/packages/epicenter/src/shared/y-doc-sync.test.ts
@@ -1,3 +1,14 @@
+/**
+ * YDoc Sync Utility Tests
+ *
+ * These tests validate string-to-CRDT sync helpers for `Y.Text` and `Y.XmlFragment`.
+ * They ensure updates are minimal when possible, transactional when required, and safe
+ * when called with detached Yjs types.
+ *
+ * Key behaviors:
+ * - Identical content is a no-op, while diffs apply expected text or fragment updates.
+ * - Helpers preserve convergence guarantees and emit predictable transaction counts.
+ */
 import { describe, expect, test } from 'bun:test';
 import * as Y from 'yjs';
 import {
@@ -46,7 +57,7 @@ describe('updateYTextFromString', () => {
 		expect(ytext.toString()).toBe('xyz');
 	});
 
-	test('works with empty initial content', () => {
+	test('inserts target content when initial text is empty', () => {
 		const ydoc = new Y.Doc();
 		const ytext = ydoc.getText('text');
 
@@ -54,7 +65,7 @@ describe('updateYTextFromString', () => {
 		expect(ytext.toString()).toBe('Hello');
 	});
 
-	test('works when target is empty', () => {
+	test('deletes all content when target text is empty', () => {
 		const ydoc = new Y.Doc();
 		const ytext = ydoc.getText('text');
 		ytext.insert(0, 'Hello');
@@ -170,7 +181,7 @@ describe('updateYXmlFragmentFromString', () => {
 		expect(serialize(frag)).toBe('replaced');
 	});
 
-	test('works with empty initial content', () => {
+	test('inserts target content when initial fragment is empty', () => {
 		const ydoc = new Y.Doc();
 		const frag = ydoc.getXmlFragment('richtext');
 

--- a/packages/epicenter/src/shared/y-keyvalue/ymap-simplicity-case.test.ts
+++ b/packages/epicenter/src/shared/y-keyvalue/ymap-simplicity-case.test.ts
@@ -1,8 +1,13 @@
 /**
- * The Case FOR Y.Map of Y.Maps (Native YJS)
+ * YMap Simplicity Case Tests
  *
- * This test file explores whether the simplicity of native Y.Map
- * outweighs the benefits of YKeyValue approaches.
+ * These tests evaluate whether a native `Y.Map` of `Y.Map` records is a practical
+ * default for collaborative table-like data. They focus on realistic usage patterns,
+ * conflict behavior, and implementation complexity tradeoffs.
+ *
+ * Key behaviors:
+ * - Simulated workloads show storage and merge behavior across common usage scenarios.
+ * - Cell-level collaboration converges consistently, even with concurrent edits.
  */
 import { describe, expect, test } from 'bun:test';
 import * as Y from 'yjs';
@@ -22,9 +27,10 @@ function createSimpleTable(ydoc: Y.Doc, name: string) {
 				rowMap = new Y.Map();
 				table.set(id, rowMap);
 			}
+			const ensuredRowMap = rowMap;
 			ydoc.transact(() => {
 				for (const [key, val] of Object.entries(row)) {
-					rowMap!.set(key, val);
+					ensuredRowMap.set(key, val);
 				}
 			});
 		},
@@ -157,7 +163,21 @@ describe('Realistic Storage Comparison', () => {
 		for (let user = 0; user < 5; user++) {
 			for (let edit = 0; edit < 20; edit++) {
 				const rowIdx = (user + edit) % 10;
-				const col = ['col_a', 'col_b', 'col_c', 'col_d'][edit % 4]!;
+				const colIndex = edit % 4;
+				let col: 'col_a' | 'col_b' | 'col_c' | 'col_d';
+				switch (colIndex) {
+					case 0:
+						col = 'col_a';
+						break;
+					case 1:
+						col = 'col_b';
+						break;
+					case 2:
+						col = 'col_c';
+						break;
+					default:
+						col = 'col_d';
+				}
 				rows.update({
 					id: `row-${rowIdx}`,
 					[col]: `User${user}-Edit${edit}`,

--- a/packages/epicenter/src/static/benchmark.test.ts
+++ b/packages/epicenter/src/static/benchmark.test.ts
@@ -1,8 +1,12 @@
 /**
- * Performance benchmarks for the Static Workspace API.
+ * Static Workspace Benchmark Tests
  *
- * Tests createWorkspace, table operations, and KV operations at scale.
- * Scaled to complete in reasonable time while still providing useful metrics.
+ * Benchmarks createWorkspace, table operations, KV operations, and storage growth under load.
+ * These tests provide practical performance baselines and tombstone-size observations for local-first usage.
+ *
+ * Key behaviors:
+ * - Bulk operations complete within expected runtime envelopes.
+ * - Encoded Y.Doc sizes and tombstone behavior are measurable across realistic workloads.
  */
 
 import { describe, expect, test } from 'bun:test';

--- a/packages/epicenter/src/static/create-document-binding.test.ts
+++ b/packages/epicenter/src/static/create-document-binding.test.ts
@@ -1,3 +1,14 @@
+/**
+ * createDocumentBinding Tests
+ *
+ * Validates document binding lifecycle, read/write behavior, and integration with table row metadata.
+ * The suite protects contracts around open/read/write idempotency, cleanup semantics, and hook orchestration.
+ *
+ * Key behaviors:
+ * - Document operations keep row metadata in sync and honor binding origins.
+ * - Lifecycle methods (`destroy`, `purge`, `destroyAll`) safely clean up open docs.
+ */
+
 import { describe, expect, test } from 'bun:test';
 import { type } from 'arktype';
 import * as Y from 'yjs';
@@ -60,7 +71,7 @@ describe('createDocumentBinding', () => {
 			expect(doc1).toBe(doc2);
 		});
 
-		test('accepts a row object', async () => {
+		test('open accepts a row object and resolves guid', async () => {
 			const { tables, binding } = setupWithBinding();
 			const row = {
 				id: 'f1',
@@ -74,7 +85,7 @@ describe('createDocumentBinding', () => {
 			expect(doc.guid).toBe('f1');
 		});
 
-		test('accepts a string GUID', async () => {
+		test('open accepts a string guid directly', async () => {
 			const { binding } = setupWithBinding();
 
 			const doc = await binding.open('f1');
@@ -161,7 +172,7 @@ describe('createDocumentBinding', () => {
 			expect(doc2).not.toBe(doc1);
 		});
 
-		test('destroy is safe on non-existent guid', async () => {
+		test('destroy on non-existent guid is a no-op', async () => {
 			const { binding } = setupWithBinding();
 
 			// Should not throw

--- a/packages/epicenter/src/static/create-kv.test.ts
+++ b/packages/epicenter/src/static/create-kv.test.ts
@@ -1,3 +1,14 @@
+/**
+ * createKv Tests
+ *
+ * Verifies key-value helpers over Y.Doc for set/get/delete behavior and migration-on-read.
+ * These tests protect the core KV contract used by workspace settings and metadata.
+ *
+ * Key behaviors:
+ * - `set` and `get` return typed value results with correct status states.
+ * - Versioned KV definitions migrate old values when read.
+ */
+
 import { describe, expect, test } from 'bun:test';
 import { type } from 'arktype';
 import * as Y from 'yjs';
@@ -6,7 +17,7 @@ import { createKv } from './create-kv.js';
 import { defineKv } from './define-kv.js';
 
 describe('createKv', () => {
-	test('set and get a value', () => {
+	test('set stores a value that get returns as valid', () => {
 		const ydoc = new Y.Doc();
 		const kv = createKv(ydoc, {
 			theme: defineKv(type({ mode: "'light' | 'dark'" })),

--- a/packages/epicenter/src/static/define-kv.test.ts
+++ b/packages/epicenter/src/static/define-kv.test.ts
@@ -1,3 +1,14 @@
+/**
+ * defineKv Tests
+ *
+ * Covers shorthand and builder KV definitions, including versioned migration strategies.
+ * The suite ensures KV schemas remain compatible with validation and gradual schema evolution.
+ *
+ * Key behaviors:
+ * - KV schemas validate both simple and versioned value shapes.
+ * - Migrations convert legacy values into the current schema.
+ */
+
 import { describe, expect, test } from 'bun:test';
 import { type } from 'arktype';
 import { defineKv } from './define-kv.js';
@@ -12,7 +23,7 @@ describe('defineKv', () => {
 			expect(result).not.toHaveProperty('issues');
 		});
 
-		test('migrate is identity function for shorthand', () => {
+		test('shorthand migrate returns the same value reference', () => {
 			const sidebar = defineKv(type({ collapsed: 'boolean', width: 'number' }));
 
 			const value = { collapsed: true, width: 300 };
@@ -66,7 +77,7 @@ describe('defineKv', () => {
 			expect(v2Result).not.toHaveProperty('issues');
 		});
 
-		test('migrate function transforms old version to latest', () => {
+		test('migrate function upgrades old values to latest version', () => {
 			const theme = defineKv()
 				.version(type({ mode: "'light' | 'dark'" }))
 				.version(type({ mode: "'light' | 'dark'", fontSize: 'number' }))

--- a/packages/epicenter/src/static/define-workspace.test.ts
+++ b/packages/epicenter/src/static/define-workspace.test.ts
@@ -1,3 +1,14 @@
+/**
+ * defineWorkspace Tests
+ *
+ * Validates that workspace definitions and created clients expose the expected typed APIs.
+ * The suite also covers extension chaining, lifecycle ordering, and action binding semantics.
+ *
+ * Key behaviors:
+ * - Workspace creation preserves typed access to tables, kv, and extensions.
+ * - Extension readiness and teardown order stay deterministic.
+ */
+
 import { describe, expect, test } from 'bun:test';
 import { type } from 'arktype';
 import * as Y from 'yjs';
@@ -41,7 +52,7 @@ describe('defineWorkspace', () => {
 		expect(client.kv.get).toBeDefined();
 	});
 
-	test('client.tables and client.kv work correctly', () => {
+	test('client.tables and client.kv support read and write operations', () => {
 		const client = createWorkspace({
 			id: 'test-app',
 			tables: {
@@ -163,7 +174,7 @@ describe('defineWorkspace', () => {
 		expect(destroyed).toBe(true);
 	});
 
-	test('workspace with empty tables and kv', () => {
+	test('workspace with empty tables and kv initializes base client APIs', () => {
 		const workspace = defineWorkspace({
 			id: 'empty-app',
 		});
@@ -206,7 +217,7 @@ describe('defineWorkspace', () => {
 		expect(typeof client.withExtension).toBe('function');
 	});
 
-	test('withExtension shares same ydoc', () => {
+	test('withExtension chain keeps the same ydoc instance', () => {
 		const baseClient = createWorkspace({
 			id: 'shared-doc-app',
 			tables: {

--- a/packages/epicenter/src/static/describe-workspace.test.ts
+++ b/packages/epicenter/src/static/describe-workspace.test.ts
@@ -1,3 +1,14 @@
+/**
+ * describeWorkspace Tests
+ *
+ * Validates workspace descriptor generation for tables, kv, actions, and awareness schemas.
+ * These tests ensure generated metadata is complete, serializable, and stable for introspection tooling.
+ *
+ * Key behaviors:
+ * - Descriptor includes table/kv/action metadata with expected schema structure.
+ * - Descriptor output remains JSON-serializable without circular references.
+ */
+
 import { describe, expect, test } from 'bun:test';
 import { type } from 'arktype';
 import { defineMutation, defineQuery } from '../shared/actions.js';
@@ -70,7 +81,7 @@ describe('describeWorkspace', () => {
 		expect(createAction!.input).toHaveProperty('type', 'object');
 	});
 
-	test('workspace with no actions returns empty actions array', () => {
+	test('workspace without actions returns an empty actions array', () => {
 		const posts = defineTable(type({ id: 'string', title: 'string', _v: '1' }));
 
 		const client = createWorkspace({
@@ -159,7 +170,7 @@ describe('describeWorkspace', () => {
 		expect(parsed.actions).toHaveLength(1);
 	});
 
-	test('workspace with no kv returns empty kv object', () => {
+	test('workspace without kv definitions returns an empty kv object', () => {
 		const posts = defineTable(type({ id: 'string', title: 'string', _v: '1' }));
 
 		const client = createWorkspace({
@@ -172,7 +183,7 @@ describe('describeWorkspace', () => {
 		expect(descriptor.kv).toEqual({});
 	});
 
-	test('workspace with no tables returns empty tables object', () => {
+	test('workspace without tables returns empty descriptor sections', () => {
 		const client = createWorkspace({
 			id: 'no-tables',
 		});

--- a/packages/epicenter/src/static/schema-union.test.ts
+++ b/packages/epicenter/src/static/schema-union.test.ts
@@ -1,3 +1,14 @@
+/**
+ * createUnionSchema Tests
+ *
+ * Verifies runtime and JSON Schema behavior for combined standard schemas.
+ * The suite ensures union validation chooses the correct matching schema and rejects unsupported async validators.
+ *
+ * Key behaviors:
+ * - Validation succeeds on the first matching schema and fails when none match.
+ * - Generated input/output JSON Schema uses `oneOf` consistently.
+ */
+
 import { describe, expect, test } from 'bun:test';
 import { type } from 'arktype';
 import type { CombinedStandardSchema } from '../shared/standard-schema/types.js';
@@ -31,7 +42,7 @@ describe('createUnionSchema', () => {
 		expect(result).not.toHaveProperty('issues');
 	});
 
-	test('returns error when no schema matches', () => {
+	test('returns validation issues when no schema matches', () => {
 		const v1 = type({ id: 'string', title: 'string' });
 
 		const union = createUnionSchema([v1]);

--- a/packages/epicenter/src/static/table-helper.test.ts
+++ b/packages/epicenter/src/static/table-helper.test.ts
@@ -1,3 +1,14 @@
+/**
+ * createTableHelper Tests
+ *
+ * Exercises the table helper CRUD, query, observation, and migration paths over the YKeyValueLww store.
+ * These tests ensure row validation and migration behavior remain consistent for both valid and corrupted data.
+ *
+ * Key behaviors:
+ * - CRUD and query operations return discriminated statuses with correct payloads.
+ * - Observers and migration logic handle batched and legacy data safely.
+ */
+
 import { describe, expect, test } from 'bun:test';
 import { type } from 'arktype';
 import * as Y from 'yjs';
@@ -18,7 +29,7 @@ function setup() {
 
 describe('createTableHelper', () => {
 	describe('set operations', () => {
-		test('set stores a row', () => {
+		test('set stores a row that get returns as valid', () => {
 			const { ykv } = setup();
 			const definition = defineTable(
 				type({ id: 'string', name: 'string', _v: '1' }),
@@ -221,7 +232,7 @@ describe('createTableHelper', () => {
 			expect(found).toEqual({ id: '2', name: 'Bob', _v: 1 });
 		});
 
-		test('find returns undefined when no match', () => {
+		test('find returns undefined when no rows match', () => {
 			const { ykv } = setup();
 			const definition = defineTable(
 				type({ id: 'string', name: 'string', _v: '1' }),
@@ -504,7 +515,7 @@ describe('createTableHelper', () => {
 	});
 
 	describe('metadata', () => {
-		test('count returns number of rows', () => {
+		test('count returns the current number of rows', () => {
 			const { ydoc, ykv } = setup();
 			const definition = defineTable(
 				type({ id: 'string', name: 'string', _v: '1' }),

--- a/packages/filesystem/src/content-doc-store.test.ts
+++ b/packages/filesystem/src/content-doc-store.test.ts
@@ -1,3 +1,15 @@
+/**
+ * Content Doc Store Tests
+ *
+ * Validates lazy Y.Doc lifecycle management for file content documents, including
+ * provider integration. These tests guard cleanup and concurrency behavior that
+ * prevents leaked docs or duplicate provider initialization.
+ *
+ * Key behaviors:
+ * - `ensure`, `destroy`, and `destroyAll` manage Y.Doc instances deterministically.
+ * - Provider factories run once per doc and are cleaned up on failures and teardown.
+ */
+
 import { describe, expect, test } from 'bun:test';
 import type { Lifecycle } from '@epicenter/hq';
 import type { ProviderFactory } from '@epicenter/hq/dynamic';

--- a/packages/filesystem/src/content-ops.test.ts
+++ b/packages/filesystem/src/content-ops.test.ts
@@ -216,7 +216,6 @@ describe('ContentOps', () => {
 			const id = generateFileId();
 			// Push a sheet entry via timeline
 			const ydoc = await (content as any).store.ensure(id);
-			const { createTimeline } = await import('./timeline-helpers.js');
 			const tl = createTimeline(ydoc);
 			ydoc.transact(() => tl.pushSheetFromCsv('Name,Age\nAlice,30\nBob,25\n'));
 			expect(await content.read(id)).toBe('Name,Age\nAlice,30\nBob,25\n');
@@ -226,7 +225,6 @@ describe('ContentOps', () => {
 			const content = setup();
 			const id = generateFileId();
 			const ydoc = await (content as any).store.ensure(id);
-			const { createTimeline } = await import('./timeline-helpers.js');
 			const tl = createTimeline(ydoc);
 			ydoc.transact(() => tl.pushSheetFromCsv('A,B\n1,2\n'));
 			await content.write(id, 'X,Y\n3,4\n');
@@ -239,7 +237,6 @@ describe('ContentOps', () => {
 			const content = setup();
 			const id = generateFileId();
 			const ydoc = await (content as any).store.ensure(id);
-			const { createTimeline } = await import('./timeline-helpers.js');
 			ydoc.transact(() => createTimeline(ydoc).pushSheetFromCsv('A\n1\n'));
 			const size = await content.write(id, 'X,Y\n3,4\n');
 			expect(size).toBe(new TextEncoder().encode('X,Y\n3,4\n').byteLength);
@@ -249,7 +246,6 @@ describe('ContentOps', () => {
 			const content = setup();
 			const id = generateFileId();
 			const ydoc = await (content as any).store.ensure(id);
-			const { createTimeline } = await import('./timeline-helpers.js');
 			ydoc.transact(() => createTimeline(ydoc).pushSheetFromCsv('A\n1\n'));
 			await content.write(id, new Uint8Array([0xde, 0xad]));
 			expect(createTimeline(ydoc).length).toBe(2);

--- a/packages/filesystem/src/content-ops.test.ts
+++ b/packages/filesystem/src/content-ops.test.ts
@@ -1,29 +1,48 @@
+/**
+ * ContentOps Tests
+ *
+ * Validates content read/write behavior across text, binary, and sheet timeline modes.
+ * These tests protect mode-switch semantics and timeline growth rules that power file storage correctness.
+ *
+ * Key behaviors:
+ * - Reading and writing preserve content and byte-size semantics.
+ * - Timeline entries grow only when mode transitions require new history entries.
+ */
+
 import { describe, expect, test } from 'bun:test';
 import { ContentOps } from './content-ops.js';
 import { createTimeline } from './timeline-helpers.js';
 import { generateFileId } from './types.js';
 
+type ContentOpsWithStore = {
+	store: {
+		ensure: (
+			id: ReturnType<typeof generateFileId>,
+		) => Promise<Parameters<typeof createTimeline>[0]>;
+	};
+};
+
 function setup() {
-	return new ContentOps();
+	return { content: new ContentOps() };
 }
 
 describe('ContentOps', () => {
 	describe('read', () => {
 		test('empty file returns empty string', async () => {
-			const content = setup();
+			const { content } = setup();
 			const id = generateFileId();
 			expect(await content.read(id)).toBe('');
 		});
 
 		test('reads written text', async () => {
-			const content = setup();
+			const { content } = setup();
 			const id = generateFileId();
 			await content.write(id, 'hello world');
 			expect(await content.read(id)).toBe('hello world');
 		});
 
 		test('reads binary data as decoded string', async () => {
-			const content = setup();
+			const { content } = setup();
 			const id = generateFileId();
 			const data = new Uint8Array([0x48, 0x65, 0x6c, 0x6c, 0x6f]); // "Hello"
 			await content.write(id, data);
@@ -33,13 +52,13 @@ describe('ContentOps', () => {
 
 	describe('readBuffer', () => {
 		test('empty file returns empty Uint8Array', async () => {
-			const content = setup();
+			const { content } = setup();
 			const id = generateFileId();
 			expect(await content.readBuffer(id)).toEqual(new Uint8Array());
 		});
 
 		test('reads text as encoded bytes', async () => {
-			const content = setup();
+			const { content } = setup();
 			const id = generateFileId();
 			await content.write(id, 'hello');
 			expect(await content.readBuffer(id)).toEqual(
@@ -48,7 +67,7 @@ describe('ContentOps', () => {
 		});
 
 		test('reads binary data as-is', async () => {
-			const content = setup();
+			const { content } = setup();
 			const id = generateFileId();
 			const data = new Uint8Array([0xff, 0xfe, 0xfd]);
 			await content.write(id, data);
@@ -58,21 +77,21 @@ describe('ContentOps', () => {
 
 	describe('write', () => {
 		test('text write returns byte size', async () => {
-			const content = setup();
+			const { content } = setup();
 			const id = generateFileId();
 			const size = await content.write(id, 'hello');
 			expect(size).toBe(5);
 		});
 
 		test('unicode text returns correct byte size', async () => {
-			const content = setup();
+			const { content } = setup();
 			const id = generateFileId();
 			const size = await content.write(id, '\u{1F600}'); // emoji is 4 bytes in UTF-8
 			expect(size).toBe(4);
 		});
 
 		test('binary write returns byte size', async () => {
-			const content = setup();
+			const { content } = setup();
 			const id = generateFileId();
 			const data = new Uint8Array([1, 2, 3, 4]);
 			const size = await content.write(id, data);
@@ -80,7 +99,7 @@ describe('ContentOps', () => {
 		});
 
 		test('text overwrite reuses same timeline entry', async () => {
-			const content = setup();
+			const { content } = setup();
 			const id = generateFileId();
 			await content.write(id, 'first');
 			await content.write(id, 'second');
@@ -88,25 +107,31 @@ describe('ContentOps', () => {
 			expect(await content.read(id)).toBe('third');
 
 			// Verify timeline didn't grow
-			const ydoc = await (content as any).store.ensure(id);
+			// Accessing internal store API not exposed in public types — needed for test setup
+			const ydoc = await (
+				content as unknown as ContentOpsWithStore
+			).store.ensure(id);
 			expect(createTimeline(ydoc).length).toBe(1);
 		});
 
 		test('binary write always pushes new entry', async () => {
-			const content = setup();
+			const { content } = setup();
 			const id = generateFileId();
 			await content.write(id, new Uint8Array([1]));
 			await content.write(id, new Uint8Array([2]));
 			await content.write(id, new Uint8Array([3]));
 
-			const ydoc = await (content as any).store.ensure(id);
+			// Accessing internal store API not exposed in public types — needed for test setup
+			const ydoc = await (
+				content as unknown as ContentOpsWithStore
+			).store.ensure(id);
 			expect(createTimeline(ydoc).length).toBe(3);
 		});
 	});
 
 	describe('mode switching', () => {
-		test('text → binary → text', async () => {
-			const content = setup();
+		test('switches text to binary to text and keeps the latest text', async () => {
+			const { content } = setup();
 			const id = generateFileId();
 
 			await content.write(id, 'hello');
@@ -120,25 +145,31 @@ describe('ContentOps', () => {
 			expect(await content.read(id)).toBe('back to text');
 
 			// Should have 3 timeline entries
-			const ydoc = await (content as any).store.ensure(id);
+			// Accessing internal store API not exposed in public types — needed for test setup
+			const ydoc = await (
+				content as unknown as ContentOpsWithStore
+			).store.ensure(id);
 			expect(createTimeline(ydoc).length).toBe(3);
 		});
 
 		test('binary → text pushes new entry', async () => {
-			const content = setup();
+			const { content } = setup();
 			const id = generateFileId();
 			await content.write(id, new Uint8Array([1, 2, 3]));
 			await content.write(id, 'now text');
 			expect(await content.read(id)).toBe('now text');
 
-			const ydoc = await (content as any).store.ensure(id);
+			// Accessing internal store API not exposed in public types — needed for test setup
+			const ydoc = await (
+				content as unknown as ContentOpsWithStore
+			).store.ensure(id);
 			expect(createTimeline(ydoc).length).toBe(2);
 		});
 	});
 
 	describe('append', () => {
 		test('append to text entry', async () => {
-			const content = setup();
+			const { content } = setup();
 			const id = generateFileId();
 			await content.write(id, 'hello');
 			const size = await content.append(id, ' world');
@@ -146,12 +177,15 @@ describe('ContentOps', () => {
 			expect(size).toBe(new TextEncoder().encode('hello world').byteLength);
 
 			// Should not grow timeline
-			const ydoc = await (content as any).store.ensure(id);
+			// Accessing internal store API not exposed in public types — needed for test setup
+			const ydoc = await (
+				content as unknown as ContentOpsWithStore
+			).store.ensure(id);
 			expect(createTimeline(ydoc).length).toBe(1);
 		});
 
 		test('append to binary entry decodes and pushes text', async () => {
-			const content = setup();
+			const { content } = setup();
 			const id = generateFileId();
 			await content.write(id, new Uint8Array([0x48, 0x69])); // "Hi"
 			const size = await content.append(id, ' there');
@@ -159,19 +193,22 @@ describe('ContentOps', () => {
 			expect(size).toBe(new TextEncoder().encode('Hi there').byteLength);
 
 			// Binary append pushes a new text entry
-			const ydoc = await (content as any).store.ensure(id);
+			// Accessing internal store API not exposed in public types — needed for test setup
+			const ydoc = await (
+				content as unknown as ContentOpsWithStore
+			).store.ensure(id);
 			expect(createTimeline(ydoc).length).toBe(2);
 		});
 
 		test('append on empty file returns null', async () => {
-			const content = setup();
+			const { content } = setup();
 			const id = generateFileId();
 			const result = await content.append(id, 'data');
 			expect(result).toBeNull();
 		});
 
 		test('multiple appends accumulate', async () => {
-			const content = setup();
+			const { content } = setup();
 			const id = generateFileId();
 			await content.write(id, 'line1\n');
 			await content.append(id, 'line2\n');
@@ -182,7 +219,7 @@ describe('ContentOps', () => {
 
 	describe('destroy', () => {
 		test('destroy cleans up file doc', async () => {
-			const content = setup();
+			const { content } = setup();
 			const id = generateFileId();
 			await content.write(id, 'hello');
 			await content.destroy(id);
@@ -191,7 +228,7 @@ describe('ContentOps', () => {
 		});
 
 		test('destroy on non-existent file is no-op', async () => {
-			const content = setup();
+			const { content } = setup();
 			const id = generateFileId();
 			await content.destroy(id); // should not throw
 		});
@@ -199,7 +236,7 @@ describe('ContentOps', () => {
 
 	describe('destroyAll', () => {
 		test('destroys all content docs', async () => {
-			const content = setup();
+			const { content } = setup();
 			const id1 = generateFileId();
 			const id2 = generateFileId();
 			await content.write(id1, 'a');
@@ -212,19 +249,25 @@ describe('ContentOps', () => {
 
 	describe('sheet mode', () => {
 		test('read returns CSV for sheet entry', async () => {
-			const content = setup();
+			const { content } = setup();
 			const id = generateFileId();
 			// Push a sheet entry via timeline
-			const ydoc = await (content as any).store.ensure(id);
+			// Accessing internal store API not exposed in public types — needed for test setup
+			const ydoc = await (
+				content as unknown as ContentOpsWithStore
+			).store.ensure(id);
 			const tl = createTimeline(ydoc);
 			ydoc.transact(() => tl.pushSheetFromCsv('Name,Age\nAlice,30\nBob,25\n'));
 			expect(await content.read(id)).toBe('Name,Age\nAlice,30\nBob,25\n');
 		});
 
 		test('write CSV to sheet-mode file re-parses in place', async () => {
-			const content = setup();
+			const { content } = setup();
 			const id = generateFileId();
-			const ydoc = await (content as any).store.ensure(id);
+			// Accessing internal store API not exposed in public types — needed for test setup
+			const ydoc = await (
+				content as unknown as ContentOpsWithStore
+			).store.ensure(id);
 			const tl = createTimeline(ydoc);
 			ydoc.transact(() => tl.pushSheetFromCsv('A,B\n1,2\n'));
 			await content.write(id, 'X,Y\n3,4\n');
@@ -234,18 +277,24 @@ describe('ContentOps', () => {
 		});
 
 		test('write CSV to sheet-mode returns byte size', async () => {
-			const content = setup();
+			const { content } = setup();
 			const id = generateFileId();
-			const ydoc = await (content as any).store.ensure(id);
+			// Accessing internal store API not exposed in public types — needed for test setup
+			const ydoc = await (
+				content as unknown as ContentOpsWithStore
+			).store.ensure(id);
 			ydoc.transact(() => createTimeline(ydoc).pushSheetFromCsv('A\n1\n'));
 			const size = await content.write(id, 'X,Y\n3,4\n');
 			expect(size).toBe(new TextEncoder().encode('X,Y\n3,4\n').byteLength);
 		});
 
 		test('binary write on sheet-mode file mode-switches', async () => {
-			const content = setup();
+			const { content } = setup();
 			const id = generateFileId();
-			const ydoc = await (content as any).store.ensure(id);
+			// Accessing internal store API not exposed in public types — needed for test setup
+			const ydoc = await (
+				content as unknown as ContentOpsWithStore
+			).store.ensure(id);
 			ydoc.transact(() => createTimeline(ydoc).pushSheetFromCsv('A\n1\n'));
 			await content.write(id, new Uint8Array([0xde, 0xad]));
 			expect(createTimeline(ydoc).length).toBe(2);

--- a/packages/filesystem/src/file-system-index.test.ts
+++ b/packages/filesystem/src/file-system-index.test.ts
@@ -1,3 +1,14 @@
+/**
+ * FileSystemIndex Tests
+ *
+ * Verifies path indexing, orphan/cycle correction, and reactive rebuild behavior.
+ * These tests ensure path lookup remains deterministic under live mutations and conflict scenarios.
+ *
+ * Key behaviors:
+ * - File rows map to stable, disambiguated filesystem paths.
+ * - Reactive updates keep index state consistent after edits and deletes.
+ */
+
 import { describe, expect, test } from 'bun:test';
 import { createWorkspace } from '@epicenter/hq/static';
 import { createFileSystemIndex } from './file-system-index.js';
@@ -45,7 +56,7 @@ describe('createFileSystemIndex', () => {
 		index.destroy();
 	});
 
-	test('single file at root', () => {
+	test('indexes a single root file by absolute path', () => {
 		const { files } = setup();
 		files.set(makeRow('f1', 'hello.txt'));
 		const index = createFileSystemIndex(files);
@@ -56,7 +67,7 @@ describe('createFileSystemIndex', () => {
 		index.destroy();
 	});
 
-	test('multiple files at root', () => {
+	test('indexes multiple root files with distinct absolute paths', () => {
 		const { files } = setup();
 		files.set(makeRow('f1', 'a.txt'));
 		files.set(makeRow('f2', 'b.txt'));
@@ -72,7 +83,7 @@ describe('createFileSystemIndex', () => {
 		index.destroy();
 	});
 
-	test('nested directory structure', () => {
+	test('indexes nested directories and files under parent paths', () => {
 		const { files } = setup();
 		files.set(makeRow('d1', 'docs', null, 'folder'));
 		files.set(makeRow('f1', 'api.md', 'd1'));
@@ -89,7 +100,7 @@ describe('createFileSystemIndex', () => {
 		index.destroy();
 	});
 
-	test('deeply nested path', () => {
+	test('resolves deeply nested file paths through multiple folders', () => {
 		const { files } = setup();
 		files.set(makeRow('d1', 'a', null, 'folder'));
 		files.set(makeRow('d2', 'b', 'd1', 'folder'));

--- a/packages/filesystem/src/markdown-helpers.test.ts
+++ b/packages/filesystem/src/markdown-helpers.test.ts
@@ -1,3 +1,15 @@
+/**
+ * Markdown Helpers Tests
+ *
+ * Covers markdown/frontmatter parsing and Yjs conversion helpers used by markdown-mode
+ * files. These tests protect fidelity between plain markdown content and structured Yjs
+ * state used by the filesystem layer.
+ *
+ * Key behaviors:
+ * - Frontmatter and markdown body round-trip predictably across parse/serialize helpers.
+ * - Y.Map and Y.XmlFragment adapters preserve expected document content.
+ */
+
 import { describe, expect, test } from 'bun:test';
 import { createWorkspace } from '@epicenter/hq/static';
 import { Bash } from 'just-bash';
@@ -14,13 +26,13 @@ import {
 import { YjsFileSystem } from './yjs-file-system.js';
 
 describe('parseFrontmatter', () => {
-	test('no front matter', () => {
+	test('parseFrontmatter returns empty metadata when front matter is absent', () => {
 		const result = parseFrontmatter('# Hello World');
 		expect(result.frontmatter).toEqual({});
 		expect(result.body).toBe('# Hello World');
 	});
 
-	test('with front matter', () => {
+	test('parseFrontmatter extracts front matter and markdown body', () => {
 		const input = '---\ntitle: Hello\ndate: 2026-02-09\n---\n# Content';
 		const result = parseFrontmatter(input);
 		expect(result.frontmatter).toEqual({ title: 'Hello', date: '2026-02-09' });
@@ -49,7 +61,7 @@ describe('serializeMarkdownWithFrontmatter', () => {
 		expect(result).toBe('# Hello');
 	});
 
-	test('with frontmatter', () => {
+	test('serializeMarkdownWithFrontmatter emits YAML block before body', () => {
 		const result = serializeMarkdownWithFrontmatter(
 			{ title: 'Test' },
 			'# Hello',
@@ -118,7 +130,7 @@ describe('XmlFragment serialization', () => {
 		expect(serialized).toContain('This is a paragraph.');
 	});
 
-	test('empty markdown', () => {
+	test('empty markdown still serializes XmlFragment to a string', () => {
 		const ydoc = new Y.Doc();
 		const fragment = ydoc.getXmlFragment('richtext');
 
@@ -128,7 +140,7 @@ describe('XmlFragment serialization', () => {
 		expect(typeof serialized).toBe('string');
 	});
 
-	test('markdown with formatting', () => {
+	test('formatted markdown preserves visible text through XmlFragment conversion', () => {
 		const ydoc = new Y.Doc();
 		const fragment = ydoc.getXmlFragment('richtext');
 

--- a/packages/filesystem/src/sheet-helpers.test.ts
+++ b/packages/filesystem/src/sheet-helpers.test.ts
@@ -1,3 +1,15 @@
+/**
+ * Sheet Helpers Tests
+ *
+ * Verifies CSV parsing/serialization and row/column ordering utilities for sheet-mode
+ * timeline entries. These tests keep spreadsheet behavior stable across import, export,
+ * and interactive reorder operations.
+ *
+ * Key behaviors:
+ * - CSV conversion preserves ordering, escaping, and round-trip fidelity.
+ * - Fractional index helpers generate valid, stable order values for reordering.
+ */
+
 import { describe, expect, test } from 'bun:test';
 import * as Y from 'yjs';
 import {
@@ -22,7 +34,7 @@ describe('serializeSheetToCsv', () => {
 		expect(serializeSheetToCsv(columns, rows)).toBe('');
 	});
 
-	test('single column, single row', () => {
+	test('single column and row serialize to one header and one record', () => {
 		const { columns, rows } = createSheetMaps();
 		const col = new Y.Map<string>();
 		col.set('name', 'Name');

--- a/packages/filesystem/src/timeline-helpers.test.ts
+++ b/packages/filesystem/src/timeline-helpers.test.ts
@@ -1,21 +1,31 @@
+/**
+ * Timeline Helpers Tests
+ *
+ * Validates timeline helper behavior for sheet entries and CSV round-tripping.
+ * These tests ensure sheet-mode content can be appended to history and serialized predictably.
+ *
+ * Key behaviors:
+ * - Sheet entries initialize expected Yjs maps for columns and rows.
+ * - CSV parse/serialize paths preserve logical sheet content.
+ */
+
 import { describe, expect, test } from 'bun:test';
 import * as Y from 'yjs';
 import { createTimeline } from './timeline-helpers.js';
 
 function setup() {
-	const ydoc = new Y.Doc();
-	return { ydoc, tl: createTimeline(ydoc) };
+	return createTimeline(new Y.Doc());
 }
 
 describe('createTimeline - sheet entries', () => {
 	test('pushSheet creates entry with type sheet', () => {
-		const { tl } = setup();
+		const tl = setup();
 		const entry = tl.pushSheet();
 		expect(entry.get('type')).toBe('sheet');
 	});
 
 	test('pushSheet creates empty columns and rows Y.Maps', () => {
-		const { tl } = setup();
+		const tl = setup();
 		const entry = tl.pushSheet();
 		const columns = entry.get('columns') as Y.Map<Y.Map<string>>;
 		const rows = entry.get('rows') as Y.Map<Y.Map<string>>;
@@ -26,20 +36,20 @@ describe('createTimeline - sheet entries', () => {
 	});
 
 	test('pushSheet increments timeline length', () => {
-		const { tl } = setup();
+		const tl = setup();
 		expect(tl.length).toBe(0);
 		tl.pushSheet();
 		expect(tl.length).toBe(1);
 	});
 
 	test('currentMode returns sheet after pushSheet', () => {
-		const { tl } = setup();
+		const tl = setup();
 		tl.pushSheet();
 		expect(tl.currentMode).toBe('sheet');
 	});
 
 	test('pushSheetFromCsv populates columns from header', () => {
-		const { tl } = setup();
+		const tl = setup();
 		tl.pushSheetFromCsv('Name,Age\nAlice,30\n');
 		const entry = tl.currentEntry!;
 		const columns = entry.get('columns') as Y.Map<Y.Map<string>>;
@@ -51,7 +61,7 @@ describe('createTimeline - sheet entries', () => {
 	});
 
 	test('pushSheetFromCsv populates rows from data', () => {
-		const { tl } = setup();
+		const tl = setup();
 		tl.pushSheetFromCsv('Name,Age\nAlice,30\nBob,25\n');
 		const entry = tl.currentEntry!;
 		const rows = entry.get('rows') as Y.Map<Y.Map<string>>;
@@ -59,14 +69,14 @@ describe('createTimeline - sheet entries', () => {
 	});
 
 	test('readAsString returns CSV for sheet entry', () => {
-		const { tl } = setup();
+		const tl = setup();
 		const csv = 'Name,Age\nAlice,30\n';
 		tl.pushSheetFromCsv(csv);
 		expect(tl.readAsString()).toBe(csv);
 	});
 
 	test('readAsBuffer returns encoded CSV for sheet entry', () => {
-		const { tl } = setup();
+		const tl = setup();
 		const csv = 'Name,Age\nAlice,30\n';
 		tl.pushSheetFromCsv(csv);
 		const buffer = tl.readAsBuffer();
@@ -74,15 +84,15 @@ describe('createTimeline - sheet entries', () => {
 	});
 
 	test('round-trip: pushSheetFromCsv → readAsString matches original', () => {
-		const { tl } = setup();
+		const tl = setup();
 		const originalCsv =
 			'Product,Price,Stock\nWidget,9.99,100\nGadget,24.99,50\n';
 		tl.pushSheetFromCsv(originalCsv);
 		expect(tl.readAsString()).toBe(originalCsv);
 	});
 
-	test('multiple entries: text then sheet then text', () => {
-		const { tl } = setup();
+	test('switching text to sheet to text updates current mode and content', () => {
+		const tl = setup();
 		tl.pushText('First entry');
 		expect(tl.currentMode).toBe('text');
 		expect(tl.length).toBe(1);
@@ -98,13 +108,13 @@ describe('createTimeline - sheet entries', () => {
 	});
 
 	test('empty sheet returns empty string', () => {
-		const { tl } = setup();
+		const tl = setup();
 		tl.pushSheet();
 		expect(tl.readAsString()).toBe('');
 	});
 
 	test('sheet with columns but no rows returns header only', () => {
-		const { tl } = setup();
+		const tl = setup();
 		tl.pushSheetFromCsv('A,B,C\n');
 		expect(tl.readAsString()).toBe('A,B,C\n');
 	});

--- a/packages/filesystem/src/validation.test.ts
+++ b/packages/filesystem/src/validation.test.ts
@@ -1,3 +1,14 @@
+/**
+ * Validation Tests
+ *
+ * Covers filename validation, duplicate-name checks, and deterministic disambiguation rules.
+ * These tests guard filesystem naming constraints that are shared across tree and index operations.
+ *
+ * Key behaviors:
+ * - Invalid path-like names are rejected with filesystem-style errors.
+ * - Duplicate names are disambiguated in stable creation order.
+ */
+
 import { describe, expect, test } from 'bun:test';
 import { createWorkspace } from '@epicenter/hq/static';
 import { filesTable } from './file-table.js';
@@ -137,7 +148,7 @@ describe('disambiguateNames', () => {
 		expect(result.get('b')).toBe('foo (1).txt');
 	});
 
-	test('three duplicates', () => {
+	test('three duplicates get incrementing suffixes by creation order', () => {
 		const rows = [
 			makeRow('c', 'file.md', null, 3000),
 			makeRow('a', 'file.md', null, 1000),

--- a/packages/filesystem/src/yjs-file-system.test.ts
+++ b/packages/filesystem/src/yjs-file-system.test.ts
@@ -498,7 +498,6 @@ describe('sheet file support', () => {
 		const content = (fs as any).content;
 		const fileId = tree.lookupId('/data.csv');
 		const ydoc = await content.store.ensure(fileId);
-		const { createTimeline } = await import('./timeline-helpers.js');
 		// Replace text entry with sheet entry
 		ydoc.transact(() => {
 			createTimeline(ydoc).pushSheetFromCsv('Name,Age\nAlice,30\n');
@@ -513,7 +512,6 @@ describe('sheet file support', () => {
 		const content = (fs as any).content;
 		const fileId = tree.lookupId('/data.csv');
 		const ydoc = await content.store.ensure(fileId);
-		const { createTimeline } = await import('./timeline-helpers.js');
 		ydoc.transact(() => {
 			createTimeline(ydoc).pushSheetFromCsv('A,B\n1,2\n');
 		});

--- a/packages/server/src/actions.test.ts
+++ b/packages/server/src/actions.test.ts
@@ -1,3 +1,15 @@
+/**
+ * Actions Router Tests
+ *
+ * Verifies HTTP routing for query and mutation actions, including nested action trees
+ * and input validation behavior. These tests protect the contract between action
+ * definitions and the generated server endpoints.
+ *
+ * Key behaviors:
+ * - Query/mutation actions map to correct HTTP methods and response payloads.
+ * - Action path discovery produces expected flattened route paths.
+ */
+
 import { describe, expect, test } from 'bun:test';
 import { defineMutation, defineQuery } from '@epicenter/hq';
 import { type } from 'arktype';
@@ -122,7 +134,7 @@ describe('createActionsRouter', () => {
 		expect(response.status).toBe(422);
 	});
 
-	test('async handlers work correctly', async () => {
+	test('async handlers resolve and return data payloads', async () => {
 		const actions = {
 			asyncQuery: defineQuery({
 				handler: async () => {
@@ -142,7 +154,7 @@ describe('createActionsRouter', () => {
 		expect(body).toEqual({ data: { async: true } });
 	});
 
-	test('supports custom base path', async () => {
+	test('custom basePath prefixes generated action routes', async () => {
 		const actions = {
 			test: defineQuery({
 				handler: () => 'ok',
@@ -217,7 +229,7 @@ describe('collectActionPaths', () => {
 		expect(paths).toHaveLength(3);
 	});
 
-	test('handles deeply nested actions', () => {
+	test('collectActionPaths flattens deeply nested actions into slash paths', () => {
 		const actions = {
 			api: {
 				v1: {

--- a/packages/sync/src/provider.test.ts
+++ b/packages/sync/src/provider.test.ts
@@ -1,9 +1,13 @@
 /**
- * Unit tests for createSyncProvider.
+ * Sync Provider Tests
  *
- * Uses a MockWebSocket injected via WebSocketConstructor to test the
- * supervisor loop, status transitions, hasLocalChanges tracking,
- * reconnection, and cleanup without a real server.
+ * Uses a mocked WebSocket to validate the provider supervisor loop without
+ * requiring a real sync server. The suite focuses on lifecycle transitions,
+ * reconnection behavior, and local-change acknowledgment tracking.
+ *
+ * Key behaviors:
+ * - Connection lifecycle transitions follow the expected status model.
+ * - `hasLocalChanges` and listener callbacks reflect local edits and server echoes.
  */
 
 import { describe, expect, test } from 'bun:test';


### PR DESCRIPTION
Test files had no consistent conventions — vague names like `should work correctly`, no doc comments explaining what a file actually tests, and unannotated `as any` scattered throughout. Meanwhile, several files were using `await import()` for modules that are always available (no platform gating, no optional deps, no dynamic paths), adding unnecessary async overhead and wrapper functions.

This PR fixes both: clean up the unnecessary dynamic imports, then codify testing conventions in a skill and apply them across the test suite.

### Dynamic import cleanup

The `file-system.ts` change is the most interesting one. Two wrapper functions existed solely to lazily import things that are always available:

```typescript
// BEFORE: 19 lines of wrappers around static modules
async function rename(oldPath: string, newPath: string): Promise<void> {
  const { rename: tauriRename } = await import('@tauri-apps/plugin-fs');
  await tauriRename(oldPath, newPath);
}

async function writeFile(path: string, data: Uint8Array): Promise<void> {
  const { writeFile: tauriWriteFile } = await import('@tauri-apps/plugin-fs');
  await tauriWriteFile(path, data);
}

// AFTER: added to the existing static import at the top
import {
  rename as tauriRename,
  writeFile as tauriWriteFile,
  // ...existing imports
} from '@tauri-apps/plugin-fs';
```

Same pattern for `nanoid` and `node:fs` — pointless dynamic imports converted to static ones. 10 `await import()` calls removed across 4 files total.

### Testing skill

A new `.agents/skills/testing/SKILL.md` codifies conventions that were inconsistent across the codebase:

- **File-level doc comments** — every test file starts with a JSDoc block explaining what's tested and key behaviors
- **Behavior-assertion test names** — `upsert stores row and get retrieves it` instead of `should create and retrieve rows correctly`
- **Negative type tests** — `@ts-expect-error` with explanatory comments to verify the compiler rejects invalid input
- **`as any` annotation** — when `as any` is genuinely needed (testing runtime errors for invalid input), a comment explains why

### Applying the conventions

48 test files updated across `epicenter`, `filesystem`, `server`, and `sync`. The changes are mechanical but meaningful — when a test fails, you now know what broke from the name alone, and the file-level doc comment tells you what contract is violated.

```typescript
// BEFORE
test('should create and retrieve rows correctly', () => { ... });
test('handles mixed types', () => { ... });
test('command handlers are accessible', () => { ... });

// AFTER
test('upsert stores row and get retrieves it', () => { ... });
test('serializes mixed JSON-compatible values as one JSON value per line', () => { ... });
test('command handlers are functions on the registered command', () => { ... });
```

New negative type tests were also added to `create-tables.types.test.ts` to verify the compiler rejects missing required fields and wrong field types at compile time.