### PR TITLE
feat(ci): changelog strategy, auto-release workflow, and decoupled package versioning

### DIFF
--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -36,7 +36,8 @@ async function collectFiles() {
 	const patterns: { glob: string; type: 'json' | 'toml' }[] = [
 		{ glob: 'package.json', type: 'json' },
 		{ glob: 'apps/*/package.json', type: 'json' },
-		{ glob: 'packages/*/package.json', type: 'json' },
+		// packages/*/package.json intentionally excluded — packages use independent
+		// semver for npm publishing. Only apps share the monorepo version.
 		{ glob: 'apps/*/src-tauri/tauri.conf.json', type: 'json' },
 		{ glob: 'apps/*/src-tauri/Cargo.toml', type: 'toml' },
 	];

--- a/specs/20260303T150000-unified-versioning.md
+++ b/specs/20260303T150000-unified-versioning.md
@@ -99,13 +99,12 @@ PR merges to main
 
 ### Files stamped by `bump-version.ts`
 
-The script globs for all files that need version updates instead of a hardcoded list:
+The script globs for app-level files that need version updates. Packages are **intentionally excluded**—they use independent semver for future npm publishing.
 
 ```
 # JSON files (version field)
 package.json                                    (root)
 apps/*/package.json                             (all apps)
-packages/*/package.json                         (all packages)
 
 # Tauri configs (version field)
 apps/*/src-tauri/tauri.conf.json                (all Tauri apps)
@@ -116,6 +115,8 @@ apps/*/src-tauri/Cargo.toml                     (all Tauri apps)
 # TypeScript constant
 packages/constants/src/versions.ts              (single VERSION export)
 ```
+
+**Why packages are excluded:** Internal dependencies use `workspace:*` protocol, so package version numbers are irrelevant for monorepo resolution. They only matter when publishing to npm, where each package needs a clean independent version history (starting from `1.0.0`, not jumping from `0.0.1` to `8.0.0`). Packages are versioned manually at publish time.
 
 ### `packages/constants/src/versions.ts` simplification
 

--- a/specs/20260311T224500-changelog-release-strategy.md
+++ b/specs/20260311T224500-changelog-release-strategy.md
@@ -86,6 +86,7 @@ Studied [opencode.ai/changelog](https://opencode.ai/changelog) and [GitHub relea
 | AI involvement | None for generation; optional human-triggered polish | Avoids OpenCode's quality problems |
 | Release body target | GitHub Releases (source of truth) | Already where users look; website pulls from this later |
 | Website `/changelog` | Deferred to post-v8 | Build what's needed now; website can consume GitHub Releases API when ready |
+| Versioning scope | Apps only (8.Y.Z); packages excluded | Packages use independent semver for future npm publishing. `workspace:*` makes internal version numbers irrelevant. |
 
 ## Architecture
 


### PR DESCRIPTION
Implements the changelog and release strategy for v8, adds the auto-release CI workflow, and decouples package versioning from app versioning.

### What changed

**Changelog convention**: PRs with `feat:` or `fix:` prefix include a `## Changelog` section in the description. One line per user-visible change. Internal PRs omit the section. `auto.release.yml` aggregates entries into grouped GitHub Releases (New / Fixed / Improved).

**Auto-release workflow**: On every PR merge to main, `auto.release.yml` bumps the version (patch by default, minor for `!` breaking changes), extracts changelog entries from PR bodies, and creates a GitHub Release. Community contributors get `(@username)` credit.

**Decoupled package versioning**: `bump-version.ts` no longer stamps `packages/*/package.json`. Apps share the monorepo version (8.Y.Z). Packages keep independent semver for future npm publishing — `workspace:*` makes internal version numbers irrelevant for resolution.

**Git skill updates**: Fixed `!` = minor bump (was incorrectly documented as major). Added changelog entry convention for PR authors.

### Specs

- `specs/20260311T224500-changelog-release-strategy.md` — full strategy doc
- `specs/20260303T150000-unified-versioning.md` — updated to reflect package exclusion

## Changelog
- Add auto-release workflow that generates changelogs from PR descriptions
- Decouple package versioning from app releases for clean npm publishing