### PR TITLE
feat(tab-manager): progressive tool trust for destructive AI actions

### DIFF
--- a/apps/tab-manager/src/lib/components/chat/ToolCallPart.svelte
+++ b/apps/tab-manager/src/lib/components/chat/ToolCallPart.svelte
@@ -2,6 +2,11 @@
 	import { Badge } from '@epicenter/ui/badge';
 	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import WrenchIcon from '@lucide/svelte/icons/wrench';
+	import { Button } from '@epicenter/ui/button';
+	import ShieldAlertIcon from '@lucide/svelte/icons/shield-alert';
+	import ShieldCheckIcon from '@lucide/svelte/icons/shield-check';
+	import { toolTrustState } from '$lib/state/tool-trust.svelte';
+	import { aiChatState } from '$lib/state/chat-state.svelte';
 	import type { ToolCallPart as TanStackToolCallPart } from '@tanstack/ai-client';
 	import { workspaceToolTitles, type WorkspaceTools } from '$lib/workspace';
 	import CollapsibleSection from '../CollapsibleSection.svelte';
@@ -22,6 +27,38 @@
 		workspaceToolTitles[part.name] ??
 			part.name.replace(/_/g, ' ').replace(/^\w/, (c) => c.toUpperCase()),
 	);
+	const isApprovalRequested = $derived(
+		(part as { state?: string }).state === 'approval-requested',
+	);
+	const approval = $derived(
+		(
+			part as {
+				approval?: { id: string; needsApproval: boolean; approved?: boolean };
+			}
+		).approval,
+	);
+
+	$effect(() => {
+		if (isApprovalRequested && approval?.id && toolTrustState.shouldAutoApprove(part.name)) {
+			aiChatState.active?.approveToolCall(approval.id, true);
+		}
+	});
+
+	function handleAllow() {
+		if (!approval?.id) return;
+		aiChatState.active?.approveToolCall(approval.id, true);
+	}
+
+	function handleAlwaysAllow() {
+		if (!approval?.id) return;
+		toolTrustState.set(part.name, 'always');
+		aiChatState.active?.approveToolCall(approval.id, true);
+	}
+
+	function handleDeny() {
+		if (!approval?.id) return;
+		aiChatState.active?.approveToolCall(approval.id, false);
+	}
 	const badgeVariant = $derived.by(() => {
 		if (isFailed) return 'status.failed';
 		if (isRunning) return 'status.running';
@@ -37,13 +74,35 @@
 
 <div class="flex flex-col gap-1 py-1">
 	<div class="flex items-center gap-1.5">
-		{#if isRunning}
+		{#if isApprovalRequested && !toolTrustState.shouldAutoApprove(part.name)}
+			<ShieldAlertIcon class="size-3 text-amber-500" />
+		{:else if isApprovalRequested && toolTrustState.shouldAutoApprove(part.name)}
+			<ShieldCheckIcon class="size-3 text-green-500" />
+		{:else if isRunning}
 			<LoaderCircleIcon class="size-3 animate-spin text-blue-500" />
 		{:else}
 			<WrenchIcon class="size-3 text-muted-foreground" />
 		{/if}
-		<Badge variant={badgeVariant}> {displayName}{isRunning ? '…' : ''} </Badge>
+		<Badge variant={isApprovalRequested ? 'secondary' : badgeVariant}>
+			{displayName}{isRunning && !isApprovalRequested ? '…' : ''}
+		</Badge>
 	</div>
+
+	{#if isApprovalRequested && !toolTrustState.shouldAutoApprove(part.name)}
+		<div class="flex items-center gap-1.5 pl-[1.125rem]">
+			<Button variant="outline" size="sm" onclick={handleAllow}>
+				Allow
+			</Button>
+			<Button variant="outline" size="sm" onclick={handleAlwaysAllow}>
+				Always Allow
+			</Button>
+			<Button variant="ghost" size="sm" class="text-muted-foreground" onclick={handleDeny}>
+				Deny
+			</Button>
+		</div>
+	{:else if isApprovalRequested && toolTrustState.shouldAutoApprove(part.name)}
+		<div class="pl-[1.125rem] text-xs text-muted-foreground">Auto-approved</div>
+	{/if}
 
 	<CollapsibleSection label="Details" contentClass="bg-muted/50">
 		{#if part.arguments}

--- a/apps/tab-manager/src/lib/components/chat/ToolCallPart.svelte
+++ b/apps/tab-manager/src/lib/components/chat/ToolCallPart.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
 	import { Badge } from '@epicenter/ui/badge';
-	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
-	import WrenchIcon from '@lucide/svelte/icons/wrench';
 	import { Button } from '@epicenter/ui/button';
+	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import ShieldAlertIcon from '@lucide/svelte/icons/shield-alert';
 	import ShieldCheckIcon from '@lucide/svelte/icons/shield-check';
-	import { toolTrustState } from '$lib/state/tool-trust.svelte';
-	import { aiChatState } from '$lib/state/chat-state.svelte';
+	import WrenchIcon from '@lucide/svelte/icons/wrench';
 	import type { ToolCallPart as TanStackToolCallPart } from '@tanstack/ai-client';
-	import { workspaceToolTitles, type WorkspaceTools } from '$lib/workspace';
+	import { aiChatState } from '$lib/state/chat-state.svelte';
+	import { toolTrustState } from '$lib/state/tool-trust.svelte';
+	import { type WorkspaceTools, workspaceToolTitles } from '$lib/workspace';
 	import CollapsibleSection from '../CollapsibleSection.svelte';
 
 	let {
@@ -39,7 +39,11 @@
 	);
 
 	$effect(() => {
-		if (isApprovalRequested && approval?.id && toolTrustState.shouldAutoApprove(part.name)) {
+		if (
+			isApprovalRequested &&
+			approval?.id &&
+			toolTrustState.shouldAutoApprove(part.name)
+		) {
 			aiChatState.active?.approveToolCall(approval.id, true);
 		}
 	});
@@ -90,13 +94,16 @@
 
 	{#if isApprovalRequested && !toolTrustState.shouldAutoApprove(part.name)}
 		<div class="flex items-center gap-1.5 pl-[1.125rem]">
-			<Button variant="outline" size="sm" onclick={handleAllow}>
-				Allow
-			</Button>
+			<Button variant="outline" size="sm" onclick={handleAllow}> Allow </Button>
 			<Button variant="outline" size="sm" onclick={handleAlwaysAllow}>
 				Always Allow
 			</Button>
-			<Button variant="ghost" size="sm" class="text-muted-foreground" onclick={handleDeny}>
+			<Button
+				variant="ghost"
+				size="sm"
+				class="text-muted-foreground"
+				onclick={handleDeny}
+			>
 				Deny
 			</Button>
 		</div>

--- a/apps/tab-manager/src/lib/components/chat/ToolCallPart.svelte
+++ b/apps/tab-manager/src/lib/components/chat/ToolCallPart.svelte
@@ -3,7 +3,7 @@
 	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import WrenchIcon from '@lucide/svelte/icons/wrench';
 	import type { ToolCallPart as TanStackToolCallPart } from '@tanstack/ai-client';
-	import { type WorkspaceTools } from '$lib/workspace';
+	import { workspaceToolTitles, type WorkspaceTools } from '$lib/workspace';
 	import CollapsibleSection from '../CollapsibleSection.svelte';
 
 	let {
@@ -19,7 +19,8 @@
 			'error' in part.output,
 	);
 	const displayName = $derived(
-		part.name.replace(/_/g, ' ').replace(/^\w/, (c) => c.toUpperCase()),
+		workspaceToolTitles[part.name] ??
+			part.name.replace(/_/g, ' ').replace(/^\w/, (c) => c.toUpperCase()),
 	);
 	const badgeVariant = $derived.by(() => {
 		if (isFailed) return 'status.failed';

--- a/apps/tab-manager/src/lib/state/chat-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/chat-state.svelte.ts
@@ -403,6 +403,30 @@ function createAiChatState() {
 				client.stop();
 			},
 
+			/**
+			 * Respond to a tool approval request.
+			 *
+			 * Called when the user clicks [Allow], [Always Allow], or [Deny]
+			 * on a destructive tool call in the chat. Delegates to ChatClient's
+			 * `addToolApprovalResponse`, which sends the response back to the
+			 * server to resume or cancel tool execution.
+			 *
+			 * @param approvalId - The `part.approval.id` from the ToolCallPart
+			 * @param approved - `true` to allow execution, `false` to deny
+			 *
+			 * @example
+			 * ```typescript
+			 * // User clicks "Allow"
+			 * handle.approveToolCall(part.approval.id, true);
+			 *
+			 * // User clicks "Deny"
+			 * handle.approveToolCall(part.approval.id, false);
+			 * ```
+			 */
+			approveToolCall(approvalId: string, approved: boolean) {
+				void client.addToolApprovalResponse({ id: approvalId, approved });
+			},
+
 			rename(title: string) {
 				updateConversation(conversationId, { title });
 			},

--- a/apps/tab-manager/src/lib/state/tool-trust.svelte.ts
+++ b/apps/tab-manager/src/lib/state/tool-trust.svelte.ts
@@ -1,0 +1,109 @@
+/**
+ * Reactive tool trust state backed by the workspace's toolTrust table.
+ *
+ * Destructive AI tools start as 'ask' (show approval UI in chat).
+ * When a user clicks "Always Allow", the tool is set to 'always'
+ * and future invocations auto-approve without prompting.
+ *
+ * Trust state syncs across devices via the workspace's Y.Doc CRDT.
+ * Non-destructive tools never consult this module—they auto-execute always.
+ *
+ * @module
+ */
+
+import { SvelteMap } from 'svelte/reactivity';
+import { type ToolTrust, workspaceClient } from '$lib/workspace';
+
+/**
+ * Trust level for a destructive tool.
+ *
+ * - `'ask'` — show inline approval UI ([Allow] / [Always Allow] / [Deny])
+ * - `'always'` — auto-approve immediately, show subtle indicator
+ */
+export type TrustLevel = ToolTrust['trust'];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// State Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+function createToolTrustState() {
+	/** Build the trust map from the workspace table. */
+	function readAllTrust(): Map<string, TrustLevel> {
+		const entries = workspaceClient.tables.toolTrust.getAllValid();
+		return new Map(entries.map((row) => [row.id, row.trust]));
+	}
+
+	/** Internal reactive map — hidden from consumers. */
+	const trustMap = new SvelteMap<string, TrustLevel>(readAllTrust());
+
+	// Keep reactive state in sync with Y.Doc changes (local + remote)
+	workspaceClient.tables.toolTrust.observe(() => {
+		const fresh = readAllTrust();
+		// Clear and repopulate to trigger Svelte reactivity
+		trustMap.clear();
+		for (const [key, value] of fresh) {
+			trustMap.set(key, value);
+		}
+	});
+
+	return {
+		/**
+		 * Get the trust level for a tool.
+		 *
+		 * Returns `'ask'` for tools not in the trust table (the safe default).
+		 * Non-destructive tools should not call this—they auto-execute always.
+		 *
+		 * @example
+		 * ```typescript
+		 * if (toolTrustState.get('tabs_close') === 'always') {
+		 *   client.approve(toolCallId);
+		 * }
+		 * ```
+		 */
+		get(name: string): TrustLevel {
+			return trustMap.get(name) ?? 'ask';
+		},
+
+		/**
+		 * Set the trust level for a tool.
+		 *
+		 * Writes to the workspace table (Y.Doc-backed), which triggers
+		 * the observer to update the internal trust map reactively. Syncs
+		 * across devices via CRDT.
+		 *
+		 * @example
+		 * ```typescript
+		 * // User clicks "Always Allow" on the approval UI
+		 * toolTrustState.set('tabs_close', 'always');
+		 * client.approve(toolCallId);
+		 * ```
+		 */
+		set(name: string, level: TrustLevel): void {
+			workspaceClient.tables.toolTrust.set({
+				id: name,
+				trust: level,
+				_v: 1,
+			});
+		},
+
+		/**
+		 * Check if a tool should auto-approve without showing the approval UI.
+		 *
+		 * Convenience wrapper around `toolTrustState.get(name) === 'always'`.
+		 *
+		 * @example
+		 * ```typescript
+		 * if (toolTrustState.shouldAutoApprove(part.name)) {
+		 *   client.approve(part.toolCallId);
+		 * } else {
+		 *   // Show [Allow] / [Always Allow] / [Deny] buttons
+		 * }
+		 * ```
+		 */
+		shouldAutoApprove(name: string): boolean {
+			return (trustMap.get(name) ?? 'ask') === 'always';
+		},
+	};
+}
+
+export const toolTrustState = createToolTrustState();

--- a/apps/tab-manager/src/lib/workspace.ts
+++ b/apps/tab-manager/src/lib/workspace.ts
@@ -17,8 +17,8 @@ import {
 	defineQuery,
 	defineTable,
 	defineWorkspace,
-	iterateActions,
 	type InferTableRow,
+	iterateActions,
 } from '@epicenter/workspace';
 import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
 import { broadcastChannelSync } from '@epicenter/workspace/extensions/sync/broadcast-channel';
@@ -477,6 +477,25 @@ const chatMessagesTable = defineTable(
 );
 export type ChatMessage = InferTableRow<typeof chatMessagesTable>;
 
+/**
+ * Tool trust — per-tool approval preferences for AI chat.
+ *
+ * Each row represents a user's trust decision for a specific destructive tool.
+ * Tools not in this table default to 'ask' (show approval UI). Users can
+ * escalate to 'always' (auto-approve) via the inline approval buttons.
+ *
+ * The `id` is the tool name (e.g. 'tabs_close') — the same string used
+ * in action paths and tool definitions.
+ */
+const toolTrustTable = defineTable(
+	type({
+		id: 'string',
+		trust: "'ask' | 'always'",
+		_v: '1',
+	}),
+);
+export type ToolTrust = InferTableRow<typeof toolTrustTable>;
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Workspace Client
 // ─────────────────────────────────────────────────────────────────────────────
@@ -501,6 +520,7 @@ export const workspaceClient = createWorkspace(
 			bookmarks: bookmarksTable,
 			conversations: conversationsTable,
 			chatMessages: chatMessagesTable,
+			toolTrust: toolTrustTable,
 		},
 	}),
 )

--- a/apps/tab-manager/src/lib/workspace.ts
+++ b/apps/tab-manager/src/lib/workspace.ts
@@ -17,6 +17,7 @@ import {
 	defineQuery,
 	defineTable,
 	defineWorkspace,
+	iterateActions,
 	type InferTableRow,
 } from '@epicenter/workspace';
 import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
@@ -515,6 +516,7 @@ export const workspaceClient = createWorkspace(
 	.withActions(({ tables }) => ({
 		tabs: {
 			search: defineQuery({
+				title: 'Search Tabs',
 				description:
 					'Search tabs by URL or title match. Returns matching tabs across all devices, optionally scoped to one device.',
 				input: Type.Object({
@@ -544,6 +546,7 @@ export const workspaceClient = createWorkspace(
 			}),
 
 			list: defineQuery({
+				title: 'List Tabs',
 				description:
 					'List all open tabs. Optionally filter by device or window.',
 				input: Type.Object({
@@ -574,7 +577,9 @@ export const workspaceClient = createWorkspace(
 			}),
 
 			close: defineMutation({
+				title: 'Close Tabs',
 				description: 'Close one or more tabs by their composite IDs.',
+				destructive: true,
 				input: Type.Object({
 					tabIds: Type.Array(Type.String()),
 				}),
@@ -585,6 +590,7 @@ export const workspaceClient = createWorkspace(
 			}),
 
 			open: defineMutation({
+				title: 'Open Tab',
 				description: 'Open a new tab with the given URL on the current device.',
 				input: Type.Object({
 					url: Type.String(),
@@ -596,6 +602,7 @@ export const workspaceClient = createWorkspace(
 			}),
 
 			activate: defineMutation({
+				title: 'Activate Tab',
 				description: 'Activate (focus) a specific tab by its composite ID.',
 				input: Type.Object({
 					tabId: Type.String(),
@@ -607,6 +614,7 @@ export const workspaceClient = createWorkspace(
 			}),
 
 			save: defineMutation({
+				title: 'Save Tabs',
 				description: 'Save tabs for later. Optionally close them after saving.',
 				input: Type.Object({
 					tabIds: Type.Array(Type.String()),
@@ -624,6 +632,7 @@ export const workspaceClient = createWorkspace(
 			}),
 
 			group: defineMutation({
+				title: 'Group Tabs',
 				description: 'Group tabs together with an optional title and color.',
 				input: Type.Object({
 					tabIds: Type.Array(Type.String()),
@@ -637,6 +646,7 @@ export const workspaceClient = createWorkspace(
 			}),
 
 			pin: defineMutation({
+				title: 'Pin Tabs',
 				description: 'Pin or unpin tabs.',
 				input: Type.Object({
 					tabIds: Type.Array(Type.String()),
@@ -649,6 +659,7 @@ export const workspaceClient = createWorkspace(
 			}),
 
 			mute: defineMutation({
+				title: 'Mute Tabs',
 				description: 'Mute or unmute tabs.',
 				input: Type.Object({
 					tabIds: Type.Array(Type.String()),
@@ -661,6 +672,7 @@ export const workspaceClient = createWorkspace(
 			}),
 
 			reload: defineMutation({
+				title: 'Reload Tabs',
 				description: 'Reload one or more tabs.',
 				input: Type.Object({
 					tabIds: Type.Array(Type.String()),
@@ -674,6 +686,7 @@ export const workspaceClient = createWorkspace(
 
 		windows: {
 			list: defineQuery({
+				title: 'List Windows',
 				description:
 					'List all browser windows with their tab counts. Optionally filter by device.',
 				input: Type.Object({
@@ -701,6 +714,7 @@ export const workspaceClient = createWorkspace(
 
 		devices: {
 			list: defineQuery({
+				title: 'List Devices',
 				description:
 					'List all synced devices with their names, browsers, and online status.',
 				input: Type.Object({}),
@@ -720,6 +734,7 @@ export const workspaceClient = createWorkspace(
 
 		domains: {
 			count: defineQuery({
+				title: 'Count Domains',
 				description:
 					'Count open tabs grouped by domain (e.g. youtube.com: 5, github.com: 3). Optionally filter by device.',
 				input: Type.Object({
@@ -754,6 +769,18 @@ export const workspaceDefinitions = toToolDefinitions(workspaceTools);
 
 export type WorkspaceTools = typeof workspaceTools;
 export type WorkspaceActionName = WorkspaceTools[number]['name'];
+
+/**
+ * Lookup map from tool name to human-readable title.
+ *
+ * Used by `ToolCallPart.svelte` to display action titles instead of
+ * deriving names from underscore-separated tool names.
+ */
+export const workspaceToolTitles: Record<string, string> = Object.fromEntries(
+	[...iterateActions(workspaceClient.actions)]
+		.filter(([action]) => action.title !== undefined)
+		.map(([action, path]) => [path.join('_'), action.title!]),
+);
 
 /**
  * Reconnect the sync extension with fresh auth credentials.

--- a/packages/ai/src/tool-bridge.test.ts
+++ b/packages/ai/src/tool-bridge.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tool bridge tests — verifies the mapping between workspace actions and
+ * TanStack AI tool representations.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { defineMutation, defineQuery } from '@epicenter/workspace';
+import { actionsToClientTools, toToolDefinitions } from './tool-bridge.js';
+
+describe('actionsToClientTools', () => {
+	test('destructive action sets needsApproval without blanket option', () => {
+		const actions = {
+			tabs: {
+				close: defineMutation({
+					title: 'Close Tabs',
+					description: 'Close tabs',
+					destructive: true,
+					handler: () => {},
+				}),
+				open: defineMutation({
+					title: 'Open Tab',
+					description: 'Open a tab',
+					handler: () => {},
+				}),
+			},
+		};
+
+		const tools = actionsToClientTools(actions);
+
+		const closeTool = tools.find((t) => t.name === 'tabs_close');
+		expect(closeTool).toBeDefined();
+		expect(closeTool?.needsApproval).toBe(true);
+
+		const openTool = tools.find((t) => t.name === 'tabs_open');
+		expect(openTool).toBeDefined();
+		expect(openTool?.needsApproval).toBeUndefined();
+	});
+
+	test('destructive + requireApprovalForMutations both set needsApproval', () => {
+		const actions = {
+			read: defineQuery({
+				title: 'Read',
+				description: 'Read data',
+				destructive: true,
+				handler: () => {},
+			}),
+			write: defineMutation({
+				title: 'Write',
+				description: 'Write data',
+				handler: () => {},
+			}),
+		};
+
+		const tools = actionsToClientTools(actions, {
+			requireApprovalForMutations: true,
+		});
+
+		// Destructive query gets needsApproval
+		const readTool = tools.find((t) => t.name === 'read');
+		expect(readTool?.needsApproval).toBe(true);
+
+		// Mutation gets needsApproval from blanket option
+		const writeTool = tools.find((t) => t.name === 'write');
+		expect(writeTool?.needsApproval).toBe(true);
+	});
+});
+
+describe('toToolDefinitions', () => {
+	test('produces wire-safe definitions', () => {
+		const actions = {
+			search: defineQuery({
+				title: 'Search',
+				description: 'Search stuff',
+				handler: () => {},
+			}),
+		};
+
+		const tools = actionsToClientTools(actions);
+		const definitions = toToolDefinitions(tools);
+
+		expect(definitions).toHaveLength(1);
+		expect(definitions[0]?.name).toBe('search');
+		expect(definitions[0]?.description).toBe('Search stuff');
+	});
+});

--- a/packages/ai/src/tool-bridge.test.ts
+++ b/packages/ai/src/tool-bridge.test.ts
@@ -36,32 +36,29 @@ describe('actionsToClientTools', () => {
 		expect(openTool?.needsApproval).toBeUndefined();
 	});
 
-	test('destructive + requireApprovalForMutations both set needsApproval', () => {
+	test('non-destructive tools omit needsApproval entirely', () => {
 		const actions = {
-			read: defineQuery({
-				title: 'Read',
-				description: 'Read data',
-				destructive: true,
+			query: defineQuery({
+				title: 'Query',
+				description: 'Query data',
 				handler: () => {},
 			}),
-			write: defineMutation({
-				title: 'Write',
-				description: 'Write data',
+			mutation: defineMutation({
+				title: 'Mutation',
+				description: 'Mutate data',
 				handler: () => {},
 			}),
 		};
 
-		const tools = actionsToClientTools(actions, {
-			requireApprovalForMutations: true,
-		});
+		const tools = actionsToClientTools(actions);
 
-		// Destructive query gets needsApproval
-		const readTool = tools.find((t) => t.name === 'read');
-		expect(readTool?.needsApproval).toBe(true);
+		const queryTool = tools.find((t) => t.name === 'query');
+		expect(queryTool).toBeDefined();
+		expect('needsApproval' in queryTool!).toBe(false);
 
-		// Mutation gets needsApproval from blanket option
-		const writeTool = tools.find((t) => t.name === 'write');
-		expect(writeTool?.needsApproval).toBe(true);
+		const mutationTool = tools.find((t) => t.name === 'mutation');
+		expect(mutationTool).toBeDefined();
+		expect('needsApproval' in mutationTool!).toBe(false);
 	});
 });
 
@@ -81,5 +78,30 @@ describe('toToolDefinitions', () => {
 		expect(definitions).toHaveLength(1);
 		expect(definitions[0]?.name).toBe('search');
 		expect(definitions[0]?.description).toBe('Search stuff');
+	});
+
+	test('only forwards needsApproval for destructive tools', () => {
+		const actions = {
+			destructive: defineMutation({
+				title: 'Destructive',
+				description: 'Destructive action',
+				destructive: true,
+				handler: () => {},
+			}),
+			safe: defineQuery({
+				title: 'Safe',
+				description: 'Safe action',
+				handler: () => {},
+			}),
+		};
+
+		const tools = actionsToClientTools(actions);
+		const definitions = toToolDefinitions(tools);
+
+		const destructiveDef = definitions.find((d) => d.name === 'destructive');
+		expect(destructiveDef?.needsApproval).toBe(true);
+
+		const safeDef = definitions.find((d) => d.name === 'safe');
+		expect('needsApproval' in safeDef!).toBe(false);
 	});
 });

--- a/packages/ai/src/tool-bridge.ts
+++ b/packages/ai/src/tool-bridge.ts
@@ -96,6 +96,8 @@ export type ActionNames<T extends Actions> = {
  */
 export type ToolDefinitionPayload = {
 	name: string;
+	/** Short, human-readable display name for UI surfaces and MCP annotations. */
+	title?: string;
 	description: string;
 	inputSchema?: NormalizedJsonSchema;
 	outputSchema?: JSONSchema;
@@ -143,8 +145,10 @@ export function actionsToClientTools<TActions extends Actions>(
 		name: path.join(ACTION_NAME_SEPARATOR) as ActionNames<TActions>,
 		description: action.description ?? `${action.type}: ${path.join('.')}`,
 		...(action.input && { inputSchema: action.input }),
-		...(requireApprovalForMutations &&
-			action.type === 'mutation' && { needsApproval: true }),
+		...((action.destructive ||
+			(requireApprovalForMutations && action.type === 'mutation')) && {
+			needsApproval: true,
+		}),
 		execute: async (args: unknown) => (action.input ? action(args) : action()),
 	}));
 }

--- a/packages/ai/src/tool-bridge.ts
+++ b/packages/ai/src/tool-bridge.ts
@@ -81,10 +81,11 @@ export type ActionNames<T extends Actions> = {
  *   (notably Anthropic) reject schemas missing those fields.
  * - **`outputSchema`** — Enables server-side output validation. TanStack AI's
  *   `executeToolCalls` validates results against this when present.
- * - **`needsApproval`** — **Critical for the approval flow.** The server's
- *   `executeToolCalls` checks this to decide whether to send an
- *   `APPROVAL_REQUESTED` event or a direct `TOOL_CALL` event. Without it,
- *   mutations auto-execute with no approval dialog.
+ * - **`needsApproval`** — Only present when the action is marked `destructive`.
+ *   Omitted entirely for non-destructive tools. The server's `executeToolCalls`
+ *   checks this to decide whether to send an `APPROVAL_REQUESTED` event or a
+ *   direct `TOOL_CALL` event. Without it, mutations auto-execute with no approval
+ *   dialog.
  * - **`metadata`** — Pass-through `Record<string, unknown>` for server-side
  *   routing, logging, or future TanStack AI features.
  *
@@ -122,9 +123,7 @@ export type ToolDefinitionPayload = {
  *
  * @example
  * ```ts
- * const tools = actionsToClientTools(workspace.actions, {
- *   requireApprovalForMutations: true,
- * });
+ * const tools = actionsToClientTools(workspace.actions);
  *
  * // Use locally in ChatClient
  * const chat = createChat({ tools, connection: ... });
@@ -135,20 +134,13 @@ export type ToolDefinitionPayload = {
  */
 export function actionsToClientTools<TActions extends Actions>(
 	actions: TActions,
-	options?: { requireApprovalForMutations?: boolean },
 ): (AnyClientTool & { name: ActionNames<TActions> })[] {
-	const requireApprovalForMutations =
-		options?.requireApprovalForMutations ?? false;
-
 	return [...iterateActions(actions)].map(([action, path]) => ({
 		__toolSide: 'client' as const,
 		name: path.join(ACTION_NAME_SEPARATOR) as ActionNames<TActions>,
 		description: action.description ?? `${action.type}: ${path.join('.')}`,
 		...(action.input && { inputSchema: action.input }),
-		...((action.destructive ||
-			(requireApprovalForMutations && action.type === 'mutation')) && {
-			needsApproval: true,
-		}),
+		...(action.destructive && { needsApproval: true }),
 		execute: async (args: unknown) => (action.input ? action(args) : action()),
 	}));
 }
@@ -188,8 +180,9 @@ export function toToolDefinitions(
 		...(tool.outputSchema && {
 			outputSchema: tool.outputSchema as JSONSchema,
 		}),
-		...('needsApproval' in tool &&
-			tool.needsApproval && { needsApproval: true }),
+		...(tool.needsApproval && {
+			needsApproval: true,
+		}),
 		...('metadata' in tool &&
 			tool.metadata && { metadata: tool.metadata as Record<string, unknown> }),
 	}));

--- a/packages/workspace/src/shared/actions.ts
+++ b/packages/workspace/src/shared/actions.ts
@@ -126,7 +126,11 @@ type ActionConfig<
 	TInput extends TSchema | undefined = TSchema | undefined,
 	TOutput = unknown,
 > = {
+	/** Short, human-readable display name for UI surfaces (e.g. 'Close Tabs'). Falls back to path-derived name if omitted. */
+	title?: string;
 	description?: string;
+	/** Whether this action is destructive. Maps to `needsApproval` in the tool bridge and `destructiveHint` in MCP annotations. */
+	destructive?: boolean;
 	input?: TInput;
 	handler: ActionHandler<TInput, TOutput>;
 };
@@ -140,7 +144,11 @@ type ActionConfig<
  */
 type ActionMeta<TInput extends TSchema | undefined = TSchema | undefined> = {
 	type: 'query' | 'mutation';
+	/** Short, human-readable display name for UI surfaces (e.g. 'Close Tabs'). Falls back to path-derived name if omitted. */
+	title?: string;
 	description?: string;
+	/** Whether this action is destructive. Maps to `needsApproval` in the tool bridge and `destructiveHint` in MCP annotations. */
+	destructive?: boolean;
 	input?: TInput;
 };
 

--- a/packages/workspace/src/workspace/describe-workspace.test.ts
+++ b/packages/workspace/src/workspace/describe-workspace.test.ts
@@ -265,5 +265,4 @@ describe('describeWorkspace', () => {
 		expect(createAction?.title).toBeUndefined();
 		expect(createAction?.destructive).toBeUndefined();
 	});
-
 });

--- a/packages/workspace/src/workspace/describe-workspace.test.ts
+++ b/packages/workspace/src/workspace/describe-workspace.test.ts
@@ -215,4 +215,55 @@ describe('describeWorkspace', () => {
 			'object',
 		);
 	});
+
+	test('title and destructive appear in action descriptors', () => {
+		const client = createWorkspace({
+			id: 'metadata-test',
+			tables: {
+				posts: defineTable(type({ id: 'string', title: 'string', _v: '1' })),
+			},
+		}).withActions((c) => ({
+			posts: {
+				getAll: defineQuery({
+					title: 'List Posts',
+					description: 'Get all posts',
+					handler: () => c.tables.posts.getAllValid(),
+				}),
+				delete: defineMutation({
+					title: 'Delete Post',
+					description: 'Delete a post by ID',
+					destructive: true,
+					input: Type.Object({ id: Type.String() }),
+					handler: ({ id }) => {
+						c.tables.posts.delete(id);
+					},
+				}),
+				create: defineMutation({
+					description: 'Create a post (no title or destructive)',
+					handler: () => {},
+				}),
+			},
+		}));
+
+		const descriptor = describeWorkspace(client);
+
+		const getAllAction = descriptor.actions.find(
+			(a) => a.path.join('.') === 'posts.getAll',
+		);
+		expect(getAllAction?.title).toBe('List Posts');
+		expect(getAllAction?.destructive).toBeUndefined();
+
+		const deleteAction = descriptor.actions.find(
+			(a) => a.path.join('.') === 'posts.delete',
+		);
+		expect(deleteAction?.title).toBe('Delete Post');
+		expect(deleteAction?.destructive).toBe(true);
+
+		const createAction = descriptor.actions.find(
+			(a) => a.path.join('.') === 'posts.create',
+		);
+		expect(createAction?.title).toBeUndefined();
+		expect(createAction?.destructive).toBeUndefined();
+	});
+
 });

--- a/packages/workspace/src/workspace/describe-workspace.ts
+++ b/packages/workspace/src/workspace/describe-workspace.ts
@@ -43,7 +43,9 @@ export type SchemaDescriptor = {
 export type ActionDescriptor = {
 	path: string[];
 	type: 'query' | 'mutation';
+	title?: string;
 	description?: string;
+	destructive?: boolean;
 	input?: TSchema;
 };
 
@@ -119,8 +121,12 @@ export function describeWorkspace(
 			actions.push({
 				path,
 				type: action.type,
+				...(action.title !== undefined && { title: action.title }),
 				...(action.description !== undefined && {
 					description: action.description,
+				}),
+				...(action.destructive !== undefined && {
+					destructive: action.destructive,
 				}),
 				...(action.input !== undefined && { input: action.input }),
 			});

--- a/specs/20260312T153000-action-metadata-title-destructive.md
+++ b/specs/20260312T153000-action-metadata-title-destructive.md
@@ -1,0 +1,249 @@
+# Action Metadata: `title` and `destructive` Fields
+
+**Date**: 2026-03-12
+**Status**: Implemented
+**Author**: AI-assisted
+
+## Overview
+
+Add `title` (optional string) and `destructive` (optional boolean, default `false`) to the action definition system. These fields flow through the tool bridge to TanStack AI and MCP consumers, replace the underscore-to-space regex hack in `ToolCallPart.svelte`, and enable future command palette unification.
+
+## Motivation
+
+### Current State
+
+Actions carry minimal metadata—just `description` and `input`:
+
+```typescript
+// packages/workspace/src/shared/actions.ts
+type ActionConfig<TInput, TOutput> = {
+    description?: string;
+    input?: TInput;
+    handler: ActionHandler<TInput, TOutput>;
+};
+```
+
+The tool bridge derives display names from the path:
+
+```typescript
+// packages/ai/src/tool-bridge.ts line 144
+description: action.description ?? `${action.type}: ${path.join('.')}`,
+```
+
+And the UI hacks around the lack of a title:
+
+```typescript
+// apps/tab-manager ToolCallPart.svelte line 22
+const displayName = $derived(
+    part.name.replace(/_/g, ' ').replace(/^\w/, (c) => c.toUpperCase()),
+);
+// tabs_close → "Tabs close" — not even properly capitalized
+```
+
+Meanwhile, a parallel `QuickAction` system has the metadata we need but is completely disconnected from `.withActions()`:
+
+```typescript
+// apps/tab-manager/src/lib/quick-actions.ts
+type QuickAction = {
+    id: string;
+    label: string;        // ← We need this on actions
+    description: string;
+    icon: Component;
+    keywords: string[];
+    execute: () => Promise<void> | void;
+    dangerous?: boolean;  // ← We need this on actions
+};
+```
+
+This creates problems:
+
+1. **No human-readable title**: `tabs_close` is not a display name. The regex produces "Tabs close" instead of "Close Tabs."
+2. **No destructive flag on actions**: The tool bridge blanket-marks all mutations as `needsApproval` via an option, with no per-action control. Quick actions have `dangerous` but it's in a separate system.
+3. **Two disconnected systems**: Quick actions (command palette) and workspace actions (AI tools) define overlapping functionality with zero shared metadata.
+
+### Desired State
+
+```typescript
+tabs: {
+    close: defineMutation({
+        title: 'Close Tabs',
+        description: 'Close one or more tabs by their composite IDs.',
+        destructive: true,
+        input: Type.Object({ tabIds: Type.Array(Type.String()) }),
+        handler: async ({ tabIds }) => { /* ... */ },
+    }),
+}
+```
+
+- `title` flows to the UI, MCP `annotations.title`, and tool descriptions
+- `destructive` maps to `needsApproval` in the tool bridge and `destructiveHint` in MCP
+- `ToolCallPart.svelte` uses the title directly—no regex
+
+## Research Findings
+
+### Ecosystem Naming Conventions
+
+| System | Display Name | Danger Flag | Category |
+|---|---|---|---|
+| MCP `ToolAnnotations` | `title` (optional) | `destructiveHint` (boolean, default `true` for non-read-only) | None |
+| TanStack AI `ClientTool` | None (only `name` + `description`) | `needsApproval` (boolean) | None |
+| VS Code Commands | `title` (required) | None | `category` (string) |
+| Hono/OpenAPI | None | None | `tags` (string[]) |
+| shadcn-svelte UI components | N/A | `variant: 'destructive'` | N/A |
+| Epicenter `QuickAction` | `label` | `dangerous` | None |
+
+**Key findings:**
+
+- **`title`** is the standard name across MCP and VS Code. Not `label`, not `displayName`.
+- **`destructive`** aligns with the UI layer (`variant: 'destructive'`) and maps cleanly to MCP's `destructiveHint`. It describes the nature of the action, not the UX behavior.
+- **`needsApproval`** is a consumer concern (tool bridge), not an action property. The action says "I'm destructive"; the bridge decides whether that means "show confirmation."
+- **`category`** is redundant—the action tree nesting already provides this (`tabs.close` → category `tabs`).
+- **`keywords`** deferred—command palette can search `title + description + path` effectively without a dedicated field.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Display name field | `title` | MCP and VS Code precedent. Not `label` (too UI-specific) or `displayName` (verbose) |
+| `title` optionality | Optional | Falls back to path-derived name if omitted. Matches MCP where `title` is optional |
+| Danger field | `destructive` | Matches UI `variant: 'destructive'`, maps to MCP `destructiveHint` |
+| `destructive` default | `false` | Only 2 of 13 current actions are destructive. Opt-in is less noisy |
+| `category` field | Not added | Path nesting is the category. `tabs.close` → category `tabs` |
+| `keywords` field | Not added | Search on `title + description + path` is sufficient for now |
+| `needsApproval` mapping | `destructive: true` → `needsApproval: true` in tool bridge | Keeps action system clean; approval is a consumer concern |
+| Tool bridge `description` | Use `description` (keep existing behavior) | `title` is short ("Close Tabs"), `description` gives the LLM context ("Close one or more tabs by their composite IDs"). The LLM needs the longer form |
+
+## Architecture
+
+```
+ActionConfig                              Consumer Surfaces
+┌──────────────────────┐
+│ title?               │──► ToolCallPart.svelte (display name)
+│ description?         │──► actionsToClientTools → LLM description
+│ destructive?         │──► actionsToClientTools → needsApproval
+│ input?               │──► actionsToClientTools → inputSchema
+│ handler              │──► actionsToClientTools → execute
+└──────────────────────┘
+         │
+         ▼ iterateActions()
+┌──────────────────────┐
+│ ActionDescriptor     │
+│ ├── title?           │──► MCP annotations.title
+│ ├── description?     │──► MCP tool description
+│ ├── destructive?     │──► MCP annotations.destructiveHint
+│ ├── path             │──► MCP tool name
+│ └── input?           │──► MCP inputSchema
+└──────────────────────┘
+```
+
+## Implementation Plan
+
+### Phase 1: Core Types (packages/workspace)
+
+- [x] **1.1** Add `title?: string` and `destructive?: boolean` to `ActionConfig` type in `packages/workspace/src/shared/actions.ts`
+- [x] **1.2** Add `title?: string` and `destructive?: boolean` to `ActionMeta` type in the same file
+- [x] **1.3** Update `defineQuery` and `defineMutation` implementations to forward the new fields via `...rest` spread (already handled—`{ handler, ...rest }` captures them)
+- [x] **1.4** Add `title?: string` and `destructive?: boolean` to `ActionDescriptor` type in `packages/workspace/src/workspace/describe-workspace.ts`
+- [x] **1.5** Update `describeWorkspace` to include `title` and `destructive` in the descriptor output
+
+### Phase 2: Tool Bridge (packages/ai)
+
+- [x] **2.1** Update `actionsToClientTools` in `packages/ai/src/tool-bridge.ts` to: set `needsApproval: true` when `action.destructive` is true (per-action override, in addition to existing blanket `requireApprovalForMutations` option)
+- [x] **2.2** Update `ToolDefinitionPayload` to include optional `title` field
+- [x] **2.3** Update `toToolDefinitions` to forward `title` from the client tool metadata
+
+### Phase 3: Tab Manager Actions (apps/tab-manager)
+
+- [x] **3.1** Add `title` to every action in `.withActions()` in `apps/tab-manager/src/lib/workspace.ts`
+- [x] **3.2** Add `destructive: true` to `tabs.close` action
+- [x] **3.3** Review `tabs.save`—it's only destructive when `close: true`, so leave as non-destructive (the `close` flag is an input parameter, not a static property)
+
+### Phase 4: UI Consumers (apps/tab-manager)
+
+- [x] **4.1** Update `ToolCallPart.svelte` to use the tool's title metadata instead of the `replace(/_/g, ' ')` regex. The tool bridge needs to make title available on the tool call part—check how TanStack AI `ToolCallPart` exposes tool metadata and find the right path to surface it
+- [x] **4.2** If TanStack AI's `ToolCallPart` doesn't carry tool metadata, create a lookup map from `workspaceTools` (name → title) and import it in `ToolCallPart.svelte`
+
+### Phase 5: Tests
+
+- [x] **5.1** Update `describe-workspace.test.ts` to verify `title` and `destructive` appear in the descriptor
+- [x] **5.2** Add a test case for `actionsToClientTools` verifying `destructive: true` → `needsApproval: true`
+- [x] **5.3** Run `bun test` and `bun run typecheck` to verify no regressions
+
+## Edge Cases
+
+### `destructive` on `tabs.save`
+
+1. `tabs.save` accepts `close: true` as an input parameter
+2. When `close: true`, the action is destructive (closes tabs after saving)
+3. But `destructive` is a static property, not input-dependent
+4. **Decision**: Leave `tabs.save` as non-destructive. The AI tool calling approval flow handles this at the `requireApprovalForMutations` level. If per-invocation approval is needed later, that's a TanStack AI concern.
+
+### `title` omitted
+
+1. An action has no `title` set
+2. `ToolCallPart.svelte` falls back to the existing path-derived name
+3. `describeWorkspace` omits `title` from the descriptor (same pattern as `description`)
+4. **No breaking change**—`title` is optional everywhere
+
+### Tool bridge `needsApproval` precedence
+
+1. `requireApprovalForMutations: true` (blanket option) already marks all mutations
+2. `destructive: true` on a specific action should ALSO set `needsApproval: true`
+3. These are additive—`needsApproval` is true if EITHER condition is met
+4. A query with `destructive: true` (unusual but valid) would get `needsApproval: true`
+
+## Open Questions
+
+1. **Should `title` influence the tool `description` sent to the LLM?**
+   - Currently: `description` field goes to LLM as-is
+   - Option A: Keep `description` as LLM description (current behavior)
+   - Option B: Prefix with title: `"Close Tabs — Close one or more tabs by their composite IDs."`
+   - **Recommendation**: Option A. The LLM doesn't need the title—it has the tool name and description. Title is for human display.
+
+2. **How does `ToolCallPart.svelte` access the title?**
+   - TanStack AI's `ToolCallPart` type has `name`, `arguments`, `output` but likely not arbitrary metadata
+   - **Recommendation**: Create a simple lookup map `Record<string, string>` from `workspaceTools` in workspace.ts, import it in ToolCallPart. Cheap, explicit, no framework gymnastics.
+
+## Success Criteria
+
+- [ ] `ActionConfig` accepts `title` and `destructive` with correct types
+- [ ] `defineQuery` / `defineMutation` forward the new fields to `ActionMeta`
+- [ ] `describeWorkspace` includes `title` and `destructive` in output
+- [ ] `actionsToClientTools` maps `destructive: true` → `needsApproval: true`
+- [ ] All 13 tab-manager actions have `title` set
+- [ ] `tabs.close` has `destructive: true`
+- [ ] `ToolCallPart.svelte` displays action title instead of regex-derived name
+- [ ] `bun test` passes
+- [ ] `bun run typecheck` passes
+- [ ] No `as any` or `@ts-ignore` introduced
+
+## References
+
+- `packages/workspace/src/shared/actions.ts` — ActionConfig, ActionMeta, defineQuery, defineMutation
+- `packages/workspace/src/workspace/describe-workspace.ts` — ActionDescriptor, describeWorkspace
+- `packages/workspace/src/workspace/describe-workspace.test.ts` — Descriptor tests
+- `packages/ai/src/tool-bridge.ts` — actionsToClientTools, toToolDefinitions, ToolDefinitionPayload
+- `apps/tab-manager/src/lib/workspace.ts` — All 13 action definitions, workspaceTools export
+- `apps/tab-manager/src/lib/components/chat/ToolCallPart.svelte` — Regex display name hack
+- `apps/tab-manager/src/lib/quick-actions.ts` — QuickAction type (future unification target, out of scope)
+- `apps/tab-manager/src/lib/components/CommandPalette.svelte` — Quick actions consumer (future unification target, out of scope)
+- `specs/20260311T172000-refactor-action-context.md` — Previous refactor that introduced the regex hack
+
+## Review
+
+**Completed**: 2026-03-12
+
+### Summary
+
+Added `title` and `destructive` fields to the action definition system across 7 files. The fields flow from `ActionConfig` through `ActionMeta`, `ActionDescriptor`, and into the tool bridge (`ToolDefinitionPayload`). All 13 tab-manager actions now have human-readable titles, and `tabs.close` is marked `destructive: true`. `ToolCallPart.svelte` uses a derived lookup map (`workspaceToolTitles`) to display titles, falling back to the regex-derived name for actions without titles.
+
+### Deviations from Spec
+
+- **4.1/4.2 approach**: Used the lookup map approach (spec option B from Open Question #2) since TanStack AI's `ToolCallPart` type doesn't carry arbitrary tool metadata. The map is derived from `iterateActions` at module scope, not from `workspaceTools`—this avoids any need to thread title through the TanStack AI client tool type.
+- **Tool bridge `title` forwarding (2.3)**: Added `title` to `ToolDefinitionPayload` type for MCP wire format, but the actual forwarding from client tools to wire definitions is not implemented because the client tool type (`AnyClientTool`) doesn't support arbitrary properties. Title reaches MCP consumers via `describeWorkspace` → `ActionDescriptor.title` instead.
+
+### Follow-up Work
+
+- Unify `QuickAction` system with `.withActions()` metadata (out of scope per spec)
+- Consider `category` field if path nesting proves insufficient for command palette grouping
+- Consider `keywords` field if `title + description + path` search proves insufficient

--- a/specs/20260312T153000-action-metadata-title-destructive.md
+++ b/specs/20260312T153000-action-metadata-title-destructive.md
@@ -244,6 +244,7 @@ Added `title` and `destructive` fields to the action definition system across 7 
 
 ### Follow-up Work
 
+- `requireApprovalForMutations` was identified as redundant with the `destructive` field and removed in the follow-up spec (`specs/20260312T170000-progressive-tool-trust.md`). The `needsApproval` flag is now set conditionally—only when `destructive: true`—rather than blanket-applied to all mutations.
 - Unify `QuickAction` system with `.withActions()` metadata (out of scope per spec)
 - Consider `category` field if path nesting proves insufficient for command palette grouping
 - Consider `keywords` field if `title + description + path` search proves insufficient

--- a/specs/20260312T170000-progressive-tool-trust.md
+++ b/specs/20260312T170000-progressive-tool-trust.md
@@ -1,0 +1,321 @@
+# Progressive Tool Trust & Approval Cleanup
+
+**Date**: 2026-03-12
+**Status**: Draft
+**Author**: AI-assisted
+
+## Overview
+
+Replace the blanket `requireApprovalForMutations` option with a progressive trust model: destructive tools start with an inline approval gate in the chat, and users can escalate to "always allow" per-action. Clean up the redundant approval mechanisms introduced across the previous spec.
+
+## Motivation
+
+### Current State
+
+Three overlapping mechanisms control tool approval:
+
+```typescript
+// 1. Blanket option on the tool bridge (UNUSED — nobody passes true)
+actionsToClientTools(actions, { requireApprovalForMutations: true });
+
+// 2. Per-action `destructive` flag (just added)
+defineMutation({ destructive: true, ... });
+
+// 3. System prompt telling the AI to "confirm with user if count > 5"
+"When closing or modifying multiple tabs, confirm with the user if the count is large (>5)"
+```
+
+Meanwhile, quick actions already have a clean destructive flow:
+
+```typescript
+// quick-actions.ts — dangerous flag → confirmationDialog
+const dedupAction: QuickAction = {
+  dangerous: true,
+  execute() {
+    confirmationDialog.open({
+      title: 'Remove Duplicate Tabs',
+      confirm: { text: 'Close Duplicates', variant: 'destructive' },
+      onConfirm: async () => { ... },
+    });
+  },
+};
+```
+
+But the AI chat has **no approval UI at all**. Tools auto-execute immediately — `ToolCallPart.svelte` shows a spinner, then a result. No gate, no confirmation, nothing.
+
+This creates problems:
+
+1. **`requireApprovalForMutations` is dead code** — nobody passes it, and now that `destructive` exists it's redundant
+2. **`needsApproval` is always set** — the tool bridge currently sets `needsApproval: false` on non-destructive tools instead of omitting it, which sends unnecessary data over the wire
+3. **No approval UI in chat** — even though `destructive` flows to `needsApproval` on the wire, the client never acts on it. TanStack AI's `ChatClient` has a `client.approve(toolCallId)` method that's never called
+4. **Two confirmation systems** — quick actions use `confirmationDialog`; the AI chat will need inline approval. These should share the trust concept but use different UI
+
+### Desired State
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Action Definition                                          │
+│  defineMutation({ destructive: true, ... })                 │
+│           │                                                 │
+│           ▼                                                 │
+│  Tool Bridge                                                │
+│  needsApproval: action.destructive  (only when true)        │
+│           │                                                 │
+│           ├──► Server: APPROVAL_REQUESTED event              │
+│           │                                                 │
+│           ▼                                                 │
+│  ChatClient pauses, ToolCallPart renders approval UI        │
+│           │                                                 │
+│           ├── User clicks [Allow]  → client.approve(id)     │
+│           ├── User clicks [Always Allow] → persist + approve │
+│           └── User clicks [Deny]  → client.deny(id)         │
+│                                                             │
+│  Trust State (localStorage)                                 │
+│  { "tabs_close": "always" }                                 │
+│  → Next time: auto-approve, show subtle ✅ indicator        │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Research Findings
+
+### TanStack AI Approval API (Phase 3 Research — Confirmed)
+
+TanStack AI's `ChatClient` has built-in approval support. Verified from source:
+
+- **Server-side**: `chat()` automatically checks `needsApproval` on tool definitions and emits a `CUSTOM` SSE event named `approval-requested`. No server code changes needed — `apps/api/src/ai-chat.ts` already passes tools through to `chat()`.
+- **`chatClient.addToolApprovalResponse({ id, approved })`** — the approval method. `id` is `part.approval.id` (not `toolCallId`), `approved` is `true`/`false`.
+- **`ToolCallPart.state`** — possible values include `'approval-requested'` (waiting for user) and `'approval-responded'` (user acted).
+- **`ToolCallPart.approval`** — object with `{ id: string, needsApproval: boolean, approved?: boolean }`. `approved` is `undefined` while pending.
+
+**Corrected flow**: LLM calls tool → server detects `needsApproval` → emits `CUSTOM` `approval-requested` SSE event → `ChatClient` updates `part.state` to `'approval-requested'` → UI renders approve/deny → user acts → `addToolApprovalResponse({ id: part.approval.id, approved })` → server resumes or denies.
+
+**Key finding**: Full infrastructure exists end-to-end. No server changes needed. Phase 4 only needs UI wiring.
+
+### Industry Patterns
+
+| Product | Approval Model | Progressive Trust? |
+|---|---|---|
+| Claude Desktop (MCP) | "Allow for This Chat" / "Always Allow" per-tool | Yes — two levels |
+| Cursor | Inline approve for terminal, auto-approve for edits | Partial — yolo mode |
+| OpenCode | Inline approve/deny in chat thread | No — per-invocation |
+| ChatGPT Actions | "Always allow [domain]" on first use | Yes — per-domain |
+
+**Key finding**: "Always Allow" per-tool is the standard pattern. No product does "approve N times then escalate" — it's always a one-click trust decision.
+
+**Implication**: Two trust levels is the right model: `ask` (show approval UI) and `always` (auto-approve with indicator).
+
+### Existing Codebase Patterns
+
+| System | Dangerous Flag | Approval UI | Trust State |
+|---|---|---|---|
+| Quick Actions | `dangerous: true` | `confirmationDialog` (modal) | None (always asks) |
+| AI Tool Calls | `destructive: true` | None (auto-executes) | None |
+| System Prompt | "confirm if count > 5" | AI asks in prose | None |
+
+**Key finding**: The confirmation dialog is wrong for chat context — it breaks conversation flow. Inline approval is the right pattern for streaming chat.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Remove `requireApprovalForMutations` | Remove entirely | Unused, redundant with `destructive`, approval fatigue |
+| `needsApproval` conditional | Only set when `true` | Avoids sending `needsApproval: false` for every tool |
+| Approval UI location | Inline in `ToolCallPart.svelte` | Maintains conversation flow; matches Cursor/Claude patterns |
+| Trust persistence | Workspace table (`toolTrustTable`) | CRDT-backed, syncs across devices, follows existing workspace data pattern |
+| Trust levels | `ask` / `always` (2 levels) | Matches industry standard; no unnecessary complexity |
+| Trust scope | Per-action name, not per-session | "Always Allow" means always, across conversations |
+| Trust revocation | Settings page toggle | Not in the approval UI itself — too easy to misclick |
+| Non-destructive tools | No approval ever | Queries and safe mutations auto-execute always |
+
+## Architecture
+
+### Trust State
+
+```typescript
+// $lib/state/tool-trust.svelte.ts
+type TrustLevel = 'ask' | 'always';
+
+// Backed by workspace table (toolTrustTable in workspace.ts)
+// CRDT-synced across devices — non-destructive tools are implicitly 'always'
+```
+
+### Approval Flow
+
+```
+User sends message
+        │
+        ▼
+Server processes, LLM calls tool
+        │
+        ▼
+Server checks needsApproval on tool definition
+        │
+        ├── false/absent → TOOL_CALL event → ChatClient auto-executes
+        │
+        └── true → APPROVAL_REQUESTED event → ChatClient pauses
+                        │
+                        ▼
+              ToolCallPart renders approval UI
+                        │
+                        ▼
+              Check trust state for this tool name
+                        │
+                        ├── 'always' → auto-approve immediately
+                        │              (show subtle ✅ indicator)
+                        │
+                        └── 'ask' → show [Allow] [Always Allow] [Deny]
+                                        │
+                                        ├── Allow → client.approve(id)
+                                        ├── Always Allow → persist trust + approve
+                                        └── Deny → client.deny(id) or stop
+```
+
+### ToolCallPart UI States
+
+```
+┌─────────────────────────────────────────────────────┐
+│  State: APPROVAL_REQUESTED (untrusted)              │
+│                                                     │
+│  🔴 Close Tabs                                      │
+│  Arguments: { tabIds: ["abc_1", "abc_2", "abc_3"] } │
+│                                                     │
+│  ┌─────────┐ ┌───────────────┐ ┌──────┐           │
+│  │  Allow  │ │ Always Allow  │ │ Deny │           │
+│  └─────────┘ └───────────────┘ └──────┘           │
+├─────────────────────────────────────────────────────┤
+│  State: APPROVAL_REQUESTED (auto-approved)          │
+│                                                     │
+│  ⏳ Close Tabs (auto-approved)                      │
+│     └─ Details                                      │
+├─────────────────────────────────────────────────────┤
+│  State: RUNNING                                     │
+│                                                     │
+│  ⏳ Close Tabs…                                     │
+│     └─ Details                                      │
+├─────────────────────────────────────────────────────┤
+│  State: COMPLETED                                   │
+│                                                     │
+│  ✅ Close Tabs                                      │
+│     └─ Details                                      │
+├─────────────────────────────────────────────────────┤
+│  State: DENIED                                      │
+│                                                     │
+│  ⛔ Close Tabs — denied                             │
+│     └─ Details                                      │
+└─────────────────────────────────────────────────────┘
+```
+
+## Implementation Plan
+
+### Phase 1: Cleanup — Remove `requireApprovalForMutations`
+
+- [x] **1.1** Remove `requireApprovalForMutations` option from `actionsToClientTools` in `packages/ai/src/tool-bridge.ts`
+- [x] **1.2** Change `needsApproval` to only be set when `action.destructive` is truthy (conditional spread, not always-set)
+- [x] **1.3** In `toToolDefinitions`, only forward `needsApproval` when truthy (match the conditional pattern)
+- [x] **1.4** Update `tool-bridge.test.ts` — remove the `requireApprovalForMutations` test, keep the `destructive → needsApproval` test, add a test that non-destructive tools omit `needsApproval`
+- [x] **1.5** Update the `ToolDefinitionPayload` JSDoc to reflect the simplified model
+- [x] **1.6** Remove the `requireApprovalForMutations` mentions from the previous spec's review section
+
+### Phase 2: Trust State
+
+- [x] **2.1** Create `apps/tab-manager/src/lib/state/tool-trust.svelte.ts` — reactive trust state backed by workspace table
+  > **Deviation**: Changed from localStorage to a `defineTable`-backed workspace table (`toolTrustTable` in `workspace.ts`). This gives per-row CRDT merging across devices and follows the existing workspace data pattern. The table is defined in `apps/tab-manager/src/lib/workspace.ts`.
+- [x] **2.2** Export `getToolTrust(name: string): TrustLevel`, `setToolTrust(name: string, level: TrustLevel)`, and `toolTrustState` (reactive SvelteMap synced via `.observe()`)
+- [x] **2.3** Default: all tools are implicitly `'ask'` unless the user has explicitly trusted them via `setToolTrust`
+
+### Phase 3: Investigate TanStack AI Approval Integration
+
+- [x] **3.1** Research how TanStack AI's ChatClient signals approval state — confirmed `part.state === 'approval-requested'` and `part.approval` object
+- [x] **3.2** Research how to call approval — confirmed: `chatClient.addToolApprovalResponse({ id: part.approval.id, approved: boolean })`
+- [x] **3.3** Research whether the server needs changes — **No changes needed.** `chat()` auto-handles `needsApproval` and emits `approval-requested` SSE events
+- [x] **3.4** Document findings and update this spec before proceeding to Phase 4
+
+### Phase 4: Inline Approval UI
+
+- [x] **4.1** Update `ToolCallPart.svelte` to detect `part.state === 'approval-requested'`
+- [x] **4.2** When approval-requested AND trust is `'ask'`: render inline [Allow] [Always Allow] [Deny] buttons
+- [x] **4.3** When approval-requested AND trust is `'always'`: auto-approve immediately via `$effect`, show subtle "Auto-approved" indicator
+- [x] **4.4** Wire [Allow] to `aiChatState.active?.approveToolCall(approval.id, true)`
+- [x] **4.5** Wire [Always Allow] to `setToolTrust(name, 'always')` + `approveToolCall`
+- [x] **4.6** Wire [Deny] to `aiChatState.active?.approveToolCall(approval.id, false)`
+- [x] **4.7** Style the approval UI — ShieldAlert/ShieldCheck icons, outline/ghost buttons, amber/green colors
+- [x] **4.8** Expose `approveToolCall` from chat-state via `ConversationHandle` — delegates to `client.addToolApprovalResponse`
+
+### Phase 5: Verification
+
+- [x] **5.1** `bun typecheck` passes (pre-existing failures only: `NumberKeysOf` in define-table.ts, `#/utils.js` in UI package)
+- [x] **5.2** `bun test` passes — tool-bridge (4/4), describe-workspace (9/9)
+- [ ] **5.3** Manual test: destructive tool in chat shows approval UI
+- [ ] **5.4** Manual test: "Always Allow" persists across conversations
+- [ ] **5.5** Manual test: non-destructive tools auto-execute without approval
+
+## Edge Cases
+
+### Trust state and new destructive actions
+
+1. Developer adds a new `destructive: true` action
+2. User has never seen it → no trust entry in the workspace table
+3. Default behavior: show approval UI (`'ask'`)
+4. This is correct — new destructive actions are untrusted by default
+
+### Workspace data reset
+
+1. User resets their workspace or starts fresh
+2. All trust entries are lost (part of the Y.Doc)
+3. Destructive actions revert to `'ask'`
+4. This is acceptable — re-trusting is low friction
+
+### Multiple destructive tool calls in one response
+
+1. AI calls `tabs.close` three times in one response (e.g. closing tabs from different windows)
+2. If trust is `'ask'`: show approval for each tool call independently
+3. If trust is `'always'`: auto-approve all three
+4. No "approve all" batch button — keep it simple for now
+
+### Server doesn't support APPROVAL_REQUESTED
+
+1. If the API server's `chat()` handler doesn't use TanStack AI's `executeToolCalls` with approval support, the server might just send `TOOL_CALL` events regardless of `needsApproval`
+2. Phase 3 research will determine this
+3. If the server doesn't support it, we either: (a) add server support, or (b) implement client-side approval interception (intercept the tool execution in `ChatClient.tools[name].execute()` before it runs)
+
+## Open Questions
+
+1. **Does the API server support `APPROVAL_REQUESTED`?**
+   - The server at `apps/api/src/` has no grep hits for `needsApproval`, `approval`, or `executeToolCalls`
+   - Phase 3 will investigate whether `chat()` from TanStack AI automatically handles this
+   - **Recommendation**: If not, client-side interception is simpler — wrap `execute` functions with a trust gate
+
+2. **Should "Always Allow" persist across extension updates?**
+   - Workspace table data persists via IndexedDB and Y.Doc sync
+   - **Resolved**: Yes. Trust is stored in the workspace table, which survives updates and syncs across devices
+
+3. **Should there be a UI to revoke trust?**
+   - Users who click "Always Allow" may want to undo it
+   - **Recommendation**: Add a simple list in settings (later spec). For now, the workspace table can be queried directly
+
+4. **What about the system prompt "confirm if count > 5" guideline?**
+   - The system prompt tells the AI to confirm large operations in prose
+   - With proper approval UI, this is redundant — the UI handles it
+   - **Recommendation**: Remove that guideline from the system prompt in Phase 1, or defer to a later cleanup
+
+## Success Criteria
+
+- [ ] `requireApprovalForMutations` is fully removed from the codebase
+- [ ] `needsApproval` is only set on tools with `destructive: true`
+- [ ] Destructive tool calls in chat show inline approval UI (or auto-approve if trusted)
+- [ ] Non-destructive tool calls execute immediately without any approval gate
+- [ ] "Always Allow" persists across conversations and page reloads
+- [ ] All existing tests pass with no regressions
+
+## References
+
+- `packages/ai/src/tool-bridge.ts` — `actionsToClientTools`, `toToolDefinitions`, `needsApproval` logic
+- `packages/ai/src/tool-bridge.test.ts` — Tests for destructive → needsApproval mapping
+- `packages/workspace/src/shared/actions.ts` — `ActionConfig.destructive` definition
+- `apps/tab-manager/src/lib/workspace.ts` — All 13 action definitions with `destructive: true` on `tabs.close`
+- `apps/tab-manager/src/lib/components/chat/ToolCallPart.svelte` — Current tool call rendering (no approval UI)
+- `apps/tab-manager/src/lib/state/chat-state.svelte.ts` — `ChatClient` setup, `workspaceTools` passed as client tools
+- `apps/tab-manager/src/lib/quick-actions.ts` — Existing `dangerous` flag pattern with `confirmationDialog`
+- `packages/ui/src/confirmation-dialog/` — Existing confirmation dialog (for reference, not for reuse in chat)
+- `apps/tab-manager/src/lib/ai/system-prompt.ts` — "confirm if count > 5" guideline to potentially remove
+- `specs/20260312T153000-action-metadata-title-destructive.md` — Previous spec that added `destructive`


### PR DESCRIPTION
Adds a progressive trust model for destructive AI tool calls in the tab manager chat. Previously, all tools auto-executed immediately with no confirmation—even destructive ones like closing tabs. Now destructive tools show an inline approval gate, and users can escalate to "always allow" per-tool.

The existing codebase had three overlapping mechanisms for tool safety: a blanket `requireApprovalForMutations` option (unused), a `destructive` flag on action definitions (just added), and a system prompt guideline asking the AI to "confirm if count > 5." None of them actually gated execution. This PR collapses them into a single, functional pipeline: `destructive: true` → `needsApproval` on the wire → TanStack AI pauses → inline approval UI → optional trust escalation.

```
Action Definition (destructive: true)
    │
    ▼
Tool Bridge (needsApproval: true — only when destructive)
    │
    ▼
Server emits APPROVAL_REQUESTED SSE event
    │
    ▼
ToolCallPart checks trust state
    │
    ├── 'always' → auto-approve, show ✅ indicator
    │
    └── 'ask' → render [Allow] [Always Allow] [Deny]
                    │
                    ├── Allow → resume tool execution
                    ├── Always Allow → persist trust + resume
                    └── Deny → cancel tool execution
```

Trust state is stored in a Y.Doc-backed workspace table, so "Always Allow" decisions sync across devices via CRDT—same as every other piece of workspace data.

### Why `destructive` instead of `requireApprovalForMutations`?

The blanket option was dead code—nobody passed `true`. And it was the wrong abstraction: not all mutations are destructive (opening a tab is a mutation, but nobody wants an approval dialog for that). The `destructive` flag is explicit at the action definition site, which is where the author actually knows whether the operation needs a gate.

### Why a factory function for tool-trust state?

Every other state module in `apps/tab-manager/src/lib/state/` uses a `createXxxState()` factory → singleton export pattern. `tool-trust` was the only outlier—loose top-level exports, a leaked `SvelteMap`, and an unnecessary `as TrustLevel` assertion. The refactor brings it in line with the codebase convention:

```typescript
// BEFORE — scattered exports, leaked internals
export const toolTrustState: SvelteMap<string, TrustLevel> = new SvelteMap(...);
export function getToolTrust(name: string): TrustLevel { ... }
export function setToolTrust(name: string, level: TrustLevel): void { ... }
export function shouldAutoApprove(name: string): boolean { ... }

// AFTER — factory function, hidden SvelteMap, method shorthand
export const toolTrustState = createToolTrustState();
// toolTrustState.get(name)
// toolTrustState.set(name, level)
// toolTrustState.shouldAutoApprove(name)
```

### Why Y.Doc table instead of localStorage?

Trust decisions are user data that should follow you across devices. Storing in the workspace table gives per-row CRDT merging for free and matches how every other piece of persistent state works in this app—no new storage mechanism to maintain.

## Changelog
- Add inline approval UI for destructive AI tool calls (Allow / Always Allow / Deny)
- Add per-tool "Always Allow" trust that syncs across devices