### PR TITLE
fix(transcription): bump transcribe-rs 0.2.1 → 0.2.9 to fix moonshine tokenization

### DIFF
--- a/apps/whispering/README.md
+++ b/apps/whispering/README.md
@@ -1120,7 +1120,7 @@ Feel free to suggest and implement any features that improve usability—I'll do
 
 Whispering's local transcription capabilities are powered by amazing open-source projects:
 
-- **[transcribe-rs](https://github.com/cjpais/transcribe-rs)** by [CJ Pais](https://github.com/cjpais) - A unified Rust library providing abstraction over multiple speech-to-text engines (Whisper and Parakeet). This library enables Whispering to seamlessly support different transcription engines with a consistent API.
+- **[transcribe-rs](https://github.com/cjpais/transcribe-rs)** by [CJ Pais](https://github.com/cjpais) - A unified Rust library providing abstraction over multiple speech-to-text engines (Whisper, Parakeet, and Moonshine). This library enables Whispering to seamlessly support different transcription engines with a consistent API.
 
 - **[Handy](https://github.com/cjpais/handy)** by [CJ Pais](https://github.com/cjpais) - The original project that birthed `transcribe-rs`. Handy is a an awesome cross-platform desktop speech-to-text application, and I personally use it especially when developing Whispering locally.
 

--- a/apps/whispering/src-tauri/Cargo.lock
+++ b/apps/whispering/src-tauri/Cargo.lock
@@ -29,20 +29,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "serde",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,12 +342,6 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -387,7 +367,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools",
  "lazy_static",
  "lazycell",
  "log",
@@ -647,15 +627,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "castaway"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,40 +736,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "compact_str"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "serde",
- "static_assertions",
-]
-
-[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
-]
-
-[[package]]
-name = "console"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1115,15 +1058,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dary_heap"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,12 +1352,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,15 +1463,6 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
-
-[[package]]
-name = "esaxx-rs"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "event-listener"
@@ -2219,7 +2138,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.8",
+ "ahash",
 ]
 
 [[package]]
@@ -2600,19 +2519,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indicatif"
-version = "0.18.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
-dependencies = [
- "console",
- "portable-atomic",
- "unicode-width",
- "unit-prefix",
- "web-time",
-]
-
-[[package]]
 name = "infer"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2672,15 +2578,6 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2950,22 +2847,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "macro_rules_attribute"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
-dependencies = [
- "macro_rules_attribute-proc_macro",
- "paste",
-]
-
-[[package]]
-name = "macro_rules_attribute-proc_macro"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
-
-[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3067,28 +2948,6 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "monostate"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
-dependencies = [
- "monostate-impl",
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "monostate-impl"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
 ]
 
 [[package]]
@@ -3679,28 +3538,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "onig"
-version = "6.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
-dependencies = [
- "bitflags 2.10.0",
- "libc",
- "once_cell",
- "onig_sys",
-]
-
-[[package]]
-name = "onig_sys"
-version = "69.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "open"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3890,12 +3727,6 @@ dependencies = [
  "smallvec 1.15.1",
  "windows-link 0.2.1",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
@@ -4552,17 +4383,6 @@ checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
-]
-
-[[package]]
-name = "rayon-cond"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
-dependencies = [
- "either",
- "itertools 0.14.0",
- "rayon",
 ]
 
 [[package]]
@@ -5401,18 +5221,6 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
-]
-
-[[package]]
-name = "spm_precompiled"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
-dependencies = [
- "base64 0.13.1",
- "nom 7.1.3",
- "serde",
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -6343,40 +6151,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tokenizers"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
-dependencies = [
- "ahash 0.8.12",
- "aho-corasick",
- "compact_str",
- "dary_heap",
- "derive_builder",
- "esaxx-rs",
- "getrandom 0.3.4",
- "indicatif",
- "itertools 0.14.0",
- "log",
- "macro_rules_attribute",
- "monostate",
- "onig",
- "paste",
- "rand 0.9.2",
- "rayon",
- "rayon-cond",
- "regex",
- "regex-syntax",
- "serde",
- "serde_json",
- "spm_precompiled",
- "thiserror 2.0.17",
- "unicode-normalization-alignments",
- "unicode-segmentation",
- "unicode_categories",
-]
-
-[[package]]
 name = "tokio"
 version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6612,9 +6386,9 @@ dependencies = [
 
 [[package]]
 name = "transcribe-rs"
-version = "0.2.1"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d8fb085c53485dfaa3f0e377c2c8f5e4affb991ddf7cb04fe32e49fc3e81bc4"
+checksum = "f6fe25a69f6aa6ca4a8cb1dfc201e94c4cc7acb43f69353aa9ebb6aa4d0d26a9"
 dependencies = [
  "derive_builder",
  "env_logger",
@@ -6627,7 +6401,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.17",
- "tokenizers",
  "whisper-rs",
 ]
 
@@ -6751,37 +6524,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
-name = "unicode-normalization-alignments"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
-dependencies = [
- "smallvec 1.15.1",
-]
-
-[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
-
-[[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
-name = "unit-prefix"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "untrusted"

--- a/apps/whispering/src-tauri/Cargo.toml
+++ b/apps/whispering/src-tauri/Cargo.toml
@@ -60,14 +60,15 @@ nix = { version = "0.29", features = ["signal"] }
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_System_Console"] }
 # Windows: Only parakeet is available due to MSVC runtime library conflicts (MT_StaticRelease vs MD_DynamicRelease)
-# - whisper-cpp: whisper-rs-sys conflicts with tokenizers/esaxx-rs
-# - moonshine: tokenizers/esaxx-rs (static CRT) conflicts with ort (dynamic CRT)
+# - whisper-cpp: whisper-rs-sys conflicts with ort
+# - moonshine: Previously blocked by tokenizers/esaxx-rs CRT conflict.
+#   tokenizers was removed in transcribe-rs 0.2.2 — moonshine on Windows may now work (untested).
 # Parakeet works because it uses ort without tokenizers dependency
-transcribe-rs = { version = "0.2.1", features = ["parakeet"] }
+transcribe-rs = { version = "0.2.9", features = ["parakeet"] }
 
 [target.'cfg(not(windows))'.dependencies]
 # macOS/Linux: full whisper-cpp support
-transcribe-rs = { version = "0.2.1", features = ["whisper", "parakeet", "moonshine"] }
+transcribe-rs = { version = "0.2.9", features = ["whisper", "parakeet", "moonshine"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 accessibility-sys =  "0.1.3"

--- a/apps/whispering/src/lib/services/isomorphic/transcription/registry.ts
+++ b/apps/whispering/src/lib/services/isomorphic/transcription/registry.ts
@@ -84,8 +84,9 @@ export const TRANSCRIPTION_SERVICES = [
 		modelPathField: 'transcription.parakeet.modelPath',
 		location: 'local',
 	},
-	// Moonshine is not available on Windows due to MSVC runtime library conflicts
-	// between tokenizers/esaxx-rs (static CRT) and ort (dynamic CRT)
+	// Moonshine is not available on Windows due to MSVC runtime library conflicts.
+	// The tokenizers/esaxx-rs CRT conflict was resolved in transcribe-rs 0.2.2,
+	// but moonshine on Windows remains untested.
 	...(IS_WINDOWS
 		? []
 		: [

--- a/specs/20260311T120000-transcribe-rs-0.2.9-upgrade.md
+++ b/specs/20260311T120000-transcribe-rs-0.2.9-upgrade.md
@@ -1,0 +1,166 @@
+# transcribe-rs 0.2.1 → 0.2.9 Upgrade Spec
+
+**Date**: 2026-03-11
+**Status**: Planning
+**Related Issue**: https://github.com/EpicenterHQ/epicenter/issues/1282
+
+## Summary
+
+Upgrade transcribe-rs from 0.2.1 to 0.2.9 to fix broken Moonshine transcription. The root cause is a tokenizer rewrite in 0.2.2 that Whispering never picked up. This is a near-drop-in version bump—the engine API is identical between these versions.
+
+## Background
+
+### The Problem
+
+Moonshine transcription in Whispering is severely degraded compared to Handy (CJ's app):
+
+- **Moonshine tiny** produces empty transcription in manual and file mode
+- **VAD mode** partially works but hallucinates names ("My name is John" → "Chad", "Jan", "Kat")
+- **Moonshine base** works better but still worse than Handy
+- **Handy** consistently transcribes "My name is John" correctly with the same model
+
+### Root Cause
+
+**Whispering is on `transcribe-rs 0.2.1` (Dec 15, 2025). Handy is on `0.2.8` (Mar 1, 2026).**
+
+The critical fix landed in **v0.2.2** (Jan 14, 2026): commit `0a31e84a` — "own impl of moonshine tokenizer (#23)".
+
+In v0.2.1, the moonshine feature depended on the HuggingFace `tokenizers` crate. In v0.2.2, CJ replaced it with a purpose-built tokenizer that properly handles:
+
+- SentencePiece `▁` → space decoding
+- Byte fallback tokens (`<0xNN>`)
+- Special token filtering (`<s>`, `</s>`)
+- UTF-8 lossy conversion for robustness
+
+The old tokenizer was producing bad token sequences → garbage model output → empty or hallucinated transcriptions.
+
+### Why VAD Mode Partially Worked
+
+VAD feeds shorter, speech-only audio chunks. Shorter sequences = fewer tokens = fewer opportunities for the bad tokenizer to compound errors. Manual/file mode sends the full recording (including silence), which amplifies the tokenization failures.
+
+### Why Not 0.3.0?
+
+Version 0.3.0 (Mar 9, 2026) is a breaking release with a completely new API:
+
+| Aspect | 0.2.x | 0.3.0 |
+|--------|-------|-------|
+| Trait name | `TranscriptionEngine` | `SpeechModel` |
+| Import path | `transcribe_rs::engines::moonshine::*` | `transcribe_rs::onnx::*` |
+| Method signature | `transcribe_samples(samples, Option<InferenceParams>)` | `transcribe(&mut self, samples, &TranscribeOptions)` |
+| Model loading | `new()` + `load_model_with_params(path, params)` | `ModelType::load(path, &quantization)` |
+| Thread safety | No `Send` requirement | `SpeechModel: Send` required |
+| Feature flags | `moonshine`, `parakeet`, `whisper` | `onnx`, `whisper-cpp` |
+
+Migrating to 0.3.0 would require rewriting all three engine integrations (moonshine, parakeet, whisper) plus the model manager. That's a separate, larger effort.
+
+## Changes Required
+
+### Version Comparison (0.2.1 → 0.2.9)
+
+I downloaded both crates from crates.io and diffed them. Findings:
+
+| File | Diff | Impact |
+|------|------|--------|
+| `engines/moonshine/engine.rs` | **Zero diff** | No code changes needed |
+| `engines/moonshine/mod.rs` | Additive: exports streaming engine types | No code changes needed |
+| `engines/moonshine/tokenizer.rs` | **Complete rewrite**: HF tokenizers → custom impl | The actual fix. Internal to crate. |
+| `engines/moonshine/model.rs` | +1 new error variant `InvalidState` | No code changes needed |
+| `engines/parakeet/engine.rs` | **Zero diff** | No code changes needed |
+| `engines/whisper.rs` | Added `use_gpu` field to `WhisperModelParams` | See note below |
+| `lib.rs` | Added `itn` module (feature-gated) | No code changes needed |
+| `Cargo.toml` | Removed `tokenizers` dep from moonshine; added `sense_voice`, `gigaam` features; pinned `ort` | See note below |
+
+**Whisper `use_gpu` note**: `WhisperModelParams` gained a `use_gpu: bool` field (defaults to `true`). Whispering calls `engine.load_model(&path)` which uses `Default::default()`, so `use_gpu` will be `true` automatically. No code change needed.
+
+**Dependency note**: The `tokenizers` crate is **removed** from the moonshine feature in 0.2.2+. This was the exact crate causing the Windows CRT conflict (`tokenizers/esaxx-rs` static CRT vs `ort` dynamic CRT). This means **moonshine on Windows may now be possible** — but that's a separate investigation, not part of this upgrade.
+
+### Concrete Changes
+
+#### 1. `apps/whispering/src-tauri/Cargo.toml`
+
+**Non-Windows target** (line 70):
+```toml
+# Before:
+transcribe-rs = { version = "0.2.1", features = ["whisper", "parakeet", "moonshine"] }
+
+# After:
+transcribe-rs = { version = "0.2.9", features = ["whisper", "parakeet", "moonshine"] }
+```
+
+**Windows target** (line 66):
+```toml
+# Before:
+transcribe-rs = { version = "0.2.1", features = ["parakeet"] }
+
+# After:
+transcribe-rs = { version = "0.2.9", features = ["parakeet"] }
+```
+
+#### 2. Update the Windows comment (lines 62-65)
+
+The comment about moonshine's Windows incompatibility should be updated to note the `tokenizers` crate was removed:
+
+```rust
+# Windows: Only parakeet is available due to MSVC runtime library conflicts
+# - whisper-cpp: whisper-rs-sys conflicts with ort
+# - moonshine: Previously blocked by tokenizers/esaxx-rs CRT conflict.
+#   tokenizers was removed in 0.2.2 — moonshine on Windows may now work (untested).
+```
+
+#### 3. No Rust code changes
+
+The `TranscriptionEngine` trait, `MoonshineEngine`, `MoonshineModelParams`, `ParakeetEngine`, `ParakeetModelParams`, `WhisperEngine` — all have identical APIs between 0.2.1 and 0.2.9. Zero code changes in `mod.rs` or `model_manager.rs`.
+
+#### 4. No TypeScript/Svelte code changes
+
+The Tauri command signatures (`transcribe_audio_moonshine`, `transcribe_audio_whisper`, `transcribe_audio_parakeet`) are unchanged. The TypeScript service layer, query layer, and UI are untouched.
+
+## What We Get
+
+| Improvement | Source Version |
+|-------------|---------------|
+| Fixed moonshine tokenizer (the main fix) | 0.2.2 |
+| Whisper GPU toggle capability | 0.2.3 |
+| Moonshine streaming engine (additive, not used yet) | 0.2.4/0.2.5 |
+| Potential Windows moonshine support (tokenizers dep removed) | 0.2.2 |
+| Pinned ort version (=2.0.0-rc.10) for reproducibility | 0.2.9 |
+
+## What We Don't Get (and don't need right now)
+
+- `sense_voice` feature — new engine, would need new Tauri command + TS service
+- `gigaam` feature — new engine, Russian-only, would need new integration
+- `itn` (Inverse Text Normalization) — feature-gated, not enabled
+- Moonshine streaming — available but needs separate integration work
+
+## Testing
+
+- [ ] `cargo check` passes (no API changes, should pass)
+- [ ] `cargo build --release` completes (the real test—compilation with new crate version)
+- [ ] Manual test: Moonshine tiny transcription in **manual mode** (previously broken)
+- [ ] Manual test: Moonshine tiny transcription in **file mode** (previously broken)
+- [ ] Manual test: Moonshine tiny transcription in **VAD mode** (partially worked before)
+- [ ] Manual test: Moonshine base transcription in all modes
+- [ ] Manual test: Parakeet transcription still works (regression check)
+- [ ] Manual test: Whisper transcription still works (regression check)
+- [ ] Test phrase: "My name is John" — should consistently transcribe correctly
+
+## Risk Assessment
+
+**Risk: Very Low**
+
+- Engine API is identical (verified via crate diff)
+- Only internal implementation changes (tokenizer rewrite)
+- Handy has been shipping 0.2.8 in production
+- The ort ONNX runtime version is the same (2.0.0-rc.10)
+- No new dependencies added to our feature set
+- One dependency removed (tokenizers crate) — strictly simpler
+
+## Future Considerations
+
+1. **Windows moonshine**: With `tokenizers` removed, the CRT conflict is gone. A follow-up PR could try enabling moonshine on Windows by adding it to the Windows features list and removing the `#[cfg(not(target_os = "windows"))]` guards.
+
+2. **0.3.0 migration**: When the 0.3.0 API stabilizes, a separate spec should cover the full migration (new trait, new import paths, new model loading pattern).
+
+3. **Moonshine streaming**: The 0.2.9 crate includes `MoonshineStreamingEngine` — could be used for real-time streaming transcription in a future feature.
+
+4. **SenseVoice / GigaAM**: New engines available if we want to expand local model options.


### PR DESCRIPTION
Bumps transcribe-rs from 0.2.1 to 0.2.9, fixing broken Moonshine transcription caused by the HuggingFace `tokenizers` crate producing garbage output for Moonshine's SentencePiece vocabulary.

In transcribe-rs 0.2.2 ([commit `0a31e84a`](https://github.com/cjpais/transcribe-rs/commit/0a31e84a)), the `tokenizers` dependency was replaced with a purpose-built moonshine tokenizer that properly handles SentencePiece decoding, byte fallback tokens (`<0xNN>`), and special token filtering. The engine API is identical between 0.2.1 and 0.2.9—zero Rust or TypeScript code changes needed. [Handy](https://github.com/cjpais/handy) has been shipping 0.2.8+ in production with no issues.

```
┌─────────────────────────────────────────────────────────────────┐
│  transcribe-rs 0.2.1 (Dec 2025)                                │
│                                                                 │
│  moonshine tokenizer = HuggingFace `tokenizers` crate           │
│  Result: empty/hallucinated transcriptions (garbage tokens)     │
│                                                                 │
└────────────────────────────────┬────────────────────────────────┘
                                 │
                                 ▼
┌─────────────────────────────────────────────────────────────────┐
│  transcribe-rs 0.2.2 (Jan 2026) — commit 0a31e84a              │
│                                                                 │
│  moonshine tokenizer = custom SentencePiece impl                │
│  Result: correct transcription ✅                               │
│                                                                 │
│  Side effect: `tokenizers` crate removed entirely               │
│  → esaxx-rs CRT conflict on Windows is gone                    │
│                                                                 │
└────────────────────────────────┬────────────────────────────────┘
                                 │
                                 ▼
┌─────────────────────────────────────────────────────────────────┐
│  transcribe-rs 0.2.9 (Mar 2026) — this PR                      │
│                                                                 │
│  Same engine API as 0.2.1. Zero code changes.                   │
│  -262 lines from Cargo.lock (tokenizers + transitive deps gone) │
│                                                                 │
└─────────────────────────────────────────────────────────────────┘
```

### What changed

**`Cargo.toml`** — Version bump for both platform targets:
```toml
# Non-Windows (macOS/Linux)
transcribe-rs = { version = "0.2.9", features = ["whisper", "parakeet", "moonshine"] }

# Windows
transcribe-rs = { version = "0.2.9", features = ["parakeet"] }
```

**`Cargo.lock`** — 262 lines removed. The `tokenizers` crate and its entire transitive dependency tree (`esaxx-rs`, `onig`, `indicatif`, `spm_precompiled`, `compact_str`, etc.) are gone.

**`registry.ts`** — Updated the Windows moonshine exclusion comment. The old comment referenced `tokenizers/esaxx-rs` as the blocker; the new comment notes the conflict was resolved in 0.2.2 but moonshine on Windows remains untested.

**`README.md`** — Added "Moonshine" to the transcribe-rs acknowledgment alongside Whisper and Parakeet.

### Why this fixes the bug

Moonshine uses SentencePiece-encoded vocabulary. The HuggingFace `tokenizers` crate (used in 0.2.1) doesn't natively understand SentencePiece's byte fallback tokens (`<0xNN>`) or its special token conventions. The custom tokenizer in 0.2.2+ properly:
- Decodes byte fallback tokens into their corresponding bytes
- Handles the `▁` (U+2581) word boundary token
- Filters `<s>`, `</s>`, and other special tokens from output

### What this does NOT change

- No Rust source changes (`mod.rs`, `model_manager.rs`, `lib.rs` untouched)
- No TypeScript/Svelte changes (Tauri command signatures identical)
- Moonshine is still disabled on Windows (untested—separate follow-up)
- New engines (`sense_voice`, `gigaam`) are not enabled (need new integrations)
- Not upgrading to 0.3.0 (breaking API rewrite)

Closes #1282