### PR TITLE
fix: .ts extension error in vite.config.ts

### DIFF
--- a/apps/fuji/package.json
+++ b/apps/fuji/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "bun --bun vite dev",
-		"build": "NODE_ENV=production vite build",
+		"build": "NODE_ENV=production bun --bun vite build",
 		"preview": "bun --bun vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"

--- a/apps/fuji/package.json
+++ b/apps/fuji/package.json
@@ -4,9 +4,9 @@
 	"version": "0.0.1",
 	"type": "module",
 	"scripts": {
-		"dev": "vite dev",
+		"dev": "bun --bun vite dev",
 		"build": "NODE_ENV=production vite build",
-		"preview": "vite preview",
+		"preview": "bun --bun vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
 	},

--- a/apps/fuji/tsconfig.json
+++ b/apps/fuji/tsconfig.json
@@ -3,4 +3,5 @@
 	"compilerOptions": {
 		"checkJs": true,
 		"types": ["bun-types"]
+	}
 }

--- a/apps/honeycrisp/package.json
+++ b/apps/honeycrisp/package.json
@@ -8,7 +8,7 @@
 	},
 	"scripts": {
 		"dev": "bun --bun vite dev",
-		"build": "NODE_ENV=production vite build",
+		"build": "NODE_ENV=production bun --bun vite build",
 		"preview": "bun --bun vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"

--- a/apps/honeycrisp/package.json
+++ b/apps/honeycrisp/package.json
@@ -7,9 +7,9 @@
 		"./schema": "./src/lib/workspace/schema.ts"
 	},
 	"scripts": {
-		"dev": "vite dev",
+		"dev": "bun --bun vite dev",
 		"build": "NODE_ENV=production vite build",
-		"preview": "vite preview",
+		"preview": "bun --bun vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
 	},

--- a/apps/whispering/package.json
+++ b/apps/whispering/package.json
@@ -10,7 +10,7 @@
 		"dev:web": "bun --bun vite dev",
 		"dev": "bun tauri dev --config '{\"identifier\": \"com.bradenwong.whispering.dev\"}'",
 		"build": "NODE_ENV=production bun --bun vite build",
-		"preview": "vite preview",
+		"preview": "bun --bun vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/apps/whispering/package.json
+++ b/apps/whispering/package.json
@@ -7,7 +7,7 @@
 		"./commands": "./src/lib/commands.ts"
 	},
 	"scripts": {
-		"dev:web": "vite dev",
+		"dev:web": "bun --bun vite dev",
 		"dev": "bun tauri dev --config '{\"identifier\": \"com.bradenwong.whispering.dev\"}'",
 		"build": "NODE_ENV=production bun --bun vite build",
 		"preview": "vite preview",


### PR DESCRIPTION
- prior script was showing .ts extension error on running `bun run dev` with node version v20.19.0
- before: 
<img width="1396" height="201" alt="Screenshot 2026-03-25 at 11 06 44 PM" src="https://github.com/user-attachments/assets/36ec1355-2c41-489b-995e-06c2b7d49766" />

- after:
<img width="756" height="187" alt="Screenshot 2026-03-25 at 11 08 53 PM" src="https://github.com/user-attachments/assets/4f8faae8-29e2-4de5-8c04-0b0bc4343cda" />
<img width="559" height="100" alt="Screenshot 2026-03-25 at 11 08 39 PM" src="https://github.com/user-attachments/assets/0fb57d19-9ce3-4841-b555-a148ebb1565d" />

Closes #1561 