### PR TITLE
refactor(cli): remove jsrepo dependency and install command

### DIFF
--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -30,19 +30,12 @@ import { defineErrors, extractErrorMessage } from 'wellcrafted/error';
 import { type Result, tryAsync } from 'wellcrafted/result';
 import { auth } from './auth';
 
-// Re-export only the contract types that components actually import.
-// Components needing other types can import from @epicenter/api/billing-contract directly.
-export type {
-	AttachResponse,
-	PortalResponse,
-	PreviewResponse,
-} from '@epicenter/api/billing-contract';
 
 /**
- * Tagged errors for the billing API boundary.
+ * Tagged error for the billing API boundary.
  *
- * Two variants cover the two failure modes: the HTTP request itself
- * failed (network, timeout, DNS) or the server returned a non-OK status.
+ * Covers both network failures (fetch throws) and non-OK HTTP
+ * responses (our status guard throws).
  */
 export const BillingApiError = defineErrors({
 	RequestFailed: ({ path, cause }: { path: string; cause: unknown }) => ({
@@ -107,16 +100,10 @@ export const api = {
 				'/api/billing/upgrade',
 				{ planId, successUrl },
 			),
-		cancel: (planId: string) =>
-			post<{ planId: string }, unknown>('/api/billing/cancel', { planId }),
-		uncancel: (planId: string) =>
-			post<{ planId: string }, unknown>('/api/billing/uncancel', { planId }),
 		topUp: (successUrl?: string) =>
 			post<{ successUrl?: string }, AttachResponse>('/api/billing/top-up', {
 				successUrl,
 			}),
 		portal: () => get<PortalResponse>('/api/billing/portal'),
-		controls: (data: unknown) =>
-			post<unknown, unknown>('/api/billing/controls', data),
 	},
 };

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -4,6 +4,9 @@
  * Uses direct fetch with auth.fetch for Bearer tokens.
  * Same-origin deployment—no CORS config needed.
  *
+ * Every method returns `Result<T, BillingApiError>` so consumers
+ * destructure `{ data, error }` instead of try/catch.
+ *
  * Response types come from the shared billing contract
  * (`@epicenter/api/billing-contract`), which the API routes also
  * satisfy. Neither side derives from the other—both derive from
@@ -12,8 +15,8 @@
  * @see docs/articles/shared-contract-over-derived-types.md
  */
 import type {
-	AttachResponse,
 	AggregateResponse,
+	AttachResponse,
 	CustomerResponse,
 	EventsListResponse,
 	EventsParams,
@@ -23,6 +26,8 @@ import type {
 	PreviewResponse,
 	UsageParams,
 } from '@epicenter/api/billing-contract';
+import { defineErrors, extractErrorMessage } from 'wellcrafted/error';
+import { type Result, tryAsync } from 'wellcrafted/result';
 import { auth } from './auth';
 
 // Re-export only the contract types that components actually import.
@@ -33,26 +38,55 @@ export type {
 	PreviewResponse,
 } from '@epicenter/api/billing-contract';
 
+/**
+ * Tagged errors for the billing API boundary.
+ *
+ * Two variants cover the two failure modes: the HTTP request itself
+ * failed (network, timeout, DNS) or the server returned a non-OK status.
+ */
+export const BillingApiError = defineErrors({
+	RequestFailed: ({ path, cause }: { path: string; cause: unknown }) => ({
+		message: `Request to ${path} failed: ${extractErrorMessage(cause)}`,
+		path,
+		cause,
+	}),
+});
+export type BillingApiError = import('wellcrafted/error').InferErrors<
+	typeof BillingApiError
+>;
+
 /** Fetch JSON from an API endpoint with auth. */
-async function get<TResponse>(path: string): Promise<TResponse> {
-	const res = await auth.fetch(path, { credentials: 'include' });
-	if (!res.ok) throw new Error(`${path} failed: ${res.status}`);
-	return res.json() as Promise<TResponse>;
+async function get<TResponse>(
+	path: string,
+): Promise<Result<TResponse, BillingApiError>> {
+	return tryAsync({
+		try: async () => {
+			const res = await auth.fetch(path, { credentials: 'include' });
+			if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+			return (await res.json()) as TResponse;
+		},
+		catch: (cause) => BillingApiError.RequestFailed({ path, cause }),
+	});
 }
 
 /** POST JSON to an API endpoint with auth. */
 async function post<TBody, TResponse>(
 	path: string,
 	body: TBody,
-): Promise<TResponse> {
-	const res = await auth.fetch(path, {
-		method: 'POST',
-		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify(body),
-		credentials: 'include',
+): Promise<Result<TResponse, BillingApiError>> {
+	return tryAsync({
+		try: async () => {
+			const res = await auth.fetch(path, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(body),
+				credentials: 'include',
+			});
+			if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+			return (await res.json()) as TResponse;
+		},
+		catch: (cause) => BillingApiError.RequestFailed({ path, cause }),
 	});
-	if (!res.ok) throw new Error(`${path} failed: ${res.status}`);
-	return res.json() as Promise<TResponse>;
 }
 
 export const api = {

--- a/apps/dashboard/src/lib/components/CreditBalance.svelte
+++ b/apps/dashboard/src/lib/components/CreditBalance.svelte
@@ -5,7 +5,7 @@
 	import { Progress } from '@epicenter/ui/progress';
 	import { Skeleton } from '@epicenter/ui/skeleton';
 	import { createQuery } from '@tanstack/svelte-query';
-	import { balance as balanceQuery } from '$lib/query/billing';
+	import { balanceQuery } from '$lib/query/billing';
 	import { capitalize } from '$lib/utils';
 
 	const balance = createQuery(() => balanceQuery.options);

--- a/apps/dashboard/src/lib/components/CreditBalance.svelte
+++ b/apps/dashboard/src/lib/components/CreditBalance.svelte
@@ -5,10 +5,10 @@
 	import { Progress } from '@epicenter/ui/progress';
 	import { Skeleton } from '@epicenter/ui/skeleton';
 	import { createQuery } from '@tanstack/svelte-query';
-	import { balanceQueryOptions } from '$lib/query/billing';
+	import { balance as balanceQuery } from '$lib/query/billing';
 	import { capitalize } from '$lib/utils';
 
-	const balance = createQuery(() => balanceQueryOptions());
+	const balance = createQuery(() => balanceQuery.options);
 
 	/** The ai_credits balance object from the customer response. */
 	const creditBalance = $derived(

--- a/apps/dashboard/src/lib/components/ModelCostGuide.svelte
+++ b/apps/dashboard/src/lib/components/ModelCostGuide.svelte
@@ -2,7 +2,7 @@
 	import { Skeleton } from '@epicenter/ui/skeleton';
 	import * as Table from '@epicenter/ui/table';
 	import { createQuery } from '@tanstack/svelte-query';
-	import { models as modelsQuery } from '$lib/query/billing';
+	import { modelsQuery } from '$lib/query/billing';
 
 	const models = createQuery(() => modelsQuery.options);
 

--- a/apps/dashboard/src/lib/components/ModelCostGuide.svelte
+++ b/apps/dashboard/src/lib/components/ModelCostGuide.svelte
@@ -2,9 +2,9 @@
 	import { Skeleton } from '@epicenter/ui/skeleton';
 	import * as Table from '@epicenter/ui/table';
 	import { createQuery } from '@tanstack/svelte-query';
-	import { modelsQueryOptions } from '$lib/query/billing';
+	import { models as modelsQuery } from '$lib/query/billing';
 
-	const models = createQuery(() => modelsQueryOptions());
+	const models = createQuery(() => modelsQuery.options);
 
 	/** Sorted model entries: cheapest first, then alphabetical. */
 	const sortedModels = $derived(

--- a/apps/dashboard/src/lib/components/PlanComparison.svelte
+++ b/apps/dashboard/src/lib/components/PlanComparison.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { ANNUAL_PLANS, PLAN_IDS, PLANS } from '@epicenter/api/billing-plans';
 	import { Badge } from '@epicenter/ui/badge';
 	import { Button } from '@epicenter/ui/button';
 	import * as Card from '@epicenter/ui/card';
@@ -7,10 +8,14 @@
 	import { Spinner } from '@epicenter/ui/spinner';
 	import { createMutation, createQuery } from '@tanstack/svelte-query';
 	import { toast } from 'svelte-sonner';
-	import { api, type AttachResponse, type PreviewResponse } from '$lib/api';
-	import { balanceQueryOptions, plansQueryOptions } from '$lib/query/billing';
+	import {
+		balance as balanceQuery,
+		billingKeys,
+		plans as plansQuery,
+		previewUpgrade as previewUpgradeDef,
+		upgradePlan as upgradePlanDef,
+	} from '$lib/query/billing';
 	import { queryClient } from '$lib/query/client';
-	import { PLANS, ANNUAL_PLANS, PLAN_IDS } from '@epicenter/api/billing-plans';
 
 	/** Visible plan IDs in display order. Free is NOT shown as a card. */
 	const VISIBLE_PLAN_IDS = {
@@ -22,7 +27,10 @@
 		return `$${amount.toLocaleString()}/${interval === 'month' ? 'mo' : 'yr'}`;
 	}
 
-	function formatOverage(overage: { amount: number; billingUnits: number }): string {
+	function formatOverage(overage: {
+		amount: number;
+		billingUnits: number;
+	}): string {
 		const amt = Number.isInteger(overage.amount)
 			? `${overage.amount}`
 			: overage.amount.toFixed(2);
@@ -36,31 +44,37 @@
 			const annual = Object.values(ANNUAL_PLANS).find(
 				(p) => p.monthlyEquivalent === id,
 			);
-			return [id, {
-				name: plan.name,
-				price: formatPrice(plan.price.amount, plan.price.interval),
-				annualPrice: annual
-					? `$${Math.round(annual.price.amount / 12)}/mo`
-					: formatPrice(plan.price.amount, plan.price.interval),
-				credits: plan.credits.included.toLocaleString(),
-				overage: formatOverage(plan.credits.overage),
-				rollover: id === PLAN_IDS.ultra || id === PLAN_IDS.max,
-				isRecommended: id === PLAN_IDS.ultra,
-			}];
+			return [
+				id,
+				{
+					name: plan.name,
+					price: formatPrice(plan.price.amount, plan.price.interval),
+					annualPrice: annual
+						? `$${Math.round(annual.price.amount / 12)}/mo`
+						: formatPrice(plan.price.amount, plan.price.interval),
+					credits: plan.credits.included.toLocaleString(),
+					overage: formatOverage(plan.credits.overage),
+					rollover: id === PLAN_IDS.ultra || id === PLAN_IDS.max,
+					isRecommended: id === PLAN_IDS.ultra,
+				},
+			];
 		}),
 		...VISIBLE_PLAN_IDS.annual.map((id) => {
 			const plan = ANNUAL_PLANS[id];
-			return [id, {
-				name: plan.name.replace(' (Annual)', ''),
-				price: formatPrice(plan.price.amount, plan.price.interval),
-				annualPrice: formatPrice(plan.price.amount, plan.price.interval),
-				credits: plan.credits.included.toLocaleString(),
-				overage: formatOverage(plan.credits.overage),
-				rollover:
-					plan.monthlyEquivalent === PLAN_IDS.ultra ||
-					plan.monthlyEquivalent === PLAN_IDS.max,
-				isRecommended: plan.monthlyEquivalent === PLAN_IDS.ultra,
-			}];
+			return [
+				id,
+				{
+					name: plan.name.replace(' (Annual)', ''),
+					price: formatPrice(plan.price.amount, plan.price.interval),
+					annualPrice: formatPrice(plan.price.amount, plan.price.interval),
+					credits: plan.credits.included.toLocaleString(),
+					overage: formatOverage(plan.credits.overage),
+					rollover:
+						plan.monthlyEquivalent === PLAN_IDS.ultra ||
+						plan.monthlyEquivalent === PLAN_IDS.max,
+					isRecommended: plan.monthlyEquivalent === PLAN_IDS.ultra,
+				},
+			];
 		}),
 	]);
 
@@ -71,18 +85,23 @@
 		currency?: string;
 	} | null>(null);
 
-	const balance = createQuery(() => balanceQueryOptions());
-	const plans = createQuery(() => plansQueryOptions());
+	const balance = createQuery(() => balanceQuery.options);
+	const plans = createQuery(() => plansQuery.options);
 
 	const currentPlanId = $derived(
 		balance.data?.subscriptions?.find((s) => !s.addOn)?.planId ?? 'free',
 	);
 
-	const subscription = $derived(balance.data?.subscriptions?.find((s) => !s.addOn) ?? null);
+	const subscription = $derived(
+		balance.data?.subscriptions?.find((s) => !s.addOn) ?? null,
+	);
 	const trialEndsAt = $derived(subscription?.trialEndsAt ?? null);
 	const trialEndDate = $derived(
 		trialEndsAt
-			? new Date(trialEndsAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+			? new Date(trialEndsAt).toLocaleDateString('en-US', {
+					month: 'short',
+					day: 'numeric',
+				})
 			: null,
 	);
 
@@ -99,44 +118,38 @@
 		),
 	);
 
-	const previewUpgrade = createMutation(() => ({
-		mutationFn: (planId: string) => api.billing.preview(planId),
-	}));
+	const previewMutation = createMutation(() => previewUpgradeDef.options);
 
-	const attachPlan = createMutation(() => ({
-		mutationFn: (planId: string) =>
-			api.billing.upgrade(planId, window.location.href),
-		onSuccess: (result: AttachResponse) => {
-			if (result.paymentUrl) {
-				window.location.href = result.paymentUrl;
-			} else {
-				toast.success('Plan updated successfully');
-				confirmDialog = null;
-				queryClient.invalidateQueries({ queryKey: ['billing'] });
-			}
-		},
-		onError: () => {
-			toast.error('Upgrade failed. Please try again.');
-		},
-	}));
+	const attachPlan = createMutation(() => upgradePlanDef.options);
 
 	async function handleUpgradeClick(planId: string, planName: string) {
 		confirmDialog = { planId, planName };
 		previewData = null;
-		previewUpgrade.mutate(planId, {
-			onSuccess: (data: PreviewResponse) => {
+		previewMutation.mutate(planId, {
+			onSuccess: (data) => {
 				previewData = data;
 			},
 		});
 	}
 </script>
-
 <section class="mt-10 mb-8">
 	<div class="flex items-center justify-between mb-4">
 		<h2 class="text-lg font-semibold">Plans</h2>
 		<div class="flex items-center gap-2 rounded-lg bg-muted p-1 text-xs">
-			<Button variant="ghost" size="sm" class="rounded-md {!isAnnual ? 'bg-background shadow-sm' : 'text-muted-foreground'}" onclick={() => (isAnnual = false)}>Monthly</Button>
-			<Button variant="ghost" size="sm" class="rounded-md {isAnnual ? 'bg-background shadow-sm' : 'text-muted-foreground'}" onclick={() => (isAnnual = true)}>Annual <span class="ml-1 text-emerald-500">Save ~17%</span></Button>
+			<Button
+				variant="ghost"
+				size="sm"
+				class="rounded-md {!isAnnual ? 'bg-background shadow-sm' : 'text-muted-foreground'}"
+				onclick={() => (isAnnual = false)}
+				>Monthly</Button
+			>
+			<Button
+				variant="ghost"
+				size="sm"
+				class="rounded-md {isAnnual ? 'bg-background shadow-sm' : 'text-muted-foreground'}"
+				onclick={() => (isAnnual = true)}
+				>Annual <span class="ml-1 text-emerald-500">Save ~17%</span></Button
+			>
 		</div>
 	</div>
 
@@ -181,7 +194,10 @@
 					<Card.Footer>
 						{#if isCurrent}
 							<Button variant="outline" class="w-full" disabled>
-							Current plan{#if trialEndsAt}&nbsp;(trial){/if}
+								Current plan
+								{#if trialEndsAt}
+									&nbsp;(trial)
+								{/if}
 							</Button>
 						{:else}
 							<Button
@@ -203,11 +219,14 @@
 
 		<p class="mt-4 text-xs text-muted-foreground text-center">
 			{#if trialEndDate}
-				Currently on {PLAN_DISPLAY[currentPlanId]?.name ?? currentPlanId} trial — ends {trialEndDate}.
+				Currently on {PLAN_DISPLAY[currentPlanId]?.name ?? currentPlanId} trial
+				— ends {trialEndDate}.
 			{:else}
-				Currently on {currentPlanId === 'free' ? 'Free (50 credits/mo)' : currentPlanId}.
+				Currently on
+				{currentPlanId === 'free' ? 'Free (50 credits/mo)' : currentPlanId}.
 			{/if}
-			All plans include cloud sync, unlimited workspaces, unlimited history, and encryption.
+			All plans include cloud sync, unlimited workspaces, unlimited history, and
+			encryption.
 		</p>
 	{/if}
 </section>
@@ -221,7 +240,7 @@
 		<Dialog.Header>
 			<Dialog.Title>Upgrade to {confirmDialog?.planName}</Dialog.Title>
 			<Dialog.Description>
-				{#if previewUpgrade.isPending}
+				{#if previewMutation.isPending}
 					Calculating cost...
 				{:else if previewData?.prorationAmount !== undefined}
 					You'll be charged ${(previewData.prorationAmount / 100).toFixed(2)}
@@ -236,7 +255,25 @@
 				Cancel
 			</Button>
 			<Button
-				onclick={() => { if (confirmDialog) attachPlan.mutate(confirmDialog.planId); }}
+				onclick={() => {
+					if (confirmDialog) {
+						attachPlan.mutate(
+							{ planId: confirmDialog.planId, successUrl: window.location.href },
+							{
+								onSuccess: (data) => {
+									if (data.paymentUrl) {
+										window.location.href = data.paymentUrl;
+									} else {
+										toast.success('Plan updated successfully');
+										confirmDialog = null;
+										queryClient.invalidateQueries({ queryKey: billingKeys.all });
+									}
+								},
+								onError: () => toast.error('Upgrade failed. Please try again.'),
+							},
+						);
+					}
+				}}
 				disabled={attachPlan.isPending}
 			>
 				{#if attachPlan.isPending}

--- a/apps/dashboard/src/lib/components/PlanComparison.svelte
+++ b/apps/dashboard/src/lib/components/PlanComparison.svelte
@@ -9,11 +9,11 @@
 	import { createMutation, createQuery } from '@tanstack/svelte-query';
 	import { toast } from 'svelte-sonner';
 	import {
-		balance as balanceQuery,
+		balanceQuery,
 		billingKeys,
-		plans as plansQuery,
-		previewUpgrade as previewUpgradeDef,
-		upgradePlan as upgradePlanDef,
+		plansQuery,
+		previewUpgradeMutation,
+		upgradePlanMutation,
 	} from '$lib/query/billing';
 	import { queryClient } from '$lib/query/client';
 
@@ -118,9 +118,9 @@
 		),
 	);
 
-	const previewMutation = createMutation(() => previewUpgradeDef.options);
+	const previewMutation = createMutation(() => previewUpgradeMutation.options);
 
-	const attachPlan = createMutation(() => upgradePlanDef.options);
+	const upgradeMutation = createMutation(() => upgradePlanMutation.options);
 
 	async function handleUpgradeClick(planId: string, planName: string) {
 		confirmDialog = { planId, planName };
@@ -257,7 +257,7 @@
 			<Button
 				onclick={() => {
 					if (confirmDialog) {
-						attachPlan.mutate(
+						upgradeMutation.mutate(
 							{ planId: confirmDialog.planId, successUrl: window.location.href },
 							{
 								onSuccess: (data) => {
@@ -274,9 +274,9 @@
 						);
 					}
 				}}
-				disabled={attachPlan.isPending}
+				disabled={upgradeMutation.isPending}
 			>
-				{#if attachPlan.isPending}
+				{#if upgradeMutation.isPending}
 					<Spinner class="size-3.5" />
 				{:else}
 					Confirm upgrade

--- a/apps/dashboard/src/lib/components/UserMenu.svelte
+++ b/apps/dashboard/src/lib/components/UserMenu.svelte
@@ -11,7 +11,7 @@
 	import { toast } from 'svelte-sonner';
 	import { api } from '$lib/api';
 	import { auth } from '$lib/auth';
-	import { balance as balanceQuery } from '$lib/query/billing';
+	import { balanceQuery } from '$lib/query/billing';
 	import { capitalize, getInitials } from '$lib/utils';
 
 	const balance = createQuery(() => balanceQuery.options);

--- a/apps/dashboard/src/lib/components/UserMenu.svelte
+++ b/apps/dashboard/src/lib/components/UserMenu.svelte
@@ -11,10 +11,10 @@
 	import { toast } from 'svelte-sonner';
 	import { api } from '$lib/api';
 	import { auth } from '$lib/auth';
-	import { balanceQueryOptions } from '$lib/query/billing';
+	import { balance as balanceQuery } from '$lib/query/billing';
 	import { capitalize, getInitials } from '$lib/utils';
 
-	const balance = createQuery(() => balanceQueryOptions());
+	const balance = createQuery(() => balanceQuery.options);
 
 	const subscription = $derived(
 		balance.data?.subscriptions?.find((s) => !s.addOn) ?? null,
@@ -32,12 +32,12 @@
 
 	/** Open Stripe billing portal via the API. */
 	async function openBillingPortal() {
-		try {
-			const data = await api.billing.portal();
-			if (data.url) window.location.href = data.url;
-		} catch {
+		const { data, error } = await api.billing.portal();
+		if (error) {
 			toast.error('Could not open billing portal.');
+			return;
 		}
+		if (data.url) window.location.href = data.url;
 	}
 	const isDark = $derived(mode.current === 'dark');
 </script>

--- a/apps/dashboard/src/lib/query/billing.ts
+++ b/apps/dashboard/src/lib/query/billing.ts
@@ -1,9 +1,9 @@
 /**
  * TanStack Query definitions for billing data.
  *
- * Uses `defineQuery` from wellcrafted/query so every query accepts
- * a Result-returning queryFn. Components use `.options` for reactive
- * queries, and `.fetch()` / `.execute()` for imperative calls.
+ * Static queries use `defineQuery` for the dual interface (.options + .fetch()).
+ * Parameterized queries return plain option objects since callers only need .options.
+ * Mutations use `defineMutation` for the dual interface (.options + .execute()).
  */
 import type {
 	EventsParams,
@@ -35,7 +35,7 @@ export const billingKeys = {
 };
 
 /** Fetch customer balance, subscription, and credit breakdown. */
-export const balance = defineQuery({
+export const balanceQuery = defineQuery({
 	queryKey: billingKeys.balance,
 	queryFn: () => api.billing.balance(),
 });
@@ -43,52 +43,54 @@ export const balance = defineQuery({
 /**
  * Fetch aggregated usage data for charts.
  *
- * @example
- * ```typescript
- * const usage = createQuery(() => usageQueryOptions({ range: '30d', binSize: 'day' }));
- * ```
+ * Returns plain query options—callers pass these to `createQuery()`.
+ * Uses a factory function because the query key depends on `params`.
  */
 export function usageQueryOptions(params: UsageParams = {}) {
-	return defineQuery({
+	return {
 		queryKey: billingKeys.usage(params),
 		queryFn: () => api.billing.usage(params),
-	}).options;
+	};
 }
 
-/** Fetch paginated event history for the activity feed. */
+/**
+ * Fetch paginated event history for the activity feed.
+ *
+ * Returns plain query options—callers pass these to `createQuery()`.
+ */
 export function eventsQueryOptions(params: EventsParams = {}) {
-	return defineQuery({
+	return {
 		queryKey: billingKeys.events(params),
 		queryFn: () => api.billing.events(params),
-	}).options;
+	};
 }
 
 /** Fetch available plans with customer eligibility. */
-export const plans = defineQuery({
+export const plansQuery = defineQuery({
 	queryKey: billingKeys.plans,
 	queryFn: () => api.billing.plans(),
 });
 
 /** Fetch model credits map and plan metadata. */
-export const models = defineQuery({
+export const modelsQuery = defineQuery({
 	queryKey: billingKeys.models,
 	queryFn: () => api.billing.models(),
 });
 
 /** Buy 500 credits via Stripe checkout. */
-export const topUp = defineMutation({
+export const topUpMutation = defineMutation({
 	mutationKey: [...billingKeys.all, 'top-up'] as const,
 	mutationFn: (successUrl?: string) => api.billing.topUp(successUrl),
 });
 
 /** Preview proration cost before changing plans. */
-export const previewUpgrade = defineMutation({
+export const previewUpgradeMutation = defineMutation({
 	mutationKey: [...billingKeys.all, 'preview'] as const,
 	mutationFn: (planId: string) => api.billing.preview(planId),
 });
 
 /** Upgrade or switch billing plan via Stripe. */
-export const upgradePlan = defineMutation({
+export const upgradePlanMutation = defineMutation({
 	mutationKey: [...billingKeys.all, 'upgrade'] as const,
 	mutationFn: ({
 		planId,

--- a/apps/dashboard/src/lib/query/billing.ts
+++ b/apps/dashboard/src/lib/query/billing.ts
@@ -1,11 +1,16 @@
 /**
- * TanStack Query options for billing data.
+ * TanStack Query definitions for billing data.
  *
- * Each export is a query options factory consumed by `createQuery()` in Svelte components.
- * Data flows from the Hono API routes via the typed API client.
+ * Uses `defineQuery` from wellcrafted/query so every query accepts
+ * a Result-returning queryFn. Components use `.options` for reactive
+ * queries, and `.fetch()` / `.execute()` for imperative calls.
  */
-import type { EventsParams, UsageParams } from '@epicenter/api/billing-contract';
+import type {
+	EventsParams,
+	UsageParams,
+} from '@epicenter/api/billing-contract';
 import { api } from '$lib/api';
+import { defineMutation, defineQuery } from '$lib/query/client';
 
 /**
  * Centralized query key objects for billing queries.
@@ -28,54 +33,68 @@ export const billingKeys = {
 	plans: ['billing', 'plans'] as const,
 	models: ['billing', 'models'] as const,
 };
+
 /** Fetch customer balance, subscription, and credit breakdown. */
-export function balanceQueryOptions() {
-	return {
-		queryKey: billingKeys.balance,
-		queryFn: () => api.billing.balance(),
-		staleTime: 30_000,
-	};
-}
+export const balance = defineQuery({
+	queryKey: billingKeys.balance,
+	queryFn: () => api.billing.balance(),
+});
 
 /**
  * Fetch aggregated usage data for charts.
  *
  * @example
  * ```typescript
- * const usage = createQuery(usageQueryOptions({ range: '30d', binSize: 'day', groupBy: 'properties.model' }));
+ * const usage = createQuery(() => usageQueryOptions({ range: '30d', binSize: 'day' }));
  * ```
  */
 export function usageQueryOptions(params: UsageParams = {}) {
-	return {
+	return defineQuery({
 		queryKey: billingKeys.usage(params),
 		queryFn: () => api.billing.usage(params),
-		staleTime: 60_000,
-	};
+	}).options;
 }
 
 /** Fetch paginated event history for the activity feed. */
 export function eventsQueryOptions(params: EventsParams = {}) {
-	return {
+	return defineQuery({
 		queryKey: billingKeys.events(params),
 		queryFn: () => api.billing.events(params),
-		staleTime: 30_000,
-	};
+	}).options;
 }
 
 /** Fetch available plans with customer eligibility. */
-export function plansQueryOptions() {
-	return {
-		queryKey: billingKeys.plans,
-		queryFn: () => api.billing.plans(),
-		staleTime: 120_000,
-	};
-}
+export const plans = defineQuery({
+	queryKey: billingKeys.plans,
+	queryFn: () => api.billing.plans(),
+});
 
 /** Fetch model credits map and plan metadata. */
-export function modelsQueryOptions() {
-	return {
-		queryKey: billingKeys.models,
-		queryFn: () => api.billing.models(),
-		staleTime: 300_000,
-	};
-}
+export const models = defineQuery({
+	queryKey: billingKeys.models,
+	queryFn: () => api.billing.models(),
+});
+
+/** Buy 500 credits via Stripe checkout. */
+export const topUp = defineMutation({
+	mutationKey: [...billingKeys.all, 'top-up'] as const,
+	mutationFn: (successUrl?: string) => api.billing.topUp(successUrl),
+});
+
+/** Preview proration cost before changing plans. */
+export const previewUpgrade = defineMutation({
+	mutationKey: [...billingKeys.all, 'preview'] as const,
+	mutationFn: (planId: string) => api.billing.preview(planId),
+});
+
+/** Upgrade or switch billing plan via Stripe. */
+export const upgradePlan = defineMutation({
+	mutationKey: [...billingKeys.all, 'upgrade'] as const,
+	mutationFn: ({
+		planId,
+		successUrl,
+	}: {
+		planId: string;
+		successUrl?: string;
+	}) => api.billing.upgrade(planId, successUrl),
+});

--- a/apps/dashboard/src/lib/query/client.ts
+++ b/apps/dashboard/src/lib/query/client.ts
@@ -1,5 +1,5 @@
 import { QueryClient } from '@tanstack/svelte-query';
-
+import { createQueryFactories } from 'wellcrafted/query';
 export const queryClient = new QueryClient({
 	defaultOptions: {
 		queries: {
@@ -8,3 +8,6 @@ export const queryClient = new QueryClient({
 		},
 	},
 });
+
+export const { defineQuery, defineMutation } =
+	createQueryFactories(queryClient);

--- a/apps/dashboard/src/routes/+page.svelte
+++ b/apps/dashboard/src/routes/+page.svelte
@@ -12,11 +12,7 @@
 	import PlanComparison from '$lib/components/PlanComparison.svelte';
 	import TopModels from '$lib/components/TopModels.svelte';
 	import UsageChart from '$lib/components/UsageChart.svelte';
-	import {
-		balance as balanceQuery,
-		billingKeys,
-		topUp,
-	} from '$lib/query/billing';
+	import { balanceQuery, billingKeys, topUpMutation } from '$lib/query/billing';
 	import { queryClient } from '$lib/query/client';
 
 	const balance = createQuery(() => balanceQuery.options);
@@ -35,7 +31,7 @@
 		if (data.url) window.location.href = data.url;
 	}
 
-	const topUpMutation = createMutation(() => topUp.options);
+	const topUp = createMutation(() => topUpMutation.options);
 </script>
 
 <CreditBalance />
@@ -74,7 +70,7 @@
 	<Button
 		variant="outline"
 		onclick={() => {
-			topUpMutation.mutate(window.location.href, {
+			topUp.mutate(window.location.href, {
 				onSuccess: (data) => {
 					if (data.paymentUrl) {
 						window.location.href = data.paymentUrl;
@@ -86,9 +82,9 @@
 				onError: () => toast.error('Top-up failed. Please try again.'),
 			});
 		}}
-		disabled={topUpMutation.isPending}
+		disabled={topUp.isPending}
 	>
-		{#if topUpMutation.isPending}
+		{#if topUp.isPending}
 			<Spinner class="size-3.5" />
 		{:else}
 			Buy 500 credits — $5

--- a/apps/dashboard/src/routes/+page.svelte
+++ b/apps/dashboard/src/routes/+page.svelte
@@ -5,17 +5,21 @@
 	import * as Tabs from '@epicenter/ui/tabs';
 	import { createMutation, createQuery } from '@tanstack/svelte-query';
 	import { toast } from 'svelte-sonner';
-	import { type AttachResponse, api } from '$lib/api';
+	import { api } from '$lib/api';
 	import ActivityFeed from '$lib/components/ActivityFeed.svelte';
 	import CreditBalance from '$lib/components/CreditBalance.svelte';
 	import ModelCostGuide from '$lib/components/ModelCostGuide.svelte';
 	import PlanComparison from '$lib/components/PlanComparison.svelte';
 	import TopModels from '$lib/components/TopModels.svelte';
 	import UsageChart from '$lib/components/UsageChart.svelte';
-	import { balanceQueryOptions, billingKeys } from '$lib/query/billing';
+	import {
+		balance as balanceQuery,
+		billingKeys,
+		topUp,
+	} from '$lib/query/billing';
 	import { queryClient } from '$lib/query/client';
 
-	const balance = createQuery(() => balanceQueryOptions());
+	const balance = createQuery(() => balanceQuery.options);
 	const subscription = $derived(
 		balance.data?.subscriptions?.find((s) => !s.addOn) ?? null,
 	);
@@ -23,28 +27,15 @@
 
 	/** Open Stripe billing portal via the API. */
 	async function openBillingPortal() {
-		try {
-			const data = await api.billing.portal();
-			if (data.url) window.location.href = data.url;
-		} catch {
+		const { data, error } = await api.billing.portal();
+		if (error) {
 			toast.error('Could not open billing portal.');
+			return;
 		}
+		if (data.url) window.location.href = data.url;
 	}
 
-	const topUp = createMutation(() => ({
-		mutationFn: () => api.billing.topUp(window.location.href),
-		onSuccess: (result: AttachResponse) => {
-			if (result.paymentUrl) {
-				window.location.href = result.paymentUrl;
-			} else {
-				toast.success('Credits added to your account');
-				queryClient.invalidateQueries({ queryKey: billingKeys.all });
-			}
-		},
-		onError: () => {
-			toast.error('Top-up failed. Please try again.');
-		},
-	}));
+	const topUpMutation = createMutation(() => topUp.options);
 </script>
 
 <CreditBalance />
@@ -82,10 +73,22 @@
 <section class="flex flex-wrap gap-3">
 	<Button
 		variant="outline"
-		onclick={() => topUp.mutate()}
-		disabled={topUp.isPending}
+		onclick={() => {
+			topUpMutation.mutate(window.location.href, {
+				onSuccess: (data) => {
+					if (data.paymentUrl) {
+						window.location.href = data.paymentUrl;
+					} else {
+						toast.success('Credits added to your account');
+						queryClient.invalidateQueries({ queryKey: billingKeys.all });
+					}
+				},
+				onError: () => toast.error('Top-up failed. Please try again.'),
+			});
+		}}
+		disabled={topUpMutation.isPending}
 	>
-		{#if topUp.isPending}
+		{#if topUpMutation.isPending}
 			<Spinner class="size-3.5" />
 		{:else}
 			Buy 500 credits — $5

--- a/apps/opensidian/package.json
+++ b/apps/opensidian/package.json
@@ -31,7 +31,8 @@
 		"arktype": "catalog:",
 		"better-auth": "catalog:",
 		"mode-watcher": "^1.1.0",
-		"wellcrafted": "catalog:"
+		"wellcrafted": "catalog:",
+		"typebox": "catalog:"
 	},
 	"devDependencies": {
 		"@codemirror/commands": "^6.10.3",

--- a/bun.lock
+++ b/bun.lock
@@ -207,6 +207,7 @@
         "arktype": "catalog:",
         "better-auth": "catalog:",
         "mode-watcher": "^1.1.0",
+        "typebox": "catalog:",
         "wellcrafted": "catalog:",
       },
       "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -476,7 +476,6 @@
       },
       "dependencies": {
         "@epicenter/workspace": "workspace:*",
-        "jsrepo": "catalog:",
         "typebox": "catalog:",
         "wellcrafted": "catalog:",
         "yargs": "catalog:",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,6 @@
 	},
 	"dependencies": {
 		"@epicenter/workspace": "workspace:*",
-		"jsrepo": "catalog:",
 		"typebox": "catalog:",
 		"wellcrafted": "catalog:",
 		"yargs": "catalog:",

--- a/packages/cli/src/README.md
+++ b/packages/cli/src/README.md
@@ -21,7 +21,7 @@ epicenter export                     # export all data as JSON
 epicenter size                       # report workspace sizes and row counts
 
 epicenter init                       # scaffold a new project
-epicenter install <item>             # install a workspace from a registry
+epicenter uninstall <workspace-id>   # remove a workspace
 epicenter uninstall <workspace-id>   # remove a workspace
 
 epicenter start [dir]                # start the workspace daemon

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -12,7 +12,7 @@ import {
 } from './commands/data';
 import { describeCommand } from './commands/describe';
 import { kvCommand } from './commands/kv';
-import { initCommand, installCommand, uninstallCommand } from './commands/project';
+import { initCommand, uninstallCommand } from './commands/project';
 import { runActionCommand } from './commands/run';
 import { sizeCommand } from './commands/size';
 import { startCommand } from './commands/start';
@@ -47,7 +47,6 @@ export function createCLI() {
 				.command(kvCommand)
 				.command(exportCommand)
 				.command(initCommand)
-				.command(installCommand)
 				.command(uninstallCommand)
 				.command(runActionCommand)
 				.command(describeCommand)

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -1,52 +1,19 @@
 /**
- * Project management commands: init, install, uninstall.
+ * Project management commands: init, uninstall.
  *
  * These commands manage the project scaffold and workspace source code.
- * `init` creates the project skeleton, `install` fetches from jsrepo registries,
- * `uninstall` removes installed workspaces.
+ * `init` creates the project skeleton, `uninstall` removes installed workspaces.
  */
 
-import { mkdir, rm } from 'node:fs/promises';
-import { dirname, join, resolve } from 'node:path';
-import { $ } from 'bun';
-import type { AbsolutePath } from 'jsrepo';
-import {
-	DEFAULT_PROVIDERS,
-	parseWantedItems,
-	resolveAndFetchAllItems,
-	resolveRegistries,
-	resolveWantedItems,
-} from 'jsrepo';
+import { rm } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
 import type { Argv } from 'yargs';
 import { output, outputError } from '../util/format-output';
 import {
-	addWorkspaceToConfig,
 	removeWorkspaceFromConfig,
 	toCamelCase,
-	toFactoryName,
 } from '../util/update-config';
 import { defineCommand } from '../util/command';
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-/** Extract registry URL from a full item path like "github/org/repo/item". */
-function extractRegistry(itemPath: string): string | undefined {
-	const parts = itemPath.split('/');
-	if (parts.length >= 4) {
-		return parts.slice(0, 3).join('/');
-	}
-	return undefined;
-}
-
-/** Extract item name from a full item path. */
-function extractItemName(itemPath: string): string {
-	const parts = itemPath.split('/');
-	if (parts.length >= 4) {
-		return parts.slice(3).join('/');
-	}
-	return itemPath;
-}
-
 
 // ─── Init ────────────────────────────────────────────────────────────────────
 
@@ -145,156 +112,6 @@ export const initCommand = defineCommand({
 		},
 	});
 
-// ─── Install ─────────────────────────────────────────────────────────────────
-
-/**
- * Core install logic extracted from the handler for linear control flow.
- * Throws on failure—the handler catches and formats the error.
- */
-async function installWorkspace(dir: string, itemArg: string, registryFlag?: string) {
-	// Verify config exists
-	const configPath = join(dir, 'epicenter.config.ts');
-	if (!(await Bun.file(configPath).exists())) {
-		throw new Error('No epicenter.config.ts found. Run "epicenter init" first.');
-	}
-
-	// Parse registry + item
-	const registryUrl = registryFlag ?? extractRegistry(itemArg);
-	const itemName = registryFlag ? itemArg : extractItemName(itemArg);
-	if (!registryUrl) {
-		throw new Error('Could not determine registry. Use --registry or provide a full path like github/myorg/workspaces/my-app');
-	}
-
-	console.log(`Resolving ${itemName} from ${registryUrl}...`);
-	const cwd = dir as AbsolutePath;
-
-	// Resolve → parse → resolve → fetch (linear, throw on failure)
-	const registriesResult = await resolveRegistries([registryUrl], { cwd, providers: DEFAULT_PROVIDERS });
-	if (registriesResult.isErr()) throw new Error(`Failed to resolve registry: ${registriesResult.error}`);
-
-	const parsedResult = parseWantedItems([itemName], { providers: DEFAULT_PROVIDERS, registries: [registryUrl] });
-	if (parsedResult.isErr()) throw new Error(`Failed to parse item: ${parsedResult.error}`);
-
-	const resolvedResult = await resolveWantedItems(parsedResult.value.wantedItems, {
-		resolvedRegistries: registriesResult.value,
-		nonInteractive: true,
-	});
-	if (resolvedResult.isErr()) throw new Error(`Failed to resolve item: ${resolvedResult.error}`);
-
-	const fetchedItems = await resolveAndFetchAllItems(resolvedResult.value);
-	if (fetchedItems.isErr()) throw new Error(`Failed to fetch item: ${fetchedItems.error}`);
-	if (fetchedItems.value.length === 0) throw new Error('No items found');
-
-	const item = fetchedItems.value[0]!;
-
-	// Check if workspace already exists
-	const wsDir = join(dir, 'workspaces', item.name);
-	if (await Bun.file(join(wsDir, 'manifest.json')).exists()) {
-		throw new Error(
-			`Workspace "${item.name}" already exists at ./workspaces/${item.name}/. Remove it first with "epicenter uninstall ${item.name}".`,
-		);
-	}
-
-	// Write files
-	await mkdir(wsDir, { recursive: true });
-	for (const file of item.files) {
-		const filePath = join(wsDir, file.path);
-		await mkdir(dirname(filePath), { recursive: true });
-		await Bun.write(filePath, file.content);
-	}
-	console.log(`  ✓ Fetched ${item.name} (${item.files.length} files)`);
-	console.log(`  ✓ Wrote to ./workspaces/${item.name}/`);
-
-	// Write manifest.json with provenance
-	const manifest = {
-		registry: registryUrl,
-		item: item.name,
-		installedAt: new Date().toISOString(),
-		files: item.files.map((f: { path: string }) => f.path),
-	};
-	await Bun.write(join(wsDir, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n');
-
-	// Handle dependencies
-	const deps: Record<string, string> = {};
-	for (const dep of item.dependencies ?? []) {
-		if (typeof dep === 'string') {
-			deps[dep] = 'latest';
-		} else {
-			deps[dep.name] = dep.version ?? 'latest';
-		}
-	}
-	if (Object.keys(deps).length > 0) {
-		console.log('  Installing dependencies...');
-		await $`bun install`.cwd(dir).quiet();
-		console.log(`  ✓ Installed ${Object.keys(deps).length} dependencies`);
-	}
-
-	// Update epicenter.config.ts
-	try {
-		const configContent = await Bun.file(configPath).text();
-		const factoryName = toFactoryName(item.name);
-		const exportName = toCamelCase(item.name);
-		const importPath = `./workspaces/${item.name}/workspace`;
-		const updated = addWorkspaceToConfig(configContent, importPath, factoryName, exportName);
-		await Bun.write(configPath, updated);
-		console.log('  ✓ Updated epicenter.config.ts');
-	} catch {
-		console.log('  ⚠ Could not auto-update epicenter.config.ts. Add manually:');
-		console.log(`    import { ${toFactoryName(item.name)} } from './workspaces/${item.name}/workspace';`);
-		console.log(`    export const ${toCamelCase(item.name)} = ${toFactoryName(item.name)}();`);
-	}
-
-	output({
-		installed: item.name,
-		path: `./workspaces/${item.name}/`,
-		files: item.files.length,
-		dependencies: Object.keys(deps).length,
-	});
-}
-
-/**
- * `epicenter install <item>` — install a workspace from a jsrepo registry.
- *
- * Fetches workspace source code via the jsrepo programmatic API, writes it to
- * `./workspaces/<name>/`, generates `manifest.json` with provenance, updates
- * `epicenter.config.ts`, and runs `bun install` for dependencies.
- *
- * @example
- * ```bash
- * epicenter install github/epicenterhq/workspaces/my-notes
- * epicenter install my-notes --registry github/epicenterhq/workspaces
- * ```
- */
-export const installCommand = defineCommand({
-		command: 'install <item>',
-		describe: 'Install a workspace from a jsrepo registry',
-		builder: (y: Argv) =>
-			y
-				.positional('item', {
-					type: 'string',
-					demandOption: true,
-					describe:
-						'Registry item to install (e.g. github/myorg/workspaces/my-app)',
-				})
-				.option('registry', {
-					type: 'string',
-					describe: 'Registry URL (e.g. github/myorg/workspaces)',
-				})
-				.option('dir', {
-					type: 'string',
-					default: '.',
-					alias: 'C',
-					description: 'Project directory containing epicenter.config.ts',
-				}),
-		handler: async (argv: any) => {
-			try {
-				await installWorkspace(resolve(argv.dir as string), argv.item as string, argv.registry as string | undefined);
-			} catch (err) {
-				outputError(err instanceof Error ? err.message : String(err));
-				process.exitCode = 1;
-			}
-		},
-	});
 
 // ─── Uninstall ───────────────────────────────────────────────────────────────
 

--- a/packages/cli/src/util/update-config.ts
+++ b/packages/cli/src/util/update-config.ts
@@ -1,79 +1,11 @@
 /**
  * Line-based manipulation of `epicenter.config.ts`.
  *
- * Adds or removes import+export lines for workspace factories.
+ * Removes import+export lines for workspace factories.
  * Uses simple string manipulation—AST parsing is overkill for
- * inserting import/export pairs.
- *
- * Strategy:
- * - **Add**: Find last import line, insert new import after it.
- *   Append new export at end of file.
- * - **Remove**: Find and remove lines matching the import path
- *   and export name.
+ * removing import/export pairs.
  */
 
-/**
- * Add a workspace import and export to an `epicenter.config.ts` file.
- *
- * Inserts the import after the last existing import line (or at the top
- * if no imports exist), and appends the export at the end of the file.
- *
- * @param content - Current file content.
- * @param importPath - Relative import path (e.g., `'./workspaces/my-notes/workspace'`).
- * @param factoryName - Factory function name (e.g., `createMyNotes`).
- * @param exportName - Export variable name (e.g., `myNotes`).
- * @returns Updated file content with the new import and export added.
- *
- * @example
- * ```typescript
- * const updated = addWorkspaceToConfig(
- *   existingContent,
- *   './workspaces/my-notes/workspace',
- *   'createMyNotes',
- *   'myNotes',
- * );
- * ```
- */
-export function addWorkspaceToConfig(
-	content: string,
-	importPath: string,
-	factoryName: string,
-	exportName: string,
-): string {
-	const importLine = `import { ${factoryName} } from '${importPath}';`;
-	const exportLine = `export const ${exportName} = ${factoryName}()\n\t.withExtension('persistence', setupPersistence);`;
-
-	const lines = content.split('\n');
-
-	// Find the last import line index
-	let lastImportIndex = -1;
-	for (let i = 0; i < lines.length; i++) {
-		if (lines[i]!.trimStart().startsWith('import ')) {
-			lastImportIndex = i;
-		}
-	}
-
-	// Insert import after last import (or at top if none)
-	if (lastImportIndex >= 0) {
-		lines.splice(lastImportIndex + 1, 0, importLine);
-	} else {
-		// No existing imports — put at top (after any leading comments)
-		let insertAt = 0;
-		for (let i = 0; i < lines.length; i++) {
-			const trimmed = lines[i]!.trim();
-			if (trimmed.startsWith('//') || trimmed.startsWith('/*') || trimmed.startsWith('*') || trimmed === '') {
-				insertAt = i + 1;
-			} else {
-				break;
-			}
-		}
-		lines.splice(insertAt, 0, importLine);
-	}
-
-	// Append export at end of file
-	const joined = lines.join('\n').trimEnd();
-	return joined + '\n\n' + exportLine + '\n';
-}
 
 /**
  * Remove a workspace import and export from an `epicenter.config.ts` file.
@@ -149,20 +81,4 @@ export function removeWorkspaceFromConfig(
  */
 export function toCamelCase(name: string): string {
 	return name.replace(/[-_](\w)/g, (_, c: string) => c.toUpperCase());
-}
-
-/**
- * Convert a kebab-case name to a PascalCase factory function name.
- *
- * @example
- * ```typescript
- * toFactoryName('my-notes'); // 'createMyNotes'
- * toFactoryName('simple');   // 'createSimple'
- * ```
- */
-export function toFactoryName(name: string): string {
-	const pascal = name.replace(/(^|[-_])(\w)/g, (_, __, c: string) =>
-		c.toUpperCase(),
-	);
-	return `create${pascal}`;
 }


### PR DESCRIPTION
The CLI's only use of jsrepo was `epicenter install`, which fetched workspace source files from a jsrepo registry into `./workspaces/` and wired them into `epicenter.config.ts`. In practice, no registry exists—every app in the monorepo defines workspaces inline via `@epicenter/workspace` imports. The install command was speculative infrastructure for a distribution model that hasn't materialized.

For now, workspace definitions will be distributed as normal npm packages. Factory functions like `createTabManagerWorkspace` can be exported from existing packages and composed with `.withActions()` at the call site. This is simpler and gives us versioning, lockfiles, and `bun update` for free.

```bash
# Before — jsrepo registry fetch
epicenter install github/epicenterhq/workspaces/my-notes
#   → resolveRegistries() → parseWantedItems() → fetch → write files
#   → patch epicenter.config.ts

# After — normal npm package
bun add @epicenter/my-notes-workspace
```

```typescript
// epicenter.config.ts — just import the package and compose
import { createMyNotes } from '@epicenter/my-notes-workspace';
import { filesystemPersistence } from '@epicenter/workspace/extensions/persistence/sqlite';

export const myNotes = createMyNotes()
  .withExtension('persistence', filesystemPersistence({ filePath: './data/my-notes.db' }));
```

### What was removed

```typescript
// packages/cli/src/commands/project.ts
// — the entire jsrepo resolve → fetch → write pipeline:
import { resolveRegistries, parseWantedItems, resolveWantedItems, resolveAndFetchAllItems } from 'jsrepo';

async function installWorkspace(dir: string, itemArg: string, registryFlag?: string) {
  const registriesResult = await resolveRegistries([registryUrl], { cwd, providers: DEFAULT_PROVIDERS });
  const parsedResult = parseWantedItems([itemName], { ... });
  const resolvedResult = await resolveWantedItems(parsedResult.value.wantedItems, { ... });
  const fetchedItems = await resolveAndFetchAllItems(resolvedResult.value);
  // write files to ./workspaces/<name>/, patch epicenter.config.ts
}

// packages/cli/src/util/update-config.ts
// — addWorkspaceToConfig(), toFactoryName() (only used by install)

// packages/cli/package.json
// — "jsrepo": "catalog:" dependency
```

### What remains

- `epicenter init` — scaffolds `epicenter.config.ts`, `package.json`, `.gitignore`
- `epicenter uninstall` — removes `./workspaces/<id>/` and patches config (cleaned up in #1621)
- `packages/ui/jsrepo.config.ts` — unrelated; manages shadcn-svelte-extras component installation

### Reinstating jsrepo later

If the ecosystem grows to where third-party workspace authors need the shadcn-style "own the code" pattern (copy source into project, interactive diff updates), jsrepo can be reintroduced. The commit being removed here documents the full integration pattern: `resolveRegistries` → `parseWantedItems` → `resolveWantedItems` → `resolveAndFetchAllItems` → write files → patch config.

Follow-up: #1621 removes the now-dead `uninstall` command and `update-config.ts` that only existed to support this flow, and fixes the `CONFIG_TEMPLATE` to show the npm pattern.

6 files changed, -278 lines.