### PR TITLE
feat(cli): add `epicenter size` command for workspace diagnostics

### DIFF
--- a/packages/cli/src/README.md
+++ b/packages/cli/src/README.md
@@ -18,6 +18,7 @@ epicenter kv delete <key>            # delete a KV entry
 epicenter run <action.path> [--args] # invoke a workspace action
 epicenter describe                   # dump workspace schema as JSON
 epicenter export                     # export all data as JSON
+epicenter size                       # report workspace sizes and row counts
 
 epicenter init                       # scaffold a new project
 epicenter install <item>             # install a workspace from a registry
@@ -82,4 +83,13 @@ If your config exports multiple workspaces, use `-w` to select one:
 ```bash
 epicenter list posts -w my-blog
 epicenter get posts abc123 -w my-blog
+```
+
+## Size Commands
+
+```bash
+epicenter size                       # all workspaces, human-readable
+epicenter size -w blog               # single workspace
+epicenter size --format json         # machine-readable JSON
+epicenter size -C apps/my-project    # different directory
 ```

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -14,6 +14,7 @@ import { describeCommand } from './commands/describe';
 import { kvCommand } from './commands/kv';
 import { initCommand, installCommand, uninstallCommand } from './commands/project';
 import { runActionCommand } from './commands/run';
+import { sizeCommand } from './commands/size';
 import { startCommand } from './commands/start';
 
 /** Resolution order: EPICENTER_HOME env > ~/.epicenter/ */
@@ -49,6 +50,7 @@ export function createCLI() {
 				.command(uninstallCommand)
 				.command(runActionCommand)
 				.command(describeCommand)
+				.command(sizeCommand)
 				.command(createAuthCommand(home))
 				.demandCommand(1)
 				.strict()

--- a/packages/cli/src/commands/size.ts
+++ b/packages/cli/src/commands/size.ts
@@ -1,0 +1,110 @@
+/**
+ * `epicenter size` — report encoded byte size and per-table row counts.
+ *
+ * Unlike most commands, `size` uses `loadConfig()` directly instead of
+ * `runCommand` because it needs to iterate ALL workspace clients, not just one.
+ */
+
+import type { AnyWorkspaceClient } from '@epicenter/workspace';
+import type { Argv } from 'yargs';
+import { loadConfig } from '../load-config';
+import { defineCommand, withWorkspaceOptions } from '../util/command';
+import { output, outputError } from '../util/format-output';
+
+/** Format a byte count as a human-readable string with 1 decimal place. */
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+type WorkspaceSizeResult = {
+	id: string;
+	encodedSize: number;
+	tables: Record<string, { rows: number }>;
+};
+
+/**
+ * `epicenter size` — report encoded byte size and per-table row counts
+ * for every workspace in the config.
+ *
+ * Outputs a human-readable summary by default, or machine-readable JSON
+ * with `--format json`.
+ *
+ * @example
+ * ```bash
+ * epicenter size                       # all workspaces, human-readable
+ * epicenter size -w blog               # single workspace
+ * epicenter size --format json         # machine-readable JSON
+ * epicenter size -C apps/my-project    # different directory
+ * ```
+ */
+export const sizeCommand = defineCommand({
+	command: 'size',
+	describe: 'Report encoded size and row counts for all workspaces',
+	builder: (y: Argv) => withWorkspaceOptions(y),
+	handler: async (argv: any) => {
+		try {
+			const { clients } = await loadConfig(argv.dir);
+
+			try {
+				let targets: AnyWorkspaceClient[] = clients;
+				if (argv.workspace) {
+					const found = clients.find((c) => c.id === argv.workspace);
+					if (!found) {
+						const ids = clients.map((c) => c.id).join(', ');
+						throw new Error(
+							`Workspace "${argv.workspace}" not found. Available: ${ids}`,
+						);
+					}
+					targets = [found];
+				}
+
+				const results: WorkspaceSizeResult[] = [];
+				for (const client of targets) {
+					await client.whenReady;
+					const tableNames = Object.keys(client.definitions.tables);
+					const tables: Record<string, { rows: number }> = {};
+					for (const name of tableNames) {
+						const table = client.tables[name];
+						if (table) tables[name] = { rows: table.count() };
+					}
+					results.push({
+						id: client.id,
+						encodedSize: client.encodedSize(),
+						tables,
+					});
+				}
+
+				if (argv.format) {
+					output(results, { format: argv.format });
+				} else {
+					for (const [i, result] of results.entries()) {
+						if (i > 0) console.log('');
+						console.log(`${result.id} (${formatBytes(result.encodedSize)})`);
+
+						const entries = Object.entries(result.tables);
+						if (entries.length > 0) {
+							const maxNameLen = Math.max(
+								...entries.map(([name]) => name.length),
+							);
+							const maxCountLen = Math.max(
+								...entries.map(([, t]) => String(t.rows).length),
+							);
+							for (const [name, t] of entries) {
+								const paddedName = name.padEnd(maxNameLen);
+								const paddedCount = String(t.rows).padStart(maxCountLen);
+								console.log(`  ${paddedName}  ${paddedCount} rows`);
+							}
+						}
+					}
+				}
+			} finally {
+				await Promise.all(clients.map((c) => c.dispose()));
+			}
+		} catch (err) {
+			outputError(err instanceof Error ? err.message : String(err));
+			process.exitCode = 1;
+		}
+	},
+});

--- a/specs/20260405T101228-epicenter-size-command.handoff.md
+++ b/specs/20260405T101228-epicenter-size-command.handoff.md
@@ -1,0 +1,198 @@
+# Handoff: Execute `epicenter size` CLI Command Spec
+
+## Task
+
+Execute the spec at `specs/20260405T101228-epicenter-size-command.md`. This adds an `epicenter size` command that reports encoded byte size and per-table row counts for all workspaces in a config. Three files touched — one new, two modified.
+
+## Context
+
+### How CLI commands work in this codebase
+
+Every command follows this pattern:
+
+1. Define a command object with `defineCommand()` (identity function for type narrowing)
+2. Use `withWorkspaceOptions(y)` to add `--dir`, `--workspace`, `--format` flags
+3. Use `runCommand(opts, fn, format)` for single-workspace commands — it handles loadConfig → resolve → whenReady → execute → dispose
+
+**However, this command is different.** It needs to show ALL workspaces, not just one. So it uses `loadConfig()` directly instead of `runCommand()`.
+
+### The existing `describe` command (simplest template)
+
+```typescript
+// packages/cli/src/commands/describe.ts — full file
+import { describeWorkspace } from '@epicenter/workspace';
+import type { Argv } from 'yargs';
+import {
+	defineCommand,
+	runCommand,
+	withWorkspaceOptions,
+} from '../util/command';
+
+export const describeCommand = defineCommand({
+	command: 'describe',
+	describe: 'Describe workspace schema, actions, and KV definitions',
+	builder: (y: Argv) => withWorkspaceOptions(y),
+	handler: async (argv: any) => {
+		await runCommand(
+			{ dir: argv.dir, workspaceId: argv.workspace },
+			(client) => describeWorkspace(client),
+			argv.format,
+		);
+	},
+});
+```
+
+### How loadConfig works
+
+```typescript
+// packages/cli/src/load-config.ts
+import type { AnyWorkspaceClient } from '@epicenter/workspace';
+
+export type LoadConfigResult = {
+	configDir: string;
+	clients: AnyWorkspaceClient[];
+};
+
+export async function loadConfig(targetDir: string): Promise<LoadConfigResult> {
+	// imports epicenter.config.ts via Bun
+	// collects all named exports that are workspace clients (duck-type check)
+	// deduplicates by workspace ID
+	// throws if no config file or no valid exports
+	return { configDir, clients };
+}
+```
+
+### How the export command iterates tables (pattern to follow)
+
+```typescript
+// packages/cli/src/commands/data.ts (exportCommand handler)
+(client) => {
+	const data: Record<string, unknown[]> = {};
+	const tableNames = argv.table
+		? [argv.table as string]
+		: Object.keys(client.definitions.tables);
+
+	for (const tableName of tableNames) {
+		const table = client.tables[tableName];
+		if (!table) {
+			throw new Error(`Table "${tableName}" not found in workspace "${client.id}"`);
+		}
+		data[tableName] = table.getAllValid();
+	}
+	return data;
+}
+```
+
+### Key workspace client APIs
+
+```typescript
+client.id                              // string — workspace ID
+client.encodedSize()                   // number — total Y.Doc byte size
+client.definitions.tables              // Record<string, TableDefinition> — table schemas
+client.tables[name].count()            // number — row count (valid + invalid)
+client.whenReady                       // Promise<void> — resolves when extensions init'd
+client.dispose()                       // Promise<void> — cleanup
+```
+
+### How output utilities work
+
+```typescript
+// packages/cli/src/util/format-output.ts
+export function output(value: unknown, options?: { format?: 'json' | 'jsonl' }): void;
+export function outputError(message: string): void;
+export function formatYargsOptions(): { format: { type: 'string', choices: ['json', 'jsonl'] } };
+```
+
+### How commands are registered
+
+```typescript
+// packages/cli/src/cli.ts — add one line in the .command() chain
+import { sizeCommand } from './commands/size';
+// ...
+.command(sizeCommand)
+```
+
+### Current CLI README structure
+
+The README at `packages/cli/src/README.md` has sections for Command Structure (full bash listing), Table Commands, KV Commands, Action Commands, Output Formats, Working Directory, and Multiple Workspaces.
+
+## Design Requirements
+
+### 1. `packages/cli/src/commands/size.ts` (NEW FILE)
+
+Create `sizeCommand` that:
+
+- Uses `loadConfig(dir)` directly (NOT `runCommand`) so it can iterate all clients
+- Accepts `--workspace` to optionally filter to one workspace
+- Accepts `--dir` / `-C` for project directory
+- Accepts `--format json` for machine-readable output
+- For each client: awaits `whenReady`, calls `encodedSize()`, iterates `Object.keys(client.definitions.tables)` calling `.count()` on each
+- Disposes ALL clients in a `finally` block (same pattern as `runCommand`)
+- Catches errors and calls `outputError()` + sets `process.exitCode = 1` (same pattern as `runCommand`)
+
+**Human-readable output** (default, when no `--format`):
+
+```
+blog (14.2 KB)
+  posts        12 rows
+  comments     47 rows
+  tags          5 rows
+
+shop (8.7 KB)
+  products     23 rows
+  orders       91 rows
+```
+
+- Format bytes as human-readable (B, KB, MB) with 1 decimal place
+- Right-align row counts within each workspace
+- Separate workspaces with blank lines
+- Print to stdout via `console.log()`
+
+**JSON output** (when `--format json`):
+
+```json
+[
+  {
+    "id": "blog",
+    "encodedSize": 14532,
+    "tables": {
+      "posts": { "rows": 12 },
+      "comments": { "rows": 47 }
+    }
+  }
+]
+```
+
+- Use `output(result, { format: argv.format })` for JSON mode
+- Raw byte counts (numbers, not formatted strings)
+
+### 2. `packages/cli/src/cli.ts` (MODIFY)
+
+- Add import: `import { sizeCommand } from './commands/size';`
+- Add `.command(sizeCommand)` in the chain (put it near `describeCommand` since they're both introspection commands)
+
+### 3. `packages/cli/src/README.md` (MODIFY)
+
+- Add `epicenter size` to the Command Structure section
+- Add a brief "Size Commands" section showing usage examples
+
+## MUST DO
+
+- Follow the exact error handling pattern from `runCommand`: wrap in try/catch, call `outputError(err.message)`, set `process.exitCode = 1`
+- Follow the exact dispose pattern: `await Promise.all(clients.map((c) => c.dispose()))` in a `finally` block
+- Use `withWorkspaceOptions(y)` for the builder to get `--dir`, `--workspace`, `--format` flags
+- Use `type` instead of `interface` for any TypeScript types
+- Keep the byte formatting function simple and inline (no new dependencies)
+- Include JSDoc on the exported `sizeCommand` with `@example` blocks showing bash usage
+- When `--workspace` is specified and not found, throw an error listing available IDs (same UX as `resolveWorkspace`)
+- Load the `monorepo` skill to find the right type-check command for verification
+
+## MUST NOT DO
+
+- Do not use `runCommand` — it resolves to a single client, but we need all clients
+- Do not install any new dependencies
+- Do not modify any files outside of `packages/cli/`
+- Do not add per-table byte sizes (not available from the Yjs API)
+- Do not use `interface` — use `type` for all TypeScript types
+- Do not use `as any` or `@ts-ignore`
+- Do not create test files (out of scope for this spec)

--- a/specs/20260405T101228-epicenter-size-command.md
+++ b/specs/20260405T101228-epicenter-size-command.md
@@ -1,0 +1,173 @@
+# `epicenter size` CLI Command
+
+**Date**: 2026-04-05
+**Status**: Implemented
+**Author**: AI-assisted
+
+## Overview
+
+Add an `epicenter size` command that reports the encoded byte size and per-table row counts for every workspace in an `epicenter.config.ts`. Useful for debugging bloat, monitoring growth, and general diagnostics.
+
+## Motivation
+
+### Current State
+
+The workspace client exposes `encodedSize()` which returns the full Y.Doc byte count:
+
+```typescript
+// packages/workspace/src/workspace/create-workspace.ts:323-325
+encodedSize(): number {
+    return Y.encodeStateAsUpdate(ydoc).byteLength;
+},
+```
+
+Per-table row counts are available via `table.count()`. But there's no CLI surface to access either. The only way to check workspace size today is to write a throwaway script or run one of the benchmark scripts in `packages/workspace/scripts/`.
+
+### Problems
+
+1. **No terminal-level diagnostics** — Can't quickly check if a workspace is bloating without writing code.
+2. **Multi-workspace blind spot** — If a config exports multiple workspaces, there's no way to compare their sizes at a glance.
+
+### Desired State
+
+```bash
+$ epicenter size
+
+blog (14.2 KB)
+  posts        12 rows
+  comments     47 rows
+  tags          5 rows
+
+shop (8.7 KB)
+  products     23 rows
+  orders       91 rows
+```
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+| --- | --- | --- |
+| Show all workspaces by default | Yes | The whole point is "each client's size" — filtering to one defeats the purpose. Use `--workspace` to narrow. |
+| Don't use `runCommand` helper | Custom handler using `loadConfig` directly | `runCommand` resolves to a single client. We need to iterate all clients. |
+| Human-readable default output | Custom formatting (not JSON) | `output()` only does JSON. A human-readable table with formatted byte sizes is more useful for quick checks. |
+| Per-table byte size | Not available — show row counts instead | Yjs stores all tables in a single `Y.Doc`. There's no per-table byte measurement without deep Yjs internals. Row counts via `table.count()` are the next best thing. |
+| `--format json` support | Yes | Machine-readable output for scripting. Raw byte counts, not formatted strings. |
+
+## Architecture
+
+```
+epicenter size [--workspace <id>] [--dir <path>] [--format json]
+        │
+        ▼
+  loadConfig(dir)
+        │
+        ▼
+  clients: AnyWorkspaceClient[]
+        │
+        ├── (filter by --workspace if provided)
+        │
+        ▼
+  for each client:
+    ├── await client.whenReady
+    ├── client.encodedSize()  →  total bytes
+    ├── Object.keys(client.definitions.tables)
+    │     └── client.tables[name].count()  →  row count per table
+    └── format and print
+        │
+        ▼
+  dispose all clients
+```
+
+### Human-readable output format
+
+```
+<workspace-id> (<formatted-size>)
+  <table-name>  <padded-count> rows
+
+<workspace-id> (<formatted-size>)
+  <table-name>  <padded-count> rows
+```
+
+Row counts are right-aligned. Workspaces separated by blank lines.
+
+### JSON output format
+
+```json
+[
+  {
+    "id": "blog",
+    "encodedSize": 14532,
+    "tables": {
+      "posts": { "rows": 12 },
+      "comments": { "rows": 47 }
+    }
+  }
+]
+```
+
+## Implementation Plan
+
+### Phase 1: Create the command (single wave)
+
+- [x] **1.1** Create `packages/cli/src/commands/size.ts` with `sizeCommand` export
+- [x] **1.2** Register `sizeCommand` in `packages/cli/src/cli.ts`
+- [x] **1.3** Update `packages/cli/src/README.md` with `epicenter size` documentation
+- [x] **1.4** Verify with type-check (`bun run tsc --noEmit` in packages/cli or equivalent)
+  > **Note**: `tsc --noEmit` shows pre-existing errors (missing Bun/node type declarations). No new errors from size command. LSP diagnostics clean except `argv: any` which matches all existing commands.
+
+## Edge Cases
+
+### No workspaces in config
+
+1. `loadConfig()` already throws `No workspace clients found in epicenter.config.ts` with a helpful hint.
+2. No special handling needed — the error propagates naturally.
+
+### Single workspace with `--workspace` flag
+
+1. Works fine — `--workspace` filters to the matching one.
+2. If the ID doesn't match, print an error listing available IDs (same pattern as `resolveWorkspace`).
+
+### Workspace with no tables
+
+1. Print the workspace ID and encoded size.
+2. Print nothing under it (no table lines). This is a valid state.
+
+### Workspace with encrypted tables
+
+1. `table.count()` returns `ykv.decryptedSize` — this may be 0 if encryption keys haven't been applied.
+2. Acceptable — the total `encodedSize()` still reflects the real Y.Doc size.
+
+## Success Criteria
+
+- [x] `epicenter size` prints all workspaces with encoded size and per-table row counts
+- [x] `epicenter size -w <id>` filters to one workspace
+- [x] `epicenter size --format json` outputs machine-readable JSON
+- [x] `epicenter size -C <dir>` works from a different directory
+- [x] Type-check passes (no new errors introduced)
+- [x] No new dependencies added
+
+## References
+
+- `packages/cli/src/commands/describe.ts` — Simplest existing command to use as template
+- `packages/cli/src/util/command.ts` — `defineCommand`, `withWorkspaceOptions`, `loadConfig` import, error handling patterns
+- `packages/cli/src/load-config.ts` — `loadConfig()` for getting all clients
+- `packages/cli/src/util/format-output.ts` — `output()`, `outputError()`, `formatYargsOptions()`
+- `packages/cli/src/cli.ts` — Registration point (`.command(sizeCommand)`)
+- `packages/cli/src/commands/data.ts` — Pattern for iterating tables (`exportCommand`)
+- `packages/workspace/src/workspace/create-workspace.ts:323-325` — `encodedSize()` implementation
+
+## Review
+
+**Completed**: 2026-04-05
+
+### Summary
+
+Added `epicenter size` command that reports encoded byte size and per-table row counts for all workspaces in an `epicenter.config.ts`. Three files changed: one new (`size.ts`), two modified (`cli.ts`, `README.md`). Implementation follows established command patterns exactly—same error handling, same dispose pattern, same option flags.
+
+### Deviations from Spec
+
+None. Implementation matches the spec exactly.
+
+### Follow-up Work
+
+- None identified.


### PR DESCRIPTION
There's no way to check workspace size from the terminal without writing a throwaway script. The workspace client already exposes `encodedSize()` and per-table `count()`, but neither has a CLI surface. If a config exports multiple workspaces, comparing their sizes means loading each one manually.

`epicenter size` fixes this. It loads every workspace in the config, reports the total Y.Doc byte size and per-table row counts, and disposes all clients when done:

```
$ epicenter size

blog (14.2 KB)
  posts       12 rows
  comments    47 rows
  tags         5 rows

shop (8.7 KB)
  products    23 rows
  orders      91 rows
```

The command uses `loadConfig()` directly instead of `runCommand` because `runCommand` resolves to a single client—`size` needs all of them. Workspace filtering (`-w`), directory override (`-C`), and JSON output (`--format json`) all work the same as other commands. Error handling and dispose follow the exact `runCommand` pattern: outer try/catch with `outputError()` + `process.exitCode = 1`, inner try/finally with `Promise.all(clients.map(c => c.dispose()))`.

```typescript
// JSON output for scripting — raw byte counts, not formatted strings
epicenter size --format json
[
  {
    "id": "blog",
    "encodedSize": 14532,
    "tables": {
      "posts": { "rows": 12 },
      "comments": { "rows": 47 }
    }
  }
]
```

One new file, two modified. No new dependencies.