### PR TITLE
feat(opensidian): onboarding, terminal persistence, and toolbar follow-ups

### DIFF
--- a/apps/opensidian/src/lib/components/AppShell.svelte
+++ b/apps/opensidian/src/lib/components/AppShell.svelte
@@ -14,6 +14,7 @@
 	import { sidebarSearchState } from '$lib/state/sidebar-search-state.svelte';
 	import { terminalState } from '$lib/state/terminal-state.svelte';
 	import { getFileIcon } from '$lib/utils/file-icons';
+	import { sampleDataLoader } from '$lib/utils/load-sample-data.svelte';
 	import AiChat from './chat/AiChat.svelte';
 	import ContentPanel from './editor/ContentPanel.svelte';
 	import StatusBar from './editor/StatusBar.svelte';
@@ -25,6 +26,37 @@
 	let paletteOpen = $state(false);
 	let chatOpen = $state(false);
 
+	// ── First-visit onboarding ──────────────────────────────────────
+	let onboarded = false;
+	$effect(() => {
+		if (onboarded) return;
+		if (fsState.rootChildIds.length > 0) {
+			onboarded = true;
+			return;
+		}
+		// Empty file tree on first render — seed data, open terminal, show welcome.
+		onboarded = true;
+		sampleDataLoader.load().then(() => {
+			const readme = fsState.walkTree((id, row) => {
+				if (row.type === 'file' && row.name === 'README.md') return { collect: id, descend: false };
+				return { descend: true };
+			});
+			if (readme[0]) fsState.selectFile(readme[0]);
+		});
+		terminalState.show();
+		terminalState.printWelcome([
+			'Welcome to OpenSidian — notes on CRDTs with a bash terminal.',
+			'',
+			'Try these:',
+			'  echo "# Hello HN" > /hello.md    create a file',
+			'  ls /                              list files',
+			'  open /hello.md                    open in editor',
+			'  cat /hello.md                     print contents',
+			'',
+			'80+ commands: awk, sed, grep, jq, find, sqlite3, curl, and more.',
+			'Press ⌘` to toggle this terminal.',
+		]);
+	});
 	$effect(() => {
 		if (!paletteOpen) searchState.reset();
 	});

--- a/apps/opensidian/src/lib/components/SidebarHeader.svelte
+++ b/apps/opensidian/src/lib/components/SidebarHeader.svelte
@@ -11,8 +11,11 @@
 
 <Tooltip.Provider>
 	<div
-		class="flex h-8 shrink-0 items-center justify-end border-b px-2"
+		class="flex h-8 shrink-0 items-center justify-between border-b px-2"
 	>
+		<div class="flex size-5 items-center justify-center rounded bg-black">
+			<img src="/logo.svg" alt="Epicenter" class="size-3.5" />
+		</div>
 		<div class="flex items-center gap-0.5">
 			<Tooltip.Root>
 				<Tooltip.Trigger>

--- a/apps/opensidian/src/lib/components/editor/ContentPanel.svelte
+++ b/apps/opensidian/src/lib/components/editor/ContentPanel.svelte
@@ -33,7 +33,7 @@
 		<Empty.Root class="h-full border-0">
 			<Empty.Header>
 				<Empty.Title>No file selected</Empty.Title>
-				<Empty.Description>Click a file in the tree to view its contents</Empty.Description>
+				<Empty.Description>Click a file in the tree, or use the terminal below</Empty.Description>
 			</Empty.Header>
 			{#if fsState.rootChildIds.length === 0}
 				<Button variant="outline" size="sm" onclick={() => sampleDataLoader.load()} disabled={sampleDataLoader.seeding}>

--- a/apps/opensidian/src/lib/state/terminal-state.svelte.ts
+++ b/apps/opensidian/src/lib/state/terminal-state.svelte.ts
@@ -171,6 +171,11 @@ function createTerminalState() {
 		clear() {
 			history = [];
 		},
+
+		/** Print a welcome message as a single output entry. */
+		printWelcome(lines: string[]) {
+			history = [...history, { type: 'output', stdout: lines.join('\n') + '\n', stderr: '', exitCode: 0 }];
+		},
 	};
 }
 

--- a/apps/opensidian/static/logo.svg
+++ b/apps/opensidian/static/logo.svg
@@ -1,0 +1,9 @@
+<svg width="7680" height="7680" viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg">
+  <!-- No background rect - this makes it transparent -->
+  
+  <!-- Top-left circle (gray) - drawn first so it appears behind -->
+  <circle cx="170" cy="170" r="100" fill="#cccccc" opacity="1"/>
+  
+  <!-- Bottom-right circle (pure white) - drawn second so it appears in front -->
+  <circle cx="230" cy="230" r="100" fill="#ffffff" opacity="1"/>
+</svg>


### PR DESCRIPTION
Follow-up to #1632 (toolbar redesign). That PR deleted the toolbar and redistributed actions to the sidebar header, status bar, and context menus. This addresses what we got wrong and adds first-visit onboarding for the HN launch.

The terminal is the feature that makes opensidian different from every other notes app — but it was hidden behind ⌘\`. A HN visitor would land on an empty file tree, see "No file selected", and leave without ever discovering the bash interpreter. Now, first-time visitors get three things simultaneously: sample data populates the file tree, the README opens in the editor, and the terminal opens with a welcome message:

```
Welcome to OpenSidian — notes on CRDTs with a bash terminal.

Try these:
  echo "# Hello HN" > /hello.md    create a file
  ls /                              list files
  open /hello.md                    open in editor
  cat /hello.md                     print contents

80+ commands: awk, sed, grep, jq, find, sqlite3, curl, and more.
Press ⌘\` to toggle this terminal.
```

The welcome prints whenever the terminal opens with empty history — not just first visit. Covers cleared storage, fresh sessions, and the \`clear\` command. Terminal open/closed state persists via \`createPersistedState\` so returning visitors see whatever they left.

---

The terminal scroll was broken — \`ScrollArea\` inside a flex column needs \`min-h-0\` to shrink below content height. Fixed by binding \`viewportRef\` on \`ScrollArea\` so auto-scroll targets the actual scrollable viewport element instead of an inner content div.

Two smaller items came along for the ride. A GitHub icon in the tab bar links to the opensidian source (HN visitors want to see code). The sample data loader was reverted to a \`createSampleDataLoader()\` factory — Svelte's compiler rejects bare \`$state\` exports that get reassigned, and the initial workaround broke the codebase convention.

2 commits, 10 files changed, +151/-72. Stacks on #1632.