### PR TITLE
perf(filesystem): replace full path index rebuild with incremental updates

### DIFF
--- a/packages/filesystem/src/tree/path-index.ts
+++ b/packages/filesystem/src/tree/path-index.ts
@@ -5,9 +5,20 @@ import { disambiguateNames } from './naming.js';
 
 const MAX_DEPTH = 50;
 
+/** Path-relevant fields tracked per row for incremental change detection. */
+type RowSnapshot = {
+	name: string;
+	parentId: FileId | null;
+	trashedAt: number | null;
+};
+
 /**
  * Create runtime indexes for O(1) path lookups from a files table.
- * Subscribes to filesTable.observe() for incremental updates.
+ *
+ * Uses incremental updates: the observer classifies each changed row and
+ * patches only the affected index entries instead of rebuilding everything.
+ * Touch-only changes (size/updatedAt) are detected via a snapshot of
+ * path-relevant fields and skipped entirely—O(1) per editing mutation.
  */
 export function createFileSystemIndex(filesTable: TableHelper<FileRow>) {
 	/** "/docs/api.md" → FileId */
@@ -17,43 +28,418 @@ export function createFileSystemIndex(filesTable: TableHelper<FileRow>) {
 	/** parentId (null = root) → [childId, ...] */
 	const childrenOf = new Map<FileId | null, FileId[]>();
 
+	/** Previous path-relevant state for change detection. */
+	const snapshot = new Map<FileId, RowSnapshot>();
+	/** FileId → display name (may differ from row.name when disambiguated). */
+	const displayName = new Map<FileId, string>();
+
+	/** Suppresses the observer during rebuild to avoid processing partial state. */
+	let rebuilding = false;
+
 	rebuild();
 
-	// Any row change (create, move, rename, trash) can invalidate paths or
-	// parent-child edges, so we do a full rebuild on every table mutation.
-	// The files table is always in memory so this is fast — O(n) where n = total files.
-	const unobserve = filesTable.observe(() => {
-		rebuild();
+	const unobserve = filesTable.observe((changedIds) => {
+		if (rebuilding) return;
+		processChanges(changedIds);
 	});
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// FULL REBUILD — initial load and recovery
+	// ═══════════════════════════════════════════════════════════════════════
 
 	/**
 	 * Recompute all indexes from scratch: childrenOf, path mappings,
 	 * and self-healing fixes for circular refs and orphans.
+	 *
+	 * Called once at construction. Can be called manually for recovery.
 	 */
 	function rebuild() {
+		rebuilding = true;
 		pathToId.clear();
 		idToPath.clear();
 		childrenOf.clear();
+		snapshot.clear();
+		displayName.clear();
 
-		const rows = filesTable.getAllValid();
-		const activeRows = rows.filter((r) => r.trashedAt === null);
+		let activeRows = filesTable
+			.getAllValid()
+			.filter((r) => r.trashedAt === null);
 
-		// Build childrenOf index
-		for (const row of activeRows) {
-			const children = childrenOf.get(row.parentId) ?? [];
-			children.push(row.id);
-			childrenOf.set(row.parentId, children);
-		}
-
-		// Detect and fix circular references
+		// Fix data integrity issues first (these mutate the table).
+		// Run before building indexes so indexes reflect corrected state.
 		fixCircularReferences(filesTable, activeRows);
 
-		// Detect and fix orphans
+		// Re-read after circular ref fixes — parentIds may have changed
+		activeRows = filesTable
+			.getAllValid()
+			.filter((r) => r.trashedAt === null);
+
+		// Build childrenOf from corrected data
+		for (const row of activeRows) {
+			addChild(row.parentId, row.id);
+		}
+
+		// Fix orphans (uses and mutates childrenOf)
 		fixOrphans(filesTable, activeRows, childrenOf);
 
-		// Build path indexes with disambiguation
-		buildPaths(filesTable, childrenOf, pathToId, idToPath);
+		// Re-read one more time after orphan fixes
+		activeRows = filesTable
+			.getAllValid()
+			.filter((r) => r.trashedAt === null);
+
+		// Build display names (disambiguation) per folder
+		for (const [parentId, childIds] of childrenOf) {
+			disambiguateFolder(parentId, childIds);
+		}
+
+		// Build path indexes
+		buildPathsFromRoot();
+
+		// Populate snapshot for incremental change detection
+		for (const row of activeRows) {
+			snapshot.set(row.id, {
+				name: row.name,
+				parentId: row.parentId,
+				trashedAt: row.trashedAt,
+			});
+		}
+		rebuilding = false;
 	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// INCREMENTAL UPDATE — the hot path
+	// ═══════════════════════════════════════════════════════════════════════
+
+	/**
+	 * Process a set of changed row IDs incrementally.
+	 *
+	 * Classifies each change by comparing current state against the snapshot,
+	 * then patches only the affected index entries. Touch-only changes
+	 * (size/updatedAt) are O(1) — detected and skipped immediately.
+	 */
+	function processChanges(changedIds: ReadonlySet<string>) {
+		const foldersToDisambiguate = new Set<FileId | null>();
+		const idsNeedingPaths = new Set<FileId>();
+
+		for (const rawId of changedIds) {
+			const id = rawId as FileId;
+			const result = filesTable.get(id);
+			const prev = snapshot.get(id);
+
+			const isActive =
+				result.status === 'valid' && result.row.trashedAt === null;
+			const wasActive = prev !== undefined && prev.trashedAt === null;
+
+			if (!wasActive && !isActive) {
+				// Was inactive, still inactive — nothing to do.
+				// Could be a trashed row getting updated, or an invalid row.
+				if (prev && result.status !== 'not_found') {
+					// Update snapshot for trashed-to-trashed changes
+					snapshot.set(id, {
+						name:
+							result.status === 'valid' ? result.row.name : prev.name,
+						parentId:
+							result.status === 'valid'
+								? result.row.parentId
+								: prev.parentId,
+						trashedAt:
+							result.status === 'valid'
+								? result.row.trashedAt
+								: prev.trashedAt,
+					});
+				}
+				continue;
+			}
+
+			if (!wasActive && isActive) {
+				// CREATED or RESTORED
+				const row = (result as { status: 'valid'; row: FileRow }).row;
+				addChild(row.parentId, id);
+				snapshot.set(id, {
+					name: row.name,
+					parentId: row.parentId,
+					trashedAt: row.trashedAt,
+				});
+				foldersToDisambiguate.add(row.parentId);
+				idsNeedingPaths.add(id);
+				continue;
+			}
+
+			if (wasActive && !isActive) {
+				// TRASHED or DELETED
+				clearPathsRecursive(id);
+				removeChild(prev.parentId, id);
+
+				// Children of this node become orphans at the index level.
+				// Move them to root in the index (don't mutate table — rebuild handles that).
+				const orphanedChildren = childrenOf.get(id);
+				if (orphanedChildren && orphanedChildren.length > 0) {
+					for (const childId of [...orphanedChildren]) {
+						removeChild(id, childId);
+						addChild(null, childId);
+						const childSnap = snapshot.get(childId);
+						if (childSnap) {
+							snapshot.set(childId, { ...childSnap, parentId: null });
+						}
+						clearPathsRecursive(childId);
+						foldersToDisambiguate.add(null);
+						idsNeedingPaths.add(childId);
+						collectDescendantIds(childId, idsNeedingPaths);
+					}
+				}
+
+				if (result.status === 'not_found') {
+					snapshot.delete(id);
+				} else {
+					snapshot.set(id, {
+						name:
+							result.status === 'valid' ? result.row.name : prev.name,
+						parentId:
+							result.status === 'valid'
+								? result.row.parentId
+								: prev.parentId,
+						trashedAt:
+							result.status === 'valid'
+								? result.row.trashedAt
+								: prev.trashedAt,
+					});
+				}
+
+				displayName.delete(id);
+				foldersToDisambiguate.add(prev.parentId);
+				continue;
+			}
+
+			// wasActive && isActive — row is still active, check what changed
+			const row = (result as { status: 'valid'; row: FileRow }).row;
+
+			const parentChanged = prev.parentId !== row.parentId;
+			const nameChanged = prev.name !== row.name;
+
+			if (!parentChanged && !nameChanged) {
+				// TOUCHED — only size/updatedAt changed. No index work needed.
+				continue;
+			}
+
+			if (parentChanged) {
+				// MOVED
+				removeChild(prev.parentId, id);
+				addChild(row.parentId, id);
+				foldersToDisambiguate.add(prev.parentId);
+				foldersToDisambiguate.add(row.parentId);
+			} else {
+				// RENAMED (same parent, different name)
+				foldersToDisambiguate.add(row.parentId);
+			}
+
+			clearPathsRecursive(id);
+			snapshot.set(id, {
+				name: row.name,
+				parentId: row.parentId,
+				trashedAt: row.trashedAt,
+			});
+			idsNeedingPaths.add(id);
+			collectDescendantIds(id, idsNeedingPaths);
+		}
+
+		// Disambiguate affected folders
+		for (const parentId of foldersToDisambiguate) {
+			const childIds = childrenOf.get(parentId) ?? [];
+			const namesChanged = disambiguateFolder(parentId, childIds);
+
+			// If any display name changed, those IDs need path recomputation
+			for (const id of namesChanged) {
+				clearPathsRecursive(id);
+				idsNeedingPaths.add(id);
+				collectDescendantIds(id, idsNeedingPaths);
+			}
+		}
+
+		// Recompute paths for all affected IDs
+		if (idsNeedingPaths.size > 0) {
+			computePathsConvergent(idsNeedingPaths);
+		}
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// INDEX HELPERS
+	// ═══════════════════════════════════════════════════════════════════════
+
+	function addChild(parentId: FileId | null, childId: FileId): void {
+		const children = childrenOf.get(parentId) ?? [];
+		if (!children.includes(childId)) {
+			children.push(childId);
+			childrenOf.set(parentId, children);
+		}
+	}
+
+	function removeChild(parentId: FileId | null, childId: FileId): void {
+		const children = childrenOf.get(parentId);
+		if (!children) return;
+		const idx = children.indexOf(childId);
+		if (idx !== -1) {
+			children.splice(idx, 1);
+		}
+	}
+
+	/** Remove path entries for an ID and all its descendants. */
+	function clearPathsRecursive(id: FileId): void {
+		const oldPath = idToPath.get(id);
+		if (oldPath) {
+			pathToId.delete(oldPath);
+			idToPath.delete(id);
+		}
+		const children = childrenOf.get(id);
+		if (children) {
+			for (const childId of children) {
+				clearPathsRecursive(childId);
+			}
+		}
+	}
+
+	/** Collect all descendant IDs of a node into a set. */
+	function collectDescendantIds(id: FileId, out: Set<FileId>): void {
+		const children = childrenOf.get(id);
+		if (!children) return;
+		for (const childId of children) {
+			out.add(childId);
+			collectDescendantIds(childId, out);
+		}
+	}
+
+	/**
+	 * Run disambiguation for a folder's children. Updates the displayName map.
+	 *
+	 * @returns IDs whose display name changed (need path recomputation).
+	 */
+	function disambiguateFolder(
+		_parentId: FileId | null,
+		childIds: FileId[],
+	): FileId[] {
+		const changed: FileId[] = [];
+		const childRows: FileRow[] = [];
+
+		for (const cid of childIds) {
+			const result = filesTable.get(cid);
+			if (result.status === 'valid' && result.row.trashedAt === null) {
+				childRows.push(result.row);
+			}
+		}
+
+		const names = disambiguateNames(childRows);
+
+		for (const [id, newName] of names) {
+			const fid = id as FileId;
+			const oldName = displayName.get(fid);
+			displayName.set(fid, newName);
+			if (oldName !== undefined && oldName !== newName) {
+				changed.push(fid);
+			}
+		}
+
+		// Clean up display names for IDs no longer in this folder
+		// (already handled by the caller removing from childrenOf)
+
+		return changed;
+	}
+
+	/**
+	 * Compute paths for a set of IDs using a convergent loop.
+	 *
+	 * Processes root-level nodes first (their parent path is known: ""),
+	 * then their children become computable, and so on. Converges in
+	 * O(maxDepth) iterations. Remaining IDs after convergence are orphans
+	 * at the index level — placed at root.
+	 */
+	function computePathsConvergent(ids: Set<FileId>): void {
+		const pending = new Set(ids);
+		let progress = true;
+		let iterations = 0;
+
+		while (progress && pending.size > 0 && iterations < MAX_DEPTH) {
+			progress = false;
+			iterations++;
+
+			for (const id of pending) {
+				const snap = snapshot.get(id);
+				if (!snap || snap.trashedAt !== null) {
+					pending.delete(id);
+					continue;
+				}
+
+				const name = displayName.get(id) ?? snap.name;
+
+				if (snap.parentId === null) {
+					// Root level — always computable
+					const path = `/${name}`;
+					pathToId.set(path, id);
+					idToPath.set(id, path);
+					pending.delete(id);
+					progress = true;
+				} else {
+					const parentPath = idToPath.get(snap.parentId);
+					if (parentPath !== undefined) {
+						// Parent path known — compute child path
+						const path = `${parentPath}/${name}`;
+						pathToId.set(path, id);
+						idToPath.set(id, path);
+						pending.delete(id);
+						progress = true;
+					}
+				}
+			}
+		}
+
+		// Remaining IDs are orphans at the index level — place at root
+		for (const id of pending) {
+			const snap = snapshot.get(id);
+			if (!snap || snap.trashedAt !== null) continue;
+			const name = displayName.get(id) ?? snap.name;
+			const path = `/${name}`;
+			pathToId.set(path, id);
+			idToPath.set(id, path);
+		}
+	}
+
+	/**
+	 * Build all paths from root downward using childrenOf and displayNames.
+	 * Used by rebuild() after disambiguation.
+	 */
+	function buildPathsFromRoot(): void {
+		const queue: Array<{ id: FileId; parentPath: string }> = [];
+
+		// Start with root-level children
+		for (const id of childrenOf.get(null) ?? []) {
+			queue.push({ id, parentPath: '' });
+		}
+
+		let depth = 0;
+		while (queue.length > 0 && depth < MAX_DEPTH) {
+			const batch = queue.splice(0, queue.length);
+			depth++;
+
+			for (const { id, parentPath } of batch) {
+				const name = displayName.get(id);
+				if (!name) continue;
+
+				const path = `${parentPath}/${name}`;
+				pathToId.set(path, id);
+				idToPath.set(id, path);
+
+				// Enqueue children of folders
+				const children = childrenOf.get(id);
+				if (children) {
+					for (const childId of children) {
+						queue.push({ id: childId, parentPath: path });
+					}
+				}
+			}
+		}
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// PUBLIC API (unchanged interface)
+	// ═══════════════════════════════════════════════════════════════════════
 
 	return {
 		/** Look up the FileId for a resolved absolute path. */
@@ -88,65 +474,9 @@ export function createFileSystemIndex(filesTable: TableHelper<FileRow>) {
 /** Runtime indexes for O(1) path lookups (ephemeral, not stored in Yjs) */
 export type FileSystemIndex = ReturnType<typeof createFileSystemIndex>;
 
-/** Walk parentId chain to compute a file's path */
-function computePath(
-	id: FileId,
-	filesTable: TableHelper<FileRow>,
-	displayNames: Map<string, string>,
-): string | null {
-	const parts: string[] = [];
-	let currentId: FileId | null = id;
-	let depth = 0;
-
-	while (currentId !== null && depth < MAX_DEPTH) {
-		const result = filesTable.get(currentId);
-		if (result.status !== 'valid') return null;
-
-		const displayName = displayNames.get(currentId) ?? result.row.name;
-		parts.unshift(displayName);
-		currentId = result.row.parentId;
-		depth++;
-	}
-
-	if (depth >= MAX_DEPTH) return null; // Circular reference or unreasonably deep
-	return `/${parts.join('/')}`;
-}
-
-/** Build path indexes for all active rows */
-function buildPaths(
-	filesTable: TableHelper<FileRow>,
-	childrenOf: Map<FileId | null, FileId[]>,
-	pathToId: Map<string, FileId>,
-	idToPath: Map<FileId, string>,
-) {
-	// Compute display names per parent (handles CRDT duplicate names)
-	const allDisplayNames = new Map<string, string>();
-
-	for (const [, childIds] of childrenOf) {
-		const childRows: FileRow[] = [];
-		for (const cid of childIds) {
-			const result = filesTable.get(cid);
-			if (result.status === 'valid' && result.row.trashedAt === null) {
-				childRows.push(result.row);
-			}
-		}
-		const names = disambiguateNames(childRows);
-		for (const [id, name] of names) {
-			allDisplayNames.set(id, name);
-		}
-	}
-
-	// Build paths for all active files
-	const rows = filesTable.getAllValid();
-	for (const row of rows) {
-		if (row.trashedAt !== null) continue;
-		const path = computePath(row.id, filesTable, allDisplayNames);
-		if (path) {
-			pathToId.set(path, row.id);
-			idToPath.set(row.id, path);
-		}
-	}
-}
+// ═══════════════════════════════════════════════════════════════════════════
+// REBUILD-ONLY HELPERS (circular refs + orphans — mutate the table)
+// ═══════════════════════════════════════════════════════════════════════════
 
 /**
  * Detect circular references in parentId chains.

--- a/packages/filesystem/src/tree/path-index.ts
+++ b/packages/filesystem/src/tree/path-index.ts
@@ -70,9 +70,7 @@ export function createFileSystemIndex(filesTable: TableHelper<FileRow>) {
 		fixCircularReferences(filesTable, activeRows);
 
 		// Re-read after circular ref fixes — parentIds may have changed
-		activeRows = filesTable
-			.getAllValid()
-			.filter((r) => r.trashedAt === null);
+		activeRows = filesTable.getAllValid().filter((r) => r.trashedAt === null);
 
 		// Build childrenOf from corrected data
 		for (const row of activeRows) {
@@ -83,9 +81,7 @@ export function createFileSystemIndex(filesTable: TableHelper<FileRow>) {
 		fixOrphans(filesTable, activeRows, childrenOf);
 
 		// Re-read one more time after orphan fixes
-		activeRows = filesTable
-			.getAllValid()
-			.filter((r) => r.trashedAt === null);
+		activeRows = filesTable.getAllValid().filter((r) => r.trashedAt === null);
 
 		// Build display names (disambiguation) per folder
 		for (const [parentId, childIds] of childrenOf) {
@@ -136,16 +132,11 @@ export function createFileSystemIndex(filesTable: TableHelper<FileRow>) {
 				if (prev && result.status !== 'not_found') {
 					// Update snapshot for trashed-to-trashed changes
 					snapshot.set(id, {
-						name:
-							result.status === 'valid' ? result.row.name : prev.name,
+						name: result.status === 'valid' ? result.row.name : prev.name,
 						parentId:
-							result.status === 'valid'
-								? result.row.parentId
-								: prev.parentId,
+							result.status === 'valid' ? result.row.parentId : prev.parentId,
 						trashedAt:
-							result.status === 'valid'
-								? result.row.trashedAt
-								: prev.trashedAt,
+							result.status === 'valid' ? result.row.trashedAt : prev.trashedAt,
 					});
 				}
 				continue;
@@ -192,16 +183,11 @@ export function createFileSystemIndex(filesTable: TableHelper<FileRow>) {
 					snapshot.delete(id);
 				} else {
 					snapshot.set(id, {
-						name:
-							result.status === 'valid' ? result.row.name : prev.name,
+						name: result.status === 'valid' ? result.row.name : prev.name,
 						parentId:
-							result.status === 'valid'
-								? result.row.parentId
-								: prev.parentId,
+							result.status === 'valid' ? result.row.parentId : prev.parentId,
 						trashedAt:
-							result.status === 'valid'
-								? result.row.trashedAt
-								: prev.trashedAt,
+							result.status === 'valid' ? result.row.trashedAt : prev.trashedAt,
 					});
 				}
 


### PR DESCRIPTION
The filesystem path index did a full O(n) rebuild on every single table mutation. Every `filesTable.set()`, every `filesTable.update()`, every `touch()`—each one triggered `rebuild()`, which called `getAllValid()` twice, ran circular reference detection, orphan fixing, per-folder disambiguation, and full path recomputation from root. A single `writeFile` call triggers two mutations (create + touch), so each file write rebuilt the entire index twice.

At 10K files, that's `2 × O(10000)` per write—~20K row scans, path computations, and disambiguations for every file added. Total work across a bulk import: O(n²). The benchmark choked at ~4,600 files and never finished. Worse, during normal editing, every content change bumps `updatedAt` via the document `onUpdate` callback, which triggers a full rebuild for a field the index doesn't even care about.

```
writeFile("/notes/meeting.md", content)
  ├── filesTable.set(row)     → rebuild()    ← O(n): getAllValid × 2, path computation
  ├── contentDocuments.open()  → write        ← fast (separate Y.Doc)
  └── filesTable.update(touch) → rebuild()   ← O(n): getAllValid × 2, path computation AGAIN
                                                      ↑ only updatedAt changed. wasted.
```

The fix is incremental index updates. The observer now classifies each change by comparing current state against a snapshot of the three path-relevant fields—`name`, `parentId`, `trashedAt`—and patches only the affected entries.

For the editing case (the hot path), the classification is instant: none of those three fields changed, so the observer returns immediately. Zero index work per keystroke, down from O(n).

```
BEFORE (editing a file with 10K siblings):
  content change → onUpdate → filesTable.update({ updatedAt })
    → rebuild(): getAllValid() × 2, fixCircularRefs, fixOrphans,
      disambiguateNames per folder, computePath per file
    = O(n) work, every keystroke

AFTER:
  content change → onUpdate → filesTable.update({ updatedAt })
    → processChanges(): compare 3 fields against snapshot
    → name same? parentId same? trashedAt same? → skip
    = O(1), done
```

For structural changes (create, move, rename, trash), only the affected entries get updated. Disambiguation runs per-folder, not globally. Path recomputation uses a convergent loop—parents resolve first, then children become computable—so bulk creates in a Yjs transaction process in a single pass regardless of insertion order.

```
processChanges(changedIds)
  │
  ├── classify each: CREATED | TRASHED | MOVED | RENAMED | TOUCHED
  │                                                         └→ skip (O(1))
  ├── update childrenOf + snapshot for structural changes
  ├── clear stale paths (cascade for folders)
  ├── disambiguate ONLY affected parent folders
  └── recompute paths (convergent: root → children → grandchildren)
```

The full `rebuild()` is preserved for initial load and for the self-healing code that fixes circular references and orphans by mutating the table. A `rebuilding` flag suppresses the observer during rebuild so the incremental handler doesn't process partial state from those table mutations.

Benchmarked against a synthetic 10K-file vault (50 MB of markdown, 23 directories, realistic size distribution). Bulk import now completes in ~42s at constant throughput—no degradation as file count grows. Read performance: 51K reads/sec. All 35 path-index tests pass with zero regressions; the 7 pre-existing just-bash integration failures are unchanged.