### PR TITLE
refactor(filesystem): replace YjsFileSystem class with factory function

### DIFF
--- a/apps/fs-explorer/src/lib/fs/fs-state.svelte.ts
+++ b/apps/fs-explorer/src/lib/fs/fs-state.svelte.ts
@@ -1,8 +1,8 @@
 import {
+	createYjsFileSystem,
 	type FileId,
 	type FileRow,
 	filesTable,
-	YjsFileSystem,
 } from '@epicenter/filesystem';
 import { createWorkspace } from '@epicenter/hq/static';
 import { SvelteSet } from 'svelte/reactivity';
@@ -58,7 +58,7 @@ function createFsState() {
 			},
 			{ tags: ['persistent'] },
 		);
-	const fs = YjsFileSystem.create(ws.tables.files);
+	const fs = createYjsFileSystem(ws.tables.files);
 
 	// ── Reactive state ────────────────────────────────────────────────
 	let version = $state(0);

--- a/packages/epicenter/src/static/create-document-binding.test.ts
+++ b/packages/epicenter/src/static/create-document-binding.test.ts
@@ -27,16 +27,19 @@ const fileSchema = type({
 });
 
 function setup() {
-	const tableDef = defineTable(fileSchema);
 	const ydoc = new Y.Doc({ guid: 'test-workspace' });
-	const tables = createTables(ydoc, { files: tableDef });
+	const tables = createTables(ydoc, { files: defineTable(fileSchema) });
 	return { ydoc, tables };
 }
 
 function setupWithBinding(
-	overrides?: Omit<
-		Partial<Parameters<typeof createDocumentBinding>[0]>,
-		'guidKey' | 'updatedAtKey' | 'tableHelper' | 'ydoc'
+	overrides?: Pick<
+		Parameters<typeof createDocumentBinding>[0],
+		| 'documentExtensions'
+		| 'documentTags'
+		| 'tableName'
+		| 'documentName'
+		| 'onRowDeleted'
 	>,
 ) {
 	const { ydoc, tables } = setup();

--- a/packages/filesystem/src/file-table.ts
+++ b/packages/filesystem/src/file-table.ts
@@ -17,5 +17,5 @@ export const filesTable = defineTable(
 ).withDocument('content', {
 	guid: 'id',
 	updatedAt: 'updatedAt',
-	tags: 'persistent',
+	tags: ['persistent'],
 });

--- a/packages/filesystem/src/index.ts
+++ b/packages/filesystem/src/index.ts
@@ -50,4 +50,4 @@ export {
 } from './validation.js';
 
 // IFileSystem implementation
-export { YjsFileSystem } from './yjs-file-system.js';
+export { createYjsFileSystem, type YjsFileSystem } from './yjs-file-system.js';

--- a/packages/filesystem/src/markdown-helpers.test.ts
+++ b/packages/filesystem/src/markdown-helpers.test.ts
@@ -23,7 +23,7 @@ import {
 	updateYXmlFragmentFromString,
 	yMapToRecord,
 } from './markdown-helpers.js';
-import { YjsFileSystem } from './yjs-file-system.js';
+import { createYjsFileSystem } from './yjs-file-system.js';
 
 describe('parseFrontmatter', () => {
 	test('parseFrontmatter returns empty metadata when front matter is absent', () => {
@@ -155,7 +155,7 @@ describe('XmlFragment serialization', () => {
 describe('markdown integration with YjsFileSystem', () => {
 	function setup() {
 		const ws = createWorkspace({ id: 'test', tables: { files: filesTable } });
-		return YjsFileSystem.create(ws.tables.files);
+		return createYjsFileSystem(ws.tables.files);
 	}
 
 	test('write and read .md file with front matter', async () => {

--- a/packages/filesystem/src/yjs-file-system.ts
+++ b/packages/filesystem/src/yjs-file-system.ts
@@ -1,19 +1,12 @@
 import type { DocumentBinding, TableHelper } from '@epicenter/hq/static';
-import type {
-	CpOptions,
-	FileContent,
-	FsStat,
-	IFileSystem,
-	MkdirOptions,
-	RmOptions,
-} from 'just-bash';
+import type { IFileSystem } from 'just-bash';
 import {
 	type ContentHelpers,
 	createContentHelpers,
 } from './content-helpers.js';
 import { FileTree } from './file-tree.js';
 import { posixResolve } from './path-utils.js';
-import type { FileRow } from './types.js';
+import type { FileId, FileRow } from './types.js';
 import { disambiguateNames, fsError } from './validation.js';
 
 /**
@@ -24,373 +17,373 @@ type FilesTableWithDocs = TableHelper<FileRow> & {
 	docs: { content: DocumentBinding<FileRow> };
 };
 
-/** Directory entry with type information, mirroring `DirentEntry` from `just-bash` (not re-exported from package root). */
-type DirentEntry = {
-	name: string;
-	isFile: boolean;
-	isDirectory: boolean;
-	isSymbolicLink: boolean;
-};
+/** Validate `fs` extends {@link IFileSystem} while preserving the full inferred type (avoids excess-property errors from `satisfies`). */
+function FileSystem<T extends IFileSystem>(fs: T): T {
+	return fs;
+}
 
 /**
- * POSIX-like virtual filesystem backed by Yjs CRDTs.
+ * Create a POSIX-like virtual filesystem backed by Yjs CRDTs.
  *
  * Thin orchestrator that delegates metadata operations to {@link FileTree}
  * and content I/O to {@link ContentHelpers} (backed by a
  * {@link DocumentBinding}). Every method applies `cwd` via
  * {@link posixResolve}, then calls the appropriate sub-service.
  *
- * Implements the `IFileSystem` interface from `just-bash`, which allows this
- * virtual filesystem to be used as a drop-in backend for shell emulation.
+ * The returned object satisfies the `IFileSystem` interface from `just-bash`,
+ * which allows this virtual filesystem to be used as a drop-in backend for
+ * shell emulation — while also exposing extra members (`content`, `index`,
+ * `lookupId`, `destroy`) that aren't part of `IFileSystem`.
  *
  * **No symlinks** — `symlink`, `link`, and `readlink` always throw ENOSYS.
  * **Soft deletes** — `rm` sets `trashedAt` rather than destroying rows.
  * **No real permissions** — `chmod` is a validated no-op.
+ *
+ * @example
+ * ```typescript
+ * const ws = createWorkspace({ id: 'app', tables: { files: filesTable } });
+ * const fs = createYjsFileSystem(ws.tables.files);
+ * ```
  */
-export class YjsFileSystem implements IFileSystem {
-	constructor(
-		private tree: FileTree,
+export function createYjsFileSystem(
+	filesTable: FilesTableWithDocs,
+	cwd: string = '/',
+) {
+	const tree = new FileTree(filesTable);
+	const content = createContentHelpers(filesTable.docs.content);
+
+	return FileSystem({
 		/** Content I/O operations — exposed for direct content reads/writes by UI layers. */
-		readonly content: ContentHelpers,
-		private cwd: string = '/',
-	) {}
+		content,
 
-	/** Reactive file-system indexes for path lookups and parent-child queries. */
-	get index(): FileTree['index'] {
-		return this.tree.index;
-	}
+		/** Reactive file-system indexes for path lookups and parent-child queries. */
+		get index(): FileTree['index'] {
+			return tree.index;
+		},
 
-	/**
-	 * Create a `YjsFileSystem` from a files table that has a document binding.
-	 *
-	 * The table must have been defined with `.withDocument('content', ...)` so that
-	 * `filesTable.docs.content` is available. Content doc lifecycle (creation,
-	 * provider wiring, cleanup on row deletion) is handled by the binding automatically.
-	 *
-	 * @example
-	 * ```typescript
-	 * const ws = createWorkspace({ id: 'app', tables: { files: filesTable } });
-	 * const fs = YjsFileSystem.create(ws.tables.files);
-	 * ```
-	 */
-	static create(filesTable: FilesTableWithDocs, cwd?: string): YjsFileSystem {
-		const tree = new FileTree(filesTable);
-		const content = createContentHelpers(filesTable.docs.content);
-		return new YjsFileSystem(tree, content, cwd);
-	}
+		/**
+		 * Look up the internal file ID for a resolved absolute path.
+		 *
+		 * Returns `undefined` if the path doesn't exist. Useful for content-layer
+		 * operations that need the ID to open a document binding directly.
+		 *
+		 * @example
+		 * ```typescript
+		 * const fileId = fs.lookupId('/docs/readme.md');
+		 * if (fileId) {
+		 *   const doc = await binding.open(fileId);
+		 * }
+		 * ```
+		 */
+		lookupId(path: string): FileId | undefined {
+			const abs = posixResolve(cwd, path);
+			return tree.lookupId(abs);
+		},
 
-	/**
-	 * Tear down reactive indexes.
-	 *
-	 * Content doc cleanup is handled by the workspace's document binding
-	 * destroy cascade — no need to call `destroyAll()` here.
-	 */
-	destroy(): void {
-		this.tree.destroy();
-	}
+		/**
+		 * Tear down reactive indexes.
+		 *
+		 * Content doc cleanup is handled by the workspace's document binding
+		 * destroy cascade — no need to call `destroyAll()` here.
+		 */
+		destroy() {
+			tree.destroy();
+		},
 
-	// ═══════════════════════════════════════════════════════════════════════
-	// READS — metadata only (fast, no content doc loaded)
-	// ═══════════════════════════════════════════════════════════════════════
+		// ═══════════════════════════════════════════════════════════════════════
+		// READS — metadata only (fast, no content doc loaded)
+		// ═══════════════════════════════════════════════════════════════════════
 
-	async readdir(path: string): Promise<string[]> {
-		const abs = posixResolve(this.cwd, path);
-		const id = this.tree.resolveId(abs);
-		this.tree.assertDirectory(id, abs);
-		const activeChildren = this.tree.activeChildren(id);
-		const displayNames = disambiguateNames(activeChildren);
-		return activeChildren.map((row) => displayNames.get(row.id)!).sort();
-	}
+		async readdir(path) {
+			const abs = posixResolve(cwd, path);
+			const id = tree.resolveId(abs);
+			tree.assertDirectory(id, abs);
+			const activeChildren = tree.activeChildren(id);
+			const displayNames = disambiguateNames(activeChildren);
+			return activeChildren.map((row) => displayNames.get(row.id)!).sort();
+		},
 
-	async readdirWithFileTypes(path: string): Promise<DirentEntry[]> {
-		const abs = posixResolve(this.cwd, path);
-		const id = this.tree.resolveId(abs);
-		this.tree.assertDirectory(id, abs);
-		const activeChildren = this.tree.activeChildren(id);
-		const displayNames = disambiguateNames(activeChildren);
-		return activeChildren
-			.map((row) => ({
-				name: displayNames.get(row.id)!,
+		async readdirWithFileTypes(path) {
+			const abs = posixResolve(cwd, path);
+			const id = tree.resolveId(abs);
+			tree.assertDirectory(id, abs);
+			const activeChildren = tree.activeChildren(id);
+			const displayNames = disambiguateNames(activeChildren);
+			return activeChildren
+				.map((row) => ({
+					name: displayNames.get(row.id)!,
+					isFile: row.type === 'file',
+					isDirectory: row.type === 'folder',
+					isSymbolicLink: false,
+				}))
+				.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+		},
+
+		async stat(path) {
+			const abs = posixResolve(cwd, path);
+			if (abs === '/') {
+				return {
+					isFile: false,
+					isDirectory: true,
+					isSymbolicLink: false,
+					size: 0,
+					mtime: new Date(0),
+					mode: 0o755,
+				};
+			}
+			const id = tree.resolveId(abs)!;
+			const row = tree.getRow(id, abs);
+			return {
 				isFile: row.type === 'file',
 				isDirectory: row.type === 'folder',
 				isSymbolicLink: false,
-			}))
-			.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
-	}
-
-	async stat(path: string): Promise<FsStat> {
-		const abs = posixResolve(this.cwd, path);
-		if (abs === '/') {
-			return {
-				isFile: false,
-				isDirectory: true,
-				isSymbolicLink: false,
-				size: 0,
-				mtime: new Date(0),
-				mode: 0o755,
+				size: row.size,
+				mtime: new Date(row.updatedAt),
+				mode: row.type === 'folder' ? 0o755 : 0o644,
 			};
-		}
-		const id = this.tree.resolveId(abs)!;
-		const row = this.tree.getRow(id, abs);
-		return {
-			isFile: row.type === 'file',
-			isDirectory: row.type === 'folder',
-			isSymbolicLink: false,
-			size: row.size,
-			mtime: new Date(row.updatedAt),
-			mode: row.type === 'folder' ? 0o755 : 0o644,
-		};
-	}
+		},
 
-	async lstat(path: string): Promise<FsStat> {
-		return this.stat(path);
-	}
+		async lstat(path) {
+			return this.stat(path);
+		},
 
-	async exists(path: string): Promise<boolean> {
-		const abs = posixResolve(this.cwd, path);
-		return this.tree.exists(abs);
-	}
+		async exists(path) {
+			const abs = posixResolve(cwd, path);
+			return tree.exists(abs);
+		},
 
-	// ═══════════════════════════════════════════════════════════════════════
-	// READS — content (may load a per-file content doc)
-	// ═══════════════════════════════════════════════════════════════════════
+		// ═══════════════════════════════════════════════════════════════════════
+		// READS — content (may load a per-file content doc)
+		// ═══════════════════════════════════════════════════════════════════════
 
-	async readFile(
-		path: string,
-		_options?: { encoding?: string | null } | string,
-	): Promise<string> {
-		const abs = posixResolve(this.cwd, path);
-		const id = this.tree.resolveId(abs)!;
-		const row = this.tree.getRow(id, abs);
-		if (row.type === 'folder') throw fsError('EISDIR', abs);
-		return this.content.read(id);
-	}
-
-	async readFileBuffer(path: string): Promise<Uint8Array> {
-		const abs = posixResolve(this.cwd, path);
-		const id = this.tree.resolveId(abs)!;
-		const row = this.tree.getRow(id, abs);
-		if (row.type === 'folder') throw fsError('EISDIR', abs);
-		return this.content.readBuffer(id);
-	}
-
-	// ═══════════════════════════════════════════════════════════════════════
-	// WRITES
-	// ═══════════════════════════════════════════════════════════════════════
-
-	async writeFile(
-		path: string,
-		data: FileContent,
-		_options?: { encoding?: string } | string,
-	): Promise<void> {
-		const abs = posixResolve(this.cwd, path);
-		let id = this.tree.lookupId(abs);
-
-		if (id) {
-			const row = this.tree.getRow(id, abs);
+		async readFile(path, _options?) {
+			const abs = posixResolve(cwd, path);
+			const id = tree.resolveId(abs)!;
+			const row = tree.getRow(id, abs);
 			if (row.type === 'folder') throw fsError('EISDIR', abs);
-		}
+			return content.read(id);
+		},
 
-		if (!id) {
-			const { parentId, name } = this.tree.parsePath(abs);
-			const size =
-				typeof data === 'string'
-					? new TextEncoder().encode(data).byteLength
-					: data.byteLength;
-			id = this.tree.create({ name, parentId, type: 'file', size });
-		}
+		async readFileBuffer(path) {
+			const abs = posixResolve(cwd, path);
+			const id = tree.resolveId(abs)!;
+			const row = tree.getRow(id, abs);
+			if (row.type === 'folder') throw fsError('EISDIR', abs);
+			return content.readBuffer(id);
+		},
 
-		const size = await this.content.write(id, data);
-		this.tree.touch(id, size);
-	}
+		// ═══════════════════════════════════════════════════════════════════════
+		// WRITES
+		// ═══════════════════════════════════════════════════════════════════════
 
-	async appendFile(
-		path: string,
-		data: FileContent,
-		_options?: { encoding?: string } | string,
-	): Promise<void> {
-		const abs = posixResolve(this.cwd, path);
-		const content =
-			typeof data === 'string' ? data : new TextDecoder().decode(data);
-		const id = this.tree.lookupId(abs);
-		if (!id) return this.writeFile(abs, data, _options);
+		async writeFile(path, data, _options?) {
+			const abs = posixResolve(cwd, path);
+			let id = tree.lookupId(abs);
 
-		const row = this.tree.getRow(id, abs);
-		if (row.type === 'folder') throw fsError('EISDIR', abs);
-
-		const newSize = await this.content.append(id, content);
-		if (newSize === null) {
-			await this.writeFile(path, data);
-			return;
-		}
-		this.tree.touch(id, newSize);
-	}
-
-	// ═══════════════════════════════════════════════════════════════════════
-	// STRUCTURE — mkdir, rm, cp, mv
-	// ═══════════════════════════════════════════════════════════════════════
-
-	async mkdir(path: string, options?: MkdirOptions): Promise<void> {
-		const abs = posixResolve(this.cwd, path);
-		if (this.tree.exists(abs)) {
-			const existingId = this.tree.lookupId(abs);
-			if (existingId) {
-				const row = this.tree.getRow(existingId, abs);
-				if (row.type === 'file') throw fsError('EEXIST', abs);
+			if (id) {
+				const row = tree.getRow(id, abs);
+				if (row.type === 'folder') throw fsError('EISDIR', abs);
 			}
-			return;
-		}
 
-		if (options?.recursive) {
-			const parts = abs.split('/').filter(Boolean);
-			let currentPath = '';
-			for (const part of parts) {
-				currentPath += '/' + part;
-				if (this.tree.exists(currentPath)) {
-					const existingId = this.tree.lookupId(currentPath);
-					if (existingId) {
-						const existingRow = this.tree.getRow(existingId, currentPath);
-						if (existingRow.type === 'file')
-							throw fsError('ENOTDIR', currentPath);
+			if (!id) {
+				const { parentId, name } = tree.parsePath(abs);
+				const size =
+					typeof data === 'string'
+						? new TextEncoder().encode(data).byteLength
+						: data.byteLength;
+				id = tree.create({ name, parentId, type: 'file', size });
+			}
+
+			const size = await content.write(id, data);
+			tree.touch(id, size);
+		},
+
+		async appendFile(path, data, _options?) {
+			const abs = posixResolve(cwd, path);
+			const text =
+				typeof data === 'string' ? data : new TextDecoder().decode(data);
+			const id = tree.lookupId(abs);
+			if (!id) return this.writeFile(abs, data, _options);
+
+			const row = tree.getRow(id, abs);
+			if (row.type === 'folder') throw fsError('EISDIR', abs);
+
+			const newSize = await content.append(id, text);
+			if (newSize === null) {
+				await this.writeFile(path, data);
+				return;
+			}
+			tree.touch(id, newSize);
+		},
+
+		// ═══════════════════════════════════════════════════════════════════════
+		// STRUCTURE — mkdir, rm, cp, mv
+		// ═══════════════════════════════════════════════════════════════════════
+
+		async mkdir(path, options?) {
+			const abs = posixResolve(cwd, path);
+			if (tree.exists(abs)) {
+				const existingId = tree.lookupId(abs);
+				if (existingId) {
+					const row = tree.getRow(existingId, abs);
+					if (row.type === 'file') throw fsError('EEXIST', abs);
+				}
+				return;
+			}
+
+			if (options?.recursive) {
+				const parts = abs.split('/').filter(Boolean);
+				let currentPath = '';
+				for (const part of parts) {
+					currentPath += '/' + part;
+					if (tree.exists(currentPath)) {
+						const existingId = tree.lookupId(currentPath);
+						if (existingId) {
+							const existingRow = tree.getRow(existingId, currentPath);
+							if (existingRow.type === 'file')
+								throw fsError('ENOTDIR', currentPath);
+						}
+						continue;
 					}
-					continue;
+					const { parentId } = tree.parsePath(currentPath);
+					tree.create({
+						name: part,
+						parentId,
+						type: 'folder',
+						size: 0,
+					});
 				}
-				const { parentId } = this.tree.parsePath(currentPath);
-				this.tree.create({
-					name: part,
-					parentId,
-					type: 'folder',
-					size: 0,
-				});
-			}
-		} else {
-			const { parentId, name } = this.tree.parsePath(abs);
-			this.tree.create({ name, parentId, type: 'folder', size: 0 });
-		}
-	}
-
-	async rm(path: string, options?: RmOptions): Promise<void> {
-		const abs = posixResolve(this.cwd, path);
-		const id = this.tree.lookupId(abs);
-		if (!id) {
-			if (options?.force) return;
-			throw fsError('ENOENT', abs);
-		}
-		const row = this.tree.getRow(id, abs);
-
-		if (row.type === 'folder' && !options?.recursive) {
-			if (this.tree.activeChildren(id).length > 0)
-				throw fsError('ENOTEMPTY', abs);
-		}
-
-		// Soft-delete the row. The document binding's table observer
-		// automatically cleans up the associated content doc.
-		this.tree.softDelete(id);
-
-		if (row.type === 'folder' && options?.recursive) {
-			for (const did of this.tree.descendantIds(id)) {
-				this.tree.softDelete(did);
-			}
-		}
-	}
-
-	async cp(src: string, dest: string, options?: CpOptions): Promise<void> {
-		const resolvedSrc = posixResolve(this.cwd, src);
-		const resolvedDest = posixResolve(this.cwd, dest);
-		const srcId = this.tree.resolveId(resolvedSrc);
-		if (srcId === null) throw fsError('EISDIR', resolvedSrc);
-		const srcRow = this.tree.getRow(srcId, resolvedSrc);
-
-		if (srcRow.type === 'folder') {
-			if (!options?.recursive) throw fsError('EISDIR', resolvedSrc);
-			await this.mkdir(resolvedDest, { recursive: true });
-			const children = await this.readdir(resolvedSrc);
-			for (const child of children) {
-				await this.cp(
-					`${resolvedSrc}/${child}`,
-					`${resolvedDest}/${child}`,
-					options,
-				);
-			}
-		} else {
-			const srcBuffer = await this.content.readBuffer(srcId);
-			const srcText = await this.content.read(srcId);
-			if (srcText === '' && srcBuffer.length === 0) {
-				await this.writeFile(resolvedDest, '');
 			} else {
-				// Check if content is binary by comparing text encoding roundtrip
-				const textBytes = new TextEncoder().encode(srcText);
-				const isBinary =
-					srcBuffer.length > 0 &&
-					(srcBuffer.length !== textBytes.length ||
-						!srcBuffer.every((b, i) => b === textBytes[i]));
-				if (isBinary) {
-					await this.writeFile(resolvedDest, srcBuffer);
-				} else {
-					await this.writeFile(resolvedDest, srcText);
+				const { parentId, name } = tree.parsePath(abs);
+				tree.create({ name, parentId, type: 'folder', size: 0 });
+			}
+		},
+
+		async rm(path, options?) {
+			const abs = posixResolve(cwd, path);
+			const id = tree.lookupId(abs);
+			if (!id) {
+				if (options?.force) return;
+				throw fsError('ENOENT', abs);
+			}
+			const row = tree.getRow(id, abs);
+
+			if (row.type === 'folder' && !options?.recursive) {
+				if (tree.activeChildren(id).length > 0) throw fsError('ENOTEMPTY', abs);
+			}
+
+			// Soft-delete the row. The document binding's table observer
+			// automatically cleans up the associated content doc.
+			tree.softDelete(id);
+
+			if (row.type === 'folder' && options?.recursive) {
+				for (const did of tree.descendantIds(id)) {
+					tree.softDelete(did);
 				}
 			}
-		}
-	}
+		},
 
-	async mv(src: string, dest: string): Promise<void> {
-		const resolvedSrc = posixResolve(this.cwd, src);
-		const resolvedDest = posixResolve(this.cwd, dest);
-		const id = this.tree.resolveId(resolvedSrc);
-		if (id === null) throw fsError('EISDIR', resolvedSrc);
-		this.tree.getRow(id, resolvedSrc);
-		const { parentId: newParentId, name: newName } =
-			this.tree.parsePath(resolvedDest);
-		this.tree.move(id, newParentId, newName);
-	}
+		async cp(src, dest, options?) {
+			const resolvedSrc = posixResolve(cwd, src);
+			const resolvedDest = posixResolve(cwd, dest);
+			const srcId = tree.resolveId(resolvedSrc);
+			if (srcId === null) throw fsError('EISDIR', resolvedSrc);
+			const srcRow = tree.getRow(srcId, resolvedSrc);
 
-	// ═══════════════════════════════════════════════════════════════════════
-	// PATH RESOLUTION
-	// ═══════════════════════════════════════════════════════════════════════
+			if (srcRow.type === 'folder') {
+				if (!options?.recursive) throw fsError('EISDIR', resolvedSrc);
+				await this.mkdir(resolvedDest, { recursive: true });
+				const children = await this.readdir(resolvedSrc);
+				for (const child of children) {
+					await this.cp(
+						`${resolvedSrc}/${child}`,
+						`${resolvedDest}/${child}`,
+						options,
+					);
+				}
+			} else {
+				const srcBuffer = await content.readBuffer(srcId);
+				const srcText = await content.read(srcId);
+				if (srcText === '' && srcBuffer.length === 0) {
+					await this.writeFile(resolvedDest, '');
+				} else {
+					// Check if content is binary by comparing text encoding roundtrip
+					const textBytes = new TextEncoder().encode(srcText);
+					const isBinary =
+						srcBuffer.length > 0 &&
+						(srcBuffer.length !== textBytes.length ||
+							!srcBuffer.every((b, i) => b === textBytes[i]));
+					if (isBinary) {
+						await this.writeFile(resolvedDest, srcBuffer);
+					} else {
+						await this.writeFile(resolvedDest, srcText);
+					}
+				}
+			}
+		},
 
-	resolvePath(base: string, path: string): string {
-		return posixResolve(base, path);
-	}
+		async mv(src, dest) {
+			const resolvedSrc = posixResolve(cwd, src);
+			const resolvedDest = posixResolve(cwd, dest);
+			const id = tree.resolveId(resolvedSrc);
+			if (id === null) throw fsError('EISDIR', resolvedSrc);
+			tree.getRow(id, resolvedSrc);
+			const { parentId: newParentId, name: newName } =
+				tree.parsePath(resolvedDest);
+			tree.move(id, newParentId, newName);
+		},
 
-	async realpath(path: string): Promise<string> {
-		const abs = posixResolve(this.cwd, path);
-		if (!(await this.exists(abs))) throw fsError('ENOENT', abs);
-		return abs;
-	}
+		// ═══════════════════════════════════════════════════════════════════════
+		// PATH RESOLUTION
+		// ═══════════════════════════════════════════════════════════════════════
 
-	getAllPaths(): string[] {
-		return this.tree.allPaths();
-	}
+		resolvePath(base, path) {
+			return posixResolve(base, path);
+		},
 
-	// ═══════════════════════════════════════════════════════════════════════
-	// PERMISSIONS / TIMESTAMPS — no-op in a collaborative system
-	// ═══════════════════════════════════════════════════════════════════════
+		async realpath(path) {
+			const abs = posixResolve(cwd, path);
+			if (!tree.exists(abs)) throw fsError('ENOENT', abs);
+			return abs;
+		},
 
-	async chmod(path: string, _mode: number): Promise<void> {
-		const abs = posixResolve(this.cwd, path);
-		this.tree.resolveId(abs);
-	}
+		getAllPaths() {
+			return tree.allPaths();
+		},
 
-	async utimes(path: string, _atime: Date, mtime: Date): Promise<void> {
-		const abs = posixResolve(this.cwd, path);
-		const id = this.tree.resolveId(abs);
-		if (id === null) return;
-		this.tree.setMtime(id, mtime);
-	}
+		// ═══════════════════════════════════════════════════════════════════════
+		// PERMISSIONS / TIMESTAMPS — no-op in a collaborative system
+		// ═══════════════════════════════════════════════════════════════════════
 
-	// ═══════════════════════════════════════════════════════════════════════
-	// SYMLINKS / LINKS — not supported (always throws ENOSYS)
-	// ═══════════════════════════════════════════════════════════════════════
+		async chmod(path, _mode) {
+			const abs = posixResolve(cwd, path);
+			tree.resolveId(abs);
+		},
 
-	async symlink(): Promise<void> {
-		throw fsError('ENOSYS', 'symlinks not supported');
-	}
+		async utimes(path, _atime, mtime) {
+			const abs = posixResolve(cwd, path);
+			const id = tree.resolveId(abs);
+			if (id === null) return;
+			tree.setMtime(id, mtime);
+		},
 
-	async link(): Promise<void> {
-		throw fsError('ENOSYS', 'hard links not supported');
-	}
+		// ═══════════════════════════════════════════════════════════════════════
+		// SYMLINKS / LINKS — not supported (always throws ENOSYS)
+		// ═══════════════════════════════════════════════════════════════════════
 
-	async readlink(): Promise<string> {
-		throw fsError('ENOSYS', 'symlinks not supported');
-	}
+		async symlink(_target, _linkPath) {
+			throw fsError('ENOSYS', 'symlinks not supported');
+		},
+
+		async link(_existingPath, _newPath) {
+			throw fsError('ENOSYS', 'hard links not supported');
+		},
+
+		async readlink(_path) {
+			throw fsError('ENOSYS', 'symlinks not supported');
+		},
+	});
 }
+
+/** Inferred type of the virtual filesystem returned by {@link createYjsFileSystem}. */
+export type YjsFileSystem = ReturnType<typeof createYjsFileSystem>;


### PR DESCRIPTION
The `YjsFileSystem` class had every method annotated with full parameter and return types that exactly duplicated the `IFileSystem` interface. Adding or changing a method meant updating the signature in two places, and the class couldn't expose extra members (`content`, `index`, `lookupId`) without losing type safety — tests resorted to `(fs as any).tree.lookupId()` to access internals.

This replaces the class with a `createYjsFileSystem` factory function. A generic `FileSystem<T extends IFileSystem>` constraint helper validates that the returned object satisfies `IFileSystem` while preserving the full inferred type, so extra members come along for free.

```typescript
// Before
import { YjsFileSystem } from '@epicenter/filesystem';
const fs = YjsFileSystem.create(ws.tables.files);
(fs as any).tree.lookupId('/path');  // no public API

// After
import { createYjsFileSystem } from '@epicenter/filesystem';
const fs = createYjsFileSystem(ws.tables.files);
fs.lookupId('/path');  // public, typed
```

The constraint helper is the key trick — it validates `IFileSystem` compliance at the definition site without widening the return type:

```typescript
function FileSystem<T extends IFileSystem>(fs: T): T {
  return fs;
}

// Methods get their types from IFileSystem via contextual typing,
// but extra members (content, index, lookupId, destroy) are preserved
export function createYjsFileSystem(filesTable: FilesTableWithDocs, cwd = '/') {
  return FileSystem({ content, index, lookupId, readdir, writeFile, /* ... */ });
}

export type YjsFileSystem = ReturnType<typeof createYjsFileSystem>;
```

Also fixes `tags: 'persistent'` → `tags: ['persistent']` in the file table definition — the string literal caused `TTags` to infer as `never`, breaking `ExtractAllDocTags` downstream.