### PR TITLE
fix(fuji): restore missing closing brace in tsconfig.json

### DIFF
--- a/apps/fuji/tsconfig.json
+++ b/apps/fuji/tsconfig.json
@@ -3,4 +3,5 @@
 	"compilerOptions": {
 		"checkJs": true,
 		"types": ["bun-types"]
+	}
 }


### PR DESCRIPTION
Commit 09528037e (refactor: add bun-types) accidentally deleted the closing brace for `compilerOptions`, leaving `tsconfig.json` as invalid JSON. This broke `bun dev` for the Fuji app&#8212;esbuild couldn&#8217;t parse the config.

## Changelog

- Fix Fuji app failing to start due to malformed tsconfig.json