### PR TITLE
feat(tab-manager): VS Code-style search modes and bookmark favicons

### DIFF
--- a/apps/tab-manager/src/entrypoints/sidepanel/App.svelte
+++ b/apps/tab-manager/src/entrypoints/sidepanel/App.svelte
@@ -4,12 +4,17 @@
 	import * as Empty from '@epicenter/ui/empty';
 	import { Input } from '@epicenter/ui/input';
 	import { Spinner } from '@epicenter/ui/spinner';
+	import { Toggle } from '@epicenter/ui/toggle';
+	import * as ToggleGroup from '@epicenter/ui/toggle-group';
 	import * as Tooltip from '@epicenter/ui/tooltip';
 	import SearchIcon from '@lucide/svelte/icons/search';
 	import TerminalIcon from '@lucide/svelte/icons/terminal';
 	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 	import XIcon from '@lucide/svelte/icons/x';
 	import ZapIcon from '@lucide/svelte/icons/zap';
+	import CaseSensitiveIcon from '@lucide/svelte/icons/case-sensitive';
+	import RegexIcon from '@lucide/svelte/icons/regex';
+	import WholeWordIcon from '@lucide/svelte/icons/whole-word';
 	import { Toaster } from '@epicenter/ui/sonner';
 	import { ModeWatcher } from 'mode-watcher';
 	import AiDrawer from '$lib/components/AiDrawer.svelte';
@@ -59,21 +64,82 @@
 							searchInputRef?.blur();
 						}
 					}}
-						class="h-8 pl-8 pr-8 text-sm [&::-webkit-search-cancel-button]:hidden"
+						class="h-8 pl-8 pr-[5.5rem] text-sm [&::-webkit-search-cancel-button]:hidden"
 					/>
-					{#if unifiedViewState.searchQuery}
-						<button
-							type="button"
-							class="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-							onclick={() => {
-								unifiedViewState.searchQuery = '';
-								searchInputRef?.focus();
-							}}
-						>
-							<XIcon class="size-3.5" />
-						</button>
-					{/if}
+					<div class="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
+						{#if unifiedViewState.searchQuery}
+							<button
+								type="button"
+								class="text-muted-foreground hover:text-foreground"
+								onclick={() => {
+									unifiedViewState.searchQuery = '';
+									searchInputRef?.focus();
+								}}
+							>
+								<XIcon class="size-3.5" />
+							</button>
+						{/if}
+						<Tooltip.Root>
+							<Tooltip.Trigger>
+								{#snippet child({ props })}
+									<Toggle
+										size="sm"
+										bind:pressed={unifiedViewState.isCaseSensitive}
+										aria-label="Match Case"
+										class="size-6 rounded-sm p-0"
+										{...props}
+									>
+										<CaseSensitiveIcon class="size-3.5" />
+									</Toggle>
+								{/snippet}
+							</Tooltip.Trigger>
+							<Tooltip.Content>Match Case</Tooltip.Content>
+						</Tooltip.Root>
+						<Tooltip.Root>
+							<Tooltip.Trigger>
+								{#snippet child({ props })}
+									<Toggle
+										size="sm"
+										bind:pressed={unifiedViewState.isRegex}
+										aria-label="Use Regular Expression"
+										class="size-6 rounded-sm p-0"
+										{...props}
+									>
+										<RegexIcon class="size-3.5" />
+									</Toggle>
+								{/snippet}
+							</Tooltip.Trigger>
+							<Tooltip.Content>Use Regular Expression</Tooltip.Content>
+						</Tooltip.Root>
+						<Tooltip.Root>
+							<Tooltip.Trigger>
+								{#snippet child({ props })}
+									<Toggle
+										size="sm"
+										bind:pressed={unifiedViewState.isExactMatch}
+										aria-label="Match Whole Word"
+										class="size-6 rounded-sm p-0"
+										{...props}
+									>
+										<WholeWordIcon class="size-3.5" />
+									</Toggle>
+								{/snippet}
+							</Tooltip.Trigger>
+							<Tooltip.Content>Match Whole Word</Tooltip.Content>
+						</Tooltip.Root>
+					</div>
 				</div>
+				<ToggleGroup.Root
+					type="single"
+					size="sm"
+					variant="outline"
+					bind:value={unifiedViewState.searchField}
+					class="h-7"
+				>
+					<ToggleGroup.Item value="all" class="px-1.5 text-xs h-7">All</ToggleGroup.Item>
+					<ToggleGroup.Item value="title" class="px-1.5 text-xs h-7">Title</ToggleGroup.Item>
+					<ToggleGroup.Item value="url" class="px-1.5 text-xs h-7">URL</ToggleGroup.Item>
+				</ToggleGroup.Root>
 				<Button
 					variant="ghost"
 					size="icon-xs"

--- a/apps/tab-manager/src/entrypoints/sidepanel/App.svelte
+++ b/apps/tab-manager/src/entrypoints/sidepanel/App.svelte
@@ -5,7 +5,7 @@
 	import { Input } from '@epicenter/ui/input';
 	import { Spinner } from '@epicenter/ui/spinner';
 	import { Toggle } from '@epicenter/ui/toggle';
-	import * as ToggleGroup from '@epicenter/ui/toggle-group';
+	import * as DropdownMenu from '@epicenter/ui/dropdown-menu';
 	import * as Tooltip from '@epicenter/ui/tooltip';
 	import SearchIcon from '@lucide/svelte/icons/search';
 	import TerminalIcon from '@lucide/svelte/icons/terminal';
@@ -15,6 +15,7 @@
 	import CaseSensitiveIcon from '@lucide/svelte/icons/case-sensitive';
 	import RegexIcon from '@lucide/svelte/icons/regex';
 	import WholeWordIcon from '@lucide/svelte/icons/whole-word';
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
 	import { Toaster } from '@epicenter/ui/sonner';
 	import { ModeWatcher } from 'mode-watcher';
 	import AiDrawer from '$lib/components/AiDrawer.svelte';
@@ -28,6 +29,8 @@
 	let searchInputRef = $state<HTMLInputElement | null>(null);
 	let commandPaletteOpen = $state(false);
 	let aiDrawerOpen = $state(false);
+	let searchFocused = $state(false);
+	const isSearchActive = $derived(searchFocused || unifiedViewState.searchQuery !== '');
 </script>
 
 {#snippet searchToggle(pressed: boolean, onPressedChange: (v: boolean) => void, Icon: typeof CaseSensitiveIcon, label: string)}
@@ -58,11 +61,18 @@
 			class="sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60 px-3 py-2"
 		>
 			<div class="flex items-center gap-2">
-				<div class="relative flex-1">
+				<div
+					class="relative flex-1"
+					onfocusin={() => { searchFocused = true; }}
+					onfocusout={(e: FocusEvent) => {
+						const container = e.currentTarget as HTMLElement;
+						if (container.contains(e.relatedTarget as Node)) return;
+						searchFocused = false;
+					}}
+				>
 					<SearchIcon
 						class="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
 					/>
-					<!-- pr-[5.5rem] = clear button + 3 toggles (size-6 each) + gaps -->
 					<Input
 						bind:ref={searchInputRef}
 						type="search"
@@ -85,37 +95,51 @@
 							searchInputRef?.blur();
 						}
 					}}
-						class="h-8 pl-8 pr-[5.5rem] text-sm [&::-webkit-search-cancel-button]:hidden"
+						class={isSearchActive
+							? "h-8 pl-8 pr-[7.5rem] text-sm [&::-webkit-search-cancel-button]:hidden"
+							: "h-8 pl-8 pr-8 text-sm [&::-webkit-search-cancel-button]:hidden"}
 					/>
-					<div class="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
-						{#if unifiedViewState.searchQuery}
-							<button
-								type="button"
-								class="text-muted-foreground hover:text-foreground"
-								onclick={() => {
-									unifiedViewState.searchQuery = '';
-									searchInputRef?.focus();
-								}}
-							>
-								<XIcon class="size-3.5" />
-							</button>
-						{/if}
-					{@render searchToggle(unifiedViewState.isCaseSensitive, (v) => { unifiedViewState.isCaseSensitive = v; }, CaseSensitiveIcon, 'Match Case')}
-					{@render searchToggle(unifiedViewState.isRegex, (v) => { unifiedViewState.isRegex = v; }, RegexIcon, 'Use Regular Expression')}
-					{@render searchToggle(unifiedViewState.isExactMatch, (v) => { unifiedViewState.isExactMatch = v; }, WholeWordIcon, 'Match Whole Word')}
-					</div>
+					{#if isSearchActive}
+						<div class="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
+							{#if unifiedViewState.searchQuery}
+								<button
+									type="button"
+									class="text-muted-foreground hover:text-foreground"
+									onclick={() => {
+										unifiedViewState.searchQuery = '';
+										searchInputRef?.focus();
+									}}
+								>
+									<XIcon class="size-3.5" />
+								</button>
+							{/if}
+							{@render searchToggle(unifiedViewState.isCaseSensitive, (v) => { unifiedViewState.isCaseSensitive = v; }, CaseSensitiveIcon, 'Match Case')}
+							{@render searchToggle(unifiedViewState.isRegex, (v) => { unifiedViewState.isRegex = v; }, RegexIcon, 'Use Regular Expression')}
+							{@render searchToggle(unifiedViewState.isExactMatch, (v) => { unifiedViewState.isExactMatch = v; }, WholeWordIcon, 'Match Whole Word')}
+							<DropdownMenu.Root>
+								<DropdownMenu.Trigger>
+									{#snippet child({ props })}
+										<button
+											type="button"
+											class="flex items-center gap-0.5 rounded-sm px-1 py-0.5 text-[10px] font-medium text-muted-foreground hover:text-foreground hover:bg-accent"
+											{...props}
+										>
+											{({ all: 'All', title: 'Title', url: 'URL' } as const)[unifiedViewState.searchField]}
+											<ChevronDownIcon class="size-2.5" />
+										</button>
+									{/snippet}
+								</DropdownMenu.Trigger>
+								<DropdownMenu.Content align="end" class="w-28">
+									<DropdownMenu.RadioGroup bind:value={unifiedViewState.searchField}>
+										<DropdownMenu.RadioItem value="all">All Fields</DropdownMenu.RadioItem>
+										<DropdownMenu.RadioItem value="title">Title Only</DropdownMenu.RadioItem>
+										<DropdownMenu.RadioItem value="url">URL Only</DropdownMenu.RadioItem>
+									</DropdownMenu.RadioGroup>
+								</DropdownMenu.Content>
+							</DropdownMenu.Root>
+						</div>
+					{/if}
 				</div>
-				<ToggleGroup.Root
-					type="single"
-					size="sm"
-					variant="outline"
-					bind:value={unifiedViewState.searchField}
-					class="h-7"
-				>
-					<ToggleGroup.Item value="all" class="px-1.5 text-xs h-7">All</ToggleGroup.Item>
-					<ToggleGroup.Item value="title" class="px-1.5 text-xs h-7">Title</ToggleGroup.Item>
-					<ToggleGroup.Item value="url" class="px-1.5 text-xs h-7">URL</ToggleGroup.Item>
-				</ToggleGroup.Root>
 				<Button
 					variant="ghost"
 					size="icon-xs"

--- a/apps/tab-manager/src/entrypoints/sidepanel/App.svelte
+++ b/apps/tab-manager/src/entrypoints/sidepanel/App.svelte
@@ -124,7 +124,7 @@
 											class="flex items-center gap-0.5 rounded-sm px-1 py-0.5 text-[10px] font-medium text-muted-foreground hover:text-foreground hover:bg-accent"
 											{...props}
 										>
-											{({ all: 'All', title: 'Title', url: 'URL' } as const)[unifiedViewState.searchField]}
+									{({ all: 'All', title: 'Title', url: 'URL' })[unifiedViewState.searchField]}
 											<ChevronDownIcon class="size-2.5" />
 										</button>
 									{/snippet}

--- a/apps/tab-manager/src/entrypoints/sidepanel/App.svelte
+++ b/apps/tab-manager/src/entrypoints/sidepanel/App.svelte
@@ -30,6 +30,26 @@
 	let aiDrawerOpen = $state(false);
 </script>
 
+{#snippet searchToggle(pressed: boolean, onPressedChange: (v: boolean) => void, Icon: typeof CaseSensitiveIcon, label: string)}
+	<Tooltip.Root>
+		<Tooltip.Trigger>
+			{#snippet child({ props })}
+				<Toggle
+					size="sm"
+					{pressed}
+					{onPressedChange}
+					aria-label={label}
+					class="size-6 rounded-sm p-0"
+					{...props}
+				>
+					<Icon class="size-3.5" />
+				</Toggle>
+			{/snippet}
+		</Tooltip.Trigger>
+		<Tooltip.Content>{label}</Tooltip.Content>
+	</Tooltip.Root>
+{/snippet}
+
 <Tooltip.Provider>
 	<main
 		class="h-full w-full overflow-hidden flex flex-col bg-background text-foreground"
@@ -42,6 +62,7 @@
 					<SearchIcon
 						class="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
 					/>
+					<!-- pr-[5.5rem] = clear button + 3 toggles (size-6 each) + gaps -->
 					<Input
 						bind:ref={searchInputRef}
 						type="search"
@@ -79,54 +100,9 @@
 								<XIcon class="size-3.5" />
 							</button>
 						{/if}
-						<Tooltip.Root>
-							<Tooltip.Trigger>
-								{#snippet child({ props })}
-									<Toggle
-										size="sm"
-										bind:pressed={unifiedViewState.isCaseSensitive}
-										aria-label="Match Case"
-										class="size-6 rounded-sm p-0"
-										{...props}
-									>
-										<CaseSensitiveIcon class="size-3.5" />
-									</Toggle>
-								{/snippet}
-							</Tooltip.Trigger>
-							<Tooltip.Content>Match Case</Tooltip.Content>
-						</Tooltip.Root>
-						<Tooltip.Root>
-							<Tooltip.Trigger>
-								{#snippet child({ props })}
-									<Toggle
-										size="sm"
-										bind:pressed={unifiedViewState.isRegex}
-										aria-label="Use Regular Expression"
-										class="size-6 rounded-sm p-0"
-										{...props}
-									>
-										<RegexIcon class="size-3.5" />
-									</Toggle>
-								{/snippet}
-							</Tooltip.Trigger>
-							<Tooltip.Content>Use Regular Expression</Tooltip.Content>
-						</Tooltip.Root>
-						<Tooltip.Root>
-							<Tooltip.Trigger>
-								{#snippet child({ props })}
-									<Toggle
-										size="sm"
-										bind:pressed={unifiedViewState.isExactMatch}
-										aria-label="Match Whole Word"
-										class="size-6 rounded-sm p-0"
-										{...props}
-									>
-										<WholeWordIcon class="size-3.5" />
-									</Toggle>
-								{/snippet}
-							</Tooltip.Trigger>
-							<Tooltip.Content>Match Whole Word</Tooltip.Content>
-						</Tooltip.Root>
+					{@render searchToggle(unifiedViewState.isCaseSensitive, (v) => { unifiedViewState.isCaseSensitive = v; }, CaseSensitiveIcon, 'Match Case')}
+					{@render searchToggle(unifiedViewState.isRegex, (v) => { unifiedViewState.isRegex = v; }, RegexIcon, 'Use Regular Expression')}
+					{@render searchToggle(unifiedViewState.isExactMatch, (v) => { unifiedViewState.isExactMatch = v; }, WholeWordIcon, 'Match Whole Word')}
 					</div>
 				</div>
 				<ToggleGroup.Root

--- a/apps/tab-manager/src/lib/components/tabs/UnifiedTabList.svelte
+++ b/apps/tab-manager/src/lib/components/tabs/UnifiedTabList.svelte
@@ -10,7 +10,6 @@
 	import FolderOpenIcon from '@lucide/svelte/icons/folder-open';
 	import RotateCcwIcon from '@lucide/svelte/icons/rotate-ccw';
 	import SearchIcon from '@lucide/svelte/icons/search';
-	import StarIcon from '@lucide/svelte/icons/star';
 	import Trash2Icon from '@lucide/svelte/icons/trash-2';
 	import { VList } from 'virtua/svelte';
 	import { bookmarkState } from '$lib/state/bookmark-state.svelte';
@@ -193,9 +192,7 @@
 				{@const bookmark = item.bookmark}
 				<div class="border-b border-border">
 					<Item.Root size="sm" class="hover:bg-accent/50">
-						<Item.Media>
-							<StarIcon class="size-4 text-amber-500" />
-						</Item.Media>
+						<Item.Media> <TabFavicon src={bookmark.favIconUrl} /> </Item.Media>
 
 						<Item.Content>
 							<Item.Title>

--- a/apps/tab-manager/src/lib/components/tabs/UnifiedTabList.svelte
+++ b/apps/tab-manager/src/lib/components/tabs/UnifiedTabList.svelte
@@ -3,6 +3,7 @@
 	import { Button } from '@epicenter/ui/button';
 	import * as Empty from '@epicenter/ui/empty';
 	import * as Item from '@epicenter/ui/item';
+	import { toastOnError } from '@epicenter/ui/sonner';
 	import { cn } from '@epicenter/ui/utils';
 	import AppWindowIcon from '@lucide/svelte/icons/app-window';
 	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
@@ -19,7 +20,6 @@
 	import { getDomain, getRelativeTime } from '$lib/utils/format';
 	import TabFavicon from './TabFavicon.svelte';
 	import TabItem from './TabItem.svelte';
-	import { toastOnError } from '@epicenter/ui/sonner';
 </script>
 
 {#if unifiedViewState.flatItems.length === 0}
@@ -34,7 +34,11 @@
 		{#if unifiedViewState.isFiltering}
 			<Empty.Title>No matching tabs</Empty.Title>
 			<Empty.Description>
-				No tabs match "{unifiedViewState.searchQuery}"
+				{#if unifiedViewState.isRegex && unifiedViewState.isRegexInvalid}
+					Check your regular expression syntax
+				{:else}
+					No tabs match "{unifiedViewState.searchQuery}"
+				{/if}
 			</Empty.Description>
 		{:else}
 			<Empty.Title>No tabs found</Empty.Title>
@@ -95,7 +99,7 @@
 								variant="ghost"
 								size="icon-xs"
 								tooltip="Restore All"
-						onclick={() => savedTabState.restoreAll().then(toastOnError)}
+								onclick={() => savedTabState.restoreAll().then(toastOnError)}
 							>
 								<RotateCcwIcon />
 							</Button>
@@ -104,7 +108,7 @@
 								size="icon-xs"
 								class="text-destructive"
 								tooltip="Delete All"
-						onclick={() => savedTabState.removeAll().then(toastOnError)}
+								onclick={() => savedTabState.removeAll().then(toastOnError)}
 							>
 								<Trash2Icon />
 							</Button>
@@ -170,7 +174,7 @@
 								variant="ghost"
 								size="icon-xs"
 								tooltip="Restore"
-							onclick={() =>
+								onclick={() =>
 								savedTabState.restore(tab).then(toastOnError)}
 							>
 								<RotateCcwIcon />
@@ -180,7 +184,7 @@
 								size="icon-xs"
 								class="text-destructive"
 								tooltip="Delete"
-							onclick={() =>
+								onclick={() =>
 								savedTabState.remove(tab.id).then(toastOnError)}
 							>
 								<Trash2Icon />
@@ -214,7 +218,7 @@
 								variant="ghost"
 								size="icon-xs"
 								tooltip="Open"
-							onclick={() => bookmarkState.open(bookmark).then(toastOnError)}
+								onclick={() => bookmarkState.open(bookmark).then(toastOnError)}
 							>
 								<ExternalLinkIcon />
 							</Button>
@@ -223,7 +227,7 @@
 								size="icon-xs"
 								class="text-destructive"
 								tooltip="Delete"
-							onclick={() => bookmarkState.remove(bookmark.id).then(toastOnError)}
+								onclick={() => bookmarkState.remove(bookmark.id).then(toastOnError)}
 							>
 								<Trash2Icon />
 							</Button>

--- a/apps/tab-manager/src/lib/state/search-preferences.svelte.ts
+++ b/apps/tab-manager/src/lib/state/search-preferences.svelte.ts
@@ -11,13 +11,10 @@ import { type } from 'arktype';
 import { createStorageState } from './storage-state.svelte';
 
 /** Whether search matching is case-sensitive. */
-export const searchCaseSensitive = createStorageState(
-	'local:search.caseSensitive',
-	{
-		fallback: false,
-		schema: type('boolean'),
-	},
-);
+export const searchCaseSensitive = createStorageState('local:search.caseSensitive', {
+	fallback: false,
+	schema: type('boolean'),
+});
 
 /** Whether the search query is interpreted as a regular expression. */
 export const searchRegex = createStorageState('local:search.regex', {

--- a/apps/tab-manager/src/lib/state/search-preferences.svelte.ts
+++ b/apps/tab-manager/src/lib/state/search-preferences.svelte.ts
@@ -1,0 +1,38 @@
+/**
+ * Persisted search preferences backed by chrome.storage.local.
+ *
+ * Toggle states survive panel close/reopen and sync across extension
+ * contexts (popup, sidebar) via chrome.storage.onChanged.
+ *
+ * @see {@link ./storage-state.svelte} — chrome.storage reactive wrapper
+ */
+
+import { type } from 'arktype';
+import { createStorageState } from './storage-state.svelte';
+
+/** Whether search matching is case-sensitive. */
+export const searchCaseSensitive = createStorageState(
+	'local:search.caseSensitive',
+	{
+		fallback: false,
+		schema: type('boolean'),
+	},
+);
+
+/** Whether the search query is interpreted as a regular expression. */
+export const searchRegex = createStorageState('local:search.regex', {
+	fallback: false,
+	schema: type('boolean'),
+});
+
+/** Whether to match whole words (titles) or exact URLs. */
+export const searchExactMatch = createStorageState('local:search.exactMatch', {
+	fallback: false,
+	schema: type('boolean'),
+});
+
+/** Which fields to search: all, title only, or URL only. */
+export const searchField = createStorageState('local:search.field', {
+	fallback: 'all' as const,
+	schema: type("'all' | 'title' | 'url'"),
+});

--- a/apps/tab-manager/src/lib/state/unified-view-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/unified-view-state.svelte.ts
@@ -26,9 +26,19 @@
 
 import { SvelteSet } from 'svelte/reactivity';
 import { bookmarkState } from '$lib/state/bookmark-state.svelte';
+import type {
+	BrowserTab,
+	BrowserWindow,
+} from '$lib/state/browser-state.svelte';
 import { browserState } from '$lib/state/browser-state.svelte';
 import { savedTabState } from '$lib/state/saved-tab-state.svelte';
-import type { BrowserTab, BrowserWindow } from '$lib/state/browser-state.svelte';
+import {
+	searchCaseSensitive,
+	searchExactMatch,
+	searchField,
+	searchRegex,
+} from '$lib/state/search-preferences.svelte';
+import { normalizeUrl } from '$lib/utils/tab-helpers';
 import type { Bookmark, SavedTab } from '$lib/workspace';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -79,16 +89,84 @@ function createUnifiedViewState() {
 	/** Whether a search filter is currently active. */
 	const isFiltering = $derived(searchQuery.trim().length > 0);
 
-	/** Case-insensitive match against title and URL. */
+	/** Whether the current regex query has invalid syntax. */
+	const isRegexInvalid = $derived.by(() => {
+		if (!searchRegex.current || !isFiltering) return false;
+		try {
+			new RegExp(searchQuery);
+			return false;
+		} catch {
+			return true;
+		}
+	});
+
+	/** Escape special regex characters for safe use in `new RegExp()`. */
+	function escapeRegex(str: string): string {
+		return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	}
+
+	/** Match against title and/or URL based on current search preferences. */
 	function matchesFilter(
 		title: string | undefined,
 		url: string | undefined,
 	): boolean {
 		if (!isFiltering) return true;
-		const lower = searchQuery.toLowerCase();
-		const t = title?.toLowerCase() ?? '';
-		const u = url?.toLowerCase() ?? '';
-		return t.includes(lower) || u.includes(lower);
+
+		const field = searchField.current;
+		const isCaseSensitive = searchCaseSensitive.current;
+		const isRegex = searchRegex.current;
+		const isExact = searchExactMatch.current;
+
+		/** Test a single string against the current query using the active mode. */
+		function testField(value: string, fieldType: 'title' | 'url'): boolean {
+			if (isRegex) {
+				try {
+					const re = new RegExp(searchQuery, isCaseSensitive ? '' : 'i');
+					return re.test(value);
+				} catch {
+					return false;
+				}
+			}
+
+			if (isExact) {
+				if (fieldType === 'title') {
+					// Whole-word boundary match for titles
+					try {
+						const re = new RegExp(
+							`\\b${escapeRegex(searchQuery)}\\b`,
+							isCaseSensitive ? '' : 'i',
+						);
+						return re.test(value);
+					} catch {
+						return false;
+					}
+				}
+				// Exact URL match after normalization
+				const normalizedValue = normalizeUrl(value);
+				const normalizedQuery = normalizeUrl(searchQuery);
+				if (isCaseSensitive) {
+					return normalizedValue === normalizedQuery;
+				}
+				return normalizedValue.toLowerCase() === normalizedQuery.toLowerCase();
+			}
+
+			// Default: substring includes
+			const q = isCaseSensitive ? searchQuery : searchQuery.toLowerCase();
+			const v = isCaseSensitive ? value : value.toLowerCase();
+			return v.includes(q);
+		}
+
+		const t = title ?? '';
+		const u = url ?? '';
+
+		switch (field) {
+			case 'title':
+				return testField(t, 'title');
+			case 'url':
+				return testField(u, 'url');
+			case 'all':
+				return testField(t, 'title') || testField(u, 'url');
+		}
 	}
 
 	/**
@@ -265,6 +343,45 @@ function createUnifiedViewState() {
 		/** Check if a window is expanded. */
 		isWindowExpanded(windowId: number): boolean {
 			return expandedWindows.has(windowId);
+		},
+
+		/** Whether search matching is case-sensitive. Persisted to chrome.storage. */
+		get isCaseSensitive() {
+			return searchCaseSensitive.current;
+		},
+		set isCaseSensitive(value: boolean) {
+			searchCaseSensitive.current = value;
+		},
+
+		/** Whether the query is a regular expression. Mutually exclusive with exactMatch. */
+		get isRegex() {
+			return searchRegex.current;
+		},
+		set isRegex(value: boolean) {
+			searchRegex.current = value;
+			if (value) searchExactMatch.current = false;
+		},
+
+		/** Whether to match whole words (titles) or exact URLs. Mutually exclusive with regex. */
+		get isExactMatch() {
+			return searchExactMatch.current;
+		},
+		set isExactMatch(value: boolean) {
+			searchExactMatch.current = value;
+			if (value) searchRegex.current = false;
+		},
+
+		/** Which fields to search: all, title only, or URL only. */
+		get searchField() {
+			return searchField.current;
+		},
+		set searchField(value: 'all' | 'title' | 'url') {
+			searchField.current = value;
+		},
+
+		/** Whether the current regex pattern has invalid syntax. */
+		get isRegexInvalid() {
+			return isRegexInvalid;
 		},
 	};
 }

--- a/apps/tab-manager/src/lib/state/unified-view-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/unified-view-state.svelte.ts
@@ -89,7 +89,6 @@ function createUnifiedViewState() {
 	/** Whether a search filter is currently active. */
 	const isFiltering = $derived(searchQuery.trim().length > 0);
 
-
 	/**
 	 * Pre-compiled regex for the current search query.
 	 * Null when regex mode is off, query is empty, or the pattern is invalid.

--- a/apps/tab-manager/src/lib/state/unified-view-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/unified-view-state.svelte.ts
@@ -89,20 +89,63 @@ function createUnifiedViewState() {
 	/** Whether a search filter is currently active. */
 	const isFiltering = $derived(searchQuery.trim().length > 0);
 
-	/** Whether the current regex query has invalid syntax. */
-	const isRegexInvalid = $derived.by(() => {
-		if (!searchRegex.current || !isFiltering) return false;
+
+	/**
+	 * Pre-compiled regex for the current search query.
+	 * Null when regex mode is off, query is empty, or the pattern is invalid.
+	 * Computed once per reactive change—avoids recompiling per tab.
+	 */
+	const compiledRegex = $derived.by(() => {
+		if (!searchRegex.current || !isFiltering) return null;
 		try {
-			new RegExp(searchQuery);
-			return false;
+			return new RegExp(searchQuery, searchCaseSensitive.current ? '' : 'i');
 		} catch {
-			return true;
+			return null;
 		}
 	});
+
+	/** Whether the current regex query has invalid syntax. */
+	const isRegexInvalid = $derived(
+		searchRegex.current && isFiltering && compiledRegex === null,
+	);
 
 	/** Escape special regex characters for safe use in `new RegExp()`. */
 	function escapeRegex(str: string): string {
 		return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	}
+
+	/** Test a single field value against the current search query using the active mode. */
+	function testField(value: string, fieldType: 'title' | 'url'): boolean {
+		if (searchRegex.current) {
+			return compiledRegex?.test(value) ?? false;
+		}
+
+		if (searchExactMatch.current) {
+			if (fieldType === 'title') {
+				// Whole-word boundary match for titles
+				try {
+					const re = new RegExp(
+						`\\b${escapeRegex(searchQuery)}\\b`,
+						searchCaseSensitive.current ? '' : 'i',
+					);
+					return re.test(value);
+				} catch {
+					return false;
+				}
+			}
+			// Exact URL match after normalization
+			const normalizedValue = normalizeUrl(value);
+			const normalizedQuery = normalizeUrl(searchQuery);
+			if (searchCaseSensitive.current) {
+				return normalizedValue === normalizedQuery;
+			}
+			return normalizedValue.toLowerCase() === normalizedQuery.toLowerCase();
+		}
+
+		// Default: substring includes
+		const q = searchCaseSensitive.current ? searchQuery : searchQuery.toLowerCase();
+		const v = searchCaseSensitive.current ? value : value.toLowerCase();
+		return v.includes(q);
 	}
 
 	/** Match against title and/or URL based on current search preferences. */
@@ -112,54 +155,10 @@ function createUnifiedViewState() {
 	): boolean {
 		if (!isFiltering) return true;
 
-		const field = searchField.current;
-		const isCaseSensitive = searchCaseSensitive.current;
-		const isRegex = searchRegex.current;
-		const isExact = searchExactMatch.current;
-
-		/** Test a single string against the current query using the active mode. */
-		function testField(value: string, fieldType: 'title' | 'url'): boolean {
-			if (isRegex) {
-				try {
-					const re = new RegExp(searchQuery, isCaseSensitive ? '' : 'i');
-					return re.test(value);
-				} catch {
-					return false;
-				}
-			}
-
-			if (isExact) {
-				if (fieldType === 'title') {
-					// Whole-word boundary match for titles
-					try {
-						const re = new RegExp(
-							`\\b${escapeRegex(searchQuery)}\\b`,
-							isCaseSensitive ? '' : 'i',
-						);
-						return re.test(value);
-					} catch {
-						return false;
-					}
-				}
-				// Exact URL match after normalization
-				const normalizedValue = normalizeUrl(value);
-				const normalizedQuery = normalizeUrl(searchQuery);
-				if (isCaseSensitive) {
-					return normalizedValue === normalizedQuery;
-				}
-				return normalizedValue.toLowerCase() === normalizedQuery.toLowerCase();
-			}
-
-			// Default: substring includes
-			const q = isCaseSensitive ? searchQuery : searchQuery.toLowerCase();
-			const v = isCaseSensitive ? value : value.toLowerCase();
-			return v.includes(q);
-		}
-
 		const t = title ?? '';
 		const u = url ?? '';
 
-		switch (field) {
+		switch (searchField.current) {
 			case 'title':
 				return testField(t, 'title');
 			case 'url':

--- a/apps/tab-manager/src/lib/utils/tab-helpers.ts
+++ b/apps/tab-manager/src/lib/utils/tab-helpers.ts
@@ -34,7 +34,7 @@ import { getDomain } from '$lib/utils/format';
  * // 'https://example.com/page?a=1&b=2'
  * ```
  */
-function normalizeUrl(url: string): string {
+export function normalizeUrl(url: string): string {
 	try {
 		const parsed = new URL(url);
 		parsed.hash = '';

--- a/specs/20260405T180000 tab-search-modes.md
+++ b/specs/20260405T180000 tab-search-modes.md
@@ -1,0 +1,331 @@
+# Tab Search Modes
+
+**Date**: 2026-04-05
+**Status**: Implemented
+**Author**: AI-assisted
+
+## Overview
+
+Add VS Code-style search mode toggles (case-sensitive, regex, whole word/exact) and a field scope selector to the tab manager's search input. Currently, search is a single case-insensitive substring match across title and URL with no way to refine matching behavior.
+
+## Motivation
+
+### Current State
+
+```ts
+// unified-view-state.svelte.ts — the entire filter logic
+function matchesFilter(title: string | undefined, url: string | undefined): boolean {
+  if (!isFiltering) return true;
+  const lower = searchQuery.toLowerCase();
+  const t = title?.toLowerCase() ?? '';
+  const u = url?.toLowerCase() ?? '';
+  return t.includes(lower) || u.includes(lower);
+}
+```
+
+One mode, no options, no way to:
+
+1. **Match case**: Searching `React` also matches `react-router` and `reactive`—can't distinguish
+2. **Use regex**: Can't search for URL patterns like `github.com/*/pull/*`
+3. **Match precisely**: Searching `log` matches `dialog`, `catalog`, `blog`—no word boundary support
+4. **Target a field**: Can't search only URLs (e.g., find all tabs on a specific domain) without title noise polluting results
+
+### Desired State
+
+Three inline toggles next to the search input plus a field scope selector:
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ 🔍  Search tabs...              [All ▾]  [Aa] [.*] [ab|]   │
+│                                  ↑        ↑    ↑    ↑       │
+│                       field scope┘  case──┘    │    │       │
+│                                       regex────┘    │       │
+│                                 exact/whole word────┘       │
+└──────────────────────────────────────────────────────────────┘
+```
+
+## Research Findings
+
+### Components Available in packages/ui
+
+| Component | Import | Relevant Props | Notes |
+|---|---|---|---|
+| Toggle | `@epicenter/ui/toggle` | `pressed` (bindable), `size`, `variant` | `data-[state=on]:bg-accent` styling built-in |
+| ToggleGroup | `@epicenter/ui/toggle-group` | `value` (bindable), `type`, `size`, `variant` | For field scope selector |
+| Button | `@epicenter/ui/button` | `tooltip`, `variant`, `size` | Has built-in `tooltip` prop |
+| Input | `@epicenter/ui/input` | `value` (bindable), `type` | Current search input |
+| Tooltip | `@epicenter/ui/tooltip` | Provider/Root/Trigger/Content | Already wrapping the app |
+
+### Lucide Icons Available
+
+All three VS Code search icons exist in `@lucide/svelte`:
+
+| Icon | Import path | Visual | Purpose |
+|---|---|---|---|
+| CaseSensitive | `@lucide/svelte/icons/case-sensitive` | `Aa` | Case-sensitive toggle |
+| Regex | `@lucide/svelte/icons/regex` | `.*` | Regex toggle |
+| WholeWord | `@lucide/svelte/icons/whole-word` | `ab\|` | Whole word / exact match toggle |
+
+### Existing Toggle Patterns in the Codebase
+
+The honeycrisp editor already uses Toggle + Tooltip for formatting buttons:
+
+```svelte
+<!-- apps/honeycrisp/src/lib/editor/Editor.svelte -->
+<Toggle size="sm" {pressed} onPressedChange={onToggle}>
+  <svelte:component this={icon} class="size-4" />
+</Toggle>
+```
+
+The whispering app uses ToggleGroup for mode switching:
+
+```svelte
+<!-- apps/whispering/src/routes/(app)/+page.svelte -->
+<ToggleGroup.Root type="single" size="sm" bind:value={mode}>
+  <ToggleGroup.Item value="manual">...</ToggleGroup.Item>
+</ToggleGroup.Root>
+```
+
+### Whole Word vs Exact Match Behavior
+
+The `ab|` icon in VS Code means "whole word" (word boundary match). But word boundaries behave differently for titles vs URLs:
+
+| Field | "Whole word" behavior | Why |
+|---|---|---|
+| **Title** | Word boundary (`\bterm\b`) | Titles are natural language—`log` should match "error log" but not "dialog" |
+| **URL** | Full URL exact match (with normalization) | URLs don't have word boundaries in a meaningful way; exact URL match is what's useful |
+
+The `normalizeUrl()` function in `tab-helpers.ts` already handles URL normalization (strips fragments, sorts params).
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Individual Toggles vs ToggleGroup for modes | Individual `Toggle` components | Modes are composable (regex + case-sensitive); ToggleGroup enforces mutual exclusivity |
+| Field scope selector | ToggleGroup with `type="single"` | Mutually exclusive (All / Title / URL); ToggleGroup is the right primitive |
+| Tooltip on toggles | Wrap with Tooltip (honeycrisp pattern) | Toggle doesn't have a built-in `tooltip` prop like Button does |
+| Regex error handling | Show no results on invalid regex | Don't surface regex syntax errors in the UI; typing `/[/` mid-edit shouldn't flash error banners |
+| Whole word for titles, exact for URLs | Different behavior per field type | Word boundary makes sense for natural language (titles); full match makes sense for structured data (URLs) |
+| Position of toggles | Inside search input, right-aligned | Follows VS Code pattern; keeps header compact |
+| Position of field scope | Between input and toggles | Groups "where to search" before "how to search" |
+
+## Architecture
+
+### Persistence
+
+Toggle states persist via `createStorageState` from `storage-state.svelte.ts` — the existing
+pattern used by `serverUrl`, `remoteServerUrl`, and `session`. This uses WXT's `@wxt-dev/storage`
+which wraps `chrome.storage.local` with reactive Svelte 5 state, schema validation via arktype,
+and cross-context sync (changes in popup reflect in sidebar).
+
+A new file `search-preferences.svelte.ts` exports four persisted states:
+
+```ts
+// search-preferences.svelte.ts
+import { type } from 'arktype';
+import { createStorageState } from './storage-state.svelte';
+
+export const searchCaseSensitive = createStorageState('local:search.caseSensitive', {
+  fallback: false,
+  schema: type('boolean'),
+});
+
+export const searchRegex = createStorageState('local:search.regex', {
+  fallback: false,
+  schema: type('boolean'),
+});
+
+export const searchExactMatch = createStorageState('local:search.exactMatch', {
+  fallback: false,
+  schema: type('boolean'),
+});
+
+export const searchField = createStorageState('local:search.field', {
+  fallback: 'all' as const,
+  schema: type("'all' | 'title' | 'url'"),
+});
+```
+
+`unified-view-state.svelte.ts` reads `.current` from these instead of local `$state`. The
+`.current` accessor is already reactive, so the existing `$derived` chain picks it up automatically.
+
+### State Shape
+
+```
+search-preferences.svelte.ts (NEW — persisted via chrome.storage.local)
+├── searchCaseSensitive.current: boolean
+├── searchRegex.current: boolean
+├── searchExactMatch.current: boolean
+└── searchField.current: 'all' | 'title' | 'url'
+
+unified-view-state.svelte.ts (reads from search-preferences)
+├── searchQuery: string              (existing, local $state — NOT persisted)
+├── isFiltering: boolean             (existing, derived)
+├── matchesFilter(title, url)        (existing, updated to read preferences)
+└── flatItems: FlatItem[]            (existing, unchanged)
+
+### Filter Logic Flow
+
+```
+searchQuery + modes + field
+        │
+        ▼
+┌─────────────────────────┐
+│   matchesFilter(t, u)   │
+│                         │
+│  1. Select fields based │
+│     on searchField      │
+│  2. Apply match mode:   │
+│     - regex → RegExp    │
+│     - exact → boundary  │
+│       or === by field   │
+│     - default → includes│
+│  3. Case sensitivity    │
+│     applied throughout  │
+└─────────────────────────┘
+        │
+        ▼
+  flatItems (unchanged consumer)
+```
+
+### UI Layout
+
+```
+┌─ header ──────────────────────────────────────────────────────────┐
+│ ┌─ relative flex-1 (search container) ──────────────────────────┐ │
+│ │ 🔍  [        search input        ] [scope] [Aa] [.*] [ab|]   │ │
+│ │  ↑                                   ↑      └─ toggles ──┘   │ │
+│ │  search icon (existing)              field scope (new)        │ │
+│ └───────────────────────────────────────────────────────────────┘ │
+│ [⌘] [⚡] [sync]  ← existing buttons, unchanged                   │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+## Implementation Plan
+
+### Phase 1: Persistence + State
+
+- [x] **1.1** Create `apps/tab-manager/src/lib/state/search-preferences.svelte.ts` with four `createStorageState` exports (see Architecture > Persistence)
+- [x] **1.2** Export `normalizeUrl` from `tab-helpers.ts` (add `export` keyword to the existing function)
+- [x] **1.3** Add `escapeRegex(str)` utility to `unified-view-state.svelte.ts` (escape special regex chars for whole-word boundary construction)
+- [x] **1.4** Import the four search preferences into `unified-view-state.svelte.ts` and read `.current` inside `matchesFilter`
+- [x] **1.5** Rewrite `matchesFilter` to respect all modes:
+  - Read `searchField.current` to determine which fields to test
+  - Read `searchRegex.current`: construct `RegExp` from query, catch invalid patterns, return `false` on error
+  - Read `searchExactMatch.current`: whole-word (`\bterm\b`) for titles, normalized exact match (`===` after `normalizeUrl`) for URLs
+  - Default mode: substring `includes` (current behavior)
+  - `searchCaseSensitive.current` applied at every level
+- [x] **1.6** Add `isRegexInvalid` derived for the UI to hint at bad regex
+- [x] **1.7** Expose preferences via getters/setters in the return object that proxy to the `createStorageState` `.current` accessor, with mutual exclusivity logic (setting regex=true sets exactMatch=false and vice versa)
+
+### Phase 2: UI — Toggles
+
+- [x] **2.1** Import `Toggle` from `@epicenter/ui/toggle` and the three Lucide icons in `App.svelte`
+- [x] **2.2** Add three `Toggle` components inside the search input's relative container, right-aligned
+- [x] **2.3** Bind each toggle's `pressed` to the corresponding state: `unifiedViewState.isCaseSensitive`, etc.
+- [x] **2.4** Wrap each toggle with `Tooltip.Root`/`Tooltip.Trigger`/`Tooltip.Content` for labels: "Match Case", "Use Regular Expression", "Match Whole Word"
+- [x] **2.5** Style toggles to fit inside the input: `class="size-6 rounded-sm p-0"`; compact feel matching existing icon buttons
+- [x] **2.6** Adjust input padding-right to `pr-[5.5rem]` to make room for the toggles
+- [x] **2.7** Keep the clear (X) button; position it before the toggles
+
+### Phase 3: UI — Field Scope
+
+- [x] **3.1** Import `ToggleGroup` from `@epicenter/ui/toggle-group` in `App.svelte`
+- [x] **3.2** Add a compact ToggleGroup with three items: All / Title / URL
+- [x] **3.3** Bind `value` to `unifiedViewState.searchField`
+- [x] **3.4** Position between the search input area and the existing header buttons
+- [x] **3.5** Use `size="sm"` and `variant="outline"` to keep it subtle
+
+### Phase 4: Polish
+
+- [x] **4.1** Verify that toggling modes on/off while typing updates results reactively (they should—`$derived` chain)
+- [x] **4.2** Verify keyboard shortcuts still work (/, @, Escape) with toggles present
+- [x] **4.3** Update the empty state message: when regex is active and no results, hint that the regex might be invalid
+- [x] **4.4** Run `lsp_diagnostics` on changed files
+- [ ] **4.5** Manual smoke test: try each mode combination, verify results make sense
+
+## Edge Cases
+
+### Invalid Regex
+
+1. User enables regex toggle
+2. Types `[` (incomplete regex)
+3. `new RegExp('[')` throws
+4. Catch and return `false`—no results shown, no error banner
+5. As they finish typing `[a-z]`, results appear naturally
+
+### Regex + Case-Sensitive Interaction
+
+1. Regex mode: flags come from `isCaseSensitive` — `new RegExp(query, isCaseSensitive ? '' : 'i')`
+2. Both toggles compose naturally
+
+### Exact Match + Field Scope Interaction
+
+1. Field = "All": whole-word on title OR exact on URL (either matches)
+2. Field = "Title": whole-word on title only
+3. Field = "URL": exact URL match only
+4. Exact match + regex are mutually exclusive in behavior—if both are on, regex takes priority (regex is the more powerful mode)
+
+### Empty Query with Toggles Active
+
+1. Toggle states persist when query is cleared
+2. This is intentional—user expects modes to be "sticky" for the next search
+3. `isFiltering` is still derived from `searchQuery.trim().length > 0`, so empty query = show all regardless of toggle state
+
+### Clear Button Interaction
+
+1. Clear (X) button clears the search query only, does NOT reset toggle states
+2. This matches VS Code behavior—clearing the search text doesn't reset case-sensitive/regex/whole-word toggles
+
+## Resolved Decisions
+
+1. **Regex and exact match are mutually exclusive.** Turning on regex turns off exact match and vice versa. Implemented via `onPressedChange` callbacks + the `createStorageState` setters.
+
+2. **Field scope selector is always visible.** It's three short labels (All / Title / URL) and the header has room.
+
+3. **Toggle states persist via `chrome.storage.local`** using WXT's `@wxt-dev/storage` through the existing `createStorageState` pattern (see Architecture > Persistence above). NOT `localStorage`—this is a Chrome extension, so `chrome.storage.local` is the correct API. The `createStorageState` wrapper handles reactive Svelte 5 state, arktype schema validation, and cross-context sync.
+## Success Criteria
+
+- [ ] Case-sensitive toggle filters correctly (verified with mixed-case tab titles)
+- [ ] Regex toggle accepts valid patterns and produces correct results
+- [ ] Invalid regex shows no results (not an error)
+- [ ] Whole word matches `log` in "error log" but not in "dialog" (title)
+- [ ] Exact URL match finds an exact page but not partial matches (URL)
+- [ ] Field scope restricts search to the selected field
+- [ ] All toggle combinations compose correctly
+- [ ] Existing keyboard shortcuts (/, @, Escape) still work
+- [ ] No TypeScript errors (`lsp_diagnostics` clean)
+- [ ] UI feels native—toggles are compact, discoverable via tooltips, and follow the existing header style
+- [ ] Toggle states persist across panel close/reopen (chrome.storage.local)
+
+## References
+
+- `apps/tab-manager/src/lib/state/unified-view-state.svelte.ts` — State + filter logic (primary change)
+- `apps/tab-manager/src/entrypoints/sidepanel/App.svelte` — Search UI (primary change)
+- `apps/tab-manager/src/lib/components/tabs/UnifiedTabList.svelte` — Renders filtered results (empty state message update)
+- `apps/tab-manager/src/lib/utils/tab-helpers.ts` — `normalizeUrl()` for exact URL matching
+- `packages/ui/src/toggle/toggle.svelte` — Toggle component API
+- `packages/ui/src/toggle-group/toggle-group.svelte` — ToggleGroup component API
+- `apps/honeycrisp/src/lib/editor/Editor.svelte` — Toggle + Tooltip usage pattern to follow
+- `apps/tab-manager/src/lib/state/storage-state.svelte.ts` — `createStorageState` utility for chrome.storage.local persistence
+- `apps/tab-manager/src/lib/state/settings.svelte.ts` — Existing usage pattern for `createStorageState`
+- `apps/tab-manager/src/lib/auth.ts` — Another `createStorageState` consumer (session persistence)
+
+## Review
+
+**Completed**: 2026-04-05
+
+### Summary
+
+Added VS Code-style search mode toggles (case-sensitive, regex, whole-word) and a field scope selector (All/Title/URL) to the tab manager search input. Toggle states persist to `chrome.storage.local` via the existing `createStorageState` pattern. The `matchesFilter` function now supports regex matching, whole-word boundary matching for titles, normalized exact URL matching, and field-scoped search—all composable with case sensitivity.
+
+### Deviations from Spec
+
+- Toggle sizing landed at `size-6 rounded-sm p-0` rather than the originally estimated `size-5`. Looks better at this size in the actual header context.
+- Input padding-right is `pr-[5.5rem]` (arbitrary Tailwind value) to accommodate the 3 toggles + clear button.
+
+### Follow-up Work
+
+- **4.5**: Manual smoke test still needed—try each mode combination in the actual extension to verify results make sense.
+- Consider adding match highlighting in tab titles/URLs when search is active (bold the matched substring).
+- Consider adding a keyboard shortcut to cycle through search modes (e.g., Alt+C for case, Alt+R for regex).

--- a/specs/20260405T180000 tab-search-modes.prompt.md
+++ b/specs/20260405T180000 tab-search-modes.prompt.md
@@ -1,0 +1,317 @@
+# Execution Prompt: Tab Search Modes
+
+> Hand this prompt to an agent with the spec at `specs/20260405T180000 tab-search-modes.md`.
+
+## Task
+
+Implement VS Code-style search mode toggles and a field scope selector for the tab manager's search input. The spec has the full design—read it first.
+
+## Context
+
+- **Monorepo**: Bun-based, Svelte 5 with runes, shadcn-svelte (bits-ui primitives), Tailwind CSS
+- **Skills to load**: `svelte`, `styling`, `typescript`, `monorepo`
+- **Primary changes**: 5 files (1 new, 4 modified)
+- **Storage**: Chrome extension uses WXT's `@wxt-dev/storage` (wraps `chrome.storage.local`), NOT `localStorage`. See `storage-state.svelte.ts` for the reactive wrapper.
+
+## Execution Order
+
+Work in this exact order. Each step is atomic—verify before moving on.
+
+### Step 1: Create Search Preferences (`search-preferences.svelte.ts`)
+
+Create a new file at `apps/tab-manager/src/lib/state/search-preferences.svelte.ts`.
+
+This file persists the four search toggle states via `createStorageState`, which uses WXT's `@wxt-dev/storage` to persist to `chrome.storage.local` with reactive Svelte 5 state and arktype schema validation.
+
+Follow the exact pattern from `settings.svelte.ts`:
+
+```ts
+/**
+ * Persisted search preferences backed by chrome.storage.local.
+ *
+ * Toggle states survive panel close/reopen and sync across extension
+ * contexts (popup, sidebar) via chrome.storage.onChanged.
+ *
+ * @see {@link ./storage-state.svelte} — chrome.storage reactive wrapper
+ */
+
+import { type } from 'arktype';
+import { createStorageState } from './storage-state.svelte';
+
+/** Whether search matching is case-sensitive. */
+export const searchCaseSensitive = createStorageState('local:search.caseSensitive', {
+  fallback: false,
+  schema: type('boolean'),
+});
+
+/** Whether the search query is interpreted as a regular expression. */
+export const searchRegex = createStorageState('local:search.regex', {
+  fallback: false,
+  schema: type('boolean'),
+});
+
+/** Whether to match whole words (titles) or exact URLs. */
+export const searchExactMatch = createStorageState('local:search.exactMatch', {
+  fallback: false,
+  schema: type('boolean'),
+});
+
+/** Which fields to search: all, title only, or URL only. */
+export const searchField = createStorageState('local:search.field', {
+  fallback: 'all' as const,
+  schema: type("'all' | 'title' | 'url'"),
+});
+```
+
+**MUST DO**:
+- Follow the JSDoc style from `settings.svelte.ts` and `auth.ts`
+- Use `local:search.*` key prefix to namespace under "search"
+- Use arktype schemas for validation
+
+**Verify**: Run `lsp_diagnostics` on the new file.
+
+### Step 2: Export normalizeUrl (`tab-helpers.ts`)
+
+In `apps/tab-manager/src/lib/utils/tab-helpers.ts`, `normalizeUrl` is currently a private function. Add `export` to it:
+
+```ts
+export function normalizeUrl(url: string): string {
+```
+
+That's the only change to this file.
+
+**Verify**: Run `lsp_diagnostics` on the file.
+
+### Step 3: State + Filter Logic (`unified-view-state.svelte.ts`)
+
+Read the existing file at `apps/tab-manager/src/lib/state/unified-view-state.svelte.ts`.
+
+Add imports for the search preferences and normalizeUrl:
+
+```ts
+import {
+  searchCaseSensitive,
+  searchRegex,
+  searchExactMatch,
+  searchField,
+} from '$lib/state/search-preferences.svelte';
+import { normalizeUrl } from '$lib/utils/tab-helpers';
+```
+
+Add a regex escape utility inside `createUnifiedViewState()`, above `matchesFilter`:
+
+```ts
+/** Escape special regex characters for safe use in `new RegExp()`. */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+```
+
+Rewrite `matchesFilter`. The logic:
+
+1. If not filtering, return true (unchanged)
+2. Read `searchField.current` to determine which fields to test
+3. For each field being tested, apply the match mode:
+   - **Regex mode** (`searchRegex.current`): construct `new RegExp(searchQuery, searchCaseSensitive.current ? '' : 'i')`. Wrap in try/catch—return `false` on invalid regex. Test against the raw field value.
+   - **Exact match mode** (`searchExactMatch.current`):
+     - For **title**: whole-word boundary match using `new RegExp('\\b' + escapeRegex(q) + '\\b', flags)`
+     - For **URL**: exact match after normalization — `normalizeUrl(url) === normalizeUrl(searchQuery)`
+   - **Default mode**: substring `includes` (current behavior, but now respecting `searchCaseSensitive.current`)
+4. Return true if ANY tested field matches
+
+Add an `isRegexInvalid` derived for the UI:
+
+```ts
+const isRegexInvalid = $derived.by(() => {
+  if (!searchRegex.current || !isFiltering) return false;
+  try { new RegExp(searchQuery); return false; }
+  catch { return true; }
+});
+```
+
+Update the return object. Add proxy getters/setters that:
+- Read/write `.current` on the corresponding `createStorageState` export
+- Enforce mutual exclusivity: setting `isRegex = true` sets `searchExactMatch.current = false` and vice versa
+
+```ts
+return {
+  // ... existing properties ...
+
+  /** Whether search matching is case-sensitive. Persisted to chrome.storage. */
+  get isCaseSensitive() { return searchCaseSensitive.current; },
+  set isCaseSensitive(value: boolean) { searchCaseSensitive.current = value; },
+
+  /** Whether the query is interpreted as a regular expression. Persisted. Mutually exclusive with exactMatch. */
+  get isRegex() { return searchRegex.current; },
+  set isRegex(value: boolean) {
+    searchRegex.current = value;
+    if (value) searchExactMatch.current = false;
+  },
+
+  /** Whether to match whole words (titles) or exact URLs. Persisted. Mutually exclusive with regex. */
+  get isExactMatch() { return searchExactMatch.current; },
+  set isExactMatch(value: boolean) {
+    searchExactMatch.current = value;
+    if (value) searchRegex.current = false;
+  },
+
+  /** Which fields to search. Persisted. */
+  get searchField() { return searchField.current; },
+  set searchField(value: 'all' | 'title' | 'url') { searchField.current = value; },
+
+  /** Whether the current regex pattern is invalid. */
+  get isRegexInvalid() { return isRegexInvalid; },
+};
+```
+
+**MUST DO**:
+- Keep the `flatItems` derivation completely unchanged—it already calls `matchesFilter`, so it picks up the new behavior automatically
+- The `$derived` chain will reactively pick up `.current` changes from `createStorageState` because the wrapper uses `$state` internally
+- Do NOT add any `$state` for the toggle values—they live in `search-preferences.svelte.ts`
+
+**MUST NOT DO**:
+- Don't change the `FlatItem` type
+- Don't change `flatItems` derivation logic
+- Don't change section expansion behavior
+- Don't use `localStorage`—this is a Chrome extension, use the `createStorageState` pattern
+
+**Verify**: Run `lsp_diagnostics` on the file after changes.
+
+### Step 4: UI — Search Toggles + Field Scope (`App.svelte`)
+
+Read `apps/tab-manager/src/entrypoints/sidepanel/App.svelte`.
+
+Add imports:
+
+```ts
+import { Toggle } from '@epicenter/ui/toggle';
+import * as ToggleGroup from '@epicenter/ui/toggle-group';
+import * as Tooltip from '@epicenter/ui/tooltip';
+import CaseSensitiveIcon from '@lucide/svelte/icons/case-sensitive';
+import RegexIcon from '@lucide/svelte/icons/regex';
+import WholeWordIcon from '@lucide/svelte/icons/whole-word';
+```
+
+Note: `Tooltip` is already available via `@epicenter/ui/tooltip` and the app is wrapped in `<Tooltip.Provider>`.
+
+Restructure the search input area. The current layout is:
+
+```
+<div class="relative flex-1">
+  <SearchIcon ... />
+  <Input ... class="h-8 pl-8 pr-8 ..." />
+  {#if searchQuery} <button (clear)> {/if}
+</div>
+```
+
+The new layout should be:
+
+```
+<div class="relative flex-1">
+  <SearchIcon ... />
+  <Input ... class="h-8 pl-8 pr-24 ..." />  <!-- more right padding -->
+  <div class="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
+    {#if unifiedViewState.searchQuery}
+      <button (clear)> ... </button>
+    {/if}
+    <!-- Three toggles with tooltips -->
+  </div>
+</div>
+```
+
+For each toggle, use the honeycrisp pattern (Toggle wrapped in Tooltip):
+
+```svelte
+<Tooltip.Root>
+  <Tooltip.Trigger>
+    {#snippet child({ props })}
+      <Toggle
+        size="sm"
+        bind:pressed={unifiedViewState.isCaseSensitive}
+        aria-label="Match Case"
+        class="size-6 rounded-sm p-0"
+        {...props}
+      >
+        <CaseSensitiveIcon class="size-3.5" />
+      </Toggle>
+    {/snippet}
+  </Tooltip.Trigger>
+  <Tooltip.Content>Match Case</Tooltip.Content>
+</Tooltip.Root>
+```
+
+Repeat for regex ("Use Regular Expression") and whole word ("Match Whole Word").
+
+**IMPORTANT**: The Toggle wrapping in Tooltip requires the `{#snippet child({ props })}` pattern to forward trigger props. This is how bits-ui tooltip triggers work with custom components. Look at how `Button` does it in `packages/ui/src/button/button.svelte` for reference.
+
+Add the field scope ToggleGroup. Place it after the search input `<div>` and before the Commands button:
+
+```svelte
+<ToggleGroup.Root
+  type="single"
+  size="sm"
+  variant="outline"
+  bind:value={unifiedViewState.searchField}
+  class="h-7"
+>
+  <ToggleGroup.Item value="all" class="px-1.5 text-xs h-7">All</ToggleGroup.Item>
+  <ToggleGroup.Item value="title" class="px-1.5 text-xs h-7">Title</ToggleGroup.Item>
+  <ToggleGroup.Item value="url" class="px-1.5 text-xs h-7">URL</ToggleGroup.Item>
+</ToggleGroup.Root>
+```
+
+**MUST DO**:
+- Increase input `pr-*` padding to make room for toggles (calculate based on 3 toggles × size-6 + gaps + clear button)
+- Keep all existing keyboard shortcuts (/, @, Escape) working—they're in the `onkeydown` handler on the Input, which doesn't change
+- Keep the existing Commands, AI Chat, and Sync buttons unchanged
+- Ensure toggles are vertically centered within the input
+
+**MUST NOT DO**:
+- Don't remove any existing functionality
+- Don't change the Tooltip.Provider wrapping—it already exists at the top of the template
+- Don't add any new dependencies
+
+**Verify**: Run `lsp_diagnostics` on App.svelte.
+
+### Step 5: Empty State Update (`UnifiedTabList.svelte`)
+
+Read `apps/tab-manager/src/lib/components/tabs/UnifiedTabList.svelte`.
+
+Update the "No matching tabs" empty state to hint about regex when relevant:
+
+```svelte
+{#if unifiedViewState.isFiltering}
+  <Empty.Title>No matching tabs</Empty.Title>
+  <Empty.Description>
+    {#if unifiedViewState.isRegex && unifiedViewState.isRegexInvalid}
+      Check your regular expression syntax
+    {:else}
+      No tabs match "{unifiedViewState.searchQuery}"
+    {/if}
+  </Empty.Description>
+{/if}
+```
+
+**Verify**: Run `lsp_diagnostics` on the file.
+
+### Step 6: Final Verification
+
+- Run `lsp_diagnostics` on all changed files
+- Verify no TypeScript errors were introduced
+- List all changes made as a summary
+
+## Files Changed (Expected)
+
+1. `apps/tab-manager/src/lib/state/search-preferences.svelte.ts` — **NEW** — Persisted search toggle states via `createStorageState`
+2. `apps/tab-manager/src/lib/utils/tab-helpers.ts` — Export `normalizeUrl`
+3. `apps/tab-manager/src/lib/state/unified-view-state.svelte.ts` — Import preferences, updated `matchesFilter`, proxy getters/setters
+4. `apps/tab-manager/src/entrypoints/sidepanel/App.svelte` — Toggle UI, field scope ToggleGroup
+5. `apps/tab-manager/src/lib/components/tabs/UnifiedTabList.svelte` — Regex hint in empty state
+
+## Key Patterns to Follow
+
+- **Storage**: `createStorageState` from `storage-state.svelte.ts` (NOT `localStorage`)
+- **Toggle + Tooltip**: honeycrisp editor pattern (`apps/honeycrisp/src/lib/editor/Editor.svelte`)
+- **ToggleGroup**: whispering app pattern (`apps/whispering/src/routes/(app)/+page.svelte`)
+- **Settings file**: `settings.svelte.ts` for `createStorageState` usage
+- **Import style**: `@epicenter/ui/toggle`, `@lucide/svelte/icons/case-sensitive`


### PR DESCRIPTION
The tab manager's search was a single case-insensitive substring match with no way to refine results—searching `React` also matched `react-router` and `reactive`, and there was no way to search only URLs or only titles. This adds VS Code-style search mode toggles that appear inline when you're actively searching.

<img width="708" height="90" alt="CleanShot 2026-04-05 at 11 33 33@2x" src="https://github.com/user-attachments/assets/ca89e6c1-4b10-473e-8540-94dfa0470d4e" />

Three toggles—case-sensitive (`Aa`), regex (`.*`), and whole-word/exact-match (`ab|`)—plus a compact dropdown for field scope (All / Title / URL). The controls only appear when the input is focused or has a query, keeping the header clean when you're not searching. Clicking a toggle doesn't collapse the controls thanks to `onfocusin`/`onfocusout` on the container with `relatedTarget` checks.

Toggle states persist to `chrome.storage.local` via the existing `createStorageState` pattern (same mechanism as `serverUrl` and `remoteServerUrl`), so your preferred search mode survives panel close/reopen and syncs across extension contexts. Regex and exact-match are mutually exclusive—turning one on turns the other off.

The "exact match" toggle does different things depending on the field type: whole-word boundary matching (`\bterm\b`) for titles (so `log` matches "error log" but not "dialog"), and normalized URL equality for URLs. The filter logic compiles the regex once as a `$derived` instead of per-tab:

```
search-preferences.svelte.ts (NEW — persisted via chrome.storage.local)
├── searchCaseSensitive.current
├── searchRegex.current
├── searchExactMatch.current
└── searchField.current: 'all' | 'title' | 'url'

unified-view-state.svelte.ts
├── compiledRegex ($derived — compiled once, reused for all tabs)
├── testField(value, fieldType) — regex / whole-word / exact-URL / substring
└── matchesFilter(title, url) — dispatcher that reads field scope
```

---

This branch also fixes bookmark rows showing a static star icon instead of the actual page favicon—one line to pass `favIconUrl` to `TabFavicon`.

5 commits, 7 files changed (+897/-32). The spec and execution prompt are in `specs/` for reference.