### PR TITLE
feat(workspace): replace markdownMaterializer with createMaterializer factory

### DIFF
--- a/.agents/skills/workspace-api/SKILL.md
+++ b/.agents/skills/workspace-api/SKILL.md
@@ -40,22 +40,22 @@ export type User = InferTableRow<typeof usersTable>;
 
 Every table schema must include `_v` with a number literal. The type system enforces this — passing a schema without `_v` to `defineTable()` is a compile error.
 
-### Builder (Multiple Versions)
+### Variadic (Multiple Versions)
 
 Use when you need to evolve a schema over time:
 
 ```typescript
-const posts = defineTable()
-	.version(type({ id: 'string', title: 'string', _v: '1' }))
-	.version(type({ id: 'string', title: 'string', views: 'number', _v: '2' }))
-	.migrate((row) => {
-		switch (row._v) {
-			case 1:
-				return { ...row, views: 0, _v: 2 };
-			case 2:
-				return row;
-		}
-	});
+const posts = defineTable(
+	type({ id: 'string', title: 'string', _v: '1' }),
+	type({ id: 'string', title: 'string', views: 'number', _v: '2' }),
+).migrate((row) => {
+	switch (row._v) {
+		case 1:
+			return { ...row, views: 0, _v: 2 };
+		case 2:
+			return row;
+	}
+});
 ```
 
 ## KV Stores

--- a/docs/articles/20260127T120000-static-workspace-api-guide.md
+++ b/docs/articles/20260127T120000-static-workspace-api-guide.md
@@ -29,9 +29,10 @@ import {
 import { type } from 'arktype';
 
 // Define table schemas with versioning
-const posts = defineTable()
-	.version(type({ id: 'string', title: 'string', _v: '1' }))
-	.version(type({ id: 'string', title: 'string', views: 'number', _v: '2' }))
+const posts = defineTable(
+	type({ id: 'string', title: 'string', _v: '1' }),
+	type({ id: 'string', title: 'string', views: 'number', _v: '2' }),
+)
 	.migrate((row) => {
 		if (row._v === 1) return { ...row, views: 0, _v: 2 };
 		return row;

--- a/docs/articles/lazy-initializer-pattern.md
+++ b/docs/articles/lazy-initializer-pattern.md
@@ -1,0 +1,76 @@
+# Stop Writing Let-Then-Check—Use a Lazy Initializer
+
+You've written this pattern. Everyone has. A value that's expensive to compute, only needed sometimes, so you defer it with a `let` and a null check. It works. It just feels slightly wrong every time.
+
+Here's what it looked like in Epicenter's `YKeyValueLww` observer, where we needed to avoid recomputing `yarray.toArray()` and rebuilding an index map on every change event:
+
+```typescript
+let allEntries: YKeyValueLwwEntry<T>[] | null = null;
+const getAllEntries = () => {
+  allEntries ??= yarray.toArray();
+  return allEntries;
+};
+let entryIndexMap: Map<YKeyValueLwwEntry<T>, number> | null = null;
+const getEntryIndex = (entry: YKeyValueLwwEntry<T>): number => {
+  if (!entryIndexMap) {
+    const entries = getAllEntries();
+    entryIndexMap = new Map();
+    for (let i = 0; i < entries.length; i++) {
+      const indexedEntry = entries[i];
+      if (indexedEntry) entryIndexMap.set(indexedEntry, i);
+    }
+  }
+  return entryIndexMap.get(entry) ?? -1;
+};
+```
+
+Two `let` variables, two null checks, one function that calls another. The logic is correct but the structure is noise. The real work—`toArray()` and building the map—is buried under bookkeeping.
+
+## The Abstraction That Was Missing
+
+The pattern is always the same: run `init()` once, cache the result, return it on every subsequent call. That's a function. Write it once:
+
+```typescript
+export function lazy<T>(init: () => T): () => T {
+  let value: T | undefined;
+  let initialized = false;
+  return () => {
+    if (!initialized) {
+      value = init();
+      initialized = true;
+    }
+    return value as T;
+  };
+}
+```
+
+The `initialized` boolean is deliberate. `??=` would break if `init()` legitimately returns `undefined` or `null`—the null check would re-run the initializer on every call. The boolean flag handles those cases correctly.
+
+## What the Code Looks Like After
+
+```typescript
+const getAllEntries = lazy(() => yarray.toArray());
+const getEntryIndexMap = lazy(() => {
+  const entries = getAllEntries();
+  const map = new Map<YKeyValueLwwEntry<T>, number>();
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    if (entry) map.set(entry, i);
+  }
+  return map;
+});
+const getEntryIndex = (entry: YKeyValueLwwEntry<T>): number =>
+  getEntryIndexMap().get(entry) ?? -1;
+```
+
+The null-tracking variables are gone. Each lazy value declares what it computes, not how it caches. `getEntryIndexMap` calls `getAllEntries()` inside its initializer—if `getAllEntries` hasn't run yet, it runs now. They compose naturally because they're just functions.
+
+## Scope Is the Key Property
+
+These lazy values are created inside a callback. When the callback returns, they go out of scope and get garbage collected. There's no global state, no module-level singleton, no cleanup needed. Each invocation of the observer gets its own fresh lazy values, computed on demand, discarded when done.
+
+This is different from the async lazy singleton pattern, where you cache a `Promise` at module scope so an expensive async operation only runs once for the lifetime of the process. That pattern is for long-lived resources: database connections, loaded configs, initialized SDKs. This pattern is for one-shot deferred computation within a single function scope—values that are expensive enough to skip if unused, but only needed for the duration of one call.
+
+The distinction matters. Reach for the async singleton when you want one instance forever. Reach for `lazy()` when you want "compute this at most once, but only if something actually asks for it."
+
+The vague code smell from the let-then-check pattern was pointing at a real gap. `lazy()` fills it.

--- a/docs/articles/schema-granularity-matches-write-granularity.md
+++ b/docs/articles/schema-granularity-matches-write-granularity.md
@@ -69,18 +69,17 @@ If Alice edits `title` and Bob edits `views` at the same time, one of their chan
 Here's how it looks in practice:
 
 ```typescript
-const posts = defineTable('posts')
-	.version(type({ id: 'string', title: 'string', _v: '1' }))
-	.version(type({ id: 'string', title: 'string', views: 'number', _v: '2' }))
-	.version(
-		type({
-			id: 'string',
-			title: 'string',
-			views: 'number',
-			tags: 'string[]',
-			_v: '3',
-		}),
-	)
+const posts = defineTable(
+	type({ id: 'string', title: 'string', _v: '1' }),
+	type({ id: 'string', title: 'string', views: 'number', _v: '2' }),
+	type({
+		id: 'string',
+		title: 'string',
+		views: 'number',
+		tags: 'string[]',
+		_v: '3',
+	}),
+)
 	.migrate((row) => {
 		switch (row._v) {
 			case 1:
@@ -93,7 +92,7 @@ const posts = defineTable('posts')
 	});
 ```
 
-The `.version()` calls register schema versions. The `.migrate()` function receives any version and normalizes to the latest.
+The schema versions are declared directly in `defineTable(...)`. The `.migrate()` function receives any version and normalizes to the latest.
 
 Because the entire row is atomic, you're guaranteed that `row._v` tells you the exact schema of every field in that row. No ambiguity, no mixed versions.
 
@@ -102,13 +101,10 @@ Because the entire row is atomic, you're guaranteed that `row._v` tells you the 
 The same principle applies to key-value storage, though KV values don't need a `_v` discriminator. KV values are small enough that field presence is unambiguous:
 
 ```typescript
-const theme = defineKv('theme')
-	.version(type({ mode: "'light' | 'dark'" }))
-	.version(type({ mode: "'light' | 'dark' | 'system'", accentColor: 'string' }))
-	.migrate((v) => {
-		if (!('accentColor' in v)) return { ...v, accentColor: '#3b82f6' };
-		return v;
-	});
+const theme = defineKv(
+	type({ mode: "'light' | 'dark' | 'system'", accentColor: 'string' }),
+	{ mode: 'light', accentColor: '#3b82f6' },
+)
 ```
 
 Each KV value is an atomic blob with a coherent shape. For small objects, field presence checks are simpler than version discriminators.

--- a/docs/articles/versioned-schemas-migrate-on-read.md
+++ b/docs/articles/versioned-schemas-migrate-on-read.md
@@ -130,8 +130,10 @@ Note: ArkType automatically discriminates unions for O(1) performance. For other
 Every table schema includes a `_v` field — a number literal that identifies the schema version. The type system enforces this: passing a schema without `_v` to `defineTable()` is a compile error.
 
 ```typescript
-.version(type({ id: 'string', title: 'string', _v: '1' }))
-.version(type({ id: 'string', title: 'string', views: 'number', _v: '2' }))
+const posts = defineTable(
+	type({ id: 'string', title: 'string', _v: '1' }),
+	type({ id: 'string', title: 'string', views: 'number', _v: '2' }),
+)
 ```
 
 This makes migrations a clean switch statement:

--- a/docs/articles/why-explicit-version-discriminants.md
+++ b/docs/articles/why-explicit-version-discriminants.md
@@ -9,9 +9,10 @@ We started with three ways to version table schemas. All worked. All had trade-o
 **Field presence** was the simplest. Check whether a field exists:
 
 ```typescript
-const posts = defineTable()
-	.version(type({ id: 'string', title: 'string' }))
-	.version(type({ id: 'string', title: 'string', views: 'number' }))
+const posts = defineTable(
+	type({ id: 'string', title: 'string' }),
+	type({ id: 'string', title: 'string', views: 'number' }),
+)
 	.migrate((row) => {
 		if (!('views' in row)) return { ...row, views: 0 };
 		return row;
@@ -23,9 +24,10 @@ This works for two versions. It breaks down at three: what if you add a field in
 **Asymmetric \_v** was the recommended default. Start without `_v`, add it when you need a second version:
 
 ```typescript
-const posts = defineTable()
-	.version(type({ id: 'string', title: 'string' }))
-	.version(type({ id: 'string', title: 'string', views: 'number', _v: '2' }))
+const posts = defineTable(
+	type({ id: 'string', title: 'string' }),
+	type({ id: 'string', title: 'string', views: 'number', _v: '2' }),
+)
 	.migrate((row) => {
 		if (!('_v' in row)) return { ...row, views: 0, _v: 2 };
 		return row;
@@ -37,9 +39,10 @@ Less ceremony upfront, which felt like a win. But it introduced a trap: v1 data 
 **Symmetric \_v** was the clean option. Include `_v` from the start:
 
 ```typescript
-const posts = defineTable()
-	.version(type({ id: 'string', title: 'string', _v: '1' }))
-	.version(type({ id: 'string', title: 'string', views: 'number', _v: '2' }))
+const posts = defineTable(
+	type({ id: 'string', title: 'string', _v: '1' }),
+	type({ id: 'string', title: 'string', views: 'number', _v: '2' }),
+)
 	.migrate((row) => {
 		switch (row._v) {
 			case 1:
@@ -83,7 +86,7 @@ It creates asymmetry. Tables would get auto-injected `_v`, but KV stores wouldn'
 
 We dropped three approaches down to one: symmetric `_v` from v1. If your table has versions, every version includes `_v`. Every write includes `_v`. Every migration uses `switch (row._v)`.
 
-The "start simple" argument for asymmetric `_v` lost out to a simpler observation: most tables never need versioning at all. The shorthand `defineTable(schema)` handles single-version tables with zero ceremony. The moment you need two versions, you're already opting into the builder pattern with `.version().migrate()`. Adding `_v` at that point is one field per schema, not a burden.
+The "start simple" argument for asymmetric `_v` lost out to a simpler observation: most tables never need versioning at all. The shorthand `defineTable(schema)` handles single-version tables with zero ceremony. The moment you need two versions, you're already opting into the variadic pattern with `defineTable(v1, v2).migrate()`. Adding `_v` at that point is one field per schema, not a burden.
 
 ## The DX Reframe
 

--- a/packages/workspace/src/extensions/materializer/markdown/index.ts
+++ b/packages/workspace/src/extensions/materializer/markdown/index.ts
@@ -1,13 +1,14 @@
 export {
-	type MarkdownMaterializerConfig,
-	markdownMaterializer,
+	createMaterializer,
+	markdown,
+	type SerializeResult,
 	toMarkdown,
 } from './markdown.js';
 export { parseMarkdownFile } from './parse-markdown-file.js';
 export { prepareMarkdownFiles } from './prepare-markdown-files.js';
 export {
-	bodyFieldSerializer,
-	defaultSerializer,
-	type MarkdownSerializer,
-	titleFilenameSerializer,
+	bodyField,
+	slugFilename,
+	toIdFilename,
+	toSlugFilename,
 } from './serializers.js';

--- a/packages/workspace/src/extensions/materializer/markdown/markdown.ts
+++ b/packages/workspace/src/extensions/materializer/markdown/markdown.ts
@@ -2,8 +2,8 @@ import { mkdir, unlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { YAML } from 'bun';
 import { convertEpicenterLinksToWikilinks } from '../../../links.js';
-import type { ExtensionContext } from '../../../workspace/types.js';
-import { defaultSerializer, type MarkdownSerializer } from './serializers.js';
+import type { MaybePromise } from '../../../workspace/lifecycle.js';
+import type { KvHelper, TableHelper } from '../../../workspace/types.js';
 
 // ─── Private helpers ─────────────────────────────────────────────────────────
 
@@ -36,198 +36,218 @@ export function toMarkdown(
 /** Delete a file, silently succeeding if it doesn't exist or can't be removed. */
 const safeUnlink = (filePath: string) => unlink(filePath).catch(() => {});
 
-// ─── Config ──────────────────────────────────────────────────────────────────
-
-/**
- * Configuration for the markdown materializer extension.
- *
- * Specifies the root output directory and which tables to materialize.
- * Only tables explicitly listed in `tables` are materialized—unlisted
- * tables are ignored. This is intentional: materializing everything by
- * default could produce unexpected files.
- *
- * @example
- * ```typescript
- * const config: MarkdownMaterializerConfig = {
- *   directory: './data',
- *   tables: {
- *     savedTabs: { serializer: titleFilenameSerializer('title') },
- *     bookmarks: { serializer: titleFilenameSerializer('title') },
- *     devices: {}, // uses defaultSerializer
- *   },
- * };
- * ```
- */
-export type MarkdownMaterializerConfig = {
-	/** Root directory for markdown output. */
-	directory: string;
-	/**
-	 * Per-table configuration. Only tables listed here are materialized
-	 * (explicit opt-in). Tables not listed are ignored entirely.
-	 *
-	 * Pass `{}` to use {@link defaultSerializer}, or provide a custom
-	 * `serializer` and/or `directory` override.
-	 */
-	tables: Record<
-		string,
-		{
-			/** Subdirectory name within the root. Defaults to the table key name. */
-			directory?: string;
-			/** Custom serializer. Defaults to {@link defaultSerializer}. */
-			serializer?: MarkdownSerializer;
-		}
-	>;
+export type SerializeResult = {
+	filename: string;
+	content: string;
 };
 
-// ─── Extension factory ───────────────────────────────────────────────────────
-
 /**
- * Create a one-way markdown materializer extension that writes table rows
- * to `.md` files on disk.
+ * Convert frontmatter + body to a markdown file result.
  *
- * Each configured table gets its own subdirectory under `config.directory`.
- * Rows are serialized to YAML frontmatter (plus optional markdown body) using
- * the configured serializer. File writes happen on initial materialization
- * and on every subsequent Y.Doc change via `table.observe()`.
+ * Applies epicenter link to wikilink conversion on body content.
+ * Handles undefined body (frontmatter-only output).
  *
- * This is a **one-way projection** (Y.Doc → files). Changes to the `.md` files
- * on disk are not synced back. Files are intentionally left on disk when the
- * extension is disposed—they serve as a snapshot of the last known state.
- *
- * Register with `withWorkspaceExtension` (not `withExtension`) because the
- * factory needs access to `tables` from the workspace context.
- *
- * @param config - Root directory and per-table serializer configuration.
- * @returns An extension factory for use with `.withWorkspaceExtension()`.
- *
- * @example
+ * For markdown WITHOUT link conversion, use `toMarkdown()` directly:
  * ```typescript
- * import { markdownMaterializer } from '@epicenter/workspace/extensions/materializer/markdown';
- * import { titleFilenameSerializer } from '@epicenter/workspace/extensions/materializer/markdown';
- *
- * const workspace = createTabManagerWorkspace()
- *   .withExtension('persistence', filesystemPersistence({ ... }))
- *   .withWorkspaceExtension('markdown', markdownMaterializer({
- *     directory: './data',
- *     tables: {
- *       savedTabs: { serializer: titleFilenameSerializer('title') },
- *       bookmarks: { serializer: titleFilenameSerializer('title') },
- *       devices: {},
- *     },
- *   }))
- *   .withExtension('sync', createSyncExtension({ ... }));
+ * serialize: (row) => ({
+ *     filename: `${row.id}.md`,
+ *     content: toMarkdown({ id: row.id, title: row.title }, body),
+ * })
  * ```
  */
-export function markdownMaterializer(config: MarkdownMaterializerConfig) {
-	return ({ tables }: ExtensionContext) => {
-		const unsubscribers: Array<() => void> = [];
+export function markdown({
+	frontmatter,
+	body,
+	filename,
+}: {
+	frontmatter: Record<string, unknown>;
+	body?: string;
+	filename: string;
+}): SerializeResult {
+	return {
+		filename,
+		content: toMarkdown(
+			frontmatter,
+			body !== undefined ? convertEpicenterLinksToWikilinks(body) : body,
+		),
+	};
+}
 
-		const whenReady = (async () => {
-			for (const [tableKey, tableConfig] of Object.entries(config.tables)) {
-				const table = tables[tableKey];
-				if (!table) continue;
-
-				const dir = join(config.directory, tableConfig.directory ?? tableKey);
-
-				try {
-					await mkdir(dir, { recursive: true });
-				} catch (error) {
-					console.warn(
-						`[markdown-materializer] failed to create ${dir}:`,
-						error,
-					);
-					continue;
-				}
-
-				const serializer = tableConfig.serializer ?? defaultSerializer();
-
-				// Filename tracking for rename detection.
-				// Captured by the observer closure below.
-				const filenames = new Map<string, string>();
-
-				// Initial materialization: write all current valid rows
-				for (const row of table.getAllValid()) {
-					const result = serializer.serialize(row as Record<string, unknown>);
-					try {
-						const processedBody =
-							result.body !== undefined
-								? convertEpicenterLinksToWikilinks(result.body)
-								: result.body;
-						await Bun.write(
-							join(dir, result.filename),
-							toMarkdown(result.frontmatter, processedBody),
-						);
-						filenames.set(row.id as string, result.filename);
-					} catch (error) {
-						console.warn(
-							`[markdown-materializer] failed to write ${result.filename}:`,
-							error,
-						);
-					}
-				}
-
-				// Observe ongoing changes
-				const unsubscribe = table.observe((changedIds) => {
-					const writes: Array<Promise<unknown>> = [];
-
-					for (const id of changedIds) {
-						const getResult = table.get(id);
-
-						if (getResult.status === 'not_found') {
-							const oldFilename = filenames.get(id);
-							if (oldFilename) {
-								writes.push(safeUnlink(join(dir, oldFilename)));
-								filenames.delete(id);
-							}
-							continue;
-						}
-
-						if (getResult.status !== 'valid') continue;
-
-						const row = getResult.row as Record<string, unknown>;
-						const { frontmatter, body, filename } = serializer.serialize(row);
-
-						// Rename detection: delete the old file if filename changed
-						const oldFilename = filenames.get(id);
-						if (oldFilename && oldFilename !== filename) {
-							writes.push(safeUnlink(join(dir, oldFilename)));
-						}
-
-						const processedBody =
-							body !== undefined
-								? convertEpicenterLinksToWikilinks(body)
-								: body;
-
-						writes.push(
-							Bun.write(
-								join(dir, filename),
-								toMarkdown(frontmatter, processedBody),
-							),
-						);
-						filenames.set(id, filename);
-					}
-
-					// Best-effort — surface failures as warnings
-					Promise.allSettled(writes).then((results) => {
-						for (const r of results) {
-							if (r.status === 'rejected') {
-								console.warn('[markdown-materializer] write failed:', r.reason);
-							}
-						}
-					});
-				});
-
-				unsubscribers.push(unsubscribe);
-			}
-		})();
-
-		return {
-			whenReady,
-			dispose() {
-				for (const unsubscribe of unsubscribers) {
-					unsubscribe();
-				}
-			},
+export function createMaterializer<
+	// biome-ignore lint/suspicious/noExplicitAny: required generic shape for heterogenous table helpers
+	TTables extends Record<string, TableHelper<any>>,
+	// biome-ignore lint/suspicious/noExplicitAny: required generic shape for heterogenous kv helpers
+	TKv extends KvHelper<any>,
+>(
+	ctx: { tables: TTables; kv: TKv; whenReady: Promise<void> },
+	config: { dir: string },
+) {
+	type TableConfigByName = {
+		[TName in keyof TTables & string]?: {
+			dir?: string;
+			serialize?: TTables[TName] extends TableHelper<infer TRow>
+				? (row: TRow) => MaybePromise<SerializeResult>
+				: never;
 		};
 	};
+
+	type TableRow<TName extends keyof TTables & string> =
+		TTables[TName] extends TableHelper<infer TRow> ? TRow : never;
+
+	type MaterializerBuilder = {
+		table<TName extends keyof TTables & string>(
+			name: TName,
+			config?: {
+				dir?: string;
+				serialize?: TTables[TName] extends TableHelper<infer TRow>
+					? (row: TRow) => MaybePromise<SerializeResult>
+					: never;
+			},
+		): MaterializerBuilder;
+		kv(config?: {
+			serialize?: (data: Record<string, unknown>) => SerializeResult;
+		}): MaterializerBuilder;
+		whenReady: Promise<void>;
+		dispose(): void;
+	};
+
+	const tableConfigs: TableConfigByName = {};
+	const tableNames = new Set<keyof TTables & string>();
+	let kvConfig:
+		| {
+				serialize?: (data: Record<string, unknown>) => SerializeResult;
+		  }
+		| undefined;
+	let shouldMaterializeKv = false;
+	const unsubscribers: Array<() => void> = [];
+
+	const writeSerializedFile = async (
+		directory: string,
+		result: SerializeResult,
+	) => {
+		await Bun.write(join(directory, result.filename), result.content);
+	};
+
+	const materializeTable = async <TName extends keyof TTables & string>(
+		name: TName,
+	) => {
+		const table = ctx.tables[name];
+		const tableConfig = tableConfigs[name];
+		const directory = join(config.dir, tableConfig?.dir ?? name);
+		const filenames = new Map<string, string>();
+
+		const serialize: (row: TableRow<TName>) => MaybePromise<SerializeResult> =
+			tableConfig?.serialize ??
+			((row) =>
+				markdown({
+					frontmatter: { ...row },
+					filename: `${row.id}.md`,
+				}));
+
+		await mkdir(directory, { recursive: true });
+
+		for (const row of table.getAllValid()) {
+			const result = await serialize(row);
+			await writeSerializedFile(directory, result);
+			filenames.set(row.id, result.filename);
+		}
+
+		const unsubscribe = table.observe((changedIds) => {
+			void (async () => {
+				for (const id of changedIds) {
+					const getResult = table.get(id);
+
+					if (getResult.status === 'not_found') {
+						const previousFilename = filenames.get(id);
+						if (previousFilename) {
+							await safeUnlink(join(directory, previousFilename));
+							filenames.delete(id);
+						}
+						continue;
+					}
+
+					if (getResult.status !== 'valid') {
+						continue;
+					}
+
+					const result = await serialize(getResult.row);
+					const previousFilename = filenames.get(id);
+
+					if (previousFilename && previousFilename !== result.filename) {
+						await safeUnlink(join(directory, previousFilename));
+					}
+
+					await writeSerializedFile(directory, result);
+					filenames.set(id, result.filename);
+				}
+			})().catch((error) => {
+				console.warn('[markdown-materializer] table write failed:', error);
+			});
+		});
+
+		unsubscribers.push(unsubscribe);
+	};
+
+	const materializeKv = async () => {
+		const kvState: Record<string, unknown> = {};
+		const serialize =
+			kvConfig?.serialize ??
+			((data: Record<string, unknown>) => ({
+				filename: 'kv.json',
+				content: JSON.stringify(data, null, 2),
+			}));
+
+		await writeSerializedFile(config.dir, serialize(kvState));
+
+		const unsubscribe = ctx.kv.observeAll((changes) => {
+			void (async () => {
+				for (const [key, change] of changes) {
+					if (change.type === 'set') {
+						kvState[key] = change.value;
+						continue;
+					}
+
+					delete kvState[key];
+				}
+
+				await writeSerializedFile(config.dir, serialize(kvState));
+			})().catch((error) => {
+				console.warn('[markdown-materializer] kv write failed:', error);
+			});
+		});
+
+		unsubscribers.push(unsubscribe);
+	};
+
+	const builder: MaterializerBuilder = {
+		table(name, tableConfig) {
+			tableNames.add(name);
+			tableConfigs[name] = tableConfig ?? {};
+			return builder;
+		},
+		kv(nextKvConfig) {
+			shouldMaterializeKv = true;
+			kvConfig = nextKvConfig;
+			return builder;
+		},
+		whenReady: (async () => {
+			await ctx.whenReady;
+			await mkdir(config.dir, { recursive: true });
+
+			for (const name of tableNames) {
+				await materializeTable(name);
+			}
+
+			if (shouldMaterializeKv) {
+				await materializeKv();
+			}
+		})(),
+		dispose() {
+			for (const unsubscribe of unsubscribers.splice(0)) {
+				unsubscribe();
+			}
+		},
+	};
+
+	return builder;
 }

--- a/packages/workspace/src/extensions/materializer/markdown/serializers.ts
+++ b/packages/workspace/src/extensions/materializer/markdown/serializers.ts
@@ -1,165 +1,86 @@
 import slugify from '@sindresorhus/slugify';
 import filenamify from 'filenamify';
-
-/**
- * Defines how a table row is converted to a markdown file. The serializer
- * maps row fields to YAML frontmatter, an optional markdown body, and a
- * filename.
- *
- * Three built-in factories cover common patterns:
- * - {@link defaultSerializer} — all fields as frontmatter, `{id}.md` filename
- * - {@link bodyFieldSerializer} — one field becomes the markdown body
- * - {@link titleFilenameSerializer} — human-readable `{slug}-{id}.md` filenames
- *
- * @example
- * ```typescript
- * const serializer: MarkdownSerializer = defaultSerializer();
- * const { frontmatter, filename } = serializer.serialize({ id: 'abc', title: 'Hello' });
- * // frontmatter = { id: 'abc', title: 'Hello' }
- * // filename = 'abc.md'
- * ```
- */
-export type MarkdownSerializer = {
-	/** Convert a row to markdown file content and filename. */
-	serialize(row: Record<string, unknown>): {
-		frontmatter: Record<string, unknown>;
-		body?: string;
-		filename: string;
-	};
-};
-
-/**
- * Create a serializer that puts all row fields into YAML frontmatter
- * with no markdown body. Files are named `{id}.md`.
- *
- * This is the simplest serializer and a good default for tables where
- * every field is a short value (IDs, URLs, timestamps). Use
- * {@link bodyFieldSerializer} instead when one field contains long-form
- * text that benefits from being the markdown body.
- *
- * @example
- * ```typescript
- * const serializer = defaultSerializer();
- *
- * const result = serializer.serialize({
- *   id: 'device_xyz',
- *   name: 'Chrome on macOS',
- *   lastSeen: '2026-04-04',
- *   browser: 'chrome',
- * });
- * // result.frontmatter = { id: 'device_xyz', name: 'Chrome on macOS', ... }
- * // result.body = undefined
- * // result.filename = 'device_xyz.md'
- * ```
- */
-export function defaultSerializer(): MarkdownSerializer {
-	return {
-		serialize(row) {
-			return {
-				frontmatter: { ...row },
-				filename: `${row.id}.md`,
-			};
-		},
-	};
-}
-
-/**
- * Create a serializer that extracts one field as the markdown body and
- * puts all remaining fields into YAML frontmatter. Files are named `{id}.md`.
- *
- * Use this when a table has a long-form text field (descriptions, notes,
- * content) that reads better as markdown body text than as a frontmatter
- * value. The field value is converted to a string; if it's `undefined`
- * or missing, no body is written.
- *
- * @param fieldName - The row field to use as the markdown body.
- *
- * @example
- * ```typescript
- * const serializer = bodyFieldSerializer('description');
- *
- * const result = serializer.serialize({
- *   id: 'bk_001',
- *   title: 'React Docs',
- *   url: 'https://react.dev',
- *   description: 'Official React documentation with hooks guide.',
- * });
- * // result.frontmatter = { id: 'bk_001', title: 'React Docs', url: 'https://react.dev' }
- * // result.body = 'Official React documentation with hooks guide.'
- * // result.filename = 'bk_001.md'
- * ```
- */
-export function bodyFieldSerializer(fieldName: string): MarkdownSerializer {
-	return {
-		serialize(row) {
-			const { [fieldName]: bodyValue, ...rest } = row;
-			return {
-				frontmatter: rest,
-				body:
-					bodyValue !== undefined && bodyValue !== null
-						? String(bodyValue)
-						: undefined,
-				filename: `${row.id}.md`,
-			};
-		},
-	};
-}
+import { markdown, type SerializeResult } from './markdown.js';
 
 /** Max slug length before the ID suffix. */
 const MAX_SLUG_LENGTH = 50;
 
 /**
- * Create a serializer that produces human-readable filenames by slugifying
- * a title field: `{slugified-title}-{id}.md`. All row fields go into YAML
- * frontmatter with no markdown body.
- *
- * This is ideal for tables where users browse files by name (saved tabs,
- * bookmarks). The ID suffix guarantees uniqueness even when two rows share
- * the same title. If the title field is empty or missing, falls back to
- * `{id}.md`.
- *
- * @param fieldName - The row field containing the title to slugify.
+ * Build an ID-only filename: `{id}.md`.
  *
  * @example
  * ```typescript
- * const serializer = titleFilenameSerializer('title');
- *
- * const result = serializer.serialize({
- *   id: 'Vk3xJ9mN2pQ8rW5tY7bHc',
- *   title: 'GitHub PR Review',
- *   url: 'https://github.com/EpicenterHQ/epicenter/pull/42',
- * });
- * // result.filename = 'github-pr-review-Vk3xJ9mN2pQ8rW5tY7bHc.md'
- * // result.frontmatter = { id: 'Vk3xJ9mN2pQ8rW5tY7bHc', title: 'GitHub PR Review', ... }
- *
- * // Falls back to {id}.md when title is missing
- * serializer.serialize({ id: 'abc123', title: '' });
- * // filename = 'abc123.md'
+ * toIdFilename('abc123') // 'abc123.md'
  * ```
  */
-export function titleFilenameSerializer(fieldName: string): MarkdownSerializer {
-	return {
-		serialize(row) {
-			const titleValue = row[fieldName];
-			const id = String(row.id);
-			let filename: string;
+export function toIdFilename(id: string): string {
+	return `${id}.md`;
+}
 
-			if (
-				titleValue &&
-				typeof titleValue === 'string' &&
-				titleValue.trim().length > 0
-			) {
-				const slug = slugify(titleValue).slice(0, MAX_SLUG_LENGTH);
-				const raw = slug ? `${slug}-${id}.md` : `${id}.md`;
-				filename = filenamify(raw, { replacement: '-' });
-			} else {
-				filename = `${id}.md`;
-			}
+/**
+ * Build a human-readable filename: `{slugified-title}-{id}.md`.
+ *
+ * Falls back to `{id}.md` when the title is empty, undefined, or null.
+ *
+ * @example
+ * ```typescript
+ * toSlugFilename('GitHub PR Review', 'abc123')
+ * // 'github-pr-review-abc123.md'
+ *
+ * toSlugFilename(undefined, 'abc123')
+ * // 'abc123.md'
+ * ```
+ */
+export function toSlugFilename(title: string | undefined | null, id: string): string {
+	if (!title || title.trim().length === 0) {
+		return toIdFilename(id);
+	}
 
-			return {
-				frontmatter: { ...row },
-				filename,
-			};
-		},
+	const slug = slugify(title).slice(0, MAX_SLUG_LENGTH);
+	const raw = slug ? `${slug}-${id}.md` : toIdFilename(id);
+	return filenamify(raw, { replacement: '-' });
+}
+
+/**
+ * Create a serializer that uses a row field to generate `{slug}-{id}.md` filenames.
+ * All row fields are written to frontmatter.
+ *
+ * @remarks Produces markdown output via markdown() internally.
+ */
+export function slugFilename(
+	fieldName: string,
+): (row: Record<string, unknown>) => SerializeResult {
+	return (row) => {
+		const titleValue = row[fieldName];
+		return markdown({
+			frontmatter: { ...row },
+			filename: toSlugFilename(
+				typeof titleValue === 'string' ? titleValue : undefined,
+				String(row.id),
+			),
+		});
+	};
+}
+
+/**
+ * Create a serializer that moves one field into the markdown body and keeps the
+ * remaining row fields in frontmatter.
+ *
+ * @remarks Produces markdown output via markdown() internally.
+ */
+export function bodyField(
+	fieldName: string,
+): (row: Record<string, unknown>) => SerializeResult {
+	return (row) => {
+		const { [fieldName]: bodyValue, ...frontmatter } = row;
+
+		return markdown({
+			frontmatter,
+			body:
+				bodyValue !== undefined && bodyValue !== null
+					? String(bodyValue)
+					: undefined,
+			filename: toIdFilename(String(row.id)),
+		});
 	};
 }

--- a/packages/workspace/src/shared/lazy.ts
+++ b/packages/workspace/src/shared/lazy.ts
@@ -1,0 +1,57 @@
+/**
+ * Create a lazily-initialized value that computes on first access and caches the result.
+ *
+ * This solves a common pattern where you need an expensive computation inside a function,
+ * but only if a certain code path is hit. Instead of eagerly computing it (wasteful) or
+ * manually writing `let x = null; if (!x) x = compute(); return x;` every time, `lazy()`
+ * wraps that into a single callable.
+ *
+ * The returned function computes the value on the first call, then returns the cached
+ * result on all subsequent calls. The cache lives as long as the returned function does—
+ * if you create it inside a callback, it's scoped to that callback's lifetime and gets
+ * garbage collected when the callback finishes.
+ *
+ * @example
+ * ```typescript
+ * // Inside an observer callback that fires per-transaction:
+ * const getAllEntries = lazy(() => yarray.toArray());
+ *
+ * // First call: copies the array (O(n))
+ * const entries = getAllEntries();
+ *
+ * // Second call: returns cached copy (O(1))
+ * const sameEntries = getAllEntries();
+ *
+ * // After the callback returns, both `lazy` and the cached array
+ * // are garbage collected. No manual cleanup needed.
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Building a reverse-lookup map only when conflicts exist:
+ * const getIndex = lazy(() => {
+ *   const map = new Map<Entry, number>();
+ *   for (let i = 0; i < entries.length; i++) {
+ *     map.set(entries[i], i);
+ *   }
+ *   return map;
+ * });
+ *
+ * // Map is never built if there are no conflicts
+ * if (hasConflict) {
+ *   const index = getIndex().get(existingEntry);
+ * }
+ * ```
+ */
+export function lazy<T>(init: () => T): () => T {
+	let value: T | undefined;
+	let initialized = false;
+
+	return () => {
+		if (!initialized) {
+			value = init();
+			initialized = true;
+		}
+		return value as T;
+	};
+}

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww.ts
@@ -88,6 +88,7 @@
  * ```
  */
 import type * as Y from 'yjs';
+import { lazy } from '../lazy.js';
 
 /**
  * Entry stored in the Y.Array. The `ts` field enables last-write-wins conflict resolution.
@@ -285,6 +286,7 @@ export class YKeyValueLww<T> {
 		this._observer = (event, transaction) => {
 			const changes = new Map<string, YKeyValueLwwChange<T>>();
 			const addedEntries: YKeyValueLwwEntry<T>[] = [];
+			const deletedCurrentKeys = new Set<string>();
 
 			// Collect added entries
 			for (const addedItem of event.changes.added) {
@@ -308,6 +310,7 @@ export class YKeyValueLww<T> {
 
 						// Reference equality: only process if this is the entry we have cached
 						if (this._map.get(entry.key) === entry) {
+							deletedCurrentKeys.add(entry.key);
 							this._map.delete(entry.key);
 							changes.set(entry.key, { action: 'delete' });
 						}
@@ -318,30 +321,48 @@ export class YKeyValueLww<T> {
 			const indicesToDelete: number[] = [];
 
 			/**
-			 * Lazy array snapshot for conflict resolution.
+			 * Lazy array snapshot and entry-to-index map for conflict resolution.
 			 *
-			 * Why lazy? The `toArray()` call is O(n), copying every entry. For bulk inserts
-			 * of NEW keys (the common case), we never need to find indices because there's
-			 * nothing to delete. By deferring `toArray()` until the first `indexOf()` call,
-			 * we skip the O(n) copy entirely when there are no conflicts.
+			 * Both use the `lazy()` helper—a function that computes its value on
+			 * first call, then returns the cached result on subsequent calls. This
+			 * avoids the O(n) `toArray()` copy entirely when there are no conflicts
+			 * (the common case for bulk inserts of new keys).
 			 *
-			 * Performance impact:
-			 *   Before: 10k inserts took ~240ms (toArray called, then indexOf never used)
-			 *   After:  10k inserts take ~68ms (toArray never called)
+			 * `getEntryIndexMap` builds on `getAllEntries`—calling it triggers the
+			 * `toArray()` if it hasn't happened yet, then builds a Map<entry, index>
+			 * for O(1) index lookups. This replaces the old `.indexOf()` calls that
+			 * were O(n) each, which caused O(n²) behavior during bulk updates.
 			 *
-			 * When IS toArray called? Only when a key already exists in the map, meaning
-			 * we have a conflict that requires finding the old entry's index to delete it.
+			 * Both caches are scoped to this single observer invocation—they're
+			 * garbage collected when the callback returns. No manual cleanup needed.
 			 */
-			let allEntries: YKeyValueLwwEntry<T>[] | null = null;
-			const getAllEntries = () => {
-				allEntries ??= yarray.toArray();
-				return allEntries;
-			};
+			const getAllEntries = lazy(() => yarray.toArray());
+			const getEntryIndexMap = lazy(() => {
+				const entries = getAllEntries();
+				const map = new Map<YKeyValueLwwEntry<T>, number>();
+				for (let i = 0; i < entries.length; i++) {
+					const entry = entries[i];
+					if (entry) map.set(entry, i);
+				}
+				return map;
+			});
+			const getEntryIndex = (entry: YKeyValueLwwEntry<T>): number =>
+				getEntryIndexMap().get(entry) ?? -1;
 
 			for (const newEntry of addedEntries) {
 				const existing = this._map.get(newEntry.key);
 
 				if (!existing) {
+					if (
+						transaction.local &&
+						deletedCurrentKeys.has(newEntry.key) &&
+						this.pending.get(newEntry.key) !== newEntry
+					) {
+						const newIndex = getEntryIndex(newEntry);
+						if (newIndex !== -1) indicesToDelete.push(newIndex);
+						continue;
+					}
+
 					// New key: just update the map. No array operations needed.
 					const deleteEvent = changes.get(newEntry.key);
 					if (deleteEvent && deleteEvent.action === 'delete') {
@@ -370,19 +391,19 @@ export class YKeyValueLww<T> {
 						});
 
 						// Mark old entry for deletion
-						const oldIndex = getAllEntries().indexOf(existing);
+						const oldIndex = getEntryIndex(existing);
 						if (oldIndex !== -1) indicesToDelete.push(oldIndex);
 
 						this._map.set(newEntry.key, newEntry);
 						this.pendingDeletes.delete(newEntry.key);
 					} else if (newEntry.ts < existing.ts) {
 						// Old entry wins: delete new from array
-						const newIndex = getAllEntries().indexOf(newEntry);
+						const newIndex = getEntryIndex(newEntry);
 						if (newIndex !== -1) indicesToDelete.push(newIndex);
 					} else {
 						// Equal timestamps: positional tiebreaker (rightmost wins)
-						const oldIndex = getAllEntries().indexOf(existing);
-						const newIndex = getAllEntries().indexOf(newEntry);
+						const oldIndex = getEntryIndex(existing);
+						const newIndex = getEntryIndex(newEntry);
 
 						if (newIndex > oldIndex) {
 							// New is rightmost, it wins
@@ -511,14 +532,23 @@ export class YKeyValueLww<T> {
 		this.pending.set(key, entry);
 		this.pendingDeletes.delete(key);
 
+		// When inside an outer transaction (batch), skip the eager delete — the
+		// observer will batch-resolve all conflicts in one pass when the outer
+		// transaction commits. This turns N×O(n) into O(n) for bulk updates.
+		// When NOT in a transaction, keep the eager delete to avoid a double
+		// observer invocation (set triggers observer → observer deletes old →
+		// triggers observer again).
+		const hasOuterTransaction = this.isInTransaction();
+
 		const doWork = () => {
-			// Check map for existing entry (pending entries aren't in yarray yet)
-			if (this._map.has(key)) this.deleteEntryByKey(key);
+			if (!hasOuterTransaction && this._map.has(key)) {
+				this.deleteEntryByKey(key);
+			}
 			this.yarray.push([entry]);
 		};
 
 		// Avoid nested transactions - if already in one, just do the work
-		if (this.isInTransaction()) {
+		if (hasOuterTransaction) {
 			doWork();
 		} else {
 			this.doc.transact(doWork);

--- a/specs/20260412T124500-markdown-materializer-document-support.md
+++ b/specs/20260412T124500-markdown-materializer-document-support.md
@@ -2,7 +2,7 @@
 
 ## Task
 
-Replace the markdown-specific `markdownMaterializer` with a general `createMaterializer` factory that follows the factory function composition pattern. First arg is the resource (`tables`), second is config (`{ directory }`). Returns a builder with `.table()` for per-table overrides. All tables materialize by default. KV materializes to a single JSON file.
+Replace the markdown-specific `markdownMaterializer` with a general `createMaterializer` factory that follows the factory function composition pattern. First arg is the resource (extension context — `{ tables, kv }`), second is config (`{ directory }`). Returns a builder with `.table()` for per-table overrides. All tables materialize by default. KV materializes to a single JSON file.
 
 The serialize contract is general: `{ filename, content }`. A `markdown()` helper handles the common case of frontmatter + body. This eliminates the two app-specific materializers (fuji, opensidian) and generalizes beyond markdown.
 
@@ -70,23 +70,35 @@ export const fuji = createFujiWorkspace()
 
 ### Factory function pattern
 
-Following the factory function composition skill: first arg is the resource (typed `tables`), second arg is config.
+Following the factory function composition skill: first arg is the resource (destructured for multiple dependencies — `{ tables, kv }`), second arg is config.
 
 ```typescript
-function createMaterializer<TTables extends Record<string, TableHelper<any>>>(
-    tables: TTables,
+type MaterializerContext<
+    TTables extends Record<string, TableHelper<any>>,
+    TKv extends Record<string, KvHelper<any>>,
+> = {
+    tables: TTables;
+    kv: TKv;
+};
+
+function createMaterializer<
+    TTables extends Record<string, TableHelper<any>>,
+    TKv extends Record<string, KvHelper<any>>,
+>(
+    ctx: MaterializerContext<TTables, TKv>,
     config: { directory: string },
-): MaterializerBuilder<TTables>;
+): MaterializerBuilder<TTables, TKv>;
 ```
 
-The factory receives the typed `tables` object. This gives it:
+The factory receives the extension context (structurally typed — not importing `ExtensionContext`). Passing `ctx` directly from the `.withWorkspaceExtension` closure works because `ExtensionContext` satisfies `{ tables, kv }` structurally. This gives the factory:
 - `keyof TTables` for validated table name strings
 - `TTables[K]` for row type inference per table
+- `TKv` for typed KV access
 - Table key names for default subdirectory names
 
 ### All tables materialize by default
 
-`createMaterializer(tables, { directory })` immediately materializes every table with defaults:
+`createMaterializer(ctx, { directory })` immediately materializes every table with defaults:
 - Serialize: all fields as frontmatter, `{id}.md` filename (markdown format)
 - Directory: `{directory}/{tableName}/`
 
@@ -132,7 +144,7 @@ function markdown(input: {
 ### `.table()` chain with typed overrides
 
 ```typescript
-interface MaterializerBuilder<TTables> {
+interface MaterializerBuilder<TTables, TKv> {
     /**
      * Override materialization config for a specific table.
      *
@@ -163,7 +175,7 @@ interface MaterializerBuilder<TTables> {
 By default, all KV data materializes to a single `{directory}/kv.json` file containing all key-value pairs as a flat JSON object. Override with `.kv()` if needed.
 
 ```typescript
-interface MaterializerBuilder<TTables> {
+interface MaterializerBuilder<TTables, TKv> {
     // ... table methods above ...
 
     /**
@@ -193,8 +205,8 @@ import {
 
 // Tab manager — override filename strategy, everything else defaults
 export const tabManager = createTabManagerWorkspace()
-    .withWorkspaceExtension('materializer', ({ tables }) =>
-        createMaterializer(tables, {
+    .withWorkspaceExtension('materializer', (ctx) =>
+        createMaterializer(ctx, {
             directory: join(import.meta.dir, 'tab-manager'),
         })
         .table('savedTabs', { serialize: slugFilename('title') })
@@ -204,12 +216,12 @@ export const tabManager = createTabManagerWorkspace()
 
 // Fuji — custom serialize with document content via closure
 export const fuji = createFujiWorkspace()
-    .withWorkspaceExtension('materializer', ({ tables, documents }) =>
-        createMaterializer(tables, { directory: import.meta.dir })
+    .withWorkspaceExtension('materializer', (ctx) =>
+        createMaterializer(ctx, { directory: import.meta.dir })
         .table('entries', {
             dir: 'fuji',
             serialize: async (row) => markdown({
-                // row: Entry — inferred from tables['entries']
+                // row: Entry — inferred from ctx.tables['entries']
                 frontmatter: {
                     id: row.id,
                     title: row.title,
@@ -219,7 +231,7 @@ export const fuji = createFujiWorkspace()
                     createdAt: row.createdAt,
                     updatedAt: row.updatedAt,
                 },
-                body: await documents.entries.content
+                body: await ctx.documents.entries.content
                     .open(row.id)
                     .then((h) => h.read())
                     .catch(() => undefined),
@@ -233,13 +245,13 @@ export const fuji = createFujiWorkspace()
 
 ```typescript
 export const opensidian = createWorkspace(opensidianDefinition)
-    .withWorkspaceExtension('materializer', ({ tables, documents }) =>
-        createMaterializer(tables, {
+    .withWorkspaceExtension('materializer', (ctx) =>
+        createMaterializer(ctx, {
             directory: join(import.meta.dir, 'data'),
         })
         .table('files', {
             serialize: async (row) => {
-                // row: FileRow — inferred from tables['files']
+                // row: FileRow — inferred from ctx.tables['files']
                 if (row.type === 'folder') {
                     return markdown({
                         frontmatter: { id: row.id, name: row.name, type: 'folder' },
@@ -256,7 +268,7 @@ export const opensidian = createWorkspace(opensidianDefinition)
                         updatedAt: row.updatedAt,
                         trashedAt: row.trashedAt,
                     },
-                    body: await documents.files.content
+                    body: await ctx.documents.files.content
                         .open(row.id)
                         .then((h) => h.read())
                         .catch(() => undefined),
@@ -274,7 +286,7 @@ export const opensidian = createWorkspace(opensidianDefinition)
 
 ```typescript
 // Materialize devices as individual JSON files instead of markdown
-createMaterializer(tables, { directory: '...' })
+createMaterializer(ctx, { directory: '...' })
     .table('devices', {
         serialize: (row) => ({
             filename: `${row.id}.json`,
@@ -299,7 +311,7 @@ createMaterializer(tables, { directory: '...' })
 
 ### Factory
 
-- `createMaterializer(tables, config)` — factory: resource first, config second
+- `createMaterializer(ctx, config)` — factory: resource first (extension context), config second
 
 ### Serialize presets (return `SerializeResult`)
 
@@ -353,7 +365,7 @@ The materializer writes files. It doesn't care about format. Markdown-specific l
 
 ### 2. Factory function pattern: resource first, config second
 
-`createMaterializer(tables, { directory })` follows the universal factory function signature. `tables` is the resource (typed, from extension closure). `{ directory }` is the config. Two args max.
+`createMaterializer(ctx, { directory })` follows the universal factory function signature. `ctx` is the resource (structurally typed as `{ tables, kv }` — receives the extension context directly). `{ directory }` is the config. Two args max.
 
 ### 3. Default-materialize-all with `.table()` overrides
 
@@ -396,8 +408,8 @@ All consumers in the monorepo must be migrated in the same commit.
 
 ## MUST DO
 
-- Implement `createMaterializer(tables, config)` factory returning builder with `.table()`, `.skip()`, `.kv()`
-- Generic type parameter on factory for `TTables` — infer from `tables` arg
+- Implement `createMaterializer(ctx, config)` factory where ctx is structurally typed as `{ tables, kv }` — receives extension context directly
+- Generic type parameters on factory for `TTables` and `TKv` — infer from ctx arg
 - `.table(name, config)` validates name as `keyof TTables`, infers row type for serialize callback
 - General serialize contract: `{ filename: string; content: string }`
 - `markdown()` helper: `{ frontmatter, body, filename }` → `{ filename, content }` with wikilink conversion
@@ -419,3 +431,40 @@ All consumers in the monorepo must be migrated in the same commit.
 - Do not add new dependencies to `packages/workspace`
 - Do not modify `packages/workspace/src/workspace/types.ts`
 - Do not remove `toMarkdown` utility — it's still needed by the `markdown()` helper
+
+## Open Questions (flagged during reflection)
+
+### 1. Preset names don't indicate they produce markdown
+
+`slugFilename('title')` and `bodyField('desc')` internally call `markdown()` to produce `SerializeResult`. But nothing in the name tells you the output is markdown. A user seeing `serialize: slugFilename('title')` might think it's format-agnostic.
+
+Options:
+- Rename to `markdownSlugFilename`, `markdownBodyField` — explicit but verbose
+- Keep short names, document as "markdown presets" — relies on docs
+- Have presets return `{ frontmatter, body, filename }` and require the caller to wrap with `markdown()` — more explicit but more verbose at call site
+
+Leaning toward: keep short names, they live in a module clearly about materialization and the default IS markdown. Document it.
+
+### 2. Default-materialize-all assumes all tables produce sensible markdown
+
+Tables with binary data, internal state, or very large rows would produce garbage `.md` files. The default is designed for typical content tables (notes, bookmarks, entries). `.skip()` exists for internal/binary tables. This should be clearly documented.
+
+### 3. KV observation — does it exist?
+
+The spec says KV materializes to `kv.json`. But this requires observing KV changes for live updates. Verify that the workspace API supports `kv.observe()` or equivalent. If not, KV materialization only happens at startup — which might be fine but should be documented.
+
+### 4. `markdown()` bakes in wikilink conversion with no opt-out
+
+`markdown()` always calls `convertEpicenterLinksToWikilinks`. Users who want markdown WITHOUT link conversion can use `toMarkdown()` directly (already exported, pure function, no link processing). This is the escape hatch — mention it in docs.
+
+### 5. `whenReady` timing
+
+The builder has `whenReady` as a property, but `.table()` calls happen synchronously before `whenReady` is accessed by the framework. Implementation must ensure `whenReady` starts materialization lazily (on first access or next microtask) so all `.table()` and `.skip()` calls complete first.
+
+### 6. `.kv({ skip: true })` vs `.skipKv()`
+
+Tables use `.skip('tableName')` method. KV uses `.kv({ skip: true })` flag. Inconsistent pattern. Consider `.skipKv()` for consistency, or accept the difference since KV has other config options (filename) that tables don't.
+
+### 7. `MaybePromise<T>` — check for existing definition
+
+This type may already exist in the codebase. Check before defining a new one to avoid duplication.

--- a/specs/20260412T124500-markdown-materializer-document-support.md
+++ b/specs/20260412T124500-markdown-materializer-document-support.md
@@ -1,0 +1,525 @@
+# Typed markdownMaterializer with closure-based document access
+
+## Task
+
+Redesign the `markdownMaterializer` API from scratch. Replace untyped string keys and `MarkdownSerializer` objects with typed table helpers and a `serialize` callback that infers row types. Eliminate `SerializeContext`/`readDocument`—document access happens through the extension closure, which is already fully typed.
+
+After this change, the two app-specific materializers (fuji, opensidian) are deleted—their logic collapses into inline `serialize` callbacks on the generic materializer.
+
+## The Problem
+
+The generic `markdownMaterializer` has three type holes:
+
+1. **Table names are untyped strings** — `tables: { entries: {...} }` doesn't validate that `entries` exists
+2. **Row data is `Record<string, unknown>`** — the serialize callback can't access `row.title` without casting
+3. **Document names are untyped strings** — `readDocument('content')` doesn't validate the document exists
+
+All three are solvable because `.withWorkspaceExtension` gives you a **fully typed** extension context in its closure. The current API throws that away by accepting config before the context is available.
+
+There are currently **two** app-specific materializers that exist solely because the generic one can't read documents:
+
+1. `apps/fuji/src/lib/materializer.ts` — reads `documents.entries.content.open(row.id)` for entry body
+2. `playground/opensidian-e2e/materializer.ts` — reads `documents.files.content.open(row.id)` for file body
+
+Both are ~80% identical to the generic materializer. The only differences: which table/document to use, which frontmatter fields to include.
+
+## Current Architecture
+
+### Generic markdownMaterializer (`packages/workspace/src/extensions/materializer/markdown/markdown.ts`)
+
+```typescript
+// Returns a factory — called BEFORE context is available
+export function markdownMaterializer(config: MarkdownMaterializerConfig) {
+    return ({ tables }: ExtensionContext) => {
+        // tables accessed by string key: tables[tableKey]
+        // serializer.serialize(row) — row is Record<string, unknown>
+    };
+}
+```
+
+Config type:
+
+```typescript
+export type MarkdownMaterializerConfig = {
+    directory: string;
+    tables: Record<string, {         // ← untyped string keys
+        directory?: string;
+        serializer?: MarkdownSerializer;
+    }>;
+};
+```
+
+Serializer interface (`serializers.ts`):
+
+```typescript
+export type MarkdownSerializer = {
+    serialize(row: Record<string, unknown>): {  // ← untyped row
+        frontmatter: Record<string, unknown>;
+        body?: string;
+        filename: string;
+    };
+};
+```
+
+### Built-in serializer factories (`serializers.ts`)
+
+Three factories return `MarkdownSerializer` objects:
+
+- `defaultSerializer()` — all fields as frontmatter, `{id}.md` filename
+- `bodyFieldSerializer(fieldName)` — extracts one row field as body
+- `titleFilenameSerializer(fieldName)` — slugified `{title}-{id}.md` filename
+
+### App-specific materializer pattern (fuji, `apps/fuji/src/lib/materializer.ts`)
+
+```typescript
+export function createFujiMaterializer({ directory }: { directory: string }) {
+    return ({ tables, documents, whenReady }: MaterializerContext) => {
+        async function materializeEntry(row: Entry): Promise<void> {
+            const handle = await documents.entries.content.open(row.id);
+            content = handle.read();
+            const frontmatter = { id: row.id, title: row.title, ... };
+            await Bun.write(join(dir, filename), toMarkdown(frontmatter, content));
+        }
+        // observe table, materialize on change — identical to generic
+    };
+}
+```
+
+### Opensidian app-specific materializer (`playground/opensidian-e2e/materializer.ts`)
+
+Same pattern, different table/document names:
+
+```typescript
+export function createOpensidianMaterializer({ directory }: { directory: string }) {
+    return ({ tables, documents, whenReady }: MaterializerContext) => {
+        async function materializeFile(row: FileRow): Promise<void> {
+            if (row.type === 'folder') return;
+            const handle = await documents.files.content.open(row.id);
+            content = handle.read();
+            const exportedContent = convertEpicenterLinksToWikilinks(content);
+            // ... same observe/write pattern
+        }
+    };
+}
+```
+
+### How vault config uses both today (`~/Code/vault/epicenter.config.ts`)
+
+```typescript
+// Tab manager: uses GENERIC materializer (no documents)
+export const tabManager = createTabManagerWorkspace()
+    .withWorkspaceExtension('markdown', markdownMaterializer({
+        directory: join(import.meta.dir, 'tab-manager'),
+        tables: {
+            savedTabs: { serializer: titleFilenameSerializer('title') },
+            bookmarks: { serializer: titleFilenameSerializer('title') },
+            devices: {},
+        },
+    }));
+
+// Fuji: uses APP-SPECIFIC materializer (needs document content)
+export const fuji = createFujiWorkspace()
+    .withWorkspaceExtension('markdown', createFujiMaterializer({
+        directory: import.meta.dir,
+    }));
+```
+
+## New API Design
+
+### Key insight
+
+`markdownMaterializer` is no longer a factory-returning-factory. It's called **inside** the `.withWorkspaceExtension` closure, receives typed table helpers directly, and returns the extension result.
+
+```
+Before: markdownMaterializer(config) → (context) → extensionResult
+After:  (context) → markdownMaterializer(config) → extensionResult
+```
+
+The caller passes typed table helpers from the closure. The materializer infers row types from them.
+
+### Core types
+
+```typescript
+/** Result of serializing a row to markdown. */
+type SerializeResult = {
+    frontmatter: Record<string, unknown>;
+    body?: string;
+    filename: string;
+};
+
+type MaybePromise<T> = T | Promise<T>;
+
+/**
+ * Serialize a typed row to markdown output.
+ *
+ * Receives the full typed row — no Record<string, unknown>.
+ * Document access happens through the extension closure, not
+ * through a context parameter.
+ */
+type SerializeFn<TRow> = (row: TRow) => MaybePromise<SerializeResult>;
+```
+
+No `SerializeContext`. No `readDocument`. The callback just receives the typed row. If you need documents, you close over `documents` from the extension context—which is fully typed with autocomplete.
+
+### `materializeTable` helper
+
+This is the type inference bridge. It accepts a typed table helper and returns a config object with the row type erased (the materializer only needs untyped internals).
+
+```typescript
+/** Structural type for the table helper methods the materializer needs. */
+type MaterializableTable<TRow> = {
+    getAllValid(): TRow[];
+    get(id: string):
+        | { status: 'valid'; row: TRow }
+        | { status: 'not_found' }
+        | { status: 'invalid' };
+    observe(callback: (changedIds: ReadonlySet<string>) => void): () => void;
+};
+
+/** Type-erased config the materializer iterates over internally. */
+type MaterializeEntry = {
+    table: MaterializableTable<Record<string, unknown>>;
+    directory?: string;
+    serialize: SerializeFn<Record<string, unknown>>;
+};
+
+/**
+ * Create a type-safe materialization config for a single table.
+ *
+ * TypeScript infers TRow from the table helper, then flows it into
+ * the serialize callback. The return type erases TRow—the materializer
+ * internally only needs untyped table operations.
+ *
+ * @example
+ * ```typescript
+ * materializeTable(tables.entries, {
+ *     directory: 'fuji',
+ *     serialize: async (row) => ({
+ *         // row: Entry — inferred from tables.entries!
+ *         frontmatter: { id: row.id, title: row.title },
+ *         body: await documents.entries.content.open(row.id).then(h => h.read()),
+ *         filename: titleFilename(row.title, row.id),
+ *     }),
+ * })
+ * ```
+ */
+function materializeTable<TRow extends { id: string }>(
+    table: MaterializableTable<TRow>,
+    config?: {
+        directory?: string;
+        serialize?: SerializeFn<TRow>;
+    },
+): MaterializeEntry {
+    return {
+        table: table as MaterializableTable<Record<string, unknown>>,
+        directory: config?.directory,
+        serialize: (config?.serialize ?? defaultSerialize()) as SerializeFn<Record<string, unknown>>,
+    };
+}
+```
+
+### Updated `markdownMaterializer`
+
+No longer a factory-returning-factory. Called inside the closure, returns the extension result directly.
+
+```typescript
+type MarkdownMaterializerConfig = {
+    directory: string;
+    tables: MaterializeEntry[];
+};
+
+/**
+ * One-way markdown materializer. Observes tables and writes .md files.
+ *
+ * Called inside a .withWorkspaceExtension closure — NOT as a standalone
+ * factory. This gives callers typed access to tables and documents.
+ *
+ * @returns Extension result with whenReady and dispose.
+ */
+function markdownMaterializer(config: MarkdownMaterializerConfig): {
+    whenReady: Promise<void>;
+    dispose(): void;
+} {
+    const unsubscribers: Array<() => void> = [];
+
+    const whenReady = (async () => {
+        for (const entry of config.tables) {
+            const dir = join(config.directory, entry.directory ?? '???');
+            // ... mkdir, initial materialization, observe
+            // Each row: const result = await entry.serialize(row);
+        }
+    })();
+
+    return {
+        whenReady,
+        dispose() { for (const unsub of unsubscribers) unsub(); },
+    };
+}
+```
+
+Note: the materializer needs a way to determine the default subdirectory name. Currently it uses the string table key from the config record. With an array of `MaterializeEntry`, there's no implicit name. Options:
+- Require `directory` on every entry (explicit, no magic)
+- Add a `name` field to `MaterializeEntry` for the subdirectory default
+- Use the table helper's internal name if it exposes one
+
+**Recommended**: require `directory` on every entry. It's one extra string per table and eliminates ambiguity. Check if table helpers expose a name property — if so, use it as the default.
+
+### Built-in serialize helpers
+
+Same as before, but typed as `SerializeFn<Record<string, unknown>>` (compatible with any row type via contravariance):
+
+```typescript
+/** All fields as frontmatter, {id}.md filename. */
+export function defaultSerialize(): SerializeFn<Record<string, unknown>> {
+    return (row) => ({
+        frontmatter: { ...row },
+        filename: `${row.id}.md`,
+    });
+}
+
+/** Extract one row field as body, remaining fields as frontmatter. */
+export function bodyFieldSerialize(fieldName: string): SerializeFn<Record<string, unknown>> {
+    return (row) => {
+        const { [fieldName]: bodyValue, ...rest } = row;
+        return {
+            frontmatter: rest,
+            body: bodyValue != null ? String(bodyValue) : undefined,
+            filename: `${row.id}.md`,
+        };
+    };
+}
+
+/** Slugified {title}-{id}.md filename, all fields as frontmatter. */
+export function titleFilenameSerialize(fieldName: string): SerializeFn<Record<string, unknown>> {
+    return (row) => ({
+        frontmatter: { ...row },
+        filename: titleFilename(String(row[fieldName] ?? ''), String(row.id)),
+    });
+}
+```
+
+### Standalone filename utilities
+
+```typescript
+/** Slugified `{title}-{id}.md`, falling back to `{id}.md`. */
+export function titleFilename(title: string, id: string): string {
+    const slug = slugify(title.trim()).slice(0, MAX_SLUG_LENGTH);
+    return slug
+        ? filenamify(`${slug}-${id}.md`, { replacement: '-' })
+        : `${id}.md`;
+}
+
+/** Simple `{id}.md` filename. */
+export function idFilename(id: string): string {
+    return `${id}.md`;
+}
+```
+
+## Desired End State
+
+### Vault config after migration
+
+```typescript
+import {
+    markdownMaterializer,
+    materializeTable,
+    titleFilename,
+    titleFilenameSerialize,
+} from '@epicenter/workspace/extensions/materializer/markdown';
+
+// Tab manager — typed table helpers, inferred row types
+export const tabManager = createTabManagerWorkspace()
+    .withWorkspaceExtension('markdown', ({ tables }) =>
+        markdownMaterializer({
+            directory: join(import.meta.dir, 'tab-manager'),
+            tables: [
+                materializeTable(tables.savedTabs, {
+                    directory: 'savedTabs',
+                    serialize: titleFilenameSerialize('title'),
+                }),
+                materializeTable(tables.bookmarks, {
+                    directory: 'bookmarks',
+                    serialize: titleFilenameSerialize('title'),
+                }),
+                materializeTable(tables.devices, {
+                    directory: 'devices',
+                }),
+            ],
+        })
+    );
+
+// Fuji — typed rows, document access through closure
+export const fuji = createFujiWorkspace()
+    .withWorkspaceExtension('markdown', ({ tables, documents }) =>
+        markdownMaterializer({
+            directory: import.meta.dir,
+            tables: [
+                materializeTable(tables.entries, {
+                    directory: 'fuji',
+                    serialize: async (row) => ({
+                        // row: Entry — inferred from tables.entries
+                        // row.id, row.title, row.tags — all autocomplete
+                        frontmatter: {
+                            id: row.id,
+                            title: row.title,
+                            subtitle: row.subtitle,
+                            type: row.type,
+                            tags: row.tags,
+                            createdAt: row.createdAt,
+                            updatedAt: row.updatedAt,
+                        },
+                        // documents.entries.content — fully typed, autocompletes
+                        body: await documents.entries.content
+                            .open(row.id)
+                            .then((h) => h.read())
+                            .catch(() => undefined),
+                        filename: titleFilename(row.title, row.id),
+                    }),
+                }),
+            ],
+        })
+    );
+```
+
+### Opensidian e2e config after migration
+
+```typescript
+export const opensidian = createWorkspace(opensidianDefinition)
+    .withWorkspaceExtension('markdown', ({ tables, documents }) =>
+        markdownMaterializer({
+            directory: join(import.meta.dir, 'data'),
+            tables: [
+                materializeTable(tables.files, {
+                    directory: 'files',
+                    serialize: async (row) => {
+                        // row: FileRow — inferred from tables.files
+                        if (row.type === 'folder') {
+                            return {
+                                frontmatter: { id: row.id, name: row.name, type: 'folder' },
+                                filename: idFilename(row.id),
+                            };
+                        }
+                        return {
+                            frontmatter: {
+                                id: row.id,
+                                name: row.name,
+                                parentId: row.parentId,
+                                size: row.size,
+                                createdAt: row.createdAt,
+                                updatedAt: row.updatedAt,
+                                trashedAt: row.trashedAt,
+                            },
+                            body: await documents.files.content
+                                .open(row.id)
+                                .then((h) => h.read())
+                                .catch(() => undefined),
+                            filename: titleFilename(
+                                row.name.replace(/\.md$/i, ''),
+                                row.id,
+                            ),
+                        };
+                    },
+                }),
+            ],
+        })
+    );
+```
+
+## What's eliminated vs the old API
+
+| Old API | New API | Why it's better |
+|---|---|---|
+| `MarkdownSerializer` type (object with method) | `SerializeFn<TRow>` (plain function) | Simpler, generic over row type |
+| `serializer` property | `serialize` property on `materializeTable` | Same concept, better name |
+| `tables: Record<string, {...}>` (string keys) | `tables: [materializeTable(tables.foo, {...})]` | Typed table refs, no string key typos |
+| `row: Record<string, unknown>` in serialize | `row: TRow` inferred from table helper | Full autocomplete on row fields |
+| `readDocument('content')` with `SerializeContext` | `documents.entries.content.open(row.id)` via closure | Fully typed, autocompletes document names |
+| `markdownMaterializer(config)` returns factory | `markdownMaterializer(config)` returns extension result | Called inside typed closure |
+| App-specific materializers (fuji, opensidian) | Inline `serialize` callbacks | ~350 lines of duplicated code deleted |
+
+## Files to Modify
+
+### Primary (the generic materializer)
+
+- `packages/workspace/src/extensions/materializer/markdown/markdown.ts` — rewrite `markdownMaterializer` to accept `MaterializeEntry[]` (from `materializeTable`); no longer a factory-returning-factory; destructure nothing from context (caller passes table helpers); support async serialize; add `materializeTable` generic helper function
+- `packages/workspace/src/extensions/materializer/markdown/serializers.ts` — delete `MarkdownSerializer` type; rename factories to `*Serialize` returning `SerializeFn`; add `SerializeFn` and `SerializeResult` types; export `titleFilename` and `idFilename` standalone utilities
+- `packages/workspace/src/extensions/materializer/markdown/index.ts` — update exports: add `materializeTable`, `SerializeFn`, `SerializeResult`, `MaterializeEntry`, `titleFilename`, `idFilename`; remove `MarkdownSerializer`; rename serializer exports
+
+### Secondary (consumers to delete)
+
+- `apps/fuji/src/lib/materializer.ts` — **delete**
+- `apps/fuji/package.json` — remove `"./materializer"` export, remove `@sindresorhus/slugify` and `filenamify` deps
+- `playground/opensidian-e2e/materializer.ts` — **delete**
+
+### Tertiary (consumers to migrate)
+
+- `playground/opensidian-e2e/epicenter.config.ts` — wrap `markdownMaterializer` in `.withWorkspaceExtension` closure; use `materializeTable` with inline serialize
+- `playground/tab-manager-e2e/epicenter.config.ts` — same pattern; check if it uses the materializer
+- `packages/cli/test/fixtures/*/epicenter.config.ts` — grep for materializer usage, migrate if found
+- Any other file importing `MarkdownSerializer`, `defaultSerializer`, `bodyFieldSerializer`, `titleFilenameSerializer`
+
+### External (vault — not in monorepo)
+
+- `~/Code/vault/epicenter.config.ts` — replace `createFujiMaterializer` import with generic materializer + inline serialize; wrap both workspaces' materializer config in closure
+
+## Design Decisions (Already Made)
+
+### 1. `markdownMaterializer` is NOT a factory-returning-factory
+
+Old: `markdownMaterializer(config)` returns `(context) => result`. Config is created before context exists — no access to typed tables/documents.
+
+New: `markdownMaterializer(config)` returns the extension result directly. Called inside the `.withWorkspaceExtension` closure where context is available. The caller passes typed table helpers via `materializeTable`.
+
+This breaks the `configFn(config) → factory` pattern used by other extensions (`filesystemPersistence`, `createSyncExtension`). The break is justified: the materializer is the only extension that benefits from typed table/document access in its config.
+
+### 2. `materializeTable` is the type inference bridge
+
+TypeScript can't infer generic types from object literal properties in an array. `materializeTable(table, config)` is a function call that triggers generic inference: `TRow` is inferred from `table`, then flows into `serialize(row: TRow)`.
+
+Without this helper, `row` would be `Record<string, unknown>` and you'd lose autocomplete.
+
+### 3. No `SerializeContext` or `readDocument`
+
+Document access through closure is **strictly better**:
+- Fully typed (autocomplete on document names)
+- No intermediate abstraction
+- No `(documents as any)` casts inside the materializer
+- Callers already have `documents` in scope
+
+### 4. `serialize` receives only `row` — no context parameter
+
+The serialize callback is `(row: TRow) => MaybePromise<SerializeResult>`. One input, one output. Everything else (documents, other tables, utilities) comes from the closure. Clean, testable, composable.
+
+### 5. Wikilink conversion applies to all body content
+
+The generic materializer calls `convertEpicenterLinksToWikilinks` on body content from serialize. This covers both row-based body and document-based body. No special handling needed.
+
+### 6. `directory` should be explicit on every `materializeTable` call
+
+With string-keyed tables, the key doubled as the subdirectory name. With array-based tables, there's no implicit name. Making `directory` explicit is one extra string per table and eliminates magic. Check if the table helper exposes an internal name property — if so, it could serve as a default fallback.
+
+## MUST DO
+
+- Rewrite `markdownMaterializer` to accept `{ directory, tables: MaterializeEntry[] }` and return extension result directly (not a factory)
+- Implement `materializeTable<TRow>` generic helper for type inference
+- Replace `MarkdownSerializer` type with `SerializeFn<TRow>` type
+- Rename built-in factories: `defaultSerializer` → `defaultSerialize`, `bodyFieldSerializer` → `bodyFieldSerialize`, `titleFilenameSerializer` → `titleFilenameSerialize`
+- Export standalone `titleFilename(title, id)` and `idFilename(id)` utilities
+- Export `materializeTable`, `SerializeFn`, `SerializeResult`, `MaterializeEntry` from the index
+- Support async `serialize` callbacks (the materialization loop must await results)
+- Apply `convertEpicenterLinksToWikilinks` to body content from serialize
+- Delete `apps/fuji/src/lib/materializer.ts`
+- Delete `playground/opensidian-e2e/materializer.ts`
+- Update `apps/fuji/package.json`: remove `"./materializer"` export, remove `@sindresorhus/slugify` and `filenamify` deps
+- Migrate ALL config files that use the old `serializer` property or `MarkdownSerializer` type
+- Run `bun test packages/workspace` to verify no regressions
+- Run `bun x epicenter start . --verbose` from `~/Code/vault` after updating vault config
+
+## MUST NOT DO
+
+- Do not add backward compatibility for the old `serializer`/`MarkdownSerializer` API — clean break
+- Do not add a `SerializeContext` or `readDocument` helper — document access through closure is the design
+- Do not add new dependencies to `packages/workspace`
+- Do not change the markdown output format (YAML frontmatter + body)
+- Do not modify `packages/workspace/src/workspace/types.ts`
+- Do not change how `convertEpicenterLinksToWikilinks` is applied

--- a/specs/20260412T124500-markdown-materializer-document-support.md
+++ b/specs/20260412T124500-markdown-materializer-document-support.md
@@ -1,27 +1,27 @@
-# Typed markdownMaterializer with closure-based document access
+# Typed createMaterializer with factory pattern and closure-based document access
 
 ## Task
 
-Redesign the `markdownMaterializer` API from scratch. Replace untyped string keys and `MarkdownSerializer` objects with typed table helpers and a `serialize` callback that infers row types. Eliminate `SerializeContext`/`readDocument`—document access happens through the extension closure, which is already fully typed.
+Replace the markdown-specific `markdownMaterializer` with a general `createMaterializer` factory that follows the factory function composition pattern. First arg is the resource (`tables`), second is config (`{ directory }`). Returns a builder with `.table()` for per-table overrides. All tables materialize by default. KV materializes to a single JSON file.
 
-After this change, the two app-specific materializers (fuji, opensidian) are deleted—their logic collapses into inline `serialize` callbacks on the generic materializer.
+The serialize contract is general: `{ filename, content }`. A `markdown()` helper handles the common case of frontmatter + body. This eliminates the two app-specific materializers (fuji, opensidian) and generalizes beyond markdown.
 
 ## The Problem
 
-The generic `markdownMaterializer` has three type holes:
+The generic `markdownMaterializer` has three categories of issues:
 
-1. **Table names are untyped strings** — `tables: { entries: {...} }` doesn't validate that `entries` exists
-2. **Row data is `Record<string, unknown>`** — the serialize callback can't access `row.title` without casting
-3. **Document names are untyped strings** — `readDocument('content')` doesn't validate the document exists
+**Type holes:**
+1. Table names are untyped strings — `tables: { entries: {...} }` doesn't validate that `entries` exists
+2. Row data is `Record<string, unknown>` — the serialize callback can't access `row.title` without casting
+3. Document names are untyped strings — no validation that a document exists
 
-All three are solvable because `.withWorkspaceExtension` gives you a **fully typed** extension context in its closure. The current API throws that away by accepting config before the context is available.
+**Markdown-specific contract:**
+4. Serialize returns `{ frontmatter, body, filename }` — hardcoded to markdown format
+5. No support for JSON, YAML, or custom file formats
+6. No KV materialization
 
-There are currently **two** app-specific materializers that exist solely because the generic one can't read documents:
-
-1. `apps/fuji/src/lib/materializer.ts` — reads `documents.entries.content.open(row.id)` for entry body
-2. `playground/opensidian-e2e/materializer.ts` — reads `documents.files.content.open(row.id)` for file body
-
-Both are ~80% identical to the generic materializer. The only differences: which table/document to use, which frontmatter fields to include.
+**Code duplication:**
+7. Two app-specific materializers (~350 lines) exist solely because the generic one can't read documents
 
 ## Current Architecture
 
@@ -31,82 +31,24 @@ Both are ~80% identical to the generic materializer. The only differences: which
 // Returns a factory — called BEFORE context is available
 export function markdownMaterializer(config: MarkdownMaterializerConfig) {
     return ({ tables }: ExtensionContext) => {
-        // tables accessed by string key: tables[tableKey]
+        // tables accessed by untyped string key: tables[tableKey]
         // serializer.serialize(row) — row is Record<string, unknown>
+        // returns { frontmatter, body, filename } — markdown-only
     };
 }
 ```
 
-Config type:
+### App-specific materializers that should not exist
 
-```typescript
-export type MarkdownMaterializerConfig = {
-    directory: string;
-    tables: Record<string, {         // ← untyped string keys
-        directory?: string;
-        serializer?: MarkdownSerializer;
-    }>;
-};
-```
+1. `apps/fuji/src/lib/materializer.ts` — reads `documents.entries.content.open(row.id)`
+2. `playground/opensidian-e2e/materializer.ts` — reads `documents.files.content.open(row.id)`
 
-Serializer interface (`serializers.ts`):
-
-```typescript
-export type MarkdownSerializer = {
-    serialize(row: Record<string, unknown>): {  // ← untyped row
-        frontmatter: Record<string, unknown>;
-        body?: string;
-        filename: string;
-    };
-};
-```
-
-### Built-in serializer factories (`serializers.ts`)
-
-Three factories return `MarkdownSerializer` objects:
-
-- `defaultSerializer()` — all fields as frontmatter, `{id}.md` filename
-- `bodyFieldSerializer(fieldName)` — extracts one row field as body
-- `titleFilenameSerializer(fieldName)` — slugified `{title}-{id}.md` filename
-
-### App-specific materializer pattern (fuji, `apps/fuji/src/lib/materializer.ts`)
-
-```typescript
-export function createFujiMaterializer({ directory }: { directory: string }) {
-    return ({ tables, documents, whenReady }: MaterializerContext) => {
-        async function materializeEntry(row: Entry): Promise<void> {
-            const handle = await documents.entries.content.open(row.id);
-            content = handle.read();
-            const frontmatter = { id: row.id, title: row.title, ... };
-            await Bun.write(join(dir, filename), toMarkdown(frontmatter, content));
-        }
-        // observe table, materialize on change — identical to generic
-    };
-}
-```
-
-### Opensidian app-specific materializer (`playground/opensidian-e2e/materializer.ts`)
-
-Same pattern, different table/document names:
-
-```typescript
-export function createOpensidianMaterializer({ directory }: { directory: string }) {
-    return ({ tables, documents, whenReady }: MaterializerContext) => {
-        async function materializeFile(row: FileRow): Promise<void> {
-            if (row.type === 'folder') return;
-            const handle = await documents.files.content.open(row.id);
-            content = handle.read();
-            const exportedContent = convertEpicenterLinksToWikilinks(content);
-            // ... same observe/write pattern
-        }
-    };
-}
-```
+Both are ~80% identical to the generic materializer. The only differences: which table/document to use and frontmatter field selection.
 
 ### How vault config uses both today (`~/Code/vault/epicenter.config.ts`)
 
 ```typescript
-// Tab manager: uses GENERIC materializer (no documents)
+// Tab manager: generic materializer (no documents)
 export const tabManager = createTabManagerWorkspace()
     .withWorkspaceExtension('markdown', markdownMaterializer({
         directory: join(import.meta.dir, 'tab-manager'),
@@ -117,7 +59,7 @@ export const tabManager = createTabManagerWorkspace()
         },
     }));
 
-// Fuji: uses APP-SPECIFIC materializer (needs document content)
+// Fuji: app-specific materializer (needs document content)
 export const fuji = createFujiWorkspace()
     .withWorkspaceExtension('markdown', createFujiMaterializer({
         directory: import.meta.dir,
@@ -126,192 +68,114 @@ export const fuji = createFujiWorkspace()
 
 ## New API Design
 
-### Key insight
+### Factory function pattern
 
-`markdownMaterializer` is no longer a factory-returning-factory. It's called **inside** the `.withWorkspaceExtension` closure, receives typed table helpers directly, and returns the extension result.
-
-```
-Before: markdownMaterializer(config) → (context) → extensionResult
-After:  (context) → markdownMaterializer(config) → extensionResult
-```
-
-The caller passes typed table helpers from the closure. The materializer infers row types from them.
-
-### Core types
+Following the factory function composition skill: first arg is the resource (typed `tables`), second arg is config.
 
 ```typescript
-/** Result of serializing a row to markdown. */
+function createMaterializer<TTables extends Record<string, TableHelper<any>>>(
+    tables: TTables,
+    config: { directory: string },
+): MaterializerBuilder<TTables>;
+```
+
+The factory receives the typed `tables` object. This gives it:
+- `keyof TTables` for validated table name strings
+- `TTables[K]` for row type inference per table
+- Table key names for default subdirectory names
+
+### All tables materialize by default
+
+`createMaterializer(tables, { directory })` immediately materializes every table with defaults:
+- Serialize: all fields as frontmatter, `{id}.md` filename (markdown format)
+- Directory: `{directory}/{tableName}/`
+
+Chain `.table()` only for tables that need customization. Chain `.skip()` to exclude tables.
+
+### General serialize contract
+
+```typescript
 type SerializeResult = {
-    frontmatter: Record<string, unknown>;
-    body?: string;
     filename: string;
+    content: string;
 };
 
 type MaybePromise<T> = T | Promise<T>;
-
-/**
- * Serialize a typed row to markdown output.
- *
- * Receives the full typed row — no Record<string, unknown>.
- * Document access happens through the extension closure, not
- * through a context parameter.
- */
-type SerializeFn<TRow> = (row: TRow) => MaybePromise<SerializeResult>;
 ```
 
-No `SerializeContext`. No `readDocument`. The callback just receives the typed row. If you need documents, you close over `documents` from the extension context—which is fully typed with autocomplete.
+The materializer writes `{ filename, content }`. It doesn't know or care about markdown, JSON, or any format.
 
-### `materializeTable` helper
-
-This is the type inference bridge. It accepts a typed table helper and returns a config object with the row type erased (the materializer only needs untyped internals).
+### `markdown()` helper for the common case
 
 ```typescript
-/** Structural type for the table helper methods the materializer needs. */
-type MaterializableTable<TRow> = {
-    getAllValid(): TRow[];
-    get(id: string):
-        | { status: 'valid'; row: TRow }
-        | { status: 'not_found' }
-        | { status: 'invalid' };
-    observe(callback: (changedIds: ReadonlySet<string>) => void): () => void;
-};
-
-/** Type-erased config the materializer iterates over internally. */
-type MaterializeEntry = {
-    table: MaterializableTable<Record<string, unknown>>;
-    directory?: string;
-    serialize: SerializeFn<Record<string, unknown>>;
-};
-
 /**
- * Create a type-safe materialization config for a single table.
+ * Convert frontmatter + body to a markdown file result.
  *
- * TypeScript infers TRow from the table helper, then flows it into
- * the serialize callback. The return type erases TRow—the materializer
- * internally only needs untyped table operations.
- *
- * @example
- * ```typescript
- * materializeTable(tables.entries, {
- *     directory: 'fuji',
- *     serialize: async (row) => ({
- *         // row: Entry — inferred from tables.entries!
- *         frontmatter: { id: row.id, title: row.title },
- *         body: await documents.entries.content.open(row.id).then(h => h.read()),
- *         filename: titleFilename(row.title, row.id),
- *     }),
- * })
- * ```
+ * Applies epicenter link → wikilink conversion to body content.
+ * Handles undefined body (frontmatter-only output).
  */
-function materializeTable<TRow extends { id: string }>(
-    table: MaterializableTable<TRow>,
-    config?: {
-        directory?: string;
-        serialize?: SerializeFn<TRow>;
-    },
-): MaterializeEntry {
+function markdown(input: {
+    frontmatter: Record<string, unknown>;
+    body?: string;
+    filename: string;
+}): SerializeResult {
+    const processedBody = input.body
+        ? convertEpicenterLinksToWikilinks(input.body)
+        : input.body;
     return {
-        table: table as MaterializableTable<Record<string, unknown>>,
-        directory: config?.directory,
-        serialize: (config?.serialize ?? defaultSerialize()) as SerializeFn<Record<string, unknown>>,
+        filename: input.filename,
+        content: toMarkdown(input.frontmatter, processedBody),
     };
 }
 ```
 
-### Updated `markdownMaterializer`
-
-No longer a factory-returning-factory. Called inside the closure, returns the extension result directly.
+### `.table()` chain with typed overrides
 
 ```typescript
-type MarkdownMaterializerConfig = {
-    directory: string;
-    tables: MaterializeEntry[];
-};
+interface MaterializerBuilder<TTables> {
+    /**
+     * Override materialization config for a specific table.
+     *
+     * Table name is validated against TTables keys.
+     * Serialize callback receives typed row inferred from the table.
+     */
+    table<K extends keyof TTables & string>(
+        name: K,
+        config: {
+            dir?: string;
+            serialize?: TTables[K] extends TableHelper<infer TRow>
+                ? (row: TRow) => MaybePromise<SerializeResult>
+                : never;
+        },
+    ): this;
 
-/**
- * One-way markdown materializer. Observes tables and writes .md files.
- *
- * Called inside a .withWorkspaceExtension closure — NOT as a standalone
- * factory. This gives callers typed access to tables and documents.
- *
- * @returns Extension result with whenReady and dispose.
- */
-function markdownMaterializer(config: MarkdownMaterializerConfig): {
+    /** Exclude tables from materialization. */
+    skip(...names: (keyof TTables & string)[]): this;
+
+    /** Extension lifecycle. */
     whenReady: Promise<void>;
     dispose(): void;
-} {
-    const unsubscribers: Array<() => void> = [];
-
-    const whenReady = (async () => {
-        for (const entry of config.tables) {
-            const dir = join(config.directory, entry.directory ?? '???');
-            // ... mkdir, initial materialization, observe
-            // Each row: const result = await entry.serialize(row);
-        }
-    })();
-
-    return {
-        whenReady,
-        dispose() { for (const unsub of unsubscribers) unsub(); },
-    };
 }
 ```
 
-Note: the materializer needs a way to determine the default subdirectory name. Currently it uses the string table key from the config record. With an array of `MaterializeEntry`, there's no implicit name. Options:
-- Require `directory` on every entry (explicit, no magic)
-- Add a `name` field to `MaterializeEntry` for the subdirectory default
-- Use the table helper's internal name if it exposes one
+### KV materialization
 
-**Recommended**: require `directory` on every entry. It's one extra string per table and eliminates ambiguity. Check if table helpers expose a name property — if so, use it as the default.
-
-### Built-in serialize helpers
-
-Same as before, but typed as `SerializeFn<Record<string, unknown>>` (compatible with any row type via contravariance):
+By default, all KV data materializes to a single `{directory}/kv.json` file containing all key-value pairs as a flat JSON object. Override with `.kv()` if needed.
 
 ```typescript
-/** All fields as frontmatter, {id}.md filename. */
-export function defaultSerialize(): SerializeFn<Record<string, unknown>> {
-    return (row) => ({
-        frontmatter: { ...row },
-        filename: `${row.id}.md`,
-    });
-}
+interface MaterializerBuilder<TTables> {
+    // ... table methods above ...
 
-/** Extract one row field as body, remaining fields as frontmatter. */
-export function bodyFieldSerialize(fieldName: string): SerializeFn<Record<string, unknown>> {
-    return (row) => {
-        const { [fieldName]: bodyValue, ...rest } = row;
-        return {
-            frontmatter: rest,
-            body: bodyValue != null ? String(bodyValue) : undefined,
-            filename: `${row.id}.md`,
-        };
-    };
-}
-
-/** Slugified {title}-{id}.md filename, all fields as frontmatter. */
-export function titleFilenameSerialize(fieldName: string): SerializeFn<Record<string, unknown>> {
-    return (row) => ({
-        frontmatter: { ...row },
-        filename: titleFilename(String(row[fieldName] ?? ''), String(row.id)),
-    });
-}
-```
-
-### Standalone filename utilities
-
-```typescript
-/** Slugified `{title}-{id}.md`, falling back to `{id}.md`. */
-export function titleFilename(title: string, id: string): string {
-    const slug = slugify(title.trim()).slice(0, MAX_SLUG_LENGTH);
-    return slug
-        ? filenamify(`${slug}-${id}.md`, { replacement: '-' })
-        : `${id}.md`;
-}
-
-/** Simple `{id}.md` filename. */
-export function idFilename(id: string): string {
-    return `${id}.md`;
+    /**
+     * Override KV materialization.
+     * Default: all KV → {directory}/kv.json
+     */
+    kv(config: {
+        /** Custom filename. Default: 'kv.json'. */
+        filename?: string;
+        /** Disable KV materialization. */
+        skip?: boolean;
+    }): this;
 }
 ```
 
@@ -321,62 +185,46 @@ export function idFilename(id: string): string {
 
 ```typescript
 import {
-    markdownMaterializer,
-    materializeTable,
-    titleFilename,
-    titleFilenameSerialize,
-} from '@epicenter/workspace/extensions/materializer/markdown';
+    createMaterializer,
+    markdown,
+    slugFilename,
+    toSlugFilename,
+} from '@epicenter/workspace/extensions/materializer';
 
-// Tab manager — typed table helpers, inferred row types
+// Tab manager — override filename strategy, everything else defaults
 export const tabManager = createTabManagerWorkspace()
-    .withWorkspaceExtension('markdown', ({ tables }) =>
-        markdownMaterializer({
+    .withWorkspaceExtension('materializer', ({ tables }) =>
+        createMaterializer(tables, {
             directory: join(import.meta.dir, 'tab-manager'),
-            tables: [
-                materializeTable(tables.savedTabs, {
-                    directory: 'savedTabs',
-                    serialize: titleFilenameSerialize('title'),
-                }),
-                materializeTable(tables.bookmarks, {
-                    directory: 'bookmarks',
-                    serialize: titleFilenameSerialize('title'),
-                }),
-                materializeTable(tables.devices, {
-                    directory: 'devices',
-                }),
-            ],
         })
+        .table('savedTabs', { serialize: slugFilename('title') })
+        .table('bookmarks', { serialize: slugFilename('title') })
+        // devices: default (all fields as markdown frontmatter, devices/{id}.md)
     );
 
-// Fuji — typed rows, document access through closure
+// Fuji — custom serialize with document content via closure
 export const fuji = createFujiWorkspace()
-    .withWorkspaceExtension('markdown', ({ tables, documents }) =>
-        markdownMaterializer({
-            directory: import.meta.dir,
-            tables: [
-                materializeTable(tables.entries, {
-                    directory: 'fuji',
-                    serialize: async (row) => ({
-                        // row: Entry — inferred from tables.entries
-                        // row.id, row.title, row.tags — all autocomplete
-                        frontmatter: {
-                            id: row.id,
-                            title: row.title,
-                            subtitle: row.subtitle,
-                            type: row.type,
-                            tags: row.tags,
-                            createdAt: row.createdAt,
-                            updatedAt: row.updatedAt,
-                        },
-                        // documents.entries.content — fully typed, autocompletes
-                        body: await documents.entries.content
-                            .open(row.id)
-                            .then((h) => h.read())
-                            .catch(() => undefined),
-                        filename: titleFilename(row.title, row.id),
-                    }),
-                }),
-            ],
+    .withWorkspaceExtension('materializer', ({ tables, documents }) =>
+        createMaterializer(tables, { directory: import.meta.dir })
+        .table('entries', {
+            dir: 'fuji',
+            serialize: async (row) => markdown({
+                // row: Entry — inferred from tables['entries']
+                frontmatter: {
+                    id: row.id,
+                    title: row.title,
+                    subtitle: row.subtitle,
+                    type: row.type,
+                    tags: row.tags,
+                    createdAt: row.createdAt,
+                    updatedAt: row.updatedAt,
+                },
+                body: await documents.entries.content
+                    .open(row.id)
+                    .then((h) => h.read())
+                    .catch(() => undefined),
+                filename: toSlugFilename(row.title, row.id),
+            }),
         })
     );
 ```
@@ -385,65 +233,100 @@ export const fuji = createFujiWorkspace()
 
 ```typescript
 export const opensidian = createWorkspace(opensidianDefinition)
-    .withWorkspaceExtension('markdown', ({ tables, documents }) =>
-        markdownMaterializer({
+    .withWorkspaceExtension('materializer', ({ tables, documents }) =>
+        createMaterializer(tables, {
             directory: join(import.meta.dir, 'data'),
-            tables: [
-                materializeTable(tables.files, {
-                    directory: 'files',
-                    serialize: async (row) => {
-                        // row: FileRow — inferred from tables.files
-                        if (row.type === 'folder') {
-                            return {
-                                frontmatter: { id: row.id, name: row.name, type: 'folder' },
-                                filename: idFilename(row.id),
-                            };
-                        }
-                        return {
-                            frontmatter: {
-                                id: row.id,
-                                name: row.name,
-                                parentId: row.parentId,
-                                size: row.size,
-                                createdAt: row.createdAt,
-                                updatedAt: row.updatedAt,
-                                trashedAt: row.trashedAt,
-                            },
-                            body: await documents.files.content
-                                .open(row.id)
-                                .then((h) => h.read())
-                                .catch(() => undefined),
-                            filename: titleFilename(
-                                row.name.replace(/\.md$/i, ''),
-                                row.id,
-                            ),
-                        };
+        })
+        .table('files', {
+            serialize: async (row) => {
+                // row: FileRow — inferred from tables['files']
+                if (row.type === 'folder') {
+                    return markdown({
+                        frontmatter: { id: row.id, name: row.name, type: 'folder' },
+                        filename: toIdFilename(row.id),
+                    });
+                }
+                return markdown({
+                    frontmatter: {
+                        id: row.id,
+                        name: row.name,
+                        parentId: row.parentId,
+                        size: row.size,
+                        createdAt: row.createdAt,
+                        updatedAt: row.updatedAt,
+                        trashedAt: row.trashedAt,
                     },
-                }),
-            ],
+                    body: await documents.files.content
+                        .open(row.id)
+                        .then((h) => h.read())
+                        .catch(() => undefined),
+                    filename: toSlugFilename(
+                        row.name.replace(/\.md$/i, ''),
+                        row.id,
+                    ),
+                });
+            },
         })
     );
 ```
 
-## What's eliminated vs the old API
+### Non-markdown example (JSON materialization)
 
-| Old API | New API | Why it's better |
+```typescript
+// Materialize devices as individual JSON files instead of markdown
+createMaterializer(tables, { directory: '...' })
+    .table('devices', {
+        serialize: (row) => ({
+            filename: `${row.id}.json`,
+            content: JSON.stringify(row, null, 2),
+        }),
+    })
+```
+
+## Materialization Model
+
+| Source | Target | Default |
 |---|---|---|
-| `MarkdownSerializer` type (object with method) | `SerializeFn<TRow>` (plain function) | Simpler, generic over row type |
-| `serializer` property | `serialize` property on `materializeTable` | Same concept, better name |
-| `tables: Record<string, {...}>` (string keys) | `tables: [materializeTable(tables.foo, {...})]` | Typed table refs, no string key typos |
-| `row: Record<string, unknown>` in serialize | `row: TRow` inferred from table helper | Full autocomplete on row fields |
-| `readDocument('content')` with `SerializeContext` | `documents.entries.content.open(row.id)` via closure | Fully typed, autocompletes document names |
-| `markdownMaterializer(config)` returns factory | `markdownMaterializer(config)` returns extension result | Called inside typed closure |
-| App-specific materializers (fuji, opensidian) | Inline `serialize` callbacks | ~350 lines of duplicated code deleted |
+| Table row | One file per row | Markdown: frontmatter + `{id}.md` |
+| KV | One JSON file for all KV | `{directory}/kv.json` |
+| Table (all rows) | NOT SUPPORTED | Use custom extension if needed |
+
+**Row → file** is the core use case (browsable content: notes, bookmarks, entries).
+**KV → file** is natural (small, flat, key-value shaped).
+**Table → file** is an export concern, not a materialization concern. Out of scope.
+
+## Exported API Surface
+
+### Factory
+
+- `createMaterializer(tables, config)` — factory: resource first, config second
+
+### Serialize presets (return `SerializeResult`)
+
+- `slugFilename(field)` — all fields as markdown frontmatter, slugified `{title}-{id}.md`
+- `bodyField(field)` — extracts one field as markdown body, rest as frontmatter, `{id}.md`
+- Default (when serialize omitted): all fields as markdown frontmatter, `{id}.md`
+
+### Helpers
+
+- `markdown({ frontmatter, body, filename })` — converts to `{ filename, content }` with wikilink processing
+- `toSlugFilename(title, id)` — standalone string utility: `{slug}-{id}.md`
+- `toIdFilename(id)` — standalone string utility: `{id}.md`
+- `toMarkdown(frontmatter, body?)` — pure YAML frontmatter + body assembly (already exists)
+
+### Types
+
+- `SerializeResult` — `{ filename: string; content: string }`
+- `MaybePromise<T>` — `T | Promise<T>`
 
 ## Files to Modify
 
-### Primary (the generic materializer)
+### Primary (new materializer)
 
-- `packages/workspace/src/extensions/materializer/markdown/markdown.ts` — rewrite `markdownMaterializer` to accept `MaterializeEntry[]` (from `materializeTable`); no longer a factory-returning-factory; destructure nothing from context (caller passes table helpers); support async serialize; add `materializeTable` generic helper function
-- `packages/workspace/src/extensions/materializer/markdown/serializers.ts` — delete `MarkdownSerializer` type; rename factories to `*Serialize` returning `SerializeFn`; add `SerializeFn` and `SerializeResult` types; export `titleFilename` and `idFilename` standalone utilities
-- `packages/workspace/src/extensions/materializer/markdown/index.ts` — update exports: add `materializeTable`, `SerializeFn`, `SerializeResult`, `MaterializeEntry`, `titleFilename`, `idFilename`; remove `MarkdownSerializer`; rename serializer exports
+- `packages/workspace/src/extensions/materializer/` — new `createMaterializer` implementation. Consider whether it replaces `materializer/markdown/` or lives alongside it at `materializer/filesystem/` or `materializer/index.ts`.
+- `packages/workspace/src/extensions/materializer/markdown/serializers.ts` — adapt existing serializer factories to return `SerializeResult` (general contract). Rename: `titleFilenameSerializer` → `slugFilename`, `bodyFieldSerializer` → `bodyField`. Add `toSlugFilename`, `toIdFilename` standalone utilities.
+- `packages/workspace/src/extensions/materializer/markdown/markdown.ts` — extract `toMarkdown` as a reusable utility. The `markdown()` helper wraps it with wikilink conversion. The old `markdownMaterializer` function is deleted.
+- `packages/workspace/src/extensions/materializer/markdown/index.ts` — update exports for new API surface.
 
 ### Secondary (consumers to delete)
 
@@ -453,73 +336,86 @@ export const opensidian = createWorkspace(opensidianDefinition)
 
 ### Tertiary (consumers to migrate)
 
-- `playground/opensidian-e2e/epicenter.config.ts` — wrap `markdownMaterializer` in `.withWorkspaceExtension` closure; use `materializeTable` with inline serialize
-- `playground/tab-manager-e2e/epicenter.config.ts` — same pattern; check if it uses the materializer
-- `packages/cli/test/fixtures/*/epicenter.config.ts` — grep for materializer usage, migrate if found
-- Any other file importing `MarkdownSerializer`, `defaultSerializer`, `bodyFieldSerializer`, `titleFilenameSerializer`
+- `playground/opensidian-e2e/epicenter.config.ts` — use `createMaterializer` with `.table()` override
+- `playground/tab-manager-e2e/epicenter.config.ts` — use `createMaterializer` if applicable
+- `packages/cli/test/fixtures/*/epicenter.config.ts` — grep for materializer usage, migrate
+- Any file importing from `@epicenter/workspace/extensions/materializer/markdown`
 
 ### External (vault — not in monorepo)
 
-- `~/Code/vault/epicenter.config.ts` — replace `createFujiMaterializer` import with generic materializer + inline serialize; wrap both workspaces' materializer config in closure
+- `~/Code/vault/epicenter.config.ts` — replace both materializer setups with `createMaterializer`
 
-## Design Decisions (Already Made)
+## Design Decisions
 
-### 1. `markdownMaterializer` is NOT a factory-returning-factory
+### 1. General serialize contract: `{ filename, content }`
 
-Old: `markdownMaterializer(config)` returns `(context) => result`. Config is created before context exists — no access to typed tables/documents.
+The materializer writes files. It doesn't care about format. Markdown-specific logic (`toMarkdown`, wikilink conversion) lives in the `markdown()` helper, not in the materializer core. This lets the same materializer handle markdown, JSON, YAML, or any custom format.
 
-New: `markdownMaterializer(config)` returns the extension result directly. Called inside the `.withWorkspaceExtension` closure where context is available. The caller passes typed table helpers via `materializeTable`.
+### 2. Factory function pattern: resource first, config second
 
-This breaks the `configFn(config) → factory` pattern used by other extensions (`filesystemPersistence`, `createSyncExtension`). The break is justified: the materializer is the only extension that benefits from typed table/document access in its config.
+`createMaterializer(tables, { directory })` follows the universal factory function signature. `tables` is the resource (typed, from extension closure). `{ directory }` is the config. Two args max.
 
-### 2. `materializeTable` is the type inference bridge
+### 3. Default-materialize-all with `.table()` overrides
 
-TypeScript can't infer generic types from object literal properties in an array. `materializeTable(table, config)` is a function call that triggers generic inference: `TRow` is inferred from `table`, then flows into `serialize(row: TRow)`.
+All tables materialize with sensible defaults (markdown frontmatter, `{id}.md`). Chain `.table(name, config)` only for tables that need customization. `.skip(name)` for tables that shouldn't materialize. This minimizes config for simple cases.
 
-Without this helper, `row` would be `Record<string, unknown>` and you'd lose autocomplete.
+### 4. Typed table names via generic + `keyof`
 
-### 3. No `SerializeContext` or `readDocument`
+`.table('entries', ...)` validates `'entries'` against `keyof TTables`. Typo → TypeScript error. Row type in serialize callback inferred from `TTables['entries']`. Table key doubles as default subdirectory name.
 
-Document access through closure is **strictly better**:
-- Fully typed (autocomplete on document names)
-- No intermediate abstraction
-- No `(documents as any)` casts inside the materializer
-- Callers already have `documents` in scope
+### 5. Document access through closure, not context parameter
 
-### 4. `serialize` receives only `row` — no context parameter
+`serialize(row)` receives only the typed row. Document access happens through the extension closure (`documents.entries.content.open(row.id)`). This is fully typed with autocomplete. No `readDocument` helper or `SerializeContext` needed.
 
-The serialize callback is `(row: TRow) => MaybePromise<SerializeResult>`. One input, one output. Everything else (documents, other tables, utilities) comes from the closure. Clean, testable, composable.
+### 6. Row → file only, no table → file
 
-### 5. Wikilink conversion applies to all body content
+Each row materializes as one file. There is no "dump entire table to one file" mode. That's an export concern, not a materialization concern. KV is the exception because it's naturally a flat structure.
 
-The generic materializer calls `convertEpicenterLinksToWikilinks` on body content from serialize. This covers both row-based body and document-based body. No special handling needed.
+### 7. KV → one JSON file
 
-### 6. `directory` should be explicit on every `materializeTable` call
+All KV data materializes to `{directory}/kv.json` by default. Simple, obvious, sufficient for the small amount of data KV typically holds.
 
-With string-keyed tables, the key doubled as the subdirectory name. With array-based tables, there's no implicit name. Making `directory` explicit is one extra string per table and eliminates magic. Check if the table helper exposes an internal name property — if so, it could serve as a default fallback.
+### 8. `markdown()` helper applies wikilink conversion
+
+The `markdown()` helper calls `convertEpicenterLinksToWikilinks` on body content. This is the only place epicenter-specific link processing happens. Custom serialize callbacks that don't use `markdown()` don't get link conversion — that's intentional.
+
+## Breaking Changes
+
+Clean break. No backward compatibility.
+
+- `markdownMaterializer` → `createMaterializer`
+- `MarkdownSerializer` type → deleted
+- `MarkdownMaterializerConfig` type → deleted
+- `serializer` config property → `.table(name, { serialize })` chain method
+- `defaultSerializer()` → omit serialize (default behavior)
+- `bodyFieldSerializer(field)` → `bodyField(field)`
+- `titleFilenameSerializer(field)` → `slugFilename(field)`
+- Serialize return: `{ frontmatter, body, filename }` → `{ filename, content }` (use `markdown()` helper)
+
+All consumers in the monorepo must be migrated in the same commit.
 
 ## MUST DO
 
-- Rewrite `markdownMaterializer` to accept `{ directory, tables: MaterializeEntry[] }` and return extension result directly (not a factory)
-- Implement `materializeTable<TRow>` generic helper for type inference
-- Replace `MarkdownSerializer` type with `SerializeFn<TRow>` type
-- Rename built-in factories: `defaultSerializer` → `defaultSerialize`, `bodyFieldSerializer` → `bodyFieldSerialize`, `titleFilenameSerializer` → `titleFilenameSerialize`
-- Export standalone `titleFilename(title, id)` and `idFilename(id)` utilities
-- Export `materializeTable`, `SerializeFn`, `SerializeResult`, `MaterializeEntry` from the index
-- Support async `serialize` callbacks (the materialization loop must await results)
-- Apply `convertEpicenterLinksToWikilinks` to body content from serialize
+- Implement `createMaterializer(tables, config)` factory returning builder with `.table()`, `.skip()`, `.kv()`
+- Generic type parameter on factory for `TTables` — infer from `tables` arg
+- `.table(name, config)` validates name as `keyof TTables`, infers row type for serialize callback
+- General serialize contract: `{ filename: string; content: string }`
+- `markdown()` helper: `{ frontmatter, body, filename }` → `{ filename, content }` with wikilink conversion
+- Default materialization: all tables, markdown frontmatter, `{id}.md`, `{directory}/{tableName}/`
+- KV materialization: `{directory}/kv.json` by default
+- Rename serialize presets: `slugFilename(field)`, `bodyField(field)`
+- Export standalone utilities: `toSlugFilename(title, id)`, `toIdFilename(id)`
 - Delete `apps/fuji/src/lib/materializer.ts`
 - Delete `playground/opensidian-e2e/materializer.ts`
-- Update `apps/fuji/package.json`: remove `"./materializer"` export, remove `@sindresorhus/slugify` and `filenamify` deps
-- Migrate ALL config files that use the old `serializer` property or `MarkdownSerializer` type
+- Update `apps/fuji/package.json`: remove `"./materializer"` export, remove deps
+- Migrate all config files
 - Run `bun test packages/workspace` to verify no regressions
-- Run `bun x epicenter start . --verbose` from `~/Code/vault` after updating vault config
+- Run `bun x epicenter start . --verbose` from `~/Code/vault` after migration
 
 ## MUST NOT DO
 
-- Do not add backward compatibility for the old `serializer`/`MarkdownSerializer` API — clean break
-- Do not add a `SerializeContext` or `readDocument` helper — document access through closure is the design
+- Do not add backward compatibility for old `markdownMaterializer` API
+- Do not support table → one file (all rows in single file)
 - Do not add new dependencies to `packages/workspace`
-- Do not change the markdown output format (YAML frontmatter + body)
 - Do not modify `packages/workspace/src/workspace/types.ts`
-- Do not change how `convertEpicenterLinksToWikilinks` is applied
+- Do not remove `toMarkdown` utility — it's still needed by the `markdown()` helper

--- a/specs/20260412T124500-markdown-materializer-document-support.md
+++ b/specs/20260412T124500-markdown-materializer-document-support.md
@@ -98,11 +98,11 @@ The factory receives the extension context (structurally typed — not importing
 
 ### All tables materialize by default
 
-`createMaterializer(ctx, { directory })` immediately materializes every table with defaults:
-- Serialize: all fields as frontmatter, `{id}.md` filename (markdown format)
+`createMaterializer(ctx, { directory })` materializes every table with sensible defaults:
+- Serialize: all fields as markdown frontmatter, `{id}.md` filename
 - Directory: `{directory}/{tableName}/`
 
-Chain `.table()` only for tables that need customization. Chain `.skip()` to exclude tables.
+Chain `.table()` only for tables that need customization. Chain `.skip()` to exclude tables that shouldn't produce files (internal state, binary data, etc.).
 
 ### General serialize contract
 
@@ -112,7 +112,8 @@ type SerializeResult = {
     content: string;
 };
 
-type MaybePromise<T> = T | Promise<T>;
+// Already exists in packages/workspace/src/workspace/lifecycle.ts — import, don't redefine
+import type { MaybePromise } from './lifecycle.js';
 ```
 
 The materializer writes `{ filename, content }`. It doesn't know or care about markdown, JSON, or any format.
@@ -125,6 +126,14 @@ The materializer writes `{ filename, content }`. It doesn't know or care about m
  *
  * Applies epicenter link → wikilink conversion to body content.
  * Handles undefined body (frontmatter-only output).
+ *
+ * For markdown WITHOUT link conversion, use `toMarkdown()` directly:
+ * ```typescript
+ * serialize: (row) => ({
+ *     filename: `${row.id}.md`,
+ *     content: toMarkdown({ id: row.id, title: row.title }, body),
+ * })
+ * ```
  */
 function markdown(input: {
     frontmatter: Record<string, unknown>;
@@ -161,10 +170,20 @@ interface MaterializerBuilder<TTables, TKv> {
         },
     ): this;
 
-    /** Exclude tables from materialization. */
+    /** Exclude tables from materialization (internal state, binary data, etc). */
     skip(...names: (keyof TTables & string)[]): this;
 
-    /** Extension lifecycle. */
+    /** Exclude KV from materialization. */
+    skipKv(): this;
+
+    /**
+     * Extension lifecycle.
+     *
+     * `whenReady` resolves after initial materialization completes.
+     * Materialization starts lazily when the framework accesses `whenReady`,
+     * which is after all `.table()`, `.skip()`, and `.skipKv()` calls have
+     * completed (they run synchronously in the factory closure).
+     */
     whenReady: Promise<void>;
     dispose(): void;
 }
@@ -172,22 +191,14 @@ interface MaterializerBuilder<TTables, TKv> {
 
 ### KV materialization
 
-By default, all KV data materializes to a single `{directory}/kv.json` file containing all key-value pairs as a flat JSON object. Override with `.kv()` if needed.
+By default, all KV data materializes to a single `{directory}/kv.json` file containing all key-value pairs as a flat JSON object. KV changes are observed live via `kv.observeAll()` — the file re-writes on every change. Use `.skipKv()` to disable.
 
 ```typescript
 interface MaterializerBuilder<TTables, TKv> {
     // ... table methods above ...
 
-    /**
-     * Override KV materialization.
-     * Default: all KV → {directory}/kv.json
-     */
-    kv(config: {
-        /** Custom filename. Default: 'kv.json'. */
-        filename?: string;
-        /** Disable KV materialization. */
-        skip?: boolean;
-    }): this;
+    /** Exclude KV from materialization. */
+    skipKv(): this;
 }
 ```
 
@@ -313,10 +324,12 @@ createMaterializer(ctx, { directory: '...' })
 
 - `createMaterializer(ctx, config)` — factory: resource first (extension context), config second
 
-### Serialize presets (return `SerializeResult`)
+### Serialize presets (markdown — return `SerializeResult`)
 
-- `slugFilename(field)` — all fields as markdown frontmatter, slugified `{title}-{id}.md`
-- `bodyField(field)` — extracts one field as markdown body, rest as frontmatter, `{id}.md`
+These produce markdown output. The names are short for call-site readability; JSDoc documents the format.
+
+- `slugFilename(field)` — all fields as markdown frontmatter, slugified `{title}-{id}.md`. JSDoc: `@remarks Produces markdown output via markdown() internally.`
+- `bodyField(field)` — extracts one field as markdown body, rest as frontmatter, `{id}.md`. JSDoc: `@remarks Produces markdown output via markdown() internally.`
 - Default (when serialize omitted): all fields as markdown frontmatter, `{id}.md`
 
 ### Helpers
@@ -329,7 +342,7 @@ createMaterializer(ctx, { directory: '...' })
 ### Types
 
 - `SerializeResult` — `{ filename: string; content: string }`
-- `MaybePromise<T>` — `T | Promise<T>`
+- `MaybePromise<T>` — import from `packages/workspace/src/workspace/lifecycle.ts` (already exists)
 
 ## Files to Modify
 
@@ -369,7 +382,7 @@ The materializer writes files. It doesn't care about format. Markdown-specific l
 
 ### 3. Default-materialize-all with `.table()` overrides
 
-All tables materialize with sensible defaults (markdown frontmatter, `{id}.md`). Chain `.table(name, config)` only for tables that need customization. `.skip(name)` for tables that shouldn't materialize. This minimizes config for simple cases.
+All tables materialize with sensible defaults (markdown frontmatter, `{id}.md`). Chain `.table(name, config)` only for tables that need customization. `.skip(name)` for tables that shouldn't materialize (internal state, binary data). This minimizes config for simple cases.
 
 ### 4. Typed table names via generic + `keyof`
 
@@ -385,11 +398,11 @@ Each row materializes as one file. There is no "dump entire table to one file" m
 
 ### 7. KV → one JSON file
 
-All KV data materializes to `{directory}/kv.json` by default. Simple, obvious, sufficient for the small amount of data KV typically holds.
+All KV data materializes to `{directory}/kv.json` by default. Live updates via `kv.observeAll()` (verified — exists in workspace API). `.skipKv()` to disable.
 
 ### 8. `markdown()` helper applies wikilink conversion
 
-The `markdown()` helper calls `convertEpicenterLinksToWikilinks` on body content. This is the only place epicenter-specific link processing happens. Custom serialize callbacks that don't use `markdown()` don't get link conversion — that's intentional.
+The `markdown()` helper calls `convertEpicenterLinksToWikilinks` on body content. This is the only place epicenter-specific link processing happens. Custom serialize callbacks that don't use `markdown()` don't get link conversion — that's intentional. For markdown without link conversion, use `toMarkdown()` directly (already exported, pure function).
 
 ## Breaking Changes
 
@@ -414,7 +427,7 @@ All consumers in the monorepo must be migrated in the same commit.
 - General serialize contract: `{ filename: string; content: string }`
 - `markdown()` helper: `{ frontmatter, body, filename }` → `{ filename, content }` with wikilink conversion
 - Default materialization: all tables, markdown frontmatter, `{id}.md`, `{directory}/{tableName}/`
-- KV materialization: `{directory}/kv.json` by default
+- KV materialization: `{directory}/kv.json` by default, live updates via `kv.observeAll()`, `.skipKv()` to disable
 - Rename serialize presets: `slugFilename(field)`, `bodyField(field)`
 - Export standalone utilities: `toSlugFilename(title, id)`, `toIdFilename(id)`
 - Delete `apps/fuji/src/lib/materializer.ts`
@@ -432,39 +445,14 @@ All consumers in the monorepo must be migrated in the same commit.
 - Do not modify `packages/workspace/src/workspace/types.ts`
 - Do not remove `toMarkdown` utility — it's still needed by the `markdown()` helper
 
-## Open Questions (flagged during reflection)
+## Resolved Open Questions
 
-### 1. Preset names don't indicate they produce markdown
-
-`slugFilename('title')` and `bodyField('desc')` internally call `markdown()` to produce `SerializeResult`. But nothing in the name tells you the output is markdown. A user seeing `serialize: slugFilename('title')` might think it's format-agnostic.
-
-Options:
-- Rename to `markdownSlugFilename`, `markdownBodyField` — explicit but verbose
-- Keep short names, document as "markdown presets" — relies on docs
-- Have presets return `{ frontmatter, body, filename }` and require the caller to wrap with `markdown()` — more explicit but more verbose at call site
-
-Leaning toward: keep short names, they live in a module clearly about materialization and the default IS markdown. Document it.
-
-### 2. Default-materialize-all assumes all tables produce sensible markdown
-
-Tables with binary data, internal state, or very large rows would produce garbage `.md` files. The default is designed for typical content tables (notes, bookmarks, entries). `.skip()` exists for internal/binary tables. This should be clearly documented.
-
-### 3. KV observation — does it exist?
-
-The spec says KV materializes to `kv.json`. But this requires observing KV changes for live updates. Verify that the workspace API supports `kv.observe()` or equivalent. If not, KV materialization only happens at startup — which might be fine but should be documented.
-
-### 4. `markdown()` bakes in wikilink conversion with no opt-out
-
-`markdown()` always calls `convertEpicenterLinksToWikilinks`. Users who want markdown WITHOUT link conversion can use `toMarkdown()` directly (already exported, pure function, no link processing). This is the escape hatch — mention it in docs.
-
-### 5. `whenReady` timing
-
-The builder has `whenReady` as a property, but `.table()` calls happen synchronously before `whenReady` is accessed by the framework. Implementation must ensure `whenReady` starts materialization lazily (on first access or next microtask) so all `.table()` and `.skip()` calls complete first.
-
-### 6. `.kv({ skip: true })` vs `.skipKv()`
-
-Tables use `.skip('tableName')` method. KV uses `.kv({ skip: true })` flag. Inconsistent pattern. Consider `.skipKv()` for consistency, or accept the difference since KV has other config options (filename) that tables don't.
-
-### 7. `MaybePromise<T>` — check for existing definition
-
-This type may already exist in the codebase. Check before defining a new one to avoid duplication.
+| # | Issue | Resolution |
+|---|---|---|
+| 1 | Preset names don't indicate markdown | **JSDoc** — add `@remarks Produces markdown output via markdown() internally` to each preset. Short names are fine for call-site readability since the default IS markdown. |
+| 2 | Default-materialize-all assumptions | **JSDoc** on `createMaterializer` + `.skip()` — document that `.skip()` should be used for non-content tables (internal state, binary data). |
+| 3 | KV observation | **Resolved** — `kv.observe(key, cb)` and `kv.observeAll(cb)` both exist in workspace API. Live KV materialization works. |
+| 4 | `markdown()` link conversion opt-out | **JSDoc** — document `toMarkdown()` as the escape hatch for markdown without link conversion. Already exported. |
+| 5 | `whenReady` timing | **JSDoc** on builder's `whenReady` — note lazy start. All `.table()`, `.skip()`, `.skipKv()` calls complete synchronously before framework accesses `whenReady`. |
+| 6 | `.kv({ skip: true })` inconsistency | **API fix** — replaced with `.skipKv()` for consistency with `.skip('tableName')` pattern. |
+| 7 | `MaybePromise<T>` duplication | **Resolved** — already defined in `packages/workspace/src/workspace/lifecycle.ts`, exported from `index.ts`. Import it, don't redefine. |

--- a/specs/20260412T124500-markdown-materializer-document-support.md
+++ b/specs/20260412T124500-markdown-materializer-document-support.md
@@ -452,17 +452,17 @@ All consumers in the monorepo must be migrated in the same commit.
 
 ## MUST DO
 
-- Implement `createMaterializer(ctx, { dir })` factory where ctx is structurally typed as `{ tables, kv, whenReady }`
-- Generic type parameters on factory for `TTables` and `TKv` — infer from ctx arg
-- `.table(name, config)` validates name as `keyof TTables`, infers row type for serialize callback
-- General serialize contract: `{ filename: string; content: string }`
-- `markdown()` helper: `{ frontmatter, body, filename }` → `{ filename, content }` with wikilink conversion
-- Opt-in materialization: nothing by default, `.table()` opts in per table, `.kv()` opts in KV
-- Await `ctx.whenReady` before initial materialization (ensures persistence/sync have loaded data)
-- Default table serialize (when `.table()` called without serialize): all fields as markdown frontmatter, `{id}.md`
-- `.kv()` default: `{dir}/kv.json` with JSON.stringify. Custom serialize receives typed KV snapshot.
-- Rename serialize presets: `slugFilename(field)`, `bodyField(field)`
-- Export standalone utilities: `toSlugFilename(title, id)`, `toIdFilename(id)`
+- [x] Implement `createMaterializer(ctx, { dir })` factory where ctx is structurally typed as `{ tables, kv, whenReady }`
+- [x] Generic type parameters on factory for `TTables` and `TKv` — infer from ctx arg
+- [x] `.table(name, config)` validates name as `keyof TTables`, infers row type for serialize callback
+- [x] General serialize contract: `{ filename: string; content: string }`
+- [x] `markdown()` helper: `{ frontmatter, body, filename }` → `{ filename, content }` with wikilink conversion
+- [x] Opt-in materialization: nothing by default, `.table()` opts in per table, `.kv()` opts in KV
+- [x] Await `ctx.whenReady` before initial materialization (ensures persistence/sync have loaded data)
+- [x] Default table serialize (when `.table()` called without serialize): all fields as markdown frontmatter, `{id}.md`
+- [x] `.kv()` default: `{dir}/kv.json` with JSON.stringify. Custom serialize receives typed KV snapshot.
+- [x] Rename serialize presets: `slugFilename(field)`, `bodyField(field)`
+- [x] Export standalone utilities: `toSlugFilename(title, id)`, `toIdFilename(id)`
 - Delete `apps/fuji/src/lib/materializer.ts`
 - Delete `playground/opensidian-e2e/materializer.ts`
 - Update `apps/fuji/package.json`: remove `"./materializer"` export, remove deps

--- a/specs/20260412T124500-markdown-materializer-document-support.md
+++ b/specs/20260412T124500-markdown-materializer-document-support.md
@@ -338,7 +338,7 @@ createMaterializer(ctx, { dir: '...' })
 | Source | Target | Default |
 |---|---|---|
 | Table row | One file per row | Markdown: frontmatter + `{id}.md` |
-| KV | One JSON file for all KV | `{directory}/kv.json` |
+| KV | One JSON file for all KV | `{dir}/kv.json` |
 | Table (all rows) | NOT SUPPORTED | Use custom extension if needed |
 
 **Row → file** is the core use case (browsable content: notes, bookmarks, entries).

--- a/specs/20260412T124500-markdown-materializer-document-support.md
+++ b/specs/20260412T124500-markdown-materializer-document-support.md
@@ -79,6 +79,7 @@ type MaterializerContext<
 > = {
     tables: TTables;
     kv: TKv;
+    whenReady: Promise<void>;  // must await before reading data
 };
 
 function createMaterializer<
@@ -90,7 +91,7 @@ function createMaterializer<
 ): MaterializerBuilder<TTables, TKv>;
 ```
 
-The factory receives the extension context (structurally typed — not importing `ExtensionContext`). Passing `ctx` directly from the `.withWorkspaceExtension` closure works because `ExtensionContext` satisfies `{ tables, kv }` structurally. This gives the factory:
+The factory receives the extension context (structurally typed—not importing `ExtensionContext`). Passing `ctx` directly from the `.withWorkspaceExtension` closure works because `ExtensionContext` satisfies `{ tables, kv, whenReady }` structurally. The materializer awaits `ctx.whenReady` before initial materialization to ensure persistence/sync have loaded data first. This gives the factory:
 - `keyof TTables` for validated table name strings
 - `TTables[K]` for row type inference per table
 - `TKv` for typed KV access
@@ -451,12 +452,13 @@ All consumers in the monorepo must be migrated in the same commit.
 
 ## MUST DO
 
-- Implement `createMaterializer(ctx, { dir })` factory where ctx is structurally typed as `{ tables, kv }`
+- Implement `createMaterializer(ctx, { dir })` factory where ctx is structurally typed as `{ tables, kv, whenReady }`
 - Generic type parameters on factory for `TTables` and `TKv` — infer from ctx arg
 - `.table(name, config)` validates name as `keyof TTables`, infers row type for serialize callback
 - General serialize contract: `{ filename: string; content: string }`
 - `markdown()` helper: `{ frontmatter, body, filename }` → `{ filename, content }` with wikilink conversion
 - Opt-in materialization: nothing by default, `.table()` opts in per table, `.kv()` opts in KV
+- Await `ctx.whenReady` before initial materialization (ensures persistence/sync have loaded data)
 - Default table serialize (when `.table()` called without serialize): all fields as markdown frontmatter, `{id}.md`
 - `.kv()` default: `{dir}/kv.json` with JSON.stringify. Custom serialize receives typed KV snapshot.
 - Rename serialize presets: `slugFilename(field)`, `bodyField(field)`
@@ -491,3 +493,4 @@ All consumers in the monorepo must be migrated in the same commit.
 | 8 | `directory` vs `dir` | **API fix** — `dir` everywhere. Short, consistent. Context makes base path vs subfolder obvious. |
 | 9 | KV serialize/overrides | **API fix** — `.kv({ serialize })` receives typed KV snapshot, returns `SerializeResult`. |
 | 10 | Global default serialize | **No** — would be `Record<string, unknown>` (untyped), defeating row type inference. Built-in default is always safe. Two-line repetition is fine. |
+| 11 | `ctx.whenReady` ordering | **API fix** — structural type includes `whenReady`. Materializer awaits it before reading data to avoid racing persistence/sync. |

--- a/specs/20260412T124500-markdown-materializer-document-support.md
+++ b/specs/20260412T124500-markdown-materializer-document-support.md
@@ -2,7 +2,7 @@
 
 ## Task
 
-Replace the markdown-specific `markdownMaterializer` with a general `createMaterializer` factory that follows the factory function composition pattern. First arg is the resource (extension context — `{ tables, kv }`), second is config (`{ directory }`). Returns a builder with `.table()` for per-table overrides. All tables materialize by default. KV materializes to a single JSON file.
+Replace the markdown-specific `markdownMaterializer` with a general `createMaterializer` factory that follows the factory function composition pattern. First arg is the resource (extension context—`{ tables, kv }`), second is config (`{ dir }`). Returns a builder with `.table()` for opt-in per-table materialization and `.kv()` for opt-in KV materialization. Nothing materializes by default—explicit `.table()` and `.kv()` calls opt in.
 
 The serialize contract is general: `{ filename, content }`. A `markdown()` helper handles the common case of frontmatter + body. This eliminates the two app-specific materializers (fuji, opensidian) and generalizes beyond markdown.
 
@@ -86,7 +86,7 @@ function createMaterializer<
     TKv extends Record<string, KvHelper<any>>,
 >(
     ctx: MaterializerContext<TTables, TKv>,
-    config: { directory: string },
+    config: { dir: string },
 ): MaterializerBuilder<TTables, TKv>;
 ```
 
@@ -96,13 +96,18 @@ The factory receives the extension context (structurally typed — not importing
 - `TKv` for typed KV access
 - Table key names for default subdirectory names
 
-### All tables materialize by default
+### Opt-in materialization via `.table()` and `.kv()`
 
-`createMaterializer(ctx, { directory })` materializes every table with sensible defaults:
-- Serialize: all fields as markdown frontmatter, `{id}.md` filename
-- Directory: `{directory}/{tableName}/`
+Nothing materializes by default. Call `.table(name)` to opt in a table. Call `.kv()` to opt in KV.
 
-Chain `.table()` only for tables that need customization. Chain `.skip()` to exclude tables that shouldn't produce files (internal state, binary data, etc.).
+**Why opt-in, not default-materialize-all:**
+- **No surprise files.** Adding a table to the workspace definition doesn't silently produce `.md` files on disk.
+- **No `.skip()` needed.** The API surface shrinks—no negation mixed into the chain.
+- **Explicit > implicit** for an extension that writes to the filesystem.
+- **Every line is additive.** Each `.table()` call opts in one table. The chain is purely constructive.
+- **In practice you customize most tables anyway** (filename strategy, document content), so you're writing `.table()` calls regardless.
+
+The built-in default serialize (when `.table()` is called without a `serialize` option) is: all row fields as markdown frontmatter, `{id}.md` filename, written to `{dir}/{tableName}/`.
 
 ### General serialize contract
 
@@ -155,34 +160,49 @@ function markdown(input: {
 ```typescript
 interface MaterializerBuilder<TTables, TKv> {
     /**
-     * Override materialization config for a specific table.
+     * Opt in a table for materialization.
      *
-     * Table name is validated against TTables keys.
-     * Serialize callback receives typed row inferred from the table.
+     * Each row produces one file in `{dir}/{tableName}/` (or `{dir}/{config.dir}/`).
+     * Table name is validated against TTables keys. Serialize callback receives
+     * typed row inferred from the table.
+     *
+     * @remarks Without a serialize option, defaults to markdown: all row fields as
+     * YAML frontmatter, `{id}.md` filename.
      */
     table<K extends keyof TTables & string>(
         name: K,
-        config: {
+        config?: {
+            /** Subdirectory name. Defaults to the table key name. */
             dir?: string;
+            /** Custom serialize. Defaults to markdown frontmatter + {id}.md. */
             serialize?: TTables[K] extends TableHelper<infer TRow>
                 ? (row: TRow) => MaybePromise<SerializeResult>
                 : never;
         },
     ): this;
 
-    /** Exclude tables from materialization (internal state, binary data, etc). */
-    skip(...names: (keyof TTables & string)[]): this;
-
-    /** Exclude KV from materialization. */
-    skipKv(): this;
+    /**
+     * Opt in KV materialization.
+     *
+     * Writes all KV data to a single file. Live updates via `kv.observeAll()`.
+     * Default: `{dir}/kv.json` with `JSON.stringify`.
+     *
+     * @remarks For custom format, provide a serialize callback that receives the
+     * full KV snapshot (all key-value pairs as a typed object) and returns
+     * `{ filename, content }`.
+     */
+    kv(config?: {
+        /** Custom serialize. Receives full KV snapshot, returns { filename, content }. */
+        serialize?: (data: { [K in keyof TKv & string]: TKv[K] extends KvHelper<infer V> ? V : never }) => SerializeResult;
+    }): this;
 
     /**
      * Extension lifecycle.
      *
-     * `whenReady` resolves after initial materialization completes.
+     * `whenReady` resolves after initial materialization of all opted-in tables and KV.
      * Materialization starts lazily when the framework accesses `whenReady`,
-     * which is after all `.table()`, `.skip()`, and `.skipKv()` calls have
-     * completed (they run synchronously in the factory closure).
+     * which is after all `.table()` and `.kv()` calls have completed
+     * (they run synchronously in the factory closure).
      */
     whenReady: Promise<void>;
     dispose(): void;
@@ -191,15 +211,19 @@ interface MaterializerBuilder<TTables, TKv> {
 
 ### KV materialization
 
-By default, all KV data materializes to a single `{directory}/kv.json` file containing all key-value pairs as a flat JSON object. KV changes are observed live via `kv.observeAll()` — the file re-writes on every change. Use `.skipKv()` to disable.
+KV materializes only when `.kv()` is called (opt-in). Default: all KV data as `{dir}/kv.json` with `JSON.stringify`. KV changes are observed live via `kv.observeAll()`. Custom format via `serialize` option:
 
 ```typescript
-interface MaterializerBuilder<TTables, TKv> {
-    // ... table methods above ...
+// Default: kv.json with JSON
+.kv()
 
-    /** Exclude KV from materialization. */
-    skipKv(): this;
-}
+// Custom: YAML format
+.kv({
+    serialize: (data) => ({
+        filename: 'settings.yaml',
+        content: YAML.stringify(data),
+    }),
+})
 ```
 
 ## Desired End State
@@ -218,17 +242,18 @@ import {
 export const tabManager = createTabManagerWorkspace()
     .withWorkspaceExtension('materializer', (ctx) =>
         createMaterializer(ctx, {
-            directory: join(import.meta.dir, 'tab-manager'),
+            dir: join(import.meta.dir, 'tab-manager'),
         })
         .table('savedTabs', { serialize: slugFilename('title') })
         .table('bookmarks', { serialize: slugFilename('title') })
-        // devices: default (all fields as markdown frontmatter, devices/{id}.md)
+        .table('devices')
+        .kv()
     );
 
 // Fuji — custom serialize with document content via closure
 export const fuji = createFujiWorkspace()
     .withWorkspaceExtension('materializer', (ctx) =>
-        createMaterializer(ctx, { directory: import.meta.dir })
+        createMaterializer(ctx, { dir: import.meta.dir })
         .table('entries', {
             dir: 'fuji',
             serialize: async (row) => markdown({
@@ -249,6 +274,7 @@ export const fuji = createFujiWorkspace()
                 filename: toSlugFilename(row.title, row.id),
             }),
         })
+        .kv()
     );
 ```
 
@@ -258,7 +284,7 @@ export const fuji = createFujiWorkspace()
 export const opensidian = createWorkspace(opensidianDefinition)
     .withWorkspaceExtension('materializer', (ctx) =>
         createMaterializer(ctx, {
-            directory: join(import.meta.dir, 'data'),
+            dir: join(import.meta.dir, 'data'),
         })
         .table('files', {
             serialize: async (row) => {
@@ -297,7 +323,7 @@ export const opensidian = createWorkspace(opensidianDefinition)
 
 ```typescript
 // Materialize devices as individual JSON files instead of markdown
-createMaterializer(ctx, { directory: '...' })
+createMaterializer(ctx, { dir: '...' })
     .table('devices', {
         serialize: (row) => ({
             filename: `${row.id}.json`,
@@ -322,7 +348,7 @@ createMaterializer(ctx, { directory: '...' })
 
 ### Factory
 
-- `createMaterializer(ctx, config)` — factory: resource first (extension context), config second
+- `createMaterializer(ctx, { dir })` — factory: resource first (extension context), config second
 
 ### Serialize presets (markdown — return `SerializeResult`)
 
@@ -378,11 +404,15 @@ The materializer writes files. It doesn't care about format. Markdown-specific l
 
 ### 2. Factory function pattern: resource first, config second
 
-`createMaterializer(ctx, { directory })` follows the universal factory function signature. `ctx` is the resource (structurally typed as `{ tables, kv }` — receives the extension context directly). `{ directory }` is the config. Two args max.
+`createMaterializer(ctx, { dir })` follows the universal factory function signature. `ctx` is the resource (structurally typed as `{ tables, kv }`—receives the extension context directly). `{ dir }` is the config. Two args max. `dir` is used consistently for both base path and table subdirectory—context makes the meaning clear.
 
-### 3. Default-materialize-all with `.table()` overrides
+### 3. Opt-in materialization, not default-materialize-all
 
-All tables materialize with sensible defaults (markdown frontmatter, `{id}.md`). Chain `.table(name, config)` only for tables that need customization. `.skip(name)` for tables that shouldn't materialize (internal state, binary data). This minimizes config for simple cases.
+Nothing materializes until you call `.table()` or `.kv()`. This is the right default for an extension that writes to the filesystem:
+- No surprise files when adding tables to a workspace definition
+- No `.skip()` / `.skipKv()` needed—the API surface is purely additive
+- Explicit enumeration: every `.table()` line is a conscious decision
+- In practice, most tables need serialize customization anyway
 
 ### 4. Typed table names via generic + `keyof`
 
@@ -396,9 +426,9 @@ All tables materialize with sensible defaults (markdown frontmatter, `{id}.md`).
 
 Each row materializes as one file. There is no "dump entire table to one file" mode. That's an export concern, not a materialization concern. KV is the exception because it's naturally a flat structure.
 
-### 7. KV → one JSON file
+### 7. KV → one JSON file (opt-in)
 
-All KV data materializes to `{directory}/kv.json` by default. Live updates via `kv.observeAll()` (verified — exists in workspace API). `.skipKv()` to disable.
+KV materializes only when `.kv()` is called. Default: `{dir}/kv.json` with JSON.stringify. Custom serialize for other formats. Live updates via `kv.observeAll()`.
 
 ### 8. `markdown()` helper applies wikilink conversion
 
@@ -421,13 +451,14 @@ All consumers in the monorepo must be migrated in the same commit.
 
 ## MUST DO
 
-- Implement `createMaterializer(ctx, config)` factory where ctx is structurally typed as `{ tables, kv }` — receives extension context directly
+- Implement `createMaterializer(ctx, { dir })` factory where ctx is structurally typed as `{ tables, kv }`
 - Generic type parameters on factory for `TTables` and `TKv` — infer from ctx arg
 - `.table(name, config)` validates name as `keyof TTables`, infers row type for serialize callback
 - General serialize contract: `{ filename: string; content: string }`
 - `markdown()` helper: `{ frontmatter, body, filename }` → `{ filename, content }` with wikilink conversion
-- Default materialization: all tables, markdown frontmatter, `{id}.md`, `{directory}/{tableName}/`
-- KV materialization: `{directory}/kv.json` by default, live updates via `kv.observeAll()`, `.skipKv()` to disable
+- Opt-in materialization: nothing by default, `.table()` opts in per table, `.kv()` opts in KV
+- Default table serialize (when `.table()` called without serialize): all fields as markdown frontmatter, `{id}.md`
+- `.kv()` default: `{dir}/kv.json` with JSON.stringify. Custom serialize receives typed KV snapshot.
 - Rename serialize presets: `slugFilename(field)`, `bodyField(field)`
 - Export standalone utilities: `toSlugFilename(title, id)`, `toIdFilename(id)`
 - Delete `apps/fuji/src/lib/materializer.ts`
@@ -443,16 +474,20 @@ All consumers in the monorepo must be migrated in the same commit.
 - Do not support table → one file (all rows in single file)
 - Do not add new dependencies to `packages/workspace`
 - Do not modify `packages/workspace/src/workspace/types.ts`
-- Do not remove `toMarkdown` utility — it's still needed by the `markdown()` helper
+- Do not remove `toMarkdown` utility—it's still needed by the `markdown()` helper
+- Do not add `.skip()` or `.skipKv()`—opt-in model makes them unnecessary
 
 ## Resolved Open Questions
 
 | # | Issue | Resolution |
 |---|---|---|
-| 1 | Preset names don't indicate markdown | **JSDoc** — add `@remarks Produces markdown output via markdown() internally` to each preset. Short names are fine for call-site readability since the default IS markdown. |
-| 2 | Default-materialize-all assumptions | **JSDoc** on `createMaterializer` + `.skip()` — document that `.skip()` should be used for non-content tables (internal state, binary data). |
-| 3 | KV observation | **Resolved** — `kv.observe(key, cb)` and `kv.observeAll(cb)` both exist in workspace API. Live KV materialization works. |
-| 4 | `markdown()` link conversion opt-out | **JSDoc** — document `toMarkdown()` as the escape hatch for markdown without link conversion. Already exported. |
-| 5 | `whenReady` timing | **JSDoc** on builder's `whenReady` — note lazy start. All `.table()`, `.skip()`, `.skipKv()` calls complete synchronously before framework accesses `whenReady`. |
-| 6 | `.kv({ skip: true })` inconsistency | **API fix** — replaced with `.skipKv()` for consistency with `.skip('tableName')` pattern. |
-| 7 | `MaybePromise<T>` duplication | **Resolved** — already defined in `packages/workspace/src/workspace/lifecycle.ts`, exported from `index.ts`. Import it, don't redefine. |
+| 1 | Preset names don't indicate markdown | **JSDoc** — `@remarks Produces markdown output via markdown() internally`. Short names fine for readability. |
+| 2 | Default-materialize-all assumptions | **API fix** — switched to opt-in. No defaults, no assumptions about table content. |
+| 3 | KV observation | **Resolved** — `kv.observeAll(cb)` exists. Live materialization works. |
+| 4 | `markdown()` link conversion opt-out | **JSDoc** — `toMarkdown()` is the escape hatch (pure, no links). |
+| 5 | `whenReady` timing | **JSDoc** — lazy start after all `.table()`/`.kv()` calls complete synchronously. |
+| 6 | `.kv({ skip })` vs `.skipKv()` | **API fix** — eliminated both. Opt-in model means no skip needed. |
+| 7 | `MaybePromise<T>` | **Resolved** — import from `lifecycle.ts`. |
+| 8 | `directory` vs `dir` | **API fix** — `dir` everywhere. Short, consistent. Context makes base path vs subfolder obvious. |
+| 9 | KV serialize/overrides | **API fix** — `.kv({ serialize })` receives typed KV snapshot, returns `SerializeResult`. |
+| 10 | Global default serialize | **No** — would be `Record<string, unknown>` (untyped), defeating row type inference. Built-in default is always safe. Two-line repetition is fine. |

--- a/specs/20260412T151815-breddit.md
+++ b/specs/20260412T151815-breddit.md
@@ -1,0 +1,280 @@
+# Breddit — Browse + Edit Your Reddit Data
+
+**Date**: 2026-04-12
+**Status**: Draft
+**Author**: AI-assisted
+
+## Overview
+
+Breddit is a local-first app for browsing, searching, and annotating your Reddit history. Drop in a Reddit GDPR export ZIP, and Breddit loads your posts, comments, votes, messages, and saved content into a searchable, offline workspace. Your data stays on your device — no servers, no accounts.
+
+## Motivation
+
+### Current State
+
+Reddit lets you [request a copy of your data](https://support.reddithelp.com/hc/en-us/articles/360043048352) as a ZIP of 38 CSV files. What you get is a pile of CSVs with no way to browse them. The only existing tool is [reddit-gdpr-export-viewer](https://github.com/guilamu/reddit-gdpr-export-viewer) — a basic web page that renders raw CSV rows.
+
+Epicenter already has a fully-typed Reddit ingest pipeline in `packages/workspace/src/ingest/reddit/` that:
+- Parses the ZIP (handles split CSVs, BOM, encoding)
+- Validates and transforms 24 CSV files via arktype schemas
+- Maps them to 24 workspace tables + 2 KV entries
+- Strips PII (IP addresses), skips redundant files (headers variants)
+- Handles edge cases (missing files, malformed rows, variant export formats)
+
+This code is currently dead — zero external consumers. It should be the data layer of an app.
+
+### Desired State
+
+A Svelte + Tauri desktop app (with a web fallback) where users can:
+
+1. **Import**: Drop a Reddit export ZIP → see import progress → data loaded
+2. **Browse**: Navigate posts, comments, saved items, messages by subreddit, date, type
+3. **Search**: Full-text search across all content
+4. **Annotate**: Add personal notes/tags to any post or comment (local-only, not on Reddit)
+5. **Export**: Export filtered subsets as JSON/CSV/Markdown
+
+## Research Findings
+
+### What's Already Built
+
+The ingest pipeline is production-quality. Here's what exists:
+
+```
+packages/workspace/src/ingest/reddit/
+├── parse.ts         → ZIP → raw CSV records (handles splits, BOM, encoding)
+├── csv-schemas.ts   → 24 arktype schemas that validate + transform in one pass
+├── transforms.ts    → Shared morphs (emptyToNull, parseDateToIso)
+├── workspace.ts     → defineWorkspace with 24 tables + 2 KV entries
+├── index.ts         → importRedditExport() orchestrator with progress callback
+└── README.md        → Exhaustive documentation of all 38 CSV files
+```
+
+| Component | Status | Quality |
+|---|---|---|
+| ZIP parsing | ✅ Complete | Handles split CSVs, BOM, missing files |
+| CSV→table schemas | ✅ Complete | 24 schemas, all with ID strategies documented |
+| Workspace definition | ✅ Complete | 24 tables, 2 KV entries, typed |
+| Import orchestrator | ✅ Complete | Progress callback, error recovery, stats |
+| Preview (dry-run) | ✅ Complete | `previewRedditExport()` returns row counts |
+| Tests | ✅ Complete | `index.test.ts`, `parse.test.ts` |
+| Documentation | ✅ Complete | Every CSV file accounted for, exclusion rationale documented |
+
+### What Needs to Be Built
+
+| Component | Effort | Description |
+|---|---|---|
+| App scaffold (`apps/breddit/`) | ~1 hour | SvelteKit + Tauri, same pattern as whispering/opensidian |
+| UI: Import page | ~2 hours | File drop zone, progress bar, stats summary |
+| UI: Browse views | ~1 day | Tabs for posts/comments/saved/messages, subreddit grouping |
+| UI: Search | ~half day | Full-text search across post/comment bodies |
+| UI: Annotation layer | ~half day | Personal notes/tags per row (additional workspace table) |
+| UI: Export | ~2 hours | Filter → JSON/CSV/Markdown download |
+| Move ingest code | ~1 hour | `packages/workspace/src/ingest/reddit/` → `apps/breddit/src/lib/workspace/` |
+
+### Reddit Export Characteristics
+
+From the existing README and workspace definition:
+
+- **Typical export size**: 5–50 MB ZIP (depends on account age and activity)
+- **Row counts**: Power users have 10K–50K post_votes, 5K–20K comment_votes, 1K–10K comments, 500–5K posts
+- **Our benchmarks**: 10K row insert = 112ms, 50K = 2.7s — manageable with progress bar
+- **Memory**: 10K small rows = 782 KB. Even 50K rows of votes = ~4 MB. Fine for browser.
+
+### Competitive Landscape
+
+| Tool | What it does | Limitation |
+|---|---|---|
+| [reddit-gdpr-export-viewer](https://github.com/guilamu/reddit-gdpr-export-viewer) | Renders CSV tables in a web page | No search, no annotation, no offline persistence |
+| Reddit's own data page | Lists your posts/comments on reddit.com | Requires internet, limited to recent activity |
+| Various Reddit scrapers | Pull data via API | Violate ToS, rate-limited, incomplete |
+
+Nobody offers a local-first, offline, searchable Reddit archive with annotation.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Move ingest code into app | Yes, into `apps/breddit/src/lib/workspace/` | The workspace definition is app-specific (24 Reddit tables). It doesn't belong in the core workspace package. |
+| Keep `shared/snakify.ts` | Move alongside ingest code | Only consumer is the Reddit importer; co-locate with it |
+| App framework | SvelteKit + Tauri (web fallback) | Matches existing apps (whispering, opensidian). Desktop for file system access, web for quick tryout. |
+| Annotation storage | Additional workspace table (`annotations`) | Keeps user notes separate from imported data. Can be synced independently. |
+| Search approach | In-memory filter initially, SQLite materializer later | Good enough for 50K rows. If needed, the existing (currently unused) SQLite materializer can power full-text search. |
+| Initial scope | Import + Browse + Search | Annotation and export are Phase 2. Ship something useful fast. |
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  apps/breddit/                                                       │
+│                                                                      │
+│  ┌──────────────────────────────────────────────────────────────┐   │
+│  │  src/lib/workspace/                                          │   │
+│  │  ├── definition.ts    ← reddit workspace (24 tables, 2 KV)  │   │
+│  │  ├── workspace.ts     ← createWorkspace + isomorphic actions │   │
+│  │  ├── ingest/          ← moved from packages/workspace        │   │
+│  │  │   ├── parse.ts                                            │   │
+│  │  │   ├── csv-schemas.ts                                      │   │
+│  │  │   ├── transforms.ts                                       │   │
+│  │  │   └── snakify.ts                                          │   │
+│  │  └── index.ts         ← barrel                               │   │
+│  ├──────────────────────────────────────────────────────────────┤   │
+│  │  src/lib/client.ts    ← runtime client                       │   │
+│  │  ├── IndexedDB persistence                                   │   │
+│  │  ├── Import action (wraps importRedditExport)                │   │
+│  │  └── Search action (in-memory filter over getAllValid)        │   │
+│  ├──────────────────────────────────────────────────────────────┤   │
+│  │  src/routes/                                                  │   │
+│  │  ├── +page.svelte           ← Import landing (file drop)    │   │
+│  │  ├── posts/+page.svelte     ← Browse posts                  │   │
+│  │  ├── comments/+page.svelte  ← Browse comments               │   │
+│  │  ├── saved/+page.svelte     ← Saved posts + comments        │   │
+│  │  ├── messages/+page.svelte  ← DMs + chat history            │   │
+│  │  ├── votes/+page.svelte     ← Voting history                │   │
+│  │  └── search/+page.svelte    ← Full-text search              │   │
+│  └──────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Data Flow
+
+```
+IMPORT FLOW:
+────────────
+User drops ZIP
+  │
+  ▼
+previewRedditExport(zip)
+  │ → Shows: "Found 12,482 posts, 3,291 comments, 45,102 votes..."
+  │ → User confirms
+  ▼
+importRedditExport(zip, workspace, { onProgress })
+  │ → Progress bar: "Importing posts... 45%"
+  │ → Phase 1: ZIP → raw CSV (single pass, ~100ms for 20MB)
+  │ → Phase 2: Transform + insert (chunked, ~2-5s for 50K rows)
+  ▼
+Done → redirect to /posts
+
+BROWSE FLOW:
+────────────
+/posts → tables.posts.getAllValid()
+  │ → sorted by date desc
+  │ → grouped by subreddit (client-side)
+  │ → paginated (virtual scroll for 10K+ rows)
+
+SEARCH FLOW:
+────────────
+/search?q=typescript
+  │ → tables.posts.filter(p => p.body?.includes(q) || p.title?.includes(q))
+  │ → tables.comments.filter(c => c.body?.includes(q))
+  │ → merged, sorted by relevance (match count) then date
+```
+
+## Implementation Plan
+
+### Phase 1: App Scaffold + Import (MVP)
+
+- [ ] **1.1** Create `apps/breddit/` using SvelteKit scaffold (same pattern as `apps/zhongwen/`)
+- [ ] **1.2** Move `packages/workspace/src/ingest/reddit/` → `apps/breddit/src/lib/workspace/ingest/`
+- [ ] **1.3** Move `packages/workspace/src/shared/snakify.ts` → `apps/breddit/src/lib/workspace/ingest/snakify.ts`
+- [ ] **1.4** Move `packages/workspace/src/ingest/utils/csv.ts` → `apps/breddit/src/lib/workspace/ingest/csv.ts`
+- [ ] **1.5** Update all internal imports in moved files
+- [ ] **1.6** Create `definition.ts` with the reddit workspace definition (moved from `workspace.ts`)
+- [ ] **1.7** Create `workspace.ts` factory with import action using `defineMutation`
+- [ ] **1.8** Create `client.ts` with IndexedDB persistence
+- [ ] **1.9** Build import page: file drop zone → preview → confirm → progress bar → done
+- [ ] **1.10** Remove `packages/workspace/src/ingest/` directory and its package.json subpath exports
+- [ ] **1.11** Verify all workspace package tests still pass
+
+### Phase 2: Browse Views
+
+- [ ] **2.1** Posts page: table view with subreddit filter, date sort, pagination
+- [ ] **2.2** Comments page: grouped by parent post permalink, chronological
+- [ ] **2.3** Saved page: tabbed (saved posts / saved comments)
+- [ ] **2.4** Messages page: threaded by `thread_id`, chronological within thread
+- [ ] **2.5** Votes page: split by post votes / comment votes, grouped by subreddit
+- [ ] **2.6** Stats dashboard: show account statistics from KV store (karma, account age, etc.)
+
+### Phase 3: Search
+
+- [ ] **3.1** Search page with query input
+- [ ] **3.2** In-memory filter across posts (title + body) and comments (body)
+- [ ] **3.3** Result ranking: exact match > partial match, sorted by date
+- [ ] **3.4** Link results back to browse views
+
+### Phase 4: Annotations + Export (stretch)
+
+- [ ] **4.1** Add `annotations` table to workspace definition: `{ id, targetTable, targetId, note, tags[], createdAt }`
+- [ ] **4.2** Annotation UI: add note/tags to any post or comment row
+- [ ] **4.3** Export: filter by subreddit/date/type/tag → JSON/CSV/Markdown download
+
+## Edge Cases
+
+### Large exports (50K+ votes)
+
+1. User imports an account with 50K post_votes
+2. `importRedditExport` takes ~3 seconds for the insert phase
+3. Progress bar keeps UI responsive (already has `onProgress` callback)
+4. Browse view uses virtual scrolling — never renders 50K DOM nodes
+
+### Missing CSV files
+
+1. Some exports are incomplete (Reddit sometimes omits files)
+2. The importer defaults missing files to empty arrays — no crash
+3. Browse views show "No data" for empty tables
+4. Import stats show exactly what was found vs missing
+
+### Variant export formats
+
+1. Some exports have `messages.csv`, others have `messages_archive.csv`
+2. The importer already handles both variants (documented in README)
+3. Both map to their respective tables
+
+### Re-import
+
+1. User imports a newer export over an existing one
+2. `createWorkspace` with same ID reuses the Y.Doc
+3. `set()` with existing IDs updates rows (same reddit post ID = same row)
+4. New rows are added, deleted content remains (CRDT append-only)
+5. Consider adding a "Clear and re-import" action for clean slate
+
+## Open Questions
+
+1. **Should Breddit support multiple Reddit accounts?**
+   - Option A: One workspace per account (workspace ID = reddit username)
+   - Option B: Single workspace, add `username` column to every table
+   - **Recommendation**: Option A. Cleaner data isolation, simpler queries. Switch between accounts via workspace selector.
+
+2. **Should we add Reddit API integration for live data?**
+   - Could fetch current vote counts, comment threads, etc.
+   - Requires Reddit OAuth app registration
+   - **Recommendation**: Defer. GDPR export is the core value prop. API integration is a separate feature.
+
+3. **Should search use the SQLite materializer?**
+   - In-memory `filter()` works fine for <50K rows
+   - SQLite would enable proper full-text search with ranking
+   - The materializer code exists but is currently unused
+   - **Recommendation**: Start with in-memory filter. If users hit search performance issues, wire up the SQLite materializer — it would go from "dead code" to "justified dependency."
+
+4. **Desktop-only or web too?**
+   - Tauri gives native file picker for ZIP import
+   - Web version works but requires `<input type="file">` instead
+   - **Recommendation**: Both. Same SvelteKit app, Tauri wraps it for desktop. File input works on web. Import is the only platform-specific part.
+
+## Success Criteria
+
+- [ ] User can drop a Reddit export ZIP and see their data in < 10 seconds
+- [ ] All 24 table types are browsable with at least a list view
+- [ ] Search returns results across posts and comments in < 500ms for 50K rows
+- [ ] Data persists across app restarts (IndexedDB)
+- [ ] Works offline after initial import
+- [ ] `packages/workspace/src/ingest/` is deleted — Breddit owns the code now
+
+## References
+
+- `packages/workspace/src/ingest/reddit/` — existing ingest pipeline to move
+- `packages/workspace/src/ingest/reddit/README.md` — exhaustive CSV file documentation
+- `packages/workspace/src/shared/snakify.ts` — dependency to co-locate
+- `packages/workspace/src/ingest/utils/csv.ts` — CSV parser dependency
+- `apps/zhongwen/` — reference SvelteKit + Tauri app scaffold
+- `apps/tab-manager/` — reference for workspace file structure pattern
+- [Reddit data request](https://support.reddithelp.com/hc/en-us/articles/360043048352) — how users get their export

--- a/specs/20260412T151815-workspace-performance-and-dead-code-cleanup.md
+++ b/specs/20260412T151815-workspace-performance-and-dead-code-cleanup.md
@@ -1,7 +1,7 @@
 # Workspace Performance Fix & Dead Code Cleanup
 
 **Date**: 2026-04-12
-**Status**: Draft
+**Status**: In Progress
 **Author**: AI-assisted (from deep audit session)
 
 ## Overview
@@ -148,26 +148,15 @@ which the observer already handles correctly.
 
 ### Wave 1: Fix O(n²) `deleteEntryByKey` (highest impact)
 
-- [ ] **1.1** Read `y-keyvalue-lww.ts` fully — understand `set()`, `delete()`, observer, `pending` mechanism
-- [ ] **1.2** Modify `set()`: remove the `deleteEntryByKey()` call for existing keys — just push the new entry
-- [ ] **1.3** In the observer's conflict resolution path, replace `getAllEntries().indexOf(existing)` with an entry→index `Map`:
-  ```typescript
-  let entryIndexMap: Map<YKeyValueLwwEntry<T>, number> | null = null;
-  const getEntryIndex = (entry: YKeyValueLwwEntry<T>): number => {
-      if (!entryIndexMap) {
-          const entries = getAllEntries();
-          entryIndexMap = new Map();
-          for (let i = 0; i < entries.length; i++) {
-              entryIndexMap.set(entries[i]!, i);
-          }
-      }
-      return entryIndexMap.get(entry) ?? -1;
-  };
-  ```
-- [ ] **1.4** Run existing tests: `bun test packages/workspace/src/shared/y-keyvalue/`
-- [ ] **1.5** Run benchmark tests and compare bulk update timing (target: ~60ms for 10K vs current 560ms)
-- [ ] **1.6** Run full workspace test suite: `bun test packages/workspace/`
-- [ ] **1.7** Stage and commit
+- [x] **1.1** Read `y-keyvalue-lww.ts` fully — understand `set()`, `delete()`, observer, `pending` mechanism
+- [x] **1.2** Modify `set()`: conditionally skip `deleteEntryByKey()` only when inside an outer transaction (batch case)
+  > **Note**: Originally planned to remove deleteEntryByKey unconditionally. During testing, found this caused a double-observer regression for individual (non-batched) set() calls. The fix: use `hasOuterTransaction = this.isInTransaction()` before the transaction boundary — only skip the eager delete when batched.
+- [x] **1.3** In the observer's conflict resolution path, replace `getAllEntries().indexOf(existing)` with an entry→index `Map`
+- [x] **1.4** Added observer guard for set→delete edge case in batched transactions (deletedCurrentKeys check)
+- [x] **1.5** Run existing tests: `bun test packages/workspace/src/shared/y-keyvalue/` — 149 pass
+- [x] **1.6** Run benchmark tests — all 40 pass, 25.5s (same as baseline)
+- [x] **1.7** Run full workspace test suite
+- [ ] **1.8** Stage and commit
 
 ### Wave 2: Move `ingest/` to Breddit app
 
@@ -183,16 +172,15 @@ See `specs/20260412T151815-breddit.md` Phase 1 for the full plan. Summary:
 ### Wave 3: Move `shared/snakify.ts` to Breddit
 
 - [ ] **3.1** Move `src/shared/snakify.ts` → `apps/breddit/src/lib/workspace/ingest/snakify.ts`
-- [ ] **3.2** Remove `@sindresorhus/slugify` from workspace package.json dependencies if no other consumer
+- [ ] **3.2** ~~Remove `@sindresorhus/slugify` from workspace package.json~~ **SKIP**: `slugify` is imported directly by `materializer/markdown/serializers.ts`, `apps/fuji`, and `playground/opensidian-e2e`
 - [ ] **3.3** Add `@sindresorhus/slugify` to breddit's package.json
 - [ ] **3.4** `bun install` to update lockfile
-- [ ] **3.5** Stage and commit
 
 ### Wave 4: Remove dead code — `materializer/sqlite/`
 
 - [ ] **4.1** Delete `src/extensions/materializer/sqlite/` directory (4 source files + tests)
-- [ ] **4.2** Remove `extensions/materializer/sqlite` subpath export from `package.json`
-- [ ] **4.3** Remove `drizzle-orm` and `@electric-sql/pglite` from dependencies if only used here
+- [ ] **4.2** ~~Remove `extensions/materializer/sqlite` subpath export from `package.json`~~ **SKIP**: No such export exists in package.json
+- [ ] **4.3** Remove `@electric-sql/pglite` from dependencies (unused anywhere). Keep `drizzle-orm` — it's re-exported from the workspace root barrel (`eq`, `and`, `sql`, etc.)
 - [ ] **4.4** Verify no imports break: `bun test`
 - [ ] **4.5** Stage and commit
 
@@ -209,24 +197,36 @@ See `specs/20260412T151815-breddit.md` Phase 1 for the full plan. Summary:
 - [ ] **6.2** Merge into single `src/shared/standard-schema.ts` with both the `CombinedStandardSchema` type and `standardSchemaToJsonSchema` function
 - [ ] **6.3** Update all internal imports (grep for `shared/standard-schema`)
 - [ ] **6.4** Remove the `shared/standard-schema/` directory
-- [ ] **6.5** Update any package.json subpath export if one exists
+- [ ] **6.5** ~~Update any package.json subpath export if one exists~~ **SKIP**: No such export exists
 - [ ] **6.6** Run tests, verify no breaks
 - [ ] **6.7** Stage and commit
 
-### Wave 7: Bulk import progress-bar API
+### Wave 7: Bulk import/delete progress-bar API
 
-- [ ] **7.1** Add a `bulkSet` method to `TableHelper` that chunks insertions and yields to the event loop:
+Architecture: `bulkDelete` gets a dedicated method on `YKeyValueLww` (optimized one-pass scan + batch delete). `bulkSet` does NOT need a ykv-level method — `set()` is already O(1) after Wave 1, so TableHelper just wraps it in chunked transactions.
+
+- [ ] **7.1** Add `bulkDelete(keys: string[])` method to `YKeyValueLww` in `y-keyvalue-lww.ts`:
+  - One `toArray()` scan to find all matching indices
+  - Sort indices descending, delete right-to-left (preserves indices)
+  - Wraps deletions in `doc.transact()`
+- [ ] **7.2** Add `bulkDelete(keys)` delegation to `EncryptedYKeyValueLww` — just calls `inner.bulkDelete(keys)`
+- [ ] **7.3** Add `bulkSet` and `bulkDelete` methods to `TableHelper` type in `types.ts`:
   ```typescript
   async bulkSet(rows: TRow[], options?: {
       chunkSize?: number;       // default: 1000
       onProgress?: (percent: number) => void;
   }): Promise<void>;
+
+  async bulkDelete(ids: string[], options?: {
+      chunkSize?: number;       // default: 1000
+      onProgress?: (percent: number) => void;
+  }): Promise<void>;
   ```
-- [ ] **7.2** Implement in `create-table.ts` — chunk by `chunkSize`, insert each chunk synchronously, call `onProgress`, then `await new Promise(resolve => setTimeout(resolve, 0))` to yield
-- [ ] **7.3** Add the type to `TableHelper` in `types.ts`
-- [ ] **7.4** Write tests: verify all rows inserted, verify progress callback fires, verify chunking behavior
-- [ ] **7.5** Run benchmarks to confirm each chunk stays under 16ms frame budget at default chunk size
-- [ ] **7.6** Stage and commit
+- [ ] **7.4** Implement both in `create-table.ts` — chunk by `chunkSize`, call operation per chunk, `onProgress`, yield with `setTimeout(0)`
+- [ ] **7.5** Write tests: verify all rows inserted/deleted, verify progress callback fires, verify chunking behavior
+- [ ] **7.6** Run benchmarks to confirm each chunk stays under 16ms frame budget at default chunk size
+- [ ] **7.7** Add detailed JSDoc explaining when to use `bulkSet`/`bulkDelete` vs `workspace.batch()` vs single-row ops
+- [ ] **7.8** Stage and commit
 
 ## Edge Cases
 
@@ -247,29 +247,24 @@ See `specs/20260412T151815-breddit.md` Phase 1 for the full plan. Summary:
 
 ### Wave 4: Drizzle dependency removal
 
-`drizzle-orm` was re-exported from the root barrel (now removed). But it might still be a dependency for the markdown materializer or other internal code. Must verify before removing from package.json.
+**Resolved**: `drizzle-orm` is re-exported from the workspace root barrel (`eq`, `and`, `sql`, etc.) per the README. Cannot be removed. Only `@electric-sql/pglite` can be removed (unused anywhere in the repo).
 
 ### Wave 6: Standard-schema subpath export
 
-If `@epicenter/workspace/shared/standard-schema` is a package.json subpath export, removing the directory would break the export. Must check and update package.json.
+**Resolved**: No `shared/standard-schema` subpath export exists in package.json. Safe to merge without export changes.
 
-## Open Questions
+## Open Questions (Resolved)
 
 1. **Should `delete()` also defer to the observer?**
-   - Currently `delete()` still does the O(n) `deleteEntryByKey` scan
-   - Option A: Leave as-is (delete is rare, benchmarks show 29.5µs per delete at 10K)
-   - Option B: Defer to observer (same pattern as `set()` fix)
-   - **Recommendation**: Leave as-is (Option A). Delete is infrequent. Optimize only if benchmarks show a problem.
+   - **Decision**: No. Leave as-is (Option A). Single delete is 29.5µs at 10K — negligible.
+   - Bulk delete is handled by the new `bulkDelete()` method which does a one-pass scan.
+   - Consistency lives at the bulk API level, not the single-op level.
 
 2. **Should removed dead code go to an archive branch?**
-   - Option A: Just delete — git history preserves it
-   - Option B: Create `archive/ingest`, `archive/materializer-sqlite` branches
-   - **Recommendation**: Just delete (Option A). Git blame and `git log --all -- path` find anything.
+   - **Decision**: Just delete (Option A). Git history preserves everything.
 
 3. **Should `bulkSet` wrap in `ydoc.transact()`?**
-   - Wrapping the whole bulk in one transaction defers observer until the end — better performance but larger memory spike
-   - Wrapping each chunk in its own transaction fires observer per chunk — more incremental but more overhead
-   - **Recommendation**: One transaction per chunk. Matches the progress-bar pattern (state updates per chunk) and keeps memory bounded.
+   - **Decision**: One transaction per chunk. Matches progress-bar pattern, keeps memory bounded.
 
 ## Success Criteria
 
@@ -279,8 +274,10 @@ If `@epicenter/workspace/shared/standard-schema` is a package.json subpath expor
 - [ ] No `@epicenter/workspace/extensions/materializer/sqlite` subpath exists
 - [ ] No `@epicenter/workspace/extensions/persistence/sqlite` subpath exists
 - [ ] `shared/standard-schema/` directory no longer exists; single file replaces it
-- [ ] `bulkSet` method exists on `TableHelper` with `onProgress` callback
-- [ ] `snakify.ts` no longer exists; `@sindresorhus/slugify` removed if unused elsewhere
+- [ ] `bulkSet` and `bulkDelete` methods exist on `TableHelper` with `onProgress` callback
+- [ ] `bulkDelete` method exists on `YKeyValueLww` (optimized batch algorithm)
+- [ ] `EncryptedYKeyValueLww` delegates `bulkDelete` to inner
+- [ ] `snakify.ts` no longer exists in workspace package; `@sindresorhus/slugify` stays (has other consumers)
 
 ## References
 

--- a/specs/20260412T151815-workspace-performance-and-dead-code-cleanup.md
+++ b/specs/20260412T151815-workspace-performance-and-dead-code-cleanup.md
@@ -87,7 +87,7 @@ Storage is not a concern with `gc: true`.
 | Fix O(n²) update | Defer delete to observer | Observer already handles this for sync conflicts; reuse existing dedup |
 | Build entry→index map | In observer, from single `toArray()` | O(n) build once + O(1) per lookup vs O(n) per `indexOf` call |
 | Keep `delete()` as O(n) | Accepted | `delete()` is rare (benchmarks confirm), not worth the complexity |
-| Remove ingest/ | Delete, don't extract | Zero consumers, no evidence anyone wants it as a package |
+| Move ingest/ to Breddit app | Move, don't delete | See `specs/20260412T151815-breddit.md` — ingest code becomes Breddit's data layer |
 | Remove materializer/sqlite/ | Delete | Zero consumers; can be rebuilt if needed |
 | Remove persistence/sqlite.ts | Delete | Zero consumers; indexeddb covers all current apps |
 | Merge standard-schema/ | Single file | 3 files for 2 exports is unnecessary indirection |
@@ -169,20 +169,24 @@ which the observer already handles correctly.
 - [ ] **1.6** Run full workspace test suite: `bun test packages/workspace/`
 - [ ] **1.7** Stage and commit
 
-### Wave 2: Remove dead code — `ingest/`
+### Wave 2: Move `ingest/` to Breddit app
 
-- [ ] **2.1** Delete `src/ingest/` directory (7 source files + tests)
-- [ ] **2.2** Delete `scripts/reddit-import-test.ts` if it exists
-- [ ] **2.3** Remove `ingest` and `ingest/reddit` subpath exports from `package.json`
-- [ ] **2.4** Verify no imports break: `bun test`
-- [ ] **2.5** Stage and commit
+See `specs/20260412T151815-breddit.md` Phase 1 for the full plan. Summary:
 
-### Wave 3: Remove dead code — `shared/snakify.ts`
+- [ ] **2.1** Create `apps/breddit/` scaffold
+- [ ] **2.2** Move `src/ingest/reddit/` → `apps/breddit/src/lib/workspace/ingest/`
+- [ ] **2.3** Move `src/ingest/utils/csv.ts` alongside
+- [ ] **2.4** Remove `ingest` and `ingest/reddit` subpath exports from workspace `package.json`
+- [ ] **2.5** Verify workspace package tests still pass
+- [ ] **2.6** Stage and commit
 
-- [ ] **3.1** Delete `src/shared/snakify.ts`
-- [ ] **3.2** Remove `@sindresorhus/slugify` from package.json dependencies if no other consumer
-- [ ] **3.3** `bun install` to update lockfile
-- [ ] **3.4** Stage and commit
+### Wave 3: Move `shared/snakify.ts` to Breddit
+
+- [ ] **3.1** Move `src/shared/snakify.ts` → `apps/breddit/src/lib/workspace/ingest/snakify.ts`
+- [ ] **3.2** Remove `@sindresorhus/slugify` from workspace package.json dependencies if no other consumer
+- [ ] **3.3** Add `@sindresorhus/slugify` to breddit's package.json
+- [ ] **3.4** `bun install` to update lockfile
+- [ ] **3.5** Stage and commit
 
 ### Wave 4: Remove dead code — `materializer/sqlite/`
 


### PR DESCRIPTION
The markdown materializer started life as a single monolithic function that owned serialization, file writing, and Yjs observation all at once. That was fine while the API was still being figured out, but the spec kept moving—closure-based document access, opt-in materialization, factory composition—so the implementation had to stop pretending the shape was settled.

This PR follows that path and lands on a workspace-bound `createMaterializer(...)` factory. The materializer now plugs into the extension chain, waits for `whenReady` before reading state, and lets each table or KV namespace opt in explicitly instead of forcing everything through one big markdown path.

```ts
// before: one function did everything
markdownMaterializer({ directory: './data', tables })

// after: compose the materializer at the workspace boundary
.withWorkspaceExtension('materializer', (ctx) =>
  createMaterializer(ctx, { dir: './data' })
    .table('posts', { serialize: slugFilename('title') })
    .kv(),
)
```

While getting there, the repeated “compute once inside an observer” pattern got pulled into a reusable `lazy()` helper so those caches stop being hand-rolled in three different places.

```ts
const getAllEntries = lazy(() => yarray.toArray())

const entries = getAllEntries()
```

That cleanup also exposed a real scaling bug in `YKeyValueLww`: bulk updates were re-scanning the array on every write, which made the hot path quadratic. The fix batches the conflict cleanup so the observer resolves the batch once instead of repeatedly walking the same data.

There’s also a short article on the lazy initializer pattern, plus doc updates to keep the workspace docs aligned with the current API instead of the older chaining examples.

Stacks on #1649. 13 commits, 14 files changed, +1322/-438.