### PR TITLE
fix: silence encrypted KV decrypt warnings during pre-key startup

### DIFF
--- a/docs/articles/yjs-storage-efficiency/encrypted-kv-benchmark.ts
+++ b/docs/articles/yjs-storage-efficiency/encrypted-kv-benchmark.ts
@@ -92,7 +92,7 @@ for (let cycle = 0; cycle < 5; cycle++) {
 		gcKv.delete(`item_${i}`);
 	}
 	console.log(
-		`  Cycle ${cycle + 1}: ${fmt(size(gcDoc)).padStart(10)}  (${gcKv.decryptedSize} active)`,
+		`  Cycle ${cycle + 1}: ${fmt(size(gcDoc)).padStart(10)}  (${gcKv.readableEntryCount} active)`,
 	);
 }
 
@@ -114,7 +114,7 @@ for (let cycle = 0; cycle < 5; cycle++) {
 		noGcKv.delete(`item_${i}`);
 	}
 	console.log(
-		`  Cycle ${cycle + 1}: ${fmt(size(noGcDoc)).padStart(10)}  (${noGcKv.decryptedSize} active)`,
+		`  Cycle ${cycle + 1}: ${fmt(size(noGcDoc)).padStart(10)}  (${noGcKv.readableEntryCount} active)`,
 	);
 }
 

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.test.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.test.ts
@@ -9,14 +9,14 @@ import { randomBytes } from '@noble/ciphers/utils.js';
 import type { YKeyValueLwwEntry } from './y-keyvalue-lww';
 import {
 	createEncryptedYkvLww,
-	type YKeyValueLwwEncrypted,
+	type EncryptedYKeyValueLww,
 } from './y-keyvalue-lww-encrypted';
 
 /** Create a single-doc encrypted KV for tests. Skips the 4-line Y.Doc ceremony. */
 function setup<T = string>(keyring?: ReadonlyMap<number, Uint8Array>) {
 	const ydoc = new Y.Doc();
 	const yarray = ydoc.getArray<YKeyValueLwwEntry<EncryptedBlob | T>>('data');
-	const kv: YKeyValueLwwEncrypted<T> = createEncryptedYkvLww<T>(
+	const kv: EncryptedYKeyValueLww<T> = createEncryptedYkvLww<T>(
 		yarray,
 		keyring,
 	);
@@ -156,7 +156,7 @@ describe('createEncryptedYkvLww', () => {
 
 			expect(kv.get('x')).toBe('10');
 			expect(kv.get('y')).toBe('20');
-			expect(kv.decryptedSize).toBe(2);
+			expect(kv.readableEntryCount).toBe(2);
 		});
 	});
 
@@ -528,7 +528,7 @@ describe('createEncryptedYkvLww', () => {
 			expect(kv.get('corrupt')).toBeUndefined();
 			expect(kv.get('good-1')).toBe('value-1');
 			expect(kv.get('good-2')).toBe('value-2');
-			expect(kv.failedDecryptCount).toBe(1);
+			expect(kv.unreadableEntryCount).toBe(1);
 		});
 
 		test('observation continues after decrypt failure', () => {
@@ -554,7 +554,7 @@ describe('createEncryptedYkvLww', () => {
 			expect(kv.get('good')).toBe('still-works');
 			expect(kv.get('new-good')).toBe('appears-after-failure');
 			expect(kv.get('corrupt')).toBeUndefined();
-			expect(kv.failedDecryptCount).toBe(1);
+			expect(kv.unreadableEntryCount).toBe(1);
 		});
 	});
 
@@ -608,7 +608,7 @@ describe('createEncryptedYkvLww', () => {
 					[1, key1],
 				]),
 			);
-			expect(kv.failedDecryptCount).toBe(0);
+			expect(kv.unreadableEntryCount).toBe(0);
 			expect(kv.get('a')).toBe('alpha');
 			expect(kv.get('b')).toBe('beta');
 
@@ -631,7 +631,7 @@ describe('createEncryptedYkvLww', () => {
 					[2, key2],
 				]),
 			);
-			expect(kv.failedDecryptCount).toBe(0);
+			expect(kv.unreadableEntryCount).toBe(0);
 			expect(kv.get('a')).toBe('alpha');
 			expect(kv.get('b')).toBe('beta');
 
@@ -689,7 +689,7 @@ describe('createEncryptedYkvLww', () => {
 			// Values still readable
 			expect(kv.get('a')).toBe('alpha');
 			expect(kv.get('b')).toBe('beta');
-			expect(kv.failedDecryptCount).toBe(0);
+			expect(kv.unreadableEntryCount).toBe(0);
 
 			// Existing blobs stay at v1
 			for (const entry of yarray.toArray()) {

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
@@ -48,7 +48,7 @@
  *
  * The observer wraps decrypt with try/catch. A failed decrypt skips the entry
  * and logs a warning instead of throwing. This prevents one bad blob from
- * crashing all observation. `failedDecryptCount` exposes the count.
+ * crashing all observation. `unreadableEntryCount` exposes the count.
  *
  * ## Related Modules
  *
@@ -73,7 +73,7 @@ import {
 
 const textEncoder = new TextEncoder();
 /** Transaction origin for re-encryption writes. Observer skips events with this origin. */
-const RE_ENCRYPT = Symbol('re-encrypt');
+const REENCRYPT_ORIGIN = Symbol('re-encrypt');
 
 /**
  * Change handler for the encrypted KV wrapper.
@@ -82,7 +82,7 @@ const RE_ENCRYPT = Symbol('re-encrypt');
  * for synthetic events emitted during `activateEncryption()` (which have
  * no backing Yjs transaction).
  */
-export type EncryptedKvChangeHandler<T> = (
+export type EncryptedKvObserver<T> = (
 	changes: Map<string, YKeyValueLwwChange<T>>,
 	origin: unknown,
 ) => void;
@@ -95,18 +95,18 @@ type EncryptionState = {
 
 /**
  * Return type of `createEncryptedYkvLww`. Same API surface as `YKeyValueLww<T>`
- * plus encryption-specific members (`failedDecryptCount`, `activateEncryption`).
+ * plus encryption-specific members (`unreadableEntryCount`, `activateEncryption`).
  * All values exposed through this type are **plaintext**—encryption is fully
  * transparent to consumers.
  */
-export type YKeyValueLwwEncrypted<T> = {
+export type EncryptedYKeyValueLww<T> = {
 	set(key: string, val: T): void;
 	get(key: string): T | undefined;
 	has(key: string): boolean;
 	delete(key: string): void;
 	entries(): IterableIterator<[string, YKeyValueLwwEntry<T>]>;
-	observe(handler: EncryptedKvChangeHandler<T>): void;
-	unobserve(handler: EncryptedKvChangeHandler<T>): void;
+	observe(handler: EncryptedKvObserver<T>): void;
+	unobserve(handler: EncryptedKvObserver<T>): void;
 
 	/**
 	 * Activate encryption with a versioned keyring. The highest-version key
@@ -140,7 +140,7 @@ export type YKeyValueLwwEncrypted<T> = {
 	 *
 	 * Computed by iterating `inner.map` and counting undecryptable entries.
 	 */
-	readonly failedDecryptCount: number;
+	readonly unreadableEntryCount: number;
 
 	/**
 	 * Iterate all decryptable entries. Decrypts on the fly from the inner
@@ -149,10 +149,10 @@ export type YKeyValueLwwEncrypted<T> = {
 	 * TableHelper uses this for `getAll()`, `filter()`, `find()`, `clear()`.
 	 * Entries that cannot be decrypted are silently omitted.
 	 */
-	decryptedEntries(): IterableIterator<[string, YKeyValueLwwEntry<T>]>;
+	readableEntries(): IterableIterator<[string, YKeyValueLwwEntry<T>]>;
 
 	/** Count of decryptable entries. TableHelper uses this for `count()`. */
-	readonly decryptedSize: number;
+	readonly readableEntryCount: number;
 
 	/** The underlying Y.Array. Contains **ciphertext** when a key is active. */
 	readonly yarray: Y.Array<YKeyValueLwwEntry<EncryptedBlob | T>>;
@@ -184,14 +184,14 @@ export type YKeyValueLwwEncrypted<T> = {
 export function createEncryptedYkvLww<T>(
 	yarray: Y.Array<YKeyValueLwwEntry<EncryptedBlob | T>>,
 	initialKeyring?: ReadonlyMap<number, Uint8Array>,
-): YKeyValueLwwEncrypted<T> {
+): EncryptedYKeyValueLww<T> {
 	/**
 	 * The inner LWW store. It sees `EncryptedBlob | T` as its value type—it
 	 * doesn't know or care that some values are ciphertext. Timestamps, conflict
 	 * resolution, and observer mechanics all live here.
 	 */
 	const inner = new YKeyValueLww<EncryptedBlob | T>(yarray);
-	const changeHandlers = new Set<EncryptedKvChangeHandler<T>>();
+	const changeHandlers = new Set<EncryptedKvObserver<T>>();
 
 	/** Active encryption state. `undefined` = passthrough mode. */
 	let encryption: EncryptionState | undefined;
@@ -303,14 +303,14 @@ export function createEncryptedYkvLww<T>(
 
 	/**
 	 * Inner observer. When entries change in the CRDT, decrypt and forward
-	 * plaintext change events to registered handlers. Skips RE_ENCRYPT writes
+	 * plaintext change events to registered handlers. Skips REENCRYPT_ORIGIN writes
 	 * (those are internal re-encryption during activation, not user changes).
 	 */
 	const observer: Parameters<typeof inner.observe>[0] = (
 		changes,
 		transaction,
 	) => {
-		if (transaction.origin === RE_ENCRYPT) return;
+		if (transaction.origin === REENCRYPT_ORIGIN) return;
 		const decryptedChanges = new Map<string, YKeyValueLwwChange<T>>();
 		for (const [key, change] of changes) {
 			if (change.action === 'delete') {
@@ -421,7 +421,7 @@ export function createEncryptedYkvLww<T>(
 							nextEncryption.currentVersion,
 						),
 					);
-			}, RE_ENCRYPT);
+			}, REENCRYPT_ORIGIN);
 
 			if (newlyReadable.size === 0) return;
 			const syntheticChanges = new Map<string, YKeyValueLwwChange<T>>();
@@ -430,13 +430,13 @@ export function createEncryptedYkvLww<T>(
 			for (const handler of changeHandlers)
 				handler(syntheticChanges, undefined);
 		},
-		get failedDecryptCount() {
+		get unreadableEntryCount() {
 			return inner.map.size - countDecryptable();
 		},
-		*decryptedEntries() {
+		*readableEntries() {
 			yield* iterateDecrypted(inner.entries());
 		},
-		get decryptedSize() {
+		get readableEntryCount() {
 			return countDecryptable();
 		},
 		yarray: inner.yarray,

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
@@ -211,17 +211,20 @@ export function createEncryptedYkvLww<T>(
 	}
 
 	/**
-	 * Decrypt an encrypted blob with version-directed keyring fallback.
+	 * Best-effort blob decryption with keyring fallback.
 	 *
-	 * Tries currentKey first (fast path for latest-version blobs).
-	 * Falls back to version-directed lookup from the keyring when
-	 * currentKey fails (handles blobs encrypted with older key versions).
+	 * Tries currentKey first (most blobs use the latest version).
+	 * On failure, reads the blob's embedded key version and tries
+	 * the matching key from the keyring.
 	 *
-	 * @param state - Explicit encryption state to use. Defaults to the
-	 *   current closure state. Overridden during `activateEncryption()` to
-	 *   compare before/after readability.
+	 * Pure function—no logging, no side effects. Callers decide
+	 * what to do with `undefined` (warn, skip, etc.).
+	 *
+	 * @param state - Defaults to the closure's `encryption`. Overridden by
+	 *   `activateEncryption()` to compare before/after readability without
+	 *   mutating the closure mid-iteration.
 	 */
-	const decryptBlobWithFallback = (
+	const tryDecryptBlob = (
 		blob: EncryptedBlob,
 		aad: Uint8Array,
 		state: EncryptionState | undefined = encryption,
@@ -230,10 +233,10 @@ export function createEncryptedYkvLww<T>(
 		try {
 			return decryptValue(blob, state.currentKey, aad);
 		} catch {
-			/* fast path miss — try version-directed lookup */
+			// Current key didn't work — try the blob's recorded key version
 		}
 		const versionKey = state.keyring.get(getKeyVersion(blob));
-		if (!versionKey || versionKey === state.currentKey) return undefined;
+		if (!versionKey || versionKey === state.currentKey) return undefined; // Missing version, or same key we already tried
 		try {
 			return decryptValue(blob, versionKey, aad);
 		} catch {
@@ -250,13 +253,13 @@ export function createEncryptedYkvLww<T>(
 		key: string,
 		entry: YKeyValueLwwEntry<EncryptedBlob | T>,
 	): YKeyValueLwwEntry<T> | undefined => {
-		if (!isEncryptedBlob(entry.val)) return { ...entry, val: entry.val as T };
-		const json = decryptBlobWithFallback(
+		if (!isEncryptedBlob(entry.val)) return { ...entry, val: entry.val as T }; // Plaintext — nothing to decrypt
+		const json = tryDecryptBlob(
 			entry.val,
 			textEncoder.encode(key),
 		);
 		if (json !== undefined) return { ...entry, val: JSON.parse(json) as T };
-		if (!encryption) return undefined;
+		if (!encryption) return undefined; // No key loaded yet — skip silently, activateEncryption() will catch up
 
 		const blobVersion = getKeyVersion(entry.val);
 		const isKnownKeyVersion = encryption.keyring.has(blobVersion);
@@ -274,13 +277,13 @@ export function createEncryptedYkvLww<T>(
 		state: EncryptionState | undefined = encryption,
 	): T | undefined => {
 		if (!isEncryptedBlob(raw)) return raw as T;
-		const json = decryptBlobWithFallback(raw, aad, state);
+		const json = tryDecryptBlob(raw, aad, state);
 		if (!json) return undefined;
 		return JSON.parse(json) as T;
 	};
 
-	/** Count entries in inner.map that can be decrypted with the current keyring. */
-	const countDecryptableInMap = (): number => {
+	/** Count entries that can be decrypted (or are plaintext) with the current keyring. */
+	const countDecryptable = (): number => {
 		let count = 0;
 		for (const [key, entry] of inner.map)
 			if (tryDecryptValue(entry.val, textEncoder.encode(key)) !== undefined)
@@ -428,13 +431,13 @@ export function createEncryptedYkvLww<T>(
 				handler(syntheticChanges, undefined);
 		},
 		get failedDecryptCount() {
-			return inner.map.size - countDecryptableInMap();
+			return inner.map.size - countDecryptable();
 		},
 		*decryptedEntries() {
 			yield* iterateDecrypted(inner.entries());
 		},
 		get decryptedSize() {
-			return countDecryptableInMap();
+			return countDecryptable();
 		},
 		yarray: inner.yarray,
 		doc: inner.doc,

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
@@ -243,7 +243,8 @@ export function createEncryptedYkvLww<T>(
 
 	/**
 	 * Attempt to decrypt an entry. Returns a plaintext entry on success,
-	 * `undefined` on failure (with a console warning when a key is active).
+	 * `undefined` on failure. When a key IS active and decryption still fails,
+	 * logs a single warning with the entry key and actionable failure reason.
 	 */
 	const tryDecryptEntry = (
 		key: string,
@@ -254,11 +255,16 @@ export function createEncryptedYkvLww<T>(
 			entry.val,
 			textEncoder.encode(key),
 		);
-		if (json === undefined) {
-			if (encryption) console.warn(`[encrypted-kv] Failed to decrypt entry "${key}"`);
-			return undefined;
-		}
-		return { ...entry, val: JSON.parse(json) as T };
+		if (json !== undefined) return { ...entry, val: JSON.parse(json) as T };
+		if (!encryption) return undefined;
+
+		const blobVersion = getKeyVersion(entry.val);
+		const isKnownKeyVersion = encryption.keyring.has(blobVersion);
+		const reason = isKnownKeyVersion
+			? 'wrong key material or corrupted blob'
+			: `keyVersion=${blobVersion} not in keyring [${[...encryption.keyring.keys()].join(', ')}]`;
+		console.warn(`[encrypted-kv] Failed to decrypt entry "${key}": ${reason}`);
+		return undefined;
 	};
 
 	/** Silent decrypt—returns plaintext value or `undefined`. No console warning. */

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
@@ -243,8 +243,7 @@ export function createEncryptedYkvLww<T>(
 
 	/**
 	 * Attempt to decrypt an entry. Returns a plaintext entry on success,
-	 * `undefined` on failure. When a key IS active and decryption still fails,
-	 * logs a single consolidated warning with the entry key and failure reason.
+	 * `undefined` on failure (with a console warning when a key is active).
 	 */
 	const tryDecryptEntry = (
 		key: string,
@@ -256,13 +255,7 @@ export function createEncryptedYkvLww<T>(
 			textEncoder.encode(key),
 		);
 		if (json === undefined) {
-			if (encryption) {
-				const blobVersion = getKeyVersion(entry.val);
-				const reason = !encryption.keyring.has(blobVersion)
-					? `keyVersion=${blobVersion} not in keyring [${[...encryption.keyring.keys()].join(',')}]`
-					: 'decryption failed (wrong key material or corrupted blob)';
-				console.warn(`[encrypted-kv] Failed to decrypt entry "${key}": ${reason}`);
-			}
+			if (encryption) console.warn(`[encrypted-kv] Failed to decrypt entry "${key}"`);
 			return undefined;
 		}
 		return { ...entry, val: JSON.parse(json) as T };

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
@@ -230,34 +230,21 @@ export function createEncryptedYkvLww<T>(
 		try {
 			return decryptValue(blob, state.currentKey, aad);
 		} catch {
-			/* fall through to version-directed lookup */
+			/* fast path miss — try version-directed lookup */
 		}
-		const blobVersion = getKeyVersion(blob);
-		const versionKey = state.keyring.get(blobVersion);
-		if (!versionKey) {
-			console.warn(
-				`[encrypted-kv] Blob keyVersion=${blobVersion} not in keyring [${[...state.keyring.keys()].join(',')}]`,
-			);
-			return undefined;
-		}
-		if (versionKey === state.currentKey) {
-			// Already tried this key above
-			return undefined;
-		}
+		const versionKey = state.keyring.get(getKeyVersion(blob));
+		if (!versionKey || versionKey === state.currentKey) return undefined;
 		try {
 			return decryptValue(blob, versionKey, aad);
-		} catch (err) {
-			console.warn(
-				`[encrypted-kv] Fallback key (v${blobVersion}) also failed. ` +
-					`Error: ${err instanceof Error ? err.message : err}`,
-			);
+		} catch {
+			return undefined;
 		}
-		return undefined;
 	};
 
 	/**
 	 * Attempt to decrypt an entry. Returns a plaintext entry on success,
-	 * `undefined` on failure (with a console warning for diagnostics).
+	 * `undefined` on failure. When a key IS active and decryption still fails,
+	 * logs a single consolidated warning with the entry key and failure reason.
 	 */
 	const tryDecryptEntry = (
 		key: string,
@@ -268,8 +255,14 @@ export function createEncryptedYkvLww<T>(
 			entry.val,
 			textEncoder.encode(key),
 		);
-		if (!json) {
-			if (encryption) console.warn(`[encrypted-kv] Failed to decrypt entry "${key}"`);
+		if (json === undefined) {
+			if (encryption) {
+				const blobVersion = getKeyVersion(entry.val);
+				const reason = !encryption.keyring.has(blobVersion)
+					? `keyVersion=${blobVersion} not in keyring [${[...encryption.keyring.keys()].join(',')}]`
+					: 'decryption failed (wrong key material or corrupted blob)';
+				console.warn(`[encrypted-kv] Failed to decrypt entry "${key}": ${reason}`);
+			}
 			return undefined;
 		}
 		return { ...entry, val: JSON.parse(json) as T };

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
@@ -232,13 +232,25 @@ export function createEncryptedYkvLww<T>(
 		} catch {
 			/* fall through to version-directed lookup */
 		}
-		const versionKey = state.keyring.get(getKeyVersion(blob));
-		if (versionKey && versionKey !== state.currentKey) {
-			try {
-				return decryptValue(blob, versionKey, aad);
-			} catch {
-				/* fall through */
-			}
+		const blobVersion = getKeyVersion(blob);
+		const versionKey = state.keyring.get(blobVersion);
+		if (!versionKey) {
+			console.warn(
+				`[encrypted-kv] Blob keyVersion=${blobVersion} not in keyring [${[...state.keyring.keys()].join(',')}]`,
+			);
+			return undefined;
+		}
+		if (versionKey === state.currentKey) {
+			// Already tried this key above
+			return undefined;
+		}
+		try {
+			return decryptValue(blob, versionKey, aad);
+		} catch (err) {
+			console.warn(
+				`[encrypted-kv] Fallback key (v${blobVersion}) also failed. ` +
+					`Error: ${err instanceof Error ? err.message : err}`,
+			);
 		}
 		return undefined;
 	};
@@ -257,7 +269,7 @@ export function createEncryptedYkvLww<T>(
 			textEncoder.encode(key),
 		);
 		if (!json) {
-			console.warn(`[encrypted-kv] Failed to decrypt entry "${key}"`);
+			if (encryption) console.warn(`[encrypted-kv] Failed to decrypt entry "${key}"`);
 			return undefined;
 		}
 		return { ...entry, val: JSON.parse(json) as T };

--- a/packages/workspace/src/workspace/create-kv.ts
+++ b/packages/workspace/src/workspace/create-kv.ts
@@ -11,7 +11,7 @@
  */
 
 import type { YKeyValueLwwChange } from '../shared/y-keyvalue/y-keyvalue-lww.js';
-import type { YKeyValueLwwEncrypted } from '../shared/y-keyvalue/y-keyvalue-lww-encrypted.js';
+import type { EncryptedYKeyValueLww } from '../shared/y-keyvalue/y-keyvalue-lww-encrypted.js';
 import type {
 	KvChange,
 	KvDefinitions,
@@ -29,7 +29,7 @@ import type {
  * @returns KvHelper with type-safe get/set/delete/observe methods
  */
 export function createKv<TKvDefinitions extends KvDefinitions>(
-	ykv: YKeyValueLwwEncrypted<unknown>,
+	ykv: EncryptedYKeyValueLww<unknown>,
 	definitions: TKvDefinitions,
 ): KvHelper<TKvDefinitions> {
 	return {

--- a/packages/workspace/src/workspace/create-table.ts
+++ b/packages/workspace/src/workspace/create-table.ts
@@ -8,7 +8,7 @@
  */
 
 import type { YKeyValueLwwChange } from '../shared/y-keyvalue/y-keyvalue-lww.js';
-import type { YKeyValueLwwEncrypted } from '../shared/y-keyvalue/y-keyvalue-lww-encrypted.js';
+import type { EncryptedYKeyValueLww } from '../shared/y-keyvalue/y-keyvalue-lww-encrypted.js';
 import type {
 	GetResult,
 	InferTableRow,
@@ -30,7 +30,7 @@ export function createTable<
 	// biome-ignore lint/suspicious/noExplicitAny: variance-friendly — defineTable already constrains schemas
 	TTableDefinition extends TableDefinition<any>,
 >(
-	ykv: YKeyValueLwwEncrypted<unknown>,
+	ykv: EncryptedYKeyValueLww<unknown>,
 	definition: TTableDefinition,
 ): TableHelper<InferTableRow<TTableDefinition>> {
 	type TRow = InferTableRow<TTableDefinition>;
@@ -97,7 +97,7 @@ export function createTable<
 
 		getAll(): RowResult<TRow>[] {
 			const results: RowResult<TRow>[] = [];
-			for (const [key, entry] of ykv.decryptedEntries()) {
+			for (const [key, entry] of ykv.readableEntries()) {
 				const result = parseRow(key, entry.val);
 				results.push(result);
 			}
@@ -106,7 +106,7 @@ export function createTable<
 
 		getAllValid(): TRow[] {
 			const rows: TRow[] = [];
-			for (const [key, entry] of ykv.decryptedEntries()) {
+			for (const [key, entry] of ykv.readableEntries()) {
 				const result = parseRow(key, entry.val);
 				if (result.status === 'valid') {
 					rows.push(result.row);
@@ -117,7 +117,7 @@ export function createTable<
 
 		getAllInvalid(): InvalidRowResult[] {
 			const invalid: InvalidRowResult[] = [];
-			for (const [key, entry] of ykv.decryptedEntries()) {
+			for (const [key, entry] of ykv.readableEntries()) {
 				const result = parseRow(key, entry.val);
 				if (result.status === 'invalid') {
 					invalid.push(result);
@@ -132,7 +132,7 @@ export function createTable<
 
 		filter(predicate: (row: TRow) => boolean): TRow[] {
 			const rows: TRow[] = [];
-			for (const [key, entry] of ykv.decryptedEntries()) {
+			for (const [key, entry] of ykv.readableEntries()) {
 				const result = parseRow(key, entry.val);
 				if (result.status === 'valid' && predicate(result.row)) {
 					rows.push(result.row);
@@ -142,7 +142,7 @@ export function createTable<
 		},
 
 		find(predicate: (row: TRow) => boolean): TRow | undefined {
-			for (const [key, entry] of ykv.decryptedEntries()) {
+			for (const [key, entry] of ykv.readableEntries()) {
 				const result = parseRow(key, entry.val);
 				if (result.status === 'valid' && predicate(result.row)) {
 					return result.row;
@@ -160,7 +160,7 @@ export function createTable<
 		},
 
 		clear(): void {
-			const keys = Array.from(ykv.decryptedEntries()).map(([k]) => k);
+			const keys = Array.from(ykv.readableEntries()).map(([k]) => k);
 			for (const key of keys) {
 				ykv.delete(key);
 			}
@@ -189,7 +189,7 @@ export function createTable<
 		// ═══════════════════════════════════════════════════════════════════════
 
 		count(): number {
-			return ykv.decryptedSize;
+			return ykv.readableEntryCount;
 		},
 
 		has(id: string): boolean {

--- a/packages/workspace/src/workspace/create-workspace.ts
+++ b/packages/workspace/src/workspace/create-workspace.ts
@@ -57,7 +57,7 @@ import { base64ToBytes, deriveWorkspaceKey } from '../shared/crypto/index.js';
 import type { YKeyValueLwwEntry } from '../shared/y-keyvalue/y-keyvalue-lww.js';
 import {
 	createEncryptedYkvLww,
-	type YKeyValueLwwEncrypted,
+	type EncryptedYKeyValueLww,
 } from '../shared/y-keyvalue/y-keyvalue-lww-encrypted.js';
 import { createAwareness } from './create-awareness.js';
 import { createDocuments } from './create-document.js';
@@ -154,7 +154,7 @@ export function createWorkspace<
 	// ── Encrypted stores (all table stores + KV store) ─────────────────────
 	// The workspace owns this list so it can coordinate activateEncryption
 	// across all stores simultaneously via applyEncryptionKeys().
-	const encryptedStores: readonly YKeyValueLwwEncrypted<unknown>[] = [
+	const encryptedStores: readonly EncryptedYKeyValueLww<unknown>[] = [
 		...tableEntries.map(({ store }) => store),
 		kvStore,
 	];


### PR DESCRIPTION
Running `epicenter start` spams ~100 "Failed to decrypt entry" warnings on startup—every encrypted entry in the Y.Doc triggers one. The data loads fine after, so it looks broken but isn't.

The cause is architectural, not a bug. Persistence loads the Y.Doc (with encrypted blobs) before the encryption key arrives from auth. The inner CRDT observer fires for every loaded entry, tries to decrypt, and warns—because there's no key yet.

```
1. persistence extension    → loads .yjs into Y.Doc
   └─ observer fires        → tries to decrypt → no key → warns ×100
2. unlock extension         → applyEncryptionKeys(session.encryptionKeys)
   └─ activateEncryption()  → diffs before/after, emits synthetic 'add' events
3. sync extension           → connects WebSocket
```

This ordering is correct by design. The Y.Doc must be populated before keys can be applied (nothing to decrypt otherwise), and the key comes from an async auth session. `activateEncryption()` handles the gap—it diffs before/after readability and emits synthetic events for all newly-readable entries. No data is lost, no events are missed.

---

**The fix is one guard in `tryDecryptEntry`: only warn when a key IS active but decryption still fails.**

```typescript
// Before — warns on every entry, including the expected no-key startup window
if (!json) {
    console.warn(`[encrypted-kv] Failed to decrypt entry "${key}"`);
    return undefined;
}

// After — silent when no key yet, actionable when a real failure occurs
if (json !== undefined) return { ...entry, val: JSON.parse(json) as T };
if (!encryption) return undefined; // No key loaded yet — activateEncryption() will catch up

const blobVersion = getKeyVersion(entry.val);
const isKnownKeyVersion = encryption.keyring.has(blobVersion);
const reason = isKnownKeyVersion
    ? 'wrong key material or corrupted blob'
    : `keyVersion=${blobVersion} not in keyring [${[...encryption.keyring.keys()].join(', ')}]`;
console.warn(`[encrypted-kv] Failed to decrypt entry "${key}": ${reason}`);
return undefined;
```

When a real failure happens now, operators see exactly what to do:

```
[encrypted-kv] Failed to decrypt entry "5w6tcxberv": keyVersion=2 not in keyring [1]
```

→ add the old key to `ENCRYPTION_SECRETS`. Or:

```
[encrypted-kv] Failed to decrypt entry "5w6tcxberv": wrong key material or corrupted blob
```

→ check user/secret mismatch.

---

**`decryptBlobWithFallback` was also cleaned up into a pure function renamed `tryDecryptBlob`.**

The old version had `console.warn` calls inside the fallback chain—meaning some failures logged twice (once from the fallback, once from the caller) while others were silent. Now the function is pure: try current key, try version-directed key, return string or undefined. No logging, no side effects. The caller decides what to do with `undefined`.

```typescript
const tryDecryptBlob = (
    blob: EncryptedBlob,
    aad: Uint8Array,
    state: EncryptionState | undefined = encryption,
): string | undefined => {
    if (!state) return undefined;
    try {
        return decryptValue(blob, state.currentKey, aad);
    } catch {
        // Current key didn't work — try the blob's recorded key version
    }
    const versionKey = state.keyring.get(getKeyVersion(blob));
    if (!versionKey || versionKey === state.currentKey) return undefined;
    try {
        return decryptValue(blob, versionKey, aad);
    } catch {
        return undefined;
    }
};
```

---

**A naming pass came along for the ride.** The oracle review flagged that `decrypted*` names were technically dishonest—these helpers also pass through plaintext entries, so "decrypted" overclaims. Public API symbols were renamed across all consumers:

```
YKeyValueLwwEncrypted<T>   →  EncryptedYKeyValueLww<T>     (adjective-first)
EncryptedKvChangeHandler   →  EncryptedKvObserver           (pairs with observe/unobserve)
decryptedEntries()         →  readableEntries()             (includes plaintext passthrough)
decryptedSize              →  readableEntryCount            (Count not Size)
failedDecryptCount         →  unreadableEntryCount          (state, not event)
RE_ENCRYPT                 →  REENCRYPT_ORIGIN              (clarifies sentinel role)
decryptBlobWithFallback    →  tryDecryptBlob                (drop implementation detail)
countDecryptableInMap      →  countDecryptable              (drop InMap leak)
```

6 commits, 6 files changed, +77/−70. 120 tests pass.