### PR TITLE
refactor(cli): replace hand-rolled ok/error Result type with wellcrafted defineErrors

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -445,7 +445,7 @@ app.post(
 		const { id } = c.req.valid('param');
 		const ok = await stub.applySnapshot(Number(id));
 		if (!ok) return c.json({ error: 'Snapshot not found' }, 404);
-		return c.json({ ok: true });
+		return c.body(null, 204);
 	},
 );
 

--- a/packages/cli/src/commands/data-command.ts
+++ b/packages/cli/src/commands/data-command.ts
@@ -153,8 +153,8 @@ function buildKvSubcommand(serverUrl: string) {
 								stdinContent,
 							});
 
-							if (!result.ok) {
-								outputError(result.error);
+							if (result.error) {
+								outputError(result.error.message);
 								process.exitCode = 1;
 								return;
 							}
@@ -258,8 +258,8 @@ function buildActionSubcommand(serverUrl: string) {
 							hasStdin: stdinContent !== undefined,
 							stdinContent,
 						});
-						if (!result.ok) {
-							outputError(result.error);
+						if (result.error) {
+							outputError(result.error.message);
 							process.exitCode = 1;
 							return;
 						}
@@ -384,8 +384,8 @@ function buildTableSubcommand(serverUrl: string) {
 							stdinContent,
 						});
 
-						if (!result.ok) {
-							outputError(result.error);
+						if (result.error) {
+							outputError(result.error.message);
 							process.exitCode = 1;
 							return;
 						}

--- a/packages/cli/src/parse-input.test.ts
+++ b/packages/cli/src/parse-input.test.ts
@@ -33,10 +33,8 @@ describe('parseJsonInput', () => {
 
 		const result = parseJsonInput<{ id: string; name: string }>(options);
 
-		expect(result.ok).toBe(true);
-		if (result.ok) {
-			expect(result.data).toEqual({ id: '1', name: 'test' });
-		}
+		expect(result.error).toBeNull();
+		expect(result.data).toEqual({ id: '1', name: 'test' });
 	});
 
 	it('reads @file shorthand', () => {
@@ -49,10 +47,8 @@ describe('parseJsonInput', () => {
 
 		const result = parseJsonInput<{ id: string; value: number }>(options);
 
-		expect(result.ok).toBe(true);
-		if (result.ok) {
-			expect(result.data).toEqual({ id: '2', value: 42 });
-		}
+		expect(result.error).toBeNull();
+		expect(result.data).toEqual({ id: '2', value: 42 });
 	});
 
 	it('reads --file flag', () => {
@@ -65,10 +61,8 @@ describe('parseJsonInput', () => {
 
 		const result = parseJsonInput<{ source: string }>(options);
 
-		expect(result.ok).toBe(true);
-		if (result.ok) {
-			expect(result.data).toEqual({ source: 'file-flag' });
-		}
+		expect(result.error).toBeNull();
+		expect(result.data).toEqual({ source: 'file-flag' });
 	});
 
 	it('reads stdin content', () => {
@@ -79,10 +73,8 @@ describe('parseJsonInput', () => {
 
 		const result = parseJsonInput<{ from: string }>(options);
 
-		expect(result.ok).toBe(true);
-		if (result.ok) {
-			expect(result.data).toEqual({ from: 'stdin' });
-		}
+		expect(result.error).toBeNull();
+		expect(result.data).toEqual({ from: 'stdin' });
 	});
 
 	it('returns error for invalid JSON', () => {
@@ -92,10 +84,8 @@ describe('parseJsonInput', () => {
 
 		const result = parseJsonInput(options);
 
-		expect(result.ok).toBe(false);
-		if (!result.ok) {
-			expect(result.error).toContain('Invalid JSON');
-		}
+		expect(result.error).toBeDefined();
+		expect(result.error?.message).toContain('Invalid JSON');
 	});
 
 	it('returns error for missing file', () => {
@@ -105,10 +95,8 @@ describe('parseJsonInput', () => {
 
 		const result = parseJsonInput(options);
 
-		expect(result.ok).toBe(false);
-		if (!result.ok) {
-			expect(result.error).toContain('File not found');
-		}
+		expect(result.error).toBeDefined();
+		expect(result.error?.message).toContain('File not found');
 	});
 
 	it('returns error when no input provided', () => {
@@ -116,10 +104,8 @@ describe('parseJsonInput', () => {
 
 		const result = parseJsonInput(options);
 
-		expect(result.ok).toBe(false);
-		if (!result.ok) {
-			expect(result.error).toContain('No input provided');
-		}
+		expect(result.error).toBeDefined();
+		expect(result.error?.message).toContain('No input provided');
 	});
 
 	it('prioritizes positional over --file', () => {
@@ -133,10 +119,8 @@ describe('parseJsonInput', () => {
 
 		const result = parseJsonInput<{ source: string }>(options);
 
-		expect(result.ok).toBe(true);
-		if (result.ok) {
-			expect(result.data.source).toBe('positional');
-		}
+		expect(result.error).toBeNull();
+		expect(result.data!.source).toBe('positional');
 	});
 
 	it('prioritizes --file over stdin', () => {
@@ -151,9 +135,7 @@ describe('parseJsonInput', () => {
 
 		const result = parseJsonInput<{ source: string }>(options);
 
-		expect(result.ok).toBe(true);
-		if (result.ok) {
-			expect(result.data.source).toBe('file');
-		}
+		expect(result.error).toBeNull();
+		expect(result.data!.source).toBe('file');
 	});
 });

--- a/packages/cli/src/parse-input.ts
+++ b/packages/cli/src/parse-input.ts
@@ -4,7 +4,7 @@ import {
 	extractErrorMessage,
 	type InferErrors,
 } from 'wellcrafted/error';
-import { Err, trySync, type Result } from 'wellcrafted/result';
+import { Err, type Result, trySync } from 'wellcrafted/result';
 
 export type ParseInputOptions = {
 	/** Positional argument (inline JSON or @file) */

--- a/packages/cli/src/parse-input.ts
+++ b/packages/cli/src/parse-input.ts
@@ -1,4 +1,10 @@
 import { readFileSync, readSync } from 'node:fs';
+import {
+	defineErrors,
+	extractErrorMessage,
+	type InferErrors,
+} from 'wellcrafted/error';
+import { Err, trySync, type Result } from 'wellcrafted/result';
 
 export type ParseInputOptions = {
 	/** Positional argument (inline JSON or @file) */
@@ -11,35 +17,51 @@ export type ParseInputOptions = {
 	stdinContent?: string;
 };
 
-export type ParseInputResult<T> =
-	| { ok: true; data: T }
-	| { ok: false; error: string };
+const ParseInputError = defineErrors({
+	InvalidJson: ({ cause }: { cause: unknown }) => ({
+		message: `Invalid JSON: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	FileNotFound: ({ path }: { path: string }) => ({
+		message: `File not found: ${path}`,
+		path,
+	}),
+	FileReadFailed: ({ path, cause }: { path: string; cause: unknown }) => ({
+		message: `Error reading file '${path}': ${extractErrorMessage(cause)}`,
+		path,
+		cause,
+	}),
+	NoInputProvided: () => ({
+		message:
+			'No input provided. Use inline JSON, --file, @file, or pipe via stdin.',
+	}),
+});
+type ParseInputError = InferErrors<typeof ParseInputError>;
 
-function parseJson<T>(input: string): ParseInputResult<T> {
-	try {
-		const data = JSON.parse(input) as T;
-		return { ok: true, data };
-	} catch (e) {
-		return {
-			ok: false,
-			error: `Invalid JSON: ${e instanceof Error ? e.message : String(e)}`,
-		};
-	}
+function parseJson<T>(input: string): Result<T, ParseInputError> {
+	return trySync({
+		try: () => JSON.parse(input) as T,
+		catch: (error) => ParseInputError.InvalidJson({ cause: error }),
+	});
 }
 
-function readJsonFile<T>(filePath: string): ParseInputResult<T> {
-	try {
-		const content = readFileSync(filePath, 'utf-8');
-		return parseJson<T>(content);
-	} catch (e) {
-		if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
-			return { ok: false, error: `File not found: ${filePath}` };
-		}
-		return {
-			ok: false,
-			error: `Error reading file: ${e instanceof Error ? e.message : String(e)}`,
-		};
-	}
+function readJsonFile<T>(filePath: string): Result<T, ParseInputError> {
+	const { data: content, error: readError } = trySync({
+		try: () => readFileSync(filePath, 'utf-8'),
+		catch: (error) => {
+			if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+				return ParseInputError.FileNotFound({ path: filePath });
+			}
+			return ParseInputError.FileReadFailed({
+				path: filePath,
+				cause: error,
+			});
+		},
+	});
+
+	if (readError) return Err(readError);
+
+	return parseJson<T>(content);
 }
 
 /**
@@ -48,7 +70,7 @@ function readJsonFile<T>(filePath: string): ParseInputResult<T> {
  */
 export function parseJsonInput<T = unknown>(
 	options: ParseInputOptions,
-): ParseInputResult<T> {
+): Result<T, ParseInputError> {
 	// 1. Check positional (could be inline JSON or @file)
 	if (options.positional) {
 		if (options.positional.startsWith('@')) {
@@ -68,11 +90,7 @@ export function parseJsonInput<T = unknown>(
 		return parseJson<T>(options.stdinContent);
 	}
 
-	return {
-		ok: false,
-		error:
-			'No input provided. Use inline JSON, --file, @file, or pipe via stdin.',
-	};
+	return ParseInputError.NoInputProvided();
 }
 
 /**


### PR DESCRIPTION
The CLI's `parse-input.ts` was the last module in the codebase still using a hand-rolled `{ ok: true; data: T } | { ok: false; error: string }` discriminated union instead of wellcrafted's `Result<T, E>`. Every other service and package already uses `defineErrors` + `trySync`/`tryAsync`—this was a holdout from before the migration.

```
┌─────────────────────────────────────────────────────────────────┐
│  BEFORE                                                         │
│                                                                 │
│  type ParseInputResult<T> =                                     │
│    | { ok: true; data: T }                                      │
│    | { ok: false; error: string }  ← untyped string errors      │
│                                                                 │
│  try { ... } catch (e) {                                        │
│    return { ok: false, error: `Invalid JSON: ${String(e)}` }    │
│  }                                                              │
│                                                                 │
│  if (!result.ok) { outputError(result.error) }                  │
└─────────────────────────────────────────────────────────────────┘
                              │
                              ▼
┌─────────────────────────────────────────────────────────────────┐
│  AFTER                                                          │
│                                                                 │
│  const ParseInputError = defineErrors({                         │
│    InvalidJson:     ({ cause }) => ({ ... }),                    │
│    FileNotFound:    ({ path })  => ({ ... }),                    │
│    FileReadFailed:  ({ path, cause }) => ({ ... }),              │
│    NoInputProvided: ()         => ({ ... }),                     │
│  });                                                            │
│                                                                 │
│  return trySync({                                               │
│    try: () => JSON.parse(input),                                │
│    catch: (error) => ParseInputError.InvalidJson({ cause }),    │
│  });                                                            │
│                                                                 │
│  if (result.error) { outputError(result.error.message) }        │
└─────────────────────────────────────────────────────────────────┘
```

The hand-rolled type had two problems: errors were untyped strings with no structured context (so consumers couldn't distinguish "file not found" from "invalid JSON" without string matching), and it sat next to `bin.ts` which already imports from `wellcrafted/result`—meaning the dependency was right there, just unused in this module.

### What changed

- **`parse-input.ts`**: Removed `ParseInputResult<T>`, defined `ParseInputError` with 4 named variants via `defineErrors`, replaced raw `try-catch` with `trySync`
- **`data-command.ts`**: Updated 3 consumer sites from `!result.ok` / `result.error` (string) → `result.error` / `result.error.message`
- **`parse-input.test.ts`**: Updated assertions to use wellcrafted Result shape (`null` for absent side, `.message` for error text)
- **`app.ts`** (API): Changed snapshot-apply endpoint from `c.json({ ok: true })` to `c.body(null, 204)`—standard HTTP "success, no content" and [the canonical Hono pattern](https://github.com/honojs/hono/blob/main/src/types.test.ts#L2534)

### Straggler audit

Ran a full-repo search for related code smells after this change. Results:

| Pattern | Occurrences | Status |
|---|---|---|
| `{ ok: true/false }` in `.ts` files | **0** | Clean |
| `createTaggedError` (old API) | **0** | Clean |
| `.withContext()` / `.withCause()` / `.withMessage()` (old chains) | **0** | Clean |
| `ReturnType<typeof ...Error>` (should be `InferErrors`) | **0** | Clean |
| `ParseInputResult` references (stale type) | **0** | Clean |
| `ok: true/false` in `.md` files | 15 hits | All in specs/articles (historical planning docs)—not actionable |
| `String(err)` in CLI catch blocks | 12 hits | These are in HTTP client error handlers (`data-command.ts`), not Result-type error handling. They catch network/HTTP errors and format them for CLI output. Separate concern from this PR. |

The codebase is now fully consistent on wellcrafted `Result` + `defineErrors` for typed error handling.