### PR TITLE
docs: README overhaul — architecture diagram, package map, and 7 new docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ yarn-error.log*
 
 # Reddit exports (personal data)
 reddit_export.zip
+
+# Temporary search clones (development only)
+tmp-search/

--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@
 
 <p align="center">
   <a href="#apps">Apps</a> •
+  <a href="#architecture">Architecture</a> •
+  <a href="#packages">Packages</a> •
   <a href="#for-developers">For Developers</a> •
-  <a href="#where-were-headed">Vision</a> •
+  <a href="#quick-start">Quick Start</a> •
   <a href="#contributing">Contributing</a> •
   <a href="https://go.epicenter.so/discord">Discord</a>
 </p>
@@ -51,6 +53,48 @@ Epicenter is an ecosystem of open-source, local-first apps. All your data—note
 Under the hood, Yjs CRDTs are the single source of truth. They materialize *down* to SQLite (for fast queries) and markdown (for human-readable files). Sync happens over the Yjs protocol; the server is a relay, not an authority—it never sees your content.
 
 The library that powers this, [`@epicenter/workspace`](packages/workspace), is something other developers can build on too. Define a typed schema, get CRDT-backed tables with multi-device sync handled for you.
+
+## Architecture
+
+```
+                              ┌──────────────────────────────────┐
+                              │         @epicenter/api           │
+                              │   Cloudflare Workers + DO hub    │
+                              │   auth · sync relay · AI chat    │
+                              └──────────┬───────────────────────┘
+                                         │ y-websocket protocol
+                    ┌────────────────────┼──────────────────────┐
+                    │                    │                      │
+               ┌────▼──────┐      ┌─────▼───────┐      ┌──────▼──────┐
+               │ Whispering│      │  Opensidian  │      │ Tab Manager │
+               │  (Tauri)  │      │ (SvelteKit)  │      │  (WXT ext)  │
+               └────┬──────┘      └─────┬────────┘      └──────┬──────┘
+                    │                    │                      │
+          ┌─────────┴────────────────────┴──────────────────────┘
+          │              All apps share these layers:
+          │
+    ┌─────▼───────────────────────────────────────────────────────────┐
+    │                     MIDDLEWARE / ADAPTERS                        │
+    │  @epicenter/svelte    — Svelte integration, auth, persistence   │
+    │  @epicenter/filesystem — POSIX file layer over Yjs              │
+    │  @epicenter/skills    — skill/reference tables                  │
+    │  @epicenter/ai        — LLM tool bridging                      │
+    └─────────────────────────────┬───────────────────────────────────┘
+                                  │
+    ┌──────────────────────────────▼───────────────────────────────────┐
+    │                           CORE                                   │
+    │  @epicenter/workspace — typed schemas, Yjs CRDTs, extensions,   │
+    │                         E2E encryption, lifecycle, materializers │
+    │  @epicenter/sync      — protocol encoding/decoding, V2 updates  │
+    │  @epicenter/constants — app URLs, versions, shared config       │
+    │  @epicenter/ui        — shadcn-svelte component library         │
+    │  @epicenter/cli       — TypeBox→yargs CLI, auth/session APIs    │
+    └─────────────────────────────────────────────────────────────────┘
+```
+
+The dependency flow is strict: core has zero upward dependencies, middleware only reaches into core, and apps compose both. [`@epicenter/workspace`](packages/workspace) is the gravitational center—every middleware package and most apps depend on it. The sync server is a relay, not an authority; it never sees your content because encryption happens client-side before anything leaves the device.
+
+[Full architecture walkthrough →](docs/architecture.md) · [Encryption design →](docs/encryption.md)
 
 ## Apps
 
@@ -80,6 +124,20 @@ The library that powers this, [`@epicenter/workspace`](packages/workspace), is s
   </tr>
 </table>
 
+## Packages
+
+| Package | Description | License |
+| --- | --- | --- |
+| [`@epicenter/workspace`](packages/workspace) | Core library. Typed schemas, Yjs CRDTs, extension builder, E2E encryption, materializers. Everything builds on this. | MIT |
+| [`@epicenter/sync`](packages/sync) | Yjs sync protocol encoding/decoding. Dumb server, smart client—protocol framing is separate from transport. | AGPL-3.0 |
+| [`@epicenter/ui`](packages/ui) | shadcn-svelte component library shared across all apps. | MIT |
+| [`@epicenter/svelte`](packages/svelte-utils) | Svelte 5 integration—persisted state, auth, workspace gate, TanStack Query helpers. | MIT |
+| [`@epicenter/filesystem`](packages/filesystem) | POSIX-style virtual filesystem over Yjs workspace tables. `mkdir`, `mv`, `rm`, `stat`. | MIT |
+| [`@epicenter/skills`](packages/skills) | Skill and reference tables for AI-enhanced workspace apps. | MIT |
+| [`@epicenter/ai`](packages/ai) | Bridges workspace actions with LLM tool calling. | MIT |
+| [`@epicenter/cli`](packages/cli) | The `epicenter` command. TypeBox schemas become CLI flags automatically. | MIT |
+| [`@epicenter/constants`](packages/constants) | Shared URLs, ports, and version info across the monorepo. | MIT |
+
 ## For Developers
 
 The hard problem with local-first apps is synchronization. If each device has its own SQLite file, how do you keep them in sync? If each device has its own markdown folder, same question. We ended up using Yjs CRDTs as the single source of truth, then materializing that data *down* to SQLite (for fast SQL reads) and markdown (for human-readable files). Yjs handles the sync; SQLite and markdown handle the reads.
@@ -87,28 +145,28 @@ The hard problem with local-first apps is synchronization. If each device has it
 The [`@epicenter/workspace`](packages/workspace) package wraps this into a single API. Define a schema, get CRDT-backed tables, attach providers to materialize to SQLite or markdown, and add sync when you're ready.
 
 ```typescript
-import { defineWorkspace, createClient, id, text, boolean, select } from '@epicenter/workspace';
+import { type } from 'arktype';
+import { createWorkspace, defineTable, defineWorkspace } from '@epicenter/workspace';
+import { indexeddbPersistence } from '@epicenter/workspace/extensions/persistence/indexeddb';
+  import { createSyncExtension } from '@epicenter/workspace/extensions/sync/websocket';
 
-const workspace = defineWorkspace({
-  id: 'blog',
-  tables: {
-    posts: {
-      id: id(),
-      title: text(),
-      published: boolean({ default: false }),
-      category: select({ options: ['tech', 'personal'] }),
-    },
-  },
-  kv: {},
-});
+    const posts = defineTable(
+  type({ id: 'string', title: 'string', published: 'boolean', _v: '1' }),
+      );
 
-const client = createClient(workspace.id)
-  .withDefinition(workspace)
-  .withExtension('persistence', setupPersistence)
-  .withExtension('sqlite', (c) => sqliteProvider(c));
+      const definition = defineWorkspace({
+  id: 'epicenter.blog',
+  tables: { posts },
+  });
 
-// Write to the Y.Doc — SQLite updates automatically
-client.tables.get('posts').upsert({ id: '1', title: 'Hello', published: false, category: 'tech' });
+const workspace = createWorkspace(definition)
+  .withExtension('persistence', indexeddbPersistence)
+  .withExtension('sync', createSyncExtension({
+    url: (docId) => `ws://localhost:3913/rooms/${docId}`,
+  }));
+
+await workspace.whenReady;
+workspace.tables.posts.set({ id: '1', title: 'Hello', published: false, _v: 1 });
 ```
 
 Each user gets their own database. Schema definitions are plain JSON, so they work with MCP and OpenAPI out of the box. Write to Yjs and SQLite updates; edit a markdown file and the CRDT merges it in.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,298 @@
+# Epicenter architecture
+Epicenter is one composition story. The core packages define the local-first model, the middle layer turns that model into app-shaped tools, and the apps decide which pieces to compose.
+The lifecycle is define→create→extend→sync. That order matters because Epicenter keeps schema definition pure, pushes side effects to the edge, and lets each app choose how much runtime machinery it needs.
+This is the five-minute map. It explains how the packages interlock without redoing the full `@epicenter/workspace` README.
+
+## The stack in one picture
+The dependency shape runs bottom to top. Apps depend on middleware; middleware depends on the core; the core stays small and reusable.
+
+```text
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ APPS                                                                         │
+│                                                                              │
+│ opensidian   whispering   tab-manager   fuji   zhongwen                      │
+│ honeycrisp   dashboard    api           landing                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+                                      │
+                                      ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ MIDDLEWARE                                                                   │
+│                                                                              │
+│ @epicenter/svelte      (packages/svelte-utils)                               │
+│ @epicenter/filesystem                                                        │
+│ @epicenter/skills                                                            │
+│ @epicenter/ai                                                                │
+└──────────────────────────────────────────────────────────────────────────────┘
+                                      │
+                                      ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ CORE                                                                         │
+│                                                                              │
+│ @epicenter/workspace   @epicenter/sync   @epicenter/constants   @epicenter/ui│
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+`@epicenter/workspace` is the center of gravity. It defines the schema layer, creates the live Yjs-backed client, owns the extension lifecycle, and exposes tables, KV, documents, awareness, and actions.
+`@epicenter/sync` is the wire format, not the app model. It exports protocol primitives like `encodeSyncStep1`, `encodeSyncUpdate`, `decodeSyncMessage`, and shared RPC error types so server and client can speak the same binary language without duplicating protocol logic.
+`@epicenter/constants` is the routing glue. It gives apps one source of truth for URLs, ports, and versioning so sync endpoints, auth URLs, and cross-app links do not drift.
+`@epicenter/ui` is the shared presentation layer. It knows Svelte components, not Yjs semantics.
+The middleware layer is where workspace data starts feeling like an application. `@epicenter/svelte` turns workspace helpers into reactive Svelte state, `@epicenter/filesystem` turns workspace rows and documents into a POSIX-style filesystem, `@epicenter/skills` proves that whole workspaces can be packaged and embedded as data products, and `@epicenter/ai` bridges workspace actions into LLM-callable tools.
+The apps are thin by comparison. Each app picks a definition, creates a client, installs the extensions it needs, and layers UI or transport concerns on top.
+
+## The lifecycle: define → create → extend → sync
+The four verbs are the architecture. If you remember nothing else, remember that Epicenter keeps those stages separate on purpose.
+
+### 1. Define is pure
+`defineTable`, `defineKv`, and `defineWorkspace` are pure declarations. They do not create a `Y.Doc`, open IndexedDB, start a WebSocket, or touch the network.
+
+```ts
+import { type } from 'arktype';
+import {
+	defineKv,
+	defineTable,
+	defineWorkspace,
+} from '@epicenter/workspace';
+
+const files = defineTable(
+	type({
+		id: 'string',
+		name: 'string',
+		_v: '1',
+	}),
+);
+
+const themeMode = defineKv(type("'light' | 'dark' | 'system'"), 'system');
+
+export const appDefinition = defineWorkspace({
+	id: 'example.app',
+	tables: { files },
+	kv: { themeMode },
+});
+```
+
+That purity is what makes cross-package reuse work. The same definition can be imported by an app, a CLI tool, a migration utility, a test, or another package without dragging runtime side effects along for the ride.
+
+### 2. Create is where the live client appears
+`createWorkspace()` is the boundary where static meaning turns into live state. This is where the root `Y.Doc` gets created, the guid is set from the workspace id, table helpers and KV helpers get wired up, awareness is created, and document managers are prepared for any `.withDocument()` tables.
+
+```ts
+import { createWorkspace } from '@epicenter/workspace';
+
+const workspace = createWorkspace(appDefinition);
+
+workspace.tables.files.set({
+	id: 'readme.md',
+	name: 'README.md',
+	_v: 1,
+});
+```
+
+The split is conceptual, not cosmetic. Definitions describe what data means; `createWorkspace()` creates the runtime that can actually hold and mutate that data.
+
+### 3. Extend is where persistence, sync, indexing, and materializers attach
+The extension chain is the plugin system. `createWorkspace()` returns a client you can use immediately, but also a builder with `.withExtension()`, `.withWorkspaceExtension()`, `.withDocumentExtension()`, and `.withActions()`.
+
+```ts
+import { createWorkspace } from '@epicenter/workspace';
+import { indexeddbPersistence } from '@epicenter/workspace/extensions/persistence/indexeddb';
+import { createSyncExtension } from '@epicenter/workspace/extensions/sync/websocket';
+
+const workspace = createWorkspace(appDefinition)
+	.withExtension('persistence', indexeddbPersistence)
+	.withExtension('sync', createSyncExtension({
+		url: (id) => `wss://sync.example.com/workspaces/${id}`,
+	}));
+```
+
+`.withExtension()` is broad on purpose. It registers the same factory for the root workspace doc and for per-document docs, which is what you want for capabilities like persistence or sync that should follow both the workspace and any attached document timelines.
+
+`.withWorkspaceExtension()` is narrower and richer. Its factory receives the full workspace context—`tables`, `kv`, `documents`, `definitions`, `awareness`, `extensions`, `batch`, `loadSnapshot`, and `whenReady`—so it is the right place for indexes, materializers, or any adapter that needs the typed workspace surface.
+
+`.withDocumentExtension()` is the per-document hook. That one attaches behavior to content documents opened through `workspace.documents`, which is how file content, note bodies, or other rich per-row docs get their own sync or transformation layers.
+
+Extensions compose progressively. Later extensions see earlier exports through `context.extensions`, because each builder step accumulates the extension map before the next one runs.
+
+```ts
+const workspace = createWorkspace(appDefinition)
+	.withExtension('persistence', indexeddbPersistence)
+	.withExtension('sync', createSyncExtension({ url }))
+	.withWorkspaceExtension('search', ({ extensions, tables }) => {
+		void extensions.persistence;
+		void extensions.sync;
+		void tables;
+
+		return {
+			search(query: string) {
+				return query;
+			},
+		};
+	});
+```
+
+That ordering is not trivia. It lets apps build capability stacks instead of monoliths, and it lets packages like `@epicenter/filesystem` or app-specific indexes sit on top of the same base client without forking core behavior.
+
+### 4. Sync is just another extension, but it changes the topology
+Sync does not own the workspace. It attaches to a workspace that already exists and starts moving CRDT updates between clients.
+
+```ts
+const workspace = createWorkspace(appDefinition)
+	.withExtension('persistence', indexeddbPersistence)
+	.withExtension('sync', createSyncExtension({
+		url: (workspaceId) => `wss://host/workspaces/${workspaceId}`,
+		getToken: async () => auth.token,
+	}));
+```
+
+That ordering is deliberate. Local state exists first, then optional durability, then optional network coordination.
+
+## The async boundary is `whenReady`
+`createWorkspace()` is synchronous, but extension setup is not. The workspace object exists right away; `workspace.whenReady` is the promise that says all registered extension `whenReady` hooks have settled.
+
+```ts
+const workspace = createWorkspace(appDefinition)
+	.withExtension('persistence', indexeddbPersistence)
+	.withExtension('sync', createSyncExtension({ url }));
+
+await workspace.whenReady;
+```
+
+That promise is the line between construction and full availability. If persistence needs to hydrate local state, or sync needs to wait on something upstream, `whenReady` is where callers pause. The pattern is simple: create now, await later.
+
+## Disposal runs in reverse
+Teardown is LIFO. The workspace closes open document handles first, then runs extension cleanup in reverse registration order, then destroys awareness and the root `Y.Doc`.
+
+```ts
+await workspace.dispose();
+```
+```text
+dispose()
+  │
+  ├─ close open document handles first
+  │
+  ├─ dispose extension C
+  ├─ dispose extension B
+  ├─ dispose extension A
+  │
+  └─ destroy awareness and root Y.Doc
+```
+
+Reverse order is the only sane rule here. If sync depends on persistence, or a materializer depends on both, the most recently attached layer should shut down before the layers under it disappear.
+
+## Write and read flow
+Writes always hit Yjs first. Everything else reacts to that state instead of becoming a competing source of truth.
+
+```text
+WRITE FLOW
+
+app code / action / UI event
+            │
+            ▼
+   workspace.tables / kv / documents
+            │
+            ▼
+          Y.Doc
+            │
+   ┌────────┼───────────────┬───────────────┐
+   ▼        ▼               ▼               ▼
+persistence sync       sqlite index   markdown/file views
+IndexedDB   WebSocket  or search      or other materializers
+SQLite      relay      extensions     built from workspace data
+```
+
+Reads split by purpose. Simple reads stay in the workspace client, while derived reads can come from extension exports built on top of that same client state.
+
+```text
+READ FLOW
+
+          Y.Doc
+            │
+   ┌────────┼───────────────────┬────────────────────────┐
+   ▼        ▼                   ▼                        ▼
+tables      kv             documents                 extensions
+typed rows  settings       per-row content docs      indexes/materializers
+   │         │                   │                        │
+   └─────────┴───────────────────┴────────────────────────┘
+                             │
+                             ▼
+                          app UI
+```
+
+That model is why Epicenter can mix SQL-like lookup, filesystem semantics, and collaborative document editing without splitting the truth into three different stores. They are three views over one CRDT core.
+
+## Opensidian is the best concrete example
+Opensidian composes nearly every layer at once. Its schema starts with `filesTable` from `@epicenter/filesystem`, adds chat tables locally, and exports one pure workspace definition.
+
+```ts
+import { filesTable } from '@epicenter/filesystem';
+import { defineTable, defineWorkspace } from '@epicenter/workspace';
+
+const conversationsTable = defineTable(/* ... */);
+const chatMessagesTable = defineTable(/* ... */);
+const toolTrustTable = defineTable(/* ... */);
+
+export const opensidianDefinition = defineWorkspace({
+	id: 'opensidian',
+	tables: {
+		files: filesTable,
+		conversations: conversationsTable,
+		chatMessages: chatMessagesTable,
+		toolTrust: toolTrustTable,
+	},
+});
+```
+
+Its runtime client then layers persistence, sync, and a workspace-only SQLite search index. This comes straight from `apps/opensidian/src/lib/client.ts`.
+
+```ts
+export const workspace = createWorkspace(opensidianDefinition)
+	.withExtension('persistence', indexeddbPersistence)
+	.withExtension('sync', createSyncExtension({
+		url: (workspaceId) => toWsUrl(`${APP_URLS.API}/workspaces/${workspaceId}`),
+		getToken: async () => auth.token,
+	}))
+	.withWorkspaceExtension('sqliteIndex', createSqliteIndex())
+	.withActions((client) => ({
+		files: {
+			search: defineQuery({
+				handler: async ({ query }) => client.extensions.sqliteIndex.search(query),
+			}),
+		},
+	}));
+```
+
+That workspace then feeds other middleware packages. `createYjsFileSystem(workspace.tables.files, workspace.documents.files.content)` turns the files table plus content docs into a real virtual filesystem; `actionsToClientTools(workspace.actions)` from `@epicenter/ai` turns workspace actions into chat tools; `createSkillsWorkspace()` mounts a second skills-focused workspace; `createAuth()` from `@epicenter/svelte` coordinates auth with encryption and sync reconnects.
+The dependency chain looks like this.
+```text
+opensidianDefinition
+    │
+    ▼
+createWorkspace(...)
+    │
+    ├─ persistence extension
+    ├─ sync extension
+    ├─ sqliteIndex extension
+    └─ workspace actions
+    │
+    ├─ createYjsFileSystem(...)       -> editor + terminal + file tree
+    ├─ actionsToClientTools(...)      -> local AI tool execution
+    ├─ toToolDefinitions(...)         -> wire payload for chat requests
+    ├─ createSkillsWorkspace(...)     -> shared skills data source
+    └─ fromTable / fromKv / auth      -> reactive Svelte app state
+```
+
+That is the whole monorepo in miniature. The app is mostly composition code because the packages under it already agree on the same runtime shape.
+
+## The sync philosophy is dumb server, smart client
+The server is a relay, not the authority. Clients own schema meaning, table helpers, migrations, encryption activation, action handlers, and most of the user-facing behavior.
+
+`@epicenter/sync` reflects that philosophy in its API. It exports protocol encode/decode functions and shared error types, while the higher-level workspace sync extension plugs those primitives into a live client that already knows how to read and write its own data.
+
+That means the server does not need to understand your tables. It forwards Yjs sync messages, awareness updates, and RPC payloads, but it does not become the canonical interpreter of the workspace schema.
+
+This is what “smart client” means here. The client can boot locally, read persisted state, apply encryption keys, expose actions, open document timelines, and keep working offline before the network helps at all.
+
+This is what “dumb server” means here. The server helps peers find each other and exchange updates, but it is not where the data model becomes valid or meaningful.
+
+## The shortest accurate mental model
+Epicenter defines data first. `@epicenter/workspace` gives that data a live Yjs client, extensions attach durability and transport, middleware packages reinterpret the same client for files, skills, Svelte state, and AI tools, and the apps compose those layers into actual products.
+
+Everything after that is detail. Useful detail, but still detail.

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -1,0 +1,236 @@
+# Encryption architecture
+Epicenter encrypts CRDT values before they enter the synced Yjs document.
+That keeps the sync path moving ciphertext instead of application JSON.
+This page only makes claims visible in the current code:
+- `packages/workspace/src/shared/crypto/index.ts`
+- `packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts`
+- `packages/workspace/src/workspace/encryption-key.ts`
+- `packages/workspace/src/workspace/create-workspace.ts`
+- `apps/api/src/auth/encryption.ts`
+- `apps/api/src/auth/create-auth.ts`
+- `packages/svelte-utils/src/auth/create-auth.svelte.ts`
+- `packages/workspace/src/extensions/persistence/indexeddb.ts`
+- `apps/api/src/base-sync-room.ts`
+If something is not visible there, it is not presented as fact here.
+
+## What this system is
+This is server-managed encryption at the workspace value layer.
+It is not user-held end-to-end encryption.
+The auth server derives per-user keys from `ENCRYPTION_SECRETS` and returns them in the session response.
+The client derives per-workspace keys locally and uses those keys to encrypt individual CRDT values.
+That split is the trust boundary.
+The sync path only relays encrypted values.
+The auth path can derive user keys because it has access to the deployment secret.
+
+## Key hierarchy
+The hierarchy is two-stage.
+Server code derives a per-user key.
+Client code derives a per-workspace key from that user key.
+```text
+ENCRYPTION_SECRETS entry
+        |
+        | SHA-256(secret)
+        v
+root key material
+        |
+        | HKDF-SHA256 info = "user:{userId}"
+        v
+user key
+        |
+        | HKDF-SHA256 info = "workspace:{workspaceId}"
+        v
+workspace key
+        |
+        | XChaCha20-Poly1305
+        v
+encrypted CRDT value
+```
+On the server, `apps/api/src/auth/encryption.ts` hashes each configured secret with SHA-256, imports that digest into Web Crypto HKDF, and derives 256 bits with `info = user:{userId}`.
+It returns one `{ version, userKeyBase64 }` entry per configured secret version.
+On the client, `createWorkspace().applyEncryptionKeys()` decodes each `userKeyBase64`, runs `deriveWorkspaceKey(userKey, workspaceId)`, and gets a 32-byte workspace key with `info = workspace:{workspaceId}`.
+The highest version becomes the current key for new writes.
+
+## How keys reach the client
+Keys come through the auth session.
+There is no separate key-fetch endpoint in the reviewed code.
+`apps/api/src/auth/create-auth.ts` attaches `encryptionKeys` to `/auth/get-session`.
+`packages/svelte-utils/src/auth/create-auth.svelte.ts` then pushes those keys through `onLogin`.
+That happens in two places:
+- on boot from a cached session
+- on every authenticated session update from Better Auth
+The boot path exists so the workspace can unlock before the first auth roundtrip finishes.
+In app clients such as `apps/tab-manager/src/lib/client.ts`, `onLogin(session)` does this:
+```ts
+workspace.applyEncryptionKeys(session.encryptionKeys);
+workspace.extensions.sync.reconnect();
+```
+The order matters.
+Keys are applied before sync reconnects.
+
+## Key lifecycle in the current code
+Keys are definitely loaded on login.
+That part is explicit.
+Logout is less clean than the high-level comments suggest.
+The reviewed code clears the auth session and wipes persisted local data, but it does not show an explicit in-memory key wipe inside `createEncryptedYkvLww`.
+The logout path in the app clients is:
+```ts
+onLogout() {
+  workspace.clearLocalData();
+  workspace.extensions.sync.reconnect();
+}
+```
+And the auth state transition in `create-auth.svelte.ts` is:
+```ts
+session.current = null;
+onLogout?.();
+```
+`workspace.clearLocalData()` runs extension `clearLocalData` hooks.
+For IndexedDB persistence, that hook is `idb.clearData()`.
+So these points are implemented and verifiable:
+- keys are loaded on login
+- the persisted IndexedDB copy is wiped on logout
+- sync reconnects without an authenticated session token
+This point is not visible as an explicit step in the reviewed code:
+- clearing the in-memory encryption state after logout
+That gap matters because the encrypted wrapper exposes `activateEncryption()` but no `deactivateEncryption()`.
+If you are reviewing the threat model, treat that as a real property of the current implementation.
+
+## Binary envelope format
+Encrypted values are stored as a bare `Uint8Array`.
+There is no JSON ciphertext wrapper.
+The v1 layout is exactly:
+```text
+formatVersion(1) || keyVersion(1) || nonce(24) || ciphertext || tag(16)
+```
+The byte layout looks like this:
+```text
+Byte:  0              1              2                           26
+       +--------------+--------------+---------------------------+----------------------+
+       | formatVersion| keyVersion   | nonce                     | ciphertext || tag    |
+       | 1 byte       | 1 byte       | 24 bytes                  | variable + 16 bytes  |
+       +--------------+--------------+---------------------------+----------------------+
+```
+The minimum blob size is 42 bytes.
+That is `2 + 24 + 16`, which is the empty-plaintext case.
+`encryptValue()` writes the header like this:
+- byte 0: format version, currently `1`
+- byte 1: key version
+- bytes 2..25: random 24-byte nonce
+- bytes 26..end: ciphertext plus the 16-byte Poly1305 tag
+`decryptValue()` validates the format version first.
+If it is not `1`, decryption throws.
+The key version is metadata, not decryption logic by itself.
+The wrapper reads `blob[1]` with `getKeyVersion(blob)` and chooses the matching key before calling `decryptValue()`.
+
+## Why XChaCha20-Poly1305
+The code uses XChaCha20-Poly1305 from `@noble/ciphers`.
+The reason is simple: workspace writes are synchronous, so the encryption path must also stay synchronous.
+The implementation uses a 32-byte key, a 24-byte nonce, and optional AAD.
+
+## Encrypted CRDTs without forking the CRDT
+Epicenter does not fork the LWW CRDT.
+It wraps it.
+The core store is `YKeyValueLww`.
+The encryption layer is `createEncryptedYkvLww()`.
+That wrapper keeps timestamps, conflict resolution, pending state, and observer mechanics in the original CRDT and only transforms values at the boundary.
+The write path is:
+```text
+set(key, value)
+  -> JSON.stringify(value)
+  -> encryptValue(json, workspaceKey, aad = keyBytes, keyVersion)
+  -> inner.set(key, encryptedBlob)
+```
+The read path is:
+```text
+get(key)
+  -> inner.get(key)
+  -> decryptValue(blob, selectedKey, aad = keyBytes)
+  -> JSON.parse(json)
+```
+Observers follow the same pattern.
+The inner CRDT emits changes, the wrapper decrypts changed entries, and callers see plaintext change events.
+The reason for composition is concrete.
+The file comment explains that Yjs `ContentAny` stores entry objects by reference, and `YKeyValueLww` relies on `indexOf()` with strict reference equality.
+If the CRDT were forked to replace entries with freshly decrypted objects, that reference equality would break.
+So the design is not “encryption-aware CRDT logic.”
+It is “existing CRDT logic plus an encryption wrapper at the edges.”
+
+## What is and is not encrypted
+The value payload is encrypted.
+The surrounding CRDT structure is not.
+That means a synced entry still has a key and timestamp in the Yjs data model.
+What changes is the `val` field.
+When encryption is active, `val` becomes an opaque `Uint8Array` blob.
+The code also binds the entry key as AAD by passing `textEncoder.encode(key)` to both encrypt and decrypt.
+That prevents a simple ciphertext transplant from one entry key to another.
+
+## No plaintext cache
+Reads decrypt on the fly.
+The wrapper does not maintain a separate plaintext cache.
+That trade is explicit in the implementation comments: decrypting a small XChaCha20-Poly1305 blob is cheap, while a dual cache would add complexity around observers, resync, and missed transactions.
+`entries()` and `readableEntries()` decrypt as they iterate.
+Undecryptable entries are skipped.
+
+## One-way activation
+Encryption activation is one-way by API surface.
+The wrapper has `activateEncryption(keyring)`.
+It does not have `deactivateEncryption()`.
+Before activation, the wrapper is a passthrough store and `set()` writes plaintext values into the inner CRDT.
+After activation, `set()` always encrypts.
+The active state holds the full keyring, the current key, and the current key version.
+Calling `activateEncryption()` again updates that state to a new keyring, but it does not switch the store back to plaintext mode.
+`createWorkspace()` reinforces that shape.
+All table stores and the KV store are created as encrypted wrappers from the start, and `applyEncryptionKeys()` later activates encryption across all of them.
+
+## What activation re-encrypts
+Activation does not rewrite everything.
+It only re-encrypts plaintext entries.
+The code in `activateEncryption()` walks the inner map and splits entries into two groups:
+- plaintext entries to encrypt now
+- encrypted blobs to leave alone
+For already encrypted blobs, the wrapper checks whether they were unreadable before and readable now.
+If a new keyring makes old blobs readable, it emits synthetic add events so observers can see them.
+It does not rewrite those blobs.
+
+## Key rotation
+Key rotation is versioned and lazy.
+The blob carries the key version that encrypted it.
+New writes always use the highest key version in the active keyring.
+Old blobs keep their old version byte.
+Decryption follows this order:
+1. try the current key first
+2. if that fails, read `blob[1]`
+3. look up that version in the keyring
+4. try that specific key
+That avoids brute-forcing every key.
+The blob tells the client which version it needs.
+Rotation does not bulk re-encrypt existing ciphertext.
+Only plaintext entries get re-encrypted when encryption is activated.
+Existing ciphertext, even if it uses an old key version, stays as-is until the next write to that key.
+
+## What the sync server sees
+The sync server sees Yjs updates and relays them.
+In the reviewed server code, `BaseSyncRoom.sync()` calls `Y.applyUpdateV2(this.doc, update, 'http')` and returns diffs with `Y.encodeStateAsUpdateV2(this.doc, clientSV)`.
+The WebSocket path broadcasts raw protocol messages to peers.
+There is no decryption step in that sync room code.
+Because encryption happens before values are written into the Yjs document, the synced value payloads are ciphertext blobs.
+Be precise here.
+The relay does not see only random bytes.
+It still sees the CRDT skeleton: document structure, entry keys, and timestamps.
+What it does not get is plaintext application values.
+
+## Error handling and unreadable data
+Decryption failures do not take down the whole observer stream.
+The wrapper catches failures, logs a warning, skips the unreadable entry, and keeps going.
+It also exposes `unreadableEntryCount` and `readableEntryCount`.
+That makes corruption or missing key versions visible without forcing a hard crash on every read.
+
+## What this means for a security review
+The useful parts are clear.
+Values are encrypted before sync, the blob format is self-describing, key rotation is versioned, and the CRDT logic is reused instead of forked.
+The trust model is also clear.
+This is not a zero-knowledge design.
+The auth server can derive per-user transport keys from `ENCRYPTION_SECRETS`, while the sync relay forwards ciphertext values rather than plaintext values.
+The sharp edge is logout behavior.
+Persisted local data is wiped on logout through the IndexedDB extension, but an explicit in-memory key deactivation path is not present in the reviewed code.
+If you are deciding whether this architecture fits your threat model, focus on that line: the sync relay handles ciphertext values, but the deployment that owns `ENCRYPTION_SECRETS` remains inside the trust boundary.

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -1,0 +1,84 @@
+# @epicenter/ai
+
+`@epicenter/ai` turns Epicenter workspace actions into LLM-callable tools. It exists because the browser owns the real action handlers, while the chat server only sees JSON over the wire. Apps like Opensidian use this package to keep the execution logic local, send tool definitions to the server, and let the model call workspace actions without hardcoding every tool twice.
+
+## Quick usage
+
+This is the pattern from `apps/opensidian/src/lib/client.ts`:
+
+```typescript
+import { actionsToClientTools, toToolDefinitions } from '@epicenter/ai';
+
+export const workspaceTools = actionsToClientTools(workspace.actions);
+export const workspaceDefinitions = toToolDefinitions(workspaceTools);
+```
+
+Under the hood, that split is the whole point:
+
+```text
+workspace.actions
+  └─ actionsToClientTools(...)   -> client tools with execute()
+  └─ toToolDefinitions(...)      -> JSON payload for the server
+```
+
+The first result stays in the browser. The second goes into the request body so the server can tell TanStack AI which tools exist.
+
+## How the bridge works
+
+Workspace actions are nested objects. `actionsToClientTools()` walks that tree with `iterateActions()` from `@epicenter/workspace`, joins path segments with `_`, and returns TanStack AI client tools.
+
+Queries become ordinary client tools. Mutations automatically get `needsApproval: true`, which is how the UI knows not to run destructive actions silently.
+
+`toToolDefinitions()` then strips runtime-only fields like `execute` and `__toolSide`. What survives is the wire-safe shape the server needs: tool name, description, schemas, approval metadata, and any extra metadata attached to the tool.
+
+One detail matters more than it looks. Input schemas are normalized so `properties` and `required` are always present. The source calls out Anthropic here—some providers reject schemas that omit those keys.
+
+## API overview
+
+### `actionsToClientTools(actions)`
+
+Converts a workspace action tree into TanStack AI client tools. Tool names come from the action path, so a nested action like `tabs.close` becomes `tabs_close`.
+
+### `toToolDefinitions(tools)`
+
+Converts client tools into plain JSON definitions for the HTTP request body. This removes non-serializable fields and keeps the data the server needs for tool-aware chat calls.
+
+### `ActionNames<TActions>`
+
+Type-level helper that turns a nested action tree into a string union of tool names.
+
+```typescript
+type Names = ActionNames<typeof workspace.actions>;
+// "tabs_search" | "tabs_close" | ...
+```
+
+### `ToolDefinitionPayload`
+
+The wire-safe tool shape produced by `toToolDefinitions()`. It matches the transport boundary: name, optional title, description, schemas, approval flag, and metadata.
+
+## Relationship to the monorepo
+
+`@epicenter/ai` sits between `@epicenter/workspace` and chat clients built on `@tanstack/ai`.
+
+- `@epicenter/workspace` defines actions and exposes `iterateActions()`.
+- `@epicenter/ai` adapts those actions into client tools and wire payloads.
+- Apps like `apps/opensidian` feed the client tools into local chat execution and send the stripped definitions to the API.
+
+If you already have a workspace with actions, this package gives you the missing adapter layer. Nothing more.
+
+## Source entry point
+
+The package exports these symbols from `src/index.ts`:
+
+```typescript
+export {
+	type ActionNames,
+	actionsToClientTools,
+	type ToolDefinitionPayload,
+	toToolDefinitions,
+} from './tool-bridge';
+```
+
+## License
+
+MIT

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,110 @@
+# @epicenter/cli
+
+`@epicenter/cli` is the package behind the `epicenter` command. It loads `epicenter.config.ts`, opens one or more workspace clients, runs a command, prints the result, and gets out of the way. Monorepo apps, playgrounds, and local debugging scripts use it when they need the same workspace data model outside the browser or desktop app.
+
+## Installation
+
+Inside this monorepo:
+
+```json
+{
+	"dependencies": {
+		"@epicenter/cli": "workspace:*"
+	}
+}
+```
+
+The package also exposes the `epicenter` binary through `src/bin.ts`.
+
+## Quick usage
+
+From the terminal, the normal entry points are the built-in commands:
+
+```bash
+bun epicenter start
+bun epicenter start ./my-project --verbose
+
+bun epicenter list posts
+bun epicenter list posts --format jsonl
+```
+
+Inside the package, the binary is intentionally thin:
+
+```typescript
+import { hideBin } from 'yargs/helpers';
+import { createCLI } from './cli';
+
+await createCLI().run(hideBin(process.argv));
+```
+
+Command definitions follow the same pattern everywhere. `defineCommand` is just a typed identity helper, so each command stays close to plain yargs:
+
+```typescript
+export const listCommand = defineCommand({
+	command: 'list <table>',
+	describe: 'List all valid rows in a table',
+	builder: (y: Argv) =>
+		withWorkspaceOptions(y).positional('table', {
+			type: 'string',
+			demandOption: true,
+		}),
+	handler: async (argv: any) => {
+		await runCommand(
+			{ dir: argv.dir, workspaceId: argv.workspace },
+			(client) => resolveTable(client, argv.table).getAllValid(),
+			argv.format,
+		);
+	},
+});
+```
+
+## API overview
+
+Public exports from `src/index.ts`:
+
+- `createCLI()` — build the yargs-based CLI runner
+- `resolveEpicenterHome()` — resolve the session/config home directory
+- `createAuthApi()` and `createSessionStore()` — auth helpers for CLI login state
+- `createCliUnlock()` — workspace extension that loads encryption keys from the CLI session store
+- `loadConfig()` — import `epicenter.config.ts` and collect named workspace exports
+
+Those are the pieces meant for reuse. Most command wiring stays internal.
+
+## How commands are defined
+
+The package keeps command authoring boring on purpose.
+
+- `createCLI()` registers top-level commands like `start`, `list`, `get`, `count`, `run`, `describe`, `size`, `rpc`, and `auth`.
+- `defineCommand()` gives command modules type inference without adding runtime behavior.
+- `runCommand()` handles the common lifecycle: load config, resolve the workspace, wait for readiness, print output, dispose clients.
+- `withWorkspaceOptions()` adds the standard `--dir`, `--workspace`, and `--format` flags.
+
+That split matters because it keeps each command file short. The command author writes the operation; the package handles the boilerplate once.
+
+## TypeBox to yargs
+
+Action input schemas already exist in the workspace layer, so the CLI reuses them. `src/util/typebox-to-yargs.ts` converts a TypeBox object schema into a yargs options record, carrying over things like descriptions, defaults, required fields, and simple enum-like choices.
+
+The conversion is permissive by design. If a schema field does not map cleanly to a yargs primitive, the option still exists and the action can do stricter validation after parsing.
+
+## Relationship to other packages
+
+`@epicenter/cli` is a consumer-facing shell on top of the workspace package.
+
+```text
+epicenter command
+        │
+@epicenter/cli         yargs commands, config loading, auth/session helpers
+        │
+@epicenter/workspace   tables, actions, sync, persistence, documents
+```
+
+In the monorepo:
+
+- playground projects use the binary to start workspace daemons and inspect data
+- workspace packages reuse `createCliUnlock()` when they need CLI-stored auth and encryption keys
+- the CLI does not reimplement sync or storage; it drives the APIs exposed by `@epicenter/workspace`
+
+## License
+
+MIT.

--- a/packages/filesystem/README.md
+++ b/packages/filesystem/README.md
@@ -1,0 +1,99 @@
+# @epicenter/filesystem
+
+`@epicenter/filesystem` gives Epicenter a POSIX-style filesystem backed by Yjs data. File metadata lives in a workspace table, each file's content lives in its own Y.Doc-backed document, and the package turns that split into familiar operations like `mkdir`, `writeFile`, `mv`, `rm`, and `stat`. Apps use it when they want collaborative data to look and behave like files and folders instead of raw CRDT structures.
+
+## Installation
+
+Inside this monorepo:
+
+```json
+{
+	"dependencies": {
+		"@epicenter/filesystem": "workspace:*"
+	}
+}
+```
+
+This package has a peer dependency on `yjs`.
+
+## Quick usage
+
+The basic setup from the tests is short: define the `files` table in a workspace, then hand the table helper and document collection to `createYjsFileSystem`.
+
+```typescript
+import { createWorkspace } from '@epicenter/workspace';
+import { createYjsFileSystem, filesTable } from '@epicenter/filesystem';
+
+const ws = createWorkspace({ id: 'test', tables: { files: filesTable } });
+const fs = createYjsFileSystem(ws.tables.files, ws.documents.files.content);
+
+await fs.mkdir('/docs');
+await fs.writeFile('/docs/hello.txt', 'Hello World');
+await fs.appendFile('/docs/hello.txt', ' again');
+await fs.mv('/docs/hello.txt', '/docs/greeting.txt');
+
+const content = await fs.readFile('/docs/greeting.txt');
+const stats = await fs.stat('/docs/greeting.txt');
+```
+
+That is the actual shape used in `src/file-system.test.ts`. The object returned by `createYjsFileSystem` matches the `just-bash` filesystem interface, with a few extra helpers layered on top.
+
+## How the model works
+
+The package splits filesystem state into two parts.
+
+- The `filesTable` row tracks metadata: `id`, `name`, `parentId`, `type`, `size`, timestamps, and soft-delete state.
+- The content for each file lives in a document keyed by that row ID.
+
+That gives you a useful mix of properties:
+
+- directory listings and path lookups stay cheap because they only touch table metadata
+- file content remains collaborative because each file is still a Yjs document
+- soft deletes are easy because `rm` marks rows as trashed instead of immediately destroying history
+
+It feels like a filesystem because the package keeps resolving paths, parents, and names for you. Underneath, it is still workspace data all the way down.
+
+## API overview
+
+Main exports from `src/index.ts`:
+
+- `createYjsFileSystem()` and `YjsFileSystem` — the POSIX-like filesystem orchestrator
+- `filesTable`, `FileRow`, and `ColumnDefinition` — the shared metadata table and related types
+- `createFileTree()` and `createFileSystemIndex()` — path/index helpers for the metadata layer
+- `FS_ERRORS` and `FsErrorCode` — filesystem-style error helpers
+- `posixResolve()` — path normalization for slash-separated paths
+- Markdown helpers like `parseFrontmatter()`, `serializeMarkdownWithFrontmatter()`, and `serializeXmlFragmentToMarkdown()`
+- Link helpers like `convertWikilinksToInternalLinks()` and `makeInternalHref()`
+- `createSqliteIndex()` — optional SQLite-backed indexing for search results
+
+If you only need the filesystem abstraction, start with `createYjsFileSystem()` and `filesTable`. The rest supports indexing, markdown, and tree-level operations.
+
+## POSIX-style behavior
+
+The surface area is intentionally familiar.
+
+- `mkdir`, `readdir`, and `readdirWithFileTypes` cover directory work
+- `writeFile`, `appendFile`, `readFile`, and `readFileBuffer` cover content I/O
+- `mv` and `cp` handle renames and copies
+- `rm` performs soft deletes, with recursive behavior for folders
+- `stat`, `lstat`, `exists`, `realpath`, and `resolvePath` cover inspection and path resolution
+
+There are a few deliberate limits. Symlinks and hard links always throw `ENOSYS`. Permissions are mostly a validated no-op. That is not an accident—it keeps the model aligned with a collaborative CRDT-backed store instead of pretending to be a full kernel filesystem.
+
+## Relationship to other packages
+
+`@epicenter/filesystem` sits on top of `@epicenter/workspace` and turns workspace tables plus document collections into file semantics.
+
+```text
+@epicenter/workspace   typed tables + documents
+        │
+@epicenter/filesystem  tree index + file content orchestration
+        │
+apps like Opensidian   markdown notes, paths, links, indexing
+```
+
+In the monorepo, apps can treat shared workspace content as files without giving up Yjs collaboration. That is the point of this package.
+
+## License
+
+MIT.

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -1,0 +1,103 @@
+# @epicenter/skills
+
+`@epicenter/skills` gives Epicenter apps a shared workspace for skills and references. It exists so prompts, conventions, and supporting docs can live in the same CRDT-backed system as everything else instead of being trapped in loose markdown files. Apps like Opensidian read from this workspace to assemble layered system prompts, while the dedicated skills app edits and syncs the same data.
+
+## Quick usage
+
+Opensidian wires it up like this in `apps/opensidian/src/lib/client.ts`:
+
+```typescript
+import { createSkillsWorkspace } from '@epicenter/skills';
+import { indexeddbPersistence } from '@epicenter/workspace/extensions/persistence/indexeddb';
+
+export const skillsWorkspace = createSkillsWorkspace().withExtension(
+	'persistence',
+	indexeddbPersistence,
+);
+```
+
+The workspace ships with read actions for progressive disclosure. This example comes from `packages/skills/src/workspace.ts`:
+
+```typescript
+const skills = ws.actions.listSkills();
+const result = await ws.actions.getSkill({ id: 'abc123' });
+if (result) systemPrompt += result.instructions;
+```
+
+That split is deliberate. You can browse the catalog cheaply, load one skill when you need it, or fetch the full skill plus references when you're building a prompt.
+
+## Data model
+
+The package defines two tables under the `epicenter.skills` workspace ID.
+
+```text
+skills row
+  ├─ metadata columns
+  └─ instructions document
+
+references row
+  ├─ skillId -> points at a skill row
+  └─ content document
+```
+
+`skillsTable` stores one row per skill. Frontmatter fields like `description`, `license`, `compatibility`, `metadata`, and `allowed-tools` map to columns. The markdown body is not stored in a plain string column—it lives in a per-row Y.Doc attached as `instructions`.
+
+`referencesTable` stores one row per file in a skill's `references/` directory. Each reference also gets its own attached Y.Doc, exposed as `content`.
+
+That design keeps the catalog small and queryable while still letting editors collaborate on large markdown bodies with Yjs.
+
+## API overview
+
+### `createSkillsWorkspace()`
+
+Creates an isomorphic workspace client with three read actions already attached:
+
+- `listSkills()` for the cheap catalog view
+- `getSkill({ id })` for one skill plus instructions
+- `getSkillWithReferences({ id })` for the full skill bundle
+
+The returned client is still a normal Epicenter workspace builder, so apps can add persistence, sync, or more actions with the usual `.withExtension()` and `.withActions()` chain.
+
+### `skillsTable`
+
+The table definition for skill metadata, with a document attachment for `instructions`.
+
+### `referencesTable`
+
+The table definition for reference metadata, with a document attachment for `content`.
+
+### `Skill` and `Reference`
+
+Row types inferred from the two table definitions.
+
+### `skillsDefinition`
+
+The prebuilt workspace definition for `epicenter.skills`. Most callers want `createSkillsWorkspace()` instead, but the definition is exported for custom embedding.
+
+## Relationship to the monorepo
+
+This package is the shared data model behind Epicenter's skill system.
+
+- `packages/skills` defines the workspace, tables, and read actions.
+- `apps/skills` uses it as the editor and manager UI.
+- `apps/opensidian` mounts a second workspace just for global skills and reads from it during prompt assembly.
+- `@epicenter/workspace` provides the CRDT tables, documents, and builder underneath it all.
+
+There is also a `@epicenter/skills/node` subpath. That version adds disk I/O actions like `importFromDisk()` and `exportToDisk()` so skill folders on disk can round-trip into the workspace and back out again.
+
+## Source entry point
+
+The root export in `src/index.ts` is small on purpose:
+
+```typescript
+export { createSkillsWorkspace } from './workspace.js';
+export { skillsDefinition } from './definition.js';
+export { skillsTable, referencesTable } from './tables.js';
+export type { Skill, Reference } from './tables.js';
+```
+
+If you only need a shared skills workspace in an app, that's enough.
+
+## License
+
+MIT

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -1,0 +1,107 @@
+# @epicenter/sync
+
+`@epicenter/sync` is the wire-format package for Epicenter sync. It owns the binary framing for Yjs sync, awareness, sync-status, and peer-to-peer RPC messages so the transport layer can stay dumb. `@epicenter/workspace` and `apps/api` use it when they need to turn a `Y.Doc` change into bytes—or turn bytes back into something the app can reason about.
+
+## Installation
+
+Inside this monorepo:
+
+```json
+{
+	"dependencies": {
+		"@epicenter/sync": "workspace:*"
+	}
+}
+```
+
+This package has a peer dependency on `yjs`.
+
+## Quick usage
+
+The core flow is small on purpose: encode a sync message, send it over whatever transport you want, then decode or handle it on the other side.
+
+```typescript
+import * as Y from 'yjs';
+import {
+	MESSAGE_TYPE,
+	SYNC_MESSAGE_TYPE,
+	decodeMessageType,
+	decodeSyncMessage,
+	encodeSyncStep1,
+	handleSyncPayload,
+} from '@epicenter/sync';
+
+const doc = new Y.Doc();
+doc.getMap('users').set('alice', { name: 'Alice', age: 30 });
+
+const step1 = encodeSyncStep1({ doc });
+const messageType = decodeMessageType(step1);
+
+if (messageType === MESSAGE_TYPE.SYNC) {
+	const decoded = decodeSyncMessage(step1);
+
+	if (decoded.type === 'step1') {
+		const response = handleSyncPayload({
+			syncType: SYNC_MESSAGE_TYPE.STEP1,
+			payload: decoded.stateVector,
+			doc,
+			origin: null,
+		});
+
+		// send response over WebSocket, HTTP, BroadcastChannel, or anything else
+	}
+}
+```
+
+That example is the same shape used in the package tests and in the API room bootstrap, where the server starts a connection with `encodeSyncStep1({ doc })`.
+
+## Dumb server, separate transport
+
+This package is strict about one boundary: it handles protocol framing, not connection management. That split is why the same message helpers work over WebSockets, one-shot HTTP sync, or any custom relay you want to write.
+
+The design shows up in a few places:
+
+- `encodeSyncStep1`, `encodeSyncStep2`, and `encodeSyncUpdate` only deal with Yjs payloads.
+- `encodeSyncRequest` and `decodeSyncRequest` collapse the WebSocket handshake into a binary HTTP request/response format.
+- `encodeSyncStatus` uses an echoed version counter for save-state UX; the server can relay the payload unchanged.
+- RPC framing is separate from RPC behavior. The package defines request/response bytes and shared error variants, not the transport policy around retries or timeouts.
+
+If you want lifecycle helpers for a WebSocket server, this package is the protocol layer under them—not the server itself.
+
+## API overview
+
+Main exports from `src/index.ts`:
+
+- Message constants: `MESSAGE_TYPE`, `SYNC_MESSAGE_TYPE`, `RPC_TYPE`
+- Sync encode/decode: `encodeSyncStep1`, `encodeSyncStep2`, `encodeSyncUpdate`, `decodeSyncMessage`, `handleSyncPayload`
+- Awareness helpers: `encodeAwareness`, `encodeAwarenessStates`, `encodeQueryAwareness`
+- HTTP sync helpers: `encodeSyncRequest`, `decodeSyncRequest`
+- Save-status helpers: `encodeSyncStatus`, `decodeSyncStatus`, `stateVectorsEqual`
+- RPC helpers: `encodeRpcRequest`, `encodeRpcResponse`, `decodeRpcMessage`, `decodeRpcPayload`
+- RPC types and guards: `DecodedRpcMessage`, `RpcError`, `isRpcError`
+
+The package exports pure functions. Feed them bytes and docs; they give you bytes or decoded shapes back.
+
+## Relationship to other packages
+
+`@epicenter/sync` sits below the rest of the sync stack.
+
+```text
+apps/api                durable-object rooms, websocket handling
+        │
+@epicenter/workspace    client sync extension, rpc helpers
+        │
+@epicenter/sync         protocol framing and shared rpc error types
+        │
+yjs + y-protocols       crdt state, awareness, update encoding
+```
+
+In practice:
+
+- `apps/api` uses it to compute initial room messages and decode incoming sync traffic.
+- `@epicenter/workspace` uses it in the client sync extension.
+- Other packages do not need to know about the wire format unless they are implementing a transport.
+
+## License
+
+AGPL-3.0. That matches the package manifest and the repository's split-license model for sync infrastructure.


### PR DESCRIPTION
Someone clicking through from Hacker News hits the root README first, and until now it didn't answer the most basic question: how do all these packages fit together? The code example used an API that no longer exists (`createClient`, `id()`, `text()`), there was no architecture diagram, no package map, and five of the nine published packages had no README at all.

This fixes all of that. The root README now opens with an ASCII diagram that shows the three-layer stack:

```
    ┌─────────────────────────────────────────────────────────────────────┐
    │                           CORE                                      │
    │  @epicenter/workspace — typed schemas, Yjs CRDTs, extensions,      │
    │                         E2E encryption, lifecycle, materializers    │
    │  @epicenter/sync      — protocol encoding/decoding, V2 updates     │
    │  @epicenter/constants — app URLs, versions, shared config          │
    │  @epicenter/ui        — shadcn-svelte component library            │
    │  @epicenter/cli       — TypeBox→yargs CLI, auth/session APIs       │
    └────────────────────────────────────────────────────────────────────┘
```

Below that, a package map table gives every package a one-liner description and license link, so anyone browsing `packages/` can orient themselves without opening each folder. The nav bar picked up Architecture, Packages, and Quick Start anchors.

The code example now matches the current API—`defineTable` with arktype, `createWorkspace`, `.withExtension()` for persistence and sync:

```typescript
const posts = defineTable(
  type({ id: 'string', title: 'string', published: 'boolean', _v: '1' }),
);

const workspace = createWorkspace(defineWorkspace({
  id: 'epicenter.blog',
  tables: { posts },
}))
  .withExtension('persistence', indexeddbPersistence)
  .withExtension('sync', createSyncExtension({
    url: (docId) => `ws://localhost:3913/rooms/${docId}`,
  }));
```

Two new architecture docs fill the gap between "what is this repo" and the 1,600-line workspace README. `docs/architecture.md` walks through the define→create→extend→sync lifecycle with diagrams and a concrete Opensidian composition example. `docs/encryption.md` covers the key hierarchy (HKDF-SHA256 user key → workspace key → XChaCha20-Poly1305), the binary envelope format, and the CRDT composition wrapper—with an honest note that this is server-managed encryption, not user-held E2E.

The five missing package READMEs—sync, cli, filesystem, ai, skills—each follow the same shape: what it does, who uses it, a real code example from the actual source, and how it relates to the rest of the monorepo. The sync README explains the dumb-server philosophy and notes the AGPL license. The cli README shows the TypeBox→yargs conversion. The filesystem README explains that every file is a Y.Doc and the directory index is a Yjs table.

`tmp-search/` was also added to `.gitignore`—it's a development-only directory of cloned repos that shouldn't be tracked.

9 files changed, +1,121/−23. Docs-only—no code changes, no dependency changes.