### PR TITLE
refactor(sync): destructure awarenessProtocol namespace imports

### DIFF
--- a/packages/server/src/sync/plugin.ts
+++ b/packages/server/src/sync/plugin.ts
@@ -1,7 +1,11 @@
 import { Elysia } from 'elysia';
 import * as decoding from 'lib0/decoding';
 import { Ok, trySync } from 'wellcrafted/result';
-import * as awarenessProtocol from 'y-protocols/awareness';
+import {
+	type Awareness,
+	applyAwarenessUpdate,
+	removeAwarenessStates,
+} from 'y-protocols/awareness';
 import type * as Y from 'yjs';
 import { type AuthConfig, CLOSE_UNAUTHORIZED, validateAuth } from './auth';
 import {
@@ -110,7 +114,7 @@ export function createSyncPlugin(config?: SyncPluginConfig) {
 		{
 			roomId: string;
 			doc: Y.Doc;
-			awareness: awarenessProtocol.Awareness;
+			awareness: Awareness;
 			/** Handler to broadcast doc updates to this client (stored for cleanup). */
 			updateHandler: (update: Uint8Array, origin: unknown) => void;
 			/** Client IDs this connection controls, for awareness cleanup on disconnect. */
@@ -261,7 +265,7 @@ export function createSyncPlugin(config?: SyncPluginConfig) {
 						catch: () => Ok(undefined),
 					});
 
-					awarenessProtocol.applyAwarenessUpdate(awareness, update, rawWs);
+					applyAwarenessUpdate(awareness, update, rawWs);
 
 					// Broadcast awareness to other clients via room manager
 					roomManager.broadcast(
@@ -321,11 +325,7 @@ export function createSyncPlugin(config?: SyncPluginConfig) {
 
 			// Clean up awareness state for all client IDs this connection controlled
 			if (controlledClientIds.size > 0) {
-				awarenessProtocol.removeAwarenessStates(
-					awareness,
-					Array.from(controlledClientIds),
-					null,
-				);
+				removeAwarenessStates(awareness, Array.from(controlledClientIds), null);
 			}
 
 			// Remove connection from room (may start eviction timer)

--- a/packages/server/src/sync/protocol.ts
+++ b/packages/server/src/sync/protocol.ts
@@ -14,7 +14,7 @@
 
 import * as decoding from 'lib0/decoding';
 import * as encoding from 'lib0/encoding';
-import * as awarenessProtocol from 'y-protocols/awareness';
+import { type Awareness, encodeAwarenessUpdate } from 'y-protocols/awareness';
 import * as syncProtocol from 'y-protocols/sync';
 import type * as Y from 'yjs';
 
@@ -279,7 +279,7 @@ export function decodeSyncStatus(data: Uint8Array): Uint8Array {
  * user names, and online status. Unlike document updates, awareness state
  * is not persisted and is cleared when users disconnect.
  *
- * @param options.update - Raw awareness update bytes (from awarenessProtocol.encodeAwarenessUpdate)
+ * @param options.update - Raw awareness update bytes (from encodeAwarenessUpdate)
  * @returns Encoded message ready to send over WebSocket
  */
 export function encodeAwareness({
@@ -307,11 +307,11 @@ export function encodeAwarenessStates({
 	awareness,
 	clients,
 }: {
-	awareness: awarenessProtocol.Awareness;
+	awareness: Awareness;
 	clients: number[];
 }): Uint8Array {
 	return encodeAwareness({
-		update: awarenessProtocol.encodeAwarenessUpdate(awareness, clients),
+		update: encodeAwarenessUpdate(awareness, clients),
 	});
 }
 

--- a/packages/server/src/sync/rooms.test.ts
+++ b/packages/server/src/sync/rooms.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import * as awarenessProtocol from 'y-protocols/awareness';
+import { Awareness } from 'y-protocols/awareness';
 import * as Y from 'yjs';
 import { createRoomManager } from './rooms';
 
@@ -45,7 +45,7 @@ describe('join()', () => {
 
 		expect(result).not.toBeNull();
 		expect(result?.doc).toBeInstanceOf(Y.Doc);
-		expect(result?.awareness).toBeInstanceOf(awarenessProtocol.Awareness);
+		expect(result?.awareness).toBeInstanceOf(Awareness);
 	});
 
 	test('returns doc and awareness for new room', () => {

--- a/packages/server/src/sync/rooms.ts
+++ b/packages/server/src/sync/rooms.ts
@@ -1,4 +1,4 @@
-import * as awarenessProtocol from 'y-protocols/awareness';
+import { Awareness } from 'y-protocols/awareness';
 import * as Y from 'yjs';
 
 /** Time (ms) to wait after the last connection leaves a room before destroying it. */
@@ -6,7 +6,7 @@ const DEFAULT_EVICTION_TIMEOUT_MS = 60_000;
 
 type Room = {
 	doc: Y.Doc;
-	awareness: awarenessProtocol.Awareness;
+	awareness: Awareness;
 	/** Connections keyed by ws.raw (stable identity). */
 	conns: Map<object, { send: (data: Buffer) => void }>;
 	evictionTimer?: ReturnType<typeof setTimeout>;
@@ -70,7 +70,7 @@ export function createRoomManager(config?: RoomManagerConfig) {
 			roomId: string,
 			wsRaw: object,
 			send: (data: Buffer) => void,
-		): { doc: Y.Doc; awareness: awarenessProtocol.Awareness } | undefined {
+		): { doc: Y.Doc; awareness: Awareness } | undefined {
 			// Cancel pending eviction if a connection joins before the timer fires
 			const existing = rooms.get(roomId);
 			if (existing?.evictionTimer) {
@@ -94,7 +94,7 @@ export function createRoomManager(config?: RoomManagerConfig) {
 				config?.onRoomCreated?.(roomId, doc);
 			}
 
-			const awareness = new awarenessProtocol.Awareness(doc);
+			const awareness = new Awareness(doc);
 			const room: Room = {
 				doc,
 				awareness,
@@ -149,7 +149,7 @@ export function createRoomManager(config?: RoomManagerConfig) {
 		},
 
 		/** Get the awareness instance for an existing room. */
-		getAwareness(roomId: string): awarenessProtocol.Awareness | undefined {
+		getAwareness(roomId: string): Awareness | undefined {
 			return rooms.get(roomId)?.awareness;
 		},
 

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -1,4 +1,4 @@
-import type * as awarenessProtocol from 'y-protocols/awareness';
+import type { Awareness } from 'y-protocols/awareness';
 import type * as Y from 'yjs';
 
 /**
@@ -44,7 +44,7 @@ export type SyncProviderConfig = {
 	connect?: boolean;
 
 	/** External awareness instance. Defaults to `new Awareness(doc)`. */
-	awareness?: awarenessProtocol.Awareness;
+	awareness?: Awareness;
 
 	/** WebSocket constructor override for testing or non-browser environments. */
 	WebSocketConstructor?: WebSocketConstructor;
@@ -84,7 +84,7 @@ export type SyncProvider = {
 	readonly hasLocalChanges: boolean;
 
 	/** The awareness instance for user presence. */
-	readonly awareness: awarenessProtocol.Awareness;
+	readonly awareness: Awareness;
 
 	/**
 	 * Start connecting. Idempotent — safe to call multiple times.


### PR DESCRIPTION
Every export from `y-protocols/awareness` already contains "awareness" in its name. The namespace import creates stuttering redundancy at every call site:

```
awarenessProtocol.Awareness              → "awareness awareness"
awarenessProtocol.encodeAwarenessUpdate  → "awareness encode awareness update"
awarenessProtocol.removeAwarenessStates  → "awareness remove awareness states"
awarenessProtocol.applyAwarenessUpdate   → "awareness apply awareness update"
```

This replaces the namespace import with named imports and updates all call sites across both packages.

```typescript
// Before
import * as awarenessProtocol from 'y-protocols/awareness';

awareness = new awarenessProtocol.Awareness(doc);
awarenessProtocol.encodeAwarenessUpdate(awareness, clients);
awarenessProtocol.applyAwarenessUpdate(awareness, update, origin);
awarenessProtocol.removeAwarenessStates(awareness, ids, origin);

// After
import { Awareness, encodeAwarenessUpdate, applyAwarenessUpdate, removeAwarenessStates } from 'y-protocols/awareness';

awareness = new Awareness(doc);
encodeAwarenessUpdate(awareness, clients);
applyAwarenessUpdate(awareness, update, origin);
removeAwarenessStates(awareness, ids, origin);
```

Each file imports only what it actually uses:

```
packages/
├── sync/src/
│   ├── provider.ts       { Awareness, encodeAwarenessUpdate, removeAwarenessStates, applyAwarenessUpdate }
│   └── types.ts          type { Awareness }
└── server/src/sync/
    ├── rooms.ts          { Awareness }
    ├── rooms.test.ts     { Awareness }
    ├── protocol.ts       { Awareness, encodeAwarenessUpdate }
    ├── protocol.test.ts  { Awareness, encodeAwarenessUpdate, applyAwarenessUpdate }
    └── plugin.ts         { Awareness, applyAwarenessUpdate, removeAwarenessStates }
```

The `encoding`, `decoding`, `syncProtocol`, and `Y` namespace imports are left untouched — those don't have the same redundancy problem.