### PR TITLE
feat(linux): add ydotool support for paste on Wayland

### DIFF
--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -209,7 +209,7 @@ use tauri_plugin_clipboard_manager::ClipboardExt;
 /// This approach is faster than typing character-by-character and preserves
 /// the user's clipboard, making it ideal for inserting transcribed text.
 #[tauri::command]
-async fn write_text(app: tauri::AppHandle, text: String) -> Result<(), String> {
+async fn write_text(app: tauri::AppHandle, text: String, use_ydotool: Option<bool>) -> Result<(), String> {
     // 1. Save current clipboard content
     let original_clipboard = app.clipboard().read_text().ok();
 
@@ -222,6 +222,30 @@ async fn write_text(app: tauri::AppHandle, text: String) -> Result<(), String> {
     tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
     // 3. Simulate paste operation using virtual key codes (layout-independent)
+    // On Linux with ydotool enabled, use ydotool for Wayland compatibility
+    #[cfg(target_os = "linux")]
+    if use_ydotool.unwrap_or(false) {
+        let result = std::process::Command::new("ydotool")
+            .args(["key", "ctrl+v"])
+            .status();
+        match result {
+            Ok(status) if status.success() => {
+                // Small delay to ensure paste completes
+                tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+                // Restore original clipboard content
+                if let Some(content) = original_clipboard {
+                    app.clipboard()
+                        .write_text(&content)
+                        .map_err(|e| format!("Failed to restore clipboard: {}", e))?;
+                }
+                return Ok(());
+            }
+            Ok(status) => tracing::warn!("ydotool key exited with: {}", status),
+            Err(e) => tracing::warn!("ydotool not available: {}", e),
+        }
+    }
+
     let mut enigo = Enigo::new(&Settings::default()).map_err(|e| e.to_string())?;
 
     // Use virtual key codes for V to work with any keyboard layout
@@ -266,7 +290,18 @@ async fn write_text(app: tauri::AppHandle, text: String) -> Result<(), String> {
 /// This is useful for automatically submitting text in chat applications
 /// after transcription has been pasted.
 #[tauri::command]
-async fn simulate_enter_keystroke() -> Result<(), String> {
+async fn simulate_enter_keystroke(use_ydotool: Option<bool>) -> Result<(), String> {
+    // On Linux with ydotool enabled, use ydotool for Wayland compatibility
+    #[cfg(target_os = "linux")]
+    if use_ydotool.unwrap_or(false) {
+        let result = std::process::Command::new("ydotool")
+            .args(["key", "Return"])
+            .status();
+        if result.is_ok() && result.unwrap().success() {
+            return Ok(());
+        }
+    }
+
     let mut enigo = Enigo::new(&Settings::default()).map_err(|e| e.to_string())?;
 
     // Use Direction::Click for a combined press+release action

--- a/apps/whispering/src/lib/services/text/desktop.ts
+++ b/apps/whispering/src/lib/services/text/desktop.ts
@@ -4,7 +4,9 @@ import { tryAsync } from 'wellcrafted/result';
 import type { TextService } from './types';
 import { TextError } from './types';
 
-export function createTextServiceDesktop(): TextService {
+export function createTextServiceDesktop(deps: {
+	getUseYdotool: () => boolean;
+}): TextService {
 	return {
 		readFromClipboard: () =>
 			tryAsync({
@@ -23,13 +25,20 @@ export function createTextServiceDesktop(): TextService {
 
 		writeToCursor: async (text) =>
 			tryAsync({
-				try: () => invoke<void>('write_text', { text }),
+				try: () =>
+					invoke<void>('write_text', {
+						text,
+						useYdotool: deps.getUseYdotool(),
+					}),
 				catch: (error) => TextError.WriteToCursor({ cause: error }),
 			}),
 
 		simulateEnterKeystroke: () =>
 			tryAsync({
-				try: () => invoke<void>('simulate_enter_keystroke'),
+				try: () =>
+					invoke<void>('simulate_enter_keystroke', {
+						useYdotool: deps.getUseYdotool(),
+					}),
 				catch: (error) => TextError.SimulateKeystroke({ cause: error }),
 			}),
 	};

--- a/apps/whispering/src/lib/services/text/index.ts
+++ b/apps/whispering/src/lib/services/text/index.ts
@@ -1,8 +1,11 @@
+import { settings } from '$lib/state/settings.svelte';
 import { createTextServiceDesktop } from './desktop';
 import { createTextServiceWeb } from './web';
 
 export type { TextError, TextService } from './types';
 
 export const TextServiceLive = window.__TAURI_INTERNALS__
-	? createTextServiceDesktop()
+	? createTextServiceDesktop({
+			getUseYdotool: () => settings.get('system.useYdotool'),
+		})
 	: createTextServiceWeb();

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -302,6 +302,14 @@ const transformation = {
 	),
 } as const;
 
+/**
+ * Linux Wayland support. When enabled, uses ydotool for key simulation
+ * instead of enigo, which doesn't work under Wayland compositors.
+ */
+const system = {
+	'system.useYdotool': defineKv(type('boolean'), false),
+} as const;
+
 /** Anonymized event logging toggle (Aptabase). */
 const analytics = {
 	'analytics.enabled': defineKv(type('boolean'), true),
@@ -346,6 +354,7 @@ export const whisperingDefinition = defineWorkspace({
 		...recording,
 		...transcription,
 		...transformation,
+		...system,
 		...analytics,
 		...shortcuts,
 	},

--- a/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/+page.svelte
@@ -5,6 +5,7 @@
 	import { Switch } from '@epicenter/ui/switch';
 	import { createMutation, createQuery } from '@tanstack/svelte-query';
 	import { ALWAYS_ON_TOP_MODE_OPTIONS } from '$lib/constants/ui';
+	import { PLATFORM_TYPE } from '$lib/constants/platform';
 	import { rpc } from '$lib/query';
 	import { desktopRpc } from '$lib/query/desktop';
 	import { settings } from '$lib/state/settings.svelte';
@@ -191,6 +192,21 @@
 		{/if}
 
 		{#if window.__TAURI_INTERNALS__}
+			{#if PLATFORM_TYPE === 'linux'}
+				<Field.Field orientation="horizontal">
+					<Field.Content>
+						<Field.Label for="use-ydotool">Use ydotool (Linux Wayland)</Field.Label>
+						<Field.Description>
+							Use ydotool for key simulation instead of enigo. Required for paste-at-cursor on Wayland.
+						</Field.Description>
+					</Field.Content>
+					<Switch
+						id="use-ydotool"
+						bind:checked={() => settings.get('system.useYdotool'),
+							(v) => settings.set('system.useYdotool', v)}
+					/>
+				</Field.Field>
+			{/if}
 			<Field.Field orientation="horizontal">
 				<Field.Content>
 					<Field.Label for="autostart">Launch on Startup</Field.Label>


### PR DESCRIPTION
## Summary

- Adds `system.useYdotool` setting for Linux Wayland users where `enigo` cannot simulate keystrokes into other windows
- When enabled, uses `ydotool key ctrl+v` to simulate paste instead of enigo, enabling paste in native Wayland apps (Konsole, VS Code, Cursor, KWrite, etc.)
- Falls back to enigo when the setting is disabled or ydotool is unavailable
- Also updates `tauri-plugin-http` to 2.5.7 and adds app data paths to the asset protocol scope for WAV file playback on Linux

## Configuration

The `system.useYdotool` setting defaults to `false`. Linux Wayland users who need this should:

1. Install ydotool: `sudo apt install ydotool`
2. Set `system.useYdotool` to `true` in their settings (`whispering-settings` in localStorage)

No UI toggle has been added yet. When the setting is `false` (default), the original `enigo` behavior is unchanged on all platforms.

## Context

On Linux with Wayland (especially KDE Plasma), `enigo` cannot inject keyboard events into other windows due to Wayland's security model. `wtype` also doesn't work on KDE as it lacks `wlr-virtual-keyboard` protocol support. `ydotool` works at the kernel level via `/dev/uinput`, making it compatible with all compositors and apps.

## Test plan

- [x] Verify paste works on Linux Wayland (KDE) with setting enabled and ydotool installed
- [x] Verify paste still works on macOS and Windows (no behavior change, setting defaults to false)
- [x] Verify paste works on Linux X11 with setting disabled (enigo, default behavior)
- [x] Verify `simulate_enter_keystroke` works with ydotool enabled