### PR TITLE
fix(whispering): fix responsive layout for recording mode tabs at small window sizes

### DIFF
--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -261,7 +261,7 @@
 				aria-label={`Switch to ${option.label.toLowerCase()} mode`}
 			>
 				{option.icon}
-				{option.label}
+				<span class="hidden sm:inline">{option.label}</span>
 			</ToggleGroup.Item>
 		{/each}
 	</ToggleGroup.Root>

--- a/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
+++ b/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
@@ -13,6 +13,10 @@
 	import { services } from '$lib/services';
 	import { vadRecorder } from '$lib/state/vad-recorder.svelte';
 	import { settings } from '$lib/state/settings.svelte';
+	import {
+		RECORDER_STATE_TO_ICON,
+		VAD_STATE_TO_ICON,
+	} from '$lib/constants/audio';
 	import { syncWindowAlwaysOnTopWithRecorderState } from '../_layout-utils/alwaysOnTop.svelte';
 	import {
 		checkCompressionRecommendation,
@@ -91,21 +95,31 @@
 	let { children } = $props();
 </script>
 
-<button
-	class="xxs:hidden hover:bg-accent hover:text-accent-foreground h-screen w-screen transform duration-300 ease-in-out"
-	onclick={() => commandCallbacks.toggleManualRecording()}
->
-	<span
-		style="filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.5));"
-		class="text-[48px] leading-none"
+{#if settings.get('recording.mode') === 'vad'}
+	<button
+		class="xxs:hidden hover:bg-accent hover:text-accent-foreground h-screen w-screen transform duration-300 ease-in-out"
+		onclick={() => commandCallbacks.toggleVadRecording()}
 	>
-		{#if getRecorderStateQuery.data === 'RECORDING'}
-			⏹️
-		{:else}
-			🎙️
-		{/if}
-	</span>
-</button>
+		<span
+			style="filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.5));"
+			class="text-[48px] leading-none"
+		>
+			{VAD_STATE_TO_ICON[vadRecorder.state]}
+		</span>
+	</button>
+{:else}
+	<button
+		class="xxs:hidden hover:bg-accent hover:text-accent-foreground h-screen w-screen transform duration-300 ease-in-out"
+		onclick={() => commandCallbacks.toggleManualRecording()}
+	>
+		<span
+			style="filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.5));"
+			class="text-[48px] leading-none"
+		>
+			{RECORDER_STATE_TO_ICON[getRecorderStateQuery.data ?? 'IDLE']}
+		</span>
+	</button>
+{/if}
 
 <div class="hidden flex-1 flex-col gap-2 xxs:flex min-w-0 w-full">
 	{@render children()}


### PR DESCRIPTION
- **Mini-window button now mode-aware**: Below the `xxs` breakpoint (196px), the full-screen recording button was hardcoded to always call `toggleManualRecording()` and show manual icons (🎙️/⏹️), even when in VAD mode. Now it checks `settings.get('recording.mode')` and dispatches the correct toggle + shows the correct icon (🎤/💬/👂 for VAD).
- **Tab text hidden at narrow widths**: The toggle group items (Manual / Voice Activated / Upload File) overflowed and overlapped at medium window sizes because items had `shrink-0` and long text labels. Wrapped labels in `<span class="hidden sm:inline">` so below `sm` (640px) only emoji icons show, preventing text overlap entirely.

## What was broken

| Window size | Before | After |
|---|---|---|
| Below 196px (mini) | Always shows 🎙️, always triggers manual recording—even in VAD mode | Shows correct mode icon, triggers correct toggle |
| 196–640px (narrow) | Tab text overlaps: "Voice Activa""dUpload File" | Icons only: 🎙️ 🎤 📁 |
| 640px+ (normal) | Fine | Fine (unchanged) |

## Files changed

- `apps/whispering/src/routes/(app)/_components/AppLayout.svelte` — mode-aware mini button
- `apps/whispering/src/routes/(app)/+page.svelte` — responsive tab labels