### PR TITLE
feat(tab-manager): pin extension ID with manifest key for stable OAuth redirects

### DIFF
--- a/apps/tab-manager/wxt.config.ts
+++ b/apps/tab-manager/wxt.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
 	manifest: {
 		name: 'Tab Manager',
 		description: 'Manage browser tabs with Epicenter',
+		// Pins the extension ID to mkbnicfhpacdofmoocppnjjmdfmkkgda across all machines.
+		// Required for stable OAuth redirect URL with chrome.identity.
+		key: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvc/CNEshfeHanSOPQlaQNi/k6Vu81LsrDyxqJEHWPzXa/a4Nk6EeQmSvWAl7YAhW0KGSJoMSGgT0QXh7A0ILCgXtIby4TfVdzlvRkLvhI6eU8iRLUgghvR4Uq9lFLt67uXMFoOQ3hRPxwVNSJqPL9BJv3iWArnaTx54Nl23uot7Xpnt+cDy8qzd8DVW751qKmVbcRgf8oKH67UdcfB1aPyQ64xs+R+P3qXAUdjwEAHDIaAJtEHFyqxIJLutpm9/ahXCyYydayK3atLWKo21M1AbkgClloDGT2CaBawaCG+YksAWrfkaO2WT/lTo0UI8HHcirXuEJuXR4DmyV7vBufwIDAQAB',
 		permissions: ['tabs', 'storage', 'identity'],
 		// host_permissions needed for favicons and tab info
 		host_permissions: ['<all_urls>'],

--- a/docs/articles/pin-your-chrome-extension-id-or-oauth-breaks.md
+++ b/docs/articles/pin-your-chrome-extension-id-or-oauth-breaks.md
@@ -1,0 +1,44 @@
+# Pin Your Chrome Extension ID or OAuth Breaks
+
+When you're developing a Chrome extension with a framework like WXT, Chrome generates the extension ID from the absolute path of the unpacked extension folder. Different developer, different path, different ID. Every URL tied to that ID—OAuth redirects, `chrome.identity.getRedirectURL()`, externally connectable allowlists—breaks silently.
+
+```
+/Users/alice/code/my-ext/.output/chrome-mv3  → ID: abcdefghijklmnop  ✅
+/Users/bob/projects/my-ext/.output/chrome-mv3 → ID: qrstuvwxyzabcdef  ❌
+```
+
+The fix is a single manifest field. Add a `key` to your manifest, and Chrome derives the ID from that key instead of the filesystem path. Same key in the repo, same ID on every machine.
+
+## Generating a Key
+
+No Chrome Web Store upload needed. Two commands:
+
+```bash
+# Generate a private key, extract the public key in Chrome's format
+openssl genrsa 2048 > ext-key.pem
+openssl rsa -in ext-key.pem -pubout -outform DER 2>/dev/null | base64 | tr -d '\n'
+```
+
+That outputs a base64 string starting with `MIIBIj...`. That's your manifest key. You can also compute the resulting extension ID upfront:
+
+```bash
+openssl rsa -in ext-key.pem -pubout -outform DER 2>/dev/null \
+  | shasum -a 256 | head -c 32 | tr '0-9a-f' 'a-p'
+```
+
+Discard the `.pem` after. Chrome only needs the public key in the manifest.
+
+## Adding It in WXT
+
+WXT generates `manifest.json` from `wxt.config.ts`. The `manifest` object accepts any valid Chrome manifest field, and `key` passes through untouched:
+
+```typescript
+export default defineConfig({
+  manifest: {
+    key: 'MIIBIjANBgkqhkiG9w0BAQE...',
+    permissions: ['identity'],
+  },
+});
+```
+
+That's it. Every developer who clones the repo gets the same extension ID, the same `chromiumapp.org` redirect URL, and OAuth just works.


### PR DESCRIPTION
Adds a stable `key` field to the tab manager's WXT manifest config so the Chrome extension ID is deterministic across all developer machines and environments.

## Why this matters

The tab manager uses `chrome.identity.launchWebAuthFlow()` for Google OAuth sign-in. This API constructs a redirect URL from the extension ID:

```
https://{extension-id}.chromiumapp.org/
```

Without a pinned key, Chrome derives the extension ID from the **absolute filesystem path** of the unpacked extension. Different developer machines have different paths, so every developer gets a different extension ID—and a different redirect URL. Google Cloud Console only allows whitelisted redirect URIs, so OAuth breaks for everyone except whoever originally registered the URL.

```
/Users/alice/code/epicenter/apps/tab-manager/.output/chrome-mv3
  → ID: abcdefghijklmnop
  → redirect: https://abcdefghijklmnop.chromiumapp.org/  ✅ (registered)

/Users/bob/projects/epicenter/apps/tab-manager/.output/chrome-mv3
  → ID: qrstuvwxyzabcdef
  → redirect: https://qrstuvwxyzabcdef.chromiumapp.org/  ❌ (not registered)
```

## The fix

Adding a `key` field (RSA public key, base64-encoded) to the manifest tells Chrome to derive the ID from the key instead of the path. Same key in the repo means same extension ID on every machine.

The pinned extension ID is `mkbnicfhpacdofmoocppnjjmdfmkkgda`. After merging, the Google Cloud Console authorized redirect URI should be updated to:

```
https://mkbnicfhpacdofmoocppnjjmdfmkkgda.chromiumapp.org/
```

Also includes a technical article (`docs/articles/pin-your-chrome-extension-id-or-oauth-breaks.md`) explaining the mechanism, how to generate keys, and when pinning is necessary vs. optional.