### PR TITLE
feat(workspace): add BroadcastChannel extension for cross-tab Y.Doc sync

### DIFF
--- a/apps/tab-manager/src/lib/workspace.ts
+++ b/apps/tab-manager/src/lib/workspace.ts
@@ -20,8 +20,8 @@ import {
 	type InferTableRow,
 } from '@epicenter/workspace';
 import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
-import { indexeddbPersistence } from '@epicenter/workspace/extensions/sync/web';
 import { broadcastChannelSync } from '@epicenter/workspace/extensions/sync/broadcast-channel';
+import { indexeddbPersistence } from '@epicenter/workspace/extensions/sync/web';
 import { type } from 'arktype';
 import Type from 'typebox';
 import type { Brand } from 'wellcrafted/brand';

--- a/apps/tab-manager/src/lib/workspace.ts
+++ b/apps/tab-manager/src/lib/workspace.ts
@@ -21,6 +21,7 @@ import {
 } from '@epicenter/workspace';
 import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
 import { indexeddbPersistence } from '@epicenter/workspace/extensions/sync/web';
+import { broadcastChannelSync } from '@epicenter/workspace/extensions/sync/broadcast-channel';
 import { type } from 'arktype';
 import Type from 'typebox';
 import type { Brand } from 'wellcrafted/brand';
@@ -558,6 +559,7 @@ export const workspaceClient = createWorkspace(
 	}),
 )
 	.withExtension('persistence', indexeddbPersistence)
+	.withExtension('broadcast', broadcastChannelSync)
 	.withExtension(
 		'sync',
 		createSyncExtension({

--- a/packages/sync-client/src/provider.ts
+++ b/packages/sync-client/src/provider.ts
@@ -46,13 +46,36 @@ const LIVENESS_CHECK_INTERVAL_MS = 10_000;
 /**
  * Creates a sync provider that connects a Y.Doc to a WebSocket sync server.
  *
+ * Handles cross-device sync via WebSocket. For same-browser cross-tab sync,
+ * use `broadcastChannelSync` from `@epicenter/workspace/extensions/sync/broadcast-channel`
+ * alongside this provider—they run in parallel safely (Yjs deduplicates).
+ *
  * Uses V2 encoding for all sync payloads (~40% smaller than V1).
  *
  * Uses a supervisor loop architecture where one loop owns all status transitions
- * and reconnection logic. Event handlers are reporters only — they resolve
+ * and reconnection logic. Event handlers are reporters only—they resolve
  * promises that the loop awaits, but never make reconnection decisions.
  *
- * @example Open mode (localhost, no auth)
+ * Most consumers use `createSyncExtension` from `@epicenter/workspace/extensions/sync`
+ * rather than this provider directly. The extension wraps this provider with
+ * workspace lifecycle management (waiting for persistence before connecting,
+ * auto-cleanup on destroy).
+ *
+ * @example Recommended: via workspace extension chain
+ * ```typescript
+ * import { indexeddbPersistence } from '@epicenter/workspace/extensions/sync/web';
+ * import { broadcastChannelSync } from '@epicenter/workspace/extensions/sync/broadcast-channel';
+ * import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
+ *
+ * createWorkspace(definition)
+ *   .withExtension('persistence', indexeddbPersistence)
+ *   .withExtension('broadcast', broadcastChannelSync)
+ *   .withExtension('sync', createSyncExtension({
+ *     url: (id) => `http://localhost:3913/rooms/${id}`,
+ *   }))
+ * ```
+ *
+ * @example Direct usage (open mode, no auth)
  * ```typescript
  * const provider = createSyncProvider({
  *   doc: myDoc,
@@ -61,7 +84,7 @@ const LIVENESS_CHECK_INTERVAL_MS = 10_000;
  * provider.connect();
  * ```
  *
- * @example Authenticated mode
+ * @example Direct usage (authenticated)
  * ```typescript
  * const provider = createSyncProvider({
  *   doc: myDoc,

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -12,6 +12,7 @@
 		"./extensions/sync": "./src/extensions/sync.ts",
 		"./extensions/sync/web": "./src/extensions/sync/web.ts",
 		"./extensions/sync/desktop": "./src/extensions/sync/desktop.ts",
+		"./extensions/sync/broadcast-channel": "./src/extensions/sync/broadcast-channel.ts",
 		"./ingest": "./src/ingest/index.ts",
 		"./ingest/reddit": "./src/ingest/reddit/index.ts"
 	},

--- a/packages/workspace/src/extensions/sync.ts
+++ b/packages/workspace/src/extensions/sync.ts
@@ -11,14 +11,20 @@ import type { ExtensionFactory } from '../workspace/types';
  * The `url` callback returns an HTTP base URL. The sync provider derives the
  * WebSocket URL automatically (`https:` → `wss:`, `http:` → `ws:`).
  *
- * Persistence is handled separately — add a persistence extension before sync
- * in the `.withExtension()` chain. The sync extension waits for all prior
- * extensions via `context.whenReady` before connecting.
+ * Chain last in the extension chain. Persistence loads local state first,
+ * BroadcastChannel handles instant cross-tab sync, then WebSocket connects
+ * for cross-device sync. The sync extension waits for all prior extensions
+ * via `context.whenReady` before connecting.
  *
- * @example Open mode (local dev)
+ * @example Recommended: persistence + BroadcastChannel + WebSocket
  * ```typescript
+ * import { indexeddbPersistence } from '@epicenter/workspace/extensions/sync/web';
+ * import { broadcastChannelSync } from '@epicenter/workspace/extensions/sync/broadcast-channel';
+ * import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
+ *
  * createWorkspace(definition)
  *   .withExtension('persistence', indexeddbPersistence)
+ *   .withExtension('broadcast', broadcastChannelSync)
  *   .withExtension('sync', createSyncExtension({
  *     url: (id) => `http://localhost:3913/rooms/${id}`,
  *   }))
@@ -28,6 +34,7 @@ import type { ExtensionFactory } from '../workspace/types';
  * ```typescript
  * createWorkspace(definition)
  *   .withExtension('persistence', indexeddbPersistence)
+ *   .withExtension('broadcast', broadcastChannelSync)
  *   .withExtension('sync', createSyncExtension({
  *     url: (id) => `https://sync.epicenter.so/rooms/${id}`,
  *     getToken: async (workspaceId) => {
@@ -55,20 +62,24 @@ export type SyncExtensionConfig = {
 /**
  * Creates a sync extension that connects after prior extensions are ready.
  *
- * Uses WebSocket for real-time sync.
+ * Uses WebSocket for cross-device real-time sync. For same-browser cross-tab
+ * sync, use `broadcastChannelSync` — it provides sub-millisecond local sync
+ * without a server round-trip.
  *
  * Lifecycle:
  * - **Waits for prior extensions**: `context.whenReady` resolves when all previously
- *   chained extensions (persistence, etc.) are ready. The provider connects only after
- *   local state is loaded, ensuring an accurate state vector for the initial sync.
+ *   chained extensions (persistence, BroadcastChannel, etc.) are ready. The provider
+ *   connects only after local state is loaded, ensuring an accurate state vector for
+ *   the initial sync.
  * - **`whenReady`**: Resolves when the connection is initiated (after prior extensions).
  *   The UI renders from local state immediately — connection status is reactive via
  *   `provider`.
  *
- * @example
+ * @example Recommended: persistence + BroadcastChannel + WebSocket
  * ```typescript
  * createWorkspace(definition)
  *   .withExtension('persistence', indexeddbPersistence)
+ *   .withExtension('broadcast', broadcastChannelSync)
  *   .withExtension('sync', createSyncExtension({
  *     url: (id) => `http://localhost:3913/rooms/${id}`,
  *   }))

--- a/packages/workspace/src/extensions/sync/broadcast-channel.ts
+++ b/packages/workspace/src/extensions/sync/broadcast-channel.ts
@@ -1,0 +1,70 @@
+import * as Y from 'yjs';
+
+/** Origin sentinel — updates applied from the BroadcastChannel carry this
+ *  so the `updateV2` handler skips re-broadcasting them (prevents echo loops). */
+const BC_ORIGIN = Symbol('bc-sync');
+
+/**
+ * BroadcastChannel cross-tab sync for a Yjs document.
+ *
+ * Broadcasts every local `updateV2` to same-origin tabs and applies incoming
+ * updates from other tabs. Uses `ydoc.guid` (= workspace ID) as the channel
+ * name so only docs for the same workspace communicate.
+ *
+ * Yjs deduplicates internally—if the WebSocket provider delivers the same
+ * update, `applyUpdateV2` with an already-applied state vector is a no-op.
+ * Running BroadcastChannel alongside WebSocket is safe and intended.
+ *
+ * No-ops gracefully when `BroadcastChannel` is unavailable (Node.js, SSR,
+ * older browsers).
+ *
+ * Works directly as an extension factory — destructures `ydoc` from the
+ * workspace client context. Chain after persistence and before WebSocket
+ * sync for optimal ordering: local state loads first, then instant local
+ * sync, then server sync.
+ *
+ * @example Persistence + BroadcastChannel + WebSocket (recommended)
+ * ```typescript
+ * import { indexeddbPersistence } from '@epicenter/workspace/extensions/sync/web';
+ * import { broadcastChannelSync } from '@epicenter/workspace/extensions/sync/broadcast-channel';
+ * import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
+ *
+ * createWorkspace(definition)
+ *   .withExtension('persistence', indexeddbPersistence)
+ *   .withExtension('broadcast', broadcastChannelSync)
+ *   .withExtension('sync', createSyncExtension({
+ *     url: (id) => `http://localhost:3913/rooms/${id}`,
+ *   }))
+ * ```
+ *
+ * @example Standalone (no server, local tabs only)
+ * ```typescript
+ * createWorkspace(definition)
+ *   .withExtension('persistence', indexeddbPersistence)
+ *   .withExtension('broadcast', broadcastChannelSync)
+ * ```
+ */
+export function broadcastChannelSync({ ydoc }: { ydoc: Y.Doc }) {
+	if (typeof BroadcastChannel === 'undefined') return {};
+
+	const channel = new BroadcastChannel(`yjs:${ydoc.guid}`);
+
+	/** Broadcast local changes to other tabs. */
+	const handleUpdate = (update: Uint8Array, origin: unknown) => {
+		if (origin === BC_ORIGIN) return;
+		channel.postMessage(update);
+	};
+	ydoc.on('updateV2', handleUpdate);
+
+	/** Apply incoming changes from other tabs. */
+	channel.onmessage = (event: MessageEvent) => {
+		Y.applyUpdateV2(ydoc, new Uint8Array(event.data), BC_ORIGIN);
+	};
+
+	return {
+		destroy() {
+			ydoc.off('updateV2', handleUpdate);
+			channel.close();
+		},
+	};
+}

--- a/packages/workspace/src/extensions/sync/web.ts
+++ b/packages/workspace/src/extensions/sync/web.ts
@@ -9,18 +9,20 @@ import type * as Y from 'yjs';
  * Yjs update (both handled internally by `y-indexeddb`).
  *
  * Works directly as an extension factory — destructures `ydoc` from the
- * workspace client context. Chain before sync so `context.whenReady`
- * includes persistence readiness.
+ * workspace client context. Chain first so all subsequent extensions
+ * (BroadcastChannel, WebSocket) start with local state already loaded.
  *
- * @example Persistence + sync (recommended pattern)
+ * @example Recommended: persistence + BroadcastChannel + WebSocket
  * ```typescript
  * import { indexeddbPersistence } from '@epicenter/workspace/extensions/sync/web';
+ * import { broadcastChannelSync } from '@epicenter/workspace/extensions/sync/broadcast-channel';
  * import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
  *
  * createWorkspace(definition)
  *   .withExtension('persistence', indexeddbPersistence)
+ *   .withExtension('broadcast', broadcastChannelSync)
  *   .withExtension('sync', createSyncExtension({
- *     url: 'ws://localhost:3913/rooms/{id}',
+ *     url: (id) => `http://localhost:3913/rooms/${id}`,
  *   }))
  * ```
  *


### PR DESCRIPTION
Two side panel windows editing the same workspace don't sync in real-time. The only path between them is a WebSocket round-trip through the Cloudflare Durable Object—and if the server is unreachable, they don't sync at all until close+reopen.

The root cause: `y-indexeddb` is persistence-only. No BroadcastChannel, no cross-tab notification, no polling. A fresh `IndexeddbPersistence` loads stored updates on construction, which is why close+reopen "fixes" it—but that's not sync, it's reload.

```
Window A                              Window B
┌─────────────┐                       ┌─────────────┐
│ Y.Doc       │                       │ Y.Doc       │
│  ├─ IDB ───►│── IndexedDB ────────►│◄─ IDB       │  (persistence, no cross-tab)
│  ├─ WS ────►│── CF Durable Obj ──►│◄─ WS        │  (cross-device, if connected)
│  │          │                       │  │          │
│  └─ BC ────►│── BroadcastChannel ─►│◄─ BC        │  ← NEW: instant local sync
└─────────────┘                       └─────────────┘
```

This adds a `broadcastChannelSync` extension—~20 lines of actual logic—that broadcasts `updateV2` events via BroadcastChannel and applies incoming updates from other tabs. Yjs deduplicates internally, so running this alongside the WebSocket provider is safe: `applyUpdateV2` with an already-applied state vector is a no-op.

### The extension

```typescript
// packages/workspace/src/extensions/sync/broadcast-channel.ts
export function broadcastChannelSync({ ydoc }: { ydoc: Y.Doc }) {
  if (typeof BroadcastChannel === 'undefined') return {};  // no-op in Node/SSR

  const ORIGIN = Symbol('bc-sync');
  const channel = new BroadcastChannel(`yjs:${ydoc.guid}`);

  const handleUpdate = (update: Uint8Array, origin: unknown) => {
    if (origin === ORIGIN) return;       // don't echo back
    channel.postMessage(update);
  };
  ydoc.on('updateV2', handleUpdate);

  channel.onmessage = (event: MessageEvent) => {
    Y.applyUpdateV2(ydoc, new Uint8Array(event.data), ORIGIN);
  };

  return {
    destroy() {
      ydoc.off('updateV2', handleUpdate);
      channel.close();
    },
  };
}
```

The `Symbol('bc-sync')` sentinel prevents echo loops—without it, Window A broadcasts → Window B applies → Window B's handler fires → broadcasts back → infinite ping-pong. Yjs would deduplicate the data (no corruption), but you'd burn CPU on no-op messages. Same pattern as `SYNC_ORIGIN` in the WebSocket provider.

### Extension chain ordering

Chain after persistence (so local state loads first) and before WebSocket (so cross-tab sync is instant while the server connection bootstraps):

```typescript
// apps/tab-manager/src/lib/workspace.ts
export const workspaceClient = createWorkspace(defineWorkspace({ ... }))
  .withExtension('persistence', indexeddbPersistence)   // 1. load from IndexedDB
  .withExtension('broadcast', broadcastChannelSync)     // 2. instant cross-tab
  .withExtension('sync', createSyncExtension({ ... }))  // 3. cross-device via server
```

### Unified JSDoc across all sync-related files

Every sync extension and the sync-client provider now show the same canonical recommended pattern in their JSDoc:

```
indexeddbPersistence  →  broadcastChannelSync  →  createSyncExtension
    (load local)          (cross-tab)              (cross-device)
```

Previously each file showed only its own slice of the chain, missing the BroadcastChannel step. Now hovering over any of these in your editor shows the full recommended setup—whether you're looking at `createSyncProvider` in `@epicenter/sync-client`, `createSyncExtension` in `@epicenter/workspace/extensions/sync`, `indexeddbPersistence`, or `broadcastChannelSync` itself.

### Why not y-webrtc?

`y-webrtc` includes BroadcastChannel support, but it also brings WebRTC signaling, ICE candidates, and a signaling server dependency. We don't need any of that. The BroadcastChannel API is 20 lines. No new dependencies.

### Edge cases

- **Simultaneous writes**: Both windows save at the same millisecond → BroadcastChannel delivers both updates → YKeyValueLww resolves via timestamp (LWW semantics)
- **WebSocket + BroadcastChannel deliver same update**: Yjs deduplicates—observer fires once from whichever arrives first
- **BroadcastChannel unavailable**: Extension checks `typeof BroadcastChannel !== 'undefined'` and returns empty object (no-op). WebSocket remains the fallback.
- **Chrome extension context**: Side panels, popups, and options pages share `chrome-extension://<id>` origin—BroadcastChannel works across all of them

Implements Phase 2–3 of `specs/20260310T220000-tab-manager-cross-window-sync.md`.