### PR TITLE
chore: remove dead packages/config and add fs-explorer README

### DIFF
--- a/apps/epicenter/package.json
+++ b/apps/epicenter/package.json
@@ -31,7 +31,6 @@
 		"yjs": "catalog:"
 	},
 	"devDependencies": {
-		"@epicenter/config": "workspace:*",
 		"@lucide/svelte": "catalog:",
 		"@sveltejs/adapter-static": "catalog:",
 		"@sveltejs/kit": "catalog:",

--- a/apps/epicenter/src/lib/components/WorkspaceSidebar.svelte
+++ b/apps/epicenter/src/lib/components/WorkspaceSidebar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Button, buttonVariants } from '@epicenter/ui/button';
 	import * as Collapsible from '@epicenter/ui/collapsible';
+	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import * as DropdownMenu from '@epicenter/ui/dropdown-menu';
 	import * as Popover from '@epicenter/ui/popover';
 	import * as Sidebar from '@epicenter/ui/sidebar';
@@ -17,7 +18,6 @@
 	import { createMutation, createQuery } from '@tanstack/svelte-query';
 	import { goto, invalidateAll } from '$app/navigation';
 	import { page } from '$app/state';
-	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import { createSettingDialog } from '$lib/components/CreateSettingDialog.svelte';
 	import { createTableDialog } from '$lib/components/CreateTableDialog.svelte';
 	import { rpc } from '$lib/query';

--- a/apps/epicenter/src/routes/(home)/+page.svelte
+++ b/apps/epicenter/src/routes/(home)/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Button } from '@epicenter/ui/button';
+	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import * as DropdownMenu from '@epicenter/ui/dropdown-menu';
 	import * as Empty from '@epicenter/ui/empty';
 	import * as Item from '@epicenter/ui/item';
@@ -11,7 +12,6 @@
 	import PlusIcon from '@lucide/svelte/icons/plus';
 	import TrashIcon from '@lucide/svelte/icons/trash-2';
 	import { createMutation, createQuery } from '@tanstack/svelte-query';
-	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import { createWorkspaceDialog } from '$lib/components/CreateWorkspaceDialog.svelte';
 	import { editWorkspaceDialog } from '$lib/components/EditWorkspaceDialog.svelte';
 	import { rpc } from '$lib/query';

--- a/apps/epicenter/src/routes/+layout.svelte
+++ b/apps/epicenter/src/routes/+layout.svelte
@@ -4,8 +4,8 @@
 	import { Toaster, type ToasterProps } from 'svelte-sonner';
 	import { queryClient } from '$lib/query';
 	import '@epicenter/ui/app.css';
-	import AddStaticWorkspaceDialog from '$lib/components/AddStaticWorkspaceDialog.svelte';
 	import { ConfirmationDialog } from '@epicenter/ui/confirmation-dialog';
+	import AddStaticWorkspaceDialog from '$lib/components/AddStaticWorkspaceDialog.svelte';
 	import CreateSettingDialog from '$lib/components/CreateSettingDialog.svelte';
 	import CreateTableDialog from '$lib/components/CreateTableDialog.svelte';
 	import CreateWorkspaceDialog from '$lib/components/CreateWorkspaceDialog.svelte';

--- a/apps/fs-explorer/README.md
+++ b/apps/fs-explorer/README.md
@@ -1,0 +1,12 @@
+# Filesystem Explorer
+
+Development UI for visualizing and testing the `@epicenter/filesystem` package. Built with SvelteKit.
+
+Not a production app—this is a dev tool for inspecting filesystem operations, browsing directory trees, and verifying the filesystem abstraction layer behaves correctly.
+
+## Running
+
+```bash
+cd apps/fs-explorer
+bun dev
+```

--- a/apps/posthog-reverse-proxy/package.json
+++ b/apps/posthog-reverse-proxy/package.json
@@ -10,7 +10,6 @@
 		"tail": "wrangler tail"
 	},
 	"devDependencies": {
-		"@epicenter/config": "workspace:*",
 		"@cloudflare/workers-types": "^4.20250803.0",
 		"wrangler": "catalog:"
 	}

--- a/apps/tab-manager/src/entrypoints/sidepanel/App.svelte
+++ b/apps/tab-manager/src/entrypoints/sidepanel/App.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import { Badge } from '@epicenter/ui/badge';
+	import { ConfirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import * as Tabs from '@epicenter/ui/tabs';
 	import * as Tooltip from '@epicenter/ui/tooltip';
 	import SparklesIcon from '@lucide/svelte/icons/sparkles';
 	import AuthGate from '$lib/components/AuthGate.svelte';
-	import { ConfirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import AiChat from '$lib/components/chat/AiChat.svelte';
 	import SyncStatusIndicator from '$lib/components/SyncStatusIndicator.svelte';
 	import FlatTabList from '$lib/components/tabs/FlatTabList.svelte';

--- a/apps/tab-manager/src/lib/components/chat/ConversationPicker.svelte
+++ b/apps/tab-manager/src/lib/components/chat/ConversationPicker.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Button } from '@epicenter/ui/button';
 	import * as Command from '@epicenter/ui/command';
+	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import { useCombobox } from '@epicenter/ui/hooks';
 	import * as Popover from '@epicenter/ui/popover';
 	import { cn } from '@epicenter/ui/utils';
@@ -9,7 +10,6 @@
 	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import MessageSquarePlusIcon from '@lucide/svelte/icons/message-square-plus';
 	import TrashIcon from '@lucide/svelte/icons/trash-2';
-	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import type { ConversationHandle } from '$lib/state/chat-state.svelte';
 	import type { ConversationId } from '$lib/workspace';
 

--- a/apps/whispering/package.json
+++ b/apps/whispering/package.json
@@ -19,7 +19,6 @@
 	},
 	"license": "AGPL-3.0",
 	"devDependencies": {
-		"@epicenter/config": "workspace:*",
 		"@epicenter/ui": "workspace:*",
 		"@lucide/svelte": "catalog:",
 		"@sveltejs/adapter-static": "catalog:",

--- a/apps/whispering/src/lib/components/transformations-editor/Runs.svelte
+++ b/apps/whispering/src/lib/components/transformations-editor/Runs.svelte
@@ -2,6 +2,7 @@
 	import { Badge } from '@epicenter/ui/badge';
 	import { Button } from '@epicenter/ui/button';
 	import * as Card from '@epicenter/ui/card';
+	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import * as Empty from '@epicenter/ui/empty';
 	import { Label } from '@epicenter/ui/label';
 	import * as Table from '@epicenter/ui/table';
@@ -10,7 +11,6 @@
 	import PlayIcon from '@lucide/svelte/icons/play';
 	import Trash2 from '@lucide/svelte/icons/trash-2';
 	import { format } from 'date-fns';
-	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import CopyablePre from '$lib/components/copyable/CopyablePre.svelte';
 	import TextPreviewDialog from '$lib/components/copyable/TextPreviewDialog.svelte';
 	import { rpc } from '$lib/query';

--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -5,6 +5,7 @@
 	import * as ButtonGroup from '@epicenter/ui/button-group';
 	import { Card } from '@epicenter/ui/card';
 	import { Checkbox } from '@epicenter/ui/checkbox';
+	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import { CopyButton } from '@epicenter/ui/copy-button';
 	import * as DropdownMenu from '@epicenter/ui/dropdown-menu';
 	import * as Empty from '@epicenter/ui/empty';
@@ -24,6 +25,7 @@
 	import StartTranscriptionIcon from '@lucide/svelte/icons/play';
 	import RetryTranscriptionIcon from '@lucide/svelte/icons/repeat';
 	import SearchIcon from '@lucide/svelte/icons/search';
+	import TrashIcon from '@lucide/svelte/icons/trash-2';
 	import { createMutation, createQuery } from '@tanstack/svelte-query';
 	import {
 		createTable as createSvelteTable,
@@ -45,9 +47,7 @@
 	import { format } from 'date-fns';
 	import { nanoid } from 'nanoid/non-secure';
 	import { createRawSnippet } from 'svelte';
-	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import TranscriptDialog from '$lib/components/copyable/TranscriptDialog.svelte';
-	import TrashIcon from '@lucide/svelte/icons/trash-2';
 	import OpenFolderButton from '$lib/components/OpenFolderButton.svelte';
 	import { PATHS } from '$lib/constants/paths';
 	import { rpc } from '$lib/query';

--- a/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/EditRecordingModal.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/EditRecordingModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Button } from '@epicenter/ui/button';
+	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import { Input } from '@epicenter/ui/input';
 	import { Label } from '@epicenter/ui/label';
 	import * as Modal from '@epicenter/ui/modal';
@@ -8,7 +9,6 @@
 	import EditIcon from '@lucide/svelte/icons/pencil';
 	import { createMutation, createQuery } from '@tanstack/svelte-query';
 	import { onDestroy } from 'svelte';
-	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import { rpc } from '$lib/query';
 	import { services } from '$lib/services';
 	import type { Recording } from '$lib/services/isomorphic/db';

--- a/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/RecordingRowActions.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/RecordingRowActions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Button } from '@epicenter/ui/button';
+	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import { CopyButton } from '@epicenter/ui/copy-button';
 	import { Skeleton } from '@epicenter/ui/skeleton';
 	import { Spinner } from '@epicenter/ui/spinner';
@@ -11,10 +12,9 @@
 	import PlayIcon from '@lucide/svelte/icons/play';
 	import RepeatIcon from '@lucide/svelte/icons/repeat';
 	import RotateCcwIcon from '@lucide/svelte/icons/rotate-ccw';
+	import TrashIcon from '@lucide/svelte/icons/trash-2';
 	import { createMutation, createQuery } from '@tanstack/svelte-query';
 	import { nanoid } from 'nanoid/non-secure';
-	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
-	import TrashIcon from '@lucide/svelte/icons/trash-2';
 	import { rpc } from '$lib/query';
 	import { createCopyFn } from '$lib/utils/createCopyFn';
 	import { viewTransition } from '$lib/utils/viewTransitions';

--- a/apps/whispering/src/routes/(app)/(config)/settings/+layout.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/+layout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { Button } from '@epicenter/ui/button';
+	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import { Link } from '@epicenter/ui/link';
 	import { Separator } from '@epicenter/ui/separator';
 	import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
-	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import { rpc } from '$lib/query';
 	import { settings } from '$lib/state/settings.svelte';
 	import SidebarNav from './SidebarNav.svelte';

--- a/apps/whispering/src/routes/(app)/(config)/transformations/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/transformations/+page.svelte
@@ -4,12 +4,14 @@
 	import { Button } from '@epicenter/ui/button';
 	import * as ButtonGroup from '@epicenter/ui/button-group';
 	import { Checkbox } from '@epicenter/ui/checkbox';
+	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import * as Empty from '@epicenter/ui/empty';
 	import { Input } from '@epicenter/ui/input';
 	import { Skeleton } from '@epicenter/ui/skeleton';
 	import * as Table from '@epicenter/ui/table';
 	import { SelectAllPopover, SortableTableHeader } from '@epicenter/ui/table';
 	import SearchIcon from '@lucide/svelte/icons/search';
+	import TrashIcon from '@lucide/svelte/icons/trash-2';
 	import WandSparklesIcon from '@lucide/svelte/icons/wand-sparkles';
 	import { createQuery } from '@tanstack/svelte-query';
 	import {
@@ -30,8 +32,6 @@
 	} from '@tanstack/table-core';
 	import { type } from 'arktype';
 	import { createRawSnippet } from 'svelte';
-	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
-	import TrashIcon from '@lucide/svelte/icons/trash-2';
 	import OpenFolderButton from '$lib/components/OpenFolderButton.svelte';
 	import { PATHS } from '$lib/constants/paths';
 	import { rpc } from '$lib/query';

--- a/apps/whispering/src/routes/(app)/(config)/transformations/CreateTransformationButton.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/transformations/CreateTransformationButton.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import { Button } from '@epicenter/ui/button';
+	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import * as Modal from '@epicenter/ui/modal';
 	import { Separator } from '@epicenter/ui/separator';
 	import PlusIcon from '@lucide/svelte/icons/plus';
 	import { createMutation } from '@tanstack/svelte-query';
-	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import { Editor } from '$lib/components/transformations-editor';
 	import { rpc } from '$lib/query';
 	import { generateDefaultTransformation } from '$lib/services/isomorphic/db';

--- a/apps/whispering/src/routes/(app)/(config)/transformations/EditTransformationModal.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/transformations/EditTransformationModal.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
 	import { Button } from '@epicenter/ui/button';
+	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import * as Modal from '@epicenter/ui/modal';
 	import { Separator } from '@epicenter/ui/separator';
 	import { Spinner } from '@epicenter/ui/spinner';
 	import HistoryIcon from '@lucide/svelte/icons/history';
+	import EditIcon from '@lucide/svelte/icons/pencil';
 	import PlayIcon from '@lucide/svelte/icons/play';
 	import TrashIcon from '@lucide/svelte/icons/trash-2';
 	import { createMutation } from '@tanstack/svelte-query';
-	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
-	import EditIcon from '@lucide/svelte/icons/pencil';
 	import { Editor } from '$lib/components/transformations-editor';
 	import { rpc } from '$lib/query';
 	import type { Transformation } from '$lib/services/isomorphic/db';

--- a/apps/whispering/src/routes/(app)/(config)/transformations/TransformationRowActions.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/transformations/TransformationRowActions.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { Button } from '@epicenter/ui/button';
-	import { Skeleton } from '@epicenter/ui/skeleton';
-	import { createQuery } from '@tanstack/svelte-query';
 	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
+	import { Skeleton } from '@epicenter/ui/skeleton';
 	import TrashIcon from '@lucide/svelte/icons/trash-2';
+	import { createQuery } from '@tanstack/svelte-query';
 	import { rpc } from '$lib/query';
 	import EditTransformationModal from './EditTransformationModal.svelte';
 

--- a/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
+++ b/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
+	import { ConfirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import * as Dialog from '@epicenter/ui/dialog';
 	// import { extension } from '@epicenter/extension';
 	import { createQuery } from '@tanstack/svelte-query';
 	import { onDestroy, onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { commandCallbacks } from '$lib/commands';
-	import { ConfirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import MoreDetailsDialog from '$lib/components/MoreDetailsDialog.svelte';
 	import NotificationLog from '$lib/components/NotificationLog.svelte';
 	import UpdateDialog from '$lib/components/UpdateDialog.svelte';

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,6 @@
         "yjs": "catalog:",
       },
       "devDependencies": {
-        "@epicenter/config": "workspace:*",
         "@lucide/svelte": "catalog:",
         "@sveltejs/adapter-static": "catalog:",
         "@sveltejs/kit": "catalog:",
@@ -105,7 +104,6 @@
       "version": "0.0.1",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250803.0",
-        "@epicenter/config": "workspace:*",
         "wrangler": "catalog:",
       },
     },
@@ -234,7 +232,6 @@
         "yjs": "catalog:",
       },
       "devDependencies": {
-        "@epicenter/config": "workspace:*",
         "@epicenter/ui": "workspace:*",
         "@lucide/svelte": "catalog:",
         "@sveltejs/adapter-static": "catalog:",
@@ -297,10 +294,6 @@
         "@types/yargs": "catalog:",
         "typescript": "catalog:",
       },
-    },
-    "packages/config": {
-      "name": "@epicenter/config",
-      "version": "0.0.1",
     },
     "packages/constants": {
       "name": "@epicenter/constants",
@@ -419,7 +412,6 @@
       },
       "devDependencies": {
         "@emoji-mart/data": "^1.2.1",
-        "@epicenter/config": "workspace:*",
         "@internationalized/date": "^3.10.0",
         "@types/node": "catalog:",
         "jsrepo": "catalog:",
@@ -719,8 +711,6 @@
     "@epicenter/app": ["@epicenter/app@workspace:apps/epicenter"],
 
     "@epicenter/cli": ["@epicenter/cli@workspace:packages/cli"],
-
-    "@epicenter/config": ["@epicenter/config@workspace:packages/config"],
 
     "@epicenter/constants": ["@epicenter/constants@workspace:packages/constants"],
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,3 +1,0 @@
-# @epicenter/config
-
-Shared configuration package for the Epicenter monorepo. Previously housed ESLint and Prettier configs for Svelte applications; these have been replaced by Biome (`biome.jsonc` at the repo root) which now handles all formatting and linting including Svelte and Astro files.

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,8 +1,0 @@
-{
-	"name": "@epicenter/config",
-	"version": "0.0.1",
-	"private": true,
-	"type": "module",
-	"exports": {},
-	"scripts": {}
-}

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,4 +1,0 @@
-{
-	"extends": ["../../tsconfig.base.json"],
-	"include": []
-}

--- a/packages/sync-client/src/index.ts
+++ b/packages/sync-client/src/index.ts
@@ -1,2 +1,7 @@
 export { createSyncProvider } from './provider';
-export type { SyncError, SyncProvider, SyncProviderConfig, SyncStatus } from './types';
+export type {
+	SyncError,
+	SyncProvider,
+	SyncProviderConfig,
+	SyncStatus,
+} from './types';

--- a/packages/sync-client/src/provider.ts
+++ b/packages/sync-client/src/provider.ts
@@ -15,7 +15,12 @@ import {
 	encodeAwarenessUpdate,
 	removeAwarenessStates,
 } from 'y-protocols/awareness';
-import type { SyncError, SyncProvider, SyncProviderConfig, SyncStatus } from './types';
+import type {
+	SyncError,
+	SyncProvider,
+	SyncProviderConfig,
+	SyncStatus,
+} from './types';
 
 // ============================================================================
 // Constants

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,7 +34,6 @@
 	},
 	"devDependencies": {
 		"@emoji-mart/data": "^1.2.1",
-		"@epicenter/config": "workspace:*",
 		"@internationalized/date": "^3.10.0",
 		"@types/node": "catalog:",
 		"jsrepo": "catalog:",

--- a/packages/workspace/src/extensions/sync.ts
+++ b/packages/workspace/src/extensions/sync.ts
@@ -1,4 +1,8 @@
-import { createSyncProvider, type SyncProvider, type SyncStatus } from '@epicenter/sync-client';
+import {
+	createSyncProvider,
+	type SyncProvider,
+	type SyncStatus,
+} from '@epicenter/sync-client';
 import type { ExtensionFactory } from '../workspace/types';
 
 /**


### PR DESCRIPTION
`packages/config/` previously housed shared ESLint and Prettier configs for the monorepo. Biome replaced both tools months ago, leaving the package with empty exports, empty scripts, no `src/` directory, and a README that said as much. Four packages still carried it as a `devDependency`—dead weight in every install.

```
packages/config/
├── package.json   ← "exports": {}, "scripts": {}
├── README.md      ← "replaced by Biome"
└── tsconfig.json
```

This PR deletes the package and scrubs the four stale `devDependency` references:

- `apps/epicenter`
- `apps/whispering`
- `packages/ui`
- `apps/posthog-reverse-proxy`

Separately, `apps/fs-explorer/` had no README despite being a non-obvious dev tool. Added one explaining it's a SvelteKit UI for visualizing the `@epicenter/filesystem` package—context that's hard to infer from the directory listing alone.

### Verification

- `grep -r "@epicenter/config" --include="package.json"` → zero results
- `bun install` completes cleanly with updated lockfile
- No source files imported from `@epicenter/config` (the package had empty exports)