### PR TITLE
feat(sync): add peer-to-peer RPC over sync layer with CLI command

### DIFF
--- a/packages/workspace/src/extensions/sync/websocket.ts
+++ b/packages/workspace/src/extensions/sync/websocket.ts
@@ -26,7 +26,7 @@ import {
 } from 'y-protocols/awareness';
 import type { DefaultRpcMap, RpcActionMap } from '../../rpc/types.js';
 import type { SharedExtensionContext } from '../../workspace/types.js';
-import { isAction, iterateActions, type Actions } from '../../shared/actions.js';
+import { isAction, type Actions } from '../../shared/actions.js';
 
 // ============================================================================
 // Types
@@ -297,7 +297,6 @@ export function createSyncExtension(config: SyncExtensionConfig): (
 			action: string;
 			input: unknown;
 		}) {
-			console.log(`[RPC] Received request: action=${rpc.action}, from=${rpc.requesterClientId}, hasActions=${!!registeredActions})`);
 			const sendResponse = (result: { data: unknown; error: unknown }) =>
 				send(
 					encodeRpcResponse({
@@ -799,6 +798,10 @@ export function createSyncExtension(config: SyncExtensionConfig): (
 
 			dispose() {
 				clearPendingRequests();
+				if (syncStatusTimer) {
+					clearTimeout(syncStatusTimer);
+					syncStatusTimer = null;
+				}
 				goOffline();
 				doc.off('updateV2', handleDocUpdate);
 				awareness.off('update', handleAwarenessUpdate);


### PR DESCRIPTION
The tab-manager extension needs to tell a browser extension to close tabs, open URLs, and query connected devices. Epicenter already syncs shared state between devices via Yjs CRDTs through a Durable Object relay, but sync is one-way—you can read shared state, but you can't ask another device to *do* something. This adds peer-to-peer RPC over the existing WebSocket sync layer, plus a CLI command to invoke it.

---

**The CLI gets an `epicenter rpc` command for cross-app action invocation.**

```bash
# List connected peers
epicenter rpc --list

# Send an RPC to a specific peer
epicenter rpc --target <clientId> --action tabs.close --input '{"tabIds": [1, 2]}'
```

This lets any CLI script or automation tool invoke actions on connected devices—browser extensions, desktop apps, or other CLI instances—without needing a separate communication channel.

---

**Inbound RPC handling is added to the sync WebSocket extension.**

The workspace sync client now processes incoming RPC requests and routes them to registered action handlers. The protocol reuses the existing WebSocket connection—no new ports or servers. The Durable Object acts as a dumb relay, forwarding request bytes to the target peer or synthesizing a `PeerOffline` response if they're disconnected.

---

This branch also includes the billing dashboard scaffolding (shared with `feat/fix-dashboard`) and a sync dispose fix—the debounced `syncStatus` timer and a dead import were cleaned up to prevent firing after WebSocket teardown.

12 commits, 41 files changed. +3605/-599 lines.