### PR TITLE
feat(workspace): migrate from single encryption key to versioned keyring

### DIFF
--- a/apps/api/src/auth/contracts/get-session.ts
+++ b/apps/api/src/auth/contracts/get-session.ts
@@ -2,8 +2,8 @@
  * Portable contract for the `/auth/get-session` response.
  *
  * Better Auth returns `{ user, session }`. Epicenter enriches that payload with
- * the current encryption key version and derived user key so clients can unlock
- * their workspace without a separate round-trip.
+ * the full encryption keyring (derived per-user keys for every active secret
+ * version) so clients can unlock their workspace without a separate round-trip.
  *
  * This file is intentionally runtime-free. Shared consumers should be able to
  * import the contract without pulling in Cloudflare Workers, Drizzle, or the
@@ -16,17 +16,27 @@ import type {
 } from 'better-auth';
 
 /**
+ * A single versioned encryption key for transport.
+ *
+ * Each entry pairs a key version (from `ENCRYPTION_SECRETS`) with the
+ * HKDF-derived per-user key encoded as base64 for JSON transport.
+ */
+export type EncryptionKey = {
+	version: number;
+	userKeyBase64: string;
+};
+
+/**
  * Canonical `/auth/get-session` response for Epicenter clients.
  *
- * Extends Better Auth's base `{ user, session }` with `keyVersion` and
- * `userKeyBase64` so clients can unlock their workspace directly from the
- * session—no separate key-fetch endpoint needed.
+ * Extends Better Auth's base `{ user, session }` with `encryptionKeys`—the
+ * full keyring of derived per-user keys so clients can decrypt blobs encrypted
+ * with any key version. First element is the current (highest-version) key.
  *
  * Import from `@epicenter/api/types` rather than hand-writing the response.
  */
 export type SessionResponse = {
 	user: User;
 	session: Session;
-	keyVersion: number;
-	userKeyBase64: string;
+	encryptionKeys: [EncryptionKey, ...EncryptionKey[]];
 };

--- a/apps/api/src/auth/contracts/index.ts
+++ b/apps/api/src/auth/contracts/index.ts
@@ -5,4 +5,4 @@
  * Client-only Better Auth inference helpers belong in the consuming package,
  * and server runtime wiring belongs next to the auth factory.
  */
-export type { SessionResponse } from './get-session';
+export type { EncryptionKey, SessionResponse } from './get-session';

--- a/apps/api/src/auth/create-auth.ts
+++ b/apps/api/src/auth/create-auth.ts
@@ -11,7 +11,7 @@ import { createAutumn } from '../autumn';
 import type * as schema from '../db/schema';
 import { BASE_AUTH_CONFIG } from './base-config';
 import type { SessionResponse } from './contracts';
-import { deriveUserEncryptionKey } from './encryption';
+import { deriveUserEncryptionKeys } from './encryption';
 
 type Db = NodePgDatabase<typeof schema>;
 
@@ -26,8 +26,8 @@ type Db = NodePgDatabase<typeof schema>;
  * - Drizzle adapter (Postgres via Hyperdrive)
  * - Google OAuth + email/password (from {@link BASE_AUTH_CONFIG})
  * - Plugins: bearer tokens, JWT, device authorization, OAuth provider (PKCE)
- * - `customSession()` enrichment that appends the current encryption key version
-	   to `/auth/get-session` responses (see {@link SessionResponse})
+ * - `customSession()` enrichment that appends the full encryption keyring
+ *   to `/auth/get-session` responses (see {@link SessionResponse})
  * - Autumn billing customer creation on user signup
  * - Cloudflare KV secondary storage for session caching
  */
@@ -141,20 +141,20 @@ export function createAuth({
 		}),
 	];
 	/**
-	 * Enrich `/auth/get-session` responses with key version and derived key.
+	 * Enrich `/auth/get-session` responses with the full encryption keyring.
 	 *
-	 * HKDF derivation adds <0.1ms—negligible next to the network round-trip.
-	 * Embedding the key here eliminates the separate `/workspace-key` endpoint
-	 * and all client-side version tracking.
+	 * Derives a per-user key for every version in `ENCRYPTION_SECRETS`.
+	 * HKDF derivation adds <0.1ms per key—negligible next to the network round-trip.
+	 * Embedding all keys here eliminates separate key-fetch endpoints and
+	 * enables fresh clients to decrypt blobs from any key version.
 	 */
 	const customSessionPlugin = customSession(
 		async ({ user, session }) => {
-			const { userKeyBase64, keyVersion } = await deriveUserEncryptionKey(user.id);
+			const encryptionKeys = await deriveUserEncryptionKeys(user.id);
 			return {
 				user,
 				session,
-				keyVersion,
-				userKeyBase64,
+				encryptionKeys,
 			} satisfies SessionResponse;
 		},
 		{

--- a/apps/api/src/auth/encryption.ts
+++ b/apps/api/src/auth/encryption.ts
@@ -61,9 +61,6 @@ const EncryptionKeyring = type('string')
  * Uses the call operator (not `.assert()`) so validation errors are returned
  * as `ArkErrors` instead of thrown as `TraversalError`. This lets us wrap
  * them in a human-readable message with the expected format.
- *
- * Destructured so `currentKeySecret` stays private and `currentKeyVersion`
- * can be exported without exposing key material.
  */
 const keyring = EncryptionKeyring(env.ENCRYPTION_SECRETS);
 if (keyring instanceof type.errors) {
@@ -74,7 +71,6 @@ if (keyring instanceof type.errors) {
 			`Validation errors:\n${keyring.summary}`,
 	);
 }
-const [{ version: currentKeyVersion, secret: currentKeySecret }] = keyring;
 
 /**
  * Derive a per-user 32-byte encryption key via two-step HKDF-SHA256.
@@ -120,17 +116,20 @@ function bytesToBase64(bytes: Uint8Array): string {
 }
 
 /**
- * Derive and return the per-user encryption key.
+ * Derive per-user encryption keys for every version in the keyring.
  *
  * Called by `customSession()` on every `/auth/get-session` response.
- * HKDF derivation adds <0.1ms—negligible next to the network round-trip.
+ * Returns one `{ version, userKeyBase64 }` per keyring entry, sorted
+ * highest-version-first (matching keyring order). HKDF derivation adds
+ * <0.1ms per key—negligible next to the network round-trip.
  */
-export async function deriveUserEncryptionKey(
+export async function deriveUserEncryptionKeys(
 	userId: string,
 ) {
-	const userKey = await deriveUserKey(currentKeySecret, userId);
-	return {
-		userKeyBase64: bytesToBase64(userKey),
-		keyVersion: currentKeyVersion,
-	};
+	return Promise.all(
+		keyring.map(async ({ version, secret }) => ({
+			version,
+			userKeyBase64: bytesToBase64(await deriveUserKey(secret, userId)),
+		})),
+	);
 }

--- a/apps/honeycrisp/src/lib/client.ts
+++ b/apps/honeycrisp/src/lib/client.ts
@@ -32,7 +32,7 @@ export const auth = createAuth({
 	baseURL: APP_URLS.API,
 	session,
 	onLogin(session) {
-		workspace.unlockWithKey(session.userKeyBase64);
+		workspace.unlockWithKeys(session.encryptionKeys);
 		workspace.extensions.sync.reconnect();
 	},
 	onLogout() {

--- a/apps/opensidian/src/lib/client.ts
+++ b/apps/opensidian/src/lib/client.ts
@@ -34,7 +34,7 @@ export const auth = createAuth({
 	baseURL: APP_URLS.API,
 	session,
 	onLogin(session) {
-		workspace.unlockWithKey(session.userKeyBase64);
+		workspace.unlockWithKeys(session.encryptionKeys);
 		workspace.extensions.sync.reconnect();
 	},
 	onLogout() {

--- a/apps/tab-manager/src/lib/client.ts
+++ b/apps/tab-manager/src/lib/client.ts
@@ -44,7 +44,7 @@ export const auth = createAuth({
 		return { provider: 'google', idToken, nonce };
 	},
 	onLogin(session) {
-		workspace.unlockWithKey(session.userKeyBase64);
+		workspace.unlockWithKeys(session.encryptionKeys);
 		workspace.extensions.sync.reconnect();
 	},
 	onLogout() {

--- a/apps/zhongwen/src/lib/client.ts
+++ b/apps/zhongwen/src/lib/client.ts
@@ -21,7 +21,7 @@ export const auth = createAuth({
 	baseURL: APP_URLS.API,
 	session,
 	onLogin(session) {
-		workspace.unlockWithKey(session.userKeyBase64);
+		workspace.unlockWithKeys(session.encryptionKeys);
 	},
 	onLogout() {
 		workspace.clearLocalData();

--- a/packages/cli/src/auth/store.ts
+++ b/packages/cli/src/auth/store.ts
@@ -27,8 +27,8 @@ export type AuthSession = {
 	accessToken: string;
 	/** Unix ms when the session expires. */
 	expiresAt: number;
-	/** Base64-encoded user encryption key for workspace decryption. */
-	userKeyBase64: string;
+	/** Versioned encryption keys for workspace decryption. */
+	encryptionKeys: SessionResponse['encryptionKeys'];
 	/** User info snapshot from the auth flow. */
 	user?: { id: string; email: string; name?: string };
 };
@@ -110,7 +110,7 @@ export function createSessionStore(home: string) {
 			store[normalizeUrl(server)] = {
 				accessToken: token.access_token,
 				expiresAt: Date.now() + token.expires_in * 1000,
-				userKeyBase64: sessionData.userKeyBase64,
+				encryptionKeys: sessionData.encryptionKeys,
 				user: sessionData.user,
 			};
 			await write(store);

--- a/packages/svelte-utils/src/auth/create-auth.svelte.ts
+++ b/packages/svelte-utils/src/auth/create-auth.svelte.ts
@@ -38,7 +38,7 @@ export type AuthError = InferErrors<typeof AuthError>;
 /**
  * Authenticated session data passed to the `onLogin` hook.
  *
- * Includes `userKeyBase64` so apps can call `workspace.unlockWithKey()`
+ * Includes `encryptionKeys` so apps can call `workspace.unlockWithKeys()`
  * directly—no separate fetch or version tracking needed. The persisted
  * session box stores the simpler `AuthSession` without key material.
  *
@@ -46,7 +46,7 @@ export type AuthError = InferErrors<typeof AuthError>;
  * ```typescript
  * createAuth({
  *   onLogin(session) {
- *     workspace.unlockWithKey(session.userKeyBase64);
+ *     workspace.unlockWithKeys(session.encryptionKeys);
  *   },
  * });
  * ```
@@ -54,8 +54,7 @@ export type AuthError = InferErrors<typeof AuthError>;
 export type AuthenticatedSession = {
 	token: string;
 	user: StoredUser;
-	keyVersion: number;
-	userKeyBase64: string;
+	encryptionKeys: SessionResponse['encryptionKeys'];
 };
 
 export type AuthClient = {
@@ -186,13 +185,13 @@ export type CreateAuthOptions = {
 	 * from storage, or token refresh.
 	 *
 	 * Fires on every authenticated session update, not just login transitions.
-	 * Consumers should use idempotent operations (e.g. `unlockWithKey` is safe
-	 * to call repeatedly with the same key).
+	 * Consumers should use idempotent operations (e.g. `unlockWithKeys` is safe
+	 * to call repeatedly with the same keys).
 	 *
 	 * @example
 	 * ```typescript
 	 * onLogin(session) {
-	 *   workspace.unlockWithKey(session.userKeyBase64);
+	 *   workspace.unlockWithKeys(session.encryptionKeys);
 	 *   workspace.extensions.sync.reconnect();
 	 * }
 	 * ```
@@ -316,8 +315,7 @@ export function createAuth({
 			onLogin?.({
 				token,
 				user,
-				keyVersion: state.data.keyVersion,
-				userKeyBase64: state.data.userKeyBase64,
+				encryptionKeys: state.data.encryptionKeys,
 			});
 		} else {
 			session.current = null;

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -166,6 +166,7 @@ export type {
 	WorkspaceClient,
 	WorkspaceClientBuilder,
 	WorkspaceEncryption,
+	EncryptionKey,
 	WorkspaceClientWithActions,
 	WorkspaceDefinition,
 } from './workspace/types';

--- a/packages/workspace/src/shared/crypto/crypto.test.ts
+++ b/packages/workspace/src/shared/crypto/crypto.test.ts
@@ -329,36 +329,36 @@ describe('deriveKeyFromPassword', () => {
 });
 
 describe('deriveSalt', () => {
-	test('deterministic: same userId + workspaceId = same salt', async () => {
+	test('deterministic: same userId + workspaceId = same salt', () => {
 		const userId = 'user123';
 		const workspaceId = 'workspace456';
 
-		const salt1 = await deriveSalt(userId, workspaceId);
-		const salt2 = await deriveSalt(userId, workspaceId);
+		const salt1 = deriveSalt(userId, workspaceId);
+		const salt2 = deriveSalt(userId, workspaceId);
 
 		expect(salt1).toEqual(salt2);
 	});
 
-	test('different userId = different salt', async () => {
+	test('different userId = different salt', () => {
 		const workspaceId = 'workspace456';
 
-		const salt1 = await deriveSalt('user1', workspaceId);
-		const salt2 = await deriveSalt('user2', workspaceId);
+		const salt1 = deriveSalt('user1', workspaceId);
+		const salt2 = deriveSalt('user2', workspaceId);
 
 		expect(salt1).not.toEqual(salt2);
 	});
 
-	test('different workspaceId = different salt', async () => {
+	test('different workspaceId = different salt', () => {
 		const userId = 'user123';
 
-		const salt1 = await deriveSalt(userId, 'workspace1');
-		const salt2 = await deriveSalt(userId, 'workspace2');
+		const salt1 = deriveSalt(userId, 'workspace1');
+		const salt2 = deriveSalt(userId, 'workspace2');
 
 		expect(salt1).not.toEqual(salt2);
 	});
 
-	test('returns 16-byte Uint8Array', async () => {
-		const salt = await deriveSalt('user123', 'workspace456');
+	test('returns 16-byte Uint8Array', () => {
+		const salt = deriveSalt('user123', 'workspace456');
 
 		expect(salt).toBeInstanceOf(Uint8Array);
 		expect(salt.length).toBe(16);
@@ -442,7 +442,7 @@ describe('binary storage overhead', () => {
 		const binaryDoc = new Y.Doc({ guid: 'bench-binary' });
 		const binaryArray =
 			binaryDoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-		const binaryKv = createEncryptedYkvLww<string>(binaryArray, { key });
+		const binaryKv = createEncryptedYkvLww<string>(binaryArray, new Map([[1, key]]));
 
 		for (const [i, val] of testValues.entries()) {
 			binaryKv.set(`key-${i}`, val);

--- a/packages/workspace/src/shared/crypto/index.ts
+++ b/packages/workspace/src/shared/crypto/index.ts
@@ -71,6 +71,7 @@ const HEADER_LENGTH = 2;
 const MINIMUM_BLOB_SIZE = HEADER_LENGTH + NONCE_LENGTH + TAG_LENGTH;
 
 const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
 
 /**
  * Encrypted blob stored directly in the CRDT as a bare Uint8Array.
@@ -92,9 +93,9 @@ const textEncoder = new TextEncoder();
  *  Total: 1 + 1 + 24 + len(plaintext) + 16 bytes
  * ```
  *
- * Detection: `value instanceof Uint8Array && value[0] === 1`.
+ * Detection: `value instanceof Uint8Array && value.length >= 42` (minimum blob size).
  * User values in the CRDT are always JS objects (never Uint8Arrays),
- * so this check is a reliable discriminant.
+ * so `instanceof Uint8Array` is the primary discriminant.
  *
  * @example
  * ```typescript
@@ -228,7 +229,7 @@ export function decryptValue(
 		: xchacha20poly1305(key, nonce);
 	const data = cipher.decrypt(ciphertext);
 
-	return new TextDecoder().decode(data);
+	return textDecoder.decode(data);
 }
 
 /**
@@ -237,11 +238,10 @@ export function decryptValue(
  * The key version is stored at byte 1 of the blob and identifies which
  * secret from the ENCRYPTION_SECRETS keyring was used to encrypt this blob.
  *
- * **Note**: Currently written but not read during decryption. The encrypted
- * KV wrapper's `activateEncryption` handles key transitions by trying the
- * current key then falling back to the previous key, without consulting
- * keyVersion. This function exists for diagnostics and future keyring
- * rotation where version-aware key lookup would avoid brute-forcing.
+ * Used by the encrypted KV wrapper for version-directed key lookup during
+ * decryption. When the current key fails to decrypt a blob, the wrapper reads
+ * the blob's key version via this function and looks up the matching key from
+ * the active keyring—avoiding brute-force trial of every key.
  *
  * @param blob - An EncryptedBlob to read the key version from
  * @returns The key version number (1-255)
@@ -307,7 +307,7 @@ export function isEncryptedBlob(value: unknown): value is EncryptedBlob {
  * @example
  * ```typescript
  * // Self-hosted password flow:
- * const salt = await deriveSalt(userId, workspaceId);
+ * const salt = deriveSalt(userId, workspaceId);
  * const userKey = await deriveKeyFromPassword(password, salt);
  * await workspace.encryption.unlock(userKey); // internally derives per-workspace key via HKDF
  * ```
@@ -318,7 +318,7 @@ export async function deriveKeyFromPassword(
 ): Promise<Uint8Array> {
 	const passwordKey = await crypto.subtle.importKey(
 		'raw',
-		new TextEncoder().encode(password),
+		textEncoder.encode(password),
 		'PBKDF2',
 		false,
 		['deriveBits'],
@@ -341,31 +341,28 @@ export async function deriveKeyFromPassword(
 /**
  * Derive a 16-byte salt from a userId and workspaceId using SHA-256.
  *
- * Combines the userId and workspaceId, hashes them with SHA-256, and returns
- * the first 16 bytes as a salt. This ensures that the same user in different
- * workspaces gets different salts, and different users get different salts.
+ * Combines the userId and workspaceId with a null-byte separator, hashes
+ * with SHA-256, and returns the first 16 bytes. Synchronous because
+ * SHA-256 of a short string is microseconds—no reason to force async.
+ *
+ * Uses `@noble/hashes` (already imported for HKDF) instead of
+ * `crypto.subtle.digest` to avoid an unnecessary `await` at every call site.
  *
  * @param userId - The user's unique identifier
  * @param workspaceId - The workspace's unique identifier
- * @returns A promise that resolves to a 16-byte Uint8Array salt
+ * @returns A 16-byte Uint8Array salt
  *
  * @example
  * ```typescript
- * const salt = await deriveSalt('user123', 'workspace456');
+ * const salt = deriveSalt('user123', 'workspace456');
  * console.log(salt.length); // 16
  * ```
  */
-export async function deriveSalt(
+export function deriveSalt(
 	userId: string,
 	workspaceId: string,
-): Promise<Uint8Array> {
-	const combined = userId + '\0' + workspaceId;
-	const hash = await crypto.subtle.digest(
-		'SHA-256',
-		new TextEncoder().encode(combined),
-	);
-
-	return new Uint8Array(hash).slice(0, 16);
+): Uint8Array {
+	return sha256(textEncoder.encode(userId + '\0' + workspaceId)).slice(0, 16);
 }
 
 /**

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.test.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.test.ts
@@ -3,6 +3,7 @@ import * as Y from 'yjs';
 import {
 	type EncryptedBlob,
 	generateEncryptionKey,
+	getKeyVersion,
 	isEncryptedBlob,
 } from '../crypto';
 import type { YKeyValueLwwEntry } from './y-keyvalue-lww';
@@ -26,7 +27,7 @@ function createEncryptedBlob<T>(value: T, key: Uint8Array, entryKey: string): En
 	const helperDoc = new Y.Doc({ guid: 'helper-blob' });
 	const helperArray =
 		helperDoc.getArray<YKeyValueLwwEntry<EncryptedBlob | T>>('helper-data');
-	const helperKv = createEncryptedYkvLww<T>(helperArray, { key: key });
+	const helperKv = createEncryptedYkvLww<T>(helperArray, new Map([[1, key]]));
 
 	helperKv.set(entryKey, value);
 
@@ -45,7 +46,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'test' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, { key: key });
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
 
 			kv.set('secret', 'hello-world');
 
@@ -57,7 +58,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'test' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, { key: key });
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
 
 			kv.set('secret', 'cipher-me');
 
@@ -72,7 +73,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'test' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | Bookmark>>('data');
-			const kv = createEncryptedYkvLww<Bookmark>(yarray, { key: key });
+			const kv = createEncryptedYkvLww<Bookmark>(yarray, new Map([[1, key]]));
 
 			const value: Bookmark = { url: 'https://bank.com', title: 'My Bank' };
 			kv.set('site', value);
@@ -85,7 +86,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'test' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, { key: key });
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
 
 			kv.set('k', 'v');
 			kv.delete('k');
@@ -98,7 +99,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'test' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, { key: key });
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
 
 			kv.set('k', 'v');
 			expect(kv.has('k')).toBe(true);
@@ -112,7 +113,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'test' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, { key: key });
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
 
 			kv.set('a', '1');
 			kv.set('b', '2');
@@ -133,7 +134,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'test' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, {});
+			const kv = createEncryptedYkvLww<string>(yarray);
 
 			kv.set('plain', 'text');
 
@@ -144,7 +145,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'test' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, {});
+			const kv = createEncryptedYkvLww<string>(yarray);
 
 			kv.set('plain', 'raw-value');
 
@@ -157,7 +158,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'test' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, {});
+			const kv = createEncryptedYkvLww<string>(yarray);
 
 			kv.set('x', '10');
 			kv.set('y', '20');
@@ -174,7 +175,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'test' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, { key: key });
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
 
 			const events: Array<{ key: string; change: PlainChange<string> }> = [];
 			kv.observe((changes) => {
@@ -194,7 +195,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'test' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, { key: key });
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
 
 			kv.set('foo', 'first');
 
@@ -222,7 +223,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'test' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, { key: key });
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
 
 			kv.set('foo', 'value');
 
@@ -242,7 +243,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'test' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, { key: key });
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
 
 			let count = 0;
 			const handler = () => {
@@ -267,7 +268,7 @@ describe('createEncryptedYkvLww', () => {
 
 			yarray.push([{ key: 'plaintext', val: 'plaintext-value', ts: 1000 }]);
 
-			const kv = createEncryptedYkvLww<string>(yarray, { key: key });
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
 			expect(kv.get('plaintext')).toBe('plaintext-value');
 		});
 
@@ -280,7 +281,7 @@ describe('createEncryptedYkvLww', () => {
 			const encrypted = createEncryptedBlob('encrypted-value', key, 'enc');
 			yarray.push([{ key: 'enc', val: encrypted, ts: 1000 }]);
 
-			const kv = createEncryptedYkvLww<string>(yarray, { key: key });
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
 			expect(kv.get('enc')).toBe('encrypted-value');
 		});
 
@@ -296,7 +297,7 @@ describe('createEncryptedYkvLww', () => {
 				{ key: 'new', val: encrypted, ts: 1001 },
 			]);
 
-			const kv = createEncryptedYkvLww<string>(yarray, { key: key });
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
 
 			expect(kv.get('old')).toBe('old-plaintext');
 			expect(kv.get('new')).toBe('new-secret');
@@ -309,7 +310,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'test' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, { key: key });
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
 
 			kv.set('k', 'plain-view');
 
@@ -328,8 +329,8 @@ describe('createEncryptedYkvLww', () => {
 			const yarray2 =
 				doc2.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
 
-			const kv1 = createEncryptedYkvLww<string>(yarray1, { key: key });
-			const kv2 = createEncryptedYkvLww<string>(yarray2, { key: key });
+			const kv1 = createEncryptedYkvLww<string>(yarray1, new Map([[1, key]]));
+			const kv2 = createEncryptedYkvLww<string>(yarray2, new Map([[1, key]]));
 
 			kv1.set('shared-key', 'from-doc1');
 			syncDocs(doc1, doc2);
@@ -351,8 +352,8 @@ describe('createEncryptedYkvLww', () => {
 			const yarray2 =
 				doc2.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
 
-			const kv1 = createEncryptedYkvLww<string>(yarray1, { key: key });
-			const kv2 = createEncryptedYkvLww<string>(yarray2, { key: key });
+			const kv1 = createEncryptedYkvLww<string>(yarray1, new Map([[1, key]]));
+			const kv2 = createEncryptedYkvLww<string>(yarray2, new Map([[1, key]]));
 
 			kv1.set('token', 'abc-123');
 			syncDocs(doc1, doc2);
@@ -389,8 +390,8 @@ describe('createEncryptedYkvLww', () => {
 
 			syncBoth(doc1, doc2);
 
-			const kv1 = createEncryptedYkvLww<string>(yarray1, { key: key });
-			const kv2 = createEncryptedYkvLww<string>(yarray2, { key: key });
+			const kv1 = createEncryptedYkvLww<string>(yarray1, new Map([[1, key]]));
+			const kv2 = createEncryptedYkvLww<string>(yarray2, new Map([[1, key]]));
 
 			expect(kv1.get('x')).toBe('from-client-2-later');
 			expect(kv2.get('x')).toBe('from-client-2-later');
@@ -407,8 +408,8 @@ describe('createEncryptedYkvLww', () => {
 			const yarray2 =
 				doc2.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
 
-			const kv1 = createEncryptedYkvLww<string>(yarray1, { key: key });
-			const kv2 = createEncryptedYkvLww<string>(yarray2, { key: key });
+			const kv1 = createEncryptedYkvLww<string>(yarray1, new Map([[1, key]]));
+			const kv2 = createEncryptedYkvLww<string>(yarray2, new Map([[1, key]]));
 
 			kv1.set('shared', 'value-from-doc1');
 			kv2.set('shared', 'value-from-doc2');
@@ -430,7 +431,7 @@ describe('createEncryptedYkvLww', () => {
 			kv.set('old-2', 'beta');
 
 			const key = generateEncryptionKey();
-			kv.activateEncryption(key);
+			kv.activateEncryption(new Map([[1, key]]));
 			kv.set('new-1', 'encrypted-c');
 
 			expect(kv.get('old-1')).toBe('alpha');
@@ -451,7 +452,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'encrypt-plaintext-on-activate' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, {});
+			const kv = createEncryptedYkvLww<string>(yarray);
 
 			kv.set('pt-1', 'plain-a');
 			kv.set('pt-2', 'plain-b');
@@ -460,7 +461,7 @@ describe('createEncryptedYkvLww', () => {
 			expect(isEncryptedBlob(yarray.toArray()[1]?.val)).toBe(false);
 
 			const key = generateEncryptionKey();
-			kv.activateEncryption(key);
+			kv.activateEncryption(new Map([[1, key]]));
 
 			const entries = yarray.toArray();
 			const pt1 = entries.find((entry) => entry.key === 'pt-1');
@@ -479,7 +480,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'test' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, { key: key });
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
 
 			let valueInBatch: string | undefined;
 			ydoc.transact(() => {
@@ -496,7 +497,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'test' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, { key: key });
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
 
 			const keysInBatch: string[] = [];
 			ydoc.transact(() => {
@@ -516,7 +517,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'mode-no-key-start' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, {});
+			const kv = createEncryptedYkvLww<string>(yarray);
 
 			kv.set('a', 'hello');
 			const raw = yarray.toArray().find((e) => e.key === 'a');
@@ -528,7 +529,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'mode-key-start' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, { key: key });
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
 
 			kv.set('a', 'hello');
 			const raw = yarray.toArray().find((e) => e.key === 'a');
@@ -540,13 +541,13 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'mode-plaintext-to-encrypted' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, {});
+			const kv = createEncryptedYkvLww<string>(yarray);
 
 			kv.set('before', 'plaintext');
 			const rawBefore = yarray.toArray().find((e) => e.key === 'before');
 			expect(isEncryptedBlob(rawBefore?.val)).toBe(false);
 
-			kv.activateEncryption(key);
+			kv.activateEncryption(new Map([[1, key]]));
 
 			kv.set('after', 'encrypted');
 			const rawAfter = yarray.toArray().find((e) => e.key === 'after');
@@ -560,7 +561,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'containment-corrupt-no-crash' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, { key: key });
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
 
 			kv.set('good-1', 'value-1');
 			kv.set('good-2', 'value-2');
@@ -589,7 +590,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'containment-observer-continues' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, { key: key });
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
 
 			kv.set('good', 'still-works');
 			yarray.push([
@@ -622,11 +623,11 @@ describe('createEncryptedYkvLww', () => {
 			});
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, {});
+			const kv = createEncryptedYkvLww<string>(yarray);
 
 			kv.set('pt-1', 'plain-a');
 			kv.set('pt-2', 'plain-b');
-			kv.activateEncryption(key);
+			kv.activateEncryption(new Map([[1, key]]));
 
 			expect(kv.get('pt-1')).toBe('plain-a');
 			expect(kv.get('pt-2')).toBe('plain-b');
@@ -637,10 +638,10 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'key-transition-new-writes-encrypt' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, {});
+			const kv = createEncryptedYkvLww<string>(yarray);
 
 			kv.set('before', 'plaintext-before-key');
-			kv.activateEncryption(key);
+			kv.activateEncryption(new Map([[1, key]]));
 			kv.set('after', 'encrypted-after-key');
 
 			const afterEntry = yarray
@@ -656,7 +657,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'key-transition-synthetic-events' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, { key: key1 });
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key1]]));
 
 			kv.set('a', 'alpha');
 			kv.set('b', 'beta');
@@ -668,7 +669,7 @@ describe('createEncryptedYkvLww', () => {
 			});
 
 			// Rotate from key1 to key2 — entries should be preserved via fallback
-			kv.activateEncryption(key2);
+			kv.activateEncryption(new Map([[2, key2], [1, key1]]));
 			expect(kv.failedDecryptCount).toBe(0);
 			expect(kv.get('a')).toBe('alpha');
 			expect(kv.get('b')).toBe('beta');
@@ -681,7 +682,7 @@ describe('createEncryptedYkvLww', () => {
 
 			// Rotate back to key1 — entries re-encrypted with key2, fallback to key2 works
 			events.length = 0;
-			kv.activateEncryption(key1);
+			kv.activateEncryption(new Map([[1, key1], [2, key2]]));
 			expect(kv.failedDecryptCount).toBe(0);
 			expect(kv.get('a')).toBe('alpha');
 			expect(kv.get('b')).toBe('beta');
@@ -706,11 +707,54 @@ describe('createEncryptedYkvLww', () => {
 			// Activate encryption — plaintext entries get encrypted under the hood
 			// but their decrypted values don't change. Should fire zero events.
 			const key = generateEncryptionKey();
-			kv.activateEncryption(key);
+			kv.activateEncryption(new Map([[1, key]]));
 
 			expect(events).toEqual([]);
 			expect(kv.get('a')).toBe('alpha');
 			expect(kv.get('b')).toBe('beta');
+		});
+
+		test('multi-version keyring decrypts entries with different keyVersions and re-encrypts with current', () => {
+			const key1 = generateEncryptionKey();
+			const key2 = generateEncryptionKey();
+			const ydoc = new Y.Doc({ guid: 'multi-version-keyring' });
+			const yarray =
+				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
+
+			// Write entries with key1 (version 1)
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key1]]));
+			kv.set('a', 'alpha');
+			kv.set('b', 'beta');
+
+			// Verify blobs have keyVersion 1
+			for (const entry of yarray.toArray()) {
+				if (isEncryptedBlob(entry.val)) {
+					expect(getKeyVersion(entry.val)).toBe(1);
+				}
+			}
+
+			// Activate with a two-key keyring: v2 is current, v1 is fallback
+			kv.activateEncryption(new Map([[2, key2], [1, key1]]));
+
+			// Values still readable
+			expect(kv.get('a')).toBe('alpha');
+			expect(kv.get('b')).toBe('beta');
+			expect(kv.failedDecryptCount).toBe(0);
+
+			// Blobs re-encrypted with v2
+			for (const entry of yarray.toArray()) {
+				if (isEncryptedBlob(entry.val)) {
+					expect(getKeyVersion(entry.val)).toBe(2);
+				}
+			}
+
+			// New writes also get version 2
+			kv.set('c', 'gamma');
+			const cEntry = yarray.toArray().find((e) => e.key === 'c');
+			expect(isEncryptedBlob(cEntry?.val)).toBe(true);
+			if (isEncryptedBlob(cEntry?.val)) {
+				expect(getKeyVersion(cEntry.val)).toBe(2);
+			}
 		});
 	});
 
@@ -720,7 +764,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'deactivate-plaintext-writes' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, { key });
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
 
 			kv.set('enc', 'secret');
 			expect(isEncryptedBlob(yarray.toArray().find((e) => e.key === 'enc')?.val)).toBe(true);
@@ -738,7 +782,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'deactivate-clears-cache' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, { key });
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
 
 			kv.set('a', 'alpha');
 			kv.set('b', 'beta');
@@ -754,7 +798,7 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'deactivate-unreadable' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, { key });
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
 
 			kv.set('secret', 'hidden');
 			kv.deactivateEncryption();
@@ -768,13 +812,13 @@ describe('createEncryptedYkvLww', () => {
 			const ydoc = new Y.Doc({ guid: 'deactivate-reactivate' });
 			const yarray =
 				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, { key });
+			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
 
 			kv.set('secret', 'hidden');
 			kv.deactivateEncryption();
 			expect(kv.get('secret')).toBeUndefined();
 
-			kv.activateEncryption(key);
+			kv.activateEncryption(new Map([[1, key]]));
 			expect(kv.get('secret')).toBe('hidden');
 		});
 	});

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
@@ -50,7 +50,7 @@
  *
  * ## Key Management
  *
- * The encryption keyring is managed through `activateEncryption(keyring)`. The optional `keyring`
+ * The encryption keyring is managed through `activateEncryption(keyring)`. The optional
  * `initialKeyring` parameter seeds the initial keyring at construction time. After creation,
  * all key transitions go through `activateEncryption()`.
  *
@@ -282,17 +282,37 @@ export function createEncryptedYkvLww<T>(
 	 * Silent decrypt — returns plaintext value or undefined.
 	 *
 	 * Used by get(), has(), and entries() for on-the-fly decryption during the
-	 * transaction gap (after set() but before the observer fires). Failures are
-	 * expected and silent — the observer will handle them with proper logging.
+	 * transaction gap (after set() but before the observer fires). Tries the
+	 * current key first, then falls back to version-directed keyring lookup
+	 * (same strategy as tryDecryptEntry).
+	 *
+	 * Defense-in-depth: in practice, the transaction gap only surfaces values
+	 * from inner.pending (always encrypted with currentKey, so the fast path
+	 * suffices) or inner.map (already processed by the observer with keyring
+	 * fallback). The keyring fallback here guards against unforeseen edge
+	 * cases where inner.map holds an old-version blob the observer missed.
 	 */
 	const tryDecryptValue = (raw: EncryptedBlob | T, aad: Uint8Array): T | undefined => {
 		if (!isEncryptedBlob(raw)) return raw as T;
 		if (!currentKey) return undefined;
+
+		// Fast path: try current key
 		try {
 			return JSON.parse(decryptValue(raw, currentKey, aad)) as T;
-		} catch {
-			return undefined;
+		} catch { /* fall through to keyring lookup */ }
+
+		// Version-directed fallback from keyring
+		if (activeKeyring) {
+			const blobVersion = getKeyVersion(raw as EncryptedBlob);
+			const versionKey = activeKeyring.get(blobVersion);
+			if (versionKey && versionKey !== currentKey) {
+				try {
+					return JSON.parse(decryptValue(raw, versionKey, aad)) as T;
+				} catch { /* undecryptable */ }
+			}
 		}
+
+		return undefined;
 	};
 
 	/** Clear and rebuild the decrypted cache from inner.map. */

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
@@ -34,8 +34,8 @@
  *
  * ## Encryption Lifecycle
  *
- * Encryption is governed by keyring presence (`activeKeyring`). There is no separate
- * state variable—encryption state is derived internally from `currentKey !== undefined`.
+ * Encryption is governed by a single `encryption` state struct. There is no separate
+ * state variable—encryption state is derived from `encryption !== undefined`.
  *
  * ```
  *   Keyring provided (activateEncryption)
@@ -211,46 +211,51 @@ export function createEncryptedYkvLww<T>(
 	const changeHandlers = new Set<EncryptedKvChangeHandler<T>>();
 
 	/**
-	 * The active encryption key (highest version from the keyring).
-	 * Set exclusively via `activateEncryption()` / `deactivateEncryption()`.
-	 */
-	let currentKey: Uint8Array | undefined;
-
-	/**
-	 * The version number of the current encryption key.
-	 * Used as the keyVersion byte in every `encryptValue()` call.
-	 * Only meaningful when `currentKey` is defined.
-	 */
-	let currentVersion = 0;
-
-	/** The full keyring for version-directed decryption. */
-	let activeKeyring: ReadonlyMap<number, Uint8Array> | undefined;
-
-	/**
-	 * Attempt to decrypt an encrypted blob with a specific key.
+	 * Active encryption state. When defined, `set()` encrypts and the observer
+	 * decrypts. When `undefined`, all operations pass through as plaintext.
 	 *
-	 * Callers must filter out plaintext entries before calling this.
-	 * Used by activateEncryption for key fallback and by tryDecryptEntry.
+	 * Collapsed into a single struct so activation/deactivation is atomic—
+	 * no risk of updating `currentKey` but forgetting `activeKeyring`.
 	 */
-	const tryDecryptEntryWithKey = (
-		key: string,
-		entry: YKeyValueLwwEntry<EncryptedBlob | T>,
-		decryptionKey: Uint8Array,
-	): YKeyValueLwwEntry<T> | undefined => {
-		try {
-			const val = JSON.parse(decryptValue(entry.val as EncryptedBlob, decryptionKey, textEncoder.encode(key))) as T;
-			return { ...entry, val };
-		} catch {
-			return undefined;
-		}
-	};
+	let encryption: {
+		keyring: ReadonlyMap<number, Uint8Array>;
+		currentKey: Uint8Array;
+		currentVersion: number;
+	} | undefined;
 
 	/**
-	 * Attempt to decrypt an entry with version-directed keyring fallback.
+	 * Decrypt an encrypted blob with version-directed keyring fallback.
 	 *
 	 * Tries currentKey first (fast path for latest-version blobs).
 	 * Falls back to version-directed lookup from activeKeyring when
 	 * currentKey fails (handles blobs encrypted with older key versions).
+	 * Returns the decrypted JSON string, or undefined on failure.
+	 */
+	const decryptBlobWithFallback = (
+		blob: EncryptedBlob,
+		aad: Uint8Array,
+	): string | undefined => {
+		if (!encryption) return undefined;
+
+		// Fast path: try current key (most blobs are on latest version)
+		try {
+			return decryptValue(blob, encryption.currentKey, aad);
+		} catch { /* fall through to version-directed lookup */ }
+
+		// Version-directed fallback from keyring
+		const blobVersion = getKeyVersion(blob);
+		const versionKey = encryption.keyring.get(blobVersion);
+		if (versionKey && versionKey !== encryption.currentKey) {
+			try {
+				return decryptValue(blob, versionKey, aad);
+			} catch { /* fall through */ }
+		}
+
+		return undefined;
+	};
+
+	/**
+	 * Attempt to decrypt an entry with version-directed keyring fallback.
 	 * Logs a warning on total failure for diagnostics.
 	 */
 	const tryDecryptEntry = (
@@ -258,61 +263,27 @@ export function createEncryptedYkvLww<T>(
 		entry: YKeyValueLwwEntry<EncryptedBlob | T>,
 	): YKeyValueLwwEntry<T> | undefined => {
 		if (!isEncryptedBlob(entry.val)) return { ...entry, val: entry.val as T };
-		if (!currentKey) return undefined;
 
-		// Fast path: try current key (most blobs are on latest version)
-		const result = tryDecryptEntryWithKey(key, entry, currentKey);
-		if (result) return result;
-
-		// Version-directed fallback from keyring
-		if (activeKeyring) {
-			const blobVersion = getKeyVersion(entry.val as EncryptedBlob);
-			const versionKey = activeKeyring.get(blobVersion);
-			if (versionKey && versionKey !== currentKey) {
-				const fallback = tryDecryptEntryWithKey(key, entry, versionKey);
-				if (fallback) return fallback;
-			}
+		const json = decryptBlobWithFallback(entry.val, textEncoder.encode(key));
+		if (!json) {
+			console.warn(`[encrypted-kv] Failed to decrypt entry "${key}"`);
+			return undefined;
 		}
-
-		console.warn(`[encrypted-kv] Failed to decrypt entry "${key}"`);
-		return undefined;
+		return { ...entry, val: JSON.parse(json) as T };
 	};
 
 	/**
 	 * Silent decrypt — returns plaintext value or undefined.
 	 *
 	 * Used by get(), has(), and entries() for on-the-fly decryption during the
-	 * transaction gap (after set() but before the observer fires). Tries the
-	 * current key first, then falls back to version-directed keyring lookup
-	 * (same strategy as tryDecryptEntry).
-	 *
-	 * Defense-in-depth: in practice, the transaction gap only surfaces values
-	 * from inner.pending (always encrypted with currentKey, so the fast path
-	 * suffices) or inner.map (already processed by the observer with keyring
-	 * fallback). The keyring fallback here guards against unforeseen edge
-	 * cases where inner.map holds an old-version blob the observer missed.
+	 * transaction gap (after set() but before the observer fires). Uses the same
+	 * version-directed fallback as tryDecryptEntry for consistency.
 	 */
 	const tryDecryptValue = (raw: EncryptedBlob | T, aad: Uint8Array): T | undefined => {
 		if (!isEncryptedBlob(raw)) return raw as T;
-		if (!currentKey) return undefined;
-
-		// Fast path: try current key
-		try {
-			return JSON.parse(decryptValue(raw, currentKey, aad)) as T;
-		} catch { /* fall through to keyring lookup */ }
-
-		// Version-directed fallback from keyring
-		if (activeKeyring) {
-			const blobVersion = getKeyVersion(raw as EncryptedBlob);
-			const versionKey = activeKeyring.get(blobVersion);
-			if (versionKey && versionKey !== currentKey) {
-				try {
-					return JSON.parse(decryptValue(raw, versionKey, aad)) as T;
-				} catch { /* undecryptable */ }
-			}
-		}
-
-		return undefined;
+		const json = decryptBlobWithFallback(raw, aad);
+		if (!json) return undefined;
+		return JSON.parse(json) as T;
 	};
 
 	/** Clear and rebuild the decrypted cache from inner.map. */
@@ -367,9 +338,13 @@ export function createEncryptedYkvLww<T>(
 	// No observers exist yet, so no events fire — just sets the state
 	// so rebuildMap() can decrypt pre-existing entries.
 	if (initialKeyring) {
-		currentVersion = Math.max(...initialKeyring.keys());
-		currentKey = initialKeyring.get(currentVersion);
-		activeKeyring = initialKeyring;
+		if (initialKeyring.size === 0) throw new Error('Keyring must contain at least one key');
+		const seedVersion = Math.max(...initialKeyring.keys());
+		encryption = {
+			keyring: initialKeyring,
+			currentKey: initialKeyring.get(seedVersion)!,
+			currentVersion: seedVersion,
+		};
 	}
 
 
@@ -420,11 +395,11 @@ export function createEncryptedYkvLww<T>(
 
 	return {
 		set(key, val) {
-			if (!currentKey) {
+			if (!encryption) {
 				inner.set(key, val);
 				return;
 			}
-			inner.set(key, encryptValue(JSON.stringify(val), currentKey, textEncoder.encode(key), currentVersion));
+			inner.set(key, encryptValue(JSON.stringify(val), encryption.currentKey, textEncoder.encode(key), encryption.currentVersion));
 		},
 
 		/**
@@ -500,44 +475,25 @@ export function createEncryptedYkvLww<T>(
 		 * @param keyring - Map from version number to 32-byte encryption key
 		 */
 		activateEncryption(keyring) {
+			if (keyring.size === 0) throw new Error('Keyring must contain at least one key');
+
 			const nextVersion = Math.max(...keyring.keys());
 			const nextKey = keyring.get(nextVersion)!;
-			currentVersion = nextVersion;
-			currentKey = nextKey;
-			activeKeyring = keyring;
+			encryption = { keyring, currentKey: nextKey, currentVersion: nextVersion };
 
 			const oldMap = new Map(map);
 			map.clear();
 			const needsReEncrypt: Array<{ key: string; val: T }> = [];
 
 			for (const [key, entry] of inner.map) {
-				if (!isEncryptedBlob(entry.val)) {
-					// Plaintext entry — always needs encryption
-					map.set(key, { ...entry, val: entry.val as T });
-					needsReEncrypt.push({ key, val: entry.val as T });
-					continue;
-				}
+				const decrypted = tryDecryptEntry(key, entry);
+				if (!decrypted) continue;
+				map.set(key, decrypted);
 
-				// Fast path: try current key (most blobs are on latest version)
-				let decrypted = tryDecryptEntryWithKey(key, entry, nextKey);
-				if (decrypted) {
-					map.set(key, decrypted);
-					continue;
+				// Re-encrypt plaintext entries and entries on older key versions
+				if (!isEncryptedBlob(entry.val) || getKeyVersion(entry.val as EncryptedBlob) !== encryption.currentVersion) {
+					needsReEncrypt.push({ key, val: decrypted.val });
 				}
-
-				// Version-directed lookup
-				const blobVersion = getKeyVersion(entry.val as EncryptedBlob);
-				const versionKey = keyring.get(blobVersion);
-				if (versionKey && versionKey !== nextKey) {
-					decrypted = tryDecryptEntryWithKey(key, entry, versionKey);
-					if (decrypted) {
-						map.set(key, decrypted);
-						needsReEncrypt.push({ key, val: decrypted.val });
-						continue;
-					}
-				}
-
-				console.warn(`[encrypted-kv] Entry "${key}" undecryptable (blob v${blobVersion})`);
 			}
 
 			// Re-encrypt only entries that need it (plaintext or old-key)
@@ -556,8 +512,7 @@ export function createEncryptedYkvLww<T>(
 		 * plaintext entries remain visible).
 		 */
 		deactivateEncryption() {
-			currentKey = undefined;
-			activeKeyring = undefined;
+			encryption = undefined;
 			const oldMap = new Map(map);
 			map.clear();
 

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
@@ -34,24 +34,24 @@
  *
  * ## Encryption Lifecycle
  *
- * Encryption is governed by key presence (`currentKey`). There is no separate
+ * Encryption is governed by keyring presence (`activeKeyring`). There is no separate
  * state variable—encryption state is derived internally from `currentKey !== undefined`.
  *
  * ```
- *   Key provided (activateEncryption)
+ *   Keyring provided (activateEncryption)
  *   ┌──────────────────┐       ┌──────────────────┐
- *   │  key: present       │◄── activateEncryption(newKey)
+ *   │  keyring: present    │◄── activateEncryption(keyring)
  *   │  rw plaintext      │       │  rw encrypted      │
  *   └──────────────────┘       └──────────────────┘
  * ```
  *
- * - **No key**: Reads and writes pass through unencrypted.
- * - **Key present**: `set()` encrypts, observer decrypts.
+ * - **No keyring**: Reads and writes pass through unencrypted.
+ * - **Keyring present**: `set()` encrypts with current (highest-version) key, observer decrypts.
  *
  * ## Key Management
  *
- * The encryption key is managed through `activateEncryption(key)`. The optional `key`
- * in options seeds the initial key at construction time. After creation,
+ * The encryption keyring is managed through `activateEncryption(keyring)`. The optional `keyring`
+ * `initialKeyring` parameter seeds the initial keyring at construction time. After creation,
  * all key transitions go through `activateEncryption()`.
  *
  * ## Pending State
@@ -82,6 +82,7 @@ import {
 	decryptValue,
 	type EncryptedBlob,
 	encryptValue,
+	getKeyVersion,
 	isEncryptedBlob,
 } from '../crypto';
 import {
@@ -107,16 +108,6 @@ export type EncryptedKvChangeHandler<T> = (
 	origin: unknown,
 ) => void;
 
-/**
- * Options for `createEncryptedYkvLww`.
- *
- * `key` seeds the initial encryption key. If provided, all writes are encrypted
- * immediately. If omitted, the store starts unencrypted. After creation, all key
- * transitions go through `activateEncryption()`.
- */
-type EncryptedKvLwwOptions = {
-	key?: Uint8Array;
-};
 
 /**
  * Return type of `createEncryptedYkvLww`. Same API surface as `YKeyValueLww<T>`
@@ -134,13 +125,13 @@ export type YKeyValueLwwEncrypted<T> = {
 	unobserve(handler: EncryptedKvChangeHandler<T>): void;
 
 	/**
-	 * Unlock the workspace with an encryption key. Rebuilds the decrypted map
-	 * from `inner.map`, transitions to encrypted state, and fires synthetic
-	 * change events for any values that changed.
+	 * Activate encryption with a keyring. The highest-version key becomes
+	 * the current key for all new encryptions. Decryption reads `getKeyVersion(blob)`
+	 * to select the correct key from the keyring.
 	 *
-	 * @param key - A 32-byte encryption key (required)
+	 * @param keyring - Map from version number to 32-byte encryption key
 	 */
-	activateEncryption(key: Uint8Array): void;
+	activateEncryption(keyring: ReadonlyMap<number, Uint8Array>): void;
 
 	/**
 	 * Deactivate encryption. Clears the key, emits delete events for entries
@@ -190,13 +181,13 @@ export type YKeyValueLwwEncrypted<T> = {
  * const kv = createEncryptedYkvLww<TabData>(yarray);
  * kv.set('tab-1', { url: '...' }); // stored as plaintext
  *
- * kv.activateEncryption(encryptionKey);
+ * kv.activateEncryption(new Map([[1, encryptionKey]]));
  * kv.set('tab-2', { url: '...' }); // stored as EncryptedBlob
  * ```
  */
 export function createEncryptedYkvLww<T>(
 	yarray: Y.Array<YKeyValueLwwEntry<EncryptedBlob | T>>,
-	options?: EncryptedKvLwwOptions,
+	initialKeyring?: ReadonlyMap<number, Uint8Array>,
 ): YKeyValueLwwEncrypted<T> {
 	/**
 	 * The inner LWW store that handles all CRDT logic. It sees `EncryptedBlob | T`
@@ -220,10 +211,20 @@ export function createEncryptedYkvLww<T>(
 	const changeHandlers = new Set<EncryptedKvChangeHandler<T>>();
 
 	/**
-	 * The active encryption key. Seeded from `options.key` at creation,
-	 * then updated exclusively via `activateEncryption()`.
+	 * The active encryption key (highest version from the keyring).
+	 * Set exclusively via `activateEncryption()` / `deactivateEncryption()`.
 	 */
-	let currentKey: Uint8Array | undefined = options?.key;
+	let currentKey: Uint8Array | undefined;
+
+	/**
+	 * The version number of the current encryption key.
+	 * Used as the keyVersion byte in every `encryptValue()` call.
+	 * Only meaningful when `currentKey` is defined.
+	 */
+	let currentVersion = 0;
+
+	/** The full keyring for version-directed decryption. */
+	let activeKeyring: ReadonlyMap<number, Uint8Array> | undefined;
 
 	/**
 	 * Attempt to decrypt an encrypted blob with a specific key.
@@ -245,10 +246,12 @@ export function createEncryptedYkvLww<T>(
 	};
 
 	/**
-	 * Attempt to decrypt an entry with warning on failure.
+	 * Attempt to decrypt an entry with version-directed keyring fallback.
 	 *
-	 * Delegates to tryDecryptEntryWithKey using currentKey.
-	 * Logs a warning on failure for diagnostics.
+	 * Tries currentKey first (fast path for latest-version blobs).
+	 * Falls back to version-directed lookup from activeKeyring when
+	 * currentKey fails (handles blobs encrypted with older key versions).
+	 * Logs a warning on total failure for diagnostics.
 	 */
 	const tryDecryptEntry = (
 		key: string,
@@ -256,9 +259,23 @@ export function createEncryptedYkvLww<T>(
 	): YKeyValueLwwEntry<T> | undefined => {
 		if (!isEncryptedBlob(entry.val)) return { ...entry, val: entry.val as T };
 		if (!currentKey) return undefined;
+
+		// Fast path: try current key (most blobs are on latest version)
 		const result = tryDecryptEntryWithKey(key, entry, currentKey);
-		if (!result) console.warn(`[encrypted-kv] Failed to decrypt entry "${key}"`);
-		return result;
+		if (result) return result;
+
+		// Version-directed fallback from keyring
+		if (activeKeyring) {
+			const blobVersion = getKeyVersion(entry.val as EncryptedBlob);
+			const versionKey = activeKeyring.get(blobVersion);
+			if (versionKey && versionKey !== currentKey) {
+				const fallback = tryDecryptEntryWithKey(key, entry, versionKey);
+				if (fallback) return fallback;
+			}
+		}
+
+		console.warn(`[encrypted-kv] Failed to decrypt entry "${key}"`);
+		return undefined;
 	};
 
 	/**
@@ -326,6 +343,16 @@ export function createEncryptedYkvLww<T>(
 		for (const handler of changeHandlers) handler(changes, undefined);
 	};
 
+	// Seed encryption state before initial map build (if provided).
+	// No observers exist yet, so no events fire — just sets the state
+	// so rebuildMap() can decrypt pre-existing entries.
+	if (initialKeyring) {
+		currentVersion = Math.max(...initialKeyring.keys());
+		currentKey = initialKeyring.get(currentVersion);
+		activeKeyring = initialKeyring;
+	}
+
+
 	// Initialize wrapper.map from inner.map (decrypt any pre-existing entries)
 	rebuildMap();
 
@@ -377,7 +404,7 @@ export function createEncryptedYkvLww<T>(
 				inner.set(key, val);
 				return;
 			}
-			inner.set(key, encryptValue(JSON.stringify(val), currentKey, textEncoder.encode(key)));
+			inner.set(key, encryptValue(JSON.stringify(val), currentKey, textEncoder.encode(key), currentVersion));
 		},
 
 		/**
@@ -443,30 +470,21 @@ export function createEncryptedYkvLww<T>(
 		},
 
 		/**
-		 * Activate encryption with a new key. Saves the previous key and uses
-		 * it as a fallback when decrypting entries encrypted with the old key.
-		 * Only re-encrypts entries that needed the fallback key or were plaintext,
-		 * avoiding unnecessary CRDT mutations for entries already on the current key.
+		 * Activate encryption with a keyring. The highest version key becomes
+		 * the current key for all new encryptions. Decryption uses
+		 * `getKeyVersion(blob)` to select the correct key from the keyring.
 		 *
-		 * ## Key rotation limitation
+		 * Entries encrypted with non-current keys are re-encrypted with the
+		 * current key. Plaintext entries are encrypted.
 		 *
-		 * Each blob stores a `keyVersion` byte (readable via `getKeyVersion()`),
-		 * but this method does NOT use it — it brute-forces by trying the current
-		 * key then the previous key. This two-key fallback covers a single key
-		 * rotation (v1 → v2) as long as the client was previously unlocked with
-		 * the old key.
-		 *
-		 * For full multi-key rotation (fresh client after N rotations), this
-		 * method would need to accept a keyring (`Map<number, Uint8Array>`) and
-		 * use `getKeyVersion(blob)` to select the correct decryption key per
-		 * entry. The API already has a keyring (`ENCRYPTION_SECRETS`); the
-		 * missing piece is transporting multiple derived keys to the client.
-		 *
-		 * @param nextKey - A 32-byte encryption key
+		 * @param keyring - Map from version number to 32-byte encryption key
 		 */
-		activateEncryption(nextKey) {
-			const previousKey = currentKey;
+		activateEncryption(keyring) {
+			const nextVersion = Math.max(...keyring.keys());
+			const nextKey = keyring.get(nextVersion)!;
+			currentVersion = nextVersion;
 			currentKey = nextKey;
+			activeKeyring = keyring;
 
 			const oldMap = new Map(map);
 			map.clear();
@@ -480,16 +498,18 @@ export function createEncryptedYkvLww<T>(
 					continue;
 				}
 
-				// Try new key first
+				// Fast path: try current key (most blobs are on latest version)
 				let decrypted = tryDecryptEntryWithKey(key, entry, nextKey);
 				if (decrypted) {
 					map.set(key, decrypted);
-					continue; // already encrypted with current key
+					continue;
 				}
 
-				// Fall back to previous key
-				if (previousKey) {
-					decrypted = tryDecryptEntryWithKey(key, entry, previousKey);
+				// Version-directed lookup
+				const blobVersion = getKeyVersion(entry.val as EncryptedBlob);
+				const versionKey = keyring.get(blobVersion);
+				if (versionKey && versionKey !== nextKey) {
+					decrypted = tryDecryptEntryWithKey(key, entry, versionKey);
 					if (decrypted) {
 						map.set(key, decrypted);
 						needsReEncrypt.push({ key, val: decrypted.val });
@@ -497,13 +517,13 @@ export function createEncryptedYkvLww<T>(
 					}
 				}
 
-				console.warn(`[encrypted-kv] Entry "${key}" undecryptable with current or previous key`);
+				console.warn(`[encrypted-kv] Entry "${key}" undecryptable (blob v${blobVersion})`);
 			}
 
 			// Re-encrypt only entries that need it (plaintext or old-key)
 			inner.doc.transact(() => {
 				for (const { key: entryKey, val } of needsReEncrypt) {
-					inner.set(entryKey, encryptValue(JSON.stringify(val), nextKey, textEncoder.encode(entryKey)));
+					inner.set(entryKey, encryptValue(JSON.stringify(val), nextKey, textEncoder.encode(entryKey), nextVersion));
 				}
 			}, RE_ENCRYPT);
 
@@ -517,6 +537,7 @@ export function createEncryptedYkvLww<T>(
 		 */
 		deactivateEncryption() {
 			currentKey = undefined;
+			activeKeyring = undefined;
 			const oldMap = new Map(map);
 			map.clear();
 

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww.ts
@@ -114,16 +114,19 @@ export class YKeyValueLww<T> {
 	/** The Y.Doc that owns this array. Required for transactions. */
 	readonly doc: Y.Doc;
 
+	/** Mutable in-memory index. Written exclusively by the constructor and observer. */
+	private readonly _map = new Map<string, YKeyValueLwwEntry<T>>();
+
 	/**
-	 * In-memory index for O(1) key lookups. Maps key -> entry object.
+	 * Read-only view of the in-memory index for O(1) key lookups.
 	 *
-	 * **Important**: This map is ONLY written to by the observer. The `set()` method
-	 * never directly updates this map. This "single-writer" architecture prevents
-	 * race conditions when operations are nested inside outer Yjs transactions.
+	 * Written exclusively by the observer and constructor. External consumers
+	 * (e.g. the encrypted wrapper) read via iteration, `.get()`, and `.size`.
+	 * The `set()` method never writes to this map—the observer is the sole writer.
 	 *
 	 * @see pending for how immediate reads work after `set()`
 	 */
-	readonly map: Map<string, YKeyValueLwwEntry<T>>;
+	readonly map: ReadonlyMap<string, YKeyValueLwwEntry<T>> = this._map;
 
 	/**
 	 * Pending entries written by `set()` but not yet processed by the observer.
@@ -186,6 +189,9 @@ export class YKeyValueLww<T> {
 	/** Registered change handlers. */
 	private changeHandlers: Set<YKeyValueLwwChangeHandler<T>> = new Set();
 
+	/** Stored observer reference for cleanup in destroy(). */
+	private _observer!: (event: Y.YArrayEvent<YKeyValueLwwEntry<T>>, transaction: Y.Transaction) => void;
+
 	/**
 	 * Last timestamp used for monotonic clock.
 	 *
@@ -221,7 +227,6 @@ export class YKeyValueLww<T> {
 	constructor(yarray: Y.Array<YKeyValueLwwEntry<T>>) {
 		this.yarray = yarray;
 		this.doc = yarray.doc as Y.Doc;
-		this.map = new Map();
 
 		const entries = yarray.toArray();
 		const indicesToDelete: number[] = [];
@@ -230,16 +235,16 @@ export class YKeyValueLww<T> {
 		for (let i = 0; i < entries.length; i++) {
 			const entry = entries[i];
 			if (!entry) continue;
-			const existing = this.map.get(entry.key);
+			const existing = this._map.get(entry.key);
 
 			if (!existing) {
-				this.map.set(entry.key, entry);
+				this._map.set(entry.key, entry);
 			} else {
 				if (entry.ts > existing.ts) {
 					// New entry wins, mark old for deletion
 					const oldIndex = entries.indexOf(existing);
 					if (oldIndex !== -1) indicesToDelete.push(oldIndex);
-					this.map.set(entry.key, entry);
+					this._map.set(entry.key, entry);
 				} else if (entry.ts < existing.ts) {
 					// Old entry wins, mark new for deletion
 					indicesToDelete.push(i);
@@ -248,7 +253,7 @@ export class YKeyValueLww<T> {
 					const oldIndex = entries.indexOf(existing);
 					if (oldIndex !== -1 && oldIndex < i) {
 						indicesToDelete.push(oldIndex);
-						this.map.set(entry.key, entry);
+						this._map.set(entry.key, entry);
 					} else {
 						indicesToDelete.push(i);
 					}
@@ -274,7 +279,7 @@ export class YKeyValueLww<T> {
 		}
 
 		// Set up observer for future changes
-		yarray.observe((event, transaction) => {
+		this._observer = (event, transaction) => {
 			const changes = new Map<string, YKeyValueLwwChange<T>>();
 			const addedEntries: YKeyValueLwwEntry<T>[] = [];
 
@@ -299,8 +304,8 @@ export class YKeyValueLww<T> {
 						this.pendingDeletes.delete(entry.key);
 
 						// Reference equality: only process if this is the entry we have cached
-						if (this.map.get(entry.key) === entry) {
-							this.map.delete(entry.key);
+						if (this._map.get(entry.key) === entry) {
+							this._map.delete(entry.key);
 							changes.set(entry.key, { action: 'delete' });
 						}
 					});
@@ -331,7 +336,7 @@ export class YKeyValueLww<T> {
 			};
 
 			for (const newEntry of addedEntries) {
-				const existing = this.map.get(newEntry.key);
+				const existing = this._map.get(newEntry.key);
 
 				if (!existing) {
 					// New key: just update the map. No array operations needed.
@@ -348,7 +353,7 @@ export class YKeyValueLww<T> {
 							newValue: newEntry.val,
 						});
 					}
-					this.map.set(newEntry.key, newEntry);
+					this._map.set(newEntry.key, newEntry);
 					this.pendingDeletes.delete(newEntry.key);
 				} else {
 					// Conflict: key exists in map. Must compare timestamps to determine winner,
@@ -365,7 +370,7 @@ export class YKeyValueLww<T> {
 						const oldIndex = getAllEntries().indexOf(existing);
 						if (oldIndex !== -1) indicesToDelete.push(oldIndex);
 
-						this.map.set(newEntry.key, newEntry);
+						this._map.set(newEntry.key, newEntry);
 						this.pendingDeletes.delete(newEntry.key);
 					} else if (newEntry.ts < existing.ts) {
 						// Old entry wins: delete new from array
@@ -383,7 +388,7 @@ export class YKeyValueLww<T> {
 								newValue: newEntry.val,
 							});
 							if (oldIndex !== -1) indicesToDelete.push(oldIndex);
-							this.map.set(newEntry.key, newEntry);
+							this._map.set(newEntry.key, newEntry);
 							this.pendingDeletes.delete(newEntry.key);
 						} else {
 							// Old is rightmost, delete new
@@ -415,7 +420,8 @@ export class YKeyValueLww<T> {
 					handler(changes, transaction);
 				}
 			}
-		});
+		};
+		yarray.observe(this._observer);
 	}
 
 	/**
@@ -504,7 +510,7 @@ export class YKeyValueLww<T> {
 
 		const doWork = () => {
 			// Check map for existing entry (pending entries aren't in yarray yet)
-			if (this.map.has(key)) this.deleteEntryByKey(key);
+			if (this._map.has(key)) this.deleteEntryByKey(key);
 			this.yarray.push([entry]);
 		};
 
@@ -534,7 +540,7 @@ export class YKeyValueLww<T> {
 		// If already pending delete, no-op
 		if (this.pendingDeletes.has(key)) return;
 
-		if (!this.map.has(key) && !wasPending) return;
+			if (!this._map.has(key) && !wasPending) return;
 
 		this.pendingDeletes.add(key);
 		this.deleteEntryByKey(key);
@@ -555,7 +561,7 @@ export class YKeyValueLww<T> {
 		const pending = this.pending.get(key);
 		if (pending) return pending.val;
 
-		return this.map.get(key)?.val;
+		return this._map.get(key)?.val;
 	}
 
 	/**
@@ -566,7 +572,7 @@ export class YKeyValueLww<T> {
 	 */
 	has(key: string): boolean {
 		if (this.pendingDeletes.has(key)) return false;
-		return this.pending.has(key) || this.map.has(key);
+		return this.pending.has(key) || this._map.has(key);
 	}
 
 	/**
@@ -594,7 +600,7 @@ export class YKeyValueLww<T> {
 		}
 
 		// Yield map entries that weren't in pending and aren't pending delete
-		for (const [key, entry] of this.map) {
+		for (const [key, entry] of this._map) {
 			if (!yieldedKeys.has(key) && !this.pendingDeletes.has(key)) {
 				yield [key, entry];
 			}
@@ -609,5 +615,13 @@ export class YKeyValueLww<T> {
 	/** Unregister an observer. */
 	unobserve(handler: YKeyValueLwwChangeHandler<T>): void {
 		this.changeHandlers.delete(handler);
+	}
+
+	/**
+	 * Unregister the Y.Array observer. Call when this wrapper is no longer needed
+	 * but the underlying Y.Array continues to exist.
+	 */
+	destroy(): void {
+		this.yarray.unobserve(this._observer);
 	}
 }

--- a/packages/workspace/src/workspace/benchmark.test.ts
+++ b/packages/workspace/src/workspace/benchmark.test.ts
@@ -374,7 +374,7 @@ describe('KV benchmarks', () => {
 	test('repeated set on same key (10,000 times)', () => {
 		const ydoc = new Y.Doc();
 		const yarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>('kv');
-		const ykv = createEncryptedYkvLww(yarray, {});
+		const ykv = createEncryptedYkvLww(yarray);
 		const kv = createKv(ykv, {
 			counter: defineKv(type({ value: 'number' }), { value: 0 }),
 		});
@@ -395,7 +395,7 @@ describe('KV benchmarks', () => {
 	test('set + get alternating (10,000 cycles)', () => {
 		const ydoc = new Y.Doc();
 		const yarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>('kv');
-		const ykv = createEncryptedYkvLww(yarray, {});
+		const ykv = createEncryptedYkvLww(yarray);
 		const kv = createKv(ykv, {
 			counter: defineKv(type({ value: 'number' }), { value: 0 }),
 		});
@@ -414,7 +414,7 @@ describe('KV benchmarks', () => {
 	test('set + delete cycle (1,000 times)', () => {
 		const ydoc = new Y.Doc();
 		const yarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>('kv');
-		const ykv = createEncryptedYkvLww(yarray, {});
+		const ykv = createEncryptedYkvLww(yarray);
 		const kv = createKv(ykv, {
 			counter: defineKv(type({ value: 'number' }), { value: 0 }),
 		});

--- a/packages/workspace/src/workspace/create-kv.test.ts
+++ b/packages/workspace/src/workspace/create-kv.test.ts
@@ -22,7 +22,7 @@ import { KV_KEY } from './ydoc-keys.js';
 test('set stores a value that get returns', () => {
 	const ydoc = new Y.Doc();
 	const yarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>(KV_KEY);
-	const ykv = createEncryptedYkvLww(yarray, {});
+	const ykv = createEncryptedYkvLww(yarray);
 	const kv = createKv(ykv, {
 		theme: defineKv(type({ mode: "'light' | 'dark'" }), { mode: 'light' }),
 	});
@@ -34,7 +34,7 @@ test('set stores a value that get returns', () => {
 test('get returns defaultValue for unset key', () => {
 	const ydoc = new Y.Doc();
 	const yarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>(KV_KEY);
-	const ykv = createEncryptedYkvLww(yarray, {});
+	const ykv = createEncryptedYkvLww(yarray);
 	const kv = createKv(ykv, {
 		theme: defineKv(type({ mode: "'light' | 'dark'" }), { mode: 'light' }),
 	});
@@ -45,7 +45,7 @@ test('get returns defaultValue for unset key', () => {
 test('delete causes get to return defaultValue', () => {
 	const ydoc = new Y.Doc();
 	const yarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>(KV_KEY);
-	const ykv = createEncryptedYkvLww(yarray, {});
+	const ykv = createEncryptedYkvLww(yarray);
 	const kv = createKv(ykv, {
 		theme: defineKv(type({ mode: "'light' | 'dark'" }), { mode: 'light' }),
 	});
@@ -60,7 +60,7 @@ test('delete causes get to return defaultValue', () => {
 test('get returns defaultValue for invalid stored data', () => {
 	const ydoc = new Y.Doc();
 	const yarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>(KV_KEY);
-	const ykv = createEncryptedYkvLww(yarray, {});
+	const ykv = createEncryptedYkvLww(yarray);
 	const kv = createKv(ykv, {
 		count: defineKv(type('number'), 0),
 	});
@@ -74,7 +74,7 @@ test('get returns defaultValue for invalid stored data', () => {
 test('observeAll fires for set changes with correct key and value', () => {
 	const ydoc = new Y.Doc();
 	const yarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>(KV_KEY);
-	const ykv = createEncryptedYkvLww(yarray, {});
+	const ykv = createEncryptedYkvLww(yarray);
 	const kv = createKv(ykv, {
 		theme: defineKv(type({ mode: "'light' | 'dark'" }), { mode: 'light' }),
 	});
@@ -100,7 +100,7 @@ test('observeAll fires for set changes with correct key and value', () => {
 test('observeAll fires for delete changes', () => {
 	const ydoc = new Y.Doc();
 	const yarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>(KV_KEY);
-	const ykv = createEncryptedYkvLww(yarray, {});
+	const ykv = createEncryptedYkvLww(yarray);
 	const kv = createKv(ykv, {
 		theme: defineKv(type({ mode: "'light' | 'dark'" }), { mode: 'light' }),
 	});
@@ -127,7 +127,7 @@ test('observeAll fires for delete changes', () => {
 test('observeAll batches multiple changes in a single callback', () => {
 	const ydoc = new Y.Doc();
 	const yarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>(KV_KEY);
-	const ykv = createEncryptedYkvLww(yarray, {});
+	const ykv = createEncryptedYkvLww(yarray);
 	const kv = createKv(ykv, {
 		theme: defineKv(type({ mode: "'light' | 'dark'" }), { mode: 'light' }),
 		fontSize: defineKv(type('number'), 14),
@@ -166,7 +166,7 @@ test('observeAll batches multiple changes in a single callback', () => {
 test('observeAll skips invalid values', () => {
 	const ydoc = new Y.Doc();
 	const yarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>(KV_KEY);
-	const ykv = createEncryptedYkvLww(yarray, {});
+	const ykv = createEncryptedYkvLww(yarray);
 	const kv = createKv(ykv, {
 		count: defineKv(type('number'), 0),
 		theme: defineKv(type({ mode: "'light' | 'dark'" }), { mode: 'light' }),
@@ -197,7 +197,7 @@ test('observeAll skips invalid values', () => {
 test('observeAll skips unknown keys', () => {
 	const ydoc = new Y.Doc();
 	const yarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>(KV_KEY);
-	const ykv = createEncryptedYkvLww(yarray, {});
+	const ykv = createEncryptedYkvLww(yarray);
 	const kv = createKv(ykv, {
 		theme: defineKv(type({ mode: "'light' | 'dark'" }), { mode: 'light' }),
 	});
@@ -227,7 +227,7 @@ test('observeAll skips unknown keys', () => {
 test('observeAll returns an unsubscribe function that works', () => {
 	const ydoc = new Y.Doc();
 	const yarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>(KV_KEY);
-	const ykv = createEncryptedYkvLww(yarray, {});
+	const ykv = createEncryptedYkvLww(yarray);
 	const kv = createKv(ykv, {
 		theme: defineKv(type({ mode: "'light' | 'dark'" }), { mode: 'light' }),
 	});

--- a/packages/workspace/src/workspace/create-table.test.ts
+++ b/packages/workspace/src/workspace/create-table.test.ts
@@ -23,7 +23,7 @@ import { createTable } from './create-table.js';
 function setup() {
 	const ydoc = new Y.Doc();
 	const yarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>('test-table');
-	const ykv = createEncryptedYkvLww(yarray, {});
+	const ykv = createEncryptedYkvLww(yarray);
 	return { ydoc, yarray, ykv };
 }
 

--- a/packages/workspace/src/workspace/create-tables.ts
+++ b/packages/workspace/src/workspace/create-tables.ts
@@ -60,14 +60,13 @@ import { TableKey } from './ydoc-keys.js';
 export function createTables<TTableDefinitions extends TableDefinitions>(
 	ydoc: Y.Doc,
 	definitions: TTableDefinitions,
-	options?: { key?: Uint8Array },
 ): TablesHelper<TTableDefinitions> {
 	const helpers: Record<string, TableHelper<BaseRow>> = {};
 
 	for (const [name, definition] of Object.entries(definitions)) {
 		// Each table gets its own encrypted KV store (passthrough when no key)
 		const yarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>(TableKey(name));
-		const ykv = createEncryptedYkvLww(yarray, { key: options?.key });
+		const ykv = createEncryptedYkvLww(yarray);
 
 		helpers[name] = createTable(ykv, definition);
 	}

--- a/packages/workspace/src/workspace/create-workspace.test.ts
+++ b/packages/workspace/src/workspace/create-workspace.test.ts
@@ -25,6 +25,17 @@ import { defineKv } from './define-kv.js';
 import { defineTable } from './define-table.js';
 import { defineWorkspace } from './define-workspace.js';
 import type { UserKeyStore } from './user-key-store.js';
+import type { EncryptionKey } from './types.js';
+
+/** Wrap a raw Uint8Array key into a single-entry EncryptionKey[] for tests. */
+function toEncryptionKeys(key: Uint8Array): EncryptionKey[] {
+	return [{ version: 1, userKeyBase64: bytesToBase64(key) }];
+}
+
+/** Serialize a raw key to the JSON format the UserKeyStore now expects. */
+function toKeysJson(key: Uint8Array): string {
+	return JSON.stringify(toEncryptionKeys(key));
+}
 
 /** Creates a workspace client with two tables and one KV for testing. */
 function setup() {
@@ -970,16 +981,16 @@ describe('workspace unlock', () => {
 
 	test('encryption.unlock transitions runtime to unlocked', async () => {
 		const { client, key } = setupUnlockedWorkspace();
-		await client.encryption.unlock(key);
+		await client.encryption.unlock(toEncryptionKeys(key));
 		expect(client.encryption.isUnlocked).toBe(true);
 	});
 
 	test('encryption.unlock preserves encrypted writes when the same key is reused', async () => {
 		const { client, key } = setupUnlockedWorkspace();
-		await client.encryption.unlock(key);
+		await client.encryption.unlock(toEncryptionKeys(key));
 		client.tables.posts.set({ id: '1', title: 'Secret', _v: 1 });
 
-		await client.encryption.unlock(key);
+		await client.encryption.unlock(toEncryptionKeys(key));
 
 		const result = client.tables.posts.get('1');
 		expect(result.status).toBe('valid');
@@ -1049,20 +1060,20 @@ describe('.withEncryption() lifecycle', () => {
 			const { client } = setupLifecycle();
 			const key = generateEncryptionKey();
 
-			await client.encryption.unlock(key);
+			await client.encryption.unlock(toEncryptionKeys(key));
 			expect(client.encryption.isUnlocked).toBe(true);
 
-			await client.encryption.unlock(key);
+			await client.encryption.unlock(toEncryptionKeys(key));
 			expect(client.encryption.isUnlocked).toBe(true);
 		});
 
 		test('different keys each keep the runtime unlocked', async () => {
 			const { client } = setupLifecycle();
 
-			await client.encryption.unlock(generateEncryptionKey());
+			await client.encryption.unlock(toEncryptionKeys(generateEncryptionKey()));
 			expect(client.encryption.isUnlocked).toBe(true);
 
-			await client.encryption.unlock(generateEncryptionKey());
+			await client.encryption.unlock(toEncryptionKeys(generateEncryptionKey()));
 			expect(client.encryption.isUnlocked).toBe(true);
 		});
 	});
@@ -1071,9 +1082,9 @@ describe('.withEncryption() lifecycle', () => {
 		test('rapid unlocks leave the runtime unlocked with the latest key', async () => {
 			const { client } = setupLifecycle();
 
-			const p1 = client.encryption.unlock(generateEncryptionKey());
-			const p2 = client.encryption.unlock(generateEncryptionKey());
-			const p3 = client.encryption.unlock(generateEncryptionKey());
+			const p1 = client.encryption.unlock(toEncryptionKeys(generateEncryptionKey()));
+			const p2 = client.encryption.unlock(toEncryptionKeys(generateEncryptionKey()));
+			const p3 = client.encryption.unlock(toEncryptionKeys(generateEncryptionKey()));
 
 			await Promise.all([p1, p2, p3]);
 
@@ -1087,7 +1098,7 @@ describe('.withEncryption() lifecycle', () => {
 
 			expect(client.encryption.isUnlocked).toBe(false);
 
-			await client.encryption.unlock(generateEncryptionKey());
+			await client.encryption.unlock(toEncryptionKeys(generateEncryptionKey()));
 			expect(client.encryption.isUnlocked).toBe(true);
 
 			client.encryption.lock();
@@ -1101,11 +1112,11 @@ describe('.withEncryption() lifecycle', () => {
 			await client.whenReady;
 			const userKey = generateEncryptionKey();
 
-			await client.encryption.unlock(userKey);
+			await client.encryption.unlock(toEncryptionKeys(userKey));
 
 			expect(userKeyStore.set).toHaveBeenCalledTimes(1);
-			expect(userKeyStore.set).toHaveBeenCalledWith(bytesToBase64(userKey));
-			expect(readCachedValue()).toBe(bytesToBase64(userKey));
+			expect(userKeyStore.set).toHaveBeenCalledWith(toKeysJson(userKey));
+			expect(readCachedValue()).toBe(toKeysJson(userKey));
 		});
 
 		test('encryption.unlock retries the same key after userKeyStore.set fails', async () => {
@@ -1115,12 +1126,12 @@ describe('.withEncryption() lifecycle', () => {
 			const userKey = generateEncryptionKey();
 
 			failNextSet();
-			await client.encryption.unlock(userKey);
-			await client.encryption.unlock(userKey);
+			await client.encryption.unlock(toEncryptionKeys(userKey));
+			await client.encryption.unlock(toEncryptionKeys(userKey));
 
 			expect(client.encryption.isUnlocked).toBe(true);
 			expect(userKeyStore.set).toHaveBeenCalledTimes(2);
-			expect(readCachedValue()).toBe(bytesToBase64(userKey));
+			expect(readCachedValue()).toBe(toKeysJson(userKey));
 		});
 
 		test('encryption.unlock updates runtime state before userKeyStore.set settles', async () => {
@@ -1145,7 +1156,7 @@ describe('.withEncryption() lifecycle', () => {
 			await client.whenReady;
 			const userKey = generateEncryptionKey();
 
-			const unlockPromise = client.encryption.unlock(userKey);
+			const unlockPromise = client.encryption.unlock(toEncryptionKeys(userKey));
 
 			expect(client.encryption.isUnlocked).toBe(true);
 			expect(cachedValue).toBe(null);
@@ -1153,7 +1164,7 @@ describe('.withEncryption() lifecycle', () => {
 			saveDeferred.resolve();
 			await unlockPromise;
 
-			expect(cachedValue ?? '').toBe(bytesToBase64(userKey));
+			expect(cachedValue ?? '').toBe(toKeysJson(userKey));
 		});
 
 		test('auto-boot stays locked when userKeyStore is empty', async () => {
@@ -1168,14 +1179,14 @@ describe('.withEncryption() lifecycle', () => {
 		test('auto-boot unlocks from cached key', async () => {
 			const userKey = generateEncryptionKey();
 			const { client, userKeyStore } = setupWithUserKeyStore(
-				bytesToBase64(userKey),
+				toKeysJson(userKey),
 			);
 			await client.whenReady;
 
 			expect(client.encryption.isUnlocked).toBe(true);
 			expect(userKeyStore.get).toHaveBeenCalledTimes(1);
 			expect(userKeyStore.set).toHaveBeenCalledTimes(1);
-			expect(userKeyStore.set).toHaveBeenCalledWith(bytesToBase64(userKey));
+			expect(userKeyStore.set).toHaveBeenCalledWith(toKeysJson(userKey));
 		});
 
 		test('auto-boot clears corrupt cache entries and stays locked', async () => {
@@ -1215,8 +1226,8 @@ describe('.withEncryption() lifecycle', () => {
 			const firstKey = generateEncryptionKey();
 			const secondKey = generateEncryptionKey();
 
-			const firstUnlock = client.encryption.unlock(firstKey);
-			const secondUnlock = client.encryption.unlock(secondKey);
+			const firstUnlock = client.encryption.unlock(toEncryptionKeys(firstKey));
+			const secondUnlock = client.encryption.unlock(toEncryptionKeys(secondKey));
 
 			expect(client.encryption.isUnlocked).toBe(true);
 
@@ -1227,7 +1238,7 @@ describe('.withEncryption() lifecycle', () => {
 			// persist task skips the write because activeUserKey has already
 			// changed to secondKey by the time the queued task runs.
 			expect(userKeyStore.set).toHaveBeenCalledTimes(1);
-			expect(cachedValue ?? '').toBe(bytesToBase64(secondKey));
+			expect(cachedValue ?? '').toBe(toKeysJson(secondKey));
 		});
 
 		test('clearLocalData clears userKeyStore after an in-flight set finishes', async () => {
@@ -1259,7 +1270,7 @@ describe('.withEncryption() lifecycle', () => {
 			await client.whenReady;
 			const userKey = generateEncryptionKey();
 
-			const unlockPromise = client.encryption.unlock(userKey);
+			const unlockPromise = client.encryption.unlock(toEncryptionKeys(userKey));
 			expect(client.encryption.isUnlocked).toBe(true);
 
 			const clearPromise = client.clearLocalData();
@@ -1293,7 +1304,7 @@ describe('.withEncryption() lifecycle', () => {
 					},
 				}));
 
-			await client.encryption.unlock(generateEncryptionKey());
+			await client.encryption.unlock(toEncryptionKeys(generateEncryptionKey()));
 			await client.clearLocalData();
 
 			expect(events).toEqual(['locked']);

--- a/packages/workspace/src/workspace/create-workspace.ts
+++ b/packages/workspace/src/workspace/create-workspace.ts
@@ -538,6 +538,8 @@ export function createWorkspace<
 				let isActiveUserKeyCached = config?.userKeyStore === undefined;
 				let workspaceKey: Uint8Array | undefined = options?.key;
 				let cacheQueue = Promise.resolve();
+				/** The last keyring passed to activateEncryption, for rollback. */
+				let activeWorkspaceKeyring: ReadonlyMap<number, Uint8Array> | undefined;
 
 				const runSerializedCacheTask = async (
 					task: () => Promise<void>,
@@ -548,7 +550,7 @@ export function createWorkspace<
 				};
 
 				const lock = () => {
-					const previousKey = workspaceKey;
+					const previousKeyring = activeWorkspaceKeyring;
 					const deactivated: YKeyValueLwwEncrypted<unknown>[] = [];
 					try {
 						for (const store of encryptedStores) {
@@ -558,12 +560,13 @@ export function createWorkspace<
 						activeUserKey = undefined;
 						isActiveUserKeyCached = config?.userKeyStore === undefined;
 						workspaceKey = undefined;
+						activeWorkspaceKeyring = undefined;
 					} catch (error) {
 						// Rollback: revert stores deactivated before the failure
-						if (previousKey) {
+						if (previousKeyring) {
 							for (const store of deactivated) {
 								try {
-							store.activateEncryption(new Map([[1, previousKey]]));
+									store.activateEncryption(previousKeyring);
 								} catch { /* best-effort rollback */ }
 							}
 						}
@@ -608,7 +611,7 @@ export function createWorkspace<
 								deriveWorkspaceKey(base64ToBytes(userKeyBase64), id),
 							);
 						}
-						const previousWorkspaceKey = workspaceKey;
+						const previousKeyring = activeWorkspaceKeyring;
 						const nextWorkspaceKey = workspaceKeyring.get(
 							Math.max(...workspaceKeyring.keys()),
 						)!;
@@ -619,14 +622,15 @@ export function createWorkspace<
 								activated.push(store);
 							}
 							workspaceKey = nextWorkspaceKey;
+							activeWorkspaceKeyring = workspaceKeyring;
 							activeUserKey = currentUserKey;
 							isActiveUserKeyCached = config?.userKeyStore === undefined;
 						} catch (error) {
 							// Rollback: revert stores activated before the failure
 							for (const store of activated) {
 								try {
-									if (previousWorkspaceKey) {
-										store.activateEncryption(new Map([[1, previousWorkspaceKey]]));
+									if (previousKeyring) {
+										store.activateEncryption(previousKeyring);
 									} else {
 										store.deactivateEncryption();
 									}

--- a/packages/workspace/src/workspace/create-workspace.ts
+++ b/packages/workspace/src/workspace/create-workspace.ts
@@ -74,7 +74,6 @@ import * as Y from 'yjs';
 import type { Actions } from '../shared/actions.js';
 import {
 	base64ToBytes,
-	bytesToBase64,
 	deriveWorkspaceKey,
 } from '../shared/crypto/index.js';
 import type { YKeyValueLwwEntry } from '../shared/y-keyvalue/y-keyvalue-lww.js';

--- a/packages/workspace/src/workspace/create-workspace.ts
+++ b/packages/workspace/src/workspace/create-workspace.ts
@@ -167,32 +167,33 @@ export function createWorkspace<
 	const kvDefs = (kvDef ?? {}) as TKvDefinitions;
 	const awarenessDefs = (awarenessDef ?? {}) as TAwarenessDefinitions;
 
-	// ── Encrypted stores ─────────────────────────────────────────────────
-	// The workspace owns all encrypted KV stores so it can coordinate
-	// activateEncryption across tables and KV simultaneously.
-	const encryptedStores: YKeyValueLwwEncrypted<unknown>[] = [];
+	// ── Tables ───────────────────────────────────────────────────────────
+	const keyring = options?.key ? new Map([[1, options.key]]) : undefined;
 
-	// Create table stores + helpers (one encrypted KV per table)
-	const tableHelpers: Record<
-		string,
-		TableHelper<BaseRow>
-	> = {};
-	for (const [name, definition] of Object.entries(tableDefs)) {
+	const tableEntries = Object.entries(tableDefs).map(([name, definition]) => {
 		const yarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>(TableKey(name));
-		const ykv = createEncryptedYkvLww(yarray, { keyring: options?.key ? new Map([[1, options.key]]) : undefined });
-		encryptedStores.push(ykv);
-		const helper = createTable(ykv, definition);
-		tableHelpers[name] = helper;
-	}
-	const tables =
-		tableHelpers as TablesHelper<TTableDefinitions>;
+		const store = createEncryptedYkvLww(yarray, { keyring });
+		const helper = createTable(store, definition);
+		return { name, store, helper };
+	});
 
+	const tables = Object.fromEntries(
+		tableEntries.map(({ name, helper }) => [name, helper]),
+	) as TablesHelper<TTableDefinitions>;
 
-	// Create KV store + helper (single shared encrypted KV)
+	// ── KV ──────────────────────────────────────────────────────────────
 	const kvYarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>(KV_KEY);
-	const kvStore = createEncryptedYkvLww(kvYarray, { keyring: options?.key ? new Map([[1, options.key]]) : undefined });
-	encryptedStores.push(kvStore);
+	const kvStore = createEncryptedYkvLww(kvYarray, { keyring });
 	const kvHelper = createKv(kvStore, kvDefs);
+
+	// ── Encrypted stores (all table stores + KV store) ─────────────────────
+	// The workspace owns this list so it can coordinate activateEncryption
+	// and deactivateEncryption across all stores simultaneously.
+	const encryptedStores: readonly YKeyValueLwwEncrypted<unknown>[] = [
+		...tableEntries.map(({ store }) => store),
+		kvStore,
+	];
+
 	const awareness = createAwareness(ydoc, awarenessDefs);
 	const definitions = {
 		tables: tableDefs,
@@ -542,11 +543,26 @@ export function createWorkspace<
 				};
 
 				const lock = () => {
-					activeUserKey = undefined;
-					isActiveUserKeyCached = config?.userKeyStore === undefined;
-					workspaceKey = undefined;
-					for (const store of encryptedStores) {
-						store.deactivateEncryption();
+					const previousKey = workspaceKey;
+					const deactivated: YKeyValueLwwEncrypted<unknown>[] = [];
+					try {
+						for (const store of encryptedStores) {
+							store.deactivateEncryption();
+							deactivated.push(store);
+						}
+						activeUserKey = undefined;
+						isActiveUserKeyCached = config?.userKeyStore === undefined;
+						workspaceKey = undefined;
+					} catch (error) {
+						// Rollback: revert stores deactivated before the failure
+						if (previousKey) {
+							for (const store of deactivated) {
+								try {
+							store.activateEncryption(previousKey);
+								} catch { /* best-effort rollback */ }
+							}
+						}
+						console.error('[workspace] Workspace lock failed:', error);
 					}
 				};
 
@@ -582,10 +598,10 @@ export function createWorkspace<
 						const previousWorkspaceKey = workspaceKey;
 						const activated: YKeyValueLwwEncrypted<unknown>[] = [];
 						try {
-							for (const store of encryptedStores) {
-							store.activateEncryption(new Map([[1, nextWorkspaceKey]]));
-								activated.push(store);
-							}
+						for (const store of encryptedStores) {
+							store.activateEncryption(nextWorkspaceKey);
+							activated.push(store);
+						}
 							workspaceKey = nextWorkspaceKey;
 							activeUserKey = userKey;
 							isActiveUserKeyCached = config?.userKeyStore === undefined;
@@ -593,11 +609,11 @@ export function createWorkspace<
 							// Rollback: revert stores activated before the failure
 							for (const store of activated) {
 								try {
-									if (previousWorkspaceKey) {
-									store.activateEncryption(new Map([[1, previousWorkspaceKey]]));
-									} else {
-										store.deactivateEncryption();
-									}
+								if (previousWorkspaceKey) {
+									store.activateEncryption(previousWorkspaceKey);
+								} else {
+									store.deactivateEncryption();
+								}
 								} catch { /* best-effort rollback */ }
 							}
 							console.error('[workspace] Workspace unlock failed:', error);

--- a/packages/workspace/src/workspace/create-workspace.ts
+++ b/packages/workspace/src/workspace/create-workspace.ts
@@ -101,6 +101,7 @@ import type {
 	Documents,
 	DocumentsHelper,
 	EncryptionConfig,
+	EncryptionKey,
 	ExtensionContext,
 	KvDefinitions,
 	TableHelper,
@@ -385,11 +386,9 @@ export function createWorkspace<
 		if (encryptionRuntime) {
 			Object.assign(client, {
 				encryption: encryptionRuntime.encryption,
-				async unlockWithKey(userKeyBase64: string) {
+				async unlockWithKeys(keys: EncryptionKey[]) {
 					await whenReady;
-					await encryptionRuntime.encryption.unlock(
-						base64ToBytes(userKeyBase64),
-					);
+					await encryptionRuntime.encryption.unlock(keys);
 				},
 			});
 		}
@@ -573,54 +572,65 @@ export function createWorkspace<
 					}
 				};
 
-				const persistUnlockedUserKey = async (userKey: Uint8Array) => {
+				const persistKeys = async (keys: EncryptionKey[]) => {
 					if (!config?.userKeyStore) return;
 
 					try {
 						await runSerializedCacheTask(async () => {
-							// Guard: only write if this key is still the active one.
-							// A rapid unlock(keyA) → unlock(keyB) sequence queues two
-							// writes. By the time keyA's task runs, activeUserKey is
-							// already keyB — skip the stale write entirely.
+							// Guard: only write if the active key still matches.
+							// A rapid unlock(keysA) → unlock(keysB) sequence queues two
+							// writes. By the time keysA's task runs, activeUserKey is
+							// already keysB — skip the stale write entirely.
 							if (
 								activeUserKey === undefined ||
-								!bytesEqual(activeUserKey, userKey)
+								!bytesEqual(activeUserKey, base64ToBytes(keys[0]!.userKeyBase64))
 							)
 								return;
 
-							await config.userKeyStore.set(bytesToBase64(userKey));
+							await config.userKeyStore.set(JSON.stringify(keys));
 							isActiveUserKeyCached = true;
 						});
 					} catch (error) {
-						console.error('[workspace] User key cache save failed:', error);
+						console.error('[workspace] Encryption key cache save failed:', error);
 					}
 				};
 
-				const unlock = async (userKey: Uint8Array) => {
+				const unlock = async (keys: EncryptionKey[]) => {
+					const currentUserKey = base64ToBytes(keys[0]!.userKeyBase64);
 					const isSameUserKey =
-						activeUserKey !== undefined && bytesEqual(activeUserKey, userKey);
+						activeUserKey !== undefined && bytesEqual(activeUserKey, currentUserKey);
 
 					if (!isSameUserKey) {
-						const nextWorkspaceKey = deriveWorkspaceKey(userKey, id);
+						// Build version → workspaceKey map from all keyring entries
+						const workspaceKeyring = new Map<number, Uint8Array>();
+						for (const { version, userKeyBase64 } of keys) {
+							workspaceKeyring.set(
+								version,
+								deriveWorkspaceKey(base64ToBytes(userKeyBase64), id),
+							);
+						}
 						const previousWorkspaceKey = workspaceKey;
+						const nextWorkspaceKey = workspaceKeyring.get(
+							Math.max(...workspaceKeyring.keys()),
+						)!;
 						const activated: YKeyValueLwwEncrypted<unknown>[] = [];
 						try {
-						for (const store of encryptedStores) {
-							store.activateEncryption(new Map([[1, nextWorkspaceKey]]));
-							activated.push(store);
-						}
+							for (const store of encryptedStores) {
+								store.activateEncryption(workspaceKeyring);
+								activated.push(store);
+							}
 							workspaceKey = nextWorkspaceKey;
-							activeUserKey = userKey;
+							activeUserKey = currentUserKey;
 							isActiveUserKeyCached = config?.userKeyStore === undefined;
 						} catch (error) {
 							// Rollback: revert stores activated before the failure
 							for (const store of activated) {
 								try {
-								if (previousWorkspaceKey) {
-									store.activateEncryption(new Map([[1, previousWorkspaceKey]]));
-								} else {
-									store.deactivateEncryption();
-								}
+									if (previousWorkspaceKey) {
+										store.activateEncryption(new Map([[1, previousWorkspaceKey]]));
+									} else {
+										store.deactivateEncryption();
+									}
 								} catch { /* best-effort rollback */ }
 							}
 							console.error('[workspace] Workspace unlock failed:', error);
@@ -629,7 +639,7 @@ export function createWorkspace<
 					}
 
 					if (config?.userKeyStore && !isActiveUserKeyCached) {
-						await persistUnlockedUserKey(userKey);
+						await persistKeys(keys);
 					}
 				};
 
@@ -654,10 +664,11 @@ export function createWorkspace<
 					const store = config.userKeyStore;
 					state.whenReadyPromises.push(
 						Promise.all(state.whenReadyPromises).then(async () => {
-							const cachedKey = await store.get();
-							if (!cachedKey) return;
+							const cached = await store.get();
+							if (!cached) return;
 							try {
-								await unlock(base64ToBytes(cachedKey));
+								const keys = JSON.parse(cached) as EncryptionKey[];
+								await unlock(keys);
 							} catch (error) {
 								console.error('[workspace] Cached key unlock failed:', error);
 								await clearCache();

--- a/packages/workspace/src/workspace/create-workspace.ts
+++ b/packages/workspace/src/workspace/create-workspace.ts
@@ -167,12 +167,10 @@ export function createWorkspace<
 	const kvDefs = (kvDef ?? {}) as TKvDefinitions;
 	const awarenessDefs = (awarenessDef ?? {}) as TAwarenessDefinitions;
 
-	// ── Tables ───────────────────────────────────────────────────────────
-	const keyring = options?.key ? new Map([[1, options.key]]) : undefined;
-
+	// ── Tables ───────────────────────────────────────────────────────────────
 	const tableEntries = Object.entries(tableDefs).map(([name, definition]) => {
 		const yarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>(TableKey(name));
-		const store = createEncryptedYkvLww(yarray, { keyring });
+		const store = createEncryptedYkvLww(yarray);
 		const helper = createTable(store, definition);
 		return { name, store, helper };
 	});
@@ -181,9 +179,9 @@ export function createWorkspace<
 		tableEntries.map(({ name, helper }) => [name, helper]),
 	) as TablesHelper<TTableDefinitions>;
 
-	// ── KV ──────────────────────────────────────────────────────────────
+	// ── KV ──────────────────────────────────────────────────────────────────
 	const kvYarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>(KV_KEY);
-	const kvStore = createEncryptedYkvLww(kvYarray, { keyring });
+	const kvStore = createEncryptedYkvLww(kvYarray);
 	const kvHelper = createKv(kvStore, kvDefs);
 
 	// ── Encrypted stores (all table stores + KV store) ─────────────────────
@@ -193,6 +191,15 @@ export function createWorkspace<
 		...tableEntries.map(({ store }) => store),
 		kvStore,
 	];
+
+	// Seed encryption from construction-time key (if provided).
+	// Equivalent to calling activateEncryption() immediately after creation.
+	if (options?.key) {
+		const keyring = new Map([[1, options.key]]);
+		for (const store of encryptedStores) {
+			store.activateEncryption(keyring);
+		}
+	}
 
 	const awareness = createAwareness(ydoc, awarenessDefs);
 	const definitions = {
@@ -558,7 +565,7 @@ export function createWorkspace<
 						if (previousKey) {
 							for (const store of deactivated) {
 								try {
-							store.activateEncryption(previousKey);
+							store.activateEncryption(new Map([[1, previousKey]]));
 								} catch { /* best-effort rollback */ }
 							}
 						}
@@ -599,7 +606,7 @@ export function createWorkspace<
 						const activated: YKeyValueLwwEncrypted<unknown>[] = [];
 						try {
 						for (const store of encryptedStores) {
-							store.activateEncryption(nextWorkspaceKey);
+							store.activateEncryption(new Map([[1, nextWorkspaceKey]]));
 							activated.push(store);
 						}
 							workspaceKey = nextWorkspaceKey;
@@ -610,7 +617,7 @@ export function createWorkspace<
 							for (const store of activated) {
 								try {
 								if (previousWorkspaceKey) {
-									store.activateEncryption(previousWorkspaceKey);
+									store.activateEncryption(new Map([[1, previousWorkspaceKey]]));
 								} else {
 									store.deactivateEncryption();
 								}

--- a/packages/workspace/src/workspace/types.ts
+++ b/packages/workspace/src/workspace/types.ts
@@ -1068,18 +1068,29 @@ export type EncryptionConfig = {
  * await workspace.clearLocalData();
  * ```
  */
+/**
+ * A single versioned encryption key for transport.
+ *
+ * Pairs a key version (from the server's `ENCRYPTION_SECRETS`) with the
+ * HKDF-derived per-user key encoded as base64 for JSON transport.
+ */
+export type EncryptionKey = {
+	version: number;
+	userKeyBase64: string;
+};
+
 export type WorkspaceEncryption = {
 	/** Whether the runtime is currently unlocked. */
 	isUnlocked: boolean;
 	/**
-	 * Unlock the workspace with a root user key.
+	 * Unlock the workspace with encryption keys.
 	 *
-	 * This accepts a root user key, not a final workspace content key. The
-	 * workspace derives a per-workspace key via HKDF-SHA256, applies it to
-	 * encrypted stores synchronously, then persists the user key if a cache is
-	 * configured.
+	 * Accepts an array of versioned user keys (from the auth session).
+	 * Derives a per-workspace key for each version via HKDF-SHA256,
+	 * builds a keyring Map, and activates encrypted stores. Persists
+	 * the keys if a cache is configured.
 	 */
-	unlock(userKey: Uint8Array): Promise<void>;
+	unlock(keys: EncryptionKey[]): Promise<void>;
 	/**
 	 * Lock the runtime.
 	 *
@@ -1095,21 +1106,14 @@ export type WorkspaceEncryption = {
  */
 export type WorkspaceKeyAccess = {
 	/**
-	 * Unlock the workspace from a base64-encoded user key.
+	 * Unlock the workspace from an array of encryption keys.
 	 *
-	 * This is a convenience wrapper for app-layer auth flows that fetch the
-	 * user key as a string payload.
+	 * Convenience wrapper for app-layer auth flows. Waits for whenReady,
+	 * then delegates to `encryption.unlock()`.
 	 */
-	unlockWithKey(userKeyBase64: string): Promise<void>;
+	unlockWithKeys(keys: EncryptionKey[]): Promise<void>;
 };
 
-export type WorkspaceKeyAccessFor<
-	TConfig extends EncryptionConfig | undefined,
-> = TConfig extends EncryptionConfig ? WorkspaceKeyAccess : WorkspaceKeyAccess;
-
-export type WorkspaceEncryptionFor<
-	TConfig extends EncryptionConfig | undefined,
-> = TConfig extends EncryptionConfig ? WorkspaceEncryption : WorkspaceEncryption;
 export type WorkspaceClientBuilder<
 	TId extends string,
 	TTableDefinitions extends TableDefinitions,
@@ -1302,11 +1306,11 @@ export type WorkspaceClientBuilder<
 		 *   .withExtension('persistence', indexeddbPersistence)
 		 *   .withExtension('sync', createSyncExtension({ ... }));
 		 *
-		 * await workspace.encryption.unlock(userKeyBytes);  // explicit unlock from auth
+		 * await workspace.encryption.unlock([{ version: 1, userKeyBase64 }]);  // explicit unlock from auth
 		 * ```
 		 */
-		withEncryption<TConfig extends EncryptionConfig | undefined = undefined>(
-			config?: TConfig,
+		withEncryption(
+			config?: EncryptionConfig,
 		): WorkspaceClientBuilder<
 			TId,
 			TTableDefinitions,
@@ -1315,8 +1319,8 @@ export type WorkspaceClientBuilder<
 			TExtensions,
 			TDocExtensions,
 		{
-			encryption: WorkspaceEncryptionFor<TConfig>;
-		} & WorkspaceKeyAccessFor<TConfig>,
+			encryption: WorkspaceEncryption;
+		} & WorkspaceKeyAccess,
 			TActions
 		>;
 

--- a/packages/workspace/src/workspace/user-key-store.ts
+++ b/packages/workspace/src/workspace/user-key-store.ts
@@ -1,14 +1,13 @@
 /**
- * Platform-agnostic interface for persisting user encryption keys.
+ * Platform-agnostic interface for persisting encryption keys across sessions.
  *
- * Stores the user key as a base64 string—the same format the auth session
- * provides and the workspace unlock boundary restores. This keeps the
- * cache representation simple: the key enters as a string, caches as a
- * string, and only decodes to bytes once the workspace calls `unlock()`.
+ * Stores the encryption keys as a JSON string—`JSON.stringify(EncryptionKey[])`
+ * where each entry is `{ version: number, userKeyBase64: string }`. The store
+ * interface deals only in opaque strings; callers handle serialization.
  *
  * Passing a `UserKeyStore` to `.withEncryption({ userKeyStore })` implies
- * auto-boot: the workspace loads the cached key on startup and unlocks
- * immediately if one is available. No explicit boot call is needed.
+ * auto-boot: the workspace loads the cached keys on startup and unlocks
+ * immediately if available. No explicit boot call is needed.
  *
  * | Platform         | Implementation                                            |
  * |------------------|-----------------------------------------------------------|
@@ -21,39 +20,39 @@
  *
  * ```
  * Server (auth session)
- *   │  userKeyBase64: base64 string
+ *   │  encryptionKeys: [{ version, userKeyBase64 }, ...]
  *   ▼
- * UserKeyStore.set(userKeyBase64)
- *   │  stored locally as-is (no conversion needed)
+ * UserKeyStore.set(JSON.stringify(encryptionKeys))
+ *   │  stored locally as opaque string
  *   ▼
  * App startup (before auth roundtrip completes)
- *   │  UserKeyStore.get() → base64 string | null
+ *   │  UserKeyStore.get() → JSON string | null
  *   │  consumed by auto-boot in whenReady
  *   ▼
- * auto-boot → base64ToBytes → unlock() → HKDF
- *   │  base64 decoding happens once, at the crypto boundary
+ * auto-boot → JSON.parse → unlock(keys) → deriveWorkspaceKey per version
+ *   │  base64 decoding + HKDF happens inside unlock()
  * ```
  *
  * Without a `UserKeyStore`, every page refresh requires a full auth roundtrip
  * before encrypted data can be read. With a store, the workspace unlocks
- * immediately on launch using the cached key, then refreshes it silently when
+ * immediately on launch using the cached keys, then refreshes them silently when
  * the session loads.
  */
 export type UserKeyStore = {
 	/**
-	 * Persist the latest base64-encoded user key.
+	 * Persist the latest encryption keys as a JSON string.
 	 *
-	 * Called after the workspace receives or refreshes a valid user key from the
-	 * auth session. Implementations usually store one value and overwrite any
-	 * older cached key.
+	 * Called after the workspace receives or refreshes valid keys from the
+	 * auth session. Implementations store one value and overwrite any
+	 * older cached entry.
 	 */
-	set(userKeyBase64: string): Promise<void>;
+	set(keysJson: string): Promise<void>;
 	/**
-	 * Retrieve the cached base64-encoded user key during startup.
+	 * Retrieve the cached encryption keys during startup.
 	 *
 	 * Called automatically during `whenReady` when a `UserKeyStore` is provided
 	 * to `.withEncryption()`. Return `null` to skip auto-unlock and wait for
-	 * the server session to provide a key.
+	 * the server session to provide keys.
 	 */
 	get(): Promise<string | null>;
 	/**


### PR DESCRIPTION
Until now, the encryption system used a single `Uint8Array` key everywhere—one key version, one derivation, one chance to decrypt. That's fine until you need to rotate keys. When the server rotates `ENCRYPTION_SECRETS`, clients with cached data encrypted under the old version can't decrypt it, and there's no mechanism to carry both keys simultaneously.

This introduces `EncryptionKey[]`—a versioned keyring where each entry pairs a `version` number with a `userKeyBase64` string. The highest version encrypts new data; older versions exist solely for decrypting legacy blobs.

```typescript
// BEFORE: single key, no versioning
workspace.encryption.unlock(userKeyBytes);
workspace.unlockWithKey(userKeyBase64);

// AFTER: versioned keyring
workspace.encryption.unlock([
  { version: 2, userKeyBase64: 'newer-key...' },
  { version: 1, userKeyBase64: 'older-key...' },
]);
workspace.unlockWithKeys(keys);
```

The change threads through every layer of the stack. The API server's session endpoint now returns `encryptionKeys: EncryptionKey[]` instead of a single `encryptionKey` string. The workspace's `withEncryption` builder derives per-workspace keys for each version via HKDF-SHA256 and builds a `Map<version, Uint8Array>` keyring. The encrypted KV layer tries the blob's embedded version first, then falls back through the keyring—so a version-2 blob decrypts with the version-2 key, but a version-1 blob still decrypts with the version-1 key.

```
┌─────────────────────────────────────────────────────────┐
│  API Session                                            │
│  encryptionKeys: [{ version: 2, userKeyBase64 }, ...]   │
└──────────────────────┬──────────────────────────────────┘
                       │
                       ▼
┌─────────────────────────────────────────────────────────┐
│  workspace.encryption.unlock(keys)                      │
│  → HKDF-derive per-workspace key for each version       │
│  → Map<version, Uint8Array> keyring                     │
└──────────────────────┬──────────────────────────────────┘
                       │
                       ▼
┌─────────────────────────────────────────────────────────┐
│  YKeyValueLwwEncrypted                                  │
│  encrypt: highest-version key                           │
│  decrypt: match blob version → fallback through keyring │
└─────────────────────────────────────────────────────────┘
```

The encrypted KV internals also got hardened in this pass—keyring validation rejects empty or duplicate-version keyrings, decrypt logic was deduplicated into a single `tryDecryptValue` path, and the internal `Map` is exposed as `ReadonlyMap` to prevent accidental mutation.

All consumers (honeycrisp, opensidian, tab-manager, zhongwen, CLI, svelte-utils auth) were updated to pass the new `EncryptionKey[]` shape.

> **Stack**: 2/5 — builds on #1584 (remove compaction). Next: type safety with arktype schemas.