### PR TITLE
feat(skills): add initial skills editor app

### DIFF
--- a/apps/skills/.gitignore
+++ b/apps/skills/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.svelte-kit
+build
+.env
+.env.*
+!.env.example
+.DS_Store

--- a/apps/skills/.npmrc
+++ b/apps/skills/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/apps/skills/package.json
+++ b/apps/skills/package.json
@@ -1,0 +1,41 @@
+{
+	"name": "skills",
+	"private": true,
+	"version": "0.0.1",
+	"type": "module",
+	"scripts": {
+		"dev": "bun --bun vite dev",
+		"build": "bun --bun vite build",
+		"preview": "bun --bun vite preview",
+		"prepare": "svelte-kit sync || echo ''",
+		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
+	},
+	"devDependencies": {
+		"@codemirror/commands": "^6.10.3",
+		"@codemirror/lang-markdown": "^6.5.0",
+		"@codemirror/language": "^6.12.2",
+		"@codemirror/state": "^6.6.0",
+		"@codemirror/view": "^6.40.0",
+		"@epicenter/filesystem": "workspace:*",
+		"@epicenter/ui": "workspace:*",
+		"@epicenter/workspace": "workspace:*",
+		"just-bash": "^2.9.7",
+		"shiki": "^3.7.0",
+		"@sveltejs/adapter-auto": "catalog:",
+		"@sveltejs/kit": "catalog:",
+		"@sveltejs/vite-plugin-svelte": "catalog:",
+		"@tailwindcss/vite": "catalog:",
+		"bun-types": "catalog:",
+		"@lucide/svelte": "catalog:",
+		"svelte": "catalog:",
+		"svelte-check": "catalog:",
+		"svelte-sonner": "catalog:",
+		"tailwindcss": "catalog:",
+		"typescript": "catalog:",
+		"vite": "catalog:",
+		"y-codemirror.next": "^0.3.5",
+		"y-indexeddb": "catalog:",
+		"yjs": "catalog:"
+	},
+	"license": "MIT"
+}

--- a/apps/skills/src/app.css
+++ b/apps/skills/src/app.css
@@ -1,0 +1,1 @@
+@import "@epicenter/ui/app.css";

--- a/apps/skills/src/app.d.ts
+++ b/apps/skills/src/app.d.ts
@@ -1,0 +1,13 @@
+// See https://svelte.dev/docs/kit/types#app.d.ts
+// for information about these interfaces
+declare global {
+	namespace App {
+		// interface Error {}
+		// interface Locals {}
+		// interface PageData {}
+		// interface PageState {}
+		// interface Platform {}
+	}
+}
+
+export {};

--- a/apps/skills/src/app.html
+++ b/apps/skills/src/app.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<title>Skills Editor</title>
+		%sveltekit.head%
+	</head>
+	<body data-sveltekit-preload-data="hover">
+		<div style="display: contents">%sveltekit.body%</div>
+	</body>
+</html>

--- a/apps/skills/src/lib/components/AppShell.svelte
+++ b/apps/skills/src/lib/components/AppShell.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+	import * as Resizable from '@epicenter/ui/resizable';
+	import { ScrollArea } from '@epicenter/ui/scroll-area';
+	import { terminalState } from '$lib/state/terminal-state.svelte';
+	import CommandPalette from './CommandPalette.svelte';
+	import DeleteConfirmation from './dialogs/DeleteConfirmation.svelte';
+	import ContentPanel from './editor/ContentPanel.svelte';
+	import Toolbar from './Toolbar.svelte';
+	import TerminalPanel from './terminal/TerminalPanel.svelte';
+	import FileTree from './tree/FileTree.svelte';
+
+	let terminalRef: ReturnType<typeof TerminalPanel> | undefined = $state();
+	let previousFocus: HTMLElement | null = $state(null);
+
+	// Restore focus when terminal closes (covers both keyboard shortcut and X button).
+	let wasOpen = false;
+	$effect(() => {
+		const isOpen = terminalState.open;
+		if (wasOpen && !isOpen) {
+			previousFocus?.focus();
+			previousFocus = null;
+		}
+		wasOpen = isOpen;
+	});
+</script>
+
+<svelte:window
+	onkeydown={(e) => {
+		if ((e.metaKey || e.ctrlKey) && e.key === '`') {
+			e.preventDefault();
+			if (!terminalState.open) {
+				previousFocus = document.activeElement as HTMLElement | null;
+				terminalState.toggle();
+				requestAnimationFrame(() => terminalRef?.focus());
+			} else {
+				terminalState.toggle();
+			}
+		}
+	}}
+/>
+
+<div class="flex h-screen flex-col">
+	<Toolbar />
+	<Resizable.PaneGroup direction="horizontal" class="flex-1">
+		<Resizable.Pane defaultSize={25} minSize={15} maxSize={50}>
+			<ScrollArea class="h-full">
+				<div class="p-2"><FileTree /></div>
+			</ScrollArea>
+		</Resizable.Pane>
+		<Resizable.Handle withHandle />
+		<Resizable.Pane defaultSize={75}>
+			<Resizable.PaneGroup direction="vertical">
+				<Resizable.Pane
+					defaultSize={terminalState.open ? 70 : 100}
+					minSize={30}
+				>
+					<ContentPanel />
+				</Resizable.Pane>
+				{#if terminalState.open}
+					<Resizable.Handle withHandle />
+					<Resizable.Pane defaultSize={30} minSize={10} maxSize={60}>
+						<TerminalPanel bind:this={terminalRef} />
+					</Resizable.Pane>
+				{/if}
+			</Resizable.PaneGroup>
+		</Resizable.Pane>
+	</Resizable.PaneGroup>
+	<CommandPalette />
+</div>
+
+<DeleteConfirmation />

--- a/apps/skills/src/lib/components/CommandPalette.svelte
+++ b/apps/skills/src/lib/components/CommandPalette.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+	import type { FileId } from '@epicenter/filesystem';
+	import {
+		CommandPalette,
+		type CommandPaletteItem,
+	} from '@epicenter/ui/command-palette';
+	import { fsState } from '$lib/state/fs-state.svelte';
+	import { getFileIcon } from '$lib/utils/file-icons';
+
+	let open = $state(false);
+	let searchQuery = $state('');
+	let debouncedQuery = $state('');
+
+	// ── Collect all files recursively (only when palette is open) ───
+	type FileEntry = { id: FileId; name: string; parentDir: string };
+
+	const allFiles = $derived.by((): FileEntry[] => {
+		if (!open) return [];
+		return fsState.walkTree<FileEntry>((id, row) => {
+			if (row.type === 'file') {
+				const fullPath = fsState.getPathForId(id) ?? '';
+				const lastSlash = fullPath.lastIndexOf('/');
+				const parentDir = lastSlash > 0 ? fullPath.slice(1, lastSlash) : '';
+				return { collect: { id, name: row.name, parentDir }, descend: false };
+			}
+			return { descend: true };
+		});
+	});
+
+	// ── Debounce search input at 150ms ───────────────────────────────
+	$effect(() => {
+		const query = searchQuery;
+		const timer = setTimeout(() => {
+			debouncedQuery = query;
+		}, 150);
+		return () => clearTimeout(timer);
+	});
+
+	// ── Reset search when palette closes ─────────────────────────────
+	$effect(() => {
+		if (!open) {
+			searchQuery = '';
+			debouncedQuery = '';
+		}
+	});
+
+	// ── Filtered results: startsWith first, then includes, cap 50 ───
+	const filteredFiles = $derived.by(() => {
+		const q = debouncedQuery.toLowerCase().trim();
+		if (!q) return allFiles.slice(0, 50);
+
+		const startsWith: FileEntry[] = [];
+		const includes: FileEntry[] = [];
+
+		for (const file of allFiles) {
+			const name = file.name.toLowerCase();
+			if (name.startsWith(q)) {
+				startsWith.push(file);
+			} else if (name.includes(q)) {
+				includes.push(file);
+			}
+			if (startsWith.length + includes.length >= 50) break;
+		}
+
+		return [...startsWith, ...includes].slice(0, 50);
+	});
+
+	// ── Convert filtered files to palette items ─────────────────────
+	const fileItems = $derived<CommandPaletteItem[]>(
+		filteredFiles.map((file) => ({
+			id: file.id,
+			label: file.name,
+			description: file.parentDir || undefined,
+			icon: getFileIcon(file.name),
+			group: 'Files',
+			onSelect: () => fsState.selectFile(file.id),
+		})),
+	);
+</script>
+
+<svelte:window
+	onkeydown={(e) => {
+		if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+			e.preventDefault();
+			open = !open;
+		}
+	}}
+/>
+
+<CommandPalette
+	items={fileItems}
+	bind:open
+	bind:value={searchQuery}
+	shouldFilter={false}
+	placeholder="Search files..."
+	emptyMessage="No files found."
+	title="Search Files"
+	description="Search for a file by name"
+/>

--- a/apps/skills/src/lib/components/Toolbar.svelte
+++ b/apps/skills/src/lib/components/Toolbar.svelte
@@ -1,0 +1,254 @@
+<script lang="ts">
+	import { Button } from '@epicenter/ui/button';
+	import * as Dialog from '@epicenter/ui/dialog';
+	import { Input } from '@epicenter/ui/input';
+	import { Label } from '@epicenter/ui/label';
+	import { Separator } from '@epicenter/ui/separator';
+	import { Spinner } from '@epicenter/ui/spinner';
+	import * as Tooltip from '@epicenter/ui/tooltip';
+	import { toast } from 'svelte-sonner';
+	import { fsState } from '$lib/state/fs-state.svelte';
+	import { createSkillTemplate, validateSkill } from '$lib/types';
+	import { fs, ws } from '$lib/workspace';
+
+	let seeding = $state(false);
+	let newSkillOpen = $state(false);
+	let newSkillName = $state('');
+	let newSkillError = $state('');
+	let searchQuery = $state('');
+	let searchResults = $state<
+		Array<{ id: string; name: string; path: string | null; snippet: string }>
+	>([]);
+	let isSearching = $state(false);
+
+	async function handleCreateSkill() {
+		const name = newSkillName.trim();
+		if (!name) return;
+
+		// Validate the name
+		const errors = validateSkill({
+			name,
+			description: 'TODO—describe when and why to use this skill.',
+		});
+		const nameErrors = errors.filter((e) => e.includes('name'));
+		if (nameErrors.length > 0) {
+			newSkillError = nameErrors[0] ?? 'Invalid name';
+			return;
+		}
+
+		try {
+			await fs.mkdir(`/${name}`);
+			await fs.writeFile(`/${name}/SKILL.md`, createSkillTemplate(name));
+			toast.success(`Created skill: ${name}`);
+			newSkillOpen = false;
+			newSkillName = '';
+			newSkillError = '';
+		} catch (err) {
+			toast.error(
+				err instanceof Error ? err.message : 'Failed to create skill',
+			);
+			console.error(err);
+		}
+	}
+
+	async function handleSearch() {
+		const query = searchQuery.trim();
+		if (!query) {
+			searchResults = [];
+			return;
+		}
+		isSearching = true;
+		try {
+			searchResults = await ws.extensions.sqliteIndex.search(query);
+		} catch (err) {
+			console.error('Search failed:', err);
+			searchResults = [];
+		} finally {
+			isSearching = false;
+		}
+	}
+
+	// Debounced search
+	$effect(() => {
+		const query = searchQuery;
+		const timer = setTimeout(() => {
+			handleSearch();
+		}, 300);
+		return () => clearTimeout(timer);
+	});
+
+	async function loadSampleSkill() {
+		seeding = true;
+		try {
+			await fs.mkdir('/example-skill');
+			await fs.writeFile(
+				'/example-skill/SKILL.md',
+				createSkillTemplate('example-skill'),
+			);
+			await fs.mkdir('/example-skill/references');
+			await fs.writeFile(
+				'/example-skill/references/patterns.md',
+				'# Patterns\n\nReference material for the example skill.\n',
+			);
+			toast.success('Loaded sample skill');
+		} catch (err) {
+			toast.error(
+				err instanceof Error ? err.message : 'Failed to load sample skill',
+			);
+			console.error(err);
+		} finally {
+			seeding = false;
+		}
+	}
+</script>
+
+<Tooltip.Provider>
+	<div class="flex items-center gap-1 border-b px-2 py-1.5">
+		<Dialog.Root bind:open={newSkillOpen}>
+			<Tooltip.Root>
+				<Tooltip.Trigger>
+					{#snippet child({ props })}
+						<Button {...props} variant="ghost" size="sm" onclick={() => (newSkillOpen = true)}>
+							New Skill
+						</Button>
+					{/snippet}
+				</Tooltip.Trigger>
+				<Tooltip.Content>Create a new skill with SKILL.md template</Tooltip.Content>
+			</Tooltip.Root>
+			<Dialog.Content class="max-w-sm">
+				<Dialog.Header>
+					<Dialog.Title>New Skill</Dialog.Title>
+					<Dialog.Description>
+						Creates a skill folder with a SKILL.md template.
+					</Dialog.Description>
+				</Dialog.Header>
+				<div class="space-y-2 py-2">
+					<Label>Skill Name</Label>
+					<Input
+						bind:value={newSkillName}
+						placeholder="my-skill"
+						class="font-mono"
+						onkeydown={(e: KeyboardEvent) => {
+							if (e.key === 'Enter') {
+								e.preventDefault();
+								handleCreateSkill();
+							}
+						}}
+					/>
+					{#if newSkillError}
+						<p class="text-sm text-destructive">{newSkillError}</p>
+					{/if}
+					<p class="text-xs text-muted-foreground">
+						Lowercase, hyphens only (1–64 chars)
+					</p>
+				</div>
+				<Dialog.Footer>
+					<Button variant="outline" onclick={() => (newSkillOpen = false)}
+						>Cancel</Button
+					>
+					<Button onclick={handleCreateSkill} disabled={!newSkillName.trim()}
+						>Create</Button
+					>
+				</Dialog.Footer>
+			</Dialog.Content>
+		</Dialog.Root>
+
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				{#snippet child({ props })}
+					<Button
+						{...props}
+						variant="ghost"
+						size="sm"
+						onclick={() => fsState.startCreate('file')}
+					>
+						New File
+					</Button>
+				{/snippet}
+			</Tooltip.Trigger>
+			<Tooltip.Content
+				>Create a new file in the selected folder</Tooltip.Content
+			>
+		</Tooltip.Root>
+
+		<Separator orientation="vertical" class="mx-1 h-4" />
+
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				{#snippet child({ props })}
+					<Button
+						{...props}
+						variant="ghost"
+						size="sm"
+						onclick={() => {
+							if (fsState.activeFileId) fsState.startRename(fsState.activeFileId);
+						}}
+						disabled={!fsState.activeFileId}
+					>
+						Rename
+					</Button>
+				{/snippet}
+			</Tooltip.Trigger>
+			<Tooltip.Content>Rename selected item</Tooltip.Content>
+		</Tooltip.Root>
+
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				{#snippet child({ props })}
+					<Button
+						{...props}
+						variant="ghost"
+						size="sm"
+						onclick={() => {
+							if (fsState.activeFileId) fsState.openDelete();
+						}}
+						disabled={!fsState.activeFileId}
+					>
+						Delete
+					</Button>
+				{/snippet}
+			</Tooltip.Trigger>
+			<Tooltip.Content>Delete selected item</Tooltip.Content>
+		</Tooltip.Root>
+
+		<Separator orientation="vertical" class="mx-1 h-4" />
+
+		<div class="relative">
+			<Input
+				bind:value={searchQuery}
+				placeholder="Search skills..."
+				class="h-7 w-48 text-xs"
+			/>
+			{#if isSearching}
+				<Spinner
+					class="absolute right-2 top-1/2 size-3 -translate-y-1/2 text-muted-foreground"
+				/>
+			{/if}
+		</div>
+
+		<div class="ml-auto flex items-center gap-1">
+			<Tooltip.Root>
+				<Tooltip.Trigger>
+					{#snippet child({ props })}
+						<Button
+							{...props}
+							variant="ghost"
+							size="sm"
+							onclick={loadSampleSkill}
+							disabled={seeding}
+						>
+							{#if seeding}
+								<Spinner class="size-3.5" />
+							{:else}
+								Load Sample
+							{/if}
+						</Button>
+					{/snippet}
+				</Tooltip.Trigger>
+				<Tooltip.Content
+					>Load a sample skill to explore the editor</Tooltip.Content
+				>
+			</Tooltip.Root>
+		</div>
+	</div>
+</Tooltip.Provider>

--- a/apps/skills/src/lib/components/dialogs/DeleteConfirmation.svelte
+++ b/apps/skills/src/lib/components/dialogs/DeleteConfirmation.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import * as AlertDialog from '@epicenter/ui/alert-dialog';
+	import { Button } from '@epicenter/ui/button';
+	import { fsState } from '$lib/state/fs-state.svelte';
+
+	const nodeName = $derived(fsState.selectedNode?.name ?? 'this item');
+	const nodeType = $derived(fsState.selectedNode?.type ?? 'file');
+
+	async function handleDelete() {
+		if (!fsState.activeFileId) return;
+		await fsState.deleteFile(fsState.activeFileId);
+		fsState.closeDelete();
+	}
+
+	function handleOpenChange(isOpen: boolean) {
+		if (!isOpen) fsState.closeDelete();
+	}
+</script>
+
+<AlertDialog.Root
+	open={fsState.deleteDialogOpen}
+	onOpenChange={handleOpenChange}
+>
+	<AlertDialog.Content>
+		<AlertDialog.Header>
+			<AlertDialog.Title>Delete {nodeName}?</AlertDialog.Title>
+			<AlertDialog.Description>
+				{#if nodeType === 'folder'}
+					This will delete the folder and all its contents. This action cannot
+					be undone.
+				{:else}
+					This will delete the file. This action cannot be undone.
+				{/if}
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+		<AlertDialog.Footer>
+			<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+			<Button variant="destructive" onclick={handleDelete}>Delete</Button>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>

--- a/apps/skills/src/lib/components/editor/CodeMirrorEditor.svelte
+++ b/apps/skills/src/lib/components/editor/CodeMirrorEditor.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	import { defaultKeymap, indentWithTab } from '@codemirror/commands';
+	import { markdown } from '@codemirror/lang-markdown';
+	import {
+		defaultHighlightStyle,
+		syntaxHighlighting,
+	} from '@codemirror/language';
+	import { EditorState } from '@codemirror/state';
+	import {
+		drawSelection,
+		EditorView,
+		keymap,
+		placeholder,
+	} from '@codemirror/view';
+	import { yCollab, yUndoManagerKeymap } from 'y-codemirror.next';
+	import type * as Y from 'yjs';
+
+	let {
+		ytext,
+	}: {
+		ytext: Y.Text;
+	} = $props();
+
+	let container: HTMLDivElement | undefined = $state();
+
+	$effect(() => {
+		if (!container) return;
+
+		const view = new EditorView({
+			state: EditorState.create({
+				doc: ytext.toString(),
+				extensions: [
+					keymap.of([...yUndoManagerKeymap, ...defaultKeymap, indentWithTab]),
+					drawSelection(),
+					EditorView.lineWrapping,
+					syntaxHighlighting(defaultHighlightStyle),
+					markdown(),
+					yCollab(ytext, null),
+					placeholder('Empty file'),
+					EditorView.theme({
+						'&': {
+							height: '100%',
+							fontSize: '14px',
+						},
+						'.cm-scroller': {
+							fontFamily:
+								'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
+							padding: '1rem',
+							overflow: 'auto',
+						},
+						'.cm-content': {
+							caretColor: 'var(--foreground, currentColor)',
+						},
+						'.cm-focused': {
+							outline: 'none',
+						},
+						'.cm-gutters': {
+							display: 'none',
+						},
+						'.cm-activeLine': {
+							backgroundColor: 'transparent',
+						},
+					}),
+				],
+			}),
+			parent: container,
+		});
+
+		return () => view.destroy();
+	});
+</script>
+
+<div
+	class="h-full w-full overflow-hidden bg-transparent"
+	bind:this={container}
+></div>

--- a/apps/skills/src/lib/components/editor/ContentEditor.svelte
+++ b/apps/skills/src/lib/components/editor/ContentEditor.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import type { FileId } from '@epicenter/filesystem';
+	import { Spinner } from '@epicenter/ui/spinner';
+	import type { DocumentHandle } from '@epicenter/workspace';
+	import { fsState } from '$lib/state/fs-state.svelte';
+	import { ws } from '$lib/workspace';
+	import CodeMirrorEditor from './CodeMirrorEditor.svelte';
+
+	let {
+		fileId,
+	}: {
+		fileId: FileId;
+	} = $props();
+
+	let handle = $state<DocumentHandle | null>(null);
+
+	$effect(() => {
+		const id = fileId;
+		handle = null;
+		ws.documents.files.content.open(id).then((h) => {
+			// Guard against race condition—if file changed while loading, ignore
+			if (fsState.activeFileId !== id) return;
+			handle = h;
+		});
+	});
+</script>
+
+{#if handle}
+	<CodeMirrorEditor ytext={handle.asText()} />
+{:else}
+	<div class="flex h-full items-center justify-center">
+		<Spinner class="size-5 text-muted-foreground" />
+	</div>
+{/if}

--- a/apps/skills/src/lib/components/editor/ContentPanel.svelte
+++ b/apps/skills/src/lib/components/editor/ContentPanel.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import * as Empty from '@epicenter/ui/empty';
+	import { ScrollArea } from '@epicenter/ui/scroll-area';
+	import { fsState } from '$lib/state/fs-state.svelte';
+	import ContentEditor from './ContentEditor.svelte';
+	import PathBreadcrumb from './PathBreadcrumb.svelte';
+	import SkillMetadataForm from './SkillMetadataForm.svelte';
+	import TabBar from './TabBar.svelte';
+
+	const isSkillMd = $derived(fsState.selectedNode?.name === 'SKILL.md');
+</script>
+
+<div class="flex h-full flex-col">
+	<TabBar />
+	{#if fsState.activeFileId && fsState.selectedNode}
+		<div class="flex items-center border-b px-4 py-2"><PathBreadcrumb /></div>
+		{#if fsState.selectedNode.type === 'folder'}
+			<Empty.Root class="flex-1 border-0">
+				<Empty.Header>
+					<Empty.Title>Folder selected</Empty.Title>
+					<Empty.Description
+						>Select a file to view its contents</Empty.Description
+					>
+				</Empty.Header>
+			</Empty.Root>
+		{:else if isSkillMd}
+			<ScrollArea class="flex-1">
+				{#key fsState.activeFileId}
+					<SkillMetadataForm fileId={fsState.activeFileId} />
+				{/key}
+				<div class="h-[50vh] min-h-64">
+					{#key fsState.activeFileId}
+						<ContentEditor fileId={fsState.activeFileId} />
+					{/key}
+				</div>
+			</ScrollArea>
+		{:else}
+			<div class="flex-1 overflow-hidden">
+				{#key fsState.activeFileId}
+					<ContentEditor fileId={fsState.activeFileId} />
+				{/key}
+			</div>
+		{/if}
+	{:else}
+		<Empty.Root class="h-full border-0">
+			<Empty.Header>
+				<Empty.Title>No file selected</Empty.Title>
+				<Empty.Description
+					>Select a skill from the tree to edit its contents</Empty.Description
+				>
+			</Empty.Header>
+		</Empty.Root>
+	{/if}
+</div>

--- a/apps/skills/src/lib/components/editor/PathBreadcrumb.svelte
+++ b/apps/skills/src/lib/components/editor/PathBreadcrumb.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import * as Breadcrumb from '@epicenter/ui/breadcrumb';
+	import { fsState } from '$lib/state/fs-state.svelte';
+
+	const pathSegments = $derived.by(() => {
+		const path = fsState.selectedPath;
+		if (!path) return [];
+		return path.split('/').filter(Boolean);
+	});
+</script>
+
+{#if pathSegments.length > 0}
+	<Breadcrumb.Root>
+		<Breadcrumb.List>
+			<Breadcrumb.Item> <Breadcrumb.Link>/</Breadcrumb.Link> </Breadcrumb.Item>
+			{#each pathSegments as segment, i (i)}
+				<Breadcrumb.Separator />
+				<Breadcrumb.Item>
+					{#if i === pathSegments.length - 1}
+						<Breadcrumb.Page>{segment}</Breadcrumb.Page>
+					{:else}
+						<Breadcrumb.Link>{segment}</Breadcrumb.Link>
+					{/if}
+				</Breadcrumb.Item>
+			{/each}
+		</Breadcrumb.List>
+	</Breadcrumb.Root>
+{/if}

--- a/apps/skills/src/lib/components/editor/SkillMetadataForm.svelte
+++ b/apps/skills/src/lib/components/editor/SkillMetadataForm.svelte
@@ -1,0 +1,200 @@
+<script lang="ts">
+	import type { FileId } from '@epicenter/filesystem';
+	import {
+		parseFrontmatter,
+		serializeMarkdownWithFrontmatter,
+	} from '@epicenter/filesystem';
+	import { Badge } from '@epicenter/ui/badge';
+	import { Button } from '@epicenter/ui/button';
+	import * as Field from '@epicenter/ui/field';
+	import { Input } from '@epicenter/ui/input';
+	import { Textarea } from '@epicenter/ui/textarea';
+	import { toast } from 'svelte-sonner';
+	import { fsState } from '$lib/state/fs-state.svelte';
+	import { type SkillFrontmatter, validateSkill } from '$lib/types';
+	import { fs } from '$lib/workspace';
+
+	let {
+		fileId,
+	}: {
+		fileId: FileId;
+	} = $props();
+
+	let name = $state('');
+	let description = $state('');
+	let license = $state('');
+	let compatibility = $state('');
+	let originalName = $state('');
+	let errors = $state<string[]>([]);
+	let isDirty = $state(false);
+
+	// Load frontmatter when fileId changes
+	$effect(() => {
+		const id = fileId;
+		loadFrontmatter(id);
+	});
+
+	async function loadFrontmatter(id: FileId) {
+		const content = await fsState.readContent(id);
+		if (!content) return;
+
+		const parsed = parseFrontmatter(content);
+		const fm = parsed.frontmatter as SkillFrontmatter;
+
+		name = fm.name ?? '';
+		description = fm.description ?? '';
+		license = fm.license ?? '';
+		compatibility = fm.compatibility ?? '';
+		originalName = fm.name ?? '';
+		errors = [];
+		isDirty = false;
+	}
+
+	function markDirty() {
+		isDirty = true;
+		// Live validation
+		errors = validateSkill({ name, description, license, compatibility });
+	}
+
+	async function handleSave() {
+		const frontmatter: SkillFrontmatter = { name, description };
+		if (license) frontmatter.license = license;
+		if (compatibility) frontmatter.compatibility = compatibility;
+
+		const validationErrors = validateSkill(frontmatter);
+		if (validationErrors.length > 0) {
+			errors = validationErrors;
+			toast.error('Fix validation errors before saving');
+			return;
+		}
+
+		// Read current content to preserve body
+		const content = await fsState.readContent(fileId);
+		if (!content) return;
+
+		const parsed = parseFrontmatter(content);
+
+		// Merge frontmatter—preserve any extra fields from the original
+		const mergedFrontmatter = {
+			...(parsed.frontmatter as Record<string, unknown>),
+			name,
+			description,
+			...(license ? { license } : {}),
+			...(compatibility ? { compatibility } : {}),
+		};
+
+		const newContent = serializeMarkdownWithFrontmatter(
+			mergedFrontmatter,
+			parsed.body,
+		);
+		await fsState.writeContent(fileId, newContent);
+
+		// Enforce folder name = name field
+		if (name !== originalName && originalName) {
+			const currentPath = fsState.selectedPath;
+			if (currentPath) {
+				// Get the skill folder path (parent of SKILL.md)
+				const parentPath = currentPath.substring(
+					0,
+					currentPath.lastIndexOf('/'),
+				);
+				if (parentPath) {
+					const newParentPath =
+						parentPath.substring(0, parentPath.lastIndexOf('/') + 1) + name;
+					try {
+						await fs.mv(parentPath, newParentPath);
+						toast.success(`Renamed skill folder to ${name}`);
+					} catch (err) {
+						toast.error('Failed to rename skill folder');
+						console.error(err);
+					}
+				}
+			}
+			originalName = name;
+		}
+
+		isDirty = false;
+		toast.success('Skill metadata saved');
+	}
+
+	const isValid = $derived(errors.length === 0);
+</script>
+
+<div class="space-y-4 border-b p-4">
+	<div class="flex items-center justify-between">
+		<h3 class="text-sm font-medium text-muted-foreground">Skill Metadata</h3>
+		<div class="flex items-center gap-2">
+			{#if errors.length > 0}
+				<Badge variant="destructive"
+					>{errors.length}
+					error{errors.length > 1 ? 's' : ''}</Badge
+				>
+			{:else if isDirty}
+				<Badge variant="secondary">Unsaved</Badge>
+			{/if}
+			<Button size="sm" onclick={handleSave} disabled={!isDirty || !isValid}>
+				Save Metadata
+			</Button>
+		</div>
+	</div>
+
+	<div class="grid grid-cols-2 gap-4">
+		<Field.Field>
+			<Field.Label>Name</Field.Label>
+			<Field.Content>
+				<Input
+					bind:value={name}
+					oninput={markDirty}
+					placeholder="my-skill"
+					class="font-mono text-sm"
+				/>
+			</Field.Content>
+			<Field.Description
+				>Lowercase, hyphens only (1–64 chars)</Field.Description
+			>
+		</Field.Field>
+
+		<Field.Field>
+			<Field.Label>License</Field.Label>
+			<Field.Content>
+				<Input bind:value={license} oninput={markDirty} placeholder="MIT" />
+			</Field.Content>
+		</Field.Field>
+	</div>
+
+	<Field.Field>
+		<Field.Label>Description</Field.Label>
+		<Field.Content>
+			<Textarea
+				bind:value={description}
+				oninput={markDirty}
+				placeholder="Describe when and why to use this skill..."
+				rows={2}
+				class="resize-none"
+			/>
+		</Field.Content>
+		<Field.Description>{description.length}/1024 characters</Field.Description>
+	</Field.Field>
+
+	<Field.Field>
+		<Field.Label>Compatibility</Field.Label>
+		<Field.Content>
+			<Input
+				bind:value={compatibility}
+				oninput={markDirty}
+				placeholder="Claude Code, OpenCode, Cursor..."
+			/>
+		</Field.Content>
+		<Field.Description
+			>Which agents/tools this skill targets (optional, ≤500 chars)</Field.Description
+		>
+	</Field.Field>
+
+	{#if errors.length > 0}
+		<div class="space-y-1">
+			{#each errors as error}
+				<Field.Error>{error}</Field.Error>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/apps/skills/src/lib/components/editor/TabBar.svelte
+++ b/apps/skills/src/lib/components/editor/TabBar.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import type { FileId } from '@epicenter/filesystem';
+	import { Button } from '@epicenter/ui/button';
+	import * as Tabs from '@epicenter/ui/tabs';
+	import XIcon from '@lucide/svelte/icons/x';
+	import { fsState } from '$lib/state/fs-state.svelte';
+
+	const hasOpenFiles = $derived(fsState.openFileIds.length > 0);
+</script>
+
+{#if hasOpenFiles}
+	<Tabs.Root
+		value={fsState.activeFileId ?? ''}
+		onValueChange={(value) => fsState.selectFile(value as FileId)}
+		class="w-full"
+	>
+		<Tabs.List
+			class="w-full justify-start overflow-x-auto rounded-none border-b bg-transparent p-0"
+		>
+			{#each fsState.openFileIds as fileId (fileId)}
+				{@const row = fsState.getRow(fileId)}
+				{#if row}
+					<Tabs.Trigger
+						value={fileId}
+						class="relative flex-none rounded-none border-0 text-muted-foreground hover:bg-accent hover:text-accent-foreground data-[state=active]:bg-muted data-[state=active]:text-foreground data-[state=active]:shadow-none"
+						onauxclick={(e) => {
+							if (e.button === 1) {
+								e.preventDefault();
+								fsState.closeFile(fileId);
+							}
+						}}
+					>
+						<span class="mr-4">{row.name}</span>
+						<Button
+							variant="ghost"
+							size="icon-xs"
+							class="absolute right-1 top-1/2 -translate-y-1/2 opacity-50 hover:opacity-100"
+							onclick={(e: MouseEvent) => {
+								e.stopPropagation();
+								e.preventDefault();
+								fsState.closeFile(fileId);
+							}}
+							aria-label="Close {row.name}"
+						>
+							<XIcon aria-hidden="true" class="size-3" />
+						</Button>
+					</Tabs.Trigger>
+				{/if}
+			{/each}
+		</Tabs.List>
+	</Tabs.Root>
+{/if}

--- a/apps/skills/src/lib/components/terminal/TerminalInput.svelte
+++ b/apps/skills/src/lib/components/terminal/TerminalInput.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import { terminalState } from '$lib/state/terminal-state.svelte';
+
+	let value = $state('');
+	let inputEl: HTMLInputElement | undefined = $state();
+
+	async function handleSubmit() {
+		const cmd = value;
+		value = '';
+		await terminalState.exec(cmd);
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter') {
+			e.preventDefault();
+			handleSubmit();
+		} else if (e.key === 'ArrowUp') {
+			e.preventDefault();
+			const prev = terminalState.previousCommand();
+			if (prev !== undefined) value = prev;
+		} else if (e.key === 'ArrowDown') {
+			e.preventDefault();
+			const next = terminalState.nextCommand();
+			value = next ?? '';
+		}
+	}
+
+	/**
+	 * Focus the input element. Called by TerminalPanel when the
+	 * terminal opens via keyboard shortcut.
+	 */
+	export function focus() {
+		inputEl?.focus();
+	}
+</script>
+
+<div class="flex items-center border-t px-3 py-2">
+	<span class="mr-2 text-green-500">$</span>
+	<input
+		bind:this={inputEl}
+		bind:value
+		onkeydown={handleKeydown}
+		disabled={terminalState.running}
+		placeholder={terminalState.running ? 'Running...' : 'Type a command...'}
+		aria-label="Terminal command input"
+		class="flex-1 bg-transparent outline-none placeholder:text-muted-foreground"
+		spellcheck="false"
+		autocomplete="off"
+	>
+</div>

--- a/apps/skills/src/lib/components/terminal/TerminalOutput.svelte
+++ b/apps/skills/src/lib/components/terminal/TerminalOutput.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import { Badge } from '@epicenter/ui/badge';
+
+	type TerminalEntry =
+		| { type: 'input'; command: string }
+		| { type: 'output'; stdout: string; stderr: string; exitCode: number };
+
+	let { entry }: { entry: TerminalEntry } = $props();
+</script>
+
+{#if entry.type === 'input'}
+	<div class="text-muted-foreground">
+		<span class="text-green-500">$</span>
+		{entry.command}
+	</div>
+{:else}
+	{#if entry.stdout}
+		<pre class="whitespace-pre-wrap text-foreground">{entry.stdout}</pre>
+	{/if}
+	{#if entry.stderr}
+		<pre
+			class="whitespace-pre-wrap text-destructive"
+		><span class="sr-only">Error: </span>{entry.stderr}</pre>
+	{/if}
+	{#if entry.exitCode !== 0}
+		<Badge variant="destructive" class="font-mono">exit {entry.exitCode}</Badge>
+	{/if}
+{/if}

--- a/apps/skills/src/lib/components/terminal/TerminalPanel.svelte
+++ b/apps/skills/src/lib/components/terminal/TerminalPanel.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import { Button } from '@epicenter/ui/button';
+	import { ScrollArea } from '@epicenter/ui/scroll-area';
+	import { Separator } from '@epicenter/ui/separator';
+	import XIcon from '@lucide/svelte/icons/x';
+	import { terminalState } from '$lib/state/terminal-state.svelte';
+	import TerminalInput from './TerminalInput.svelte';
+	import TerminalOutput from './TerminalOutput.svelte';
+
+	let inputRef: ReturnType<typeof TerminalInput> | undefined = $state();
+	let scrollEl: HTMLDivElement | undefined = $state();
+
+	/**
+	 * Focus the input element. Called from AppShell when the
+	 * terminal opens via keyboard shortcut.
+	 */
+	export function focus() {
+		inputRef?.focus();
+	}
+
+	// Auto-scroll to bottom when new entries appear.
+	$effect(() => {
+		void terminalState.history.length;
+		if (scrollEl) {
+			requestAnimationFrame(() => {
+				scrollEl?.scrollTo({ top: scrollEl.scrollHeight });
+			});
+		}
+	});
+</script>
+
+<div class="flex h-full flex-col border-t bg-background font-mono text-sm">
+	<div class="flex items-center justify-between px-3 py-1">
+		<span class="text-xs font-medium text-muted-foreground">Terminal</span>
+		<Button
+			variant="ghost"
+			size="icon-xs"
+			aria-label="Close terminal"
+			onclick={() => terminalState.hide()}
+		>
+			<XIcon aria-hidden="true" class="size-3" />
+		</Button>
+	</div>
+	<Separator />
+	<ScrollArea class="flex-1">
+		<div bind:this={scrollEl} class="space-y-1 p-3">
+			{#each terminalState.history as entry}
+				<TerminalOutput {entry} />
+			{/each}
+		</div>
+	</ScrollArea>
+	<TerminalInput bind:this={inputRef} />
+</div>

--- a/apps/skills/src/lib/components/tree/FileTree.svelte
+++ b/apps/skills/src/lib/components/tree/FileTree.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+	import type { FileId } from '@epicenter/filesystem';
+	import * as Empty from '@epicenter/ui/empty';
+	import * as TreeView from '@epicenter/ui/tree-view';
+	import { fsState } from '$lib/state/fs-state.svelte';
+	import FileTreeItem from './FileTreeItem.svelte';
+	import InlineNameInput from './InlineNameInput.svelte';
+
+	/**
+	 * Flat list of visible item IDs in visual order.
+	 * Respects folder expansion state—collapsed folders hide their descendants.
+	 */
+	const visibleIds = $derived.by(() => {
+		return fsState.walkTree<FileId>((id, row) => ({
+			collect: id,
+			descend: row.type === 'folder' && fsState.expandedIds.has(id),
+		}));
+	});
+
+	/** Whether an inline create/rename is active (suppresses tree keyboard shortcuts). */
+	const isEditing = $derived(
+		fsState.inlineCreate !== null || fsState.renamingId !== null,
+	);
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (isEditing) return;
+
+		const focused = fsState.focusedId;
+		const idx = focused ? visibleIds.indexOf(focused) : -1;
+
+		switch (e.key) {
+			case 'ArrowDown': {
+				e.preventDefault();
+				const next = visibleIds[idx + 1] ?? visibleIds[0];
+				if (next) fsState.focus(next);
+				break;
+			}
+			case 'ArrowUp': {
+				e.preventDefault();
+				const prev = visibleIds[idx - 1] ?? visibleIds.at(-1);
+				if (prev) fsState.focus(prev);
+				break;
+			}
+			case 'ArrowRight': {
+				if (!focused) break;
+				const row = fsState.getRow(focused);
+				if (row?.type === 'folder' && !fsState.expandedIds.has(focused)) {
+					fsState.toggleExpand(focused);
+				}
+				break;
+			}
+			case 'ArrowLeft': {
+				if (!focused) break;
+				const row = fsState.getRow(focused);
+				if (row?.type === 'folder' && fsState.expandedIds.has(focused)) {
+					fsState.toggleExpand(focused);
+				}
+				break;
+			}
+			case 'Enter': {
+				if (focused) fsState.selectFile(focused);
+				break;
+			}
+			case 'F2': {
+				if (focused) fsState.startRename(focused);
+				break;
+			}
+			case 'Delete':
+			case 'Backspace': {
+				if (focused) {
+					fsState.selectFile(focused);
+					fsState.openDelete();
+				}
+				break;
+			}
+		}
+	}
+</script>
+
+{#if fsState.rootChildIds.length === 0 && !fsState.inlineCreate}
+	<Empty.Root class="border-0">
+		<Empty.Header>
+			<Empty.Title>No skills yet</Empty.Title>
+			<Empty.Description
+				>Use the toolbar to create a new skill</Empty.Description
+			>
+		</Empty.Header>
+	</Empty.Root>
+{:else}
+	<TreeView.Root
+		tabindex={0}
+		aria-label="Skill explorer"
+		onkeydown={handleKeydown}
+	>
+		{#each fsState.rootChildIds as childId (childId)}
+			<FileTreeItem id={childId} />
+		{/each}
+		{#if fsState.inlineCreate?.parentId === null}
+			<InlineNameInput
+				icon={fsState.inlineCreate.type}
+				onConfirm={fsState.confirmCreate}
+				onCancel={fsState.cancelCreate}
+			/>
+		{/if}
+	</TreeView.Root>
+{/if}

--- a/apps/skills/src/lib/components/tree/FileTreeItem.svelte
+++ b/apps/skills/src/lib/components/tree/FileTreeItem.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+	import type { FileId } from '@epicenter/filesystem';
+	import * as ContextMenu from '@epicenter/ui/context-menu';
+	import * as TreeView from '@epicenter/ui/tree-view';
+	import { fsState } from '$lib/state/fs-state.svelte';
+	import { getFileIcon } from '$lib/utils/file-icons';
+	import FileTreeItem from './FileTreeItem.svelte';
+	import InlineNameInput from './InlineNameInput.svelte';
+
+	let { id }: { id: FileId } = $props();
+
+	const row = $derived(fsState.getRow(id));
+	const isFolder = $derived(row?.type === 'folder');
+	const isExpanded = $derived(fsState.expandedIds.has(id));
+	const isSelected = $derived(fsState.activeFileId === id);
+	const children = $derived(isFolder ? fsState.getChildIds(id) : []);
+	const isFocused = $derived(fsState.focusedId === id);
+	const isRenaming = $derived(fsState.renamingId === id);
+	const showInlineCreate = $derived(fsState.inlineCreate?.parentId === id);
+	const isContextTarget = $derived(fsState.contextMenuTargetId === id);
+	const isHighlighted = $derived(isSelected || isContextTarget);
+</script>
+
+{#if row}
+	<ContextMenu.Root
+		onOpenChange={(open) => fsState.setContextMenuTarget(open ? id : null)}
+	>
+		<ContextMenu.Trigger>
+			{#snippet child({ props })}
+				{#if isFolder && isRenaming}
+					<div
+						{...props}
+						role="treeitem"
+						aria-selected={isSelected}
+						aria-expanded={isExpanded}
+						class="w-full"
+					>
+						<InlineNameInput
+							defaultValue={row.name}
+							icon="folder"
+							onConfirm={fsState.confirmRename}
+							onCancel={fsState.cancelRename}
+						/>
+					</div>
+				{:else if isFolder}
+					<div
+						{...props}
+						role="treeitem"
+						aria-selected={isSelected}
+						aria-expanded={isExpanded}
+					>
+						<TreeView.Folder
+							name={row.name}
+							open={isExpanded}
+							onOpenChange={() => fsState.toggleExpand(id)}
+							class="w-full rounded-sm px-2 py-1 text-sm hover:bg-accent {isHighlighted
+								? 'bg-accent text-accent-foreground'
+								: ''} {isFocused ? 'ring-1 ring-ring' : ''}"
+						>
+							{#each children as childId (childId)}
+								<FileTreeItem id={childId} />
+							{/each}
+							{#if showInlineCreate}
+								<InlineNameInput
+									icon={fsState.inlineCreate?.type ?? 'file'}
+									onConfirm={fsState.confirmCreate}
+									onCancel={fsState.cancelCreate}
+								/>
+							{/if}
+						</TreeView.Folder>
+					</div>
+				{:else if isRenaming}
+					<div
+						{...props}
+						role="treeitem"
+						aria-selected={isSelected}
+						class="w-full"
+					>
+						<InlineNameInput
+							defaultValue={row.name}
+							icon="file"
+							onConfirm={fsState.confirmRename}
+							onCancel={fsState.cancelRename}
+						/>
+					</div>
+				{:else}
+					<TreeView.File
+						{...props}
+						name={row.name}
+						{id}
+						class="w-full rounded-sm px-2 py-1 text-sm hover:bg-accent {isHighlighted
+							? 'bg-accent text-accent-foreground'
+							: ''} {isFocused ? 'ring-1 ring-ring' : ''}"
+						onclick={() => fsState.selectFile(id)}
+						aria-selected={isSelected}
+						role="treeitem"
+					>
+						{#snippet icon()}
+							{@const Icon = getFileIcon(row.name)}
+							<Icon
+								aria-hidden="true"
+								class="h-4 w-4 shrink-0 text-muted-foreground"
+							/>
+						{/snippet}
+					</TreeView.File>
+				{/if}
+			{/snippet}
+		</ContextMenu.Trigger>
+		<ContextMenu.Content
+			onCloseAutoFocus={(e) => {
+				if (fsState.inlineCreate || fsState.renamingId) {
+					e.preventDefault();
+				}
+			}}
+		>
+			{#if isFolder}
+				<ContextMenu.Item
+					onclick={() => {
+						fsState.focus(id);
+						fsState.expandedIds.add(id);
+						fsState.startCreate('file');
+					}}
+				>
+					New File
+					<ContextMenu.Shortcut>N</ContextMenu.Shortcut>
+				</ContextMenu.Item>
+				<ContextMenu.Item
+					onclick={() => {
+						fsState.focus(id);
+						fsState.expandedIds.add(id);
+						fsState.startCreate('folder');
+					}}
+				>
+					New Folder
+					<ContextMenu.Shortcut>⇧N</ContextMenu.Shortcut>
+				</ContextMenu.Item>
+				<ContextMenu.Separator />
+			{/if}
+			<ContextMenu.Item onclick={() => fsState.startRename(id)}>
+				Rename
+				<ContextMenu.Shortcut>F2</ContextMenu.Shortcut>
+			</ContextMenu.Item>
+			<ContextMenu.Item
+				class="text-destructive"
+				onclick={() => {
+					fsState.selectFile(id);
+					fsState.openDelete();
+				}}
+			>
+				Delete
+				<ContextMenu.Shortcut>⌫</ContextMenu.Shortcut>
+			</ContextMenu.Item>
+		</ContextMenu.Content>
+	</ContextMenu.Root>
+{/if}

--- a/apps/skills/src/lib/components/tree/InlineNameInput.svelte
+++ b/apps/skills/src/lib/components/tree/InlineNameInput.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+	import FileIcon from '@lucide/svelte/icons/file';
+	import FolderIcon from '@lucide/svelte/icons/folder';
+
+	let {
+		defaultValue = '',
+		icon = 'file',
+		onConfirm,
+		onCancel,
+	}: {
+		defaultValue?: string;
+		icon?: 'file' | 'folder';
+		onConfirm: (name: string) => void;
+		onCancel: () => void;
+	} = $props();
+
+	let value = $state(defaultValue);
+	let inputEl = $state<HTMLInputElement | null>(null);
+
+	/**
+	 * Select just the filename stem (before the last dot) on mount,
+	 * so typing immediately replaces the name but keeps the extension.
+	 * If no extension, selects all.
+	 */
+	$effect(() => {
+		if (!inputEl) return;
+		inputEl.focus();
+		const dotIndex = defaultValue.lastIndexOf('.');
+		if (dotIndex > 0) {
+			inputEl.setSelectionRange(0, dotIndex);
+		} else {
+			inputEl.select();
+		}
+	});
+
+	/**
+	 * Idempotency guard—prevents double-fire when Enter keydown and
+	 * blur both call confirm().
+	 */
+	let confirmed = false;
+	function confirm() {
+		if (confirmed) return;
+		confirmed = true;
+		if (value.trim()) {
+			onConfirm(value.trim());
+		} else {
+			onCancel();
+		}
+	}
+</script>
+
+<div class="flex items-center gap-1 px-2 py-0.5">
+	{#if icon === 'folder'}
+		<FolderIcon
+			aria-hidden="true"
+			class="h-4 w-4 shrink-0 text-muted-foreground"
+		/>
+	{:else}
+		<FileIcon
+			aria-hidden="true"
+			class="h-4 w-4 shrink-0 text-muted-foreground"
+		/>
+	{/if}
+	<input
+		bind:this={inputEl}
+		bind:value
+		aria-label={defaultValue ? `Rename ${icon}` : `New ${icon} name`}
+		class="h-6 w-full rounded-sm border border-ring bg-background px-1 text-sm outline-none"
+		onkeydown={(e) => {
+			if (e.key === 'Enter') {
+				e.preventDefault();
+				confirm();
+			} else if (e.key === 'Escape') {
+				e.preventDefault();
+				onCancel();
+			}
+			e.stopPropagation();
+		}}
+		onblur={() => {
+			requestAnimationFrame(() => {
+				if (inputEl && document.activeElement !== inputEl) {
+					confirm();
+				}
+			});
+		}}
+	>
+</div>

--- a/apps/skills/src/lib/state/fs-state.svelte.ts
+++ b/apps/skills/src/lib/state/fs-state.svelte.ts
@@ -1,0 +1,367 @@
+import type { FileId, FileRow } from '@epicenter/filesystem';
+import { SvelteSet } from 'svelte/reactivity';
+import { toast } from 'svelte-sonner';
+import { fs, ws } from '$lib/workspace';
+
+/**
+ * Interaction mode discriminated union.
+ *
+ * Only one interaction can be active at a time. Setting any mode
+ * implicitly cancels the previous one—impossible states are unrepresentable.
+ */
+type InteractionMode =
+	| { type: 'idle' }
+	| { type: 'renaming'; targetId: FileId }
+	| { type: 'creating'; parentId: FileId | null; fileType: 'file' | 'folder' }
+	| { type: 'confirming-delete' };
+
+/**
+ * Reactive filesystem state singleton.
+ *
+ * Follows the tab-manager pattern: factory function creates all state,
+ * exports a single const. Components import and read directly.
+ *
+ * Reactivity bridge: `FileSystemIndex` rebuilds itself on every table
+ * mutation via its own observer. We layer a `version` counter ($state)
+ * that bumps on every mutation (coalesced via rAF), which triggers
+ * `$derived` recomputations that re-read from the already-updated index.
+ *
+ * @example
+ * ```svelte
+ * <script>
+ *   import { fsState } from '$lib/state/fs-state.svelte';
+ *   const children = $derived(fsState.rootChildIds);
+ * </script>
+ * ```
+ */
+function createFsState() {
+	// ── Reactive state ────────────────────────────────────────────────
+	let version = $state(0);
+	let activeFileId = $state<FileId | null>(null);
+	let openFileIds = $state<FileId[]>([]);
+	const expandedIds = new SvelteSet<FileId>();
+	let focusedId = $state<FileId | null>(null);
+
+	// ── Interaction mode ─────────────────────────────────────────────
+	let interactionMode = $state<InteractionMode>({ type: 'idle' });
+
+	// ── Context menu hover persistence ───────────────────────────────
+	let contextMenuTargetId = $state<FileId | null>(null);
+
+	// ── rAF-coalesced observer ─────────────────────────────────────────
+	let pendingBump = false;
+	const unobserve = ws.tables.files.observe(() => {
+		if (!pendingBump) {
+			pendingBump = true;
+			requestAnimationFrame(() => {
+				version++;
+				pendingBump = false;
+			});
+		}
+	});
+
+	// ── Derived state ─────────────────────────────────────────────────
+	const rootChildIds = $derived.by(() => {
+		void version;
+		return fs.index.getChildIds(null);
+	});
+
+	const selectedNode = $derived.by(() => {
+		void version;
+		if (!activeFileId) return null;
+		const result = ws.tables.files.get(activeFileId);
+		return result.status === 'valid' ? result.row : null;
+	});
+
+	const selectedPath = $derived.by(() => {
+		void version;
+		if (!activeFileId) return null;
+		return fs.index.getPathById(activeFileId) ?? null;
+	});
+
+	// ── Derived from interaction mode ────────────────────────────────
+	const renamingId = $derived(
+		interactionMode.type === 'renaming' ? interactionMode.targetId : null,
+	);
+
+	const inlineCreate = $derived(
+		interactionMode.type === 'creating'
+			? {
+					parentId: interactionMode.parentId,
+					type: interactionMode.fileType,
+				}
+			: null,
+	);
+
+	const deleteDialogOpen = $derived(
+		interactionMode.type === 'confirming-delete',
+	);
+
+	// ── Private helpers ───────────────────────────────────────────────
+	async function withErrorToast(
+		fn: () => Promise<void>,
+		fallbackMessage: string,
+	) {
+		try {
+			await fn();
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : fallbackMessage);
+			console.error(err);
+		}
+	}
+
+	const state = {
+		// Read-only getters
+		get version() {
+			return version;
+		},
+		get activeFileId() {
+			return activeFileId;
+		},
+		get openFileIds() {
+			return openFileIds;
+		},
+		get rootChildIds() {
+			return rootChildIds;
+		},
+		get selectedNode() {
+			return selectedNode;
+		},
+		get selectedPath() {
+			return selectedPath;
+		},
+		get focusedId() {
+			return focusedId;
+		},
+		get inlineCreate() {
+			return inlineCreate;
+		},
+		get renamingId() {
+			return renamingId;
+		},
+		get deleteDialogOpen() {
+			return deleteDialogOpen;
+		},
+		get contextMenuTargetId() {
+			return contextMenuTargetId;
+		},
+
+		expandedIds,
+
+		getChildIds(parentId: FileId | null) {
+			void version;
+			return fs.index.getChildIds(parentId);
+		},
+
+		getRow(id: FileId): FileRow | null {
+			void version;
+			const result = ws.tables.files.get(id);
+			return result.status === 'valid' ? result.row : null;
+		},
+
+		getPathForId(id: FileId): string | null {
+			void version;
+			return fs.index.getPathById(id) ?? null;
+		},
+
+		/**
+		 * Walk the file tree recursively, calling `visitor` for each node.
+		 *
+		 * The visitor receives a file ID and its row, and returns an object:
+		 * - `collect`: if present, the value is added to the result array
+		 * - `descend`: if true, recurse into children (only meaningful for folders)
+		 *
+		 * @example
+		 * ```typescript
+		 * const visibleIds = fsState.walkTree((id, row) => ({
+		 *   collect: id,
+		 *   descend: row.type === 'folder' && fsState.expandedIds.has(id),
+		 * }));
+		 * ```
+		 */
+		walkTree<T>(
+			visitor: (id: FileId, row: FileRow) => { collect?: T; descend: boolean },
+			parentId: FileId | null = null,
+		): T[] {
+			void version;
+			const results: T[] = [];
+			function walk(pid: FileId | null) {
+				for (const childId of fs.index.getChildIds(pid)) {
+					const result = ws.tables.files.get(childId);
+					if (result.status !== 'valid' || result.row.trashedAt !== null)
+						continue;
+					const { collect, descend } = visitor(childId, result.row);
+					if (collect !== undefined) results.push(collect);
+					if (descend) walk(childId);
+				}
+			}
+			walk(parentId);
+			return results;
+		},
+
+		// ── Inline editing ───────────────────────────────────────────
+		startCreate(fileType: 'file' | 'folder') {
+			const focused = focusedId ?? activeFileId;
+			if (!focused) {
+				interactionMode = { type: 'creating', parentId: null, fileType };
+				return;
+			}
+			const row = state.getRow(focused);
+			if (row?.type === 'folder') {
+				expandedIds.add(focused);
+				interactionMode = { type: 'creating', parentId: focused, fileType };
+			} else if (row?.parentId) {
+				interactionMode = {
+					type: 'creating',
+					parentId: row.parentId,
+					fileType,
+				};
+			} else {
+				interactionMode = { type: 'creating', parentId: null, fileType };
+			}
+		},
+
+		cancelCreate() {
+			interactionMode = { type: 'idle' };
+		},
+
+		async confirmCreate(name: string) {
+			if (!name.trim() || interactionMode.type !== 'creating') return;
+			const { parentId, fileType } = interactionMode;
+			interactionMode = { type: 'idle' };
+			if (fileType === 'file') {
+				await state.createFile(parentId, name.trim());
+			} else {
+				await state.createFolder(parentId, name.trim());
+			}
+		},
+
+		startRename(id: FileId) {
+			interactionMode = { type: 'renaming', targetId: id };
+		},
+
+		cancelRename() {
+			interactionMode = { type: 'idle' };
+		},
+
+		async confirmRename(newName: string) {
+			if (!newName.trim() || interactionMode.type !== 'renaming') return;
+			const id = interactionMode.targetId;
+			interactionMode = { type: 'idle' };
+			await state.rename(id, newName.trim());
+		},
+
+		// ── Delete dialog ───────────────────────────────────────────
+		openDelete() {
+			interactionMode = { type: 'confirming-delete' };
+		},
+
+		closeDelete() {
+			interactionMode = { type: 'idle' };
+		},
+
+		// ── Context menu ─────────────────────────────────────────────
+		setContextMenuTarget(id: FileId | null) {
+			contextMenuTargetId = id;
+		},
+
+		// ── Actions ──────────────────────────────────────────────────
+		selectFile(id: FileId) {
+			activeFileId = id;
+			if (!openFileIds.includes(id)) {
+				openFileIds = [...openFileIds, id];
+			}
+		},
+
+		closeFile(id: FileId) {
+			openFileIds = openFileIds.filter((f) => f !== id);
+			if (activeFileId === id) {
+				activeFileId = openFileIds.at(-1) ?? null;
+			}
+		},
+
+		toggleExpand(id: FileId) {
+			if (expandedIds.has(id)) expandedIds.delete(id);
+			else expandedIds.add(id);
+		},
+
+		focus(id: FileId | null) {
+			focusedId = id;
+		},
+
+		// Async actions
+		async createFile(parentId: FileId | null, name: string) {
+			await withErrorToast(async () => {
+				const parentPath = parentId
+					? (state.getPathForId(parentId) ?? '/')
+					: '/';
+				const path = parentPath === '/' ? `/${name}` : `${parentPath}/${name}`;
+				await fs.writeFile(path, '');
+				toast.success(`Created ${path}`);
+			}, 'Failed to create file');
+		},
+
+		async createFolder(parentId: FileId | null, name: string) {
+			await withErrorToast(async () => {
+				const parentPath = parentId
+					? (state.getPathForId(parentId) ?? '/')
+					: '/';
+				const path = parentPath === '/' ? `/${name}` : `${parentPath}/${name}`;
+				await fs.mkdir(path);
+				if (parentId) expandedIds.add(parentId);
+				toast.success(`Created ${path}/`);
+			}, 'Failed to create folder');
+		},
+
+		async deleteFile(id: FileId) {
+			await withErrorToast(async () => {
+				const path = state.getPathForId(id);
+				if (!path) return;
+				await fs.rm(path, { recursive: true });
+				if (activeFileId === id) activeFileId = null;
+				openFileIds = openFileIds.filter((f) => f !== id);
+				toast.success(`Deleted ${path}`);
+			}, 'Failed to delete');
+		},
+
+		async rename(id: FileId, newName: string) {
+			await withErrorToast(async () => {
+				const oldPath = state.getPathForId(id);
+				if (!oldPath) return;
+				const parentPath =
+					oldPath.substring(0, oldPath.lastIndexOf('/')) || '/';
+				const newPath =
+					parentPath === '/' ? `/${newName}` : `${parentPath}/${newName}`;
+				await fs.mv(oldPath, newPath);
+				toast.success(`Renamed to ${newName}`);
+			}, 'Failed to rename');
+		},
+
+		async readContent(id: FileId): Promise<string | null> {
+			try {
+				const handle = await ws.documents.files.content.open(id);
+				return handle.read();
+			} catch (err) {
+				console.error('Failed to read content:', err);
+				return null;
+			}
+		},
+
+		async writeContent(id: FileId, data: string): Promise<void> {
+			await withErrorToast(async () => {
+				const handle = await ws.documents.files.content.open(id);
+				handle.write(data);
+			}, 'Failed to save file');
+		},
+
+		async dispose() {
+			unobserve();
+			fs.index.dispose();
+			fs.dispose();
+		},
+	};
+
+	return state;
+}
+
+export const fsState = createFsState();

--- a/apps/skills/src/lib/state/terminal-state.svelte.ts
+++ b/apps/skills/src/lib/state/terminal-state.svelte.ts
@@ -1,0 +1,154 @@
+import { defineCommand } from 'just-bash';
+import { fsState } from '$lib/state/fs-state.svelte';
+import { bash, fs } from '$lib/workspace';
+
+/**
+ * A single entry in the terminal history.
+ *
+ * Input entries show the command the user typed (rendered with a `$` prompt).
+ * Output entries carry the result of executing that command—stdout, stderr,
+ * and the process exit code.
+ */
+type TerminalEntry =
+	| { type: 'input'; command: string }
+	| { type: 'output'; stdout: string; stderr: string; exitCode: number };
+
+/**
+ * Reactive terminal state singleton.
+ *
+ * Follows the same factory pattern as `fs-state.svelte.ts`: a factory
+ * function creates all `$state` and exposes a public API via a returned
+ * object with getters. Components import the singleton and read directly.
+ *
+ * Manages:
+ * - **History**: scrollable list of input/output entries
+ * - **Command recall**: arrow-up/down cycles through previously executed commands
+ * - **Execution**: delegates to `bash.exec()` from workspace.ts
+ * - **Visibility**: open/closed state for the terminal panel
+ *
+ * @example
+ * ```svelte
+ * <script>
+ *   import { terminalState } from '$lib/state/terminal-state.svelte';
+ *   const isOpen = $derived(terminalState.open);
+ * </script>
+ * ```
+ */
+function createTerminalState() {
+	let open = $state(false);
+	let history = $state<TerminalEntry[]>([]);
+	let commandHistory = $state<string[]>([]);
+	let historyIndex = $state(-1);
+	let running = $state(false);
+
+	// ── Custom commands ──────────────────────────────────────────────
+	bash.registerCommand(
+		defineCommand('open', async (args) => {
+			const path = args[0];
+			if (!path)
+				return {
+					stdout: '',
+					stderr: 'Usage: open <path>',
+					exitCode: 1,
+				};
+			const id = fs.lookupId(path);
+			if (!id)
+				return {
+					stdout: '',
+					stderr: `No such file: ${path}`,
+					exitCode: 1,
+				};
+			fsState.selectFile(id);
+			return { stdout: `Opened ${path}\n`, stderr: '', exitCode: 0 };
+		}),
+	);
+
+	return {
+		get open() {
+			return open;
+		},
+		get history() {
+			return history;
+		},
+		get running() {
+			return running;
+		},
+
+		toggle() {
+			open = !open;
+		},
+
+		show() {
+			open = true;
+		},
+
+		hide() {
+			open = false;
+		},
+
+		/**
+		 * Execute a command against the Yjs virtual filesystem.
+		 *
+		 * Appends an input entry, runs `bash.exec()`, then appends an
+		 * output entry. No-ops if the command is blank or another command
+		 * is already running.
+		 */
+		async exec(command: string) {
+			if (!command.trim() || running) return;
+			running = true;
+			history = [...history, { type: 'input', command }];
+			commandHistory = [...commandHistory, command];
+			historyIndex = -1;
+			try {
+				const result = await bash.exec(command);
+				history = [
+					...history,
+					{
+						type: 'output',
+						stdout: result.stdout,
+						stderr: result.stderr,
+						exitCode: result.exitCode,
+					},
+				];
+			} catch (err) {
+				history = [
+					...history,
+					{
+						type: 'output',
+						stdout: '',
+						stderr: err instanceof Error ? err.message : 'Unknown error',
+						exitCode: 1,
+					},
+				];
+			} finally {
+				running = false;
+			}
+		},
+
+		previousCommand(): string | undefined {
+			if (commandHistory.length === 0) return undefined;
+			if (historyIndex === -1) {
+				historyIndex = commandHistory.length - 1;
+			} else if (historyIndex > 0) {
+				historyIndex--;
+			}
+			return commandHistory[historyIndex];
+		},
+
+		nextCommand(): string | undefined {
+			if (historyIndex === -1) return undefined;
+			if (historyIndex < commandHistory.length - 1) {
+				historyIndex++;
+				return commandHistory[historyIndex];
+			}
+			historyIndex = -1;
+			return undefined;
+		},
+
+		clear() {
+			history = [];
+		},
+	};
+}
+
+export const terminalState = createTerminalState();

--- a/apps/skills/src/lib/types.ts
+++ b/apps/skills/src/lib/types.ts
@@ -1,0 +1,107 @@
+/**
+ * Frontmatter schema for a SKILL.md file.
+ *
+ * Mirrors the Agent Skills specification structure:
+ * - `name` and `description` are required
+ * - `metadata` holds optional key-value pairs (author, version, etc.)
+ * - `compatibility` describes which agents/tools the skill targets
+ * - `license` for redistribution terms
+ *
+ * @example
+ * ```typescript
+ * const fm: SkillFrontmatter = {
+ *   name: 'svelte',
+ *   description: 'Svelte 5 patterns including runes...',
+ *   metadata: { author: 'epicenter', version: '2.0' },
+ * };
+ * ```
+ */
+export type SkillFrontmatter = {
+	name: string;
+	description: string;
+	license?: string;
+	compatibility?: string;
+	metadata?: Record<string, string>;
+};
+
+/**
+ * Name validation regex from Agent Skills spec.
+ *
+ * Rules:
+ * - Lowercase alphanumeric + hyphens only
+ * - Must start and end with alphanumeric
+ * - No consecutive hyphens
+ * - 1–64 characters
+ */
+const SKILL_NAME_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+
+/**
+ * Validate skill frontmatter against the Agent Skills spec.
+ *
+ * Returns an array of human-readable error strings. Empty array = valid.
+ * Runs on save and before export—never blocks editing.
+ *
+ * @example
+ * ```typescript
+ * const errors = validateSkill({ name: 'My Skill', description: '' });
+ * // ['name must be lowercase alphanumeric...', 'description is required']
+ * ```
+ */
+export function validateSkill(frontmatter: SkillFrontmatter): string[] {
+	const errors: string[] = [];
+
+	// name: required, 1–64 chars, lowercase + hyphens, no leading/trailing/consecutive hyphens
+	if (!frontmatter.name) {
+		errors.push('name is required');
+	} else if (frontmatter.name.length > 64) {
+		errors.push('name must be ≤64 characters');
+	} else if (!SKILL_NAME_PATTERN.test(frontmatter.name)) {
+		errors.push(
+			'name must be lowercase alphanumeric with hyphens, no leading/trailing/consecutive hyphens',
+		);
+	}
+	if (frontmatter.name?.includes('--')) {
+		errors.push('name must not contain consecutive hyphens');
+	}
+
+	// description: required, 1–1024 chars
+	if (!frontmatter.description) {
+		errors.push('description is required');
+	} else if (frontmatter.description.length > 1024) {
+		errors.push('description must be ≤1024 characters');
+	}
+
+	// compatibility: optional, ≤500 chars
+	if (frontmatter.compatibility && frontmatter.compatibility.length > 500) {
+		errors.push('compatibility must be ≤500 characters');
+	}
+
+	return errors;
+}
+
+/**
+ * Default SKILL.md content for new skills.
+ *
+ * Creates valid frontmatter with placeholder values that pass validation,
+ * plus a minimal instruction body with standard sections.
+ */
+export function createSkillTemplate(name: string): string {
+	return `---
+name: ${name}
+description: TODO—describe when and why to use this skill.
+---
+
+# ${name
+		.split('-')
+		.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+		.join(' ')}
+
+## When to Apply This Skill
+
+- TODO
+
+## Instructions
+
+TODO
+`;
+}

--- a/apps/skills/src/lib/utils/file-icons.ts
+++ b/apps/skills/src/lib/utils/file-icons.ts
@@ -1,0 +1,34 @@
+/**
+ * Extension → Lucide icon mapping for file type awareness.
+ *
+ * Used by FileTreeItem (tree view icons) and CommandPalette (search results).
+ * Returns the Lucide component to render for a given filename.
+ *
+ * @example
+ * ```svelte
+ * {@const Icon = getFileIcon('readme.md')}
+ * <Icon class="h-4 w-4" />
+ * ```
+ */
+
+import FileIcon from '@lucide/svelte/icons/file';
+import FileCode from '@lucide/svelte/icons/file-code';
+import FileJson from '@lucide/svelte/icons/file-json';
+import FileText from '@lucide/svelte/icons/file-text';
+
+const EXTENSION_ICONS: Record<string, typeof FileIcon> = {
+	'.md': FileText,
+	'.txt': FileText,
+	'.ts': FileCode,
+	'.js': FileCode,
+	'.tsx': FileCode,
+	'.jsx': FileCode,
+	'.json': FileJson,
+};
+
+export function getFileIcon(name: string): typeof FileIcon {
+	const dotIndex = name.lastIndexOf('.');
+	if (dotIndex === -1) return FileIcon;
+	const ext = name.slice(dotIndex).toLowerCase();
+	return EXTENSION_ICONS[ext] ?? FileIcon;
+}

--- a/apps/skills/src/lib/workspace.ts
+++ b/apps/skills/src/lib/workspace.ts
@@ -1,0 +1,45 @@
+import {
+	createSqliteIndex,
+	createYjsFileSystem,
+	filesTable,
+} from '@epicenter/filesystem';
+import { createWorkspace } from '@epicenter/workspace';
+import { indexeddbPersistence } from '@epicenter/workspace/extensions/sync/web';
+import { Bash } from 'just-bash';
+
+/**
+ * Skills editor workspace infrastructure.
+ *
+ * Pure TypeScript—no Svelte runes. Creates the Yjs workspace,
+ * filesystem abstraction, and extensions. Imported by both
+ * fs-state.svelte.ts (for reactive wrappers) and components
+ * that need direct infra access (Toolbar, ContentEditor).
+ */
+export const ws = createWorkspace({
+	id: 'epicenter.skills',
+	tables: { files: filesTable },
+})
+	.withExtension('persistence', indexeddbPersistence)
+	.withWorkspaceExtension('sqliteIndex', createSqliteIndex());
+
+/** Yjs-backed virtual filesystem with path-based operations. */
+export const fs = createYjsFileSystem(
+	ws.tables.files,
+	ws.documents.files.content,
+);
+
+/**
+ * Shell emulator backed by the Yjs virtual filesystem.
+ *
+ * Executes `just-bash` commands against the same `fs` used by the UI,
+ * so files created via `echo "x" > /foo.md` are immediately visible
+ * in the file tree. Shell state (env, cwd) resets between `exec()` calls.
+ *
+ * @example
+ * ```typescript
+ * const result = await bash.exec('echo "hello" > /greeting.md');
+ * const cat = await bash.exec('cat /greeting.md');
+ * console.log(cat.stdout); // "hello\n"
+ * ```
+ */
+export const bash = new Bash({ fs, cwd: '/' });

--- a/apps/skills/src/routes/+layout.svelte
+++ b/apps/skills/src/routes/+layout.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import '../app.css';
+	import { Toaster } from 'svelte-sonner';
+
+	let { children } = $props();
+</script>
+
+<Toaster richColors />
+{@render children()}

--- a/apps/skills/src/routes/+layout.ts
+++ b/apps/skills/src/routes/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = false;

--- a/apps/skills/src/routes/+page.svelte
+++ b/apps/skills/src/routes/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import AppShell from '$lib/components/AppShell.svelte';
+</script>
+
+<AppShell />

--- a/apps/skills/svelte.config.js
+++ b/apps/skills/svelte.config.js
@@ -1,0 +1,12 @@
+import adapter from '@sveltejs/adapter-auto';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	preprocess: vitePreprocess(),
+	kit: {
+		adapter: adapter(),
+	},
+};
+
+export default config;

--- a/apps/skills/tsconfig.json
+++ b/apps/skills/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": ["../../tsconfig.base.dom.json", "./.svelte-kit/tsconfig.json"],
+	"compilerOptions": {
+		"checkJs": true,
+		"types": ["bun-types"]
+	}
+}

--- a/apps/skills/vite.config.ts
+++ b/apps/skills/vite.config.ts
@@ -1,0 +1,24 @@
+import { sveltekit } from '@sveltejs/kit/vite';
+import tailwindcss from '@tailwindcss/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+	plugins: [sveltekit(), tailwindcss()],
+	resolve: {
+		dedupe: ['yjs'],
+	},
+	optimizeDeps: {
+		// @libsql/client-wasm bundles a WASM SQLite build via
+		// @libsql/libsql-wasm-experimental. Vite's dep optimizer
+		// can't handle WASM imports from these packages, so we
+		// exclude them from pre-bundling and let them load natively.
+		exclude: ['@libsql/libsql-wasm-experimental'],
+	},
+	server: {
+		headers: {
+			// Required for SharedArrayBuffer (used by @libsql WASM worker)
+			'Cross-Origin-Opener-Policy': 'same-origin',
+			'Cross-Origin-Embedder-Policy': 'require-corp',
+		},
+	},
+});


### PR DESCRIPTION
Skills live in flat markdown files scattered across a config directory. Browsing them means opening Finder or a terminal; editing means knowing the frontmatter schema by heart; creating a new one means copying an old one and hoping you got the folder name right. That friction adds up, and it's the kind of thing that quietly discourages people from writing skills at all.

This PR adds `apps/skills/`, a SvelteKit app built on the same workspace/filesystem architecture as the rest of Epicenter. It uses `epicenter.skills` as the workspace ID and ports the shared shell, tree, editor, command palette, and terminal flows so skills can be created, browsed, edited, searched, and manipulated without leaving the app. Skills-specific additions include `SKILL.md` frontmatter editing, validation on save, folder-name enforcement, and a new-skill dialog scaffold.

Changes are scoped entirely to `apps/skills/`. The app code is type-clean; any check noise in CI comes from pre-existing issues in the workspace and ui packages, not this change.

Still a draft. The product shape is real, but the UX needs another pass before this is ready to merge.