### PR TITLE
fix(sound): use Web Audio API to fix PipeWire node accumulation and volume resets

### DIFF
--- a/apps/whispering/src/lib/services/sound/assets/index.ts
+++ b/apps/whispering/src/lib/services/sound/assets/index.ts
@@ -10,13 +10,63 @@ import cancelSoundSrc from './zapsplat_multimedia_click_button_short_sharp_73510
 import transformationCompleteSoundSrc from './zapsplat_multimedia_notification_alert_ping_bright_chime_001_93276.mp3';
 import transcriptionCompleteSoundSrc from './zapsplat_multimedia_ui_notification_classic_bell_synth_success_107505.mp3';
 
-export const audioElements = {
-	'manual-start': new Audio(startManualSoundSrc),
-	'manual-cancel': new Audio(cancelSoundSrc),
-	'manual-stop': new Audio(stopManualSoundSrc),
-	'vad-start': new Audio(startVadSoundSrc),
-	'vad-capture': new Audio(captureVadSoundSrc),
-	'vad-stop': new Audio(stopVadSoundSrc),
-	transcriptionComplete: new Audio(transcriptionCompleteSoundSrc),
-	transformationComplete: new Audio(transformationCompleteSoundSrc),
-} satisfies Record<WhisperingSoundNames, HTMLAudioElement>;
+const soundSources = {
+	'manual-start': startManualSoundSrc,
+	'manual-cancel': cancelSoundSrc,
+	'manual-stop': stopManualSoundSrc,
+	'vad-start': startVadSoundSrc,
+	'vad-capture': captureVadSoundSrc,
+	'vad-stop': stopVadSoundSrc,
+	transcriptionComplete: transcriptionCompleteSoundSrc,
+	transformationComplete: transformationCompleteSoundSrc,
+} satisfies Record<WhisperingSoundNames, string>;
+
+/**
+ * A single AudioContext is created on first use and kept alive for the app's
+ * lifetime. This registers exactly one PipeWire node that persists across all
+ * sound playback, allowing WirePlumber to reliably track and persist volume
+ * adjustments. HTMLAudioElement creates a new PipeWire node per element, and
+ * WebKit tears down/recreates the node on any src change, so WirePlumber
+ * restores 1.0 (full volume) every time before user adjustments can be saved.
+ */
+let audioContext: AudioContext | null = null;
+const bufferCache = new Map<WhisperingSoundNames, AudioBuffer>();
+
+function getAudioContext(): AudioContext {
+	if (audioContext === null) audioContext = new AudioContext();
+	return audioContext;
+}
+
+async function getBuffer(
+	soundName: WhisperingSoundNames,
+): Promise<AudioBuffer> {
+	const cached = bufferCache.get(soundName);
+	if (cached !== undefined) return cached;
+
+	const ctx = getAudioContext();
+	const response = await fetch(soundSources[soundName]);
+	const arrayBuffer = await response.arrayBuffer();
+	const buffer = await ctx.decodeAudioData(arrayBuffer);
+	bufferCache.set(soundName, buffer);
+	return buffer;
+}
+
+/**
+ * Play a sound effect through the shared AudioContext.
+ *
+ * Each call creates a lightweight BufferSourceNode (no PipeWire overhead)
+ * connected to the context's destination. The source is automatically
+ * cleaned up by the browser after playback ends.
+ */
+export async function playSound(
+	soundName: WhisperingSoundNames,
+): Promise<void> {
+	const ctx = getAudioContext();
+	if (ctx.state === 'suspended') await ctx.resume();
+
+	const buffer = await getBuffer(soundName);
+	const source = ctx.createBufferSource();
+	source.buffer = buffer;
+	source.connect(ctx.destination);
+	source.start();
+}

--- a/apps/whispering/src/lib/services/sound/desktop.ts
+++ b/apps/whispering/src/lib/services/sound/desktop.ts
@@ -1,15 +1,13 @@
 import { tryAsync } from 'wellcrafted/result';
 import type { PlaySoundService } from '.';
-import { audioElements } from './assets';
+import { playSound } from './assets';
 import { SoundError } from './types';
 
 export function createPlaySoundServiceDesktop(): PlaySoundService {
 	return {
 		playSound: async (soundName) =>
 			tryAsync({
-				try: async () => {
-					await audioElements[soundName].play();
-				},
+				try: () => playSound(soundName),
 				catch: (error) => SoundError.Play({ cause: error }),
 			}),
 	};

--- a/apps/whispering/src/lib/services/sound/web.ts
+++ b/apps/whispering/src/lib/services/sound/web.ts
@@ -1,13 +1,13 @@
 import { Ok } from 'wellcrafted/result';
 // import { extension } from '@epicenter/extension';
 import type { PlaySoundService } from '.';
-import { audioElements } from './assets';
+import { playSound } from './assets';
 
 export function createPlaySoundServiceWeb(): PlaySoundService {
 	return {
 		playSound: async (soundName) => {
 			if (!document.hidden) {
-				await audioElements[soundName].play();
+				await playSound(soundName);
 				return Ok(undefined);
 			}
 			return Ok(undefined);


### PR DESCRIPTION
## Summary

Replaces `HTMLAudioElement` with the Web Audio API (`AudioContext` + `BufferSourceNode`) for sound playback. This fixes both the PipeWire node accumulation from #842 and a volume reset issue on Linux where WirePlumber restores full volume on every sound play.

Supersedes #1374.

## Problem

`HTMLAudioElement` has two issues on Linux with PipeWire/WirePlumber:

1. **Node accumulation (#842):** Each `Audio` element registers a PipeWire output node that persists as long as the element is reachable. The original code cached 8 elements at module load, and HMR reloads orphaned old elements without releasing their nodes.

2. **Volume resets:** #1374 fixed accumulation by creating a fresh element per playback and tearing it down after `ended`. However, WebKit tears down and recreates the underlying PipeWire media pipeline on every new `Audio()` or `src` change, so WirePlumber sees each playback as a brand-new stream and restores it to its database volume (1.0 / full) before the user's adjustment can be saved back.

```
HTMLAudioElement approaches — both broken:

Cached elements:   Module load → new Audio() × 8 → PipeWire nodes pile up on HMR
Per-play elements: playSound() → new Audio() → WirePlumber restores 1.0 → volume resets
```

## Solution

A single `AudioContext` is created lazily on first use and kept alive for the app's lifetime. This registers exactly one PipeWire node that persists across all sound playback. Audio files are decoded once into `AudioBuffer`s (cached in memory), and each `playSound()` call creates a lightweight `BufferSourceNode` — no new PipeWire nodes.

```
AudioContext approach:

First playSound() → new AudioContext() → 1 PipeWire node (persists forever)
                  → fetch + decodeAudioData → cached AudioBuffer

Subsequent calls  → new BufferSourceNode (no PipeWire overhead)
                  → connect to destination → start()
                  → auto-cleaned up after playback
```

- No node accumulation — one stable node for the app's lifetime
- WirePlumber can reliably track and persist volume adjustments
- Decoded buffers are cached, so repeat plays are efficient
- No `ended` event race conditions that could hang the playback promise

Fixes #842