### PR TITLE
feat(opensidian): editor, navigation, and SQLite index for OpenSidian MVP

### DIFF
--- a/apps/opensidian/package.json
+++ b/apps/opensidian/package.json
@@ -11,6 +11,11 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
 	},
 	"devDependencies": {
+		"@codemirror/commands": "^6.10.3",
+		"@codemirror/lang-markdown": "^6.5.0",
+		"@codemirror/language": "^6.12.2",
+		"@codemirror/state": "^6.6.0",
+		"@codemirror/view": "^6.40.0",
 		"@epicenter/filesystem": "workspace:*",
 		"@epicenter/ui": "workspace:*",
 		"@epicenter/workspace": "workspace:*",
@@ -26,6 +31,7 @@
 		"tailwindcss": "catalog:",
 		"typescript": "catalog:",
 		"vite": "catalog:",
+		"y-codemirror.next": "^0.3.5",
 		"y-indexeddb": "catalog:",
 		"yjs": "catalog:"
 	}

--- a/apps/opensidian/src/lib/components/AppShell.svelte
+++ b/apps/opensidian/src/lib/components/AppShell.svelte
@@ -4,6 +4,7 @@
 	import ContentPanel from './ContentPanel.svelte';
 	import FileTree from './FileTree.svelte';
 	import Toolbar from './Toolbar.svelte';
+	import CommandPalette from './CommandPalette.svelte';
 </script>
 
 <div class="flex h-screen flex-col">
@@ -17,4 +18,5 @@
 		<Resizable.Handle withHandle />
 		<Resizable.Pane defaultSize={75}> <ContentPanel /> </Resizable.Pane>
 	</Resizable.PaneGroup>
+	<CommandPalette />
 </div>

--- a/apps/opensidian/src/lib/components/CodeMirrorEditor.svelte
+++ b/apps/opensidian/src/lib/components/CodeMirrorEditor.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	import { defaultKeymap, indentWithTab } from '@codemirror/commands';
+	import { markdown } from '@codemirror/lang-markdown';
+	import {
+		defaultHighlightStyle,
+		syntaxHighlighting,
+	} from '@codemirror/language';
+	import { EditorState } from '@codemirror/state';
+	import {
+		drawSelection,
+		EditorView,
+		keymap,
+		placeholder,
+	} from '@codemirror/view';
+	import { yCollab, yUndoManagerKeymap } from 'y-codemirror.next';
+	import type * as Y from 'yjs';
+
+	let {
+		ytext,
+	}: {
+		ytext: Y.Text;
+	} = $props();
+
+	let container: HTMLDivElement | undefined = $state();
+
+	$effect(() => {
+		if (!container) return;
+
+		const view = new EditorView({
+			state: EditorState.create({
+				doc: ytext.toString(),
+				extensions: [
+					keymap.of([...yUndoManagerKeymap, ...defaultKeymap, indentWithTab]),
+					drawSelection(),
+					EditorView.lineWrapping,
+					syntaxHighlighting(defaultHighlightStyle),
+					markdown(),
+					yCollab(ytext, null),
+					placeholder('Empty file'),
+					EditorView.theme({
+						'&': {
+							height: '100%',
+							fontSize: '14px',
+						},
+						'.cm-scroller': {
+							fontFamily:
+								'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
+							padding: '1rem',
+							overflow: 'auto',
+						},
+						'.cm-content': {
+							caretColor: 'var(--foreground, currentColor)',
+						},
+						'.cm-focused': {
+							outline: 'none',
+						},
+						'.cm-gutters': {
+							display: 'none',
+						},
+						'.cm-activeLine': {
+							backgroundColor: 'transparent',
+						},
+					}),
+				],
+			}),
+			parent: container,
+		});
+
+		return () => view.destroy();
+	});
+</script>
+
+<div
+	class="h-full w-full overflow-hidden bg-transparent"
+	bind:this={container}
+></div>

--- a/apps/opensidian/src/lib/components/CommandPalette.svelte
+++ b/apps/opensidian/src/lib/components/CommandPalette.svelte
@@ -1,35 +1,13 @@
 <script lang="ts">
 	import type { FileId } from '@epicenter/filesystem';
 	import * as Command from '@epicenter/ui/command';
-	import {
-		FileCode,
-		File as FileIcon,
-		FileJson,
-		FileText,
-	} from 'lucide-svelte';
+	import { getFileIcon } from '$lib/fs/file-icons';
 	import { fsState } from '$lib/fs/fs-state.svelte';
 
 	let open = $state(false);
 	let searchQuery = $state('');
 	let debouncedQuery = $state('');
 
-	// ── Extension → icon mapping ─────────────────────────────────────
-	const ICON_MAP: Record<string, typeof FileIcon> = {
-		'.md': FileText,
-		'.txt': FileText,
-		'.ts': FileCode,
-		'.js': FileCode,
-		'.tsx': FileCode,
-		'.jsx': FileCode,
-		'.json': FileJson,
-	};
-
-	function getFileIcon(name: string): typeof FileIcon {
-		const dotIndex = name.lastIndexOf('.');
-		if (dotIndex === -1) return FileIcon;
-		const ext = name.slice(dotIndex).toLowerCase();
-		return ICON_MAP[ext] ?? FileIcon;
-	}
 
 	// ── Collect all files recursively (only when palette is open) ────
 	type FileEntry = { id: FileId; name: string; parentDir: string };

--- a/apps/opensidian/src/lib/components/CommandPalette.svelte
+++ b/apps/opensidian/src/lib/components/CommandPalette.svelte
@@ -32,7 +32,7 @@
 	}
 
 	// ── Collect all files recursively (only when palette is open) ────
-	type FileEntry = { id: FileId; name: string; path: string };
+	type FileEntry = { id: FileId; name: string; parentDir: string };
 
 	const allFiles = $derived.by((): FileEntry[] => {
 		if (!open) return [];
@@ -44,10 +44,13 @@
 				const row = fsState.getRow(childId);
 				if (!row) continue;
 				if (row.type === 'file') {
+					const fullPath = fsState.getPathForId(childId) ?? '';
+					const lastSlash = fullPath.lastIndexOf('/');
+					const parentDir = lastSlash > 0 ? fullPath.slice(1, lastSlash) : '';
 					files.push({
 						id: childId,
 						name: row.name,
-						path: fsState.getPathForId(childId) ?? '',
+						parentDir,
 					});
 				} else if (row.type === 'folder') {
 					collect(childId);
@@ -127,9 +130,11 @@
 					{@const Icon = getFileIcon(file.name)}
 					<Icon class="h-4 w-4 shrink-0 text-muted-foreground" />
 					<span>{file.name}</span>
-					<span class="ml-auto text-xs truncate text-muted-foreground">
-						{file.path}
-					</span>
+					{#if file.parentDir}
+						<span class="ml-auto text-xs truncate text-muted-foreground">
+							{file.parentDir}
+						</span>
+					{/if}
 				</Command.Item>
 			{/each}
 		</Command.Group>

--- a/apps/opensidian/src/lib/components/CommandPalette.svelte
+++ b/apps/opensidian/src/lib/components/CommandPalette.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+	import type { FileId } from '@epicenter/filesystem';
+	import * as Command from '@epicenter/ui/command';
+	import {
+		FileCode,
+		File as FileIcon,
+		FileJson,
+		FileText,
+	} from 'lucide-svelte';
+	import { fsState } from '$lib/fs/fs-state.svelte';
+
+	let open = $state(false);
+	let searchQuery = $state('');
+	let debouncedQuery = $state('');
+
+	// ── Extension → icon mapping ─────────────────────────────────────
+	const ICON_MAP: Record<string, typeof FileIcon> = {
+		'.md': FileText,
+		'.txt': FileText,
+		'.ts': FileCode,
+		'.js': FileCode,
+		'.tsx': FileCode,
+		'.jsx': FileCode,
+		'.json': FileJson,
+	};
+
+	function getFileIcon(name: string): typeof FileIcon {
+		const dotIndex = name.lastIndexOf('.');
+		if (dotIndex === -1) return FileIcon;
+		const ext = name.slice(dotIndex).toLowerCase();
+		return ICON_MAP[ext] ?? FileIcon;
+	}
+
+	// ── Collect all files recursively (only when palette is open) ────
+	type FileEntry = { id: FileId; name: string; path: string };
+
+	const allFiles = $derived.by((): FileEntry[] => {
+		if (!open) return [];
+		void fsState.version;
+
+		const files: FileEntry[] = [];
+		function collect(parentId: FileId | null) {
+			for (const childId of fsState.getChildIds(parentId)) {
+				const row = fsState.getRow(childId);
+				if (!row) continue;
+				if (row.type === 'file') {
+					files.push({
+						id: childId,
+						name: row.name,
+						path: fsState.getPathForId(childId) ?? '',
+					});
+				} else if (row.type === 'folder') {
+					collect(childId);
+				}
+			}
+		}
+		collect(null);
+		return files;
+	});
+
+	// ── Debounce search input at 150ms ───────────────────────────────
+	$effect(() => {
+		const query = searchQuery;
+		const timer = setTimeout(() => {
+			debouncedQuery = query;
+		}, 150);
+		return () => clearTimeout(timer);
+	});
+
+	// ── Reset search when palette closes ─────────────────────────────
+	$effect(() => {
+		if (!open) {
+			searchQuery = '';
+			debouncedQuery = '';
+		}
+	});
+
+	// ── Filtered results: startsWith first, then includes, cap 50 ───
+	const filteredFiles = $derived.by(() => {
+		const q = debouncedQuery.toLowerCase().trim();
+		if (!q) return allFiles.slice(0, 50);
+
+		const startsWith: FileEntry[] = [];
+		const includes: FileEntry[] = [];
+
+		for (const file of allFiles) {
+			const name = file.name.toLowerCase();
+			if (name.startsWith(q)) {
+				startsWith.push(file);
+			} else if (name.includes(q)) {
+				includes.push(file);
+			}
+			if (startsWith.length + includes.length >= 50) break;
+		}
+
+		return [...startsWith, ...includes].slice(0, 50);
+	});
+
+	// ── Handlers ─────────────────────────────────────────────────────
+	function handleSelect(id: FileId) {
+		fsState.actions.selectFile(id);
+		open = false;
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+			e.preventDefault();
+			open = !open;
+		}
+	}
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<Command.Dialog
+	bind:open
+	title="Search Files"
+	description="Search for a file by name"
+	shouldFilter={false}
+>
+	<Command.Input placeholder="Search files..." bind:value={searchQuery} />
+	<Command.List>
+		<Command.Empty>No files found.</Command.Empty>
+		<Command.Group heading="Files">
+			{#each filteredFiles as file (file.id)}
+				<Command.Item value={file.id} onSelect={() => handleSelect(file.id)}>
+					{@const Icon = getFileIcon(file.name)}
+					<Icon class="h-4 w-4 shrink-0 text-muted-foreground" />
+					<span>{file.name}</span>
+					<span class="ml-auto text-xs truncate text-muted-foreground">
+						{file.path}
+					</span>
+				</Command.Item>
+			{/each}
+		</Command.Group>
+	</Command.List>
+</Command.Dialog>

--- a/apps/opensidian/src/lib/components/ContentEditor.svelte
+++ b/apps/opensidian/src/lib/components/ContentEditor.svelte
@@ -1,74 +1,30 @@
 <script lang="ts">
 	import type { FileId } from '@epicenter/filesystem';
+	import type { DocumentHandle } from '@epicenter/workspace';
 	import { fsState } from '$lib/fs/fs-state.svelte';
-	import { Textarea } from '@epicenter/ui/textarea';
+	import CodeMirrorEditor from './CodeMirrorEditor.svelte';
 
-	type Props = {
+	let { fileId }: {
 		fileId: FileId;
-	};
+	} = $props();
 
-	let { fileId }: Props = $props();
+	let handle = $state<DocumentHandle | null>(null);
 
-	let content = $state('');
-	let loading = $state(true);
-	let dirty = $state(false);
-
-	async function loadContent() {
-		loading = true;
-		const result = await fsState.actions.readContent(fileId);
-		// Guard against race condition — if file changed while loading, ignore
-		if (fsState.activeFileId !== fileId) return;
-		content = result ?? '';
-		loading = false;
-		dirty = false;
-	}
-
-	async function saveContent() {
-		if (!dirty) return;
-		await fsState.actions.writeContent(fileId, content);
-		dirty = false;
-	}
-
-	function handleInput() {
-		dirty = true;
-	}
-
-	function handleKeydown(e: KeyboardEvent) {
-		if ((e.metaKey || e.ctrlKey) && e.key === 's') {
-			e.preventDefault();
-			saveContent();
-		}
-	}
-
-	// Load content when fileId changes; save dirty content on cleanup.
-	// The {#key} block in ContentPanel destroys this component when
-	// activeFileId changes—DOM removal doesn't fire blur, so the
-	// cleanup function is the only chance to persist unsaved edits.
 	$effect(() => {
 		const id = fileId;
-		loadContent();
-		return () => {
-			if (dirty) {
-				fsState.actions.writeContent(id, content);
-			}
-		};
+		handle = null;
+		fsState.fs.content.open(id).then((h) => {
+			// Guard against race condition -- if file changed while loading, ignore
+			if (fsState.activeFileId !== id) return;
+			handle = h;
+		});
 	});
 </script>
 
-{#if loading}
-	<div
-		class="flex h-full items-center justify-center text-sm text-muted-foreground"
-	>
+{#if handle}
+	<CodeMirrorEditor ytext={handle.asText()} />
+{:else}
+	<div class="flex h-full items-center justify-center text-sm text-muted-foreground">
 		Loading...
 	</div>
-{:else}
-	<Textarea
-		class="h-full w-full resize-none border-0 shadow-none rounded-none bg-transparent p-4 font-mono text-sm outline-none focus-visible:ring-0 focus-visible:border-transparent"
-		bind:value={content}
-		oninput={handleInput}
-		onblur={saveContent}
-		onkeydown={handleKeydown}
-		spellcheck={false}
-		placeholder="Empty file"
-	/>
 {/if}

--- a/apps/opensidian/src/lib/components/ContentEditor.svelte
+++ b/apps/opensidian/src/lib/components/ContentEditor.svelte
@@ -13,7 +13,7 @@
 	$effect(() => {
 		const id = fileId;
 		handle = null;
-		fsState.fs.content.open(id).then((h) => {
+		fsState.documents.open(id).then((h) => {
 			// Guard against race condition -- if file changed while loading, ignore
 			if (fsState.activeFileId !== id) return;
 			handle = h;

--- a/apps/opensidian/src/lib/components/ContentPanel.svelte
+++ b/apps/opensidian/src/lib/components/ContentPanel.svelte
@@ -2,9 +2,12 @@
 	import { fsState } from '$lib/fs/fs-state.svelte';
 	import ContentEditor from './ContentEditor.svelte';
 	import PathBreadcrumb from './PathBreadcrumb.svelte';
+	import TabBar from './TabBar.svelte';
 </script>
 
 <div class="flex h-full flex-col">
+	<TabBar />
+
 	{#if fsState.activeFileId && fsState.selectedNode}
 		<div class="flex items-center border-b px-4 py-2"><PathBreadcrumb /></div>
 

--- a/apps/opensidian/src/lib/components/FileTree.svelte
+++ b/apps/opensidian/src/lib/components/FileTree.svelte
@@ -1,8 +1,107 @@
 <script lang="ts">
+	import type { FileId } from '@epicenter/filesystem';
 	import * as Empty from '@epicenter/ui/empty';
 	import * as TreeView from '@epicenter/ui/tree-view';
 	import { fsState } from '$lib/fs/fs-state.svelte';
 	import FileTreeItem from './FileTreeItem.svelte';
+
+	/**
+	 * Flat list of visible item IDs in visual order.
+	 * Respects folder expansion state—collapsed folders hide their descendants.
+	 */
+	const visibleIds = $derived.by(() => {
+		void fsState.version;
+		const ids: FileId[] = [];
+		function walk(parentId: FileId | null) {
+			for (const childId of fsState.getChildIds(parentId)) {
+				const row = fsState.getRow(childId);
+				if (!row) continue;
+				ids.push(childId);
+				if (row.type === 'folder' && fsState.expandedIds.has(childId)) {
+					walk(childId);
+				}
+			}
+		}
+		walk(null);
+		return ids;
+	});
+
+	function handleKeydown(e: KeyboardEvent) {
+		const current = fsState.focusedId;
+		const currentIndex = current ? visibleIds.indexOf(current) : -1;
+
+		switch (e.key) {
+			case 'ArrowDown': {
+				e.preventDefault();
+				if (currentIndex === -1) {
+					fsState.actions.focus(visibleIds[0] ?? null);
+				} else {
+					const next =
+						visibleIds[Math.min(currentIndex + 1, visibleIds.length - 1)];
+					fsState.actions.focus(next ?? null);
+				}
+				break;
+			}
+			case 'ArrowUp': {
+				e.preventDefault();
+				if (currentIndex === -1) {
+					fsState.actions.focus(visibleIds[0] ?? null);
+				} else {
+					const prev = visibleIds[Math.max(currentIndex - 1, 0)];
+					fsState.actions.focus(prev ?? null);
+				}
+				break;
+			}
+			case 'ArrowRight': {
+				e.preventDefault();
+				if (!current) break;
+				const row = fsState.getRow(current);
+				if (row?.type !== 'folder') break;
+				if (!fsState.expandedIds.has(current)) {
+					fsState.actions.toggleExpand(current);
+				} else {
+					const children = fsState.getChildIds(current);
+					if (children.length > 0) fsState.actions.focus(children[0]!);
+				}
+				break;
+			}
+			case 'ArrowLeft': {
+				e.preventDefault();
+				if (!current) break;
+				const row = fsState.getRow(current);
+				if (row?.type === 'folder' && fsState.expandedIds.has(current)) {
+					fsState.actions.toggleExpand(current);
+				} else if (row?.parentId) {
+					fsState.actions.focus(row.parentId);
+				}
+				break;
+			}
+			case 'Enter':
+			case ' ': {
+				e.preventDefault();
+				if (!current) break;
+				const row = fsState.getRow(current);
+				if (row?.type === 'file') {
+					fsState.actions.selectFile(current);
+				} else if (row?.type === 'folder') {
+					fsState.actions.toggleExpand(current);
+				}
+				break;
+			}
+			case 'Home': {
+				e.preventDefault();
+				fsState.actions.focus(visibleIds[0] ?? null);
+				break;
+			}
+			case 'End': {
+				e.preventDefault();
+				fsState.actions.focus(visibleIds.at(-1) ?? null);
+				break;
+			}
+			default:
+				return; // don't prevent default for unhandled keys
+		}
+	}
 </script>
 
 {#if fsState.rootChildIds.length === 0}
@@ -15,7 +114,8 @@
 		</Empty.Header>
 	</Empty.Root>
 {:else}
-	<TreeView.Root class="gap-0.5">
+	<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+	<TreeView.Root tabindex={0} onkeydown={handleKeydown}>
 		{#each fsState.rootChildIds as childId (childId)}
 			<FileTreeItem id={childId} />
 		{/each}

--- a/apps/opensidian/src/lib/components/FileTreeItem.svelte
+++ b/apps/opensidian/src/lib/components/FileTreeItem.svelte
@@ -2,7 +2,7 @@
 	import type { FileId } from '@epicenter/filesystem';
 	import * as ContextMenu from '@epicenter/ui/context-menu';
 	import * as TreeView from '@epicenter/ui/tree-view';
-	import { File as FileIcon } from 'lucide-svelte';
+	import { getFileIcon } from '$lib/fs/file-icons';
 	import { fsState } from '$lib/fs/fs-state.svelte';
 	import CreateDialog from './CreateDialog.svelte';
 	import DeleteConfirmation from './DeleteConfirmation.svelte';
@@ -16,6 +16,7 @@
 	const isExpanded = $derived(fsState.expandedIds.has(id));
 	const isSelected = $derived(fsState.activeFileId === id);
 	const children = $derived(isFolder ? fsState.getChildIds(id) : []);
+	const isFocused = $derived(fsState.focusedId === id);
 
 	let createDialogOpen = $state(false);
 	let createDialogMode = $state<'file' | 'folder'>('file');
@@ -51,7 +52,7 @@
 							onOpenChange={() => fsState.actions.toggleExpand(id)}
 							class="w-full rounded-sm px-2 py-1 text-sm hover:bg-accent {isSelected
 								? 'bg-accent text-accent-foreground'
-								: ''}"
+								: ''} {isFocused ? 'ring-1 ring-ring' : ''}"
 						>
 							{#each children as childId (childId)}
 								<FileTreeItem id={childId} />
@@ -62,20 +63,16 @@
 					<TreeView.File
 						{...props}
 						name={row.name}
+						id={id}
 						class="w-full rounded-sm px-2 py-1 text-sm hover:bg-accent {isSelected
 							? 'bg-accent text-accent-foreground'
-							: ''}"
+							: ''} {isFocused ? 'ring-1 ring-ring' : ''}"
 						onclick={() => fsState.actions.selectFile(id)}
-						onkeydown={(e) => {
-							if (e.key === 'Enter' || e.key === ' ') {
-								e.preventDefault();
-								fsState.actions.selectFile(id);
-							}
-						}}
 						role="treeitem"
 					>
 						{#snippet icon()}
-							<FileIcon class="h-4 w-4 shrink-0 text-muted-foreground" />
+							{@const Icon = getFileIcon(row.name)}
+							<Icon class="h-4 w-4 shrink-0 text-muted-foreground" />
 						{/snippet}
 					</TreeView.File>
 				{/if}

--- a/apps/opensidian/src/lib/components/TabBar.svelte
+++ b/apps/opensidian/src/lib/components/TabBar.svelte
@@ -37,30 +37,28 @@
 		class="w-full"
 	>
 		<Tabs.List
-			class="h-9 w-full justify-start gap-0 rounded-none border-b bg-transparent p-0"
+			class="h-9 w-full justify-start gap-0 overflow-x-auto rounded-none border-b bg-transparent p-0"
 		>
-			<div class="flex overflow-x-auto">
-				{#each fsState.openFileIds as fileId (fileId)}
-					{@const row = fsState.getRow(fileId)}
-					{#if row}
-						<Tabs.Trigger
-							value={fileId}
-							class="relative shrink-0 rounded-none border-b-2 border-transparent px-3 py-1.5 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
-							onauxclick={(e) => handleAuxClick(e, fileId)}
+			{#each fsState.openFileIds as fileId (fileId)}
+				{@const row = fsState.getRow(fileId)}
+				{#if row}
+					<Tabs.Trigger
+						value={fileId}
+						class="relative shrink-0 rounded-none border-b-2 border-transparent px-3 py-1.5 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+						onauxclick={(e) => handleAuxClick(e, fileId)}
+					>
+						<span class="mr-4">{row.name}</span>
+						<button
+							type="button"
+							class="absolute right-1 top-1/2 -translate-y-1/2 rounded-sm p-0.5 opacity-50 hover:opacity-100 hover:bg-accent"
+							onclick={(e) => handleClose(e, fileId)}
+							aria-label="Close {row.name}"
 						>
-							<span class="mr-4">{row.name}</span>
-							<button
-								type="button"
-								class="absolute right-1 top-1/2 -translate-y-1/2 rounded-sm p-0.5 opacity-50 hover:opacity-100 hover:bg-accent"
-								onclick={(e) => handleClose(e, fileId)}
-								aria-label="Close {row.name}"
-							>
-								<X class="h-3 w-3" />
-							</button>
-						</Tabs.Trigger>
-					{/if}
-				{/each}
-			</div>
+							<X class="h-3 w-3" />
+						</button>
+					</Tabs.Trigger>
+				{/if}
+			{/each}
 		</Tabs.List>
 	</Tabs.Root>
 {/if}

--- a/apps/opensidian/src/lib/components/TabBar.svelte
+++ b/apps/opensidian/src/lib/components/TabBar.svelte
@@ -37,14 +37,14 @@
 		class="w-full"
 	>
 		<Tabs.List
-			class="w-full justify-start gap-1 overflow-x-auto rounded-none border-b bg-transparent p-0 px-1"
+			class="w-full justify-start overflow-x-auto rounded-none border-b bg-transparent p-0"
 		>
 			{#each fsState.openFileIds as fileId (fileId)}
 				{@const row = fsState.getRow(fileId)}
 				{#if row}
 					<Tabs.Trigger
 						value={fileId}
-						class="relative flex-none border-0 text-muted-foreground hover:bg-accent hover:text-accent-foreground data-[state=active]:bg-accent data-[state=active]:text-accent-foreground data-[state=active]:shadow-none"
+						class="relative flex-none rounded-none border-0 text-muted-foreground hover:bg-accent hover:text-accent-foreground data-[state=active]:bg-accent data-[state=active]:text-accent-foreground data-[state=active]:shadow-none"
 						onauxclick={(e) => handleAuxClick(e, fileId)}
 					>
 						<span class="mr-4">{row.name}</span>

--- a/apps/opensidian/src/lib/components/TabBar.svelte
+++ b/apps/opensidian/src/lib/components/TabBar.svelte
@@ -37,14 +37,14 @@
 		class="w-full"
 	>
 		<Tabs.List
-			class="h-9 w-full justify-start gap-0 overflow-x-auto rounded-none border-b bg-transparent p-0"
+			class="h-9 w-full justify-start gap-1 overflow-x-auto rounded-none border-b bg-transparent p-0 px-1"
 		>
 			{#each fsState.openFileIds as fileId (fileId)}
 				{@const row = fsState.getRow(fileId)}
 				{#if row}
 					<Tabs.Trigger
 						value={fileId}
-						class="relative shrink-0 rounded-none border-b-2 border-transparent px-3 py-1.5 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+						class="relative flex-none rounded-sm border-0 px-3 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground data-[state=active]:bg-accent data-[state=active]:text-accent-foreground data-[state=active]:shadow-none"
 						onauxclick={(e) => handleAuxClick(e, fileId)}
 					>
 						<span class="mr-4">{row.name}</span>

--- a/apps/opensidian/src/lib/components/TabBar.svelte
+++ b/apps/opensidian/src/lib/components/TabBar.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import type { FileId } from '@epicenter/filesystem';
+	import * as Tabs from '@epicenter/ui/tabs';
+	import { X } from 'lucide-svelte';
+	import { fsState } from '$lib/fs/fs-state.svelte';
+
+	const hasOpenFiles = $derived(fsState.openFileIds.length > 0);
+
+	function handleValueChange(value: string) {
+		fsState.actions.selectFile(value as FileId);
+	}
+
+	/**
+	 * Close a tab, stopping propagation so the tab doesn't also get selected.
+	 */
+	function handleClose(e: MouseEvent, id: FileId) {
+		e.stopPropagation();
+		e.preventDefault();
+		fsState.actions.closeFile(id);
+	}
+
+	/**
+	 * Middle-click to close a tab.
+	 */
+	function handleAuxClick(e: MouseEvent, id: FileId) {
+		if (e.button === 1) {
+			e.preventDefault();
+			fsState.actions.closeFile(id);
+		}
+	}
+</script>
+
+{#if hasOpenFiles}
+	<Tabs.Root
+		value={fsState.activeFileId ?? ''}
+		onValueChange={handleValueChange}
+		class="w-full"
+	>
+		<Tabs.List
+			class="h-9 w-full justify-start gap-0 rounded-none border-b bg-transparent p-0"
+		>
+			<div class="flex overflow-x-auto">
+				{#each fsState.openFileIds as fileId (fileId)}
+					{@const row = fsState.getRow(fileId)}
+					{#if row}
+						<Tabs.Trigger
+							value={fileId}
+							class="relative shrink-0 rounded-none border-b-2 border-transparent px-3 py-1.5 text-xs data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+							onauxclick={(e) => handleAuxClick(e, fileId)}
+						>
+							<span class="mr-4">{row.name}</span>
+							<button
+								type="button"
+								class="absolute right-1 top-1/2 -translate-y-1/2 rounded-sm p-0.5 opacity-50 hover:opacity-100 hover:bg-accent"
+								onclick={(e) => handleClose(e, fileId)}
+								aria-label="Close {row.name}"
+							>
+								<X class="h-3 w-3" />
+							</button>
+						</Tabs.Trigger>
+					{/if}
+				{/each}
+			</div>
+		</Tabs.List>
+	</Tabs.Root>
+{/if}

--- a/apps/opensidian/src/lib/components/TabBar.svelte
+++ b/apps/opensidian/src/lib/components/TabBar.svelte
@@ -37,14 +37,14 @@
 		class="w-full"
 	>
 		<Tabs.List
-			class="h-9 w-full justify-start gap-1 overflow-x-auto rounded-none border-b bg-transparent p-0 px-1"
+			class="w-full justify-start gap-1 overflow-x-auto rounded-none border-b bg-transparent p-0 px-1"
 		>
 			{#each fsState.openFileIds as fileId (fileId)}
 				{@const row = fsState.getRow(fileId)}
 				{#if row}
 					<Tabs.Trigger
 						value={fileId}
-						class="relative flex-none rounded-sm border-0 px-3 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground data-[state=active]:bg-accent data-[state=active]:text-accent-foreground data-[state=active]:shadow-none"
+						class="relative flex-none border-0 text-muted-foreground hover:bg-accent hover:text-accent-foreground data-[state=active]:bg-accent data-[state=active]:text-accent-foreground data-[state=active]:shadow-none"
 						onauxclick={(e) => handleAuxClick(e, fileId)}
 					>
 						<span class="mr-4">{row.name}</span>

--- a/apps/opensidian/src/lib/components/TabBar.svelte
+++ b/apps/opensidian/src/lib/components/TabBar.svelte
@@ -44,7 +44,7 @@
 				{#if row}
 					<Tabs.Trigger
 						value={fileId}
-						class="relative flex-none rounded-none border-0 text-muted-foreground hover:bg-accent hover:text-accent-foreground data-[state=active]:bg-accent data-[state=active]:text-accent-foreground data-[state=active]:shadow-none"
+						class="relative flex-none rounded-none border-0 text-muted-foreground hover:bg-accent hover:text-accent-foreground data-[state=active]:bg-muted data-[state=active]:text-foreground data-[state=active]:shadow-none"
 						onauxclick={(e) => handleAuxClick(e, fileId)}
 					>
 						<span class="mr-4">{row.name}</span>

--- a/apps/opensidian/src/lib/fs/file-icons.ts
+++ b/apps/opensidian/src/lib/fs/file-icons.ts
@@ -1,0 +1,30 @@
+/**
+ * Extension → Lucide icon mapping for file type awareness.
+ *
+ * Used by FileTreeItem (tree view icons) and CommandPalette (search results).
+ * Returns the Lucide component to render for a given filename.
+ *
+ * @example
+ * ```svelte
+ * {@const Icon = getFileIcon('readme.md')}
+ * <Icon class="h-4 w-4" />
+ * ```
+ */
+import { FileCode, File as FileIcon, FileJson, FileText } from 'lucide-svelte';
+
+const EXTENSION_ICONS: Record<string, typeof FileIcon> = {
+	'.md': FileText,
+	'.txt': FileText,
+	'.ts': FileCode,
+	'.js': FileCode,
+	'.tsx': FileCode,
+	'.jsx': FileCode,
+	'.json': FileJson,
+};
+
+export function getFileIcon(name: string): typeof FileIcon {
+	const dotIndex = name.lastIndexOf('.');
+	if (dotIndex === -1) return FileIcon;
+	const ext = name.slice(dotIndex).toLowerCase();
+	return EXTENSION_ICONS[ext] ?? FileIcon;
+}

--- a/apps/opensidian/src/lib/fs/fs-state.svelte.ts
+++ b/apps/opensidian/src/lib/fs/fs-state.svelte.ts
@@ -40,6 +40,7 @@ function createFsState() {
 	let activeFileId = $state<FileId | null>(null);
 	let openFileIds = $state<FileId[]>([]);
 	const expandedIds = new SvelteSet<FileId>();
+	let focusedId = $state<FileId | null>(null);
 
 	// ── rAF-coalesced observer ────────────────────────────────────────
 	let pendingBump = false;
@@ -102,6 +103,9 @@ function createFsState() {
 		get selectedPath() {
 			return selectedPath;
 		},
+		get focusedId() {
+			return focusedId;
+		},
 
 		expandedIds,
 		fs,
@@ -155,6 +159,10 @@ function createFsState() {
 			toggleExpand(id: FileId) {
 				if (expandedIds.has(id)) expandedIds.delete(id);
 				else expandedIds.add(id);
+			},
+
+			focus(id: FileId | null) {
+				focusedId = id;
 			},
 
 			async createFile(parentId: FileId | null, name: string) {

--- a/apps/opensidian/src/lib/fs/fs-state.svelte.ts
+++ b/apps/opensidian/src/lib/fs/fs-state.svelte.ts
@@ -1,4 +1,5 @@
 import {
+	createSqliteIndex,
 	createYjsFileSystem,
 	type FileId,
 	type FileRow,
@@ -32,7 +33,8 @@ function createFsState() {
 	const ws = createWorkspace({
 		id: 'opensidian',
 		tables: { files: filesTable },
-	}).withExtension('persistence', indexeddbPersistence);
+	}).withExtension('persistence', indexeddbPersistence)
+		.withWorkspaceExtension('sqliteIndex', createSqliteIndex());
 	const fs = createYjsFileSystem(ws.tables.files, ws.documents.files.content);
 	const documents = ws.documents.files.content;
 
@@ -111,6 +113,7 @@ function createFsState() {
 		expandedIds,
 		fs,
 		documents,
+		sqliteIndex: ws.extensions.sqliteIndex,
 
 		/**
 		 * Get child FileIds of a folder. Reads from FileSystemIndex.
@@ -278,3 +281,10 @@ function createFsState() {
 }
 
 export const fsState = createFsState();
+
+// Expose on window for dev console access
+// Usage: await fsState.sqliteIndex.search('hello')
+//        await fsState.sqliteIndex.client.execute('SELECT * FROM files')
+if (typeof window !== 'undefined') {
+	(window as unknown as Record<string, unknown>).fsState = fsState;
+}

--- a/apps/opensidian/src/lib/fs/fs-state.svelte.ts
+++ b/apps/opensidian/src/lib/fs/fs-state.svelte.ts
@@ -34,6 +34,7 @@ function createFsState() {
 		tables: { files: filesTable },
 	}).withExtension('persistence', indexeddbPersistence);
 	const fs = createYjsFileSystem(ws.tables.files, ws.documents.files.content);
+	const documents = ws.documents.files.content;
 
 	// ── Reactive state ────────────────────────────────────────────────
 	let version = $state(0);
@@ -109,6 +110,7 @@ function createFsState() {
 
 		expandedIds,
 		fs,
+		documents,
 
 		/**
 		 * Get child FileIds of a folder. Reads from FileSystemIndex.
@@ -231,14 +233,14 @@ function createFsState() {
 			},
 
 			/**
-			 * Read file content as string via the filesystem's timeline-backed content helpers.
+			 * Read file content as string.
 			 *
-			 * Uses `fs.content.read()` which reads from the `Y.Array('timeline')` in the
-			 * per-file content Y.Doc—the same shared type that `fs.writeFile()` writes to.
+			 * Opens the per-file content Y.Doc and reads from the timeline.
 			 */
 			async readContent(id: FileId): Promise<string | null> {
 				try {
-					return await fs.content.read(id);
+					const handle = await documents.open(id);
+					return handle.read();
 				} catch (err) {
 					console.error('Failed to read content:', err);
 					return null;
@@ -246,15 +248,15 @@ function createFsState() {
 			},
 
 			/**
-			 * Write file content via the filesystem's timeline-backed content helpers.
+			 * Write file content as string.
 			 *
-			 * Uses `fs.content.write()` which writes to the `Y.Array('timeline')` in the
-			 * per-file content Y.Doc. The documents manager's `onUpdate` callback still
-			 * fires (it watches all Y.Doc changes) and bumps `updatedAt` on the file row.
+			 * Opens the per-file content Y.Doc and writes to the timeline.
+			 * The documents manager's `onUpdate` callback bumps `updatedAt` on the file row.
 			 */
 			async writeContent(id: FileId, data: string): Promise<void> {
 				try {
-					await fs.content.write(id, data);
+					const handle = await documents.open(id);
+					handle.write(data);
 				} catch (err) {
 					toast.error(
 						err instanceof Error ? err.message : 'Failed to save file',

--- a/apps/opensidian/vite.config.ts
+++ b/apps/opensidian/vite.config.ts
@@ -7,4 +7,18 @@ export default defineConfig({
 	resolve: {
 		dedupe: ['yjs'],
 	},
+	optimizeDeps: {
+		// @libsql/client-wasm bundles a WASM SQLite build via
+		// @libsql/libsql-wasm-experimental. Vite's dep optimizer
+		// can't handle WASM imports from these packages, so we
+		// exclude them from pre-bundling and let them load natively.
+		exclude: ['@libsql/libsql-wasm-experimental'],
+	},
+	server: {
+		headers: {
+			// Required for SharedArrayBuffer (used by @libsql WASM worker)
+			'Cross-Origin-Opener-Policy': 'same-origin',
+			'Cross-Origin-Embedder-Policy': 'require-corp',
+		},
+	},
 });

--- a/bun.lock
+++ b/bun.lock
@@ -366,7 +366,10 @@
       "version": "0.0.1",
       "dependencies": {
         "@epicenter/workspace": "workspace:*",
+        "@libsql/client": "^0.14.0",
+        "@libsql/client-wasm": "^0.14.0",
         "arktype": "catalog:",
+        "drizzle-orm": "^0.38.3",
         "just-bash": "^2.9.7",
         "prosemirror-markdown": "^1.13.4",
         "wellcrafted": "catalog:",
@@ -942,6 +945,32 @@
 
     "@lezer/markdown": ["@lezer/markdown@1.6.3", "", { "dependencies": { "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0" } }, "sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw=="],
 
+    "@libsql/client": ["@libsql/client@0.14.0", "", { "dependencies": { "@libsql/core": "^0.14.0", "@libsql/hrana-client": "^0.7.0", "js-base64": "^3.7.5", "libsql": "^0.4.4", "promise-limit": "^2.7.0" } }, "sha512-/9HEKfn6fwXB5aTEEoMeFh4CtG0ZzbncBb1e++OCdVpgKZ/xyMsIVYXm0w7Pv4RUel803vE6LwniB3PqD72R0Q=="],
+
+    "@libsql/client-wasm": ["@libsql/client-wasm@0.14.0", "", { "dependencies": { "@libsql/core": "^0.14.0", "@libsql/libsql-wasm-experimental": "^0.0.2", "js-base64": "^3.7.5" } }, "sha512-gB/jtz0xuwrqAHApBv9e9JSew2030Fhj2edyZ83InZ4yPj/Q2LTUlEhaspEYT0T0xsAGqPy38uGrmq/OGS+DdQ=="],
+
+    "@libsql/core": ["@libsql/core@0.14.0", "", { "dependencies": { "js-base64": "^3.7.5" } }, "sha512-nhbuXf7GP3PSZgdCY2Ecj8vz187ptHlZQ0VRc751oB2C1W8jQUXKKklvt7t1LJiUTQBVJuadF628eUk+3cRi4Q=="],
+
+    "@libsql/darwin-arm64": ["@libsql/darwin-arm64@0.4.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-yOL742IfWUlUevnI5PdnIT4fryY3LYTdLm56bnY0wXBw7dhFcnjuA7jrH3oSVz2mjZTHujxoITgAE7V6Z+eAbg=="],
+
+    "@libsql/darwin-x64": ["@libsql/darwin-x64@0.4.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-ezc7V75+eoyyH07BO9tIyJdqXXcRfZMbKcLCeF8+qWK5nP8wWuMcfOVywecsXGRbT99zc5eNra4NEx6z5PkSsA=="],
+
+    "@libsql/hrana-client": ["@libsql/hrana-client@0.7.0", "", { "dependencies": { "@libsql/isomorphic-fetch": "^0.3.1", "@libsql/isomorphic-ws": "^0.1.5", "js-base64": "^3.7.5", "node-fetch": "^3.3.2" } }, "sha512-OF8fFQSkbL7vJY9rfuegK1R7sPgQ6kFMkDamiEccNUvieQ+3urzfDFI616oPl8V7T9zRmnTkSjMOImYCAVRVuw=="],
+
+    "@libsql/isomorphic-fetch": ["@libsql/isomorphic-fetch@0.3.1", "", {}, "sha512-6kK3SUK5Uu56zPq/Las620n5aS9xJq+jMBcNSOmjhNf/MUvdyji4vrMTqD7ptY7/4/CAVEAYDeotUz60LNQHtw=="],
+
+    "@libsql/isomorphic-ws": ["@libsql/isomorphic-ws@0.1.5", "", { "dependencies": { "@types/ws": "^8.5.4", "ws": "^8.13.0" } }, "sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg=="],
+
+    "@libsql/linux-arm64-gnu": ["@libsql/linux-arm64-gnu@0.4.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-WlX2VYB5diM4kFfNaYcyhw5y+UJAI3xcMkEUJZPtRDEIu85SsSFrQ+gvoKfcVh76B//ztSeEX2wl9yrjF7BBCA=="],
+
+    "@libsql/linux-arm64-musl": ["@libsql/linux-arm64-musl@0.4.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-6kK9xAArVRlTCpWeqnNMCoXW1pe7WITI378n4NpvU5EJ0Ok3aNTIC2nRPRjhro90QcnmLL1jPcrVwO4WD1U0xw=="],
+
+    "@libsql/linux-x64-gnu": ["@libsql/linux-x64-gnu@0.4.7", "", { "os": "linux", "cpu": "x64" }, "sha512-CMnNRCmlWQqqzlTw6NeaZXzLWI8bydaXDke63JTUCvu8R+fj/ENsLrVBtPDlxQ0wGsYdXGlrUCH8Qi9gJep0yQ=="],
+
+    "@libsql/linux-x64-musl": ["@libsql/linux-x64-musl@0.4.7", "", { "os": "linux", "cpu": "x64" }, "sha512-nI6tpS1t6WzGAt1Kx1n1HsvtBbZ+jHn0m7ogNNT6pQHZQj7AFFTIMeDQw/i/Nt5H38np1GVRNsFe99eSIMs9XA=="],
+
+    "@libsql/win32-x64-msvc": ["@libsql/win32-x64-msvc@0.4.7", "", { "os": "win32", "cpu": "x64" }, "sha512-7pJzOWzPm6oJUxml+PCDRzYQ4A1hTMHAciTAHfFK4fkbDZX33nWPVG7Y3vqdKtslcwAzwmrNDc6sXy2nwWnbiw=="],
+
     "@lucide/astro": ["@lucide/astro@0.536.0", "", { "peerDependencies": { "astro": "^4 || ^5" } }, "sha512-YtnEpWuk+ETun3kcLFbfYlPWuE5fhStg76u8dmhOUsRHk7E1ZsXbtxY612GobgJRiD9tqXmhcg1qu0yVuceTvw=="],
 
     "@lucide/svelte": ["@lucide/svelte@0.561.0", "", { "peerDependencies": { "svelte": "^5" } }, "sha512-vofKV2UFVrKE6I4ewKJ3dfCXSV6iP6nWVmiM83MLjsU91EeJcEg7LoWUABLp/aOTxj1HQNbJD1f3g3L0JQgH9A=="],
@@ -957,6 +986,8 @@
     "@mongodb-js/zstd": ["@mongodb-js/zstd@7.0.0", "", { "dependencies": { "node-addon-api": "^8.5.0", "prebuild-install": "^7.1.3" } }, "sha512-mQ2s0pYYiav+tzCDR05Zptem8Ey2v8s11lri5RKGhTtL4COVCvVCk5vtyRYNT+9L8qSfyOqqefF9UtnW8mC5jA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
+
+    "@neon-rs/load": ["@neon-rs/load@0.0.4", "", {}, "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw=="],
 
     "@noble/ciphers": ["@noble/ciphers@2.1.1", "", {}, "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw=="],
 
@@ -1370,6 +1401,8 @@
 
     "@types/dompurify": ["@types/dompurify@3.2.0", "", { "dependencies": { "dompurify": "*" } }, "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg=="],
 
+    "@types/emscripten": ["@types/emscripten@1.41.5", "", {}, "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/filesystem": ["@types/filesystem@0.0.36", "", { "dependencies": { "@types/filewriter": "*" } }, "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA=="],
@@ -1408,6 +1441,8 @@
 
     "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
 
+    "@types/sql.js": ["@types/sql.js@1.4.9", "", { "dependencies": { "@types/emscripten": "*", "@types/node": "*" } }, "sha512-ep8b36RKHlgWPqjNG9ToUrPiwkhwh0AEzy883mO5Xnd+cL6VBH1EvSjBAAuxLUFF2Vn/moE3Me6v9E1Lo+48GQ=="],
+
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
@@ -1415,6 +1450,8 @@
     "@types/webidl-conversions": ["@types/webidl-conversions@7.0.3", "", {}, "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="],
 
     "@types/whatwg-url": ["@types/whatwg-url@13.0.0", "", { "dependencies": { "@types/webidl-conversions": "*" } }, "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
 
@@ -2022,6 +2059,8 @@
 
     "jose": ["jose@6.2.1", "", {}, "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw=="],
 
+    "js-base64": ["js-base64@3.7.8", "", {}, "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow=="],
+
     "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
@@ -2061,6 +2100,8 @@
     "latest-version": ["latest-version@9.0.0", "", { "dependencies": { "package-json": "^10.0.0" } }, "sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA=="],
 
     "lib0": ["lib0@0.2.117", "", { "dependencies": { "isomorphic.js": "^0.2.4" }, "bin": { "0serve": "bin/0serve.js", "0gentesthtml": "bin/gentesthtml.js", "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js" } }, "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw=="],
+
+    "libsql": ["libsql@0.4.7", "", { "dependencies": { "@neon-rs/load": "^0.0.4", "detect-libc": "2.0.2" }, "optionalDependencies": { "@libsql/darwin-arm64": "0.4.7", "@libsql/darwin-x64": "0.4.7", "@libsql/linux-arm64-gnu": "0.4.7", "@libsql/linux-arm64-musl": "0.4.7", "@libsql/linux-x64-gnu": "0.4.7", "@libsql/linux-x64-musl": "0.4.7", "@libsql/win32-x64-msvc": "0.4.7" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "x64", "arm64", ] }, "sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw=="],
 
     "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
 
@@ -2475,6 +2516,8 @@
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
 
     "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
+
+    "promise-limit": ["promise-limit@2.7.0", "", {}, "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw=="],
 
     "promise-toolbox": ["promise-toolbox@0.21.0", "", { "dependencies": { "make-error": "^1.3.2" } }, "sha512-NV8aTmpwrZv+Iys54sSFOBx3tuVaOBvvrft5PNppnxy9xpU/akHbaWIril22AB22zaPgrgwKdD0KsrM0ptUtpg=="],
 
@@ -3078,11 +3121,17 @@
 
     "@devicefarmer/adbkit/debug": ["debug@4.3.7", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ=="],
 
+    "@epicenter/filesystem/drizzle-orm": ["drizzle-orm@0.38.4", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/react": ">=18", "@types/sql.js": "*", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "react": ">=18", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/react", "@types/sql.js", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "knex", "kysely", "mysql2", "pg", "postgres", "react", "sql.js", "sqlite3"] }, "sha512-s7/5BpLKO+WJRHspvpqTydxFob8i1vo2rEx4pY6TGY7QSMuUfWUuzaY0DIpXCkgHOo37BaFC+SJQb99dDUXT3Q=="],
+
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "@libsql/client-wasm/@libsql/libsql-wasm-experimental": ["@libsql/libsql-wasm-experimental@0.0.2", "", { "bundled": true, "bin": { "sqlite-wasm": "bin/index.js" } }, "sha512-xkiu88QwozGr3KEt9h0zeHLYUIWkeDchXmuOUW4/Wh/mRZkDlNtIIePAR0FiLl1j0o4OyTEOtPnvmaXQ5MNTKQ=="],
+
+    "@libsql/hrana-client/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "@opentelemetry/otlp-transformer/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
 
@@ -3189,6 +3238,8 @@
     "jwa/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "jws/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "libsql/detect-libc": ["detect-libc@2.0.2", "", {}, "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="],
 
     "listr2/wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -148,6 +148,11 @@
       "name": "opensidian",
       "version": "0.0.1",
       "devDependencies": {
+        "@codemirror/commands": "^6.10.3",
+        "@codemirror/lang-markdown": "^6.5.0",
+        "@codemirror/language": "^6.12.2",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.40.0",
         "@epicenter/filesystem": "workspace:*",
         "@epicenter/ui": "workspace:*",
         "@epicenter/workspace": "workspace:*",
@@ -163,6 +168,7 @@
         "tailwindcss": "catalog:",
         "typescript": "catalog:",
         "vite": "catalog:",
+        "y-codemirror.next": "^0.3.5",
         "y-indexeddb": "catalog:",
         "yjs": "catalog:",
       },
@@ -688,6 +694,26 @@
 
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260313.1", "", {}, "sha512-jMEeX3RKfOSVqqXRKr/ulgglcTloeMzSH3FdzIfqJHtvc12/ELKd5Ldsg8ZHahKX/4eRxYdw3kbzb8jLXbq/jQ=="],
 
+    "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.1", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A=="],
+
+    "@codemirror/commands": ["@codemirror/commands@6.10.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.6.0", "@codemirror/view": "^6.27.0", "@lezer/common": "^1.1.0" } }, "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q=="],
+
+    "@codemirror/lang-css": ["@codemirror/lang-css@6.3.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.0.2", "@lezer/css": "^1.1.7" } }, "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg=="],
+
+    "@codemirror/lang-html": ["@codemirror/lang-html@6.4.11", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/lang-css": "^6.0.0", "@codemirror/lang-javascript": "^6.0.0", "@codemirror/language": "^6.4.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/css": "^1.1.0", "@lezer/html": "^1.3.12" } }, "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw=="],
+
+    "@codemirror/lang-javascript": ["@codemirror/lang-javascript@6.2.5", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.6.0", "@codemirror/lint": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/javascript": "^1.0.0" } }, "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A=="],
+
+    "@codemirror/lang-markdown": ["@codemirror/lang-markdown@6.5.0", "", { "dependencies": { "@codemirror/autocomplete": "^6.7.1", "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.3.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.2.1", "@lezer/markdown": "^1.0.0" } }, "sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw=="],
+
+    "@codemirror/language": ["@codemirror/language@6.12.2", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg=="],
+
+    "@codemirror/lint": ["@codemirror/lint@6.9.5", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.35.0", "crelt": "^1.0.5" } }, "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA=="],
+
+    "@codemirror/state": ["@codemirror/state@6.6.0", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ=="],
+
+    "@codemirror/view": ["@codemirror/view@6.40.0", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg=="],
+
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
     "@devicefarmer/adbkit": ["@devicefarmer/adbkit@3.3.8", "", { "dependencies": { "@devicefarmer/adbkit-logcat": "^2.1.2", "@devicefarmer/adbkit-monkey": "~1.2.1", "bluebird": "~3.7", "commander": "^9.1.0", "debug": "~4.3.1", "node-forge": "^1.3.1", "split": "~1.0.1" }, "bin": { "adbkit": "bin/adbkit" } }, "sha512-7rBLLzWQnBwutH2WZ0EWUkQdihqrnLYCUMaB44hSol9e0/cdIhuNFcqZO0xNheAU6qqHVA8sMiLofkYTgb+lmw=="],
@@ -902,9 +928,25 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@lezer/common": ["@lezer/common@1.5.1", "", {}, "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw=="],
+
+    "@lezer/css": ["@lezer/css@1.3.1", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.0" } }, "sha512-PYAKeUVBo3HFThruRyp/iK91SwiZJnzXh8QzkQlwijB5y+N5iB28+iLk78o2zmKqqV0uolNhCwFqB8LA7b0Svg=="],
+
+    "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
+
+    "@lezer/html": ["@lezer/html@1.3.13", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg=="],
+
+    "@lezer/javascript": ["@lezer/javascript@1.5.4", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.1.3", "@lezer/lr": "^1.3.0" } }, "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA=="],
+
+    "@lezer/lr": ["@lezer/lr@1.4.8", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA=="],
+
+    "@lezer/markdown": ["@lezer/markdown@1.6.3", "", { "dependencies": { "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0" } }, "sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw=="],
+
     "@lucide/astro": ["@lucide/astro@0.536.0", "", { "peerDependencies": { "astro": "^4 || ^5" } }, "sha512-YtnEpWuk+ETun3kcLFbfYlPWuE5fhStg76u8dmhOUsRHk7E1ZsXbtxY612GobgJRiD9tqXmhcg1qu0yVuceTvw=="],
 
     "@lucide/svelte": ["@lucide/svelte@0.561.0", "", { "peerDependencies": { "svelte": "^5" } }, "sha512-vofKV2UFVrKE6I4ewKJ3dfCXSV6iP6nWVmiM83MLjsU91EeJcEg7LoWUABLp/aOTxj1HQNbJD1f3g3L0JQgH9A=="],
+
+    "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
 
     "@mistralai/mistralai": ["@mistralai/mistralai@1.15.1", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.24.1" } }, "sha512-fb995eiz3r0KsBGtRjFV+/iLbX+UpfalxpF+YitT3R6ukrPD4PN+FGwwmYcRFhNAzVzDUtTVxQYnjQWEnwV5nw=="],
 
@@ -2688,6 +2730,8 @@
 
     "stubborn-utils": ["stubborn-utils@1.0.2", "", {}, "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg=="],
 
+    "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
+
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
 
     "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
@@ -2965,6 +3009,8 @@
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
     "xxhash-wasm": ["xxhash-wasm@1.1.0", "", {}, "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="],
+
+    "y-codemirror.next": ["y-codemirror.next@0.3.5", "", { "dependencies": { "lib0": "^0.2.42" }, "peerDependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "yjs": "^13.5.6" } }, "sha512-VluNu3e5HfEXybnypnsGwKAj+fKLd4iAnR7JuX1Sfyydmn1jCBS5wwEL/uS04Ch2ib0DnMAOF6ZRR/8kK3wyGw=="],
 
     "y-indexeddb": ["y-indexeddb@9.0.12", "", { "dependencies": { "lib0": "^0.2.74" }, "peerDependencies": { "yjs": "^13.0.0" } }, "sha512-9oCFRSPPzBK7/w5vOkJBaVCQZKHXB/v6SIT+WYhnJxlEC61juqG0hBrAf+y3gmSMLFLwICNH9nQ53uscuse6Hg=="],
 

--- a/packages/filesystem/package.json
+++ b/packages/filesystem/package.json
@@ -12,7 +12,10 @@
 	},
 	"dependencies": {
 		"@epicenter/workspace": "workspace:*",
+		"@libsql/client": "^0.14.0",
+		"@libsql/client-wasm": "^0.14.0",
 		"arktype": "catalog:",
+		"drizzle-orm": "^0.38.3",
 		"just-bash": "^2.9.7",
 		"prosemirror-markdown": "^1.13.4",
 		"y-prosemirror": "^1.3.7",

--- a/packages/filesystem/src/extensions/sqlite-index/ddl.ts
+++ b/packages/filesystem/src/extensions/sqlite-index/ddl.ts
@@ -1,0 +1,100 @@
+/**
+ * Runtime DDL generation from Drizzle schema definitions.
+ *
+ * Uses `getTableConfig()` from `drizzle-orm/sqlite-core` to introspect a
+ * `sqliteTable` definition and produce `CREATE TABLE` + `CREATE INDEX`
+ * SQL strings. This eliminates the duplication of defining columns in
+ * both Drizzle schema and raw SQL.
+ *
+ * Drizzle itself doesn't expose DDL generation at runtime—that logic
+ * lives in drizzle-kit's serializer. This utility replicates the
+ * subset needed for in-memory SQLite (sql.js) table creation.
+ *
+ * @module
+ */
+
+import {
+	getTableConfig,
+	type SQLiteTableWithColumns,
+} from 'drizzle-orm/sqlite-core';
+
+/**
+ * Generate `CREATE TABLE IF NOT EXISTS` SQL from a Drizzle `sqliteTable` definition.
+ *
+ * Introspects columns via `getTableConfig()` and builds the DDL string.
+ * Handles TEXT, INTEGER primary keys, NOT NULL constraints.
+ *
+ * @example
+ * ```typescript
+ * import { files } from './schema.js';
+ * const sql = generateCreateTableSQL(files);
+ * // CREATE TABLE IF NOT EXISTS files (id TEXT PRIMARY KEY NOT NULL, ...)
+ * ```
+ */
+export function generateCreateTableSQL(
+	// biome-ignore lint/suspicious/noExplicitAny: getTableConfig requires SQLiteTable<any>
+	table: SQLiteTableWithColumns<any>,
+): string {
+	const config = getTableConfig(table);
+
+	const columnDefs = config.columns.map((col) => {
+		let def = `${col.name} ${col.getSQLType()}`;
+		if (col.primary) def += ' PRIMARY KEY';
+		if (col.notNull) def += ' NOT NULL';
+		return def;
+	});
+
+	return `CREATE TABLE IF NOT EXISTS ${config.name} (${columnDefs.join(', ')})`;
+}
+
+/**
+ * Generate `CREATE INDEX IF NOT EXISTS` SQL statements from a Drizzle table's indexes.
+ *
+ * Returns one SQL string per index defined in the schema's third argument.
+ *
+ * @example
+ * ```typescript
+ * import { files } from './schema.js';
+ * const statements = generateCreateIndexSQL(files);
+ * // ['CREATE INDEX IF NOT EXISTS parent_idx ON files(parent_id)', ...]
+ * ```
+ */
+// biome-ignore lint/suspicious/noExplicitAny: getTableConfig requires SQLiteTable<any>
+export function generateCreateIndexSQL(
+	table: SQLiteTableWithColumns<any>,
+): string[] {
+	const config = getTableConfig(table);
+
+	return config.indexes.map((idx) => {
+		const idxConfig = idx.config;
+		const columns = idxConfig.columns
+			.map((col) => {
+				if ('name' in col) return (col as { name: string }).name;
+				return String(col);
+			})
+			.join(', ');
+
+		const unique = idxConfig.unique ? 'UNIQUE ' : '';
+		return `CREATE ${unique}INDEX IF NOT EXISTS ${idxConfig.name} ON ${config.name}(${columns})`;
+	});
+}
+
+/**
+ * Generate all DDL statements (CREATE TABLE + CREATE INDEX) for a Drizzle table.
+ *
+ * Convenience wrapper that combines {@link generateCreateTableSQL} and
+ * {@link generateCreateIndexSQL} into a single array of SQL strings,
+ * ready to be executed sequentially.
+ *
+ * @example
+ * ```typescript
+ * import { files } from './schema.js';
+ * for (const sql of generateDDL(files)) {
+ *   sqlite.run(sql);
+ * }
+ * ```
+ */
+// biome-ignore lint/suspicious/noExplicitAny: getTableConfig requires SQLiteTable<any>
+export function generateDDL(table: SQLiteTableWithColumns<any>): string[] {
+	return [generateCreateTableSQL(table), ...generateCreateIndexSQL(table)];
+}

--- a/packages/filesystem/src/extensions/sqlite-index/index.ts
+++ b/packages/filesystem/src/extensions/sqlite-index/index.ts
@@ -1,0 +1,374 @@
+/**
+ * SQLite index extension for the Yjs filesystem.
+ *
+ * Mirrors the CRDT files table into an in-memory SQLite database
+ * (libSQL WASM) wrapped with Drizzle ORM. Provides SQL queries,
+ * full-text search, and fast lookups against file metadata and content.
+ *
+ * The SQLite database is **never** the source of truth—it's a derived,
+ * rebuildable cache. On every page load the index is rebuilt from Yjs.
+ * Ongoing mutations are picked up via a debounced table observer.
+ *
+ * Uses `@libsql/client-wasm` for browser WASM SQLite. To upgrade to
+ * remote Turso, swap `url: ':memory:'` for `url: 'libsql://your-db.turso.io'`.
+ *
+ * @example
+ * ```typescript
+ * const ws = createWorkspace({ id: 'app', tables: { files: filesTable } })
+ *   .withWorkspaceExtension('sqliteIndex', createSqliteIndex());
+ *
+ * await ws.whenReady;
+ * const results = await ws.extensions.sqliteIndex.search('meeting notes');
+ * ```
+ *
+ * @module
+ */
+
+import type { Documents, TableHelper } from '@epicenter/workspace';
+import type { Client, InStatement } from '@libsql/client-wasm';
+import { createClient } from '@libsql/client-wasm';
+import { drizzle, type LibSQLDatabase } from 'drizzle-orm/libsql';
+
+import type { FileRow } from '../../table.js';
+import { generateDDL } from './ddl.js';
+import * as schema from './schema.js';
+
+const MAX_PATH_DEPTH = 50;
+
+// ════════════════════════════════════════════════════════════════════════════
+// PUBLIC TYPES
+// ════════════════════════════════════════════════════════════════════════════
+
+export type SqliteIndexOptions = {
+	/** Debounce interval (ms) between table mutation and rebuild. @default 100 */
+	debounceMs?: number;
+};
+
+/**
+ * A single full-text search result.
+ *
+ * Returned by {@link SqliteIndex.search}. The `snippet` field contains
+ * an HTML fragment with `<mark>` tags around matched terms.
+ */
+export type SearchResult = {
+	/** File ID matching the query. */
+	id: string;
+	/** File name. */
+	name: string;
+	/** Materialized POSIX path, or null if the file is orphaned. */
+	path: string | null;
+	/** FTS5 snippet with `<mark>` highlights around matched terms. */
+	snippet: string;
+};
+
+/** The public surface returned by the SQLite index extension. */
+export type SqliteIndex = {
+	/** Drizzle database instance for typed queries against the index. */
+	readonly db: LibSQLDatabase<typeof schema>;
+	/**
+	 * Raw libSQL client for arbitrary SQL queries.
+	 *
+	 * Use this when you need to run user-authored SQL strings directly.
+	 * The database is read-only in intent (writes are overwritten on rebuild).
+	 *
+	 * @example
+	 * ```typescript
+	 * const result = await ws.extensions.sqliteIndex.client.execute(
+	 *   "SELECT name, path FROM files WHERE type = 'file' AND trashed_at IS NULL"
+	 * );
+	 * console.log(result.rows);
+	 * ```
+	 */
+	readonly client: Client;
+	/** Drizzle schema (re-exported for query building convenience). */
+	readonly schema: typeof schema;
+	/**
+	 * Full-text search across file names and content.
+	 *
+	 * Uses SQLite FTS5 under the hood. Returns ranked results with
+	 * highlighted snippets. Empty/whitespace queries return `[]`.
+	 *
+	 * @example
+	 * ```typescript
+	 * const hits = await ws.extensions.sqliteIndex.search('meeting notes');
+	 * for (const hit of hits) {
+	 *   console.log(hit.name, hit.path, hit.snippet);
+	 * }
+	 * ```
+	 */
+	search: (query: string) => Promise<SearchResult[]>;
+	/**
+	 * Manually nuke and rebuild the entire index from Yjs.
+	 *
+	 * Called automatically on init and after every debounced table mutation.
+	 * Exposed for manual recovery (e.g. suspected corruption).
+	 */
+	rebuild: () => Promise<void>;
+	/** Promise that resolves after the initial rebuild completes. */
+	whenReady: Promise<void>;
+	/** Tear down observers and close the SQLite database. */
+	destroy: () => void;
+};
+
+// ════════════════════════════════════════════════════════════════════════════
+// EXTENSION CONTEXT
+// ════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Minimal context shape this extension needs from the workspace.
+ *
+ * Structural subtyping means any workspace with a `files` table
+ * (using `filesTable` from `@epicenter/filesystem`) satisfies this.
+ */
+type SqliteIndexContext = {
+	tables: { files: TableHelper<FileRow> };
+	documents: { files: { content: Documents<FileRow> } };
+};
+
+// ════════════════════════════════════════════════════════════════════════════
+// FACTORY
+// ════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Create a SQLite index workspace extension.
+ *
+ * Returns a curried factory: call with options, then pass to
+ * `.withWorkspaceExtension()`. The inner factory receives the
+ * workspace context and returns the extension exports.
+ *
+ * @example
+ * ```typescript
+ * createWorkspace({ id: 'opensidian', tables: { files: filesTable } })
+ *   .withExtension('persistence', indexeddbPersistence)
+ *   .withWorkspaceExtension('sqliteIndex', createSqliteIndex());
+ * ```
+ */
+export function createSqliteIndex(options: SqliteIndexOptions = {}) {
+	const { debounceMs = 100 } = options;
+
+	return (context: SqliteIndexContext): SqliteIndex => {
+		const filesTable = context.tables.files;
+		const contentDocs = context.documents.files.content;
+
+		const client = createClient({ url: ':memory:' });
+		let db: LibSQLDatabase<typeof schema>;
+		let syncTimeout: ReturnType<typeof setTimeout> | null = null;
+		let rebuilding = false;
+		let unobserve: (() => void) | null = null;
+
+		// ── Async initialization ──────────────────────────────────────
+		const whenReady = (async () => {
+			// WAL mode — no-op for in-memory but documents intent
+			await client.execute('PRAGMA journal_mode = WAL');
+
+			// Create files table + indexes from the Drizzle schema (single source of truth)
+			for (const ddl of generateDDL(schema.files)) {
+				await client.execute(ddl);
+			}
+
+			// FTS5 virtual table — standalone (not external-content)
+			// Drizzle has no virtual table support, so this stays as raw SQL
+			await client.execute(`
+				CREATE VIRTUAL TABLE IF NOT EXISTS files_fts
+				USING fts5(file_id UNINDEXED, name, content)
+			`);
+
+			db = drizzle(client, { schema });
+
+			// Initial rebuild from Yjs
+			await rebuild();
+
+			// Observe ongoing table mutations
+			unobserve = filesTable.observe(() => scheduleSync());
+		})();
+
+		// ── Debounced sync ────────────────────────────────────────────
+		function scheduleSync() {
+			if (syncTimeout) clearTimeout(syncTimeout);
+			syncTimeout = setTimeout(() => {
+				syncTimeout = null;
+				void rebuild();
+			}, debounceMs);
+		}
+
+		// ── Full rebuild ──────────────────────────────────────────────
+		async function rebuild(): Promise<void> {
+			if (rebuilding) return;
+			rebuilding = true;
+
+			try {
+				const rows = filesTable.getAllValid();
+				const paths = computePaths(rows);
+
+				// Read content for files (skip folders)
+				const contentMap = new Map<string, string | null>();
+				for (const row of rows) {
+					if (row.type === 'folder') {
+						contentMap.set(row.id, null);
+						continue;
+					}
+					try {
+						const handle = await contentDocs.open(row.id);
+						const text = handle.read();
+						contentMap.set(row.id, text || null);
+					} catch {
+						contentMap.set(row.id, null);
+					}
+				}
+
+				// Build batch: nuke + reinsert in a single transaction
+				const statements: InStatement[] = [
+					'DELETE FROM files_fts',
+					'DELETE FROM files',
+				];
+
+				for (const row of rows) {
+					const path = paths.get(row.id) ?? null;
+					const content = contentMap.get(row.id) ?? null;
+
+					statements.push({
+						sql: `INSERT INTO files
+							(id, name, parent_id, type, path, size, created_at, updated_at, trashed_at, content)
+							VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+						args: [
+							row.id,
+							row.name,
+							row.parentId,
+							row.type,
+							path,
+							row.size,
+							row.createdAt,
+							row.updatedAt,
+							row.trashedAt,
+							content,
+						],
+					});
+
+					// Insert into FTS — use empty string for null content
+					// so the file name is still searchable
+					statements.push({
+						sql: 'INSERT INTO files_fts (file_id, name, content) VALUES (?, ?, ?)',
+						args: [row.id, row.name, content ?? ''],
+					});
+				}
+
+				// libSQL batch executes all statements in a single transaction
+				await client.batch(statements, 'write');
+			} finally {
+				rebuilding = false;
+			}
+		}
+
+		// ── Full-text search ──────────────────────────────────────────
+
+		/**
+		 * Search file names and content using FTS5 MATCH.
+		 *
+		 * Returns up to 50 results ranked by relevance, each with an
+		 * HTML snippet (`<mark>` tags around matched terms).
+		 */
+		async function search(query: string): Promise<SearchResult[]> {
+			const trimmed = query.trim();
+			if (!trimmed) return [];
+
+			try {
+				// snippet() args: table, column-index, open, close, ellipsis, max-tokens
+				const result = await client.execute({
+					sql: `SELECT
+						fts.file_id,
+						f.name,
+						f.path,
+						snippet(files_fts, 2, '<mark>', '</mark>', '...', 64) AS snippet
+					 FROM files_fts fts
+					 JOIN files f ON f.id = fts.file_id
+					 WHERE files_fts MATCH ?
+					 ORDER BY rank
+					 LIMIT 50`,
+					args: [trimmed],
+				});
+
+				return result.rows.map((row) => ({
+					id: row.file_id as string,
+					name: row.name as string,
+					path: (row.path as string) ?? null,
+					snippet: row.snippet as string,
+				}));
+			} catch {
+				// Invalid FTS5 query syntax — return empty rather than throw
+				return [];
+			}
+		}
+
+		// ── Extension exports ─────────────────────────────────────────
+		return {
+			get db() {
+				return db;
+			},
+			get client() {
+				return client;
+			},
+			schema,
+			search,
+			rebuild,
+			whenReady,
+			destroy() {
+				if (syncTimeout) clearTimeout(syncTimeout);
+				unobserve?.();
+				client.close();
+			},
+		};
+	};
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// PATH COMPUTATION
+// ════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Compute materialized POSIX paths for all rows by walking parentId chains.
+ *
+ * Memoized per-call — each path is computed once and cached. Handles
+ * cycles (via visited-set) and orphans (fallback to root `/name`).
+ */
+function computePaths(rows: FileRow[]): Map<string, string> {
+	const rowById = new Map<string, FileRow>();
+	for (const row of rows) rowById.set(row.id, row);
+
+	const paths = new Map<string, string>();
+
+	function getPath(id: string, visited: Set<string>): string | null {
+		if (paths.has(id)) return paths.get(id)!;
+		if (visited.has(id)) return null; // Cycle
+		visited.add(id);
+
+		const row = rowById.get(id);
+		if (!row) return null;
+
+		if (row.parentId === null) {
+			const path = `/${row.name}`;
+			paths.set(id, path);
+			return path;
+		}
+
+		// Guard against unreasonably deep trees
+		if (visited.size > MAX_PATH_DEPTH) return null;
+
+		const parentPath = getPath(row.parentId, visited);
+		if (parentPath === null) {
+			// Orphan or cycle — treat as root-level
+			const path = `/${row.name}`;
+			paths.set(id, path);
+			return path;
+		}
+
+		const path = `${parentPath}/${row.name}`;
+		paths.set(id, path);
+		return path;
+	}
+
+	for (const row of rows) {
+		getPath(row.id, new Set());
+	}
+
+	return paths;
+}

--- a/packages/filesystem/src/extensions/sqlite-index/schema.ts
+++ b/packages/filesystem/src/extensions/sqlite-index/schema.ts
@@ -1,0 +1,33 @@
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+/**
+ * SQLite table mirroring {@link FileRow} from the Yjs files table.
+ *
+ * This is a read-only index—never the source of truth. Rebuilt from Yjs
+ * on every page load and kept in sync via debounced observation.
+ *
+ * Adds two derived columns not present in FileRow:
+ * - `path`: materialized POSIX path computed from the parentId chain
+ * - `content`: serialized text from the per-file Y.Doc (null for folders)
+ */
+export const files = sqliteTable(
+	'files',
+	{
+		id: text('id').primaryKey(),
+		name: text('name').notNull(),
+		parentId: text('parent_id'),
+		type: text('type').notNull(),
+		path: text('path'),
+		size: integer('size').notNull(),
+		createdAt: integer('created_at').notNull(),
+		updatedAt: integer('updated_at').notNull(),
+		trashedAt: integer('trashed_at'),
+		content: text('content'),
+	},
+	(t) => [
+		index('parent_idx').on(t.parentId),
+		index('type_idx').on(t.type),
+		index('path_idx').on(t.path),
+		index('updated_idx').on(t.updatedAt),
+	],
+);

--- a/packages/filesystem/src/file-system.ts
+++ b/packages/filesystem/src/file-system.ts
@@ -27,7 +27,7 @@ function FileSystem<T extends IFileSystem>(fs: T): T {
  *
  * The returned object satisfies the `IFileSystem` interface from `just-bash`,
  * which allows this virtual filesystem to be used as a drop-in backend for
- * shell emulation — while also exposing extra members (`content`, `index`,
+ * shell emulation — while also exposing extra members (`index`,
  * `lookupId`, `destroy`) that aren't part of `IFileSystem`.
  *
  * **No symlinks** — `symlink`, `link`, and `readlink` always throw ENOSYS.
@@ -48,102 +48,6 @@ export function createYjsFileSystem(
 	const tree = new FileTree(filesTable);
 
 	return FileSystem({
-		/**
-		 * Content I/O for direct reads/writes by UI layers.
-		 *
-		 * Opens the per-file content Y.Doc via `contentDocuments.open()` and
-		 * delegates to the handle's timeline-backed methods.
-		 * The `write` method handles sheet mode switching automatically.
-		 *
-		 * Use `open()` to get the full {@link DocumentHandle} for editor
-		 * binding (e.g. `handle.asText()` for CodeMirror + Yjs).
-		 *
-		 * @example
-		 * ```typescript
-		 * const text = await fs.content.read(fileId);
-		 * await fs.content.write(fileId, 'hello');
-		 *
-		 * // Editor binding
-		 * const handle = await fs.content.open(fileId);
-		 * const ytext = handle.asText();
-		 * ```
-		 */
-		content: {
-			/**
-			 * Open a file's content document and return the full handle.
-			 *
-			 * The returned {@link DocumentHandle} exposes timeline-backed methods
-			 * for editor binding: `asText()` returns a `Y.Text` suitable for
-			 * CodeMirror/y-codemirror.next, `asRichText()` returns a `Y.XmlFragment`
-			 * for TipTap, and `asSheet()` returns column/row maps.
-			 *
-			 * Documents are cached -- calling `open()` twice for the same file returns
-			 * handles backed by the same Y.Doc.
-			 */
-			async open(fileId: FileId) {
-				return contentDocuments.open(fileId);
-			},
-
-			/**
-			 * Read file content as a string.
-			 *
-			 * Opens the file's content Y.Doc and reads from the timeline.
-			 * Returns text content, or sheet CSV for sheet-mode files.
-			 */
-			async read(fileId: FileId): Promise<string> {
-				const handle = await contentDocuments.open(fileId);
-				return handle.read();
-			},
-
-			/**
-			 * Write text data to a file, handling sheet mode switching.
-			 *
-			 * If the file is in sheet mode, clears existing columns/rows and
-			 * re-parses from the CSV string. Otherwise delegates to
-			 * `handle.write()` which replaces the timeline text entry.
-			 *
-			 * @returns The byte size of the written data.
-			 */
-			async write(fileId: FileId, data: string): Promise<number> {
-				const handle = await contentDocuments.open(fileId);
-				const validated = readEntry(handle.timeline.currentEntry);
-
-				if (validated.mode === 'sheet') {
-					handle.batch(() => {
-						validated.columns.forEach((_, key) => {
-							validated.columns.delete(key);
-						});
-						validated.rows.forEach((_, key) => {
-							validated.rows.delete(key);
-						});
-						parseSheetFromCsv(data, validated.columns, validated.rows);
-					});
-				} else {
-					handle.write(data);
-				}
-				return new TextEncoder().encode(data).byteLength;
-			},
-
-			/**
-			 * Append text to a file's existing content.
-			 *
-			 * Only works for text-mode files—inserts at the end of the Y.Text.
-			 * Returns the new total byte size, or `null` if the current mode
-			 * doesn't support append (caller should fall back to `write`).
-			 */
-			async append(fileId: FileId, data: string): Promise<number | null> {
-				const handle = await contentDocuments.open(fileId);
-				const validated = readEntry(handle.timeline.currentEntry);
-
-				if (validated.mode !== 'text') return null;
-
-				handle.batch(() => validated.content.insert(validated.content.length, data));
-
-				// Re-read after mutation
-				return new TextEncoder().encode(validated.content.toString()).byteLength;
-			},
-		},
-
 		/** Reactive file-system indexes for path lookups and parent-child queries. */
 		get index(): FileTree['index'] {
 			return tree.index;
@@ -285,7 +189,25 @@ export function createYjsFileSystem(
 
 			const textData =
 				typeof data === 'string' ? data : new TextDecoder().decode(data);
-			const size = await this.content.write(id, textData);
+			const handle = await contentDocuments.open(id);
+			const validated = readEntry(handle.timeline.currentEntry);
+
+			let size: number;
+			if (validated.mode === 'sheet') {
+				handle.batch(() => {
+					validated.columns.forEach((_, key) => {
+						validated.columns.delete(key);
+					});
+					validated.rows.forEach((_, key) => {
+						validated.rows.delete(key);
+					});
+					parseSheetFromCsv(textData, validated.columns, validated.rows);
+				});
+				size = new TextEncoder().encode(textData).byteLength;
+			} else {
+				handle.write(textData);
+				size = new TextEncoder().encode(textData).byteLength;
+			}
 			tree.touch(id, size);
 		},
 
@@ -299,11 +221,16 @@ export function createYjsFileSystem(
 			const row = tree.getRow(id, abs);
 			if (row.type === 'folder') throw FS_ERRORS.EISDIR(abs);
 
-			const newSize = await this.content.append(id, text);
-			if (newSize === null) {
+			const handle = await contentDocuments.open(id);
+			const validated = readEntry(handle.timeline.currentEntry);
+
+			if (validated.mode !== 'text') {
 				await this.writeFile(path, data);
 				return;
 			}
+
+			handle.batch(() => validated.content.insert(validated.content.length, text));
+			const newSize = new TextEncoder().encode(validated.content.toString()).byteLength;
 			tree.touch(id, newSize);
 		},
 

--- a/packages/filesystem/src/file-system.ts
+++ b/packages/filesystem/src/file-system.ts
@@ -55,13 +55,35 @@ export function createYjsFileSystem(
 		 * delegates to the handle's timeline-backed methods.
 		 * The `write` method handles sheet mode switching automatically.
 		 *
+		 * Use `open()` to get the full {@link DocumentHandle} for editor
+		 * binding (e.g. `handle.asText()` for CodeMirror + Yjs).
+		 *
 		 * @example
 		 * ```typescript
 		 * const text = await fs.content.read(fileId);
 		 * await fs.content.write(fileId, 'hello');
+		 *
+		 * // Editor binding
+		 * const handle = await fs.content.open(fileId);
+		 * const ytext = handle.asText();
 		 * ```
 		 */
 		content: {
+			/**
+			 * Open a file's content document and return the full handle.
+			 *
+			 * The returned {@link DocumentHandle} exposes timeline-backed methods
+			 * for editor binding: `asText()` returns a `Y.Text` suitable for
+			 * CodeMirror/y-codemirror.next, `asRichText()` returns a `Y.XmlFragment`
+			 * for TipTap, and `asSheet()` returns column/row maps.
+			 *
+			 * Documents are cached -- calling `open()` twice for the same file returns
+			 * handles backed by the same Y.Doc.
+			 */
+			async open(fileId: FileId) {
+				return contentDocuments.open(fileId);
+			},
+
 			/**
 			 * Read file content as a string.
 			 *

--- a/packages/filesystem/src/index.ts
+++ b/packages/filesystem/src/index.ts
@@ -44,3 +44,16 @@ export {
 	FileTree,
 	validateName,
 } from './tree/index.js';
+
+// Extensions
+export {
+	createSqliteIndex,
+	type SearchResult,
+	type SqliteIndex,
+	type SqliteIndexOptions,
+} from './extensions/sqlite-index/index.js';
+export {
+	generateDDL,
+	generateCreateIndexSQL,
+	generateCreateTableSQL,
+} from './extensions/sqlite-index/ddl.js';

--- a/packages/ui/src/tree-view/tree-view-folder.svelte
+++ b/packages/ui/src/tree-view/tree-view-folder.svelte
@@ -29,7 +29,7 @@
 	<Collapsible.Content class="mx-2 border-l">
 		<div class="relative flex place-items-start">
 			<div class="bg-border mx-2 h-full w-px"></div>
-			<div class="flex flex-col">{@render children?.()}</div>
+			<div class="flex flex-1 flex-col">{@render children?.()}</div>
 		</div>
 	</Collapsible.Content>
 </Collapsible.Root>

--- a/packages/ui/src/tree-view/tree-view-folder.svelte
+++ b/packages/ui/src/tree-view/tree-view-folder.svelte
@@ -26,7 +26,7 @@
 		{/if}
 		<span>{name}</span>
 	</Collapsible.Trigger>
-	<Collapsible.Content class="mx-2 border-l">
+	<Collapsible.Content class="ml-2 border-l">
 		<div class="relative flex place-items-start">
 			<div class="bg-border mx-2 h-full w-px"></div>
 			<div class="flex flex-1 flex-col gap-0.5">{@render children?.()}</div>

--- a/packages/ui/src/tree-view/tree-view-folder.svelte
+++ b/packages/ui/src/tree-view/tree-view-folder.svelte
@@ -29,7 +29,7 @@
 	<Collapsible.Content class="mx-2 border-l">
 		<div class="relative flex place-items-start">
 			<div class="bg-border mx-2 h-full w-px"></div>
-			<div class="flex flex-1 flex-col">{@render children?.()}</div>
+			<div class="flex flex-1 flex-col gap-0.5">{@render children?.()}</div>
 		</div>
 	</Collapsible.Content>
 </Collapsible.Root>

--- a/packages/ui/src/tree-view/tree-view.svelte
+++ b/packages/ui/src/tree-view/tree-view.svelte
@@ -5,6 +5,6 @@
 	let { children, class: className, ...rest }: TreeViewRootProps = $props();
 </script>
 
-<div role="tree" class={cn('flex flex-col', className)} {...rest}>
+<div role="tree" class={cn('flex flex-col gap-0.5', className)} {...rest}>
 	{@render children?.()}
 </div>

--- a/specs/20260313T143000-opensidian-sqlite-index-extension.md
+++ b/specs/20260313T143000-opensidian-sqlite-index-extension.md
@@ -252,24 +252,24 @@ export function createSqliteIndex(options: SqliteIndexOptions = {}) {
 
 ### Phase 1: Core Extension
 
-- [ ] **1.1** Add `sql.js` and `drizzle-orm` dependencies to `packages/filesystem`
-- [ ] **1.2** Create `packages/filesystem/src/extensions/sqlite-index/schema.ts` — Drizzle schema mirroring `FileRow`
-- [ ] **1.3** Create `packages/filesystem/src/extensions/sqlite-index/index.ts` — extension factory with `rebuild()`, `destroy()`, `whenReady`
-- [ ] **1.4** Implement debounced rebuild: observe `tables.files` → schedule → nuke + reinsert
-- [ ] **1.5** Wire content serialization: for each file, `documents.open(fileId)` → `content.read()` → store in `content` column
-- [ ] **1.6** Add materialized `path` column populated from `FileTree.index.getPathById()`
-- [ ] **1.7** Export from `packages/filesystem/src/index.ts`
+- [x] **1.1** Add `sql.js` and `drizzle-orm` dependencies to `packages/filesystem`
+- [x] **1.2** Create `packages/filesystem/src/extensions/sqlite-index/schema.ts` — Drizzle schema mirroring `FileRow`
+- [x] **1.3** Create `packages/filesystem/src/extensions/sqlite-index/index.ts` — extension factory with `rebuild()`, `destroy()`, `whenReady`
+- [x] **1.4** Implement debounced rebuild: observe `tables.files` → schedule → nuke + reinsert
+- [x] **1.5** Wire content serialization: for each file, `documents.open(fileId)` → `content.read()` → store in `content` column
+- [x] **1.6** Add materialized `path` column populated via parentId chain traversal
+- [x] **1.7** Export from `packages/filesystem/src/index.ts`
 
 ### Phase 2: Full-Text Search
 
-- [ ] **2.1** Create FTS5 virtual table via raw SQL in the schema setup
-- [ ] **2.2** Implement `search(query: string)` method using FTS5 `MATCH`
-- [ ] **2.3** Return ranked results with highlighted snippets via `snippet()` function
-- [ ] **2.4** Handle content-less files (folders, binary) gracefully in FTS
+- [x] **2.1** Create FTS5 virtual table via raw SQL in the schema setup
+- [x] **2.2** Implement `search(query: string)` method using FTS5 `MATCH`
+- [x] **2.3** Return ranked results with highlighted snippets via `snippet()` function
+- [x] **2.4** Handle content-less files (folders, binary) gracefully in FTS
 
 ### Phase 3: OpenSidian Integration
 
-- [ ] **3.1** Wire extension into OpenSidian's workspace: `.withWorkspaceExtension('sqliteIndex', createSqliteIndex())`
+- [x] **3.1** Wire extension into OpenSidian's workspace: `.withWorkspaceExtension('sqliteIndex', createSqliteIndex())`
 - [ ] **3.2** Create a search service in `apps/opensidian/src/lib/fs/` that wraps the extension's `search()` method
 - [ ] **3.3** Expose rebuild/status in the UI (e.g., "Index: 1,234 files" in the status bar)
 
@@ -344,3 +344,38 @@ export function createSqliteIndex(options: SqliteIndexOptions = {}) {
 - `specs/20251205T164620-sqlite-index-batching.md` — Previous debounced rebuild design
 - `specs/20251030T120000-sqlite-config-inversion.md` — Previous config pattern
 - `specs/20251112T132055-sqlite-schema-namespace-refactor.md` — Previous schema organization
+
+
+## Review
+
+### Changes Made (2026-03-14)
+
+**Files created:**
+- `packages/filesystem/src/extensions/sqlite-index/schema.ts` — Drizzle `sqliteTable` definition with 10 columns (id, name, parentId, type, path, size, createdAt, updatedAt, trashedAt, content) plus 4 indexes
+- `packages/filesystem/src/extensions/sqlite-index/index.ts` — Extension factory (386 lines) implementing:
+  - sql.js WASM initialization with in-memory database
+  - Raw SQL schema creation (files table + FTS5 virtual table)
+  - Debounced full rebuild from Yjs (100ms default)
+  - Eager content indexing via `documents.open()` → `handle.read()`
+  - Materialized path computation via parentId chain traversal (handles cycles and orphans)
+  - FTS5 `search()` with `snippet()` highlighting and `<mark>` tags
+  - Concurrent rebuild guard (`rebuilding` flag)
+  - Proper cleanup: timeout clearing, observer unsubscribe, SQLite close
+
+**Files modified:**
+- `packages/filesystem/package.json` — Added `sql.js`, `drizzle-orm`, `@types/sql.js`
+- `packages/filesystem/src/index.ts` — Added exports for `createSqliteIndex`, `SearchResult`, `SqliteIndex`, `SqliteIndexOptions`
+- `apps/opensidian/src/lib/fs/fs-state.svelte.ts` — Added `.withWorkspaceExtension('sqliteIndex', createSqliteIndex())` to workspace chain
+
+### Deviations from Spec
+
+1. **Path computation**: Spec referenced `FileTree.index.getPathById()` which doesn't exist. Implemented equivalent via parentId chain traversal with cycle detection and orphan handling (same algorithm as `path-index.ts`).
+2. **FTS5 table**: Used standalone FTS5 (`file_id UNINDEXED, name, content`) instead of external-content (`content=files, content_rowid=rowid`) for simplicity—both get nuked and rebuilt together anyway.
+3. **Index syntax**: Used array-style Drizzle index syntax (`(t) => [...]`) instead of object-style (`(t) => ({...})`) to match current drizzle-orm API.
+4. **Phase 3.2–3.3 deferred**: Search service wrapper and status bar UI left for a follow-up—the extension is usable directly via `ws.extensions.sqliteIndex.search()`.
+
+### Verification
+
+- All existing tests pass: 189 pass, 0 fail (packages/filesystem)
+- LSP diagnostics clean on all changed files (schema.ts, index.ts, index.ts barrel, fs-state.svelte.ts)
+- Extension is purely additive—no existing code was modified beyond the barrel export and OpenSidian wiring

--- a/specs/20260313T143000-opensidian-sqlite-index-extension.md
+++ b/specs/20260313T143000-opensidian-sqlite-index-extension.md
@@ -1,0 +1,346 @@
+# OpenSidian SQLite Index Extension
+
+**Date**: 2026-03-13
+**Status**: Draft
+**Author**: AI-assisted
+
+## Overview
+
+A workspace extension that mirrors the Yjs CRDT filesystem into a local SQLite database as a read-optimized index. The SQLite database is never the source of truth—it's a derived, rebuildable cache that enables SQL queries, full-text search, and fast lookups against file metadata and content.
+
+## Motivation
+
+### Current State
+
+OpenSidian's filesystem is backed by Yjs CRDTs via `@epicenter/filesystem`. The `FileTree` class provides reactive indexes for path lookups and parent-child queries:
+
+```typescript
+const ws = createWorkspace({ id: 'opensidian', tables: { files: filesTable } })
+  .withExtension('persistence', indexeddbPersistence);
+
+const fs = createYjsFileSystem(ws.tables.files, ws.documents.files.content);
+```
+
+All queries go through the `FileTree.index` object, which maintains in-memory `Map`s derived from Yjs observeDeep callbacks. This works for tree navigation but can't support:
+
+1. **Full-text search**: No way to search across file contents. Users can't find files by content.
+2. **Complex queries**: Can't do "find all .md files modified in the last week" or "find files larger than 10KB" without iterating every row.
+3. **SQL-powered features**: No aggregate queries, joins, or filtering that SQL gives you for free.
+4. **Content indexing**: File content lives in per-file Y.Docs—no unified view exists.
+
+### Previous Implementation
+
+This codebase previously had a `sqliteIndex` function (in the now-removed `packages/epicenter/src/indexes/sqlite/`). Key lessons from existing specs:
+
+- **Debounced rebuild beats incremental sync** (`20251205T164620-sqlite-index-batching.md`): Individual change tracking caused race conditions and ordering bugs. Rebuilding from Yjs on a 100ms debounce is simpler and guarantees correctness at ~7.4k rows/s.
+- **Config inversion** (`20251030T120000-sqlite-config-inversion.md`): The caller should pass the path/config, not the extension.
+- **WAL mode on, foreign keys off** — SQLite is a read index, not a relational database.
+
+### Desired State
+
+A workspace extension that:
+
+```typescript
+const ws = createWorkspace({ id: 'opensidian', tables: { files: filesTable } })
+  .withExtension('persistence', indexeddbPersistence)
+  .withExtension('sqliteIndex', createSqliteIndex);
+
+// Extension provides SQL query capabilities
+const results = ws.extensions.sqliteIndex.query(
+  sql`SELECT * FROM files WHERE name LIKE ${'%.md'} AND trashed_at IS NULL`
+);
+
+// Full-text search across file content
+const searchResults = ws.extensions.sqliteIndex.search('meeting notes');
+
+// Manual rebuild (e.g., after suspected corruption)
+await ws.extensions.sqliteIndex.rebuild();
+```
+
+## Research Findings
+
+### Browser SQLite Options
+
+OpenSidian is a SvelteKit web app (no Tauri backend). SQLite must run in the browser via WASM.
+
+| Option | Browser Support | Drizzle Adapter | Maturity | Notes |
+|---|---|---|---|---|
+| **sql.js** | Excellent (WASM, battle-tested) | `drizzle-orm/sql-js` | Very mature | Emscripten-compiled SQLite, widely used |
+| **@libsql/client-wasm** | Exists (wasm32 target) | Via `drizzle-orm/libsql` | Less proven | Turso's WASM build, thin browser docs |
+| **sqlite-wasm** (official) | Good (official SQLite WASM) | No native Drizzle adapter | Newer | Official build, OPFS backend |
+| **wa-sqlite** | Good | No Drizzle adapter | Moderate | IndexedDB/OPFS VFS backends |
+
+**Key finding**: sql.js is the safest choice for browser today. It has the most ecosystem support and a first-class Drizzle adapter.
+
+**Turso/libSQL upgrade path**: If OpenSidian later needs remote sync (sharing indexes across devices), the schema stays identical—only the driver changes from sql.js to `@libsql/client`. Turso's "embedded replicas" pattern (local SQLite that syncs to a remote Turso database) maps perfectly to this architecture. The local SQLite index remains the read surface; the remote database becomes the sync target.
+
+### Turso Platform
+
+Turso is a managed libSQL platform built on SQLite. Key capabilities relevant to this design:
+
+- **Embedded replicas**: A local SQLite file that syncs with a remote Turso database. Local reads are instant; writes propagate to remote.
+- **Database-per-tenant**: Turso supports creating databases programmatically via their Platform API—one database per workspace is a natural fit.
+- **libSQL extensions**: libSQL is a fork of SQLite that adds features like native vector search and remote replication.
+
+For a LOCAL-ONLY index (no remote sync), Turso adds no value over sql.js. The value comes IF/WHEN remote sync is needed. The upgrade path is clean because:
+
+1. Drizzle schema definitions are driver-agnostic (`sqliteTable` works with sql.js, libSQL, better-sqlite3, bun:sqlite)
+2. The extension factory pattern means swapping the driver is a single-line change
+3. Turso's embedded replica pattern matches our "index as derived cache" architecture perfectly
+
+### Workspace Extension System
+
+The workspace provides three extension methods:
+
+- `.withExtension(key, factory)` — applies to both workspace Y.Doc and per-file content Y.Docs (90% use case)
+- `.withWorkspaceExtension(key, factory)` — workspace Y.Doc only
+- `.withDocumentExtension(key, factory, opts?)` — per-file content Y.Docs only
+
+The SQLite index should use `.withWorkspaceExtension()` because it observes the workspace-level files table, not individual content documents. Content serialization happens by explicitly opening each file's content doc via `documents.open(fileId)`.
+
+Factory receives: `{ id, ydoc, tables, kv, documents, awareness, extensions, whenReady }`
+
+### Content Serialization
+
+File content lives in per-file Y.Docs managed by `documents.files.content`. The `ContentHelpers` abstraction provides:
+
+- `content.read(fileId): Promise<string>` — reads text content from the file's Y.Doc
+- `content.readBuffer(fileId): Promise<Uint8Array>` — reads binary content
+
+The timeline abstraction inside `ContentHelpers` handles three content modes: `text`, `binary`, and `sheet` (CSV-like). For the SQLite index, we serialize text content as UTF-8 strings and skip binary content (not searchable).
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Extension type | `.withWorkspaceExtension()` | Observes workspace table, not individual content docs |
+| Browser SQLite driver | sql.js (WASM) | Most mature browser SQLite, first-class Drizzle adapter |
+| Sync strategy | Debounced full rebuild | Proven simpler and more correct than incremental (per existing spec) |
+| Default debounce | 100ms | Matches previous implementation; good balance of latency vs write batching |
+| Content indexing | Include text content | Enables full-text search; skip binary files |
+| FTS implementation | SQLite FTS5 | Native to SQLite, no additional dependencies |
+| Schema definition | Drizzle ORM `sqliteTable` | Driver-agnostic schema, typed queries, migration support |
+| Turso/remote sync | Deferred | No value for local-only index; clean upgrade path exists via driver swap |
+| Package location | `packages/filesystem/src/extensions/` | Co-located with the filesystem it indexes |
+| Persistence | None (ephemeral) | Index is rebuilt from Yjs on every page load; optionally persist to IndexedDB/OPFS later |
+
+## Architecture
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│  Yjs Y.Doc (Source of Truth)                                  │
+│  ├── Y.Array('table:files')  ← FileRow metadata              │
+│  │   observe() fires on add/update/delete                     │
+│  └── Per-file Y.Doc          ← content via documents.open()   │
+└────────────────────┬──────────────────────────────────────────┘
+                     │ observe() callback
+                     ▼
+┌───────────────────────────────────────────────────────────────┐
+│  Debounce (100ms default)                                     │
+│  scheduleSync() → clearTimeout → setTimeout → rebuild()       │
+└────────────────────┬──────────────────────────────────────────┘
+                     │
+                     ▼
+┌───────────────────────────────────────────────────────────────┐
+│  rebuild()                                                    │
+│  1. Delete all rows from `files` table                        │
+│  2. Read all valid rows from tables.files.getAllValid()        │
+│  3. For each file: serialize content via documents.open()     │
+│  4. Batch INSERT into SQLite `files` table                    │
+│  5. Rebuild FTS5 index                                        │
+└───────────────────────────────────────────────────────────────┘
+
+Extension Exports:
+┌───────────────────────────────────────────────────────────────┐
+│  { db, query, search, rebuild, destroy, whenReady }           │
+│                                                               │
+│  db:       Drizzle SQLite database instance                   │
+│  query:    Run typed Drizzle queries against the index        │
+│  search:   Full-text search across file names + content       │
+│  rebuild:  Manually nuke and rebuild the entire index         │
+│  destroy:  Tear down observers, close SQLite                  │
+│  whenReady: Promise that resolves after initial rebuild       │
+└───────────────────────────────────────────────────────────────┘
+```
+
+### SQLite Schema
+
+```typescript
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+/** 1:1 mirror of FileRow from the Yjs files table */
+export const files = sqliteTable('files', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  parentId: text('parent_id'),
+  type: text('type').notNull(),           // 'file' | 'folder'
+  path: text('path'),                      // materialized path from FileTree.index
+  size: integer('size').notNull(),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+  trashedAt: integer('trashed_at'),
+  content: text('content'),                // serialized text from Y.Doc (null for folders/binary)
+}, (t) => ({
+  parentIdx: index('parent_idx').on(t.parentId),
+  typeIdx: index('type_idx').on(t.type),
+  pathIdx: index('path_idx').on(t.path),
+  updatedIdx: index('updated_idx').on(t.updatedAt),
+}));
+
+// FTS5 virtual table (created via raw SQL — Drizzle can't define virtual tables)
+// CREATE VIRTUAL TABLE files_fts USING fts5(name, content, content=files, content_rowid=rowid);
+```
+
+### Extension Factory
+
+```typescript
+import { drizzle } from 'drizzle-orm/sql-js';
+import initSqlJs from 'sql.js';
+import type { ExtensionContext } from '@epicenter/workspace';
+import * as schema from './schema.js';
+
+type SqliteIndexOptions = {
+  debounceMs?: number;
+};
+
+export function createSqliteIndex(options: SqliteIndexOptions = {}) {
+  const { debounceMs = 100 } = options;
+
+  return (context: ExtensionContext) => {
+    const { tables, documents } = context;
+
+    let db: ReturnType<typeof drizzle>;
+    let syncTimeout: ReturnType<typeof setTimeout> | null = null;
+
+    const whenReady = (async () => {
+      const SQL = await initSqlJs();
+      const sqlite = new SQL.Database();
+      db = drizzle(sqlite, { schema });
+
+      // Create tables and FTS index
+      sqlite.run(`CREATE TABLE IF NOT EXISTS files (...)`);
+      sqlite.run(`CREATE VIRTUAL TABLE IF NOT EXISTS files_fts USING fts5(...)`);
+
+      // Initial rebuild
+      await rebuild();
+
+      // Observe ongoing changes
+      tables.files.observe(() => scheduleSync());
+    })();
+
+    function scheduleSync() { /* debounced rebuild */ }
+    async function rebuild() { /* nuke + reinsert from Yjs */ }
+    function search(query: string) { /* FTS5 MATCH query */ }
+
+    return {
+      get db() { return db; },
+      query: (q: Parameters<typeof db.select>) => db.select(...q),
+      search,
+      rebuild,
+      whenReady,
+      destroy() {
+        if (syncTimeout) clearTimeout(syncTimeout);
+        tables.files.unobserve?.();
+        db?.close?.();
+      },
+    };
+  };
+}
+```
+
+## Implementation Plan
+
+### Phase 1: Core Extension
+
+- [ ] **1.1** Add `sql.js` and `drizzle-orm` dependencies to `packages/filesystem`
+- [ ] **1.2** Create `packages/filesystem/src/extensions/sqlite-index/schema.ts` — Drizzle schema mirroring `FileRow`
+- [ ] **1.3** Create `packages/filesystem/src/extensions/sqlite-index/index.ts` — extension factory with `rebuild()`, `destroy()`, `whenReady`
+- [ ] **1.4** Implement debounced rebuild: observe `tables.files` → schedule → nuke + reinsert
+- [ ] **1.5** Wire content serialization: for each file, `documents.open(fileId)` → `content.read()` → store in `content` column
+- [ ] **1.6** Add materialized `path` column populated from `FileTree.index.getPathById()`
+- [ ] **1.7** Export from `packages/filesystem/src/index.ts`
+
+### Phase 2: Full-Text Search
+
+- [ ] **2.1** Create FTS5 virtual table via raw SQL in the schema setup
+- [ ] **2.2** Implement `search(query: string)` method using FTS5 `MATCH`
+- [ ] **2.3** Return ranked results with highlighted snippets via `snippet()` function
+- [ ] **2.4** Handle content-less files (folders, binary) gracefully in FTS
+
+### Phase 3: OpenSidian Integration
+
+- [ ] **3.1** Wire extension into OpenSidian's workspace: `.withWorkspaceExtension('sqliteIndex', createSqliteIndex())`
+- [ ] **3.2** Create a search service in `apps/opensidian/src/lib/fs/` that wraps the extension's `search()` method
+- [ ] **3.3** Expose rebuild/status in the UI (e.g., "Index: 1,234 files" in the status bar)
+
+### Phase 4: Turso Upgrade Path (Future)
+
+- [ ] **4.1** Swap sql.js driver for `@libsql/client-wasm` or `@libsql/client`
+- [ ] **4.2** Configure embedded replica with `syncUrl` pointing to Turso
+- [ ] **4.3** Add sync controls (manual sync, auto-sync interval)
+
+## Edge Cases
+
+### Large Workspaces (>10k files)
+
+1. Rebuild iterates all rows and opens each file's content doc
+2. Content docs may not all be loaded in memory—`documents.open()` may trigger Y.Doc creation
+3. For >10k files, rebuild could take seconds. Consider: showing a progress indicator, or deferring content indexing to a second pass.
+
+### Binary Files
+
+1. A file's content mode is `binary` (detected by the timeline abstraction)
+2. Binary content is not UTF-8 text and shouldn't be indexed
+3. Store `null` in the `content` column for binary files; exclude from FTS5
+
+### Concurrent Rebuilds
+
+1. A rebuild is in progress when another change triggers `scheduleSync()`
+2. The debounce handles this naturally—the new timer replaces the old one
+3. If a rebuild is actively running (async), a flag should prevent overlapping rebuilds
+
+### Page Reload / Fresh Load
+
+1. SQLite index is ephemeral (in-memory via sql.js)
+2. On page load, `whenReady` triggers a full rebuild from Yjs
+3. Yjs data is persisted via IndexedDB (`y-indexeddb`), so the source of truth survives reloads
+4. Rebuild time depends on workspace size. For fast startup, consider persisting the SQLite DB to IndexedDB/OPFS (Phase 5).
+
+## Open Questions
+
+1. **Should the SQLite database persist across page reloads?**
+   - Options: (a) Always ephemeral—rebuild from Yjs on every load, (b) Persist to IndexedDB via sql.js export, (c) Persist to OPFS via sqlite-wasm
+   - **Recommendation**: Start ephemeral (a). It's simpler and the index is always fresh. Add persistence later if rebuild time becomes a problem on large workspaces.
+
+2. **Should content indexing be eager or lazy?**
+   - Options: (a) Index all file content during rebuild (eager), (b) Index content only when a file is first opened (lazy), (c) Index metadata eagerly, content in a background pass
+   - **Recommendation**: (c) — rebuild metadata first (fast, synchronous), then index content in a background pass. This keeps `whenReady` fast while still enabling full-text search.
+
+3. **Where should this package live?**
+   - Options: (a) `packages/filesystem/src/extensions/`, (b) `packages/workspace/src/extensions/`, (c) New `packages/sqlite-index/`
+   - **Recommendation**: (a) — it's specifically an index over the filesystem, not a generic workspace extension.
+
+4. **Should we use sql.js or target the official sqlite-wasm with OPFS?**
+   - sql.js is more mature and has Drizzle support. Official sqlite-wasm has OPFS persistence built in but no Drizzle adapter.
+   - **Recommendation**: sql.js for now. Revisit if persistence becomes a requirement (sqlite-wasm's OPFS support would be compelling then).
+
+## Success Criteria
+
+- [ ] `createSqliteIndex` extension can be wired into any workspace with a files table
+- [ ] Full rebuild from Yjs completes in <1s for 1,000 files
+- [ ] `search()` returns results with file name, path, and content snippets
+- [ ] `rebuild()` produces an identical database state regardless of call order
+- [ ] Extension properly destroys observers and closes SQLite on `destroy()`
+- [ ] Drizzle schema is driver-agnostic (can swap sql.js for libSQL/bun:sqlite without schema changes)
+- [ ] Tests pass using in-memory SQLite (no browser required)
+
+## References
+
+- `packages/filesystem/src/table.ts` — `filesTable` definition with `withDocument('content', ...)`
+- `packages/filesystem/src/file-system.ts` — `createYjsFileSystem` orchestrator
+- `packages/filesystem/src/content/content.ts` — `createContentHelpers` for reading file content
+- `packages/filesystem/src/tree/tree.ts` — `FileTree` class with index/observe patterns
+- `packages/workspace/src/workspace/create-workspace.ts` — Extension API (`withWorkspaceExtension`)
+- `specs/20251205T164620-sqlite-index-batching.md` — Previous debounced rebuild design
+- `specs/20251030T120000-sqlite-config-inversion.md` — Previous config pattern
+- `specs/20251112T132055-sqlite-schema-namespace-refactor.md` — Previous schema organization

--- a/specs/20260313T143300-opensidian-feature-additions.md
+++ b/specs/20260313T143300-opensidian-feature-additions.md
@@ -176,7 +176,7 @@ This requires managing a `focusedId` state separate from `activeFileId` (focused
 
 - [x] **1.1** Build `TabBar.svelte` using `Tabs` from `@epicenter/ui/tabs`
 - [x] **1.2** Wire tab state to `fsState.openFileIds` / `fsState.activeFileId`
-- [x] **1.3** Add close button on tabs, dirty indicator
+- [x] **1.3** Add close button on tabs (dirty indicator removed—no save concept in CRDT-backed storage)
 - [x] **1.4** Build `CommandPalette.svelte` using `Command` from `@epicenter/ui/command`
 - [x] **1.5** Implement file-name search (no SQLite dependency)
 - [x] **1.6** Add `Ctrl+K` / `Cmd+K` keyboard shortcut to open palette

--- a/specs/20260313T143300-opensidian-feature-additions.md
+++ b/specs/20260313T143300-opensidian-feature-additions.md
@@ -192,12 +192,12 @@ This requires managing a `focusedId` state separate from `activeFileId` (focused
 
 ### Phase 3: Rich Editing
 
-- [ ] **3.1** Add CodeMirror 6 dependency with Svelte wrapper
-- [ ] **3.2** Add `y-codemirror.next` for Yjs binding
-- [ ] **3.3** Replace `ContentEditor.svelte`'s textarea with CodeMirror
-- [ ] **3.4** Bind CodeMirror to the file's Y.Doc directly (no serialization)
-- [ ] **3.5** Add markdown syntax highlighting
-- [ ] **3.6** Optional: Add split-pane markdown preview
+- [x] **3.1** Add CodeMirror 6 dependency with Svelte wrapper
+- [x] **3.2** Add `y-codemirror.next` for Yjs binding
+- [x] **3.3** Replace `ContentEditor.svelte`'s textarea with CodeMirror
+- [x] **3.4** Bind CodeMirror to the file's Y.Doc directly (no serialization)
+- [x] **3.5** Add markdown syntax highlighting
+- [ ] **3.6** Optional: Add split-pane markdown preview (skipped for now)
 
 ### Phase 4: Advanced Interactions
 
@@ -263,3 +263,39 @@ This requires managing a `focusedId` state separate from `activeFileId` (focused
 - `packages/ui/src/tabs/` — Tabs component
 - `packages/ui/src/command/` — Command palette component
 - `packages/filesystem/src/content/content.ts` — content read/write for editor binding
+
+## Phase 3 Review
+
+### Summary
+
+Replaced the plain `<Textarea>` in ContentEditor with CodeMirror 6 bound directly to Yjs via `y-codemirror.next`. Every keystroke is now a Y.Doc operation with no intermediate string copy.
+
+### Key Discovery
+
+The Y.Array('timeline') / Y.Text compatibility concern was a non-issue. The timeline Y.Array is a container for versioned entries; each text entry contains a Y.Text inside it. The existing `DocumentHandle.asText()` method (designed explicitly for editor binding) returns the Y.Text directly, handling mode conversion and empty-doc initialization automatically.
+
+### Changes Made
+
+1. **`packages/filesystem/src/file-system.ts`** -- Added `open()` method to `fs.content`. One-line passthrough to `contentDocuments.open(fileId)` that returns the full `DocumentHandle`. This bridges the string-based I/O layer to the richer handle API needed for editor binding.
+
+2. **`apps/opensidian/package.json`** -- Added devDependencies: `@codemirror/state`, `@codemirror/view`, `@codemirror/commands`, `@codemirror/lang-markdown`, `@codemirror/language`, `y-codemirror.next`.
+
+3. **`apps/opensidian/src/lib/components/CodeMirrorEditor.svelte`** (NEW) -- Svelte 5 wrapper for CodeMirror 6. Accepts a `Y.Text` prop, creates an `EditorView` in `$effect`, destroys on cleanup. Extensions: `yCollab` (Yjs binding with built-in UndoManager), `markdown()` (syntax highlighting), `defaultKeymap`, `indentWithTab`, `drawSelection`, `EditorView.lineWrapping`. Styled to match the original textarea: monospace font, no gutters, no focus ring, transparent background, 1rem padding.
+
+4. **`apps/opensidian/src/lib/components/ContentEditor.svelte`** -- Complete rewrite. Dropped: `content` state, `loading`/`dirty` flags, `loadContent()`, `saveContent()`, `handleInput()`, `handleKeydown()`, cleanup write-on-destroy, `Textarea` import. Added: async `open()` call to get `DocumentHandle`, `handle.asText()` to extract `Y.Text`, renders `CodeMirrorEditor` with the Y.Text. The entire read-edit-writeback cycle is eliminated.
+
+### What Was Eliminated
+
+- No more `readContent` / `writeContent` calls from the editor
+- No more `dirty` flag tracking
+- No more `saveContent` on blur / Ctrl+S / cleanup
+- No more race condition guard on string loading (the Y.Text is the source of truth)
+- No more Textarea component import
+
+### Lifecycle
+
+The `{#key fsState.activeFileId}` block in ContentPanel.svelte destroys/recreates ContentEditor on tab switch. This naturally handles CodeMirror lifecycle: the `$effect` cleanup calls `view.destroy()`, and a new EditorView is created for the next file's Y.Text. The `DocumentHandle` caching in the Documents manager means re-opening the same file is cheap (returns the existing cached Y.Doc).
+
+### Pre-existing Issues
+
+svelte-check reports 80 pre-existing errors in `@epicenter/ui` (missing `#/utils.js` module resolution) and `define-table.ts` (missing `NumberKeysOf` type). None are related to our changes.

--- a/specs/20260313T143300-opensidian-feature-additions.md
+++ b/specs/20260313T143300-opensidian-feature-additions.md
@@ -184,11 +184,11 @@ This requires managing a `focusedId` state separate from `activeFileId` (focused
 
 ### Phase 2: Navigation and Polish
 
-- [ ] **2.1** Implement keyboard tree navigation (arrow keys, Home/End)
-- [ ] **2.2** Add `focusedId` state to `fsState`
-- [ ] **2.3** Compute flat visible-items list from tree expansion state
-- [ ] **2.4** Add file type icon mapping utility
-- [ ] **2.5** Wire icons into TreeNode/FileTreeItem based on file extension
+- [x] **2.1** Implement keyboard tree navigation (arrow keys, Home/End)
+- [x] **2.2** Add `focusedId` state to `fsState`
+- [x] **2.3** Compute flat visible-items list from tree expansion state
+- [x] **2.4** Add file type icon mapping utility
+- [x] **2.5** Wire icons into TreeNode/FileTreeItem based on file extension
 
 ### Phase 3: Rich Editing
 

--- a/specs/20260313T143300-opensidian-feature-additions.md
+++ b/specs/20260313T143300-opensidian-feature-additions.md
@@ -174,13 +174,13 @@ This requires managing a `focusedId` state separate from `activeFileId` (focused
 
 ### Phase 1: High-Priority Features
 
-- [ ] **1.1** Build `TabBar.svelte` using `Tabs` from `@epicenter/ui/tabs`
-- [ ] **1.2** Wire tab state to `fsState.openFileIds` / `fsState.activeFileId`
-- [ ] **1.3** Add close button on tabs, dirty indicator
-- [ ] **1.4** Build `CommandPalette.svelte` using `Command` from `@epicenter/ui/command`
-- [ ] **1.5** Implement file-name search (no SQLite dependency)
-- [ ] **1.6** Add `Ctrl+K` / `Cmd+K` keyboard shortcut to open palette
-- [ ] **1.7** Wire result selection to `fsState.actions.selectFile`
+- [x] **1.1** Build `TabBar.svelte` using `Tabs` from `@epicenter/ui/tabs`
+- [x] **1.2** Wire tab state to `fsState.openFileIds` / `fsState.activeFileId`
+- [x] **1.3** Add close button on tabs, dirty indicator
+- [x] **1.4** Build `CommandPalette.svelte` using `Command` from `@epicenter/ui/command`
+- [x] **1.5** Implement file-name search (no SQLite dependency)
+- [x] **1.6** Add `Ctrl+K` / `Cmd+K` keyboard shortcut to open palette
+- [x] **1.7** Wire result selection to `fsState.actions.selectFile`
 
 ### Phase 2: Navigation and Polish
 

--- a/specs/20260313T143300-opensidian-feature-additions.md
+++ b/specs/20260313T143300-opensidian-feature-additions.md
@@ -1,0 +1,265 @@
+# OpenSidian Feature Additions
+
+**Date**: 2026-03-13
+**Status**: Draft
+**Author**: AI-assisted
+
+## Overview
+
+New features for OpenSidian that transform it from a filesystem demo into a usable note-taking application. Each feature is scoped independently—they can be built in any order, though some have natural dependencies.
+
+## Motivation
+
+### Current State
+
+OpenSidian has the bones of a file manager:
+- Tree view with expand/collapse
+- Single-file text editing (raw textarea)
+- Create, rename, delete operations
+- Breadcrumb navigation
+- CRDT-backed persistence via Yjs + IndexedDB
+
+But it lacks features that users expect from any file-based note app:
+
+1. **No open file tabs** — `fsState.openFileIds` tracks open files, but there's no tab bar. Users can only view one file at a time with no way to switch between recently opened files.
+2. **No search** — No way to find files by name or content. The only navigation is manual tree browsing.
+3. **No keyboard tree navigation** — Only Enter/Space work. No arrow keys for up/down/expand/collapse.
+4. **No rich editing** — Plain textarea. No markdown rendering, no syntax highlighting, no formatting.
+5. **No file type awareness** — All files show the same icon regardless of extension.
+6. **No drag-and-drop** — Can't move files/folders by dragging in the tree.
+7. **No sort options** — Tree is always sorted alphabetically by name.
+
+### Desired State
+
+A note-taking app where users can efficiently navigate large file trees, search across all content, edit markdown with live preview, and reorganize files via drag-and-drop—all built on shadcn-svelte primitives from `@epicenter/ui`.
+
+## Feature Catalog
+
+### Feature 1: Open File Tabs
+
+**Priority**: High
+**Depends on**: None
+**Complexity**: Low
+
+The state already exists (`fsState.openFileIds`, `fsState.activeFileId`, `fsState.actions.selectFile`, `fsState.actions.closeFile`). This is purely a UI addition.
+
+**Design**:
+- Use `Tabs` from `@epicenter/ui/tabs` above the `ContentPanel`
+- Each tab shows the file name with a close button
+- Active tab corresponds to `fsState.activeFileId`
+- Tab overflow scrolls horizontally
+- Middle-click or close button calls `fsState.actions.closeFile(id)`
+- Dirty indicator (unsaved changes) on tab if `ContentEditor` has modifications
+
+**Architecture**:
+```
+ContentPanel.svelte
+  ├── TabBar.svelte (NEW)
+  │     └── Tabs.Root > Tabs.List > Tabs.Trigger (per open file)
+  ├── PathBreadcrumb.svelte
+  └── ContentEditor.svelte
+```
+
+### Feature 2: Command Palette (Search)
+
+**Priority**: High
+**Depends on**: SQLite Index Extension (for content search), or can work with name-only search initially
+**Complexity**: Medium
+
+**Design**:
+- Use `Command` from `@epicenter/ui/command` (cmdk-sv under the hood)
+- Trigger via `Ctrl+K` / `Cmd+K` keyboard shortcut
+- Two modes:
+  - **File search** (default): Filter files by name using `fsState` data (no SQLite needed)
+  - **Content search**: If SQLite index extension is available, search file contents via FTS5
+- Results show file icon, name, path, and content snippet (for content search)
+- Selecting a result opens the file via `fsState.actions.selectFile(id)`
+
+**Architecture**:
+```
+AppShell.svelte
+  └── CommandPalette.svelte (NEW)
+        └── Command.Root > Command.Input > Command.List > Command.Item
+```
+
+**Without SQLite**: File name search works by filtering `fsState.rootChildIds` recursively. This is O(n) over all files but fast enough for <10k files.
+
+**With SQLite**: Content search uses the extension's `search()` method with FTS5 for ranked, highlighted results.
+
+### Feature 3: Keyboard Tree Navigation
+
+**Priority**: Medium
+**Depends on**: None (or Tree View Adoption spec)
+**Complexity**: Medium
+
+**Design**:
+- Arrow Up/Down: Move focus between visible tree items
+- Arrow Right: Expand focused folder (or move to first child)
+- Arrow Left: Collapse focused folder (or move to parent)
+- Enter: Open focused file / toggle focused folder
+- Home/End: Jump to first/last visible item
+- Type-ahead: Start typing to jump to matching file name
+
+This requires managing a `focusedId` state separate from `activeFileId` (focused ≠ selected). The tree container handles keydown events and translates them to focus movements.
+
+**Implementation approach**:
+- Add `focusedId` to `fsState`
+- Compute a flat list of visible item IDs (respecting expansion state)
+- Arrow Up/Down moves `focusedId` through the flat list
+- `aria-activedescendant` on the tree root points to the focused item
+- Focus is managed via the roving tabindex pattern
+
+### Feature 4: File Type Icons
+
+**Priority**: Low
+**Depends on**: UI Idiomaticity spec (lucide-svelte icons)
+**Complexity**: Low
+
+**Design**:
+- Map file extensions to Lucide icons:
+  - `.md` → `FileText`
+  - `.ts` / `.js` → `FileCode`
+  - `.json` → `FileJson`
+  - `.csv` → `Sheet`
+  - `.png` / `.jpg` / `.svg` → `Image`
+  - Default → `File`
+- Extract extension from `row.name` in `TreeNode.svelte` (or `FileTreeItem.svelte`)
+- Small utility function: `getFileIcon(name: string): ComponentType`
+
+### Feature 5: Rich Text Editor
+
+**Priority**: Medium
+**Depends on**: None directly, but makes more sense after tabs
+**Complexity**: High
+
+**Design options**:
+
+| Editor | Yjs Integration | Markdown Support | Bundle Size | Maturity |
+|---|---|---|---|---|
+| **TipTap** | `y-tiptap` | Via extensions | ~150KB | Very mature |
+| **CodeMirror 6** | `y-codemirror.next` | Syntax highlighting | ~200KB | Very mature |
+| **Milkdown** | Built on ProseMirror + Yjs | First-class markdown | ~100KB | Moderate |
+| **BlockNote** | Built on TipTap + Yjs | Block-based markdown | ~250KB | Growing |
+
+**Key insight**: OpenSidian's content layer already stores data in Yjs Y.Docs. Editors with native Yjs bindings (TipTap via y-tiptap, CodeMirror via y-codemirror) can bind DIRECTLY to the existing content documents without any serialization layer. This is the ideal path.
+
+**Recommendation**: Start with CodeMirror 6 for a code/markdown editor with syntax highlighting and Yjs binding. It's the most flexible and has excellent Svelte integration patterns.
+
+### Feature 6: Drag-and-Drop
+
+**Priority**: Low
+**Depends on**: Tree View Adoption (easier with structured tree components)
+**Complexity**: High
+
+**Design**:
+- Drag files/folders within the tree to move them
+- Visual indicator showing drop target (folder highlight, insertion line)
+- Drop action calls `fsState.actions` to move the file: `fs.mv(sourcePath, destPath)`
+- Prevent invalid drops (e.g., dropping a folder into its own descendant)
+- Use native HTML5 drag-and-drop or a library like `@formkit/drag-and-drop`
+
+### Feature 7: Sort Options
+
+**Priority**: Low
+**Depends on**: None
+**Complexity**: Low
+
+**Design**:
+- Dropdown or toggle in the Toolbar: Sort by Name (A-Z, Z-A), Date Modified, Type, Size
+- Sort state stored in `fsState` (persisted in KV or local)
+- Applied when computing child display order in `FileTree` / `TreeNode`
+- Folders always sorted before files (configurable)
+
+## Implementation Plan
+
+### Phase 1: High-Priority Features
+
+- [ ] **1.1** Build `TabBar.svelte` using `Tabs` from `@epicenter/ui/tabs`
+- [ ] **1.2** Wire tab state to `fsState.openFileIds` / `fsState.activeFileId`
+- [ ] **1.3** Add close button on tabs, dirty indicator
+- [ ] **1.4** Build `CommandPalette.svelte` using `Command` from `@epicenter/ui/command`
+- [ ] **1.5** Implement file-name search (no SQLite dependency)
+- [ ] **1.6** Add `Ctrl+K` / `Cmd+K` keyboard shortcut to open palette
+- [ ] **1.7** Wire result selection to `fsState.actions.selectFile`
+
+### Phase 2: Navigation and Polish
+
+- [ ] **2.1** Implement keyboard tree navigation (arrow keys, Home/End)
+- [ ] **2.2** Add `focusedId` state to `fsState`
+- [ ] **2.3** Compute flat visible-items list from tree expansion state
+- [ ] **2.4** Add file type icon mapping utility
+- [ ] **2.5** Wire icons into TreeNode/FileTreeItem based on file extension
+
+### Phase 3: Rich Editing
+
+- [ ] **3.1** Add CodeMirror 6 dependency with Svelte wrapper
+- [ ] **3.2** Add `y-codemirror.next` for Yjs binding
+- [ ] **3.3** Replace `ContentEditor.svelte`'s textarea with CodeMirror
+- [ ] **3.4** Bind CodeMirror to the file's Y.Doc directly (no serialization)
+- [ ] **3.5** Add markdown syntax highlighting
+- [ ] **3.6** Optional: Add split-pane markdown preview
+
+### Phase 4: Advanced Interactions
+
+- [ ] **4.1** Implement drag-and-drop in tree (library selection TBD)
+- [ ] **4.2** Add sort options to toolbar
+- [ ] **4.3** Wire content search to SQLite index extension (when available)
+
+## Edge Cases
+
+### Tab State Persistence
+
+1. User has 5 tabs open, refreshes the page
+2. `fsState.openFileIds` is derived from Yjs state—does it persist?
+3. If not, tabs reset on reload. Consider storing open tab IDs in workspace KV.
+
+### Command Palette with Large File Trees
+
+1. Workspace has 10,000 files
+2. File-name search needs to be fast (filtering 10k items on every keystroke)
+3. Solution: Debounce input (150ms), limit results to 50, use `startsWith` before `includes`
+
+### CodeMirror + Yjs Binding Lifecycle
+
+1. User opens a file → CodeMirror binds to its Y.Doc
+2. User switches tabs → CodeMirror instance must unbind from old Y.Doc, bind to new one
+3. Y.Doc lifecycle is managed by `documents.open(fileId)` / `documents.close(fileId)`
+4. Must coordinate CodeMirror lifecycle with document open/close
+
+## Open Questions
+
+1. **Should tabs persist across sessions?**
+   - Options: (a) Ephemeral—reset on reload, (b) Persist in workspace KV, (c) Persist in localStorage
+   - **Recommendation**: (b) — workspace KV is already available and persists via Yjs. Store `openFileIds` and `activeFileId` there.
+
+2. **Which rich text editor to use?**
+   - Options: (a) CodeMirror 6, (b) TipTap, (c) Milkdown
+   - **Recommendation**: (a) CodeMirror 6. It's the most flexible, has excellent Yjs integration, and supports both code editing and markdown. TipTap is better for WYSIWYG rich text; CodeMirror is better for a code/note editor.
+
+3. **Should the command palette support commands beyond search?**
+   - Options: (a) Search only, (b) Search + actions (create file, delete, rename, change theme)
+   - **Recommendation**: Start with (a). Add actions later—the Command component supports grouping results, making it easy to add "Actions" sections.
+
+4. **Should drag-and-drop use native HTML5 or a library?**
+   - Native DnD is painful for tree reordering. Libraries like `@formkit/drag-and-drop` or `dnd-kit` (React-first but adaptable) handle edge cases.
+   - **Recommendation**: Defer DnD to last. Evaluate library options when the time comes.
+
+## Success Criteria
+
+- [ ] Open file tabs render above the content area with close buttons
+- [ ] Switching tabs switches the active file instantly (no load delay for recently opened files)
+- [ ] Command palette opens with Ctrl+K and searches files by name
+- [ ] Arrow keys navigate the file tree (up/down/left/right)
+- [ ] File icons change based on extension (.md, .ts, .json, etc.)
+- [ ] All new UI uses shadcn-svelte primitives (Tabs, Command) from `@epicenter/ui`
+- [ ] `svelte-check` passes with no new errors
+
+## References
+
+- `apps/opensidian/src/lib/fs/fs-state.svelte.ts` — existing `openFileIds`, `activeFileId`, `selectFile`, `closeFile`
+- `apps/opensidian/src/lib/components/ContentPanel.svelte` — content area where tabs would go
+- `apps/opensidian/src/lib/components/ContentEditor.svelte` — textarea to replace with rich editor
+- `apps/opensidian/src/lib/components/AppShell.svelte` — top-level layout for command palette
+- `packages/ui/src/tabs/` — Tabs component
+- `packages/ui/src/command/` — Command palette component
+- `packages/filesystem/src/content/content.ts` — content read/write for editor binding

--- a/specs/20260314T091500-remove-fs-content-namespace.md
+++ b/specs/20260314T091500-remove-fs-content-namespace.md
@@ -1,0 +1,57 @@
+# Remove `fs.content` Namespace
+
+**Date:** 2026-03-14
+**Status:** Planned
+**Scope:** `packages/filesystem/src/file-system.ts`, `apps/opensidian/`
+
+## Problem
+
+`fs.content` is an inline object on the filesystem with 4 methods:
+
+- `open(id)` — pure passthrough to `contentDocuments.open()`
+- `read(id)` — two-liner: open + `handle.read()`
+- `write(id, data)` — has real sheet-mode CSV reparsing logic
+- `append(id, data)` — has real text-mode Y.Text.insert logic
+
+2 of 4 methods are pure passthrough. The namespace isn't required by `IFileSystem` (just-bash). Consumers already have access to `Documents<FileRow>` through the workspace client (`ws.documents.files.content`). The filesystem shouldn't own a partial proxy of the documents API.
+
+## Solution
+
+Remove `fs.content`. Inline its non-trivial logic into the filesystem's own methods. Consumers access documents directly from the workspace.
+
+## Waves
+
+### Wave 1: Filesystem — inline content helpers, remove namespace
+
+**Files:** `packages/filesystem/src/file-system.ts`
+
+- [ ] **1.1** Inline `content.write` sheet-mode CSV logic directly into `writeFile`
+  - Currently `writeFile` calls `this.content.write(id, textData)` on line 288
+  - Move the sheet-mode check + CSV reparse + `handle.write()` logic inline
+  - Return byte size from the inlined logic (same as `content.write` did)
+- [ ] **1.2** Inline `content.append` text-mode logic directly into `appendFile`
+  - Currently `appendFile` calls `this.content.append(id, text)` on line 302
+  - Move the text-mode check + Y.Text.insert logic inline
+  - Return byte size or null (same as `content.append` did)
+- [ ] **1.3** Remove the `content` inline object (lines 71–145)
+- [ ] **1.4** Update JSDoc on `createYjsFileSystem` — remove mention of `content` from extra members list (line 30)
+- [ ] **1.5** Verify: `bun test` in `packages/filesystem` passes (tests don't use `fs.content.*`)
+
+### Wave 2: Consumers — switch to workspace documents
+
+**Files:** `apps/opensidian/src/lib/fs/fs-state.svelte.ts`, `apps/opensidian/src/lib/components/ContentEditor.svelte`
+
+- [ ] **2.1** In `fs-state.svelte.ts`: store `ws.documents.files.content` as a `documents` const alongside `fs`
+- [ ] **2.2** Expose `documents` on the state object (so components can access it)
+- [ ] **2.3** Update `readContent`: `fs.content.read(id)` → `documents.open(id).then(h => h.read())`
+  - Or: `const handle = await documents.open(id); return handle.read();`
+- [ ] **2.4** Update `writeContent`: `fs.content.write(id, data)` → `const handle = await documents.open(id); handle.write(data);`
+  - Note: this loses the sheet-mode CSV reparsing that `fs.content.write` did. But `writeContent` is only used by the textarea editor which is always text mode. The sheet path was dead code for this call site.
+- [ ] **2.5** Update `ContentEditor.svelte`: `fsState.fs.content.open(id)` → `fsState.documents.open(id)`
+- [ ] **2.6** Verify: opensidian builds cleanly (`bun run --filter opensidian build` or typecheck)
+
+## Risk Assessment
+
+- **Tests:** filesystem tests don't use `fs.content.*` — they go through `fs.readFile`/`fs.writeFile` or `ws.documents.files.content` directly. No test changes needed.
+- **Sheet-mode write in consumers:** `writeContent` in fs-state.svelte.ts loses the CSV reparsing path, but that path was unreachable — the textarea editor only writes text-mode content. Sheet writes go through `fs.writeFile` which will have the logic inlined.
+- **Type export:** `YjsFileSystem` is `ReturnType<typeof createYjsFileSystem>` — removing `content` narrows this type automatically. Any external consumers referencing `fs.content` would get a compile error, which is the desired behavior.


### PR DESCRIPTION
Adds the core editing, navigation, and search infrastructure to make OpenSidian a functional local-first note editor. Previously it was a file tree with a textarea — now it's a Yjs-backed editor with tabs, keyboard navigation, a command palette, and a full SQLite read index with FTS5 search.

The deeper motivation: OpenSidian's filesystem is a Yjs CRDT, which is great for real-time collaboration and offline-first sync, but terrible for queries. You can't do "find all markdown files updated this week" against a Y.Map. This PR bridges that gap by mirroring the CRDT into an in-memory SQLite database that rebuilds on every mutation, giving users arbitrary SQL access to their workspace.

### Editor

- Replace the bare `<textarea>` with CodeMirror 6 bound to Yjs via `y-codemirror.next`, giving real-time collaborative editing with proper syntax highlighting
- Add open file tabs with active/hover state differentiation and a contained strip feel
- Add a command palette (`Cmd+K`) for fuzzy file search and quick open

```svelte
<CodeMirrorEditor ydoc={handle.ydoc} />
```

### Navigation

- Keyboard navigation in the file tree (arrow keys, Enter to open)
- File type icons (folder, markdown, code, image, etc.)
- Tree view UX fixes: consistent gaps, full-width nested items

### Content Architecture

- Remove the `fs.content` namespace that wrapped document operations — was adding indirection without value
- Components now use `ws.documents.files.content` directly, matching the workspace API

### SQLite Index Extension

This is the main architectural addition. A workspace extension that mirrors the Yjs files table into an in-memory SQLite database for read-optimized queries and full-text search.

```typescript
const ws = createWorkspace({ id: 'opensidian', tables: { files: filesTable } })
  .withExtension('persistence', indexeddbPersistence)
  .withWorkspaceExtension('sqliteIndex', createSqliteIndex());

// Typed queries via Drizzle
await ws.extensions.sqliteIndex.db.select().from(schema.files).all();

// Arbitrary SQL via raw libSQL client
await ws.extensions.sqliteIndex.client.execute("SELECT * FROM files WHERE type = 'file'");

// Full-text search with highlighted snippets
await ws.extensions.sqliteIndex.search('meeting notes');
```

```
┌──────────────────────────────────────────────────────────┐
│  Yjs Y.Doc (source of truth)                             │
│  tables.files ──observe()──→ debounce 100ms ──→ rebuild  │
└───────────────────────────────┬──────────────────────────┘
                                │
                                ▼
┌──────────────────────────────────────────────────────────┐
│  libSQL WASM (in-memory SQLite)                          │
│                                                          │
│  files table ── Drizzle schema (single source of truth)  │
│    + materialized path column (parentId chain walk)      │
│    + content column (from per-file Y.Doc)                │
│                                                          │
│  files_fts ── FTS5 virtual table                         │
│    search() with snippet() highlighting                  │
│                                                          │
│  Exposed as:                                             │
│    .db     → Drizzle typed queries                       │
│    .client → raw libSQL for arbitrary SQL                │
│    .search → FTS5 convenience method                     │
└──────────────────────────────────────────────────────────┘
```

### Why libSQL over sql.js?

We started with sql.js but switched to `@libsql/client-wasm` because:

- **Zero WASM config** — sql.js needs `locateFile` or a CDN for its WASM file; libSQL bundles its own
- **Turso upgrade path** — change `url: ':memory:'` to `url: 'libsql://your-db.turso.io'` and add `authToken`. Same client, same Drizzle adapter
- **Drizzle adapter** — `drizzle-orm/libsql` works directly, no separate types package

### Why getTableConfig() for DDL?

Drizzle can't generate `CREATE TABLE` SQL at runtime (that logic lives in drizzle-kit). But `getTableConfig()` from `drizzle-orm/sqlite-core` exposes all column metadata — names, SQL types, constraints, indexes. We wrote a small `generateDDL()` utility that introspects the Drizzle schema and produces the DDL, so the schema is defined once and the raw SQL is derived from it. No duplication.

### Why workspace extension, not document extension?

Content document changes (user edits a file) trigger `onUpdate` on the `filesTable.withDocument('content', { onUpdate: () => ({ updatedAt: Date.now() }) })` config. This bumps `updatedAt` on the workspace Y.Doc, which fires `tables.files.observe()`. So a workspace-level observer already sees content changes — no document extension needed.

### Future work

- Search UI component wired to `sqliteIndex.search()`
- Status bar showing index size ("1,234 files indexed")
- Turso remote sync (change one URL)
- OPFS persistence to skip rebuild on reload (via `@tursodatabase/database-wasm` when it gets a Drizzle adapter)

## Changelog

- Add CodeMirror 6 editor with real-time Yjs collaboration
- Add open file tabs, command palette, and keyboard tree navigation
- Add SQLite index extension with full-text search across file names and content
- Add arbitrary SQL query access to workspace data via libSQL WASM