### PR TITLE
refactor(server): collapse sync routes to canonical resource path

### DIFF
--- a/apps/tab-manager/src/entrypoints/background.ts
+++ b/apps/tab-manager/src/entrypoints/background.ts
@@ -135,7 +135,7 @@ export default defineBackground(() => {
 			 * Default: ws://127.0.0.1:3913
 			 */
 			createSyncExtension({
-				url: 'ws://127.0.0.1:3913/rooms/{id}/sync',
+				url: 'ws://127.0.0.1:3913/rooms/{id}',
 			}),
 		);
 

--- a/apps/tab-manager/src/lib/workspace-popup.ts
+++ b/apps/tab-manager/src/lib/workspace-popup.ts
@@ -27,7 +27,7 @@ export const popupWorkspace = createWorkspace(definition)
 	.withExtension(
 		'sync',
 		createSyncExtension({
-			url: 'ws://127.0.0.1:3913/rooms/{id}/sync',
+			url: 'ws://127.0.0.1:3913/rooms/{id}',
 		}),
 	);
 

--- a/packages/epicenter/README.md
+++ b/packages/epicenter/README.md
@@ -319,7 +319,7 @@ const client = createClient(definition.id)
 	.withExtension(
 		'sync',
 		createSyncExtension({
-			url: 'ws://localhost:3913/rooms/{id}/sync',
+			url: 'ws://localhost:3913/rooms/{id}',
 		}),
 	);
 ```
@@ -895,7 +895,7 @@ const client = createClient(definition.id)
 	.withExtension(
 		'sync',
 		createSyncExtension({
-			url: 'ws://localhost:3913/rooms/{id}/sync',
+			url: 'ws://localhost:3913/rooms/{id}',
 		}),
 	);
 
@@ -903,7 +903,7 @@ The `{id}` placeholder is replaced with the workspace ID automatically.
 
 **Server-side sync endpoint:**
 
-The Epicenter server (`@epicenter/server`) includes a sync endpoint at `/rooms/{workspaceId}/sync`:
+The Epicenter server (`@epicenter/server`) includes a sync endpoint at `/rooms/{workspaceId}`:
 
 ```typescript
 import { createServer } from '@epicenter/server';
@@ -911,12 +911,12 @@ import { createServer } from '@epicenter/server';
 const server = createServer(blogClient, { port: 3913 });
 server.start();
 
-// Clients connect to: ws://localhost:3913/rooms/blog/sync
+// Clients connect to: ws://localhost:3913/rooms/blog
 ````
 
 **How it works:**
 
-1. Client opens WebSocket to `/rooms/{workspaceId}/sync`
+1. Client opens WebSocket to `/rooms/{workspaceId}`
 2. Server sends initial sync state (sync step 1)
 3. Client and server exchange updates bidirectionally
 4. Server broadcasts updates to all connected clients
@@ -942,14 +942,14 @@ Epicenter supports a distributed sync architecture where Y.Doc instances can be 
 // src/config/sync-nodes.ts
 export const SYNC_NODES = {
 	// Local devices via Tailscale
-	desktop: 'ws://desktop.my-tailnet.ts.net:3913/rooms/{id}/sync',
-	laptop: 'ws://laptop.my-tailnet.ts.net:3913/rooms/{id}/sync',
+	desktop: 'ws://desktop.my-tailnet.ts.net:3913/rooms/{id}',
+	laptop: 'ws://laptop.my-tailnet.ts.net:3913/rooms/{id}',
 
 	// Cloud server (optional, always-on)
-	cloud: 'wss://sync.myapp.com/rooms/{id}/sync',
+	cloud: 'wss://sync.myapp.com/rooms/{id}',
 
 	// Localhost (for browser connecting to local server)
-	localhost: 'ws://localhost:3913/rooms/{id}/sync',
+	localhost: 'ws://localhost:3913/rooms/{id}',
 } as const;
 ```
 
@@ -1227,7 +1227,7 @@ providers: {
 
   // WebSocket sync extension (y-websocket protocol via @epicenter/sync)
   sync: createSyncExtension({
-    url: 'ws://localhost:3913/rooms/{id}/sync',
+    url: 'ws://localhost:3913/rooms/{id}',
   }),
 
   // Custom provider
@@ -1716,7 +1716,7 @@ Create an HTTP server from workspace clients. Exposes:
 
 - REST endpoints for actions: `/workspaces/{id}/actions/{action}`
 - Table CRUD: `/workspaces/{id}/tables/{table}`
-- WebSocket sync: `/rooms/{id}/sync`
+- WebSocket sync: `/rooms/{id}`
 - OpenAPI documentation: `/openapi`
 
 ## MCP Integration

--- a/packages/epicenter/SYNC_ARCHITECTURE.md
+++ b/packages/epicenter/SYNC_ARCHITECTURE.md
@@ -22,13 +22,13 @@ Yjs supports **multiple providers simultaneously**. Each provider connects to a 
 const doc = new Y.Doc();
 
 // Provider 1: Local desktop server
-new WebsocketProvider('ws://desktop.tailnet:3913/rooms/blog/sync', 'blog', doc);
+new WebsocketProvider('ws://desktop.tailnet:3913/rooms/blog', 'blog', doc);
 
 // Provider 2: Laptop server
-new WebsocketProvider('ws://laptop.tailnet:3913/rooms/blog/sync', 'blog', doc);
+new WebsocketProvider('ws://laptop.tailnet:3913/rooms/blog', 'blog', doc);
 
 // Provider 3: Cloud server
-new WebsocketProvider('wss://sync.myapp.com/rooms/blog/sync', 'blog', doc);
+new WebsocketProvider('wss://sync.myapp.com/rooms/blog', 'blog', doc);
 
 // Changes sync through ALL connected providers
 // Yjs deduplicates updates automatically
@@ -98,14 +98,14 @@ Define your sync nodes as a constant for easy reference:
  */
 export const SYNC_NODES = {
 	// Local devices via Tailscale
-	desktop: 'ws://desktop.my-tailnet.ts.net:3913/rooms/{id}/sync',
-	laptop: 'ws://laptop.my-tailnet.ts.net:3913/rooms/{id}/sync',
+	desktop: 'ws://desktop.my-tailnet.ts.net:3913/rooms/{id}',
+	laptop: 'ws://laptop.my-tailnet.ts.net:3913/rooms/{id}',
 
 	// Cloud server (optional, always-on)
-	cloud: 'wss://sync.myapp.com/rooms/{id}/sync',
+	cloud: 'wss://sync.myapp.com/rooms/{id}',
 
 	// Localhost (for browser connecting to local server)
-	localhost: 'ws://localhost:3913/rooms/{id}/sync',
+	localhost: 'ws://localhost:3913/rooms/{id}',
 } as const;
 
 export type SyncNodeId = keyof typeof SYNC_NODES;
@@ -338,9 +338,9 @@ When offline:
 ```typescript
 // With Tailscale, use hostnames instead of IPs
 const SYNC_NODES = {
-	desktop: 'ws://desktop.my-tailnet.ts.net:3913/rooms/{id}/sync', // Tailscale hostname
-	laptop: 'ws://laptop.my-tailnet.ts.net:3913/rooms/{id}/sync', // Tailscale hostname
-	cloud: 'wss://sync.myapp.com/rooms/{id}/sync', // Public domain
+	desktop: 'ws://desktop.my-tailnet.ts.net:3913/rooms/{id}', // Tailscale hostname
+	laptop: 'ws://laptop.my-tailnet.ts.net:3913/rooms/{id}', // Tailscale hostname
+	cloud: 'wss://sync.myapp.com/rooms/{id}', // Public domain
 } as const;
 ```
 

--- a/packages/epicenter/docs/architecture/network-topology.md
+++ b/packages/epicenter/docs/architecture/network-topology.md
@@ -106,10 +106,10 @@ Phone has no local server, so it connects directly to all available servers:
 ```typescript
 providers: {
   syncToLaptopA: createSyncExtension({
-    url: 'ws://laptop-a.tailnet:3913/rooms/{id}/sync'
+    url: 'ws://laptop-a.tailnet:3913/rooms/{id}'
   }),
   syncToLaptopB: createSyncExtension({
-    url: 'ws://laptop-b.tailnet:3913/rooms/{id}/sync'
+    url: 'ws://laptop-b.tailnet:3913/rooms/{id}'
   }),
 }
 ```
@@ -121,7 +121,7 @@ Browser connects to its own local server:
 ```typescript
 providers: {
   sync: createSyncExtension({
-    url: 'ws://localhost:3913/rooms/{id}/sync'
+    url: 'ws://localhost:3913/rooms/{id}'
   }),
 }
 ```
@@ -134,7 +134,7 @@ Server accepts connections AND connects to other servers:
 // Laptop A server connects to Laptop B
 providers: {
   syncToLaptopB: createSyncExtension({
-    url: 'ws://laptop-b.tailnet:3913/rooms/{id}/sync'
+    url: 'ws://laptop-b.tailnet:3913/rooms/{id}'
   }),
 }
 
@@ -151,11 +151,11 @@ const doc = new Y.Doc();
 // Connect to multiple servers via createSyncProvider from @epicenter/sync
 const provider1 = createSyncProvider({
 	doc,
-	url: 'ws://laptop-a.tailnet:3913/rooms/blog/sync',
+	url: 'ws://laptop-a.tailnet:3913/rooms/blog',
 });
 const provider2 = createSyncProvider({
 	doc,
-	url: 'ws://laptop-b.tailnet:3913/rooms/blog/sync',
+	url: 'ws://laptop-b.tailnet:3913/rooms/blog',
 });
 
 // Changes sync through ALL connected providers
@@ -179,7 +179,7 @@ providers: {
   persistence: setupPersistence,
 
   // Network sync (via @epicenter/sync)
-  sync: createSyncExtension({ url: 'ws://localhost:3913/rooms/{id}/sync' }),
+  sync: createSyncExtension({ url: 'ws://localhost:3913/rooms/{id}' }),
 }
 ```
 

--- a/packages/epicenter/docs/architecture/security.md
+++ b/packages/epicenter/docs/architecture/security.md
@@ -47,7 +47,7 @@ const server = createEpicenterServer({
 
 // Client
 const provider = createSyncExtension({
-	url: 'ws://server:3913/rooms/{id}/sync',
+	url: 'ws://server:3913/rooms/{id}',
 	token: process.env.EPICENTER_PSK,
 });
 ```

--- a/packages/epicenter/src/extensions/sync.test.ts
+++ b/packages/epicenter/src/extensions/sync.test.ts
@@ -50,7 +50,7 @@ describe('createSyncExtension', () => {
 			const ydoc = new Y.Doc({ guid: 'test-doc' });
 
 			const factory = createSyncExtension({
-				url: 'ws://localhost:8080/rooms/{id}/sync',
+				url: 'ws://localhost:8080/rooms/{id}',
 			});
 
 			const result = factory(
@@ -62,7 +62,7 @@ describe('createSyncExtension', () => {
 
 			// Reconnect with a different URL
 			result.exports.reconnect({
-				url: 'ws://cloud.example.com/rooms/test-doc/sync',
+				url: 'ws://cloud.example.com/rooms/test-doc',
 			});
 
 			// Old provider should be destroyed (offline)
@@ -81,7 +81,7 @@ describe('createSyncExtension', () => {
 			const ydoc = new Y.Doc({ guid: 'test-doc-getter' });
 
 			const factory = createSyncExtension({
-				url: 'ws://localhost:8080/rooms/{id}/sync',
+				url: 'ws://localhost:8080/rooms/{id}',
 			});
 
 			const result = factory(
@@ -90,11 +90,11 @@ describe('createSyncExtension', () => {
 
 			const firstProvider = result.exports.provider;
 			result.exports.reconnect({
-				url: 'ws://server-2/rooms/test-doc-getter/sync',
+				url: 'ws://server-2/rooms/test-doc-getter',
 			});
 			const secondProvider = result.exports.provider;
 			result.exports.reconnect({
-				url: 'ws://server-3/rooms/test-doc-getter/sync',
+				url: 'ws://server-3/rooms/test-doc-getter',
 			});
 			const thirdProvider = result.exports.provider;
 
@@ -113,14 +113,14 @@ describe('createSyncExtension', () => {
 			const ydoc = new Y.Doc({ guid: 'test-doc-destroy' });
 
 			const factory = createSyncExtension({
-				url: 'ws://localhost:8080/rooms/{id}/sync',
+				url: 'ws://localhost:8080/rooms/{id}',
 			});
 
 			const result = factory(
 				createMockClient(ydoc),
 			) as unknown as SyncExtensionResult;
 			result.exports.reconnect({
-				url: 'ws://cloud.example.com/rooms/test-doc-destroy/sync',
+				url: 'ws://cloud.example.com/rooms/test-doc-destroy',
 			});
 
 			const currentProvider = result.exports.provider;
@@ -135,7 +135,7 @@ describe('createSyncExtension', () => {
 		const ydoc = new Y.Doc({ guid: 'my-workspace' });
 
 		const factory = createSyncExtension({
-			url: 'ws://localhost:3913/rooms/{id}/sync',
+			url: 'ws://localhost:3913/rooms/{id}',
 		});
 
 		// The factory creates a provider with connect: false, so no actual connection
@@ -177,7 +177,7 @@ describe('createSyncExtension', () => {
 		});
 
 		const factory = createSyncExtension({
-			url: 'ws://localhost:8080/rooms/{id}/sync',
+			url: 'ws://localhost:8080/rooms/{id}',
 		});
 
 		const result = factory({

--- a/packages/epicenter/src/extensions/sync.ts
+++ b/packages/epicenter/src/extensions/sync.ts
@@ -18,7 +18,7 @@ import type { ExtensionFactory } from '../static/types';
  * createWorkspace(definition)
  *   .withExtension('persistence', indexeddbPersistence)
  *   .withExtension('sync', createSyncExtension({
- *     url: 'ws://localhost:3913/rooms/{id}/sync',
+ *     url: 'ws://localhost:3913/rooms/{id}',
  *   }))
  * ```
  *
@@ -27,7 +27,7 @@ import type { ExtensionFactory } from '../static/types';
  * createWorkspace(definition)
  *   .withExtension('persistence', indexeddbPersistence)
  *   .withExtension('sync', createSyncExtension({
- *     url: 'ws://my-server:3913/rooms/{id}/sync',
+ *     url: 'ws://my-server:3913/rooms/{id}',
  *     token: 'my-shared-secret',
  *   }))
  * ```
@@ -37,7 +37,7 @@ import type { ExtensionFactory } from '../static/types';
  * createWorkspace(definition)
  *   .withExtension('persistence', indexeddbPersistence)
  *   .withExtension('sync', createSyncExtension({
- *     url: 'wss://sync.epicenter.so/rooms/{id}/sync',
+ *     url: 'wss://sync.epicenter.so/rooms/{id}',
  *     getToken: async (workspaceId) => {
  *       const res = await fetch('/api/sync/token', {
  *         method: 'POST',
@@ -82,7 +82,7 @@ export type SyncExtensionConfig = {
  * createWorkspace(definition)
  *   .withExtension('persistence', indexeddbPersistence)
  *   .withExtension('sync', createSyncExtension({
- *     url: 'ws://localhost:3913/rooms/{id}/sync',
+ *     url: 'ws://localhost:3913/rooms/{id}',
  *   }))
  * ```
  */
@@ -134,7 +134,7 @@ export function createSyncExtension(
 				 * @example
 				 * ```typescript
 				 * workspace.extensions.sync.reconnect({
-				 *   url: 'wss://cloud.example.com/rooms/my-workspace/sync',
+				 *   url: 'wss://cloud.example.com/rooms/my-workspace',
 				 * });
 				 * ```
 				 */

--- a/packages/epicenter/src/extensions/sync/desktop.ts
+++ b/packages/epicenter/src/extensions/sync/desktop.ts
@@ -93,7 +93,7 @@ export const persistence = (
  *     filePath: join(epicenterDir, 'persistence', `${ctx.id}.yjs`),
  *   }))
  *   .withExtension('sync', createSyncExtension({
- *     url: 'ws://localhost:3913/rooms/{id}/sync',
+ *     url: 'ws://localhost:3913/rooms/{id}',
  *   }))
  * ```
  */

--- a/packages/epicenter/src/extensions/sync/web.ts
+++ b/packages/epicenter/src/extensions/sync/web.ts
@@ -20,7 +20,7 @@ import type * as Y from 'yjs';
  * createWorkspace(definition)
  *   .withExtension('persistence', indexeddbPersistence)
  *   .withExtension('sync', createSyncExtension({
- *     url: 'ws://localhost:3913/rooms/{id}/sync',
+ *     url: 'ws://localhost:3913/rooms/{id}',
  *   }))
  * ```
  *

--- a/packages/server/specs/20260220T223633 collapse-sync-routes.md
+++ b/packages/server/specs/20260220T223633 collapse-sync-routes.md
@@ -1,0 +1,160 @@
+# Collapse Sync Plugin Routes
+
+**Date**: 2026-02-20
+**Status**: Draft
+**Author**: AI-assisted
+
+## Overview
+
+Simplify the sync plugin's route structure from four routes with redundant path segments (`/:room/sync`, `/:room/doc`) to three routes on the canonical resource path (`/:room`). One resource, one URL.
+
+## Motivation
+
+### Current State
+
+The sync plugin registers four routes:
+
+```
+GET  /              → list rooms
+WS   /:room/sync    → real-time y-websocket protocol
+GET  /:room/doc     → document state as binary Yjs update
+POST /:room/doc     → apply binary Yjs update
+```
+
+When mounted at `/rooms` prefix (the default), the actual URLs are:
+
+```
+GET  /rooms/
+WS   /rooms/{id}/sync
+GET  /rooms/{id}/doc
+POST /rooms/{id}/doc
+```
+
+This creates problems:
+
+1. **Redundant path segments**: `/rooms/{id}/doc` says "the doc of the room" but the room IS the document. There's no other sub-resource. It's like `/users/{id}/user`.
+2. **Transport in the URL**: `/rooms/{id}/sync` names the protocol, not a resource. REST says URLs identify resources, not how you talk to them.
+3. **Same resource, two URLs**: The room has two different identifiers depending on whether you're using HTTP or WebSocket, violating the uniform interface constraint.
+
+### Desired State
+
+```
+GET  /              → list rooms
+WS   /:room         → real-time y-websocket protocol
+GET  /:room         → document state as binary Yjs update
+POST /:room         → apply binary Yjs update
+```
+
+Mounted at `/rooms`:
+
+```
+GET  /rooms/
+WS   /rooms/{id}
+GET  /rooms/{id}
+POST /rooms/{id}
+```
+
+One resource, one URL. WebSocket upgrade is distinguished by the `Upgrade: websocket` header per RFC 6455 -- it doesn't collide with HTTP GET/POST.
+
+## Design Decisions
+
+| Decision                           | Choice       | Rationale                                                                                                                          |
+| ---------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Collapse `/:room/doc` to `/:room`  | Yes          | The room IS the document. No sub-resource exists.                                                                                  |
+| Collapse `/:room/sync` to `/:room` | Yes          | WS upgrade is a protocol-level concern, not a resource. RFC 6455 distinguishes via `Upgrade` header.                               |
+| Keep `GET /` for room listing      | Yes          | Collection resource at the root is standard REST. No change needed.                                                                |
+| Elysia WS + HTTP on same path      | Verify first | Need to confirm Elysia/Bun can route both `.ws('/:room')` and `.get('/:room')` without collision. This is the only technical risk. |
+
+## Implementation Plan
+
+### Phase 0: Verify Elysia Can Handle WS + HTTP on Same Path
+
+- [ ] **0.1** Write a minimal Elysia test that registers `.ws('/:room')` and `.get('/:room')` on the same path, confirm HTTP GET and WS upgrade both work without collision.
+
+If this fails, fallback plan: keep WS at `/:room` and HTTP at `/:room` but with different Elysia route registration order, or worst case keep `/:room/ws` (transport label, not resource duplication).
+
+### Phase 1: Update the Plugin Route Definitions
+
+- [ ] **1.1** In `packages/server/src/sync/plugin.ts`: change `.ws('/:room/sync', ...)` to `.ws('/:room', ...)`
+- [ ] **1.2** In `packages/server/src/sync/plugin.ts`: change `.get('/:room/doc', ...)` to `.get('/:room', ...)`
+- [ ] **1.3** In `packages/server/src/sync/plugin.ts`: change `.post('/:room/doc', ...)` to `.post('/:room', ...)`
+- [ ] **1.4** Update the JSDoc route table in `createSyncPlugin` to reflect new routes
+
+### Phase 2: Update Tests
+
+- [ ] **2.1** In `packages/server/src/sync/plugin.test.ts`: update `wsUrl()` helper from `/rooms/${room}/sync` to `/rooms/${room}`
+- [ ] **2.2** In `packages/server/src/sync/plugin.test.ts`: update all `httpUrl('/rooms/${room}/doc')` calls to `httpUrl('/rooms/${room}')`
+- [ ] **2.3** In `packages/server/src/sync/plugin.test.ts`: update `startIntegratedTestServer` `wsUrl()` from `/${room}/sync` to `/${room}`
+- [ ] **2.4** In `packages/server/src/sync/plugin.test.ts`: update integrated mode `httpUrl('/${room}/doc')` to `httpUrl('/${room}')`
+- [ ] **2.5** Run tests, confirm all pass
+
+### Phase 3: Update Server + Standalone Wrappers
+
+- [ ] **3.1** In `packages/server/src/server.ts`: update JSDoc URL references
+- [ ] **3.2** In `packages/server/src/sync/server.ts`: update JSDoc URL references
+- [ ] **3.3** In `packages/server/src/start.ts`: update console.log URL and JSDoc comment
+
+### Phase 4: Update Client-Side Consumers
+
+- [ ] **4.1** In `packages/epicenter/src/extensions/sync.ts`: update all `url` examples from `/rooms/{id}/sync` to `/rooms/{id}`
+- [ ] **4.2** In `packages/epicenter/src/extensions/sync/web.ts`: update URL examples
+- [ ] **4.3** In `packages/epicenter/src/extensions/sync/desktop.ts`: update URL examples
+- [ ] **4.4** In `packages/epicenter/src/extensions/sync.test.ts`: update all URL strings from `/rooms/{id}/sync` to `/rooms/{id}`
+- [ ] **4.5** In `packages/sync/src/provider.ts`: update JSDoc URL examples
+- [ ] **4.6** In `apps/tab-manager/src/entrypoints/background.ts`: update URL string
+- [ ] **4.7** In `apps/tab-manager/src/lib/workspace-popup.ts`: update URL string
+
+### Phase 5: Update Documentation
+
+- [ ] **5.1** In `packages/server/README.md`: update all route tables, URL examples, URL hierarchy
+- [ ] **5.2** In `packages/sync/README.md`: update URL examples and relationship diagram
+- [ ] **5.3** In `packages/epicenter/README.md`: update sync URL examples throughout
+
+### Phase 6: Final Verification
+
+- [ ] **6.1** Run full test suite for `@epicenter/server`
+- [ ] **6.2** Grep for any remaining `/sync` or `/doc` path references that were missed
+- [ ] **6.3** Run build to confirm no breakage
+
+## Edge Cases
+
+### Elysia Route Collision
+
+1. Register both `.ws('/:room')` and `.get('/:room')` on same Elysia instance
+2. Elysia may not support this natively
+3. If collision: fallback to `.ws('/:room/ws')` -- still better than `/sync` since `ws` describes transport, and the HTTP routes would still be on `/:room`
+
+### Reverse Proxy Confusion
+
+1. Some reverse proxies (nginx, Cloudflare) may need explicit WebSocket upgrade configuration
+2. This is already the case with `/sync` -- moving to `/:room` doesn't change the requirement
+3. No new edge case introduced
+
+## Open Questions
+
+1. **Does Elysia support WS and HTTP GET on the same path?**
+   - This is the gating question. Phase 0 answers it.
+   - **Recommendation**: Spike it first. If it fails, fall back to `/:room/ws` for WS only.
+
+## Success Criteria
+
+- [ ] All four routes work at their new paths
+- [ ] All existing tests pass with updated URLs
+- [ ] No remaining references to `/:room/sync` or `/:room/doc` in codebase
+- [ ] JSDoc and README documentation reflects new routes
+
+## References
+
+- `packages/server/src/sync/plugin.ts` -- route definitions (the core change)
+- `packages/server/src/sync/plugin.test.ts` -- integration tests (largest file to update)
+- `packages/server/src/sync/server.ts` -- standalone server wrapper
+- `packages/server/src/server.ts` -- full server compositor
+- `packages/server/src/start.ts` -- CLI entry point
+- `packages/epicenter/src/extensions/sync.ts` -- client-side sync extension
+- `packages/epicenter/src/extensions/sync.test.ts` -- client-side tests
+- `packages/sync/src/provider.ts` -- raw sync provider
+- `apps/tab-manager/src/entrypoints/background.ts` -- app consumer
+- `apps/tab-manager/src/lib/workspace-popup.ts` -- app consumer
+- `packages/server/README.md` -- server docs
+- `packages/sync/README.md` -- sync client docs
+- `packages/epicenter/README.md` -- epicenter docs

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -29,7 +29,7 @@ export type ServerOptions = {
  * - `/openapi/json` - OpenAPI specification
  * - `/workspaces/{id}/tables/{table}` - RESTful table CRUD endpoints
  * - `/workspaces/{id}/actions/{action}` - Workspace action endpoints (queries via GET, mutations via POST)
- * - `/rooms/{id}/sync` - WebSocket sync endpoint (y-websocket protocol)
+ * - `/rooms/{id}` - WebSocket sync + REST document state (GET/POST)
  *
  * @example
  * ```typescript

--- a/packages/server/src/start.ts
+++ b/packages/server/src/start.ts
@@ -9,7 +9,7 @@
  *   bun run --filter @epicenter/server start
  *
  * Clients connect to:
- *   ws://localhost:3913/rooms/{room}/sync
+ *   ws://localhost:3913/rooms/{room}
  */
 
 import { createSyncServer } from './sync';
@@ -25,7 +25,7 @@ const server = createSyncServer({
 server.start();
 
 console.log(`Epicenter sync server running on http://localhost:${port}`);
-console.log(`WebSocket: ws://localhost:${port}/rooms/{room}/sync`);
+console.log(`WebSocket: ws://localhost:${port}/rooms/{room}`);
 
 // Graceful shutdown
 process.on('SIGINT', async () => {

--- a/packages/server/src/sync/plugin.test.ts
+++ b/packages/server/src/sync/plugin.test.ts
@@ -48,7 +48,7 @@ function startTestServer(config?: SyncServerConfig) {
 		server,
 		port,
 		wsUrl(room: string) {
-			return `ws://localhost:${port}/rooms/${room}/sync`;
+			return `ws://localhost:${port}/rooms/${room}`;
 		},
 		httpUrl(path = '/') {
 			const actualPath = path === '/' ? '/rooms/health' : path;
@@ -73,7 +73,7 @@ function startIntegratedTestServer({
 		app,
 		port,
 		wsUrl(room: string) {
-			return `ws://localhost:${port}/${room}/sync`;
+			return `ws://localhost:${port}/${room}`;
 		},
 		httpUrl(path = '/') {
 			return `http://localhost:${port}${path}`;
@@ -473,7 +473,7 @@ describe('sync plugin REST document snapshot', () => {
 
 		try {
 			const room = uniqueRoom();
-			const res = await fetch(ctx.httpUrl(`/rooms/${room}/doc`));
+			const res = await fetch(ctx.httpUrl(`/rooms/${room}`));
 			expect(res.status).toBe(404);
 			expect(await res.json()).toEqual({ error: `Room not found: ${room}` });
 		} finally {
@@ -498,7 +498,7 @@ describe('sync plugin REST document snapshot', () => {
 			expect(provider.hasLocalChanges).toBe(true);
 			await waitForLocalChanges(provider, false);
 
-			const res = await fetch(ctx.httpUrl(`/rooms/${room}/doc`));
+			const res = await fetch(ctx.httpUrl(`/rooms/${room}`));
 			expect(res.status).toBe(200);
 			expect(res.headers.get('content-type')).toContain(
 				'application/octet-stream',
@@ -527,7 +527,7 @@ describe('sync plugin REST document update', () => {
 			sourceDoc.getMap('data').set('seed', 'from-rest');
 			const update = Y.encodeStateAsUpdate(sourceDoc);
 
-			const postRes = await fetch(ctx.httpUrl(`/rooms/${room}/doc`), {
+			const postRes = await fetch(ctx.httpUrl(`/rooms/${room}`), {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/octet-stream' },
 				body: toArrayBuffer(update),
@@ -556,7 +556,7 @@ describe('sync plugin REST document update', () => {
 		const room = uniqueRoom();
 
 		try {
-			const res = await fetch(ctx.httpUrl(`/rooms/${room}/doc`), {
+			const res = await fetch(ctx.httpUrl(`/rooms/${room}`), {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/octet-stream' },
 				body: new ArrayBuffer(0),
@@ -578,7 +578,7 @@ describe('sync plugin REST document update', () => {
 			sourceDoc.getMap('data').set('ignored', 'value');
 			const update = Y.encodeStateAsUpdate(sourceDoc);
 
-			const res = await fetch(ctx.httpUrl(`/${room}/doc`), {
+			const res = await fetch(ctx.httpUrl(`/${room}`), {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/octet-stream' },
 				body: toArrayBuffer(update),
@@ -628,7 +628,7 @@ describe('sync plugin REST auth', () => {
 			sourceDoc.getMap('data').set('k', 'v');
 			const update = Y.encodeStateAsUpdate(sourceDoc);
 
-			const postRes = await fetch(ctx.httpUrl(`/rooms/${room}/doc`), {
+			const postRes = await fetch(ctx.httpUrl(`/rooms/${room}`), {
 				method: 'POST',
 				headers: {
 					Authorization: 'Bearer secret',

--- a/packages/server/src/sync/plugin.ts
+++ b/packages/server/src/sync/plugin.ts
@@ -63,12 +63,12 @@ export type SyncPluginConfig = {
  *
  * Registers four routes:
  *
- * | Method | Route          | Description                                |
- * | ------ | -------------- | ------------------------------------------ |
- * | `GET`  | `/`            | List active rooms with connection counts   |
- * | `WS`   | `/:room/sync`  | Real-time y-websocket protocol             |
- * | `GET`  | `/:room/doc`   | Full document state as binary Yjs update   |
- * | `POST` | `/:room/doc`   | Apply a binary Yjs update to the document  |
+ * | Method | Route    | Description                                |
+ * | ------ | -------- | ------------------------------------------ |
+ * | `GET`  | `/`      | List active rooms with connection counts   |
+ * | `WS`   | `/:room` | Real-time y-websocket protocol             |
+ * | `GET`  | `/:room` | Full document state as binary Yjs update   |
+ * | `POST` | `/:room` | Apply a binary Yjs update to the document  |
  *
  * **Auth**: WebSocket uses `?token=` query param (browser WS API cannot set
  * headers). REST routes use `Authorization: Bearer` header.
@@ -95,7 +95,7 @@ export type SyncPluginConfig = {
  *   .listen(3913);
  *
  * // REST document access
- * const state = await fetch('http://localhost:3913/rooms/my-room/doc', {
+ * const state = await fetch('http://localhost:3913/rooms/my-room', {
  *   headers: { Authorization: 'Bearer my-secret' },
  * });
  * ```
@@ -152,7 +152,7 @@ export function createSyncPlugin(config?: SyncPluginConfig) {
 		.use(
 			restAuth
 				.get('/', () => ({ rooms: roomManager.roomInfo() }))
-				.get('/:room/doc', ({ params, set }) => {
+				.get('/:room', ({ params, set }) => {
 					const doc = roomManager.getDoc(params.room);
 					if (!doc) {
 						set.status = 404;
@@ -161,7 +161,7 @@ export function createSyncPlugin(config?: SyncPluginConfig) {
 					set.headers['content-type'] = 'application/octet-stream';
 					return Y.encodeStateAsUpdate(doc);
 				})
-				.post('/:room/doc', async ({ params, request, set }) => {
+				.post('/:room', async ({ params, request, set }) => {
 					const doc = roomManager.getOrCreateDoc(params.room);
 					if (!doc) {
 						set.status = 404;
@@ -191,7 +191,7 @@ export function createSyncPlugin(config?: SyncPluginConfig) {
 					return { ok: true };
 				}),
 		)
-		.ws('/:room/sync', {
+		.ws('/:room', {
 			query: t.Object({
 				token: t.Optional(t.String()),
 			}),

--- a/packages/server/src/sync/server.ts
+++ b/packages/server/src/sync/server.ts
@@ -15,7 +15,7 @@ export type SyncServerConfig = {
  *
  * Rooms are created on demand when clients connect. No workspace schemas needed.
  * Mounts the sync plugin under `/rooms` so the WebSocket URL matches
- * `createServer`: `ws://host:port/rooms/{room}/sync`.
+ * `createServer`: `ws://host:port/rooms/{room}`.
  *
  * Includes a health/status endpoint at `GET /`.
  *
@@ -25,7 +25,7 @@ export type SyncServerConfig = {
  *
  * // Zero-config relay
  * createSyncServer().start();
- * // Clients connect to: ws://localhost:3913/rooms/{room}/sync
+ * // Clients connect to: ws://localhost:3913/rooms/{room}
  *
  * // With auth
  * createSyncServer({ port: 3913, auth: { token: 'my-secret' } }).start();

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -20,7 +20,7 @@ const doc = new Y.Doc();
 
 const provider = createSyncProvider({
 	doc,
-	url: 'ws://localhost:3913/rooms/my-workspace/sync',
+	url: 'ws://localhost:3913/rooms/my-workspace',
 });
 
 // Provider connects automatically. Check status:
@@ -48,7 +48,7 @@ For localhost, Tailscale, LAN, or development:
 ```typescript
 const provider = createSyncProvider({
 	doc,
-	url: 'ws://localhost:3913/rooms/blog/sync',
+	url: 'ws://localhost:3913/rooms/blog',
 });
 ```
 
@@ -59,7 +59,7 @@ A shared secret passed as a query parameter:
 ```typescript
 const provider = createSyncProvider({
 	doc,
-	url: 'ws://my-server:3913/rooms/blog/sync',
+	url: 'ws://my-server:3913/rooms/blog',
 	token: 'my-shared-secret',
 });
 ```
@@ -71,7 +71,7 @@ A function that fetches a fresh token on each connect/reconnect. Useful for JWTs
 ```typescript
 const provider = createSyncProvider({
 	doc,
-	url: 'wss://sync.epicenter.so/rooms/blog/sync',
+	url: 'wss://sync.epicenter.so/rooms/blog',
 	getToken: async () => {
 		const res = await fetch('/api/sync/token');
 		return (await res.json()).token;
@@ -198,5 +198,5 @@ This eliminates the race conditions common in event-driven WebSocket reconnectio
 ```
 
 - **`@epicenter/sync`** (this package): Raw sync provider. Connects a Y.Doc to a WebSocket.
-- **`@epicenter/server`**: The server that this provider connects to. Exposes `ws://host:port/rooms/{id}/sync`.
+- **`@epicenter/server`**: The server that this provider connects to. Exposes `ws://host:port/rooms/{id}`.
 - **`@epicenter/hq/extensions/sync`**: Workspace extension wrapper. Most consumers use this instead of the raw provider.

--- a/packages/sync/src/provider.ts
+++ b/packages/sync/src/provider.ts
@@ -64,7 +64,7 @@ const HEARTBEAT_TIMEOUT_MS = 3_000;
  * ```typescript
  * const provider = createSyncProvider({
  *   doc: myDoc,
- *   url: 'ws://localhost:3913/rooms/blog/sync',
+ *   url: 'ws://localhost:3913/rooms/blog',
  * });
  * ```
  *
@@ -72,7 +72,7 @@ const HEARTBEAT_TIMEOUT_MS = 3_000;
  * ```typescript
  * const provider = createSyncProvider({
  *   doc: myDoc,
- *   url: 'ws://my-server:3913/rooms/blog/sync',
+ *   url: 'ws://my-server:3913/rooms/blog',
  *   token: 'my-shared-secret',
  * });
  * ```
@@ -81,7 +81,7 @@ const HEARTBEAT_TIMEOUT_MS = 3_000;
  * ```typescript
  * const provider = createSyncProvider({
  *   doc: myDoc,
- *   url: 'wss://sync.epicenter.so/rooms/blog/sync',
+ *   url: 'wss://sync.epicenter.so/rooms/blog',
  *   getToken: async () => {
  *     const res = await fetch('/api/sync/token');
  *     return (await res.json()).token;


### PR DESCRIPTION
The sync plugin had three sub-paths for what is fundamentally one resource — a room:

```
WS   /rooms/{id}/sync    →  /rooms/{id}
GET  /rooms/{id}/doc     →  /rooms/{id}
POST /rooms/{id}/doc     →  /rooms/{id}
```

`/rooms/{id}/doc` says "the doc of the room" but the room IS the document — there's no other sub-resource. `/rooms/{id}/sync` names the protocol, not a resource. REST says URLs identify resources, not how you talk to them.

WebSocket upgrades are distinguished by the `Upgrade: websocket` header per RFC 6455. They don't collide with HTTP GET/POST on the same path. Verified this works in Elysia with a spike test before making the change.

```
Before                              After
──────                              ─────
GET  /rooms/                        GET  /rooms/           (unchanged)
WS   /rooms/{id}/sync               WS   /rooms/{id}
GET  /rooms/{id}/doc                GET  /rooms/{id}
POST /rooms/{id}/doc                POST /rooms/{id}
```

One resource, one URL. The change is mechanical — route registrations in `plugin.ts` plus string replacements across tests, JSDoc, README files, and client-side URL configs. All 30 tests pass (24 server integration + 6 extension unit).