### PR TITLE
docs: add CLA infrastructure and modernize GitHub templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Commercially relevant code — requires @braden-w review
+# These paths contain the sync server and protocol (dual-licensed commercially).
+
+/apps/api/              @braden-w
+/packages/sync/         @braden-w
+/packages/sync-client/  @braden-w

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -72,6 +72,10 @@ body:
         - Settings
         - Transcription
         - Local Models
+        - Sync (sync server/client)
+        - CLI
+        - Workspace (data layer)
+        - Landing Page
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -78,8 +78,8 @@ body:
   - type: input
     id: version
     attributes:
-      label: Whispering Version
-      description: What version of Whispering are you using?
+      label: Epicenter Version
+      description: What version are you using? (Check Settings or About)
       placeholder: e.g., v7.5.0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discord Community
+    url: https://go.epicenter.so/discord
+    about: Ask questions, share ideas, or get help from the community
+  - name: Contributing Guide
+    url: https://github.com/EpicenterHQ/epicenter/blob/main/CONTRIBUTING.md
+    about: Read the contributing guide before opening your first PR

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -70,7 +70,7 @@ body:
     id: contribution
     attributes:
       label: Willing to Contribute?
-      description: Would you be interested in helping implement this feature?
+      description: Would you be interested in helping implement this feature? First-time contributors sign a one-time CLA—see CONTRIBUTING.md for details.
       options:
         - "Yes, I can implement this"
         - "Yes, but I'd need guidance"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,19 +6,6 @@
 
 <!-- One line per user-visible change. Omit this section entirely for internal-only changes. -->
 
-## Type of Change
-
-<!-- Mark the relevant option with an "x" -->
-
-- [ ] `feat`: New feature
-- [ ] `fix`: Bug fix
-- [ ] `docs`: Documentation update
-- [ ] `refactor`: Code refactoring (no functional changes)
-- [ ] `perf`: Performance improvement
-- [ ] `test`: Test additions or changes
-- [ ] `chore`: Maintenance tasks
-- [ ] `style`: Code style changes
-
 ## Related Issue
 
 <!-- Link to the issue this PR addresses, if applicable -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,6 +42,7 @@ Closes #
 - [ ] I've added/updated tests for my changes (if applicable)
 - [ ] My changes don't break existing functionality
 - [ ] I've updated documentation (if needed)
+- [ ] If touching `apps/api/`, `packages/sync/`, or `packages/sync-client/`—CODEOWNERS requires @braden-w review
 
 ## Screenshots/Recordings
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -39,6 +39,7 @@ Web apps (Cloudflare Workers) deploy **together in one workflow** because deploy
 |---|---|---|
 | `ci.format.yml` | Push, pull requests | Runs `bun run lint:check` and `bun run typecheck`. |
 | `ci.autofix.yml` | Push, pull requests | Runs `bun run format` and commits fixes back via autofix-ci. |
+| `ci.cla.yml` | Pull requests, issue comments | Enforces CLA signing via [contributor-assistant](https://github.com/contributor-assistant/github-action). Stores signatures in `signatures/cla.json`. |
 
 ### Automation
 

--- a/.github/workflows/ci.cla.yml
+++ b/.github/workflows/ci.cla.yml
@@ -1,0 +1,42 @@
+name: CLA
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    if: |
+      (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')
+      || github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        uses: contributor-assistant/github-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_ACTIONS_PAT }}
+        with:
+          path-to-signatures: 'signatures/cla.json'
+          path-to-document: 'https://github.com/EpicenterHQ/epicenter/blob/main/CLA.md'
+          branch: 'main'
+          allowlist: 'bot*,dependabot[bot],renovate[bot],github-actions[bot]'
+          custom-notsigned-prcomment: >-
+            Thank you for your contribution! Before we can merge this PR, we need you to sign our
+            [Contributor License Agreement](https://github.com/EpicenterHQ/epicenter/blob/main/CLA.md).
+            This is a one-time requirement—it lets us offer commercial licenses for the sync server
+            while you retain full copyright on your code.
+
+
+            To sign, please comment on this PR with:
+
+            > I have read the CLA Document and I hereby sign the CLA
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,31 @@
+# Epicenter Contributor License Agreement (CLA)
+
+Thank you for your interest in Epicenter. This document clarifies the terms under which you provide "Contributions" to the Epicenter project and the EpicenterHQ GitHub organization.
+
+By commenting "I have read the CLA Document and I hereby sign the CLA" on a pull request, you agree to the terms below.
+
+## 1. Definitions
+"You" means the individual or legal entity that is making this Agreement with EpicenterHQ. "Contribution" means any source code, documentation, or other material submitted by You for inclusion in, or documentation of, the Epicenter project. "Work" means the work of authorship made available by EpicenterHQ under an open-source license, to which Your Contribution was submitted.
+
+## 2. Grant of Copyright License
+Subject to the terms and conditions of this Agreement, You hereby grant to EpicenterHQ and to recipients of software distributed by EpicenterHQ a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works.
+
+## 3. Grant of Patent License
+Subject to the terms and conditions of this Agreement, You hereby grant to EpicenterHQ and to recipients of software distributed by EpicenterHQ a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution(s) alone or by combination of Your Contribution(s) with the Work to which such Contribution(s) was submitted.
+
+## 4. Representations
+You represent that You are legally entitled to grant the above licenses. If your employer(s) has rights to intellectual property that You create that includes Your Contributions, You represent that You have received permission to make Contributions on behalf of that employer, that Your employer has waived such rights for Your Contributions to EpicenterHQ, or that Your employer has executed a separate Corporate CLA with EpicenterHQ.
+
+You represent that each of Your Contributions is Your original creation. You represent that Your Contribution submissions include complete details of any third-party license or other restriction (including, but not limited to, related patents and trademarks) of which you are personally aware and which are associated with any part of Your Contributions.
+
+## 5. Retained Rights
+Except for the licenses granted herein to EpicenterHQ and recipients of software distributed by EpicenterHQ, You reserve all right, title, and interest in and to Your Contributions. You retain copyright in Your Contributions.
+
+## 6. Disclaimer of Warranty
+Unless required by applicable law or agreed to in writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## 7. Limitation of Liability
+In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall You be liable to EpicenterHQ or any other party for any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this Agreement or out of the use or inability to use the Contribution.
+
+---
+*Note: Contributors retain copyright on their own code.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,6 +246,14 @@ curl -fsSL https://bun.sh/install | bash -s "bun-v1.2.19"
 - **Issues**: Check existing issues or create a new one
 - **Documentation**: Each app has its own README with specific details
 
+## Licensing and CLA
+
+Epicenter is licensed under [AGPL-3.0](LICENSE). All contributions are made under this license.
+
+We require a one-time [Contributor License Agreement](CLA.md) (CLA) for all contributions. The CLA is a license grant—not a copyright assignment. You keep full copyright on your code. It gives the project the right to distribute your contribution under additional license terms, which is how we offer commercial licenses for the sync server.
+
+When you open your first PR, the CLA bot will comment with instructions. Just reply with the signing phrase and you're set—it takes about ten seconds.
+
 ## Philosophy
 
 We believe in:

--- a/HOW_TO_MONETIZE.md
+++ b/HOW_TO_MONETIZE.md
@@ -1,0 +1,74 @@
+# How to Monetize Epicenter
+
+Honestly, we're still figuring this out. I've been thinking about it a lot—talked it through with contributors, posted about it in [#792](https://github.com/EpicenterHQ/epicenter/issues/792), and gone back and forth on a few different models. What follows is where my head is at right now.
+
+## The short version
+
+Epicenter is AGPL-3.0. It stays that way. We require a lightweight CLA (license grant, not copyright assignment—contributors keep their copyright) and we don't need to formally "dual license" anything. When an enterprise wants to self-host our sync server but can't accept AGPL (because their legal team won't let them), we sell them a commercial license. That's just a private contract between us and them—nothing changes on the public repo.
+
+The AGPL isn't the business model. It's the moat that makes the business model work.
+
+## What we considered
+
+In issue [#792](https://github.com/EpicenterHQ/epicenter/issues/792), I wrote about wanting Epicenter to become a foundational data framework—an SSO for AI applications where users own their data and developers build on top. That goal hasn't changed. But the question of how to fund it has evolved.
+
+We looked at a few options:
+
+1. Traditional SaaS (like a Proton Suite or Google Suite of apps)
+2. Formal dual licensing (AGPL for open source, commercial license for closed-source use)
+3. Keeping it simple—AGPL plus selling commercial contracts when enterprises come knocking
+
+Option 3 won. It's the least complicated, stays faithful to open source, and doesn't require any infrastructure or legal overhead we don't need yet.
+
+## How AGPL actually works as leverage
+
+Here's something I didn't fully appreciate until recently: AGPL is effectively a lead generation tool for enterprise sales. Not because we'd ever sue anyone, but because of how corporate compliance works.
+
+The typical flow looks like this: a developer at a company discovers Epicenter, starts using it, loves it. Then their compliance tooling (Snyk, FOSSA, whatever they use) flags AGPL in a dependency scan. Legal sees the flag and applies their blanket ban—most Fortune 500 companies prohibit AGPL by default. At that point, the company has two options: stop using it, or buy a commercial license. We get a sales conversation we didn't have to create.
+
+This is the same playbook that Grafana Labs ($9B valuation, $400M+ ARR), Bitwarden ($100M Series B), and MinIO ($1B+ valuation) all use. AGPL creates the constraint. The commercial license removes it.
+
+## The three revenue streams
+
+We see three ways this generates revenue, serving different kinds of customers:
+
+**Hosted sync.** We run the sync server. Users pay for the convenience of not managing infrastructure, plus end-to-end encryption. This is the Obsidian model—they make roughly 80% of their revenue from Sync alone. Individual users and small teams will never self-host; they just want it to work. This is the volume play.
+
+**Enterprise self-host licenses.** Banks, healthcare companies, defense contractors, anyone with strict data sovereignty requirements—they need to run the sync server on their own infrastructure. Their legal team flags the AGPL, and that forces a commercial conversation. They're buying AGPL escape plus SSO, audit logs, and a support SLA. This is the high-ticket play.
+
+**AI compute.** Epicenter does transcription and AI assistance. Users who don't want to manage their own API keys pay us for bundled access. We negotiate volume pricing with model providers and mark it up slightly. Nice margin on top.
+
+These aren't competing streams. The person paying $10/month for hosted sync will never self-host. The enterprise paying $100k/year for a commercial license will never use our hosted sync—their compliance team won't let data leave their network. Different buyers, different motivations, same AGPL foundation.
+
+## Why not a formal dual license?
+
+A formal dual license means you publish the code as "available under AGPL-3.0 OR our Commercial License" with public pricing and self-serve purchasing. That makes sense when you have hundreds of companies needing licenses and you want to scale sales without talking to each one.
+
+We're nowhere near that stage. Adding that complexity now would be solving a problem we don't have. When the first enterprise comes to us, we write them a contract. If we end up writing the same contract ten times, we formalize it into a public offering. Until then, AGPL on the repo is all we need.
+
+## The CLA
+
+Every project on the list below uses a CLA—it's basically table stakes for the AGPL-to-commercial model. So we added one. It's a lightweight Apache ICLA-style agreement that grants us a license to include your code in both the open-source and commercial versions of Epicenter.
+
+The sync server is still 100% my code, but adding this now future-proofs the project as we grow. Here's something I didn't fully appreciate until recently: without a CLA, we'd eventually hit a wall where we couldn't offer a commercial license for the whole stack because of a few small external commits. That feels like a risk we shouldn't take.
+
+Crucially, this is a license grant, NOT copyright assignment. You keep your copyright. You're just giving us permission to use your work in the ecosystem we're building together. You can read the full text in [CLA.md](CLA.md). That feels like an honest trade to me.
+
+## The comps
+
+Projects using this same AGPL approach at venture scale right now:
+
+- Grafana Labs—$9B valuation, switched to AGPL specifically to prevent cloud providers from strip-mining their value
+- Bitwarden—AGPL, $100M Series B, sells enterprise self-host licenses
+- MinIO—$1B+ valuation, AGPL forces enterprise licenses starting at ~$96k/year
+- AppFlowy—AGPL, $6.4M seed, open core plus enterprise self-host (closest to our architecture)
+- Logseq—AGPL, local-first desktop app, VC-backed (closest comp to Epicenter overall)
+
+Nobody's proven a $10B+ exit with this exact model yet. But Grafana at $9B is close, and none of those comps had our AI angle.
+Every one of these projects requires a CLA. We do now too.
+
+## What I care about
+
+I wrote in [#792](https://github.com/EpicenterHQ/epicenter/issues/792) that I want to double down on supporting scrappy developers who are building in the open. That hasn't changed. AGPL keeps the project truly open for the community. If you're building open-source software with Epicenter, it's completely free—no strings, no license fees, no gotchas.
+
+The commercial side is for companies that want to take the sync server, run it behind their firewall, and not share their modifications. That feels like an honest trade to me.

--- a/HOW_TO_MONETIZE.md
+++ b/HOW_TO_MONETIZE.md
@@ -28,6 +28,15 @@ The typical flow looks like this: a developer at a company discovers Epicenter, 
 
 This is the same playbook that Grafana Labs ($9B valuation, $400M+ ARR), Bitwarden ($100M Series B), and MinIO ($1B+ valuation) all use. AGPL creates the constraint. The commercial license removes it.
 
+
+## What this means for developers building on Epicenter
+
+If you're building on top of Epicenter's libraries, your own code can be under any license that's compatible with AGPL-3.0. That includes most modern permissive licenses—MIT, Apache 2.0, BSD, ISC, and others. You don't have to use AGPL for your own code.
+
+The catch is that the **combined work** (your code + our AGPL library) must comply with AGPL when you distribute it or serve it over a network. In practice, this means users of your app must be able to get the full source code. Your original files keep whatever license you put on them—someone could fork your MIT code, swap out the Epicenter dependency, and redistribute under pure MIT. But as long as our AGPL library is in the mix, the distributed package follows AGPL rules.
+
+This is the same pattern Grafana uses—their UI libraries (`grafana-ui`, `grafana-data`) are Apache 2.0 so plugin developers aren't forced into AGPL for their own code, even though the combined Grafana distribution is AGPL.
+
 ## The three revenue streams
 
 We see three ways this generates revenue, serving different kinds of customers:

--- a/specs/20260313T071500-add-cla-infrastructure.md
+++ b/specs/20260313T071500-add-cla-infrastructure.md
@@ -1,0 +1,134 @@
+# Add CLA Infrastructure
+
+## Problem
+
+HOW_TO_MONETIZE.md claims Epicenter follows the same AGPL dual-licensing playbook as Grafana ($9B), MongoDB, Bitwarden, and MinIO—but omits that every one of those companies requires a Contributor License Agreement. Without a CLA:
+
+1. Community contributions to commercially relevant code (sync server, sync protocol) can't be commercially licensed
+2. Future relicensing is blocked by copyright fragmentation across ~30 contributors
+3. The "add CLA later" approach creates a timing risk—any contribution that lands before the CLA is in place is permanently AGPL-only
+4. CONTRIBUTING.md has zero mention of licensing, copyright, or contributor agreements
+
+## Solution
+
+Add a lightweight CLA using the CLA Assistant GitHub Action (signatures stored in-repo, no external dependencies), update CONTRIBUTING.md, fix HOW_TO_MONETIZE.md's misleading comps section, and add CODEOWNERS to gate commercially relevant paths.
+
+## Commercially Relevant Code Paths
+
+These directories contain the sync server and protocol code that Braden wrote 100% and intends to sell commercially:
+
+- `apps/api/` — Sync server (Cloudflare Workers + Durable Objects)
+- `packages/sync/` — Sync protocol library
+- `packages/sync-client/` — Sync client library
+
+## CLA Template Choice
+
+**Apache-style ICLA (license grant, NOT copyright assignment).**
+
+Why:
+- Grafana uses a modified Apache ICLA—closest comp to Epicenter's model
+- License grant is less intimidating to contributors than copyright assignment
+- Grants the project perpetual, worldwide, royalty-free, non-exclusive right to sublicense contributions—which is exactly what's needed for dual-licensing
+- Contributors retain copyright on their own code
+- Standard, well-understood, legally tested
+
+What the CLA covers:
+- Copyright license: right to reproduce, prepare derivative works, sublicense, and distribute
+- Patent license: non-exclusive patent grant for the contribution
+- Contributor represents they have the right to submit the work
+- Contributor represents the work is their original creation
+
+## Implementation Plan
+
+### Todo Items
+
+- [x] **1. Draft CLA document** — Create `CLA.md` at repo root based on Apache ICLA template, adapted for Epicenter/EpicenterHQ. Keep it short (under 2 pages).
+
+- [x] **2. Add CLA Assistant GitHub Action** — Create `.github/workflows/ci.cla.yml` that:
+  - Triggers on `pull_request_target` and `issue_comment`
+  - Comments on PRs from first-time contributors asking them to sign
+  - Accepts signature via PR comment ("I have read the CLA Document and I hereby sign the CLA")
+  - Stores signatures in `signatures/cla.json` in the repo
+  - Allowlists bots (dependabot, renovate, etc.)
+
+- [x] **3. Create CODEOWNERS** — Add `.github/CODEOWNERS` gating:
+  - `apps/api/` → @braden-w (sync server)
+  - `packages/sync/` → @braden-w (sync protocol)
+  - `packages/sync-client/` → @braden-w (sync client)
+  - This ensures all PRs touching commercially relevant code require Braden's explicit review
+
+- [x] **4. Update CONTRIBUTING.md** — Add a "Licensing and CLA" section that:
+  - States the project is AGPL-3.0
+  - Explains that a CLA is required for contributions
+  - Links to CLA.md
+  - Notes that the CLA bot will prompt on first PR
+
+- [x] **5. Update HOW_TO_MONETIZE.md** — Fix the misleading sections:
+  - "Why not a CLA?" → Update to reflect that a CLA is now in place
+  - Comps section → Add acknowledgment that all listed comps use CLAs
+  - Keep the overall strategy and tone the same—just make it accurate
+
+## What This Does NOT Change
+
+- The AGPL-3.0 license stays
+- The monetization strategy stays (it was correct, just incomplete)
+- Existing contributors' code remains under AGPL (their past contributions don't retroactively fall under the CLA)
+- No copyright assignment—contributors keep their copyright
+
+## Decisions Made
+
+1. **CLA scope**: All contributions (matches Grafana/MongoDB/Bitwarden)
+2. **CLA style**: Apache ICLA adapted for Epicenter
+3. **Retroactive outreach**: Yes, belt-and-suspenders approach
+
+## Retroactive Outreach Plan
+
+**Key insight**: Existing contributions are already under AGPL. The CLA is about granting additional commercial sublicensing rights. Since existing contributions are in the desktop app (not the sync server), non-response does NOT block commercial licensing.
+
+### Process
+
+1. Run `git shortlog -sne` to identify all contributors + GitHub handles
+2. Create a GitHub Discussion explaining the CLA, why it exists, and how to sign
+3. Tag all ~30 contributors in the discussion
+4. **30-day grace period** (industry standard)
+5. For non-responders after 30 days:
+   - Their existing code stays under AGPL (nothing changes for them)
+   - Note which files they contributed to in an internal tracking doc
+   - If you ever need to commercially license those specific files, rewrite them at that point
+   - **No rebasing needed** you just create new commits replacing their code if/when needed
+6. For responders: their signature goes into signatures/cla.json with a note that it covers past and future contributions
+
+### Why NOT rebase/rewrite now
+
+- Rewriting ~220 commits is massive effort for near-zero benefit
+- Their code is in the desktop app, not the sync server
+- The commercial product is the sync server, which is 100% Braden's code
+- Rewriting would only matter if you wanted to sell the desktop app under a commercial license (you don't)
+
+## Review
+
+**Status**: Implemented
+
+### Summary
+
+All five spec items implemented in a single wave (all touched different files). Added CLA infrastructure following the Apache ICLA model with GitHub Action enforcement, CODEOWNERS gating for commercially relevant paths, and updated both CONTRIBUTING.md and HOW_TO_MONETIZE.md to reflect the CLA.
+
+### Files Created
+
+- `CLA.md` — Apache ICLA-style license grant (31 lines, 7 sections)
+- `.github/workflows/ci.cla.yml` — CLA enforcement via contributor-assistant/github-action@v2
+- `.github/CODEOWNERS` — Gates `apps/api/`, `packages/sync/`, `packages/sync-client/` for @braden-w review
+
+### Files Modified
+
+- `CONTRIBUTING.md` — Added "Licensing and CLA" section before Philosophy
+- `HOW_TO_MONETIZE.md` — Updated "The short version" (removed "we don't need a CLA right now"), renamed "Why not a CLA?" to "The CLA", added CLA acknowledgment to comps section
+
+### Deviations from Spec
+
+- Workflow named `ci.cla.yml` instead of `cla.yml` — follows the repo's established `ci.` prefix convention for PR check workflows
+
+### Follow-up Work
+
+- Retroactive outreach to ~30 existing contributors (see Retroactive Outreach Plan section above)
+- Create initial `signatures/cla.json` on first contributor signature (the GitHub Action handles this automatically)


### PR DESCRIPTION
Adds CLA infrastructure—Apache ICLA-style license grant, GitHub Action enforcement, CODEOWNERS gating for commercially relevant paths—and updates GitHub templates to reflect the Epicenter rebrand.

FINANCIAL_SUSTAINABILITY.md lays out how we hope to become financially sustainable: AGPL stays, we sell commercial licenses to enterprises that can't accept it. Grafana, Bitwarden, MinIO, AppFlowy, and Logseq all use this same model, and every one of them requires a CLA.

### CLA infrastructure

```
.github/workflows/ci.cla.yml    ← GitHub Action via contributor-assistant/github-action@v2
CLA.md                           ← Apache ICLA adapted for Epicenter (license grant, NOT copyright assignment)
signatures/cla.json              ← Created automatically on first signature
.github/CODEOWNERS               ← Gates apps/api/, packages/sync/, packages/sync-client/ for @braden-w review
```

The CLA bot comments on first-time PRs with signing instructions. Contributors reply with the signing phrase and they're set—takes about ten seconds. Bots (dependabot, renovate, github-actions) are allowlisted.

### Template updates

The GitHub templates were still referencing "Whispering" in places and missing ecosystem-wide components. This PR:

- Renames "Whispering Version" → "Epicenter Version" in bug reports
- Adds Sync, CLI, Workspace, and Landing Page to the affected component dropdown
- Removes the redundant "Type of Change" checkbox section from the PR template (the commit prefix already communicates this)
- Adds a CODEOWNERS reminder to the PR checklist
- Mentions CLA in the feature request's "Willing to Contribute?" dropdown
- Adds issue template config with blank issue option and Discord/Contributing links

### Documentation updates

CONTRIBUTING.md gets a new "Licensing and CLA" section explaining the requirement. FINANCIAL_SUSTAINABILITY.md is updated to reflect that the CLA is now in place (previously it said "we don't need one yet") and acknowledges that all listed comps use CLAs. A new section clarifies AGPL-compatible license options for downstream developers.

Lays groundwork for #792