### PR TITLE
fix: use disabled attribute over JS guards for non-interactive elements

### DIFF
--- a/.agents/skills/styling/SKILL.md
+++ b/.agents/skills/styling/SKILL.md
@@ -36,3 +36,47 @@ This principle applies to all elements where the styling doesn't conflict with t
 - Use `tailwind-variants` for component variant systems
 - Follow the `background`/`foreground` convention for colors
 - Leverage CSS variables for theme consistency
+
+## Disabled States: Use HTML `disabled` + Tailwind Variants
+
+When an interactive element can be non-interactive (empty section, loading state, no items), use the HTML `disabled` attribute instead of JS conditional guards. Pair it with Tailwind's `enabled:` and `group-disabled:` variants.
+
+### Why `disabled` Over JS Guards
+
+- `disabled` natively blocks clicks—no `if (!hasItems) return` needed
+- Enables the `:disabled` CSS pseudo-class for styling
+- Semantically correct for accessibility (screen readers announce "dimmed" or "unavailable")
+- Tailwind's `enabled:` and `group-disabled:` variants compose cleanly
+
+### Pattern
+
+```svelte
+<!-- The button disables itself when count is 0 -->
+<button
+  class="group enabled:cursor-pointer enabled:hover:opacity-80"
+  disabled={item.count === 0}
+  onclick={toggle}
+>
+  {item.label} ({item.count})
+  <ChevronIcon class="group-disabled:invisible" />
+</button>
+```
+
+### Key Variants
+
+- `enabled:cursor-pointer` — pointer cursor only when clickable
+- `enabled:hover:bg-accent/50` — hover effects only when interactive
+- `group-disabled:invisible` — hide child elements (e.g., expand chevron) when parent is disabled
+- `disabled:opacity-50` — dim the element when disabled
+
+### Anti-Pattern
+
+```svelte
+<!-- Don't do this: JS guard duplicates what disabled does natively -->
+<button
+  class="cursor-pointer hover:opacity-80"
+  onclick={() => { if (item.count > 0) toggle(); }}
+>
+```
+
+The JS guard leaves `cursor-pointer` and `hover:opacity-80` active on a non-interactive element. The user sees a clickable button that does nothing. Use `disabled` and let the browser + CSS handle it.

--- a/apps/tab-manager/src/lib/components/tabs/UnifiedTabList.svelte
+++ b/apps/tab-manager/src/lib/components/tabs/UnifiedTabList.svelte
@@ -70,16 +70,17 @@
 				>
 					<button
 						type="button"
+						disabled={item.count === 0}
 						onclick={() => {
 							if (!unifiedViewState.isFiltering) {
 								unifiedViewState.toggleSection(item.section);
 							}
 						}}
-						class="flex flex-1 cursor-pointer items-center gap-2 transition hover:opacity-80"
+						class="group flex flex-1 items-center gap-2 transition enabled:cursor-pointer enabled:hover:opacity-80"
 					>
 						<ChevronRightIcon
 							class={cn(
-								'size-4 shrink-0 text-muted-foreground transition',
+								'size-4 shrink-0 text-muted-foreground transition group-disabled:invisible',
 								isExpanded && 'rotate-90',
 							)}
 						/>

--- a/apps/whispering/src/lib/components/copyable/TextPreviewDialog.svelte
+++ b/apps/whispering/src/lib/components/copyable/TextPreviewDialog.svelte
@@ -87,7 +87,7 @@
 				<textarea
 					{...props}
 					data-slot="input-group-control"
-					class="flex-1 min-w-0 resize-none rounded-none border-0 bg-transparent py-2 px-3 shadow-none focus-visible:ring-0 focus:outline-none dark:bg-transparent text-sm leading-snug hover:cursor-pointer hover:bg-accent/50 transition-colors min-h-0"
+					class="flex-1 min-w-0 resize-none rounded-none border-0 bg-transparent py-2 px-3 shadow-none focus-visible:ring-0 focus:outline-none dark:bg-transparent text-sm leading-snug enabled:hover:cursor-pointer enabled:hover:bg-accent/50 transition-colors min-h-0"
 					readonly
 					value={text}
 					style="view-transition-name: {id}"

--- a/docs/articles/disabled-attribute-over-js-guards.md
+++ b/docs/articles/disabled-attribute-over-js-guards.md
@@ -1,0 +1,65 @@
+# Use `disabled` Instead of JS Guards for Non-Interactive States
+
+When a button can't do anything—zero items to expand, nothing to submit, no action available—use the HTML `disabled` attribute. Don't write `if (!hasItems) return` inside an `onclick` handler and call it done. The browser already has a mechanism for "this element isn't interactive right now," and it's one attribute.
+
+## The Problem
+
+A collapsible section header with zero items. The button has `cursor-pointer` and `hover:opacity-80`. Clicking it does nothing because the handler checks `if (count === 0) return`. But the user still sees a pointer cursor, still sees the hover effect, and still clicks expecting something to happen.
+
+```svelte
+<!-- Looks clickable, does nothing -->
+<button
+  class="cursor-pointer hover:opacity-80"
+  onclick={() => { if (item.count > 0) toggle(); }}
+>
+  Bookmarks ({item.count})
+  <ChevronRight />
+</button>
+```
+
+The JS guard stops the toggle, but the CSS doesn't know about it. `cursor-pointer` and `hover:opacity-80` apply unconditionally. The element lies to the user.
+
+## The Fix
+
+```svelte
+<button
+  class="group enabled:cursor-pointer enabled:hover:opacity-80"
+  disabled={item.count === 0}
+  onclick={toggle}
+>
+  Bookmarks ({item.count})
+  <ChevronRight class="group-disabled:invisible" />
+</button>
+```
+
+Three things happen when `disabled` is true:
+
+1. The browser blocks the click event natively. No JS guard needed; `toggle` never fires.
+2. `enabled:cursor-pointer` and `enabled:hover:opacity-80` deactivate. The element looks and feels non-interactive.
+3. `group-disabled:invisible` hides the chevron. There's nothing to expand, so there's no arrow.
+
+When `item.count` goes from 0 to 1, `disabled` is removed and everything reactivates. No state management, no effect cleanup.
+
+## Why Not Just Add `pointer-events-none`?
+
+`pointer-events-none` removes hover and click, but it's a CSS hack over a semantic problem. Screen readers still announce the element as a button. Keyboard navigation still focuses it. `disabled` communicates to the browser, assistive technology, and CSS all at once.
+
+## The Tailwind Variants That Matter
+
+Tailwind provides modifier variants for the `:enabled` and `:disabled` pseudo-classes, and a `group-disabled:` variant for styling children based on a parent's disabled state.
+
+```svelte
+<!-- Parent: use enabled: for self-styling -->
+<button class="group enabled:cursor-pointer enabled:hover:bg-accent/50" disabled={!canAct}>
+
+<!-- Child: use group-disabled: for parent-aware styling -->
+<span class="group-disabled:invisible group-disabled:opacity-0">
+  <ChevronRight />
+</span>
+```
+
+`enabled:` gates the style behind `:enabled`. `group-disabled:` gates the style behind the nearest `group` ancestor's `:disabled` state. Together they replace all the JS guards and conditional class logic.
+
+## Where This Applies
+
+Any element where interactivity depends on a runtime condition: collapsible sections with zero children, submit buttons during validation, textareas that can be readonly, action buttons that depend on selection state. If the condition maps to "this element should not be interactive," `disabled` is the answer.


### PR DESCRIPTION
Fixes interactive elements that look clickable when they can't do anything. Section headers in the tab manager had `cursor-pointer` and hover effects even when they contained zero items. A textarea in whispering's TextPreviewDialog had `hover:cursor-pointer` that overrode the browser's disabled cursor.

The root cause is using JS guards (`if (count === 0) return`) inside onclick handlers instead of the HTML `disabled` attribute. The JS guard prevents the action but leaves cursor, hover, and focus styles active—the element lies to the user.

The fix uses `disabled` paired with Tailwind's `enabled:` and `group-disabled:` variants:

```svelte
<button
  class="group enabled:cursor-pointer enabled:hover:opacity-80"
  disabled={item.count === 0}
  onclick={toggle}
>
  {item.label} ({item.count})
  <ChevronRight class="group-disabled:invisible" />
</button>
```

`disabled` blocks the click natively, `enabled:` gates hover/cursor styles behind `:enabled`, and `group-disabled:` hides child elements (like expand chevrons) when the parent is disabled. No JS guard needed.

A full monorepo sweep (6 parallel agents with different grep strategies) found most flagged locations were false alarms—empty folders that are expandable by design, sections with intentional empty states, etc. Two real fixes survived triage.

This also adds the pattern to the `styling` skill as a guideline, and documents it in `docs/articles/disabled-attribute-over-js-guards.md` for reference.

## Changelog
- Fix section headers in tab manager being expandable when they have zero items
- Fix hover cursor overriding disabled state on whispering's text preview textarea