### PR TITLE
feat(tab-manager): add client-side AI tool definitions and implementations

### DIFF
--- a/apps/tab-manager/src/entrypoints/background.ts
+++ b/apps/tab-manager/src/entrypoints/background.ts
@@ -397,7 +397,6 @@ export default defineBackground(() => {
 		console.log('[Background] Command consumer started');
 	});
 
-
 	// ─────────────────────────────────────────────────────────────────────────
 	// Browser Keepalive (Chrome MV3 only)
 	// Chrome service workers go dormant after ~30 seconds of inactivity.

--- a/apps/tab-manager/src/lib/ai/system-prompt.ts
+++ b/apps/tab-manager/src/lib/ai/system-prompt.ts
@@ -1,0 +1,28 @@
+/**
+ * Default system prompt for the tab manager AI chat.
+ *
+ * Describes the AI's role, capabilities, and behavioral guidelines.
+ * Sent as `systemPrompt` in the request body when the conversation
+ * doesn't have a custom system prompt set.
+ *
+ * Kept minimal — the LLM already sees tool schemas with descriptions.
+ * This just provides context about the environment and behavioral norms.
+ */
+export const TAB_MANAGER_SYSTEM_PROMPT = `You are a browser tab management assistant running inside a Chrome extension sidebar. You help users organize, find, and manage their browser tabs across devices.
+
+## Environment
+
+- You run client-side in the Chrome extension's side panel
+- You have access to real-time browser state (tabs, windows, devices) via Y.Doc CRDT tables
+- You can execute Chrome browser APIs directly (close tabs, open tabs, group tabs, etc.)
+- Tab IDs are composite: "deviceId_tabId" format (e.g. "abc123_42")
+- Multiple devices may be synced — always confirm which device before mutating if ambiguous
+
+## Guidelines
+
+- Use read tools first to understand the current state before making mutations
+- When closing or modifying multiple tabs, confirm with the user if the count is large (>5)
+- Group related tabs proactively when you notice patterns
+- Be concise — the sidebar has limited space
+- When listing tabs, include the URL and title so the user can identify them
+- If a mutation fails, report the error clearly without retrying automatically`;

--- a/apps/tab-manager/src/lib/ai/tools/client.ts
+++ b/apps/tab-manager/src/lib/ai/tools/client.ts
@@ -1,0 +1,222 @@
+/**
+ * Client-side tool implementations for the sidebar.
+ *
+ * Read tools query the Y.Doc tables directly via `popupWorkspace`.
+ * Mutation tools call Chrome `browser.*` APIs directly — the sidebar
+ * (side panel) has full Chrome API access.
+ *
+ * Each definition's `.client(execute)` produces a `ClientTool` that
+ * `ChatClient` auto-executes when the LLM calls it.
+ */
+
+import { clientTools } from '@tanstack/ai-client';
+import { getDeviceId } from '$lib/device/device-id';
+import {
+	executeActivateTab,
+	executeCloseTabs,
+	executeGroupTabs,
+	executeMuteTabs,
+	executeOpenTab,
+	executePinTabs,
+	executeReloadTabs,
+	executeSaveTabs,
+} from '$lib/commands/actions';
+import type { DeviceId } from '$lib/workspace';
+import { popupWorkspace } from '$lib/workspace-popup';
+import {
+	activateTabDef,
+	closeTabsDef,
+	countByDomainDef,
+	groupTabsDef,
+	listDevicesDef,
+	listTabsDef,
+	listWindowsDef,
+	muteTabsDef,
+	openTabDef,
+	pinTabsDef,
+	reloadTabsDef,
+	saveTabsDef,
+	searchTabsDef,
+} from './definitions';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const tables = popupWorkspace.tables;
+
+/**
+ * Lazily resolve the device ID for mutation tools.
+ *
+ * Cached after first call. Needed to convert composite tab IDs
+ * (e.g. `deviceId_123`) into native Chrome tab IDs for API calls.
+ */
+let cachedDeviceId: DeviceId | null = null;
+async function resolveDeviceId(): Promise<DeviceId> {
+	if (!cachedDeviceId) {
+		cachedDeviceId = await getDeviceId();
+	}
+	return cachedDeviceId;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Client Tools
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * All client tools with execute functions, ready for `createChat({ tools })`.
+ *
+ * Read tools query Y.Doc tables directly.
+ * Mutation tools call Chrome APIs via the shared action functions.
+ *
+ * @example
+ * ```typescript
+ * const chat = createChat({
+ *   tools: tabManagerClientTools,
+ *   connection: fetchServerSentEvents('/ai/chat'),
+ * });
+ * ```
+ */
+export const tabManagerClientTools = clientTools(
+	// ── Read Tools ──────────────────────────────────────────────────────
+
+	searchTabsDef.client(async ({ query, deviceId }) => {
+		const lower = query.toLowerCase();
+		const matched = tables.tabs.filter((tab) => {
+			if (deviceId && tab.deviceId !== deviceId) return false;
+			const title = tab.title?.toLowerCase() ?? '';
+			const url = tab.url?.toLowerCase() ?? '';
+			return title.includes(lower) || url.includes(lower);
+		});
+		return {
+			results: matched.map((tab) => ({
+				id: tab.id,
+				deviceId: tab.deviceId,
+				windowId: tab.windowId,
+				title: tab.title ?? '(untitled)',
+				url: tab.url ?? '',
+				active: tab.active,
+				pinned: tab.pinned,
+			})),
+		};
+	}),
+
+	listTabsDef.client(async ({ deviceId, windowId }) => {
+		const matched = tables.tabs.filter((tab) => {
+			if (deviceId && tab.deviceId !== deviceId) return false;
+			if (windowId && tab.windowId !== windowId) return false;
+			return true;
+		});
+		return {
+			tabs: matched.map((tab) => ({
+				id: tab.id,
+				deviceId: tab.deviceId,
+				windowId: tab.windowId,
+				title: tab.title ?? '(untitled)',
+				url: tab.url ?? '',
+				active: tab.active,
+				pinned: tab.pinned,
+				audible: tab.audible ?? false,
+				muted: tab.mutedInfo?.muted ?? false,
+				groupId: tab.groupId ?? null,
+			})),
+		};
+	}),
+
+	listWindowsDef.client(async ({ deviceId }) => {
+		const windows = tables.windows.filter((w) => {
+			if (deviceId && w.deviceId !== deviceId) return false;
+			return true;
+		});
+		const allTabs = tables.tabs.getAllValid();
+		return {
+			windows: windows.map((w) => ({
+				id: w.id,
+				deviceId: w.deviceId,
+				focused: w.focused,
+				state: w.state ?? 'normal',
+				type: w.type ?? 'normal',
+				tabCount: allTabs.filter((t) => t.windowId === w.id).length,
+			})),
+		};
+	}),
+
+	listDevicesDef.client(async () => {
+		const devices = tables.devices.getAllValid();
+		return {
+			devices: devices.map((d) => ({
+				id: d.id,
+				name: d.name,
+				browser: d.browser,
+				lastSeen: d.lastSeen,
+			})),
+		};
+	}),
+
+	countByDomainDef.client(async ({ deviceId }) => {
+		const matched = tables.tabs.filter((tab) => {
+			if (deviceId && tab.deviceId !== deviceId) return false;
+			return true;
+		});
+		const counts = new Map<string, number>();
+		for (const tab of matched) {
+			if (!tab.url) continue;
+			try {
+				const domain = new URL(tab.url).hostname;
+				counts.set(domain, (counts.get(domain) ?? 0) + 1);
+			} catch {
+				// Skip tabs with invalid URLs (e.g. chrome:// pages)
+			}
+		}
+		const domains = Array.from(counts.entries())
+			.map(([domain, count]) => ({ domain, count }))
+			.sort((a, b) => b.count - a.count);
+		return { domains };
+	}),
+
+	// ── Mutation Tools ───────────────────────────────────────────────────
+
+	closeTabsDef.client(async ({ tabIds }) => {
+		const deviceId = await resolveDeviceId();
+		return executeCloseTabs(tabIds, deviceId);
+	}),
+
+	openTabDef.client(async ({ url, windowId }) => {
+		return executeOpenTab(url, windowId);
+	}),
+
+	activateTabDef.client(async ({ tabId }) => {
+		const deviceId = await resolveDeviceId();
+		return executeActivateTab(tabId, deviceId);
+	}),
+
+	saveTabsDef.client(async ({ tabIds, close }) => {
+		const deviceId = await resolveDeviceId();
+		return executeSaveTabs(
+			tabIds,
+			close ?? false,
+			deviceId,
+			tables.savedTabs,
+		);
+	}),
+
+	groupTabsDef.client(async ({ tabIds, title, color }) => {
+		const deviceId = await resolveDeviceId();
+		return executeGroupTabs(tabIds, deviceId, title, color);
+	}),
+
+	pinTabsDef.client(async ({ tabIds, pinned }) => {
+		const deviceId = await resolveDeviceId();
+		return executePinTabs(tabIds, pinned, deviceId);
+	}),
+
+	muteTabsDef.client(async ({ tabIds, muted }) => {
+		const deviceId = await resolveDeviceId();
+		return executeMuteTabs(tabIds, muted, deviceId);
+	}),
+
+	reloadTabsDef.client(async ({ tabIds }) => {
+		const deviceId = await resolveDeviceId();
+		return executeReloadTabs(tabIds, deviceId);
+	}),
+);

--- a/apps/tab-manager/src/lib/ai/tools/client.ts
+++ b/apps/tab-manager/src/lib/ai/tools/client.ts
@@ -10,7 +10,6 @@
  */
 
 import { clientTools } from '@tanstack/ai-client';
-import { getDeviceId } from '$lib/device/device-id';
 import {
 	executeActivateTab,
 	executeCloseTabs,
@@ -21,6 +20,7 @@ import {
 	executeReloadTabs,
 	executeSaveTabs,
 } from '$lib/commands/actions';
+import { getDeviceId } from '$lib/device/device-id';
 import type { DeviceId } from '$lib/workspace';
 import { popupWorkspace } from '$lib/workspace-popup';
 import {
@@ -192,12 +192,7 @@ export const tabManagerClientTools = clientTools(
 
 	saveTabsDef.client(async ({ tabIds, close }) => {
 		const deviceId = await resolveDeviceId();
-		return executeSaveTabs(
-			tabIds,
-			close ?? false,
-			deviceId,
-			tables.savedTabs,
-		);
+		return executeSaveTabs(tabIds, close ?? false, deviceId, tables.savedTabs);
 	}),
 
 	groupTabsDef.client(async ({ tabIds, title, color }) => {

--- a/apps/tab-manager/src/lib/ai/tools/definitions.ts
+++ b/apps/tab-manager/src/lib/ai/tools/definitions.ts
@@ -11,7 +11,7 @@
  * @see docs/articles/tanstack-ai-isomorphic-tool-pattern.md
  */
 
-import { toolDefinition } from '@tanstack/ai';
+import { convertSchemaToJsonSchema, toolDefinition } from '@tanstack/ai';
 import { type } from 'arktype';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -144,9 +144,7 @@ export const reloadTabsDef = toolDefinition({
 /**
  * All tool definitions as an array.
  *
- * Used in two places:
- * 1. `.client(execute)` in client.ts — for ChatClient auto-execution
- * 2. Raw in the request body — so the server can forward schemas to the LLM
+ * Used for `.client(execute)` in client.ts — ChatClient auto-execution.
  */
 export const allToolDefinitions = [
 	searchTabsDef,
@@ -163,3 +161,19 @@ export const allToolDefinitions = [
 	muteTabsDef,
 	reloadTabsDef,
 ];
+
+/**
+ * Tool definitions with arktype schemas pre-converted to JSON Schema.
+ *
+ * Arktype schemas implement Standard Schema but their `~standard` protocol
+ * (methods and symbol-keyed properties) doesn't survive JSON serialization.
+ * This pre-converts them so the server receives valid JSON Schema objects
+ * it can forward directly to the LLM provider.
+ */
+export const allServerToolDefinitions = allToolDefinitions.map((def) => ({
+	name: def.name,
+	description: def.description,
+	...(def.inputSchema
+		? { inputSchema: convertSchemaToJsonSchema(def.inputSchema) }
+		: {}),
+}));

--- a/apps/tab-manager/src/lib/ai/tools/definitions.ts
+++ b/apps/tab-manager/src/lib/ai/tools/definitions.ts
@@ -1,0 +1,165 @@
+/**
+ * Tool definition contracts for AI chat.
+ *
+ * Uses `toolDefinition()` from TanStack AI with arktype schemas (Standard
+ * Schema compatible). Definitions are pure schema contracts with no runtime
+ * dependencies — they describe the tool's name, description, and input shape.
+ *
+ * `.client()` implementations live in `client.ts`, which bind these contracts
+ * to the sidebar's Y.Doc tables and Chrome APIs.
+ *
+ * @see docs/articles/tanstack-ai-isomorphic-tool-pattern.md
+ */
+
+import { toolDefinition } from '@tanstack/ai';
+import { type } from 'arktype';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Read Tools (5)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const searchTabsDef = toolDefinition({
+	name: 'searchTabs',
+	description:
+		'Search tabs by URL or title match. Returns matching tabs across all devices, optionally scoped to one device.',
+	inputSchema: type({
+		query: 'string',
+		'deviceId?': 'string',
+	}),
+});
+
+export const listTabsDef = toolDefinition({
+	name: 'listTabs',
+	description: 'List all open tabs. Optionally filter by device or window.',
+	inputSchema: type({
+		'deviceId?': 'string',
+		'windowId?': 'string',
+	}),
+});
+
+export const listWindowsDef = toolDefinition({
+	name: 'listWindows',
+	description:
+		'List all browser windows with their tab counts. Optionally filter by device.',
+	inputSchema: type({
+		'deviceId?': 'string',
+	}),
+});
+
+export const listDevicesDef = toolDefinition({
+	name: 'listDevices',
+	description:
+		'List all synced devices with their names, browsers, and online status.',
+	inputSchema: type({}),
+});
+
+export const countByDomainDef = toolDefinition({
+	name: 'countByDomain',
+	description:
+		'Count open tabs grouped by domain (e.g. youtube.com: 5, github.com: 3). Optionally filter by device.',
+	inputSchema: type({
+		'deviceId?': 'string',
+	}),
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mutation Tools (8)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const closeTabsDef = toolDefinition({
+	name: 'closeTabs',
+	description: 'Close one or more tabs by their composite IDs.',
+	inputSchema: type({
+		tabIds: 'string[]',
+	}),
+});
+
+export const openTabDef = toolDefinition({
+	name: 'openTab',
+	description: 'Open a new tab with the given URL on a specific device.',
+	inputSchema: type({
+		url: 'string',
+		deviceId: 'string',
+		'windowId?': 'string',
+	}),
+});
+
+export const activateTabDef = toolDefinition({
+	name: 'activateTab',
+	description: 'Activate (focus) a specific tab by its composite ID.',
+	inputSchema: type({
+		tabId: 'string',
+	}),
+});
+
+export const saveTabsDef = toolDefinition({
+	name: 'saveTabs',
+	description: 'Save tabs for later. Optionally close them after saving.',
+	inputSchema: type({
+		tabIds: 'string[]',
+		'close?': 'boolean',
+	}),
+});
+
+export const groupTabsDef = toolDefinition({
+	name: 'groupTabs',
+	description: 'Group tabs together with an optional title and color.',
+	inputSchema: type({
+		tabIds: 'string[]',
+		'title?': 'string',
+		'color?': 'string',
+	}),
+});
+
+export const pinTabsDef = toolDefinition({
+	name: 'pinTabs',
+	description: 'Pin or unpin tabs.',
+	inputSchema: type({
+		tabIds: 'string[]',
+		pinned: 'boolean',
+	}),
+});
+
+export const muteTabsDef = toolDefinition({
+	name: 'muteTabs',
+	description: 'Mute or unmute tabs.',
+	inputSchema: type({
+		tabIds: 'string[]',
+		muted: 'boolean',
+	}),
+});
+
+export const reloadTabsDef = toolDefinition({
+	name: 'reloadTabs',
+	description: 'Reload one or more tabs.',
+	inputSchema: type({
+		tabIds: 'string[]',
+	}),
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// All Definitions (for passing schemas to server in request body)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * All tool definitions as an array.
+ *
+ * Used in two places:
+ * 1. `.client(execute)` in client.ts — for ChatClient auto-execution
+ * 2. Raw in the request body — so the server can forward schemas to the LLM
+ */
+export const allToolDefinitions = [
+	searchTabsDef,
+	listTabsDef,
+	listWindowsDef,
+	listDevicesDef,
+	countByDomainDef,
+	closeTabsDef,
+	openTabDef,
+	activateTabDef,
+	saveTabsDef,
+	groupTabsDef,
+	pinTabsDef,
+	muteTabsDef,
+	reloadTabsDef,
+];

--- a/apps/tab-manager/src/lib/components/AiChat.svelte
+++ b/apps/tab-manager/src/lib/components/AiChat.svelte
@@ -31,7 +31,7 @@
 		parts: Array<{ type: string; content?: string }>,
 	): string {
 		return parts
-			.filter((p): p is { type: 'text'; content: string } => p.type === 'text')
+			.filter((p) => p.type === 'text')
 			.map((p) => p.content)
 			.join('');
 	}

--- a/apps/tab-manager/src/lib/state/chat.svelte.ts
+++ b/apps/tab-manager/src/lib/state/chat.svelte.ts
@@ -49,7 +49,7 @@ import type {
 import { popupWorkspace } from '$lib/workspace-popup';
 
 import { tabManagerClientTools } from '$lib/ai/tools/client';
-import { allToolDefinitions } from '$lib/ai/tools/definitions';
+import { allServerToolDefinitions } from '$lib/ai/tools/definitions';
 import { TAB_MANAGER_SYSTEM_PROMPT } from '$lib/ai/system-prompt';
 // ─────────────────────────────────────────────────────────────────────────────
 // Provider / Model Configuration
@@ -207,7 +207,7 @@ function createAiChatState() {
 							model: conv?.model ?? DEFAULT_MODEL,
 							conversationId,
 							systemPrompt: conv?.systemPrompt ?? TAB_MANAGER_SYSTEM_PROMPT,
-							tools: allToolDefinitions,
+							tools: allServerToolDefinitions,
 						},
 					};
 				},

--- a/apps/tab-manager/src/lib/state/chat.svelte.ts
+++ b/apps/tab-manager/src/lib/state/chat.svelte.ts
@@ -48,6 +48,9 @@ import type {
 } from '$lib/workspace';
 import { popupWorkspace } from '$lib/workspace-popup';
 
+import { tabManagerClientTools } from '$lib/ai/tools/client';
+import { allToolDefinitions } from '$lib/ai/tools/definitions';
+import { TAB_MANAGER_SYSTEM_PROMPT } from '$lib/ai/system-prompt';
 // ─────────────────────────────────────────────────────────────────────────────
 // Provider / Model Configuration
 // ─────────────────────────────────────────────────────────────────────────────
@@ -192,6 +195,7 @@ function createAiChatState() {
 
 		const instance = createChat({
 			initialMessages: loadMessagesForConversation(conversationId),
+			tools: tabManagerClientTools,
 			connection: fetchServerSentEvents(
 				() => `${hubUrlCache}/ai/chat`,
 				async () => {
@@ -202,7 +206,8 @@ function createAiChatState() {
 							provider: conv?.provider ?? DEFAULT_PROVIDER,
 							model: conv?.model ?? DEFAULT_MODEL,
 							conversationId,
-							systemPrompt: conv?.systemPrompt ?? undefined,
+							systemPrompt: conv?.systemPrompt ?? TAB_MANAGER_SYSTEM_PROMPT,
+							tools: allToolDefinitions,
 						},
 					};
 				},
@@ -210,14 +215,13 @@ function createAiChatState() {
 			onFinish: (message) => {
 				// conversationId is baked in — can never target the wrong conversation
 				popupWorkspace.tables.chatMessages.set({
-				id: message.id as string as ChatMessageId,
+					id: message.id as string as ChatMessageId,
 					conversationId,
 					role: 'assistant',
 					parts: message.parts,
 					createdAt: message.createdAt?.getTime() ?? Date.now(),
 					_v: 1,
 				});
-
 				// Touch conversation's updatedAt so it floats to top of list
 				const conv = conversations.find((c) => c.id === conversationId);
 				if (conv) {

--- a/apps/tab-manager/src/lib/state/chat.svelte.ts
+++ b/apps/tab-manager/src/lib/state/chat.svelte.ts
@@ -39,6 +39,9 @@ import { GROK_CHAT_MODELS } from '@tanstack/ai-grok';
 import { OPENAI_CHAT_MODELS } from '@tanstack/ai-openai';
 import type { UIMessage } from '@tanstack/ai-svelte';
 import { createChat, fetchServerSentEvents } from '@tanstack/ai-svelte';
+import { TAB_MANAGER_SYSTEM_PROMPT } from '$lib/ai/system-prompt';
+import { tabManagerClientTools } from '$lib/ai/tools/client';
+import { allServerToolDefinitions } from '$lib/ai/tools/definitions';
 import { getHubServerUrl } from '$lib/state/settings';
 import type {
 	ChatMessage,
@@ -48,9 +51,6 @@ import type {
 } from '$lib/workspace';
 import { popupWorkspace } from '$lib/workspace-popup';
 
-import { tabManagerClientTools } from '$lib/ai/tools/client';
-import { allServerToolDefinitions } from '$lib/ai/tools/definitions';
-import { TAB_MANAGER_SYSTEM_PROMPT } from '$lib/ai/system-prompt';
 // ─────────────────────────────────────────────────────────────────────────────
 // Provider / Model Configuration
 // ─────────────────────────────────────────────────────────────────────────────
@@ -557,7 +557,9 @@ function createAiChatState() {
 			const chat = ensureChat(activeConversationId);
 			const lastMessage = chat.messages.at(-1);
 			if (lastMessage?.role === 'assistant') {
-				popupWorkspace.tables.chatMessages.delete(lastMessage.id as string as ChatMessageId);
+				popupWorkspace.tables.chatMessages.delete(
+					lastMessage.id as string as ChatMessageId,
+				);
 			}
 			void chat.reload();
 		},

--- a/bun.lock
+++ b/bun.lock
@@ -132,8 +132,6 @@
         "@epicenter/ui": "workspace:*",
         "@lucide/svelte": "catalog:",
         "@tanstack/ai": "^0.5.1",
-        "@tanstack/ai-anthropic": "^0.5.0",
-        "@tanstack/ai-openai": "^0.5.0",
         "@tanstack/ai-svelte": "^0.5.4",
         "@wxt-dev/storage": "^1.2.6",
         "arktype": "catalog:",

--- a/packages/server/src/ai/plugin.test.ts
+++ b/packages/server/src/ai/plugin.test.ts
@@ -86,9 +86,7 @@ describe('createAIPlugin', () => {
 
 	test('route is reachable through Elysia prefix mount', async () => {
 		const app = new Elysia().use(
-			new Elysia({ prefix: '/ai' }).use(
-				createAIPlugin(),
-			),
+			new Elysia({ prefix: '/ai' }).use(createAIPlugin()),
 		);
 
 		const response = await app.handle(

--- a/packages/server/src/ai/plugin.ts
+++ b/packages/server/src/ai/plugin.ts
@@ -53,6 +53,7 @@ export function createAIPlugin() {
 				conversationId,
 				systemPrompt,
 				modelOptions,
+				tools,
 			} = body;
 
 			if (!isSupportedProvider(provider)) {
@@ -85,6 +86,7 @@ export function createAIPlugin() {
 						abortController,
 						agentLoopStrategy: maxIterations(10),
 						systemPrompts: systemPrompt ? [systemPrompt] : [],
+						...(tools ? { tools } : {}),
 						...(modelOptions ? { modelOptions } : {}),
 					}),
 				catch: (e) => Err(e instanceof Error ? e : new Error(String(e))),
@@ -107,6 +109,7 @@ export function createAIPlugin() {
 				conversationId: t.Optional(t.String()),
 				systemPrompt: t.Optional(t.String()),
 				modelOptions: t.Optional(t.Any()),
+				tools: t.Optional(t.Array(t.Any())),
 			}),
 			response: {
 				400: t.String(),

--- a/specs/20260224T171500-ai-chat-architecture-client-tools.md
+++ b/specs/20260224T171500-ai-chat-architecture-client-tools.md
@@ -111,5 +111,5 @@ The command queue infrastructure is kept intact for future cross-device AI mutat
 - [x] Remove AI code from background.ts
 - [x] Revert chat.svelte.ts to createChat() pattern
 - [x] Verify typecheck passes (0 new errors)
-- [ ] Implement client-side tools in sidebar (follow-up)
-- [ ] Add system prompt back (client-side, in createChat body)
+- [x] Implement client-side tools in sidebar (follow-up) — see `20260224T190000-client-side-ai-tools.md`
+- [x] Add system prompt back (client-side, in createChat body) — default `TAB_MANAGER_SYSTEM_PROMPT` in `$lib/ai/system-prompt.ts`

--- a/specs/20260224T190000-client-side-ai-tools.md
+++ b/specs/20260224T190000-client-side-ai-tools.md
@@ -1,0 +1,75 @@
+# Client-Side AI Tools
+
+**Date**: 2026-02-24
+**Status**: Complete
+**Related**: `20260224T171500-ai-chat-architecture-client-tools.md`
+
+## Overview
+
+Wire TanStack AI client tools into the sidebar's `createChat()`. The server stays generic — it just forwards tool schemas to the LLM. Tool execution happens client-side in the sidebar, which has full Chrome API access and Y.Doc state.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Shared: toolDefinition({ name, description, inputSchema })     │
+│                                                                 │
+│  .client(execute)    →  createChat({ tools })                   │
+│  raw definitions     →  request body → server chat({ tools })   │
+│                                                                 │
+│  LLM calls tool  →  SSE tool-call event  →  ChatClient          │
+│  ChatClient auto-executes  →  addToolResult  →  continues       │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Changes
+
+### 1. Delete dead `broadcast-channel.ts`
+Orphan file with zero imports.
+
+### 2. Create `tools/definitions.ts`
+Restore the 13 `toolDefinition()` contracts from git history (5 read + 8 mutation). Pure schemas, no runtime deps.
+
+### 3. Create `tools/client.ts`
+Client-side `.client(execute)` implementations:
+- Read tools query `popupWorkspace.tables.*` directly (Y.Doc)
+- Mutation tools call Chrome `browser.*` APIs directly (sidebar has full access)
+
+### 4. Update server plugin
+Accept `tools` from request body, forward to `chat({ tools })`. One-line change.
+
+### 5. Wire into `chat.svelte.ts`
+Pass client tools to `createChat({ tools })` and raw definitions in the request body.
+
+## Todo
+
+- [x] Delete broadcast-channel.ts
+- [x] Create tools/definitions.ts (tool schemas)
+- [x] Create tools/client.ts (client implementations)
+- [x] Update server plugin to forward tools
+- [x] Wire tools into chat.svelte.ts
+- [x] Typecheck passes
+
+
+## Review
+
+### Summary
+
+Implemented 13 client-side AI tools (5 read + 8 mutation) for the tab-manager sidebar chat. The server stays generic — it just forwards tool schemas from the request body to the LLM. Tool execution happens entirely client-side.
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `apps/tab-manager/src/lib/ai/tools/definitions.ts` | Created — 13 `toolDefinition()` contracts with arktype schemas |
+| `apps/tab-manager/src/lib/ai/tools/client.ts` | Created — Client `.client(execute)` implementations using Y.Doc reads + Chrome APIs |
+| `packages/server/src/ai/plugin.ts` | Modified — Accept `tools` in request body, forward to `chat()` |
+| `apps/tab-manager/src/lib/state/chat.svelte.ts` | Modified — Wire `tabManagerClientTools` into `createChat()` and `allToolDefinitions` into request body |
+| `apps/tab-manager/src/lib/sync/broadcast-channel.ts` | Deleted — Dead code with zero imports |
+
+### Design Decisions
+
+1. **arktype for input schemas**: Used arktype (Standard Schema compatible) so `toolDefinition()` gets proper runtime validation. Optional fields use `'key?': 'string'` syntax per project conventions.
+2. **Reused existing action functions**: Mutation tools delegate to `$lib/commands/actions.ts` which already wraps all Chrome API calls. No duplication.
+3. **Device ID lazy caching**: Mutation tools need to convert composite tab IDs (`deviceId_tabId`) to native Chrome tab IDs. Used `getDeviceId()` with a module-level cache.
+4. **Server forwards raw definitions**: `allToolDefinitions` (without `.client()`) are sent in the request body. The server passes them to `chat({ tools })` so the LLM sees the schemas. Client tools auto-execute when the LLM calls them.


### PR DESCRIPTION
> **Stack**: PR 2 of 5 — depends on #1420

Now that the server is a generic relay (PR 1), tools move client-side where they have direct access to `chrome.tabs`, `chrome.bookmarks`, and `chrome.tabGroups`.

The architecture splits tool definitions from implementations:

```
src/lib/ai/
├── tools/
│   ├── definitions.ts   ← Pure schema contracts (arktype + TanStack AI)
│   └── client.ts         ← Chrome API implementations
└── system-prompt.ts      ← Default personality
```

Definitions are pure `toolDefinition()` calls with arktype input schemas — no runtime dependencies, no imports from Chrome APIs. This means they can be serialized to JSON Schema and sent to the server for LLM function-calling, while the actual execution stays in the sidebar:

```typescript
// definitions.ts — pure contracts
export const closeTabsDef = toolDefinition({
  name: 'closeTabs',
  description: 'Close one or more tabs by their composite IDs.',
  inputSchema: type({ tabIds: 'string[]' }),
});

// client.ts — Chrome API execution
closeTabsDef.client(async ({ input }) => {
  await executeCloseTabs(input.tabIds);
  return { closed: input.tabIds };
});
```

```
┌──────────────────────────────────────────────────────────┐
│  Browser Extension (sidepanel)                           │
│                                                          │
│  definitions.ts ──→ createChat() ──→ Server AI Plugin    │
│  client.ts      ←── tool call results ←──┘               │
│                                                          │
│  13 tools: 5 read (Y.Doc queries) + 8 mutation (Chrome)  │
└──────────────────────────────────────────────────────────┘
```

Read tools query the Y.Doc tables directly (`searchTabs`, `listTabs`, `listWindows`, `listDevices`, `countByDomain`). Mutation tools call existing action functions that wrap Chrome APIs (`openTab`, `closeTabs`, `activateTab`, `groupTabs`, `pinTabs`, `muteTabs`, `reloadTabs`, `saveTabs`).

The server endpoint now accepts an optional `tools` array in the request body and forwards it to `chat()`, keeping it fully app-agnostic while letting clients define their own tool schemas.