### PR TITLE
feat(whispering): add config import export

### DIFF
--- a/apps/whispering/src/lib/components/settings/ImportExportConfig.svelte
+++ b/apps/whispering/src/lib/components/settings/ImportExportConfig.svelte
@@ -1,0 +1,218 @@
+<script lang="ts">
+	import { Button } from '@epicenter/ui/button';
+	import * as Field from '@epicenter/ui/field';
+	import { settings } from '$lib/state/settings.svelte';
+	import { rpc } from '$lib/query';
+	import { services } from '$lib/services';
+	import { createMutation } from '@tanstack/svelte-query';
+	import DownloadIcon from '@lucide/svelte/icons/download';
+	import UploadIcon from '@lucide/svelte/icons/upload';
+	import type { ConfigExport } from '$lib/services/isomorphic/config-export';
+	import { confirmationDialog } from '$lib/components/ConfirmationDialog.svelte';
+	import { Switch } from '@epicenter/ui/switch';
+
+	const exportMutation = createMutation(() => rpc.config.export.options);
+	const importMutation = createMutation(() => rpc.config.import.options);
+
+	let includeApiKeys = $state(false);
+	let fileInput: HTMLInputElement;
+
+	function handleExport() {
+		exportMutation.mutate(
+			{
+				settings: settings.value,
+				options: { includeApiKeys },
+			},
+			{
+				onSuccess: (config: ConfigExport) => {
+					// createQueryFactories unwraps Result types automatically
+					// config is already the unwrapped data here
+					const json = JSON.stringify(config, null, 2);
+
+					const timestamp = new Date()
+						.toISOString()
+						.replace(/:/g, '-')
+						.split('.')[0];
+					const filename = `whispering-config-${timestamp}.json`;
+
+					saveConfigFile(filename, json);
+				},
+				onError: (error: any) => {
+					rpc.notify.error({
+						title: error.title || 'Failed to export configuration',
+						description: error.description || String(error),
+					});
+				},
+			},
+		);
+	}
+
+	async function saveConfigFile(filename: string, json: string) {
+		// Desktop: Use Tauri file dialog
+		if (window.__TAURI_INTERNALS__) {
+			const { save } = await import('@tauri-apps/plugin-dialog');
+			const { writeTextFile } = await import('@tauri-apps/plugin-fs');
+
+			const path = await save({
+				defaultPath: filename,
+				filters: [
+					{
+						name: 'JSON Config',
+						extensions: ['json'],
+					},
+				],
+			});
+
+			if (!path) return; // User cancelled
+
+			try {
+				await writeTextFile(path, json);
+				rpc.notify.success({
+					title: 'Configuration exported',
+					description: `Saved to ${path}`,
+				});
+			} catch (e) {
+				rpc.notify.error({
+					title: 'Failed to save file',
+					description: String(e),
+				});
+			}
+		} else {
+			// Web: Download as file
+			const blob = new Blob([json], { type: 'application/json' });
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement('a');
+			a.href = url;
+			a.download = filename;
+			a.click();
+			URL.revokeObjectURL(url);
+
+			rpc.notify.success({
+				title: 'Configuration exported',
+				description: `Downloaded ${filename}`,
+			});
+		}
+	}
+
+	function handleImportClick() {
+		fileInput.click();
+	}
+
+	async function handleFileSelect(event: Event) {
+		const input = event.target as HTMLInputElement;
+		const file = input.files?.[0];
+		if (!file) return;
+
+		try {
+			const text = await file.text();
+			const data = JSON.parse(text);
+
+			// Validate the config
+			const validationResult = services.configExport.validateConfig(data);
+			if (validationResult.error) {
+				rpc.notify.error({
+					title: 'Invalid configuration file',
+					description: validationResult.error.message,
+					action: { type: 'more-details', error: validationResult.error },
+				});
+				return;
+			}
+
+			const config: ConfigExport = validationResult.data;
+
+			// Show confirmation dialog with preview
+			confirmationDialog.open({
+				title: 'Import Configuration',
+				description: `This will replace your current settings and transformations. Are you sure you want to continue?\n\n• ${Object.keys(config.settings).length} settings\n• ${config.transformations.length} transformations\n\nExported: ${new Date(config.exportedAt).toLocaleString()}`,
+				confirm: { text: 'Import', variant: 'default' },
+				onConfirm: () => {
+					importMutation.mutate(
+						{
+							config,
+							options: { mergeStrategy: 'replace' },
+						},
+						{
+							onSuccess: (summary) => {
+								// createQueryFactories unwraps Result types automatically
+								// summary is already the unwrapped data here
+
+								// Apply the imported settings
+								settings.update(config.settings);
+
+								rpc.notify.success({
+									title: 'Configuration imported',
+									description: `Imported ${summary.settingsUpdated} settings and ${summary.transformationsCreated} transformations`,
+								});
+							},
+							onError: (error: any) => {
+								rpc.notify.error({
+									title: error.title || 'Failed to import configuration',
+									description: error.description || String(error),
+								});
+							},
+						},
+					);
+				},
+			});
+		} catch (e) {
+			rpc.notify.error({
+				title: 'Failed to read file',
+				description: e instanceof Error ? e.message : String(e),
+			});
+		} finally {
+			// Reset file input
+			input.value = '';
+		}
+	}
+</script>
+
+<Field.Set>
+	<Field.Legend variant="label">Import/Export Configuration</Field.Legend>
+	<Field.Description>
+		Backup your settings and transformations or transfer them to another device.
+	</Field.Description>
+
+	<Field.Group>
+		<Field.Field orientation="horizontal">
+			<Switch id="include-api-keys" bind:checked={includeApiKeys} />
+			<Field.Label for="include-api-keys">
+				<Field.Content>
+					<Field.Title>Include API Keys</Field.Title>
+					<Field.Description>
+						⚠️ Warning: API keys will be included in plain text
+					</Field.Description>
+				</Field.Content>
+			</Field.Label>
+		</Field.Field>
+
+		<div class="flex gap-2">
+			<Button
+				onclick={handleExport}
+				disabled={exportMutation.isPending}
+				variant="outline"
+				class="flex-1"
+			>
+				<DownloadIcon class="size-4" />
+				Export Configuration
+			</Button>
+
+			<Button
+				onclick={handleImportClick}
+				disabled={importMutation.isPending}
+				variant="outline"
+				class="flex-1"
+			>
+				<UploadIcon class="size-4" />
+				Import Configuration
+			</Button>
+		</div>
+
+		<input
+			bind:this={fileInput}
+			type="file"
+			accept=".json"
+			onchange={handleFileSelect}
+			class="hidden"
+		/>
+	</Field.Group>
+</Field.Set>

--- a/apps/whispering/src/lib/query/isomorphic/config.ts
+++ b/apps/whispering/src/lib/query/isomorphic/config.ts
@@ -1,0 +1,73 @@
+import { Err, Ok } from 'wellcrafted/result';
+import type { Settings } from '$lib/settings/settings';
+import { defineMutation, defineQuery } from '$lib/query/client';
+import { services } from '$lib/services';
+import type {
+	ConfigExport,
+	ExportConfigOptions,
+	ImportConfigOptions,
+} from '$lib/services/isomorphic/config-export';
+
+/**
+ * Query keys for config export/import operations
+ */
+export const configKeys = {
+	validate: (data: unknown) => ['config', 'validate', data] as const,
+};
+
+/**
+ * Config export/import query layer
+ */
+export const config = {
+	/**
+	 * Export current configuration to JSON
+	 */
+	export: defineMutation({
+		mutationKey: ['config', 'export'] as const,
+		mutationFn: async (params: {
+			settings: Settings;
+			options?: ExportConfigOptions;
+		}) => {
+			const { settings, options } = params;
+			const { data, error } =
+				await services.configExport.exportConfig(settings, options);
+
+			if (error) {
+				return Err({
+					title: 'Failed to export configuration',
+					description: error.message,
+					action: { type: 'more-details' as const, error },
+				});
+			}
+
+			return Ok(data);
+		},
+	}),
+
+	/**
+	 * Import configuration from validated ConfigExport object
+	 */
+	import: defineMutation({
+		mutationKey: ['config', 'import'] as const,
+		mutationFn: async (params: {
+			config: ConfigExport;
+			options?: ImportConfigOptions;
+		}) => {
+			const { config: configData, options } = params;
+			const { data, error } = await services.configExport.importConfig(
+				configData,
+				options,
+			);
+
+			if (error) {
+				return Err({
+					title: 'Failed to import configuration',
+					description: error.message,
+					action: { type: 'more-details' as const, error },
+				});
+			}
+
+			return Ok(data);
+		},
+	}),
+};

--- a/apps/whispering/src/lib/query/isomorphic/config.ts
+++ b/apps/whispering/src/lib/query/isomorphic/config.ts
@@ -1,5 +1,4 @@
 import { Err, Ok } from 'wellcrafted/result';
-import type { Settings } from '$lib/settings/settings';
 import { defineMutation, defineQuery } from '$lib/query/client';
 import { services } from '$lib/services';
 import type {
@@ -7,6 +6,7 @@ import type {
 	ExportConfigOptions,
 	ImportConfigOptions,
 } from '$lib/services/isomorphic/config-export';
+import type { Settings } from '$lib/settings/settings';
 
 /**
  * Query keys for config export/import operations
@@ -29,8 +29,10 @@ export const config = {
 			options?: ExportConfigOptions;
 		}) => {
 			const { settings, options } = params;
-			const { data, error } =
-				await services.configExport.exportConfig(settings, options);
+			const { data, error } = await services.configExport.exportConfig(
+				settings,
+				options,
+			);
 
 			if (error) {
 				return Err({

--- a/apps/whispering/src/lib/query/isomorphic/index.ts
+++ b/apps/whispering/src/lib/query/isomorphic/index.ts
@@ -1,5 +1,6 @@
 import { commands } from './actions';
 import { analytics } from './analytics';
+import { config } from './config';
 import { db } from './db';
 import { delivery } from './delivery';
 import { download } from './download';
@@ -19,6 +20,7 @@ export const rpc = {
 	analytics,
 	text,
 	commands,
+	config,
 	db,
 	download,
 	recorder,

--- a/apps/whispering/src/lib/services/isomorphic/config-export/index.ts
+++ b/apps/whispering/src/lib/services/isomorphic/config-export/index.ts
@@ -1,17 +1,17 @@
-import { Err, Ok, trySync, type Result } from 'wellcrafted/result';
 import { type } from 'arktype';
+import { Err, Ok, type Result, trySync } from 'wellcrafted/result';
+import type { Transformation as TransformationType } from '$lib/services/isomorphic/db';
+import { Transformation } from '$lib/services/isomorphic/db/models/transformations';
+import type { DbService } from '$lib/services/isomorphic/db/types';
 import type { Settings } from '$lib/settings/settings';
 import { Settings as SettingsSchema } from '$lib/settings/settings';
-import { Transformation } from '$lib/services/isomorphic/db/models/transformations';
-import type { Transformation as TransformationType } from '$lib/services/isomorphic/db';
-import type { DbService } from '$lib/services/isomorphic/db/types';
 import {
-	ConfigExportErr,
-	ConfigImportErr,
-	ConfigValidationErr,
 	type ConfigExport,
+	ConfigExportErr,
 	type ConfigExportError,
+	ConfigImportErr,
 	type ConfigImportError,
+	ConfigValidationErr,
 	type ConfigValidationError,
 	type ExportConfigOptions,
 	type ImportConfigOptions,
@@ -252,8 +252,7 @@ export function createConfigExportService(
 
 			// Create all imported transformations
 			for (const transformation of config.transformations) {
-				const createResult =
-					await db.transformations.create(transformation);
+				const createResult = await db.transformations.create(transformation);
 				if (createResult.error) {
 					// Log error but continue with other transformations
 					console.error(
@@ -275,15 +274,12 @@ export function createConfigExportService(
 				});
 			}
 
-			const existingIds = new Set(
-				existingResult.data.map((t) => t.id),
-			);
+			const existingIds = new Set(existingResult.data.map((t) => t.id));
 
 			for (const transformation of config.transformations) {
 				if (existingIds.has(transformation.id)) {
 					// Update existing transformation
-					const updateResult =
-						await db.transformations.update(transformation);
+					const updateResult = await db.transformations.update(transformation);
 					if (updateResult.error) {
 						console.error(
 							'Failed to update transformation:',
@@ -296,8 +292,7 @@ export function createConfigExportService(
 					}
 				} else {
 					// Create new transformation
-					const createResult =
-						await db.transformations.create(transformation);
+					const createResult = await db.transformations.create(transformation);
 					if (createResult.error) {
 						console.error(
 							'Failed to create transformation:',

--- a/apps/whispering/src/lib/services/isomorphic/config-export/index.ts
+++ b/apps/whispering/src/lib/services/isomorphic/config-export/index.ts
@@ -1,0 +1,327 @@
+import { Err, Ok, trySync, type Result } from 'wellcrafted/result';
+import { type } from 'arktype';
+import type { Settings } from '$lib/settings/settings';
+import { Settings as SettingsSchema } from '$lib/settings/settings';
+import { Transformation } from '$lib/services/isomorphic/db/models/transformations';
+import type { Transformation as TransformationType } from '$lib/services/isomorphic/db';
+import type { DbService } from '$lib/services/isomorphic/db/types';
+import {
+	ConfigExportErr,
+	ConfigImportErr,
+	ConfigValidationErr,
+	type ConfigExport,
+	type ConfigExportError,
+	type ConfigImportError,
+	type ConfigValidationError,
+	type ExportConfigOptions,
+	type ImportConfigOptions,
+	type ImportSummary,
+} from './types';
+
+export type {
+	ConfigExport,
+	ConfigExportError,
+	ConfigImportError,
+	ConfigValidationError,
+	ExportConfigOptions,
+	ImportConfigOptions,
+	ImportSummary,
+} from './types';
+
+/**
+ * Dependencies for ConfigExportService.
+ */
+type ConfigExportServiceDependencies = {
+	db: DbService;
+};
+
+/**
+ * Service for exporting and importing application configuration.
+ *
+ * Handles serialization and deserialization of settings and transformations,
+ * with options for security (excluding API keys) and merge strategies.
+ */
+export function createConfigExportService(
+	deps: ConfigExportServiceDependencies,
+) {
+	const { db } = deps;
+
+	/**
+	 * Export current configuration to a JSON-serializable object.
+	 *
+	 * @param settings - Current application settings
+	 * @param options - Export options (API key exclusion, etc.)
+	 * @returns Serializable configuration object
+	 *
+	 * @example
+	 * const { data: config, error } = await exportConfig(settings.value, {
+	 *   includeApiKeys: false
+	 * });
+	 * if (error) return Err(error);
+	 * const json = JSON.stringify(config, null, 2);
+	 */
+	async function exportConfig(
+		settings: Settings,
+		options: ExportConfigOptions = {},
+	): Promise<Result<ConfigExport, ConfigExportError>> {
+		const { includeApiKeys = false } = options;
+
+		// Fetch all transformations
+		const transformationsResult = await db.transformations.getAll();
+
+		if (transformationsResult.error) {
+			return ConfigExportErr({
+				message: `Failed to fetch transformations for export: ${transformationsResult.error.message}`,
+			});
+		}
+
+		// Create a copy of settings
+		let exportSettings = { ...settings };
+
+		// Remove API keys if requested
+		if (!includeApiKeys) {
+			const apiKeyFields: (keyof Settings)[] = [
+				'apiKeys.openai',
+				'apiKeys.anthropic',
+				'apiKeys.groq',
+				'apiKeys.google',
+				'apiKeys.deepgram',
+				'apiKeys.elevenlabs',
+				'apiKeys.mistral',
+				'apiKeys.openrouter',
+				'apiKeys.custom',
+			];
+
+			for (const key of apiKeyFields) {
+				(exportSettings as any)[key] = '';
+			}
+		}
+
+		const config: ConfigExport = {
+			version: '1.0',
+			exportedAt: new Date().toISOString(),
+			settings: exportSettings,
+			transformations: transformationsResult.data,
+		};
+
+		return Ok(config);
+	}
+
+	/**
+	 * Validate a configuration object against expected schema.
+	 *
+	 * @param data - Raw data to validate
+	 * @returns Validated ConfigExport object
+	 *
+	 * @example
+	 * const { data: config, error } = validateConfig(jsonData);
+	 * if (error) {
+	 *   console.error('Invalid config file:', error.message);
+	 *   return;
+	 * }
+	 */
+	function validateConfig(
+		data: unknown,
+	): Result<ConfigExport, ConfigValidationError> {
+		// Check if data is an object
+		if (typeof data !== 'object' || data === null) {
+			return ConfigValidationErr({
+				message: 'Config must be an object',
+			});
+		}
+
+		const config = data as Record<string, unknown>;
+
+		// Validate version
+		if (config.version !== '1.0') {
+			return ConfigValidationErr({
+				message: `Unsupported config version: ${config.version}`,
+			});
+		}
+
+		// Validate exportedAt
+		if (typeof config.exportedAt !== 'string') {
+			return ConfigValidationErr({
+				message: 'Config must have exportedAt timestamp',
+			});
+		}
+
+		// Validate settings
+		const settingsResult = trySync({
+			try: () => {
+				const result = SettingsSchema(config.settings);
+				if (result instanceof type.errors) {
+					throw new Error(result.summary);
+				}
+				return result;
+			},
+			catch: (e) =>
+				ConfigValidationErr({
+					message: `Invalid settings schema: ${e instanceof Error ? e.message : String(e)}`,
+				}),
+		});
+
+		if (settingsResult.error) {
+			return Err(settingsResult.error);
+		}
+
+		// Validate transformations array
+		if (!Array.isArray(config.transformations)) {
+			return ConfigValidationErr({
+				message: 'Config must have transformations array',
+			});
+		}
+
+		// Validate each transformation
+		const validatedTransformations: TransformationType[] = [];
+		for (const [index, transformation] of config.transformations.entries()) {
+			const transformationResult = trySync({
+				try: () => {
+					const result = Transformation(transformation);
+					if (result instanceof type.errors) {
+						throw new Error(result.summary);
+					}
+					return result as TransformationType;
+				},
+				catch: (e) =>
+					ConfigValidationErr({
+						message: `Invalid transformation at index ${index}: ${e instanceof Error ? e.message : String(e)}`,
+					}),
+			});
+
+			if (transformationResult.error) {
+				return Err(transformationResult.error);
+			}
+
+			validatedTransformations.push(transformationResult.data);
+		}
+
+		return Ok({
+			version: '1.0',
+			exportedAt: config.exportedAt as string,
+			settings: settingsResult.data,
+			transformations: validatedTransformations,
+		});
+	}
+
+	/**
+	 * Import configuration from a validated ConfigExport object.
+	 *
+	 * @param config - Validated configuration to import
+	 * @param options - Import options (merge strategy, etc.)
+	 * @returns Summary of what was imported
+	 *
+	 * @example
+	 * // Replace mode - overwrites everything
+	 * const { data: summary, error } = await importConfig(config, {
+	 *   mergeStrategy: 'replace'
+	 * });
+	 *
+	 * @example
+	 * // Merge mode - keeps existing, adds new
+	 * const { data: summary, error } = await importConfig(config, {
+	 *   mergeStrategy: 'merge'
+	 * });
+	 */
+	async function importConfig(
+		config: ConfigExport,
+		options: ImportConfigOptions = {},
+	): Promise<Result<ImportSummary, ConfigImportError>> {
+		const { mergeStrategy = 'replace' } = options;
+
+		const summary: ImportSummary = {
+			settingsUpdated: 0,
+			transformationsCreated: 0,
+			transformationsUpdated: 0,
+			transformationsSkipped: 0,
+		};
+
+		// Settings are always imported (there's only one settings object)
+		// The settings will be applied by the caller using settings.update()
+		summary.settingsUpdated = Object.keys(config.settings).length;
+
+		// Handle transformations based on merge strategy
+		if (mergeStrategy === 'replace') {
+			// Clear existing transformations first
+			const clearResult = await db.transformations.clear();
+			if (clearResult.error) {
+				return ConfigImportErr({
+					message: `Failed to clear existing transformations: ${clearResult.error.message}`,
+				});
+			}
+
+			// Create all imported transformations
+			for (const transformation of config.transformations) {
+				const createResult =
+					await db.transformations.create(transformation);
+				if (createResult.error) {
+					// Log error but continue with other transformations
+					console.error(
+						'Failed to import transformation:',
+						transformation.id,
+						createResult.error,
+					);
+					summary.transformationsSkipped++;
+				} else {
+					summary.transformationsCreated++;
+				}
+			}
+		} else {
+			// Merge mode: keep existing, add new, update if IDs match
+			const existingResult = await db.transformations.getAll();
+			if (existingResult.error) {
+				return ConfigImportErr({
+					message: `Failed to fetch existing transformations: ${existingResult.error.message}`,
+				});
+			}
+
+			const existingIds = new Set(
+				existingResult.data.map((t) => t.id),
+			);
+
+			for (const transformation of config.transformations) {
+				if (existingIds.has(transformation.id)) {
+					// Update existing transformation
+					const updateResult =
+						await db.transformations.update(transformation);
+					if (updateResult.error) {
+						console.error(
+							'Failed to update transformation:',
+							transformation.id,
+							updateResult.error,
+						);
+						summary.transformationsSkipped++;
+					} else {
+						summary.transformationsUpdated++;
+					}
+				} else {
+					// Create new transformation
+					const createResult =
+						await db.transformations.create(transformation);
+					if (createResult.error) {
+						console.error(
+							'Failed to create transformation:',
+							transformation.id,
+							createResult.error,
+						);
+						summary.transformationsSkipped++;
+					} else {
+						summary.transformationsCreated++;
+					}
+				}
+			}
+		}
+
+		return Ok(summary);
+	}
+
+	return {
+		exportConfig,
+		validateConfig,
+		importConfig,
+	};
+}
+
+export const ConfigExportService = {
+	create: createConfigExportService,
+};

--- a/apps/whispering/src/lib/services/isomorphic/config-export/types.ts
+++ b/apps/whispering/src/lib/services/isomorphic/config-export/types.ts
@@ -1,6 +1,6 @@
 import { createTaggedError } from 'wellcrafted/error';
-import type { Settings } from '$lib/settings/settings';
 import type { Transformation } from '$lib/services/isomorphic/db';
+import type { Settings } from '$lib/settings/settings';
 
 /**
  * Configuration export format.

--- a/apps/whispering/src/lib/services/isomorphic/config-export/types.ts
+++ b/apps/whispering/src/lib/services/isomorphic/config-export/types.ts
@@ -1,0 +1,80 @@
+import { createTaggedError } from 'wellcrafted/error';
+import type { Settings } from '$lib/settings/settings';
+import type { Transformation } from '$lib/services/isomorphic/db';
+
+/**
+ * Configuration export format.
+ * Contains all user settings and transformations in a portable JSON format.
+ */
+export type ConfigExport = {
+	/** Schema version for future migration compatibility */
+	version: '1.0';
+	/** ISO timestamp of when the config was exported */
+	exportedAt: string;
+	/** All application settings */
+	settings: Settings;
+	/** User-created transformation pipelines */
+	transformations: Transformation[];
+};
+
+/**
+ * Options for exporting configuration.
+ */
+export type ExportConfigOptions = {
+	/**
+	 * Whether to include API keys in the export.
+	 * @default false - API keys are excluded for security
+	 */
+	includeApiKeys?: boolean;
+};
+
+/**
+ * Strategy for handling conflicts during import.
+ */
+export type ImportMergeStrategy =
+	/** Replace all existing config with imported data */
+	| 'replace'
+	/** Merge imported data with existing, keeping newer items */
+	| 'merge';
+
+/**
+ * Options for importing configuration.
+ */
+export type ImportConfigOptions = {
+	/**
+	 * How to handle conflicts between existing and imported data.
+	 * @default 'replace'
+	 */
+	mergeStrategy?: ImportMergeStrategy;
+};
+
+/**
+ * Summary of what was imported.
+ */
+export type ImportSummary = {
+	/** Number of settings updated */
+	settingsUpdated: number;
+	/** Number of transformations created */
+	transformationsCreated: number;
+	/** Number of transformations updated (merge mode only) */
+	transformationsUpdated: number;
+	/** Number of transformations skipped */
+	transformationsSkipped: number;
+};
+
+// ============================================================================
+// Errors
+// ============================================================================
+
+export const { ConfigExportError, ConfigExportErr } =
+	createTaggedError('ConfigExportError');
+export type ConfigExportError = ReturnType<typeof ConfigExportError>;
+
+export const { ConfigImportError, ConfigImportErr } =
+	createTaggedError('ConfigImportError');
+export type ConfigImportError = ReturnType<typeof ConfigImportError>;
+
+export const { ConfigValidationError, ConfigValidationErr } = createTaggedError(
+	'ConfigValidationError',
+);
+export type ConfigValidationError = ReturnType<typeof ConfigValidationError>;

--- a/apps/whispering/src/lib/services/isomorphic/index.ts
+++ b/apps/whispering/src/lib/services/isomorphic/index.ts
@@ -1,5 +1,6 @@
 import { AnalyticsServiceLive } from './analytics';
 import * as completions from './completion';
+import { ConfigExportService } from './config-export';
 import { DbServiceLive } from './db';
 import { DownloadServiceLive } from './download';
 import { LocalShortcutManagerLive } from './local-shortcut-manager';
@@ -19,6 +20,7 @@ export const services = {
 	analytics: AnalyticsServiceLive,
 	text: TextServiceLive,
 	completions,
+	configExport: ConfigExportService.create({ db: DbServiceLive }),
 	db: DbServiceLive,
 	download: DownloadServiceLive,
 	localShortcutManager: LocalShortcutManagerLive,

--- a/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
@@ -10,6 +10,7 @@
 	} from '$lib/constants/ui';
 	import { desktopRpc, rpc } from '$lib/query';
 	import { settings } from '$lib/state/settings.svelte';
+	import ImportExportConfig from '$lib/components/settings/ImportExportConfig.svelte';
 
 	const retentionItems = [
 		{ value: 'keep-forever', label: 'Keep All Recordings' },
@@ -298,5 +299,9 @@
 				{/each}
 			</RadioGroup.Root>
 		</Field.Set>
+
+		<Field.Separator />
+
+		<ImportExportConfig />
 	</Field.Group>
 </Field.Set>


### PR DESCRIPTION
# Import/Export Configuration

Adds the ability to backup and restore Whispering settings and transformations via JSON files.

## Features
- [X] `feat`: New feature

- **Export**: Generates a timestamped JSON file containing:
  - All settings (with optional API key inclusion via toggle)
  - Transformation definitions
  - Version metadata and export timestamp

- **Import**: Validates and restores configuration from JSON files
  - Shows confirmation dialog with import preview
  - Replaces current settings and transformations
  - Updates active settings state after import

## Implementation

The feature follows a layered architecture:

1. **Service Layer** (`ConfigExportService`): Core export/import logic with validation
2. **Query Layer** (`rpc.config.*`): TanStack Query mutations wrapping service calls
3. **UI Component** (`ImportExportConfig.svelte`): User interface with file handling
4. **Platform Support**: Works on both web (downloads) and desktop (Tauri file dialogs)

## Future Enhancements

- Version migration system to handle older config formats
- Merge strategy option (currently only supports "replace")
- Migration guide/registry for backwards compatibility with schema changes

## Related Issue

Closes #1186 