### PR TITLE
feat(workspace): make EncryptionKey an arktype schema with typed UserKeyStore

### DIFF
--- a/apps/api/src/auth/contracts/get-session.ts
+++ b/apps/api/src/auth/contracts/get-session.ts
@@ -14,29 +14,19 @@ import type {
 	Session,
 	User,
 } from 'better-auth';
-
-/**
- * A single versioned encryption key for transport.
- *
- * Each entry pairs a key version (from `ENCRYPTION_SECRETS`) with the
- * HKDF-derived per-user key encoded as base64 for JSON transport.
- */
-export type EncryptionKey = {
-	version: number;
-	userKeyBase64: string;
-};
+import type { EncryptionKeys } from '@epicenter/workspace';
 
 /**
  * Canonical `/auth/get-session` response for Epicenter clients.
  *
  * Extends Better Auth's base `{ user, session }` with `encryptionKeys`—the
  * full keyring of derived per-user keys so clients can decrypt blobs encrypted
- * with any key version. First element is the current (highest-version) key.
+ * with any key version.
  *
  * Import from `@epicenter/api/types` rather than hand-writing the response.
  */
 export type SessionResponse = {
 	user: User;
 	session: Session;
-	encryptionKeys: [EncryptionKey, ...EncryptionKey[]];
+	encryptionKeys: EncryptionKeys;
 };

--- a/apps/api/src/auth/contracts/index.ts
+++ b/apps/api/src/auth/contracts/index.ts
@@ -5,4 +5,4 @@
  * Client-only Better Auth inference helpers belong in the consuming package,
  * and server runtime wiring belongs next to the auth factory.
  */
-export type { EncryptionKey, SessionResponse } from './get-session';
+export type { SessionResponse } from './get-session';

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -167,9 +167,16 @@ export type {
 	WorkspaceClientBuilder,
 	WorkspaceEncryption,
 	EncryptionKey,
+	EncryptionKeys,
 	WorkspaceClientWithActions,
 	WorkspaceDefinition,
 } from './workspace/types';
+
+// Runtime schemas (arktype) — for validation at deserialization boundaries
+export {
+	EncryptionKey,
+	EncryptionKeys,
+} from './workspace/encryption-key';
 
 // ════════════════════════════════════════════════════════════════════════════
 // DRIZZLE RE-EXPORTS

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.test.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.test.ts
@@ -7,7 +7,15 @@ import {
 	isEncryptedBlob,
 } from '../crypto';
 import type { YKeyValueLwwEntry } from './y-keyvalue-lww';
-import { createEncryptedYkvLww } from './y-keyvalue-lww-encrypted';
+import { createEncryptedYkvLww, type YKeyValueLwwEncrypted } from './y-keyvalue-lww-encrypted';
+
+/** Create a single-doc encrypted KV for tests. Skips the 4-line Y.Doc ceremony. */
+function setup<T = string>(keyring?: ReadonlyMap<number, Uint8Array>) {
+	const ydoc = new Y.Doc();
+	const yarray = ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | T>>('data');
+	const kv: YKeyValueLwwEncrypted<T> = createEncryptedYkvLww<T>(yarray, keyring);
+	return { ydoc, yarray, kv };
+}
 
 type PlainChange<T> =
 	| { action: 'add'; newValue: T }
@@ -43,10 +51,7 @@ describe('createEncryptedYkvLww', () => {
 	describe('Basic encrypted operations', () => {
 		test('set() encrypts, get() decrypts round-trip', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'test' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
+			const { kv } = setup(new Map([[1, key]]));
 
 			kv.set('secret', 'hello-world');
 
@@ -55,10 +60,7 @@ describe('createEncryptedYkvLww', () => {
 
 		test('values in Y.Array are encrypted', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'test' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
+			const { kv, yarray } = setup(new Map([[1, key]]));
 
 			kv.set('secret', 'cipher-me');
 
@@ -70,10 +72,7 @@ describe('createEncryptedYkvLww', () => {
 		test('complex object round-trip', () => {
 			type Bookmark = { url: string; title: string };
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'test' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | Bookmark>>('data');
-			const kv = createEncryptedYkvLww<Bookmark>(yarray, new Map([[1, key]]));
+			const { kv } = setup<Bookmark>(new Map([[1, key]]));
 
 			const value: Bookmark = { url: 'https://bank.com', title: 'My Bank' };
 			kv.set('site', value);
@@ -83,10 +82,7 @@ describe('createEncryptedYkvLww', () => {
 
 		test('delete works', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'test' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
+			const { kv } = setup(new Map([[1, key]]));
 
 			kv.set('k', 'v');
 			kv.delete('k');
@@ -96,10 +92,7 @@ describe('createEncryptedYkvLww', () => {
 
 		test('has works', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'test' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
+			const { kv } = setup(new Map([[1, key]]));
 
 			kv.set('k', 'v');
 			expect(kv.has('k')).toBe(true);
@@ -110,10 +103,7 @@ describe('createEncryptedYkvLww', () => {
 
 		test('entries returns decrypted values', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'test' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
+			const { kv } = setup(new Map([[1, key]]));
 
 			kv.set('a', '1');
 			kv.set('b', '2');
@@ -131,10 +121,7 @@ describe('createEncryptedYkvLww', () => {
 
 	describe('No-key passthrough', () => {
 		test('when no key is provided, set/get work as plaintext', () => {
-			const ydoc = new Y.Doc({ guid: 'test' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray);
+			const { kv } = setup();
 
 			kv.set('plain', 'text');
 
@@ -142,10 +129,7 @@ describe('createEncryptedYkvLww', () => {
 		});
 
 		test('when no key is provided, yarray contains plaintext', () => {
-			const ydoc = new Y.Doc({ guid: 'test' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray);
+			const { kv, yarray } = setup();
 
 			kv.set('plain', 'raw-value');
 
@@ -155,10 +139,7 @@ describe('createEncryptedYkvLww', () => {
 		});
 
 		test('zero overhead: wrapper.map mirrors inner behavior', () => {
-			const ydoc = new Y.Doc({ guid: 'test' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray);
+			const { kv } = setup();
 
 			kv.set('x', '10');
 			kv.set('y', '20');
@@ -172,10 +153,7 @@ describe('createEncryptedYkvLww', () => {
 	describe('Observer decryption', () => {
 		test('observer receives decrypted values on add', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'test' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
+			const { kv } = setup(new Map([[1, key]]));
 
 			const events: Array<{ key: string; change: PlainChange<string> }> = [];
 			kv.observe((changes) => {
@@ -192,10 +170,7 @@ describe('createEncryptedYkvLww', () => {
 
 		test('observer receives decrypted values on update', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'test' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
+			const { kv } = setup(new Map([[1, key]]));
 
 			kv.set('foo', 'first');
 
@@ -220,10 +195,7 @@ describe('createEncryptedYkvLww', () => {
 
 		test('observer receives correct action on delete', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'test' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
+			const { kv } = setup(new Map([[1, key]]));
 
 			kv.set('foo', 'value');
 
@@ -240,10 +212,7 @@ describe('createEncryptedYkvLww', () => {
 
 		test('unobserve stops notifications', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'test' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
+			const { kv } = setup(new Map([[1, key]]));
 
 			let count = 0;
 			const handler = () => {
@@ -262,9 +231,7 @@ describe('createEncryptedYkvLww', () => {
 	describe('Mixed plaintext/encrypted (migration)', () => {
 		test('reads plaintext entries as-is when key exists', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'test' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
+			const { yarray } = setup();
 
 			yarray.push([{ key: 'plaintext', val: 'plaintext-value', ts: 1000 }]);
 
@@ -274,9 +241,7 @@ describe('createEncryptedYkvLww', () => {
 
 		test('reads encrypted entries correctly', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'test' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
+			const { yarray } = setup();
 
 			const encrypted = createEncryptedBlob('encrypted-value', key, 'enc');
 			yarray.push([{ key: 'enc', val: encrypted, ts: 1000 }]);
@@ -287,9 +252,7 @@ describe('createEncryptedYkvLww', () => {
 
 		test('mixed entries: some plaintext, some encrypted', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'test' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
+			const { yarray } = setup();
 
 			const encrypted = createEncryptedBlob('new-secret', key, 'new');
 			yarray.push([
@@ -307,10 +270,7 @@ describe('createEncryptedYkvLww', () => {
 	describe('wrapper.map always plaintext', () => {
 		test('wrapper.map contains decrypted values after set', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'test' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
+			const { kv, yarray } = setup(new Map([[1, key]]));
 
 			kv.set('k', 'plain-view');
 
@@ -422,10 +382,7 @@ describe('createEncryptedYkvLww', () => {
 
 	describe('Key becomes available mid-session', () => {
 		test('passthrough then encrypted via activateEncryption', () => {
-			const ydoc = new Y.Doc({ guid: 'test' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray);
+			const { kv, yarray } = setup();
 
 			kv.set('old-1', 'alpha');
 			kv.set('old-2', 'beta');
@@ -449,10 +406,7 @@ describe('createEncryptedYkvLww', () => {
 		});
 
 		test('activateEncryption encrypts existing plaintext entries in-place', () => {
-			const ydoc = new Y.Doc({ guid: 'encrypt-plaintext-on-activate' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray);
+			const { kv, yarray } = setup();
 
 			kv.set('pt-1', 'plain-a');
 			kv.set('pt-2', 'plain-b');
@@ -477,10 +431,7 @@ describe('createEncryptedYkvLww', () => {
 	describe('Batch operations', () => {
 		test('set in batch is readable via get in same batch', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'test' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
+			const { kv, ydoc } = setup(new Map([[1, key]]));
 
 			let valueInBatch: string | undefined;
 			ydoc.transact(() => {
@@ -494,10 +445,7 @@ describe('createEncryptedYkvLww', () => {
 
 		test('multiple sets in batch all visible via entries', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'test' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
+			const { kv, ydoc } = setup(new Map([[1, key]]));
 
 			const keysInBatch: string[] = [];
 			ydoc.transact(() => {
@@ -514,10 +462,7 @@ describe('createEncryptedYkvLww', () => {
 
 	describe('Mode transitions', () => {
 		test('starts unencrypted when no key provided', () => {
-			const ydoc = new Y.Doc({ guid: 'mode-no-key-start' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray);
+			const { kv, yarray } = setup();
 
 			kv.set('a', 'hello');
 			const raw = yarray.toArray().find((e) => e.key === 'a');
@@ -526,10 +471,7 @@ describe('createEncryptedYkvLww', () => {
 
 		test('starts encrypted when key provided', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'mode-key-start' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
+			const { kv, yarray } = setup(new Map([[1, key]]));
 
 			kv.set('a', 'hello');
 			const raw = yarray.toArray().find((e) => e.key === 'a');
@@ -538,10 +480,7 @@ describe('createEncryptedYkvLww', () => {
 
 		test('plaintext → encrypted via activateEncryption(key)', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'mode-plaintext-to-encrypted' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray);
+			const { kv, yarray } = setup();
 
 			kv.set('before', 'plaintext');
 			const rawBefore = yarray.toArray().find((e) => e.key === 'before');
@@ -558,10 +497,7 @@ describe('createEncryptedYkvLww', () => {
 	describe('Error containment', () => {
 		test('corrupted blob does not crash observation', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'containment-corrupt-no-crash' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
+			const { kv, yarray } = setup(new Map([[1, key]]));
 
 			kv.set('good-1', 'value-1');
 			kv.set('good-2', 'value-2');
@@ -587,10 +523,7 @@ describe('createEncryptedYkvLww', () => {
 
 		test('observation continues after decrypt failure', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'containment-observer-continues' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
+			const { kv, yarray } = setup(new Map([[1, key]]));
 
 			kv.set('good', 'still-works');
 			yarray.push([
@@ -618,12 +551,7 @@ describe('createEncryptedYkvLww', () => {
 	describe('Key transition (activateEncryption)', () => {
 		test('plaintext entries remain accessible after activateEncryption', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({
-				guid: 'key-transition-plaintext-stays-readable',
-			});
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray);
+			const { kv } = setup();
 
 			kv.set('pt-1', 'plain-a');
 			kv.set('pt-2', 'plain-b');
@@ -635,10 +563,7 @@ describe('createEncryptedYkvLww', () => {
 
 		test('new writes after activateEncryption encrypt', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'key-transition-new-writes-encrypt' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray);
+			const { kv, yarray } = setup();
 
 			kv.set('before', 'plaintext-before-key');
 			kv.activateEncryption(new Map([[1, key]]));
@@ -654,10 +579,7 @@ describe('createEncryptedYkvLww', () => {
 		test('activateEncryption with key rotation preserves entries via fallback', () => {
 			const key1 = generateEncryptionKey();
 			const key2 = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'key-transition-synthetic-events' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key1]]));
+			const { kv } = setup(new Map([[1, key1]]));
 
 			kv.set('a', 'alpha');
 			kv.set('b', 'beta');
@@ -689,11 +611,7 @@ describe('createEncryptedYkvLww', () => {
 		});
 
 		test('activateEncryption does not emit spurious events for plaintext re-encryption', () => {
-			const ydoc = new Y.Doc({ guid: 'no-spurious-reencrypt' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			// Start without encryption — entries stored as plaintext
-			const kv = createEncryptedYkvLww<string>(yarray);
+			const { kv } = setup();
 
 			kv.set('a', 'alpha');
 			kv.set('b', 'beta');
@@ -717,12 +635,7 @@ describe('createEncryptedYkvLww', () => {
 		test('multi-version keyring decrypts entries with different keyVersions and re-encrypts with current', () => {
 			const key1 = generateEncryptionKey();
 			const key2 = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'multi-version-keyring' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-
-			// Write entries with key1 (version 1)
-			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key1]]));
+			const { kv, yarray } = setup(new Map([[1, key1]]));
 			kv.set('a', 'alpha');
 			kv.set('b', 'beta');
 
@@ -761,10 +674,7 @@ describe('createEncryptedYkvLww', () => {
 	describe('deactivateEncryption', () => {
 		test('clears key so new writes are plaintext', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'deactivate-plaintext-writes' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
+			const { kv, yarray } = setup(new Map([[1, key]]));
 
 			kv.set('enc', 'secret');
 			expect(isEncryptedBlob(yarray.toArray().find((e) => e.key === 'enc')?.val)).toBe(true);
@@ -779,10 +689,7 @@ describe('createEncryptedYkvLww', () => {
 
 		test('clears decrypted cache', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'deactivate-clears-cache' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
+			const { kv } = setup(new Map([[1, key]]));
 
 			kv.set('a', 'alpha');
 			kv.set('b', 'beta');
@@ -795,10 +702,7 @@ describe('createEncryptedYkvLww', () => {
 
 		test('encrypted entries unreadable after deactivation', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'deactivate-unreadable' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
+			const { kv } = setup(new Map([[1, key]]));
 
 			kv.set('secret', 'hidden');
 			kv.deactivateEncryption();
@@ -809,10 +713,7 @@ describe('createEncryptedYkvLww', () => {
 
 		test('reactivation restores access to encrypted entries', () => {
 			const key = generateEncryptionKey();
-			const ydoc = new Y.Doc({ guid: 'deactivate-reactivate' });
-			const yarray =
-				ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | string>>('data');
-			const kv = createEncryptedYkvLww<string>(yarray, new Map([[1, key]]));
+			const { kv } = setup(new Map([[1, key]]));
 
 			kv.set('secret', 'hidden');
 			kv.deactivateEncryption();

--- a/packages/workspace/src/workspace/create-workspace.test.ts
+++ b/packages/workspace/src/workspace/create-workspace.test.ts
@@ -25,10 +25,10 @@ import { defineKv } from './define-kv.js';
 import { defineTable } from './define-table.js';
 import { defineWorkspace } from './define-workspace.js';
 import type { UserKeyStore } from './user-key-store.js';
-import type { EncryptionKey } from './types.js';
+import type { EncryptionKeys } from './types.js';
 
-/** Wrap a raw Uint8Array key into a single-entry EncryptionKey[] for tests. */
-function toEncryptionKeys(key: Uint8Array): EncryptionKey[] {
+/** Wrap a raw Uint8Array key into a single-entry EncryptionKeys for tests. */
+function toEncryptionKeys(key: Uint8Array): EncryptionKeys {
 	return [{ version: 1, userKeyBase64: bytesToBase64(key) }];
 }
 

--- a/packages/workspace/src/workspace/create-workspace.test.ts
+++ b/packages/workspace/src/workspace/create-workspace.test.ts
@@ -32,10 +32,6 @@ function toEncryptionKeys(key: Uint8Array): EncryptionKeys {
 	return [{ version: 1, userKeyBase64: bytesToBase64(key) }];
 }
 
-/** Serialize a raw key to the JSON format the UserKeyStore now expects. */
-function toKeysJson(key: Uint8Array): string {
-	return JSON.stringify(toEncryptionKeys(key));
-}
 
 /** Creates a workspace client with two tables and one KV for testing. */
 function setup() {
@@ -1024,17 +1020,17 @@ describe('.withEncryption() lifecycle', () => {
 		return { client };
 	}
 
-	function setupWithUserKeyStore(cachedKeyBase64: string | null = null) {
+	function setupWithUserKeyStore(cachedKeys: EncryptionKeys | null = null) {
 		const posts = defineTable(type({ id: 'string', title: 'string', _v: '1' }));
-		let cachedValue = cachedKeyBase64;
+		let cachedValue: EncryptionKeys | null = cachedKeys;
 		let shouldFailNextSave = false;
 		const userKeyStore: UserKeyStore = {
-			set: mock(async (keyBase64: string) => {
+			set: mock(async (keys: EncryptionKeys) => {
 				if (shouldFailNextSave) {
 					shouldFailNextSave = false;
 					throw new Error('forced user key store set failure');
 				}
-				cachedValue = keyBase64;
+				cachedValue = keys;
 			}),
 			get: mock(async () => cachedValue),
 			delete: mock(async () => {
@@ -1115,8 +1111,8 @@ describe('.withEncryption() lifecycle', () => {
 			await client.encryption.unlock(toEncryptionKeys(userKey));
 
 			expect(userKeyStore.set).toHaveBeenCalledTimes(1);
-			expect(userKeyStore.set).toHaveBeenCalledWith(toKeysJson(userKey));
-			expect(readCachedValue()).toBe(toKeysJson(userKey));
+			expect(userKeyStore.set).toHaveBeenCalledWith(toEncryptionKeys(userKey));
+			expect(readCachedValue()).toEqual(toEncryptionKeys(userKey));
 		});
 
 		test('encryption.unlock retries the same key after userKeyStore.set fails', async () => {
@@ -1131,7 +1127,7 @@ describe('.withEncryption() lifecycle', () => {
 
 			expect(client.encryption.isUnlocked).toBe(true);
 			expect(userKeyStore.set).toHaveBeenCalledTimes(2);
-			expect(readCachedValue()).toBe(toKeysJson(userKey));
+			expect(readCachedValue()).toEqual(toEncryptionKeys(userKey));
 		});
 
 		test('encryption.unlock updates runtime state before userKeyStore.set settles', async () => {
@@ -1139,11 +1135,11 @@ describe('.withEncryption() lifecycle', () => {
 				type({ id: 'string', title: 'string', _v: '1' }),
 			);
 			const saveDeferred = createDeferred<void>();
-			let cachedValue: string | null = null;
+			let cachedValue: EncryptionKeys | null = null;
 			const userKeyStore: UserKeyStore = {
-				set: mock(async (keyBase64: string) => {
+				set: mock(async (keys: EncryptionKeys) => {
 					await saveDeferred.promise;
-					cachedValue = keyBase64;
+					cachedValue = keys;
 				}),
 				get: mock(async () => cachedValue),
 				delete: mock(async () => {
@@ -1164,7 +1160,8 @@ describe('.withEncryption() lifecycle', () => {
 			saveDeferred.resolve();
 			await unlockPromise;
 
-			expect(cachedValue ?? '').toBe(toKeysJson(userKey));
+			expect(cachedValue).not.toBeNull();
+			expect(cachedValue!).toEqual(toEncryptionKeys(userKey));
 		});
 
 		test('auto-boot stays locked when userKeyStore is empty', async () => {
@@ -1179,19 +1176,22 @@ describe('.withEncryption() lifecycle', () => {
 		test('auto-boot unlocks from cached key', async () => {
 			const userKey = generateEncryptionKey();
 			const { client, userKeyStore } = setupWithUserKeyStore(
-				toKeysJson(userKey),
+				toEncryptionKeys(userKey),
 			);
 			await client.whenReady;
 
 			expect(client.encryption.isUnlocked).toBe(true);
 			expect(userKeyStore.get).toHaveBeenCalledTimes(1);
 			expect(userKeyStore.set).toHaveBeenCalledTimes(1);
-			expect(userKeyStore.set).toHaveBeenCalledWith(toKeysJson(userKey));
+			expect(userKeyStore.set).toHaveBeenCalledWith(toEncryptionKeys(userKey));
 		});
 
-		test('auto-boot clears corrupt cache entries and stays locked', async () => {
+		test('auto-boot clears cache and stays locked when unlock fails', async () => {
+			// The store returns valid EncryptionKeys shape, but with bad base64
+			// that causes unlock() to throw during key derivation.
+			const corruptKeys: EncryptionKeys = [{ version: 1, userKeyBase64: '%%%not-base64%%%' }];
 			const { client, userKeyStore, readCachedValue } =
-				setupWithUserKeyStore('%%%not-base64%%%');
+				setupWithUserKeyStore(corruptKeys);
 			await client.whenReady;
 
 			expect(client.encryption.isUnlocked).toBe(false);
@@ -1205,14 +1205,14 @@ describe('.withEncryption() lifecycle', () => {
 			);
 			const firstSaveDeferred = createDeferred<void>();
 			let saveCalls = 0;
-			let cachedValue: string | null = null;
+			let cachedValue: EncryptionKeys | null = null;
 			const userKeyStore: UserKeyStore = {
-				set: mock(async (keyBase64: string) => {
+				set: mock(async (keys: EncryptionKeys) => {
 					saveCalls += 1;
 					if (saveCalls === 1) {
 						await firstSaveDeferred.promise;
 					}
-					cachedValue = keyBase64;
+					cachedValue = keys;
 				}),
 				get: mock(async () => cachedValue),
 				delete: mock(async () => {
@@ -1238,7 +1238,8 @@ describe('.withEncryption() lifecycle', () => {
 			// persist task skips the write because activeUserKey has already
 			// changed to secondKey by the time the queued task runs.
 			expect(userKeyStore.set).toHaveBeenCalledTimes(1);
-			expect(cachedValue ?? '').toBe(toKeysJson(secondKey));
+			expect(cachedValue).not.toBeNull();
+			expect(cachedValue!).toEqual(toEncryptionKeys(secondKey));
 		});
 
 		test('clearLocalData clears userKeyStore after an in-flight set finishes', async () => {
@@ -1247,12 +1248,12 @@ describe('.withEncryption() lifecycle', () => {
 			);
 			const saveDeferred = createDeferred<void>();
 			const events: string[] = [];
-			let cachedValue: string | null = null;
+			let cachedValue: EncryptionKeys | null = null;
 			const userKeyStore: UserKeyStore = {
-				set: mock(async (keyBase64: string) => {
+				set: mock(async (keys: EncryptionKeys) => {
 					events.push('set:start');
 					await saveDeferred.promise;
-					cachedValue = keyBase64;
+					cachedValue = keys;
 					events.push('set:end');
 				}),
 				get: mock(async () => cachedValue),

--- a/packages/workspace/src/workspace/create-workspace.ts
+++ b/packages/workspace/src/workspace/create-workspace.ts
@@ -101,6 +101,7 @@ import type {
 	DocumentsHelper,
 	EncryptionConfig,
 	EncryptionKey,
+	EncryptionKeys,
 	ExtensionContext,
 	KvDefinitions,
 	TableHelper,
@@ -112,6 +113,8 @@ import type {
 	WorkspaceEncryption,
 } from './types.js';
 import { KV_KEY, TableKey } from './ydoc-keys.js';
+import { EncryptionKeys as EncryptionKeysSchema } from './encryption-key.js';
+import { type as arktype } from 'arktype';
 
 /** Byte-level comparison for Uint8Array dedup. */
 function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
@@ -574,7 +577,7 @@ export function createWorkspace<
 					}
 				};
 
-				const persistKeys = async (keys: EncryptionKey[]) => {
+				const persistKeys = async (keys: EncryptionKeys, currentUserKey: Uint8Array) => {
 					if (!config?.userKeyStore) return;
 
 					try {
@@ -585,7 +588,7 @@ export function createWorkspace<
 							// already keysB — skip the stale write entirely.
 							if (
 								activeUserKey === undefined ||
-								!bytesEqual(activeUserKey, base64ToBytes(keys[0]!.userKeyBase64))
+								!bytesEqual(activeUserKey, currentUserKey)
 							)
 								return;
 
@@ -597,24 +600,30 @@ export function createWorkspace<
 					}
 				};
 
-				const unlock = async (keys: EncryptionKey[]) => {
-					const currentUserKey = base64ToBytes(keys[0]!.userKeyBase64);
+				const unlock = async (keys: EncryptionKeys) => {
+					// Decode all keys once — avoids double base64 decode for the current key
+					const decoded = keys.map((k) => ({
+						version: k.version,
+						userKey: base64ToBytes(k.userKeyBase64),
+					}));
+					const maxEntry = decoded.reduce((a, b) =>
+						a.version > b.version ? a : b,
+					);
+					const currentUserKey = maxEntry.userKey;
 					const isSameUserKey =
 						activeUserKey !== undefined && bytesEqual(activeUserKey, currentUserKey);
 
 					if (!isSameUserKey) {
 						// Build version → workspaceKey map from all keyring entries
 						const workspaceKeyring = new Map<number, Uint8Array>();
-						for (const { version, userKeyBase64 } of keys) {
+						for (const { version, userKey } of decoded) {
 							workspaceKeyring.set(
 								version,
-								deriveWorkspaceKey(base64ToBytes(userKeyBase64), id),
+								deriveWorkspaceKey(userKey, id),
 							);
 						}
 						const previousKeyring = activeWorkspaceKeyring;
-						const nextWorkspaceKey = workspaceKeyring.get(
-							Math.max(...workspaceKeyring.keys()),
-						)!;
+						const nextWorkspaceKey = workspaceKeyring.get(maxEntry.version)!;
 						const activated: YKeyValueLwwEncrypted<unknown>[] = [];
 						try {
 							for (const store of encryptedStores) {
@@ -642,7 +651,7 @@ export function createWorkspace<
 					}
 
 					if (config?.userKeyStore && !isActiveUserKeyCached) {
-						await persistKeys(keys);
+						await persistKeys(keys, currentUserKey);
 					}
 				};
 
@@ -670,8 +679,13 @@ export function createWorkspace<
 							const cached = await store.get();
 							if (!cached) return;
 							try {
-								const keys = JSON.parse(cached) as EncryptionKey[];
-								await unlock(keys);
+								const parsed = EncryptionKeysSchema(JSON.parse(cached));
+								if (parsed instanceof arktype.errors) {
+									console.error('[workspace] Cached encryption keys invalid:', parsed.summary);
+									await clearCache();
+									return;
+								}
+								await unlock(parsed);
 							} catch (error) {
 								console.error('[workspace] Cached key unlock failed:', error);
 								await clearCache();

--- a/packages/workspace/src/workspace/create-workspace.ts
+++ b/packages/workspace/src/workspace/create-workspace.ts
@@ -113,14 +113,38 @@ import type {
 	WorkspaceEncryption,
 } from './types.js';
 import { KV_KEY, TableKey } from './ydoc-keys.js';
-import { EncryptionKeys as EncryptionKeysSchema } from './encryption-key.js';
-import { type as arktype } from 'arktype';
 
 /** Byte-level comparison for Uint8Array dedup. */
 function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
 	if (a.length !== b.length) return false;
 	for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
 	return true;
+}
+
+/**
+ * Apply an operation to every encrypted store with automatic rollback on partial failure.
+ *
+ * If any store throws during `apply`, all previously applied stores are reverted
+ * via `rollback` (best-effort). The original error is re-thrown so the caller
+ * can handle it (log, return early, etc.).
+ */
+function transactStores(
+	stores: YKeyValueLwwEncrypted<unknown>[],
+	apply: (store: YKeyValueLwwEncrypted<unknown>) => void,
+	rollback: (store: YKeyValueLwwEncrypted<unknown>) => void,
+): void {
+	const applied: YKeyValueLwwEncrypted<unknown>[] = [];
+	try {
+		for (const store of stores) {
+			apply(store);
+			applied.push(store);
+		}
+	} catch (error) {
+		for (const store of applied) {
+			try { rollback(store); } catch { /* best-effort */ }
+		}
+		throw error;
+	}
 }
 
 
@@ -537,12 +561,18 @@ export function createWorkspace<
 			},
 
 			withEncryption(config?: EncryptionConfig) {
-				let activeUserKey: Uint8Array | undefined;
-				let isActiveUserKeyCached = config?.userKeyStore === undefined;
-				let workspaceKey: Uint8Array | undefined = options?.key;
+				// ── State ────────────────────────────────────────────────────
+				// Two core variables instead of five. `encryptionState` collapses
+				// activeUserKey + activeWorkspaceKeyring + workspaceKey into one
+				// atomic object. `storesActive` tracks the construction-time key
+				// path where stores are activated before withEncryption() runs.
+				let encryptionState: {
+					userKey: Uint8Array;
+					keyring: ReadonlyMap<number, Uint8Array>;
+				} | undefined;
+				let storesActive = options?.key !== undefined;
+				let persisted = !config?.userKeyStore;
 				let cacheQueue = Promise.resolve();
-				/** The last keyring passed to activateEncryption, for rollback. */
-				let activeWorkspaceKeyring: ReadonlyMap<number, Uint8Array> | undefined;
 
 				const runSerializedCacheTask = async (
 					task: () => Promise<void>,
@@ -552,48 +582,37 @@ export function createWorkspace<
 					return await next;
 				};
 
+				// ── Operations ──────────────────────────────────────────────
+
 				const lock = () => {
-					const previousKeyring = activeWorkspaceKeyring;
-					const deactivated: YKeyValueLwwEncrypted<unknown>[] = [];
+					const previous = encryptionState;
 					try {
-						for (const store of encryptedStores) {
-							store.deactivateEncryption();
-							deactivated.push(store);
-						}
-						activeUserKey = undefined;
-						isActiveUserKeyCached = config?.userKeyStore === undefined;
-						workspaceKey = undefined;
-						activeWorkspaceKeyring = undefined;
+						transactStores(
+							encryptedStores,
+							(s) => s.deactivateEncryption(),
+							(s) => { if (previous) s.activateEncryption(previous.keyring); },
+						);
 					} catch (error) {
-						// Rollback: revert stores deactivated before the failure
-						if (previousKeyring) {
-							for (const store of deactivated) {
-								try {
-									store.activateEncryption(previousKeyring);
-								} catch { /* best-effort rollback */ }
-							}
-						}
 						console.error('[workspace] Workspace lock failed:', error);
+						return;
 					}
+					encryptionState = undefined;
+					storesActive = false;
+					persisted = !config?.userKeyStore;
 				};
 
 				const persistKeys = async (keys: EncryptionKeys, currentUserKey: Uint8Array) => {
 					if (!config?.userKeyStore) return;
-
 					try {
 						await runSerializedCacheTask(async () => {
-							// Guard: only write if the active key still matches.
-							// A rapid unlock(keysA) → unlock(keysB) sequence queues two
-							// writes. By the time keysA's task runs, activeUserKey is
-							// already keysB — skip the stale write entirely.
+							// Guard: skip stale writes from earlier unlock() calls
 							if (
-								activeUserKey === undefined ||
-								!bytesEqual(activeUserKey, currentUserKey)
+								!encryptionState ||
+								!bytesEqual(encryptionState.userKey, currentUserKey)
 							)
 								return;
-
-							await config.userKeyStore.set(JSON.stringify(keys));
-							isActiveUserKeyCached = true;
+							await config.userKeyStore.set(keys);
+							persisted = true;
 						});
 					} catch (error) {
 						console.error('[workspace] Encryption key cache save failed:', error);
@@ -601,58 +620,45 @@ export function createWorkspace<
 				};
 
 				const unlock = async (keys: EncryptionKeys) => {
-					// Decode all keys once — avoids double base64 decode for the current key
 					const decoded = keys.map((k) => ({
 						version: k.version,
 						userKey: base64ToBytes(k.userKeyBase64),
 					}));
-					const maxEntry = decoded.reduce((a, b) =>
+					const current = decoded.reduce((a, b) =>
 						a.version > b.version ? a : b,
 					);
-					const currentUserKey = maxEntry.userKey;
-					const isSameUserKey =
-						activeUserKey !== undefined && bytesEqual(activeUserKey, currentUserKey);
 
-					if (!isSameUserKey) {
-						// Build version → workspaceKey map from all keyring entries
-						const workspaceKeyring = new Map<number, Uint8Array>();
-						for (const { version, userKey } of decoded) {
-							workspaceKeyring.set(
-								version,
-								deriveWorkspaceKey(userKey, id),
-							);
-						}
-						const previousKeyring = activeWorkspaceKeyring;
-						const nextWorkspaceKey = workspaceKeyring.get(maxEntry.version)!;
-						const activated: YKeyValueLwwEncrypted<unknown>[] = [];
-						try {
-							for (const store of encryptedStores) {
-								store.activateEncryption(workspaceKeyring);
-								activated.push(store);
-							}
-							workspaceKey = nextWorkspaceKey;
-							activeWorkspaceKeyring = workspaceKeyring;
-							activeUserKey = currentUserKey;
-							isActiveUserKeyCached = config?.userKeyStore === undefined;
-						} catch (error) {
-							// Rollback: revert stores activated before the failure
-							for (const store of activated) {
-								try {
-									if (previousKeyring) {
-										store.activateEncryption(previousKeyring);
-									} else {
-										store.deactivateEncryption();
-									}
-								} catch { /* best-effort rollback */ }
-							}
-							console.error('[workspace] Workspace unlock failed:', error);
-							return;
-						}
+					// De-dup: same user key → skip re-derivation, just persist if needed
+					if (encryptionState && bytesEqual(encryptionState.userKey, current.userKey)) {
+						if (!persisted) await persistKeys(keys, current.userKey);
+						return;
 					}
 
-					if (config?.userKeyStore && !isActiveUserKeyCached) {
-						await persistKeys(keys, currentUserKey);
+					// Derive workspace keyring from all key versions
+					const keyring = new Map<number, Uint8Array>();
+					for (const { version, userKey } of decoded) {
+						keyring.set(version, deriveWorkspaceKey(userKey, id));
 					}
+
+					// Activate all stores (automatic rollback on partial failure)
+					const previous = encryptionState;
+					try {
+						transactStores(
+							encryptedStores,
+							(s) => s.activateEncryption(keyring),
+							(s) => previous ? s.activateEncryption(previous.keyring) : s.deactivateEncryption(),
+						);
+					} catch (error) {
+						console.error('[workspace] Workspace unlock failed:', error);
+						return;
+					}
+
+					// Atomic state transition — one assignment, not three
+					encryptionState = { userKey: current.userKey, keyring };
+					storesActive = true;
+					persisted = !config?.userKeyStore;
+
+					if (!persisted) await persistKeys(keys, current.userKey);
 				};
 
 				const clearCache = async () => {
@@ -662,35 +668,31 @@ export function createWorkspace<
 					});
 				};
 
+				const bootFromCache = async (store: { get(): Promise<EncryptionKeys | null> }) => {
+					const keys = await store.get();
+					if (!keys) return;
+					try {
+						await unlock(keys);
+					} catch (error) {
+						console.error('[workspace] Cached key unlock failed:', error);
+						await clearCache();
+					}
+				};
+
+				// ── Wire up ──────────────────────────────────────────────────
+
 				const baseEncryption: WorkspaceEncryption = {
 					get isUnlocked() {
-						return workspaceKey !== undefined;
+						return encryptionState !== undefined || storesActive;
 					},
 					unlock,
 					lock,
 				};
 
-				// Auto-boot: if a key store is provided, attempt unlock from store
-				// after all extensions are ready. Passing userKeyStore implies auto-boot.
 				if (config?.userKeyStore) {
 					const store = config.userKeyStore;
 					state.whenReadyPromises.push(
-						Promise.all(state.whenReadyPromises).then(async () => {
-							const cached = await store.get();
-							if (!cached) return;
-							try {
-								const parsed = EncryptionKeysSchema(JSON.parse(cached));
-								if (parsed instanceof arktype.errors) {
-									console.error('[workspace] Cached encryption keys invalid:', parsed.summary);
-									await clearCache();
-									return;
-								}
-								await unlock(parsed);
-							} catch (error) {
-								console.error('[workspace] Cached key unlock failed:', error);
-								await clearCache();
-							}
-						}),
+						Promise.all(state.whenReadyPromises).then(() => bootFromCache(store)),
 					);
 				}
 

--- a/packages/workspace/src/workspace/encryption-key.ts
+++ b/packages/workspace/src/workspace/encryption-key.ts
@@ -1,0 +1,45 @@
+/**
+ * ArkType schema for versioned encryption keys in transit.
+ *
+ * This is the **source of truth** for the `EncryptionKey` shape. The TypeScript
+ * type is derived from the schema via `typeof EncryptionKey.infer`, so runtime
+ * validation and static types are always in sync.
+ *
+ * Used by:
+ * - Session response (`encryptionKeys` field)
+ * - `workspace.encryption.unlock(keys)`
+ * - `UserKeyStore` cache deserialization (runtime validation)
+ *
+ * @module
+ */
+import { type } from 'arktype';
+
+/**
+ * A single versioned encryption key for transport.
+ *
+ * Pairs a key version (from the server's `ENCRYPTION_SECRETS`) with the
+ * HKDF-derived per-user key encoded as base64 for JSON transport.
+ */
+export const EncryptionKey = type({
+	version: 'number.integer > 0',
+	userKeyBase64: 'string',
+});
+
+/**
+ * Non-empty array of versioned encryption keys.
+ *
+ * Guarantees at least one key is present. The highest-version entry is the
+ * current key for new encryptions; older entries exist for decrypting blobs
+ * encrypted with previous key versions.
+ */
+export const EncryptionKeys = type([
+	EncryptionKey,
+	'...',
+	EncryptionKey.array(),
+]);
+
+/** A single versioned encryption key for transport. */
+export type EncryptionKey = typeof EncryptionKey.infer;
+
+/** Non-empty array of versioned encryption keys. */
+export type EncryptionKeys = typeof EncryptionKeys.infer;

--- a/packages/workspace/src/workspace/types.ts
+++ b/packages/workspace/src/workspace/types.ts
@@ -1068,16 +1068,7 @@ export type EncryptionConfig = {
  * await workspace.clearLocalData();
  * ```
  */
-/**
- * A single versioned encryption key for transport.
- *
- * Pairs a key version (from the server's `ENCRYPTION_SECRETS`) with the
- * HKDF-derived per-user key encoded as base64 for JSON transport.
- */
-export type EncryptionKey = {
-	version: number;
-	userKeyBase64: string;
-};
+export type { EncryptionKey, EncryptionKeys } from './encryption-key';
 
 export type WorkspaceEncryption = {
 	/** Whether the runtime is currently unlocked. */
@@ -1090,7 +1081,7 @@ export type WorkspaceEncryption = {
 	 * builds a keyring Map, and activates encrypted stores. Persists
 	 * the keys if a cache is configured.
 	 */
-	unlock(keys: EncryptionKey[]): Promise<void>;
+	unlock(keys: EncryptionKeys): Promise<void>;
 	/**
 	 * Lock the runtime.
 	 *

--- a/packages/workspace/src/workspace/user-key-store.ts
+++ b/packages/workspace/src/workspace/user-key-store.ts
@@ -1,9 +1,9 @@
 /**
  * Platform-agnostic interface for persisting encryption keys across sessions.
  *
- * Stores the encryption keys as a JSON string—`JSON.stringify(EncryptionKey[])`
- * where each entry is `{ version: number, userKeyBase64: string }`. The store
- * interface deals only in opaque strings; callers handle serialization.
+ * Stores typed `EncryptionKeys` directly—implementations handle serialization
+ * internally (JSON for IndexedDB/WXT, could be binary for Stronghold). Callers
+ * pass and receive validated `EncryptionKeys` values, never raw strings.
  *
  * Passing a `UserKeyStore` to `.withEncryption({ userKeyStore })` implies
  * auto-boot: the workspace loads the cached keys on startup and unlocks
@@ -12,7 +12,7 @@
  * | Platform         | Implementation                                            |
  * |------------------|-----------------------------------------------------------|
  * | Tauri desktop    | `tauri-plugin-stronghold` — encrypted vault, memory zeroization |
- * | Browser          | `sessionStorage` — survives refresh, clears on tab close  |
+ * | Browser          | IndexedDB — survives refresh, clears on explicit delete   |
  * | Chrome extension | WXT storage (`session:` area over `chrome.storage.session`) — survives popup/sidebar reopens |
  * | Self-hosted      | No cache — user enters password each session              |
  *
@@ -22,14 +22,14 @@
  * Server (auth session)
  *   │  encryptionKeys: [{ version, userKeyBase64 }, ...]
  *   ▼
- * UserKeyStore.set(JSON.stringify(encryptionKeys))
- *   │  stored locally as opaque string
+ * UserKeyStore.set(encryptionKeys)
+ *   │  stored locally (serialization is implementation detail)
  *   ▼
  * App startup (before auth roundtrip completes)
- *   │  UserKeyStore.get() → JSON string | null
+ *   │  UserKeyStore.get() → EncryptionKeys | null
  *   │  consumed by auto-boot in whenReady
  *   ▼
- * auto-boot → JSON.parse → unlock(keys) → deriveWorkspaceKey per version
+ * auto-boot → unlock(keys) → deriveWorkspaceKey per version
  *   │  base64 decoding + HKDF happens inside unlock()
  * ```
  *
@@ -38,23 +38,27 @@
  * immediately on launch using the cached keys, then refreshes them silently when
  * the session loads.
  */
+import type { EncryptionKeys } from './encryption-key.js';
+
 export type UserKeyStore = {
 	/**
-	 * Persist the latest encryption keys as a JSON string.
+	 * Persist the latest encryption keys.
 	 *
 	 * Called after the workspace receives or refreshes valid keys from the
-	 * auth session. Implementations store one value and overwrite any
-	 * older cached entry.
+	 * auth session. Implementations serialize internally (e.g. JSON.stringify
+	 * for IndexedDB) and overwrite any older cached entry.
 	 */
-	set(keysJson: string): Promise<void>;
+	set(keys: EncryptionKeys): Promise<void>;
 	/**
 	 * Retrieve the cached encryption keys during startup.
 	 *
 	 * Called automatically during `whenReady` when a `UserKeyStore` is provided
-	 * to `.withEncryption()`. Return `null` to skip auto-unlock and wait for
-	 * the server session to provide keys.
+	 * to `.withEncryption()`. Implementations deserialize and validate with the
+	 * ArkType `EncryptionKeys` schema, returning `null` on any failure (corrupt
+	 * data, schema mismatch, missing entry). Return `null` to skip auto-unlock
+	 * and wait for the server session to provide keys.
 	 */
-	get(): Promise<string | null>;
+	get(): Promise<EncryptionKeys | null>;
 	/**
 	 * Remove the cached key on sign-out or account switch.
 	 *

--- a/specs/20260402T170000-typed-user-key-store.md
+++ b/specs/20260402T170000-typed-user-key-store.md
@@ -1,0 +1,111 @@
+# Typed UserKeyStore
+
+**Date**: 2026-04-02
+**Status**: Draft
+**Author**: AI-assisted
+
+## Overview
+
+Change `UserKeyStore` from an opaque string interface (`set(json: string)` / `get(): string | null`) to a typed interface (`set(keys: EncryptionKeys)` / `get(): EncryptionKeys | null`). Serialization moves into the store implementations, and deserialization gets ArkType validation at the boundary.
+
+## Motivation
+
+### Current State
+
+```typescript
+// user-key-store.ts — interface
+export type UserKeyStore = {
+  set(keysJson: string): Promise<void>;
+  get(): Promise<string | null>;
+  delete(): Promise<void>;
+};
+
+// create-workspace.ts — caller must JSON.stringify
+await config.userKeyStore.set(JSON.stringify(keys));
+
+// create-workspace.ts — caller must JSON.parse + cast
+const keys = JSON.parse(cached) as EncryptionKey[];
+await unlock(keys);
+```
+
+This creates problems:
+
+1. **Shape errors surface at JSON.parse, not at the boundary.** A corrupt or schema-mismatched string crashes `JSON.parse` or silently produces wrong data. The ArkType `EncryptionKeys` schema exists but is only used in `create-workspace.ts`—the store interface doesn't enforce it.
+2. **Every caller handles serialization.** `create-workspace.ts` does `JSON.stringify` on set and `JSON.parse` + ArkType validation on get. If a second caller ever uses `UserKeyStore`, it would need to duplicate this logic.
+3. **The type signature lies.** `set(keysJson: string)` looks like it accepts any string. The actual contract is "must be `JSON.stringify(EncryptionKeys)`"—invisible to TypeScript.
+
+### Desired State
+
+```typescript
+// user-key-store.ts — typed interface
+import type { EncryptionKeys } from './encryption-key.js';
+
+export type UserKeyStore = {
+  set(keys: EncryptionKeys): Promise<void>;
+  get(): Promise<EncryptionKeys | null>;
+  delete(): Promise<void>;
+};
+
+// create-workspace.ts — no serialization at call site
+await config.userKeyStore.set(keys);
+
+// auto-boot — store returns validated data
+const keys = await store.get();
+if (!keys) return;
+await unlock(keys);
+```
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Where serialization lives | Inside each store implementation | Store owns its persistence format (JSON for IndexedDB/WXT, could be binary for Stronghold) |
+| Validation on `get()` | ArkType `EncryptionKeys` schema | Catches corrupt data at the boundary, not at `unlock()` |
+| Return type on validation failure | `null` (same as "no cached key") | Consumer already handles null. Logging the error inside the store is sufficient. |
+| `set()` parameter type | `EncryptionKeys` (non-empty tuple) | Matches `unlock()` parameter. Prevents storing an empty array. |
+
+## Implementation Plan
+
+### Phase 1: Change the interface + workspace caller
+
+- [ ] **1.1** Update `UserKeyStore` type in `user-key-store.ts`: `set(keys: EncryptionKeys)`, `get(): Promise<EncryptionKeys | null>`
+- [ ] **1.2** Update `create-workspace.ts`: remove `JSON.stringify()` in `persistKeys`, remove `JSON.parse()` + ArkType validation in auto-boot
+- [ ] **1.3** Update `create-workspace.test.ts`: `setupWithUserKeyStore` mock now stores/returns `EncryptionKeys | null` instead of `string | null`. Update `toKeysJson` → inline `toEncryptionKeys` in assertions.
+
+### Phase 2: Update store implementations
+
+- [ ] **2.1** `indexed-db-key-store.ts` (svelte-utils): `set()` calls `JSON.stringify`, `get()` calls `JSON.parse` + `EncryptionKeys(parsed)` validation, returns `null` on failure
+- [ ] **2.2** `key-store.ts` (tab-manager WXT storage): same pattern—serialize on set, validate on get
+- [ ] **2.3** Run `bun test` on affected packages, `bun typecheck`
+
+## Edge Cases
+
+### Corrupt data in existing IndexedDB stores
+
+1. User upgrades to new code with old JSON string in IndexedDB
+2. `get()` reads string, `JSON.parse` succeeds, ArkType validation succeeds (schema is unchanged)
+3. Works transparently—no migration needed
+
+### Corrupt data from manual tampering
+
+1. User edits IndexedDB value directly
+2. `get()` reads string, `JSON.parse` or ArkType validation fails
+3. Store returns `null`, auto-boot skips, workspace waits for server session
+
+## Success Criteria
+
+- [ ] `UserKeyStore.set()` accepts `EncryptionKeys`, not `string`
+- [ ] `UserKeyStore.get()` returns `EncryptionKeys | null`, not `string | null`
+- [ ] No `JSON.stringify` or `JSON.parse` in `create-workspace.ts` for key store operations
+- [ ] ArkType validation happens inside `get()` implementations
+- [ ] All tests pass, typecheck clean
+- [ ] Existing IndexedDB data works without migration
+
+## References
+
+- `packages/workspace/src/workspace/user-key-store.ts` — Interface definition
+- `packages/workspace/src/workspace/encryption-key.ts` — `EncryptionKeys` ArkType schema
+- `packages/workspace/src/workspace/create-workspace.ts` — Primary caller (persistKeys, auto-boot)
+- `packages/workspace/src/workspace/create-workspace.test.ts` — Mock UserKeyStore + assertions
+- `packages/svelte-utils/src/indexed-db-key-store.ts` — IndexedDB implementation
+- `apps/tab-manager/src/lib/state/key-store.ts` — WXT storage implementation


### PR DESCRIPTION
The `EncryptionKey` type from the previous PR was a plain TypeScript type—good enough for static checking, but the `UserKeyStore` cache deserializes keys from IndexedDB/localStorage where anything could come back. A corrupted or stale cache entry would silently produce garbage keys that fail at decrypt time with an opaque crypto error.

This makes the arktype schema the single source of truth for what an encryption key looks like:

```typescript
import { type } from 'arktype';

export const EncryptionKey = type({
  version: 'number.integer > 0',
  userKeyBase64: 'string',
});

export const EncryptionKeys = type([EncryptionKey, '...', EncryptionKey.array()]);

// TypeScript type is derived from the schema
export type EncryptionKey = typeof EncryptionKey.infer;
```

Runtime and static types are now the same definition. Any code deserializing keys from a cache or network response validates against this schema before using them—if IndexedDB returns a stale shape, you get a clear validation error instead of a silent crypto failure downstream.

The `UserKeyStore` interface was also tightened to speak `EncryptionKeys` instead of raw strings:

```typescript
// BEFORE: raw string storage, caller responsible for parsing
type UserKeyStore = {
  get(): Promise<string | null>;
  set(value: string): Promise<void>;
  delete(): Promise<void>;
};

// AFTER: typed keys, store handles serialization internally
type UserKeyStore = {
  get(): Promise<EncryptionKeys | null>;
  set(keys: EncryptionKeys): Promise<void>;
  delete(): Promise<void>;
};
```

This pushes serialization responsibility into the store implementations (IndexedDB, in-memory) where it belongs, instead of having the workspace core JSON.stringify/parse at every call site. The spec at `specs/20260402T170000-typed-user-key-store.md` documents the full design.

Test setup was also cleaned up—the encrypted KV tests now use a shared `setup()` factory instead of repeating Y.Doc + YArray + key generation in every test block.

> **Stack**: 3/5 — builds on #1585 (keyring API). Next: state machine simplification.