### PR TITLE
feat(sync): bake BroadcastChannel into createSyncExtension

### DIFF
--- a/apps/fuji/package.json
+++ b/apps/fuji/package.json
@@ -32,6 +32,7 @@
 		"vite": "catalog:"
 	},
 	"dependencies": {
+		"@epicenter/constants": "workspace:*",
 		"@epicenter/svelte": "workspace:*",
 		"@epicenter/workspace": "workspace:*",
 		"@tanstack/svelte-table": "catalog:",

--- a/apps/fuji/src/lib/auth.ts
+++ b/apps/fuji/src/lib/auth.ts
@@ -1,0 +1,8 @@
+import { createPersistedState } from '@epicenter/svelte';
+import { AuthSession } from '@epicenter/svelte/auth';
+
+export const session = createPersistedState({
+	key: 'fuji:authSession',
+	schema: AuthSession.or('null'),
+	defaultValue: null,
+});

--- a/apps/fuji/src/lib/client.ts
+++ b/apps/fuji/src/lib/client.ts
@@ -1,16 +1,43 @@
 /**
- * Fuji workspace client — single Y.Doc instance with IndexedDB persistence.
+ * Fuji workspace client — single Y.Doc instance with IndexedDB persistence,
+ * encryption, and WebSocket sync (with built-in BroadcastChannel cross-tab sync).
  *
  * Access tables via `workspace.tables.entries` and KV settings via
  * `workspace.kv`. The client is ready when `workspace.whenReady`
  * resolves.
  */
 
+import { APP_URLS } from '@epicenter/constants/vite';
+import { createAuth } from '@epicenter/svelte/auth';
 import { createWorkspace } from '@epicenter/workspace';
 import { indexeddbPersistence } from '@epicenter/workspace/extensions/persistence/indexeddb';
+import {
+	createSyncExtension,
+	toWsUrl,
+} from '@epicenter/workspace/extensions/sync/websocket';
+import { session } from '$lib/auth';
 import { fujiWorkspace } from './workspace/definition';
 
-export const workspace = createWorkspace(fujiWorkspace).withExtension(
-	'persistence',
-	indexeddbPersistence,
-);
+export const workspace = createWorkspace(fujiWorkspace)
+	.withExtension('persistence', indexeddbPersistence)
+	.withExtension(
+		'sync',
+		createSyncExtension({
+			url: (workspaceId) =>
+				toWsUrl(`${APP_URLS.API}/workspaces/${workspaceId}`),
+			getToken: async () => auth.token,
+		}),
+	);
+
+export const auth = createAuth({
+	baseURL: APP_URLS.API,
+	session,
+	onLogin(session) {
+		workspace.applyEncryptionKeys(session.encryptionKeys);
+		workspace.extensions.sync.reconnect();
+	},
+	onLogout() {
+		workspace.clearLocalData();
+		workspace.extensions.sync.reconnect();
+	},
+});

--- a/apps/tab-manager/src/lib/client.ts
+++ b/apps/tab-manager/src/lib/client.ts
@@ -2,8 +2,8 @@
  * Workspace client — browser-specific wiring and AI-callable actions.
  *
  * Imports the definition from `definition.ts` and adds IndexedDB persistence,
- * BroadcastChannel sync, WebSocket sync, encryption, and action handlers
- * that call Chrome extension APIs.
+ * WebSocket sync (with built-in BroadcastChannel cross-tab sync), encryption,
+ * and action handlers that call Chrome extension APIs.
  *
  * Live browser state (tabs, windows, tab groups) is NOT stored here—Chrome is
  * the sole authority for ephemeral browser state. See `browser-state.svelte.ts`.
@@ -17,7 +17,6 @@ import {
 	iterateActions,
 } from '@epicenter/workspace';
 import { createSyncExtension, toWsUrl } from '@epicenter/workspace/extensions/sync/websocket';
-import { broadcastChannelSync } from '@epicenter/workspace/extensions/sync/broadcast-channel';
 import { indexeddbPersistence } from '@epicenter/workspace/extensions/persistence/indexeddb';
 import Type from 'typebox';
 import { Ok, tryAsync } from 'wellcrafted/result';
@@ -100,7 +99,6 @@ async function registerDevice(): Promise<void> {
 function buildWorkspaceClient() {
 	const client = createTabManagerWorkspace()
 		.withExtension('persistence', indexeddbPersistence)
-		.withExtension('broadcast', broadcastChannelSync)
 		.withExtension(
 			'sync',
 			createSyncExtension({

--- a/bun.lock
+++ b/bun.lock
@@ -87,6 +87,7 @@
       "name": "@epicenter/fuji",
       "version": "0.0.1",
       "dependencies": {
+        "@epicenter/constants": "workspace:*",
         "@epicenter/svelte": "workspace:*",
         "@epicenter/workspace": "workspace:*",
         "@tanstack/svelte-table": "catalog:",

--- a/packages/workspace/src/extensions/persistence/indexeddb.ts
+++ b/packages/workspace/src/extensions/persistence/indexeddb.ts
@@ -10,18 +10,16 @@ import type * as Y from 'yjs';
  *
  * Works directly as an extension factory — destructures `ydoc` from the
  * workspace client context. Chain first so all subsequent extensions
- * (BroadcastChannel, WebSocket) start with local state already loaded.
+ * (sync, which now includes BroadcastChannel) start with local state already loaded.
  *
- * @example Recommended: persistence + BroadcastChannel + WebSocket
+ * @example Persistence + sync (BroadcastChannel included automatically)
  * ```typescript
  * import { indexeddbPersistence } from '@epicenter/workspace/extensions/persistence/indexeddb';
- * import { broadcastChannelSync } from '@epicenter/workspace/extensions/sync/broadcast-channel';
  * import { createSyncExtension } from '@epicenter/workspace/extensions/sync/websocket';
  *
  * createWorkspace(definition)
  *   .withExtension('persistence', indexeddbPersistence)
- *   .withExtension('broadcast', broadcastChannelSync)
- *   .withWorkspaceExtension('sync', createSyncExtension({
+ *   .withExtension('sync', createSyncExtension({
  *     url: (id) => `ws://localhost:3913/rooms/${id}`,
  *   }))
  * ```

--- a/packages/workspace/src/extensions/persistence/sqlite.ts
+++ b/packages/workspace/src/extensions/persistence/sqlite.ts
@@ -3,14 +3,6 @@ import { mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import * as Y from 'yjs';
 
-/**
- * Configuration for the persistence extension.
- */
-export type PersistenceConfig = {
-	/** Absolute path to the SQLite database file for storing YJS state. */
-	filePath: string;
-};
-
 /** Max compacted update size (2 MB). Matches the Cloudflare DO limit. */
 const MAX_COMPACTED_BYTES = 2 * 1024 * 1024;
 
@@ -39,7 +31,7 @@ function compactUpdateLog(db: Database, ydoc: Y.Doc): void {
 /**
  * Initialize a SQLite persistence database: create table, replay updates, compact.
  *
- * Shared setup logic used by both `persistence` and `filesystemPersistence`.
+ * Shared setup logic used by `filesystemPersistence`.
  */
 function initPersistenceDb(filePath: string, ydoc: Y.Doc): Database {
 	const db = new Database(filePath);
@@ -62,10 +54,13 @@ function initPersistenceDb(filePath: string, ydoc: Y.Doc): Database {
 }
 
 /**
- * Filesystem persistence factory.
+ * Filesystem persistence factory using SQLite append-log.
  *
- * Uses SQLite append-log for efficient incremental persistence.
- * Same pattern as the Cloudflare DO sync server.
+ * Stores incremental Y.Doc updates in a SQLite database using the same
+ * append-only update log pattern as the Cloudflare Durable Object sync server.
+ * Each update is a tiny INSERT (O(update_size)), not a full doc re-encode.
+ *
+ * **Platform**: Desktop (Tauri, Bun)
  *
  * @example
  * ```typescript
@@ -76,16 +71,12 @@ function initPersistenceDb(filePath: string, ydoc: Y.Doc): Database {
  *   .withExtension('persistence', filesystemPersistence({
  *     filePath: join(epicenterDir, 'persistence', `workspace.db`),
  *   }))
- *   .withWorkspaceExtension('sync', createSyncExtension({
- *     url: 'ws://localhost:3913/rooms/{id}',
+ *   .withExtension('sync', createSyncExtension({
+ *     url: (id) => `ws://localhost:3913/rooms/${id}`,
  *   }))
  * ```
  */
-export function filesystemPersistence({
-	filePath,
-}: {
-	filePath: string;
-}) {
+export function filesystemPersistence({ filePath }: { filePath: string }) {
 	return ({ ydoc }: { ydoc: Y.Doc }) => {
 		let db: Database | null = null;
 

--- a/packages/workspace/src/extensions/sync/broadcast-channel.ts
+++ b/packages/workspace/src/extensions/sync/broadcast-channel.ts
@@ -18,27 +18,15 @@ const BC_ORIGIN = Symbol('bc-sync');
  * No-ops gracefully when `BroadcastChannel` is unavailable (Node.js, SSR,
  * older browsers).
  *
- * Works directly as an extension factory — destructures `ydoc` from the
- * workspace client context. Chain after persistence and before WebSocket
- * sync for optimal ordering: local state loads first, then instant local
- * sync, then server sync.
- *
- * @example Persistence + BroadcastChannel + WebSocket (recommended)
- * ```typescript
- * import { indexeddbPersistence } from '@epicenter/workspace/extensions/persistence/indexeddb';
- * import { broadcastChannelSync } from '@epicenter/workspace/extensions/sync/broadcast-channel';
- * import { createSyncExtension } from '@epicenter/workspace/extensions/sync/websocket';
- *
- * createWorkspace(definition)
- *   .withExtension('persistence', indexeddbPersistence)
- *   .withExtension('broadcast', broadcastChannelSync)
- *   .withWorkspaceExtension('sync', createSyncExtension({
- *     url: (id) => `ws://localhost:3913/rooms/${id}`,
- *   }))
- * ```
+ * Included automatically by `createSyncExtension`—most apps don't need to
+ * register this separately. Use the standalone export only when you want
+ * cross-tab sync without a WebSocket server (e.g., offline-only apps).
  *
  * @example Standalone (no server, local tabs only)
  * ```typescript
+ * import { indexeddbPersistence } from '@epicenter/workspace/extensions/persistence/indexeddb';
+ * import { broadcastChannelSync } from '@epicenter/workspace/extensions/sync/broadcast-channel';
+ *
  * createWorkspace(definition)
  *   .withExtension('persistence', indexeddbPersistence)
  *   .withExtension('broadcast', broadcastChannelSync)

--- a/packages/workspace/src/extensions/sync/websocket.ts
+++ b/packages/workspace/src/extensions/sync/websocket.ts
@@ -27,6 +27,7 @@ import {
 import type { DefaultRpcMap, RpcActionMap } from '../../rpc/types.js';
 import type { SharedExtensionContext } from '../../workspace/types.js';
 import { isAction, type Actions } from '../../shared/actions.js';
+import { broadcastChannelSync } from './broadcast-channel.js';
 
 // ============================================================================
 // Types
@@ -70,9 +71,8 @@ export type SyncStatus =
  * (`ws:` or `wss:`).
  *
  * Chain last in the extension chain. Persistence loads local state first,
- * BroadcastChannel handles instant cross-tab sync, then WebSocket connects
- * for cross-device sync. The sync extension waits for all prior extensions
- * via `context.whenReady` before connecting.
+ * then WebSocket connects for cross-device sync. BroadcastChannel cross-tab
+ * sync is included automatically—no separate extension needed.
  *
  * @example
  * ```typescript
@@ -80,7 +80,6 @@ export type SyncStatus =
  *
  * createWorkspace(definition)
  *   .withExtension('persistence', indexeddbPersistence)
- *   .withExtension('broadcast', broadcastChannelSync)
  *   .withExtension('sync', createSyncExtension({
  *     url: (docId) => `ws://localhost:3913/rooms/${docId}`,
  *   }))
@@ -212,6 +211,10 @@ export function toWsUrl(httpUrl: string): string {
  * exponential backoff, and RPC between peers. Waits for prior extensions
  * (`whenReady`) before connecting, so local state is loaded first.
  *
+ * Automatically includes BroadcastChannel cross-tab sync so multiple tabs
+ * converge instantly without waiting for the server round-trip. BroadcastChannel
+ * no-ops gracefully when unavailable (Node.js, SSR, older browsers).
+ *
  * Uses a supervisor loop architecture where one loop owns all status transitions
  * and reconnection logic. Event handlers are reporters only—they resolve
  * promises that the loop awaits, but never make reconnection decisions.
@@ -229,6 +232,10 @@ export function createSyncExtension(config: SyncExtensionConfig): (
 		const getToken = config.getToken ? () => config.getToken!(docId) : undefined;
 
 		const awareness = ctxAwareness.raw;
+
+		// BroadcastChannel cross-tab sync — instant convergence between same-origin tabs.
+		// Runs independently of WebSocket. No-ops when BroadcastChannel is unavailable.
+		const bc = broadcastChannelSync({ ydoc: doc });
 
 		// ── Zone 2: Mutable state ──
 
@@ -805,6 +812,7 @@ export function createSyncExtension(config: SyncExtensionConfig): (
 				goOffline();
 				doc.off('updateV2', handleDocUpdate);
 				awareness.off('update', handleAwarenessUpdate);
+				bc.dispose?.();
 				status.clear();
 			},
 		};


### PR DESCRIPTION
Only 2 of 7 workspace apps were wiring BroadcastChannel despite it being free, safe, and always useful for multi-tab web apps. The manual `.withExtension('broadcast', broadcastChannelSync)` opt-in created a pit of forgetting—opensidian and honeycrisp were silently missing instant cross-tab convergence, and fuji had no sync at all.

BroadcastChannel is now initialized unconditionally inside `createSyncExtension`. No config option, no opt-out—it no-ops gracefully when `BroadcastChannel` is unavailable (Node, SSR), and Yjs deduplicates internally so receiving the same update from both broadcast and WebSocket is a no-op. The implementation is ~4 lines:

```typescript
// Inside createSyncExtension factory, before WebSocket setup
const bc = broadcastChannelSync({ ydoc: doc });

// In dispose()
bc.dispose?.();
```

---

**tab-manager had the only explicit broadcast wiring—that line is now redundant.**

The separate `.withExtension('broadcast', broadcastChannelSync)` import and registration are removed. Sync handles it internally. opensidian and honeycrisp already had sync and get broadcast for free with zero code changes.

---

**fuji was persistence-only—it now has full sync and auth.**

Following the exact opensidian/honeycrisp pattern: new `$lib/auth.ts` with persisted session state, `@epicenter/constants` dependency for `APP_URLS`, and `createSyncExtension` wiring with token auth. Before this, fuji data never left the device.

```typescript
// apps/fuji/src/lib/client.ts — was just persistence, now full sync
export const workspace = createWorkspace(fujiWorkspace)
  .withExtension('persistence', indexeddbPersistence)
  .withExtension('sync', createSyncExtension({
    url: (workspaceId) => toWsUrl(`${APP_URLS.API}/workspaces/${workspaceId}`),
    getToken: async () => auth.token,
  }));
```

---

**The standalone `broadcastChannelSync` export stays for broadcast-without-server use cases.** zhongwen uses it today (broadcast only, no WebSocket). That file's JSDoc now marks it as auto-included by sync, with the standalone example as the secondary use case.

7 files changed, +60/−29.