### PR TITLE
fix(whispering): Made the table rows selectable

### DIFF
--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -308,7 +308,6 @@
 		},
 		onRowSelectionChange: (updater) => {
 			if (typeof updater === 'function') {
-			  console.log(rowSelection.current)
 				rowSelection.current = updater(rowSelection.current);
 			} else {
 				rowSelection.current = updater;

--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -287,9 +287,9 @@
 		getPaginationRowModel: getPaginationRowModel(),
 		onSortingChange: (updater) => {
 			if (typeof updater === 'function') {
-				sorting.value = updater(sorting.value);
+				sorting.current = updater(sorting.current);
 			} else {
-				sorting.value = updater;
+				sorting.current = updater;
 			}
 		},
 		onColumnFiltersChange: (updater) => {
@@ -301,16 +301,17 @@
 		},
 		onColumnVisibilityChange: (updater) => {
 			if (typeof updater === 'function') {
-				columnVisibility.value = updater(columnVisibility.value);
+				columnVisibility.current = updater(columnVisibility.current);
 			} else {
-				columnVisibility.value = updater;
+				columnVisibility.current = updater;
 			}
 		},
 		onRowSelectionChange: (updater) => {
 			if (typeof updater === 'function') {
-				rowSelection.value = updater(rowSelection.value);
+			  console.log(rowSelection.current)
+				rowSelection.current = updater(rowSelection.current);
 			} else {
-				rowSelection.value = updater;
+				rowSelection.current = updater;
 			}
 		},
 		onPaginationChange: (updater) => {
@@ -329,16 +330,16 @@
 		},
 		state: {
 			get sorting() {
-				return sorting.value;
+				return sorting.current;
 			},
 			get columnFilters() {
 				return columnFilters;
 			},
 			get columnVisibility() {
-				return columnVisibility.value;
+				return columnVisibility.current;
 			},
 			get rowSelection() {
-				return rowSelection.value;
+				return rowSelection.current;
 			},
 			get pagination() {
 				return pagination;

--- a/apps/whispering/src/routes/(app)/(config)/transformations/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/transformations/+page.svelte
@@ -131,9 +131,9 @@
 		getPaginationRowModel: getPaginationRowModel(),
 		onSortingChange: (updater) => {
 			if (typeof updater === 'function') {
-				sorting.value = updater(sorting.value);
+				sorting.current = updater(sorting.current);
 			} else {
-				sorting.value = updater;
+				sorting.current = updater;
 			}
 		},
 		onColumnFiltersChange: (updater) => {
@@ -145,9 +145,9 @@
 		},
 		onRowSelectionChange: (updater) => {
 			if (typeof updater === 'function') {
-				rowSelection.value = updater(rowSelection.value);
+				rowSelection.current = updater(rowSelection.current);
 			} else {
-				rowSelection.value = updater;
+				rowSelection.current = updater;
 			}
 		},
 		onPaginationChange: (updater) => {
@@ -166,13 +166,13 @@
 		},
 		state: {
 			get sorting() {
-				return sorting.value;
+				return sorting.current;
 			},
 			get columnFilters() {
 				return columnFilters;
 			},
 			get rowSelection() {
-				return rowSelection.value;
+				return rowSelection.current;
 			},
 			get pagination() {
 				return pagination;


### PR DESCRIPTION
Changed the `rowSelection` variable to use `.current` instead of `.value`. This is because `.value` isn't a property on `rowSelection` so it was trying to modify an undefined value which prevented the table rows from being selected.

## Changelog

<!--
One line per user-visible change. Imperative mood. Written for end users, not developers.
Required for feat: and fix: PRs. Omit this section entirely for chore/refactor/docs.
-->
- Made the rows inside the transformations and recordings table selectable.

Closes #1569 
