### PR TITLE
fix(cli): add Node-compatible bin wrapper for npm publish

### DIFF
--- a/packages/cli/bin/epicenter.mjs
+++ b/packages/cli/bin/epicenter.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const isBun = typeof Bun !== "undefined";
+
+if (!isBun) {
+	const bunCheck = spawnSync("bun", ["--version"], { stdio: "ignore" });
+
+	if (bunCheck.status === 0) {
+		const result = spawnSync(
+			"bun",
+			[fileURLToPath(import.meta.url), ...process.argv.slice(2)],
+			{ stdio: "inherit" },
+		);
+		process.exit(result.status ?? 1);
+	}
+
+	console.error(`Epicenter CLI requires Bun.
+
+Install it:
+
+  curl -fsSL https://bun.sh/install | bash
+
+Then run this command again. Learn more: https://bun.sh`);
+	process.exit(1);
+}
+
+await import("../src/bin.ts");

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
 	"main": "./src/index.ts",
 	"types": "./src/index.ts",
 	"bin": {
-		"epicenter": "./src/bin.ts"
+		"epicenter": "./bin/epicenter.mjs"
 	},
 	"dependencies": {
 		"@epicenter/workspace": "workspace:*",


### PR DESCRIPTION
`npm publish` strips `.ts` files, so our bin field pointing to `./src/bin.ts` meant `npx epicenter` and `bunx epicenter` would fail silently after publish.

The fix is `bin/epicenter.mjs`, a Node-compatible wrapper that handles three scenarios. Running under Bun (the happy path): detects `typeof Bun !== "undefined"` and directly imports `../src/bin.ts` with zero overhead. Running under Node with Bun installed: checks if Bun is on PATH via `spawnSync("bun", ["--version"])` and re-execs itself with Bun. Running under Node without Bun: prints a clear error with install instructions and exits 1.

The shebang is `#!/usr/bin/env node` rather than `#!/usr/bin/env bun` because `npx` on Windows ignores shebangs and always invokes with Node. A Bun shebang would produce a cryptic error on machines without Bun installed. Compiling to JS isn't an option either—the CLI uses `bun:sqlite`, so the output still can't run on Node. Bun is a genuine runtime requirement, not a convenience.

This is the established pattern for Bun-first CLIs on npm: [trekker](https://github.com/obsfx/trekker/blob/main/bin/trekker.js), [pensar](https://github.com/pensarai/apex/blob/canary/bin/pensar.js), [t1code](https://github.com/maria-rcks/t1code/blob/main/apps/tui/bin/t1code.js).

| Scenario | Result |
|---|---|
| `bun epicenter.mjs --help` | ✅ Direct import, no subprocess |
| `node epicenter.mjs --help` | ✅ Re-execs with Bun |
| Node without Bun on PATH | ✅ Prints install instructions, exits 1 |