### PR TITLE
docs: launch-readiness documentation

### DIFF
--- a/.agents/skills/writing-voice/SKILL.md
+++ b/.agents/skills/writing-voice/SKILL.md
@@ -214,3 +214,42 @@ When the user provides example text or tone guidance, match it:
 Epicenter's primary goal is not to make money. Vision and mission come first. Financial sustainability exists to fund more open-source development and sponsor contributors—it's a means, not the point.
 
 When writing about how the project sustains itself, be cautious with language that sounds like a pitch deck. Avoid "revenue," "monetization," "ARR," dollar-figure valuations, and other tech bro jargon. Say "financial sustainability" or "sustaining the project" instead. Name companies like Grafana or Bitwarden as references, but drop the dollar figures—otherwise it reads as if we're chasing their numbers rather than explaining our approach.
+
+## Empathy for the Reader
+
+Technical writing works when the reader feels understood, not lectured. This means:
+
+- Acknowledge the reader's frustration before offering the fix. If a warning is confusing, say so. "This warning is confusing" costs nothing and builds trust.
+- Show the path they likely walked. If you found the answer after hitting the same wall, trace that path briefly. "You probably tried X, then Y, and ended up here"—this signals you understand their situation.
+- Respect their time by leading with the answer. Don't make them wade through context to find the fix. Give them the fix, then explain why it works.
+- Assume competence. Don't over-explain fundamentals. If someone is reading about `$derived` vs `$state`, they already know what reactivity is.
+- Present trade-offs honestly. Every solution has costs. Saying "this is perfect" when it has caveats will lose the reader's trust the moment they hit those caveats.
+- Write from beside them, not above them. "Here's what worked" reads differently than "The correct approach is". Both convey the same information; the first treats the reader as a peer.
+
+## Braden's Personal Voice
+
+These patterns come from actual HN posts and community interactions. They define how Epicenter sounds when Braden is writing.
+
+### Lead with your story, not the product
+
+Don't describe what the tool does in the abstract. Tell the reader why you built it. "I was paying $30/month for a transcription app. Then I did the math" is more compelling than "Epicenter reduces transcription costs." The product emerges from the story; the story doesn't serve the product.
+
+### Vulnerability builds trust
+
+"I just finished college and was about to move back with my parents" earns more credibility than any feature list. Admitting uncertainty ("It's not there yet regarding memory, but it's getting there") signals honesty. Don't perform confidence—show real progress and real gaps.
+
+### First person over generalized claims
+
+Write "I have a phone and a laptop" not "Most users have multiple devices." Write "I'm the kind of person who ends up back in a folder of markdown files" not "Many developers prefer plain text." Your experience is the evidence; generalizations are filler.
+
+### End with an invitation, not a summary
+
+Don't restate the thesis. End with a door: "Fork it, break it, ship your own version, copy whatever you want!" or "If you want to look at the code: [link]." The reader should feel invited to participate, not lectured at.
+
+### Specificity over superlatives
+
+"I use it for several hours a day, from coding to thinking out loud while carrying pizza boxes back from the office" is better than "I use it every day for everything." Specific details are memorable; superlatives are forgettable.
+
+### Casual honesty about competitors
+
+"There are plenty of transcription apps out there" and "one of my other OSS favorites is Handy" — acknowledge the ecosystem without trash-talking. Recommend alternatives genuinely. The confidence to name competitors signals you're not insecure about your position.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -46,6 +46,71 @@ Web apps (Cloudflare Workers) deploy **together in one workflow** because deploy
 |---|---|---|
 | `auto.label-issues.yml` | Issues opened/edited | Uses Claude to auto-label issues by type, priority, platform, and area. |
 | `auto.release.yml` | PR merged to `main` | Bumps version, collects `## Changelog` entries from merged PRs, commits release, tags, creates GitHub Release with grouped changelog. |
+| changesets (manual) | Manual | `bunx changeset version` + `bunx changeset publish`. `@changesets/action` will automate this later. |
+
+## Package Releases (npm)
+
+We use [changesets](https://github.com/changesets/changesets) to version and publish npm packages.
+
+### Public and private packages
+
+| Package | npm name | Published |
+|---|---|---|
+| `packages/workspace` | `@epicenter/workspace` | yes |
+| `packages/cli` | `@epicenter/cli` | yes |
+| `packages/sync` | `@epicenter/sync` | yes |
+| `packages/filesystem` | `@epicenter/filesystem` | yes |
+| `packages/skills` | `@epicenter/skills` | yes |
+| `packages/ui` | `@epicenter/ui` | yes |
+| `packages/svelte-utils` | `@epicenter/svelte` | yes |
+| `packages/ai` | `@epicenter/ai` | no (private) |
+| `packages/constants` | `@epicenter/constants` | no (private) |
+| `packages/vault` | `@epicenter/vault` | no (private) |
+
+### Fixed version group
+
+All seven public packages share one version number, configured via the `fixed` array in `.changeset/config.json`. When any one of them changes, all seven bump together. This keeps the ecosystem coherent: if you install `@epicenter/workspace@0.3.0`, you know `@epicenter/cli@0.3.0` is the matching release.
+
+### Day-to-day: adding a changeset
+
+After making changes to any package, record what changed before committing:
+
+```bash
+bunx changeset
+```
+
+The CLI will ask which packages changed, what semver bump applies (patch/minor/major), and for a short summary. It writes a `.changeset/*.md` file. Commit that file alongside your code changes.
+
+Don't skip this step. Without a changeset, the change won't appear in the CHANGELOG and won't trigger a version bump.
+
+### Cutting a release
+
+When you're ready to publish accumulated changesets:
+
+1. Bump versions and write CHANGELOGs:
+   ```bash
+   bunx changeset version
+   ```
+
+2. Commit the result:
+   ```bash
+   git add . && git commit -m "chore: release vX.Y.Z"
+   ```
+
+3. Publish to npm and create git tags:
+   ```bash
+   bunx changeset publish
+   ```
+
+4. Push commits and tags:
+   ```bash
+   git push && git push --tags
+   ```
+
+### What not to do
+
+- Don't manually edit `version` fields in `package.json`. Changesets owns those.
+- Don't run `npm publish` or `bun publish` directly. `bunx changeset publish` handles the registry upload and git tagging together.
 
 ### Meta
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,6 +189,56 @@ cd packages/epicenter
 bun unlink
 ```
 
+## Releasing
+
+This section is for maintainers with npm publish access to the `@epicenter` scope.
+
+### Prerequisites
+
+- Bun installed (see above)
+- An npm account with publish access to the `@epicenter` scope
+- `npm login` completed in your terminal
+
+### How versioning works
+
+All seven public packages (`@epicenter/workspace`, `@epicenter/cli`, `@epicenter/sync`, `@epicenter/filesystem`, `@epicenter/skills`, `@epicenter/ui`, `@epicenter/svelte`) share a single version number. They move together. Apps (Whispering, the API) are versioned independently.
+
+We use [changesets](https://github.com/changesets/changesets) to track changes and publish. Never edit `version` fields in `package.json` by hand.
+
+### Adding a changeset
+
+After making changes to any package, run this before committing:
+
+```bash
+bunx changeset
+```
+
+Select the affected packages, pick the semver bump (patch for fixes, minor for new features), and write a short summary. Commit the generated `.changeset/*.md` file with your code.
+
+### Publishing a release
+
+```bash
+# 1. Consume all pending changesets, bump versions, write CHANGELOGs
+bunx changeset version
+
+# 2. Commit
+git add . && git commit -m "chore: release vX.Y.Z"
+
+# 3. Publish to npm and create git tags
+bunx changeset publish
+
+# 4. Push
+git push && git push --tags
+```
+
+### App deployments
+
+Apps deploy separately from npm packages:
+
+- **Whispering (desktop)**: Push a `v*` tag. `release.whispering.yml` builds for all four platforms and publishes a GitHub Release draft.
+- **Web apps (Cloudflare Workers)**: Merge to `main`. `deploy.cloudflare.yml` deploys automatically.
+
+See [`.github/workflows/README.md`](.github/workflows/README.md) for the full workflow reference.
 ## Coding Standards
 
 ### TypeScript

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   </a>
   <h1 align="center">Epicenter</h1>
   <p align="center">Local-first, open-source apps</p>
-  <p align="center">Own your data. Use any model you want. Free and open source ❤️</p>
+  <p align="center">One folder of plain text and SQLite on your machine, synced across all your devices.<br>Grep it, query it, host it wherever you want.</p>
 </p>
 
 <p align="center">
@@ -46,9 +46,11 @@
 
 ## What is Epicenter?
 
-Epicenter is an ecosystem of open-source, local-first apps. Our goal is to store all of your data—notes, transcripts, chat histories—in a single folder of plain text and SQLite. Every tool we build shares this memory. It's open, tweakable, and yours. Grep it, open it in Obsidian, host it wherever you'd like.
+Epicenter is an ecosystem of open-source, local-first apps. All your data—notes, transcripts, chat histories—lives in a single folder of plain text and SQLite on your machine. Every tool we build reads and writes to the same place. It's open, tweakable, and yours. Grep it, open it in Obsidian, version it with Git, host it wherever you want.
 
-The library that powers this, [`@epicenter/workspace`](packages/workspace), is something other developers can build on too. Define a schema, get CRDT-powered tables that materialize down to SQLite files and markdown, with multi-device sync handled for you.
+Under the hood, Yjs CRDTs are the single source of truth. They materialize *down* to SQLite (for fast queries) and markdown (for human-readable files). Sync happens over the Yjs protocol; the server is a relay, not an authority—it never sees your content.
+
+The library that powers this, [`@epicenter/workspace`](packages/workspace), is something other developers can build on too. Define a typed schema, get CRDT-backed tables with multi-device sync handled for you.
 
 ## Apps
 
@@ -72,8 +74,8 @@ The library that powers this, [`@epicenter/workspace`](packages/workspace), is s
       <p><strong><a href="apps/api">Source</a></strong></p>
     </td>
     <td align="center" width="50%">
-      <h3>More coming</h3>
-      <p>The workspace library makes it straightforward to add new apps that share the same data. Notes, assistants, and other tools are in various stages of development.</p>
+      <h3>Build your own</h3>
+      <p>The <a href="packages/workspace"><code>@epicenter/workspace</code></a> library makes it straightforward to build apps that share the same CRDT-backed data. Define a schema, get tables, add sync.</p>
     </td>
   </tr>
 </table>
@@ -115,9 +117,9 @@ Each user gets their own database. Schema definitions are plain JSON, so they wo
 
 ## Where We're Headed
 
-The goal is a personal workspace where every app you use shares the same memory, your data stays on your machine, and you choose your own models. Epicenter Cloud will provide hosted sync infrastructure for people who don't want to run their own server—the same model as Supabase selling hosted Postgres or Liveblocks selling hosted collaboration. Enterprise features (team management, SSO, admin dashboards) will live in a separate proprietary layer.
+More apps are coming—notes, an AI assistant, and others—all sharing the same workspace. The architecture already supports it; the [`@epicenter/workspace`](packages/workspace) library handles the hard parts (schemas, CRDT sync, materialization), so each new app is mostly UI.
 
-Self-hosting is and will remain a first-class option. The sync server is open source under AGPL, and when you run it on your own infrastructure, you control the encryption keys and trust boundary.
+Epicenter Cloud will provide hosted sync for people who don't want to run their own server. Same model as Supabase selling hosted Postgres or Liveblocks selling hosted collaboration. Self-hosting is and will remain first-class—the sync server is open source under AGPL, and when you run it yourself, you control the encryption keys and trust boundary.
 
 ## Quick Start
 
@@ -193,5 +195,5 @@ See [FINANCIAL_SUSTAINABILITY.md](FINANCIAL_SUSTAINABILITY.md) for the full reas
 </p>
 
 <p align="center">
-  <sub>Own your data · Local-first · Open source</sub>
+  <sub>Local-first · CRDT · Own your data · Open source</sub>
 </p>

--- a/apps/landing/src/content/blog/second-brain-infrastructure.md
+++ b/apps/landing/src/content/blog/second-brain-infrastructure.md
@@ -1,0 +1,69 @@
+---
+title: "Karpathy's second brain is a folder. Here's what's missing."
+description: 'The idea is great. Three folders and a schema file. But it breaks the moment you use two devices—and I think we can fix that without losing the simplicity.'
+pubDate: 2025-04-06
+---
+
+Karpathy posted his "second brain" setup recently. Three folders: `raw/` for dumping everything, `wiki/` where AI organizes it, `outputs/` where AI answers your questions. One schema file—CLAUDE.md—that tells the AI how to think about your knowledge. No apps. No databases. Just markdown files and a good prompt.
+
+41,000 people bookmarked it. I was one of them.
+
+I get the appeal. I'm the kind of person who has tried every note-taking app and always ends up back in a folder of markdown files. There's something about plain text that feels right—you own it, you can grep it, it'll outlive whatever app you're using today. Karpathy nailed the insight: stop organizing by hand. Let the AI do it. Your job is to capture; the AI's job is to file.
+
+The thing is, I've been building something that looks a lot like this for the past year. Epicenter stores all your data—notes, transcripts, chat histories—in one folder of plain text and SQLite. Every app we build reads and writes to the same place. When I saw Karpathy's post, my first thought was "oh cool, he's doing the same thing." My second thought was "he's going to hit the same walls I did."
+
+## The walls
+
+It's one laptop. That's the first one. You edit a wiki article on your desktop, then open your laptop on the couch, and you're looking at stale files. You can hack around this with iCloud or Dropbox, but file-level sync doesn't understand content—if you edit the same file from two places, you get a conflict, and now you're manually merging markdown at 11pm.
+
+There's no structured querying. Ripgrep is great, and I use it constantly, but try asking "all notes tagged #project that I haven't looked at in 30 days." That's a SQL query, not a text search. Karpathy's system doesn't have a way to express that without writing a custom script every time.
+
+There's no encryption. Your `raw/` folder sits as plaintext on disk. If you're dumping medical notes, financial records, or anything genuinely private in there, you're trusting your disk encryption and nothing else. If you ever sync it anywhere, it's exposed.
+
+And the schema file is a gentleman's agreement. CLAUDE.md tells the AI what to do, but nothing enforces it. The AI can write `inbox` instead of `raw` and your system silently drifts. Over months, the wiki accumulates contradictions and nobody notices until the monthly health check—which, let's be honest, you'll forget to run.
+
+## What we're building differently
+
+Epicenter uses Yjs, a CRDT library, as the single source of truth. CRDTs are data structures designed for exactly this problem—multiple devices editing the same data, merging automatically, no conflicts. Two people (or two of your devices) editing the same note at the same time always produces a valid merge. No "which version wins?" conversations.
+
+The trick that makes this feel like Karpathy's system: Yjs materializes *down* to plain files. The markdown files are still there. Still greppable. Still openable in Obsidian. But underneath, the CRDT handles sync and conflict resolution. Edit from your phone, edit from your laptop—the Yjs layer merges it.
+
+It also materializes down to SQLite, which is where structured queries come in:
+
+```bash
+epicenter query "SELECT * FROM notes WHERE tags LIKE '%project%' AND updated_at < date('now', '-30 days')"
+```
+
+That's the `epicenter` CLI. Karpathy's monthly health check becomes a script you can cron instead of a prompt you remember to type.
+
+Schemas are typed and enforced at runtime, not just documented:
+
+```typescript
+const workspace = defineWorkspace({
+  id: 'second-brain',
+  tables: {
+    notes: {
+      id: id(),
+      title: text(),
+      content: text(),
+      tags: text(),
+      folder: select({ options: ['raw', 'wiki', 'outputs'] }),
+    },
+  },
+  kv: {},
+});
+```
+
+That `folder` field can only be `raw`, `wiki`, or `outputs`. If the AI tries to write `inbox`, it fails at the schema level. Drift doesn't happen silently.
+
+Encryption is XChaCha20-Poly1305 with HKDF key derivation. The sync server—which you can self-host—is a relay. It passes encrypted blobs between your devices but never sees the content. The keys never leave your machines.
+
+## The honest trade-off
+
+Karpathy's system is simpler. Three folders and a text file. Anyone can set it up in five minutes. Epicenter adds a library, a sync server, a CLI, a schema definition. That's real complexity. If you're one person on one laptop who never needs structured queries and never puts anything sensitive in your notes, Karpathy's system is probably the right call.
+
+But I have a phone and a laptop. I want to search my notes by date and tag, not just by keyword. I have notes I'd rather not store in plaintext. And I definitely want to automate things—a weekly digest, a health check, a script that surfaces stuff I've forgotten about. For me, the infrastructure overhead is worth it because the alternative is doing all of that by hand, badly, forever.
+
+The markdown files are still there. You can still grep them. You can still open them in Obsidian. The CRDT layer is invisible until you need it—and then it's exactly what you needed.
+
+If you want to look at the code: [github.com/EpicenterHQ/epicenter](https://github.com/EpicenterHQ/epicenter). The workspace library is at [packages/workspace](https://github.com/EpicenterHQ/epicenter/tree/main/packages/workspace). Everything's MIT, except the sync server which is AGPL. Fork it, break it, build your own second brain on top of it.

--- a/apps/opensidian/README.md
+++ b/apps/opensidian/README.md
@@ -1,12 +1,108 @@
 # Opensidian
 
-Open-source, local-first note-taking app inspired by Obsidian. Built with SvelteKit on the Epicenter ecosystem.
+Opensidian is a local-first note-taking app with a built-in bash terminal, end-to-end encryption, and real-time sync. Your notes live in a CRDT-backed virtual filesystem that a shell can write to just as easily as the editor can. Try it at [opensidian.com](https://opensidian.com).
 
-Part of the [Epicenter](https://github.com/EpicenterHQ/epicenter) monorepo.
+Part of the [Epicenter](https://github.com/EpicenterHQ/epicenter) monorepo. MIT licensed.
 
-## Running
+---
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  SvelteKit UI (CodeMirror, File Tree, Terminal, AI Chat) │
+├──────────────────────────────────────────────────────────┤
+│  @epicenter/filesystem (POSIX ops, file tree, soft del)  │
+├──────────────────────────────────────────────────────────┤
+│  @epicenter/workspace (Yjs CRDTs, versioned tables, E2E) │
+├──────────────────────────────────────────────────────────┤
+│  Extensions: IndexedDB, WebSocket sync, SQLite FTS,      │
+│  markdown materializer                                   │
+├──────────────────────────────────────────────────────────┤
+│  Yjs (Y.Doc, Y.Array, Y.Map, Y.Text)                    │
+└──────────────────────────────────────────────────────────┘
+```
+
+The key design decision: Yjs CRDTs are the single source of truth, not the database. Every file is a Y.Doc. The filesystem is a versioned Yjs table. SQLite, IndexedDB, and the sync server are all downstream consumers of that CRDT state—they can be rebuilt from scratch at any time.
+
+---
+
+## How it works
+
+### CRDT filesystem
+
+Every file is a Yjs document. The filesystem itself is a versioned table with columns for `id`, `name`, `parentId`, `type`, `size`, and timestamps. File content lives in separate per-file Y.Docs, so a large note doesn't bloat the directory index. Deletes are soft—files get a `trashedAt` timestamp rather than disappearing from the CRDT, which means concurrent deletes and edits resolve cleanly instead of causing conflicts.
+
+The `@epicenter/filesystem` package wraps this with POSIX-style operations: `mkdir`, `mv`, `rm`, `stat`, and so on. The file tree in the UI and the bash terminal both go through the same layer.
+
+### The terminal
+
+The terminal runs [just-bash](https://github.com/nicolo-ribaudo/just-bash)—a full bash interpreter written in TypeScript, with over 80 Unix commands including `awk`, `sed`, `grep`, `jq`, `sort`, `find`, `tar`, `sqlite3`, `curl`, and `xargs`. It's wired directly to the CRDT filesystem, so shell operations and editor operations are the same thing.
 
 ```bash
+$ echo "# Meeting notes" > /notes/2026-04-06.md
+$ mkdir /notes/archive
+$ mv /notes/2026-04-06.md /notes/archive/
+```
+
+Each of those commands creates or moves a real file that immediately appears in the editor's file tree. There's also a custom `open <path>` command that navigates the editor to a file. If you're the kind of person who reaches for the terminal to organize files, you don't have to context-switch.
+
+### Editor
+
+The editor is CodeMirror 6 with a Yjs binding via `y-codemirror.next`. Undo and redo go through Yjs rather than CodeMirror's own history, so they're CRDT-aware and work correctly across devices. Vim mode is available and toggleable; the preference persists across sessions. Language detection is automatic based on file extension, with custom highlighting for markdown.
+
+Internal links use `[[` autocomplete: typing `[[` opens a file picker, and selecting a file inserts `[File Name](id:GUID)`. The link stores the file's ID rather than its path, so renaming or moving the target doesn't break it. Links render as clickable decorations in the editor and navigate to the target file on click.
+
+### Sync and encryption
+
+Sync uses the Yjs protocol (STEP1/STEP2/UPDATE messages) over WebSocket, with exponential backoff and jitter on reconnect. A BroadcastChannel handles tab-to-tab sync within the same browser without going through the server. The server side runs on Cloudflare Durable Objects with a SQLite update log and auto-compaction.
+
+Encryption is XChaCha20-Poly1305. Keys are derived with HKDF-SHA256 in a two-level hierarchy: a user key derives a workspace key, and the workspace key encrypts the data. The sync server receives only ciphertext—it can relay updates without being able to read them. Keys are loaded on login and cleared from memory on logout; IndexedDB is wiped on logout too.
+
+### Search
+
+Full-text search runs against SQLite FTS5. It indexes both file names and content, supports match-case and regex toggles, and returns paginated results. The SQLite database is a materialized view of the CRDT state, rebuilt from Yjs updates whenever needed.
+
+### AI chat
+
+Conversations are stored in Yjs tables, so they sync across devices like everything else. Responses stream over SSE. The AI can call tools—file operations, search, and others—with an approval UI that shows what the tool will do before it runs. The system prompt is layered: a base prompt plus per-skill additions. Provider and model are selectable at runtime.
+
+---
+
+## Running locally
+
+Prerequisites: [Bun](https://bun.sh).
+
+```bash
+git clone https://github.com/EpicenterHQ/epicenter.git
+cd epicenter
+bun install
 cd apps/opensidian
 bun dev
 ```
+
+By default this runs against a local dev server. To run against the production sync server:
+
+```bash
+bun run dev:remote
+```
+
+---
+
+## Tech stack
+
+- [SvelteKit](https://kit.svelte.dev) — UI framework
+- [Yjs](https://yjs.dev) — CRDT engine (Y.Doc, Y.Array, Y.Map, Y.Text)
+- [CodeMirror 6](https://codemirror.net) — editor, with `y-codemirror.next` for Yjs binding
+- [just-bash](https://github.com/nicolo-ribaudo/just-bash) — bash interpreter in TypeScript
+- [Better Auth](https://better-auth.com) — authentication
+- [Tailwind CSS](https://tailwindcss.com) — styling
+- [Cloudflare Workers + Durable Objects](https://developers.cloudflare.com/durable-objects/) — sync server
+- `@epicenter/workspace` — CRDT-backed tables, versioning, E2E encryption
+- `@epicenter/filesystem` — POSIX filesystem layer over Yjs
+
+---
+
+## License
+
+[MIT](./LICENSE)

--- a/docs/articles/release-strategy.md
+++ b/docs/articles/release-strategy.md
@@ -1,0 +1,91 @@
+# How We Version and Release Epicenter Packages
+
+Seven npm packages, ten apps, three deployment targets. The question isn't whether you need a release strategy—it's which one you can actually live with.
+
+## The problem with a monorepo at this scale
+
+Epicenter has 13 packages and 11 apps. Seven packages publish to npm. Apps deploy to Cloudflare Workers, the Chrome Web Store, and GitHub Releases via Tauri. Each target has different audiences, different cadences, and different failure modes.
+
+The naive approach—version everything independently—sounds flexible until you're debugging a user's issue and asking "which version of `@epicenter/workspace` are you on, and does it match your `@epicenter/sync`?" Independent versioning creates a compatibility matrix. We didn't want to maintain one.
+
+## One version number for all public packages
+
+All seven public packages share a single version, enforced in `.changeset/config.json`:
+
+```json
+{
+  "fixed": [
+    [
+      "@epicenter/workspace",
+      "@epicenter/cli",
+      "@epicenter/sync",
+      "@epicenter/filesystem",
+      "@epicenter/skills",
+      "@epicenter/ui",
+      "@epicenter/svelte"
+    ]
+  ]
+}
+```
+
+The `fixed` group means changesets treats them as one unit. When any package gets a bump, all seven bump together. Users install matching versions. No compatibility matrix.
+
+The honest trade-off: sometimes a package gets a version bump with no actual changes. If you fix a bug in `@epicenter/workspace`, `@epicenter/ui` gets a new version number even if nothing in it changed. We accept this. The alternative—tracking which packages changed and which didn't—costs more than the empty bumps.
+
+## Three separate release systems
+
+npm packages, GitHub Releases, and app deploys are handled by three different systems. They don't conflict because they serve different audiences.
+
+**Changesets** handles npm. It's explicit and developer-controlled: you run `bunx changeset` during development, commit the changeset file with your code, and publish when you're ready. Nothing happens automatically.
+
+**Auto-release** (`auto.release.yml`) handles GitHub Releases. It fires on every merged PR, reads `## Changelog` sections from PR descriptions, and creates a versioned GitHub Release with categorized entries. It's currently disabled (`if: false`) until the v8.0.0 tag is in place and the `GH_ACTIONS_PAT` secret is configured. When re-enabled, it runs on every merge to `main`.
+
+**App deploys** are separate from both. Cloudflare Workers (the API, landing page, Whispering web) deploy on every push to `main` via `deploy.cloudflare.yml`. Tauri desktop builds trigger on `v*` tags via `release.whispering.yml`—a 4-platform matrix (macOS ARM, macOS Intel, Ubuntu, Windows) that takes 20+ minutes and produces signed, notarized binaries.
+
+The version number in a GitHub Release and the version number on npm are related but not the same thing. GitHub Releases track the overall project; npm versions track the library API.
+
+## The npm release flow
+
+From "I changed `packages/workspace/src/...`" to "it's on npm":
+
+```bash
+# 1. During development, after making changes:
+bunx changeset
+# Interactive prompt: which packages changed? what kind of bump (major/minor/patch)?
+# Creates .changeset/funny-name.md with your intent
+```
+
+Commit the changeset file alongside your code. It's a plain markdown file describing what changed and why—it becomes the CHANGELOG entry.
+
+```bash
+# 2. When ready to cut a release:
+bunx changeset version
+# Reads all pending .changeset/*.md files
+# Bumps all packages in the fixed group to the same new version
+# Updates CHANGELOG.md in each package
+# Deletes the consumed changeset files
+```
+
+Review the version bump and CHANGELOG entries. Then publish:
+
+```bash
+# 3. Publish to npm and create git tags:
+bunx changeset publish
+git push --tags
+```
+
+`changeset publish` builds each package and runs `npm publish`. The `git push --tags` pushes the version tags created during publish, which triggers the Tauri release workflow if the tag matches `v*`.
+
+## What stays private
+
+Three packages never publish to npm: `@epicenter/ai`, `@epicenter/constants`, and `@epicenter/vault`. They're internal implementation details—AI provider wrappers, shared constants, and the encryption vault. `"private": true` in their `package.json` is all it takes; changesets ignores them automatically.
+
+The public/private split is intentional. `@epicenter/workspace` is the library other developers build on. The private packages are the internals that make Epicenter's own apps work. Keeping them private means we can change them without worrying about semver contracts.
+
+## What we considered and rejected
+
+Independent versioning was the first thing we looked at. It's the default for most monorepos. We rejected it because the packages are tightly coupled—`@epicenter/sync` depends on `@epicenter/workspace`, `@epicenter/svelte` depends on both. Keeping them in sync manually is exactly the kind of work a tool should do.
+
+Lerna came up. It's the predecessor to changesets and still works, but changesets is the active project with better tooling and a cleaner mental model. No reason to use the older thing.
+
+Publishing on every merge was tempting pre-1.0 when we wanted fast iteration. We decided against it: too noisy for users tracking the package, and it forces every PR to include a changeset even for internal refactors. Manual publish gives us control over when a release is "ready."

--- a/docs/articles/svelte-5-writable-derived-kills-state-referenced-locally.md
+++ b/docs/articles/svelte-5-writable-derived-kills-state-referenced-locally.md
@@ -67,14 +67,22 @@ The frustration is real. If you have a working app and a point release floods yo
 
 The fix isn't to suppress the warning or to panic-replace everything. It's to understand what `$derived` does now and apply it where it fits.
 
-## The one-line migration
+## Find and fix every instance in your codebase
 
-For every `$state(prop)` that captures a destructured prop value:
+If you've been suppressing this warning with `svelte-ignore`, you probably have more than one. Find them all:
+
+```bash
+grep -rn 'svelte-ignore state_referenced_locally' --include='*.svelte' src/
+```
+
+Each result is a candidate. For every `$state(prop)` that captures a destructured prop value:
 
 ```diff
 - // svelte-ignore state_referenced_locally
 - let open = $state(defaultOpen);
 + let open = $derived(defaultOpen);
 ```
+
+Not every `$state` that follows an ignore comment is a prop capture—some initialize from array indexing (`teams[0]`), object spreads, or function calls. Those work the same way with `$derived` as long as the expression is reactive. The one exception is when you need deep reactivity on an object; `$derived` is shallow like `$state.raw`, so reach for `$derived.by(() => { const s = $state(prop); return s; })` in that case.
 
 Keep your destructured `$props()`. Keep your clean templates. Drop the ignore comment.

--- a/docs/articles/svelte-5-writable-derived-kills-state-referenced-locally.md
+++ b/docs/articles/svelte-5-writable-derived-kills-state-referenced-locally.md
@@ -1,0 +1,80 @@
+# Writable $derived Is the Fix for state_referenced_locally
+
+If you've upgraded to Svelte 5.45+ and your terminal is full of `state_referenced_locally` warnings, you're not alone. The warning fires when you capture a prop's value in `$state()`:
+
+```svelte
+let { defaultOpen = true } = $props();
+let open = $state(defaultOpen); // ⚠️ state_referenced_locally
+```
+
+The internet will tell you to add `// svelte-ignore state_referenced_locally`. shadcn-svelte does this. It works. But since Svelte 5.25 there's a better fix that most people don't know about: writable `$derived`.
+
+```svelte
+let { defaultOpen = true } = $props();
+let open = $derived(defaultOpen); // ✅ no warning, tracks prop, accepts writes
+```
+
+One line. No ignore comment. No lifted state. No `$effect` gymnastics.
+
+## Why the warning exists
+
+Rich Harris explained the thinking in [sveltejs/svelte#17289](https://github.com/sveltejs/svelte/issues/17289):
+
+> The reality is that almost all of the time, if you're using a prop's initial value, it's a bug. It may not appear buggy immediately—perhaps the prop doesn't change when you're testing the app, or maybe the users of the component in question are only passing static values to it at the moment—but the bug is there, waiting to bite you.
+
+He's right. `$state(prop)` snapshots the value at mount time. If the parent ever changes that prop—SvelteKit reuses components across navigations, search results refresh, a keyed list re-renders—your component shows stale data and you won't notice until a user reports it.
+
+The warning can't know whether your prop will change. It just knows you captured it in a way that won't react if it does. That's worth a heads-up.
+
+## Why $derived works here
+
+Before Svelte 5.25, `$derived` was read-only. You could derive a value from props but couldn't write to it. That meant uncontrolled components—collapsibles, inputs, dropdowns—needed `$state` for their local overrides.
+
+Since 5.25, `$derived` is writable ([docs](https://svelte.dev/docs/svelte/$derived#Overriding-derived-values)). You can override a derived value locally, and it resets to the source expression when the dependency changes. This gives you both behaviors:
+
+```svelte
+let { defaultOpen = true } = $props();
+let open = $derived(defaultOpen);
+
+// User clicks toggle → open = false → works (overrides the derived)
+// Parent changes defaultOpen → open resets to new value → correct
+```
+
+Compare that to `$state`:
+
+```svelte
+let open = $state(defaultOpen);
+
+// User clicks toggle → open = false → works
+// Parent changes defaultOpen → open stays stale → bug
+```
+
+The writable `$derived` pattern is strictly better for initial-value props. It handles the case you're building for (user overrides) and the case you forgot about (prop changes).
+
+## When to use what
+
+`$derived(prop)` replaces `$state(prop)` when the value comes from a prop and the component should track changes while allowing local overrides. This covers most "default value" patterns: collapsibles with `defaultOpen`, inputs with `defaultValue`, selectors with an initial selection.
+
+`$state` is still right when the value doesn't come from a prop at all—purely internal component state like `let inputEl = $state<HTMLElement | null>(null)` or a counter that starts at zero regardless of props.
+
+`$derived.by(() => { ... })` with `$state` inside is for deep reactivity on objects, when you need the proxy behavior that `$derived` alone doesn't provide. This is the `$derived($state())` pattern [being discussed](https://github.com/sveltejs/svelte/pull/17308) for a cleaner syntax.
+
+## The community reaction
+
+The `state_referenced_locally` warning landed in 5.45.3 and hit a nerve. People called it ["obnoxious"](https://github.com/sveltejs/svelte/issues/17289), reported hundreds of warnings on previously clean codebases, and one developer [lost leads](https://github.com/sveltejs/svelte/issues/17289) after rashly swapping `$state` for `$derived` without understanding the deep reactivity difference.
+
+The frustration is real. If you have a working app and a point release floods your terminal with warnings, that's jarring. But the warning caught real bugs in multiple codebases—Rich Harris mentioned an inherited project "infested" with stale-prop bugs that this warning would have prevented.
+
+The fix isn't to suppress the warning or to panic-replace everything. It's to understand what `$derived` does now and apply it where it fits.
+
+## The one-line migration
+
+For every `$state(prop)` that captures a destructured prop value:
+
+```diff
+- // svelte-ignore state_referenced_locally
+- let open = $state(defaultOpen);
++ let open = $derived(defaultOpen);
+```
+
+Keep your destructured `$props()`. Keep your clean templates. Drop the ignore comment.

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -1,0 +1,127 @@
+# Positioning
+
+Canonical messaging for Epicenter. Every public surface—README, landing page, package descriptions, social posts—should derive from this document.
+
+## One-Liner
+
+**Local-first apps, one shared workspace.** Your notes, transcripts, and chat histories live in one folder of plain text and SQLite. Every app reads and writes to the same place.
+
+For developers: a CRDT-powered workspace engine that materializes to SQLite and markdown, with typed schemas and multi-device sync. Not another note app—the infrastructure that apps share.
+
+*"PKM substrate" is accurate but too niche for a tagline. Use it in developer-facing contexts (blog posts, technical talks) but not in the README or landing page hero.*
+
+## The Hook
+
+Most tools store your data in their own silo. Epicenter stores it in one folder on your machine—plain text and SQLite—and every app reads from the same place. Your transcripts inform your notes. Your notes guide your AI. Nothing gets copy-pasted between apps because there's nothing to copy-paste.
+
+Under the hood, Yjs CRDTs are the single source of truth. They materialize *down* to SQLite (for fast queries) and markdown (for human-readable files). Sync happens over the Yjs protocol. The server is a relay, not an authority—it never sees your content if you encrypt it.
+
+## What Epicenter Is
+
+- An **ecosystem of open-source, local-first apps** that share one workspace
+- A **TypeScript library** (`@epicenter/workspace`) for building CRDT-backed apps with typed schemas
+- A **CLI** (`epicenter`) for inspecting, querying, and automating your workspace from the terminal
+- A **sync server** (AGPL, self-hostable) that relays encrypted CRDT updates between devices
+
+## What Epicenter Is Not
+
+- Not a single app (it's a platform multiple apps share)
+- Not cloud-first (local-first by default, sync is optional)
+- Not a Notion/Obsidian clone (it's the layer beneath apps like those)
+
+## Core Claims (Verifiable)
+
+Every claim we make publicly should be provable by inspecting the repo:
+
+| Claim | Proof |
+|---|---|
+| "Plain text and SQLite" | Markdown materializer writes `.md` files with YAML frontmatter. SQLite persistence stores Yjs updates. |
+| "One folder" | All workspace data lives under a single directory per user. |
+| "CRDT-powered sync" | Yjs `Y.Doc` is source of truth; sync uses the Yjs protocol over WebSocket. |
+| "Encrypted at the CRDT level" | `XChaCha20-Poly1305` via `@noble/ciphers`; HKDF-SHA256 key derivation. Row values encrypted before sync. |
+| "Self-hostable" | Sync server is open source under AGPL. Run it on your infrastructure, control the encryption keys. |
+| "Bring your own model" | AI features use user-provided API keys. No middleman, no proxy required. |
+
+## Competitor Positioning
+
+### vs Obsidian
+> Obsidian is a markdown editor with sync. Epicenter is the offline-first storage substrate where multiple apps share the same CRDT-backed data.
+
+- **Win**: Shared memory across apps, not per-plugin storage. CRDT sync instead of file-level conflict resolution.
+- **Lose**: Obsidian's plugin ecosystem and years of UX polish. We're earlier.
+
+### vs Anytype
+> Anytype is a purpose-built encrypted space ecosystem. Epicenter is the Yjs-backed substrate that lets many apps share the same schema and data.
+
+- **Win**: Standard CRDT stack (Yjs—widely adopted, battle-tested) vs custom protocol. Developer-facing API with typed schemas, not just an end-user app.
+- **Lose**: Anytype's product is more complete today. Their P2P sync story is more mature.
+
+### vs Logseq
+> Logseq is an outliner-first app. Epicenter is the structured local-first storage engine that can power outline UIs without trapping data in a single app.
+
+- **Win**: SQL + structured schemas. Shared memory across tools. Encryption.
+- **Lose**: Logseq's block/journal UX is more native. Larger community.
+
+### vs Standard Notes
+> Standard Notes secures your notes. Epicenter secures a whole local-first workspace that multiple apps share—with CRDTs, schemas, and materialized exports.
+
+- **Win**: Platform, not just "notes." Structured data with schemas. Materialized to files you can inspect.
+- **Lose**: Standard Notes' encryption UX is simpler to communicate. They've earned trust over years.
+
+### vs Notion
+> Notion is where your knowledge lives. Epicenter is where your knowledge stays.
+
+- **Win**: Offline-first, local-first, open source, no cloud lock-in.
+- **Lose**: Notion's UX, templates, collaboration, and distribution are years ahead.
+
+### vs Karpathy's "Second Brain" System
+> Karpathy showed the architecture. Epicenter is the runtime.
+
+- **Win**: CRDT sync across devices, typed schemas, encryption, CLI automation—everything raw folders can't do.
+- **Lose**: Karpathy's system wins on simplicity. A folder of markdown files needs zero infrastructure.
+
+## Headlines and Hooks
+
+### Hacker News
+1. "A local-first PKM substrate—CRDT-powered tables that materialize to SQLite and markdown"
+2. "Stop arguing about apps. Own a portable workspace that multiple tools share"
+3. "CRDTs + plain files: offline-first notes without sync nightmares"
+
+### Twitter/X
+1. "Your notes shouldn't depend on a vendor. Here's the CRDT-based way to keep them in a folder"
+2. "Markdown is the export. The real system is the CRDT state that powers conflict-free sync"
+3. "Notion stores knowledge in the cloud. Epicenter stores it in your folder"
+
+### Karpathy Angle (strongest entry point)
+Karpathy's "second brain" post (41K bookmarks) describes: three folders of .md files + a schema file (CLAUDE.md) + AI organizes everything. Epicenter is the infrastructure version of that system—same philosophy (local files, AI organizes, no cloud lock-in), but with real sync, real schemas, real encryption, and a CLI that makes "compile the wiki" a single command.
+
+## Keywords
+
+### Use These
+`local-first`, `CRDT`, `Yjs`, `offline-first`, `own your data`, `conflict-free sync`, `personal knowledge base`, `PKM`, `second brain`, `plain text`, `SQLite`, `markdown`, `self-hosted`, `open source`, `end-to-end encryption`, `multi-device sync`, `materialize`, `workspace`
+
+### Avoid These
+`AI-native`, `agentic`, `next-gen`, `revolutionary`, `redefine`, `game changer`, `Web3`, `metaverse`, buzzword-stacking ("CRDT-powered AI-first encrypted next-gen offline-first workspace"—say less, prove more)
+
+## Package Descriptions
+
+Canonical descriptions for npm/GitHub discoverability:
+
+| Package | Description |
+|---|---|
+| `@epicenter/workspace` | Local-first workspace engine. CRDT-powered tables that materialize to SQLite and markdown, with typed schemas and multi-device sync. |
+| `@epicenter/cli` | CLI for Epicenter workspaces. Inspect tables, query data, run actions, and manage sync from the terminal. |
+| `@epicenter/sync` | Yjs-based sync protocol for Epicenter. Handles CRDT document exchange, awareness, and RPC over WebSocket. |
+| `@epicenter/vault` | Adapter and MCP layer for Epicenter. Schema migrations, codec pipelines, and data access patterns. |
+| `@epicenter/filesystem` | Filesystem operations for Epicenter workspaces. Read, write, and watch plain text and markdown files. |
+| `@epicenter/skills` | Skill definitions and loaders for Epicenter workspace actions. |
+| `@epicenter/ui` | Shared UI components for Epicenter apps. Built with Svelte 5 and shadcn-svelte. |
+
+## Keywords per Package
+
+| Package | Keywords |
+|---|---|
+| `@epicenter/workspace` | `local-first`, `CRDT`, `Yjs`, `offline-first`, `SQLite`, `markdown`, `personal knowledge base`, `PKM`, `second brain`, `sync`, `workspace`, `typed schema` |
+| `@epicenter/cli` | `local-first`, `CLI`, `workspace`, `CRDT`, `offline-first`, `PKM`, `terminal` |
+| `@epicenter/sync` | `Yjs`, `CRDT`, `sync`, `WebSocket`, `offline-first`, `local-first`, `real-time` |
+| `@epicenter/vault` | `local-first`, `schema`, `migrations`, `MCP`, `adapter`, `CRDT`, `markdown` |

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -2,7 +2,9 @@
 
 The hard problem with local-first apps is synchronization. If each device has its own SQLite file, how do you keep them in sync? If each device has its own markdown folder, same question.
 
-This package uses Yjs CRDTs as the single source of truth, then materializes that data *down* to SQLite (for fast SQL reads) and markdown (for human-readable files). Yjs handles the sync; SQLite and markdown handle the reads. Define a schema, get CRDT-backed tables, attach providers for the read formats you want, and add multi-device sync when you're ready.
+`@epicenter/workspace` solves that by making Yjs the source of truth. Tables, KV entries, document content, and awareness all live in a `Y.Doc`; persistence, sync, and materializers hang off that core through the extension builder. Write to the workspace, and everything else reacts.
+
+If you're coming from the old README, the API really did change. Older docs showed a different client/bootstrap surface than the one this package exports today. The public path now is `defineWorkspace(...)` or `createWorkspace(...)`, direct property access like `client.tables.posts`, `table.set(...)`, and extension subpaths such as `@epicenter/workspace/extensions/persistence/indexeddb`.
 
 ## Quick Start
 
@@ -11,104 +13,155 @@ bun add @epicenter/workspace
 ```
 
 ```typescript
+import { type } from 'arktype';
+import Type from 'typebox';
 import {
+	createWorkspace,
+	defineMutation,
+	defineQuery,
+	defineTable,
 	defineWorkspace,
-	createClient,
-	id,
-	text,
-	integer,
-	boolean,
-	date,
-	select,
-	sqliteProvider,
-	markdownProvider,
+	generateId,
 } from '@epicenter/workspace';
-import { setupPersistence } from '@epicenter/workspace/providers';
+import { indexeddbPersistence } from '@epicenter/workspace/extensions/persistence/indexeddb';
+import { createSyncExtension } from '@epicenter/workspace/extensions/sync/websocket';
 
-// 1. Define your workspace
-const blogWorkspace = defineWorkspace({
-	id: 'blog',
+const posts = defineTable(
+	type({
+		id: 'string',
+		title: 'string',
+		body: 'string',
+		published: 'boolean',
+		_v: '1',
+	}),
+);
 
-	tables: {
+const blogDefinition = defineWorkspace({
+	id: 'epicenter.blog',
+	tables: { posts },
+});
+
+export const blogWorkspace = createWorkspace(blogDefinition)
+	.withExtension('persistence', indexeddbPersistence)
+	.withExtension(
+		'sync',
+		createSyncExtension({
+			url: (docId) => `ws://localhost:3913/rooms/${docId}`,
+		}),
+	)
+	.withActions(({ tables }) => ({
 		posts: {
-			id: id(),
-			title: text(),
-			content: text({ nullable: true }),
-			category: select({ options: ['tech', 'personal'] }),
-			published: boolean({ default: false }),
-			views: integer({ default: 0 }),
-			publishedAt: date({ nullable: true }),
+			list: defineQuery({
+				title: 'List Posts',
+				description: 'List all posts in the workspace.',
+				handler: () => tables.posts.getAllValid(),
+			}),
+
+			create: defineMutation({
+				title: 'Create Post',
+				description: 'Create a new post row.',
+				input: Type.Object({
+					title: Type.String(),
+					body: Type.String(),
+				}),
+				handler: ({ title, body }) => {
+					const id = generateId();
+					tables.posts.set({
+						id,
+						title,
+						body,
+						published: false,
+						_v: 1,
+					});
+
+					return { id };
+				},
+			}),
 		},
-	},
+	}));
 
-	kv: {},
-});
+async function quickStart() {
+	await blogWorkspace.whenReady;
 
-// 2. Initialize the workspace client
-const client = createClient(blogWorkspace.id)
-	.withDefinition(blogWorkspace)
-	.withExtension('persistence', setupPersistence)
-	.withExtension('sqlite', (c) => sqliteProvider(c))
-	.withExtension('markdown', (c) => markdownProvider(c));
+	blogWorkspace.tables.posts.set({
+		id: 'welcome',
+		title: 'Hello World',
+		body: 'This row lives in the Y.Doc.',
+		published: false,
+		_v: 1,
+	});
 
-// 3. Write data — SQLite and markdown update automatically
-client.tables.get('posts').upsert({
-	id: generateId(),
-	title: 'Hello World',
-	content: null,
-	category: 'tech',
-	published: false,
-	views: 0,
-	publishedAt: null,
-});
+	const result = blogWorkspace.tables.posts.get('welcome');
+	if (result.status === 'valid') {
+		blogWorkspace.tables.posts.update(result.row.id, { published: true });
+	}
 
-// 4. Read via table operations or SQL
-const allPosts = client.tables.get('posts').getAll();
-const { posts } = client.extensions.sqlite;
-const published = await posts.select().where(eq(posts.published, true));
+	const unsubscribe = blogWorkspace.tables.posts.observe((changedIds) => {
+		for (const id of changedIds) {
+			console.log('changed:', id);
+		}
+	});
 
-// 5. Cleanup when done
-await client.destroy();
+	const allPosts = blogWorkspace.tables.posts.getAllValid();
+	console.log(allPosts.length);
+
+	blogWorkspace.tables.posts.delete('welcome');
+	unsubscribe();
+
+	const created = await blogWorkspace.actions.posts.create({
+		title: 'Created through an action',
+		body: 'Actions close over the client via closure.',
+	});
+	console.log(created.id);
+}
+
+void quickStart;
 ```
+
+That example uses the current public API end to end:
+
+- `defineTable(...)` with a real schema
+- `defineWorkspace(...)` for a reusable definition
+- `createWorkspace(...)` for the client
+- `.withExtension(...)` for persistence and sync
+- direct property access via `client.tables.posts`
+- `set`, `get`, `update`, `delete`, `getAllValid`, and `observe`
+- `.withActions(...)` plus `defineQuery(...)` and `defineMutation(...)`
 
 ## Core Philosophy
 
-**YJS Document as Source of Truth**
+### Yjs is the source of truth
 
-Epicenter uses YJS documents as the single source of truth for all data. YJS provides:
+Epicenter keeps the write path brutally simple: the `Y.Doc` is authoritative. Tables and KV are just typed helpers over Yjs collections, and document content is a Yjs timeline. Sync providers, SQLite mirrors, and markdown files are all derived from that core.
 
-- CRDT-based conflict-free merging
-- Real-time collaborative editing
-- Built-in undo/redo
-- Efficient binary encoding
+That matters because conflict resolution only has to happen once. Yjs handles merge semantics; extensions react to the merged state.
 
-**Unified Providers for Querying and Persistence**
+### Definitions are pure; clients are live
 
-Providers are a unified map of capabilities that can mirror YJS data:
+`defineTable`, `defineKv`, and `defineWorkspace` are pure. They do not create a `Y.Doc`, open a socket, or touch IndexedDB. `createWorkspace` is the boundary where the live client appears.
 
-- **SQLite Provider**: Enables SQL queries via Drizzle ORM
-- **Markdown Provider**: Persists data as human-readable markdown files
-- **Custom Providers**: Build your own (vector search, full-text search, etc.)
+That split is not cosmetic. It lets you share definitions across modules, infer types once, and instantiate different clients in different runtimes without rewriting the schema layer.
 
-Providers auto-sync bidirectionally with YJS. They're completely optional—you can use just YJS, just SQLite, both, or build custom providers.
+### The builder is the extension system
 
-**Pure JSON Column Schemas**
+The old provider map is gone. The current model is a builder:
 
-Column definitions are plain JSON objects, not builder functions. This enables:
+- `.withExtension(...)` registers an extension for the workspace doc and all document docs
+- `.withWorkspaceExtension(...)` registers a workspace-only extension
+- `.withDocumentExtension(...)` registers a document-only extension
+- `.withActions(...)` attaches callable action functions to the live client
 
-- Serialization for MCP/OpenAPI
-- Runtime introspection
-- Type-safe conversions to validation schemas
+Extensions compose progressively. Each later extension sees the exports from earlier extensions through typed `client.extensions` access.
 
-**Client-Side Only — No SSR**
+### Read-time validation beats write-time ceremony
 
-Workspaces always initialize in the browser, never on the server. This is by design, not a limitation. While Y.Doc itself is pure JS, everything plugged into it is browser-only: IndexedDB persistence, WebSocket sync, encryption key caches, and Svelte's `createSubscriber` bridge. More fundamentally, there's nothing useful to server-render — the data lives on the device, encrypted, per-user. The server is a sync relay, not a content authority. A server-rendered workspace would be empty, then immediately replaced by the client's local state, producing a flash of wrong content worse than a loading spinner.
+Tables validate and migrate on read, not on write. `set(...)` writes the row shape TypeScript already approved. `get(...)` is where invalid old data shows up as `{ status: 'invalid' }` and old versions are migrated to the latest schema.
 
-If you're using SvelteKit, disable SSR for workspace pages (`export const ssr = false` in `+layout.ts`) or initialize the workspace in a `.svelte.ts` module that only runs client-side. This matches the local-first model: the device owns the data, the server just helps it travel.
+That trade-off is deliberate. It keeps the write path cheap and pushes schema evolution into one place—the table definition.
 
-**Storage Scales With Data, Not History**
+### Storage scales with active data, not edit history
 
-With Yjs garbage collection enabled (the default), storage is proportional to your active data—not your operation count. Deleted rows, overwritten values, and edit history are garbage collected into compact metadata. A workspace with 20 active rows stays at roughly the same size whether it was created yesterday or has been edited daily for ten years. The only additional overhead comes from unique device count (~22 bytes per device that has ever synced). See [CRDT Storage Scales With Data, Not History](../../docs/articles/yjs-storage-efficiency/storage-scales-with-data-not-history.md) for the full proof with 16 test scenarios.
+With Yjs garbage collection enabled, storage tracks the live document much more closely than the number of operations that happened over time. Deleted rows, overwritten values, and old content states collapse down to compact metadata. The workspace grows because you keep more data—not because you clicked save a thousand times.
 
 ## Architecture Overview
 
@@ -131,8 +184,8 @@ Every piece of data lives in a `Y.Doc`, which provides conflict-free merging, re
 │  └───────────────────────────────────────────────────────┘  │
 └─────────────────────────────────────────────────────────────┘
 
-Note: Schema definitions are stored in static JSON files, NOT in Y.Doc.
-This keeps Y.Docs lean and focused on data only.
+Note: Schema definitions are stored in static TypeScript modules, not in the Y.Doc.
+The Y.Doc carries data. Your definition files carry meaning.
 ```
 
 ### Three-Layer Data Flow
@@ -141,19 +194,20 @@ This keeps Y.Docs lean and focused on data only.
 ┌────────────────────────────────────────────────────────────────────┐
 │  WRITE FLOW                                                         │
 │                                                                     │
-│  Action Called → Y.Doc Updated → Auto-sync to Providers             │
+│  App code / action → Y.Doc updated → Extensions react              │
 │                       │                                             │
 │              ┌────────┼────────┐                                    │
 │              ▼        ▼        ▼                                    │
-│         IndexedDB  SQLite   Markdown                                │
-│         (or .yjs)   (.db)   (files)                                 │
+│         IndexedDB  WebSocket  Markdown                              │
+│         or SQLite   sync      materializer                          │
 └────────────────────────────────────────────────────────────────────┘
 
 ┌────────────────────────────────────────────────────────────────────┐
 │  READ FLOW                                                          │
 │                                                                     │
-│  Query Called → Read from Provider (SQLite for complex queries)     │
-│                 or directly from Y.Doc (simple lookups)             │
+│  Simple reads → table / kv helpers over Y.Doc                       │
+│  Rich text  → document handles over timeline Y.Docs                 │
+│  Derived reads → extension exports built on the same core           │
 └────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -177,1619 +231,1404 @@ Epicenter supports distributed sync where Y.Doc instances replicate across devic
                            Connect to multiple nodes
 ```
 
-Yjs supports multiple providers simultaneously. Phone can connect to desktop, laptop, AND cloud—changes merge automatically via CRDTs.
+Yjs supports multiple providers simultaneously. A phone can connect to desktop, laptop, and cloud at the same time; CRDT merge semantics do the rest.
 
 ### How It All Fits Together
 
-1. **Define workspace** with `defineWorkspace({ id, tables, kv })`
-2. **Create workspace** with `createWorkspace(workspace)`
-3. **Attach extensions** with `.withExtension('persistence', setupPersistence).withExtension('sqlite', sqliteProvider)`
-4. **Y.Doc created** with workspace ID + epoch as GUID
-5. **Extensions initialize** in parallel (persistence, SQLite, markdown, sync)
-6. **Tables API** wraps Y.Doc with type-safe CRUD
-7. **Server** exposes REST/MCP/WebSocket endpoints for actions and tables
-8. **Multi-device sync** via y-websocket to any number of nodes
-9. **CRDTs ensure** eventual consistency across all clients
+1. Define tables, KV entries, and awareness with `defineTable`, `defineKv`, and `defineWorkspace`.
+2. Create a live client with `createWorkspace(definition)`.
+3. Chain extensions with `.withExtension(...)`, `.withWorkspaceExtension(...)`, and `.withDocumentExtension(...)`.
+4. Attach actions with `.withActions(...)`.
+5. Wait for `client.whenReady` if your extensions load persisted state or open connections.
+6. Read and write through `client.tables`, `client.kv`, `client.documents`, and `client.awareness`.
+7. Use `iterateActions(...)`, `describeWorkspace(...)`, and action metadata if you want to build adapters such as HTTP, CLI, or MCP.
+8. Dispose the client with `await client.dispose()` when you're done.
 
-The architecture is **local-first**: everything works offline, syncs opportunistically, and your data lives in plain files (`.yjs`, SQLite, markdown) that you fully control.
+The architecture stays local-first: the workspace works offline, synchronizes opportunistically, and treats external systems as helpers around the document—not the other way around.
 
 ## Shared Workspace ID Convention
 
 Epicenter uses stable, shared workspace IDs so multiple apps can collaborate on the same data.
 
-- **Format**: `epicenter.<app>` (for example, `epicenter.whispering`)
-- **Purpose**: Ensures the same workspace is discovered, synced, and shared across Epicenter apps
-- **Stability**: IDs must be globally unique and never change once published
-- **Usage**: The workspace ID is used for routing, persistence paths, Y.Doc IDs, and sharing
+- Format: `epicenter.<app>`
+- Purpose: stable routing, persistence keys, sync room names, and workspace discovery
+- Stability: once published, an ID should not change
+- Scope: two apps with the same ID are intentionally pointing at the same workspace
 
-When two apps declare the same workspace ID, they intentionally point to the same shared workspace and data.
+The ID becomes `ydoc.guid` for the workspace doc, so it is not a throwaway string. Pick one and keep it.
 
 ## Core Concepts
 
 ### Workspaces
 
-A workspace is a self-contained module with:
+A workspace definition is plain data:
 
-- **Tables**: Table definitions with column types
-- **KV Store**: Simple key-value store for settings and metadata
-- **Extensions**: Capabilities including persistence, sync, and materializers (SQLite, markdown, custom)
+- `id`
+- `tables`
+- `kv`
+- `awareness`
 
-Workspaces can be defined once and used to create multiple clients at different epochs.
+A workspace client is that definition plus a live `Y.Doc`, typed helpers, optional documents, optional extensions, and optional actions.
 
-### YJS Document
+### Yjs document
 
-Every workspace has a YJS document that stores all table data. The YJS document:
-
-- Is the source of truth for all data
-- Supports real-time collaboration
-- Provides CRDT-based conflict resolution
-- Enables undo/redo
-- Can be persisted to disk or IndexedDB
+The raw `Y.Doc` is still available at `client.ydoc`. That is the escape hatch, not the primary API. Most consumers should stay at the workspace layer unless they are building a new extension or debugging storage internals.
 
 ### Tables
 
-Tables are defined as column schemas (pure JSON):
+Tables are versioned row collections. Each row must include:
 
-```typescript
-tables: {
-  posts: {
-    id: id(),                           // Auto-generated ID (always required)
-    title: text(),                      // NOT NULL by default
-    content: text({ nullable: true }), // Explicitly nullable
-    views: integer({ default: 0 }),    // NOT NULL with default
-  }
-}
-```
+- `id: string`
+- `_v: number`
 
-At runtime, tables become YJS-backed collections with CRUD operations:
+At runtime, each table becomes a `TableHelper` exposed as a direct property:
 
-```typescript
-tables.get('posts').upsert({ id: '1', title: 'Hello', ... })
-tables.get('posts').get({ id: '1' })
-tables.get('posts').update({ id: '1', views: 100 })
-tables.get('posts').delete({ id: '1' })
-```
+- `client.tables.posts.set(row)`
+- `client.tables.posts.get(id)`
+- `client.tables.posts.update(id, partial)`
+- `client.tables.posts.delete(id)`
+
+Table access is direct property access in the current API.
+
+### KV
+
+KV entries are for settings and scalar preferences. They are keyed by string and always return a valid value because invalid or missing data falls back to the definition's default.
+
+- `client.kv.get('theme.mode')`
+- `client.kv.set('theme.mode', 'dark')`
+- `client.kv.observe('theme.mode', ...)`
 
 ### Extensions
 
-Extensions add capabilities to your workspace, such as persistence, sync, and materializers (SQLite, markdown). They are attached to the client during initialization:
+Extensions are opt-in capabilities layered onto the workspace builder.
 
-```typescript
-const client = createWorkspace(definition)
-	.withExtension('persistence', setupPersistence) // YJS persistence
-	.withExtension('sqlite', (c) => sqliteProvider(c)) // SQL queries via Drizzle ORM
-	.withExtension('markdown', (c) => markdownProvider(c)); // File-based persistence
-```
-
-Materializer extensions (sqlite, markdown) automatically sync with YJS:
-
-- **Write to YJS** → Extensions auto-update
-- **Pull from extension** → Replaces YJS data
-- **Push to extension** → Replaces extension data
-
-Access extension exports in your actions:
-
-```typescript
-const queryPosts = defineQuery({
-  handler: async () => {
-    // Access SQLite extension via client.extensions
-    const { sqlite } = client.extensions;
-    return await sqlite.posts.select().where(...);
-  }
-});
-```
-
-Extension factory functions receive a context object with `{ id, ydoc, tables, kv, extensions }` (the "client-so-far") and can return exports. Each factory receives typed access to all previously added extensions. For example, sync extensions:
-
-```typescript
-const client = createWorkspace(definition)
-	.withExtension('persistence', setupPersistence)
-	.withExtension('sqlite', (c) => sqliteProvider(c))
-	.withExtension(
-		'sync',
-		createSyncExtension({
-			url: 'ws://localhost:3913/rooms/{id}',
-		}),
-	);
-```
+- Use `.withExtension(...)` when the same factory should apply to the workspace doc and every document doc.
+- Use `.withWorkspaceExtension(...)` when the factory needs `tables`, `kv`, `definitions`, or other workspace-only fields.
+- Use `.withDocumentExtension(...)` when the factory needs `timeline`, `tableName`, or `documentName`.
 
 ### Actions
 
-Actions are workspace operations defined with `defineQuery` (read) or `defineMutation` (write). They are lightweight objects that can be exposed via REST, MCP, or CLI:
+Actions are callable functions with metadata.
 
-```typescript
-const blogActions = {
-  getPost: defineQuery({
-    input: type({ id: 'string' }),
-    handler: ({ id }) => {
-      return client.tables.get('posts').get({ id });
-    }
-  }),
+- `defineQuery(...)` creates a read action
+- `defineMutation(...)` creates a write action
+- `.withActions(...)` attaches them to `client.actions`
 
-  createPost: defineMutation({
-    input: type({ title: 'string' }),
-    handler: ({ title }) => {
-      const id = generateId();
-      client.tables.get('posts').upsert({ id, title, ... });
-      return { id };
-    }
-  })
-};
-```
+Handlers close over the client through normal JavaScript closure. They do not receive a framework context object.
 
-Actions can be exposed via MCP servers or HTTP APIs by passing them to `createServer()`.
+### Documents
+
+Tables can declare document-backed content via `.withDocument(...)`. That creates typed document managers under `client.documents`.
+
+If you define a `files` table with `.withDocument('content', ...)`, you get this shape at runtime:
+
+- `client.documents.files.content.open(rowOrGuid)`
+- `client.documents.files.content.close(rowOrGuid)`
+- `client.documents.files.content.closeAll()`
+
+An open handle is a timeline API with methods such as `read()`, `write(...)`, `asText()`, `asRichText()`, and `asSheet()`.
 
 ## Column Types
 
-All columns support `nullable` (default: `false`) and `default` options.
+The old column builder API is gone. There is no `id()`, `text()`, `boolean()`, `date()`, `select()`, `tags()`, or `json()` in the current package surface.
 
-### `id()`
+Today, tables and KV entries are defined with schemas directly.
 
-Auto-generated primary key. Always required, always NOT NULL.
+### Required table fields
 
-```typescript
-id: id();
-```
+Every table row schema must include:
 
-### `text(options?)`
+- `id`
+- `_v`
 
-Text column.
+In arktype, `_v: '1'` means the numeric literal `1`, not the string `'1'` at runtime.
 
-```typescript
-name: text(); // NOT NULL
-bio: text({ nullable: true }); // Nullable
-role: text({ default: 'user' }); // NOT NULL with default
-```
-
-### `ytext(options?)`
-
-Collaborative text editor column using Y.Text. Supports inline formatting and is ideal for code editors (Monaco, CodeMirror) or simple rich text (Quill).
+### Single-version tables
 
 ```typescript
-code: ytext(); // Collaborative code editor
-notes: ytext({ nullable: true }); // Optional collaborative text
-```
-
-### `integer(options?)`, `real(options?)`
-
-Numeric columns.
-
-```typescript
-age: integer();
-price: real({ default: 0.0 });
-score: integer({ nullable: true });
-```
-
-### `boolean(options?)`
-
-Boolean column.
-
-```typescript
-published: boolean({ default: false });
-verified: boolean({ nullable: true });
-```
-
-### `date(options?)`
-
-Date with timezone support using `DateTimeString` (branded string with lazy Temporal parsing).
-
-```typescript
-createdAt: date();
-publishedAt: date({ nullable: true });
-```
-
-Working with dates:
-
-```typescript
-import { DateTimeString } from '@epicenter/workspace';
-
-// Create current timestamp
-const now = DateTimeString.now(); // Uses system timezone
-const nowNY = DateTimeString.now('America/New_York');
-
-// Storage format: "2024-01-01T20:00:00.000Z|America/New_York"
-
-// Parse to Temporal.ZonedDateTime when you need date math
-const live = DateTimeString.parse(now);
-const nextMonth = live.add({ months: 1 });
-
-// Stringify back for storage
-const stored = DateTimeString.stringify(nextMonth);
-```
-
-### `select(options)`
-
-Single choice from predefined options.
-
-```typescript
-status: select({
-	options: ['draft', 'published', 'archived'],
-});
-
-priority: select({
-	options: ['low', 'medium', 'high'],
-	default: 'medium',
-});
-
-visibility: select({
-	options: ['public', 'private'],
-	nullable: true,
-});
-```
-
-### `tags(options?)`
-
-Array of strings with optional validation.
-
-```typescript
-// Unconstrained (any string array)
-tags: tags();
-freeTags: tags({ nullable: true });
-
-// Constrained (validated against options)
-categories: tags({
-	options: ['tech', 'personal', 'work'],
-});
-```
-
-### `json(options)`
-
-JSON column with arktype schema validation.
-
-**Important**: When used in action inputs, schemas are converted to JSON Schema for MCP/OpenAPI. Avoid:
-
-- Transforms: `.pipe()` (arktype), `.transform()` (Zod)
-- Custom validation: `.filter()` (arktype), `.refine()` (Zod)
-- Use `.matching(regex)` for patterns
-
-```typescript
-import { json } from '@epicenter/workspace';
 import { type } from 'arktype';
+import { defineTable } from '@epicenter/workspace';
 
-metadata: json({
-	schema: type({
-		key: 'string',
-		value: 'string',
+const users = defineTable(
+	type({
+		id: 'string',
+		email: 'string',
+		name: 'string',
+		_v: '1',
 	}),
+);
+
+void users;
+```
+
+Use the single-schema form when the table has only one version today.
+
+### Versioned tables
+
+```typescript
+import { type } from 'arktype';
+import { defineTable } from '@epicenter/workspace';
+
+const posts = defineTable(
+	type({
+		id: 'string',
+		title: 'string',
+		_v: '1',
+	}),
+	type({
+		id: 'string',
+		title: 'string',
+		slug: 'string',
+		_v: '2',
+	}),
+).migrate((row) => {
+		switch (row._v) {
+			case 1:
+				return {
+					...row,
+					slug: row.title.toLowerCase().replaceAll(' ', '-'),
+					_v: 2,
+				};
+
+			case 2:
+				return row;
+		}
+	});
+
+void posts;
+```
+
+Migration runs on read. Old rows stay old in storage until you rewrite them.
+
+### KV entries
+
+```typescript
+import { type } from 'arktype';
+import { defineKv } from '@epicenter/workspace';
+
+const themeMode = defineKv(type("'light' | 'dark' | 'system'"), 'light');
+const sidebarWidth = defineKv(type('number'), 280);
+const sidebarCollapsed = defineKv(type('boolean'), false);
+
+void themeMode;
+void sidebarWidth;
+void sidebarCollapsed;
+```
+
+KV is validate-or-default. There is no migration function.
+
+### Awareness definitions
+
+```typescript
+import { type } from 'arktype';
+import { createWorkspace, defineTable, defineWorkspace } from '@epicenter/workspace';
+
+const notes = defineTable(
+	type({
+		id: 'string',
+		title: 'string',
+		_v: '1',
+	}),
+);
+
+const definition = defineWorkspace({
+	id: 'epicenter.notes',
+	tables: { notes },
+	awareness: {
+		name: type('string'),
+		color: type('string'),
+		cursor: type({ line: 'number', column: 'number' }),
+	},
 });
 
-preferences: json({
-	schema: type({
-		theme: 'string',
-		notifications: 'boolean',
+const workspace = createWorkspace(definition);
+
+workspace.awareness.setLocal({ name: 'Braden', color: '#ff4d4f' });
+workspace.awareness.setLocalField('cursor', { line: 12, column: 3 });
+
+void workspace;
+```
+
+### Document-backed tables
+
+```typescript
+import { type } from 'arktype';
+import { createWorkspace, defineTable, defineWorkspace } from '@epicenter/workspace';
+
+const files = defineTable(
+	type({
+		id: 'string',
+		name: 'string',
+		contentGuid: 'string',
+		updatedAt: 'number',
+		_v: '1',
 	}),
-	nullable: true,
-	default: { theme: 'dark', notifications: true },
+).withDocument('content', {
+	guid: 'contentGuid',
+	onUpdate: () => ({ updatedAt: Date.now() }),
 });
+
+const definition = defineWorkspace({
+	id: 'epicenter.files',
+	tables: { files },
+});
+
+const workspace = createWorkspace(definition);
+
+async function documentExample() {
+	workspace.tables.files.set({
+		id: 'file-1',
+		name: 'hello.md',
+		contentGuid: 'doc-1',
+		updatedAt: 0,
+		_v: 1,
+	});
+
+	const handle = await workspace.documents.files.content.open('doc-1');
+	handle.write('# Hello from a document');
+	console.log(handle.read());
+	console.log(handle.currentType);
+	await workspace.documents.files.content.close('doc-1');
+	await workspace.dispose();
+	return handle;
+}
+
+void documentExample;
 ```
 
 ## Table Operations
 
-All table operations are accessed via `tables.get('{tableName}')`.
+All table operations live on direct properties such as `client.tables.posts`.
 
-### Upsert Operations
+### Write operations
 
-**`upsert(row)`**
-
-Insert or update a row. Never fails. This is the primary way to write data.
-
-For Y.js columns (ytext, tags), provide plain values:
-
-- ytext: provide strings
-- tags: provide arrays
-
-```typescript
-tables.get('posts').upsert({
-	id: generateId(),
-	title: 'Hello World',
-	content: 'Post content here', // For ytext column, pass string
-	tags: ['tech', 'blog'], // For tags column, pass array
-	published: false,
-});
-```
-
-**`upsertMany(rows)`**
-
-Insert or update multiple rows. Never fails.
-
-### Update Operations
-
-**`update(partialRow)`**
-
-Update specific fields of an existing row. **If the row doesn't exist locally, this is a no-op.**
-
-This is intentional: Y.js uses Last-Writer-Wins at the key level when setting a Y.Map. Creating a new Y.Map for a missing row could overwrite an existing row from another peer, causing data loss.
-
-For Y.js columns, pass plain values and they'll be synced to existing Y.Text/Y.Array.
-
-```typescript
-tables.get('posts').update({
-	id: '1',
-	title: 'New Title',
-	tags: ['updated', 'tags'], // Syncs to existing Y.Array
-});
-```
-
-**`updateMany(partialRows)`**
-
-Update multiple rows. Rows that don't exist locally are skipped (see `update` for rationale).
-
-### Read Operations
-
-**`get({ id })`**
-
-Get a row by ID. Returns a discriminated union with status:
-
-- `{ status: 'valid', row }` - Row exists and passes validation
-- `{ status: 'invalid', id, error }` - Row exists but fails validation
-- `{ status: 'not_found', id }` - Row doesn't exist
-
-Returns Y.js objects for collaborative editing:
-
-- ytext columns: Y.Text instances
-- tags columns: Y.Array instances
-
-```typescript
-const result = tables.get('posts').get({ id: '1' });
-switch (result.status) {
-	case 'valid':
-		console.log('Row:', result.row);
-		const ytext = result.row.content; // Y.Text instance
-		break;
-	case 'invalid':
-		console.error('Validation error:', result.error.context.summary);
-		break;
-	case 'not_found':
-		console.log('Not found:', result.id);
-		break;
-}
-```
-
-**`getAll()`**
-
-Get all rows with their validation status. Returns `RowResult<Row>[]`.
-
-```typescript
-const results = tables.get('posts').getAll();
-for (const result of results) {
-	if (result.status === 'valid') {
-		console.log(result.row.title);
-	} else {
-		console.log('Invalid row:', result.id);
-	}
-}
-```
-
-**`getAllValid()`**
-
-Get all valid rows. Skips invalid rows that fail validation.
-
-```typescript
-const posts = tables.get('posts').getAllValid(); // Row[]
-```
-
-**`getAllInvalid()`**
-
-Get validation errors for all invalid rows.
-
-```typescript
-const errors = tables.get('posts').getAllInvalid(); // RowValidationError[]
-```
-
-**`has({ id })`**
-
-Check if a row exists.
-
-```typescript
-const exists = tables.get('posts').has({ id: '1' }); // boolean
-```
-
-**`count()`**
-
-Get total row count.
-
-```typescript
-const total = tables.get('posts').count(); // number
-```
-
-**`filter(predicate)`**
-
-Filter valid rows by predicate. Invalid rows are skipped.
-
-```typescript
-const published = tables.get('posts').filter((row) => row.published);
-```
-
-**`find(predicate)`**
-
-Find first valid row matching predicate. Returns `Row | null`.
-
-```typescript
-const first = tables.get('posts').find((row) => row.published);
-```
-
-### Delete Operations
-
-**`delete({ id })`**
-
-Delete a row.
-
-```typescript
-tables.get('posts').delete({ id: '1' });
-```
-
-**`deleteMany({ ids })`**
-
-Delete multiple rows.
-
-```typescript
-tables.get('posts').deleteMany({ ids: ['1', '2', '3'] });
-```
-
-**`clear()`**
-
-Delete all rows.
-
-```typescript
-tables.get('posts').clear();
-```
-
-### Reactive Updates
-
-**`observe(callback)`**
-
-Watch for real-time changes. Returns unsubscribe function.
-
-The callback receives a `Map<id, action>` where action is `'add' | 'update' | 'delete'`. To get row data, call `table.get(id)`; the observer intentionally does not include row data to avoid unnecessary reconstruction.
-
-```typescript
-const unsubscribe = tables.posts.observe((changes, transaction) => {
-	for (const [id, action] of changes) {
-		if (action === 'delete') {
-			console.log('Post deleted:', id);
-			removeFromCache(id);
-		} else {
-			// Fetch row data only when needed
-			const result = tables.posts.get(id);
-			if (result.status === 'valid') {
-				console.log(`Post ${action}:`, result.row);
-				updateCache(id, result.row);
-			}
-		}
-	}
-});
-
-// Stop watching
-unsubscribe();
-```
-
-**How it works:**
-
-- Changes are batched per Y.Transaction; bulk operations fire one callback
-- The `transaction` object enables origin checks (local vs remote changes)
-- `'add'`: Fires when a new row Y.Map is added to the table
-- `'update'`: Fires when any field changes within an existing row
-- `'delete'`: Fires when a row Y.Map is removed from the table
-
-## Provider System
-
-Providers are a unified map of capabilities. All workspace capabilities (persistence, sync, materializers like SQLite/markdown) are defined in a single `providers` map.
-
-### SQLite Extension
-
-The SQLite extension provides SQL query capabilities via Drizzle ORM.
-
-**Setup:**
-
-```typescript
-import { createWorkspace, sqliteProvider } from '@epicenter/workspace';
-
-const client = createWorkspace(definition)
-	.withExtension('sqlite', (c) => sqliteProvider(c));
-```
-
-**Storage:**
-
-- Database: `.epicenter/providers/sqlite/{workspaceId}.db`
-- Logs: `.epicenter/providers/sqlite/logs/{workspaceId}.log`
-
-**Exports:**
-
-```typescript
-{
-  pullToSqlite: Query,              // Sync YJS → SQLite (replace all)
-  pushFromSqlite: Query,            // Sync SQLite → YJS (replace all)
-  db: BetterSQLite3Database,       // Drizzle database instance
-  posts: DrizzleTable,              // Each table as Drizzle table reference
-  users: DrizzleTable,
-  // ... all tables
-}
-```
-
-**Usage:**
-
-```typescript
-const blogActions = {
-	getPublishedPosts: defineQuery({
-		handler: async () => {
-			// Query with full Drizzle power via client.extensions
-			const { sqlite } = client.extensions;
-			return await sqlite.posts
-				.select()
-				.where(eq(sqlite.posts.published, true))
-				.orderBy(desc(sqlite.posts.publishedAt))
-				.limit(10);
-		},
-	}),
-
-	getPostStats: defineQuery({
-		handler: async () => {
-			const { sqlite } = client.extensions;
-			return await sqlite.posts
-				.select({
-					category: sqlite.posts.category,
-					total: count(),
-					avgViews: avg(sqlite.posts.views),
-				})
-				.groupBy(sqlite.posts.category);
-		},
-	}),
-
-	// Manual sync operations
-	syncToSqlite: defineMutation({
-		handler: () => client.extensions.sqlite.pullToSqlite(),
-	}),
-};
-```
-
-**How it works:**
-
-- Observes YJS changes and updates SQLite automatically
-- Uses WAL mode for concurrent access
-- Prevents infinite loops with sync coordination flags
-- Logs validation errors without blocking sync
-- Performs full initial sync on startup
-
-### Markdown Extension
-
-The markdown extension persists data as human-readable markdown files.
-
-**Setup:**
-
-```typescript
-import { createWorkspace, markdownProvider } from '@epicenter/workspace';
-
-const client = createWorkspace(definition)
-	.withExtension('markdown', (c) =>
-		markdownProvider(c, {
-			directory: './data', // Optional: workspace-level directory
-			tableConfigs: {
-				posts: {
-					directory: './posts', // Optional: per-table directory
-					serialize: ({ row }) => ({
-						frontmatter: { title: row.title, published: row.published },
-						body: row.content,
-						filename: `${row.id}.md`,
-					}),
-					deserialize: ({ frontmatter, body, filename }) => {
-						const id = basename(filename, '.md');
-						return Ok({ id, content: body, ...frontmatter });
-					},
-				},
-			},
-		}),
-	);
-```
-
-**Storage:**
-
-- Markdown files: `./{workspaceId}/{tableName}/*.md` (configurable)
-- Logs: `.epicenter/providers/markdown/logs/{workspaceId}.log`
-- Diagnostics: `.epicenter/providers/markdown/diagnostics/{workspaceId}.json`
-
-**Exports:**
-
-```typescript
-{
-  pullToMarkdown: Query,            // Sync YJS → Markdown files (replace all)
-  pushFromMarkdown: Query,          // Sync Markdown files → YJS (replace all)
-  scanForErrors: Query,             // Validate all files, rebuild diagnostics
-}
-```
-
-**Usage:**
-
-```typescript
-const blogActions = {
-	// Export markdown sync operations
-	syncToMarkdown: defineMutation({
-		handler: () => client.extensions.markdown.pullToMarkdown(),
-	}),
-	syncFromMarkdown: defineMutation({
-		handler: () => client.extensions.markdown.pushFromMarkdown(),
-	}),
-	validateFiles: defineQuery({
-		handler: () => client.extensions.markdown.scanForErrors(),
-	}),
-};
-```
-
-**How it works:**
-
-- Watches markdown directories for file changes
-- Syncs changes bidirectionally with YJS
-- Maintains rowId ↔ filename mapping (handles renames/deletions)
-- Validates all files on startup
-- Tracks errors in diagnostics (JSON) and error log (append-only)
-- Prevents infinite loops with sync coordination
-
-**Default serialization:**
-
-- Frontmatter: All columns except content
-- Body: `content` column (if exists)
-- Filename: `{id}.md`
-
-**Custom serialization:**
-
-```typescript
-serialize: ({ row, table }) => {
-  // Custom logic
-  return {
-    frontmatter: { /* YAML frontmatter */ },
-    body: 'markdown body',
-    filename: 'custom-name.md'
-  };
-},
-deserialize: ({ frontmatter, body, filename, table }) => {
-  // Custom parsing
-  const row = { id: '...', ... };
-  return Ok(row); // or Err(MarkdownProviderErr({ ... }))
-}
-```
-
-### Sync Extension
-
-The sync extension enables real-time Y.Doc synchronization using the y-websocket protocol with `@epicenter/sync` as the underlying provider. This is the recommended sync solution for Epicenter.
-
-**Setup:**
-
-````typescript
-import { createWorkspace } from '@epicenter/workspace';
-import { createSyncExtension } from '@epicenter/workspace/extensions/sync/websocket';
-
-const client = createWorkspace(definition)
-	.withExtension(
-		'sync',
-		createSyncExtension({
-			url: 'ws://localhost:3913/rooms/{id}',
-		}),
-	);
-````
-
-The `{id}` placeholder is replaced with the workspace ID automatically.
-
-The `{id}` placeholder is replaced with the workspace ID automatically. Point the URL at any y-websocket compatible server (e.g., `apps/api`).
-
-**How it works:**
-
-1. Client opens WebSocket to `/rooms/{workspaceId}`
-2. Server sends initial sync state (sync step 1)
-3. Client and server exchange updates bidirectionally
-4. Server broadcasts updates to all connected clients
-5. All Y.Docs converge via Yjs CRDTs
-
-**Key properties:**
-
-- Standard protocol: Compatible with any y-websocket client
-- Text ping/pong liveness detection via Cloudflare auto-response
-- Built-in awareness: User presence/cursors work out of the box
-- Two auth modes: open (no auth) and authenticated (dynamic token refresh)
-- No native modules: Pure JS, works with Bun
-
-See `@epicenter/sync` for the client-side provider API.
-
-### Multi-Device Sync Architecture
-
-Epicenter supports a distributed sync architecture where Y.Doc instances can be replicated across multiple devices and servers.
-
-**Define your sync nodes:**
-
-```typescript
-// src/config/sync-nodes.ts
-export const SYNC_NODES = {
-	// Local devices via Tailscale
-	desktop: 'ws://desktop.my-tailnet.ts.net:3913/rooms/{id}',
-	laptop: 'ws://laptop.my-tailnet.ts.net:3913/rooms/{id}',
-
-	// Cloud server (optional, always-on)
-	cloud: 'wss://sync.myapp.com/rooms/{id}',
-
-	// Localhost (for browser connecting to local server)
-	localhost: 'ws://localhost:3913/rooms/{id}',
-} as const;
-```
-
-**Provider strategy per device:**
-
-| Device          | Role          | Connects To                  |
-| --------------- | ------------- | ---------------------------- |
-| Phone browser   | Client only   | `desktop`, `laptop`, `cloud` |
-| Laptop browser  | Client        | `localhost`                  |
-| Desktop browser | Client        | `localhost`                  |
-| Laptop server   | Node + Client | `desktop`, `cloud`           |
-| Desktop server  | Node + Client | `laptop`, `cloud`            |
-
-**Multi-extension example (phone):**
-
-```typescript
-// Phone connects to ALL available sync nodes
-const client = createWorkspace(definition)
-	.withExtension(
-		'syncDesktop',
-		createSyncExtension({ url: SYNC_NODES.desktop }),
-	)
-	.withExtension('syncLaptop', createSyncExtension({ url: SYNC_NODES.laptop }))
-	.withExtension('syncCloud', createSyncExtension({ url: SYNC_NODES.cloud }));
-```
-
-**Server-to-server sync:**
-
-```typescript
-// Desktop server connects to OTHER servers (not itself!)
-const client = createWorkspace(definition)
-	.withExtension(
-		'syncToLaptop',
-		createSyncExtension({ url: SYNC_NODES.laptop }),
-	)
-	.withExtension('syncToCloud', createSyncExtension({ url: SYNC_NODES.cloud }));
-```
-
-Yjs supports multiple providers simultaneously. Changes merge automatically via CRDTs regardless of which provider delivers them first.
-
-See [SYNC_ARCHITECTURE.md](./SYNC_ARCHITECTURE.md) for complete multi-device sync documentation.
-
-## Workspace Dependencies
-
-Workspaces can depend on other workspaces, enabling modular architecture. For cross-workspace communication, simply import the initialized client of the dependency.
-
-**Access pattern (regular imports):**
-
-```typescript
-import { authClient } from './auth-client';
-import { storageClient } from './storage-client';
-
-// blog-actions.ts
-export const createPost = defineMutation({
-	input: type({ title: 'string', authorId: 'string' }),
-	handler: async ({ title, authorId }) => {
-		// Access dependency workspace actions via imported client
-		const user = await authClient.getUserById({ id: authorId });
-		if (!user) {
-			return Err({ message: 'User not found' });
-		}
-
-		// Access dependency workspace tables
-		const allUsers = authClient.tables.get('users').getAll();
-
-		// Create post in local workspace
-		const id = generateId();
-		blogClient.tables.get('posts').upsert({
-			id,
-			title,
-			authorId,
-			published: false,
-		});
-		return Ok({ id });
-	},
-});
-```
-
-## Actions
-
-Actions are workspace operations defined with `defineQuery` or `defineMutation`.
-
-### Query Actions
-
-Read operations with no side effects. Use HTTP GET when exposed via API/MCP.
-
-**Variants:**
-
-```typescript
-// With input, returns Result<T, E>
-defineQuery({
-	input: type({ id: 'string' }),
-	handler: ({ id }) => {
-		const post = db.tables.get('posts').get({ id });
-		if (!post) {
-			return Err({ message: 'Not found' });
-		}
-		return Ok(post.data);
-	},
-});
-
-// With input, returns T (can't fail)
-defineQuery({
-	input: type({ limit: 'number' }),
-	handler: ({ limit }) => {
-		return db.tables.get('posts').getAll().slice(0, limit);
-	},
-});
-
-// No input, returns Result<T, E>
-defineQuery({
-	handler: () => {
-		const result = someOperationThatCanFail();
-		if (result.error) {
-			return Err(result.error);
-		}
-		return Ok(result.data);
-	},
-});
-
-// No input, returns T (can't fail)
-defineQuery({
-	handler: () => {
-		return db.tables.get('posts').count();
-	},
-});
-```
-
-All variants support async handlers:
-
-```typescript
-defineQuery({
-	input: type({ id: 'string' }),
-	handler: async ({ id }) => {
-		const data = await fetchExternal(id);
-		return Ok(data);
-	},
-});
-```
-
-### Mutation Actions
-
-Write operations that modify state. Use HTTP POST when exposed via API/MCP.
-
-**Variants:** Same as queries (8 overloads: with/without input, sync/async, Result/raw).
-
-```typescript
-// With input, returns Result<T, E>
-defineMutation({
-	input: type({ title: 'string' }),
-	handler: ({ title }) => {
-		const id = generateId();
-		db.tables.get('posts').upsert({
-			id,
-			title,
-			published: false,
-		});
-		return Ok({ id });
-	},
-});
-
-// With input, returns void (can't fail)
-defineMutation({
-	input: type({ id: 'string' }),
-	handler: ({ id }) => {
-		db.tables.get('posts').delete({ id });
-	},
-});
-```
-
-### Input Validation
-
-Actions support Standard Schema validation (ArkType, Zod, Valibot, Effect):
+`set(row)` inserts or replaces a whole row.
 
 ```typescript
 import { type } from 'arktype';
-import { z } from 'zod';
+import { createWorkspace, defineTable } from '@epicenter/workspace';
 
-// ArkType (recommended)
-defineQuery({
-  input: type({
-    email: 'string.email',
-    age: 'number>0',
-  }),
-  handler: (input) => { ... }
-})
+const posts = defineTable(
+	type({
+		id: 'string',
+		title: 'string',
+		published: 'boolean',
+		_v: '1',
+	}),
+);
 
-// Zod
-defineQuery({
-  input: z.object({
-    email: z.string().email(),
-    age: z.number().positive(),
-  }),
-  handler: (input) => { ... }
-})
+const workspace = createWorkspace({
+	id: 'epicenter.examples.tables',
+	tables: { posts },
+});
+
+workspace.tables.posts.set({
+	id: 'post-1',
+	title: 'First post',
+	published: false,
+	_v: 1,
+});
+
+workspace.tables.posts.set({
+	id: 'post-1',
+	title: 'First post, replaced',
+	published: true,
+	_v: 1,
+});
+
+void workspace;
 ```
 
-**JSON Schema Limitations:**
+`set(...)` is the insert-or-replace API.
 
-Input schemas are converted to JSON Schema for MCP/CLI/OpenAPI. Avoid:
+### Update operations
 
-- Transforms: `.pipe()` (ArkType), `.transform()` (Zod)
-- Custom validation: `.filter()` (ArkType), `.refine()` (Zod)
-- Non-JSON types: `bigint`, `symbol`, `undefined`, `Date`, `Map`, `Set`
+`update(id, partial)` reads the row, merges the partial fields, validates the merged result, and writes it back.
 
-Use basic types and `.matching(regex)` for patterns. For complex validation, validate in the handler.
+Possible return values:
 
-### Action Properties
-
-Actions have metadata properties:
+- `{ status: 'updated', row }`
+- `{ status: 'not_found', id, row: undefined }`
+- `{ status: 'invalid', id, errors, row }`
 
 ```typescript
-const action = defineQuery({ ... });
+import { type } from 'arktype';
+import { createWorkspace, defineTable } from '@epicenter/workspace';
 
-action.type         // 'query' | 'mutation'
-action.input        // StandardSchemaV1 | undefined
-action.description  // string | undefined
+const posts = defineTable(
+	type({
+		id: 'string',
+		title: 'string',
+		published: 'boolean',
+		views: 'number',
+		_v: '1',
+	}),
+);
+
+const workspace = createWorkspace({
+	id: 'epicenter.examples.update',
+	tables: { posts },
+});
+
+workspace.tables.posts.set({
+	id: 'post-1',
+	title: 'Draft',
+	published: false,
+	views: 0,
+	_v: 1,
+});
+
+const updateResult = workspace.tables.posts.update('post-1', {
+	published: true,
+	views: 1,
+});
+
+if (updateResult.status === 'updated') {
+	console.log(updateResult.row.views);
+}
+
+void workspace;
 ```
 
-### Type Guards
+### Read operations
+
+The table helper has two styles of read:
+
+| Method | Return type | Notes |
+| --- | --- | --- |
+| `get(id)` | `GetResult<TRow>` | Returns `valid`, `invalid`, or `not_found` |
+| `getAll()` | `RowResult<TRow>[]` | Includes invalid rows |
+| `getAllValid()` | `TRow[]` | Skips invalid rows |
+| `getAllInvalid()` | `InvalidRowResult[]` | Debug schema drift or corrupt data |
+| `filter(predicate)` | `TRow[]` | Runs only on valid rows |
+| `find(predicate)` | `TRow | undefined` | First valid match |
+| `has(id)` | `boolean` | Existence only |
+| `count()` | `number` | Counts valid and invalid rows |
 
 ```typescript
-import { isAction, isQuery, isMutation } from '@epicenter/workspace';
+import { type } from 'arktype';
+import { createWorkspace, defineTable } from '@epicenter/workspace';
 
-isAction(value); // value is Query | Mutation
-isQuery(value); // value is Query
-isMutation(value); // value is Mutation
+const posts = defineTable(
+	type({
+		id: 'string',
+		title: 'string',
+		published: 'boolean',
+		_v: '1',
+	}),
+);
+
+const workspace = createWorkspace({
+	id: 'epicenter.examples.reads',
+	tables: { posts },
+});
+
+workspace.tables.posts.set({ id: '1', title: 'One', published: false, _v: 1 });
+workspace.tables.posts.set({ id: '2', title: 'Two', published: true, _v: 1 });
+
+const one = workspace.tables.posts.get('1');
+if (one.status === 'valid') {
+	console.log(one.row.title);
+}
+
+const all = workspace.tables.posts.getAll();
+const valid = workspace.tables.posts.getAllValid();
+const published = workspace.tables.posts.filter((row) => row.published);
+const firstPublished = workspace.tables.posts.find((row) => row.published);
+const hasPostTwo = workspace.tables.posts.has('2');
+const count = workspace.tables.posts.count();
+
+console.log(all.length, valid.length, published.length, firstPublished?.id, hasPostTwo, count);
+
+void workspace;
+```
+
+### Delete operations
+
+| Method | Behavior |
+| --- | --- |
+| `delete(id)` | Deletes one row; missing IDs are a silent no-op |
+| `clear()` | Deletes all rows in the table |
+
+```typescript
+import { type } from 'arktype';
+import { createWorkspace, defineTable } from '@epicenter/workspace';
+
+const tags = defineTable(
+	type({
+		id: 'string',
+		name: 'string',
+		_v: '1',
+	}),
+);
+
+const workspace = createWorkspace({
+	id: 'epicenter.examples.deletes',
+	tables: { tags },
+});
+
+workspace.tables.tags.set({ id: 'tag-1', name: 'important', _v: 1 });
+workspace.tables.tags.delete('tag-1');
+workspace.tables.tags.clear();
+
+void workspace;
+```
+
+### Reactive updates
+
+`observe(...)` reports a set of changed IDs and the optional Yjs transaction origin.
+
+Use `table.get(id)` inside the callback to see whether the row now exists.
+
+```typescript
+import { type } from 'arktype';
+import { createWorkspace, defineTable } from '@epicenter/workspace';
+import { DOCUMENTS_ORIGIN } from '@epicenter/workspace';
+
+const files = defineTable(
+	type({
+		id: 'string',
+		name: 'string',
+		_v: '1',
+	}),
+);
+
+const workspace = createWorkspace({
+	id: 'epicenter.examples.observe',
+	tables: { files },
+});
+
+const unsubscribe = workspace.tables.files.observe((changedIds, origin) => {
+	if (origin === DOCUMENTS_ORIGIN) {
+		return;
+	}
+
+	for (const id of changedIds) {
+		const result = workspace.tables.files.get(id);
+		if (result.status === 'not_found') {
+			console.log('deleted:', id);
+			continue;
+		}
+
+		if (result.status === 'valid') {
+			console.log('present:', result.row.name);
+		}
+	}
+});
+
+workspace.tables.files.set({ id: 'file-1', name: 'notes.md', _v: 1 });
+workspace.tables.files.delete('file-1');
+unsubscribe();
+
+void workspace;
+```
+
+## Provider System
+
+The old provider map is gone. The current public API is the extension chain.
+
+That means this:
+
+```text
+createWorkspace(definition)
+	.withExtension('persistence', indexeddbPersistence)
+	.withExtension('sync', createSyncExtension({ ... }))
+	.withWorkspaceExtension('markdown', markdownMaterializer({ ... }));
+```
+
+Not this:
+
+```text
+// This API does not exist anymore.
+// providers: { persistence: ..., sync: ... }
+```
+
+### Builder methods
+
+| Method | Scope | Use when |
+| --- | --- | --- |
+| `.withExtension(key, factory)` | Workspace doc + all document docs | Same factory should run everywhere |
+| `.withWorkspaceExtension(key, factory)` | Workspace doc only | Factory needs `tables`, `kv`, or `definitions` |
+| `.withDocumentExtension(key, factory)` | Document docs only | Factory needs `timeline`, `tableName`, or `documentName` |
+| `.withActions(factory)` | Live client only | Attach callable queries and mutations |
+
+### Persistence extensions
+
+The current public persistence subpaths are:
+
+- `@epicenter/workspace/extensions/persistence/indexeddb`
+- `@epicenter/workspace/extensions/persistence/sqlite`
+
+The first exports `indexeddbPersistence`. The second exports `filesystemPersistence({ filePath })`, which returns an extension factory.
+
+```typescript
+import { type } from 'arktype';
+import { createWorkspace, defineTable } from '@epicenter/workspace';
+import { filesystemPersistence } from '@epicenter/workspace/extensions/persistence/sqlite';
+
+const notes = defineTable(
+	type({
+		id: 'string',
+		title: 'string',
+		_v: '1',
+	}),
+);
+
+const workspace = createWorkspace({
+	id: 'epicenter.notes.desktop',
+	tables: { notes },
+}).withExtension(
+	'persistence',
+	filesystemPersistence({
+		filePath: '/tmp/epicenter/notes.db',
+	}),
+);
+
+void workspace;
+```
+
+### Sync extension
+
+The public sync subpaths are:
+
+- `@epicenter/workspace/extensions/sync/websocket`
+- `@epicenter/workspace/extensions/sync/broadcast-channel`
+
+In practice, `createSyncExtension(...)` is the main entry point. It already includes BroadcastChannel cross-tab sync.
+
+```typescript
+import { type } from 'arktype';
+import { createWorkspace, defineTable } from '@epicenter/workspace';
+import { indexeddbPersistence } from '@epicenter/workspace/extensions/persistence/indexeddb';
+import {
+	createSyncExtension,
+	toWsUrl,
+} from '@epicenter/workspace/extensions/sync/websocket';
+
+const tabs = defineTable(
+	type({
+		id: 'string',
+		url: 'string',
+		_v: '1',
+	}),
+);
+
+const workspace = createWorkspace({
+	id: 'epicenter.tabs',
+	tables: { tabs },
+})
+	.withExtension('persistence', indexeddbPersistence)
+	.withExtension(
+		'sync',
+		createSyncExtension({
+			url: (docId) => toWsUrl(`https://sync.epicenter.so/rooms/${docId}`),
+		}),
+	);
+
+void workspace;
+```
+
+### Markdown materializer
+
+The markdown materializer is exported at `@epicenter/workspace/extensions/materializer/markdown`. It is a workspace-only extension because it needs access to `tables`.
+
+```typescript
+import { type } from 'arktype';
+import { createWorkspace, defineTable } from '@epicenter/workspace';
+import { filesystemPersistence } from '@epicenter/workspace/extensions/persistence/sqlite';
+import {
+	markdownMaterializer,
+	titleFilenameSerializer,
+} from '@epicenter/workspace/extensions/materializer/markdown';
+
+const notes = defineTable(
+	type({
+		id: 'string',
+		title: 'string',
+		body: 'string',
+		_v: '1',
+	}),
+);
+
+const workspace = createWorkspace({
+	id: 'epicenter.notes',
+	tables: { notes },
+})
+	.withExtension(
+		'persistence',
+		filesystemPersistence({
+			filePath: '/tmp/epicenter/notes-workspace.db',
+		}),
+	)
+	.withWorkspaceExtension('markdown', (context) =>
+		markdownMaterializer({
+			directory: '/tmp/epicenter/markdown',
+			tables: {
+				notes: {
+					serializer: titleFilenameSerializer('title'),
+				},
+			},
+		})(context),
+	);
+
+void workspace;
+```
+
+### Honest note about SQLite materialization
+
+There is SQLite mirror code in `src/extensions/materializer/sqlite`, but it is not in the current `package.json` exports map for `@epicenter/workspace`. This README sticks to public APIs you can actually import today. If that export changes later, the README should change with it—not before.
+
+## Workspace Dependencies
+
+Workspaces depend on each other the normal way: regular imports.
+
+There is no special dependency graph inside the workspace package. If one action needs another workspace, import the other workspace client or factory and call it directly.
+
+```typescript
+import Type from 'typebox';
+import { defineMutation } from '@epicenter/workspace';
+
+declare const authWorkspace: {
+	actions: {
+		users: {
+			getById: (input: { id: string }) => { id: string; name: string } | null;
+		};
+	};
+};
+
+declare const blogWorkspace: {
+	tables: {
+		posts: {
+			set: (row: {
+				id: string;
+				title: string;
+				authorId: string;
+				_v: 1;
+			}) => void;
+		};
+	};
+};
+
+const createPost = defineMutation({
+	title: 'Create Post',
+	description: 'Create a post for an existing author.',
+	input: Type.Object({
+		id: Type.String(),
+		title: Type.String(),
+		authorId: Type.String(),
+	}),
+	handler: ({ id, title, authorId }) => {
+		const author = authWorkspace.actions.users.getById({ id: authorId });
+		if (!author) return null;
+
+		blogWorkspace.tables.posts.set({
+			id,
+			title,
+			authorId,
+			_v: 1,
+		});
+
+		return { id };
+	},
+});
+
+void createPost;
+```
+
+That example uses `declare` stubs so the snippet compiles on its own, but the real pattern is just plain module composition.
+
+## Actions
+
+Actions are the current abstraction for developer-facing operations.
+
+They have four important properties:
+
+1. They are callable functions.
+2. They carry metadata (`type`, `title`, `description`, `input`).
+3. They close over the client by normal JavaScript closure.
+4. They are attached to the workspace with `.withActions(...)`.
+
+### Query actions
+
+Use `defineQuery(...)` for reads.
+
+```typescript
+import { type } from 'arktype';
+import Type from 'typebox';
+import {
+	createWorkspace,
+	defineQuery,
+	defineTable,
+} from '@epicenter/workspace';
+
+const posts = defineTable(
+	type({
+		id: 'string',
+		title: 'string',
+		published: 'boolean',
+		_v: '1',
+	}),
+);
+
+const workspace = createWorkspace({
+	id: 'epicenter.actions.queries',
+	tables: { posts },
+}).withActions(({ tables }) => ({
+	posts: {
+		list: defineQuery({
+			title: 'List Posts',
+			description: 'List all posts.',
+			handler: () => tables.posts.getAllValid(),
+		}),
+
+		getById: defineQuery({
+			title: 'Get Post',
+			description: 'Get one post by ID.',
+			input: Type.Object({ id: Type.String() }),
+			handler: ({ id }) => tables.posts.get(id),
+		}),
+	},
+}));
+
+const actionType = workspace.actions.posts.list.type;
+void actionType;
+void workspace;
+```
+
+### Mutation actions
+
+Use `defineMutation(...)` for writes or side effects.
+
+```typescript
+import { type } from 'arktype';
+import Type from 'typebox';
+import {
+	createWorkspace,
+	defineMutation,
+	defineTable,
+	generateId,
+} from '@epicenter/workspace';
+
+const posts = defineTable(
+	type({
+		id: 'string',
+		title: 'string',
+		published: 'boolean',
+		_v: '1',
+	}),
+);
+
+const workspace = createWorkspace({
+	id: 'epicenter.actions.mutations',
+	tables: { posts },
+}).withActions(({ tables }) => ({
+	posts: {
+		create: defineMutation({
+			title: 'Create Post',
+			description: 'Create a new post row.',
+			input: Type.Object({ title: Type.String() }),
+			handler: ({ title }) => {
+				const id = generateId();
+				tables.posts.set({ id, title, published: false, _v: 1 });
+				return { id };
+			},
+		}),
+
+		publish: defineMutation({
+			title: 'Publish Post',
+			description: 'Mark a post as published.',
+			input: Type.Object({ id: Type.String() }),
+			handler: ({ id }) => tables.posts.update(id, { published: true }),
+		}),
+	},
+}));
+
+void workspace;
+```
+
+### Input validation
+
+Action inputs are TypeBox today.
+
+That point matters because older docs implied a wider schema surface than the current implementation. `defineQuery` and `defineMutation` are typed around `typebox` `TSchema` inputs, so the safe example is:
+
+```typescript
+import Type from 'typebox';
+import { defineQuery } from '@epicenter/workspace';
+
+const searchPosts = defineQuery({
+	title: 'Search Posts',
+	description: 'Search posts by query string.',
+	input: Type.Object({ query: Type.String(), limit: Type.Optional(Type.Number()) }),
+	handler: ({ query, limit }) => ({ query, limit: limit ?? 10 }),
+});
+
+void searchPosts;
+```
+
+No-input actions are just as valid:
+
+```typescript
+import { defineMutation } from '@epicenter/workspace';
+
+const clearCache = defineMutation({
+	title: 'Clear Cache',
+	description: 'Clear a local cache.',
+	handler: () => {
+		return { cleared: true };
+	},
+});
+
+void clearCache;
+```
+
+### Action properties
+
+Every action exposes:
+
+- `action.type` — `'query'` or `'mutation'`
+- `action.title` — optional UI-facing label
+- `action.description` — optional adapter-facing description
+- `action.input` — optional TypeBox schema
+
+And the action itself is callable. There is no separate `.handler` property on the returned object.
+
+### Type guards and iteration
+
+```typescript
+import Type from 'typebox';
+import {
+	defineMutation,
+	defineQuery,
+	isAction,
+	isMutation,
+	isQuery,
+	iterateActions,
+	type Actions,
+} from '@epicenter/workspace';
+
+const actions = {
+	posts: {
+		list: defineQuery({ handler: () => [] as string[] }),
+		create: defineMutation({
+			input: Type.Object({ title: Type.String() }),
+			handler: ({ title }) => ({ title }),
+		}),
+	},
+} satisfies Actions;
+
+for (const [action, path] of iterateActions(actions)) {
+	if (isAction(action)) {
+		console.log(path.join('.'), action.type);
+	}
+}
+
+const listAction = actions.posts.list;
+if (isQuery(listAction)) {
+	console.log(listAction.type);
+}
+
+const createAction = actions.posts.create;
+if (isMutation(createAction)) {
+	console.log(createAction.type);
+}
 ```
 
 ## Providers
 
-Providers are defined as a map and can attach capabilities to YJS documents. They run in parallel during workspace initialization.
+Historically, Epicenter called many of these things “providers.” In the current package surface, the better mental model is “extensions.” This section lists the public extension entry points the package actually exports.
 
-**Type:**
+| Import path | What it exports | Public today |
+| --- | --- | --- |
+| `@epicenter/workspace` | Core workspace API, actions, ids, dates, types | Yes |
+| `@epicenter/workspace/extensions/persistence/indexeddb` | `indexeddbPersistence` | Yes |
+| `@epicenter/workspace/extensions/persistence/sqlite` | `filesystemPersistence` | Yes |
+| `@epicenter/workspace/extensions/sync/websocket` | `createSyncExtension`, `toWsUrl`, sync types | Yes |
+| `@epicenter/workspace/extensions/sync/broadcast-channel` | BroadcastChannel sync extension | Yes |
+| `@epicenter/workspace/extensions/materializer/markdown` | `markdownMaterializer`, serializers | Yes |
+| `src/extensions/materializer/sqlite/*` | SQLite mirror internals | Not exported from package.json |
 
-```typescript
-type Provider<TExports> = (
-	context: ProviderContext,
-) => TExports | void | Promise<TExports | void>;
+### Create workspace
 
-type ProviderContext = {
-	id: string; // Workspace ID
-	providerId: string; // Provider key (e.g., 'sqlite', 'persistence')
-	ydoc: Y.Doc; // YJS document
-	schema: TSchema; // Workspace schema (table definitions)
-	tables: Tables<TSchema>; // Access to workspace tables
-	paths: ProviderPaths | undefined; // Filesystem paths (undefined in browser)
-};
-
-type ProviderPaths = {
-	project: ProjectDir; // Project root for user content
-	epicenter: EpicenterDir; // .epicenter directory
-	provider: ProviderDir; // .epicenter/providers/{providerId}/
-};
-```
-
-**Common providers:**
+The builder is usable immediately. You do not need a separate “finalize” step.
 
 ```typescript
-import { setupPersistence } from '@epicenter/workspace/providers';
-import { sqliteProvider, markdownProvider } from '@epicenter/workspace';
-import { createSyncExtension } from '@epicenter/workspace/extensions/sync/websocket';
+import { type } from 'arktype';
+import { createWorkspace, defineTable } from '@epicenter/workspace';
 
-providers: {
-  // Filesystem persistence (Node.js) or IndexedDB (browser)
-  persistence: setupPersistence,
+const notes = defineTable(
+	type({
+		id: 'string',
+		title: 'string',
+		_v: '1',
+	}),
+);
 
-  // SQLite materializer
-  sqlite: (c) => sqliteProvider(c),
+const workspace = createWorkspace({
+	id: 'epicenter.examples.builder',
+	tables: { notes },
+});
 
-  // Markdown materializer
-  markdown: (c) => markdownProvider(c),
+workspace.tables.notes.set({ id: '1', title: 'Ready immediately', _v: 1 });
 
-  // WebSocket sync extension (y-websocket protocol via @epicenter/sync)
-  sync: createSyncExtension({
-    url: 'ws://localhost:3913/rooms/{id}',
-  }),
-
-  // Custom provider
-  custom: ({ id, ydoc, paths }) => {
-    console.log(`Setting up workspace: ${id}`);
-    // Attach custom capabilities
-  },
-}
+void workspace;
 ```
 
-**Execution:**
-
-Providers run in parallel during initialization. Providers that return exports make those exports available in the `providers` object passed to handlers.
-
-### Create Workspace
-
-Create a workspace client using the builder pattern:
-
-```typescript
-// Create a workspace with extensions
-const blogClient = createWorkspace(blogWorkspace)
-	.withExtension('sqlite', sqliteProvider);
-
-// Direct table access
-const posts = blogClient.tables.get('posts').getAllValid();
-
-// Cleanup when done
-await blogClient.destroy();
-
-// Or use with `await using` for automatic cleanup
-{
-	await using client = createWorkspace(blogWorkspace)
-		.withExtension('sqlite', sqliteProvider);
-
-	client.tables.get('posts').upsert({ id: '1', title: 'Hello' });
-}
-```
-
-**projectDir**: Defaults to `process.cwd()` in Node.js, `undefined` in browser.
+If you add extensions, use `whenReady` as the async boundary.
 
 ## Architecture & Lifecycle
 
-### Client Initialization Lifecycle
+### Client initialization lifecycle
 
-When you call `.withExtension()`, here's what happens:
+When you call `createWorkspace(...)`, here is the actual lifecycle:
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│ 1. CREATE Y.Doc (CRDT data structure)                       │
-│    • Unique document ID = workspace ID                      │
-│    • In-memory collaborative data structure                 │
+│ 1. CREATE Y.Doc                                            │
+│    • guid = workspace id                                   │
+│    • tables, kv, and awareness helpers are created         │
 └─────────────────────────────────────────────────────────────┘
                            │
                            ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ 2. INITIALIZE TABLES                                        │
-│    • Create YJS-backed table operations                     │
-│    • Set up runtime validators from schema                  │
+│ 2. CREATE DOCUMENT MANAGERS                                │
+│    • Only for tables that called .withDocument()           │
+│    • Managers are eager; document Y.Docs open lazily       │
 └─────────────────────────────────────────────────────────────┘
                            │
                            ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ 3. INITIALIZE PROVIDERS                                     │
-│    • Run provider factories (SQLite, markdown, etc.)        │
-│    • Providers receive YDoc, tables, paths, validators      │
-│    • Loads existing state, starts auto-sync                 │
+│ 3. APPLY BUILDER CHAIN                                     │
+│    • withExtension / withWorkspaceExtension /              │
+│      withDocumentExtension / withActions                   │
+│    • each step returns a fresh builder                     │
 └─────────────────────────────────────────────────────────────┘
                            │
                            ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ 4. BIND ACTION HANDLERS                                     │
-│    • Connect handlers to contracts                          │
-│    • Inject handler context (tables, providers, etc.)       │
+│ 4. RESOLVE whenReady                                       │
+│    • composite promise across all registered extensions    │
+│    • persistence loads first, sync can wait on it          │
 └─────────────────────────────────────────────────────────────┘
                            │
                            ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ 5. RETURN BOUND CLIENT                                      │
-│    • client.id - workspace ID                               │
-│    • client.tables - YJS table operations                   │
-│    • client.actions - bound action methods                  │
-│    • client.contracts - action schemas (for introspection)  │
-│    • client.destroy() - cleanup resources                   │
+│ 5. LIVE CLIENT                                             │
+│    • tables / kv / documents / awareness / extensions      │
+│    • actions callable directly through client.actions      │
 └─────────────────────────────────────────────────────────────┘
 ```
 
-### Storage Context
+### `batch(fn)`
 
-Each client instance writes to a **storage context** determined by:
+`client.batch(fn)` groups workspace mutations into a single Yjs transaction.
 
-- **Directory**: Where the script runs (affects `.epicenter/` path)
-- **Environment**: Browser (IndexedDB) vs Node (filesystem)
-- **Workspace ID**: The specific workspace being accessed
+```typescript
+import { type } from 'arktype';
+import { createWorkspace, defineTable } from '@epicenter/workspace';
 
-```
-Storage Context = Directory + Environment + Workspace ID
+const posts = defineTable(
+	type({
+		id: 'string',
+		title: 'string',
+		_v: '1',
+	}),
+);
 
-Examples:
-  /project-a + Node + pages → /project-a/.epicenter/providers/persistence/pages.yjs
-  /project-b + Node + pages → /project-b/.epicenter/providers/persistence/pages.yjs (different!)
-  Browser + pages → IndexedDB:pages (different!)
-```
+const tags = defineTable(
+	type({
+		id: 'string',
+		name: 'string',
+		_v: '1',
+	}),
+);
 
-### `.epicenter/` Folder Structure
+const workspace = createWorkspace({
+	id: 'epicenter.examples.batch',
+	tables: { posts, tags },
+});
 
-The `.epicenter` folder contains all internal data, organized by provider:
+workspace.batch(() => {
+	workspace.tables.posts.set({ id: 'p1', title: 'One transaction', _v: 1 });
+	workspace.tables.tags.set({ id: 't1', name: 'docs', _v: 1 });
+});
 
-```
-.epicenter/
-└── providers/                        # GITIGNORED
-    ├── persistence/                  # YJS persistence provider
-    │   ├── blog.yjs
-    │   └── auth.yjs
-    ├── sqlite/                       # SQLite provider
-    │   ├── blog.db
-    │   ├── auth.db
-    │   └── logs/
-    │       ├── blog.log
-    │       └── auth.log
-    ├── markdown/                     # Markdown provider
-    │   ├── logs/
-    │   │   └── blog.log
-    │   └── diagnostics/
-    │       └── blog.json
-    └── gmailAuth/                    # Custom auth provider example
-        └── token.json
+void workspace;
 ```
 
-**Key design decisions:**
+Yjs transactions do not roll back on throw. They batch notifications; they are not SQL transactions.
 
-- Each provider gets isolated storage at `.epicenter/providers/{providerId}/`
-- Provider artifacts are gitignored (add `.epicenter/providers/` to `.gitignore`)
-- Simple naming within providers: `{workspaceId}.{ext}` for data, `logs/{workspaceId}.log` for logs
-- **Rule**: Only one client can access the same storage context at a time.
+### `whenReady`, `clearLocalData`, and `dispose`
 
-### Cleanup Lifecycle
+| API | What it means |
+| --- | --- |
+| `whenReady` | Composite readiness promise across all installed extensions |
+| `clearLocalData()` | Calls extension `clearLocalData` hooks in LIFO order |
+| `dispose()` | Tears down observers, connections, and extension resources |
 
-When you dispose a client (automatically with `await using` or manually with `await client.destroy()`):
+`dispose()` preserves data. It cleans up resources. If you want to wipe persisted local state, that is what `clearLocalData()` is for.
+
+### Cleanup lifecycle
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│ destroy() or Symbol.asyncDispose Called                      │
+│ dispose() called                                           │
 └─────────────────────────────────────────────────────────────┘
                            │
                            ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ For Each Workspace:                                          │
-│                                                              │
-│    1. Destroy Providers                                      │
-│       • Close SQLite connections                             │
-│       • Unsubscribe observers                                │
-│       • Disconnect persistence                               │
-│                                                              │
-│    2. Destroy Y.Doc                                          │
-│       • Clean up observers                                   │
-│       • Free memory                                          │
+│ 1. Close open document handles                             │
+│    • document providers disconnect                         │
+│    • document observers stop                               │
+└─────────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 2. Dispose extensions in LIFO order                        │
+│    • sockets close                                         │
+│    • persistence adapters flush / detach                   │
+│    • status emitters stop                                  │
+└─────────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 3. Destroy awareness + Y.Doc                               │
 └─────────────────────────────────────────────────────────────┘
 ```
 
 ## Client vs Server
 
-Epicenter can be used in two primary ways:
+`@epicenter/workspace` is the core client/workspace library.
 
-### 1. As a Client (Scripts, Migrations, CLI Tools)
+The public root export does not currently ship a built-in server helper. Older docs implied otherwise; that is stale.
 
-Create a client directly for standalone scripts. Use `await using` for automatic cleanup:
+What the package does give you is the raw material a server adapter needs:
 
-```typescript
-// Script or migration
-{
-	await using client = createWorkspace(blogWorkspace)
-		.withExtension('sqlite', sqliteProvider);
+- `client.actions`
+- `iterateActions(...)`
+- `describeWorkspace(...)`
+- action metadata (`type`, `input`, `description`)
+- direct access to workspace tables, KV, documents, and awareness
 
-	client.tables.get('posts').upsert({ id: '1', title: 'Hello' });
-	// Automatic cleanup when block exits
-}
-```
-
-**Important**: When running scripts, **ensure no server is running** in the same directory. Multiple clients accessing the same storage context simultaneously will conflict.
-
-### 2. As a Server (Web APIs, Long-Running Processes)
-
-The server is a wrapper around the client that maps REST, MCP, and WebSocket Sync endpoints to workspace actions and tables.
-
-```typescript
-import { createWorkspace, createServer } from '@epicenter/workspace';
-
-const client = createWorkspace(blogWorkspace)
-  .withExtension('sqlite', sqliteProvider);
-
-// Expose the client and custom actions via HTTP
-const server = createServer(client, {
-  port: 3913,
-  actions: blogActions
-});
-
-server.start();
-
-// Other processes can now use the HTTP API
-await fetch('http://localhost:3913/actions/createPost', {
-  method: 'POST',
-  body: JSON.stringify({ title: 'New Post', ... }),
-});
-```
+If you want HTTP, CLI, or MCP on top, build or import an adapter around those primitives.
 
 ## API Reference
 
-### Workspace Definition
-
-```typescript
-import { defineWorkspace, defineMutation, defineQuery } from '@epicenter/workspace';
-```
-
-**`defineWorkspace({ id, tables, kv })`**
-
-Define a workspace contract with tables and key-value store.
-
-```typescript
-const blogWorkspace = defineWorkspace({
-	id: 'blog',
-	tables: {
-		posts: {
-			name: 'Posts',
-			fields: { id: id(), title: text() },
-		},
-	},
-	kv: {},
-});
-```
-
-### Client Creation
-
-```typescript
-// Create workspace with extensions
-const client = createWorkspace(blogWorkspace)
-	.withExtension('sqlite', sqliteProvider);
-
-// Use tables directly
-const id = generateId();
-client.tables.get('posts').upsert({ id, title: 'Hello' });
-```
-
-### Client Properties
-
-```typescript
-client.id; // Workspace ID ('blog')
-client.tables; // YJS-backed table operations
-client.kv; // Key-value store
-client.extensions; // Extension exports
-client.ydoc; // Underlying Y.Doc
-client.whenReady; // Promise for async initialization
-
-await client.destroy(); // Cleanup resources
-```
-
-### Document Content Model
-
-> Tables with `.withDocument()` create per-row content Y.Docs backed by a **timeline model** (`Y.Array('timeline')`) supporting text, richtext, and sheet content. Use `handle.read()`/`.writeText()` for simple string I/O, `handle.asText()` for Y.Text editor binding, `handle.asRichText()` for Y.XmlFragment richtext binding, and `handle.asSheet()` for spreadsheet binding. The `as*()` methods automatically convert between content modes—all conversions are infallible.
-
-
-### Column Schemas
+### Workspace definition
 
 ```typescript
 import {
-	id,
-	text,
-	ytext,
-	integer,
-	real,
-	boolean,
-	date,
-	select,
-	tags,
-	json,
-	type ColumnSchema,
-	type TableSchema,
-	type WorkspaceSchema,
+	defineKv,
+	defineTable,
+	defineWorkspace,
+	type WorkspaceDefinition,
 } from '@epicenter/workspace';
 ```
 
-**Column factory functions:**
+Core definition helpers:
 
-- `id()`: Auto-generated ID
-- `text(options?)`: Text column
-- `ytext(options?)`: Collaborative text (Y.Text)
-- `integer(options?)`, `real(options?)`: Numeric columns
-- `boolean(options?)`: Boolean column
-- `date(options?)`: Date with timezone
-- `select<TOptions>(options)`: Single choice enum
-- `tags<TOptions>(options?)`: String array
-- `json<TSchema>(options)`: JSON with arktype validation
+- `defineTable(schema)`
+- `defineTable(v1, v2, ...).migrate(fn)`
+- `defineKv(schema, defaultValue)`
+- `defineWorkspace({ id, tables, kv, awareness })`
 
-**Common options:**
+### Client creation
 
-- `nullable?: boolean` (default: `false`)
-- `default?: T | (() => T)`
+```typescript
+import {
+	createWorkspace,
+	type WorkspaceClient,
+	type WorkspaceClientBuilder,
+} from '@epicenter/workspace';
+```
+
+The builder returned by `createWorkspace(...)` is already a usable client.
+
+### Client properties
+
+The important runtime properties are:
+
+- `client.id`
+- `client.ydoc`
+- `client.definitions`
+- `client.tables`
+- `client.documents`
+- `client.kv`
+- `client.awareness`
+- `client.extensions`
+- `client.actions` when attached through `.withActions(...)`
+- `client.whenReady`
+
+Lifecycle and utility methods:
+
+- `client.batch(fn)`
+- `client.loadSnapshot(update)`
+- `client.applyEncryptionKeys(keys)`
+- `client.clearLocalData()`
+- `client.dispose()`
+
+### Document content model
+
+Open document handles are timeline APIs.
+
+Important methods and properties:
+
+- `handle.read()`
+- `handle.write(text)`
+- `handle.appendText(text)`
+- `handle.asText()`
+- `handle.asRichText()`
+- `handle.asSheet()`
+- `handle.currentType`
+- `handle.observe(...)`
+- `handle.restoreFromSnapshot(binary)`
+
+Document managers live at `client.documents.{tableName}.{documentName}` and expose:
+
+- `open(rowOrGuid)`
+- `close(rowOrGuid)`
+- `closeAll()`
 
 ### Actions
 
 ```typescript
 import {
-	defineQuery,
 	defineMutation,
+	defineQuery,
 	isAction,
-	isQuery,
 	isMutation,
-	defineActions,
-	type Query,
-	type Mutation,
+	isQuery,
+	iterateActions,
 	type Action,
 	type Actions,
+	type Mutation,
+	type Query,
 } from '@epicenter/workspace';
 ```
 
-**`defineQuery(config)`**
-
-Define a query action (read operation).
-
-**`defineMutation(config)`**
-
-Define a mutation action (write operation).
-
-**Type guards:**
-
-- `isAction(value)`: Check if value is Query or Mutation
-- `isQuery(value)`: Check if value is Query
-- `isMutation(value)`: Check if value is Mutation
-
-**`defineActions<T>(exports)`**
-
-Identity function for type inference.
-
-### Table Operations
+### Table operations
 
 ```typescript
-import { type Tables, type TableHelper } from '@epicenter/workspace';
-```
-
-**`TableHelper<TSchema>`** methods:
-
-- `upsert(row)`, `upsertMany(rows)`: Create or replace entire row (never fails)
-- `update(partial)`, `updateMany(partials)`: Merge fields into existing row (no-op if not found)
-- `get({ id })`, `getAll()`, `getAllInvalid()`
-- `has({ id })`, `count()`
-- `delete({ id })`, `deleteMany({ ids })`, `clear()`
-- `filter(predicate)`, `find(predicate)`
-- `observe(callback)`: Watch for changes (receives `Map<id, 'add'|'update'|'delete'>`)
-
-### Providers
-
-```typescript
-import { sqliteProvider } from '@epicenter/workspace';
-import { markdownProvider, type MarkdownProviderConfig } from '@epicenter/workspace';
 import {
-	type Provider,
-	type ProviderContext,
-	type Providers,
-	type WorkspaceProviderMap,
+	type GetResult,
+	type InvalidRowResult,
+	type RowResult,
+	type TableHelper,
+	type UpdateResult,
+	type ValidRowResult,
 } from '@epicenter/workspace';
 ```
 
-**`sqliteProvider(context)`**
+Public table helper methods:
 
-Create SQLite provider with Drizzle ORM.
+- `parse(id, input)`
+- `set(row)`
+- `update(id, partial)`
+- `get(id)`
+- `getAll()`
+- `getAllValid()`
+- `getAllInvalid()`
+- `filter(predicate)`
+- `find(predicate)`
+- `delete(id)`
+- `clear()`
+- `observe(callback)`
+- `count()`
+- `has(id)`
 
-**`markdownProvider(context, config?)`**
-
-Create markdown file provider.
-
-### Persistence Provider
+### KV operations
 
 ```typescript
-import { setupPersistence } from '@epicenter/workspace/providers';
+import { type KvChange, type KvHelper } from '@epicenter/workspace';
 ```
 
-**`setupPersistence`**
+Public KV helper methods:
 
-Built-in persistence provider (IndexedDB in browser, filesystem in Node.js).
+- `get(key)`
+- `set(key, value)`
+- `delete(key)`
+- `observe(key, callback)`
+- `observeAll(callback)`
 
-### Date Utilities
+### Awareness
+
+```typescript
+import {
+	type AwarenessDefinitions,
+	type AwarenessHelper,
+	type AwarenessState,
+	type InferAwarenessValue,
+} from '@epicenter/workspace';
+```
+
+Public awareness helper methods:
+
+- `setLocal(state)`
+- `setLocalField(key, value)`
+- `getLocal()`
+- `getLocalField(key)`
+- `getAll()`
+- `peers()`
+- `observe(callback)`
+- `raw`
+
+### Introspection
+
+```typescript
+import {
+	describeWorkspace,
+	standardSchemaToJsonSchema,
+	type ActionDescriptor,
+	type SchemaDescriptor,
+	type WorkspaceDescriptor,
+} from '@epicenter/workspace';
+```
+
+`describeWorkspace(client)` gives you a serializable description of tables, KV, awareness, and actions. `standardSchemaToJsonSchema(...)` converts compatible standard schemas to JSON Schema.
+
+### IDs and dates
 
 ```typescript
 import {
 	DateTimeString,
+	dateTimeStringNow,
+	generateGuid,
+	generateId,
 	type DateIsoString,
+	type Guid,
+	type Id,
 	type TimezoneId,
 } from '@epicenter/workspace';
 ```
 
-**`DateTimeString.now(timezone?)`**
-
-Create a DateTimeString for the current moment. Uses system timezone if not specified.
-
-**`DateTimeString.parse(str)`**
-
-Parse storage string to `Temporal.ZonedDateTime` for date math and manipulation.
-
-**`DateTimeString.stringify(dt)`**
-
-Convert `Temporal.ZonedDateTime` back to storage format.
-
-**`DateTimeString.is(value)`**
-
-Type guard to check if a value is a valid DateTimeString.
-
-### Validation
+### Storage keys
 
 ```typescript
 import {
-	createTableValidators,
-	createWorkspaceValidators,
-	type TableValidators,
-	type WorkspaceValidators,
+	KV_KEY,
+	TableKey,
+	type KvKey,
+	type TableKeyType,
 } from '@epicenter/workspace';
 ```
 
-**`createTableValidators<TSchema>(schema)`**
+These matter when you are writing low-level tooling against raw Yjs structures.
 
-Create validators for a table schema.
-
-**`createWorkspaceValidators<TSchema>(schema)`**
-
-Create validators for all tables in a workspace.
-
-### Error Types
+### Drizzle re-exports
 
 ```typescript
 import {
-	EpicenterOperationErr,
-	IndexErr,
-	ValidationErr,
-	type EpicenterOperationError,
-	type IndexError,
-	type ValidationError,
-} from '@epicenter/workspace';
-```
-
-**Error constructors:**
-
-- `EpicenterOperationErr({ message, context, cause })`: General operation errors
-- `IndexErr({ message, context, cause })`: Index sync errors
-- `ValidationErr({ message, context, cause })`: Schema validation errors
-
-### Drizzle Re-exports
-
-```typescript
-import {
+	and,
+	asc,
+	desc,
 	eq,
-	ne,
 	gt,
 	gte,
+	inArray,
+	isNotNull,
+	isNull,
+	like,
 	lt,
 	lte,
-	and,
-	or,
+	ne,
 	not,
-	like,
-	inArray,
-	isNull,
-	isNotNull,
+	or,
 	sql,
-	desc,
-	asc,
 } from '@epicenter/workspace';
 ```
 
-Commonly used Drizzle operators for querying SQLite provider.
-
-### Server
-
-```typescript
-import { createServer } from '@epicenter/workspace';
-
-// Single workspace
-const server = createServer(blogClient, { port: 3913 });
-
-// Multiple workspaces (IDs from workspace definitions)
-const server = createServer([blogClient, authClient], { port: 3913 });
-
-server.start();
-```
-
-**`createServer(client | clients, options?)`**
-
-Create an HTTP server from workspace clients. Exposes:
-
-- REST endpoints for actions: `/workspaces/{id}/actions/{action}`
-- Table CRUD: `/workspaces/{id}/tables/{table}`
-- WebSocket sync: `/rooms/{id}`
-- OpenAPI documentation: `/openapi`
+These are convenience re-exports for extension code and mirror/query packages that already depend on Drizzle.
 
 ## MCP Integration
 
-Epicenter workspaces can be exposed as MCP (Model Context Protocol) servers for AI assistant integration.
+The core package does not export an MCP server. What it does export is the metadata you need to build one.
 
-### HTTP Transport Only
+The current pieces are:
 
-Epicenter uses HTTP transport exclusively, not stdio. This is intentional:
+- actions with `type`, `title`, `description`, and `input`
+- `iterateActions(...)` to flatten a nested action tree
+- `describeWorkspace(...)` for schema introspection
+- `standardSchemaToJsonSchema(...)` for schema conversion where supported
 
-**Why not stdio?**
-
-stdio spawns a new process per AI session, which creates problems:
-
-- Expensive cold starts (initialize YJS, build providers, parse files)
-- File system conflicts (multiple watchers, SQLite locks)
-- No shared state (wasted memory, duplicate work)
-
-**Why HTTP?**
-
-A long-running HTTP server models Epicenter's folder-based architecture:
-
-- Initialize once, serve many sessions
-- Share state across all AI assistants
-- Handle file watching without conflicts
-- Efficient resource usage
-
-### Route Handling
-
-Workspace actions are exposed via REST endpoints under the `/workspaces` prefix:
-
-**Query Actions** (HTTP GET):
-
-- Path: `/workspaces/{workspaceId}/{actionName}`
-- Input: Query string parameters
-
-**Mutation Actions** (HTTP POST):
-
-- Path: `/workspaces/{workspaceId}/{actionName}`
-- Input: JSON request body
-
-**URL Hierarchy:**
-
-```
-/                                    - API root/discovery
-/openapi                             - OpenAPI spec (JSON)
-/scalar                              - Scalar UI documentation
-/mcp                                 - MCP endpoint
-/signaling                           - WebRTC signaling WebSocket
-/workspaces/{workspaceId}/{action}   - Workspace actions
-```
+That is enough to build adapters that expose workspace actions over HTTP, CLI, or MCP without coupling the core package to one transport.
 
 ### Setup
 
 ```typescript
-import { createWorkspace, createServer } from '@epicenter/workspace';
+import Type from 'typebox';
+import {
+	defineMutation,
+	defineQuery,
+	iterateActions,
+	type Actions,
+} from '@epicenter/workspace';
 
-// Create workspaces with extensions
-const blogClient = createWorkspace(blogWorkspace)
-	.withExtension('sqlite', sqliteProvider);
+const actions: Actions = {
+	posts: {
+		list: defineQuery({
+			title: 'List Posts',
+			description: 'List all posts.',
+			handler: () => [] as Array<{ id: string; title: string }>,
+		}),
 
-const authClient = createWorkspace(authWorkspace)
-	.withExtension('sqlite', sqliteProvider);
+		create: defineMutation({
+			title: 'Create Post',
+			description: 'Create a post.',
+			input: Type.Object({ title: Type.String() }),
+			handler: ({ title }) => ({ id: title.toLowerCase() }),
+		}),
+	},
+};
 
-// Create and start server
-const server = createServer([blogClient, authClient], { port: 3913 });
-server.start();
-console.log('Server running on http://localhost:3913');
+for (const [action, path] of iterateActions(actions)) {
+	console.log({
+		name: path.join('.'),
+		type: action.type,
+		title: action.title,
+		description: action.description,
+		hasInput: action.input !== undefined,
+	});
+}
 ```
 
-AI assistants connect via HTTP, with no cold start penalty.
+That is the public adapter surface today.
 
 ## Contributing
 
-### Local Development
+### Local development
 
-If you're working on the Epicenter package, test it locally using `bun link`:
+From the repo root:
 
 ```bash
-# Install dependencies (from repository root)
 bun install
-
-# One-time setup: Link the package globally
-cd packages/workspace
-bun link
-
-# Now use from any directory
-cd examples/content-hub
-epicenter --help
-epicenter blog createPost --title "Test"
-
-# When done testing
-cd packages/workspace
-bun unlink
 ```
 
-**Alternative:** Use local `cli.ts` in examples:
+Type-check the workspace package itself:
 
 ```bash
-cd examples/content-hub
-bun cli.ts --help
-bun cli.ts blog createPost --title "Test"
+bun run typecheck
 ```
 
-### Running Tests
+If you're working on the package from another local project, use Bun's normal workspace linking flow. Nothing about the current API requires a special README-only workflow.
+
+### Running tests
+
+From the repo root:
 
 ```bash
-# Run all tests
-bun test
-
-# Run specific workspace tests
-cd examples/content-hub
-bun test
+bun test packages/workspace
 ```
 
-### More Information
+Or run the package test suite directly from `packages/workspace` if you prefer the local context.
 
-See [CONTRIBUTING.md](../../CONTRIBUTING.md) for complete development setup and guidelines.
+### More information
+
+Useful internal docs live nearby:
+
+- `src/workspace/README.md` — mental model for the lower-level workspace layer
+- `docs/` — package-specific architecture notes
+- `specs/` — historical design docs and implementation specs
 
 ## License
 
-AGPL-3.0
+MIT

--- a/specs/20260407T120000-launch-readiness.md
+++ b/specs/20260407T120000-launch-readiness.md
@@ -1,0 +1,111 @@
+# Launch Readiness: Versioning, Publishing, and Public Surface Fixes
+
+**Date**: 2026-04-07
+**Status**: In Progress
+**Author**: AI-assisted
+
+## Overview
+
+Prepare Epicenter for public launch on Twitter/HN by fixing the four P0 blockers: outdated workspace README, non-publishable npm packages, "not yet implemented" UI strings, and landing page conversion gaps.
+
+## Motivation
+
+### Current State
+
+The codebase is feature-complete for a first public impression, but the surfaces people actually touch—README, npm install, landing page, app UI—have gaps that will be called out immediately on HN.
+
+Problems:
+
+1. **Workspace README references dead API**: `createClient`, `withDefinition`, `upsert`, `createServer`, `providers/setupPersistence`—none exist anymore. Actual API is `createWorkspace`, `client.tables.<name>.set/get/update/delete`.
+2. **npm packages aren't publishable**: `@epicenter/workspace` isn't on npm. CLI has `workspace:*` and `catalog:` deps that break externally. No changeset tooling.
+3. **"Not yet implemented" in shipped UI**: `alert('Live recording not yet implemented')` in Whispering layout, `// TODO: Implement form submission` in landing waitlist form.
+4. **Landing page won't convert HN visitors**: No quickstart code block, no FAQ, blog posts from Jan 2025 only.
+
+### Desired State
+
+- README matches the real API with working code examples
+- `bun add @epicenter/workspace` works and the code in README runs
+- No user-visible TODO/WIP strings
+- Landing page has technical credibility (code snippets, FAQ)
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Versioning scope | All packages/ unified at 0.1.0 | Simplicity. One version, one release. `private: true` prevents npm publish for internal packages. |
+| Version tooling | Changesets | Industry standard for Bun/pnpm monorepos. |
+| CLI runtime | Bun-only | Matches the stack. `bin` points to `.ts` files. Document requirement. |
+| Public packages | workspace, cli, sync, filesystem, skills, ui, svelte | UI and Svelte bindings enable ecosystem development. |
+| Private packages | constants, ai, vault | No standalone value or not ready (vault at 0.0.0). |
+| Apps versioning | Independent, via deploy mechanisms | Apps are `private: true`, deployed to CF/Tauri/Chrome. |
+| Landing page framework | Keep Astro + Svelte islands | Already works, uses @epicenter/ui components. |
+
+## Implementation Plan
+
+### Phase 1: README Rewrite (P0-A)
+
+- [ ] **1.1** Read `packages/workspace/src/index.ts` exports to inventory the real public API
+- [ ] **1.2** Read key source files: `create-workspace.ts`, `create-table.ts`, `types.ts`, `actions.ts`
+- [ ] **1.3** Rewrite README Quick Start with working `createWorkspace` + `defineTable` example
+- [ ] **1.4** Update all table operation examples: `set`, `get`, `update`, `delete`, `getAll`, `observe`
+- [ ] **1.5** Update extension examples to use `withExtension` pattern (not `providers` map)
+- [ ] **1.6** Update action examples: `defineQuery`, `defineMutation` with current signatures
+- [ ] **1.7** Remove references to `createClient`, `withDefinition`, `upsert`, `createServer`, `providers/setupPersistence`
+- [ ] **1.8** Verify every code block compiles against current types
+
+### Phase 2: npm Publish Readiness (P0-B)
+
+- [ ] **2.1** Install and configure changesets: `bunx changeset init`
+- [ ] **2.2** Set all package versions to `0.1.0`
+- [ ] **2.3** Add `description`, `keywords`, `repository`, `homepage` to all publishable package.json files
+- [ ] **2.4** Mark `constants`, `ai`, `vault` as `"private": true` (constants already is)
+- [ ] **2.5** Remove `"private": true` from `ui` and `svelte` packages
+- [ ] **2.6** Verify `workspace:*` deps resolve correctly for npm publish (changesets handles this)
+- [ ] **2.7** Verify `catalog:` deps are replaced with actual versions at publish time
+- [ ] **2.8** Add root `release` script: `"release": "changeset version && changeset publish"`
+- [ ] **2.9** Test publish with `--dry-run`
+
+### Phase 3: UI TODO Removal (P0-C)
+
+- [ ] **3.1** Remove `alert('Live recording not yet implemented')` from `apps/whispering/src/routes/(app)/(config)/+layout.svelte:132` — either implement or remove the toggle entirely
+- [ ] **3.2** Fix `WaitlistForm.svelte` — either wire to a real endpoint (Discord webhook, Resend, etc.) or remove the TODO and show a Discord join link instead
+- [ ] **3.3** Remove `// TODO: Implement real extension detection` from `apps/whispering/src/lib/services/notifications/web.ts`
+
+### Phase 4: Landing Page Improvements (P0-D)
+
+- [ ] **4.1** Add quickstart code block section after hero (terminal-style `bun add` + minimal example)
+- [ ] **4.2** Add FAQ section before footer (3-5 questions HN will ask: "How is this different from Obsidian?", "Is my data encrypted?", "Can I self-host?")
+- [ ] **4.3** Add OG image meta tag to `BaseLayout.astro` (og:image is missing)
+- [ ] **4.4** Update bottom CTA section: swap primary to GitHub, secondary to Discord (hero is already correct)
+
+## Open Questions
+
+1. **WaitlistForm — wire or remove?**
+   - Options: (a) Wire to Discord webhook, (b) Wire to Resend/email list, (c) Replace with Discord invite button
+   - **Recommendation**: (c) Replace with Discord invite. Simplest, no backend needed, matches existing CTA pattern.
+
+2. **Live recording toggle — implement or hide?**
+   - Options: (a) Implement live recording, (b) Hide the toggle, (c) Show as "coming soon" badge
+   - **Recommendation**: (b) Hide the toggle. Don't ship half-baked features.
+
+## Success Criteria
+
+- [ ] `bun add @epicenter/workspace` works (package exists on npm)
+- [ ] README Quick Start code compiles and runs without errors
+- [ ] No `alert()` with "not implemented" in any shipped UI
+- [ ] Landing page has a code snippet section visible within first scroll
+- [ ] `bunx changeset version` and `bunx changeset publish --dry-run` succeed
+
+## References
+
+- `packages/workspace/README.md` — Primary rewrite target
+- `packages/workspace/src/index.ts` — Source of truth for public API
+- `packages/workspace/src/workspace/create-workspace.ts` — Builder pattern implementation
+- `packages/workspace/src/workspace/create-table.ts` — Table operations
+- `packages/workspace/src/workspace/types.ts` — Type definitions
+- `packages/workspace/package.json` — Exports map and metadata
+- `packages/cli/package.json` — CLI metadata and bin field
+- `apps/landing/src/pages/index.astro` — Landing page homepage
+- `apps/landing/src/layouts/BaseLayout.astro` — Meta tags
+- `apps/landing/src/components/WaitlistForm.svelte` — Broken form
+- `apps/whispering/src/routes/(app)/(config)/+layout.svelte` — "Not implemented" alert


### PR DESCRIPTION
Before this PR, the workspace README was 1249 lines of API docs that no longer matched the actual API. The `defineWorkspace` / `createClient` pattern had evolved, but the docs still showed the old shape. New contributors would read it, try to follow along, and hit errors immediately. The contributing guide didn't exist. There was no release strategy written down anywhere. No positioning doc. No technical articles. Nothing that would make a new contributor or early user feel like this project was ready.

This PR fixes that across the board.

The workspace README was rewritten from scratch. The old version documented a `createWorkspace()` call that returned a flat object with methods hanging directly off it. The new API is layered: you define a schema with `defineWorkspace`, then instantiate it with `createClient`, and the resulting client gives you typed table accessors. The old docs showed something like:

```ts
// Old (no longer accurate)
const workspace = createWorkspace({ tables: [...] })
workspace.insert('notes', { id: '1', content: 'hello' })
```

The new README shows the actual pattern:

```ts
// Current API
const schema = defineWorkspace({
  tables: { notes: notesTable },
})

const client = createClient(schema, { storage })
await client.notes.insert({ id: '1', content: 'hello' })
const all = await client.notes.getAll()
```

That's not a cosmetic change—it's a different mental model. The new README walks through it with working examples throughout.

A CONTRIBUTING.md landed alongside it: setup instructions, PR conventions, and a short architecture overview so contributors know where things live before they start digging. A `docs/articles/release-strategy.md` documents the versioning approach (unified version across all packages, changesets, fixed group). A `specs/20260407T120000-launch-readiness.md` is the planning checklist that drove this whole batch of work. A `.github/workflows/README.md` explains the CI pipeline. A `docs/positioning.md` defines what Epicenter is and isn't—the kind of document that should exist before you tell anyone about the project.

One of the more interesting additions is a technical article on a Svelte 5 gotcha. When you initialize `$state` from a prop, Svelte warns about `state_referenced_locally`:

```svelte
<!-- Triggers state_referenced_locally warning -->
let { initialValue } = $props();
let value = $state(initialValue);
```

The fix is writable `$derived`, which both silences the warning and correctly tracks parent updates:

```svelte
<!-- Clean, no warning, tracks parent changes -->
let { initialValue } = $props();
let value = $derived(initialValue);
```

The article explains why this works and when you'd actually want it. It lives in `docs/articles/`.

The docs that landed in this PR, roughly:

```
packages/workspace/README.md       (rewritten, 1088 lines)
CONTRIBUTING.md                    (new)
docs/
  articles/
    release-strategy.md            (new)
    svelte-5-writable-derived-...  (new)
  positioning.md                   (new)
specs/
  20260407T120000-launch-readiness.md  (new)
.github/workflows/README.md        (new)
apps/
  opensidian/README.md             (new)
  landing/src/content/blog/...     (draft blog post)
```

The writing-voice skill got an "empathy for the reader" section, and a blog post draft about second-brain infrastructure came along for the ride.

11 files, roughly 1800 lines added—mostly prose, not code.