### PR TITLE
fix: todo of notification extension detection

### DIFF
--- a/apps/whispering/src/lib/services/notifications/web.ts
+++ b/apps/whispering/src/lib/services/notifications/web.ts
@@ -19,11 +19,27 @@ export function createNotificationServiceWeb(): NotificationService {
 	const detectExtension = async (): Promise<boolean> => {
 		if (extensionChecked) return hasExtension;
 
-		// TODO: Implement real extension detection
-		// This would involve sending a ping message to the extension
-		// and waiting for a response with a timeout
-		// For now, always use browser API
-		hasExtension = false;
+		hasExtension = await new Promise<boolean>((resolve) => {
+			const timer = setTimeout(() => {
+				window.removeEventListener('message', onPong);
+				resolve(false);
+			}, 200);
+
+			function onPong(event: MessageEvent) {
+				if (
+					event.source === window &&
+					event.data?.type === 'whispering-extension-pong'
+				) {
+					clearTimeout(timer);
+					window.removeEventListener('message', onPong);
+					resolve(true);
+				}
+			}
+
+			window.addEventListener('message', onPong);
+			window.postMessage({ type: 'whispering-extension-ping' }, '*');
+		});
+
 		extensionChecked = true;
 		return hasExtension;
 	};

--- a/apps/whispering/src/lib/services/notifications/web.ts
+++ b/apps/whispering/src/lib/services/notifications/web.ts
@@ -8,18 +8,22 @@ import { NotificationError, toBrowserNotification } from './types';
  * with fallback support for extension-based notifications.
  */
 export function createNotificationServiceWeb(): NotificationService {
-	// Cache extension detection result
-	let extensionChecked = false;
-	let hasExtension = false;
+	// Cache the in-flight detection promise so concurrent callers all await the
+	// same result rather than each racing to set up their own listener/timeout.
+	let extensionDetectionPromise: Promise<boolean> | null = null;
 
 	/**
 	 * Detects if a browser extension is available for enhanced notification support.
-	 * Results are cached to avoid repeated detection attempts.
+	 * Uses a per-request nonce and origin check to prevent spoofing by other page scripts.
+	 * The result is cached as a promise—concurrent calls all share the same one.
 	 */
-	const detectExtension = async (): Promise<boolean> => {
-		if (extensionChecked) return hasExtension;
+	const detectExtension = (): Promise<boolean> => {
+		if (extensionDetectionPromise) return extensionDetectionPromise;
 
-		hasExtension = await new Promise<boolean>((resolve) => {
+		extensionDetectionPromise = new Promise<boolean>((resolve) => {
+			const nonce = nanoid();
+			const origin = window.location.origin;
+
 			const timer = setTimeout(() => {
 				window.removeEventListener('message', onPong);
 				resolve(false);
@@ -27,8 +31,9 @@ export function createNotificationServiceWeb(): NotificationService {
 
 			function onPong(event: MessageEvent) {
 				if (
-					event.source === window &&
-					event.data?.type === 'whispering-extension-pong'
+					event.origin === origin &&
+					event.data?.type === 'whispering-extension-pong' &&
+					event.data?.nonce === nonce
 				) {
 					clearTimeout(timer);
 					window.removeEventListener('message', onPong);
@@ -37,11 +42,10 @@ export function createNotificationServiceWeb(): NotificationService {
 			}
 
 			window.addEventListener('message', onPong);
-			window.postMessage({ type: 'whispering-extension-ping' }, '*');
+			window.postMessage({ type: 'whispering-extension-ping', nonce }, origin);
 		});
 
-		extensionChecked = true;
-		return hasExtension;
+		return extensionDetectionPromise;
 	};
 
 	return {

--- a/bun.lock
+++ b/bun.lock
@@ -1874,7 +1874,7 @@
 
     "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
 
-    "detect-libc": ["detect-libc@2.0.2", "", {}, "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="],
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "devalue": ["devalue@5.6.4", "", {}, "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA=="],
 
@@ -3484,7 +3484,7 @@
 
     "jws/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
-    "lightningcss/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+    "libsql/detect-libc": ["detect-libc@2.0.2", "", {}, "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="],
 
     "listr2/wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
 
@@ -3524,8 +3524,6 @@
 
     "posthog-js/fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
 
-    "prebuild-install/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
-
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
     "prosemirror-trailing-node/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
@@ -3541,8 +3539,6 @@
     "rolldown/@oxc-project/types": ["@oxc-project/types@0.120.0", "", {}, "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg=="],
 
     "run-jxa/type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
-
-    "sharp/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 


### PR DESCRIPTION
Replaces the `detectExtension`stub with a real postMessage ping/pong posts `whispering-extension-ping` to the page and waits 200ms for a whispering-extension-pong reply from a content script, falling back to the browser Notification API if none arrives.

Follow-up: wiring the actual extension notification send path once a content script ships.

Closes #1563 