### PR TITLE
refactor(errors): migrate service errors to semantic defineErrors variants

### DIFF
--- a/.agents/skills/create-tagged-error/SKILL.md
+++ b/.agents/skills/create-tagged-error/SKILL.md
@@ -1,130 +1,187 @@
 ---
 name: create-tagged-error
-description: How to define and use createTaggedError from wellcrafted. Use when creating new error types, updating error definitions, or reviewing error patterns. Covers withMessage (required terminal step), withContext, withCause, discriminated unions, and call site patterns.
+description: How to define and use defineErrors from wellcrafted. Use when creating new error types, updating error definitions, or reviewing error patterns. Covers variant factories, extractErrorMessage for cause, InferErrors/InferError for types, and call site patterns.
 metadata:
   author: epicenter
-  version: '1.0'
+  version: '2.0'
 ---
 
-# createTaggedError
+# defineErrors
 
 ## Import
 
 ```typescript
-import { createTaggedError } from 'wellcrafted/error';
+import {
+  defineErrors,
+  extractErrorMessage,
+  type InferErrors,
+  type InferError,
+} from 'wellcrafted/error';
 ```
 
 ## Core Rules
 
-1. `.withMessage(fn)` is **always required** — you cannot get factories without it
-2. `.withMessage(fn)` is **always last** — nothing chains after it
-3. `.withContext()` and `.withCause()` can appear in any order before `.withMessage()`
-4. Factory input: provide `context`/`cause`, **not** `message` (message is auto-computed)
-5. `message` is an optional override at call sites only
-6. Context must be `JsonObject` — no `Date`, `Error` instances, functions, or class instances
-7. Split monolithic errors into discriminated unions — 2–5 errors per service, each named by failure mode
-8. Use `ReturnType<typeof FooError>` to extract the type
+1. All variants for a service live in **one `defineErrors` call** — never spread them across multiple calls
+2. The factory function **returns `{ message, ...fields }`** — that is the entire API; no `.withMessage()`, `.withContext()`, or `.withCause()` chains
+3. **`cause: unknown`** is just a field like any other — accept it in the input and forward it in the return object
+4. **Call `extractErrorMessage(cause)` inside the factory**, never at the call site
+5. Each call like `MyError.Variant({ ... })` **returns `Err(...)` automatically** — no separate `FooErr` pair
+6. **Shadow the const with a same-name type** using `InferErrors` — `const FooError` / `type FooError`
+7. Use `InferError<typeof FooError.Variant>` to extract a single variant's type when needed
+8. Aim for 2–5 variants per service, each named by failure mode
 
 ## Patterns
 
-### 1. Simple error — static message
+### 1. Simple variant — no input, static message
 
 ```typescript
-const { RecorderBusyError, RecorderBusyErr } = createTaggedError('RecorderBusyError')
-  .withMessage(() => 'A recording is already in progress');
-
-RecorderBusyErr({});
-type RecorderBusyError = ReturnType<typeof RecorderBusyError>;
-```
-
-### 2. Error with context — message computed from structured data
-
-```typescript
-const { DbNotFoundError, DbNotFoundErr } = createTaggedError('DbNotFoundError')
-  .withContext<{ table: string; id: string }>()
-  .withMessage(({ context }) => `${context.table} '${context.id}' not found`);
-
-DbNotFoundErr({ context: { table: 'users', id: '123' } });
-// error.message → "users '123' not found"
-type DbNotFoundError = ReturnType<typeof DbNotFoundError>;
-```
-
-### 3. Error with optional context
-
-```typescript
-const { LogError, LogErr } = createTaggedError('LogError')
-  .withContext<{ file: string; line: number } | undefined>()
-  .withMessage(({ context }) =>
-    context ? `Parse failed at ${context.file}:${context.line}` : 'Parse failed'
-  );
-
-LogErr({});
-LogErr({ context: { file: 'app.ts', line: 42 } });
-type LogError = ReturnType<typeof LogError>;
-```
-
-### 4. Error with cause
-
-```typescript
-const { ServiceError, ServiceErr } = createTaggedError('ServiceError')
-  .withContext<{ operation: string }>()
-  .withCause<DbNotFoundError | undefined>()
-  .withMessage(({ context, cause }) =>
-    cause
-      ? `Operation '${context.operation}' failed: ${cause.message}`
-      : `Operation '${context.operation}' failed`
-  );
-
-type ServiceError = ReturnType<typeof ServiceError>;
-```
-
-### 5. Message override at call site (one-off cases)
-
-```typescript
-DbNotFoundErr({
-  message: 'The recording you are looking for has been deleted',
-  context: { table: 'recordings', id: '123' },
+export const RecorderError = defineErrors({
+  AlreadyRecording: () => ({
+    message: 'A recording is already in progress',
+  }),
 });
+export type RecorderError = InferErrors<typeof RecorderError>;
+
+// Call site
+return RecorderError.AlreadyRecording();
 ```
 
-## Discriminated Unions
-
-Prefer specific, named errors over one monolithic error per service. Aim for 2–5 errors per service, each named by failure mode.
+### 2. Variant with structured fields — message computed from input
 
 ```typescript
-const { RecorderBusyError, RecorderBusyErr } = createTaggedError('RecorderBusyError')
-  .withMessage(() => 'A recording is already in progress');
+export const DbError = defineErrors({
+  NotFound: ({ table, id }: { table: string; id: string }) => ({
+    message: `${table} '${id}' not found`,
+    table,
+    id,
+  }),
+});
+export type DbError = InferErrors<typeof DbError>;
 
-const { RecorderPermissionError, RecorderPermissionErr } = createTaggedError('RecorderPermissionError')
-  .withContext<{ device: string }>()
-  .withMessage(({ context }) => `Microphone permission denied for ${context.device}`);
+// Call site
+return DbError.NotFound({ table: 'users', id: '123' });
+// error.message → "users '123' not found"
+// error.table   → "users"
+// error.id      → "123"
+```
 
-const { RecorderDeviceError, RecorderDeviceErr } = createTaggedError('RecorderDeviceError')
-  .withContext<{ deviceId: string }>()
-  .withMessage(({ context }) => `Failed to acquire stream from device '${context.deviceId}'`);
+### 3. Variant with cause — extractErrorMessage inside the factory
 
-type RecorderServiceError = RecorderBusyError | RecorderPermissionError | RecorderDeviceError;
+```typescript
+import { extractErrorMessage } from 'wellcrafted/error';
+
+export const FfmpegError = defineErrors({
+  Service: ({ operation, cause }: { operation: string; cause: unknown }) => ({
+    message: `Failed to ${operation}: ${extractErrorMessage(cause)}`,
+    operation,
+    cause,
+  }),
+});
+export type FfmpegError = InferErrors<typeof FfmpegError>;
+
+// Call site — pass the raw caught error, never call extractErrorMessage here
+catch: (error) => FfmpegError.Service({ operation: 'compress audio', cause: error }),
+```
+
+### 4. Multiple variants in one object — discriminated union built-in
+
+```typescript
+export const DeviceStreamError = defineErrors({
+  PermissionDenied: ({ cause }: { cause: unknown }) => ({
+    message: `Microphone permission denied. ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+  DeviceConnectionFailed: ({
+    deviceId,
+    cause,
+  }: {
+    deviceId: string;
+    cause: unknown;
+  }) => ({
+    message: `Unable to connect to device '${deviceId}'. ${extractErrorMessage(cause)}`,
+    deviceId,
+    cause,
+  }),
+  NoDevicesFound: () => ({
+    message: "No microphones found. Check your connections and try again.",
+  }),
+});
+export type DeviceStreamError = InferErrors<typeof DeviceStreamError>;
+// DeviceStreamError is automatically the union of all three variants
+
+// Extracting a single variant type
+type NoDevicesFoundError = InferError<typeof DeviceStreamError.NoDevicesFound>;
+```
+
+### 5. Simple service error — pass-through message from caller
+
+```typescript
+export const RecorderError = defineErrors({
+  Service: ({ message }: { message: string }) => ({ message }),
+});
+export type RecorderError = InferErrors<typeof RecorderError>;
+
+// Call site
+return RecorderError.Service({ message: 'Already recording.' });
+```
+
+## Type Extraction
+
+```typescript
+// Full union type for all variants
+type MyServiceError = InferErrors<typeof MyServiceError>;
+
+// Single variant type
+type NotFoundError = InferError<typeof MyServiceError.NotFound>;
 ```
 
 ## Anti-Patterns
 
 ```typescript
-// WRONG — missing .withMessage()
-const { FooError } = createTaggedError('FooError'); // TS error!
+// WRONG — old createTaggedError API
+import { createTaggedError } from 'wellcrafted/error';
+const { FooError, FooErr } = createTaggedError('FooError')
+  .withContext<{ id: string }>()
+  .withMessage(({ context }) => `Not found: ${context.id}`);
 
-// WRONG — message as primary factory input (old API)
-FooErr({ message: 'Something failed' });
+// WRONG — calling extractErrorMessage at the call site
+catch: (error) => MyError.Failed({ message: extractErrorMessage(error) });
+// CORRECT — pass raw cause, call extractErrorMessage inside the factory
+catch: (error) => MyError.Failed({ cause: error });
 
-// WRONG — chaining after .withMessage()
-createTaggedError('FooError').withMessage(() => 'x').withContext<{}>(); // TS error
+// WRONG — one defineErrors per variant (defeats the namespace grouping)
+const BusyError = defineErrors({ BusyError: () => ({ message: 'Busy' }) });
+const PermError = defineErrors({ PermError: () => ({ message: 'No perm' }) });
+// CORRECT — all variants for a service in one call
+const RecorderError = defineErrors({
+  Busy: () => ({ message: 'A recording is already in progress' }),
+  PermissionDenied: () => ({ message: 'Microphone permission denied' }),
+});
 
-// WRONG — Date in context (not JSON-serializable)
-.withContext<{ createdAt: Date }>()
+// WRONG — using ReturnType instead of InferErrors
+type FooError = ReturnType<typeof FooError>;
+// CORRECT
+type FooError = InferErrors<typeof FooError>;
 
-// WRONG — monolithic error
-const { RecorderServiceError } = createTaggedError('RecorderServiceError')
-  .withMessage(() => 'Recorder error'); // Too vague — split by failure mode
+// WRONG — using separate Err/FooErr pair (old API)
+FooErr({ context: { id: '1' } });
+// CORRECT — each variant call returns Err(...) automatically
+FooError.NotFound({ id: '1' });
 
-// CORRECT — always extract type via ReturnType
-type DbNotFoundError = ReturnType<typeof DbNotFoundError>;
+// WRONG — monolithic single-variant error for a service with many failure modes
+const RecorderError = defineErrors({
+  Error: ({ message }: { message: string }) => ({ message }), // Too vague
+});
+// CORRECT — split by failure mode
+const RecorderError = defineErrors({
+  AlreadyRecording: () => ({ message: 'A recording is already in progress' }),
+  PermissionDenied: ({ cause }: { cause: unknown }) => ({
+    message: `Microphone permission denied. ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+  DeviceNotFound: ({ deviceId }: { deviceId: string }) => ({
+    message: `Device not found: ${deviceId}`,
+    deviceId,
+  }),
+});
 ```

--- a/.agents/skills/error-handling/SKILL.md
+++ b/.agents/skills/error-handling/SKILL.md
@@ -79,13 +79,13 @@ catch: (error) => MyServiceError.OperationFailed({ underlyingError: extractError
 8. **CRITICAL: Wrap destructured errors with Err()** - When you destructure `{ data, error }` from tryAsync/trySync, the `error` variable is the raw error value, NOT wrapped in `Err`. You must wrap it before returning:
 
 ```typescript
-// WRONG - error is just the raw TaggedError, not a Result
+// WRONG - error is just the raw error value, not a Result
 const { data, error } = await tryAsync({...});
-if (error) return error; // TYPE ERROR: Returns TaggedError, not Result
+if (error) return error; // TYPE ERROR: Returns raw error, not Result
 
 // CORRECT - wrap with Err() to return a proper Result
 const { data, error } = await tryAsync({...});
-if (error) return Err(error); // Returns Err<TaggedError>
+if (error) return Err(error); // Returns Err<CustomError>
 ```
 
 This is different from returning the entire result object:
@@ -195,7 +195,7 @@ const { data, error } = await tryAsync({
 		await someOtherAsyncCall();
 		return processResults();
 	},
-	catch: (error) => GenericErr({ message: 'Something failed' }), // Too vague!
+	catch: (error) => Err(error), // Too vague! No specific error type
 });
 ```
 
@@ -252,7 +252,7 @@ const { data: mediaRecorder, error: recorderError } = trySync({
 		return recorder;
 	},
 	catch: (error) =>
-		RecorderServiceError.InitFailed({ cause: error }),
+		RecorderError.InitFailed({ cause: error }),
 });
 ```
 
@@ -284,7 +284,7 @@ async function getStreamForDeviceIdentifier(
 // From navigator.ts
 startRecording: async (params, { sendStatus }) => {
   if (activeRecording) {
-    return RecorderServiceErr({ message: 'Already recording.' });
+    return RecorderError.Service({ message: 'Already recording.' });
   }
 
   // First try block - get stream
@@ -297,7 +297,7 @@ startRecording: async (params, { sendStatus }) => {
   // Second try block - create recorder
   const { data: mediaRecorder, error: recorderError } = trySync({
     try: () => new MediaRecorder(stream, { bitsPerSecond: bitrate }),
-    catch: (error) => RecorderServiceError.InitFailed({ cause: error }),
+    catch: (error) => RecorderError.InitFailed({ cause: error }),
   });
 
   if (recorderError) {

--- a/.agents/skills/single-or-array-pattern/SKILL.md
+++ b/.agents/skills/single-or-array-pattern/SKILL.md
@@ -94,7 +94,7 @@ delete: async (recordingOrRecordings) => {
   const ids = recordings.map((r) => r.id);
   return tryAsync({
     try: () => db.recordings.bulkDelete(ids),
-    catch: (error) => DbServiceErr({ message: `Error deleting: ${error}` }),
+    catch: (error) => DbError.Service({ message: `Error deleting: ${error}` }),
   });
 },
 ```

--- a/.claude/agents/codebase-pattern-finder.md
+++ b/.claude/agents/codebase-pattern-finder.md
@@ -65,12 +65,16 @@ Use Grep, Glob, and LS to find relevant files
 
 ```typescript
 // Actual code example
+const Error = defineErrors({
+  Service: { message: string; cause?: unknown },
+});
+
 export function exampleService() {
   return {
-    async doThing(input: Input): Promise<Result<Output, ServiceErr>> {
+    async doThing(input: Input): Promise<Result<Output, typeof Error.Service>> {
       const { data, error } = await tryAsync({
         try: () => performOperation(input),
-        catch: (e) => ServiceErr({ message: 'Operation failed', cause: e }),
+        catch: (e) => Error.Service({ message: 'Operation failed', cause: e }),
       });
       if (error) return Err(error);
       return Ok(data);

--- a/apps/epicenter/src/lib/workspaces/dynamic/queries.ts
+++ b/apps/epicenter/src/lib/workspaces/dynamic/queries.ts
@@ -1,6 +1,6 @@
 import { appLocalDataDir, join } from '@tauri-apps/api/path';
 import { revealItemInDir } from '@tauri-apps/plugin-opener';
-import { defineErrors, type InferErrors } from 'wellcrafted/error';
+import { defineErrors, extractErrorMessage, type InferErrors } from 'wellcrafted/error';
 import { Ok } from 'wellcrafted/result';
 import { defineMutation, defineQuery, queryClient } from '$lib/query/client';
 import type { WorkspaceTemplate } from '$lib/templates';
@@ -17,7 +17,18 @@ import {
 // ─────────────────────────────────────────────────────────────────────────────
 
 export const WorkspaceError = defineErrors({
-	Failed: ({ message }: { message: string }) => ({ message }),
+	NotFound: ({ workspaceId }: { workspaceId: string }) => ({
+		message: `Workspace "${workspaceId}" not found`,
+		workspaceId,
+	}),
+	NotImplemented: ({ feature }: { feature: string }) => ({
+		message: `${feature} is not yet implemented`,
+		feature,
+	}),
+	DirectoryAccessFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to open workspaces directory: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
 });
 export type WorkspaceError = InferErrors<typeof WorkspaceError>;
 
@@ -56,9 +67,7 @@ export const workspaces = {
 			queryFn: async () => {
 				const definition = await getWorkspace(workspaceId);
 				if (!definition) {
-					return WorkspaceError.Failed({
-						message: `Workspace "${workspaceId}" not found`,
-					});
+					return WorkspaceError.NotFound({ workspaceId });
 				}
 				return Ok(definition);
 			},
@@ -114,9 +123,7 @@ export const workspaces = {
 			});
 
 			if (!updated) {
-				return WorkspaceError.Failed({
-					message: `Workspace "${input.workspaceId}" not found`,
-				});
+				return WorkspaceError.NotFound({ workspaceId: input.workspaceId });
 			}
 
 			console.log(`[updateWorkspace] Updated workspace:`, {
@@ -143,9 +150,7 @@ export const workspaces = {
 			const deleted = await deleteWorkspace(id);
 
 			if (!deleted) {
-				return WorkspaceError.Failed({
-					message: `Workspace "${id}" not found`,
-				});
+				return WorkspaceError.NotFound({ workspaceId: id });
 			}
 
 			// Invalidate queries
@@ -168,9 +173,7 @@ export const workspaces = {
 				await revealItemInDir(workspacesPath);
 				return Ok(undefined);
 			} catch (error) {
-				return WorkspaceError.Failed({
-					message: `Failed to open workspaces directory: ${error}`,
-				});
+				return WorkspaceError.DirectoryAccessFailed({ cause: error });
 			}
 		},
 	}),
@@ -192,9 +195,7 @@ export const workspaces = {
 			description?: string;
 		}) => {
 			// TODO: Implement via updateWorkspaceDefinition
-			return WorkspaceError.Failed({
-				message: 'Adding tables is not yet implemented',
-			});
+			return WorkspaceError.NotImplemented({ feature: 'Adding tables' });
 		},
 	}),
 
@@ -205,9 +206,7 @@ export const workspaces = {
 		mutationKey: ['workspaces', 'removeTable'],
 		mutationFn: async (_input: { workspaceId: string; tableName: string }) => {
 			// TODO: Implement via updateWorkspaceDefinition
-			return WorkspaceError.Failed({
-				message: 'Removing tables is not yet implemented',
-			});
+			return WorkspaceError.NotImplemented({ feature: 'Removing tables' });
 		},
 	}),
 
@@ -222,9 +221,7 @@ export const workspaces = {
 			key: string;
 		}) => {
 			// TODO: Implement via updateWorkspaceDefinition
-			return WorkspaceError.Failed({
-				message: 'Adding KV entries is not yet implemented',
-			});
+			return WorkspaceError.NotImplemented({ feature: 'Adding KV entries' });
 		},
 	}),
 
@@ -235,9 +232,7 @@ export const workspaces = {
 		mutationKey: ['workspaces', 'removeKvEntry'],
 		mutationFn: async (_input: { workspaceId: string; key: string }) => {
 			// TODO: Implement via updateWorkspaceDefinition
-			return WorkspaceError.Failed({
-				message: 'Removing KV entries is not yet implemented',
-			});
+			return WorkspaceError.NotImplemented({ feature: 'Removing KV entries' });
 		},
 	}),
 };

--- a/apps/epicenter/src/lib/workspaces/static/queries.ts
+++ b/apps/epicenter/src/lib/workspaces/static/queries.ts
@@ -1,11 +1,14 @@
-import { defineErrors, type InferErrors } from 'wellcrafted/error';
+import { defineErrors, extractErrorMessage, type InferErrors } from 'wellcrafted/error';
 import { Ok } from 'wellcrafted/result';
 import { defineMutation, defineQuery, queryClient } from '$lib/query/client';
 import { addStaticWorkspace, listStaticWorkspaces } from './service';
 import type { StaticWorkspaceEntry } from './types';
 
 const StaticWorkspaceError = defineErrors({
-	Failed: ({ message }: { message: string }) => ({ message }),
+	AddFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to add static workspace: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
 });
 type StaticWorkspaceError = InferErrors<typeof StaticWorkspaceError>;
 
@@ -39,7 +42,7 @@ export const staticWorkspaces = {
 				});
 				return Ok(entry);
 			} catch (error) {
-				return StaticWorkspaceError.Failed({ message: String(error) });
+				return StaticWorkspaceError.AddFailed({ cause: error });
 			}
 		},
 	}),

--- a/apps/whispering/src/lib/components/MigrationDialog.svelte
+++ b/apps/whispering/src/lib/components/MigrationDialog.svelte
@@ -665,9 +665,7 @@
 					onProgress(
 						`[Migration] ❌ Error: ${error instanceof Error ? error.message : String(error)}`,
 					);
-					throw DbError.Service({
-						message: 'Failed to migrate recordings',
-					});
+					throw DbError.MigrationFailed({ cause: error });
 				},
 			});
 		}
@@ -817,9 +815,7 @@
 					onProgress(
 						`[Migration] ❌ Error: ${error instanceof Error ? error.message : String(error)}`,
 					);
-					throw DbError.Service({
-						message: 'Failed to migrate transformations',
-					});
+					throw DbError.MigrationFailed({ cause: error });
 				},
 			});
 		}
@@ -969,9 +965,7 @@
 					onProgress(
 						`[Migration] ❌ Error: ${error instanceof Error ? error.message : String(error)}`,
 					);
-					throw DbError.Service({
-						message: 'Failed to migrate transformation runs',
-					});
+					throw DbError.MigrationFailed({ cause: error });
 				},
 			});
 		}
@@ -1031,9 +1025,7 @@
 					};
 				},
 				catch: (error) => {
-					throw DbError.Service({
-						message: 'Failed to get migration counts',
-					});
+					throw DbError.MigrationFailed({ cause: error });
 				},
 			});
 		}

--- a/apps/whispering/src/lib/query/README.md
+++ b/apps/whispering/src/lib/query/README.md
@@ -127,7 +127,7 @@ A critical responsibility of the query layer is transforming service-specific er
 
 The error handling follows a clear pattern across three layers:
 
-1. **Service Layer**: Returns domain-specific tagged errors (e.g., `RecorderServiceError`)
+1. **Service Layer**: Returns domain-specific errors using `defineErrors` pattern
 2. **Query Layer**: Wraps service errors into `WhisperingError` objects
 3. **UI Layer**: Uses `WhisperingError` directly without re-wrapping
 
@@ -135,7 +135,7 @@ This pattern ensures consistent error handling and avoids double-wrapping errors
 
 ### How It Works
 
-Services return their own specific error types (e.g., `RecorderServiceError`, `CpalRecorderServiceError`), which contain detailed error information. The query layer transforms these into `WhisperingError` with UI-friendly formatting:
+Services return their own specific error types (defined with `defineErrors`), which contain detailed error information. The query layer transforms these into `WhisperingError` with UI-friendly formatting:
 
 ```typescript
 // From manualRecorder.ts - Error transformation in mutationFn
@@ -169,11 +169,13 @@ startRecording: defineMutation({
 
 ### The Pattern Explained
 
-1. **Service Layer**: Returns domain-specific errors (`TaggedError` types from WellCrafted)
+1. **Service Layer**: Returns domain-specific errors using `defineErrors`
 
    ```typescript
    // In manual-recorder.ts
-   type RecorderServiceError = TaggedError<'RecorderServiceError'>;
+   const { RecorderError } = defineErrors({
+   	RecorderError: {},
+   });
    ```
 
 2. **Query Layer**: Transforms to `WhisperingError` in `mutationFn`/`queryFn`
@@ -213,7 +215,7 @@ getRecorderState: defineQuery({
 			await services.cpalRecorder.getRecorderState();
 
 		if (getRecorderStateError) {
-			// Transform CpalRecorderServiceError → WhisperingError
+			// Transform CpalRecorderError → WhisperingError
 			return Err(
 				WhisperingError({
 					title: '❌ Failed to get recorder state',

--- a/apps/whispering/src/lib/query/isomorphic/actions.ts
+++ b/apps/whispering/src/lib/query/isomorphic/actions.ts
@@ -437,9 +437,7 @@ export const commands = {
 			);
 
 			if (validFiles.length === 0) {
-				return DbError.Service({
-					message: 'No valid audio or video files found.',
-				});
+				return DbError.NoValidFiles();
 			}
 
 			if (invalidFiles.length > 0) {

--- a/apps/whispering/src/lib/query/isomorphic/delivery.ts
+++ b/apps/whispering/src/lib/query/isomorphic/delivery.ts
@@ -89,18 +89,15 @@ export const delivery = {
 
 			// Warns that write to cursor failed
 			const warnWriteToCursorFailed = (error: TextError | WhisperingError) => {
-				if (error.name === 'Service') {
-					rpc.notify.warning({
-						title: 'Unable to write to cursor automatically',
-						description: error.message,
-						action: { type: 'more-details', error },
-					});
-					return;
-				}
 				if (error.name === 'WhisperingError') {
 					rpc.notify[error.severity](error);
 					return;
 				}
+				rpc.notify.warning({
+					title: 'Unable to write to cursor automatically',
+					description: error.message,
+					action: { type: 'more-details', error },
+				});
 			};
 
 			// Show appropriate success notification based on what succeeded
@@ -275,18 +272,15 @@ export const delivery = {
 
 			// Warns that write to cursor failed
 			const warnWriteToCursorFailed = (error: TextError | WhisperingError) => {
-				if (error.name === 'Service') {
-					rpc.notify.error({
-						title: 'Error writing transformed text to cursor',
-						description: error.message,
-						action: { type: 'more-details', error },
-					});
-					return;
-				}
 				if (error.name === 'WhisperingError') {
 					rpc.notify[error.severity](error);
 					return;
 				}
+				rpc.notify.error({
+					title: 'Error writing transformed text to cursor',
+					description: error.message,
+					action: { type: 'more-details', error },
+				});
 			};
 
 			// Show appropriate success notification based on what succeeded

--- a/apps/whispering/src/lib/services/README.md
+++ b/apps/whispering/src/lib/services/README.md
@@ -202,7 +202,13 @@ Services should **never** import or use `WhisperingError`. That transformation h
 import { WhisperingError } from '$lib/result';
 
 // ✅ CORRECT - Service uses its own error type
-type MyServiceError = TaggedError<'MyServiceError'>;
+const MyError = defineErrors({
+	Failed: ({ cause }: { cause: unknown }) => ({
+		message: `Operation failed: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+});
+type MyError = InferErrors<typeof MyError>;
 ```
 
 The query layer is responsible for transforming service errors into `WhisperingError` for toast notifications. This separation ensures:
@@ -268,7 +274,7 @@ Never wrap an already-wrapped error. The query layer handles the single transfor
 ```typescript
 // ❌ BAD: Service returns tagged error, query wraps it, then UI wraps again
 if (error) {
-	const whisperingError = WhisperingErr({
+	const whisperingError = WhisperingError({
 		/* ... */
 	});
 	notify.error.execute({ ...whisperingError.error }); // Double wrapping!

--- a/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
+++ b/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
@@ -1,6 +1,5 @@
 import { invoke as tauriInvoke } from '@tauri-apps/api/core';
 import { remove } from '@tauri-apps/plugin-fs';
-import { extractErrorMessage } from 'wellcrafted/error';
 import { Err, Ok, type Result, tryAsync } from 'wellcrafted/result';
 import type {
 	CancelRecordingResult,
@@ -35,8 +34,8 @@ const enumerateDevices = async (): Promise<Result<Device[], RecorderError>> => {
 	const { data: deviceNames, error: enumerateRecordingDevicesError } =
 		await invoke<string[]>('enumerate_recording_devices');
 	if (enumerateRecordingDevicesError) {
-		return RecorderError.Service({
-			message: 'Failed to enumerate recording devices',
+		return RecorderError.EnumerateDevices({
+			cause: enumerateRecordingDevicesError,
 		});
 	}
 	// On desktop, device names serve as both ID and label
@@ -64,9 +63,8 @@ export const CpalRecorderServiceLive: RecorderService = {
 			string | null
 		>('get_current_recording_id');
 		if (getRecorderStateError)
-			return RecorderError.Service({
-				message:
-					'We encountered an issue while getting the recorder state. This could be because your microphone is being used by another app, your microphone permissions are denied, or the selected recording device is disconnected',
+			return RecorderError.GetStateFailed({
+				cause: getRecorderStateError,
 			});
 
 		return Ok(recordingId ? 'RECORDING' : 'IDLE');
@@ -103,7 +101,7 @@ export const CpalRecorderServiceLive: RecorderService = {
 			const deviceIds = devices.map((d) => d.id);
 			const fallbackDeviceId = deviceIds.at(0);
 			if (!fallbackDeviceId) {
-				return RecorderError.Service({
+				return RecorderError.NoDevice({
 					message: selectedDeviceId
 						? "We couldn't find the selected microphone. Make sure it's connected and try again!"
 						: "We couldn't find any microphones. Make sure they're connected and try again!",
@@ -170,9 +168,8 @@ export const CpalRecorderServiceLive: RecorderService = {
 			},
 		);
 		if (initRecordingSessionError)
-			return RecorderError.Service({
-				message:
-					'We encountered an issue while setting up your recording session. This could be because your microphone is being used by another app, your microphone permissions are denied, or the selected recording device is disconnected',
+			return RecorderError.InitFailed({
+				cause: initRecordingSessionError,
 			});
 
 		sendStatus({
@@ -183,10 +180,7 @@ export const CpalRecorderServiceLive: RecorderService = {
 		const { error: startRecordingError } =
 			await invoke<void>('start_recording');
 		if (startRecordingError)
-			return RecorderError.Service({
-				message:
-					'Unable to start recording. Please check your microphone and try again.',
-			});
+			return RecorderError.StartFailed({ cause: startRecordingError });
 
 		return Ok(deviceOutcome);
 	},
@@ -203,17 +197,13 @@ export const CpalRecorderServiceLive: RecorderService = {
 		const { data: audioRecording, error: stopRecordingError } =
 			await invoke<AudioRecording>('stop_recording');
 		if (stopRecordingError) {
-			return RecorderError.Service({
-				message: 'Unable to save your recording. Please try again.',
-			});
+			return RecorderError.StopFailed({ cause: stopRecordingError });
 		}
 
 		const { filePath } = audioRecording;
 		// Desktop recorder should always write to a file
 		if (!filePath) {
-			return RecorderError.Service({
-				message: 'Recording file path not provided by method.',
-			});
+			return RecorderError.NoFilePath();
 		}
 		// audioRecording is now AudioRecordingWithFile
 
@@ -226,8 +216,8 @@ export const CpalRecorderServiceLive: RecorderService = {
 		const { data: blob, error: readRecordingFileError } =
 			await FsServiceLive.pathToBlob(filePath);
 		if (readRecordingFileError)
-			return RecorderError.Service({
-				message: `Unable to read recording file: ${readRecordingFileError.message}`,
+			return RecorderError.ReadFileFailed({
+				cause: readRecordingFileError,
 			});
 		// Close the recording session after stopping
 		sendStatus({
@@ -257,9 +247,8 @@ export const CpalRecorderServiceLive: RecorderService = {
 			string | null
 		>('get_current_recording_id');
 		if (getRecordingIdError) {
-			return RecorderError.Service({
-				message:
-					'Unable to check recording state. Please try closing the app and starting again.',
+			return RecorderError.GetStateFailed({
+				cause: getRecordingIdError,
 			});
 		}
 
@@ -283,9 +272,7 @@ export const CpalRecorderServiceLive: RecorderService = {
 			const { error: removeError } = await tryAsync({
 				try: () => remove(filePath),
 				catch: (error) =>
-					RecorderError.Service({
-						message: `Failed to delete recording file: ${extractErrorMessage(error)}`,
-					}),
+					RecorderError.FileDeleteFailed({ cause: error }),
 			});
 			if (removeError)
 				sendStatus({
@@ -321,8 +308,6 @@ async function invoke<T>(command: string, args?: Record<string, unknown>) {
 	return tryAsync({
 		try: async () => await tauriInvoke<T>(command, args),
 		catch: (error) =>
-			RecorderError.Service({
-				message: `Tauri invoke '${command}' failed: ${extractErrorMessage(error)}`,
-			}),
+			RecorderError.InvokeFailed({ command, cause: error }),
 	});
 }

--- a/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
+++ b/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
@@ -321,6 +321,8 @@ async function invoke<T>(command: string, args?: Record<string, unknown>) {
 	return tryAsync({
 		try: async () => await tauriInvoke<T>(command, args),
 		catch: (error) =>
-			Err({ name: 'TauriInvokeError', command, error } as const),
+			RecorderError.Service({
+				message: `Tauri invoke '${command}' failed: ${extractErrorMessage(error)}`,
+			}),
 	});
 }

--- a/apps/whispering/src/lib/services/desktop/recorder/ffmpeg.ts
+++ b/apps/whispering/src/lib/services/desktop/recorder/ffmpeg.ts
@@ -250,9 +250,7 @@ const enumerateDevices = async (): Promise<Result<Device[], RecorderError>> => {
 	const { data: result, error: executeError } =
 		await CommandServiceLive.execute(command);
 	if (executeError) {
-		return RecorderError.Service({
-			message: 'Failed to enumerate recording devices',
-		});
+		return RecorderError.EnumerateDevices({ cause: executeError });
 	}
 
 	// FFmpeg lists devices to stderr, not stdout
@@ -261,7 +259,7 @@ const enumerateDevices = async (): Promise<Result<Device[], RecorderError>> => {
 	const devices = parseDevices(output);
 
 	if (devices.length === 0) {
-		return RecorderError.Service({
+		return RecorderError.NoDevice({
 			message: 'No recording devices found',
 		});
 	}
@@ -308,7 +306,7 @@ export const FfmpegRecorderServiceLive: RecorderService = {
 			const fallbackDeviceId = deviceIds.at(0);
 
 			if (!fallbackDeviceId) {
-				return RecorderError.Service({
+				return RecorderError.NoDevice({
 					message: selectedDeviceId
 						? "We couldn't find the selected microphone. Make sure it's connected and try again!"
 						: "We couldn't find any microphones. Make sure they're connected and try again!",
@@ -380,10 +378,7 @@ export const FfmpegRecorderServiceLive: RecorderService = {
 		);
 
 		if (startError) {
-			// The spawn function already caught the FFmpeg error and extracted the message
-			return RecorderError.Service({
-				message: 'Failed to start recording',
-			});
+			return RecorderError.StartFailed({ cause: startError });
 		}
 
 		// Store the PID and session info for recovery after refresh
@@ -406,7 +401,7 @@ export const FfmpegRecorderServiceLive: RecorderService = {
 		const child = getCurrentChild();
 		const session = sessionState.value;
 		if (!child || !session) {
-			return RecorderError.Service({
+			return RecorderError.NotRecording({
 				message: 'No active recording to stop',
 			});
 		}
@@ -433,10 +428,7 @@ export const FfmpegRecorderServiceLive: RecorderService = {
 					}, 1000);
 				}
 			},
-			catch: (error) =>
-				RecorderError.Service({
-					message: `Failed to stop FFmpeg process: ${extractErrorMessage(error)}`,
-				}),
+			catch: (error) => RecorderError.StopFailed({ cause: error }),
 		});
 
 		if (killError) {
@@ -501,16 +493,12 @@ export const FfmpegRecorderServiceLive: RecorderService = {
 			await FsServiceLive.pathToBlob(outputPath);
 
 		if (readError) {
-			return RecorderError.Service({
-				message: 'Unable to read recording file',
-			});
+			return RecorderError.ReadFileFailed({ cause: readError });
 		}
 
 		// Validate the blob has actual content
 		if (!blob || blob.size === 0) {
-			return RecorderError.Service({
-				message: 'Recording file is empty',
-			});
+			return RecorderError.EmptyRecording();
 		}
 
 		return Ok(blob);
@@ -543,9 +531,7 @@ export const FfmpegRecorderServiceLive: RecorderService = {
 					if (fileExists) await remove(pathToCleanup);
 				},
 				catch: (error) =>
-					RecorderError.Service({
-						message: `Failed to delete recording file: ${extractErrorMessage(error)}`,
-					}),
+					RecorderError.FileDeleteFailed({ cause: error }),
 			});
 
 			if (removeError) {

--- a/apps/whispering/src/lib/services/isomorphic/analytics/desktop.ts
+++ b/apps/whispering/src/lib/services/isomorphic/analytics/desktop.ts
@@ -1,5 +1,4 @@
 import { invoke } from '@tauri-apps/api/core';
-import { extractErrorMessage } from 'wellcrafted/error';
 import { tryAsync } from 'wellcrafted/result';
 import type { AnalyticsService } from './types';
 import { AnalyticsError } from './types';
@@ -16,9 +15,7 @@ export function createAnalyticsServiceDesktop(): AnalyticsService {
 					});
 				},
 				catch: (error) =>
-					AnalyticsError.Service({
-						message: `Failed to log analytics event via Tauri: ${extractErrorMessage(error)}`,
-					}),
+					AnalyticsError.LogEventFailed({ cause: error }),
 			}),
 	};
 }

--- a/apps/whispering/src/lib/services/isomorphic/analytics/types.ts
+++ b/apps/whispering/src/lib/services/isomorphic/analytics/types.ts
@@ -1,9 +1,12 @@
-import { defineErrors, type InferErrors } from 'wellcrafted/error';
+import { defineErrors, extractErrorMessage, type InferErrors } from 'wellcrafted/error';
 import type { Result } from 'wellcrafted/result';
 import type { TRANSCRIPTION_SERVICE_IDS } from '$lib/services/isomorphic/transcription/registry';
 
 export const AnalyticsError = defineErrors({
-	Service: ({ message }: { message: string }) => ({ message }),
+	LogEventFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to log analytics event: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
 });
 export type AnalyticsError = InferErrors<typeof AnalyticsError>;
 

--- a/apps/whispering/src/lib/services/isomorphic/analytics/web.ts
+++ b/apps/whispering/src/lib/services/isomorphic/analytics/web.ts
@@ -1,5 +1,4 @@
 import { init, trackEvent } from '@aptabase/web';
-import { extractErrorMessage } from 'wellcrafted/error';
 import { tryAsync } from 'wellcrafted/result';
 import type { AnalyticsService } from './types';
 import { AnalyticsError } from './types';
@@ -15,9 +14,7 @@ export function createAnalyticsServiceWeb(): AnalyticsService {
 					await trackEvent(type, properties);
 				},
 				catch: (error) =>
-					AnalyticsError.Service({
-						message: `Failed to log analytics event: ${extractErrorMessage(error)}`,
-					}),
+					AnalyticsError.LogEventFailed({ cause: error }),
 			}),
 	};
 }

--- a/apps/whispering/src/lib/services/isomorphic/completion/anthropic.ts
+++ b/apps/whispering/src/lib/services/isomorphic/completion/anthropic.ts
@@ -20,47 +20,16 @@ export function createAnthropicCompletionService(): CompletionService {
 						messages: [{ role: 'user', content: userPrompt }],
 						max_tokens: 1024,
 					}),
-				catch: (error) => {
-					// Check if it's NOT an Anthropic API error
-					if (!(error instanceof Anthropic.APIError)) {
-						// This is an unexpected error type
-						throw error;
+				catch: (error): Err<CompletionError> => {
+					if (!(error instanceof Anthropic.APIError)) throw error;
+					if (!error.status && error.name === 'APIConnectionError') {
+						return CompletionError.ConnectionFailed({ cause: error });
 					}
-					// Return the error directly
-					return Err(error);
+					return CompletionError.Http({ status: error.status ?? 0, cause: error });
 				},
 			});
 
-			if (anthropicApiError) {
-				// Error handling follows https://www.npmjs.com/package/@anthropic-ai/sdk#error-handling
-				const { status, name } = anthropicApiError;
-
-				if (status === 400)
-					return CompletionError.BadRequest({ cause: anthropicApiError });
-
-				if (status === 401)
-					return CompletionError.Unauthorized({ cause: anthropicApiError });
-
-				if (status === 403)
-					return CompletionError.Forbidden({ cause: anthropicApiError });
-
-				if (status === 404)
-					return CompletionError.ModelNotFound({ cause: anthropicApiError });
-
-				if (status === 422)
-					return CompletionError.UnprocessableEntity({ cause: anthropicApiError });
-
-				if (status === 429)
-					return CompletionError.RateLimit({ cause: anthropicApiError });
-
-				if (status && status >= 500)
-					return CompletionError.ServerError({ cause: anthropicApiError });
-
-				if (!status && name === 'APIConnectionError')
-					return CompletionError.ConnectionFailed({ cause: anthropicApiError });
-
-				return CompletionError.Api({ cause: anthropicApiError });
-			}
+			if (anthropicApiError) return Err(anthropicApiError);
 
 			// Extract the response text
 			const responseText = completion.content

--- a/apps/whispering/src/lib/services/isomorphic/completion/anthropic.ts
+++ b/apps/whispering/src/lib/services/isomorphic/completion/anthropic.ts
@@ -21,11 +21,11 @@ export function createAnthropicCompletionService(): CompletionService {
 						max_tokens: 1024,
 					}),
 				catch: (error): Err<CompletionError> => {
-					if (!(error instanceof Anthropic.APIError)) throw error;
-					if (!error.status && error.name === 'APIConnectionError') {
+					if (error instanceof Anthropic.APIConnectionError) {
 						return CompletionError.ConnectionFailed({ cause: error });
 					}
-					return CompletionError.Http({ status: error.status ?? 0, cause: error });
+					if (!(error instanceof Anthropic.APIError)) throw error;
+					return CompletionError.Http({ status: error.status, cause: error });
 				},
 			});
 

--- a/apps/whispering/src/lib/services/isomorphic/completion/anthropic.ts
+++ b/apps/whispering/src/lib/services/isomorphic/completion/anthropic.ts
@@ -33,82 +33,33 @@ export function createAnthropicCompletionService(): CompletionService {
 
 			if (anthropicApiError) {
 				// Error handling follows https://www.npmjs.com/package/@anthropic-ai/sdk#error-handling
-				const { status, name, message, error } = anthropicApiError;
+				const { status, name } = anthropicApiError;
 
-				// 400 - BadRequestError
-				if (status === 400) {
-					return CompletionError.Service({
-						message:
-							message ??
-							`Invalid request to Anthropic API. ${error?.message ?? ''}`.trim(),
-					});
-				}
+				if (status === 400)
+					return CompletionError.BadRequest({ cause: anthropicApiError });
 
-				// 401 - AuthenticationError
-				if (status === 401) {
-					return CompletionError.Service({
-						message:
-							message ??
-							'Your API key appears to be invalid or expired. Please update your API key in settings.',
-					});
-				}
+				if (status === 401)
+					return CompletionError.Unauthorized({ cause: anthropicApiError });
 
-				// 403 - PermissionDeniedError
-				if (status === 403) {
-					return CompletionError.Service({
-						message:
-							message ??
-							"Your account doesn't have access to this model or feature.",
-					});
-				}
+				if (status === 403)
+					return CompletionError.Forbidden({ cause: anthropicApiError });
 
-				// 404 - NotFoundError
-				if (status === 404) {
-					return CompletionError.Service({
-						message:
-							message ??
-							'The requested model was not found. Please check the model name.',
-					});
-				}
+				if (status === 404)
+					return CompletionError.ModelNotFound({ cause: anthropicApiError });
 
-				// 422 - UnprocessableEntityError
-				if (status === 422) {
-					return CompletionError.Service({
-						message:
-							message ??
-							'The request was valid but the server cannot process it. Please check your parameters.',
-					});
-				}
+				if (status === 422)
+					return CompletionError.UnprocessableEntity({ cause: anthropicApiError });
 
-				// 429 - RateLimitError
-				if (status === 429) {
-					return CompletionError.Service({
-						message: message ?? 'Too many requests. Please try again later.',
-					});
-				}
+				if (status === 429)
+					return CompletionError.RateLimit({ cause: anthropicApiError });
 
-				// >=500 - InternalServerError
-				if (status && status >= 500) {
-					return CompletionError.Service({
-						message:
-							message ??
-							`The Anthropic service is temporarily unavailable (Error ${status}). Please try again in a few minutes.`,
-					});
-				}
+				if (status && status >= 500)
+					return CompletionError.ServerError({ cause: anthropicApiError });
 
-				// Handle APIConnectionError (no status code)
-				if (!status && name === 'APIConnectionError') {
-					return CompletionError.Service({
-						message:
-							message ??
-							'Unable to connect to the Anthropic service. This could be a network issue or temporary service interruption.',
-					});
-				}
+				if (!status && name === 'APIConnectionError')
+					return CompletionError.ConnectionFailed({ cause: anthropicApiError });
 
-				// Catch-all for unexpected errors
-				return CompletionError.Service({
-					message: message ?? 'An unexpected error occurred. Please try again.',
-				});
+				return CompletionError.Api({ cause: anthropicApiError });
 			}
 
 			// Extract the response text
@@ -118,8 +69,8 @@ export function createAnthropicCompletionService(): CompletionService {
 				.join('');
 
 			if (!responseText) {
-				return CompletionError.Service({
-					message: 'Anthropic API returned an empty response',
+				return CompletionError.EmptyResponse({
+					providerLabel: 'Anthropic',
 				});
 			}
 

--- a/apps/whispering/src/lib/services/isomorphic/completion/custom.ts
+++ b/apps/whispering/src/lib/services/isomorphic/completion/custom.ts
@@ -12,13 +12,13 @@ export const CustomCompletionServiceLive =
 		getBaseUrl: (params) => params.baseUrl,
 		validateParams: (params) => {
 			if (!params.baseUrl) {
-				return CompletionError.Service({
-					message: 'Custom provider requires a base URL.',
+				return CompletionError.MissingParam({
+					param: 'Custom provider base URL',
 				});
 			}
 			if (!params.model) {
-				return CompletionError.Service({
-					message: 'Custom provider requires a model name.',
+				return CompletionError.MissingParam({
+					param: 'Custom provider model name',
 				});
 			}
 			return Ok(undefined);

--- a/apps/whispering/src/lib/services/isomorphic/completion/google.ts
+++ b/apps/whispering/src/lib/services/isomorphic/completion/google.ts
@@ -1,4 +1,7 @@
-import { GoogleGenerativeAI } from '@google/generative-ai';
+import {
+	GoogleGenerativeAI,
+	GoogleGenerativeAIFetchError,
+} from '@google/generative-ai';
 import { Err, Ok, tryAsync } from 'wellcrafted/result';
 import type { CompletionService } from './types';
 import { CompletionError } from './types';
@@ -18,8 +21,12 @@ export const GoogleCompletionServiceLive: CompletionService = {
 				const { response } = await model.generateContent(combinedPrompt);
 				return response.text();
 			},
-			catch: (error) =>
-				CompletionError.Http({ status: 0, cause: error }),
+			catch: (error): Err<CompletionError> => {
+				if (error instanceof GoogleGenerativeAIFetchError) {
+					return CompletionError.Http({ status: error.status ?? 0, cause: error });
+				}
+				throw error;
+			},
 		});
 
 		if (completionError) return Err(completionError);

--- a/apps/whispering/src/lib/services/isomorphic/completion/google.ts
+++ b/apps/whispering/src/lib/services/isomorphic/completion/google.ts
@@ -19,7 +19,7 @@ export const GoogleCompletionServiceLive: CompletionService = {
 				return response.text();
 			},
 			catch: (error) =>
-				CompletionError.Api({ cause: error }),
+				CompletionError.Http({ status: 0, cause: error }),
 		});
 
 		if (completionError) return Err(completionError);

--- a/apps/whispering/src/lib/services/isomorphic/completion/google.ts
+++ b/apps/whispering/src/lib/services/isomorphic/completion/google.ts
@@ -1,5 +1,4 @@
 import { GoogleGenerativeAI } from '@google/generative-ai';
-import { extractErrorMessage } from 'wellcrafted/error';
 import { Err, Ok, tryAsync } from 'wellcrafted/result';
 import type { CompletionService } from './types';
 import { CompletionError } from './types';
@@ -20,16 +19,14 @@ export const GoogleCompletionServiceLive: CompletionService = {
 				return response.text();
 			},
 			catch: (error) =>
-				CompletionError.Service({
-					message: `Google API Error: ${extractErrorMessage(error)}`,
-				}),
+				CompletionError.Api({ cause: error }),
 		});
 
 		if (completionError) return Err(completionError);
 
 		if (!completion) {
-			return CompletionError.Service({
-				message: 'Google API returned an empty response',
+			return CompletionError.EmptyResponse({
+				providerLabel: 'Google',
 			});
 		}
 

--- a/apps/whispering/src/lib/services/isomorphic/completion/groq.ts
+++ b/apps/whispering/src/lib/services/isomorphic/completion/groq.ts
@@ -36,89 +36,40 @@ export const GroqCompletionServiceLive: CompletionService = {
 
 		if (groqApiError) {
 			// Error handling follows https://www.npmjs.com/package/groq-sdk#error-handling
-			const { status, name, message, error } = groqApiError;
+			const { status, name } = groqApiError;
 
-			// 400 - BadRequestError
-			if (status === 400) {
-				return CompletionError.Service({
-					message:
-						message ??
-						`Invalid request to Groq API. ${error?.message ?? ''}`.trim(),
-				});
-			}
+			if (status === 400)
+				return CompletionError.BadRequest({ cause: groqApiError });
 
-			// 401 - AuthenticationError
-			if (status === 401) {
-				return CompletionError.Service({
-					message:
-						message ??
-						'Your API key appears to be invalid or expired. Please update your API key in settings.',
-				});
-			}
+			if (status === 401)
+				return CompletionError.Unauthorized({ cause: groqApiError });
 
-			// 403 - PermissionDeniedError
-			if (status === 403) {
-				return CompletionError.Service({
-					message:
-						message ??
-						"Your account doesn't have access to this model or feature.",
-				});
-			}
+			if (status === 403)
+				return CompletionError.Forbidden({ cause: groqApiError });
 
-			// 404 - NotFoundError
-			if (status === 404) {
-				return CompletionError.Service({
-					message:
-						message ??
-						'The requested model was not found. Please check the model name.',
-				});
-			}
+			if (status === 404)
+				return CompletionError.ModelNotFound({ cause: groqApiError });
 
-			// 422 - UnprocessableEntityError
-			if (status === 422) {
-				return CompletionError.Service({
-					message:
-						message ??
-						'The request was valid but the server cannot process it. Please check your parameters.',
-				});
-			}
+			if (status === 422)
+				return CompletionError.UnprocessableEntity({ cause: groqApiError });
 
-			// 429 - RateLimitError
-			if (status === 429) {
-				return CompletionError.Service({
-					message: message ?? 'Too many requests. Please try again later.',
-				});
-			}
+			if (status === 429)
+				return CompletionError.RateLimit({ cause: groqApiError });
 
-			// >=500 - InternalServerError
-			if (status && status >= 500) {
-				return CompletionError.Service({
-					message:
-						message ??
-						`The Groq service is temporarily unavailable (Error ${status}). Please try again in a few minutes.`,
-				});
-			}
+			if (status && status >= 500)
+				return CompletionError.ServerError({ cause: groqApiError });
 
-			// Handle APIConnectionError (no status code)
-			if (!status && name === 'APIConnectionError') {
-				return CompletionError.Service({
-					message:
-						message ??
-						'Unable to connect to the Groq service. This could be a network issue or temporary service interruption.',
-				});
-			}
+			if (!status && name === 'APIConnectionError')
+				return CompletionError.ConnectionFailed({ cause: groqApiError });
 
-			// Catch-all for unexpected errors
-			return CompletionError.Service({
-				message: message ?? 'An unexpected error occurred. Please try again.',
-			});
+			return CompletionError.Api({ cause: groqApiError });
 		}
 
 		// Extract the response text
 		const responseText = completion.choices.at(0)?.message?.content;
 		if (!responseText) {
-			return CompletionError.Service({
-				message: 'Groq API returned an empty response',
+			return CompletionError.EmptyResponse({
+				providerLabel: 'Groq',
 			});
 		}
 

--- a/apps/whispering/src/lib/services/isomorphic/completion/groq.ts
+++ b/apps/whispering/src/lib/services/isomorphic/completion/groq.ts
@@ -24,11 +24,11 @@ export const GroqCompletionServiceLive: CompletionService = {
 					],
 				}),
 			catch: (error): Err<CompletionError> => {
-				if (!(error instanceof Groq.APIError)) throw error;
-				if (!error.status && error.name === 'APIConnectionError') {
+				if (error instanceof Groq.APIConnectionError) {
 					return CompletionError.ConnectionFailed({ cause: error });
 				}
-				return CompletionError.Http({ status: error.status ?? 0, cause: error });
+				if (!(error instanceof Groq.APIError)) throw error;
+				return CompletionError.Http({ status: error.status, cause: error });
 			},
 		});
 

--- a/apps/whispering/src/lib/services/isomorphic/completion/groq.ts
+++ b/apps/whispering/src/lib/services/isomorphic/completion/groq.ts
@@ -23,47 +23,16 @@ export const GroqCompletionServiceLive: CompletionService = {
 						{ role: 'user', content: userPrompt },
 					],
 				}),
-			catch: (error) => {
-				// Check if it's NOT a Groq API error
-				if (!(error instanceof Groq.APIError)) {
-					// This is an unexpected error type
-					throw error;
+			catch: (error): Err<CompletionError> => {
+				if (!(error instanceof Groq.APIError)) throw error;
+				if (!error.status && error.name === 'APIConnectionError') {
+					return CompletionError.ConnectionFailed({ cause: error });
 				}
-				// Return the error directly
-				return Err(error);
+				return CompletionError.Http({ status: error.status ?? 0, cause: error });
 			},
 		});
 
-		if (groqApiError) {
-			// Error handling follows https://www.npmjs.com/package/groq-sdk#error-handling
-			const { status, name } = groqApiError;
-
-			if (status === 400)
-				return CompletionError.BadRequest({ cause: groqApiError });
-
-			if (status === 401)
-				return CompletionError.Unauthorized({ cause: groqApiError });
-
-			if (status === 403)
-				return CompletionError.Forbidden({ cause: groqApiError });
-
-			if (status === 404)
-				return CompletionError.ModelNotFound({ cause: groqApiError });
-
-			if (status === 422)
-				return CompletionError.UnprocessableEntity({ cause: groqApiError });
-
-			if (status === 429)
-				return CompletionError.RateLimit({ cause: groqApiError });
-
-			if (status && status >= 500)
-				return CompletionError.ServerError({ cause: groqApiError });
-
-			if (!status && name === 'APIConnectionError')
-				return CompletionError.ConnectionFailed({ cause: groqApiError });
-
-			return CompletionError.Api({ cause: groqApiError });
-		}
+		if (groqApiError) return Err(groqApiError);
 
 		// Extract the response text
 		const responseText = completion.choices.at(0)?.message?.content;

--- a/apps/whispering/src/lib/services/isomorphic/completion/openai-compatible.ts
+++ b/apps/whispering/src/lib/services/isomorphic/completion/openai-compatible.ts
@@ -41,11 +41,7 @@ export type OpenAiCompatibleConfig = {
 	 * ```typescript
 	 * validateParams: (params) => {
 	 *   if (!params.baseUrl) {
-	 *     return CompletionError.Service({
-	 *       message: 'Base URL is required',
-	 *       context: { status: 400, name: 'MissingBaseUrl' },
-	 *       cause: null,
-	 *     });
+	 *     return CompletionError.MissingParam({ param: 'Base URL' });
 	 *   }
 	 *   return Ok(undefined);
 	 * }
@@ -154,92 +150,46 @@ export function createOpenAiCompatibleCompletionService(
 			});
 
 			if (apiError) {
-				const { status, name, message, error } = apiError;
+				const { status, name } = apiError;
 
 				if (typeof status === 'number') {
 					const override = config.statusMessageOverrides?.[status];
 					if (override) {
-						return CompletionError.Service({
-							message: override,
-						});
+						return CompletionError.Api({ cause: override });
 					}
 				}
 
-				if (status === 400) {
-					return CompletionError.Service({
-						message:
-							message ??
-							`Invalid request to ${config.providerLabel} API. ${error?.message ?? ''}`.trim(),
-					});
-				}
+				if (status === 400)
+					return CompletionError.BadRequest({ cause: apiError });
 
-				if (status === 401) {
-					return CompletionError.Service({
-						message:
-							message ??
-							`Your ${config.providerLabel} API key appears to be invalid or expired. Please update your API key in settings.`,
-					});
-				}
+				if (status === 401)
+					return CompletionError.Unauthorized({ cause: apiError });
 
-				if (status === 403) {
-					return CompletionError.Service({
-						message:
-							message ??
-							`Your ${config.providerLabel} account doesn't have access to this model or feature.`,
-					});
-				}
+				if (status === 403)
+					return CompletionError.Forbidden({ cause: apiError });
 
-				if (status === 404) {
-					return CompletionError.Service({
-						message:
-							message ??
-							`The requested model was not found on ${config.providerLabel}. Please check the model name.`,
-					});
-				}
+				if (status === 404)
+					return CompletionError.ModelNotFound({ cause: apiError });
 
-				if (status === 422) {
-					return CompletionError.Service({
-						message:
-							message ??
-							`The request was valid but ${config.providerLabel} cannot process it. Please check your parameters.`,
-					});
-				}
+				if (status === 422)
+					return CompletionError.UnprocessableEntity({ cause: apiError });
 
-				if (status === 429) {
-					return CompletionError.Service({
-						message:
-							message ??
-							`${config.providerLabel} rate limit exceeded. Please try again later.`,
-					});
-				}
+				if (status === 429)
+					return CompletionError.RateLimit({ cause: apiError });
 
-				if (status && status >= 500) {
-					return CompletionError.Service({
-						message:
-							message ??
-							`The ${config.providerLabel} service is temporarily unavailable (Error ${status}). Please try again in a few minutes.`,
-					});
-				}
+				if (status && status >= 500)
+					return CompletionError.ServerError({ cause: apiError });
 
-				if (!status && name === 'APIConnectionError') {
-					return CompletionError.Service({
-						message:
-							message ??
-							`Unable to connect to the ${config.providerLabel} service. This could be a network issue or temporary service interruption.`,
-					});
-				}
+				if (!status && name === 'APIConnectionError')
+					return CompletionError.ConnectionFailed({ cause: apiError });
 
-				return CompletionError.Service({
-					message:
-						message ??
-						`An unexpected error occurred with ${config.providerLabel}. Please try again.`,
-				});
+				return CompletionError.Api({ cause: apiError });
 			}
 
 			const responseText = completion.choices.at(0)?.message?.content;
 			if (!responseText) {
-				return CompletionError.Service({
-					message: `${config.providerLabel} API returned an empty response`,
+				return CompletionError.EmptyResponse({
+					providerLabel: config.providerLabel,
 				});
 			}
 

--- a/apps/whispering/src/lib/services/isomorphic/completion/openai-compatible.ts
+++ b/apps/whispering/src/lib/services/isomorphic/completion/openai-compatible.ts
@@ -141,50 +141,21 @@ export function createOpenAiCompatibleCompletionService(
 							{ role: 'user', content: params.userPrompt },
 						],
 					}),
-				catch: (error) => {
-					if (!(error instanceof OpenAI.APIError)) {
-						throw error;
+				catch: (error): Err<CompletionError> => {
+					if (!(error instanceof OpenAI.APIError)) throw error;
+					if (!error.status && error.name === 'APIConnectionError') {
+						return CompletionError.ConnectionFailed({ cause: error });
 					}
-					return Err(error);
+					const status = error.status ?? 0;
+					const override = config.statusMessageOverrides?.[status];
+					return CompletionError.Http({
+						status,
+						cause: override ?? error,
+					});
 				},
 			});
 
-			if (apiError) {
-				const { status, name } = apiError;
-
-				if (typeof status === 'number') {
-					const override = config.statusMessageOverrides?.[status];
-					if (override) {
-						return CompletionError.Api({ cause: override });
-					}
-				}
-
-				if (status === 400)
-					return CompletionError.BadRequest({ cause: apiError });
-
-				if (status === 401)
-					return CompletionError.Unauthorized({ cause: apiError });
-
-				if (status === 403)
-					return CompletionError.Forbidden({ cause: apiError });
-
-				if (status === 404)
-					return CompletionError.ModelNotFound({ cause: apiError });
-
-				if (status === 422)
-					return CompletionError.UnprocessableEntity({ cause: apiError });
-
-				if (status === 429)
-					return CompletionError.RateLimit({ cause: apiError });
-
-				if (status && status >= 500)
-					return CompletionError.ServerError({ cause: apiError });
-
-				if (!status && name === 'APIConnectionError')
-					return CompletionError.ConnectionFailed({ cause: apiError });
-
-				return CompletionError.Api({ cause: apiError });
-			}
+			if (apiError) return Err(apiError);
 
 			const responseText = completion.choices.at(0)?.message?.content;
 			if (!responseText) {

--- a/apps/whispering/src/lib/services/isomorphic/completion/openai-compatible.ts
+++ b/apps/whispering/src/lib/services/isomorphic/completion/openai-compatible.ts
@@ -60,16 +60,6 @@ export type OpenAiCompatibleConfig = {
 	 * @example { 'HTTP-Referer': 'https://myapp.com', 'X-Title': 'MyApp' }
 	 */
 	defaultHeaders?: Record<string, string>;
-
-	/**
-	 * Custom error messages for specific HTTP status codes.
-	 *
-	 * Allows providers to override default error messages with
-	 * provider-specific guidance (e.g., billing issues, service-specific errors).
-	 *
-	 * @example { 402: 'Insufficient credits. Please add credits to continue.' }
-	 */
-	statusMessageOverrides?: Partial<Record<number, string>>;
 };
 
 /**
@@ -95,15 +85,12 @@ export type OpenAiCompatibleConfig = {
  *   providerLabel: 'OpenAI',
  * });
  *
- * // Provider with custom headers and error messages
+ * // Provider with custom headers
  * const openrouter = createOpenAiCompatibleCompletionService({
  *   providerLabel: 'OpenRouter',
  *   defaultHeaders: {
  *     'HTTP-Referer': 'https://whispering.epicenter.so',
  *     'X-Title': 'Whispering',
- *   },
- *   statusMessageOverrides: {
- *     402: 'Insufficient credits in your OpenRouter account.',
  *   },
  * });
  * ```
@@ -146,10 +133,9 @@ export function createOpenAiCompatibleCompletionService(
 						return CompletionError.ConnectionFailed({ cause: error });
 					}
 					if (!(error instanceof OpenAI.APIError)) throw error;
-					const override = config.statusMessageOverrides?.[error.status];
 					return CompletionError.Http({
 						status: error.status,
-						cause: override ?? error,
+						cause: error,
 					});
 				},
 			});

--- a/apps/whispering/src/lib/services/isomorphic/completion/openai-compatible.ts
+++ b/apps/whispering/src/lib/services/isomorphic/completion/openai-compatible.ts
@@ -142,14 +142,13 @@ export function createOpenAiCompatibleCompletionService(
 						],
 					}),
 				catch: (error): Err<CompletionError> => {
-					if (!(error instanceof OpenAI.APIError)) throw error;
-					if (!error.status && error.name === 'APIConnectionError') {
+					if (error instanceof OpenAI.APIConnectionError) {
 						return CompletionError.ConnectionFailed({ cause: error });
 					}
-					const status = error.status ?? 0;
-					const override = config.statusMessageOverrides?.[status];
+					if (!(error instanceof OpenAI.APIError)) throw error;
+					const override = config.statusMessageOverrides?.[error.status];
 					return CompletionError.Http({
-						status,
+						status: error.status,
 						cause: override ?? error,
 					});
 				},

--- a/apps/whispering/src/lib/services/isomorphic/completion/openrouter.ts
+++ b/apps/whispering/src/lib/services/isomorphic/completion/openrouter.ts
@@ -8,11 +8,6 @@ export const OpenRouterCompletionServiceLive =
 			'HTTP-Referer': 'https://whispering.epicenter.so',
 			'X-Title': 'Whispering',
 		},
-		statusMessageOverrides: {
-			402: 'Insufficient credits in your OpenRouter account. Please add credits to continue.',
-			502: 'The model provider is temporarily unavailable. OpenRouter will automatically retry with fallback models if configured.',
-			503: 'OpenRouter is temporarily unavailable. Please try again in a few minutes.',
-		},
 	});
 
 export type OpenRouterCompletionService =

--- a/apps/whispering/src/lib/services/isomorphic/completion/types.ts
+++ b/apps/whispering/src/lib/services/isomorphic/completion/types.ts
@@ -6,49 +6,26 @@ import {
 import type { Result } from 'wellcrafted/result';
 
 export const CompletionError = defineErrors({
-	BadRequest: ({ cause }: { cause: unknown }) => ({
-		message: `Invalid request: ${extractErrorMessage(cause)}`,
+	/** HTTP-level failure from the provider API. Status preserved for callers that need it. */
+	Http: ({ status, cause }: { status: number; cause: unknown }) => ({
+		message: `Request failed (${status}): ${extractErrorMessage(cause)}`,
+		status,
 		cause,
 	}),
-	Unauthorized: ({ cause }: { cause: unknown }) => ({
-		message: `Authentication failed: ${extractErrorMessage(cause)}`,
-		cause,
-	}),
-	Forbidden: ({ cause }: { cause: unknown }) => ({
-		message: `Access denied: ${extractErrorMessage(cause)}`,
-		cause,
-	}),
-	ModelNotFound: ({ cause }: { cause: unknown }) => ({
-		message: `Model not found: ${extractErrorMessage(cause)}`,
-		cause,
-	}),
-	UnprocessableEntity: ({ cause }: { cause: unknown }) => ({
-		message: `Unprocessable request: ${extractErrorMessage(cause)}`,
-		cause,
-	}),
-	RateLimit: ({ cause }: { cause: unknown }) => ({
-		message: `Rate limit exceeded: ${extractErrorMessage(cause)}`,
-		cause,
-	}),
-	ServerError: ({ cause }: { cause: unknown }) => ({
-		message: `Server error: ${extractErrorMessage(cause)}`,
-		cause,
-	}),
+	/** Network/DNS/TLS failure — never reached the server */
 	ConnectionFailed: ({ cause }: { cause: unknown }) => ({
 		message: `Connection failed: ${extractErrorMessage(cause)}`,
 		cause,
 	}),
+	/** Provider returned a successful response with no usable content */
 	EmptyResponse: ({ providerLabel }: { providerLabel: string }) => ({
 		message: `${providerLabel} API returned an empty response`,
 		providerLabel,
 	}),
+	/** Required parameter was not provided */
 	MissingParam: ({ param }: { param: string }) => ({
 		message: `${param} is required`,
 		param,
-	}),
-	Api: ({ cause }: { cause: unknown }) => ({
-		message: `API error: ${extractErrorMessage(cause)}`,
-		cause,
 	}),
 });
 export type CompletionError = InferErrors<typeof CompletionError>;

--- a/apps/whispering/src/lib/services/isomorphic/completion/types.ts
+++ b/apps/whispering/src/lib/services/isomorphic/completion/types.ts
@@ -1,8 +1,55 @@
-import { defineErrors, type InferErrors } from 'wellcrafted/error';
+import {
+	defineErrors,
+	extractErrorMessage,
+	type InferErrors,
+} from 'wellcrafted/error';
 import type { Result } from 'wellcrafted/result';
 
 export const CompletionError = defineErrors({
-	Service: ({ message }: { message: string }) => ({ message }),
+	BadRequest: ({ cause }: { cause: unknown }) => ({
+		message: `Invalid request: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	Unauthorized: ({ cause }: { cause: unknown }) => ({
+		message: `Authentication failed: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	Forbidden: ({ cause }: { cause: unknown }) => ({
+		message: `Access denied: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	ModelNotFound: ({ cause }: { cause: unknown }) => ({
+		message: `Model not found: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	UnprocessableEntity: ({ cause }: { cause: unknown }) => ({
+		message: `Unprocessable request: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	RateLimit: ({ cause }: { cause: unknown }) => ({
+		message: `Rate limit exceeded: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	ServerError: ({ cause }: { cause: unknown }) => ({
+		message: `Server error: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	ConnectionFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Connection failed: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	EmptyResponse: ({ providerLabel }: { providerLabel: string }) => ({
+		message: `${providerLabel} API returned an empty response`,
+		providerLabel,
+	}),
+	MissingParam: ({ param }: { param: string }) => ({
+		message: `${param} is required`,
+		param,
+	}),
+	Api: ({ cause }: { cause: unknown }) => ({
+		message: `API error: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
 });
 export type CompletionError = InferErrors<typeof CompletionError>;
 

--- a/apps/whispering/src/lib/services/isomorphic/db/README.md
+++ b/apps/whispering/src/lib/services/isomorphic/db/README.md
@@ -208,15 +208,15 @@ All implementations expose the same `DbService` interface:
 ```typescript
 type DbService = {
 	recordings: {
-		getAll: () => Promise<Result<Recording[], DbServiceError>>;
-		getById: (id: string) => Promise<Result<Recording | null, DbServiceError>>;
+		getAll: () => Promise<Result<Recording[], DbError>>;
+		getById: (id: string) => Promise<Result<Recording | null, DbError>>;
 		create: (
 			recording: Recording,
-		) => Promise<Result<Recording, DbServiceError>>;
+		) => Promise<Result<Recording, DbError>>;
 		update: (
 			recording: Recording,
-		) => Promise<Result<Recording, DbServiceError>>;
-		delete: (id: string) => Promise<Result<void, DbServiceError>>;
+		) => Promise<Result<Recording, DbError>>;
+		delete: (id: string) => Promise<Result<void, DbError>>;
 	};
 	// ... other stores
 };

--- a/apps/whispering/src/lib/services/isomorphic/db/desktop.ts
+++ b/apps/whispering/src/lib/services/isomorphic/db/desktop.ts
@@ -39,8 +39,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return Err({
-						name: 'Service' as const,
+					return DbError.Service({
 						message: 'Error getting all recordings from both sources',
 					});
 				}
@@ -94,8 +93,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return Err({
-						name: 'Service' as const,
+					return DbError.Service({
 						message:
 							'Error getting transcribing recording ids from both sources',
 					});
@@ -130,8 +128,7 @@ export function createDbServiceDesktop({
 				// If both failed, return an error only if both actually errored
 				// (not just returned null/undefined)
 				if (fsResult.error && idbResult.error) {
-					return Err({
-						name: 'Service' as const,
+					return DbError.Service({
 						message: 'Error getting recording by id from both sources',
 					});
 				}
@@ -160,8 +157,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return Err({
-						name: 'Service' as const,
+					return DbError.Service({
 						message: 'Error deleting recording(s) from both sources',
 					});
 				}
@@ -179,8 +175,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return Err({
-						name: 'Service' as const,
+					return DbError.Service({
 						message: 'Error cleaning up expired recordings from both sources',
 					});
 				}
@@ -209,8 +204,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return Err({
-						name: 'Service' as const,
+					return DbError.Service({
 						message: 'Error getting audio blob from both sources',
 					});
 				}
@@ -240,8 +234,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return Err({
-						name: 'Service' as const,
+					return DbError.Service({
 						message: 'Error getting audio playback URL from both sources',
 					});
 				}
@@ -265,8 +258,7 @@ export function createDbServiceDesktop({
 
 				// Return error only if both failed
 				if (fsResult.error && idbResult.error) {
-					return Err({
-						name: 'Service' as const,
+					return DbError.Service({
 						message: 'Error clearing recordings from both sources',
 					});
 				}
@@ -290,8 +282,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return Err({
-						name: 'Service' as const,
+					return DbError.Service({
 						message: 'Error getting all transformations from both sources',
 					});
 				}
@@ -333,8 +324,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error only if both actually errored
 				if (fsResult.error && idbResult.error) {
-					return Err({
-						name: 'Service' as const,
+					return DbError.Service({
 						message: 'Error getting transformation by id from both sources',
 					});
 				}
@@ -364,8 +354,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return Err({
-						name: 'Service' as const,
+					return DbError.Service({
 						message: 'Error deleting transformation(s) from both sources',
 					});
 				}
@@ -383,8 +372,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return Err({
-						name: 'Service' as const,
+					return DbError.Service({
 						message: 'Error clearing transformations from both sources',
 					});
 				}
@@ -409,8 +397,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return Err({
-						name: 'Service' as const,
+					return DbError.Service({
 						message: 'Error getting all transformation runs from both sources',
 					});
 				}
@@ -452,8 +439,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error only if both actually errored
 				if (fsResult.error && idbResult.error) {
-					return Err({
-						name: 'Service' as const,
+					return DbError.Service({
 						message: 'Error getting transformation run by id from both sources',
 					});
 				}
@@ -471,8 +457,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return Err({
-						name: 'Service' as const,
+					return DbError.Service({
 						message:
 							'Error getting transformation runs by transformation id from both sources',
 					});
@@ -512,8 +497,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return Err({
-						name: 'Service' as const,
+					return DbError.Service({
 						message:
 							'Error getting transformation runs by recording id from both sources',
 					});

--- a/apps/whispering/src/lib/services/isomorphic/db/desktop.ts
+++ b/apps/whispering/src/lib/services/isomorphic/db/desktop.ts
@@ -39,9 +39,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return DbError.Service({
-						message: 'Error getting all recordings from both sources',
-					});
+					return DbError.QueryFailed({ cause: fsResult.error });
 				}
 
 				// Use data from successful sources (empty array for failed ones)
@@ -93,10 +91,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return DbError.Service({
-						message:
-							'Error getting transcribing recording ids from both sources',
-					});
+					return DbError.QueryFailed({ cause: fsResult.error });
 				}
 
 				// Use data from successful sources (empty array for failed ones)
@@ -128,9 +123,7 @@ export function createDbServiceDesktop({
 				// If both failed, return an error only if both actually errored
 				// (not just returned null/undefined)
 				if (fsResult.error && idbResult.error) {
-					return DbError.Service({
-						message: 'Error getting recording by id from both sources',
-					});
+					return DbError.QueryFailed({ cause: fsResult.error });
 				}
 
 				// Not found in either source (but no errors)
@@ -157,9 +150,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return DbError.Service({
-						message: 'Error deleting recording(s) from both sources',
-					});
+					return DbError.MutationFailed({ cause: fsResult.error });
 				}
 
 				// Success if at least one succeeded
@@ -175,9 +166,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return DbError.Service({
-						message: 'Error cleaning up expired recordings from both sources',
-					});
+					return DbError.MutationFailed({ cause: fsResult.error });
 				}
 
 				// Success if at least one succeeded
@@ -204,9 +193,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return DbError.Service({
-						message: 'Error getting audio blob from both sources',
-					});
+					return DbError.QueryFailed({ cause: fsResult.error });
 				}
 
 				// Not found in either source (but no errors)
@@ -234,9 +221,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return DbError.Service({
-						message: 'Error getting audio playback URL from both sources',
-					});
+					return DbError.QueryFailed({ cause: fsResult.error });
 				}
 
 				// Not found in either source (but no errors)
@@ -258,9 +243,7 @@ export function createDbServiceDesktop({
 
 				// Return error only if both failed
 				if (fsResult.error && idbResult.error) {
-					return DbError.Service({
-						message: 'Error clearing recordings from both sources',
-					});
+					return DbError.MutationFailed({ cause: fsResult.error });
 				}
 
 				return Ok(undefined);
@@ -282,9 +265,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return DbError.Service({
-						message: 'Error getting all transformations from both sources',
-					});
+					return DbError.QueryFailed({ cause: fsResult.error });
 				}
 
 				// Use data from successful sources (empty array for failed ones)
@@ -324,9 +305,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error only if both actually errored
 				if (fsResult.error && idbResult.error) {
-					return DbError.Service({
-						message: 'Error getting transformation by id from both sources',
-					});
+					return DbError.QueryFailed({ cause: fsResult.error });
 				}
 
 				// Not found in either source (but no errors)
@@ -354,9 +333,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return DbError.Service({
-						message: 'Error deleting transformation(s) from both sources',
-					});
+					return DbError.MutationFailed({ cause: fsResult.error });
 				}
 
 				// Success if at least one succeeded
@@ -372,9 +349,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return DbError.Service({
-						message: 'Error clearing transformations from both sources',
-					});
+					return DbError.MutationFailed({ cause: fsResult.error });
 				}
 
 				// Success if at least one succeeded
@@ -397,9 +372,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return DbError.Service({
-						message: 'Error getting all transformation runs from both sources',
-					});
+					return DbError.QueryFailed({ cause: fsResult.error });
 				}
 
 				// Use data from successful sources (empty array for failed ones)
@@ -439,9 +412,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error only if both actually errored
 				if (fsResult.error && idbResult.error) {
-					return DbError.Service({
-						message: 'Error getting transformation run by id from both sources',
-					});
+					return DbError.QueryFailed({ cause: fsResult.error });
 				}
 
 				// Not found in either source (but no errors)
@@ -457,10 +428,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return DbError.Service({
-						message:
-							'Error getting transformation runs by transformation id from both sources',
-					});
+					return DbError.QueryFailed({ cause: fsResult.error });
 				}
 
 				// Use data from successful sources (empty array for failed ones)
@@ -497,10 +465,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return DbError.Service({
-						message:
-							'Error getting transformation runs by recording id from both sources',
-					});
+					return DbError.QueryFailed({ cause: fsResult.error });
 				}
 
 				// Use data from successful sources (empty array for failed ones)
@@ -562,9 +527,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return DbError.Service({
-						message: 'Error deleting transformation run(s) from both sources',
-					});
+					return DbError.MutationFailed({ cause: fsResult.error });
 				}
 
 				// Success if at least one succeeded
@@ -580,9 +543,7 @@ export function createDbServiceDesktop({
 
 				// If both failed, return an error
 				if (fsResult.error && idbResult.error) {
-					return DbError.Service({
-						message: 'Error clearing transformation runs from both sources',
-					});
+					return DbError.MutationFailed({ cause: fsResult.error });
 				}
 
 				// Success if at least one succeeded

--- a/apps/whispering/src/lib/services/isomorphic/db/file-system.ts
+++ b/apps/whispering/src/lib/services/isomorphic/db/file-system.ts
@@ -13,7 +13,6 @@ import { type } from 'arktype';
 import matter from 'gray-matter';
 import mime from 'mime';
 import { nanoid } from 'nanoid/non-secure';
-import { extractErrorMessage } from 'wellcrafted/error';
 import { Ok, tryAsync } from 'wellcrafted/result';
 import { PATHS } from '$lib/constants/paths';
 import { FsServiceLive } from '$lib/services/desktop/fs';
@@ -142,9 +141,7 @@ export function createFileSystemDb(): DbService {
 						return validRecordings;
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting all recordings from file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 
@@ -159,9 +156,7 @@ export function createFileSystemDb(): DbService {
 						return recordings.at(0)!;
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting latest recording from file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 
@@ -176,9 +171,7 @@ export function createFileSystemDb(): DbService {
 							.map((r) => r.id);
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting transcribing recording ids from file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 
@@ -204,9 +197,7 @@ export function createFileSystemDb(): DbService {
 						return markdownToRecording({ frontMatter, body });
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting recording by id from file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 
@@ -246,9 +237,7 @@ export function createFileSystemDb(): DbService {
 						);
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error creating recording(s) in file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 			},
 
@@ -285,9 +274,7 @@ export function createFileSystemDb(): DbService {
 						return recordingWithTimestamp;
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error updating recording in file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 			},
 
@@ -318,9 +305,7 @@ export function createFileSystemDb(): DbService {
 						await bulkDeleteFiles(pathsToDelete);
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error deleting recording(s) from file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 			},
 
@@ -343,9 +328,7 @@ export function createFileSystemDb(): DbService {
 								await this.delete(toDelete);
 							},
 							catch: (error) =>
-								DbError.Service({
-									message: `Error cleaning up expired recordings: ${extractErrorMessage(error)}`,
-								}),
+								DbError.MutationFailed({ cause: error }),
 						});
 					}
 				}
@@ -376,9 +359,7 @@ export function createFileSystemDb(): DbService {
 						return blob;
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting audio blob from file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 
@@ -405,9 +386,7 @@ export function createFileSystemDb(): DbService {
 						return assetUrl;
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting audio playback URL from file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 
@@ -432,9 +411,7 @@ export function createFileSystemDb(): DbService {
 						await bulkDeleteFiles(pathsToDelete);
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error clearing recordings from file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 			},
 
@@ -448,9 +425,7 @@ export function createFileSystemDb(): DbService {
 						return count;
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting recordings count from file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 		},
@@ -490,9 +465,7 @@ export function createFileSystemDb(): DbService {
 						);
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting all transformations from file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 
@@ -516,9 +489,7 @@ export function createFileSystemDb(): DbService {
 						return validated;
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting transformation by id from file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 
@@ -543,9 +514,7 @@ export function createFileSystemDb(): DbService {
 						);
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error creating transformation(s) in file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 			},
 
@@ -571,9 +540,7 @@ export function createFileSystemDb(): DbService {
 						return transformationWithTimestamp;
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error updating transformation in file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 			},
 
@@ -589,9 +556,7 @@ export function createFileSystemDb(): DbService {
 						await bulkDeleteFiles(pathsToDelete);
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error deleting transformation(s) from file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 			},
 
@@ -606,9 +571,7 @@ export function createFileSystemDb(): DbService {
 						}
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error clearing transformations from file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 			},
 
@@ -620,9 +583,7 @@ export function createFileSystemDb(): DbService {
 						return transformations.length;
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting transformations count from file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 		},
@@ -661,9 +622,7 @@ export function createFileSystemDb(): DbService {
 						return runs.filter((run) => run !== null);
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting all transformation runs from file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 
@@ -689,9 +648,7 @@ export function createFileSystemDb(): DbService {
 						return validated;
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting transformation run by id from file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 
@@ -738,9 +695,7 @@ export function createFileSystemDb(): DbService {
 						return runs;
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting transformation runs by transformation id from file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 
@@ -787,9 +742,7 @@ export function createFileSystemDb(): DbService {
 						return runs;
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting transformation runs by recording id from file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 
@@ -811,9 +764,7 @@ export function createFileSystemDb(): DbService {
 						);
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error creating transformation run(s) in file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 			},
 
@@ -847,9 +798,7 @@ export function createFileSystemDb(): DbService {
 						return newTransformationStepRun;
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error adding step to transformation run in file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 			},
 
@@ -888,9 +837,7 @@ export function createFileSystemDb(): DbService {
 						return failedRun;
 					},
 					catch: (e) =>
-						DbError.Service({
-							message: `Error failing step in transformation run in file system: ${extractErrorMessage(e)}`,
-						}),
+						DbError.MutationFailed({ cause: e }),
 				});
 			},
 
@@ -926,9 +873,7 @@ export function createFileSystemDb(): DbService {
 						return updatedRun;
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error completing step in transformation run in file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 			},
 
@@ -956,9 +901,7 @@ export function createFileSystemDb(): DbService {
 						return completedRun;
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error completing transformation run in file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 			},
 
@@ -972,9 +915,7 @@ export function createFileSystemDb(): DbService {
 						await bulkDeleteFiles(pathsToDelete);
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error deleting transformation run(s) from file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 			},
 
@@ -989,9 +930,7 @@ export function createFileSystemDb(): DbService {
 						}
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error clearing transformation runs from file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 			},
 
@@ -1003,9 +942,7 @@ export function createFileSystemDb(): DbService {
 						return runs.length;
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting transformation runs count from file system: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 		},

--- a/apps/whispering/src/lib/services/isomorphic/db/types.ts
+++ b/apps/whispering/src/lib/services/isomorphic/db/types.ts
@@ -1,4 +1,4 @@
-import { defineErrors, type InferErrors } from 'wellcrafted/error';
+import { defineErrors, extractErrorMessage, type InferErrors } from 'wellcrafted/error';
 import type { Result } from 'wellcrafted/result';
 import type { Settings } from '$lib/settings';
 import type {
@@ -11,7 +11,21 @@ import type {
 } from './models';
 
 export const DbError = defineErrors({
-	Service: ({ message }: { message: string }) => ({ message }),
+	QueryFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to query database: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	MutationFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to write to database: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	MigrationFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Database migration failed: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	NoValidFiles: () => ({
+		message: 'No valid audio or video files found',
+	}),
 });
 export type DbError = InferErrors<typeof DbError>;
 

--- a/apps/whispering/src/lib/services/isomorphic/db/web.ts
+++ b/apps/whispering/src/lib/services/isomorphic/db/web.ts
@@ -399,9 +399,7 @@ export function createDbServiceWeb({
 						);
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting all recordings from Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 
@@ -418,9 +416,7 @@ export function createDbServiceWeb({
 						return recording;
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting latest recording from Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 
@@ -432,9 +428,7 @@ export function createDbServiceWeb({
 							.equals('TRANSCRIBING' satisfies Recording['transcriptionStatus'])
 							.primaryKeys(),
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting transcribing recording ids from Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 
@@ -448,9 +442,7 @@ export function createDbServiceWeb({
 						return recording;
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting recording by id from Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 
@@ -472,9 +464,7 @@ export function createDbServiceWeb({
 						await db.recordings.bulkAdd(dbRecordings);
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error adding recording(s) to Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 			},
 
@@ -500,9 +490,7 @@ export function createDbServiceWeb({
 						await db.recordings.put(dbRecording);
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error updating recording in Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 				if (updateRecordingError) return Err(updateRecordingError);
 				return Ok(recordingWithTimestamp);
@@ -516,9 +504,7 @@ export function createDbServiceWeb({
 				return tryAsync({
 					try: () => db.recordings.bulkDelete(ids),
 					catch: (error) =>
-						DbError.Service({
-							message: `Error deleting recording(s) from Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 			},
 
@@ -544,9 +530,7 @@ export function createDbServiceWeb({
 						const { data: count, error: countError } = await tryAsync({
 							try: () => db.recordings.count(),
 							catch: (error) =>
-								DbError.Service({
-									message: `Unable to get recording count while cleaning up old recordings: ${extractErrorMessage(error)}`,
-								}),
+								DbError.QueryFailed({ cause: error }),
 						});
 						if (countError) return Err(countError);
 						if (count === 0) return Ok(undefined);
@@ -564,9 +548,7 @@ export function createDbServiceWeb({
 								await db.recordings.bulkDelete(idsToDelete);
 							},
 							catch: (error) =>
-								DbError.Service({
-									message: `Unable to clean up old recordings: ${extractErrorMessage(error)}`,
-								}),
+								DbError.MutationFailed({ cause: error }),
 						});
 					}
 				}
@@ -591,9 +573,7 @@ export function createDbServiceWeb({
 						return blob;
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting audio blob from IndexedDB: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 
@@ -626,9 +606,7 @@ export function createDbServiceWeb({
 						return objectUrl;
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error ensuring audio playback URL from IndexedDB: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 
@@ -644,9 +622,7 @@ export function createDbServiceWeb({
 				return tryAsync({
 					try: () => db.recordings.clear(),
 					catch: (error) =>
-						DbError.Service({
-							message: `Error clearing recordings from Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 			},
 
@@ -654,9 +630,7 @@ export function createDbServiceWeb({
 				return tryAsync({
 					try: () => db.recordings.count(),
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting recordings count from Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 		}, // End of recordings namespace
@@ -666,9 +640,7 @@ export function createDbServiceWeb({
 				return tryAsync({
 					try: () => db.transformations.toArray(),
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting all transformations from Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 
@@ -680,9 +652,7 @@ export function createDbServiceWeb({
 						return maybeTransformation;
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting transformation by id from Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 
@@ -695,9 +665,7 @@ export function createDbServiceWeb({
 						await db.transformations.bulkAdd(transformations);
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error adding transformation(s) to Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 			},
 
@@ -710,9 +678,7 @@ export function createDbServiceWeb({
 				const { error: updateTransformationError } = await tryAsync({
 					try: () => db.transformations.put(transformationWithTimestamp),
 					catch: (error) =>
-						DbError.Service({
-							message: `Error updating transformation in Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 				if (updateTransformationError) return Err(updateTransformationError);
 				return Ok(transformationWithTimestamp);
@@ -728,9 +694,7 @@ export function createDbServiceWeb({
 						await db.transformations.bulkDelete(ids);
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error deleting transformation(s) from Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 			},
 
@@ -738,9 +702,7 @@ export function createDbServiceWeb({
 				return tryAsync({
 					try: () => db.transformations.clear(),
 					catch: (error) =>
-						DbError.Service({
-							message: `Error clearing transformations from Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 			},
 
@@ -748,9 +710,7 @@ export function createDbServiceWeb({
 				return tryAsync({
 					try: () => db.transformations.count(),
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting transformations count from Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 		}, // End of transformations namespace
@@ -763,9 +723,7 @@ export function createDbServiceWeb({
 						return runs ?? [];
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting all transformation runs from Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 
@@ -776,9 +734,7 @@ export function createDbServiceWeb({
 				} = await tryAsync({
 					try: () => db.transformationRuns.where('id').equals(id).first(),
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting transformation run by id from Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 				if (getTransformationRunByIdError)
 					return Err(getTransformationRunByIdError);
@@ -803,9 +759,7 @@ export function createDbServiceWeb({
 						);
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting transformation runs by transformation id from Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 
@@ -826,9 +780,7 @@ export function createDbServiceWeb({
 						);
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting transformation runs by recording id from Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 
@@ -839,9 +791,7 @@ export function createDbServiceWeb({
 						await db.transformationRuns.bulkAdd(runs);
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error adding transformation run(s) to Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 			},
 
@@ -864,9 +814,7 @@ export function createDbServiceWeb({
 				const { error: addStepRunToTransformationRunError } = await tryAsync({
 					try: () => db.transformationRuns.put(updatedRun),
 					catch: (error) =>
-						DbError.Service({
-							message: `Error adding step run to transformation run in Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 				if (addStepRunToTransformationRunError)
 					return Err(addStepRunToTransformationRunError);
@@ -900,9 +848,7 @@ export function createDbServiceWeb({
 				const { error: updateTransformationStepRunError } = await tryAsync({
 					try: () => db.transformationRuns.put(failedRun),
 					catch: (error) =>
-						DbError.Service({
-							message: `Error updating transformation run as failed in Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 				if (updateTransformationStepRunError)
 					return Err(updateTransformationStepRunError);
@@ -933,9 +879,7 @@ export function createDbServiceWeb({
 				const { error: updateTransformationStepRunError } = await tryAsync({
 					try: () => db.transformationRuns.put(updatedRun),
 					catch: (error) =>
-						DbError.Service({
-							message: `Error updating transformation step run status in Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 				if (updateTransformationStepRunError)
 					return Err(updateTransformationStepRunError);
@@ -957,9 +901,7 @@ export function createDbServiceWeb({
 				const { error: updateTransformationStepRunError } = await tryAsync({
 					try: () => db.transformationRuns.put(completedRun),
 					catch: (error) =>
-						DbError.Service({
-							message: `Error updating transformation run as completed in Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 				if (updateTransformationStepRunError)
 					return Err(updateTransformationStepRunError);
@@ -975,9 +917,7 @@ export function createDbServiceWeb({
 						await db.transformationRuns.bulkDelete(runIds);
 					},
 					catch: (error) =>
-						DbError.Service({
-							message: `Error deleting transformation run(s) from Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 			},
 
@@ -985,9 +925,7 @@ export function createDbServiceWeb({
 				return tryAsync({
 					try: () => db.transformationRuns.clear(),
 					catch: (error) =>
-						DbError.Service({
-							message: `Error clearing transformation runs from Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.MutationFailed({ cause: error }),
 				});
 			},
 
@@ -995,9 +933,7 @@ export function createDbServiceWeb({
 				return tryAsync({
 					try: () => db.transformationRuns.count(),
 					catch: (error) =>
-						DbError.Service({
-							message: `Error getting transformation runs count from Dexie: ${extractErrorMessage(error)}`,
-						}),
+						DbError.QueryFailed({ cause: error }),
 				});
 			},
 		}, // End of runs namespace

--- a/apps/whispering/src/lib/services/isomorphic/download/desktop.ts
+++ b/apps/whispering/src/lib/services/isomorphic/download/desktop.ts
@@ -1,6 +1,5 @@
 import { save } from '@tauri-apps/plugin-dialog';
 import { writeFile } from '@tauri-apps/plugin-fs';
-import { extractErrorMessage } from 'wellcrafted/error';
 import { Err, Ok, tryAsync } from 'wellcrafted/result';
 import { getAudioExtension } from '$lib/services/isomorphic/transcription/utils';
 import type { DownloadService } from '.';
@@ -16,15 +15,11 @@ export function createDownloadServiceDesktop(): DownloadService {
 						filters: [{ name, extensions: [extension] }],
 					}),
 				catch: (error) =>
-					DownloadError.Service({
-						message: `There was an error saving the recording using the Tauri Filesystem API. Please try again. ${extractErrorMessage(error)}`,
-					}),
+					DownloadError.SaveDialogFailed({ cause: error }),
 			});
 			if (saveError) return Err(saveError);
 			if (path === null) {
-				return DownloadError.Service({
-					message: 'Please specify a path to save the recording.',
-				});
+				return DownloadError.SaveCancelled();
 			}
 			const { error: writeError } = await tryAsync({
 				try: async () => {
@@ -32,9 +27,7 @@ export function createDownloadServiceDesktop(): DownloadService {
 					await writeFile(path, contents);
 				},
 				catch: (error) =>
-					DownloadError.Service({
-						message: `There was an error saving the recording using the Tauri Filesystem API. Please try again. ${extractErrorMessage(error)}`,
-					}),
+					DownloadError.WriteFailed({ cause: error }),
 			});
 			if (writeError) return Err(writeError);
 			return Ok(undefined);

--- a/apps/whispering/src/lib/services/isomorphic/download/types.ts
+++ b/apps/whispering/src/lib/services/isomorphic/download/types.ts
@@ -1,8 +1,22 @@
-import { defineErrors, type InferErrors } from 'wellcrafted/error';
+import { defineErrors, extractErrorMessage, type InferErrors } from 'wellcrafted/error';
 import type { Result } from 'wellcrafted/result';
 
 export const DownloadError = defineErrors({
-	Service: ({ message }: { message: string }) => ({ message }),
+	SaveDialogFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to open save dialog: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	SaveCancelled: () => ({
+		message: 'Please specify a path to save the recording.',
+	}),
+	WriteFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to write file: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	BrowserDownloadFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to download in browser: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
 });
 export type DownloadError = InferErrors<typeof DownloadError>;
 

--- a/apps/whispering/src/lib/services/isomorphic/download/web.ts
+++ b/apps/whispering/src/lib/services/isomorphic/download/web.ts
@@ -1,4 +1,3 @@
-import { extractErrorMessage } from 'wellcrafted/error';
 import { tryAsync } from 'wellcrafted/result';
 import type { DownloadService } from '.';
 import { DownloadError } from './types';
@@ -19,9 +18,7 @@ export function createDownloadServiceWeb(): DownloadService {
 					URL.revokeObjectURL(url);
 				},
 				catch: (error) =>
-					DownloadError.Service({
-						message: `There was an error saving the recording in your browser. Please try again. ${extractErrorMessage(error)}`,
-					}),
+					DownloadError.BrowserDownloadFailed({ cause: error }),
 			}),
 	};
 }

--- a/apps/whispering/src/lib/services/isomorphic/local-shortcut-manager.ts
+++ b/apps/whispering/src/lib/services/isomorphic/local-shortcut-manager.ts
@@ -1,6 +1,10 @@
 import { on } from 'svelte/events';
 import type { Brand } from 'wellcrafted/brand';
-import { defineErrors, type InferErrors } from 'wellcrafted/error';
+import {
+	defineErrors,
+	extractErrorMessage,
+	type InferErrors,
+} from 'wellcrafted/error';
 import { Ok, type Result } from 'wellcrafted/result';
 import type { ShortcutEventState } from '$lib/commands';
 import {
@@ -11,14 +15,19 @@ import {
 } from '$lib/constants/keyboard';
 import { IS_MACOS } from '$lib/constants/platform';
 
-/**
- * Error type for local shortcut service operations.
- * This error is returned when shortcut registration, unregistration, or other
- * local shortcut operations fail. Uses a tagged error pattern for type safety
- * and better error discrimination in Result types.
- */
 const LocalShortcutError = defineErrors({
-	Service: () => ({ message: 'Local shortcut operation failed' }),
+	RegisterFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to register local shortcut: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	UnregisterFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to unregister local shortcut: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	UnregisterAllFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to unregister all local shortcuts: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
 });
 type LocalShortcutError = InferErrors<typeof LocalShortcutError>;
 

--- a/apps/whispering/src/lib/services/isomorphic/notifications/desktop.ts
+++ b/apps/whispering/src/lib/services/isomorphic/notifications/desktop.ts
@@ -6,7 +6,6 @@ import {
 	sendNotification,
 } from '@tauri-apps/plugin-notification';
 import { nanoid } from 'nanoid/non-secure';
-import { extractErrorMessage } from 'wellcrafted/error';
 import { Err, Ok, type Result, tryAsync } from 'wellcrafted/result';
 import type { NotificationService, UnifiedNotificationOptions } from './types';
 import {
@@ -33,9 +32,7 @@ export function createNotificationServiceDesktop(): NotificationService {
 			await tryAsync({
 				try: async () => await active(),
 				catch: (error) =>
-					NotificationError.Service({
-						message: `Unable to retrieve active desktop notifications: ${extractErrorMessage(error)}`,
-					}),
+					NotificationError.ListActiveFailed({ cause: error }),
 			});
 		if (activeNotificationsError) return Err(activeNotificationsError);
 		const matchingActiveNotification = activeNotifications.find(
@@ -45,9 +42,7 @@ export function createNotificationServiceDesktop(): NotificationService {
 			const { error: removeActiveError } = await tryAsync({
 				try: async () => await removeActive([matchingActiveNotification]),
 				catch: (error) =>
-					NotificationError.Service({
-						message: `Unable to remove notification with id ${id}: ${extractErrorMessage(error)}`,
-					}),
+					NotificationError.RemoveFailed({ id, cause: error }),
 			});
 			if (removeActiveError) return Err(removeActiveError);
 		}
@@ -84,9 +79,7 @@ export function createNotificationServiceDesktop(): NotificationService {
 					}
 				},
 				catch: (error) =>
-					NotificationError.Service({
-						message: `Could not send notification: ${extractErrorMessage(error)}`,
-					}),
+					NotificationError.SendFailed({ cause: error }),
 			});
 			if (notifyError) return Err(notifyError);
 			return Ok(idStringified);

--- a/apps/whispering/src/lib/services/isomorphic/notifications/types.ts
+++ b/apps/whispering/src/lib/services/isomorphic/notifications/types.ts
@@ -1,5 +1,5 @@
 import type { Options as TauriNotificationOptions } from '@tauri-apps/plugin-notification';
-import { defineErrors, type InferErrors } from 'wellcrafted/error';
+import { defineErrors, extractErrorMessage, type InferErrors } from 'wellcrafted/error';
 import type { Result } from 'wellcrafted/result';
 
 /**
@@ -16,7 +16,19 @@ import type { Result } from 'wellcrafted/result';
  */
 
 export const NotificationError = defineErrors({
-	Service: ({ message }: { message: string }) => ({ message }),
+	SendFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to send notification: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	ListActiveFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to retrieve active notifications: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	RemoveFailed: ({ id, cause }: { id: number; cause: unknown }) => ({
+		message: `Failed to remove notification with id ${id}: ${extractErrorMessage(cause)}`,
+		id,
+		cause,
+	}),
 });
 export type NotificationError = InferErrors<typeof NotificationError>;
 

--- a/apps/whispering/src/lib/services/isomorphic/notifications/web.ts
+++ b/apps/whispering/src/lib/services/isomorphic/notifications/web.ts
@@ -1,5 +1,4 @@
 import { nanoid } from 'nanoid/non-secure';
-import { extractErrorMessage } from 'wellcrafted/error';
 import { Err, Ok, tryAsync } from 'wellcrafted/result';
 import type { NotificationService, UnifiedNotificationOptions } from './types';
 import { NotificationError, toBrowserNotification } from './types';
@@ -77,9 +76,7 @@ export function createNotificationServiceWeb(): NotificationService {
 					}
 				},
 				catch: (error) =>
-					NotificationError.Service({
-						message: `Failed to send browser notification: ${extractErrorMessage(error)}`,
-					}),
+					NotificationError.SendFailed({ cause: error }),
 			});
 
 			if (error) return Err(error);

--- a/apps/whispering/src/lib/services/isomorphic/notifications/web.ts
+++ b/apps/whispering/src/lib/services/isomorphic/notifications/web.ts
@@ -41,22 +41,7 @@ export function createNotificationServiceWeb(): NotificationService {
 
 			// Try extension first if available
 			if (await detectExtension()) {
-				// Extension notification path (for future implementation)
-				// const extensionOptions = toExtensionNotification(options);
-				// const { error } = await tryAsync({
-				//   try: async () => {
-				//     await extension.createNotification({
-				//       ...extensionOptions,
-				//       notificationId,
-				//     });
-				//   },
-				//   catch: (error) => ({
-				//     name: 'NotificationServiceError' as const,
-				//     message: 'Failed to send extension notification',
-				//     cause: error,
-				//   }),
-				// });
-				// if (!error) return Ok(notificationId);
+				// Future: Extension notification support
 			}
 
 			// Browser notification fallback

--- a/apps/whispering/src/lib/services/isomorphic/os/types.ts
+++ b/apps/whispering/src/lib/services/isomorphic/os/types.ts
@@ -1,8 +1,11 @@
 import type { OsType } from '@tauri-apps/plugin-os';
-import { defineErrors, type InferErrors } from 'wellcrafted/error';
+import { defineErrors, extractErrorMessage, type InferErrors } from 'wellcrafted/error';
 
 export const OsError = defineErrors({
-	Service: () => ({ message: 'OS service operation failed' }),
+	DetectionFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to detect OS type: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
 });
 export type OsError = InferErrors<typeof OsError>;
 

--- a/apps/whispering/src/lib/services/isomorphic/recorder/navigator.ts
+++ b/apps/whispering/src/lib/services/isomorphic/recorder/navigator.ts
@@ -1,4 +1,3 @@
-import { extractErrorMessage } from 'wellcrafted/error';
 import { Err, Ok, type Result, tryAsync, trySync } from 'wellcrafted/result';
 import {
 	type CancelRecordingResult,
@@ -42,9 +41,7 @@ export const NavigatorRecorderServiceLive: RecorderService = {
 	enumerateDevices: async () => {
 		const { data: devices, error } = await enumerateDevices();
 		if (error) {
-			return RecorderError.Service({
-				message: error.message,
-			});
+			return RecorderError.EnumerateDevices({ cause: error });
 		}
 		return Ok(devices);
 	},
@@ -55,10 +52,7 @@ export const NavigatorRecorderServiceLive: RecorderService = {
 	): Promise<Result<DeviceAcquisitionOutcome, RecorderError>> => {
 		// Ensure we're not already recording
 		if (activeRecording) {
-			return RecorderError.Service({
-				message:
-					'A recording is already in progress. Please stop the current recording before starting a new one.',
-			});
+			return RecorderError.AlreadyRecording();
 		}
 
 		sendStatus({
@@ -70,9 +64,7 @@ export const NavigatorRecorderServiceLive: RecorderService = {
 		const { data: streamResult, error: acquireStreamError } =
 			await getRecordingStream({ selectedDeviceId, sendStatus });
 		if (acquireStreamError) {
-			return RecorderError.Service({
-				message: acquireStreamError.message,
-			});
+			return RecorderError.StreamAcquisition({ cause: acquireStreamError });
 		}
 
 		const { stream, deviceOutcome } = streamResult;
@@ -82,10 +74,7 @@ export const NavigatorRecorderServiceLive: RecorderService = {
 				new MediaRecorder(stream, {
 					bitsPerSecond: Number(bitrateKbps) * 1000,
 				}),
-			catch: (error) =>
-				RecorderError.Service({
-					message: `Failed to initialize the audio recorder. This could be due to unsupported audio settings, microphone conflicts, or browser limitations. Please check your microphone is working and try adjusting your audio settings. ${extractErrorMessage(error)}`,
-				}),
+			catch: (error) => RecorderError.InitFailed({ cause: error }),
 		});
 
 		if (recorderError) {
@@ -123,7 +112,7 @@ export const NavigatorRecorderServiceLive: RecorderService = {
 		sendStatus,
 	}): Promise<Result<Blob, RecorderError>> => {
 		if (!activeRecording) {
-			return RecorderError.Service({
+			return RecorderError.NotRecording({
 				message:
 					'Cannot stop recording because no active recording session was found. Make sure you have started recording before attempting to stop it.',
 			});
@@ -149,10 +138,7 @@ export const NavigatorRecorderServiceLive: RecorderService = {
 					});
 					recording.mediaRecorder.stop();
 				}),
-			catch: (error) =>
-				RecorderError.Service({
-					message: `Failed to properly stop and save the recording. This might be due to corrupted audio data, insufficient storage space, or a browser issue. Your recording data may be lost. ${extractErrorMessage(error)}`,
-				}),
+			catch: (error) => RecorderError.StopFailed({ cause: error }),
 		});
 
 		// Always clean up the stream

--- a/apps/whispering/src/lib/services/isomorphic/recorder/types.ts
+++ b/apps/whispering/src/lib/services/isomorphic/recorder/types.ts
@@ -1,4 +1,8 @@
-import { defineErrors, type InferErrors } from 'wellcrafted/error';
+import {
+	defineErrors,
+	extractErrorMessage,
+	type InferErrors,
+} from 'wellcrafted/error';
 import type { Result } from 'wellcrafted/result';
 import type {
 	CancelRecordingResult,
@@ -12,7 +16,65 @@ import type {
 } from '$lib/services/types';
 
 export const RecorderError = defineErrors({
-	Service: ({ message }: { message: string }) => ({ message }),
+	EnumerateDevices: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to enumerate recording devices: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	NoDevice: ({ message }: { message: string }) => ({
+		message,
+	}),
+	AlreadyRecording: () => ({
+		message:
+			'A recording is already in progress. Please stop the current recording before starting a new one.',
+	}),
+	NotRecording: ({ message }: { message: string }) => ({
+		message,
+	}),
+	InitFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to initialize the audio recorder: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	StartFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Unable to start recording: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	StopFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to stop recording: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	StreamAcquisition: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to acquire recording stream: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	ReadFileFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Unable to read recording file: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	NoFilePath: () => ({
+		message: 'Recording file path not provided by method.',
+	}),
+	EmptyRecording: () => ({
+		message: 'Recording file is empty.',
+	}),
+	FileDeleteFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to delete recording file: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	GetStateFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to get recorder state: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	InvokeFailed: ({
+		command,
+		cause,
+	}: {
+		command: string;
+		cause: unknown;
+	}) => ({
+		message: `Tauri invoke '${command}' failed: ${extractErrorMessage(cause)}`,
+		command,
+		cause,
+	}),
 });
 export type RecorderError = InferErrors<typeof RecorderError>;
 

--- a/apps/whispering/src/lib/services/isomorphic/sound/desktop.ts
+++ b/apps/whispering/src/lib/services/isomorphic/sound/desktop.ts
@@ -1,4 +1,3 @@
-import { extractErrorMessage } from 'wellcrafted/error';
 import { tryAsync } from 'wellcrafted/result';
 import type { PlaySoundService } from '.';
 import { audioElements } from './assets';
@@ -11,10 +10,7 @@ export function createPlaySoundServiceDesktop(): PlaySoundService {
 				try: async () => {
 					await audioElements[soundName].play();
 				},
-				catch: (error) =>
-					SoundError.Play({
-						message: `Failed to play sound: ${extractErrorMessage(error)}`,
-					}),
+				catch: (error) => SoundError.Play({ cause: error }),
 			}),
 	};
 }

--- a/apps/whispering/src/lib/services/isomorphic/sound/types.ts
+++ b/apps/whispering/src/lib/services/isomorphic/sound/types.ts
@@ -1,9 +1,16 @@
-import { defineErrors, type InferErrors } from 'wellcrafted/error';
+import {
+	defineErrors,
+	extractErrorMessage,
+	type InferErrors,
+} from 'wellcrafted/error';
 import type { Result } from 'wellcrafted/result';
 import type { WhisperingSoundNames } from '$lib/constants/sounds';
 
 export const SoundError = defineErrors({
-	Play: ({ message }: { message: string }) => ({ message }),
+	Play: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to play sound: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
 });
 export type SoundError = InferErrors<typeof SoundError>;
 

--- a/apps/whispering/src/lib/services/isomorphic/sound/web.ts
+++ b/apps/whispering/src/lib/services/isomorphic/sound/web.ts
@@ -10,18 +10,6 @@ export function createPlaySoundServiceWeb(): PlaySoundService {
 				await audioElements[soundName].play();
 				return Ok(undefined);
 			}
-			// const { error: playSoundError } = await extension.playSound({
-			// 	sound: soundName,
-			// });
-			// if (playSoundError) {
-			// 	return PlaySoundServiceErr(
-			// 		`We encountered an issue while playing the ${soundName} sound`,
-			// 		{
-			// 			context: { soundName },
-			// 			cause: playSoundError,
-			// 		}
-			// 	);
-			// }
 			return Ok(undefined);
 		},
 	};

--- a/apps/whispering/src/lib/services/isomorphic/text/desktop.ts
+++ b/apps/whispering/src/lib/services/isomorphic/text/desktop.ts
@@ -1,6 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
 import { readText, writeText } from '@tauri-apps/plugin-clipboard-manager';
-import { extractErrorMessage } from 'wellcrafted/error';
 import { tryAsync } from 'wellcrafted/result';
 import type { TextService } from './types';
 import { TextError } from './types';
@@ -13,37 +12,25 @@ export function createTextServiceDesktop(): TextService {
 					const text = await readText();
 					return text ?? null;
 				},
-				catch: (error) =>
-					TextError.Service({
-						message: `There was an error reading from the clipboard using the Tauri Clipboard Manager API. Please try again. ${extractErrorMessage(error)}`,
-					}),
+				catch: (error) => TextError.ClipboardRead({ cause: error }),
 			}),
 
 		copyToClipboard: (text) =>
 			tryAsync({
 				try: () => writeText(text),
-				catch: (error) =>
-					TextError.Service({
-						message: `There was an error copying to the clipboard using the Tauri Clipboard Manager API. Please try again. ${extractErrorMessage(error)}`,
-					}),
+				catch: (error) => TextError.ClipboardWrite({ cause: error }),
 			}),
 
 		writeToCursor: async (text) =>
 			tryAsync({
 				try: () => invoke<void>('write_text', { text }),
-				catch: (error) =>
-					TextError.Service({
-						message: `There was an error writing the text. Please try pasting manually with Cmd/Ctrl+V. ${extractErrorMessage(error)}`,
-					}),
+				catch: (error) => TextError.WriteToCursor({ cause: error }),
 			}),
 
 		simulateEnterKeystroke: () =>
 			tryAsync({
 				try: () => invoke<void>('simulate_enter_keystroke'),
-				catch: (error) =>
-					TextError.Service({
-						message: `There was an error simulating the Enter keystroke. Please press Enter manually. ${extractErrorMessage(error)}`,
-					}),
+				catch: (error) => TextError.SimulateKeystroke({ cause: error }),
 			}),
 	};
 }

--- a/apps/whispering/src/lib/services/isomorphic/text/extension.ts
+++ b/apps/whispering/src/lib/services/isomorphic/text/extension.ts
@@ -1,4 +1,3 @@
-import { extractErrorMessage } from 'wellcrafted/error';
 import { tryAsync } from 'wellcrafted/result';
 import { TextError, type TextService } from './types';
 
@@ -10,19 +9,13 @@ export function createTextServiceExtension(): TextService {
 					const text = await navigator.clipboard.readText();
 					return text || null;
 				},
-				catch: (error) =>
-					TextError.Service({
-						message: `Unable to read from clipboard: ${extractErrorMessage(error)}`,
-					}),
+				catch: (error) => TextError.ClipboardRead({ cause: error }),
 			}),
 
 		copyToClipboard: (text) =>
 			tryAsync({
 				try: () => navigator.clipboard.writeText(text),
-				catch: (error) =>
-					TextError.Service({
-						message: `Unable to copy to clipboard: ${extractErrorMessage(error)}`,
-					}),
+				catch: (error) => TextError.ClipboardWrite({ cause: error }),
 			}),
 
 		writeToCursor: (text) =>
@@ -32,16 +25,12 @@ export function createTextServiceExtension(): TextService {
 					await navigator.clipboard.writeText(text);
 					return writeTextToCursor(text);
 				},
-				catch: (error) =>
-					TextError.Service({
-						message: `Unable to write text at cursor position: ${extractErrorMessage(error)}`,
-					}),
+				catch: (error) => TextError.WriteToCursor({ cause: error }),
 			}),
 
 		simulateEnterKeystroke: async () =>
-			TextError.Service({
-				message:
-					'Simulating keystrokes is not supported in browser extensions for security reasons.',
+			TextError.NotSupported({
+				operation: 'Simulating keystrokes',
 			}),
 	};
 }

--- a/apps/whispering/src/lib/services/isomorphic/text/types.ts
+++ b/apps/whispering/src/lib/services/isomorphic/text/types.ts
@@ -1,9 +1,28 @@
-import { defineErrors, type InferErrors } from 'wellcrafted/error';
+import { defineErrors, extractErrorMessage, type InferErrors } from 'wellcrafted/error';
 import type { Result } from 'wellcrafted/result';
 import type { MaybePromise, WhisperingError } from '$lib/result';
 
 export const TextError = defineErrors({
-	Service: ({ message }: { message: string }) => ({ message }),
+	ClipboardRead: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to read from clipboard: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	ClipboardWrite: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to write to clipboard: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	WriteToCursor: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to write text at cursor position: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	SimulateKeystroke: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to simulate keystroke: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	NotSupported: ({ operation }: { operation: string }) => ({
+		message: `${operation} is not supported in this environment for security reasons.`,
+		operation,
+	}),
 });
 export type TextError = InferErrors<typeof TextError>;
 

--- a/apps/whispering/src/lib/services/isomorphic/text/web.ts
+++ b/apps/whispering/src/lib/services/isomorphic/text/web.ts
@@ -1,4 +1,3 @@
-import { extractErrorMessage } from 'wellcrafted/error';
 import { Ok, tryAsync } from 'wellcrafted/result';
 import type { TextService } from './types';
 import { TextError } from './types';
@@ -11,19 +10,13 @@ export function createTextServiceWeb(): TextService {
 					const text = await navigator.clipboard.readText();
 					return text || null;
 				},
-				catch: (error) =>
-					TextError.Service({
-						message: `There was an error reading from the clipboard using the browser Clipboard API. Please try again. ${extractErrorMessage(error)}`,
-					}),
+				catch: (error) => TextError.ClipboardRead({ cause: error }),
 			}),
 
 		copyToClipboard: async (text) => {
 			const { error: copyError } = await tryAsync({
 				try: () => navigator.clipboard.writeText(text),
-				catch: (error) =>
-					TextError.Service({
-						message: `There was an error copying to the clipboard using the browser Clipboard API. Please try again. ${extractErrorMessage(error)}`,
-					}),
+				catch: (error) => TextError.ClipboardWrite({ cause: error }),
 			});
 
 			if (copyError) {
@@ -38,16 +31,14 @@ export function createTextServiceWeb(): TextService {
 			// In web browsers, we cannot programmatically paste for security reasons
 			// We can copy the text to clipboard but the user must manually paste with Cmd/Ctrl+V
 			await navigator.clipboard.writeText(text);
-			return TextError.Service({
-				message:
-					'Text copied to clipboard. Automatic paste is not supported in web browsers for security reasons. Please paste manually using Cmd/Ctrl+V.',
+			return TextError.NotSupported({
+				operation: 'Automatic paste',
 			});
 		},
 
 		simulateEnterKeystroke: async () =>
-			TextError.Service({
-				message:
-					'Simulating keystrokes is not supported in web browsers for security reasons.',
+			TextError.NotSupported({
+				operation: 'Simulating keystrokes',
 			}),
 	};
 }

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/packages/epicenter/src/shared/errors.ts
+++ b/packages/epicenter/src/shared/errors.ts
@@ -1,7 +1,7 @@
 import { defineErrors, type InferErrors } from 'wellcrafted/error';
 
 export const ExtensionError = defineErrors({
-	TableOperation: ({
+	Table: ({
 		tableName,
 		rowId,
 		operation,
@@ -15,7 +15,7 @@ export const ExtensionError = defineErrors({
 		rowId,
 		operation,
 	}),
-	FileOperation: ({
+	File: ({
 		filename,
 		filePath,
 		operation,
@@ -29,7 +29,7 @@ export const ExtensionError = defineErrors({
 		filePath,
 		operation,
 	}),
-	DirectoryOperation: ({
+	Directory: ({
 		directory,
 		operation,
 	}: {

--- a/packages/svelte-utils/src/createPersistedState.svelte.ts
+++ b/packages/svelte-utils/src/createPersistedState.svelte.ts
@@ -174,10 +174,10 @@ export function createPersistedState<TSchema extends StandardSchemaV1>({
 }
 
 const ParseError = defineErrors({
-	Json: ({ value, parseError }: { value: string; parseError: string }) => ({
-		message: `Failed to parse JSON for value "${value.slice(0, 100)}...": ${parseError}`,
+	Json: ({ value, cause }: { value: string; cause: unknown }) => ({
+		message: `Failed to parse JSON for value "${value.slice(0, 100)}...": ${extractErrorMessage(cause)}`,
 		value,
-		parseError,
+		cause,
 	}),
 });
 type ParseError = InferErrors<typeof ParseError>;
@@ -188,7 +188,7 @@ function parseJson(value: string) {
 		catch: (e) =>
 			ParseError.Json({
 				value,
-				parseError: extractErrorMessage(e),
+				cause: e,
 			}),
 	});
 }

--- a/specs/20260303T120000-completion-error-thiserror-redesign.md
+++ b/specs/20260303T120000-completion-error-thiserror-redesign.md
@@ -100,24 +100,24 @@ const { data: completion, error: groqApiError } = await tryAsync({
 			],
 		}),
 	catch: (error) => {
-		if (!(error instanceof Groq.APIError)) throw error;
-		if (!error.status && error.name === 'APIConnectionError') {
+		if (error instanceof Groq.APIConnectionError) {
 			return CompletionError.ConnectionFailed({ cause: error });
 		}
-		return CompletionError.Http({ status: error.status ?? 0, cause: error });
+		if (!(error instanceof Groq.APIError)) throw error;
+		return CompletionError.Http({ status: error.status, cause: error });
 	},
 });
 
 if (groqApiError) return Err(groqApiError);
 ```
 
-The entire 30-line status mapping collapses into 2 branches inside the catch handler. No more destructuring `{ status, name }` after `tryAsync` — the mapping happens at the catch site.
+The entire 30-line status mapping collapses into 2 branches inside the catch handler. The `instanceof APIConnectionError` check comes first (since it's a subclass of `APIError`), and after that guard, TypeScript narrows `error.status` to `number` — no `?? 0` needed.
 
 ### 3. `anthropic.ts` — Same pattern as groq
 
 **Before (lines 34–63):** 30-line if-chain.
 
-**After:** Same 2-branch catch pattern. Replace `Anthropic.APIError` instanceof check, same `ConnectionFailed` vs `Http` split.
+**After:** Same 2-branch catch pattern. `instanceof Anthropic.APIConnectionError` first, then `instanceof Anthropic.APIError` guard. `error.status` narrows to `number` after the connection error early return.
 
 ### 4. `openai-compatible.ts` — Same pattern + status overrides
 
@@ -126,20 +126,19 @@ The entire 30-line status mapping collapses into 2 branches inside the catch han
 **After:**
 ```typescript
 catch: (error) => {
-	if (!(error instanceof OpenAI.APIError)) throw error;
-	if (!error.status && error.name === 'APIConnectionError') {
+	if (error instanceof OpenAI.APIConnectionError) {
 		return CompletionError.ConnectionFailed({ cause: error });
 	}
-	const status = error.status ?? 0;
-	const override = config.statusMessageOverrides?.[status];
+	if (!(error instanceof OpenAI.APIError)) throw error;
+	const override = config.statusMessageOverrides?.[error.status];
 	return CompletionError.Http({
-		status,
+		status: error.status,
 		cause: override ?? error,
 	});
 },
 ```
 
-Status override check moves into the catch handler. If override exists, it becomes the cause (producing a clean message). If not, the raw SDK error is the cause.
+The `instanceof APIConnectionError` check comes first — since it's a subclass of `APIError`, it must be caught before the general `APIError` guard. After the connection error early return, TypeScript narrows `error.status` to `number` (not `number | undefined`), eliminating the need for `?? 0`. Status override check uses `error.status` directly.
 
 ### 5. `google.ts` — No changes
 

--- a/specs/20260303T120000-completion-error-thiserror-redesign.md
+++ b/specs/20260303T120000-completion-error-thiserror-redesign.md
@@ -1,0 +1,166 @@
+# Completion Error Redesign: thiserror-Inspired Variants
+
+**Created**: 2026-03-03
+**Status**: Implemented
+**Scope**: `apps/whispering/src/lib/services/isomorphic/completion/` — 7 files
+
+## Summary
+
+Redesign `CompletionError` from 11 status-code-mapped variants to 4 recovery-strategy-based variants, following Rust's `thiserror` principle: **each variant represents a different recovery strategy, not a different cause.** HTTP status codes become data on the `Http` variant rather than separate variant identities.
+
+## Motivation
+
+The current design has 11 variants (`BadRequest`, `Unauthorized`, `Forbidden`, `ModelNotFound`, `UnprocessableEntity`, `RateLimit`, `ServerError`, `ConnectionFailed`, `EmptyResponse`, `MissingParam`, `Api`). Problems:
+
+1. **No consumer discriminates on the HTTP variants.** Every call site does `if (completionError) return Err(completionError.message)` — the `.tag` is never inspected for `BadRequest` vs `RateLimit` vs `Unauthorized`.
+2. **30 lines of status-code mapping duplicated 3 times** across `groq.ts`, `anthropic.ts`, and `openai-compatible.ts`. Identical `if (status === 400) ... if (status === 401) ...` chains.
+3. **Redundant message prefixes.** `"Rate limit exceeded: Rate limit exceeded on ..."` — the SDK error already contains the descriptive message, and `extractErrorMessage` pulls it out. The prefix duplicates what the cause already says.
+4. **8 of 11 variants have identical shape** (`{ cause: unknown }` → `{ message, cause }`), differing only in message prefix. This is a `thiserror` anti-pattern — when variants share shape and handling, they're the same variant with different data.
+
+## Design
+
+### New `CompletionError` (4 variants)
+
+```typescript
+// types.ts
+export const CompletionError = defineErrors({
+	/** HTTP-level failure from the provider API. Status preserved for callers that need it. */
+	Http: ({ status, cause }: { status: number; cause: unknown }) => ({
+		message: `Request failed (${status}): ${extractErrorMessage(cause)}`,
+		status,
+		cause,
+	}),
+	/** Network/DNS/TLS failure — never reached the server */
+	ConnectionFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Connection failed: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	/** Provider returned a successful response with no usable content */
+	EmptyResponse: ({ providerLabel }: { providerLabel: string }) => ({
+		message: `${providerLabel} API returned an empty response`,
+		providerLabel,
+	}),
+	/** Required parameter was not provided */
+	MissingParam: ({ param }: { param: string }) => ({
+		message: `${param} is required`,
+		param,
+	}),
+});
+export type CompletionError = InferErrors<typeof CompletionError>;
+```
+
+**Why each variant exists:**
+
+| Variant | Recovery strategy | Example consumer action |
+|---|---|---|
+| `Http` | Show message; caller can inspect `.status` for retry (429), re-auth (401), etc. | `if (error.status === 429) showRetryTimer()` |
+| `ConnectionFailed` | "Check your internet" / automatic retry | Different from Http — server was never reached |
+| `EmptyResponse` | Model/prompt issue — user should adjust | No cause to inspect, just a provider label |
+| `MissingParam` | Validation error — fix the form | No cause, just which param is missing |
+
+### Removed variants
+
+`BadRequest`, `Unauthorized`, `Forbidden`, `ModelNotFound`, `UnprocessableEntity`, `RateLimit`, `ServerError`, `Api` — all collapse into `Http`. The status code is preserved as `error.status` for any future consumer that needs it.
+
+### Status message overrides (`openai-compatible.ts`)
+
+OpenRouter's `statusMessageOverrides` (e.g., `402: 'Insufficient credits...'`) still work naturally. When an override exists, the override string becomes the cause:
+
+```typescript
+const override = config.statusMessageOverrides?.[status];
+if (override) {
+	return CompletionError.Http({ status, cause: override });
+}
+```
+
+This produces: `"Request failed (402): Insufficient credits in your OpenRouter account."` — cleaner than before because there's no redundant "API error:" prefix.
+
+## File-by-File Changes
+
+### 1. `types.ts` — Replace error definitions
+
+**Before:** 11 variants (53 lines of `defineErrors`)
+**After:** 4 variants (~20 lines)
+
+Remove `BadRequest`, `Unauthorized`, `Forbidden`, `ModelNotFound`, `UnprocessableEntity`, `RateLimit`, `ServerError`, `Api`. Add `Http` with `status: number` field. Keep `ConnectionFailed`, `EmptyResponse`, `MissingParam` unchanged.
+
+### 2. `groq.ts` — Replace status mapping with 2-branch catch
+
+**Before (lines 37–66):** 30-line if-chain mapping status codes to individual variants.
+
+**After:**
+```typescript
+const { data: completion, error: groqApiError } = await tryAsync({
+	try: () =>
+		client.chat.completions.create({
+			model,
+			messages: [
+				{ role: 'system', content: systemPrompt },
+				{ role: 'user', content: userPrompt },
+			],
+		}),
+	catch: (error) => {
+		if (!(error instanceof Groq.APIError)) throw error;
+		if (!error.status && error.name === 'APIConnectionError') {
+			return CompletionError.ConnectionFailed({ cause: error });
+		}
+		return CompletionError.Http({ status: error.status ?? 0, cause: error });
+	},
+});
+
+if (groqApiError) return Err(groqApiError);
+```
+
+The entire 30-line status mapping collapses into 2 branches inside the catch handler. No more destructuring `{ status, name }` after `tryAsync` — the mapping happens at the catch site.
+
+### 3. `anthropic.ts` — Same pattern as groq
+
+**Before (lines 34–63):** 30-line if-chain.
+
+**After:** Same 2-branch catch pattern. Replace `Anthropic.APIError` instanceof check, same `ConnectionFailed` vs `Http` split.
+
+### 4. `openai-compatible.ts` — Same pattern + status overrides
+
+**Before (lines 152–187):** 35-line if-chain with status override check.
+
+**After:**
+```typescript
+catch: (error) => {
+	if (!(error instanceof OpenAI.APIError)) throw error;
+	if (!error.status && error.name === 'APIConnectionError') {
+		return CompletionError.ConnectionFailed({ cause: error });
+	}
+	const status = error.status ?? 0;
+	const override = config.statusMessageOverrides?.[status];
+	return CompletionError.Http({
+		status,
+		cause: override ?? error,
+	});
+},
+```
+
+Status override check moves into the catch handler. If override exists, it becomes the cause (producing a clean message). If not, the raw SDK error is the cause.
+
+### 5. `google.ts` — No changes
+
+Google already uses a single catch-all pattern (`CompletionError.Api({ cause: error })`). Change `Api` → `Http` with `status: 0` (Google's SDK doesn't expose status codes, so 0 signals "unknown"):
+
+```typescript
+catch: (error) =>
+	CompletionError.Http({ status: 0, cause: error }),
+```
+
+### 6. `openai.ts`, `openrouter.ts`, `custom.ts` — No changes
+
+These files use the `createOpenAiCompatibleCompletionService` factory. They don't reference `CompletionError` variants directly (except `custom.ts` which uses `MissingParam`, which is unchanged).
+
+### 7. Consumer: `transformer.ts` — No changes needed
+
+Every consumer already does `if (completionError) return Err(completionError.message)`. The `.message` field still exists on all variants. No consumer matches on `.tag`, so no consumer breaks.
+
+## Verification
+
+1. `bun run typecheck` passes in `apps/whispering`
+2. `bun test` passes (if completion-related tests exist)
+3. Grep for any remaining references to removed variant names: `CompletionError.BadRequest`, `CompletionError.Unauthorized`, `CompletionError.Forbidden`, `CompletionError.ModelNotFound`, `CompletionError.UnprocessableEntity`, `CompletionError.RateLimit`, `CompletionError.ServerError`, `CompletionError.Api` — should return 0 results
+4. Grep for `CompletionError.Http` — should appear in `groq.ts`, `anthropic.ts`, `openai-compatible.ts`, `google.ts`


### PR DESCRIPTION
Every service in Whispering used to have a single catch-all error variant — `Service: ({ message }) => ({ message })`. This made error handling at the call site a coin flip: you'd match on `RecorderError` but had no way to distinguish "microphone not found" from "failed to stop recording" without parsing the message string. The query/UI layer couldn't make intelligent recovery decisions.

This PR splits each service's error type into semantic variants that carry structured data instead of strung-together messages.

```typescript
// BEFORE — one variant, stringly-typed
const RecorderError = defineErrors({
  Service: ({ message }: { message: string }) => ({ message }),
});

// AFTER — each failure mode is its own variant with structured cause
const RecorderError = defineErrors({
  EnumerateDevices: ({ cause }) => ({ message: `Failed to enumerate…`, cause }),
  AlreadyRecording: () => ({ message: 'A recording is already in progress…' }),
  InitFailed: ({ cause }) => ({ message: `Failed to initialize…`, cause }),
  StartFailed: ({ cause }) => ({ message: `Unable to start…`, cause }),
  StopFailed: ({ cause }) => ({ message: `Failed to stop…`, cause }),
  // ... 9 more domain-specific variants
});
```

The same treatment applies across all service boundaries:

```
┌──────────────────────────────────────────────────────────────┐
│  Service              │  Before    │  After                  │
├───────────────────────┼────────────┼─────────────────────────┤
│  RecorderError        │  1 variant │  14 semantic variants   │
│  CompletionError      │  1 variant │  4 recovery-strategy    │
│  DbError              │  1 variant │  4 (query/mutation/     │
│                       │            │   migration/noFiles)    │
│  TextError            │  1 variant │  3 (clipboard/paste/    │
│                       │            │   setText)              │
│  NotificationError    │  1 variant │  2 (show/permission)    │
│  DownloadError        │  1 variant │  2 (fetch/write)        │
│  SoundError, OsError, │  1 each   │  wellcrafted v0.33      │
│  AnalyticsError, etc. │            │  best practices         │
└──────────────────────────────────────────────────────────────┘
```

`CompletionError` got special attention — collapsed from a growing bag of provider-specific variants into 4 recovery-strategy variants (`Http`, `ConnectionFailed`, `EmptyResponse`, `MissingParam`). The discriminant is what the caller can *do about it*, not which provider threw:

```typescript
const CompletionError = defineErrors({
  Http: ({ status, cause }) => ({ message: `Request failed (${status}):…`, status, cause }),
  ConnectionFailed: ({ cause }) => ({ message: `Connection failed:…`, cause }),
  EmptyResponse: ({ providerLabel }) => ({ message: `${providerLabel} returned empty…` }),
  MissingParam: ({ param }) => ({ message: `${param} is required` }),
});
```

The completion providers also now use `instanceof APIConnectionError` instead of fragile `error.name === 'APIConnectionError'` string checks, and the Google provider properly discriminates `GoogleGenerativeAIFetchError` to extract real HTTP status codes instead of swallowing them into a generic message.

Lays groundwork for #975 (configurable retry logic — now possible since `Http` carries `status` and `ConnectionFailed` is a distinct variant).