### PR TITLE
feat(fuji): migrate view state to URL search params + UI/a11y polish

### DIFF
--- a/.agents/skills/define-errors/SKILL.md
+++ b/.agents/skills/define-errors/SKILL.md
@@ -8,7 +8,7 @@ metadata:
 
 # defineErrors
 
-> **Related Skills**: See `error-handling` for trySync/tryAsync usage. See `services-layer` for service architecture and namespace exports.
+> **Related Skills**: See `error-handling` for trySync/tryAsync usage and toast-on-error patterns. See `services-layer` for service architecture and namespace exports.
 
 ## When to Apply This Skill
 
@@ -42,6 +42,15 @@ import {
 7. Use `InferError<typeof FooError.Variant>` to extract a single variant's type when needed
 8. **Variant names describe the specific failure mode** — never use generic names like `Service`, `Error`, or `Failed`
 9. Aim for 2–5 variants per domain, each named by failure mode
+10. **Write `.message` for end-user readability** — `toastOnError` shows `.message` as the muted toast description below the bold title. Write messages that make sense to users, not just developers. Avoid raw paths, status codes, or stack traces as the primary message. Include them after a human-readable prefix:
+
+```typescript
+// ✅ GOOD — human-readable prefix, technical detail after
+message: `Could not save recording: ${extractErrorMessage(cause)}`
+
+// ❌ BAD — raw technical output as the entire message
+message: `POST /api/recordings 500: ${extractErrorMessage(cause)}`
+```
 
 ## Patterns
 

--- a/.agents/skills/error-handling/SKILL.md
+++ b/.agents/skills/error-handling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: error-handling
-description: Error handling patterns using wellcrafted trySync and tryAsync. Use when writing or reviewing try-catch blocks, refactoring try-catch to linear control flow, working with Result types, or returning HTTP error responses from route handlers.
+description: Error handling patterns using wellcrafted trySync and tryAsync, and toastOnError for surfacing errors to users. Use when writing or reviewing try-catch blocks, refactoring try-catch to linear control flow, working with Result types, showing error toasts, or returning HTTP error responses from route handlers.
 metadata:
   author: epicenter
   version: '2.0'
@@ -23,6 +23,7 @@ Use this pattern when you need to:
 Load these on demand based on what you're working on:
 
 - If working with **wrapping boundaries, minimal vs extended wrapping, or immediate-return control flow**, read [references/wrapping-patterns.md](references/wrapping-patterns.md)
+- If working with **toast notifications for errors** (`toastOnError`, `extractErrorMessage` in UI), read [references/toast-on-error.md](references/toast-on-error.md)
 - If working with **real-world codebase examples and wrapping scenario guidelines**, read [references/real-world-examples.md](references/real-world-examples.md)
 - If working with **HTTP route handlers and status-response error conversion**, read [references/http-handlers.md](references/http-handlers.md)
 

--- a/.agents/skills/error-handling/references/toast-on-error.md
+++ b/.agents/skills/error-handling/references/toast-on-error.md
@@ -1,0 +1,106 @@
+# Toast-on-Error Patterns
+
+How to surface errors to users via toast notifications across the monorepo.
+
+## The `toastOnError` Passthrough
+
+`toastOnError` from `@epicenter/ui/sonner` is a passthrough function inspired by Rust's `inspect_err`. It shows a toast and returns the input unchanged—so you can slot it into `return` statements or `.then()` chains without disrupting control flow.
+
+It accepts either a `Result<T, AnyTaggedError>` or a bare `AnyTaggedError`.
+
+- **Title** (bold headline): provided at the call site—this is UI copy, not a service concern.
+- **Description** (muted text below): always `error.message` from the tagged error, shown automatically.
+
+```typescript
+import { toastOnError } from '@epicenter/ui/sonner';
+```
+
+## Preferred Pattern: Destructure First, Then Toast-and-Return
+
+Always destructure the Result first, then use `toastOnError` in the error guard. Never mix `.then()` with `await` on the same expression.
+
+```typescript
+// ✅ GOOD — destructure, then one-liner error guard
+const { data, error } = await api.billing.portal();
+if (error) return toastOnError(error, 'Could not open billing portal');
+if (data.url) window.location.href = data.url;
+
+// ❌ BAD — mixing .then() with await
+const { data, error } = await api.billing.portal().then(r => toastOnError(r, '...'));
+```
+
+## Fire-and-Forget Pattern
+
+For onclick handlers where you don't need the result, use `.then()`:
+
+```typescript
+// ✅ Fire-and-forget — no await, no destructuring
+bookmarkState.toggle(tab).then((r) => toastOnError(r, 'Failed to toggle bookmark'));
+savedTabState.save(tab).then((r) => toastOnError(r, 'Failed to save tab'));
+```
+
+## When NOT to Use `toastOnError`
+
+### Catch blocks with `unknown` errors
+
+`toastOnError` requires `AnyTaggedError` (from `defineErrors`). Raw `catch (err)` blocks have `unknown` errors—use `extractErrorMessage` instead:
+
+```typescript
+import { extractErrorMessage } from 'wellcrafted/error';
+
+// ✅ catch blocks — use extractErrorMessage
+try {
+    await riskyOperation();
+} catch (err) {
+    toast.error('Operation failed', { description: extractErrorMessage(err) });
+}
+
+// ✅ tryAsync catch handlers — same pattern
+await tryAsync({
+    try: () => someOperation(),
+    catch: (error) => {
+        toast.error('Failed', { description: extractErrorMessage(error) });
+        return Ok(undefined);
+    },
+});
+```
+
+### TanStack Query `onError` callbacks
+
+Errors from mutation rejection may not be tagged errors. Use `extractErrorMessage`:
+
+```typescript
+// ✅ TanStack onError — extractErrorMessage for unknown error types
+topUp.mutate(url, {
+    onError: (error) => toast.error('Top-up failed', {
+        description: extractErrorMessage(error),
+    }),
+});
+```
+
+### Toasts with extra options (actions, custom duration)
+
+`toastOnError` only sets `title` + `description`. If you need `action`, `duration`, or other Sonner options, call `toast.error()` directly:
+
+```typescript
+// ✅ Needs action button — use toast.error directly
+if (error) {
+    toast.error('Failed to open accessibility settings', {
+        description: error.message,
+        action: {
+            label: 'Open Settings',
+            onClick: () => openSystemSettings(),
+        },
+    });
+}
+```
+
+## Decision Table
+
+| Situation | Pattern |
+|---|---|
+| Result with tagged error, need to handle data | `if (error) return toastOnError(error, 'title')` |
+| Result, fire-and-forget | `.then((r) => toastOnError(r, 'title'))` |
+| `catch` block, `unknown` error | `toast.error('title', { description: extractErrorMessage(err) })` |
+| TanStack `onError` callback | `toast.error('title', { description: extractErrorMessage(error) })` |
+| Toast needs action/duration/id | `toast.error('title', { description: error.message, action: ... })` |

--- a/.agents/skills/query-layer/SKILL.md
+++ b/.agents/skills/query-layer/SKILL.md
@@ -14,7 +14,7 @@ metadata:
 
 The query layer is the reactive bridge between UI components and the service layer. It wraps pure service functions with caching, reactivity, and state management using TanStack Query and WellCrafted factories.
 
-> **Related Skills**: See `services-layer` for the service layer these queries consume. See `svelte` for Svelte-specific TanStack Query patterns.
+> **Related Skills**: See `services-layer` for the service layer these queries consume. See `svelte` for Svelte-specific TanStack Query patterns. See `error-handling` for toast-on-error patterns—how errors from Results surface to users via `toastOnError` and `extractErrorMessage`.
 
 ## When to Apply This Skill
 
@@ -114,24 +114,24 @@ Use in event handlers and workflows without reactive overhead:
 ```typescript
 // In an event handler or workflow
 async function handleTransform(recordingId: string, transformation: Transformation) {
-	const { error } = await rpc.transformer.transformRecording.execute({
+	const { error } = await rpc.transformer.transformRecording({
 		recordingId,
 		transformation,
 	});
 	if (error) {
-		notify.error.execute(error);
+		notify.error(error);
 		return;
 	}
-	notify.success.execute({ title: 'Transformation complete' });
+	notify.success({ title: 'Transformation complete' });
 }
 
 // In a sequential workflow
 async function stopAndTranscribe(toastId: string) {
 	const { data: blobData, error: stopError } =
-		await rpc.recorder.stopRecording.execute({ toastId });
+		await rpc.recorder.stopRecording({ toastId });
 
 	if (stopError) {
-		notify.error.execute(stopError);
+		notify.error(stopError);
 		return;
 	}
 
@@ -155,7 +155,7 @@ async function stopAndTranscribe(toastId: string) {
 2. **Use `.options` (no parentheses)** - It's a static object, wrap in accessor for Svelte
 3. **Never double-wrap errors** - Each error is wrapped exactly once
 4. **Services are pure, queries inject settings** - Services take explicit params
-5. **Use `.execute()` in `.ts` files** - `createMutation` requires component context
+5. **Use imperative calls in `.ts` files** - `createMutation` requires component context
 6. **Update cache optimistically** - Better UX for mutations
 
 ## References
@@ -168,4 +168,4 @@ Load these on demand based on what you're working on:
 
 - See `apps/whispering/src/lib/query/README.md` for detailed architecture
 - See the `services-layer` skill for how services are implemented
-- See the `error-handling` skill for trySync/tryAsync patterns
+- See the `error-handling` skill for trySync/tryAsync patterns and toast-on-error conventions

--- a/.agents/skills/svelte/SKILL.md
+++ b/.agents/skills/svelte/SKILL.md
@@ -14,7 +14,7 @@ metadata:
 - [shadcn-svelte](https://github.com/huntabyte/shadcn-svelte) — Port of shadcn/ui for Svelte with Bits UI primitives
 - [shadcn-svelte-extras](https://github.com/ieedan/shadcn-svelte-extras) — Additional components for shadcn-svelte
 
-> **Related Skills**: See `query-layer` for TanStack Query integration. See `styling` for CSS and Tailwind conventions, including the **Flex Column Scroll Trap** pattern (critical when building scrollable content inside `Resizable.Pane`, `ScrollArea`, or any flex column with siblings).
+> **Related Skills**: See `query-layer` for TanStack Query integration. See `error-handling` for toast-on-error patterns (`toastOnError`, `extractErrorMessage`) when handling errors in components. See `styling` for CSS and Tailwind conventions, including the **Flex Column Scroll Trap** pattern (critical when building scrollable content inside `Resizable.Pane`, `ScrollArea`, or any flex column with siblings).
 
 ## When to Apply This Skill
 

--- a/apps/dashboard/src/lib/components/PlanComparison.svelte
+++ b/apps/dashboard/src/lib/components/PlanComparison.svelte
@@ -8,6 +8,7 @@
 	import { Spinner } from '@epicenter/ui/spinner';
 	import { createMutation, createQuery } from '@tanstack/svelte-query';
 	import { toast } from 'svelte-sonner';
+	import { extractErrorMessage } from 'wellcrafted/error';
 	import {
 		balanceQuery,
 		billingKeys,
@@ -269,7 +270,7 @@
 										queryClient.invalidateQueries({ queryKey: billingKeys.all });
 									}
 								},
-								onError: () => toast.error('Upgrade failed. Please try again.'),
+							onError: (error) => toast.error('Upgrade failed', { description: extractErrorMessage(error) }),
 							},
 						);
 					}

--- a/apps/dashboard/src/lib/components/UserMenu.svelte
+++ b/apps/dashboard/src/lib/components/UserMenu.svelte
@@ -8,7 +8,7 @@
 	import SunIcon from '@lucide/svelte/icons/sun';
 	import { createQuery } from '@tanstack/svelte-query';
 	import { mode, toggleMode } from 'mode-watcher';
-	import { toast } from 'svelte-sonner';
+	import { toastOnError } from '@epicenter/ui/sonner';
 	import { api } from '$lib/api';
 	import { auth } from '$lib/auth';
 	import { balanceQuery } from '$lib/query/billing';
@@ -33,10 +33,7 @@
 	/** Open Stripe billing portal via the API. */
 	async function openBillingPortal() {
 		const { data, error } = await api.billing.portal();
-		if (error) {
-			toast.error('Could not open billing portal.');
-			return;
-		}
+		if (error) return toastOnError(error, 'Could not open billing portal');
 		if (data.url) window.location.href = data.url;
 	}
 	const isDark = $derived(mode.current === 'dark');

--- a/apps/dashboard/src/routes/+page.svelte
+++ b/apps/dashboard/src/routes/+page.svelte
@@ -5,6 +5,8 @@
 	import * as Tabs from '@epicenter/ui/tabs';
 	import { createMutation, createQuery } from '@tanstack/svelte-query';
 	import { toast } from 'svelte-sonner';
+	import { extractErrorMessage } from 'wellcrafted/error';
+	import { toastOnError } from '@epicenter/ui/sonner';
 	import { api } from '$lib/api';
 	import ActivityFeed from '$lib/components/ActivityFeed.svelte';
 	import CreditBalance from '$lib/components/CreditBalance.svelte';
@@ -24,10 +26,7 @@
 	/** Open Stripe billing portal via the API. */
 	async function openBillingPortal() {
 		const { data, error } = await api.billing.portal();
-		if (error) {
-			toast.error('Could not open billing portal.');
-			return;
-		}
+		if (error) return toastOnError(error, 'Could not open billing portal');
 		if (data.url) window.location.href = data.url;
 	}
 
@@ -79,7 +78,7 @@
 						queryClient.invalidateQueries({ queryKey: billingKeys.all });
 					}
 				},
-				onError: () => toast.error('Top-up failed. Please try again.'),
+				onError: (error) => toast.error('Top-up failed', { description: extractErrorMessage(error) }),
 			});
 		}}
 		disabled={topUp.isPending}

--- a/apps/fuji/src/lib/client.ts
+++ b/apps/fuji/src/lib/client.ts
@@ -2,9 +2,8 @@
  * Fuji workspace client — single Y.Doc instance with IndexedDB persistence,
  * encryption, and WebSocket sync (with built-in BroadcastChannel cross-tab sync).
  *
- * Access tables via `workspace.tables.entries` and KV settings via
- * `workspace.kv`. The client is ready when `workspace.whenReady`
- * resolves.
+ * Access tables via `workspace.tables.entries`. The client is ready when
+ * `workspace.whenReady` resolves.
  */
 
 import { APP_URLS } from '@epicenter/constants/vite';

--- a/apps/fuji/src/lib/components/AppHeader.svelte
+++ b/apps/fuji/src/lib/components/AppHeader.svelte
@@ -6,7 +6,7 @@
 	import * as Tooltip from '@epicenter/ui/tooltip';
 	import PlusIcon from '@lucide/svelte/icons/plus';
 	import SearchIcon from '@lucide/svelte/icons/search';
-	import { entriesState } from '$lib/entries.svelte';
+	import { entriesState } from '$lib/entries-state.svelte';
 	import BulkAddModal from './BulkAddModal.svelte';
 	import SyncStatusIndicator from './SyncStatusIndicator.svelte';
 

--- a/apps/fuji/src/lib/components/EntriesSidebar.svelte
+++ b/apps/fuji/src/lib/components/EntriesSidebar.svelte
@@ -9,14 +9,17 @@
 	import { VList } from 'virtua/svelte';
 	import { format, isToday, isYesterday } from 'date-fns';
 	import { DateTimeString } from '@epicenter/workspace';
-	import { entriesState, matchesEntrySearch, viewState } from '$lib/entries.svelte';
+	import { entriesState, matchesEntrySearch } from '$lib/entries-state.svelte';
+	import { viewState } from '$lib/view-state.svelte';
 
 	const isSearching = $derived(viewState.searchQuery.trim().length > 0);
 
 	/** Entries matching the search query across title, subtitle, tags, and type. */
 	const searchResults = $derived.by(() => {
 		if (!isSearching) return [];
-		return entriesState.active.filter((entry) => matchesEntrySearch(entry, viewState.searchQuery));
+		return entriesState.active.filter((entry) =>
+			matchesEntrySearch(entry, viewState.searchQuery),
+		);
 	});
 
 	/** Unique types with entry counts, sorted by count descending. */
@@ -78,13 +81,13 @@
 				<Sidebar.Menu>
 					<Sidebar.MenuItem>
 						<Sidebar.MenuButton
-						isActive={page.url.pathname === '/' && !isSearching}
-						onclick={() => goto('/')}
-					>
+							isActive={page.url.pathname === '/' && !isSearching}
+							onclick={() => goto('/')}
+						>
 							<FileTextIcon class="size-4" />
 							<span>All Entries</span>
 							<span class="ml-auto text-xs text-muted-foreground">
-						{entriesState.active.length}
+								{entriesState.active.length}
 							</span>
 						</Sidebar.MenuButton>
 					</Sidebar.MenuItem>
@@ -114,35 +117,40 @@
 				</Sidebar.GroupLabel>
 				<Sidebar.GroupContent>
 					<Sidebar.Menu>
-					{#if searchResults.length > 0}
-					<div class="min-h-0 flex-1">
-							<VList
-								data={searchResults}
-							style="height: 100%; overflow: hidden;"
-								getKey={(entry) => entry.id}
-							>
-								{#snippet children(entry)}
-									<Sidebar.MenuItem>
-										<Sidebar.MenuButton size="lg" onclick={() => goto(`/entries/${entry.id}`)}>
-										<div class="flex w-full flex-col gap-1 overflow-hidden">
-												<span class="truncate text-sm font-medium">
-													{entry.title || 'Untitled'}
-												</span>
-												{#if entry.subtitle}
-													<span class="truncate text-xs text-muted-foreground">
-														{entry.subtitle}
+						{#if searchResults.length > 0}
+							<div class="min-h-0 flex-1">
+								<VList
+									data={searchResults}
+									style="height: 100%; overflow: hidden;"
+									getKey={(entry) => entry.id}
+								>
+									{#snippet children(entry)}
+										<Sidebar.MenuItem>
+											<Sidebar.MenuButton
+												size="lg"
+												onclick={() => goto(`/entries/${entry.id}`)}
+											>
+												<div class="flex w-full flex-col gap-1 overflow-hidden">
+													<span class="truncate text-sm font-medium">
+														{entry.title || 'Untitled'}
 													</span>
-												{/if}
-											</div>
-										</Sidebar.MenuButton>
-									</Sidebar.MenuItem>
-								{/snippet}
-							</VList>
-						</div>
+													{#if entry.subtitle}
+														<span
+															class="truncate text-xs text-muted-foreground"
+														>
+															{entry.subtitle}
+														</span>
+													{/if}
+												</div>
+											</Sidebar.MenuButton>
+										</Sidebar.MenuItem>
+									{/snippet}
+								</VList>
+							</div>
 						{:else}
 							<Sidebar.MenuItem>
 								<span class="px-2 py-1 text-xs text-muted-foreground">
-								No entries match "{viewState.searchQuery}"
+									No entries match "{viewState.searchQuery}"
 								</span>
 							</Sidebar.MenuItem>
 						{/if}
@@ -158,10 +166,10 @@
 						<Sidebar.Menu>
 							{#each typeGroups as group (group.name)}
 								<Sidebar.MenuItem>
-							<Sidebar.MenuButton
-								isActive={page.url.pathname === `/type/${encodeURIComponent(group.name)}`}
-								onclick={() => goto(`/type/${encodeURIComponent(group.name)}`)}
-							>
+									<Sidebar.MenuButton
+										isActive={page.url.pathname === `/type/${encodeURIComponent(group.name)}`}
+										onclick={() => goto(`/type/${encodeURIComponent(group.name)}`)}
+									>
 										<HashIcon class="size-4" />
 										<span>{group.name}</span>
 										<span class="ml-auto text-xs text-muted-foreground">
@@ -183,10 +191,10 @@
 						<Sidebar.Menu>
 							{#each tagGroups as group (group.name)}
 								<Sidebar.MenuItem>
-							<Sidebar.MenuButton
-								isActive={page.url.pathname === `/tag/${encodeURIComponent(group.name)}`}
-								onclick={() => goto(`/tag/${encodeURIComponent(group.name)}`)}
-							>
+									<Sidebar.MenuButton
+										isActive={page.url.pathname === `/tag/${encodeURIComponent(group.name)}`}
+										onclick={() => goto(`/tag/${encodeURIComponent(group.name)}`)}
+									>
 										<TagIcon class="size-4" />
 										<span>{group.name}</span>
 										<span class="ml-auto text-xs text-muted-foreground">
@@ -208,7 +216,10 @@
 						<Sidebar.Menu>
 							{#each recentEntries as entry (entry.id)}
 								<Sidebar.MenuItem>
-								<Sidebar.MenuButton size="lg" onclick={() => goto(`/entries/${entry.id}`)}>
+									<Sidebar.MenuButton
+										size="lg"
+										onclick={() => goto(`/entries/${entry.id}`)}
+									>
 										<div class="flex w-full flex-col gap-1 overflow-hidden">
 											<span class="truncate text-sm font-medium">
 												{entry.title || 'Untitled'}
@@ -226,5 +237,4 @@
 			{/if}
 		{/if}
 	</Sidebar.Content>
-
 </Sidebar.Root>

--- a/apps/fuji/src/lib/components/EntriesTable.svelte
+++ b/apps/fuji/src/lib/components/EntriesTable.svelte
@@ -19,11 +19,8 @@
 		getSortedRowModel,
 	} from '@tanstack/table-core';
 	import { goto } from '$app/navigation';
-	import {
-		entriesState,
-		matchesEntrySearch,
-		viewState,
-	} from '$lib/entries.svelte';
+	import { entriesState, matchesEntrySearch } from '$lib/entries-state.svelte';
+	import { viewState } from '$lib/view-state.svelte';
 	import { relativeTime } from '$lib/format';
 	import type { Entry } from '$lib/workspace';
 	import BadgeList from './BadgeList.svelte';
@@ -247,7 +244,7 @@
 				{:else}
 					<Table.Row>
 						<Table.Cell colspan={columns.length}>
-						<Empty.Root class="min-h-[50vh]">
+							<Empty.Root class="min-h-[50vh]">
 								<Empty.Media>
 									<FileTextIcon class="size-8 text-muted-foreground" />
 								</Empty.Media>

--- a/apps/fuji/src/lib/components/EntriesTable.svelte
+++ b/apps/fuji/src/lib/components/EntriesTable.svelte
@@ -134,7 +134,7 @@
 		},
 	];
 
-	let sorting = $state<SortingState>([
+	const sorting = $derived<SortingState>([
 		{ id: viewState.sortBy, desc: viewState.sortBy !== 'title' },
 	]);
 
@@ -148,13 +148,8 @@
 		getSortedRowModel: getSortedRowModel(),
 		getFilteredRowModel: getFilteredRowModel(),
 		onSortingChange: (updater) => {
-			if (typeof updater === 'function') {
-				sorting = updater(sorting);
-			} else {
-				sorting = updater;
-			}
-			// Propagate sort change back to persisted KV
-			const primary = sorting[0];
+			const next = typeof updater === 'function' ? updater(sorting) : updater;
+			const primary = next[0];
 			if (primary) {
 				viewState.sortBy = primary.id as typeof viewState.sortBy;
 			}
@@ -223,12 +218,13 @@
 			<Table.Body>
 				{#if table.getRowModel().rows?.length}
 					{#each table.getRowModel().rows as row (row.id)}
-						<!-- svelte-ignore a11y_click_events_have_key_events -->
-						<!-- svelte-ignore a11y_no_static_element_interactions -->
-						<Table.Row
-							class="cursor-pointer transition-colors hover:bg-accent/50"
-							onclick={() => goto(`/entries/${row.original.id}`)}
-						>
+					<Table.Row
+						role="button"
+						tabindex="0"
+						class="cursor-pointer transition-colors hover:bg-accent/50"
+						onclick={() => goto(`/entries/${row.original.id}`)}
+						onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); goto(`/entries/${row.original.id}`); } }}
+					>
 							{#each row.getVisibleCells() as cell}
 								<Table.Cell
 									class={cell.column.id === 'title' ? 'max-w-[400px] truncate' : ''}

--- a/apps/fuji/src/lib/components/EntriesTimeline.svelte
+++ b/apps/fuji/src/lib/components/EntriesTimeline.svelte
@@ -184,11 +184,12 @@
 						</h3>
 					</div>
 				{:else}
-					<!-- svelte-ignore a11y_click_events_have_key_events -->
-					<!-- svelte-ignore a11y_no_static_element_interactions -->
 					<div
+						role="button"
+						tabindex="0"
 						class="group mx-4 flex cursor-pointer flex-col gap-0.5 rounded-lg p-3 text-sm transition-colors hover:bg-accent/50"
 						onclick={() => goto(`/entries/${item.entry.id}`)}
+						onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); goto(`/entries/${item.entry.id}`); } }}
 					>
 						<div class="flex items-start justify-between gap-2">
 							<span class="font-medium line-clamp-1">

--- a/apps/fuji/src/lib/components/EntriesTimeline.svelte
+++ b/apps/fuji/src/lib/components/EntriesTimeline.svelte
@@ -15,11 +15,8 @@
 	import { format, isToday, isYesterday } from 'date-fns';
 	import { VList } from 'virtua/svelte';
 	import { goto } from '$app/navigation';
-	import {
-		entriesState,
-		matchesEntrySearch,
-		viewState,
-	} from '$lib/entries.svelte';
+	import { entriesState, matchesEntrySearch } from '$lib/entries-state.svelte';
+	import { viewState } from '$lib/view-state.svelte';
 	import type { Entry } from '$lib/workspace';
 
 	let { entries, title }: { entries: Entry[]; title?: string } = $props();
@@ -36,13 +33,21 @@
 
 	/** Multi-sort: non-date fields sort within date groups. */
 	const sorting = $derived(
-		({
-			date: [{ id: 'date', desc: true }],
-			updatedAt: [{ id: 'updatedAt', desc: true }],
-			createdAt: [{ id: 'createdAt', desc: true }],
-			title: [{ id: 'date', desc: true }, { id: 'title', desc: false }],
-			rating: [{ id: 'date', desc: true }, { id: 'rating', desc: true }],
-		} satisfies Record<typeof viewState.sortBy, SortingState>)[viewState.sortBy],
+		(
+			{
+				date: [{ id: 'date', desc: true }],
+				updatedAt: [{ id: 'updatedAt', desc: true }],
+				createdAt: [{ id: 'createdAt', desc: true }],
+				title: [
+					{ id: 'date', desc: true },
+					{ id: 'title', desc: false },
+				],
+				rating: [
+					{ id: 'date', desc: true },
+					{ id: 'rating', desc: true },
+				],
+			} satisfies Record<typeof viewState.sortBy, SortingState>
+		)[viewState.sortBy],
 	);
 
 	const table = createSvelteTable({
@@ -71,13 +76,18 @@
 
 	/** Which date field to use for timeline headers. */
 	const groupField = $derived(
-		({
-			date: 'date',
-			updatedAt: 'updatedAt',
-			createdAt: 'createdAt',
-			title: 'date',
-			rating: 'date',
-		} satisfies Record<typeof viewState.sortBy, 'date' | 'updatedAt' | 'createdAt'>)[viewState.sortBy],
+		(
+			{
+				date: 'date',
+				updatedAt: 'updatedAt',
+				createdAt: 'createdAt',
+				title: 'date',
+				rating: 'date',
+			} satisfies Record<
+				typeof viewState.sortBy,
+				'date' | 'updatedAt' | 'createdAt'
+			>
+		)[viewState.sortBy],
 	);
 
 	function getDateLabel(dts: string): string {
@@ -137,27 +147,27 @@
 				<Empty.Media>
 					<ClockIcon class="size-8 text-muted-foreground" />
 				</Empty.Media>
-			{#if viewState.searchQuery}
-				<Empty.Title>No entries match your search</Empty.Title>
-				<Empty.Description
-					>Try a different search term or clear your filters.</Empty.Description
-				>
-			{:else}
-				<Empty.Title>No entries yet</Empty.Title>
-				<Empty.Description
-					>Create your first entry to get started.</Empty.Description
-				>
-				<Empty.Content>
-					<Button
-						variant="outline"
-						size="sm"
-						onclick={entriesState.createEntry}
+				{#if viewState.searchQuery}
+					<Empty.Title>No entries match your search</Empty.Title>
+					<Empty.Description
+						>Try a different search term or clear your filters.</Empty.Description
 					>
-						<PlusIcon class="mr-1.5 size-4" />
-						New Entry
-					</Button>
-				</Empty.Content>
-			{/if}
+				{:else}
+					<Empty.Title>No entries yet</Empty.Title>
+					<Empty.Description
+						>Create your first entry to get started.</Empty.Description
+					>
+					<Empty.Content>
+						<Button
+							variant="outline"
+							size="sm"
+							onclick={entriesState.createEntry}
+						>
+							<PlusIcon class="mr-1.5 size-4" />
+							New Entry
+						</Button>
+					</Empty.Content>
+				{/if}
 			</Empty.Root>
 		</div>
 	{:else}
@@ -185,7 +195,7 @@
 								{item.entry.title || 'Untitled'}
 							</span>
 							<span class="shrink-0 text-xs text-muted-foreground">
-							{format(DateTimeString.toDate(item.entry[groupField]), 'h:mm a')}
+								{format(DateTimeString.toDate(item.entry[groupField]), 'h:mm a')}
 							</span>
 						</div>
 						{#if item.entry.subtitle}

--- a/apps/fuji/src/lib/components/TagInput.svelte
+++ b/apps/fuji/src/lib/components/TagInput.svelte
@@ -26,6 +26,7 @@
 			<button
 				type="button"
 				class="rounded-full p-0.5 hover:bg-muted"
+				aria-label={`Remove ${value}`}
 				onclick={() => onRemove(value)}
 			>
 				<XIcon class="size-3" />

--- a/apps/fuji/src/lib/entries-state.svelte.ts
+++ b/apps/fuji/src/lib/entries-state.svelte.ts
@@ -1,25 +1,19 @@
 /**
- * Reactive state for Fuji—entries, view preferences, and search.
+ * Reactive Fuji entry state and search helpers.
  *
- * Three exports:
- * - `entriesState` — active/deleted entry collections from the workspace table
- * - `viewState` — persisted view mode, sort preference, and search query
- * - `matchesEntrySearch` — pure function for filtering entries by query
+ * Keeps the workspace-backed entry collection and search predicate together,
+ * while view preferences live in `view-state.svelte.ts`.
  *
  * @example
  * ```svelte
  * <script>
- *   import { entriesState, viewState } from '$lib/entries.svelte';
+ *   import { entriesState, matchesEntrySearch } from '$lib/entries-state.svelte';
  * </script>
- *
- * {#each entriesState.active as entry (entry.id)}
- *   <p>{entry.title}</p>
- * {/each}
  * ```
  */
 
 import { goto } from '$app/navigation';
-import { fromKv, fromTable } from '@epicenter/svelte';
+import { fromTable } from '@epicenter/svelte';
 import { workspace } from '$lib/client';
 import type { EntryId } from '$lib/workspace';
 
@@ -88,51 +82,3 @@ function createEntriesState() {
 }
 
 export const entriesState = createEntriesState();
-
-// ─── View State ──────────────────────────────────────────────────────────────
-
-function createViewState() {
-	const viewModeKv = fromKv(workspace.kv, 'viewMode');
-	const sortByKv = fromKv(workspace.kv, 'sortBy');
-	let searchQuery = $state('');
-
-	return {
-		get viewMode(): 'table' | 'timeline' {
-			return viewModeKv.current ?? 'table';
-		},
-
-		/**
-		 * Toggle between table and timeline view modes.
-		 *
-		 * Persisted via workspace KV so the preference survives reloads
-		 * and syncs across devices.
-		 */
-		toggleViewMode() {
-			viewModeKv.current =
-				viewModeKv.current === 'table' ? 'timeline' : 'table';
-		},
-
-		get sortBy(): 'date' | 'updatedAt' | 'createdAt' | 'title' | 'rating' {
-			return sortByKv.current ?? 'date';
-		},
-
-		/**
-		 * Set the sort preference. Persisted via workspace KV so it survives
-		 * reloads and syncs across devices.
-		 */
-		set sortBy(value: 'date' | 'updatedAt' | 'createdAt' | 'title' | 'rating') {
-			sortByKv.current = value;
-		},
-
-		get searchQuery() {
-			return searchQuery;
-		},
-
-		/** Update the search query. Used by the sidebar search input. */
-		set searchQuery(value: string) {
-			searchQuery = value;
-		},
-	};
-}
-
-export const viewState = createViewState();

--- a/apps/fuji/src/lib/entries-state.svelte.ts
+++ b/apps/fuji/src/lib/entries-state.svelte.ts
@@ -12,8 +12,8 @@
  * ```
  */
 
-import { goto } from '$app/navigation';
 import { fromTable } from '@epicenter/svelte';
+import { goto } from '$app/navigation';
 import { workspace } from '$lib/client';
 import type { EntryId } from '$lib/workspace';
 

--- a/apps/fuji/src/lib/view-state.svelte.ts
+++ b/apps/fuji/src/lib/view-state.svelte.ts
@@ -1,0 +1,55 @@
+/**
+ * Reactive Fuji view preferences.
+ *
+ * Holds persisted UI choices like view mode, sort order, and search query.
+ * The entry collection and search helpers live in `entries-state.svelte.ts`.
+ */
+
+import { fromKv } from '@epicenter/svelte';
+import { workspace } from '$lib/client';
+
+function createViewState() {
+	const viewModeKv = fromKv(workspace.kv, 'viewMode');
+	const sortByKv = fromKv(workspace.kv, 'sortBy');
+	let searchQuery = $state('');
+
+	return {
+		get viewMode(): 'table' | 'timeline' {
+			return viewModeKv.current ?? 'table';
+		},
+
+		/**
+		 * Toggle between table and timeline view modes.
+		 *
+		 * Persisted via workspace KV so the preference survives reloads
+		 * and syncs across devices.
+		 */
+		toggleViewMode() {
+			viewModeKv.current =
+				viewModeKv.current === 'table' ? 'timeline' : 'table';
+		},
+
+		get sortBy(): 'date' | 'updatedAt' | 'createdAt' | 'title' | 'rating' {
+			return sortByKv.current ?? 'date';
+		},
+
+		/**
+		 * Set the sort preference. Persisted via workspace KV so it survives
+		 * reloads and syncs across devices.
+		 */
+		set sortBy(value: 'date' | 'updatedAt' | 'createdAt' | 'title' | 'rating') {
+			sortByKv.current = value;
+		},
+
+		get searchQuery() {
+			return searchQuery;
+		},
+
+		/** Update the search query. Used by the sidebar search input. */
+		set searchQuery(value: string) {
+			searchQuery = value;
+		},
+	};
+}
+
+export const viewState = createViewState();

--- a/apps/fuji/src/lib/view-state.svelte.ts
+++ b/apps/fuji/src/lib/view-state.svelte.ts
@@ -15,6 +15,9 @@ import { page } from '$app/state';
 type ViewMode = 'table' | 'timeline';
 type SortBy = 'date' | 'updatedAt' | 'createdAt' | 'title' | 'rating';
 
+const VIEW_MODES: ViewMode[] = ['table', 'timeline'];
+const SORT_KEYS: SortBy[] = ['date', 'updatedAt', 'createdAt', 'title', 'rating'];
+
 /** Update a single URL search param, removing it when null to keep URLs clean. */
 function setSearchParam(key: string, value: string | null) {
 	const params = new URLSearchParams(page.url.searchParams);
@@ -34,7 +37,8 @@ function setSearchParam(key: string, value: string | null) {
 function createViewState() {
 	return {
 		get viewMode(): ViewMode {
-			return (page.url.searchParams.get('view') as ViewMode) ?? 'table';
+			const raw = page.url.searchParams.get('view');
+			return VIEW_MODES.includes(raw as ViewMode) ? (raw as ViewMode) : 'table';
 		},
 
 		/**
@@ -49,7 +53,8 @@ function createViewState() {
 		},
 
 		get sortBy(): SortBy {
-			return (page.url.searchParams.get('sort') as SortBy) ?? 'date';
+			const raw = page.url.searchParams.get('sort');
+			return SORT_KEYS.includes(raw as SortBy) ? (raw as SortBy) : 'date';
 		},
 
 		/**

--- a/apps/fuji/src/lib/view-state.svelte.ts
+++ b/apps/fuji/src/lib/view-state.svelte.ts
@@ -1,53 +1,72 @@
 /**
- * Reactive Fuji view preferences.
+ * Reactive Fuji view preferences backed by URL search params.
  *
- * Holds persisted UI choices like view mode, sort order, and search query.
+ * View mode, sort order, and search query live in the URL so they're
+ * bookmarkable, shareable, and work with browser back/forward.
+ * Default values are elided from the URL to keep it clean—`/` means
+ * table view, sorted by date, no search.
+ *
  * The entry collection and search helpers live in `entries-state.svelte.ts`.
  */
 
-import { fromKv } from '@epicenter/svelte';
-import { workspace } from '$lib/client';
+import { goto } from '$app/navigation';
+import { page } from '$app/state';
+
+type ViewMode = 'table' | 'timeline';
+type SortBy = 'date' | 'updatedAt' | 'createdAt' | 'title' | 'rating';
+
+/** Update a single URL search param, removing it when null to keep URLs clean. */
+function setSearchParam(key: string, value: string | null) {
+	const params = new URLSearchParams(page.url.searchParams);
+	if (value === null) {
+		params.delete(key);
+	} else {
+		params.set(key, value);
+	}
+	const search = params.toString();
+	goto(`${page.url.pathname}${search ? `?${search}` : ''}${page.url.hash}`, {
+		replaceState: true,
+		noScroll: true,
+		keepFocus: true,
+	});
+}
 
 function createViewState() {
-	const viewModeKv = fromKv(workspace.kv, 'viewMode');
-	const sortByKv = fromKv(workspace.kv, 'sortBy');
-	let searchQuery = $state('');
-
 	return {
-		get viewMode(): 'table' | 'timeline' {
-			return viewModeKv.current ?? 'table';
+		get viewMode(): ViewMode {
+			return (page.url.searchParams.get('view') as ViewMode) ?? 'table';
 		},
 
 		/**
 		 * Toggle between table and timeline view modes.
 		 *
-		 * Persisted via workspace KV so the preference survives reloads
-		 * and syncs across devices.
+		 * Updates the `view` search param. Default ('table') is elided
+		 * from the URL so `/` always means table view.
 		 */
 		toggleViewMode() {
-			viewModeKv.current =
-				viewModeKv.current === 'table' ? 'timeline' : 'table';
+			const next: ViewMode = this.viewMode === 'table' ? 'timeline' : 'table';
+			setSearchParam('view', next === 'table' ? null : next);
 		},
 
-		get sortBy(): 'date' | 'updatedAt' | 'createdAt' | 'title' | 'rating' {
-			return sortByKv.current ?? 'date';
+		get sortBy(): SortBy {
+			return (page.url.searchParams.get('sort') as SortBy) ?? 'date';
 		},
 
 		/**
-		 * Set the sort preference. Persisted via workspace KV so it survives
-		 * reloads and syncs across devices.
+		 * Set the sort preference via the `sort` search param.
+		 * Default ('date') is elided to keep URLs clean.
 		 */
-		set sortBy(value: 'date' | 'updatedAt' | 'createdAt' | 'title' | 'rating') {
-			sortByKv.current = value;
+		set sortBy(value: SortBy) {
+			setSearchParam('sort', value === 'date' ? null : value);
 		},
 
 		get searchQuery() {
-			return searchQuery;
+			return page.url.searchParams.get('q') ?? '';
 		},
 
-		/** Update the search query. Used by the sidebar search input. */
+		/** Update the search query via the `q` search param. Empty values are elided. */
 		set searchQuery(value: string) {
-			searchQuery = value;
+			setSearchParam('q', value || null);
 		},
 	};
 }

--- a/apps/fuji/src/lib/workspace.ts
+++ b/apps/fuji/src/lib/workspace.ts
@@ -24,7 +24,6 @@
 import {
 	createWorkspace,
 	DateTimeString,
-	defineKv,
 	defineMutation,
 	defineTable,
 	defineWorkspace,
@@ -116,10 +115,6 @@ export type Entry = InferTableRow<typeof entriesTable>;
 const fujiWorkspace = defineWorkspace({
 	id: 'epicenter.fuji' as const,
 	tables: { entries: entriesTable },
-	kv: {
-		viewMode: defineKv(type("'table' | 'timeline'")),
-		sortBy: defineKv(type("'date' | 'updatedAt' | 'createdAt' | 'title' | 'rating'")),
-	},
 });
 
 // ─── Factory ──────────────────────────────────────────────────────────────────

--- a/apps/fuji/src/routes/+layout.svelte
+++ b/apps/fuji/src/routes/+layout.svelte
@@ -16,7 +16,7 @@
 	import { workspace } from '$lib/client';
 	import AppHeader from '$lib/components/AppHeader.svelte';
 	import EntriesSidebar from '$lib/components/EntriesSidebar.svelte';
-	import { entriesState } from '$lib/entries.svelte';
+	import { entriesState } from '$lib/entries-state.svelte';
 	import '@epicenter/ui/app.css';
 
 	let { children } = $props();
@@ -74,19 +74,20 @@
 			<AppHeader onOpenSearch={() => (paletteOpen = true)} />
 			<Resizable.PaneGroup direction="horizontal" class="flex-1">
 				<Resizable.Pane defaultSize={20} minSize={15} maxSize={40}>
-				<EntriesSidebar />
+					<EntriesSidebar />
 				</Resizable.Pane>
 				<Resizable.Handle withHandle />
-				<Resizable.Pane defaultSize={80}>
-					{@render children()}
-				</Resizable.Pane>
+				<Resizable.Pane defaultSize={80}> {@render children()} </Resizable.Pane>
 			</Resizable.PaneGroup>
-			<div class="flex h-7 shrink-0 items-center gap-3 border-t bg-background px-3 text-xs text-muted-foreground">
-				<span>{entriesState.active.length} {entriesState.active.length === 1 ? 'entry' : 'entries'}</span>
+			<div
+				class="flex h-7 shrink-0 items-center gap-3 border-t bg-background px-3 text-xs text-muted-foreground"
+			>
+				<span
+					>{entriesState.active.length}
+					{entriesState.active.length === 1 ? 'entry' : 'entries'}</span
+				>
 				<div class="ml-auto flex items-center gap-1.5">
-					<span class="flex items-center gap-1">
-						Search <Kbd>⌘K</Kbd>
-					</span>
+					<span class="flex items-center gap-1"> Search <Kbd>⌘K</Kbd> </span>
 				</div>
 			</div>
 		</div>

--- a/apps/fuji/src/routes/+page.svelte
+++ b/apps/fuji/src/routes/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import EntriesTable from '$lib/components/EntriesTable.svelte';
 	import EntriesTimeline from '$lib/components/EntriesTimeline.svelte';
-	import { entriesState, viewState } from '$lib/entries.svelte';
+	import { entriesState } from '$lib/entries-state.svelte';
+	import { viewState } from '$lib/view-state.svelte';
 </script>
 
 {#if viewState.viewMode === 'table'}

--- a/apps/fuji/src/routes/entries/[id]/+page.svelte
+++ b/apps/fuji/src/routes/entries/[id]/+page.svelte
@@ -7,7 +7,7 @@
 	import type * as Y from 'yjs';
 	import { workspace } from '$lib/client';
 	import EntryEditor from '$lib/components/EntryEditor.svelte';
-	import { entriesState } from '$lib/entries.svelte';
+	import { entriesState } from '$lib/entries-state.svelte';
 	import type { EntryId } from '$lib/workspace';
 
 	const entryId = $derived(page.params.id as EntryId);
@@ -59,7 +59,9 @@
 				<FileXIcon class="size-8 text-muted-foreground" />
 			</Empty.Media>
 			<Empty.Title>Entry not found</Empty.Title>
-			<Empty.Description>This entry may have been deleted or the URL is invalid.</Empty.Description>
+			<Empty.Description
+				>This entry may have been deleted or the URL is invalid.</Empty.Description
+			>
 		</Empty.Root>
 	{:else if currentYXmlFragment}
 		{#key entryId}

--- a/apps/fuji/src/routes/entries/[id]/+page.svelte
+++ b/apps/fuji/src/routes/entries/[id]/+page.svelte
@@ -36,7 +36,10 @@
 
 		let cancelled = false;
 		workspace.documents.entries.content.open(entryId).then((handle) => {
-			if (cancelled) return;
+			if (cancelled) {
+				workspace.documents.entries.content.close(entryId);
+				return;
+			}
 			currentDocHandle = handle;
 			currentYXmlFragment = handle.asRichText();
 		});

--- a/apps/fuji/src/routes/stress-test/+page.svelte
+++ b/apps/fuji/src/routes/stress-test/+page.svelte
@@ -1,0 +1,347 @@
+<script lang="ts">
+	import { Button } from '@epicenter/ui/button';
+	import * as Card from '@epicenter/ui/card';
+	import { Badge } from '@epicenter/ui/badge';
+	import { workspace } from '$lib/client';
+	import { entriesState } from '$lib/entries-state.svelte';
+	import { generateId, DateTimeString } from '@epicenter/workspace';
+	import type { EntryId } from '$lib/workspace';
+	import * as Y from 'yjs';
+	import { toast } from 'svelte-sonner';
+
+	// ─── Config ──────────────────────────────────────────────────────────────────
+
+	const COUNTS = [1_000, 10_000] as const;
+
+	/**
+	 * Small chunk size so the browser event loop yields between chunks,
+	 * giving Svelte a chance to re-render the progress bar. 1000 entries
+	 * per chunk would mean 1 chunk for 1k count—no intermediate updates.
+	 */
+	const CHUNK_SIZE = 100;
+
+	const TITLES = [
+		'Morning Reflections',
+		'Project Update',
+		'Book Notes',
+		'Meeting Summary',
+		'Travel Plans',
+		'Recipe Ideas',
+		'Code Review Notes',
+		'Design Critique',
+		'Weekly Goals',
+		'Research Findings',
+		'Product Roadmap',
+		'Bug Report',
+		'Feature Request',
+		'Architecture Decision',
+		'Performance Analysis',
+		'User Feedback',
+		'Sprint Retrospective',
+		'Technical Debt',
+		'API Design',
+		'Database Schema',
+		'Security Audit',
+		'Deployment Checklist',
+		'Onboarding Guide',
+		'Style Guide',
+		'Release Notes',
+		'Changelog',
+		'Migration Plan',
+		'Brainstorm',
+		'Interview Notes',
+		'Competitive Analysis',
+	];
+
+	const SUBTITLES = [
+		'A deep dive into the details',
+		'Quick thoughts on the topic',
+		'Notes for future reference',
+		'Draft in progress',
+		'Ready for review',
+		'Needs more research',
+		'Follow up required',
+		'Summary of key points',
+		'Initial exploration',
+		'Final draft',
+		'Work in progress',
+		'Archived',
+		'For discussion',
+		'Action items included',
+		'',
+	];
+
+	const TYPES = ['article', 'thought', 'idea', 'research', 'journal'];
+	const EXTRA_TAGS = [
+		'draft',
+		'published',
+		'favorite',
+		'personal',
+		'work',
+		'code',
+		'design',
+		'writing',
+	];
+
+	// ─── State ───────────────────────────────────────────────────────────────────
+
+	let count = $state<1000 | 10000>(1000);
+	let running = $state(false);
+	let clearing = $state(false);
+	let progress = $state(0);
+
+	type Results = {
+		insertTimeMs: number;
+		rowCount: number;
+		ydocSizeBytes: number;
+		readTimeMs: number;
+		filterTimeMs: number;
+	};
+
+	let results = $state<Results | null>(null);
+
+	const stressTestCount = $derived(
+		entriesState.active.filter((e) => e.tags.includes('stress-test')).length,
+	);
+
+	// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+	function pick<T>(arr: T[]): T {
+		return arr[Math.floor(Math.random() * arr.length)]!;
+	}
+
+	function pickN<T>(arr: T[], min: number, max: number): T[] {
+		const n = min + Math.floor(Math.random() * (max - min + 1));
+		const shuffled = [...arr].sort(() => Math.random() - 0.5);
+		return shuffled.slice(0, n);
+	}
+
+	const LOCAL_TZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+	function randomDate(): DateTimeString {
+		const now = Date.now();
+		const twoYearsMs = 2 * 365 * 24 * 60 * 60 * 1000;
+		const ts = now - twoYearsMs + Math.random() * twoYearsMs;
+		return DateTimeString.stringify(new Date(ts).toISOString(), LOCAL_TZ);
+	}
+
+	function generateEntryRow(index: number, now: DateTimeString) {
+		return {
+			id: generateId() as string as EntryId,
+			title: `${pick(TITLES)} #${index + 1}`,
+			subtitle: pick(SUBTITLES),
+			type: pickN(TYPES, 0, 2),
+			tags: ['stress-test', ...pickN(EXTRA_TAGS, 0, 2)],
+			pinned: Math.random() < 0.05,
+			rating: Math.random() < 0.7 ? 0 : Math.floor(Math.random() * 5) + 1,
+			deletedAt: undefined,
+			date: randomDate(),
+			createdAt: now,
+			updatedAt: now,
+			_v: 2 as const,
+		};
+	}
+
+	function formatBytes(bytes: number): string {
+		if (bytes < 1024) return `${bytes} B`;
+		if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+		return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+	}
+
+	function formatMs(ms: number): string {
+		if (ms < 1000) return `${ms.toFixed(1)}ms`;
+		return `${(ms / 1000).toFixed(2)}s`;
+	}
+
+	// ─── Actions ─────────────────────────────────────────────────────────────────
+
+	async function generate() {
+		running = true;
+		progress = 0;
+		results = null;
+
+		try {
+			const now = DateTimeString.now();
+			const rows = Array.from({ length: count }, (_, i) => generateEntryRow(i, now));
+
+			const insertStart = performance.now();
+			await workspace.tables.entries.bulkSet(rows, {
+				chunkSize: CHUNK_SIZE,
+				onProgress: (p) => {
+					progress = p;
+				},
+			});
+			const insertTimeMs = performance.now() - insertStart;
+
+			// Read performance
+			const readStart = performance.now();
+			const allValid = workspace.tables.entries.getAllValid();
+			const readTimeMs = performance.now() - readStart;
+
+			// Filter performance
+			const filterStart = performance.now();
+			const stressEntries = workspace.tables.entries.filter((e) =>
+				e.tags.includes('stress-test'),
+			);
+			const filterTimeMs = performance.now() - filterStart;
+
+			// Y.Doc binary size
+			const ydocSizeBytes = Y.encodeStateAsUpdate(workspace.ydoc).byteLength;
+
+			results = {
+				insertTimeMs,
+				rowCount: allValid.length,
+				ydocSizeBytes,
+				readTimeMs,
+				filterTimeMs,
+			};
+
+			toast.success(
+				`Generated ${count.toLocaleString()} entries in ${formatMs(insertTimeMs)}`,
+			);
+		} catch (error) {
+			toast.error(
+				`Generation failed: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		} finally {
+			running = false;
+		}
+	}
+
+	async function clearGenerated() {
+		clearing = true;
+
+		try {
+			const stressEntries = workspace.tables.entries.filter((e) =>
+				e.tags.includes('stress-test'),
+			);
+			const ids = stressEntries.map((e) => e.id);
+
+			await workspace.tables.entries.bulkDelete(ids, {
+				chunkSize: CHUNK_SIZE,
+			});
+
+			results = null;
+			toast.success(`Cleared ${ids.length.toLocaleString()} stress-test entries`);
+		} catch (error) {
+			toast.error(
+				`Clear failed: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		} finally {
+			clearing = false;
+		}
+	}
+</script>
+
+<main class="flex h-full flex-col gap-6 overflow-auto p-6">
+	<!-- Header -->
+	<div>
+		<h2 class="text-lg font-semibold">Stress Test</h2>
+		<p class="text-sm text-muted-foreground">
+			Generate bulk entries to stress test CRDT performance and UI rendering.
+		</p>
+	</div>
+
+	<!-- Controls -->
+	<Card.Root>
+		<Card.Header>
+			<Card.Title class="text-sm">Generate Entries</Card.Title>
+			<Card.Description>
+				All generated entries are tagged
+				<Badge variant="secondary">stress-test</Badge>
+				for easy cleanup.
+			</Card.Description>
+		</Card.Header>
+		<Card.Content>
+			<div class="flex flex-wrap items-center gap-3">
+				<!-- Count selector -->
+				{#each COUNTS as c}
+					<Button
+						variant={count === c ? 'default' : 'outline'}
+						size="sm"
+						disabled={running}
+						onclick={() => (count = c)}
+					>
+						{c.toLocaleString()}
+					</Button>
+				{/each}
+
+				<div class="h-6 w-px bg-border"></div>
+
+				<!-- Generate -->
+				<Button size="sm" disabled={running || clearing} onclick={generate}>
+					{running
+						? `Generating… ${Math.round(progress * 100)}%`
+						: `Generate ${count.toLocaleString()} entries`}
+				</Button>
+
+				<!-- Clear -->
+				{#if stressTestCount > 0}
+					<Button
+						variant="destructive"
+						size="sm"
+						disabled={running || clearing}
+						onclick={clearGenerated}
+					>
+						{clearing
+							? 'Clearing…'
+							: `Clear ${stressTestCount.toLocaleString()} stress-test entries`}
+					</Button>
+				{/if}
+			</div>
+		</Card.Content>
+	</Card.Root>
+
+	<!-- Progress -->
+	{#if running}
+		<div class="space-y-1.5">
+			<div
+				class="flex items-center justify-between text-xs text-muted-foreground"
+			>
+				<span>Inserting entries…</span>
+				<span>{Math.round(progress * 100)}%</span>
+			</div>
+			<div class="h-2 overflow-hidden rounded-full bg-muted">
+				<div
+					class="h-full rounded-full bg-primary transition-all duration-150"
+					style:width="{progress * 100}%"
+				></div>
+			</div>
+		</div>
+	{/if}
+
+	<!-- Results -->
+	{#if results}
+		<Card.Root>
+			<Card.Header>
+				<Card.Title class="text-sm">Results</Card.Title>
+			</Card.Header>
+			<Card.Content>
+				{@const stats = [
+					{ label: 'Insert time', value: formatMs(results.insertTimeMs) },
+					{ label: 'Total rows', value: results.rowCount.toLocaleString() },
+					{ label: 'Stress-test rows', value: stressTestCount.toLocaleString() },
+					{ label: 'Y.Doc size', value: formatBytes(results.ydocSizeBytes) },
+					{ label: 'getAllValid() time', value: formatMs(results.readTimeMs) },
+					{ label: 'filter() time', value: formatMs(results.filterTimeMs) },
+				]}
+				<div class="grid grid-cols-2 gap-4 sm:grid-cols-3">
+					{#each stats as stat}
+						<div>
+							<p class="text-xs text-muted-foreground">{stat.label}</p>
+							<p class="text-lg font-semibold tabular-nums">{stat.value}</p>
+						</div>
+					{/each}
+				</div>
+			</Card.Content>
+		</Card.Root>
+	{/if}
+
+	<!-- Live count -->
+	<div class="text-xs text-muted-foreground">
+		Total active entries: {entriesState.active.length.toLocaleString()}
+		{#if stressTestCount > 0}
+			· Stress-test entries: {stressTestCount.toLocaleString()}
+		{/if}
+	</div>
+</main>

--- a/apps/fuji/src/routes/tag/[tag]/+page.svelte
+++ b/apps/fuji/src/routes/tag/[tag]/+page.svelte
@@ -2,7 +2,8 @@
 	import { page } from '$app/state';
 	import EntriesTable from '$lib/components/EntriesTable.svelte';
 	import EntriesTimeline from '$lib/components/EntriesTimeline.svelte';
-	import { entriesState, viewState } from '$lib/entries.svelte';
+	import { entriesState } from '$lib/entries-state.svelte';
+	import { viewState } from '$lib/view-state.svelte';
 
 	const tagParam = $derived(decodeURIComponent(page.params.tag ?? ''));
 	const filteredEntries = $derived(

--- a/apps/fuji/src/routes/trash/+page.svelte
+++ b/apps/fuji/src/routes/trash/+page.svelte
@@ -8,7 +8,7 @@
 	import XIcon from '@lucide/svelte/icons/x';
 	import { goto } from '$app/navigation';
 	import { workspace } from '$lib/client';
-	import { entriesState } from '$lib/entries.svelte';
+	import { entriesState } from '$lib/entries-state.svelte';
 	import { relativeTime } from '$lib/format';
 
 	const deletedEntries = $derived(

--- a/apps/fuji/src/routes/type/[type]/+page.svelte
+++ b/apps/fuji/src/routes/type/[type]/+page.svelte
@@ -2,7 +2,8 @@
 	import { page } from '$app/state';
 	import EntriesTable from '$lib/components/EntriesTable.svelte';
 	import EntriesTimeline from '$lib/components/EntriesTimeline.svelte';
-	import { entriesState, viewState } from '$lib/entries.svelte';
+	import { entriesState } from '$lib/entries-state.svelte';
+	import { viewState } from '$lib/view-state.svelte';
 
 	const typeParam = $derived(decodeURIComponent(page.params.type ?? ''));
 	const filteredEntries = $derived(

--- a/apps/opensidian/src/lib/components/AppShell.svelte
+++ b/apps/opensidian/src/lib/components/AppShell.svelte
@@ -9,6 +9,7 @@
 	import * as Tooltip from '@epicenter/ui/tooltip';
 	import FileIcon from '@lucide/svelte/icons/file';
 	import TextIcon from '@lucide/svelte/icons/text';
+	import { session } from '$lib/auth';
 	import { fsState } from '$lib/state/fs-state.svelte';
 	import { searchState } from '$lib/state/search-state.svelte';
 	import { sidebarSearchState } from '$lib/state/sidebar-search-state.svelte';
@@ -27,6 +28,9 @@
 	let chatOpen = $state(false);
 
 	// ── First-visit onboarding ──────────────────────────────────────
+	// Only auto-seed for anonymous visitors. Authenticated users get
+	// their data from sync — seeding before sync finishes would create
+	// duplicates (new CRDT IDs locally + old IDs from the server).
 	let onboarded = false;
 	$effect(() => {
 		if (onboarded) return;
@@ -34,7 +38,11 @@
 			onboarded = true;
 			return;
 		}
-		// Empty file tree on first render — seed data, open terminal, show welcome.
+		if (session.current) {
+			onboarded = true;
+			return;
+		}
+		// Empty file tree + anonymous — seed demo data, open terminal, show welcome.
 		onboarded = true;
 		sampleDataLoader.load().then(() => {
 			const readme = fsState.walkTree((id, row) => {

--- a/apps/opensidian/src/lib/state/fs-state.svelte.ts
+++ b/apps/opensidian/src/lib/state/fs-state.svelte.ts
@@ -1,6 +1,7 @@
 import type { FileId, FileRow } from '@epicenter/filesystem';
 import { fromTable } from '@epicenter/svelte';
 import { toast } from '@epicenter/ui/sonner';
+import { extractErrorMessage } from 'wellcrafted/error';
 import { SvelteSet } from 'svelte/reactivity';
 import { fs, workspace } from '$lib/client';
 
@@ -165,7 +166,7 @@ function createFsState() {
 		try {
 			await fn();
 		} catch (err) {
-			toast.error(err instanceof Error ? err.message : fallbackMessage);
+			toast.error(fallbackMessage, { description: extractErrorMessage(err) });
 			console.error(err);
 		}
 	}

--- a/apps/opensidian/src/lib/utils/load-sample-data.svelte.ts
+++ b/apps/opensidian/src/lib/utils/load-sample-data.svelte.ts
@@ -1,4 +1,5 @@
 import { toast } from '@epicenter/ui/sonner';
+import { extractErrorMessage } from 'wellcrafted/error';
 import { fs } from '$lib/client';
 
 function createSampleDataLoader() {
@@ -36,9 +37,9 @@ function createSampleDataLoader() {
 				);
 				toast.success('Loaded sample data');
 			} catch (err) {
-				toast.error(
-					err instanceof Error ? err.message : 'Failed to load sample data',
-				);
+				toast.error('Failed to load sample data', {
+					description: extractErrorMessage(err),
+				});
 				console.error(err);
 			} finally {
 				seeding = false;

--- a/apps/tab-manager/src/lib/components/command-palette-items.ts
+++ b/apps/tab-manager/src/lib/components/command-palette-items.ts
@@ -198,7 +198,7 @@ export const items: CommandPaletteItem[] = [
 					const tabsWithUrls = allTabs.filter((tab) => tab.url);
 					await Promise.allSettled(
 						tabsWithUrls.map((tab) =>
-							savedTabState.save(tab).then(toastOnError),
+						savedTabState.save(tab).then((r) => toastOnError(r, 'Failed to save tab')),
 						),
 					);
 				},

--- a/apps/tab-manager/src/lib/components/tabs/TabItem.svelte
+++ b/apps/tab-manager/src/lib/components/tabs/TabItem.svelte
@@ -151,7 +151,7 @@
 					tooltip="Save for later"
 					onclick={(e: MouseEvent) => {
 						e.stopPropagation();
-						savedTabState.save(tab).then(toastOnError);
+						savedTabState.save(tab).then((r) => toastOnError(r, 'Failed to save tab'));
 					}}
 				>
 					<ArchiveIcon />
@@ -163,7 +163,7 @@
 					tooltip={isBookmarked ? 'Remove bookmark' : 'Bookmark'}
 					onclick={(e: MouseEvent) => {
 						e.stopPropagation();
-						bookmarkState.toggle(tab).then(toastOnError);
+						bookmarkState.toggle(tab).then((r) => toastOnError(r, 'Failed to toggle bookmark'));
 					}}
 				>
 					<StarIcon

--- a/apps/tab-manager/src/lib/components/tabs/UnifiedTabList.svelte
+++ b/apps/tab-manager/src/lib/components/tabs/UnifiedTabList.svelte
@@ -99,7 +99,7 @@
 								variant="ghost"
 								size="icon-xs"
 								tooltip="Restore All"
-								onclick={() => savedTabState.restoreAll().then(toastOnError)}
+							onclick={() => savedTabState.restoreAll().then((r) => toastOnError(r, 'Failed to restore tabs'))}
 							>
 								<RotateCcwIcon />
 							</Button>
@@ -108,7 +108,7 @@
 								size="icon-xs"
 								class="text-destructive"
 								tooltip="Delete All"
-								onclick={() => savedTabState.removeAll().then(toastOnError)}
+							onclick={() => savedTabState.removeAll().then((r) => toastOnError(r, 'Failed to remove tabs'))}
 							>
 								<Trash2Icon />
 							</Button>
@@ -174,8 +174,8 @@
 								variant="ghost"
 								size="icon-xs"
 								tooltip="Restore"
-								onclick={() =>
-								savedTabState.restore(tab).then(toastOnError)}
+							onclick={() =>
+							savedTabState.restore(tab).then((r) => toastOnError(r, 'Failed to restore tab'))}
 							>
 								<RotateCcwIcon />
 							</Button>
@@ -184,8 +184,8 @@
 								size="icon-xs"
 								class="text-destructive"
 								tooltip="Delete"
-								onclick={() =>
-								savedTabState.remove(tab.id).then(toastOnError)}
+							onclick={() =>
+							savedTabState.remove(tab.id).then((r) => toastOnError(r, 'Failed to remove tab'))}
 							>
 								<Trash2Icon />
 							</Button>
@@ -218,7 +218,7 @@
 								variant="ghost"
 								size="icon-xs"
 								tooltip="Open"
-								onclick={() => bookmarkState.open(bookmark).then(toastOnError)}
+							onclick={() => bookmarkState.open(bookmark).then((r) => toastOnError(r, 'Failed to open bookmark'))}
 							>
 								<ExternalLinkIcon />
 							</Button>
@@ -227,7 +227,7 @@
 								size="icon-xs"
 								class="text-destructive"
 								tooltip="Delete"
-								onclick={() => bookmarkState.remove(bookmark.id).then(toastOnError)}
+							onclick={() => bookmarkState.remove(bookmark.id).then((r) => toastOnError(r, 'Failed to remove bookmark'))}
 							>
 								<Trash2Icon />
 							</Button>

--- a/apps/whispering/src/routes/(app)/(config)/macos-enable-accessibility/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/macos-enable-accessibility/+page.svelte
@@ -19,8 +19,7 @@
 
 		if (error) {
 			toast.error('Failed to open accessibility settings', {
-				description:
-					'Please enable Accessibility in System Settings > Privacy & Security > Accessibility manually',
+				description: error.message,
 				action: {
 					label: 'Open Accessibility Settings',
 					onClick: () => openSystemSettings(),

--- a/apps/whispering/src/routes/(app)/_layout-utils/register-permissions.ts
+++ b/apps/whispering/src/routes/(app)/_layout-utils/register-permissions.ts
@@ -1,4 +1,4 @@
-import { toast } from '@epicenter/ui/sonner';
+import { toast, toastOnError } from '@epicenter/ui/sonner';
 import { nanoid } from 'nanoid/non-secure';
 import { goto } from '$app/navigation';
 import { IS_MACOS } from '$lib/constants/platform';
@@ -73,12 +73,7 @@ export function registerMicrophonePermission() {
 						const { error: requestError } =
 							await desktopServices.permissions.microphone.request();
 
-						if (requestError) {
-							toast.error('Failed to request microphone permission', {
-								description: 'Please check your system settings',
-							});
-							return;
-						}
+						if (requestError) return toastOnError(requestError, 'Failed to request microphone permission');
 						// Dismiss the toast after requesting
 						toast.dismiss(microphoneToastId);
 					},

--- a/packages/ui/src/sonner/toast-on-error.ts
+++ b/packages/ui/src/sonner/toast-on-error.ts
@@ -19,16 +19,12 @@ import type { Result } from 'wellcrafted/result';
  *
  * @example
  * ```typescript
- * // Wrapping before destructure
- * const { data, error } = toastOnError(await api.billing.portal(), 'Could not open billing portal');
- * if (error) return;
- *
- * // Already destructured—toast and return in one expression
+ * // Destructure first, toast and return in one expression (preferred)
  * const { data, error } = await api.billing.portal();
  * if (error) return toastOnError(error, 'Could not open billing portal');
  *
- * // Fire-and-forget
- * bookmarkState.toggle(tab).then(r => toastOnError(r, 'Failed to toggle bookmark'));
+ * // Fire-and-forget in onclick handlers
+ * bookmarkState.toggle(tab).then((r) => toastOnError(r, 'Failed to toggle bookmark'));
  * ```
  */
 export function toastOnError<TInput extends Result<unknown, AnyTaggedError> | AnyTaggedError>(

--- a/packages/ui/src/sonner/toast-on-error.ts
+++ b/packages/ui/src/sonner/toast-on-error.ts
@@ -3,26 +3,41 @@ import type { AnyTaggedError } from 'wellcrafted/error';
 import type { Result } from 'wellcrafted/result';
 
 /**
- * Show an error toast when a Result contains an error, then pass the Result through.
+ * Show an error toast and pass through the value unchanged.
  *
- * Works as both a `.then()` callback and a direct wrapper—the Result is
- * returned untouched so callers can still destructure `{ data, error }`.
+ * Accepts either a full `Result` or a bare tagged error. When given a Result,
+ * it toasts only if the error branch is present. When given a bare error, it
+ * always toasts. Either way the input is returned unchanged—so you can wrap
+ * expressions or slot it into `return` statements without disrupting control flow.
+ *
+ * The title appears as the bold headline. The error's `.message`—typically the
+ * detailed output from `defineErrors`—is shown as the muted description below.
+ *
+ * @param resultOrError - A `Result` to inspect, or a bare tagged error to toast
+ * @param title - Human-readable headline shown in the toast
+ * @returns The same `resultOrError`, unchanged
  *
  * @example
  * ```typescript
- * // Chainable — fire-and-forget in onclick handlers
- * bookmarkState.toggle(tab).then(toastOnError);
+ * // Wrapping before destructure
+ * const { data, error } = toastOnError(await api.billing.portal(), 'Could not open billing portal');
+ * if (error) return;
  *
- * // Wrapping — when you need the result afterward
- * const { data, error } = toastOnError(await bookmarkState.toggle(tab));
- * if (error) return; // already toasted
+ * // Already destructured—toast and return in one expression
+ * const { data, error } = await api.billing.portal();
+ * if (error) return toastOnError(error, 'Could not open billing portal');
+ *
+ * // Fire-and-forget
+ * bookmarkState.toggle(tab).then(r => toastOnError(r, 'Failed to toggle bookmark'));
  * ```
  */
-export function toastOnError<TResult extends Result<unknown, AnyTaggedError>>(
-	result: TResult,
-): TResult {
-	if (result.error) {
-		toast.error(result.error.message);
+export function toastOnError<TInput extends Result<unknown, AnyTaggedError> | AnyTaggedError>(
+	resultOrError: TInput,
+	title: string,
+): TInput {
+	const error = 'data' in resultOrError ? resultOrError.error : resultOrError;
+	if (error) {
+		toast.error(title, { description: error.message });
 	}
-	return result;
+	return resultOrError;
 }

--- a/packages/workspace/src/extensions/sync/origins.ts
+++ b/packages/workspace/src/extensions/sync/origins.ts
@@ -1,16 +1,31 @@
 /**
  * Transport origin sentinels for Yjs sync.
  *
- * Every transport that applies remote updates to a Y.Doc must tag them
- * with an origin Symbol so other handlers can skip re-broadcasting:
+ * These Symbols live in a shared file because multiple modules participate
+ * in the same echo-prevention protocol: the BC handler needs to know about
+ * SYNC_ORIGIN (to not re-broadcast server updates), the WS handler needs to
+ * know about BC_ORIGIN (to not re-send tab-synced updates), and the
+ * `onUpdate` handler in `create-documents.ts` uses `typeof origin === 'symbol'`
+ * to skip all transport-delivered updates at once. No single module owns
+ * these—they're a cross-cutting contract.
  *
- * - BroadcastChannel applies with `BC_ORIGIN`
- * - WebSocket applies with `SYNC_ORIGIN`
- * - The `onUpdate` handler in `create-documents.ts` skips all Symbol
- *   origins via `typeof origin === 'symbol'`—this convention means
- *   local edits (y-prosemirror uses a PluginKey object, direct
- *   mutations use null) pass through while transport-delivered updates
- *   are ignored.
+ * Other origin Symbols in the codebase are intentionally NOT here:
+ *
+ * - `DOCUMENTS_ORIGIN` (create-documents.ts)—a self-referential guard.
+ *   The document manager writes to the workspace Y.Doc with this origin,
+ *   then checks for it on the same Y.Doc to avoid re-triggering itself.
+ *   Both the write and the check live in the same file. No other module
+ *   needs to see it.
+ *
+ * - `DEDUP_ORIGIN` (y-keyvalue-lww.ts), `REENCRYPT_ORIGIN`
+ *   (y-keyvalue-lww-encrypted.ts)—internal self-loop guards for LWW
+ *   conflict resolution and key rotation. They never leave their
+ *   defining module.
+ *
+ * Convention: every transport that applies remote updates to a Y.Doc must
+ * tag them with a Symbol origin defined here. The `typeof origin === 'symbol'`
+ * check in create-documents.ts relies on this—local edits use non-Symbol
+ * origins (y-prosemirror uses a PluginKey object, direct mutations use null).
  *
  * If you add a new transport, define its origin here as a Symbol.
  *

--- a/specs/20260413T225625-fuji-stress-test.md
+++ b/specs/20260413T225625-fuji-stress-test.md
@@ -1,0 +1,64 @@
+# Fuji Stress Test — 1k/10k Notes (In-App UI)
+
+## Goal
+
+Build an in-app `/stress-test` page in `apps/fuji` that generates 1,000 or 10,000 entries with realistic data via the workspace API. Stress tests both the CRDT layer and the UI rendering under load. Measures insertion time, Y.Doc binary size, and read performance—all visible in the browser.
+
+## Context
+
+- Fuji's data model: `entries` table (v2) with fields `id`, `title`, `subtitle`, `type`, `tags`, `pinned`, `rating`, `deletedAt`, `date`, `createdAt`, `updatedAt`, `_v: 2`
+- Each entry has a `.withDocument('content')` creating a per-entry Y.Doc with a timeline → Y.XmlFragment for ProseMirror rich text
+- Existing reference: `packages/workspace/scripts/stress-test-static.ts` — raw Y.Doc + `createTables`, measures add/delete cycles and binary size
+- Fuji factory: `createFujiWorkspace()` returns a workspace builder with `entries.create`, `entries.bulkCreate`, and `tables.entries.bulkSet`
+- `bulkSet` already chunks in 1k batches with `onProgress` callback
+
+## Design
+
+**In-app page at `/stress-test`** so the UI renders the entries after insertion—testing both CRDT perf and Svelte rendering under load.
+
+**Uses the live `workspace` client from `$lib/client`** (with IndexedDB persistence and sync extensions). This is the real app workspace, so generated entries show up in the sidebar, table view, etc.—the actual stress test scenario.
+
+**Controls:**
+- Count selector: 1,000 or 10,000
+- "Generate" button to kick off insertion
+- "Clear Generated" button to remove stress test entries
+- Live progress display during generation
+
+**Results panel** shows insertion time, row count, and Y.Doc binary size after completion.
+
+**Tag all generated entries with `["stress-test"]`** so they can be identified and bulk-deleted.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `apps/fuji/src/routes/stress-test/+page.svelte` | Stress test UI page |
+
+## Implementation
+
+### Todo
+
+- [x] Update spec to reflect UI-based approach
+- [ ] Create `apps/fuji/src/routes/stress-test/+page.svelte`
+- [ ] Implement data generation (varied titles, dates, tags, types, ratings)
+- [ ] Wire generate button to `workspace.tables.entries.bulkSet`
+- [ ] Show progress during insertion (bulkSet onProgress callback)
+- [ ] Measure and display: insertion time, row count, Y.Doc binary size
+- [ ] Add "Clear Generated" button that deletes entries tagged `stress-test`
+- [ ] Verify no type errors
+
+### Data Generation
+
+```
+Titles:     Pool of ~30 realistic note titles, picked randomly + index suffix for uniqueness
+Subtitles:  Pool of ~15 editorial hooks, or empty string (50% chance)
+Types:      ["article", "thought", "idea", "research", "journal"] — pick 0–2 randomly
+Tags:       Always includes "stress-test" + 0–2 from ["draft", "published", "favorite", "personal", "work", "code", "design", "writing"]
+Rating:     0–5 integer, weighted toward 0 (unrated)
+Date:       Random date within last 2 years
+Pinned:     5% chance of true
+```
+
+## Review
+
+_To be filled after implementation._


### PR DESCRIPTION
Fuji's view preferences—view mode, sort order, search query—used to live in workspace KV. That meant they were persisted to the document, synced across devices, and completely invisible to the browser. No deep-linking, no back button, no shareable URLs. This PR moves all three into URL search params where they belong.

**The URL is now the source of truth for view state.** `?view=timeline`, `?sort=title`, `?q=...` are the canonical representations. Default values are elided so a clean `/` means table view, sorted by date, no filter. Reads go through `page.url.searchParams` (reactive in `.svelte.ts` files), writes go through a small `setSearchParam()` utility that calls `goto()` with `replaceState: true`. The old `viewMode` and `sortBy` KV definitions are gone from the workspace schema entirely.

The previous `entries.svelte.ts` was split into two files to make the separation explicit: `entries-state.svelte.ts` owns data CRUD, `view-state.svelte.ts` owns URL-derived view preferences. The table's sort controls are now keyboard-navigable and derive their active state from the URL params directly.

---

**`toastOnError` got a structural fix while we were here.** It now supports a `title + description` pattern instead of collapsing everything into a single string. The `extractErrorMessage` helper provides structured error descriptions, which fixes the `[object Object]` toast that was showing in Whispering's accessibility settings when an error object landed where a string was expected. All toast consumers across the apps (dashboard, tab-manager, opensidian, whispering) were updated to the new shape.

---

**A few smaller things rounded out the window.** A `/stress-test` route in Fuji lets you bulk-generate entries during development—not user-facing, just useful for testing table and timeline performance at scale. On the accessibility side, timeline entry items now have keyboard support and tag remove buttons have `aria-label`s. A leaked document handle on async cleanup race in the Fuji entry editor is fixed. Opensidian's auto-seeding no longer runs for authenticated users.

Stacks on #1655. 35 files across `apps/fuji/`, `packages/ui/`, `apps/whispering/`, `apps/opensidian/`, `apps/dashboard/`, `apps/tab-manager/`, and `.agents/skills/`.