### PR TITLE
feat(opensidian): add sidebar search panel with FTS5 backend

### DIFF
--- a/apps/opensidian/src/lib/components/AppShell.svelte
+++ b/apps/opensidian/src/lib/components/AppShell.svelte
@@ -11,13 +11,15 @@
 	import TextIcon from '@lucide/svelte/icons/text';
 	import { fsState } from '$lib/state/fs-state.svelte';
 	import { searchState } from '$lib/state/search-state.svelte';
+	import { sidebarSearchState } from '$lib/state/sidebar-search-state.svelte';
 	import { terminalState } from '$lib/state/terminal-state.svelte';
 	import { getFileIcon } from '$lib/utils/file-icons';
 	import AiChat from './chat/AiChat.svelte';
 	import ContentPanel from './editor/ContentPanel.svelte';
 	import StatusBar from './editor/StatusBar.svelte';
-	import TerminalPanel from './terminal/TerminalPanel.svelte';
+	import SearchPanel from './search/SearchPanel.svelte';
 	import Toolbar from './Toolbar.svelte';
+	import TerminalPanel from './terminal/TerminalPanel.svelte';
 	import FileTree from './tree/FileTree.svelte';
 
 	let paletteOpen = $state(false);
@@ -54,6 +56,7 @@
 		searchState.shouldFilter ? allFileItems : searchState.searchResults,
 	);
 
+	let searchPanelRef: ReturnType<typeof SearchPanel> | undefined = $state();
 	let terminalRef: ReturnType<typeof TerminalPanel> | undefined = $state();
 	let previousFocus: HTMLElement | null = $state(null);
 
@@ -69,6 +72,16 @@
 	});
 
 	function handleKeydown(e: KeyboardEvent) {
+		if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'f') {
+			e.preventDefault();
+			if (sidebarSearchState.leftPaneView === 'search') {
+				sidebarSearchState.closeSearch();
+			} else {
+				sidebarSearchState.openSearch();
+				requestAnimationFrame(() => searchPanelRef?.focusInput());
+			}
+		}
+
 		if ((e.metaKey || e.ctrlKey) && e.key === '`') {
 			e.preventDefault();
 			if (!terminalState.open) {
@@ -93,9 +106,13 @@
 	<Toolbar bind:chatOpen />
 	<Resizable.PaneGroup direction="horizontal" class="flex-1">
 		<Resizable.Pane defaultSize={25} minSize={15} maxSize={50}>
-			<ScrollArea class="h-full">
-				<div class="p-2"><FileTree /></div>
-			</ScrollArea>
+			{#if sidebarSearchState.leftPaneView === 'search'}
+				<SearchPanel bind:this={searchPanelRef} />
+			{:else}
+				<ScrollArea class="h-full">
+					<div class="p-2"><FileTree /></div>
+				</ScrollArea>
+			{/if}
 		</Resizable.Pane>
 		<Resizable.Handle withHandle />
 		<Resizable.Pane defaultSize={chatOpen ? 45 : 75}>

--- a/apps/opensidian/src/lib/components/search/SearchPanel.svelte
+++ b/apps/opensidian/src/lib/components/search/SearchPanel.svelte
@@ -1,0 +1,188 @@
+<script lang="ts">
+	import * as Empty from '@epicenter/ui/empty';
+	import { Input } from '@epicenter/ui/input';
+	import { ScrollArea } from '@epicenter/ui/scroll-area';
+	import { Spinner } from '@epicenter/ui/spinner';
+	import { Toggle } from '@epicenter/ui/toggle';
+	import * as Tooltip from '@epicenter/ui/tooltip';
+	import CaseSensitiveIcon from '@lucide/svelte/icons/case-sensitive';
+	import RegexIcon from '@lucide/svelte/icons/regex';
+	import SearchIcon from '@lucide/svelte/icons/search';
+	import XIcon from '@lucide/svelte/icons/x';
+	import { sidebarSearchState } from '$lib/state/sidebar-search-state.svelte';
+	import SearchResultGroup from './SearchResultGroup.svelte';
+
+	let searchInputRef = $state<HTMLInputElement | null>(null);
+	let searchFocused = $state(false);
+
+	const isSearchActive = $derived(
+		searchFocused || sidebarSearchState.searchQuery !== '',
+	);
+	const hasQuery = $derived(sidebarSearchState.searchQuery.trim().length >= 2);
+	const hasResults = $derived(sidebarSearchState.fileGroups.length > 0);
+
+	export function focusInput() {
+		searchInputRef?.focus();
+	}
+</script>
+
+{#snippet searchToggle(pressed: boolean, onPressedChange: (v: boolean) => void, Icon: typeof CaseSensitiveIcon, label: string)}
+	<Tooltip.Root>
+		<Tooltip.Trigger>
+			{#snippet child({ props })}
+				<Toggle
+					size="sm"
+					{pressed}
+					{onPressedChange}
+					aria-label={label}
+					class="size-6 rounded-sm p-0"
+					{...props}
+				>
+					<Icon class="size-3.5" />
+				</Toggle>
+			{/snippet}
+		</Tooltip.Trigger>
+		<Tooltip.Content>{label}</Tooltip.Content>
+	</Tooltip.Root>
+{/snippet}
+
+<div class="flex h-full flex-col">
+	<div class="border-b p-2">
+		<div
+			class="relative"
+			onfocusin={() => {
+				searchFocused = true;
+			}}
+			onfocusout={(e: FocusEvent) => {
+				const container = e.currentTarget as HTMLElement;
+				if (container.contains(e.relatedTarget as Node)) return;
+				searchFocused = false;
+			}}
+		>
+			<SearchIcon
+				class="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+			/>
+			<Input
+				bind:ref={searchInputRef}
+				type="search"
+				placeholder="Search files..."
+				value={sidebarSearchState.searchQuery}
+				oninput={(e: Event) => {
+					sidebarSearchState.searchQuery = (e.target as HTMLInputElement).value;
+				}}
+				onkeydown={(e: KeyboardEvent) => {
+					if (e.key === 'Escape') {
+						if (sidebarSearchState.searchQuery === '') {
+							sidebarSearchState.closeSearch();
+						} else {
+							sidebarSearchState.searchQuery = '';
+						}
+					}
+				}}
+				class={isSearchActive
+					? 'h-8 pl-8 pr-20 text-sm [&::-webkit-search-cancel-button]:hidden'
+					: 'h-8 pl-8 pr-8 text-sm [&::-webkit-search-cancel-button]:hidden'}
+			/>
+			{#if isSearchActive}
+				<div
+					class="absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-0.5"
+				>
+					{#if sidebarSearchState.searchQuery}
+						<button
+							type="button"
+							class="flex size-6 items-center justify-center text-muted-foreground hover:text-foreground"
+							onclick={() => {
+								sidebarSearchState.searchQuery = '';
+								searchInputRef?.focus();
+							}}
+						>
+							<XIcon class="size-3.5" />
+						</button>
+					{/if}
+					{@render searchToggle(
+						sidebarSearchState.caseSensitive,
+						(v) => {
+							sidebarSearchState.caseSensitive = v;
+						},
+						CaseSensitiveIcon,
+						'Match Case'
+					)}
+					{@render searchToggle(
+						sidebarSearchState.regex,
+						(v) => {
+							sidebarSearchState.regex = v;
+						},
+						RegexIcon,
+						'Use Regular Expression'
+					)}
+				</div>
+			{/if}
+		</div>
+	</div>
+
+	{#if sidebarSearchState.isSearching && !hasResults}
+		<div class="flex flex-1 items-center justify-center">
+			<Spinner class="size-5 text-muted-foreground" />
+		</div>
+	{:else if hasResults}
+		<div class="border-b px-3 py-1.5 text-xs text-muted-foreground">
+			{sidebarSearchState.totalResults}
+			result{sidebarSearchState.totalResults === 1
+				? ''
+				: 's'}
+			in
+			{sidebarSearchState.totalFiles}
+			file{sidebarSearchState.totalFiles === 1
+				? ''
+				: 's'}
+			{#if sidebarSearchState.isSearching}
+				<Spinner class="ml-1 inline-block size-3" />
+			{/if}
+		</div>
+		<ScrollArea class="flex-1">
+			<div class="p-1">
+				{#each sidebarSearchState.fileGroups as group (group.fileId)}
+					<SearchResultGroup {group} defaultOpen={group.matchCount <= 5} />
+				{/each}
+				{#if sidebarSearchState.hasMore}
+					<button
+						type="button"
+						class="w-full rounded-sm px-3 py-2 text-center text-xs text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+						onclick={() => sidebarSearchState.loadMore()}
+						disabled={sidebarSearchState.isSearching}
+					>
+						{#if sidebarSearchState.isSearching}
+							Loading...
+						{:else}
+							Load more results
+						{/if}
+					</button>
+				{/if}
+			</div>
+		</ScrollArea>
+	{:else if hasQuery && !sidebarSearchState.isSearching}
+		<Empty.Root class="flex-1 border-0">
+			<Empty.Media>
+				<SearchIcon class="size-8 text-muted-foreground" />
+			</Empty.Media>
+			<Empty.Header>
+				<Empty.Title>No results</Empty.Title>
+				<Empty.Description
+					>No matches for "{sidebarSearchState.searchQuery}"</Empty.Description
+				>
+			</Empty.Header>
+		</Empty.Root>
+	{:else}
+		<Empty.Root class="flex-1 border-0">
+			<Empty.Media>
+				<SearchIcon class="size-8 text-muted-foreground" />
+			</Empty.Media>
+			<Empty.Header>
+				<Empty.Title>Search files</Empty.Title>
+				<Empty.Description
+					>Type to search file names and content</Empty.Description
+				>
+			</Empty.Header>
+		</Empty.Root>
+	{/if}
+</div>

--- a/apps/opensidian/src/lib/components/search/SearchResultGroup.svelte
+++ b/apps/opensidian/src/lib/components/search/SearchResultGroup.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+	import type { FileId } from '@epicenter/filesystem';
+	import { Badge } from '@epicenter/ui/badge';
+	import * as Collapsible from '@epicenter/ui/collapsible';
+	import { cn } from '@epicenter/ui/utils';
+	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
+	import FileTextIcon from '@lucide/svelte/icons/file-text';
+	import { fsState } from '$lib/state/fs-state.svelte';
+	import type { FileGroup } from '$lib/state/sidebar-search-state.svelte';
+
+	let {
+		group,
+		defaultOpen = true,
+	}: {
+		group: FileGroup;
+		defaultOpen?: boolean;
+	} = $props();
+
+	let open = $state(defaultOpen);
+
+	/**
+	 * Strip all HTML tags except <mark> for safe snippet rendering.
+	 */
+	function sanitizeSnippet(html: string): string {
+		return html.replace(/<(?!\/?mark\b)[^>]*>/gi, '');
+	}
+
+	function handleMatchClick(fileId: string) {
+		fsState.selectFile(fileId as FileId);
+	}
+
+	const displayPath = $derived(
+		group.filePath
+			? group.filePath.slice(1, group.filePath.lastIndexOf('/')) || ''
+			: '',
+	);
+</script>
+
+<Collapsible.Root bind:open>
+	<Collapsible.Trigger
+		class="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm transition-colors hover:bg-accent/50"
+	>
+		<ChevronRightIcon
+			class={cn(
+				'size-4 shrink-0 text-muted-foreground transition-transform',
+				open && 'rotate-90',
+			)}
+		/>
+		<FileTextIcon class="size-4 shrink-0 text-muted-foreground" />
+		<span class="truncate font-medium">{group.fileName}</span>
+		{#if displayPath}
+			<span class="truncate text-xs text-muted-foreground">{displayPath}</span>
+		{/if}
+		<Badge variant="outline" class="ml-auto shrink-0 text-xs">
+			{group.matchCount}
+		</Badge>
+	</Collapsible.Trigger>
+
+	<Collapsible.Content>
+		<div class="ml-6 border-l border-border pl-3">
+			{#each group.matches as match, i (i)}
+				<button
+					type="button"
+					class="block w-full cursor-pointer rounded-sm px-2 py-1 text-left text-sm text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+					onclick={() => handleMatchClick(group.fileId)}
+				>
+					<span class="line-clamp-2 break-all text-xs">
+						{@html sanitizeSnippet(match.snippet)}
+					</span>
+				</button>
+			{/each}
+		</div>
+	</Collapsible.Content>
+</Collapsible.Root>

--- a/apps/opensidian/src/lib/state/sidebar-search-state.svelte.ts
+++ b/apps/opensidian/src/lib/state/sidebar-search-state.svelte.ts
@@ -1,0 +1,283 @@
+import { createPersistedState } from '@epicenter/svelte';
+import { type } from 'arktype';
+import { workspace } from '$lib/client';
+
+export type MatchSnippet = {
+	snippet: string;
+};
+
+export type FileGroup = {
+	fileId: string;
+	fileName: string;
+	filePath: string | null;
+	matchCount: number;
+	matches: MatchSnippet[];
+};
+
+const PAGE_SIZE = 50;
+
+function createSidebarSearchState() {
+	// Persisted preferences
+	const caseSensitiveState = createPersistedState({
+		key: 'opensidian.sidebar-search.case-sensitive',
+		schema: type('boolean'),
+		defaultValue: false,
+	});
+
+	const regexState = createPersistedState({
+		key: 'opensidian.sidebar-search.regex',
+		schema: type('boolean'),
+		defaultValue: false,
+	});
+
+	const leftPaneViewState = createPersistedState({
+		key: 'opensidian.left-pane-view',
+		schema: type("'files' | 'search'"),
+		defaultValue: 'files' as 'files' | 'search',
+	});
+
+	// Mutable state
+	let searchQuery = $state('');
+	let fileGroups = $state<FileGroup[]>([]);
+	let isSearching = $state(false);
+	let totalResults = $state(0);
+	let totalFiles = $state(0);
+	let hasMore = $state(false);
+	let currentOffset = 0;
+	let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+	function groupByFile(
+		rows: Array<{
+			fileId: string;
+			name: string;
+			path: string | null;
+			snippet: string;
+		}>,
+	): FileGroup[] {
+		const groups = new Map<string, FileGroup>();
+		for (const row of rows) {
+			let group = groups.get(row.fileId);
+			if (!group) {
+				group = {
+					fileId: row.fileId,
+					fileName: row.name,
+					filePath: row.path,
+					matchCount: 0,
+					matches: [],
+				};
+				groups.set(row.fileId, group);
+			}
+			group.matchCount++;
+			group.matches.push({ snippet: row.snippet });
+		}
+		return Array.from(groups.values());
+	}
+
+	function applyPostFilters(
+		rows: Array<{
+			fileId: string;
+			name: string;
+			path: string | null;
+			snippet: string;
+		}>,
+		query: string,
+		caseSensitive: boolean,
+		regex: boolean,
+	) {
+		let filtered = rows;
+
+		if (caseSensitive) {
+			filtered = filtered.filter(
+				(r) => r.snippet.includes(query) || r.name.includes(query),
+			);
+		}
+
+		if (regex) {
+			try {
+				const re = new RegExp(query, caseSensitive ? '' : 'i');
+				filtered = filtered.filter(
+					(r) => re.test(r.snippet) || re.test(r.name),
+				);
+			} catch {
+				// Invalid regex — return unfiltered (FTS already matched)
+			}
+		}
+
+		return filtered;
+	}
+
+	async function executeSearch(query: string, offset: number) {
+		const client = workspace.extensions.sqliteIndex.client;
+		const trimmed = query.trim();
+
+		try {
+			const result = await client.execute({
+				sql: `SELECT
+				  fts.file_id,
+				  f.name,
+				  f.path,
+				  snippet(files_fts, 2, '<mark>', '</mark>', '...', 64) AS snippet
+				FROM files_fts fts
+				JOIN files f ON f.id = fts.file_id
+				WHERE files_fts MATCH ?
+				ORDER BY rank
+				LIMIT ? OFFSET ?`,
+				args: [trimmed, PAGE_SIZE + 1, offset],
+			});
+
+			const rows = result.rows.map((row) => ({
+				fileId: row.file_id as string,
+				name: row.name as string,
+				path: (row.path as string) ?? null,
+				snippet: row.snippet as string,
+			}));
+
+			const hasMoreResults = rows.length > PAGE_SIZE;
+			const pageRows = hasMoreResults ? rows.slice(0, PAGE_SIZE) : rows;
+
+			// Apply post-filters for case sensitivity and regex
+			const filtered = applyPostFilters(
+				pageRows,
+				trimmed,
+				caseSensitiveState.current,
+				regexState.current,
+			);
+
+			return { rows: filtered, hasMore: hasMoreResults };
+		} catch {
+			// Invalid FTS5 query syntax
+			return { rows: [], hasMore: false };
+		}
+	}
+
+	function triggerSearch(query: string) {
+		if (debounceTimer) clearTimeout(debounceTimer);
+
+		const trimmed = query.trim();
+		if (trimmed.length < 2) {
+			fileGroups = [];
+			totalResults = 0;
+			totalFiles = 0;
+			hasMore = false;
+			isSearching = false;
+			currentOffset = 0;
+			return;
+		}
+
+		isSearching = true;
+		debounceTimer = setTimeout(async () => {
+			currentOffset = 0;
+			const result = await executeSearch(trimmed, 0);
+
+			const groups = groupByFile(result.rows);
+			fileGroups = groups;
+			totalResults = result.rows.length;
+			totalFiles = groups.length;
+			hasMore = result.hasMore;
+			currentOffset = result.rows.length;
+			isSearching = false;
+		}, 200);
+	}
+
+	return {
+		get searchQuery() {
+			return searchQuery;
+		},
+		set searchQuery(value: string) {
+			searchQuery = value;
+			triggerSearch(value);
+		},
+
+		get caseSensitive() {
+			return caseSensitiveState.current;
+		},
+		set caseSensitive(value: boolean) {
+			caseSensitiveState.current = value;
+			if (searchQuery.trim().length >= 2) triggerSearch(searchQuery);
+		},
+
+		get regex() {
+			return regexState.current;
+		},
+		set regex(value: boolean) {
+			regexState.current = value;
+			if (searchQuery.trim().length >= 2) triggerSearch(searchQuery);
+		},
+
+		get isSearching() {
+			return isSearching;
+		},
+		get fileGroups() {
+			return fileGroups;
+		},
+		get totalResults() {
+			return totalResults;
+		},
+		get totalFiles() {
+			return totalFiles;
+		},
+		get hasMore() {
+			return hasMore;
+		},
+
+		get leftPaneView() {
+			return leftPaneViewState.current;
+		},
+		set leftPaneView(value: 'files' | 'search') {
+			leftPaneViewState.current = value;
+		},
+
+		openSearch() {
+			leftPaneViewState.current = 'search';
+		},
+
+		closeSearch() {
+			leftPaneViewState.current = 'files';
+		},
+
+		async loadMore() {
+			if (!hasMore || isSearching) return;
+			const trimmed = searchQuery.trim();
+			if (trimmed.length < 2) return;
+
+			isSearching = true;
+			const result = await executeSearch(trimmed, currentOffset);
+
+			const newGroups = groupByFile(result.rows);
+
+			// Merge into existing groups
+			const mergedMap = new Map<string, FileGroup>();
+			for (const g of fileGroups)
+				mergedMap.set(g.fileId, { ...g, matches: [...g.matches] });
+			for (const g of newGroups) {
+				const existing = mergedMap.get(g.fileId);
+				if (existing) {
+					existing.matches.push(...g.matches);
+					existing.matchCount += g.matchCount;
+				} else {
+					mergedMap.set(g.fileId, g);
+				}
+			}
+
+			fileGroups = Array.from(mergedMap.values());
+			totalResults += result.rows.length;
+			totalFiles = fileGroups.length;
+			hasMore = result.hasMore;
+			currentOffset += result.rows.length;
+			isSearching = false;
+		},
+
+		reset() {
+			searchQuery = '';
+			fileGroups = [];
+			totalResults = 0;
+			totalFiles = 0;
+			hasMore = false;
+			isSearching = false;
+			currentOffset = 0;
+			if (debounceTimer) clearTimeout(debounceTimer);
+		},
+	};
+}
+
+export const sidebarSearchState = createSidebarSearchState();


### PR DESCRIPTION
The command palette (Cmd+K) gives you quick file-open, but it's ephemeral—dismiss it and your results are gone. There's no way to browse multiple matches across files, see several match contexts within a single file, or keep search results visible while editing. This adds a persistent sidebar search panel following the VS Code/Obsidian model: Cmd+Shift+F opens it, results stay visible alongside the editor.

The search panel replaces the file tree in the left pane when active—same pattern VS Code and Obsidian use. The file tree and search panel serve similar navigation purposes, so you rarely need both simultaneously.

```
┌─ Left Pane ─────────────────────┐
│                                 │
│  [FileTree]  ←→  [SearchPanel]  │
│                                 │
│  Toggled via Cmd+Shift+F        │
│  Escape (empty query) → back    │
└─────────────────────────────────┘
```

The state module (`sidebar-search-state.svelte.ts`) runs raw SQL against the existing `sqliteIndex.client` rather than reusing `search()`. The built-in `search()` is hard-capped at 50 results with no pagination, no match counts per file, and no post-filtering—fine for the ephemeral command palette, too limited for a persistent panel. The raw SQL query uses the same FTS5 `snippet()` function with `<mark>` highlights, same `ORDER BY rank`, but adds `LIMIT/OFFSET` for pagination and groups results by file:

```typescript
const result = await client.execute({
  sql: `SELECT fts.file_id, f.name, f.path,
        snippet(files_fts, 2, '<mark>', '</mark>', '...', 64) AS snippet
        FROM files_fts fts
        JOIN files f ON f.id = fts.file_id
        WHERE files_fts MATCH ?
        ORDER BY rank
        LIMIT ? OFFSET ?`,
  args: [query, PAGE_SIZE + 1, offset],
});
```

Case-sensitive and regex toggles sit inline in the search input (same pattern as the tab-manager). FTS5 doesn't natively support either, so both are implemented as post-query filters—FTS5 does the heavy lifting for relevance ranking, then the filters narrow results client-side.

```
SearchPanel
├── Input (debounced 200ms, 2+ chars)
│   ├── Toggle: Case Sensitive (Aa)
│   └── Toggle: Regex (.*)
├── Results Summary ("12 results in 5 files")
├── ScrollArea
│   └── SearchResultGroup (collapsible per file)
│       ├── File header + Badge count
│       └── Match snippets (click → open file)
└── Empty states (no query / no results / searching)
```

Preferences (case-sensitive, regex, which pane is active) persist via `createPersistedState` so the panel remembers your last search across sessions. Search state itself is preserved when toggling between file tree and search—switching back doesn't lose your results.

4 files, +566/−4. Arrow key navigation through results deferred to a follow-up.