### PR TITLE
feat(server): add AI chat plugin with TanStack AI streaming

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -353,6 +353,12 @@
       "version": "0.0.1",
       "dependencies": {
         "@elysiajs/openapi": "^1.4.11",
+        "@tanstack/ai": "^0.5.1",
+        "@tanstack/ai-anthropic": "^0.5.0",
+        "@tanstack/ai-gemini": "^0.5.0",
+        "@tanstack/ai-grok": "^0.5.0",
+        "@tanstack/ai-ollama": "^0.5.0",
+        "@tanstack/ai-openai": "^0.5.0",
         "elysia": "^1.2.25",
         "lib0": "catalog:",
         "wellcrafted": "catalog:",
@@ -744,6 +750,8 @@
 
     "@fontsource-variable/manrope": ["@fontsource-variable/manrope@5.2.8", "", {}, "sha512-nc9lOuCRz73UHnovDE2bwXUdghE2SEOc7Aii0qGe3CLyE03W1a7VnY5Z6euRiapiKbCkGS+eXbY3s/kvWeGeSw=="],
 
+    "@google/genai": ["@google/genai@1.42.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-+3nlMTcrQufbQ8IumGkOphxD5Pd5kKyJOzLcnY0/1IuE8upJk5aLmoexZ2BJhBp1zAjRJMEB4a2CJwKI9e2EYw=="],
+
     "@google/generative-ai": ["@google/generative-ai@0.24.1", "", {}, "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
@@ -809,6 +817,8 @@
     "@isaacs/balanced-match": ["@isaacs/balanced-match@4.0.1", "", {}, "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="],
 
     "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.1", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ=="],
+
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -929,6 +939,8 @@
     "@oxc-parser/binding-win32-x64-msvc": ["@oxc-parser/binding-win32-x64-msvc@0.112.0", "", { "os": "win32", "cpu": "x64" }, "sha512-oGHluohzmVFAuQrkEnl1OXAxMz2aYmimxUqIgKXpBgbr7PvFv0doELB273sX+5V3fKeggohKg1A2Qq21W9Z9cQ=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.112.0", "", {}, "sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ=="],
+
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@pnpm/config.env-replace": ["@pnpm/config.env-replace@1.1.0", "", {}, "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w=="],
 
@@ -1098,6 +1110,20 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.1.18", "", { "dependencies": { "@tailwindcss/node": "4.1.18", "@tailwindcss/oxide": "4.1.18", "tailwindcss": "4.1.18" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7" } }, "sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA=="],
 
+    "@tanstack/ai": ["@tanstack/ai@0.5.1", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.0", "partial-json": "^0.1.7" } }, "sha512-kHZb8Q/aI/z20d4CB7U49Pbk8IoypbFA1saDYlPBFPbdSzikeutJ2oRyN4hY2qtrxnfyC1oHOhiWkDH0i+5kwg=="],
+
+    "@tanstack/ai-anthropic": ["@tanstack/ai-anthropic@0.5.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.71.2" }, "peerDependencies": { "@tanstack/ai": "^0.5.0", "zod": "^4.0.0" } }, "sha512-PiQx4Kpw+NNjXvVhes29LoO/IvD8M9GGQsNvtLCd+dDhZt3FzdNwHWMZBCpaQWPW142iuhowagh79X//onNjDw=="],
+
+    "@tanstack/ai-gemini": ["@tanstack/ai-gemini@0.5.0", "", { "dependencies": { "@google/genai": "^1.30.0" }, "peerDependencies": { "@tanstack/ai": "^0.5.0" } }, "sha512-gunJgwRG+38fbYSE83/XJMHFy/7hDN4Fb91vAAZLK3nh4DoN0ReVbRB4BK9cY9iVYQqGq2PA8d5ruDgfcKO2hQ=="],
+
+    "@tanstack/ai-grok": ["@tanstack/ai-grok@0.5.0", "", { "dependencies": { "openai": "^6.9.1" }, "peerDependencies": { "@tanstack/ai": "^0.5.0", "zod": "^4.0.0" } }, "sha512-X2ix/NmAXC1EyE3UIDSdX+T9A3VwWvQrnAomMyxqGDbDHHm+yQbjioloGOcwQ6Z3yzONeVcO36T6apoX2UPLsw=="],
+
+    "@tanstack/ai-ollama": ["@tanstack/ai-ollama@0.5.0", "", { "dependencies": { "ollama": "^0.6.3" }, "peerDependencies": { "@tanstack/ai": "^0.5.0" } }, "sha512-CR/f6OS7WzrC1VIK819lDSHeEJWfpaEVyO0bSmE7EGUAfbv+JmDLd8tI2Pk/DhIRVw/rk0Zlcn35jWvvXLjwTg=="],
+
+    "@tanstack/ai-openai": ["@tanstack/ai-openai@0.5.0", "", { "dependencies": { "openai": "^6.9.1" }, "peerDependencies": { "@tanstack/ai": "^0.5.0", "zod": "^4.0.0" } }, "sha512-0xJg+BkqVgIRbl4LyiPQWCLOapfGpK4lSzqjaWRkz2Hf1C3m4exg76rBuv1mvr4G3XAR5SnMRSj3XxlWMuRImA=="],
+
+    "@tanstack/devtools-event-client": ["@tanstack/devtools-event-client@0.4.0", "", {}, "sha512-RPfGuk2bDZgcu9bAJodvO2lnZeHuz4/71HjZ0bGb/SPg8+lyTA+RLSKQvo7fSmPSi8/vcH3aKQ8EM9ywf1olaw=="],
+
     "@tanstack/query-core": ["@tanstack/query-core@5.90.20", "", {}, "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg=="],
 
     "@tanstack/query-devtools": ["@tanstack/query-devtools@5.93.0", "", {}, "sha512-+kpsx1NQnOFTZsw6HAFCW3HkKg0+2cepGtAWXjiiSOJJ1CtQpt72EE2nyZb+AjAbLRPoeRmPJ8MtQd8r8gsPdg=="],
@@ -1224,6 +1250,8 @@
 
     "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
 
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
@@ -1292,6 +1320,8 @@
 
     "adm-zip": ["adm-zip@0.5.16", "", {}, "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ=="],
 
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
     "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
 
     "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
@@ -1357,6 +1387,8 @@
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "better-sqlite3": ["better-sqlite3@12.6.2", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
     "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 
@@ -1610,6 +1642,8 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "elevenlabs": ["elevenlabs@1.59.0", "", { "dependencies": { "command-exists": "^1.2.9", "execa": "^5.1.1", "form-data": "^4.0.0", "form-data-encoder": "^4.0.2", "formdata-node": "^6.0.3", "node-fetch": "^2.7.0", "qs": "^6.13.1", "readable-stream": "^4.5.2", "url-join": "4.0.1" } }, "sha512-OVKOd+lxNya8h4Rn5fcjv00Asd+DGWfTT6opGrQ16sTI+1HwdLn/kYtjl8tRMhDXbNmksD/9SBRKjb9neiUuVg=="],
@@ -1760,6 +1794,8 @@
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "form-data-encoder": ["form-data-encoder@4.1.0", "", {}, "sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw=="],
@@ -1779,6 +1815,10 @@
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
     "fx-runner": ["fx-runner@1.4.0", "", { "dependencies": { "commander": "2.9.0", "shell-quote": "1.7.3", "spawn-sync": "1.0.15", "when": "3.7.7", "which": "1.2.4", "winreg": "0.0.12" }, "bin": { "fx-runner": "bin/fx-runner" } }, "sha512-rci1g6U0rdTg6bAaBboP7XdRu01dzTAaKXxFf+PUqGuCv6Xu7o8NZdY1D5MvKGIjb6EdS1g3VlXOgksir1uGkg=="],
+
+    "gaxios": ["gaxios@7.1.3", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2", "rimraf": "^5.0.1" } }, "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ=="],
+
+    "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
 
     "generator-function": ["generator-function@2.0.1", "", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
 
@@ -1802,6 +1842,8 @@
 
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
 
+    "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
     "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
@@ -1809,6 +1851,10 @@
     "global-directory": ["global-directory@4.0.1", "", { "dependencies": { "ini": "4.1.1" } }, "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q=="],
 
     "globals": ["globals@16.5.0", "", {}, "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ=="],
+
+    "google-auth-library": ["google-auth-library@10.5.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.0.0", "gcp-metadata": "^8.0.0", "google-logging-utils": "^1.0.0", "gtoken": "^8.0.0", "jws": "^4.0.0" } }, "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w=="],
+
+    "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
@@ -1821,6 +1867,8 @@
     "groq-sdk": ["groq-sdk@0.25.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-IZQb/U0LZQcoF6Amoq8Kh+3seDYdk7278VrAOCz/W4I2nC7PvqEwik3RjRe3bxrOBFvUFHhL/3J+jzVzfjhZUQ=="],
 
     "growly": ["growly@1.3.0", "", {}, "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw=="],
+
+    "gtoken": ["gtoken@8.0.0", "", { "dependencies": { "gaxios": "^7.0.0", "jws": "^4.0.0" } }, "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw=="],
 
     "guid-typescript": ["guid-typescript@1.0.9", "", {}, "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="],
 
@@ -1873,6 +1921,8 @@
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
 
     "https-browserify": ["https-browserify@1.0.0", "", {}, "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
 
@@ -1970,6 +2020,8 @@
 
     "isomorphic.js": ["isomorphic.js@0.2.5", "", {}, "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw=="],
 
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "js-base64": ["js-base64@3.7.8", "", {}, "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow=="],
@@ -1978,9 +2030,13 @@
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@3.0.2", "", {}, "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
@@ -2234,6 +2290,8 @@
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
     "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
 
     "mlly": ["mlly@1.8.0", "", { "dependencies": { "acorn": "^8.15.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.1" } }, "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g=="],
@@ -2308,6 +2366,8 @@
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 
+    "ollama": ["ollama@0.6.3", "", { "dependencies": { "whatwg-fetch": "^3.6.20" } }, "sha512-KEWEhIqE5wtfzEIZbDCLH51VFZ6Z3ZSa6sIOg/E/tBV8S51flyqBOXi+bRxlOYKDf8i327zG9eSTb8IJxvm3Zg=="],
+
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
@@ -2348,9 +2408,13 @@
 
     "p-queue": ["p-queue@8.1.1", "", { "dependencies": { "eventemitter3": "^5.0.1", "p-timeout": "^6.1.2" } }, "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ=="],
 
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
     "p-timeout": ["p-timeout@6.1.4", "", {}, "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg=="],
 
     "package-json": ["package-json@10.0.1", "", { "dependencies": { "ky": "^1.2.0", "registry-auth-token": "^5.0.2", "registry-url": "^6.0.1", "semver": "^7.6.0" } }, "sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg=="],
+
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
     "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
 
@@ -2370,6 +2434,8 @@
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
+    "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
+
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
@@ -2377,6 +2443,8 @@
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
+
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
@@ -2558,9 +2626,13 @@
 
     "retext-stringify": ["retext-stringify@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "nlcst-to-string": "^4.0.0", "unified": "^11.0.0" } }, "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA=="],
 
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
+
+    "rimraf": ["rimraf@5.0.10", "", { "dependencies": { "glob": "^10.3.7" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ=="],
 
     "ripemd160": ["ripemd160@2.0.3", "", { "dependencies": { "hash-base": "^3.1.2", "inherits": "^2.0.4" } }, "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA=="],
 
@@ -2666,11 +2738,15 @@
 
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
     "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-bom": ["strip-bom@5.0.0", "", {}, "sha512-p+byADHF7SzEcVnLvc/r3uognM1hUhObuHXxJcgLCfD194XAkaLbjq3Wzb0N5G2tgIjH0dgT708Z51QxMeu60A=="],
 
@@ -2765,6 +2841,8 @@
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
 
@@ -2956,6 +3034,8 @@
 
     "wellcrafted": ["wellcrafted@0.29.1", "", {}, "sha512-NAqtmAdZffcmiQqjy9uE7g67hpjkpN7l5uvU6F/JSAd2OfiqjPTDsiJBBlLbGo9w+UfSnGMnvP5TkH/sGqONkQ=="],
 
+    "whatwg-fetch": ["whatwg-fetch@3.6.20", "", {}, "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="],
+
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "when": ["when@3.7.7", "", {}, "sha512-9lFZp/KHoqH6bPKjbWqa+3Dg/K/r2v0X/3/G2x4DBGchVS2QX2VXL3cZV994WQVnTM1/PD71Az25nAzryEUugw=="],
@@ -2979,6 +3059,8 @@
     "wrangler": ["wrangler@4.64.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.12.1", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260210.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260210.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260210.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-0PBiVEbshQT4Av/KLHbOAks4ioIKp/eAO7Xr2BgAX5v7cFYYgeOvudBrbtZa/hDDIA6858QuJnTQ8mI+cm8Vqw=="],
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
@@ -3078,6 +3160,12 @@
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
+    "@google/genai/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+
+    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
     "@libsql/hrana-client/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "@libsql/isomorphic-ws/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
@@ -3117,6 +3205,12 @@
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@tailwindcss/typography/postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
+
+    "@tanstack/ai-anthropic/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.71.2", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ=="],
+
+    "@tanstack/ai-grok/openai": ["openai@6.22.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-7Yvy17F33Bi9RutWbsaYt5hJEEJ/krRPOrwan+f9aCPuMat1WVsb2VNSII5W1EksKT6fF69TG/xj4XzodK3JZw=="],
+
+    "@tanstack/ai-openai/openai": ["openai@6.22.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-7Yvy17F33Bi9RutWbsaYt5hJEEJ/krRPOrwan+f9aCPuMat1WVsb2VNSII5W1EksKT6fF69TG/xj4XzodK3JZw=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
@@ -3196,11 +3290,17 @@
 
     "firefox-profile/ini": ["ini@4.1.3", "", {}, "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg=="],
 
+    "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "fx-runner/commander": ["commander@2.9.0", "", { "dependencies": { "graceful-readlink": ">= 1.0.0" } }, "sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A=="],
 
     "fx-runner/shell-quote": ["shell-quote@1.7.3", "", {}, "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw=="],
 
     "fx-runner/which": ["which@1.2.4", "", { "dependencies": { "is-absolute": "^0.1.7", "isexe": "^1.1.1" }, "bin": { "which": "./bin/which" } }, "sha512-zDRAqDSBudazdfM9zpiI30Fu9ve47htYXcGi3ln0wfKu2a7SmrT6F3VDoYONu//48V8Vz4TdCRNPjtvyRO3yBA=="],
+
+    "gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "global-directory/ini": ["ini@4.1.1", "", {}, "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g=="],
 
@@ -3268,6 +3368,8 @@
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
+    "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
     "pbkdf2/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
@@ -3314,7 +3416,13 @@
 
     "stream-http/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "svelte-check/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
@@ -3347,6 +3455,10 @@
     "web-ext-run/strip-json-comments": ["strip-json-comments@5.0.2", "", {}, "sha512-4X2FR3UwhNUE9G49aIsJW5hRRR3GXGTBTZRMfv568O60ojM8HcWjV/VxAxCDW3SUND33O6ZY66ZuRcdkj73q2g=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "wxt/minimatch": ["minimatch@10.1.2", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.1" } }, "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw=="],
 
@@ -3425,6 +3537,10 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
+    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
@@ -3556,6 +3672,8 @@
 
     "fx-runner/which/isexe": ["isexe@1.1.2", "", {}, "sha512-d2eJzK691yZwPHcv1LbeAOa91yMJ9QmfTgSO1oXB65ezVhXQsxBac2vEB4bMVms9cGzaA99n6V2viHMq82VLDw=="],
 
+    "glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
     "gray-matter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "groq-sdk/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
@@ -3576,7 +3694,13 @@
 
     "ripemd160/hash-base/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
+    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "svelte-check/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "yaml-language-server/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,7 +6,8 @@
 	"exports": {
 		".": "./src/index.ts",
 		"./sync": "./src/sync/index.ts",
-		"./workspace": "./src/workspace/index.ts"
+		"./workspace": "./src/workspace/index.ts",
+		"./ai": "./src/ai/index.ts"
 	},
 	"license": "AGPL-3.0",
 	"scripts": {
@@ -15,6 +16,12 @@
 	},
 	"dependencies": {
 		"@elysiajs/openapi": "^1.4.11",
+		"@tanstack/ai": "^0.5.1",
+		"@tanstack/ai-anthropic": "^0.5.0",
+		"@tanstack/ai-gemini": "^0.5.0",
+		"@tanstack/ai-grok": "^0.5.0",
+		"@tanstack/ai-ollama": "^0.5.0",
+		"@tanstack/ai-openai": "^0.5.0",
 		"elysia": "^1.2.25",
 		"lib0": "catalog:",
 		"wellcrafted": "catalog:",

--- a/packages/server/src/ai/adapters.ts
+++ b/packages/server/src/ai/adapters.ts
@@ -1,9 +1,12 @@
 import type { AnyTextAdapter } from '@tanstack/ai';
-import { createAnthropicChat } from '@tanstack/ai-anthropic';
-import { createGeminiChat } from '@tanstack/ai-gemini';
-import { createGrokText } from '@tanstack/ai-grok';
+import {
+	type AnthropicChatModel,
+	createAnthropicChat,
+} from '@tanstack/ai-anthropic';
+import { createGeminiChat, type GeminiTextModel } from '@tanstack/ai-gemini';
+import { createGrokText, type GrokChatModel } from '@tanstack/ai-grok';
 import { createOllamaChat } from '@tanstack/ai-ollama';
-import { createOpenaiChat } from '@tanstack/ai-openai';
+import { createOpenaiChat, type OpenAIChatModel } from '@tanstack/ai-openai';
 
 /**
  * Providers supported by the AI plugin.
@@ -44,19 +47,12 @@ const ADAPTER_FACTORIES: Record<
 	SupportedProvider,
 	(model: string, apiKey: string) => AnyTextAdapter
 > = {
-	openai: (model, apiKey) =>
-		createOpenaiChat(model as Parameters<typeof createOpenaiChat>[0], apiKey),
+	openai: (model, apiKey) => createOpenaiChat(model as OpenAIChatModel, apiKey),
 	anthropic: (model, apiKey) =>
-		createAnthropicChat(
-			model as Parameters<typeof createAnthropicChat>[0],
-			apiKey,
-		),
-	gemini: (model, apiKey) =>
-		createGeminiChat(model as Parameters<typeof createGeminiChat>[0], apiKey),
-	ollama: (model, _apiKey) =>
-		createOllamaChat(model) as unknown as AnyTextAdapter,
-	grok: (model, apiKey) =>
-		createGrokText(model as Parameters<typeof createGrokText>[0], apiKey),
+		createAnthropicChat(model as AnthropicChatModel, apiKey),
+	gemini: (model, apiKey) => createGeminiChat(model as GeminiTextModel, apiKey),
+	ollama: (model, _apiKey) => createOllamaChat(model),
+	grok: (model, apiKey) => createGrokText(model as GrokChatModel, apiKey),
 };
 
 /**

--- a/packages/server/src/ai/adapters.ts
+++ b/packages/server/src/ai/adapters.ts
@@ -1,0 +1,59 @@
+import { createAnthropicChat } from '@tanstack/ai-anthropic';
+import { createGeminiChat } from '@tanstack/ai-gemini';
+import { createGrokText } from '@tanstack/ai-grok';
+import { createOllamaChat } from '@tanstack/ai-ollama';
+import { createOpenaiChat } from '@tanstack/ai-openai';
+
+type AnyModel = Parameters<typeof createOpenaiChat>[0];
+
+/**
+ * Factory functions for each supported provider.
+ *
+ * Uses the explicit-key variants (`createOpenaiChat`, `createAnthropicChat`, etc.)
+ * instead of the env-auto-detect variants (`openaiText`, `anthropicText`) because
+ * API keys are sent per-request from the client, not read from server env vars.
+ *
+ * Model names come from the client as arbitrary strings. Invalid model names
+ * will fail at the provider API level with a descriptive error — they won't
+ * crash the server.
+ *
+ * API key presence is validated by the plugin layer before calling `createAdapter`,
+ * so factories receive a non-empty string for providers that require one.
+ */
+const ADAPTER_FACTORIES: Record<
+	string,
+	(model: string, apiKey: string) => unknown
+> = {
+	openai: (model, apiKey) => createOpenaiChat(model as AnyModel, apiKey),
+	anthropic: (model, apiKey) =>
+		createAnthropicChat(
+			model as Parameters<typeof createAnthropicChat>[0],
+			apiKey,
+		),
+	gemini: (model, apiKey) =>
+		createGeminiChat(model as Parameters<typeof createGeminiChat>[0], apiKey),
+	ollama: (model, _apiKey) => createOllamaChat(model),
+	grok: (model, apiKey) =>
+		createGrokText(model as Parameters<typeof createGrokText>[0], apiKey),
+};
+
+export type SupportedProvider = keyof typeof ADAPTER_FACTORIES;
+
+export const SUPPORTED_PROVIDERS = Object.keys(
+	ADAPTER_FACTORIES,
+) as SupportedProvider[];
+
+/**
+ * Create a TanStack AI text adapter for the given provider.
+ *
+ * @returns The adapter instance, or `undefined` if the provider is not supported.
+ */
+export function createAdapter(
+	provider: string,
+	model: string,
+	apiKey: string = '',
+) {
+	const factory = ADAPTER_FACTORIES[provider as SupportedProvider];
+	if (!factory) return undefined;
+	return factory(model, apiKey);
+}

--- a/packages/server/src/ai/index.ts
+++ b/packages/server/src/ai/index.ts
@@ -6,6 +6,7 @@
 
 export {
 	createAdapter,
+	isSupportedProvider,
 	SUPPORTED_PROVIDERS,
 	type SupportedProvider,
 } from './adapters';

--- a/packages/server/src/ai/index.ts
+++ b/packages/server/src/ai/index.ts
@@ -1,0 +1,12 @@
+/**
+ * AI plugin public API.
+ *
+ * This is the entry point for `@epicenter/server/ai`.
+ */
+
+export {
+	createAdapter,
+	SUPPORTED_PROVIDERS,
+	type SupportedProvider,
+} from './adapters';
+export { type AIPluginConfig, createAIPlugin } from './plugin';

--- a/packages/server/src/ai/plugin.test.ts
+++ b/packages/server/src/ai/plugin.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createAIPlugin } from './plugin';
+
+/** Build a POST /chat request for the given path, body, and optional headers. */
+function chatRequest(
+	path: string,
+	body: Record<string, unknown>,
+	headers?: Record<string, string>,
+) {
+	return new Request(`http://test${path}`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json', ...headers },
+		body: JSON.stringify(body),
+	});
+}
+
+describe('createAIPlugin', () => {
+	test('returns 401 when x-provider-api-key header is missing (non-ollama)', async () => {
+		const app = new Elysia().use(createAIPlugin());
+
+		const response = await app.handle(
+			chatRequest('/chat', {
+				messages: [{ role: 'user', content: 'Hello' }],
+				provider: 'openai',
+				model: 'gpt-4o',
+			}),
+		);
+
+		expect(response.status).toBe(401);
+		const body = await response.json();
+		expect(body.error).toBe('Missing x-provider-api-key header');
+	});
+
+	test('returns 400 for unsupported provider', async () => {
+		const app = new Elysia().use(createAIPlugin());
+
+		const response = await app.handle(
+			chatRequest(
+				'/chat',
+				{
+					messages: [{ role: 'user', content: 'Hello' }],
+					provider: 'mistral',
+					model: 'mistral-large',
+				},
+				{ 'x-provider-api-key': 'sk-test-key' },
+			),
+		);
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toBe('Unsupported provider: mistral');
+	});
+
+	test('returns 422 when required body fields are missing', async () => {
+		const app = new Elysia().use(createAIPlugin());
+
+		const response = await app.handle(
+			chatRequest(
+				'/chat',
+				{ messages: [] },
+				{ 'x-provider-api-key': 'sk-test-key' },
+			),
+		);
+
+		// Elysia returns 422 for schema validation failures
+		expect(response.status).toBe(422);
+	});
+
+	test('ollama does not require x-provider-api-key header', async () => {
+		const app = new Elysia().use(createAIPlugin());
+
+		// Ollama will fail at the adapter level (no Ollama running),
+		// but it should NOT fail with 401 (missing key).
+		const response = await app.handle(
+			chatRequest('/chat', {
+				messages: [{ role: 'user', content: 'Hello' }],
+				provider: 'ollama',
+				model: 'llama3',
+			}),
+		);
+
+		// Should not be 401 — Ollama doesn't need a key
+		expect(response.status).not.toBe(401);
+	});
+
+	test('config.providers restricts allowed providers', async () => {
+		const app = new Elysia().use(createAIPlugin({ providers: ['openai'] }));
+
+		const response = await app.handle(
+			chatRequest(
+				'/chat',
+				{
+					messages: [{ role: 'user', content: 'Hello' }],
+					provider: 'anthropic',
+					model: 'claude-sonnet-4',
+				},
+				{ 'x-provider-api-key': 'sk-test-key' },
+			),
+		);
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toBe('Unsupported provider: anthropic');
+	});
+
+	test('route is reachable through Elysia prefix mount', async () => {
+		const app = new Elysia().use(
+			new Elysia({ prefix: '/ai' }).use(createAIPlugin()),
+		);
+
+		const response = await app.handle(
+			chatRequest('/ai/chat', {
+				messages: [{ role: 'user', content: 'Hello' }],
+				provider: 'openai',
+				model: 'gpt-4o',
+			}),
+		);
+
+		// Should hit our handler (401 because no API key), not 404
+		expect(response.status).toBe(401);
+	});
+});

--- a/packages/server/src/ai/plugin.ts
+++ b/packages/server/src/ai/plugin.ts
@@ -1,0 +1,108 @@
+import {
+	type AnyTextAdapter,
+	chat,
+	toServerSentEventsResponse,
+} from '@tanstack/ai';
+import { Elysia, t } from 'elysia';
+import { createAdapter, SUPPORTED_PROVIDERS } from './adapters';
+
+/**
+ * Configuration for the AI plugin.
+ *
+ * All options are optional — the plugin works out-of-the-box with sensible defaults.
+ */
+export type AIPluginConfig = {
+	/** Override the list of supported providers. Defaults to all built-in adapters. */
+	providers?: string[];
+};
+
+/**
+ * Creates an Elysia plugin that provides a streaming AI chat endpoint.
+ *
+ * Registers a single route:
+ *
+ * | Method | Route   | Description                                         |
+ * | ------ | ------- | --------------------------------------------------- |
+ * | `POST` | `/chat` | Streaming chat via SSE (Server-Sent Events)         |
+ *
+ * The client sends messages, provider name, model, and API key (via header).
+ * The server creates the appropriate TanStack AI adapter, calls `chat()`,
+ * and streams the response back as SSE using `toServerSentEventsResponse()`.
+ *
+ * **API key handling**: Keys are sent per-request in the `x-provider-api-key`
+ * header. The server never stores, logs, or syncs API keys.
+ *
+ * @example
+ * ```typescript
+ * import { createAIPlugin } from '@epicenter/server/ai';
+ *
+ * const app = new Elysia()
+ *   .use(new Elysia({ prefix: '/ai' }).use(createAIPlugin()))
+ *   .listen(3913);
+ *
+ * // POST /ai/chat → SSE stream
+ * ```
+ */
+export function createAIPlugin(config?: AIPluginConfig) {
+	const allowedProviders = config?.providers ?? SUPPORTED_PROVIDERS;
+
+	return new Elysia().post(
+		'/chat',
+		async ({ body, headers, set }) => {
+			const apiKey = headers['x-provider-api-key'];
+			const { messages, provider, model, conversationId, systemPrompt } = body;
+
+			// Ollama is local — no API key needed
+			if (provider !== 'ollama' && !apiKey) {
+				set.status = 401;
+				return { error: 'Missing x-provider-api-key header' };
+			}
+
+			if (!allowedProviders.includes(provider)) {
+				set.status = 400;
+				return { error: `Unsupported provider: ${provider}` };
+			}
+
+			const adapter = createAdapter(provider, model, apiKey) as
+				| AnyTextAdapter
+				| undefined;
+			if (!adapter) {
+				set.status = 400;
+				return { error: `Unsupported provider: ${provider}` };
+			}
+
+			// AbortController for cleanup when client disconnects mid-stream.
+			// Passed to both chat() and toServerSentEventsResponse() so the
+			// LLM API call and the SSE stream are both cancelled on disconnect.
+			const abortController = new AbortController();
+
+			try {
+				const stream = chat({
+					adapter,
+					messages,
+					conversationId,
+					abortController,
+					...(systemPrompt ? { systemPrompts: [systemPrompt] } : {}),
+				});
+
+				return toServerSentEventsResponse(stream, { abortController });
+			} catch (error) {
+				// Provider errors (bad API key, rate limit, model not found)
+				// may throw synchronously before streaming starts.
+				const message =
+					error instanceof Error ? error.message : 'Unknown error';
+				set.status = 502;
+				return { error: `Provider error: ${message}` };
+			}
+		},
+		{
+			body: t.Object({
+				messages: t.Array(t.Any()), // ModelMessage[] — validated by TanStack AI at runtime
+				provider: t.String(),
+				model: t.String(),
+				conversationId: t.Optional(t.String()),
+				systemPrompt: t.Optional(t.String()),
+			}),
+		},
+	);
+}

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,6 +1,7 @@
 import { openapi } from '@elysiajs/openapi';
 import type { AnyWorkspaceClient } from '@epicenter/hq/static';
 import { Elysia } from 'elysia';
+import { createAIPlugin } from './ai';
 import type { AuthConfig } from './sync/auth';
 import { createSyncPlugin } from './sync/plugin';
 import { createWorkspacePlugin } from './workspace';
@@ -82,6 +83,7 @@ export function createServer(
 		.use(
 			new Elysia({ prefix: '/workspaces' }).use(createWorkspacePlugin(clients)),
 		)
+		.use(new Elysia({ prefix: '/ai' }).use(createAIPlugin()))
 		.get('/', () => ({
 			name: 'Epicenter API',
 			version: '1.0.0',

--- a/specs/20260220T200100 ai-plugin.md
+++ b/specs/20260220T200100 ai-plugin.md
@@ -668,3 +668,42 @@ The `openaiText(model)` / `anthropicText(model)` variants auto-detect API keys f
 - `bun run typecheck` — passes clean (0 errors)
 - `bun test src/ai/plugin.test.ts` — 6 tests pass (401, 400, 422, ollama exemption, config restriction, prefix mount)
 - `bun test src/server.test.ts` — 6 existing tests still pass (no regressions)
+
+## Idiomatic Review (DeepWiki Research)
+
+Reviewed against [DeepWiki TanStack/ai](https://deepwiki.com/TanStack/ai) (indexed at commit b4d988) and the official reference implementation in `examples/ts-react-chat/src/routes/api.tanchat.ts` from [TanStack/ai](https://github.com/TanStack/ai).
+
+### What Was Already Correct
+
+1. **`chat()` → `toServerSentEventsResponse()` pipeline** — This is the canonical server-side pattern. All TanStack AI examples (Next.js, TanStack Start, SvelteKit, Express) follow it.
+2. **`AbortController` passed to both `chat()` and `toServerSentEventsResponse()`** — Matches the best practice documented in DeepWiki's "Streaming Response Utilities" and the reference example.
+3. **`systemPrompts` as first-class `chat()` parameter** — Idiomatic. The alternative (prepending a system message to the messages array) is explicitly discouraged.
+4. **`conversationId` passthrough** — Used in the reference example for analytics/debugging.
+5. **Explicit-key adapter factories** — Correct for our per-request key model. The reference example uses env-auto-detect (`openaiText`, `anthropicText`) because it reads keys from env vars, but our architecture sends keys per-request from the client, so `createOpenaiChat(model, apiKey)` is the right choice.
+6. **Try/catch for synchronous provider errors** — Matches the reference's error handling structure.
+
+### Improvements Made
+
+| Issue                                           | Before                                                                                                                                    | After                                                                                                                                            | Source                                                   |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
+| **`SupportedProvider` was `string`**            | `type SupportedProvider = keyof typeof ADAPTER_FACTORIES` where `ADAPTER_FACTORIES` was `Record<string, ...>` — `keyof string` = `string` | Explicit union: `'openai' \| 'anthropic' \| 'gemini' \| 'ollama' \| 'grok'`. Added `isSupportedProvider()` type guard.                           | Type safety best practice                                |
+| **`ADAPTER_FACTORIES` returned `unknown`**      | `Record<string, (model, apiKey) => unknown>`                                                                                              | `Record<SupportedProvider, (model, apiKey) => AnyTextAdapter>` — return type is now the proper TanStack AI adapter type                          | DeepWiki adapter architecture                            |
+| **Missing abort error handling**                | Generic catch returned 502 for all errors including aborts                                                                                | Distinguishes `AbortError` / aborted signal → returns 499 (Client Closed Request). Provider errors still return 502.                             | Reference `api.tanchat.ts` lines 154-156                 |
+| **No `modelOptions` passthrough**               | Endpoint accepted only messages/provider/model/conversationId/systemPrompt                                                                | Added optional `modelOptions` body field, passed through to `chat()`. Enables client to set temperature, thinking budget, reasoning effort, etc. | DeepWiki "Provider-Specific Options" + reference example |
+| **`createAdapter` returned untyped**            | Return type was implicit `unknown`                                                                                                        | Explicit return type `AnyTextAdapter \| undefined`                                                                                               | DeepWiki adapter interface docs                          |
+| **Unused `AnyTextAdapter` import in plugin.ts** | `import { type AnyTextAdapter, chat, ... }` with a cast `as AnyTextAdapter \| undefined` on the adapter                                   | Removed the import and cast — `createAdapter` now returns `AnyTextAdapter \| undefined` directly                                                 | Cleanup after adapters.ts fix                            |
+
+### Patterns We Chose NOT to Adopt
+
+| Pattern                                      | Why Not                                                                                                                                                                                                                                                                                                  |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`createChatOptions()` helper**             | The reference uses it for per-provider type inference on `modelOptions`. Our server receives `modelOptions` as opaque JSON from the client (not statically typed per-provider), so `createChatOptions()` adds no value here. It becomes useful when we have server-side preset configurations (Phase 3). |
+| **`maxIterations()` agent loop strategy**    | We don't support tools yet (deferred to Phase 3). Adding `agentLoopStrategy` without tools is a no-op.                                                                                                                                                                                                   |
+| **Detailed error logging**                   | The reference logs `error.status`, `error.statusText`, `error.code`, `error.type`, `error.stack`. We keep it minimal — the server's consumer will add their own logging/observability layer.                                                                                                             |
+| **`requestSignal` capture before body read** | The reference captures `request.signal` before `await request.json()` to detect early aborts. In Elysia, the body is already parsed by the framework before our handler runs, so this pattern doesn't apply.                                                                                             |
+
+### Verification
+
+- `bun run typecheck` — passes clean (0 errors)
+- `bun test src/ai/plugin.test.ts` — 6 tests pass
+- `bun test src/server.test.ts` — 6 existing tests pass (no regressions)

--- a/specs/20260220T200100 ai-plugin.md
+++ b/specs/20260220T200100 ai-plugin.md
@@ -1,0 +1,670 @@
+# AI Plugin for Epicenter Server
+
+**Date**: 2026-02-20
+**Status**: Draft
+**Author**: AI-assisted
+
+## Overview
+
+Add a `createAIPlugin` to `@epicenter/server` that exposes a streaming AI chat endpoint via TanStack AI. Users bring their own API keys (stored locally in settings), send them per-request, and the server proxies to LLM providers via SSE. The Svelte client consumes the stream via `@tanstack/ai-svelte`'s `useChat()`.
+
+## Motivation
+
+### Current State
+
+Whispering handles AI completions directly in the Tauri app — each provider SDK is imported and called client-side:
+
+```typescript
+// apps/whispering/src/lib/services/isomorphic/completion/anthropic.ts
+async complete({ apiKey, model, systemPrompt, userPrompt }) {
+  const client = new Anthropic({ apiKey });
+  const message = await client.messages.create({ model, messages: [...] });
+  return Ok(message.content[0].text);
+}
+```
+
+```typescript
+// apps/whispering/src/lib/query/isomorphic/transformer.ts
+case 'Anthropic':
+  return services.completions.anthropic.complete({
+    apiKey: settings.value['apiKeys.anthropic'],
+    model: step['prompt_transform.inference.provider.Anthropic.model'],
+    systemPrompt,
+    userPrompt,
+  });
+```
+
+This creates problems:
+
+1. **No streaming chat**: Current completion services return full responses, not streaming SSE. Building a chat assistant requires real-time streaming.
+2. **No server-side AI**: The server (`packages/server`) has sync and workspace plugins but no AI capabilities. Other apps in the ecosystem (Epicenter Assistant) need a server-side chat endpoint.
+3. **Duplicated provider wiring**: Each new app would need to re-implement provider adapter selection, API key handling, and streaming mechanics.
+
+### Desired State
+
+A composable Elysia plugin that any Epicenter app can mount:
+
+```typescript
+import { createServer } from '@epicenter/server';
+import { createAIPlugin } from '@epicenter/server/ai';
+
+const server = createServer(blogClient, { port: 3913 });
+server.app.use(new Elysia({ prefix: '/ai' }).use(createAIPlugin()));
+server.start();
+
+// POST /ai/chat → SSE stream
+```
+
+Client-side:
+
+```typescript
+import { useChat } from '@tanstack/ai-svelte';
+
+const chat = useChat({
+	api: 'http://localhost:3913/ai/chat',
+	// API key sent via headers, configured in connection adapter
+});
+```
+
+## Research Findings
+
+### TanStack AI Server Integration
+
+TanStack AI's server-side is framework-agnostic. The core flow is:
+
+```
+chat(options) → AsyncIterable<StreamChunk> → toServerSentEventsResponse() → Response
+```
+
+`toServerSentEventsResponse()` returns a standard Web `Response` object with SSE headers. Elysia handlers can return `Response` objects directly, making the integration trivial at the mechanics level.
+
+| Framework      | Route Definition               | Response Helper                |
+| -------------- | ------------------------------ | ------------------------------ |
+| Next.js        | `export async function POST()` | `toServerSentEventsResponse()` |
+| TanStack Start | `createFileRoute('/api/chat')` | `toServerSentEventsResponse()` |
+| SvelteKit      | `export async function POST()` | `toServerSentEventsResponse()` |
+| **Elysia**     | `.post('/chat', handler)`      | `toServerSentEventsResponse()` |
+
+**Key finding**: No Elysia-specific adapter exists in TanStack AI. None is needed — just return the `Response`.
+
+### TanStack AI Svelte Integration
+
+`@tanstack/ai-svelte` provides a `useChat()` binding using Svelte 5 runes. It wraps `@tanstack/ai-client`'s `ChatClient` with `$state`-based reactivity.
+
+| Feature           | Support                             |
+| ----------------- | ----------------------------------- |
+| `useChat()` rune  | Yes                                 |
+| SSE streaming     | Yes                                 |
+| HTTP streaming    | Yes                                 |
+| Client-side tools | Yes                                 |
+| UI components     | No (manual rendering with `marked`) |
+| Devtools          | No                                  |
+
+**Key finding**: Svelte integration exists but is thinner than React/Solid/Vue — no UI component library, no devtools. We'd render messages manually (which is fine for Epicenter's design).
+
+### Provider Adapters Available
+
+| Provider   | TanStack AI Adapter      | Currently in Whispering |
+| ---------- | ------------------------ | ----------------------- |
+| OpenAI     | `@tanstack/ai-openai`    | `openai` SDK            |
+| Anthropic  | `@tanstack/ai-anthropic` | `@anthropic-ai/sdk`     |
+| Google     | `@tanstack/ai-gemini`    | `@google/generative-ai` |
+| Groq       | `@tanstack/ai-grok`      | `groq-sdk`              |
+| Ollama     | `@tanstack/ai-ollama`    | Not used                |
+| Mistral    | Not available            | `@mistralai/mistralai`  |
+| ElevenLabs | Not available            | `elevenlabs`            |
+
+**Implication**: TanStack AI covers the major chat providers. Transcription-specific providers (ElevenLabs, Mistral for transcription) stay on raw SDKs in Whispering.
+
+### Existing Server Plugin Pattern
+
+The server uses a consistent plugin composition pattern:
+
+```typescript
+// packages/server/src/server.ts
+const app = new Elysia()
+  .use(openapi({ ... }))
+  .use(new Elysia({ prefix: '/rooms' }).use(createSyncPlugin({ ... })))
+  .use(new Elysia({ prefix: '/workspaces' }).use(createWorkspacePlugin(clients)))
+  .get('/', () => ({ name: 'Epicenter API', ... }));
+```
+
+Each plugin:
+
+- Is a function returning `new Elysia()` with routes
+- Takes a config object
+- Is prefix-agnostic (caller mounts with `new Elysia({ prefix })`)
+- Uses Elysia's `t` for request/response schemas
+
+## Design Decisions
+
+| Decision                | Choice                                    | Rationale                                                         |
+| ----------------------- | ----------------------------------------- | ----------------------------------------------------------------- |
+| Plugin vs raw routes    | Elysia plugin (`createAIPlugin`)          | Matches existing composition pattern; gets auth, OpenAPI for free |
+| Route mount point       | `/ai/chat`                                | Cross-cutting, not workspace-scoped yet; simple starting point    |
+| API key transport       | `x-provider-api-key` header               | Avoids conflating with server auth; explicit about what it is     |
+| Provider selection      | Client sends `provider` + `model` in body | Server validates against whitelist; keeps control server-side     |
+| TanStack AI vs raw SDKs | TanStack AI for chat only                 | Unified streaming + SSE; don't replace working transcription code |
+| Streaming protocol      | SSE via `toServerSentEventsResponse()`    | TanStack AI's default; `useChat()` expects it                     |
+| API key storage         | Never server-side                         | Local-first principle; keys stay in client settings               |
+| "Spells" abstraction    | Deferred                                  | Build the endpoint first; abstraction patterns will emerge later  |
+
+## Architecture
+
+### System Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        Epicenter Server                             │
+│                                                                     │
+│  ┌──────────────┐  ┌──────────────────┐  ┌───────────────────────┐ │
+│  │  Sync Plugin  │  │ Workspace Plugin │  │     AI Plugin         │ │
+│  │  /rooms/      │  │ /workspaces/     │  │     /ai/              │ │
+│  │               │  │                  │  │                       │ │
+│  │  WS y-doc     │  │  REST CRUD for   │  │  POST /chat           │ │
+│  │  sync         │  │  tables/actions  │  │  → SSE stream         │ │
+│  └──────────────┘  └──────────────────┘  └───────────────────────┘ │
+│                                                                     │
+│  ┌─────────────────────────────────────────────────────────────┐   │
+│  │  OpenAPI (Scalar UI)                                         │   │
+│  └─────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Request Flow
+
+```
+Client (Tauri App / Browser)                  Server (Elysia)
+┌────────────────────────────┐    POST /ai/chat    ┌───────────────────────┐
+│                            │    ─────────────▶   │                       │
+│  useChat() sends:          │    Headers:          │  1. Extract API key   │
+│  {                         │    x-provider-api-key│     from header       │
+│    messages: [...],        │    ───────────────   │                       │
+│    provider: "openai",     │    Body:             │  2. Validate provider │
+│    model: "gpt-4o"         │    { messages, ...}  │     against whitelist │
+│  }                         │                      │                       │
+│                            │                      │  3. Create adapter:   │
+│  Settings store            │                      │     openaiText({      │
+│  ┌──────────────────┐      │                      │       apiKey,         │
+│  │ apiKeys.openai:  │──────│──▶ (sent in header)  │       model           │
+│  │ "sk-..."         │      │                      │     })                │
+│  └──────────────────┘      │                      │                       │
+│                            │    SSE stream         │  4. chat({            │
+│  useChat() receives:       │    ◀─────────────    │       adapter,        │
+│  streaming chunks          │    text/event-stream  │       messages        │
+│  → updates $state          │                      │     })                │
+│  → reactive UI             │                      │                       │
+│                            │                      │  5. toSSEResponse()   │
+└────────────────────────────┘                      └───────────────────────┘
+                                                              │
+                                                              ▼
+                                                    ┌───────────────────┐
+                                                    │   LLM Provider    │
+                                                    │   (OpenAI, etc.)  │
+                                                    │                   │
+                                                    │   API key passed  │
+                                                    │   directly from   │
+                                                    │   client → here   │
+                                                    └───────────────────┘
+```
+
+### Plugin Composition (createServer)
+
+```
+createServer(clients, options)
+│
+├── openapi()                           ── /openapi, /openapi/json
+│
+├── new Elysia({ prefix: '/rooms' })
+│   └── createSyncPlugin(config)        ── WS /:room/sync, GET/POST /:room/doc
+│
+├── new Elysia({ prefix: '/workspaces' })
+│   └── createWorkspacePlugin(clients)  ── REST /:id/tables/:table, /:id/actions/:action
+│
+├── new Elysia({ prefix: '/ai' })       ── NEW
+│   └── createAIPlugin(config)          ── POST /chat
+│
+└── GET /                               ── Discovery endpoint
+```
+
+### API Key Flow — What NOT To Do
+
+```
+                    NEVER DO THIS
+                    ─────────────
+ ┌──────────┐   sync    ┌──────────┐
+ │ Client A │ ────────▶ │  Y.Doc   │  ← API keys in synced doc = leaked to all clients
+ └──────────┘           └──────────┘
+                            │ sync
+ ┌──────────┐              ▼
+ │ Client B │ ◀──────── (receives Client A's keys!)
+ └──────────┘
+
+                    DO THIS INSTEAD
+                    ───────────────
+ ┌──────────┐   per-request header   ┌──────────┐   API call   ┌──────────┐
+ │ Client   │ ─────────────────────▶ │  Server  │ ───────────▶ │ Provider │
+ │ (keys in │   x-provider-api-key   │ (no key  │  (key used   │ (OpenAI) │
+ │  local   │   Authorization:...    │  storage)│   once, then │          │
+ │  store)  │                        │          │   discarded) │          │
+ └──────────┘                        └──────────┘              └──────────┘
+```
+
+## Implementation Plan
+
+### Phase 1: Server-Side AI Plugin
+
+New files in `packages/server/src/ai/`.
+
+- [x] **1.1** Create `packages/server/src/ai/plugin.ts` — `createAIPlugin(config?)` Elysia plugin
+  - Registers `POST /chat` route
+  - Request schema: `{ messages: ModelMessage[], provider: string, model: string, conversationId?: string, systemPrompt?: string }`
+  - Extracts API key from `x-provider-api-key` header
+  - Creates provider adapter based on `provider` + `model` + `apiKey`
+  - Creates `AbortController` for client disconnect cleanup
+  - Calls `chat({ adapter, messages, abortController, systemPrompts })` → `toServerSentEventsResponse(stream, { abortController })`
+  - Wraps in try/catch for provider errors (bad key, rate limit) → returns structured 502 error
+  - Returns the `Response` directly on success
+
+- [x] **1.2** Create `packages/server/src/ai/adapters.ts` — Provider adapter factory
+  - `createAdapter(provider, model, apiKey)` → returns TanStack AI adapter
+  - Whitelist of supported providers: `openai`, `anthropic`, `gemini`, `ollama`, `grok`
+  - Type-safe: provider string maps to correct adapter factory
+  - Ollama doesn't need an API key (local)
+
+- [x] **1.3** Create `packages/server/src/ai/index.ts` — Public exports
+  - Export `createAIPlugin` and `AIPluginConfig` type
+
+- [x] **1.4** Add sub-entry to `packages/server/package.json`
+  - `"./ai": "./src/ai/index.ts"` (matches existing `./sync`, `./workspace` pattern)
+
+- [x] **1.5** Wire into `createServer` in `packages/server/src/server.ts`
+  - Mount as `new Elysia({ prefix: '/ai' }).use(createAIPlugin())`
+
+- [x] **1.6** Add TanStack AI dependencies to `packages/server/package.json`
+  - `@tanstack/ai` (core)
+  - `@tanstack/ai-openai`, `@tanstack/ai-anthropic`, `@tanstack/ai-gemini`, `@tanstack/ai-ollama`, `@tanstack/ai-grok` (adapters)
+
+- [ ] **1.7** Update `packages/server/README.md`
+  - Document the new `/ai/chat` endpoint, request/response format, and API key handling
+
+- [x] **1.8** Add basic test in `packages/server/src/ai/plugin.test.ts`
+  - Test route registration, request validation, error responses
+  - Tests cover: 401 missing key, 400 unsupported provider, 422 missing body, ollama key exemption, config.providers restriction, prefix mount
+
+### Phase 2: Client-Side Integration
+
+Integration in the Svelte app(s) that consume the AI chat endpoint.
+
+- [ ] **2.1** Add `@tanstack/ai-svelte` and `@tanstack/ai-client` to the consuming app's dependencies
+
+- [ ] **2.2** Create a chat service/query layer that uses `useChat()` from `@tanstack/ai-svelte`
+  - Configure with server URL (`http://localhost:3913/ai/chat`)
+  - Custom connection adapter that injects `x-provider-api-key` header from settings
+  - Handle provider/model selection from user settings
+
+- [ ] **2.3** Build chat UI components
+  - Message list (streaming text display)
+  - Input form
+  - Provider/model selector
+  - Loading/error states
+
+- [ ] **2.4** Wire API key management
+  - Reuse existing settings pattern (`apiKeys.openai`, `apiKeys.anthropic`, etc.)
+  - Selected provider's key is sent in header per-request
+  - Show "API key required" prompt if key is missing for selected provider
+
+## Conceptual Code
+
+### createAIPlugin (Phase 1)
+
+```typescript
+// packages/server/src/ai/plugin.ts
+import { Elysia, t } from 'elysia';
+import { chat, toServerSentEventsResponse } from '@tanstack/ai';
+import { createAdapter } from './adapters';
+
+export type AIPluginConfig = {
+	/** Optional: override supported providers. Defaults to all built-in adapters. */
+	providers?: string[];
+};
+
+export function createAIPlugin(config?: AIPluginConfig) {
+	return new Elysia().post(
+		'/chat',
+		async ({ body, headers, set }) => {
+			const apiKey = headers['x-provider-api-key'];
+			const { messages, provider, model, conversationId, systemPrompt } = body;
+
+			// Ollama is local — no key needed
+			if (provider !== 'ollama' && !apiKey) {
+				set.status = 401;
+				return { error: 'Missing x-provider-api-key header' };
+			}
+
+			const adapter = createAdapter(provider, model, apiKey);
+			if (!adapter) {
+				set.status = 400;
+				return { error: `Unsupported provider: ${provider}` };
+			}
+
+			// AbortController for cleanup when client disconnects mid-stream.
+			// TanStack AI best practice: always pass abortController to chat() and
+			// toServerSentEventsResponse() so both the LLM API call and the SSE
+			// stream are cancelled on disconnect.
+			const abortController = new AbortController();
+
+			try {
+				const stream = chat({
+					adapter,
+					messages,
+					conversationId,
+					abortController,
+					// chat() has a first-class systemPrompts parameter — use it
+					// instead of prepending a system message to the messages array.
+					...(systemPrompt ? { systemPrompts: [systemPrompt] } : {}),
+				});
+
+				return toServerSentEventsResponse(stream, { abortController });
+			} catch (error) {
+				// Provider errors (bad API key, rate limit, model not found) throw
+				// synchronously before streaming starts. Catch and return structured
+				// error responses instead of letting Elysia's default 500 handle it.
+				const message =
+					error instanceof Error ? error.message : 'Unknown error';
+				set.status = 502;
+				return { error: `Provider error: ${message}` };
+			}
+		},
+		{
+			body: t.Object({
+				messages: t.Array(t.Any()), // ModelMessage[] — validated by TanStack AI
+				provider: t.String(),
+				model: t.String(),
+				conversationId: t.Optional(t.String()),
+				systemPrompt: t.Optional(t.String()),
+			}),
+		},
+	);
+}
+```
+
+### createAdapter (Phase 1)
+
+> **CORRECTED**: The original conceptual code used `openaiText({ apiKey, model })` which is the
+> env-auto-detect variant. The actual API uses positional arguments: `createOpenaiChat(model, apiKey)`.
+> See "Phase 1 Review" section below for details.
+
+```typescript
+// packages/server/src/ai/adapters.ts
+import { createOpenaiChat } from '@tanstack/ai-openai';
+import { createAnthropicChat } from '@tanstack/ai-anthropic';
+import { createGeminiChat } from '@tanstack/ai-gemini';
+import { createOllamaChat } from '@tanstack/ai-ollama';
+import { createGrokText } from '@tanstack/ai-grok';
+
+const ADAPTER_FACTORIES = {
+	openai: (model, apiKey) => createOpenaiChat(model, apiKey),
+	anthropic: (model, apiKey) => createAnthropicChat(model, apiKey),
+	gemini: (model, apiKey) => createGeminiChat(model, apiKey),
+	ollama: (model, _apiKey) => createOllamaChat(model),
+	grok: (model, apiKey) => createGrokText(model, apiKey),
+};
+
+export function createAdapter(
+	provider: string,
+	model: string,
+	apiKey: string = '',
+) {
+	const factory = ADAPTER_FACTORIES[provider];
+	if (!factory) return undefined;
+	return factory(model, apiKey);
+}
+```
+
+### Server Composition (Phase 1)
+
+```typescript
+// packages/server/src/server.ts (updated)
+import { createAIPlugin } from './ai';
+
+const app = new Elysia()
+  .use(openapi({ ... }))
+  .use(new Elysia({ prefix: '/rooms' }).use(createSyncPlugin({ ... })))
+  .use(new Elysia({ prefix: '/workspaces' }).use(createWorkspacePlugin(clients)))
+  .use(new Elysia({ prefix: '/ai' }).use(createAIPlugin()))   // ← NEW
+  .get('/', () => ({
+    name: 'Epicenter API',
+    version: '1.0.0',
+    workspaces: Object.keys(workspaces),
+    actions: allActionPaths,
+  }));
+```
+
+### Client Usage (Phase 2)
+
+```svelte
+<script lang="ts">
+	import { useChat } from '@tanstack/ai-svelte';
+	import { sseAdapter } from '@tanstack/ai-client';
+	import { settings } from '$lib/state/settings.svelte';
+
+	const chat = useChat({
+		api: 'http://localhost:3913/ai/chat',
+		connectionAdapter: sseAdapter({
+			headers: () => ({
+				'x-provider-api-key':
+					settings.value[`apiKeys.${settings.value['ai.provider']}`],
+			}),
+			body: () => ({
+				provider: settings.value['ai.provider'],
+				model: settings.value['ai.model'],
+			}),
+		}),
+	});
+</script>
+
+{#each chat.messages as message}
+	<div class={message.role === 'user' ? 'text-right' : 'text-left'}>
+		{message.content}
+	</div>
+{/each}
+
+<form onsubmit={chat.handleSubmit}>
+	<input bind:value={chat.input} placeholder="Ask anything..." />
+</form>
+```
+
+## Edge Cases
+
+### Missing or Invalid API Key
+
+1. Client sends request without `x-provider-api-key` header
+2. Server returns `401 { error: "Missing x-provider-api-key header" }`
+3. Client shows "Add your API key in Settings" prompt
+
+### Unsupported Provider
+
+1. Client sends `{ provider: "mistral" }` (not in adapter whitelist)
+2. Server returns `400 { error: "Unsupported provider: mistral" }`
+3. Client should only show providers from the supported list
+
+### Client Disconnects Mid-Stream
+
+1. User navigates away or closes tab during streaming
+2. The `abortController` passed to both `chat()` and `toServerSentEventsResponse()` signals cancellation
+3. This aborts the in-flight LLM API call (saving cost) and tears down the SSE stream cleanly
+4. The conceptual code already wires this — see `createAIPlugin` above
+
+### Ollama (Local Provider)
+
+1. User selects Ollama — no API key needed
+2. Server skips key validation for `provider: "ollama"`
+3. Ollama must be running locally; connection failure returns a clear error
+
+### API Key in Synced Workspace Data
+
+1. Developer accidentally stores API key in a Yjs-synced table
+2. Key replicates to all connected clients
+3. **Mitigation**: API keys MUST stay in local-only storage (IndexedDB settings). The AI plugin never persists keys. Document this clearly.
+
+## DeepWiki Research Findings
+
+Verified against DeepWiki analysis of [TanStack/ai](https://deepwiki.com/TanStack/ai) (indexed at commit b4d988) and [elysiajs/elysia](https://deepwiki.com/elysiajs/elysia) (indexed at commit 3edbde).
+
+### TanStack AI API Surface (Verified)
+
+- **`chat()`** is the correct function for conversation-oriented streaming. There is also `generate()` for simpler single-turn prompts, but `chat()` is what we need for a chat endpoint.
+- **`toServerSentEventsResponse(stream, init?)`** returns a standard Web `Response` with headers `Content-Type: text/event-stream`, `Cache-Control: no-cache`, `Connection: keep-alive`. Elysia handlers can return `Response` directly.
+- **`toServerSentEventsStream(stream, abortController?)`** is the lower-level variant returning `ReadableStream<Uint8Array>` — not needed here.
+- **SSE format**: Each chunk is `data: {JSON}\n\n`, stream terminates with `data: [DONE]\n\n`.
+- **`abortController`** is accepted by both `chat()` and `toServerSentEventsResponse()` for cancellation propagation.
+- **`systemPrompts`** is a first-class `chat()` parameter — no need to prepend system messages to the messages array.
+- **`chat()` returns `AsyncIterable<StreamChunk>`** where `StreamChunk` is a discriminated union: `content`, `thinking`, `tool_call`, `tool_result`, `tool-input-available`, `approval-requested`, `done`, `error`.
+
+### Adapter Package Exports (Verified — then Corrected)
+
+Each adapter package exports from its root `.` path only. However, each package exports **two** factory functions — one env-auto-detect variant and one explicit-key variant:
+
+| Provider  | Env-auto-detect (reads env var) | Explicit key (our use case)          |
+| --------- | ------------------------------- | ------------------------------------ |
+| OpenAI    | `openaiText(model, config?)`    | `createOpenaiChat(model, apiKey)`    |
+| Anthropic | `anthropicText(model, config?)` | `createAnthropicChat(model, apiKey)` |
+| Gemini    | `geminiText(model, config?)`    | `createGeminiChat(model, apiKey)`    |
+| Ollama    | `ollamaText(model)`             | `createOllamaChat(model, host?)`     |
+| Grok      | `grokText(model, config?)`      | `createGrokText(model, apiKey)`      |
+
+**Critical finding**: The original conceptual code used `openaiText({ apiKey, model })` which is **wrong** in two ways:
+
+1. `openaiText` reads API keys from `process.env`, not from arguments — no `apiKey` param
+2. The signature is `openaiText(model)` (positional string), not `openaiText({ model })`
+
+Since our server receives API keys per-request from clients (not from env vars), we must use the explicit-key variants (`createOpenaiChat`, `createAnthropicChat`, etc.).
+
+```typescript
+// ✅ Correct — explicit API key variants for per-request keys
+import { createOpenaiChat } from '@tanstack/ai-openai';
+import { createAnthropicChat } from '@tanstack/ai-anthropic';
+import { createGeminiChat } from '@tanstack/ai-gemini';
+import { createOllamaChat } from '@tanstack/ai-ollama';
+import { createGrokText } from '@tanstack/ai-grok';
+
+// ❌ Wrong — these read from process.env, not per-request
+// import { openaiText } from '@tanstack/ai-openai';
+```
+
+Current versions: `@tanstack/ai@0.5.1`, `@tanstack/ai-openai@0.5.0`. Each adapter has a peer dependency on `@tanstack/ai` at `workspace:^`.
+
+### Svelte Integration (Verified)
+
+- `@tanstack/ai-svelte` requires Svelte 5.0.0+ (runes-based).
+- Provides `useChat()` binding wrapping `@tanstack/ai-client`'s `ChatClient` with `$state` reactivity.
+- **No UI component library** exists for Svelte yet (unlike React, Solid, Vue) — messages must be rendered manually.
+- **No devtools** package for Svelte yet.
+- Connection adapters (`fetchServerSentEvents`, `fetchHttpStream`) are imported from `@tanstack/ai-client`.
+
+### Elysia Plugin Mechanics (Verified)
+
+- Elysia plugins are `new Elysia()` instances registered via `.use()`.
+- Handlers returning `Response` objects bypass Elysia's serialization — SSE streaming works natively.
+- Three-tier scope system (global/scoped/local) — our plugin uses local scope correctly.
+- TypeBox `t.*` schemas provide runtime validation and OpenAPI generation.
+
+## Open Questions
+
+1. **Should the AI plugin be included in `createServer` by default, or opt-in?**
+   - Options: (a) Always mounted, (b) Opt-in via config flag, (c) Separate import
+   - **Recommendation**: Opt-in. `createServer(clients, { ai: true })` or manual `.use()`. Not everyone running a sync server wants AI routes. Defer until usage patterns emerge.
+
+2. **System prompts — where do they come from?**
+   - Options: (a) Client sends in body, (b) Server-side config, (c) Workspace-stored "spells"
+   - **Decision**: Client sends optional `systemPrompt` string in body. The plugin passes it to `chat()` via its first-class `systemPrompts` parameter. Server-side presets can come later.
+
+3. **Tools / function calling — Phase 1 or later?**
+   - Options: (a) Support tools in Phase 1, (b) Defer to Phase 3
+   - **Recommendation**: Defer. Get basic chat streaming working first. Tools add significant complexity (server-side execution, client-side tools, approval flows).
+
+4. **Rate limiting / cost guardrails?**
+   - Since users bring their own keys, rate limiting is the provider's concern
+   - **Recommendation**: Don't implement rate limiting initially. Add optional `maxTokens` cap later if needed.
+
+5. **Conversation persistence?**
+   - Options: (a) Stateless (client manages history), (b) Server stores in workspace table
+   - **Recommendation**: Stateless. Client sends full message history each request. This is how TanStack AI works by default and avoids server-side state.
+
+## Success Criteria
+
+- [ ] `POST /ai/chat` returns SSE stream for a valid request with API key
+- [ ] Provider adapter selection works for openai, anthropic, gemini, ollama, grok
+- [ ] Missing API key returns 401; unsupported provider returns 400
+- [ ] Client disconnect aborts the server-side stream
+- [ ] API keys are never logged, persisted, or synced by the server
+- [ ] Plugin mounts cleanly alongside existing sync and workspace plugins
+- [ ] OpenAPI docs include the `/ai/chat` endpoint
+- [ ] `packages/server` typecheck passes
+- [ ] Basic test coverage for route validation and error paths
+
+## URL Hierarchy (Updated)
+
+```
+/                                              - API root / discovery
+/openapi                                       - Scalar UI documentation
+/openapi/json                                  - OpenAPI spec (JSON)
+/rooms/                                        - Active rooms with connection counts
+/rooms/{workspaceId}/sync                      - WebSocket sync (y-websocket protocol)
+/rooms/{workspaceId}/doc                       - Document state (GET/POST)
+/workspaces/{workspaceId}/tables/{table}       - RESTful table CRUD
+/workspaces/{workspaceId}/tables/{table}/{id}  - Single row operations
+/workspaces/{workspaceId}/actions/{action}     - Workspace action endpoints
+/ai/chat                                       - AI chat (SSE streaming)    ← NEW
+```
+
+## References
+
+- `packages/server/src/server.ts` — Main server composition, plugin mounting pattern
+- `packages/server/src/sync/plugin.ts` — Reference plugin implementation (sync)
+- `packages/server/src/workspace/plugin.ts` — Reference plugin implementation (workspace)
+- `packages/server/package.json` — Dependencies, sub-entries pattern
+- `apps/whispering/src/lib/settings/settings.ts` — API key storage pattern
+- `apps/whispering/src/lib/services/isomorphic/completion/` — Existing completion services
+- TanStack AI docs: `chat()` function, `toServerSentEventsResponse()`, adapter APIs
+- TanStack AI Svelte: `@tanstack/ai-svelte` `useChat()` binding
+
+## Phase 1 Review
+
+### What Was Implemented
+
+All Phase 1 items (1.1–1.8) except 1.7 (README update, deferred to Phase 2 when the full endpoint behavior is documented with client examples).
+
+**Files created:**
+
+```
+packages/server/src/ai/
+├── adapters.ts      — Provider adapter factory (5 providers)
+├── plugin.ts        — createAIPlugin() Elysia plugin with POST /chat
+├── index.ts         — Public exports for @epicenter/server/ai
+└── plugin.test.ts   — 6 tests: auth, validation, error paths, prefix mount
+```
+
+**Files modified:**
+
+- `packages/server/package.json` — `"./ai"` sub-entry + 6 `@tanstack/ai-*` dependencies
+- `packages/server/src/server.ts` — Wired `createAIPlugin()` under `/ai` prefix
+
+### Key Deviation from Spec
+
+The conceptual code in this spec used `openaiText({ apiKey, model })` which does not exist. After reading the actual TanStack AI source code (GitHub `TanStack/ai` at `packages/typescript/ai-*/src/adapters/text.ts`), the correct APIs are:
+
+- `createOpenaiChat(model, apiKey)` — positional `(model: string, apiKey: string)`
+- `createAnthropicChat(model, apiKey)` — same pattern
+- `createGeminiChat(model, apiKey)` — same pattern
+- `createOllamaChat(model, host?)` — no API key, optional host
+- `createGrokText(model, apiKey)` — same pattern
+
+The `openaiText(model)` / `anthropicText(model)` variants auto-detect API keys from `process.env.OPENAI_API_KEY` etc., which is wrong for our per-request key model.
+
+### Verification
+
+- `bun run typecheck` — passes clean (0 errors)
+- `bun test src/ai/plugin.test.ts` — 6 tests pass (401, 400, 422, ollama exemption, config restriction, prefix mount)
+- `bun test src/server.test.ts` — 6 existing tests still pass (no regressions)


### PR DESCRIPTION
The tab manager needs a server-side AI chat endpoint so the browser extension can stream LLM responses without exposing API keys in the extension's content security policy. This adds a `/ai/chat` endpoint that takes messages + provider config and returns an SSE stream.

```typescript
const app = new Elysia()
  .use(new Elysia({ prefix: '/ai' }).use(createAIPlugin()))
  .listen(3913);

// POST /ai/chat with:
// - body: { messages, provider, model, conversationId?, systemPrompt?, modelOptions? }
// - header: x-provider-api-key (per-request, never stored)
// → SSE stream via TanStack AI's toServerSentEventsResponse()
```

```
createServer()
├── Sync Plugin        → /rooms/:room
├── Workspace Plugin   → /workspaces/:id/tables/...
├── AI Plugin          → /ai/chat          ← new
└── OpenAPI + Discovery
```

Five providers are supported out of the box: OpenAI, Anthropic, Gemini, Grok, and Ollama (local, no API key needed). The adapter factory pattern makes adding new providers a one-liner.

API keys flow per-request in the `x-provider-api-key` header. The server never stores, logs, or syncs keys — it's a stateless proxy between the extension and the LLM API. This keeps the security model simple: keys live in the browser's `storage.local` on each device, and the server just forwards them.

Error handling distinguishes three cases: client disconnect (499), missing auth (401), and provider errors (502 — bad key, rate limit, model not found). An `AbortController` is wired through both `chat()` and `toServerSentEventsResponse()` so disconnected clients don't leave orphaned API calls running.