### PR TITLE
refactor(tab-manager): replace alarms keepalive with offscreen document

### DIFF
--- a/apps/tab-manager/src/entrypoints/offscreen.html
+++ b/apps/tab-manager/src/entrypoints/offscreen.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+	<head>
+		<title>Offscreen</title>
+	</head>
+	<body>
+		<script>
+			setInterval(() => {
+				chrome.runtime.sendMessage({ type: 'keepalive' });
+			}, 20_000);
+		</script>
+	</body>
+</html>

--- a/apps/tab-manager/wxt.config.ts
+++ b/apps/tab-manager/wxt.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
 	manifest: {
 		name: 'Tab Manager',
 		description: 'Manage browser tabs with Epicenter',
-		permissions: ['tabs', 'storage'],
+		permissions: ['tabs', 'storage', 'offscreen'],
 		// host_permissions needed for favicons and tab info
 		host_permissions: ['<all_urls>'],
 	},


### PR DESCRIPTION
Chrome's Alarms API has a minimum interval of 30 seconds (`periodInMinutes` floors to 0.5), which is exactly the threshold where MV3 service workers go dormant. This created a race condition — the alarm might fire just barely too late, and the service worker would sleep, dropping the WebSocket connection mid-sync.

An offscreen document sidesteps this entirely. It's a lightweight HTML page that lives outside the service worker lifecycle and sends `runtime.sendMessage` every 20 seconds — well under the dormancy threshold:

```
┌─────────────────────────┐     runtime.sendMessage      ┌───────────────────────┐
│   offscreen.html        │ ──── { type: 'keepalive' } ──→  background.ts        │
│   setInterval(20_000)   │          every 20s            │   (service worker)    │
└─────────────────────────┘                               └───────────────────────┘
```

The message listener in the background script is a no-op — receiving the message is sufficient to reset Chrome's inactivity timer. The offscreen document is created on startup and re-ensured on `runtime.onStartup` in case Chrome reclaims it.

This also drops the `alarms` permission in favor of `offscreen`, which is a narrower capability.