### PR TITLE
feat(whispering): update Anthropic model list to current Claude lineup

### DIFF
--- a/apps/whispering/README.md
+++ b/apps/whispering/README.md
@@ -462,8 +462,8 @@ You'll need additional API keys for AI transformations. Choose from these provid
 
 #### 🤖 Anthropic
 
-- **API Key:** [console.anthropic.com/settings/keys](https://console.anthropic.com/settings/keys)
-- **Models:** `claude-opus-4-0`, `claude-sonnet-4-0`, `claude-3-7-sonnet-latest`
+- **API Key:** [platform.claude.com/settings/keys](https://platform.claude.com/settings/keys)
+- **Models:** `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5`
 - **Why:** Excellent writing quality, nuanced understanding
 
 #### ✨ Google Gemini

--- a/apps/whispering/src/lib/constants/inference.ts
+++ b/apps/whispering/src/lib/constants/inference.ts
@@ -47,11 +47,17 @@ export const INFERENCE = {
 	Anthropic: {
 		label: 'Anthropic',
 		models: [
-			// Claude 4.5 models (latest generation - recommended)
+			// Claude 4.6 models (latest generation - recommended)
+			'claude-opus-4-6',
+			'claude-sonnet-4-6',
+			// Claude 4.5 models
+			'claude-opus-4-5-20251101',
+			'claude-opus-4-5',
 			'claude-sonnet-4-5-20250929',
 			'claude-sonnet-4-5',
 			'claude-haiku-4-5-20251001',
 			'claude-haiku-4-5',
+			// Claude 4.1 models (legacy but still available)
 			'claude-opus-4-1-20250805',
 			'claude-opus-4-1',
 			// Claude 4 models (legacy but still available)
@@ -59,13 +65,7 @@ export const INFERENCE = {
 			'claude-sonnet-4-0',
 			'claude-opus-4-20250514',
 			'claude-opus-4-0',
-			// Claude 3.7 models (legacy)
-			'claude-3-7-sonnet-20250219',
-			'claude-3-7-sonnet-latest',
-			// Claude 3.5 models (legacy)
-			'claude-3-5-haiku-20241022',
-			'claude-3-5-haiku-latest',
-			// Claude 3 models (legacy)
+			// Claude 3 models (deprecated, retires 2026-04-20)
 			'claude-3-haiku-20240307',
 		],
 	},


### PR DESCRIPTION
## Summary

Aligns Whispering's Anthropic model dropdown (in the transformation-step configuration) with the current list of Claude models at [platform.claude.com/docs/en/about-claude/models/overview](https://platform.claude.com/docs/en/about-claude/models/overview) and the [model-deprecations page](https://platform.claude.com/docs/en/about-claude/model-deprecations).

Two problems today:

1. **Missing current models.** The dropdown doesn't include the Claude 4.6 generation (`claude-opus-4-6`, `claude-sonnet-4-6`) that Anthropic now recommends, or Claude Opus 4.5 (`claude-opus-4-5`). Users setting up LLM transformations have to manually edit the accelerator JSON to get at the flagship models.
2. **Dead model IDs still listed.** Four IDs in the list have already been retired as of 2026-02-19 and API calls to them now fail outright:
   - `claude-3-7-sonnet-20250219` and `claude-3-7-sonnet-latest`
   - `claude-3-5-haiku-20241022` and `claude-3-5-haiku-latest`

### Changes

`apps/whispering/src/lib/constants/inference.ts` — Anthropic model list:

- **Added**: `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-opus-4-5-20251101`, `claude-opus-4-5`.
- **Removed**: `claude-3-7-sonnet-*` and `claude-3-5-haiku-*` (retired).
- **Kept**: `claude-3-haiku-20240307` — it's deprecated and retires 2026-04-20, but still callable today. Comment updated with the retirement date so it's easy to remove in a follow-up.
- Reshuffled the comment headers so each block labels its own generation accurately (the old list labelled Sonnet 4.5 / Haiku 4.5 / Opus 4.1 as "Claude 4.5 models" together, which was never quite right).

`apps/whispering/README.md` — Anthropic provider section:

- Bumped the example model IDs from the retired `claude-opus-4-0`, `claude-sonnet-4-0`, `claude-3-7-sonnet-latest` to the current `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5`.
- Updated the API key link from `console.anthropic.com` (legacy host) to `platform.claude.com`, matching where Anthropic's docs now point users.

### Note on model-ID conventions

Starting with the 4.6 generation, Anthropic's docs list the **alias** (`claude-opus-4-6`) as both the "Claude API ID" and the "Claude API alias" — there's no dated snapshot variant exposed publicly yet. The existing list includes both dated and aliased forms for earlier models, so I've added just the alias for 4.6 to match what the docs surface. Happy to also add a dated form once Anthropic publishes one.

## Test plan

- [ ] `bun check` passes (no TypeScript regressions from the `readonly [...]` type update).
- [ ] Open Whispering → Transformations → create a new transformation with an LLM step → set provider to Anthropic → confirm the dropdown shows the new 4.6 / 4.5 IDs and no longer shows 3.7 Sonnet or 3.5 Haiku.
- [ ] Sanity-check a transformation using `claude-haiku-4-5` end-to-end against a valid API key to confirm no schema/type breakage on the provider call path.