### PR TITLE
feat(whispering): migrate recording schema to V2 with InferTableRow types

### DIFF
--- a/apps/whispering/src/lib/components/copyable/TranscriptDialog.svelte
+++ b/apps/whispering/src/lib/components/copyable/TranscriptDialog.svelte
@@ -12,7 +12,7 @@
 	 * ```svelte
 	 * <TranscriptDialog
 	 *   recordingId={recording.id}
-	 *   transcribedText={recording.transcribedText}
+ *   transcript={recording.transcript}
 	 *   rows={1}
 	 * />
 	 * ```
@@ -22,7 +22,7 @@
 	 * <!-- With loading state -->
 	 * <TranscriptDialog
 	 *   recordingId={recording.id}
-	 *   transcribedText="..."
+ *   transcript="..."
 	 *   loading={true}
 	 * />
 	 * ```
@@ -32,7 +32,7 @@
 	 * <!-- With delete button -->
 	 * <TranscriptDialog
 	 *   recordingId={recording.id}
-	 *   transcribedText={recording.transcribedText}
+ *   transcript={recording.transcript}
 	 *   onDelete={() => handleDelete(recording)}
 	 * />
 	 * ```
@@ -41,7 +41,7 @@
 		/** The ID of the recording whose transcript is being displayed */
 		recordingId,
 		/** The transcript content to display */
-		transcribedText,
+		transcript,
 		/** Number of rows for the preview textarea (default: 2) */
 		rows = 2,
 		/** Whether the dialog trigger is disabled */
@@ -52,7 +52,7 @@
 		onDelete,
 	}: {
 		recordingId: string;
-		transcribedText: string;
+		transcript: string;
 		rows?: number;
 		disabled?: boolean;
 		loading?: boolean;
@@ -64,7 +64,7 @@
 	id={viewTransition.recording(recordingId).transcript}
 	title="Transcript"
 	label="transcript"
-	text={transcribedText}
+	text={transcript}
 	{rows}
 	{disabled}
 	{loading}

--- a/apps/whispering/src/lib/migration/migrate-database.ts
+++ b/apps/whispering/src/lib/migration/migrate-database.ts
@@ -112,12 +112,17 @@ export async function migrateDatabaseToWorkspace({
 					}
 
 					const row: WorkspaceRecordingRow = {
-						...recording,
+						id: recording.id,
+						title: recording.title,
+						recordedAt: recording.recordedAt,
+						updatedAt: recording.updatedAt,
+						transcript: recording.transcript,
 						transcriptionStatus:
 							recording.transcriptionStatus === 'TRANSCRIBING'
 								? 'FAILED'
 								: recording.transcriptionStatus,
-						_v: 1 as const,
+						duration: recording.duration ?? undefined,
+						_v: 2 as const,
 					};
 
 					ws.tables.recordings.set(row);
@@ -170,7 +175,8 @@ export async function migrateDatabaseToWorkspace({
 		});
 
 		for (let index = 0; index < transformation.steps.length; index += 1) {
-			const step = transformation.steps[index]!;
+			const step = transformation.steps[index];
+			if (!step) continue;
 
 			trySync({
 				try: () => {

--- a/apps/whispering/src/lib/migration/migration-test-data.ts
+++ b/apps/whispering/src/lib/migration/migration-test-data.ts
@@ -23,11 +23,10 @@ function createMockRecording(index: number): {
 	const recording: Recording = {
 		id,
 		title: `Mock Recording ${index + 1}`,
-		subtitle: 'Generated for workspace migration testing',
-		timestamp: now,
-		createdAt: now,
+		recordedAt: now,
 		updatedAt: now,
-		transcribedText: index % 5 === 0 ? '' : `Mock transcript ${index + 1}`,
+		transcript: index % 5 === 0 ? '' : `Mock transcript ${index + 1}`,
+		duration: undefined,
 		transcriptionStatus,
 	};
 

--- a/apps/whispering/src/lib/query/actions.ts
+++ b/apps/whispering/src/lib/query/actions.ts
@@ -612,11 +612,10 @@ async function processRecordingPipeline({
 	const recording = {
 		id: newRecordingId,
 		title: '',
-		subtitle: '',
-		timestamp: now,
-		createdAt: now,
+		recordedAt: now,
 		updatedAt: now,
-		transcribedText: '',
+		transcript: '',
+		duration: undefined,
 		transcriptionStatus: 'UNPROCESSED',
 	} as const;
 
@@ -681,9 +680,11 @@ async function processRecordingPipeline({
 		description: completionDescription,
 	});
 
+	const title = transcribedText.slice(0, 60).trim() || 'Untitled Recording';
 	recordings.update(recording.id, {
-		transcribedText,
+		transcript: transcribedText,
 		transcriptionStatus: 'DONE',
+		title,
 	});
 
 	// Determine if we need to chain to transformation

--- a/apps/whispering/src/lib/query/transcription.ts
+++ b/apps/whispering/src/lib/query/transcription.ts
@@ -60,9 +60,11 @@ export const transcription = {
 				return Err(transcribeError);
 			}
 
+			const title = transcribedText.slice(0, 60).trim() || 'Untitled Recording';
 			recordings.update(recording.id, {
-				transcribedText,
+				transcript: transcribedText,
 				transcriptionStatus: 'DONE',
+				title,
 			});
 			return Ok(transcribedText);
 		},

--- a/apps/whispering/src/lib/query/transformer.ts
+++ b/apps/whispering/src/lib/query/transformer.ts
@@ -168,7 +168,7 @@ export const transformer = {
 
 			const { data: transformationRun, error: transformationRunError } =
 				await runTransformation({
-					input: recording.transcribedText,
+					input: recording.transcript,
 					transformation,
 					steps,
 					recordingId,

--- a/apps/whispering/src/lib/services/db/desktop.ts
+++ b/apps/whispering/src/lib/services/db/desktop.ts
@@ -59,11 +59,11 @@ export function createDbServiceDesktop({
 					merged.set(rec.id, rec);
 				}
 
-				// Convert back to array and sort by timestamp (newest first)
+				// Convert back to array and sort by recordedAt (newest first)
 				const result = Array.from(merged.values());
 				result.sort(
 					(a, b) =>
-						new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+						new Date(b.recordedAt).getTime() - new Date(a.recordedAt).getTime(),
 				);
 
 				return Ok(result);

--- a/apps/whispering/src/lib/services/db/file-system.ts
+++ b/apps/whispering/src/lib/services/db/file-system.ts
@@ -22,28 +22,68 @@ import type { DbService } from './types';
 import { DbError } from './types';
 
 /**
- * Schema validator for Recording front matter (everything except transcribedText)
+ * Schema validator for normalized Recording front matter.
+ *
+ * The transcript lives in the markdown body, not the YAML frontmatter.
  */
 const RecordingFrontMatter = type({
 	id: 'string',
 	title: 'string',
-	subtitle: 'string',
-	timestamp: 'string',
-	createdAt: 'string',
+	recordedAt: 'string',
 	updatedAt: 'string',
 	transcriptionStatus: '"UNPROCESSED" | "TRANSCRIBING" | "DONE" | "FAILED"',
+	'duration?': 'number | undefined',
+});
+
+const RecordingFrontMatterRaw = type({
+	id: 'string',
+	title: 'string',
+	'recordedAt?': 'string | undefined',
+	'timestamp?': 'string | undefined',
+	'updatedAt?': 'string | undefined',
+	'updated_at?': 'string | undefined',
+	'transcriptionStatus?':
+		'"UNPROCESSED" | "TRANSCRIBING" | "DONE" | "FAILED" | undefined',
+	'transcription_status?':
+		'"UNPROCESSED" | "TRANSCRIBING" | "DONE" | "FAILED" | undefined',
+	'duration?': 'number | undefined',
+	'subtitle?': 'string | undefined',
+	'createdAt?': 'string | undefined',
+	'created_at?': 'string | undefined',
 });
 
 type RecordingFrontMatter = typeof RecordingFrontMatter.infer;
+type RecordingFrontMatterRaw = typeof RecordingFrontMatterRaw.infer;
+
+function normalizeRecordingFrontMatter(
+	rawFrontMatter: RecordingFrontMatterRaw,
+): RecordingFrontMatter | null {
+	const normalized = {
+		id: rawFrontMatter.id,
+		title: rawFrontMatter.title,
+		recordedAt: rawFrontMatter.recordedAt ?? rawFrontMatter.timestamp,
+		updatedAt: rawFrontMatter.updatedAt ?? rawFrontMatter.updated_at,
+		transcriptionStatus:
+			rawFrontMatter.transcriptionStatus ?? rawFrontMatter.transcription_status,
+		duration: rawFrontMatter.duration,
+	};
+
+	const frontMatter = RecordingFrontMatter(normalized);
+	if (frontMatter instanceof type.errors) {
+		return null;
+	}
+
+	return frontMatter;
+}
 
 /**
  * Convert Recording to markdown format (frontmatter + body)
  */
 function recordingToMarkdown({
-	transcribedText,
+	transcript,
 	...frontMatter
 }: Recording): string {
-	return stringifyFrontmatter(transcribedText ?? '', frontMatter);
+	return stringifyFrontmatter(transcript, frontMatter);
 }
 
 /**
@@ -58,7 +98,7 @@ function markdownToRecording({
 }): Recording {
 	return {
 		...frontMatter,
-		transcribedText: body.trimEnd(),
+		transcript: body.trimEnd(),
 	};
 }
 
@@ -121,23 +161,27 @@ export function createFileSystemDb(): DbService {
 						const recordings = contents.map((content) => {
 							const { data, content: body } = parseFrontmatter(content);
 
-							// Validate the front matter schema
-							const frontMatter = RecordingFrontMatter(data);
-							if (frontMatter instanceof type.errors) {
+							const rawFrontMatter = RecordingFrontMatterRaw(data);
+							if (rawFrontMatter instanceof type.errors) {
+								return null; // Skip invalid recording, don't crash the app
+							}
+
+							const frontMatter = normalizeRecordingFrontMatter(rawFrontMatter);
+							if (!frontMatter) {
 								return null; // Skip invalid recording, don't crash the app
 							}
 
 							return markdownToRecording({ frontMatter, body });
 						});
 
-						// Filter out any null entries and sort by timestamp (newest first)
+						// Filter out any null entries and sort by recordedAt (newest first)
 						const validRecordings = recordings.filter(
 							(r): r is Recording => r !== null,
 						);
 						validRecordings.sort(
 							(a, b) =>
-								new Date(b.timestamp).getTime() -
-								new Date(a.timestamp).getTime(),
+								new Date(b.recordedAt).getTime() -
+								new Date(a.recordedAt).getTime(),
 						);
 
 						return validRecordings;
@@ -185,11 +229,17 @@ export function createFileSystemDb(): DbService {
 						const content = await readTextFile(mdPath);
 						const { data, content: body } = parseFrontmatter(content);
 
-						// Validate the front matter schema
-						const frontMatter = RecordingFrontMatter(data);
-						if (frontMatter instanceof type.errors) {
+						const rawFrontMatter = RecordingFrontMatterRaw(data);
+						if (rawFrontMatter instanceof type.errors) {
 							throw new Error(
-								`Invalid recording front matter: ${frontMatter.summary}`,
+								`Invalid recording front matter: ${rawFrontMatter.summary}`,
+							);
+						}
+
+						const frontMatter = normalizeRecordingFrontMatter(rawFrontMatter);
+						if (!frontMatter) {
+							throw new Error(
+								'Invalid recording front matter: failed to normalize legacy fields',
 							);
 						}
 

--- a/apps/whispering/src/lib/services/db/file-system.ts
+++ b/apps/whispering/src/lib/services/db/file-system.ts
@@ -16,7 +16,7 @@ import { Ok, tryAsync } from 'wellcrafted/result';
 import { PATHS } from '$lib/constants/paths';
 import { FsServiceLive } from '$lib/services/desktop/fs';
 import { parseFrontmatter, stringifyFrontmatter } from './frontmatter';
-import type { Recording } from './models';
+import type { DbRecording } from './models';
 import { Transformation, TransformationRun } from './models';
 import type { DbService } from './types';
 import { DbError } from './types';
@@ -77,17 +77,17 @@ function normalizeRecordingFrontMatter(
 }
 
 /**
- * Convert Recording to markdown format (frontmatter + body)
+ * Convert DbRecording to markdown format (frontmatter + body)
  */
 function recordingToMarkdown({
 	transcript,
 	...frontMatter
-}: Recording): string {
+}: DbRecording): string {
 	return stringifyFrontmatter(transcript, frontMatter);
 }
 
 /**
- * Convert markdown file (YAML frontmatter + body) to Recording
+ * Convert markdown file (YAML frontmatter + body) to DbRecording
  */
 function markdownToRecording({
 	frontMatter,
@@ -95,7 +95,7 @@ function markdownToRecording({
 }: {
 	frontMatter: RecordingFrontMatter;
 	body: string;
-}): Recording {
+}): DbRecording {
 	return {
 		...frontMatter,
 		transcript: body.trimEnd(),
@@ -176,7 +176,7 @@ export function createFileSystemDb(): DbService {
 
 						// Filter out any null entries and sort by recordedAt (newest first)
 						const validRecordings = recordings.filter(
-							(r): r is Recording => r !== null,
+						(r): r is DbRecording => r !== null,
 						);
 						validRecordings.sort(
 							(a, b) =>
@@ -293,7 +293,7 @@ export function createFileSystemDb(): DbService {
 				const recordingWithTimestamp = {
 					...recording,
 					updatedAt: now,
-				} satisfies Recording;
+				} satisfies DbRecording;
 
 				return tryAsync({
 					try: async () => {

--- a/apps/whispering/src/lib/services/db/index.ts
+++ b/apps/whispering/src/lib/services/db/index.ts
@@ -3,7 +3,7 @@ import { createDbServiceDesktop } from './desktop';
 import { createDbServiceWeb } from './web';
 
 export type {
-	Recording,
+	DbRecording,
 	Transformation,
 	TransformationRun,
 	TransformationRunCompleted,

--- a/apps/whispering/src/lib/services/db/models/index.ts
+++ b/apps/whispering/src/lib/services/db/models/index.ts
@@ -1,5 +1,5 @@
 // Recordings
-export type { Recording } from './recordings';
+export type { DbRecording } from './recordings';
 
 // Transformation Runs
 export {

--- a/apps/whispering/src/lib/services/db/models/recordings.ts
+++ b/apps/whispering/src/lib/services/db/models/recordings.ts
@@ -1,28 +1,30 @@
 /**
  * Recording intermediate representation.
  *
- * This type represents the unified interface for recordings across the application.
- * It is NOT the storage format - different storage implementations use different formats:
+ * This is the DB service's normalized recording shape. Storage adapters read their
+ * native format and convert into this type before the rest of the app touches it.
  *
- * - Desktop: Stores metadata in markdown files (.md) and audio in separate files (.webm, .mp3)
- * - Web: Stores in IndexedDB with serialized audio (see web/dexie-schemas.ts)
+ * - Desktop stores recording metadata in markdown frontmatter, with the markdown body
+ *   holding the transcript and a sibling audio file holding the blob.
+ * - Web stores recording metadata in IndexedDB, alongside serialized audio data.
  *
- * Both implementations read their storage format and convert it to this intermediate
- * representation for use in the UI layer.
- *
- * Audio access: Audio data is NOT stored in this intermediate representation. Instead, use:
- * - `db.recordings.getAudioBlob(id)` to fetch audio as a Blob
- * - `db.recordings.ensureAudioPlaybackUrl(id)` to get a playback URL
- * - `db.recordings.revokeAudioUrl(id)` to clean up cached URLs
+ * Audio bytes are intentionally excluded from this type. Use the recording DB service
+ * methods to fetch or create playback URLs on demand instead of passing blobs around
+ * in the intermediate representation.
  */
 export type Recording = {
 	id: string;
 	title: string;
-	subtitle: string;
-	timestamp: string;
-	createdAt: string;
+	recordedAt: string;
 	updatedAt: string;
-	transcribedText: string;
+	transcript: string;
+	/**
+	 * Optional recording duration in milliseconds.
+	 *
+	 * Older recordings will not have this populated, so callers must handle it being
+	 * absent.
+	 */
+	duration?: number;
 	/**
 	 * Recording lifecycle status:
 	 * 1. Begins in 'UNPROCESSED' state

--- a/apps/whispering/src/lib/services/db/models/recordings.ts
+++ b/apps/whispering/src/lib/services/db/models/recordings.ts
@@ -1,18 +1,14 @@
 /**
- * Recording intermediate representation.
+ * DB service's recording storage shape.
  *
- * This is the DB service's normalized recording shape. Storage adapters read their
- * native format and convert into this type before the rest of the app touches it.
+ * This is NOT the domain Recording type (that lives in `$lib/workspace`). This type
+ * describes what the storage adapters (file-system, IndexedDB) persist alongside audio
+ * blobs. It exists because storage formats embed metadata for human readability (markdown
+ * frontmatter) and backward compatibility (IndexedDB rows).
  *
- * - Desktop stores recording metadata in markdown frontmatter, with the markdown body
- *   holding the transcript and a sibling audio file holding the blob.
- * - Web stores recording metadata in IndexedDB, alongside serialized audio data.
- *
- * Audio bytes are intentionally excluded from this type. Use the recording DB service
- * methods to fetch or create playback URLs on demand instead of passing blobs around
- * in the intermediate representation.
+ * Once the DB service is slimmed to audio-blob-only operations, this type can be removed.
  */
-export type Recording = {
+export type DbRecording = {
 	id: string;
 	title: string;
 	recordedAt: string;

--- a/apps/whispering/src/lib/services/db/types.ts
+++ b/apps/whispering/src/lib/services/db/types.ts
@@ -6,7 +6,7 @@ import {
 import type { Result } from 'wellcrafted/result';
 
 import type {
-	Recording,
+	DbRecording,
 	Transformation,
 	TransformationRun,
 	TransformationRunCompleted,
@@ -33,19 +33,19 @@ export const DbError = defineErrors({
 });
 export type DbError = InferErrors<typeof DbError>;
 
-type RecordingWithAudio = { recording: Recording; audio: Blob };
+type RecordingWithAudio = { recording: DbRecording; audio: Blob };
 
 export type DbService = {
 	recordings: {
-		getAll(): Promise<Result<Recording[], DbError>>;
-		getLatest(): Promise<Result<Recording | null, DbError>>;
+		getAll(): Promise<Result<DbRecording[], DbError>>;
+		getLatest(): Promise<Result<DbRecording | null, DbError>>;
 		getTranscribingIds(): Promise<Result<string[], DbError>>;
-		getById(id: string): Promise<Result<Recording | null, DbError>>;
+		getById(id: string): Promise<Result<DbRecording | null, DbError>>;
 		create(
 			params: RecordingWithAudio | RecordingWithAudio[],
 		): Promise<Result<void, DbError>>;
-		update(recording: Recording): Promise<Result<Recording, DbError>>;
-		delete(recording: Recording | Recording[]): Promise<Result<void, DbError>>;
+		update(recording: DbRecording): Promise<Result<DbRecording, DbError>>;
+		delete(recording: DbRecording | DbRecording[]): Promise<Result<void, DbError>>;
 		cleanupExpired(params: {
 			recordingRetentionStrategy: 'keep-forever' | 'limit-count';
 			maxRecordingCount: number;

--- a/apps/whispering/src/lib/services/db/web/dexie-schemas.ts
+++ b/apps/whispering/src/lib/services/db/web/dexie-schemas.ts
@@ -7,7 +7,7 @@
  *
  * @see {@link ../models/recordings.ts} for the domain type used by UI and services
  */
-import type { Recording } from '../models/recordings';
+import type { DbRecording } from '../models/recordings';
 
 /**
  * Serialized audio format for IndexedDB storage.
@@ -46,7 +46,7 @@ type RecordingStoredInIndexedDbLegacy = {
  * both shapes.
  */
 export type RecordingStoredInIndexedDB =
-	| (Recording & {
+	| (DbRecording & {
 			serializedAudio: SerializedAudio | undefined;
 	  })
 	| RecordingStoredInIndexedDbLegacy;

--- a/apps/whispering/src/lib/services/db/web/dexie-schemas.ts
+++ b/apps/whispering/src/lib/services/db/web/dexie-schemas.ts
@@ -26,18 +26,30 @@ export type SerializedAudio = {
 	blobType: string;
 };
 
+type RecordingStoredInIndexedDbLegacy = {
+	id: string;
+	title: string;
+	subtitle: string;
+	timestamp: string;
+	createdAt: string;
+	updatedAt: string;
+	transcribedText: string;
+	transcriptionStatus: 'UNPROCESSED' | 'TRANSCRIBING' | 'DONE' | 'FAILED';
+	serializedAudio: SerializedAudio | undefined;
+};
+
 /**
  * How a recording is actually stored in IndexedDB (storage format).
  *
- * This is NOT the intermediate representation used by the UI (see Recording type).
- *
- * Extends Recording with:
- * - `serializedAudio` field for storing audio data (see SerializedAudio type)
- * - Audio is stored in serialized format to work around iOS Safari Blob storage issues
+ * New writes use the V2 recording field names. Existing IndexedDB rows may still carry
+ * legacy V1/V4-style names until they are read and rewritten, so the storage type accepts
+ * both shapes.
  */
-export type RecordingStoredInIndexedDB = Recording & {
-	serializedAudio: SerializedAudio | undefined;
-};
+export type RecordingStoredInIndexedDB =
+	| (Recording & {
+			serializedAudio: SerializedAudio | undefined;
+	  })
+	| RecordingStoredInIndexedDbLegacy;
 
 export type RecordingsDbSchemaV5 = {
 	recordings: RecordingStoredInIndexedDB;

--- a/apps/whispering/src/lib/services/db/web/index.ts
+++ b/apps/whispering/src/lib/services/db/web/index.ts
@@ -2,7 +2,7 @@ import { nanoid } from 'nanoid/non-secure';
 import { Err, Ok, tryAsync } from 'wellcrafted/result';
 import type { DownloadService } from '$lib/services/download';
 import type {
-	Recording,
+	DbRecording,
 	Transformation,
 	TransformationRun,
 	TransformationRunCompleted,
@@ -32,7 +32,7 @@ function serializedAudioToBlob(serializedAudio: SerializedAudio): Blob {
 
 function storedRecordingToRecording(
 	recording: RecordingStoredInIndexedDB,
-): Recording {
+): DbRecording {
 	return {
 		id: recording.id,
 		title: recording.title,
@@ -52,7 +52,7 @@ function recordingToStoredRecording({
 	recording,
 	serializedAudio,
 }: {
-	recording: Recording;
+	recording: DbRecording;
 	serializedAudio: SerializedAudio | undefined;
 }): RecordingsDbSchemaV5['recordings'] {
 	return {
@@ -61,7 +61,7 @@ function recordingToStoredRecording({
 	};
 }
 
-function sortByRecordedAtDesc(recordings: Recording[]): Recording[] {
+function sortByRecordedAtDesc(recordings: DbRecording[]): DbRecording[] {
 	return [...recordings].sort(
 		(a, b) =>
 			new Date(b.recordedAt).getTime() - new Date(a.recordedAt).getTime(),
@@ -112,7 +112,7 @@ export function createDbServiceWeb({
 					try: () =>
 						db.recordings
 							.where('transcriptionStatus')
-							.equals('TRANSCRIBING' satisfies Recording['transcriptionStatus'])
+							.equals('TRANSCRIBING' satisfies DbRecording['transcriptionStatus'])
 							.primaryKeys(),
 					catch: (error) => DbError.QueryFailed({ cause: error }),
 				});
@@ -157,7 +157,7 @@ export function createDbServiceWeb({
 				const recordingWithTimestamp = {
 					...recording,
 					updatedAt: now,
-				} satisfies Recording;
+				} satisfies DbRecording;
 
 				// Get existing record to preserve serializedAudio (audio is immutable)
 				const existingRecord = await db.recordings.get(recording.id);

--- a/apps/whispering/src/lib/services/db/web/index.ts
+++ b/apps/whispering/src/lib/services/db/web/index.ts
@@ -1,7 +1,6 @@
 import { nanoid } from 'nanoid/non-secure';
 import { Err, Ok, tryAsync } from 'wellcrafted/result';
 import type { DownloadService } from '$lib/services/download';
-
 import type {
 	Recording,
 	Transformation,
@@ -12,10 +11,13 @@ import type {
 	TransformationStepRunFailed,
 	TransformationStepRunRunning,
 } from '../models';
-import type { DbService } from '../types';
-import { DbError } from '../types';
+import { DbError, type DbService } from '../types';
 import { blobToSerializedAudio, WhisperingDatabase } from './dexie-database';
-import type { RecordingsDbSchemaV5, SerializedAudio } from './dexie-schemas';
+import type {
+	RecordingsDbSchemaV5,
+	RecordingStoredInIndexedDB,
+	SerializedAudio,
+} from './dexie-schemas';
 
 // const downloadIndexedDbBlobWithToast = useDownloadIndexedDbBlobWithToast();
 
@@ -26,6 +28,44 @@ function serializedAudioToBlob(serializedAudio: SerializedAudio): Blob {
 	return new Blob([serializedAudio.arrayBuffer], {
 		type: serializedAudio.blobType,
 	});
+}
+
+function storedRecordingToRecording(
+	recording: RecordingStoredInIndexedDB,
+): Recording {
+	return {
+		id: recording.id,
+		title: recording.title,
+		recordedAt:
+			'recordedAt' in recording ? recording.recordedAt : recording.timestamp,
+		updatedAt: recording.updatedAt,
+		transcript:
+			'transcript' in recording
+				? recording.transcript
+				: recording.transcribedText,
+		transcriptionStatus: recording.transcriptionStatus,
+		duration: 'duration' in recording ? recording.duration : undefined,
+	};
+}
+
+function recordingToStoredRecording({
+	recording,
+	serializedAudio,
+}: {
+	recording: Recording;
+	serializedAudio: SerializedAudio | undefined;
+}): RecordingsDbSchemaV5['recordings'] {
+	return {
+		...recording,
+		serializedAudio,
+	};
+}
+
+function sortByRecordedAtDesc(recordings: Recording[]): Recording[] {
+	return [...recordings].sort(
+		(a, b) =>
+			new Date(b.recordedAt).getTime() - new Date(a.recordedAt).getTime(),
+	);
 }
 
 /**
@@ -45,13 +85,9 @@ export function createDbServiceWeb({
 			getAll: async () => {
 				return tryAsync({
 					try: async () => {
-						const recordings = await db.recordings
-							.orderBy('timestamp')
-							.reverse()
-							.toArray();
-						// Strip serializedAudio field to return Recording type
-						return recordings.map(
-							({ serializedAudio, ...recording }) => recording,
+						const recordings = await db.recordings.toArray();
+						return sortByRecordedAtDesc(
+							recordings.map(storedRecordingToRecording),
 						);
 					},
 					catch: (error) => DbError.QueryFailed({ cause: error }),
@@ -61,14 +97,11 @@ export function createDbServiceWeb({
 			getLatest: async () => {
 				return tryAsync({
 					try: async () => {
-						const latestRecording = await db.recordings
-							.orderBy('timestamp')
-							.reverse()
-							.first();
-						if (!latestRecording) return null;
-						// Strip serializedAudio field to return Recording type
-						const { serializedAudio, ...recording } = latestRecording;
-						return recording;
+						const recordings = await db.recordings.toArray();
+						const [latestRecording] = sortByRecordedAtDesc(
+							recordings.map(storedRecordingToRecording),
+						);
+						return latestRecording ?? null;
 					},
 					catch: (error) => DbError.QueryFailed({ cause: error }),
 				});
@@ -90,9 +123,7 @@ export function createDbServiceWeb({
 					try: async () => {
 						const maybeRecording = await db.recordings.get(id);
 						if (!maybeRecording) return null;
-						// Strip serializedAudio field to return Recording type
-						const { serializedAudio, ...recording } = maybeRecording;
-						return recording;
+						return storedRecordingToRecording(maybeRecording);
 					},
 					catch: (error) => DbError.QueryFailed({ cause: error }),
 				});
@@ -105,10 +136,12 @@ export function createDbServiceWeb({
 
 				const dbRecordings: RecordingsDbSchemaV5['recordings'][] =
 					await Promise.all(
-						paramsArray.map(async ({ recording, audio }) => ({
-							...recording,
-							serializedAudio: await blobToSerializedAudio(audio),
-						})),
+						paramsArray.map(async ({ recording, audio }) =>
+							recordingToStoredRecording({
+								recording,
+								serializedAudio: await blobToSerializedAudio(audio),
+							}),
+						),
 					);
 
 				return tryAsync({
@@ -131,10 +164,10 @@ export function createDbServiceWeb({
 				const serializedAudio = existingRecord?.serializedAudio;
 
 				// Create updated IndexedDB record with preserved audio
-				const dbRecording = {
-					...recordingWithTimestamp,
+				const dbRecording = recordingToStoredRecording({
+					recording: recordingWithTimestamp,
 					serializedAudio,
-				};
+				});
 
 				const { error: updateRecordingError } = await tryAsync({
 					try: async () => {
@@ -187,10 +220,14 @@ export function createDbServiceWeb({
 
 						return tryAsync({
 							try: async () => {
-								const idsToDelete = await db.recordings
-									.orderBy('createdAt')
-									.limit(count - maxRecordingCount)
-									.primaryKeys();
+								const idsToDelete = sortByRecordedAtDesc(
+									(await db.recordings.toArray()).map(
+										storedRecordingToRecording,
+									),
+								)
+									.reverse()
+									.slice(0, count - maxRecordingCount)
+									.map((recording) => recording.id);
 								await db.recordings.bulkDelete(idsToDelete);
 							},
 							catch: (error) => DbError.MutationFailed({ cause: error }),

--- a/apps/whispering/src/lib/state/recordings.svelte.ts
+++ b/apps/whispering/src/lib/state/recordings.svelte.ts
@@ -35,11 +35,10 @@ function createRecordings() {
 	// Without this, every access creates a new array → TanStack Table's $derived
 	// sees "new data" → updates internal $state → re-triggers $derived → infinite loop.
 	const sorted = $derived(
-		[...map.values()]
-			.sort(
-				(a, b) =>
-					new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
-			),
+		[...map.values()].sort(
+			(a, b) =>
+				new Date(b.recordedAt).getTime() - new Date(a.recordedAt).getTime(),
+		),
 	);
 
 	return {
@@ -65,7 +64,7 @@ function createRecordings() {
 		},
 
 		/**
-		 * All recordings as a sorted array (newest first by timestamp).
+		 * All recordings as a sorted array (newest first by recordedAt).
 		 *
 		 * Memoized via `$derived`—returns a stable reference until the
 		 * SvelteMap actually changes. This is critical for TanStack Table,
@@ -82,7 +81,7 @@ function createRecordings() {
 		 * No manual cache invalidation needed—the observer handles UI updates.
 		 */
 		set(recording: Omit<Recording, '_v'>) {
-			workspace.tables.recordings.set({ ...recording, _v: 1 } as Recording);
+			workspace.tables.recordings.set({ ...recording, _v: 2 } as Recording);
 		},
 
 		/**

--- a/apps/whispering/src/lib/state/recordings.svelte.ts
+++ b/apps/whispering/src/lib/state/recordings.svelte.ts
@@ -23,10 +23,8 @@
 import { fromTable } from '@epicenter/svelte';
 import { workspace } from '$lib/client';
 
-/** Recording row type inferred from the workspace table schema. */
-export type Recording = ReturnType<
-	typeof workspace.tables.recordings.getAllValid
->[number];
+/** Re-exported from the workspace definition for consumer convenience. */
+export type { Recording } from '$lib/workspace';
 
 function createRecordings() {
 	const map = fromTable(workspace.tables.recordings);

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -1,4 +1,4 @@
-import { defineKv, defineTable, defineWorkspace } from '@epicenter/workspace';
+import { defineKv, defineTable, defineWorkspace, type InferTableRow } from '@epicenter/workspace';
 import { type } from 'arktype';
 
 // ── Constant imports ─────────────────────────────────────────────────────────
@@ -62,6 +62,9 @@ const recordings = defineTable(
 			return row;
 	}
 });
+
+/** Recording row type inferred from the latest workspace table schema version. */
+export type Recording = InferTableRow<typeof recordings>;
 
 /** User-defined transformation pipelines. Each transformation has ordered steps. */
 const transformations = defineTable(

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -30,7 +30,38 @@ const recordings = defineTable(
 		transcriptionStatus: "'UNPROCESSED' | 'TRANSCRIBING' | 'DONE' | 'FAILED'",
 		_v: '1',
 	}),
-);
+	type({
+		id: 'string',
+		title: 'string',
+		recordedAt: 'string',
+		updatedAt: 'string',
+		transcript: 'string',
+		transcriptionStatus: "'UNPROCESSED' | 'TRANSCRIBING' | 'DONE' | 'FAILED'",
+		'duration?': 'number | undefined',
+		_v: '2',
+	}),
+).migrate((row) => {
+	switch (row._v) {
+		case 1: {
+			const title =
+				row.transcribedText.slice(0, 60).trim() ||
+				row.title ||
+				'Untitled Recording';
+			return {
+				id: row.id,
+				title,
+				recordedAt: row.timestamp,
+				updatedAt: row.updatedAt,
+				transcript: row.transcribedText,
+				transcriptionStatus: row.transcriptionStatus,
+				duration: undefined,
+				_v: 2,
+			};
+		}
+		case 2:
+			return row;
+	}
+});
 
 /** User-defined transformation pipelines. Each transformation has ordered steps. */
 const transformations = defineTable(

--- a/apps/whispering/src/lib/workspace/index.ts
+++ b/apps/whispering/src/lib/workspace/index.ts
@@ -1,1 +1,1 @@
-export { whisperingDefinition } from './definition';
+export { whisperingDefinition, type Recording } from './definition';

--- a/apps/whispering/src/routes/(app)/(config)/debug/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/debug/+page.svelte
@@ -149,16 +149,16 @@
 							workspace.ydoc.transact(() => {
 								for (let i = 0; i < count; i++) {
 									const now = new Date().toISOString();
+									const transcript = content;
 									workspace.tables.recordings.set({
 										id: nanoid(),
-										title: `Test Recording #${i + 1}`,
-										subtitle: 'Generated for stress testing',
-										timestamp: now,
-										createdAt: now,
+										title: transcript,
+										recordedAt: now,
 										updatedAt: now,
-										transcribedText: content,
+										transcript,
 										transcriptionStatus: 'DONE',
-										_v: 1,
+										duration: undefined,
+										_v: 2,
 									});
 								}
 							});

--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -98,12 +98,10 @@
 			enableHiding: false,
 			filterFn: (row, _columnId, filterValue) => {
 				const title = String(row.getValue('title'));
-				const subtitle = String(row.getValue('subtitle'));
-				const transcribedText = String(row.getValue('transcribedText'));
+				const transcript = String(row.getValue('transcript'));
 				return (
 					title.toLowerCase().includes(filterValue.toLowerCase()) ||
-					subtitle.toLowerCase().includes(filterValue.toLowerCase()) ||
-					transcribedText.toLowerCase().includes(filterValue.toLowerCase())
+					transcript.toLowerCase().includes(filterValue.toLowerCase())
 				);
 			},
 		},
@@ -132,31 +130,12 @@
 				}),
 		},
 		{
-			accessorKey: 'subtitle',
-			meta: { label: 'Subtitle' },
+			accessorKey: 'recordedAt',
+			meta: { label: 'Recorded' },
 			header: ({ column }) =>
 				renderComponent(SortableTableHeader, {
 					column,
-					headerText: 'Subtitle',
-				}),
-		},
-		{
-			accessorKey: 'timestamp',
-			meta: { label: 'Timestamp' },
-			header: ({ column }) =>
-				renderComponent(SortableTableHeader, {
-					column,
-					headerText: 'Timestamp',
-				}),
-			cell: formattedCell(DATE_FORMAT),
-		},
-		{
-			accessorKey: 'createdAt',
-			meta: { label: 'Created At' },
-			header: ({ column }) =>
-				renderComponent(SortableTableHeader, {
-					column,
-					headerText: 'Created At',
+					headerText: 'Recorded',
 				}),
 			cell: formattedCell(DATE_FORMAT),
 		},
@@ -171,7 +150,7 @@
 			cell: formattedCell(DATE_FORMAT),
 		},
 		{
-			accessorKey: 'transcribedText',
+			accessorKey: 'transcript',
 			meta: { label: 'Transcript' },
 			header: ({ column }) =>
 				renderComponent(SortableTableHeader, {
@@ -179,11 +158,11 @@
 					headerText: 'Transcript',
 				}),
 			cell: ({ getValue, row }) => {
-				const transcribedText = getValue<string>();
-				if (!transcribedText) return;
+				const transcript = getValue<string>();
+				if (!transcript) return;
 				return renderComponent(TranscriptDialog, {
 					recordingId: row.id,
-					transcribedText,
+					transcript: transcript,
 					onDelete: () => {
 						confirmationDialog.open({
 							title: 'Delete recording',
@@ -252,25 +231,22 @@
 
 	let sorting = createPersistedState({
 		key: 'whispering-recordings-data-table-sorting',
-		onParseError: (_error) => [{ id: 'timestamp', desc: true }],
 		schema: type({ desc: 'boolean', id: 'string' }).array(),
+		defaultValue: [{ id: 'recordedAt', desc: true }],
 	});
 	let columnFilters = $state<ColumnFiltersState>([]);
 	let columnVisibility = createPersistedState({
 		key: 'whispering-recordings-data-table-column-visibility',
-		onParseError: (_error) => ({
-			id: false,
-			title: false,
-			subtitle: false,
-			createdAt: false,
-			updatedAt: false,
-		}),
 		schema: type('Record<string, boolean>'),
+		defaultValue: {
+			id: false,
+			updatedAt: false,
+		},
 	});
 	let rowSelection = createPersistedState({
 		key: 'whispering-recordings-data-table-row-selection',
-		onParseError: (_error) => ({}),
 		schema: type('Record<string, boolean>'),
+		defaultValue: {},
 	});
 	let pagination = $state<PaginationState>({ pageIndex: 0, pageSize: 10 });
 	let globalFilter = $state('');
@@ -287,9 +263,9 @@
 		getPaginationRowModel: getPaginationRowModel(),
 		onSortingChange: (updater) => {
 			if (typeof updater === 'function') {
-				sorting.value = updater(sorting.value);
+				sorting.current = updater(sorting.current);
 			} else {
-				sorting.value = updater;
+				sorting.current = updater;
 			}
 		},
 		onColumnFiltersChange: (updater) => {
@@ -301,16 +277,16 @@
 		},
 		onColumnVisibilityChange: (updater) => {
 			if (typeof updater === 'function') {
-				columnVisibility.value = updater(columnVisibility.value);
+				columnVisibility.current = updater(columnVisibility.current);
 			} else {
-				columnVisibility.value = updater;
+				columnVisibility.current = updater;
 			}
 		},
 		onRowSelectionChange: (updater) => {
 			if (typeof updater === 'function') {
-				rowSelection.value = updater(rowSelection.value);
+				rowSelection.current = updater(rowSelection.current);
 			} else {
-				rowSelection.value = updater;
+				rowSelection.current = updater;
 			}
 		},
 		onPaginationChange: (updater) => {
@@ -329,16 +305,16 @@
 		},
 		state: {
 			get sorting() {
-				return sorting.value;
+				return sorting.current;
 			},
 			get columnFilters() {
 				return columnFilters;
 			},
 			get columnVisibility() {
-				return columnVisibility.value;
+				return columnVisibility.current;
 			},
 			get rowSelection() {
-				return rowSelection.value;
+				return rowSelection.current;
 			},
 			get pagination() {
 				return pagination;
@@ -353,7 +329,7 @@
 		table.getFilteredSelectedRowModel().rows,
 	);
 
-	let template = $state('{{timestamp}} {{transcribedText}}');
+	let template = $state('{{recordedAt}} {{transcript}}');
 	let delimiter = $state('\n\n');
 
 	let isDialogOpen = $state(false);
@@ -361,7 +337,7 @@
 	const joinedTranscriptionsText = $derived.by(() => {
 		const transcriptions = selectedRecordingRows
 			.map(({ original }) => original)
-			.filter((recording) => recording.transcribedText !== '')
+			.filter((recording) => recording.transcript !== '')
 			.map((recording) =>
 				template.replace(/\{\{(\w+)\}\}/g, (_, key) => {
 					if (key in recording) {

--- a/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/EditRecordingModal.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/EditRecordingModal.svelte
@@ -149,38 +149,26 @@
 				/>
 			</div>
 			<div class="grid grid-cols-4 items-center gap-4">
-				<Label for="subtitle" class="text-right">Subtitle</Label>
+				<Label for="recordedAt" class="text-right">Recorded At</Label>
 				<Input
-					id="subtitle"
-					value={workingCopy.subtitle}
+					id="recordedAt"
+					value={workingCopy.recordedAt}
 					oninput={(e) => {
-						workingCopy = { ...workingCopy, subtitle: e.currentTarget.value };
+						workingCopy = { ...workingCopy, recordedAt: e.currentTarget.value };
 						isWorkingCopyDirty = true;
 					}}
 					class="col-span-3"
 				/>
 			</div>
 			<div class="grid grid-cols-4 items-center gap-4">
-				<Label for="timestamp" class="text-right">Created At</Label>
-				<Input
-					id="timestamp"
-					value={workingCopy.timestamp}
-					oninput={(e) => {
-						workingCopy = { ...workingCopy, timestamp: e.currentTarget.value };
-						isWorkingCopyDirty = true;
-					}}
-					class="col-span-3"
-				/>
-			</div>
-			<div class="grid grid-cols-4 items-center gap-4">
-				<Label for="transcribedText" class="text-right">Transcript</Label>
+				<Label for="transcript" class="text-right">Transcript</Label>
 				<Textarea
-					id="transcribedText"
-					value={workingCopy.transcribedText}
+					id="transcript"
+					value={workingCopy.transcript}
 					oninput={(e) => {
 						workingCopy = {
 							...workingCopy,
-							transcribedText: e.currentTarget.value,
+							transcript: e.currentTarget.value,
 						};
 						isWorkingCopyDirty = true;
 					}}

--- a/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/RecordingRowActions.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/RecordingRowActions.svelte
@@ -105,7 +105,7 @@
 		<EditRecordingModal {recording} />
 
 		<CopyButton
-			text={recording.transcribedText}
+			text={recording.transcript}
 			copyFn={createCopyFn('transcript')}
 			style="view-transition-name: {viewTransition.recording(recordingId)
 				.transcript}"

--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -364,11 +364,11 @@
 		<div class="xxs:flex hidden w-full flex-col gap-2">
 			<TranscriptDialog
 				recordingId={latestRecording.id}
-				transcribedText={latestRecording.transcriptionStatus === 'TRANSCRIBING'
+				transcript={latestRecording.transcriptionStatus === 'TRANSCRIBING'
 					? '...'
-					: latestRecording.transcribedText}
+					: latestRecording.transcript}
 				rows={1}
-				disabled={!latestRecording.transcribedText.trim()}
+				disabled={!latestRecording.transcript.trim()}
 				loading={latestRecording.transcriptionStatus === 'TRANSCRIBING'}
 				onDelete={() => {
 					confirmationDialog.open({

--- a/specs/20260415T150000-recording-schema-cleanup.md
+++ b/specs/20260415T150000-recording-schema-cleanup.md
@@ -1,0 +1,144 @@
+# Recording Schema Cleanup
+
+Rename columns, drop redundant fields, add `duration`.
+
+## Current → Target Schema
+
+```
+V1 (current)                →  V2 (target)
+──────────────────────────────────────────────────
+id: string                  →  id: string
+title: string               →  title: string            (auto-generated from transcript)
+subtitle: string            →  (dropped)
+timestamp: string           →  recordedAt: string       (renamed)
+createdAt: string           →  (dropped — redundant with recordedAt)
+updatedAt: string           →  updatedAt: string
+transcribedText: string     →  transcript: string       (renamed)
+transcriptionStatus: enum   →  transcriptionStatus: enum
+                            →  duration: number | null  (new — seconds, null for legacy)
+_v: 1                       →  _v: 2
+```
+
+## Workspace Migration (definition.ts)
+
+```typescript
+const recordings = defineTable()
+  .version(type({
+    id: 'string',
+    title: 'string',
+    subtitle: 'string',
+    timestamp: 'string',
+    createdAt: 'string',
+    updatedAt: 'string',
+    transcribedText: 'string',
+    transcriptionStatus: "'UNPROCESSED' | 'TRANSCRIBING' | 'DONE' | 'FAILED'",
+    _v: '1',
+  }))
+  .version(type({
+    id: 'string',
+    title: 'string',
+    recordedAt: 'string',
+    updatedAt: 'string',
+    transcript: 'string',
+    transcriptionStatus: "'UNPROCESSED' | 'TRANSCRIBING' | 'DONE' | 'FAILED'",
+    'duration?': 'number | undefined',
+    _v: '2',
+  }))
+  .migrate((row) => {
+    switch (row._v) {
+      case 1: {
+        const title = row.transcribedText.slice(0, 60).trim() || row.title || 'Untitled Recording';
+        return {
+          id: row.id,
+          title,
+          recordedAt: row.timestamp,
+          updatedAt: row.updatedAt,
+          transcript: row.transcribedText,
+          transcriptionStatus: row.transcriptionStatus,
+          duration: undefined,
+          _v: 2,
+        };
+      }
+      case 2:
+        return row;
+    }
+  });
+```
+
+Migrates on read—existing V1 rows in Yjs stay untouched until accessed, then silently upgraded to V2.
+
+## Files to Change
+
+### Layer 1: Schema + Type (must go first)
+
+- [ ] `src/lib/workspace/definition.ts` — Add V2 schema with builder pattern + `.migrate()`
+- [ ] `src/lib/state/recordings.svelte.ts` — Update sort key `timestamp` → `recordedAt`, JSDoc references
+
+### Layer 2: Recording Creation
+
+- [ ] `src/lib/query/actions.ts` — Update the recording object literal (lines 612-621): new field names, auto-generate title from transcript, drop `subtitle`/`createdAt`
+- [ ] `src/lib/state/transformations.svelte.ts` — Comment referencing "timestamps" (cosmetic)
+
+### Layer 3: UI Consumers
+
+- [ ] `src/routes/(app)/(config)/recordings/+page.svelte` — Update column `accessorKey`s, column visibility defaults, search filter
+- [ ] `src/routes/(app)/(config)/recordings/row-actions/EditRecordingModal.svelte` — Update field bindings: drop subtitle, rename timestamp → recordedAt, transcribedText → transcript
+- [ ] `src/routes/(app)/(config)/debug/+page.svelte` — Update test recording creation
+
+### Layer 4: DB Service (audio blob storage)
+
+- [ ] `src/lib/services/db/models/recordings.ts` — Update `Recording` intermediate type to match V2 fields
+- [ ] `src/lib/services/db/file-system.ts` — Update `RecordingFrontMatter` schema, `recordingToMarkdown`, and parsing. Handle backward compat for existing .md files with old field names
+- [ ] `src/lib/services/db/web/dexie-schemas.ts` — Update `RecordingStoredInIndexedDB` type (V5 Dexie schema stays for read compat, types updated)
+- [ ] `src/lib/services/db/web/index.ts` — Update any field references in create/update
+- [ ] `src/lib/migration/migrate-database.ts` — Update the Dexie→workspace migration to write V2 fields
+
+### Layer 5: Query layer references
+
+- [ ] `src/lib/query/transcription.ts` — `transcribedText` → `transcript`, `transcriptionStatus` refs
+- [ ] `src/lib/query/actions.ts` — Also handles title auto-generation after transcription completes (set title from first 60 chars of transcript)
+- [ ] `src/lib/query/transformer.ts` — Any `transcribedText` references
+- [ ] `src/lib/migration/migration-test-data.ts` — Update mock data
+
+### Layer 6: Duration tracking (new)
+
+- [ ] `src/lib/query/actions.ts` — Extract duration from audio blob during recording creation
+- [ ] Recording creation sites need to compute duration from the Blob (or set null if unavailable)
+
+## Duration: How to Get It
+
+Audio duration can be extracted from the Blob before saving:
+
+```typescript
+function getAudioDuration(blob: Blob): Promise<number | undefined> {
+  return new Promise((resolve) => {
+    const audio = new Audio();
+    audio.addEventListener('loadedmetadata', () => {
+      resolve(Number.isFinite(audio.duration) ? audio.duration : undefined);
+    });
+    audio.addEventListener('error', () => resolve(undefined));
+    audio.src = URL.createObjectURL(blob);
+  });
+}
+```
+
+This runs in the browser, works with WebM and MP3, and gracefully falls back to `undefined`.
+
+## File-System Backward Compat
+
+Existing `.md` files on desktop have old frontmatter keys (`timestamp`, `transcribedText`, `subtitle`, `createdAt`). Two options:
+
+**Option A: Migrate on read** — When parsing a .md file, check for old field names and remap. Simple but keeps stale files on disk.
+
+**Option B: Migrate on write** — Read old format, write back with new field names on first access. Cleans up files but adds write operations.
+
+**Recommendation**: Option A (migrate on read). The file-system layer is secondary storage for audio—the workspace is the source of truth for metadata. No need to rewrite files.
+
+## Not Changing
+
+- Dexie V1-V5 upgrade schemas (`dexie-database.ts`) — Historical migration code, must preserve old field names to read legacy data
+- Any existing Dexie→workspace migration code that reads old field names — It reads V1 format and the workspace migration handles the rest
+
+## Review
+
+_To be filled after implementation._

--- a/specs/20260415T160000-recording-materializer.md
+++ b/specs/20260415T160000-recording-materializer.md
@@ -1,0 +1,190 @@
+# Recording Markdown Materializer
+
+**Date**: 2026-04-15
+**Status**: Draft
+**Branch**: refactor/whispering-recording-schema-v2
+
+## Overview
+
+Replace the desktop file-system DB service's recording metadata writes with a workspace extension that materializes recording rows to `.md` files on change. The workspace becomes the sole source of truth; markdown files become a derived, human-readable view.
+
+## Motivation
+
+### Current State
+
+Two parallel systems store recording metadata:
+
+```
+processRecordingPipeline()
+├── recordings.set(recording)           ← workspace (source of truth)
+└── services.db.recordings.create({     ← DB service (parallel copy)
+      recording, audio: blob
+    })
+```
+
+The DB service writes a `{id}.md` with YAML frontmatter (metadata) + body (transcript) alongside a `{id}.webm` (audio). The workspace writes the same metadata to Yjs. Both store identical data in different formats with different types (`Recording` vs `DbRecording`).
+
+Problems:
+
+1. **Two writes, one source of truth.** Metadata updates via `recordings.update()` only go to the workspace—the `.md` file on disk gets stale the moment the user edits a transcript or transcription completes.
+2. **Dead write path.** `services.db.recordings.update()` and `services.db.recordings.delete()` are never called from app code. The file-system's metadata layer is write-once, then abandoned.
+3. **Unnecessary middleman type.** `DbRecording` exists solely to bridge the DB service's storage format to the workspace type.
+
+### Desired State
+
+```
+processRecordingPipeline()
+├── recordings.set(recording)           ← workspace (sole source of truth)
+└── audioBlobs.save(id, blob)           ← audio-only storage (simple)
+
+workspace extension (materializer)
+└── recordings.observe() → write {id}.md on every change
+```
+
+Markdown files stay in sync because they're derived from workspace observations. Audio blob storage is a simple id→blob service. No `DbRecording` type needed.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Materializer runtime | Tauri-specific extension using `@tauri-apps/plugin-fs` | Existing `createMarkdownMaterializer` uses `Bun.write`—browser WebView can't use Bun APIs |
+| Scope | Recordings table only (Phase 3) | Transformations/runs still use DB service for CRUD; tackle later |
+| Audio handling | Separate from materializer | Audio is a one-time write at recording time, not a derived view. Materializer only handles metadata→markdown. |
+| `.md` format | Same YAML frontmatter + transcript body | Backward compatible with existing files. Users can read/grep their recordings. |
+| Delete behavior | Materializer deletes `{id}.md` when row is removed from workspace | Matches current behavior. Audio cleanup stays separate. |
+| Backward compat | Old `.md` files left on disk | Migration reads from workspace (already migrated). Old files are harmless and get overwritten on first workspace change. |
+
+## Architecture
+
+```
+┌───────────────────────────────────┐
+│   Workspace (Yjs)                 │
+│   recordings table                │
+│   SOLE source of truth            │
+└──────────┬────────────────────────┘
+           │ table.observe(changedIds)
+           ▼
+┌───────────────────────────────────┐
+│   Recording materializer          │
+│   (workspace extension)           │
+│                                   │
+│   on set/update → write {id}.md   │
+│   on delete     → unlink {id}.md  │
+│   uses @tauri-apps/plugin-fs      │
+└──────────┬────────────────────────┘
+           │ writeTextFile / remove
+           ▼
+┌───────────────────────────────────┐
+│   {appDataDir}/recordings/        │
+│   ├── {id}.md   (derived view)    │
+│   └── {id}.webm (audio, separate) │
+└───────────────────────────────────┘
+```
+
+Audio flow (unchanged, just simplified):
+```
+processRecordingPipeline()
+└── audioBlobs.save(recordingId, blob)
+    └── tauriWriteFile(PATHS.DB.RECORDING_AUDIO(id, ext), bytes)
+```
+
+## Implementation Plan
+
+### Phase 3a: Create the materializer extension
+
+- [ ] **3a.1** Create `src/lib/workspace/extensions/recording-materializer.ts`
+  - Workspace extension factory that returns `{ whenReady, dispose }`
+  - On `whenReady`: initial flush of all recordings to `.md` files
+  - Observe recordings table: on change, serialize row → write `{id}.md`; on delete, unlink `{id}.md`
+  - Uses Tauri `writeTextFile` + `remove` from `@tauri-apps/plugin-fs`
+  - Reuses existing `stringifyFrontmatter` from `services/db/frontmatter.ts` for identical `.md` format
+  - Atomic writes: write to `{id}.md.tmp`, then `rename` to `{id}.md`
+- [ ] **3a.2** Wire into `src/lib/client.ts` via `.withWorkspaceExtension('materializer', ...)`
+  - Only on desktop (guard with `window.__TAURI_INTERNALS__`)
+- [ ] **3a.3** Remove metadata write from `services.db.recordings.create()`
+  - `create()` becomes audio-only: just writes `{id}.webm`
+  - Remove `recordingToMarkdown` call from create path
+- [ ] **3a.4** Remove `services.db.recordings.update()` method
+  - Never called from app code (confirmed by exploration)
+- [ ] **3a.5** Verify: recordings table changes → `.md` files update on disk
+
+### Phase 3b: Slim the DB service interface
+
+- [ ] **3b.1** Remove metadata-only methods from `DbService.recordings`: `getAll`, `getLatest`, `getById`, `getTranscribingIds`, `getCount`, `update`
+- [ ] **3b.2** Rename `create` → `saveAudio` with signature `(recordingId: string, audio: Blob)`
+- [ ] **3b.3** Simplify `delete` to accept `string | string[]` (IDs, not full objects)
+- [ ] **3b.4** Remove `DbRecording` type entirely
+- [ ] **3b.5** Remove `RecordingFrontMatter`, `RecordingFrontMatterRaw`, `normalizeRecordingFrontMatter`, `recordingToMarkdown`, `markdownToRecording` from `file-system.ts`
+- [ ] **3b.6** Remove `storedRecordingToRecording` from `web/index.ts`
+- [ ] **3b.7** Update `cleanupExpired` to work with recording IDs from workspace, not from DB service `getAll()`
+
+### Phase 3c: Clean up web (IndexedDB) path
+
+- [ ] **3c.1** Web `create` becomes audio-only (drop metadata from IndexedDB row)
+- [ ] **3c.2** Web `delete` accepts IDs only
+- [ ] **3c.3** Simplify `RecordingStoredInIndexedDB` to `{ id: string; serializedAudio: SerializedAudio }`
+- [ ] **3c.4** Remove `RecordingStoredInIndexedDbLegacy` type (no longer needed after migration)
+
+## Edge Cases
+
+### Initial flush on first launch after migration
+
+1. User has existing recordings in workspace (migrated from Dexie)
+2. Materializer starts, calls `table.getAllValid()`, flushes all to `.md`
+3. Old `.md` files with V1 field names get overwritten with V2 field names
+4. Expected: clean migration, no data loss
+
+### Recording created while materializer is initializing
+
+1. `processRecordingPipeline` runs before `whenReady` resolves
+2. Recording is written to workspace immediately
+3. Materializer's initial flush picks it up—no gap
+4. Expected: `.md` file appears after `whenReady`, not lost
+
+### Audio save fails but metadata succeeds
+
+1. Workspace write succeeds (instant, local)
+2. Audio `tauriWriteFile` fails (disk full, permission error)
+3. Materializer writes `.md` (metadata is in workspace)
+4. Expected: `.md` exists, audio doesn't. User sees recording without audio. Already handled by current error flow.
+
+### Web platform (no Tauri)
+
+1. Materializer is guarded by `window.__TAURI_INTERNALS__`
+2. Web platform skips materializer entirely
+3. IndexedDB stores audio blobs only
+4. Expected: no change in behavior for web users
+
+## Open Questions
+
+1. **Should the materializer delete audio files too, or keep that in a separate cleanup?**
+   - Options: (a) materializer handles both `.md` and audio deletion, (b) audio cleanup stays in DB service
+   - **Recommendation**: (b) Keep audio cleanup separate. The materializer's job is metadata→markdown. Audio lifecycle is a different concern.
+
+2. **Should `cleanupExpired` move to a workspace action instead of DB service?**
+   - It currently reads all recordings from DB, sorts, and deletes excess. With workspace as source of truth, it should read from workspace.
+   - **Recommendation**: Move to a workspace action in Phase 3b. It reads `recordings.sorted`, takes IDs of expired ones, deletes from workspace (materializer handles `.md` cleanup) + calls audio delete.
+
+3. **Should the materializer be generalized for reuse by other apps?**
+   - The existing `createMarkdownMaterializer` is Bun-specific. A Tauri-compatible version could live in a shared package.
+   - **Recommendation**: Build it app-local first (`src/lib/workspace/extensions/`). Extract to `@epicenter/tauri` if a second app needs it.
+
+## Success Criteria
+
+- [ ] Recording metadata changes (title, transcript, transcriptionStatus) → `.md` file updates on disk within seconds
+- [ ] New recordings → `.md` + `.webm` both appear in recordings directory
+- [ ] Deleted recordings → `.md` removed (audio removal via separate path)
+- [ ] `DbRecording` type no longer exists
+- [ ] DB service `recordings` interface is audio-only: `saveAudio`, `getAudioBlob`, `ensureAudioPlaybackUrl`, `revokeUrl`, `deleteAudio`
+- [ ] No type errors, diagnostics clean
+- [ ] Web platform unaffected
+
+## References
+
+- `packages/workspace/src/extensions/materializer/markdown/materializer.ts` — Bun materializer (pattern to follow, not the runtime)
+- `apps/whispering/src/lib/services/db/file-system.ts` — Current desktop write path (to be replaced)
+- `apps/whispering/src/lib/services/db/frontmatter.ts` — YAML serialization (reuse)
+- `apps/whispering/src/lib/workspace/definition.ts` — Recording V2 schema
+- `apps/whispering/src/lib/client.ts` — Where to chain `.withWorkspaceExtension()`
+- `apps/whispering/src/lib/constants/paths.ts` — `PATHS.DB.RECORDINGS()`, `PATHS.DB.RECORDING_MD(id)`
+- `playground/tab-manager-e2e/epicenter.config.ts` — Example materializer usage


### PR DESCRIPTION
The V1 schema had field names that didn't match what they actually represented. `timestamp` was really when the recording happened. `transcribedText` was just the transcript. `subtitle` and `createdAt` were redundant noise. V2 cleans all of that up, and this PR also fixes a latent type drift problem where the `Recording` type was derived from a live client instance rather than the schema definition itself.

The schema change adds a second version to the `recordings` table and wires up a migration function:

```typescript
// Before (V1)
const recordings = defineTable(
  type({
    id: 'string',
    title: 'string',
    subtitle: 'string',
    timestamp: 'string',
    createdAt: 'string',
    updatedAt: 'string',
    transcribedText: 'string',
    transcriptionStatus: "'UNPROCESSED' | 'TRANSCRIBING' | 'DONE' | 'FAILED'",
    _v: '1',
  }),
);

// After (V2)
const recordings = defineTable(
  type({ /* V1 shape */ }),
  type({
    id: 'string',
    title: 'string',
    recordedAt: 'string',
    updatedAt: 'string',
    transcript: 'string',
    transcriptionStatus: "'UNPROCESSED' | 'TRANSCRIBING' | 'DONE' | 'FAILED'",
    'duration?': 'number | undefined',
    _v: '2',
  }),
).migrate((row) => {
  switch (row._v) {
    case 1: {
      const title = row.transcribedText.slice(0, 60).trim() || row.title || 'Untitled Recording';
      return {
        id: row.id,
        title,
        recordedAt: row.timestamp,
        updatedAt: row.updatedAt,
        transcript: row.transcribedText,
        transcriptionStatus: row.transcriptionStatus,
        duration: undefined,
        _v: 2,
      };
    }
    case 2:
      return row;
  }
});
```

Migration is lazy—existing V1 rows in Yjs stay untouched until they're read, then silently upgraded. No bulk migration pass, no downtime. The title auto-generation (first 60 chars of transcript, falling back to the old title) also runs here, so old recordings get reasonable titles without manual intervention.

---

The second commit fixes a type derivation problem that's been lurking since the workspace client was introduced. `Recording` was previously defined like this:

```typescript
// Before: derived from a live client instance
export type Recording = ReturnType<
  typeof workspace.tables.recordings.getAllValid
>[number];
```

That works, but it's fragile—the type depends on the runtime client being importable at type-check time, and it can drift if the schema changes without the client being updated. Now it's derived directly from the table definition:

```typescript
// After: derived from the schema itself
export type Recording = InferTableRow<typeof recordings>;
```

The type lives alongside the schema, so they can't get out of sync. Any schema change immediately propagates to the type.

---

The DB service's internal `Recording` type got renamed to `DbRecording` to avoid a naming collision. Both types represent recordings, but they're different things: `Recording` is the workspace domain type (what the UI works with), while `DbRecording` is the storage adapter shape used by the file-system and IndexedDB implementations. The rename makes that distinction explicit.

The third commit adds a spec for Phase 3—replacing the metadata-write path in the DB service with a workspace extension that derives `.md` files from table observations instead. That's the work in PR #1667.

Touches the workspace definition, both DB service implementations, the migration path, the query layer, and a handful of UI components. PR 2 of 4.