### PR TITLE
refactor(workspace): replace updatedAt column mapping with onUpdate callback in .withDocument()

### DIFF
--- a/packages/epicenter/src/workspace/create-document.test.ts
+++ b/packages/epicenter/src/workspace/create-document.test.ts
@@ -42,7 +42,7 @@ function setup(
 	const { ydoc, tables } = setupTables();
 	const documents = createDocuments({
 		guidKey: 'id',
-		updatedAtKey: 'updatedAt',
+		onUpdate: () => ({ updatedAt: Date.now() }),
 		tableHelper: tables.files,
 		ydoc,
 		...overrides,
@@ -125,8 +125,8 @@ describe('createDocuments', () => {
 		});
 	});
 
-	describe('updatedAt auto-bump', () => {
-		test('content doc change bumps updatedAt on the row', async () => {
+	describe('onUpdate callback', () => {
+		test('content doc change invokes onUpdate and writes returned fields', async () => {
 			const { tables, documents } = setup();
 			tables.files.set({
 				id: 'f1',
@@ -146,7 +146,79 @@ describe('createDocuments', () => {
 			}
 		});
 
-		test('updatedAt bump uses DOCUMENTS_ORIGIN', async () => {
+		test('onUpdate callback return values are written to the row', async () => {
+			const customSchema = type({
+				id: 'string',
+				name: 'string',
+				updatedAt: 'number',
+				lastEditedBy: 'string',
+				_v: '1',
+			});
+			const ydoc = new Y.Doc({ guid: 'test-custom-onUpdate' });
+			const tables = createTables(ydoc, {
+				files: defineTable(customSchema),
+			});
+
+			const documents = createDocuments({
+				guidKey: 'id',
+				onUpdate: () => ({
+					updatedAt: 999,
+					lastEditedBy: 'test-user',
+				}),
+				tableHelper: tables.files,
+				ydoc,
+			});
+
+			tables.files.set({
+				id: 'f1',
+				name: 'test.txt',
+				updatedAt: 0,
+				lastEditedBy: '',
+				_v: 1,
+			});
+
+			const handle = await documents.open('f1');
+			handle.ydoc.getText('content').insert(0, 'hello');
+
+			const result = tables.files.get('f1');
+			expect(result.status).toBe('valid');
+			if (result.status === 'valid') {
+				expect(result.row.updatedAt).toBe(999);
+				expect(result.row.lastEditedBy).toBe('test-user');
+			}
+		});
+
+		test('onUpdate returning empty object is a no-op', async () => {
+			const ydoc = new Y.Doc({ guid: 'test-noop-onUpdate' });
+			const tables = createTables(ydoc, {
+				files: defineTable(fileSchema),
+			});
+
+			const documents = createDocuments({
+				guidKey: 'id',
+				onUpdate: () => ({}),
+				tableHelper: tables.files,
+				ydoc,
+			});
+
+			tables.files.set({
+				id: 'f1',
+				name: 'test.txt',
+				updatedAt: 0,
+				_v: 1,
+			});
+
+			const handle = await documents.open('f1');
+			handle.ydoc.getText('content').insert(0, 'hello');
+
+			const result = tables.files.get('f1');
+			expect(result.status).toBe('valid');
+			if (result.status === 'valid') {
+				expect(result.row.updatedAt).toBe(0); // unchanged
+			}
+		});
+
+		test('onUpdate bump uses DOCUMENTS_ORIGIN', async () => {
 			const { tables, documents } = setup();
 			tables.files.set({
 				id: 'f1',
@@ -166,7 +238,7 @@ describe('createDocuments', () => {
 			expect(capturedOrigin).toBe(DOCUMENTS_ORIGIN);
 		});
 
-		test('remote update does NOT bump updatedAt', async () => {
+		test('remote update does NOT invoke onUpdate', async () => {
 			const { tables, documents } = setup();
 			tables.files.set({
 				id: 'f1',
@@ -324,7 +396,7 @@ describe('createDocuments', () => {
 
 			const documents = createDocuments({
 				guidKey: 'id',
-				updatedAtKey: 'updatedAt',
+				onUpdate: () => ({ updatedAt: Date.now() }),
 				tableHelper: tables.files,
 				ydoc: new Y.Doc({ guid: 'test' }),
 				onRowDeleted: (_documents, guid) => {

--- a/packages/epicenter/src/workspace/create-document.ts
+++ b/packages/epicenter/src/workspace/create-document.ts
@@ -4,7 +4,7 @@
  * Creates a bidirectional link between a table and its associated content Y.Docs.
  * It:
  * 1. Manages Y.Doc creation and provider lifecycle for each content document
- * 2. Watches content documents → automatically bumps `updatedAt` on the row
+ * 2. Watches content documents → calls `onUpdate` callback and writes returned fields to the row
  * 3. Watches the table → automatically cleans up documents when rows are deleted
  *
  * Most users never call this directly — `createWorkspace()` wires it automatically
@@ -18,14 +18,17 @@
  *
  * const filesTable = defineTable(
  *   type({ id: 'string', name: 'string', updatedAt: 'number', _v: '1' }),
- * ).withDocument('content', { guid: 'id', updatedAt: 'updatedAt' });
+ * ).withDocument('content', {
+ *   guid: 'id',
+ *   onUpdate: () => ({ updatedAt: Date.now() }),
+ * });
  *
  * const ydoc = new Y.Doc({ guid: 'my-workspace' });
  * const tables = createTables(ydoc, { files: filesTable });
  *
  * const contentDocuments = createDocuments({
  *   guidKey: 'id',
- *   updatedAtKey: 'updatedAt',
+ *   onUpdate: () => ({ updatedAt: Date.now() }),
  *   tableHelper: tables.files,
  *   ydoc,
  * });
@@ -126,9 +129,9 @@ export type CreateDocumentsConfig<TRow extends BaseRow> = {
 	id?: string;
 	/** Column name storing the Y.Doc GUID. */
 	guidKey: keyof TRow & string;
-	/** Column name to bump when the doc changes. */
-	updatedAtKey: keyof TRow & string;
-	/** The table helper — needed to bump updatedAt and observe row deletions. */
+	/** Called when the content Y.Doc changes. Return the fields to write to the row. */
+	onUpdate: () => Partial<Omit<TRow, 'id'>>;
+	/** The table helper — needed to update the row and observe row deletions. */
 	tableHelper: TableHelper<TRow>;
 	/** The workspace Y.Doc — needed for transact() when bumping updatedAt. */
 	ydoc: Y.Doc;
@@ -171,7 +174,7 @@ export function createDocuments<TRow extends BaseRow>(
 	const {
 		id = '',
 		guidKey,
-		updatedAtKey,
+		onUpdate,
 		tableHelper,
 		ydoc: workspaceYdoc,
 		documentExtensions = [],
@@ -293,11 +296,11 @@ export function createDocuments<TRow extends BaseRow>(
 				throw err;
 			}
 
-			// Attach updatedAt observer — fires when content doc changes.
+			// Attach onUpdate observer — fires when content doc changes.
 			// The Y.Doc 'update' handler receives (update, origin, doc, transaction).
 			// We use transaction.local to skip remote sync updates — only local edits
-			// should bump updatedAt. Remote devices receive the bumped value via
-			// workspace ydoc sync; redundant bumping would cause unnecessary churn.
+			// should trigger the callback. Remote devices receive the updated values via
+			// workspace ydoc sync; redundant writes would cause unnecessary churn.
 			const updateHandler = (
 				_update: Uint8Array,
 				origin: unknown,
@@ -306,15 +309,12 @@ export function createDocuments<TRow extends BaseRow>(
 			) => {
 				// Skip updates from the documents manager itself to avoid loops
 				if (origin === DOCUMENTS_ORIGIN) return;
-				// Skip remote updates — only local edits bump updatedAt
+				// Skip remote updates — only local edits trigger onUpdate
 				if (!transaction.local) return;
 
-				// Find the row that references this guid and bump updatedAt
-				// For guid === rowId (common case), we can update directly
+				// Call the user's onUpdate callback and write the returned fields
 				workspaceYdoc.transact(() => {
-					tableHelper.update(guid, {
-						[updatedAtKey]: Date.now(),
-					} as Partial<Omit<TRow, 'id'>>);
+					tableHelper.update(guid, onUpdate());
 				}, DOCUMENTS_ORIGIN);
 			};
 

--- a/packages/epicenter/src/workspace/create-workspace.test.ts
+++ b/packages/epicenter/src/workspace/create-workspace.test.ts
@@ -487,7 +487,10 @@ describe('createWorkspace', () => {
 					updatedAt: 'number',
 					_v: '1',
 				}),
-			).withDocument('content', { guid: 'id', onUpdate: () => ({ updatedAt: Date.now() }) });
+			).withDocument('content', {
+				guid: 'id',
+				onUpdate: () => ({ updatedAt: Date.now() }),
+			});
 
 			const client = createWorkspace({
 				id: 'doc-test',
@@ -518,7 +521,10 @@ describe('createWorkspace', () => {
 					updatedAt: 'number',
 					_v: '1',
 				}),
-			).withDocument('content', { guid: 'id', onUpdate: () => ({ updatedAt: Date.now() }) });
+			).withDocument('content', {
+				guid: 'id',
+				onUpdate: () => ({ updatedAt: Date.now() }),
+			});
 
 			const client = createWorkspace({
 				id: 'doc-ext-test',
@@ -607,7 +613,10 @@ describe('createWorkspace', () => {
 					updatedAt: 'number',
 					_v: '1',
 				}),
-			).withDocument('content', { guid: 'id', onUpdate: () => ({ updatedAt: Date.now() }) });
+			).withDocument('content', {
+				guid: 'id',
+				onUpdate: () => ({ updatedAt: Date.now() }),
+			});
 
 			const client = createWorkspace({
 				id: 'doc-destroy-test',
@@ -631,7 +640,10 @@ describe('createWorkspace', () => {
 					updatedAt: 'number',
 					_v: '1',
 				}),
-			).withDocument('content', { guid: 'id', onUpdate: () => ({ updatedAt: Date.now() }) });
+			).withDocument('content', {
+				guid: 'id',
+				onUpdate: () => ({ updatedAt: Date.now() }),
+			});
 
 			const notesTable = defineTable(
 				type({
@@ -640,7 +652,10 @@ describe('createWorkspace', () => {
 					bodyUpdatedAt: 'number',
 					_v: '1',
 				}),
-			).withDocument('body', { guid: 'bodyDocId', onUpdate: () => ({ bodyUpdatedAt: Date.now() }) });
+			).withDocument('body', {
+				guid: 'bodyDocId',
+				onUpdate: () => ({ bodyUpdatedAt: Date.now() }),
+			});
 
 			const client = createWorkspace({
 				id: 'multi-doc-test',

--- a/packages/epicenter/src/workspace/create-workspace.test.ts
+++ b/packages/epicenter/src/workspace/create-workspace.test.ts
@@ -487,7 +487,7 @@ describe('createWorkspace', () => {
 					updatedAt: 'number',
 					_v: '1',
 				}),
-			).withDocument('content', { guid: 'id', updatedAt: 'updatedAt' });
+			).withDocument('content', { guid: 'id', onUpdate: () => ({ updatedAt: Date.now() }) });
 
 			const client = createWorkspace({
 				id: 'doc-test',
@@ -518,7 +518,7 @@ describe('createWorkspace', () => {
 					updatedAt: 'number',
 					_v: '1',
 				}),
-			).withDocument('content', { guid: 'id', updatedAt: 'updatedAt' });
+			).withDocument('content', { guid: 'id', onUpdate: () => ({ updatedAt: Date.now() }) });
 
 			const client = createWorkspace({
 				id: 'doc-ext-test',
@@ -548,12 +548,12 @@ describe('createWorkspace', () => {
 			)
 				.withDocument('content', {
 					guid: 'id',
-					updatedAt: 'updatedAt',
+					onUpdate: () => ({ updatedAt: Date.now() }),
 					tags: ['persistent', 'synced'],
 				})
 				.withDocument('thumb', {
 					guid: 'thumbId',
-					updatedAt: 'thumbUpdatedAt',
+					onUpdate: () => ({ thumbUpdatedAt: Date.now() }),
 					tags: ['ephemeral'],
 				});
 
@@ -607,7 +607,7 @@ describe('createWorkspace', () => {
 					updatedAt: 'number',
 					_v: '1',
 				}),
-			).withDocument('content', { guid: 'id', updatedAt: 'updatedAt' });
+			).withDocument('content', { guid: 'id', onUpdate: () => ({ updatedAt: Date.now() }) });
 
 			const client = createWorkspace({
 				id: 'doc-destroy-test',
@@ -631,7 +631,7 @@ describe('createWorkspace', () => {
 					updatedAt: 'number',
 					_v: '1',
 				}),
-			).withDocument('content', { guid: 'id', updatedAt: 'updatedAt' });
+			).withDocument('content', { guid: 'id', onUpdate: () => ({ updatedAt: Date.now() }) });
 
 			const notesTable = defineTable(
 				type({
@@ -640,7 +640,7 @@ describe('createWorkspace', () => {
 					bodyUpdatedAt: 'number',
 					_v: '1',
 				}),
-			).withDocument('body', { guid: 'bodyDocId', updatedAt: 'bodyUpdatedAt' });
+			).withDocument('body', { guid: 'bodyDocId', onUpdate: () => ({ bodyUpdatedAt: Date.now() }) });
 
 			const client = createWorkspace({
 				id: 'multi-doc-test',
@@ -732,7 +732,7 @@ describe('createWorkspace', () => {
 
 			const documents = createDocuments({
 				guidKey: 'id',
-				updatedAtKey: 'updatedAt',
+				onUpdate: () => ({ updatedAt: Date.now() }),
 				tableHelper: tables.files,
 				ydoc: mockYdoc,
 				documentExtensions: [
@@ -800,7 +800,7 @@ describe('createWorkspace', () => {
 
 			const documents = createDocuments({
 				guidKey: 'id',
-				updatedAtKey: 'updatedAt',
+				onUpdate: () => ({ updatedAt: Date.now() }),
 				tableHelper: tables.files,
 				ydoc: mockYdoc,
 				documentExtensions: [

--- a/packages/epicenter/src/workspace/create-workspace.ts
+++ b/packages/epicenter/src/workspace/create-workspace.ts
@@ -173,7 +173,7 @@ export function createWorkspace<
 			const documents = createDocuments({
 				id,
 				guidKey: documentConfig.guid as keyof BaseRow & string,
-				updatedAtKey: documentConfig.updatedAt as keyof BaseRow & string,
+				onUpdate: documentConfig.onUpdate,
 				tableHelper,
 				ydoc,
 				documentExtensions: documentExtensionRegistrations,

--- a/packages/epicenter/src/workspace/define-table.test.ts
+++ b/packages/epicenter/src/workspace/define-table.test.ts
@@ -246,13 +246,18 @@ describe('defineTable', () => {
 	});
 
 	describe('withDocument', () => {
+		const noopUpdate = () => ({});
+
 		test('shorthand path adds documents to definition', () => {
 			const files = defineTable(
 				type({ id: 'string', name: 'string', updatedAt: 'number', _v: '1' }),
-			).withDocument('content', { guid: 'id', updatedAt: 'updatedAt' });
+			).withDocument('content', {
+				guid: 'id',
+				onUpdate: () => ({ updatedAt: Date.now() }),
+			});
 
 			expect(files.documents.content.guid).toBe('id');
-			expect(files.documents.content.updatedAt).toBe('updatedAt');
+			expect(typeof files.documents.content.onUpdate).toBe('function');
 			expect(files.documents.content.tags).toEqual([]);
 		});
 
@@ -266,11 +271,11 @@ describe('defineTable', () => {
 				}),
 			).withDocument('content', {
 				guid: 'docId',
-				updatedAt: 'modifiedAt',
+				onUpdate: () => ({ modifiedAt: Date.now() }),
 			});
 
 			expect(notes.documents.content.guid).toBe('docId');
-			expect(notes.documents.content.updatedAt).toBe('modifiedAt');
+			expect(typeof notes.documents.content.onUpdate).toBe('function');
 			expect(notes.documents.content.tags).toEqual([]);
 		});
 
@@ -280,24 +285,23 @@ describe('defineTable', () => {
 					id: 'string',
 					bodyDocId: 'string',
 					coverDocId: 'string',
-					bodyUpdatedAt: 'number',
-					coverUpdatedAt: 'number',
+					updatedAt: 'number',
 					_v: '1',
 				}),
 			)
 				.withDocument('body', {
 					guid: 'bodyDocId',
-					updatedAt: 'bodyUpdatedAt',
+					onUpdate: () => ({ updatedAt: Date.now() }),
 				})
 				.withDocument('cover', {
 					guid: 'coverDocId',
-					updatedAt: 'coverUpdatedAt',
+					onUpdate: () => ({ updatedAt: Date.now() }),
 				});
 
 			expect(notes.documents.body.guid).toBe('bodyDocId');
-			expect(notes.documents.body.updatedAt).toBe('bodyUpdatedAt');
+			expect(typeof notes.documents.body.onUpdate).toBe('function');
 			expect(notes.documents.cover.guid).toBe('coverDocId');
-			expect(notes.documents.cover.updatedAt).toBe('coverUpdatedAt');
+			expect(typeof notes.documents.cover.onUpdate).toBe('function');
 		});
 
 		test('table without withDocument keeps documents map empty', () => {
@@ -313,12 +317,12 @@ describe('defineTable', () => {
 				type({ id: 'string', name: 'string', updatedAt: 'number', _v: '1' }),
 			).withDocument('content', {
 				guid: 'id',
-				updatedAt: 'updatedAt',
+				onUpdate: () => ({ updatedAt: Date.now() }),
 				tags: ['persistent'],
 			});
 
 			expect(files.documents.content.guid).toBe('id');
-			expect(files.documents.content.updatedAt).toBe('updatedAt');
+			expect(typeof files.documents.content.onUpdate).toBe('function');
 			expect(files.documents.content.tags).toEqual(['persistent']);
 		});
 
@@ -327,19 +331,22 @@ describe('defineTable', () => {
 				type({ id: 'string', name: 'string', updatedAt: 'number', _v: '1' }),
 			).withDocument('content', {
 				guid: 'id',
-				updatedAt: 'updatedAt',
+				onUpdate: () => ({ updatedAt: Date.now() }),
 				tags: ['persistent', 'synced'] as const,
 			});
 
 			expect(files.documents.content.guid).toBe('id');
-			expect(files.documents.content.updatedAt).toBe('updatedAt');
+			expect(typeof files.documents.content.onUpdate).toBe('function');
 			expect(files.documents.content.tags).toEqual(['persistent', 'synced']);
 		});
 
 		test('withDocument without tags defaults to empty array', () => {
 			const files = defineTable(
 				type({ id: 'string', name: 'string', updatedAt: 'number', _v: '1' }),
-			).withDocument('content', { guid: 'id', updatedAt: 'updatedAt' });
+			).withDocument('content', {
+				guid: 'id',
+				onUpdate: noopUpdate,
+			});
 
 			expect(files.documents.content.tags).toEqual([]);
 		});
@@ -347,7 +354,10 @@ describe('defineTable', () => {
 		test('withDocument preserves schema validation and migrate behavior', () => {
 			const files = defineTable(
 				type({ id: 'string', name: 'string', updatedAt: 'number', _v: '1' }),
-			).withDocument('content', { guid: 'id', updatedAt: 'updatedAt' });
+			).withDocument('content', {
+				guid: 'id',
+				onUpdate: () => ({ updatedAt: Date.now() }),
+			});
 
 			// Schema still works
 			const result = files.schema['~standard'].validate({
@@ -378,14 +388,14 @@ describe('defineTable', () => {
 			void _invalidRow;
 		});
 
-		test('rejects withDocument mappings that reference missing keys', () => {
+		test('rejects withDocument mappings that reference missing guid keys', () => {
 			const files = defineTable(
 				type({ id: 'string', updatedAt: 'number', _v: '1' }),
 			);
 			files.withDocument('content', {
 				// @ts-expect-error guid key must exist on the row schema
 				guid: 'missing',
-				updatedAt: 'updatedAt',
+				onUpdate: () => ({}),
 			});
 		});
 
@@ -395,39 +405,28 @@ describe('defineTable', () => {
 					id: 'string',
 					bodyDocId: 'string',
 					coverDocId: 'string',
-					bodyUpdatedAt: 'number',
-					coverUpdatedAt: 'number',
+					updatedAt: 'number',
 					_v: '1',
 				}),
 			).withDocument('body', {
 				guid: 'bodyDocId',
-				updatedAt: 'bodyUpdatedAt',
+				onUpdate: () => ({ updatedAt: Date.now() }),
 			});
 			notes.withDocument('cover', {
 				// @ts-expect-error bodyDocId is already claimed by the 'body' document
 				guid: 'bodyDocId',
-				updatedAt: 'coverUpdatedAt',
+				onUpdate: () => ({ updatedAt: Date.now() }),
 			});
 		});
 
-		test('rejects reusing an updatedAt column claimed by a prior withDocument', () => {
-			const notes = defineTable(
-				type({
-					id: 'string',
-					bodyDocId: 'string',
-					coverDocId: 'string',
-					bodyUpdatedAt: 'number',
-					coverUpdatedAt: 'number',
-					_v: '1',
-				}),
-			).withDocument('body', {
-				guid: 'bodyDocId',
-				updatedAt: 'bodyUpdatedAt',
-			});
-			notes.withDocument('cover', {
-				guid: 'coverDocId',
-				// @ts-expect-error bodyUpdatedAt is already claimed by the 'body' document
-				updatedAt: 'bodyUpdatedAt',
+		test('onUpdate return type is checked against the row schema', () => {
+			const files = defineTable(
+				type({ id: 'string', name: 'string', updatedAt: 'number', _v: '1' }),
+			);
+			files.withDocument('content', {
+				guid: 'id',
+				// @ts-expect-error nonExistent is not a column on the row
+				onUpdate: () => ({ nonExistent: 123 }),
 			});
 		});
 	});

--- a/packages/epicenter/src/workspace/define-table.ts
+++ b/packages/epicenter/src/workspace/define-table.ts
@@ -17,7 +17,10 @@
  * // Shorthand with document config
  * const files = defineTable(
  *   type({ id: 'string', name: 'string', updatedAt: 'number', _v: '1' }),
- * ).withDocument('content', { guid: 'id', updatedAt: 'updatedAt' });
+ * ).withDocument('content', {
+ *   guid: 'id',
+ *   onUpdate: () => ({ updatedAt: Date.now() }),
+ * });
  *
  * // Variadic for multiple versions with migration
  * const posts = defineTable(
@@ -33,7 +36,10 @@
  * // Shorthand with document config (multiple documents)
  * const notes = defineTable(
  *   type({ id: 'string', bodyDocId: 'string', bodyUpdatedAt: 'number', _v: '1' }),
- * ).withDocument('body', { guid: 'bodyDocId', updatedAt: 'bodyUpdatedAt' });
+ * ).withDocument('body', {
+ *   guid: 'bodyDocId',
+ *   onUpdate: () => ({ bodyUpdatedAt: Date.now() }),
+ * });
  * ```
  */
 
@@ -45,7 +51,6 @@ import type {
 	ClaimedDocumentColumns,
 	DocumentConfig,
 	LastSchema,
-	NumberKeysOf,
 	StringKeysOf,
 	TableDefinition,
 } from './types.js';
@@ -66,40 +71,44 @@ type TableDefinitionWithDocBuilder<
 	/**
 	 * Declare a named document on this table.
 	 *
-	 * Maps a document concept (e.g., 'content') to a GUID column and an updatedAt column.
+	 * Maps a document concept (e.g., 'content') to a GUID column and an `onUpdate` callback.
 	 * The name becomes a property under `client.documents.{tableName}` at runtime.
 	 *
 	 * Chainable — call multiple times for tables with multiple documents.
-	 * Each call claims its `guid` and `updatedAt` columns exclusively — subsequent
-	 * calls cannot reuse columns already bound to a prior document. This prevents
-	 * two documents from sharing a GUID (which would cause storage collisions).
+	 * Each call claims its `guid` column exclusively — subsequent calls cannot reuse
+	 * a GUID column already bound to a prior document (prevents storage collisions).
 	 *
 	 * @param name - The document name (becomes `client.documents.{tableName}[name]`)
-	 * @param config - Column mapping: `guid` (string column) and `updatedAt` (number column)
+	 * @param config - `guid` (string column), `onUpdate` (callback returning partial row), and optional `tags`
 	 *
 	 * @example
 	 * ```typescript
 	 * const files = defineTable(
 	 *   type({ id: 'string', name: 'string', updatedAt: 'number', _v: '1' }),
-	 * ).withDocument('content', { guid: 'id', updatedAt: 'updatedAt' });
+	 * ).withDocument('content', {
+	 *   guid: 'id',
+	 *   onUpdate: () => ({ updatedAt: Date.now() }),
+	 * });
 	 *
-	 * // Multiple documents — each must use unique columns
+	 * // Multiple documents — each must use a unique guid column
 	 * const notes = defineTable(
 	 *   type({ id: 'string', bodyDocId: 'string', coverDocId: 'string',
-	 *          bodyUpdatedAt: 'number', coverUpdatedAt: 'number', _v: '1' }),
+	 *          updatedAt: 'number', _v: '1' }),
 	 * )
-	 *   .withDocument('body', { guid: 'bodyDocId', updatedAt: 'bodyUpdatedAt' })
-	 *   .withDocument('cover', { guid: 'coverDocId', updatedAt: 'coverUpdatedAt' });
+	 *   .withDocument('body', {
+	 *     guid: 'bodyDocId',
+	 *     onUpdate: () => ({ updatedAt: Date.now() }),
+	 *   })
+	 *   .withDocument('cover', {
+	 *     guid: 'coverDocId',
+	 *     onUpdate: () => ({ updatedAt: Date.now() }),
+	 *   });
 	 * ```
 	 */
 	withDocument<
 		TName extends string,
 		TGuid extends Exclude<
 			StringKeysOf<StandardSchemaV1.InferOutput<LastSchema<TVersions>>>,
-			ClaimedDocumentColumns<TDocuments>
-		>,
-		TUpdatedAt extends Exclude<
-			NumberKeysOf<StandardSchemaV1.InferOutput<LastSchema<TVersions>>>,
 			ClaimedDocumentColumns<TDocuments>
 		>,
 		// Defaults to `never` when no tags are passed. This flows into
@@ -109,12 +118,22 @@ type TableDefinitionWithDocBuilder<
 		name: TName,
 		config: {
 			guid: TGuid;
-			updatedAt: TUpdatedAt;
+			onUpdate: () => Partial<
+				Omit<StandardSchemaV1.InferOutput<LastSchema<TVersions>>, 'id'>
+			>;
 			tags?: readonly TTags[];
 		},
 	): TableDefinitionWithDocBuilder<
 		TVersions,
-		TDocuments & Record<TName, DocumentConfig<TGuid, TUpdatedAt, TTags>>
+		TDocuments &
+			Record<
+				TName,
+				DocumentConfig<
+					TGuid,
+					StandardSchemaV1.InferOutput<LastSchema<TVersions>>,
+					TTags
+				>
+			>
 	>;
 };
 
@@ -236,7 +255,11 @@ function attachDocumentBuilder<
 				...def,
 				documents: {
 					...def.documents,
-					[name]: { ...config, tags: config.tags ?? [] },
+					[name]: {
+						guid: config.guid,
+						onUpdate: config.onUpdate,
+						tags: config.tags ?? [],
+					},
 				},
 			});
 		},

--- a/packages/epicenter/src/workspace/types.ts
+++ b/packages/epicenter/src/workspace/types.ts
@@ -154,13 +154,15 @@ export type InferTableVersionUnion<T> = T extends {
 /**
  * A named document declared via `.withDocument()`.
  *
- * Maps a document concept (e.g., 'content') to two columns on the table:
+ * Maps a document concept (e.g., 'content') to a GUID column and an `onUpdate` callback
+ * that fires when the content Y.Doc changes:
  * - `guid`: The column storing the Y.Doc GUID (must be a string column)
- * - `updatedAt`: The column to bump when the doc changes (must be a number column)
+ * - `onUpdate`: Zero-argument callback returning `Partial<Omit<TRow, 'id'>>` — the fields
+ *   to write when the doc changes. Callers control both the value and which columns to update.
  * - `tags`: Optional tag literals for document extension targeting
  *
  * @typeParam TGuid - Literal string type of the guid column name
- * @typeParam TUpdatedAt - Literal string type of the updatedAt column name
+ * @typeParam TRow - The row type of the table (used to type-check `onUpdate` return)
  * @typeParam TTags - Literal union of tag strings for document extension targeting.
  *   Defaults to `string` so bare `DocumentConfig` works as a wide constraint (accepts any tags).
  *   When `.withDocument()` is called without tags, `TTags` infers as `never` via the
@@ -169,11 +171,12 @@ export type InferTableVersionUnion<T> = T extends {
  */
 export type DocumentConfig<
 	TGuid extends string = string,
-	TUpdatedAt extends string = string,
+	TRow extends BaseRow = BaseRow,
 	TTags extends string = string,
 > = {
 	guid: TGuid;
-	updatedAt: TUpdatedAt;
+	/** Called when the content Y.Doc changes. Return the fields to write to the row. */
+	onUpdate: () => Partial<Omit<TRow, 'id'>>;
 	/**
 	 * Tag literals for document extension targeting.
 	 *
@@ -221,7 +224,7 @@ export type DocumentExtensionRegistration = {
  */
 export type ExtractAllDocumentTags<TTableDefs extends TableDefinitions> = {
 	[K in keyof TTableDefs]: TTableDefs[K] extends {
-		documents: Record<string, DocumentConfig<string, string, infer TTags>>;
+		documents: Record<string, DocumentConfig<string, BaseRow, infer TTags>>;
 	}
 		? TTags
 		: never;
@@ -236,27 +239,19 @@ export type StringKeysOf<TRow> = {
 }[keyof TRow & string];
 
 /**
- * Extract keys of `TRow` whose value type extends `number`.
- * Used to constrain the `updatedAt` parameter of `.withDocument()`.
- */
-export type NumberKeysOf<TRow> = {
-	[K in keyof TRow & string]: TRow[K] extends number ? K : never;
-}[keyof TRow & string];
-
-/**
- * Collect all column names already claimed as `guid` or `updatedAt` by prior
- * `.withDocument()` calls. Subsequent calls cannot reuse these columns,
- * preventing two documents from sharing a GUID (storage collision) or
- * racing on the same `updatedAt` timestamp.
+ * Collect all column names already claimed as `guid` by prior `.withDocument()` calls.
+ * Subsequent calls cannot reuse these columns, preventing two documents from sharing
+ * a GUID (which would cause storage collisions).
+ *
+ * With the `onUpdate` callback model, updatedAt columns are no longer claimed —
+ * multiple documents can write to the same column via their callbacks (last write wins).
  *
  * Requires `{}` (not `Record<string, never>`) as the initial empty `TDocuments`,
  * so that `keyof {}` = `never` and the union resolves cleanly.
  */
 export type ClaimedDocumentColumns<
 	TDocuments extends Record<string, DocumentConfig>,
-> =
-	| TDocuments[keyof TDocuments]['guid']
-	| TDocuments[keyof TDocuments]['updatedAt'];
+> = TDocuments[keyof TDocuments]['guid'];
 
 /**
  * A handle to an open content Y.Doc, returned by `documents.open()`.

--- a/packages/filesystem/src/table.ts
+++ b/packages/filesystem/src/table.ts
@@ -16,7 +16,7 @@ export const filesTable = defineTable(
 	}),
 ).withDocument('content', {
 	guid: 'id',
-	updatedAt: 'updatedAt',
+	onUpdate: () => ({ updatedAt: Date.now() }),
 	tags: ['persistent'],
 });
 

--- a/specs/20260304T000000-withDocument-onUpdate-callback.md
+++ b/specs/20260304T000000-withDocument-onUpdate-callback.md
@@ -1,0 +1,200 @@
+# withDocument: Replace updatedAt Column Mapping with onUpdate Callback
+
+**Date**: 2026-03-04
+**Status**: Draft
+**Author**: AI-assisted
+
+## Overview
+
+Replace the `updatedAt` column-name mapping in `.withDocument()` with a zero-argument `onUpdate` callback that returns a partial row update. This gives callers full control over what gets written when a content Y.Doc changes, instead of hardcoding `Date.now()` to a single `number` column.
+
+## Motivation
+
+### Current State
+
+```typescript
+// file-table.ts
+export const filesTable = defineTable(
+  type({
+    id: FileId,
+    name: 'string',
+    parentId: FileId.or(type.null),
+    type: "'file' | 'folder'",
+    size: 'number',
+    createdAt: 'number',
+    updatedAt: 'number',  // must be number — system writes Date.now()
+    trashedAt: 'number | null',
+    _v: '1',
+  }),
+).withDocument('content', {
+  guid: 'id',
+  updatedAt: 'updatedAt',  // column name, not a value
+  tags: ['persistent'],
+});
+```
+
+The type system enforces `updatedAt` must point to a `number` column via `NumberKeysOf<TRow>`. At runtime, `create-document.ts:316` writes `Date.now()` unconditionally.
+
+This creates problems:
+
+1. **Format inflexibility**: Callers who store timestamps as ISO strings or DateWithTimezoneStrings (`"2024-01-01T20:00:00.000Z|America/New_York"`) can't use those columns as `updatedAt`. They're forced to maintain a separate `number` column just for the document system.
+2. **No co-located writes**: If you want to write `lastEditedBy` or other metadata atomically when a doc changes, there's no hook — you'd need a separate observer that races with the system's own write.
+3. **Over-specified API**: The system dictates both *which column* and *what value* to write. Callers only need to say "what to do when a doc changes."
+
+### Desired State
+
+```typescript
+export const filesTable = defineTable(
+  type({
+    id: FileId,
+    name: 'string',
+    parentId: FileId.or(type.null),
+    type: "'file' | 'folder'",
+    size: 'number',
+    createdAt: 'number',
+    updatedAt: 'number',
+    trashedAt: 'number | null',
+    _v: '1',
+  }),
+).withDocument('content', {
+  guid: 'id',
+  onUpdate: () => ({ updatedAt: Date.now() }),
+  tags: ['persistent'],
+});
+```
+
+The callback takes zero arguments and returns `Partial<Omit<TRow, 'id'>>`. TypeScript verifies the returned object against the row shape. Callers compute whatever they need inline — `Date.now()`, `new Date().toISOString()`, a DateWithTimezoneString, multiple fields, etc.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+| --- | --- | --- |
+| Callback arity | Zero arguments | Nothing useful to pass — `Date.now()`, timezone, user ID are all app state the caller already has via closure. Keeps the API surface minimal. |
+| Callback return type | `Partial<Omit<TRow, 'id'>>` | Type-safe against the row schema. The system plugs the return value into `tableHelper.update(guid, ...)`. |
+| Remove `NumberKeysOf` from withDocument | Yes | No longer needed — the callback return type provides equivalent safety. |
+| Remove `ClaimedDocumentColumns` for updatedAt | Yes, for updatedAt only | The claiming was needed because the system auto-targeted a column. With a callback, the user owns the write. Guid claiming stays — two documents sharing a GUID still causes storage collisions. |
+| Dual API (column name OR callback) | No — callback only | One path through the code, one set of types. The column-name shorthand saves one line but adds a discriminated union and two code paths. |
+| `onUpdate` is required | Yes | A document without change tracking is a footgun — you'd have stale metadata and no way to detect it. If someone truly wants a no-op, `onUpdate: () => ({})` is explicit. |
+
+## Architecture
+
+```
+BEFORE:
+┌─────────────────────────────────────────────────┐
+│ .withDocument('content', {                      │
+│   guid: 'id',            ← string column name   │
+│   updatedAt: 'updatedAt' ← number column name   │
+│ })                                               │
+└───────────────────────┬─────────────────────────┘
+                        │
+                        ▼ runtime (create-document.ts:316)
+          tableHelper.update(guid, {
+              [updatedAtKey]: Date.now()   ← hardcoded
+          })
+
+AFTER:
+┌─────────────────────────────────────────────────┐
+│ .withDocument('content', {                      │
+│   guid: 'id',                  ← string column   │
+│   onUpdate: () => ({           ← user callback   │
+│     updatedAt: Date.now()                        │
+│   })                                             │
+│ })                                               │
+└───────────────────────┬─────────────────────────┘
+                        │
+                        ▼ runtime (create-document.ts:316)
+          tableHelper.update(guid, onUpdate())
+```
+
+## Implementation Plan
+
+### Phase 1: Type Changes
+
+- [ ] **1.1** In `types.ts`: Update `DocumentConfig` — replace `updatedAt: TUpdatedAt` with `onUpdate: () => Partial<Omit<TRow, 'id'>>`. This changes the type params: remove `TUpdatedAt`, add `TRow` (the inferred row type from the schema).
+- [ ] **1.2** In `types.ts`: Remove `NumberKeysOf` (no longer used anywhere).
+- [ ] **1.3** In `types.ts`: Update `ClaimedDocumentColumns` to only collect `guid` keys (not updatedAt).
+- [ ] **1.4** In `define-table.ts`: Update `TableDefinitionWithDocBuilder.withDocument` generic signature — remove the `TUpdatedAt` type parameter, add `TOnUpdate` constrained to `() => Partial<Omit<InferredRow, 'id'>>`.
+- [ ] **1.5** In `define-table.ts`: Update the config param shape from `{ guid, updatedAt, tags? }` to `{ guid, onUpdate, tags? }`.
+- [ ] **1.6** In `define-table.ts`: Update the runtime `attachDocumentBuilder` to store `onUpdate` instead of `updatedAt` in the documents map.
+- [ ] **1.7** In `define-table.ts`: Update JSDoc examples.
+
+### Phase 2: Runtime Changes
+
+- [ ] **2.1** In `create-document.ts`: Replace `updatedAtKey` in `CreateDocumentsConfig` with `onUpdate: () => Partial<Omit<TRow, 'id'>>`.
+- [ ] **2.2** In `create-document.ts`: Change the update handler (line ~316) from `{ [updatedAtKey]: Date.now() }` to `onUpdate()`.
+- [ ] **2.3** In `create-workspace.ts`: Update the wiring in the `createDocuments()` call (line ~176) to pass `onUpdate` from the document config instead of `updatedAtKey`.
+
+### Phase 3: Update Consumers
+
+- [ ] **3.1** In `packages/filesystem/src/file-table.ts`: Change `.withDocument('content', { guid: 'id', updatedAt: 'updatedAt', tags: ['persistent'] })` to `.withDocument('content', { guid: 'id', onUpdate: () => ({ updatedAt: Date.now() }), tags: ['persistent'] })`.
+- [ ] **3.2** Search for any other `.withDocument()` call sites and update them.
+
+### Phase 4: Update Tests
+
+- [ ] **4.1** In `define-table.test.ts`: Update all `withDocument` tests to use `onUpdate` callback instead of `updatedAt` column name.
+- [ ] **4.2** Update type error tests — the "rejects reusing an updatedAt column" test becomes irrelevant (remove it). The "rejects reusing a guid column" test stays.
+- [ ] **4.3** Add new type-level test: `onUpdate` return type is checked against the row schema (returning a non-existent column or wrong type is a compile error).
+- [ ] **4.4** In `create-workspace.test.ts`: Update all `withDocument` usages to use `onUpdate`.
+- [ ] **4.5** Add runtime test: verify the callback is actually invoked when a doc changes, and the returned values are written to the row.
+
+### Phase 5: Cleanup
+
+- [ ] **5.1** In `index.ts` (workspace package exports): Verify `DocumentConfig` export still works with the new shape. Remove `NumberKeysOf` export if it was exported.
+- [ ] **5.2** Update JSDoc on `DocumentConfig`, `CreateDocumentsConfig`, and `createDocuments`.
+
+## Edge Cases
+
+### onUpdate returns empty object
+
+1. User writes `onUpdate: () => ({})`
+2. `tableHelper.update(guid, {})` is called — should be a no-op
+3. Valid use case: user tracks changes via a separate observer and doesn't need the built-in bump
+
+### onUpdate returns fields that don't exist on the row
+
+1. User writes `onUpdate: () => ({ nonExistent: 123 })`
+2. TypeScript catches this at compile time — `Partial<Omit<TRow, 'id'>>` won't include `nonExistent`
+3. No runtime issue
+
+### onUpdate closure captures stale state
+
+1. User defines `onUpdate` at table definition time, captures a `let userId` variable
+2. The closure runs later when the doc changes — `userId` may have changed
+3. This is standard JavaScript closure behavior. Not our problem to solve, but worth noting in JSDoc.
+
+### Two documents with onUpdate writing to the same column
+
+1. `body` and `cover` documents both write `{ updatedAt: Date.now() }` via their respective callbacks
+2. Both fire independently — last write wins (LWW via Yjs)
+3. This is valid and expected. The `ClaimedDocumentColumns` restriction only applies to `guid` (preventing GUID collisions), not to onUpdate write targets.
+
+## Open Questions
+
+1. **Should `onUpdate` be optional?**
+   - If omitted, no row update happens when the doc changes (pure Y.Doc tracking with no metadata bump).
+   - **Recommendation**: Keep it required. A document with no change tracking is almost always a bug. `onUpdate: () => ({})` is an explicit no-op if someone truly wants it.
+
+2. **Should the `DocumentConfig` type carry the row type as a generic parameter?**
+   - Currently `DocumentConfig<TGuid, TUpdatedAt, TTags>`. With this change, the `onUpdate` return type needs to know the row shape.
+   - Options: (a) Add `TRow` as a type param to `DocumentConfig`, (b) Use a wide type (`Record<string, unknown>`) at the config level and narrow at the `withDocument` call site.
+   - **Recommendation**: Option (a) is cleaner — it keeps the type safety threaded through. Investigate whether this creates issues for `ExtractAllDocumentTags` or other type-level consumers of `DocumentConfig`.
+
+## Success Criteria
+
+- [ ] `.withDocument()` accepts `onUpdate: () => Partial<Omit<TRow, 'id'>>` instead of `updatedAt: string`
+- [ ] `NumberKeysOf` is removed from the codebase
+- [ ] All existing tests pass (updated to new API)
+- [ ] New type-level test verifies `onUpdate` return type is checked against row schema
+- [ ] New runtime test verifies callback is invoked and return values are written
+- [ ] `packages/filesystem/src/file-table.ts` compiles and works with the new API
+- [ ] `bun run typecheck` passes
+- [ ] `bun test` passes
+
+## References
+
+- `packages/epicenter/src/workspace/types.ts` — `DocumentConfig`, `NumberKeysOf`, `StringKeysOf`, `ClaimedDocumentColumns`
+- `packages/epicenter/src/workspace/define-table.ts` — `TableDefinitionWithDocBuilder.withDocument`, `attachDocumentBuilder`
+- `packages/epicenter/src/workspace/create-document.ts` — `CreateDocumentsConfig`, `createDocuments`, the update handler at line ~316
+- `packages/epicenter/src/workspace/create-workspace.ts` — wiring at line ~173
+- `packages/epicenter/src/workspace/define-table.test.ts` — withDocument tests starting line 248
+- `packages/filesystem/src/file-table.ts` — primary consumer


### PR DESCRIPTION
Replaces the `updatedAt` column-name mapping in `.withDocument()` with a zero-argument `onUpdate` callback returning `Partial<Omit<TRow, 'id'>>`, giving callers full control over what gets written when a Y.Doc changes.

The old API hardcoded `Date.now()` to a single `number` column, which meant callers storing timestamps as ISO strings or wanting to write multiple fields atomically on doc change were out of luck.

```typescript
// BEFORE — system dictates column name and value
.withDocument('content', {
  guid: 'id',
  updatedAt: 'updatedAt',       // must be a number column
  tags: ['persistent'],
})

// AFTER — caller owns the write
.withDocument('content', {
  guid: 'id',
  onUpdate: () => ({ updatedAt: Date.now() }),   // any Partial<Omit<TRow, 'id'>>
  tags: ['persistent'],
})
```

```
BEFORE:
  .withDocument('content', { guid, updatedAt })
         │
         ▼  runtime (create-document.ts)
  tableHelper.update(guid, { [updatedAtKey]: Date.now() })  ← hardcoded

AFTER:
  .withDocument('content', { guid, onUpdate })
         │
         ▼  runtime (create-document.ts)
  tableHelper.update(guid, onUpdate())  ← caller-controlled
```

### Type threading

`DocumentConfig` now carries `TRow` as a generic parameter (replacing `TUpdatedAt`), so the `onUpdate` return type is checked against the actual row schema at compile time:

```typescript
export type DocumentConfig<
  TGuid extends string = string,
  TRow extends BaseRow = BaseRow,
  TTags extends string = string,
> = {
  guid: TGuid;
  onUpdate: () => Partial<Omit<TRow, 'id'>>;
  tags: readonly TTags[];
};
```

Returning a non-existent column or wrong type from `onUpdate` is a compile error. `NumberKeysOf` is removed — the callback return type provides equivalent safety.

### Why callback-only (no dual API)?

One path through the code, one set of types. The column-name shorthand saves one line but adds a discriminated union and two code paths. `onUpdate: () => ({ updatedAt: Date.now() })` is explicit and trivial.

### Why `onUpdate` is required?

A document without change tracking is a footgun — stale metadata with no way to detect it. `onUpdate: () => ({})` is an explicit no-op for callers who truly don't need it.

### `ClaimedDocumentColumns` simplified

Only collects `guid` keys now (not `updatedAt`). Two documents writing to the same column via their `onUpdate` callbacks is valid — last write wins via Yjs LWW semantics. GUID claiming stays to prevent storage collisions.