### PR TITLE
refactor(tab-manager): brand all table IDs with nominal types

### DIFF
--- a/.agents/skills/typescript/SKILL.md
+++ b/.agents/skills/typescript/SKILL.md
@@ -644,6 +644,25 @@ function processRow(rowId: string) {
 
 This makes type boundaries visible and intentional, without forcing awkward parameter renames.
 
+### Branded IDs for Workspace Tables
+
+Every `defineTable()` schema MUST use branded ID types for the `id` field and all string foreign keys. Never use plain `'string'` for table IDs.
+
+For tables that use arktype schemas, define the brand as a type + arktype pipe pair:
+
+```typescript
+export type ConversationId = string & Brand<'ConversationId'>;
+export const ConversationId = type('string').pipe(
+	(s): ConversationId => s as ConversationId,
+);
+```
+
+Then use directly in the schema: `id: ConversationId` and for optional FKs: `'parentId?': ConversationId.or('undefined')`.
+
+When generating IDs with `generateId()` (which returns `Id`, a different brand), cast through string: `generateId() as string as ConversationId`.
+
+See the `static-workspace-api` skill for the full pattern and rules.
+
 # Const Generic Array Inference
 
 Use `const T extends readonly T[]` to preserve literal types without requiring `as const` at call sites.

--- a/.agents/skills/workspace-api/SKILL.md
+++ b/.agents/skills/workspace-api/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: static-workspace-api
-description: Static workspace API patterns for defineTable, defineKv, versioning, and migrations. Use when defining workspace schemas, adding versions to existing tables/KV stores, or writing migration functions.
+name: workspace-api
+description: Workspace API patterns for defineTable, defineKv, versioning, and migrations. Use when defining workspace schemas, adding versions to existing tables/KV stores, or writing migration functions.
 metadata:
   author: epicenter
-  version: '2.0'
+  version: '3.0'
 ---
 
-# Static Workspace API
+# Workspace API
 
 Type-safe schema definitions for tables and KV stores with versioned migrations.
 
@@ -24,7 +24,7 @@ Type-safe schema definitions for tables and KV stores with versioned migrations.
 Use when a table has only one version:
 
 ```typescript
-import { defineTable } from 'epicenter/static';
+import { defineTable } from '@epicenter/hq';
 import { type } from 'arktype';
 
 const users = defineTable(type({ id: 'string', email: 'string', _v: '1' }));
@@ -57,7 +57,7 @@ KV stores are flexible — `_v` is optional. Both patterns work:
 ### Without `_v` (field presence)
 
 ```typescript
-import { defineKv } from 'epicenter/static';
+import { defineKv } from '@epicenter/hq';
 
 const sidebar = defineKv(type({ collapsed: 'boolean', width: 'number' }));
 
@@ -203,8 +203,8 @@ return { ...row, views: 0, _v: 2 as const }; // Also works — redundant
 
 ## References
 
-- `packages/epicenter/src/static/define-table.ts`
-- `packages/epicenter/src/static/define-kv.ts`
-- `packages/epicenter/src/static/index.ts`
-- `packages/epicenter/src/static/create-tables.ts`
-- `packages/epicenter/src/static/create-kv.ts`
+- `packages/epicenter/src/workspace/define-table.ts`
+- `packages/epicenter/src/workspace/define-kv.ts`
+- `packages/epicenter/src/workspace/index.ts`
+- `packages/epicenter/src/workspace/create-tables.ts`
+- `packages/epicenter/src/workspace/create-kv.ts`

--- a/apps/tab-manager/src/entrypoints/background.ts
+++ b/apps/tab-manager/src/entrypoints/background.ts
@@ -38,6 +38,7 @@ import {
 	createGroupCompositeId,
 	createTabCompositeId,
 	createWindowCompositeId,
+	type DeviceId,
 	definition,
 	type GroupCompositeId,
 	parseGroupId,
@@ -368,7 +369,7 @@ export default defineBackground(() => {
 	// ─────────────────────────────────────────────────────────────────────────
 
 	const whenReady = (async (): Promise<{
-		deviceId: string;
+		deviceId: DeviceId;
 	}> => {
 		const deviceId = await deviceIdPromise;
 

--- a/apps/tab-manager/src/lib/device/device-id.ts
+++ b/apps/tab-manager/src/lib/device/device-id.ts
@@ -8,6 +8,7 @@
 
 import { generateId } from '@epicenter/hq';
 import { storage } from '@wxt-dev/storage';
+import type { DeviceId } from '$lib/workspace';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Device ID Storage
@@ -25,14 +26,14 @@ const deviceIdItem = storage.defineItem<string>('local:deviceId', {
  * In-memory cache for device ID to avoid repeated storage lookups.
  * Reset on browser restart (null initially).
  */
-let cachedDeviceId: string | null = null;
+let cachedDeviceId: DeviceId | null = null;
 
 /**
  * Get the stable device ID for this browser installation.
  * Generated once on first install, persisted in storage.local.
  * Cached in memory after first access to avoid repeated storage calls.
  */
-export async function getDeviceId(): Promise<string> {
+export async function getDeviceId(): Promise<DeviceId> {
 	// Return cached value if available
 	if (cachedDeviceId !== null) {
 		return cachedDeviceId;
@@ -46,8 +47,8 @@ export async function getDeviceId(): Promise<string> {
 	}
 
 	// Cache for future calls
-	cachedDeviceId = deviceId;
-	return deviceId;
+	cachedDeviceId = deviceId as DeviceId;
+	return cachedDeviceId;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/apps/tab-manager/src/lib/state/browser-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/browser-state.svelte.ts
@@ -27,6 +27,7 @@ import { getDeviceId } from '$lib/device/device-id';
 import { tabToRow, windowToRow } from '$lib/sync/row-converters';
 import {
 	createWindowCompositeId,
+	type DeviceId,
 	type Tab,
 	type Window,
 	type WindowCompositeId,
@@ -68,7 +69,7 @@ function createBrowserState() {
 	 * events that arrive before the seed completes are silently dropped
 	 * (they'd be stale anyway — the seed is the authoritative snapshot).
 	 */
-	let deviceId: string | null = null;
+	let deviceId: DeviceId | null = null;
 
 	// ── Seed ─────────────────────────────────────────────────────────────
 	// Single IPC call via `getAll({ populate: true })` returns windows with

--- a/apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts
@@ -33,7 +33,7 @@
 
 import { generateId } from '@epicenter/hq';
 import { getDeviceId } from '$lib/device/device-id';
-import type { SavedTab, Tab } from '$lib/workspace';
+import type { SavedTab, SavedTabId, Tab } from '$lib/workspace';
 import { popupWorkspace } from '$lib/workspace-popup';
 
 function createSavedTabState() {
@@ -86,7 +86,7 @@ function createSavedTabState() {
 				if (!tab.url) return;
 				const deviceId = await getDeviceId();
 				popupWorkspace.tables.savedTabs.set({
-					id: generateId(),
+					id: generateId() as string as SavedTabId,
 					url: tab.url,
 					title: tab.title || 'Untitled',
 					favIconUrl: tab.favIconUrl,
@@ -149,7 +149,7 @@ function createSavedTabState() {
 			},
 
 			/** Delete a saved tab without restoring it. */
-			remove(id: string) {
+			remove(id: SavedTabId) {
 				popupWorkspace.tables.savedTabs.delete(id);
 			},
 

--- a/apps/tab-manager/src/lib/sync/row-converters.ts
+++ b/apps/tab-manager/src/lib/sync/row-converters.ts
@@ -9,6 +9,7 @@ import {
 	createGroupCompositeId,
 	createTabCompositeId,
 	createWindowCompositeId,
+	type DeviceId,
 	TAB_ID_NONE,
 	type Tab,
 	type TabGroup,
@@ -33,7 +34,10 @@ import {
  * if (row) tables.tabs.set(row);
  * ```
  */
-export function tabToRow(deviceId: string, tab: Browser.tabs.Tab): Tab | null {
+export function tabToRow(
+	deviceId: DeviceId,
+	tab: Browser.tabs.Tab,
+): Tab | null {
 	// tab.id is undefined for foreign tabs (sessions API) and TAB_ID_NONE (-1)
 	// for non-browser tabs like devtools windows.
 	if (tab.id === undefined || tab.id === TAB_ID_NONE) return null;
@@ -68,7 +72,7 @@ export function tabToRow(deviceId: string, tab: Browser.tabs.Tab): Tab | null {
  * ```
  */
 export function windowToRow(
-	deviceId: string,
+	deviceId: DeviceId,
 	window: Browser.windows.Window,
 ): Window | null {
 	if (window.id === undefined) return null;
@@ -97,7 +101,7 @@ export function windowToRow(
  * ```
  */
 export function tabGroupToRow(
-	deviceId: string,
+	deviceId: DeviceId,
 	group: Browser.tabGroups.TabGroup,
 ): TabGroup {
 	const { id, windowId, ...rest } = group;


### PR DESCRIPTION
Table IDs in the tab-manager workspace are all plain strings at the type level, which means you can pass a `ConversationId` where a `ChatMessageId` is expected and TypeScript won't complain. This has already caused subtle bugs in the chat state where conversation IDs and message IDs were accidentally swapped in Map lookups.

This applies the same branding pattern we already use for composite IDs (`WindowCompositeId`, `TabCompositeId`, `GroupCompositeId`) to all remaining table primary keys and foreign keys:

```typescript
// Before — all IDs are interchangeable strings
id: 'string',
conversationId: 'string',
deviceId: 'string',

// After — each ID is a distinct nominal type
id: ConversationId,
conversationId: ConversationId,
deviceId: DeviceId,
```

Each branded type follows the established `type + const` dual-export pattern:

```typescript
export type DeviceId = string & Brand<'DeviceId'>;
export const DeviceId = type('string').pipe((s): DeviceId => s as DeviceId);
```

The branding permeates through all consumers — `generateId()` calls cast through string (`generateId() as string as ConversationId`), function parameters accept the specific branded type, and Maps/state variables are typed with the correct ID:

```typescript
// chat.svelte.ts
let conversationId = $state<ConversationId | null>(null);
const conversationClients = new Map<ConversationId, ChatClient>();

// device-id.ts
export async function getDeviceId(): Promise<DeviceId> { ... }

// row-converters.ts
export function convertTabRow(deviceId: DeviceId, tab: Tab): TabRow { ... }
```

```
┌─────────────────────────────────────────────────────────────┐
│  Branded ID Coverage                                        │
├────────────────────────┬────────────────────────────────────┤
│  DeviceId              │  devices.id, tabs.deviceId,        │
│                        │  windows.deviceId, tabGroups.      │
│                        │  deviceId, savedTabs.sourceDeviceId│
├────────────────────────┼────────────────────────────────────┤
│  SavedTabId            │  savedTabs.id                      │
├────────────────────────┼────────────────────────────────────┤
│  ConversationId        │  conversations.id,                 │
│                        │  conversations.parentId,           │
│                        │  chatMessages.conversationId       │
├────────────────────────┼────────────────────────────────────┤
│  ChatMessageId         │  chatMessages.id,                  │
│                        │  conversations.sourceMessageId     │
├────────────────────────┼────────────────────────────────────┤
│  (already existed)     │  TabCompositeId, WindowCompositeId,│
│                        │  GroupCompositeId                  │
└────────────────────────┴────────────────────────────────────┘
```

The workspace-api and typescript agent skills have been updated to document this as a required pattern for all future `defineTable` schemas, so new tables will get branded IDs from the start.