### PR TITLE
fix(workspace): harden encryption lifecycle and stabilize epoch transitions

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -28,7 +28,7 @@ Better Auth handles identity: email/password and Google OAuth for sign-in, plus 
 
 ## Encryption and trust model
 
-Workspace data is encrypted at the CRDT level using AES-256-GCM via @noble/ciphers (audited by Cure53). The encryption wraps YKeyValueLww—a synchronous layer that encrypts individual values within the data structure itself. Durable Objects see the CRDT skeleton (key names like `tab-1`, timestamps for conflict resolution) but every value is an opaque ciphertext blob: `{ v: 1, ct: Uint8Array }`. Yjs `writeAny` serializes `Uint8Array` natively as binary (type tag 116), so there is no base64 overhead.
+Workspace data is encrypted at the CRDT level using XChaCha20-Poly1305 via @noble/ciphers (audited by Cure53). The encryption wraps YKeyValueLww—a synchronous layer that encrypts individual values within the data structure itself. Durable Objects see the CRDT skeleton (key names like `tab-1`, timestamps for conflict resolution) but every value is an opaque ciphertext blob: `[formatVersion(1) ‖ keyVersion(1) ‖ nonce(24) ‖ ciphertext ‖ tag(16)]`. Yjs `writeAny` serializes `Uint8Array` natively as binary (type tag 116), so there is no base64 overhead.
 
 The encryption key derives from the deployment's auth secret (`BETTER_AUTH_SECRET`). This is server-managed, deployment-level encryption—the same model used by Notion, Linear, and most SaaS products, but applied deeper (individual CRDT values rather than database-level). The server can decrypt data to power search indexing, AI summarization, and password recovery.
 
@@ -47,7 +47,7 @@ PGP has been trying to make key management practical for thirty years. Signal wo
 
 ### Overhead
 
-Encryption adds a fixed ~28 bytes per value (12-byte nonce + 16-byte GCM auth tag) with zero proportional expansion—`ct` is stored as a raw `Uint8Array` via Yjs binary serialization. For typical workspace data (100–2000 byte values), total overhead is 14–28%. Performance impact is negligible—AES-256-GCM via @noble/ciphers encrypts 1 KB in ~0.01 ms, and decrypting an entire workspace (500 entries) takes under 5 ms.
+Encryption adds a fixed 42 bytes per value (2-byte header + 24-byte nonce + 16-byte Poly1305 auth tag) with zero proportional expansion—blobs are stored as raw `Uint8Array` via Yjs binary serialization. For typical workspace data (100–2000 byte values), total overhead is 2–42%. Performance impact is negligible—XChaCha20-Poly1305 via @noble/ciphers encrypts 1 KB in ~0.01 ms, and decrypting an entire workspace (500 entries) takes under 5 ms.
 
 For the full argument:
 

--- a/apps/api/src/auth/encryption.ts
+++ b/apps/api/src/auth/encryption.ts
@@ -58,11 +58,23 @@ const EncryptionKeyring = type('string')
  * malformed ENCRYPTION_SECRETS prevents the worker from loading at all rather
  * than failing on the first auth request.
  *
+ * Uses the call operator (not `.assert()`) so validation errors are returned
+ * as `ArkErrors` instead of thrown as `TraversalError`. This lets us wrap
+ * them in a human-readable message with the expected format.
+ *
  * Destructured so `currentKeySecret` stays private and `currentKeyVersion`
  * can be exported without exposing key material.
  */
-const [{ version: currentKeyVersion, secret: currentKeySecret }] =
-	EncryptionKeyring.assert(env.ENCRYPTION_SECRETS);
+const keyring = EncryptionKeyring(env.ENCRYPTION_SECRETS);
+if (keyring instanceof type.errors) {
+	throw new Error(
+		`ENCRYPTION_SECRETS is missing or malformed. ` +
+			`Expected format: "2:base64Secret2,1:base64Secret1" (comma-separated version:secret pairs). ` +
+			`Generate a secret with: openssl rand -base64 32\n\n` +
+			`Validation errors:\n${keyring.summary}`,
+	);
+}
+const [{ version: currentKeyVersion, secret: currentKeySecret }] = keyring;
 
 /**
  * Derive a per-user 32-byte encryption key via two-step HKDF-SHA256.

--- a/apps/tab-manager/src/lib/components/SyncStatusIndicator.svelte
+++ b/apps/tab-manager/src/lib/components/SyncStatusIndicator.svelte
@@ -16,7 +16,7 @@
 	import { workspace } from '$lib/client';
 
 	function createSyncStatus() {
-		let current = $state<SyncStatus>('offline' as SyncStatus);
+		let current = $state<SyncStatus>({ phase: 'offline' });
 
 		current = workspace.extensions.sync.status;
 		workspace.extensions.sync.onStatusChange((status) => {
@@ -35,7 +35,6 @@
 
 	function getTooltip(s: SyncStatus, isAuthenticated: boolean): string {
 		if (!isAuthenticated) return 'Sign in to sync across devices';
-		if (!isSignedIn) return 'Sign in to sync across devices';
 		switch (s.phase) {
 			case 'connected':
 				return 'Connected';
@@ -97,14 +96,14 @@
 					<p class="text-xs text-muted-foreground">{auth.user?.email}</p>
 				</div>
 				<div class="border-t pt-3 space-y-1">
-					<p class="text-xs text-muted-foreground">
-						Sync:
-						{syncStatus.current.phase === 'connected'
-							? 'Connected'
-							: syncStatus.current.phase === 'connecting'
-								? 'Connecting…'
-								: 'Offline'}
-					</p>
+				<p class="text-xs text-muted-foreground">
+					Sync:
+					{({
+						connected: 'Connected',
+						connecting: 'Connecting…',
+						offline: 'Offline',
+					} satisfies Record<SyncStatus['phase'], string>)[syncStatus.current.phase]}
+				</p>
 				</div>
 				<div class="border-t pt-3 flex gap-2">
 					{#if syncStatus.current.phase !== 'connected'}
@@ -123,7 +122,7 @@
 						size="sm"
 						class="flex-1"
 						onclick={async () => {
-					await auth.signOut();
+							await auth.signOut();
 							popoverOpen = false;
 						}}
 					>

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -160,7 +160,6 @@ export type {
 	TableDefinition,
 	TableDefinitions,
 	TableHelper,
-	TransactionMeta,
 	TablesHelper,
 	UpdateResult,
 	ValidRowResult,

--- a/packages/workspace/src/shared/crypto/crypto.test.ts
+++ b/packages/workspace/src/shared/crypto/crypto.test.ts
@@ -256,16 +256,16 @@ describe('isEncryptedBlob', () => {
 		expect(isEncryptedBlob({})).toBe(false);
 	});
 
-	test('returns true for Uint8Array with format version 1 at byte 0', () => {
-		expect(isEncryptedBlob(new Uint8Array([1]))).toBe(true);
-		expect(isEncryptedBlob(new Uint8Array([1, 0, 0, 0]))).toBe(true);
-		expect(isEncryptedBlob(new Uint8Array(42).fill(0).map((_, i) => (i === 0 ? 1 : 0)))).toBe(true);
+	test('returns true for Uint8Array at or above minimum blob size (42 bytes)', () => {
+		// Minimum: 2 header + 24 nonce + 16 tag = 42 bytes
+		expect(isEncryptedBlob(new Uint8Array(42))).toBe(true);
+		expect(isEncryptedBlob(new Uint8Array(100))).toBe(true);
 	});
 
-	test('returns false for Uint8Array with byte 0 !== 1', () => {
-		expect(isEncryptedBlob(new Uint8Array([0]))).toBe(false);
-		expect(isEncryptedBlob(new Uint8Array([2]))).toBe(false);
-		expect(isEncryptedBlob(new Uint8Array([255]))).toBe(false);
+	test('returns false for Uint8Array below minimum blob size', () => {
+		expect(isEncryptedBlob(new Uint8Array([1]))).toBe(false);
+		expect(isEncryptedBlob(new Uint8Array([1, 0, 0, 0]))).toBe(false);
+		expect(isEncryptedBlob(new Uint8Array(41))).toBe(false);
 	});
 
 	test('returns false for empty Uint8Array', () => {

--- a/packages/workspace/src/shared/crypto/index.ts
+++ b/packages/workspace/src/shared/crypto/index.ts
@@ -61,6 +61,15 @@ import { hkdf } from '@noble/hashes/hkdf.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 
 const NONCE_LENGTH = 24;
+const TAG_LENGTH = 16;
+const HEADER_LENGTH = 2;
+
+/**
+ * Minimum valid EncryptedBlob size: 2-byte header + 24-byte nonce + 16-byte auth tag.
+ * An empty plaintext produces a blob of exactly this size.
+ */
+const MINIMUM_BLOB_SIZE = HEADER_LENGTH + NONCE_LENGTH + TAG_LENGTH;
+
 const textEncoder = new TextEncoder();
 
 /**
@@ -128,9 +137,10 @@ export function generateEncryptionKey(): Uint8Array {
  * eliminating base64 overhead and the old `{ v, ct }` JSON wrapper.
  *
  * @param plaintext - The string to encrypt
- * @param key - A 32-byte Uint8Array encryption key
  * @param aad - Optional additional authenticated data bound to ciphertext integrity
- * @param keyVersion - Key version from ENCRYPTION_SECRETS keyring (default 1). Embedded as byte 1.
+ * @param keyVersion - Key version embedded as byte 1. Currently written but not read
+ *   during decryption—reserved for future keyring rotation. The caller is responsible
+ *   for passing the correct version from the ENCRYPTION_SECRETS keyring.
  * @returns A bare Uint8Array: `[formatVersion, keyVersion, ...nonce(24), ...ciphertext, ...tag(16)]`
  *
  * @example
@@ -227,13 +237,18 @@ export function decryptValue(
  * The key version is stored at byte 1 of the blob and identifies which
  * secret from the ENCRYPTION_SECRETS keyring was used to encrypt this blob.
  *
+ * **Note**: Currently written but not read during decryption. The encrypted
+ * KV wrapper's `activateEncryption` handles key transitions by trying the
+ * current key then falling back to the previous key, without consulting
+ * keyVersion. This function exists for diagnostics and future keyring
+ * rotation where version-aware key lookup would avoid brute-forcing.
+ *
  * @param blob - An EncryptedBlob to read the key version from
  * @returns The key version number (1-255)
  */
 export function getKeyVersion(blob: EncryptedBlob): number {
 	return blob[1]!;
 }
-
 /**
  * Read the format version from an EncryptedBlob without decrypting.
  *
@@ -252,13 +267,16 @@ export function getFormatVersion(blob: EncryptedBlob): number {
 /**
  * Type guard to check if a value is a valid EncryptedBlob.
  *
- * Checks that the value is a `Uint8Array` with format version 1 at byte 0.
- * User values stored in the CRDT are always JS objects (from schema definitions),
- * never `Uint8Array` instances, so this check is a reliable discriminant.
+ * Checks that the value is a `Uint8Array` with at least the minimum blob size
+ * (2-byte header + 24-byte nonce + 16-byte auth tag = 42 bytes). User values
+ * stored in the CRDT are always JS objects (from schema definitions), never
+ * `Uint8Array` instances, so `instanceof Uint8Array` is the primary discriminant.
  *
- * Truncated or corrupted blobs that pass this check will fail during
- * `decryptValue()` and get quarantined by the encrypted wrapper's error
- * containment—they are not silently misinterpreted.
+ * The minimum-length check replaces the previous `value[0] === 1` format-version
+ * check so that future format versions (v2, v3, etc.) are recognized as encrypted
+ * blobs without updating this guard. Truncated or corrupted blobs that pass this
+ * check will fail during `decryptValue()` and get quarantined by the encrypted
+ * wrapper's error containment—they are not silently misinterpreted.
  *
  * @param value - The value to check
  * @returns True if value is a valid EncryptedBlob, false otherwise
@@ -272,7 +290,7 @@ export function getFormatVersion(blob: EncryptedBlob): number {
  * ```
  */
 export function isEncryptedBlob(value: unknown): value is EncryptedBlob {
-	return value instanceof Uint8Array && value[0] === 1;
+	return value instanceof Uint8Array && value.length >= MINIMUM_BLOB_SIZE;
 }
 
 /**

--- a/packages/workspace/src/shared/crypto/index.ts
+++ b/packages/workspace/src/shared/crypto/index.ts
@@ -162,7 +162,7 @@ export function encryptValue(
 	const cipher = aad
 		? xchacha20poly1305(key, nonce, aad)
 		: xchacha20poly1305(key, nonce);
-	const data = new TextEncoder().encode(plaintext);
+	const data = textEncoder.encode(plaintext);
 	const ciphertext = cipher.encrypt(data);
 
 	// Pack formatVersion(1) || keyVersion(1) || nonce(24) || ciphertext || tag(16)

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.test.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.test.ts
@@ -650,7 +650,7 @@ describe('createEncryptedYkvLww', () => {
 			expect(isEncryptedBlob(afterEntry?.val)).toBe(true);
 		});
 
-		test('activateEncryption rebuilds map and fires synthetic events', () => {
+		test('activateEncryption with key rotation preserves entries via fallback', () => {
 			const key1 = generateEncryptionKey();
 			const key2 = generateEncryptionKey();
 			const ydoc = new Y.Doc({ guid: 'key-transition-synthetic-events' });
@@ -667,21 +667,22 @@ describe('createEncryptedYkvLww', () => {
 					events.push({ key: entryKey, change });
 			});
 
+			// Rotate from key1 to key2 — entries should be preserved via fallback
 			kv.activateEncryption(key2);
-			expect(kv.failedDecryptCount).toBe(2);
+			expect(kv.failedDecryptCount).toBe(0);
+			expect(kv.get('a')).toBe('alpha');
+			expect(kv.get('b')).toBe('beta');
 
+			// No delete events — entries were recovered via previous key fallback
 			const deleteEvents = events.filter(
 				(event) => event.change.action === 'delete',
 			);
-			expect(deleteEvents.length).toBe(2);
-			expect(deleteEvents.map((event) => event.key).sort()).toEqual(['a', 'b']);
+			expect(deleteEvents.length).toBe(0);
 
+			// Rotate back to key1 — entries re-encrypted with key2, fallback to key2 works
+			events.length = 0;
 			kv.activateEncryption(key1);
 			expect(kv.failedDecryptCount).toBe(0);
-
-			const addEvents = events.filter((event) => event.change.action === 'add');
-			expect(addEvents.length).toBe(2);
-			expect(addEvents.map((event) => event.key).sort()).toEqual(['a', 'b']);
 			expect(kv.get('a')).toBe('alpha');
 			expect(kv.get('b')).toBe('beta');
 		});

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
@@ -148,8 +148,13 @@ export type YKeyValueLwwEncrypted<T> = {
 	 */
 	deactivateEncryption(): void;
 	/**
-	 * Number of entries that failed to decrypt. Computed as
-	 * `inner.map.size - map.size`. Entries are retried on `activateEncryption()`.
+	 * Number of entries in the inner store that are not in the decrypted cache.
+	 * When a key is active, this counts entries that failed to decrypt.
+	 * When no key is active, this counts all encrypted entries (they are not
+	 * "failed"—they are waiting for a key). Entries are retried on
+	 * `activateEncryption()`.
+	 *
+	 * Computed as `inner.map.size - map.size`.
 	 */
 	readonly failedDecryptCount: number;
 
@@ -411,9 +416,15 @@ export function createEncryptedYkvLww<T>(
 			inner.delete(key);
 		},
 
+		/**
+		 * Iterate all entries with decrypted values. Prefers the wrapper.map cache;
+		 * falls back to on-the-fly decryption for entries in the transaction gap
+		 * (after set() but before the observer fires).
+		 *
+		 * Entries that cannot be decrypted (wrong key, corrupted blob, no key active)
+		 * are silently omitted. Use `failedDecryptCount` to detect missing entries.
+		 */
 		*entries() {
-			// Yield from inner.entries() (includes pending values during transaction gap),
-			// decrypting on the fly. Prefer wrapper.map cache when available.
 			for (const [key, entry] of inner.entries()) {
 				const cached = map.get(key);
 				if (cached) {

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
@@ -23,7 +23,7 @@
  *         │                                                (inner handles pending)
  *         ▼  inner.observe fires
  *   ├── inner.map has encrypted entry
- *   ├── maybeDecrypt → plaintext (or skip on failure)
+ *   ├── tryDecryptEntry → plaintext (or skip on failure)
  *   ├── wrapper.map.set('tab-1', plaintext entry)       ← cachedEntries() exposes this
  *   └── change event forwarded with decrypted values
  *
@@ -64,7 +64,7 @@
  *
  * ## Error Containment
  *
- * The observer wraps `maybeDecrypt` with `trySync`. A failed decrypt skips
+ * The observer wraps decrypt with try/catch. A failed decrypt skips
  * the entry and logs a warning instead of throwing. This prevents one bad blob
  * from crashing all observation. `failedDecryptCount` exposes the number of
  * entries that failed to decrypt. Entries are retried on `activateEncryption()`.
@@ -91,6 +91,9 @@ import {
 } from './y-keyvalue-lww';
 
 const textEncoder = new TextEncoder();
+
+/** Transaction origin for re-encryption writes. Observer skips events with this origin. */
+const RE_ENCRYPT = Symbol('re-encrypt');
 
 /**
  * Change handler for the encrypted KV wrapper.
@@ -142,9 +145,8 @@ export type YKeyValueLwwEncrypted<T> = {
 	activateEncryption(key: Uint8Array): void;
 
 	/**
-	 * Deactivate encryption. Clears the key and the decrypted cache.
-	 * After this call, new writes are plaintext and encrypted entries
-	 * are no longer readable until `activateEncryption()` is called again.
+	 * Deactivate encryption. Clears the key, emits delete events for entries
+	 * that become unreadable, and retains any plaintext entries.
 	 */
 	deactivateEncryption(): void;
 	/**
@@ -284,6 +286,10 @@ export function createEncryptedYkvLww<T>(
 		}
 	};
 
+	/** Compare two decrypted values for equality (deep via JSON.stringify fallback). */
+	const areValuesEqual = (left: T, right: T): boolean =>
+		Object.is(left, right) || JSON.stringify(left) === JSON.stringify(right);
+
 	/**
 	 * Diff old map vs current map and emit synthetic change events.
 	 *
@@ -309,7 +315,7 @@ export function createEncryptedYkvLww<T>(
 			}
 
 			if (!oldEntry || !newEntry) continue;
-			if (Object.is(oldEntry.val, newEntry.val) || JSON.stringify(oldEntry.val) === JSON.stringify(newEntry.val)) continue;
+			if (areValuesEqual(oldEntry.val, newEntry.val)) continue;
 
 			changes.set(key, { action: 'update', newValue: newEntry.val });
 		}
@@ -332,6 +338,10 @@ export function createEncryptedYkvLww<T>(
 	 * plaintext values. The observer is the sole writer to `map`.
 	 */
 	inner.observe((changes, transaction) => {
+		// Skip re-encryption writes — they don't change decrypted values.
+		// activateEncryption handles its own event emission via diffAndEmit.
+		if (transaction.origin === RE_ENCRYPT) return;
+
 		const decryptedChanges = new Map<string, YKeyValueLwwChange<T>>();
 
 		for (const [key, change] of changes) {
@@ -345,15 +355,7 @@ export function createEncryptedYkvLww<T>(
 				const decrypted = tryDecryptEntry(key, entry);
 				if (!decrypted) continue;
 
-				const existing = map.get(key);
-				if (existing && JSON.stringify(existing.val) === JSON.stringify(decrypted.val)) {
-					// Decrypted value unchanged (e.g., re-encryption during activateEncryption).
-					// Update the cache entry but don't emit a change event.
-					map.set(key, decrypted);
-					continue;
-				}
-
-				const wasNew = !existing;
+				const wasNew = !map.has(key);
 				map.set(key, decrypted);
 				decryptedChanges.set(key, {
 					action: wasNew ? 'add' : 'update',
@@ -476,10 +478,12 @@ export function createEncryptedYkvLww<T>(
 			}
 
 			// Re-encrypt only entries that need it (plaintext or old-key)
-			for (const entryKey of needsReEncrypt) {
-				const plainVal = map.get(entryKey)!;
-				inner.set(entryKey, encryptValue(JSON.stringify(plainVal.val), nextKey, textEncoder.encode(entryKey)));
-			}
+			inner.doc.transact(() => {
+				for (const entryKey of needsReEncrypt) {
+					const plainVal = map.get(entryKey)!;
+					inner.set(entryKey, encryptValue(JSON.stringify(plainVal.val), nextKey, textEncoder.encode(entryKey)));
+				}
+			}, RE_ENCRYPT);
 
 			diffAndEmit(oldMap);
 		},

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
@@ -335,7 +335,8 @@ export function createEncryptedYkvLww<T>(
 	 * 3. Forward decrypted change events to registered handlers
 	 *
 	 * This keeps `wrapper.map` always in sync with `inner.map` but with
-	 * plaintext values. The observer is the sole writer to `map`.
+	 * plaintext values. `activateEncryption` and `deactivateEncryption` also
+	 * write to `map` during encryption state transitions.
 	 */
 	inner.observe((changes, transaction) => {
 		// Skip re-encryption writes — they don't change decrypted values.
@@ -447,13 +448,13 @@ export function createEncryptedYkvLww<T>(
 
 			const oldMap = new Map(map);
 			map.clear();
-			const needsReEncrypt: string[] = [];
+			const needsReEncrypt: Array<{ key: string; val: T }> = [];
 
 			for (const [key, entry] of inner.map) {
 				if (!isEncryptedBlob(entry.val)) {
 					// Plaintext entry — always needs encryption
 					map.set(key, { ...entry, val: entry.val as T });
-					needsReEncrypt.push(key);
+					needsReEncrypt.push({ key, val: entry.val as T });
 					continue;
 				}
 
@@ -469,7 +470,7 @@ export function createEncryptedYkvLww<T>(
 					decrypted = tryDecryptEntryWithKey(key, entry, previousKey);
 					if (decrypted) {
 						map.set(key, decrypted);
-						needsReEncrypt.push(key);
+						needsReEncrypt.push({ key, val: decrypted.val });
 						continue;
 					}
 				}
@@ -479,9 +480,8 @@ export function createEncryptedYkvLww<T>(
 
 			// Re-encrypt only entries that need it (plaintext or old-key)
 			inner.doc.transact(() => {
-				for (const entryKey of needsReEncrypt) {
-					const plainVal = map.get(entryKey)!;
-					inner.set(entryKey, encryptValue(JSON.stringify(plainVal.val), nextKey, textEncoder.encode(entryKey)));
+				for (const { key: entryKey, val } of needsReEncrypt) {
+					inner.set(entryKey, encryptValue(JSON.stringify(val), nextKey, textEncoder.encode(entryKey)));
 				}
 			}, RE_ENCRYPT);
 

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
@@ -98,15 +98,13 @@ const RE_ENCRYPT = Symbol('re-encrypt');
 /**
  * Change handler for the encrypted KV wrapper.
  *
- * The second parameter is `Y.Transaction | undefined` because encryption
- * state transitions (`activateEncryption`, `deactivateEncryption`) fire
- * change events without a backing Yjs transaction. Real CRDT changes
- * always provide a `Y.Transaction`; encryption lifecycle events pass
- * `undefined`.
+ * Receives the Yjs transaction origin for real CRDT changes, or `undefined`
+ * for encryption lifecycle events (activateEncryption, deactivateEncryption)
+ * which have no backing Yjs transaction.
  */
 export type EncryptedKvChangeHandler<T> = (
 	changes: Map<string, YKeyValueLwwChange<T>>,
-	transaction: Y.Transaction | undefined,
+	origin: unknown,
 ) => void;
 
 /**
@@ -366,7 +364,7 @@ export function createEncryptedYkvLww<T>(
 		}
 
 		for (const handler of changeHandlers)
-			handler(decryptedChanges, transaction);
+			handler(decryptedChanges, transaction.origin);
 	});
 
 	return {

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
@@ -221,15 +221,30 @@ export function createEncryptedYkvLww<T>(
 	let currentKey: Uint8Array | undefined = options?.key;
 
 	/**
+	 * Attempt to decrypt an entry with a specific key.
+	 *
+	 * Returns the decrypted entry or undefined on failure.
+	 * Used by activateEncryption for key fallback and by the default tryDecryptEntry.
+	 */
+	const tryDecryptEntryWithKey = (
+		key: string,
+		entry: YKeyValueLwwEntry<EncryptedBlob | T>,
+		decryptionKey: Uint8Array,
+	): YKeyValueLwwEntry<T> | undefined => {
+		if (!isEncryptedBlob(entry.val)) return { ...entry, val: entry.val as T };
+		try {
+			const val = JSON.parse(decryptValue(entry.val, decryptionKey, textEncoder.encode(key))) as T;
+			return { ...entry, val };
+		} catch {
+			return undefined;
+		}
+	};
+
+	/**
 	 * Attempt to decrypt an entry with warning on failure.
 	 *
-	 * Handles three cases:
-	 * 1. Value is not an EncryptedBlob → return as-is (plaintext)
-	 * 2. No key available → return undefined (can't decrypt)
-	 * 3. EncryptedBlob + key → decrypt with AAD, return entry or undefined on failure
-	 *
-	 * Used during map rebuild and observer processing where failures indicate
-	 * corruption or key mismatch and should be logged.
+	 * Delegates to tryDecryptEntryWithKey using currentKey.
+	 * Logs a warning on failure for diagnostics.
 	 */
 	const tryDecryptEntry = (
 		key: string,
@@ -237,13 +252,9 @@ export function createEncryptedYkvLww<T>(
 	): YKeyValueLwwEntry<T> | undefined => {
 		if (!isEncryptedBlob(entry.val)) return { ...entry, val: entry.val as T };
 		if (!currentKey) return undefined;
-		try {
-			const val = JSON.parse(decryptValue(entry.val, currentKey, textEncoder.encode(key))) as T;
-			return { ...entry, val };
-		} catch (e) {
-			console.warn(`[encrypted-kv] Failed to decrypt entry "${key}":`, e);
-			return undefined;
-		}
+		const result = tryDecryptEntryWithKey(key, entry, currentKey);
+		if (!result) console.warn(`[encrypted-kv] Failed to decrypt entry "${key}"`);
+		return result;
 	};
 
 	/**
@@ -271,6 +282,40 @@ export function createEncryptedYkvLww<T>(
 			if (!decryptedEntry) continue;
 			map.set(key, decryptedEntry);
 		}
+	};
+
+	/**
+	 * Diff old map vs current map and emit synthetic change events.
+	 *
+	 * Shared by activateEncryption and deactivateEncryption to ensure
+	 * symmetric event emission on all encryption state transitions.
+	 */
+	const diffAndEmit = (oldMap: Map<string, YKeyValueLwwEntry<T>>) => {
+		const changes = new Map<string, YKeyValueLwwChange<T>>();
+		const allKeys = new Set([...oldMap.keys(), ...map.keys()]);
+
+		for (const key of allKeys) {
+			const oldEntry = oldMap.get(key);
+			const newEntry = map.get(key);
+
+			if (!oldEntry && newEntry) {
+				changes.set(key, { action: 'add', newValue: newEntry.val });
+				continue;
+			}
+
+			if (oldEntry && !newEntry) {
+				changes.set(key, { action: 'delete' });
+				continue;
+			}
+
+			if (!oldEntry || !newEntry) continue;
+			if (Object.is(oldEntry.val, newEntry.val) || JSON.stringify(oldEntry.val) === JSON.stringify(newEntry.val)) continue;
+
+			changes.set(key, { action: 'update', newValue: newEntry.val });
+		}
+
+		if (changes.size === 0) return;
+		for (const handler of changeHandlers) handler(changes, undefined);
 	};
 
 	// Initialize wrapper.map from inner.map (decrypt any pre-existing entries)
@@ -387,56 +432,76 @@ export function createEncryptedYkvLww<T>(
 		},
 
 		/**
-		 * Activate encryption with a new encryption key. Rebuilds the decrypted map
-		 * from scratch and fires synthetic change events for any values
-		 * that changed.
+		 * Activate encryption with a new key. Saves the previous key and uses
+		 * it as a fallback when decrypting entries encrypted with the old key.
+		 * Only re-encrypts entries that needed the fallback key or were plaintext,
+		 * avoiding unnecessary CRDT mutations for entries already on the current key.
 		 *
 		 * @param nextKey - A 32-byte encryption key
 		 */
 		activateEncryption(nextKey) {
+			const previousKey = currentKey;
 			currentKey = nextKey;
+
 			const oldMap = new Map(map);
-			rebuildMap();
+			map.clear();
+			const needsReEncrypt: string[] = [];
 
-			// Encrypt any plaintext entries stored before encryption was activated
-			for (const [entryKey, entry] of inner.map) {
-				if (isEncryptedBlob(entry.val)) continue;
-				inner.set(entryKey, encryptValue(JSON.stringify(entry.val), nextKey, textEncoder.encode(entryKey)));
-			}
-
-			// Diff old vs new and fire change events
-			const changes = new Map<string, YKeyValueLwwChange<T>>();
-			const allKeys = new Set<string>([...oldMap.keys(), ...map.keys()]);
-
-			for (const key of allKeys) {
-				const oldEntry = oldMap.get(key);
-				const newEntry = map.get(key);
-
-				if (!oldEntry && newEntry) {
-					changes.set(key, { action: 'add', newValue: newEntry.val });
+			for (const [key, entry] of inner.map) {
+				if (!isEncryptedBlob(entry.val)) {
+					// Plaintext entry — always needs encryption
+					map.set(key, { ...entry, val: entry.val as T });
+					needsReEncrypt.push(key);
 					continue;
 				}
 
-				if (oldEntry && !newEntry) {
-					changes.set(key, { action: 'delete' });
-					continue;
+				// Try new key first
+				let decrypted = tryDecryptEntryWithKey(key, entry, nextKey);
+				if (decrypted) {
+					map.set(key, decrypted);
+					continue; // already encrypted with current key
 				}
 
-				if (!oldEntry || !newEntry) continue;
-				if (Object.is(oldEntry.val, newEntry.val) || JSON.stringify(oldEntry.val) === JSON.stringify(newEntry.val)) continue;
+				// Fall back to previous key
+				if (previousKey) {
+					decrypted = tryDecryptEntryWithKey(key, entry, previousKey);
+					if (decrypted) {
+						map.set(key, decrypted);
+						needsReEncrypt.push(key);
+						continue;
+					}
+				}
 
-				changes.set(key, { action: 'update', newValue: newEntry.val });
+				console.warn(`[encrypted-kv] Entry "${key}" undecryptable with current or previous key`);
 			}
 
-			if (changes.size === 0) return;
+			// Re-encrypt only entries that need it (plaintext or old-key)
+			for (const entryKey of needsReEncrypt) {
+				const plainVal = map.get(entryKey)!;
+				inner.set(entryKey, encryptValue(JSON.stringify(plainVal.val), nextKey, textEncoder.encode(entryKey)));
+			}
 
-			for (const handler of changeHandlers)
-				handler(changes, undefined);
+			diffAndEmit(oldMap);
 		},
 
+		/**
+		 * Deactivate encryption. Clears the key and emits delete events for
+		 * entries that are no longer readable (encrypted entries disappear,
+		 * plaintext entries remain visible).
+		 */
 		deactivateEncryption() {
 			currentKey = undefined;
+			const oldMap = new Map(map);
 			map.clear();
+
+			// Plaintext entries survive deactivation
+			for (const [key, entry] of inner.map) {
+				if (!isEncryptedBlob(entry.val)) {
+					map.set(key, { ...entry, val: entry.val as T });
+				}
+			}
+
+			diffAndEmit(oldMap);
 		},
 		get failedDecryptCount() {
 			return inner.map.size - map.size;

--- a/packages/workspace/src/workspace/compact.test.ts
+++ b/packages/workspace/src/workspace/compact.test.ts
@@ -130,13 +130,36 @@ describe('workspace.compact()', () => {
 		}
 	});
 
-	test('observers survive compact and fire on new doc', async () => {
+	test('observers on old doc stop firing after compact', async () => {
 		const { client } = setup();
 
 		const changes: string[] = [];
 		client.tables.posts.observe((ids) => {
 			for (const id of ids) changes.push(id);
 		});
+
+		client.tables.posts.set({ id: '1', title: 'Pre', _v: 1 });
+		expect(changes).toContain('1');
+
+		await client.compact();
+		client.tables.posts.set({ id: '2', title: 'Post', _v: 1 });
+
+		// Observer was on the old data doc — does not fire after compact
+		expect(changes).not.toContain('2');
+	});
+
+	test('re-registering observers via onEpochChange works', async () => {
+		const { client } = setup();
+
+		const changes: string[] = [];
+		function registerObserver() {
+			client.tables.posts.observe((ids) => {
+				for (const id of ids) changes.push(id);
+			});
+		}
+
+		registerObserver();
+		client.onEpochChange(() => registerObserver());
 
 		client.tables.posts.set({ id: '1', title: 'Pre', _v: 1 });
 		await client.compact();

--- a/packages/workspace/src/workspace/create-document.test.ts
+++ b/packages/workspace/src/workspace/create-document.test.ts
@@ -228,8 +228,8 @@ describe('createDocuments', () => {
 			});
 
 			let capturedOrigin: unknown = null;
-			tables.files.observe((_changedIds, transaction) => {
-				capturedOrigin = transaction.origin;
+			tables.files.observe((_changedIds, origin) => {
+				capturedOrigin = origin;
 			});
 
 			const handle = await documents.open('f1');

--- a/packages/workspace/src/workspace/create-document.ts
+++ b/packages/workspace/src/workspace/create-document.ts
@@ -60,15 +60,15 @@ import type {
 
 /**
  * Sentinel symbol used as the Y.js transaction origin when the documents manager
- * bumps `updatedAt` on a row. Consumers can check `transaction.origin === DOCUMENTS_ORIGIN`
+ * bumps `updatedAt` on a row. Consumers can check `origin === DOCUMENTS_ORIGIN`
  * to distinguish auto-bumps from user-initiated row changes.
  *
  * @example
  * ```typescript
  * import { DOCUMENTS_ORIGIN } from '@epicenter/workspace';
  *
- * client.tables.files.observe((changedIds, transaction) => {
- *   if (transaction.origin === DOCUMENTS_ORIGIN) {
+ * client.tables.files.observe((changedIds, origin) => {
+ *   if (origin === DOCUMENTS_ORIGIN) {
  *     // This was an auto-bump from a content doc edit
  *     return;
  *   }

--- a/packages/workspace/src/workspace/create-kv.ts
+++ b/packages/workspace/src/workspace/create-kv.ts
@@ -101,7 +101,7 @@ export function createKv<TKvDefinitions extends KvDefinitions>(
 		observeAll(
 			callback: (
 				changes: Map<string, KvChange<unknown>>,
-				transaction: unknown,
+				origin: unknown,
 			) => void,
 		) {
 			const handler = (

--- a/packages/workspace/src/workspace/create-kv.ts
+++ b/packages/workspace/src/workspace/create-kv.ts
@@ -10,7 +10,6 @@
  * and by tests.
  */
 
-import type * as Y from 'yjs';
 import type { YKeyValueLwwChange } from '../shared/y-keyvalue/y-keyvalue-lww.js';
 import type { YKeyValueLwwEncrypted } from '../shared/y-keyvalue/y-keyvalue-lww-encrypted.js';
 import type {
@@ -67,14 +66,14 @@ export function createKv<TKvDefinitions extends KvDefinitions>(
 
 			const handler = (
 				changes: Map<string, YKeyValueLwwChange<unknown>>,
-				transaction: Y.Transaction | undefined,
+				origin: unknown,
 			) => {
 				const change = changes.get(key);
 				if (!change) return;
 
 				switch (change.action) {
 					case 'delete':
-						callback({ type: 'delete' }, transaction);
+						callback({ type: 'delete' }, origin);
 						break;
 					case 'add':
 					case 'update': {
@@ -86,7 +85,7 @@ export function createKv<TKvDefinitions extends KvDefinitions>(
 								{ type: 'set', value: result.value } as Parameters<
 									typeof callback
 								>[0],
-								transaction,
+								origin,
 							);
 						}
 						// Skip callback for invalid values
@@ -107,7 +106,7 @@ export function createKv<TKvDefinitions extends KvDefinitions>(
 		) {
 			const handler = (
 				changes: Map<string, YKeyValueLwwChange<unknown>>,
-				transaction: Y.Transaction | undefined,
+				origin: unknown,
 			) => {
 				const parsed = new Map<string, KvChange<unknown>>();
 				for (const [key, change] of changes) {
@@ -127,7 +126,7 @@ export function createKv<TKvDefinitions extends KvDefinitions>(
 						}
 					}
 				}
-				if (parsed.size > 0) callback(parsed, transaction);
+				if (parsed.size > 0) callback(parsed, origin);
 			};
 			ykv.observe(handler);
 			return () => ykv.unobserve(handler);

--- a/packages/workspace/src/workspace/create-table.ts
+++ b/packages/workspace/src/workspace/create-table.ts
@@ -7,7 +7,6 @@
  * and by tests.
  */
 
-import type * as Y from 'yjs';
 import type { YKeyValueLwwChange } from '../shared/y-keyvalue/y-keyvalue-lww.js';
 import type { YKeyValueLwwEncrypted } from '../shared/y-keyvalue/y-keyvalue-lww-encrypted.js';
 import type {
@@ -17,7 +16,6 @@ import type {
 	RowResult,
 	TableDefinition,
 	TableHelper,
-	TransactionMeta,
 	UpdateResult,
 } from './types.js';
 
@@ -173,13 +171,13 @@ export function createTable<
 		// ═══════════════════════════════════════════════════════════════════════
 
 		observe(
-			callback: (changedIds: ReadonlySet<TRow['id']>, transaction: TransactionMeta) => void,
+			callback: (changedIds: ReadonlySet<TRow['id']>, origin?: unknown) => void,
 		): () => void {
 			const handler = (
 				changes: Map<string, YKeyValueLwwChange<unknown>>,
-				transaction: Y.Transaction | undefined,
+				origin: unknown,
 			) => {
-				callback(new Set(changes.keys()) as ReadonlySet<TRow['id']>, { origin: transaction?.origin });
+				callback(new Set(changes.keys()) as ReadonlySet<TRow['id']>, origin);
 			};
 
 			ykv.observe(handler);

--- a/packages/workspace/src/workspace/create-workspace.test.ts
+++ b/packages/workspace/src/workspace/create-workspace.test.ts
@@ -1223,7 +1223,10 @@ describe('.withEncryption() lifecycle', () => {
 			firstSaveDeferred.resolve();
 			await Promise.all([firstUnlock, secondUnlock]);
 
-			expect(userKeyStore.set).toHaveBeenCalledTimes(2);
+			// Only the second (current) key is written — the first key's
+			// persist task skips the write because activeUserKey has already
+			// changed to secondKey by the time the queued task runs.
+			expect(userKeyStore.set).toHaveBeenCalledTimes(1);
 			expect(cachedValue ?? '').toBe(bytesToBase64(secondKey));
 		});
 
@@ -1268,7 +1271,9 @@ describe('.withEncryption() lifecycle', () => {
 			expect(client.encryption.isUnlocked).toBe(false);
 			expect(userKeyStore.delete).toHaveBeenCalledTimes(1);
 			expect(cachedValue).toBe(null);
-			expect(events).toEqual(['set:start', 'set:end', 'delete']);
+			// The set task is skipped entirely because lock() clears
+			// activeUserKey synchronously before the queued task runs.
+			expect(events).toEqual(['delete']);
 		});
 
 		test('clearLocalData locks first and then runs persistence cleanup', async () => {

--- a/packages/workspace/src/workspace/create-workspace.ts
+++ b/packages/workspace/src/workspace/create-workspace.ts
@@ -114,6 +114,8 @@ import type {
 	EncryptionConfig,
 	ExtensionContext,
 	KvDefinitions,
+	TableHelper,
+	TablesHelper,
 	TableDefinitions,
 	WorkspaceClient,
 	WorkspaceClientBuilder,
@@ -129,11 +131,6 @@ function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
 	return true;
 }
 
-/** Table observer callback type for tracking across compaction. */
-type TableObserverCallback = (
-	changedIds: ReadonlySet<string>,
-	origin?: unknown,
-) => void;
 
 /**
  * Create a workspace client with chainable extension support.
@@ -197,59 +194,32 @@ export function createWorkspace<
 	// activateEncryption across tables and KV simultaneously.
 	const encryptedStores: YKeyValueLwwEncrypted<unknown>[] = [];
 
-	// ── Table observer tracking ─────────────────────────────────────────
-	// Observers registered via table.observe() are tracked so they can be
-	// re-registered on the new table helpers after compact().
-	const tableObserverRegistry = new Map<string, Set<TableObserverCallback>>();
+	// Create table stores + helpers (one encrypted KV per table)
 
 	// Create table stores + helpers (one encrypted KV per table)
 	const tableHelpers: Record<
 		string,
-		import('./types.js').TableHelper<BaseRow>
+		TableHelper<BaseRow>
 	> = {};
 	for (const [name, definition] of Object.entries(tableDefs)) {
 		const yarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>(TableKey(name));
 		const ykv = createEncryptedYkvLww(yarray, { key: options?.key });
 		encryptedStores.push(ykv);
 		const helper = createTable(ykv, definition);
-		tableHelpers[name] = wrapTableWithObserverTracking(name, helper);
+		tableHelpers[name] = helper;
 	}
 	const tables =
-		tableHelpers as import('./types.js').TablesHelper<TTableDefinitions>;
+		tableHelpers as TablesHelper<TTableDefinitions>;
 
-	/**
-	 * Wrap a table helper's observe method to track callbacks for compact re-registration.
-	 * Returns a new object that delegates all calls and tracks observe/unobserve.
-	 */
-	function wrapTableWithObserverTracking(
-		name: string,
-		helper: import('./types.js').TableHelper<BaseRow>,
-	): import('./types.js').TableHelper<BaseRow> {
-		if (!tableObserverRegistry.has(name)) {
-			tableObserverRegistry.set(name, new Set());
-		}
-		const registry = tableObserverRegistry.get(name)!;
-		const originalObserve = helper.observe;
-
-		return {
-			...helper,
-			observe(callback: TableObserverCallback) {
-				registry.add(callback);
-				const unsub = originalObserve.call(helper, callback);
-				return () => {
-					registry.delete(callback);
-					unsub();
-				};
-			},
-		};
-	}
 
 	// Create KV store + helper (single shared encrypted KV)
 	const kvYarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>(KV_KEY);
 	let kvStore = createEncryptedYkvLww(kvYarray, { key: options?.key });
 	encryptedStores.push(kvStore);
 	let kvHelper = createKv(kvStore, kvDefs);
-	const awareness = createAwareness(ydoc, awarenessDefs);
+	// Awareness lives on the coordination doc — it represents peer presence,
+	// which persists across data doc epoch transitions (compaction).
+	const awareness = createAwareness(coordYdoc, awarenessDefs);
 	const definitions = {
 		tables: tableDefs,
 		kv: kvDefs,
@@ -367,7 +337,7 @@ export function createWorkspace<
 		const freshEncryptedStores: YKeyValueLwwEncrypted<unknown>[] = [];
 		const freshTableHelpers: Record<
 			string,
-			import('./types.js').TableHelper<BaseRow>
+			TableHelper<BaseRow>
 		> = {};
 
 		for (const [name, definition] of Object.entries(tableDefs)) {
@@ -386,14 +356,7 @@ export function createWorkspace<
 				}
 			}
 
-			const wrapped = wrapTableWithObserverTracking(name, newHelper);
-			const registry = tableObserverRegistry.get(name);
-			if (registry) {
-				for (const cb of registry) {
-					newHelper.observe(cb);
-				}
-			}
-			freshTableHelpers[name] = wrapped;
+			freshTableHelpers[name] = newHelper;
 		}
 
 		// Fresh KV

--- a/packages/workspace/src/workspace/create-workspace.ts
+++ b/packages/workspace/src/workspace/create-workspace.ts
@@ -502,6 +502,13 @@ export function createWorkspace<
 		}
 
 		// ── COMMIT (synchronous) ─────────────────────────────────────
+		// For local compact (dataToWrite present), bump the epoch NOW —
+		// after prep succeeded but before committing. This ensures the
+		// coordination doc is only updated if the swap will complete.
+		// For remote swaps, the epoch was already bumped by the remote client.
+		if (dataToWrite) {
+			epochTracker.bumpEpoch();
+		}
 		const oldYdoc = ydoc;
 		const oldCleanups = [...state.extensionCleanups];
 
@@ -719,14 +726,13 @@ export function createWorkspace<
 						kvSnapshot[key] = raw;
 					}
 				}
-
-				// Guard: bumpEpoch fires the epoch observer synchronously,
-				// which calls requestSwap. Setting isSwapping prevents the
-				// observer from starting a concurrent drainSwapQueue.
+				// Guard: the epoch observer fires synchronously when the
+				// coordination doc changes (inside doBlueGreenSwap's commit).
+				// Setting isSwapping prevents the observer from racing.
 				isSwapping = true;
-				const newEpoch = epochTracker.bumpEpoch();
+				const nextEpoch = epochTracker.getEpoch() + 1;
 				try {
-					await doBlueGreenSwap(newEpoch, state, extensions, {
+					await doBlueGreenSwap(nextEpoch, state, extensions, {
 						tables: tableSnapshots,
 						kv: kvSnapshot,
 					});

--- a/packages/workspace/src/workspace/create-workspace.ts
+++ b/packages/workspace/src/workspace/create-workspace.ts
@@ -671,15 +671,18 @@ export function createWorkspace<
 			 * copies all current table rows and KV entries into it, bumps
 			 * the epoch in the coordination doc, and tears down the old data doc.
 			 *
-			 * Other connected clients will see the epoch change via CRDT
-			 * sync on the coordination doc and automatically transition.
+			 * **Important:** Compaction invalidates all existing table and KV
+			 * observers (they were bound to the old Y.Doc). Callers should
+			 * reload the page or recreate the client after compaction.
+			 *
+			 * Other connected clients will detect the epoch change via the
+			 * coordination doc's `onEpochChange` callback and should reload
+			 * as well.
 			 *
 			 * @example
 			 * ```typescript
-			 * const sizeBefore = Y.encodeStateAsUpdate(client.ydoc).byteLength;
 			 * await client.compact();
-			 * const sizeAfter = Y.encodeStateAsUpdate(client.ydoc).byteLength;
-			 * // sizeAfter < sizeBefore (no CRDT history overhead)
+			 * window.location.reload();
 			 * ```
 			 */
 			async compact(): Promise<void> {
@@ -725,9 +728,20 @@ export function createWorkspace<
 			dispose,
 			[Symbol.asyncDispose]: dispose,
 			/**
-			 * Register a callback for epoch transitions. Fires after a successful
-			 * swap with the new epoch number. Opt-in—not required for correctness.
-			 * Returns an unsubscribe function.
+			 * Register a callback for epoch transitions (local or remote).
+			 *
+			 * Fires after a successful data doc swap with the new epoch number.
+			 * Since compaction invalidates all table and KV observers, the
+			 * recommended response is to reload the page or recreate the client.
+			 *
+			 * @example
+			 * ```typescript
+			 * workspace.onEpochChange(() => {
+			 *   window.location.reload();
+			 * });
+			 * ```
+			 *
+			 * @returns Unsubscribe function
 			 */
 			onEpochChange(callback: (epoch: number) => void): () => void {
 				epochChangeCallbacks.push(callback);

--- a/packages/workspace/src/workspace/create-workspace.ts
+++ b/packages/workspace/src/workspace/create-workspace.ts
@@ -115,7 +115,6 @@ import type {
 	ExtensionContext,
 	KvDefinitions,
 	TableDefinitions,
-	TransactionMeta,
 	WorkspaceClient,
 	WorkspaceClientBuilder,
 	WorkspaceDefinition,
@@ -133,7 +132,7 @@ function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
 /** Table observer callback type for tracking across compaction. */
 type TableObserverCallback = (
 	changedIds: ReadonlySet<string>,
-	transaction: TransactionMeta,
+	origin?: unknown,
 ) => void;
 
 /**

--- a/packages/workspace/src/workspace/create-workspace.ts
+++ b/packages/workspace/src/workspace/create-workspace.ts
@@ -449,9 +449,17 @@ export function createWorkspace<
 			}
 		}
 
-		// Wait for all new extensions to be ready
+		// Wait for all new extensions to be ready (with timeout)
 		try {
-			await Promise.all(freshWhenReady);
+			await Promise.race([
+				Promise.all(freshWhenReady),
+				new Promise<never>((_, reject) =>
+					setTimeout(
+						() => reject(new Error('[workspace] Extension init timed out during epoch transition')),
+						10_000,
+					),
+				),
+			]);
 		} catch (err) {
 			await disposeLifo(freshCleanups);
 			throw err;

--- a/packages/workspace/src/workspace/create-workspace.ts
+++ b/packages/workspace/src/workspace/create-workspace.ts
@@ -921,13 +921,18 @@ export function createWorkspace<
 
 					try {
 						await runSerializedCacheTask(async () => {
-							await config.userKeyStore.set(bytesToBase64(userKey));
+							// Guard: only write if this key is still the active one.
+							// A rapid unlock(keyA) → unlock(keyB) sequence queues two
+							// writes. By the time keyA's task runs, activeUserKey is
+							// already keyB — skip the stale write entirely.
 							if (
-								activeUserKey !== undefined &&
-								bytesEqual(activeUserKey, userKey)
-							) {
-								isActiveUserKeyCached = true;
-							}
+								activeUserKey === undefined ||
+								!bytesEqual(activeUserKey, userKey)
+							)
+								return;
+
+							await config.userKeyStore.set(bytesToBase64(userKey));
+							isActiveUserKeyCached = true;
 						});
 					} catch (error) {
 						console.error('[workspace] User key cache save failed:', error);
@@ -939,15 +944,28 @@ export function createWorkspace<
 						activeUserKey !== undefined && bytesEqual(activeUserKey, userKey);
 
 					if (!isSameUserKey) {
+						const nextWorkspaceKey = deriveWorkspaceKey(userKey, id);
+						const previousWorkspaceKey = workspaceKey;
+						const activated: YKeyValueLwwEncrypted<unknown>[] = [];
 						try {
-							const nextWorkspaceKey = deriveWorkspaceKey(userKey, id);
 							for (const store of encryptedStores) {
 								store.activateEncryption(nextWorkspaceKey);
+								activated.push(store);
 							}
 							workspaceKey = nextWorkspaceKey;
 							activeUserKey = userKey;
 							isActiveUserKeyCached = config?.userKeyStore === undefined;
 						} catch (error) {
+							// Rollback: revert stores activated before the failure
+							for (const store of activated) {
+								try {
+									if (previousWorkspaceKey) {
+										store.activateEncryption(previousWorkspaceKey);
+									} else {
+										store.deactivateEncryption();
+									}
+								} catch { /* best-effort rollback */ }
+							}
 							console.error('[workspace] Workspace unlock failed:', error);
 							return;
 						}

--- a/packages/workspace/src/workspace/index.ts
+++ b/packages/workspace/src/workspace/index.ts
@@ -162,7 +162,6 @@ export type {
 	TableDefinitions,
 	// Helper types
 	TableHelper,
-	TransactionMeta,
 	TablesHelper,
 	UpdateResult,
 	// Result types - building blocks

--- a/packages/workspace/src/workspace/types.ts
+++ b/packages/workspace/src/workspace/types.ts
@@ -528,11 +528,6 @@ export type InferKvValue<T> =
  *
  * @typeParam TRow - The fully-typed row shape for this table (extends `{ id: string }`)
  */
-/** Transaction metadata exposed to table observe() callbacks. */
-export type TransactionMeta = {
-	/** The origin of this transaction. `null` for local writes, non-null for remote syncs. */
-	origin: unknown;
-};
 
 export type TableHelper<TRow extends BaseRow> = {
 	// ═══════════════════════════════════════════════════════════════════════
@@ -680,16 +675,17 @@ export type TableHelper<TRow extends BaseRow> = {
 	 * - `status === 'not_found'` → the row was deleted
 	 * - Otherwise → the row was added or updated
 	 *
-	 * Changes are batched per Y.Transaction. The `transaction` object exposes
-	 * `origin` for distinguishing local writes (`null`) from remote syncs.
+	 * Changes are batched per Y.Transaction. The `origin` parameter exposes
+	 * the transaction origin for distinguishing local writes (`null`) from remote syncs.
+	 * Encryption lifecycle events (activate/deactivate) pass `undefined`.
 	 *
-	 * @param callback - Receives changed IDs and transaction metadata
+	 * @param callback - Receives changed IDs and optional transaction origin
 	 * @returns Unsubscribe function
 	 */
 	observe(
 		callback: (
 			changedIds: ReadonlySet<TRow['id']>,
-			transaction: TransactionMeta,
+			origin?: unknown,
 		) => void,
 	): () => void;
 

--- a/packages/workspace/src/workspace/types.ts
+++ b/packages/workspace/src/workspace/types.ts
@@ -903,14 +903,14 @@ export type KvHelper<TKvDefinitions extends KvDefinitions> = {
 	 * are silently skipped—the callback only fires for valid state transitions.
 	 *
 	 * @param key - The KV key to observe
-	 * @param callback - Receives the change event and the Yjs transaction
+	 * @param callback - Receives the change event and the transaction origin
 	 * @returns Unsubscribe function
 	 */
 	observe<K extends keyof TKvDefinitions & string>(
 		key: K,
 		callback: (
 			change: KvChange<InferKvValue<TKvDefinitions[K]>>,
-			transaction: unknown,
+			origin?: unknown,
 		) => void,
 	): () => void;
 
@@ -924,13 +924,13 @@ export type KvHelper<TKvDefinitions extends KvDefinitions> = {
 	 * Useful for bulk reactivity (e.g., syncing all settings to a SvelteMap)
 	 * without registering per-key observers.
 	 *
-	 * @param callback - Receives a Map of changed keys to their KvChange, plus the transaction
+	 * @param callback - Receives a Map of changed keys to their KvChange, plus the transaction origin
 	 * @returns Unsubscribe function
 	 */
 	observeAll(
 		callback: (
 			changes: Map<keyof TKvDefinitions & string, KvChange<unknown>>,
-			transaction: unknown,
+			origin?: unknown,
 		) => void,
 	): () => void;
 };

--- a/specs/20260401T160000-self-managed-encryption-password.md
+++ b/specs/20260401T160000-self-managed-encryption-password.md
@@ -1,0 +1,398 @@
+# Self-Managed Encryption Password
+
+**Date**: 2026-04-01
+**Status**: Draft
+**Author**: AI-assisted (Sisyphus + Oracle + Librarian research)
+
+## Overview
+
+Add an opt-in mode where users provide their own encryption password instead of relying on the server-derived key. The server never sees the encryption key in this mode—functionally zero-knowledge. Users can switch between server-managed and self-managed encryption, and change their encryption password.
+
+## Motivation
+
+### Current State
+
+Encryption keys derive from the server's `ENCRYPTION_SECRETS` environment variable. The flow:
+
+```
+Server: HKDF(SHA-256(ENCRYPTION_SECRETS), "user:{userId}") → userKey
+  → sent to client as userKeyBase64 in session response
+Client: HKDF(userKey, "workspace:{workspaceId}") → workspaceKey
+  → activateEncryption(workspaceKey) on all stores
+```
+
+The server can derive every user's key. For Epicenter Cloud, this is intentional—it enables search, AI, and password recovery. For self-hosted deployments, the user controls the server, so it's functionally zero-knowledge.
+
+```typescript
+// apps/api/src/auth/encryption.ts — server always sends the key
+export async function deriveUserEncryptionKey(userId: string) {
+    const userKey = await deriveUserKey(currentKeySecret, userId);
+    return {
+        userKeyBase64: bytesToBase64(userKey),
+        keyVersion: currentKeyVersion,
+    };
+}
+```
+
+```typescript
+// apps/honeycrisp/src/lib/client.ts — client always receives it
+onLogin(session) {
+    workspace.unlockWithKey(session.userKeyBase64);
+}
+```
+
+This creates one problem:
+
+1. **No true zero-knowledge option for cloud users.** A user on Epicenter Cloud who wants the server unable to read their data has no path to that today. The only option is self-hosting, which not everyone can do. The articles ("If You Don't Trust the Server, Become the Server") argue this is acceptable, but offering an opt-in ZK mode costs very little given the existing architecture.
+
+### Desired State
+
+Two encryption modes per workspace, switchable at runtime:
+
+```typescript
+// Server-managed (default, unchanged):
+onLogin(session) {
+    workspace.unlockWithKey(session.userKeyBase64);  // server sends key
+}
+
+// Self-managed (opt-in):
+// Server sends no key. Client prompts for password.
+const userKey = await deriveKeyFromPassword(password, salt);
+await workspace.encryption.unlock(userKey);
+```
+
+The encryption layer itself (`createEncryptedYkvLww`, `activateEncryption`, HKDF derivation) stays identical. Only the key source changes.
+
+## Research Findings
+
+### Existing Infrastructure Readiness
+
+Investigated every component in the encryption stack to determine what already supports this and what doesn't.
+
+| Component | Ready? | Evidence |
+|---|---|---|
+| `activateEncryption(nextKey)` with previous-key fallback | ✅ | Lines 444-489 of `y-keyvalue-lww-encrypted.ts`—saves `previousKey`, decrypts with fallback, re-encrypts only entries that need it |
+| `deriveKeyFromPassword(password, salt)` | ✅ | `crypto/index.ts`—PBKDF2 with 600K iterations, returns 32-byte key |
+| `deriveSalt(userId, workspaceId)` | ⚠️ | Exists but has concatenation collision bug (`"user1" + "23ws"` === `"user12" + "3ws"`) |
+| `deriveWorkspaceKey(userKey, workspaceId)` | ✅ | HKDF-SHA256 per-workspace isolation, key-source agnostic |
+| `unlock(userKey)` API | ✅ | `create-workspace.ts` line 961—accepts any `Uint8Array`, doesn't care about source |
+| `UserKeyStore` caching | ✅ | Interface + IndexedDB implementation, stores base64 key regardless of source |
+| Auto-boot from cache | ✅ | `create-workspace.ts` lines 1002-1016—reads cached key on startup |
+| Server keyring parsing | ✅ | `apps/api/src/auth/encryption.ts`—`ENCRYPTION_SECRETS` supports versioned keys |
+| Password change / `changeKey` | ❌ | No explicit API. But `activateEncryption` with fallback handles the mechanics |
+| Mode flag (self-managed vs server-managed) | ❌ | Doesn't exist anywhere |
+| Multi-device password change detection | ❌ | `failedDecryptCount` exists but nothing watches it for re-prompting |
+
+### How Other E2EE Apps Handle This
+
+Research from librarian agents across Notesnook, Standard Notes, Anytype, SecSync, and Matrix.
+
+| Product | Key Source | Password Change | Multi-device |
+|---|---|---|---|
+| Standard Notes | PBKDF2 from password → per-item keys | Re-encrypt all items with new key | Other devices prompted for new password |
+| Notesnook | Client-side, XChaCha20 + Argon2 | Re-derive key, re-encrypt | Sync delivers new ciphertext, old key fails |
+| Bitwarden | PBKDF2 from master password → HKDF split for auth/encryption | Server never sees master password; re-encrypt vault on change | All devices re-prompted |
+
+The pattern is consistent: PBKDF2 from password, re-encrypt on change, other devices detect failure and re-prompt.
+
+### Key Transition Mechanics (Already Implemented)
+
+The `activateEncryption` code already handles old-key→new-key transitions:
+
+```
+activateEncryption(nextKey):
+  1. Save previousKey = currentKey
+  2. Set currentKey = nextKey
+  3. For each entry in inner.map:
+     a. Try decrypt with nextKey → success? Already on current key, skip
+     b. Try decrypt with previousKey → success? Mark for re-encryption
+     c. Both fail → warn, skip (failedDecryptCount increases)
+  4. Re-encrypt marked entries with nextKey (batched in Y.Transaction)
+  5. Diff old vs new plaintext map, emit synthetic change events
+```
+
+This means calling `unlock(newKey)` while the old key is active already re-encrypts everything. A `changePassword` API is a thin wrapper—derive new key, call unlock.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Where to store mode flag | Server-side (workspace settings table or user preferences) | Server needs to know whether to include `userKeyBase64` in the session response. Client-side only wouldn't sync across devices. |
+| One password or two | Two: auth password (email/password for Better Auth) + encryption password (PBKDF2 for workspace key) | Same-password requires SRP or similar protocol change to prevent server from seeing the password. Two passwords is simpler and the auth layer stays untouched. |
+| Salt derivation | `HKDF(SHA-256(userId + ":" + workspaceId), 16)` — fix concatenation collision with separator | Deterministic from known values, no storage needed. The separator prevents `("user1", "23ws")` colliding with `("user12", "3ws")`. |
+| Password change mechanism | Thin wrapper over existing `unlock()` which calls `activateEncryption` with previous-key fallback | The mechanics already work. No new CRDT primitive needed. |
+| Features disabled in self-managed mode | Server-side search, AI summarization, password recovery for encryption key | Server can't read data without the key. Auth password recovery still works (Better Auth handles that). |
+| `changePassword` API location | On `WorkspaceEncryption` (exposed via `workspace.encryption.changePassword`) | Consistent with existing `workspace.encryption.unlock` and `workspace.encryption.lock` |
+| Multi-device password change detection | Watch `failedDecryptCount` after sync delivers new entries | Already computed as `inner.map.size - map.size`. No new state needed. |
+| Mode switching direction | Both directions supported: server→self, self→server | Server→self: client re-encrypts with password-derived key. Self→server: server sends its derived key, client re-encrypts with that. Both use `activateEncryption`. |
+
+## Architecture
+
+### Key Derivation—Two Paths, Same Destination
+
+```
+SERVER-MANAGED (default):
+  ENCRYPTION_SECRETS + userId
+    → HKDF(SHA-256(secret), "user:{userId}")
+    → userKey (32 bytes, sent to client in session)
+    → HKDF(userKey, "workspace:{workspaceId}")
+    → workspaceKey
+    → activateEncryption(workspaceKey)
+
+SELF-MANAGED (opt-in):
+  User enters encryption password
+    → PBKDF2(password, salt, 600K iterations) ~500ms
+    → userKey (32 bytes, never leaves client)
+    → HKDF(userKey, "workspace:{workspaceId}")    ← same as above
+    → workspaceKey                                  ← same as above
+    → activateEncryption(workspaceKey)              ← same as above
+```
+
+Everything below `userKey` is identical. The entire change is above the `userKey` boundary.
+
+### Password Change Flow
+
+```
+1. User is unlocked (old key active, plaintext cached in wrapper.map)
+2. User enters old password + new password
+3. Client: PBKDF2(oldPassword, salt) → oldUserKey
+4. Client: verify bytesEqual(oldUserKey, activeUserKey) → reject if wrong
+5. Client: PBKDF2(newPassword, salt) → newUserKey
+6. Client: workspace.encryption.unlock(newUserKey)
+   └─ activateEncryption(newWorkspaceKey):
+      ├─ previousKey = oldWorkspaceKey (saved automatically)
+      ├─ Try each entry with newKey → fails (encrypted with old)
+      ├─ Fallback to previousKey → succeeds → mark for re-encrypt
+      └─ Re-encrypt all entries with newKey (batched transaction)
+7. Sync propagates new ciphertext to other devices
+8. Client: update UserKeyStore cache with newUserKey
+```
+
+### Multi-Device After Password Change
+
+```
+Device A: changes password → re-encrypts → syncs new ciphertext
+                                              │
+Device B: receives new ciphertext via sync ───┘
+  → activateEncryption auto-runs on observer? No—
+  → Old cached key tries to decrypt new blobs → fails
+  → failedDecryptCount > 0
+  → UI detects this → shows "Encryption password changed" prompt
+  → User enters new password → PBKDF2 → unlock → data readable
+```
+
+### Mode Switch Flow
+
+```
+SERVER-MANAGED → SELF-MANAGED:
+  1. User clicks "Manage my own encryption password"
+  2. Server marks workspace as self-managed
+  3. Client prompts for new encryption password
+  4. Client: PBKDF2(password, salt) → newUserKey
+  5. Client: workspace.encryption.unlock(newUserKey)
+     └─ activateEncryption re-encrypts with new key
+  6. Server stops sending userKeyBase64 for this workspace
+
+SELF-MANAGED → SERVER-MANAGED:
+  1. User clicks "Let Epicenter manage encryption"
+  2. User enters current encryption password (to verify identity)
+  3. Server derives key: HKDF(secret, userId) → serverUserKey
+  4. Server sends serverUserKey to client
+  5. Client: workspace.encryption.unlock(serverUserKey)
+     └─ activateEncryption re-encrypts with server key
+  6. Server marks workspace as server-managed
+  7. Future sessions include userKeyBase64 automatically
+```
+
+## Implementation Plan
+
+### Phase 1: Fix Existing Bugs
+
+Before adding new features, fix the issues found during analysis.
+
+- [ ] **1.1** Fix `deriveSalt` concatenation collision—add `":"` separator between `userId` and `workspaceId`
+- [ ] **1.2** Fix `bytesToBase64` stack bomb—replace `String.fromCharCode(...bytes)` spread with loop (in `crypto/index.ts`, the shared version—the server version at `apps/api/src/auth/encryption.ts` line 104 already uses a loop)
+
+### Phase 2: Core Encryption Primitives
+
+Add `changePassword` capability to the workspace encryption runtime. No UI, no server changes—just the primitive.
+
+- [ ] **2.1** Add `changePassword(oldPassword: string, newPassword: string): Promise<void>` to `WorkspaceEncryption` type in `create-workspace.ts`
+  - Derive old key, verify against active key
+  - Derive new key, call `unlock(newKey)` (which handles re-encryption via `activateEncryption`)
+  - Update `UserKeyStore` cache
+  - Requires `userId` in scope—pass via `EncryptionConfig` or closure from `withEncryption`
+- [ ] **2.2** Add `unlockWithPassword(password: string): Promise<void>` convenience method alongside `unlockWithKey`
+  - Wraps `deriveKeyFromPassword` + `deriveSalt` + `unlock`
+  - Requires `userId` in scope
+- [ ] **2.3** Export `deriveKeyFromPassword` and `deriveSalt` from the workspace package public API (currently internal to `crypto/index.ts`)
+- [ ] **2.4** Write tests: password-based unlock, password change with re-encryption verification, wrong old password rejection
+
+### Phase 3: Server Mode Flag
+
+Make the server aware of encryption mode so it can conditionally send (or not send) the key.
+
+- [ ] **3.1** Add `encryptionMode` field to workspace/user settings (database schema). Values: `'server'` (default) | `'self'`
+- [ ] **3.2** Update `customSession()` hook in `create-auth.ts`—skip `deriveUserEncryptionKey` when mode is `'self'`
+- [ ] **3.3** Add API endpoint: `POST /workspaces/:id/encryption-mode` to toggle the mode
+  - When switching to `'self'`: just flip the flag (client handles re-encryption)
+  - When switching to `'server'`: flip the flag and return the server-derived key so the client can re-encrypt
+- [ ] **3.4** Update session response types to make `userKeyBase64` and `keyVersion` nullable
+
+### Phase 4: Client Integration
+
+Wire the mode into the client auth flow and workspace initialization.
+
+- [ ] **4.1** Update `onLogin` handler pattern—check if `session.userKeyBase64` is present
+  - If present: `workspace.unlockWithKey(session.userKeyBase64)` (unchanged)
+  - If absent: rely on auto-boot from cache, or signal UI to prompt
+- [ ] **4.2** Add `workspace.encryption.mode: 'server' | 'self' | 'unknown'` reactive state
+  - Derived from session response (key present = server, key absent = self)
+  - `'unknown'` before session loads
+- [ ] **4.3** Add `workspace.encryption.needsPassword: boolean` reactive state
+  - True when: mode is `'self'` AND not unlocked AND no cached key
+  - UI components bind to this to show/hide the password prompt
+- [ ] **4.4** Add `workspace.encryption.passwordChanged: boolean` reactive state
+  - True when: unlocked but `failedDecryptCount > 0` after sync
+  - Triggers re-prompt on other devices after password change
+
+### Phase 5: UI Components
+
+Build the Svelte components for password management.
+
+- [ ] **5.1** `EncryptionPasswordGate.svelte`—wraps page content, shows password prompt when `needsPassword` is true
+  - Password input, submit button, error state for wrong password
+  - Shows ~500ms spinner during PBKDF2 derivation
+  - On success: slot content renders (workspace data visible)
+- [ ] **5.2** `EncryptionPasswordChanged.svelte`—banner/dialog shown when `passwordChanged` is true
+  - "Your encryption password was changed on another device. Enter your new password."
+  - Password input, submit on enter
+- [ ] **5.3** `ChangeEncryptionPassword.svelte`—settings panel component
+  - Old password, new password, confirm new password
+  - Calls `workspace.encryption.changePassword(old, new)`
+  - Success toast, error handling for wrong old password
+- [ ] **5.4** `EncryptionModeSwitch.svelte`—settings panel toggle
+  - Switch between "Epicenter manages encryption" and "I manage my own password"
+  - Server→self: prompts for new encryption password
+  - Self→server: prompts for current password (verification), then switches
+  - Warning copy: "Self-managed encryption cannot be recovered if you forget your password"
+
+### Phase 6: Documentation
+
+- [ ] **6.1** Update `apps/api/README.md` encryption section—document the two modes
+- [ ] **6.2** Update or create article explaining the self-managed option and when to use it
+- [ ] **6.3** Add JSDoc to new public APIs (`changePassword`, `unlockWithPassword`, `encryptionMode`)
+
+## Edge Cases
+
+### Password change interrupted mid-re-encryption
+
+1. User initiates password change. `activateEncryption` starts re-encrypting entries.
+2. App crashes or tab closes during re-encryption.
+3. Some entries are encrypted with new key, some with old key.
+
+**Outcome**: On next launch, the cached key is the new key (cache updates after `unlock` succeeds). `activateEncryption` runs with `previousKey` = undefined (no old key in memory). Entries still on old key fail to decrypt and show in `failedDecryptCount`. User can't recover without the old password.
+
+**Mitigation**: `activateEncryption` uses `inner.doc.transact()` for re-encryption writes (line 481), so all CRDT mutations are batched. Yjs transactions are atomic within a single JS event loop tick—XChaCha20 is synchronous, so the entire re-encryption completes in one transaction. The risk of partial re-encryption is extremely low (process kill, not a JS exception).
+
+**Recommendation**: Accept the risk. For belt-and-suspenders, keep the old key in the `UserKeyStore` as a fallback entry until re-encryption is confirmed complete. Defer to Open Questions.
+
+### User forgets encryption password
+
+1. Self-managed mode. User forgets their encryption password.
+2. No recovery possible—server doesn't have the key.
+
+**Outcome**: Data is permanently inaccessible. Auth still works (different password). Workspace can be reset (delete encrypted data, start fresh).
+
+**Mitigation**: Clear warning during self-managed setup. Consider recovery codes (see Open Questions).
+
+### Two devices change password simultaneously
+
+1. Device A changes password to "alpha". Device B changes password to "beta". Both online.
+2. Both re-encrypt all entries with their respective new keys.
+3. Sync delivers both sets of encrypted entries.
+
+**Outcome**: LWW timestamp resolution picks the latest write per entry. Some entries end up encrypted with "alpha" key, some with "beta" key. Neither device can decrypt all entries.
+
+**Mitigation**: This is a user error (changing password on two devices simultaneously). The `failedDecryptCount` mechanism will surface the problem. The user would need to pick one password and re-enter it on both devices. In practice, password changes are rare and sequential.
+
+**Recommendation**: Accept the risk. Document that password changes should be done on one device at a time.
+
+### Switching modes while other devices are offline
+
+1. Device A switches from server-managed to self-managed. Sets encryption password.
+2. Device B is offline. Has server-derived key cached.
+3. Device B comes online. Sync delivers entries encrypted with password-derived key.
+
+**Outcome**: Device B's cached server key can't decrypt new entries. `failedDecryptCount > 0`. But Device B doesn't know the encryption password—it was using server-managed mode.
+
+**Mitigation**: The mode flag syncs via the server. When Device B reconnects, its next `getSession()` call returns no `userKeyBase64` (server knows mode changed). The client detects this and shows the password prompt.
+
+### Self-managed mode with no `userId` available
+
+1. `deriveSalt(userId, workspaceId)` requires `userId`.
+2. In self-managed mode, the user is authenticated (Better Auth handles auth). `userId` is available from the session.
+3. But what about pre-auth state? If the user isn't signed in yet, there's no `userId` for salt derivation.
+
+**Outcome**: Not a problem. Self-managed encryption still requires authentication (Better Auth sign-in). The encryption password is a second layer on top of auth. `userId` is always available when the encryption prompt appears.
+
+## Open Questions
+
+1. **Should we support recovery codes for self-managed mode?**
+   - If yes: generate N random words at setup time, user stores them. Recovery code derives the same key as the password (via a different path). Adds complexity.
+   - If no: simpler implementation, but "forgot password = data gone" is harsh.
+   - **Recommendation**: Defer. Ship without recovery codes. The self-managed audience understands the tradeoff (they opted in). Add recovery codes later if user feedback demands it.
+
+2. **Should the old key be kept as a fallback in `UserKeyStore` during password change?**
+   - If yes: cache stores `{ current: base64, previous: base64 }`. Auto-boot tries current, falls back to previous. Protects against interrupted re-encryption.
+   - If no: simpler cache, but interrupted re-encryption means data loss.
+   - **Recommendation**: Keep it simple—single key in cache. The re-encryption is transactional (synchronous XChaCha20 in a Yjs transaction). The risk is negligible.
+
+3. **Per-workspace or per-user encryption mode?**
+   - Per-workspace: different workspaces can have different modes. More granular. User might forget which workspaces are self-managed.
+   - Per-user: all workspaces use the same mode. Simpler mental model.
+   - **Recommendation**: Per-user. A user who opts into self-managed encryption wants it everywhere. Simplifies UI and reduces confusion. The mode flag lives on the user record, not workspace settings.
+
+4. **Should self-managed mode use a single password for all workspaces?**
+   - Yes (single password): one PBKDF2 derivation → userKey → HKDF per workspace. Same as server-managed but with a different key source. User remembers one password.
+   - No (per-workspace passwords): more secure isolation, but absurd UX.
+   - **Recommendation**: Single password. HKDF already provides per-workspace isolation from a single userKey. This mirrors the server-managed model exactly.
+
+5. **What happens to server-side search/AI indexes when switching to self-managed?**
+   - The server can no longer read data. Existing indexes become stale.
+   - Options: (a) delete indexes on switch, (b) keep stale indexes, (c) show warning that search/AI won't work
+   - **Recommendation**: Delete indexes on switch to self-managed. Show a clear warning before switching: "Server-side search and AI features will be disabled."
+
+6. **Should `EncryptionConfig` accept `userId` directly, or should it be injected later?**
+   - `withEncryption({ userKeyStore, userId })` — requires userId at workspace creation time, which may not be available yet (pre-auth).
+   - `withEncryption({ userKeyStore })` with userId injected via `unlockWithPassword(password, userId)` — more flexible but less ergonomic.
+   - **Recommendation**: Accept `userId` on the method calls (`unlockWithPassword`, `changePassword`), not in config. The workspace is created before auth completes. userId arrives with the session.
+
+## Success Criteria
+
+- [ ] A workspace can be unlocked with a user-provided password via `unlockWithPassword(password, userId)`
+- [ ] Password change re-encrypts all entries and syncs new ciphertext to other devices
+- [ ] Other devices detect password change (`failedDecryptCount > 0`) and prompt for new password
+- [ ] Server omits `userKeyBase64` from session response when mode is `'self'`
+- [ ] Mode can be switched in both directions (server→self, self→server) with re-encryption
+- [ ] Auto-boot from cached key works identically in both modes
+- [ ] `deriveSalt` concatenation collision is fixed
+- [ ] Wrong old password is rejected with a clear error
+- [ ] Self-managed setup shows an unrecoverable-password warning
+- [ ] All existing tests continue to pass (server-managed mode is unchanged)
+- [ ] New tests cover: password-based unlock, password change, wrong password, mode switch
+
+## References
+
+- `packages/workspace/src/shared/crypto/index.ts` — Encryption primitives, `deriveKeyFromPassword`, `deriveSalt`, `deriveWorkspaceKey`
+- `packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts` — Encrypted KV wrapper, `activateEncryption` with previous-key fallback
+- `packages/workspace/src/workspace/create-workspace.ts` — `withEncryption()` builder, `unlock`, `lock`, `EncryptionRuntime`
+- `packages/workspace/src/workspace/user-key-store.ts` — `UserKeyStore` interface
+- `apps/api/src/auth/encryption.ts` — Server-side key derivation, keyring parsing
+- `apps/api/src/auth/create-auth.ts` — `customSession()` hook that sends `userKeyBase64`
+- `packages/svelte-utils/src/auth/create-auth.svelte.ts` — Client auth with `onLogin`/`onLogout` hooks
+- `packages/svelte-utils/src/indexed-db-key-store.ts` — IndexedDB `UserKeyStore` implementation
+- `docs/articles/if-you-dont-trust-the-server-become-the-server.md` — Philosophy article on trust model
+- `docs/articles/let-the-server-handle-encryption.md` — Philosophy article on server-managed keys
+- `docs/articles/why-epicenter-doesnt-encrypt-without-authentication.md` — Why no encryption pre-auth
+- `specs/20260328T120000-key-version-propagation.md` — Related DRAFT spec for keyVersion propagation


### PR DESCRIPTION
After landing the blue-green epoch swap, real-world testing revealed a class of edge cases where the encryption layer and compaction machinery interact poorly—partial activation failures leaving stores in a half-unlocked state, stale key cache writes racing with lock(), and observer signatures diverging between tables and KV. This PR is the stabilization pass that makes epoch transitions production-safe.

The biggest fix is unlock rollback. Previously, if `activateEncryption` succeeded on 3 of 5 stores and then threw on the 4th, the first 3 stayed activated while the workspace reported itself as locked. Now activation is atomic—on any failure, all stores roll back to their pre-activation state and the key cache write is skipped:

```typescript
// Before: partial activation left stores in mixed state
workspace.encryption.unlock(key);
// Store 1: ✅ activated
// Store 2: ✅ activated
// Store 3: ❌ threw — stores 1-2 still activated, workspace says "locked"

// After: all-or-nothing with rollback
workspace.encryption.unlock(key);
// Store 1: ✅ activated → ❌ store 3 fails → 🔄 rolled back
// Store 2: ✅ activated → ❌ store 3 fails → 🔄 rolled back
// Store 3: ❌ threw — all stores back to deactivated, key cache untouched
```

The epoch transition also gets a 10-second timeout on extension initialization. Without it, a stuck persistence or sync provider could block the swap indefinitely, leaving the workspace in limbo between epochs. If any extension times out, the epoch bump is rolled back and the old doc continues serving.

Observer signatures between tables and KV had quietly diverged—tables passed `(changes, origin)` while KV passed `(changes, transaction)`. This aligns them both to `(changes, origin)` and removes the `TransactionMeta` wrapper type entirely, since origin is the only thing consumers actually need:

```typescript
// Before: inconsistent signatures
table.observe((changes, origin) => { ... });
kv.observe((changes, transaction) => { ... });  // different!

// After: unified
table.observe((changes, origin) => { ... });
kv.observe((changes, origin) => { ... });
```

Other fixes: key rotation now falls back to re-reading from the encrypted store when the cached key version is stale, `isEncryptedBlob` validates minimum blob size to avoid false positives on short `Uint8Array`s, awareness is moved to the coordination doc (where it belongs—it shouldn't reset on compaction), and the API's arktype error handling for `ENCRYPTION_SECRETS` is rewritten to use idiomatic `.problems` instead of manual string checks.

The self-managed encryption password spec is included here since it was written as part of this stabilization work.

> **Part 2 of 4** in the epoch compaction series. Depends on #1577. Next: tab-manager + CLI.