### PR TITLE
Initialize CLA signatures file

### DIFF
--- a/.github/workflows/ci.cla.yml
+++ b/.github/workflows/ci.cla.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: CLA Assistant
-        uses: contributor-assistant/github-action@v2
+        uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_ACTIONS_PAT }}

--- a/signatures/cla.json
+++ b/signatures/cla.json
@@ -1,0 +1,3 @@
+{
+	"signedContributors": []
+}


### PR DESCRIPTION
Hey everyone!

We added a Contributor License Agreement to Epicenter.

Epicenter recently shifted from MIT to AGPL-3.0. The goal is to keep the project open while leaving room for a dual license approach in the future so we can seek financial sustainability to support our open source work. [FINANCIAL_SUSTAINABILITY.md](https://github.com/EpicenterHQ/epicenter/blob/main/FINANCIAL_SUSTAINABILITY.md) has the longer version of my thoughts on this.

As part of that, we're adding a CLA. It's an Apache ICLA-style license grant, not a copyright assignment: you keep copyright to your contributions. Full text: [CLA.md](https://github.com/EpicenterHQ/epicenter/blob/main/CLA.md)

To sign, comment on this PR with:

> I have read the CLA Document and I hereby sign the CLA

The bot records it automatically. Signing covers your existing and future contributions.

Questions or concerns? Drop them here.

cc @colecrouter @Leftium @Github11200 @vishesh-sachan @thisisharsh7 @rupokghosh @thurstonsand @onel @wchest @brummelte @borghiste @heliole @nocdn @tatn @aspiers