### PR TITLE
feat(runner,api): add headless runner and device auth foundation

### DIFF
--- a/apps/api/better-auth.config.ts
+++ b/apps/api/better-auth.config.ts
@@ -8,9 +8,13 @@
  */
 
 import { fileURLToPath } from 'node:url';
+import { oauthProvider } from '@better-auth/oauth-provider';
 import { type } from 'arktype';
 import { betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
+import { bearer } from 'better-auth/plugins/bearer';
+import { deviceAuthorization } from 'better-auth/plugins/device-authorization';
+import { jwt } from 'better-auth/plugins/jwt';
 import { config } from 'dotenv';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
@@ -28,6 +32,13 @@ const db = drizzle(sql);
 
 export const auth = betterAuth({
 	...BASE_AUTH_CONFIG,
+	baseURL: 'http://localhost:8787',
 	database: drizzleAdapter(db, { provider: 'pg' }),
 	secret: env.BETTER_AUTH_SECRET,
+	plugins: [
+		bearer(),
+		jwt(),
+		deviceAuthorization(),
+		oauthProvider({ loginPage: '/sign-in', consentPage: '/consent' }),
+	],
 });

--- a/apps/api/better-auth.config.ts
+++ b/apps/api/better-auth.config.ts
@@ -23,8 +23,8 @@ import { type } from 'arktype';
 import { betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { config } from 'dotenv';
-import { drizzle } from 'drizzle-orm/postgres-js';
-import postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import pg from 'pg';
 import { BASE_AUTH_CONFIG } from './src/app';
 import { LOCAL_DATABASE_URL } from './env';
 
@@ -34,8 +34,9 @@ const env = type({
 	'DATABASE_URL?': 'string',
 }).assert(process.env);
 
-const sql = postgres(env.DATABASE_URL ?? LOCAL_DATABASE_URL);
-const db = drizzle(sql);
+const client = new pg.Client({ connectionString: env.DATABASE_URL ?? LOCAL_DATABASE_URL });
+await client.connect();
+const db = drizzle(client);
 
 export const auth = betterAuth({
 	...BASE_AUTH_CONFIG,

--- a/apps/api/better-auth.config.ts
+++ b/apps/api/better-auth.config.ts
@@ -1,25 +1,32 @@
 /**
  * CLI-only config for Better Auth schema tools.
  *
- * Run via:
- *   bun run auth:generate  — generate Drizzle schema from Better Auth tables
+ * This file exists solely for `@better-auth/cli generate` to introspect the auth
+ * config and emit the correct Drizzle schema. It is never used at runtime—the
+ * Cloudflare Worker uses `createAuth()` in `src/app.ts` instead.
  *
- * Loads `.dev.vars` via `tooling/env.ts`.
+ * Both configs spread `BASE_AUTH_CONFIG` (which owns the plugin list) so the CLI
+ * and runtime always agree on which tables exist.
+ *
+ * Run via:
+ *   bun run auth:generate
+ *
+ * Env strategy:
+ *   - `BETTER_AUTH_SECRET` comes from `.dev.vars` (loaded via dotenv) or Infisical.
+ *   - `DATABASE_URL` falls back to the local Postgres URL parsed from `wrangler.jsonc`
+ *     by `env.ts`.
  */
 
 import { fileURLToPath } from 'node:url';
-import { oauthProvider } from '@better-auth/oauth-provider';
+import { createApps } from '@epicenter/constants/apps';
 import { type } from 'arktype';
 import { betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
-import { bearer } from 'better-auth/plugins/bearer';
-import { deviceAuthorization } from 'better-auth/plugins/device-authorization';
-import { jwt } from 'better-auth/plugins/jwt';
 import { config } from 'dotenv';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import { BASE_AUTH_CONFIG } from './src/app';
-import { LOCAL_DATABASE_URL } from './tooling/env';
+import { LOCAL_DATABASE_URL } from './env';
 
 config({ path: fileURLToPath(new URL('.dev.vars', import.meta.url)) });
 const env = type({
@@ -32,13 +39,12 @@ const db = drizzle(sql);
 
 export const auth = betterAuth({
 	...BASE_AUTH_CONFIG,
-	baseURL: 'http://localhost:8787',
+	/**
+	 * The CLI always runs locally, so we hardcode the dev URL. The value doesn't
+	 * affect schema generation—it only prevents `oauthProvider` from crashing on
+	 * `new URL('')` during plugin init. The runtime config uses `env.BASE_URL` instead.
+	 */
+	baseURL: createApps('development').API.URL,
 	database: drizzleAdapter(db, { provider: 'pg' }),
 	secret: env.BETTER_AUTH_SECRET,
-	plugins: [
-		bearer(),
-		jwt(),
-		deviceAuthorization(),
-		oauthProvider({ loginPage: '/sign-in', consentPage: '/consent' }),
-	],
 });

--- a/apps/api/drizzle.config.ts
+++ b/apps/api/drizzle.config.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from 'node:url';
 import { config } from 'dotenv';
 import { defineConfig } from 'drizzle-kit';
-import { LOCAL_DATABASE_URL } from './tooling/env';
+import { LOCAL_DATABASE_URL } from './env';
 
 config({ path: fileURLToPath(new URL('.dev.vars', import.meta.url)) });
 

--- a/apps/api/drizzle/0002_chubby_captain_america.sql
+++ b/apps/api/drizzle/0002_chubby_captain_america.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "device_code" (
+	"id" text PRIMARY KEY NOT NULL,
+	"device_code" text NOT NULL,
+	"user_code" text NOT NULL,
+	"user_id" text,
+	"expires_at" timestamp NOT NULL,
+	"status" text NOT NULL,
+	"last_polled_at" timestamp,
+	"polling_interval" integer,
+	"client_id" text,
+	"scope" text
+);

--- a/apps/api/drizzle/meta/0002_snapshot.json
+++ b/apps/api/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1128 @@
+{
+  "id": "18fc87f8-40ac-4c6c-800f-fc8d770f42b4",
+  "prevId": "8f68f18c-6863-451e-99fd-19d2d930cabd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_code": {
+      "name": "device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.durable_object_instance": {
+      "name": "durable_object_instance",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "do_type": {
+          "name": "do_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_name": {
+          "name": "resource_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "do_name": {
+          "name": "do_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "storage_bytes": {
+          "name": "storage_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "storage_measured_at": {
+          "name": "storage_measured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "doi_user_id_idx": {
+          "name": "doi_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "durable_object_instance_user_id_user_id_fk": {
+          "name": "durable_object_instance_user_id_user_id_fk",
+          "tableFrom": "durable_object_instance",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1773443824067,
       "tag": "0001_futuristic_santa_claus",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1774071339224,
+      "tag": "0002_chubby_captain_america",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/env.ts
+++ b/apps/api/env.ts
@@ -27,7 +27,7 @@ const WranglerConfig = type('string')
 	});
 
 const jsoncString = readFileSync(
-	fileURLToPath(new URL('../wrangler.jsonc', import.meta.url)),
+	fileURLToPath(new URL('./wrangler.jsonc', import.meta.url)),
 	'utf-8',
 );
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -26,6 +26,7 @@
 		"@better-auth/drizzle-adapter": "catalog:",
 		"@better-auth/oauth-provider": "catalog:",
 		"@epicenter/sync": "workspace:*",
+		"@epicenter/constants": "workspace:*",
 		"@hono/standard-validator": "catalog:",
 		"@tanstack/ai": "catalog:",
 		"@tanstack/ai-anthropic": "catalog:",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,7 +12,7 @@
 		"dev:remote": "infisical run --watch --path=/api -- wrangler dev",
 		"deploy": "wrangler deploy",
 		"typegen": "wrangler types",
-		"auth:generate": "bun x @better-auth/cli generate --yes --config ./better-auth.config.ts --output ./src/db/schema.ts",
+		"auth:generate": "infisical run --path=/api -- bun x @better-auth/cli generate --yes --config ./better-auth.config.ts --output ./src/db/schema.ts",
 		"db:generate": "drizzle-kit generate",
 		"db:drop": "drizzle-kit drop",
 		"db:push:local": "drizzle-kit push",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -38,7 +38,6 @@
 		"hono-openapi": "catalog:",
 		"lib0": "catalog:",
 		"pg": "^8.20.0",
-		"postgres": "^3.4.8",
 		"wellcrafted": "catalog:",
 		"y-protocols": "catalog:",
 		"yjs": "catalog:"

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -208,7 +208,7 @@ function bytesToBase64(bytes: Uint8Array): string {
 }
 
 /** Creates a Better Auth instance using an already-connected Drizzle instance. */
-function createAuth(db: Db) {
+function createAuth(db: Db, env: Env['Bindings']) {
 	return betterAuth({
 		...BASE_AUTH_CONFIG,
 		database: drizzleAdapter(db, { provider: 'pg' }),
@@ -365,7 +365,7 @@ const factory = createFactory<Env>({
 
 		// Layer 2: Auth — pure, reads db from context.
 		app.use('*', async (c, next) => {
-			c.set('auth', createAuth(c.var.db));
+			c.set('auth', createAuth(c.var.db, c.env));
 			await next();
 		});
 	},

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,10 +6,11 @@ import {
 } from '@better-auth/oauth-provider';
 import { sValidator } from '@hono/standard-validator';
 import { type } from 'arktype';
-import { betterAuth } from 'better-auth';
+import { type BetterAuthOptions, betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { customSession } from 'better-auth/plugins';
 import { bearer } from 'better-auth/plugins/bearer';
+import { deviceAuthorization } from 'better-auth/plugins/device-authorization';
 import { jwt } from 'better-auth/plugins/jwt';
 import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres';
 import type { Context } from 'hono';
@@ -20,6 +21,7 @@ import pg from 'pg';
 import { aiChatHandlers } from './ai-chat';
 import { MAX_PAYLOAD_BYTES } from './constants';
 import * as schema from './db/schema';
+import { devicePage } from './device-page';
 
 export { DocumentRoom } from './document-room';
 // Re-export so wrangler types generates DurableObjectNamespace<WorkspaceRoom|DocumentRoom>
@@ -96,7 +98,7 @@ export const BASE_AUTH_CONFIG = {
 			trustedProviders: ['google', 'email-password'],
 		},
 	},
-};
+} satisfies BetterAuthOptions;
 
 /**
  * Validated shape of a single keyring entry.
@@ -104,7 +106,10 @@ export const BASE_AUTH_CONFIG = {
  * `version` is a positive integer identifying the key generation; `secret` is
  * the raw key material (typically base64-encoded via `openssl rand -base64 32`).
  */
-const EncryptionEntry = type({ version: 'number.integer > 0', secret: 'string' });
+const EncryptionEntry = type({
+	version: 'number.integer > 0',
+	secret: 'string',
+});
 
 /**
  * Parse a single `"version:secret"` string into a validated `EncryptionEntry`.
@@ -113,11 +118,13 @@ const EncryptionEntry = type({ version: 'number.integer > 0', secret: 'string' }
  * is the secret (which may itself contain colons). Uses `ctx.error()` for
  * arktype-native error reporting when the colon delimiter is missing.
  */
-const EncryptionEntryParser = type('string').pipe((entry, ctx) => {
-	const i = entry.indexOf(':');
-	if (i === -1) return ctx.error('must be "version:secret"');
-	return { version: Number(entry.slice(0, i)), secret: entry.slice(i + 1) };
-}).to(EncryptionEntry);
+const EncryptionEntryParser = type('string')
+	.pipe((entry, ctx) => {
+		const i = entry.indexOf(':');
+		if (i === -1) return ctx.error('must be "version:secret"');
+		return { version: Number(entry.slice(0, i)), secret: entry.slice(i + 1) };
+	})
+	.to(EncryptionEntry);
 
 /**
  * Parse and validate the full ENCRYPTION_SECRETS env var into a sorted keyring.
@@ -225,6 +232,11 @@ function createAuth(db: Db) {
 					keyVersion: currentKey.version,
 				};
 			}),
+			deviceAuthorization({
+				verificationUri: '/device',
+				expiresIn: '10m',
+				interval: '5s',
+			}),
 			oauthProvider({
 				loginPage: '/sign-in',
 				consentPage: '/consent',
@@ -244,6 +256,14 @@ function createAuth(db: Db) {
 						name: 'Epicenter Mobile',
 						type: 'native',
 						redirectUrls: ['epicenter://auth/callback'],
+						skipConsent: true,
+						metadata: {},
+					},
+					{
+						clientId: 'epicenter-runner',
+						name: 'Epicenter Runner',
+						type: 'native',
+						redirectUrls: [],
 						skipConsent: true,
 						metadata: {},
 					},
@@ -362,6 +382,12 @@ app.get(
 	}),
 	(c) => c.json({ mode: 'hub', version: '0.1.0', runtime: 'cloudflare' }),
 );
+
+// Device authorization verification page (RFC 8628)
+app.get('/device', (c) => {
+	const userCode = c.req.query('user_code');
+	return c.html(devicePage(userCode));
+});
 
 // Auth
 app.on(

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -3,6 +3,7 @@ import {
 	bigint,
 	boolean,
 	index,
+	integer,
 	jsonb,
 	pgTable,
 	text,
@@ -90,6 +91,19 @@ export const jwks = pgTable('jwks', {
 	privateKey: text('private_key').notNull(),
 	createdAt: timestamp('created_at').notNull(),
 	expiresAt: timestamp('expires_at'),
+});
+
+export const deviceCode = pgTable('device_code', {
+	id: text('id').primaryKey(),
+	deviceCode: text('device_code').notNull(),
+	userCode: text('user_code').notNull(),
+	userId: text('user_id'),
+	expiresAt: timestamp('expires_at').notNull(),
+	status: text('status').notNull(),
+	lastPolledAt: timestamp('last_polled_at'),
+	pollingInterval: integer('polling_interval'),
+	clientId: text('client_id'),
+	scope: text('scope'),
 });
 
 export const oauthClient = pgTable('oauth_client', {

--- a/apps/api/src/device-page.ts
+++ b/apps/api/src/device-page.ts
@@ -1,0 +1,131 @@
+/**
+ * Minimal HTML verification page for the OAuth device authorization flow (RFC 8628).
+ *
+ * Served at `/device` by the Hono app. The user enters the code displayed by the runner,
+ * clicks Approve, and the runner's polling loop picks up the token automatically.
+ *
+ * Session cookies from `epicenter.so` work here via cross-subdomain cookies
+ * (`domain: 'epicenter.so'`), so the user only needs to sign in once.
+ */
+export function devicePage(userCode?: string) {
+	const prefilled = userCode ? escapeHtml(userCode) : '';
+
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Authorize Device — Epicenter</title>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+body{font-family:system-ui,-apple-system,sans-serif;min-height:100vh;display:flex;align-items:center;justify-content:center;background:#fafafa;color:#111;padding:1rem}
+.card{background:#fff;border:1px solid #e5e5e5;border-radius:12px;padding:2.5rem;max-width:380px;width:100%}
+h1{font-size:1.25rem;font-weight:600;margin-bottom:.25rem}
+.subtitle{color:#666;font-size:.875rem;margin-bottom:1.5rem}
+label{display:block;font-size:.875rem;font-weight:500;margin-bottom:.5rem}
+input{width:100%;padding:.625rem .75rem;border:1px solid #d1d5db;border-radius:8px;font-size:1.125rem;font-family:monospace;letter-spacing:.15em;text-align:center;text-transform:uppercase;outline:none;transition:border-color .15s}
+input:focus{border-color:#111;box-shadow:0 0 0 1px #111}
+.actions{display:flex;gap:.5rem;margin-top:1rem}
+button{flex:1;padding:.625rem 1rem;border-radius:8px;font-size:.875rem;font-weight:500;cursor:pointer;border:1px solid transparent;transition:opacity .15s}
+button:disabled{opacity:.5;cursor:not-allowed}
+.btn-approve{background:#111;color:#fff;border-color:#111}
+.btn-approve:hover:not(:disabled){opacity:.85}
+.btn-deny{background:#fff;color:#111;border-color:#d1d5db}
+.btn-deny:hover:not(:disabled){background:#f5f5f5}
+.msg{margin-top:1rem;padding:.75rem;border-radius:8px;font-size:.875rem;line-height:1.4}
+.msg.ok{background:#f0fdf4;color:#166534;border:1px solid #bbf7d0}
+.msg.err{background:#fef2f2;color:#991b1b;border:1px solid #fecaca}
+.msg.warn{background:#fffbeb;color:#92400e;border:1px solid #fde68a}
+.hidden{display:none}
+</style>
+</head>
+<body>
+<div class="card">
+	<h1>Authorize device</h1>
+	<p class="subtitle">Enter the code shown by Epicenter Runner.</p>
+	<form id="form">
+		<label for="code">Device code</label>
+		<input id="code" name="code" type="text" required autocomplete="off"
+			placeholder="ABCD-1234" maxlength="20" value="${prefilled}">
+		<div class="actions">
+			<button type="submit" class="btn-approve" id="approve">Approve</button>
+			<button type="button" class="btn-deny" id="deny">Deny</button>
+		</div>
+	</form>
+	<div id="msg" class="msg hidden"></div>
+</div>
+<script>
+(function() {
+	var form = document.getElementById('form');
+	var code = document.getElementById('code');
+	var approve = document.getElementById('approve');
+	var deny = document.getElementById('deny');
+	var msg = document.getElementById('msg');
+
+	function show(text, type) {
+		msg.textContent = text;
+		msg.className = 'msg ' + type;
+	}
+
+	function setLoading(on) {
+		approve.disabled = on;
+		deny.disabled = on;
+		code.disabled = on;
+	}
+
+	async function send(endpoint, userCode) {
+		setLoading(true);
+		msg.className = 'msg hidden';
+		try {
+			var res = await fetch('/auth/device/' + endpoint, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				credentials: 'include',
+				body: JSON.stringify({ userCode: userCode }),
+			});
+			var data = await res.json();
+			if (!res.ok) {
+				if (res.status === 401 || data.error === 'unauthorized') {
+					show('Sign in first, then come back to this page.', 'warn');
+				} else {
+					show(data.error_description || data.message || 'Something went wrong.', 'err');
+				}
+				return;
+			}
+			if (endpoint === 'approve') {
+				show('Device authorized. You can close this page.', 'ok');
+				form.classList.add('hidden');
+			} else {
+				show('Device denied.', 'ok');
+				form.classList.add('hidden');
+			}
+		} catch (e) {
+			show('Network error. Check your connection and try again.', 'err');
+		} finally {
+			setLoading(false);
+		}
+	}
+
+	form.addEventListener('submit', function(e) {
+		e.preventDefault();
+		var val = code.value.trim();
+		if (val) send('approve', val);
+	});
+
+	deny.addEventListener('click', function() {
+		var val = code.value.trim();
+		if (val) send('deny', val);
+	});
+})();
+</script>
+</body>
+</html>`;
+}
+
+function escapeHtml(s: string): string {
+	return s
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;');
+}

--- a/apps/runner/example/epicenter.config.ts
+++ b/apps/runner/example/epicenter.config.ts
@@ -1,0 +1,14 @@
+import { defineWorkspace } from '@epicenter/workspace';
+
+/**
+ * Headless runner config for the tab-manager workspace.
+ *
+ * Uses the same workspace ID as the browser extension, so the runner
+ * joins the same Y.Doc room on the sync server. Table schemas aren't
+ * needed here—persistence and sync operate on raw Y.Doc updates.
+ *
+ * Run:
+ *   EPICENTER_SERVER_URL=wss://api.epicenter.so EPICENTER_TOKEN=<your-token> \
+ *     bun run apps/runner -- apps/runner/example
+ */
+export const tabManager = defineWorkspace({ id: 'tab-manager' });

--- a/apps/runner/package.json
+++ b/apps/runner/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "@epicenter/runner",
+	"version": "0.0.1",
+	"type": "module",
+	"private": true,
+	"scripts": {
+		"dev": "bun run src/index.ts",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@epicenter/workspace": "workspace:*",
+		"yjs": "catalog:"
+	},
+	"devDependencies": {
+		"@types/bun": "catalog:",
+		"typescript": "catalog:"
+	},
+	"module": "src/index.ts"
+}

--- a/apps/runner/src/auth.ts
+++ b/apps/runner/src/auth.ts
@@ -10,6 +10,32 @@ type StoredToken = {
 	expires_in: number;
 };
 
+// ─── Server API helpers ─────────────────────────────────────────────────────
+
+/** POST to a JSON endpoint and return the parsed response. */
+async function post(url: string, body: Record<string, string>): Promise<Record<string, unknown>> {
+	const res = await fetch(url, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body),
+	});
+	return res.json() as Promise<Record<string, unknown>>;
+}
+
+/** Request a device code for the OAuth device authorization flow. */
+async function requestDeviceCode(serverUrl: string) {
+	return post(`${serverUrl}/auth/device/code`, { client_id: CLIENT_ID });
+}
+
+/** Poll the token endpoint with a previously-issued device code. */
+async function pollDeviceToken(serverUrl: string, deviceCode: string) {
+	return post(`${serverUrl}/auth/device/token`, {
+		grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+		device_code: deviceCode,
+		client_id: CLIENT_ID,
+	});
+}
+
 /**
  * Authenticate with an Epicenter server using the RFC 8628 device code flow.
  *
@@ -21,41 +47,27 @@ export async function login(
 	serverUrl: string,
 	configDir: string,
 ): Promise<void> {
-	const codeRes = await fetch(`${serverUrl}/auth/device/code`, {
-		method: 'POST',
-		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify({ client_id: CLIENT_ID }),
-	});
-	const codeData = await codeRes.json();
+	const codeData = await requestDeviceCode(serverUrl);
 
 	console.log(`\nVisit: ${codeData.verification_uri_complete}`);
 	console.log(`Enter code: ${codeData.user_code}\n`);
 
-	let interval = codeData.interval * 1000;
+	let interval = (codeData.interval as number) * 1000;
 
 	while (true) {
 		await Bun.sleep(interval);
 
-		const tokenRes = await fetch(`${serverUrl}/auth/device/token`, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
-				device_code: codeData.device_code,
-				client_id: CLIENT_ID,
-			}),
-		});
-		const tokenData = await tokenRes.json();
+		const tokenData = await pollDeviceToken(serverUrl, codeData.device_code as string);
 
 		if (!tokenData.error) {
 			const authDir = join(configDir, '.epicenter', 'auth');
 			await mkdir(authDir, { recursive: true });
 
 			const stored: StoredToken = {
-				access_token: tokenData.access_token,
+				access_token: tokenData.access_token as string,
 				server: serverUrl,
 				created_at: Date.now(),
-				expires_in: tokenData.expires_in,
+				expires_in: tokenData.expires_in as number,
 			};
 			await Bun.write(
 				join(authDir, 'token.json'),
@@ -77,7 +89,7 @@ export async function login(
 			case 'access_denied':
 				throw new Error('Authorization denied — you rejected the request');
 			default:
-				throw new Error(tokenData.error_description ?? tokenData.error);
+				throw new Error((tokenData.error_description as string) ?? (tokenData.error as string));
 		}
 	}
 }

--- a/apps/runner/src/auth.ts
+++ b/apps/runner/src/auth.ts
@@ -10,30 +10,39 @@ type StoredToken = {
 	expires_in: number;
 };
 
-// ─── Server API helpers ─────────────────────────────────────────────────────
+// ─── Server API ────────────────────────────────────────────────────────────────────
 
-/** POST to a JSON endpoint and return the parsed response. */
-async function post(url: string, body: Record<string, string>): Promise<Record<string, unknown>> {
-	const res = await fetch(url, {
-		method: 'POST',
-		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify(body),
-	});
-	return res.json() as Promise<Record<string, unknown>>;
-}
+/**
+ * Create an API client bound to a specific Epicenter server.
+ *
+ * Closes over `serverUrl` so callers don't repeat it on every request.
+ * `post` is a private helper; only the named operations are exposed.
+ */
+function createServerApi(serverUrl: string) {
+	async function post(path: string, body: Record<string, string>) {
+		const res = await fetch(`${serverUrl}${path}`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(body),
+		});
+		return res.json() as Promise<Record<string, unknown>>;
+	}
 
-/** Request a device code for the OAuth device authorization flow. */
-async function requestDeviceCode(serverUrl: string) {
-	return post(`${serverUrl}/auth/device/code`, { client_id: CLIENT_ID });
-}
+	return {
+		/** Request a device code for the OAuth device authorization flow. */
+		requestDeviceCode() {
+			return post('/auth/device/code', { client_id: CLIENT_ID });
+		},
 
-/** Poll the token endpoint with a previously-issued device code. */
-async function pollDeviceToken(serverUrl: string, deviceCode: string) {
-	return post(`${serverUrl}/auth/device/token`, {
-		grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
-		device_code: deviceCode,
-		client_id: CLIENT_ID,
-	});
+		/** Poll the token endpoint with a previously-issued device code. */
+		pollDeviceToken(deviceCode: string) {
+			return post('/auth/device/token', {
+				grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+				device_code: deviceCode,
+				client_id: CLIENT_ID,
+			});
+		},
+	};
 }
 
 /**
@@ -47,7 +56,8 @@ export async function login(
 	serverUrl: string,
 	configDir: string,
 ): Promise<void> {
-	const codeData = await requestDeviceCode(serverUrl);
+	const api = createServerApi(serverUrl);
+	const codeData = await api.requestDeviceCode();
 
 	console.log(`\nVisit: ${codeData.verification_uri_complete}`);
 	console.log(`Enter code: ${codeData.user_code}\n`);
@@ -57,7 +67,7 @@ export async function login(
 	while (true) {
 		await Bun.sleep(interval);
 
-		const tokenData = await pollDeviceToken(serverUrl, codeData.device_code as string);
+		const tokenData = await api.pollDeviceToken(codeData.device_code as string);
 
 		if (!tokenData.error) {
 			const authDir = join(configDir, '.epicenter', 'auth');

--- a/apps/runner/src/auth.ts
+++ b/apps/runner/src/auth.ts
@@ -1,0 +1,122 @@
+import { mkdir, unlink } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const CLIENT_ID = 'epicenter-runner';
+
+type StoredToken = {
+	access_token: string;
+	server: string;
+	created_at: number;
+	expires_in: number;
+};
+
+/**
+ * Authenticate with an Epicenter server using the RFC 8628 device code flow.
+ *
+ * Initiates a device authorization request, prints the verification URL and user code,
+ * then polls until the user completes authorization or the request expires.
+ * On success, writes the token to `{configDir}/.epicenter/auth/token.json`.
+ */
+export async function login(
+	serverUrl: string,
+	configDir: string,
+): Promise<void> {
+	const codeRes = await fetch(`${serverUrl}/auth/device/code`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ client_id: CLIENT_ID }),
+	});
+	const codeData = await codeRes.json();
+
+	console.log(`\nVisit: ${codeData.verification_uri_complete}`);
+	console.log(`Enter code: ${codeData.user_code}\n`);
+
+	let interval = codeData.interval * 1000;
+
+	while (true) {
+		await Bun.sleep(interval);
+
+		const tokenRes = await fetch(`${serverUrl}/auth/device/token`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+				device_code: codeData.device_code,
+				client_id: CLIENT_ID,
+			}),
+		});
+		const tokenData = await tokenRes.json();
+
+		if (!tokenData.error) {
+			const authDir = join(configDir, '.epicenter', 'auth');
+			await mkdir(authDir, { recursive: true });
+
+			const stored: StoredToken = {
+				access_token: tokenData.access_token,
+				server: serverUrl,
+				created_at: Date.now(),
+				expires_in: tokenData.expires_in,
+			};
+			await Bun.write(
+				join(authDir, 'token.json'),
+				JSON.stringify(stored, null, '\t'),
+			);
+
+			console.log(`✓ Logged in to ${serverUrl}`);
+			return;
+		}
+
+		switch (tokenData.error) {
+			case 'authorization_pending':
+				continue;
+			case 'slow_down':
+				interval *= 2;
+				continue;
+			case 'expired_token':
+				throw new Error('Device code expired — please run login again');
+			case 'access_denied':
+				throw new Error('Authorization denied — you rejected the request');
+			default:
+				throw new Error(tokenData.error_description ?? tokenData.error);
+		}
+	}
+}
+
+/**
+ * Delete the stored auth token. No-op if no token exists.
+ */
+export async function logout(configDir: string): Promise<void> {
+	try {
+		await unlink(join(configDir, '.epicenter', 'auth', 'token.json'));
+	} catch {
+		// No-op — file doesn't exist
+	}
+	console.log('✓ Logged out');
+}
+
+/**
+ * Resolve an auth token for the sync extension.
+ *
+ * Resolution order:
+ * 1. `EPICENTER_TOKEN` env var (override for CI/scripts)
+ * 2. Stored token file at `{configDir}/.epicenter/auth/token.json`
+ * 3. `undefined` (unauthenticated)
+ *
+ * Called on each WebSocket reconnect so a freshly-minted token from
+ * `login` in another terminal is picked up without restarting the runner.
+ */
+export async function loadToken(
+	configDir: string,
+): Promise<string | undefined> {
+	if (process.env.EPICENTER_TOKEN) return process.env.EPICENTER_TOKEN;
+
+	const tokenFile = Bun.file(
+		join(configDir, '.epicenter', 'auth', 'token.json'),
+	);
+	if (await tokenFile.exists()) {
+		const stored: StoredToken = await tokenFile.json();
+		return stored.access_token;
+	}
+
+	return undefined;
+}

--- a/apps/runner/src/index.ts
+++ b/apps/runner/src/index.ts
@@ -1,0 +1,89 @@
+/**
+ * Headless Workspace Runner
+ *
+ * Loads epicenter.config.ts from a project folder, auto-wires persistence and sync
+ * extensions for each workspace definition, and stays alive as a headless client
+ * connected to the Epicenter server.
+ *
+ * Usage:
+ *   bun run apps/runner -- /path/to/project
+ *   bun run apps/runner -- .
+ *   bun run apps/runner              # defaults to cwd
+ *
+ * Environment:
+ *   EPICENTER_SERVER_URL  Server URL (default: ws://localhost:3913)
+ *   EPICENTER_TOKEN       Auth token for authenticated sync servers
+ */
+
+import { join } from 'node:path';
+import type { AnyWorkspaceClient } from '@epicenter/workspace';
+import { createWorkspace } from '@epicenter/workspace';
+import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
+import { filesystemPersistence } from '@epicenter/workspace/extensions/sync/desktop';
+import { loadConfig } from './load-config';
+
+// ─── Resolve target directory ──────────────────────────────────────────────
+
+const targetDir = process.argv[2] ?? process.cwd();
+
+// ─── Load config ───────────────────────────────────────────────────────────
+
+const { configDir, definitions, clients } = await loadConfig(targetDir);
+
+const serverUrl = process.env.EPICENTER_SERVER_URL ?? 'ws://localhost:3913';
+const token = process.env.EPICENTER_TOKEN;
+
+// ─── Wire extensions for raw definitions ───────────────────────────────────
+
+const allClients: AnyWorkspaceClient[] = [...clients];
+
+for (const definition of definitions) {
+	const persistencePath = join(
+		configDir,
+		'.epicenter',
+		'persistence',
+		`${definition.id}.db`,
+	);
+
+	const client = createWorkspace(definition)
+		.withExtension(
+			'persistence',
+			filesystemPersistence({ filePath: persistencePath }),
+		)
+		.withExtension(
+			'sync',
+			createSyncExtension({
+				url: (id) => `${serverUrl}/workspaces/${id}`,
+				...(token && { getToken: async () => token }),
+			}),
+		);
+
+	allClients.push(client);
+}
+
+// ─── Wait for all clients to be ready ──────────────────────────────────────
+
+await Promise.all(allClients.map((c) => c.whenReady));
+
+// ─── Log status ────────────────────────────────────────────────────────────
+
+const ids = allClients.map((c) => c.id);
+console.log(`\u2713 Runner started \u2014 ${allClients.length} workspace(s)`);
+console.log(`  Workspaces: ${ids.join(', ')}`);
+console.log(`  Server: ${serverUrl}`);
+console.log(`  Auth: ${token ? 'token provided' : 'none (open mode)'}`);
+console.log(`  Config: ${configDir}`);
+console.log('');
+console.log('Press Ctrl+C to stop');
+
+// ─── Graceful shutdown ─────────────────────────────────────────────────────
+
+async function shutdown() {
+	console.log('\nShutting down...');
+	await Promise.all(allClients.map((c) => c.destroy()));
+	console.log('✓ Graceful shutdown complete');
+	process.exit(0);
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);

--- a/apps/runner/src/index.ts
+++ b/apps/runner/src/index.ts
@@ -10,28 +10,54 @@
  *   bun run apps/runner -- .
  *   bun run apps/runner              # defaults to cwd
  *
+ * Subcommands:
+ *   bun run apps/runner login --server https://api.epicenter.so [dir]
+ *   bun run apps/runner logout [dir]
+ *
  * Environment:
  *   EPICENTER_SERVER_URL  Server URL (default: ws://localhost:3913)
- *   EPICENTER_TOKEN       Auth token for authenticated sync servers
+ *   EPICENTER_TOKEN       Auth token override (takes precedence over stored token)
  */
 
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import type { AnyWorkspaceClient } from '@epicenter/workspace';
 import { createWorkspace } from '@epicenter/workspace';
 import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
 import { filesystemPersistence } from '@epicenter/workspace/extensions/sync/desktop';
+import { login, logout, loadToken } from './auth';
 import { loadConfig } from './load-config';
 
-// ─── Resolve target directory ──────────────────────────────────────────────
 
-const targetDir = process.argv[2] ?? process.cwd();
+const args = process.argv.slice(2);
+let targetDir: string;
 
-// ─── Load config ───────────────────────────────────────────────────────────
+switch (args[0]) {
+	case 'login': {
+		const serverIdx = args.indexOf('--server');
+		if (serverIdx === -1 || !args[serverIdx + 1]) {
+			console.error('Usage: runner login --server <url> [dir]');
+			process.exit(1);
+		}
+		const server = args[serverIdx + 1]!;
+		const remaining = args.filter((_, i) => i !== 0 && i !== serverIdx && i !== serverIdx + 1);
+		const dir = remaining[0] ?? process.cwd();
+		await login(server, resolve(dir));
+		process.exit(0);
+	}
+	case 'logout': {
+		const dir = args[1] ?? process.cwd();
+		await logout(resolve(dir));
+		process.exit(0);
+	}
+	default:
+		targetDir = args[0] ?? process.cwd();
+}
+
+
 
 const { configDir, definitions, clients } = await loadConfig(targetDir);
 
 const serverUrl = process.env.EPICENTER_SERVER_URL ?? 'ws://localhost:3913';
-const token = process.env.EPICENTER_TOKEN;
 
 // ─── Wire extensions for raw definitions ───────────────────────────────────
 
@@ -54,7 +80,7 @@ for (const definition of definitions) {
 			'sync',
 			createSyncExtension({
 				url: (id) => `${serverUrl}/workspaces/${id}`,
-				...(token && { getToken: async () => token }),
+				getToken: () => loadToken(configDir),
 			}),
 		);
 
@@ -71,7 +97,8 @@ const ids = allClients.map((c) => c.id);
 console.log(`\u2713 Runner started \u2014 ${allClients.length} workspace(s)`);
 console.log(`  Workspaces: ${ids.join(', ')}`);
 console.log(`  Server: ${serverUrl}`);
-console.log(`  Auth: ${token ? 'token provided' : 'none (open mode)'}`);
+const initialToken = await loadToken(configDir);
+console.log(`  Auth: ${initialToken ? 'token loaded' : 'none (open mode)'}`);
 console.log(`  Config: ${configDir}`);
 console.log('');
 console.log('Press Ctrl+C to stop');

--- a/apps/runner/src/load-config.ts
+++ b/apps/runner/src/load-config.ts
@@ -1,0 +1,91 @@
+/**
+ * Load workspace definitions and pre-wired clients from an epicenter.config.ts file.
+ *
+ * Mirrors the dynamic import pattern from packages/cli/src/discovery.ts but collects
+ * raw WorkspaceDefinitions (for auto-wiring) alongside pre-wired WorkspaceClients
+ * (for passthrough lifecycle management).
+ */
+
+import { join, resolve } from 'node:path';
+import type { AnyWorkspaceClient, WorkspaceDefinition } from '@epicenter/workspace';
+
+const CONFIG_FILENAME = 'epicenter.config.ts';
+
+/**
+ * Broadest WorkspaceDefinition—erases table/kv generics for dynamic import use.
+ * Equivalent to `WorkspaceDefinition<string, any, any, any>`.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: intentional variance-friendly type for dynamic imports
+type AnyWorkspaceDefinition = WorkspaceDefinition<string, any, any, any>;
+
+export type LoadConfigResult = {
+	configDir: string;
+	definitions: AnyWorkspaceDefinition[];
+	clients: AnyWorkspaceClient[];
+};
+
+/**
+ * Load epicenter.config.ts from the target directory.
+ *
+ * Detects each named export as either:
+ * - WorkspaceDefinition (has `id`, lacks `definitions`) → needs extension wiring
+ * - WorkspaceClient (has `id` and `definitions`) → already wired, passthrough
+ *
+ * @example
+ * ```typescript
+ * const { configDir, definitions, clients } = await loadConfig('/path/to/project');
+ * ```
+ */
+export async function loadConfig(targetDir: string): Promise<LoadConfigResult> {
+	const configDir = resolve(targetDir);
+	const configPath = join(configDir, CONFIG_FILENAME);
+
+	if (!(await Bun.file(configPath).exists())) {
+		throw new Error(`No ${CONFIG_FILENAME} found in ${configDir}`);
+	}
+
+	const module = await import(Bun.pathToFileURL(configPath).href);
+
+	const definitions: AnyWorkspaceDefinition[] = [];
+	const clients: AnyWorkspaceClient[] = [];
+	const seenIds = new Set<string>();
+
+	for (const [name, value] of Object.entries(module)) {
+		if (name === 'default' || typeof value !== 'object' || value === null) {
+			continue;
+		}
+
+		const record = value as Record<string, unknown>;
+		if (typeof record.id !== 'string') continue;
+
+		// Duplicate ID check
+		if (seenIds.has(record.id)) {
+			throw new Error(
+				`Duplicate workspace ID "${record.id}" found in ${CONFIG_FILENAME}`,
+			);
+		}
+		seenIds.add(record.id);
+
+		if (isWorkspaceClient(record)) {
+			clients.push(value as AnyWorkspaceClient);
+		} else if (isWorkspaceDefinition(record)) {
+			definitions.push(value as AnyWorkspaceDefinition);
+		}
+	}
+
+	if (definitions.length === 0 && clients.length === 0) {
+		throw new Error(`No workspace definitions found in ${CONFIG_FILENAME}`);
+	}
+
+	return { configDir, definitions, clients };
+}
+
+/** A pre-wired client has `definitions` (set by createWorkspace). */
+function isWorkspaceClient(value: Record<string, unknown>): boolean {
+	return 'id' in value && 'definitions' in value && 'tables' in value;
+}
+
+/** A raw definition has `id` but no `definitions` property. */
+function isWorkspaceDefinition(value: Record<string, unknown>): boolean {
+	return 'id' in value && !('definitions' in value);
+}

--- a/apps/runner/tsconfig.json
+++ b/apps/runner/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"lib": ["ESNext", "DOM"],
+		"target": "ESNext"
+	},
+	"include": ["src/**/*"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -190,6 +190,18 @@
         "wrangler": "catalog:",
       },
     },
+    "apps/runner": {
+      "name": "@epicenter/runner",
+      "version": "0.0.1",
+      "dependencies": {
+        "@epicenter/workspace": "workspace:*",
+        "yjs": "catalog:",
+      },
+      "devDependencies": {
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "apps/tab-manager": {
       "name": "@epicenter/tab-manager",
       "version": "0.0.1",
@@ -782,6 +794,8 @@
     "@epicenter/landing": ["@epicenter/landing@workspace:apps/landing"],
 
     "@epicenter/posthog-reverse-proxy": ["@epicenter/posthog-reverse-proxy@workspace:apps/posthog-reverse-proxy"],
+
+    "@epicenter/runner": ["@epicenter/runner@workspace:apps/runner"],
 
     "@epicenter/svelte": ["@epicenter/svelte@workspace:packages/svelte-utils"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
       "dependencies": {
         "@better-auth/drizzle-adapter": "catalog:",
         "@better-auth/oauth-provider": "catalog:",
+        "@epicenter/constants": "workspace:*",
         "@epicenter/sync": "workspace:*",
         "@hono/standard-validator": "catalog:",
         "@tanstack/ai": "catalog:",
@@ -32,7 +33,6 @@
         "hono-openapi": "catalog:",
         "lib0": "catalog:",
         "pg": "^8.20.0",
-        "postgres": "^3.4.8",
         "wellcrafted": "catalog:",
         "y-protocols": "catalog:",
         "yjs": "catalog:",

--- a/docs/articles/repeated-first-arg-is-a-factory-waiting-to-happen.md
+++ b/docs/articles/repeated-first-arg-is-a-factory-waiting-to-happen.md
@@ -1,0 +1,85 @@
+# Repeated First Argument Is a Factory Waiting to Happen
+
+When two sibling functions share the same first argument, they're telling you they belong together. The repeated parameter is a dependency that should be closed over once, not threaded through every call.
+
+```typescript
+// ⚠️ Both functions take `serverUrl` as their first argument
+async function requestDeviceCode(serverUrl: string) {
+	return post(`${serverUrl}/auth/device/code`, { client_id: CLIENT_ID });
+}
+
+async function pollDeviceToken(serverUrl: string, deviceCode: string) {
+	return post(`${serverUrl}/auth/device/token`, {
+		grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+		device_code: deviceCode,
+		client_id: CLIENT_ID,
+	});
+}
+```
+
+The call site repeats `serverUrl` on every invocation:
+
+```typescript
+const codeData = await requestDeviceCode(serverUrl);
+// ...
+const tokenData = await pollDeviceToken(serverUrl, deviceCode);
+```
+
+`serverUrl` is the same value both times. It's not method-specific—it's the shared context these functions operate in.
+
+## The fix: close over the shared dependency
+
+Wrap the sibling functions in a factory that takes the shared argument once. The private helper (`post`) moves inside too—it was already coupled to the same server.
+
+```typescript
+function createServerApi(serverUrl: string) {
+	// Private: only the factory's methods use this
+	async function post(path: string, body: Record<string, string>) {
+		const res = await fetch(`${serverUrl}${path}`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(body),
+		});
+		return res.json() as Promise<Record<string, unknown>>;
+	}
+
+	return {
+		requestDeviceCode() {
+			return post('/auth/device/code', { client_id: CLIENT_ID });
+		},
+
+		pollDeviceToken(deviceCode: string) {
+			return post('/auth/device/token', {
+				grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+				device_code: deviceCode,
+				client_id: CLIENT_ID,
+			});
+		},
+	};
+}
+```
+
+The call site reads like named RPC calls on a bound client:
+
+```typescript
+const api = createServerApi(serverUrl);
+const codeData = await api.requestDeviceCode();
+// ...
+const tokenData = await api.pollDeviceToken(deviceCode);
+```
+
+`serverUrl` appears once. Each method's signature now contains only what varies per call.
+
+## How to spot this
+
+The code smell is mechanical: scan your standalone functions for a shared first parameter. When two or more functions take the same first argument—a URL, a database client, an SDK instance—they're siblings that belong in a factory.
+
+| Smell | Fix |
+|---|---|
+| `fn1(db, ...)` and `fn2(db, ...)` | `createService(db)` → `{ fn1(...), fn2(...) }` |
+| `fn1(serverUrl, ...)` and `fn2(serverUrl, ...)` | `createApi(serverUrl)` → `{ fn1(...), fn2(...) }` |
+| `fn1(doc, ...)` and `fn2(doc, ...)` | `createStore(doc)` → `{ fn1(...), fn2(...) }` |
+
+The shared parameter becomes the factory's single argument. Any helper that was also using that parameter (`post` in the example above) moves inside the factory body as a private function.
+
+This is a special case of the broader [Stop Passing Clients as Arguments](./stop-passing-clients-as-arguments.md) principle—but the trigger is even more obvious. You don't need to think about "is this a client?" Just look for the repeated first argument.

--- a/specs/20260312T211500-headless-workspace-runner.md
+++ b/specs/20260312T211500-headless-workspace-runner.md
@@ -224,6 +224,144 @@ Running `bun run apps/runner -- .` in that folder creates two workspace clients,
 - [ ] **5.2** Verify the runner loads and runs it successfully
 - [ ] **5.3** Decide: keep `apps/tab-manager-markdown/` as a reference, or remove it entirely
 
+### Phase 6: Device Code Auth (RFC 8628)
+
+The runner needs authenticated sync against remote servers (e.g. `api.epicenter.so`). The server already has `bearer()` and `jwt()` plugins, and the auth guard supports `?token=` on WebSocket upgrades. What's missing is a way for the headless runner to obtain a token without a browser.
+
+Better Auth has a first-party `deviceAuthorization` plugin implementing RFC 8628 (OAuth 2.0 Device Authorization Grant)—the same flow used by `gh auth login`, `wrangler login`, and every serious CLI tool.
+
+```
+Runner                           Server                          User's Browser
+  │                                │                                │
+  ├─POST /auth/device/code────────►│                                │
+  │  { client_id }                 │                                │
+  │◄───────────────────────────────│                                │
+  │  { device_code, user_code,     │                                │
+  │    verification_uri }          │                                │
+  │                                │                                │
+  │  "Visit api.epicenter.so/device │                                │
+  │   and enter code: ABCD-1234"   │                                │
+  │                                │                                │
+  │                                │◄──── User visits /device ──────┤
+  │                                │◄──── Enters code, approves ────┤
+  │                                │                                │
+  ├─POST /auth/device/token───────►│  (polling)                     │
+  │  { device_code, client_id }    │                                │
+  │◄───────────────────────────────│                                │
+  │  { access_token, expires_in }  │                                │
+  │                                │                                │
+  │  Store token → .epicenter/auth │                                │
+  │  Use for WebSocket sync        │                                │
+```
+
+#### 6.1 — Server: Add `deviceAuthorization` plugin
+
+Surgical change to `apps/api/src/app.ts`:
+
+```typescript
+import { deviceAuthorization } from 'better-auth/plugins';
+
+plugins: [
+  bearer(),
+  jwt(),
+  deviceAuthorization({
+    verificationUri: '/device',
+    expiresIn: 600,  // 10 min to complete flow
+    interval: 5,     // poll every 5s
+  }),
+  oauthProvider({ ... }),
+]
+```
+
+- [ ] **6.1.1** Add `deviceAuthorization` plugin to `createAuth` in `apps/api/src/app.ts`
+- [ ] **6.1.2** Register `epicenter-runner` as a trusted client (similar to `epicenter-desktop` and `epicenter-mobile`)
+
+#### 6.2 — Server: Build `/device` verification page
+
+Simple page where the user enters the code displayed by the runner. Can be a minimal HTML form or part of the existing Epicenter web app.
+
+- [ ] **6.2.1** Create verification page at the `verificationUri` path
+- [ ] **6.2.2** Page flow: enter code → approve → confirmation message
+- [ ] **6.2.3** User must be logged in to approve (redirect to sign-in if not)
+
+#### 6.3 — Runner: `login` command
+
+```bash
+bun run apps/runner login                         # login to default server
+bun run apps/runner login --server api.epicenter.so  # login to specific server
+```
+
+Implementation (~50 lines):
+
+```typescript
+// src/auth.ts
+const CLIENT_ID = 'epicenter-runner';
+const TOKEN_PATH = join(configDir, '.epicenter', 'auth', 'token.json');
+
+async function login(serverUrl: string) {
+  // 1. Request device + user codes
+  const { device_code, user_code, verification_uri } = await fetch(
+    `${serverUrl}/auth/device/code`,
+    { method: 'POST', body: JSON.stringify({ client_id: CLIENT_ID }) },
+  ).then(r => r.json());
+
+  console.log(`\nVisit: ${verification_uri}`);
+  console.log(`Enter code: ${user_code}\n`);
+
+  // 2. Poll for token
+  while (true) {
+    await Bun.sleep(5000);
+    const res = await fetch(`${serverUrl}/auth/device/token`, {
+      method: 'POST',
+      body: JSON.stringify({
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code,
+        client_id: CLIENT_ID,
+      }),
+    }).then(r => r.json());
+
+    if (res.error === 'authorization_pending') continue;
+    if (res.error === 'slow_down') { await Bun.sleep(5000); continue; }
+    if (res.error) throw new Error(`Auth failed: ${res.error}`);
+
+    // 3. Store token
+    await Bun.write(TOKEN_PATH, JSON.stringify({
+      access_token: res.access_token,
+      server: serverUrl,
+      created_at: Date.now(),
+    }));
+    console.log('✓ Login successful');
+    return;
+  }
+}
+```
+
+- [ ] **6.3.1** Create `apps/runner/src/auth.ts` with `login()` and `loadToken()` functions
+- [ ] **6.3.2** Token storage at `.epicenter/auth/token.json` relative to config dir
+- [ ] **6.3.3** Add `login` subcommand to entry point arg parsing
+- [ ] **6.3.4** Auto-load stored token on startup (replaces `EPICENTER_TOKEN` env var as primary method, env var remains as override)
+
+#### 6.4 — Runner: Token lifecycle
+
+- [ ] **6.4.1** On startup: check for stored token → use it; check for `EPICENTER_TOKEN` env var → use it; neither → warn "not authenticated, sync will fail against auth-required servers"
+- [ ] **6.4.2** Pass token to `createSyncExtension`'s `getToken` callback
+- [ ] **6.4.3** Handle token expiry gracefully—sync extension reconnects automatically, `getToken` is called on each reconnect so a refreshed token is used if available
+- [ ] **6.4.4** Add `logout` subcommand that deletes stored token
+
+#### Scope boundaries
+
+What's IN scope for Phase 6:
+- `deviceAuthorization` plugin on server
+- `epicenter-runner` trusted client registration
+- Verification page (minimal)
+- Runner `login`/`logout` commands
+- Token storage + auto-loading
+
+What's OUT of scope:
+- Token refresh (Better Auth sessions last 7 days; `login` again when expired)
+- Keychain integration (file storage is fine for v1; tokens are scoped to one server)
+- Multiple server profiles (one token file per config dir is sufficient)
+
 ## Edge Cases
 
 ### Config exports pre-wired clients
@@ -283,6 +421,9 @@ Running `bun run apps/runner -- .` in that folder creates two workspace clients,
 - [ ] Graceful shutdown (SIGINT) flushes all pending persistence writes
 - [ ] `apps/tab-manager-markdown/` functionality reproducible by pointing the runner at the right config
 - [ ] No type errors; `bun run typecheck` passes
+- [ ] `bun run apps/runner login` completes device code flow and stores token
+- [ ] Stored token is automatically used for authenticated WebSocket sync
+- [ ] `bun run apps/runner -- .` against `api.epicenter.so` syncs successfully with stored token
 
 ## References
 
@@ -294,6 +435,10 @@ Running `bun run apps/runner -- .` in that folder creates two workspace clients,
 - `packages/workspace/src/workspace/define-workspace.ts` — `defineWorkspace()` and `WorkspaceDefinition` type
 - `specs/20251225T210000-epicenter-folder-discovery.md` — `.epicenter/` folder conventions
 - `specs/20251030T000000 persistence-factory-pattern.md` — persistence factory pattern (storagePath)
+- Better Auth Device Authorization plugin — `better-auth/plugins/deviceAuthorization`
+- Better Auth Bearer plugin — `better-auth/plugins/bearer` (already active in `apps/api/src/app.ts`)
+- RFC 8628: OAuth 2.0 Device Authorization Grant
+- `apps/api/src/app.ts` lines 73–100 — existing plugin config and trusted clients
 
 ## Review
 

--- a/specs/20260312T211500-headless-workspace-runner.md
+++ b/specs/20260312T211500-headless-workspace-runner.md
@@ -466,3 +466,136 @@ Created `apps/runner/` with 4 files:
 ### Phase 5 (deferred)
 
 Folding `apps/tab-manager-markdown/` into the runner is deferred per instructions. The runner already supports all the functionality needed—a user would create an `epicenter.config.ts` that exports the tab-manager definition and optionally wire custom extensions by exporting a pre-wired client instead.
+
+### Phase 6.3–6.4 Implementation Plan
+
+#### Overview
+
+Two files change. One new file (`auth.ts`), one modified file (`index.ts`). Total ~80 lines new code.
+
+#### File 1: `apps/runner/src/auth.ts` (new, ~55 lines)
+
+Three exported functions, one module-level constant, one type.
+
+```typescript
+const CLIENT_ID = 'epicenter-runner';
+
+type StoredToken = {
+  access_token: string;
+  server: string;
+  created_at: number;
+  expires_in: number;
+};
+```
+
+**`login(serverUrl: string, configDir: string): Promise<void>`**
+
+Device code flow (RFC 8628):
+1. POST `{serverUrl}/auth/device/code` with `{ client_id: CLIENT_ID }`
+2. Print `verification_uri_complete` and `user_code` to console
+3. Poll POST `{serverUrl}/auth/device/token` with `{ grant_type: 'urn:ietf:params:oauth:grant-type:device_code', device_code, client_id: CLIENT_ID }`
+4. Handle poll responses:
+   - `authorization_pending` → continue polling
+   - `slow_down` → double the interval, continue
+   - `expired_token` → throw, tell user to retry
+   - `access_denied` → throw, user denied
+   - Success → write token to disk
+5. `mkdir` the auth directory with `recursive: true`
+6. `Bun.write` the token as `StoredToken` JSON to `{configDir}/.epicenter/auth/token.json`
+
+Control flow: while(true) loop with early returns on terminal errors. Uses `Bun.sleep()` for polling interval.
+
+**`logout(configDir: string): Promise<void>`**
+
+Delete `{configDir}/.epicenter/auth/token.json` via `unlink`. No-op if file doesn't exist (catch and ignore ENOENT).
+
+**`loadToken(configDir: string): Promise<string | undefined>`**
+
+Token resolution order:
+1. `EPICENTER_TOKEN` env var → return immediately (override)
+2. Read `{configDir}/.epicenter/auth/token.json` → return `access_token` field
+3. Neither exists → return `undefined`
+
+This function is called once on startup. The `getToken` callback passed to `createSyncExtension` calls `loadToken` each time, so a token refreshed by running `login` in another terminal is picked up on the next WebSocket reconnect.
+
+#### File 2: `apps/runner/src/index.ts` (modify, ~25 lines changed)
+
+Insert subcommand parsing before the existing config-loading flow.
+
+**Arg parsing changes:**
+
+Current: `const targetDir = process.argv[2] ?? process.cwd();`
+
+New: parse `process.argv.slice(2)` — first non-flag arg is either a subcommand (`login`, `logout`) or the target dir.
+
+```
+bun run apps/runner login --server https://api.epicenter.so [dir]
+bun run apps/runner logout [dir]
+bun run apps/runner -- [dir]        ← existing flow, unchanged
+```
+
+**Subcommand handling (switch statement):**
+
+- `login`: extract `--server` flag value (required), resolve config dir from remaining positional arg or cwd, call `login()`, exit
+- `logout`: resolve config dir from positional arg or cwd, call `logout()`, exit
+- default: treat first arg as target dir (existing behavior)
+
+**Token integration in normal startup:**
+
+Replace the current static env-var read:
+```typescript
+// Before
+const token = process.env.EPICENTER_TOKEN;
+...(token && { getToken: async () => token })
+
+// After
+import { loadToken } from './auth';
+getToken: async () => loadToken(configDir),
+```
+
+The `getToken` callback returns `string | undefined`. The sync extension already handles `undefined` (no token → unauthenticated connection). Passing `loadToken` as a callback (not a captured value) means each reconnect re-reads from disk.
+
+**Startup log update:**
+
+```typescript
+// Before
+console.log(`  Auth: ${token ? 'token provided' : 'none (open mode)'}`);
+
+// After — resolve token once for logging, but getToken callback re-reads
+const initialToken = await loadToken(configDir);
+console.log(`  Auth: ${initialToken ? 'token loaded' : 'none (open mode)'}`);
+```
+
+#### Execution checklist
+
+- [x] **6.3.1** Create `apps/runner/src/auth.ts` with `login()`, `logout()`, and `loadToken()`
+- [x] **6.3.2** Token storage at `.epicenter/auth/token.json` relative to config dir
+- [x] **6.3.3** Add `login` and `logout` subcommands to `index.ts` arg parsing
+- [x] **6.3.4** Replace static env-var token with `loadToken()` callback in `createSyncExtension`
+- [x] **6.4.1** Startup token resolution: env var override → stored file → undefined with warning
+- [x] **6.4.2** Log authentication state on startup
+- [x] **6.4.3** `getToken` callback re-reads from disk on each reconnect (not cached)
+- [x] **6.4.4** Typecheck passes: `bun run typecheck` in `apps/runner`
+
+#### API contract reference (from Better Auth source)
+
+**POST `/auth/device/code`**
+- Request: `{ client_id: string, scope?: string }`
+- Response: `{ device_code, user_code, verification_uri, verification_uri_complete, expires_in, interval }`
+- Errors: `{ error: 'invalid_request' | 'invalid_client', error_description }`
+
+**POST `/auth/device/token`**
+- Request: `{ grant_type: 'urn:ietf:params:oauth:grant-type:device_code', device_code: string, client_id: string }`
+- Response: `{ access_token, token_type: 'Bearer', expires_in, scope }`
+- Errors: `{ error: 'authorization_pending' | 'slow_down' | 'expired_token' | 'access_denied' | 'invalid_grant', error_description }`
+
+#### Design decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Token scope | Per-project (config dir) | Different projects may connect to different servers |
+| `login` dir resolution | Optional positional arg, default CWD | Matches existing runner UX for target dir |
+| `getToken` caching | No cache (re-read on each call) | Reconnect picks up fresh token if `login` ran in another terminal |
+| Env var precedence | `EPICENTER_TOKEN` overrides stored file | Escape hatch for CI/scripts; matches existing behavior |
+| Polling backoff | Use server-provided `interval`, double on `slow_down` | Per RFC 8628 §3.5 |
+| Arg parsing | Manual (no library) | Only 2 subcommands + 1 flag; adding a dep is overkill |

--- a/specs/20260312T211500-headless-workspace-runner.md
+++ b/specs/20260312T211500-headless-workspace-runner.md
@@ -1,0 +1,323 @@
+# Headless Workspace Runner
+
+**Date**: 2026-03-12
+**Status**: Draft
+
+## Overview
+
+A new `apps/runner/` app that loads `epicenter.config.ts` from any project folder, auto-wires persistence and sync extensions, and stays alive as a headless workspace client connected to the Epicenter server.
+
+## Motivation
+
+### Current State
+
+`apps/tab-manager-markdown/` is a hardcoded headless client for one specific workspace:
+
+```typescript
+// apps/tab-manager-markdown/src/index.ts
+import { definition } from '@epicenter/tab-manager/workspace';
+import { createWorkspace } from '@epicenter/workspace';
+import { createSyncExtension } from '@epicenter/workspace/extensions/sync';
+import { createMarkdownPersistenceExtension } from './markdown-persistence-extension';
+
+const client = createWorkspace(definition)
+  .withExtension('persistence', createMarkdownPersistenceExtension({
+    outputDir: './markdown/devices',
+    debounceMs: 1000,
+  }))
+  .withExtension('sync', createSyncExtension({
+    url: (id) => `ws://localhost:3913/workspaces/${id}`,
+  }));
+
+await client.whenReady;
+// ... SIGINT handler
+```
+
+Every workspace that needs headless operation requires a new `apps/` entry with duplicate extension wiring. The "load workspace, wire extensions, keep alive" pattern is generic but each instance is bespoke.
+
+This creates problems:
+
+1. **No reusable runner**: Each headless use case requires a new app with duplicate extension wiring
+2. **Users write boilerplate**: Understanding the extension API shouldn't be required to run a workspace headlessly
+3. **tab-manager-markdown is too specific**: The only tab-manager-specific code is the markdown serializer; the runner pattern is completely generic
+
+### Desired State
+
+```bash
+cd my-project/
+bun run apps/runner -- .
+# → Loads epicenter.config.ts from current directory
+# → Creates workspace clients with persistence + sync
+# → Stays alive, syncs with Epicenter server
+```
+
+The user writes only `defineWorkspace()` in their config. Zero extension wiring.
+
+## Research Findings
+
+### Existing Building Blocks
+
+Every piece needed already exists in the codebase. The runner is pure composition.
+
+| Component | Location | What it does |
+|---|---|---|
+| Config loading | `packages/cli/src/discovery.ts` | Loads `epicenter.config.ts`, validates exports, detects ambiguous configs |
+| SQLite persistence | `packages/workspace/src/extensions/sync/desktop.ts` | Append-only update log via `bun:sqlite`, compaction on startup/shutdown |
+| Sync extension | `packages/workspace/src/extensions/sync/` | WebSocket connection to Epicenter server |
+| Workspace creation | `packages/workspace/src/workspace/create-workspace.ts` | `createWorkspace(def).withExtension(...)` chaining |
+| Tab manager markdown | `apps/tab-manager-markdown/src/index.ts` | Manual extension wiring (the pattern to generalize) |
+
+### Config Export Convention
+
+The CLI currently loads **pre-wired clients** from config files:
+
+```typescript
+// What CLI expects (packages/cli/src/discovery.ts)
+function isWorkspaceClient(value: unknown): value is AnyWorkspaceClient {
+  return (
+    typeof value === 'object' && value !== null &&
+    'id' in value && 'tables' in value && 'definitions' in value &&
+    typeof (value as Record<string, unknown>).id === 'string'
+  );
+}
+```
+
+The runner needs to load **raw definitions**. A `WorkspaceDefinition` has `id` and `tables` but NOT `definitions` (that property only exists on instantiated clients). This makes detection straightforward:
+
+```typescript
+function isWorkspaceDefinition(value: unknown): boolean {
+  return (
+    typeof value === 'object' && value !== null &&
+    'id' in value && !('definitions' in value) &&
+    typeof (value as Record<string, unknown>).id === 'string'
+  );
+}
+```
+
+The runner can also accept pre-wired clients (detected via `isWorkspaceClient`), in which case it skips extension wiring and just keeps them alive.
+
+### Persistence Format
+
+The codebase already settled on SQLite append-only log (same pattern as the Cloudflare Durable Object sync server):
+
+```sql
+CREATE TABLE updates (id INTEGER PRIMARY KEY AUTOINCREMENT, data BLOB NOT NULL)
+```
+
+Each Y.Doc `updateV2` event is a tiny INSERT. Compaction merges all rows into one via `Y.encodeStateAsUpdateV2` on startup and shutdown. Uses `bun:sqlite`—no external dependencies.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| App location | `apps/runner/` | Separate app with clean boundary from packages |
+| Config file | `epicenter.config.ts` | Existing convention; CLI already uses it |
+| Export format | Named exports of `defineWorkspace()` results | Multiple workspaces via named exports; natural TypeScript |
+| Persistence | SQLite append-log (auto-wired) | Already battle-tested in codebase; `bun:sqlite` is built-in |
+| Sync | WebSocket via `createSyncExtension` (auto-wired) | Existing extension; connects to Epicenter server |
+| `.epicenter/` location | Sibling to `epicenter.config.ts` | Consistent with existing folder discovery spec |
+| Markdown output | Not auto-wired by runner | Markdown is workspace-specific presentation, not generic infra |
+| tab-manager-markdown | Fold into runner | Its config becomes a standard `epicenter.config.ts` |
+| Server URL | `EPICENTER_SERVER_URL` env var, default `ws://localhost:3913` | Configurable without touching code |
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  User's Project Folder                                              │
+│                                                                     │
+│  epicenter.config.ts          ← exports defineWorkspace() results   │
+│  posts/                       ← markdown output (visible to user)   │
+│  .epicenter/                  ← runner creates this (gitignored)    │
+│    └── persistence/                                                 │
+│        └── {workspaceId}.db   ← SQLite append-log                   │
+└──────────────────┬──────────────────────────────────────────────────┘
+                   │
+                   │  bun run apps/runner -- /path/to/project
+                   ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  Runner Process                                                     │
+│                                                                     │
+│  1. Resolve target directory (arg or cwd)                           │
+│  2. Load epicenter.config.ts via dynamic import                     │
+│  3. Collect all defineWorkspace() exports                           │
+│  4. For each definition:                                            │
+│     createWorkspace(definition)                                     │
+│       .withExtension('persistence', filesystemPersistence({         │
+│         filePath: '.epicenter/persistence/{id}.db'                  │
+│       }))                                                           │
+│       .withExtension('sync', createSyncExtension({                  │
+│         url: serverUrl + '/workspaces/{id}'                         │
+│       }))                                                           │
+│  5. await Promise.all(clients.map(c => c.whenReady))                │
+│  6. Log status, keep alive                                          │
+│  7. SIGINT/SIGTERM → destroy all clients (flushes persistence)      │
+└──────────────────┬──────────────────────────────────────────────────┘
+                   │
+                   │  ws://localhost:3913/workspaces/{id}
+                   ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  Epicenter Sync Server (packages/server)                            │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Config file example
+
+```typescript
+// epicenter.config.ts
+import { defineWorkspace, text, ytext, boolean } from '@epicenter/workspace';
+
+export const blog = defineWorkspace({
+  id: 'blog',
+  tables: {
+    posts: {
+      title: text(),
+      content: ytext({ nullable: true }),
+      published: boolean(),
+    },
+  },
+});
+
+export const notes = defineWorkspace({
+  id: 'notes',
+  tables: {
+    entries: {
+      title: text(),
+      body: ytext({ nullable: true }),
+    },
+  },
+});
+```
+
+Running `bun run apps/runner -- .` in that folder creates two workspace clients, each with their own persistence DB and sync connection.
+
+## Implementation Plan
+
+### Phase 1: Scaffold `apps/runner/`
+
+- [x] **1.1** Create `apps/runner/package.json` — dependencies: `@epicenter/workspace`, `yjs`
+- [x] **1.2** Create `apps/runner/tsconfig.json`
+- [x] **1.3** Create `apps/runner/src/index.ts` — entry point with arg parsing and SIGINT handler
+
+### Phase 2: Config loading
+
+- [x] **2.1** Create `apps/runner/src/load-config.ts` — load `epicenter.config.ts` from target dir via `Bun.pathToFileURL` + dynamic import (same approach as `packages/cli/src/discovery.ts`)
+- [x] **2.2** Filter exports: detect `WorkspaceDefinition` (has `id`, lacks `definitions`) and `WorkspaceClient` (has `definitions`)
+- [x] **2.3** Error cases: no config found, no valid exports, duplicate workspace IDs
+
+### Phase 3: Extension wiring
+
+- [x] **3.1** For each `WorkspaceDefinition`: `createWorkspace(def).withExtension('persistence', ...).withExtension('sync', ...)`
+- [x] **3.2** For each pre-wired `WorkspaceClient`: skip wiring, just track for lifecycle
+- [x] **3.3** Persistence path: `.epicenter/persistence/{workspaceId}.db` relative to config dir
+- [x] **3.4** Sync URL: `EPICENTER_SERVER_URL` env var or `ws://localhost:3913`, append `/workspaces/{id}`
+
+### Phase 4: Process lifecycle
+
+- [x] **4.1** `await Promise.all(...)` on all clients' `whenReady`
+- [x] **4.2** Log: workspace count, IDs, server URL, persistence paths
+- [x] **4.3** SIGINT + SIGTERM: call `destroy()` on all clients, then `process.exit(0)`
+
+### Phase 5: Fold `apps/tab-manager-markdown/`
+
+- [ ] **5.1** Create `epicenter.config.ts` for the tab-manager workspace (exports `defineWorkspace(...)` with tab-manager schema)
+- [ ] **5.2** Verify the runner loads and runs it successfully
+- [ ] **5.3** Decide: keep `apps/tab-manager-markdown/` as a reference, or remove it entirely
+
+## Edge Cases
+
+### Config exports pre-wired clients
+
+1. User exports `createWorkspace(...)` result (already has extensions)
+2. Runner detects the `definitions` property → identifies as a client
+3. Skips extension wiring, just tracks for lifecycle management
+
+### Server unreachable
+
+1. Sync extension fails to connect on startup
+2. Persistence still works—offline-first by design
+3. Sync extension reconnects automatically (existing behavior)
+4. Runner stays alive; logs warning
+
+### Multiple workspaces with the same ID
+
+1. Config exports two definitions with identical `id` values
+2. Runner throws before creating any clients: "Duplicate workspace ID 'X' found"
+
+### No `epicenter.config.ts` found
+
+1. Runner checks target directory
+2. Prints: `No epicenter.config.ts found in {dir}`
+
+### Config has no workspace exports
+
+1. File exists but contains no `defineWorkspace()` or `createWorkspace()` exports
+2. Prints: `No workspace definitions found in epicenter.config.ts`
+
+## Open Questions
+
+1. **Should the runner accept a `--dir` flag, a positional arg, or default to cwd?**
+   - `bun run apps/runner -- --dir /path` vs `bun run apps/runner -- /path` vs `bun run apps/runner` (uses cwd)
+   - **Recommendation**: Positional arg with cwd fallback. Simplest UX.
+
+2. **Should the runner watch `epicenter.config.ts` for changes?**
+   - Hot-reload during development would be convenient
+   - Adds complexity; config changes might mean schema changes which need migration logic
+   - **Recommendation**: Defer. Manual restart is fine for v1.
+
+3. **Should the runner support markdown materialization as a built-in?**
+   - Currently markdown is workspace-specific (different serializers per workspace)
+   - A generic "dump all tables to markdown" might be useful
+   - **Recommendation**: Out of scope for v1. Users can wire markdown extensions in the config by exporting pre-wired clients instead of raw definitions.
+
+4. **What happens to `apps/tab-manager-markdown/` after folding?**
+   - Option A: Delete entirely—the runner replaces it
+   - Option B: Keep as a reference/example
+   - **Recommendation**: Delete. The runner + a tab-manager `epicenter.config.ts` fully replaces it.
+
+## Success Criteria
+
+- [ ] `bun run apps/runner -- .` in a folder with `epicenter.config.ts` connects to the Epicenter server
+- [ ] Each workspace's state persists to `.epicenter/persistence/{id}.db`
+- [ ] Multiple workspaces from a single config all run simultaneously
+- [ ] Graceful shutdown (SIGINT) flushes all pending persistence writes
+- [ ] `apps/tab-manager-markdown/` functionality reproducible by pointing the runner at the right config
+- [ ] No type errors; `bun run typecheck` passes
+
+## References
+
+- `apps/tab-manager-markdown/src/index.ts` — pattern to generalize
+- `apps/tab-manager-markdown/src/markdown-persistence-extension.ts` — example custom extension
+- `packages/cli/src/discovery.ts` — config loading logic (detection, error messages)
+- `packages/workspace/src/extensions/sync/desktop.ts` — `filesystemPersistence()` and `persistence()` functions
+- `packages/workspace/src/workspace/create-workspace.ts` — `createWorkspace()` and `.withExtension()` chain
+- `packages/workspace/src/workspace/define-workspace.ts` — `defineWorkspace()` and `WorkspaceDefinition` type
+- `specs/20251225T210000-epicenter-folder-discovery.md` — `.epicenter/` folder conventions
+- `specs/20251030T000000 persistence-factory-pattern.md` — persistence factory pattern (storagePath)
+
+## Review
+
+### Implementation Summary (Phases 1–4)
+
+Created `apps/runner/` with 4 files:
+
+| File | Lines | Purpose |
+|---|---|---|
+| `package.json` | 20 | Deps: `@epicenter/workspace`, `yjs`. Scripts: `dev`, `typecheck` |
+| `tsconfig.json` | 9 | Extends `tsconfig.base.json`, ESNext target |
+| `src/load-config.ts` | ~95 | Dynamic import of `epicenter.config.ts`, duck-type detection of definitions vs clients |
+| `src/index.ts` | ~82 | Entry point: arg parsing → config loading → extension wiring → lifecycle |
+
+**Total new code**: ~175 lines (as predicted by spec's "~100 lines of real code").
+
+### Key decisions made during implementation
+
+1. **`AnyWorkspaceDefinition` type**: Used `WorkspaceDefinition<string, any, any, any>` from the workspace package rather than a manual duck type. Dynamic imports erase generics, so the `any` variance is justified at this boundary—matches the `AnyWorkspaceClient` pattern already in the codebase.
+
+2. **Named exports only**: The loader skips `default` exports and only processes named exports, matching the spec's convention of `export const blog = defineWorkspace(...)`. This avoids ambiguity with configs that might `export default` something unrelated.
+
+3. **Pre-existing type errors**: Two errors in `packages/workspace` (`NumberKeysOf`, `TDocuments` indexing) are pre-existing and unrelated to this change. Verified by running typecheck on `apps/tab-manager-markdown/` which shows the same errors.
+
+### Phase 5 (deferred)
+
+Folding `apps/tab-manager-markdown/` into the runner is deferred per instructions. The runner already supports all the functionality needed—a user would create an `epicenter.config.ts` that exports the tab-manager definition and optionally wire custom extensions by exporting a pre-wired client instead.

--- a/specs/20260312T211500-headless-workspace-runner.md
+++ b/specs/20260312T211500-headless-workspace-runner.md
@@ -273,16 +273,16 @@ plugins: [
 ]
 ```
 
-- [ ] **6.1.1** Add `deviceAuthorization` plugin to `createAuth` in `apps/api/src/app.ts`
-- [ ] **6.1.2** Register `epicenter-runner` as a trusted client (similar to `epicenter-desktop` and `epicenter-mobile`)
+- [x] **6.1.1** Add `deviceAuthorization` plugin to `createAuth` in `apps/api/src/app.ts`
+- [x] **6.1.2** Register `epicenter-runner` as a trusted client (similar to `epicenter-desktop` and `epicenter-mobile`)
 
 #### 6.2 — Server: Build `/device` verification page
 
 Simple page where the user enters the code displayed by the runner. Can be a minimal HTML form or part of the existing Epicenter web app.
 
-- [ ] **6.2.1** Create verification page at the `verificationUri` path
-- [ ] **6.2.2** Page flow: enter code → approve → confirmation message
-- [ ] **6.2.3** User must be logged in to approve (redirect to sign-in if not)
+- [x] **6.2.1** Create verification page at the `verificationUri` path
+- [x] **6.2.2** Page flow: enter code → approve → confirmation message
+- [x] **6.2.3** User must be logged in to approve (redirect to sign-in if not)
 
 #### 6.3 — Runner: `login` command
 


### PR DESCRIPTION
This adds the headless workspace runner and the device-code authorization primitives it needs in `apps/api`.

The later auth-page and CLI consolidation work needs a browserless way to authenticate and stay connected to the hub. Pulling that foundation into its own PR keeps the stack reviewable and lets us land the runner/auth contract before the UI and CLI polish layers on top.

The main changes are straightforward:
- add `apps/runner` as a standalone long-lived client that can load workspace config, wire persistence + sync, and stay connected to the server
- add Better Auth device authorization support in `apps/api`, including the runner OAuth client and the `/device` verification page
- add the `device_code` table and generated migration/spec updates that support the new auth flow

### CLI usage

```bash
bun run apps/runner -- login --server https://api.epicenter.so
bun run apps/runner -- .
bun run apps/runner logout
```

### Why the migration changed during stack rebuild

The original branch generated the device-code migration before `main` picked up its own `0001` migration. Rebuilding this stack on top of current `main` meant the right result was not to keep the old filename—it was to regenerate the migration so it lands cleanly after today's baseline.

That is why this PR uses:

```text
apps/api/drizzle/0002_chubby_captain_america.sql
```

instead of the older `0001_*` migration from the long-lived branch.

### Reviewer guide

Review this as the contract-setting PR in the stack:
1. runner lifecycle and CLI shape
2. API-side device authorization support
3. schema + migration correctness

The stack was rebuilt by cherry-picking the original branch onto current `main`, so a few conflict resolutions intentionally favored today's `main` behavior where that behavior was newer and already correct.