### PR TITLE
fix(honeycrisp): update to simplified KV API

### DIFF
--- a/apps/honeycrisp/src/lib/workspace.ts
+++ b/apps/honeycrisp/src/lib/workspace.ts
@@ -95,10 +95,10 @@ export const honeycrisp = defineWorkspace({
 	id: 'epicenter.honeycrisp' as const,
 	tables: { folders: foldersTable, notes: notesTable },
 	kv: {
-		selectedFolderId: defineKv(FolderId.or(type('null'))),
-		selectedNoteId: defineKv(NoteId.or(type('null'))),
-		sortBy: defineKv(type("'dateEdited' | 'dateCreated' | 'title'")),
-		sidebarCollapsed: defineKv(type('boolean')),
+		selectedFolderId: defineKv(FolderId.or(type('null')), null),
+		selectedNoteId: defineKv(NoteId.or(type('null')), null),
+		sortBy: defineKv(type("'dateEdited' | 'dateCreated' | 'title'"), 'dateEdited'),
+		sidebarCollapsed: defineKv(type('boolean'), false),
 	},
 });
 

--- a/apps/honeycrisp/src/routes/+page.svelte
+++ b/apps/honeycrisp/src/routes/+page.svelte
@@ -31,13 +31,9 @@
 		folders = workspaceClient.tables.folders.getAllValid();
 		notes = workspaceClient.tables.notes.getAllValid();
 
-		const kvFolderId = workspaceClient.kv.get('selectedFolderId');
-		selectedFolderId = kvFolderId.status === 'valid' ? kvFolderId.value : null;
-
-		const kvNoteId = workspaceClient.kv.get('selectedNoteId');
-		selectedNoteId = kvNoteId.status === 'valid' ? kvNoteId.value : null;
-		const kvSortBy = workspaceClient.kv.get('sortBy');
-		sortBy = kvSortBy.status === 'valid' ? kvSortBy.value : 'dateEdited';
+		selectedFolderId = workspaceClient.kv.get('selectedFolderId');
+		selectedNoteId = workspaceClient.kv.get('selectedNoteId');
+		sortBy = workspaceClient.kv.get('sortBy');
 
 		const unsubFolders = workspaceClient.tables.folders.observe(() => {
 			folders = workspaceClient.tables.folders.getAllValid();


### PR DESCRIPTION
## Summary

- Add missing `defaultValue` params to all `defineKv()` calls in honeycrisp workspace
- Update `+page.svelte` to use the new direct-return `kv.get()` API instead of the removed `{ status, value }` wrapper