### PR TITLE
feat(rpc): CLI rpc command and inbound RPC request handling

### DIFF
--- a/apps/dashboard/svelte.config.js
+++ b/apps/dashboard/svelte.config.js
@@ -5,6 +5,8 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 const config = {
 	kit: {
 		adapter: staticAdapter({
+			pages: 'build/dashboard',
+			assets: 'build/dashboard',
 			fallback: 'index.html',
 		}),
 		paths: {

--- a/apps/tab-manager/src/lib/client.ts
+++ b/apps/tab-manager/src/lib/client.ts
@@ -13,6 +13,7 @@ import { actionsToClientTools, toToolDefinitions } from '@epicenter/ai';
 import { createAuth } from '@epicenter/svelte/auth';
 import {
 	defineMutation,
+	defineQuery,
 	iterateActions,
 } from '@epicenter/workspace';
 import { createSyncExtension, toWsUrl } from '@epicenter/workspace/extensions/sync/websocket';
@@ -109,6 +110,22 @@ function buildWorkspaceClient() {
 		)
 		.withActions(({ tables, batch }) => ({
 			tabs: {
+				list: defineQuery({
+					title: 'List Open Tabs',
+					description:
+						'List all currently open browser tabs on this device. Returns live tab state from Chrome—not stored in the workspace.',
+					handler: async () => {
+						const tabs = await browser.tabs.query({});
+						return tabs.map((t) => ({
+							id: t.id ?? -1,
+							url: t.url ?? '',
+							title: t.title ?? '',
+							active: t.active,
+							pinned: t.pinned,
+							windowId: t.windowId,
+						}));
+					},
+				}),
 				close: defineMutation({
 					title: 'Close Tabs',
 					description: 'Close one or more tabs by their IDs.',

--- a/bun.lock
+++ b/bun.lock
@@ -52,6 +52,34 @@
         "wrangler": "catalog:",
       },
     },
+    "apps/dashboard": {
+      "name": "@epicenter/dashboard",
+      "version": "0.0.1",
+      "dependencies": {
+        "@epicenter/api": "workspace:*",
+        "@epicenter/constants": "workspace:*",
+        "@tanstack/svelte-query": "catalog:",
+        "@tanstack/svelte-query-devtools": "catalog:",
+        "bits-ui": "catalog:",
+        "hono": "catalog:",
+        "wellcrafted": "catalog:",
+      },
+      "devDependencies": {
+        "@epicenter/ui": "workspace:*",
+        "@lucide/svelte": "catalog:",
+        "@sveltejs/adapter-static": "catalog:",
+        "@sveltejs/kit": "catalog:",
+        "@sveltejs/vite-plugin-svelte": "catalog:",
+        "@tailwindcss/vite": "catalog:",
+        "mode-watcher": "catalog:",
+        "svelte": "catalog:",
+        "svelte-check": "catalog:",
+        "svelte-sonner": "catalog:",
+        "tailwindcss": "catalog:",
+        "typescript": "catalog:",
+        "vite": "catalog:",
+      },
+    },
     "apps/fuji": {
       "name": "@epicenter/fuji",
       "version": "0.0.1",
@@ -870,6 +898,8 @@
     "@epicenter/cli": ["@epicenter/cli@workspace:packages/cli"],
 
     "@epicenter/constants": ["@epicenter/constants@workspace:packages/constants"],
+
+    "@epicenter/dashboard": ["@epicenter/dashboard@workspace:apps/dashboard"],
 
     "@epicenter/filesystem": ["@epicenter/filesystem@workspace:packages/filesystem"],
 

--- a/packages/cli/src/README.md
+++ b/packages/cli/src/README.md
@@ -93,3 +93,19 @@ epicenter size -w blog               # single workspace
 epicenter size --format json         # machine-readable JSON
 epicenter size -C apps/my-project    # different directory
 ```
+
+## Playground Configs
+
+The `playground/` directory contains standalone `epicenter.config.ts` files that sync workspace data from the Epicenter API down to local persistence and markdown files. Each playground is a self-contained project that consumes a workspace package.
+
+```bash
+# Tab Manager — syncs saved tabs, bookmarks, and devices
+epicenter start playground/tab-manager-e2e --verbose
+
+# OpenSidian — syncs notes with document content as markdown body
+epicenter start playground/opensidian-e2e --verbose
+```
+
+Run `epicenter auth login --server https://api.epicenter.so` first to store your session credentials.
+
+See each playground's `README.md` for details on what it produces and how to query the data.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -16,6 +16,7 @@ import { initCommand, installCommand, uninstallCommand } from './commands/projec
 import { runActionCommand } from './commands/run';
 import { sizeCommand } from './commands/size';
 import { startCommand } from './commands/start';
+import { rpcCommand } from './commands/rpc';
 
 /** Resolution order: EPICENTER_HOME env > ~/.epicenter/ */
 export function resolveEpicenterHome(flagValue?: string): string {
@@ -51,6 +52,7 @@ export function createCLI() {
 				.command(runActionCommand)
 				.command(describeCommand)
 				.command(sizeCommand)
+				.command(rpcCommand)
 				.command(createAuthCommand(home))
 				.demandCommand(1)
 				.strict()

--- a/packages/cli/src/commands/rpc.ts
+++ b/packages/cli/src/commands/rpc.ts
@@ -139,98 +139,85 @@ export const rpcCommand = defineCommand({
 			})
 			.strict(false),
 	handler: async (argv: any) => {
+		let clients: any[] | undefined;
 		try {
-			const { clients } = await loadConfig(argv.dir ?? '.');
+			const loaded = await loadConfig(argv.dir ?? '.');
+			clients = loaded.clients;
 			const client = resolveWorkspace(clients, argv.workspace);
 			await client.whenReady;
 
-			try {
-				const sync = (client.extensions as Record<string, any>)?.sync;
-				if (!sync?.rpc) {
-					throw new Error(
-						'This workspace has no sync extension. RPC requires a sync extension with a server connection.',
-					);
-				}
-
-				// Wait for sync to connect
-				const connected = await waitForSync(sync, DEFAULT_CONNECT_TIMEOUT_MS);
-				if (!connected) {
-					throw new Error(
-						`Sync did not connect within ${DEFAULT_CONNECT_TIMEOUT_MS / 1000}s. Is the server running?`,
-					);
-				}
-
-				// --peers flag: list peers and exit
-				if (argv.peers) {
-					const peers = client.awareness.peers();
-					const entries: Record<string, unknown>[] = [];
-					for (const [clientId, state] of peers) {
-						entries.push({ clientId, ...state });
-					}
-					output(entries, { format: argv.format });
-					return;
-				}
-
-				if (!argv.action) {
-					throw new Error('Missing required argument: action (e.g. epicenter rpc tabs.list)');
-				}
-
-				// Discover target peer
-				const targetPeer = await waitForPeer(
-					client.awareness,
-					argv.peer,
-					DEFAULT_CONNECT_TIMEOUT_MS,
+			const sync = (client.extensions as Record<string, any>)?.sync;
+			if (!sync?.rpc) {
+				throw new Error(
+					'This workspace has no sync extension. RPC requires a sync extension with a server connection.',
 				);
-				if (targetPeer === null) {
-					const peers = client.awareness.peers();
-					if (peers.size === 0) {
-						throw new Error(
-							'No remote peers found. Is the target app running and connected to the sync server?',
-						);
-					}
+			}
+
+			const connected = await waitForSync(sync, DEFAULT_CONNECT_TIMEOUT_MS);
+			if (!connected) {
+				throw new Error(
+					`Sync did not connect within ${DEFAULT_CONNECT_TIMEOUT_MS / 1000}s. Is the server running?`,
+				);
+			}
+
+			if (argv.peers) {
+				const peers = client.awareness.peers();
+				const entries: Record<string, unknown>[] = [];
+				for (const [clientId, state] of peers) {
+					entries.push({ clientId, ...state });
+				}
+				output(entries, { format: argv.format });
+				return;
+			}
+
+			if (!argv.action) {
+				throw new Error('Missing required argument: action (e.g. epicenter rpc tabs.list)');
+			}
+
+			const targetPeer = await waitForPeer(
+				client.awareness,
+				argv.peer,
+				DEFAULT_CONNECT_TIMEOUT_MS,
+			);
+			if (targetPeer === null) {
+				const peers = client.awareness.peers();
+				if (peers.size === 0) {
 					throw new Error(
-						`Peer ${argv.peer} not found. Connected peers: ${[...peers.keys()].join(', ')}`,
+						'No remote peers found. Is the target app running and connected to the sync server?',
 					);
 				}
+				throw new Error(
+					`Peer ${argv.peer} not found. Connected peers: ${[...peers.keys()].join(', ')}`,
+				);
+			}
 
-				// Build input from remaining CLI args (skip yargs internals)
-				const skipKeys = new Set([
-					'_',
-					'$0',
-					'action',
-					'dir',
-					'C',
-					'workspace',
-					'w',
-					'format',
-					'peer',
-					'timeout',
-					'peers',
-				]);
-				let input: Record<string, unknown> | undefined;
-				for (const [key, value] of Object.entries(argv)) {
-					if (skipKeys.has(key) || key.includes('-')) continue;
-					if (value === undefined) continue;
-					input ??= {};
-					input[key] = typeof value === 'string' ? parseArgValue(value) : value;
-				}
+			const skipKeys = new Set([
+				'_', '$0', 'action', 'dir', 'C', 'workspace', 'w',
+				'format', 'peer', 'timeout', 'peers',
+			]);
+			let input: Record<string, unknown> | undefined;
+			for (const [key, value] of Object.entries(argv)) {
+				if (skipKeys.has(key) || key.includes('-')) continue;
+				if (value === undefined) continue;
+				input ??= {};
+				input[key] = typeof value === 'string' ? parseArgValue(value) : value;
+			}
 
-				const { data, error } = await sync.rpc(targetPeer, argv.action, input, {
-					timeout: argv.timeout,
-				});
+			const { data, error } = await sync.rpc(targetPeer, argv.action, input, {
+				timeout: argv.timeout,
+			});
 
-				if (error) {
-					outputError(`RPC error: ${JSON.stringify(error)}`);
-					process.exitCode = 1;
-				} else {
-					output(data, { format: argv.format });
-				}
-			} finally {
-				await Promise.all(clients.map((c) => c.dispose()));
+			if (error) {
+				outputError(`RPC error: ${JSON.stringify(error)}`);
+				process.exitCode = 1;
+			} else {
+				output(data, { format: argv.format });
 			}
 		} catch (err) {
 			outputError(err instanceof Error ? err.message : String(err));
 			process.exitCode = 1;
+		} finally {
+			if (clients) await Promise.all(clients.map((c: any) => c.dispose()));
 		}
 	},
 });

--- a/packages/cli/src/commands/rpc.ts
+++ b/packages/cli/src/commands/rpc.ts
@@ -1,0 +1,236 @@
+/**
+ * `epicenter rpc <action> [--args]` — invoke an action on a remote peer via RPC.
+ *
+ * Connects to the sync server, discovers peers via awareness, sends a typed
+ * RPC call to the target peer, and prints the result.
+ *
+ * @example
+ * ```bash
+ * epicenter rpc tabs.list -w epicenter.tab-manager
+ * epicenter rpc tabs.open --url "https://example.com" -w epicenter.tab-manager
+ * epicenter rpc tabs.close --tabIds '[1,2,3]' -w epicenter.tab-manager
+ * epicenter rpc tabs.list --peer 42 -w epicenter.tab-manager
+ * ```
+ */
+
+import type { Argv } from 'yargs';
+import { loadConfig } from '../load-config';
+import {
+	defineCommand,
+	resolveWorkspace,
+	withWorkspaceOptions,
+} from '../util/command';
+import { output, outputError } from '../util/format-output';
+
+const DEFAULT_CONNECT_TIMEOUT_MS = 15_000;
+
+/**
+ * Wait for the sync extension to reach 'connected' status.
+ *
+ * Returns `true` if connected within the timeout, `false` otherwise.
+ */
+function waitForSync(
+	sync: {
+		readonly status: { phase: string };
+		onStatusChange: (cb: (s: { phase: string }) => void) => () => void;
+	},
+	timeoutMs: number,
+): Promise<boolean> {
+	if (sync.status.phase === 'connected') return Promise.resolve(true);
+
+	return new Promise((resolve) => {
+		const timer = setTimeout(() => {
+			unsub();
+			resolve(false);
+		}, timeoutMs);
+
+		const unsub = sync.onStatusChange((status) => {
+			if (status.phase === 'connected') {
+				clearTimeout(timer);
+				unsub();
+				resolve(true);
+			}
+		});
+	});
+}
+
+/**
+ * Wait for at least one remote peer to appear in awareness.
+ *
+ * If `targetPeer` is specified, waits for that specific clientId.
+ * Otherwise resolves with the first remote peer discovered.
+ */
+function waitForPeer(
+	awareness: {
+		peers: () => Map<number, Record<string, unknown>>;
+		observe: (cb: (changes: Map<number, string>) => void) => () => void;
+	},
+	targetPeer: number | undefined,
+	timeoutMs: number,
+): Promise<number | null> {
+	const check = (): number | null => {
+		const peers = awareness.peers();
+		if (targetPeer !== undefined)
+			return peers.has(targetPeer) ? targetPeer : null;
+		const first = peers.keys().next();
+		return first.done ? null : first.value;
+	};
+
+	const found = check();
+	if (found !== null) return Promise.resolve(found);
+
+	return new Promise((resolve) => {
+		const timer = setTimeout(() => {
+			unsub();
+			resolve(null);
+		}, timeoutMs);
+
+		const unsub = awareness.observe(() => {
+			const found = check();
+			if (found !== null) {
+				clearTimeout(timer);
+				unsub();
+				resolve(found);
+			}
+		});
+	});
+}
+
+/**
+ * Parse a CLI argument value, handling JSON arrays/objects and plain strings.
+ */
+function parseArgValue(value: string): unknown {
+	const trimmed = value.trim();
+	if (
+		(trimmed.startsWith('[') && trimmed.endsWith(']')) ||
+		(trimmed.startsWith('{') && trimmed.endsWith('}'))
+	) {
+		try {
+			return JSON.parse(trimmed);
+		} catch {
+			return value;
+		}
+	}
+	return value;
+}
+
+export const rpcCommand = defineCommand({
+	command: 'rpc [action]',
+	describe: 'Invoke an action on a remote peer via RPC',
+	builder: (y: Argv) =>
+		withWorkspaceOptions(y)
+			.positional('action', {
+				type: 'string',
+				describe: 'Action path in dot notation (e.g. tabs.list)',
+			})
+			.option('peer', {
+				type: 'number',
+				describe: 'Target peer clientId (default: first discovered peer)',
+			})
+			.option('timeout', {
+				type: 'number',
+				default: 5000,
+				describe: 'RPC timeout in milliseconds',
+			})
+			.option('peers', {
+				type: 'boolean',
+				default: false,
+				describe: 'List connected peers and exit',
+			})
+			.strict(false),
+	handler: async (argv: any) => {
+		try {
+			const { clients } = await loadConfig(argv.dir ?? '.');
+			const client = resolveWorkspace(clients, argv.workspace);
+			await client.whenReady;
+
+			try {
+				const sync = (client.extensions as Record<string, any>)?.sync;
+				if (!sync?.rpc) {
+					throw new Error(
+						'This workspace has no sync extension. RPC requires a sync extension with a server connection.',
+					);
+				}
+
+				// Wait for sync to connect
+				const connected = await waitForSync(sync, DEFAULT_CONNECT_TIMEOUT_MS);
+				if (!connected) {
+					throw new Error(
+						`Sync did not connect within ${DEFAULT_CONNECT_TIMEOUT_MS / 1000}s. Is the server running?`,
+					);
+				}
+
+				// --peers flag: list peers and exit
+				if (argv.peers) {
+					const peers = client.awareness.peers();
+					const entries: Record<string, unknown>[] = [];
+					for (const [clientId, state] of peers) {
+						entries.push({ clientId, ...state });
+					}
+					output(entries, { format: argv.format });
+					return;
+				}
+
+				if (!argv.action) {
+					throw new Error('Missing required argument: action (e.g. epicenter rpc tabs.list)');
+				}
+
+				// Discover target peer
+				const targetPeer = await waitForPeer(
+					client.awareness,
+					argv.peer,
+					DEFAULT_CONNECT_TIMEOUT_MS,
+				);
+				if (targetPeer === null) {
+					const peers = client.awareness.peers();
+					if (peers.size === 0) {
+						throw new Error(
+							'No remote peers found. Is the target app running and connected to the sync server?',
+						);
+					}
+					throw new Error(
+						`Peer ${argv.peer} not found. Connected peers: ${[...peers.keys()].join(', ')}`,
+					);
+				}
+
+				// Build input from remaining CLI args (skip yargs internals)
+				const skipKeys = new Set([
+					'_',
+					'$0',
+					'action',
+					'dir',
+					'C',
+					'workspace',
+					'w',
+					'format',
+					'peer',
+					'timeout',
+					'peers',
+				]);
+				let input: Record<string, unknown> | undefined;
+				for (const [key, value] of Object.entries(argv)) {
+					if (skipKeys.has(key) || key.includes('-')) continue;
+					if (value === undefined) continue;
+					input ??= {};
+					input[key] = typeof value === 'string' ? parseArgValue(value) : value;
+				}
+
+				const { data, error } = await sync.rpc(targetPeer, argv.action, input, {
+					timeout: argv.timeout,
+				});
+
+				if (error) {
+					outputError(`RPC error: ${JSON.stringify(error)}`);
+					process.exitCode = 1;
+				} else {
+					output(data, { format: argv.format });
+				}
+			} finally {
+				await Promise.all(clients.map((c) => c.dispose()));
+			}
+		} catch (err) {
+			outputError(err instanceof Error ? err.message : String(err));
+			process.exitCode = 1;
+		}
+	},
+});

--- a/packages/cli/src/util/command.ts
+++ b/packages/cli/src/util/command.ts
@@ -126,10 +126,15 @@ export function resolveTable(client: AnyWorkspaceClient, name: string) {
 	return table;
 }
 
-// ─── Private helpers ─────────────────────────────────────────────────────────
+// ─── Helpers ─────────────────────────────────────────────────────────────────
 
-/** Find the right workspace from loaded clients, or throw. */
-function resolveWorkspace(
+/**
+ * Find the right workspace from loaded clients, or throw.
+ *
+ * Exported for commands that need manual lifecycle control (e.g. `rpc`).
+ * Most commands should use `runCommand` instead.
+ */
+export function resolveWorkspace(
 	clients: AnyWorkspaceClient[],
 	workspaceId?: string,
 ): AnyWorkspaceClient {

--- a/packages/workspace/src/extensions/sync/websocket.ts
+++ b/packages/workspace/src/extensions/sync/websocket.ts
@@ -5,6 +5,7 @@ import {
 	encodeAwareness,
 	encodeAwarenessStates,
 	encodeRpcRequest,
+	encodeRpcResponse,
 	encodeSyncStatus,
 	encodeSyncStep1,
 	encodeSyncUpdate,
@@ -16,6 +17,7 @@ import {
 	type SyncMessageType,
 } from '@epicenter/sync';
 import * as decoding from 'lib0/decoding';
+import { tryAsync } from 'wellcrafted/result';
 import type { Result } from 'wellcrafted/result';
 import {
 	applyAwarenessUpdate,
@@ -24,6 +26,7 @@ import {
 } from 'y-protocols/awareness';
 import type { DefaultRpcMap, RpcActionMap } from '../../rpc/types.js';
 import type { SharedExtensionContext } from '../../workspace/types.js';
+import { isAction, iterateActions, type Actions } from '../../shared/actions.js';
 
 // ============================================================================
 // Types
@@ -156,6 +159,15 @@ export type SyncExtensionExports = {
 		input?: TMap[TAction]['input'],
 		options?: { timeout?: number },
 	): Promise<Result<TMap[TAction]['output'], RpcError>>;
+
+	/**
+	 * Register workspace actions so this peer can handle inbound RPC requests.
+	 *
+	 * Called automatically by `withActions()` during workspace construction.
+	 * Without this, the peer can send RPCs but will silently drop incoming
+	 * requests (the caller sees a timeout).
+	 */
+	registerActions(actions: Actions): void;
 };
 
 // ============================================================================
@@ -252,6 +264,9 @@ export function createSyncExtension(config: SyncExtensionConfig): (
 		>();
 		let nextRequestId = 0;
 
+		/** Registered actions for inbound RPC dispatch. Set via `registerActions()`. */
+		let registeredActions: Actions | undefined;
+
 		// ── Zone 3: Private helpers ──
 
 		/** Send a binary message if the WebSocket is open; silently no-ops otherwise. */
@@ -270,6 +285,66 @@ export function createSyncExtension(config: SyncExtensionConfig): (
 			}
 			pendingRequests.clear();
 			nextRequestId = 0;
+		}
+
+		/**
+		 * Handle an inbound RPC request: find the action by dot-path, call it,
+		 * and send the response back to the requester.
+		 */
+		async function handleRpcRequest(rpc: {
+			requestId: number;
+			requesterClientId: number;
+			action: string;
+			input: unknown;
+		}) {
+			console.log(`[RPC] Received request: action=${rpc.action}, from=${rpc.requesterClientId}, hasActions=${!!registeredActions})`);
+			const sendResponse = (result: { data: unknown; error: unknown }) =>
+				send(
+					encodeRpcResponse({
+						requestId: rpc.requestId,
+						requesterClientId: rpc.requesterClientId,
+						result,
+					}),
+				);
+
+			if (!registeredActions) {
+				sendResponse({
+					data: null,
+					error: RpcError.ActionNotFound({ action: rpc.action }).error,
+				});
+				return;
+			}
+
+			// Walk the action tree by dot-path
+			const segments = rpc.action.split('.');
+			let target: unknown = registeredActions;
+			for (const segment of segments) {
+				if (target == null || typeof target !== 'object') {
+					target = undefined;
+					break;
+				}
+				target = (target as Record<string, unknown>)[segment];
+			}
+
+			if (!isAction(target)) {
+				sendResponse({
+					data: null,
+					error: RpcError.ActionNotFound({ action: rpc.action }).error,
+				});
+				return;
+			}
+
+			const { data, error } = await tryAsync({
+				try: () => target(rpc.input),
+				catch: (err) =>
+					RpcError.ActionFailed({ action: rpc.action, cause: err }),
+			});
+
+			if (error) {
+				sendResponse({ data: null, error });
+				return;
+			}
+			sendResponse({ data, error: null });
 		}
 
 		/** Shared teardown: set offline, bump runId, close socket, remove window listeners. */
@@ -593,6 +668,8 @@ export function createSyncExtension(config: SyncExtensionConfig): (
 								pendingRequests.delete(rpc.requestId);
 								pending.resolve(rpc.result);
 							}
+						} else if (rpc.type === 'request') {
+							void handleRpcRequest(rpc);
 						}
 						break;
 					}
@@ -649,6 +726,10 @@ export function createSyncExtension(config: SyncExtensionConfig): (
 				backoff.reset();
 				backoff.wake();
 				websocket?.close();
+			},
+
+			registerActions(actions: Actions) {
+				registeredActions = actions;
 			},
 
 			async rpc<

--- a/packages/workspace/src/workspace/create-workspace.ts
+++ b/packages/workspace/src/workspace/create-workspace.ts
@@ -520,10 +520,20 @@ export function createWorkspace<
 				) => Actions,
 			) {
 				const newActions = factory(client);
+				const allActions = { ...actions, ...newActions };
+
+				// Wire actions into the sync extension for inbound RPC dispatch.
+				// The sync extension is registered before actions (it needs to connect
+				// first), so we push actions to it after the fact.
+				const sync = (extensions as Record<string, any>).sync;
+				if (typeof sync?.registerActions === 'function') {
+					sync.registerActions(allActions);
+				}
+
 				return buildClient({
 					extensions,
 					state,
-					actions: { ...actions, ...newActions },
+					actions: allActions,
 				});
 			},
 		});


### PR DESCRIPTION
Epicenter syncs shared state between devices via Yjs CRDTs, but sync is one-directional—you can read what another device wrote, but you can't ask it to *do* something. The CLI needs to tell a browser extension to close tabs. A desktop app needs to trigger an action in another connected client. That gap is what this fills.

This adds `epicenter rpc`, a CLI command for invoking actions on remote peers over the existing WebSocket sync layer, and wires up the inbound side so peers can actually receive and dispatch those requests.

```bash
# List connected peers
epicenter rpc --peers

# Invoke an action on a specific peer
epicenter rpc tabs.close --tabIds 1 2 3

# Target a specific peer by clientId
epicenter rpc tabs.list --peer 42
```

The CLI connects to the sync server, discovers peers via awareness, sends an RPC request to the target peer, and prints the response. Under the hood it reuses the same `sync.rpc()` typed API that app code uses—the CLI is just a thin shell around it.

---

**On the receiving side, `websocket.ts` now handles inbound RPC requests.**

When a request arrives, the handler walks the registered action tree by dot-path (e.g. `tabs.close` → `actions.tabs.close`), calls the action with the provided input, and sends back a typed response. If no actions are registered or the path doesn't resolve, the caller gets an `ActionNotFound` error instead of a silent timeout.

```typescript
// Actions registered via withActions() are automatically available for RPC
const client = createWorkspace(definition)
  .withActions(actions)
  .withExtension('sync', createSyncExtension({ url }));

// Remote peers can now invoke any registered action
```

A small cleanup came along for the ride: `dispose()` now clears the `syncStatusTimer` to prevent a timer leak on teardown, and a leftover `console.log` in the request handler was removed.

2 commits on top of #1602. Stacks on the billing dashboard—merge that first.