### PR TITLE
refactor(workspace): replace document tags with tableName/documentName

### DIFF
--- a/packages/filesystem/src/table.ts
+++ b/packages/filesystem/src/table.ts
@@ -17,7 +17,6 @@ export const filesTable = defineTable(
 ).withDocument('content', {
 	guid: 'id',
 	onUpdate: () => ({ updatedAt: Date.now() }),
-	tags: ['persistent'],
 });
 
 /** File metadata row derived from the files table definition */

--- a/packages/workspace/src/workspace/create-document.test.ts
+++ b/packages/workspace/src/workspace/create-document.test.ts
@@ -75,6 +75,47 @@ describe('createDocuments', () => {
 			expect(handle.ydoc.gc).toBe(false);
 		});
 
+		test('handle exposes tableName and documentName', async () => {
+			const { documents } = setup();
+			const handle = await documents.open('f1');
+			expect(handle.tableName).toBe('files');
+			expect(handle.documentName).toBe('content');
+		});
+
+		test('document extension factory receives tableName and documentName in context', async () => {
+			let receivedTableName: string | undefined;
+			let receivedDocumentName: string | undefined;
+			const { documents } = setup({
+				documentExtensions: [
+					{
+						key: 'test',
+						factory: (ctx) => {
+							receivedTableName = ctx.tableName;
+							receivedDocumentName = ctx.documentName;
+						},
+					},
+				],
+			});
+			await documents.open('f1');
+			expect(receivedTableName).toBe('files');
+			expect(receivedDocumentName).toBe('content');
+		});
+
+		test('document extension factory can return void to skip', async () => {
+			const { documents } = setup({
+				documentExtensions: [
+					{
+						key: 'skipped',
+						factory: () => {
+							return; // void — opt out
+						},
+					},
+				],
+			});
+			const handle = await documents.open('f1');
+			expect(handle.extensions.skipped).toBeUndefined();
+		});
+
 		test('is idempotent — same GUID returns same underlying Y.Doc', async () => {
 			const { documents } = setup();
 

--- a/packages/workspace/src/workspace/create-document.test.ts
+++ b/packages/workspace/src/workspace/create-document.test.ts
@@ -48,6 +48,8 @@ function setup(
 	const { ydoc, tables } = setupTables();
 	const documents = createDocuments({
 		id: 'test-workspace',
+		tableName: 'files',
+		documentName: 'content',
 		guidKey: 'id',
 		onUpdate: () => ({ updatedAt: Date.now() }),
 		tableHelper: tables.files,
@@ -168,6 +170,8 @@ describe('createDocuments', () => {
 
 			const documents = createDocuments({
 				id: 'test-custom-onUpdate',
+				tableName: 'files',
+				documentName: 'content',
 				guidKey: 'id',
 				onUpdate: () => ({
 					updatedAt: 999,
@@ -204,6 +208,8 @@ describe('createDocuments', () => {
 
 			const documents = createDocuments({
 				id: 'test-noop-onUpdate',
+				tableName: 'files',
+				documentName: 'content',
 				guidKey: 'id',
 				onUpdate: () => ({}),
 				tableHelper: tables.files,
@@ -662,6 +668,8 @@ describe('handle.asText / asRichText / asSheet', () => {
 		const tables = createTables(ydoc, { files: tableDef });
 		const documents = createDocuments({
 			id: 'test-timeline',
+			tableName: 'files',
+			documentName: 'content',
 			guidKey: 'id',
 			onUpdate: () => ({ updatedAt: Date.now() }),
 			tableHelper: tables.files,

--- a/packages/workspace/src/workspace/create-document.test.ts
+++ b/packages/workspace/src/workspace/create-document.test.ts
@@ -40,7 +40,7 @@ function setupTables() {
 function setup(
 	overrides?: Pick<
 		CreateDocumentsConfig<typeof fileSchema.infer>,
-		'documentExtensions' | 'documentTags'
+		'documentExtensions'
 	> & {
 		awarenessDefinitions?: AwarenessDefinitions;
 	},
@@ -327,7 +327,6 @@ describe('createDocuments', () => {
 							clearLocalData: () => {},
 							dispose: () => {},
 						}),
-						tags: [],
 					},
 				],
 			});
@@ -348,7 +347,6 @@ describe('createDocuments', () => {
 						factory: () => ({
 							dispose: () => {},
 						}),
-						tags: [],
 					},
 				],
 			});
@@ -369,7 +367,6 @@ describe('createDocuments', () => {
 						factory: () => ({
 							helper: () => 42,
 						}),
-						tags: [],
 					},
 				],
 			});
@@ -435,7 +432,6 @@ describe('createDocuments', () => {
 							order.push(1);
 							return { dispose: () => {} };
 						},
-						tags: [],
 					},
 					{
 						key: 'second',
@@ -443,7 +439,6 @@ describe('createDocuments', () => {
 							order.push(2);
 							return { dispose: () => {} };
 						},
-						tags: [],
 					},
 					{
 						key: 'third',
@@ -451,7 +446,6 @@ describe('createDocuments', () => {
 							order.push(3);
 							return { dispose: () => {} };
 						},
-						tags: [],
 					},
 				],
 			});
@@ -471,7 +465,6 @@ describe('createDocuments', () => {
 							whenReady: Promise.resolve(),
 							dispose: () => {},
 						}),
-						tags: [],
 					},
 					{
 						key: 'second',
@@ -479,7 +472,6 @@ describe('createDocuments', () => {
 							secondReceivedWhenReady = whenReady instanceof Promise;
 							return { dispose: () => {} };
 						},
-						tags: [],
 					},
 				],
 			});
@@ -499,7 +491,6 @@ describe('createDocuments', () => {
 							hooksCalled++;
 							return undefined; // void return
 						},
-						tags: [],
 					},
 					{
 						key: 'normal-hook',
@@ -507,7 +498,6 @@ describe('createDocuments', () => {
 							hooksCalled++;
 							return { dispose: () => {} };
 						},
-						tags: [],
 					},
 				],
 			});
@@ -521,94 +511,6 @@ describe('createDocuments', () => {
 
 			const handle = await documents.open('f1');
 			expect(handle.ydoc).toBeInstanceOf(Y.Doc);
-		});
-
-		test('tag matching: extension with no tags fires for all documents', async () => {
-			let called = false;
-			const { documents } = setup({
-				documentTags: ['persistent'],
-				documentExtensions: [
-					{
-						key: 'universal',
-						factory: () => {
-							called = true;
-							return { dispose: () => {} };
-						},
-						tags: [], // universal — no tags
-					},
-				],
-			});
-
-			await documents.open('f1');
-			expect(called).toBe(true);
-		});
-
-		test('tag matching: extension with matching tag fires', async () => {
-			let called = false;
-			const { documents } = setup({
-				documentTags: ['persistent', 'synced'],
-				documentExtensions: [
-					{
-						key: 'sync-ext',
-						factory: () => {
-							called = true;
-							return { dispose: () => {} };
-						},
-						tags: ['synced'],
-					},
-				],
-			});
-
-			await documents.open('f1');
-			expect(called).toBe(true);
-		});
-
-		test('tag matching: extension with non-matching tag does NOT fire', async () => {
-			let called = false;
-			const { documents } = setup({
-				documentTags: ['persistent'],
-				documentExtensions: [
-					{
-						key: 'ephemeral-ext',
-						factory: () => {
-							called = true;
-							return { dispose: () => {} };
-						},
-						tags: ['ephemeral'],
-					},
-				],
-			});
-
-			await documents.open('f1');
-			expect(called).toBe(false);
-		});
-
-		test('tag matching: doc with no tags only gets universal extensions', async () => {
-			const calls: string[] = [];
-			const { documents } = setup({
-				documentTags: [], // no tags on doc
-				documentExtensions: [
-					{
-						key: 'tagged',
-						factory: () => {
-							calls.push('tagged');
-							return { dispose: () => {} };
-						},
-						tags: ['persistent'],
-					},
-					{
-						key: 'universal',
-						factory: () => {
-							calls.push('universal');
-							return { dispose: () => {} };
-						},
-						tags: [],
-					},
-				],
-			});
-
-			await documents.open('f1');
-			expect(calls).toEqual(['universal']);
 		});
 	});
 
@@ -624,7 +526,6 @@ describe('createDocuments', () => {
 							someValue: 42,
 							dispose: () => {},
 						}),
-						tags: [],
 					},
 					{
 						key: 'second',
@@ -632,7 +533,6 @@ describe('createDocuments', () => {
 							capturedFirstExtension = context.extensions.first;
 							return { dispose: () => {} };
 						},
-						tags: [],
 					},
 				],
 			});
@@ -642,64 +542,6 @@ describe('createDocuments', () => {
 			expect(
 				(capturedFirstExtension as Record<string, unknown>).someValue,
 			).toBe(42);
-		});
-
-		test('document extension extensions map is optional (tag filtering may skip)', async () => {
-			let taggedPresentForPersistentDoc = false;
-			let taggedPresentForEphemeralDoc = true;
-
-			const persistentSetup = setup({
-				documentTags: ['persistent'],
-				documentExtensions: [
-					{
-						key: 'tagged',
-						factory: () => ({
-							label: 'tagged',
-							dispose: () => {},
-						}),
-						tags: ['persistent'],
-					},
-					{
-						key: 'universal',
-						factory: (context) => {
-							taggedPresentForPersistentDoc =
-								context.extensions.tagged !== undefined;
-							return { dispose: () => {} };
-						},
-						tags: [],
-					},
-				],
-			});
-
-			await persistentSetup.documents.open('f1');
-
-			const ephemeralSetup = setup({
-				documentTags: ['ephemeral'],
-				documentExtensions: [
-					{
-						key: 'tagged',
-						factory: () => ({
-							label: 'tagged',
-							dispose: () => {},
-						}),
-						tags: ['persistent'],
-					},
-					{
-						key: 'universal',
-						factory: (context) => {
-							taggedPresentForEphemeralDoc =
-								context.extensions.tagged !== undefined;
-							return { dispose: () => {} };
-						},
-						tags: [],
-					},
-				],
-			});
-
-			await ephemeralSetup.documents.open('f1');
-
-			expect(taggedPresentForPersistentDoc).toBe(true);
-			expect(taggedPresentForEphemeralDoc).toBe(false);
 		});
 
 		test('document extension with no exports is still accessible', async () => {
@@ -712,7 +554,6 @@ describe('createDocuments', () => {
 						factory: () => ({
 							dispose: () => {},
 						}),
-						tags: [],
 					},
 					{
 						key: 'second',
@@ -720,7 +561,6 @@ describe('createDocuments', () => {
 							firstExtensionSeen = context.extensions.first !== undefined;
 							return { dispose: () => {} };
 						},
-						tags: [],
 					},
 				],
 			});
@@ -738,7 +578,6 @@ describe('createDocuments', () => {
 							helper: () => 42,
 							dispose: () => {},
 						}),
-						tags: [],
 					},
 				],
 			});

--- a/packages/workspace/src/workspace/create-document.ts
+++ b/packages/workspace/src/workspace/create-document.ts
@@ -115,6 +115,10 @@ export type CreateDocumentsConfig<
 	 * collisions or silent failures in extensions.
 	 */
 	id: string;
+	/** The table this document belongs to (e.g., 'files', 'notes'). */
+	tableName: string;
+	/** The document name from `.withDocument()` (e.g., 'content', 'body'). */
+	documentName: string;
 	/** Column name storing the Y.Doc GUID. */
 	guidKey: keyof TRow & string;
 	/** Called when the content Y.Doc changes. Return the fields to write to the row. */
@@ -154,6 +158,8 @@ export function createDocuments<
 ): Documents<TRow, TDocExtensions, TAwarenessDefinitions> {
 	const {
 		id,
+		tableName,
+		documentName,
 		guidKey,
 		onUpdate,
 		tableHelper,
@@ -218,6 +224,8 @@ export function createDocuments<
 				for (const { key, factory } of documentExtensions) {
 					const ctx = {
 						id,
+						tableName,
+						documentName,
 						ydoc: contentYdoc,
 						timeline,
 						awareness: { raw: contentAwareness },
@@ -274,6 +282,8 @@ export function createDocuments<
 					: Promise.all(whenReadyPromises).then(() => {});
 			const handle = Object.assign(timeline, {
 				id,
+				tableName,
+				documentName,
 				timeline,
 				awareness,
 				extensions: resolvedExtensions,

--- a/packages/workspace/src/workspace/create-document.ts
+++ b/packages/workspace/src/workspace/create-document.ts
@@ -125,15 +125,9 @@ export type CreateDocumentsConfig<
 	ydoc: Y.Doc;
 	/**
 	 * Document extension registrations (from `withDocumentExtension()` calls).
-	 * Each registration has a key, factory, and optional tags for filtering.
-	 * At open time, registrations are filtered by tag matching before firing.
+	 * Each registration has a key and factory.
 	 */
 	documentExtensions?: DocumentExtensionRegistration[];
-	/**
-	 * Tags declared on this documents instance (from `withDocument(..., { tags })`).
-	 * Used for tag matching against document extension registrations.
-	 */
-	documentTags?: readonly string[];
 	/** Optional typed awareness schemas for this document scope. */
 	awarenessDefinitions?: TAwarenessDefinitions;
 };
@@ -165,7 +159,6 @@ export function createDocuments<
 		tableHelper,
 		ydoc: workspaceYdoc,
 		documentExtensions = [],
-		documentTags = [],
 		awarenessDefinitions,
 	} = config;
 
@@ -211,14 +204,6 @@ export function createDocuments<
 			);
 			const timeline = createTimeline(contentYdoc);
 
-			// Filter document extensions by tag matching:
-			// - No tags on extension → fire for all documents (universal)
-			// - Has tags → fire only if document tags and extension tags share ANY value
-			const applicableExtensions = documentExtensions.filter((reg) => {
-				if (reg.tags.length === 0) return true;
-				return reg.tags.some((tag) => documentTags.includes(tag));
-			});
-
 			// Call document extension factories synchronously.
 			// IMPORTANT: No await between openDocuments.get() and openDocuments.set() — ensures
 			// concurrent open() calls for the same guid are safe.
@@ -230,7 +215,7 @@ export function createDocuments<
 			const whenReadyPromises: Promise<unknown>[] = [];
 
 			try {
-				for (const { key, factory } of applicableExtensions) {
+				for (const { key, factory } of documentExtensions) {
 					const ctx = {
 						id,
 						ydoc: contentYdoc,

--- a/packages/workspace/src/workspace/create-document.ts
+++ b/packages/workspace/src/workspace/create-document.ts
@@ -28,6 +28,8 @@
  *
  * const contentDocuments = createDocuments({
  *   id: 'my-workspace',
+ *   tableName: 'files',
+ *   documentName: 'content',
  *   guidKey: 'id',
  *   onUpdate: () => ({ updatedAt: Date.now() }),
  *   tableHelper: tables.files,
@@ -35,7 +37,9 @@
  * });
  *
  * const handle = await contentDocuments.open(someRow);
- * const text = handle.read();
+ * handle.tableName;    // 'files'
+ * handle.documentName; // 'content'
+ * handle.read();       // read content
  * handle.write('new content');
  * ```
  *

--- a/packages/workspace/src/workspace/create-workspace.test.ts
+++ b/packages/workspace/src/workspace/create-workspace.test.ts
@@ -767,6 +767,8 @@ describe('createWorkspace', () => {
 
 			const documents = createDocuments({
 				id: 'test-lifo',
+				tableName: 'files',
+				documentName: 'content',
 				guidKey: 'id',
 				onUpdate: () => ({ updatedAt: Date.now() }),
 				tableHelper: tables.files,
@@ -836,6 +838,8 @@ describe('createWorkspace', () => {
 
 			const documents = createDocuments({
 				id: 'test-whenready-rejection',
+				tableName: 'files',
+				documentName: 'content',
 				guidKey: 'id',
 				onUpdate: () => ({ updatedAt: Date.now() }),
 				tableHelper: tables.files,

--- a/packages/workspace/src/workspace/create-workspace.test.ts
+++ b/packages/workspace/src/workspace/create-workspace.test.ts
@@ -11,13 +11,11 @@
  */
 
 import { describe, expect, test } from 'bun:test';
+import { randomBytes } from '@noble/ciphers/utils.js';
 import { type } from 'arktype';
 import * as Y from 'yjs';
-import {
-	bytesToBase64,
-	} from '../shared/crypto/index.js';
-import { randomBytes } from '@noble/ciphers/utils.js';
 import { defineMutation, defineQuery } from '../shared/actions.js';
+import { bytesToBase64 } from '../shared/crypto/index.js';
 import { createDocuments } from './create-document.js';
 import { createTables } from './create-tables.js';
 import { createWorkspace } from './create-workspace.js';
@@ -51,7 +49,6 @@ function setup() {
 	const client = createWorkspace(definition);
 	return { client };
 }
-
 
 describe('createWorkspace', () => {
 	describe('batch()', () => {
@@ -552,72 +549,6 @@ describe('createWorkspace', () => {
 			expect(hookCalled).toBe(true);
 		});
 
-		test('withDocumentExtension with tags only fires for matching documents', async () => {
-			const hookCalls: string[] = [];
-
-			const notesTable = defineTable(
-				type({
-					id: 'string',
-					name: 'string',
-					updatedAt: 'number',
-					thumbId: 'string',
-					thumbUpdatedAt: 'number',
-					_v: '1',
-				}),
-			)
-				.withDocument('content', {
-					guid: 'id',
-					onUpdate: () => ({ updatedAt: Date.now() }),
-					tags: ['persistent', 'synced'],
-				})
-				.withDocument('thumb', {
-					guid: 'thumbId',
-					onUpdate: () => ({ thumbUpdatedAt: Date.now() }),
-					tags: ['ephemeral'],
-				});
-
-			const client = createWorkspace({
-				id: 'doc-tag-test',
-				tables: { notes: notesTable },
-			})
-				.withDocumentExtension(
-					'persistent-only',
-					() => {
-						hookCalls.push('persistent-only');
-						return { dispose: () => {} };
-					},
-					{ tags: ['persistent'] },
-				)
-				.withDocumentExtension(
-					'ephemeral-only',
-					() => {
-						hookCalls.push('ephemeral-only');
-						return { dispose: () => {} };
-					},
-					{ tags: ['ephemeral'] },
-				)
-				.withDocumentExtension('universal', () => {
-					hookCalls.push('universal');
-					return { dispose: () => {} };
-				});
-
-			// Content doc has tags ['persistent', 'synced']
-			await client.documents.notes.content.open('f1');
-			// 'persistent-only' matches (shares 'persistent')
-			// 'ephemeral-only' does NOT match (no overlap)
-			// 'universal' matches (no tags = fires for all)
-			expect(hookCalls).toEqual(['persistent-only', 'universal']);
-
-			hookCalls.length = 0;
-
-			// Thumb doc has tag ['ephemeral']
-			await client.documents.notes.thumb.open('t1');
-			// 'persistent-only' does NOT match
-			// 'ephemeral-only' matches (shares 'ephemeral')
-			// 'universal' matches (no tags = fires for all)
-			expect(hookCalls).toEqual(['ephemeral-only', 'universal']);
-		});
-
 		test('withExtension registers for both workspace and document Y.Docs', async () => {
 			let factoryCallCount = 0;
 
@@ -634,7 +565,7 @@ describe('createWorkspace', () => {
 			});
 
 			// withExtension fires factory for workspace Y.Doc AND registers
-			// it as a document extension (tags: [] = universal)
+			// it as a document extension
 			const client = createWorkspace({
 				id: 'three-tier-both-test',
 				tables: { files: filesTable },
@@ -841,9 +772,9 @@ describe('createWorkspace', () => {
 				tableHelper: tables.files,
 				ydoc: mockYdoc,
 				documentExtensions: [
-					{ key: 'first', factory: factory('first'), tags: [] },
-					{ key: 'second', factory: factory('second'), tags: [] },
-					{ key: 'third', factory: factory('third'), tags: [] },
+					{ key: 'first', factory: factory('first') },
+					{ key: 'second', factory: factory('second') },
+					{ key: 'third', factory: factory('third') },
 				],
 			});
 
@@ -917,7 +848,6 @@ describe('createWorkspace', () => {
 								cleanupCalled.add('first');
 							},
 						}),
-						tags: [],
 					},
 					{
 						key: 'second',
@@ -927,7 +857,6 @@ describe('createWorkspace', () => {
 								cleanupCalled.add('second');
 							},
 						}),
-						tags: [],
 					},
 				],
 			});
@@ -997,7 +926,9 @@ describe('applyEncryptionKeys', () => {
 		const keyV2 = randomBytes(32);
 
 		// Write with key v1
-		client.applyEncryptionKeys([{ version: 1, userKeyBase64: bytesToBase64(keyV1) }]);
+		client.applyEncryptionKeys([
+			{ version: 1, userKeyBase64: bytesToBase64(keyV1) },
+		]);
 		client.tables.posts.set({ id: '1', title: 'Written with v1', _v: 1 });
 
 		// Rotate to v2 (keyring includes both versions for backward compat)
@@ -1193,17 +1124,16 @@ describe('withActions (non-terminal)', () => {
 	test('actions work correctly — factory closes over live tables', () => {
 		const { definition } = actionsSetup();
 
-		const ws = createWorkspace(definition)
-			.withActions(({ tables }) => ({
-				getAll: defineQuery({
-					handler: () => tables.posts.getAllValid(),
-				}),
-				create: defineMutation({
-					handler: () => {
-						tables.posts.set({ id: '1', title: 'Hello', _v: 1 });
-					},
-				}),
-			}));
+		const ws = createWorkspace(definition).withActions(({ tables }) => ({
+			getAll: defineQuery({
+				handler: () => tables.posts.getAllValid(),
+			}),
+			create: defineMutation({
+				handler: () => {
+					tables.posts.set({ id: '1', title: 'Hello', _v: 1 });
+				},
+			}),
+		}));
 
 		// Mutation writes to tables
 		ws.actions.create();

--- a/packages/workspace/src/workspace/create-workspace.ts
+++ b/packages/workspace/src/workspace/create-workspace.ts
@@ -220,6 +220,8 @@ export function createWorkspace<
 
 			const documents = createDocuments({
 				id,
+				tableName,
+				documentName: docName,
 				guidKey: guid as keyof BaseRow & string,
 				onUpdate,
 				tableHelper,

--- a/packages/workspace/src/workspace/create-workspace.ts
+++ b/packages/workspace/src/workspace/create-workspace.ts
@@ -216,7 +216,7 @@ export function createWorkspace<
 		const tableDocumentsNamespace: Record<string, Documents<BaseRow>> = {};
 
 		for (const [docName, rawConfig] of Object.entries(tableDef.documents)) {
-			const { guid, onUpdate, tags, awareness } = rawConfig as DocumentConfig;
+			const { guid, onUpdate, awareness } = rawConfig as DocumentConfig;
 
 			const documents = createDocuments({
 				id,
@@ -225,7 +225,6 @@ export function createWorkspace<
 				tableHelper,
 				ydoc,
 				documentExtensions: documentExtensionRegistrations,
-				documentTags: tags ?? [],
 				awarenessDefinitions: awareness,
 			});
 
@@ -464,7 +463,6 @@ export function createWorkspace<
 				documentExtensionRegistrations.push({
 					key,
 					factory,
-					tags: [],
 				});
 				return applyWorkspaceExtension(key, factory);
 			},
@@ -500,12 +498,10 @@ export function createWorkspace<
 							clearLocalData?: () => MaybePromise<void>;
 					  })
 					| void,
-				options?: { tags?: string[] },
 			) {
 				documentExtensionRegistrations.push({
 					key,
 					factory,
-					tags: options?.tags ?? [],
 				});
 				return buildClient({ extensions, state, actions });
 			},

--- a/packages/workspace/src/workspace/define-table.test.ts
+++ b/packages/workspace/src/workspace/define-table.test.ts
@@ -246,8 +246,6 @@ describe('defineTable', () => {
 	});
 
 	describe('withDocument', () => {
-		const noopUpdate = () => ({});
-
 		test('shorthand path adds documents to definition', () => {
 			const files = defineTable(
 				type({ id: 'string', name: 'string', updatedAt: 'number', _v: '1' }),
@@ -258,7 +256,6 @@ describe('defineTable', () => {
 
 			expect(files.documents.content.guid).toBe('id');
 			expect(typeof files.documents.content.onUpdate).toBe('function');
-			expect(files.documents.content.tags).toEqual([]);
 		});
 
 		test('builder path adds documents to definition', () => {
@@ -276,7 +273,6 @@ describe('defineTable', () => {
 
 			expect(notes.documents.content.guid).toBe('docId');
 			expect(typeof notes.documents.content.onUpdate).toBe('function');
-			expect(notes.documents.content.tags).toEqual([]);
 		});
 
 		test('multiple withDocument chains accumulate documents', () => {
@@ -310,45 +306,6 @@ describe('defineTable', () => {
 			);
 
 			expect(Object.keys(tags.documents)).toHaveLength(0);
-		});
-
-		test('withDocument accepts a single-element tag array', () => {
-			const files = defineTable(
-				type({ id: 'string', name: 'string', updatedAt: 'number', _v: '1' }),
-			).withDocument('content', {
-				guid: 'id',
-				onUpdate: () => ({ updatedAt: Date.now() }),
-				tags: ['persistent'],
-			});
-
-			expect(files.documents.content.guid).toBe('id');
-			expect(typeof files.documents.content.onUpdate).toBe('function');
-			expect(files.documents.content.tags).toEqual(['persistent']);
-		});
-
-		test('withDocument accepts an array of tags', () => {
-			const files = defineTable(
-				type({ id: 'string', name: 'string', updatedAt: 'number', _v: '1' }),
-			).withDocument('content', {
-				guid: 'id',
-				onUpdate: () => ({ updatedAt: Date.now() }),
-				tags: ['persistent', 'synced'] as const,
-			});
-
-			expect(files.documents.content.guid).toBe('id');
-			expect(typeof files.documents.content.onUpdate).toBe('function');
-			expect(files.documents.content.tags).toEqual(['persistent', 'synced']);
-		});
-
-		test('withDocument without tags defaults to empty array', () => {
-			const files = defineTable(
-				type({ id: 'string', name: 'string', updatedAt: 'number', _v: '1' }),
-			).withDocument('content', {
-				guid: 'id',
-				onUpdate: noopUpdate,
-			});
-
-			expect(files.documents.content.tags).toEqual([]);
 		});
 
 		test('withDocument preserves schema validation and migrate behavior', () => {

--- a/packages/workspace/src/workspace/define-table.ts
+++ b/packages/workspace/src/workspace/define-table.ts
@@ -82,7 +82,7 @@ type TableDefinitionWithDocBuilder<
 	 * a GUID column already bound to a prior document (prevents storage collisions).
 	 *
 	 * @param name - The document name (becomes `client.documents.{tableName}[name]`)
-	 * @param config - `guid` (string column), `onUpdate` (callback returning partial row), and optional `tags`
+	 * @param config - `guid` (string column) and `onUpdate` (callback returning partial row)
 	 *
 	 * @example
 	 * ```typescript
@@ -123,7 +123,6 @@ type TableDefinitionWithDocBuilder<
 				Omit<StandardSchemaV1.InferOutput<LastSchema<TVersions>>, 'id'>
 			>;
 			awareness?: TAwarenessDefs;
-			tags?: readonly string[];
 		},
 	): TableDefinitionWithDocBuilder<
 		TVersions,
@@ -257,12 +256,11 @@ function attachDocumentBuilder<
 				...def,
 				documents: {
 					...def.documents,
-					[name]: {
-						guid: config.guid,
-						onUpdate: config.onUpdate,
-						awareness: config.awareness,
-						tags: config.tags ?? [],
-					},
+				[name]: {
+					guid: config.guid,
+					onUpdate: config.onUpdate,
+					awareness: config.awareness,
+				},
 				},
 			});
 		},

--- a/packages/workspace/src/workspace/types.ts
+++ b/packages/workspace/src/workspace/types.ts
@@ -231,6 +231,10 @@ export type DocumentClient<
 > = Timeline & {
 	/** The workspace identifier. */
 	id: string;
+	/** The table this document belongs to (e.g., 'files', 'notes'). */
+	tableName: string;
+	/** The document name declared via `.withDocument()` (e.g., 'content', 'body'). */
+	documentName: string;
 	/**
 	 * Self-reference for destructuring convenience.
 	 *
@@ -241,8 +245,8 @@ export type DocumentClient<
 	/**
 	 * Accumulated document extension exports with lifecycle hooks.
 	 *
-	 * Each entry is optional because tag-filtered extensions may be skipped
-	 * for certain document types. Guard access with optional chaining.
+	 * Each entry is optional because extension factories may return `void`
+	 * to skip specific documents. Guard access with optional chaining.
 	 */
 	extensions: {
 		[K in keyof TDocExtensions]?: Extension<
@@ -266,12 +270,11 @@ export type DocumentClient<
  *
  * ```typescript
  * .withDocumentExtension('persistence', ({ ydoc }) => { ... })
- * .withDocumentExtension('sync', ({ id, ydoc, timeline, whenReady }) => { ... })
+ * .withDocumentExtension('sync', ({ id, tableName, documentName, ydoc }) => { ... })
  * ```
  *
- * Uses `Pick` instead of `Omit<DocumentClient, 'dispose'>` because `DocumentClient`
- * extends `Timeline` (the handle IS a timeline), but factory contexts have `timeline`
- * as a field (factories destructure `{ timeline }`, not `{ read, write }`).
+ * Factories inspect `tableName` and `documentName` to decide whether to activate.
+ * Return `void` to skip a specific document.
  *
  * @typeParam TDocExtensions - Accumulated document extension exports from prior calls.
  *   Defaults to `Record<string, unknown>` so `DocumentExtensionRegistration` can
@@ -281,7 +284,13 @@ export type DocumentContext<
 	TDocExtensions extends Record<string, unknown> = Record<string, unknown>,
 > = Pick<
 	DocumentClient<TDocExtensions>,
-	'id' | 'ydoc' | 'timeline' | 'extensions' | 'whenReady'
+	| 'id'
+	| 'tableName'
+	| 'documentName'
+	| 'ydoc'
+	| 'timeline'
+	| 'extensions'
+	| 'whenReady'
 > & {
 	/**
 	 * Raw awareness instance for this document scope.
@@ -386,6 +395,27 @@ export type HasDocuments<T> = T extends { documents: infer TDocuments }
 		? false
 		: true
 	: false;
+
+/**
+ * Extract all document names across all tables.
+ *
+ * Collects all document names (from `.withDocument()` calls) into a union
+ * for type-safe autocomplete in `withDocumentExtension()` factory context.
+ *
+ * @example
+ * ```typescript
+ * // Given tables with .withDocument('content') and .withDocument('body'):
+ * type Names = AllDocumentNames<typeof tables>;
+ * // => 'content' | 'body'
+ * ```
+ */
+export type AllDocumentNames<TTableDefs extends TableDefinitions> = {
+	[K in keyof TTableDefs]: TTableDefs[K] extends {
+		documents: infer TDocuments;
+	}
+		? keyof TDocuments & string
+		: never;
+}[keyof TTableDefs];
 
 /**
  * Extract the document map for a single table definition.
@@ -1129,7 +1159,10 @@ export type WorkspaceClientBuilder<
 		TDocExports extends Record<string, unknown>,
 	>(
 		key: K,
-		factory: (context: DocumentContext<TDocExtensions>) =>
+		factory: (context: DocumentContext<TDocExtensions> & {
+			tableName: keyof TTableDefinitions & string;
+			documentName: AllDocumentNames<TTableDefinitions>;
+		}) =>
 			| (TDocExports & {
 					whenReady?: Promise<unknown>;
 					dispose?: () => MaybePromise<void>;

--- a/packages/workspace/src/workspace/types.ts
+++ b/packages/workspace/src/workspace/types.ts
@@ -178,7 +178,7 @@ export type DocumentConfig<
  * Factories receive `DocumentContext` with `tableName` and `documentName`
  * and can return `void` to opt out for specific documents.
  */
-	export type DocumentExtensionRegistration = {
+export type DocumentExtensionRegistration = {
 	key: string;
 	factory: (context: DocumentContext) =>
 		| (Record<string, unknown> & {
@@ -1048,7 +1048,7 @@ export type WorkspaceClientBuilder<
 	 * for persistence, sync, broadcast, or any extension that should apply everywhere.
 	 *
 	 * For workspace-only extensions, use {@link withWorkspaceExtension}.
-	 * For document-only extensions (with optional tag filtering), use {@link withDocumentExtension}.
+	 * For document-only extensions, use {@link withDocumentExtension}.
 	 *
 	 * @param key - Unique name for this extension (used as the key in `.extensions`)
 	 * @param factory - Factory receiving the client-so-far context, returns flat exports

--- a/packages/workspace/src/workspace/types.ts
+++ b/packages/workspace/src/workspace/types.ts
@@ -152,7 +152,6 @@ export type InferTableRow<T> = T extends {
  * - `guid`: The column storing the Y.Doc GUID (must be a string column)
  * - `onUpdate`: Zero-argument callback returning `Partial<Omit<TRow, 'id'>>` — the fields
  *   to write when the doc changes. Callers control both the value and which columns to update.
- * - `tags`: Optional string tags for document extension targeting
  *
  * @typeParam TGuid - Literal string type of the guid column name
  * @typeParam TRow - The row type of the table (used to type-check `onUpdate` return)
@@ -167,27 +166,19 @@ export type DocumentConfig<
 	onUpdate: () => Partial<Omit<TRow, 'id'>>;
 	/** Optional awareness schemas for this document scope. */
 	awareness?: TAwarenessDefs;
-	/**
-	 * String tags for document extension targeting.
-	 *
-	 * Extensions registered via `withDocumentExtension({ tags })` only fire
-	 * for documents whose tags overlap. Extensions with no tags are universal.
-	 *
-	 * Defaults to `[]` when no tags are declared.
-	 */
-	tags: readonly string[];
 };
 
 /**
  * Internal registration for a document extension.
  *
  * Stored in an array by `withDocumentExtension()`. Each entry contains
- * the extension key, factory function, and optional tag filter.
+ * the extension key and factory function.
  *
- * At document open time, the runtime iterates registrations and fires
- * factories whose tags match (set intersection) or have no tags (universal).
+ * At document open time, the runtime calls every registered factory.
+ * Factories receive `DocumentContext` with `tableName` and `documentName`
+ * and can return `void` to opt out for specific documents.
  */
-export type DocumentExtensionRegistration = {
+	export type DocumentExtensionRegistration = {
 	key: string;
 	factory: (context: DocumentContext) =>
 		| (Record<string, unknown> & {
@@ -196,7 +187,6 @@ export type DocumentExtensionRegistration = {
 				clearLocalData?: () => MaybePromise<void>;
 		  })
 		| void;
-	tags: readonly string[];
 };
 
 /**
@@ -1116,20 +1106,22 @@ export type WorkspaceClientBuilder<
 	 * Register a document extension that fires when content Y.Docs are opened.
 	 *
 	 * Document extensions operate on content Y.Docs (not the workspace Y.Doc).
-	 * Use optional `{ tags }` to target specific document types declared via
-	 * `withDocument(..., { tags })`.
+	 * Every registered factory fires for every document opened via `documents.open()`.
 	 *
-	 * If no `tags` option is provided, the extension is universal (fires for all content documents).
+	 * To skip specific documents, inspect `ctx.tableName` or `ctx.documentName`
+	 * in your factory and return `void` (the factory's return type allows this).
 	 *
 	 * @param key - Unique name for this document extension
-	 * @param factory - Factory receiving DocumentContext, returns Extension or void
-	 * @param options - Optional tag filter for targeting specific document types
+	 * @param factory - Factory receiving DocumentContext, returns Extension or void to skip
 	 *
 	 * @example
 	 * ```typescript
-	 * createWorkspace({ id: 'app', tables: { notes } })
-	 *   .withExtension('persistence', workspacePersistence)
-	 *   .withDocumentExtension('persistence', indexeddbPersistence, { tags: ['persistent'] });
+	 * createWorkspace({ id: 'app', tables: { files, notes } })
+	 *   .withExtension('persistence', indexeddbPersistence)
+	 *   .withDocumentExtension('sync', (ctx) => {
+	 *     if (ctx.documentName === 'thumbnail') return; // skip ephemeral docs
+	 *     return ySweetSync(ctx);
+	 *   });
 	 * ```
 	 */
 	withDocumentExtension<
@@ -1144,7 +1136,6 @@ export type WorkspaceClientBuilder<
 					clearLocalData?: () => MaybePromise<void>;
 			  })
 			| void,
-		options?: { tags?: string[] },
 	): WorkspaceClientBuilder<
 		TId,
 		TTableDefinitions,


### PR DESCRIPTION
Document extensions needed a way to know which document they were operating on—to skip persistence for ephemeral thumbnails, or apply different sync strategies per table. Tags were the original mechanism: you'd declare `tags: ['persistent']` on a document config, then pass `{ tags: ['persistent'] }` to `withDocumentExtension()`, and the runtime would match them via set intersection. But tags are an indirection layer that obscures what extensions actually care about: which table and which document name.

Every real use of tags mapped 1:1 to a specific table/document pair anyway. An extension tagged `['persistent']` really meant "fire for `files.content` but not `files.thumbnail`." The tag was a proxy for information the runtime already had—it just wasn't passing it through.

Now the runtime threads `tableName` and `documentName` directly into `DocumentContext`, and extension factories inspect them to decide whether to activate:

```typescript
// Before — indirect tag matching
.withDocument('content', { guid: 'id', onUpdate, tags: ['persistent'] })
.withDocumentExtension('sync', ySweetSync, { tags: ['persistent'] })

// After — explicit document inspection
.withDocument('content', { guid: 'id', onUpdate })
.withDocumentExtension('sync', (ctx) => {
  if (ctx.documentName === 'thumbnail') return; // skip ephemeral docs
  return ySweetSync(ctx);
})
```

The factory return type already allowed `void`—this just makes that the intended opt-out mechanism instead of a dead code path. `DocumentContext` now includes `tableName` and `documentName` with full type narrowing from the workspace definition, so the factory parameter autocompletes to the actual table and document names declared in the schema.

```
Before:
  DocumentConfig { guid, onUpdate, tags: string[] }
  DocumentExtensionRegistration { key, factory, tags: string[] }
  Runtime: filter extensions by tag intersection → fire matches

After:
  DocumentConfig { guid, onUpdate }
  DocumentExtensionRegistration { key, factory }
  Runtime: fire all extensions → factory returns void to skip
```

`AllDocumentNames<TTableDefs>` is a new utility type that collects all document names across all tables into a union, so the `documentName` parameter on extension factories is typed as `'content' | 'body' | ...` rather than just `string`.

6 commits, 16 files changed. Entirely scoped to `packages/workspace/` and `packages/filesystem/`.