### PR TITLE
feat(ai): add AI tools and command queue for cross-device tab management

### DIFF
--- a/.agents/skills/arktype/SKILL.md
+++ b/.agents/skills/arktype/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: arktype
+description: Arktype patterns for discriminated unions using .merge() and .or(), spread key syntax, and type composition. Use when building union types, combining base schemas with variants, or defining command/event schemas with arktype.
+---
+
+# Arktype Discriminated Unions
+
+Patterns for composing discriminated unions with arktype's `.merge()` and `.or()` methods.
+
+## When to Apply This Skill
+
+- Defining a discriminated union schema (e.g., commands, events, actions)
+- Composing a base type with per-variant fields
+- Working with `defineTable()` schemas that use union types
+
+## `type.or()` + `.merge()` Pattern (Recommended for 5+ variants)
+
+Use when you have shared base fields, per-variant payloads discriminated on a literal key, and **5 or more variants**. The static `type.or()` form avoids deeply nested `.or()` chaining and reads as a flat list.
+
+**Important**: `.merge()` only accepts object types, not unions. You cannot do `commandBase.merge(variantA.or(variantB))` — you must merge each variant individually, then combine via `type.or()`.
+
+```typescript
+import { type } from 'arktype';
+
+const commandBase = type({
+	id: 'string',
+	deviceId: DeviceId,
+	createdAt: 'number',
+	_v: '1',
+});
+
+const Command = type.or(
+	commandBase.merge({
+		action: "'closeTabs'",
+		tabIds: 'string[]',
+		'result?': type({ closedCount: 'number' }).or('undefined'),
+	}),
+	commandBase.merge({
+		action: "'openTab'",
+		url: 'string',
+		'result?': type({ tabId: 'string' }).or('undefined'),
+	}),
+	commandBase.merge({
+		action: "'activateTab'",
+		tabId: 'string',
+		'result?': type({ activated: 'boolean' }).or('undefined'),
+	}),
+);
+```
+
+### How it works
+
+1. `commandBase.merge({...})` creates a new object type with all base fields plus the variant-specific fields. Conflicting keys are overwritten by the merge argument.
+2. `type.or(...)` creates the union from all branches at once. Arktype auto-detects the `action` key as a discriminant because each branch has a distinct literal value.
+3. `switch (cmd.action)` in TypeScript narrows the full union — payload fields and result types are type-safe per branch.
+
+### Why this pattern
+
+| Property                  | Benefit                                                       |
+| ------------------------- | ------------------------------------------------------------- |
+| Base is a real `Type`     | Reusable, composable, inspectable at runtime                  |
+| `.merge()` is first-class | Not a workaround — arktype's own API for type combination     |
+| `type.or()` is flat       | No deeply nested `.or()` chains — reads as a list of variants |
+| Auto-discrimination       | No manual discriminant config needed                          |
+| Flat payload              | No nested `payload` object — fields are top-level             |
+
+## `.merge().or()` Chaining Pattern (Good for 2-4 variants)
+
+Use when you have a small number of variants where chaining reads naturally.
+
+```typescript
+const Command = commandBase
+	.merge({
+		action: "'closeTabs'",
+		tabIds: 'string[]',
+		'result?': type({ closedCount: 'number' }).or('undefined'),
+	})
+	.or(
+		commandBase.merge({
+			action: "'openTab'",
+			url: 'string',
+			'result?': type({ tabId: 'string' }).or('undefined'),
+		}),
+	);
+```
+
+Same semantics as `type.or()` — the only difference is readability at scale. For 5+ variants, prefer `type.or()`.
+
+## The `"..."` Spread Key Pattern (Alternative)
+
+Use when defining inline without a pre-declared base variable, or when you prefer a more compact syntax.
+
+```typescript
+const User = type({ isAdmin: 'false', name: 'string' });
+
+const Admin = type({
+	'...': User,
+	isAdmin: 'true',
+	permissions: 'string[]',
+});
+```
+
+The `"..."` key spreads all properties from the referenced type into the new object definition. Conflicting keys in the outer object override the spread type (same as `.merge()`).
+
+### Spread key in unions
+
+```typescript
+const Command = type({
+	'...': commandBase,
+	action: "'closeTabs'",
+	tabIds: 'string[]',
+}).or({
+	'...': commandBase,
+	action: "'openTab'",
+	url: 'string',
+});
+```
+
+Functionally equivalent to `.merge().or()`. Choose based on readability preference.
+
+## `.or()` Chaining vs `type.or()` Static
+
+### Chaining (preferred for 2-4 variants)
+
+```typescript
+const Command = variantA.or(variantB).or(variantC);
+```
+
+### Static `type.or()` (preferred for 5+ variants)
+
+```typescript
+const Command = type.or(variantA, variantB, variantC, variantD, variantE);
+```
+
+The static form avoids deeply nested chaining and creates the union in a single call.
+
+## `.merge()` Limitations
+
+**`.merge()` only accepts object types.** You cannot pass a union type into `.merge()`:
+
+```typescript
+// ❌ WRONG: .merge() rejects union types
+commandBase.merge(variantA.or(variantB));
+
+// ✅ CORRECT: merge each variant individually, then union
+type.or(commandBase.merge(variantA), commandBase.merge(variantB));
+```
+
+Arktype's `NaryMergeParser` validates that each argument `extends object` and will produce an error if you pass a union.
+
+## Optional Properties in Unions
+
+Use arktype's `'key?'` syntax for optional properties. Never use `| undefined` for optionals — it breaks JSON Schema conversion.
+
+```typescript
+// Good: optional property syntax
+commandBase.merge({
+	action: "'openTab'",
+	url: 'string',
+	'windowId?': 'string',
+	'result?': type({ tabId: 'string' }).or('undefined'),
+});
+
+// Bad: explicit undefined union on a required key
+commandBase.merge({
+	action: "'openTab'",
+	url: 'string',
+	windowId: 'string | undefined', // Breaks JSON Schema
+});
+```
+
+The `'result?': type({...}).or('undefined')` pattern is correct — the `?` makes the key optional, and `.or('undefined')` allows the value to be explicitly `undefined` when present. This is the standard pattern for "pending = absent, done = has value" semantics.
+
+## Merge Behavior
+
+- **Override**: When both the base and merge argument define the same key, the merge argument wins
+- **Optional preservation**: If a key is optional (`'key?'`) in the base and required in the merge, the merge argument's optionality wins
+- **No deep merge**: `.merge()` is shallow — it replaces top-level keys, not nested objects
+
+## Discriminant Detection
+
+Arktype auto-detects discriminants when union branches have distinct literal values on the same key:
+
+```typescript
+const AorB = type({ kind: "'A'", value: 'number' }).or({
+	kind: "'B'",
+	label: 'string',
+});
+
+// Arktype internally uses `kind` as the discriminant
+// Validation checks `kind` first, then validates only the matching branch
+```
+
+This works with any literal type — string literals, number literals, or boolean literals.
+
+## Anti-Patterns
+
+### JS object spread (loses Type composition)
+
+```typescript
+// Bad: base is a plain object, not a Type
+const baseFields = { id: 'string', deviceId: DeviceId, createdAt: 'number' };
+const Command = type({ ...baseFields, action: "'closeTabs'" }).or({
+	...baseFields,
+	action: "'openTab'",
+});
+```
+
+This works but `baseFields` is not an arktype `Type` — you can't call `.merge()`, `.or()`, or inspect it at runtime. Prefer `.merge()` when the base should be a proper type.
+
+### Passing unions into `.merge()`
+
+```typescript
+// Bad: .merge() only accepts object types
+commandBase.merge(variantA.or(variantB));
+
+// Good: merge individually, then union
+type.or(commandBase.merge(variantA), commandBase.merge(variantB));
+```
+
+### Forgetting `'key?'` syntax for optionals
+
+```typescript
+// Bad: makes windowId required but accepting undefined
+commandBase.merge({ windowId: 'string | undefined' });
+
+// Good: makes windowId truly optional
+commandBase.merge({ 'windowId?': 'string' });
+```
+
+## References
+
+- `apps/tab-manager/src/lib/workspace.ts` — Commands table using `type.or()` + `.merge()` (when implemented)
+- `.agents/skills/typescript/SKILL.md` — Arktype optional properties section
+- `.agents/skills/workspace-api/SKILL.md` — `defineTable()` accepts union types

--- a/.claude/skills/arktype
+++ b/.claude/skills/arktype
@@ -1,0 +1,1 @@
+../../.agents/skills/arktype

--- a/.claude/skills/static-workspace-api
+++ b/.claude/skills/static-workspace-api
@@ -1,1 +1,0 @@
-../../.agents/skills/static-workspace-api

--- a/.claude/skills/testing
+++ b/.claude/skills/testing
@@ -1,0 +1,1 @@
+../../.agents/skills/testing

--- a/.claude/skills/workspace-api
+++ b/.claude/skills/workspace-api
@@ -1,0 +1,1 @@
+../../.agents/skills/workspace-api

--- a/apps/tab-manager/src/entrypoints/background.ts
+++ b/apps/tab-manager/src/entrypoints/background.ts
@@ -28,13 +28,13 @@ import { indexeddbPersistence } from '@epicenter/hq/extensions/sync/web';
 import { Ok, tryAsync } from 'wellcrafted/result';
 import { defineBackground } from 'wxt/utils/define-background';
 import type { Transaction } from 'yjs';
+import { startCommandConsumer } from '$lib/commands/consumer';
 import {
 	generateDefaultDeviceName,
 	getBrowserName,
 	getDeviceId,
 } from '$lib/device/device-id';
 import { tabGroupToRow, tabToRow, windowToRow } from '$lib/sync/row-converters';
-import { startCommandConsumer } from '$lib/commands/consumer';
 import {
 	createGroupCompositeId,
 	createTabCompositeId,
@@ -388,10 +388,13 @@ export default defineBackground(() => {
 	// ─────────────────────────────────────────────────────────────────────────
 
 	whenReady.then(({ deviceId }) => {
-		startCommandConsumer(client.tables.commands, client.tables.savedTabs, deviceId);
+		startCommandConsumer(
+			client.tables.commands,
+			client.tables.savedTabs,
+			deviceId,
+		);
 		console.log('[Background] Command consumer started');
 	});
-
 
 	// ─────────────────────────────────────────────────────────────────────────
 	// Browser Keepalive (Chrome MV3 only)

--- a/apps/tab-manager/src/entrypoints/background.ts
+++ b/apps/tab-manager/src/entrypoints/background.ts
@@ -34,6 +34,7 @@ import {
 	getDeviceId,
 } from '$lib/device/device-id';
 import { tabGroupToRow, tabToRow, windowToRow } from '$lib/sync/row-converters';
+import { startCommandConsumer } from '$lib/commands/consumer';
 import {
 	createGroupCompositeId,
 	createTabCompositeId,
@@ -381,6 +382,16 @@ export default defineBackground(() => {
 		console.error('[Background] Initialization failed:', err);
 		throw err;
 	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	// Command Consumer — execute AI commands targeting this device
+	// ─────────────────────────────────────────────────────────────────────────
+
+	whenReady.then(({ deviceId }) => {
+		startCommandConsumer(client.tables.commands, client.tables.savedTabs, deviceId);
+		console.log('[Background] Command consumer started');
+	});
+
 
 	// ─────────────────────────────────────────────────────────────────────────
 	// Browser Keepalive (Chrome MV3 only)

--- a/apps/tab-manager/src/lib/commands/actions.ts
+++ b/apps/tab-manager/src/lib/commands/actions.ts
@@ -6,11 +6,10 @@
  * after filtering for this device and checking TTL.
  */
 
-import { generateId } from '@epicenter/hq';
-import type { Command, DeviceId, SavedTabId } from '$lib/workspace';
-import { parseTabId } from '$lib/workspace';
 import type { TableHelper } from '@epicenter/hq';
-import type { SavedTab } from '$lib/workspace';
+import { generateId } from '@epicenter/hq';
+import type { Command, DeviceId, SavedTab, SavedTabId } from '$lib/workspace';
+import { parseTabId } from '$lib/workspace';
 
 /**
  * Extract the native tab ID (number) from a composite tab ID string.
@@ -18,7 +17,10 @@ import type { SavedTab } from '$lib/workspace';
  * Composite format: `${deviceId}_${tabId}`. Returns the number portion.
  * Returns `undefined` if the composite ID doesn't belong to this device.
  */
-function nativeTabId(compositeId: string, deviceId: DeviceId): number | undefined {
+function nativeTabId(
+	compositeId: string,
+	deviceId: DeviceId,
+): number | undefined {
 	const parsed = parseTabId(compositeId as Parameters<typeof parseTabId>[0]);
 	if (!parsed || parsed.deviceId !== deviceId) return undefined;
 	return parsed.tabId;

--- a/apps/tab-manager/src/lib/commands/actions.ts
+++ b/apps/tab-manager/src/lib/commands/actions.ts
@@ -1,0 +1,213 @@
+/**
+ * Per-action Chrome API execution functions.
+ *
+ * Each function receives the command payload, executes the corresponding
+ * Chrome browser API, and returns the result. Called by the command consumer
+ * after filtering for this device and checking TTL.
+ */
+
+import { generateId } from '@epicenter/hq';
+import type { Command, DeviceId, SavedTabId } from '$lib/workspace';
+import { parseTabId } from '$lib/workspace';
+import type { TableHelper } from '@epicenter/hq';
+import type { SavedTab } from '$lib/workspace';
+
+/**
+ * Extract the native tab ID (number) from a composite tab ID string.
+ *
+ * Composite format: `${deviceId}_${tabId}`. Returns the number portion.
+ * Returns `undefined` if the composite ID doesn't belong to this device.
+ */
+function nativeTabId(compositeId: string, deviceId: DeviceId): number | undefined {
+	const parsed = parseTabId(compositeId as Parameters<typeof parseTabId>[0]);
+	if (!parsed || parsed.deviceId !== deviceId) return undefined;
+	return parsed.tabId;
+}
+
+/**
+ * Close the specified tabs.
+ */
+export async function executeCloseTabs(
+	tabIds: string[],
+	deviceId: DeviceId,
+): Promise<{ closedCount: number }> {
+	const nativeIds = tabIds
+		.map((id) => nativeTabId(id, deviceId))
+		.filter((id) => id !== undefined);
+
+	let closedCount = 0;
+	for (const id of nativeIds) {
+		try {
+			await browser.tabs.remove(id);
+			closedCount++;
+		} catch {
+			// Tab may already be closed
+		}
+	}
+	return { closedCount };
+}
+
+/**
+ * Open a new tab with the given URL.
+ */
+export async function executeOpenTab(
+	url: string,
+	_windowId?: string,
+): Promise<{ tabId: string }> {
+	const tab = await browser.tabs.create({ url });
+	return { tabId: String(tab.id ?? -1) };
+}
+
+/**
+ * Activate (focus) a specific tab.
+ */
+export async function executeActivateTab(
+	compositeTabId: string,
+	deviceId: DeviceId,
+): Promise<{ activated: boolean }> {
+	const id = nativeTabId(compositeTabId, deviceId);
+	if (id === undefined) return { activated: false };
+
+	try {
+		await browser.tabs.update(id, { active: true });
+		return { activated: true };
+	} catch {
+		return { activated: false };
+	}
+}
+
+/**
+ * Save tabs to the savedTabs table, optionally closing them.
+ */
+export async function executeSaveTabs(
+	tabIds: string[],
+	close: boolean,
+	deviceId: DeviceId,
+	savedTabsTable: TableHelper<SavedTab>,
+): Promise<{ savedCount: number }> {
+	let savedCount = 0;
+	for (const compositeId of tabIds) {
+		const id = nativeTabId(compositeId, deviceId);
+		if (id === undefined) continue;
+
+		try {
+			const tab = await browser.tabs.get(id);
+			if (!tab.url) continue;
+
+			savedTabsTable.set({
+				id: generateId() as string as SavedTabId,
+				url: tab.url,
+				title: tab.title || 'Untitled',
+				favIconUrl: tab.favIconUrl,
+				pinned: tab.pinned ?? false,
+				sourceDeviceId: deviceId,
+				savedAt: Date.now(),
+				_v: 1,
+			});
+			savedCount++;
+
+			if (close) {
+				await browser.tabs.remove(id);
+			}
+		} catch {
+			// Tab may have been closed already
+		}
+	}
+	return { savedCount };
+}
+
+/**
+ * Group tabs together with an optional title and color.
+ */
+export async function executeGroupTabs(
+	tabIds: string[],
+	deviceId: DeviceId,
+	title?: string,
+	color?: string,
+): Promise<{ groupId: string }> {
+	const nativeIds = tabIds
+		.map((id) => nativeTabId(id, deviceId))
+		.filter((id) => id !== undefined);
+
+	const groupId = await browser.tabs.group({ tabIds: nativeIds });
+
+	if (title || color) {
+		const updateProps: browser.TabGroups.UpdateProperties = {};
+		if (title) updateProps.title = title;
+		if (color) updateProps.color = color as browser.TabGroups.ColorEnum;
+		await browser.tabGroups.update(groupId, updateProps);
+	}
+
+	return { groupId: String(groupId) };
+}
+
+/**
+ * Pin or unpin tabs.
+ */
+export async function executePinTabs(
+	tabIds: string[],
+	pinned: boolean,
+	deviceId: DeviceId,
+): Promise<{ pinnedCount: number }> {
+	const nativeIds = tabIds
+		.map((id) => nativeTabId(id, deviceId))
+		.filter((id) => id !== undefined);
+
+	let pinnedCount = 0;
+	for (const id of nativeIds) {
+		try {
+			await browser.tabs.update(id, { pinned });
+			pinnedCount++;
+		} catch {
+			// Tab may not exist
+		}
+	}
+	return { pinnedCount };
+}
+
+/**
+ * Mute or unmute tabs.
+ */
+export async function executeMuteTabs(
+	tabIds: string[],
+	muted: boolean,
+	deviceId: DeviceId,
+): Promise<{ mutedCount: number }> {
+	const nativeIds = tabIds
+		.map((id) => nativeTabId(id, deviceId))
+		.filter((id) => id !== undefined);
+
+	let mutedCount = 0;
+	for (const id of nativeIds) {
+		try {
+			await browser.tabs.update(id, { muted });
+			mutedCount++;
+		} catch {
+			// Tab may not exist
+		}
+	}
+	return { mutedCount };
+}
+
+/**
+ * Reload tabs.
+ */
+export async function executeReloadTabs(
+	tabIds: string[],
+	deviceId: DeviceId,
+): Promise<{ reloadedCount: number }> {
+	const nativeIds = tabIds
+		.map((id) => nativeTabId(id, deviceId))
+		.filter((id) => id !== undefined);
+
+	let reloadedCount = 0;
+	for (const id of nativeIds) {
+		try {
+			await browser.tabs.reload(id);
+			reloadedCount++;
+		} catch {
+			// Tab may not exist
+		}
+	}
+	return { reloadedCount };
+}

--- a/apps/tab-manager/src/lib/commands/constants.ts
+++ b/apps/tab-manager/src/lib/commands/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * Maximum time a command stays actionable after creation.
+ *
+ * If the target device doesn't execute a command within this window,
+ * the command is considered expired. The server times out its
+ * `waitForCommandResult` promise, and the device skips stale commands
+ * on wake.
+ */
+export const COMMAND_TTL_MS = 30_000;

--- a/apps/tab-manager/src/lib/commands/consumer.ts
+++ b/apps/tab-manager/src/lib/commands/consumer.ts
@@ -1,0 +1,119 @@
+/**
+ * Command consumer — observes the commands table and executes Chrome APIs.
+ *
+ * Filters for commands targeting this device, checks TTL, dispatches by action,
+ * and writes the result back. Expired commands are deleted.
+ *
+ * @see specs/20260223T200500-ai-tools-command-queue.md
+ */
+
+import type { TableHelper } from '@epicenter/hq';
+import type { Command, DeviceId, SavedTab } from '$lib/workspace';
+import {
+	executeActivateTab,
+	executeCloseTabs,
+	executeGroupTabs,
+	executeMuteTabs,
+	executeOpenTab,
+	executePinTabs,
+	executeReloadTabs,
+	executeSaveTabs,
+} from './actions';
+import { COMMAND_TTL_MS } from './constants';
+
+/**
+ * Start observing the commands table and executing commands for this device.
+ *
+ * Returns an unsubscribe function to stop the observer.
+ *
+ * @param commandsTable - The table helper for the commands table
+ * @param savedTabsTable - The table helper for the savedTabs table (needed by saveTabs action)
+ * @param deviceId - This device's ID
+ */
+export function startCommandConsumer(
+	commandsTable: TableHelper<Command>,
+	savedTabsTable: TableHelper<SavedTab>,
+	deviceId: DeviceId,
+): () => void {
+	return commandsTable.observe((changedIds) => {
+		for (const id of changedIds) {
+			const result = commandsTable.get(id);
+			if (result.status !== 'valid') continue;
+
+			const cmd = result.row;
+
+			// Only process commands targeting this device
+			if (cmd.deviceId !== deviceId) continue;
+
+			// Skip already-completed commands
+			if (cmd.result !== undefined) continue;
+
+			// Check TTL — delete expired commands, skip execution
+			const isExpired = cmd.createdAt + COMMAND_TTL_MS < Date.now();
+			if (isExpired) {
+				commandsTable.delete(id);
+				continue;
+			}
+
+			// Dispatch by action and write result
+			void executeCommand(cmd, commandsTable, savedTabsTable, deviceId);
+		}
+	});
+}
+
+/**
+ * Execute a single command and write the result back to the table.
+ */
+async function executeCommand(
+	cmd: Command,
+	commandsTable: TableHelper<Command>,
+	savedTabsTable: TableHelper<SavedTab>,
+	deviceId: DeviceId,
+): Promise<void> {
+	try {
+		let commandResult: unknown;
+
+		switch (cmd.action) {
+			case 'closeTabs':
+				commandResult = await executeCloseTabs(cmd.tabIds, deviceId);
+				break;
+			case 'openTab':
+				commandResult = await executeOpenTab(cmd.url, cmd.windowId);
+				break;
+			case 'activateTab':
+				commandResult = await executeActivateTab(cmd.tabId, deviceId);
+				break;
+			case 'saveTabs':
+				commandResult = await executeSaveTabs(
+					cmd.tabIds,
+					cmd.close,
+					deviceId,
+					savedTabsTable,
+				);
+				break;
+			case 'groupTabs':
+				commandResult = await executeGroupTabs(
+					cmd.tabIds,
+					deviceId,
+					cmd.title,
+					cmd.color,
+				);
+				break;
+			case 'pinTabs':
+				commandResult = await executePinTabs(cmd.tabIds, cmd.pinned, deviceId);
+				break;
+			case 'muteTabs':
+				commandResult = await executeMuteTabs(cmd.tabIds, cmd.muted, deviceId);
+				break;
+			case 'reloadTabs':
+				commandResult = await executeReloadTabs(cmd.tabIds, deviceId);
+				break;
+		}
+
+		// Write result back — cast needed because discriminated union narrows
+		// per-action but we're writing the generic Command shape back
+		commandsTable.set({ ...cmd, result: commandResult } as Command);
+	} catch (error) {
+		console.error('[Commands] Failed to execute command:', cmd.action, error);
+	}
+}

--- a/apps/tab-manager/src/lib/workspace.ts
+++ b/apps/tab-manager/src/lib/workspace.ts
@@ -89,9 +89,7 @@ export const ChatMessageId = type('string').pipe(
  * Prevents accidental mixing with other string IDs (tab, conversation, etc.).
  */
 export type CommandId = string & Brand<'CommandId'>;
-export const CommandId = type('string').pipe(
-	(s): CommandId => s as CommandId,
-);
+export const CommandId = type('string').pipe((s): CommandId => s as CommandId);
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Composite ID Types

--- a/docs/articles/bearer-tokens-are-cookies-without-the-cookie-jar.md
+++ b/docs/articles/bearer-tokens-are-cookies-without-the-cookie-jar.md
@@ -1,0 +1,101 @@
+# Bearer Tokens Are Cookies Without the Cookie Jar
+
+A bearer token is a session cookie sent as a header instead of a cookie. To behave like a cookie, it needs the same two properties: included in every request, and persisted across requests. Since there's no cookie jar to handle that automatically, you store the token yourself (local storage, a file, a Rust variable) and read it back into the `Authorization` header before each request.
+
+```
+Cookie:                               Bearer token:
+
+  Set-Cookie: session=abc123            { "token": "abc123" }
+  ↓                                     ↓
+  Browser stores in cookie jar          You store in localStorage
+  ↓                                     ↓
+  Browser sends automatically:          You send manually:
+  Cookie: session=abc123                Authorization: Bearer abc123
+  ↓                                     ↓
+  Server reads cookie                   Server reads header
+  ↓                                     ↓
+  DB lookup → user                      DB lookup → user
+```
+
+Same token. Same server-side validation. Same result. The only difference is who's responsible for storage and delivery.
+
+## Cookies are automatic; bearer tokens are manual
+With cookies, the browser does everything. You sign in, the server responds with `Set-Cookie: session=abc123`, and every subsequent request to that domain carries it. Zero code.
+
+With bearer tokens, you do the two jobs yourself: persist the token, and include it on every request. This is why Better Auth's docs tell you to extract the token on sign-in and store it:
+
+```typescript
+const { data } = await authClient.signIn.email({
+  email: "user@example.com",
+  password: "securepassword"
+}, {
+  onSuccess: (ctx) => {
+    // Get the token from the response headers
+    const authToken = ctx.response.headers.get("set-auth-token");
+    // Store the token securely (e.g., in localStorage)
+    localStorage.setItem("bearer_token", authToken);
+  }
+});
+```
+
+And then configure the client to read it back and include it in every request:
+
+```typescript
+export const authClient = createAuthClient({
+  fetchOptions: {
+    auth: {
+      type: "Bearer",
+      token: () => localStorage.getItem("bearer_token") || ""
+    }
+  }
+});
+```
+
+That's the whole pattern. Extract the token, store it, read it back into the header. You're doing what the cookie jar does, manually.
+Three steps instead of zero. So why bother?
+
+## Cookies break outside the browser
+
+The cookie jar is a browser feature. It handles `Set-Cookie` parsing, `SameSite` policies, `Secure` flags, domain scoping, expiry, and cross-origin rules. Browsers have spent decades getting this right.
+
+Desktop apps don't have a cookie jar. Tauri uses the system webview (WebKit on macOS, WebView2 on Windows), and each has its own problems:
+
+| Problem                                           | What happens                              |
+| ------------------------------------------------- | ----------------------------------------- |
+| WebKit rejects `Secure` cookies from `tauri://`   | Cookie silently vanishes. No error.       |
+| Webview and Rust HTTP have separate cookie stores | Sign in via one, the other doesn't know.  |
+| Debug builds work, release builds don't           | Cookie persistence changes between modes. |
+
+Bearer tokens sidestep all of this. The token is a string. Put it anywhere. Read it back. Attach it. No cookie machinery, no platform quirks.
+
+## How Better Auth bridges the gap
+
+Better Auth is cookie-first, but its `bearer()` plugin makes it work for non-browser clients. When the plugin is active, the sign-in response includes the token in three places:
+
+```
+HTTP/1.1 200 OK
+Set-Cookie: session_token=abc123    ← for browsers
+set-auth-token: abc123              ← response header for native apps
+Content-Type: application/json
+
+{ "token": "abc123", "user": {...} } ← response body
+```
+
+The native client ignores `Set-Cookie` and grabs the token from the body or header. On subsequent requests, the bearer plugin intercepts `Authorization: Bearer abc123`, converts it to a cookie internally, and hands it to Better Auth's normal session logic:
+
+```
+Tauri App              bearer() plugin              Better Auth
+    │                       │                           │
+    │  Authorization:       │                           │
+    │  Bearer abc123   ────►│  convert to cookie   ────►│  getSession()
+    │                       │  header internally        │  ↓
+    │◄── 200 ───────────────│◄── user session ─────────│  DB lookup
+```
+
+Better Auth doesn't know the token came from a header. It thinks it read a cookie. Same validation, same session, same user.
+
+## The mental model
+
+A session cookie is a token with automatic delivery. A bearer token is the same token with manual delivery. Persistence moves from the cookie jar to your app's storage. Transport moves from `Cookie:` to `Authorization:`. Everything else is identical: token format, server validation, session lifetime, revocation.
+
+Browsers: use cookies. Everything else: use bearer tokens.

--- a/packages/server/src/ai/plugin.test.ts
+++ b/packages/server/src/ai/plugin.test.ts
@@ -86,7 +86,9 @@ describe('createAIPlugin', () => {
 
 	test('route is reachable through Elysia prefix mount', async () => {
 		const app = new Elysia().use(
-			new Elysia({ prefix: '/ai' }).use(createAIPlugin({ getDoc: () => undefined })),
+			new Elysia({ prefix: '/ai' }).use(
+				createAIPlugin({ getDoc: () => undefined }),
+			),
 		);
 
 		const response = await app.handle(

--- a/packages/server/src/ai/plugin.test.ts
+++ b/packages/server/src/ai/plugin.test.ts
@@ -17,7 +17,7 @@ function chatRequest(
 
 describe('createAIPlugin', () => {
 	test('returns 401 when x-provider-api-key header is missing', async () => {
-		const app = new Elysia().use(createAIPlugin());
+		const app = new Elysia().use(createAIPlugin({ getDoc: () => undefined }));
 
 		const response = await app.handle(
 			chatRequest('/chat', {
@@ -33,7 +33,7 @@ describe('createAIPlugin', () => {
 	});
 
 	test('returns 400 for unsupported provider', async () => {
-		const app = new Elysia().use(createAIPlugin());
+		const app = new Elysia().use(createAIPlugin({ getDoc: () => undefined }));
 
 		const response = await app.handle(
 			chatRequest(
@@ -53,7 +53,7 @@ describe('createAIPlugin', () => {
 	});
 
 	test('returns 422 when required body fields are missing', async () => {
-		const app = new Elysia().use(createAIPlugin());
+		const app = new Elysia().use(createAIPlugin({ getDoc: () => undefined }));
 
 		const response = await app.handle(
 			chatRequest(
@@ -68,7 +68,7 @@ describe('createAIPlugin', () => {
 	});
 
 	test('unsupported provider returns 400 (ollama removed)', async () => {
-		const app = new Elysia().use(createAIPlugin());
+		const app = new Elysia().use(createAIPlugin({ getDoc: () => undefined }));
 
 		const response = await app.handle(
 			chatRequest('/chat', {
@@ -86,7 +86,7 @@ describe('createAIPlugin', () => {
 
 	test('route is reachable through Elysia prefix mount', async () => {
 		const app = new Elysia().use(
-			new Elysia({ prefix: '/ai' }).use(createAIPlugin()),
+			new Elysia({ prefix: '/ai' }).use(createAIPlugin({ getDoc: () => undefined })),
 		);
 
 		const response = await app.handle(
@@ -128,7 +128,7 @@ describe('createAIPlugin', () => {
 	});
 
 	test('401 error message mentions env var name', async () => {
-		const app = new Elysia().use(createAIPlugin());
+		const app = new Elysia().use(createAIPlugin({ getDoc: () => undefined }));
 		delete process.env.OPENAI_API_KEY;
 
 		const response = await app.handle(
@@ -145,7 +145,7 @@ describe('createAIPlugin', () => {
 	});
 
 	test('plugin accepts request without header when env var set', async () => {
-		const app = new Elysia().use(createAIPlugin());
+		const app = new Elysia().use(createAIPlugin({ getDoc: () => undefined }));
 		process.env.OPENAI_API_KEY = 'sk-test-env-key';
 
 		try {

--- a/packages/server/src/ai/plugin.ts
+++ b/packages/server/src/ai/plugin.ts
@@ -1,15 +1,29 @@
-import { chat, toServerSentEventsResponse } from '@tanstack/ai';
+import { chat, maxIterations, toServerSentEventsResponse } from '@tanstack/ai';
 import { Elysia, t } from 'elysia';
 import { Err, trySync } from 'wellcrafted/result';
+import type * as Y from 'yjs';
 import {
 	createAdapter,
 	isSupportedProvider,
 	PROVIDER_ENV_VARS,
 	resolveApiKey,
 } from './adapters';
+import { createMutationTools } from './tools/mutation-tools';
+import { createReadTools } from './tools/read-tools';
+
+export type AIPluginConfig = {
+	/**
+	 * Retrieve a Y.Doc by room name.
+	 *
+	 * Used to create table helpers for the tab-manager workspace,
+	 * enabling read tools (query tabs/windows/devices) and mutation tools
+	 * (write commands to the commands table).
+	 */
+	getDoc: (room: string) => Y.Doc | undefined;
+};
 
 /**
- * Creates an Elysia plugin that provides a streaming AI chat endpoint.
+ * Creates an Elysia plugin that provides a streaming AI chat endpoint with tools.
  *
  * Registers a single route:
  *
@@ -18,8 +32,8 @@ import {
  * | `POST` | `/chat` | Streaming chat via SSE (Server-Sent Events)         |
  *
  * The client sends messages, provider name, model, and API key (via header).
- * The server creates the appropriate TanStack AI adapter, calls `chat()`,
- * and streams the response back as SSE using `toServerSentEventsResponse()`.
+ * The server creates the appropriate TanStack AI adapter, calls `chat()` with
+ * read and mutation tools, and streams the response back as SSE.
  *
  * **API key resolution chain:**
  * 1. `x-provider-api-key` header (per-request BYOK — user's own billing)
@@ -32,11 +46,11 @@ import {
  * import { createAIPlugin } from '@epicenter/server/ai';
  *
  * const app = new Elysia()
- *   .use(new Elysia({ prefix: '/ai' }).use(createAIPlugin()))
+ *   .use(new Elysia({ prefix: '/ai' }).use(createAIPlugin({ getDoc })))
  *   .listen(3913);
  * ```
  */
-export function createAIPlugin() {
+export function createAIPlugin({ getDoc }: AIPluginConfig) {
 	return new Elysia().post(
 		'/chat',
 		async ({ body, headers, status }) => {
@@ -69,6 +83,12 @@ export function createAIPlugin() {
 				return status('Bad Request', `Unsupported provider: ${provider}`);
 			}
 
+			// Build tools from the tab-manager Y.Doc (if available)
+			const doc = getDoc('tab-manager');
+			const tools = doc
+				? [...createReadTools(doc), ...createMutationTools(doc)]
+				: [];
+
 			const abortController = new AbortController();
 
 			const { data: stream, error: chatError } = trySync({
@@ -78,7 +98,12 @@ export function createAIPlugin() {
 						messages,
 						conversationId,
 						abortController,
-						...(systemPrompt ? { systemPrompts: [systemPrompt] } : {}),
+						tools,
+						agentLoopStrategy: maxIterations(10),
+						systemPrompts: [
+							SYSTEM_PROMPT,
+							...(systemPrompt ? [systemPrompt] : []),
+						],
 						...(modelOptions ? { modelOptions } : {}),
 					}),
 				catch: (e) => Err(e instanceof Error ? e : new Error(String(e))),
@@ -111,3 +136,17 @@ export function createAIPlugin() {
 		},
 	);
 }
+
+const SYSTEM_PROMPT = `You are a helpful browser tab manager assistant. You can search, list, organize, and manage browser tabs across the user's devices.
+
+Available capabilities:
+- Search and list tabs, windows, and devices across all synced browsers
+- Close, open, activate, pin, mute, group, save, and reload tabs
+- Aggregate tab counts by domain
+
+Guidelines:
+- When the user asks to close/manage tabs, use searchTabs first to find the right ones
+- When a device is ambiguous, use listDevices to show options and ask the user
+- Tab IDs are composite (deviceId_tabId) — always use the full composite ID from search results
+- For mutations, all tabs in a single command must belong to the same device
+- Be concise in responses — confirm what you did, don't over-explain`;

--- a/packages/server/src/ai/tools/definitions.ts
+++ b/packages/server/src/ai/tools/definitions.ts
@@ -27,8 +27,7 @@ export const searchTabsDef = toolDefinition({
 
 export const listTabsDef = toolDefinition({
 	name: 'listTabs',
-	description:
-		'List all open tabs. Optionally filter by device or window.',
+	description: 'List all open tabs. Optionally filter by device or window.',
 	inputSchema: type({
 		'deviceId?': 'string',
 		'windowId?': 'string',
@@ -92,8 +91,7 @@ export const activateTabDef = toolDefinition({
 
 export const saveTabsDef = toolDefinition({
 	name: 'saveTabs',
-	description:
-		'Save tabs for later. Optionally close them after saving.',
+	description: 'Save tabs for later. Optionally close them after saving.',
 	inputSchema: type({
 		tabIds: 'string[]',
 		'close?': 'boolean',

--- a/packages/server/src/ai/tools/definitions.ts
+++ b/packages/server/src/ai/tools/definitions.ts
@@ -1,0 +1,137 @@
+/**
+ * Tool definition contracts for AI chat.
+ *
+ * Uses `toolDefinition()` from TanStack AI with arktype schemas (Standard
+ * Schema compatible). Definitions are shared; `.server()` implementations
+ * live in read-tools.ts and mutation-tools.ts.
+ *
+ * @see docs/articles/tanstack-ai-isomorphic-tool-pattern.md
+ */
+
+import { toolDefinition } from '@tanstack/ai';
+import { type } from 'arktype';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Read Tools (5)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const searchTabsDef = toolDefinition({
+	name: 'searchTabs',
+	description:
+		'Search tabs by URL or title match. Returns matching tabs across all devices, optionally scoped to one device.',
+	inputSchema: type({
+		query: 'string',
+		'deviceId?': 'string',
+	}),
+});
+
+export const listTabsDef = toolDefinition({
+	name: 'listTabs',
+	description:
+		'List all open tabs. Optionally filter by device or window.',
+	inputSchema: type({
+		'deviceId?': 'string',
+		'windowId?': 'string',
+	}),
+});
+
+export const listWindowsDef = toolDefinition({
+	name: 'listWindows',
+	description:
+		'List all browser windows with their tab counts. Optionally filter by device.',
+	inputSchema: type({
+		'deviceId?': 'string',
+	}),
+});
+
+export const listDevicesDef = toolDefinition({
+	name: 'listDevices',
+	description:
+		'List all synced devices with their names, browsers, and online status.',
+	inputSchema: type({}),
+});
+
+export const countByDomainDef = toolDefinition({
+	name: 'countByDomain',
+	description:
+		'Count open tabs grouped by domain (e.g. youtube.com: 5, github.com: 3). Optionally filter by device.',
+	inputSchema: type({
+		'deviceId?': 'string',
+	}),
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mutation Tools (8)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const closeTabsDef = toolDefinition({
+	name: 'closeTabs',
+	description: 'Close one or more tabs by their composite IDs.',
+	inputSchema: type({
+		tabIds: 'string[]',
+	}),
+});
+
+export const openTabDef = toolDefinition({
+	name: 'openTab',
+	description: 'Open a new tab with the given URL on a specific device.',
+	inputSchema: type({
+		url: 'string',
+		deviceId: 'string',
+		'windowId?': 'string',
+	}),
+});
+
+export const activateTabDef = toolDefinition({
+	name: 'activateTab',
+	description: 'Activate (focus) a specific tab by its composite ID.',
+	inputSchema: type({
+		tabId: 'string',
+	}),
+});
+
+export const saveTabsDef = toolDefinition({
+	name: 'saveTabs',
+	description:
+		'Save tabs for later. Optionally close them after saving.',
+	inputSchema: type({
+		tabIds: 'string[]',
+		'close?': 'boolean',
+	}),
+});
+
+export const groupTabsDef = toolDefinition({
+	name: 'groupTabs',
+	description: 'Group tabs together with an optional title and color.',
+	inputSchema: type({
+		tabIds: 'string[]',
+		'title?': 'string',
+		'color?': 'string',
+	}),
+});
+
+export const pinTabsDef = toolDefinition({
+	name: 'pinTabs',
+	description: 'Pin or unpin tabs.',
+	inputSchema: type({
+		tabIds: 'string[]',
+		pinned: 'boolean',
+	}),
+});
+
+export const muteTabsDef = toolDefinition({
+	name: 'muteTabs',
+	description: 'Mute or unmute tabs.',
+	inputSchema: type({
+		tabIds: 'string[]',
+		muted: 'boolean',
+	}),
+});
+
+export const reloadTabsDef = toolDefinition({
+	name: 'reloadTabs',
+	description: 'Reload one or more tabs.',
+	inputSchema: type({
+		tabIds: 'string[]',
+	}),
+});

--- a/packages/server/src/ai/tools/mutation-tools.ts
+++ b/packages/server/src/ai/tools/mutation-tools.ts
@@ -1,0 +1,213 @@
+/**
+ * Server-side mutation tool implementations.
+ *
+ * Each tool writes a command row to the `commands` table in the Y.Doc,
+ * then awaits the result via `waitForCommandResult()`. The target device's
+ * background worker observes the command, executes Chrome APIs, and writes
+ * the result back.
+ *
+ * @see specs/20260223T200500-ai-tools-command-queue.md
+ */
+
+import { createTables, generateId } from '@epicenter/hq';
+import {
+	type Command,
+	type CommandId,
+	type DeviceId,
+	definition,
+} from '@epicenter/tab-manager/workspace';
+import type * as Y from 'yjs';
+import {
+	activateTabDef,
+	closeTabsDef,
+	groupTabsDef,
+	muteTabsDef,
+	openTabDef,
+	pinTabsDef,
+	reloadTabsDef,
+	saveTabsDef,
+} from './definitions';
+import { waitForCommandResult } from './wait-for-result';
+
+/**
+ * Maximum time a command stays actionable after creation.
+ *
+ * Duplicated from `apps/tab-manager/src/lib/commands/constants.ts` because
+ * the tab-manager package only exports `./workspace`. Both values must stay
+ * in sync.
+ */
+const COMMAND_TTL_MS = 30_000;
+
+/**
+ * Extract the device ID from a composite tab ID (`${deviceId}_${tabId}`).
+ */
+function extractDeviceId(compositeId: string): DeviceId {
+	const idx = compositeId.indexOf('_');
+	if (idx === -1) return compositeId as DeviceId;
+	return compositeId.slice(0, idx) as DeviceId;
+}
+
+/**
+ * Extract device ID from the first element of a composite ID array.
+ *
+ * All tabs in a single command must belong to the same device,
+ * so extracting from the first element is correct.
+ */
+function extractDeviceIdFromIds(compositeIds: string[]): DeviceId {
+	const first = compositeIds[0];
+	if (!first) throw new Error('tabIds array is empty');
+	return extractDeviceId(first);
+}
+
+/**
+ * Create a fresh command ID.
+ */
+function createCommandId(): CommandId {
+	return generateId() as string as CommandId;
+}
+
+/**
+ * Create server-side mutation tools bound to a Y.Doc.
+ *
+ * Each tool writes a command row to the `commands` table, then blocks
+ * (async) until the target device writes the result or TTL expires.
+ *
+ * @param doc - The tab-manager Y.Doc (from the sync plugin's dynamicDocs)
+ * @returns Array of server tools ready for `chat({ tools })`
+ */
+export function createMutationTools(doc: Y.Doc) {
+	// biome-ignore lint/style/noNonNullAssertion: tab-manager definition always has tables
+	const tables = createTables(doc, definition.tables!);
+
+	/**
+	 * Write a command and await its result.
+	 *
+	 * Shared by all mutation tools — extracts `deviceId` from the first
+	 * composite ID (or uses an explicit one), writes the command row,
+	 * and waits for the background worker to write the result.
+	 */
+	function writeAndAwait(command: Command): Promise<unknown> {
+		tables.commands.set(command);
+		return waitForCommandResult(tables.commands, command.id, COMMAND_TTL_MS);
+	}
+
+	return [
+		closeTabsDef.server(async ({ tabIds }) => {
+			const deviceId = extractDeviceIdFromIds(tabIds);
+			const result = await writeAndAwait({
+				id: createCommandId(),
+				deviceId,
+				action: 'closeTabs',
+				tabIds,
+				createdAt: Date.now(),
+				_v: 1,
+			});
+			return result;
+		}),
+
+		openTabDef.server(async ({ url, deviceId, windowId }) => {
+			const result = await writeAndAwait({
+				id: createCommandId(),
+				deviceId: deviceId as DeviceId,
+				action: 'openTab',
+				url,
+				...(windowId ? { windowId } : {}),
+				createdAt: Date.now(),
+				_v: 1,
+			});
+			return result;
+		}),
+
+		activateTabDef.server(async ({ tabId }) => {
+			const deviceId = extractDeviceId(tabId);
+			const result = await writeAndAwait({
+				id: createCommandId(),
+				deviceId,
+				action: 'activateTab',
+				tabId,
+				createdAt: Date.now(),
+				_v: 1,
+			});
+			return result;
+		}),
+
+		saveTabsDef.server(async ({ tabIds, close }) => {
+			const deviceId = extractDeviceIdFromIds(tabIds);
+			const result = await writeAndAwait({
+				id: createCommandId(),
+				deviceId,
+				action: 'saveTabs',
+				tabIds,
+				close: close ?? false,
+				createdAt: Date.now(),
+				_v: 1,
+			});
+			return result;
+		}),
+
+		groupTabsDef.server(async ({ tabIds, title, color }) => {
+			const deviceId = extractDeviceIdFromIds(tabIds);
+			const result = await writeAndAwait({
+				id: createCommandId(),
+				deviceId,
+				action: 'groupTabs',
+				tabIds,
+				...(title ? { title } : {}),
+				...(color
+					? {
+							color: color as Command extends {
+								action: 'groupTabs';
+								color?: infer C;
+							}
+								? C
+								: never,
+						}
+					: {}),
+				createdAt: Date.now(),
+				_v: 1,
+			});
+			return result;
+		}),
+
+		pinTabsDef.server(async ({ tabIds, pinned }) => {
+			const deviceId = extractDeviceIdFromIds(tabIds);
+			const result = await writeAndAwait({
+				id: createCommandId(),
+				deviceId,
+				action: 'pinTabs',
+				tabIds,
+				pinned,
+				createdAt: Date.now(),
+				_v: 1,
+			});
+			return result;
+		}),
+
+		muteTabsDef.server(async ({ tabIds, muted }) => {
+			const deviceId = extractDeviceIdFromIds(tabIds);
+			const result = await writeAndAwait({
+				id: createCommandId(),
+				deviceId,
+				action: 'muteTabs',
+				tabIds,
+				muted,
+				createdAt: Date.now(),
+				_v: 1,
+			});
+			return result;
+		}),
+
+		reloadTabsDef.server(async ({ tabIds }) => {
+			const deviceId = extractDeviceIdFromIds(tabIds);
+			const result = await writeAndAwait({
+				id: createCommandId(),
+				deviceId,
+				action: 'reloadTabs',
+				tabIds,
+				createdAt: Date.now(),
+				_v: 1,
+			});
+			return result;
+		}),
+	];
+}

--- a/packages/server/src/ai/tools/read-tools.ts
+++ b/packages/server/src/ai/tools/read-tools.ts
@@ -1,0 +1,129 @@
+/**
+ * Server-side read tool implementations.
+ *
+ * Each tool queries the tab-manager Y.Doc tables directly. Instant,
+ * cross-device global view — no command queue needed.
+ *
+ * @see specs/20260223T200500-ai-tools-command-queue.md
+ */
+
+import { createTables } from '@epicenter/hq';
+import { definition } from '@epicenter/tab-manager/workspace';
+import type * as Y from 'yjs';
+import {
+	countByDomainDef,
+	listDevicesDef,
+	listTabsDef,
+	listWindowsDef,
+	searchTabsDef,
+} from './definitions';
+
+/**
+ * Create server-side read tools bound to a Y.Doc.
+ *
+ * Uses `createTables()` to bind the tab-manager table definitions to the
+ * given doc. Each tool queries tables directly — no Chrome APIs needed.
+ *
+ * @param doc - The tab-manager Y.Doc (from the sync plugin's dynamicDocs)
+ * @returns Array of server tools ready for `chat({ tools })`
+ */
+export function createReadTools(doc: Y.Doc) {
+	// biome-ignore lint/style/noNonNullAssertion: tab-manager definition always has tables
+	const tables = createTables(doc, definition.tables!);
+
+	return [
+		searchTabsDef.server(async ({ query, deviceId }) => {
+			const lower = query.toLowerCase();
+			const tabs = tables.tabs.filter((tab) => {
+				if (deviceId && tab.deviceId !== deviceId) return false;
+				const title = tab.title?.toLowerCase() ?? '';
+				const url = tab.url?.toLowerCase() ?? '';
+				return title.includes(lower) || url.includes(lower);
+			});
+			return {
+				results: tabs.map((tab) => ({
+					id: tab.id,
+					deviceId: tab.deviceId,
+					windowId: tab.windowId,
+					title: tab.title ?? '(untitled)',
+					url: tab.url ?? '',
+					active: tab.active,
+					pinned: tab.pinned,
+				})),
+			};
+		}),
+
+		listTabsDef.server(async ({ deviceId, windowId }) => {
+			const tabs = tables.tabs.filter((tab) => {
+				if (deviceId && tab.deviceId !== deviceId) return false;
+				if (windowId && tab.windowId !== windowId) return false;
+				return true;
+			});
+			return {
+				tabs: tabs.map((tab) => ({
+					id: tab.id,
+					deviceId: tab.deviceId,
+					windowId: tab.windowId,
+					title: tab.title ?? '(untitled)',
+					url: tab.url ?? '',
+					active: tab.active,
+					pinned: tab.pinned,
+					audible: tab.audible ?? false,
+					muted: tab.mutedInfo?.muted ?? false,
+					groupId: tab.groupId ?? null,
+				})),
+			};
+		}),
+
+		listWindowsDef.server(async ({ deviceId }) => {
+			const windows = tables.windows.filter((w) => {
+				if (deviceId && w.deviceId !== deviceId) return false;
+				return true;
+			});
+			const allTabs = tables.tabs.getAllValid();
+			return {
+				windows: windows.map((w) => ({
+					id: w.id,
+					deviceId: w.deviceId,
+					focused: w.focused,
+					state: w.state ?? 'normal',
+					type: w.type ?? 'normal',
+					tabCount: allTabs.filter((t) => t.windowId === w.id).length,
+				})),
+			};
+		}),
+
+		listDevicesDef.server(async () => {
+			const devices = tables.devices.getAllValid();
+			return {
+				devices: devices.map((d) => ({
+					id: d.id,
+					name: d.name,
+					browser: d.browser,
+					lastSeen: d.lastSeen,
+				})),
+			};
+		}),
+
+		countByDomainDef.server(async ({ deviceId }) => {
+			const tabs = tables.tabs.filter((tab) => {
+				if (deviceId && tab.deviceId !== deviceId) return false;
+				return true;
+			});
+			const counts = new Map<string, number>();
+			for (const tab of tabs) {
+				if (!tab.url) continue;
+				try {
+					const domain = new URL(tab.url).hostname;
+					counts.set(domain, (counts.get(domain) ?? 0) + 1);
+				} catch {
+					// Skip tabs with invalid URLs (e.g. chrome:// pages)
+				}
+			}
+			const domains = Array.from(counts.entries())
+				.map(([domain, count]) => ({ domain, count }))
+				.sort((a, b) => b.count - a.count);
+			return { domains };
+		}),
+	];
+}

--- a/packages/server/src/ai/tools/wait-for-result.ts
+++ b/packages/server/src/ai/tools/wait-for-result.ts
@@ -1,0 +1,69 @@
+/**
+ * Promise-based Y.Doc observation for command results.
+ *
+ * The server writes a command row, then waits here until the target device
+ * writes a `result` field or the TTL expires.
+ *
+ * @see specs/20260223T200500-ai-tools-command-queue.md
+ */
+
+import type { TableHelper } from '@epicenter/hq';
+import type { Command } from '@epicenter/tab-manager/workspace';
+
+/**
+ * Wait for a command result by observing the commands table.
+ *
+ * Resolves with the result object when the target device writes it.
+ * Rejects on TTL timeout or abort signal. Cleans up the command row
+ * after resolution (success or abort).
+ *
+ * @param commandsTable - The commands table helper bound to the Y.Doc
+ * @param commandId - The ID of the command to watch
+ * @param ttlMs - Maximum time to wait before timing out
+ * @param abortSignal - Optional signal for client disconnect cleanup
+ * @returns The result object from the command row
+ */
+export function waitForCommandResult(
+	commandsTable: TableHelper<Command>,
+	commandId: string,
+	ttlMs: number,
+	abortSignal?: AbortSignal,
+): Promise<unknown> {
+	return new Promise((resolve, reject) => {
+		let unobserve: (() => void) | undefined;
+
+		const cleanup = () => {
+			clearTimeout(timeout);
+			unobserve?.();
+		};
+
+		const timeout = setTimeout(() => {
+			cleanup();
+			reject(new Error('Command timed out \u2014 device may be offline'));
+		}, ttlMs);
+
+		// Abort when client disconnects
+		abortSignal?.addEventListener(
+			'abort',
+			() => {
+				cleanup();
+				commandsTable.delete(commandId);
+				reject(new DOMException('Client disconnected', 'AbortError'));
+			},
+			{ once: true },
+		);
+
+		unobserve = commandsTable.observe((changedIds) => {
+			if (!changedIds.has(commandId)) return;
+			const result = commandsTable.get(commandId);
+			if (result.status !== 'valid') return;
+			if (!result.row.result) return;
+
+			const commandResult = result.row.result;
+			cleanup();
+			// Clean up the command row after getting result
+			commandsTable.delete(commandId);
+			resolve(commandResult);
+		});
+	});
+}

--- a/packages/server/src/hub.ts
+++ b/packages/server/src/hub.ts
@@ -103,7 +103,9 @@ export function createHubServer(config: HubServerConfig) {
 				}),
 			),
 		)
-		.use(new Elysia({ prefix: '/ai' }).use(createAIPlugin()))
+		.use(new Elysia({ prefix: '/ai' }).use(createAIPlugin({
+			getDoc: (room) => dynamicDocs.get(room),
+		})))
 		.get('/', () => ({
 			name: 'Epicenter Hub',
 			version: '1.0.0',

--- a/packages/server/src/hub.ts
+++ b/packages/server/src/hub.ts
@@ -103,9 +103,13 @@ export function createHubServer(config: HubServerConfig) {
 				}),
 			),
 		)
-		.use(new Elysia({ prefix: '/ai' }).use(createAIPlugin({
-			getDoc: (room) => dynamicDocs.get(room),
-		})))
+		.use(
+			new Elysia({ prefix: '/ai' }).use(
+				createAIPlugin({
+					getDoc: (room) => dynamicDocs.get(room),
+				}),
+			),
+		)
 		.get('/', () => ({
 			name: 'Epicenter Hub',
 			version: '1.0.0',

--- a/specs/20260223T160300-jwt-auth-for-local-server-and-sync.md
+++ b/specs/20260223T160300-jwt-auth-for-local-server-and-sync.md
@@ -1,0 +1,225 @@
+# Simplified Auth: Bearer Tokens for Hub, Open Mode for Local Server
+
+**Date**: 2026-02-23
+**Status**: Draft
+**Author**: AI-assisted
+
+## Overview
+
+Simplify the authentication architecture by using a single token type (Better Auth session token) and eliminating JWT entirely. The Tauri app uses bearer tokens for hub communication to bypass unreliable webview cookies. The local server operates in open mode, relying on localhost-only binding and CORS restrictions for security.
+
+## Motivation
+
+### Current State
+
+The hub server runs Better Auth with the `bearer()` plugin. The local server validates sessions by making a raw `fetch` to the hub on every unique token, caching results for 5 minutes:
+
+```typescript
+// packages/server/src/auth/local-auth.ts (line 108)
+const response = await fetch(`${hubUrl}/auth/get-session`, {
+	headers: { Authorization: `Bearer ${token}` },
+});
+```
+
+The sync layer has its own independent auth system with three modes:
+
+```typescript
+// packages/sync/src/types.ts
+type SyncProviderConfig = {
+	token?: string; // Mode 2: static shared secret
+	getToken?: () => Promise<string>; // Mode 3: dynamic token fetcher
+};
+```
+
+The proxy plugin (`packages/server/src/proxy/plugin.ts`) also validates sessions via an injected `validateSession` callback, which in practice would also be a fetch-based check.
+
+This creates problems:
+
+1. **Hub coupling**: Every unique token triggers an HTTP roundtrip to the hub. The 5-minute cache helps, but each new token still incurs network latency + a DB lookup on the hub.
+2. **Hub-down fragility**: If the hub is unreachable, the local server falls back to stale cache entries only. New tokens cannot be validated at all.
+3. **Environment variable sprawl**: The local server would need `BETTER_AUTH_SECRET` and database access to run Better Auth locally, which defeats the stateless-sidecar design.
+4. **Parallel auth systems**: Sync auth (static token / `getToken`) and HTTP auth (Bearer → hub fetch) are completely separate. A user authenticates twice through different mechanisms.
+5. **No offline grace period**: Once the cache expires, a valid user gets 401'd if the hub is down — even though their session hasn't actually expired.
+
+### Desired State
+
+A unified auth system using a single session token. The Tauri app authenticates with the hub via Bearer tokens. The local server and local sync layer run without auth, secured by network isolation. Hub-hosted sync and proxy services validate the session token directly against the database.
+
+## Research Findings
+
+### Tauri Webview Cookies Are Unreliable
+
+Tauri's reliance on the system webview (WebKit on macOS, WebView2 on Windows) introduces significant cookie management issues:
+
+- WebKit rejects `Secure` cookies from `tauri://` origins (Issue #2604).
+- Two independent cookie jars exist: the webview vs `@tauri-apps/plugin-http` (Issue #13045).
+- Debug vs Release builds show inconsistent cookie persistence (Issue #2490).
+- Lucia Auth explicitly recommends bearer tokens over cookies for Tauri apps.
+
+**Conclusion**: Tauri apps must use bearer tokens for reliable authentication.
+
+### Better Auth Native App Support
+
+Better Auth provides built-in support for native apps via the `bearer()` plugin:
+
+- The `bearer()` plugin adds a `set-auth-token` response header (source: `packages/better-auth/src/plugins/bearer/index.ts`).
+- Sign-in and sign-up endpoints already return `{ token: session.token }` in the response body.
+- `createAuthClient` supports `fetchOptions.auth.type: "Bearer"` with a token callback.
+- Community plugins like `@daveyplate/better-auth-tauri` implement similar patterns.
+
+### Local Server Doesn't Need Auth
+
+The local server's security model relies on network isolation rather than cryptographic tokens:
+
+- It binds to `localhost` only, preventing external access.
+- CORS is restricted to `tauri://localhost`.
+- Any local process capable of hitting the API could also read the underlying Yjs files or SQLite database directly.
+- Auth on localhost is "defense-in-depth theater" — it adds complexity without a meaningful security gain.
+- This matches the security model of Docker Desktop, VS Code Server, Raycast, and Obsidian sync.
+
+### Better Auth Token Architecture
+
+Better Auth uses two cookies, not one:
+
+| Cookie                    | Format                                                       | Purpose                       |
+| ------------------------- | ------------------------------------------------------------ | ----------------------------- |
+| `session_token`           | Opaque random string, HMAC-SHA256 signed                     | Database lookup key           |
+| `session_data` (optional) | `compact` (base64+HMAC), `jwt` (HS256), or `jwe` (encrypted) | Read-cache to skip DB lookups |
+
+**Key finding**: The `session_token` is never a JWT. It's a random string that maps to a `session` table row. The HMAC signature prevents cookie tampering, not token forgery.
+
+**Implication**: You cannot validate a `session_token` without the hub's database. This is why the current local-auth.ts must fetch from the hub.
+
+### Better Auth JWT Plugin (Previous Research)
+
+Better Auth provides a `jwt()` plugin for service-to-service auth:
+
+| Aspect                 | Detail                                                                            |
+| ---------------------- | --------------------------------------------------------------------------------- |
+| Token endpoint         | `GET /auth/token` (requires active session via cookie or bearer)                  |
+| JWKS endpoint          | `GET /auth/jwks` (public, no auth required)                                       |
+| Default algorithm      | EdDSA with Ed25519 curve                                                          |
+| Default TTL            | 15 minutes                                                                        |
+| Key storage            | `jwks` database table (`id`, `publicKey`, `privateKey`, `createdAt`, `expiresAt`) |
+| Key rotation           | Optional `rotationInterval` (seconds) + `gracePeriod` (default 30 days)           |
+| Private key encryption | AES256 GCM by default (can disable)                                               |
+
+**Implication**: While JWT allows local validation, it adds significant complexity (JWKS, rotation, short TTLs, refresh logic) that is unnecessary if the local server doesn't require auth.
+
+### Bearer Plugin Does NOT Validate JWTs
+
+The `bearer()` plugin only handles **opaque session tokens**, not JWTs.
+
+When a request arrives with `Authorization: Bearer <token>`:
+
+1. Bearer plugin extracts the token.
+2. Attempts to deserialize it as a **session cookie** (HMAC-SHA256 signed).
+3. If valid session token → converts to cookie header → normal session flow.
+4. If JWT → fails silently.
+
+### JWKS Validation with jose
+
+The `jose` library provides `createRemoteJWKSet` for fetching and caching public keys. This was the proposed mechanism for local JWT validation before the architecture was simplified.
+
+### Sync Auth Integration
+
+The sync provider's Mode 3 (`getToken` callback) supports dynamic token fetching. The sync server validates tokens in the WebSocket `open` handler.
+
+## Why Not JWT?
+
+The original spec proposed JWT to avoid hub roundtrips on the local server. However, if the local server doesn't need auth at all, there are no roundtrips to avoid. JWT adds complexity (JWKS, jose, token refresh, 15-minute TTL) for a problem that doesn't exist in our threat model.
+
+## Design Decisions
+
+| Decision           | Choice                             | Rationale                                                                           |
+| ------------------ | ---------------------------------- | ----------------------------------------------------------------------------------- |
+| Auth Token Type    | Better Auth Session Token (Opaque) | Simplest model. Supported natively by Better Auth and the `bearer()` plugin.        |
+| Hub Auth Mechanism | Bearer Token                       | Bypasses unreliable Tauri webview cookies.                                          |
+| Local Server Auth  | None (Open Mode)                   | Secured by localhost binding and CORS. Auth on localhost is unnecessary complexity. |
+| Local Sync Auth    | None (Open Mode)                   | Same as local server.                                                               |
+| Hub Sync Auth      | Session Token via Query Param      | Validated by `auth.api.getSession()` at connect time.                               |
+| Proxy Plugin Auth  | Session Token via Bearer Header    | Validated by Better Auth directly on the hub.                                       |
+| JWT Usage          | Eliminated                         | Over-engineered for the threat model. Adds complexity without benefit.              |
+| `jose` Dependency  | Dropped                            | No longer needed for JWT validation.                                                |
+| JWKS Endpoint      | Dropped                            | No longer needed.                                                                   |
+| Token Storage      | `tauri-plugin-store`               | Persistent, secure storage for the session token on the client.                     |
+
+## Architecture
+
+The new architecture uses ONE token type (Better Auth session token) and eliminates JWT entirely:
+
+```
+Tauri App                    Hub Server                   Local Server
+    │                         │                              │
+    │── POST /auth/sign-in ──►│                              │
+    │◄── { token: "ses..." } ─│  (session token in body +    │
+    │    + set-auth-token hdr  │   set-auth-token header)     │
+    │                         │                              │
+    │  store token in         │                              │
+    │  tauri-plugin-store     │                              │
+    │                         │                              │
+    │── Bearer ses... ───────►│  bearer() converts to cookie │
+    │◄── 200 OK ──────────────│  Better Auth validates       │
+    │                         │                              │
+    │── http://localhost ─────────────────────────────────────►│
+    │   (no auth needed)       │                              │  localhost-only
+    │◄── 200 OK ──────────────────────────────────────────────│  CORS: tauri://localhost
+    │                         │                              │
+    │── ws://hub/rooms?token=ses... ─►│                      │
+    │                         │  auth.api.getSession()       │
+    │                         │                              │
+    │── ws://localhost/rooms ──────────────────────────────────►│
+    │   (no auth needed)                                      │  open mode
+```
+
+### Key Points
+
+- **Hub auth**: Session token via `Authorization: Bearer` header. The `bearer()` plugin converts this to a cookie, which Better Auth validates via database lookup.
+- **Local server auth**: None. Localhost-only binding and CORS restriction to `tauri://localhost` provide sufficient isolation.
+- **Hub sync auth**: Session token passed via query parameter, validated by `auth.api.getSession()` during the WebSocket handshake.
+- **Local sync auth**: Open mode (no auth).
+- **Proxy plugin auth**: Session token via Bearer header, validated by Better Auth directly (runs on the hub where the database is accessible).
+
+## Implementation Plan
+
+### Phase 1: Local Server Cleanup
+
+- [ ] **1.1** Remove `packages/server/src/auth/local-auth.ts`.
+- [ ] **1.2** Remove the hub fetch validator from the local server startup.
+- [ ] **1.3** Remove `hubUrl` configuration requirement from the local server (it now defaults to open mode).
+
+### Phase 2: Hub Sync Auth
+
+- [ ] **2.1** Update hub sync layer to use Better Auth `getSession()` for token validation.
+- [ ] **2.2** Ensure the `?token=` query parameter is correctly extracted and passed to the validator.
+
+### Phase 3: Proxy Auth
+
+- [ ] **3.1** Update the proxy plugin to validate Bearer tokens using Better Auth's internal API.
+- [ ] **3.2** Ensure the proxy runs on the hub where it has database access.
+
+### Phase 4: Frontend Integration
+
+- [ ] **4.1** Configure `createAuthClient` to use `tauri-plugin-store` for token persistence.
+- [ ] **4.2** Set `fetchOptions.auth.type` to `"Bearer"` in the auth client.
+- [ ] **4.3** Update the sync provider to pass the stored session token in the connection URL.
+
+### Phase 5: Cleanup
+
+- [ ] **5.1** Remove any remaining JWT-related code or configuration.
+- [ ] **5.2** Update documentation to reflect the simplified bearer-only model.
+
+## Success Criteria
+
+- [ ] Tauri app successfully signs in and receives an opaque session token.
+- [ ] Hub API requests succeed using the `Authorization: Bearer` header.
+- [ ] Local server accepts requests from the Tauri app without requiring a token.
+- [ ] Local server rejects requests from non-Tauri origins via CORS.
+- [ ] Hub sync connections are authorized using the session token.
+- [ ] Local sync connections work in open mode.
+- [ ] No JWT, `jose`, or JWKS complexity remains in the codebase.
+
+## Revision History
+
+- **v1 (original)**: Proposed a 3-token JWT architecture for local server and sync validation. Over-engineered for the threat model.
+- **v2 (current)**: Simplified to bearer-only for hub communication and open mode for the local server. Eliminated JWT, `jose`, and JWKS entirely.

--- a/specs/20260223T200500-ai-tools-command-queue.md
+++ b/specs/20260223T200500-ai-tools-command-queue.md
@@ -1,0 +1,567 @@
+# AI Tools via Command Queue
+
+**Date**: 2026-02-23
+**Status**: Draft
+**Author**: AI-assisted design session
+
+---
+
+## Overview
+
+Add AI tool calling to the tab manager chat. Read tools query the Y.Doc on the server for cross-device tab state. Mutation tools write to a `commands` table with a discriminated union schema — the target device's background worker observes, executes the Chrome API action, and writes the result. The `action` field discriminates the union; payload fields and result types are flattened and fully typed per action (no JSON strings).
+
+---
+
+## Motivation
+
+### Current State
+
+The AI chat endpoint (`packages/server/src/ai/plugin.ts`) passes zero tools to `chat()`:
+
+```typescript
+const stream = chat({
+	adapter,
+	messages,
+	conversationId,
+	abortController,
+});
+```
+
+The extension chat (`apps/tab-manager/src/lib/state/chat.svelte.ts`) sends messages to the server but has no way to act on tabs. The AI can only generate text — it can't search, close, or organize tabs.
+
+### Problems
+
+1. **No tab awareness**: The AI can't see what tabs are open. It can only respond to what the user types.
+2. **No tab actions**: "Close my YouTube tabs" requires 15 manual clicks. The AI could do it in one sentence.
+3. **No cross-device reach**: The background worker has `browser.tabs.*` APIs, but only for its own device. The Y.Doc already syncs all devices' tabs to the server — read tools get a global view for free.
+
+### Desired State
+
+User types "close my YouTube tabs on my work laptop" → AI calls `searchTabs` (server reads Y.Doc) → finds 5 YouTube tabs on device "abc" → calls `closeTabs` (server writes command row targeting device "abc") → background worker on work laptop observes, executes `browser.tabs.remove()`, writes result → AI reports "Closed 5 YouTube tabs on your MacBook."
+
+---
+
+## Research Findings
+
+### Arktype Discriminated Unions
+
+Arktype supports discriminated unions natively via `.or()` chaining, with automatic discrimination on literal-typed keys.
+
+Three patterns for combining base fields with variants:
+
+| Pattern                      | Syntax                                                                              | Tradeoff                                                                       |
+| ---------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| **`type.or()` + `.merge()`** | `type.or(base.merge({action: "'foo'", ...}), base.merge({action: "'bar'", ...}))`   | Cleanest for 5+ variants — flat list, no nesting, base is a real `Type`        |
+| **`.merge().or()` chaining** | `base.merge({action: "'foo'", ...}).or(base.merge({action: "'bar'", ...}))`         | Good for 2-4 variants — base is a real `Type`, merge is first-class            |
+| **`"..."` spread key**       | `type({"...": base, action: "'foo'", ...}).or({"...": base, action: "'bar'", ...})` | Also clean, inline syntax                                                      |
+| **JS object spread**         | `type({...baseObj, action: "'foo'", ...}).or({...baseObj, action: "'bar'", ...})`   | Works but base is a plain object, not a Type — loses arktype-level composition |
+
+**Recommendation**: `type.or()` + `.merge()` — for 5+ variants (like our 8 command actions), the static `type.or()` form avoids deeply nested `.or()` chaining and reads as a flat list of variants. Each variant still uses `.merge()` to combine the base type with variant-specific fields.
+
+**Important**: `.merge()` only accepts object types, not unions. You cannot do `commandBase.merge(variantA.or(variantB))` — you must merge each variant individually, then union the results.
+
+```typescript
+const commandBase = type({
+	id: 'string',
+	deviceId: DeviceId,
+	createdAt: 'number',
+	_v: '1' as const,
+});
+
+// Static type.or() — preferred for 5+ variants
+const Command = type.or(
+	commandBase.merge({
+		action: "'closeTabs'",
+		tabIds: 'string[]',
+		'result?': type({ closedCount: 'number' }).or('undefined'),
+	}),
+	commandBase.merge({
+		action: "'openTab'",
+		url: 'string',
+		'result?': type({ tabId: 'string' }).or('undefined'),
+	}),
+);
+// arktype auto-discriminates on `action`
+```
+
+### TanStack AI Tool Pattern
+
+TanStack AI uses `toolDefinition()` to define tool contracts with Zod schemas, then `.server()` / `.client()` to attach implementations.
+
+For this feature, all tools use `.server()` implementations:
+
+- **Read tools**: Query the Y.Doc tables directly on the server
+- **Mutation tools**: Write to the `commands` table and await the result via Y.Doc observation
+
+The server already has the Y.Doc via the sync plugin's `dynamicDocs` map. The AI plugin needs access to this map (or the specific tab-manager Y.Doc) to create table helpers for read tools and command writing.
+
+### Server Y.Doc Access
+
+The hub server creates ephemeral Y.Docs in `dynamicDocs`:
+
+```typescript
+// hub.ts — current
+const dynamicDocs = new Map<string, Y.Doc>();
+// ...
+getDoc: (room) => {
+  if (!dynamicDocs.has(room)) dynamicDocs.set(room, new Y.Doc());
+  return dynamicDocs.get(room);
+},
+```
+
+The AI plugin needs the tab-manager Y.Doc to:
+
+1. Read tables (tabs, windows, devices, tabGroups) for read tools
+2. Write to the `commands` table for mutation tools
+3. Observe the `commands` table for results
+
+This means `createAIPlugin()` needs the `dynamicDocs` map (or a `getDoc` callback) passed in from the hub.
+
+---
+
+## Design Decisions
+
+| Decision                 | Choice                                                      | Rationale                                                                                                                   |
+| ------------------------ | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Tool execution location  | Server-side `.server()` for all tools                       | Read tools query Y.Doc directly; mutation tools write commands. No client tools needed — avoids sidepanel↔background relay. |
+| Mutation mechanism       | `commands` table in Y.Doc                                   | Persists across brief disconnects (within TTL). Cross-device by design. Background worker already observes Y.Doc tables.    |
+| Command schema           | Discriminated union on `action` key                         | Type-safe dispatch, no JSON.parse, payload/result typed per action. Arktype auto-discriminates.                             |
+| Union pattern            | `type.or()` + `.merge()`                                    | Static `type.or()` for flat readability with 8 variants. `.merge()` per variant to compose base fields.                     |
+| TTL strategy             | Constant `COMMAND_TTL_MS = 30_000` derived from `createdAt` | All commands have the same urgency. No per-command expiry field needed (YAGNI).                                             |
+| Status tracking          | Implicit from `result?` field                               | No result = pending, has result = done, expired = `createdAt + TTL < now && no result`. Fewer fields.                       |
+| Pin/mute commands        | Bidirectional (`pinned: boolean`, `muted: boolean`)         | One command instead of two (pinTabs/unpinTabs → pinTabs with `pinned` flag). Fewer union variants.                          |
+| Server-side Y.Doc access | Pass `getDoc` callback to `createAIPlugin()`                | Hub already has `dynamicDocs`. Plugin gets the tab-manager doc on demand.                                                   |
+| Tool schema library      | Zod (required by TanStack AI `toolDefinition`)              | `toolDefinition()` requires Zod schemas for `inputSchema`/`outputSchema`. Arktype is used for the Y.Doc table schema.       |
+
+---
+
+## Architecture
+
+### System Overview
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Extension Side Panel (Svelte UI)                                            │
+│  ┌─────────────────────────────────────────┐                                 │
+│  │ chat.svelte.ts                          │                                 │
+│  │ createChat({ connection: SSE })         │                                 │
+│  │ No client tools — server handles all    │                                 │
+│  └──────────────┬──────────────────────────┘                                 │
+│                 │ POST /ai/chat                                              │
+└─────────────────┼────────────────────────────────────────────────────────────┘
+                  │
+                  ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Hub Server (Elysia, localhost:3913)                                         │
+│                                                                              │
+│  /ai/chat endpoint                                                           │
+│    │                                                                         │
+│    ▼                                                                         │
+│  chat({                                                                      │
+│    adapter,                                                                  │
+│    messages,                                                                 │
+│    tools: [                                                                  │
+│      ── Read Tools (instant, cross-device) ──                                │
+│      searchTabs    → query tabs table in Y.Doc                               │
+│      listTabs      → query tabs table in Y.Doc                               │
+│      listWindows   → query windows table in Y.Doc                            │
+│      listDevices   → awareness + devices table                               │
+│      countByDomain → aggregate from tabs table                               │
+│                                                                              │
+│      ── Mutation Tools (command queue) ──                                     │
+│      closeTabs     → write command → await result                            │
+│      openTab       → write command → await result                            │
+│      activateTab   → write command → await result                            │
+│      saveTabs      → write command → await result                            │
+│      groupTabs     → write command → await result                            │
+│      pinTabs       → write command → await result                            │
+│      muteTabs      → write command → await result                            │
+│      reloadTabs    → write command → await result                            │
+│    ],                                                                        │
+│  })                                                                          │
+│    │                 │                                                        │
+│    │ SSE stream      │ Y.Doc sync                                            │
+│    ▼                 ▼                                                        │
+└──────────────────────┬───────────────────────────────────────────────────────┘
+                       │
+                       ▼ commands table syncs via Y.Doc
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Extension Background Worker (target device)                                 │
+│                                                                              │
+│  client.tables.commands.observe((changedIds) => {                            │
+│    for each command where:                                                   │
+│      deviceId === myDeviceId                                                 │
+│      && !result                                                              │
+│      && createdAt + COMMAND_TTL_MS > Date.now()                              │
+│    → dispatch(command)                                                       │
+│    → write result                                                            │
+│  })                                                                          │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Command Lifecycle
+
+```
+1. AI tool execute()
+   │
+   ▼
+2. Server writes command to Y.Doc:
+   commands.set({ id, deviceId, action: 'closeTabs', tabIds, createdAt })
+   │
+   ▼
+3. Y.Doc syncs to all devices
+   │
+   ▼
+4. Target device's background worker observes new row
+   Checks: deviceId === mine? No result? Within TTL?
+   │
+   ▼
+5. Executes: browser.tabs.remove(nativeTabIds)
+   │
+   ▼
+6. Writes result: commands.set({ ...cmd, result: { closedCount: 5 } })
+   │
+   ▼
+7. Server observes result appearing (Promise-based Y.Doc observer)
+   Deletes command row → returns result to AI
+   │
+   ▼
+8. AI generates response: "Closed 5 YouTube tabs on your MacBook."
+```
+
+### Server-Side Command Awaiting
+
+The server blocks (async) inside a tool's `.server()` execute function until the target device writes the result or TTL expires:
+
+```typescript
+function waitForCommandResult(
+	commandsTable: TableHelper,
+	commandId: string,
+	ttlMs: number,
+	abortSignal?: AbortSignal,
+): Promise<unknown> {
+	return new Promise((resolve, reject) => {
+		let unobserve: (() => void) | undefined;
+
+		const cleanup = () => {
+			clearTimeout(timeout);
+			unobserve?.();
+		};
+
+		const timeout = setTimeout(() => {
+			cleanup();
+			reject(new Error('Command timed out — device may be offline'));
+		}, ttlMs);
+
+		// Abort when client disconnects
+		abortSignal?.addEventListener(
+			'abort',
+			() => {
+				cleanup();
+				commandsTable.delete(commandId);
+				reject(new DOMException('Client disconnected', 'AbortError'));
+			},
+			{ once: true },
+		);
+
+		unobserve = commandsTable.observe((changedIds) => {
+			if (!changedIds.has(commandId)) return;
+			const result = commandsTable.get(commandId);
+			if (result.status !== 'valid') return;
+			if (!result.row.result) return;
+
+			cleanup();
+			resolve(result.row.result);
+		});
+	});
+}
+```
+
+---
+
+## Commands Table Schema
+
+### Discriminated Union with `type.or()` + `.merge()`
+
+The `commands` table uses arktype's static `type.or()` with per-variant `.merge()` to create a discriminated union on the `action` key. Base fields are shared; payload fields and result types are flattened and typed per action.
+
+Note: `.merge()` only accepts object types — you cannot pass a union into `.merge()`. Each variant must be merged individually, then combined via `type.or()`.
+
+```typescript
+import { type } from 'arktype';
+
+// ─── Shared base fields ──────────────────────────────────────────────
+const commandBase = type({
+  id: 'string',
+  deviceId: DeviceId,
+  createdAt: 'number',
+  _v: '1' as const,
+});
+
+// ─── Tab group color (reusable) ──────────────────────────────────────
+const tabGroupColor = "'grey' | 'blue' | 'red' | 'yellow' | 'green' | 'pink' | 'purple' | 'cyan' | 'orange'";
+
+// ─── Commands table: discriminated union on `action` ─────────────────
+commands: defineTable(
+  type.or(
+    commandBase.merge({
+      action: "'closeTabs'",
+      tabIds: 'string[]',
+      'result?': type({ closedCount: 'number' }).or('undefined'),
+    }),
+    commandBase.merge({
+      action: "'openTab'",
+      url: 'string',
+      'windowId?': 'string',
+      'result?': type({ tabId: 'string' }).or('undefined'),
+    }),
+    commandBase.merge({
+      action: "'activateTab'",
+      tabId: 'string',
+      'result?': type({ activated: 'boolean' }).or('undefined'),
+    }),
+    commandBase.merge({
+      action: "'saveTabs'",
+      tabIds: 'string[]',
+      close: 'boolean',
+      'result?': type({ savedCount: 'number' }).or('undefined'),
+    }),
+    commandBase.merge({
+      action: "'groupTabs'",
+      tabIds: 'string[]',
+      'title?': 'string',
+      'color?': tabGroupColor,
+      'result?': type({ groupId: 'string' }).or('undefined'),
+    }),
+    commandBase.merge({
+      action: "'pinTabs'",
+      tabIds: 'string[]',
+      pinned: 'boolean',
+      'result?': type({ pinnedCount: 'number' }).or('undefined'),
+    }),
+    commandBase.merge({
+      action: "'muteTabs'",
+      tabIds: 'string[]',
+      muted: 'boolean',
+      'result?': type({ mutedCount: 'number' }).or('undefined'),
+    }),
+    commandBase.merge({
+      action: "'reloadTabs'",
+      tabIds: 'string[]',
+      'result?': type({ reloadedCount: 'number' }).or('undefined'),
+    }),
+  ),
+),
+```
+
+### Type Exports
+
+```typescript
+export type Command = InferTableRow<Tables['commands']>;
+// Command is a discriminated union — switch on `action` to narrow
+```
+
+### Why This Design
+
+| Property                      | Benefit                                                                |
+| ----------------------------- | ---------------------------------------------------------------------- |
+| Flattened payload             | No `JSON.parse(cmd.payload)`. Fields are native Y.Map key-value pairs. |
+| Typed result per action       | `closeTabs` result is `{ closedCount: number }`, not `string`.         |
+| `action` discriminant         | `switch (cmd.action)` narrows the full type in TypeScript.             |
+| `type.or()` + `.merge()`      | Flat list of 8 variants. No deeply nested `.or()` chains.              |
+| Base is a real arktype `Type` | Reusable, composable, inspectable at runtime.                          |
+| `result?` presence = status   | No separate `status` field. Pending = no result. Done = has result.    |
+| `_v: '1'`                     | Ready for schema evolution if command shapes need to change.           |
+
+---
+
+## Tool Definitions
+
+All tools use `toolDefinition()` from `@tanstack/ai` with Zod schemas (required by TanStack AI), then `.server()` implementations.
+
+### Read Tools (5)
+
+These query the tab-manager Y.Doc tables directly on the server. Instant, cross-device global view.
+
+| Tool            | inputSchema                                | What it does                                                         |
+| --------------- | ------------------------------------------ | -------------------------------------------------------------------- |
+| `searchTabs`    | `{ query: string, deviceId?: string }`     | Filter tabs by URL/title match, optionally scoped to one device      |
+| `listTabs`      | `{ deviceId?: string, windowId?: string }` | List all tabs, optionally filtered by device or window               |
+| `listWindows`   | `{ deviceId?: string }`                    | List all windows with tab counts, optionally filtered by device      |
+| `listDevices`   | `{}`                                       | Merge awareness (online status) with devices table (names, browsers) |
+| `countByDomain` | `{ deviceId?: string }`                    | Aggregate tab counts by domain across devices                        |
+
+### Mutation Tools (8)
+
+These write to the `commands` table and await the result.
+
+| Tool          | inputSchema                                            | Command action |
+| ------------- | ------------------------------------------------------ | -------------- |
+| `closeTabs`   | `{ tabIds: string[] }`                                 | `closeTabs`    |
+| `openTab`     | `{ url: string, deviceId: string, windowId?: string }` | `openTab`      |
+| `activateTab` | `{ tabId: string }`                                    | `activateTab`  |
+| `saveTabs`    | `{ tabIds: string[], close?: boolean }`                | `saveTabs`     |
+| `groupTabs`   | `{ tabIds: string[], title?: string, color?: string }` | `groupTabs`    |
+| `pinTabs`     | `{ tabIds: string[], pinned: boolean }`                | `pinTabs`      |
+| `muteTabs`    | `{ tabIds: string[], muted: boolean }`                 | `muteTabs`     |
+| `reloadTabs`  | `{ tabIds: string[] }`                                 | `reloadTabs`   |
+
+### deviceId Resolution
+
+Mutation tools need a `deviceId` to target. The tool schemas accept tab composite IDs (e.g. `"abc_42"`) which embed the deviceId. The server extracts `deviceId` from the first tab ID's prefix — all tabs in a single command must belong to the same device.
+
+For `openTab`, `deviceId` is explicit because there's no existing tab to derive it from.
+
+The AI should call `listDevices` first when it needs to know which devices are available, then `searchTabs` or `listTabs` to find specific tab IDs.
+
+---
+
+## File Structure
+
+```
+packages/server/src/ai/
+├── plugin.ts              ← Modified: accept getDoc, pass tools to chat()
+├── adapters.ts            ← Unchanged
+├── tools/
+│   ├── definitions.ts     ← toolDefinition() contracts (Zod schemas)
+│   ├── read-tools.ts      ← .server() implementations for read tools
+│   ├── mutation-tools.ts  ← .server() implementations for mutation tools
+│   └── wait-for-result.ts ← waitForCommandResult() helper
+
+apps/tab-manager/src/lib/
+├── workspace.ts           ← Modified: add commands table (discriminated union)
+├── commands/
+│   ├── constants.ts       ← COMMAND_TTL_MS = 30_000
+│   ├── consumer.ts        ← Background worker command observer + dispatcher
+│   └── actions.ts         ← Per-action Chrome API execution functions
+```
+
+---
+
+## Implementation Plan
+
+### Phase 1: Commands Table Schema
+
+- [ ] **1.1** Add `commandBase` type and discriminated union `commands` table to `apps/tab-manager/src/lib/workspace.ts` using `type.or()` + `.merge()` pattern
+- [ ] **1.2** Export `Command` type and `COMMAND_TTL_MS` constant
+- [ ] **1.3** Verify the union type works with `defineTable` — `table.set()`, `table.get()`, `table.getAllValid()` should all handle the discriminated union correctly
+
+### Phase 2: Background Worker Command Consumer
+
+- [ ] **2.1** Create `apps/tab-manager/src/lib/commands/constants.ts` — export `COMMAND_TTL_MS`
+- [ ] **2.2** Create `apps/tab-manager/src/lib/commands/actions.ts` — per-action Chrome API execution functions (`closeTabs`, `openTab`, `activateTab`, etc.)
+- [ ] **2.3** Create `apps/tab-manager/src/lib/commands/consumer.ts` — `commands.observe()` handler that dispatches to actions
+- [ ] **2.4** Wire consumer into `apps/tab-manager/src/entrypoints/background.ts` — add observer after `whenReady`
+- [ ] **2.5** Add TTL cleanup — delete stale rows (past TTL, no result) on any device
+
+### Phase 3: Server-Side Read Tools
+
+- [ ] **3.1** Modify `createAIPlugin()` to accept a `getDoc` callback for Y.Doc access
+- [ ] **3.2** Modify `hub.ts` to pass `dynamicDocs` access to the AI plugin
+- [ ] **3.3** Create `packages/server/src/ai/tools/definitions.ts` — Zod-based `toolDefinition()` contracts for all 13 tools
+- [ ] **3.4** Create `packages/server/src/ai/tools/read-tools.ts` — `.server()` implementations that query Y.Doc tables
+- [ ] **3.5** Create table helpers from the tab-manager workspace definition for server-side Y.Doc access (import `definition` from `@epicenter/tab-manager/workspace`)
+
+### Phase 4: Server-Side Mutation Tools
+
+- [ ] **4.1** Create `packages/server/src/ai/tools/wait-for-result.ts` — Promise-based Y.Doc observation with TTL timeout and abort signal cleanup
+- [ ] **4.2** Create `packages/server/src/ai/tools/mutation-tools.ts` — `.server()` implementations that write commands and await results
+- [ ] **4.3** Wire all tools into `chat()` call in `plugin.ts`
+- [ ] **4.4** Add system prompt with tool descriptions and behavior guidelines
+
+### Phase 5: Integration & Testing
+
+- [ ] **5.1** End-to-end test: send chat message → AI calls searchTabs → returns tab data
+- [ ] **5.2** End-to-end test: send "close tabs" → AI calls closeTabs → command written → background executes → result returned
+- [ ] **5.3** Test TTL expiry — command written, device offline, timeout fires
+- [ ] **5.4** Test abort — client disconnects, pending command cleaned up
+
+---
+
+## Edge Cases
+
+### Command Expires (Target Device Offline)
+
+1. AI calls `closeTabs` targeting device "abc" (shown online via awareness)
+2. Server writes command row with `createdAt: Date.now()`
+3. Device "abc" goes offline immediately after
+4. After 30s, `waitForCommandResult` rejects with timeout error
+5. AI responds: "Your work laptop didn't respond. It might be offline."
+6. Next cleanup cycle on any device deletes the stale row
+
+### Stale Commands on Device Wake
+
+1. Laptop wakes from sleep, reconnects to Y.Doc
+2. Y.Doc syncs — laptop sees 3 command rows targeting it
+3. Background worker checks `createdAt + COMMAND_TTL_MS > Date.now()` on each
+4. 2 expired → delete them. 1 still valid → execute it.
+5. No surprise tab closures from old commands
+
+### Client Disconnects Mid-Tool-Execution
+
+1. User closes the side panel while AI is waiting for a command result
+2. `request.signal` fires abort
+3. `waitForCommandResult` cleans up: clears timeout, removes observer, deletes the pending command row
+4. No orphaned commands
+
+### Multiple Devices — Which One?
+
+1. AI calls `closeTabs` with tab IDs like `["abc_42", "abc_55"]`
+2. Server extracts deviceId from the tab ID prefix: `"abc"`
+3. Command targets device `"abc"` specifically
+4. If the user says "close all YouTube tabs" without specifying a device, the AI should call `listDevices` first, then ask which device (or target all)
+
+### Composite ID Parsing
+
+Tab IDs in the commands table use the composite format `${deviceId}_${tabId}`. The background worker needs to extract the native `tabId` (number) to call `browser.tabs.remove()`. Use the existing `parseTabId()`, `parseWindowId()` from `workspace.ts`.
+
+---
+
+## Open Questions
+
+1. **Should `openTab` be able to target a specific position (index)?**
+   - Current design only specifies `url` and optional `windowId`
+   - **Recommendation**: Start without index. Add later if users ask "open this tab next to my current tab."
+
+2. **Should the system prompt be hardcoded or configurable per conversation?**
+   - The `conversations` table already has a `systemPrompt?` field
+   - **Recommendation**: Use a base system prompt (tool descriptions, behavior guidelines) merged with the conversation-level `systemPrompt` if present.
+
+3. **How to handle `agentLoopStrategy`?**
+   - TanStack AI supports `maxIterations(N)` to prevent runaway tool loops
+   - **Recommendation**: `maxIterations(10)` — generous enough for search → filter → act flows, low enough to prevent cost runaway.
+
+4. **Should read tools return raw composite IDs or parsed human-readable output?**
+   - Raw: `{ id: "abc_42", deviceId: "abc", tabId: 42, title: "YouTube", ... }`
+   - Human: `{ id: "abc_42", device: "Chrome on MacBook", title: "YouTube", ... }`
+   - **Recommendation**: Raw with device name included. The AI can present it however it wants.
+
+5. **Zod dependency for tool definitions**
+   - TanStack AI `toolDefinition()` requires Zod schemas, but the workspace uses arktype
+   - The two don't conflict — Zod is for tool input/output schemas (AI layer), arktype is for Y.Doc table schemas (data layer)
+   - **Recommendation**: Accept the dual-schema reality. They serve different purposes at different boundaries.
+
+---
+
+## Success Criteria
+
+- [ ] `commands` table defined with discriminated union on `action`, validates correctly via arktype
+- [ ] Background worker observes commands, dispatches by action, executes Chrome APIs, writes results
+- [ ] Expired commands (past TTL) are ignored and cleaned up
+- [ ] Server read tools query Y.Doc and return tab/window/device data
+- [ ] Server mutation tools write commands, await results, return to AI
+- [ ] AI can successfully answer "what tabs do I have open?" (read tool)
+- [ ] AI can successfully close tabs when asked (mutation tool → command → execute → result)
+- [ ] Client disconnect during tool execution cleans up gracefully (no orphaned commands)
+- [ ] `switch (cmd.action)` in TypeScript narrows the type correctly (type-safe dispatch)
+
+---
+
+## References
+
+- `apps/tab-manager/src/lib/workspace.ts` — Current workspace definition (add commands table here)
+- `apps/tab-manager/src/entrypoints/background.ts` — Background worker (add command consumer here)
+- `packages/server/src/ai/plugin.ts` — AI chat endpoint (add tools here)
+- `packages/server/src/hub.ts` — Hub server (pass Y.Doc access to AI plugin)
+- `docs/articles/tanstack-ai-isomorphic-tool-pattern.md` — Tool definition pattern reference
+- `specs/20260214T174800-tanstack-ai-tab-manager-integration.md` (worktree) — Prior spec with command queue design, system prompt, streaming architecture


### PR DESCRIPTION
The AI chat endpoint could stream responses but had no way to actually interact with browser tabs — no searching, closing duplicates, or organizing across devices. We needed tools, but mutations require Chrome APIs that only exist in the target device's browser extension, not on the server.

We chose a command queue through the existing Yjs sync layer over direct WebSocket RPC because the Y.Doc already connects every device, handles offline/reconnection, and gives us conflict-free writes for free. One-sentence summary: the server writes a command row to a shared Y.Doc table, the target device observes it, executes the Chrome API, and writes the result back — all through the same sync infrastructure.

```
Server (AI tool)                  Y.Doc                    Device (background worker)
      │                             │                              │
      │  write command row    ────► │                              │
      │                             │ ──── sync ────►              │
      │                             │                    observe → execute Chrome API
      │                             │ ◄──── sync ─────             │
      │  ◄── observe result         │                    write result back
      │                             │                              │
      │  resolve Promise            │                              │
```

## API Migration

`createAIPlugin()` now requires a `getDoc` callback to access the tab-manager Y.Doc:

```typescript
// Before
new Elysia({ prefix: '/ai' }).use(createAIPlugin())

// After
new Elysia({ prefix: '/ai' }).use(createAIPlugin({
  getDoc: (room) => dynamicDocs.get(room),
}))
```

The hub wires this up by passing its existing `dynamicDocs` map from the sync plugin.

## Storage / Data Structure

The `commands` table uses a discriminated union on `action` — 8 variants sharing a common base, built with arktype's `type.or()` + `.merge()`:

```typescript
const commandBase = type({
  id: CommandId,
  deviceId: DeviceId,
  createdAt: 'number',
  _v: '1',
});

// Each variant merges base + action-specific fields + typed result
commandBase.merge({
  action: "'closeTabs'",
  tabIds: 'string[]',
  'result?': type({ closedCount: 'number' }).or('undefined'),
}),
```

No `status` field — presence of `result` *is* the status. No result = pending, has result = done. Expired commands get deleted by the consumer.

```
┌─────────────────────────────────────────────────────────────────┐
│  commands table — 8 action variants                             │
├─────────────────────────────────────────────────────────────────┤
│  Shared base: id, deviceId, createdAt, _v                       │
├──────────────┬──────────────────────────────────────────────────┤
│  closeTabs   │  tabIds: string[], result?: { closedCount }      │
│  openTab     │  url, windowId?, result?: { tabId }              │
│  activateTab │  tabId, result?: { activated }                   │
│  saveTabs    │  tabIds, close, result?: { savedCount }          │
│  groupTabs   │  tabIds, title?, color?, result?: { groupId }    │
│  pinTabs     │  tabIds, pinned, result?: { pinnedCount }        │
│  muteTabs    │  tabIds, muted, result?: { mutedCount }          │
│  reloadTabs  │  tabIds, result?: { reloadedCount }              │
└──────────────┴──────────────────────────────────────────────────┘
```

## Technical Details

**Read tools** (5) query the Y.Doc directly — the server already holds the full doc in memory via the sync plugin's `dynamicDocs`. No command queue needed, instant cross-device view:

```typescript
searchTabsDef.server(async ({ query, deviceId }) => {
  const tabs = tables.tabs.filter((tab) => {
    if (deviceId && tab.deviceId !== deviceId) return false;
    return tab.title?.toLowerCase().includes(query.toLowerCase())
        || tab.url?.toLowerCase().includes(query.toLowerCase());
  });
  return { results: tabs.map(/* ... */) };
});
```

Tools: `searchTabs`, `listTabs`, `listWindows`, `listDevices`, `countByDomain`.

**Mutation tools** (8) write a command row, then block on `waitForCommandResult()` — a Promise that observes the commands table until the device writes `result` or TTL (30s) expires:

```typescript
closeTabsDef.server(async ({ tabIds }) => {
  const deviceId = extractDeviceIdFromIds(tabIds);
  tables.commands.set({
    id: createCommandId(), deviceId,
    action: 'closeTabs', tabIds,
    createdAt: Date.now(), _v: 1,
  });
  return waitForCommandResult(tables.commands, cmd.id, COMMAND_TTL_MS);
});
```

**Command consumer** in the background worker observes, filters for this device, checks TTL, dispatches by action, and writes back:

```typescript
commandsTable.observe((changedIds) => {
  for (const id of changedIds) {
    const cmd = commandsTable.get(id);
    if (cmd.deviceId !== deviceId) continue;
    if (cmd.result !== undefined) continue;
    if (cmd.createdAt + COMMAND_TTL_MS < Date.now()) {
      commandsTable.delete(id);
      continue;
    }
    void executeCommand(cmd, ...);
  }
});
```

Tool definitions use TanStack AI's `toolDefinition()` with arktype schemas (Standard Schema compatible). Definitions are shared; `.server()` implementations live in separate files for read vs mutation.

## Rationale

The Y.Doc command queue reuses infrastructure we already have — Yjs sync handles delivery, reconnection, and offline buffering. A direct WebSocket RPC approach would need its own connection management, retry logic, and device discovery, duplicating what Yjs already does. The tradeoff is slightly higher latency (Y.Doc sync round-trip vs direct message), but for tab management operations that's imperceptible.

Read tools query the server's in-memory Y.Doc because the hub already holds the full document state via the sync plugin. There's no reason to round-trip to the device for data the server already has.

The `COMMAND_TTL_MS` constant is duplicated between the server and the tab-manager extension because the tab-manager package only exports `./workspace`. Both values must stay in sync manually — not ideal, but acceptable for a single constant.

## Also Included

The first commit adds a bearer-token auth spec and article documenting why Tauri apps need bearer tokens instead of cookies (WebKit rejects `Secure` cookies from `tauri://`, split cookie jars between webview and Rust HTTP). Updates the better-auth skill with native app patterns.