### PR TITLE
refactor: rename @epicenter/hq to @epicenter/workspace

### DIFF
--- a/.agents/skills/workspace-api/SKILL.md
+++ b/.agents/skills/workspace-api/SKILL.md
@@ -24,7 +24,7 @@ Type-safe schema definitions for tables and KV stores with versioned migrations.
 Use when a table has only one version:
 
 ```typescript
-import { defineTable } from '@epicenter/hq';
+import { defineTable } from '@epicenter/workspace';
 import { type } from 'arktype';
 
 const users = defineTable(type({ id: 'string', email: 'string', _v: '1' }));
@@ -57,7 +57,7 @@ KV stores are flexible — `_v` is optional. Both patterns work:
 ### Without `_v` (field presence)
 
 ```typescript
-import { defineKv } from '@epicenter/hq';
+import { defineKv } from '@epicenter/workspace';
 
 const sidebar = defineKv(type({ collapsed: 'boolean', width: 'number' }));
 

--- a/apps/epicenter/package.json
+++ b/apps/epicenter/package.json
@@ -13,7 +13,7 @@
 		"lint": "eslint ."
 	},
 	"dependencies": {
-		"@epicenter/hq": "workspace:*",
+		"@epicenter/workspace": "workspace:*",
 		"@epicenter/ui": "workspace:*",
 		"@sindresorhus/slugify": "^3.0.0",
 		"@tanstack/svelte-query": "catalog:",

--- a/apps/epicenter/specs/20260121T211800-tables-sqlite-persistence-HANDOFF.md
+++ b/apps/epicenter/specs/20260121T211800-tables-sqlite-persistence-HANDOFF.md
@@ -35,7 +35,7 @@ import {
 	getWorkspaceDocMaps,
 	type ProviderExports,
 	readSchemaFromYDoc,
-} from '@epicenter/hq';
+} from '@epicenter/workspace';
 import { appLocalDataDir, dirname, join } from '@tauri-apps/api/path';
 import {
 	exists,

--- a/apps/epicenter/specs/20260121T211800-tables-sqlite-persistence.md
+++ b/apps/epicenter/specs/20260121T211800-tables-sqlite-persistence.md
@@ -89,7 +89,7 @@ Y.Map('tables')
   └── {tableName}: Y.Map<rowId, Y.Map<fieldName, value>>
 ```
 
-Type aliases from `@epicenter/hq`:
+Type aliases from `@epicenter/workspace`:
 
 ```typescript
 type RowMap = Y.Map<unknown>; // Single row: fieldName → value
@@ -178,7 +178,7 @@ import {
 	getWorkspaceDocMaps,
 	type ProviderExports,
 	readSchemaFromYDoc,
-} from '@epicenter/hq';
+} from '@epicenter/workspace';
 import { appLocalDataDir, dirname, join } from '@tauri-apps/api/path';
 import {
 	exists,

--- a/apps/epicenter/src/lib/templates/entries.ts
+++ b/apps/epicenter/src/lib/templates/entries.ts
@@ -9,7 +9,7 @@
  * - tags: additional tagging (string)
  */
 
-import { defineTable, defineWorkspace } from '@epicenter/hq';
+import { defineTable, defineWorkspace } from '@epicenter/workspace';
 import { type } from 'arktype';
 
 const entries = defineTable(

--- a/apps/epicenter/src/lib/templates/whispering.ts
+++ b/apps/epicenter/src/lib/templates/whispering.ts
@@ -6,7 +6,7 @@
  * Epicenter workspace.
  */
 
-import { defineTable, defineWorkspace } from '@epicenter/hq';
+import { defineTable, defineWorkspace } from '@epicenter/workspace';
 import { type } from 'arktype';
 
 const recordings = defineTable(

--- a/apps/epicenter/src/lib/yjs/workspace-persistence.ts
+++ b/apps/epicenter/src/lib/yjs/workspace-persistence.ts
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from '@epicenter/hq';
+import type { ExtensionContext } from '@epicenter/workspace';
 import { appLocalDataDir, join } from '@tauri-apps/api/path';
 import { mkdir, readFile, writeFile } from '@tauri-apps/plugin-fs';
 import * as Y from 'yjs';

--- a/apps/epicenter/src/lib/yjs/workspace.ts
+++ b/apps/epicenter/src/lib/yjs/workspace.ts
@@ -1,4 +1,4 @@
-import { createWorkspace } from '@epicenter/hq';
+import { createWorkspace } from '@epicenter/workspace';
 import { WORKSPACE_TEMPLATE_BY_ID } from '$lib/templates';
 import { workspacePersistence } from './workspace-persistence';
 

--- a/apps/fs-explorer/package.json
+++ b/apps/fs-explorer/package.json
@@ -12,7 +12,7 @@
 	},
 	"devDependencies": {
 		"@epicenter/filesystem": "workspace:*",
-		"@epicenter/hq": "workspace:*",
+		"@epicenter/workspace": "workspace:*",
 		"@epicenter/ui": "workspace:*",
 		"@sveltejs/adapter-auto": "^6.1.0",
 		"@sveltejs/kit": "catalog:",

--- a/apps/fs-explorer/src/lib/fs/fs-state.svelte.ts
+++ b/apps/fs-explorer/src/lib/fs/fs-state.svelte.ts
@@ -4,8 +4,8 @@ import {
 	type FileRow,
 	filesTable,
 } from '@epicenter/filesystem';
-import { createWorkspace } from '@epicenter/hq';
-import { indexeddbPersistence } from '@epicenter/hq/extensions/sync/web';
+import { createWorkspace } from '@epicenter/workspace';
+import { indexeddbPersistence } from '@epicenter/workspace/extensions/sync/web';
 import { SvelteSet } from 'svelte/reactivity';
 import { toast } from 'svelte-sonner';
 

--- a/apps/tab-manager-markdown/package.json
+++ b/apps/tab-manager-markdown/package.json
@@ -8,7 +8,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@epicenter/hq": "workspace:*",
+		"@epicenter/workspace": "workspace:*",
 		"@epicenter/tab-manager": "workspace:*",
 		"yjs": "^13.6.27"
 	},

--- a/apps/tab-manager-markdown/src/index.ts
+++ b/apps/tab-manager-markdown/src/index.ts
@@ -17,8 +17,8 @@
  * ONE-WAY sync: Y.Doc → Markdown only (read-only export)
  */
 
-import { createWorkspace } from '@epicenter/hq';
-import { createSyncExtension } from '@epicenter/hq/extensions/sync';
+import { createWorkspace } from '@epicenter/workspace';
+import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
 import { definition } from '@epicenter/tab-manager/workspace';
 import { createMarkdownPersistenceExtension } from './markdown-persistence-extension';
 

--- a/apps/tab-manager/package.json
+++ b/apps/tab-manager/package.json
@@ -18,7 +18,7 @@
 	},
 	"dependencies": {
 		"@epicenter/ai": "workspace:*",
-		"@epicenter/hq": "workspace:*",
+		"@epicenter/workspace": "workspace:*",
 		"@epicenter/ui": "workspace:*",
 		"@lucide/svelte": "catalog:",
 		"@tanstack/ai": "^0.5.1",

--- a/apps/tab-manager/src/entrypoints/background.ts
+++ b/apps/tab-manager/src/entrypoints/background.ts
@@ -22,9 +22,9 @@
  * - Coordination flags prevent infinite loops between the two directions
  */
 
-import { createWorkspace } from '@epicenter/hq';
-import { createSyncExtension } from '@epicenter/hq/extensions/sync';
-import { indexeddbPersistence } from '@epicenter/hq/extensions/sync/web';
+import { createWorkspace } from '@epicenter/workspace';
+import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
+import { indexeddbPersistence } from '@epicenter/workspace/extensions/sync/web';
 import { Ok, tryAsync } from 'wellcrafted/result';
 import { defineBackground } from 'wxt/utils/define-background';
 import type { Transaction } from 'yjs';

--- a/apps/tab-manager/src/lib/commands/actions.ts
+++ b/apps/tab-manager/src/lib/commands/actions.ts
@@ -6,8 +6,8 @@
  * after filtering for this device and checking TTL.
  */
 
-import type { TableHelper } from '@epicenter/hq';
-import { generateId } from '@epicenter/hq';
+import type { TableHelper } from '@epicenter/workspace';
+import { generateId } from '@epicenter/workspace';
 import type { Command, DeviceId, SavedTab, SavedTabId } from '$lib/workspace';
 import { parseTabId } from '$lib/workspace';
 

--- a/apps/tab-manager/src/lib/commands/consumer.ts
+++ b/apps/tab-manager/src/lib/commands/consumer.ts
@@ -7,7 +7,7 @@
  * @see specs/20260223T200500-ai-tools-command-queue.md
  */
 
-import type { TableHelper } from '@epicenter/hq';
+import type { TableHelper } from '@epicenter/workspace';
 import type { Command, DeviceId, SavedTab } from '$lib/workspace';
 import {
 	executeActivateTab,

--- a/apps/tab-manager/src/lib/device/device-id.ts
+++ b/apps/tab-manager/src/lib/device/device-id.ts
@@ -6,7 +6,7 @@
  * persisted in storage.local across sessions.
  */
 
-import { generateId } from '@epicenter/hq';
+import { generateId } from '@epicenter/workspace';
 import { storage } from '@wxt-dev/storage';
 import type { DeviceId } from '$lib/workspace';
 

--- a/apps/tab-manager/src/lib/state/chat-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/chat-state.svelte.ts
@@ -35,7 +35,7 @@
  * ```
  */
 
-import { generateId } from '@epicenter/hq';
+import { generateId } from '@epicenter/workspace';
 import {
 	ChatClient,
 	type ChatClientState,

--- a/apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts
@@ -31,7 +31,7 @@
  * ```
  */
 
-import { generateId } from '@epicenter/hq';
+import { generateId } from '@epicenter/workspace';
 import { getDeviceId } from '$lib/device/device-id';
 import type { SavedTab, SavedTabId, Tab } from '$lib/workspace';
 import { popupWorkspace } from '$lib/workspace-popup';

--- a/apps/tab-manager/src/lib/workspace-popup.ts
+++ b/apps/tab-manager/src/lib/workspace-popup.ts
@@ -15,9 +15,9 @@
  */
 
 import { createActionContext } from '@epicenter/ai';
-import { createWorkspace, defineMutation, defineQuery } from '@epicenter/hq';
-import { createSyncExtension } from '@epicenter/hq/extensions/sync';
-import { indexeddbPersistence } from '@epicenter/hq/extensions/sync/web';
+import { createWorkspace, defineMutation, defineQuery } from '@epicenter/workspace';
+import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
+import { indexeddbPersistence } from '@epicenter/workspace/extensions/sync/web';
 import Type from 'typebox';
 import {
 	executeActivateTab,

--- a/apps/tab-manager/src/lib/workspace.ts
+++ b/apps/tab-manager/src/lib/workspace.ts
@@ -12,7 +12,7 @@ import {
 	defineTable,
 	defineWorkspace,
 	type InferTableRow,
-} from '@epicenter/hq';
+} from '@epicenter/workspace';
 import { type } from 'arktype';
 import type { Brand } from 'wellcrafted/brand';
 

--- a/apps/whispering/package.json
+++ b/apps/whispering/package.json
@@ -47,7 +47,7 @@
 		"@aptabase/web": "^0.4.3",
 		"@tauri-apps/plugin-autostart": "^2.0.1",
 		"@epicenter/constants": "workspace:*",
-		"@epicenter/hq": "workspace:*",
+		"@epicenter/workspace": "workspace:*",
 		"@epicenter/shared": "workspace:*",
 		"@epicenter/svelte-utils": "workspace:*",
 		"@google/generative-ai": "^0.24.1",

--- a/docs/articles/archived-head-registry-patterns.md
+++ b/docs/articles/archived-head-registry-patterns.md
@@ -402,7 +402,7 @@ See `docs/articles/ykeyvalue-gc-the-hidden-variable.md` for details.
 Pattern for reactive epoch state in Svelte:
 
 ```typescript
-import type { HeadDoc } from '@epicenter/hq';
+import type { HeadDoc } from '@epicenter/workspace';
 
 export function createReactiveHead(head: HeadDoc) {
 	let epoch = $state(head.getEpoch());
@@ -447,7 +447,7 @@ When implementing versioned workspaces, the API might look like:
 
 ```typescript
 // Option 1: Separate function
-import { createVersionedWorkspace } from '@epicenter/hq/dynamic';
+import { createVersionedWorkspace } from '@epicenter/workspace/dynamic';
 
 const head = createHeadDoc({ workspaceId, providers: {...} });
 const workspace = createVersionedWorkspace({ headDoc: head, definition });

--- a/docs/articles/why-async-client-creation.md
+++ b/docs/articles/why-async-client-creation.md
@@ -133,7 +133,7 @@ Since the client is only going to be accessed in the scope of async handlers (li
 
 ```typescript
 // workspace.ts - create promise at module level
-import { createWorkspaceClient } from '@epicenter/hq';
+import { createWorkspaceClient } from '@epicenter/workspace';
 import { workspace } from './workspace-config';
 
 // Promise starts immediately, shared across your app
@@ -174,7 +174,7 @@ Put the client creation in your load function:
 
 ```typescript
 // src/routes/+page.ts
-import { createWorkspaceClient } from '@epicenter/hq';
+import { createWorkspaceClient } from '@epicenter/workspace';
 import { workspace } from './workspace';
 
 export const load = async () => {
@@ -205,7 +205,7 @@ Use a query to initialize the client once:
 ```typescript
 // hooks/useWorkspaceClient.ts
 import { useQuery } from '@tanstack/react-query';
-import { createWorkspaceClient } from '@epicenter/hq';
+import { createWorkspaceClient } from '@epicenter/workspace';
 import { workspace } from './workspace';
 
 export function useWorkspaceClient() {
@@ -238,7 +238,7 @@ Create the client at the module level and wrap it:
 
 ```typescript
 // lib/workspace.ts
-import { createWorkspaceClient } from '@epicenter/hq';
+import { createWorkspaceClient } from '@epicenter/workspace';
 import { workspace } from './workspace';
 
 // Create promise at module load

--- a/docs/guides/handoff-yjs-persistence-rollout.md
+++ b/docs/guides/handoff-yjs-persistence-rollout.md
@@ -399,7 +399,7 @@ If `package.json` doesn't exist or lacks CLI scripts, create/update:
 		"cli": "bun ../../packages/epicenter/src/cli/bin.ts"
 	},
 	"dependencies": {
-		"@epicenter/hq": "workspace:*"
+		"@epicenter/workspace": "workspace:*"
 	}
 }
 ```

--- a/docs/guides/yjs-persistence-guide.md
+++ b/docs/guides/yjs-persistence-guide.md
@@ -37,7 +37,7 @@ Epicenter uses a provider pattern for persisting your YJS document. Providers ar
 
 ### Desktop Persistence with `setupPersistence`
 
-For desktop applications (Tauri, Electron, Bun), use the built-in `setupPersistence` provider from `@epicenter/hq/providers/desktop`. This provider:
+For desktop applications (Tauri, Electron, Bun), use the built-in `setupPersistence` provider from `@epicenter/workspace/providers/desktop`. This provider:
 
 - Automatically saves to `.epicenter/providers/persistence/{workspaceId}.yjs` in your project directory
 - Loads existing state on startup
@@ -47,9 +47,9 @@ For desktop applications (Tauri, Electron, Bun), use the built-in `setupPersiste
 **Example**: Using the built-in provider
 
 ```typescript
-import { defineWorkspace } from '@epicenter/hq';
-import { setupPersistence } from '@epicenter/hq/providers/desktop';
-import { text, ytext } from '@epicenter/hq';
+import { defineWorkspace } from '@epicenter/workspace';
+import { setupPersistence } from '@epicenter/workspace/providers/desktop';
+import { text, ytext } from '@epicenter/workspace';
 
 const blogWorkspace = defineWorkspace({
 	id: 'blog',
@@ -77,9 +77,9 @@ const blogWorkspace = defineWorkspace({
 For web applications, you'll need to create a custom provider using `y-indexeddb`:
 
 ```typescript
-import { defineWorkspace } from '@epicenter/hq';
-import { text, ytext } from '@epicenter/hq';
-import type { Provider } from '@epicenter/hq';
+import { defineWorkspace } from '@epicenter/workspace';
+import { text, ytext } from '@epicenter/workspace';
+import type { Provider } from '@epicenter/workspace';
 import { IndexeddbPersistence } from 'y-indexeddb';
 
 // Create a web persistence provider
@@ -125,13 +125,13 @@ The only difference is WHERE you save (filesystem vs IndexedDB). You can abstrac
 
 ```typescript
 // persistence.desktop.ts
-import type { Provider } from '@epicenter/hq';
-export { setupPersistence } from '@epicenter/hq/providers/desktop';
+import type { Provider } from '@epicenter/workspace';
+export { setupPersistence } from '@epicenter/workspace/providers/desktop';
 ```
 
 ```typescript
 // persistence.web.ts
-import type { Provider } from '@epicenter/hq';
+import type { Provider } from '@epicenter/workspace';
 import { IndexeddbPersistence } from 'y-indexeddb';
 
 export const setupPersistence: Provider = ({ ydoc }) => {
@@ -146,7 +146,7 @@ export const setupPersistence: Provider = ({ ydoc }) => {
 
 ```typescript
 // epicenter.config.ts
-import { defineWorkspace } from '@epicenter/hq';
+import { defineWorkspace } from '@epicenter/workspace';
 // Import the right one based on your platform
 import { setupPersistence } from './persistence.desktop';
 // or
@@ -166,7 +166,7 @@ const workspace = defineWorkspace({
 
 ```typescript
 // persistence.ts
-import type { Provider } from '@epicenter/hq';
+import type { Provider } from '@epicenter/workspace';
 
 export const setupPersistence: Provider = ({ ydoc }) => {
 	// Detect environment - for runtime detection, choose a default
@@ -197,8 +197,8 @@ The provider pattern in Epicenter offers several advantages:
 Each workspace gets its own file, automatically named by workspace ID:
 
 ```typescript
-import { defineWorkspace } from '@epicenter/hq';
-import { setupPersistence } from '@epicenter/hq/providers/desktop';
+import { defineWorkspace } from '@epicenter/workspace';
+import { setupPersistence } from '@epicenter/workspace/providers/desktop';
 
 // Workspace A → saves to .epicenter/providers/persistence/workspace-a.yjs
 const workspaceA = defineWorkspace({
@@ -226,9 +226,9 @@ Both workspaces share the `.epicenter/providers/persistence/` directory but have
 You can use multiple providers on the same workspace:
 
 ```typescript
-import { defineWorkspace } from '@epicenter/hq';
-import { setupPersistence } from '@epicenter/hq/providers/desktop';
-import type { Provider } from '@epicenter/hq';
+import { defineWorkspace } from '@epicenter/workspace';
+import { setupPersistence } from '@epicenter/workspace/providers/desktop';
+import type { Provider } from '@epicenter/workspace';
 import { WebrtcProvider } from 'y-webrtc';
 
 // Create a sync provider
@@ -261,7 +261,7 @@ const workspace = defineWorkspace({
 If you need custom save behavior, create your own provider:
 
 ```typescript
-import type { Provider } from '@epicenter/hq';
+import type { Provider } from '@epicenter/workspace';
 import * as Y from 'yjs';
 
 const customPersistence: Provider = async ({ id, ydoc }) => {
@@ -308,8 +308,8 @@ const customPersistence: Provider = async ({ id, ydoc }) => {
 For tests, you can conditionally exclude persistence providers:
 
 ```typescript
-import { defineWorkspace } from '@epicenter/hq';
-import { setupPersistence } from '@epicenter/hq/providers/desktop';
+import { defineWorkspace } from '@epicenter/workspace';
+import { setupPersistence } from '@epicenter/workspace/providers/desktop';
 
 const isTest = process.env.NODE_ENV === 'test';
 
@@ -327,7 +327,7 @@ const workspace = defineWorkspace({
 
 1. **YJS is your source of truth** - All data lives in a YJS document
 2. **Use the provider pattern** - Add `setupPersistence` to the `providers` object
-3. **Desktop**: Use `@epicenter/hq/providers/desktop` for filesystem persistence
+3. **Desktop**: Use `@epicenter/workspace/providers/desktop` for filesystem persistence
 4. **Web**: Create a custom provider with `y-indexeddb` for IndexedDB persistence
 5. **Cross-platform is easy** - Same provider interface works everywhere
 6. **Composable**: Combine multiple providers (persistence + sync) on the same workspace

--- a/docs/specs/20260218T172212-tab-manager-markdown-export.md
+++ b/docs/specs/20260218T172212-tab-manager-markdown-export.md
@@ -195,8 +195,8 @@ _No tab groups_
 **File:** `apps/tab-manager-markdown/src/index.ts`
 
 ```typescript
-import { createWorkspace } from '@epicenter/hq/static';
-import { createSyncExtension } from '@epicenter/hq/extensions/sync';
+import { createWorkspace } from '@epicenter/workspace/static';
+import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
 import { definition } from '@epicenter/tab-manager/workspace';
 import { createExporter } from './exporter';
 
@@ -413,7 +413,7 @@ function generateSummary(data: {
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@epicenter/hq": "workspace:*",
+		"@epicenter/workspace": "workspace:*",
 		"@epicenter/tab-manager": "workspace:*",
 		"yjs": "^13.6.27"
 	},

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -12,7 +12,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@epicenter/hq": "workspace:*",
+		"@epicenter/workspace": "workspace:*",
 		"@tanstack/ai": "^0.5.1"
 	},
 	"devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,7 @@
 		"epicenter": "./src/bin.ts"
 	},
 	"dependencies": {
-		"@epicenter/hq": "workspace:*",
+		"@epicenter/workspace": "workspace:*",
 		"@epicenter/server": "workspace:*",
 		"typebox": "catalog:",
 		"wellcrafted": "catalog:",

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -10,7 +10,7 @@
  * - Parses command input into typed action handler arguments
  */
 import { describe, expect, test } from 'bun:test';
-import { defineMutation, defineQuery } from '@epicenter/hq';
+import { defineMutation, defineQuery } from '@epicenter/workspace';
 import Type from 'typebox';
 import yargs from 'yargs';
 import { buildActionCommands } from './command-builder';

--- a/packages/cli/src/command-builder.test.ts
+++ b/packages/cli/src/command-builder.test.ts
@@ -10,7 +10,7 @@
  * - Builds per-command yargs option builders from input schemas
  */
 import { describe, expect, test } from 'bun:test';
-import { defineMutation, defineQuery } from '@epicenter/hq';
+import { defineMutation, defineQuery } from '@epicenter/workspace';
 import Type from 'typebox';
 import { buildActionCommands } from './command-builder';
 

--- a/packages/cli/src/command-builder.ts
+++ b/packages/cli/src/command-builder.ts
@@ -1,4 +1,4 @@
-import { type Actions, iterateActions } from '@epicenter/hq';
+import { type Actions, iterateActions } from '@epicenter/workspace';
 import { ParseError, Parser } from 'typebox/value';
 import type { CommandModule } from 'yargs';
 import { jsonSchemaToYargsOptions } from './json-schema-to-yargs';

--- a/packages/cli/src/discovery.ts
+++ b/packages/cli/src/discovery.ts
@@ -1,5 +1,5 @@
 import { join, resolve } from 'node:path';
-import type { AnyWorkspaceClient, ProjectDir } from '@epicenter/hq';
+import type { AnyWorkspaceClient, ProjectDir } from '@epicenter/workspace';
 
 // ═══════════════════════════════════════════════════════════════════════════
 // EXPORTED TYPES

--- a/packages/epicenter/README-API.md
+++ b/packages/epicenter/README-API.md
@@ -11,7 +11,7 @@ import {
 	defineQuery,
 	defineMutation,
 	runWorkspace,
-} from '@epicenter/hq';
+} from '@epicenter/workspace';
 
 // Define your workspace
 const todosWorkspace = defineWorkspace({

--- a/packages/epicenter/README.md
+++ b/packages/epicenter/README.md
@@ -131,7 +131,7 @@ When two apps declare the same workspace ID, they intentionally point to the sam
 ### Installation
 
 ```bash
-bun add @epicenter/hq
+bun add @epicenter/workspace
 ```
 
 ### Basic Example
@@ -148,8 +148,8 @@ import {
 	select,
 	sqliteProvider,
 	markdownProvider,
-} from '@epicenter/hq';
-import { setupPersistence } from '@epicenter/hq/providers';
+} from '@epicenter/workspace';
+import { setupPersistence } from '@epicenter/workspace/providers';
 import { type } from 'arktype';
 
 // 1. Define your workspace
@@ -412,7 +412,7 @@ publishedAt: date({ nullable: true });
 Working with dates:
 
 ```typescript
-import { DateTimeString } from '@epicenter/hq';
+import { DateTimeString } from '@epicenter/workspace';
 
 // Create current timestamp
 const now = DateTimeString.now(); // Uses system timezone
@@ -474,7 +474,7 @@ JSON column with arktype schema validation.
 - Use `.matching(regex)` for patterns
 
 ```typescript
-import { json } from '@epicenter/hq';
+import { json } from '@epicenter/workspace';
 import { type } from 'arktype';
 
 metadata: json({
@@ -713,7 +713,7 @@ The SQLite extension provides SQL query capabilities via Drizzle ORM.
 **Setup:**
 
 ```typescript
-import { createClient, sqliteProvider } from '@epicenter/hq';
+import { createClient, sqliteProvider } from '@epicenter/workspace';
 
 const client = createClient(definition.id)
 	.withDefinition(definition)
@@ -789,7 +789,7 @@ The markdown extension persists data as human-readable markdown files.
 **Setup:**
 
 ```typescript
-import { createClient, markdownProvider } from '@epicenter/hq';
+import { createClient, markdownProvider } from '@epicenter/workspace';
 
 const client = createClient(definition.id)
 	.withDefinition(definition)
@@ -887,8 +887,8 @@ The sync extension enables real-time Y.Doc synchronization using the y-websocket
 **Setup:**
 
 ````typescript
-import { createClient } from '@epicenter/hq';
-import { createSyncExtension } from '@epicenter/hq/extensions/sync';
+import { createClient } from '@epicenter/workspace';
+import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
 
 const client = createClient(definition.id)
 	.withDefinition(definition)
@@ -1174,7 +1174,7 @@ action.description  // string | undefined
 ### Type Guards
 
 ```typescript
-import { isAction, isQuery, isMutation } from '@epicenter/hq';
+import { isAction, isQuery, isMutation } from '@epicenter/workspace';
 
 isAction(value); // value is Query | Mutation
 isQuery(value); // value is Query
@@ -1211,9 +1211,9 @@ type ProviderPaths = {
 **Common providers:**
 
 ```typescript
-import { setupPersistence } from '@epicenter/hq/providers';
-import { sqliteProvider, markdownProvider } from '@epicenter/hq';
-import { createSyncExtension } from '@epicenter/hq/extensions/sync';
+import { setupPersistence } from '@epicenter/workspace/providers';
+import { sqliteProvider, markdownProvider } from '@epicenter/workspace';
+import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
 
 providers: {
   // Filesystem persistence (Node.js) or IndexedDB (browser)
@@ -1416,7 +1416,7 @@ Create a client directly for standalone scripts. Use `await using` for automatic
 The server is a wrapper around the client that maps REST, MCP, and WebSocket Sync endpoints to workspace actions and tables.
 
 ```typescript
-import { createClient, createServer } from '@epicenter/hq';
+import { createClient, createServer } from '@epicenter/workspace';
 
 const client = createClient(blogWorkspace.id)
   .withDefinition(blogWorkspace)
@@ -1442,7 +1442,7 @@ await fetch('http://localhost:3913/actions/createPost', {
 ### Workspace Definition
 
 ```typescript
-import { defineWorkspace, defineMutation, defineQuery } from '@epicenter/hq';
+import { defineWorkspace, defineMutation, defineQuery } from '@epicenter/workspace';
 ```
 
 **`defineWorkspace({ id, tables, kv })`**
@@ -1505,7 +1505,7 @@ import {
 	type ColumnSchema,
 	type TableSchema,
 	type WorkspaceSchema,
-} from '@epicenter/hq';
+} from '@epicenter/workspace';
 ```
 
 **Column factory functions:**
@@ -1539,7 +1539,7 @@ import {
 	type Mutation,
 	type Action,
 	type Actions,
-} from '@epicenter/hq';
+} from '@epicenter/workspace';
 ```
 
 **`defineQuery(config)`**
@@ -1563,7 +1563,7 @@ Identity function for type inference.
 ### Table Operations
 
 ```typescript
-import { type Tables, type TableHelper } from '@epicenter/hq';
+import { type Tables, type TableHelper } from '@epicenter/workspace';
 ```
 
 **`TableHelper<TSchema>`** methods:
@@ -1579,14 +1579,14 @@ import { type Tables, type TableHelper } from '@epicenter/hq';
 ### Providers
 
 ```typescript
-import { sqliteProvider } from '@epicenter/hq';
-import { markdownProvider, type MarkdownProviderConfig } from '@epicenter/hq';
+import { sqliteProvider } from '@epicenter/workspace';
+import { markdownProvider, type MarkdownProviderConfig } from '@epicenter/workspace';
 import {
 	type Provider,
 	type ProviderContext,
 	type Providers,
 	type WorkspaceProviderMap,
-} from '@epicenter/hq';
+} from '@epicenter/workspace';
 ```
 
 **`sqliteProvider(context)`**
@@ -1600,7 +1600,7 @@ Create markdown file provider.
 ### Persistence Provider
 
 ```typescript
-import { setupPersistence } from '@epicenter/hq/providers';
+import { setupPersistence } from '@epicenter/workspace/providers';
 ```
 
 **`setupPersistence`**
@@ -1614,7 +1614,7 @@ import {
 	DateTimeString,
 	type DateIsoString,
 	type TimezoneId,
-} from '@epicenter/hq';
+} from '@epicenter/workspace';
 ```
 
 **`DateTimeString.now(timezone?)`**
@@ -1641,7 +1641,7 @@ import {
 	createWorkspaceValidators,
 	type TableValidators,
 	type WorkspaceValidators,
-} from '@epicenter/hq';
+} from '@epicenter/workspace';
 ```
 
 **`createTableValidators<TSchema>(schema)`**
@@ -1662,7 +1662,7 @@ import {
 	type EpicenterOperationError,
 	type IndexError,
 	type ValidationError,
-} from '@epicenter/hq';
+} from '@epicenter/workspace';
 ```
 
 **Error constructors:**
@@ -1691,7 +1691,7 @@ import {
 	sql,
 	desc,
 	asc,
-} from '@epicenter/hq';
+} from '@epicenter/workspace';
 ```
 
 Commonly used Drizzle operators for querying SQLite provider.
@@ -1699,7 +1699,7 @@ Commonly used Drizzle operators for querying SQLite provider.
 ### Server
 
 ```typescript
-import { createServer } from '@epicenter/hq';
+import { createServer } from '@epicenter/workspace';
 
 // Single workspace
 const server = createServer(blogClient, { port: 3913 });
@@ -1772,7 +1772,7 @@ Workspace actions are exposed via REST endpoints under the `/workspaces` prefix:
 ### Setup
 
 ```typescript
-import { createClient, createServer } from '@epicenter/hq';
+import { createClient, createServer } from '@epicenter/workspace';
 
 // Create clients with extensions
 const blogClient = createClient(blogWorkspace.id)

--- a/packages/epicenter/SYNC_ARCHITECTURE.md
+++ b/packages/epicenter/SYNC_ARCHITECTURE.md
@@ -138,8 +138,8 @@ Phone has no local server, so it connects directly to all available sync nodes:
 
 ```typescript
 // phone/src/workspace.ts
-import { defineWorkspace } from '@epicenter/hq/dynamic';
-import { createSyncExtension } from '@epicenter/hq/extensions/sync';
+import { defineWorkspace } from '@epicenter/workspace/dynamic';
+import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
 import { SYNC_NODES } from './config/sync-nodes';
 
 export const blogWorkspace = defineWorkspace({
@@ -165,8 +165,8 @@ Browser connects to its own local server (localhost). The server handles cross-d
 
 ```typescript
 // desktop/browser/src/workspace.ts
-import { defineWorkspace } from '@epicenter/hq/dynamic';
-import { createSyncExtension } from '@epicenter/hq/extensions/sync';
+import { defineWorkspace } from '@epicenter/workspace/dynamic';
+import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
 import { SYNC_NODES } from './config/sync-nodes';
 
 export const blogWorkspace = defineWorkspace({
@@ -194,8 +194,8 @@ The server acts as BOTH:
 
 ```typescript
 // desktop/server/src/workspace.ts
-import { defineWorkspace } from '@epicenter/hq/dynamic';
-import { createSyncExtension } from '@epicenter/hq/extensions/sync';
+import { defineWorkspace } from '@epicenter/workspace/dynamic';
+import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
 import { SYNC_NODES } from './config/sync-nodes';
 
 export const blogWorkspace = defineWorkspace({
@@ -219,8 +219,8 @@ export const blogWorkspace = defineWorkspace({
 
 ```typescript
 // laptop/server/src/workspace.ts
-import { defineWorkspace } from '@epicenter/hq/dynamic';
-import { createSyncExtension } from '@epicenter/hq/extensions/sync';
+import { defineWorkspace } from '@epicenter/workspace/dynamic';
+import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
 import { SYNC_NODES } from './config/sync-nodes';
 
 export const blogWorkspace = defineWorkspace({
@@ -245,7 +245,7 @@ Cloud server typically only accepts connections (doesn't initiate):
 
 ```typescript
 // cloud/src/workspace.ts
-import { defineWorkspace } from '@epicenter/hq/dynamic';
+import { defineWorkspace } from '@epicenter/workspace/dynamic';
 
 export const blogWorkspace = defineWorkspace({
 	id: 'blog',
@@ -306,8 +306,8 @@ export const blogWorkspace = defineWorkspace({
 Each device should also use local persistence:
 
 ```typescript
-import { persistence } from '@epicenter/hq/extensions/persistence';
-import { createSyncExtension } from '@epicenter/hq/extensions/sync';
+import { persistence } from '@epicenter/workspace/extensions/persistence';
+import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
 
 const workspace = defineWorkspace({
 	id: 'blog',

--- a/packages/epicenter/docs/articles/yarray-diff-sync.md
+++ b/packages/epicenter/docs/articles/yarray-diff-sync.md
@@ -18,11 +18,11 @@ This works, but it destroys the CRDT element identity. Every element becomes "ne
 `updateYArrayFromArray` computes the minimal element-level differences between the current Y.Array content and the target array, then applies only the necessary insertions and deletions:
 
 ```typescript
-// NOTE: updateYArrayFromArray is not currently exported from @epicenter/hq
-// This function may be available in @epicenter/hq/dynamic or as a utility
+// NOTE: updateYArrayFromArray is not currently exported from @epicenter/workspace
+// This function may be available in @epicenter/workspace/dynamic or as a utility
 // For now, implement the diff logic directly or check the dynamic module
 
-import { updateYArrayFromArray } from '@epicenter/hq/dynamic';
+import { updateYArrayFromArray } from '@epicenter/workspace/dynamic';
 
 const yarray = ydoc.getArray('tags');
 yarray.push(['typescript', 'javascript']);
@@ -68,7 +68,7 @@ const post = db.tables.posts.get(postId);
 const tagsArray = post.row.tags; // This is a Y.Array<string>
 
 // Sync with minimal diff operations
-import { updateYArrayFromArray } from '@epicenter/hq/dynamic';
+import { updateYArrayFromArray } from '@epicenter/workspace/dynamic';
 updateYArrayFromArray(tagsArray, frontmatter.tags);
 
 // Now the Y.Array matches the file metadata, and changes

--- a/packages/epicenter/docs/articles/ytext-diff-sync.md
+++ b/packages/epicenter/docs/articles/ytext-diff-sync.md
@@ -18,11 +18,11 @@ This works, but it destroys the CRDT character identity. Every character becomes
 `updateYTextFromString` computes the minimal character-level differences between the current Y.Text content and the target string, then applies only the necessary insertions and deletions:
 
 ```typescript
-// NOTE: updateYTextFromString is not currently exported from @epicenter/hq
-// This function may be available in @epicenter/hq/dynamic or as a utility
+// NOTE: updateYTextFromString is not currently exported from @epicenter/workspace
+// This function may be available in @epicenter/workspace/dynamic or as a utility
 // For now, implement the diff logic directly or check the dynamic module
 
-import { updateYTextFromString } from '@epicenter/hq/dynamic';
+import { updateYTextFromString } from '@epicenter/workspace/dynamic';
 
 const ytext = ydoc.getText('content');
 ytext.insert(0, 'Hello World');
@@ -49,7 +49,7 @@ The main use case is syncing file system changes to Y.Text. When you have markdo
 ```typescript
 import { watch } from 'chokidar';
 import { readFile } from 'fs/promises';
-import { updateYTextFromString } from '@epicenter/hq/dynamic';
+import { updateYTextFromString } from '@epicenter/workspace/dynamic';
 
 // Watch a markdown file
 const watcher = watch('notes.md');

--- a/packages/epicenter/package.json
+++ b/packages/epicenter/package.json
@@ -1,12 +1,11 @@
 {
-	"name": "@epicenter/hq",
+	"name": "@epicenter/workspace",
 	"version": "0.0.1",
 	"main": "./src/index.ts",
 	"types": "./src/index.ts",
 	"exports": {
 		".": "./src/index.ts",
-		"./static": "./src/workspace/index.ts",
-		"./extensions": {
+"./extensions": {
 			"node": "./src/extensions/index.ts",
 			"default": "./src/extensions/index.ts"
 		},

--- a/packages/epicenter/package.json
+++ b/packages/epicenter/package.json
@@ -5,7 +5,7 @@
 	"types": "./src/index.ts",
 	"exports": {
 		".": "./src/index.ts",
-"./extensions": {
+		"./extensions": {
 			"node": "./src/extensions/index.ts",
 			"default": "./src/extensions/index.ts"
 		},

--- a/packages/epicenter/specs/20251022T174038-consolidate-cli-package.md
+++ b/packages/epicenter/specs/20251022T174038-consolidate-cli-package.md
@@ -1,17 +1,17 @@
-# Consolidate CLI Package into @epicenter/hq
+# Consolidate CLI Package into @epicenter/workspace
 
 ## Problem
 
 Currently we have two packages:
 
-- `@epicenter/hq` - Main library with bin entry at `src/cli/bin.ts`
-- `@epicenter/cli` - Separate CLI package that re-exports `@epicenter/hq/cli`
+- `@epicenter/workspace` - Main library with bin entry at `src/cli/bin.ts`
+- `@epicenter/cli` - Separate CLI package that re-exports `@epicenter/workspace/cli`
 
 This creates duplication and maintenance overhead. Both packages have nearly identical entry points that load config and generate the CLI.
 
 ## Goal
 
-Consolidate into a single `@epicenter/hq` package that serves three purposes:
+Consolidate into a single `@epicenter/workspace` package that serves three purposes:
 
 1. TypeScript library for importing Epicenter functionality
 2. CLI tool (replacing `@epicenter/cli`)
@@ -28,23 +28,23 @@ Consolidate into a single `@epicenter/hq` package that serves three purposes:
 ## Tradeoffs
 
 - CLI-only users download the full library (negligible impact for TypeScript packages)
-- Package name `@epicenter/hq` less obvious than `@epicenter/cli` for CLI usage (mitigated by documentation)
+- Package name `@epicenter/workspace` less obvious than `@epicenter/cli` for CLI usage (mitigated by documentation)
 
 ## Implementation Plan
 
 ### Todo List
 
 - [ ] Verify current state of both packages
-- [ ] Update `@epicenter/hq` package.json
-- [ ] Update examples to use `@epicenter/hq` instead of file paths
-- [ ] Update documentation references from `@epicenter/cli` to `@epicenter/hq`
+- [ ] Update `@epicenter/workspace` package.json
+- [ ] Update examples to use `@epicenter/workspace` instead of file paths
+- [ ] Update documentation references from `@epicenter/cli` to `@epicenter/workspace`
 - [ ] Delete `packages/cli/` package
 - [ ] Test CLI functionality works from consolidated package
 - [ ] Verify library imports still work
 
 ## Changes
 
-### 1. Keep @epicenter/hq package.json bin entry
+### 1. Keep @epicenter/workspace package.json bin entry
 
 The current `bin` entry is already correct:
 
@@ -89,7 +89,7 @@ Remove the entire `@epicenter/cli` package directory.
 
 ### 4. Update documentation
 
-Update any references from `@epicenter/cli` to `@epicenter/hq` in:
+Update any references from `@epicenter/cli` to `@epicenter/workspace` in:
 
 - README files
 - Documentation
@@ -102,28 +102,28 @@ After consolidation, users can:
 **Install globally:**
 
 ```bash
-bun install -g @epicenter/hq
+bun install -g @epicenter/workspace
 epicenter
 ```
 
 **Use with bunx (no installation):**
 
 ```bash
-bunx @epicenter/hq
-bunx @epicenter/hq pages createPage --title "My Post"
+bunx @epicenter/workspace
+bunx @epicenter/workspace pages createPage --title "My Post"
 ```
 
 **Local project installation:**
 
 ```bash
-bun add -D @epicenter/hq
+bun add -D @epicenter/workspace
 bunx epicenter
 ```
 
 **Library usage (unchanged):**
 
 ```typescript
-import { defineEpicenter } from '@epicenter/hq/dynamic';
+import { defineEpicenter } from '@epicenter/workspace/dynamic';
 ```
 
 ### Future: bun create support
@@ -138,17 +138,17 @@ This is out of scope for this consolidation but the structure enables it.
 
 ## Testing
 
-1. Install `@epicenter/hq` in a test project
+1. Install `@epicenter/workspace` in a test project
 2. Run `bunx epicenter --help`
 3. Run `epicenter` in example projects
-4. Verify library imports work: `import { defineEpicenter } from '@epicenter/hq/dynamic'`
-5. Verify CLI generation works: `import { createCLI } from '@epicenter/hq/cli'`
+4. Verify library imports work: `import { defineEpicenter } from '@epicenter/workspace/dynamic'`
+5. Verify CLI generation works: `import { createCLI } from '@epicenter/workspace/cli'`
 
 ## Review
 
 ### Implementation Summary
 
-Successfully consolidated `@epicenter/cli` into `@epicenter/hq`. The package now serves as both a library and CLI tool.
+Successfully consolidated `@epicenter/cli` into `@epicenter/workspace`. The package now serves as both a library and CLI tool.
 
 ### Changes Made
 
@@ -163,30 +163,30 @@ Successfully consolidated `@epicenter/cli` into `@epicenter/hq`. The package now
 
 - ✅ CLI help command works: `bun cli.ts --help`
 - ✅ Workspace commands work: `bun cli.ts blog --help`
-- ✅ Library imports work: `import { defineEpicenter } from '@epicenter/hq'`
-- ✅ CLI imports work: `import { createCLI } from '@epicenter/hq/cli'`
+- ✅ Library imports work: `import { defineEpicenter } from '@epicenter/workspace'`
+- ✅ CLI imports work: `import { createCLI } from '@epicenter/workspace/cli'`
 
 ### Package Structure
 
-`@epicenter/hq` now handles:
+`@epicenter/workspace` now handles:
 
-- **Library usage**: `import { defineEpicenter } from '@epicenter/hq/dynamic'`
-- **CLI tool**: `bunx @epicenter/hq` or global install
-- **Programmatic CLI**: `import { createCLI } from '@epicenter/hq/cli'`
+- **Library usage**: `import { defineEpicenter } from '@epicenter/workspace/dynamic'`
+- **CLI tool**: `bunx @epicenter/workspace` or global install
+- **Programmatic CLI**: `import { createCLI } from '@epicenter/workspace/cli'`
 
 ### Usage Patterns
 
 **Global installation:**
 
 ```bash
-bun install -g @epicenter/hq
+bun install -g @epicenter/workspace
 epicenter
 ```
 
 **Direct execution:**
 
 ```bash
-bunx @epicenter/hq
+bunx @epicenter/workspace
 ```
 
 **Local CLI file (examples):**
@@ -197,6 +197,6 @@ bun cli.ts blog createPost --title "Hello"
 
 ### Notes
 
-- The `bin` entry in `@epicenter/hq/package.json` was already correctly configured
+- The `bin` entry in `@epicenter/workspace/package.json` was already correctly configured
 - Examples use local `cli.ts` files for educational purposes (shows programmatic CLI creation)
 - Pre-existing test failures in markdown index are unrelated to this consolidation

--- a/packages/epicenter/specs/20260121T112000-createclient-builder-api.md
+++ b/packages/epicenter/specs/20260121T112000-createclient-builder-api.md
@@ -228,8 +228,8 @@ const client = createClient(definition).withExtensions({ ... });
 ### Whispering App (Static Schema)
 
 ```typescript
-import { defineWorkspace, createClient, id, text } from '@epicenter/hq/dynamic';
-import { persistence } from '@epicenter/hq/extensions/persistence';
+import { defineWorkspace, createClient, id, text } from '@epicenter/workspace/dynamic';
+import { persistence } from '@epicenter/workspace/extensions/persistence';
 
 const whisperingDefinition = defineWorkspace({
   id: 'epicenter.whispering',
@@ -257,8 +257,8 @@ client.tables.recordings.upsert({ ... });
 ### Epicenter App (Dynamic Schema)
 
 ```typescript
-import { createClient } from '@epicenter/hq/dynamic';
-import { persistence } from '@epicenter/hq/extensions/persistence';
+import { createClient } from '@epicenter/workspace/dynamic';
+import { persistence } from '@epicenter/workspace/extensions/persistence';
 
 // Schema comes from Y.Doc, not code
 const client = createClient('user-workspace-123', { epoch: 2 }).withExtensions({

--- a/packages/epicenter/src/extensions/index.ts
+++ b/packages/epicenter/src/extensions/index.ts
@@ -5,12 +5,12 @@
  * use the conditional export:
  *
  * ```typescript
- * import { indexeddbPersistence } from '@epicenter/hq/extensions/sync/web';
+ * import { indexeddbPersistence } from '@epicenter/workspace/extensions/sync/web';
  * ```
  *
  * @example Node.js/Bun usage
  * ```typescript
- * import { persistence } from '@epicenter/hq/extensions';
+ * import { persistence } from '@epicenter/workspace/extensions';
  * ```
  *
  * @packageDocumentation

--- a/packages/epicenter/src/extensions/sync/desktop.ts
+++ b/packages/epicenter/src/extensions/sync/desktop.ts
@@ -26,8 +26,8 @@ export type PersistenceConfig = {
  *
  * @example
  * ```typescript
- * import { createWorkspace } from '@epicenter/hq';
- * import { persistence } from '@epicenter/hq/extensions/sync/desktop';
+ * import { createWorkspace } from '@epicenter/workspace';
+ * import { persistence } from '@epicenter/workspace/extensions/sync/desktop';
  * import { join } from 'node:path';
  *
  * const projectDir = '/my/project';
@@ -85,8 +85,8 @@ export const persistence = (
  *
  * @example With the persistence extension pattern
  * ```typescript
- * import { persistence } from '@epicenter/hq/extensions/sync/desktop';
- * import { createSyncExtension } from '@epicenter/hq/extensions/sync';
+ * import { persistence } from '@epicenter/workspace/extensions/sync/desktop';
+ * import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
  *
  * createWorkspace(definition)
  *   .withExtension('persistence', (ctx) => persistence(ctx, {

--- a/packages/epicenter/src/extensions/sync/web.ts
+++ b/packages/epicenter/src/extensions/sync/web.ts
@@ -14,8 +14,8 @@ import type * as Y from 'yjs';
  *
  * @example Persistence + sync (recommended pattern)
  * ```typescript
- * import { indexeddbPersistence } from '@epicenter/hq/extensions/sync/web';
- * import { createSyncExtension } from '@epicenter/hq/extensions/sync';
+ * import { indexeddbPersistence } from '@epicenter/workspace/extensions/sync/web';
+ * import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
  *
  * createWorkspace(definition)
  *   .withExtension('persistence', indexeddbPersistence)

--- a/packages/epicenter/src/index.ts
+++ b/packages/epicenter/src/index.ts
@@ -3,13 +3,13 @@
  *
  * This root export provides the full workspace API and shared utilities.
  *
- * - `@epicenter/hq` - Full API (workspace creation, tables, KV, extensions)
- * - `@epicenter/hq/static` - Alias (kept for backward compatibility)
- * - `@epicenter/hq/extensions` - Extension plugins (persistence, sync)
+ * - `@epicenter/workspace` - Full API (workspace creation, tables, KV, extensions)
+ * - `@epicenter/workspace/static` - Alias (kept for backward compatibility)
+ * - `@epicenter/workspace/extensions` - Extension plugins (persistence, sync)
  *
  * @example
  * ```typescript
- * import { createWorkspace, defineTable } from '@epicenter/hq';
+ * import { createWorkspace, defineTable } from '@epicenter/workspace';
  * import { type } from 'arktype';
  *
  * const posts = defineTable(type({ id: 'string', title: 'string', _v: '1' }));

--- a/packages/epicenter/src/shared/actions.ts
+++ b/packages/epicenter/src/shared/actions.ts
@@ -28,7 +28,7 @@
  *
  * @example
  * ```typescript
- * import { createWorkspace, defineQuery, defineMutation } from '@epicenter/hq';
+ * import { createWorkspace, defineQuery, defineMutation } from '@epicenter/workspace';
  * import Type from 'typebox';
  *
  * // Step 1: Create the client (with all tables and extensions)

--- a/packages/epicenter/src/workspace/create-awareness.ts
+++ b/packages/epicenter/src/workspace/create-awareness.ts
@@ -23,7 +23,7 @@
  * @example
  * ```typescript
  * import * as Y from 'yjs';
- * import { createAwareness } from '@epicenter/hq';
+ * import { createAwareness } from '@epicenter/workspace';
  * import { type } from 'arktype';
  *
  * const ydoc = new Y.Doc({ guid: 'my-doc' });

--- a/packages/epicenter/src/workspace/create-document.ts
+++ b/packages/epicenter/src/workspace/create-document.ts
@@ -12,7 +12,7 @@
  *
  * @example
  * ```typescript
- * import { createDocuments, createTables, defineTable } from '@epicenter/hq';
+ * import { createDocuments, createTables, defineTable } from '@epicenter/workspace';
  * import * as Y from 'yjs';
  * import { type } from 'arktype';
  *
@@ -59,7 +59,7 @@ import type {
  *
  * @example
  * ```typescript
- * import { DOCUMENTS_ORIGIN } from '@epicenter/hq';
+ * import { DOCUMENTS_ORIGIN } from '@epicenter/workspace';
  *
  * client.tables.files.observe((changedIds, transaction) => {
  *   if (transaction.origin === DOCUMENTS_ORIGIN) {

--- a/packages/epicenter/src/workspace/create-kv.ts
+++ b/packages/epicenter/src/workspace/create-kv.ts
@@ -4,7 +4,7 @@
  * @example
  * ```typescript
  * import * as Y from 'yjs';
- * import { createKv, defineKv } from '@epicenter/hq';
+ * import { createKv, defineKv } from '@epicenter/workspace';
  * import { type } from 'arktype';
  *
  * // Shorthand for single version

--- a/packages/epicenter/src/workspace/create-tables.ts
+++ b/packages/epicenter/src/workspace/create-tables.ts
@@ -4,7 +4,7 @@
  * @example
  * ```typescript
  * import * as Y from 'yjs';
- * import { createTables, defineTable } from '@epicenter/hq';
+ * import { createTables, defineTable } from '@epicenter/workspace';
  * import { type } from 'arktype';
  *
  * // Shorthand for single version

--- a/packages/epicenter/src/workspace/define-kv.ts
+++ b/packages/epicenter/src/workspace/define-kv.ts
@@ -11,7 +11,7 @@
  *
  * @example
  * ```typescript
- * import { defineKv } from '@epicenter/hq';
+ * import { defineKv } from '@epicenter/workspace';
  * import { type } from 'arktype';
  *
  * // Shorthand for single version

--- a/packages/epicenter/src/workspace/define-table.ts
+++ b/packages/epicenter/src/workspace/define-table.ts
@@ -8,7 +8,7 @@
  *
  * @example
  * ```typescript
- * import { defineTable } from '@epicenter/hq';
+ * import { defineTable } from '@epicenter/workspace';
  * import { type } from 'arktype';
  *
  * // Shorthand for single version

--- a/packages/epicenter/src/workspace/define-workspace.ts
+++ b/packages/epicenter/src/workspace/define-workspace.ts
@@ -6,7 +6,7 @@
  *
  * @example
  * ```typescript
- * import { defineWorkspace, createWorkspace, defineTable } from '@epicenter/hq';
+ * import { defineWorkspace, createWorkspace, defineTable } from '@epicenter/workspace';
  *
  * const posts = defineTable(type({ id: 'string', title: 'string' }));
  *

--- a/packages/epicenter/src/workspace/describe-workspace.ts
+++ b/packages/epicenter/src/workspace/describe-workspace.ts
@@ -8,7 +8,7 @@
  *
  * @example
  * ```typescript
- * import { describeWorkspace } from '@epicenter/hq';
+ * import { describeWorkspace } from '@epicenter/workspace';
  *
  * const descriptor = describeWorkspace(client);
  * console.log(JSON.stringify(descriptor, null, 2));

--- a/packages/epicenter/src/workspace/index.ts
+++ b/packages/epicenter/src/workspace/index.ts
@@ -9,7 +9,7 @@
  *
  * @example
  * ```typescript
- * import { createWorkspace, defineTable, defineKv } from '@epicenter/hq';
+ * import { createWorkspace, defineTable, defineKv } from '@epicenter/workspace';
  * import { type } from 'arktype';
  *
  * // Tables: shorthand for single version

--- a/packages/filesystem/package.json
+++ b/packages/filesystem/package.json
@@ -12,7 +12,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@epicenter/hq": "workspace:*",
+		"@epicenter/workspace": "workspace:*",
 		"arktype": "catalog:",
 		"just-bash": "^2.9.7",
 		"prosemirror-markdown": "^1.13.4",

--- a/packages/filesystem/src/content-helpers.ts
+++ b/packages/filesystem/src/content-helpers.ts
@@ -1,4 +1,4 @@
-import type { Documents } from '@epicenter/hq';
+import type { Documents } from '@epicenter/workspace';
 import { parseSheetFromCsv } from './sheet-helpers.js';
 import { createTimeline } from './timeline-helpers.js';
 import type { FileId, FileRow } from './types.js';

--- a/packages/filesystem/src/file-system-index.test.ts
+++ b/packages/filesystem/src/file-system-index.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { createWorkspace } from '@epicenter/hq';
+import { createWorkspace } from '@epicenter/workspace';
 import { createFileSystemIndex } from './file-system-index.js';
 import { filesTable } from './file-table.js';
 import type { FileId } from './types.js';

--- a/packages/filesystem/src/file-system-index.ts
+++ b/packages/filesystem/src/file-system-index.ts
@@ -1,4 +1,4 @@
-import type { TableHelper } from '@epicenter/hq';
+import type { TableHelper } from '@epicenter/workspace';
 import type { FileId, FileRow } from './types.js';
 import { disambiguateNames } from './validation.js';
 

--- a/packages/filesystem/src/file-table.ts
+++ b/packages/filesystem/src/file-table.ts
@@ -1,4 +1,4 @@
-import { defineTable } from '@epicenter/hq';
+import { defineTable } from '@epicenter/workspace';
 import { type } from 'arktype';
 import { FileId } from './types.js';
 

--- a/packages/filesystem/src/file-tree.test.ts
+++ b/packages/filesystem/src/file-tree.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { createWorkspace } from '@epicenter/hq';
+import { createWorkspace } from '@epicenter/workspace';
 import { filesTable } from './file-table.js';
 import { FileTree } from './file-tree.js';
 import type { FileId } from './types.js';

--- a/packages/filesystem/src/file-tree.ts
+++ b/packages/filesystem/src/file-tree.ts
@@ -1,4 +1,4 @@
-import type { TableHelper } from '@epicenter/hq';
+import type { TableHelper } from '@epicenter/workspace';
 import {
 	createFileSystemIndex,
 	type FileSystemIndex,

--- a/packages/filesystem/src/markdown-helpers.test.ts
+++ b/packages/filesystem/src/markdown-helpers.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { createWorkspace } from '@epicenter/hq';
+import { createWorkspace } from '@epicenter/workspace';
 import { Bash } from 'just-bash';
 import * as Y from 'yjs';
 import { filesTable } from './file-table.js';

--- a/packages/filesystem/src/types.ts
+++ b/packages/filesystem/src/types.ts
@@ -1,4 +1,4 @@
-import { type Guid, generateGuid, generateId, type Id } from '@epicenter/hq';
+import { type Guid, generateGuid, generateId, type Id } from '@epicenter/workspace';
 import { type } from 'arktype';
 import type { Brand } from 'wellcrafted/brand';
 import type * as Y from 'yjs';
@@ -29,7 +29,7 @@ export type TimelineEntry =
 /** Content modes supported by timeline entries */
 export type ContentMode = TimelineEntry['type'];
 
-import type { InferTableRow } from '@epicenter/hq';
+import type { InferTableRow } from '@epicenter/workspace';
 import type { filesTable } from './file-table.js';
 
 /** Branded file identifier — a Guid that is specifically a file ID */

--- a/packages/filesystem/src/validation.test.ts
+++ b/packages/filesystem/src/validation.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { createWorkspace } from '@epicenter/hq';
+import { createWorkspace } from '@epicenter/workspace';
 import { filesTable } from './file-table.js';
 import type { FileId } from './types.js';
 import {

--- a/packages/filesystem/src/validation.ts
+++ b/packages/filesystem/src/validation.ts
@@ -1,4 +1,4 @@
-import type { TableHelper } from '@epicenter/hq';
+import type { TableHelper } from '@epicenter/workspace';
 import type { FileId, FileRow } from './types.js';
 
 export type FsErrorCode =

--- a/packages/filesystem/src/yjs-file-system.test.ts
+++ b/packages/filesystem/src/yjs-file-system.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { createWorkspace } from '@epicenter/hq';
+import { createWorkspace } from '@epicenter/workspace';
 import { Bash } from 'just-bash';
 import { filesTable } from './file-table.js';
 import { createTimeline } from './timeline-helpers.js';

--- a/packages/filesystem/src/yjs-file-system.ts
+++ b/packages/filesystem/src/yjs-file-system.ts
@@ -1,4 +1,4 @@
-import type { Documents, TableHelper } from '@epicenter/hq';
+import type { Documents, TableHelper } from '@epicenter/workspace';
 import type { IFileSystem } from 'just-bash';
 import {
 	type ContentHelpers,

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -24,7 +24,7 @@ import {
 	createWorkspace,
 	id,
 	text,
-} from '@epicenter/hq/static';
+} from '@epicenter/workspace/static';
 import { createLocalServer } from '@epicenter/server';
 
 // 1. Define workspace
@@ -209,10 +209,10 @@ Clients connect to:
 ws://host:3913/rooms/{workspaceId}
 ```
 
-The recommended client is `@epicenter/sync` (via `createSyncExtension` from `@epicenter/hq/extensions/sync`):
+The recommended client is `@epicenter/sync` (via `createSyncExtension` from `@epicenter/workspace/extensions/sync`):
 
 ```typescript
-import { createSyncExtension } from '@epicenter/hq/extensions/sync';
+import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
 
 const client = createClient(definition.id)
 	.withDefinition(definition)

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -40,7 +40,7 @@
 		"y-protocols": "catalog:"
 	},
 	"peerDependencies": {
-		"@epicenter/hq": "workspace:*",
+		"@epicenter/workspace": "workspace:*",
 		"yjs": "catalog:"
 	},
 	"devDependencies": {

--- a/packages/server/src/local.test.ts
+++ b/packages/server/src/local.test.ts
@@ -4,7 +4,7 @@ import {
 	defineQuery,
 	defineTable,
 	defineWorkspace,
-} from '@epicenter/hq';
+} from '@epicenter/workspace';
 import { type } from 'arktype';
 import { createLocalServer } from './local';
 import { DEFAULT_PORT } from './server';

--- a/packages/server/src/local.ts
+++ b/packages/server/src/local.ts
@@ -1,6 +1,6 @@
 import { cors } from '@elysiajs/cors';
 import { openapi } from '@elysiajs/openapi';
-import type { AnyWorkspaceClient } from '@epicenter/hq';
+import type { AnyWorkspaceClient } from '@epicenter/workspace';
 import { Elysia } from 'elysia';
 import * as Y from 'yjs';
 import { createHubSessionValidator } from './auth/local-auth';

--- a/packages/server/src/sync/index.ts
+++ b/packages/server/src/sync/index.ts
@@ -2,7 +2,7 @@
  * Sync plugin public API.
  *
  * This is the entry point for `@epicenter/server/sync`.
- * CRITICAL: This file must NOT import from `@epicenter/hq` — it's the dependency firewall.
+ * CRITICAL: This file must NOT import from `@epicenter/workspace` — it's the dependency firewall.
  */
 
 export type { AuthConfig } from './auth';

--- a/packages/server/src/workspace/actions.test.ts
+++ b/packages/server/src/workspace/actions.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { defineMutation, defineQuery } from '@epicenter/hq';
+import { defineMutation, defineQuery } from '@epicenter/workspace';
 import Type from 'typebox';
 import { collectActionPaths, createActionsRouter } from './actions';
 

--- a/packages/server/src/workspace/actions.ts
+++ b/packages/server/src/workspace/actions.ts
@@ -1,5 +1,5 @@
-import type { Actions } from '@epicenter/hq';
-import { iterateActions } from '@epicenter/hq';
+import type { Actions } from '@epicenter/workspace';
+import { iterateActions } from '@epicenter/workspace';
 import { Elysia } from 'elysia';
 import Value from 'typebox/value';
 

--- a/packages/server/src/workspace/plugin.test.ts
+++ b/packages/server/src/workspace/plugin.test.ts
@@ -4,7 +4,7 @@ import {
 	defineQuery,
 	defineTable,
 	defineWorkspace,
-} from '@epicenter/hq';
+} from '@epicenter/workspace';
 import { type } from 'arktype';
 import { Elysia } from 'elysia';
 import { createWorkspacePlugin } from './plugin';

--- a/packages/server/src/workspace/plugin.ts
+++ b/packages/server/src/workspace/plugin.ts
@@ -1,4 +1,4 @@
-import type { AnyWorkspaceClient } from '@epicenter/hq';
+import type { AnyWorkspaceClient } from '@epicenter/workspace';
 import { Elysia } from 'elysia';
 import { createActionsRouter } from './actions';
 import { createTablesPlugin } from './tables';

--- a/packages/server/src/workspace/tables.test.ts
+++ b/packages/server/src/workspace/tables.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { createWorkspace, defineTable, defineWorkspace } from '@epicenter/hq';
+import { createWorkspace, defineTable, defineWorkspace } from '@epicenter/workspace';
 import { type } from 'arktype';
 import { Elysia } from 'elysia';
 import { createTablesPlugin } from './tables';

--- a/packages/server/src/workspace/tables.ts
+++ b/packages/server/src/workspace/tables.ts
@@ -1,4 +1,4 @@
-import type { AnyWorkspaceClient, BaseRow, TableHelper } from '@epicenter/hq';
+import type { AnyWorkspaceClient, BaseRow, TableHelper } from '@epicenter/workspace';
 import { Elysia } from 'elysia';
 
 /**

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -6,7 +6,7 @@ Client-side Yjs sync provider for `@epicenter/server`.
 
 `createSyncProvider()` connects a `Y.Doc` to a WebSocket sync server using the y-websocket protocol, plus a custom heartbeat extension (MESSAGE_SYNC_STATUS, tag 102) for `hasLocalChanges` tracking and fast dead-connection detection.
 
-Most consumers don't use this package directly. Instead, they use `createSyncExtension` from `@epicenter/hq/extensions/sync`, which wraps this provider with workspace lifecycle management (waiting for persistence to load before connecting, auto-cleanup on destroy, URL templating with workspace IDs).
+Most consumers don't use this package directly. Instead, they use `createSyncExtension` from `@epicenter/workspace/extensions/sync`, which wraps this provider with workspace lifecycle management (waiting for persistence to load before connecting, auto-cleanup on destroy, URL templating with workspace IDs).
 
 Use this package directly when you need raw Y.Doc sync without the workspace extension system.
 
@@ -183,7 +183,7 @@ This eliminates the race conditions common in event-driven WebSocket reconnectio
 ## Relationship to Other Packages
 
 ```
-@epicenter/hq                          @epicenter/server
+@epicenter/workspace                          @epicenter/server
  └─ extensions/sync.ts                  └─ sync/index.ts (Elysia plugin)
      │                                      │
      │  createSyncExtension()               │  createSyncPlugin()
@@ -199,4 +199,4 @@ This eliminates the race conditions common in event-driven WebSocket reconnectio
 
 - **`@epicenter/sync`** (this package): Raw sync provider. Connects a Y.Doc to a WebSocket.
 - **`@epicenter/server`**: The server that this provider connects to. Exposes `ws://host:port/rooms/{id}`.
-- **`@epicenter/hq/extensions/sync`**: Workspace extension wrapper. Most consumers use this instead of the raw provider.
+- **`@epicenter/workspace/extensions/sync`**: Workspace extension wrapper. Most consumers use this instead of the raw provider.

--- a/specs/20250107T143456-provider-to-capability-refactor.md
+++ b/specs/20250107T143456-provider-to-capability-refactor.md
@@ -171,7 +171,7 @@ This is a breaking change for users of the Epicenter library:
 
 1. `withProviders()` → `withCapabilities()`
 2. `client.providers` → `client.capabilities`
-3. `@epicenter/hq/providers/*` → `@epicenter/hq/capabilities/*`
+3. `@epicenter/workspace/providers/*` → `@epicenter/workspace/capabilities/*`
 4. `sqliteProvider` → `sqlite`
 5. `markdownProvider` → `markdown`
 6. `createWebsocketSyncProvider` → `websocketSync`
@@ -181,9 +181,9 @@ This is a breaking change for users of the Epicenter library:
 
 ```typescript
 // Before
-import { setupPersistence } from '@epicenter/hq/providers/persistence';
-import { sqliteProvider } from '@epicenter/hq/providers/sqlite';
-import { createWebsocketSyncProvider } from '@epicenter/hq/providers/websocket-sync';
+import { setupPersistence } from '@epicenter/workspace/providers/persistence';
+import { sqliteProvider } from '@epicenter/workspace/providers/sqlite';
+import { createWebsocketSyncProvider } from '@epicenter/workspace/providers/websocket-sync';
 
 const client = await workspace
   .withProviders({
@@ -196,9 +196,9 @@ const client = await workspace
 client.providers.sqlite.db.select()...
 
 // After
-import { persistence } from '@epicenter/hq/capabilities/persistence';
-import { sqlite } from '@epicenter/hq/capabilities/sqlite';
-import { websocketSync } from '@epicenter/hq/capabilities/websocket-sync';
+import { persistence } from '@epicenter/workspace/capabilities/persistence';
+import { sqlite } from '@epicenter/workspace/capabilities/sqlite';
+import { websocketSync } from '@epicenter/workspace/capabilities/websocket-sync';
 
 const client = await workspace
   .withCapabilities({

--- a/specs/20250107T163200-remove-projectdir-from-capability-context.md
+++ b/specs/20250107T163200-remove-projectdir-from-capability-context.md
@@ -256,7 +256,7 @@ const client = await workspace
 ### AFTER (Option 2: Helper function)
 
 ```typescript
-import { buildEpicenterPaths } from '@epicenter/hq';
+import { buildEpicenterPaths } from '@epicenter/workspace';
 
 const paths = buildEpicenterPaths('/my/project');
 

--- a/specs/20251001T175148 vault-collaborative-workspaces.md
+++ b/specs/20251001T175148 vault-collaborative-workspaces.md
@@ -46,7 +46,7 @@ Each workspace can be synchronized across multiple users via Yjs and a WebSocket
 ```typescript
 import { runPlugin } from '@epicenter/vault';
 import * as Y from 'yjs';
-import { createWebsocketSyncProvider } from '@epicenter/hq/providers/websocket-sync';
+import { createWebsocketSyncProvider } from '@epicenter/workspace/providers/websocket-sync';
 
 // Load workspace config
 const workspace = await import('./users/epicenter.config.ts');

--- a/specs/20251030T000000 persistence-factory-pattern.md
+++ b/specs/20251030T000000 persistence-factory-pattern.md
@@ -55,7 +55,7 @@ providers: [
 
 For this initial implementation, we're **removing the isomorphic abstraction**:
 - Focus on desktop-only implementation first
-- All imports will be from the desktop-specific module: `@epicenter/hq/providers/desktop`
+- All imports will be from the desktop-specific module: `@epicenter/workspace/providers/desktop`
 - Isomorphic support can be added later when there's an actual browser use case
 - Web persistence (`persistence/web.ts`) remains unchanged for future use
 
@@ -72,7 +72,7 @@ For this initial implementation, we're **removing the isomorphic abstraction**:
 ### Phase 2: Update All Call Sites
 
 All call sites will:
-1. Import from desktop-specific module: `from '@epicenter/hq/providers/desktop'` or `from '../../../../src/core/workspace/providers/persistence/desktop'`
+1. Import from desktop-specific module: `from '@epicenter/workspace/providers/desktop'` or `from '../../../../src/core/workspace/providers/persistence/desktop'`
 2. Add `import path from 'node:path'`
 3. Change `setupPersistence` to `setupPersistence({ storagePath: path.join(import.meta.dirname, '.epicenter') })`
 
@@ -111,7 +111,7 @@ Files to update:
 
 ### Before (Current)
 ```typescript
-import { setupPersistence } from '@epicenter/hq/providers/persistence';
+import { setupPersistence } from '@epicenter/workspace/providers/persistence';
 
 const workspace = defineWorkspace({
   id: 'blog',
@@ -121,7 +121,7 @@ const workspace = defineWorkspace({
 
 ### After (With Factory)
 ```typescript
-import { setupPersistence } from '@epicenter/hq/providers/desktop';
+import { setupPersistence } from '@epicenter/workspace/providers/desktop';
 import path from 'node:path';
 
 // Each workspace persists in its own directory

--- a/specs/20251103T180000 move-examples-to-root.md
+++ b/specs/20251103T180000 move-examples-to-root.md
@@ -1,10 +1,10 @@
 # Move Examples to Root Level with Package Imports
 
 ## Problem
-Examples currently live inside `packages/epicenter/examples/` and use relative imports (`../../src/index`). This doesn't demonstrate how real users would consume the `@epicenter/hq` package.
+Examples currently live inside `packages/epicenter/examples/` and use relative imports (`../../src/index`). This doesn't demonstrate how real users would consume the `@epicenter/workspace` package.
 
 ## Solution
-Move examples to root-level `examples/` directory and use proper package imports (`@epicenter/hq`).
+Move examples to root-level `examples/` directory and use proper package imports (`@epicenter/workspace`).
 
 ## Todo Items
 - [x] Create `examples/` directory at root
@@ -13,8 +13,8 @@ Move examples to root-level `examples/` directory and use proper package imports
 - [x] Move `basic-workspace` example to `examples/basic-workspace`
 - [x] Create `package.json` for content-hub example
 - [x] Create `package.json` for basic-workspace example
-- [x] Update all imports in content-hub to use `@epicenter/hq`
-- [x] Update all imports in basic-workspace to use `@epicenter/hq`
+- [x] Update all imports in content-hub to use `@epicenter/workspace`
+- [x] Update all imports in basic-workspace to use `@epicenter/workspace`
 - [x] Update test files to use package imports
 - [x] Remove old examples directory from packages/epicenter
 - [x] Test that examples work with new structure
@@ -41,10 +41,10 @@ Move examples to root-level `examples/` directory and use proper package imports
 
 ### Import Changes
 - From: `import { defineEpicenter } from '../../src/index'`
-- To: `import { defineEpicenter } from '@epicenter/hq'`
+- To: `import { defineEpicenter } from '@epicenter/workspace'`
 
 - From: `import { setupPersistence } from '../../src/core/workspace/providers'`
-- To: `import { setupPersistence } from '@epicenter/hq/providers/persistence'`
+- To: `import { setupPersistence } from '@epicenter/workspace/providers/persistence'`
 
 ## Review
 
@@ -59,15 +59,15 @@ Successfully migrated both examples to root-level `examples/` directory with pro
 ### Package Configuration
 Each example now has its own `package.json` with:
 - Private package flag
-- Workspace dependency on `@epicenter/hq`
+- Workspace dependency on `@epicenter/workspace`
 - Required dependencies (arktype, wellcrafted, yargs)
 - CLI script for running the example
 
 ### Import Updates
 All imports updated from relative paths to package imports:
-- `../../src/index` → `@epicenter/hq`
-- `../../src/core/workspace/providers` → `@epicenter/hq/providers`
-- `../../src/cli/index.ts` → `@epicenter/hq/cli`
+- `../../src/index` → `@epicenter/workspace`
+- `../../src/core/workspace/providers` → `@epicenter/workspace/providers`
+- `../../src/cli/index.ts` → `@epicenter/workspace/cli`
 
 Updated files:
 - All workspace TypeScript files (15+ in content-hub, 1 in basic-workspace)

--- a/specs/20251105T150000_subpath-exports.md
+++ b/specs/20251105T150000_subpath-exports.md
@@ -22,7 +22,7 @@ Looking at the codebase structure, I see several distinct modules:
 
 ## Decision: Clear Separation by Purpose
 
-**Main barrel (`@epicenter/hq`)**: Export everything from `core/`
+**Main barrel (`@epicenter/workspace`)**: Export everything from `core/`
 - All core functionality (workspace, schema, actions, epicenter, db, errors)
 - Everything needed to define and use workspaces
 - Principle: If it's in `core/`, it's fundamental API
@@ -66,7 +66,7 @@ Looking at the codebase structure, I see several distinct modules:
 ## Proposed Export Structure
 
 ```typescript
-// @epicenter/hq (main barrel - everything in core/)
+// @epicenter/workspace (main barrel - everything in core/)
 - Workspace: defineWorkspace, createWorkspaceClient
 - Epicenter: defineEpicenter, createEpicenterClient
 - Schema: id, text, date, ytext, boolean, etc.
@@ -77,21 +77,21 @@ Looking at the codebase structure, I see several distinct modules:
 - Errors: IndexErr, EpicenterOperationError, IndexError
 - Drizzle re-exports: eq, ne, gt, lt, and, or, sql, etc.
 
-// @epicenter/hq/indexes/markdown (markdown index utilities)
+// @epicenter/workspace/indexes/markdown (markdown index utilities)
 - MarkdownIndexErr, MarkdownIndexError
 - MarkdownIndexConfig type
 - Helper functions for custom serializers/deserializers
 
-// @epicenter/hq/indexes/sqlite (sqlite index utilities)
+// @epicenter/workspace/indexes/sqlite (sqlite index utilities)
 - SQLite-specific types and utilities (if any)
 - Custom query helpers (if any)
 
-// @epicenter/hq/providers (already exists)
+// @epicenter/workspace/providers (already exists)
 - setupPersistence
 
-// @epicenter/hq/cli (already exists)
-// @epicenter/hq/desktop (already exists)
-// @epicenter/hq/web (already exists)
+// @epicenter/workspace/cli (already exists)
+// @epicenter/workspace/desktop (already exists)
+// @epicenter/workspace/web (already exists)
 ```
 
 ## Changes Required
@@ -167,8 +167,8 @@ import { isDateWithTimezoneString } from '../../../packages/epicenter/src/core/s
 import { MarkdownIndexErr } from '../../../packages/epicenter/src/indexes/markdown';
 
 // After:
-import { isDateWithTimezoneString } from '@epicenter/hq';
-import { MarkdownIndexErr } from '@epicenter/hq/providers/markdown';
+import { isDateWithTimezoneString } from '@epicenter/workspace';
+import { MarkdownIndexErr } from '@epicenter/workspace/providers/markdown';
 ```
 
 ## Alternative: Everything in Main Barrel
@@ -184,7 +184,7 @@ export type { MarkdownIndexConfig } from './indexes/markdown';
 
 Then consumers would import:
 ```typescript
-import { isDateWithTimezoneString, MarkdownIndexErr } from '@epicenter/hq';
+import { isDateWithTimezoneString, MarkdownIndexErr } from '@epicenter/workspace';
 ```
 
 **Downsides**:
@@ -201,8 +201,8 @@ import { isDateWithTimezoneString, MarkdownIndexErr } from '@epicenter/hq';
 
 This approach provides:
 1. **Clear mental model**: Everything in `core/` directory = everything in main barrel
-2. **Simple imports**: Core functionality is all `@epicenter/hq`
-3. **Index utilities isolated**: Advanced customization uses `@epicenter/hq/indexes/*`
+2. **Simple imports**: Core functionality is all `@epicenter/workspace`
+3. **Index utilities isolated**: Advanced customization uses `@epicenter/workspace/indexes/*`
 4. **Natural boundaries**: File structure matches export structure
 5. **Consistency**: Follows pattern already established with platform exports
 
@@ -231,8 +231,8 @@ The key insight: `core/` contains the fundamental API, `indexes/` contains imple
 
 **Consumer Updates:**
 - ✅ Updated `EpicenterHQ/workspaces/email.ts` to use new imports:
-  - `isDateWithTimezoneString` from `@epicenter/hq`
-  - `MarkdownIndexErr` from `@epicenter/hq/indexes/markdown`
+  - `isDateWithTimezoneString` from `@epicenter/workspace`
+  - `MarkdownIndexErr` from `@epicenter/workspace/indexes/markdown`
 
 **Verification:**
 - ✅ Typecheck passes with no import errors (TS2307)
@@ -267,13 +267,13 @@ packages/epicenter/src/
 ### Export Map
 
 ```typescript
-@epicenter/hq                    // Everything in core/ (workspace, schema, db, etc.)
-@epicenter/hq/indexes/markdown   // Markdown index utilities
-@epicenter/hq/indexes/sqlite     // SQLite index utilities
-@epicenter/hq/providers          // Provider utilities (already existed)
-@epicenter/hq/cli                // CLI tools (already existed)
-@epicenter/hq/desktop            // Desktop-specific (already existed)
-@epicenter/hq/web                // Web-specific (already existed)
+@epicenter/workspace                    // Everything in core/ (workspace, schema, db, etc.)
+@epicenter/workspace/indexes/markdown   // Markdown index utilities
+@epicenter/workspace/indexes/sqlite     // SQLite index utilities
+@epicenter/workspace/providers          // Provider utilities (already existed)
+@epicenter/workspace/cli                // CLI tools (already existed)
+@epicenter/workspace/desktop            // Desktop-specific (already existed)
+@epicenter/workspace/web                // Web-specific (already existed)
 ```
 
 ### Key Insights

--- a/specs/20251114T190000-transform-dates-validation.md
+++ b/specs/20251114T190000-transform-dates-validation.md
@@ -36,7 +36,7 @@ Use the existing regex patterns from `packages/epicenter/src/core/schema/regex.t
 
 ## Implementation Plan
 
-- [ ] Import regex patterns from `@epicenter/hq/core/schema/regex`
+- [ ] Import regex patterns from `@epicenter/workspace/core/schema/regex`
 - [ ] Create validation helper function `isValidIsoDateTime(value: unknown): boolean`
 - [ ] Create check helper function `isAlreadyTransformed(value: unknown): boolean`
 - [ ] Update transformation logic to validate before transforming
@@ -70,10 +70,10 @@ Successfully added validation to the date transformation script using centralize
 1. **Added `isIsoDateTimeString` helper function** (`packages/epicenter/src/core/schema/date-with-timezone.ts:128-131`)
    - Type guard to check if a value is a valid ISO 8601 datetime string
    - Uses `ISO_DATETIME_REGEX` for validation
-   - Exported from `@epicenter/hq` for reuse
+   - Exported from `@epicenter/workspace` for reuse
 
 2. **Updated transformation script** (`examples/content-hub/scripts/02-transform-dates.ts`)
-   - Imports `isIsoDateTimeString` and `isDateWithTimezoneString` from `@epicenter/hq`
+   - Imports `isIsoDateTimeString` and `isDateWithTimezoneString` from `@epicenter/workspace`
    - Validates date fields before transformation
    - Skips already-transformed dates (with pipe separator)
    - Reports invalid date values with field name and value

--- a/specs/20251203T161900-rename-repo-to-epicenter.md
+++ b/specs/20251203T161900-rename-repo-to-epicenter.md
@@ -9,7 +9,7 @@ Migrate all packages from `@repo/*` scope to `@epicenter/*` scope and set approp
 | Package | Current Name | Private? |
 |---------|--------------|----------|
 | packages/ui | `@repo/ui` | - |
-| packages/epicenter | `@epicenter/hq` | - |
+| packages/epicenter | `@epicenter/workspace` | - |
 | packages/config | `@repo/config` | true |
 | packages/svelte-utils | `@repo/svelte-utils` | true |
 | packages/constants | `@repo/constants` | - |
@@ -26,7 +26,7 @@ Migrate all packages from `@repo/*` scope to `@epicenter/*` scope and set approp
 | Package | New Name | Private? | Rationale |
 |---------|----------|----------|-----------|
 | packages/ui | `@epicenter/ui` | true | Internal design system |
-| packages/epicenter | `@epicenter/hq` | - | Public SDK |
+| packages/epicenter | `@epicenter/workspace` | - | Public SDK |
 | packages/config | `@epicenter/config` | true | Internal build configs |
 | packages/svelte-utils | `@epicenter/svelte-utils` | true | Internal utilities |
 | packages/constants | `@epicenter/constants` | true | Internal constants |
@@ -97,4 +97,4 @@ Renamed all packages from `@repo/*` scope to `@epicenter/*`:
 ### Notes
 
 - The `private: true` flag prevents accidental npm publishing; all packages remain open source on GitHub
-- Packages marked as public (`@epicenter/hq`, `@epicenter/vault-core`, `@epicenter/code`) are intended for npm publishing
+- Packages marked as public (`@epicenter/workspace`, `@epicenter/vault-core`, `@epicenter/code`) are intended for npm publishing

--- a/specs/20251205T162000-yjs-stress-test.md
+++ b/specs/20251205T162000-yjs-stress-test.md
@@ -7,7 +7,7 @@ Create a stress test script that inserts 1 million items across 10 different tab
 ## Plan
 
 - [ ] Create new example directory `examples/stress-test/`
-- [ ] Create `package.json` with dependencies on `@epicenter/hq`, `arktype`, `wellcrafted`
+- [ ] Create `package.json` with dependencies on `@epicenter/workspace`, `arktype`, `wellcrafted`
 - [ ] Create `epicenter.config.ts` with a workspace defining 10 simple tables
 - [ ] Create `stress-test.ts` script that:
   - Uses `await using client = await createEpicenterClient(config)` pattern

--- a/specs/20251206T120000-wxt-browser-extension.md
+++ b/specs/20251206T120000-wxt-browser-extension.md
@@ -56,7 +56,7 @@ apps/tab-manager/
   - `@tanstack/svelte-query` (query layer)
   - `wellcrafted` (from catalog)
   - `arktype` (from catalog)
-  - Workspace packages: `@epicenter/hq`, `@epicenter/ui`
+  - Workspace packages: `@epicenter/workspace`, `@epicenter/ui`
 
 ### Phase 2: Epicenter Client Setup
 
@@ -108,7 +108,7 @@ apps/tab-manager/
 
 ```typescript
 // src/lib/epicenter.ts
-import { defineEpicenter, createEpicenterClient } from '@epicenter/hq';
+import { defineEpicenter, createEpicenterClient } from '@epicenter/workspace';
 import { browser } from '../../examples/content-hub/browser/browser.workspace';
 
 export const epicenter = defineEpicenter({

--- a/specs/20251213T180000-table-config-api-redesign.md
+++ b/specs/20251213T180000-table-config-api-redesign.md
@@ -411,7 +411,7 @@ The new `defineSerializer()` builder provides bidirectional type flow:
 - `TParsed`: Inferred from parser return → provided to fromContent's parsed param
 
 ```typescript
-import { defineSerializer } from '@epicenter/hq/providers/markdown';
+import { defineSerializer } from '@epicenter/workspace/providers/markdown';
 
 // Basic usage
 const serializer = defineSerializer<MySchema>()

--- a/specs/20251213T231125-multi-device-tab-sync.md
+++ b/specs/20251213T231125-multi-device-tab-sync.md
@@ -83,7 +83,7 @@ Using `@wxt-dev/storage` for cleaner storage with auto-initialization:
 
 ```typescript
 import { storage } from '@wxt-dev/storage';
-import { generateId } from '@epicenter/hq';
+import { generateId } from '@epicenter/workspace';
 
 /**
  * Device ID storage item.

--- a/specs/20251230T132500-kv-store-feature.md
+++ b/specs/20251230T132500-kv-store-feature.md
@@ -87,7 +87,7 @@ import {
 	boolean,
 	date,
 	json,
-} from '@epicenter/hq';
+} from '@epicenter/workspace';
 
 const appWorkspace = defineWorkspace({
 	id: 'app',

--- a/specs/20260106T000000-json-serializable-rows.md
+++ b/specs/20260106T000000-json-serializable-rows.md
@@ -159,7 +159,7 @@ export function createRichContentId(): RichContentId {
 
 ```typescript
 // BEFORE
-import { ytext, tags } from '@epicenter/hq';
+import { ytext, tags } from '@epicenter/workspace';
 
 const schema = {
 	content: ytext(),
@@ -172,7 +172,7 @@ row.content.toString(); // Y.Text method
 row.labels.toArray(); // Y.Array method
 
 // AFTER
-import { richtext, tags, createRichContentId } from '@epicenter/hq';
+import { richtext, tags, createRichContentId } from '@epicenter/workspace';
 
 const schema = {
 	content: richtext(),

--- a/specs/20260106T212243-temporal-intermediate-representation.md
+++ b/specs/20260106T212243-temporal-intermediate-representation.md
@@ -210,7 +210,7 @@ Reasons:
 ### Creating DateTimes
 
 ```typescript
-import { DateTime } from '@epicenter/hq';
+import { DateTime } from '@epicenter/workspace';
 
 // Current moment in a timezone
 const now = DateTime.now('America/New_York');
@@ -300,7 +300,7 @@ Once browsers ship native Temporal support, the polyfill can be dropped with zer
 Went with the simpler approach—no wrapper namespace. Just use `Temporal.ZonedDateTime` directly with two helper functions for serialization:
 
 ```typescript
-import { Temporal, toDateTimeString, fromDateTimeString } from '@epicenter/hq';
+import { Temporal, toDateTimeString, fromDateTimeString } from '@epicenter/workspace';
 
 // Create - use Temporal directly
 const now = Temporal.Now.zonedDateTimeISO('America/New_York');

--- a/specs/20260106T214000-schema-folder-consolidation-analysis.md
+++ b/specs/20260106T214000-schema-folder-consolidation-analysis.md
@@ -69,7 +69,7 @@ If we moved `runtime/` into `fields/`, then `providers/` and `converters/` would
 **File**: `examples/content-hub/scripts/02-transform-dates.ts`
 
 ```typescript
-import { isDateWithTimezoneString, isIsoDateTimeString } from '@epicenter/hq';
+import { isDateWithTimezoneString, isIsoDateTimeString } from '@epicenter/workspace';
 //                                  ^^^^^^^^^^^^^^^^^^^ REMOVED
 ```
 

--- a/specs/20260107T005800-workspace-guid-and-epochs.md
+++ b/specs/20260107T005800-workspace-guid-and-epochs.md
@@ -323,7 +323,7 @@ packages/epicenter/src/
 ### Defining a Workspace with GUID
 
 ```typescript
-import { defineWorkspace, generateGuid, id, text } from '@epicenter/hq';
+import { defineWorkspace, generateGuid, id, text } from '@epicenter/workspace';
 
 const blogWorkspace = defineWorkspace({
 	guid: 'abc123xyz789012', // Stable forever (15 chars)

--- a/specs/20260107T194104-action-system-redesign.md
+++ b/specs/20260107T194104-action-system-redesign.md
@@ -57,7 +57,7 @@ Actions should be defined **after** client creation, **separately** from capabil
 ### Code Example
 
 ```typescript
-import { defineWorkspace, defineQuery, defineMutation } from '@epicenter/hq';
+import { defineWorkspace, defineQuery, defineMutation } from '@epicenter/workspace';
 import { type } from 'arktype';
 
 // Step 1: Define workspace

--- a/specs/20260108T053000-turso-wasm-vector-search.md
+++ b/specs/20260108T053000-turso-wasm-vector-search.md
@@ -207,7 +207,7 @@ apps/epicenter/src/lib/providers/
 
 ```typescript
 import { connect, type Database } from '@tursodatabase/database-wasm/vite';
-import { defineCapabilities, type CapabilityContext } from '@epicenter/hq';
+import { defineCapabilities, type CapabilityContext } from '@epicenter/workspace';
 
 const DEFAULT_DEBOUNCE_MS = 100;
 
@@ -287,7 +287,7 @@ export const turso = async <TTablesSchema extends TablesSchema>(
 
 ```typescript
 import Database from '@tauri-apps/plugin-sql';
-import { defineCapabilities, type CapabilityContext } from '@epicenter/hq';
+import { defineCapabilities, type CapabilityContext } from '@epicenter/workspace';
 
 const DEFAULT_DEBOUNCE_MS = 100;
 
@@ -389,7 +389,7 @@ bun add @tauri-apps/plugin-sql
 ### Phase 5: Usage in Workspace
 
 ```typescript
-import { defineWorkspace } from '@epicenter/hq';
+import { defineWorkspace } from '@epicenter/workspace';
 import { turso } from './lib/providers/turso';
 import { sqlite } from './lib/providers/sqlite';
 

--- a/specs/20260109T174900-epicenter-app-three-fetch-migration.md
+++ b/specs/20260109T174900-epicenter-app-three-fetch-migration.md
@@ -82,7 +82,7 @@ When navigating to `/workspaces/my-blog`:
 
 ### Phase 1: Tauri Persistence Providers
 
-Create specialized persistence providers in the app (not in `@epicenter/hq` package).
+Create specialized persistence providers in the app (not in `@epicenter/workspace` package).
 
 #### File: `apps/epicenter/src/lib/capabilities/tauri-persistence.ts`
 
@@ -188,7 +188,7 @@ import {
 	type RegistryDoc,
 	type HeadDoc,
 	type WorkspaceSchema,
-} from '@epicenter/hq';
+} from '@epicenter/workspace';
 import {
 	registryPersistence,
 	headPersistence,
@@ -329,7 +329,7 @@ import {
 	getAllWorkspaceSchemas,
 	findWorkspaceBySlug,
 } from '$lib/services/workspace-registry';
-import { generateGuid } from '@epicenter/hq';
+import { generateGuid } from '@epicenter/workspace';
 import { Ok, Err } from 'wellcrafted/result';
 
 const workspaceKeys = {
@@ -443,7 +443,7 @@ export const workspaces = {
 #### File: `apps/epicenter/src/routes/(workspace)/workspaces/[id]/+layout.ts`
 
 ```typescript
-import { defineWorkspace } from '@epicenter/hq';
+import { defineWorkspace } from '@epicenter/workspace';
 import {
 	getHeadDoc,
 	getWorkspaceSchema,
@@ -495,7 +495,7 @@ The registry and cached schemas need to be loaded when the app starts.
 
 ```typescript
 import { getRegistry, setWorkspaceSchema } from './workspace-registry';
-import { defineWorkspace } from '@epicenter/hq';
+import { defineWorkspace } from '@epicenter/workspace';
 import { workspacePersistence } from '$lib/capabilities/tauri-persistence';
 
 /**
@@ -578,7 +578,7 @@ async function loadWorkspaceSchema(guid: string) {
 1. **No `.epicenter/` subfolder** — App data directory is already app-specific
 2. **Slug in URLs, GUID in filesystem** — Best of both worlds
 3. **Specialized providers (Option B)** — Path logic centralized, type-safe
-4. **Tauri persistence in app, not package** — Keeps `@epicenter/hq` dependency-lean
+4. **Tauri persistence in app, not package** — Keeps `@epicenter/workspace` dependency-lean
 5. **No backwards compatibility** — Existing JSON workspaces won't be migrated
 
 ## Open Implementation Questions

--- a/specs/20260111T122900-unified-local-persistence-provider.md
+++ b/specs/20260111T122900-unified-local-persistence-provider.md
@@ -190,8 +190,8 @@ type SnapshotEntry = {
 ### Usage Example
 
 ```typescript
-import { defineWorkspace } from '@epicenter/hq';
-import { localPersistence } from '@epicenter/hq/providers';
+import { defineWorkspace } from '@epicenter/workspace';
+import { localPersistence } from '@epicenter/workspace/providers';
 
 const workspace = defineWorkspace({
   id: 'my-workspace',

--- a/specs/20260117T160800-workspace-api-simplification.md
+++ b/specs/20260117T160800-workspace-api-simplification.md
@@ -11,7 +11,7 @@ Consolidated workspace architectures into a unified Cell API:
 - **Cell** inherits HeadDoc + Epochs + Extensions from Core
 - **Static** remains unchanged (row-level, compile-time typed schemas)
 - **Core** is deprecated after migration
-- Everything exports from `@epicenter/hq` and `@epicenter/hq/cell`
+- Everything exports from `@epicenter/workspace` and `@epicenter/workspace/cell`
 
 ## Problem
 
@@ -29,7 +29,7 @@ Cell's cell-level CRDT was better for concurrent editing, but it lacked Core's H
 ### Target API
 
 ```typescript
-import { createHeadDoc, createCellWorkspace, defineExports } from '@epicenter/hq';
+import { createHeadDoc, createCellWorkspace, defineExports } from '@epicenter/workspace';
 
 // 1. Create head doc (identity + epochs)
 const headDoc = createHeadDoc({
@@ -166,7 +166,7 @@ type CellWorkspaceBuilder<TTableDefs> = {
 ```
 
 ```typescript
-// From @epicenter/hq
+// From @epicenter/workspace
 export { createCellWorkspace } from './cell';
 export type {
   CellExtensionContext,
@@ -181,7 +181,7 @@ export type {
   SchemaFieldDefinition as CellFieldDefinition,
 } from './cell';
 
-// From @epicenter/hq/cell (full Cell API)
+// From @epicenter/workspace/cell (full Cell API)
 export { createHeadDoc, type HeadDoc } from '../core/docs/head-doc';
 export { defineExports, type Lifecycle, type MaybePromise } from '../core/lifecycle';
 export { createCellWorkspace } from './create-cell-workspace';
@@ -197,7 +197,7 @@ export type { CellExtensionContext, ... } from './extensions';
 
 ```typescript
 /**
- * @deprecated Use `createCellWorkspace` from `@epicenter/hq` or `@epicenter/hq/cell` instead.
+ * @deprecated Use `createCellWorkspace` from `@epicenter/workspace` or `@epicenter/workspace/cell` instead.
  * The Cell API provides cell-level CRDT (better concurrent editing) and a simpler builder pattern.
  *
  * Migration:
@@ -263,7 +263,7 @@ All 162 cell tests pass.
 
 ```typescript
 // Before (Core)
-import { createHeadDoc, createClient, defineWorkspace } from '@epicenter/hq';
+import { createHeadDoc, createClient, defineWorkspace } from '@epicenter/workspace';
 
 const head = createHeadDoc({ workspaceId: 'blog', providers: {} });
 const definition = defineWorkspace({
@@ -275,7 +275,7 @@ const client = createClient(head)
   .withExtensions({ persistence });
 
 // After (Cell)
-import { createHeadDoc, createCellWorkspace, defineExports } from '@epicenter/hq';
+import { createHeadDoc, createCellWorkspace, defineExports } from '@epicenter/workspace';
 
 const headDoc = createHeadDoc({ workspaceId: 'blog', providers: {} });
 const workspace = createCellWorkspace({

--- a/specs/20260119T231252-resilient-client-architecture.md
+++ b/specs/20260119T231252-resilient-client-architecture.md
@@ -388,7 +388,7 @@ User creates workspaces through UI. Schema lives in Y.Doc and is discovered, not
 **Use `createDynamicClient()`** - only needs workspace ID, schema comes from Y.Doc.
 
 ```typescript
-import { createDynamicClient } from '@epicenter/hq';
+import { createDynamicClient } from '@epicenter/workspace';
 
 // Load existing workspace - schema comes from Y.Doc
 const client = createDynamicClient('my-workspace', {
@@ -420,7 +420,7 @@ Developer defines schema in code. Schema is fixed at compile time.
 **Use `createClient()`** - requires full `WorkspaceDefinition` (id, name, tables, kv).
 
 ```typescript
-import { createClient, defineWorkspace } from '@epicenter/hq';
+import { createClient, defineWorkspace } from '@epicenter/workspace';
 
 const definition = defineWorkspace({
 	id: 'my-app',
@@ -463,7 +463,7 @@ Instead of one function with optional fields and a boolean flag, we have two sep
 ### Where Each API Lives
 
 ```
-packages/epicenter/           ← The library (@epicenter/hq)
+packages/epicenter/           ← The library (@epicenter/workspace)
 ├── createClient()            ← Static schema API (requires full definition)
 ├── createDynamicClient()     ← Dynamic schema API (only needs ID)
 ├── createHeadDoc()           ← Low-level Head Doc (exported)
@@ -594,7 +594,7 @@ await oldClient.whenSynced;
 ### Static Schema App (Library Usage)
 
 ```typescript
-import { createClient, defineWorkspace, text, number } from '@epicenter/hq';
+import { createClient, defineWorkspace, text, number } from '@epicenter/workspace';
 
 const definition = defineWorkspace({
 	id: 'my-app',
@@ -873,7 +873,7 @@ When the epoch changes (due to migration on another device), the current client 
 <script lang="ts">
 	import { onMount, onDestroy } from 'svelte';
 	import { toast } from '$lib/components/ui/toast';
-	import { createClient, type WorkspaceClient } from '@epicenter/hq';
+	import { createClient, type WorkspaceClient } from '@epicenter/workspace';
 
 	let { definition, head, capabilities } = $props();
 
@@ -952,7 +952,7 @@ import {
 	createClient,
 	type WorkspaceClient,
 	type HeadDoc,
-} from '@epicenter/hq';
+} from '@epicenter/workspace';
 
 export function createWorkspaceStore(
 	definition: WorkspaceDefinition,
@@ -1162,7 +1162,7 @@ No longer needed - definition comes from Y.Doc.
 
 ### Phase 2: Safe Migration
 
-- [ ] Add `migrateToNewEpoch()` helper function to `@epicenter/hq`
+- [ ] Add `migrateToNewEpoch()` helper function to `@epicenter/workspace`
 - [ ] Document `bumpEpoch()` with warning about prepare-then-bump requirement
 - [ ] Add migration examples to README
 

--- a/specs/20260121T170000-sync-architecture.md
+++ b/specs/20260121T170000-sync-architecture.md
@@ -977,7 +977,7 @@ export function getSyncContext(
 ```typescript
 // apps/epicenter/src/lib/docs/workspace.ts
 
-import { createClient } from '@epicenter/hq';
+import { createClient } from '@epicenter/workspace';
 import { getSyncContext } from '../sync/context';
 
 export async function createSyncedWorkspaceClient(

--- a/specs/20260123T103903-rename-fieldschema-to-field.md
+++ b/specs/20260123T103903-rename-fieldschema-to-field.md
@@ -41,7 +41,7 @@ By the documented convention, these should be called `FieldDefinition`. But that
 
 The UI package has a `Field` Svelte component, but:
 
-- Different packages (`@epicenter/ui` vs `@epicenter/hq`)
+- Different packages (`@epicenter/ui` vs `@epicenter/workspace`)
 - Different namespaces (runtime value vs TypeScript type)
 - TypeScript distinguishes type imports from value imports
 

--- a/specs/20260124T125300-workspace-schema-versioning.md
+++ b/specs/20260124T125300-workspace-schema-versioning.md
@@ -58,7 +58,7 @@ import {
 	integer,
 	boolean,
 	setting,
-} from '@epicenter/hq';
+} from '@epicenter/workspace';
 
 const whispering = workspace('epicenter.whispering')
 	// Version 1: Initial schema (no callback - this IS the base)

--- a/specs/20260124T160000-developer-experience-schema-api.md
+++ b/specs/20260124T160000-developer-experience-schema-api.md
@@ -84,7 +84,7 @@ const recordingsTable = defineTable({
 
 ```typescript
 // Option B: Keep current factory syntax (familiar, metadata inline)
-import { table, id, text, select, integer } from '@epicenter/hq';
+import { table, id, text, select, integer } from '@epicenter/workspace';
 
 const recordingsTable = table({
   name: 'Recordings',
@@ -232,7 +232,7 @@ Your existing specs establish the right pattern:
 #### Defining a Versioned Workspace
 
 ```typescript
-import { defineWorkspace, table, id, text, select, integer, setting } from '@epicenter/hq';
+import { defineWorkspace, table, id, text, select, integer, setting } from '@epicenter/workspace';
 
 // Version 1: Initial schema
 const whisperingV1 = {
@@ -695,7 +695,7 @@ import {
   table,
   setting,
   id, text, select, integer, boolean, date, tags, richtext
-} from '@epicenter/hq';
+} from '@epicenter/workspace';
 
 export const myWorkspace = defineWorkspace({
   id: 'my.workspace',

--- a/specs/20260124T163000-developer-experience-schema-api.md
+++ b/specs/20260124T163000-developer-experience-schema-api.md
@@ -583,7 +583,7 @@ The best migration system is one where:
 
 ```typescript
 import { type } from 'arktype';
-import { defineStore } from '@epicenter/hq';
+import { defineStore } from '@epicenter/workspace';
 
 // Define your types using ArkType
 const Recording = type({
@@ -638,7 +638,7 @@ If developers prefer Zod, Valibot, or other libraries:
 
 ```typescript
 import { z } from 'zod';
-import { defineStore, fromStandardSchema } from '@epicenter/hq';
+import { defineStore, fromStandardSchema } from '@epicenter/workspace';
 
 const Recording = z.object({
   id: z.string(),
@@ -819,7 +819,7 @@ const store = defineStore('whispering')
 When you need to rename, retype, or restructure:
 
 ```typescript
-import { createMigration } from '@epicenter/hq';
+import { createMigration } from '@epicenter/workspace';
 
 // Step 1: Define migration
 const migrationV2 = createMigration({
@@ -1169,7 +1169,7 @@ store.kv.observe('theme', (value) => {
 
 ```typescript
 import { type } from 'arktype';
-import { defineStore, createClient } from '@epicenter/hq';
+import { defineStore, createClient } from '@epicenter/workspace';
 
 // ============================================
 // SCHEMA DEFINITION

--- a/specs/20260127T150000-dynamic-workspace-architecture.md
+++ b/specs/20260127T150000-dynamic-workspace-architecture.md
@@ -570,7 +570,7 @@ type CellsStore = {
 ## Usage Example
 
 ```typescript
-import { createDynamicWorkspace } from '@epicenter/hq/dynamic'
+import { createDynamicWorkspace } from '@epicenter/workspace/dynamic'
 
 // Create workspace
 const workspace = createDynamicWorkspace({ id: 'my-workspace' })
@@ -653,7 +653,7 @@ workspace.tables.delete('posts')
 ### Phase 3: Integration
 
 **Tasks:**
-- [ ] Export public API from `@epicenter/hq/dynamic`
+- [ ] Export public API from `@epicenter/workspace/dynamic`
 - [ ] Ensure compatibility with persistence capability
 - [ ] Ensure compatibility with sync capability
 - [ ] Write migration guide from core API

--- a/specs/20260129T212116-workspace-api-v2-cleanup.md
+++ b/specs/20260129T212116-workspace-api-v2-cleanup.md
@@ -148,7 +148,7 @@ Run full test suite to ensure nothing breaks.
 ### Before
 
 ```typescript
-import { defineWorkspace, createClient, createHeadDoc } from '@epicenter/hq';
+import { defineWorkspace, createClient, createHeadDoc } from '@epicenter/workspace';
 
 const definition = defineWorkspace({
   name: 'Blog',
@@ -165,7 +165,7 @@ const client = createClient(head)
 ### After
 
 ```typescript
-import { defineWorkspace, createCellWorkspace, createHeadDoc } from '@epicenter/hq';
+import { defineWorkspace, createCellWorkspace, createHeadDoc } from '@epicenter/workspace';
 
 const definition = defineWorkspace({
   name: 'Blog',

--- a/specs/20260130T025939-grid-workspace-api.md
+++ b/specs/20260130T025939-grid-workspace-api.md
@@ -376,7 +376,7 @@ packages/epicenter/src/grid/
 
 ```typescript
 // Before (Cell)
-import { createCellWorkspace } from '@epicenter/hq/cell';
+import { createCellWorkspace } from '@epicenter/workspace/cell';
 
 const client = createCellWorkspace({
 	headDoc,
@@ -384,7 +384,7 @@ const client = createCellWorkspace({
 }).withExtensions({ persistence });
 
 // After (Grid)
-import { createGridWorkspace } from '@epicenter/hq/grid';
+import { createGridWorkspace } from '@epicenter/workspace/grid';
 
 const client = createGridWorkspace({
 	id: headDoc.workspaceId, // Extract ID
@@ -397,14 +397,14 @@ const client = createGridWorkspace({
 
 ```typescript
 // Before (Dynamic)
-import { createDynamicWorkspace } from '@epicenter/hq/dynamic';
+import { createDynamicWorkspace } from '@epicenter/workspace/dynamic';
 
 const workspace = createDynamicWorkspace({ id: 'my-workspace' });
 workspace.tables.create('posts', { name: 'Posts' });
 workspace.fields.create('posts', 'title', { type: 'text' });
 
 // After (Grid)
-import { createGridWorkspace } from '@epicenter/hq/grid';
+import { createGridWorkspace } from '@epicenter/workspace/grid';
 
 // Define schema externally (JSON file, database, etc.)
 const definition = {

--- a/specs/20260130T111500-unified-workspace-architecture.md
+++ b/specs/20260130T111500-unified-workspace-architecture.md
@@ -316,9 +316,9 @@ The Epicenter desktop app uses both workspace types:
 ```typescript
 // apps/epicenter/src/lib/workspaces/whispering.ts
 
-import { createGridWorkspace } from '@epicenter/hq/grid';
-import { createHeadDoc } from '@epicenter/hq/core/docs';
-import { workspacePersistence } from '@epicenter/hq/extensions/persistence';
+import { createGridWorkspace } from '@epicenter/workspace/grid';
+import { createHeadDoc } from '@epicenter/workspace/core/docs';
+import { workspacePersistence } from '@epicenter/workspace/extensions/persistence';
 
 // 1. Create HeadDoc (if you want epochs/snapshots)
 const headDoc = createHeadDoc({

--- a/specs/20260130T135852-unified-workspace-api-pattern.md
+++ b/specs/20260130T135852-unified-workspace-api-pattern.md
@@ -59,7 +59,7 @@ They need:
 ### Static Workspace
 
 ```typescript
-import { defineWorkspace, defineTable, defineKv } from '@epicenter/hq/static';
+import { defineWorkspace, defineTable, defineKv } from '@epicenter/workspace/static';
 import { type } from 'arktype';
 
 // ═══════════════════════════════════════════════════════════════
@@ -98,7 +98,7 @@ const client = workspace.create({
 ### Grid Workspace
 
 ```typescript
-import { createGridWorkspace } from '@epicenter/hq/grid';
+import { createGridWorkspace } from '@epicenter/workspace/grid';
 
 // ═══════════════════════════════════════════════════════════════
 // Step 1: Define workspace schema (ID is NOT in definition)

--- a/specs/20260130T160535-consolidate-grid-into-dynamic.md
+++ b/specs/20260130T160535-consolidate-grid-into-dynamic.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-Replace the old Dynamic workspace implementation with Grid's implementation, using the `dynamic` namespace. This consolidates three overlapping systems (Cell, Grid, old Dynamic) into one canonical cell-level CRDT workspace API exported from `@epicenter/hq/dynamic`.
+Replace the old Dynamic workspace implementation with Grid's implementation, using the `dynamic` namespace. This consolidates three overlapping systems (Cell, Grid, old Dynamic) into one canonical cell-level CRDT workspace API exported from `@epicenter/workspace/dynamic`.
 
 **Key Design Decision**: Static and Dynamic are completely separate sub-path exports. They do NOT export from root `index.ts`. This means no namespace prefixes are needed - both use `createWorkspace`, `WorkspaceClient`, etc.
 
@@ -17,13 +17,13 @@ Replace the old Dynamic workspace implementation with Grid's implementation, usi
 
 ```typescript
 // Dynamic workspace (cell-level CRDT, external schema)
-import { createWorkspace, WorkspaceClient } from '@epicenter/hq/dynamic';
+import { createWorkspace, WorkspaceClient } from '@epicenter/workspace/dynamic';
 
 // Static workspace (row-level CRDT, arktype schema, migrations)
-import { createWorkspace, WorkspaceClient } from '@epicenter/hq/static';
+import { createWorkspace, WorkspaceClient } from '@epicenter/workspace/static';
 
 // Core utilities (shared, if needed)
-import { generateId, DateTimeString } from '@epicenter/hq';
+import { generateId, DateTimeString } from '@epicenter/workspace';
 ```
 
 ### Dynamic Workspace Usage
@@ -54,7 +54,7 @@ import {
   type TableHelper,
   type ExtensionContext,
   type KvStore,
-} from '@epicenter/hq/dynamic';
+} from '@epicenter/workspace/dynamic';
 
 const workspace = createWorkspace({
   id: 'my-workspace',
@@ -105,7 +105,7 @@ Since imports come from distinct paths, no "Dynamic" or "Static" prefix is neede
 
 ### Field Helpers Inventory
 
-All 11 field helpers available from `@epicenter/hq/dynamic`:
+All 11 field helpers available from `@epicenter/workspace/dynamic`:
 
 1. **`id()`** - Primary key, always NOT NULL
 2. **`text({ id, nullable?, default? })`** - String field
@@ -177,10 +177,10 @@ This creates problems:
 
 ### Desired State
 
-One canonical implementation in `@epicenter/hq/dynamic` with clean naming:
+One canonical implementation in `@epicenter/workspace/dynamic` with clean naming:
 
 ```typescript
-import { createWorkspace } from '@epicenter/hq/dynamic';
+import { createWorkspace } from '@epicenter/workspace/dynamic';
 
 const client = createWorkspace({
   id: 'my-workspace',
@@ -407,8 +407,8 @@ Update `package.json` exports:
 
 ### Phase 5: Update Dependents
 
-- [ ] **5.1** Search for all `@epicenter/hq/cell` imports in the codebase
-- [ ] **5.2** Search for all `@epicenter/hq/grid` imports in the codebase
+- [ ] **5.1** Search for all `@epicenter/workspace/cell` imports in the codebase
+- [ ] **5.2** Search for all `@epicenter/workspace/grid` imports in the codebase
 - [ ] **5.3** Update extension documentation (`persistence`, `sqlite`, `websocket-sync`)
 - [ ] **5.4** Update test files to use new imports
 - [ ] **5.5** Update JSDoc examples throughout
@@ -433,7 +433,7 @@ Update `package.json` exports:
 ### Extension Documentation References Cell
 
 1. All extension JSDoc examples reference `createCellWorkspace`
-2. During migration, update these to `createWorkspace` (from `@epicenter/hq/dynamic`)
+2. During migration, update these to `createWorkspace` (from `@epicenter/workspace/dynamic`)
 3. Search pattern: `createCellWorkspace` in `src/extensions/`
 
 ### Grid Imports from Cell
@@ -452,8 +452,8 @@ Update `package.json` exports:
 
 1. `src/index.ts` currently exports `CellWorkspaceClient`, etc.
 2. After migration, root index exports ONLY core utilities
-3. Dynamic types come from `@epicenter/hq/dynamic`
-4. Static types come from `@epicenter/hq/static`
+3. Dynamic types come from `@epicenter/workspace/dynamic`
+4. Static types come from `@epicenter/workspace/static`
 
 ## Open Questions
 
@@ -477,12 +477,12 @@ Update `package.json` exports:
 
 ## Success Criteria
 
-- [x] `createWorkspace` from `@epicenter/hq/dynamic` works identically to current `createGridWorkspace`
-- [x] `createWorkspace` from `@epicenter/hq/static` unchanged
+- [x] `createWorkspace` from `@epicenter/workspace/dynamic` works identically to current `createGridWorkspace`
+- [x] `createWorkspace` from `@epicenter/workspace/static` unchanged
 - [x] All existing Grid tests pass with renamed imports
 - [x] No `cell/` or `grid/` directories remain
-- [x] `@epicenter/hq/dynamic` exports all necessary types and utilities
-- [x] `@epicenter/hq` does NOT export dynamic/static workspace APIs
+- [x] `@epicenter/workspace/dynamic` exports all necessary types and utilities
+- [x] `@epicenter/workspace` does NOT export dynamic/static workspace APIs
 - [x] Extension examples work with `createWorkspace` from dynamic
 - [x] TypeScript type checking passes (pre-existing issues in scripts/tests unrelated to this change)
 - [x] Full test suite passes (509 tests pass)

--- a/specs/20260131T013000-core-folder-reorganization.md
+++ b/specs/20260131T013000-core-folder-reorganization.md
@@ -426,7 +426,7 @@ Any file importing these should NOT be updated:
 
 6. **Run tests frequently** - After each phase, run `bun test` to catch issues early.
 
-7. **The public API must not change** - External consumers import from `@epicenter/hq`. The same exports must remain available, just sourced from different internal paths.
+7. **The public API must not change** - External consumers import from `@epicenter/workspace`. The same exports must remain available, just sourced from different internal paths.
 
 ---
 

--- a/specs/20260131T021500-phase1-fix-core-violations.md
+++ b/specs/20260131T021500-phase1-fix-core-violations.md
@@ -76,7 +76,7 @@ ls packages/epicenter/src/dynamic/workspace/node.ts
 **Acceptance Criteria**:
 
 - [ ] `package.json` points to correct file
-- [ ] Import `from '@epicenter/hq/node'` resolves correctly
+- [ ] Import `from '@epicenter/workspace/node'` resolves correctly
 
 ---
 

--- a/specs/20260131T030000-consolidate-to-ykeyvalue-lww.md
+++ b/specs/20260131T030000-consolidate-to-ykeyvalue-lww.md
@@ -283,9 +283,9 @@ TablesFunction APIs:
 
 ### Migration Notes
 
-Apps using `createWorkspace` from `@epicenter/hq/dynamic` will break. They should:
+Apps using `createWorkspace` from `@epicenter/workspace/dynamic` will break. They should:
 
 1. Use `createTables` directly for table operations
-2. Or use `@epicenter/hq/static` for the full workspace API with versioning support
+2. Or use `@epicenter/workspace/static` for the full workspace API with versioning support
 
 No data migration utility was created (Phase 4 was optional). Existing Y.Doc data using nested Y.Map will need to be recreated.

--- a/specs/20260131T154500-dynamic-workspace-builder-pattern.md
+++ b/specs/20260131T154500-dynamic-workspace-builder-pattern.md
@@ -442,7 +442,7 @@ import {
 	table,
 	id,
 	text,
-} from '@epicenter/hq/dynamic';
+} from '@epicenter/workspace/dynamic';
 
 // 1. Create HeadDoc for epoch management
 const headDoc = createHeadDoc({
@@ -519,7 +519,7 @@ import {
 	createWorkspace,
 	createHeadDoc,
 	defineWorkspace,
-} from '@epicenter/hq/dynamic';
+} from '@epicenter/workspace/dynamic';
 
 test('table operations work without extensions', () => {
 	// Minimal HeadDoc (in-memory, no persistence)
@@ -696,7 +696,7 @@ Static uses `capabilities`, dynamic uses `extensions`. Should we unify?
 
 ```typescript
 // Before
-import { createWorkspaceDoc, WorkspaceDoc } from '@epicenter/hq';
+import { createWorkspaceDoc, WorkspaceDoc } from '@epicenter/workspace';
 const workspace: WorkspaceDoc = createWorkspaceDoc({
   headDoc,
   tables: [...],
@@ -705,7 +705,7 @@ const workspace: WorkspaceDoc = createWorkspaceDoc({
 });
 
 // After
-import { createWorkspace, WorkspaceClient } from '@epicenter/hq';
+import { createWorkspace, WorkspaceClient } from '@epicenter/workspace';
 const workspace: WorkspaceClient = createWorkspace({
   headDoc,
   definition: { name: 'Blog', tables: [...], kv: [...] },

--- a/specs/20260201T000000-examples-and-scripts-fixes.md
+++ b/specs/20260201T000000-examples-and-scripts-fixes.md
@@ -20,7 +20,7 @@ The examples and scripts used a completely non-existent API pattern. Rather than
 
 ### Kept
 
-- `examples/yjs-size-benchmark/` - Pure Yjs benchmark, no `@epicenter/hq` dependencies
+- `examples/yjs-size-benchmark/` - Pure Yjs benchmark, no `@epicenter/workspace` dependencies
 - `packages/epicenter/scripts/yjs-data-structure-benchmark.ts` - Pure Yjs benchmark
 - `packages/epicenter/scripts/demo-yjs-nested-map-lww.ts` - Pure Yjs demonstration
 - `packages/epicenter/scripts/yjs-gc-benchmark.ts` - Pure Yjs benchmark
@@ -29,7 +29,7 @@ The examples and scripts used a completely non-existent API pattern. Rather than
 
 ### Public API Status
 
-The following types were already exported from `@epicenter/hq`:
+The following types were already exported from `@epicenter/workspace`:
 
 - `DateTimeString` (with companion object methods `.parse()`, `.stringify()`, `.now()`)
 - `ExtensionContext`
@@ -51,11 +51,11 @@ defineWorkspace({
 });
 ```
 
-Neither the **static API** (`@epicenter/hq/static`) nor the **dynamic API** (`@epicenter/hq/dynamic`) supports this pattern. The examples require **complete rewrites** or **deletion**.
+Neither the **static API** (`@epicenter/workspace/static`) nor the **dynamic API** (`@epicenter/workspace/dynamic`) supports this pattern. The examples require **complete rewrites** or **deletion**.
 
 ### Actual Available APIs
 
-**Dynamic API** (`@epicenter/hq/dynamic`):
+**Dynamic API** (`@epicenter/workspace/dynamic`):
 
 ```typescript
 const definition = defineWorkspace({
@@ -75,7 +75,7 @@ const client = createWorkspace({ headDoc, definition })
 	.withExtension('persistence', persistence);
 ```
 
-**Static API** (`@epicenter/hq/static`):
+**Static API** (`@epicenter/workspace/static`):
 
 ```typescript
 const posts = defineTable(type({ id: 'string', title: 'string' }));
@@ -127,7 +127,7 @@ const client = createWorkspace({
 | `email-minimal-simulation.ts`     | Critical | Same as above                                                                                   |
 | `yjs-vs-sqlite-comparison.ts`     | Critical | Same as above                                                                                   |
 | `ymap-vs-ykeyvalue-benchmark.ts`  | Low      | Uses internal `y-keyvalue` utility (may be fine)                                                |
-| `yjs-data-structure-benchmark.ts` | None     | Pure Yjs benchmark, no @epicenter/hq imports                                                    |
+| `yjs-data-structure-benchmark.ts` | None     | Pure Yjs benchmark, no @epicenter/workspace imports                                                    |
 | `demo-yjs-nested-map-lww.ts`      | Unknown  | Needs review                                                                                    |
 | `yjs-gc-benchmark.ts`             | Unknown  | Needs review                                                                                    |
 | `ykeyvalue-write-benchmark.ts`    | Unknown  | Needs review                                                                                    |
@@ -152,15 +152,15 @@ const client = createWorkspace({
 
 ```typescript
 // OLD (broken)
-import { ... } from '@epicenter/hq/providers/markdown';
-import { ... } from '@epicenter/hq/providers/persistence';
-import { ... } from '@epicenter/hq/providers/sqlite';
-import { ... } from '@epicenter/hq/capabilities/markdown';
+import { ... } from '@epicenter/workspace/providers/markdown';
+import { ... } from '@epicenter/workspace/providers/persistence';
+import { ... } from '@epicenter/workspace/providers/sqlite';
+import { ... } from '@epicenter/workspace/capabilities/markdown';
 
 // NEW (correct)
-import { ... } from '@epicenter/hq/extensions/markdown';
-import { ... } from '@epicenter/hq/extensions/persistence';
-import { ... } from '@epicenter/hq/extensions/sqlite';
+import { ... } from '@epicenter/workspace/extensions/markdown';
+import { ... } from '@epicenter/workspace/extensions/persistence';
+import { ... } from '@epicenter/workspace/extensions/sqlite';
 ```
 
 **Files affected**: 12 files
@@ -171,16 +171,16 @@ import { ... } from '@epicenter/hq/extensions/sqlite';
 
 | Old Name              | New Name               | Export Path                            |
 | --------------------- | ---------------------- | -------------------------------------- |
-| `markdownProvider`    | `markdown`             | `@epicenter/hq/extensions/markdown`    |
-| `sqliteProvider`      | `sqlite`               | `@epicenter/hq/extensions/sqlite`      |
-| `setupPersistence`    | `persistence`          | `@epicenter/hq/extensions/persistence` |
-| `MarkdownProviderErr` | `MarkdownExtensionErr` | `@epicenter/hq/extensions/markdown`    |
+| `markdownProvider`    | `markdown`             | `@epicenter/workspace/extensions/markdown`    |
+| `sqliteProvider`      | `sqlite`               | `@epicenter/workspace/extensions/sqlite`      |
+| `setupPersistence`    | `persistence`          | `@epicenter/workspace/extensions/persistence` |
+| `MarkdownProviderErr` | `MarkdownExtensionErr` | `@epicenter/workspace/extensions/markdown`    |
 
 **Files affected**: 11 files
 
 ### Category 3: Removed/Non-Exported Types
 
-**Problem**: Certain types/utilities are no longer exported from `@epicenter/hq` root.
+**Problem**: Certain types/utilities are no longer exported from `@epicenter/workspace` root.
 
 | Missing Export               | Status              | Recommendation                                                            |
 | ---------------------------- | ------------------- | ------------------------------------------------------------------------- |
@@ -189,7 +189,7 @@ import { ... } from '@epicenter/hq/extensions/sqlite';
 | `DateWithTimezoneString`     | Not exported (type) | Define locally or use string type                                         |
 | `SerializedRow`              | Not exported        | Import from internal path or use `Row<T>` type                            |
 | `WorkspaceSchema`            | Not exported        | Use `WorkspaceDefinition` type                                            |
-| `ProviderContext`            | Not exported        | Import from `@epicenter/hq/dynamic` subpath                               |
+| `ProviderContext`            | Not exported        | Import from `@epicenter/workspace/dynamic` subpath                               |
 
 **Files affected**: 6 files
 
@@ -316,7 +316,7 @@ For files that can be updated with find-and-replace style fixes:
 Update import paths in all files simultaneously:
 
 ```bash
-# Pattern: @epicenter/hq/providers/* → @epicenter/hq/extensions/*
+# Pattern: @epicenter/workspace/providers/* → @epicenter/workspace/extensions/*
 ```
 
 Files: All 12 workspace files in examples/
@@ -345,7 +345,7 @@ Delete files that require complete rewrites:
 
 ### Phase 4: DateWithTimezone Resolution (Requires Decision)
 
-**Option 4A**: Re-export `DateWithTimezone` utilities from `@epicenter/hq`
+**Option 4A**: Re-export `DateWithTimezone` utilities from `@epicenter/workspace`
 
 **Option 4B**: Replace with inline implementations:
 
@@ -372,7 +372,7 @@ import {
 	sqliteProvider, // Should come from extensions/sqlite
 	type ProviderContext, // Not publicly exported
 	type WorkspaceSchema, // Not publicly exported
-} from '@epicenter/hq';
+} from '@epicenter/workspace';
 ```
 
 Options:
@@ -412,8 +412,8 @@ After fixes are applied:
 import {
 	domainTitleFilenameSerializer,
 	markdownProvider,
-} from '@epicenter/hq/providers/markdown';
-import { sqliteProvider } from '@epicenter/hq/providers/sqlite';
+} from '@epicenter/workspace/providers/markdown';
+import { sqliteProvider } from '@epicenter/workspace/providers/sqlite';
 ```
 
 **Fix**:
@@ -422,8 +422,8 @@ import { sqliteProvider } from '@epicenter/hq/providers/sqlite';
 import {
 	domainTitleFilenameSerializer,
 	markdown,
-} from '@epicenter/hq/extensions/markdown';
-import { sqlite } from '@epicenter/hq/extensions/sqlite';
+} from '@epicenter/workspace/extensions/markdown';
+import { sqlite } from '@epicenter/workspace/extensions/sqlite';
 ```
 
 Also update usages: `markdownProvider` → `markdown`, `sqliteProvider` → `sqlite`
@@ -440,14 +440,14 @@ import {
 	DateWithTimezoneFromString,
 	DateWithTimezoneString,
 	// ... other imports
-} from '@epicenter/hq';
+} from '@epicenter/workspace';
 import {
 	bodyFieldSerializer,
 	MarkdownProviderErr,
 	markdownProvider,
-} from '@epicenter/hq/providers/markdown';
-import { setupPersistence } from '@epicenter/hq/providers/persistence';
-import { sqliteProvider } from '@epicenter/hq/providers/sqlite';
+} from '@epicenter/workspace/providers/markdown';
+import { setupPersistence } from '@epicenter/workspace/providers/persistence';
+import { sqliteProvider } from '@epicenter/workspace/providers/sqlite';
 ```
 
 **Issues**:
@@ -517,7 +517,7 @@ await using client = await createClient(head)
 
 ### packages/epicenter/scripts/yjs-data-structure-benchmark.ts
 
-**No @epicenter/hq imports** - Pure Yjs benchmark, should still work.
+**No @epicenter/workspace imports** - Pure Yjs benchmark, should still work.
 
 ---
 

--- a/specs/20260201T025500-consolidate-id-types.md
+++ b/specs/20260201T025500-consolidate-id-types.md
@@ -362,7 +362,7 @@ This is a **breaking change** for anyone using the table API:
 tables.get('posts').upsert({ id: 'my-id', ... });
 
 // After (required)
-import { Id } from '@epicenter/hq';
+import { Id } from '@epicenter/workspace';
 tables.get('posts').upsert({ id: Id('my-id'), ... });
 // OR
 tables.get('posts').upsert({ id: generateId(), ... });
@@ -394,7 +394,7 @@ Key changes made:
 6. Updated extensions (`sqlite`, `markdown`) to convert string IDs to branded `Id` at deserialization boundaries
 7. Updated `server/tables.ts` to wrap URL params with `Id()`
 8. Updated all test files to use `Id()` constructor
-9. Exported `Id` function from package root (`@epicenter/hq`)
+9. Exported `Id` function from package root (`@epicenter/workspace`)
 
 Related commits:
 - `1b65057a3` - Removed duplicate `dynamic/keys.ts` and public API exports of key utilities

--- a/specs/20260201T120000-simple-definition-first-workspace-handoff.md
+++ b/specs/20260201T120000-simple-definition-first-workspace-handoff.md
@@ -82,7 +82,7 @@ Update `create-workspace.ts` to pass definition into the context.
 
 **1.3 Verify exports in `index.ts`**
 
-Ensure `WorkspaceDefinition` type is exported from `@epicenter/hq/dynamic`.
+Ensure `WorkspaceDefinition` type is exported from `@epicenter/workspace/dynamic`.
 
 ---
 
@@ -127,7 +127,7 @@ Replace complex HeadDoc-based creation with:
 import {
 	createWorkspace,
 	type WorkspaceDefinition,
-} from '@epicenter/hq/dynamic';
+} from '@epicenter/workspace/dynamic';
 import { workspacePersistence } from './workspace-persistence';
 
 export function createWorkspaceClient(definition: WorkspaceDefinition) {
@@ -226,7 +226,7 @@ The app should:
 
 3. **Skip SQLite for now**: The spec mentions SQLite materialized views but this can be a follow-up task. Focus on the core JSON + YJS persistence first.
 
-4. **Imports**: The app imports from `@epicenter/hq` (the root), which re-exports from dynamic. Make sure the new types/functions are exported properly.
+4. **Imports**: The app imports from `@epicenter/workspace` (the root), which re-exports from dynamic. Make sure the new types/functions are exported properly.
 
 ---
 

--- a/specs/20260201T120000-simple-definition-first-workspace.md
+++ b/specs/20260201T120000-simple-definition-first-workspace.md
@@ -56,7 +56,7 @@ For these simple cases, the HeadDoc is overhead. The `WorkspaceDefinition` alrea
 ### New API
 
 ```typescript
-import { createWorkspace } from '@epicenter/hq/dynamic';
+import { createWorkspace } from '@epicenter/workspace/dynamic';
 
 const workspace = createWorkspace(definition)
 	.withExtension('persistence', (ctx) => workspacePersistence(ctx))
@@ -313,7 +313,7 @@ Simplify to use new API:
 import {
 	createWorkspace,
 	type WorkspaceDefinition,
-} from '@epicenter/hq/dynamic';
+} from '@epicenter/workspace/dynamic';
 import { workspacePersistence } from './workspace-persistence';
 
 /**
@@ -337,7 +337,7 @@ import {
 	defineExports,
 	type ExtensionContext,
 	type Lifecycle,
-} from '@epicenter/hq/dynamic';
+} from '@epicenter/workspace/dynamic';
 import { appLocalDataDir, join } from '@tauri-apps/api/path';
 import { mkdir, readFile, writeFile } from '@tauri-apps/plugin-fs';
 import * as Y from 'yjs';
@@ -473,7 +473,7 @@ export function workspacePersistence<TTableDefs, TKvFields>(
 New service for workspace management:
 
 ```typescript
-import type { WorkspaceDefinition } from '@epicenter/hq/dynamic';
+import type { WorkspaceDefinition } from '@epicenter/workspace/dynamic';
 import { appLocalDataDir, join } from '@tauri-apps/api/path';
 import {
 	readDir,
@@ -482,7 +482,7 @@ import {
 	mkdir,
 	remove,
 } from '@tauri-apps/plugin-fs';
-import { generateGuid } from '@epicenter/hq';
+import { generateGuid } from '@epicenter/workspace';
 
 const WORKSPACES_DIR = 'workspaces';
 

--- a/specs/20260202T162500-reddit-workspace-migration.md
+++ b/specs/20260202T162500-reddit-workspace-migration.md
@@ -26,8 +26,8 @@ Following the refactoring work documented in `20260203T000000-ingest-simplificat
 
 3. **Updated usage pattern**:
    ```typescript
-   import { redditWorkspace, importRedditExport } from '@epicenter/hq/ingest/reddit';
-   import { createWorkspace } from '@epicenter/hq/static';
+   import { redditWorkspace, importRedditExport } from '@epicenter/workspace/ingest/reddit';
+   import { createWorkspace } from '@epicenter/workspace/static';
 
    // Before: const workspace = createRedditWorkspace();
    // After:
@@ -59,8 +59,8 @@ Following the refactoring work documented in `20260203T000000-ingest-simplificat
 3. **Performance**: Real reddit_export.zip (~5.8K rows) imports in ~86ms
 4. **API**:
    ```typescript
-   import { redditWorkspace, importRedditExport, previewRedditExport } from '@epicenter/hq/ingest/reddit';
-   import { createWorkspace } from '@epicenter/hq/static';
+   import { redditWorkspace, importRedditExport, previewRedditExport } from '@epicenter/workspace/ingest/reddit';
+   import { createWorkspace } from '@epicenter/workspace/static';
 
    const workspace = createWorkspace(redditWorkspace);
    const stats = await importRedditExport(zipFile, workspace);
@@ -747,7 +747,7 @@ export function validateRedditExport(
 ```typescript
 // packages/ingest/src/platforms/reddit/schema.ts
 
-import { defineTable, defineWorkspace } from '@epicenter/hq/static';
+import { defineTable, defineWorkspace } from '@epicenter/workspace/static';
 import { type } from 'arktype';
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1067,7 +1067,7 @@ The importer uses the **Static API** with `batch()` for atomic writes:
 ```typescript
 // packages/ingest/src/importer.ts
 
-import type { StaticWorkspace } from '@epicenter/hq/static';
+import type { StaticWorkspace } from '@epicenter/workspace/static';
 
 /**
  * Importer definition config
@@ -1134,7 +1134,7 @@ import { defineImporter } from '../../importer';
 import { parseRedditZip } from './parse';
 import { validateRedditExport, type ValidatedRedditExport } from './validation';
 import { redditWorkspace } from './schema';
-import type { StaticWorkspace } from '@epicenter/hq/static';
+import type { StaticWorkspace } from '@epicenter/workspace/static';
 
 type Workspace = StaticWorkspace<typeof redditWorkspace>;
 

--- a/specs/20260202T203000-modernize-tab-manager-client.md
+++ b/specs/20260202T203000-modernize-tab-manager-client.md
@@ -119,7 +119,7 @@ const indexedDbPersistence = (ctx: CapabilityContext) => {
 
 ### Phase 2: Migrate to Static Workspace API
 
-- [ ] Change import from `@epicenter/hq/dynamic` to `@epicenter/hq/static`
+- [ ] Change import from `@epicenter/workspace/dynamic` to `@epicenter/workspace/static`
 - [ ] Remove `extensions` field from `defineWorkspace`
 - [ ] Remove `actions` field from `defineWorkspace`
 - [ ] Use stable workspace ID: `'tab-manager'` instead of `generateGuid()`
@@ -128,7 +128,7 @@ const indexedDbPersistence = (ctx: CapabilityContext) => {
 **Before** (broken):
 
 ```typescript
-import { defineWorkspace, generateGuid } from '@epicenter/hq/dynamic';
+import { defineWorkspace, generateGuid } from '@epicenter/workspace/dynamic';
 
 const backgroundWorkspace = defineWorkspace({
   id: generateGuid(),  // Random ID = new Y.Doc every restart!
@@ -147,7 +147,7 @@ const client = createWorkspaceClient(backgroundWorkspace); // NOT IMPORTED!
 **After** (correct):
 
 ```typescript
-import { createWorkspace, defineWorkspace } from '@epicenter/hq/static';
+import { createWorkspace, defineWorkspace } from '@epicenter/workspace/static';
 import { IndexeddbPersistence } from 'y-indexeddb';
 
 // 1. Define workspace schema (pure, no runtime)
@@ -240,9 +240,9 @@ const initPromise = (async () => {
 ### background.ts Structure (After)
 
 ```typescript
-import { createWorkspace, defineWorkspace } from '@epicenter/hq/static';
+import { createWorkspace, defineWorkspace } from '@epicenter/workspace/static';
 import { IndexeddbPersistence } from 'y-indexeddb';
-import { websocketSync } from '@epicenter/hq/extensions/websocket-sync';
+import { websocketSync } from '@epicenter/workspace/extensions/websocket-sync';
 import { defineBackground } from 'wxt/utils/define-background';
 // ... other imports
 
@@ -331,7 +331,7 @@ export default defineBackground(() => {
   - [ ] Create persistence capability
   - [ ] Test service worker restart recovery
 - [ ] **Phase 2: Static Workspace API**
-  - [ ] Change import to `@epicenter/hq/static`
+  - [ ] Change import to `@epicenter/workspace/static`
   - [ ] Use stable workspace ID `'tab-manager'`
   - [ ] Remove `extensions` and `actions` from `defineWorkspace`
   - [ ] Use `createWorkspace().withExtension()`

--- a/specs/20260203T000000-action-system-v2-context-passing.md
+++ b/specs/20260203T000000-action-system-v2-context-passing.md
@@ -54,7 +54,7 @@ import {
 	createWorkspaceClient,
 	defineQuery,
 	defineMutation,
-} from '@epicenter/hq';
+} from '@epicenter/workspace';
 import { type } from 'arktype';
 
 export default createWorkspaceClient({

--- a/specs/20260205T110000-unify-extension-naming.md
+++ b/specs/20260205T110000-unify-extension-naming.md
@@ -298,10 +298,10 @@ If you're using the static API, you'll need to update your code:
 
 ```typescript
 // Before
-import type { CapabilityFactory, CapabilityMap } from '@epicenter/hq/static';
+import type { CapabilityFactory, CapabilityMap } from '@epicenter/workspace/static';
 
 // After
-import type { ExtensionFactory, ExtensionMap } from '@epicenter/hq/static';
+import type { ExtensionFactory, ExtensionMap } from '@epicenter/workspace/static';
 ```
 
 ### Client Property Access

--- a/specs/20260208T010000-example-implementation.md
+++ b/specs/20260208T010000-example-implementation.md
@@ -69,7 +69,7 @@ npx y-sweet@latest serve ./y-sweet-data
 
 ### Reusable Library Code
 
-These patterns should live in `@epicenter/hq` for reuse:
+These patterns should live in `@epicenter/workspace` for reuse:
 
 ```typescript
 // packages/epicenter/src/filesystem/sync-coordination.ts
@@ -230,9 +230,9 @@ With the library code above, the application becomes simple:
 
 ```typescript
 // scripts/fs-sync.ts
-import { defineWorkspace, defineTable, createWorkspace } from '@epicenter/hq/static';
-import { ySweetSync } from '@epicenter/hq/extensions';
-import { ContentDocManager, createBidirectionalSync } from '@epicenter/hq/filesystem';
+import { defineWorkspace, defineTable, createWorkspace } from '@epicenter/workspace/static';
+import { ySweetSync } from '@epicenter/workspace/extensions';
+import { ContentDocManager, createBidirectionalSync } from '@epicenter/workspace/filesystem';
 import { type } from 'arktype';
 
 // 1. Define workspace
@@ -291,9 +291,9 @@ bun scripts/fs-sync.ts
 ```svelte
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { defineWorkspace, createWorkspace } from '@epicenter/hq/static';
-  import { ySweetSync } from '@epicenter/hq/extensions';
-  import { ContentDocManager } from '@epicenter/hq/filesystem';
+  import { defineWorkspace, createWorkspace } from '@epicenter/workspace/static';
+  import { ySweetSync } from '@epicenter/workspace/extensions';
+  import { ContentDocManager } from '@epicenter/workspace/filesystem';
   import * as Y from 'yjs';
 
   // Same workspace definition as backend

--- a/specs/20260211T200000-fork-y-sweet-client.md
+++ b/specs/20260211T200000-fork-y-sweet-client.md
@@ -331,7 +331,7 @@ Source: https://github.com/jamsocket/y-sweet/tree/main/js-pkg/client
 ### What depends on `@epicenter/y-sweet`
 
 ```
-@epicenter/hq (packages/epicenter/)
+@epicenter/workspace (packages/epicenter/)
 └── extensions/y-sweet-sync.ts
 ```
 

--- a/specs/20260212T190000-y-sweet-persistence-architecture.md
+++ b/specs/20260212T190000-y-sweet-persistence-architecture.md
@@ -99,8 +99,8 @@ The extension mirrors the provider's API. Instead of a `mode` discriminant wrapp
 // Consumer API:
 
 // Web — IndexedDB persistence + sync:
-import { indexeddbPersistence } from '@epicenter/hq/extensions/persistence/web';
-import { directAuth, ySweetSync } from '@epicenter/hq/extensions/y-sweet-sync';
+import { indexeddbPersistence } from '@epicenter/workspace/extensions/persistence/web';
+import { directAuth, ySweetSync } from '@epicenter/workspace/extensions/y-sweet-sync';
 
 createWorkspace(def).withExtensions({
 	sync: ySweetSync({
@@ -110,7 +110,7 @@ createWorkspace(def).withExtensions({
 });
 
 // Desktop — filesystem persistence + sync:
-import { filesystemPersistence } from '@epicenter/hq/extensions/persistence/desktop';
+import { filesystemPersistence } from '@epicenter/workspace/extensions/persistence/desktop';
 
 createWorkspace(def).withExtensions({
 	sync: ySweetSync({

--- a/specs/20260213T104500-y-sweet-persist-sync-rename.md
+++ b/specs/20260213T104500-y-sweet-persist-sync-rename.md
@@ -90,12 +90,12 @@ type YSweetSyncConfig = {
 
 ```typescript
 // apps/tab-manager/src/lib/workspace-popup.ts
-import { indexeddbPersistence } from '@epicenter/hq/extensions/persistence';
-import { directAuth, ySweetSync } from '@epicenter/hq/extensions/y-sweet-sync';
+import { indexeddbPersistence } from '@epicenter/workspace/extensions/persistence';
+import { directAuth, ySweetSync } from '@epicenter/workspace/extensions/y-sweet-sync';
 
 // apps/tab-manager/src/entrypoints/background.ts
-import { indexeddbPersistence } from '@epicenter/hq/extensions/persistence';
-import { directAuth, ySweetSync } from '@epicenter/hq/extensions/y-sweet-sync';
+import { indexeddbPersistence } from '@epicenter/workspace/extensions/persistence';
+import { directAuth, ySweetSync } from '@epicenter/workspace/extensions/y-sweet-sync';
 ```
 
 ### Current Usage
@@ -147,7 +147,7 @@ packages/epicenter/src/extensions/
 
 Note: The old export paths (`./extensions/persistence`, `./extensions/y-sweet-sync`) are kept temporarily as re-export shims. They can be removed in a future breaking change.
 
-**Alternative (clean break, recommended if external consumers are few):** Remove the old paths entirely. The only known consumers are the two tab-manager files. If there are no external consumers of `@epicenter/hq/extensions/persistence`, skip the shims.
+**Alternative (clean break, recommended if external consumers are few):** Remove the old paths entirely. The only known consumers are the two tab-manager files. If there are no external consumers of `@epicenter/workspace/extensions/persistence`, skip the shims.
 
 ### New Config Type
 
@@ -169,22 +169,22 @@ type YSweetPersistSyncConfig = {
 import {
 	ySweetPersistSync,
 	directAuth,
-} from '@epicenter/hq/extensions/y-sweet-persist-sync';
+} from '@epicenter/workspace/extensions/y-sweet-persist-sync';
 
 // Persistence from platform-specific sub-paths
-import { indexeddbPersistence } from '@epicenter/hq/extensions/y-sweet-persist-sync/web';
-import { filesystemPersistence } from '@epicenter/hq/extensions/y-sweet-persist-sync/desktop';
+import { indexeddbPersistence } from '@epicenter/workspace/extensions/y-sweet-persist-sync/web';
+import { filesystemPersistence } from '@epicenter/workspace/extensions/y-sweet-persist-sync/desktop';
 ```
 
 ### New Usage
 
 ```typescript
 // Browser (tab-manager)
-import { indexeddbPersistence } from '@epicenter/hq/extensions/y-sweet-persist-sync/web';
+import { indexeddbPersistence } from '@epicenter/workspace/extensions/y-sweet-persist-sync/web';
 import {
 	ySweetPersistSync,
 	directAuth,
-} from '@epicenter/hq/extensions/y-sweet-persist-sync';
+} from '@epicenter/workspace/extensions/y-sweet-persist-sync';
 
 createWorkspace(definition).withExtension(
 	'sync',
@@ -195,11 +195,11 @@ createWorkspace(definition).withExtension(
 );
 
 // Desktop/Node.js
-import { filesystemPersistence } from '@epicenter/hq/extensions/y-sweet-persist-sync/desktop';
+import { filesystemPersistence } from '@epicenter/workspace/extensions/y-sweet-persist-sync/desktop';
 import {
 	ySweetPersistSync,
 	directAuth,
-} from '@epicenter/hq/extensions/y-sweet-persist-sync';
+} from '@epicenter/workspace/extensions/y-sweet-persist-sync';
 
 createWorkspace(definition).withExtension(
 	'sync',
@@ -306,7 +306,7 @@ Two options:
 ```typescript
 // packages/epicenter/src/extensions/y-sweet-sync.ts
 /**
- * @deprecated Use `@epicenter/hq/extensions/y-sweet-persist-sync` instead.
+ * @deprecated Use `@epicenter/workspace/extensions/y-sweet-persist-sync` instead.
  */
 export {
 	ySweetPersistSync as ySweetSync,
@@ -330,7 +330,7 @@ If we're doing a clean break (no external consumers), just delete `y-sweet-sync.
 ```typescript
 // packages/epicenter/src/extensions/persistence/web.ts
 /**
- * @deprecated Import from '@epicenter/hq/extensions/y-sweet-persist-sync/web' instead.
+ * @deprecated Import from '@epicenter/workspace/extensions/y-sweet-persist-sync/web' instead.
  */
 export { indexeddbPersistence } from '../y-sweet-persist-sync/web';
 ```
@@ -340,7 +340,7 @@ export { indexeddbPersistence } from '../y-sweet-persist-sync/web';
 ```typescript
 // packages/epicenter/src/extensions/persistence/desktop.ts
 /**
- * @deprecated Import from '@epicenter/hq/extensions/y-sweet-persist-sync/desktop' instead.
+ * @deprecated Import from '@epicenter/workspace/extensions/y-sweet-persist-sync/desktop' instead.
  */
 export {
 	filesystemPersistence,
@@ -360,7 +360,7 @@ The `persistence/` directory's only real consumers are:
 1. `apps/tab-manager/src/lib/workspace-popup.ts`
 2. `apps/tab-manager/src/entrypoints/background.ts`
 
-Both will be updated to import from the new path. The only reason to keep `persistence/` is if external packages import from `@epicenter/hq/extensions/persistence`. If that's not a concern, delete the directory and the package.json export.
+Both will be updated to import from the new path. The only reason to keep `persistence/` is if external packages import from `@epicenter/workspace/extensions/persistence`. If that's not a concern, delete the directory and the package.json export.
 
 **Recommendation:** Keep as re-export shims initially. Mark `@deprecated`. Remove in a future version.
 
@@ -389,8 +389,8 @@ export { indexeddbPersistence as webPersistence } from './y-sweet-persist-sync/w
 
 ```typescript
 // Before
-import { indexeddbPersistence } from '@epicenter/hq/extensions/persistence';
-import { directAuth, ySweetSync } from '@epicenter/hq/extensions/y-sweet-sync';
+import { indexeddbPersistence } from '@epicenter/workspace/extensions/persistence';
+import { directAuth, ySweetSync } from '@epicenter/workspace/extensions/y-sweet-sync';
 
 export const popupWorkspace = createWorkspace(definition).withExtension(
 	'sync',
@@ -401,7 +401,7 @@ export const popupWorkspace = createWorkspace(definition).withExtension(
 );
 ```
 
-This is a different pattern — standalone persistence, no Y-Sweet. It does NOT use `ySweetSync` or `indexeddbPersistence`. Leave it as-is. The `workspacePersistence` function is app-specific and imports `ExtensionContext` from `@epicenter/hq/dynamic`, not from `extensions/persistence`.
+This is a different pattern — standalone persistence, no Y-Sweet. It does NOT use `ySweetSync` or `indexeddbPersistence`. Leave it as-is. The `workspacePersistence` function is app-specific and imports `ExtensionContext` from `@epicenter/workspace/dynamic`, not from `extensions/persistence`.
 
 **TODO for future:** This app should eventually use `ySweetPersistSync` when Y-Sweet sync is added to the Epicenter desktop app.
 

--- a/specs/20260213T120800-extract-epicenter-server-package.md
+++ b/specs/20260213T120800-extract-epicenter-server-package.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-Extract the server code from `@epicenter/hq` (currently at `packages/epicenter/src/server/`) into a standalone `@epicenter/server` package at `packages/server/`. Then build the sync core: a transport-agnostic room manager and three-mode authentication system that serve as the shared foundation for both the self-hosted Elysia server and the Cloudflare Durable Objects cloud path.
+Extract the server code from `@epicenter/workspace` (currently at `packages/epicenter/src/server/`) into a standalone `@epicenter/server` package at `packages/server/`. Then build the sync core: a transport-agnostic room manager and three-mode authentication system that serve as the shared foundation for both the self-hosted Elysia server and the Cloudflare Durable Objects cloud path.
 
 **Scope boundary**: This spec covers `@epicenter/server` — the self-hosted Elysia/Bun sync server and the transport-agnostic sync core (`createRoom()`, `createAuthValidator()`, `Connection` type) that both deployment paths depend on. It also defines the **canonical client-side provider API** consumed by all three specs. The Cloudflare Durable Objects cloud path is a separate codebase documented in `20260213T120800-cloud-sync-durable-objects.md`. Client-side E2EE is documented in `20260213T120813-encryption-at-rest-architecture.md`.
 
@@ -16,7 +16,7 @@ Extract the server code from `@epicenter/hq` (currently at `packages/epicenter/s
 
 ### Current State
 
-The server lives inside `@epicenter/hq` at `src/server/`:
+The server lives inside `@epicenter/workspace` at `src/server/`:
 
 ```
 packages/epicenter/src/server/
@@ -46,7 +46,7 @@ And `package.json` exports it as:
 
 This creates problems:
 
-1. **Server code is coupled to the library package.** Users who want a self-hostable server must install `@epicenter/hq`, which includes the entire workspace system, CLI, providers, and ingest modules.
+1. **Server code is coupled to the library package.** Users who want a self-hostable server must install `@epicenter/workspace`, which includes the entire workspace system, CLI, providers, and ingest modules.
 2. **No authentication.** `MESSAGE_AUTH=2` is reserved in the protocol but unimplemented. Anyone who can reach the WebSocket can read and write all data.
 3. **No encryption at rest.** Yjs documents are stored and synced as plaintext. Sensitive data (API keys, tokens) stored in Yjs is visible to anyone with disk or network access.
 4. **Topology is implicit.** Multi-device sync works but there's no formal server identity, discovery, or trust model for self-hosted deployments.
@@ -68,8 +68,8 @@ The server imports from two internal modules:
 
 | Import              | Source          | What's Used                             |
 | ------------------- | --------------- | --------------------------------------- |
-| `../static/types`   | `@epicenter/hq` | `AnyWorkspaceClient`, `TableHelper`     |
-| `../shared/actions` | `@epicenter/hq` | `Actions`, `iterateActions`, `isAction` |
+| `../static/types`   | `@epicenter/workspace` | `AnyWorkspaceClient`, `TableHelper`     |
+| `../shared/actions` | `@epicenter/workspace` | `Actions`, `iterateActions`, `isAction` |
 
 External dependencies:
 
@@ -82,7 +82,7 @@ External dependencies:
 | `yjs`               | sync/protocol.ts (type-only)                    | Y.Doc type                    |
 | `wellcrafted`       | sync/index.ts                                   | `trySync` for error handling  |
 
-**Key finding**: The server's dependency on `@epicenter/hq` is narrow — just 5 type imports and 2 function imports (`iterateActions`, `isAction`). The types can be imported from `@epicenter/hq` as a peer dependency.
+**Key finding**: The server's dependency on `@epicenter/workspace` is narrow — just 5 type imports and 2 function imports (`iterateActions`, `isAction`). The types can be imported from `@epicenter/workspace` as a peer dependency.
 
 ### Elysia.js and Cloudflare Durable Objects
 
@@ -113,9 +113,9 @@ The sync server's only auth question: **"should I let this WebSocket connection 
 
 | Decision                     | Choice                                                                          | Rationale                                                                                                    |
 | ---------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| Package dependency direction | `@epicenter/server` depends on `@epicenter/hq` as peer dep                      | Server needs workspace types; keeping them in `@epicenter/hq` avoids a types-only package                    |
-| Backward compatibility       | Breaking change, no re-export from `@epicenter/hq/server`                       | Clean break. The server export path was pre-1.0 and has few consumers.                                       |
-| No circular deps             | `@epicenter/hq` must NEVER depend on `@epicenter/server`                        | One-way dependency: `server → hq`. CLI uses dynamic import for `serve` command until CLI is extracted later. |
+| Package dependency direction | `@epicenter/server` depends on `@epicenter/workspace` as peer dep                      | Server needs workspace types; keeping them in `@epicenter/workspace` avoids a types-only package                    |
+| Backward compatibility       | Breaking change, no re-export from `@epicenter/workspace/server`                       | Clean break. The server export path was pre-1.0 and has few consumers.                                       |
+| No circular deps             | `@epicenter/workspace` must NEVER depend on `@epicenter/server`                        | One-way dependency: `server → hq`. CLI uses dynamic import for `serve` command until CLI is extracted later. |
 | CLI extraction (future)      | Extract `@epicenter/cli` that depends on both `hq` and `server`                 | Clean leaf package that composes everything. Deferred — not in scope for Phase 1.                            |
 | Auth model                   | Three modes: open, shared secret, external JWT — NOT Better Auth on the server  | Sync server is a relay, not an auth authority. Auth complexity belongs in a separate service.                |
 | Auth default                 | Mode 1 (open, no auth) is the default                                           | Self-hosted on a trusted network shouldn't require OAuth setup to sync your own devices.                     |
@@ -158,7 +158,7 @@ Dependency graph after extraction (no circular deps):
                  depends  │        │  depends
                           ▼        ▼
 ┌──────────────────┐              ┌──────────────────┐
-│ @epicenter/server │──────────►  │  @epicenter/hq   │
+│ @epicenter/server │──────────►  │  @epicenter/workspace   │
 │                   │  peer dep   │                   │
 │ createServer()    │             │ AnyWorkspaceClient│
 │ createSyncPlugin  │             │ TableHelper       │
@@ -173,7 +173,7 @@ Dependency graph after extraction (no circular deps):
   wellcrafted
 ```
 
-**Key constraint**: `@epicenter/hq` NEVER depends on `@epicenter/server`. The arrow is one-way.
+**Key constraint**: `@epicenter/workspace` NEVER depends on `@epicenter/server`. The arrow is one-way.
 
 ### Phase 2: Three-Mode Auth + Room Extraction
 
@@ -497,28 +497,28 @@ These are handled by companion specs:
 
 - [x] **1.1** Create `packages/server/` directory with `package.json`, `tsconfig.json`
   - Name: `@epicenter/server`
-  - Peer dep: `@epicenter/hq` (for types)
+  - Peer dep: `@epicenter/workspace` (for types)
   - Direct deps: `elysia`, `@elysiajs/openapi`, `lib0`, `y-protocols`, `yjs`, `wellcrafted`
 - [x] **1.2** Copy server source files from `packages/epicenter/src/server/` to `packages/server/src/`
   - `server.ts`, `actions.ts`, `tables.ts`, `index.ts`
   - `sync/index.ts`, `sync/protocol.ts`
   - `actions.test.ts`, `sync/protocol.test.ts`
 - [x] **1.3** Update imports in copied files
-  - `../static/types` → `@epicenter/hq/static` (for `AnyWorkspaceClient`, `TableHelper`)
-  - `../shared/actions` → `@epicenter/hq` (for `Actions`, `iterateActions`, `isAction`)
+  - `../static/types` → `@epicenter/workspace/static` (for `AnyWorkspaceClient`, `TableHelper`)
+  - `../shared/actions` → `@epicenter/workspace` (for `Actions`, `iterateActions`, `isAction`)
   - Verify all imports resolve correctly
 - [x] **1.4** Update `packages/epicenter/src/cli/cli.ts` to use dynamic import
   - Changed static import to `const { createServer } = await import('@epicenter/server')` with try/catch
-  - `@epicenter/server` is NOT a dependency of `@epicenter/hq` — no circular deps
+  - `@epicenter/server` is NOT a dependency of `@epicenter/workspace` — no circular deps
   - If `@epicenter/server` is not installed, the `serve` command prints a helpful error and exits
 - [x] **1.5** Remove `./server` export from `packages/epicenter/package.json`
   - Deleted the `"./server": "./src/server/index.ts"` entry
-  - Also removed `@elysiajs/openapi` from `@epicenter/hq` dependencies (now owned by `@epicenter/server`)
+  - Also removed `@elysiajs/openapi` from `@epicenter/workspace` dependencies (now owned by `@epicenter/server`)
 - [x] **1.6** Delete `packages/epicenter/src/server/` directory entirely
 - [x] **1.7** Verify the server README at `packages/epicenter/src/server/README.md` is moved to `packages/server/README.md`
 - [x] **1.8** Run existing tests in new location: `bun test` from `packages/server/` — 50 pass, 0 fail
-- [x] **1.9** Run `bun typecheck` on both `@epicenter/server` and `@epicenter/hq` — all errors are pre-existing upstream, none related to extraction
-- [x] **1.10** No documentation references to `@epicenter/hq/server` found outside the spec itself
+- [x] **1.9** Run `bun typecheck` on both `@epicenter/server` and `@epicenter/workspace` — all errors are pre-existing upstream, none related to extraction
+- [x] **1.10** No documentation references to `@epicenter/workspace/server` found outside the spec itself
 
 ### Phase 2: Room Extraction + Three-Mode Auth (Design Only — Implementation Deferred)
 
@@ -555,10 +555,10 @@ These are handled by companion specs:
 
 ### Phase 1: CLI `serve` Command Without Circular Dependency
 
-1. `@epicenter/hq` currently exports the server AND defines the types the server uses
-2. After extraction, `@epicenter/server` depends on `@epicenter/hq` for types
-3. The CLI's `serve` command (in `@epicenter/hq`) needs `createServer` from `@epicenter/server`
-4. **`@epicenter/hq` must NEVER depend on `@epicenter/server`** — no circular deps
+1. `@epicenter/workspace` currently exports the server AND defines the types the server uses
+2. After extraction, `@epicenter/server` depends on `@epicenter/workspace` for types
+3. The CLI's `serve` command (in `@epicenter/workspace`) needs `createServer` from `@epicenter/server`
+4. **`@epicenter/workspace` must NEVER depend on `@epicenter/server`** — no circular deps
 
 **Resolution**: The CLI uses a dynamic import: `const { createServer } = await import('@epicenter/server')`. This makes `@epicenter/server` an optional peer dep. If not installed, the `serve` command prints "Install @epicenter/server to use this command." Later, the entire CLI will be extracted to `@epicenter/cli` which depends on both packages normally.
 
@@ -612,10 +612,10 @@ If using `?token=secret` query param fallback, the secret appears in server acce
 - [x] `bun test` passes in `packages/server/` (50 pass, 0 fail)
 - [x] `bun typecheck` passes in both packages (all errors pre-existing, none from extraction)
 - [x] `epicenter serve` CLI command uses dynamic import from `@epicenter/server`
-- [x] `@epicenter/hq` no longer contains server code in `src/server/`
-- [x] No `./server` export in `@epicenter/hq/package.json`
-- [x] `@epicenter/hq` has NO dependency (direct or peer) on `@epicenter/server` in package.json
-- [x] Dependency direction is strictly one-way: `@epicenter/server` → `@epicenter/hq`
+- [x] `@epicenter/workspace` no longer contains server code in `src/server/`
+- [x] No `./server` export in `@epicenter/workspace/package.json`
+- [x] `@epicenter/workspace` has NO dependency (direct or peer) on `@epicenter/server` in package.json
+- [x] Dependency direction is strictly one-way: `@epicenter/server` → `@epicenter/workspace`
 
 ### Phase 2
 
@@ -651,25 +651,25 @@ Phase 1 was a pure extraction — ~95% move/rename, ~5% glue code. No business l
 
 **New package: `packages/server/`**
 
-- `package.json` — `@epicenter/server`, peer dep on `@epicenter/hq`, direct deps on `elysia`, `@elysiajs/openapi`, `lib0`, `y-protocols`, `yjs`, `wellcrafted`
-- `tsconfig.json` — mirrors `@epicenter/hq` compiler options
+- `package.json` — `@epicenter/server`, peer dep on `@epicenter/workspace`, direct deps on `elysia`, `@elysiajs/openapi`, `lib0`, `y-protocols`, `yjs`, `wellcrafted`
+- `tsconfig.json` — mirrors `@epicenter/workspace` compiler options
 - `src/index.ts` — 1-line re-export of `createServer`, `DEFAULT_PORT`, `ServerOptions`
 - `src/server.ts` — moved from `packages/epicenter/src/server/server.ts`, import paths updated
-- `src/actions.ts` — moved, import paths updated (`../shared/actions` → `@epicenter/hq`)
-- `src/tables.ts` — moved, import paths updated (`../static/types` → `@epicenter/hq/static`)
+- `src/actions.ts` — moved, import paths updated (`../shared/actions` → `@epicenter/workspace`)
+- `src/tables.ts` — moved, import paths updated (`../static/types` → `@epicenter/workspace/static`)
 - `src/sync/index.ts` — moved verbatim (no import changes needed, all deps are external)
 - `src/sync/protocol.ts` — moved verbatim
 - `src/actions.test.ts` — moved, import paths updated
 - `src/sync/protocol.test.ts` — moved verbatim
 - `README.md` — moved verbatim
 
-**Modified in `@epicenter/hq`:**
+**Modified in `@epicenter/workspace`:**
 
 - `src/static/index.ts` — added `AnyWorkspaceClient` to type exports (was missing, needed by server package)
 - `src/cli/cli.ts` — replaced static `import { createServer }` with dynamic `await import('@epicenter/server')` + try/catch error handling
 - `package.json` — removed `"./server"` export, removed `@elysiajs/openapi` dependency
 
-**Deleted from `@epicenter/hq`:**
+**Deleted from `@epicenter/workspace`:**
 
 - `src/server/` — entire directory
 
@@ -686,5 +686,5 @@ Phase 1 was a pure extraction — ~95% move/rename, ~5% glue code. No business l
 ### Notes for Phase 2
 
 - The `DEFAULT_PORT` constant (3913) is now hardcoded in the CLI fallback since it can't import from `@epicenter/server` at module level. When Phase 2 adds auth config, the CLI will need `@epicenter/server` installed anyway, so this becomes moot.
-- `AnyWorkspaceClient` was not previously exported from `@epicenter/hq/static`. It is now. This is the only new public API surface from Phase 1.
-- The `@elysiajs/openapi` dependency moved from `@epicenter/hq` to `@epicenter/server`. If anything else in `@epicenter/hq` used it, it would break — but nothing does.
+- `AnyWorkspaceClient` was not previously exported from `@epicenter/workspace/static`. It is now. This is the only new public API surface from Phase 1.
+- The `@elysiajs/openapi` dependency moved from `@epicenter/workspace` to `@epicenter/server`. If anything else in `@epicenter/workspace` used it, it would break — but nothing does.

--- a/specs/20260213T120800-extract-filesystem-package.md
+++ b/specs/20260213T120800-extract-filesystem-package.md
@@ -6,13 +6,13 @@
 
 ## Overview
 
-Extract the virtual filesystem implementation from `@epicenter/hq` (at `packages/epicenter/src/filesystem/`) into a standalone `@epicenter/filesystem` package. This removes 5 heavy, filesystem-only dependencies from the core package and establishes the filesystem as a first-class, independently consumable layer on top of `@epicenter/hq`.
+Extract the virtual filesystem implementation from `@epicenter/workspace` (at `packages/epicenter/src/filesystem/`) into a standalone `@epicenter/filesystem` package. This removes 5 heavy, filesystem-only dependencies from the core package and establishes the filesystem as a first-class, independently consumable layer on top of `@epicenter/workspace`.
 
 ## Motivation
 
 ### Current State
 
-The `@epicenter/hq` package (`packages/epicenter/`) contains three abstraction layers that serve different purposes:
+The `@epicenter/workspace` package (`packages/epicenter/`) contains three abstraction layers that serve different purposes:
 
 ```
 packages/epicenter/src/
@@ -34,15 +34,15 @@ The filesystem module already has its own export path in package.json:
 
 This creates problems:
 
-1. **Dependency bloat**: `@epicenter/hq` ships `just-bash`, `prosemirror-markdown`, `prosemirror-model`, `prosemirror-schema-basic`, and `y-prosemirror` — all used ONLY by the filesystem module. Anyone importing `@epicenter/hq/static` for table definitions pays the install cost of these unrelated deps.
-2. **Conceptual confusion**: The filesystem is a consumer of `@epicenter/hq` (it uses `defineTable`, `TableHelper`, `Lifecycle`), not a primitive. It sits at a higher abstraction level but lives inside the primitives package.
+1. **Dependency bloat**: `@epicenter/workspace` ships `just-bash`, `prosemirror-markdown`, `prosemirror-model`, `prosemirror-schema-basic`, and `y-prosemirror` — all used ONLY by the filesystem module. Anyone importing `@epicenter/workspace/static` for table definitions pays the install cost of these unrelated deps.
+2. **Conceptual confusion**: The filesystem is a consumer of `@epicenter/workspace` (it uses `defineTable`, `TableHelper`, `Lifecycle`), not a primitive. It sits at a higher abstraction level but lives inside the primitives package.
 3. **Future coupling risk**: As the filesystem grows, its dependencies will continue to inflate the core package.
 
 ### Desired State
 
 ```
 packages/
-├── epicenter/          # @epicenter/hq — workspace primitives only
+├── epicenter/          # @epicenter/workspace — workspace primitives only
 │   └── src/
 │       ├── shared/
 │       ├── static/
@@ -67,7 +67,7 @@ packages/
         └── (all test files)
 ```
 
-`@epicenter/hq` loses 5 dependencies. `@epicenter/filesystem` depends on `@epicenter/hq` as a peer/workspace dep. Clean layering.
+`@epicenter/workspace` loses 5 dependencies. `@epicenter/filesystem` depends on `@epicenter/workspace` as a peer/workspace dep. Clean layering.
 
 ## Research Findings
 
@@ -75,7 +75,7 @@ packages/
 
 Every import relationship from the filesystem module was traced to determine the exact coupling surface.
 
-#### Filesystem → `@epicenter/hq` internals (what filesystem imports):
+#### Filesystem → `@epicenter/workspace` internals (what filesystem imports):
 
 | Import                       | Source File                 | Kind         | Used In                                                        |
 | ---------------------------- | --------------------------- | ------------ | -------------------------------------------------------------- |
@@ -90,7 +90,7 @@ Every import relationship from the filesystem module was traced to determine the
 
 #### Filesystem → External dependencies (unique to filesystem):
 
-| Dependency                 | Used In                                         | Used Elsewhere in `@epicenter/hq`? |
+| Dependency                 | Used In                                         | Used Elsewhere in `@epicenter/workspace`? |
 | -------------------------- | ----------------------------------------------- | ---------------------------------- |
 | `just-bash`                | `yjs-file-system.ts` (implements `IFileSystem`) | **NO**                             |
 | `prosemirror-markdown`     | `markdown-helpers.ts`                           | **NO**                             |
@@ -100,7 +100,7 @@ Every import relationship from the filesystem module was traced to determine the
 
 All 5 dependencies are filesystem-exclusive.
 
-#### Filesystem → Shared external deps (already in `@epicenter/hq`):
+#### Filesystem → Shared external deps (already in `@epicenter/workspace`):
 
 | Dependency          | Used In                                                      |
 | ------------------- | ------------------------------------------------------------ |
@@ -108,11 +108,11 @@ All 5 dependencies are filesystem-exclusive.
 | `arktype`           | file-table.ts, types.ts                                      |
 | `wellcrafted/brand` | types.ts                                                     |
 
-These will come transitively through the `@epicenter/hq` dependency.
+These will come transitively through the `@epicenter/workspace` dependency.
 
 #### Consumers of filesystem (who imports from it):
 
-**Zero consumers.** No app or package currently imports from `@epicenter/hq/filesystem`. The module is self-contained with only internal test files consuming it.
+**Zero consumers.** No app or package currently imports from `@epicenter/workspace/filesystem`. The module is self-contained with only internal test files consuming it.
 
 ### File Inventory
 
@@ -138,12 +138,12 @@ These will come transitively through the `@epicenter/hq` dependency.
 
 | Decision                         | Choice                                                          | Rationale                                                                              |
 | -------------------------------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| Package name                     | `@epicenter/filesystem`                                         | Matches `@epicenter/hq` naming convention. Short, clear.                               |
+| Package name                     | `@epicenter/filesystem`                                         | Matches `@epicenter/workspace` naming convention. Short, clear.                               |
 | Package location                 | `packages/filesystem/`                                          | Follows monorepo convention (`packages/{name}/`)                                       |
-| Dependency on `@epicenter/hq`    | `workspace:*` in dependencies                                   | Filesystem is a consumer of hq primitives. Workspace protocol keeps versions in sync.  |
-| Import style                     | Import from `@epicenter/hq` and `@epicenter/hq/static` subpaths | Use the existing public export paths, not relative `../` imports                       |
-| `ProviderFactory` import         | Import from `@epicenter/hq/dynamic`                             | This type lives in `dynamic/provider-types.ts` and is exported via the dynamic subpath |
-| Export path from `@epicenter/hq` | **Remove** `"./filesystem"` from hq's package.json exports      | Consumers will import from `@epicenter/filesystem` directly                            |
+| Dependency on `@epicenter/workspace`    | `workspace:*` in dependencies                                   | Filesystem is a consumer of hq primitives. Workspace protocol keeps versions in sync.  |
+| Import style                     | Import from `@epicenter/workspace` and `@epicenter/workspace/static` subpaths | Use the existing public export paths, not relative `../` imports                       |
+| `ProviderFactory` import         | Import from `@epicenter/workspace/dynamic`                             | This type lives in `dynamic/provider-types.ts` and is exported via the dynamic subpath |
+| Export path from `@epicenter/workspace` | **Remove** `"./filesystem"` from hq's package.json exports      | Consumers will import from `@epicenter/filesystem` directly                            |
 | Test runner                      | `bun test`                                                      | Consistent with rest of monorepo                                                       |
 
 ## Architecture
@@ -152,7 +152,7 @@ These will come transitively through the `@epicenter/hq` dependency.
 
 ```
 ┌─────────────────────────────────────────────────┐
-│  @epicenter/hq                                   │
+│  @epicenter/workspace                                   │
 │                                                   │
 │  ┌──────────┐  ┌──────────┐  ┌───────────────┐  │
 │  │ shared/  │  │ static/  │  │  dynamic/     │  │
@@ -172,7 +172,7 @@ These will come transitively through the `@epicenter/hq` dependency.
 
 ```
 ┌─────────────────────────────────────────┐
-│  @epicenter/hq                           │
+│  @epicenter/workspace                           │
 │                                           │
 │  ┌──────────┐ ┌──────────┐ ┌──────────┐ │
 │  │ shared/  │ │ static/  │ │ dynamic/ │ │
@@ -183,7 +183,7 @@ These will come transitively through the `@epicenter/hq` dependency.
 ┌─────────────────────────────────────────┐
 │  @epicenter/filesystem                   │
 │                                           │
-│  Imports from @epicenter/hq:             │
+│  Imports from @epicenter/workspace:             │
 │    defineTable, TableHelper, Lifecycle,   │
 │    defineExports, Guid, ProviderFactory  │
 │                                           │
@@ -220,7 +220,7 @@ These will come transitively through the `@epicenter/hq` dependency.
   		"typecheck": "tsc --noEmit"
   	},
   	"dependencies": {
-  		"@epicenter/hq": "workspace:*",
+  		"@epicenter/workspace": "workspace:*",
   		"arktype": "catalog:",
   		"just-bash": "^2.9.7",
   		"prosemirror-markdown": "^1.13.4",
@@ -241,24 +241,24 @@ These will come transitively through the `@epicenter/hq` dependency.
 ### Phase 2: Move files and rewrite imports
 
 - [x] **2.1** Move all 19 files from `packages/epicenter/src/filesystem/` to `packages/filesystem/src/`
-- [x] **2.2** Rewrite internal `../` imports to `@epicenter/hq` public subpath imports:
+- [x] **2.2** Rewrite internal `../` imports to `@epicenter/workspace` public subpath imports:
       | Old Import | New Import |
       |-----------|-----------|
-      | `from '../static/types.js'` | `from '@epicenter/hq/static'` |
-      | `from '../static/define-table.js'` | `from '@epicenter/hq/static'` |
-      | `from '../dynamic/provider-types.js'` | `from '@epicenter/hq/dynamic'` |
-      | `from '../shared/lifecycle.js'` | `from '@epicenter/hq'` |
-      | `from '../shared/id.js'` | `from '@epicenter/hq'` (if exported) or a new subpath |
-- [x] **2.3** Verify that all needed symbols are actually exported from the public subpaths. If not, add them to the appropriate `index.ts` barrel in `@epicenter/hq`. Specifically check:
-  - `TableHelper` exported from `@epicenter/hq/static`
-  - `InferTableRow` exported from `@epicenter/hq/static`
-  - `defineTable` exported from `@epicenter/hq/static`
-  - `ProviderFactory`, `ProviderContext` exported from `@epicenter/hq/dynamic`
-  - `defineExports`, `Lifecycle` exported from `@epicenter/hq`
-  - `Guid`, `generateGuid` exported from `@epicenter/hq`
+      | `from '../static/types.js'` | `from '@epicenter/workspace/static'` |
+      | `from '../static/define-table.js'` | `from '@epicenter/workspace/static'` |
+      | `from '../dynamic/provider-types.js'` | `from '@epicenter/workspace/dynamic'` |
+      | `from '../shared/lifecycle.js'` | `from '@epicenter/workspace'` |
+      | `from '../shared/id.js'` | `from '@epicenter/workspace'` (if exported) or a new subpath |
+- [x] **2.3** Verify that all needed symbols are actually exported from the public subpaths. If not, add them to the appropriate `index.ts` barrel in `@epicenter/workspace`. Specifically check:
+  - `TableHelper` exported from `@epicenter/workspace/static`
+  - `InferTableRow` exported from `@epicenter/workspace/static`
+  - `defineTable` exported from `@epicenter/workspace/static`
+  - `ProviderFactory`, `ProviderContext` exported from `@epicenter/workspace/dynamic`
+  - `defineExports`, `Lifecycle` exported from `@epicenter/workspace`
+  - `Guid`, `generateGuid` exported from `@epicenter/workspace`
 - [x] **2.4** Update `packages/filesystem/src/index.ts` — should be identical to the current barrel, just with updated internal paths (all `./` relative within the new package)
 
-### Phase 3: Clean up `@epicenter/hq`
+### Phase 3: Clean up `@epicenter/workspace`
 
 - [x] **3.1** Delete `packages/epicenter/src/filesystem/` directory entirely
 - [x] **3.2** Remove the `"./filesystem"` export from `packages/epicenter/package.json`
@@ -277,18 +277,18 @@ These will come transitively through the `@epicenter/hq` dependency.
 - [x] **4.3** Run `bun run typecheck` in `packages/epicenter/` — zero errors (no regressions)
 - [x] **4.4** Run `bun test` in `packages/epicenter/` — all tests pass
 - [x] **4.5** Run `bun install` from root — no resolution errors
-- [x] **4.6** Grep the entire repo for any lingering `@epicenter/hq/filesystem` imports — should find zero
+- [x] **4.6** Grep the entire repo for any lingering `@epicenter/workspace/filesystem` imports — should find zero
 
 ## Edge Cases
 
-### Missing public exports from `@epicenter/hq`
+### Missing public exports from `@epicenter/workspace`
 
 The filesystem currently imports via relative `../` paths. Some of these symbols may not be re-exported from the public barrel files (`index.ts`). Phase 2.3 handles this — check each symbol and add missing exports before changing imports.
 
 Specifically watch for:
 
-- `Guid` and `generateGuid` from `shared/id.ts` — verify they're in `@epicenter/hq`'s root `index.ts`
-- `ProviderFactory` from `dynamic/provider-types.ts` — verify it's in `@epicenter/hq/dynamic`'s `index.ts`
+- `Guid` and `generateGuid` from `shared/id.ts` — verify they're in `@epicenter/workspace`'s root `index.ts`
+- `ProviderFactory` from `dynamic/provider-types.ts` — verify it's in `@epicenter/workspace/dynamic`'s `index.ts`
 
 ### `just-bash` test imports
 
@@ -296,33 +296,33 @@ The test files (`yjs-file-system.test.ts`, `markdown-helpers.test.ts`) import `{
 
 ### `prosemirror-schema-basic` not directly imported
 
-This dep is listed in `@epicenter/hq`'s `package.json` but never directly imported in any `.ts` file. It's likely a transitive requirement of `prosemirror-markdown`. Move it to the new package deps to be safe, and verify tests pass.
+This dep is listed in `@epicenter/workspace`'s `package.json` but never directly imported in any `.ts` file. It's likely a transitive requirement of `prosemirror-markdown`. Move it to the new package deps to be safe, and verify tests pass.
 
 ## Open Questions
 
 1. **Should `Guid`/`generateGuid` be extracted to a tiny shared package?**
-   - Currently in `@epicenter/hq`'s `shared/id.ts`. The filesystem needs it for `FileId`.
-   - Options: (a) import from `@epicenter/hq` root, (b) create `@epicenter/ids` micro-package, (c) just use nanoid directly in the filesystem package
-   - **Recommendation**: (a) Import from `@epicenter/hq` — simplest, no new packages. Only consider (b) if a circular dep emerges.
+   - Currently in `@epicenter/workspace`'s `shared/id.ts`. The filesystem needs it for `FileId`.
+   - Options: (a) import from `@epicenter/workspace` root, (b) create `@epicenter/ids` micro-package, (c) just use nanoid directly in the filesystem package
+   - **Recommendation**: (a) Import from `@epicenter/workspace` — simplest, no new packages. Only consider (b) if a circular dep emerges.
 
 2. **Should `ProviderFactory` move to a shared location?**
    - It's in `dynamic/provider-types.ts` but the filesystem uses it for content doc providers. It's not really dynamic-workspace-specific.
-   - Options: (a) leave in dynamic, import from `@epicenter/hq/dynamic`, (b) move to `shared/`, export from root
+   - Options: (a) leave in dynamic, import from `@epicenter/workspace/dynamic`, (b) move to `shared/`, export from root
    - **Recommendation**: (a) for now. It's already exported from the dynamic subpath. Move later if more packages need it.
 
 3. **Should `prosemirror-schema-basic` stay in deps?**
-   - Not directly imported but listed in `@epicenter/hq` dependencies. May be a transitive requirement.
+   - Not directly imported but listed in `@epicenter/workspace` dependencies. May be a transitive requirement.
    - **Recommendation**: Include it in `@epicenter/filesystem` deps. If tests pass without it, remove it in a follow-up.
 
 ## Success Criteria
 
 - [x] `packages/filesystem/` exists with all 19 files moved over
 - [x] `packages/epicenter/src/filesystem/` no longer exists
-- [x] `@epicenter/hq`'s `package.json` has no `just-bash`, `prosemirror-*`, or `y-prosemirror` deps
-- [x] `@epicenter/hq`'s `package.json` has no `"./filesystem"` export
+- [x] `@epicenter/workspace`'s `package.json` has no `just-bash`, `prosemirror-*`, or `y-prosemirror` deps
+- [x] `@epicenter/workspace`'s `package.json` has no `"./filesystem"` export
 - [x] `bun run typecheck` passes in both packages
 - [x] `bun test` passes in both packages
-- [x] Zero `@epicenter/hq/filesystem` imports remain anywhere in the repo
+- [x] Zero `@epicenter/workspace/filesystem` imports remain anywhere in the repo
 - [x] `bun install` succeeds from repo root
 
 ## References
@@ -346,11 +346,11 @@ This dep is listed in `@epicenter/hq`'s `package.json` but never directly import
 Below is a self-contained prompt for a handoff agent to execute this extraction.
 
 ```
-You are extracting the virtual filesystem module from `@epicenter/hq` into a new `@epicenter/filesystem` package. This is a mechanical extraction — no behavior changes, no refactoring, no new features. The goal is a clean package boundary.
+You are extracting the virtual filesystem module from `@epicenter/workspace` into a new `@epicenter/filesystem` package. This is a mechanical extraction — no behavior changes, no refactoring, no new features. The goal is a clean package boundary.
 
 ## Context
 
-The monorepo is at the repo root. The core package is `packages/epicenter/` (published as `@epicenter/hq`). It contains a `src/filesystem/` directory (19 files) that implements a POSIX-like virtual filesystem backed by Yjs CRDTs. This module is a CONSUMER of the core workspace API — it uses `defineTable`, `TableHelper`, `Lifecycle`, etc. from the core. It also has 5 heavy dependencies (`just-bash`, `prosemirror-markdown`, `prosemirror-model`, `prosemirror-schema-basic`, `y-prosemirror`) that nothing else in `@epicenter/hq` uses.
+The monorepo is at the repo root. The core package is `packages/epicenter/` (published as `@epicenter/workspace`). It contains a `src/filesystem/` directory (19 files) that implements a POSIX-like virtual filesystem backed by Yjs CRDTs. This module is a CONSUMER of the core workspace API — it uses `defineTable`, `TableHelper`, `Lifecycle`, etc. from the core. It also has 5 heavy dependencies (`just-bash`, `prosemirror-markdown`, `prosemirror-model`, `prosemirror-schema-basic`, `y-prosemirror`) that nothing else in `@epicenter/workspace` uses.
 
 The full specification with dependency maps, file inventory, and architecture diagrams is at:
 `specs/20260213T120800-extract-filesystem-package.md`
@@ -364,22 +364,22 @@ The full specification with dependency maps, file inventory, and architecture di
 1. Create the directory structure: `packages/filesystem/src/`
 2. Create `package.json` — see spec for the exact content. Key points:
    - Name: `@epicenter/filesystem`
-   - Dependencies: `@epicenter/hq` (workspace:*), plus the 5 filesystem-specific deps, plus `arktype`, `wellcrafted`, `yjs`
+   - Dependencies: `@epicenter/workspace` (workspace:*), plus the 5 filesystem-specific deps, plus `arktype`, `wellcrafted`, `yjs`
    - Follow the patterns of existing package.json files in the monorepo (check `packages/epicenter/package.json` for script patterns, catalog references, etc.)
 3. Create `tsconfig.json` — follow the pattern of other `packages/*/tsconfig.json` in the monorepo
 
 ### Phase 2: Move files and fix imports
 
 1. Move ALL files from `packages/epicenter/src/filesystem/` to `packages/filesystem/src/`
-2. Rewrite imports. The filesystem files currently use relative `../` imports to reach into `@epicenter/hq` internals. Change these to public subpath imports:
+2. Rewrite imports. The filesystem files currently use relative `../` imports to reach into `@epicenter/workspace` internals. Change these to public subpath imports:
 
    | Old Import | New Import |
    |-----------|-----------|
-   | `from '../static/types.js'` | `from '@epicenter/hq/static'` |
-   | `from '../static/define-table.js'` | `from '@epicenter/hq/static'` |
-   | `from '../dynamic/provider-types.js'` | `from '@epicenter/hq/dynamic'` |
-   | `from '../shared/lifecycle.js'` | `from '@epicenter/hq'` |
-   | `from '../shared/id.js'` | `from '@epicenter/hq'` |
+   | `from '../static/types.js'` | `from '@epicenter/workspace/static'` |
+   | `from '../static/define-table.js'` | `from '@epicenter/workspace/static'` |
+   | `from '../dynamic/provider-types.js'` | `from '@epicenter/workspace/dynamic'` |
+   | `from '../shared/lifecycle.js'` | `from '@epicenter/workspace'` |
+   | `from '../shared/id.js'` | `from '@epicenter/workspace'` |
 
 3. **CRITICAL**: Before rewriting imports, verify that every symbol is actually exported from the target public path. Check the barrel files:
    - `packages/epicenter/src/index.ts` — for `defineExports`, `Lifecycle`, `Guid`, `generateGuid`
@@ -390,7 +390,7 @@ The full specification with dependency maps, file inventory, and architecture di
 
 4. Internal imports within the filesystem module (e.g., `from './types.js'`) stay as-is — they're all within the new package.
 
-### Phase 3: Clean up `@epicenter/hq`
+### Phase 3: Clean up `@epicenter/workspace`
 
 1. Delete `packages/epicenter/src/filesystem/` entirely
 2. Remove `"./filesystem": "./src/filesystem/index.ts"` from `packages/epicenter/package.json` exports
@@ -409,7 +409,7 @@ The full specification with dependency maps, file inventory, and architecture di
 3. `bun run typecheck` in `packages/epicenter/` — zero errors
 4. `bun test` in `packages/epicenter/` — all tests pass
 5. `bun install` from root — no resolution errors
-6. Grep the entire repo for `@epicenter/hq/filesystem` — should find zero matches
+6. Grep the entire repo for `@epicenter/workspace/filesystem` — should find zero matches
 
 ## Rules
 
@@ -428,7 +428,7 @@ The full specification with dependency maps, file inventory, and architecture di
 
 ### Summary
 
-Successfully extracted the virtual filesystem module from `@epicenter/hq` into a standalone `@epicenter/filesystem` package. This was a pure mechanical extraction with zero behavior changes.
+Successfully extracted the virtual filesystem module from `@epicenter/workspace` into a standalone `@epicenter/filesystem` package. This was a pure mechanical extraction with zero behavior changes.
 
 ### Changes Made
 
@@ -437,16 +437,16 @@ Successfully extracted the virtual filesystem module from `@epicenter/hq` into a
 - Created `package.json` (`@epicenter/filesystem@0.0.1`) with only the dependencies the filesystem actually needs
 - Created `tsconfig.json` matching the epicenter package's compiler options
 - Moved all 19 source and test files from `packages/epicenter/src/filesystem/`
-- Rewrote 18 relative `../` imports to use `@epicenter/hq` public subpath imports
+- Rewrote 18 relative `../` imports to use `@epicenter/workspace` public subpath imports
 
-#### Barrel Export Additions in `@epicenter/hq`
+#### Barrel Export Additions in `@epicenter/workspace`
 
 Two symbols groups were missing from the public barrels and needed to be added before the filesystem could import them through package boundaries:
 
 1. **Root `index.ts`**: Added `Guid`, `generateGuid`, `Id`, `generateId`, `createId` from `shared/id.ts`
 2. **`dynamic/index.ts`**: Added `ProviderFactory`, `ProviderContext`, `ProviderExports`, `ProviderFactoryMap` from `provider-types.ts`
 
-#### Cleanup of `@epicenter/hq`
+#### Cleanup of `@epicenter/workspace`
 
 - Deleted `packages/epicenter/src/filesystem/` (19 files)
 - Removed `"./filesystem"` export path from `package.json`
@@ -469,10 +469,10 @@ Two symbols groups were missing from the public barrels and needed to be added b
 | `bun test` (filesystem)          | 201 pass, 0 fail                                        |
 | `bun run typecheck` (epicenter)  | Only pre-existing errors (cli.test.ts, table-helper.ts) |
 | `bun test` (epicenter)           | 610 pass, 2 skip, 0 fail                                |
-| `@epicenter/hq/filesystem` grep  | Zero matches                                            |
+| `@epicenter/workspace/filesystem` grep  | Zero matches                                            |
 
 ### Open Questions Resolved
 
-1. **`Guid`/`generateGuid` location**: Kept in `@epicenter/hq`, imported from root — simplest approach, no new packages needed.
-2. **`ProviderFactory` location**: Kept in `dynamic/`, exported via `@epicenter/hq/dynamic` — already there, works fine.
+1. **`Guid`/`generateGuid` location**: Kept in `@epicenter/workspace`, imported from root — simplest approach, no new packages needed.
+2. **`ProviderFactory` location**: Kept in `dynamic/`, exported via `@epicenter/workspace/dynamic` — already there, works fine.
 3. **`prosemirror-schema-basic` in deps**: Not needed. Transitive dep only. Dropped.

--- a/specs/20260213T120800-separate-extension-lifecycle-from-exports.md
+++ b/specs/20260213T120800-separate-extension-lifecycle-from-exports.md
@@ -290,7 +290,7 @@ return defineExtension({
 
 ## Success Criteria
 
-- [x] `defineExtension()` exists and is exported from `@epicenter/hq`
+- [x] `defineExtension()` exists and is exported from `@epicenter/workspace`
 - [x] `workspace.extensions.sqlite` does NOT have `.destroy` or `.whenReady` in its type
 - [x] `workspace.whenReady` works on both static and dynamic workspaces
 - [x] `workspace.destroy()` still calls all extension cleanup in reverse order

--- a/specs/20260214T174800-sheet-timeline-entry.md
+++ b/specs/20260214T174800-sheet-timeline-entry.md
@@ -79,7 +79,7 @@ Source: [Yjs DeepWiki](https://deepwiki.com/yjs/yjs), maintainer guidance.
 | Cell value type | Always `string` | Simplest CRDT layer. Interpretation (number, date, boolean) is a column `kind` hint. Parse on read, stringify on write. Google Sheets does the same. |
 | Row ordering | Fractional indexing (string property `order`) | Y.Array reorder = delete+insert = lost updates + duplicates. Property update is atomic. Already documented in `docs/articles/fractional-ordering-meta-data-structure.md`. |
 | Column ordering | Fractional indexing (string property `order`) | Same rationale as row ordering. |
-| Row/column IDs | 10-char nanoid via `generateId()` | Stable across concurrent edits. No positional re-keying. Uses existing `generateId()` from `@epicenter/hq` (10-char alphanumeric, safe for millions of rows). Branded types `RowId` and `ColumnId`. No prefixes (raw nanoid strings). |
+| Row/column IDs | 10-char nanoid via `generateId()` | Stable across concurrent edits. No positional re-keying. Uses existing `generateId()` from `@epicenter/workspace` (10-char alphanumeric, safe for millions of rows). Branded types `RowId` and `ColumnId`. No prefixes (raw nanoid strings). |
 | Column definition versioning | No `_v` field | Y.Maps allow atomic field updates, making object-level versioning misleading. Use defensive reading (provide defaults for missing fields) + strict writing (always set all current schema fields). Additive changes (new optional fields) are safe without versioning. |
 | Column defs location | Nested Y.Map on the timeline entry | Co-located with data. No external schema reference needed. |
 | `order` as reserved key | Yes, on row Y.Map | Column IDs are nanoid-generated (e.g., `k7x9m2p4q8`), never the literal string `"order"`. No collision possible. |
@@ -243,7 +243,7 @@ Gadget,24.99,false
 Added to `packages/filesystem/src/types.ts`:
 
 ```typescript
-import { type Id, generateId } from '@epicenter/hq';
+import { type Id, generateId } from '@epicenter/workspace';
 import type { Brand } from 'wellcrafted/brand';
 
 /** Branded row identifier — a 10-char nanoid that is specifically a row ID */
@@ -263,7 +263,7 @@ export function generateColumnId(): ColumnId {
 }
 ```
 
-**Why 10-char IDs?** `generateId()` from `@epicenter/hq` produces 10-character alphanumeric strings (alphabet: `a-z0-9`), safe for ~85 million entities with 1-in-a-million collision chance. Both rows and columns are table-scoped, not globally unique, so 10 chars is sufficient.
+**Why 10-char IDs?** `generateId()` from `@epicenter/workspace` produces 10-character alphanumeric strings (alphabet: `a-z0-9`), safe for ~85 million entities with 1-in-a-million collision chance. Both rows and columns are table-scoped, not globally unique, so 10 chars is sufficient.
 
 **Why branded types?** Prevents accidentally using a `RowId` where a `ColumnId` is expected at compile time. Follows the existing `FileId` pattern in the codebase.
 

--- a/specs/20260217T094400-table-level-document-api.md
+++ b/specs/20260217T094400-table-level-document-api.md
@@ -368,7 +368,7 @@ client.tables.tags.docs; // ← TypeScript error: property 'docs' does not exist
 ### Standalone usage (without `createWorkspace()`)
 
 ```typescript
-import { createDocumentBinding, createTables } from '@epicenter/hq/static';
+import { createDocumentBinding, createTables } from '@epicenter/workspace/static';
 
 const ydoc = new Y.Doc({ guid: 'my-workspace' });
 const tables = createTables(ydoc, { files: filesTable });

--- a/specs/20260219T094400-migrate-filesystem-to-document-binding.md
+++ b/specs/20260219T094400-migrate-filesystem-to-document-binding.md
@@ -301,7 +301,7 @@ Every `ContentOps` method maps to either the document binding directly or a thin
 
 2. **Two content access paths**: `ws.tables.files.docs.content` (binding) for simple text I/O, and `fs.content` (ContentHelpers) for full mode-aware operations. The UI uses the binding directly; filesystem operations use ContentHelpers.
 
-3. **Persistence extension inline**: The IndexedDB extension is defined inline in `fs-state.svelte.ts` rather than imported, because it needs `onDocumentOpen` which the existing `indexeddbPersistence` from `@epicenter/hq/extensions/sync/web` doesn't provide.
+3. **Persistence extension inline**: The IndexedDB extension is defined inline in `fs-state.svelte.ts` rather than imported, because it needs `onDocumentOpen` which the existing `indexeddbPersistence` from `@epicenter/workspace/extensions/sync/web` doesn't provide.
 
 ### Known Issues
 

--- a/specs/20260220T044539-pure-sync-server.md
+++ b/specs/20260220T044539-pure-sync-server.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-02-20
 **Status**: Superseded
-**Superseded by**: `specs/20260220T080000-plugin-first-server-architecture.md` — all capabilities (on-demand rooms, 3 auth modes, zero @epicenter/hq dependency) are included via `createSyncPlugin()` + `createSyncServer()` wrapper.
+**Superseded by**: `specs/20260220T080000-plugin-first-server-architecture.md` — all capabilities (on-demand rooms, 3 auth modes, zero @epicenter/workspace dependency) are included via `createSyncPlugin()` + `createSyncServer()` wrapper.
 **Author**: Braden + Claude
 **Relates to**: `specs/20260219T195800-server-architecture-rethink.md` (Layers 0+1)
 
@@ -38,7 +38,7 @@ This creates three problems:
 
 2. **Zero server-side auth.** The client (`@epicenter/sync`) sends `?token=xxx` in the WebSocket URL. The server never reads it. Any connection is accepted. The three auth modes exist only client-side.
 
-3. **Tight coupling to `@epicenter/hq`.** You can't run a sync server without importing the entire workspace system. The server's `package.json` has `@epicenter/hq` as a peer dependency.
+3. **Tight coupling to `@epicenter/workspace`.** You can't run a sync server without importing the entire workspace system. The server's `package.json` has `@epicenter/workspace` as a peer dependency.
 
 ### Desired State
 
@@ -104,7 +104,7 @@ The 102 extension is backward-compatible — standard y-websocket clients ignore
 | Room eviction                 | 60s after last disconnect (existing)                               | Already implemented and tested. Keep as-is.                                    |
 | Doc persistence               | Out of scope (in-memory only)                                      | Persistence is a Layer 4 concern (see broader spec). Sync relay = ephemeral.   |
 | Separate from full server     | `createSyncServer` alongside `createServer`                        | Full server composes sync + tables + actions. Sync server is the minimal core. |
-| No `@epicenter/hq` dependency | Sync server depends only on `yjs`, `lib0`, `y-protocols`, `elysia` | Removes coupling. Full server still depends on hq for tables/actions.          |
+| No `@epicenter/workspace` dependency | Sync server depends only on `yjs`, `lib0`, `y-protocols`, `elysia` | Removes coupling. Full server still depends on hq for tables/actions.          |
 
 ## Architecture
 
@@ -164,9 +164,9 @@ New function that composes the sync plugin into a standalone server.
 - [ ] **2.4** Export from `packages/server/src/index.ts`
 - [ ] **2.5** Integration test: two `@epicenter/sync` clients sync through `createSyncServer`
 
-### Phase 3: Decouple from `@epicenter/hq` (optional, future)
+### Phase 3: Decouple from `@epicenter/workspace` (optional, future)
 
-- [ ] **3.1** Move sync-only code to a subpath export (`@epicenter/server/sync`) that doesn't import `@epicenter/hq`
+- [ ] **3.1** Move sync-only code to a subpath export (`@epicenter/server/sync`) that doesn't import `@epicenter/workspace`
 - [ ] **3.2** Keep `@epicenter/server` (full) depending on hq for tables/actions
 - [ ] **3.3** Or: extract sync server to its own package (`@epicenter/sync-server`)
 
@@ -240,7 +240,7 @@ Already handled correctly by existing code.
 - [ ] MESSAGE_SYNC_STATUS (102) heartbeat echo still works
 - [ ] Room eviction still works (60s after last disconnect)
 - [ ] Existing `createServer` still works (backward compatible)
-- [ ] No `@epicenter/hq` import in the sync-only code path
+- [ ] No `@epicenter/workspace` import in the sync-only code path
 
 ## References
 

--- a/specs/20260220T080000-plugin-first-server-architecture.md
+++ b/specs/20260220T080000-plugin-first-server-architecture.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-Restructure `@epicenter/server` around two independent Elysia plugins: a sync plugin with zero `@epicenter/hq` dependency and a workspace plugin that provides REST tables, actions, and OpenAPI. Convenience wrappers (`createSyncServer`, `createServer`) compose the plugins for users who don't want to touch Elysia directly. The sync plugin fixes the ws identity tracking bug and adds auth.
+Restructure `@epicenter/server` around two independent Elysia plugins: a sync plugin with zero `@epicenter/workspace` dependency and a workspace plugin that provides REST tables, actions, and OpenAPI. Convenience wrappers (`createSyncServer`, `createServer`) compose the plugins for users who don't want to touch Elysia directly. The sync plugin fixes the ws identity tracking bug and adds auth.
 
 ## Motivation
 
@@ -114,7 +114,7 @@ Key behaviors:
 | Decision               | Choice                                                                | Rationale                                                                                                                                                        |
 | ---------------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Architecture           | Two Elysia plugins + convenience wrappers                             | Plugins are the primitive. Wrappers are sugar. Matches how Elysia is designed.                                                                                   |
-| Sync plugin dependency | Zero `@epicenter/hq` imports                                          | Sync only needs `yjs`, `lib0`, `y-protocols`, `elysia`. Decouples completely.                                                                                    |
+| Sync plugin dependency | Zero `@epicenter/workspace` imports                                          | Sync only needs `yjs`, `lib0`, `y-protocols`, `elysia`. Decouples completely.                                                                                    |
 | Room creation          | On-demand by default, `getDoc` override for workspace-integrated mode | Standalone mode creates docs automatically. Workspace mode provides existing docs.                                                                               |
 | Connection tracking    | `ws.raw` keyed `Map`, not `Set`                                       | Fixes the identity bug by construction. `Map<object, { send }>` keyed by `ws.raw`.                                                                               |
 | Auth modes             | Open (no auth), shared token, verify function                         | Matches the three modes in `@epicenter/sync` client. Verify function enables JWTs without us implementing JWT.                                                   |
@@ -150,9 +150,9 @@ Key behaviors:
 │   └── POST /:room/doc (update)                                   │
 │                                                                  │
 │   Depends on:                    Depends on:                     │
-│     elysia, yjs, lib0,            elysia, @epicenter/hq          │
+│     elysia, yjs, lib0,            elysia, @epicenter/workspace          │
 │     y-protocols                                                  │
-│   NO @epicenter/hq               (tables, actions, types)        │
+│   NO @epicenter/workspace               (tables, actions, types)        │
 └────────────────────────────────────────────────────────────────┘
                     │
                     ▼
@@ -230,9 +230,9 @@ packages/server/
       protocol.ts               # unchanged — encode/decode functions
 ```
 
-**Critical**: `src/sync/index.ts` must NOT import from `@epicenter/hq`. The `./sync` subpath export is the dependency firewall.
+**Critical**: `src/sync/index.ts` must NOT import from `@epicenter/workspace`. The `./sync` subpath export is the dependency firewall.
 
-`src/index.ts` re-exports `createServer` and `createWorkspacePlugin`. It does NOT re-export sync — users import sync from `@epicenter/server/sync` to avoid pulling in `@epicenter/hq`.
+`src/index.ts` re-exports `createServer` and `createWorkspacePlugin`. It does NOT re-export sync — users import sync from `@epicenter/server/sync` to avoid pulling in `@epicenter/workspace`.
 
 ### How createServer() Composes the Plugins
 
@@ -474,7 +474,7 @@ for (const [raw, conn] of room.conns) {
 - [ ] **5.1** Create `packages/server/src/sync/index.ts` — exports `createSyncPlugin`, `createSyncServer`
 - [ ] **5.2** Update `packages/server/src/index.ts` — exports `createServer`, `createWorkspacePlugin`, `DEFAULT_PORT`
 - [ ] **5.3** Add `"./sync": "./src/sync/index.ts"` to `package.json` exports
-- [ ] **5.4** Verify `@epicenter/server/sync` has zero `@epicenter/hq` imports (grep for it)
+- [ ] **5.4** Verify `@epicenter/server/sync` has zero `@epicenter/workspace` imports (grep for it)
 - [ ] **5.5** Update existing tests
 - [ ] **5.6** Add new tests: sync plugin standalone mode, auth modes, room manager lifecycle
 
@@ -547,7 +547,7 @@ for (const [raw, conn] of room.conns) {
 - [ ] Awareness broadcast doesn't echo back to sender (fixes the current bug)
 - [ ] `createServer(client)` still works identically (backward compatible)
 - [ ] `createServer(client, { auth: { token: 'secret' } })` adds auth to sync
-- [ ] `import { createSyncPlugin } from '@epicenter/server/sync'` has zero `@epicenter/hq` imports
+- [ ] `import { createSyncPlugin } from '@epicenter/server/sync'` has zero `@epicenter/workspace` imports
 - [ ] MESSAGE_SYNC_STATUS (102) heartbeat echo still works
 - [ ] Existing server tests pass unchanged (or with minimal updates)
 - [ ] Power user can mount `createSyncPlugin` on their own Elysia app
@@ -622,7 +622,7 @@ This replaced the earlier `routePrefix` config + `Object.values(params)[0]` extr
 
 - `bun run typecheck` — clean after every phase
 - `bun test` — 56 tests pass, 103 expect() calls, 0 failures
-- `grep @epicenter/hq src/sync/` — zero imports (only the JSDoc comment about the firewall)
+- `grep @epicenter/workspace src/sync/` — zero imports (only the JSDoc comment about the firewall)
 - `protocol.ts` — untouched
 - `tables.ts`, `actions.ts` — untouched
 - Backward compatibility: `createServer(client, { port })` signature unchanged, additive `auth` option

--- a/specs/20260220T195900-deprecate-dynamic-api.md
+++ b/specs/20260220T195900-deprecate-dynamic-api.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-Remove the Dynamic workspace API (`@epicenter/hq/dynamic`) and promote the Static API to the primary (and only) workspace API. The `static/` folder becomes the top-level workspace implementation; the `dynamic/` folder is deleted. The extensions coupled to Dynamic (sqlite, markdown, revision-history) are deleted alongside it since no app imports them.
+Remove the Dynamic workspace API (`@epicenter/workspace/dynamic`) and promote the Static API to the primary (and only) workspace API. The `static/` folder becomes the top-level workspace implementation; the `dynamic/` folder is deleted. The extensions coupled to Dynamic (sqlite, markdown, revision-history) are deleted alongside it since no app imports them.
 
 ## Motivation
 
@@ -33,7 +33,7 @@ This creates problems:
 
 4. **Architectural overhead with no payoff**: The Dynamic API layers CellStore → RowStore → TableHelper on top of a flat `Y.Array`. The RowStore maintains an in-memory index to compensate for the flat storage model. The Sheet's nested `Y.Map` gives O(1) row lookups without an index.
 
-5. **Confusing developer experience**: New code has to choose between `@epicenter/hq/dynamic` and `@epicenter/hq/static` without a clear reason to pick one over the other. The naming implies "dynamic = flexible, static = rigid," which is backwards: the Dynamic API has fixed schemas while the Sheet structure is truly dynamic.
+5. **Confusing developer experience**: New code has to choose between `@epicenter/workspace/dynamic` and `@epicenter/workspace/static` without a clear reason to pick one over the other. The naming implies "dynamic = flexible, static = rigid," which is backwards: the Dynamic API has fixed schemas while the Sheet structure is truly dynamic.
 
 6. **The coupled extensions are dead code**: The sqlite, markdown, and revision-history extensions import Dynamic types directly. No app in the monorepo (`apps/epicenter`, `apps/tab-manager`, `apps/fs-explorer`) actually imports these extensions. They exist only as internal code within `packages/epicenter/`. Deleting Dynamic means deleting these extensions too, which simplifies the migration enormously.
 
@@ -72,13 +72,13 @@ packages/epicenter/src/
 └── shared/      ← Common utilities
 ```
 
-Imports go from `@epicenter/hq/static` to `@epicenter/hq` (or a new subpath like `@epicenter/hq/workspace`). The `dynamic/` folder and its coupled extensions are gone. Consumers that need "Notion-like" dynamic columns use the Sheet data structure from `@epicenter/filesystem`.
+Imports go from `@epicenter/workspace/static` to `@epicenter/workspace` (or a new subpath like `@epicenter/workspace/workspace`). The `dynamic/` folder and its coupled extensions are gone. Consumers that need "Notion-like" dynamic columns use the Sheet data structure from `@epicenter/filesystem`.
 
 ## Research Findings
 
 ### What Each Consumer Actually Uses
 
-Grepping the codebase for `@epicenter/hq/dynamic` imports reveals:
+Grepping the codebase for `@epicenter/workspace/dynamic` imports reveals:
 
 | Consumer                                          | What it imports                                                                              | What it actually needs                                                      |
 | ------------------------------------------------- | -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
@@ -86,7 +86,7 @@ Grepping the codebase for `@epicenter/hq/dynamic` imports reveals:
 | `apps/epicenter/` workspace service               | `WorkspaceDefinition` type                                                                   | Type — migrate to Static equivalent                                         |
 | `apps/epicenter/` yjs workspace                   | `createWorkspace`, `Extension`, `ExtensionContext`                                           | Core workspace — migrate to Static `createWorkspace`                        |
 | `apps/epicenter/` workspace-persistence           | `ExtensionContext` type                                                                      | Type only — migrate to Static                                               |
-| `apps/tab-manager/` (2 files)                     | `generateId`                                                                                 | Just the ID utility — already exported from root `@epicenter/hq`            |
+| `apps/tab-manager/` (2 files)                     | `generateId`                                                                                 | Just the ID utility — already exported from root `@epicenter/workspace`            |
 | `extensions/sqlite`                               | `ExtensionContext`, schema types, `Row`, `TableDefinition`, Drizzle converters               | **Dead code** — no app imports this extension                               |
 | `extensions/markdown`                             | `ExtensionContext`, schema types, `Field`, `Row`, `TableHelper`, `TableById`, `getTableById` | **Dead code** — no app imports this extension                               |
 | `extensions/revision-history`                     | `ExtensionContext`, schema types                                                             | **Dead code** — no app imports this extension                               |
@@ -182,13 +182,13 @@ Files to delete (confirmed via grep and glob):
 | Decision                                   | Choice                                                     | Rationale                                                                                                                                                           |
 | ------------------------------------------ | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Folder rename                              | `static/` → `workspace/` (or promote to root)              | "Static" only made sense as a contrast to "Dynamic." Without the contrast, it's just the workspace API.                                                             |
-| Export path                                | `@epicenter/hq/static` → `@epicenter/hq` (merge into root) | Reduces import ceremony. Most consumers just want `createWorkspace`.                                                                                                |
+| Export path                                | `@epicenter/workspace/static` → `@epicenter/workspace` (merge into root) | Reduces import ceremony. Most consumers just want `createWorkspace`.                                                                                                |
 | Migration approach                         | Two phases: migrate apps, then delete                      | App imports are shallow (path changes only). Extensions are dead code. No need for phased re-exports.                                                               |
 | Dead extensions                            | Delete alongside Dynamic                                   | sqlite, markdown, revision-history: zero app imports. Migrating them would be the most expensive part for no benefit.                                               |
 | `./node` export                            | Delete                                                     | Dead. Only self-references in its own JSDoc.                                                                                                                        |
 | `typebox` dependency                       | Remove                                                     | Only used by Dynamic's schema system and `extensions/sqlite/builders.ts` (which is being deleted). After removal, verify no imports remain.                         |
 | Comparison test files                      | Keep                                                       | `ymap-simplicity-case.test.ts` and `y-keyvalue-comparison.test.ts` document the reasoning behind this decision. They're in `shared/`, not `dynamic/`.               |
-| Backward compat for `@epicenter/hq/static` | Temporary re-export                                        | Keep the old path working during migration with a deprecation comment. Remove in a follow-up.                                                                       |
+| Backward compat for `@epicenter/workspace/static` | Temporary re-export                                        | Keep the old path working during migration with a deprecation comment. Remove in a follow-up.                                                                       |
 | Display metadata (table name, icon)        | Defer                                                      | Dynamic definitions had `name`, `icon`, `description`. Static doesn't. No app currently depends on this through the Static API. Add if migration surfaces the need. |
 | Sync extension                             | Keep, migrate `ExtensionContext` import                    | `sync/desktop.ts` imports `ExtensionContext` from Dynamic. Single line change to import from Static.                                                                |
 
@@ -197,7 +197,7 @@ Files to delete (confirmed via grep and glob):
 ### Before
 
 ```
-@epicenter/hq
+@epicenter/workspace
 ├── .                  → shared utilities (Id, actions, lifecycle)
 ├── ./dynamic          → Dynamic workspace API (field-based)
 │   ├── schema/        → Field factories, TypeBox converters
@@ -218,7 +218,7 @@ Files to delete (confirmed via grep and glob):
 ### After
 
 ```
-@epicenter/hq
+@epicenter/workspace
 ├── .                  → Workspace API + shared utilities (merged)
 │   ├── define-table   → defineTable with versioning
 │   ├── create-*       → createWorkspace, createTables, createKv
@@ -234,7 +234,7 @@ Files to delete (confirmed via grep and glob):
 
 The app-level migration is shallow. No logic changes, just import paths.
 
-- [x] **1.1** `apps/tab-manager/` (2 files): Changed `import { generateId } from '@epicenter/hq/dynamic'` to `import { generateId } from '@epicenter/hq'`.
+- [x] **1.1** `apps/tab-manager/` (2 files): Changed `import { generateId } from '@epicenter/workspace/dynamic'` to `import { generateId } from '@epicenter/workspace'`.
 - [x] **1.2** `apps/epicenter/src/lib/templates/whispering.ts`: Rewrote from Dynamic field factories to Static `defineTable` + arktype schemas.
 - [x] **1.3** `apps/epicenter/src/lib/templates/entries.ts`: Same rewrite as 1.2.
 - [x] **1.4** `apps/epicenter/src/lib/workspaces/dynamic/service.ts`: Defined local `WorkspaceDefinition` type (display metadata only), removed Dynamic import.
@@ -244,7 +244,7 @@ The app-level migration is shallow. No logic changes, just import paths.
 - [x] **1.8** `apps/epicenter/src/routes/(workspace)/workspaces/[id]/+layout.ts`: Updated to pass workspace ID instead of definition.
 - [x] **1.8b** `apps/epicenter/src/routes/.../tables/[tableId]/+page.svelte`: Rewrote for Static API (property access, data-derived columns).
 - [x] **1.8c** `apps/epicenter/src/routes/.../settings/[key]/+page.svelte`: Simplified to not-found state (no runtime KV schema).
-- [x] **1.9** Verified: zero `@epicenter/hq/dynamic` imports in `apps/`. Pre-existing errors only.
+- [x] **1.9** Verified: zero `@epicenter/workspace/dynamic` imports in `apps/`. Pre-existing errors only.
 
 **NOTE on 1.2-1.3**: This is the only non-trivial step. The Dynamic templates define workspaces like:
 
@@ -279,7 +279,7 @@ Every field factory (`id()`, `text()`, `select()`, etc.) must be translated to a
 - [x] **3.2** Merged Static exports into root `src/index.ts` (defineTable, defineWorkspace, createWorkspace, all types, introspection, validation).
 - [x] **3.3** Updated `package.json` exports: removed `"./dynamic"` and `"./node"`. Kept `"./static"` as alias.
 - [x] **3.4** Kept `"./static"` export pointing to `./src/static/index.ts` for backward compatibility.
-- [ ] **3.5** Existing `@epicenter/hq/static` imports left as-is (still works via the kept export). Migration deferred.
+- [ ] **3.5** Existing `@epicenter/workspace/static` imports left as-is (still works via the kept export). Migration deferred.
 - [x] **3.6** Deleted `src/dynamic/` folder entirely (58 files).
 - [x] **3.7** Deleted `src/shared/cell-keys.ts` and `cell-keys.test.ts`.
 - [x] **3.8** Deleted `src/extensions/sqlite/` folder entirely.
@@ -298,7 +298,7 @@ Every field factory (`id()`, `text()`, `select()`, etc.) must be translated to a
 - [ ] **4.5** Kept `"./static"` re-export for backward compatibility.
 - [x] **4.6** `bun run typecheck` — 0 source errors (149 pre-existing test file errors only).
 - [x] **4.7** `bun test` — 377 pass, 0 fail.
-- [x] **4.8** Zero imports of `@epicenter/hq/dynamic` or `@epicenter/hq/node` anywhere in the monorepo.
+- [x] **4.8** Zero imports of `@epicenter/workspace/dynamic` or `@epicenter/workspace/node` anywhere in the monorepo.
 - [ ] **4.9** App build — not tested (requires Tauri build environment). Typecheck passes.
 - [x] **4.10** Deleted `scripts/ymap-vs-ykeyvalue-benchmark.ts`.
 
@@ -329,11 +329,11 @@ Currently exports sqlite, markdown, revision-history, sync, and error-logger. Af
 | App templates fail to compile after field factory → arktype migration | Medium     | High   | Phase 1 is first; verify with typecheck before proceeding                                       |
 | Static `ExtensionContext` shape breaks sync extension                 | Low        | Medium | Check that sync only uses `{ ydoc }` from context                                               |
 | Removing typebox breaks something unexpected                          | Low        | Medium | Grep for all typebox imports before removing                                                    |
-| External consumers of `@epicenter/hq/dynamic` exist outside monorepo  | Very Low   | Medium | Package is `0.0.1`; likely no external consumers. Temporary re-export at `./static` for safety. |
+| External consumers of `@epicenter/workspace/dynamic` exist outside monorepo  | Very Low   | Medium | Package is `0.0.1`; likely no external consumers. Temporary re-export at `./static` for safety. |
 
 ## Success Criteria
 
-- [x] Zero imports of `@epicenter/hq/dynamic` or `@epicenter/hq/node` across the monorepo
+- [x] Zero imports of `@epicenter/workspace/dynamic` or `@epicenter/workspace/node` across the monorepo
 - [x] `src/dynamic/` folder deleted
 - [x] `src/extensions/sqlite/`, `src/extensions/markdown/`, `src/extensions/revision-history/` deleted
 - [x] `typebox` removed from package.json dependencies
@@ -346,7 +346,7 @@ Currently exports sqlite, markdown, revision-history, sync, and error-logger. Af
 
 ### Summary
 
-Removed the entire Dynamic workspace API and its coupled extensions. ~17,900 lines deleted across 58 files. The Static API is now the sole workspace API, with its exports merged into the root `@epicenter/hq` package.
+Removed the entire Dynamic workspace API and its coupled extensions. ~17,900 lines deleted across 58 files. The Static API is now the sole workspace API, with its exports merged into the root `@epicenter/workspace` package.
 
 ### Key Decisions Made During Implementation
 
@@ -360,13 +360,13 @@ Removed the entire Dynamic workspace API and its coupled extensions. ~17,900 lin
 
 5. **Settings page simplified**: Current templates don't define KV stores, so the settings detail page shows "not found" state.
 
-6. **Kept `./static` export as alias**: Rather than breaking existing `@epicenter/hq/static` imports, kept the export path working. Migration to `@epicenter/hq` deferred.
+6. **Kept `./static` export as alias**: Rather than breaking existing `@epicenter/workspace/static` imports, kept the export path working. Migration to `@epicenter/workspace` deferred.
 
 7. **Renamed `src/static/` → `src/workspace/`**: The "static" name only made sense as contrast to "dynamic." Now that the Dynamic API is gone, the folder is simply the workspace implementation. All internal imports updated. The `./static` package.json export alias is preserved (points to new path) for backward compatibility with external consumers.
 
 ### Deferred Work
 
-- Migrate remaining external `@epicenter/hq/static` imports to `@epicenter/hq` (tab-manager, fs-explorer, server, filesystem packages)
+- Migrate remaining external `@epicenter/workspace/static` imports to `@epicenter/workspace` (tab-manager, fs-explorer, server, filesystem packages)
 - Update `packages/epicenter/README.md` and `AGENTS.md`
 - Remove the `./static` re-export alias once all consumers migrated
 - Re-implement sqlite/markdown extensions against the Workspace API if needed in future
@@ -376,7 +376,7 @@ Removed the entire Dynamic workspace API and its coupled extensions. ~17,900 lin
 - **Tests**: 377 pass, 0 fail
 - **Package typecheck**: 0 source errors (149 pre-existing in test files)
 - **App typecheck**: 233 errors, all pre-existing
-- **Import grep**: Zero `@epicenter/hq/dynamic` or `@epicenter/hq/node` anywhere
+- **Import grep**: Zero `@epicenter/workspace/dynamic` or `@epicenter/workspace/node` anywhere
 
 ## References
 

--- a/specs/20260220T195900-unify-document-extension-shape.md
+++ b/specs/20260220T195900-unify-document-extension-shape.md
@@ -36,7 +36,7 @@ Both do the same thing: create an IndexedDB persistence provider for a Y.Doc. Bu
 
 ```typescript
 // Line 7: imports the built-in helper for workspace-level
-import { indexeddbPersistence } from '@epicenter/hq/extensions/sync/web';
+import { indexeddbPersistence } from '@epicenter/workspace/extensions/sync/web';
 // Line 11: imports the raw class for document-level
 import { IndexeddbPersistence } from 'y-indexeddb';
 ```

--- a/specs/20260221T161919-extract-cli-package.md
+++ b/specs/20260221T161919-extract-cli-package.md
@@ -1,4 +1,4 @@
-# Extract CLI from @epicenter/hq into packages/cli
+# Extract CLI from @epicenter/workspace into packages/cli
 
 ## Goal
 
@@ -8,7 +8,7 @@ Move `packages/epicenter/src/cli/` into a standalone `packages/cli/` package (`@
 
 1. **Dependency cleanup**: `yargs` (+ `@types/yargs`) is a CLI-only dependency polluting the core library
 2. **Logical separation**: The CLI is already semi-separated (`./cli` subpath export, own README)
-3. **Architecture clarity**: Keeps `@epicenter/hq` focused on the workspace runtime
+3. **Architecture clarity**: Keeps `@epicenter/workspace` focused on the workspace runtime
 4. **Monorepo hygiene**: Clear boundaries between runtime and tooling packages
 
 ## Current State Analysis
@@ -42,7 +42,7 @@ src/cli/
 
 ### Import Dependencies (Files Requiring Rewiring)
 
-Only **2 files** import from `@epicenter/hq` internals:
+Only **2 files** import from `@epicenter/workspace` internals:
 
 1. **discovery.ts**
    ```typescript
@@ -51,7 +51,7 @@ Only **2 files** import from `@epicenter/hq` internals:
    import type { AnyWorkspaceClient } from '../workspace/types';
    
    // Target
-   import type { ProjectDir, AnyWorkspaceClient } from '@epicenter/hq';
+   import type { ProjectDir, AnyWorkspaceClient } from '@epicenter/workspace';
    ```
 
 2. **command-builder.ts**
@@ -62,7 +62,7 @@ Only **2 files** import from `@epicenter/hq` internals:
    import { standardSchemaToJsonSchema } from '../shared/standard-schema/to-json-schema';
    
    // Target
-   import { type Actions, iterateActions, standardSchemaToJsonSchema } from '@epicenter/hq';
+   import { type Actions, iterateActions, standardSchemaToJsonSchema } from '@epicenter/workspace';
    ```
 
 ### Test Files (cli.test.ts, command-builder.test.ts, json-schema-to-yargs.test.ts)
@@ -76,7 +76,7 @@ Same import pattern as their source files.
 
 ## Implementation Steps
 
-### Step 1: Export standardSchemaToJsonSchema from @epicenter/hq
+### Step 1: Export standardSchemaToJsonSchema from @epicenter/workspace
 
 **File**: `packages/epicenter/src/index.ts`
 
@@ -129,7 +129,7 @@ packages/cli/
     "epicenter": "./src/bin.ts"
   },
   "dependencies": {
-    "@epicenter/hq": "workspace:*",
+    "@epicenter/workspace": "workspace:*",
     "wellcrafted": "catalog:",
     "yargs": "catalog:"
   },
@@ -153,7 +153,7 @@ import type { ProjectDir } from '../shared/types';
 import type { AnyWorkspaceClient } from '../workspace/types';
 
 // TO:
-import type { ProjectDir, AnyWorkspaceClient } from '@epicenter/hq';
+import type { ProjectDir, AnyWorkspaceClient } from '@epicenter/workspace';
 ```
 
 **command-builder.ts**:
@@ -164,12 +164,12 @@ import { iterateActions } from '../shared/actions';
 import { standardSchemaToJsonSchema } from '../shared/standard-schema/to-json-schema';
 
 // TO:
-import { type Actions, iterateActions, standardSchemaToJsonSchema } from '@epicenter/hq';
+import { type Actions, iterateActions, standardSchemaToJsonSchema } from '@epicenter/workspace';
 ```
 
 **Test files** (cli.test.ts, command-builder.test.ts, json-schema-to-yargs.test.ts):
 - Same import rewiring pattern as source files
-- Any `../shared/*` imports → `@epicenter/hq`
+- Any `../shared/*` imports → `@epicenter/workspace`
 
 ### Step 6: Clean Up packages/epicenter/
 
@@ -227,7 +227,7 @@ All should pass with no type errors or missing imports.
 
 ## Todo List
 
-- [ ] Export standardSchemaToJsonSchema from @epicenter/hq
+- [ ] Export standardSchemaToJsonSchema from @epicenter/workspace
 - [ ] Create packages/cli/ directory structure
 - [ ] Create packages/cli/package.json
 - [ ] Create packages/cli/tsconfig.json
@@ -264,7 +264,7 @@ All changes are isolated — no complex merge conflicts expected.
 
 ## Notes
 
-- The CLI doesn't import from other @epicenter/* packages at the code level (only @epicenter/hq)
+- The CLI doesn't import from other @epicenter/* packages at the code level (only @epicenter/workspace)
 - Dynamic imports like `await import('@epicenter/server')` will continue to work (that's the design)
 - No changes to the bin entry point — just moved to a new location
 - The workspace ID convention ("epicenter.config.ts") remains unchanged

--- a/specs/20260221T190252-ai-chat-tab.md
+++ b/specs/20260221T190252-ai-chat-tab.md
@@ -94,7 +94,7 @@ interface ToolResultPart {
 - **TanStack AI message format mismatch**: Server's Elysia uses strict body validation; TanStack AI may send extra fields → Elysia strips unknown properties by default, not a blocker
 - **Chrome extension CSP**: Sidepanel should be able to fetch localhost, but `host_permissions: ['<all_urls>']` already covers this → Verified, low risk
 - **Message format**: TanStack AI uses `message.parts[0].content`, not `message.content` → Plan stores parts array directly in Y.Doc
-- **Y.Doc schema addition**: New tables in existing Y.Doc are handled gracefully by `@epicenter/hq` (new Y.Map keys appear as needed)
+- **Y.Doc schema addition**: New tables in existing Y.Doc are handled gracefully by `@epicenter/workspace` (new Y.Map keys appear as needed)
 - **Empty state UI**: Need to handle no-messages state → Plan includes empty state in chat component task
 - **Error state UX**: Need to handle server errors, unreachable → Plan includes inline error display
 

--- a/specs/20260225T120000-rename-epicenter-hq-package.md
+++ b/specs/20260225T120000-rename-epicenter-hq-package.md
@@ -1,0 +1,97 @@
+# Rename `@epicenter/workspace` to `@epicenter/workspace`
+
+## Problem
+
+The package `@epicenter/workspace` (`packages/epicenter/`) is the core library of the monorepo. Its API is entirely about defining and creating workspaces:
+
+- `defineWorkspace()`, `defineTable()`, `defineKv()`
+- `createWorkspace()` with `.withExtension()` / `.withActions()`
+- `TableHelper`, `KvHelper`, `AwarenessHelper`, `Documents`
+- Action system (`defineQuery`, `defineMutation`)
+
+The name "hq" (headquarters) is a metaphor for "the central package" but communicates nothing about what the package actually does. A new developer reading `import { createWorkspace } from '@epicenter/workspace'` has to wonder: what is "hq"? Why not just call it what it is?
+
+## Decision
+
+Rename `@epicenter/workspace` to `@epicenter/workspace`.
+
+### Why `workspace` and not alternatives?
+
+| Candidate | Verdict |
+|---|---|
+| `@epicenter/workspace` | Matches the API exactly. You `defineWorkspace`, you `createWorkspace`, you get a `WorkspaceClient`. The package IS the workspace SDK. |
+| `@epicenter/core` | Generic. Every monorepo has a "core" package. Tells you nothing. |
+| `@epicenter/sdk` | Too broad. An SDK for what? The workspace. Just say workspace. |
+| `@epicenter/workspaces-api` | Overly formal. The `-api` suffix is redundant when the package is already a code library. |
+| `@epicenter/workspace` (keep) | Cute but confusing. "HQ" as a concept has no future — it doesn't map to any real domain concept. |
+
+### What would "hq" refer to in the future?
+
+Nothing meaningful. The name was chosen as a catch-all for "the main package," but as the monorepo matured, the package's identity crystallized around workspaces specifically. There's no future feature where "hq" becomes the right word. The package won't grow into a general-purpose toolkit — it will stay focused on workspace definition, creation, and the extension/action system around workspaces.
+
+## Scope
+
+### What changes
+
+1. **`packages/epicenter/package.json`**: `"name": "@epicenter/workspace"` becomes `"name": "@epicenter/workspace"`
+2. **All import statements** across the monorepo referencing `@epicenter/workspace` or its subpaths (`@epicenter/workspace/extensions`, `@epicenter/workspace/extensions/sync`, etc.) become `@epicenter/workspace/...`
+3. **All `package.json` dependency entries** referencing `@epicenter/workspace` become `@epicenter/workspace`
+4. **Internal docs, comments, and JSDoc** referencing `@epicenter/workspace`
+5. **`bun.lock`** regenerated after the rename
+
+### What does NOT change
+
+- The directory stays `packages/epicenter/` — the directory name is the project name, not the npm package name. No need to rename it.
+- No API changes. Every export stays identical.
+- No subpath export changes. `@epicenter/workspace/extensions/sync/web` etc. all keep their structure, just under the new scope.
+
+## Affected files
+
+### Direct dependency references (package.json files)
+
+These packages list `@epicenter/workspace` as a dependency or peer dependency:
+
+- `packages/filesystem/package.json`
+- `packages/ai/package.json`
+- `packages/server/package.json` (peerDependencies)
+- `packages/cli/package.json`
+- `apps/epicenter/package.json`
+- `apps/tab-manager/package.json`
+- `apps/tab-manager-markdown/package.json`
+- `apps/whispering/package.json`
+- `apps/fs-explorer/package.json`
+
+### Import statements (source files)
+
+Every `.ts` file importing from `@epicenter/workspace` or its subpaths. Key locations:
+
+- `apps/epicenter/src/lib/yjs/` — workspace creation and persistence
+- `apps/epicenter/src/lib/templates/` — workspace definitions
+- `apps/tab-manager/src/` — workspace definition, background, popup, commands, state
+- `apps/tab-manager-markdown/src/` — workspace creation
+- `apps/fs-explorer/src/` — workspace creation
+- `packages/filesystem/src/` — table helpers, types, documents
+- `packages/ai/src/` — action iteration
+- `packages/server/src/` — workspace plugin, routes, types
+- `packages/cli/src/` — action iteration, types
+
+### Docs and specs
+
+Many files in `specs/`, `docs/`, and `packages/epicenter/docs/` reference `@epicenter/workspace` in examples. These should be updated but are lower priority — they can be batch-updated with a find-and-replace.
+
+## Execution plan
+
+This is a mechanical rename. The safest approach:
+
+1. **Update `packages/epicenter/package.json`** — change the name field
+2. **Global find-and-replace** `@epicenter/workspace` with `@epicenter/workspace` across all `.ts`, `.json`, and `.md` files
+3. **Run `bun install`** to regenerate the lockfile
+4. **Run `bun run typecheck`** from root to verify nothing broke
+5. **Run tests** for the core package and key consumers
+6. **Single commit**: `refactor: rename @epicenter/workspace to @epicenter/workspace`
+
+## Decisions
+
+1. **Directory stays `packages/epicenter/`.** No directory rename for now.
+2. **`@epicenter/server/workspace` subpath keeps its name.** It exports `createWorkspacePlugin` (Elysia plugin that mounts workspace REST routes). The distinction between `@epicenter/workspace` (the SDK) and `@epicenter/server/workspace` (HTTP routes for workspaces) is clear enough — one is a package, the other is a server subpath.
+3. **Drop the `./static` backward-compat alias.** Since this is already a breaking rename, clean up the dead alias too. Remove the `"./static"` entry from the exports map in `package.json`.


### PR DESCRIPTION
The package `@epicenter/hq` has always been the workspace SDK — it exports `defineWorkspace`, `createWorkspace`, `defineTable`, `defineKv`, `TableHelper`, `KvHelper`, and the entire action system. The name "hq" (headquarters) is a metaphor for "the central package" that communicates nothing about what it actually does. A new developer reading `import { createWorkspace } from '@epicenter/hq'` has to wonder: what is hq?

This renames the package to `@epicenter/workspace`, which matches the API exactly.

```typescript
// Before
import { createWorkspace, defineWorkspace } from "@epicenter/hq";
import type { WorkspaceClient } from "@epicenter/hq";

// After
import { createWorkspace, defineWorkspace } from "@epicenter/workspace";
import type { WorkspaceClient } from "@epicenter/workspace";
```

Subpath imports follow the same pattern with no structural changes:

```typescript
// Before
import { createSyncExtension } from "@epicenter/hq/extensions/sync/web";

// After
import { createSyncExtension } from "@epicenter/workspace/extensions/sync/web";
```

The directory stays `packages/epicenter/` — only the npm package name changes. No API changes, no export changes, no behavior changes. Pure rename.

This also drops the `./static` backward-compat alias from the exports map in `packages/epicenter/package.json` — it was a dead alias kept around for a migration that completed long ago.

**Note**: this branch includes the `feat/conversation-handle-refactor` work (PR #1428) as its base, since that work added new files (`packages/ai`, updated `apps/tab-manager/src/lib/state/chat-state.svelte.ts`) that also needed the rename applied. The net new changes in this PR are the two commits at the tip: the rename across 144 files and a one-line formatting fix.

Tested: `bun run typecheck` passes (pre-existing failures in `@epicenter/ai` are unrelated), `bun test` passes for `packages/epicenter` (335/336, pre-existing failure) and `packages/server` (161/161).