### PR TITLE
refactor(tab-manager): harden tab-actions and establish branded ID factory convention

### DIFF
--- a/.agents/skills/typescript/SKILL.md
+++ b/.agents/skills/typescript/SKILL.md
@@ -682,10 +682,8 @@ import { generateId, type Id } from '@epicenter/workspace';
 // 1. TYPE — extends Id so generateId() can single-cast
 export type SavedTabId = Id & Brand<'SavedTabId'>;
 
-// 2. VALIDATOR — arktype pipe for schema composition in defineTable()
-export const SavedTabId = type('string').pipe(
-	(s): SavedTabId => s as SavedTabId,
-);
+// 2. VALIDATOR — type-only cast via .as<T>() (zero runtime overhead)
+export const SavedTabId = type('string').as<SavedTabId>();
 
 // 3. FACTORY — generate* prefix, single-cast thanks to Id base
 export const generateSavedTabId = (): SavedTabId =>

--- a/.agents/skills/typescript/SKILL.md
+++ b/.agents/skills/typescript/SKILL.md
@@ -670,20 +670,47 @@ This makes type boundaries visible and intentional, without forcing awkward para
 
 Every `defineTable()` schema MUST use branded ID types for the `id` field and all string foreign keys. Never use plain `'string'` for table IDs.
 
-For tables that use arktype schemas, define the brand as a type + arktype pipe pair:
+For tables that use arktype schemas, follow the **three-part pattern**:
 
 ```typescript
-export type ConversationId = string & Brand<'ConversationId'>;
-export const ConversationId = type('string').pipe(
-	(s): ConversationId => s as ConversationId,
+import type { Brand } from 'wellcrafted/brand';
+import { type } from 'arktype';
+import { generateId } from '@epicenter/workspace';
+
+// 1. TYPE — the branded type itself
+export type SavedTabId = string & Brand<'SavedTabId'>;
+
+// 2. VALIDATOR — arktype pipe for schema composition in defineTable()
+export const SavedTabId = type('string').pipe(
+	(s): SavedTabId => s as SavedTabId,
 );
+
+// 3. FACTORY — create* prefix, encapsulates the double-cast
+export const createSavedTabId = (): SavedTabId =>
+	generateId() as string as SavedTabId;
 ```
 
-Then use directly in the schema: `id: ConversationId` and for optional FKs: `'parentId?': ConversationId.or('undefined')`.
+Then use directly in the schema: `id: SavedTabId` and for optional FKs: `'parentId?': SavedTabId.or('undefined')`.
 
-When generating IDs with `generateId()` (which returns `Id`, a different brand), cast through string: `generateId() as string as ConversationId`.
+**At call sites, use the factory—never the double-cast directly:**
 
-See the `static-workspace-api` skill for the full pattern and rules.
+```typescript
+// Good: factory encapsulates the cast
+const id = createSavedTabId();
+
+// Bad: double-cast scattered across files
+const id = generateId() as string as SavedTabId;
+```
+
+| Part | Naming | Required When |
+|------|--------|--------------|
+| Type | PascalCase (`SavedTabId`) | Always |
+| Validator | Same PascalCase (`SavedTabId`) | Used in `defineTable()` schemas |
+| Factory | `create` + PascalCase (`createSavedTabId`) | IDs generated at runtime |
+
+Not every branded type needs all three. Path types like `AbsolutePath` need only the type. Composite IDs like `TabCompositeId` already have `createTabCompositeId()` factories.
+
+See `packages/filesystem/src/ids.ts` for the reference implementation (`generateRowId`, `generateColumnId`, `generateFileId`). See `specs/20260312T180000-branded-id-convention.md` for the full inventory and migration plan.
 
 # Extract Coupled `let` State Into Sub-Factories
 

--- a/.agents/skills/typescript/SKILL.md
+++ b/.agents/skills/typescript/SKILL.md
@@ -670,51 +670,38 @@ This makes type boundaries visible and intentional, without forcing awkward para
 
 Every `defineTable()` schema MUST use branded ID types for the `id` field and all string foreign keys. Never use plain `'string'` for table IDs.
 
-#### The Three-Part Pattern
-
-Every branded ID type that is generated at runtime MUST follow the three-part pattern:
+For tables that use arktype schemas, follow the three-part pattern:
 
 ```typescript
-import { type Brand } from 'wellcrafted/brand';
-import { type } from 'arktype';
-import { generateId, type Id } from '@epicenter/workspace';
-
-// 1. TYPE — extends Id so generateId() can single-cast
+// 1. TYPE — extends Id, not string (enables single-cast in generator)
 export type SavedTabId = Id & Brand<'SavedTabId'>;
 
-// 2. VALIDATOR — type-only cast via .as<T>() (zero runtime overhead)
+// 2. VALIDATOR — zero-cost type assertion for schema composition
 export const SavedTabId = type('string').as<SavedTabId>();
 
-// 3. FACTORY — generate* prefix, single-cast thanks to Id base
+// 3. GENERATOR — wraps generateId() so the cast lives in one place
 export const generateSavedTabId = (): SavedTabId =>
 	generateId() as SavedTabId;
 ```
 
-| Part | Naming | Required When |
-|------|--------|--------------|
-| Type | PascalCase (`SavedTabId`) | Always — this IS the branded type |
-| Validator | Same PascalCase (TS allows type+value same name) | Used in `defineTable()` or other arktype schemas |
-| Factory | `generate` + PascalCase (`generateSavedTabId`) | IDs are generated at runtime (via `generateId()`) |
+Use directly in the schema: `id: SavedTabId` and for optional FKs: `'parentId?': SavedTabId.or('undefined')`.
 
-Not every branded type needs all three. Path types like `AbsolutePath` are cast from external sources — they need only the type. `DeviceId` is set from `chrome.storage.local`, not generated.
-
-#### Why `Id & Brand<…>` Instead of `string & Brand<…>`
-
-`generateId()` returns `Id` (which is `string & Brand<'Id'>`). If you define `SavedTabId = string & Brand<'SavedTabId'>`, the brands are incompatible—TypeScript requires a double-cast: `generateId() as string as SavedTabId`. By extending `Id` instead of `string`, `SavedTabId` becomes a subtype of `Id`, allowing a single cast: `generateId() as SavedTabId`.
+At call sites, use the generator—never the double-cast:
 
 ```typescript
-// BAD: string & Brand means double-cast needed
-type SavedTabId = string & Brand<'SavedTabId'>;
-const id = generateId() as string as SavedTabId;
+// Good
+const id = generateSavedTabId();
 
-// GOOD: Id & Brand means single-cast
-type SavedTabId = Id & Brand<'SavedTabId'>;
-const id = generateId() as SavedTabId;
+// Bad — scattered casts
+const id = generateId() as string as SavedTabId;
 ```
 
-Then use directly in the schema: `id: ConversationId` and for optional FKs: `'parentId?': ConversationId.or('undefined')`.
+The `generate*` prefix means "new ID from scratch." The `create*` prefix means "assemble from inputs" (e.g., `createTabCompositeId(deviceId, tabId)`).
+
+Not every branded type needs all three parts. `DeviceId` is set from an external source (no generator). Path types like `AbsolutePath` need only the type.
 
 See the `workspace-api` skill for the full workspace file structure and rules.
+
 # Extract Coupled `let` State Into Sub-Factories
 
 When a factory function accumulates `let` statements that are always read, written, and reset together, extract them into a sub-factory. The tell: two or three `let` declarations that move as a pack across multiple inner functions.

--- a/.agents/skills/typescript/SKILL.md
+++ b/.agents/skills/typescript/SKILL.md
@@ -670,10 +670,12 @@ This makes type boundaries visible and intentional, without forcing awkward para
 
 Every `defineTable()` schema MUST use branded ID types for the `id` field and all string foreign keys. Never use plain `'string'` for table IDs.
 
-For tables that use arktype schemas, follow the **three-part pattern**:
+#### The Three-Part Pattern
+
+Every branded ID type that is generated at runtime MUST follow the three-part pattern:
 
 ```typescript
-import type { Brand } from 'wellcrafted/brand';
+import { type Brand } from 'wellcrafted/brand';
 import { type } from 'arktype';
 import { generateId } from '@epicenter/workspace';
 
@@ -685,33 +687,28 @@ export const SavedTabId = type('string').pipe(
 	(s): SavedTabId => s as SavedTabId,
 );
 
-// 3. FACTORY — create* prefix, encapsulates the double-cast
+// 3. FACTORY — create* prefix, encapsulates the cast
 export const createSavedTabId = (): SavedTabId =>
 	generateId() as string as SavedTabId;
 ```
 
-Then use directly in the schema: `id: SavedTabId` and for optional FKs: `'parentId?': SavedTabId.or('undefined')`.
+| Part | Naming | Required When |
+|------|--------|--------------|
+| Type | PascalCase (`SavedTabId`) | Always — this IS the branded type |
+| Validator | Same PascalCase (TS allows type+value same name) | Used in `defineTable()` or other arktype schemas |
+| Factory | `create` + PascalCase (`createSavedTabId`) | IDs are generated at runtime (via `generateId()`) |
 
-**At call sites, use the factory—never the double-cast directly:**
+At call sites, **always use the factory**:
 
 ```typescript
-// Good: factory encapsulates the cast
+// Good — factory encapsulates the cast
 const id = createSavedTabId();
 
-// Bad: double-cast scattered across files
+// Bad — double-cast scattered across call sites
 const id = generateId() as string as SavedTabId;
 ```
 
-| Part | Naming | Required When |
-|------|--------|--------------|
-| Type | PascalCase (`SavedTabId`) | Always |
-| Validator | Same PascalCase (`SavedTabId`) | Used in `defineTable()` schemas |
-| Factory | `create` + PascalCase (`createSavedTabId`) | IDs generated at runtime |
-
-Not every branded type needs all three. Path types like `AbsolutePath` need only the type. Composite IDs like `TabCompositeId` already have `createTabCompositeId()` factories.
-
-See `packages/filesystem/src/ids.ts` for the reference implementation (`generateRowId`, `generateColumnId`, `generateFileId`). See `specs/20260312T180000-branded-id-convention.md` for the full inventory and migration plan.
-
+See the `workspace-api` skill for the full pattern with `defineTable()` usage, and `specs/20260312T180000-branded-id-convention.md` for the complete inventory.
 # Extract Coupled `let` State Into Sub-Factories
 
 When a factory function accumulates `let` statements that are always read, written, and reset together, extract them into a sub-factory. The tell: two or three `let` declarations that move as a pack across multiple inner functions.

--- a/.agents/skills/typescript/SKILL.md
+++ b/.agents/skills/typescript/SKILL.md
@@ -677,19 +677,19 @@ Every branded ID type that is generated at runtime MUST follow the three-part pa
 ```typescript
 import { type Brand } from 'wellcrafted/brand';
 import { type } from 'arktype';
-import { generateId } from '@epicenter/workspace';
+import { generateId, type Id } from '@epicenter/workspace';
 
-// 1. TYPE — the branded type itself
-export type SavedTabId = string & Brand<'SavedTabId'>;
+// 1. TYPE — extends Id so generateId() can single-cast
+export type SavedTabId = Id & Brand<'SavedTabId'>;
 
 // 2. VALIDATOR — arktype pipe for schema composition in defineTable()
 export const SavedTabId = type('string').pipe(
 	(s): SavedTabId => s as SavedTabId,
 );
 
-// 3. FACTORY — generate* prefix, encapsulates the cast
+// 3. FACTORY — generate* prefix, single-cast thanks to Id base
 export const generateSavedTabId = (): SavedTabId =>
-	generateId() as string as SavedTabId;
+	generateId() as SavedTabId;
 ```
 
 | Part | Naming | Required When |
@@ -697,21 +697,21 @@ export const generateSavedTabId = (): SavedTabId =>
 | Type | PascalCase (`SavedTabId`) | Always — this IS the branded type |
 | Validator | Same PascalCase (TS allows type+value same name) | Used in `defineTable()` or other arktype schemas |
 | Factory | `generate` + PascalCase (`generateSavedTabId`) | IDs are generated at runtime (via `generateId()`) |
-,
+
 Not every branded type needs all three. Path types like `AbsolutePath` are cast from external sources — they need only the type. `DeviceId` is set from `chrome.storage.local`, not generated.
 
-#### Bad Pattern (Scattered Double-Casts)
+#### Why `Id & Brand<…>` Instead of `string & Brand<…>`
+
+`generateId()` returns `Id` (which is `string & Brand<'Id'>`). If you define `SavedTabId = string & Brand<'SavedTabId'>`, the brands are incompatible—TypeScript requires a double-cast: `generateId() as string as SavedTabId`. By extending `Id` instead of `string`, `SavedTabId` becomes a subtype of `Id`, allowing a single cast: `generateId() as SavedTabId`.
 
 ```typescript
-// BAD: Double-cast scattered across call sites
+// BAD: string & Brand means double-cast needed
+type SavedTabId = string & Brand<'SavedTabId'>;
 const id = generateId() as string as SavedTabId;
-```
 
-#### Good Pattern (Factory Function)
-
-```typescript
-// GOOD: Factory encapsulates the cast — single source of truth
-const id = generateSavedTabId();
+// GOOD: Id & Brand means single-cast
+type SavedTabId = Id & Brand<'SavedTabId'>;
+const id = generateId() as SavedTabId;
 ```
 
 Then use directly in the schema: `id: ConversationId` and for optional FKs: `'parentId?': ConversationId.or('undefined')`.

--- a/.agents/skills/typescript/SKILL.md
+++ b/.agents/skills/typescript/SKILL.md
@@ -687,8 +687,8 @@ export const SavedTabId = type('string').pipe(
 	(s): SavedTabId => s as SavedTabId,
 );
 
-// 3. FACTORY — create* prefix, encapsulates the cast
-export const createSavedTabId = (): SavedTabId =>
+// 3. FACTORY — generate* prefix, encapsulates the cast
+export const generateSavedTabId = (): SavedTabId =>
 	generateId() as string as SavedTabId;
 ```
 
@@ -696,19 +696,27 @@ export const createSavedTabId = (): SavedTabId =>
 |------|--------|--------------|
 | Type | PascalCase (`SavedTabId`) | Always — this IS the branded type |
 | Validator | Same PascalCase (TS allows type+value same name) | Used in `defineTable()` or other arktype schemas |
-| Factory | `create` + PascalCase (`createSavedTabId`) | IDs are generated at runtime (via `generateId()`) |
+| Factory | `generate` + PascalCase (`generateSavedTabId`) | IDs are generated at runtime (via `generateId()`) |
+,
+Not every branded type needs all three. Path types like `AbsolutePath` are cast from external sources — they need only the type. `DeviceId` is set from `chrome.storage.local`, not generated.
 
-At call sites, **always use the factory**:
+#### Bad Pattern (Scattered Double-Casts)
 
 ```typescript
-// Good — factory encapsulates the cast
-const id = createSavedTabId();
-
-// Bad — double-cast scattered across call sites
+// BAD: Double-cast scattered across call sites
 const id = generateId() as string as SavedTabId;
 ```
 
-See the `workspace-api` skill for the full pattern with `defineTable()` usage, and `specs/20260312T180000-branded-id-convention.md` for the complete inventory.
+#### Good Pattern (Factory Function)
+
+```typescript
+// GOOD: Factory encapsulates the cast — single source of truth
+const id = generateSavedTabId();
+```
+
+Then use directly in the schema: `id: ConversationId` and for optional FKs: `'parentId?': ConversationId.or('undefined')`.
+
+See the `workspace-api` skill for the full workspace file structure and rules.
 # Extract Coupled `let` State Into Sub-Factories
 
 When a factory function accumulates `let` statements that are always read, written, and reset together, extract them into a sub-factory. The tell: two or three `let` declarations that move as a pack across multiple inner functions.

--- a/.agents/skills/workspace-api/SKILL.md
+++ b/.agents/skills/workspace-api/SKILL.md
@@ -94,21 +94,28 @@ const theme = defineKv()
 
 Every table's `id` field and every string foreign key field MUST use a branded type instead of plain `'string'`. This prevents accidental mixing of IDs from different tables at compile time.
 
-### Pattern
+### Three-Part Pattern
 
-Define a branded type + arktype pipe pair in the same file as the workspace definition:
+Define a branded type + arktype validator + factory in the same file as the workspace definition:
 
 ```typescript
 import type { Brand } from 'wellcrafted/brand';
 import { type } from 'arktype';
+import { generateId } from '@epicenter/workspace';
 
-// 1. Branded type + arktype pipe (co-located with workspace definition)
+// 1. TYPE — the branded type
 export type ConversationId = string & Brand<'ConversationId'>;
+
+// 2. VALIDATOR — arktype pipe for schema composition
 export const ConversationId = type('string').pipe(
 	(s): ConversationId => s as ConversationId,
 );
 
-// 2. Wrap in defineTable + co-locate type export
+// 3. FACTORY — create* prefix, encapsulates the double-cast
+export const createConversationId = (): ConversationId =>
+	generateId() as string as ConversationId;
+
+// Use in defineTable schema:
 const conversationsTable = defineTable(
 	type({
 		id: ConversationId,              // Primary key — branded
@@ -129,7 +136,7 @@ const chatMessagesTable = defineTable(
 );
 export type ChatMessage = InferTableRow<typeof chatMessagesTable>;
 
-// 3. Compose in createWorkspace
+// Compose in createWorkspace
 export const workspaceClient = createWorkspace(
 	defineWorkspace({
 		tables: {
@@ -146,7 +153,7 @@ export const workspaceClient = createWorkspace(
 2. **Foreign keys use the referenced table's ID type**: `chatMessages.conversationId` uses `ConversationId`, not `'string'`
 3. **Optional FKs use `.or('undefined')`**: `'parentId?': ConversationId.or('undefined')`
 4. **Composite IDs are also branded**: `TabCompositeId`, `WindowCompositeId`, `GroupCompositeId`
-5. **Brand at generation site**: When creating IDs with `generateId()`, cast through string: `generateId() as string as ConversationId`
+5. **Use `create*` factories at generation sites**: `createConversationId()` not `generateId() as string as ConversationId`
 6. **Functions accept branded types**: `function switchConversation(id: ConversationId)` not `(id: string)`
 
 ### Why Not Plain `'string'`
@@ -164,6 +171,8 @@ deleteConversation(message.id);  // Error: ChatMessageId is not ConversationId
 ### Reference Implementation
 
 See `apps/tab-manager/src/lib/workspace.ts` for the canonical example with 7 branded ID types.
+See `packages/filesystem/src/ids.ts` for the reference factory pattern (`generateRowId`, `generateColumnId`, `generateFileId`).
+See `specs/20260312T180000-branded-id-convention.md` for the full inventory and migration plan.
 
 ## Workspace File Structure
 

--- a/.agents/skills/workspace-api/SKILL.md
+++ b/.agents/skills/workspace-api/SKILL.md
@@ -96,18 +96,18 @@ Every table's `id` field and every string foreign key field MUST use a branded t
 
 ### Pattern
 
-Define a branded type + arktype validator + factory in the same file as the workspace definition:
+Define a branded type + arktype validator + generator in the same file as the workspace definition:
 
 ```typescript
 import type { Brand } from 'wellcrafted/brand';
 import { type } from 'arktype';
 import { generateId, type Id } from '@epicenter/workspace';
 
-// 1. Branded type — extends Id for single-cast generation
+// 1. Branded type + arktype validator (co-located with workspace definition)
 export type ConversationId = Id & Brand<'ConversationId'>;
 export const ConversationId = type('string').as<ConversationId>();
 
-// 2. Factory function — single-cast thanks to Id base type
+// 2. Generator function — the ONLY place with the cast
 export const generateConversationId = (): ConversationId =>
 	generateId() as ConversationId;
 
@@ -122,9 +122,9 @@ const conversationsTable = defineTable(
 );
 export type Conversation = InferTableRow<typeof conversationsTable>;
 
-// 4. At call sites — use the factory, never cast manually
+// 4. At call sites — use the generator, never cast directly
 const newId = generateConversationId();  // Good
-// const newId = generateId() as ConversationId;  // Bad — use factory
+// const newId = generateId() as string as ConversationId;  // Bad
 ```
 
 ### Rules
@@ -133,7 +133,7 @@ const newId = generateConversationId();  // Good
 2. **Foreign keys use the referenced table's ID type**: `chatMessages.conversationId` uses `ConversationId`, not `'string'`
 3. **Optional FKs use `.or('undefined')`**: `'parentId?': ConversationId.or('undefined')`
 4. **Composite IDs are also branded**: `TabCompositeId`, `WindowCompositeId`, `GroupCompositeId`
-5. **Use factory functions**: When IDs are generated at runtime, use a `generate*` factory: `generateConversationId()`. Never cast manually at call sites.
+5. **Use generator functions**: When IDs are generated at runtime, use a `generate*` factory: `generateConversationId()`. Never scatter double-casts across call sites.
 6. **Functions accept branded types**: `function switchConversation(id: ConversationId)` not `(id: string)`
 
 ### Why Not Plain `'string'`
@@ -150,7 +150,7 @@ deleteConversation(message.id);  // Error: ChatMessageId is not ConversationId
 
 ### Reference Implementation
 
-See `apps/tab-manager/src/lib/workspace.ts` for the canonical example with 7 branded ID types and 4 factory functions.
+See `apps/tab-manager/src/lib/workspace.ts` for the canonical example with 7 branded ID types and 4 generator functions.
 See `packages/filesystem/src/ids.ts` for the reference factory pattern (`generateRowId`, `generateColumnId`, `generateFileId`).
 See `specs/20260312T180000-branded-id-convention.md` for the full inventory and migration plan.
 

--- a/.agents/skills/workspace-api/SKILL.md
+++ b/.agents/skills/workspace-api/SKILL.md
@@ -105,9 +105,7 @@ import { generateId, type Id } from '@epicenter/workspace';
 
 // 1. Branded type — extends Id for single-cast generation
 export type ConversationId = Id & Brand<'ConversationId'>;
-export const ConversationId = type('string').pipe(
-	(s): ConversationId => s as ConversationId,
-);
+export const ConversationId = type('string').as<ConversationId>();
 
 // 2. Factory function — single-cast thanks to Id base type
 export const generateConversationId = (): ConversationId =>

--- a/.agents/skills/workspace-api/SKILL.md
+++ b/.agents/skills/workspace-api/SKILL.md
@@ -101,17 +101,17 @@ Define a branded type + arktype validator + factory in the same file as the work
 ```typescript
 import type { Brand } from 'wellcrafted/brand';
 import { type } from 'arktype';
-import { generateId } from '@epicenter/workspace';
+import { generateId, type Id } from '@epicenter/workspace';
 
-// 1. Branded type + arktype validator (co-located with workspace definition)
-export type ConversationId = string & Brand<'ConversationId'>;
+// 1. Branded type — extends Id for single-cast generation
+export type ConversationId = Id & Brand<'ConversationId'>;
 export const ConversationId = type('string').pipe(
 	(s): ConversationId => s as ConversationId,
 );
 
-// 2. Factory function — the ONLY place with the double-cast
+// 2. Factory function — single-cast thanks to Id base type
 export const generateConversationId = (): ConversationId =>
-	generateId() as string as ConversationId;
+	generateId() as ConversationId;
 
 // 3. Use in defineTable + co-locate type export
 const conversationsTable = defineTable(
@@ -124,9 +124,9 @@ const conversationsTable = defineTable(
 );
 export type Conversation = InferTableRow<typeof conversationsTable>;
 
-// 4. At call sites — use the factory, never double-cast
+// 4. At call sites — use the factory, never cast manually
 const newId = generateConversationId();  // Good
-// const newId = generateId() as string as ConversationId;  // Bad — don't do this
+// const newId = generateId() as ConversationId;  // Bad — use factory
 ```
 
 ### Rules
@@ -135,7 +135,7 @@ const newId = generateConversationId();  // Good
 2. **Foreign keys use the referenced table's ID type**: `chatMessages.conversationId` uses `ConversationId`, not `'string'`
 3. **Optional FKs use `.or('undefined')`**: `'parentId?': ConversationId.or('undefined')`
 4. **Composite IDs are also branded**: `TabCompositeId`, `WindowCompositeId`, `GroupCompositeId`
-5. **Use factory functions**: When IDs are generated at runtime, use a `generate*` factory: `generateConversationId()`. Never scatter double-casts (`generateId() as string as ConversationId`) across call sites.
+5. **Use factory functions**: When IDs are generated at runtime, use a `generate*` factory: `generateConversationId()`. Never cast manually at call sites.
 6. **Functions accept branded types**: `function switchConversation(id: ConversationId)` not `(id: string)`
 
 ### Why Not Plain `'string'`

--- a/.agents/skills/workspace-api/SKILL.md
+++ b/.agents/skills/workspace-api/SKILL.md
@@ -110,7 +110,7 @@ export const ConversationId = type('string').pipe(
 );
 
 // 2. Factory function — the ONLY place with the double-cast
-export const createConversationId = (): ConversationId =>
+export const generateConversationId = (): ConversationId =>
 	generateId() as string as ConversationId;
 
 // 3. Use in defineTable + co-locate type export
@@ -125,7 +125,7 @@ const conversationsTable = defineTable(
 export type Conversation = InferTableRow<typeof conversationsTable>;
 
 // 4. At call sites — use the factory, never double-cast
-const newId = createConversationId();  // Good
+const newId = generateConversationId();  // Good
 // const newId = generateId() as string as ConversationId;  // Bad — don't do this
 ```
 
@@ -135,7 +135,7 @@ const newId = createConversationId();  // Good
 2. **Foreign keys use the referenced table's ID type**: `chatMessages.conversationId` uses `ConversationId`, not `'string'`
 3. **Optional FKs use `.or('undefined')`**: `'parentId?': ConversationId.or('undefined')`
 4. **Composite IDs are also branded**: `TabCompositeId`, `WindowCompositeId`, `GroupCompositeId`
-5. **Use factory functions**: When IDs are generated at runtime, use a `create*` factory: `createConversationId()`. Never scatter double-casts (`generateId() as string as ConversationId`) across call sites.
+5. **Use factory functions**: When IDs are generated at runtime, use a `generate*` factory: `generateConversationId()`. Never scatter double-casts (`generateId() as string as ConversationId`) across call sites.
 6. **Functions accept branded types**: `function switchConversation(id: ConversationId)` not `(id: string)`
 
 ### Why Not Plain `'string'`

--- a/.agents/skills/workspace-api/SKILL.md
+++ b/.agents/skills/workspace-api/SKILL.md
@@ -94,7 +94,7 @@ const theme = defineKv()
 
 Every table's `id` field and every string foreign key field MUST use a branded type instead of plain `'string'`. This prevents accidental mixing of IDs from different tables at compile time.
 
-### Three-Part Pattern
+### Pattern
 
 Define a branded type + arktype validator + factory in the same file as the workspace definition:
 
@@ -103,19 +103,17 @@ import type { Brand } from 'wellcrafted/brand';
 import { type } from 'arktype';
 import { generateId } from '@epicenter/workspace';
 
-// 1. TYPE — the branded type
+// 1. Branded type + arktype validator (co-located with workspace definition)
 export type ConversationId = string & Brand<'ConversationId'>;
-
-// 2. VALIDATOR — arktype pipe for schema composition
 export const ConversationId = type('string').pipe(
 	(s): ConversationId => s as ConversationId,
 );
 
-// 3. FACTORY — create* prefix, encapsulates the double-cast
+// 2. Factory function — the ONLY place with the double-cast
 export const createConversationId = (): ConversationId =>
 	generateId() as string as ConversationId;
 
-// Use in defineTable schema:
+// 3. Use in defineTable + co-locate type export
 const conversationsTable = defineTable(
 	type({
 		id: ConversationId,              // Primary key — branded
@@ -126,25 +124,9 @@ const conversationsTable = defineTable(
 );
 export type Conversation = InferTableRow<typeof conversationsTable>;
 
-const chatMessagesTable = defineTable(
-	type({
-		id: ChatMessageId,               // Different branded type
-		conversationId: ConversationId,   // FK to conversations — branded
-		role: "'user' | 'assistant'",
-		_v: '1',
-	}),
-);
-export type ChatMessage = InferTableRow<typeof chatMessagesTable>;
-
-// Compose in createWorkspace
-export const workspaceClient = createWorkspace(
-	defineWorkspace({
-		tables: {
-			conversations: conversationsTable,
-			chatMessages: chatMessagesTable,
-		},
-	}),
-);
+// 4. At call sites — use the factory, never double-cast
+const newId = createConversationId();  // Good
+// const newId = generateId() as string as ConversationId;  // Bad — don't do this
 ```
 
 ### Rules
@@ -153,7 +135,7 @@ export const workspaceClient = createWorkspace(
 2. **Foreign keys use the referenced table's ID type**: `chatMessages.conversationId` uses `ConversationId`, not `'string'`
 3. **Optional FKs use `.or('undefined')`**: `'parentId?': ConversationId.or('undefined')`
 4. **Composite IDs are also branded**: `TabCompositeId`, `WindowCompositeId`, `GroupCompositeId`
-5. **Use `create*` factories at generation sites**: `createConversationId()` not `generateId() as string as ConversationId`
+5. **Use factory functions**: When IDs are generated at runtime, use a `create*` factory: `createConversationId()`. Never scatter double-casts (`generateId() as string as ConversationId`) across call sites.
 6. **Functions accept branded types**: `function switchConversation(id: ConversationId)` not `(id: string)`
 
 ### Why Not Plain `'string'`
@@ -170,7 +152,7 @@ deleteConversation(message.id);  // Error: ChatMessageId is not ConversationId
 
 ### Reference Implementation
 
-See `apps/tab-manager/src/lib/workspace.ts` for the canonical example with 7 branded ID types.
+See `apps/tab-manager/src/lib/workspace.ts` for the canonical example with 7 branded ID types and 4 factory functions.
 See `packages/filesystem/src/ids.ts` for the reference factory pattern (`generateRowId`, `generateColumnId`, `generateFileId`).
 See `specs/20260312T180000-branded-id-convention.md` for the full inventory and migration plan.
 

--- a/apps/api/src/document-room.ts
+++ b/apps/api/src/document-room.ts
@@ -74,9 +74,7 @@ export class DocumentRoom extends BaseSyncRoom {
 			.toArray();
 		if (!row) return null;
 
-		const snap = Y.decodeSnapshot(
-			new Uint8Array(row.snapshot as ArrayBuffer),
-		);
+		const snap = Y.decodeSnapshot(new Uint8Array(row.snapshot as ArrayBuffer));
 		const restoredDoc = Y.createDocFromSnapshot(this.doc, snap);
 		return Y.encodeStateAsUpdateV2(restoredDoc);
 	}

--- a/apps/api/src/document-room.ts
+++ b/apps/api/src/document-room.ts
@@ -69,13 +69,13 @@ export class DocumentRoom extends BaseSyncRoom {
 
 	/** Reconstruct a past doc state from a snapshot. Returns full state as binary update. */
 	async getSnapshot(snapshotId: number): Promise<Uint8Array | null> {
-		const rows = this.ctx.storage.sql
+		const [row] = this.ctx.storage.sql
 			.exec('SELECT snapshot FROM snapshots WHERE id = ?', snapshotId)
 			.toArray();
-		if (rows.length === 0) return null;
+		if (!row) return null;
 
 		const snap = Y.decodeSnapshot(
-			new Uint8Array(rows[0]!.snapshot as ArrayBuffer),
+			new Uint8Array(row.snapshot as ArrayBuffer),
 		);
 		const restoredDoc = Y.createDocFromSnapshot(this.doc, snap);
 		return Y.encodeStateAsUpdateV2(restoredDoc);

--- a/apps/api/src/sync-handlers.test.ts
+++ b/apps/api/src/sync-handlers.test.ts
@@ -132,6 +132,7 @@ describe('computeInitialMessages', () => {
 		const { initialMessages } = setup();
 
 		expect(initialMessages.length).toBeGreaterThanOrEqual(1);
+		// biome-ignore lint/style/noNonNullAssertion: length asserted above
 		const decoded = decodeSyncMessage(initialMessages[0]!);
 		expect(decoded.type).toBe('step1');
 	});
@@ -145,6 +146,7 @@ describe('computeInitialMessages', () => {
 		const initialMessages = computeInitialMessages({ doc, awareness });
 
 		expect(initialMessages).toHaveLength(1);
+		// biome-ignore lint/style/noNonNullAssertion: length asserted above
 		expect(decodeMessageType(initialMessages[0]!)).toBe(MESSAGE_TYPE.SYNC);
 	});
 
@@ -156,7 +158,9 @@ describe('computeInitialMessages', () => {
 		const initialMessages = computeInitialMessages({ doc, awareness });
 
 		expect(initialMessages).toHaveLength(2);
+		// biome-ignore lint/style/noNonNullAssertion: length asserted above
 		expect(decodeMessageType(initialMessages[0]!)).toBe(MESSAGE_TYPE.SYNC);
+		// biome-ignore lint/style/noNonNullAssertion: length asserted above
 		expect(decodeMessageType(initialMessages[1]!)).toBe(MESSAGE_TYPE.AWARENESS);
 	});
 });
@@ -180,6 +184,7 @@ describe('registerConnection', () => {
 		);
 
 		expect(ws.sent.length).toBeGreaterThan(sentBefore);
+		// biome-ignore lint/style/noNonNullAssertion: length asserted above
 		expect(decodeMessageType(ws.sent[ws.sent.length - 1]!)).toBe(
 			MESSAGE_TYPE.SYNC,
 		);
@@ -226,8 +231,10 @@ describe('applyMessage — SYNC', () => {
 		const result = applyMessage({ data: step1Message, room, connection });
 
 		expect(result.error).toBeNull();
+		// biome-ignore lint/style/noNonNullAssertion: error is null, so data is non-null
 		expect(result.data!.response).toBeDefined();
 
+		// biome-ignore lint/style/noNonNullAssertion: error is null, so data is non-null
 		const decoded = decodeSyncMessage(result.data!.response!);
 		expect(decoded.type).toBe('step2');
 	});
@@ -244,6 +251,7 @@ describe('applyMessage — SYNC', () => {
 		const result = applyMessage({ data: step2Message, room, connection });
 
 		expect(result.error).toBeNull();
+		// biome-ignore lint/style/noNonNullAssertion: error is null, so data is non-null
 		expect(result.data!.response).toBeUndefined();
 		expect(doc.getMap('data').get('client-key')).toBe('client-value');
 	});
@@ -259,10 +267,12 @@ describe('applyMessage — SYNC', () => {
 		});
 		sourceDoc.getMap('data').set('incremental', 'update-value');
 
+		// biome-ignore lint/style/noNonNullAssertion: updateV2 handler fires synchronously from .set() above
 		const updateMessage = encodeSyncUpdate({ update: capturedUpdate! });
 		const result = applyMessage({ data: updateMessage, room, connection });
 
 		expect(result.error).toBeNull();
+		// biome-ignore lint/style/noNonNullAssertion: error is null, so data is non-null
 		expect(result.data!.response).toBeUndefined();
 		expect(doc.getMap('data').get('incremental')).toBe('update-value');
 	});
@@ -292,10 +302,13 @@ describe('applyMessage — AWARENESS', () => {
 		const result = applyMessage({ data: message, room, connection });
 
 		expect(result.error).toBeNull();
+		// biome-ignore lint/style/noNonNullAssertion: error is null, so data is non-null
 		expect(result.data!.broadcast).toBeDefined();
+		// biome-ignore lint/style/noNonNullAssertion: error is null and broadcast asserted above
 		expect(decodeMessageType(result.data!.broadcast!)).toBe(
 			MESSAGE_TYPE.AWARENESS,
 		);
+		// biome-ignore lint/style/noNonNullAssertion: error is null, so data is non-null
 		expect(result.data!.persistAttachment).toBe(true);
 	});
 
@@ -332,8 +345,10 @@ describe('applyMessage — QUERY_AWARENESS', () => {
 		const result = applyMessage({ data: message, room, connection });
 
 		expect(result.error).toBeNull();
-		expect(result.data?.response).toBeDefined();
-		expect(decodeMessageType(result.data?.response!)).toBe(
+		// biome-ignore lint/style/noNonNullAssertion: error is null, so data is non-null
+		expect(result.data!.response).toBeDefined();
+		// biome-ignore lint/style/noNonNullAssertion: error is null and response asserted above
+		expect(decodeMessageType(result.data!.response!)).toBe(
 			MESSAGE_TYPE.AWARENESS,
 		);
 	});
@@ -355,6 +370,7 @@ describe('applyMessage — QUERY_AWARENESS', () => {
 		const result = applyMessage({ data: message, room, connection });
 
 		expect(result.error).toBeNull();
+		// biome-ignore lint/style/noNonNullAssertion: error is null, so data is non-null
 		expect(result.data!.response).toBeUndefined();
 	});
 });
@@ -372,6 +388,7 @@ describe('applyMessage — error handling', () => {
 		const result = applyMessage({ data: malformed, room, connection });
 
 		expect(result.error).not.toBeNull();
+		// biome-ignore lint/style/noNonNullAssertion: error is non-null (asserted above)
 		expect(result.error!.message).toContain(
 			'Failed to decode WebSocket message',
 		);
@@ -386,6 +403,7 @@ describe('applyMessage — error handling', () => {
 
 		// Unknown types return empty effects array with no error
 		expect(result.error).toBeNull();
+		// biome-ignore lint/style/noNonNullAssertion: error is null, so data is non-null
 		expect(result.data!.response).toBeUndefined();
 	});
 });
@@ -469,6 +487,7 @@ describe('multi-client broadcast', () => {
 		});
 		sourceDoc.getMap('data').set('from-client-a', 'hello');
 
+		// biome-ignore lint/style/noNonNullAssertion: updateV2 handler fires synchronously from .set() above
 		const updateMessage = encodeSyncUpdate({ update: capturedUpdate! });
 		applyMessage({ data: updateMessage, room, connection: connection1 });
 
@@ -476,8 +495,8 @@ describe('multi-client broadcast', () => {
 		expect(ws2.sent.length).toBeGreaterThan(ws2SentBefore);
 
 		// The forwarded message should be a SYNC message
-		const lastSent = ws2.sent[ws2.sent.length - 1]!;
-		expect(decodeMessageType(lastSent)).toBe(MESSAGE_TYPE.SYNC);
+		// biome-ignore lint/style/noNonNullAssertion: length asserted above
+		expect(decodeMessageType(ws2.sent[ws2.sent.length - 1]!)).toBe(MESSAGE_TYPE.SYNC);
 
 		// Client A's ws should NOT have received it (echo prevention)
 		expect(ws1.sent.length).toBe(ws1SentBefore);
@@ -504,6 +523,7 @@ describe('multi-client broadcast', () => {
 		});
 
 		// The broadcast field should be set for the DO to distribute
+		// biome-ignore lint/style/noNonNullAssertion: error is null, so data is non-null
 		expect(result.data!.broadcast).toBeDefined();
 
 		// The awareness state should be applied to the shared instance
@@ -532,6 +552,7 @@ describe('full handshake convergence', () => {
 		const clientDoc = new Y.Doc();
 
 		// Step 1: Client receives server's SyncStep1 (from initialMessages)
+		// biome-ignore lint/style/noNonNullAssertion: setup() always returns at least one message
 		const serverStep1 = initialMessages[0]!;
 		const decoded = decodeSyncMessage(serverStep1);
 		expect(decoded.type).toBe('step1');
@@ -541,9 +562,11 @@ describe('full handshake convergence', () => {
 		const result = applyMessage({ data: clientStep1, room, connection });
 
 		expect(result.error).toBeNull();
+		// biome-ignore lint/style/noNonNullAssertion: error is null, so data is non-null
 		expect(result.data!.response).toBeDefined();
 
 		// Step 3: Client applies server's SyncStep2 response
+		// biome-ignore lint/style/noNonNullAssertion: error is null and response asserted above
 		const decodedStep2 = decodeSyncMessage(result.data!.response!);
 		expect(decodedStep2.type).toBe('step2');
 		if (decodedStep2.type === 'step2') {
@@ -578,9 +601,11 @@ describe('full handshake convergence', () => {
 		// Client sends SyncStep1 to server → gets SyncStep2 back
 		const clientStep1 = encodeSyncStep1({ doc: clientDoc });
 		const result1 = applyMessage({ data: clientStep1, room, connection });
+		// biome-ignore lint/style/noNonNullAssertion: error is null, so data is non-null
 		expect(result1.data!.response).toBeDefined();
 
 		// Client applies server's diff
+		// biome-ignore lint/style/noNonNullAssertion: error is null and response asserted above
 		const serverDiff = decodeSyncMessage(result1.data!.response!);
 		if (serverDiff.type === 'step2') {
 			Y.applyUpdateV2(clientDoc, serverDiff.update, 'server');

--- a/apps/api/src/sync-handlers.test.ts
+++ b/apps/api/src/sync-handlers.test.ts
@@ -496,7 +496,9 @@ describe('multi-client broadcast', () => {
 
 		// The forwarded message should be a SYNC message
 		// biome-ignore lint/style/noNonNullAssertion: length asserted above
-		expect(decodeMessageType(ws2.sent[ws2.sent.length - 1]!)).toBe(MESSAGE_TYPE.SYNC);
+		expect(decodeMessageType(ws2.sent[ws2.sent.length - 1]!)).toBe(
+			MESSAGE_TYPE.SYNC,
+		);
 
 		// Client A's ws should NOT have received it (echo prevention)
 		expect(ws1.sent.length).toBe(ws1SentBefore);

--- a/apps/api/src/sync-handlers.ts
+++ b/apps/api/src/sync-handlers.ts
@@ -34,10 +34,7 @@ import {
 	type SyncMessageType,
 } from '@epicenter/sync';
 import * as decoding from 'lib0/decoding';
-import {
-	defineErrors,
-	extractErrorMessage,
-} from 'wellcrafted/error';
+import { defineErrors, extractErrorMessage } from 'wellcrafted/error';
 import { Ok, trySync } from 'wellcrafted/result';
 import {
 	type Awareness,

--- a/apps/tab-manager/src/lib/quick-actions.ts
+++ b/apps/tab-manager/src/lib/quick-actions.ts
@@ -230,10 +230,10 @@ const saveAllAction: QuickAction = {
 			description: `Save and close ${allTabs.length} tab${allTabs.length === 1 ? '' : 's'}?`,
 			confirm: { text: 'Save & Close All', variant: 'destructive' },
 			async onConfirm() {
-				for (const tab of allTabs) {
-					if (!tab.url) continue;
-					await savedTabState.actions.save(tab);
-				}
+				const tabsWithUrls = allTabs.filter((tab) => tab.url);
+				await Promise.allSettled(
+					tabsWithUrls.map((tab) => savedTabState.actions.save(tab)),
+				);
 			},
 		});
 	},

--- a/apps/tab-manager/src/lib/quick-actions.ts
+++ b/apps/tab-manager/src/lib/quick-actions.ts
@@ -172,11 +172,10 @@ const sortAction: QuickAction = {
 				if (!tab) continue;
 				const parsed = parseTabId(tab.id as TabCompositeId);
 				if (!parsed) continue;
-				try {
-					await browser.tabs.move(parsed.tabId, { index: i });
-				} catch {
-					// Tab may not exist
-				}
+				await tryAsync({
+					try: () => browser.tabs.move(parsed.tabId, { index: i }),
+					catch: () => Ok(undefined),
+				});
 			}
 		}
 	},

--- a/apps/tab-manager/src/lib/quick-actions.ts
+++ b/apps/tab-manager/src/lib/quick-actions.ts
@@ -50,6 +50,15 @@ export type QuickAction = {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
+ * Batch-resolve composite tab IDs to native Chrome tab IDs.
+ */
+function compositeToNativeIds(compositeIds: TabCompositeId[]): number[] {
+	return compositeIds
+		.map((id) => parseTabId(id)?.tabId)
+		.filter((id) => id !== undefined);
+}
+
+/**
  * Normalize a URL for duplicate comparison.
  *
  * Strips trailing slash, query params, and hash to treat
@@ -142,9 +151,7 @@ const dedupAction: QuickAction = {
 			description: `Found ${totalDuplicates} duplicate tab${totalDuplicates === 1 ? '' : 's'} across ${dupes.size} URL${dupes.size === 1 ? '' : 's'}. Close them?`,
 			confirm: { text: 'Close Duplicates', variant: 'destructive' },
 			async onConfirm() {
-				const nativeIds = toClose
-					.map((tabId) => parseTabId(tabId)?.tabId)
-					.filter((id) => id !== undefined);
+				const nativeIds = compositeToNativeIds(toClose);
 				await tryAsync({
 					try: () => browser.tabs.remove(nativeIds),
 					catch: () => Ok(undefined),
@@ -193,9 +200,7 @@ const groupByDomainAction: QuickAction = {
 		const groupOps = [...domains.entries()]
 			.filter(([, tabIds]) => tabIds.length >= 2)
 			.map(([domain, tabIds]) => {
-				const nativeIds = tabIds
-					.map((id) => parseTabId(id)?.tabId)
-					.filter((id) => id !== undefined);
+				const nativeIds = compositeToNativeIds(tabIds);
 				return nativeIds.length >= 2 ? { domain, nativeIds } : null;
 			})
 			.filter(
@@ -266,9 +271,7 @@ const closeByDomainAction: QuickAction = {
 			description: `Close ${topCount} tab${topCount === 1 ? '' : 's'} from ${topDomain}?`,
 			confirm: { text: 'Close Tabs', variant: 'destructive' },
 			async onConfirm() {
-				const nativeIds = tabIds
-					.map((tabId) => parseTabId(tabId)?.tabId)
-					.filter((id) => id !== undefined);
+				const nativeIds = compositeToNativeIds(tabIds);
 				await tryAsync({
 					try: () => browser.tabs.remove(nativeIds),
 					catch: () => Ok(undefined),

--- a/apps/tab-manager/src/lib/quick-actions.ts
+++ b/apps/tab-manager/src/lib/quick-actions.ts
@@ -23,12 +23,12 @@ import CopyMinusIcon from '@lucide/svelte/icons/copy-minus';
 import GlobeIcon from '@lucide/svelte/icons/globe';
 import GroupIcon from '@lucide/svelte/icons/group';
 import type { Component } from 'svelte';
+import { Ok, tryAsync } from 'wellcrafted/result';
 import { browserState } from '$lib/state/browser-state.svelte';
 import { savedTabState } from '$lib/state/saved-tab-state.svelte';
 import { getDomain } from '$lib/utils/format';
 import type { TabCompositeId } from '$lib/workspace';
 import { parseTabId } from '$lib/workspace';
-import { Ok, tryAsync } from 'wellcrafted/result';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types

--- a/apps/tab-manager/src/lib/quick-actions.ts
+++ b/apps/tab-manager/src/lib/quick-actions.ts
@@ -80,7 +80,10 @@ function normalizeUrl(url: string): string {
  * Returns only groups with 2+ tabs (actual duplicates).
  * Within each group, tabs are ordered by their original array position.
  */
-function findDuplicates(): Map<string, { tabId: TabCompositeId; title: string }[]> {
+function findDuplicates(): Map<
+	string,
+	{ tabId: TabCompositeId; title: string }[]
+> {
 	const byUrl = new Map<string, { tabId: TabCompositeId; title: string }[]>();
 
 	for (const window of browserState.windows) {
@@ -203,9 +206,7 @@ const groupByDomainAction: QuickAction = {
 				const nativeIds = compositeToNativeIds(tabIds);
 				return nativeIds.length >= 2 ? { domain, nativeIds } : null;
 			})
-			.filter(
-				(op) => op !== null,
-			);
+			.filter((op) => op !== null);
 
 		await Promise.allSettled(
 			groupOps.map(async ({ domain, nativeIds }) => {

--- a/apps/tab-manager/src/lib/quick-actions.ts
+++ b/apps/tab-manager/src/lib/quick-actions.ts
@@ -71,8 +71,8 @@ function normalizeUrl(url: string): string {
  * Returns only groups with 2+ tabs (actual duplicates).
  * Within each group, tabs are ordered by their original array position.
  */
-function findDuplicates(): Map<string, { tabId: string; title: string }[]> {
-	const byUrl = new Map<string, { tabId: string; title: string }[]>();
+function findDuplicates(): Map<string, { tabId: TabCompositeId; title: string }[]> {
+	const byUrl = new Map<string, { tabId: TabCompositeId; title: string }[]>();
 
 	for (const window of browserState.windows) {
 		for (const tab of browserState.tabsByWindow(window.id)) {
@@ -97,8 +97,8 @@ function getAllTabs() {
 /**
  * Get unique domains from all open tabs.
  */
-function getUniqueDomains(): Map<string, string[]> {
-	const byDomain = new Map<string, string[]>();
+function getUniqueDomains(): Map<string, TabCompositeId[]> {
+	const byDomain = new Map<string, TabCompositeId[]>();
 
 	for (const tab of getAllTabs()) {
 		if (!tab.url) continue;
@@ -143,7 +143,7 @@ const dedupAction: QuickAction = {
 			confirm: { text: 'Close Duplicates', variant: 'destructive' },
 			async onConfirm() {
 				const nativeIds = toClose
-					.map((tabId) => parseTabId(tabId as TabCompositeId)?.tabId)
+					.map((tabId) => parseTabId(tabId)?.tabId)
 					.filter((id) => id !== undefined);
 				await tryAsync({
 					try: () => browser.tabs.remove(nativeIds),
@@ -170,7 +170,7 @@ const sortAction: QuickAction = {
 			for (let i = 0; i < sorted.length; i++) {
 				const tab = sorted[i];
 				if (!tab) continue;
-				const parsed = parseTabId(tab.id as TabCompositeId);
+				const parsed = parseTabId(tab.id);
 				if (!parsed) continue;
 				await tryAsync({
 					try: () => browser.tabs.move(parsed.tabId, { index: i }),
@@ -194,7 +194,7 @@ const groupByDomainAction: QuickAction = {
 			.filter(([, tabIds]) => tabIds.length >= 2)
 			.map(([domain, tabIds]) => {
 				const nativeIds = tabIds
-					.map((id) => parseTabId(id as TabCompositeId)?.tabId)
+					.map((id) => parseTabId(id)?.tabId)
 					.filter((id) => id !== undefined);
 				return nativeIds.length >= 2 ? { domain, nativeIds } : null;
 			})
@@ -267,7 +267,7 @@ const closeByDomainAction: QuickAction = {
 			confirm: { text: 'Close Tabs', variant: 'destructive' },
 			async onConfirm() {
 				const nativeIds = tabIds
-					.map((tabId) => parseTabId(tabId as TabCompositeId)?.tabId)
+					.map((tabId) => parseTabId(tabId)?.tabId)
 					.filter((id) => id !== undefined);
 				await tryAsync({
 					try: () => browser.tabs.remove(nativeIds),

--- a/apps/tab-manager/src/lib/quick-actions.ts
+++ b/apps/tab-manager/src/lib/quick-actions.ts
@@ -28,6 +28,7 @@ import { savedTabState } from '$lib/state/saved-tab-state.svelte';
 import { getDomain } from '$lib/utils/format';
 import type { TabCompositeId } from '$lib/workspace';
 import { parseTabId } from '$lib/workspace';
+import { Ok, tryAsync } from 'wellcrafted/result';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -141,16 +142,13 @@ const dedupAction: QuickAction = {
 			description: `Found ${totalDuplicates} duplicate tab${totalDuplicates === 1 ? '' : 's'} across ${dupes.size} URL${dupes.size === 1 ? '' : 's'}. Close them?`,
 			confirm: { text: 'Close Duplicates', variant: 'destructive' },
 			async onConfirm() {
-				for (const tabId of toClose) {
-					try {
-						const parsed = parseTabId(tabId as TabCompositeId);
-						if (parsed) {
-							await browser.tabs.remove(parsed.tabId);
-						}
-					} catch {
-						// Tab may already be closed
-					}
-				}
+				const nativeIds = toClose
+					.map((tabId) => parseTabId(tabId as TabCompositeId)?.tabId)
+					.filter((id): id is number => id !== undefined);
+				await tryAsync({
+					try: () => browser.tabs.remove(nativeIds),
+					catch: () => Ok(undefined),
+				});
 			},
 		});
 	},
@@ -193,27 +191,26 @@ const groupByDomainAction: QuickAction = {
 	async execute() {
 		const domains = getUniqueDomains();
 
-		for (const [domain, tabIds] of domains) {
-			if (tabIds.length < 2) continue;
+		const groupOps = [...domains.entries()]
+			.filter(([, tabIds]) => tabIds.length >= 2)
+			.map(([domain, tabIds]) => {
+				const nativeIds = tabIds
+					.map((id) => parseTabId(id as TabCompositeId)?.tabId)
+					.filter((id): id is number => id !== undefined);
+				return nativeIds.length >= 2 ? { domain, nativeIds } : null;
+			})
+			.filter(
+				(op): op is { domain: string; nativeIds: number[] } => op !== null,
+			);
 
-			const nativeIds = tabIds
-				.map((id) => {
-					const parsed = parseTabId(id as TabCompositeId);
-					return parsed?.tabId;
-				})
-				.filter((id): id is number => id !== undefined);
-
-			if (nativeIds.length < 2) continue;
-
-			try {
+		await Promise.allSettled(
+			groupOps.map(async ({ domain, nativeIds }) => {
 				const groupId = await browser.tabs.group({
 					tabIds: nativeIds as [number, ...number[]],
 				});
 				await browser.tabGroups.update(groupId, { title: domain });
-			} catch {
-				// Grouping may fail
-			}
-		}
+			}),
+		);
 	},
 };
 
@@ -270,15 +267,13 @@ const closeByDomainAction: QuickAction = {
 			description: `Close ${topCount} tab${topCount === 1 ? '' : 's'} from ${topDomain}?`,
 			confirm: { text: 'Close Tabs', variant: 'destructive' },
 			async onConfirm() {
-				for (const tabId of tabIds) {
-					const parsed = parseTabId(tabId as TabCompositeId);
-					if (!parsed) continue;
-					try {
-						await browser.tabs.remove(parsed.tabId);
-					} catch {
-						// Tab may already be closed
-					}
-				}
+				const nativeIds = tabIds
+					.map((tabId) => parseTabId(tabId as TabCompositeId)?.tabId)
+					.filter((id): id is number => id !== undefined);
+				await tryAsync({
+					try: () => browser.tabs.remove(nativeIds),
+					catch: () => Ok(undefined),
+				});
 			},
 		});
 	},

--- a/apps/tab-manager/src/lib/quick-actions.ts
+++ b/apps/tab-manager/src/lib/quick-actions.ts
@@ -144,7 +144,7 @@ const dedupAction: QuickAction = {
 			async onConfirm() {
 				const nativeIds = toClose
 					.map((tabId) => parseTabId(tabId as TabCompositeId)?.tabId)
-					.filter((id): id is number => id !== undefined);
+					.filter((id) => id !== undefined);
 				await tryAsync({
 					try: () => browser.tabs.remove(nativeIds),
 					catch: () => Ok(undefined),
@@ -196,11 +196,11 @@ const groupByDomainAction: QuickAction = {
 			.map(([domain, tabIds]) => {
 				const nativeIds = tabIds
 					.map((id) => parseTabId(id as TabCompositeId)?.tabId)
-					.filter((id): id is number => id !== undefined);
+					.filter((id) => id !== undefined);
 				return nativeIds.length >= 2 ? { domain, nativeIds } : null;
 			})
 			.filter(
-				(op): op is { domain: string; nativeIds: number[] } => op !== null,
+				(op) => op !== null,
 			);
 
 		await Promise.allSettled(
@@ -269,7 +269,7 @@ const closeByDomainAction: QuickAction = {
 			async onConfirm() {
 				const nativeIds = tabIds
 					.map((tabId) => parseTabId(tabId as TabCompositeId)?.tabId)
-					.filter((id): id is number => id !== undefined);
+					.filter((id) => id !== undefined);
 				await tryAsync({
 					try: () => browser.tabs.remove(nativeIds),
 					catch: () => Ok(undefined),

--- a/apps/tab-manager/src/lib/state/bookmark-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/bookmark-state.svelte.ts
@@ -81,7 +81,7 @@ function createBookmarkState() {
 				if (!tab.url) return;
 				const deviceId = await getDeviceId();
 				workspaceClient.tables.bookmarks.set({
-				id: createBookmarkId(),
+					id: createBookmarkId(),
 					url: tab.url,
 					title: tab.title || 'Untitled',
 					favIconUrl: tab.favIconUrl,

--- a/apps/tab-manager/src/lib/state/bookmark-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/bookmark-state.svelte.ts
@@ -30,7 +30,7 @@ import { getDeviceId } from '$lib/device/device-id';
 import {
 	type Bookmark,
 	type BookmarkId,
-	createBookmarkId,
+	generateBookmarkId,
 	type Tab,
 	workspaceClient,
 } from '$lib/workspace';
@@ -81,7 +81,7 @@ function createBookmarkState() {
 				if (!tab.url) return;
 				const deviceId = await getDeviceId();
 				workspaceClient.tables.bookmarks.set({
-					id: createBookmarkId(),
+					id: generateBookmarkId(),
 					url: tab.url,
 					title: tab.title || 'Untitled',
 					favIconUrl: tab.favIconUrl,

--- a/apps/tab-manager/src/lib/state/bookmark-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/bookmark-state.svelte.ts
@@ -26,11 +26,11 @@
  * ```
  */
 
-import { generateId } from '@epicenter/workspace';
 import { getDeviceId } from '$lib/device/device-id';
 import {
 	type Bookmark,
 	type BookmarkId,
+	createBookmarkId,
 	type Tab,
 	workspaceClient,
 } from '$lib/workspace';
@@ -81,7 +81,7 @@ function createBookmarkState() {
 				if (!tab.url) return;
 				const deviceId = await getDeviceId();
 				workspaceClient.tables.bookmarks.set({
-					id: generateId() as string as BookmarkId,
+				id: createBookmarkId(),
 					url: tab.url,
 					title: tab.title || 'Untitled',
 					favIconUrl: tab.favIconUrl,

--- a/apps/tab-manager/src/lib/state/chat-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/chat-state.svelte.ts
@@ -74,7 +74,6 @@ const DEFAULT_STREAM_STATE: StreamState = {
 // State Factory
 // ─────────────────────────────────────────────────────────────────────────────
 
-
 function createAiChatState() {
 	// ── Conversation List (Y.Doc-backed) ──────────────────────────────
 

--- a/apps/tab-manager/src/lib/state/chat-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/chat-state.svelte.ts
@@ -35,7 +35,6 @@
  * ```
  */
 
-import { generateId } from '@epicenter/workspace';
 import {
 	ChatClient,
 	type ChatClientState,
@@ -45,19 +44,11 @@ import {
 import { SvelteMap } from 'svelte/reactivity';
 import type { JsonValue } from 'wellcrafted/json';
 import {
-	AVAILABLE_PROVIDERS,
-	DEFAULT_MODEL,
-	DEFAULT_PROVIDER,
-	PROVIDER_MODELS,
-	type Provider,
-} from '$lib/ai/providers';
-import { TAB_MANAGER_SYSTEM_PROMPT } from '$lib/ai/system-prompt';
-import { toUiMessage } from '$lib/ai/ui-message';
-import { remoteServerUrl } from '$lib/state/settings.svelte';
-import {
 	type ChatMessageId,
 	type Conversation,
 	type ConversationId,
+	createChatMessageId,
+	createConversationId,
 	workspaceClient,
 	workspaceDefinitions,
 	workspaceTools,
@@ -83,8 +74,6 @@ const DEFAULT_STREAM_STATE: StreamState = {
 // State Factory
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** Generate a new branded ConversationId from a random ID. */
-const generateConversationId = () => generateId() as string as ConversationId;
 
 function createAiChatState() {
 	// ── Conversation List (Y.Doc-backed) ──────────────────────────────
@@ -105,7 +94,7 @@ function createAiChatState() {
 	 */
 	function ensureDefaultConversation(): ConversationId | undefined {
 		if (conversations.length > 0) return undefined;
-		const id = generateConversationId();
+		const id = createConversationId();
 		const now = Date.now();
 		workspaceClient.tables.conversations.set({
 			id,
@@ -358,7 +347,7 @@ function createAiChatState() {
 
 			sendMessage(content: string) {
 				if (!content.trim()) return;
-				const userMessageId = generateId() as string as ChatMessageId;
+				const userMessageId = createChatMessageId();
 
 				// Send to client FIRST so isLoading=true before the
 				// Y.Doc observer fires refreshFromDoc (which skips
@@ -503,7 +492,7 @@ function createAiChatState() {
 		sourceMessageId?: ChatMessageId;
 		systemPrompt?: string;
 	}): ConversationId {
-		const id = generateConversationId();
+		const id = createConversationId();
 		const now = Date.now();
 		const current = handles.get(activeConversationId);
 

--- a/apps/tab-manager/src/lib/state/chat-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/chat-state.svelte.ts
@@ -47,8 +47,8 @@ import {
 	type ChatMessageId,
 	type Conversation,
 	type ConversationId,
-	createChatMessageId,
-	createConversationId,
+	generateChatMessageId,
+	generateConversationId,
 	workspaceClient,
 	workspaceDefinitions,
 	workspaceTools,
@@ -93,7 +93,7 @@ function createAiChatState() {
 	 */
 	function ensureDefaultConversation(): ConversationId | undefined {
 		if (conversations.length > 0) return undefined;
-		const id = createConversationId();
+		const id = generateConversationId();
 		const now = Date.now();
 		workspaceClient.tables.conversations.set({
 			id,
@@ -346,7 +346,7 @@ function createAiChatState() {
 
 			sendMessage(content: string) {
 				if (!content.trim()) return;
-				const userMessageId = createChatMessageId();
+				const userMessageId = generateChatMessageId();
 
 				// Send to client FIRST so isLoading=true before the
 				// Y.Doc observer fires refreshFromDoc (which skips
@@ -491,7 +491,7 @@ function createAiChatState() {
 		sourceMessageId?: ChatMessageId;
 		systemPrompt?: string;
 	}): ConversationId {
-		const id = createConversationId();
+		const id = generateConversationId();
 		const now = Date.now();
 		const current = handles.get(activeConversationId);
 

--- a/apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts
@@ -33,7 +33,7 @@
 
 import { getDeviceId } from '$lib/device/device-id';
 import {
-	createSavedTabId,
+	generateSavedTabId,
 	type SavedTab,
 	type SavedTabId,
 	type Tab,
@@ -90,7 +90,7 @@ function createSavedTabState() {
 				if (!tab.url) return;
 				const deviceId = await getDeviceId();
 				workspaceClient.tables.savedTabs.set({
-					id: createSavedTabId(),
+					id: generateSavedTabId(),
 					url: tab.url,
 					title: tab.title || 'Untitled',
 					favIconUrl: tab.favIconUrl,

--- a/apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts
@@ -90,7 +90,7 @@ function createSavedTabState() {
 				if (!tab.url) return;
 				const deviceId = await getDeviceId();
 				workspaceClient.tables.savedTabs.set({
-				id: createSavedTabId(),
+					id: createSavedTabId(),
 					url: tab.url,
 					title: tab.title || 'Untitled',
 					favIconUrl: tab.favIconUrl,

--- a/apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts
@@ -31,9 +31,9 @@
  * ```
  */
 
-import { generateId } from '@epicenter/workspace';
 import { getDeviceId } from '$lib/device/device-id';
 import {
+	createSavedTabId,
 	type SavedTab,
 	type SavedTabId,
 	type Tab,
@@ -90,7 +90,7 @@ function createSavedTabState() {
 				if (!tab.url) return;
 				const deviceId = await getDeviceId();
 				workspaceClient.tables.savedTabs.set({
-					id: generateId() as string as SavedTabId,
+				id: createSavedTabId(),
 					url: tab.url,
 					title: tab.title || 'Untitled',
 					favIconUrl: tab.favIconUrl,

--- a/apps/tab-manager/src/lib/tab-actions.ts
+++ b/apps/tab-manager/src/lib/tab-actions.ts
@@ -7,9 +7,9 @@
  */
 import type { TableHelper } from '@epicenter/workspace';
 import { generateId } from '@epicenter/workspace';
+import { Ok, tryAsync } from 'wellcrafted/result';
 import type { DeviceId, SavedTab, SavedTabId } from '$lib/workspace';
 import { parseTabId } from '$lib/workspace';
-import { Ok, tryAsync } from 'wellcrafted/result';
 
 /**
  * Extract the native tab ID (number) from a composite tab ID string.
@@ -93,8 +93,11 @@ export async function executeSaveTabs(
 
 	const validTabs = results
 		.filter(
-			(r): r is PromiseFulfilledResult<Awaited<ReturnType<typeof browser.tabs.get>>> =>
-				r.status === 'fulfilled' && !!r.value.url,
+			(
+				r,
+			): r is PromiseFulfilledResult<
+				Awaited<ReturnType<typeof browser.tabs.get>>
+			> => r.status === 'fulfilled' && !!r.value.url,
 		)
 		.map((r) => r.value);
 
@@ -168,7 +171,9 @@ export async function executePinTabs(
 	const results = await Promise.allSettled(
 		nativeIds.map((id) => browser.tabs.update(id, { pinned })),
 	);
-	return { pinnedCount: results.filter((r) => r.status === 'fulfilled').length };
+	return {
+		pinnedCount: results.filter((r) => r.status === 'fulfilled').length,
+	};
 }
 
 /**
@@ -203,5 +208,7 @@ export async function executeReloadTabs(
 	const results = await Promise.allSettled(
 		nativeIds.map((id) => browser.tabs.reload(id)),
 	);
-	return { reloadedCount: results.filter((r) => r.status === 'fulfilled').length };
+	return {
+		reloadedCount: results.filter((r) => r.status === 'fulfilled').length,
+	};
 }

--- a/apps/tab-manager/src/lib/tab-actions.ts
+++ b/apps/tab-manager/src/lib/tab-actions.ts
@@ -82,35 +82,48 @@ export async function executeSaveTabs(
 	deviceId: DeviceId,
 	savedTabsTable: TableHelper<SavedTab>,
 ): Promise<{ savedCount: number }> {
-	let savedCount = 0;
-	for (const compositeId of tabIds) {
-		const id = nativeTabId(compositeId, deviceId);
-		if (id === undefined) continue;
+	const nativeIds = tabIds
+		.map((id) => nativeTabId(id, deviceId))
+		.filter((id) => id !== undefined);
 
-		try {
-			const tab = await browser.tabs.get(id);
-			if (!tab.url) continue;
+	// Fetch all tabs in parallel
+	const results = await Promise.allSettled(
+		nativeIds.map((id) => browser.tabs.get(id)),
+	);
 
-			savedTabsTable.set({
-				id: generateId() as string as SavedTabId,
-				url: tab.url,
-				title: tab.title || 'Untitled',
-				favIconUrl: tab.favIconUrl,
-				pinned: tab.pinned ?? false,
-				sourceDeviceId: deviceId,
-				savedAt: Date.now(),
-				_v: 1,
-			});
-			savedCount++;
+	const validTabs = results
+		.filter(
+			(r): r is PromiseFulfilledResult<Awaited<ReturnType<typeof browser.tabs.get>>> =>
+				r.status === 'fulfilled' && !!r.value.url,
+		)
+		.map((r) => r.value);
 
-			if (close) {
-				await browser.tabs.remove(id);
-			}
-		} catch {
-			// Tab may have been closed already
-		}
+	// Sync writes to Y.Doc
+	for (const tab of validTabs) {
+		savedTabsTable.set({
+			id: generateId() as string as SavedTabId,
+			url: tab.url!,
+			title: tab.title || 'Untitled',
+			favIconUrl: tab.favIconUrl,
+			pinned: tab.pinned ?? false,
+			sourceDeviceId: deviceId,
+			savedAt: Date.now(),
+			_v: 1,
+		});
 	}
-	return { savedCount };
+
+	// Batch close if requested
+	if (close) {
+		const idsToClose = validTabs
+			.map((t) => t.id)
+			.filter((id): id is number => id !== undefined);
+		await tryAsync({
+			try: () => browser.tabs.remove(idsToClose),
+			catch: () => Ok(undefined),
+		});
+	}
+
+	return { savedCount: validTabs.length };
 }
 
 /**

--- a/apps/tab-manager/src/lib/tab-actions.ts
+++ b/apps/tab-manager/src/lib/tab-actions.ts
@@ -7,8 +7,8 @@
  */
 import type { TableHelper } from '@epicenter/workspace';
 import {
-	generateSavedTabId,
 	type DeviceId,
+	generateSavedTabId,
 	parseTabId,
 	type SavedTab,
 	type SavedTabId,

--- a/apps/tab-manager/src/lib/tab-actions.ts
+++ b/apps/tab-manager/src/lib/tab-actions.ts
@@ -9,6 +9,7 @@ import type { TableHelper } from '@epicenter/workspace';
 import { generateId } from '@epicenter/workspace';
 import type { DeviceId, SavedTab, SavedTabId } from '$lib/workspace';
 import { parseTabId } from '$lib/workspace';
+import { Ok, tryAsync } from 'wellcrafted/result';
 
 /**
  * Extract the native tab ID (number) from a composite tab ID string.
@@ -36,16 +37,11 @@ export async function executeCloseTabs(
 		.map((id) => nativeTabId(id, deviceId))
 		.filter((id) => id !== undefined);
 
-	let closedCount = 0;
-	for (const id of nativeIds) {
-		try {
-			await browser.tabs.remove(id);
-			closedCount++;
-		} catch {
-			// Tab may already be closed
-		}
-	}
-	return { closedCount };
+	await tryAsync({
+		try: () => browser.tabs.remove(nativeIds),
+		catch: () => Ok(undefined),
+	});
+	return { closedCount: nativeIds.length };
 }
 
 /**
@@ -156,16 +152,10 @@ export async function executePinTabs(
 		.map((id) => nativeTabId(id, deviceId))
 		.filter((id) => id !== undefined);
 
-	let pinnedCount = 0;
-	for (const id of nativeIds) {
-		try {
-			await browser.tabs.update(id, { pinned });
-			pinnedCount++;
-		} catch {
-			// Tab may not exist
-		}
-	}
-	return { pinnedCount };
+	const results = await Promise.allSettled(
+		nativeIds.map((id) => browser.tabs.update(id, { pinned })),
+	);
+	return { pinnedCount: results.filter((r) => r.status === 'fulfilled').length };
 }
 
 /**
@@ -180,16 +170,10 @@ export async function executeMuteTabs(
 		.map((id) => nativeTabId(id, deviceId))
 		.filter((id) => id !== undefined);
 
-	let mutedCount = 0;
-	for (const id of nativeIds) {
-		try {
-			await browser.tabs.update(id, { muted });
-			mutedCount++;
-		} catch {
-			// Tab may not exist
-		}
-	}
-	return { mutedCount };
+	const results = await Promise.allSettled(
+		nativeIds.map((id) => browser.tabs.update(id, { muted })),
+	);
+	return { mutedCount: results.filter((r) => r.status === 'fulfilled').length };
 }
 
 /**
@@ -203,14 +187,8 @@ export async function executeReloadTabs(
 		.map((id) => nativeTabId(id, deviceId))
 		.filter((id) => id !== undefined);
 
-	let reloadedCount = 0;
-	for (const id of nativeIds) {
-		try {
-			await browser.tabs.reload(id);
-			reloadedCount++;
-		} catch {
-			// Tab may not exist
-		}
-	}
-	return { reloadedCount };
+	const results = await Promise.allSettled(
+		nativeIds.map((id) => browser.tabs.reload(id)),
+	);
+	return { reloadedCount: results.filter((r) => r.status === 'fulfilled').length };
 }

--- a/apps/tab-manager/src/lib/tab-actions.ts
+++ b/apps/tab-manager/src/lib/tab-actions.ts
@@ -65,12 +65,11 @@ export async function executeActivateTab(
 	const id = nativeTabId(compositeTabId, deviceId);
 	if (id === undefined) return { activated: false };
 
-	try {
-		await browser.tabs.update(id, { active: true });
-		return { activated: true };
-	} catch {
-		return { activated: false };
-	}
+	const { error } = await tryAsync({
+		try: () => browser.tabs.update(id, { active: true }),
+		catch: () => Ok(undefined),
+	});
+	return { activated: !error };
 }
 
 /**

--- a/apps/tab-manager/src/lib/tab-actions.ts
+++ b/apps/tab-manager/src/lib/tab-actions.ts
@@ -6,9 +6,8 @@
  * mutation handlers in workspace.ts.
  */
 import type { TableHelper } from '@epicenter/workspace';
-import { Ok, tryAsync } from 'wellcrafted/result';
 import {
-	createSavedTabId,
+	generateSavedTabId,
 	type DeviceId,
 	parseTabId,
 	type SavedTab,
@@ -180,7 +179,7 @@ export async function executeSaveTabs(
 	// Sync writes to Y.Doc
 	for (const tab of validTabs) {
 		savedTabsTable.set({
-			id: createSavedTabId(),
+			id: generateSavedTabId(),
 			url: tab.url,
 			title: tab.title || 'Untitled',
 			favIconUrl: tab.favIconUrl,

--- a/apps/tab-manager/src/lib/tab-actions.ts
+++ b/apps/tab-manager/src/lib/tab-actions.ts
@@ -27,7 +27,25 @@ function nativeTabId(
 }
 
 /**
- * Close the specified tabs.
+ * Close the specified browser tabs by their composite IDs.
+ *
+ * Resolves each composite ID to a native Chrome tab ID scoped to `deviceId`,
+ * then batch-removes them. IDs belonging to other devices are silently ignored.
+ * Chrome API failures are swallowed—`closedCount` reflects the number of tabs
+ * targeted, not confirmed closed (Chrome doesn't report individual failures).
+ *
+ * @param tabIds - Composite tab IDs in `${deviceId}_${nativeId}` format
+ * @param deviceId - The local device ID used to filter composite IDs
+ * @returns The number of tabs targeted for removal
+ *
+ * @example
+ * ```typescript
+ * const { closedCount } = await executeCloseTabs(
+ *   ['device1_42', 'device1_99', 'device2_7'],
+ *   DeviceId('device1'),
+ * );
+ * // closedCount === 2 (device2_7 is ignored)
+ * ```
  */
 export async function executeCloseTabs(
 	tabIds: string[],
@@ -45,7 +63,21 @@ export async function executeCloseTabs(
 }
 
 /**
- * Open a new tab with the given URL.
+ * Open a new browser tab at the given URL.
+ *
+ * Creates a tab via `browser.tabs.create`. If the Chrome API call fails
+ * (e.g., invalid URL, extension permissions), returns `tabId: "-1"` as a
+ * sentinel value instead of throwing.
+ *
+ * @param url - The URL to open in the new tab
+ * @param _windowId - Reserved for future use (target window)
+ * @returns The string-encoded native tab ID, or `"-1"` on failure
+ *
+ * @example
+ * ```typescript
+ * const { tabId } = await executeOpenTab('https://example.com');
+ * if (tabId === '-1') console.error('Failed to open tab');
+ * ```
  */
 export async function executeOpenTab(
 	url: string,
@@ -60,7 +92,21 @@ export async function executeOpenTab(
 }
 
 /**
- * Activate (focus) a specific tab.
+ * Activate (bring to focus) a specific browser tab.
+ *
+ * Resolves the composite ID to a native tab ID scoped to `deviceId`.
+ * If the ID belongs to a different device or the tab no longer exists,
+ * returns `{ activated: false }` without throwing.
+ *
+ * @param compositeTabId - Composite tab ID in `${deviceId}_${nativeId}` format
+ * @param deviceId - The local device ID used to scope the lookup
+ * @returns Whether the tab was successfully activated
+ *
+ * @example
+ * ```typescript
+ * const { activated } = await executeActivateTab('device1_42', deviceId);
+ * if (!activated) console.warn('Tab not found or not on this device');
+ * ```
  */
 export async function executeActivateTab(
 	compositeTabId: string,
@@ -77,7 +123,28 @@ export async function executeActivateTab(
 }
 
 /**
- * Save tabs to the savedTabs table, optionally closing them.
+ * Save browser tabs to the Y.Doc savedTabs table, optionally closing them.
+ *
+ * Fetches full tab metadata via `Promise.allSettled` (tolerating tabs that
+ * vanished between query and fetch), filters to tabs with valid URLs, writes
+ * each to the CRDT-backed savedTabs table, and optionally batch-closes them.
+ * Tabs without URLs (e.g., `chrome://` pages) are silently skipped.
+ *
+ * @param tabIds - Composite tab IDs to save
+ * @param close - Whether to close the tabs after saving
+ * @param deviceId - The local device ID used to scope composite IDs
+ * @param savedTabsTable - The Y.Doc table helper for persisting saved tabs
+ * @returns The number of tabs successfully saved
+ *
+ * @example
+ * ```typescript
+ * const { savedCount } = await executeSaveTabs(
+ *   selectedTabIds,
+ *   true, // close after saving
+ *   deviceId,
+ *   workspace.tables.savedTabs,
+ * );
+ * ```
  */
 export async function executeSaveTabs(
 	tabIds: string[],
@@ -128,7 +195,25 @@ export async function executeSaveTabs(
 }
 
 /**
- * Group tabs together with an optional title and color.
+ * Group browser tabs together with an optional title and color.
+ *
+ * Creates a Chrome tab group from the resolved native IDs, then optionally
+ * applies a title and/or color. If grouping fails (e.g., tabs don't exist),
+ * returns `groupId: "-1"`. If the group is created but title/color update
+ * fails, the group still exists—the cosmetic failure is swallowed.
+ *
+ * @param tabIds - Composite tab IDs to group
+ * @param deviceId - The local device ID used to scope composite IDs
+ * @param title - Optional group label shown in the tab strip
+ * @param color - Optional group color (Chrome tab group color name)
+ * @returns The string-encoded group ID, or `"-1"` on failure
+ *
+ * @example
+ * ```typescript
+ * const { groupId } = await executeGroupTabs(
+ *   tabIds, deviceId, 'Research', 'blue',
+ * );
+ * ```
  */
 export async function executeGroupTabs(
 	tabIds: string[],
@@ -160,7 +245,21 @@ export async function executeGroupTabs(
 }
 
 /**
- * Pin or unpin tabs.
+ * Pin or unpin browser tabs.
+ *
+ * Applies the pin state to each resolved native tab ID via `Promise.allSettled`,
+ * tolerating individual failures (e.g., tab closed mid-operation). Returns the
+ * count of tabs that were successfully updated.
+ *
+ * @param tabIds - Composite tab IDs to pin/unpin
+ * @param pinned - `true` to pin, `false` to unpin
+ * @param deviceId - The local device ID used to scope composite IDs
+ * @returns The number of tabs successfully pinned/unpinned
+ *
+ * @example
+ * ```typescript
+ * const { pinnedCount } = await executePinTabs(tabIds, true, deviceId);
+ * ```
  */
 export async function executePinTabs(
 	tabIds: string[],
@@ -180,7 +279,20 @@ export async function executePinTabs(
 }
 
 /**
- * Mute or unmute tabs.
+ * Mute or unmute browser tabs.
+ *
+ * Applies the mute state to each resolved native tab ID via `Promise.allSettled`,
+ * tolerating individual failures. Returns the count of tabs successfully updated.
+ *
+ * @param tabIds - Composite tab IDs to mute/unmute
+ * @param muted - `true` to mute, `false` to unmute
+ * @param deviceId - The local device ID used to scope composite IDs
+ * @returns The number of tabs successfully muted/unmuted
+ *
+ * @example
+ * ```typescript
+ * const { mutedCount } = await executeMuteTabs(tabIds, true, deviceId);
+ * ```
  */
 export async function executeMuteTabs(
 	tabIds: string[],
@@ -198,7 +310,20 @@ export async function executeMuteTabs(
 }
 
 /**
- * Reload tabs.
+ * Reload browser tabs.
+ *
+ * Triggers a reload on each resolved native tab ID via `Promise.allSettled`,
+ * tolerating individual failures (e.g., tab closed mid-operation). Returns the
+ * count of tabs that were successfully reloaded.
+ *
+ * @param tabIds - Composite tab IDs to reload
+ * @param deviceId - The local device ID used to scope composite IDs
+ * @returns The number of tabs successfully reloaded
+ *
+ * @example
+ * ```typescript
+ * const { reloadedCount } = await executeReloadTabs(tabIds, deviceId);
+ * ```
  */
 export async function executeReloadTabs(
 	tabIds: string[],

--- a/apps/tab-manager/src/lib/tab-actions.ts
+++ b/apps/tab-manager/src/lib/tab-actions.ts
@@ -6,8 +6,14 @@
  * mutation handlers in workspace.ts.
  */
 import type { TableHelper } from '@epicenter/workspace';
-import { createSavedTabId, type DeviceId, parseTabId, type SavedTab, type SavedTabId } from '$lib/workspace';
 import { Ok, tryAsync } from 'wellcrafted/result';
+import {
+	createSavedTabId,
+	type DeviceId,
+	parseTabId,
+	type SavedTab,
+	type SavedTabId,
+} from '$lib/workspace';
 
 /**
  * Extract the native tab ID (number) from a composite tab ID string.
@@ -229,7 +235,8 @@ export async function executeGroupTabs(
 	const nativeIds = toNativeIds(tabIds, deviceId);
 
 	const { data: groupId, error: groupError } = await tryAsync({
-		try: () => browser.tabs.group({ tabIds: nativeIds as [number, ...number[]] }),
+		try: () =>
+			browser.tabs.group({ tabIds: nativeIds as [number, ...number[]] }),
 		catch: () => Ok(undefined),
 	});
 	if (groupError || groupId === undefined) return { groupId: String(-1) };

--- a/apps/tab-manager/src/lib/tab-actions.ts
+++ b/apps/tab-manager/src/lib/tab-actions.ts
@@ -27,6 +27,17 @@ function nativeTabId(
 }
 
 /**
+ * Batch-resolve composite tab IDs to native Chrome tab IDs.
+ *
+ * Filters out IDs that don't belong to the given device.
+ */
+function toNativeIds(tabIds: string[], deviceId: DeviceId): number[] {
+	return tabIds
+		.map((id) => nativeTabId(id, deviceId))
+		.filter((id) => id !== undefined);
+}
+
+/**
  * Close the specified browser tabs by their composite IDs.
  *
  * Resolves each composite ID to a native Chrome tab ID scoped to `deviceId`,
@@ -51,9 +62,7 @@ export async function executeCloseTabs(
 	tabIds: string[],
 	deviceId: DeviceId,
 ): Promise<{ closedCount: number }> {
-	const nativeIds = tabIds
-		.map((id) => nativeTabId(id, deviceId))
-		.filter((id) => id !== undefined);
+	const nativeIds = toNativeIds(tabIds, deviceId);
 
 	await tryAsync({
 		try: () => browser.tabs.remove(nativeIds),
@@ -152,9 +161,7 @@ export async function executeSaveTabs(
 	deviceId: DeviceId,
 	savedTabsTable: TableHelper<SavedTab>,
 ): Promise<{ savedCount: number }> {
-	const nativeIds = tabIds
-		.map((id) => nativeTabId(id, deviceId))
-		.filter((id) => id !== undefined);
+	const nativeIds = toNativeIds(tabIds, deviceId);
 
 	// Fetch all tabs in parallel
 	const results = await Promise.allSettled(
@@ -221,9 +228,7 @@ export async function executeGroupTabs(
 	title?: string,
 	color?: string,
 ): Promise<{ groupId: string }> {
-	const nativeIds = tabIds
-		.map((id) => nativeTabId(id, deviceId))
-		.filter((id) => id !== undefined);
+	const nativeIds = toNativeIds(tabIds, deviceId);
 
 	const { data: groupId, error: groupError } = await tryAsync({
 		try: () => browser.tabs.group({ tabIds: nativeIds as [number, ...number[]] }),
@@ -266,9 +271,7 @@ export async function executePinTabs(
 	pinned: boolean,
 	deviceId: DeviceId,
 ): Promise<{ pinnedCount: number }> {
-	const nativeIds = tabIds
-		.map((id) => nativeTabId(id, deviceId))
-		.filter((id) => id !== undefined);
+	const nativeIds = toNativeIds(tabIds, deviceId);
 
 	const results = await Promise.allSettled(
 		nativeIds.map((id) => browser.tabs.update(id, { pinned })),
@@ -299,9 +302,7 @@ export async function executeMuteTabs(
 	muted: boolean,
 	deviceId: DeviceId,
 ): Promise<{ mutedCount: number }> {
-	const nativeIds = tabIds
-		.map((id) => nativeTabId(id, deviceId))
-		.filter((id) => id !== undefined);
+	const nativeIds = toNativeIds(tabIds, deviceId);
 
 	const results = await Promise.allSettled(
 		nativeIds.map((id) => browser.tabs.update(id, { muted })),
@@ -329,9 +330,7 @@ export async function executeReloadTabs(
 	tabIds: string[],
 	deviceId: DeviceId,
 ): Promise<{ reloadedCount: number }> {
-	const nativeIds = tabIds
-		.map((id) => nativeTabId(id, deviceId))
-		.filter((id) => id !== undefined);
+	const nativeIds = toNativeIds(tabIds, deviceId);
 
 	const results = await Promise.allSettled(
 		nativeIds.map((id) => browser.tabs.reload(id)),

--- a/apps/tab-manager/src/lib/tab-actions.ts
+++ b/apps/tab-manager/src/lib/tab-actions.ts
@@ -51,7 +51,11 @@ export async function executeOpenTab(
 	url: string,
 	_windowId?: string,
 ): Promise<{ tabId: string }> {
-	const tab = await browser.tabs.create({ url });
+	const { data: tab, error } = await tryAsync({
+		try: () => browser.tabs.create({ url }),
+		catch: () => Ok(undefined),
+	});
+	if (error || !tab) return { tabId: String(-1) };
 	return { tabId: String(tab.id ?? -1) };
 }
 
@@ -141,15 +145,20 @@ export async function executeGroupTabs(
 		.map((id) => nativeTabId(id, deviceId))
 		.filter((id) => id !== undefined);
 
-	const groupId = await browser.tabs.group({
-		tabIds: nativeIds as [number, ...number[]],
+	const { data: groupId, error: groupError } = await tryAsync({
+		try: () => browser.tabs.group({ tabIds: nativeIds as [number, ...number[]] }),
+		catch: () => Ok(undefined),
 	});
+	if (groupError || groupId === undefined) return { groupId: String(-1) };
 
 	if (title || color) {
 		const updateProps: Browser.tabGroups.UpdateProperties = {};
 		if (title) updateProps.title = title;
 		if (color) updateProps.color = color as `${Browser.tabGroups.Color}`;
-		await browser.tabGroups.update(groupId as number, updateProps);
+		await tryAsync({
+			try: () => browser.tabGroups.update(groupId as number, updateProps),
+			catch: () => Ok(undefined),
+		});
 	}
 
 	return { groupId: String(groupId) };

--- a/apps/tab-manager/src/lib/tab-actions.ts
+++ b/apps/tab-manager/src/lib/tab-actions.ts
@@ -119,7 +119,7 @@ export async function executeSaveTabs(
 	if (close) {
 		const idsToClose = validTabs
 			.map((t) => t.id)
-			.filter((id): id is number => id !== undefined);
+			.filter((id) => id !== undefined);
 		await tryAsync({
 			try: () => browser.tabs.remove(idsToClose),
 			catch: () => Ok(undefined),

--- a/apps/tab-manager/src/lib/tab-actions.ts
+++ b/apps/tab-manager/src/lib/tab-actions.ts
@@ -94,21 +94,16 @@ export async function executeSaveTabs(
 		nativeIds.map((id) => browser.tabs.get(id)),
 	);
 
-	const validTabs = results
-		.filter(
-			(
-				r,
-			): r is PromiseFulfilledResult<
-				Awaited<ReturnType<typeof browser.tabs.get>>
-			> => r.status === 'fulfilled' && !!r.value.url,
-		)
-		.map((r) => r.value);
+	const validTabs = results.flatMap((r) => {
+		if (r.status !== 'fulfilled' || !r.value.url) return [];
+		return [{ ...r.value, url: r.value.url }];
+	});
 
 	// Sync writes to Y.Doc
 	for (const tab of validTabs) {
 		savedTabsTable.set({
 			id: generateId() as string as SavedTabId,
-			url: tab.url!,
+			url: tab.url,
 			title: tab.title || 'Untitled',
 			favIconUrl: tab.favIconUrl,
 			pinned: tab.pinned ?? false,

--- a/apps/tab-manager/src/lib/tab-actions.ts
+++ b/apps/tab-manager/src/lib/tab-actions.ts
@@ -6,10 +6,8 @@
  * mutation handlers in workspace.ts.
  */
 import type { TableHelper } from '@epicenter/workspace';
-import { generateId } from '@epicenter/workspace';
+import { createSavedTabId, type DeviceId, parseTabId, type SavedTab, type SavedTabId } from '$lib/workspace';
 import { Ok, tryAsync } from 'wellcrafted/result';
-import type { DeviceId, SavedTab, SavedTabId } from '$lib/workspace';
-import { parseTabId } from '$lib/workspace';
 
 /**
  * Extract the native tab ID (number) from a composite tab ID string.
@@ -176,7 +174,7 @@ export async function executeSaveTabs(
 	// Sync writes to Y.Doc
 	for (const tab of validTabs) {
 		savedTabsTable.set({
-			id: generateId() as string as SavedTabId,
+			id: createSavedTabId(),
 			url: tab.url,
 			title: tab.title || 'Untitled',
 			favIconUrl: tab.favIconUrl,

--- a/apps/tab-manager/src/lib/workspace.ts
+++ b/apps/tab-manager/src/lib/workspace.ts
@@ -86,6 +86,22 @@ export type SavedTabId = string & Brand<'SavedTabId'>;
 export const SavedTabId = type('string').pipe(
 	(s): SavedTabId => s as SavedTabId,
 );
+/**
+ * Generate a unique {@link SavedTabId} for a newly saved tab.
+ *
+ * Wraps `generateId()` with the branded cast so call sites never
+ * need the error-prone `as string as SavedTabId` double-cast.
+ *
+ * @example
+ * ```typescript
+ * workspaceClient.tables.savedTabs.set({
+ *   id: createSavedTabId(),
+ *   url: tab.url,
+ *   title: tab.title || 'Untitled',
+ *   // …remaining fields
+ * });
+ * ```
+ */
 export const createSavedTabId = (): SavedTabId =>
 	generateId() as string as SavedTabId;
 
@@ -99,6 +115,22 @@ export type BookmarkId = string & Brand<'BookmarkId'>;
 export const BookmarkId = type('string').pipe(
 	(s): BookmarkId => s as BookmarkId,
 );
+/**
+ * Generate a unique {@link BookmarkId} for a newly created bookmark.
+ *
+ * Wraps `generateId()` with the branded cast so call sites never
+ * need the error-prone `as string as BookmarkId` double-cast.
+ *
+ * @example
+ * ```typescript
+ * workspaceClient.tables.bookmarks.set({
+ *   id: createBookmarkId(),
+ *   url: tab.url,
+ *   title: tab.title || 'Untitled',
+ *   // …remaining fields
+ * });
+ * ```
+ */
 export const createBookmarkId = (): BookmarkId =>
 	generateId() as string as BookmarkId;
 
@@ -112,6 +144,26 @@ export type ConversationId = string & Brand<'ConversationId'>;
 export const ConversationId = type('string').pipe(
 	(s): ConversationId => s as ConversationId,
 );
+/**
+ * Generate a unique {@link ConversationId} for a new chat conversation.
+ *
+ * Wraps `generateId()` with the branded cast so call sites never
+ * need the error-prone `as string as ConversationId` double-cast.
+ *
+ * @example
+ * ```typescript
+ * const id = createConversationId();
+ * workspaceClient.tables.conversations.set({
+ *   id,
+ *   title: 'New Chat',
+ *   provider: DEFAULT_PROVIDER,
+ *   model: DEFAULT_MODEL,
+ *   createdAt: Date.now(),
+ *   updatedAt: Date.now(),
+ *   // …remaining fields
+ * });
+ * ```
+ */
 export const createConversationId = (): ConversationId =>
 	generateId() as string as ConversationId;
 
@@ -124,6 +176,25 @@ export type ChatMessageId = string & Brand<'ChatMessageId'>;
 export const ChatMessageId = type('string').pipe(
 	(s): ChatMessageId => s as ChatMessageId,
 );
+/**
+ * Generate a unique {@link ChatMessageId} for a new chat message.
+ *
+ * Wraps `generateId()` with the branded cast so call sites never
+ * need the error-prone `as string as ChatMessageId` double-cast.
+ *
+ * @example
+ * ```typescript
+ * const userMessageId = createChatMessageId();
+ * workspaceClient.tables.chatMessages.set({
+ *   id: userMessageId,
+ *   conversationId,
+ *   role: 'user',
+ *   parts: [{ type: 'text', content }],
+ *   createdAt: Date.now(),
+ *   // …remaining fields
+ * });
+ * ```
+ */
 export const createChatMessageId = (): ChatMessageId =>
 	generateId() as string as ChatMessageId;
 

--- a/apps/tab-manager/src/lib/workspace.ts
+++ b/apps/tab-manager/src/lib/workspace.ts
@@ -95,14 +95,14 @@ export const SavedTabId = type('string').pipe(
  * @example
  * ```typescript
  * workspaceClient.tables.savedTabs.set({
- *   id: createSavedTabId(),
+ *   id: generateSavedTabId(),
  *   url: tab.url,
  *   title: tab.title || 'Untitled',
  *   // …remaining fields
  * });
  * ```
  */
-export const createSavedTabId = (): SavedTabId =>
+export const generateSavedTabId = (): SavedTabId =>
 	generateId() as string as SavedTabId;
 
 /**
@@ -124,14 +124,14 @@ export const BookmarkId = type('string').pipe(
  * @example
  * ```typescript
  * workspaceClient.tables.bookmarks.set({
- *   id: createBookmarkId(),
+ *   id: generateBookmarkId(),
  *   url: tab.url,
  *   title: tab.title || 'Untitled',
  *   // …remaining fields
  * });
  * ```
  */
-export const createBookmarkId = (): BookmarkId =>
+export const generateBookmarkId = (): BookmarkId =>
 	generateId() as string as BookmarkId;
 
 /**
@@ -152,7 +152,7 @@ export const ConversationId = type('string').pipe(
  *
  * @example
  * ```typescript
- * const id = createConversationId();
+ * const id = generateConversationId();
  * workspaceClient.tables.conversations.set({
  *   id,
  *   title: 'New Chat',
@@ -164,7 +164,7 @@ export const ConversationId = type('string').pipe(
  * });
  * ```
  */
-export const createConversationId = (): ConversationId =>
+export const generateConversationId = (): ConversationId =>
 	generateId() as string as ConversationId;
 
 /**
@@ -184,7 +184,7 @@ export const ChatMessageId = type('string').pipe(
  *
  * @example
  * ```typescript
- * const userMessageId = createChatMessageId();
+ * const userMessageId = generateChatMessageId();
  * workspaceClient.tables.chatMessages.set({
  *   id: userMessageId,
  *   conversationId,
@@ -195,7 +195,7 @@ export const ChatMessageId = type('string').pipe(
  * });
  * ```
  */
-export const createChatMessageId = (): ChatMessageId =>
+export const generateChatMessageId = (): ChatMessageId =>
 	generateId() as string as ChatMessageId;
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/apps/tab-manager/src/lib/workspace.ts
+++ b/apps/tab-manager/src/lib/workspace.ts
@@ -76,7 +76,7 @@ export const TAB_GROUP_ID_NONE = -1;
  * Prevents accidental mixing with other string IDs (conversation, tab, etc.).
  */
 export type DeviceId = string & Brand<'DeviceId'>;
-export const DeviceId = type('string').pipe((s): DeviceId => s as DeviceId);
+export const DeviceId = type('string').as<DeviceId>();
 
 /**
  * Branded saved tab ID — nanoid generated when a tab is explicitly saved.
@@ -84,9 +84,7 @@ export const DeviceId = type('string').pipe((s): DeviceId => s as DeviceId);
  * Prevents accidental mixing with composite tab IDs or other string IDs.
  */
 export type SavedTabId = Id & Brand<'SavedTabId'>;
-export const SavedTabId = type('string').pipe(
-	(s): SavedTabId => s as SavedTabId,
-);
+export const SavedTabId = type('string').as<SavedTabId>();
 /**
  * Generate a unique {@link SavedTabId} for a newly saved tab.
  *
@@ -112,9 +110,7 @@ export const generateSavedTabId = (): SavedTabId => generateId() as SavedTabId;
  * bookmarked URL does NOT delete the record.
  */
 export type BookmarkId = Id & Brand<'BookmarkId'>;
-export const BookmarkId = type('string').pipe(
-	(s): BookmarkId => s as BookmarkId,
-);
+export const BookmarkId = type('string').as<BookmarkId>();
 /**
  * Generate a unique {@link BookmarkId} for a newly created bookmark.
  *
@@ -140,9 +136,7 @@ export const generateBookmarkId = (): BookmarkId => generateId() as BookmarkId;
  * Prevents accidental mixing with message IDs or other string IDs.
  */
 export type ConversationId = Id & Brand<'ConversationId'>;
-export const ConversationId = type('string').pipe(
-	(s): ConversationId => s as ConversationId,
-);
+export const ConversationId = type('string').as<ConversationId>();
 /**
  * Generate a unique {@link ConversationId} for a new chat conversation.
  *
@@ -172,9 +166,7 @@ export const generateConversationId = (): ConversationId =>
  * Prevents accidental mixing with conversation IDs or other string IDs.
  */
 export type ChatMessageId = Id & Brand<'ChatMessageId'>;
-export const ChatMessageId = type('string').pipe(
-	(s): ChatMessageId => s as ChatMessageId,
-);
+export const ChatMessageId = type('string').as<ChatMessageId>();
 /**
  * Generate a unique {@link ChatMessageId} for a new chat message.
  *
@@ -207,9 +199,7 @@ export const generateChatMessageId = (): ChatMessageId =>
  * Prevents accidental mixing with plain strings, window IDs, or group IDs.
  */
 export type TabCompositeId = string & Brand<'TabCompositeId'>;
-export const TabCompositeId = type('string').pipe(
-	(s): TabCompositeId => s as TabCompositeId,
-);
+export const TabCompositeId = type('string').as<TabCompositeId>();
 
 /**
  * Device-scoped composite window ID: `${deviceId}_${windowId}`.
@@ -217,9 +207,7 @@ export const TabCompositeId = type('string').pipe(
  * Prevents accidental mixing with plain strings, tab IDs, or group IDs.
  */
 export type WindowCompositeId = string & Brand<'WindowCompositeId'>;
-export const WindowCompositeId = type('string').pipe(
-	(s): WindowCompositeId => s as WindowCompositeId,
-);
+export const WindowCompositeId = type('string').as<WindowCompositeId>();
 
 /**
  * Device-scoped composite group ID: `${deviceId}_${groupId}`.
@@ -227,9 +215,7 @@ export const WindowCompositeId = type('string').pipe(
  * Prevents accidental mixing with plain strings, tab IDs, or window IDs.
  */
 export type GroupCompositeId = string & Brand<'GroupCompositeId'>;
-export const GroupCompositeId = type('string').pipe(
-	(s): GroupCompositeId => s as GroupCompositeId,
-);
+export const GroupCompositeId = type('string').as<GroupCompositeId>();
 
 /**
  * Create a device-scoped composite tab ID: `${deviceId}_${tabId}`.

--- a/apps/tab-manager/src/lib/workspace.ts
+++ b/apps/tab-manager/src/lib/workspace.ts
@@ -17,6 +17,7 @@ import {
 	defineQuery,
 	defineTable,
 	defineWorkspace,
+	generateId,
 	type InferTableRow,
 } from '@epicenter/workspace';
 import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
@@ -85,6 +86,8 @@ export type SavedTabId = string & Brand<'SavedTabId'>;
 export const SavedTabId = type('string').pipe(
 	(s): SavedTabId => s as SavedTabId,
 );
+export const createSavedTabId = (): SavedTabId =>
+	generateId() as string as SavedTabId;
 
 /**
  * Branded bookmark ID — nanoid generated when a URL is bookmarked.
@@ -96,6 +99,8 @@ export type BookmarkId = string & Brand<'BookmarkId'>;
 export const BookmarkId = type('string').pipe(
 	(s): BookmarkId => s as BookmarkId,
 );
+export const createBookmarkId = (): BookmarkId =>
+	generateId() as string as BookmarkId;
 
 /**
  * Branded conversation ID — nanoid generated when a chat conversation is created.
@@ -107,6 +112,8 @@ export type ConversationId = string & Brand<'ConversationId'>;
 export const ConversationId = type('string').pipe(
 	(s): ConversationId => s as ConversationId,
 );
+export const createConversationId = (): ConversationId =>
+	generateId() as string as ConversationId;
 
 /**
  * Branded chat message ID — nanoid generated when a message is created.
@@ -117,6 +124,8 @@ export type ChatMessageId = string & Brand<'ChatMessageId'>;
 export const ChatMessageId = type('string').pipe(
 	(s): ChatMessageId => s as ChatMessageId,
 );
+export const createChatMessageId = (): ChatMessageId =>
+	generateId() as string as ChatMessageId;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Composite ID Types

--- a/apps/tab-manager/src/lib/workspace.ts
+++ b/apps/tab-manager/src/lib/workspace.ts
@@ -18,6 +18,7 @@ import {
 	defineTable,
 	defineWorkspace,
 	generateId,
+	type Id,
 	type InferTableRow,
 } from '@epicenter/workspace';
 import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
@@ -82,7 +83,7 @@ export const DeviceId = type('string').pipe((s): DeviceId => s as DeviceId);
  *
  * Prevents accidental mixing with composite tab IDs or other string IDs.
  */
-export type SavedTabId = string & Brand<'SavedTabId'>;
+export type SavedTabId = Id & Brand<'SavedTabId'>;
 export const SavedTabId = type('string').pipe(
 	(s): SavedTabId => s as SavedTabId,
 );
@@ -90,7 +91,7 @@ export const SavedTabId = type('string').pipe(
  * Generate a unique {@link SavedTabId} for a newly saved tab.
  *
  * Wraps `generateId()` with the branded cast so call sites never
- * need the error-prone `as string as SavedTabId` double-cast.
+ * need a manual cast.
  *
  * @example
  * ```typescript
@@ -103,7 +104,7 @@ export const SavedTabId = type('string').pipe(
  * ```
  */
 export const generateSavedTabId = (): SavedTabId =>
-	generateId() as string as SavedTabId;
+	generateId() as SavedTabId;
 
 /**
  * Branded bookmark ID — nanoid generated when a URL is bookmarked.
@@ -111,7 +112,7 @@ export const generateSavedTabId = (): SavedTabId =>
  * Unlike {@link SavedTabId}, bookmarks persist indefinitely—opening a
  * bookmarked URL does NOT delete the record.
  */
-export type BookmarkId = string & Brand<'BookmarkId'>;
+export type BookmarkId = Id & Brand<'BookmarkId'>;
 export const BookmarkId = type('string').pipe(
 	(s): BookmarkId => s as BookmarkId,
 );
@@ -119,7 +120,7 @@ export const BookmarkId = type('string').pipe(
  * Generate a unique {@link BookmarkId} for a newly created bookmark.
  *
  * Wraps `generateId()` with the branded cast so call sites never
- * need the error-prone `as string as BookmarkId` double-cast.
+ * need a manual cast.
  *
  * @example
  * ```typescript
@@ -132,7 +133,7 @@ export const BookmarkId = type('string').pipe(
  * ```
  */
 export const generateBookmarkId = (): BookmarkId =>
-	generateId() as string as BookmarkId;
+	generateId() as BookmarkId;
 
 /**
  * Branded conversation ID — nanoid generated when a chat conversation is created.
@@ -140,7 +141,7 @@ export const generateBookmarkId = (): BookmarkId =>
  * Used as the primary key for conversations and as a foreign key in chat messages.
  * Prevents accidental mixing with message IDs or other string IDs.
  */
-export type ConversationId = string & Brand<'ConversationId'>;
+export type ConversationId = Id & Brand<'ConversationId'>;
 export const ConversationId = type('string').pipe(
 	(s): ConversationId => s as ConversationId,
 );
@@ -148,7 +149,7 @@ export const ConversationId = type('string').pipe(
  * Generate a unique {@link ConversationId} for a new chat conversation.
  *
  * Wraps `generateId()` with the branded cast so call sites never
- * need the error-prone `as string as ConversationId` double-cast.
+ * need a manual cast.
  *
  * @example
  * ```typescript
@@ -165,14 +166,14 @@ export const ConversationId = type('string').pipe(
  * ```
  */
 export const generateConversationId = (): ConversationId =>
-	generateId() as string as ConversationId;
+	generateId() as ConversationId;
 
 /**
  * Branded chat message ID — nanoid generated when a message is created.
  *
  * Prevents accidental mixing with conversation IDs or other string IDs.
  */
-export type ChatMessageId = string & Brand<'ChatMessageId'>;
+export type ChatMessageId = Id & Brand<'ChatMessageId'>;
 export const ChatMessageId = type('string').pipe(
 	(s): ChatMessageId => s as ChatMessageId,
 );
@@ -180,7 +181,7 @@ export const ChatMessageId = type('string').pipe(
  * Generate a unique {@link ChatMessageId} for a new chat message.
  *
  * Wraps `generateId()` with the branded cast so call sites never
- * need the error-prone `as string as ChatMessageId` double-cast.
+ * need a manual cast.
  *
  * @example
  * ```typescript
@@ -196,7 +197,7 @@ export const ChatMessageId = type('string').pipe(
  * ```
  */
 export const generateChatMessageId = (): ChatMessageId =>
-	generateId() as string as ChatMessageId;
+	generateId() as ChatMessageId;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Composite ID Types

--- a/apps/tab-manager/src/lib/workspace.ts
+++ b/apps/tab-manager/src/lib/workspace.ts
@@ -103,8 +103,7 @@ export const SavedTabId = type('string').pipe(
  * });
  * ```
  */
-export const generateSavedTabId = (): SavedTabId =>
-	generateId() as SavedTabId;
+export const generateSavedTabId = (): SavedTabId => generateId() as SavedTabId;
 
 /**
  * Branded bookmark ID — nanoid generated when a URL is bookmarked.
@@ -132,8 +131,7 @@ export const BookmarkId = type('string').pipe(
  * });
  * ```
  */
-export const generateBookmarkId = (): BookmarkId =>
-	generateId() as BookmarkId;
+export const generateBookmarkId = (): BookmarkId => generateId() as BookmarkId;
 
 /**
  * Branded conversation ID — nanoid generated when a chat conversation is created.

--- a/docs/articles/same-name-for-type-and-value.md
+++ b/docs/articles/same-name-for-type-and-value.md
@@ -4,7 +4,7 @@ TypeScript has two parallel namespaces: one for types, one for values. Most peop
 
 ```typescript
 export type FileId = Guid & Brand<'FileId'>;
-export const FileId = type('string').pipe((s): FileId => s as FileId);
+export const FileId = type('string').as<FileId>();
 ```
 
 `FileId` here is two things at once. In type position it's a branded string. In value position it's an arktype schema that validates and brands at runtime. Same name, zero ambiguity, because TypeScript resolves which one you mean from context.
@@ -20,9 +20,7 @@ Here's the underrated part. When you hover over `FileId` in your IDE—whether y
  * Prevents accidental mixing with plain strings, window IDs, or group IDs.
  */
 export type TabCompositeId = string & Brand<'TabCompositeId'>;
-export const TabCompositeId = type('string').pipe(
-	(s): TabCompositeId => s as TabCompositeId,
-);
+export const TabCompositeId = type('string').as<TabCompositeId>();
 ```
 
 Hover over `TabCompositeId` anywhere in the codebase and you'll see that doc comment. Whether it's used as a type annotation on a function parameter, or as a runtime schema passed into `defineTable`—same hover, same docs.
@@ -97,9 +95,7 @@ Sometimes the value-side name is taken by a schema validator (for deserializatio
  * Prevents accidental mixing with plain strings, window IDs, or group IDs.
  */
 export type TabCompositeId = string & Brand<'TabCompositeId'>;
-export const TabCompositeId = type('string').pipe(
-	(s): TabCompositeId => s as TabCompositeId,
-);
+export const TabCompositeId = type('string').as<TabCompositeId>();
 
 /**
  * Create a device-scoped composite tab ID from its parts.
@@ -150,7 +146,7 @@ export const DateTimeString = {
 | Variant                 | Type Side                                | Value Side                                         | Constructor                          |
 | ----------------------- | ---------------------------------------- | -------------------------------------------------- | ------------------------------------ |
 | Constructor function    | `type Id = string & Brand<'Id'>`         | `function Id(s: string): Id`                       | Same as value side                   |
-| Validator + constructor | `type TabCompositeId = ... & Brand<...>` | `const TabCompositeId = type('string').pipe(...)`  | `function createTabCompositeId(...)` |
+| Validator + constructor | `type TabCompositeId = ... & Brand<...>` | `const TabCompositeId = type('string').as<…>()`    | `function createTabCompositeId(...)` |
 | Companion object        | `type DateTimeString = ... & Brand<...>` | `const DateTimeString = { parse, stringify, now }` | Methods on the companion             |
 
 ## When Not to Do This

--- a/docs/articles/same-name-for-type-and-value.md
+++ b/docs/articles/same-name-for-type-and-value.md
@@ -117,6 +117,22 @@ export function createTabCompositeId(
 Here `TabCompositeId` (the type) and `TabCompositeId` (the const) handle the two-namespace pattern—the type brands your strings, the const validates them in schema definitions. `createTabCompositeId` is the constructor that does real work: it takes the component parts and joins them. The `create` prefix makes intent obvious at call sites.
 
 This three-part split arises when the validator and the constructor have different jobs. The validator says "this string is already a `TabCompositeId`" (deserialization from Y.Doc). The constructor says "build me a new one from these parts." They don't collapse into one function because they serve different callers.
+### Shadowed type with a validator + generator
+
+The variant for IDs generated from scratch. The validator handles deserialization (Y.Doc reads), the generator wraps `generateId()` so the double-cast lives in exactly one place:
+
+````typescript
+export type SavedTabId = Id & Brand<'SavedTabId'>;
+export const SavedTabId = type('string').as<SavedTabId>();
+
+export const generateSavedTabId = (): SavedTabId =>
+  generateId() as SavedTabId;
+````
+
+Three parts, three jobs. The type brands the string. The const validates it in `defineTable()` schemas. The generator creates new ones. Call sites just write `generateSavedTabId()`—no casts, no imports of `generateId`.
+
+The `generate` prefix distinguishes these from `create` factories that compose from parts (like `createTabCompositeId(deviceId, tabId)`). `generate` means "new ID from scratch"; `create` means "assemble from inputs."
+
 
 ### Companion object
 
@@ -147,6 +163,7 @@ export const DateTimeString = {
 | ----------------------- | ---------------------------------------- | -------------------------------------------------- | ------------------------------------ |
 | Constructor function    | `type Id = string & Brand<'Id'>`         | `function Id(s: string): Id`                       | Same as value side                   |
 | Validator + constructor | `type TabCompositeId = ... & Brand<...>` | `const TabCompositeId = type('string').as<…>()`    | `function createTabCompositeId(...)` |
+| Validator + generator  | `type SavedTabId = Id & Brand<…>`        | `const SavedTabId = type('string').as<…>()` | `const generateSavedTabId = () => …`  |
 | Companion object        | `type DateTimeString = ... & Brand<...>` | `const DateTimeString = { parse, stringify, now }` | Methods on the companion             |
 
 ## When Not to Do This

--- a/docs/articles/three-part-branded-id-pattern.md
+++ b/docs/articles/three-part-branded-id-pattern.md
@@ -1,0 +1,57 @@
+# Three Parts, One ID: Type the Brand, Validate the Schema, Generate the Value
+
+Every generated branded ID in the workspace codebase follows the same three-part pattern. The type brands the string, the validator slots into `defineTable()` schemas, and the generator wraps `generateId()` so the cast lives in one place. A `SavedTabId` with all three parts looks like this:
+
+```typescript
+export type SavedTabId = Id & Brand<'SavedTabId'>;
+export const SavedTabId = type('string').as<SavedTabId>();
+export const generateSavedTabId = (): SavedTabId =>
+  generateId() as SavedTabId;
+```
+
+## Extend the base Id type to simplify the factory cast
+
+The base type extends `Id` (which is `string & Brand<'Id'>`) rather than bare `string`. This means the factory only needs a single cast (`generateId() as SavedTabId`) instead of the double cast (`generateId() as string as SavedTabId`). Since `generateId()` returns `Id`, the types are compatible without stripping the brand first.
+
+```typescript
+// Good: compatible with generateId()
+export type SavedTabId = Id & Brand<'SavedTabId'>;
+
+// Bad: requires double cast
+export type SavedTabId = string & Brand<'SavedTabId'>;
+```
+
+## Use .as<>() for zero-cost type assertions in Arktype
+
+Both `.as<>()` and `.pipe()` create the same runtime validator, but `.as<>()` is a zero-cost type assertion. Arktype knows the output type without a pipe function, which keeps the schema definition clean. The pipe version is three lines of ceremony for the same result.
+
+```typescript
+// Good: concise and zero-cost
+export const SavedTabId = type('string').as<SavedTabId>();
+
+// Bad: unnecessary ceremony
+export const SavedTabId = type('string').pipe((s): SavedTabId => s as SavedTabId);
+```
+
+## Distinguish generators from constructors with the generate prefix
+
+The codebase distinguishes generators from constructors. `generate*` means a new ID from scratch that calls `generateId()` or nanoid. `create*` means assembling an ID from inputs, like `createTabCompositeId(deviceId, tabId)`. Both are factory functions, but the prefix signals the difference.
+
+```typescript
+// New ID from scratch
+export const generateSavedTabId = (): SavedTabId => generateId() as SavedTabId;
+
+// Assembled from inputs
+export const createTabCompositeId = (deviceId: DeviceId, tabId: TabId): TabCompositeId =>
+  `${deviceId}:${tabId}` as TabCompositeId;
+```
+
+## Each part serves a specific purpose in the schema
+
+| Part | When to use |
+| --- | --- |
+| Type | Always |
+| Validator | When used in `defineTable()` or Arktype schemas |
+| Generator | When IDs are created at runtime |
+
+You can find the canonical implementation with 7 branded types and 4 generators in `apps/tab-manager/src/lib/workspace.ts`. Every ID in the system stays type-safe and validated at the boundary without leaking implementation details.

--- a/packages/filesystem/src/ids.ts
+++ b/packages/filesystem/src/ids.ts
@@ -9,7 +9,7 @@ import type { Brand } from 'wellcrafted/brand';
 
 /** Branded file identifier — a Guid that is specifically a file ID */
 export type FileId = Guid & Brand<'FileId'>;
-export const FileId = type('string').pipe((s): FileId => s as FileId);
+export const FileId = type('string').as<FileId>();
 
 /** Generate a new unique file identifier */
 export function generateFileId(): FileId {

--- a/specs/20260312T163132-tab-actions-cleanup.md
+++ b/specs/20260312T163132-tab-actions-cleanup.md
@@ -57,7 +57,7 @@ The double-cast `generateId() as string as SavedTabId` appeared in **7 sites acr
 
 **Resolution**: A separate spec (`20260312T180000-branded-id-convention.md`) standardizes the three-part branded ID convention:
 1. `type SavedTabId = Id & Brand<'SavedTabId'>` — branded type extending `Id` for single-cast
-2. `const SavedTabId = type('string').pipe(...)` — arktype validator for schema composition
+2. `const SavedTabId = type('string').as<SavedTabId>()` — arktype validator (zero-cost type cast)
 3. `const generateSavedTabId = (): SavedTabId => generateId() as SavedTabId` — factory with single-cast
 
 This applies to all branded IDs codebase-wide, not just `SavedTabId`.

--- a/specs/20260312T163132-tab-actions-cleanup.md
+++ b/specs/20260312T163132-tab-actions-cleanup.md
@@ -53,12 +53,12 @@ Pure deletion only. No behavior changes. Run `lsp_diagnostics` on both files aft
 
 **Deferred to dedicated spec.** Investigation revealed that `SavedTabId` is an arktype validator (`type('string').pipe(...)`) used in `defineTable()` schema composition — not a callable brand constructor. Calling `SavedTabId(value)` returns `SavedTabId | ArkErrors`, which isn't directly assignable.
 
-The double-cast `generateId() as string as SavedTabId` appears in **7 sites across 4 files** and is the established convention for all branded IDs (`BookmarkId`, `ConversationId`, `ChatMessageId`, etc.).
+The double-cast `generateId() as string as SavedTabId` appeared in **7 sites across 4 files**. This was later resolved by extending `Id` instead of `string` in the type definition (`Id & Brand<'SavedTabId'>`), eliminating the double-cast entirely.
 
 **Resolution**: A separate spec (`20260312T180000-branded-id-convention.md`) standardizes the three-part branded ID convention:
-1. `type SavedTabId = string & Brand<'SavedTabId'>` — the branded type
+1. `type SavedTabId = Id & Brand<'SavedTabId'>` — branded type extending `Id` for single-cast
 2. `const SavedTabId = type('string').pipe(...)` — arktype validator for schema composition
-3. `const generateSavedTabId = (): SavedTabId => generateId() as string as SavedTabId` — factory with `generate` prefix
+3. `const generateSavedTabId = (): SavedTabId => generateId() as SavedTabId` — factory with single-cast
 
 This applies to all branded IDs codebase-wide, not just `SavedTabId`.
 
@@ -336,6 +336,6 @@ All 10 items addressed. 8 committed as individual refactors, 1 skipped (deferred
 ### Key Discoveries
 
 1. **TS 5.5+ type predicate inference**—Manual type predicates on `.filter()` are unnecessary noise. TypeScript infers them automatically.
-2. **`SavedTabId` is an arktype validator**, not a simple brand—Calling it returns `SavedTabId | ArkErrors`. The double-cast `generateId() as string as SavedTabId` is the established convention across the codebase. A separate spec (`20260312T180000-branded-id-convention.md`) standardizes the three-part pattern: branded type + arktype validator + `create*` factory.
+2. **`SavedTabId` is an arktype validator**, not a simple brand—Calling it returns `SavedTabId | ArkErrors`. A separate spec (`20260312T180000-branded-id-convention.md`) standardizes the three-part pattern: branded type (extending `Id`) + arktype validator + `generate*` factory. The `Id & Brand<'SavedTabId'>` base type eliminates the double-cast.
 3. **`Tab.id` was already `TabCompositeId`**—The casts in quick-actions.ts were caused by helper functions (`findDuplicates`, `getUniqueDomains`) widening return types to `string`. Fixed upstream.
 4. **`toNativeIds()` and `compositeToNativeIds()`**—Extracted to replace 9 total inline occurrences of the map-filter-parse pattern across both files.

--- a/specs/20260312T163132-tab-actions-cleanup.md
+++ b/specs/20260312T163132-tab-actions-cleanup.md
@@ -1,0 +1,341 @@
+# Tab Actions & Quick Actions Cleanup
+
+Files under review:
+- `apps/tab-manager/src/lib/tab-actions.ts`
+- `apps/tab-manager/src/lib/quick-actions.ts`
+
+---
+
+## Tier 1 — Clear Wins (no debate, minimal risk)
+
+### 1. Remove unnecessary manual type predicates
+
+TS 5.5+ auto-infers `.filter()` type predicates. These are noise.
+
+**tab-actions.ts:119**
+```typescript
+// Before
+.filter((id): id is number => id !== undefined)
+
+// After
+.filter((id) => id !== undefined)
+```
+
+**quick-actions.ts:147, 199, 272** — same pattern.
+
+**quick-actions.ts:203**
+```typescript
+// Before
+.filter((op): op is { domain: string; nativeIds: number[] } => op !== null)
+
+// After
+.filter((op) => op !== null)
+```
+
+Pure deletion. Zero behavior change.
+
+<details>
+<summary>Prompt</summary>
+
+In `apps/tab-manager/src/lib/tab-actions.ts` and `apps/tab-manager/src/lib/quick-actions.ts`, remove all unnecessary manual type predicates from `.filter()` callbacks. TS 5.5+ infers these automatically.
+
+Specifically:
+- `tab-actions.ts:119` — `.filter((id): id is number => id !== undefined)` → `.filter((id) => id !== undefined)`
+- `quick-actions.ts:147, 199, 272` — same `: id is number` removal
+- `quick-actions.ts:203` — `.filter((op): op is { domain: string; nativeIds: number[] } => op !== null)` → `.filter((op) => op !== null)`
+
+Pure deletion only. No behavior changes. Run `lsp_diagnostics` on both files after to confirm no type errors.
+</details>
+
+---
+
+### 2. ~~Use `SavedTabId` brand constructor instead of double-cast~~ — SKIPPED
+
+**Deferred to dedicated spec.** Investigation revealed that `SavedTabId` is an arktype validator (`type('string').pipe(...)`) used in `defineTable()` schema composition — not a callable brand constructor. Calling `SavedTabId(value)` returns `SavedTabId | ArkErrors`, which isn't directly assignable.
+
+The double-cast `generateId() as string as SavedTabId` appears in **7 sites across 4 files** and is the established convention for all branded IDs (`BookmarkId`, `ConversationId`, `ChatMessageId`, etc.).
+
+**Resolution**: A separate spec (`20260312T180000-branded-id-convention.md`) standardizes the three-part branded ID convention:
+1. `type SavedTabId = string & Brand<'SavedTabId'>` — the branded type
+2. `const SavedTabId = type('string').pipe(...)` — arktype validator for schema composition
+3. `const createSavedTabId = (): SavedTabId => generateId() as string as SavedTabId` — factory with `create` prefix
+
+This applies to all branded IDs codebase-wide, not just `SavedTabId`.
+
+
+### 3. Replace `try/catch` with `tryAsync` in `executeActivateTab`
+
+**tab-actions.ts:68–73**
+```typescript
+// Before
+try {
+    await browser.tabs.update(id, { active: true });
+    return { activated: true };
+} catch {
+    return { activated: false };
+}
+
+// After
+const { error } = await tryAsync({
+    try: () => browser.tabs.update(id, { active: true }),
+    catch: () => Ok(undefined),
+});
+return { activated: !error };
+```
+
+Direct pattern swap. Matches every other Chrome API call in the file.
+
+<details>
+<summary>Prompt</summary>
+
+In `apps/tab-manager/src/lib/tab-actions.ts`, replace the `try/catch` block in `executeActivateTab` (lines 68–73) with `tryAsync`. The file already imports `tryAsync` and `Ok` from `wellcrafted/result`. Use:
+
+```typescript
+const { error } = await tryAsync({
+    try: () => browser.tabs.update(id, { active: true }),
+    catch: () => Ok(undefined),
+});
+return { activated: !error };
+```
+
+This replaces the `try { ... return { activated: true } } catch { return { activated: false } }` block. Run `lsp_diagnostics` after to confirm no type errors.
+</details>
+
+---
+
+### 4. Replace empty catch block with `tryAsync` in `sortAction`
+
+**quick-actions.ts:175–179**
+```typescript
+// Before
+try {
+    await browser.tabs.move(parsed.tabId, { index: i });
+} catch {
+    // Tab may not exist
+}
+
+// After
+await tryAsync({
+    try: () => browser.tabs.move(parsed.tabId, { index: i }),
+    catch: () => Ok(undefined),
+});
+```
+
+Eliminates an anti-pattern (empty catch block). Same graceful swallow, consistent style.
+
+<details>
+<summary>Prompt</summary>
+
+In `apps/tab-manager/src/lib/quick-actions.ts`, replace the `try/catch` with empty catch block in `sortAction.execute` (lines 175–179) with `tryAsync`. The file already imports `tryAsync` and `Ok` from `wellcrafted/result`. Use:
+
+```typescript
+await tryAsync({
+    try: () => browser.tabs.move(parsed.tabId, { index: i }),
+    catch: () => Ok(undefined),
+});
+```
+
+This replaces `try { await browser.tabs.move(...) } catch { // Tab may not exist }`. Run `lsp_diagnostics` after to confirm no type errors.
+</details>
+
+---
+
+### 5. Wrap unprotected Chrome API calls with `tryAsync`
+
+Two exported functions have zero error handling on browser APIs that can throw.
+
+**`executeOpenTab` (tab-actions.ts:54–55)**
+```typescript
+// Before
+const tab = await browser.tabs.create({ url });
+return { tabId: String(tab.id ?? -1) };
+
+// After
+const { data: tab, error } = await tryAsync({
+    try: () => browser.tabs.create({ url }),
+    catch: () => Ok(undefined),
+});
+if (error || !tab) return { tabId: String(-1) };
+return { tabId: String(tab.id ?? -1) };
+```
+
+**`executeGroupTabs` (tab-actions.ts:142–151)** — both `browser.tabs.group()` and `browser.tabGroups.update()` need wrapping. Exact shape TBD during implementation—main point is neither call is protected today.
+
+<details>
+<summary>Prompt</summary>
+
+In `apps/tab-manager/src/lib/tab-actions.ts`, wrap the unprotected Chrome API calls in `executeOpenTab` and `executeGroupTabs` with `tryAsync`. The file already imports `tryAsync` and `Ok` from `wellcrafted/result`.
+
+For `executeOpenTab` (lines 54–55), wrap `browser.tabs.create({ url })`:
+```typescript
+const { data: tab, error } = await tryAsync({
+    try: () => browser.tabs.create({ url }),
+    catch: () => Ok(undefined),
+});
+if (error || !tab) return { tabId: String(-1) };
+return { tabId: String(tab.id ?? -1) };
+```
+
+For `executeGroupTabs` (lines 142–151), wrap both `browser.tabs.group()` and `browser.tabGroups.update()` with `tryAsync`. Each call should gracefully handle failure — if `tabs.group()` fails, return a fallback `groupId: String(-1)`. If `tabGroups.update()` fails, swallow with `Ok(undefined)` (the group was already created, the title/color just didn't apply).
+
+Run `lsp_diagnostics` after to confirm no type errors.
+</details>
+
+---
+
+## Tier 2 — Solid improvements, small judgment calls
+
+### 6. Fix `tab.url!` non-null assertion in `executeSaveTabs`
+
+**tab-actions.ts:105**
+
+The filter checks `!!r.value.url` but TypeScript can't narrow through the `PromiseFulfilledResult` wrapper + `.map()` boundary. Options:
+
+- **Option A**: Combine filter + map into a single `.flatMap()` that extracts the url in the same step, eliminating the need for `!`.
+- **Option B**: Leave the `!` with an inline comment explaining why it's safe.
+
+Leaning toward A—it's cleaner and removes the assertion entirely.
+
+<details>
+<summary>Prompt</summary>
+
+In `apps/tab-manager/src/lib/tab-actions.ts`, fix the `tab.url!` non-null assertion on line 105 inside `executeSaveTabs`. The current code filters `PromiseFulfilledResult` entries for truthy `.url` and then maps, but TypeScript can't narrow through that boundary.
+
+Refactor the `results` → `validTabs` pipeline (lines 94–99) to use `.flatMap()` so the URL truthiness check and value extraction happen in the same step, eliminating the need for `!`. The resulting `validTabs` array entries should have `url: string` (not `string | undefined`).
+
+Don't change any other logic in the function. Run `lsp_diagnostics` after to confirm no type errors.
+</details>
+
+---
+
+### 7. Expand JSDoc on exported functions in `tab-actions.ts`
+
+Current docs are bare one-liners (`/** Close the specified tabs. */`). Per AGENTS.md, exported functions should document:
+- What the function does and when to use it
+- Parameter semantics (especially `deviceId` scoping)
+- Error behavior (what happens on Chrome API failure)
+- `@example` block
+
+Not urgent, but the file is a public API surface consumed by `workspace.ts`.
+
+<details>
+<summary>Prompt</summary>
+
+In `apps/tab-manager/src/lib/tab-actions.ts`, expand the JSDoc on all exported functions (`executeCloseTabs`, `executeOpenTab`, `executeActivateTab`, `executeSaveTabs`, `executeGroupTabs`, `executePinTabs`, `executeMuteTabs`, `executeReloadTabs`). Load the `documentation` skill first.
+
+Each function's JSDoc should include:
+- A description of what the function does and when it's called (these are Chrome API execution functions used by `.withActions()` mutation handlers in workspace.ts)
+- Parameter semantics — especially how `deviceId` scopes composite IDs to the local device
+- Error behavior — what happens when Chrome API calls fail (graceful swallow, partial success count, etc.)
+- An `@example` block with realistic usage
+
+Don't change any code logic — JSDoc only.
+</details>
+
+---
+
+### 8. Investigate `as TabCompositeId` casts in `quick-actions.ts`
+
+Lines 146, 173, 198, 271 all cast `tab.id as TabCompositeId`. Two possibilities:
+
+- **`browserState` already types `.id` as `TabCompositeId`** → casts are redundant noise, just remove them.
+- **`browserState` types `.id` as `string`** → the upstream type is wrong. Fix it there, then remove the casts.
+
+Needs a quick check of `browser-state.svelte.ts` to determine which case.
+
+<details>
+<summary>Prompt</summary>
+
+In `apps/tab-manager/src/lib/quick-actions.ts`, lines 146, 173, 198, and 271 all cast `tab.id as TabCompositeId`. Investigate whether this cast is necessary.
+
+1. Check the type of `tab.id` as returned by `browserState.tabsByWindow()` and `browserState.windows.flatMap(...)` in `$lib/state/browser-state.svelte.ts`.
+2. If `tab.id` is already typed as `TabCompositeId` → remove all four `as TabCompositeId` casts (they're redundant).
+3. If `tab.id` is typed as `string` → the upstream type in browser-state is wrong. Fix the type there so these casts become unnecessary, then remove them.
+
+Run `lsp_diagnostics` on both files after to confirm no type errors.
+</details>
+
+---
+
+## Tier 3 — More debatable (adds indirection or is a UX decision)
+
+### 9. Extract duplicated native ID conversion into a shared helper
+
+The pattern appears 6× in `tab-actions.ts`:
+```typescript
+const nativeIds = tabIds
+    .map((id) => nativeTabId(id, deviceId))
+    .filter((id) => id !== undefined);
+```
+
+And 3× in `quick-actions.ts` (using `parseTabId` instead):
+```typescript
+const nativeIds = tabIds
+    .map((tabId) => parseTabId(tabId as TabCompositeId)?.tabId)
+    .filter((id) => id !== undefined);
+```
+
+A helper like `toNativeIds(tabIds, deviceId)` would deduplicate both variants.
+
+**Counterargument**: The pattern is 3 lines, immediately readable, and each call site is self-contained. Extracting adds a layer of indirection for a trivial operation. The duplication is repetitive but not error-prone—there's no logic to drift.
+
+Include or skip based on taste.
+
+<details>
+<summary>Prompt</summary>
+
+In `apps/tab-manager/src/lib/tab-actions.ts`, extract the repeated native ID conversion pattern into a helper function. The pattern appears 6 times:
+
+```typescript
+const nativeIds = tabIds
+    .map((id) => nativeTabId(id, deviceId))
+    .filter((id) => id !== undefined);
+```
+
+Create a private helper `toNativeIds(tabIds: string[], deviceId: DeviceId): number[]` that encapsulates this, and replace all 6 occurrences.
+
+Then in `apps/tab-manager/src/lib/quick-actions.ts`, the same concept appears 3 times but using `parseTabId` directly:
+```typescript
+const nativeIds = tabIds
+    .map((tabId) => parseTabId(tabId as TabCompositeId)?.tabId)
+    .filter((id) => id !== undefined);
+```
+
+Create a similar helper `compositeToNativeIds(compositeIds: string[]): number[]` in quick-actions.ts (or export from tab-actions if it makes sense) and replace those 3 occurrences.
+
+Run `lsp_diagnostics` on both files after to confirm no type errors.
+</details>
+
+---
+
+### 10. `closeByDomainAction` silently picks the top domain
+
+Current behavior: finds whichever domain has the most open tabs and offers to close those. The comment says `This action needs a domain picker`. This is a UX decision, not a code quality fix—leaving it here for awareness but it's out of scope for a cleanup pass.
+
+---
+
+## Review
+
+### Summary
+
+All 10 items addressed. 8 committed as individual refactors, 1 skipped (deferred), 1 out of scope.
+
+| Item | Description | Status | Commit |
+|------|-------------|--------|--------|
+| 1 | Remove redundant type predicates | ✅ Committed | `f0b3f30b9` |
+| 2 | SavedTabId double-cast cleanup | ⏭️ Skipped | Deferred to `20260312T180000-branded-id-convention.md` |
+| 3 | `try/catch` → `tryAsync` in executeActivateTab | ✅ Committed | `06358567b` |
+| 4 | Empty catch → `tryAsync` in sortAction | ✅ Committed | `42ffd84b9` |
+| 5 | Wrap unprotected Chrome API calls | ✅ Committed | `88458d564` |
+| 6 | Eliminate `tab.url!` non-null assertion | ✅ Committed | `ebe2e01bf` |
+| 7 | Expand JSDoc on exported functions | ✅ Committed | `e11404b1f` |
+| 8 | Fix upstream types, remove TabCompositeId casts | ✅ Committed | `be8837030` |
+| 9 | Extract native ID conversion helpers | ✅ Committed | `fb6eb5522` |
+| 10 | `closeByDomainAction` domain picker | 🚫 Out of scope | UX decision, not code quality |
+
+### Key Discoveries
+
+1. **TS 5.5+ type predicate inference**—Manual type predicates on `.filter()` are unnecessary noise. TypeScript infers them automatically.
+2. **`SavedTabId` is an arktype validator**, not a simple brand—Calling it returns `SavedTabId | ArkErrors`. The double-cast `generateId() as string as SavedTabId` is the established convention across the codebase. A separate spec (`20260312T180000-branded-id-convention.md`) standardizes the three-part pattern: branded type + arktype validator + `create*` factory.
+3. **`Tab.id` was already `TabCompositeId`**—The casts in quick-actions.ts were caused by helper functions (`findDuplicates`, `getUniqueDomains`) widening return types to `string`. Fixed upstream.
+4. **`toNativeIds()` and `compositeToNativeIds()`**—Extracted to replace 9 total inline occurrences of the map-filter-parse pattern across both files.

--- a/specs/20260312T163132-tab-actions-cleanup.md
+++ b/specs/20260312T163132-tab-actions-cleanup.md
@@ -58,7 +58,7 @@ The double-cast `generateId() as string as SavedTabId` appears in **7 sites acro
 **Resolution**: A separate spec (`20260312T180000-branded-id-convention.md`) standardizes the three-part branded ID convention:
 1. `type SavedTabId = string & Brand<'SavedTabId'>` — the branded type
 2. `const SavedTabId = type('string').pipe(...)` — arktype validator for schema composition
-3. `const createSavedTabId = (): SavedTabId => generateId() as string as SavedTabId` — factory with `create` prefix
+3. `const generateSavedTabId = (): SavedTabId => generateId() as string as SavedTabId` — factory with `generate` prefix
 
 This applies to all branded IDs codebase-wide, not just `SavedTabId`.
 

--- a/specs/20260312T180000-branded-id-convention.md
+++ b/specs/20260312T180000-branded-id-convention.md
@@ -22,10 +22,8 @@ import { generateId, type Id } from '@epicenter/workspace';
 // 1. TYPE — extends Id for single-cast generation
 export type SavedTabId = Id & Brand<'SavedTabId'>;
 
-// 2. VALIDATOR — arktype pipe for schema composition in defineTable()
-export const SavedTabId = type('string').pipe(
-    (s): SavedTabId => s as SavedTabId,
-);
+// 2. VALIDATOR — type-only cast via .as<T>() (zero runtime overhead)
+export const SavedTabId = type('string').as<SavedTabId>();
 
 // 3. FACTORY — generate* prefix, single-cast thanks to Id base
 export const generateSavedTabId = (): SavedTabId =>

--- a/specs/20260312T180000-branded-id-convention.md
+++ b/specs/20260312T180000-branded-id-convention.md
@@ -88,27 +88,33 @@ Not every branded type needs all three. Path types like `AbsolutePath`, `Project
 
 ### Wave 1: Add factory functions (workspace.ts)
 
-- [ ] Add `createSavedTabId` to `apps/tab-manager/src/lib/workspace.ts`
-- [ ] Add `createBookmarkId` to `apps/tab-manager/src/lib/workspace.ts`
-- [ ] Add `createConversationId` to `apps/tab-manager/src/lib/workspace.ts`
-- [ ] Add `createChatMessageId` to `apps/tab-manager/src/lib/workspace.ts`
+- [x] Add `createSavedTabId` to `apps/tab-manager/src/lib/workspace.ts`
+- [x] Add `createBookmarkId` to `apps/tab-manager/src/lib/workspace.ts`
+- [x] Add `createConversationId` to `apps/tab-manager/src/lib/workspace.ts`
+- [x] Add `createChatMessageId` to `apps/tab-manager/src/lib/workspace.ts`
 
 ### Wave 2: Replace double-casts at call sites
 
-- [ ] `apps/tab-manager/src/lib/tab-actions.ts:104` — `generateId() as string as SavedTabId` → `createSavedTabId()`
-- [ ] `apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts:93` — same
-- [ ] `apps/tab-manager/src/lib/state/bookmark-state.svelte.ts:84` — `generateId() as string as BookmarkId` → `createBookmarkId()`
-- [ ] `apps/tab-manager/src/lib/state/chat-state.svelte.ts:87` — `generateId() as string as ConversationId` → `createConversationId()`
-- [ ] `apps/tab-manager/src/lib/state/chat-state.svelte.ts:361` — `generateId() as string as ChatMessageId` → `createChatMessageId()`
+- [x] `apps/tab-manager/src/lib/tab-actions.ts:179` — `generateId() as string as SavedTabId` → `createSavedTabId()`
+- [x] `apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts:93` — same
+- [x] `apps/tab-manager/src/lib/state/bookmark-state.svelte.ts:84` — `generateId() as string as BookmarkId` → `createBookmarkId()`
+- [x] `apps/tab-manager/src/lib/state/chat-state.svelte.ts:87` — `generateConversationId` wrapper removed, replaced with `createConversationId()`
+- [x] `apps/tab-manager/src/lib/state/chat-state.svelte.ts:361` — `generateId() as string as ChatMessageId` → `createChatMessageId()`
 
 ### Wave 3: Update skills and documentation
 
-- [ ] Update `.agents/skills/typescript/SKILL.md` — branded types section to document `create*` factory convention
-- [ ] Update `.agents/skills/workspace-api/SKILL.md` — branded table IDs section to use factories instead of double-casts
-- [ ] Update JSDoc on each factory function with `@example` blocks
+- [x] Update `.agents/skills/typescript/SKILL.md` — branded types section to document `create*` factory convention
+- [x] Update `.agents/skills/workspace-api/SKILL.md` — branded table IDs section to use factories instead of double-casts
+- [x] Update JSDoc on each factory function with `@example` blocks
 
 ---
 
 ## Review
 
-_To be filled after implementation._
+Three commits landed:
+
+1. `feat(tab-manager): add create* factory functions for branded ID types` — added `generateId` import and 4 factories (`createSavedTabId`, `createBookmarkId`, `createConversationId`, `createChatMessageId`) co-located with their type+validator pairs in `workspace.ts`.
+2. `refactor(tab-manager): replace double-cast ID generation with create* factories` — replaced all 5 double-cast call sites across 4 files. Removed the local `generateConversationId` wrapper in `chat-state.svelte.ts` and eliminated all `generateId` imports from consumer files.
+3. `docs(tab-manager): add JSDoc with @example blocks to create* ID factories` — each factory has a description, `{@link}` to its branded type, and a realistic `@example` block.
+
+4. `docs(skills): update typescript and workspace-api skills with branded ID factory convention` — completed the truncated three-part pattern section in typescript skill; refined the workspace-api skill's pattern section with factory-first examples and call-site guidance.

--- a/specs/20260312T180000-branded-id-convention.md
+++ b/specs/20260312T180000-branded-id-convention.md
@@ -27,8 +27,8 @@ export const SavedTabId = type('string').pipe(
     (s): SavedTabId => s as SavedTabId,
 );
 
-// 3. FACTORY — create* prefix, encapsulates the cast
-export const createSavedTabId = (): SavedTabId =>
+// 3. FACTORY — generate* prefix, encapsulates the cast
+export const generateSavedTabId = (): SavedTabId =>
     generateId() as string as SavedTabId;
 ```
 
@@ -38,7 +38,7 @@ export const createSavedTabId = (): SavedTabId =>
 |------|--------|---------|
 | Type | PascalCase | `SavedTabId` |
 | Validator | Same PascalCase (TypeScript allows type+value same name) | `SavedTabId` |
-| Factory | `create` + PascalCase | `createSavedTabId` |
+| Factory | `generate` + PascalCase | `generateSavedTabId` |
 
 ### When Each Part Is Needed
 
@@ -88,18 +88,18 @@ Not every branded type needs all three. Path types like `AbsolutePath`, `Project
 
 ### Wave 1: Add factory functions (workspace.ts)
 
-- [x] Add `createSavedTabId` to `apps/tab-manager/src/lib/workspace.ts`
-- [x] Add `createBookmarkId` to `apps/tab-manager/src/lib/workspace.ts`
-- [x] Add `createConversationId` to `apps/tab-manager/src/lib/workspace.ts`
-- [x] Add `createChatMessageId` to `apps/tab-manager/src/lib/workspace.ts`
+- [x] Add `generateSavedTabId` to `apps/tab-manager/src/lib/workspace.ts`
+- [x] Add `generateBookmarkId` to `apps/tab-manager/src/lib/workspace.ts`
+- [x] Add `generateConversationId` to `apps/tab-manager/src/lib/workspace.ts`
+- [x] Add `generateChatMessageId` to `apps/tab-manager/src/lib/workspace.ts`
 
 ### Wave 2: Replace double-casts at call sites
 
-- [x] `apps/tab-manager/src/lib/tab-actions.ts:179` — `generateId() as string as SavedTabId` → `createSavedTabId()`
+- [x] `apps/tab-manager/src/lib/tab-actions.ts:179` — `generateId() as string as SavedTabId` → `generateSavedTabId()`
 - [x] `apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts:93` — same
-- [x] `apps/tab-manager/src/lib/state/bookmark-state.svelte.ts:84` — `generateId() as string as BookmarkId` → `createBookmarkId()`
-- [x] `apps/tab-manager/src/lib/state/chat-state.svelte.ts:87` — `generateConversationId` wrapper removed, replaced with `createConversationId()`
-- [x] `apps/tab-manager/src/lib/state/chat-state.svelte.ts:361` — `generateId() as string as ChatMessageId` → `createChatMessageId()`
+- [x] `apps/tab-manager/src/lib/state/bookmark-state.svelte.ts:84` — `generateId() as string as BookmarkId` → `generateBookmarkId()`
+- [x] `apps/tab-manager/src/lib/state/chat-state.svelte.ts:87` — `generateConversationId` wrapper removed, replaced with `generateConversationId()`
+- [x] `apps/tab-manager/src/lib/state/chat-state.svelte.ts:361` — `generateId() as string as ChatMessageId` → `generateChatMessageId()`
 
 ### Wave 3: Update skills and documentation
 
@@ -113,8 +113,8 @@ Not every branded type needs all three. Path types like `AbsolutePath`, `Project
 
 Three commits landed:
 
-1. `feat(tab-manager): add create* factory functions for branded ID types` — added `generateId` import and 4 factories (`createSavedTabId`, `createBookmarkId`, `createConversationId`, `createChatMessageId`) co-located with their type+validator pairs in `workspace.ts`.
-2. `refactor(tab-manager): replace double-cast ID generation with create* factories` — replaced all 5 double-cast call sites across 4 files. Removed the local `generateConversationId` wrapper in `chat-state.svelte.ts` and eliminated all `generateId` imports from consumer files.
-3. `docs(tab-manager): add JSDoc with @example blocks to create* ID factories` — each factory has a description, `{@link}` to its branded type, and a realistic `@example` block.
+1. `feat(tab-manager): add generate* factory functions for branded ID types` — added `generateId` import and 4 factories (`generateSavedTabId`, `generateBookmarkId`, `generateConversationId`, `generateChatMessageId`) co-located with their type+validator pairs in `workspace.ts`.
+2. `refactor(tab-manager): replace double-cast ID generation with generate* factories` — replaced all 5 double-cast call sites across 4 files. Removed the local `generateConversationId` wrapper in `chat-state.svelte.ts` and eliminated all `generateId` imports from consumer files.
+3. `docs(tab-manager): add JSDoc with @example blocks to generate* ID factories` — each factory has a description, `{@link}` to its branded type, and a realistic `@example` block.
 
 4. `docs(skills): update typescript and workspace-api skills with branded ID factory convention` — completed the truncated three-part pattern section in typescript skill; refined the workspace-api skill's pattern section with factory-first examples and call-site guidance.

--- a/specs/20260312T180000-branded-id-convention.md
+++ b/specs/20260312T180000-branded-id-convention.md
@@ -117,3 +117,14 @@ Six commits landed:
 4. `docs(skills): update typescript and workspace-api skills with branded ID factory convention` — documented the three-part pattern in both skills.
 5. `refactor(tab-manager): rename create* ID factories to generate* for cross-package consistency` — aligned with `packages/filesystem` naming convention.
 6. `refactor(tab-manager): extend Id instead of string in branded types to eliminate double-cast` — changed type definitions from `string & Brand<'*'>` to `Id & Brand<'*'>`, enabling single-cast `generateId() as *Id` inside factories. Matches the pattern in `packages/filesystem/src/ids.ts`.
+
+Additional changes (session 2):
+
+7. `refactor(tab-manager): replace .pipe() validators with .as<>() for zero-cost type casts` — all branded ID validators in `workspace.ts` updated from `type('string').pipe((s): T => s as T)` to `type('string').as<T>()`.
+8. `docs(skills): update typescript and workspace-api skills with generate* + .as<>() convention` — skills now show `Id & Brand<>`, `.as<>()`, and `generate*` as the canonical pattern.
+9. `docs(articles): add validator+generator variant to same-name-for-type-and-value.md` — added the fourth same-name variant (type + validator + generator) with summary table row.
+10. `docs(articles): create three-part-branded-id-pattern.md` — standalone article documenting the type + validator + generator convention with rationale for `Id &` vs `string &`, `.as<>()` vs `.pipe()`, and `generate*` vs `create*`.
+
+### Naming Decision
+
+The spec originally proposed `create*` prefix for factories. During implementation, we chose `generate*` instead to match the existing codebase convention (`generateId`, `generateGuid`, `generateFileId`, `generateRowId`, `generateColumnId`). The semantic distinction: `generate*` = new ID from scratch, `create*` = assemble from inputs.

--- a/specs/20260312T180000-branded-id-convention.md
+++ b/specs/20260312T180000-branded-id-convention.md
@@ -4,11 +4,11 @@
 
 Branded ID types in the codebase lack a consistent construction pattern. Currently:
 
-- The **type** (`type SavedTabId = string & Brand<'SavedTabId'>`) exists everywhere
+- The **type** (`type SavedTabId = string & Brand<'SavedTabId'>`) used `string` as the base—requiring a double-cast to convert from `Id`
 - The **arktype validator** (`const SavedTabId = type('string').pipe(...)`) exists for types used in `defineTable()` schemas
 - **No factory function** exists—every call site uses the ugly double-cast: `generateId() as string as SavedTabId`
 
-The double-cast is error-prone (easy to forget the intermediate `as string`), inconsistent with `packages/filesystem` which already has factories (`generateRowId`, `generateColumnId`), and scattered across 7+ call sites.
+The double-cast existed because `Id` (`string & Brand<'Id'>`) and `SavedTabId` (`string & Brand<'SavedTabId'>`) have incompatible brands. By extending `Id` instead of `string`, the cast becomes single-step. Combined with factory functions (matching `packages/filesystem`'s existing convention), the cast is fully encapsulated.
 
 ## Convention
 
@@ -17,19 +17,19 @@ Every branded ID type that is generated at runtime MUST follow the three-part pa
 ```typescript
 import { type Brand } from 'wellcrafted/brand';
 import { type } from 'arktype';
-import { generateId } from '@epicenter/workspace';
+import { generateId, type Id } from '@epicenter/workspace';
 
-// 1. TYPE — the branded type itself
-export type SavedTabId = string & Brand<'SavedTabId'>;
+// 1. TYPE — extends Id for single-cast generation
+export type SavedTabId = Id & Brand<'SavedTabId'>;
 
 // 2. VALIDATOR — arktype pipe for schema composition in defineTable()
 export const SavedTabId = type('string').pipe(
     (s): SavedTabId => s as SavedTabId,
 );
 
-// 3. FACTORY — generate* prefix, encapsulates the cast
+// 3. FACTORY — generate* prefix, single-cast thanks to Id base
 export const generateSavedTabId = (): SavedTabId =>
-    generateId() as string as SavedTabId;
+    generateId() as SavedTabId;
 ```
 
 ### Naming Rules
@@ -111,10 +111,11 @@ Not every branded type needs all three. Path types like `AbsolutePath`, `Project
 
 ## Review
 
-Three commits landed:
+Six commits landed:
 
-1. `feat(tab-manager): add generate* factory functions for branded ID types` — added `generateId` import and 4 factories (`generateSavedTabId`, `generateBookmarkId`, `generateConversationId`, `generateChatMessageId`) co-located with their type+validator pairs in `workspace.ts`.
-2. `refactor(tab-manager): replace double-cast ID generation with generate* factories` — replaced all 5 double-cast call sites across 4 files. Removed the local `generateConversationId` wrapper in `chat-state.svelte.ts` and eliminated all `generateId` imports from consumer files.
-3. `docs(tab-manager): add JSDoc with @example blocks to generate* ID factories` — each factory has a description, `{@link}` to its branded type, and a realistic `@example` block.
-
-4. `docs(skills): update typescript and workspace-api skills with branded ID factory convention` — completed the truncated three-part pattern section in typescript skill; refined the workspace-api skill's pattern section with factory-first examples and call-site guidance.
+1. `feat(tab-manager): add generate* factory functions for branded ID types` — added `generateId` import and 4 factories co-located with their type+validator pairs in `workspace.ts`.
+2. `refactor(tab-manager): replace double-cast ID generation with generate* factories` — replaced all 5 double-cast call sites across 4 files. Removed the local `generateConversationId` wrapper in `chat-state.svelte.ts`.
+3. `docs(tab-manager): add JSDoc with @example blocks to generate* ID factories` — each factory has a description, `{@link}`, and a realistic `@example` block.
+4. `docs(skills): update typescript and workspace-api skills with branded ID factory convention` — documented the three-part pattern in both skills.
+5. `refactor(tab-manager): rename create* ID factories to generate* for cross-package consistency` — aligned with `packages/filesystem` naming convention.
+6. `refactor(tab-manager): extend Id instead of string in branded types to eliminate double-cast` — changed type definitions from `string & Brand<'*'>` to `Id & Brand<'*'>`, enabling single-cast `generateId() as *Id` inside factories. Matches the pattern in `packages/filesystem/src/ids.ts`.

--- a/specs/20260312T180000-branded-id-convention.md
+++ b/specs/20260312T180000-branded-id-convention.md
@@ -1,0 +1,114 @@
+# Branded ID Convention: Three-Part Pattern
+
+## Problem
+
+Branded ID types in the codebase lack a consistent construction pattern. Currently:
+
+- The **type** (`type SavedTabId = string & Brand<'SavedTabId'>`) exists everywhere
+- The **arktype validator** (`const SavedTabId = type('string').pipe(...)`) exists for types used in `defineTable()` schemas
+- **No factory function** exists—every call site uses the ugly double-cast: `generateId() as string as SavedTabId`
+
+The double-cast is error-prone (easy to forget the intermediate `as string`), inconsistent with `packages/filesystem` which already has factories (`generateRowId`, `generateColumnId`), and scattered across 7+ call sites.
+
+## Convention
+
+Every branded ID type that is generated at runtime MUST follow the three-part pattern:
+
+```typescript
+import { type Brand } from 'wellcrafted/brand';
+import { type } from 'arktype';
+import { generateId } from '@epicenter/workspace';
+
+// 1. TYPE — the branded type itself
+export type SavedTabId = string & Brand<'SavedTabId'>;
+
+// 2. VALIDATOR — arktype pipe for schema composition in defineTable()
+export const SavedTabId = type('string').pipe(
+    (s): SavedTabId => s as SavedTabId,
+);
+
+// 3. FACTORY — create* prefix, encapsulates the cast
+export const createSavedTabId = (): SavedTabId =>
+    generateId() as string as SavedTabId;
+```
+
+### Naming Rules
+
+| Part | Naming | Example |
+|------|--------|---------|
+| Type | PascalCase | `SavedTabId` |
+| Validator | Same PascalCase (TypeScript allows type+value same name) | `SavedTabId` |
+| Factory | `create` + PascalCase | `createSavedTabId` |
+
+### When Each Part Is Needed
+
+| Part | Required When |
+|------|--------------|
+| Type | Always — this IS the branded type |
+| Validator | Used in `defineTable()` or other arktype schemas |
+| Factory | IDs are generated at runtime (via `generateId()` or similar) |
+
+Not every branded type needs all three. Path types like `AbsolutePath`, `ProjectDir` are cast from external sources—they need only the type. Composite IDs like `TabCompositeId` already have `createTabCompositeId()` factories.
+
+---
+
+## Inventory of Branded IDs Requiring `create*` Factories
+
+### apps/tab-manager/src/lib/workspace.ts
+
+| Type | Has Type | Has Validator | Has Factory | Needs Factory | Call Sites |
+|------|----------|---------------|-------------|---------------|------------|
+| `DeviceId` | ✅ | ✅ | ❌ | ❌ (set from external source) | — |
+| `SavedTabId` | ✅ | ✅ | ❌ | ✅ | tab-actions.ts:104, saved-tab-state.svelte.ts:93 |
+| `BookmarkId` | ✅ | ✅ | ❌ | ✅ | bookmark-state.svelte.ts:84 |
+| `ConversationId` | ✅ | ✅ | ❌ | ✅ | chat-state.svelte.ts:87 |
+| `ChatMessageId` | ✅ | ✅ | ❌ | ✅ | chat-state.svelte.ts:361 |
+| `TabCompositeId` | ✅ | ✅ | ✅ (`createTabCompositeId`) | — | Already done |
+| `WindowCompositeId` | ✅ | ✅ | ✅ (`createWindowCompositeId`) | — | Already done |
+| `GroupCompositeId` | ✅ | ✅ | ✅ (`createGroupCompositeId`) | — | Already done |
+
+### packages/filesystem/src/ids.ts (already follows this convention)
+
+| Type | Has Type | Has Validator | Has Factory |
+|------|----------|---------------|-------------|
+| `FileId` | ✅ | ✅ | ✅ (`generateFileId`) |
+| `RowId` | ✅ | ❌ | ✅ (`generateRowId`) |
+| `ColumnId` | ✅ | ❌ | ✅ (`generateColumnId`) |
+
+### packages/workspace/src/shared/id.ts (already follows this convention)
+
+| Type | Has Type | Has Validator | Has Factory |
+|------|----------|---------------|-------------|
+| `Id` | ✅ | ❌ | ✅ (`generateId`) |
+| `Guid` | ✅ | ❌ | ✅ (`generateGuid`) |
+
+---
+
+## Implementation Plan
+
+### Wave 1: Add factory functions (workspace.ts)
+
+- [ ] Add `createSavedTabId` to `apps/tab-manager/src/lib/workspace.ts`
+- [ ] Add `createBookmarkId` to `apps/tab-manager/src/lib/workspace.ts`
+- [ ] Add `createConversationId` to `apps/tab-manager/src/lib/workspace.ts`
+- [ ] Add `createChatMessageId` to `apps/tab-manager/src/lib/workspace.ts`
+
+### Wave 2: Replace double-casts at call sites
+
+- [ ] `apps/tab-manager/src/lib/tab-actions.ts:104` — `generateId() as string as SavedTabId` → `createSavedTabId()`
+- [ ] `apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts:93` — same
+- [ ] `apps/tab-manager/src/lib/state/bookmark-state.svelte.ts:84` — `generateId() as string as BookmarkId` → `createBookmarkId()`
+- [ ] `apps/tab-manager/src/lib/state/chat-state.svelte.ts:87` — `generateId() as string as ConversationId` → `createConversationId()`
+- [ ] `apps/tab-manager/src/lib/state/chat-state.svelte.ts:361` — `generateId() as string as ChatMessageId` → `createChatMessageId()`
+
+### Wave 3: Update skills and documentation
+
+- [ ] Update `.agents/skills/typescript/SKILL.md` — branded types section to document `create*` factory convention
+- [ ] Update `.agents/skills/workspace-api/SKILL.md` — branded table IDs section to use factories instead of double-casts
+- [ ] Update JSDoc on each factory function with `@example` blocks
+
+---
+
+## Review
+
+_To be filled after implementation._


### PR DESCRIPTION
This PR started as a targeted performance pass on tab-manager's Chrome API calls and evolved into a broader hardening effort—culminating in a new convention for branded ID generation that eliminates scattered type casts entirely.

The work falls into two arcs: **hardening tab-actions** (error handling, type safety, parallelization) and **establishing the branded ID factory convention** (type-safe factories with zero double-casts).

---

### Arc 1: Hardening tab-actions

The tab-actions module had several patterns that could silently fail or were unnecessarily sequential:

```typescript
// BEFORE: unprotected Chrome API calls, sequential execution
const tab = await browser.tabs.get(nativeId);     // throws on invalid tab
const tabs = [];
for (const id of ids) {
  tabs.push(await browser.tabs.get(id));           // sequential, one at a time
}
```

```typescript
// AFTER: tryAsync wrapping, parallel execution
const [tab] = await tryAsync(() => browser.tabs.get(nativeId));
const results = await Promise.allSettled(
  nativeIds.map((id) => browser.tabs.get(id)),     // parallel
);
```

Changes in this arc:
- Wrap all unprotected Chrome API calls with `tryAsync`
- Replace empty `catch {}` blocks with `tryAsync` for proper error propagation
- Parallelize `save-tabs` and `save-all` actions via `Promise.allSettled`
- Eliminate non-null assertions by restructuring with `.flatMap()`
- Remove redundant type predicates from `.filter()` calls
- Fix upstream types to eliminate `TabCompositeId` casts
- Extract `nativeTabId()` and `nativeTabIds()` helpers
- Expand JSDoc on all exported functions

### Arc 2: Branded ID factory convention

Tab-manager defines branded ID types like `SavedTabId`, `BookmarkId`, `ConversationId`, and `ChatMessageId`. Previously, generating new instances required a double-cast scattered across call sites:

```typescript
// BEFORE: double-cast at every call site
type SavedTabId = string & Brand<'SavedTabId'>;
const id = generateId() as string as SavedTabId;
```

The double-cast existed because `generateId()` returns `Id` (which is `string & Brand<'Id'>`), and `string & Brand<'SavedTabId'>` has an incompatible brand. You had to unbrand first (`as string`), then rebrand (`as SavedTabId`).

The fix has two parts: **extend `Id` instead of `string`** in the type definition, and **encapsulate the cast in a factory**.

```typescript
// AFTER: Id-based type + factory = single-cast, fully encapsulated
type SavedTabId = Id & Brand<'SavedTabId'>;

export const generateSavedTabId = (): SavedTabId =>
  generateId() as SavedTabId;  // single-cast — Id is a supertype
```

```typescript
// Call sites are clean
const id = generateSavedTabId();
```

The type algebra:

```
Id           = string & Brand<'Id'>
SavedTabId   = Id & Brand<'SavedTabId'>
             = string & Brand<'Id'> & Brand<'SavedTabId'>

Id → SavedTabId is narrowing (adding a brand), so TypeScript allows single-cast.
```

### Arc 3: Replace `.pipe()` cast-only validators with `.as<T>()`

The arktype validators for branded types were using `.pipe()` to run a function that did nothing at runtime:

```typescript
// BEFORE: runtime function call for a compile-time operation
export const SavedTabId = type('string').pipe(
  (s): SavedTabId => s as SavedTabId,
);
```

Arktype's `.as<T>()` is a `@typenoop` — it changes the inferred output type without adding any runtime behavior. Same validation, same type inference, zero function call overhead:

```typescript
// AFTER: type-only cast, zero runtime overhead
export const SavedTabId = type('string').as<SavedTabId>();
```

Replaced 9 validators in tab-manager and 1 in filesystem. `.or()` and all other arktype methods remain fully available on the result.

```
┌─────────────────────────────────────────────────────────────┐
│  The Three-Part Pattern (final form)                        │
├─────────────────────────────────────────────────────────────┤
│                                                             │
│  1. TYPE       export type SavedTabId = Id & Brand<…>       │
│  2. VALIDATOR  export const SavedTabId = type('string')     │
│                  .as<SavedTabId>()                          │
│  3. FACTORY    export const generateSavedTabId = (): … =>   │
│                  generateId() as SavedTabId                 │
│                                                             │
│  Type extends Id → single-cast in factory.                  │
│  Validator uses .as<T>() → zero runtime overhead.           │
│  Consumers import the factory; casts are invisible.         │
│                                                             │
└─────────────────────────────────────────────────────────────┘
```

### What about `as string as ChatMessageId` in chat-state?

Two casts remain in `chat-state.svelte.ts`. These brand *external* strings from TanStack AI's `UIMessage.id`—they're not generating new IDs, so a `generate*` factory doesn't apply. They're a different pattern (branding foreign strings) and are correctly left as-is.

### Skills and documentation updated

The `typescript` and `workspace-api` agent skills, the `same-name-for-type-and-value` doc article, and both specs now document the final three-part pattern with `Id & Brand<…>` types and `.as<T>()` validators.