### PR TITLE
refactor(errors): ban generic Service variant, update docs and code

### DIFF
--- a/.agents/skills/define-errors/SKILL.md
+++ b/.agents/skills/define-errors/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: create-tagged-error
+name: define-errors
 description: How to define and use defineErrors from wellcrafted. Use when creating new error types, updating error definitions, or reviewing error patterns. Covers variant factories, extractErrorMessage for cause, InferErrors/InferError for types, and call site patterns.
 metadata:
   author: epicenter
-  version: '2.0'
+  version: '3.0'
 ---
 
 # defineErrors
@@ -21,14 +21,15 @@ import {
 
 ## Core Rules
 
-1. All variants for a service live in **one `defineErrors` call** — never spread them across multiple calls
+1. All variants for a domain live in **one `defineErrors` call** — never spread them across multiple calls
 2. The factory function **returns `{ message, ...fields }`** — that is the entire API; no `.withMessage()`, `.withContext()`, or `.withCause()` chains
 3. **`cause: unknown`** is just a field like any other — accept it in the input and forward it in the return object
 4. **Call `extractErrorMessage(cause)` inside the factory**, never at the call site
 5. Each call like `MyError.Variant({ ... })` **returns `Err(...)` automatically** — no separate `FooErr` pair
 6. **Shadow the const with a same-name type** using `InferErrors` — `const FooError` / `type FooError`
 7. Use `InferError<typeof FooError.Variant>` to extract a single variant's type when needed
-8. Aim for 2–5 variants per service, each named by failure mode
+8. **Variant names describe the specific failure mode** — never use generic names like `Service`, `Error`, or `Failed`
+9. Aim for 2–5 variants per domain, each named by failure mode
 
 ## Patterns
 
@@ -71,16 +72,19 @@ return DbError.NotFound({ table: 'users', id: '123' });
 import { extractErrorMessage } from 'wellcrafted/error';
 
 export const FfmpegError = defineErrors({
-  Service: ({ operation, cause }: { operation: string; cause: unknown }) => ({
-    message: `Failed to ${operation}: ${extractErrorMessage(cause)}`,
-    operation,
+  CompressFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to compress audio: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+  VerifyFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to verify temp file: ${extractErrorMessage(cause)}`,
     cause,
   }),
 });
 export type FfmpegError = InferErrors<typeof FfmpegError>;
 
 // Call site — pass the raw caught error, never call extractErrorMessage here
-catch: (error) => FfmpegError.Service({ operation: 'compress audio', cause: error }),
+catch: (error) => FfmpegError.CompressFailed({ cause: error }),
 ```
 
 ### 4. Multiple variants in one object — discriminated union built-in
@@ -113,26 +117,40 @@ export type DeviceStreamError = InferErrors<typeof DeviceStreamError>;
 type NoDevicesFoundError = InferError<typeof DeviceStreamError.NoDevicesFound>;
 ```
 
-### 5. Simple service error — pass-through message from caller
+### 5. Domain errors with specific operation failures
 
 ```typescript
-export const RecorderError = defineErrors({
-  Service: ({ message }: { message: string }) => ({ message }),
+export const FsError = defineErrors({
+  ReadFailed: ({ path, cause }: { path: string; cause: unknown }) => ({
+    message: `Failed to read '${path}': ${extractErrorMessage(cause)}`,
+    path,
+    cause,
+  }),
+  WriteFailed: ({ path, cause }: { path: string; cause: unknown }) => ({
+    message: `Failed to write '${path}': ${extractErrorMessage(cause)}`,
+    path,
+    cause,
+  }),
+  DeleteFailed: ({ path, cause }: { path: string; cause: unknown }) => ({
+    message: `Failed to delete '${path}': ${extractErrorMessage(cause)}`,
+    path,
+    cause,
+  }),
 });
-export type RecorderError = InferErrors<typeof RecorderError>;
+export type FsError = InferErrors<typeof FsError>;
 
 // Call site
-return RecorderError.Service({ message: 'Already recording.' });
+return FsError.ReadFailed({ path: '/tmp/foo.txt', cause: error });
 ```
 
 ## Type Extraction
 
 ```typescript
 // Full union type for all variants
-type MyServiceError = InferErrors<typeof MyServiceError>;
+type HttpError = InferErrors<typeof HttpError>;
 
 // Single variant type
-type NotFoundError = InferError<typeof MyServiceError.NotFound>;
+type ConnectionError = InferError<typeof HttpError.Connection>;
 ```
 
 ## Anti-Patterns
@@ -152,7 +170,7 @@ catch: (error) => MyError.Failed({ cause: error });
 // WRONG — one defineErrors per variant (defeats the namespace grouping)
 const BusyError = defineErrors({ BusyError: () => ({ message: 'Busy' }) });
 const PermError = defineErrors({ PermError: () => ({ message: 'No perm' }) });
-// CORRECT — all variants for a service in one call
+// CORRECT — all variants for a domain in one call
 const RecorderError = defineErrors({
   Busy: () => ({ message: 'A recording is already in progress' }),
   PermissionDenied: () => ({ message: 'Microphone permission denied' }),
@@ -168,11 +186,12 @@ FooErr({ context: { id: '1' } });
 // CORRECT — each variant call returns Err(...) automatically
 FooError.NotFound({ id: '1' });
 
-// WRONG — monolithic single-variant error for a service with many failure modes
+// WRONG — generic "Service" variant name (says nothing about the failure mode)
 const RecorderError = defineErrors({
-  Error: ({ message }: { message: string }) => ({ message }), // Too vague
+  Service: ({ message }: { message: string }) => ({ message }),
 });
-// CORRECT — split by failure mode
+// RecorderError.Service({ message: '...' }) — "Service" is not a failure mode
+// CORRECT — name each variant by what actually went wrong
 const RecorderError = defineErrors({
   AlreadyRecording: () => ({ message: 'A recording is already in progress' }),
   PermissionDenied: ({ cause }: { cause: unknown }) => ({
@@ -182,6 +201,44 @@ const RecorderError = defineErrors({
   DeviceNotFound: ({ deviceId }: { deviceId: string }) => ({
     message: `Device not found: ${deviceId}`,
     deviceId,
+  }),
+});
+
+// WRONG — generic catch-all with operation string (hides failure modes behind a parameter)
+const FfmpegError = defineErrors({
+  Service: ({ operation, cause }: { operation: string; cause: unknown }) => ({
+    message: `Failed to ${operation}: ${extractErrorMessage(cause)}`,
+    operation,
+    cause,
+  }),
+});
+// FfmpegError.Service({ operation: 'compress audio', cause }) — variant name is meaningless
+// CORRECT — each operation is its own variant
+const FfmpegError = defineErrors({
+  CompressFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to compress audio: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+  VerifyFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to verify temp file: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+});
+
+// WRONG — monolithic single-variant error for a domain with many failure modes
+const RecorderError = defineErrors({
+  Error: ({ message }: { message: string }) => ({ message }), // Too vague
+});
+// CORRECT — split by failure mode
+const RecorderError = defineErrors({
+  AlreadyRecording: () => ({ message: 'A recording is already in progress' }),
+  InitFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to initialize recorder: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+  StreamAcquisition: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to acquire recording stream: ${extractErrorMessage(cause)}`,
+    cause,
   }),
 });
 ```

--- a/.agents/skills/error-handling/SKILL.md
+++ b/.agents/skills/error-handling/SKILL.md
@@ -53,7 +53,7 @@ const syncResult = trySync({
 		// For recoverable errors, return Ok with fallback value
 		return Ok('fallback-value');
 		// For unrecoverable errors, pass the raw cause — the constructor handles extractErrorMessage
-		return MyServiceError.OperationFailed({ cause: error });
+		return CompletionError.ConnectionFailed({ cause: error });
 	},
 });
 ```
@@ -70,10 +70,10 @@ const syncResult = trySync({
 
 ```typescript
 // ✅ GOOD: cause: error at call site, extractErrorMessage in constructor
-catch: (error) => MyServiceError.OperationFailed({ cause: error })
+catch: (error) => CompletionError.ConnectionFailed({ cause: error })
 
 // ❌ BAD: extractErrorMessage at call site, string passed to constructor
-catch: (error) => MyServiceError.OperationFailed({ underlyingError: extractErrorMessage(error) })
+catch: (error) => CompletionError.ConnectionFailed({ underlyingError: extractErrorMessage(error) })
 ```
 
 8. **CRITICAL: Wrap destructured errors with Err()** - When you destructure `{ data, error }` from tryAsync/trySync, the `error` variable is the raw error value, NOT wrapped in `Err`. You must wrap it before returning:
@@ -139,7 +139,7 @@ const { data: content } = await tryAsync({
 const { data, error } = await tryAsync({
 	try: () => criticalOperation(),
 	catch: (error) =>
-		MyServiceError.OperationFailed({ cause: error }),
+		CompletionError.ConnectionFailed({ cause: error }),
 });
 if (error) return Err(error);
 ```
@@ -284,7 +284,7 @@ async function getStreamForDeviceIdentifier(
 // From navigator.ts
 startRecording: async (params, { sendStatus }) => {
   if (activeRecording) {
-    return RecorderError.Service({ message: 'Already recording.' });
+    return RecorderError.AlreadyRecording();
   }
 
   // First try block - get stream

--- a/.agents/skills/services-layer/SKILL.md
+++ b/.agents/skills/services-layer/SKILL.md
@@ -3,7 +3,7 @@ name: services-layer
 description: Service layer patterns with defineErrors, namespace exports, and Result types. Use when creating new services, defining domain-specific errors, or understanding the service architecture.
 metadata:
   author: epicenter
-  version: '2.0'
+  version: '3.0'
 ---
 
 # Services Layer Patterns
@@ -45,31 +45,30 @@ Every service defines domain-specific errors using `defineErrors` from wellcraft
 import { defineErrors, type InferError, type InferErrors, extractErrorMessage } from 'wellcrafted/error';
 import { Err, Ok, type Result, tryAsync, trySync } from 'wellcrafted/result';
 
-// Namespace-style error definition
-const MyServiceError = defineErrors({
-  NotFound: ({ id }: { id: string }) => ({
-    message: `Resource '${id}' not found`,
-    id,
-  }),
-  InvalidInput: ({ field, reason }: { field: string; reason: string }) => ({
-    message: `Invalid input for '${field}': ${reason}`,
-    field,
-    reason,
-  }),
-  Unexpected: ({ cause }: { cause: unknown }) => ({
-    message: `Unexpected error: ${extractErrorMessage(cause)}`,
+// Namespace-style error definition — name describes the domain
+const CompletionError = defineErrors({
+  ConnectionFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Connection failed: ${extractErrorMessage(cause)}`,
     cause,
+  }),
+  EmptyResponse: ({ providerLabel }: { providerLabel: string }) => ({
+    message: `${providerLabel} API returned an empty response`,
+    providerLabel,
+  }),
+  MissingParam: ({ param }: { param: string }) => ({
+    message: `${param} is required`,
+    param,
   }),
 });
 
 // Type derivation — shadow the const with a type of the same name
-type MyServiceError = InferErrors<typeof MyServiceError>;
-type NotFoundError = InferError<typeof MyServiceError.NotFound>;
+type CompletionError = InferErrors<typeof CompletionError>;
+type ConnectionFailedError = InferError<typeof CompletionError.ConnectionFailed>;
 
 // Call sites — each variant returns Err<...> directly
-return MyServiceError.NotFound({ id: '123' });
-return MyServiceError.InvalidInput({ field: 'email', reason: 'must contain @' });
-return MyServiceError.Unexpected({ cause: error });
+return CompletionError.ConnectionFailed({ cause: error });
+return CompletionError.EmptyResponse({ providerLabel: 'OpenAI' });
+return CompletionError.MissingParam({ param: 'apiKey' });
 ```
 
 ### How defineErrors Works
@@ -309,47 +308,46 @@ This applies to:
 import { defineErrors, type InferErrors, extractErrorMessage } from 'wellcrafted/error';
 import { Err, Ok, type Result, tryAsync, trySync } from 'wellcrafted/result';
 
-// 1. Define domain-specific errors as a namespace
-const MyServiceError = defineErrors({
-  InvalidParam: ({ param }: { param: string }) => ({
-    message: `${param} is required`,
-    param,
+// 1. Define domain-specific errors — variant names describe failure modes
+const AutostartError = defineErrors({
+  CheckFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to check autostart: ${extractErrorMessage(cause)}`,
+    cause,
   }),
-  OperationFailed: ({ cause }: { cause: unknown }) => ({
-    message: `Operation failed: ${extractErrorMessage(cause)}`,
+  EnableFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to enable autostart: ${extractErrorMessage(cause)}`,
+    cause,
+  }),
+  DisableFailed: ({ cause }: { cause: unknown }) => ({
+    message: `Failed to disable autostart: ${extractErrorMessage(cause)}`,
     cause,
   }),
 });
-type MyServiceError = InferErrors<typeof MyServiceError>;
+type AutostartError = InferErrors<typeof AutostartError>;
 
 // 2. Create factory function that returns service object
-export function createMyService() {
+export function createAutostartService() {
 	return {
-		async doSomething(options: {
-			param1: string;
-			param2: number;
-		}): Promise<Result<OutputType, MyServiceError>> {
-			// Input validation
-			if (!options.param1) {
-				return MyServiceError.InvalidParam({ param: 'param1' });
-			}
-
-			// Wrap risky operations with tryAsync
-			const { data, error } = await tryAsync({
-				try: () => riskyAsyncOperation(options),
+		async isEnabled(): Promise<Result<boolean, AutostartError>> {
+			return tryAsync({
+				try: () => isEnabled(),
 				catch: (error) =>
-					MyServiceError.OperationFailed({ cause: error }),
+					AutostartError.CheckFailed({ cause: error }),
 			});
-
-			if (error) return Err(error);
-			return Ok(data);
+		},
+		async enable(): Promise<Result<void, AutostartError>> {
+			return tryAsync({
+				try: () => enable(),
+				catch: (error) =>
+					AutostartError.EnableFailed({ cause: error }),
+			});
 		},
 	};
 }
 
 // 3. Export the "Live" instance (production singleton)
-export type MyService = ReturnType<typeof createMyService>;
-export const MyServiceLive = createMyService();
+export type AutostartService = ReturnType<typeof createAutostartService>;
+export const AutostartServiceLive = createAutostartService();
 ```
 
 ### Real-World Example: Recorder Service
@@ -357,11 +355,11 @@ export const MyServiceLive = createMyService();
 ```typescript
 // From apps/whispering/src/lib/services/isomorphic/recorder/navigator.ts
 
-const RecorderServiceError = defineErrors({
+const RecorderError = defineErrors({
   AlreadyRecording: () => ({
     message: 'A recording is already in progress. Please stop the current recording.',
   }),
-  StreamAcquisitionFailed: ({ cause }: { cause: unknown }) => ({
+  StreamAcquisition: ({ cause }: { cause: unknown }) => ({
     message: `Failed to acquire recording stream: ${extractErrorMessage(cause)}`,
     cause,
   }),
@@ -370,14 +368,14 @@ const RecorderServiceError = defineErrors({
     cause,
   }),
 });
-type RecorderServiceError = InferErrors<typeof RecorderServiceError>;
+type RecorderError = InferErrors<typeof RecorderError>;
 
 export function createNavigatorRecorderService(): RecorderService {
 	let activeRecording: ActiveRecording | null = null;
 
 	return {
 		getRecorderState: async (): Promise<
-			Result<WhisperingRecordingState, RecorderServiceError>
+			Result<WhisperingRecordingState, RecorderError>
 		> => {
 			return Ok(activeRecording ? 'RECORDING' : 'IDLE');
 		},
@@ -385,10 +383,10 @@ export function createNavigatorRecorderService(): RecorderService {
 		startRecording: async (
 			params: NavigatorRecordingParams,
 			{ sendStatus },
-		): Promise<Result<DeviceAcquisitionOutcome, RecorderServiceError>> => {
+		): Promise<Result<DeviceAcquisitionOutcome, RecorderError>> => {
 			// Validate state
 			if (activeRecording) {
-				return RecorderServiceError.AlreadyRecording();
+				return RecorderError.AlreadyRecording();
 			}
 
 			// Get stream (calls another service)
@@ -396,7 +394,7 @@ export function createNavigatorRecorderService(): RecorderService {
 				await getRecordingStream({ selectedDeviceId, sendStatus });
 
 			if (acquireStreamError) {
-				return RecorderServiceError.StreamAcquisitionFailed({
+				return RecorderError.StreamAcquisition({
 					cause: acquireStreamError,
 				});
 			}
@@ -408,7 +406,7 @@ export function createNavigatorRecorderService(): RecorderService {
 						bitsPerSecond: Number(bitrateKbps) * 1000,
 					}),
 				catch: (error) =>
-					RecorderServiceError.InitFailed({ cause: error }),
+					RecorderError.InitFailed({ cause: error }),
 			});
 
 			if (recorderError) {
@@ -507,9 +505,9 @@ For services that need different implementations per platform:
 ```typescript
 // services/isomorphic/text/types.ts
 export type TextService = {
-	readFromClipboard(): Promise<Result<string | null, TextServiceError>>;
-	copyToClipboard(text: string): Promise<Result<void, TextServiceError>>;
-	writeToCursor(text: string): Promise<Result<void, TextServiceError>>;
+	readFromClipboard(): Promise<Result<string | null, TextError>>;
+	copyToClipboard(text: string): Promise<Result<void, TextError>>;
+	writeToCursor(text: string): Promise<Result<void, TextError>>;
 };
 ```
 
@@ -517,7 +515,7 @@ export type TextService = {
 
 ```typescript
 // services/isomorphic/text/desktop.ts
-const TextServiceError = defineErrors({
+const TextError = defineErrors({
   ClipboardWriteFailed: ({ cause }: { cause: unknown }) => ({
     message: `Clipboard write failed: ${extractErrorMessage(cause)}`,
     cause,
@@ -530,7 +528,7 @@ export function createTextServiceDesktop(): TextService {
 			tryAsync({
 				try: () => writeText(text), // Tauri API
 				catch: (error) =>
-					TextServiceError.ClipboardWriteFailed({ cause: error }),
+					TextError.ClipboardWriteFailed({ cause: error }),
 			}),
 	};
 }
@@ -542,7 +540,7 @@ export function createTextServiceWeb(): TextService {
 			tryAsync({
 				try: () => navigator.clipboard.writeText(text), // Browser API
 				catch: (error) =>
-					TextServiceError.ClipboardWriteFailed({ cause: error }),
+					TextError.ClipboardWriteFailed({ cause: error }),
 			}),
 	};
 }
@@ -608,8 +606,9 @@ const RecorderError = defineErrors({
 5. **Export factory + Live instance** - Factory for testing, Live for production
 6. **Use defineErrors namespaces** - Group related errors under a single namespace
 7. **Derive types with InferError/InferErrors** - Not `ReturnType`
-8. **Split discriminated union inputs** - Each variant gets its own name and shape. If the constructor branches on its inputs (if/switch/ternary) to decide the message, each branch should be its own variant
-9. **Transform cause in the constructor, not the call site** - Accept `cause: unknown` and call `extractErrorMessage(cause)` inside the factory's message template. Call sites pass the raw error: `{ cause: error }`. This centralizes message extraction where the message is composed and keeps call sites clean.
+8. **Variant names describe the failure mode** - Never use generic names like `Service`, `Error`, or `Failed`. The namespace provides domain context (`RecorderError`), so the variant must say *what went wrong* (`AlreadyRecording`, `InitFailed`, `StreamAcquisition`). `RecorderError.Service` is meaningless — `RecorderError.AlreadyRecording` tells you exactly what happened.
+9. **Split discriminated union inputs** - Each variant gets its own name and shape. If the constructor branches on its inputs (if/switch/ternary) to decide the message, each branch should be its own variant
+10. **Transform cause in the constructor, not the call site** - Accept `cause: unknown` and call `extractErrorMessage(cause)` inside the factory's message template. Call sites pass the raw error: `{ cause: error }`. This centralizes message extraction where the message is composed and keeps call sites clean.
 
 ## References
 

--- a/.agents/skills/single-or-array-pattern/SKILL.md
+++ b/.agents/skills/single-or-array-pattern/SKILL.md
@@ -94,7 +94,7 @@ delete: async (recordingOrRecordings) => {
   const ids = recordings.map((r) => r.id);
   return tryAsync({
     try: () => db.recordings.bulkDelete(ids),
-    catch: (error) => DbError.Service({ message: `Error deleting: ${error}` }),
+    catch: (error) => DbError.MutationFailed({ cause: error }),
   });
 },
 ```

--- a/apps/whispering/src/lib/services/README.md
+++ b/apps/whispering/src/lib/services/README.md
@@ -162,7 +162,7 @@ This pattern ensures consistent error handling and avoids double-wrapping errors
 1. **Use `defineErrors` namespaces**: Group related errors under a single namespace
 
    ```typescript
-   const RecorderServiceError = defineErrors({
+   const RecorderError = defineErrors({
      AlreadyRecording: () => ({
        message: 'A recording is already in progress. Please stop the current recording.',
      }),
@@ -171,17 +171,17 @@ This pattern ensures consistent error handling and avoids double-wrapping errors
        cause,
      }),
    });
-   type RecorderServiceError = InferErrors<typeof RecorderServiceError>;
+   type RecorderError = InferErrors<typeof RecorderError>;
    ```
 
 2. **Accept `cause: unknown`, extract inside constructor**: Error constructors accept the raw caught error and call `extractErrorMessage(cause)` inside the message template. Call sites stay clean with `{ cause: error }`.
 
    ```typescript
    // ✅ GOOD: cause: error at call site, extractErrorMessage in constructor
-   catch: (error) => RecorderServiceError.InitFailed({ cause: error })
+   catch: (error) => RecorderError.InitFailed({ cause: error })
 
    // ❌ BAD: extractErrorMessage at call site, string passed to constructor
-   catch: (error) => RecorderServiceError.InitFailed({ underlyingError: extractErrorMessage(error) })
+   catch: (error) => RecorderError.InitFailed({ underlyingError: extractErrorMessage(error) })
    ```
 
 3. **Map Platform Errors**: Transform platform-specific errors
@@ -220,11 +220,11 @@ The query layer is responsible for transforming service errors into `WhisperingE
 ### Real-World Example: Recording Service Errors
 
 ```typescript
-const RecorderServiceError = defineErrors({
+const RecorderError = defineErrors({
 	AlreadyRecording: () => ({
 		message: 'A recording is already in progress. Please stop the current recording.',
 	}),
-	StreamAcquisitionFailed: ({ cause }: { cause: unknown }) => ({
+	StreamAcquisition: ({ cause }: { cause: unknown }) => ({
 		message: `Failed to acquire recording stream: ${extractErrorMessage(cause)}`,
 		cause,
 	}),
@@ -233,23 +233,23 @@ const RecorderServiceError = defineErrors({
 		cause,
 	}),
 });
-type RecorderServiceError = InferErrors<typeof RecorderServiceError>;
+type RecorderError = InferErrors<typeof RecorderError>;
 
 export function createManualRecorderService() {
 	return {
 		startRecording: async (
 			recordingSettings,
 			{ sendStatus },
-		): Promise<Result<DeviceAcquisitionOutcome, RecorderServiceError>> => {
+		): Promise<Result<DeviceAcquisitionOutcome, RecorderError>> => {
 			if (activeRecording) {
-				return RecorderServiceError.AlreadyRecording();
+				return RecorderError.AlreadyRecording();
 			}
 
 			const { data: streamResult, error: acquireStreamError } =
 				await getRecordingStream(selectedDeviceId, sendStatus);
 
 			if (acquireStreamError) {
-				return RecorderServiceError.StreamAcquisitionFailed({
+				return RecorderError.StreamAcquisition({
 					cause: acquireStreamError,
 				});
 			}

--- a/apps/whispering/src/lib/services/desktop/ffmpeg.ts
+++ b/apps/whispering/src/lib/services/desktop/ffmpeg.ts
@@ -12,9 +12,16 @@ import { FsServiceLive } from './fs';
 import { getFileExtensionFromFfmpegOptions } from './recorder/ffmpeg';
 
 export const FfmpegError = defineErrors({
-	Service: ({ operation, cause }: { operation: string; cause: unknown }) => ({
-		message: `Failed to ${operation}: ${extractErrorMessage(cause)}`,
-		operation,
+	InstallCheckFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to check FFmpeg installation: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	VerifyFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to verify temp file accessibility: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	CompressFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to compress audio: ${extractErrorMessage(cause)}`,
 		cause,
 	}),
 });
@@ -36,10 +43,7 @@ export const FfmpegServiceLive = {
 					return result;
 				},
 				catch: (error) =>
-					FfmpegError.Service({
-						operation: 'check FFmpeg installation via shell',
-						cause: error,
-					}),
+					FfmpegError.InstallCheckFailed({ cause: error }),
 			});
 
 		if (shellFfmpegError) return Err(shellFfmpegError);
@@ -82,10 +86,7 @@ export const FfmpegServiceLive = {
 					const { error: verifyError } = await tryAsync({
 						try: () => FsServiceLive.pathToBlob(inputPath),
 						catch: (error) =>
-							FfmpegError.Service({
-								operation: 'verify temp file accessibility',
-								cause: error,
-							}),
+							FfmpegError.VerifyFailed({ cause: error }),
 					});
 					if (verifyError) throw new Error(verifyError.message);
 
@@ -141,11 +142,7 @@ export const FfmpegServiceLive = {
 					});
 				}
 			},
-			catch: (error) =>
-				FfmpegError.Service({
-					operation: 'compress audio',
-					cause: error,
-				}),
+			catch: (error) => FfmpegError.CompressFailed({ cause: error }),
 		});
 	},
 };

--- a/apps/whispering/src/lib/services/desktop/ffmpeg.ts
+++ b/apps/whispering/src/lib/services/desktop/ffmpeg.ts
@@ -42,8 +42,7 @@ export const FfmpegServiceLive = {
 					if (commandError) throw commandError;
 					return result;
 				},
-				catch: (error) =>
-					FfmpegError.InstallCheckFailed({ cause: error }),
+				catch: (error) => FfmpegError.InstallCheckFailed({ cause: error }),
 			});
 
 		if (shellFfmpegError) return Err(shellFfmpegError);
@@ -85,8 +84,7 @@ export const FfmpegServiceLive = {
 					// Verify file is accessible (forces OS flush on Windows)
 					const { error: verifyError } = await tryAsync({
 						try: () => FsServiceLive.pathToBlob(inputPath),
-						catch: (error) =>
-							FfmpegError.VerifyFailed({ cause: error }),
+						catch: (error) => FfmpegError.VerifyFailed({ cause: error }),
 					});
 					if (verifyError) throw new Error(verifyError.message);
 

--- a/apps/whispering/src/lib/services/desktop/fs.ts
+++ b/apps/whispering/src/lib/services/desktop/fs.ts
@@ -19,13 +19,7 @@ export const FsError = defineErrors({
 		path,
 		cause,
 	}),
-	ReadFilesFailed: ({
-		paths,
-		cause,
-	}: {
-		paths: string[];
-		cause: unknown;
-	}) => ({
+	ReadFilesFailed: ({ paths, cause }: { paths: string[]; cause: unknown }) => ({
 		message: `Failed to read files: ${paths.join(', ')}: ${extractErrorMessage(cause)}`,
 		paths,
 		cause,

--- a/apps/whispering/src/lib/services/desktop/fs.ts
+++ b/apps/whispering/src/lib/services/desktop/fs.ts
@@ -9,23 +9,27 @@ import {
 import { tryAsync } from 'wellcrafted/result';
 
 export const FsError = defineErrors({
-	Service: ({
-		operation,
+	ReadBlobFailed: ({ path, cause }: { path: string; cause: unknown }) => ({
+		message: `Failed to read file as Blob: ${path}: ${extractErrorMessage(cause)}`,
+		path,
+		cause,
+	}),
+	ReadFileFailed: ({ path, cause }: { path: string; cause: unknown }) => ({
+		message: `Failed to read file as File: ${path}: ${extractErrorMessage(cause)}`,
+		path,
+		cause,
+	}),
+	ReadFilesFailed: ({
 		paths,
 		cause,
 	}: {
-		operation: string;
-		paths: string | string[];
+		paths: string[];
 		cause: unknown;
-	}) => {
-		const pathStr = Array.isArray(paths) ? paths.join(', ') : paths;
-		return {
-			message: `Failed to ${operation}: ${pathStr}: ${extractErrorMessage(cause)}`,
-			operation,
-			paths,
-			cause,
-		};
-	},
+	}) => ({
+		message: `Failed to read files: ${paths.join(', ')}: ${extractErrorMessage(cause)}`,
+		paths,
+		cause,
+	}),
 });
 export type FsError = InferErrors<typeof FsError>;
 
@@ -37,12 +41,7 @@ export const FsServiceLive = {
 	pathToBlob: (path: string) =>
 		tryAsync({
 			try: () => createBlobFromPath(path),
-			catch: (error) =>
-				FsError.Service({
-					operation: 'read file as Blob',
-					paths: path,
-					cause: error,
-				}),
+			catch: (error) => FsError.ReadBlobFailed({ path, cause: error }),
 		}),
 
 	/**
@@ -52,12 +51,7 @@ export const FsServiceLive = {
 	pathToFile: (path: string) =>
 		tryAsync({
 			try: () => createFileFromPath(path),
-			catch: (error) =>
-				FsError.Service({
-					operation: 'read file as File',
-					paths: path,
-					cause: error,
-				}),
+			catch: (error) => FsError.ReadFileFailed({ path, cause: error }),
 		}),
 
 	/**
@@ -67,12 +61,7 @@ export const FsServiceLive = {
 	pathsToFiles: (paths: string[]) =>
 		tryAsync({
 			try: () => Promise.all(paths.map(createFileFromPath)),
-			catch: (error) =>
-				FsError.Service({
-					operation: 'read files',
-					paths,
-					cause: error,
-				}),
+			catch: (error) => FsError.ReadFilesFailed({ paths, cause: error }),
 		}),
 };
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",


### PR DESCRIPTION
Error variant names like `Service`, `Error`, and `Failed` are meaningless; the namespace already tells you which service you're in. This PR bans generic variant names and replaces them with ones that describe the actual failure mode.

**New rule**: Core Rule 8 in the `define-errors` skill (renamed from `create-tagged-error`, v3.0): variant names must describe the specific failure mode. `Service`, `Error`, and bare `Failed` are banned.

**Code**: split two catch-all `Service` variants into specific ones:
- `FfmpegError.Service` → `InstallCheckFailed`, `VerifyFailed`, `CompressFailed`
- `FsError.Service` → `ReadBlobFailed`, `ReadFileFailed`, `ReadFilesFailed`

**Docs**: fixed examples across 5 files to use real, specific names instead of placeholder generics:
- `RecorderError.Service(...)` → `RecorderError.AlreadyRecording()`
- `MyServiceError` → `CompletionError`
- `DbError.Service(...)` → `DbError.MutationFailed(...)`
- `StreamAcquisitionFailed` → `StreamAcquisition`
- `RecorderServiceError` → `RecorderError`