### PR TITLE
feat(whispering): add delete button to transcript preview dialog

### DIFF
--- a/apps/whispering/src/lib/components/copyable/TextPreviewDialog.svelte
+++ b/apps/whispering/src/lib/components/copyable/TextPreviewDialog.svelte
@@ -5,6 +5,7 @@
 	import * as Modal from '@epicenter/ui/modal';
 	import { Spinner } from '@epicenter/ui/spinner';
 	import { Textarea } from '@epicenter/ui/textarea';
+	import TrashIcon from '@lucide/svelte/icons/trash';
 	import { createCopyFn } from '$lib/utils/createCopyFn';
 
 	/**
@@ -35,6 +36,18 @@
 	 *   loading={true}
 	 * />
 	 * ```
+	 *
+	 * @example
+	 * ```svelte
+	 * <!-- With delete button -->
+	 * <TextPreviewDialog
+	 *   id="transcription-1"
+	 *   title="Transcript"
+	 *   text={transcriptionResult}
+	 *   label="transcription"
+	 *   onDelete={() => handleDelete()}
+	 * />
+	 * ```
 	 */
 	let {
 		/** Unique identifier for view transitions */
@@ -51,6 +64,8 @@
 		disabled = false,
 		/** Whether to show a loading spinner instead of copy button */
 		loading = false,
+		/** Optional callback to delete the associated item. When provided, a delete button appears in the dialog footer. */
+		onDelete,
 	}: {
 		id: string;
 		title: string;
@@ -59,6 +74,7 @@
 		rows?: number;
 		disabled?: boolean;
 		loading?: boolean;
+		onDelete?: () => void;
 	} = $props();
 
 	let isDialogOpen = $state(false);
@@ -98,6 +114,19 @@
 		<Modal.Title>{title}</Modal.Title>
 		<Textarea readonly value={text} rows={20} />
 		<Modal.Footer>
+			{#if onDelete}
+				<Button
+					variant="destructive"
+					onclick={() => {
+						isDialogOpen = false;
+						onDelete();
+					}}
+				>
+					<TrashIcon class="size-4" />
+					Delete
+				</Button>
+			{/if}
+			<div class="flex-1" />
 			<Button variant="outline" onclick={() => (isDialogOpen = false)}>
 				Close
 			</Button>

--- a/apps/whispering/src/lib/components/copyable/TranscriptDialog.svelte
+++ b/apps/whispering/src/lib/components/copyable/TranscriptDialog.svelte
@@ -26,6 +26,16 @@
 	 *   loading={true}
 	 * />
 	 * ```
+	 *
+	 * @example
+	 * ```svelte
+	 * <!-- With delete button -->
+	 * <TranscriptDialog
+	 *   recordingId={recording.id}
+	 *   transcribedText={recording.transcribedText}
+	 *   onDelete={() => handleDelete(recording)}
+	 * />
+	 * ```
 	 */
 	let {
 		/** The ID of the recording whose transcript is being displayed */
@@ -38,12 +48,15 @@
 		disabled = false,
 		/** Whether to show a loading spinner instead of copy button */
 		loading = false,
+		/** Optional callback to delete the recording. When provided, a delete button appears in the dialog footer. */
+		onDelete,
 	}: {
 		recordingId: string;
 		transcribedText: string;
 		rows?: number;
 		disabled?: boolean;
 		loading?: boolean;
+		onDelete?: () => void;
 	} = $props();
 </script>
 
@@ -55,4 +68,5 @@
 	{rows}
 	{disabled}
 	{loading}
+	{onDelete}
 />

--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -188,26 +188,21 @@
 					onDelete: () => {
 						confirmationDialog.open({
 							title: 'Delete recording',
-							description:
-								'Are you sure you want to delete this recording?',
+							description: 'Are you sure you want to delete this recording?',
 							confirm: { text: 'Delete', variant: 'destructive' },
 							onConfirm: async () => {
-								const { error } = await rpc.db.recordings.delete(
-									row.original,
-								);
+								const { error } = await rpc.db.recordings.delete(row.original);
 								if (error) {
 									rpc.notify.error({
 										title: 'Failed to delete recording!',
-										description:
-											'Your recording could not be deleted.',
+										description: 'Your recording could not be deleted.',
 										action: { type: 'more-details', error },
 									});
 									throw error;
 								}
 								rpc.notify.success({
 									title: 'Deleted recording!',
-									description:
-										'Your recording has been deleted.',
+									description: 'Your recording has been deleted.',
 								});
 							},
 						});

--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -185,6 +185,33 @@
 				return renderComponent(TranscriptDialog, {
 					recordingId: row.id,
 					transcribedText,
+					onDelete: () => {
+						confirmationDialog.open({
+							title: 'Delete recording',
+							description:
+								'Are you sure you want to delete this recording?',
+							confirm: { text: 'Delete', variant: 'destructive' },
+							onConfirm: async () => {
+								const { error } = await rpc.db.recordings.delete(
+									row.original,
+								);
+								if (error) {
+									rpc.notify.error({
+										title: 'Failed to delete recording!',
+										description:
+											'Your recording could not be deleted.',
+										action: { type: 'more-details', error },
+									});
+									throw error;
+								}
+								rpc.notify.success({
+									title: 'Deleted recording!',
+									description:
+										'Your recording has been deleted.',
+								});
+							},
+						});
+					},
 				});
 			},
 		},

--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -15,6 +15,7 @@
 	import { extractErrorMessage } from 'wellcrafted/error';
 	import { Err, tryAsync } from 'wellcrafted/result';
 	import { commandCallbacks } from '$lib/commands';
+	import { confirmationDialog } from '$lib/components/ConfirmationDialog.svelte';
 	import TranscriptDialog from '$lib/components/copyable/TranscriptDialog.svelte';
 	import NavItems from '$lib/components/NavItems.svelte';
 	import {
@@ -309,6 +310,28 @@
 				rows={1}
 				disabled={!latestRecording.transcribedText.trim()}
 				loading={latestRecording.transcriptionStatus === 'TRANSCRIBING'}
+				onDelete={() => {
+					confirmationDialog.open({
+						title: 'Delete recording',
+						description: 'Are you sure you want to delete this recording?',
+						confirm: { text: 'Delete', variant: 'destructive' },
+						onConfirm: async () => {
+							const { error } = await rpc.db.recordings.delete(latestRecording);
+							if (error) {
+								rpc.notify.error({
+									title: 'Failed to delete recording!',
+									description: 'Your recording could not be deleted.',
+									action: { type: 'more-details', error },
+								});
+								throw error;
+							}
+							rpc.notify.success({
+								title: 'Deleted recording!',
+								description: 'Your recording has been deleted.',
+							});
+						},
+					});
+				}}
 			/>
 
 			{#if blobUrl}


### PR DESCRIPTION
The transcript text preview dialog only offered Copy Text and Close. To delete a recording, you had to close the dialog, find the row's Actions column, and click delete there—extra steps that break flow when you're reviewing transcriptions and want to discard one quickly.

This adds an optional `onDelete` callback to `TextPreviewDialog` that, when provided, renders a destructive Delete button on the left side of the dialog footer. Clicking it closes the dialog and opens the existing `ConfirmationDialog` with the standard "Are you sure?" flow before calling `rpc.db.recordings.delete`.

The dialog footer layout becomes:

```
┌──────────────────────────────────────────────────────────────┐
│  [🗑 Delete]              ────spacer────   [Close] [Copy Text] │
│  (only when onDelete provided)                                │
└──────────────────────────────────────────────────────────────┘
```

When `onDelete` is not provided, the footer is unchanged—backward compatible.

### How it works

`TextPreviewDialog` is generic (used for transcripts, transformation outputs, step errors). The `onDelete` prop is optional there so non-deletable previews stay clean. `TranscriptDialog` is the domain wrapper that threads it through. The actual delete logic lives in the parent components that have access to the recording:

```svelte
<!-- recordings/+page.svelte (table cell) -->
<TranscriptDialog
  recordingId={row.id}
  transcribedText={transcribedText}
  onDelete={() => {
    confirmationDialog.open({
      title: 'Delete recording',
      description: 'Are you sure you want to delete this recording?',
      confirm: { text: 'Delete', variant: 'destructive' },
      onConfirm: async () => {
        const { error } = await rpc.db.recordings.delete(row.original);
        if (error) { /* notify error, throw to keep dialog open */ }
        rpc.notify.success({ title: 'Deleted recording!' });
      },
    });
  }}
/>
```

This is the exact same `confirmationDialog.open` + `rpc.db.recordings.delete` pattern used by `RecordingRowActions`—no new patterns introduced.

### Wired up in both TranscriptDialog usage sites

- **Recordings table** (`recordings/+page.svelte`): Transcript column cell now passes `onDelete`
- **Home page** (`(app)/+page.svelte`): Latest recording preview now passes `onDelete`

The remaining `TextPreviewDialog` usages (`LatestTransformationRunOutputByRecordingId`, `transformations-editor/Runs`) display transformation run data—a different entity—so they intentionally don't get `onDelete`.