### PR TITLE
fix(honeycrisp): move action buttons below date

### DIFF
--- a/apps/honeycrisp/src/lib/components/NoteList.svelte
+++ b/apps/honeycrisp/src/lib/components/NoteList.svelte
@@ -167,7 +167,7 @@
 								</p>
 
 								<div
-									class="absolute right-2 top-2 hidden items-center gap-0.5 group-hover:flex {selectedNoteId ===
+									class="absolute bottom-1 right-2 hidden items-center gap-0.5 group-hover:flex {selectedNoteId ===
 									note.id
 										? 'flex'
 										: ''}"


### PR DESCRIPTION
## Summary
- Pin/delete buttons on note list items were overlapping the date text on hover
- Moved buttons from `top-2` to `bottom-1` so they render below the date row

> Before

<img width="629" height="67" alt="Screenshot 2026-03-12 at 11 43 32 PM" src="https://github.com/user-attachments/assets/0ec55adb-bced-4ed6-9b96-e6e67b627c18" />


> After

<img width="637" height="117" alt="Screenshot 2026-03-12 at 11 43 06 PM" src="https://github.com/user-attachments/assets/7ac6eb86-cf12-4df2-a0ff-76187e68bf6f" />

