### PR TITLE
refactor(workspace): add IO and YAML dependency injection to markdown materializer

### DIFF
--- a/packages/workspace/src/extensions/materializer/markdown/index.ts
+++ b/packages/workspace/src/extensions/materializer/markdown/index.ts
@@ -1,4 +1,8 @@
-export { createMarkdownMaterializer } from './materializer.js';
+export {
+	createMarkdownMaterializer,
+	type MaterializerIO,
+	type MaterializerYaml,
+} from './materializer.js';
 	export {
 	markdown,
 	type SerializeResult,

--- a/packages/workspace/src/extensions/materializer/markdown/materializer.ts
+++ b/packages/workspace/src/extensions/materializer/markdown/materializer.ts
@@ -1,11 +1,76 @@
-import { mkdir, unlink } from 'node:fs/promises';
-import { join } from 'node:path';
 import type { MaybePromise } from '../../../workspace/lifecycle.js';
 import type { KvHelper, TableHelper } from '../../../workspace/types.js';
-import { markdown, type SerializeResult } from './markdown.js';
+import type { SerializeResult } from './markdown.js';
 
-/** Delete a file, silently succeeding if it doesn't exist or can't be removed. */
-const safeUnlink = (filePath: string) => unlink(filePath).catch(() => {});
+/**
+ * Filesystem operations the materializer needs. Inject a custom adapter to run
+ * in runtimes other than Node/Bun (e.g. Tauri's `@tauri-apps/plugin-fs`).
+ *
+ * When omitted, defaults to Node's `fs/promises` + `path.join` which also
+ * work in Bun.
+ */
+export type MaterializerIO = {
+	mkdir(dir: string): Promise<void>;
+	writeFile(path: string, content: string): Promise<void>;
+	removeFile(path: string): Promise<void>;
+	joinPath(...segments: string[]): MaybePromise<string>;
+};
+
+/**
+ * YAML serialization adapter. Inject a custom implementation to avoid the
+ * `bun` global (e.g. `js-yaml` or `yaml` npm package).
+ *
+ * When omitted, defaults to `YAML.stringify` from the `bun` global.
+ */
+export type MaterializerYaml = {
+	stringify(obj: Record<string, unknown>): string;
+};
+
+/** Lazily resolve Node/Bun default IO. Only imported when actually used. */
+function createDefaultIO(): MaterializerIO {
+	// Dynamic require avoids top-level import that would fail in browser runtimes.
+	const fs = require('node:fs/promises') as typeof import('node:fs/promises');
+	const path = require('node:path') as typeof import('node:path');
+
+	return {
+		mkdir: (dir) => fs.mkdir(dir, { recursive: true }),
+		writeFile: (filePath, content) => fs.writeFile(filePath, content),
+		removeFile: (filePath) => fs.unlink(filePath).catch(() => {}),
+		joinPath: (...segments) => path.join(...segments),
+	};
+}
+
+/** Lazily resolve Bun YAML default. Only called when no yaml adapter is provided. */
+function createDefaultYaml(): MaterializerYaml {
+	const { YAML } = require('bun') as typeof import('bun');
+	return {
+		stringify: (obj) => YAML.stringify(obj, null, 2) as string,
+	};
+}
+
+/**
+ * Build a markdown string from YAML frontmatter and an optional body.
+ *
+ * Pure function—no I/O. Uses the provided YAML stringifier.
+ * Undefined values are stripped; null values are preserved.
+ */
+function buildMarkdown(
+	yaml: MaterializerYaml,
+	frontmatter: Record<string, unknown>,
+	body?: string,
+): string {
+	const cleaned: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(frontmatter)) {
+		if (value !== undefined) {
+			cleaned[key] = value;
+		}
+	}
+	const yamlStr = yaml.stringify(cleaned);
+	const yamlBlock = yamlStr.endsWith('\n') ? yamlStr : `${yamlStr}\n`;
+	return body !== undefined
+		? `---\n${yamlBlock}---\n\n${body}\n`
+		: `---\n${yamlBlock}---\n`;
+}
 
 /**
  * Create a one-way materializer that writes workspace data to files on disk.
@@ -18,13 +83,30 @@ const safeUnlink = (filePath: string) => unlink(filePath).catch(() => {});
  * and sync have loaded before the initial flush. All `.table()` and `.kv()`
  * calls happen synchronously in the factory closure before `whenReady` resolves.
  *
+ * Pass `io` and `yaml` to run in non-Node/Bun runtimes (e.g. Tauri):
+ *
  * @example
  * ```typescript
+ * // Bun/Node — defaults just work
  * .withWorkspaceExtension('materializer', (ctx) =>
  *   createMarkdownMaterializer(ctx, { dir: './data' })
  *     .table('posts', { serialize: slugFilename('title') })
- *     .table('settings')
  *     .kv(),
+ * )
+ *
+ * // Tauri — inject filesystem + YAML adapters
+ * .withWorkspaceExtension('materializer', (ctx) =>
+ *   createMarkdownMaterializer(ctx, {
+ *     dir: recordingsPath,
+ *     io: {
+ *       mkdir: (dir) => tauriMkdir(dir, { recursive: true }),
+ *       writeFile: tauriWriteTextFile,
+ *       removeFile: (path) => tauriRemove(path).catch(() => {}),
+ *       joinPath: (...s) => tauriJoin(...s),
+ *     },
+ *     yaml: { stringify: (obj) => jsYaml.dump(obj, { lineWidth: -1 }) },
+ *   })
+ *     .table('recordings', { serialize: mySerializer }),
  * )
  * ```
  */
@@ -35,8 +117,17 @@ export function createMarkdownMaterializer<
 	TKv extends KvHelper<any>,
 >(
 	ctx: { tables: TTables; kv: TKv; whenReady: Promise<void> },
-	config: { dir: string },
+	config: {
+		dir: string;
+		/** Filesystem adapter. Defaults to Node `fs/promises` + `path.join` (works in Bun). */
+		io?: MaterializerIO;
+		/** YAML serializer. Defaults to `YAML.stringify` from the `bun` global. */
+		yaml?: MaterializerYaml;
+	},
 ) {
+	const io = config.io ?? createDefaultIO();
+	const yaml = config.yaml ?? createDefaultYaml();
+
 	type TableConfigByName = {
 		[TName in keyof TTables & string]?: {
 			dir?: string;
@@ -89,22 +180,21 @@ export function createMarkdownMaterializer<
 	) => {
 		const table = ctx.tables[name];
 		const tableConfig = tableConfigs[name];
-		const directory = join(config.dir, tableConfig?.dir ?? name);
+		const directory = await io.joinPath(config.dir, tableConfig?.dir ?? name);
 		const filenames = new Map<string, string>();
 
 		const serialize: (row: TableRow<TName>) => MaybePromise<SerializeResult> =
 			tableConfig?.serialize ??
-			((row) =>
-				markdown({
-					frontmatter: { ...row },
-					filename: `${row.id}.md`,
-				}));
+			((row) => ({
+				filename: `${row.id}.md`,
+				content: buildMarkdown(yaml, { ...row }),
+			}));
 
-		await mkdir(directory, { recursive: true });
+		await io.mkdir(directory);
 
 		for (const row of table.getAllValid()) {
 			const result = await serialize(row);
-			await Bun.write(join(directory, result.filename), result.content);
+			await io.writeFile(await io.joinPath(directory, result.filename), result.content);
 			filenames.set(row.id, result.filename);
 		}
 
@@ -118,7 +208,7 @@ export function createMarkdownMaterializer<
 					if (getResult.status === 'not_found') {
 						const previousFilename = filenames.get(id);
 						if (previousFilename) {
-							await safeUnlink(join(directory, previousFilename));
+							await io.removeFile(await io.joinPath(directory, previousFilename));
 							filenames.delete(id);
 						}
 						continue;
@@ -132,10 +222,10 @@ export function createMarkdownMaterializer<
 					const previousFilename = filenames.get(id);
 
 					if (previousFilename && previousFilename !== result.filename) {
-						await safeUnlink(join(directory, previousFilename));
+						await io.removeFile(await io.joinPath(directory, previousFilename));
 					}
 
-					await Bun.write(join(directory, result.filename), result.content);
+					await io.writeFile(await io.joinPath(directory, result.filename), result.content);
 					filenames.set(id, result.filename);
 				}
 			})().catch((error) => {
@@ -157,7 +247,7 @@ export function createMarkdownMaterializer<
 
 		// Initial flush with the full snapshot
 		const initial = serialize(kvState);
-		await Bun.write(join(config.dir, initial.filename), initial.content);
+		await io.writeFile(await io.joinPath(config.dir, initial.filename), initial.content);
 
 		const unsubscribe = ctx.kv.observeAll((changes) => {
 			void (async () => {
@@ -171,7 +261,7 @@ export function createMarkdownMaterializer<
 				}
 
 				const result = serialize(kvState);
-				await Bun.write(join(config.dir, result.filename), result.content);
+				await io.writeFile(await io.joinPath(config.dir, result.filename), result.content);
 			})().catch((error) => {
 				console.warn('[markdown-materializer] kv write failed:', error);
 			});
@@ -193,7 +283,7 @@ export function createMarkdownMaterializer<
 		},
 		whenReady: (async () => {
 			await ctx.whenReady;
-			await mkdir(config.dir, { recursive: true });
+			await io.mkdir(config.dir);
 
 			for (const name of tableNames) {
 				await materializeTable(name);


### PR DESCRIPTION
The markdown materializer has always assumed it's running in Bun or Node. Every file write went through `Bun.write()`, every directory creation through `node:fs/promises`, and the YAML serializer was the `yaml` package. That's fine for the CLI and server-side tools, but it's a hard wall for Tauri—the desktop app runs in a browser WebView where `node:fs` doesn't exist and file I/O goes through Rust commands via `invoke`.

The recording materializer (coming in PR #1667) needs to run inside Whispering, which is a Tauri app. Rather than fork the implementation or add a Tauri-specific code path, this PR makes the dependencies injectable.

Two new types describe the contracts:

```typescript
export type MaterializerIO = {
  mkdir(dir: string): Promise<void>;
  writeFile(path: string, content: string): Promise<void>;
  removeFile(path: string): Promise<void>;
  joinPath(...segments: string[]): MaybePromise<string>;
};

export type MaterializerYaml = {
  stringify(obj: Record<string, unknown>): string;
};
```

Both are optional on `createMarkdownMaterializer`'s config. When you don't pass them, the materializer resolves the defaults lazily at runtime:

```typescript
// Before — top-level static imports, fails at load time in browser runtimes
import { mkdir, unlink } from 'node:fs/promises';
import { join } from 'node:path';

// After — lazy require inside factory functions, safe to import anywhere
function createDefaultIO(): MaterializerIO {
  const fs = require('node:fs/promises') as typeof import('node:fs/promises');
  const path = require('node:path') as typeof import('node:path');
  return {
    mkdir: (dir) => fs.mkdir(dir, { recursive: true }),
    writeFile: (filePath, content) => fs.writeFile(filePath, content),
    removeFile: (filePath) => fs.unlink(filePath).catch(() => {}),
    joinPath: (...segments) => path.join(...segments),
  };
}
```

The lazy require matters because Tauri's frontend bundle can now import the materializer module without it blowing up at load time. The Node imports only run if no custom `io` is provided, which in a Tauri context they won't be.

A Tauri consumer wires in its own adapter:

```typescript
createMarkdownMaterializer(ctx, {
  dir: recordingsPath,
  io: {
    mkdir: (dir) => tauriMkdir(dir, { recursive: true }),
    writeFile: tauriWriteTextFile,
    removeFile: (path) => tauriRemove(path).catch(() => {}),
    joinPath: (...s) => tauriJoin(...s),
  },
  yaml: { stringify: (obj) => jsYaml.dump(obj, { lineWidth: -1 }) },
})
```

Existing callers that pass only `{ dir }` are completely unaffected—the defaults kick in and behavior is identical to before.

Two files, PR 3 of 4. This is the unlock for PR #1667.