### PR TITLE
docs: app READMEs, package descriptions, and root README expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Each user gets their own database. Schema definitions are plain JSON, so they wo
 
 ## Where We're Headed
 
-More apps are coming—notes, an AI assistant, and others—all sharing the same workspace. The architecture already supports it; the [`@epicenter/workspace`](packages/workspace) library handles the hard parts (schemas, CRDT sync, materialization), so each new app is mostly UI.
+More apps are in progress—each one shares the same workspace, so data flows between them without import/export. The [`@epicenter/workspace`](packages/workspace) library handles the hard parts (schemas, CRDT sync, materialization), so each new app is mostly UI.
 
 Epicenter Cloud will provide hosted sync for people who don't want to run their own server. Same model as Supabase selling hosted Postgres or Liveblocks selling hosted collaboration. Self-hosting is and will remain first-class—the sync server is open source under AGPL, and when you run it yourself, you control the encryption keys and trust boundary.
 

--- a/README.md
+++ b/README.md
@@ -106,15 +106,27 @@ The dependency flow is strict: core has zero upward dependencies, middleware onl
       <p><strong><a href="apps/whispering">Source</a></strong> · <strong><a href="apps/whispering#install-whispering">Install</a></strong></p>
     </td>
     <td align="center" width="50%">
+      <h3><a href="apps/opensidian">Opensidian</a></h3>
+      <p>Local-first note-taking with a built-in bash terminal, end-to-end encryption, and real-time sync. Your notes live in a CRDT-backed virtual filesystem.</p>
+      <p><strong><a href="apps/opensidian">Source</a></strong> · <strong><a href="https://opensidian.com">Try it</a></strong></p>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="50%">
       <h3><a href="apps/tab-manager">Tab Manager</a></h3>
-      <p>Chrome extension for saving tabs as bookmarks and building a read-later list, all stored in the shared workspace.</p>
+      <p>Browser extension side panel for managing tabs with workspace sync and AI chat that can call workspace tools with inline approval.</p>
       <p><strong><a href="apps/tab-manager">Source</a></strong></p>
+    </td>
+    <td align="center" width="50%">
+      <h3><a href="apps/honeycrisp">Honeycrisp</a></h3>
+      <p>Apple Notes-style local-first notes app. Folders, rich-text editing with ProseMirror, and collaborative sync via Yjs.</p>
+      <p><strong><a href="apps/honeycrisp">Source</a></strong></p>
     </td>
   </tr>
   <tr>
     <td align="center" width="50%">
       <h3><a href="apps/api">Epicenter API</a></h3>
-      <p>The hub server. Handles authentication, real-time sync via Durable Objects, and AI inference. Everything that needs a single authority across devices.</p>
+      <p>The hub server. Auth, real-time sync via Durable Objects, and AI inference. Everything that needs a single authority across devices.</p>
       <p><strong><a href="apps/api">Source</a></strong></p>
     </td>
     <td align="center" width="50%">
@@ -123,6 +135,8 @@ The dependency flow is strict: core has zero upward dependencies, middleware onl
     </td>
   </tr>
 </table>
+
+Also in the repo: [Fuji](apps/fuji) (personal CMS), [Zhongwen](apps/zhongwen) (Mandarin learning chat), [Skills Editor](apps/skills) (agent skill manager), [Dashboard](apps/dashboard) (billing UI), and [Landing](apps/landing) (public site).
 
 ## Packages
 
@@ -239,6 +253,20 @@ Contributors coordinate in our [Discord](https://go.epicenter.so/discord).
   <img alt="Cloudflare Workers" src="https://img.shields.io/badge/-Cloudflare%20Workers-F38020?style=flat-square&logo=cloudflare&logoColor=white" />
   <img alt="Tailwind CSS" src="https://img.shields.io/badge/-Tailwind%20CSS-38B2AC?style=flat-square&logo=tailwind-css&logoColor=white" />
 </p>
+
+## Design Decisions
+
+We publish our implementation specs. These are the reasoning behind non-obvious architectural choices—alternatives considered, trade-offs made, and why we landed where we did.
+
+| Spec | What it decided |
+| --- | --- |
+| [Encrypted Workspace Storage](specs/20260213T005300-encrypted-workspace-storage.md) | XChaCha20-Poly1305 at the CRDT value level; server-managed keys with self-hosting as the trust boundary |
+| [Y-Sweet Persistence Architecture](specs/20260212T190000-y-sweet-persistence-architecture.md) | How Yjs documents persist and compact in Durable Objects |
+| [Simple Definition-First Workspace API](specs/20260201T120000-simple-definition-first-workspace.md) | The `defineTable` → `createWorkspace` → `.withExtension()` builder pattern |
+| [Resilient Client Architecture](specs/20260119T231252-resilient-client-architecture.md) | How workspace clients handle offline, reconnect, and extension failures |
+| [Migrate to @epicenter/sync](specs/20260214T120800-migrate-y-sweet-to-epicenter-sync.md) | Custom sync protocol replacing Y-Sweet with our own framing layer |
+
+All 112 implemented specs live in [`specs/`](specs/).
 
 ## License
 

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -2,6 +2,8 @@
 
 The hub server. Handles authentication, real-time sync, and AI inference—everything that needs a single authority across devices.
 
+Part of the [Epicenter](https://github.com/EpicenterHQ/epicenter) monorepo. AGPL-3.0 licensed—if you host a modified version, you share your changes. Self-hosting the unmodified server is encouraged; see the encryption and trust model below.
+
 Runs on Cloudflare Workers with Durable Objects. Each user gets dedicated Durable Objects for their workspaces and documents, providing per-user isolation with WebSocket-based real-time sync.
 
 ## Why a hub exists
@@ -127,3 +129,7 @@ bun run db:studio:remote # Open Drizzle Studio (remote, via Infisical)
 ```
 
 See `wrangler.jsonc` for Durable Object bindings, KV namespaces, and Hyperdrive (Postgres connection pool) configuration.
+
+## License
+
+[AGPL-3.0](../../licenses/LICENSE-AGPL-3.0). The sync server and sync protocol are AGPL so that anyone hosting a modified version shares their changes. Client libraries and apps are MIT. This follows the same pattern as Yjs (MIT core, AGPL y-redis), Liveblocks (Apache clients, AGPL server), and Bitwarden (GPL clients, AGPL server).

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@epicenter/api",
+	"description": "Hub server for auth, real-time sync, and AI inference on Cloudflare Workers",
 	"version": "0.0.1",
 	"type": "module",
 	"main": "./src/app.ts",

--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -1,0 +1,60 @@
+# Dashboard
+
+A billing and credits dashboard for Epicenter customers. It fetches billing data from the hub API, renders usage charts and activity feeds, and drives Stripe flows for top-ups and plan changes.
+
+Part of the [Epicenter](https://github.com/EpicenterHQ/epicenter) monorepo. AGPL-3.0 licensed.
+
+---
+
+## How it works
+
+The dashboard is a SvelteKit SPA with SSR disabled and a static adapter. All data comes from the hub API at `/api`—there's no Yjs, no CRDTs, no local workspace. It's a pure API consumer.
+
+**Auth** uses Google sign-in via `@epicenter/svelte/auth-form`. The session is persisted in localStorage and gates the entire app.
+
+**Overview tab** shows a credit balance progress bar with trial info, a stacked area chart of usage by model over time (D3 + layerchart), and a top-10 models table for the last 30 days.
+
+**Models tab** has a cost guide listing credits-per-call for each model.
+
+**Activity tab** shows a feed of recent billing events.
+
+**Plan management** lives below the tabs: a monthly/annual toggle, a prorated charge preview, and a confirm button to upgrade. Clicking "Buy 500 credits" triggers a mutation that opens a Stripe checkout session. "Manage billing" opens the Stripe billing portal directly.
+
+All UI components come from `@epicenter/ui` (shadcn-svelte). Types for billing contracts and plans come from `@epicenter/api`.
+
+## Development
+
+**Prerequisites**
+
+- Bun
+- The hub API running locally (see `apps/api`)
+
+**Start the API first**
+
+```bash
+# in apps/api
+bun run dev:local
+```
+
+The API must be running at `localhost:8787` before starting the dashboard. The Vite dev server proxies `/api` and `/auth` there.
+
+**Start the dashboard**
+
+```bash
+# in apps/dashboard
+bun run dev:local
+```
+
+Runs on port 5178.
+
+**Build**
+
+```bash
+bun run build
+```
+
+Outputs a static site with `/dashboard` as the base path.
+
+## License
+
+[AGPL-3.0](../../LICENSE). Note that most packages in this monorepo are MIT licensed—this app is the exception.

--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -1,60 +1,61 @@
 # Dashboard
 
-A billing and credits dashboard for Epicenter customers. It fetches billing data from the hub API, renders usage charts and activity feeds, and drives Stripe flows for top-ups and plan changes.
+Billing data has one source of truth: the server. Dashboard doesn't pretend otherwise—it's a pure API consumer with no CRDTs, no local state, no sync layer. Just a clean read of what Stripe and the hub already know.
 
 Part of the [Epicenter](https://github.com/EpicenterHQ/epicenter) monorepo. AGPL-3.0 licensed.
 
 ---
 
+## Architecture
+
+```
+┌─────────────────────────────────────────────┐
+│  SvelteKit SPA (tabs, charts, plan picker)  │
+├─────────────────────────────────────────────┤
+│  TanStack Query (billing data + mutations)  │
+├─────────────────────────────────────────────┤
+│  Epicenter Hub API (/api, /auth, Stripe)    │
+└─────────────────────────────────────────────┘
+```
+
+Unlike every other Epicenter app, there's no workspace here. Billing needs a single authority, so the dashboard fetches everything from the hub API and writes back through Stripe. The diagram is intentionally simple—that's the point.
+
+---
+
 ## How it works
 
-The dashboard is a SvelteKit SPA with SSR disabled and a static adapter. All data comes from the hub API at `/api`—there's no Yjs, no CRDTs, no local workspace. It's a pure API consumer.
+Auth gates the entire app via Google sign-in (`@epicenter/svelte/auth-form`). Once signed in, a tabbed UI shows three views: an overview with credit balance, usage-by-model charts (D3 + layerchart), and a top-10 models table; a model cost guide; and a billing activity feed.
 
-**Auth** uses Google sign-in via `@epicenter/svelte/auth-form`. The session is persisted in localStorage and gates the entire app.
+Plan management sits below the tabs—monthly/annual toggle, prorated charge preview, confirm to upgrade. "Buy 500 credits" opens a Stripe checkout session. "Manage billing" opens the Stripe billing portal.
 
-**Overview tab** shows a credit balance progress bar with trial info, a stacked area chart of usage by model over time (D3 + layerchart), and a top-10 models table for the last 30 days.
-
-**Models tab** has a cost guide listing credits-per-call for each model.
-
-**Activity tab** shows a feed of recent billing events.
-
-**Plan management** lives below the tabs: a monthly/annual toggle, a prorated charge preview, and a confirm button to upgrade. Clicking "Buy 500 credits" triggers a mutation that opens a Stripe checkout session. "Manage billing" opens the Stripe billing portal directly.
-
-All UI components come from `@epicenter/ui` (shadcn-svelte). Types for billing contracts and plans come from `@epicenter/api`.
+---
 
 ## Development
 
-**Prerequisites**
-
-- Bun
-- The hub API running locally (see `apps/api`)
-
-**Start the API first**
+Prerequisites: [Bun](https://bun.sh) and the hub API running locally (see `apps/api`).
 
 ```bash
-# in apps/api
+git clone https://github.com/EpicenterHQ/epicenter.git
+cd epicenter
+bun install
+
+# Start the API first (must be running at localhost:8787)
+cd apps/api
+bun run dev:local
+
+# Then start the dashboard (in another terminal)
+cd apps/dashboard
 bun run dev:local
 ```
 
-The API must be running at `localhost:8787` before starting the dashboard. The Vite dev server proxies `/api` and `/auth` there.
-
-**Start the dashboard**
+Runs on port 5178. The Vite dev server proxies `/api` and `/auth` to `localhost:8787`.
 
 ```bash
-# in apps/dashboard
-bun run dev:local
+bun run build    # Static output with /dashboard base path
 ```
 
-Runs on port 5178.
-
-**Build**
-
-```bash
-bun run build
-```
-
-Outputs a static site with `/dashboard` as the base path.
+---
 
 ## License
 
-[AGPL-3.0](../../LICENSE). Note that most packages in this monorepo are MIT licensed—this app is the exception.
+[AGPL-3.0](../../LICENSE). Most packages in this monorepo are MIT—this app is the exception.

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@epicenter/dashboard",
+	"description": "Billing and credits dashboard for Epicenter customers",
 	"private": true,
 	"version": "0.0.1",
 	"type": "module",

--- a/apps/fuji/README.md
+++ b/apps/fuji/README.md
@@ -1,6 +1,6 @@
 # Fuji
 
-A local-first personal CMS. Create and manage entries with a collaborative rich-text editor; data lives in IndexedDB and syncs to the Epicenter API over WebSocket.
+Fuji is a local-first CMS where every entry's body is its own CRDT. Write offline, sync later, and collaborate on a single entry without touching the rest of your content. Think of it as a structured journal, knowledge base, or portfolio—whatever you tag and type your entries as.
 
 Part of the [Epicenter](https://github.com/EpicenterHQ/epicenter) monorepo. MIT licensed.
 
@@ -8,16 +8,18 @@ Part of the [Epicenter](https://github.com/EpicenterHQ/epicenter) monorepo. MIT 
 
 ## How it works
 
-Fuji is a SvelteKit app (static adapter, SSR disabled) with three panels: a sidebar for filtering and search, a main area that toggles between table and timeline views, and an editor panel for rich-text content.
+### Layout
 
-**Workspace schema** (`id: "epicenter.fuji"`)
+SvelteKit app (static adapter, SSR disabled) with three panels: a sidebar for filtering by type, tags, and search; a main area that toggles between table and timeline views; and an editor panel for rich-text content.
 
-The workspace holds all app state in a single Yjs document:
+### Data model
 
-- `entries` table — each row has `id` (EntryId), `title`, `subtitle`, `type` (string[]), `tags` (string[]), `createdAt`, `updatedAt`, and `_v`. Each entry also carries an attached content document via `withDocument('content', { guid: 'id', onUpdate })`, which exposes a `Y.Text` instance bound to the ProseMirror editor via `y-prosemirror`.
-- KV keys — `selectedEntryId`, `viewMode` (`'table' | 'timeline'`), `sidebarCollapsed`.
+Workspace ID: `epicenter.fuji`. Rich-text content and entry metadata are separate CRDTs. The entries table stays lean—just IDs, titles, tags, timestamps—while each entry's body lives in its own `Y.Text` document via `withDocument`. Loading a list of 500 entries doesn't mean loading 500 rich-text trees; the editor and the list never contend for the same document.
 
-**Client wiring** (`src/lib/client.ts`)
+- `entries` table—`id` (EntryId), `title`, `subtitle`, `type` (string[]), `tags` (string[]), `createdAt`, `updatedAt`, `_v`. Each entry carries an attached content document bound to ProseMirror via `y-prosemirror`.
+- KV keys—`selectedEntryId`, `viewMode` (`'table' | 'timeline'`), `sidebarCollapsed`.
+
+### Client wiring
 
 ```ts
 createWorkspace(fujiWorkspace)
@@ -27,23 +29,49 @@ createWorkspace(fujiWorkspace)
 
 Encryption keys are applied on login. Local data is cleared on logout.
 
-**Editor**
+### Editor
 
 ProseMirror with `y-prosemirror` binds directly to the entry's `Y.Text`. Edits are conflict-free by default; two sessions editing the same entry merge automatically.
 
-**Keyboard shortcuts**
+### Keyboard shortcuts
 
-- `Cmd+N` — new entry
-- `Escape` — deselect current entry
+- `Cmd+N`—new entry
+- `Escape`—deselect current entry
+
+---
 
 ## Development
 
-```sh
-bun run dev:local     # vite dev on port 5174
-bun run dev:remote    # vite dev --mode production (remote API)
-bun run build         # NODE_ENV=production vite build
-bun run typecheck     # svelte-kit sync && svelte-check
+Prerequisites: [Bun](https://bun.sh).
+
+```bash
+git clone https://github.com/EpicenterHQ/epicenter.git
+cd epicenter
+bun install
+cd apps/fuji
+bun dev
 ```
+
+By default this runs against a local dev server on port 5174. To run against the production sync server:
+
+```bash
+bun run dev:remote
+```
+
+---
+
+## Tech stack
+
+- [SvelteKit](https://kit.svelte.dev)—UI framework (static adapter, SSR disabled)
+- [ProseMirror](https://prosemirror.net) + [y-prosemirror](https://github.com/yjs/y-prosemirror)—collaborative rich-text editing
+- [TanStack Svelte Table](https://tanstack.com/table)—entry list table view
+- [Yjs](https://yjs.dev)—CRDT engine
+- [Tailwind CSS](https://tailwindcss.com)—styling
+- `@epicenter/workspace`—CRDT-backed tables, versioning, documents
+- `@epicenter/svelte`—auth, workspace gate, reactive table/KV bindings
+- `@epicenter/ui`—shadcn-svelte component library
+
+---
 
 ## License
 

--- a/apps/fuji/README.md
+++ b/apps/fuji/README.md
@@ -1,0 +1,50 @@
+# Fuji
+
+A local-first personal CMS. Create and manage entries with a collaborative rich-text editor; data lives in IndexedDB and syncs to the Epicenter API over WebSocket.
+
+Part of the [Epicenter](https://github.com/EpicenterHQ/epicenter) monorepo. MIT licensed.
+
+---
+
+## How it works
+
+Fuji is a SvelteKit app (static adapter, SSR disabled) with three panels: a sidebar for filtering and search, a main area that toggles between table and timeline views, and an editor panel for rich-text content.
+
+**Workspace schema** (`id: "epicenter.fuji"`)
+
+The workspace holds all app state in a single Yjs document:
+
+- `entries` table — each row has `id` (EntryId), `title`, `subtitle`, `type` (string[]), `tags` (string[]), `createdAt`, `updatedAt`, and `_v`. Each entry also carries an attached content document via `withDocument('content', { guid: 'id', onUpdate })`, which exposes a `Y.Text` instance bound to the ProseMirror editor via `y-prosemirror`.
+- KV keys — `selectedEntryId`, `viewMode` (`'table' | 'timeline'`), `sidebarCollapsed`.
+
+**Client wiring** (`src/lib/client.ts`)
+
+```ts
+createWorkspace(fujiWorkspace)
+  .withExtension('persistence', indexeddbPersistence)
+  .withExtension('sync', createSyncExtension({ url, getToken }))
+```
+
+Encryption keys are applied on login. Local data is cleared on logout.
+
+**Editor**
+
+ProseMirror with `y-prosemirror` binds directly to the entry's `Y.Text`. Edits are conflict-free by default; two sessions editing the same entry merge automatically.
+
+**Keyboard shortcuts**
+
+- `Cmd+N` — new entry
+- `Escape` — deselect current entry
+
+## Development
+
+```sh
+bun run dev:local     # vite dev on port 5174
+bun run dev:remote    # vite dev --mode production (remote API)
+bun run build         # NODE_ENV=production vite build
+bun run typecheck     # svelte-kit sync && svelte-check
+```
+
+## License
+
+MIT

--- a/apps/fuji/package.json
+++ b/apps/fuji/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@epicenter/fuji",
+	"description": "Local-first personal CMS with collaborative rich-text editing",
 	"private": true,
 	"version": "0.0.1",
 	"type": "module",

--- a/apps/honeycrisp/README.md
+++ b/apps/honeycrisp/README.md
@@ -1,0 +1,105 @@
+# Honeycrisp
+
+A local-first notes app styled after Apple Notes. Folders, a note list, and a collaborative rich-text editor—all backed by an Epicenter workspace with Yjs CRDTs, persisted to IndexedDB, and synced over WebSocket.
+
+Part of the [Epicenter](https://github.com/EpicenterHQ/epicenter) monorepo. MIT licensed.
+
+---
+
+## How it works
+
+### Layout
+
+Single-route SvelteKit app (`+page.svelte`) with a three-pane layout: sidebar (folders) → note list → editor. SSR is disabled; the app runs entirely in the browser as a static site.
+
+### Data layer
+
+All state lives in an Epicenter workspace (`id: "epicenter.honeycrisp"`). The workspace is created once on startup, wired to IndexedDB for local persistence, and connected to a WebSocket server for real-time sync. Auth tokens and encryption keys are applied at login before any data is read or written.
+
+### Rich-text editing
+
+Each note's body is a `Y.XmlFragment` stored as an attached document on the `notes` table. ProseMirror binds to it via `y-prosemirror`, giving collaborative editing for free. The editor schema covers paragraphs, headings, lists, task lists, underline, and strikethrough. Every ProseMirror transaction extracts a title, preview snippet, and word count, which are written back to the note's table row.
+
+### Auth
+
+Google sign-in via `@epicenter/svelte/auth-form`. The session is persisted across reloads. Encryption keys are applied on login before the workspace connects.
+
+---
+
+## Workspace schema
+
+**Workspace ID:** `epicenter.honeycrisp`
+
+### Tables
+
+**`folders`**
+| Field | Type |
+|---|---|
+| `id` | `FolderId` |
+| `name` | `string` |
+| `icon` | `string` (optional) |
+| `sortOrder` | `number` |
+| `_v` | version |
+
+**`notes`** (v2, migrated from v1)
+| Field | Type |
+|---|---|
+| `id` | `NoteId` |
+| `folderId` | `FolderId` (optional) |
+| `title` | `string` |
+| `preview` | `string` |
+| `pinned` | `boolean` |
+| `createdAt` | `number` |
+| `updatedAt` | `number` |
+| `deletedAt` | `number` (optional, soft delete) |
+| `wordCount` | `number` (optional) |
+
+Each note has an attached document: `withDocument('body', { guid: 'id', onUpdate })` → `Y.XmlFragment`.
+
+The v1→v2 migration adds `deletedAt` and `wordCount`.
+
+### KV
+
+| Key | Type |
+|---|---|
+| `selectedFolderId` | `FolderId` |
+| `selectedNoteId` | `NoteId` |
+| `sortBy` | `'dateEdited' \| 'dateCreated' \| 'title'` |
+
+---
+
+## Features
+
+- **Soft delete** — notes get a `deletedAt` timestamp and appear in "Recently Deleted". Restore or permanently delete from there.
+- **Pin/unpin** — pinned notes sort to the top of the list.
+- **Folder deletion** — re-parents all notes in the folder to unfiled and clears the KV selection, keeping the data intact.
+- **Sorting** — note list sorts by date edited, date created, or title.
+- **Search** — filters the note list by title and preview content.
+- **Keyboard shortcuts** — `Cmd+N` creates a new note, `Cmd+Shift+N` creates a new folder.
+- **Context menus** — per-note actions: pin, move to folder, delete, restore.
+
+---
+
+## Development
+
+```bash
+# Start dev server (local API)
+bun run dev:local
+
+# Start dev server (production API)
+bun run dev:remote
+
+# Production build
+bun run build
+
+# Type checking
+bun run typecheck
+```
+
+The dev server runs on port **5175**.
+
+---
+
+## License
+
+MIT

--- a/apps/honeycrisp/README.md
+++ b/apps/honeycrisp/README.md
@@ -1,6 +1,6 @@
 # Honeycrisp
 
-A local-first notes app styled after Apple Notes. Folders, a note list, and a collaborative rich-text editor—all backed by an Epicenter workspace with Yjs CRDTs, persisted to IndexedDB, and synced over WebSocket.
+Honeycrisp is a notes app that works offline first and syncs when it can. Notes, folders, and rich text are all Yjs CRDTs—two devices can edit the same note simultaneously and converge without conflicts. Open two browser tabs and try it.
 
 Part of the [Epicenter](https://github.com/EpicenterHQ/epicenter) monorepo. MIT licensed.
 
@@ -10,7 +10,7 @@ Part of the [Epicenter](https://github.com/EpicenterHQ/epicenter) monorepo. MIT 
 
 ### Layout
 
-Single-route SvelteKit app (`+page.svelte`) with a three-pane layout: sidebar (folders) → note list → editor. SSR is disabled; the app runs entirely in the browser as a static site.
+Single-route SvelteKit app with a three-pane layout: sidebar (folders) → note list → editor. SSR is disabled; the app runs entirely in the browser as a static site.
 
 ### Data layer
 
@@ -19,6 +19,10 @@ All state lives in an Epicenter workspace (`id: "epicenter.honeycrisp"`). The wo
 ### Rich-text editing
 
 Each note's body is a `Y.XmlFragment` stored as an attached document on the `notes` table. ProseMirror binds to it via `y-prosemirror`, giving collaborative editing for free. The editor schema covers paragraphs, headings, lists, task lists, underline, and strikethrough. Every ProseMirror transaction extracts a title, preview snippet, and word count, which are written back to the note's table row.
+
+### Soft deletion
+
+Notes are never removed from the CRDT—they're soft-deleted with a `deletedAt` timestamp. This matters when two devices diverge: one deletes a note while the other keeps editing it. Without soft deletion, the CRDT has no way to represent "deleted but also modified." With it, you can restore the note and keep the edits. Soft-deleted notes appear in "Recently Deleted" where you can restore or permanently remove them.
 
 ### Auth
 
@@ -68,35 +72,47 @@ The v1→v2 migration adds `deletedAt` and `wordCount`.
 
 ---
 
-## Features
+## Other features
 
-- **Soft delete** — notes get a `deletedAt` timestamp and appear in "Recently Deleted". Restore or permanently delete from there.
-- **Pin/unpin** — pinned notes sort to the top of the list.
-- **Folder deletion** — re-parents all notes in the folder to unfiled and clears the KV selection, keeping the data intact.
-- **Sorting** — note list sorts by date edited, date created, or title.
-- **Search** — filters the note list by title and preview content.
-- **Keyboard shortcuts** — `Cmd+N` creates a new note, `Cmd+Shift+N` creates a new folder.
-- **Context menus** — per-note actions: pin, move to folder, delete, restore.
+- **Pin/unpin**—pinned notes sort to the top of the list.
+- **Folder deletion**—re-parents all notes in the folder to unfiled, keeping data intact.
+- **Sorting**—by date edited, date created, or title.
+- **Search**—filters by title and preview content.
+- **Keyboard shortcuts**—`Cmd+N` (new note), `Cmd+Shift+N` (new folder).
+- **Context menus**—per-note actions: pin, move to folder, delete, restore.
 
 ---
 
 ## Development
 
+Prerequisites: [Bun](https://bun.sh).
+
 ```bash
-# Start dev server (local API)
-bun run dev:local
-
-# Start dev server (production API)
-bun run dev:remote
-
-# Production build
-bun run build
-
-# Type checking
-bun run typecheck
+git clone https://github.com/EpicenterHQ/epicenter.git
+cd epicenter
+bun install
+cd apps/honeycrisp
+bun dev
 ```
 
-The dev server runs on port **5175**.
+By default this runs against a local dev server on port 5175. To run against the production sync server:
+
+```bash
+bun run dev:remote
+```
+
+---
+
+## Tech stack
+
+- [SvelteKit](https://kit.svelte.dev)—UI framework (static adapter, SSR disabled)
+- [ProseMirror](https://prosemirror.net) + [y-prosemirror](https://github.com/yjs/y-prosemirror)—collaborative rich-text editing
+- [Yjs](https://yjs.dev)—CRDT engine (Y.Doc, Y.XmlFragment)
+- [Tailwind CSS](https://tailwindcss.com)—styling
+- [Better Auth](https://better-auth.com)—authentication
+- `@epicenter/workspace`—CRDT-backed tables, versioning, E2E encryption
+- `@epicenter/svelte`—auth, workspace gate, reactive table/KV bindings
+- `@epicenter/ui`—shadcn-svelte component library
 
 ---
 

--- a/apps/honeycrisp/package.json
+++ b/apps/honeycrisp/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@epicenter/honeycrisp",
+	"description": "Local-first notes app with collaborative rich-text editing",
 	"private": true,
 	"version": "0.0.1",
 	"type": "module",

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@epicenter/landing",
+	"description": "Public landing site for Epicenter",
 	"private": true,
 	"type": "module",
 	"version": "0.0.1",

--- a/apps/opensidian/package.json
+++ b/apps/opensidian/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "opensidian",
+	"description": "Local-first note-taking app with a built-in bash terminal and real-time sync",
 	"private": true,
 	"version": "0.0.1",
 	"type": "module",

--- a/apps/opensidian/wrangler.jsonc
+++ b/apps/opensidian/wrangler.jsonc
@@ -2,8 +2,12 @@
 	"$schema": "../../node_modules/wrangler/config-schema.json",
 	"name": "opensidian",
 	"compatibility_date": "2025-11-04",
-	// --- Custom domain: opensidian.epicenter.so (auto-creates DNS record on deploy) ---
+	// --- Custom domains: opensidian.com + opensidian.epicenter.so (auto-creates DNS records on deploy) ---
 	"routes": [
+		{
+			"pattern": "opensidian.com",
+			"custom_domain": true
+		},
 		{
 			"pattern": "opensidian.epicenter.so",
 			"custom_domain": true

--- a/apps/skills/README.md
+++ b/apps/skills/README.md
@@ -1,0 +1,51 @@
+# Skills Editor
+
+Browser-based editor for creating and managing Epicenter agent skills. Backed by Yjs CRDTs for collaborative editing, with full offline support via IndexedDB.
+
+Part of the [Epicenter](https://github.com/EpicenterHQ/epicenter) monorepo. MIT licensed.
+
+---
+
+## How it works
+
+**Workspace connection.** The app imports `createSkillsWorkspace` from `@epicenter/skills`, which provides two tables: `skills` (metadata + attached instructions document) and `references` (per-skill reference files, each with its own content document). The workspace ID is `epicenter.skills`.
+
+**Collaborative editing.** Each skill's instructions and each reference's content are `Y.Doc`-backed documents. CodeMirror 6 with `y-codemirror.next` binds directly to those documents, so edits are conflict-free and survive concurrent sessions.
+
+**Local-first only.** Persistence is IndexedDB. No remote sync provider is wired in this app—it's a standalone local editor.
+
+**UI shell.** A single route renders an `AppShell` with a resizable split view: a sidebar on the left and an editor panel on the right.
+
+- **Sidebar** — skill list with search, keyboard navigation (arrow keys), inline rename (F2), and delete with confirmation.
+- **Editor panel** — `SkillMetadataForm` (name, description, license, compatibility), `InstructionsEditor` (CodeMirror + Yjs), and `ReferencesPanel` (expandable list of reference files, each with its own CodeMirror editor).
+- **Command palette** — search across skills from anywhere.
+- **NewSkillDialog** — creates a new skill and focuses it immediately.
+
+## Workspace schema
+
+Workspace ID: `epicenter.skills`
+
+| Table | Columns | Attached doc |
+|---|---|---|
+| `skills` | `id`, `name`, `description`, `license`, `compatibility` | `instructions` (Y.Doc) |
+| `references` | `id`, `skillId`, `name` | `content` (Y.Doc) |
+
+## Stack
+
+- SvelteKit (SSR disabled), Svelte 5 runes
+- Tailwind CSS
+- CodeMirror 6 + `y-codemirror.next`
+- `@epicenter/skills`, `@epicenter/workspace`, `@epicenter/svelte`, `@epicenter/ui`
+
+## Development
+
+```sh
+bun run dev:local    # local dev server (bun --bun vite dev)
+bun run dev:remote   # dev server against production mode
+bun run build        # production build
+bun run check        # svelte-kit sync && svelte-check
+```
+
+## License
+
+MIT

--- a/apps/skills/README.md
+++ b/apps/skills/README.md
@@ -1,6 +1,6 @@
 # Skills Editor
 
-Browser-based editor for creating and managing Epicenter agent skills. Backed by Yjs CRDTs for collaborative editing, with full offline support via IndexedDB.
+A local editor for writing the prompt files and configuration that power Epicenter agents. It uses Yjs CRDTs under the hood—so undo/redo works across sessions and the format is ready for collaboration—but it doesn't sync anywhere. Your skills stay on your machine.
 
 Part of the [Epicenter](https://github.com/EpicenterHQ/epicenter) monorepo. MIT licensed.
 
@@ -8,18 +8,27 @@ Part of the [Epicenter](https://github.com/EpicenterHQ/epicenter) monorepo. MIT 
 
 ## How it works
 
-**Workspace connection.** The app imports `createSkillsWorkspace` from `@epicenter/skills`, which provides two tables: `skills` (metadata + attached instructions document) and `references` (per-skill reference files, each with its own content document). The workspace ID is `epicenter.skills`.
+### What's a skill?
 
-**Collaborative editing.** Each skill's instructions and each reference's content are `Y.Doc`-backed documents. CodeMirror 6 with `y-codemirror.next` binds directly to those documents, so edits are conflict-free and survive concurrent sessions.
+A skill is a set of instructions (markdown) plus reference files that tell an Epicenter agent how to perform a specific task. Each skill has metadata (name, description, license, compatibility) and one or more reference documents. The Skills Editor is where you author and organize these.
 
-**Local-first only.** Persistence is IndexedDB. No remote sync provider is wired in this app—it's a standalone local editor.
+### Workspace connection
 
-**UI shell.** A single route renders an `AppShell` with a resizable split view: a sidebar on the left and an editor panel on the right.
+The app imports `createSkillsWorkspace` from `@epicenter/skills`, which provides two tables: `skills` (metadata + attached instructions document) and `references` (per-skill reference files, each with its own content document). The workspace ID is `epicenter.skills`. Persistence is IndexedDB—no remote sync is wired in, so the editor works entirely offline.
 
-- **Sidebar** — skill list with search, keyboard navigation (arrow keys), inline rename (F2), and delete with confirmation.
-- **Editor panel** — `SkillMetadataForm` (name, description, license, compatibility), `InstructionsEditor` (CodeMirror + Yjs), and `ReferencesPanel` (expandable list of reference files, each with its own CodeMirror editor).
-- **Command palette** — search across skills from anywhere.
-- **NewSkillDialog** — creates a new skill and focuses it immediately.
+### Collaborative editing
+
+Each skill's instructions and each reference's content are `Y.Doc`-backed documents. CodeMirror 6 with `y-codemirror.next` binds directly to those documents, so edits are conflict-free and survive concurrent sessions.
+
+### UI
+
+A single route renders a resizable split view: sidebar on the left, editor panel on the right.
+
+- **Sidebar**—skill list with search, keyboard navigation (arrow keys), inline rename (F2), and delete with confirmation.
+- **Editor panel**—metadata form (name, description, license, compatibility), instructions editor (CodeMirror + Yjs), and a references panel with expandable entries, each with its own CodeMirror editor.
+- **Command palette**—search across skills from anywhere.
+
+---
 
 ## Workspace schema
 
@@ -30,21 +39,34 @@ Workspace ID: `epicenter.skills`
 | `skills` | `id`, `name`, `description`, `license`, `compatibility` | `instructions` (Y.Doc) |
 | `references` | `id`, `skillId`, `name` | `content` (Y.Doc) |
 
-## Stack
-
-- SvelteKit (SSR disabled), Svelte 5 runes
-- Tailwind CSS
-- CodeMirror 6 + `y-codemirror.next`
-- `@epicenter/skills`, `@epicenter/workspace`, `@epicenter/svelte`, `@epicenter/ui`
+---
 
 ## Development
 
-```sh
-bun run dev:local    # local dev server (bun --bun vite dev)
-bun run dev:remote   # dev server against production mode
-bun run build        # production build
-bun run check        # svelte-kit sync && svelte-check
+Prerequisites: [Bun](https://bun.sh).
+
+```bash
+git clone https://github.com/EpicenterHQ/epicenter.git
+cd epicenter
+bun install
+cd apps/skills
+bun dev
 ```
+
+---
+
+## Tech stack
+
+- [SvelteKit](https://kit.svelte.dev)—UI framework (SSR disabled)
+- [CodeMirror 6](https://codemirror.net) + [y-codemirror.next](https://github.com/yjs/y-codemirror.next)—collaborative markdown editing
+- [Yjs](https://yjs.dev)—CRDT engine
+- [Tailwind CSS](https://tailwindcss.com)—styling
+- `@epicenter/skills`—workspace definition for skills and references
+- `@epicenter/workspace`—CRDT-backed tables, persistence
+- `@epicenter/svelte`—reactive table bindings
+- `@epicenter/ui`—shadcn-svelte component library
+
+---
 
 ## License
 

--- a/apps/skills/package.json
+++ b/apps/skills/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "skills",
+	"description": "Browser-based editor for Epicenter agent skills",
 	"private": true,
 	"version": "0.0.1",
 	"type": "module",

--- a/apps/tab-manager/README.md
+++ b/apps/tab-manager/README.md
@@ -1,0 +1,69 @@
+# Tab Manager
+
+A browser extension side panel that shows your live tabs, lets you save and bookmark URLs into an Epicenter workspace, and includes an AI chat drawer that can call workspace tools with inline approval.
+
+Part of the [Epicenter](https://github.com/EpicenterHQ/epicenter) monorepo. MIT licensed.
+
+---
+
+## How it works
+
+The extension has two distinct layers of state that serve different purposes.
+
+**Ephemeral browser state** lives in `browser-state.svelte.ts`. On load it seeds from `chrome.windows.getAll`, then stays current via Chrome's tab and window event listeners. This layer owns the live tab list and exposes actions like close, activate, pin, mute, reload, and duplicate. Nothing here persists; it's a reactive mirror of what the browser already knows.
+
+**Synced workspace state** is the persistent layer. Saved tabs and bookmarks are stored in Epicenter workspace tables and synced across devices over WebSocket. The UI reads from these tables via `fromTable` and writes through workspace actions. This is what survives a browser restart or shows up on another device.
+
+The side panel is a Svelte app mounted into `#app`. There's no popup and no content scripts—everything runs in the side panel, which opens when you click the extension action button. The background service worker is minimal; its only job is to open the side panel on click.
+
+The main UI (`App.svelte`) has a search bar with case-sensitive, regex, and exact-match toggles, a unified tab list that shows open tabs grouped by window alongside saved tabs and bookmarks in a single virtualized list, per-tab actions, a command palette for bulk operations (dedupe, group by domain, sort, close by domain, save all), and a sync status indicator with reconnect and sign-out controls.
+
+## Workspace schema
+
+The workspace ID is `epicenter.tab-manager`. It defines six tables:
+
+| Table | Key | Notable fields |
+|---|---|---|
+| `devices` | `DeviceId` | `name`, `lastSeen`, `browser` |
+| `savedTabs` | `SavedTabId` | `url`, `title`, `favIconUrl?`, `pinned`, `sourceDeviceId`, `savedAt` |
+| `bookmarks` | `BookmarkId` | `url`, `title`, `favIconUrl?`, `description?`, `sourceDeviceId`, `createdAt` |
+| `conversations` | `ConversationId` | `title`, `parentId?`, `systemPrompt?`, `provider`, `model`, `createdAt`, `updatedAt` |
+| `chatMessages` | `ChatMessageId` | `conversationId`, `role`, `parts[]`, `createdAt` |
+| `toolTrust` | tool name | `trust: 'ask' \| 'always'` |
+
+Awareness entries carry `{ deviceId, client: "extension" | "desktop" | "cli" }` so you can see which devices are currently connected.
+
+## AI chat
+
+The `AiDrawer` component is a sign-in-gated chat drawer that supports multiple conversations. Chat streams via SSE from the configured remote server. Workspace actions are converted to AI tools via `@epicenter/ai`'s `actionsToClientTools`, so the AI can read and write workspace data directly.
+
+Destructive tool calls require inline approval before they execute. Each tool can also be set to "always allow," and that preference is stored in the `toolTrust` table so it syncs across all your devices.
+
+## Development
+
+```sh
+# Start dev server against local backend
+bun run dev:local
+
+# Start dev server against production backend
+bun run dev:remote
+
+# Firefox
+bun run dev:firefox
+
+# Production build
+bun run build
+
+# Package for Chrome Web Store / Firefox Add-ons
+bun run zip
+bun run zip:firefox
+
+# Type check
+bun run typecheck
+```
+
+Auth uses Google OAuth via `browser.identity`. Encryption keys are applied on login.
+
+## License
+
+MIT

--- a/apps/tab-manager/README.md
+++ b/apps/tab-manager/README.md
@@ -1,26 +1,54 @@
 # Tab Manager
 
-A browser extension side panel that shows your live tabs, lets you save and bookmark URLs into an Epicenter workspace, and includes an AI chat drawer that can call workspace tools with inline approval.
+Live tabs and saved tabs are fundamentally different things. Live tabs mirror Chrome's reality—they're ephemeral, they vanish on restart, and they're not yours to own. Saved tabs and bookmarks are workspace data: they persist, sync across devices, and survive browser restarts. Tab Manager is a browser extension that keeps these two layers separate and bridges them with an AI chat drawer that can act on your workspace.
 
 Part of the [Epicenter](https://github.com/EpicenterHQ/epicenter) monorepo. MIT licensed.
 
 ---
 
+## Architecture
+
+```
+┌──────────────────────────────────────────────────┐
+│  WXT Side Panel (Svelte app)                     │
+├──────────────────────────────────────────────────┤
+│  Chrome APIs (tabs, windows, identity)           │
+├──────────────┬───────────────────────────────────┤
+│  Browser     │  Workspace state (saved tabs,     │
+│  state       │  bookmarks, chat, tool trust)     │
+│  (ephemeral) │  @epicenter/workspace + sync      │
+├──────────────┴───────────────────────────────────┤
+│  @epicenter/ai (tool bridge for AI chat)         │
+└──────────────────────────────────────────────────┘
+```
+
+The extension never fights Chrome for ownership of tab state. Ephemeral state seeds from `chrome.windows.getAll` and stays current via event listeners. Workspace state persists to IndexedDB, syncs over WebSocket, and replicates to every device you sign into.
+
+---
+
 ## How it works
 
-The extension has two distinct layers of state that serve different purposes.
+### Browser state
 
-**Ephemeral browser state** lives in `browser-state.svelte.ts`. On load it seeds from `chrome.windows.getAll`, then stays current via Chrome's tab and window event listeners. This layer owns the live tab list and exposes actions like close, activate, pin, mute, reload, and duplicate. Nothing here persists; it's a reactive mirror of what the browser already knows.
+On load, `browser-state.svelte.ts` seeds a reactive map of every open window and tab. Chrome's tab and window event listeners keep it current. This layer exposes actions—close, activate, pin, mute, reload, duplicate—all backed by Chrome APIs. Nothing here persists; it's a mirror.
 
-**Synced workspace state** is the persistent layer. Saved tabs and bookmarks are stored in Epicenter workspace tables and synced across devices over WebSocket. The UI reads from these tables via `fromTable` and writes through workspace actions. This is what survives a browser restart or shows up on another device.
+### Workspace state
 
-The side panel is a Svelte app mounted into `#app`. There's no popup and no content scripts—everything runs in the side panel, which opens when you click the extension action button. The background service worker is minimal; its only job is to open the side panel on click.
+Saved tabs and bookmarks live in Epicenter workspace tables and sync across devices over WebSocket. The UI reads from these tables via `fromTable` and writes through workspace actions. Save a tab on your laptop and it shows up on your desktop.
 
-The main UI (`App.svelte`) has a search bar with case-sensitive, regex, and exact-match toggles, a unified tab list that shows open tabs grouped by window alongside saved tabs and bookmarks in a single virtualized list, per-tab actions, a command palette for bulk operations (dedupe, group by domain, sort, close by domain, save all), and a sync status indicator with reconnect and sign-out controls.
+### Side panel
+
+A Svelte app mounted into `#app`. There's no popup and no content scripts—everything runs in the side panel, which opens when you click the extension action button. The background service worker is minimal; its only job is to open the side panel on click.
+
+### UI
+
+The main UI has a search bar with case-sensitive, regex, and exact-match toggles; a unified tab list that shows open tabs grouped by window alongside saved tabs and bookmarks in a single virtualized list; per-tab actions; a command palette for bulk operations (dedupe, group by domain, sort, close by domain, save all); and a sync status indicator.
+
+---
 
 ## Workspace schema
 
-The workspace ID is `epicenter.tab-manager`. It defines six tables:
+Workspace ID: `epicenter.tab-manager`. Six tables:
 
 | Table | Key | Notable fields |
 |---|---|---|
@@ -33,36 +61,67 @@ The workspace ID is `epicenter.tab-manager`. It defines six tables:
 
 Awareness entries carry `{ deviceId, client: "extension" | "desktop" | "cli" }` so you can see which devices are currently connected.
 
+---
+
 ## AI chat
 
 The `AiDrawer` component is a sign-in-gated chat drawer that supports multiple conversations. Chat streams via SSE from the configured remote server. Workspace actions are converted to AI tools via `@epicenter/ai`'s `actionsToClientTools`, so the AI can read and write workspace data directly.
 
-Destructive tool calls require inline approval before they execute. Each tool can also be set to "always allow," and that preference is stored in the `toolTrust` table so it syncs across all your devices.
+Destructive tool calls require inline approval before they execute. Each tool can also be set to "always allow," and that preference is stored in the `toolTrust` table—so it syncs across all your devices like any other workspace data.
+
+---
 
 ## Development
 
-```sh
-# Start dev server against local backend
-bun run dev:local
+Prerequisites: [Bun](https://bun.sh).
 
-# Start dev server against production backend
+```bash
+git clone https://github.com/EpicenterHQ/epicenter.git
+cd epicenter
+bun install
+cd apps/tab-manager
+bun dev
+```
+
+This starts a dev build. To load the extension in Chrome: open `chrome://extensions`, enable Developer Mode, click "Load unpacked," and select the `.output/chrome-mv3-dev` directory.
+
+To run against the production sync server:
+
+```bash
 bun run dev:remote
+```
 
-# Firefox
+Firefox:
+
+```bash
 bun run dev:firefox
+```
 
-# Production build
-bun run build
+To build for distribution:
 
-# Package for Chrome Web Store / Firefox Add-ons
-bun run zip
-bun run zip:firefox
-
-# Type check
-bun run typecheck
+```bash
+bun run build          # Chrome
+bun run zip            # Package for Chrome Web Store
+bun run zip:firefox    # Package for Firefox Add-ons
 ```
 
 Auth uses Google OAuth via `browser.identity`. Encryption keys are applied on login.
+
+---
+
+## Tech stack
+
+- [WXT](https://wxt.dev)—browser extension framework
+- [Svelte 5](https://svelte.dev)—UI (side panel)
+- [Yjs](https://yjs.dev)—CRDT engine
+- [virtua](https://github.com/inokawa/virtua)—virtualized tab list
+- [Tailwind CSS](https://tailwindcss.com)—styling
+- `@epicenter/workspace`—CRDT-backed tables, sync, persistence
+- `@epicenter/ai`—workspace-to-LLM tool bridge
+- `@epicenter/svelte`—auth integration
+- `@epicenter/ui`—shadcn-svelte component library
+
+---
 
 ## License
 

--- a/apps/tab-manager/package.json
+++ b/apps/tab-manager/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@epicenter/tab-manager",
+	"description": "Browser extension for managing tabs with workspace sync and AI chat",
 	"version": "0.0.1",
 	"type": "module",
 	"private": true,

--- a/apps/whispering/package.json
+++ b/apps/whispering/package.json
@@ -2,7 +2,7 @@
 	"name": "@epicenter/whispering",
 	"private": true,
 	"version": "7.11.0",
-	"description": "",
+	"description": "Desktop and web speech-to-text with global shortcuts and AI transformations",
 	"exports": {
 		"./commands": "./src/lib/commands.ts",
 		"./workspace": "./src/lib/workspace/index.ts"

--- a/apps/zhongwen/package.json
+++ b/apps/zhongwen/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@epicenter/zhongwen",
+	"description": "Bilingual Chinese-English chat app for learning Mandarin",
 	"private": true,
 	"version": "0.0.1",
 	"type": "module",

--- a/bun.lock
+++ b/bun.lock
@@ -461,7 +461,7 @@
     },
     "packages/ai": {
       "name": "@epicenter/ai",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@epicenter/workspace": "workspace:*",
         "@tanstack/ai": "catalog:",
@@ -472,7 +472,7 @@
     },
     "packages/cli": {
       "name": "@epicenter/cli",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "bin": {
         "epicenter": "./src/bin.ts",
       },
@@ -494,7 +494,10 @@
     },
     "packages/constants": {
       "name": "@epicenter/constants",
-      "version": "0.0.1",
+      "version": "0.1.0",
+      "dependencies": {
+        "wellcrafted": "catalog:",
+      },
       "devDependencies": {
         "@types/node": "catalog:",
         "typescript": "catalog:",
@@ -503,7 +506,7 @@
     },
     "packages/filesystem": {
       "name": "@epicenter/filesystem",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@epicenter/workspace": "workspace:*",
         "@libsql/client": "^0.14.0",
@@ -526,11 +529,10 @@
     },
     "packages/skills": {
       "name": "@epicenter/skills",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@epicenter/workspace": "workspace:*",
         "arktype": "catalog:",
-        "typebox": "catalog:",
         "wellcrafted": "catalog:",
         "yaml": "^2.8.0",
       },
@@ -545,9 +547,10 @@
     },
     "packages/svelte-utils": {
       "name": "@epicenter/svelte",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@epicenter/api": "workspace:*",
+        "@epicenter/constants": "workspace:*",
         "@epicenter/ui": "workspace:*",
         "@epicenter/workspace": "workspace:*",
         "@lucide/svelte": "catalog:",
@@ -566,7 +569,7 @@
     },
     "packages/sync": {
       "name": "@epicenter/sync",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "lib0": "catalog:",
         "wellcrafted": "catalog:",
@@ -583,7 +586,7 @@
     },
     "packages/ui": {
       "name": "@epicenter/ui",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@fontsource-variable/manrope": "^5.2.6",
         "@lucide/svelte": "catalog:",
@@ -619,7 +622,7 @@
     },
     "packages/workspace": {
       "name": "@epicenter/workspace",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@ark/json-schema": "^0.0.4",
         "@epicenter/sync": "workspace:*",

--- a/docs/articles/your-data-is-probably-a-table-not-a-file.md
+++ b/docs/articles/your-data-is-probably-a-table-not-a-file.md
@@ -1,0 +1,97 @@
+# Your Data Is Probably a Table, Not a File
+
+Epicenter has two packages for storing application data: `@epicenter/workspace` (typed tables, KV, documents) and `@epicenter/filesystem` (POSIX-style virtual files and folders). The workspace is the default. Most apps should use it directly and never touch the filesystem package.
+
+The interesting part is that the filesystem isn't a separate storage system—it's built on top of workspace tables. The specialized API composes on the general-purpose one, not beside it.
+
+## Honeycrisp thinks in records
+
+Honeycrisp is an Apple Notes clone. Its data model is two tables and some KV settings:
+
+```typescript
+const foldersTable = defineTable(type({
+  id: FolderId,
+  name: 'string',
+  sortOrder: 'number',
+  _v: '1',
+}));
+
+const notesTable = defineTable(
+  type({ id: NoteId, folderId: FolderId, title: 'string', preview: 'string', _v: '1' }),
+  type({ id: NoteId, folderId: FolderId, title: 'string', preview: 'string', deletedAt: DateTimeString, _v: '2' }),
+).withDocument('body', { guid: 'id' });
+
+export const honeycrisp = defineWorkspace({
+  id: 'epicenter.honeycrisp',
+  tables: { folders: foldersTable, notes: notesTable },
+  kv: { selectedFolderId: defineKv(...), sortBy: defineKv(...) },
+});
+```
+
+Every note has a known shape: `title`, `preview`, `folderId`, timestamps. The UI reads them with `table.getAllValid()`, filters with `table.filter(...)`, and writes with `table.set(...)`. Rich text content lives in per-note Y.Doc documents via `.withDocument('body', ...)`.
+
+No filesystem needed. Notes don't have paths. Users don't `mkdir` or `mv`. The app thinks in "records with fields," and workspace tables express that directly.
+
+## Opensidian thinks in files
+
+Opensidian is a local-first note editor with a built-in bash terminal. Users create markdown files, organize them into nested folders, rename them, move them around. The file tree IS the interface.
+
+```typescript
+import { filesTable } from '@epicenter/filesystem';
+
+export const opensidianDefinition = defineWorkspace({
+  id: 'opensidian',
+  tables: {
+    files: filesTable,
+    conversations: conversationsTable,
+    chatMessages: chatMessagesTable,
+  },
+});
+```
+
+The `filesTable` comes from `@epicenter/filesystem`. It defines rows with `name`, `parentId`, `type` (file or folder), `size`, timestamps, and soft-delete state. That table gets plugged into `defineWorkspace()` like any other table—because that's what it is.
+
+The filesystem wrapper then turns those table rows into POSIX operations:
+
+```typescript
+import { createYjsFileSystem } from '@epicenter/filesystem';
+
+export const fs = createYjsFileSystem(
+  workspace.tables.files,
+  workspace.documents.files.content,
+);
+
+await fs.mkdir('/docs');
+await fs.writeFile('/docs/hello.md', '# Hello');
+await fs.mv('/docs/hello.md', '/notes/hello.md');
+```
+
+Opensidian needs this because the appeal IS files and folders. Users expect to see a file tree, right-click to create files, drag things between directories. A bash terminal writes to the same filesystem. Paths, not IDs, are the primary way users think about their data.
+
+But notice: the filesystem still uses workspace tables underneath. It doesn't replace them. Opensidian also has `conversations` and `chatMessages` tables alongside the `files` table—those are plain workspace records that don't need file semantics at all.
+
+## The filesystem composes on the workspace
+
+This is the architectural point worth calling out. The dependency graph looks like this:
+
+```
+@epicenter/workspace   defineTable, documents, extensions
+        │
+@epicenter/filesystem  filesTable + createYjsFileSystem
+        │
+apps (Opensidian)      fs.mkdir, fs.writeFile, fs.mv
+```
+
+`@epicenter/filesystem` imports `defineTable` from `@epicenter/workspace` to create the `filesTable`. It imports workspace types like `TableHelper` and `Documents` to build the POSIX wrapper. The filesystem package doesn't introduce a new storage layer—it adds a semantic layer on top of the existing one.
+
+That means you get both: structured table access for metadata queries (fast directory listings, path lookups, search indexing) and POSIX-style operations for user-facing file interactions. The same row that `fs.mv` updates is the same row that `workspace.tables.files.get(id)` returns.
+
+## When to use which
+
+The decision comes down to how users think about the data.
+
+If the app knows the shape of every record upfront—notes with titles, bookmarks with URLs, chat messages with timestamps—workspace tables are the right fit. The data is structured. The fields are known. You define a schema, get typed CRUD, and move on.
+
+If the app's data model is inherently hierarchical files—a code editor, a note vault with nested folders, anything where users expect `mkdir` and path resolution—add the filesystem package on top. You still get workspace tables underneath (for metadata queries and other structured data), plus the POSIX operations users expect.
+
+Honeycrisp doesn't use the filesystem because notes don't need paths. Opensidian does because the file tree is the product.

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@epicenter/ai",
+	"description": "Bridges workspace actions with LLM tool calling",
 	"version": "0.1.0",
 	"private": true,
 	"type": "module",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -12,12 +12,16 @@
 	"exports": {
 		"./apps": "./src/apps.ts",
 		"./vite": "./src/vite.ts",
-		"./versions": "./src/versions.ts"
+		"./versions": "./src/versions.ts",
+		"./ai-chat-errors": "./src/ai-chat-errors.ts"
 	},
 	"devDependencies": {
 		"@types/node": "catalog:",
 		"typescript": "catalog:",
 		"vite": "catalog:"
+	},
+	"dependencies": {
+		"wellcrafted": "catalog:"
 	},
 	"scripts": {
 		"typecheck": "tsc --noEmit"

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@epicenter/constants",
+	"description": "Shared URLs, ports, and version info for the Epicenter monorepo",
 	"private": true,
 	"version": "0.1.0",
 	"type": "module",

--- a/packages/constants/src/ai-chat-errors.ts
+++ b/packages/constants/src/ai-chat-errors.ts
@@ -1,0 +1,111 @@
+import { defineErrors, type InferErrors } from 'wellcrafted/error';
+
+/**
+ * Structured error variants for the `/ai/chat` endpoint.
+ *
+ * Defined once in the shared constants package so both server and client
+ * reference the same discriminated union. The server calls the factories
+ * at runtime (`AiChatError.Unauthorized()`); the client imports only the
+ * `AiChatError` type via `InferErrors` for zero-cost type narrowing.
+ *
+ * Each variant's `name` field is the discriminant—use `switch (error.name)`
+ * for exhaustive handling with full TypeScript narrowing.
+ *
+ * @example
+ * ```ts
+ * // Server — runtime usage
+ * import { AiChatError } from '@epicenter/constants/ai-chat-errors';
+ * return c.json(AiChatError.InsufficientCredits({ balance: 42 }), 402);
+ *
+ * // Client — type-only usage
+ * import { AiChatHttpError } from '@epicenter/constants/ai-chat-errors';
+ * if (err instanceof AiChatHttpError) {
+ *   switch (err.serverError.name) {
+ *     case 'Unauthorized': // show sign-in
+ *     case 'InsufficientCredits': // err.serverError.balance
+ *   }
+ * }
+ * ```
+ */
+export const AiChatError = defineErrors({
+	Unauthorized: () => ({ message: 'Unauthorized' }),
+	ProviderNotConfigured: ({ provider }: { provider: string }) => ({
+		message: `${provider} not configured`,
+		provider,
+	}),
+	UnknownModel: ({ model }: { model: string }) => ({
+		message: `Unknown model: ${model}`,
+		model,
+	}),
+	InsufficientCredits: ({ balance }: { balance: unknown }) => ({
+		message: 'Insufficient credits',
+		balance,
+	}),
+	ModelRequiresPaidPlan: ({
+		model,
+		credits,
+	}: {
+		model: string;
+		credits: number;
+	}) => ({
+		message: `${model} requires a paid plan (costs ${credits} credits)`,
+		model,
+		credits,
+	}),
+});
+
+/**
+ * Discriminated union of all AI chat error payloads.
+ *
+ * Reused by both server (runtime) and client (type narrowing).
+ * The `name` field discriminates variants in `switch` statements.
+ *
+ * @example
+ * ```ts
+ * function handleError(error: AiChatError) {
+ *   switch (error.name) {
+ *     case 'InsufficientCredits':
+ *       console.log(error.balance); // TypeScript knows this exists
+ *       break;
+ *     case 'ModelRequiresPaidPlan':
+ *       console.log(error.model, error.credits); // narrowed
+ *       break;
+ *   }
+ * }
+ * ```
+ */
+export type AiChatError = InferErrors<typeof AiChatError>;
+
+/**
+ * Error subclass that carries structured server error data across
+ * TanStack AI's throw boundary.
+ *
+ * Created by `createAiFetchClient` when the server returns a non-2xx
+ * response with a wellcrafted `{ data, error }` JSON envelope. The
+ * `Error` propagates unchanged through TanStack AI's `ChatClient`
+ * pipeline—`instanceof AiChatHttpError` works in `onError` and
+ * when reading `chat.error`.
+ *
+ * @example
+ * ```ts
+ * if (err instanceof AiChatHttpError) {
+ *   console.log(err.status);            // 402
+ *   console.log(err.serverError.name);  // "InsufficientCredits"
+ *   switch (err.serverError.name) {
+ *     case 'InsufficientCredits':
+ *       console.log(err.serverError.balance); // narrowed
+ *       break;
+ *   }
+ * }
+ * ```
+ */
+export class AiChatHttpError extends Error {
+	override readonly name = 'AiChatHttpError';
+
+	constructor(
+		readonly status: number,
+		readonly serverError: AiChatError,
+	) {
+		super(serverError.message);
+	}
+}

--- a/packages/constants/tsconfig.json
+++ b/packages/constants/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": ["../../tsconfig.base.lib.json"],
+	"extends": ["../../tsconfig.base.json"],
 	"compilerOptions": {
 		"module": "NodeNext",
 		"moduleResolution": "NodeNext",

--- a/packages/filesystem/README.md
+++ b/packages/filesystem/README.md
@@ -94,6 +94,10 @@ apps like Opensidian   markdown notes, paths, links, indexing
 
 In the monorepo, apps can treat shared workspace content as files without giving up Yjs collaboration. That is the point of this package.
 
+Most Epicenter apps use [`@epicenter/workspace`](../workspace) directly and don't need this package. Workspace tables are the right default when the app knows the shape of every record upfront—notes with titles, bookmarks with URLs, chat messages with timestamps. Reach for `@epicenter/filesystem` when the data model is inherently hierarchical files: a code editor, a note vault with nested folders, anything where users expect a file tree and path-based operations.
+
+Honeycrisp (Apple Notes clone) uses only workspace tables. Opensidian (file-based editor with a bash terminal) uses both—`filesTable` from this package alongside plain workspace tables for chat and settings. See [Your Data Is Probably a Table, Not a File](../../docs/articles/your-data-is-probably-a-table-not-a-file.md) for the full comparison.
+
 ## License
 
 MIT.

--- a/packages/svelte-utils/package.json
+++ b/packages/svelte-utils/package.json
@@ -19,6 +19,7 @@
 		"./workspace-gate": "./src/workspace-gate/index.ts"
 	},
 	"dependencies": {
+		"@epicenter/constants": "workspace:*",
 		"@epicenter/api": "workspace:*",
 		"@epicenter/ui": "workspace:*",
 		"@epicenter/workspace": "workspace:*",

--- a/packages/svelte-utils/src/auth/create-ai-fetch-client.ts
+++ b/packages/svelte-utils/src/auth/create-ai-fetch-client.ts
@@ -1,0 +1,82 @@
+import {
+	type AiChatError,
+	AiChatHttpError,
+} from '@epicenter/constants/ai-chat-errors';
+
+/**
+ * Wrap an authenticated fetch client to read structured error bodies
+ * before TanStack AI's adapter can throw a generic status-only error.
+ *
+ * When the server returns a non-2xx response, this wrapper:
+ * 1. Reads the JSON body (wellcrafted's `{ data, error }` envelope)
+ * 2. Extracts the structured error (`name`, `message`, variant fields)
+ * 3. Throws an `AiChatHttpError` with `.status` and `.serverError`
+ *
+ * The thrown error propagates unchanged through TanStack AI's
+ * `ChatClient` pipeline to `onError` / `chat.error`. Use
+ * `instanceof AiChatHttpError` on the client side to narrow it.
+ *
+ * @param authFetch - An authenticated fetch function (e.g. `auth.fetch`)
+ * @returns A fetch-compatible function that enriches errors with server data
+ *
+ * @example
+ * ```ts
+ * import { createAiFetchClient } from '@epicenter/svelte-utils';
+ * import { AiChatHttpError } from '@epicenter/constants/ai-chat-errors';
+ *
+ * // In chat-state.svelte.ts:
+ * connection: fetchServerSentEvents(
+ *   () => `${APP_URLS.API}/ai/chat`,
+ *   async () => ({
+ *     fetchClient: createAiFetchClient(auth.fetch),
+ *     body: { data: { provider, model } },
+ *   }),
+ * ),
+ *
+ * // Then in error handling:
+ * if (chat.error instanceof AiChatHttpError) {
+ *   switch (chat.error.serverError.name) {
+ *     case 'Unauthorized': // show sign-in
+ *     case 'InsufficientCredits': // show upgrade
+ *   }
+ * }
+ * ```
+ */
+type FetchFn = (
+	input: RequestInfo | URL,
+	init?: RequestInit,
+) => Promise<Response>;
+
+export function createAiFetchClient(authFetch: FetchFn): FetchFn {
+	return async (input, init) => {
+		const response = await authFetch(input, init);
+
+		if (!response.ok) {
+			let serverError: AiChatError | undefined;
+			try {
+				const body = await response.json();
+				// wellcrafted Err envelope: { data: null, error: { name, message, ... } }
+				if (
+					body?.error &&
+					typeof body.error === 'object' &&
+					'name' in body.error
+				) {
+					serverError = body.error as AiChatError;
+				}
+			} catch {
+				// Body wasn't JSON — fall through with undefined serverError
+			}
+
+			if (serverError) {
+				throw new AiChatHttpError(response.status, serverError);
+			}
+
+			// Non-JSON or unrecognized error body — throw generic Error
+			throw new Error(
+				`HTTP error! status: ${response.status} ${response.statusText}`,
+			);
+		}
+
+		return response;
+	};
+}

--- a/packages/svelte-utils/src/auth/index.ts
+++ b/packages/svelte-utils/src/auth/index.ts
@@ -8,3 +8,4 @@ export {
 	type CreateAuthOptions,
 	createAuth,
 } from './create-auth.svelte.js';
+export { createAiFetchClient } from './create-ai-fetch-client.js';

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -1629,6 +1629,12 @@ Useful internal docs live nearby:
 - `docs/` — package-specific architecture notes
 - `specs/` — historical design docs and implementation specs
 
+## Related Packages
+
+If your app's data model is inherently files and folders—a code editor, a note vault with nested directories, anything where users expect `mkdir` and path resolution—[`@epicenter/filesystem`](../filesystem) builds that abstraction on top of this package. It imports `defineTable` to create a `filesTable`, wraps workspace tables and documents into POSIX-style operations (`writeFile`, `mv`, `rm`, `stat`), and plugs into the same extension system.
+
+Most apps won't need it. If you know the shape of every record upfront, workspace tables are the right default. See [Your Data Is Probably a Table, Not a File](../../docs/articles/your-data-is-probably-a-table-not-a-file.md) for the full decision matrix.
+
 ## License
 
 MIT

--- a/specs/20260407T165605-structured-ai-chat-errors.md
+++ b/specs/20260407T165605-structured-ai-chat-errors.md
@@ -1,0 +1,515 @@
+# Structured AI Chat Errors: defineErrors End-to-End
+
+**Date**: 2026-04-07
+**Status**: Draft
+**Author**: AI-assisted
+
+## Overview
+
+Carry wellcrafted `defineErrors` structured errors from the API's JSON response all the way to the client's chat UI, so the frontend can show "Sign in to use AI Chat" instead of "HTTP error! status: 401". The server already sends structured errors—the client just doesn't read them.
+
+## Motivation
+
+### Current State
+
+The server returns structured, discriminated errors:
+
+```ts
+// apps/api/src/ai-chat.ts
+const AiChatError = defineErrors({
+  InsufficientCredits: ({ balance }) => ({ message: 'Insufficient credits', balance }),
+  ModelRequiresPaidPlan: ({ model, credits }) => ({
+    message: `${model} requires a paid plan (costs ${credits} credits)`,
+    model, credits,
+  }),
+});
+
+return c.json(AiChatError.InsufficientCredits({ balance }), 402);
+// Wire: { "data": null, "error": { "name": "InsufficientCredits", "message": "...", "balance": 42 } }
+```
+
+But TanStack AI's `fetchServerSentEvents` throws before reading the body:
+
+```ts
+// @tanstack/ai-client — connection-adapters.ts:297
+if (!response.ok) {
+  throw new Error(`HTTP error! status: ${response.status} ${response.statusText}`)
+  //                ▲ body is NEVER read — structured error is lost
+}
+```
+
+The client parses status codes from error message strings:
+
+```ts
+// apps/opensidian/src/lib/chat/chat-state.svelte.ts
+get isCreditsExhausted() {
+  return chat.error.message.includes('status: 402');  // fragile string parsing
+},
+```
+
+This creates problems:
+
+1. **Lost structured data**: The server sends `{ name, message, balance, model, credits }` but the client only sees `"HTTP error! status: 402"`. All fields besides the status code are discarded.
+2. **Fragile discrimination**: `error.message.includes('status: 402')` breaks if TanStack AI ever changes the message format. Can't distinguish between different error variants that share a status code.
+3. **No actionable UI**: The error banner shows `"HTTP error! status: 401"` instead of "Sign in to use AI Chat" with a sign-in button. Each error type should drive specific UI affordances.
+
+### Desired State
+
+```ts
+// Client-side — typed, structured error from the server
+const err = chat.error;
+if (isAiChatError(err)) {
+  switch (err.serverError.name) {
+    case 'Unauthorized':
+      // Show sign-in prompt
+      break;
+    case 'InsufficientCredits':
+      // Show "upgrade plan" with err.serverError.balance
+      break;
+    case 'ModelRequiresPaidPlan':
+      // Show "this model needs Pro" with err.serverError.model
+      break;
+    case 'ProviderNotConfigured':
+      // Show BYOK API key prompt
+      break;
+  }
+}
+```
+
+## Research Findings
+
+### TanStack AI Error Pipeline
+
+Traced the full path from server response to client `onError`:
+
+```
+fetchServerSentEvents
+  └─ calls fetchClient(url, opts)
+       └─ gets Response
+            └─ if (!response.ok) throw Error(`HTTP error! status: ${status}`)
+                                       ▲ body never read
+                                       │
+normalizeConnectionAdapter.send()
+  └─ catches thrown error
+       └─ pushes RUN_ERROR chunk: { type: 'RUN_ERROR', error: { message: err.message } }
+       └─ re-throws the error
+            │
+ChatClient.streamResponse()
+  └─ catches thrown error
+       └─ reportStreamError(err)
+            └─ setError(err)         → chat.error
+            └─ onError(err)          → your callback
+```
+
+**Key finding**: The `Error` instance thrown by `fetchServerSentEvents` is the exact same `Error` object that arrives at `onError`. It's not re-wrapped or cloned. Any properties we attach to it survive the entire pipeline.
+
+**Key finding**: `fetchClient` is called *before* the `!response.ok` check. If our custom `fetchClient` throws first (after reading the body), TanStack AI's check never executes. The thrown error propagates directly through the same catch chain.
+
+### wellcrafted defineErrors Wire Format
+
+`defineErrors` produces `Err(Object.freeze({ ...body, name }))` which Hono's `c.json()` serializes as:
+
+```json
+{
+  "data": null,
+  "error": {
+    "name": "InsufficientCredits",
+    "message": "Insufficient credits",
+    "balance": 42
+  }
+}
+```
+
+The `name` field is the discriminant—identical to how `switch (error.name)` works in the Result pattern. The full `error` object is a frozen plain object, fully JSON-serializable, no prototype chain.
+
+### Can We Avoid Throwing Entirely?
+
+**Constraint**: TanStack AI's `ChatClient` consumes the connection adapter via `await this.connection.send(messages, body, signal)`. The only error channel is throwing—`send()` returns `void`, and `ChatClient.streamResponse()` only checks for errors via the catch block (line 636) and the `RUN_ERROR` chunk.
+
+We cannot change `ChatClient`'s internal error handling without forking TanStack AI. The throw boundary is inside `ChatClient`—it's their code.
+
+**However**: We control everything *before* the throw. The `fetchClient` option lets us:
+1. Read the response body
+2. Parse the structured error
+3. Attach it to the `Error` object we throw
+4. The `Error` propagates unchanged to `onError`
+
+So the answer is: **defineErrors all the way down to the throw boundary, then attach the structured data to the Error that crosses it**. On the client side, we extract it back out.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Where to read error body | Custom `fetchClient` wrapper | Only intervention point before TanStack AI discards the body. The `fetchClient` option is explicitly designed for this (auth, proxies, custom transport). |
+| How to attach structured data | Properties on the thrown `Error` | The same `Error` instance propagates to `onError`—verified by tracing the code. No cloning or re-wrapping occurs. |
+| Error shape on the wire | Keep `{ data, error }` Result envelope | Already in place. `c.json(AiChatError.Variant(), status)` produces this. No server changes needed for serialization. |
+| Client-side type narrowing | Type guard function `isAiChatHttpError(err)` | Clean narrowing. Avoids `as any` casts. Single place to define the shape. |
+| Client-side error type | `InferErrors<typeof AiChatError>` reused from server's `defineErrors` | No manual type mirroring. The server defines the error variants once; the client imports the type. `switch (err.serverError.name)` gives full TypeScript narrowing with variant-specific fields. |
+| Where to define shared errors | `@epicenter/constants` | Both server and client import from here. Server uses the factories at runtime; client uses `InferErrors` type-only + the type guard at runtime. |
+| Server response changes | Merge `Unauthorized` into `AiChatError` | Currently `AuthError.Unauthorized()` is in `app.ts` separately. Moving it into the shared `AiChatError` keeps all `/ai/chat` errors in one discriminated union. |
+
+## Architecture
+
+### Error Flow (After)
+
+```
+SERVER                              WIRE                          CLIENT
+──────                              ────                          ──────
+
+AiChatError                         HTTP 402                      createAiFetchClient
+  .InsufficientCredits              Body:                           │
+  ({ balance: 42 })                 ┌──────────────────┐            ▼
+    │                               │{ "data": null,   │         response = await
+    ▼                               │  "error": {      │           authFetch(url, init)
+  c.json(result, 402)              │    "name":       │         if (!response.ok) {
+                                    │     "Insufficient│           body = await response.json()
+                                    │      Credits",   │           ──────────────────────────
+                                    │    "message":    │           READS BODY ← key change
+                                    │     "Insuffici..."│          ──────────────────────────
+                                    │    "balance": 42 │           const err = new Error(...)
+                                    │  }               │           err.status = 402
+                                    │}                 │           err.serverError = body.error
+                                    └──────────────────┘           throw err
+                                                                     │
+                                    (body IS read this time)         │
+                                                                     ▼
+                                                                  normalizeConnectionAdapter
+                                                                    └─ re-throws (same err)
+                                                                       │
+                                                                       ▼
+                                                                  ChatClient.reportStreamError
+                                                                    └─ setError(err)
+                                                                    └─ onError(err)
+                                                                       │
+                                                                       ▼
+                                                                  chat.error  ← has .serverError
+                                                                       │
+                                                                       ▼
+                                                                  AiChat.svelte
+                                                                    if isAiChatError(err):
+                                                                      switch (err.serverError.name)
+                                                                        "Unauthorized" → sign-in UI
+                                                                        "InsufficientCredits" → upgrade
+                                                                        "ModelRequiresPaidPlan" → hint
+                                                                        "ProviderNotConfigured" → BYOK
+```
+
+### Type Hierarchy
+
+The key insight: `InferErrors<typeof AiChatError>` already produces the exact discriminated union that goes over the wire. We reuse the server's type directly—no manual mirroring.
+
+```ts
+// What InferErrors<typeof AiChatError> produces:
+| Readonly<{ name: "ProviderNotConfigured"; message: string; provider: string }>
+| Readonly<{ name: "UnknownModel"; message: string; model: string }>
+| Readonly<{ name: "InsufficientCredits"; message: string; balance: unknown }>
+| Readonly<{ name: "ModelRequiresPaidPlan"; message: string; model: string; credits: number }>
+
+// This is the EXACT shape that c.json() serializes into response.error.
+// The client type-asserts the parsed JSON into this union.
+// switch (error.name) narrows to the specific variant with all its fields.
+```
+
+```
+                   Error (JS built-in)
+                     │
+                     ▼
+               AiChatHttpError extends Error
+                 ├── status: number
+                 ├── serverError: InferErrors<typeof AiChatError>
+                 │                      ▲
+                 │                      │ same type from server's defineErrors
+                 │                      │ reused via type-only import
+                 └── message: string (from serverError.message or fallback)
+```
+
+## Implementation Plan
+
+### Phase 1: Extract Shared Error Definitions
+
+- [ ] **1.1** Move `AiChatError` defineErrors (and the `AuthError.Unauthorized` variant for `/ai/*`) into a shared location that both server and client can import. Two options:
+
+**Option A (recommended)**: Extract the `defineErrors` call into a shared package (e.g. `packages/constants/src/ai-chat-errors.ts`). The server imports and uses the factories. The client imports the type only (`InferErrors`).
+
+```ts
+// packages/constants/src/ai-chat-errors.ts
+import { defineErrors, type InferErrors } from 'wellcrafted/error';
+
+export const AiChatError = defineErrors({
+  Unauthorized: () => ({ message: 'Unauthorized' }),
+  ProviderNotConfigured: ({ provider }: { provider: string }) => ({
+    message: `${provider} not configured`,
+    provider,
+  }),
+  UnknownModel: ({ model }: { model: string }) => ({
+    message: `Unknown model: ${model}`,
+    model,
+  }),
+  InsufficientCredits: ({ balance }: { balance: unknown }) => ({
+    message: 'Insufficient credits',
+    balance,
+  }),
+  ModelRequiresPaidPlan: ({
+    model,
+    credits,
+  }: {
+    model: string;
+    credits: number;
+  }) => ({
+    message: `${model} requires a paid plan (costs ${credits} credits)`,
+    model,
+    credits,
+  }),
+});
+
+/** Discriminated union of all AI chat error payloads—reused by both server and client. */
+export type AiChatError = InferErrors<typeof AiChatError>;
+```
+
+**Option B**: Keep `defineErrors` in `apps/api/src/ai-chat.ts` and export only the type. The client imports `type AiChatError` from the API package. Simpler if you don't want to move runtime code, but creates a dependency from client → API types.
+
+- [ ] **1.2** Create the type guard and HTTP error type using `InferErrors`:
+
+```ts
+// packages/constants/src/ai-chat-errors.ts (continued)
+
+/** An Error with structured server error data attached. */
+export type AiChatHttpError = Error & {
+  status: number;
+  serverError: AiChatError;  // ← the InferErrors union, not a manual type
+};
+
+/** Type guard: narrows an Error to AiChatHttpError with full variant discrimination. */
+export function isAiChatHttpError(err: unknown): err is AiChatHttpError {
+  return (
+    err instanceof Error &&
+    'status' in err &&
+    typeof (err as any).status === 'number' &&
+    'serverError' in err &&
+    typeof (err as any).serverError === 'object' &&
+    (err as any).serverError !== null &&
+    'name' in (err as any).serverError
+  );
+}
+```
+
+Now the client gets full TypeScript narrowing:
+
+```ts
+if (isAiChatHttpError(err)) {
+  switch (err.serverError.name) {
+    case 'InsufficientCredits':
+      err.serverError.balance;  // ← TypeScript knows this exists
+      break;
+    case 'ModelRequiresPaidPlan':
+      err.serverError.model;    // ← narrowed to string
+      err.serverError.credits;  // ← narrowed to number
+      break;
+    case 'Unauthorized':
+      // no extra fields, just show sign-in UI
+      break;
+  }
+}
+```
+
+- [ ] **1.3** Export from `packages/constants/src/index.ts` and verify the package builds.
+
+### Phase 2: Custom fetchClient Wrapper
+
+- [ ] **2.1** Create `packages/svelte-utils/src/auth/create-ai-fetch-client.ts`:
+
+```ts
+import type { AiChatError } from '@epicenter/constants';
+
+/**
+ * Wrap an authenticated fetch client to read structured error bodies
+ * before TanStack AI's adapter can throw a generic status-only error.
+ *
+ * When the server returns a non-2xx response, this wrapper:
+ * 1. Reads the JSON body (wellcrafted's { data, error } envelope)
+ * 2. Extracts the structured error (name, message, variant fields)
+ * 3. Throws an Error with .status and .serverError attached
+ *
+ * The thrown Error propagates unchanged through TanStack AI's
+ * ChatClient pipeline to onError / chat.error.
+ */
+export function createAiFetchClient(authFetch: typeof fetch): typeof fetch {
+  return async (input, init) => {
+    const response = await authFetch(input, init);
+
+    if (!response.ok) {
+      let serverError: AiChatError | undefined;
+      try {
+        const body = await response.json();
+        // wellcrafted Err envelope: { data: null, error: { name, message, ... } }
+        if (body?.error && typeof body.error === 'object' && 'name' in body.error) {
+          serverError = body.error as AiChatError;
+        }
+      } catch {
+        // Body wasn't JSON — fall through with undefined serverError
+      }
+
+      const message = serverError?.message ?? `HTTP error! status: ${response.status}`;
+      const error = new Error(message) as Error & {
+        status: number;
+        serverError: AiChatError | undefined;
+      };
+      error.status = response.status;
+      error.serverError = serverError;
+      throw error;
+    }
+
+    return response;
+  };
+}
+```
+
+- [ ] **2.2** Export from `packages/svelte-utils/src/index.ts`.
+
+### Phase 3: Wire Into Chat State
+
+- [ ] **3.1** Update `apps/opensidian/src/lib/chat/chat-state.svelte.ts`:
+
+```ts
+import { createAiFetchClient } from '@epicenter/svelte-utils';
+import { isAiChatHttpError } from '@epicenter/constants';
+
+// In createConversationHandle:
+connection: fetchServerSentEvents(
+  () => `${APP_URLS.API}/ai/chat`,
+  async () => ({
+    fetchClient: createAiFetchClient(auth.fetch),  // ← swap
+    body: { data: { ... } },
+  }),
+),
+```
+
+- [ ] **3.2** Replace string-based error detection with typed checks:
+
+```ts
+get isCreditsExhausted() {
+  return isAiChatHttpError(chat.error)
+    && chat.error.serverError.name === 'InsufficientCredits';
+},
+
+get isUnauthorized() {
+  return isAiChatHttpError(chat.error)
+    && chat.error.serverError.name === 'Unauthorized';
+},
+
+get isModelRestricted() {
+  return isAiChatHttpError(chat.error)
+    && chat.error.serverError.name === 'ModelRequiresPaidPlan';
+},
+```
+
+- [ ] **3.3** Apply the same changes to `apps/tab-manager/src/lib/chat/chat-state.svelte.ts` (same pattern).
+
+### Phase 4: Server — Unify Auth Error Into AiChatError
+
+- [ ] **4.1** The `authGuard` in `app.ts` returns `AuthError.Unauthorized()` before the request reaches `ai-chat.ts`. Two options:
+
+**Option A (minimal)**: Keep `AuthError` in `app.ts` as-is. The fetchClient wrapper already reads any `{ data, error }` envelope regardless of which `defineErrors` produced it. The `name: "Unauthorized"` field matches the shared type.
+
+**Option B (clean)**: Add `Unauthorized` to `AiChatError` in `ai-chat.ts` and use a route-level middleware override for `/ai/chat` that returns the ai-chat-specific error. This keeps all `/ai/chat` error variants in one union.
+
+**Recommendation**: Option A. The existing `AuthError.Unauthorized()` already produces `{ name: "Unauthorized", message: "Unauthorized" }` which the client type guard handles. No server changes needed.
+
+### Phase 5: UI Error States
+
+- [ ] **5.1** Update `AiChat.svelte` to show contextual error UI:
+
+```svelte
+{#if active?.isUnauthorized}
+  <div class="...">
+    <span>Sign in to use AI Chat</span>
+    <Button onclick={() => /* open auth popover or navigate */}>Sign In</Button>
+  </div>
+{:else if active?.isCreditsExhausted}
+  <div class="...">
+    <span>You're out of credits</span>
+    <Button onclick={() => /* open billing */}>Upgrade</Button>
+  </div>
+{:else if active?.isModelRestricted}
+  <div class="...">
+    <span>{active.error?.serverError?.message}</span>
+    <Button onclick={() => /* switch to free model */}>Switch Model</Button>
+  </div>
+{:else if errorVisible}
+  <!-- Generic fallback for unknown errors -->
+  <div class="...">{active?.error?.message}</div>
+{/if}
+```
+
+- [ ] **5.2** Decide whether to also show a subtle auth indicator in the chat header (e.g. small "Not signed in" badge) *before* the user sends a message.
+
+## Edge Cases
+
+### Non-JSON Error Responses
+
+1. Server returns HTML error page (502 from Cloudflare, proxy error)
+2. `response.json()` throws in the wrapper
+3. `serverError` stays `undefined`, `message` falls back to `HTTP error! status: 502`
+4. UI shows generic error banner—same as today, but with a cleaner message
+
+### Network Errors (No Response At All)
+
+1. `fetch()` itself throws (DNS failure, offline)
+2. Wrapper never reaches the `!response.ok` check—the thrown error propagates directly
+3. `isAiChatHttpError` returns `false` (no `.status` or `.serverError`)
+4. UI shows generic error banner with the network error message
+
+### BYOK Requests That Fail
+
+1. User provides their own API key, server's provider adapter throws
+2. Server catches in `ai-chat.ts`, refunds credits via `afterResponse`
+3. The thrown error from the stream adapter is a different shape (not from `defineErrors`)
+4. Client shows generic error—this is correct behavior, the error is from the LLM provider, not from our auth/billing
+
+### Concurrent Conversations With Different Auth States
+
+1. User is signed in, opens conversation A, starts streaming
+2. Token expires mid-stream
+3. Conversation B send fails with 401
+4. Each conversation handle has independent `error` state—conversation A continues, B shows auth prompt
+5. No global state corruption
+
+## Open Questions
+
+1. **Should we show an auth state indicator before the user sends?**
+   - Options: (a) Subtle "Not signed in" badge in chat header, (b) Nothing until they try to send, (c) Replace the input placeholder text with "Sign in to chat..."
+   - **Recommendation**: (b) initially—the "discover, try, get prompted" flow is what you described. Can add (a) or (c) later if users are confused.
+
+2. **Where should the shared error types live?**
+   - Options: (a) `@epicenter/constants`, (b) New `@epicenter/ai-errors` package, (c) Inline in each app
+   - **Recommendation**: (a) `@epicenter/constants`—it already exists and holds shared cross-app types. The error type is small and stable.
+
+3. **Should we expose `serverError` directly on the conversation handle, or keep it internal?**
+   - Options: (a) `active.serverError` property on ConversationHandle, (b) Only expose boolean helpers like `isUnauthorized`, (c) Both
+   - **Recommendation**: (c) Both. Booleans for common cases in templates, raw access for uncommon cases.
+
+4. **Should we attempt to parse `defineErrors` bodies from ALL non-2xx routes, or only `/ai/chat`?**
+   - The wrapper is generic—it'll parse any `{ data, error }` envelope from any Hono route. Could be reused for sync errors, billing errors, asset errors.
+   - **Recommendation**: Make the wrapper generic (it already is). Use the specific `AiChatErrorName` union only for the AI chat UI logic. Other features can define their own unions later.
+
+## Success Criteria
+
+- [ ] Sending a message when not authenticated shows "Sign in to use AI Chat" (not "HTTP error! status: 401")
+- [ ] Running out of credits shows "You're out of credits" with the balance from the server
+- [ ] Using an expensive model on free tier shows the model name and credit cost from the server
+- [ ] Network errors still show a reasonable generic message
+- [ ] No `error.message.includes('status:')` string parsing anywhere in the codebase
+- [ ] `isAiChatHttpError` type guard works with TypeScript narrowing
+- [ ] Both opensidian and tab-manager apps use the same pattern
+- [ ] Existing behavior for successful requests is unchanged
+
+## References
+
+- `apps/api/src/app.ts` — `authGuard` middleware, `AuthError.Unauthorized()` (lines 274-291)
+- `apps/api/src/ai-chat.ts` — `AiChatError` defineErrors, all error responses (lines 37-61, 89-120)
+- `apps/opensidian/src/lib/chat/chat-state.svelte.ts` — Chat state, `fetchServerSentEvents` wiring, `isCreditsExhausted` (lines 97-128, 208-211)
+- `apps/tab-manager/src/lib/chat/chat-state.svelte.ts` — Same pattern, needs same changes
+- `packages/svelte-utils/src/auth/create-auth.svelte.ts` — `auth.fetch` implementation (lines 410-415)
+- `tmp-search/tanstack-ai/.../connection-adapters.ts` — `fetchServerSentEvents` `!response.ok` branch (lines 297-301)
+- `tmp-search/tanstack-ai/.../chat-client.ts` — `reportStreamError`, error propagation (lines 328-344, 636-644)
+- `node_modules/.bun/wellcrafted@0.34.1/.../error/index.js` — `defineErrors` runtime, `Err` wrapper (lines 57-67)


### PR DESCRIPTION
Five of nine apps had no README at all. A Hacker News visitor clicking into `apps/dashboard` or `apps/tab-manager` saw an empty directory listing — no explanation of what the app does, how to run it, or why it exists. The root README linked to apps that couldn't explain themselves, and 12 package.json files had empty or missing `description` fields, making them invisible to npm search and GitHub's sidebar.

This fills every gap. Each new README was stress-tested by simulating three reader perspectives — a skeptical senior engineer, a mid-level developer new to CRDTs, and a technical writer — then revised based on their feedback. The biggest revision: the first drafts applied Opensidian's README structure as a rigid template, which produced "README uncanny valley" where every app looked equally important and equally architected regardless of complexity. The second pass fixed that by varying depth per app and dropping sections that didn't earn their place.

---

**The five new READMEs each lead with what makes the app interesting, not what it's built with.**

Dashboard opens with "billing data has one source of truth: the server" — deliberately pushing back on the repo's local-first narrative. Tab Manager opens with "live tabs and saved tabs are fundamentally different things" and explains the ephemeral/persistent split that most browser extensions blur. Honeycrisp invites you to "open two browser tabs and try it." Skills explains what a skill even is before describing the editor. Fuji names what you'd actually build with it: a journal, knowledge base, or portfolio.

Architecture sections only appear where they show a non-obvious boundary. Dashboard earns one (it's deliberately not local-first). Tab Manager earns one (the browser-state vs workspace-state split is genuinely app-specific). Fuji, Honeycrisp, and Skills don't get one — their stack diagrams were interchangeable.

---

**The root README now shows the full breadth of what's been built.**

The Apps table expanded from four entries to six (adds Opensidian and Honeycrisp), with a single line linking the remaining five apps. A new Design Decisions section links five key implemented specs — encrypted workspace storage, Y-Sweet persistence, the definition-first workspace API, resilient client architecture, and the sync protocol migration. The "Where We're Headed" section was claiming "notes are coming" when Honeycrisp and Opensidian already exist; that's fixed.

---

**Package descriptions are the kind of thing nobody notices until they're missing.** Twelve package.json files now have one-line descriptions so they surface correctly in npm, GitHub search, and monorepo tooling.

18 files changed across 4 commits.