### PR TITLE
chore: dev scripts, SQLite mirror spec/types, grok removal

### DIFF
--- a/.agents/skills/monorepo/SKILL.md
+++ b/.agents/skills/monorepo/SKILL.md
@@ -38,6 +38,31 @@ Use this pattern when you need to:
 - `:check` suffix = check only (for CI, no modifications)
 - `typecheck` alone = type checking (separate concern, cannot auto-fix)
 
+## Dev Scripts
+
+Every app uses explicit `dev:local` / `dev:remote` naming:
+
+| Script | Meaning |
+| --- | --- |
+| `dev:local` | Local everything—local API, local secrets |
+| `dev:remote` | Local app, remote/prod resources |
+| `dev` | Alias for `dev:local` (convenience) |
+
+Not every app has `dev:remote`—only add it when there's a real use case.
+
+## CLI (`epicenter`)
+
+From the monorepo root, `bun epicenter` runs the local CLI against `localhost:8787`:
+
+```bash
+bun epicenter start playground/opensidian-e2e --verbose
+bun epicenter list files -C playground/opensidian-e2e
+```
+
+The bare `epicenter` command (global install) defaults to `api.epicenter.so`.
+Config files read `process.env.EPICENTER_SERVER` with a prod fallback—the root
+script sets it automatically.
+
 ## After Completing Code Changes
 
 Run type checking to verify:

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,6 +13,7 @@
 	"scripts": {
 		"test": "bun test",
 		"typecheck": "tsc --noEmit",
+		"dev": "bun run dev:local",
 		"dev:local": "mkdir -p ../dashboard/build/dashboard && infisical export --path=/api --format=dotenv > .dev.vars && wrangler dev",
 		"dev:dashboard": "bun --cwd ../dashboard run build && bun run dev:local",
 		"dev:remote": "mkdir -p ../dashboard/build/dashboard && infisical run --watch --path=/api -- wrangler dev",

--- a/apps/api/src/ai-chat.ts
+++ b/apps/api/src/ai-chat.ts
@@ -8,7 +8,6 @@ import {
 } from '@tanstack/ai';
 import { ANTHROPIC_MODELS, createAnthropicChat } from '@tanstack/ai-anthropic';
 import { createGeminiChat, GeminiTextModels } from '@tanstack/ai-gemini';
-import { createGrokText, GROK_CHAT_MODELS } from '@tanstack/ai-grok';
 import { createOpenaiChat, OPENAI_CHAT_MODELS } from '@tanstack/ai-openai';
 import { type } from 'arktype';
 import { createFactory } from 'hono/factory';
@@ -68,7 +67,6 @@ const aiChatBody = type({
 			{ provider: "'openai'", model: type.enumerated(...OPENAI_CHAT_MODELS) },
 			{ provider: "'anthropic'", model: type.enumerated(...ANTHROPIC_MODELS) },
 			{ provider: "'gemini'", model: type.enumerated(...GeminiTextModels) },
-			{ provider: "'grok'", model: type.enumerated(...GROK_CHAT_MODELS) },
 		),
 	),
 	/** User-provided API key for BYOK. When present, billing is bypassed entirely. */
@@ -146,13 +144,6 @@ export const aiChatHandlers = factory.createHandlers(
 				if (!apiKey)
 					return c.json(AiChatError.ProviderNotConfigured({ provider }), 503);
 				adapter = createGeminiChat(data.model, apiKey);
-				break;
-			}
-			case 'grok': {
-				const apiKey = userApiKey ?? c.env.GROK_API_KEY;
-				if (!apiKey)
-					return c.json(AiChatError.ProviderNotConfigured({ provider }), 503);
-				adapter = createGrokText(data.model, apiKey);
 				break;
 			}
 		}

--- a/apps/api/worker-configuration.d.ts
+++ b/apps/api/worker-configuration.d.ts
@@ -17,7 +17,6 @@ declare namespace Cloudflare {
 		ANTHROPIC_API_KEY: string;
 		AUTUMN_SECRET_KEY: string;
 		GEMINI_API_KEY: string;
-		GROK_API_KEY: string;
 		WORKSPACE_ROOM: DurableObjectNamespace<import("./src/app").WorkspaceRoom>;
 		DOCUMENT_ROOM: DurableObjectNamespace<import("./src/app").DocumentRoom>;
 	}
@@ -27,7 +26,7 @@ type StringifyValues<EnvType extends Record<string, unknown>> = {
 	[Binding in keyof EnvType]: EnvType[Binding] extends string ? EnvType[Binding] : string;
 };
 declare namespace NodeJS {
-	interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, "GOOGLE_CLIENT_ID" | "BETTER_AUTH_SECRET" | "ENCRYPTION_SECRETS" | "GOOGLE_CLIENT_SECRET" | "OPENAI_API_KEY" | "ANTHROPIC_API_KEY" | "AUTUMN_SECRET_KEY" | "GEMINI_API_KEY" | "GROK_API_KEY">> {}
+	interface ProcessEnv extends StringifyValues<Pick<Cloudflare.Env, "GOOGLE_CLIENT_ID" | "BETTER_AUTH_SECRET" | "ENCRYPTION_SECRETS" | "GOOGLE_CLIENT_SECRET" | "OPENAI_API_KEY" | "ANTHROPIC_API_KEY" | "AUTUMN_SECRET_KEY" | "GEMINI_API_KEY">> {}
 }
 
 // Begin runtime types

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -64,7 +64,6 @@
 			"ANTHROPIC_API_KEY",
 			"AUTUMN_SECRET_KEY",
 			"GEMINI_API_KEY",
-			"GROK_API_KEY"
 		]
 	},
 	// --- Hyperdrive: Postgres connection pool ---

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"dev": "bun run dev:local",
 		"dev:local": "vite dev",
+		"dev:remote": "vite dev --mode production",
 		"build": "NODE_ENV=production vite build",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -4,7 +4,8 @@
 	"version": "0.0.1",
 	"type": "module",
 	"scripts": {
-		"dev": "vite dev",
+		"dev": "bun run dev:local",
+		"dev:local": "vite dev",
 		"build": "NODE_ENV=production vite build",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",

--- a/apps/fuji/package.json
+++ b/apps/fuji/package.json
@@ -7,7 +7,8 @@
 		"./workspace": "./src/lib/workspace/index.ts"
 	},
 	"scripts": {
-		"dev": "vite dev",
+		"dev": "bun run dev:local",
+		"dev:local": "vite dev",
 		"build": "NODE_ENV=production vite build",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",

--- a/apps/fuji/package.json
+++ b/apps/fuji/package.json
@@ -9,6 +9,7 @@
 	"scripts": {
 		"dev": "bun run dev:local",
 		"dev:local": "vite dev",
+		"dev:remote": "vite dev --mode production",
 		"build": "NODE_ENV=production vite build",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",

--- a/apps/honeycrisp/package.json
+++ b/apps/honeycrisp/package.json
@@ -7,7 +7,8 @@
 		"./workspace": "./src/lib/workspace/index.ts"
 	},
 	"scripts": {
-		"dev": "vite dev",
+		"dev": "bun run dev:local",
+		"dev:local": "vite dev",
 		"build": "NODE_ENV=production vite build",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",

--- a/apps/honeycrisp/package.json
+++ b/apps/honeycrisp/package.json
@@ -9,6 +9,7 @@
 	"scripts": {
 		"dev": "bun run dev:local",
 		"dev:local": "vite dev",
+		"dev:remote": "vite dev --mode production",
 		"build": "NODE_ENV=production vite build",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -4,7 +4,8 @@
 	"type": "module",
 	"version": "0.0.1",
 	"scripts": {
-		"dev": "astro dev",
+		"dev": "bun run dev:local",
+		"dev:local": "astro dev",
 		"build": "astro build",
 		"preview": "astro preview",
 		"astro": "astro",

--- a/apps/opensidian/package.json
+++ b/apps/opensidian/package.json
@@ -9,6 +9,7 @@
 	"scripts": {
 		"dev": "bun run dev:local",
 		"dev:local": "bun --bun vite dev",
+		"dev:remote": "bun --bun vite dev --mode production",
 		"build": "bun --bun vite build",
 		"preview": "bun --bun vite preview",
 		"prepare": "svelte-kit sync || echo ''",

--- a/apps/opensidian/package.json
+++ b/apps/opensidian/package.json
@@ -7,7 +7,8 @@
 		"./workspace": "./src/lib/workspace/index.ts"
 	},
 	"scripts": {
-		"dev": "bun --bun vite dev",
+		"dev": "bun run dev:local",
+		"dev:local": "bun --bun vite dev",
 		"build": "bun --bun vite build",
 		"preview": "bun --bun vite preview",
 		"prepare": "svelte-kit sync || echo ''",

--- a/apps/posthog-reverse-proxy/package.json
+++ b/apps/posthog-reverse-proxy/package.json
@@ -5,7 +5,8 @@
 	"description": "PostHog reverse proxy for epicenter.so",
 	"type": "module",
 	"scripts": {
-		"dev": "wrangler dev",
+		"dev": "bun run dev:local",
+		"dev:local": "wrangler dev",
 		"deploy": "wrangler deploy --minify",
 		"tail": "wrangler tail"
 	},

--- a/apps/skills/package.json
+++ b/apps/skills/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"dev": "bun run dev:local",
 		"dev:local": "bun --bun vite dev",
+		"dev:remote": "bun --bun vite dev --mode production",
 		"build": "bun --bun vite build",
 		"preview": "bun --bun vite preview",
 		"prepare": "svelte-kit sync || echo ''",

--- a/apps/skills/package.json
+++ b/apps/skills/package.json
@@ -4,7 +4,8 @@
 	"version": "0.0.1",
 	"type": "module",
 	"scripts": {
-		"dev": "bun --bun vite dev",
+		"dev": "bun run dev:local",
+		"dev:local": "bun --bun vite dev",
 		"build": "bun --bun vite build",
 		"preview": "bun --bun vite preview",
 		"prepare": "svelte-kit sync || echo ''",

--- a/apps/tab-manager/package.json
+++ b/apps/tab-manager/package.json
@@ -7,7 +7,8 @@
 		"./workspace": "./src/lib/workspace/index.ts"
 	},
 	"scripts": {
-		"dev": "wxt",
+		"dev": "bun run dev:local",
+		"dev:local": "wxt",
 		"dev:remote": "wxt --mode production",
 		"dev:firefox": "wxt -b firefox",
 		"build": "wxt build",

--- a/apps/whispering/package.json
+++ b/apps/whispering/package.json
@@ -9,7 +9,8 @@
 	},
 	"scripts": {
 		"dev:web": "vite dev",
-		"dev": "bun tauri dev --config '{\"identifier\": \"com.bradenwong.whispering.dev\"}'",
+		"dev": "bun run dev:local",
+		"dev:local": "bun tauri dev --config '{\"identifier\": \"com.bradenwong.whispering.dev\"}'",
 		"build": "NODE_ENV=production bun --bun vite build",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",

--- a/apps/whispering/package.json
+++ b/apps/whispering/package.json
@@ -9,8 +9,10 @@
 	},
 	"scripts": {
 		"dev:web": "vite dev",
+		"dev:web:remote": "vite dev --mode production",
 		"dev": "bun run dev:local",
 		"dev:local": "bun tauri dev --config '{\"identifier\": \"com.bradenwong.whispering.dev\"}'",
+		"dev:remote": "bun tauri dev --config '{\"identifier\": \"com.bradenwong.whispering.dev\", \"build\": {\"beforeDevCommand\": \"bun run dev:web:remote\"}}'",
 		"build": "NODE_ENV=production bun --bun vite build",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",

--- a/apps/zhongwen/package.json
+++ b/apps/zhongwen/package.json
@@ -7,7 +7,8 @@
 		"./workspace": "./src/lib/workspace/index.ts"
 	},
 	"scripts": {
-		"dev": "bun --bun vite dev",
+		"dev": "bun run dev:local",
+		"dev:local": "bun --bun vite dev",
 		"build": "bun --bun vite build",
 		"preview": "bun --bun vite preview",
 		"typecheck": "svelte-check",

--- a/apps/zhongwen/package.json
+++ b/apps/zhongwen/package.json
@@ -9,6 +9,7 @@
 	"scripts": {
 		"dev": "bun run dev:local",
 		"dev:local": "bun --bun vite dev",
+		"dev:remote": "bun --bun vite dev --mode production",
 		"build": "bun --bun vite build",
 		"preview": "bun --bun vite preview",
 		"typecheck": "svelte-check",

--- a/docs/articles/sqlite-is-a-projection-not-a-database.md
+++ b/docs/articles/sqlite-is-a-projection-not-a-database.md
@@ -1,0 +1,135 @@
+# SQLite Is a Projection, Not the Database
+
+Yjs is the database. SQLite is a read cache that happens to look like one.
+
+Every write in the workspace goes through a Yjs CRDT. The Y.Doc is the source of truth: it handles conflict resolution, offline merges, and multi-device sync. SQLite doesn't participate in any of that. It sits downstream, populated by an observer that watches the Y.Doc and mirrors changes into rows and columns. If you delete the SQLite file, nothing is lost. The workspace rebuilds it from the CRDT on next open—the same way a database rebuilds a materialized view from the underlying tables.
+
+That distinction matters because it changes what SQLite is for. It's not where you write. It's where you read.
+
+## Yjs stores data in a format optimized for merging, not querying
+
+Each table is a Y.Array of timestamped cell entries:
+
+```
+Y.Array("table:recordings")
+  { key: "rec_abc", val: { id: "rec_abc", title: "Team standup",
+    transcriptionStatus: "DONE", createdAt: "2026-03-30", _v: 1 },
+    ts: 1743964800000 }
+  { key: "rec_def", val: { id: "rec_def", title: "Client call",
+    transcriptionStatus: "PENDING", createdAt: "2026-03-31", _v: 1 },
+    ts: 1743965000000 }
+  ...
+
+The `ts` field is what makes Last-Write-Wins work. Two devices edit the same row offline; after sync, the higher timestamp wins, regardless of which update arrived first. The Y.Array grows monotonically—entries are never deleted, just superseded by newer ones with the same key.
+
+This is great for sync. It's terrible for queries. To find all recordings transcribed this week, you'd scan every entry, apply LWW per key to get current rows, filter by status and date, and reconstruct the result. That's O(n) over the raw CRDT data every time.
+
+SQLite fixes this. The observer collapses the Y.Array into a normal relational table—one row per recording, one column per field—and keeps it current as the CRDT changes. Queries that would require custom traversal logic become standard SQL.
+
+## The layers build on each other
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Layer 0: Yjs CRDT                                              │
+│                                                                 │
+│  Y.Array of { key, val, ts } entries                           │
+│  Source of truth. All writes go here.                           │
+│  Handles offline merges, conflict resolution, multi-device sync │
+└────────────────────────────┬────────────────────────────────────┘
+                             │ observer syncs on change
+                             ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  Layer 1: Persistent mirror (auto-generated SQLite tables)      │
+│                                                                 │
+│  CREATE TABLE recordings (                                      │
+│    id TEXT PRIMARY KEY,                                         │
+│    title TEXT,                                                  │
+│    transcription_status TEXT,                                   │
+│    created_at INTEGER                                           │
+│  );                                                             │
+│                                                                 │
+│  Schema derived from defineTable() definitions.                 │
+│  Rebuilt from Yjs if lost. Never the source of truth.          │
+└────────────────────────────┬────────────────────────────────────┘
+                             │ FTS5 virtual tables + triggers
+                             ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  Layer 2: Full-text search (FTS5)                               │
+│                                                                 │
+│  CREATE VIRTUAL TABLE recordings_fts USING fts5(               │
+│    title, content='recordings', content_rowid='rowid'          │
+│  );                                                             │
+│                                                                 │
+│  Triggers keep the FTS index in sync with the mirror.          │
+│  Enables keyword search over text fields.                       │
+└────────────────────────────┬────────────────────────────────────┘
+                             │ FLOAT32 columns + DiskANN indexes
+                             ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  Layer 3: Vector embeddings (libSQL/Turso)                      │
+│                                                                 │
+│  ALTER TABLE recordings ADD COLUMN embedding F32_BLOB(1536);   │
+│  CREATE INDEX recordings_idx                                    │
+│    ON recordings(libsql_vector_idx(embedding));                 │
+│                                                                 │
+│  Nearest-neighbor search over semantic embeddings.             │
+│  Each layer adds one capability without touching the one below. │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Each layer is optional. A CLI tool that only needs SQL queries stops at Layer 1. A search feature adds Layer 2. An AI assistant that needs semantic retrieval adds Layer 3. The Yjs layer is always there regardless.
+
+## Any tool that speaks SQL can now read workspace data
+
+This is the practical payoff. The workspace API is TypeScript-first—it understands Yjs, CRDT semantics, table helpers, and LWW resolution. That's fine for application code. It's not fine for a coding agent that just wants to answer a question about your recordings.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Coding Agent / MCP Tool                                        │
+│                                                                 │
+│  "Show me all recordings transcribed this week"                 │
+│                                                                 │
+│  Option A: TypeScript workspace API                             │
+│    workspace.tables.recordings.getAllValid()                     │
+│      .filter(r => r.transcriptionStatus === 'DONE'             │
+│           && r.createdAt > weekAgo)                             │
+│    → requires understanding Yjs, CRDT, table helpers            │
+│                                                                 │
+│  Option B: SQL against the materialized mirror                  │
+│    SELECT * FROM recordings                                     │
+│    WHERE transcription_status = 'DONE'                          │
+│      AND created_at > 1743278400000                             │
+│    → any agent can write this                                   │
+│                                                                 │
+│  Option C: Full-text search (FTS5)                              │
+│    SELECT * FROM recordings_fts                                 │
+│    WHERE recordings_fts MATCH 'meeting notes'                   │
+│    → keyword search over text fields                            │
+│                                                                 │
+│  Option D: Vector similarity (libSQL/Turso)                     │
+│    SELECT * FROM vector_top_k('recordings_idx',                 │
+│      vector32('[0.12, 0.87, ...]'), 10)                         │
+│    JOIN recordings ON recordings.rowid = id                     │
+│    → nearest-neighbor over semantic embeddings                  │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Option A requires the agent to know the workspace API. Options B through D require only SQL—a language every coding agent, analytics tool, CLI, and MCP server already understands. The materialized SQLite layer is what makes workspace data universally queryable without coupling every consumer to the CRDT internals.
+
+## Writes still go through Yjs
+
+The projection is read-only by design. If an MCP tool or CLI command needs to write data, it goes through the workspace API, which writes to the Y.Doc. The observer picks up the change and updates SQLite. The flow is always:
+
+```
+write → Y.Doc → observer → SQLite
+read  → SQLite (or Y.Doc directly, for simple lookups)
+```
+
+Writing directly to SQLite would bypass conflict resolution entirely. Two devices editing the same row offline would produce a split-brain state with no way to merge. Yjs exists precisely to prevent that. SQLite is downstream of it, not a peer.
+
+## Rebuilding from scratch is the proof
+
+The clearest way to understand the relationship: delete the SQLite file. The workspace still works. Open it, and the observer replays the entire Y.Doc into a fresh SQLite database. All your data is there. Nothing was lost because nothing was stored there in the first place—it was always in the CRDT.
+
+That's what "projection" means. SQLite is a view over the Yjs data, materialized to disk for query performance. The CRDT is the record; SQLite is the index.

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
 		"typecheck": "turbo run typecheck",
 		"bump-version": "bun run scripts/bump-version.ts",
 		"clean": "bun run scripts/clean.ts",
-		"nuke": "bun run scripts/clean.ts --nuke"
+		"nuke": "bun run scripts/clean.ts --nuke",
 		"epicenter": "EPICENTER_SERVER=http://localhost:8787 bun run --bun epicenter"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
 		"bump-version": "bun run scripts/bump-version.ts",
 		"clean": "bun run scripts/clean.ts",
 		"nuke": "bun run scripts/clean.ts --nuke"
+		"epicenter": "EPICENTER_SERVER=http://localhost:8787 bun run --bun epicenter"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.8",

--- a/packages/workspace/src/extensions/materializer/sqlite/ddl.ts
+++ b/packages/workspace/src/extensions/materializer/sqlite/ddl.ts
@@ -1,0 +1,211 @@
+/**
+ * Generate SQLite DDL from workspace JSON Schema descriptors.
+ *
+ * The SQLite mirror only needs the latest materialized row shape. When a table
+ * schema has multiple versions, this module picks the highest `_v` variant and
+ * generates a `CREATE TABLE IF NOT EXISTS` statement that preserves the exact
+ * workspace field names.
+ *
+ * Complex values like arrays and objects are stored as JSON-serialized `TEXT`
+ * columns because the mirror is a read cache, not the source-of-truth schema.
+ *
+ * @module
+ */
+
+type JsonSchema = Record<string, unknown>;
+
+/**
+ * Resolve the concrete schema variant used for SQLite DDL generation.
+ *
+ * Multi-version workspace tables expose a `oneOf` where each entry represents a
+ * versioned row shape. The workspace read path migrates rows to the latest
+ * version before materialization, so the SQLite mirror should generate columns
+ * from the schema whose `_v.const` is highest.
+ *
+ * If the schema is not versioned, this returns the original object unchanged.
+ *
+ * @param schema - A JSON Schema object from `describeWorkspace()`
+ * @returns The highest-version object schema when `oneOf` is present, otherwise the original schema
+ *
+ * @example
+ * ```typescript
+ * const resolved = resolveSchema({
+ *   oneOf: [
+ *     { type: 'object', properties: { _v: { const: 1 }, id: { type: 'string' } } },
+ *     { type: 'object', properties: { _v: { const: 2 }, id: { type: 'string' }, title: { type: 'string' } } },
+ *   ],
+ * });
+ *
+ * // Picks the `_v: 2` schema
+ * console.log((resolved.properties as Record<string, unknown>).title);
+ * ```
+ */
+export function resolveSchema(schema: JsonSchema): JsonSchema {
+	const candidates = Array.isArray(schema.oneOf)
+		? schema.oneOf.filter(isRecord)
+		: undefined;
+
+	if (candidates === undefined || candidates.length === 0) {
+		return schema;
+	}
+
+	let resolved: JsonSchema | undefined;
+	let highestVersion = Number.NEGATIVE_INFINITY;
+
+	for (const candidate of candidates) {
+		const version = getSchemaVersion(candidate);
+		if (resolved === undefined || version > highestVersion) {
+			resolved = candidate;
+			highestVersion = version;
+		}
+	}
+
+	if (resolved === undefined) {
+		return schema;
+	}
+
+	return resolved;
+}
+
+/**
+ * Generate a `CREATE TABLE IF NOT EXISTS` statement for a workspace table.
+ *
+ * This mirrors the JSON Schema shape exposed by `describeWorkspace()` into a
+ * SQLite table definition. Required scalar fields become `NOT NULL`, `id`
+ * becomes the primary key, version discriminants use `INTEGER NOT NULL`, and
+ * complex values are stored as JSON text.
+ *
+ * @param tableName - The SQLite table name to create
+ * @param jsonSchema - The JSON Schema from `describeWorkspace().tables[name].schema`
+ * @returns A `CREATE TABLE IF NOT EXISTS` SQL statement
+ *
+ * @example
+ * ```typescript
+ * const sql = generateDdl('posts', {
+ *   type: 'object',
+ *   properties: {
+ *     id: { type: 'string' },
+ *     _v: { const: 2 },
+ *     title: { type: 'string' },
+ *     published: { type: 'boolean' },
+ *   },
+ *   required: ['id', '_v', 'title'],
+ * });
+ *
+ * // CREATE TABLE IF NOT EXISTS "posts" ("id" TEXT PRIMARY KEY, "_v" INTEGER NOT NULL, "title" TEXT NOT NULL, "published" INTEGER)
+ * ```
+ */
+export function generateDdl(
+	tableName: string,
+	jsonSchema: Record<string, unknown>,
+): string {
+	const resolved = resolveSchema(jsonSchema);
+	const properties = getProperties(resolved);
+	const required = getRequiredSet(resolved);
+	const columns = Object.entries(properties).map(([name, propSchema]) =>
+		columnDef(name, toSchema(propSchema), required.has(name)),
+	);
+
+	return `CREATE TABLE IF NOT EXISTS ${quoteIdentifier(tableName)} (${columns.join(', ')})`;
+}
+
+function columnDef(
+	name: string,
+	propSchema: JsonSchema,
+	isRequired: boolean,
+): string {
+	const quotedName = quoteIdentifier(name);
+
+	if (name === 'id') {
+		return `${quotedName} TEXT PRIMARY KEY`;
+	}
+
+	if (name === '_v' && typeof propSchema.const === 'number') {
+		return `${quotedName} INTEGER NOT NULL`;
+	}
+
+	if (Array.isArray(propSchema.enum)) {
+		return appendNullability(`${quotedName} TEXT`, isRequired);
+	}
+
+	const jsonType =
+		typeof propSchema.type === 'string' ? propSchema.type : undefined;
+
+	switch (jsonType) {
+		case 'string':
+			return appendNullability(`${quotedName} TEXT`, isRequired);
+		case 'number':
+			return appendNullability(`${quotedName} REAL`, isRequired);
+		case 'integer':
+			return appendNullability(`${quotedName} INTEGER`, isRequired);
+		case 'boolean':
+			return appendNullability(`${quotedName} INTEGER`, isRequired);
+		case 'object':
+		case 'array':
+			return `${quotedName} TEXT`;
+		default:
+			return appendNullability(`${quotedName} TEXT`, isRequired);
+	}
+}
+
+function appendNullability(column: string, isRequired: boolean) {
+	if (!isRequired) {
+		return column;
+	}
+
+	return `${column} NOT NULL`;
+}
+
+function getSchemaVersion(schema: JsonSchema) {
+	const properties = schema.properties;
+	if (!isRecord(properties)) {
+		return Number.NEGATIVE_INFINITY;
+	}
+
+	const versionSchema = properties._v;
+	if (!isRecord(versionSchema) || typeof versionSchema.const !== 'number') {
+		return Number.NEGATIVE_INFINITY;
+	}
+
+	return versionSchema.const;
+}
+
+function getProperties(schema: JsonSchema) {
+	if (!isRecord(schema.properties)) {
+		throw new Error(
+			'SQLite DDL generation requires an object schema with properties.',
+		);
+	}
+
+	return schema.properties;
+}
+
+function getRequiredSet(schema: JsonSchema) {
+	if (!Array.isArray(schema.required)) {
+		return new Set<string>();
+	}
+
+	return new Set(
+		schema.required.filter(
+			(value): value is string => typeof value === 'string',
+		),
+	);
+}
+
+function quoteIdentifier(identifier: string) {
+	return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+function toSchema(value: unknown): JsonSchema {
+	if (!isRecord(value)) {
+		throw new Error(
+			'SQLite DDL generation requires each property schema to be an object.',
+		);
+	}
+
+	return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/workspace/src/extensions/materializer/sqlite/index.ts
+++ b/packages/workspace/src/extensions/materializer/sqlite/index.ts
@@ -1,0 +1,21 @@
+/**
+ * SQLite mirror extension — auto-materializes Yjs table data into SQLite.
+ *
+ * Yjs stays the source of truth; SQLite is a derived, rebuildable read cache.
+ * Provides SQL queries, full-text search (FTS5), and lifecycle hooks for
+ * vector columns and custom indexes.
+ *
+ * @module
+ */
+
+// createSqliteMirror is exported after Wave 2 creates the file
+export { generateDdl, resolveSchema } from './ddl.js';
+export type {
+	MirrorDatabase,
+	MirrorStatement,
+	SearchOptions,
+	SearchResult,
+	SqliteMirror,
+	SqliteMirrorOptions,
+	SyncChange,
+} from './types.js';

--- a/packages/workspace/src/extensions/materializer/sqlite/types.ts
+++ b/packages/workspace/src/extensions/materializer/sqlite/types.ts
@@ -1,0 +1,165 @@
+/**
+ * Public type surface for the SQLite mirror workspace extension.
+ *
+ * This module stays implementation-free on purpose. Consumers can import the
+ * mirror's options, callbacks, search types, and injected database contract
+ * without pulling in a specific SQLite driver.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * Minimal database interface for the SQLite mirror.
+ *
+ * Structurally compatible with `@tursodatabase/database` (native) and
+ * `@tursodatabase/database-wasm` (browser). The mirror never imports a
+ * specific driver—consumers inject whichever they need.
+ *
+ * @example
+ * ```typescript
+ * const db: MirrorDatabase = createClientDatabase();
+ * await db.exec('PRAGMA journal_mode = WAL');
+ * ```
+ */
+export type MirrorDatabase = {
+	/** Execute raw SQL that does not return rows. */
+	exec(sql: string): Promise<void>;
+
+	/** Prepare a reusable statement for repeated reads or writes. */
+	prepare(sql: string): MirrorStatement;
+};
+
+/**
+ * Minimal prepared statement interface used by the SQLite mirror.
+ *
+ * The mirror only needs async write, many-row read, and single-row read
+ * primitives. Keeping this structural lets callers use native or WASM-backed
+ * Turso drivers with the same extension API.
+ *
+ * @example
+ * ```typescript
+ * const statement = db.prepare('SELECT * FROM posts WHERE id = ?');
+ * const row = await statement.get('post_123');
+ * ```
+ */
+export type MirrorStatement = {
+	/** Run a statement that writes data or otherwise returns no rows. */
+	run(...params: unknown[]): Promise<void>;
+
+	/** Fetch all matching rows as plain objects. */
+	all(...params: unknown[]): Promise<Record<string, unknown>[]>;
+
+	/** Fetch the first matching row, if one exists. */
+	get(...params: unknown[]): Promise<Record<string, unknown> | undefined>;
+};
+
+/**
+ * Configuration for `createSqliteMirror`.
+ *
+ * Use this to choose the injected database, limit which workspace tables get
+ * mirrored, opt into FTS5 search, and hook into lifecycle events.
+ *
+ * @example
+ * ```typescript
+ * const options: SqliteMirrorOptions = {
+ *   db,
+ *   tables: ['posts', 'notes'],
+ *   fts: { posts: ['title', 'body'] },
+ *   debounceMs: 100,
+ * };
+ * ```
+ */
+export type SqliteMirrorOptions = {
+	/** Turso database instance. Caller chooses driver and storage mode. */
+	db: MirrorDatabase;
+
+	/** Which tables to mirror. Default: all workspace tables. */
+	tables?: 'all' | string[];
+
+	/** FTS5 config. Map of table name → column names to index. */
+	fts?: Record<string, string[]>;
+
+	/** Called after mirror tables created and initial data loaded. */
+	onReady?: (db: MirrorDatabase) => void | Promise<void>;
+
+	/** Called after each sync cycle with change details. */
+	onSync?: (db: MirrorDatabase, changes: SyncChange[]) => void | Promise<void>;
+
+	/** Debounce interval in milliseconds before applying queued sync work. @default 100 */
+	debounceMs?: number;
+};
+
+/**
+ * Summary of how one table changed during a sync cycle.
+ *
+ * Use this in `onSync` callbacks to react to fresh upserts and deletions
+ * without re-querying the whole mirror.
+ */
+export type SyncChange = {
+	/** Mirrored table name. */
+	table: string;
+
+	/** Row IDs that were inserted or updated. */
+	upserted: string[];
+
+	/** Row IDs that were deleted. */
+	deleted: string[];
+};
+
+/**
+ * Public API returned by the SQLite mirror extension.
+ *
+ * It exposes the injected database for custom SQL, a full rebuild operation,
+ * and optional FTS5 search across configured mirror tables.
+ *
+ * @example
+ * ```typescript
+ * await mirror.rebuild();
+ * const results = await mirror.search('posts', 'local-first');
+ * ```
+ */
+export type SqliteMirror = {
+	/** Database instance for arbitrary SQL queries. */
+	db: MirrorDatabase;
+
+	/** Rebuild all mirrored tables from Yjs. Drops and recreates. */
+	rebuild: () => Promise<void>;
+
+	/** FTS5 search. Only useful if `fts` config was provided. */
+	search: (
+		table: string,
+		query: string,
+		options?: SearchOptions,
+	) => Promise<SearchResult[]>;
+};
+
+/**
+ * Optional arguments for FTS5 searches.
+ *
+ * Use this when you want to cap result count or choose which indexed column is
+ * used for snippets in the search response.
+ */
+export type SearchOptions = {
+	/** Maximum number of matches to return. */
+	limit?: number;
+
+	/** Column name used to generate the snippet text. */
+	snippetColumn?: string;
+};
+
+/**
+ * One full-text search result returned by the mirror.
+ *
+ * `id` points back to the mirrored row, `snippet` is display-ready text, and
+ * `rank` is the database-provided relevance score.
+ */
+export type SearchResult = {
+	/** ID of the mirrored row that matched the query. */
+	id: string;
+
+	/** Snippet generated from indexed text content. */
+	snippet: string;
+
+	/** Relevance score returned by the FTS query. */
+	rank: number;
+};

--- a/specs/20260406T180000-sqlite-mirror-extension.md
+++ b/specs/20260406T180000-sqlite-mirror-extension.md
@@ -108,18 +108,29 @@ JOIN recordings ON recordings.rowid = id;
 
 Supported vector types: `F64_BLOB`, `F32_BLOB`, `F16_BLOB`, `FB16_BLOB`, `F8_BLOB`, `F1BIT_BLOB`. Distance functions: `vector_distance_cos`, `vector_distance_l2`.
 
-### libSQL vs Vanilla SQLite: Platform Matrix
+### SQLite Driver: `@tursodatabase/database` Family
 
-| Platform | Current SQLite | libSQL Option | Vector Support | FTS5 |
-|---|---|---|---|---|
-| **Browser** | `@libsql/client-wasm` (already used by filesystem) | Same | Unclear—DiskANN may be server-only in WASM builds | Yes |
-| **Desktop (Tauri)** | `bun:sqlite` (vanilla) | `libsql` Rust crate via Tauri command | Yes (native) | Yes |
-| **CLI (Bun)** | `bun:sqlite` (vanilla) | `@libsql/client` (Node/Bun native) | Yes | Yes |
-| **Server** | `better-sqlite3` (dev dep) | `@libsql/client` | Yes | Yes |
+Turso publishes two packages with the same `better-sqlite3`-compatible API:
 
-**Key finding**: `@libsql/client-wasm` is already a dependency in `packages/filesystem`. Using libSQL everywhere gives us vector support on desktop/server. Browser vector support needs verification—WASM builds may not include the DiskANN index. FTS5 works everywhere regardless.
+| Package | Platform | Persistence | Notes |
+|---|---|---|---|
+| `@tursodatabase/database` | Node, Bun, Deno | File-based | Native bindings, sync API with async option |
+| `@tursodatabase/database-wasm` | Browser | OPFS (persistent across reloads) | WASM, all methods async, requires COEP/COOP headers |
 
-**Implication**: Use libSQL as the default SQLite driver. Fall back to vanilla SQLite only if libSQL WASM proves too large or missing vector support in browser. The mirror extension should accept an injected `Client` so the driver choice is the consumer's concern.
+Both packages include the full Turso/libSQL engine: FTS5, vector columns (`F32_BLOB`), DiskANN indexes (`libsql_vector_idx`), `vector_top_k()`. Same API surface:
+
+```typescript
+import { connect } from '@tursodatabase/database';       // Node/Bun
+import { connect } from '@tursodatabase/database-wasm';  // Browser
+
+const db = await connect(':memory:');  // or 'file:workspace.db'
+await db.exec('CREATE TABLE recordings (id TEXT PRIMARY KEY, title TEXT)');
+const rows = await db.prepare('SELECT * FROM recordings').all();
+```
+
+**Key finding**: `@libsql/client-wasm` is already used by `packages/filesystem`, but `@tursodatabase/database-wasm` is the newer, cleaner API (better-sqlite3 style vs HTTP client style). Both use the same libSQL engine under the hood.
+
+**Implication**: Use `@tursodatabase/database` (native) and `@tursodatabase/database-wasm` (browser) as the standard SQLite driver. The mirror extension accepts an injected database instance, so the driver choice is the consumer's concern. This gives us vectors + FTS5 everywhere, including browser.
 
 ### Drizzle ORM: Needed or Not?
 
@@ -141,7 +152,7 @@ Supported vector types: `F64_BLOB`, `F32_BLOB`, `F16_BLOB`, `FB16_BLOB`, `F8_BLO
 | Decision | Choice | Rationale |
 |---|---|---|
 | DDL generation | Auto-generate from workspace JSON Schema | Eliminates schema duplication. `describeWorkspace()` already produces JSON Schema per table. |
-| SQL driver | Raw `@libsql/client` (injected) | No Drizzle in core. FTS5 and vectors require raw SQL anyway. Driver injection lets consumers choose WASM vs native. |
+| SQL driver | `@tursodatabase/database` family (injected) | No Drizzle in core. FTS5 and vectors require raw SQL. Driver injection lets consumers choose native vs WASM. `better-sqlite3`-compatible API. |
 | FTS5 | Config option inside the extension | FTS triggers reference mirrored tables—same concern. Separate extension would need to reach into mirror internals. |
 | Vectors | `onReady`/`onSync` lifecycle hooks | Vector columns and embeddings are app-specific (which columns, which model, what dimensions). Hooks give full control without baking AI concerns into the core. |
 | Filesystem sqlite-index | Stays separate | It has derived columns (`path`, `content`), custom logic, in-memory storage. It's a specialized projection, not a generic mirror. |
@@ -244,13 +255,13 @@ FTS5 triggers fire automatically        ← FTS index updated
 
 type SqliteMirrorOptions = {
   /**
-   * libSQL client instance. Caller chooses driver and storage mode.
+   * Turso database instance. Caller chooses driver and storage mode.
    *
-   * Browser: createClient({ url: ':memory:' }) from @libsql/client-wasm
-   * Desktop: createClient({ url: 'file:///path/to/workspace.db' })
-   * CLI:     createClient({ url: 'file:workspace.db' })
+   * Browser: connect(':memory:') from @tursodatabase/database-wasm
+   * Desktop: connect('workspace-mirror.db') from @tursodatabase/database
+   * CLI:     connect('workspace-mirror.db') from @tursodatabase/database
    */
-  client: Client;
+  db: Database;
 
   /**
    * Which tables to mirror. Default: all workspace tables.
@@ -270,7 +281,7 @@ type SqliteMirrorOptions = {
    * Called after mirror tables are created and initial data is loaded.
    * Use for: vector columns, custom indexes, views, additional tables.
    */
-  onReady?: (db: Client) => void | Promise<void>;
+  onReady?: (db: Database) => void | Promise<void>;
 
   /**
    * Called after each sync cycle (batch of observer changes applied).
@@ -278,7 +289,7 @@ type SqliteMirrorOptions = {
    *
    * `changes` contains which tables had rows upserted or deleted.
    */
-  onSync?: (db: Client, changes: SyncChange[]) => void | Promise<void>;
+  onSync?: (db: Database, changes: SyncChange[]) => void | Promise<void>;
 
   /** Debounce interval (ms). @default 100 */
   debounceMs?: number;
@@ -293,8 +304,8 @@ type SyncChange = {
 // ── Extension return type ─────────────────────────────────────
 
 type SqliteMirror = {
-  /** Raw libSQL client for arbitrary SQL. */
-  client: Client;
+  /** Turso database instance for arbitrary SQL. */
+  db: Database;
 
   /** Rebuild all mirrored tables from Yjs. Drops and recreates. */
   rebuild: () => Promise<void>;
@@ -321,12 +332,12 @@ type SearchResult = {
 **Minimal (just mirror, no FTS):**
 
 ```typescript
-import { createClient } from '@libsql/client-wasm';
+import { connect } from '@tursodatabase/database-wasm';
 
 export const workspace = createWorkspace(whisperingDefinition)
   .withExtension('persistence', indexeddbPersistence)
   .withWorkspaceExtension('sqlite', createSqliteMirror({
-    client: createClient({ url: ':memory:' }),
+    db: await connect(':memory:'),
   }));
 ```
 
@@ -336,7 +347,7 @@ export const workspace = createWorkspace(whisperingDefinition)
 export const workspace = createWorkspace(whisperingDefinition)
   .withExtension('persistence', indexeddbPersistence)
   .withWorkspaceExtension('sqlite', createSqliteMirror({
-    client: createClient({ url: ':memory:' }),
+    db: await connect(':memory:'),
     fts: {
       recordings: ['title', 'transcribedText'],
       transformations: ['title', 'description'],
@@ -347,42 +358,42 @@ export const workspace = createWorkspace(whisperingDefinition)
 **With vectors (desktop, via lifecycle hook):**
 
 ```typescript
-export const workspace = createWorkspace(whisperingDefinition)
+import { connect } from '@tursodatabase/database';
+
+  export const workspace = createWorkspace(whisperingDefinition)
   .withExtension('persistence', indexeddbPersistence)
   .withWorkspaceExtension('sqlite', createSqliteMirror({
-    client: createClient({ url: 'file:workspace-mirror.db' }),
+    db: await connect('workspace-mirror.db'),
     fts: {
       recordings: ['title', 'transcribedText'],
     },
     async onReady(db) {
-      await db.execute(
+      await db.exec(
         'ALTER TABLE recordings ADD COLUMN IF NOT EXISTS embedding F32_BLOB(1536)'
       );
-      await db.execute(
+      await db.exec(
         'CREATE INDEX IF NOT EXISTS recordings_vec_idx ON recordings(libsql_vector_idx(embedding))'
       );
     },
     async onSync(db, changes) {
-      // Re-embed changed recordings
       const recordingChanges = changes.find(c => c.table === 'recordings');
       if (!recordingChanges) return;
       for (const id of recordingChanges.upserted) {
-        const row = await db.execute('SELECT transcribed_text FROM recordings WHERE id = ?', [id]);
-        if (!row.rows[0]) continue;
-        const embedding = await getEmbedding(row.rows[0].transcribed_text as string);
-        await db.execute(
-          'UPDATE recordings SET embedding = vector32(?) WHERE id = ?',
-          [JSON.stringify(embedding), id]
+        const row = await db.prepare('SELECT transcribed_text FROM recordings WHERE id = ?').get(id);
+        if (!row) continue;
+        const embedding = await getEmbedding(row.transcribed_text as string);
+        await db.prepare('UPDATE recordings SET embedding = vector32(?) WHERE id = ?').run(
+          JSON.stringify(embedding), id
         );
       }
     },
   }));
 ```
 
-**With optional Drizzle typed queries (app-local):**
+**With optional Drizzle typed queries (app-local, if you really want them):**
 
 ```typescript
-// sqlite/schema.ts — hand-written, opt-in
+// sqlite/schema.ts — hand-written, opt-in, only if you need typed SELECT queries
 import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
 
 export const recordings = sqliteTable('recordings', {
@@ -409,9 +420,9 @@ const done = await db.select().from(schema.recordings)
 queryData: defineQuery({
   description: 'Run a read-only SQL query against workspace data',
   input: type({ sql: 'string' }),
-  handler: ({ sql }) => {
-    const result = workspace.extensions.sqlite.client.execute(sql);
-    return { rows: result.rows, columns: result.columns };
+  handler: async ({ sql }) => {
+    const rows = await workspace.extensions.sqlite.db.prepare(sql).all();
+    return { rows };
   },
 });
 ```
@@ -426,7 +437,7 @@ queryData: defineQuery({
   - Await `ctx.whenReady` before touching SQLite
   - Generate and execute DDL for each table
   - Full load: `table.getAllValid()` → batch `INSERT OR REPLACE INTO`
-  - Return `{ client, rebuild }`
+  - Return `{ db, rebuild }`
 - [ ] **1.4** Implement observer-based incremental sync:
   - `table.observe()` per mirrored table
   - Debounced batch: collect changed IDs, then `INSERT OR REPLACE` for upserts, `DELETE` for removals
@@ -495,12 +506,12 @@ queryData: defineQuery({
 
 ## Open Questions
 
-1. **libSQL WASM vector support**: Does `@libsql/client-wasm` include `F32_BLOB` columns and `libsql_vector_idx`? DiskANN may require native code not available in WASM. If not, vectors are desktop/server-only.
+1. **WASM vector support**: Does `@tursodatabase/database-wasm` include `F32_BLOB` columns and `libsql_vector_idx`? DiskANN may require native code not available in WASM. If not, vectors are desktop/server-only.
    - **Recommendation**: Verify by testing. If WASM lacks vectors, document it. FTS5 works everywhere regardless—that's the primary browser use case.
 
-2. **Encrypted on-disk mirrors**: If the SQLite file is persistent and the workspace uses encryption, should we encrypt the SQLite file too?
-   - Options: (a) Accept plaintext (local disk is trusted), (b) Use SQLCipher/libSQL encryption, (c) Only allow `:memory:` for encrypted workspaces
-   - **Recommendation**: Accept plaintext for v1. The user's local filesystem is the same trust boundary as IndexedDB. Revisit if users request at-rest encryption for the mirror.
+2. **Encrypted on-disk mirrors**: `@tursodatabase/database-wasm` uses OPFS for browser persistence (survives page reloads). If the workspace uses encryption, the OPFS-persisted SQLite file contains plaintext.
+   - Options: (a) Accept plaintext (same trust boundary as IndexedDB), (b) Use libSQL encryption, (c) Only allow `:memory:` for encrypted workspaces
+   - **Recommendation**: Accept plaintext for v1. The user's local filesystem / OPFS is the same trust boundary as IndexedDB. Revisit if users request at-rest encryption for the mirror.
 
 3. **Column name mapping**: Workspace schemas use camelCase (`transcribedText`). Should SQLite columns be snake_case (`transcribed_text`) or match the workspace?
    - Options: (a) Match workspace camelCase exactly, (b) Convert to snake_case for SQL convention
@@ -510,13 +521,13 @@ queryData: defineQuery({
    - Options: (a) Tables only, (b) Also mirror KV as a `kv` table with `key TEXT PRIMARY KEY, value TEXT` columns
    - **Recommendation**: Tables only for v1. KV is settings/preferences—not useful for SQL queries or agent access.
 
-5. **Should the extension own the client lifecycle?**: Currently the caller creates and passes the `Client`. Should the extension optionally accept a file path and create the client internally?
-   - Options: (a) Always injected, (b) Accept `client` OR `filePath`, create client if path given
-   - **Recommendation**: Support both. `filePath` is sugar for the common case; `client` gives full control.
+5. **Should the extension own the database lifecycle?**: Currently the caller creates and passes the `Database`. Should the extension optionally accept a path string and create the database internally?
+   - Options: (a) Always injected, (b) Accept `db` OR `path`, create database if path given
+   - **Recommendation**: Support both. `path` is sugar for the common case; `db` gives full control.
 
 ## Success Criteria
 
-- [ ] `createSqliteMirror({ client })` mirrors all workspace tables to SQLite with zero configuration
+- [ ] `createSqliteMirror({ db })` mirrors all workspace tables to SQLite with zero configuration
 - [ ] DDL is auto-generated from workspace JSON Schema—no manual schema declaration required
 - [ ] Incremental sync: Yjs table mutations appear in SQLite within `debounceMs`
 - [ ] `fts` config generates working FTS5 virtual tables with trigger-based sync

--- a/specs/20260406T180000-sqlite-mirror-extension.md
+++ b/specs/20260406T180000-sqlite-mirror-extension.md
@@ -234,6 +234,42 @@ INSERT OR REPLACE INTO recordings ...   ← SQLite updated
 FTS5 triggers fire automatically        ← FTS index updated
 ```
 
+### Multi-Version Table Handling
+
+Multi-version tables produce `{ "oneOf": [v1Schema, v2Schema] }` from `describeWorkspace()` instead of a flat object schema. The DDL generator must:
+
+1. Detect `oneOf` in the schema
+2. Pick the version with the highest `_v.const` value — the last entry in `oneOf` is always the latest, but we use `_v.const` for safety
+3. Generate DDL from that version's `properties` and `required` arrays
+4. This is safe because `table.getAllValid()` runs migrations — all returned rows are already at the latest version
+
+```json
+// describeWorkspace() output for a multi-version table
+{
+  "oneOf": [
+    { "type": "object", "properties": { "_v": { "const": 1 }, "title": ... }, ... },
+    { "type": "object", "properties": { "_v": { "const": 2 }, "title": ..., "views": ... }, ... }
+  ]
+}
+// DDL generator picks the schema where _v.const is highest (2)
+// → CREATE TABLE posts (id TEXT PRIMARY KEY, title TEXT NOT NULL, views REAL NOT NULL, _v INTEGER NOT NULL)
+```
+
+### Async Everywhere
+
+Both `@tursodatabase/database` (native) and `@tursodatabase/database-wasm` (browser) use async APIs — `await db.exec()`, `await db.prepare().run()`. The extension uses `async/await` throughout. No sync/async branching needed.
+
+### OPFS Browser Persistence
+
+`@tursodatabase/database-wasm` uses OPFS (Origin Private File System) for persistent browser storage — SQLite files survive page reloads without IndexedDB. This requires COEP/COOP headers:
+
+```
+Cross-Origin-Embedder-Policy: require-corp
+Cross-Origin-Opener-Policy: same-origin
+```
+
+Apps already using SharedArrayBuffer (common for Yjs sync) will have these headers set. For `:memory:` mode, OPFS isn't used and no headers are needed.
+
 ### JSON Schema → DDL Type Mapping
 
 | JSON Schema | SQLite Type | Notes |
@@ -242,10 +278,10 @@ FTS5 triggers fire automatically        ← FTS index updated
 | `{ "type": "number" }` | `REAL` | Floats |
 | `{ "type": "integer" }` | `INTEGER` | When JSON Schema has `"type": "integer"` |
 | `{ "type": "boolean" }` | `INTEGER` | 0/1 |
-| nullable (anyOf with null) | Column allows `NULL` | |
-| `{ "type": "object" }` or `{ "type": "array" }` | `TEXT` | JSON-serialized |
-| Union of string literals | `TEXT` | e.g., `'DONE' | 'PENDING'` → `TEXT` |
-| `_v` field | `INTEGER NOT NULL` | Version discriminant, always present |
+| `{ "enum": ["A", "B"] }` | `TEXT` | String literal unions from arktype |
+| Not in `required[]` | Column allows `NULL` | Arktype optional fields (`'key?'`) |
+| `{ "type": "object" }` or `{ "type": "array" }` | `TEXT` | JSON-serialized via `JSON.stringify` |
+| `{ "const": N }` (`_v` field) | `INTEGER NOT NULL` | Version discriminant, always present |
 | `id` field | `TEXT PRIMARY KEY` | Always the primary key |
 
 ## API Design
@@ -432,16 +468,16 @@ queryData: defineQuery({
 ### Phase 1: Core Mirror (no FTS, no vectors)
 
 - [ ] **1.1** Create `packages/workspace/src/extensions/materializer/sqlite/` directory
-- [ ] **1.2** Implement `generateDDL(tableDefinitions)`: walk `describeWorkspace()` JSON Schema per table → `CREATE TABLE IF NOT EXISTS` statements using the type mapping table above
+- [ ] **1.2** Implement `generateDDL(jsonSchema)`: walk JSON Schema per table → `CREATE TABLE IF NOT EXISTS`. Handle `oneOf` (multi-version) by picking the schema with the highest `_v.const`. Use `required[]` to determine NOT NULL vs nullable.
 - [ ] **1.3** Implement `createSqliteMirror(options)` extension factory:
   - Await `ctx.whenReady` before touching SQLite
   - Generate and execute DDL for each table
   - Full load: `table.getAllValid()` → batch `INSERT OR REPLACE INTO`
   - Return `{ db, rebuild }`
 - [ ] **1.4** Implement observer-based incremental sync:
-  - `table.observe()` per mirrored table
-  - Debounced batch: collect changed IDs, then `INSERT OR REPLACE` for upserts, `DELETE` for removals
-  - Call `onSync` hook after each batch
+  - `table.observe((changedIds: ReadonlySet<string>) => ...)` per mirrored table — returns unsubscribe fn
+  - Debounced batch: collect changed IDs into a Set, then for each ID: `table.get(id)` → `valid` = `INSERT OR REPLACE`, `not_found` = `DELETE`
+  - Call `onSync` hook after each batch with `{ table, upserted, deleted }` arrays
 - [ ] **1.5** Implement `dispose()`: unsubscribe observers, close client if owned
 - [ ] **1.6** Add tests: mirror creation, full load, incremental sync, rebuild
 

--- a/specs/20260406T180000-sqlite-mirror-extension.md
+++ b/specs/20260406T180000-sqlite-mirror-extension.md
@@ -1,0 +1,539 @@
+# SQLite Mirror Extension
+
+**Date**: 2026-04-06
+**Status**: Draft
+**Author**: AI-assisted
+**Related**: `docs/articles/sqlite-is-a-projection-not-a-database.md`
+
+## Overview
+
+A workspace extension that auto-materializes Yjs table data into SQLite for SQL queries, full-text search, and vector similarity search. Yjs stays the source of truth; SQLite is a derived, rebuildable read cache.
+
+## Motivation
+
+### Current State
+
+Workspace persistence stores opaque Yjs binary updates—not queryable table data:
+
+```typescript
+// packages/workspace/src/extensions/persistence/sqlite.ts
+db.run('CREATE TABLE IF NOT EXISTS updates (id INTEGER PRIMARY KEY AUTOINCREMENT, data BLOB NOT NULL)');
+// INSERT INTO updates (data) VALUES (<Yjs binary blob>)
+```
+
+The only SQLite materialization that exists is the filesystem sqlite-index—a specialized, hardcoded extension for one table (`files`) with derived columns (`path`, `content`):
+
+```typescript
+// packages/filesystem/src/extensions/sqlite-index/index.ts
+// - In-memory only (:memory:), rebuilt every page load
+// - Hand-written Drizzle schema (duplicates workspace schema)
+// - FTS5 for file content search
+// - Not reusable for other tables
+```
+
+Application data access is all in-memory via Yjs:
+
+```typescript
+// apps/whispering — every table access pattern
+workspace.tables.recordings.getAllValid()   // load all rows into memory
+map.get(id)                                // lookup by ID
+runs.filter(r => r.transformationId === id) // client-side JS filter
+```
+
+This creates problems:
+
+1. **No SQL access**: Coding agents, MCP tools, and CLI commands can't query workspace data without understanding Yjs/CRDT internals. SQL is universal; the workspace API is not.
+2. **No full-text search**: Searching recording transcriptions requires scanning every row in memory.
+3. **No vector search**: Semantic similarity search over embeddings is impossible without SQLite vector columns.
+4. **No portable export**: Users can't get a `.sqlite` file they can open in any SQL tool.
+5. **No reusable pattern**: The filesystem sqlite-index is hardcoded to one table. Building equivalent functionality for Whispering's 5 tables means writing 5 separate extensions.
+
+### Desired State
+
+```typescript
+// One line in client.ts — all workspace tables materialized to SQLite
+export const workspace = createWorkspace(whisperingDefinition)
+  .withExtension('persistence', indexeddbPersistence)
+  .withWorkspaceExtension('sqlite', createSqliteMirror({
+    fts: {
+      recordings: ['title', 'transcribedText'],
+    },
+  }));
+
+// Agent/MCP: plain SQL
+workspace.extensions.sqlite.client.execute(
+  'SELECT * FROM recordings WHERE transcription_status = ? AND created_at > ?',
+  ['DONE', '2026-03-30']
+);
+
+// FTS:
+workspace.extensions.sqlite.search('recordings', 'meeting notes');
+```
+
+## Research Findings
+
+### How Other Frameworks Handle This
+
+| Framework | Schema Declaration | SQLite Role | FTS Approach |
+|---|---|---|---|
+| **PowerSync** | Manual JS schema, auto-generates SQLite tables via `powersync_replace_schema()` | Persistent materialization | FTS5 virtual tables + triggers (manual setup) |
+| **ElectricSQL** | Manual local SQL tables, shape sync fills them | Persistent materialization | Postgres GIN indexes (manual SQL migrations) |
+| **LiveStore** | Declare SQLite tables + event materializers | SQLite is the state store | Not built-in |
+| **cr-sqlite** | Regular tables upgraded via `crsql_as_crr()` | SQLite IS the CRDT | FTS5 via extension |
+| **Triplit** | Schema → KV store (not relational) | KV backend | None |
+| **TinyBase** | In-memory store, SQLite = optional persistence | Persistence only | None |
+
+**Key finding**: PowerSync's model is closest to what we need—manual schema declaration in code, auto-materialization into SQLite, FTS as a separate trigger-based layer. But we can go further: our workspace schemas already carry enough type information (via JSON Schema from `describeWorkspace()`) to auto-generate DDL without any manual schema declaration.
+
+**Key finding**: No framework we surveyed auto-generates Drizzle ORM schemas from CRDT definitions. They either require manual SQL/schema declaration or use opaque KV storage. This validates our approach of generating raw DDL and keeping Drizzle as an optional, app-local concern.
+
+### Turso/libSQL Vector Support
+
+libSQL (Turso's SQLite fork) has native vector search—no extensions:
+
+```sql
+-- Vector column (1536-dim float32)
+CREATE TABLE recordings (
+  id TEXT PRIMARY KEY,
+  embedding F32_BLOB(1536)
+);
+
+-- DiskANN index (auto-maintained on INSERT/UPDATE/DELETE)
+CREATE INDEX recordings_vec_idx ON recordings(libsql_vector_idx(embedding));
+
+-- Query: top-k nearest neighbors
+SELECT * FROM vector_top_k('recordings_vec_idx', vector32('[0.12, ...]'), 10)
+JOIN recordings ON recordings.rowid = id;
+```
+
+Supported vector types: `F64_BLOB`, `F32_BLOB`, `F16_BLOB`, `FB16_BLOB`, `F8_BLOB`, `F1BIT_BLOB`. Distance functions: `vector_distance_cos`, `vector_distance_l2`.
+
+### libSQL vs Vanilla SQLite: Platform Matrix
+
+| Platform | Current SQLite | libSQL Option | Vector Support | FTS5 |
+|---|---|---|---|---|
+| **Browser** | `@libsql/client-wasm` (already used by filesystem) | Same | Unclear—DiskANN may be server-only in WASM builds | Yes |
+| **Desktop (Tauri)** | `bun:sqlite` (vanilla) | `libsql` Rust crate via Tauri command | Yes (native) | Yes |
+| **CLI (Bun)** | `bun:sqlite` (vanilla) | `@libsql/client` (Node/Bun native) | Yes | Yes |
+| **Server** | `better-sqlite3` (dev dep) | `@libsql/client` | Yes | Yes |
+
+**Key finding**: `@libsql/client-wasm` is already a dependency in `packages/filesystem`. Using libSQL everywhere gives us vector support on desktop/server. Browser vector support needs verification—WASM builds may not include the DiskANN index. FTS5 works everywhere regardless.
+
+**Implication**: Use libSQL as the default SQLite driver. Fall back to vanilla SQLite only if libSQL WASM proves too large or missing vector support in browser. The mirror extension should accept an injected `Client` so the driver choice is the consumer's concern.
+
+### Drizzle ORM: Needed or Not?
+
+| Concern | Drizzle | Raw SQL |
+|---|---|---|
+| DDL generation (`CREATE TABLE`) | Requires hand-written schema | Generate from JSON Schema—simpler |
+| INSERT/UPDATE/DELETE sync | `db.insert().values()` | Parameterized SQL—just as easy |
+| FTS5 virtual tables | **Not supported** | Raw SQL (native) |
+| Vector columns | **Not supported** | Raw SQL (native) |
+| Typed SELECT queries | Real value—autocomplete, type safety | Returns `unknown[]` |
+| Agent SQL queries | Agents write raw SQL regardless | Native |
+
+**Key finding**: Drizzle adds no value for the mirror sync engine (DDL + INSERT/UPDATE/DELETE) and doesn't support FTS5 or vectors. Its only value is typed SELECT queries in TypeScript app code—a concern that belongs to the app, not the extension.
+
+**Implication**: The extension core uses raw SQL only. Zero Drizzle dependency. Apps that want typed queries add Drizzle themselves with a hand-written schema against the mirrored tables.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| DDL generation | Auto-generate from workspace JSON Schema | Eliminates schema duplication. `describeWorkspace()` already produces JSON Schema per table. |
+| SQL driver | Raw `@libsql/client` (injected) | No Drizzle in core. FTS5 and vectors require raw SQL anyway. Driver injection lets consumers choose WASM vs native. |
+| FTS5 | Config option inside the extension | FTS triggers reference mirrored tables—same concern. Separate extension would need to reach into mirror internals. |
+| Vectors | `onReady`/`onSync` lifecycle hooks | Vector columns and embeddings are app-specific (which columns, which model, what dimensions). Hooks give full control without baking AI concerns into the core. |
+| Filesystem sqlite-index | Stays separate | It has derived columns (`path`, `content`), custom logic, in-memory storage. It's a specialized projection, not a generic mirror. |
+| Drizzle typed queries | Opt-in, app-local | Apps declare a Drizzle schema locally only when they need typed SELECT queries. Not the extension's concern. |
+| Storage mode | Injected client (caller decides `:memory:` vs file path) | Browser apps may want in-memory; CLI/desktop may want persistent. Extension doesn't decide. |
+| Sync strategy | Observer-based with debounce | Match existing filesystem sqlite-index pattern. `table.observe()` → debounced batch upsert/delete. |
+| `ctx.whenReady` | **Must await** before first sync | If SQLite materializes before Yjs persistence hydrates, we get partial data. The filesystem sqlite-index appears to skip this—we won't. |
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Workspace (Yjs Y.Doc)                                          │
+│                                                                 │
+│  tables.recordings  ←→  Y.Array("table:recordings")            │
+│  tables.transformations ←→ Y.Array("table:transformations")     │
+│  kv.*               ←→  Y.Array("kv")                          │
+│                                                                 │
+│  Source of truth. All writes go here.                           │
+└────────────┬──────────────────────────────────┬─────────────────┘
+             │ table.observe() per table        │
+             ▼                                  │
+┌────────────────────────────────┐              │
+│  createSqliteMirror()          │              │
+│                                │              │
+│  1. await ctx.whenReady        │              │
+│  2. generateDDL(jsonSchema)    │              │
+│     → CREATE TABLE per table   │              │
+│  3. fullLoad: getAllValid()     │              │
+│     → INSERT INTO ...          │              │
+│  4. fts: CREATE VIRTUAL TABLE  │              │
+│     + INSERT/UPDATE/DELETE      │              │
+│     triggers                   │              │
+│  5. onReady(db) hook           │              │
+│  6. observe → debounced sync   │              │
+│  7. onSync(db, changes) hook   │              │
+│                                │              │
+│  Exposes: { client, rebuild,   │              │
+│    search? }                   │              │
+└────────────┬───────────────────┘              │
+             │                                  │
+             ▼                                  │
+┌────────────────────────────────┐              │
+│  SQLite (libSQL)               │              │
+│                                │              │
+│  recordings     (auto DDL)     │              │
+│  transformations (auto DDL)    │              │
+│  recordings_fts (FTS5)         │              │
+│  [vector cols]  (via onReady)  │              │
+│  [custom indexes] (via onReady)│              │
+└────────────────────────────────┘              │
+                                                │
+          ┌──── reads ────┐                     │
+          ▼               ▼                     │
+  ┌──────────────┐ ┌────────────┐  ┌───────────┴───────┐
+  │ Coding Agent │ │ CLI tool   │  │ App code (writes) │
+  │ (SQL)        │ │ (SQL)      │  │ (workspace API)   │
+  └──────────────┘ └────────────┘  └───────────────────┘
+```
+
+### Write Flow
+
+```
+App code
+  │
+  ▼
+workspace.tables.recordings.set(row)    ← writes to Yjs Y.Array
+  │
+  ▼
+Y.Array fires observe callback
+  │
+  ▼
+createSqliteMirror debounced sync
+  │
+  ▼
+INSERT OR REPLACE INTO recordings ...   ← SQLite updated
+  │
+  ▼
+FTS5 triggers fire automatically        ← FTS index updated
+```
+
+### JSON Schema → DDL Type Mapping
+
+| JSON Schema | SQLite Type | Notes |
+|---|---|---|
+| `{ "type": "string" }` | `TEXT` | All strings, including branded IDs |
+| `{ "type": "number" }` | `REAL` | Floats |
+| `{ "type": "integer" }` | `INTEGER` | When JSON Schema has `"type": "integer"` |
+| `{ "type": "boolean" }` | `INTEGER` | 0/1 |
+| nullable (anyOf with null) | Column allows `NULL` | |
+| `{ "type": "object" }` or `{ "type": "array" }` | `TEXT` | JSON-serialized |
+| Union of string literals | `TEXT` | e.g., `'DONE' | 'PENDING'` → `TEXT` |
+| `_v` field | `INTEGER NOT NULL` | Version discriminant, always present |
+| `id` field | `TEXT PRIMARY KEY` | Always the primary key |
+
+## API Design
+
+```typescript
+// ── Types ─────────────────────────────────────────────────────
+
+type SqliteMirrorOptions = {
+  /**
+   * libSQL client instance. Caller chooses driver and storage mode.
+   *
+   * Browser: createClient({ url: ':memory:' }) from @libsql/client-wasm
+   * Desktop: createClient({ url: 'file:///path/to/workspace.db' })
+   * CLI:     createClient({ url: 'file:workspace.db' })
+   */
+  client: Client;
+
+  /**
+   * Which tables to mirror. Default: all workspace tables.
+   * Use an array to mirror a subset.
+   */
+  tables?: 'all' | string[];
+
+  /**
+   * FTS5 full-text search configuration.
+   * Map of table name → column names to index.
+   *
+   * Generates FTS5 virtual tables and INSERT/UPDATE/DELETE triggers.
+   */
+  fts?: Record<string, string[]>;
+
+  /**
+   * Called after mirror tables are created and initial data is loaded.
+   * Use for: vector columns, custom indexes, views, additional tables.
+   */
+  onReady?: (db: Client) => void | Promise<void>;
+
+  /**
+   * Called after each sync cycle (batch of observer changes applied).
+   * Use for: updating vector embeddings, custom derived columns.
+   *
+   * `changes` contains which tables had rows upserted or deleted.
+   */
+  onSync?: (db: Client, changes: SyncChange[]) => void | Promise<void>;
+
+  /** Debounce interval (ms). @default 100 */
+  debounceMs?: number;
+};
+
+type SyncChange = {
+  table: string;
+  upserted: string[];  // row IDs that were inserted or updated
+  deleted: string[];    // row IDs that were deleted
+};
+
+// ── Extension return type ─────────────────────────────────────
+
+type SqliteMirror = {
+  /** Raw libSQL client for arbitrary SQL. */
+  client: Client;
+
+  /** Rebuild all mirrored tables from Yjs. Drops and recreates. */
+  rebuild: () => Promise<void>;
+
+  /**
+   * FTS5 search helper. Only available if `fts` config was provided.
+   * Returns rows with snippet highlights.
+   */
+  search: (table: string, query: string, options?: {
+    limit?: number;
+    snippetColumn?: string;
+  }) => Promise<SearchResult[]>;
+};
+
+type SearchResult = {
+  id: string;
+  snippet: string;
+  rank: number;
+};
+```
+
+### Call-Site Examples
+
+**Minimal (just mirror, no FTS):**
+
+```typescript
+import { createClient } from '@libsql/client-wasm';
+
+export const workspace = createWorkspace(whisperingDefinition)
+  .withExtension('persistence', indexeddbPersistence)
+  .withWorkspaceExtension('sqlite', createSqliteMirror({
+    client: createClient({ url: ':memory:' }),
+  }));
+```
+
+**With FTS:**
+
+```typescript
+export const workspace = createWorkspace(whisperingDefinition)
+  .withExtension('persistence', indexeddbPersistence)
+  .withWorkspaceExtension('sqlite', createSqliteMirror({
+    client: createClient({ url: ':memory:' }),
+    fts: {
+      recordings: ['title', 'transcribedText'],
+      transformations: ['title', 'description'],
+    },
+  }));
+```
+
+**With vectors (desktop, via lifecycle hook):**
+
+```typescript
+export const workspace = createWorkspace(whisperingDefinition)
+  .withExtension('persistence', indexeddbPersistence)
+  .withWorkspaceExtension('sqlite', createSqliteMirror({
+    client: createClient({ url: 'file:workspace-mirror.db' }),
+    fts: {
+      recordings: ['title', 'transcribedText'],
+    },
+    async onReady(db) {
+      await db.execute(
+        'ALTER TABLE recordings ADD COLUMN IF NOT EXISTS embedding F32_BLOB(1536)'
+      );
+      await db.execute(
+        'CREATE INDEX IF NOT EXISTS recordings_vec_idx ON recordings(libsql_vector_idx(embedding))'
+      );
+    },
+    async onSync(db, changes) {
+      // Re-embed changed recordings
+      const recordingChanges = changes.find(c => c.table === 'recordings');
+      if (!recordingChanges) return;
+      for (const id of recordingChanges.upserted) {
+        const row = await db.execute('SELECT transcribed_text FROM recordings WHERE id = ?', [id]);
+        if (!row.rows[0]) continue;
+        const embedding = await getEmbedding(row.rows[0].transcribed_text as string);
+        await db.execute(
+          'UPDATE recordings SET embedding = vector32(?) WHERE id = ?',
+          [JSON.stringify(embedding), id]
+        );
+      }
+    },
+  }));
+```
+
+**With optional Drizzle typed queries (app-local):**
+
+```typescript
+// sqlite/schema.ts — hand-written, opt-in
+import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+
+export const recordings = sqliteTable('recordings', {
+  id: text('id').primaryKey(),
+  title: text('title').notNull(),
+  transcribedText: text('transcribed_text').notNull(),
+  transcriptionStatus: text('transcription_status').notNull(),
+  createdAt: text('created_at').notNull(),
+});
+
+// usage.ts
+import { drizzle } from 'drizzle-orm/libsql';
+import * as schema from './sqlite/schema';
+
+const db = drizzle(workspace.extensions.sqlite.client, { schema });
+const done = await db.select().from(schema.recordings)
+  .where(eq(schema.recordings.transcriptionStatus, 'DONE'));
+```
+
+**MCP/Agent query surface:**
+
+```typescript
+// workspace action exposing SQL to agents
+queryData: defineQuery({
+  description: 'Run a read-only SQL query against workspace data',
+  input: type({ sql: 'string' }),
+  handler: ({ sql }) => {
+    const result = workspace.extensions.sqlite.client.execute(sql);
+    return { rows: result.rows, columns: result.columns };
+  },
+});
+```
+
+## Implementation Plan
+
+### Phase 1: Core Mirror (no FTS, no vectors)
+
+- [ ] **1.1** Create `packages/workspace/src/extensions/materializer/sqlite/` directory
+- [ ] **1.2** Implement `generateDDL(tableDefinitions)`: walk `describeWorkspace()` JSON Schema per table → `CREATE TABLE IF NOT EXISTS` statements using the type mapping table above
+- [ ] **1.3** Implement `createSqliteMirror(options)` extension factory:
+  - Await `ctx.whenReady` before touching SQLite
+  - Generate and execute DDL for each table
+  - Full load: `table.getAllValid()` → batch `INSERT OR REPLACE INTO`
+  - Return `{ client, rebuild }`
+- [ ] **1.4** Implement observer-based incremental sync:
+  - `table.observe()` per mirrored table
+  - Debounced batch: collect changed IDs, then `INSERT OR REPLACE` for upserts, `DELETE` for removals
+  - Call `onSync` hook after each batch
+- [ ] **1.5** Implement `dispose()`: unsubscribe observers, close client if owned
+- [ ] **1.6** Add tests: mirror creation, full load, incremental sync, rebuild
+
+### Phase 2: FTS5
+
+- [ ] **2.1** Implement FTS config parsing: `fts: { recordings: ['title', 'transcribedText'] }` → `CREATE VIRTUAL TABLE recordings_fts USING fts5(title, transcribedText, content=recordings, content_rowid=rowid)`
+- [ ] **2.2** Generate INSERT/UPDATE/DELETE triggers to keep FTS in sync with mirror tables
+- [ ] **2.3** Implement `search(table, query, options)` helper using FTS5 `MATCH` + `snippet()` + `rank`
+- [ ] **2.4** Add tests: FTS creation, search, trigger-based sync after upsert/delete
+
+### Phase 3: Lifecycle Hooks
+
+- [ ] **3.1** Implement `onReady(db)` — called after DDL + full load + FTS setup
+- [ ] **3.2** Implement `onSync(db, changes)` — called after each debounced sync batch with change details
+- [ ] **3.3** Document hook patterns: vector columns, custom indexes, derived columns
+
+### Phase 4: Integration
+
+- [ ] **4.1** Wire into an app (opensidian or whispering) as proof of concept
+- [ ] **4.2** Add MCP/agent query action using the mirror
+- [ ] **4.3** Verify filesystem sqlite-index can coexist (separate extension, same workspace)
+
+## Edge Cases
+
+### Observer fires before persistence hydrates Yjs
+
+1. Workspace created, SQLite mirror extension registered
+2. Persistence extension starts loading Yjs updates from IndexedDB
+3. Mirror extension starts observing—sees partial data
+
+**Mitigation**: Mirror awaits `ctx.whenReady` before subscribing to observers. This ensures Yjs is fully hydrated before the first sync. The filesystem sqlite-index appears to skip this—we won't.
+
+### Table schema changes (workspace version migration)
+
+1. User updates app, workspace table gains a new column in `_v: 2`
+2. SQLite mirror has the old schema (missing column)
+3. Observer pushes rows with the new column
+
+**Mitigation**: On startup, the mirror compares generated DDL against existing SQLite schema. If columns were added, run `ALTER TABLE ADD COLUMN`. If the schema change is more complex (column removed, type changed), drop and recreate the table. This is safe because SQLite is a rebuildable cache.
+
+### Encrypted tables
+
+1. Workspace uses `.withEncryption()` — table values in Yjs are ciphertext
+2. Mirror calls `table.getAllValid()` — this returns decrypted rows (the table helper handles decryption)
+3. SQLite would contain plaintext
+
+**Consideration**: If the SQLite file is persistent (on-disk), it contains plaintext copies of encrypted workspace data. This may be acceptable (the user's local disk is already trusted) or may need SQLite-level encryption (SQLCipher, libSQL encryption). Left as an open question.
+
+### Large tables
+
+1. A table has 10,000+ rows
+2. Full load on startup inserts all rows
+
+**Mitigation**: Use `INSERT OR REPLACE` in transactions (batch 500 rows per transaction). The debounced observer handles incremental updates after the initial load, so startup is the only expensive operation.
+
+### Concurrent observers (mirror + app code)
+
+1. Mirror extension observes table changes
+2. App code also observes the same table (e.g., SvelteMap reactive state)
+
+**No issue**: Yjs supports multiple observers. Both fire independently.
+
+## Open Questions
+
+1. **libSQL WASM vector support**: Does `@libsql/client-wasm` include `F32_BLOB` columns and `libsql_vector_idx`? DiskANN may require native code not available in WASM. If not, vectors are desktop/server-only.
+   - **Recommendation**: Verify by testing. If WASM lacks vectors, document it. FTS5 works everywhere regardless—that's the primary browser use case.
+
+2. **Encrypted on-disk mirrors**: If the SQLite file is persistent and the workspace uses encryption, should we encrypt the SQLite file too?
+   - Options: (a) Accept plaintext (local disk is trusted), (b) Use SQLCipher/libSQL encryption, (c) Only allow `:memory:` for encrypted workspaces
+   - **Recommendation**: Accept plaintext for v1. The user's local filesystem is the same trust boundary as IndexedDB. Revisit if users request at-rest encryption for the mirror.
+
+3. **Column name mapping**: Workspace schemas use camelCase (`transcribedText`). Should SQLite columns be snake_case (`transcribed_text`) or match the workspace?
+   - Options: (a) Match workspace camelCase exactly, (b) Convert to snake_case for SQL convention
+   - **Recommendation**: Match workspace names exactly. Agents and MCP tools will see the same names as the TypeScript API. No mapping confusion.
+
+4. **KV store mirroring**: Should KV entries also be materialized to a SQLite table?
+   - Options: (a) Tables only, (b) Also mirror KV as a `kv` table with `key TEXT PRIMARY KEY, value TEXT` columns
+   - **Recommendation**: Tables only for v1. KV is settings/preferences—not useful for SQL queries or agent access.
+
+5. **Should the extension own the client lifecycle?**: Currently the caller creates and passes the `Client`. Should the extension optionally accept a file path and create the client internally?
+   - Options: (a) Always injected, (b) Accept `client` OR `filePath`, create client if path given
+   - **Recommendation**: Support both. `filePath` is sugar for the common case; `client` gives full control.
+
+## Success Criteria
+
+- [ ] `createSqliteMirror({ client })` mirrors all workspace tables to SQLite with zero configuration
+- [ ] DDL is auto-generated from workspace JSON Schema—no manual schema declaration required
+- [ ] Incremental sync: Yjs table mutations appear in SQLite within `debounceMs`
+- [ ] `fts` config generates working FTS5 virtual tables with trigger-based sync
+- [ ] `search()` returns ranked results with snippet highlights
+- [ ] `onReady` and `onSync` hooks fire at the right time with the right data
+- [ ] Filesystem sqlite-index coexists as a separate extension on the same workspace
+- [ ] No Drizzle dependency in the extension—raw SQL only
+- [ ] Tests cover: full load, incremental upsert, incremental delete, FTS search, rebuild, schema migration
+
+## References
+
+- `packages/workspace/src/extensions/persistence/sqlite.ts` — Current Yjs binary persistence (NOT the mirror)
+- `packages/workspace/src/extensions/materializer/markdown/` — Materializer extension pattern to follow
+- `packages/filesystem/src/extensions/sqlite-index/` — Existing specialized sqlite-index (stays separate)
+- `packages/filesystem/src/extensions/sqlite-index/ddl.ts` — DDL generation from Drizzle (reference for raw DDL approach)
+- `packages/filesystem/src/extensions/sqlite-index/schema.ts` — Hand-written Drizzle schema (what we're replacing with auto-generation)
+- `packages/workspace/src/workspace/describe-workspace.ts` — JSON Schema output for workspace introspection
+- `packages/workspace/src/workspace/types.ts` — `BaseRow`, `TableDefinition`, extension types
+- `packages/workspace/src/workspace/create-workspace.ts` — Extension registration and `ctx.whenReady`
+- `docs/articles/sqlite-is-a-projection-not-a-database.md` — Conceptual article explaining the architecture


### PR DESCRIPTION
Dev scripts are now normalized across all apps, with a consistent `dev:remote` variant added wherever remote API development makes sense.

---

**The SQLite mirror work is the main addition here.** A new spec and article lay out the design for using SQLite as a read-side projection of CRDT data—essentially a materializer that keeps a relational mirror in sync with the Yjs document. The initial types and DDL generation land in `packages/workspace/src/extensions/materializer/sqlite/` as a foundation for that extension.

---

The grok provider and its `GROK_API_KEY` are removed from the API. Also fixes a trailing comma in the root `package.json` scripts that was causing issues.