### PR TITLE
chore(api): remove db:push:remote and db:migrate:local scripts

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -103,7 +103,7 @@ There are three layers, each with a different URL source:
 |---|---|---|
 | Local dev (runtime) | `wrangler.jsonc` Hyperdrive `localConnectionString` | `bun dev:local` (wrangler) |
 | Local dev (drizzle-kit) | `DATABASE_URL` from `.dev.vars` (generated from Infisical dev env) | `db:push:local`, `db:studio:local` |
-| Remote | `DATABASE_URL` injected by `infisical run` | `db:push:remote`, `db:studio:remote` |
+| Remote | `DATABASE_URL` injected by `infisical run` | `db:migrate:remote`, `db:studio:remote` |
 
 `dev:local` regenerates `.dev.vars` from Infisical's dev environment on every run. Infisical dev has `DATABASE_URL` set to the local Postgres URL, so `.dev.vars` always points to local. The `:remote` scripts use `infisical run` which injects the production `DATABASE_URL` at runtime without touching `.dev.vars`.
 
@@ -122,8 +122,8 @@ bun test             # Run tests
 ```bash
 bun run auth:generate    # Generate Better Auth schema
 bun run db:generate      # Generate Drizzle migrations
-bun run db:push:local    # Push schema to local Postgres
-bun run db:push:remote   # Push schema to remote (via Infisical)
+bun run db:push:local     # Push schema to local Postgres (dev only—use migrations for remote)
+bun run db:migrate:remote # Run migrations against remote (via Infisical)
 bun run db:studio:local  # Open Drizzle Studio (local)
 bun run db:studio:remote # Open Drizzle Studio (remote, via Infisical)
 ```

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -26,8 +26,6 @@
 		"db:generate": "drizzle-kit generate",
 		"db:drop": "drizzle-kit drop",
 		"db:push:local": "drizzle-kit push",
-		"db:push:remote": "infisical run --env=prod --path=/api -- drizzle-kit push",
-		"db:migrate:local": "drizzle-kit migrate",
 		"db:migrate:remote": "infisical run --env=prod --path=/api -- drizzle-kit migrate",
 		"db:studio:local": "drizzle-kit studio",
 		"db:studio:remote": "infisical run --env=prod --path=/api -- drizzle-kit studio"


### PR DESCRIPTION
Removes `db:push:remote` and `db:migrate:local` from the API's database scripts, enforcing a clean separation between local development and production database management.

`drizzle-kit push` applies schema changes directly to a database without generating migration files. For local development this is ideal—fast iteration, blow away and recreate anytime. For production, it's the wrong tool. Push doesn't generate SQL files, so there's no reviewable record of what changed. Without migration files, reverting a bad schema change means writing manual SQL or restoring from backup. Schema changes happen silently at the CLI instead of going through version control and code review. The Drizzle migrations API (`db:generate` → `db:migrate:remote`) already exists and handles all of this correctly.

`db:migrate:local` goes for similar reasons. If you've been using `db:push:local` to iterate on schema during development, your local database is already at the latest schema state. Running `db:migrate:local` against it is either a no-op or misleading—it doesn't serve as a reliable pre-production test.

| Environment | Command | Tool |
|---|---|---|
| Local dev | `db:push:local` | `drizzle-kit push` (fast, destructive, no migration files) |
| Remote/prod | `db:generate` → review SQL → `db:migrate:remote` | `drizzle-kit generate` + `drizzle-kit migrate` (versioned, reviewable) |

Two clean mental models, no overlap: **push for local, migrate for remote.**