### PR TITLE
feat(tab-manager): add AI chat tab with streaming LLM support

### DIFF
--- a/.agents/skills/elysia/SKILL.md
+++ b/.agents/skills/elysia/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: elysia
+description: Elysia.js server patterns for error handling, status responses, and plugin composition. Use when writing Elysia route handlers, returning HTTP errors, creating plugins, or working with Eden Treaty type safety.
+metadata:
+  author: epicenter
+  version: '1.0'
+---
+
+# Elysia.js Patterns (v1.2+)
+
+## The `status()` Helper (ALWAYS use this)
+
+**Never use `set.status` + return object.** Always destructure `status` from the handler context and use it for all non-200 responses. This gives you:
+
+- Typesafe string literals with full IntelliSense (e.g. `"Bad Request"` instead of `400`)
+- Automatic response type inference per status code
+- Eden Treaty end-to-end type safety on error responses
+
+### Basic Usage
+
+```typescript
+import { Elysia, t } from 'elysia';
+
+new Elysia().post(
+	'/chat',
+	async ({ body, headers, status }) => {
+		//                       ^^^^^^ destructure status from context
+
+		if (!isValid(body.provider)) {
+			// Use string literal for self-documenting, typesafe status codes
+			return status('Bad Request', 'Unsupported provider');
+		}
+
+		if (!apiKey) {
+			return status('Unauthorized', 'Missing API key');
+		}
+
+		return doWork(body);
+	},
+	{
+		// Define response schemas per status code for full type safety
+		response: {
+			200: t.Any(),
+			400: t.String(),
+			401: t.String(),
+		},
+	},
+);
+```
+
+### `return status()` vs `throw status()`
+
+Both work. The framework handles either. The difference is purely control flow:
+
+| Pattern              | Behavior                                      | Use when                                                               |
+| -------------------- | --------------------------------------------- | ---------------------------------------------------------------------- |
+| `return status(...)` | Normal return, continues to response pipeline | You're at a natural return point (validation guards, end of handler)   |
+| `throw status(...)`  | Short-circuits execution immediately          | You're deep in nested logic or inside a try/catch and want to bail out |
+
+**This codebase convention: prefer `return status(...)`.** It matches the existing early-return-on-error pattern used everywhere else (see `error-handling` skill). Reserve `throw status(...)` for catch blocks or deeply nested code where `return` would be awkward.
+
+```typescript
+// GOOD: return for validation guards (matches codebase style)
+async ({ body, status }) => {
+	if (!isValid(body.provider)) {
+		return status('Bad Request', `Unsupported provider: ${body.provider}`);
+	}
+
+	const apiKey = resolveApiKey(body.provider, headerApiKey);
+	if (!apiKey) {
+		return status('Unauthorized', 'Missing API key');
+	}
+
+	// happy path
+	return doWork(body);
+};
+
+// GOOD: throw inside catch blocks
+async ({ body, status }) => {
+	try {
+		return await streamResponse(body);
+	} catch (error) {
+		if (isAbortError(error)) {
+			throw status(499, 'Client closed request');
+		}
+		throw status('Bad Gateway', `Provider error: ${error.message}`);
+	}
+};
+```
+
+### Type inference is identical for both
+
+Both `return status(...)` and `throw status(...)` produce the same `ElysiaCustomStatusResponse` object. Elysia's type system infers response types from the `response` schema in route options, not from how you invoke `status()`. Eden Treaty type safety works equally with either approach.
+
+## Available String Status Codes (StatusMap)
+
+Use these string literals instead of numeric codes for better readability:
+
+| String Literal            | Code | Common Use                                 |
+| ------------------------- | ---- | ------------------------------------------ |
+| `'Bad Request'`           | 400  | Validation failures, malformed input       |
+| `'Unauthorized'`          | 401  | Missing/invalid auth credentials           |
+| `'Forbidden'`             | 403  | Valid auth but insufficient permissions    |
+| `'Not Found'`             | 404  | Resource doesn't exist                     |
+| `'Conflict'`              | 409  | State conflict (duplicate, already exists) |
+| `'Unprocessable Content'` | 422  | Semantically invalid input                 |
+| `'Too Many Requests'`     | 429  | Rate limiting                              |
+| `'Internal Server Error'` | 500  | Unexpected server failure                  |
+| `'Bad Gateway'`           | 502  | Upstream provider error                    |
+| `'Service Unavailable'`   | 503  | Temporary overload/maintenance             |
+
+For non-standard codes (e.g. nginx's 499), use the numeric literal directly: `status(499, 'Client closed request')`.
+
+## Response Schemas for Eden Treaty Type Safety
+
+Define `response` schemas per status code in route options. This is what makes Eden Treaty infer error types on the client:
+
+```typescript
+new Elysia().post(
+	'/chat',
+	async ({ body, status }) => {
+		if (!isValid(body.provider)) {
+			return status('Bad Request', `Unsupported provider: ${body.provider}`);
+		}
+		return streamResult;
+	},
+	{
+		body: t.Object({
+			provider: t.String(),
+			model: t.String(),
+		}),
+		response: {
+			200: t.Any(), // Success type
+			400: t.String(), // Bad Request body type
+			401: t.String(), // Unauthorized body type
+			502: t.String(), // Bad Gateway body type
+		},
+	},
+);
+```
+
+Eden Treaty then infers:
+
+```typescript
+const { data, error } = await api.chat.post({
+	provider: 'openai',
+	model: 'gpt-4',
+});
+
+if (error) {
+	// error.status is typed as 400 | 401 | 502
+	// error.value is typed per status code (string in this case)
+	switch (error.status) {
+		case 400: // error.value: string
+		case 401: // error.value: string
+		case 502: // error.value: string
+	}
+}
+```
+
+## Error Response Body: Strings vs Objects
+
+**Prefer plain strings as error bodies.** The status code already communicates the error class. A descriptive string message is sufficient and keeps the API simple.
+
+```typescript
+// GOOD: Plain string - status code provides the category
+return status('Bad Request', `Unsupported provider: ${provider}`);
+return status('Unauthorized', 'Missing API key: set x-provider-api-key header');
+
+// AVOID: Wrapping in { error: "..." } object - redundant with status code
+set.status = 400;
+return { error: `Unsupported provider: ${provider}` };
+```
+
+If you need structured error bodies (multiple fields, error codes, validation details), define a TypeBox schema:
+
+```typescript
+const ErrorBody = t.Object({
+  message: t.String(),
+  code: t.Optional(t.String()),
+});
+
+// In route options:
+response: {
+  400: ErrorBody,
+  401: ErrorBody,
+}
+```
+
+## Plugin Composition
+
+Elysia plugins are just functions that return Elysia instances. Use `new Elysia()` inside the plugin, not `new Elysia({ prefix })` — let the consumer control mounting:
+
+```typescript
+// GOOD: Plugin is prefix-agnostic
+export function createMyPlugin() {
+	return new Elysia().post('/endpoint', async ({ body, status }) => {
+		// ...
+	});
+}
+
+// Consumer controls the prefix
+app.use(new Elysia({ prefix: '/api' }).use(createMyPlugin()));
+```
+
+## Guards for Shared Auth
+
+Use `.guard()` with `beforeHandle` for auth that applies to multiple routes:
+
+```typescript
+const authed = new Elysia().guard({
+	async beforeHandle({ headers, status }) {
+		const token = extractBearerToken(headers.authorization);
+		if (!isValid(token)) {
+			return status('Unauthorized', 'Invalid or missing token');
+		}
+	},
+});
+
+// All routes under this guard require auth
+return authed
+	.get('/protected', () => 'secret')
+	.post('/admin', () => 'admin stuff');
+```
+
+## Migration Checklist: `set.status` to `status()`
+
+When updating existing handlers:
+
+1. Replace `set` with `status` in the handler destructuring
+2. Replace `set.status = N; return { error: msg };` with `return status('String Literal', msg);`
+3. In catch blocks, use `throw status(...)` instead of `set.status = N; return { error: msg };`
+4. Add `response` schemas to route options for Eden Treaty type inference
+5. Keep `set` in the destructuring ONLY if you still need `set.headers` for things like `content-type`
+
+```typescript
+// BEFORE
+async ({ body, headers, set }) => {
+	if (!valid) {
+		set.status = 400;
+		return { error: 'Bad input' };
+	}
+};
+
+// AFTER
+async ({ body, headers, status }) => {
+	if (!valid) {
+		return status('Bad Request', 'Bad input');
+	}
+};
+
+// AFTER (when you also need set.headers)
+async ({ body, headers, set, status }) => {
+	if (!valid) {
+		return status('Bad Request', 'Bad input');
+	}
+	set.headers['content-type'] = 'application/octet-stream';
+	return binaryData;
+};
+```

--- a/apps/tab-manager/package.json
+++ b/apps/tab-manager/package.json
@@ -20,6 +20,8 @@
 		"@epicenter/hq": "workspace:*",
 		"@epicenter/ui": "workspace:*",
 		"@lucide/svelte": "catalog:",
+		"@tanstack/ai": "^0.5.1",
+		"@tanstack/ai-svelte": "^0.5.4",
 		"@wxt-dev/storage": "^1.2.6",
 		"arktype": "catalog:",
 		"clsx": "catalog:",

--- a/apps/tab-manager/src/entrypoints/sidepanel/App.svelte
+++ b/apps/tab-manager/src/entrypoints/sidepanel/App.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import AiChat from '$lib/components/AiChat.svelte';
 	import FlatTabList from '$lib/components/FlatTabList.svelte';
 	import SavedTabList from '$lib/components/SavedTabList.svelte';
 	import { browserState } from '$lib/state/browser-state.svelte';
@@ -6,6 +7,7 @@
 	import { Badge } from '@epicenter/ui/badge';
 	import * as Tabs from '@epicenter/ui/tabs';
 	import * as Tooltip from '@epicenter/ui/tooltip';
+	import SparklesIcon from '@lucide/svelte/icons/sparkles';
 
 	const totalTabs = $derived(
 		browserState.windows.reduce(
@@ -37,6 +39,10 @@
 							</Badge>
 						{/if}
 					</Tabs.Trigger>
+					<Tabs.Trigger value="ai" class="flex-1 gap-1.5">
+						<SparklesIcon class="size-3.5" />
+						AI
+					</Tabs.Trigger>
 				</Tabs.List>
 			</header>
 			<!-- Gate on browser state seed so child components can read data synchronously -->
@@ -52,6 +58,9 @@
 					<SavedTabList />
 				</Tabs.Content>
 			{/await}
+			<Tabs.Content value="ai" class="flex-1 min-h-0 mt-0">
+				<AiChat />
+			</Tabs.Content>
 		</Tabs.Root>
 	</main>
 </Tooltip.Provider>

--- a/apps/tab-manager/src/lib/state/ai-chat-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/ai-chat-state.svelte.ts
@@ -1,0 +1,242 @@
+/**
+ * Reactive AI chat state for the sidepanel.
+ *
+ * Manages a TanStack AI chat connection with SSE streaming, backed by
+ * Y.Doc persistence for message history. Uses a unidirectional persistence
+ * model: write to Y.Doc on send/complete, read from Y.Doc on panel open.
+ *
+ * The TanStack AI `createChat` provides reactive Svelte 5 state via runes —
+ * `.messages`, `.isLoading`, `.error` are all reactive getters that update
+ * automatically as streaming progresses.
+ *
+ * @example
+ * ```svelte
+ * <script>
+ *   import { aiChatState } from '$lib/state/ai-chat-state.svelte';
+ * </script>
+ *
+ * {#each aiChatState.messages as message (message.id)}
+ *   <ChatBubble {message} />
+ * {/each}
+ * ```
+ */
+
+import { generateId } from '@epicenter/hq';
+import {
+	createChat,
+	fetchServerSentEvents,
+	type UIMessage,
+} from '@tanstack/ai-svelte';
+import { getServerUrl } from '$lib/state/settings';
+import { popupWorkspace } from '$lib/workspace-popup';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Provider / Model Configuration
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Curated model list per provider.
+ *
+ * Only includes models that are generally available and well-tested.
+ * This is intentionally static — no runtime fetching of model lists.
+ */
+const PROVIDER_MODELS: Record<string, string[]> = {
+	openai: ['gpt-4o', 'gpt-4o-mini', 'o3-mini'],
+	anthropic: ['claude-sonnet-4-20250514', 'claude-haiku-4-20250414'],
+	gemini: ['gemini-2.0-flash', 'gemini-2.5-pro'],
+	ollama: ['llama3', 'mistral', 'codellama'],
+	grok: ['grok-2', 'grok-2-mini'],
+};
+
+const AVAILABLE_PROVIDERS = Object.keys(PROVIDER_MODELS);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Server URL Cache
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Cached server URL for synchronous access.
+ *
+ * `fetchServerSentEvents` requires a synchronous URL getter (`string | (() => string)`).
+ * We initialize with the default and update asynchronously from settings.
+ * For 99% of users the default never changes.
+ */
+let serverUrlCache = 'http://127.0.0.1:3913';
+void getServerUrl().then((url) => {
+	serverUrlCache = url;
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// State Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+function createAiChatState() {
+	// Reactive state for provider/model selection
+	let provider = $state('openai');
+	let model = $state('gpt-4o-mini');
+
+	// Default conversation ID for v1 (single conversation)
+	const conversationId = generateId();
+
+	// ── Y.Doc Persistence: Read existing messages on init ──────────────
+
+	/**
+	 * Load persisted messages for the active conversation from Y.Doc.
+	 *
+	 * This is the "read on open" part of unidirectional persistence.
+	 * Called once at init to seed `initialMessages` in `createChat`.
+	 */
+	const loadPersistedMessages = () => {
+		const rows = popupWorkspace.tables.chatMessages
+			.getAllValid()
+			.filter((m) => m.conversationId === conversationId)
+			.sort((a, b) => a.createdAt - b.createdAt);
+
+		return rows.map(
+			(row) =>
+				({
+					id: row.id,
+					role: row.role,
+					parts: row.parts,
+					createdAt: new Date(row.createdAt),
+				}) as UIMessage,
+		);
+	};
+
+	// ── TanStack AI Chat Connection ───────────────────────────────────
+
+	/**
+	 * The core chat instance from `@tanstack/ai-svelte`.
+	 *
+	 * - `connection`: SSE adapter pointing at the server's `/ai/chat` endpoint.
+	 *   The URL getter is synchronous (reads from cache). The options callback
+	 *   is async and injects the current provider/model as body params.
+	 * - `initialMessages`: Seeded from Y.Doc on panel open.
+	 * - `onFinish`: Writes the completed assistant message to Y.Doc.
+	 */
+	const chatInstance = createChat({
+		initialMessages: loadPersistedMessages(),
+		connection: fetchServerSentEvents(
+			() => `${serverUrlCache}/ai/chat`,
+			async () => ({
+				body: {
+					provider,
+					model,
+				},
+			}),
+		),
+		onFinish: (message) => {
+			// Write assistant message to Y.Doc on stream complete
+			popupWorkspace.tables.chatMessages.set({
+				id: message.id,
+				conversationId,
+				role: 'assistant',
+				parts: message.parts,
+				createdAt: message.createdAt?.getTime() ?? Date.now(),
+				_v: 1,
+			});
+		},
+	});
+
+	return {
+		/** The current list of chat messages (reactive via Svelte 5 runes). */
+		get messages() {
+			return chatInstance.messages;
+		},
+
+		/** Whether a response is currently streaming. */
+		get isLoading() {
+			return chatInstance.isLoading;
+		},
+
+		/** The latest error from the chat connection, if any. */
+		get error() {
+			return chatInstance.error;
+		},
+
+		/** The active conversation ID. */
+		get conversationId() {
+			return conversationId;
+		},
+
+		/** Current provider name. */
+		get provider() {
+			return provider;
+		},
+		set provider(value: string) {
+			provider = value;
+			// Auto-select first model for new provider
+			const models = PROVIDER_MODELS[value];
+			if (models?.[0]) {
+				model = models[0];
+			}
+		},
+
+		/** Current model name. */
+		get model() {
+			return model;
+		},
+		set model(value: string) {
+			model = value;
+		},
+
+		/** List of available provider names. */
+		get availableProviders() {
+			return AVAILABLE_PROVIDERS;
+		},
+
+		/**
+		 * Get the curated model list for a given provider.
+		 *
+		 * @example
+		 * ```typescript
+		 * aiChatState.modelsForProvider('openai')
+		 * // → ['gpt-4o', 'gpt-4o-mini', 'o3-mini']
+		 * ```
+		 */
+		modelsForProvider(providerName: string): string[] {
+			return PROVIDER_MODELS[providerName] ?? [];
+		},
+
+		/**
+		 * Send a user message and begin streaming the assistant response.
+		 *
+		 * Writes the user message to Y.Doc immediately before the TanStack AI
+		 * `sendMessage` call. The assistant response is persisted via `onFinish`.
+		 *
+		 * Uses `MultimodalContent` format with a custom `id` so the Y.Doc row
+		 * and the TanStack AI message share the same identifier.
+		 */
+		sendMessage(content: string) {
+			if (!content.trim()) return;
+
+			const userMessageId = generateId();
+
+			// Write user message to Y.Doc (unidirectional: write on send)
+			popupWorkspace.tables.chatMessages.set({
+				id: userMessageId,
+				conversationId,
+				role: 'user',
+				parts: [{ type: 'text', content }],
+				createdAt: Date.now(),
+				_v: 1,
+			});
+
+			// Send via TanStack AI (triggers SSE streaming).
+			// Pass { content, id } to use our custom ID for the user message.
+			void chatInstance.sendMessage({ content, id: userMessageId });
+		},
+
+		/** Stop the current streaming response. */
+		stop() {
+			chatInstance.stop();
+		},
+
+		/** Clear all messages from the chat (does not delete from Y.Doc). */
+		clear() {
+			chatInstance.setMessages([]);
+		},
+	};
+}
+
+export const aiChatState = createAiChatState();

--- a/apps/tab-manager/src/lib/state/settings.ts
+++ b/apps/tab-manager/src/lib/state/settings.ts
@@ -1,0 +1,44 @@
+/**
+ * Server URL settings for the tab manager extension.
+ *
+ * Stores the AI chat server URL in chrome.storage.local with a sensible default.
+ * Used by the AI chat state module to connect to the streaming endpoint.
+ *
+ * @example
+ * ```typescript
+ * const url = await getServerUrl(); // 'http://127.0.0.1:3913'
+ * await setServerUrl('http://my-server.local:3913');
+ * ```
+ */
+
+import { storage } from '@wxt-dev/storage';
+
+/**
+ * Server URL storage item.
+ *
+ * Defaults to localhost — the standard self-hosted server address.
+ * Persisted in chrome.storage.local so it survives browser restarts.
+ */
+const serverUrlItem = storage.defineItem<string>('local:serverUrl', {
+	fallback: 'http://127.0.0.1:3913',
+});
+
+/**
+ * Get the current server URL.
+ *
+ * Returns the user-configured URL, or the default localhost address
+ * if no custom URL has been set.
+ */
+export async function getServerUrl(): Promise<string> {
+	return await serverUrlItem.getValue();
+}
+
+/**
+ * Set the server URL.
+ *
+ * Persisted to chrome.storage.local. Takes effect on the next
+ * chat request (not retroactively on active connections).
+ */
+export async function setServerUrl(url: string): Promise<void> {
+	await serverUrlItem.setValue(url);
+}

--- a/apps/tab-manager/src/lib/workspace.ts
+++ b/apps/tab-manager/src/lib/workspace.ts
@@ -334,6 +334,27 @@ export const definition = defineWorkspace({
 				_v: '1',
 			}),
 		),
+
+		/**
+		 * Chat messages table — AI chat messages persisted for conversation history.
+		 *
+		 * Stores TanStack AI UIMessage data with a conversationId for future
+		 * multi-conversation support. The `parts` field stores MessagePart[]
+		 * directly as a native array — no JSON serialization needed.
+		 *
+		 * v1 uses a single default conversation. The conversationId field
+		 * future-proofs for multi-conversation UI.
+		 */
+		chatMessages: defineTable(
+			type({
+				id: 'string', // TanStack AI message ID or nanoid
+				conversationId: 'string', // Groups messages into threads
+				role: "'user' | 'assistant'", // Message sender
+				parts: 'unknown[]', // TanStack AI MessagePart[] — stored as native array
+				createdAt: 'number', // ms since epoch
+				_v: '1',
+			}),
+		),
 	},
 });
 
@@ -348,3 +369,4 @@ export type Tab = InferTableRow<Tables['tabs']>;
 export type Window = InferTableRow<Tables['windows']>;
 export type TabGroup = InferTableRow<Tables['tabGroups']>;
 export type SavedTab = InferTableRow<Tables['savedTabs']>;
+export type ChatMessage = InferTableRow<Tables['chatMessages']>;

--- a/bun.lock
+++ b/bun.lock
@@ -131,6 +131,8 @@
         "@epicenter/hq": "workspace:*",
         "@epicenter/ui": "workspace:*",
         "@lucide/svelte": "catalog:",
+        "@tanstack/ai": "^0.5.1",
+        "@tanstack/ai-svelte": "^0.5.4",
         "@wxt-dev/storage": "^1.2.6",
         "arktype": "catalog:",
         "clsx": "catalog:",
@@ -1143,6 +1145,8 @@
 
     "@tanstack/ai-anthropic": ["@tanstack/ai-anthropic@0.5.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.71.2" }, "peerDependencies": { "@tanstack/ai": "^0.5.0", "zod": "^4.0.0" } }, "sha512-PiQx4Kpw+NNjXvVhes29LoO/IvD8M9GGQsNvtLCd+dDhZt3FzdNwHWMZBCpaQWPW142iuhowagh79X//onNjDw=="],
 
+    "@tanstack/ai-client": ["@tanstack/ai-client@0.4.5", "", { "dependencies": { "@tanstack/ai": "0.5.1" } }, "sha512-L5pAuwtBs/iLFgiFB3acq/NNj/xBCMWTCZvOKC2PQsMHBnxjU5l8cZNYVCGk8Tzf/a9fe6s4wHOgckcHxkHStA=="],
+
     "@tanstack/ai-gemini": ["@tanstack/ai-gemini@0.5.0", "", { "dependencies": { "@google/genai": "^1.30.0" }, "peerDependencies": { "@tanstack/ai": "^0.5.0" } }, "sha512-gunJgwRG+38fbYSE83/XJMHFy/7hDN4Fb91vAAZLK3nh4DoN0ReVbRB4BK9cY9iVYQqGq2PA8d5ruDgfcKO2hQ=="],
 
     "@tanstack/ai-grok": ["@tanstack/ai-grok@0.5.0", "", { "dependencies": { "openai": "^6.9.1" }, "peerDependencies": { "@tanstack/ai": "^0.5.0", "zod": "^4.0.0" } }, "sha512-X2ix/NmAXC1EyE3UIDSdX+T9A3VwWvQrnAomMyxqGDbDHHm+yQbjioloGOcwQ6Z3yzONeVcO36T6apoX2UPLsw=="],
@@ -1150,6 +1154,8 @@
     "@tanstack/ai-ollama": ["@tanstack/ai-ollama@0.5.0", "", { "dependencies": { "ollama": "^0.6.3" }, "peerDependencies": { "@tanstack/ai": "^0.5.0" } }, "sha512-CR/f6OS7WzrC1VIK819lDSHeEJWfpaEVyO0bSmE7EGUAfbv+JmDLd8tI2Pk/DhIRVw/rk0Zlcn35jWvvXLjwTg=="],
 
     "@tanstack/ai-openai": ["@tanstack/ai-openai@0.5.0", "", { "dependencies": { "openai": "^6.9.1" }, "peerDependencies": { "@tanstack/ai": "^0.5.0", "zod": "^4.0.0" } }, "sha512-0xJg+BkqVgIRbl4LyiPQWCLOapfGpK4lSzqjaWRkz2Hf1C3m4exg76rBuv1mvr4G3XAR5SnMRSj3XxlWMuRImA=="],
+
+    "@tanstack/ai-svelte": ["@tanstack/ai-svelte@0.5.4", "", { "dependencies": { "@tanstack/ai-client": "0.4.5" }, "peerDependencies": { "@tanstack/ai": "^0.5.1", "svelte": "^5.0.0" } }, "sha512-IZkQMnS4j1z3i99hSXwRxrk5bIdHgcThagLQLJ8EfZKJKctsG+YIOH2lJXZ3qjlmjkL2pTNUtdkVOo9GbSMzwg=="],
 
     "@tanstack/devtools-event-client": ["@tanstack/devtools-event-client@0.4.0", "", {}, "sha512-RPfGuk2bDZgcu9bAJodvO2lnZeHuz4/71HjZ0bGb/SPg8+lyTA+RLSKQvo7fSmPSi8/vcH3aKQ8EM9ywf1olaw=="],
 

--- a/packages/server/src/ai/adapters.ts
+++ b/packages/server/src/ai/adapters.ts
@@ -75,3 +75,28 @@ export function isSupportedProvider(
 ): provider is SupportedProvider {
 	return SUPPORTED_PROVIDERS.includes(provider as SupportedProvider);
 }
+
+/** Environment variable names for each provider's API key. */
+export const PROVIDER_ENV_VARS: Record<SupportedProvider, string> = {
+	openai: 'OPENAI_API_KEY',
+	anthropic: 'ANTHROPIC_API_KEY',
+	gemini: 'GEMINI_API_KEY',
+	grok: 'GROK_API_KEY',
+	ollama: '', // no key needed
+};
+
+/**
+ * Resolve an API key for the given provider.
+ *
+ * Priority: (1) per-request header key, (2) server env var, (3) undefined.
+ * Reads env vars at request time (not module load) so they can change at runtime.
+ */
+export function resolveApiKey(
+	provider: SupportedProvider,
+	headerKey?: string,
+): string | undefined {
+	if (headerKey) return headerKey;
+	const envVarName = PROVIDER_ENV_VARS[provider];
+	if (envVarName) return process.env[envVarName];
+	return undefined;
+}

--- a/packages/server/src/ai/plugin.test.ts
+++ b/packages/server/src/ai/plugin.test.ts
@@ -28,8 +28,8 @@ describe('createAIPlugin', () => {
 		);
 
 		expect(response.status).toBe(401);
-		const body = await response.json();
-		expect(body.error).toContain('Missing API key');
+		const body = await response.text();
+		expect(body).toContain('Missing API key');
 	});
 
 	test('returns 400 for unsupported provider', async () => {
@@ -48,8 +48,8 @@ describe('createAIPlugin', () => {
 		);
 
 		expect(response.status).toBe(400);
-		const body = await response.json();
-		expect(body.error).toBe('Unsupported provider: mistral');
+		const body = await response.text();
+		expect(body).toBe('Unsupported provider: mistral');
 	});
 
 	test('returns 422 when required body fields are missing', async () => {
@@ -100,8 +100,8 @@ describe('createAIPlugin', () => {
 		);
 
 		expect(response.status).toBe(400);
-		const body = await response.json();
-		expect(body.error).toBe('Unsupported provider: anthropic');
+		const body = await response.text();
+		expect(body).toBe('Unsupported provider: anthropic');
 	});
 
 	test('route is reachable through Elysia prefix mount', async () => {
@@ -160,8 +160,8 @@ describe('createAIPlugin', () => {
 		);
 
 		expect(response.status).toBe(401);
-		const body = await response.json();
-		expect(body.error).toContain('OPENAI_API_KEY');
+		const body = await response.text();
+		expect(body).toContain('OPENAI_API_KEY');
 	});
 
 	test('plugin accepts request without header when env var set', async () => {

--- a/packages/server/src/sync/plugin.test.ts
+++ b/packages/server/src/sync/plugin.test.ts
@@ -478,7 +478,7 @@ describe('sync plugin REST document snapshot', () => {
 			const room = uniqueRoom();
 			const res = await fetch(ctx.httpUrl(`/rooms/${room}`));
 			expect(res.status).toBe(404);
-			expect(await res.json()).toEqual({ error: `Room not found: ${room}` });
+			expect(await res.text()).toBe(`Room not found: ${room}`);
 		} finally {
 			await ctx.server.stop();
 		}
@@ -566,7 +566,7 @@ describe('sync plugin REST document update', () => {
 			});
 
 			expect(res.status).toBe(400);
-			expect(await res.json()).toEqual({ error: 'Empty update body' });
+			expect(await res.text()).toBe('Empty update body');
 		} finally {
 			await ctx.server.stop();
 		}
@@ -588,7 +588,7 @@ describe('sync plugin REST document update', () => {
 			});
 
 			expect(res.status).toBe(404);
-			expect(await res.json()).toEqual({ error: `Room not found: ${room}` });
+			expect(await res.text()).toBe(`Room not found: ${room}`);
 		} finally {
 			ctx.app.stop();
 		}
@@ -602,7 +602,7 @@ describe('sync plugin REST auth', () => {
 		try {
 			const res = await fetch(ctx.httpUrl('/rooms/'));
 			expect(res.status).toBe(401);
-			expect(await res.json()).toEqual({ error: 'Unauthorized' });
+			expect(await res.text()).toBe('Unauthorized');
 		} finally {
 			await ctx.server.stop();
 		}
@@ -616,7 +616,7 @@ describe('sync plugin REST auth', () => {
 				headers: { Authorization: 'Bearer wrong' },
 			});
 			expect(res.status).toBe(401);
-			expect(await res.json()).toEqual({ error: 'Unauthorized' });
+			expect(await res.text()).toBe('Unauthorized');
 		} finally {
 			await ctx.server.stop();
 		}

--- a/specs/20260221T190252-ai-chat-tab.md
+++ b/specs/20260221T190252-ai-chat-tab.md
@@ -1,0 +1,659 @@
+# AI Chat Tab in Tab Manager Extension
+
+## TL;DR
+
+> **Quick Summary**: Add a third "AI" tab to the tab manager Chrome extension sidepanel that lets users chat with LLMs via TanStack AI Svelte, using the existing `packages/server` backend with server-owned API keys.
+>
+> **Deliverables**:
+>
+> - Server: env var API key support in `createAIPlugin()` (backward-compatible)
+> - Extension: new "AI" tab with chat interface using `@epicenter/ui/chat` components
+> - Extension: `@tanstack/ai-svelte` integration with SSE streaming
+> - Extension: Y.Doc persistence for chat messages (unidirectional: write on send/complete, read on open)
+> - Extension: configurable server URL setting
+> - Extension: provider dropdown + curated model dropdown per provider
+>
+> **Estimated Effort**: Medium
+> **Parallel Execution**: YES - 3 waves
+> **Critical Path**: Task 2 (deps) → Task 5 (state) → Task 6 (UI + wiring)
+
+---
+
+## Context
+
+### Original Request
+
+Add an AI chat tab to the tab manager Chrome extension where users can chat with LLMs. Uses `packages/server` as the backend with TanStack AI adapters.
+
+### Interview Summary
+
+**Key Discussions**:
+
+- **API key architecture**: Server owns keys via env vars — extension never handles secrets
+- **Provider/model selection**: Provider dropdown + curated model dropdown per provider at bottom of chat
+- **Chat persistence**: Y.Doc — messages persist and sync across devices, using unidirectional flow (write to Y.Doc on send/complete, read from Y.Doc on panel open)
+- **UI scope**: Minimal functional — basic bubbles, input, loading indicator
+- **Server URL**: Configurable via chrome.storage.local (default: localhost:3913)
+- **Conversation model**: Multi-conversation ready (conversationId on each message), single-conversation UI for v1
+
+**Research Findings**:
+
+- `@tanstack/ai-svelte` v0.5.3 exists with `createChat()` + `fetchServerSentEvents()` (Svelte 5 runes)
+- `@epicenter/ui/chat` already has Chat.List, Chat.Bubble, Chat.BubbleMessage, LoadingDots components
+- Server's `POST /ai/chat` SSE endpoint is already implemented and tested
+- Server currently requires `x-provider-api-key` header per-request (needs env var fallback)
+- `start.ts` already uses `createServer()` with AI endpoint mounted — no changes needed
+- Y.Doc tables natively support nested objects and arrays (proven by `mutedInfo` field in tabs table) — no JSON serialization needed for `parts`
+- TanStack AI `UIMessage` format: `{ id, role, parts: MessagePart[], createdAt? }` where `MessagePart` is a union of `TextPart | ToolCallPart | ToolResultPart | ThinkingPart`
+- TanStack AI `createChat` supports `initialMessages` for seeding from database, and `setMessages()` for runtime updates
+
+### TanStack AI Message Format
+
+```typescript
+// UIMessage — what createChat() manages internally
+interface UIMessage {
+	id: string;
+	role: 'system' | 'user' | 'assistant';
+	parts: Array<MessagePart>;
+	createdAt?: Date;
+}
+
+// MessagePart — discriminated union
+type MessagePart = TextPart | ToolCallPart | ToolResultPart | ThinkingPart;
+
+interface TextPart {
+	type: 'text';
+	content: string;
+	metadata?: unknown;
+}
+interface ThinkingPart {
+	type: 'thinking';
+	content: string;
+}
+interface ToolCallPart {
+	type: 'tool-call';
+	id: string;
+	name: string;
+	arguments: string;
+	state: string;
+}
+interface ToolResultPart {
+	type: 'tool-result';
+	toolCallId: string;
+	content: string;
+	state: string;
+}
+```
+
+### Metis Review
+
+**Identified Gaps** (addressed):
+
+- **TanStack AI message format mismatch**: Server's Elysia uses strict body validation; TanStack AI may send extra fields → Elysia strips unknown properties by default, not a blocker
+- **Chrome extension CSP**: Sidepanel should be able to fetch localhost, but `host_permissions: ['<all_urls>']` already covers this → Verified, low risk
+- **Message format**: TanStack AI uses `message.parts[0].content`, not `message.content` → Plan stores parts array directly in Y.Doc
+- **Y.Doc schema addition**: New tables in existing Y.Doc are handled gracefully by `@epicenter/hq` (new Y.Map keys appear as needed)
+- **Empty state UI**: Need to handle no-messages state → Plan includes empty state in chat component task
+- **Error state UX**: Need to handle server errors, unreachable → Plan includes inline error display
+
+---
+
+## Work Objectives
+
+### Core Objective
+
+Enable AI chat directly within the tab manager Chrome extension sidepanel, connecting to the existing server backend via SSE streaming.
+
+### Concrete Deliverables
+
+- `packages/server/src/ai/plugin.ts` — modified to support env var API keys
+- `packages/server/src/ai/adapters.ts` — modified with env var resolution
+- `apps/tab-manager/src/lib/state/ai-chat-state.svelte.ts` — new state module
+- `apps/tab-manager/src/lib/state/settings.ts` — new settings module for server URL
+- `apps/tab-manager/src/lib/components/AiChat.svelte` — new chat component
+- `apps/tab-manager/src/entrypoints/sidepanel/App.svelte` — modified with third tab
+- `apps/tab-manager/src/lib/workspace.ts` — modified with chatMessages table
+
+### Definition of Done
+
+- [ ] `bun run typecheck` in `apps/tab-manager/` passes
+- [ ] `bun run build` in `apps/tab-manager/` succeeds
+- [ ] `bun test` in `packages/server/` passes (including new tests)
+- [ ] AI tab visible in extension sidepanel with send/receive working
+- [ ] Server starts with AI endpoint via `bun run start` in `packages/server/`
+
+### Must Have
+
+- Third "AI" tab in sidepanel with chat interface
+- SSE streaming via `@tanstack/ai-svelte`
+- Server env var API key support (backward-compatible with per-request header)
+- Provider dropdown (OpenAI, Anthropic, Gemini, Ollama, Grok)
+- Model dropdown with curated per-provider options
+- Loading indicator during streaming
+- Error display when server unreachable or provider errors
+- Chat messages persisted in Y.Doc with `conversationId` field (future-proofed for multi-conversation)
+
+### Must NOT Have (Guardrails)
+
+- NO changes to `background.ts` — AI chat is sidepanel-only
+- NO markdown rendering (plain text only in v1)
+- NO system prompt configuration
+- NO conversation management UI (new chat, history, rename) — single conversation for v1
+- NO new Chrome extension permissions
+- NO modifications to `@epicenter/ui/chat` components (use as-is)
+- NO model temperature/options controls
+- NO streaming token count display
+- NO client-side API key handling (keys are server-owned)
+
+---
+
+## Verification Strategy
+
+> **ZERO HUMAN INTERVENTION** — ALL verification is agent-executed. No exceptions.
+
+### Test Decision
+
+- **Infrastructure exists**: YES (bun test, existing `plugin.test.ts`)
+- **Automated tests**: Tests-after
+- **Framework**: bun test
+- **If TDD**: N/A
+
+### QA Policy
+
+Every task MUST include agent-executed QA scenarios.
+Evidence saved to `.sisyphus/evidence/task-{N}-{scenario-slug}.{ext}`.
+
+- **Server API**: Use Bash (curl) — send requests, assert status + response fields
+- **Extension build**: Use Bash (bun) — typecheck, build commands
+
+---
+
+## Execution Strategy
+
+### Parallel Execution Waves
+
+```
+Wave 1 (Start Immediately — no dependencies, 3 parallel):
+├── Task 1: Server env var API key fallback [quick]
+├── Task 2: Extension add @tanstack/ai-svelte dependencies [quick]
+└── Task 3: Extension server URL settings module [quick]
+
+Wave 2 (After Wave 1 — schema + state, 2 parallel):
+├── Task 4: Extension workspace schema (chatMessages table) [quick]
+└── Task 5: Extension AI chat state module (depends: 2, 3, 4) [unspecified-high]
+
+Wave 3 (After Wave 2 — UI + wiring):
+└── Task 6: Extension AI chat component + App.svelte wiring [visual-engineering]
+
+Wave 4 (After Wave 3 — tests + verification, 2 parallel):
+├── Task 7: Server tests for env var API key fallback [quick]
+└── Task 8: Extension build + typecheck verification [quick]
+
+Wave FINAL (After ALL tasks — 2 parallel):
+├── Task F1: Plan compliance audit (oracle)
+└── Task F2: Code quality review (unspecified-high)
+
+Critical Path: Task 2 → Task 5 → Task 6 → Task 8 → F1-F2
+Parallel Speedup: ~35% faster than sequential
+Max Concurrent: 3 (Wave 1)
+```
+
+### Dependency Matrix
+
+| Task | Depends On | Blocks | Wave |
+| ---- | ---------- | ------ | ---- |
+| 1    | —          | 5, 7   | 1    |
+| 2    | —          | 5      | 1    |
+| 3    | —          | 5      | 1    |
+| 4    | —          | 5      | 2    |
+| 5    | 1, 2, 3, 4 | 6      | 2    |
+| 6    | 5          | 8      | 3    |
+| 7    | 1          | F1-F2  | 4    |
+| 8    | 6          | F1-F2  | 4    |
+
+### Agent Dispatch Summary
+
+- **Wave 1**: **3** — T1 → `quick`, T2 → `quick`, T3 → `quick`
+- **Wave 2**: **2** — T4 → `quick`, T5 → `unspecified-high`
+- **Wave 3**: **1** — T6 → `visual-engineering`
+- **Wave 4**: **2** — T7 → `quick`, T8 → `quick`
+- **FINAL**: **2** — F1 → `oracle`, F2 → `unspecified-high`
+
+---
+
+## TODOs
+
+- [ ] 1. Server: Add env var API key fallback to `createAIPlugin()`
+
+  **What to do**:
+  - In `packages/server/src/ai/adapters.ts`, add an env var name mapping constant:
+    ```typescript
+    const PROVIDER_ENV_VARS: Record<SupportedProvider, string> = {
+    	openai: 'OPENAI_API_KEY',
+    	anthropic: 'ANTHROPIC_API_KEY',
+    	gemini: 'GEMINI_API_KEY',
+    	grok: 'GROK_API_KEY',
+    	ollama: '', // no key needed
+    };
+    ```
+  - Add a `resolveApiKey(provider, headerKey?)` function that: (1) returns `headerKey` if provided (backward compat), (2) falls back to `process.env[PROVIDER_ENV_VARS[provider]]`, (3) returns `undefined` if neither exists.
+  - In `packages/server/src/ai/plugin.ts`, replace the direct `headers['x-provider-api-key']` usage with `resolveApiKey(provider, headers['x-provider-api-key'])`. Update the 401 error message to: `'Missing API key: set x-provider-api-key header or configure ${envVarName} environment variable'`.
+  - Export the env var mapping and `resolveApiKey` from `adapters.ts`.
+
+  **Must NOT do**:
+  - Do NOT remove per-request header support (backward compatibility)
+  - Do NOT change Ollama behavior (still no key needed)
+  - Do NOT add env var reading at module level (read at request time so env can change)
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+  - **Skills**: [`typescript`, `error-handling`]
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 1 (with Tasks 2, 3)
+  - **Blocks**: Tasks 5, 7
+  - **Blocked By**: None
+
+  **References**:
+  - `packages/server/src/ai/adapters.ts` — Full file. Contains `SUPPORTED_PROVIDERS`, `ADAPTER_FACTORIES`, `createAdapter()`, `isSupportedProvider()`.
+  - `packages/server/src/ai/plugin.ts:47-67` — The `createAIPlugin()` handler where `apiKey` is extracted from headers and validated.
+  - `packages/server/src/ai/plugin.test.ts` — Existing tests. The 401 test will need updating since the error message changes.
+
+  **Acceptance Criteria**:
+
+  ```
+  Scenario: Env var API key works when header is absent
+    Tool: Bash (curl)
+    Preconditions: Server running with OPENAI_API_KEY=sk-test-invalid-key env var
+    Steps:
+      1. Start server: OPENAI_API_KEY=sk-test-key bun packages/server/src/start.ts &
+      2. curl POST to /ai/chat with provider=openai, no x-provider-api-key header
+      3. Assert: HTTP status is NOT 401
+    Expected Result: Status 200 (streaming) or 502 (provider error from invalid key) — NOT 401
+
+  Scenario: Header key overrides env var key (backward compat)
+    Tool: Bash (curl)
+    Preconditions: Server running with OPENAI_API_KEY=sk-env-key
+    Steps:
+      1. curl POST with x-provider-api-key: sk-header-key header
+      2. Assert: Request uses header key
+    Expected Result: HTTP 502 (provider error — tried to use header key)
+
+  Scenario: Missing key returns 401 with helpful message
+    Tool: Bash (curl)
+    Preconditions: Server running with NO env vars set
+    Steps:
+      1. curl POST with no header, no env var
+      2. Assert: Response contains "OPENAI_API_KEY" in error message
+    Expected Result: HTTP 401 with error message mentioning both header and env var options
+
+  Scenario: Ollama still works without any key
+    Tool: Bash (curl)
+    Preconditions: Server running with NO env vars
+    Steps:
+      1. curl POST with provider=ollama, no header
+      2. Assert: NOT 401
+    Expected Result: NOT 401 (likely 502 if no Ollama running, but not auth error)
+  ```
+
+  **Commit**: YES
+  - Message: `feat(server): add env var API key fallback for AI providers`
+  - Files: `packages/server/src/ai/adapters.ts`, `packages/server/src/ai/plugin.ts`
+
+- [ ] 2. Extension: Add `@tanstack/ai-svelte` and `@tanstack/ai` dependencies
+
+  **What to do**:
+  - Run `bun add @tanstack/ai-svelte @tanstack/ai` in `apps/tab-manager/`
+  - Verify the packages resolve correctly
+  - Run `bun run build` and `bun run typecheck` to verify no conflicts
+
+  **Must NOT do**:
+  - Do NOT add any other dependencies
+  - Do NOT modify any source files
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+  - **Skills**: [`monorepo`]
+
+  **Parallelization**: Wave 1 (with Tasks 1, 3). Blocks Task 5.
+
+  **References**:
+  - `apps/tab-manager/package.json` — Add to `dependencies` (not devDependencies)
+
+  **Acceptance Criteria**:
+
+  ```
+  Scenario: Dependencies install and build succeeds
+    Steps: bun install, bun run build, bun run typecheck in apps/tab-manager
+    Expected Result: All exit 0
+  ```
+
+  **Commit**: YES — `build(tab-manager): add @tanstack/ai-svelte dependencies`
+
+- [ ] 3. Extension: Create server URL settings module
+
+  **What to do**:
+  - Create `apps/tab-manager/src/lib/state/settings.ts` using `@wxt-dev/storage` pattern
+  - Define `serverUrl` storage item: `storage.defineItem<string>('local:serverUrl', { fallback: 'http://127.0.0.1:3913' })`
+  - Export `getServerUrl()` and `setServerUrl(url)` async functions
+  - Follow pattern from `apps/tab-manager/src/lib/device/device-id.ts`
+
+  **Must NOT do**:
+  - Do NOT create a settings UI (future work)
+  - Do NOT make the WebSocket sync URL configurable
+  - Do NOT validate the URL format
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+  - **Skills**: [`typescript`]
+
+  **Parallelization**: Wave 1 (with Tasks 1, 2). Blocks Task 5.
+
+  **References**:
+  - `apps/tab-manager/src/lib/device/device-id.ts` — `storage.defineItem()` pattern
+
+  **Acceptance Criteria**:
+
+  ```
+  Scenario: Settings module exports correct API
+    Steps: bun run typecheck, verify both functions exported
+    Expected Result: typecheck passes
+  ```
+
+  **Commit**: YES — `feat(tab-manager): add configurable server URL setting`
+
+- [ ] 4. Extension: Add `chatMessages` table to workspace schema
+
+  **What to do**:
+  - In `apps/tab-manager/src/lib/workspace.ts`, add a `chatMessages` table after `savedTabs`:
+    ```typescript
+    chatMessages: defineTable(
+      type({
+        id: 'string',                  // TanStack AI message ID or nanoid
+        conversationId: 'string',       // Groups messages into threads
+        role: "'user' | 'assistant'",   // Message sender
+        parts: 'unknown[]',             // TanStack AI MessagePart[] — stored as native array
+        createdAt: 'number',            // ms since epoch
+        _v: '1',
+      }),
+    ),
+    ```
+  - Add type export: `export type ChatMessage = InferTableRow<Tables['chatMessages']>;`
+  - The `parts` field stores TanStack AI's `MessagePart[]` directly as a native array in Y.Doc — no JSON serialization needed. Y.Doc LWW storage handles objects and arrays natively (proven by `mutedInfo` object in tabs table).
+  - `conversationId` included now for future multi-conversation support. v1 UI uses a single default conversation.
+
+  **Must NOT do**:
+  - Do NOT add a `conversations` table
+  - Do NOT add `systemPrompt` or `modelOptions` fields
+  - Do NOT add per-message `provider` or `model` fields (those are preferences, not per-message data)
+  - Do NOT modify any existing table definitions
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+  - **Skills**: [`typescript`, `static-workspace-api`]
+
+  **Parallelization**: Wave 2 (with Task 5). Blocks Task 5.
+
+  **References**:
+  - `apps/tab-manager/src/lib/workspace.ts:324-337` — `savedTabs` table. Follow this pattern.
+  - `apps/tab-manager/src/lib/workspace.ts:344-350` — Type exports section.
+  - `apps/tab-manager/src/lib/workspace.ts:243` — `mutedInfo` field. Proof nested objects work.
+
+  **Acceptance Criteria**:
+
+  ```
+  Scenario: Schema typechecks and type exported
+    Steps: bun run typecheck, verify ChatMessage export exists
+    Expected Result: 0 errors, export found
+  ```
+
+  **Commit**: YES — `feat(tab-manager): add chatMessages table to workspace schema`
+
+- [ ] 5. Extension: Create AI chat state module
+
+  **What to do**:
+  - Create `apps/tab-manager/src/lib/state/ai-chat-state.svelte.ts`
+  - Follow `createXxxState()` singleton pattern from `saved-tab-state.svelte.ts`
+  - Use `createChat` and `fetchServerSentEvents` from `@tanstack/ai-svelte`
+  - Use `getServerUrl` from `$lib/state/settings`
+
+  **The state module must**:
+  1. Create `$state` fields for `provider` (default: `'openai'`) and `model` (default: `'gpt-4o-mini'`)
+  2. Create a static `PROVIDER_MODELS` map with curated models per provider:
+     ```typescript
+     const PROVIDER_MODELS: Record<string, string[]> = {
+     	openai: ['gpt-4o', 'gpt-4o-mini', 'o3-mini'],
+     	anthropic: ['claude-sonnet-4-20250514', 'claude-haiku-4-20250414'],
+     	gemini: ['gemini-2.0-flash', 'gemini-2.5-pro'],
+     	ollama: ['llama3', 'mistral', 'codellama'],
+     	grok: ['grok-2', 'grok-2-mini'],
+     };
+     ```
+  3. Create chat connection: `createChat({ connection: fetchServerSentEvents({ url: serverUrl + '/ai/chat' }), body: { provider, model } })`
+  4. Handle `body` dynamically — read current provider/model at send time
+  5. Generate default `conversationId` (nanoid) on init
+  6. **Unidirectional Y.Doc persistence** (NOT bidirectional sync):
+     - **On send**: Write user message to `popupWorkspace.tables.chatMessages` immediately before server request
+     - **On stream complete**: Write final assistant message to `popupWorkspace.tables.chatMessages`
+     - **On panel open (init)**: Read existing messages from Y.Doc for active conversationId → seed via `initialMessages` or `setMessages()`
+     - **Message format**: Store `parts` array directly (no JSON serialization). Write: `{ id, conversationId, role, parts: message.parts, createdAt: Date.now() }`. Read: reconstruct `UIMessage` from row.
+     - Use Y.Doc observer only for remote change detection
+  7. Expose: `messages`, `isLoading`, `error`, `sendMessage(content)`, `stop()`, `clear()`, `provider` (get/set), `model` (get/set), `availableProviders`, `modelsForProvider(provider)`, `conversationId`
+
+  **Must NOT do**:
+  - Do NOT implement bidirectional state sync
+  - Do NOT add conversation management (switching, naming, history list)
+  - Do NOT add system prompt support
+  - Do NOT add model options (temperature, etc.)
+  - Do NOT modify `workspace-popup.ts`
+
+  **Recommended Agent Profile**:
+  - **Category**: `unspecified-high`
+  - **Skills**: [`svelte`, `typescript`, `factory-function-composition`, `yjs`]
+
+  **Parallelization**: Wave 2 (needs Tasks 1-4). Blocks Task 6.
+
+  **References**:
+  - `apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts` — THE reference pattern. Factory, $state, Y.Doc observer, CRUD, generateId.
+  - `apps/tab-manager/src/lib/workspace-popup.ts` — `popupWorkspace` for Y.Doc access.
+  - `apps/tab-manager/src/lib/workspace.ts` — `ChatMessage` type (Task 4).
+  - `apps/tab-manager/src/lib/state/settings.ts` — `getServerUrl()` (Task 3).
+
+  **Acceptance Criteria**:
+
+  ```
+  Scenario: State module typechecks and exports correct shape
+    Steps: bun run typecheck, verify aiChatState exports all properties
+    Expected Result: Typecheck passes, all exports present
+
+  Scenario: Provider list includes all supported providers
+    Steps: Verify openai, anthropic, gemini, ollama, grok in file
+    Expected Result: All 5 present
+  ```
+
+  **Commit**: YES — `feat(tab-manager): add AI chat state module with TanStack AI + Y.Doc persistence`
+
+- [ ] 6. Extension: Create AI chat component and wire into App.svelte
+
+  **What to do**:
+
+  **Part A — Create `AiChat.svelte`**:
+  - Create `apps/tab-manager/src/lib/components/AiChat.svelte`
+  - Import `aiChatState`, Chat components, Select, Textarea, Button, icons
+
+  **Layout** (flex column, full height):
+
+  ```
+  ┌─────────────────────────┐
+  │ [Empty state / Messages] │  ← Chat.List (flex-1, overflow-y-auto)
+  ├─────────────────────────┤
+  │ [Error banner]           │  ← Conditional
+  ├─────────────────────────┤
+  │ [Provider ▼] [Model ▼]  │  ← Select dropdowns
+  │ [Textarea........][Send] │  ← Input area
+  └─────────────────────────┘
+  ```
+
+  **Message rendering**:
+  - `{#each aiChatState.messages as message (message.id)}`
+  - `Chat.Bubble variant={role === 'user' ? 'sent' : 'received'}`
+  - Render text parts: `message.parts.filter(p => p.type === 'text').map(p => p.content).join('')`
+  - Loading dots bubble when `isLoading` and last message is from user
+
+  **Provider/model selection**:
+  - Provider: `Select` dropdown (OpenAI, Anthropic, Gemini, Ollama, Grok)
+  - Model: `Select` dropdown from `aiChatState.modelsForProvider(currentProvider)` — curated per-provider list
+  - When provider changes, auto-select first model for that provider
+
+  **Input**: Textarea (Enter sends, Shift+Enter newline), send/stop button toggle
+
+  **Part B — Wire into App.svelte**:
+  - Add third `Tabs.Trigger value="ai"` with "AI" label + sparkle icon
+  - Add `Tabs.Content value="ai"` with `<AiChat />`
+  - AI tab OUTSIDE the `{#await browserState.whenReady}` block
+
+  **Must NOT do**:
+  - Do NOT add markdown rendering, code formatting, copy/edit/delete actions
+  - Do NOT add conversation management buttons
+  - Do NOT modify existing components or tab behavior
+
+  **Recommended Agent Profile**:
+  - **Category**: `visual-engineering`
+  - **Skills**: [`svelte`, `styling`, `frontend-ui-ux`]
+
+  **Parallelization**: Wave 3. Blocks Task 8.
+
+  **References**:
+  - `apps/tab-manager/src/entrypoints/sidepanel/App.svelte` — File to modify.
+  - `apps/tab-manager/src/lib/components/SavedTabList.svelte` — Component pattern.
+  - `@epicenter/ui/chat` — Bubble, BubbleAvatar, BubbleMessage, List.
+  - `@epicenter/ui/select` — Root, Trigger, Content, Item.
+  - `@epicenter/ui/empty` — Root, Media, Title, Description.
+
+  **Acceptance Criteria**:
+
+  ```
+  Scenario: Extension builds
+    Steps: bun run typecheck && bun run build in apps/tab-manager
+    Expected Result: Both exit 0
+
+  Scenario: Three tabs in App.svelte
+    Steps: Count Tabs.Trigger elements, verify value="ai"
+    Expected Result: 3 triggers, "ai" present
+  ```
+
+  **Commit**: YES — `feat(tab-manager): add AI chat tab with TanStack AI streaming`
+
+- [ ] 7. Server: Add tests for env var API key fallback
+
+  **What to do**:
+  - Add tests to `packages/server/src/ai/plugin.test.ts`:
+    1. `resolveApiKey()` returns header key when both present
+    2. Returns env var key when header absent
+    3. Returns undefined when neither present
+    4. Updated 401 message mentions env var name
+    5. Plugin accepts request without header when env var set
+  - Update existing 401 test if error message changed
+
+  **Must NOT do**: No actual provider API calls, no integration tests, no test infra changes.
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+  - **Skills**: [`typescript`]
+
+  **Parallelization**: Wave 4 (with Task 8). Blocked by Task 1.
+
+  **Acceptance Criteria**:
+
+  ```
+  Scenario: All server tests pass
+    Steps: bun test in packages/server
+    Expected Result: All pass
+  ```
+
+  **Commit**: YES — `test(server): add tests for env var API key fallback`
+
+- [ ] 8. Extension: Build + typecheck verification
+
+  **What to do**: Run `bun run typecheck` and `bun run build` in `apps/tab-manager/`. Fix any errors.
+
+  **Must NOT do**: Do NOT modify source code unless fixing a genuine build error.
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+  - **Skills**: [`monorepo`]
+
+  **Parallelization**: Wave 4 (with Task 7). Blocked by Task 6.
+
+  **Acceptance Criteria**:
+
+  ```
+  Scenario: Full build pipeline passes
+    Steps: bun run typecheck && bun run build in apps/tab-manager
+    Expected Result: Both exit 0
+  ```
+
+  **Commit**: NO (verification only)
+
+---
+
+## Final Verification Wave (MANDATORY — after ALL implementation tasks)
+
+> 2 review agents run in PARALLEL. Both must APPROVE. Rejection → fix → re-run.
+
+- [ ] F1. **Plan Compliance Audit** — `oracle`
+      For each "Must Have": verify implementation exists. For each "Must NOT Have": search codebase for forbidden patterns — reject with file:line if found. Compare deliverables against plan.
+      Output: `Must Have [N/N] | Must NOT Have [N/N] | Tasks [N/N] | VERDICT: APPROVE/REJECT`
+
+- [ ] F2. **Code Quality Review** — `unspecified-high`
+      Run typecheck + tests. Review changed files for: `as any`/`@ts-ignore`, empty catches, console.log in prod, commented-out code, unused imports. Check AI slop.
+      Output: `Build [PASS/FAIL] | Tests [N pass/N fail] | Files [N clean/N issues] | VERDICT`
+
+---
+
+## Commit Strategy
+
+- **T1**: `feat(server): add env var API key fallback for AI providers` — adapters.ts, plugin.ts
+- **T2**: `build(tab-manager): add @tanstack/ai-svelte dependencies` — package.json, bun.lock
+- **T3**: `feat(tab-manager): add configurable server URL settings` — settings.ts
+- **T4**: `feat(tab-manager): add chatMessages table to workspace schema` — workspace.ts
+- **T5**: `feat(tab-manager): add AI chat state module` — ai-chat-state.svelte.ts
+- **T6**: `feat(tab-manager): add AI chat tab with TanStack AI streaming` — AiChat.svelte, App.svelte
+- **T7**: `test(server): add tests for env var API key fallback` — plugin.test.ts
+
+---
+
+## Success Criteria
+
+### Verification Commands
+
+```bash
+# Server tests pass
+cd packages/server && bun test
+
+# Extension typechecks
+cd apps/tab-manager && bun run typecheck
+
+# Extension builds
+cd apps/tab-manager && bun run build
+
+# Server env var API key works
+OPENAI_API_KEY=sk-test bun packages/server/src/start.ts &
+curl -s -X POST http://localhost:3913/ai/chat \
+  -H 'Content-Type: application/json' \
+  -d '{"messages":[{"role":"user","content":[{"type":"text","content":"say hi"}]}],"provider":"openai","model":"gpt-4o-mini"}' \
+  | head -3  # Expected: NOT 401
+```
+
+### Final Checklist
+
+- [ ] All "Must Have" items present and verified
+- [ ] All "Must NOT Have" items absent
+- [ ] All tests pass (server + extension typecheck + build)
+- [ ] Three tabs visible in sidepanel (Tabs, Saved, AI)
+- [ ] Chat messages stream via SSE
+- [ ] Provider dropdown functional
+- [ ] Model dropdown functional (curated per provider)
+- [ ] Error states handled gracefully
+- [ ] Messages persist in Y.Doc across panel reopens


### PR DESCRIPTION
The tab manager extension has two tabs — active tabs and saved tabs — but no way to interact with LLMs from the sidepanel. This adds a third "AI" tab that streams chat completions from the existing `packages/server` backend, with message history persisted in Y.Doc so conversations survive panel closes.

The key design decision: the extension never touches API keys. Keys are resolved server-side — from env vars or per-request headers — so the browser extension stays secret-free.

```
┌───────────────────────────────────────────────────────────────────┐
│  Chrome Sidepanel (apps/tab-manager)                              │
│                                                                   │
│  ┌─────────┐  ┌──────────┐  ┌────────────┐                       │
│  │ Tabs    │  │ Saved    │  │ AI Chat ✨ │  ← new tab             │
│  └─────────┘  └──────────┘  └─────┬──────┘                       │
│                                   │                               │
│  AiChat.svelte ───────────────────┤                               │
│    ├── ModelCombobox (searchable, supports custom model names)     │
│    ├── Provider select (openai, anthropic, gemini, grok, ollama)  │
│    └── Chat.List / Chat.Bubble (shadcn-svelte components)         │
│                                   │                               │
│  ai-chat-state.svelte.ts ─────────┤                               │
│    ├── TanStack AI createChat() for reactive streaming            │
│    ├── fetchServerSentEvents() → SSE connection                   │
│    └── Y.Doc persistence (write on send/complete, read on open)   │
│                                   │                               │
├───────────────────────────────────┼───────────────────────────────┤
│  Server (packages/server)         │                               │
│                                   ▼                               │
│  POST /ai/chat ── resolveApiKey(provider, headerKey) ─────────── │
│    1. Check x-provider-api-key header                             │
│    2. Fall back to env var (OPENAI_API_KEY, etc.)                 │
│    3. 401 if neither found                                        │
│                                   │                               │
│  chat() ── TanStack AI ── SSE stream back to client               │
└───────────────────────────────────────────────────────────────────┘
```

## Chat State and Persistence

The chat state uses a unidirectional persistence model — Y.Doc is the durable store, TanStack AI is the runtime state. Messages flow in one direction at each lifecycle point:

```
Panel opens:        Y.Doc ──→ createChat({ initialMessages })
User sends:         Y.Doc ←── sendMessage() ──→ SSE request
Stream completes:   Y.Doc ←── onFinish()
Panel closes:       (Y.Doc already has everything)
```

The state module is a singleton factory that wires these together:

```typescript
import { aiChatState } from '$lib/state/ai-chat-state.svelte';

// Reactive getters — Svelte 5 runes update automatically during streaming
aiChatState.messages    // UIMessage[]
aiChatState.isLoading   // boolean
aiChatState.status      // 'ready' | 'submitted' | 'streaming' | ...

// Provider/model selection — auto-selects first model on provider change
aiChatState.provider = 'anthropic';
aiChatState.model       // → 'claude-sonnet-4-20250514'

// Model lists imported from TanStack AI provider packages (not hardcoded)
aiChatState.modelsForProvider('openai')  // → ['gpt-4o', 'gpt-4o-mini', ...]

// Send, stop, regenerate
aiChatState.sendMessage('explain this code');
aiChatState.stop();
aiChatState.reload();   // deletes old assistant msg from Y.Doc, re-requests
```

The workspace schema gains a `chatMessages` table with a `conversationId` field. v1 uses a single `'default'` conversation — the field is there so multi-conversation UI doesn't require a migration later:

```typescript
chatMessages: defineTable(
  type({
    id: 'string',
    conversationId: 'string',
    role: "'user' | 'assistant'",
    parts: 'unknown[]',       // TanStack AI MessagePart[] — native array, no JSON serialization
    createdAt: 'number',
    _v: '1',
  }),
),
```

## Server-Side API Key Resolution

Previously the server required API keys via `x-provider-api-key` header on every request. That works for apps that manage their own keys, but a browser extension shouldn't handle secrets at all.

```typescript
// BEFORE: header-only, extension must somehow have the key
const apiKey = headers['x-provider-api-key'];
if (provider !== 'ollama' && !apiKey) {
  set.status = 401;
  return { error: 'Missing x-provider-api-key header' };
}

// AFTER: header takes priority, env var as fallback
const apiKey = resolveApiKey(provider, headerApiKey);
//                           ↓
// 1. headerApiKey exists?  → use it
// 2. OPENAI_API_KEY set?   → use it
// 3. neither?              → 401 with specific guidance
```

The 401 message now tells you exactly what's missing — both the header name and the env var name — so you're not guessing:

```
Missing API key: set x-provider-api-key header or configure OPENAI_API_KEY environment variable
```

The `SupportedProvider` type and `SUPPORTED_PROVIDERS` array are now derived from the adapter factory object rather than maintained as a separate list. Adding a provider means adding one factory entry — the type and array update automatically.

Other server cleanup: replaced `set.status = N` with Elysia's idiomatic `status()` helper, swapped the try-catch around `chat()` with `trySync` for a surgical error boundary (only wraps the one call that can throw synchronously — streaming errors flow as SSE events, not exceptions), and added typed response schemas for 400/401/499/502.

## Intentional v1 Scope

This is a minimal first pass. No markdown rendering, no conversation management, no system prompts, no model option controls (temperature, etc.). The `conversationId` field and the `ModelCombobox`'s freeform input are the main future-proofing affordances — everything else is explicitly deferred.