### PR TITLE
fix(auth): persist OAuth verification records to Postgres

### DIFF
--- a/apps/api/src/auth/create-auth.ts
+++ b/apps/api/src/auth/create-auth.ts
@@ -47,6 +47,22 @@ export function createAuth({
 		database: drizzleAdapter(db, { provider: 'pg' }),
 		baseURL,
 		secret: env.BETTER_AUTH_SECRET,
+		account: {
+			...BASE_AUTH_CONFIG.account,
+			// Better Auth's database strategy validates OAuth callbacks two ways:
+			// 1. A verification record in Postgres (random token, single-use, 10min TTL)
+			// 2. A signed state cookie set during the sign-in POST
+			//
+			// Layer 2 fails in our architecture. The sign-in POST is a cross-origin
+			// fetch (opensidian.com → api.epicenter.so), and modern browsers block
+			// third-party Set-Cookie from fetch responses—even with SameSite=None.
+			// Chrome Privacy Sandbox, Safari ITP, and Firefox ETP all enforce this.
+			// The cookie is never stored, so the callback can't read it back.
+			//
+			// Layer 1 (DB verification) is the primary security mechanism and is
+			// unaffected. skipStateCookieCheck disables only layer 2.
+			skipStateCookieCheck: true,
+		},
 		socialProviders: {
 			google: {
 				clientId: env.GOOGLE_CLIENT_ID,
@@ -56,6 +72,8 @@ export function createAuth({
 		session: {
 			expiresIn: 60 * 60 * 24 * 7,
 			updateAge: 60 * 60 * 24,
+			// Write sessions to Postgres (source of truth), not just KV.
+			// Required when secondaryStorage is configured—see comment below.
 			storeSessionInDatabase: true,
 			cookieCache: {
 				enabled: true,
@@ -63,29 +81,30 @@ export function createAuth({
 				strategy: 'jwe',
 			},
 		},
-		// Cross-origin cookie config for OAuth and sessions.
+		// Cross-origin cookie config for sessions.
 		//
 		// The auth server (api.epicenter.so) serves multiple client apps:
-		//   - Production subdomains: fuji.epicenter.so, opensidian.com
+		//   - Subdomains: fuji.epicenter.so, opensidian.epicenter.so
+		//   - External domains: opensidian.com
 		//   - Desktop: tauri://localhost
 		//   - Dev: localhost:5173, localhost:5174, etc.
 		//
-		// OAuth state cookies are set during a cross-origin POST (client → API),
-		// then read back on a top-level GET (Google → API callback). With the
-		// default SameSite=lax, browsers may drop cookies set via cross-origin
-		// POST responses, causing "state_mismatch" errors on the callback.
+		// SameSite=None + Secure lets browsers send session cookies on
+		// cross-origin fetches (e.g. opensidian.com → api.epicenter.so).
+		// This trades browser-level CSRF for app-level origin checking,
+		// which Better Auth enforces via trustedOrigins on every request.
+		// Standard practice for auth servers on a separate domain—same
+		// model as Auth0, Clerk, and Supabase Auth.
 		//
-		// SameSite=none tells the browser to send cookies on all cross-origin
-		// requests. This trades browser-level CSRF protection for app-level
-		// protection (trustedOrigins + origin header checking, which Better Auth
-		// already enforces on every request). Standard practice for auth servers
-		// on a separate domain—same model as Auth0, Clerk, and Supabase Auth.
+		// crossSubDomainCookies scopes cookies to .epicenter.so so any
+		// subdomain shares sessions. Apps on other domains (opensidian.com)
+		// still work because their fetches target api.epicenter.so.
 		//
-		// NOTE: We intentionally omit `partitioned: true` (CHIPS). Partitioned
-		// cookies are keyed by the top-level site at creation time. During OAuth,
-		// the top-level site changes mid-flow (client → Google → API callback),
-		// so the cookie becomes invisible at the callback step. Partitioned is
-		// designed for embedded iframes/subresources, not redirect-based OAuth.
+		// NOTE: We intentionally omit `partitioned: true` (CHIPS).
+		// Partitioned cookies are keyed by the top-level site at creation
+		// time. During OAuth the top-level site changes mid-flow (client →
+		// Google → API callback), so the cookie becomes invisible at the
+		// callback step. Partitioned is for iframes, not redirect OAuth.
 		advanced: {
 			crossSubDomainCookies: {
 				enabled: true,
@@ -154,15 +173,23 @@ export function createAuth({
 			}
 			return origins;
 		},
-		// secondaryStorage = Cloudflare KV read cache for sessions/verification.
-		// Postgres (Germany) is always the source of truth—KV just avoids the
+		// secondaryStorage = Cloudflare KV as a read-through cache.
+		// Postgres (Germany) is always the source of truth. KV avoids the
 		// ~150ms round-trip on repeated session reads from distant edges.
 		//
-		// IMPORTANT: When secondaryStorage is configured, Better Auth defaults
-		// to KV-only writes for sessions and verification unless you explicitly
-		// opt back into Postgres with storeSessionInDatabase / storeInDatabase.
-		// Missing either flag causes silent data loss (state_mismatch, lost
-		// sessions). If you remove secondaryStorage, remove both flags too.
+		// Staleness: KV is eventually consistent, so cached entries may
+		// briefly outlive their Postgres counterparts after deletion.
+		//   - Sessions: a revoked session stays valid in KV for up to
+		//     cookieCache.maxAge (5 min). Standard Redis/KV cache tradeoff.
+		//   - Verification: a consumed OAuth state may linger in KV, but
+		//     replaying it requires a valid Google authorization code that
+		//     was already consumed—harmless.
+		//
+		// IMPORTANT: When secondaryStorage is configured, Better Auth
+		// defaults to KV-only writes unless you opt back into Postgres
+		// with storeSessionInDatabase / storeInDatabase. Missing either
+		// flag causes silent data loss. If you remove secondaryStorage,
+		// remove both flags too.
 		secondaryStorage: {
 			get: (key: string) => env.SESSION_KV.get(key),
 			set: (key: string, value: string, ttl?: number) =>
@@ -171,11 +198,9 @@ export function createAuth({
 				}),
 			delete: (key: string) => env.SESSION_KV.delete(key),
 		},
-		// Ensure OAuth state verification records are written to Postgres,
-		// not just KV. Without this, secondaryStorage causes Better Auth to
-		// skip the DB write for verification records. KV is eventually
-		// consistent, so the OAuth callback often can't find the record
-		// written moments earlier at a different edge → state_mismatch.
+		// Write verification records to Postgres, not just KV. Required
+		// for OAuth state—KV eventual consistency means the callback edge
+		// may not see a record written moments earlier at a different edge.
 		verification: {
 			storeInDatabase: true,
 		},

--- a/apps/api/src/auth/create-auth.ts
+++ b/apps/api/src/auth/create-auth.ts
@@ -154,6 +154,15 @@ export function createAuth({
 			}
 			return origins;
 		},
+		// secondaryStorage = Cloudflare KV read cache for sessions/verification.
+		// Postgres (Germany) is always the source of truth—KV just avoids the
+		// ~150ms round-trip on repeated session reads from distant edges.
+		//
+		// IMPORTANT: When secondaryStorage is configured, Better Auth defaults
+		// to KV-only writes for sessions and verification unless you explicitly
+		// opt back into Postgres with storeSessionInDatabase / storeInDatabase.
+		// Missing either flag causes silent data loss (state_mismatch, lost
+		// sessions). If you remove secondaryStorage, remove both flags too.
 		secondaryStorage: {
 			get: (key: string) => env.SESSION_KV.get(key),
 			set: (key: string, value: string, ttl?: number) =>
@@ -161,6 +170,14 @@ export function createAuth({
 					expirationTtl: ttl ?? 60 * 5,
 				}),
 			delete: (key: string) => env.SESSION_KV.delete(key),
+		},
+		// Ensure OAuth state verification records are written to Postgres,
+		// not just KV. Without this, secondaryStorage causes Better Auth to
+		// skip the DB write for verification records. KV is eventually
+		// consistent, so the OAuth callback often can't find the record
+		// written moments earlier at a different edge → state_mismatch.
+		verification: {
+			storeInDatabase: true,
 		},
 	} satisfies Omit<BetterAuthOptions, 'plugins'>;
 

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -72,7 +72,7 @@
 	"hyperdrive": [
 		{
 			"binding": "HYPERDRIVE",
-			"id": "d1a10cd127d64897a9c817291fde043f",
+			"id": "8e3481a8472248e0a883d07471f0cc36",
 			"localConnectionString": "postgres://postgres:postgres@localhost:5432/epicenter"
 		}
 	],


### PR DESCRIPTION
Google OAuth sign-in was failing with \`state_mismatch\` on the callback. Two independent issues stacked on top of each other, and neither was obvious on its own.

The first: verification records never reached Postgres. When \`secondaryStorage\` (KV) is configured, Better Auth changes its default write path—verification records go to KV only, skipping the database entirely, unless \`verification.storeInDatabase\` is explicitly \`true\`. The second: the signed state cookie was being blocked by the browser. The sign-in POST is a cross-origin fetch (opensidian.com → api.epicenter.so), and modern browsers treat \`Set-Cookie\` from cross-origin fetch responses as third-party cookies—Chrome Privacy Sandbox, Safari ITP, Firefox ETP all block them.

Here's how the flow breaks down:

\`\`\`
SIGN-IN INITIATION
══════════════════
opensidian.com                              api.epicenter.so
┌──────────┐    POST /auth/sign-in/social   ┌──────────────────────────┐
│  Browser  │ ─────────────────────────────→ │  Better Auth             │
│           │   (cross-origin fetch)         │                          │
│           │                                │  1. Generate state token │
│           │                                │  2. Write verification   │
│           │                                │  3. Set signed cookie    │
│           │ ←───────────────────────────── │  4. Return Google URL    │
│           │   Set-Cookie: state=xyz        │                          │
└──────────┘   + { url: google.com/... }     └──────────────────────────┘
                                                    │
                                               ┌────┴────┐
                                     ┌─────────┤  Step 2 ├─────────┐
                                     │         └─────────┘         │
                                     ▼                             ▼
                              ┌─────────────┐             ┌──────────────┐
                              │  Postgres   │             │ Cloudflare   │
                              │  (Germany)  │             │ KV (edge)    │
                              │  DURABLE ✅  │             │ CACHE ⚠️     │
                              └─────────────┘             └──────────────┘
\`\`\`

Without \`storeInDatabase: true\`, step 2 only writes to KV. The callback may land on a different edge node where the KV write hasn't propagated yet, producing \`state_mismatch\`. And even when the record is found, the signed cookie check at layer 2 fails because the browser never stored it in the first place.

\`\`\`
CALLBACK
════════
Google → GET /auth/callback/google?state=xyz → api.epicenter.so

  LAYER 1: DB verification lookup
  ├─ KV.get("verification:xyz") → hit? return it
  │                              → miss? ↓
  └─ Postgres.find(xyz)         → found ✅ (with storeInDatabase: true)

  LAYER 2: Signed cookie check
  ├─ Read cookie from request   → MISSING (browser blocked it)
  └─ skipStateCookieCheck: true → SKIPPED ⏭️
\`\`\`

The root cause for the first issue is in Better Auth's internal adapter. When \`secondaryStorage\` is configured, it gates the Postgres write behind \`executeMainFn\`:

\`\`\`ts
// better-auth/dist/db/internal-adapter.mjs
return await createWithHooks(data, "verification", secondaryStorage ? {
    async fn(verificationData) {
        await secondaryStorage.set(\`verification:\${id}\`, JSON.stringify(verificationData), ttl);
        return verificationData;
    },
    executeMainFn: options.verification?.storeInDatabase  // undefined → skip DB
} : void 0);
\`\`\`

We already had \`session.storeSessionInDatabase: true\` for exactly this reason. The verification table needed the same flag—we just hadn't added it.

For the cookie issue, Better Auth's own source comments flag \`skipStateCookieCheck\` as a "security issue" for same-domain setups. For a cross-domain auth server like ours, the cookie structurally cannot work—the browser will never store it. The DB verification record is the real security mechanism: cryptographically random, single-use, 10-minute TTL. Skipping the cookie check doesn't open any practical attack vector, because an attacker would also need a valid Google authorization code.

The fix lands in two commits. The first adds \`verification: { storeInDatabase: true }\` to \`create-auth.ts\` and updates the Hyperdrive ID in \`wrangler.jsonc\` to the new PlanetScale config after the DB migration to Germany. The second adds \`account: { ...BASE_AUTH_CONFIG.account, skipStateCookieCheck: true }\`—and importantly, spreads \`BASE_AUTH_CONFIG.account\` first, which fixes a pre-existing shallow-spread bug where the \`account\` override was silently dropping \`accountLinking\`.

KV is still useful as a read cache after this change. Verification records may persist briefly in KV after Postgres deletes them on a successful callback—harmless, since replaying the state requires a valid Google authorization code that's already been consumed. Sessions have a 5-minute cache window, bounded by \`cookieCache.maxAge\`. Standard tradeoff for any KV-backed session cache.

---

- [Better Auth: \`state_mismatch\` docs](https://better-auth.com/docs/reference/errors/state_mismatch)
- [Better Auth #8266](https://github.com/better-auth/better-auth/issues/8266)
- [Better Auth #8893](https://github.com/better-auth/better-auth/issues/8893)