### PR TITLE
feat(tab-manager): chat UX — confirmation, error handling, conversation picker

### DIFF
--- a/apps/tab-manager/specs/20260224T141300 ai-chat-controls-redesign.md
+++ b/apps/tab-manager/specs/20260224T141300 ai-chat-controls-redesign.md
@@ -1,0 +1,56 @@
+# AI Chat Controls Area Redesign
+
+## Problem
+
+The bottom controls area of `AiChat.svelte` has several UX and styling issues:
+
+1. **Send button / textarea size mismatch** — The send button uses `size="icon"` (36×36px) but the textarea's natural height doesn't match, creating visual misalignment
+2. **Provider + model selects take too much space** — Two full-width selects eat into valuable chat real estate in a narrow sidebar panel
+3. **The controls area feels cluttered** — Provider select, model combobox, textarea, and send/stop button all stacked vertically creates a lot of visual noise for a compact sidebar
+4. **Missing `<form>` wrapper** — Enter-to-submit works via `onkeydown`, but there's no `<form>` element. Best practice for chat UIs wraps the input area in a `<form>` with `onsubmit` for accessibility and semantic HTML
+
+## Scope
+
+Only the controls area at the bottom of `AiChat.svelte` (lines 188-244). The message list, conversation bar, and error banner are out of scope.
+
+## Design
+
+### 1. Wrap input area in a `<form>` element
+
+Replace the raw `<div>` around textarea + button with a `<form onsubmit>`. This gives us:
+- Native form submission semantics (Enter submits, button type="submit")
+- Better accessibility (screen readers understand it's a form)
+- Cleaner event handling (single `onsubmit` instead of `onkeydown` + `onclick`)
+
+### 2. Fix textarea + send button alignment
+
+- Use `items-end` on the flex row so the send button aligns to the bottom of the textarea
+- Set textarea to single-line height by default with `field-sizing-content` (already on the base component) and override `min-h` to match the button height
+- Use `size="icon-sm"` (32×32) for the send button to match the compact sidebar context, or explicitly size it with a class
+
+### 3. Collapse provider + model into a single compact row
+
+Instead of two full-width selects, combine them into a tighter layout:
+- Show as a single row: `[Provider ▾] [Model ▾]` with smaller text (`text-xs`)
+- Both use `size="sm"` for compactness (they already do)
+- This is already the current layout; the main improvement is reducing vertical padding
+
+### 4. Tighten vertical spacing
+
+- Reduce `space-y-2` to `space-y-1.5` or `gap-1.5`
+- Reduce `px-3 py-2` padding to `px-2 py-1.5` to match the conversation bar above
+
+## Todo
+
+- [ ] Wrap textarea + send button in a `<form>` with `onsubmit` handler
+- [ ] Remove redundant `onkeydown` Enter handler (form handles it), keep Shift+Enter for newlines via `e.preventDefault()` on plain Enter
+- [ ] Fix send button to self-align to bottom of textarea (`items-end`)
+- [ ] Override textarea `min-h` to remove the default `min-h-16` and let `rows={1}` control height
+- [ ] Tighten controls area padding and spacing to match conversation bar
+- [ ] Verify all functionality: Enter submits, Shift+Enter newline, stop button works, disabled state works
+
+## Non-goals
+
+- Changing the message list or chat bubble components
+- Changing the conversation dropdown
+- Adding new features (markdown rendering, file attachments, etc.)

--- a/apps/tab-manager/src/entrypoints/sidepanel/App.svelte
+++ b/apps/tab-manager/src/entrypoints/sidepanel/App.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import AiChat from '$lib/components/AiChat.svelte';
+	import ConfirmationDialog from '$lib/components/ConfirmationDialog.svelte';
 	import FlatTabList from '$lib/components/FlatTabList.svelte';
 	import SavedTabList from '$lib/components/SavedTabList.svelte';
 	import { browserState } from '$lib/state/browser-state.svelte';
@@ -8,7 +9,6 @@
 	import * as Tabs from '@epicenter/ui/tabs';
 	import * as Tooltip from '@epicenter/ui/tooltip';
 	import SparklesIcon from '@lucide/svelte/icons/sparkles';
-
 	const totalTabs = $derived(
 		browserState.windows.reduce(
 			(sum, w) => sum + browserState.tabsByWindow(w.id).length,
@@ -64,3 +64,4 @@
 		</Tabs.Root>
 	</main>
 </Tooltip.Provider>
+<ConfirmationDialog />

--- a/apps/tab-manager/src/lib/components/AiChat.svelte
+++ b/apps/tab-manager/src/lib/components/AiChat.svelte
@@ -270,7 +270,7 @@
 	{/if}
 
 	<!-- Controls area -->
-	<div class="space-y-1.5 border-t bg-background px-2 py-1.5">
+	<div class="flex flex-col gap-1.5 border-t bg-background px-2 py-1.5">
 		<!-- Provider + Model selects -->
 		<div class="flex gap-2">
 			<Select.Root
@@ -296,18 +296,19 @@
 		<!-- Input + send/stop button -->
 		<form
 			class="flex items-end gap-1.5"
+			aria-label="Chat message"
 			onsubmit={(e) => {
 				e.preventDefault();
 				send();
 			}}
 		>
 			<Textarea
-				class="min-h-0 flex-1 resize-none"
+				class="min-h-0 max-h-32 flex-1 resize-none overflow-y-auto"
 				rows={1}
 				placeholder="Type a message…"
 				bind:value={inputValue}
 				onkeydown={(e: KeyboardEvent) => {
-					if (e.key === 'Enter' && !e.shiftKey) {
+					if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
 						e.preventDefault();
 						send();
 					}
@@ -320,7 +321,7 @@
 					type="button"
 					onclick={() => aiChatState.stop()}
 				>
-					<SquareIcon class="size-3.5" />
+					<SquareIcon />
 				</Button>
 			{:else}
 				<Button
@@ -329,7 +330,7 @@
 					type="submit"
 					disabled={!inputValue.trim()}
 				>
-					<SendIcon class="size-3.5" />
+					<SendIcon />
 				</Button>
 			{/if}
 		</form>

--- a/apps/tab-manager/src/lib/components/AiChat.svelte
+++ b/apps/tab-manager/src/lib/components/AiChat.svelte
@@ -62,7 +62,10 @@
 		if (hours < 24) return `${hours}h`;
 		const days = Math.floor(hours / 24);
 		if (days < 7) return `${days}d`;
-		return new Date(ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+		return new Date(ms).toLocaleDateString(undefined, {
+			month: 'short',
+			day: 'numeric',
+		});
 	}
 
 	/**
@@ -132,20 +135,29 @@
 										conversationPicker.closeAndFocusTrigger();
 									}}
 								>
-									<span class="flex w-full items-center justify-between gap-1.5 text-xs">
+									<span
+										class="flex w-full items-center justify-between gap-1.5 text-xs"
+									>
 										<span class="flex min-w-0 items-center gap-1.5">
 											<CheckIcon
 												class={cn('mr-0.5 size-3 shrink-0', {
-													'text-transparent': conv.id !== aiChatState.activeConversationId,
+													'text-transparent':
+														conv.id !== aiChatState.activeConversationId,
 												})}
 											/>
-											<span class="min-w-0 truncate font-medium">{conv.title}</span>
+											<span class="min-w-0 truncate font-medium"
+												>{conv.title}</span
+											>
 											{#if aiChatState.isStreaming(conv.id)}
-												<LoaderCircleIcon class="size-3 shrink-0 animate-spin text-muted-foreground" />
+												<LoaderCircleIcon
+													class="size-3 shrink-0 animate-spin text-muted-foreground"
+												/>
 											{/if}
 										</span>
 										<span class="flex shrink-0 items-center gap-1">
-											<span class="text-[10px] text-muted-foreground">{formatRelativeTime(conv.updatedAt)}</span>
+											<span class="text-[10px] text-muted-foreground"
+												>{formatRelativeTime(conv.updatedAt)}</span
+											>
 											<button
 												class="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100"
 												onclick={(e) => {
@@ -153,9 +165,10 @@
 													e.preventDefault();
 													confirmationDialog.open({
 														title: 'Delete conversation',
-													description: `Delete "${conv.title}"? This will remove all messages in this conversation.`,
+														description: `Delete "${conv.title}"? This will remove all messages in this conversation.`,
 														confirm: { text: 'Delete', variant: 'destructive' },
-														onConfirm: () => aiChatState.deleteConversation(conv.id),
+														onConfirm: () =>
+															aiChatState.deleteConversation(conv.id),
 													});
 												}}
 											>
@@ -165,7 +178,10 @@
 									</span>
 									{@const preview = aiChatState.getLastMessagePreview(conv.id)}
 									{#if preview}
-										<span class="w-full truncate pl-5 text-[10px] text-muted-foreground">{preview}</span>
+										<span
+											class="w-full truncate pl-5 text-[10px] text-muted-foreground"
+											>{preview}</span
+										>
 									{/if}
 								</Command.Item>
 							{/each}

--- a/apps/tab-manager/src/lib/components/AiChat.svelte
+++ b/apps/tab-manager/src/lib/components/AiChat.svelte
@@ -4,13 +4,16 @@
 	import { Button } from '@epicenter/ui/button';
 	import { cn } from '@epicenter/ui/utils';
 	import * as Chat from '@epicenter/ui/chat';
-	import * as DropdownMenu from '@epicenter/ui/dropdown-menu';
+	import * as Command from '@epicenter/ui/command';
+	import { useCombobox } from '@epicenter/ui/hooks';
+	import * as Popover from '@epicenter/ui/popover';
 	import * as Empty from '@epicenter/ui/empty';
 	import ModelCombobox from '$lib/components/ModelCombobox.svelte';
 	import * as Select from '@epicenter/ui/select';
 	import { Textarea } from '@epicenter/ui/textarea';
 	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
 	import MessageSquarePlusIcon from '@lucide/svelte/icons/message-square-plus';
+	import CheckIcon from '@lucide/svelte/icons/check';
 	import RotateCcwIcon from '@lucide/svelte/icons/rotate-ccw';
 	import SendIcon from '@lucide/svelte/icons/send';
 	import SparklesIcon from '@lucide/svelte/icons/sparkles';
@@ -23,6 +26,16 @@
 
 	/** Tracks dismissed error to avoid re-showing the same one. */
 	let dismissedError = $state<string | null>(null);
+	const conversationPicker = useCombobox();
+	let conversationSearch = $state('');
+
+	const filteredConversations = $derived(
+		conversationSearch
+			? aiChatState.conversations.filter((c) =>
+					c.title.toLowerCase().includes(conversationSearch.toLowerCase()),
+				)
+			: aiChatState.conversations,
+	);
 	function send() {
 		const content = inputValue.trim();
 		if (!content) return;
@@ -84,69 +97,82 @@
 	<!-- Conversation bar -->
 	<div class="flex items-center gap-1 border-b px-2 py-1.5">
 		{#if hasConversations}
-			<DropdownMenu.Root>
-				<DropdownMenu.Trigger>
+			<Popover.Root bind:open={conversationPicker.open}>
+				<Popover.Trigger bind:ref={conversationPicker.triggerRef}>
 					{#snippet child({ props })}
 						<Button
 							{...props}
 							variant="ghost"
 							size="sm"
+							role="combobox"
+							aria-expanded={conversationPicker.open}
 							class="h-7 min-w-0 flex-1 justify-between gap-1 px-2 text-xs"
 						>
 							<span class="truncate">{activeTitle}</span>
 							<ChevronDownIcon class="size-3 shrink-0 opacity-50" />
 						</Button>
 					{/snippet}
-				</DropdownMenu.Trigger>
-				<DropdownMenu.Content align="start" class="w-[260px]">
-					{#each aiChatState.conversations as conv (conv.id)}
-					<DropdownMenu.Item
-						class="group flex-col items-start gap-0.5 text-xs"
-						onclick={() => aiChatState.switchConversation(conv.id)}
-					>
-						<span class="flex w-full items-center justify-between gap-1.5">
-							<span class="flex min-w-0 items-center gap-1.5">
-								<span
-									class={cn(
-										'min-w-0 truncate',
-										conv.id === aiChatState.activeConversationId &&
-											'font-medium',
-									)}
-								>
-									{conv.title}
-								</span>
-								{#if aiChatState.isStreaming(conv.id)}
-									<LoaderCircleIcon
-										class="size-3 shrink-0 animate-spin text-muted-foreground"
-									/>
-								{/if}
-							</span>
-							<span class="flex shrink-0 items-center gap-1">
-								<span class="text-[10px] text-muted-foreground">{formatRelativeTime(conv.updatedAt)}</span>
-								<button
-									class="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100"
-									onclick={(e) => {
-										e.stopPropagation();
-										confirmationDialog.open({
-											title: 'Delete conversation',
-										description: `Delete "${conv.title}"? This will remove all messages in this conversation.`,
-											confirm: { text: 'Delete', variant: 'destructive' },
-											onConfirm: () => aiChatState.deleteConversation(conv.id),
-										});
+				</Popover.Trigger>
+				<Popover.Content class="w-[280px] p-0" align="start">
+					<Command.Root shouldFilter={false}>
+						<Command.Input
+							placeholder="Search conversations\u2026"
+							class="h-9 text-sm"
+							bind:value={conversationSearch}
+						/>
+						<Command.List class="max-h-[300px]">
+							<Command.Empty>No conversations found.</Command.Empty>
+							{#each filteredConversations as conv (conv.id)}
+								<Command.Item
+									value={conv.id}
+									class="group flex-col items-start gap-0.5"
+									onSelect={() => {
+										aiChatState.switchConversation(conv.id);
+										conversationSearch = '';
+										conversationPicker.closeAndFocusTrigger();
 									}}
 								>
-									<TrashIcon class="size-3" />
-								</button>
-							</span>
-						</span>
-						{@const preview = aiChatState.getLastMessagePreview(conv.id)}
-						{#if preview}
-							<span class="w-full truncate text-[10px] text-muted-foreground">{preview}</span>
-						{/if}
-					</DropdownMenu.Item>
-					{/each}
-				</DropdownMenu.Content>
-			</DropdownMenu.Root>
+									<span class="flex w-full items-center justify-between gap-1.5 text-xs">
+										<span class="flex min-w-0 items-center gap-1.5">
+											<CheckIcon
+												class={cn('mr-0.5 size-3 shrink-0', {
+													'text-transparent': conv.id !== aiChatState.activeConversationId,
+												})}
+											/>
+											<span class="min-w-0 truncate font-medium">{conv.title}</span>
+											{#if aiChatState.isStreaming(conv.id)}
+												<LoaderCircleIcon class="size-3 shrink-0 animate-spin text-muted-foreground" />
+											{/if}
+										</span>
+										<span class="flex shrink-0 items-center gap-1">
+											<span class="text-[10px] text-muted-foreground">{formatRelativeTime(conv.updatedAt)}</span>
+											<button
+												class="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100"
+												onclick={(e) => {
+													e.stopPropagation();
+													e.preventDefault();
+													confirmationDialog.open({
+														title: 'Delete conversation',
+													description: `Delete "${conv.title}"? This will remove all messages in this conversation.`,
+														confirm: { text: 'Delete', variant: 'destructive' },
+														onConfirm: () => aiChatState.deleteConversation(conv.id),
+													});
+												}}
+											>
+												<TrashIcon class="size-3" />
+											</button>
+										</span>
+									</span>
+									{@const preview = aiChatState.getLastMessagePreview(conv.id)}
+									{#if preview}
+										<span class="w-full truncate pl-5 text-[10px] text-muted-foreground">{preview}</span>
+									{/if}
+								</Command.Item>
+							{/each}
+						</Command.List>
+					</Command.Root>
+				</Popover.Content>
+			</Popover.Root>
 		{:else}
 			<span class="flex-1 px-2 text-xs text-muted-foreground">No chats yet</span
 			>

--- a/apps/tab-manager/src/lib/components/AiChat.svelte
+++ b/apps/tab-manager/src/lib/components/AiChat.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { aiChatState } from '$lib/state/chat.svelte';
+	import { confirmationDialog } from '$lib/components/ConfirmationDialog.svelte';
 	import { Button } from '@epicenter/ui/button';
 	import { cn } from '@epicenter/ui/utils';
 	import * as Chat from '@epicenter/ui/chat';
@@ -94,15 +95,20 @@
 									/>
 								{/if}
 							</span>
-							<button
-								class="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100"
-								onclick={(e) => {
-									e.stopPropagation();
-									aiChatState.deleteConversation(conv.id);
-								}}
-							>
-								<TrashIcon class="size-3" />
-							</button>
+						<button
+							class="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100"
+							onclick={(e) => {
+								e.stopPropagation();
+								confirmationDialog.open({
+									title: 'Delete conversation',
+									description: `Delete "${conv.title}"? This will remove all messages in this conversation.`,
+									confirm: { text: 'Delete', variant: 'destructive' },
+									onConfirm: () => aiChatState.deleteConversation(conv.id),
+								});
+							}}
+						>
+							<TrashIcon class="size-3" />
+						</button>
 						</DropdownMenu.Item>
 					{/each}
 				</DropdownMenu.Content>
@@ -139,7 +145,7 @@
 				</Empty.Description>
 			</Empty.Root>
 		{:else}
-			<Chat.List class="h-full">
+			<Chat.List>
 				{#each aiChatState.messages as message (message.id)}
 					<Chat.Bubble variant={message.role === 'user' ? 'sent' : 'received'}>
 						<Chat.BubbleMessage>
@@ -215,7 +221,6 @@
 						send();
 					}
 				}}
-				disabled={aiChatState.isLoading}
 			/>
 			{#if aiChatState.isLoading}
 				<Button

--- a/apps/tab-manager/src/lib/components/AiChat.svelte
+++ b/apps/tab-manager/src/lib/components/AiChat.svelte
@@ -17,9 +17,12 @@
 	import SquareIcon from '@lucide/svelte/icons/square';
 	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import TrashIcon from '@lucide/svelte/icons/trash';
+	import XIcon from '@lucide/svelte/icons/x';
 
 	let inputValue = $state('');
 
+	/** Tracks dismissed error to avoid re-showing the same one. */
+	let dismissedError = $state<string | null>(null);
 	function send() {
 		const content = inputValue.trim();
 		if (!content) return;
@@ -105,20 +108,20 @@
 									/>
 								{/if}
 							</span>
-						<button
-							class="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100"
-							onclick={(e) => {
-								e.stopPropagation();
-								confirmationDialog.open({
-									title: 'Delete conversation',
-									description: `Delete "${conv.title}"? This will remove all messages in this conversation.`,
-									confirm: { text: 'Delete', variant: 'destructive' },
-									onConfirm: () => aiChatState.deleteConversation(conv.id),
-								});
-							}}
-						>
-							<TrashIcon class="size-3" />
-						</button>
+							<button
+								class="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100"
+								onclick={(e) => {
+									e.stopPropagation();
+									confirmationDialog.open({
+										title: 'Delete conversation',
+										description: `Delete "${conv.title}"? This will remove all messages in this conversation.`,
+										confirm: { text: 'Delete', variant: 'destructive' },
+										onConfirm: () => aiChatState.deleteConversation(conv.id),
+									});
+								}}
+							>
+								<TrashIcon class="size-3" />
+							</button>
 						</DropdownMenu.Item>
 					{/each}
 				</DropdownMenu.Content>
@@ -186,16 +189,41 @@
 	</div>
 
 	<!-- Error banner -->
-	{#if aiChatState.error}
+	{#if aiChatState.error && aiChatState.error.message !== dismissedError}
 		<div
-			class="border-t border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+			role="alert"
+			class="flex items-center justify-between gap-2 border-t border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive"
 		>
-			{aiChatState.error.message}
+			<span class="min-w-0 flex-1">{aiChatState.error.message}</span>
+			<div class="flex shrink-0 items-center gap-1">
+				<Button
+					variant="ghost"
+					size="sm"
+					class="h-6 gap-1 px-2 text-xs text-destructive hover:text-destructive"
+					onclick={() => {
+						dismissedError = null;
+						aiChatState.reload();
+					}}
+				>
+					<RotateCcwIcon class="size-3" />
+					Retry
+				</Button>
+				<Button
+					variant="ghost"
+					size="icon"
+					class="size-6 text-destructive hover:text-destructive"
+					onclick={() => {
+						dismissedError = aiChatState.error?.message ?? null;
+					}}
+				>
+					<XIcon class="size-3" />
+				</Button>
+			</div>
 		</div>
 	{/if}
 
 	<!-- Controls area -->
-	<div class="space-y-2 border-t bg-background px-3 py-2">
+	<div class="space-y-1.5 border-t bg-background px-2 py-1.5">
 		<!-- Provider + Model selects -->
 		<div class="flex gap-2">
 			<Select.Root
@@ -219,7 +247,13 @@
 		</div>
 
 		<!-- Input + send/stop button -->
-		<div class="flex gap-2">
+		<form
+			class="flex items-end gap-1.5"
+			onsubmit={(e) => {
+				e.preventDefault();
+				send();
+			}}
+		>
 			<Textarea
 				class="min-h-0 flex-1 resize-none"
 				rows={1}
@@ -235,21 +269,22 @@
 			{#if aiChatState.isLoading}
 				<Button
 					variant="outline"
-					size="icon"
+					size="icon-lg"
+					type="button"
 					onclick={() => aiChatState.stop()}
 				>
-					<SquareIcon class="size-4" />
+					<SquareIcon class="size-3.5" />
 				</Button>
 			{:else}
 				<Button
 					variant="default"
-					size="icon"
-					onclick={() => send()}
+					size="icon-lg"
+					type="submit"
 					disabled={!inputValue.trim()}
 				>
-					<SendIcon class="size-4" />
+					<SendIcon class="size-3.5" />
 				</Button>
 			{/if}
-		</div>
+		</form>
 	</div>
 </div>

--- a/apps/tab-manager/src/lib/components/AiChat.svelte
+++ b/apps/tab-manager/src/lib/components/AiChat.svelte
@@ -37,8 +37,18 @@
 			.join('');
 	}
 
-	/** Show loading dots when request is submitted but no tokens yet. */
-	const showLoadingDots = $derived(aiChatState.status === 'submitted');
+	/**
+	 * Show loading dots when waiting for assistant content.
+	 *
+	 * Covers the gap between 'submitted' (request sent) and first visible
+	 * assistant token. Without this, dots flash away when status transitions
+	 * to 'streaming' before any text is actually rendered.
+	 */
+	const showLoadingDots = $derived(
+		aiChatState.status === 'submitted' ||
+			(aiChatState.status === 'streaming' &&
+				aiChatState.messages.at(-1)?.role !== 'assistant'),
+	);
 
 	/** Show regenerate button when idle and last message is from assistant. */
 	const showRegenerate = $derived(

--- a/apps/tab-manager/src/lib/components/AiChat.svelte
+++ b/apps/tab-manager/src/lib/components/AiChat.svelte
@@ -39,6 +39,18 @@
 			.map((p) => p.content)
 			.join('');
 	}
+	/** Format a timestamp as a short relative time string. */
+	function formatRelativeTime(ms: number): string {
+		const seconds = Math.floor((Date.now() - ms) / 1000);
+		if (seconds < 60) return 'now';
+		const minutes = Math.floor(seconds / 60);
+		if (minutes < 60) return `${minutes}m`;
+		const hours = Math.floor(minutes / 60);
+		if (hours < 24) return `${hours}h`;
+		const days = Math.floor(hours / 24);
+		if (days < 7) return `${days}d`;
+		return new Date(ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+	}
 
 	/**
 	 * Show loading dots when waiting for assistant content.
@@ -88,10 +100,11 @@
 				</DropdownMenu.Trigger>
 				<DropdownMenu.Content align="start" class="w-[260px]">
 					{#each aiChatState.conversations as conv (conv.id)}
-						<DropdownMenu.Item
-							class="group justify-between gap-2 text-xs"
-							onclick={() => aiChatState.switchConversation(conv.id)}
-						>
+					<DropdownMenu.Item
+						class="group flex-col items-start gap-0.5 text-xs"
+						onclick={() => aiChatState.switchConversation(conv.id)}
+					>
+						<span class="flex w-full items-center justify-between gap-1.5">
 							<span class="flex min-w-0 items-center gap-1.5">
 								<span
 									class={cn(
@@ -108,21 +121,29 @@
 									/>
 								{/if}
 							</span>
-							<button
-								class="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100"
-								onclick={(e) => {
-									e.stopPropagation();
-									confirmationDialog.open({
-										title: 'Delete conversation',
+							<span class="flex shrink-0 items-center gap-1">
+								<span class="text-[10px] text-muted-foreground">{formatRelativeTime(conv.updatedAt)}</span>
+								<button
+									class="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100"
+									onclick={(e) => {
+										e.stopPropagation();
+										confirmationDialog.open({
+											title: 'Delete conversation',
 										description: `Delete "${conv.title}"? This will remove all messages in this conversation.`,
-										confirm: { text: 'Delete', variant: 'destructive' },
-										onConfirm: () => aiChatState.deleteConversation(conv.id),
-									});
-								}}
-							>
-								<TrashIcon class="size-3" />
-							</button>
-						</DropdownMenu.Item>
+											confirm: { text: 'Delete', variant: 'destructive' },
+											onConfirm: () => aiChatState.deleteConversation(conv.id),
+										});
+									}}
+								>
+									<TrashIcon class="size-3" />
+								</button>
+							</span>
+						</span>
+						{@const preview = aiChatState.getLastMessagePreview(conv.id)}
+						{#if preview}
+							<span class="w-full truncate text-[10px] text-muted-foreground">{preview}</span>
+						{/if}
+					</DropdownMenu.Item>
 					{/each}
 				</DropdownMenu.Content>
 			</DropdownMenu.Root>

--- a/apps/tab-manager/src/lib/components/ConfirmationDialog.svelte
+++ b/apps/tab-manager/src/lib/components/ConfirmationDialog.svelte
@@ -1,0 +1,164 @@
+<script module lang="ts">
+	/**
+	 * Options for opening a confirmation dialog.
+	 */
+	export type ConfirmationDialogOptions = {
+		/** Title displayed at the top of the dialog */
+		title: string;
+		/** Description text shown below the title */
+		description: string;
+		/** Configuration for the confirm button */
+		confirm?: {
+			/** Text for the confirm button. Defaults to "Confirm" */
+			text?: string;
+			/** Variant for the confirm button. Defaults to "default" */
+			variant?: 'default' | 'destructive';
+		};
+		/** Configuration for the cancel button */
+		cancel?: {
+			/** Text for the cancel button. Defaults to "Cancel" */
+			text?: string;
+		};
+		/**
+		 * Called when the user confirms. Can be async - the dialog will show
+		 * a loading state and stay open until the promise resolves.
+		 * Throw an error to keep the dialog open (e.g., on failure).
+		 */
+		onConfirm: () => void | Promise<unknown>;
+		/** Called when the user cancels */
+		onCancel?: () => void;
+	};
+
+	/**
+	 * Creates a confirmation dialog state manager.
+	 *
+	 * @example
+	 * ```ts
+	 * confirmationDialog.open({
+	 *   title: 'Delete conversation',
+	 *   description: 'Are you sure?',
+	 *   confirm: { text: 'Delete', variant: 'destructive' },
+	 *   onConfirm: () => deleteConversation(id),
+	 * });
+	 * ```
+	 */
+	function createConfirmationDialog() {
+		let isOpen = $state(false);
+		let isPending = $state(false);
+		let options = $state<ConfirmationDialogOptions | null>(null);
+
+		return {
+			get isOpen() {
+				return isOpen;
+			},
+			set isOpen(value) {
+				isOpen = value;
+			},
+			get isPending() {
+				return isPending;
+			},
+			get options() {
+				return options;
+			},
+
+			/**
+			 * Opens the confirmation dialog with the given options.
+			 */
+			open(opts: ConfirmationDialogOptions) {
+				options = opts;
+				isPending = false;
+				isOpen = true;
+			},
+
+			/**
+			 * Closes the dialog and resets state.
+			 */
+			close() {
+				isOpen = false;
+				isPending = false;
+				options = null;
+			},
+
+			/**
+			 * Handles the confirm action. If onConfirm returns a promise,
+			 * shows a loading state until it resolves.
+			 */
+			async confirm() {
+				if (!options) return;
+
+				const result = options.onConfirm();
+
+				if (result instanceof Promise) {
+					isPending = true;
+					try {
+						await result;
+						isOpen = false;
+					} catch {
+						// Keep dialog open on error (caller should handle notification)
+					} finally {
+						isPending = false;
+					}
+				} else {
+					isOpen = false;
+				}
+			},
+
+			/**
+			 * Handles the cancel action.
+			 */
+			cancel() {
+				options?.onCancel?.();
+				isOpen = false;
+			},
+		};
+	}
+
+	export const confirmationDialog = createConfirmationDialog();
+</script>
+
+<script lang="ts">
+	import * as AlertDialog from '@epicenter/ui/alert-dialog';
+	import { cn } from '@epicenter/ui/utils';
+</script>
+
+<AlertDialog.Root bind:open={confirmationDialog.isOpen}>
+	<AlertDialog.Content class="sm:max-w-xl">
+		<form
+			method="POST"
+			onsubmit={(e) => {
+				e.preventDefault();
+				confirmationDialog.confirm();
+			}}
+			class="flex flex-col gap-4"
+		>
+			<AlertDialog.Header>
+				<AlertDialog.Title
+					>{confirmationDialog.options?.title}</AlertDialog.Title
+				>
+				<AlertDialog.Description>
+					{confirmationDialog.options?.description}
+				</AlertDialog.Description>
+			</AlertDialog.Header>
+
+			<AlertDialog.Footer>
+				<AlertDialog.Cancel
+					type="button"
+					onclick={confirmationDialog.cancel}
+					disabled={confirmationDialog.isPending}
+				>
+					{confirmationDialog.options?.cancel?.text ?? 'Cancel'}
+				</AlertDialog.Cancel>
+				<AlertDialog.Action
+					type="submit"
+					disabled={confirmationDialog.isPending}
+					class={cn(
+						confirmationDialog.options?.confirm?.variant === 'destructive' &&
+							'bg-destructive hover:bg-destructive/90 text-white',
+					)}
+				>
+					{confirmationDialog.options?.confirm?.text ?? 'Confirm'}
+				</AlertDialog.Action>
+			</AlertDialog.Footer>
+		</form>
+	</AlertDialog.Content>
+</AlertDialog.Root>

--- a/apps/tab-manager/src/lib/state/chat.svelte.ts
+++ b/apps/tab-manager/src/lib/state/chat.svelte.ts
@@ -242,10 +242,7 @@ function createAiChatState() {
 	 * - No `setMessages()` swapping needed on conversation switch
 	 * - Multiple conversations can stream concurrently
 	 */
-	const chatInstances = new Map<
-		ConversationId,
-		ReturnType<typeof createChat>
-	>();
+	const chatInstances = new Map<ConversationId, CreateChatReturn>();
 
 	/**
 	 * Get or create a ChatClient for a conversation.

--- a/apps/tab-manager/src/lib/state/chat.svelte.ts
+++ b/apps/tab-manager/src/lib/state/chat.svelte.ts
@@ -562,7 +562,9 @@ function createAiChatState() {
 			const conv = getActiveConversation();
 			updateConversation(convId, {
 				title:
-					conv?.title === 'New Chat' ? content.trim().slice(0, 50) : conv?.title,
+					conv?.title === 'New Chat'
+						? content.trim().slice(0, 50)
+						: conv?.title,
 			});
 			// Send via this conversation's ChatClient (triggers SSE streaming)
 			void ensureChat(convId).sendMessage({ content, id: userMessageId });

--- a/apps/tab-manager/src/lib/state/chat.svelte.ts
+++ b/apps/tab-manager/src/lib/state/chat.svelte.ts
@@ -109,15 +109,15 @@ function createAiChatState() {
 			.sort((a, b) => b.updatedAt - a.updatedAt);
 
 	let conversations = $state<Conversation[]>(readAllConversations());
-	// Re-read on every Y.Doc change — observer fires on persistence load
-	// and any subsequent remote/local modification.
-	popupWorkspace.tables.conversations.observe(() => {
-		conversations = readAllConversations();
-	});
 
-	// Ensure at least one conversation always exists. Creates a default
-	// on first load so provider/model dropdowns always have a target.
-	if (conversations.length === 0) {
+	/**
+	 * Ensure at least one conversation exists.
+	 *
+	 * Called after persistence loads and in the conversations observer.
+	 * Safe to call multiple times — only creates if truly empty.
+	 */
+	function ensureDefaultConversation(): ConversationId | undefined {
+		if (conversations.length > 0) return undefined;
 		const id = generateConversationId();
 		const now = Date.now();
 		popupWorkspace.tables.conversations.set({
@@ -130,7 +130,27 @@ function createAiChatState() {
 			_v: 1,
 		});
 		conversations = readAllConversations();
+		return id;
 	}
+
+	// Re-read on every Y.Doc change — observer fires on persistence load
+	// and any subsequent remote/local modification.
+	popupWorkspace.tables.conversations.observe(() => {
+		conversations = readAllConversations();
+	});
+
+	// Defer default conversation creation until Y.Doc persistence loads.
+	// Before this resolves, conversations may be empty — the UI handles
+	// this gracefully by showing the empty state.
+	void popupWorkspace.whenReady.then(() => {
+		conversations = readAllConversations();
+		const newId = ensureDefaultConversation();
+		// Point active to first real conversation after persistence merge
+		if (conversations.length > 0) {
+			activeConversationId = newId ?? conversations[0].id;
+		}
+	});
+
 	// Refresh active conversation's messages when Y.Doc changes (e.g. background completion).
 	// Non-active conversations get refreshed on switch via `switchConversation`.
 	popupWorkspace.tables.chatMessages.observe(() => {
@@ -138,9 +158,18 @@ function createAiChatState() {
 		if (!instance || instance.isLoading) return;
 		instance.setMessages(loadMessagesForConversation(activeConversationId));
 	});
+
 	// ── Active Conversation ───────────────────────────────────────────
-	/** Always points to a valid conversation — guaranteed by eager creation. */
-	let activeConversationId = $state<ConversationId>(conversations[0].id);
+
+	/**
+	 * The active conversation ID.
+	 *
+	 * May briefly be invalid before Y.Doc persistence loads — all getters
+	 * that depend on this handle the not-found case gracefully.
+	 */
+	let activeConversationId = $state<ConversationId>(
+		(conversations[0]?.id ?? '') as ConversationId,
+	);
 
 	/**
 	 * Derived from `activeConversationId` + `conversations`.
@@ -148,21 +177,21 @@ function createAiChatState() {
 	 * Re-evaluates when either changes — e.g. when provider/model is
 	 * updated in the table, the observer fires, `conversations` updates,
 	 * and this re-derives with the new metadata.
+	 *
+	 * Returns undefined if active conversation doesn't exist yet
+	 * (before persistence loads).
 	 */
 	const activeConversation = $derived(findConversation(activeConversationId));
 
 	// ── Helpers ───────────────────────────────────────────────────────
 
 	/**
-	 * Find a conversation by ID — throws if not found.
+	 * Find a conversation by ID.
 	 *
-	 * Safe because eager creation guarantees at least one conversation
-	 * always exists, and `activeConversationId` is always valid.
+	 * Returns undefined if not found (e.g., before persistence loads).
 	 */
-	function findConversation(id: ConversationId): Conversation {
-		const conv = conversations.find((c) => c.id === id);
-		if (!conv) throw new Error(`Conversation ${id} not found`);
-		return conv;
+	function findConversation(id: ConversationId): Conversation | undefined {
+		return conversations.find((c) => c.id === id);
 	}
 
 	/**
@@ -170,8 +199,9 @@ function createAiChatState() {
 	 *
 	 * Used in non-reactive contexts (async callbacks, event handlers)
 	 * where `$derived` tracking isn't needed.
+	 * Returns undefined if no active conversation exists yet.
 	 */
-	const getActiveConversation = (): Conversation =>
+	const getActiveConversation = (): Conversation | undefined =>
 		findConversation(activeConversationId);
 
 	/**
@@ -394,7 +424,7 @@ function createAiChatState() {
 		const models = PROVIDER_MODELS[providerName as Provider];
 		updateConversation(activeConversationId, {
 			provider: providerName,
-			model: models?.[0] ?? conv.model,
+			model: models?.[0] ?? conv?.model ?? DEFAULT_MODEL,
 		});
 	}
 
@@ -474,7 +504,7 @@ function createAiChatState() {
 
 		/** Current provider name (reads from active conversation). */
 		get provider() {
-			return activeConversation.provider;
+			return activeConversation?.provider ?? DEFAULT_PROVIDER;
 		},
 		set provider(value: string) {
 			setProvider(value);
@@ -482,7 +512,7 @@ function createAiChatState() {
 
 		/** Current model name (reads from active conversation). */
 		get model() {
-			return activeConversation.model;
+			return activeConversation?.model ?? DEFAULT_MODEL;
 		},
 		set model(value: string) {
 			setModel(value);
@@ -535,7 +565,7 @@ function createAiChatState() {
 			const conv = getActiveConversation();
 			updateConversation(convId, {
 				title:
-					conv.title === 'New Chat' ? content.trim().slice(0, 50) : conv.title,
+					conv?.title === 'New Chat' ? content.trim().slice(0, 50) : conv?.title,
 			});
 			// Send via this conversation's ChatClient (triggers SSE streaming)
 			void ensureChat(convId).sendMessage({ content, id: userMessageId });

--- a/apps/tab-manager/src/lib/state/chat.svelte.ts
+++ b/apps/tab-manager/src/lib/state/chat.svelte.ts
@@ -611,6 +611,28 @@ function createAiChatState() {
 		isStreaming(conversationId: ConversationId): boolean {
 			return chatInstances.get(conversationId)?.isLoading ?? false;
 		},
+		/**
+		 * Get a short preview of the last message in a conversation.
+		 *
+		 * Returns the first 60 characters of text content from the most
+		 * recent message, or an empty string if no messages exist.
+		 * Queries Y.Doc directly so it works for any conversation,
+		 * not just the active one.
+		 */
+		getLastMessagePreview(conversationId: ConversationId): string {
+			const messages = popupWorkspace.tables.chatMessages
+				.filter((m) => m.conversationId === conversationId)
+				.sort((a, b) => b.createdAt - a.createdAt);
+			const last = messages[0];
+			if (!last) return '';
+			const parts = last.parts as Array<{ type: string; content?: string }>;
+			const text = parts
+				.filter((p) => p.type === 'text')
+				.map((p) => p.content ?? '')
+				.join('')
+				.trim();
+			return text.length > 60 ? text.slice(0, 60) + '\u2026' : text;
+		},
 	};
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/packages/ui/src/chat/chat-list.svelte
+++ b/packages/ui/src/chat/chat-list.svelte
@@ -29,7 +29,7 @@
 	});
 </script>
 
-<div class="relative">
+<div class="relative h-full">
 	<div
 		{...rest}
 		bind:this={ref}


### PR DESCRIPTION
> **Stack**: PR 5 of 5 — depends on #1423

Chat UX polish pass. Every commit here is a visible user-facing improvement.

**Confirmation dialog for destructive actions.** Deleting a conversation now shows a `ConfirmationDialog` component (new, reusable) instead of silently destroying messages. The dialog uses shadcn-svelte AlertDialog under the hood with customizable title, description, and action labels.

**Error handling with retry/dismiss.** The error banner was fire-and-forget — no user actions. Now includes a retry button (`reload()` re-sends the last request), a dismiss button (tracks dismissed errors by message to prevent re-showing), and `role=alert` for screen reader announcement.

**Loading indicator gap fix.** Loading dots only showed during `submitted` status, flashing away when transitioning to `streaming` before any assistant text arrived. Now shows dots until an actual assistant message with content appears, covering the full submitted → streaming → first-token gap.

**Conversation picker upgrade.** `DropdownMenu` has menu/action semantics — wrong for a selection list. Replaced with `Popover+Command` (same pattern as the model combobox) which gives search/filter, checkmark for active conversation, proper combobox ARIA semantics, and keyboard-first interaction. Each conversation now shows relative time (5m, 2h, 3d) and a truncated last-message preview for distinguishability.

**Persistence race fix.** The eager conversation creation from PR 3 raced with IndexedDB persistence, causing duplicate "New Chat" entries. Now defers to `popupWorkspace.whenReady` and makes all active-conversation getters null-safe for the brief window before persistence resolves.

Also: CJK input support (`e.isComposing` guard on Enter), `max-h-32` textarea cap for the sidebar, `<form>` wrapper with `aria-label`, and consistent flex+gap layout for controls.