### PR TITLE
Demo/gg integration demo

### DIFF
--- a/apps/whispering/.gitignore
+++ b/apps/whispering/.gitignore
@@ -22,3 +22,6 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# gg runtime logs
+.gg

--- a/apps/whispering/AGENTS.md
+++ b/apps/whispering/AGENTS.md
@@ -24,3 +24,83 @@ Tauri + Svelte 5 desktop/web app for voice transcription.
 - Cross-cutting docs: `/docs/`
 
 See root `AGENTS.md` for the full organization guide.
+
+## Reading `gg()` Runtime Logs
+
+This project uses `@leftium/gg` with the file sink plugin. All `gg()` calls are captured to `.gg/logs-{port}.jsonl` during development.
+
+**Log file location**: `.gg/logs-1420.jsonl` (Tauri dev server port). Discover active log files with `ls .gg/logs-*.jsonl`.
+
+**Workflow:**
+
+1. **Instrument** — Ensure `gg()` calls exist in the code paths you want to observe. `gg()` is zero-config — just `import { gg } from '@leftium/gg'` and call `gg(value)`. Skip this step if the relevant calls are already in place.
+
+2. **Reset** — Clear the log file so you're only reading entries from the action you care about.
+
+   ```bash
+   curl -X DELETE http://localhost:1420/__gg/logs
+   ```
+
+3. **Trigger** — Ask the user to perform the action under investigation (page load, button click, form submit, etc.). Wait for the user to confirm they're done.
+
+4. **Query** — Read and filter the log entries.
+
+   ```bash
+   curl -s http://localhost:1420/__gg/logs
+   ```
+
+5. **Analyze** — Interpret the entries in context. The `file` and `line` fields point to source locations. The `ns` field shows the call site (file + function). If more data is needed, go back to step 1 and add more `gg()` calls.
+
+This cycle — instrument, reset, trigger, query, analyze — is the primary debugging loop. Each iteration narrows the investigation.
+
+**Each JSONL line contains:**
+
+| Field    | Description                                                             |
+| -------- | ----------------------------------------------------------------------- |
+| `ns`     | Namespace (file + function, e.g., `gg:lib/notify.ts@createNotifyMutation`) |
+| `msg`    | Formatted message string                                                |
+| `ts`     | Unix epoch ms                                                           |
+| `lvl`    | `"debug"` \| `"info"` \| `"warn"` \| `"error"` (omitted if debug)       |
+| `file`   | Source file path                                                        |
+| `line`   | Source line number                                                      |
+| `count`  | Repeat count when consecutive entries share the same `ns`+`msg` (HTTP only, omitted when 1) |
+
+**Prefer `jq` over `grep`** for filtering NDJSON:
+
+```bash
+# Filter by message content
+curl -s http://localhost:1420/__gg/logs | jq 'select(.msg | test("myFunction"))'
+
+# Extract just the msg field as plain text
+curl -s http://localhost:1420/__gg/logs | jq -r '.msg'
+
+# Errors only
+curl -s http://localhost:1420/__gg/logs | jq 'select(.lvl == "error")'
+
+# Messages with source location
+curl -s http://localhost:1420/__gg/logs | jq -r '"\(.file):\(.line) \(.msg)"'
+
+# Unrolled — one line per entry, no count collapsing
+curl -s "http://localhost:1420/__gg/logs?raw"
+```
+
+**Key details:**
+
+- The file is truncated on dev server start. Use `DELETE /__gg/logs` to clear mid-session.
+- Each line is independently valid JSON — partial file reads and streaming work.
+- This is a Tauri SPA (no SSR), so all entries will have `env: "client"` and `origin: "tauri"`.
+
+**Opening files in the editor:**
+
+```bash
+# Open the file+line from the first error entry
+curl -s http://localhost:1420/__gg/logs \
+  | jq -r 'select(.lvl == "error") | "/__open-in-editor?file=\(.file)&line=\(.line)"' \
+  | head -1 \
+  | xargs -I{} curl -s "http://localhost:1420{}"
+
+# Open a specific file+line directly
+curl "http://localhost:1420/__open-in-editor?file=src/routes/+page.svelte&line=42"
+```
+
+Use this proactively when you identify a relevant source location in log output — open the file for the developer rather than just citing `file:line` in text.

--- a/apps/whispering/package.json
+++ b/apps/whispering/package.json
@@ -49,7 +49,7 @@
 		"@epicenter/svelte-utils": "workspace:*",
 		"@epicenter/workspace": "workspace:*",
 		"@google/generative-ai": "^0.24.1",
-		"@leftium/gg": "0.0.52",
+		"@leftium/gg": "0.0.53",
 		"@mistralai/mistralai": "^1.9.18",
 		"@ricky0123/vad-web": "^0.0.24",
 		"@standard-schema/spec": "catalog:",

--- a/apps/whispering/package.json
+++ b/apps/whispering/package.json
@@ -49,7 +49,7 @@
 		"@epicenter/svelte-utils": "workspace:*",
 		"@epicenter/workspace": "workspace:*",
 		"@google/generative-ai": "^0.24.1",
-		"@leftium/gg": "0.0.53",
+		"@leftium/gg": "0.0.54",
 		"@mistralai/mistralai": "^1.9.18",
 		"@ricky0123/vad-web": "^0.0.24",
 		"@standard-schema/spec": "catalog:",

--- a/apps/whispering/package.json
+++ b/apps/whispering/package.json
@@ -49,6 +49,7 @@
 		"@epicenter/svelte-utils": "workspace:*",
 		"@epicenter/workspace": "workspace:*",
 		"@google/generative-ai": "^0.24.1",
+		"@leftium/gg": "0.0.52",
 		"@mistralai/mistralai": "^1.9.18",
 		"@ricky0123/vad-web": "^0.0.24",
 		"@standard-schema/spec": "catalog:",

--- a/apps/whispering/src/lib/query/isomorphic/actions.ts
+++ b/apps/whispering/src/lib/query/isomorphic/actions.ts
@@ -1,3 +1,4 @@
+import { gg } from '@leftium/gg';
 import { nanoid } from 'nanoid/non-secure';
 import { Ok } from 'wellcrafted/result';
 import { defineMutation } from '$lib/query/client';
@@ -48,7 +49,7 @@ const startManualRecording = defineMutation({
 	mutationFn: async () => {
 		// Prevent concurrent recording operations
 		if (isRecordingOperationBusy) {
-			console.info('Recording operation already in progress, ignoring start');
+			gg('Recording operation already in progress, ignoring start').info();
 			return Ok(undefined);
 		}
 		isRecordingOperationBusy = true;
@@ -122,7 +123,7 @@ const startManualRecording = defineMutation({
 		}
 		// Track start time for duration calculation
 		manualRecordingStartTime = Date.now();
-		console.info('Recording started');
+		gg('Recording started').info();
 		sound.playSoundIfEnabled('manual-start');
 		return Ok(undefined);
 	},
@@ -133,7 +134,7 @@ const stopManualRecording = defineMutation({
 	mutationFn: async () => {
 		// Prevent concurrent recording operations
 		if (isRecordingOperationBusy) {
-			console.info('Recording operation already in progress, ignoring stop');
+			gg('Recording operation already in progress, ignoring stop').info();
 			return Ok(undefined);
 		}
 		isRecordingOperationBusy = true;
@@ -165,7 +166,7 @@ const stopManualRecording = defineMutation({
 			title: '🎙️ Recording stopped',
 			description: 'Your recording has been saved',
 		});
-		console.info('Recording stopped');
+		gg('Recording stopped').info();
 		sound.playSoundIfEnabled('manual-stop');
 
 		// Log manual recording completion
@@ -201,7 +202,7 @@ const startVadRecording = defineMutation({
 		await settings.switchRecordingMode('vad');
 
 		const toastId = nanoid();
-		console.info('Starting voice activated capture');
+		gg('Starting voice activated capture').info();
 		notify.loading({
 			id: toastId,
 			title: '🎙️ Starting voice activated capture',
@@ -222,7 +223,7 @@ const startVadRecording = defineMutation({
 						title: '🎙️ Voice activated speech captured',
 						description: 'Your voice activated speech has been captured.',
 					});
-					console.info('Voice activated speech captured');
+					gg('Voice activated speech captured').info();
 					sound.playSoundIfEnabled('vad-capture');
 
 					// Log VAD recording completion
@@ -303,7 +304,7 @@ const stopVadRecording = defineMutation({
 	mutationKey: ['commands', 'stopVadRecording'] as const,
 	mutationFn: async () => {
 		const toastId = nanoid();
-		console.info('Stopping voice activated capture');
+		gg('Stopping voice activated capture').info();
 		notify.loading({
 			id: toastId,
 			title: '⏸️ Stopping voice activated capture...',
@@ -353,9 +354,7 @@ export const commands = {
 		mutationFn: async () => {
 			// Prevent concurrent recording operations
 			if (isRecordingOperationBusy) {
-				console.info(
-					'Recording operation already in progress, ignoring cancel',
-				);
+				gg('Recording operation already in progress, ignoring cancel').info();
 				return Ok(undefined);
 			}
 			isRecordingOperationBusy = true;
@@ -395,7 +394,7 @@ export const commands = {
 						description: 'Recording cancelled successfully',
 					});
 					sound.playSoundIfEnabled('manual-cancel');
-					console.info('Recording cancelled');
+					gg('Recording cancelled').info();
 					break;
 				}
 			}

--- a/apps/whispering/src/lib/query/isomorphic/notify.ts
+++ b/apps/whispering/src/lib/query/isomorphic/notify.ts
@@ -1,6 +1,5 @@
 import { gg } from '@leftium/gg';
 import { Ok } from 'wellcrafted/result';
-import { dev } from '$app/environment';
 import { notificationLog } from '$lib/components/NotificationLog.svelte';
 import { defineMutation } from '$lib/query/client';
 import { services } from '$lib/services';
@@ -17,25 +16,22 @@ const createNotifyMutation = (
 		) => {
 			const fullOptions: UnifiedNotificationOptions = { ...options, variant };
 
-			// Log in dev mode
-			if (dev) {
-				switch (variant) {
-					case 'error':
-						gg(fullOptions).ns('[Notify]').error();
-						break;
-					case 'warning':
-						gg(fullOptions).ns('[Notify]').warn();
-						break;
-					case 'info':
-						gg(fullOptions).ns('[Notify]').info();
-						break;
-					case 'loading':
-						gg(fullOptions).ns('[Notify]').info();
-						break;
-					case 'success':
-						gg(fullOptions).ns('[Notify]');
-						break;
-				}
+			switch (variant) {
+				case 'error':
+					gg(fullOptions).ns('[Notify]').error();
+					break;
+				case 'warning':
+					gg(fullOptions).ns('[Notify]').warn();
+					break;
+				case 'info':
+					gg(fullOptions).ns('[Notify]').info();
+					break;
+				case 'loading':
+					gg(fullOptions).ns('[Notify]').info();
+					break;
+				case 'success':
+					gg(fullOptions).ns('[Notify]');
+					break;
 			}
 
 			// Add to notification log
@@ -111,8 +107,8 @@ const createNotifyMutation = (
  *   - Loading states are temporary and would create notification spam
  *   - Toasts can be updated in-place using the same ID
  *
- * - **Dev logging**: In development mode, notifications are logged to console
- *   with appropriate log levels (error, warn, info, etc.)
+ * - **Logging**: Notifications are logged via `gg()` with appropriate
+ *   log levels (error, warn, info, etc.)
  *
  * - **Notification log**: All notifications are stored in a log for debugging
  *   and user history via `notificationLog.addLog()`

--- a/apps/whispering/src/lib/query/isomorphic/notify.ts
+++ b/apps/whispering/src/lib/query/isomorphic/notify.ts
@@ -1,3 +1,4 @@
+import { gg } from '@leftium/gg';
 import { Ok } from 'wellcrafted/result';
 import { dev } from '$app/environment';
 import { notificationLog } from '$lib/components/NotificationLog.svelte';
@@ -20,19 +21,19 @@ const createNotifyMutation = (
 			if (dev) {
 				switch (variant) {
 					case 'error':
-						console.error('[Notify]', fullOptions);
+						gg(fullOptions).ns('[Notify]').error();
 						break;
 					case 'warning':
-						console.warn('[Notify]', fullOptions);
+						gg(fullOptions).ns('[Notify]').warn();
 						break;
 					case 'info':
-						console.info('[Notify]', fullOptions);
+						gg(fullOptions).ns('[Notify]').info();
 						break;
 					case 'loading':
-						console.info('[Notify]', fullOptions);
+						gg(fullOptions).ns('[Notify]').info();
 						break;
 					case 'success':
-						console.log('[Notify]', fullOptions);
+						gg(fullOptions).ns('[Notify]');
 						break;
 				}
 			}
@@ -52,7 +53,7 @@ const createNotifyMutation = (
 				const { error: notifyError } =
 					await services.notification.notify(fullOptions);
 				if (notifyError) {
-					console.error('[Notify] OS notification error:', notifyError);
+					gg('OS notification error:', notifyError).ns('[Notify]').error();
 				}
 			}
 

--- a/apps/whispering/src/routes/+layout.svelte
+++ b/apps/whispering/src/routes/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { GgConsole } from '@leftium/gg';
 	import { QueryClientProvider } from '@tanstack/svelte-query';
 	import { SvelteQueryDevtools } from '@tanstack/svelte-query-devtools';
 	import { ModeWatcher, mode } from 'mode-watcher';
@@ -53,6 +54,7 @@
 />
 <ModeWatcher defaultMode="dark" track={false} />
 <SvelteQueryDevtools client={queryClient} buttonPosition="bottom-right" />
+<GgConsole />
 
 <style>
 	/* Override inspector button to bottom-center, above sidebar (z-10).

--- a/apps/whispering/vite.config.ts
+++ b/apps/whispering/vite.config.ts
@@ -1,3 +1,4 @@
+import { ggCallSitesPlugin } from '@leftium/gg/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
@@ -9,6 +10,7 @@ const host = process.env.TAURI_DEV_HOST;
 // https://vitejs.dev/config/
 export default defineConfig(async () => ({
 	plugins: [
+		ggCallSitesPlugin(),
 		sveltekit(),
 		tailwindcss(),
 		devtoolsJson(),

--- a/apps/whispering/vite.config.ts
+++ b/apps/whispering/vite.config.ts
@@ -1,4 +1,4 @@
-import { ggCallSitesPlugin } from '@leftium/gg/vite';
+import ggPlugins from '@leftium/gg/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
@@ -10,7 +10,7 @@ const host = process.env.TAURI_DEV_HOST;
 // https://vitejs.dev/config/
 export default defineConfig(async () => ({
 	plugins: [
-		ggCallSitesPlugin(),
+		...ggPlugins(),
 		sveltekit(),
 		tailwindcss(),
 		devtoolsJson(),

--- a/bun.lock
+++ b/bun.lock
@@ -196,7 +196,7 @@
         "@epicenter/svelte-utils": "workspace:*",
         "@epicenter/workspace": "workspace:*",
         "@google/generative-ai": "^0.24.1",
-        "@leftium/gg": "0.0.52",
+        "@leftium/gg": "0.0.53",
         "@mistralai/mistralai": "^1.9.18",
         "@ricky0123/vad-web": "^0.0.24",
         "@standard-schema/spec": "catalog:",
@@ -942,7 +942,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@leftium/gg": ["@leftium/gg@0.0.52", "", { "dependencies": { "@sveltejs/acorn-typescript": "^1.0.9", "@tanstack/virtual-core": "^3.13.21", "acorn": "^8.16.0", "eruda": "^3.4.3", "esm-env": "^1.2.2", "launch-editor": "^2.13.1" }, "peerDependencies": { "svelte": "^5.0.0" }, "optionalPeers": ["svelte"] }, "sha512-QhO/0vLuHv3aPaxqiisTHazldRK8ed2eWKjmDGdGInsIB6c6UOg7TVSDNHZCuG6ZBz/75VSD+PjtoctPwv6TKQ=="],
+    "@leftium/gg": ["@leftium/gg@0.0.53", "", { "dependencies": { "@sveltejs/acorn-typescript": "^1.0.9", "@tanstack/virtual-core": "^3.13.21", "acorn": "^8.16.0", "eruda": "^3.4.3", "esm-env": "^1.2.2", "launch-editor": "^2.13.1" }, "peerDependencies": { "svelte": "^5.0.0" }, "optionalPeers": ["svelte"] }, "sha512-zVewdA9MjiQiFMe4HINRJJzviwUawZOhpUpCqtDNc2C0rjxE93XB/f+8XHlZbmC/fLlSMQGu3fvagwB4b7EYzg=="],
 
     "@libsql/client": ["@libsql/client@0.11.0", "", { "dependencies": { "@libsql/core": "^0.11.0", "@libsql/hrana-client": "^0.6.2", "js-base64": "^3.7.5", "libsql": "^0.4.4", "promise-limit": "^2.7.0" } }, "sha512-IkMxBFI43JXBRf4K57m6zeoa8M6u0FFEI11vHh4/ObTCZFk20wJNO9hRa1Zq1BeVDqABxMRf02HPAr02pC06bQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -196,7 +196,7 @@
         "@epicenter/svelte-utils": "workspace:*",
         "@epicenter/workspace": "workspace:*",
         "@google/generative-ai": "^0.24.1",
-        "@leftium/gg": "0.0.53",
+        "@leftium/gg": "0.0.54",
         "@mistralai/mistralai": "^1.9.18",
         "@ricky0123/vad-web": "^0.0.24",
         "@standard-schema/spec": "catalog:",
@@ -942,7 +942,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@leftium/gg": ["@leftium/gg@0.0.53", "", { "dependencies": { "@sveltejs/acorn-typescript": "^1.0.9", "@tanstack/virtual-core": "^3.13.21", "acorn": "^8.16.0", "eruda": "^3.4.3", "esm-env": "^1.2.2", "launch-editor": "^2.13.1" }, "peerDependencies": { "svelte": "^5.0.0" }, "optionalPeers": ["svelte"] }, "sha512-zVewdA9MjiQiFMe4HINRJJzviwUawZOhpUpCqtDNc2C0rjxE93XB/f+8XHlZbmC/fLlSMQGu3fvagwB4b7EYzg=="],
+    "@leftium/gg": ["@leftium/gg@0.0.54", "", { "dependencies": { "@sveltejs/acorn-typescript": "^1.0.9", "@tanstack/virtual-core": "^3.13.21", "acorn": "^8.16.0", "eruda": "^3.4.3", "esm-env": "^1.2.2", "launch-editor": "^2.13.1" }, "peerDependencies": { "svelte": "^5.0.0" }, "optionalPeers": ["svelte"] }, "sha512-Knpjk9KdQNdU/7zUEHbsb73vF2bqAhXlxhgfoX+5qbj7hfIOeN8ZdTQPq9F1DRntItVIEL4J+UEYq47GL0kMtQ=="],
 
     "@libsql/client": ["@libsql/client@0.11.0", "", { "dependencies": { "@libsql/core": "^0.11.0", "@libsql/hrana-client": "^0.6.2", "js-base64": "^3.7.5", "libsql": "^0.4.4", "promise-limit": "^2.7.0" } }, "sha512-IkMxBFI43JXBRf4K57m6zeoa8M6u0FFEI11vHh4/ObTCZFk20wJNO9hRa1Zq1BeVDqABxMRf02HPAr02pC06bQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -196,6 +196,7 @@
         "@epicenter/svelte-utils": "workspace:*",
         "@epicenter/workspace": "workspace:*",
         "@google/generative-ai": "^0.24.1",
+        "@leftium/gg": "0.0.52",
         "@mistralai/mistralai": "^1.9.18",
         "@ricky0123/vad-web": "^0.0.24",
         "@standard-schema/spec": "catalog:",
@@ -941,6 +942,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@leftium/gg": ["@leftium/gg@0.0.52", "", { "dependencies": { "@sveltejs/acorn-typescript": "^1.0.9", "@tanstack/virtual-core": "^3.13.21", "acorn": "^8.16.0", "eruda": "^3.4.3", "esm-env": "^1.2.2", "launch-editor": "^2.13.1" }, "peerDependencies": { "svelte": "^5.0.0" }, "optionalPeers": ["svelte"] }, "sha512-QhO/0vLuHv3aPaxqiisTHazldRK8ed2eWKjmDGdGInsIB6c6UOg7TVSDNHZCuG6ZBz/75VSD+PjtoctPwv6TKQ=="],
+
     "@libsql/client": ["@libsql/client@0.11.0", "", { "dependencies": { "@libsql/core": "^0.11.0", "@libsql/hrana-client": "^0.6.2", "js-base64": "^3.7.5", "libsql": "^0.4.4", "promise-limit": "^2.7.0" } }, "sha512-IkMxBFI43JXBRf4K57m6zeoa8M6u0FFEI11vHh4/ObTCZFk20wJNO9hRa1Zq1BeVDqABxMRf02HPAr02pC06bQ=="],
 
     "@libsql/core": ["@libsql/core@0.11.0", "", { "dependencies": { "js-base64": "^3.7.5" } }, "sha512-ksMxodOCXoU2tiQtlY7DzOLZ0xq8EWbXlmBk+56/8U7e7QMDrYmdt+XhOcCr4DAO5HSD9kMPqS4iVFBKGcWbBA=="],
@@ -1258,6 +1261,8 @@
     "@tanstack/svelte-table": ["@tanstack/svelte-table@9.0.0-alpha.10", "", { "dependencies": { "@tanstack/table-core": "9.0.0-alpha.10" }, "peerDependencies": { "svelte": "^5.0.0-next" } }, "sha512-H0eAQlpXgK9JYYrgc0cWXVqEJywxkhuYODnVobUZGskFg6J+5PP+7UCjzrY9ftMge6s1hwb2Ipq3u4wPYJz7HA=="],
 
     "@tanstack/table-core": ["@tanstack/table-core@9.0.0-alpha.10", "", {}, "sha512-f2kEGGL+d+I7evkhU926cID2MyH7nPI8acAPcwpaAR1DrgTNStAMp3NS+tgMDyrYtc8zd+RyTxC8m+NBhHhFmA=="],
+
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.13.21", "", {}, "sha512-ww+fmLHyCbPSf7JNbWZP3g7wl6SdNo3ah5Aiw+0e9FDErkVHLKprYUrwTm7dF646FtEkN/KkAKPYezxpmvOjxw=="],
 
     "@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
 
@@ -1773,6 +1778,8 @@
 
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
+    "eruda": ["eruda@3.4.3", "", {}, "sha512-J2TsF4dXSspOXev5bJ6mljv0dRrxj21wklrDzbvPmYaEmVoC+2psylyRi70nUPFh1mTQfIBsSusUtAMZtUN+/w=="],
+
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
@@ -2180,6 +2187,8 @@
     "kysely": ["kysely@0.28.11", "", {}, "sha512-zpGIFg0HuoC893rIjYX1BETkVWdDnzTzF5e0kWXJFg5lE0k1/LfNWBejrcnOFu8Q2Rfq/hTDTU7XLUM8QOrpzg=="],
 
     "latest-version": ["latest-version@9.0.0", "", { "dependencies": { "package-json": "^10.0.0" } }, "sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA=="],
+
+    "launch-editor": ["launch-editor@2.13.1", "", { "dependencies": { "picocolors": "^1.1.1", "shell-quote": "^1.8.3" } }, "sha512-lPSddlAAluRKJ7/cjRFoXUFzaX7q/YKI7yPHuEvSJVqoXvFnJov1/Ud87Aa4zULIbA9Nja4mSPK8l0z/7eV2wA=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
@@ -2801,7 +2810,7 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "shell-quote": ["shell-quote@1.7.3", "", {}, "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw=="],
+    "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
     "shellwords": ["shellwords@0.1.1", "", {}, "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="],
 
@@ -3410,6 +3419,8 @@
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "fx-runner/commander": ["commander@2.9.0", "", { "dependencies": { "graceful-readlink": ">= 1.0.0" } }, "sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A=="],
+
+    "fx-runner/shell-quote": ["shell-quote@1.7.3", "", {}, "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw=="],
 
     "fx-runner/which": ["which@1.2.4", "", { "dependencies": { "is-absolute": "^0.1.7", "isexe": "^1.1.1" }, "bin": { "which": "./bin/which" } }, "sha512-zDRAqDSBudazdfM9zpiI30Fu9ve47htYXcGi3ln0wfKu2a7SmrT6F3VDoYONu//48V8Vz4TdCRNPjtvyRO3yBA=="],
 


### PR DESCRIPTION
> **This is a demo branch — not intended for merging.** It exists to demo how `@leftium/gg` can integrate into an existing app with minimal effort, and to set up a live debug session for issue #1282.

This branch incrementally adds `@leftium/gg` to Whispering across 4 commits, replacing `console.*` calls with `gg()` to demonstrate the integration path and unlock agent-accessible runtime logs.

### What each commit does

```
ad72939  chore: install @leftium/gg
   ↓
7468f31  feat: replace 15 console.* → gg() in notify.ts + actions.ts
   ↓
ba04382  feat: add ggCallSitesPlugin — one config line, zero code changes
         (upgrades random namespaces like "jazzy-perch" → real file@function paths)
   ↓
14495bc  feat: add <GgConsole />, enable all vite plugins, ungate prod logging
         (Eruda in-browser console, click-to-open-in-editor, fileSink for agent access)
```

### What this enables

- **In-browser console** — 5-tap gesture opens Eruda with a dedicated GG panel showing all `gg()` output with source locations, level filtering, and click-to-open-in-editor
- **Agent log access** — `curl http://localhost:1420/__gg/logs` returns NDJSON for programmatic querying (filter by level, file, message content via `jq`)
- **Production logging** — `gg()` calls are always-on (no-op when not activated), so logs are available in Tauri builds without a dev server
- **Zero-effort source mapping** — `ggCallSitesPlugin` rewrites call sites at build time, so every log entry includes its real file path and function name

### Integration effort

The actual integration is 3 touches:
1. `bun add @leftium/gg`
2. `...ggPlugins()` spread in `vite.config.ts`
3. `<GgConsole />` in root layout

After that, replacing `console.*` → `gg()` is mechanical 1:1 substitution. No refactoring, no new abstractions.

### Next: live debug demo for #1282

The next step (not committed) is a live agent-driven debug session targeting issue #1282 (moonshine tiny model returns empty transcription). The agent will add `gg()` calls to the transcription pipeline, query logs via the fileSink endpoint, and iterate — demonstrating the agent-accessible logging workflow.' | pbcopy