### PR TITLE
feat: structured AI chat errors with defineErrors end-to-end

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,7 +201,9 @@ This section is for maintainers with npm publish access to the `@epicenter` scop
 
 ### How versioning works
 
-All seven public packages (`@epicenter/workspace`, `@epicenter/cli`, `@epicenter/sync`, `@epicenter/filesystem`, `@epicenter/skills`, `@epicenter/ui`, `@epicenter/svelte`) share a single version number. They move together. Apps (Whispering, the API) are versioned independently.
+All seven public packages (`@epicenter/workspace`, `@epicenter/cli`, `@epicenter/sync`, `@epicenter/filesystem`, `@epicenter/skills`, `@epicenter/ui`, `@epicenter/svelte`) share a single version number. They move together.
+
+**Apps are completely separate from changesets.** Changesets only touches packages that are (a) not marked `"private": true` and (b) listed under `packages/`. Every app in `apps/` is `"private": true` and has its own deploy mechanism—changesets will never version or publish them. Whispering versions come from `tauri.conf.json` and git tags. Web apps deploy on push to `main`. See [App deployments](#app-deployments) below.
 
 We use [changesets](https://github.com/changesets/changesets) to track changes and publish. Never edit `version` fields in `package.json` by hand.
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@epicenter/api",
+	"private": true,
 	"version": "0.0.1",
 	"type": "module",
 	"main": "./src/app.ts",

--- a/apps/api/src/ai-chat.ts
+++ b/apps/api/src/ai-chat.ts
@@ -11,7 +11,7 @@ import { createGeminiChat, GeminiTextModels } from '@tanstack/ai-gemini';
 import { createOpenaiChat, OPENAI_CHAT_MODELS } from '@tanstack/ai-openai';
 import { type } from 'arktype';
 import { createFactory } from 'hono/factory';
-import { defineErrors } from 'wellcrafted/error';
+import { AiChatError } from '@epicenter/constants/ai-chat-errors';
 import type { Env } from './app';
 import { createAutumn } from './autumn';
 import { FEATURE_IDS, PLAN_IDS } from './billing-plans';
@@ -34,31 +34,6 @@ const chatOptions = type({
 	'tools?': 'object[] | undefined',
 });
 
-const AiChatError = defineErrors({
-	ProviderNotConfigured: ({ provider }: { provider: string }) => ({
-		message: `${provider} not configured`,
-		provider,
-	}),
-	UnknownModel: ({ model }: { model: string }) => ({
-		message: `Unknown model: ${model}`,
-		model,
-	}),
-	InsufficientCredits: ({ balance }: { balance: unknown }) => ({
-		message: 'Insufficient credits',
-		balance,
-	}),
-	ModelRequiresPaidPlan: ({
-		model,
-		credits,
-	}: {
-		model: string;
-		credits: number;
-	}) => ({
-		message: `${model} requires a paid plan (costs ${credits} credits, Free tier limit is ${FREE_TIER_MAX_CREDITS})`,
-		model,
-		credits,
-	}),
-});
 
 const aiChatBody = type({
 	messages: 'object[] >= 1',

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -3,10 +3,10 @@ import {
 	oauthProviderOpenIdConfigMetadata,
 } from '@better-auth/oauth-provider';
 import { APPS } from '@epicenter/constants/apps';
+import { AiChatError } from '@epicenter/constants/ai-chat-errors';
 import { sValidator } from '@hono/standard-validator';
 import { type } from 'arktype';
 import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres';
-import { defineErrors } from 'wellcrafted/error';
 import type { Context } from 'hono';
 import { cors } from 'hono/cors';
 import { createFactory } from 'hono/factory';
@@ -271,9 +271,6 @@ app.get(
 // Must be mounted BEFORE authGuard so GET requests aren't blocked.
 app.route('/api/assets', assetPublicRoutes);
 
-const AuthError = defineErrors({
-	Unauthorized: () => ({ message: 'Unauthorized' }),
-});
 
 // Auth guard for protected routes
 const authGuard = factory.createMiddleware(async (c, next) => {
@@ -283,7 +280,7 @@ const authGuard = factory.createMiddleware(async (c, next) => {
 		: c.req.raw.headers;
 
 	const result = await c.var.auth.api.getSession({ headers });
-	if (!result) return c.json(AuthError.Unauthorized(), 401);
+	if (!result) return c.json(AiChatError.Unauthorized(), 401);
 
 	c.set('user', result.user);
 	c.set('session', result.session);

--- a/apps/opensidian/src/lib/chat/chat-state.svelte.ts
+++ b/apps/opensidian/src/lib/chat/chat-state.svelte.ts
@@ -1,7 +1,7 @@
 import { AiChatHttpError } from '@epicenter/constants/ai-chat-errors';
 import { APP_URLS } from '@epicenter/constants/vite';
 import { fromTable } from '@epicenter/svelte';
-import { createAiFetchClient } from '@epicenter/svelte-utils/auth';
+import { createAiChatFetch } from '@epicenter/svelte-utils/auth';
 import { createChat, fetchServerSentEvents } from '@tanstack/ai-svelte';
 import type { JsonValue } from 'wellcrafted/json';
 import {
@@ -101,7 +101,7 @@ function createAiChatState() {
 			connection: fetchServerSentEvents(
 				() => `${APP_URLS.API}/ai/chat`,
 				async () => ({
-					fetchClient: createAiFetchClient(auth.fetch),
+					fetchClient: createAiChatFetch(auth.fetch),
 					body: {
 						data: {
 							provider: metadata?.provider ?? DEFAULT_PROVIDER,
@@ -208,17 +208,17 @@ function createAiChatState() {
 
 			get isCreditsExhausted() {
 				return chat.error instanceof AiChatHttpError
-					&& chat.error.serverError.name === 'InsufficientCredits';
+					&& chat.error.detail.name === 'InsufficientCredits';
 			},
 
 			get isUnauthorized() {
 				return chat.error instanceof AiChatHttpError
-					&& chat.error.serverError.name === 'Unauthorized';
+					&& chat.error.detail.name === 'Unauthorized';
 			},
 
 			get isModelRestricted() {
 				return chat.error instanceof AiChatHttpError
-					&& chat.error.serverError.name === 'ModelRequiresPaidPlan';
+					&& chat.error.detail.name === 'ModelRequiresPaidPlan';
 			},
 
 			sendMessage(content: string) {
@@ -410,17 +410,6 @@ function createAiChatState() {
 			return handles.get(activeConversationId)?.error;
 		},
 
-		get isCreditsExhausted() {
-			return handles.get(activeConversationId)?.isCreditsExhausted ?? false;
-		},
-
-		get isUnauthorized() {
-			return handles.get(activeConversationId)?.isUnauthorized ?? false;
-		},
-
-		get isModelRestricted() {
-			return handles.get(activeConversationId)?.isModelRestricted ?? false;
-		},
 
 		sendMessage(content: string) {
 			handles.get(activeConversationId)?.sendMessage(content);

--- a/apps/opensidian/src/lib/chat/chat-state.svelte.ts
+++ b/apps/opensidian/src/lib/chat/chat-state.svelte.ts
@@ -1,5 +1,7 @@
+import { AiChatHttpError } from '@epicenter/constants/ai-chat-errors';
 import { APP_URLS } from '@epicenter/constants/vite';
 import { fromTable } from '@epicenter/svelte';
+import { createAiFetchClient } from '@epicenter/svelte-utils/auth';
 import { createChat, fetchServerSentEvents } from '@tanstack/ai-svelte';
 import type { JsonValue } from 'wellcrafted/json';
 import {
@@ -99,7 +101,7 @@ function createAiChatState() {
 			connection: fetchServerSentEvents(
 				() => `${APP_URLS.API}/ai/chat`,
 				async () => ({
-					fetchClient: auth.fetch as typeof fetch,
+					fetchClient: createAiFetchClient(auth.fetch),
 					body: {
 						data: {
 							provider: metadata?.provider ?? DEFAULT_PROVIDER,
@@ -205,8 +207,18 @@ function createAiChatState() {
 			},
 
 			get isCreditsExhausted() {
-				if (!chat.error) return false;
-				return chat.error.message.includes('status: 402');
+				return chat.error instanceof AiChatHttpError
+					&& chat.error.serverError.name === 'InsufficientCredits';
+			},
+
+			get isUnauthorized() {
+				return chat.error instanceof AiChatHttpError
+					&& chat.error.serverError.name === 'Unauthorized';
+			},
+
+			get isModelRestricted() {
+				return chat.error instanceof AiChatHttpError
+					&& chat.error.serverError.name === 'ModelRequiresPaidPlan';
 			},
 
 			sendMessage(content: string) {
@@ -400,6 +412,14 @@ function createAiChatState() {
 
 		get isCreditsExhausted() {
 			return handles.get(activeConversationId)?.isCreditsExhausted ?? false;
+		},
+
+		get isUnauthorized() {
+			return handles.get(activeConversationId)?.isUnauthorized ?? false;
+		},
+
+		get isModelRestricted() {
+			return handles.get(activeConversationId)?.isModelRestricted ?? false;
 		},
 
 		sendMessage(content: string) {

--- a/apps/opensidian/src/lib/chat/chat-state.svelte.ts
+++ b/apps/opensidian/src/lib/chat/chat-state.svelte.ts
@@ -406,11 +406,6 @@ function createAiChatState() {
 			return PROVIDER_MODELS[providerName as Provider] ?? [];
 		},
 
-		get error() {
-			return handles.get(activeConversationId)?.error;
-		},
-
-
 		sendMessage(content: string) {
 			handles.get(activeConversationId)?.sendMessage(content);
 		},

--- a/apps/opensidian/src/lib/components/chat/AiChat.svelte
+++ b/apps/opensidian/src/lib/components/chat/AiChat.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { Button } from '@epicenter/ui/button';
-	import { AiChatHttpError } from '@epicenter/constants/ai-chat-errors';
 	import LogInIcon from '@lucide/svelte/icons/log-in';
 	import RotateCcwIcon from '@lucide/svelte/icons/rotate-ccw';
 	import SquarePenIcon from '@lucide/svelte/icons/square-pen';
@@ -89,10 +88,7 @@
 			role="alert"
 			class="flex items-center justify-between gap-2 border-t border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive"
 		>
-			<span class="min-w-0 flex-1">
-				{active?.error instanceof AiChatHttpError
-					? active.error.detail.message
-					: active?.error?.message}
+			<span class="min-w-0 flex-1">{active?.error?.message}</span>
 			</span>
 			<div class="flex shrink-0 items-center gap-1">
 				<Button

--- a/apps/opensidian/src/lib/components/chat/AiChat.svelte
+++ b/apps/opensidian/src/lib/components/chat/AiChat.svelte
@@ -47,7 +47,7 @@
 		/>
 	</div>
 
-	<!-- Error states -->
+	<!-- Error states: auth + credits are persistent (no dismiss), others are dismissable -->
 	{#if active?.isUnauthorized}
 		<div
 			role="alert"
@@ -83,34 +83,17 @@
 				Upgrade
 			</Button>
 		</div>
-	{:else if active?.isModelRestricted}
+	{:else if errorVisible}
+		<!-- Dismissable errors: model restriction, generic, etc. -->
 		<div
 			role="alert"
 			class="flex items-center justify-between gap-2 border-t border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive"
 		>
 			<span class="min-w-0 flex-1">
-				{active.error instanceof AiChatHttpError
-					? active.error.serverError.message
-					: 'This model requires a paid plan'}
+				{active?.error instanceof AiChatHttpError
+					? active.error.detail.message
+					: active?.error?.message}
 			</span>
-			<Button
-				variant="ghost"
-				size="sm"
-				class="h-6 gap-1 px-2 text-xs text-destructive hover:text-destructive"
-				onclick={() => {
-					dismissedError = active?.error?.message ?? null;
-				}}
-			>
-				Dismiss
-			</Button>
-		</div>
-	{:else if errorVisible}
-		<!-- Generic fallback for unknown errors -->
-		<div
-			role="alert"
-			class="flex items-center justify-between gap-2 border-t border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive"
-		>
-			<span class="min-w-0 flex-1">{active?.error?.message}</span>
 			<div class="flex shrink-0 items-center gap-1">
 				<Button
 					variant="ghost"

--- a/apps/opensidian/src/lib/components/chat/AiChat.svelte
+++ b/apps/opensidian/src/lib/components/chat/AiChat.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { Button } from '@epicenter/ui/button';
+	import { AiChatHttpError } from '@epicenter/constants/ai-chat-errors';
+	import LogInIcon from '@lucide/svelte/icons/log-in';
 	import RotateCcwIcon from '@lucide/svelte/icons/rotate-ccw';
 	import SquarePenIcon from '@lucide/svelte/icons/square-pen';
 	import XIcon from '@lucide/svelte/icons/x';
@@ -45,8 +47,65 @@
 		/>
 	</div>
 
-	<!-- Inline error banner -->
-	{#if errorVisible}
+	<!-- Error states -->
+	{#if active?.isUnauthorized}
+		<div
+			role="alert"
+			class="flex items-center justify-between gap-2 border-t border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+		>
+			<span class="min-w-0 flex-1">Sign in to use AI Chat</span>
+			<Button
+				variant="ghost"
+				size="sm"
+				class="h-6 gap-1 px-2 text-xs text-destructive hover:text-destructive"
+				onclick={() => {
+					// TODO: open auth popover or navigate to sign-in
+				}}
+			>
+				<LogInIcon class="size-3" />
+				Sign In
+			</Button>
+		</div>
+	{:else if active?.isCreditsExhausted}
+		<div
+			role="alert"
+			class="flex items-center justify-between gap-2 border-t border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+		>
+			<span class="min-w-0 flex-1">You're out of credits</span>
+			<Button
+				variant="ghost"
+				size="sm"
+				class="h-6 gap-1 px-2 text-xs text-destructive hover:text-destructive"
+				onclick={() => {
+					// TODO: open billing / upgrade flow
+				}}
+			>
+				Upgrade
+			</Button>
+		</div>
+	{:else if active?.isModelRestricted}
+		<div
+			role="alert"
+			class="flex items-center justify-between gap-2 border-t border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+		>
+			<span class="min-w-0 flex-1">
+				{active.error instanceof AiChatHttpError
+					? active.error.serverError.message
+					: 'This model requires a paid plan'}
+			</span>
+			<Button
+				variant="ghost"
+				size="sm"
+				class="h-6 gap-1 px-2 text-xs text-destructive hover:text-destructive"
+				onclick={() => {
+					dismissedError = active?.error?.message ?? null;
+				}}
+			>
+				Dismiss
+			</Button>
+		</div>
+	{:else if errorVisible}
+		<!-- Generic fallback for unknown errors -->
 		<div
 			role="alert"
 			class="flex items-center justify-between gap-2 border-t border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive"

--- a/apps/opensidian/wrangler.jsonc
+++ b/apps/opensidian/wrangler.jsonc
@@ -2,8 +2,12 @@
 	"$schema": "../../node_modules/wrangler/config-schema.json",
 	"name": "opensidian",
 	"compatibility_date": "2025-11-04",
-	// --- Custom domain: opensidian.epicenter.so (auto-creates DNS record on deploy) ---
+	// --- Custom domains: opensidian.com + opensidian.epicenter.so (auto-creates DNS records on deploy) ---
 	"routes": [
+		{
+			"pattern": "opensidian.com",
+			"custom_domain": true
+		},
 		{
 			"pattern": "opensidian.epicenter.so",
 			"custom_domain": true

--- a/apps/tab-manager/src/lib/chat/chat-state.svelte.ts
+++ b/apps/tab-manager/src/lib/chat/chat-state.svelte.ts
@@ -28,6 +28,8 @@
  * ```
  */
 
+import { AiChatHttpError } from '@epicenter/constants/ai-chat-errors';
+import { createAiFetchClient } from '@epicenter/svelte-utils/auth';
 import { createChat, fetchServerSentEvents } from '@tanstack/ai-svelte';
 import { SvelteMap } from 'svelte/reactivity';
 import { fromTable } from '@epicenter/svelte';
@@ -147,7 +149,7 @@ function createAiChatState() {
 				async () => {
 					const deviceId = await getDeviceId();
 					return {
-						fetchClient: auth.fetch,
+						fetchClient: createAiFetchClient(auth.fetch),
 						body: {
 							data: {
 								provider: metadata?.provider ?? DEFAULT_PROVIDER,
@@ -265,8 +267,18 @@ function createAiChatState() {
 			 * UI should show an upgrade prompt when true.
 			 */
 			get isCreditsExhausted() {
-				if (!chat.error) return false;
-				return chat.error.message.includes('status: 402');
+				return chat.error instanceof AiChatHttpError
+					&& chat.error.serverError.name === 'InsufficientCredits';
+			},
+
+			get isUnauthorized() {
+				return chat.error instanceof AiChatHttpError
+					&& chat.error.serverError.name === 'Unauthorized';
+			},
+
+			get isModelRestricted() {
+				return chat.error instanceof AiChatHttpError
+					&& chat.error.serverError.name === 'ModelRequiresPaidPlan';
 			},
 
 			// ── Ephemeral UI state ──

--- a/apps/tab-manager/src/lib/chat/chat-state.svelte.ts
+++ b/apps/tab-manager/src/lib/chat/chat-state.svelte.ts
@@ -29,7 +29,7 @@
  */
 
 import { AiChatHttpError } from '@epicenter/constants/ai-chat-errors';
-import { createAiFetchClient } from '@epicenter/svelte-utils/auth';
+import { createAiChatFetch } from '@epicenter/svelte-utils/auth';
 import { createChat, fetchServerSentEvents } from '@tanstack/ai-svelte';
 import { SvelteMap } from 'svelte/reactivity';
 import { fromTable } from '@epicenter/svelte';
@@ -149,7 +149,7 @@ function createAiChatState() {
 				async () => {
 					const deviceId = await getDeviceId();
 					return {
-						fetchClient: createAiFetchClient(auth.fetch),
+						fetchClient: createAiChatFetch(auth.fetch),
 						body: {
 							data: {
 								provider: metadata?.provider ?? DEFAULT_PROVIDER,
@@ -268,17 +268,17 @@ function createAiChatState() {
 			 */
 			get isCreditsExhausted() {
 				return chat.error instanceof AiChatHttpError
-					&& chat.error.serverError.name === 'InsufficientCredits';
+					&& chat.error.detail.name === 'InsufficientCredits';
 			},
 
 			get isUnauthorized() {
 				return chat.error instanceof AiChatHttpError
-					&& chat.error.serverError.name === 'Unauthorized';
+					&& chat.error.detail.name === 'Unauthorized';
 			},
 
 			get isModelRestricted() {
 				return chat.error instanceof AiChatHttpError
-					&& chat.error.serverError.name === 'ModelRequiresPaidPlan';
+					&& chat.error.detail.name === 'ModelRequiresPaidPlan';
 			},
 
 			// ── Ephemeral UI state ──

--- a/apps/tab-manager/src/lib/components/chat/AiChat.svelte
+++ b/apps/tab-manager/src/lib/components/chat/AiChat.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { Button } from '@epicenter/ui/button';
-	import { Button } from '@epicenter/ui/button';
 	import LogInIcon from '@lucide/svelte/icons/log-in';
 	import { aiChatState } from '$lib/chat/chat-state.svelte';
 	import ChatErrorBanner from './ChatErrorBanner.svelte';

--- a/apps/tab-manager/src/lib/components/chat/AiChat.svelte
+++ b/apps/tab-manager/src/lib/components/chat/AiChat.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+	import { Button } from '@epicenter/ui/button';
+	import { Button } from '@epicenter/ui/button';
+	import LogInIcon from '@lucide/svelte/icons/log-in';
 	import { aiChatState } from '$lib/chat/chat-state.svelte';
 	import ChatErrorBanner from './ChatErrorBanner.svelte';
 	import ChatInput from './ChatInput.svelte';
@@ -26,7 +29,43 @@
 		/>
 	</div>
 
-	{#if active}
+	<!-- Error states: auth + credits are persistent, others go to ChatErrorBanner -->
+	{#if active?.isUnauthorized}
+		<div
+			role="alert"
+			class="flex items-center justify-between gap-2 border-t border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+		>
+			<span class="min-w-0 flex-1">Sign in to use AI Chat</span>
+			<Button
+				variant="ghost"
+				size="sm"
+				class="h-6 gap-1 px-2 text-xs text-destructive hover:text-destructive"
+				onclick={() => {
+					// TODO: open auth popover or navigate to sign-in
+				}}
+			>
+				<LogInIcon class="size-3" />
+				Sign In
+			</Button>
+		</div>
+	{:else if active?.isCreditsExhausted}
+		<div
+			role="alert"
+			class="flex items-center justify-between gap-2 border-t border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+		>
+			<span class="min-w-0 flex-1">You're out of credits</span>
+			<Button
+				variant="ghost"
+				size="sm"
+				class="h-6 gap-1 px-2 text-xs text-destructive hover:text-destructive"
+				onclick={() => {
+					// TODO: open billing / upgrade flow
+				}}
+			>
+				Upgrade
+			</Button>
+		</div>
+	{:else if active}
 		<ChatErrorBanner
 			error={active.error}
 			dismissedError={active.dismissedError}

--- a/apps/tab-manager/src/lib/components/chat/ChatErrorBanner.svelte
+++ b/apps/tab-manager/src/lib/components/chat/ChatErrorBanner.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { AiChatHttpError } from '@epicenter/constants/ai-chat-errors';
 	import { Button } from '@epicenter/ui/button';
 	import RotateCcwIcon from '@lucide/svelte/icons/rotate-ccw';
 	import XIcon from '@lucide/svelte/icons/x';
@@ -17,9 +16,6 @@
 	} = $props();
 
 	const visible = $derived(error && error.message !== dismissedError);
-	const displayMessage = $derived(
-		error instanceof AiChatHttpError ? error.detail.message : error?.message,
-	);
 </script>
 
 {#if visible}

--- a/apps/tab-manager/src/lib/components/chat/ChatErrorBanner.svelte
+++ b/apps/tab-manager/src/lib/components/chat/ChatErrorBanner.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { AiChatHttpError } from '@epicenter/constants/ai-chat-errors';
 	import { Button } from '@epicenter/ui/button';
 	import RotateCcwIcon from '@lucide/svelte/icons/rotate-ccw';
 	import XIcon from '@lucide/svelte/icons/x';
@@ -16,6 +17,9 @@
 	} = $props();
 
 	const visible = $derived(error && error.message !== dismissedError);
+	const displayMessage = $derived(
+		error instanceof AiChatHttpError ? error.detail.message : error?.message,
+	);
 </script>
 
 {#if visible}
@@ -23,7 +27,7 @@
 		role="alert"
 		class="flex items-center justify-between gap-2 border-t border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive"
 	>
-		<span class="min-w-0 flex-1">{error?.message}</span>
+		<span class="min-w-0 flex-1">{displayMessage}</span>
 		<div class="flex shrink-0 items-center gap-1">
 			<Button variant="ghost-destructive" onclick={onRetry}>
 				<RotateCcwIcon class="size-3" />

--- a/bun.lock
+++ b/bun.lock
@@ -461,7 +461,7 @@
     },
     "packages/ai": {
       "name": "@epicenter/ai",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@epicenter/workspace": "workspace:*",
         "@tanstack/ai": "catalog:",
@@ -472,7 +472,7 @@
     },
     "packages/cli": {
       "name": "@epicenter/cli",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "bin": {
         "epicenter": "./src/bin.ts",
       },
@@ -494,7 +494,10 @@
     },
     "packages/constants": {
       "name": "@epicenter/constants",
-      "version": "0.0.1",
+      "version": "0.1.0",
+      "dependencies": {
+        "wellcrafted": "catalog:",
+      },
       "devDependencies": {
         "@types/node": "catalog:",
         "typescript": "catalog:",
@@ -503,7 +506,7 @@
     },
     "packages/filesystem": {
       "name": "@epicenter/filesystem",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@epicenter/workspace": "workspace:*",
         "@libsql/client": "^0.14.0",
@@ -526,11 +529,10 @@
     },
     "packages/skills": {
       "name": "@epicenter/skills",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@epicenter/workspace": "workspace:*",
         "arktype": "catalog:",
-        "typebox": "catalog:",
         "wellcrafted": "catalog:",
         "yaml": "^2.8.0",
       },
@@ -545,9 +547,10 @@
     },
     "packages/svelte-utils": {
       "name": "@epicenter/svelte",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@epicenter/api": "workspace:*",
+        "@epicenter/constants": "workspace:*",
         "@epicenter/ui": "workspace:*",
         "@epicenter/workspace": "workspace:*",
         "@lucide/svelte": "catalog:",
@@ -566,7 +569,7 @@
     },
     "packages/sync": {
       "name": "@epicenter/sync",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "lib0": "catalog:",
         "wellcrafted": "catalog:",
@@ -583,7 +586,7 @@
     },
     "packages/ui": {
       "name": "@epicenter/ui",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@fontsource-variable/manrope": "^5.2.6",
         "@lucide/svelte": "catalog:",
@@ -619,7 +622,7 @@
     },
     "packages/workspace": {
       "name": "@epicenter/workspace",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@ark/json-schema": "^0.0.4",
         "@epicenter/sync": "workspace:*",

--- a/docs/articles/release-strategy.md
+++ b/docs/articles/release-strategy.md
@@ -76,9 +76,13 @@ git push --tags
 
 `changeset publish` builds each package and runs `npm publish`. The `git push --tags` pushes the version tags created during publish, which triggers the Tauri release workflow if the tag matches `v*`.
 
-## What stays private
+## What changesets touches (and what it doesn't)
 
-Three packages never publish to npm: `@epicenter/ai`, `@epicenter/constants`, and `@epicenter/vault`. They're internal implementation details—AI provider wrappers, shared constants, and the encryption vault. `"private": true` in their `package.json` is all it takes; changesets ignores them automatically.
+Changesets only publishes packages that are (a) not `"private": true` and (b) under `packages/`. Everything else is invisible to it.
+
+Three packages never publish to npm: `@epicenter/ai`, `@epicenter/constants`, and `@epicenter/vault`. They're internal implementation details. `"private": true` in their `package.json` is all it takes; changesets ignores them automatically.
+
+**Every app in `apps/` is also `"private": true` and completely outside the changeset system.** Whispering versions come from `tauri.conf.json` and `v*` git tags. The API and landing page deploy via Cloudflare Workers on push to `main`. The Chrome extension versions via `manifest.json`. Changesets will never touch any of them—they have their own deploy pipelines documented in `.github/workflows/README.md`.
 
 The public/private split is intentional. `@epicenter/workspace` is the library other developers build on. The private packages are the internals that make Epicenter's own apps work. Keeping them private means we can change them without worrying about semver contracts.
 

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -12,12 +12,16 @@
 	"exports": {
 		"./apps": "./src/apps.ts",
 		"./vite": "./src/vite.ts",
-		"./versions": "./src/versions.ts"
+		"./versions": "./src/versions.ts",
+		"./ai-chat-errors": "./src/ai-chat-errors.ts"
 	},
 	"devDependencies": {
 		"@types/node": "catalog:",
 		"typescript": "catalog:",
 		"vite": "catalog:"
+	},
+	"dependencies": {
+		"wellcrafted": "catalog:"
 	},
 	"scripts": {
 		"typecheck": "tsc --noEmit"

--- a/packages/constants/src/ai-chat-errors.ts
+++ b/packages/constants/src/ai-chat-errors.ts
@@ -20,9 +20,9 @@ import { defineErrors, type InferErrors } from 'wellcrafted/error';
  * // Client — type-only usage
  * import { AiChatHttpError } from '@epicenter/constants/ai-chat-errors';
  * if (err instanceof AiChatHttpError) {
- *   switch (err.serverError.name) {
+ *   switch (err.detail.name) {
  *     case 'Unauthorized': // show sign-in
- *     case 'InsufficientCredits': // err.serverError.balance
+ *     case 'InsufficientCredits': // err.detail.balance
  *   }
  * }
  * ```
@@ -77,23 +77,26 @@ export const AiChatError = defineErrors({
 export type AiChatError = InferErrors<typeof AiChatError>;
 
 /**
- * Error subclass that carries structured server error data across
- * TanStack AI's throw boundary.
+ * Error subclass that carries structured error data across TanStack AI's
+ * throw boundary.
  *
- * Created by `createAiFetchClient` when the server returns a non-2xx
- * response with a wellcrafted `{ data, error }` JSON envelope. The
- * `Error` propagates unchanged through TanStack AI's `ChatClient`
- * pipeline—`instanceof AiChatHttpError` works in `onError` and
- * when reading `chat.error`.
+ * Created by `createAiChatFetch` when the server returns a non-2xx response
+ * with a wellcrafted `{ data, error }` JSON envelope. The `Error` propagates
+ * unchanged through TanStack AI's `ChatClient` pipeline—`instanceof
+ * AiChatHttpError` works in `onError` and when reading `chat.error`.
+ *
+ * The `detail` property carries the full discriminated union with
+ * variant-specific fields. Use `switch (err.detail.name)` for
+ * exhaustive handling.
  *
  * @example
  * ```ts
  * if (err instanceof AiChatHttpError) {
- *   console.log(err.status);            // 402
- *   console.log(err.serverError.name);  // "InsufficientCredits"
- *   switch (err.serverError.name) {
+ *   console.log(err.status);        // 402
+ *   console.log(err.detail.name);   // "InsufficientCredits"
+ *   switch (err.detail.name) {
  *     case 'InsufficientCredits':
- *       console.log(err.serverError.balance); // narrowed
+ *       console.log(err.detail.balance); // narrowed
  *       break;
  *   }
  * }
@@ -104,8 +107,8 @@ export class AiChatHttpError extends Error {
 
 	constructor(
 		readonly status: number,
-		readonly serverError: AiChatError,
+		readonly detail: AiChatError,
 	) {
-		super(serverError.message);
+		super(detail.message);
 	}
 }

--- a/packages/constants/src/ai-chat-errors.ts
+++ b/packages/constants/src/ai-chat-errors.ts
@@ -1,0 +1,111 @@
+import { defineErrors, type InferErrors } from 'wellcrafted/error';
+
+/**
+ * Structured error variants for the `/ai/chat` endpoint.
+ *
+ * Defined once in the shared constants package so both server and client
+ * reference the same discriminated union. The server calls the factories
+ * at runtime (`AiChatError.Unauthorized()`); the client imports only the
+ * `AiChatError` type via `InferErrors` for zero-cost type narrowing.
+ *
+ * Each variant's `name` field is the discriminant—use `switch (error.name)`
+ * for exhaustive handling with full TypeScript narrowing.
+ *
+ * @example
+ * ```ts
+ * // Server — runtime usage
+ * import { AiChatError } from '@epicenter/constants/ai-chat-errors';
+ * return c.json(AiChatError.InsufficientCredits({ balance: 42 }), 402);
+ *
+ * // Client — type-only usage
+ * import { AiChatHttpError } from '@epicenter/constants/ai-chat-errors';
+ * if (err instanceof AiChatHttpError) {
+ *   switch (err.serverError.name) {
+ *     case 'Unauthorized': // show sign-in
+ *     case 'InsufficientCredits': // err.serverError.balance
+ *   }
+ * }
+ * ```
+ */
+export const AiChatError = defineErrors({
+	Unauthorized: () => ({ message: 'Unauthorized' }),
+	ProviderNotConfigured: ({ provider }: { provider: string }) => ({
+		message: `${provider} not configured`,
+		provider,
+	}),
+	UnknownModel: ({ model }: { model: string }) => ({
+		message: `Unknown model: ${model}`,
+		model,
+	}),
+	InsufficientCredits: ({ balance }: { balance: unknown }) => ({
+		message: 'Insufficient credits',
+		balance,
+	}),
+	ModelRequiresPaidPlan: ({
+		model,
+		credits,
+	}: {
+		model: string;
+		credits: number;
+	}) => ({
+		message: `${model} requires a paid plan (costs ${credits} credits)`,
+		model,
+		credits,
+	}),
+});
+
+/**
+ * Discriminated union of all AI chat error payloads.
+ *
+ * Reused by both server (runtime) and client (type narrowing).
+ * The `name` field discriminates variants in `switch` statements.
+ *
+ * @example
+ * ```ts
+ * function handleError(error: AiChatError) {
+ *   switch (error.name) {
+ *     case 'InsufficientCredits':
+ *       console.log(error.balance); // TypeScript knows this exists
+ *       break;
+ *     case 'ModelRequiresPaidPlan':
+ *       console.log(error.model, error.credits); // narrowed
+ *       break;
+ *   }
+ * }
+ * ```
+ */
+export type AiChatError = InferErrors<typeof AiChatError>;
+
+/**
+ * Error subclass that carries structured server error data across
+ * TanStack AI's throw boundary.
+ *
+ * Created by `createAiFetchClient` when the server returns a non-2xx
+ * response with a wellcrafted `{ data, error }` JSON envelope. The
+ * `Error` propagates unchanged through TanStack AI's `ChatClient`
+ * pipeline—`instanceof AiChatHttpError` works in `onError` and
+ * when reading `chat.error`.
+ *
+ * @example
+ * ```ts
+ * if (err instanceof AiChatHttpError) {
+ *   console.log(err.status);            // 402
+ *   console.log(err.serverError.name);  // "InsufficientCredits"
+ *   switch (err.serverError.name) {
+ *     case 'InsufficientCredits':
+ *       console.log(err.serverError.balance); // narrowed
+ *       break;
+ *   }
+ * }
+ * ```
+ */
+export class AiChatHttpError extends Error {
+	override readonly name = 'AiChatHttpError';
+
+	constructor(
+		readonly status: number,
+		readonly serverError: AiChatError,
+	) {
+		super(serverError.message);
+	}
+}

--- a/packages/constants/tsconfig.json
+++ b/packages/constants/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": ["../../tsconfig.base.lib.json"],
+	"extends": ["../../tsconfig.base.json"],
 	"compilerOptions": {
 		"module": "NodeNext",
 		"moduleResolution": "NodeNext",

--- a/packages/svelte-utils/package.json
+++ b/packages/svelte-utils/package.json
@@ -19,6 +19,7 @@
 		"./workspace-gate": "./src/workspace-gate/index.ts"
 	},
 	"dependencies": {
+		"@epicenter/constants": "workspace:*",
 		"@epicenter/api": "workspace:*",
 		"@epicenter/ui": "workspace:*",
 		"@epicenter/workspace": "workspace:*",

--- a/packages/svelte-utils/src/auth/create-ai-chat-fetch.ts
+++ b/packages/svelte-utils/src/auth/create-ai-chat-fetch.ts
@@ -2,6 +2,7 @@ import {
 	type AiChatError,
 	AiChatHttpError,
 } from '@epicenter/constants/ai-chat-errors';
+import { tryAsync, Ok } from 'wellcrafted/result';
 
 /**
  * Wrap an authenticated fetch client to read structured error bodies
@@ -50,33 +51,30 @@ type FetchFn = (
 export function createAiChatFetch(authFetch: FetchFn): FetchFn {
 	return async (input, init) => {
 		const response = await authFetch(input, init);
+		if (response.ok) return response;
 
-		if (!response.ok) {
-			let detail: AiChatError | undefined;
-			try {
+		// Read the body before TanStack AI's adapter can throw its generic
+		// "HTTP error! status: 401" without reading it.
+		const { data: detail } = await tryAsync({
+			try: async () => {
 				const body = await response.json();
-				// wellcrafted Err envelope: { data: null, error: { name, message, ... } }
 				if (
 					body?.error &&
 					typeof body.error === 'object' &&
 					'name' in body.error
 				) {
-					detail = body.error as AiChatError;
+					return body.error as AiChatError;
 				}
-			} catch {
-				// Body wasn't JSON — fall through with undefined detail
-			}
+			},
+			catch: () => Ok(undefined),
+		});
 
-			if (detail) {
-				throw new AiChatHttpError(response.status, detail);
-			}
-
-			// Non-JSON or unrecognized error body — throw generic Error
-			throw new Error(
-				`HTTP error! status: ${response.status} ${response.statusText}`,
-			);
+		if (detail) {
+			throw new AiChatHttpError(response.status, detail);
 		}
 
-		return response;
+		throw new Error(
+			`HTTP error! status: ${response.status} ${response.statusText}`,
+		);
 	};
 }

--- a/packages/svelte-utils/src/auth/create-ai-chat-fetch.ts
+++ b/packages/svelte-utils/src/auth/create-ai-chat-fetch.ts
@@ -10,7 +10,7 @@ import {
  * When the server returns a non-2xx response, this wrapper:
  * 1. Reads the JSON body (wellcrafted's `{ data, error }` envelope)
  * 2. Extracts the structured error (`name`, `message`, variant fields)
- * 3. Throws an `AiChatHttpError` with `.status` and `.serverError`
+ * 3. Throws an `AiChatHttpError` with `.status` and `.detail`
  *
  * The thrown error propagates unchanged through TanStack AI's
  * `ChatClient` pipeline to `onError` / `chat.error`. Use
@@ -21,21 +21,21 @@ import {
  *
  * @example
  * ```ts
- * import { createAiFetchClient } from '@epicenter/svelte-utils';
+ * import { createAiChatFetch } from '@epicenter/svelte-utils/auth';
  * import { AiChatHttpError } from '@epicenter/constants/ai-chat-errors';
  *
  * // In chat-state.svelte.ts:
  * connection: fetchServerSentEvents(
  *   () => `${APP_URLS.API}/ai/chat`,
  *   async () => ({
- *     fetchClient: createAiFetchClient(auth.fetch),
+ *     fetchClient: createAiChatFetch(auth.fetch),
  *     body: { data: { provider, model } },
  *   }),
  * ),
  *
  * // Then in error handling:
  * if (chat.error instanceof AiChatHttpError) {
- *   switch (chat.error.serverError.name) {
+ *   switch (chat.error.detail.name) {
  *     case 'Unauthorized': // show sign-in
  *     case 'InsufficientCredits': // show upgrade
  *   }
@@ -47,12 +47,12 @@ type FetchFn = (
 	init?: RequestInit,
 ) => Promise<Response>;
 
-export function createAiFetchClient(authFetch: FetchFn): FetchFn {
+export function createAiChatFetch(authFetch: FetchFn): FetchFn {
 	return async (input, init) => {
 		const response = await authFetch(input, init);
 
 		if (!response.ok) {
-			let serverError: AiChatError | undefined;
+			let detail: AiChatError | undefined;
 			try {
 				const body = await response.json();
 				// wellcrafted Err envelope: { data: null, error: { name, message, ... } }
@@ -61,14 +61,14 @@ export function createAiFetchClient(authFetch: FetchFn): FetchFn {
 					typeof body.error === 'object' &&
 					'name' in body.error
 				) {
-					serverError = body.error as AiChatError;
+					detail = body.error as AiChatError;
 				}
 			} catch {
-				// Body wasn't JSON — fall through with undefined serverError
+				// Body wasn't JSON — fall through with undefined detail
 			}
 
-			if (serverError) {
-				throw new AiChatHttpError(response.status, serverError);
+			if (detail) {
+				throw new AiChatHttpError(response.status, detail);
 			}
 
 			// Non-JSON or unrecognized error body — throw generic Error

--- a/packages/svelte-utils/src/auth/create-ai-fetch-client.ts
+++ b/packages/svelte-utils/src/auth/create-ai-fetch-client.ts
@@ -1,0 +1,82 @@
+import {
+	type AiChatError,
+	AiChatHttpError,
+} from '@epicenter/constants/ai-chat-errors';
+
+/**
+ * Wrap an authenticated fetch client to read structured error bodies
+ * before TanStack AI's adapter can throw a generic status-only error.
+ *
+ * When the server returns a non-2xx response, this wrapper:
+ * 1. Reads the JSON body (wellcrafted's `{ data, error }` envelope)
+ * 2. Extracts the structured error (`name`, `message`, variant fields)
+ * 3. Throws an `AiChatHttpError` with `.status` and `.serverError`
+ *
+ * The thrown error propagates unchanged through TanStack AI's
+ * `ChatClient` pipeline to `onError` / `chat.error`. Use
+ * `instanceof AiChatHttpError` on the client side to narrow it.
+ *
+ * @param authFetch - An authenticated fetch function (e.g. `auth.fetch`)
+ * @returns A fetch-compatible function that enriches errors with server data
+ *
+ * @example
+ * ```ts
+ * import { createAiFetchClient } from '@epicenter/svelte-utils';
+ * import { AiChatHttpError } from '@epicenter/constants/ai-chat-errors';
+ *
+ * // In chat-state.svelte.ts:
+ * connection: fetchServerSentEvents(
+ *   () => `${APP_URLS.API}/ai/chat`,
+ *   async () => ({
+ *     fetchClient: createAiFetchClient(auth.fetch),
+ *     body: { data: { provider, model } },
+ *   }),
+ * ),
+ *
+ * // Then in error handling:
+ * if (chat.error instanceof AiChatHttpError) {
+ *   switch (chat.error.serverError.name) {
+ *     case 'Unauthorized': // show sign-in
+ *     case 'InsufficientCredits': // show upgrade
+ *   }
+ * }
+ * ```
+ */
+type FetchFn = (
+	input: RequestInfo | URL,
+	init?: RequestInit,
+) => Promise<Response>;
+
+export function createAiFetchClient(authFetch: FetchFn): FetchFn {
+	return async (input, init) => {
+		const response = await authFetch(input, init);
+
+		if (!response.ok) {
+			let serverError: AiChatError | undefined;
+			try {
+				const body = await response.json();
+				// wellcrafted Err envelope: { data: null, error: { name, message, ... } }
+				if (
+					body?.error &&
+					typeof body.error === 'object' &&
+					'name' in body.error
+				) {
+					serverError = body.error as AiChatError;
+				}
+			} catch {
+				// Body wasn't JSON — fall through with undefined serverError
+			}
+
+			if (serverError) {
+				throw new AiChatHttpError(response.status, serverError);
+			}
+
+			// Non-JSON or unrecognized error body — throw generic Error
+			throw new Error(
+				`HTTP error! status: ${response.status} ${response.statusText}`,
+			);
+		}
+
+		return response;
+	};
+}

--- a/packages/svelte-utils/src/auth/index.ts
+++ b/packages/svelte-utils/src/auth/index.ts
@@ -8,4 +8,4 @@ export {
 	type CreateAuthOptions,
 	createAuth,
 } from './create-auth.svelte.js';
-export { createAiFetchClient } from './create-ai-fetch-client.js';
+export { createAiChatFetch } from './create-ai-chat-fetch.js';

--- a/packages/svelte-utils/src/auth/index.ts
+++ b/packages/svelte-utils/src/auth/index.ts
@@ -8,3 +8,4 @@ export {
 	type CreateAuthOptions,
 	createAuth,
 } from './create-auth.svelte.js';
+export { createAiFetchClient } from './create-ai-fetch-client.js';

--- a/specs/20260407T165605-structured-ai-chat-errors.md
+++ b/specs/20260407T165605-structured-ai-chat-errors.md
@@ -1,0 +1,515 @@
+# Structured AI Chat Errors: defineErrors End-to-End
+
+**Date**: 2026-04-07
+**Status**: Draft
+**Author**: AI-assisted
+
+## Overview
+
+Carry wellcrafted `defineErrors` structured errors from the API's JSON response all the way to the client's chat UI, so the frontend can show "Sign in to use AI Chat" instead of "HTTP error! status: 401". The server already sends structured errors—the client just doesn't read them.
+
+## Motivation
+
+### Current State
+
+The server returns structured, discriminated errors:
+
+```ts
+// apps/api/src/ai-chat.ts
+const AiChatError = defineErrors({
+  InsufficientCredits: ({ balance }) => ({ message: 'Insufficient credits', balance }),
+  ModelRequiresPaidPlan: ({ model, credits }) => ({
+    message: `${model} requires a paid plan (costs ${credits} credits)`,
+    model, credits,
+  }),
+});
+
+return c.json(AiChatError.InsufficientCredits({ balance }), 402);
+// Wire: { "data": null, "error": { "name": "InsufficientCredits", "message": "...", "balance": 42 } }
+```
+
+But TanStack AI's `fetchServerSentEvents` throws before reading the body:
+
+```ts
+// @tanstack/ai-client — connection-adapters.ts:297
+if (!response.ok) {
+  throw new Error(`HTTP error! status: ${response.status} ${response.statusText}`)
+  //                ▲ body is NEVER read — structured error is lost
+}
+```
+
+The client parses status codes from error message strings:
+
+```ts
+// apps/opensidian/src/lib/chat/chat-state.svelte.ts
+get isCreditsExhausted() {
+  return chat.error.message.includes('status: 402');  // fragile string parsing
+},
+```
+
+This creates problems:
+
+1. **Lost structured data**: The server sends `{ name, message, balance, model, credits }` but the client only sees `"HTTP error! status: 402"`. All fields besides the status code are discarded.
+2. **Fragile discrimination**: `error.message.includes('status: 402')` breaks if TanStack AI ever changes the message format. Can't distinguish between different error variants that share a status code.
+3. **No actionable UI**: The error banner shows `"HTTP error! status: 401"` instead of "Sign in to use AI Chat" with a sign-in button. Each error type should drive specific UI affordances.
+
+### Desired State
+
+```ts
+// Client-side — typed, structured error from the server
+const err = chat.error;
+if (isAiChatError(err)) {
+  switch (err.serverError.name) {
+    case 'Unauthorized':
+      // Show sign-in prompt
+      break;
+    case 'InsufficientCredits':
+      // Show "upgrade plan" with err.serverError.balance
+      break;
+    case 'ModelRequiresPaidPlan':
+      // Show "this model needs Pro" with err.serverError.model
+      break;
+    case 'ProviderNotConfigured':
+      // Show BYOK API key prompt
+      break;
+  }
+}
+```
+
+## Research Findings
+
+### TanStack AI Error Pipeline
+
+Traced the full path from server response to client `onError`:
+
+```
+fetchServerSentEvents
+  └─ calls fetchClient(url, opts)
+       └─ gets Response
+            └─ if (!response.ok) throw Error(`HTTP error! status: ${status}`)
+                                       ▲ body never read
+                                       │
+normalizeConnectionAdapter.send()
+  └─ catches thrown error
+       └─ pushes RUN_ERROR chunk: { type: 'RUN_ERROR', error: { message: err.message } }
+       └─ re-throws the error
+            │
+ChatClient.streamResponse()
+  └─ catches thrown error
+       └─ reportStreamError(err)
+            └─ setError(err)         → chat.error
+            └─ onError(err)          → your callback
+```
+
+**Key finding**: The `Error` instance thrown by `fetchServerSentEvents` is the exact same `Error` object that arrives at `onError`. It's not re-wrapped or cloned. Any properties we attach to it survive the entire pipeline.
+
+**Key finding**: `fetchClient` is called *before* the `!response.ok` check. If our custom `fetchClient` throws first (after reading the body), TanStack AI's check never executes. The thrown error propagates directly through the same catch chain.
+
+### wellcrafted defineErrors Wire Format
+
+`defineErrors` produces `Err(Object.freeze({ ...body, name }))` which Hono's `c.json()` serializes as:
+
+```json
+{
+  "data": null,
+  "error": {
+    "name": "InsufficientCredits",
+    "message": "Insufficient credits",
+    "balance": 42
+  }
+}
+```
+
+The `name` field is the discriminant—identical to how `switch (error.name)` works in the Result pattern. The full `error` object is a frozen plain object, fully JSON-serializable, no prototype chain.
+
+### Can We Avoid Throwing Entirely?
+
+**Constraint**: TanStack AI's `ChatClient` consumes the connection adapter via `await this.connection.send(messages, body, signal)`. The only error channel is throwing—`send()` returns `void`, and `ChatClient.streamResponse()` only checks for errors via the catch block (line 636) and the `RUN_ERROR` chunk.
+
+We cannot change `ChatClient`'s internal error handling without forking TanStack AI. The throw boundary is inside `ChatClient`—it's their code.
+
+**However**: We control everything *before* the throw. The `fetchClient` option lets us:
+1. Read the response body
+2. Parse the structured error
+3. Attach it to the `Error` object we throw
+4. The `Error` propagates unchanged to `onError`
+
+So the answer is: **defineErrors all the way down to the throw boundary, then attach the structured data to the Error that crosses it**. On the client side, we extract it back out.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Where to read error body | Custom `fetchClient` wrapper | Only intervention point before TanStack AI discards the body. The `fetchClient` option is explicitly designed for this (auth, proxies, custom transport). |
+| How to attach structured data | Properties on the thrown `Error` | The same `Error` instance propagates to `onError`—verified by tracing the code. No cloning or re-wrapping occurs. |
+| Error shape on the wire | Keep `{ data, error }` Result envelope | Already in place. `c.json(AiChatError.Variant(), status)` produces this. No server changes needed for serialization. |
+| Client-side type narrowing | Type guard function `isAiChatHttpError(err)` | Clean narrowing. Avoids `as any` casts. Single place to define the shape. |
+| Client-side error type | `InferErrors<typeof AiChatError>` reused from server's `defineErrors` | No manual type mirroring. The server defines the error variants once; the client imports the type. `switch (err.serverError.name)` gives full TypeScript narrowing with variant-specific fields. |
+| Where to define shared errors | `@epicenter/constants` | Both server and client import from here. Server uses the factories at runtime; client uses `InferErrors` type-only + the type guard at runtime. |
+| Server response changes | Merge `Unauthorized` into `AiChatError` | Currently `AuthError.Unauthorized()` is in `app.ts` separately. Moving it into the shared `AiChatError` keeps all `/ai/chat` errors in one discriminated union. |
+
+## Architecture
+
+### Error Flow (After)
+
+```
+SERVER                              WIRE                          CLIENT
+──────                              ────                          ──────
+
+AiChatError                         HTTP 402                      createAiFetchClient
+  .InsufficientCredits              Body:                           │
+  ({ balance: 42 })                 ┌──────────────────┐            ▼
+    │                               │{ "data": null,   │         response = await
+    ▼                               │  "error": {      │           authFetch(url, init)
+  c.json(result, 402)              │    "name":       │         if (!response.ok) {
+                                    │     "Insufficient│           body = await response.json()
+                                    │      Credits",   │           ──────────────────────────
+                                    │    "message":    │           READS BODY ← key change
+                                    │     "Insuffici..."│          ──────────────────────────
+                                    │    "balance": 42 │           const err = new Error(...)
+                                    │  }               │           err.status = 402
+                                    │}                 │           err.serverError = body.error
+                                    └──────────────────┘           throw err
+                                                                     │
+                                    (body IS read this time)         │
+                                                                     ▼
+                                                                  normalizeConnectionAdapter
+                                                                    └─ re-throws (same err)
+                                                                       │
+                                                                       ▼
+                                                                  ChatClient.reportStreamError
+                                                                    └─ setError(err)
+                                                                    └─ onError(err)
+                                                                       │
+                                                                       ▼
+                                                                  chat.error  ← has .serverError
+                                                                       │
+                                                                       ▼
+                                                                  AiChat.svelte
+                                                                    if isAiChatError(err):
+                                                                      switch (err.serverError.name)
+                                                                        "Unauthorized" → sign-in UI
+                                                                        "InsufficientCredits" → upgrade
+                                                                        "ModelRequiresPaidPlan" → hint
+                                                                        "ProviderNotConfigured" → BYOK
+```
+
+### Type Hierarchy
+
+The key insight: `InferErrors<typeof AiChatError>` already produces the exact discriminated union that goes over the wire. We reuse the server's type directly—no manual mirroring.
+
+```ts
+// What InferErrors<typeof AiChatError> produces:
+| Readonly<{ name: "ProviderNotConfigured"; message: string; provider: string }>
+| Readonly<{ name: "UnknownModel"; message: string; model: string }>
+| Readonly<{ name: "InsufficientCredits"; message: string; balance: unknown }>
+| Readonly<{ name: "ModelRequiresPaidPlan"; message: string; model: string; credits: number }>
+
+// This is the EXACT shape that c.json() serializes into response.error.
+// The client type-asserts the parsed JSON into this union.
+// switch (error.name) narrows to the specific variant with all its fields.
+```
+
+```
+                   Error (JS built-in)
+                     │
+                     ▼
+               AiChatHttpError extends Error
+                 ├── status: number
+                 ├── serverError: InferErrors<typeof AiChatError>
+                 │                      ▲
+                 │                      │ same type from server's defineErrors
+                 │                      │ reused via type-only import
+                 └── message: string (from serverError.message or fallback)
+```
+
+## Implementation Plan
+
+### Phase 1: Extract Shared Error Definitions
+
+- [ ] **1.1** Move `AiChatError` defineErrors (and the `AuthError.Unauthorized` variant for `/ai/*`) into a shared location that both server and client can import. Two options:
+
+**Option A (recommended)**: Extract the `defineErrors` call into a shared package (e.g. `packages/constants/src/ai-chat-errors.ts`). The server imports and uses the factories. The client imports the type only (`InferErrors`).
+
+```ts
+// packages/constants/src/ai-chat-errors.ts
+import { defineErrors, type InferErrors } from 'wellcrafted/error';
+
+export const AiChatError = defineErrors({
+  Unauthorized: () => ({ message: 'Unauthorized' }),
+  ProviderNotConfigured: ({ provider }: { provider: string }) => ({
+    message: `${provider} not configured`,
+    provider,
+  }),
+  UnknownModel: ({ model }: { model: string }) => ({
+    message: `Unknown model: ${model}`,
+    model,
+  }),
+  InsufficientCredits: ({ balance }: { balance: unknown }) => ({
+    message: 'Insufficient credits',
+    balance,
+  }),
+  ModelRequiresPaidPlan: ({
+    model,
+    credits,
+  }: {
+    model: string;
+    credits: number;
+  }) => ({
+    message: `${model} requires a paid plan (costs ${credits} credits)`,
+    model,
+    credits,
+  }),
+});
+
+/** Discriminated union of all AI chat error payloads—reused by both server and client. */
+export type AiChatError = InferErrors<typeof AiChatError>;
+```
+
+**Option B**: Keep `defineErrors` in `apps/api/src/ai-chat.ts` and export only the type. The client imports `type AiChatError` from the API package. Simpler if you don't want to move runtime code, but creates a dependency from client → API types.
+
+- [ ] **1.2** Create the type guard and HTTP error type using `InferErrors`:
+
+```ts
+// packages/constants/src/ai-chat-errors.ts (continued)
+
+/** An Error with structured server error data attached. */
+export type AiChatHttpError = Error & {
+  status: number;
+  serverError: AiChatError;  // ← the InferErrors union, not a manual type
+};
+
+/** Type guard: narrows an Error to AiChatHttpError with full variant discrimination. */
+export function isAiChatHttpError(err: unknown): err is AiChatHttpError {
+  return (
+    err instanceof Error &&
+    'status' in err &&
+    typeof (err as any).status === 'number' &&
+    'serverError' in err &&
+    typeof (err as any).serverError === 'object' &&
+    (err as any).serverError !== null &&
+    'name' in (err as any).serverError
+  );
+}
+```
+
+Now the client gets full TypeScript narrowing:
+
+```ts
+if (isAiChatHttpError(err)) {
+  switch (err.serverError.name) {
+    case 'InsufficientCredits':
+      err.serverError.balance;  // ← TypeScript knows this exists
+      break;
+    case 'ModelRequiresPaidPlan':
+      err.serverError.model;    // ← narrowed to string
+      err.serverError.credits;  // ← narrowed to number
+      break;
+    case 'Unauthorized':
+      // no extra fields, just show sign-in UI
+      break;
+  }
+}
+```
+
+- [ ] **1.3** Export from `packages/constants/src/index.ts` and verify the package builds.
+
+### Phase 2: Custom fetchClient Wrapper
+
+- [ ] **2.1** Create `packages/svelte-utils/src/auth/create-ai-fetch-client.ts`:
+
+```ts
+import type { AiChatError } from '@epicenter/constants';
+
+/**
+ * Wrap an authenticated fetch client to read structured error bodies
+ * before TanStack AI's adapter can throw a generic status-only error.
+ *
+ * When the server returns a non-2xx response, this wrapper:
+ * 1. Reads the JSON body (wellcrafted's { data, error } envelope)
+ * 2. Extracts the structured error (name, message, variant fields)
+ * 3. Throws an Error with .status and .serverError attached
+ *
+ * The thrown Error propagates unchanged through TanStack AI's
+ * ChatClient pipeline to onError / chat.error.
+ */
+export function createAiFetchClient(authFetch: typeof fetch): typeof fetch {
+  return async (input, init) => {
+    const response = await authFetch(input, init);
+
+    if (!response.ok) {
+      let serverError: AiChatError | undefined;
+      try {
+        const body = await response.json();
+        // wellcrafted Err envelope: { data: null, error: { name, message, ... } }
+        if (body?.error && typeof body.error === 'object' && 'name' in body.error) {
+          serverError = body.error as AiChatError;
+        }
+      } catch {
+        // Body wasn't JSON — fall through with undefined serverError
+      }
+
+      const message = serverError?.message ?? `HTTP error! status: ${response.status}`;
+      const error = new Error(message) as Error & {
+        status: number;
+        serverError: AiChatError | undefined;
+      };
+      error.status = response.status;
+      error.serverError = serverError;
+      throw error;
+    }
+
+    return response;
+  };
+}
+```
+
+- [ ] **2.2** Export from `packages/svelte-utils/src/index.ts`.
+
+### Phase 3: Wire Into Chat State
+
+- [ ] **3.1** Update `apps/opensidian/src/lib/chat/chat-state.svelte.ts`:
+
+```ts
+import { createAiFetchClient } from '@epicenter/svelte-utils';
+import { isAiChatHttpError } from '@epicenter/constants';
+
+// In createConversationHandle:
+connection: fetchServerSentEvents(
+  () => `${APP_URLS.API}/ai/chat`,
+  async () => ({
+    fetchClient: createAiFetchClient(auth.fetch),  // ← swap
+    body: { data: { ... } },
+  }),
+),
+```
+
+- [ ] **3.2** Replace string-based error detection with typed checks:
+
+```ts
+get isCreditsExhausted() {
+  return isAiChatHttpError(chat.error)
+    && chat.error.serverError.name === 'InsufficientCredits';
+},
+
+get isUnauthorized() {
+  return isAiChatHttpError(chat.error)
+    && chat.error.serverError.name === 'Unauthorized';
+},
+
+get isModelRestricted() {
+  return isAiChatHttpError(chat.error)
+    && chat.error.serverError.name === 'ModelRequiresPaidPlan';
+},
+```
+
+- [ ] **3.3** Apply the same changes to `apps/tab-manager/src/lib/chat/chat-state.svelte.ts` (same pattern).
+
+### Phase 4: Server — Unify Auth Error Into AiChatError
+
+- [ ] **4.1** The `authGuard` in `app.ts` returns `AuthError.Unauthorized()` before the request reaches `ai-chat.ts`. Two options:
+
+**Option A (minimal)**: Keep `AuthError` in `app.ts` as-is. The fetchClient wrapper already reads any `{ data, error }` envelope regardless of which `defineErrors` produced it. The `name: "Unauthorized"` field matches the shared type.
+
+**Option B (clean)**: Add `Unauthorized` to `AiChatError` in `ai-chat.ts` and use a route-level middleware override for `/ai/chat` that returns the ai-chat-specific error. This keeps all `/ai/chat` error variants in one union.
+
+**Recommendation**: Option A. The existing `AuthError.Unauthorized()` already produces `{ name: "Unauthorized", message: "Unauthorized" }` which the client type guard handles. No server changes needed.
+
+### Phase 5: UI Error States
+
+- [ ] **5.1** Update `AiChat.svelte` to show contextual error UI:
+
+```svelte
+{#if active?.isUnauthorized}
+  <div class="...">
+    <span>Sign in to use AI Chat</span>
+    <Button onclick={() => /* open auth popover or navigate */}>Sign In</Button>
+  </div>
+{:else if active?.isCreditsExhausted}
+  <div class="...">
+    <span>You're out of credits</span>
+    <Button onclick={() => /* open billing */}>Upgrade</Button>
+  </div>
+{:else if active?.isModelRestricted}
+  <div class="...">
+    <span>{active.error?.serverError?.message}</span>
+    <Button onclick={() => /* switch to free model */}>Switch Model</Button>
+  </div>
+{:else if errorVisible}
+  <!-- Generic fallback for unknown errors -->
+  <div class="...">{active?.error?.message}</div>
+{/if}
+```
+
+- [ ] **5.2** Decide whether to also show a subtle auth indicator in the chat header (e.g. small "Not signed in" badge) *before* the user sends a message.
+
+## Edge Cases
+
+### Non-JSON Error Responses
+
+1. Server returns HTML error page (502 from Cloudflare, proxy error)
+2. `response.json()` throws in the wrapper
+3. `serverError` stays `undefined`, `message` falls back to `HTTP error! status: 502`
+4. UI shows generic error banner—same as today, but with a cleaner message
+
+### Network Errors (No Response At All)
+
+1. `fetch()` itself throws (DNS failure, offline)
+2. Wrapper never reaches the `!response.ok` check—the thrown error propagates directly
+3. `isAiChatHttpError` returns `false` (no `.status` or `.serverError`)
+4. UI shows generic error banner with the network error message
+
+### BYOK Requests That Fail
+
+1. User provides their own API key, server's provider adapter throws
+2. Server catches in `ai-chat.ts`, refunds credits via `afterResponse`
+3. The thrown error from the stream adapter is a different shape (not from `defineErrors`)
+4. Client shows generic error—this is correct behavior, the error is from the LLM provider, not from our auth/billing
+
+### Concurrent Conversations With Different Auth States
+
+1. User is signed in, opens conversation A, starts streaming
+2. Token expires mid-stream
+3. Conversation B send fails with 401
+4. Each conversation handle has independent `error` state—conversation A continues, B shows auth prompt
+5. No global state corruption
+
+## Open Questions
+
+1. **Should we show an auth state indicator before the user sends?**
+   - Options: (a) Subtle "Not signed in" badge in chat header, (b) Nothing until they try to send, (c) Replace the input placeholder text with "Sign in to chat..."
+   - **Recommendation**: (b) initially—the "discover, try, get prompted" flow is what you described. Can add (a) or (c) later if users are confused.
+
+2. **Where should the shared error types live?**
+   - Options: (a) `@epicenter/constants`, (b) New `@epicenter/ai-errors` package, (c) Inline in each app
+   - **Recommendation**: (a) `@epicenter/constants`—it already exists and holds shared cross-app types. The error type is small and stable.
+
+3. **Should we expose `serverError` directly on the conversation handle, or keep it internal?**
+   - Options: (a) `active.serverError` property on ConversationHandle, (b) Only expose boolean helpers like `isUnauthorized`, (c) Both
+   - **Recommendation**: (c) Both. Booleans for common cases in templates, raw access for uncommon cases.
+
+4. **Should we attempt to parse `defineErrors` bodies from ALL non-2xx routes, or only `/ai/chat`?**
+   - The wrapper is generic—it'll parse any `{ data, error }` envelope from any Hono route. Could be reused for sync errors, billing errors, asset errors.
+   - **Recommendation**: Make the wrapper generic (it already is). Use the specific `AiChatErrorName` union only for the AI chat UI logic. Other features can define their own unions later.
+
+## Success Criteria
+
+- [ ] Sending a message when not authenticated shows "Sign in to use AI Chat" (not "HTTP error! status: 401")
+- [ ] Running out of credits shows "You're out of credits" with the balance from the server
+- [ ] Using an expensive model on free tier shows the model name and credit cost from the server
+- [ ] Network errors still show a reasonable generic message
+- [ ] No `error.message.includes('status:')` string parsing anywhere in the codebase
+- [ ] `isAiChatHttpError` type guard works with TypeScript narrowing
+- [ ] Both opensidian and tab-manager apps use the same pattern
+- [ ] Existing behavior for successful requests is unchanged
+
+## References
+
+- `apps/api/src/app.ts` — `authGuard` middleware, `AuthError.Unauthorized()` (lines 274-291)
+- `apps/api/src/ai-chat.ts` — `AiChatError` defineErrors, all error responses (lines 37-61, 89-120)
+- `apps/opensidian/src/lib/chat/chat-state.svelte.ts` — Chat state, `fetchServerSentEvents` wiring, `isCreditsExhausted` (lines 97-128, 208-211)
+- `apps/tab-manager/src/lib/chat/chat-state.svelte.ts` — Same pattern, needs same changes
+- `packages/svelte-utils/src/auth/create-auth.svelte.ts` — `auth.fetch` implementation (lines 410-415)
+- `tmp-search/tanstack-ai/.../connection-adapters.ts` — `fetchServerSentEvents` `!response.ok` branch (lines 297-301)
+- `tmp-search/tanstack-ai/.../chat-client.ts` — `reportStreamError`, error propagation (lines 328-344, 636-644)
+- `node_modules/.bun/wellcrafted@0.34.1/.../error/index.js` — `defineErrors` runtime, `Err` wrapper (lines 57-67)


### PR DESCRIPTION
When you're not logged in and send a chat message in opensidian, the server returns a perfectly structured JSON error—variant name, human message, typed fields like `balance` and `model`—wrapped in wellcrafted's `{ data, error }` envelope. But TanStack AI's `fetchServerSentEvents` adapter throws `new Error("HTTP error! status: 401")` *before reading the response body*. The structured payload is sent over the wire and discarded on arrival. The user sees a red banner saying "HTTP error! status: 401".

```
SERVER                            WIRE                           CLIENT (before)
──────                            ────                           ──────────────
AiChatError                       HTTP 401                       fetchServerSentEvents
  .Unauthorized()                 Body:                            if (!response.ok)
      │                           { "data": null,                    throw new Error(
      ▼                             "error": {                         "HTTP error!
  c.json(result, 401)                "name": "Unauthorized",            status: 401"
                                     "message": "Unauthorized"        )
                                   }                               BODY NEVER READ
                                  }                                ──────────────
                                                                   User sees:
                                  ← sent, discarded →             "HTTP error! status: 401"
```

The server already does everything right. The fix is a 30-line fetch wrapper that sits between `auth.fetch` and TanStack AI's adapter, reads `response.json()` on non-2xx, and throws an `AiChatHttpError` (proper Error subclass) with the full typed payload attached as `.detail`.

```
SERVER                            WIRE                           CLIENT (after)
──────                            ────                           ─────────────
AiChatError                       HTTP 401                       createAiChatFetch
  .Unauthorized()                 Body:                            reads response.json()
      │                           { "data": null,                  throws AiChatHttpError(
      ▼                             "error": {                       status: 401,
  c.json(result, 401)                "name": "Unauthorized"          detail: { name: "Unauthorized" }
                                   }                               )
                                  }                                    │
                                                                       ▼
                                  ← sent, read ✓ →                 chat.error instanceof
                                                                     AiChatHttpError ✓
                                                                   chat.error.detail.name
                                                                     → "Unauthorized"
```

The `AiChatError` `defineErrors` definition (variants: `Unauthorized`, `InsufficientCredits`, `ModelRequiresPaidPlan`, `UnknownModel`, `ProviderNotConfigured`) lives in `@epicenter/constants/ai-chat-errors` so both server and client share the same discriminated union. The server calls the factories at runtime; the client uses `InferErrors<typeof AiChatError>` for type narrowing. `switch (err.detail.name)` gives exhaustive narrowing with variant-specific fields:

```typescript
if (err instanceof AiChatHttpError) {
  switch (err.detail.name) {
    case 'InsufficientCredits':
      err.detail.balance;  // TS knows: unknown
      break;
    case 'ModelRequiresPaidPlan':
      err.detail.model;    // TS knows: string
      err.detail.credits;  // TS knows: number
      break;
    case 'Unauthorized':
      // no extra fields—show sign-in UI
      break;
  }
}
```

The server-side `defineErrors` that was duplicated in `ai-chat.ts` and `app.ts` is now imported from the shared package. Net deletion of ~30 lines of server code.

---

**On the UI side**, both opensidian and tab-manager now show contextual error banners instead of the raw error string. Auth and credits errors are persistent (you must act—sign in or upgrade), everything else is dismissable with retry/dismiss buttons. The previous dismiss logic had a bug where structured errors couldn't be dismissed because the `isModelRestricted` branch didn't check `dismissedError`—fixed by collapsing all dismissable errors into the single `errorVisible` branch.

```
┌─────────────────────────────────────────────────────────┐
│  Error Type              │  UX                          │
├──────────────────────────┼──────────────────────────────┤
│  Unauthorized            │  "Sign in to use AI Chat"    │
│                          │  + Sign In button (sticky)   │
├──────────────────────────┼──────────────────────────────┤
│  InsufficientCredits     │  "You're out of credits"     │
│                          │  + Upgrade button (sticky)   │
├──────────────────────────┼──────────────────────────────┤
│  ModelRequiresPaidPlan   │  Server message with model   │
│  + all other errors      │  name + Retry/Dismiss        │
└──────────────────────────┴──────────────────────────────┘
```

7 commits, 19 files changed, ~870 lines added / ~60 removed. Most of the addition is the spec doc and JSDoc.