### PR TITLE
feat(whispering): add dev-only debug page for workspace metrics and stress testing

### DIFF
--- a/apps/whispering/specs/20260316T235800-debug-storage-monitor.md
+++ b/apps/whispering/specs/20260316T235800-debug-storage-monitor.md
@@ -1,0 +1,241 @@
+# Debug Storage & Stress Test Page
+
+**Date**: 2026-03-16
+**Status**: Implemented
+**Author**: AI-assisted
+
+## Overview
+
+A dev-only debug page in Whispering that lets developers bulk-generate recordings, monitor Yjs document size, track browser/Tauri storage usage, and stress-test the workspace at scale—all from within the app itself.
+
+## Motivation
+
+### Current State
+
+Performance benchmarks exist in `packages/workspace/src/workspace/benchmark.test.ts` (1,294 lines). They run in Bun's test runner and measure Yjs doc sizes, tombstone behavior, and operation throughput. The migration dialog has basic dev tools (seed/clear/reset) behind `import.meta.env.DEV`.
+
+This creates problems:
+
+1. **No in-app visibility**: The benchmarks run in a terminal. There's no way to see Yjs doc size, IndexedDB usage, or per-table row counts from inside the running app. Developers have to guess whether the app is approaching storage limits.
+2. **No scalable stress testing**: The migration dialog seeds a fixed number of recordings (`MOCK_RECORDING_COUNT`). There's no way to generate 1,000 or 10,000 recordings on demand to test how the UI, queries, and storage behave at scale.
+3. **No storage monitoring**: No dashboard shows browser storage quota vs usage, whether persistent storage is granted, or how much space the Yjs doc vs audio blobs consume.
+
+### Desired State
+
+A hidden debug page (dev-only) where developers can:
+- See live storage metrics at a glance
+- Generate N recordings with configurable parameters
+- Watch Yjs doc size grow in real time during stress tests
+- Understand storage costs and identify the breaking point for their device
+
+## Research Findings
+
+### Tombstone Behavior (from benchmarks + librarian research)
+
+| Scenario | Y.Doc Size After | Notes |
+|----------|-----------------|-------|
+| 1,000 rows inserted | 77 KB | ~79 bytes/row |
+| Delete all 1,000 rows | 35 bytes | Tombstones fully compacted |
+| 5 add/delete cycles × 1,000 rows | 34 bytes per cycle | No accumulation |
+| Delete 2 of 5 heavy rows (50K chars), add 2 new | +42 bytes (0.02%) | Minimal residue |
+| 300 autosaves to 1 doc over 10 min | +37 bytes growth | YKV pattern is optimal |
+
+**Key finding**: YKV (Y.Array + LWW) with `gc: true` (default) compacts tombstones to ~2 bytes each. Creating and deleting 1M recordings over time produces ~2MB tombstone overhead. This is a non-issue.
+
+**Implication**: No special tombstone mitigation is needed. The existing architecture handles this well. The debug page should _confirm_ this rather than _solve_ it.
+
+### Browser/Tauri Storage Limits
+
+| Platform | Engine | Storage Limit | Notes |
+|----------|--------|--------------|-------|
+| Tauri Windows | WebView2 (Chromium) | 60% of disk | Most generous |
+| Tauri macOS | WebKit (embedded) | ~15% of disk | Most restrictive |
+| Tauri Linux | WebKit (embedded) | ~15% of disk | Same as macOS |
+| Chrome browser | Chromium | 60% of disk | Web version |
+| Safari browser | WebKit | ~60% of disk | Browser app gets more |
+| Safari iOS | WebKit | ~15% embedded, ~60% PWA | Depends on context |
+
+**Key finding**: `navigator.storage.estimate()` returns approximate `{ usage, quota }`. Not exact (padded to prevent fingerprinting), but good enough for a monitoring dashboard. `navigator.storage.persist()` prevents eviction.
+
+**Implication**: On a 512GB Mac with Tauri, the limit is ~77GB—far more than recordings metadata will ever need. The real storage concern is audio blobs (`serializedAudio: ArrayBuffer`), not workspace data.
+
+### IndexedDB Performance Thresholds
+
+| Record Count | Read Performance | Write Performance | Recommendation |
+|-------------|-----------------|-------------------|----------------|
+| <10K | Fast | Fast | No concerns |
+| 10K–50K | Noticeable slowdown | Batch recommended | Sweet spot ceiling |
+| 50K–100K | Significant | Need relaxed durability | Consider archiving |
+| 100K+ | Problematic | Problematic | Need pagination/sharding |
+
+**Key finding**: Chrome is ~5x slower than Safari/Firefox for large IndexedDB reads. Batching with `getAll()` improves performance 2–3x vs cursor iteration.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Page vs dialog | Dev-only route page | More space for metrics, tables, and controls than a dialog. Follows settings page pattern. |
+| Location | `(app)/(config)/debug/+page.svelte` | Fits naturally in the existing (config) layout. Could add as settings sub-page later. |
+| Dev guard | `import.meta.env.DEV` | Matches existing pattern (migration dialog, TanStack devtools). Zero production overhead. |
+| Navigation | Link in NavItems.svelte | Same approach as migration dialog. Only visible in dev. |
+| Stress test data shape | Match `recordings` table schema from `workspace.ts` | Must generate valid rows that the workspace API accepts: `{ id, title, subtitle, timestamp, createdAt, updatedAt, transcribedText, transcriptionStatus, _v: 1 }`. |
+| Audio blobs in stress test | Optional/configurable | Audio blobs dominate storage but stress-testing the workspace layer doesn't require them. Offer a toggle. |
+| Storage API usage | `navigator.storage.estimate()` | Standardized, works in all target browsers, available in Tauri WebView. |
+| Yjs size measurement | `Y.encodeStateAsUpdate(ydoc).byteLength` | Standard approach per Yjs docs. Already used in existing benchmarks. |
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│  Debug Page                                      │
+│                                                  │
+│  ┌─────────────────────────────────────────┐    │
+│  │  Storage Dashboard                       │    │
+│  │  ├── Browser quota / usage / percentage  │    │
+│  │  ├── Persistent storage status           │    │
+│  │  ├── Y.Doc encoded size (all tables)     │    │
+│  │  └── Per-table row counts                │    │
+│  └─────────────────────────────────────────┘    │
+│                                                  │
+│  ┌─────────────────────────────────────────┐    │
+│  │  Stress Test Panel                       │    │
+│  │  ├── Count selector (100/500/1K/5K/10K)  │    │
+│  │  ├── Content length (short/medium/long)  │    │
+│  │  ├── Include audio blobs toggle          │    │
+│  │  ├── [Generate] [Delete All] buttons     │    │
+│  │  └── Results: timing, size delta, count  │    │
+│  └─────────────────────────────────────────┘    │
+│                                                  │
+│  ┌─────────────────────────────────────────┐    │
+│  │  Tombstone Monitor                       │    │
+│  │  ├── Current Y.Doc size                  │    │
+│  │  ├── Estimated compacted size            │    │
+│  │  ├── Tombstone overhead %                │    │
+│  │  └── [Run add/delete cycle] test         │    │
+│  └─────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────┘
+```
+
+Data flows:
+```
+Debug Page
+    │
+    ├──▶ workspace.tables.recordings.set()     (bulk generate)
+    ├──▶ workspace.tables.recordings.delete()  (bulk delete)
+    ├──▶ workspace.tables.recordings.count()   (row counts)
+    ├──▶ workspace.tables.recordings.getAll()  (enumerate)
+    │
+    ├──▶ Y.encodeStateAsUpdate(ydoc)           (doc size)
+    ├──▶ navigator.storage.estimate()          (browser storage)
+    └──▶ navigator.storage.persist()           (request persistence)
+```
+
+## Implementation Plan
+
+### Phase 1: Storage Dashboard
+
+- [x] **1.1** Create route at `src/routes/(app)/(config)/debug/+page.svelte`
+- [x] **1.2** Add dev-only nav link in `NavItems.svelte` (Bug icon, both collapsed and expanded variants)
+- [x] **1.3** ~~Implement `getStorageReport()` utility~~ Skipped — unnecessary abstraction, inlined directly
+- [ ] **1.4** ~~Display browser storage: used / quota / percentage with progress bar~~ Deferred — nice-to-have, not essential
+- [x] **1.5** Display Yjs doc size: `Y.encodeStateAsUpdate(workspace.ydoc).byteLength`
+- [x] **1.6** Display per-table row counts for all 5 tables
+- [ ] **1.7** ~~Add "Request Persistent Storage" button~~ Skipped — Tauri apps don't face eviction
+
+### Phase 2: Stress Test Panel
+
+- [x] **2.1** Create mock recording generator inline in the page component
+- [x] **2.2** Add count selector (100, 500, 1000, 5000, 10000) and content length selector (short/medium/long)
+- [x] **2.3** Add "Generate" button with `ydoc.transact()` batch + `performance.now()` timing
+- [x] **2.4** Add "Delete All Recordings" button with browser `confirm()` dialog
+- [x] **2.5** Display results: duration, throughput (rows/s), size before/after/delta
+- [x] **2.6** Auto-refresh metrics after generate/delete operations
+
+### Phase 3: Tombstone Monitor
+
+- [ ] **3.1** ~~Show current vs compacted Y.Doc size~~ Deferred — benchmarks prove tombstones are a non-issue
+- [ ] **3.2** ~~Show tombstone overhead percentage~~ Deferred
+- [ ] **3.3** ~~Run Tombstone Test button~~ Deferred
+
+## Edge Cases
+
+### Tauri vs Browser storage API availability
+
+1. `navigator.storage` might behave differently in Tauri's WebView
+2. Should gracefully degrade if API is unavailable
+3. Show "Not available" instead of crashing
+
+### Very large stress tests (10K+)
+
+1. UI might freeze during bulk insert
+2. Consider using `requestAnimationFrame` or chunked inserts to keep UI responsive
+3. Show a progress indicator for large batches
+
+### Audio blob toggle
+
+1. When "include audio blobs" is on, generating 1,000 recordings with 500KB audio each = 500MB
+2. This could actually fill storage on constrained devices
+3. Should show an estimate before generating and require explicit confirmation
+
+## Open Questions
+
+1. **Should this page also be accessible in production behind a hidden gesture?**
+   - Some developers may want to debug storage on real user devices
+   - Options: (a) dev-only, (b) dev + hidden URL param, (c) dev + settings toggle
+   - **Recommendation**: Start dev-only. Add a hidden URL param (`?debug=1`) later if needed.
+
+2. **Should stress tests generate audio blobs or just metadata?**
+   - Audio blobs dominate storage but are separate from the workspace Y.Doc
+   - Options: (a) metadata only, (b) audio only, (c) both with toggle
+   - **Recommendation**: Default to metadata only (tests workspace layer). Add audio toggle for storage limit testing.
+
+3. **Should the storage dashboard auto-refresh or manual refresh?**
+   - Auto-refresh adds polling overhead; manual refresh is simpler
+   - **Recommendation**: Manual refresh button. Auto-refresh after stress test operations only.
+
+4. **How should per-table size breakdown work?**
+   - Yjs encodes the entire doc as one binary. Per-table size requires encoding separate sub-docs or estimating proportionally.
+   - **Recommendation**: Show per-table row counts (cheap). Show total doc size (cheap). Skip per-table byte breakdown for now—it requires sub-doc encoding which adds complexity.
+
+## Success Criteria
+
+- [ ] Debug page renders at `/debug` in dev mode only
+- [ ] Storage dashboard shows browser quota, usage, percentage, and Y.Doc size
+- [ ] Can generate 1,000 recordings and see doc size update
+- [ ] Can delete all recordings and confirm doc size returns to baseline
+- [ ] Tombstone monitor shows overhead percentage after add/delete cycles
+- [ ] Page uses existing `@epicenter/ui` Field/Button patterns and matches app style
+- [ ] No production code is affected (all behind `import.meta.env.DEV`)
+
+## References
+
+- `apps/whispering/src/lib/workspace.ts` — Recording table schema, workspace definition
+- `apps/whispering/src/lib/migration/MigrationDialog.svelte` — Dev tools pattern (`import.meta.env.DEV`)
+- `apps/whispering/src/lib/migration/migration-dialog.svelte.ts` — Svelte reactive state pattern for dialog
+- `apps/whispering/src/lib/components/NavItems.svelte` — Navigation with dev-mode conditional
+- `apps/whispering/src/routes/(app)/(config)/settings/+layout.svelte` — Settings layout pattern
+- `packages/workspace/src/workspace/benchmark.test.ts` — Existing benchmarks (reference for data generation)
+- `packages/workspace/src/workspace/create-tables.ts` — Table API (set, delete, count, getAll)
+
+## Review
+
+**Completed**: 2026-03-17
+**Branch**: current working branch
+
+### Summary
+
+Built the essential subset of the spec: Y.Doc size display, per-table row counts for all 5 workspace tables, and a stress test panel with configurable count/content-length, bulk generate via `ydoc.transact()`, delete all with confirmation, and detailed timing results (duration, throughput, size before/after/delta). Added dev-only nav link (Bug icon) in both collapsed dropdown and expanded nav bar variants.
+
+### Deviations from Spec
+
+- **Skipped browser storage quota/usage** (1.4): The real constraint is Y.Doc size, not browser quota (~77GB on a 512GB Mac). Added as nice-to-have for later.
+- **Skipped "Request Persistent Storage"** (1.7): Tauri apps don't face browser eviction. This solves a non-problem.
+- **Skipped `getStorageReport()` utility** (1.3): Overengineered abstraction. The single `Y.encodeStateAsUpdate()` call is inlined directly.
+- **Deferred Phase 3 (Tombstone Monitor)**: The spec's own research proves tombstones are a non-issue (2 bytes each with `gc: true`). The monitor would confirm a non-problem.
+- **No separate utility file**: Everything is self-contained in the page component. Simple, no abstractions to maintain.
+
+### Follow-up Work
+
+- Add browser storage estimate display if storage debugging becomes needed
+- Add audio blob generation toggle for storage limit testing
+- Consider chunked inserts with progress indicator for 10K+ tests if UI freezing is observed

--- a/apps/whispering/src/lib/components/NavItems.svelte
+++ b/apps/whispering/src/lib/components/NavItems.svelte
@@ -2,7 +2,6 @@
 	import { Button } from '@epicenter/ui/button';
 	import * as DropdownMenu from '@epicenter/ui/dropdown-menu';
 	import { cn } from '@epicenter/ui/utils';
-	import BugIcon from '@lucide/svelte/icons/bug';
 	import Database from '@lucide/svelte/icons/database';
 	import LayersIcon from '@lucide/svelte/icons/layers';
 	import ListIcon from '@lucide/svelte/icons/list';
@@ -185,16 +184,6 @@
 					{/snippet}
 				</MigrationDialog>
 			{/if}
-			{#if import.meta.env.DEV}
-				<DropdownMenu.Item>
-					{#snippet child({ props })}
-						<a href="/debug" class="flex items-center gap-2" {...props}>
-							<BugIcon class="size-4" aria-hidden="true" />
-							<span>Debug Storage</span>
-						</a>
-					{/snippet}
-				</DropdownMenu.Item>
-			{/if}
 		</DropdownMenu.Content>
 	</DropdownMenu.Root>
 {:else}
@@ -259,11 +248,6 @@
 					</Button>
 				{/snippet}
 			</MigrationDialog>
-		{/if}
-		{#if import.meta.env.DEV}
-			<Button tooltip="Debug Storage" href="/debug" variant="ghost" size="icon">
-				<BugIcon class="size-4" aria-hidden="true" />
-			</Button>
 		{/if}
 	</nav>
 {/if}

--- a/apps/whispering/src/lib/components/NavItems.svelte
+++ b/apps/whispering/src/lib/components/NavItems.svelte
@@ -2,6 +2,7 @@
 	import { Button } from '@epicenter/ui/button';
 	import * as DropdownMenu from '@epicenter/ui/dropdown-menu';
 	import { cn } from '@epicenter/ui/utils';
+	import BugIcon from '@lucide/svelte/icons/bug';
 	import Database from '@lucide/svelte/icons/database';
 	import LayersIcon from '@lucide/svelte/icons/layers';
 	import ListIcon from '@lucide/svelte/icons/list';
@@ -184,6 +185,16 @@
 					{/snippet}
 				</MigrationDialog>
 			{/if}
+			{#if import.meta.env.DEV}
+				<DropdownMenu.Item>
+					{#snippet child({ props })}
+						<a href="/debug" class="flex items-center gap-2" {...props}>
+							<BugIcon class="size-4" aria-hidden="true" />
+							<span>Debug Storage</span>
+						</a>
+					{/snippet}
+				</DropdownMenu.Item>
+			{/if}
 		</DropdownMenu.Content>
 	</DropdownMenu.Root>
 {:else}
@@ -248,6 +259,11 @@
 					</Button>
 				{/snippet}
 			</MigrationDialog>
+		{/if}
+		{#if import.meta.env.DEV}
+			<Button tooltip="Debug Storage" href="/debug" variant="ghost" size="icon">
+				<BugIcon class="size-4" aria-hidden="true" />
+			</Button>
 		{/if}
 	</nav>
 {/if}

--- a/apps/whispering/src/routes/(app)/(config)/debug/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/debug/+page.svelte
@@ -1,0 +1,359 @@
+<script lang="ts">
+	import { Button } from '@epicenter/ui/button';
+	import * as Card from '@epicenter/ui/card';
+	import * as SectionHeader from '@epicenter/ui/section-header';
+	import * as Select from '@epicenter/ui/select';
+	import DatabaseIcon from '@lucide/svelte/icons/database';
+	import FlaskConicalIcon from '@lucide/svelte/icons/flask-conical';
+	import RefreshCwIcon from '@lucide/svelte/icons/refresh-cw';
+	import TrashIcon from '@lucide/svelte/icons/trash';
+	import * as Y from 'yjs';
+	import workspace from '$lib/workspace';
+
+	// ── Metrics ────────────────────────────────────────────────────────────────
+
+	function createMetrics() {
+		const tableDefs = [
+			{ label: 'Recordings', count: () => workspace.tables.recordings.count() },
+			{
+				label: 'Transformations',
+				count: () => workspace.tables.transformations.count(),
+			},
+			{
+				label: 'Transformation Steps',
+				count: () => workspace.tables.transformationSteps.count(),
+			},
+			{
+				label: 'Transformation Runs',
+				count: () => workspace.tables.transformationRuns.count(),
+			},
+			{
+				label: 'Transformation Step Runs',
+				count: () => workspace.tables.transformationStepRuns.count(),
+			},
+		] as const;
+
+		function snapshot() {
+			return {
+				ydocSize: Y.encodeStateAsUpdate(workspace.ydoc).byteLength,
+				tables: tableDefs.map((t) => ({ label: t.label, count: t.count() })),
+			};
+		}
+
+		let current = $state(snapshot());
+
+		return {
+			get current() {
+				return current;
+			},
+			refresh() {
+				current = snapshot();
+			},
+		};
+	}
+
+	// ── Stress test ────────────────────────────────────────────────────────────
+
+	type StressTestResult = {
+		label: string;
+		durationMs: number;
+		rowCount: number;
+		rowsPerSecond: number;
+		sizeBefore: number;
+		sizeAfter: number;
+		sizeDelta: number;
+	};
+
+	function createStressTest(onComplete: () => void) {
+		const LOREM =
+			'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
+
+		const loremByLength = {
+			short: LOREM.slice(0, 50),
+			medium: LOREM,
+			long: Array(10).fill(LOREM).join(' '),
+		} satisfies Record<string, string>;
+
+		let selectedCount = $state('100');
+		let selectedContentLength = $state<keyof typeof loremByLength>('short');
+		let lastResult = $state<StressTestResult | null>(null);
+
+		function measure(label: string, count: number, operation: () => void) {
+			const sizeBefore = Y.encodeStateAsUpdate(workspace.ydoc).byteLength;
+			const start = performance.now();
+			operation();
+			const durationMs = performance.now() - start;
+			const sizeAfter = Y.encodeStateAsUpdate(workspace.ydoc).byteLength;
+			lastResult = {
+				label,
+				durationMs,
+				rowCount: count,
+				rowsPerSecond: count > 0 ? Math.round((count / durationMs) * 1000) : 0,
+				sizeBefore,
+				sizeAfter,
+				sizeDelta: sizeAfter - sizeBefore,
+			};
+			onComplete();
+		}
+
+		return {
+			get selectedCount() {
+				return selectedCount;
+			},
+			set selectedCount(v: string) {
+				selectedCount = v;
+			},
+			get selectedContentLength() {
+				return selectedContentLength;
+			},
+			set selectedContentLength(v: keyof typeof loremByLength) {
+				selectedContentLength = v;
+			},
+			get lastResult() {
+				return lastResult;
+			},
+			generate() {
+				const count = Number(selectedCount);
+				const content =
+					loremByLength[selectedContentLength] ?? loremByLength.short;
+				measure('Generated', count, () => {
+					workspace.ydoc.transact(() => {
+						for (let i = 0; i < count; i++) {
+							const now = new Date().toISOString();
+							workspace.tables.recordings.set({
+								id: crypto.randomUUID(),
+								title: `Test Recording #${i + 1}`,
+								subtitle: 'Generated for stress testing',
+								timestamp: now,
+								createdAt: now,
+								updatedAt: now,
+								transcribedText: content,
+								transcriptionStatus: 'DONE',
+								_v: 1,
+							});
+						}
+					});
+				});
+			},
+			deleteAll() {
+				if (!confirm('Delete ALL recordings? This cannot be undone.')) return;
+				const count = workspace.tables.recordings.count();
+				measure('Deleted', count, () => workspace.tables.recordings.clear());
+			},
+		};
+	}
+
+	// ── Constants ──────────────────────────────────────────────────────────────
+
+	const countOptions = [
+		{ value: '100', label: '100' },
+		{ value: '500', label: '500' },
+		{ value: '1000', label: '1,000' },
+		{ value: '5000', label: '5,000' },
+		{ value: '10000', label: '10,000' },
+	];
+
+	const contentLengthOptions = [
+		{ value: 'short', label: 'Short (~50 chars)' },
+		{ value: 'medium', label: 'Medium (~500 chars)' },
+		{ value: 'long', label: 'Long (~5,000 chars)' },
+	];
+
+	// ── Instance ──────────────────────────────────────────────────────────────
+
+	const metrics = createMetrics();
+	const stressTest = createStressTest(() => metrics.refresh());
+
+	const selectedCountLabel = $derived(
+		countOptions.find((o) => o.value === stressTest.selectedCount)?.label,
+	);
+
+	const selectedContentLengthLabel = $derived(
+		contentLengthOptions.find(
+			(o) => o.value === stressTest.selectedContentLength,
+		)?.label,
+	);
+
+	function formatBytes(bytes: number): string {
+		if (bytes < 1024) return `${bytes} B`;
+		if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+		return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+	}
+</script>
+
+{#if import.meta.env.DEV}
+	<div class="space-y-8">
+		<!-- Page Header -->
+		<SectionHeader.Root>
+			<div class="flex items-center gap-3">
+				<SectionHeader.Title level={3} class="text-xl tracking-tight">
+					Debug
+				</SectionHeader.Title>
+			</div>
+			<SectionHeader.Description class="max-w-2xl">
+				Workspace metrics and stress testing tools. Only visible in development.
+			</SectionHeader.Description>
+		</SectionHeader.Root>
+
+		<!-- Workspace Metrics -->
+		<Card.Root>
+			<Card.Header>
+				<div class="flex items-center justify-between">
+					<div class="flex items-center gap-2">
+						<DatabaseIcon class="h-4 w-4 text-muted-foreground" />
+						<Card.Title class="text-base font-medium"
+							>Workspace Metrics</Card.Title
+						>
+					</div>
+					<Button variant="outline" size="sm" onclick={() => metrics.refresh()}>
+						<RefreshCwIcon class="mr-1.5 h-3.5 w-3.5" />
+						Refresh
+					</Button>
+				</div>
+			</Card.Header>
+			<Card.Content>
+				<div class="space-y-4">
+					<!-- Y.Doc Size -->
+					<div class="flex items-center justify-between rounded-md border p-3">
+						<span class="text-sm text-muted-foreground"
+							>Y.Doc encoded size</span
+						>
+						<span class="font-mono text-sm font-medium">
+							{formatBytes(metrics.current.ydocSize)}
+							<span class="text-muted-foreground"
+								>({metrics.current.ydocSize.toLocaleString()}
+								bytes)</span
+							>
+						</span>
+					</div>
+
+					<!-- Table Row Counts -->
+					<div class="grid gap-2">
+						{#each metrics.current.tables as table}
+							<div
+								class="flex items-center justify-between rounded-md border px-3 py-2"
+							>
+								<span class="text-sm text-muted-foreground">{table.label}</span>
+								<span class="font-mono text-sm font-medium"
+									>{table.count.toLocaleString()}</span
+								>
+							</div>
+						{/each}
+					</div>
+				</div>
+			</Card.Content>
+		</Card.Root>
+
+		<!-- Stress Test -->
+		<Card.Root>
+			<Card.Header>
+				<div class="flex items-center gap-2">
+					<FlaskConicalIcon class="h-4 w-4 text-muted-foreground" />
+					<Card.Title class="text-base font-medium">Stress Test</Card.Title>
+				</div>
+				<Card.Description>
+					Generate mock recordings to benchmark Y.Doc performance.
+				</Card.Description>
+			</Card.Header>
+			<Card.Content class="space-y-4">
+				<!-- Controls -->
+				<div class="grid gap-4 sm:grid-cols-2">
+					<div class="space-y-1.5">
+						<label for="stress-count" class="text-sm font-medium leading-none">
+							Count
+						</label>
+						<Select.Root
+							type="single"
+							bind:value={() => stressTest.selectedCount,
+								(v) => (stressTest.selectedCount = v)}
+						>
+							<Select.Trigger id="stress-count" class="w-full">
+								{selectedCountLabel ?? 'Select count'}
+							</Select.Trigger>
+							<Select.Content>
+								{#each countOptions as option}
+									<Select.Item value={option.value} label={option.label} />
+								{/each}
+							</Select.Content>
+						</Select.Root>
+					</div>
+
+					<div class="space-y-1.5">
+						<label
+							for="stress-content-length"
+							class="text-sm font-medium leading-none"
+						>
+							Content Length
+						</label>
+						<Select.Root
+							type="single"
+							bind:value={() => stressTest.selectedContentLength,
+								(v) => (stressTest.selectedContentLength = v)}
+						>
+							<Select.Trigger id="stress-content-length" class="w-full">
+								{selectedContentLengthLabel ?? 'Select length'}
+							</Select.Trigger>
+							<Select.Content>
+								{#each contentLengthOptions as option}
+									<Select.Item value={option.value} label={option.label} />
+								{/each}
+							</Select.Content>
+						</Select.Root>
+					</div>
+				</div>
+
+				<!-- Actions -->
+				<div class="flex gap-2">
+					<Button onclick={() => stressTest.generate()}>
+						<FlaskConicalIcon class="mr-1.5 h-3.5 w-3.5" />
+						Generate
+					</Button>
+					<Button variant="destructive" onclick={() => stressTest.deleteAll()}>
+						<TrashIcon class="mr-1.5 h-3.5 w-3.5" />
+						Delete All Recordings
+					</Button>
+				</div>
+
+				<!-- Results -->
+				{#if stressTest.lastResult}
+					{@const result = stressTest.lastResult}
+					<div class="rounded-md border bg-muted/30 p-4 space-y-2">
+						<p class="text-sm font-medium">
+							{result.label}
+							{result.rowCount.toLocaleString()}
+							rows
+						</p>
+						<div class="grid gap-1.5 text-sm">
+							<div class="flex justify-between">
+								<span class="text-muted-foreground">Duration</span>
+								<span class="font-mono">{result.durationMs.toFixed(1)} ms</span>
+							</div>
+							<div class="flex justify-between">
+								<span class="text-muted-foreground">Throughput</span>
+								<span class="font-mono"
+									>{result.rowsPerSecond.toLocaleString()}
+									rows/s</span
+								>
+							</div>
+							<div class="flex justify-between">
+								<span class="text-muted-foreground">Size before</span>
+								<span class="font-mono">{formatBytes(result.sizeBefore)}</span>
+							</div>
+							<div class="flex justify-between">
+								<span class="text-muted-foreground">Size after</span>
+								<span class="font-mono">{formatBytes(result.sizeAfter)}</span>
+							</div>
+							<div class="flex justify-between">
+								<span class="text-muted-foreground">Size delta</span>
+								<span class="font-mono">
+									{result.sizeDelta >= 0 ? '+' : ''}
+									{formatBytes(Math.abs(result.sizeDelta))}
+								</span>
+							</div>
+						</div>
+					</div>
+				{/if}
+			</Card.Content>
+		</Card.Root>
+	</div>
+{/if}

--- a/apps/whispering/src/routes/(app)/(config)/debug/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/debug/+page.svelte
@@ -64,7 +64,7 @@
 		sizeDelta: number;
 	};
 
-	function createStressTest(onComplete: () => void) {
+	function createStressTest() {
 		const LOREM =
 			'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
 
@@ -93,7 +93,6 @@
 				sizeAfter,
 				sizeDelta: sizeAfter - sizeBefore,
 			};
-			onComplete();
 		}
 
 		return {
@@ -162,7 +161,7 @@
 	// ── Instance ──────────────────────────────────────────────────────────────
 
 	const metrics = createMetrics();
-	const stressTest = createStressTest(() => metrics.refresh());
+	const stressTest = createStressTest();
 
 	const selectedCountLabel = $derived(
 		countOptions.find((o) => o.value === stressTest.selectedCount)?.label,
@@ -304,11 +303,11 @@
 
 				<!-- Actions -->
 				<div class="flex gap-2">
-					<Button onclick={() => stressTest.generate()}>
+					<Button onclick={() => { stressTest.generate(); metrics.refresh(); }}>
 						<FlaskConicalIcon class="mr-1.5 h-3.5 w-3.5" />
 						Generate
 					</Button>
-					<Button variant="destructive" onclick={() => stressTest.deleteAll()}>
+					<Button variant="destructive" onclick={() => { stressTest.deleteAll(); metrics.refresh(); }}>
 						<TrashIcon class="mr-1.5 h-3.5 w-3.5" />
 						Delete All Recordings
 					</Button>


### PR DESCRIPTION
Adds a debug page at `/debug` (dev-only, `import.meta.env.DEV` guard) for monitoring workspace storage and stress-testing at scale.

The page started as a comprehensive spec with browser quota monitoring, tombstone analysis, and persistent storage requests—most of which turned out to be unnecessary. Browser quota is ~77GB on a 512GB Mac (non-issue), tombstones compact to ~2 bytes each with `gc: true` (confirmed by existing benchmarks), and Tauri apps don't face storage eviction. What remained were the two things you can't see today: how big is the Y.Doc, and what happens when you throw thousands of rows at it.

The implementation uses two independent factory functions (`createMetrics`, `createStressTest`) that co-locate reactive `$state` with their operations. The component orchestrates them: `{ stressTest.generate(); metrics.refresh(); }`. No callbacks or coupling between factories.

```svelte
<!-- Template reads naturally -->
{formatBytes(metrics.current.ydocSize)}
{metrics.current.tables[0].count}

<Button onclick={() => { stressTest.generate(); metrics.refresh(); }}>
<Button onclick={() => { stressTest.deleteAll(); metrics.refresh(); }}>
```

What it shows:
- Y.Doc encoded size (human-readable + raw bytes)
- Per-table row counts for all 5 workspace tables
- Stress test panel: count selector (100–10K), content length selector (short/medium/long), Generate and Delete All with timing results (duration, throughput, size before/after/delta)

## Changelog
- Add dev-only debug page at `/debug` for workspace metrics and stress testing