### PR TITLE
refactor: flatten Extension type from nested to flat object

### DIFF
--- a/.agents/skills/technical-articles/SKILL.md
+++ b/.agents/skills/technical-articles/SKILL.md
@@ -15,6 +15,70 @@ Lead with a strong opening paragraph that states the key insight in plain langua
 
 Code speaks louder than prose. Show real examples from actual codebases, not abstract `foo`/`bar` illustrations. If the code is self-explanatory, don't over-explain.
 
+## Section Headings Are Arguments
+
+Section headings should make claims, not announce topics. The reader should know your position from the heading alone.
+
+Bad (topic headings):
+
+> ## What's in the binary
+>
+> ## How Go and Rust compare
+>
+> ## Why tree-shaking is difficult
+
+Good (argument headings):
+
+> ## Go and Rust: Your code IS the binary
+>
+> ## Bun (and Deno/Node): Your code rides on top of a VM
+>
+> ## Why tree-shaking the runtime is brutally hard
+
+The first set describes what the section is about. The second set tells you what the section argues. A reader who only skims headings should walk away with the article's core argument.
+
+This applies to the title too: "Bun Compile Is 57MB Because It's Not Your Code" is an argument. "Understanding Bun Compile Binary Size" is a topic.
+
+## Conversational Directness
+
+Write like you're explaining to a peer, not presenting to an audience. Short declarative sentences. Opinions stated plainly. Concessions acknowledged without hedging.
+
+Bad (formal article-speak):
+
+> The resulting bundle size of the `bun build --compile` command is notably large. With careful analysis, we can identify several contributing factors.
+
+Good (direct, conversational):
+
+> A `console.log("Hello World")` compiles to 57MB. Your code adds almost nothing. The binary is the entire Bun runtime.
+
+Parenthetical asides, dashes for emphasis, and sentence fragments are all fine when they serve clarity. "Stripping the JIT? Now your code runs 10-100x slower." reads better than a formally constructed alternative.
+
+## Numbered Bold Points for Multi-Part Arguments
+
+When explaining WHY something is the case and there are multiple independent reasons, use numbered bold points. Each point gets a bold heading, a short explanation, and optionally a code block.
+
+```
+**1. JavaScriptCore is monolithic (~40MB+ of the binary)**
+
+It's Apple's JS engine. Bun doesn't own it. You can't remove "the parts
+you don't use" because it's a tightly coupled C++ codebase.
+
+**2. `eval()` and dynamic imports break static analysis**
+
+Go and Rust know at compile time exactly what functions are called.
+JavaScript doesn't:
+
+\`\`\`js
+const module = await import(userInput)
+\`\`\`
+
+**3. Node.js compatibility is a massive surface area**
+
+Bun promises Node compat. That means all of node:fs, node:http, etc.
+```
+
+This pattern works because each reason stands alone. The reader can skim the bold lines and get the gist, or read deeply on the ones that interest them. Reserve this for 3-5 reasons; fewer than 3 should just be prose, more than 5 needs consolidation.
+
 ASCII diagrams for architecture or flow:
 
 ```

--- a/docs/articles/bun-compile-is-57mb-because-its-not-your-code.md
+++ b/docs/articles/bun-compile-is-57mb-because-its-not-your-code.md
@@ -1,0 +1,83 @@
+# Bun Compile Is 57MB Because It's Not Your Code
+
+It's a fundamentally different architecture. Not an optimization problem: a category problem.
+
+## Go and Rust: Your code IS the binary
+
+```
+Source code → Compiler → Machine code
+```
+
+The compiler translates your logic directly into CPU instructions. The binary contains your program logic as native instructions, a small runtime (Go: goroutine scheduler + GC at ~1.5MB, Rust: almost nothing), and only the standard library functions you actually called. Dead code elimination happens at link time.
+
+The linker literally strips everything you don't use. A Go HTTP server only includes the `net/http` code paths it reaches. Rust is even more aggressive: no runtime, no GC, just your code.
+
+## Bun (and Deno/Node): Your code rides on top of a VM
+
+```
+Bun binary = JavaScriptCore VM + Bun runtime + your JS appended at the end
+```
+
+Your code is **not** compiled to machine code at build time. It's bundled as JavaScript (or bytecode) and **stapled onto the full interpreter**. At runtime, JavaScriptCore JIT-compiles it on the fly.
+
+The binary isn't "your program." It's **an entire JavaScript engine that happens to run your script.** A `console.log("Hello World")` compiles to 57MB. Your code adds almost nothing. The rest is JavaScriptCore, the bundler, the test runner, the package manager, embedded SQLite, the Node.js compatibility layer, the HTTP server, and the TypeScript transpiler. None of it tree-shaken.
+
+## Why tree-shaking the runtime is brutally hard
+
+This is why [oven-sh/bun#14546](https://github.com/oven-sh/bun/issues/14546) has no timeline. It's not laziness: it's genuinely difficult.
+
+**1. JavaScriptCore is monolithic (~40MB+ of the binary)**
+
+It's Apple's JS engine. Bun doesn't own it. It includes the interpreter, multiple JIT tiers (Baseline, DFG, FTL/B3), garbage collector, and the entire ECMAScript spec implementation. You can't remove "the parts you don't use" because it's a tightly coupled C++ codebase designed to work as a unit. Stripping the JIT? Now your code runs 10-100x slower.
+
+**2. `eval()` and dynamic imports break static analysis**
+
+Go and Rust know at compile time exactly what functions are called. JavaScript doesn't:
+
+```js
+// Which APIs does this use? Nobody knows until runtime.
+const module = await import(userInput);
+globalThis[dynamicKey]();
+eval(arbitrary);
+```
+
+You can't prove that `bun:sqlite` or `node:crypto` won't be needed. So you ship everything.
+
+**3. Node.js compatibility is a massive surface area**
+
+Bun promises Node compat. That means `node:fs`, `node:http`, `node:crypto`, `node:zlib`, `node:net`, `node:child_process`, `node:stream`, and more, all reimplemented in Zig/C++ and baked in. These have deep cross-dependencies. Pulling one out risks breaking others.
+
+**4. It's a binary blob, not a linkable library**
+
+Go and Rust use a linker that says "function X is never called → remove it." Bun's compile just takes the pre-built `bun` executable and appends your bundled JS to the end. There's no link step. There's no dead code elimination. It's literally:
+
+```
+cat bun-runtime your-bundle.js > output-binary
+```
+
+(Simplified, but that's the essence.)
+
+## What "minimal runtime" would actually require
+
+Making the Bun runtime modularly compilable means rebuilding from source with only needed features, which requires restructuring a massive Zig/C++ codebase into optional compilation units. Static analysis of the JS bundle could determine which Node and Bun APIs are reachable, then exclude the rest at C++ compile time. And shipping a JavaScriptCore "lite" that strips JIT tiers for simpler programs is theoretically possible (interpreter-only mode exists but performance suffers).
+
+Each of these is months of engineering. And JavaScriptCore alone sets a hard floor of ~30-40MB no matter what.
+
+## The honest takeaway
+
+|                       | Go/Rust              | Bun/Deno/Node                   |
+| --------------------- | -------------------- | ------------------------------- |
+| Compilation model     | AOT to native code   | Bundle JS + ship full VM        |
+| Dead code elimination | Yes, at link time    | Not possible (dynamic language) |
+| Runtime overhead      | ~0-2MB               | ~50-60MB (the entire engine)    |
+| Theoretical minimum   | Your code + syscalls | ~30-40MB (just JSC)             |
+
+Bun compile will never match Go/Rust on binary size. The floor is the JS engine. The question is whether they can get from 57MB down to ~30-35MB by stripping the bundler, test runner, package manager, and unused Node polyfills. That's the tractable version of the problem, and it's still hard.
+
+---
+
+_Sources:_
+
+- [oven-sh/bun#14546](https://github.com/oven-sh/bun/issues/14546): "Use a minimal runtime for binary executables" (open, assigned)
+- [oven-sh/bun#4453](https://github.com/oven-sh/bun/issues/4453): "Smaller Executable build size" (closed as not planned)
+- [Optimizing Bun compiled binary for gg2](https://www.peterbe.com/plog/optimizing-bun-compiled-binary-for-gg2): real-world size measurements with `--bytecode` and `--production`

--- a/docs/articles/tauri-bun-dual-backend-architecture.md
+++ b/docs/articles/tauri-bun-dual-backend-architecture.md
@@ -1,0 +1,234 @@
+# Tauri's Webview Doesn't Care What Serves It
+
+Tauri's `invoke()` IPC and a Bun HTTP server can run side by side from the same frontend. The webview loads from Bun, fetches data from Bun, and calls native Rust commands through `invoke()` — all on the same page, no hacks required. This is how Epicenter gets native OS APIs (audio, shortcuts, tray) from Rust while keeping all business logic in TypeScript.
+
+## The Architecture
+
+```
+┌───────────────────────────────────────────────────────────┐
+│                    Tauri Process                           │
+│                                                           │
+│  ┌─────────────────────────────────────────────────────┐  │
+│  │  Rust (thin shell)                                  │  │
+│  │                                                     │  │
+│  │  setup() {                                          │  │
+│  │    spawn(bun-server sidecar)                        │  │
+│  │    read port from stdout                            │  │
+│  │    webview → http://localhost:N                      │  │
+│  │  }                                                  │  │
+│  │                                                     │  │
+│  │  invoke_handler: [                                  │  │
+│  │    start_recording,                                 │  │
+│  │    stop_recording,                                  │  │
+│  │    get_audio_devices,                               │  │
+│  │  ]                                                  │  │
+│  └─────────────────────────────────────────────────────┘  │
+│                                                           │
+│  ┌─────────────────────────────────────────────────────┐  │
+│  │  Bun Sidecar (HTTP server)                          │  │
+│  │                                                     │  │
+│  │  GET /              → Svelte SPA                    │  │
+│  │  GET /assets/*      → static files                  │  │
+│  │  /api/documents     → workspace CRUD                │  │
+│  │  /api/fs/*          → filesystem operations         │  │
+│  │  /ws/sync           → Yjs sync protocol             │  │
+│  │                                                     │  │
+│  │  127.0.0.1:N                                        │  │
+│  └──────────────────────────┬──────────────────────────┘  │
+│                             │                             │
+│  ┌──────────────────────────▼──────────────────────────┐  │
+│  │  Webview                                            │  │
+│  │  loaded from http://127.0.0.1:N                     │  │
+│  │                                                     │  │
+│  │  fetch('/api/documents')  ──► Bun (same origin)     │  │
+│  │  invoke('start_recording') ──► Rust (ipc://)        │  │
+│  └─────────────────────────────────────────────────────┘  │
+└───────────────────────────────────────────────────────────┘
+```
+
+Bun handles everything that's HTTP: serving the frontend, API routes, WebSocket connections, Yjs CRDT sync. Rust handles what JavaScript can't: system audio devices, global keyboard shortcuts, native notifications, tray icons.
+
+## Why This Works
+
+Tauri injects `__TAURI_INTERNALS__` into every webview unconditionally. The code path in `manager/webview.rs` → `prepare_pending_webview` registers the `ipc://` protocol handler and the invoke key regardless of whether the webview loaded from `tauri://localhost` or `http://localhost:54321`.
+
+When `invoke()` fires from a Bun-served page, this is the exact sequence:
+
+```
+invoke('start_recording', { device: 'default' })
+    │
+    ▼
+__TAURI_INTERNALS__.invoke()
+    │
+    ▼
+fetch('ipc://localhost/start_recording', {
+    headers: {
+        'Tauri-Invoke-Key': '<runtime key>',
+        'Tauri-Callback': '<id>',
+        'Tauri-Error': '<id>',
+        'Origin': 'http://localhost:54321'   ← the Bun server origin
+    }
+})
+    │
+    ▼
+Rust IPC handler:
+  1. Validates Tauri-Invoke-Key  ✓  (injected at init, always matches)
+  2. Extracts Origin             → http://localhost:54321
+  3. ACL classifies as           → Origin::Remote
+  4. resolve_access() checks     → remote.urls: ["http://localhost:*"]
+  5. URLPattern match            ✓
+  6. Executes Rust command       → start_recording()
+```
+
+The `ipc://` protocol handler sets `Access-Control-Allow-Origin: *`, so CORS never blocks it. The fetch goes to a custom protocol handler registered in-process; it never hits the network. If the custom protocol fails for any reason, `ipc-protocol.js` has a built-in fallback to `window.ipc.postMessage()`.
+
+The one thing you need: a Tauri v2 capability that whitelists your localhost origin.
+
+```json
+{
+	"identifier": "main-capability",
+	"remote": {
+		"urls": ["http://localhost:*"]
+	},
+	"permissions": ["core:default", "shell:allow-spawn", "shell:allow-execute"]
+}
+```
+
+## The Rust Side
+
+The entire Rust codebase shrinks to a sidecar launcher and a handful of native commands:
+
+```rust
+use tauri_plugin_shell::ShellExt;
+use tauri::webview::{WebviewWindowBuilder, WebviewUrl};
+
+#[tauri::command]
+fn start_recording(device: String) -> Result<String, String> {
+    // cpal audio recording — requires OS-level access
+    Ok("recording_started".into())
+}
+
+#[tauri::command]
+fn get_audio_devices() -> Result<Vec<String>, String> {
+    // enumerate system audio input devices
+    Ok(vec!["Default".into()])
+}
+
+pub fn run() {
+    tauri::Builder::default()
+        .plugin(tauri_plugin_shell::init())
+        .invoke_handler(tauri::generate_handler![
+            start_recording,
+            get_audio_devices,
+        ])
+        .setup(|app| {
+            let (mut rx, _child) = app.shell()
+                .sidecar("bun-server")
+                .unwrap()
+                .spawn()
+                .expect("Failed to spawn Bun sidecar");
+
+            let handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                while let Some(event) = rx.recv().await {
+                    if let tauri_plugin_shell::process::CommandEvent::Stdout(line) = event {
+                        let line = String::from_utf8_lossy(&line);
+                        if let Some(port) = line.strip_prefix("PORT:") {
+                            let url = format!("http://127.0.0.1:{}", port.trim());
+                            WebviewWindowBuilder::new(
+                                &handle, "main",
+                                WebviewUrl::External(url.parse().unwrap()),
+                            )
+                            .title("Epicenter")
+                            .build()
+                            .unwrap();
+                            break;
+                        }
+                    }
+                }
+            });
+            Ok(())
+        })
+        .run(tauri::generate_context!())
+        .expect("error running app");
+}
+```
+
+Two commands and a sidecar launcher. That's the entire Rust backend.
+
+## The Frontend
+
+The frontend doesn't know which backend it's talking to. `fetch()` goes to Bun. `invoke()` goes to Rust. Feature detection handles web mode gracefully.
+
+```typescript
+import { invoke } from '@tauri-apps/api/core';
+
+const isTauri = '__TAURI_INTERNALS__' in window;
+
+// Bun backend — always available (desktop and web)
+async function loadDocuments() {
+	return fetch('/api/documents').then((r) => r.json());
+}
+
+// Yjs sync — always available
+const ws = new WebSocket('/ws/sync');
+
+// Rust backend — only inside Tauri desktop app
+async function startRecording(device: string) {
+	if (isTauri) {
+		return invoke('start_recording', { device });
+	}
+	// Web fallback: browser MediaRecorder or "desktop only" message
+	return navigator.mediaDevices.getUserMedia({ audio: true });
+}
+```
+
+## Web Mode
+
+Without Tauri, the Bun server runs standalone. Same frontend, same API, no Rust at all:
+
+```
+$ bun run server.ts
+PORT:54321
+Epicenter running at http://127.0.0.1:54321
+```
+
+`invoke()` calls don't exist because `__TAURI_INTERNALS__` isn't injected. The `isTauri` check catches this and uses browser APIs or shows "desktop only" for native features. Everything else — documents, Yjs sync, workspace operations — works identically.
+
+## Why Bun Instead of Rust for the Server
+
+Yjs is a JavaScript library. The entire CRDT layer in `packages/epicenter/` is TypeScript. With a Bun server, the same Y.Doc code runs on both client and server: same sync protocol, same encoding, every Yjs plugin just works.
+
+With a Rust server, you'd use `yrs` (the Rust port). It's wire-compatible but a different implementation. Every Yjs extension used on the frontend would need a Rust equivalent on the server. That's a serialization boundary where there doesn't need to be one.
+
+| What it handles      | Bun (HTTP)           | Rust (IPC)                |
+| -------------------- | -------------------- | ------------------------- |
+| Frontend serving     | ✓ Static files + SPA |                           |
+| REST API             | ✓ /api/\*            |                           |
+| Yjs CRDT sync        | ✓ Native JS Yjs      |                           |
+| WebSocket            | ✓ /ws/\*             |                           |
+| Audio recording      |                      | ✓ cpal, OS-level access   |
+| Global shortcuts     |                      | ✓ Native key hooks        |
+| System tray          |                      | ✓ Platform tray APIs      |
+| Native notifications |                      | ✓ OS notification center  |
+| File watching        | ✓ Bun's fs.watch     | Alternative: notify crate |
+
+The split is clean: if JavaScript can do it, Bun does it. If it needs native OS APIs, Rust does it.
+
+## Sidecar Lifecycle
+
+Tauri manages the Bun process automatically. The shell plugin kills child processes on app exit, even on crash. The `rx` channel in `setup()` lets you detect sidecar failure and either restart it or show an error dialog.
+
+```
+Tauri starts    → spawns Bun sidecar → reads port → opens webview
+Tauri closes    → kills Bun sidecar automatically
+Bun crashes     → rx channel receives exit event → restart or error dialog
+```
+
+The compiled Bun binary goes into `src-tauri/binaries/` with a target-triple suffix (`bun-server-aarch64-apple-darwin`, `bun-server-x86_64-unknown-linux-gnu`). Tauri's bundler picks the right one per platform. The user never sees it.
+
+## The Tradeoff
+
+You ship two binaries instead of one. The Tauri shell is ~5MB, the compiled Bun server adds ~30MB. Startup takes 100-200ms longer because the sidecar needs to boot and report its port. And sidecar crash recovery is complexity that doesn't exist in a single-process Rust server.
+
+The payoff: your entire business logic is TypeScript. Your Yjs sync is native JS. Your dev loop is hot reload instead of recompile. And your web mode is just `bun run server.ts` — no Tauri, no Rust, same frontend.

--- a/docs/articles/the-server-starts-the-client-not-the-other-way-around.md
+++ b/docs/articles/the-server-starts-the-client-not-the-other-way-around.md
@@ -1,0 +1,99 @@
+# The Server Starts the Client, Not the Other Way Around
+
+Your server picks port 3913. It's taken, so it tries 3914. That's taken too. It lands on 3915. Now the frontend needs to connect. How does it know the port?
+
+The naive answer: have the client try 3913, then 3914, then 3915, incrementing until it finds the server. This is fragile. Another process could be listening on 3914, and now your client is talking to the wrong server. Race conditions, security holes, wasted time.
+
+The real answer is simpler: don't start the client until the server knows its port. Then hand it over.
+
+## The Parent Process Owns the Port
+
+Users don't open frontends directly. They launch something: a CLI command, a desktop app, a system tray icon. That launcher is the parent process. It starts the server, gets the port back, and only then opens the client with that port baked in.
+
+```
+User runs CLI / clicks app
+    │
+    ▼
+Parent process starts
+    │
+    ├── Start server ──► Server binds to port 3915
+    │                         │
+    │                         ▼
+    │                    Returns actual port
+    │
+    ├── open("http://localhost:3915")
+    │
+    ▼
+Browser opens, already connected
+```
+
+The server never broadcasts its port. The parent already knows it because the parent started the server. The client never guesses because the parent tells it exactly where to go. The browser tab doesn't exist until the server is ready to receive requests.
+
+This is how most local dev tools work in practice. [Vibe Kanban](https://github.com/BloopAI/vibe-kanban) is a good example: you run `npx vibe-kanban`, the Rust backend binds to an available port, and the process opens your browser to `localhost:{port}`. [OpenCode](https://github.com/anomalyco/opencode) does the same thing with its client/server architecture: the CLI starts the server, then the TUI (or a web browser) connects to it. In both cases, the user runs one command and the port is handled internally.
+
+For a CLI tool, the implementation is straightforward. Start the server, capture the port, open the browser:
+
+```typescript
+const port = await startServer({ defaultPort: 3913 });
+open(`http://localhost:${port}`);
+```
+
+One function call to bind, one to open the browser. The frontend doesn't need the port passed as a query parameter or stored anywhere; it's already running on the right origin.
+
+In a Tauri desktop app, the Rust backend is the parent process. It starts the server before the webview loads, then the frontend retrieves the port through Tauri's built-in IPC bridge:
+
+```rust
+#[tauri::command]
+fn get_api_port(state: tauri::State<'_, AppState>) -> u16 {
+    state.api_port
+}
+```
+
+```typescript
+const port = await invoke<number>('get_api_port');
+const api = `http://localhost:${port}`;
+```
+
+The IPC channel that Tauri already provides is the port discovery mechanism. No extra infrastructure needed.
+
+## When the Client Starts Independently
+
+The parent process pattern works when the server controls the client's lifecycle. But sometimes the client and server start separately: a web dashboard that's already open when you restart the backend, multiple clients connecting at different times, or separate executables that don't share a process tree. In those cases, the port needs to be discoverable after the fact.
+
+### Write the Port to a Known File
+
+The server writes its port to a well-known path on startup. Any client that needs to connect reads that file.
+
+```typescript
+// Server writes on startup
+const port = await bindToAvailablePort(3913);
+await writeFile('~/.config/myapp/port', String(port));
+```
+
+```typescript
+// Client reads on connect
+const port = Number(await readFile('~/.config/myapp/port'));
+```
+
+Simple, works across processes, no network overhead. The downside is stale files: if the server crashes without cleaning up, the next client reads a dead port. A PID file alongside the port file handles this, but it's more machinery. PostgreSQL uses exactly this pattern with its `postmaster.pid` file, which stores the PID, port, and socket path in the data directory.
+
+### Reserve a Discovery Port
+
+Reserve one fixed port as a discovery endpoint. The server always tries to bind port 3913 for discovery, even if the actual API runs elsewhere.
+
+```typescript
+// Discovery server on fixed port
+app.get('/discover', (req, res) => {
+	res.json({ apiPort: actualPort });
+});
+```
+
+The client hits `localhost:3913/discover`, gets the real port, and connects. This only fails if another process has already claimed 3913, which is unlikely for a niche port but not impossible.
+
+The tradeoff: you still need one known port, so you haven't fully solved the "what if it's taken" problem. You've just made it much less likely to matter, since the discovery endpoint is tiny and rarely conflicts.
+
+## Why the Client Shouldn't Guess
+
+Having the client increment through ports looking for the server seems simple, but it breaks in quiet ways. A different application listening on an intermediate port will accept the connection. The client has no way to verify it found _your_ server without an additional handshake protocol, and at that point you've reinvented service discovery.
+
+The startup sequence matters: something has to know the port first, and that something should tell everyone else. In most local apps, that's the parent process. The user starts the app, the app starts the server, and the server opens the client. The port flows downward through the process tree, never upward through guessing.

--- a/packages/epicenter/src/dynamic/extension.ts
+++ b/packages/epicenter/src/dynamic/extension.ts
@@ -13,8 +13,8 @@
  *   like SQLite queries, Markdown sync, revision history. Receive the client-so-far
  *   as context, including previously added extensions.
  *
- * Extension factories return `{ exports?, lifecycle? }`.
- * The framework normalizes defaults internally.
+ * Extension factories return flat objects `{ ...customExports, whenReady?, destroy? }`.
+ * The framework normalizes defaults internally via `defineExtension()`.
  */
 
 // Re-export lifecycle types for extension authors

--- a/packages/epicenter/src/dynamic/index.ts
+++ b/packages/epicenter/src/dynamic/index.ts
@@ -55,6 +55,7 @@ export type { Id } from '../shared/id';
 export { generateId, Id as createId } from '../shared/id';
 // Lifecycle utilities (re-exported for extension authors)
 export type {
+	Extension,
 	Lifecycle,
 	MaybePromise,
 } from '../shared/lifecycle';

--- a/packages/epicenter/src/dynamic/workspace/create-workspace.test.ts
+++ b/packages/epicenter/src/dynamic/workspace/create-workspace.test.ts
@@ -130,9 +130,7 @@ describe('createWorkspace', () => {
 
 			// Use inline factory for better type inference
 			const workspace = baseWorkspace.withExtension('mock', ({ id }) => ({
-				exports: {
-					greeting: `Hello from ${id}`,
-				},
+				greeting: `Hello from ${id}`,
 			}));
 
 			// Should have extension exports
@@ -171,24 +169,20 @@ describe('createWorkspace', () => {
 
 			const workspace = baseWorkspace
 				.withExtension('ext1', () => ({
-					lifecycle: {
-						whenReady: new Promise<void>((resolve) => {
-							setTimeout(() => {
-								resolved1 = true;
-								resolve();
-							}, 10);
-						}),
-					},
+					whenReady: new Promise<void>((resolve) => {
+						setTimeout(() => {
+							resolved1 = true;
+							resolve();
+						}, 10);
+					}),
 				}))
 				.withExtension('ext2', () => ({
-					lifecycle: {
-						whenReady: new Promise<void>((resolve) => {
-							setTimeout(() => {
-								resolved2 = true;
-								resolve();
-							}, 20);
-						}),
-					},
+					whenReady: new Promise<void>((resolve) => {
+						setTimeout(() => {
+							resolved2 = true;
+							resolve();
+						}, 20);
+					}),
 				}));
 
 			// Before awaiting, neither should be resolved
@@ -206,15 +200,13 @@ describe('createWorkspace', () => {
 
 			const workspace = createWorkspace(testDefinition)
 				.withExtension('slow', () => ({
-					exports: { tag: 'slow' },
-					lifecycle: {
-						whenReady: new Promise<void>((resolve) =>
-							setTimeout(() => {
-								order.push('slow-ready');
-								resolve();
-							}, 50),
-						),
-					},
+					tag: 'slow',
+					whenReady: new Promise<void>((resolve) =>
+						setTimeout(() => {
+							order.push('slow-ready');
+							resolve();
+						}, 50),
+					),
 				}))
 				.withExtension('dependent', (context) => {
 					// context.whenReady should be a promise representing all prior extensions
@@ -226,10 +218,8 @@ describe('createWorkspace', () => {
 					})();
 
 					return {
-						exports: { tag: 'dependent' },
-						lifecycle: {
-							whenReady,
-						},
+						tag: 'dependent',
+						whenReady,
 					};
 				});
 
@@ -255,7 +245,7 @@ describe('createWorkspace', () => {
 			const baseWorkspace = createWorkspace(testDefinition);
 
 			const chainedWorkspace = baseWorkspace.withExtension('mock', () => ({
-				exports: { data: 'test' },
+				data: 'test',
 			}));
 
 			// Base should still have empty extensions
@@ -292,17 +282,13 @@ describe('createWorkspace', () => {
 
 			const workspace = baseWorkspace
 				.withExtension('ext1', () => ({
-					lifecycle: {
-						destroy: () => {
-							destroyed1 = true;
-						},
+					destroy: () => {
+						destroyed1 = true;
 					},
 				}))
 				.withExtension('ext2', () => ({
-					lifecycle: {
-						destroy: () => {
-							destroyed2 = true;
-						},
+					destroy: () => {
+						destroyed2 = true;
 					},
 				}));
 
@@ -322,10 +308,8 @@ describe('createWorkspace', () => {
 			const workspace = createWorkspace(testDefinition).withExtension(
 				'tracker',
 				() => ({
-					lifecycle: {
-						destroy: () => {
-							destroyed = true;
-						},
+					destroy: () => {
+						destroyed = true;
 					},
 				}),
 			);
@@ -367,10 +351,8 @@ describe('createWorkspace', () => {
 			const workspace = createWorkspace(testDefinition).withExtension(
 				'myExt',
 				() => ({
-					exports: {
-						version: 1,
-						getName: () => 'my-extension',
-					},
+					version: 1,
+					getName: () => 'my-extension',
 				}),
 			);
 
@@ -384,22 +366,20 @@ describe('createWorkspace', () => {
 		test('extension N+1 can access extension N exports via context', () => {
 			const workspace = createWorkspace(testDefinition)
 				.withExtension('first', () => ({
-					exports: {
-						value: 42,
-						helper: () => 'from-first',
-					},
+					value: 42,
+					helper: () => 'from-first',
 				}))
 				.withExtension('second', ({ extensions }) => {
 					// extensions.first is fully typed — no casts needed
 					const doubled = extensions.first.value * 2;
 					const msg = extensions.first.helper();
-					return { exports: { doubled, msg } };
+					return { doubled, msg };
 				})
 				.withExtension('third', ({ extensions }) => {
 					// extensions.first AND extensions.second are both fully typed
 					const tripled = extensions.first.value * 3;
 					const fromSecond = extensions.second.doubled;
-					return { exports: { tripled, fromSecond } };
+					return { tripled, fromSecond };
 				});
 
 			// All extensions accessible and typed on the final client
@@ -425,24 +405,18 @@ describe('createWorkspace', () => {
 
 			const workspace = createWorkspace(testDefinition)
 				.withExtension('a', () => ({
-					lifecycle: {
-						destroy: () => {
-							order.push('a');
-						},
+					destroy: () => {
+						order.push('a');
 					},
 				}))
 				.withExtension('b', () => ({
-					lifecycle: {
-						destroy: () => {
-							order.push('b');
-						},
+					destroy: () => {
+						order.push('b');
 					},
 				}))
 				.withExtension('c', () => ({
-					lifecycle: {
-						destroy: () => {
-							order.push('c');
-						},
+					destroy: () => {
+						order.push('c');
 					},
 				}));
 

--- a/packages/epicenter/src/dynamic/workspace/create-workspace.ts
+++ b/packages/epicenter/src/dynamic/workspace/create-workspace.ts
@@ -129,6 +129,7 @@ export function createWorkspace<
 				const result = factory(client);
 				const destroy = result.lifecycle?.destroy;
 				if (destroy) extensionCleanups.push(destroy);
+
 				whenReadyPromises.push(
 					result.lifecycle?.whenReady ?? Promise.resolve(),
 				);

--- a/packages/epicenter/src/extensions/sync.ts
+++ b/packages/epicenter/src/extensions/sync.ts
@@ -120,47 +120,43 @@ export function createSyncExtension(
 		})();
 
 		return {
-			exports: {
-				get provider() {
-					return provider;
-				},
-				/**
-				 * Swap the sync rail (WebSocket target) without affecting other extensions.
-				 *
-				 * Destroys the current provider, creates a new `SyncProvider` on the same
-				 * `Y.Doc`, and connects it. Other extensions (persistence, etc.) are untouched —
-				 * only the sync provider changes.
-				 *
-				 * @example
-				 * ```typescript
-				 * workspace.extensions.sync.reconnect({
-				 *   url: 'wss://cloud.example.com/rooms/my-workspace/sync',
-				 * });
-				 * ```
-				 */
-				reconnect(
-					newConfig: {
-						url?: string;
-						token?: string;
-						getToken?: () => Promise<string>;
-					} = {},
-				) {
-					provider.destroy();
-					provider = createSyncProvider({
-						doc: ydoc,
-						url: newConfig.url ?? resolvedUrl,
-						token: newConfig.token,
-						getToken: newConfig.getToken,
-						connect: true,
-						awareness: awareness.raw,
-					});
-				},
+			get provider() {
+				return provider;
 			},
-			lifecycle: {
-				whenReady,
-				destroy() {
-					provider.destroy();
-				},
+			/**
+			 * Swap the sync rail (WebSocket target) without affecting other extensions.
+			 *
+			 * Destroys the current provider, creates a new `SyncProvider` on the same
+			 * `Y.Doc`, and connects it. Other extensions (persistence, etc.) are untouched —
+			 * only the sync provider changes.
+			 *
+			 * @example
+			 * ```typescript
+			 * workspace.extensions.sync.reconnect({
+			 *   url: 'wss://cloud.example.com/rooms/my-workspace/sync',
+			 * });
+			 * ```
+			 */
+			reconnect(
+				newConfig: {
+					url?: string;
+					token?: string;
+					getToken?: () => Promise<string>;
+				} = {},
+			) {
+				provider.destroy();
+				provider = createSyncProvider({
+					doc: ydoc,
+					url: newConfig.url ?? resolvedUrl,
+					token: newConfig.token,
+					getToken: newConfig.getToken,
+					connect: true,
+					awareness: awareness.raw,
+				});
+			},
+			whenReady,
+			destroy() {
+				provider.destroy();
 			},
 		};
 	};

--- a/packages/epicenter/src/extensions/sync/desktop.ts
+++ b/packages/epicenter/src/extensions/sync/desktop.ts
@@ -70,7 +70,7 @@ export const persistence = (
 		});
 	})();
 
-	return { lifecycle: { whenReady } };
+	return { whenReady };
 };
 
 /**

--- a/packages/epicenter/src/extensions/sync/web.ts
+++ b/packages/epicenter/src/extensions/sync/web.ts
@@ -33,13 +33,9 @@ import type * as Y from 'yjs';
 export function indexeddbPersistence({ ydoc }: { ydoc: Y.Doc }) {
 	const idb = new IndexeddbPersistence(ydoc.guid, ydoc);
 	return {
-		exports: {
-			clearData: () => idb.clearData(),
-		},
-		lifecycle: {
-			// y-indexeddb's whenSynced = "data loaded from IndexedDB"
-			whenReady: idb.whenSynced,
-			destroy: () => idb.destroy(),
-		},
+		clearData: () => idb.clearData(),
+		// y-indexeddb's whenSynced = "data loaded from IndexedDB"
+		whenReady: idb.whenSynced,
+		destroy: () => idb.destroy(),
 	};
 }

--- a/packages/epicenter/src/shared/lifecycle.ts
+++ b/packages/epicenter/src/shared/lifecycle.ts
@@ -18,8 +18,8 @@
  *          ▼                                    ▼
  * ┌──────────────────────────┐    ┌──────────────────────────────┐
  * │  Providers (doc-level)   │    │  Extensions (workspace-level) │
- * │  return Lifecycle & T    │    │  return Extension<T>          │
- * │  directly                │    │  { exports?, lifecycle? }     │
+ * │  return Lifecycle & T    │    │  return flat { T, whenReady?, │
+ * │  directly                │    │    destroy? }                  │
  * └──────────────────────────┘    └──────────────────────────────┘
  * ```
  *
@@ -28,17 +28,15 @@
  * Factory functions are **always synchronous**. Async initialization is tracked
  * via the returned `whenReady` promise, not the factory itself.
  *
- * **Extensions** return `{ exports?, lifecycle? }`:
+ * **Extensions** return a flat object with custom exports + optional lifecycle hooks:
  *
  * ```typescript
- * // Extension with cleanup — lifecycle wraps whenReady/destroy
+ * // Extension with exports and cleanup
  * const withCleanup: ExtensionFactory = ({ ydoc }) => {
  *   const db = new Database(':memory:');
  *   return {
- *     exports: { db },
- *     lifecycle: {
- *       destroy: () => db.close(),
- *     },
+ *     db,
+ *     destroy: () => db.close(),
  *   };
  * };
  * ```
@@ -138,62 +136,81 @@ export type Lifecycle = {
 };
 
 // ════════════════════════════════════════════════════════════════════════════
-// EXTENSION RESULT — Separated lifecycle from consumer exports
+// EXTENSION — Flat resolved type with required lifecycle hooks
 // ════════════════════════════════════════════════════════════════════════════
 
 /**
- * What extension factories return — an object with optional exports and lifecycle hooks.
+ * The resolved form of an extension — a flat object with custom exports
+ * alongside required `whenReady` and `destroy` lifecycle hooks.
  *
- * The framework normalizes defaults internally:
- * - `exports` defaults to `{}` (empty — lifecycle-only extensions)
- * - `lifecycle.whenReady` defaults to `Promise.resolve()` (instantly ready)
- * - `lifecycle.destroy` defaults to `() => {}` (no-op cleanup)
+ * Extension factories return a raw flat object with optional `whenReady` and
+ * `destroy`. The framework normalizes defaults via `defineExtension()` so the
+ * stored form always has both lifecycle hooks present.
  *
- * Document-level extensions are registered separately via `withDocumentExtension()`.
+ * `whenReady` and `destroy` are reserved property names — extension authors
+ * should not use them for custom exports.
  *
- * The `exports` object is stored **by reference** in `workspace.extensions[key]` —
- * getters, proxies, and object identity are preserved.
- *
- * @typeParam T - The exports object type (what consumers access via `workspace.extensions[key]`)
+ * @typeParam T - Custom exports (everything except `whenReady` and `destroy`).
+ *   Defaults to `Record<string, never>` for lifecycle-only extensions.
  *
  * @example
  * ```typescript
- * // Extension with exports + lifecycle
- * .withExtension('sqlite', (ctx) => ({
- *   exports: { db, pullToSqlite },
- *   lifecycle: {
- *     whenReady: initPromise,
- *     destroy: () => db.close(),
- *   },
- * }))
+ * // What the consumer sees:
+ * client.extensions.sqlite.db.query('...');
+ * await client.extensions.sqlite.whenReady;
+ * // typeof client.extensions.sqlite = Extension<{ db: Database; pullToSqlite: ...; }>
  *
- * // Lifecycle-only (no exports)
- * .withExtension('persistence', (ctx) => ({
- *   lifecycle: {
- *     whenReady: loadFromDisk(),
- *     destroy: () => flush(),
- *   },
- * }))
- *
- * // Exports-only (no lifecycle)
- * .withExtension('helpers', () => ({
- *   exports: { compute: (x: number) => x * 2 },
- * }))
+ * // Lifecycle-only extension:
+ * await client.extensions.persistence.whenReady;
+ * // typeof client.extensions.persistence = Extension<Record<string, never>>
  * ```
  */
 export type Extension<
 	T extends Record<string, unknown> = Record<string, never>,
-> = {
-	/** Consumer-facing exports stored by reference in `workspace.extensions[key]` */
-	exports?: T;
-	/** Lifecycle hooks for initialization and cleanup. */
-	lifecycle?: {
-		/** Resolves when initialization is complete. Defaults to `Promise.resolve()`. */
-		whenReady?: Promise<unknown>;
-		/** Clean up resources. Defaults to no-op. */
-		destroy?: () => MaybePromise<void>;
-	};
+> = T & {
+	/** Resolves when initialization is complete. Always present (defaults to resolved). */
+	whenReady: Promise<void>;
+	/** Clean up resources. Always present (defaults to no-op). */
+	destroy: () => MaybePromise<void>;
 };
+
+/**
+ * Normalize a raw flat extension return into the resolved `Extension<T>` form.
+ *
+ * Applies defaults:
+ * - `whenReady` defaults to `Promise.resolve()` (instantly ready)
+ * - `destroy` defaults to `() => {}` (no-op cleanup)
+ * - `whenReady` is coerced to `Promise<void>` via `.then(() => {})`
+ *
+ * Called by the framework inside `withExtension()` and the document extension
+ * `open()` loop. Extension authors never import this — they return plain objects
+ * and the framework normalizes.
+ *
+ * @param input - Raw extension return (custom exports + optional whenReady/destroy)
+ * @returns Resolved extension with required whenReady and destroy
+ *
+ * @example
+ * ```typescript
+ * // Framework usage (inside withExtension):
+ * const raw = factory(context);
+ * const resolved = defineExtension(raw ?? {});
+ * extensionMap[key] = resolved;
+ * destroys.push(resolved.destroy);
+ * whenReadyPromises.push(resolved.whenReady);
+ * ```
+ */
+export function defineExtension<T extends Record<string, unknown>>(
+	input: T & {
+		whenReady?: Promise<unknown>;
+		destroy?: () => MaybePromise<void>;
+	},
+): Extension<Omit<T, 'whenReady' | 'destroy'>> {
+	return {
+		...input,
+		whenReady: input.whenReady?.then(() => {}) ?? Promise.resolve(),
+		destroy: input.destroy ?? (() => {}),
+	} as Extension<Omit<T, 'whenReady' | 'destroy'>>;
+}
 
 // ════════════════════════════════════════════════════════════════════════════
 // DOCUMENT CONTEXT — Passed to document extension factories
@@ -216,7 +233,8 @@ export type Extension<
  * @example
  * ```typescript
  * .withDocumentExtension('sync', (context) => {
- *   // Access prior document extension exports directly
+ *   // Access prior document extension exports + lifecycle directly
+ *   await context.extensions.persistence?.whenReady;
  *   context.extensions.persistence?.clearData();
  *
  *   // Composite: await ALL prior doc extensions
@@ -245,17 +263,22 @@ export type DocumentContext<
 		tags: readonly string[];
 	};
 	/**
-	 * Typed access to prior document extensions' exports.
+	 * Typed access to prior document extensions (resolved form with lifecycle hooks).
 	 *
 	 * Each entry is optional because tag-filtered extensions may be skipped.
 	 * Factories should guard access with optional chaining.
 	 *
 	 * @example
 	 * ```typescript
+	 * await context.extensions.persistence?.whenReady;
 	 * context.extensions.persistence?.clearData();
 	 * ```
 	 */
 	extensions: {
-		[K in keyof TDocExtensions]?: TDocExtensions[K];
+		[K in keyof TDocExtensions]?: Extension<
+			TDocExtensions[K] extends Record<string, unknown>
+				? TDocExtensions[K]
+				: Record<string, never>
+		>;
 	};
 };

--- a/packages/epicenter/src/static/create-document-binding.test.ts
+++ b/packages/epicenter/src/static/create-document-binding.test.ts
@@ -224,8 +224,8 @@ describe('createDocumentBinding', () => {
 					{
 						key: 'persistence',
 						factory: () => ({
-							exports: { clearData: () => {} },
-							lifecycle: { destroy: () => {} },
+							clearData: () => {},
+							destroy: () => {},
 						}),
 						tags: [],
 					},
@@ -238,13 +238,13 @@ describe('createDocumentBinding', () => {
 			expect(typeof handle.exports.persistence!.clearData).toBe('function');
 		});
 
-		test('returns empty exports when extension has no exports', async () => {
+		test('lifecycle-only extension is accessible with whenReady and destroy', async () => {
 			const { binding } = setupWithBinding({
 				documentExtensions: [
 					{
 						key: 'lifecycle-only',
 						factory: () => ({
-							lifecycle: { destroy: () => {} },
+							destroy: () => {},
 						}),
 						tags: [],
 					},
@@ -253,7 +253,10 @@ describe('createDocumentBinding', () => {
 
 			const handle = await binding.open('f1');
 			expect(handle.exports).toBeDefined();
-			expect(handle.exports['lifecycle-only']).toBeUndefined();
+			const ext = handle.exports['lifecycle-only'];
+			expect(ext).toBeDefined();
+			expect(ext!.whenReady).toBeInstanceOf(Promise);
+			expect(typeof ext!.destroy).toBe('function');
 		});
 
 		test('accepts a row object', async () => {
@@ -262,7 +265,7 @@ describe('createDocumentBinding', () => {
 					{
 						key: 'test',
 						factory: () => ({
-							exports: { helper: () => 42 },
+							helper: () => 42,
 						}),
 						tags: [],
 					},
@@ -365,7 +368,7 @@ describe('createDocumentBinding', () => {
 						key: 'first',
 						factory: () => {
 							order.push(1);
-							return { lifecycle: { destroy: () => {} } };
+							return { destroy: () => {} };
 						},
 						tags: [],
 					},
@@ -373,7 +376,7 @@ describe('createDocumentBinding', () => {
 						key: 'second',
 						factory: () => {
 							order.push(2);
-							return { lifecycle: { destroy: () => {} } };
+							return { destroy: () => {} };
 						},
 						tags: [],
 					},
@@ -381,7 +384,7 @@ describe('createDocumentBinding', () => {
 						key: 'third',
 						factory: () => {
 							order.push(3);
-							return { lifecycle: { destroy: () => {} } };
+							return { destroy: () => {} };
 						},
 						tags: [],
 					},
@@ -400,10 +403,8 @@ describe('createDocumentBinding', () => {
 					{
 						key: 'first',
 						factory: () => ({
-							lifecycle: {
-								whenReady: Promise.resolve(),
-								destroy: () => {},
-							},
+							whenReady: Promise.resolve(),
+							destroy: () => {},
 						}),
 						tags: [],
 					},
@@ -411,7 +412,7 @@ describe('createDocumentBinding', () => {
 						key: 'second',
 						factory: ({ whenReady }) => {
 							secondReceivedWhenReady = whenReady instanceof Promise;
-							return { lifecycle: { destroy: () => {} } };
+							return { destroy: () => {} };
 						},
 						tags: [],
 					},
@@ -439,7 +440,7 @@ describe('createDocumentBinding', () => {
 						key: 'normal-hook',
 						factory: () => {
 							hooksCalled++;
-							return { lifecycle: { destroy: () => {} } };
+							return { destroy: () => {} };
 						},
 						tags: [],
 					},
@@ -480,7 +481,7 @@ describe('createDocumentBinding', () => {
 						key: 'capture',
 						factory: (ctx) => {
 							capturedBinding = ctx.binding;
-							return { lifecycle: { destroy: () => {} } };
+							return { destroy: () => {} };
 						},
 						tags: [],
 					},
@@ -503,7 +504,7 @@ describe('createDocumentBinding', () => {
 						key: 'universal',
 						factory: () => {
 							called = true;
-							return { lifecycle: { destroy: () => {} } };
+							return { destroy: () => {} };
 						},
 						tags: [], // universal — no tags
 					},
@@ -523,7 +524,7 @@ describe('createDocumentBinding', () => {
 						key: 'sync-ext',
 						factory: () => {
 							called = true;
-							return { lifecycle: { destroy: () => {} } };
+							return { destroy: () => {} };
 						},
 						tags: ['synced'],
 					},
@@ -543,7 +544,7 @@ describe('createDocumentBinding', () => {
 						key: 'ephemeral-ext',
 						factory: () => {
 							called = true;
-							return { lifecycle: { destroy: () => {} } };
+							return { destroy: () => {} };
 						},
 						tags: ['ephemeral'],
 					},
@@ -563,7 +564,7 @@ describe('createDocumentBinding', () => {
 						key: 'tagged',
 						factory: () => {
 							calls.push('tagged');
-							return { lifecycle: { destroy: () => {} } };
+							return { destroy: () => {} };
 						},
 						tags: ['persistent'],
 					},
@@ -571,7 +572,7 @@ describe('createDocumentBinding', () => {
 						key: 'universal',
 						factory: () => {
 							calls.push('universal');
-							return { lifecycle: { destroy: () => {} } };
+							return { destroy: () => {} };
 						},
 						tags: [],
 					},
@@ -592,8 +593,8 @@ describe('createDocumentBinding', () => {
 					{
 						key: 'first',
 						factory: () => ({
-							exports: { someValue: 42 },
-							lifecycle: { destroy: () => {} },
+							someValue: 42,
+							destroy: () => {},
 						}),
 						tags: [],
 					},
@@ -601,7 +602,7 @@ describe('createDocumentBinding', () => {
 						key: 'second',
 						factory: (context) => {
 							capturedFirstExtension = context.extensions.first;
-							return { lifecycle: { destroy: () => {} } };
+							return { destroy: () => {} };
 						},
 						tags: [],
 					},
@@ -625,8 +626,8 @@ describe('createDocumentBinding', () => {
 					{
 						key: 'tagged',
 						factory: () => ({
-							exports: { label: 'tagged' },
-							lifecycle: { destroy: () => {} },
+							label: 'tagged',
+							destroy: () => {},
 						}),
 						tags: ['persistent'],
 					},
@@ -635,7 +636,7 @@ describe('createDocumentBinding', () => {
 						factory: (context) => {
 							taggedPresentForPersistentDoc =
 								context.extensions.tagged !== undefined;
-							return { lifecycle: { destroy: () => {} } };
+							return { destroy: () => {} };
 						},
 						tags: [],
 					},
@@ -650,8 +651,8 @@ describe('createDocumentBinding', () => {
 					{
 						key: 'tagged',
 						factory: () => ({
-							exports: { label: 'tagged' },
-							lifecycle: { destroy: () => {} },
+							label: 'tagged',
+							destroy: () => {},
 						}),
 						tags: ['persistent'],
 					},
@@ -660,7 +661,7 @@ describe('createDocumentBinding', () => {
 						factory: (context) => {
 							taggedPresentForEphemeralDoc =
 								context.extensions.tagged !== undefined;
-							return { lifecycle: { destroy: () => {} } };
+							return { destroy: () => {} };
 						},
 						tags: [],
 					},
@@ -681,7 +682,7 @@ describe('createDocumentBinding', () => {
 					{
 						key: 'first',
 						factory: () => ({
-							lifecycle: { destroy: () => {} },
+							destroy: () => {},
 						}),
 						tags: [],
 					},
@@ -689,7 +690,7 @@ describe('createDocumentBinding', () => {
 						key: 'second',
 						factory: (context) => {
 							firstExtensionSeen = context.extensions.first !== undefined;
-							return { lifecycle: { destroy: () => {} } };
+							return { destroy: () => {} };
 						},
 						tags: [],
 					},
@@ -706,8 +707,8 @@ describe('createDocumentBinding', () => {
 					{
 						key: 'test',
 						factory: () => ({
-							exports: { helper: () => 42 },
-							lifecycle: { destroy: () => {} },
+							helper: () => 42,
+							destroy: () => {},
 						}),
 						tags: [],
 					},

--- a/packages/epicenter/src/static/define-workspace.test.ts
+++ b/packages/epicenter/src/static/define-workspace.test.ts
@@ -81,9 +81,7 @@ describe('defineWorkspace', () => {
 			tables: unknown;
 			kv: unknown;
 		}) => ({
-			exports: {
-				customMethod: () => 'hello',
-			},
+			customMethod: () => 'hello',
 		});
 
 		const client = createWorkspace({
@@ -100,22 +98,18 @@ describe('defineWorkspace', () => {
 	test('extension exports are fully typed', () => {
 		// Extension with rich exports
 		const persistenceExtension = () => ({
-			exports: {
-				db: {
-					query: (sql: string) => sql.toUpperCase(),
-					execute: (sql: string) => ({ rows: [sql] }),
-				},
-				stats: { writes: 0, reads: 0 },
+			db: {
+				query: (sql: string) => sql.toUpperCase(),
+				execute: (sql: string) => ({ rows: [sql] }),
 			},
+			stats: { writes: 0, reads: 0 },
 		});
 
 		// Another extension with different exports
 		const syncExtension = () => ({
-			exports: {
-				connect: (url: string) => `connected to ${url}`,
-				disconnect: () => 'disconnected',
-				status: 'idle' as 'idle' | 'syncing' | 'synced',
-			},
+			connect: (url: string) => `connected to ${url}`,
+			disconnect: () => 'disconnected',
+			status: 'idle' as 'idle' | 'syncing' | 'synced',
 		});
 
 		const client = createWorkspace({
@@ -156,10 +150,8 @@ describe('defineWorkspace', () => {
 	test('client.destroy() cleans up', async () => {
 		let destroyed = false;
 		const mockExtension = () => ({
-			lifecycle: {
-				destroy: async () => {
-					destroyed = true;
-				},
+			destroy: async () => {
+				destroyed = true;
 			},
 		});
 
@@ -245,22 +237,20 @@ describe('defineWorkspace', () => {
 			},
 		})
 			.withExtension('first', () => ({
-				exports: {
-					value: 42,
-					helper: () => 'from-first',
-				},
+				value: 42,
+				helper: () => 'from-first',
 			}))
 			.withExtension('second', ({ extensions }) => {
 				// extensions.first is fully typed here — no casts needed
 				const doubled = extensions.first.value * 2;
 				const msg = extensions.first.helper();
-				return { exports: { doubled, msg } };
+				return { doubled, msg };
 			})
 			.withExtension('third', ({ extensions }) => {
 				// extensions.first AND extensions.second are both fully typed
 				const tripled = extensions.first.value * 3;
 				const fromSecond = extensions.second.doubled;
-				return { exports: { tripled, fromSecond } };
+				return { tripled, fromSecond };
 			});
 
 		// All extensions accessible and typed on the final client
@@ -289,9 +279,7 @@ describe('defineWorkspace', () => {
 			},
 		})
 			.withExtension('analytics', () => ({
-				exports: {
-					getCount: () => 5,
-				},
+				getCount: () => 5,
 			}))
 			.withActions((c) => ({
 				getAnalyticsCount: defineQuery({
@@ -327,15 +315,13 @@ describe('defineWorkspace', () => {
 			},
 		})
 			.withExtension('slow', () => ({
-				exports: { tag: 'slow' },
-				lifecycle: {
-					whenReady: new Promise<void>((resolve) =>
-						setTimeout(() => {
-							order.push('slow-ready');
-							resolve();
-						}, 50),
-					),
-				},
+				tag: 'slow',
+				whenReady: new Promise<void>((resolve) =>
+					setTimeout(() => {
+						order.push('slow-ready');
+						resolve();
+					}, 50),
+				),
 			}))
 			.withExtension('dependent', (context) => {
 				// context.whenReady should be a promise representing all prior extensions
@@ -347,10 +333,8 @@ describe('defineWorkspace', () => {
 				})();
 
 				return {
-					exports: { tag: 'dependent' },
-					lifecycle: {
-						whenReady,
-					},
+					tag: 'dependent',
+					whenReady,
 				};
 			});
 
@@ -366,7 +350,7 @@ describe('defineWorkspace', () => {
 			id: 'first-ext-test',
 		}).withExtension('first', (context) => {
 			contextWhenReady = context.whenReady;
-			return { exports: { tag: 'first' } };
+			return { tag: 'first' };
 		});
 
 		// First extension's context.whenReady = Promise.all([]) which resolves immediately
@@ -405,24 +389,18 @@ describe('defineWorkspace', () => {
 			id: 'destroy-order',
 		})
 			.withExtension('a', () => ({
-				lifecycle: {
-					destroy: () => {
-						order.push('a');
-					},
+				destroy: () => {
+					order.push('a');
 				},
 			}))
 			.withExtension('b', () => ({
-				lifecycle: {
-					destroy: () => {
-						order.push('b');
-					},
+				destroy: () => {
+					order.push('b');
 				},
 			}))
 			.withExtension('c', () => ({
-				lifecycle: {
-					destroy: () => {
-						order.push('c');
-					},
+				destroy: () => {
+					order.push('c');
 				},
 			}));
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,6 +11,7 @@
 	"license": "AGPL-3.0",
 	"scripts": {
 		"start": "bun src/start.ts",
+		"dev": "bun src/start.ts",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {

--- a/specs/20260220T200000-flat-extension-type.md
+++ b/specs/20260220T200000-flat-extension-type.md
@@ -1,0 +1,489 @@
+# Flat Extension Type
+
+**Date**: 2026-02-20
+**Status**: Draft
+**Author**: AI-assisted
+**Scope**: `lifecycle.ts`, `create-workspace.ts` (static + dynamic), `create-document-binding.ts`, `types.ts` (static + dynamic), all extension factories, tests
+
+## Overview
+
+Flatten the `Extension` type from `{ exports?, lifecycle?: { whenReady?, destroy? } }` to a single flat object where custom exports, `whenReady`, and `destroy` coexist at the same level. The framework normalizes defaults via an internal `defineExtension()` helper so the stored form always has `whenReady: Promise<void>` and `destroy: () => MaybePromise<void>`. Both workspace and document extension initialization loops use the same normalization pattern.
+
+## Motivation
+
+### Current State
+
+Extension factories return a nested shape — custom exports under `exports`, lifecycle hooks under `lifecycle`:
+
+```typescript
+// indexeddbPersistence (extensions/sync/web.ts)
+return {
+	exports: { clearData: () => idb.clearData() },
+	lifecycle: {
+		whenReady: idb.whenSynced,
+		destroy: () => idb.destroy(),
+	},
+};
+
+// revision-history (extensions/revision-history/local.ts)
+return {
+	exports: { save, list, view, restore, count, directory: snapshotDir },
+	lifecycle: {
+		destroy() {
+			/* cleanup */
+		},
+	},
+};
+```
+
+The framework destructures the nested shape:
+
+```typescript
+// In withExtension():
+const result = factory(client);
+const destroy = result.lifecycle?.destroy; // lifecycle.destroy
+const whenReady = result.lifecycle?.whenReady; // lifecycle.whenReady
+extensions[key] = result.exports ?? {}; // only exports stored
+```
+
+This creates problems:
+
+1. **Five specs of churn.** The exports/lifecycle boundary has been introduced, wrapped, injected into, reverted, and re-flattened across five separate specs. The nesting is an internal bookkeeping detail that keeps surfacing as an authoring and ergonomics problem.
+
+2. **Pre-existing bug: sqlite's `destroy` is silently dropped.** The sqlite extension already returns `destroy` at the top level (not inside `lifecycle`). The framework reads `result.lifecycle?.destroy` and misses it. The extension's cleanup never runs.
+
+   ```typescript
+   // sqlite returns this (extensions/sqlite/sqlite.ts:263-326):
+   return {
+   	exports: { pullToSqlite, pushFromSqlite, db, ...drizzleTables },
+   	async destroy() {
+   		/* close db, clear timeouts */
+   	},
+   };
+   // Framework reads result.lifecycle?.destroy → undefined. Bug.
+   ```
+
+3. **No per-extension `whenReady` on stored form.** The stored form is just exports — no `whenReady`. Surgical await (waiting for a specific prior extension) requires either `Object.assign` injection or redundant `whenReady` in both exports and lifecycle.
+
+4. **Two different initialization patterns.** Workspace extensions use separate `whenReadyPromises[]` and `extensionCleanups[]` arrays mutated across chained calls. Document extensions use a `lifecycles[]` array in a for loop. Same logic, different shapes.
+
+### Desired State
+
+Extension factories return a flat bag of properties. `whenReady` and `destroy` are reserved names at the top level alongside custom exports:
+
+```typescript
+// indexeddbPersistence — flat
+return {
+	clearData: () => idb.clearData(),
+	whenReady: idb.whenSynced,
+	destroy: () => idb.destroy(),
+};
+
+// revision-history — flat
+return {
+	save,
+	list,
+	view,
+	restore,
+	count,
+	directory: snapshotDir,
+	destroy() {
+		/* cleanup */
+	},
+};
+
+// sqlite — already partially flat (destroy was top-level), now fully flat
+return {
+	pullToSqlite,
+	pushFromSqlite,
+	db: sqliteDb,
+	...drizzleTables,
+	whenReady: initPromise,
+	destroy: async () => {
+		/* close db */
+	},
+};
+```
+
+The framework normalizes once. The stored form always includes `whenReady` and `destroy`:
+
+```typescript
+// Consumer access — flat, whenReady always present:
+client.extensions.persistence.clearData();
+await client.extensions.persistence.whenReady; // surgical await
+client.extensions.sqlite.db.query('...');
+await client.extensions.sqlite.whenReady; // surgical await
+```
+
+## Research Findings
+
+### Spec History (5 Iterations)
+
+| Spec                                              | Date       | What it did                                                          | Status              |
+| ------------------------------------------------- | ---------- | -------------------------------------------------------------------- | ------------------- |
+| `20260213T120800` Separate Lifecycle from Exports | 2026-02-13 | Introduced `{ exports, lifecycle }` separation + `defineExtension()` | Complete            |
+| `20260214T133054` Remove defineExtension          | 2026-02-14 | Removed `defineExtension()`, kept nested `{ exports?, lifecycle? }`  | Complete            |
+| `20260220T200000` Extension Handle Passthrough    | 2026-02-20 | Wrapped stored form in `{ exports, lifecycle }` handle               | Complete (reverted) |
+| `20260220T200000` Surgical Extension Await        | 2026-02-20 | Added per-extension `whenReady` via `Object.assign` injection        | Complete (reverted) |
+| `20260220T195900` Flatten Extension Exports       | 2026-02-20 | Reverted handle passthrough, removed per-extension `whenReady`       | Complete            |
+
+**Key finding**: Every iteration tried to solve the same tension: exports need to be flat for consumers, but lifecycle needs to be tracked for the framework. The nesting was never the right boundary — it kept leaking. The answer is to not separate them at all: `whenReady` and `destroy` are just properties on the same flat object, with reserved names.
+
+### Current Factory Return Shapes (Audit)
+
+| Extension             | `exports` key | `lifecycle` key | Top-level `destroy` | Top-level `whenReady` |
+| --------------------- | ------------- | --------------- | ------------------- | --------------------- |
+| sqlite                | Yes           | No              | **Yes (bug!)**      | No                    |
+| indexeddbPersistence  | Yes           | Yes             | No                  | No                    |
+| desktop persistence   | No            | Yes             | No                  | No                    |
+| revision-history      | Yes           | Yes             | No                  | No                    |
+| workspace-persistence | No            | Yes             | No                  | No                    |
+
+**Key finding**: sqlite already returns `destroy` at the top level. The framework reads `result.lifecycle?.destroy` and silently misses it. This is a pre-existing bug that the flat type fixes by reading `result.destroy` directly.
+
+### Initialization Loop Comparison
+
+| Aspect            | Workspace extensions                   | Document extensions                       |
+| ----------------- | -------------------------------------- | ----------------------------------------- |
+| Collection        | Chain calls to `.withExtension()`      | `for` loop over registrations in `open()` |
+| whenReady storage | `whenReadyPromises[]` (Promise array)  | `lifecycles[]` (objects, mapped later)    |
+| Cleanup storage   | `extensionCleanups[]` (function array) | `lifecycles[]` (objects, mapped later)    |
+| Void coercion     | `.then(() => {})` on each promise      | None                                      |
+| Missing whenReady | Pushes `Promise.resolve()`             | Pushes lifecycle object, maps later       |
+
+**Key finding**: Both loops do the same normalization differently. A shared `defineExtension()` utility eliminates the divergence.
+
+## Design Decisions
+
+| Decision                                             | Choice | Rationale                                                                                                                                                                |
+| ---------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Flatten `{ exports, lifecycle }` to flat object      | Yes    | Ends 5 specs of churn. The nesting was never the right abstraction — it kept leaking through to authoring and consumer APIs.                                             |
+| `whenReady` and `destroy` as reserved property names | Yes    | Unambiguously framework concepts. No domain extension would plausibly export either name for a different purpose.                                                        |
+| Internal `defineExtension()` normalizer              | Yes    | Single function applies defaults (`whenReady ?? Promise.resolve()`, `destroy ?? () => {}`). Called by the framework, not by extension authors.                           |
+| Extension authors return raw flat object             | Yes    | No wrapper function to import. `{ db, whenReady, destroy }` is a plain object literal. TypeScript infers the type.                                                       |
+| One named type: `Extension<T>` = resolved form       | Yes    | The stored/consumer form with required `whenReady` and `destroy`. The factory input doesn't need a named type — it's just the constraint on `withExtension`'s parameter. |
+| Composite `client.whenReady` kept                    | Yes    | Still useful as "wait for everything." Per-extension whenReady is additive, not a replacement.                                                                           |
+| `Lifecycle` type kept                                | Yes    | Still used by providers and other non-extension contexts (e.g., `filesystemPersistence` returns raw `Lifecycle`). Independent of the `Extension` type change.            |
+
+## Architecture
+
+### Type Flow
+
+```
+Extension author writes:              Framework does:                  Consumer sees:
+──────────────────────                 ──────────────                   ──────────────
+{ db, whenReady, destroy }        →   defineExtension(raw)         →   extensions.sqlite
+{ db }                            →   defineExtension(raw)         →   extensions.sqlite
+{ whenReady }                     →   defineExtension(raw)         →   extensions.persistence
+{}  (or void)                     →   defineExtension(raw ?? {})   →   extensions.lifecycle
+
+Every stored entry is Extension<T>:
+  { db, whenReady: Promise<void>, destroy: () => MaybePromise<void> }
+  { whenReady: Promise<void>, destroy: () => MaybePromise<void> }
+```
+
+### Types
+
+```typescript
+// What's stored and what consumers/factories see — always has whenReady + destroy:
+type Extension<T extends Record<string, unknown> = Record<string, never>> =
+	T & {
+		whenReady: Promise<void>;
+		destroy: () => MaybePromise<void>;
+	};
+```
+
+The factory return type is expressed inline on `withExtension`:
+
+```typescript
+withExtension<TKey, TExports>(
+  key: TKey,
+  factory: (context) => TExports & {
+    whenReady?: Promise<unknown>;
+    destroy?: () => MaybePromise<void>;
+  },
+): Builder<TExtensions & Record<TKey, Extension<Omit<TExports, 'whenReady' | 'destroy'>>>>
+```
+
+`TExports` captures everything the factory returns. `Omit<TExports, 'whenReady' | 'destroy'>` extracts just the custom exports for the `Extension<T>` generic parameter. The stored form is `Extension<CustomExports>` — flat object with required `whenReady` and `destroy`.
+
+### `defineExtension()` — Internal Normalizer
+
+```typescript
+function defineExtension<T extends Record<string, unknown>>(
+	input: T & {
+		whenReady?: Promise<unknown>;
+		destroy?: () => MaybePromise<void>;
+	},
+): Extension<Omit<T, 'whenReady' | 'destroy'>> {
+	return {
+		...input,
+		whenReady: input.whenReady?.then(() => {}) ?? Promise.resolve(),
+		destroy: input.destroy ?? (() => {}),
+	} as Extension<Omit<T, 'whenReady' | 'destroy'>>;
+}
+```
+
+Called by the framework only. Extension authors never import it.
+
+Optional: export for extension library authors who want the resolved type for testing. But not required — the framework handles normalization.
+
+### Standardized Initialization Loop
+
+Both workspace and document extensions use the same pattern:
+
+```typescript
+// Shared normalization (identical for workspace + document extension loops):
+const raw = factory(context);
+const resolved = defineExtension(raw ?? {});
+extensionMap[key] = resolved;
+destroys.push(resolved.destroy);
+whenReadyPromises.push(resolved.whenReady);
+```
+
+Five lines. Same for both levels. The workspace chain does this inside `withExtension()`. The document loop does this inside `open()`. The logic is identical.
+
+### Before/After Comparison
+
+```
+BEFORE (nested, two separate arrays):
+
+  Workspace:                               Document:
+  ┌─────────────────────────────┐          ┌──────────────────────────────┐
+  │ result.lifecycle?.destroy   │          │ for (reg of extensions) {    │
+  │   → extensionCleanups[]    │          │   lifecycles.push(lifecycle) │
+  │ result.lifecycle?.whenReady │          │   docExports[key] = exports  │
+  │   → whenReadyPromises[]    │          │ }                            │
+  │ result.exports ?? {}        │          │ Promise.all(lifecycles.map(  │
+  │   → extensions[key]        │          │   l => l.whenReady           │
+  └─────────────────────────────┘          │ ))                           │
+                                           └──────────────────────────────┘
+
+AFTER (flat, same pattern):
+
+  Both levels:
+  ┌──────────────────────────────────────┐
+  │ const resolved = defineExtension(raw)│
+  │ extensionMap[key] = resolved         │
+  │ destroys.push(resolved.destroy)      │
+  │ whenReadyPromises.push(              │
+  │   resolved.whenReady                 │
+  │ )                                    │
+  └──────────────────────────────────────┘
+```
+
+## Implementation Plan
+
+### Phase 1: Type Definitions
+
+- [x] **1.1** In `shared/lifecycle.ts`: Redefine `Extension<T>` as the flat resolved type:
+  ```typescript
+  type Extension<T extends Record<string, unknown> = Record<string, never>> =
+  	T & {
+  		whenReady: Promise<void>;
+  		destroy: () => MaybePromise<void>;
+  	};
+  ```
+- [x] **1.2** In `shared/lifecycle.ts`: Add `defineExtension()` normalizer function (internal utility).
+- [x] **1.3** In `shared/lifecycle.ts`: Update `DocumentContext.extensions` — each entry is `Extension<T>` (optional due to tag filtering: `[K in keyof TDocExtensions]?: Extension<TDocExtensions[K]>`).
+- [x] **1.4** In `static/types.ts`: Update `WorkspaceClient.extensions` mapped type — each entry is `Extension<TExtensions[K]>`.
+- [x] **1.5** In `static/types.ts`: Update `withExtension` signature — factory returns flat object, `TExports` captures all properties, stored type is `Extension<Omit<TExports, 'whenReady' | 'destroy'>>`.
+- [x] **1.6** In `static/types.ts`: Update `DocumentExtensionRegistration` — factory return type changes from `Extension<Record<string, unknown>> | void` to the flat input shape.
+- [x] **1.7** In `static/types.ts`: Update `ExtensionFactory` type alias.
+- [x] **1.8** In `dynamic/workspace/types.ts`: Same changes as 1.4–1.7 for the dynamic workspace system.
+
+### Phase 2: Runtime — Workspace Extensions
+
+- [x] **2.1** In `static/create-workspace.ts` `withExtension()`: Replace nested destructuring with `defineExtension()`. Store resolved extension (not just exports).
+- [x] **2.2** In `static/create-workspace.ts` `buildClient()`: Update `destroy()` to iterate resolved extensions directly (or keep separate `destroys[]` array populated by the standardized loop).
+- [x] **2.3** In `dynamic/workspace/create-workspace.ts`: Same changes as 2.1–2.2.
+
+### Phase 3: Runtime — Document Extensions
+
+- [x] **3.1** In `static/create-document-binding.ts` `open()` loop: Replace lifecycle-object collection with `defineExtension()` normalization. Store resolved extensions in `docExtensionsMap`.
+- [x] **3.2** Update `DocEntry` type: replace `lifecycles: NormalizedLifecycle[]` and `exports: Record<string, Record<string, unknown>>` with a single `extensions: Record<string, Extension>` (the resolved map).
+- [x] **3.3** Update `close()` and `closeAll()`: iterate `extensions` values for destroy, instead of `lifecycles` array.
+- [x] **3.4** Update `makeHandle()`: pass through the resolved extensions map (handle.exports becomes the map of `Extension<T>` entries, which includes `whenReady`/`destroy` alongside custom exports).
+
+### Phase 4: Update Extension Factories
+
+All factories change from nested `{ exports, lifecycle }` to flat `{ ...customExports, whenReady?, destroy? }`.
+
+- [x] **4.1** `extensions/sync/web.ts` (`indexeddbPersistence`): `{ clearData, whenReady, destroy }`.
+- [x] **4.2** `extensions/sync/desktop.ts` (`persistence`): `{ whenReady }` (already nearly flat).
+- [x] **4.3** `extensions/sqlite/sqlite.ts`: `{ pullToSqlite, pushFromSqlite, db, ...drizzleTables, whenReady?, destroy }` — fixes the pre-existing `destroy` bug.
+- [x] **4.4** `extensions/revision-history/local.ts`: `{ save, list, view, restore, count, directory, destroy }`.
+- [x] **4.5** `apps/epicenter/.../workspace-persistence.ts`: `{ whenReady, destroy }`.
+- [x] **4.6** `extensions/sync/desktop.ts` (`filesystemPersistence`): Returns `Lifecycle`, not `Extension`. Unchanged — this is a provider factory, not an extension factory.
+
+### Phase 5: Update Tests
+
+- [x] **5.1** `static/create-workspace.test.ts`: Update all extension factories to flat shape. Update assertions to access `extensions.X.prop` directly (no `.exports.`).
+- [x] **5.2** `static/create-document-binding.test.ts`: Same.
+- [x] **5.3** `static/define-workspace.test.ts`: Same.
+- [x] **5.4** `dynamic/workspace/create-workspace.test.ts`: Same.
+- [x] **5.5** Add tests: verify `extensions.X.whenReady` is always a resolved `Promise<void>` for lifecycle-only extensions. Verify `extensions.X.destroy` is always a function.
+- [x] **5.6** Add tests: verify surgical await works (extension B chains off `ctx.extensions.A.whenReady`, resolves after A but not before).
+
+### Phase 6: JSDoc + Cleanup
+
+- [x] **6.1** Update JSDoc in `lifecycle.ts` — module docstring, `Extension<T>`, `DocumentContext`.
+- [x] **6.2** Update JSDoc in `static/types.ts` — `WorkspaceClientBuilder`, `ExtensionContext`, `ExtensionFactory`.
+- [x] **6.3** Update JSDoc examples in extension files (`sync.ts`, `sqlite.ts`, `revision-history/index.ts`).
+- [x] **6.4** Remove `NormalizedLifecycle` type from `create-document-binding.ts` (no longer needed).
+- [x] **6.5** Grep for `result.lifecycle` — zero results in framework code (all replaced by flat access).
+- [x] **6.6** Grep for `exports:` in extension return statements — zero results (all flattened).
+
+### Phase 7: Verify
+
+- [x] **7.1** `bun typecheck` from repo root — zero new type errors. (127 pre-existing errors in `@epicenter/filesystem`, unrelated.)
+- [x] **7.2** `bun test` from `packages/epicenter` — all 690 tests pass, 0 failures.
+- [ ] **7.3** Build the Epicenter app — verify it compiles. (Skipped — Tauri app requires native build toolchain.)
+- [x] **7.4** Grep `result\.lifecycle` in framework code — zero results.
+- [x] **7.5** Grep `NormalizedLifecycle` — zero results.
+
+## Edge Cases
+
+### Extension factory returns `void` or `undefined`
+
+Some extensions may return nothing (e.g., a side-effect-only extension). The framework normalizes:
+
+```typescript
+const raw = factory(context);
+const resolved = defineExtension(raw ?? {});
+// resolved = { whenReady: Promise.resolve(), destroy: () => {} }
+```
+
+### Extension exports a property named `whenReady` or `destroy`
+
+These are reserved. The framework's defaults overwrite them. TypeScript prevents this at the type level if the constraint is set up correctly (`TExports extends Record<string, unknown>` where `whenReady` and `destroy` are handled by the framework, not the generic).
+
+If an extension genuinely needs an export called `whenReady` (extremely unlikely), it's a naming collision they need to resolve by renaming their export.
+
+### `filesystemPersistence` returns `Lifecycle`, not `Extension`
+
+The `filesystemPersistence` function in `extensions/sync/desktop.ts` returns a raw `Lifecycle` (required `whenReady` + `destroy`). This is used as a provider factory, not directly with `withExtension()`. The `persistence` wrapper wraps it into an `Extension`-compatible shape. No change needed — `Lifecycle` type is independent of `Extension`.
+
+### Document extensions filtered by tags
+
+When a document extension is skipped due to tag filtering, its entry is absent from `context.extensions`. The type is already optional (`[K in keyof TDocExtensions]?: Extension<TDocExtensions[K]>`). Factories should guard with optional chaining: `context.extensions.persistence?.whenReady`.
+
+### Composite `client.whenReady` vs per-extension whenReady
+
+Both coexist. `client.whenReady` is `Promise.all` of all extensions' `whenReady` promises — "wait for everything." `client.extensions.X.whenReady` is one specific extension — "wait for just this." They serve different use cases.
+
+## Open Questions
+
+1. **Should `defineExtension()` be exported for extension library authors?**
+   - It's useful for testing and for libraries that want to construct `Extension<T>` values outside the framework.
+   - Most extension authors won't need it — they return plain objects and the framework normalizes.
+   - **Recommendation**: Export it but don't emphasize it. It's there if you need it.
+
+2. **Should `destroy` be visible on `client.extensions.X`?**
+   - Currently visible. Consumers could call it directly, bypassing the framework's reverse-order cleanup.
+   - Hiding it requires stripping from the consumer-facing type (adds type complexity).
+   - **Recommendation**: Keep it visible. Same trust model as `client.ydoc.destroy()` — visible but not meant to be called directly. Document this.
+
+3. **Type inference: overloads vs conditional type on `withExtension`?**
+   - Need to extract custom exports from the flat return (everything minus `whenReady` and `destroy`).
+   - Conditional type: `TResult extends { ... } ? Omit<TResult, 'whenReady' | 'destroy'> : ...`
+   - Overloads: Two signatures (with exports / lifecycle-only).
+   - **Recommendation**: Try conditional type first. If IDE hover types are ugly, fall back to overloads.
+
+## Success Criteria
+
+- [x] `Extension<T>` is a flat type: `T & { whenReady: Promise<void>; destroy: () => MaybePromise<void> }`
+- [x] `defineExtension()` exists as the single normalization point (internal, optionally exported)
+- [x] All extension factories return flat objects (no `exports` key, no `lifecycle` key)
+- [x] `client.extensions.X.whenReady` works for surgical await (no injection, no wrapper)
+- [x] `client.extensions.X.customExport` works directly (no `.exports.` indirection)
+- [x] Workspace and document extension loops use the same normalization pattern
+- [x] sqlite's `destroy` is correctly captured (pre-existing bug fixed)
+- [x] Composite `client.whenReady` still works
+- [x] All tests pass, type check passes
+- [x] Zero `result.lifecycle` references in framework code
+- [x] Zero `NormalizedLifecycle` references in codebase
+
+## Superseded Specs
+
+This spec supersedes the following, which all addressed different facets of the same exports/lifecycle boundary problem:
+
+- `specs/20260213T120800-separate-extension-lifecycle-from-exports.md`
+- `specs/20260214T133054-remove-define-extension.md`
+- `specs/20260220T200000-extension-handle-passthrough.md`
+- `specs/20260220T200000-surgical-extension-await.md`
+- `specs/20260220T195900-flatten-extension-exports.md`
+- `specs/20260220T195900-unify-document-extension-shape.md`
+
+## References
+
+- `packages/epicenter/src/shared/lifecycle.ts` — `Extension<T>`, `Lifecycle`, `MaybePromise`, `DocumentContext`
+- `packages/epicenter/src/static/create-workspace.ts` — `withExtension()`, `withDocumentExtension()`, `buildClient()`
+- `packages/epicenter/src/static/create-document-binding.ts` — `open()` loop, `DocEntry`, `NormalizedLifecycle`, `makeHandle()`
+- `packages/epicenter/src/static/types.ts` — `WorkspaceClientBuilder`, `ExtensionContext`, `ExtensionFactory`, `DocumentExtensionRegistration`
+- `packages/epicenter/src/dynamic/workspace/create-workspace.ts` — Dynamic `withExtension()` implementation
+- `packages/epicenter/src/dynamic/workspace/types.ts` — Dynamic `WorkspaceClientBuilder`, `ExtensionContext`
+- `packages/epicenter/src/extensions/sqlite/sqlite.ts` — Pre-existing `destroy` bug (top-level, not in `lifecycle`)
+- `packages/epicenter/src/extensions/sync/web.ts` — `indexeddbPersistence` factory
+- `packages/epicenter/src/extensions/sync/desktop.ts` — `persistence` + `filesystemPersistence` factories
+- `packages/epicenter/src/extensions/revision-history/local.ts` — `localRevisionHistory` factory
+- `apps/epicenter/src/lib/yjs/workspace-persistence.ts` — App-level persistence factory
+
+## Implementation Review
+
+### Summary
+
+All 7 phases completed. The `Extension` type is now flat, all extension factories return `{ ...customExports, whenReady?, destroy? }`, and `defineExtension()` normalizes defaults in both workspace and document extension loops.
+
+### Files Changed
+
+**Type definitions (3 files):**
+
+- `shared/lifecycle.ts` — Redefined `Extension<T>` as flat type, added `defineExtension()`, updated `DocumentContext.extensions`
+- `static/types.ts` — Updated `withExtension` signature, `DocumentExtensionRegistration`, `ExtensionFactory`
+- `dynamic/workspace/types.ts` — Same changes for dynamic workspace system
+
+**Runtime (3 files):**
+
+- `static/create-workspace.ts` — `withExtension()` uses `defineExtension()`, stores resolved extension
+- `static/create-document-binding.ts` — Removed `NormalizedLifecycle`, `DocEntry.extensions` is `Record<string, Extension<any>>`, `open()` loop uses `defineExtension()`
+- `dynamic/workspace/create-workspace.ts` — Same pattern with `defineExtension()`, added `as unknown as` cast for builder type
+
+**Extension factories (7 files):**
+
+- `extensions/sync/web.ts` — Flattened `indexeddbPersistence`
+- `extensions/sync/desktop.ts` — Flattened `persistence` (left `filesystemPersistence` unchanged — returns `Lifecycle`)
+- `extensions/sqlite/sqlite.ts` — Flattened, fixing pre-existing `destroy` bug
+- `extensions/revision-history/local.ts` — Flattened
+- `extensions/sync.ts` — Flattened `createSyncExtension` (discovered during Phase 6 grep)
+- `extensions/markdown/markdown.ts` — Flattened `markdown` (discovered during Phase 6 grep)
+- `apps/epicenter/src/lib/yjs/workspace-persistence.ts` — Flattened, removed `Extension` return type annotation
+
+**Re-exports (2 files):**
+
+- `dynamic/index.ts` — Added `Extension` to lifecycle re-exports
+- `dynamic/extension.ts` — Updated JSDoc
+
+**Tests (5 files):**
+
+- `static/create-workspace.test.ts` — Flattened all factory returns, added 3 new tests (whenReady default, destroy default, surgical await)
+- `static/create-document-binding.test.ts` — Flattened all factory returns, updated lifecycle-only test to verify `whenReady`/`destroy` presence
+- `static/define-workspace.test.ts` — Flattened all factory returns
+- `dynamic/workspace/create-workspace.test.ts` — Flattened all factory returns
+- `extensions/sync.test.ts` — Flattened type and all `result.exports.`/`result.lifecycle.` references
+
+### Deviations from Spec
+
+1. **Two additional extensions discovered**: `sync.ts` and `markdown/markdown.ts` were not listed in the Phase 4 checklist but still used the nested `{ exports, lifecycle }` shape. Both were flattened during Phase 6 grep verification.
+2. **`Extension` re-export added**: `dynamic/index.ts` did not re-export `Extension` from `shared/lifecycle.ts`. Added to allow `workspace-persistence.ts` to import it (though the return type annotation was ultimately removed).
+3. **`Extension<T>` default parameter `Record<string, never>`**: This is very strict — runtime storage maps needed `Extension<any>` to avoid variance issues. Documented as a discovery.
+4. **Test assertion updated**: The "returns empty exports when extension has no exports" test was renamed and updated. Lifecycle-only extensions now produce `{ whenReady, destroy }` entries (correct new behavior).
+5. **Phase 7.3 skipped**: Tauri app build requires native toolchain not available in this environment.
+
+### Verification
+
+- `bun typecheck`: Zero new type errors (127 pre-existing in `@epicenter/filesystem`, unrelated)
+- `bun test`: 690 pass, 0 fail, 2 skip
+- `grep result\.lifecycle` in framework code: Zero results
+- `grep NormalizedLifecycle`: Zero results
+- `grep 'exports:\s*\{'` in extension returns: Zero results


### PR DESCRIPTION
Extension factories now return `{ ...customExports, whenReady?, destroy? }` instead of the nested `{ exports?: {...}, lifecycle?: { whenReady?, destroy? } }` shape.

The nested structure was internal bookkeeping that kept surfacing as an ergonomics problem — five specs of churn introducing, wrapping, injecting into, and re-flattening the exports/lifecycle boundary. It also caused a real bug: the sqlite extension returned `destroy` at the top level (not inside `lifecycle`), so the framework silently dropped its cleanup. That bug is now impossible because `destroy` lives at the same level as everything else.

A new internal `defineExtension()` normalizer guarantees the stored form always has `whenReady: Promise<void>` and `destroy: () => MaybePromise<void>`, regardless of what the factory returns:

```typescript
// Before — nested, easy to get wrong
return {
  exports: { db, pullToSqlite },
  lifecycle: {
    whenReady: initPromise,
    destroy: () => db.close(),
  },
};

// After — flat, matches what consumers see
return {
  db,
  pullToSqlite,
  whenReady: initPromise,
  destroy: () => db.close(),
};
```

Both workspace and document extension paths use `defineExtension()`. All existing extensions (sqlite, sync, markdown, revision-history, workspace-persistence) are migrated to the flat shape.

This PR also includes three technical articles:
- "Bun compile is 57MB because it's not your code"
- "Tauri's dual backend architecture"
- "The server starts the client, not the other way around"