### PR TITLE
refactor(ai): collapse actionsToClientTools + toToolDefinitions into actionsToAiTools

### DIFF
--- a/apps/opensidian/src/lib/client.ts
+++ b/apps/opensidian/src/lib/client.ts
@@ -1,4 +1,4 @@
-import { actionsToClientTools, toToolDefinitions } from '@epicenter/ai';
+import { actionsToAiTools } from '@epicenter/ai';
 import { APP_URLS } from '@epicenter/constants/vite';
 import { createSqliteIndex, createYjsFileSystem } from '@epicenter/filesystem';
 import { createSkillsWorkspace } from '@epicenter/skills';
@@ -214,27 +214,13 @@ export const auth = createAuth({
 });
 
 /**
- * Workspace actions converted to TanStack AI client tools.
+ * Workspace actions converted to AI tool representations.
  *
- * Each action becomes a client-side tool with `__toolSide: 'client'` and
- * its handler wired as the `execute` function. Queries auto-execute;
- * mutations trigger the approval UI.
- *
- * Passed to `createChat({ tools: workspaceTools })` for local execution.
+ * `clientTools` — passed to `createChat({ tools })` for local auto-execution.
+ * `definitions` — sent to the server as wire-safe JSON in the request body.
  */
-export const workspaceTools = actionsToClientTools(workspace.actions);
-
-/**
- * Wire-safe tool definitions stripped for the HTTP request body.
- *
- * Removes `execute` functions (not JSON-serializable) and normalizes
- * input schemas for provider compatibility (Anthropic requires
- * `properties` + `required` on every schema).
- *
- * Sent to the server in `body.data.tools` so `chat()` knows what
- * tools exist without needing them hardcoded.
- */
-export const workspaceDefinitions = toToolDefinitions(workspaceTools);
+export const { clientTools: workspaceTools, definitions: workspaceDefinitions } =
+	actionsToAiTools(workspace.actions);
 
 /** All workspace tool names as a type union. */
 export type WorkspaceTools = typeof workspaceTools;

--- a/apps/tab-manager/src/lib/client.ts
+++ b/apps/tab-manager/src/lib/client.ts
@@ -9,7 +9,7 @@
  * the sole authority for ephemeral browser state. See `browser-state.svelte.ts`.
  */
 
-import { actionsToClientTools, toToolDefinitions } from '@epicenter/ai';
+import { actionsToAiTools } from '@epicenter/ai';
 import { createAuth } from '@epicenter/svelte/auth';
 import {
 	defineMutation,
@@ -53,8 +53,8 @@ export const auth = createAuth({
 	},
 });
 
-export const workspaceTools = actionsToClientTools(workspace.actions);
-export const workspaceDefinitions = toToolDefinitions(workspaceTools);
+export const { clientTools: workspaceTools, definitions: workspaceDefinitions } =
+	actionsToAiTools(workspace.actions);
 
 export type WorkspaceTools = typeof workspaceTools;
 export type WorkspaceActionName = WorkspaceTools[number]['name'];

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -1,6 +1,5 @@
 export {
 	type ActionNames,
-	actionsToClientTools,
+	actionsToAiTools,
 	type ToolDefinitionPayload,
-	toToolDefinitions,
 } from './tool-bridge';

--- a/packages/ai/src/tool-bridge.test.ts
+++ b/packages/ai/src/tool-bridge.test.ts
@@ -5,101 +5,101 @@
 
 import { describe, expect, test } from 'bun:test';
 import { defineMutation, defineQuery } from '@epicenter/workspace';
-import { actionsToClientTools, toToolDefinitions } from './tool-bridge.js';
+import { actionsToAiTools } from './tool-bridge.js';
 
-describe('actionsToClientTools', () => {
-	test('all mutations get needsApproval', () => {
-		const actions = {
-			tabs: {
-				close: defineMutation({
-					title: 'Close Tabs',
-					description: 'Close tabs',
+describe('actionsToAiTools', () => {
+	describe('clientTools', () => {
+		test('all mutations get needsApproval', () => {
+			const actions = {
+				tabs: {
+					close: defineMutation({
+						title: 'Close Tabs',
+						description: 'Close tabs',
+						handler: () => {},
+					}),
+					open: defineMutation({
+						title: 'Open Tab',
+						description: 'Open a tab',
+						handler: () => {},
+					}),
+				},
+			};
+
+			const { clientTools } = actionsToAiTools(actions);
+
+			const closeTool = clientTools.find((t) => t.name === 'tabs_close');
+			expect(closeTool).toBeDefined();
+			expect(closeTool?.needsApproval).toBe(true);
+
+			const openTool = clientTools.find((t) => t.name === 'tabs_open');
+			expect(openTool).toBeDefined();
+			expect(openTool?.needsApproval).toBe(true);
+		});
+
+		test('queries omit needsApproval entirely', () => {
+			const actions = {
+				query: defineQuery({
+					title: 'Query',
+					description: 'Query data',
 					handler: () => {},
 				}),
-				open: defineMutation({
-					title: 'Open Tab',
-					description: 'Open a tab',
+				mutation: defineMutation({
+					title: 'Mutation',
+					description: 'Mutate data',
 					handler: () => {},
 				}),
-			},
-		};
+			};
 
-		const tools = actionsToClientTools(actions);
+			const { clientTools } = actionsToAiTools(actions);
 
-		const closeTool = tools.find((t) => t.name === 'tabs_close');
-		expect(closeTool).toBeDefined();
-		expect(closeTool?.needsApproval).toBe(true);
+			const queryTool = clientTools.find((t) => t.name === 'query');
+			expect(queryTool).toBeDefined();
+			expect('needsApproval' in queryTool!).toBe(false);
 
-		const openTool = tools.find((t) => t.name === 'tabs_open');
-		expect(openTool).toBeDefined();
-		expect(openTool?.needsApproval).toBe(true);
+			const mutationTool = clientTools.find((t) => t.name === 'mutation');
+			expect(mutationTool).toBeDefined();
+			expect(mutationTool?.needsApproval).toBe(true);
+		});
 	});
 
-	test('queries omit needsApproval entirely', () => {
-		const actions = {
-			query: defineQuery({
-				title: 'Query',
-				description: 'Query data',
-				handler: () => {},
-			}),
-			mutation: defineMutation({
-				title: 'Mutation',
-				description: 'Mutate data',
-				handler: () => {},
-			}),
-		};
+	describe('definitions', () => {
+		test('produces wire-safe definitions', () => {
+			const actions = {
+				search: defineQuery({
+					title: 'Search',
+					description: 'Search stuff',
+					handler: () => {},
+				}),
+			};
 
-		const tools = actionsToClientTools(actions);
+			const { definitions } = actionsToAiTools(actions);
 
-		const queryTool = tools.find((t) => t.name === 'query');
-		expect(queryTool).toBeDefined();
-		expect('needsApproval' in queryTool!).toBe(false);
+			expect(definitions).toHaveLength(1);
+			expect(definitions[0]?.name).toBe('search');
+			expect(definitions[0]?.description).toBe('Search stuff');
+		});
 
-		const mutationTool = tools.find((t) => t.name === 'mutation');
-		expect(mutationTool).toBeDefined();
-		expect(mutationTool?.needsApproval).toBe(true);
-	});
-});
+		test('forwards needsApproval for all mutations, not queries', () => {
+			const actions = {
+				save: defineMutation({
+					title: 'Save',
+					description: 'Save action',
+					handler: () => {},
+				}),
+				safe: defineQuery({
+					title: 'Safe',
+					description: 'Safe action',
+					handler: () => {},
+				}),
+			};
 
-describe('toToolDefinitions', () => {
-	test('produces wire-safe definitions', () => {
-		const actions = {
-			search: defineQuery({
-				title: 'Search',
-				description: 'Search stuff',
-				handler: () => {},
-			}),
-		};
+			const { definitions } = actionsToAiTools(actions);
 
-		const tools = actionsToClientTools(actions);
-		const definitions = toToolDefinitions(tools);
+			const saveDef = definitions.find((d) => d.name === 'save');
+			expect(saveDef?.needsApproval).toBe(true);
 
-		expect(definitions).toHaveLength(1);
-		expect(definitions[0]?.name).toBe('search');
-		expect(definitions[0]?.description).toBe('Search stuff');
-	});
-
-	test('forwards needsApproval for all mutations, not queries', () => {
-		const actions = {
-			save: defineMutation({
-				title: 'Save',
-				description: 'Save action',
-				handler: () => {},
-			}),
-			safe: defineQuery({
-				title: 'Safe',
-				description: 'Safe action',
-				handler: () => {},
-			}),
-		};
-
-		const tools = actionsToClientTools(actions);
-		const definitions = toToolDefinitions(tools);
-
-		const saveDef = definitions.find((d) => d.name === 'save');
-		expect(saveDef?.needsApproval).toBe(true);
-
-		const safeDef = definitions.find((d) => d.name === 'safe');
-		expect('needsApproval' in safeDef!).toBe(false);
+			const safeDef = definitions.find((d) => d.name === 'safe');
+			expect('needsApproval' in safeDef!).toBe(false);
+		});
 	});
 });

--- a/packages/ai/src/tool-bridge.ts
+++ b/packages/ai/src/tool-bridge.ts
@@ -58,16 +58,14 @@ export type ActionNames<T extends Actions> = {
  * `execute` are treated as client tools whose calls get forwarded back to the browser.
  *
  * ```
- * ┌─ actionsToClientTools ─────────────┐     ┌─ toToolDefinitions ─────────────┐
+ * ┌─ clientTools ───────────────────────┐     ┌─ definitions ───────────────────┐
  * │ AnyClientTool (kept in browser)    │     │ ToolDefinitionPayload (wire)    │
  * │                                    │     │                                 │
  * │ __toolSide: 'client'  ──── skip ───┼──►  │                                 │
  * │ name                  ── forward ──┼──►  │ name                            │
  * │ description           ── forward ──┼──►  │ description                     │
  * │ inputSchema?          ── normalize ┼──►  │ inputSchema? (+ properties/req) │
- * │ outputSchema?         ── forward ──┼──►  │ outputSchema?                   │
  * │ needsApproval?        ── forward ──┼──►  │ needsApproval?                  │
- * │ metadata?             ── forward ──┼──►  │ metadata?                       │
  * │ execute               ──── skip ───┼──►  │                                 │
  * └────────────────────────────────────┘     └─────────────────────────────────┘
  * ```
@@ -79,14 +77,10 @@ export type ActionNames<T extends Actions> = {
  * - **`inputSchema`** — The LLM uses this to generate valid arguments. Normalized
  *   with `properties` and `required` guaranteed present because some providers
  *   (notably Anthropic) reject schemas missing those fields.
- * - **`outputSchema`** — Enables server-side output validation. TanStack AI's
- *   `executeToolCalls` validates results against this when present.
  * - **`needsApproval`** — Present on all mutations. Queries never need approval.
  *   The server's `executeToolCalls` checks this to decide whether to send an
  *   `APPROVAL_REQUESTED` event or a direct `TOOL_CALL` event. Without it,
  *   actions auto-execute with no approval dialog.
- * - **`metadata`** — Pass-through `Record<string, unknown>` for server-side
- *   routing, logging, or future TanStack AI features.
  *
  * ### Fields intentionally excluded
  *
@@ -100,9 +94,7 @@ export type ToolDefinitionPayload = {
 	title?: string;
 	description: string;
 	inputSchema?: NormalizedJsonSchema;
-	outputSchema?: JSONSchema;
 	needsApproval?: boolean;
-	metadata?: Record<string, unknown>;
 };
 
 // ---------------------------------------------------------------------------
@@ -110,31 +102,42 @@ export type ToolDefinitionPayload = {
 // ---------------------------------------------------------------------------
 
 /**
- * Convert a workspace action tree into client-side AI tools.
+ * Convert a workspace action tree into both AI tool representations at once.
  *
- * Each action becomes a `ClientTool` with `__toolSide: 'client'` and its
- * handler wired as the `execute` function. Tool names are path segments
- * joined with `_` (e.g. `tabs_search`, `windows_list`).
+ * Returns two parallel arrays derived from the same action tree:
  *
- * The returned tools serve two purposes:
- * 1. Passed to `ChatClientOptions.tools` for local auto-execution.
- * 2. Passed to {@link toToolDefinitions} to create the wire payload.
+ * - **`clientTools`** — `AnyClientTool[]` with `execute` wired to action handlers.
+ *   Pass to `ChatClientOptions.tools` for local auto-execution.
+ * - **`definitions`** — `ToolDefinitionPayload[]` stripped of runtime-only fields
+ *   (`execute`, `__toolSide`) and with schemas normalized for provider compatibility.
+ *   Send to the server as JSON in the request body.
+ *
+ * Tool names are path segments joined with `_` (e.g. `tabs_search`, `files_read`).
+ * Mutations automatically get `needsApproval: true`; queries omit it entirely.
+ *
+ * Input schemas are normalized for provider compatibility: `properties` and
+ * `required` are guaranteed present (Anthropic rejects schemas without them).
  *
  * @example
  * ```ts
- * const tools = actionsToClientTools(workspace.actions);
+ * const { clientTools, definitions } = actionsToAiTools(workspace.actions);
  *
  * // Use locally in ChatClient
- * const chat = createChat({ tools, connection: ... });
+ * const chat = createChat({ tools: clientTools, connection: ... });
  *
  * // Send definitions to server in the request body
- * const definitions = toToolDefinitions(tools);
+ * fetch('/chat', { body: JSON.stringify({ tools: definitions }) });
  * ```
  */
-export function actionsToClientTools<TActions extends Actions>(
+export function actionsToAiTools<TActions extends Actions>(
 	actions: TActions,
-): (AnyClientTool & { name: ActionNames<TActions> })[] {
-	return [...iterateActions(actions)].map(([action, path]) => ({
+): {
+	clientTools: (AnyClientTool & { name: ActionNames<TActions> })[];
+	definitions: ToolDefinitionPayload[];
+} {
+	const entries = [...iterateActions(actions)];
+
+	const clientTools = entries.map(([action, path]) => ({
 		__toolSide: 'client' as const,
 		name: path.join(ACTION_NAME_SEPARATOR) as ActionNames<TActions>,
 		description: action.description ?? `${action.type}: ${path.join('.')}`,
@@ -142,49 +145,23 @@ export function actionsToClientTools<TActions extends Actions>(
 		...(action.type === 'mutation' && { needsApproval: true }),
 		execute: async (args: unknown) => (action.input ? action(args) : action()),
 	}));
-}
 
-/**
- * Strip client tools to wire-safe definitions for the HTTP request body.
- *
- * Removes runtime-only fields (`execute`, `__toolSide`) and forwards everything
- * the server needs to pass to `chat({ tools })`. The server receives these as
- * plain JSON and uses them directly—no reconstruction needed.
- *
- * Input schemas are normalized for provider compatibility: `properties` and
- * `required` are guaranteed present (Anthropic rejects schemas without them).
- *
- * @see {@link ToolDefinitionPayload} for per-field rationale on what's forwarded and why.
- *
- * @example
- * ```ts
- * const tools = actionsToClientTools(workspace.actions);
- * const definitions = toToolDefinitions(tools);
- * // [{ name: 'tabs_search', description: '...', inputSchema?: { ... }, needsApproval?: true }]
- * ```
- */
-export function toToolDefinitions(
-	tools: readonly AnyClientTool[],
-): ToolDefinitionPayload[] {
-	return tools.map((tool) => ({
-		name: tool.name,
-		description: tool.description,
-		// Safe cast: our action system only accepts TypeBox schemas (TSchema),
-		// which ARE plain JSON Schema objects. AnyClientTool widens the type to
-		// SchemaInput (JSONSchema | StandardJSONSchemaV1), but only TypeBox flows
-		// through actionsToClientTools.
-		...(tool.inputSchema && {
-			inputSchema: normalizeSchema(tool.inputSchema as JSONSchema),
+	// Derive wire definitions directly from actions—avoids the type-widening
+	// round-trip through AnyClientTool that required `as JSONSchema` casts.
+	const definitions: ToolDefinitionPayload[] = entries.map(
+		([action, path]) => ({
+			name: path.join(ACTION_NAME_SEPARATOR),
+			description: action.description ?? `${action.type}: ${path.join('.')}`,
+			// Safe cast: workspace actions only accept TypeBox schemas (TSchema),
+			// which ARE plain JSON Schema objects at runtime.
+			...(action.input && {
+				inputSchema: normalizeSchema(action.input as JSONSchema),
+			}),
+			...(action.type === 'mutation' && { needsApproval: true }),
 		}),
-		...(tool.outputSchema && {
-			outputSchema: tool.outputSchema as JSONSchema,
-		}),
-		...(tool.needsApproval && {
-			needsApproval: true,
-		}),
-		...('metadata' in tool &&
-			tool.metadata && { metadata: tool.metadata as Record<string, unknown> }),
-	}));
+	);
+
+	return { clientTools, definitions };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Both callsites in the repo—tab-manager and opensidian—always called `actionsToClientTools` then immediately fed the result into `toToolDefinitions`. The intermediate array was also used directly by `ChatClient`, so both outputs were needed, but the two-step pipeline was choreography every consumer had to remember:

```typescript
// Before: two-step pipeline
const tools = actionsToClientTools(workspace.actions);
const defs = toToolDefinitions(tools);
```

```typescript
// After: single call, destructure both
const { clientTools, definitions } = actionsToAiTools(workspace.actions);
```

Collapsing into one function also eliminates a type-widening round-trip. The old `toToolDefinitions` accepted `readonly AnyClientTool[]` (the TanStack AI base type), which widened `inputSchema` to `SchemaInput`—forcing `as JSONSchema` casts to narrow it back. The new function derives definitions directly from the action entries, so the cast goes straight from `action.input` (TypeBox `TSchema`) to `JSONSchema` without the intermediate widening.

The name change from `actionsToClientTools` to `actionsToAiTools` drops TanStack-specific jargon ("client tools") from the public API surface. Consumers importing from `@epicenter/ai` don't need to know about TanStack's internal type hierarchy—they need "give me AI tools from my actions."

All 4 existing tests pass under the new API, restructured into `clientTools` and `definitions` describe blocks.