### PR TITLE
refactor(auth, sync): internalize auth lifecycle and fix getToken error classification

### DIFF
--- a/apps/tab-manager/specs/20260311T225500-auth-state-effect-root-refactor.md
+++ b/apps/tab-manager/specs/20260311T225500-auth-state-effect-root-refactor.md
@@ -184,8 +184,8 @@ This is a defensive measure. Current consumers don't need it, but it prevents a 
 
 ### Phase 2: Update consumer
 
-- [ ] **2.1** In `App.svelte`, remove the `$effect` block (lines 37-40)
-- [ ] **2.2** Add `authState.onExternalSignIn(() => reconnectSync())` inside the existing `onMount`, returning the unsubscribe in cleanup
+- [x] **2.1** In `App.svelte`, remove the `$effect` block (lines 37-40)
+- [x] **2.2** Add `authState.onExternalSignIn(() => reconnectSync())` inside the existing `onMount`, returning the unsubscribe in cleanup
 
 ### Phase 3: Verify
 

--- a/apps/tab-manager/specs/20260311T225500-auth-state-effect-root-refactor.md
+++ b/apps/tab-manager/specs/20260311T225500-auth-state-effect-root-refactor.md
@@ -1,7 +1,7 @@
 # Auth State: Internalize Reactive Lifecycle with $effect.root
 
 **Date**: 2026-03-11
-**Status**: Draft
+**Status**: In Progress
 **Author**: AI-assisted
 
 ## Overview
@@ -178,9 +178,9 @@ This is a defensive measure. Current consumers don't need it, but it prevents a 
 
 ### Phase 1: Refactor auth state internals
 
-- [ ] **1.1** Add `$effect.root()` block inside `createAuthState()` with two internal effects (token cleared, token set)
-- [ ] **1.2** Add `externalSignInListeners` Set and `onExternalSignIn(callback)` method to the return object
-- [ ] **1.3** Remove `reactToTokenCleared()` and `reactToTokenSet()` from the return object
+- [x] **1.1** Add `$effect.root()` block inside `createAuthState()` with two internal effects (token cleared, token set)
+- [x] **1.2** Add `externalSignInListeners` Set and `onExternalSignIn(callback)` method to the return object
+- [x] **1.3** Remove `reactToTokenCleared()` and `reactToTokenSet()` from the return object
 
 ### Phase 2: Update consumer
 

--- a/apps/tab-manager/specs/20260311T225500-auth-state-effect-root-refactor.md
+++ b/apps/tab-manager/specs/20260311T225500-auth-state-effect-root-refactor.md
@@ -1,7 +1,7 @@
 # Auth State: Internalize Reactive Lifecycle with $effect.root
 
 **Date**: 2026-03-11
-**Status**: In Progress
+**Status**: Implemented
 **Author**: AI-assisted
 
 ## Overview
@@ -194,7 +194,7 @@ This is a defensive measure. Current consumers don't need it, but it prevents a 
 - [ ] **3.3** Test: sign out → verify clearState and phase reset
 - [ ] **3.4** Test: open two sidepanels → sign in in one → verify the other transitions to signed-in and reconnects sync
 - [ ] **3.5** Test: open two sidepanels → sign out in one → verify the other transitions to signed-out
-- [ ] **3.6** LSP diagnostics clean on `auth.svelte.ts` and `App.svelte`
+- [x] **3.6** LSP diagnostics clean on `auth.svelte.ts` and `App.svelte`
 
 ## Edge Cases
 
@@ -217,11 +217,11 @@ No impact on the refactored code—`$derived` on `client` is unchanged.
 
 ## Success Criteria
 
-- [ ] `reactToTokenCleared()` and `reactToTokenSet()` removed from public API
-- [ ] No `$effect` block in `App.svelte` for auth lifecycle management
-- [ ] Cross-context sign-in/sign-out still works (token changes in one panel are reflected in another)
-- [ ] `reconnectSync()` still fires on external sign-in
-- [ ] LSP diagnostics pass on all changed files
+- [x] `reactToTokenCleared()` and `reactToTokenSet()` removed from public API
+- [x] No `$effect` block in `App.svelte` for auth lifecycle management
+- [ ] Cross-context sign-in/sign-out still works (token changes in one panel are reflected in another) *(requires manual testing)*
+- [ ] `reconnectSync()` still fires on external sign-in *(requires manual testing)*
+- [x] LSP diagnostics pass on all changed files
 
 ## References
 
@@ -230,3 +230,19 @@ No impact on the refactored code—`$derived` on `client` is unchanged.
 - `apps/tab-manager/src/entrypoints/sidepanel/App.svelte` — Sole consumer of reactToToken* methods
 - `apps/tab-manager/src/lib/workspace.ts` — `reconnectSync()` definition (line 870)
 - `docs/articles/your-spa-singleton-doesnt-need-effect-cleanup.md` — Prior art on singleton lifecycle
+
+## Review
+
+**Completed**: 2026-03-11
+
+### Summary
+
+Internalized auth state's reactive lifecycle by replacing the two public `reactToTokenCleared()`/`reactToTokenSet()` methods with `$effect.root()` effects inside `createAuthState()`. Added `onExternalSignIn(callback)` subscription method so consumers can react to cross-context sign-ins without understanding the auth state machine. App.svelte now uses a simple `onMount` subscription instead of a raw `$effect` block.
+
+### Deviations from Spec
+
+None—implementation matched the spec exactly.
+
+### Follow-up Work
+
+- Manual testing items 3.1–3.5 (sign-in/sign-out flows, cross-context sync) need human verification

--- a/apps/tab-manager/specs/20260311T225500-auth-state-effect-root-refactor.md
+++ b/apps/tab-manager/specs/20260311T225500-auth-state-effect-root-refactor.md
@@ -1,0 +1,232 @@
+# Auth State: Internalize Reactive Lifecycle with $effect.root
+
+**Date**: 2026-03-11
+**Status**: Draft
+**Author**: AI-assisted
+
+## Overview
+
+Replace the two "call me inside $effect" methods (`reactToTokenCleared`, `reactToTokenSet`) in `auth.svelte.ts` with internal `$effect.root()` effects that the auth state module manages itself. Consumers no longer participate in the auth state machine—they subscribe to events.
+
+## Motivation
+
+### Current State
+
+The auth state singleton exposes two methods that only work when called inside a `$effect`:
+
+```typescript
+// auth.svelte.ts
+reactToTokenCleared() {
+    if (!authToken.current && phase.status === 'signed-in') {
+        void authUser.set(undefined);
+        phase = { status: 'signed-out' };
+    }
+},
+reactToTokenSet() {
+    if (authToken.current && authUser.current && phase.status === 'signed-out') {
+        phase = { status: 'signed-in' };
+        return true;
+    }
+    return false;
+},
+```
+
+The sole consumer wires them up in `App.svelte`:
+
+```svelte
+$effect(() => {
+    authState.reactToTokenCleared();
+    if (authState.reactToTokenSet()) reconnectSync();
+});
+```
+
+This creates problems:
+
+1. **Implicit contract**: Nothing in the type signature enforces that these must be called inside `$effect`. The JSDoc says "Call this inside a $effect" but that's a comment, not a guarantee. If someone calls them from a plain function, they silently do nothing.
+2. **Leaky abstraction**: The auth module's internal state transitions (signed-in → signed-out, signed-out → signed-in) are exposed as public API. The consumer has to understand the auth state machine to use it correctly.
+3. **Coupled concerns**: `reconnectSync()` (a workspace concern) is tangled into auth's reactive lifecycle via a boolean return value.
+4. **Fragile**: Both methods run inside a single `$effect` block. Svelte tracks all reactive reads in the block as dependencies. If either method reads a new `$state` in the future, the entire effect re-runs for both conditions—potentially causing unexpected behavior.
+
+### Desired State
+
+Auth state manages its own reactive lifecycle internally. Consumers subscribe to events they care about:
+
+```svelte
+<!-- App.svelte -->
+<script lang="ts">
+    import { onMount } from 'svelte';
+
+    onMount(() => {
+        authState.checkSession();
+        const unsub = authState.onExternalSignIn(() => reconnectSync());
+        return unsub;
+    });
+    // No $effect block needed
+</script>
+```
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Effect scope mechanism | `$effect.root()` inside `createAuthState()` | Module-level singleton has no component context; `$effect.root()` is the Svelte 5 API for exactly this case |
+| Cleanup of root effects | None (intentional) | Singleton lives for the JS context lifetime; cleanup is the tab/window closing. See existing article: `your-spa-singleton-doesnt-need-effect-cleanup.md` |
+| External sign-in notification | `onExternalSignIn(callback)` returning unsubscribe | Clean separation—auth manages state, consumer decides what to do about it (e.g. reconnect sync) |
+| External sign-out notification | No separate callback | Token cleared → phase goes to signed-out. Consumers already read `authState.status` reactively. No callback needed unless a specific side effect is required |
+| Callback invocation safety | `untrack()` around callback execution | Prevents callbacks from accidentally creating reactive dependencies inside the effect body |
+
+## Architecture
+
+```
+BEFORE:
+
+┌─ auth.svelte.ts ─────────────────────────────┐
+│ reactToTokenCleared()  ← "call in $effect"    │
+│ reactToTokenSet()      ← "call in $effect"    │
+└───────────────────────────────────────────────┘
+         ▲ consumer must wire up
+┌─ App.svelte ──────────────────────────────────┐
+│ $effect(() => {                               │
+│   authState.reactToTokenCleared();            │
+│   if (authState.reactToTokenSet())            │
+│     reconnectSync();                          │
+│ })                                            │
+└───────────────────────────────────────────────┘
+
+
+AFTER:
+
+┌─ auth.svelte.ts ─────────────────────────────┐
+│ $effect.root(() => {                          │
+│   $effect → token cleared → phase=signed-out  │
+│   $effect → token set → phase=signed-in       │
+│                          → fire listeners     │
+│ })                                            │
+│ onExternalSignIn(cb) → returns unsubscribe    │
+└───────────────────────────────────────────────┘
+         ▲ just subscribes
+┌─ App.svelte ──────────────────────────────────┐
+│ onMount(() => {                               │
+│   authState.checkSession();                   │
+│   return authState.onExternalSignIn(          │
+│     () => reconnectSync()                     │
+│   );                                          │
+│ })                                            │
+└───────────────────────────────────────────────┘
+```
+
+## Safety Analysis
+
+This section documents every concern we considered and why each is safe.
+
+### No premature firing on initialization
+
+`phase` starts as `{ status: 'checking' }`. Neither effect condition matches:
+- Token cleared effect requires `phase.status === 'signed-in'` → false during 'checking'
+- Token set effect requires `phase.status === 'signed-out'` → false during 'checking'
+
+The effects are inert until `checkSession()` resolves and sets a definitive phase.
+
+### No infinite loops (self-stabilizing effects)
+
+**Token cleared effect**: reads `authToken.current` and `phase.status`. Writes `phase = { status: 'signed-out' }`. On the re-run triggered by the phase write, the condition `phase.status === 'signed-in'` is now false. Effect exits. Stable.
+
+**Token set effect**: reads `authToken.current`, `authUser.current`, and `phase.status`. Writes `phase = { status: 'signed-in' }`. On the re-run, `phase.status === 'signed-out'` is false. Effect exits. Stable.
+
+### No cross-effect loops
+
+The two effects have mutually exclusive activation conditions based on token presence:
+- Token cleared fires when `!authToken.current` (token absent) AND `phase.status === 'signed-in'`
+- Token set fires when `authToken.current` (token present) AND `phase.status === 'signed-out'`
+
+If effect 1 sets phase to `signed-out`, effect 2 would need a truthy token to fire—but effect 1 only fires when token is falsy. If effect 2 sets phase to `signed-in`, effect 1 would need a falsy token—but effect 2 only fires when token is truthy. They can never trigger each other.
+
+### No race with checkSession()
+
+`checkSession()` is async. While it runs, phase is `'checking'`. Neither effect fires during `'checking'`. Once `checkSession()` sets a definitive phase, the effects respond correctly to the current token state. No interleaving concern.
+
+### No race with signIn()/signUp()/signOut()
+
+These methods set phase to `'signing-in'` or `'signing-out'` during their operation. Neither effect fires during these transitional states—they only match `'signed-in'` and `'signed-out'`. Once the method completes and sets the final phase, the effects align with the token state at that moment.
+
+### No accidental dependencies from callbacks
+
+`reconnectSync()` is `workspaceClient.extensions.sync.reconnect()`—a one-liner that reads no reactive state. However, future callbacks might read `$state` values. Wrapping callback invocation in `untrack()` prevents any callback from accidentally becoming a dependency of the effect:
+
+```typescript
+$effect(() => {
+    if (authToken.current && authUser.current && phase.status === 'signed-out') {
+        phase = { status: 'signed-in' };
+        untrack(() => {
+            for (const fn of externalSignInListeners) fn();
+        });
+    }
+});
+```
+
+This is a defensive measure. Current consumers don't need it, but it prevents a subtle bug if a future callback reads reactive state.
+
+### No memory leak
+
+`$effect.root()` returns a cleanup function, but we intentionally don't call it. The auth state singleton lives for the entire JS context (browser extension sidepanel). When the context dies, everything—effects, listeners, state—is garbage collected together. This matches the existing pattern in `createStorageState`, which uses `item.watch()` without cleanup.
+
+### No cleanup concern for listener Set
+
+`externalSignInListeners` is a `Set<() => void>`. Subscribers call the returned unsubscribe function in their `onMount` cleanup. If they don't (e.g. another module-level singleton subscribes permanently), that's also fine—the Set lives as long as the auth state, which lives as long as the JS context.
+
+## Implementation Plan
+
+### Phase 1: Refactor auth state internals
+
+- [ ] **1.1** Add `$effect.root()` block inside `createAuthState()` with two internal effects (token cleared, token set)
+- [ ] **1.2** Add `externalSignInListeners` Set and `onExternalSignIn(callback)` method to the return object
+- [ ] **1.3** Remove `reactToTokenCleared()` and `reactToTokenSet()` from the return object
+
+### Phase 2: Update consumer
+
+- [ ] **2.1** In `App.svelte`, remove the `$effect` block (lines 37-40)
+- [ ] **2.2** Add `authState.onExternalSignIn(() => reconnectSync())` inside the existing `onMount`, returning the unsubscribe in cleanup
+
+### Phase 3: Verify
+
+- [ ] **3.1** Test: sign in via email → verify phase transitions
+- [ ] **3.2** Test: sign in via Google → verify phase transitions
+- [ ] **3.3** Test: sign out → verify clearState and phase reset
+- [ ] **3.4** Test: open two sidepanels → sign in in one → verify the other transitions to signed-in and reconnects sync
+- [ ] **3.5** Test: open two sidepanels → sign out in one → verify the other transitions to signed-out
+- [ ] **3.6** LSP diagnostics clean on `auth.svelte.ts` and `App.svelte`
+
+## Edge Cases
+
+### Token and user arrive at different times from another context
+
+1. Another context calls `signIn()`, which writes `authUser` first via `authUser.set(user)`, then the `onSuccess` callback writes `authToken` via the `set-auth-token` header
+2. After `authUser` is set but before `authToken` arrives, the token set effect checks `authToken.current && authUser.current && phase.status === 'signed-out'`. Token is still falsy → effect doesn't fire
+3. Once `authToken` arrives, both conditions are met → effect fires → transition to signed-in
+
+This is the same behavior as the current implementation. The conditions naturally handle partial state.
+
+### URL changes while signed in
+
+1. User changes `remoteServerUrl` in settings
+2. `$derived` creates a new `client` instance
+3. Existing session is still valid; `authToken` and `authUser` unchanged
+4. Next API call uses the new client with the existing token
+
+No impact on the refactored code—`$derived` on `client` is unchanged.
+
+## Success Criteria
+
+- [ ] `reactToTokenCleared()` and `reactToTokenSet()` removed from public API
+- [ ] No `$effect` block in `App.svelte` for auth lifecycle management
+- [ ] Cross-context sign-in/sign-out still works (token changes in one panel are reflected in another)
+- [ ] `reconnectSync()` still fires on external sign-in
+- [ ] LSP diagnostics pass on all changed files
+
+## References
+
+- `apps/tab-manager/src/lib/state/auth.svelte.ts` — The file being refactored
+- `apps/tab-manager/src/lib/state/storage-state.svelte.ts` — Underlying reactive storage wrapper (unchanged)
+- `apps/tab-manager/src/entrypoints/sidepanel/App.svelte` — Sole consumer of reactToToken* methods
+- `apps/tab-manager/src/lib/workspace.ts` — `reconnectSync()` definition (line 870)
+- `docs/articles/your-spa-singleton-doesnt-need-effect-cleanup.md` — Prior art on singleton lifecycle

--- a/apps/tab-manager/src/entrypoints/sidepanel/App.svelte
+++ b/apps/tab-manager/src/entrypoints/sidepanel/App.svelte
@@ -20,7 +20,9 @@
 	// Auth initialization — check cached session on mount, react to external token changes
 	onMount(() => {
 		authState.checkSession();
-		const unsubExternalSignIn = authState.onExternalSignIn(() => reconnectSync());
+		const unsubExternalSignIn = authState.onExternalSignIn(() =>
+			reconnectSync(),
+		);
 
 		const onVisibilityChange = () => {
 			if (

--- a/apps/tab-manager/src/entrypoints/sidepanel/App.svelte
+++ b/apps/tab-manager/src/entrypoints/sidepanel/App.svelte
@@ -20,6 +20,7 @@
 	// Auth initialization — check cached session on mount, react to external token changes
 	onMount(() => {
 		authState.checkSession();
+		const unsubExternalSignIn = authState.onExternalSignIn(() => reconnectSync());
 
 		const onVisibilityChange = () => {
 			if (
@@ -30,13 +31,10 @@
 			}
 		};
 		document.addEventListener('visibilitychange', onVisibilityChange);
-		return () =>
+		return () => {
 			document.removeEventListener('visibilitychange', onVisibilityChange);
-	});
-
-	$effect(() => {
-		authState.reactToTokenCleared();
-		if (authState.reactToTokenSet()) reconnectSync();
+			unsubExternalSignIn();
+		};
 	});
 
 	let searchInputRef = $state<HTMLInputElement | null>(null);

--- a/apps/tab-manager/src/lib/components/AiDrawer.svelte
+++ b/apps/tab-manager/src/lib/components/AiDrawer.svelte
@@ -19,7 +19,9 @@
 		{#if authState.status === 'signed-in'}
 			<div class="h-[60vh] px-4 pb-4"><AiChat /></div>
 		{:else}
-			<div class="flex flex-col items-center justify-center gap-3 h-[200px] px-4 pb-4">
+			<div
+				class="flex flex-col items-center justify-center gap-3 h-[200px] px-4 pb-4"
+			>
 				<ZapIcon class="size-8 text-muted-foreground" />
 				<p class="text-sm text-muted-foreground text-center">
 					Sign in to use AI chat

--- a/apps/tab-manager/src/lib/state/auth.svelte.ts
+++ b/apps/tab-manager/src/lib/state/auth.svelte.ts
@@ -9,13 +9,13 @@
 
 import { type } from 'arktype';
 import { createAuthClient } from 'better-auth/client';
+import { untrack } from 'svelte';
 import {
 	defineErrors,
 	extractErrorMessage,
 	type InferErrors,
 } from 'wellcrafted/error';
 import { Ok, tryAsync } from 'wellcrafted/result';
-import { untrack } from 'svelte';
 import { remoteServerUrl } from './settings.svelte';
 import { createStorageState } from './storage-state.svelte';
 
@@ -134,7 +134,11 @@ function createAuthState() {
 
 		// Token + user set externally (e.g. sign-in in another extension context).
 		$effect(() => {
-			if (authToken.current && authUser.current && phase.status === 'signed-out') {
+			if (
+				authToken.current &&
+				authUser.current &&
+				phase.status === 'signed-out'
+			) {
 				phase = { status: 'signed-in' };
 				untrack(() => {
 					for (const fn of externalSignInListeners) fn();

--- a/apps/tab-manager/src/lib/state/auth.svelte.ts
+++ b/apps/tab-manager/src/lib/state/auth.svelte.ts
@@ -15,6 +15,7 @@ import {
 	type InferErrors,
 } from 'wellcrafted/error';
 import { Ok, tryAsync } from 'wellcrafted/result';
+import { untrack } from 'svelte';
 import { remoteServerUrl } from './settings.svelte';
 import { createStorageState } from './storage-state.svelte';
 
@@ -118,6 +119,29 @@ function createAuthState() {
 	async function clearState() {
 		await Promise.all([authToken.set(undefined), authUser.set(undefined)]);
 	}
+
+	// Listeners notified when an *external* context signs in (e.g. another sidepanel).
+	const externalSignInListeners = new Set<() => void>();
+
+	$effect.root(() => {
+		// Token cleared externally (e.g. sign-out in another extension context).
+		$effect(() => {
+			if (!authToken.current && phase.status === 'signed-in') {
+				void authUser.set(undefined);
+				phase = { status: 'signed-out' };
+			}
+		});
+
+		// Token + user set externally (e.g. sign-in in another extension context).
+		$effect(() => {
+			if (authToken.current && authUser.current && phase.status === 'signed-out') {
+				phase = { status: 'signed-in' };
+				untrack(() => {
+					for (const fn of externalSignInListeners) fn();
+				});
+			}
+		});
+	});
 
 	return {
 		get status() {
@@ -352,26 +376,26 @@ function createAuthState() {
 		},
 
 		/**
-		 * Watch for token being cleared externally (e.g. another extension context).
-		 * Call this inside a $effect.
+		 * Subscribe to external sign-in events (e.g. sign-in from another extension context).
+		 *
+		 * When the auth token and user appear while this context is signed-out,
+		 * the callback fires. Useful for triggering side effects like reconnecting
+		 * sync without coupling those concerns to the auth module.
+		 *
+		 * @returns Unsubscribe function. Call in `onMount` cleanup.
+		 *
+		 * @example
+		 * ```typescript
+		 * onMount(() => {
+		 *     return authState.onExternalSignIn(() => reconnectSync());
+		 * });
+		 * ```
 		 */
-		reactToTokenCleared() {
-			if (!authToken.current && phase.status === 'signed-in') {
-				void authUser.set(undefined);
-				phase = { status: 'signed-out' };
-			}
-		},
-		/**
-		 * Watch for token being set externally (e.g. sign-in in another extension context).
-		 * When a token and user appear while this context is signed-out, transition to signed-in.
-		 * Call this inside a $effect. Returns `true` if a transition occurred.
-		 */
-		reactToTokenSet() {
-			if (authToken.current && authUser.current && phase.status === 'signed-out') {
-				phase = { status: 'signed-in' };
-				return true;
-			}
-			return false;
+		onExternalSignIn(callback: () => void) {
+			externalSignInListeners.add(callback);
+			return () => {
+				externalSignInListeners.delete(callback);
+			};
 		},
 	};
 }

--- a/apps/tab-manager/src/lib/workspace.ts
+++ b/apps/tab-manager/src/lib/workspace.ts
@@ -597,7 +597,7 @@ export const workspaceClient = createWorkspace(
 		'sync',
 		createSyncExtension({
 			url: (workspaceId) => `${serverUrl.current}/workspaces/${workspaceId}`,
-			getToken: async () => authState.token ?? '',
+			getToken: async () => authState.token,
 		}),
 	)
 	.withActions(({ tables }) => ({

--- a/docs/articles/this-smells-wrong-design-it-from-scratch.md
+++ b/docs/articles/this-smells-wrong-design-it-from-scratch.md
@@ -1,0 +1,81 @@
+# "This Smells Wrong—Design It from Scratch"
+
+The most effective prompt I give an AI coding agent isn't "fix this" or "refactor that." It's: "This feels like a code smell. If you were designing this from scratch, what would you have done differently?"
+
+That framing does three things no other prompt does: it invites the agent to critique without being defensive, it detaches the agent from sunk-cost loyalty to existing code, and it forces architectural thinking instead of line-level fixes.
+
+## Why "fix this" produces bad results
+
+When you tell an AI to fix something, it tries to preserve what's there. It patches. It adds null checks, wraps things in try-catch, introduces a helper function that smooths over the real problem. The fix works, technically, but the architecture stays wrong.
+
+```typescript
+// You say: "fix the race condition in auth"
+// AI adds:
+if (isAlreadyChecking) return; // band-aid
+isAlreadyChecking = true;
+```
+
+The agent treats existing code as correct-but-broken. It never questions whether the structure should exist at all.
+
+## Why "from scratch" changes the output
+
+"Design it from scratch" gives the agent permission to throw away the current approach. It stops trying to preserve—and starts evaluating. The internal reasoning shifts from "how do I make this work" to "what's the right way to solve this problem."
+
+Here's a real example. A browser extension had two methods on an auth state object that consumers had to call inside a `$effect` block:
+
+```typescript
+// The code that smelled wrong
+$effect(() => {
+    authState.reactToTokenCleared();
+    if (authState.reactToTokenSet()) reconnectSync();
+});
+```
+
+Two methods that only work when called inside a reactive scope, with an implicit contract that nothing in the type system enforces. Asking "fix this" would produce a comment explaining the contract, or maybe a runtime check that throws if called outside `$effect`. Asking "design it from scratch" produced something different: the auth module should manage its own reactive lifecycle with `$effect.root()`, expose a clean `onExternalSignIn(callback)` subscription, and never require consumers to know about its internal state machine.
+
+The consumer went from this:
+
+```svelte
+$effect(() => {
+    authState.reactToTokenCleared();
+    if (authState.reactToTokenSet()) reconnectSync();
+});
+```
+
+To this:
+
+```svelte
+onMount(() => {
+    return authState.onExternalSignIn(() => reconnectSync());
+});
+```
+
+Same behavior. The smell is gone. The agent found it because the prompt gave it room to think architecturally instead of surgically.
+
+## The three-part structure
+
+The full prompt has three parts, and each one matters:
+
+**"This feels like a code smell"** tells the agent something is wrong without specifying what. It has to identify the problem, not just apply a pre-selected fix. This is important—you might be wrong about what the smell is, and the agent might find the real issue is somewhere you didn't expect.
+
+**"If you were designing this from scratch"** detaches the agent from the current implementation. It stops anchoring to variable names, function boundaries, and file structure. It can propose moving responsibility to a different module, splitting a file, or eliminating a layer entirely.
+
+**"What would you have done differently?"** invites comparison. The agent has to articulate why the new approach is better than the old one. This forces it to identify the specific properties that make the current code problematic—not just "it's messy" but "it exposes internal state transitions as public API" or "it creates an implicit dependency between modules."
+
+## When to use it
+
+This prompt works best on code that technically works but feels wrong. The kind of code where you look at it and think "there has to be a better way" but can't immediately articulate what that way is.
+
+It's less useful for straightforward bugs (just describe the bug) or trivial cleanup (just ask for the refactor). It shines on architectural smells: tight coupling, leaky abstractions, responsibilities in the wrong place, patterns that force consumers to know too much about internals.
+
+## When it goes wrong
+
+The failure mode is over-engineering. "From scratch" can lead an agent to propose a complete rewrite when the existing code just needs a small adjustment. If the agent comes back with three new abstractions and a design pattern you've never heard of, it overshot. The response should be a simpler version of what exists, not a more complex one.
+
+The antidote: follow up with "what's the simplest version of this?" If the agent's from-scratch design is genuinely simpler than what exists, it's probably right. If it's more complex, the original code might not have been as smelly as you thought.
+
+## The real insight
+
+The reason this prompt works is that it mirrors how experienced engineers think. You don't look at messy code and immediately start editing. You step back, understand what it's trying to do, and ask yourself how you'd build it if you were starting today with everything you now know. The gap between "what exists" and "what I'd build" is the refactoring plan.
+
+Giving an AI agent that same framing produces the same kind of thinking. It's not a hack or a jailbreak. It's just the right question.

--- a/packages/sync-client/README.md
+++ b/packages/sync-client/README.md
@@ -4,7 +4,7 @@ Client-side Yjs sync provider for any y-websocket compatible server.
 
 ## What This Does
 
-`createSyncProvider()` connects a `Y.Doc` to a WebSocket sync server using the y-websocket protocol, plus a custom heartbeat extension (MESSAGE_SYNC_STATUS, tag 102) for `hasLocalChanges` tracking and fast dead-connection detection.
+`createSyncProvider()` connects a `Y.Doc` to a WebSocket sync server using the y-websocket protocol with text-based ping/pong liveness detection.
 
 Most consumers don't use this package directly. Instead, they use `createSyncExtension` from `@epicenter/workspace/extensions/sync`, which wraps this provider with workspace lifecycle management (waiting for persistence to load before connecting, auto-cleanup on destroy, URL templating with workspace IDs).
 
@@ -26,11 +26,6 @@ const provider = createSyncProvider({
 // Provider connects automatically. Check status:
 provider.onStatusChange((status) => {
 	console.log('Sync phase:', status.phase);
-});
-
-// Track whether local changes have reached the server:
-provider.onLocalChanges((hasChanges) => {
-	console.log(hasChanges ? 'Saving...' : 'Saved');
 });
 
 // Clean up when done:
@@ -67,7 +62,7 @@ const provider = createSyncProvider({
 });
 ```
 
-The provider caches the token and refreshes it after every 3 consecutive connection failures.
+The token is fetched fresh on every connection attempt—no caching.
 
 ## API
 
@@ -83,7 +78,7 @@ function createSyncProvider(config: SyncProviderConfig): SyncProvider;
 | ---------------------- | ----------------------- | -------------------- | --------------------------------------------------------------- |
 | `doc`                  | `Y.Doc`                 | (required)           | The Yjs document to sync                                        |
 | `url`                  | `string`                | (required)           | WebSocket URL to connect to                                     |
-| `getToken`             | `() => Promise<string>` | —                    | Dynamic token fetcher for authenticated mode                    |
+| `getToken`             | `() => Promise<string \| undefined>` | —                    | Dynamic token fetcher for authenticated mode. Return `undefined` when no token is available. |
 | `connect`              | `boolean`               | `true`               | Whether to connect immediately                                  |
 | `awareness`            | `Awareness`             | `new Awareness(doc)` | External awareness instance for user presence                   |
 
@@ -92,12 +87,10 @@ function createSyncProvider(config: SyncProviderConfig): SyncProvider;
 | Property / Method    | Type                                                     | Description                                            |
 | -------------------- | -------------------------------------------------------- | ------------------------------------------------------ |
 | `status`             | `SyncStatus` (readonly)                                  | Current connection status (discriminated on `phase`)   |
-| `hasLocalChanges`    | `boolean` (readonly)                                     | Whether unacknowledged local changes exist             |
 | `awareness`          | `Awareness` (readonly)                                   | The awareness instance for user presence               |
 | `connect()`          | `() => void`                                             | Start connecting. Idempotent.                          |
 | `disconnect()`       | `() => void`                                             | Stop connecting and close the socket                   |
 | `onStatusChange(fn)` | `(listener: (status: SyncStatus) => void) => () => void` | Subscribe to status changes. Returns unsubscribe.      |
-| `onLocalChanges(fn)` | `(listener: (has: boolean) => void) => () => void`       | Subscribe to local changes state. Returns unsubscribe. |
 | `destroy()`          | `() => void`                                             | Disconnect, remove all listeners, release resources    |
 
 ## Connection Status Model
@@ -141,37 +134,15 @@ provider.onStatusChange((status) => {
 });
 ```
 
-## `hasLocalChanges`
+## Liveness Detection
 
-Tracks whether all local Y.Doc mutations have been acknowledged by the server.
+The provider sends text `"ping"` messages at a fixed interval. Any incoming message (binary sync data or text `"pong"`) resets the liveness timer. If no message arrives within the timeout window, the WebSocket is closed and reconnection begins.
 
-The provider sends a MESSAGE_SYNC_STATUS (tag 102) frame after each local edit containing a monotonic version counter. The server echoes it back unchanged. When the echoed version matches the local version, all changes have reached the server.
+- **Ping interval**: 30 seconds
+- **Liveness timeout**: 45 seconds (checked every 10 seconds)
+- **Worst-case dead connection detection**: ~55 seconds
 
-This powers "Saving..." / "Saved" UI indicators and `beforeunload` warnings:
-
-```typescript
-provider.onLocalChanges((hasChanges) => {
-	statusBar.text = hasChanges ? 'Saving...' : 'Saved';
-});
-
-window.addEventListener('beforeunload', (e) => {
-	if (provider.hasLocalChanges) {
-		e.preventDefault();
-	}
-});
-```
-
-## Heartbeat
-
-The same MESSAGE_SYNC_STATUS message doubles as a heartbeat probe:
-
-- After **2 seconds** of silence (no messages sent or received), the provider sends a probe
-- If no response arrives within **3 seconds**, the WebSocket is closed and reconnection begins
-- Worst-case dead connection detection: **5 seconds**
-
-The heartbeat timeout only arms after the server has responded to at least one probe (proving it supports tag 102). This prevents false-positive disconnects from standard y-websocket servers.
-
-Browser `offline` events trigger an immediate probe. Browser `online` events wake the reconnect backoff sleeper.
+Browser `offline` events close the socket immediately. Browser `online` events wake the reconnect backoff sleeper. Tab visibility changes trigger an immediate ping to detect stale connections.
 
 ## Architecture
 
@@ -190,14 +161,14 @@ This eliminates the race conditions common in event-driven WebSocket reconnectio
  └─ extensions/sync.ts                  └─ WebSocket endpoint
      │                                      │
      │  createSyncExtension()               │  y-websocket protocol
-     │  - URL templating ({id})             │  MESSAGE_SYNC_STATUS echo
-     │  - Waits for persistence             │  Ping/pong keepalive
+     │  - URL templating ({id})             │  Ping/pong keepalive
+     │  - Waits for persistence             │
      │  - Lifecycle management              │
      │                                      │
      └──── uses ────▶ @epicenter/sync ◀──── talks to ────┘
                       └─ createSyncProvider()
                       └─ Supervisor loop
-                      └─ Heartbeat + hasLocalChanges
+                      └─ Liveness (ping/pong)
 ```
 
 - **`@epicenter/sync`** (this package): Raw sync provider. Connects a Y.Doc to a WebSocket.

--- a/packages/sync-client/src/provider.ts
+++ b/packages/sync-client/src/provider.ts
@@ -246,25 +246,22 @@ export function createSyncProvider(config: SyncProviderConfig): SyncProvider {
 				}
 			}
 
-			if (runId !== myRunId) break;
-
 			// --- Single connection attempt ---
 			const result = await attemptConnection(token, myRunId);
 
-			if (runId !== myRunId) break;
-
-			if (result === 'connected') {
-				backoff.reset();
-				lastError = undefined;
-			}
-
 			if (result === 'cancelled') break;
 
-			// Connection failed or closed — backoff and retry
+			if (result === 'connected') {
+				// Connection was live, then dropped — retry quickly
+				backoff.reset();
+				lastError = undefined;
+			} else {
+				// Never connected
+				lastError = { type: 'connection' };
+			}
+
+			// Backoff before retry (skip if cancelled externally)
 			if (desired === 'online' && runId === myRunId) {
-				if (result === 'failed') {
-					lastError = { type: 'connection' };
-				}
 				attempt += 1;
 				status.set({ phase: 'connecting', attempt, lastError });
 				await backoff.sleep();

--- a/packages/sync-client/src/provider.ts
+++ b/packages/sync-client/src/provider.ts
@@ -235,6 +235,13 @@ export function createSyncProvider(config: SyncProviderConfig): SyncProvider {
 			if (getToken) {
 				try {
 					token = await getToken();
+					if (!token) {
+						lastError = { type: 'auth', error: new Error('No token available') };
+						status.set({ phase: 'connecting', attempt, lastError });
+						await backoff.sleep();
+						attempt += 1;
+						continue;
+					}
 				} catch (e) {
 					console.warn('[SyncProvider] Failed to get token', e);
 					lastError = { type: 'auth', error: e };

--- a/packages/sync-client/src/provider.ts
+++ b/packages/sync-client/src/provider.ts
@@ -235,13 +235,7 @@ export function createSyncProvider(config: SyncProviderConfig): SyncProvider {
 			if (getToken) {
 				try {
 					token = await getToken();
-					if (!token) {
-						lastError = { type: 'auth', error: new Error('No token available') };
-						status.set({ phase: 'connecting', attempt, lastError });
-						await backoff.sleep();
-						attempt += 1;
-						continue;
-					}
+					if (!token) throw new Error('No token available');
 				} catch (e) {
 					console.warn('[SyncProvider] Failed to get token', e);
 					lastError = { type: 'auth', error: e };

--- a/packages/sync-client/src/types.ts
+++ b/packages/sync-client/src/types.ts
@@ -38,7 +38,7 @@ export type SyncProviderConfig = {
 	/**
 	 * Dynamic token fetcher for authenticated mode. Called on each connect/reconnect.
 	 */
-	getToken?: () => Promise<string>;
+	getToken?: () => Promise<string | undefined>;
 
 	/** External awareness instance. If provided, destroy() will NOT remove its states. Defaults to `new Awareness(doc)`. */
 	awareness?: Awareness;

--- a/packages/workspace/src/extensions/sync.ts
+++ b/packages/workspace/src/extensions/sync.ts
@@ -60,7 +60,7 @@ export type SyncExtensionConfig = {
 	 * The same token is used for both WebSocket (`?token=` query param) and
 	 * HTTP snapshot (`Authorization: Bearer` header).
 	 */
-	getToken?: (workspaceId: string) => Promise<string>;
+	getToken?: (workspaceId: string) => Promise<string | undefined>;
 };
 
 /**

--- a/specs/20260311T230000-gettoken-falsy-return-fix.md
+++ b/specs/20260311T230000-gettoken-falsy-return-fix.md
@@ -1,0 +1,94 @@
+# Fix: getToken returning empty string misclassifies auth errors
+
+**Status:** Implementing
+**Scope:** 4 files, ~10 lines changed
+
+## Problem
+
+`workspace.ts` line 600:
+
+```typescript
+getToken: async () => authState.token ?? '',
+```
+
+When a user is not signed in, `authState.token` is `undefined`. The `?? ''` coerces it to an empty string to satisfy `getToken`'s return type (`() => Promise<string>`). The provider then:
+
+1. Calls `getToken()` → gets `''`
+2. Checks `if (token)` → `''` is falsy, skips adding `?token=` param
+3. Opens WebSocket without auth → server rejects with 401
+4. Classifies the failure as `{ type: 'connection' }` instead of `{ type: 'auth' }`
+5. Retries with backoff indefinitely
+
+The root cause: `getToken`'s return type is `() => Promise<string>`, which forces callers to return *something* even when no token exists. The type is a lie—sometimes there genuinely is no token.
+
+## Fix
+
+Make the types honest. Let `getToken` return `string | undefined`. Add a guard in the provider to classify a falsy return as an auth error.
+
+### Changes
+
+**1. `packages/sync-client/src/types.ts`** — Widen return type
+
+```typescript
+// Before
+getToken?: () => Promise<string>;
+
+// After
+getToken?: () => Promise<string | undefined>;
+```
+
+**2. `packages/sync-client/src/provider.ts`** — Guard falsy token
+
+After `token = await getToken()`, treat a falsy result as an auth error:
+
+```typescript
+token = await getToken();
+if (!token) {
+    lastError = { type: 'auth', error: new Error('No token available') };
+    status.set({ phase: 'connecting', attempt, lastError });
+    await backoff.sleep();
+    attempt += 1;
+    continue;
+}
+```
+
+No new mutable state. The `let token` already exists on line 234. This is a guard after the existing assignment.
+
+**3. `packages/workspace/src/extensions/sync.ts`** — Widen config type
+
+```typescript
+// Before
+getToken?: (workspaceId: string) => Promise<string>;
+
+// After
+getToken?: (workspaceId: string) => Promise<string | undefined>;
+```
+
+**4. `apps/tab-manager/src/lib/workspace.ts`** — Remove the hack
+
+```typescript
+// Before
+getToken: async () => authState.token ?? '',
+
+// After
+getToken: async () => authState.token,
+```
+
+### What this does NOT change
+
+- The provider still retries on auth errors (with backoff). This is fine—the user might sign in while the provider is retrying, and `getToken` is called fresh each iteration.
+- The UI already checks `lastError?.type === 'auth'` in the tooltip. Correct classification means the UI now shows "Authentication failed" instead of treating it as a generic connection problem.
+- The `reconnectSync()` call from `reactToTokenSet()` still handles the sign-in→reconnect flow. The retry loop is a fallback, not the primary recovery path.
+
+### Future consideration (not in scope)
+
+The provider could stop retrying entirely on auth errors and wait for an explicit `reconnect()`. This would eliminate the wasteful polling for unauthenticated users. But at 30s max backoff for a browser extension sidebar, the cost is negligible. Separate concern, separate PR.
+
+## Todo
+
+- [x] Write spec
+- [ ] Update `SyncProviderConfig.getToken` return type
+- [ ] Add falsy token guard in provider `runLoop`
+- [ ] Update `SyncExtensionConfig.getToken` return type
+- [ ] Remove `?? ''` from workspace.ts callsite
+- [ ] LSP diagnostics clean on all 4 files

--- a/specs/20260311T230000-gettoken-falsy-return-fix.md
+++ b/specs/20260311T230000-gettoken-falsy-return-fix.md
@@ -1,6 +1,6 @@
 # Fix: getToken returning empty string misclassifies auth errors
 
-**Status:** Implementing
+**Status:** Implemented
 **Scope:** 4 files, ~10 lines changed
 
 ## Problem
@@ -78,7 +78,7 @@ getToken: async () => authState.token,
 
 - The provider still retries on auth errors (with backoff). This is fine—the user might sign in while the provider is retrying, and `getToken` is called fresh each iteration.
 - The UI already checks `lastError?.type === 'auth'` in the tooltip. Correct classification means the UI now shows "Authentication failed" instead of treating it as a generic connection problem.
-- The `reconnectSync()` call from `reactToTokenSet()` still handles the sign-in→reconnect flow. The retry loop is a fallback, not the primary recovery path.
+- The `reconnectSync()` call from `onExternalSignIn()` still handles the sign-in→reconnect flow. The retry loop is a fallback, not the primary recovery path.
 
 ### Future consideration (not in scope)
 
@@ -87,8 +87,8 @@ The provider could stop retrying entirely on auth errors and wait for an explici
 ## Todo
 
 - [x] Write spec
-- [ ] Update `SyncProviderConfig.getToken` return type
-- [ ] Add falsy token guard in provider `runLoop`
-- [ ] Update `SyncExtensionConfig.getToken` return type
-- [ ] Remove `?? ''` from workspace.ts callsite
-- [ ] LSP diagnostics clean on all 4 files
+- [x] Update `SyncProviderConfig.getToken` return type
+- [x] Add falsy token guard in provider `runLoop`
+- [x] Update `SyncExtensionConfig.getToken` return type
+- [x] Remove `?? ''` from workspace.ts callsite
+- [x] LSP diagnostics clean on all 4 files


### PR DESCRIPTION
Internalizes the auth state module's reactive lifecycle so consumers no longer participate in its state machine, and fixes a misclassification bug where unauthenticated users saw "connection failed" instead of "authentication failed" in the sync status tooltip.

The tab manager's auth module (`auth.svelte.ts`) exposed two methods—`reactToTokenCleared()` and `reactToTokenSet()`—that only worked when called inside a Svelte `$effect` block. Nothing in the type system enforced this contract; it was a JSDoc comment and a prayer. Consumers had to understand the auth state machine to wire them up correctly, and a boolean return value (`reactToTokenSet() → true`) was the sole bridge between auth transitions and workspace sync reconnection. Meanwhile, the sync provider's `getToken` type signature was `() => Promise<string>`, which forced the workspace callsite to coerce `undefined` to `''` via `?? ''`—hiding the "no token" case from error classification.

### Auth state: from leaky abstraction to event subscription

The two public methods are replaced by `$effect.root()` effects inside `createAuthState()`. The module manages its own reactive lifecycle and exposes a clean `onExternalSignIn(callback)` subscription for consumers who need to react to cross-context sign-ins.

```
BEFORE:

┌─ auth.svelte.ts ─────────────────────────────┐
│ reactToTokenCleared()  ← "call in $effect"    │
│ reactToTokenSet()      ← "call in $effect"    │
└───────────────────────────────────────────────┘
         ▲ consumer must wire up
┌─ App.svelte ──────────────────────────────────┐
│ $effect(() => {                               │
│   authState.reactToTokenCleared();            │
│   if (authState.reactToTokenSet())            │
│     reconnectSync();                          │
│ })                                            │
└───────────────────────────────────────────────┘


AFTER:

┌─ auth.svelte.ts ─────────────────────────────┐
│ $effect.root(() => {                          │
│   $effect → token cleared → phase=signed-out  │
│   $effect → token set → phase=signed-in       │
│                          → fire listeners     │
│ })                                            │
│ onExternalSignIn(cb) → returns unsubscribe    │
└───────────────────────────────────────────────┘
         ▲ just subscribes
┌─ App.svelte ──────────────────────────────────┐
│ onMount(() => {                               │
│   authState.checkSession();                   │
│   return authState.onExternalSignIn(          │
│     () => reconnectSync()                     │
│   );                                          │
│ })                                            │
└───────────────────────────────────────────────┘
```

The consumer went from a raw `$effect` block that called two opaque methods to a standard `onMount` with a subscription that returns an unsubscribe function. No knowledge of the auth state machine required.

### getToken: making the types honest

`getToken`'s return type widened from `Promise<string>` to `Promise<string | undefined>`. The provider now guards against a falsy return and classifies it as `{ type: 'auth' }` instead of letting the empty string fall through to a 401 → `{ type: 'connection' }` misclassification.

```typescript
// Before: type lie forces coercion
getToken: async () => authState.token ?? '',
// '' passes getToken but fails server auth → classified as "connection" error

// After: type is honest
getToken: async () => authState.token,
// undefined caught by provider guard → classified as "auth" error
```

This means the UI now correctly shows "Authentication failed" in the sync tooltip when a user isn't signed in, instead of treating it as a generic network problem.

### Sync client: simplified control flow

The `runLoop` in `provider.ts` had two places checking `runId !== myRunId` (cancellation) with slightly different behavior, and duplicated the `lastError = { type: 'connection' }` assignment across branches. Merged the cancellation checks into a single `result === 'cancelled'` guard and consolidated the post-result logic into a clean if/else.

### Docs

- Sync-client README overhauled: removed phantom `hasLocalChanges`/`onLocalChanges` API surface that was documented but never implemented, replaced incorrect `MESSAGE_SYNC_STATUS` heartbeat description with actual ping/pong liveness detection, updated `getToken` type signature.
- New article: "This Smells Wrong—Design It from Scratch" (prompting technique that produced the auth refactor).
- Specs for both the auth refactor and getToken fix, with completed todos.