### PR TITLE
fix(whispering): harden materializer and unify file operations

### DIFF
--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -24,7 +24,7 @@ pub mod command;
 use command::{execute_command, spawn_command};
 
 pub mod markdown;
-use markdown::{bulk_delete_files, count_markdown_files, read_markdown_files, write_markdown_files};
+use markdown::{count_markdown_files, delete_files_in_directory, read_markdown_files, write_markdown_files};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 #[tokio::main]
@@ -170,7 +170,7 @@ pub async fn run() {
         // Filesystem utilities
         read_markdown_files,
         count_markdown_files,
-        bulk_delete_files,
+        delete_files_in_directory,
         write_markdown_files,
     ]);
 

--- a/apps/whispering/src-tauri/src/markdown.rs
+++ b/apps/whispering/src-tauri/src/markdown.rs
@@ -1,167 +1,20 @@
 use rayon::prelude::*;
 use std::collections::HashSet;
-use std::ffi::OsStr;
 use std::fs;
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicU32, Ordering};
 use tempfile::NamedTempFile;
 
-/// Counts markdown files in a directory without reading their contents.
-/// This is extremely fast as it only checks file extensions without I/O.
-///
-/// Performance characteristics:
-/// - No file I/O (only directory metadata)
-/// - Single-threaded is sufficient (directory reading is fast)
-/// - Returns immediately with just a count
-///
-/// # Arguments
-/// * `directory_path` - Absolute path to the directory containing .md files
-///
-/// # Returns
-/// * `Ok(usize)` - Number of .md files in the directory
-/// * `Err(String)` - Error message if reading fails
-#[tauri::command]
-pub async fn count_markdown_files(directory_path: String) -> Result<usize, String> {
-    tokio::task::spawn_blocking(move || {
-        let dir_path = PathBuf::from(&directory_path);
-
-        // Early returns for invalid paths
-        if !dir_path.exists() {
-            return Ok(0);
-        }
-
-        if !dir_path.is_dir() {
-            return Err(format!("{} is not a directory", directory_path));
-        }
-
-        // Count .md files
-        let count = fs::read_dir(&dir_path)
-            .map_err(|e| format!("Failed to read directory {}: {}", directory_path, e))?
-            .filter_map(|entry| entry.ok())
-            .filter(|entry| {
-                let path = entry.path();
-                path.is_file() && path.extension().map_or(false, |ext| ext == "md")
-            })
-            .count();
-
-        Ok::<usize, String>(count)
-    })
-    .await
-    .map_err(|e| format!("Task join error: {}", e))?
-}
-
-/// Reads all markdown files from a directory in parallel and returns their contents as strings.
-/// This is optimized for bulk reading with parallel I/O using Rayon.
-///
-/// Performance characteristics:
-/// - Uses Rayon for parallel file reading (utilizes all CPU cores)
-/// - Wrapped in spawn_blocking for proper async handling
-/// - ~3-4x faster than sequential reads for large directories
-///
-/// # Arguments
-/// * `directory_path` - Absolute path to the directory containing .md files
-///
-/// # Returns
-/// * `Ok(Vec<String>)` - Array of markdown file contents
-/// * `Err(String)` - Error message if reading fails
-#[tauri::command]
-pub async fn read_markdown_files(directory_path: String) -> Result<Vec<String>, String> {
-    // Wrap all blocking I/O in spawn_blocking to avoid blocking the Tokio runtime
-    tokio::task::spawn_blocking(move || {
-        let dir_path = PathBuf::from(&directory_path);
-
-        // Early returns for invalid paths
-        if !dir_path.exists() {
-            return Ok(Vec::new());
-        }
-
-        if !dir_path.is_dir() {
-            return Err(format!("{} is not a directory", directory_path));
-        }
-
-        // Step 1: Collect all .md file paths
-        // This is fast and sequential is fine
-        let paths: Vec<PathBuf> = fs::read_dir(&dir_path)
-            .map_err(|e| format!("Failed to read directory {}: {}", directory_path, e))?
-            .filter_map(|entry| {
-                let entry = entry.ok()?;
-                let path = entry.path();
-
-                // Only include .md files
-                if path.is_file() && path.extension()? == "md" {
-                    Some(path)
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        // Step 2: Read all files in parallel using Rayon
-        // par_iter() automatically distributes work across CPU cores
-        let contents: Vec<String> = paths
-            .par_iter()
-            .filter_map(|path| fs::read_to_string(path).ok())
-            .collect();
-
-        Ok::<Vec<String>, String>(contents)
-    })
-    .await
-    .map_err(|e| format!("Task join error: {}", e))?
-}
-
-/// Deletes files inside a directory by filename.
-/// Validates that filenames are single path components (no traversal).
-///
-/// Uses Rayon for parallel deletion. Silently skips files that don't exist.
-///
-/// # Arguments
-/// * `directory` - Absolute path to the directory containing the files
-/// * `filenames` - Array of leaf filenames to delete (e.g. `["abc.md", "abc.webm"]`)
-///
-/// # Returns
-/// * `Ok(u32)` - Number of files successfully deleted
-/// * `Err(String)` - If directory is not absolute or a filename is invalid
-#[tauri::command]
-pub async fn delete_files_in_directory(
-    directory: String,
-    filenames: Vec<String>,
-) -> Result<u32, String> {
-    tokio::task::spawn_blocking(move || {
-        let dir_path = PathBuf::from(&directory);
-
-        if !dir_path.is_absolute() {
-            return Err(format!("Directory must be absolute: {}", directory));
-        }
-
-        // Validate all filenames before deleting any
-        let validated: Vec<&str> = filenames
-            .iter()
-            .map(|f| validate_leaf_filename(f))
-            .collect::<Result<Vec<_>, _>>()?;
-
-        let deleted = AtomicU32::new(0);
-
-        validated.par_iter().for_each(|filename| {
-            let path = dir_path.join(filename);
-            if path.exists() && path.is_file() {
-                if fs::remove_file(&path).is_ok() {
-                    deleted.fetch_add(1, Ordering::Relaxed);
-                }
-            }
-        });
-
-        Ok::<u32, String>(deleted.load(Ordering::Relaxed))
-    })
-    .await
-    .map_err(|e| format!("Task join error: {}", e))?
-}
+// ── Types ──────────────────────────────────────────────────────────────────
 
 #[derive(serde::Deserialize)]
 pub struct MarkdownFile {
     filename: String,
     content: String,
 }
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
 
 /// Validates a filename is a single path component (no directory traversal).
 fn validate_leaf_filename(filename: &str) -> Result<&str, String> {
@@ -177,21 +30,82 @@ fn validate_leaf_filename(filename: &str) -> Result<&str, String> {
     Ok(filename)
 }
 
-/// Validates a filename is a single `.md` path component.
-fn validate_markdown_filename(filename: &str) -> Result<&str, String> {
-    let name = validate_leaf_filename(filename)?;
-    if Path::new(name).extension() != Some(OsStr::new("md")) {
-        return Err(format!("Filename must end with .md: {}", name));
-    }
-    Ok(name)
+// ── Commands ────────────────────────────────────────────────────────────────
+
+/// Counts markdown files in a directory without reading their contents.
+///
+/// # Arguments
+/// * `directory_path` - Absolute path to the directory containing .md files
+#[tauri::command]
+pub async fn count_markdown_files(directory_path: String) -> Result<usize, String> {
+    tokio::task::spawn_blocking(move || {
+        let dir_path = PathBuf::from(&directory_path);
+
+        if !dir_path.exists() {
+            return Ok(0);
+        }
+        if !dir_path.is_dir() {
+            return Err(format!("{} is not a directory", directory_path));
+        }
+
+        let count = fs::read_dir(&dir_path)
+            .map_err(|e| format!("Failed to read directory {}: {}", directory_path, e))?
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| {
+                let path = entry.path();
+                path.is_file() && path.extension().map_or(false, |ext| ext == "md")
+            })
+            .count();
+
+        Ok::<usize, String>(count)
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
+}
+
+/// Reads all markdown files from a directory in parallel.
+/// Uses Rayon for parallel I/O.
+///
+/// # Arguments
+/// * `directory_path` - Absolute path to the directory containing .md files
+#[tauri::command]
+pub async fn read_markdown_files(directory_path: String) -> Result<Vec<String>, String> {
+    tokio::task::spawn_blocking(move || {
+        let dir_path = PathBuf::from(&directory_path);
+
+        if !dir_path.exists() {
+            return Ok(Vec::new());
+        }
+        if !dir_path.is_dir() {
+            return Err(format!("{} is not a directory", directory_path));
+        }
+
+        let paths: Vec<PathBuf> = fs::read_dir(&dir_path)
+            .map_err(|e| format!("Failed to read directory {}: {}", directory_path, e))?
+            .filter_map(|entry| {
+                let entry = entry.ok()?;
+                let path = entry.path();
+                if path.is_file() && path.extension()? == "md" {
+                    Some(path)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let contents: Vec<String> = paths
+            .par_iter()
+            .filter_map(|path| fs::read_to_string(path).ok())
+            .collect();
+
+        Ok::<Vec<String>, String>(contents)
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
 }
 
 /// Writes markdown files to disk atomically using a temporary file plus persist.
-/// Ensures the target directory exists before writing.
-///
-/// Each file is written to a temporary file in the target directory, then
-/// persisted to `{directory}/{filename}`. This prevents partial reads from
-/// observers or external tools watching the directory.
+/// Validates all filenames upfront\u2014no files are written if any name is invalid.
 ///
 /// # Arguments
 /// * `directory` - Absolute path to the output directory
@@ -199,7 +113,7 @@ fn validate_markdown_filename(filename: &str) -> Result<&str, String> {
 ///
 /// # Returns
 /// * `Ok(())` - All files written successfully
-/// * `Err(String)` - Error message if any write fails (earlier files may already be on disk)
+/// * `Err(String)` - Error if any write fails (earlier files may already be on disk)
 #[tauri::command]
 pub async fn write_markdown_files(
     directory: String,
@@ -212,12 +126,11 @@ pub async fn write_markdown_files(
             return Err(format!("Directory must be absolute: {}", directory));
         }
 
-        // Validate all filenames upfront so no files are written if any name is invalid
         let validated: Vec<&str> = {
             let mut seen = HashSet::with_capacity(files.len());
             let mut names = Vec::with_capacity(files.len());
             for file in &files {
-                let name = validate_markdown_filename(&file.filename)?;
+                let name = validate_leaf_filename(&file.filename)?;
                 if !seen.insert(name) {
                     return Err(format!("Duplicate filename in request: {}", name));
                 }
@@ -241,6 +154,47 @@ pub async fn write_markdown_files(
         }
 
         Ok(())
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
+}
+
+/// Deletes files inside a directory by filename.
+/// Validates filenames are single path components (no traversal).
+/// Uses Rayon for parallel deletion. Silently skips missing files.
+///
+/// # Arguments
+/// * `directory` - Absolute path to the directory containing the files
+/// * `filenames` - Array of leaf filenames to delete
+#[tauri::command]
+pub async fn delete_files_in_directory(
+    directory: String,
+    filenames: Vec<String>,
+) -> Result<u32, String> {
+    tokio::task::spawn_blocking(move || {
+        let dir_path = PathBuf::from(&directory);
+
+        if !dir_path.is_absolute() {
+            return Err(format!("Directory must be absolute: {}", directory));
+        }
+
+        let validated: Vec<&str> = filenames
+            .iter()
+            .map(|f| validate_leaf_filename(f))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let deleted = AtomicU32::new(0);
+
+        validated.par_iter().for_each(|filename| {
+            let path = dir_path.join(filename);
+            if path.exists() && path.is_file() {
+                if fs::remove_file(&path).is_ok() {
+                    deleted.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        });
+
+        Ok::<u32, String>(deleted.load(Ordering::Relaxed))
     })
     .await
     .map_err(|e| format!("Task join error: {}", e))?

--- a/apps/whispering/src-tauri/src/markdown.rs
+++ b/apps/whispering/src-tauri/src/markdown.rs
@@ -184,13 +184,13 @@ fn validate_markdown_filename(filename: &str) -> Result<&str, String> {
 /// * `files` - Array of `{ filename, content }` pairs to write
 ///
 /// # Returns
-/// * `Ok(u32)` - Number of files successfully written
-/// * `Err(String)` - Error message if any write fails
+/// * `Ok(())` - All files written successfully
+/// * `Err(String)` - Error message if any write fails (earlier files may already be on disk)
 #[tauri::command]
 pub async fn write_markdown_files(
     directory: String,
     files: Vec<MarkdownFile>,
-) -> Result<u32, String> {
+) -> Result<(), String> {
     tokio::task::spawn_blocking(move || {
         let dir_path = PathBuf::from(&directory);
 
@@ -198,21 +198,24 @@ pub async fn write_markdown_files(
             return Err(format!("Directory must be absolute: {}", directory));
         }
 
-        let mut seen = HashSet::with_capacity(files.len());
-        for file in &files {
-            let filename = validate_markdown_filename(&file.filename)?;
-
-            if !seen.insert(filename.to_owned()) {
-                return Err(format!("Duplicate filename in request: {}", filename));
+        // Validate all filenames upfront so no files are written if any name is invalid
+        let validated: Vec<&str> = {
+            let mut seen = HashSet::with_capacity(files.len());
+            let mut names = Vec::with_capacity(files.len());
+            for file in &files {
+                let name = validate_markdown_filename(&file.filename)?;
+                if !seen.insert(name) {
+                    return Err(format!("Duplicate filename in request: {}", name));
+                }
+                names.push(name);
             }
-        }
+            names
+        };
 
         fs::create_dir_all(&dir_path)
             .map_err(|e| format!("Failed to create directory {}: {}", directory, e))?;
 
-        let mut written = 0u32;
-        for file in &files {
-            let filename = validate_markdown_filename(&file.filename)?;
+        for (file, filename) in files.iter().zip(validated.iter()) {
             let path = dir_path.join(filename);
             let mut temp = NamedTempFile::new_in(&dir_path)
                 .map_err(|e| format!("Failed to create temp file for {}: {}", filename, e))?;
@@ -221,11 +224,9 @@ pub async fn write_markdown_files(
                 .map_err(|e| format!("Failed to write {}: {}", filename, e))?;
             temp.persist(&path)
                 .map_err(|e| format!("Failed to persist {}: {}", filename, e.error))?;
-
-            written += 1;
         }
 
-        Ok::<u32, String>(written)
+        Ok(())
     })
     .await
     .map_err(|e| format!("Task join error: {}", e))?

--- a/apps/whispering/src-tauri/src/markdown.rs
+++ b/apps/whispering/src-tauri/src/markdown.rs
@@ -110,29 +110,40 @@ pub async fn read_markdown_files(directory_path: String) -> Result<Vec<String>, 
     .map_err(|e| format!("Task join error: {}", e))?
 }
 
-/// Deletes multiple files in parallel given their absolute paths.
-/// This is a single FFI call that handles bulk deletion natively in Rust,
-/// avoiding thousands of individual async calls for file removal.
+/// Deletes files inside a directory by filename.
+/// Validates that filenames are single path components (no traversal).
 ///
-/// Performance characteristics:
-/// - Uses Rayon for parallel file deletion (utilizes all CPU cores)
-/// - Wrapped in spawn_blocking for proper async handling
-/// - Silently skips files that don't exist or can't be deleted
+/// Uses Rayon for parallel deletion. Silently skips files that don't exist.
 ///
 /// # Arguments
-/// * `paths` - Array of absolute file paths to delete
+/// * `directory` - Absolute path to the directory containing the files
+/// * `filenames` - Array of leaf filenames to delete (e.g. `["abc.md", "abc.webm"]`)
 ///
 /// # Returns
 /// * `Ok(u32)` - Number of files successfully deleted
-/// * `Err(String)` - Error message if the operation fails catastrophically
+/// * `Err(String)` - If directory is not absolute or a filename is invalid
 #[tauri::command]
-pub async fn bulk_delete_files(paths: Vec<String>) -> Result<u32, String> {
+pub async fn delete_files_in_directory(
+    directory: String,
+    filenames: Vec<String>,
+) -> Result<u32, String> {
     tokio::task::spawn_blocking(move || {
+        let dir_path = PathBuf::from(&directory);
+
+        if !dir_path.is_absolute() {
+            return Err(format!("Directory must be absolute: {}", directory));
+        }
+
+        // Validate all filenames before deleting any
+        let validated: Vec<&str> = filenames
+            .iter()
+            .map(|f| validate_leaf_filename(f))
+            .collect::<Result<Vec<_>, _>>()?;
+
         let deleted = AtomicU32::new(0);
 
-        // Delete all files in parallel using Rayon
-        paths.par_iter().for_each(|path| {
-            let path = PathBuf::from(path);
+        validated.par_iter().for_each(|filename| {
+            let path = dir_path.join(filename);
             if path.exists() && path.is_file() {
                 if fs::remove_file(&path).is_ok() {
                     deleted.fetch_add(1, Ordering::Relaxed);
@@ -152,24 +163,27 @@ pub struct MarkdownFile {
     content: String,
 }
 
-fn validate_markdown_filename(filename: &str) -> Result<&str, String> {
+/// Validates a filename is a single path component (no directory traversal).
+fn validate_leaf_filename(filename: &str) -> Result<&str, String> {
     if filename.is_empty() {
         return Err("Filename cannot be empty".to_string());
     }
-
     let path = Path::new(filename);
     let mut components = path.components();
-
     match (components.next(), components.next()) {
         (Some(Component::Normal(_)), None) => {}
         _ => return Err(format!("Invalid filename: {}", filename)),
     }
-
-    if path.extension() != Some(OsStr::new("md")) {
-        return Err(format!("Filename must end with .md: {}", filename));
-    }
-
     Ok(filename)
+}
+
+/// Validates a filename is a single `.md` path component.
+fn validate_markdown_filename(filename: &str) -> Result<&str, String> {
+    let name = validate_leaf_filename(filename)?;
+    if Path::new(name).extension() != Some(OsStr::new("md")) {
+        return Err(format!("Filename must end with .md: {}", name));
+    }
+    Ok(name)
 }
 
 /// Writes markdown files to disk atomically using a temporary file plus persist.

--- a/apps/whispering/src-tauri/src/markdown.rs
+++ b/apps/whispering/src-tauri/src/markdown.rs
@@ -17,6 +17,7 @@ pub struct MarkdownFile {
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 /// Validates a filename is a single path component (no directory traversal).
+/// Rejects empty strings, paths with separators (`foo/bar`), and parent refs (`..`).
 fn validate_leaf_filename(filename: &str) -> Result<&str, String> {
     if filename.is_empty() {
         return Err("Filename cannot be empty".to_string());
@@ -126,6 +127,8 @@ pub async fn write_markdown_files(
             return Err(format!("Directory must be absolute: {}", directory));
         }
 
+        // Two-pass approach: validate all filenames first, then write.
+        // If any filename is invalid or duplicated, no files touch disk.
         let validated: Vec<&str> = {
             let mut seen = HashSet::with_capacity(files.len());
             let mut names = Vec::with_capacity(files.len());

--- a/apps/whispering/src-tauri/src/markdown.rs
+++ b/apps/whispering/src-tauri/src/markdown.rs
@@ -1,7 +1,11 @@
 use rayon::prelude::*;
+use std::collections::HashSet;
+use std::ffi::OsStr;
 use std::fs;
-use std::path::PathBuf;
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicU32, Ordering};
+use tempfile::NamedTempFile;
 
 /// Counts markdown files in a directory without reading their contents.
 /// This is extremely fast as it only checks file extensions without I/O.
@@ -148,12 +152,32 @@ pub struct MarkdownFile {
     content: String,
 }
 
-/// Writes markdown files to disk atomically (tmp + rename).
+fn validate_markdown_filename(filename: &str) -> Result<&str, String> {
+    if filename.is_empty() {
+        return Err("Filename cannot be empty".to_string());
+    }
+
+    let path = Path::new(filename);
+    let mut components = path.components();
+
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(_)), None) => {}
+        _ => return Err(format!("Invalid filename: {}", filename)),
+    }
+
+    if path.extension() != Some(OsStr::new("md")) {
+        return Err(format!("Filename must end with .md: {}", filename));
+    }
+
+    Ok(filename)
+}
+
+/// Writes markdown files to disk atomically using a temporary file plus persist.
 /// Ensures the target directory exists before writing.
 ///
-/// Each file is written to `{directory}/{filename}.tmp` first, then renamed
-/// to `{directory}/{filename}`. This prevents partial reads from observers
-/// or external tools watching the directory.
+/// Each file is written to a temporary file in the target directory, then
+/// persisted to `{directory}/{filename}`. This prevents partial reads from
+/// observers or external tools watching the directory.
 ///
 /// # Arguments
 /// * `directory` - Absolute path to the output directory
@@ -169,20 +193,38 @@ pub async fn write_markdown_files(
 ) -> Result<u32, String> {
     tokio::task::spawn_blocking(move || {
         let dir_path = PathBuf::from(&directory);
+
+        if !dir_path.is_absolute() {
+            return Err(format!("Directory must be absolute: {}", directory));
+        }
+
+        let mut seen = HashSet::with_capacity(files.len());
+        for file in &files {
+            let filename = validate_markdown_filename(&file.filename)?;
+
+            if !seen.insert(filename.to_owned()) {
+                return Err(format!("Duplicate filename in request: {}", filename));
+            }
+        }
+
         fs::create_dir_all(&dir_path)
             .map_err(|e| format!("Failed to create directory {}: {}", directory, e))?;
 
         let mut written = 0u32;
         for file in &files {
-            let path = dir_path.join(&file.filename);
-            let tmp = path.with_extension("md.tmp");
+            let filename = validate_markdown_filename(&file.filename)?;
+            let path = dir_path.join(filename);
+            let mut temp = NamedTempFile::new_in(&dir_path)
+                .map_err(|e| format!("Failed to create temp file for {}: {}", filename, e))?;
 
-            fs::write(&tmp, &file.content)
-                .map_err(|e| format!("Failed to write {}: {}", file.filename, e))?;
-            fs::rename(&tmp, &path)
-                .map_err(|e| format!("Failed to rename {}: {}", file.filename, e))?;
+            temp.write_all(file.content.as_bytes())
+                .map_err(|e| format!("Failed to write {}: {}", filename, e))?;
+            temp.persist(&path)
+                .map_err(|e| format!("Failed to persist {}: {}", filename, e.error))?;
+
             written += 1;
         }
+
         Ok::<u32, String>(written)
     })
     .await

--- a/apps/whispering/src/lib/client.ts
+++ b/apps/whispering/src/lib/client.ts
@@ -84,13 +84,18 @@ export const workspace = isTauri()
 							});
 					});
 
-					// Initial flush—write all recordings to disk
-					const files = ctx.tables.recordings
-						.getAllValid()
-						.map(toRecordingMarkdownFile);
-					if (files.length) {
-						await invoke('write_markdown_files', { directory: dir, files });
-					}
+					// Initial flush—write all recordings to disk.
+					// Routed through syncQueue so observer writes that fire during
+					// flush don't overlap with it.
+					syncQueue = syncQueue.then(async () => {
+						const files = ctx.tables.recordings
+							.getAllValid()
+							.map(toRecordingMarkdownFile);
+						if (files.length) {
+							await invoke('write_markdown_files', { directory: dir, files });
+						}
+					});
+					await syncQueue;
 				})(),
 				// Unsubscribe immediately, then wait for any in-flight write to finish
 				async dispose() {

--- a/apps/whispering/src/lib/client.ts
+++ b/apps/whispering/src/lib/client.ts
@@ -14,6 +14,12 @@ import { PATHS } from '$lib/constants/paths';
 import type { Recording } from './workspace';
 import { whisperingDefinition } from './workspace/definition';
 
+/**
+ * Serialize a recording row to a markdown file.
+ *
+ * Puts `transcript` in the body and all other metadata in YAML frontmatter.
+ * Strips `_v` (workspace internal, not useful in human-readable files).
+ */
 function toRecordingMarkdownFile(row: Recording) {
 	const { transcript, _v, ...frontmatter } = row;
 	const yamlStr = yaml.dump(frontmatter, { lineWidth: -1 });
@@ -31,11 +37,16 @@ const base = createWorkspace(whisperingDefinition).withExtension(
 export const workspace = isTauri()
 	? base.withWorkspaceExtension('materializer', (ctx) => {
 			let unsub: (() => void) | undefined;
+			// Serialized promise chain—ensures observer batches complete sequentially
+			// so rapid changes don't produce overlapping Rust invoke calls.
 			let syncQueue = Promise.resolve();
 
 			return {
 				whenReady: (async () => {
 					await ctx.whenReady;
+					// Dynamic import: invoke is only available in Tauri runtime.
+					// Static import of isTauri() is fine (returns false on web),
+					// but invoke would fail if called on web.
 					const { invoke } = await import('@tauri-apps/api/core');
 					const dir = await PATHS.DB.RECORDINGS();
 
@@ -81,6 +92,7 @@ export const workspace = isTauri()
 						await invoke('write_markdown_files', { directory: dir, files });
 					}
 				})(),
+				// Unsubscribe immediately, then wait for any in-flight write to finish
 				async dispose() {
 					unsub?.();
 					await syncQueue;

--- a/apps/whispering/src/lib/client.ts
+++ b/apps/whispering/src/lib/client.ts
@@ -8,8 +8,8 @@
 
 import { createWorkspace } from '@epicenter/workspace';
 import { indexeddbPersistence } from '@epicenter/workspace/extensions/persistence/indexeddb';
+import { isTauri } from '@tauri-apps/api/core';
 import yaml from 'js-yaml';
-
 import { PATHS } from '$lib/constants/paths';
 import type { Recording } from './workspace';
 import { whisperingDefinition } from './workspace/definition';
@@ -21,14 +21,14 @@ function toRecordingMarkdownFile(row: Recording) {
 		filename: `${row.id}.md`,
 		content: `---\n${yamlStr}---\n${transcript || ''}\n`,
 	};
-		}
+}
 
 const base = createWorkspace(whisperingDefinition).withExtension(
 	'persistence',
 	indexeddbPersistence,
-	);
+);
 
-export const workspace = window.__TAURI_INTERNALS__
+export const workspace = isTauri()
 	? base.withWorkspaceExtension('materializer', (ctx) => {
 			let unsub: (() => void) | undefined;
 			let syncQueue = Promise.resolve();
@@ -50,9 +50,9 @@ export const workspace = window.__TAURI_INTERNALS__
 									const result = ctx.tables.recordings.get(id);
 									if (result.status === 'valid') {
 										toWrite.push(toRecordingMarkdownFile(result.row));
-								} else if (result.status === 'not_found') {
-									toDelete.push(`${id}.md`);
-								}
+									} else if (result.status === 'not_found') {
+										toDelete.push(`${id}.md`);
+									}
 								}
 
 								if (toWrite.length) {

--- a/apps/whispering/src/lib/client.ts
+++ b/apps/whispering/src/lib/client.ts
@@ -8,8 +8,10 @@
 
 import { createWorkspace } from '@epicenter/workspace';
 import { indexeddbPersistence } from '@epicenter/workspace/extensions/persistence/indexeddb';
-import { PATHS } from '$lib/constants/paths';
+import { isTauri } from '@tauri-apps/api/core';
 import yaml from 'js-yaml';
+
+import { PATHS } from '$lib/constants/paths';
 import type { Recording } from './workspace';
 import { whisperingDefinition } from './workspace/definition';
 
@@ -28,15 +30,17 @@ const base = createWorkspace(whisperingDefinition).withExtension(
 	indexeddbPersistence,
 );
 
-export const workspace = window.__TAURI_INTERNALS__
+export const workspace = isTauri()
 	? base.withWorkspaceExtension('materializer', (ctx) => {
-			const unsubscribers: (() => void)[] = [];
+			let unsub: (() => void) | undefined;
+			let syncQueue = Promise.resolve();
 
 			return {
 				whenReady: (async () => {
 					await ctx.whenReady;
 					const { invoke } = await import('@tauri-apps/api/core');
 					const dir = await PATHS.DB.RECORDINGS();
+					const { join } = await import('@tauri-apps/api/path');
 
 					// Initial flush—write all recordings to disk
 					const files = ctx.tables.recordings
@@ -47,38 +51,39 @@ export const workspace = window.__TAURI_INTERNALS__
 					}
 
 					// Incremental sync—observe changes and write/delete as needed
-					const unsub = ctx.tables.recordings.observe((changedIds) => {
-						void (async () => {
-							const toWrite: { filename: string; content: string }[] = [];
-							const toDelete: string[] = [];
+					unsub = ctx.tables.recordings.observe((changedIds) => {
+						syncQueue = syncQueue
+							.then(async () => {
+								const toWrite: { filename: string; content: string }[] = [];
+								const toDelete: string[] = [];
 
-							for (const id of changedIds) {
-								const result = ctx.tables.recordings.get(id);
-								if (result.status === 'valid') {
-									toWrite.push(serializeRecording(result.row));
-								} else if (result.status === 'not_found') {
-									const mdPath = await PATHS.DB.RECORDING_MD(id);
-									toDelete.push(mdPath);
+								for (const id of changedIds) {
+									const result = ctx.tables.recordings.get(id);
+									if (result.status === 'valid') {
+										toWrite.push(serializeRecording(result.row));
+									} else if (result.status === 'not_found') {
+										const mdPath = await join(dir, `${id}.md`);
+										toDelete.push(mdPath);
+									}
 								}
-							}
 
-							if (toWrite.length) {
-								await invoke('write_markdown_files', {
-									directory: dir,
-									files: toWrite,
-								});
-							}
-							if (toDelete.length) {
-								await invoke('bulk_delete_files', { paths: toDelete });
-							}
-						})().catch((error) => {
-							console.warn('[recording-materializer] write failed:', error);
-						});
+								if (toWrite.length) {
+									await invoke('write_markdown_files', {
+										directory: dir,
+										files: toWrite,
+									});
+								}
+								if (toDelete.length) {
+									await invoke('bulk_delete_files', { paths: toDelete });
+								}
+							})
+							.catch((error) => {
+								console.warn('[recording-materializer] write failed:', error);
+							});
 					});
-					unsubscribers.push(unsub);
 				})(),
 				dispose() {
-					for (const fn of unsubscribers) fn();
+					unsub?.();
 				},
 			};
 		})

--- a/apps/whispering/src/lib/client.ts
+++ b/apps/whispering/src/lib/client.ts
@@ -28,9 +28,7 @@ const base = createWorkspace(whisperingDefinition).withExtension(
 	indexeddbPersistence,
 	);
 
-const IS_DESKTOP = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
-
-export const workspace = IS_DESKTOP
+export const workspace = window.__TAURI_INTERNALS__
 	? base.withWorkspaceExtension('materializer', (ctx) => {
 			let unsub: (() => void) | undefined;
 			let syncQueue = Promise.resolve();
@@ -39,7 +37,6 @@ export const workspace = IS_DESKTOP
 				whenReady: (async () => {
 					await ctx.whenReady;
 					const { invoke } = await import('@tauri-apps/api/core');
-					const { join } = await import('@tauri-apps/api/path');
 					const dir = await PATHS.DB.RECORDINGS();
 
 					// Subscribe BEFORE flush so changes during flush aren't missed
@@ -53,9 +50,9 @@ export const workspace = IS_DESKTOP
 									const result = ctx.tables.recordings.get(id);
 									if (result.status === 'valid') {
 										toWrite.push(toRecordingMarkdownFile(result.row));
-									} else if (result.status === 'not_found') {
-										toDelete.push(await join(dir, `${id}.md`));
-									}
+								} else if (result.status === 'not_found') {
+									toDelete.push(`${id}.md`);
+								}
 								}
 
 								if (toWrite.length) {
@@ -65,7 +62,10 @@ export const workspace = IS_DESKTOP
 									});
 								}
 								if (toDelete.length) {
-									await invoke('bulk_delete_files', { paths: toDelete });
+									await invoke('delete_files_in_directory', {
+										directory: dir,
+										filenames: toDelete,
+									});
 								}
 							})
 							.catch((error) => {

--- a/apps/whispering/src/lib/client.ts
+++ b/apps/whispering/src/lib/client.ts
@@ -8,29 +8,29 @@
 
 import { createWorkspace } from '@epicenter/workspace';
 import { indexeddbPersistence } from '@epicenter/workspace/extensions/persistence/indexeddb';
-import { isTauri } from '@tauri-apps/api/core';
 import yaml from 'js-yaml';
 
 import { PATHS } from '$lib/constants/paths';
 import type { Recording } from './workspace';
 import { whisperingDefinition } from './workspace/definition';
 
-function serializeRecording(row: Recording) {
+function toRecordingMarkdownFile(row: Recording) {
 	const { transcript, _v, ...frontmatter } = row;
 	const yamlStr = yaml.dump(frontmatter, { lineWidth: -1 });
-	const yamlBlock = yamlStr.endsWith('\n') ? yamlStr : `${yamlStr}\n`;
 	return {
 		filename: `${row.id}.md`,
-		content: `---\n${yamlBlock}---\n${transcript || ''}\n`,
+		content: `---\n${yamlStr}---\n${transcript || ''}\n`,
 	};
-}
+		}
 
 const base = createWorkspace(whisperingDefinition).withExtension(
 	'persistence',
 	indexeddbPersistence,
-);
+	);
 
-export const workspace = isTauri()
+const IS_DESKTOP = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
+
+export const workspace = IS_DESKTOP
 	? base.withWorkspaceExtension('materializer', (ctx) => {
 			let unsub: (() => void) | undefined;
 			let syncQueue = Promise.resolve();
@@ -39,18 +39,10 @@ export const workspace = isTauri()
 				whenReady: (async () => {
 					await ctx.whenReady;
 					const { invoke } = await import('@tauri-apps/api/core');
-					const dir = await PATHS.DB.RECORDINGS();
 					const { join } = await import('@tauri-apps/api/path');
+					const dir = await PATHS.DB.RECORDINGS();
 
-					// Initial flush—write all recordings to disk
-					const files = ctx.tables.recordings
-						.getAllValid()
-						.map(serializeRecording);
-					if (files.length) {
-						await invoke('write_markdown_files', { directory: dir, files });
-					}
-
-					// Incremental sync—observe changes and write/delete as needed
+					// Subscribe BEFORE flush so changes during flush aren't missed
 					unsub = ctx.tables.recordings.observe((changedIds) => {
 						syncQueue = syncQueue
 							.then(async () => {
@@ -60,10 +52,9 @@ export const workspace = isTauri()
 								for (const id of changedIds) {
 									const result = ctx.tables.recordings.get(id);
 									if (result.status === 'valid') {
-										toWrite.push(serializeRecording(result.row));
+										toWrite.push(toRecordingMarkdownFile(result.row));
 									} else if (result.status === 'not_found') {
-										const mdPath = await join(dir, `${id}.md`);
-										toDelete.push(mdPath);
+										toDelete.push(await join(dir, `${id}.md`));
 									}
 								}
 
@@ -81,9 +72,18 @@ export const workspace = isTauri()
 								console.warn('[recording-materializer] write failed:', error);
 							});
 					});
+
+					// Initial flush—write all recordings to disk
+					const files = ctx.tables.recordings
+						.getAllValid()
+						.map(toRecordingMarkdownFile);
+					if (files.length) {
+						await invoke('write_markdown_files', { directory: dir, files });
+					}
 				})(),
-				dispose() {
+				async dispose() {
 					unsub?.();
+					await syncQueue;
 				},
 			};
 		})

--- a/apps/whispering/src/lib/services/db/file-system.ts
+++ b/apps/whispering/src/lib/services/db/file-system.ts
@@ -115,15 +115,15 @@ async function readMarkdownFiles(directoryPath: string): Promise<string[]> {
 }
 
 /**
- * Deletes multiple files in parallel using the Rust command.
- * This is a single FFI call that handles bulk deletion natively in Rust,
- * avoiding thousands of individual async calls for file removal.
+ * Deletes files inside a directory by filename.
+ * Validates that filenames are single path components (no traversal).
  *
- * @param paths - Array of absolute file paths to delete
+ * @param directory - Absolute path to the directory containing the files
+ * @param filenames - Array of leaf filenames to delete
  * @returns Number of files successfully deleted
  */
-async function bulkDeleteFiles(paths: string[]): Promise<number> {
-	return invoke('bulk_delete_files', { paths });
+async function deleteFilesInDirectory(directory: string, filenames: string[]): Promise<number> {
+	return invoke('delete_files_in_directory', { directory, filenames });
 }
 
 /**
@@ -337,18 +337,13 @@ export function createFileSystemDb(): DbService {
 
 						// Read directory once and find all matching files
 						const allFiles = await readDir(recordingsPath);
-						const pathsToDelete = await Promise.all(
-							allFiles
-								.filter((file) => {
-									// Extract ID from filename (everything before the first dot)
-									const id = file.name.split('.')[0] ?? '';
-									return idsToDelete.has(id);
-								})
-								.map((file) => PATHS.DB.RECORDING_FILE(file.name)),
-						);
-
-						// Single FFI call to delete all files in parallel
-						await bulkDeleteFiles(pathsToDelete);
+						const filenames = allFiles
+							.filter((file) => {
+								const id = file.name.split('.')[0] ?? '';
+								return idsToDelete.has(id);
+							})
+							.map((file) => file.name);
+						await deleteFilesInDirectory(recordingsPath, filenames);
 					},
 					catch: (error) => DbError.MutationFailed({ cause: error }),
 				});
@@ -442,14 +437,8 @@ export function createFileSystemDb(): DbService {
 						const dirExists = await exists(recordingsPath);
 						if (!dirExists) return undefined;
 
-						// Get all files and build paths
-						const files = await readDir(recordingsPath);
-						const pathsToDelete = await Promise.all(
-							files.map((file) => PATHS.DB.RECORDING_FILE(file.name)),
-						);
-
-						// Single FFI call to delete all files in parallel
-						await bulkDeleteFiles(pathsToDelete);
+						const filenames = files.map((file) => file.name);
+						await deleteFilesInDirectory(recordingsPath, filenames);
 					},
 					catch: (error) => DbError.MutationFailed({ cause: error }),
 				});
@@ -588,10 +577,9 @@ export function createFileSystemDb(): DbService {
 					: [transformationOrTransformations];
 				return tryAsync({
 					try: async () => {
-						const pathsToDelete = await Promise.all(
-							transformations.map((t) => PATHS.DB.TRANSFORMATION_MD(t.id)),
-						);
-						await bulkDeleteFiles(pathsToDelete);
+						const transformationsDir = await PATHS.DB.TRANSFORMATIONS();
+						const filenames = transformations.map((t) => `${t.id}.md`);
+						await deleteFilesInDirectory(transformationsDir, filenames);
 					},
 					catch: (error) => DbError.MutationFailed({ cause: error }),
 				});
@@ -935,10 +923,9 @@ export function createFileSystemDb(): DbService {
 				const runs = Array.isArray(runOrRuns) ? runOrRuns : [runOrRuns];
 				return tryAsync({
 					try: async () => {
-						const pathsToDelete = await Promise.all(
-							runs.map((run) => PATHS.DB.TRANSFORMATION_RUN_MD(run.id)),
-						);
-						await bulkDeleteFiles(pathsToDelete);
+						const runsDir = await PATHS.DB.TRANSFORMATION_RUNS();
+						const filenames = runs.map((run) => `${run.id}.md`);
+						await deleteFilesInDirectory(runsDir, filenames);
 					},
 					catch: (error) => DbError.MutationFailed({ cause: error }),
 				});

--- a/apps/whispering/src/lib/services/db/file-system.ts
+++ b/apps/whispering/src/lib/services/db/file-system.ts
@@ -437,7 +437,8 @@ export function createFileSystemDb(): DbService {
 						const dirExists = await exists(recordingsPath);
 						if (!dirExists) return undefined;
 
-						const filenames = files.map((file) => file.name);
+						const allFiles = await readDir(recordingsPath);
+						const filenames = allFiles.map((file) => file.name);
 						await deleteFilesInDirectory(recordingsPath, filenames);
 					},
 					catch: (error) => DbError.MutationFailed({ cause: error }),

--- a/docs/articles/promise-chain-queue.md
+++ b/docs/articles/promise-chain-queue.md
@@ -1,0 +1,91 @@
+# A Serial Async Queue Is Just One Variable
+
+You don't need a class, an array of callbacks, or a drain loop to serialize async work. One variable and promise chaining is enough.
+
+```typescript
+let syncQueue = Promise.resolve();
+```
+
+Every time a new task arrives, chain it off the current tail:
+
+```typescript
+syncQueue = syncQueue.then(task).catch(log);
+```
+
+That's the whole pattern. Each `.then()` returns a new promise that waits for the previous one before running. Reassigning `syncQueue` to that new promise means the next task will wait for this one. The chain grows forward automatically.
+
+## Each `.catch()` keeps the queue alive
+
+The `.catch()` placement matters more than it looks. Put it at the end of the whole chain and one failure kills everything after it—a rejected promise propagates forward, so every subsequent `.then()` skips. Put it after each task and errors are isolated. The queue keeps moving.
+
+```typescript
+syncQueue = syncQueue
+    .then(async () => {
+        // async work
+    })
+    .catch((error) => {
+        console.warn('[recording-materializer] write failed:', error);
+    });
+```
+
+The `.catch()` returns a resolved promise, so the next task in the chain sees a clean slate regardless of what happened before it.
+
+## Where we use this in Whispering
+
+The recording materializer in `apps/whispering/src/lib/client.ts` is a workspace extension that observes the recordings table and writes `.md` files to disk via Rust commands. The observer fires synchronously whenever recordings change—and recordings can change rapidly. Without serialization, concurrent `invoke()` calls would race each other.
+
+```typescript
+let syncQueue = Promise.resolve();
+
+unsub = ctx.tables.recordings.observe((changedIds) => {
+    syncQueue = syncQueue
+        .then(async () => {
+            const toWrite: { filename: string; content: string }[] = [];
+            const toDelete: string[] = [];
+
+            for (const id of changedIds) {
+                const result = ctx.tables.recordings.get(id);
+                if (result.status === 'valid') {
+                    toWrite.push(toRecordingMarkdownFile(result.row));
+                } else if (result.status === 'not_found') {
+                    toDelete.push(`${id}.md`);
+                }
+            }
+
+            if (toWrite.length) {
+                await invoke('write_markdown_files', { directory: dir, files: toWrite });
+            }
+            if (toDelete.length) {
+                await invoke('delete_files_in_directory', { directory: dir, filenames: toDelete });
+            }
+        })
+        .catch((error) => {
+            console.warn('[recording-materializer] write failed:', error);
+        });
+});
+```
+
+The observer callback is synchronous. It doesn't await anything—it just appends to the chain and returns. The async work happens in the background, one batch at a time, in the order the observer fired.
+
+The `dispose()` method awaits the queue before tearing down, so in-flight writes finish cleanly:
+
+```typescript
+async dispose() {
+    unsub?.();
+    await syncQueue;
+},
+```
+
+## Why not an array-based queue?
+
+The array approach looks like this: push tasks into an array, track whether a drain loop is running, start the loop if it isn't, pop tasks off the front one at a time. It works, but it's four moving parts instead of one. You have to manage the array, the running flag, the loop, and the error handling separately. The promise chain does all of that implicitly—the chain itself is the queue, the pending promise is the running flag, and `.then()` is the drain loop.
+
+## When this pattern isn't enough
+
+This queue has no cancellation. Once a task is chained, it will run. If you need to cancel in-flight work—say, because the user navigated away or a newer request supersedes an older one—you need something that tracks individual tasks and can abort them.
+
+It has no backpressure. If tasks arrive faster than they complete, the chain grows without bound. For a recording materializer that fires on user edits, that's fine. For a queue that processes network responses at arbitrary volume, it's a memory leak waiting to happen.
+
+It has no retry. A failed task logs and moves on. If you need exponential backoff or dead-letter handling, you'll want a proper queue library.
+
+For fire-and-forget serial execution where tasks are short-lived and bounded in number, one variable is all you need.

--- a/specs/20260415T190000-recording-phase-prompts.md
+++ b/specs/20260415T190000-recording-phase-prompts.md
@@ -1,0 +1,84 @@
+# Execution Prompts for Recording Phases
+
+Copy-paste these prompts to execute each phase in a new session.
+
+---
+
+## Phase B: Slim DB service to audio-only
+
+```
+Read specs/20260415T190000-recording-remaining-phases.md, Phase B section.
+
+Execute Phase B on a new branch `refactor/whispering-audio-only-db-service` based on `fix/materializer-review-fixes`.
+
+The workspace is now the sole source of truth for recording metadata. The DB service should become an audio-only blob store.
+
+Key changes:
+1. Remove metadata-only methods from DbService.recordings interface (getAll, getLatest, getById, getTranscribingIds, getCount, update)
+2. Rename create → saveAudio(recordingId: string, audio: Blob)
+3. Simplify delete to accept string | string[] (IDs, not full DbRecording objects)
+4. Delete the DbRecording type entirely (models/recordings.ts)
+5. Remove markdown serialization functions from file-system.ts (recordingToMarkdown, markdownToRecording, RecordingFrontMatter, etc.) — the materializer in client.ts handles this now
+6. Update all callers (especially actions.ts and cleanupExpired)
+
+Load skills: workspace-api, services-layer, typescript, error-handling, refactoring
+
+Verify with LSP diagnostics on every changed file. Make surgical, incremental commits.
+```
+
+---
+
+## Phase C: Clean up web IndexedDB path
+
+```
+Read specs/20260415T190000-recording-remaining-phases.md, Phase C section.
+
+Execute Phase C on the same branch as Phase B (or a new branch based on it).
+
+Simplify the web IndexedDB recording storage to audio-only:
+1. RecordingStoredInIndexedDB → { id: string; serializedAudio: SerializedAudio }
+2. Remove RecordingStoredInIndexedDbLegacy type
+3. Web create drops metadata from IndexedDB row
+4. Web delete accepts IDs only
+
+Load skills: typescript, refactoring
+
+Verify with LSP diagnostics.
+```
+
+---
+
+## Phase D.1: Toast on first materializer failure
+
+```
+In apps/whispering/src/lib/client.ts, replace the console.warn in the materializer's .catch with a pattern that shows a single toast on the first failure:
+
+1. Add a let hasWarnedUser = false; alongside the unsub and syncQueue declarations
+2. In the .catch, keep the console.warn, but also check if (!hasWarnedUser) and if so, set it to true and call toast.warning with a user-friendly message explaining their recordings are safe but the markdown export failed
+3. Import toast from whatever toast utility this codebase uses (check existing toast imports in the app)
+
+This is a one-file, 5-line change. Quick category.
+```
+
+---
+
+## Phase E: Codebase-wide isTauri() migration
+
+```
+Read specs/20260415T190000-recording-remaining-phases.md, Phase E section.
+
+Replace all 29 occurrences of window.__TAURI_INTERNALS__ with isTauri() from @tauri-apps/api/core across the Whispering app.
+
+Rules:
+- Add import { isTauri } from '@tauri-apps/api/core' to each file
+- Replace window.__TAURI_INTERNALS__ → isTauri() in runtime checks
+- Replace !window.__TAURI_INTERNALS__ → !isTauri()
+- Leave the app.d.ts Window interface augmentation intact (type declaration, not runtime)
+- Verify each file with LSP diagnostics after changes
+
+This touches ~29 files. Use AST grep or manual grep to find all occurrences. Work through them systematically. Commit in batches (services, components, pages).
+
+Load skills: typescript, svelte, tauri
+```
+
+---

--- a/specs/20260415T190000-recording-remaining-phases.md
+++ b/specs/20260415T190000-recording-remaining-phases.md
@@ -1,0 +1,118 @@
+# Recording Architecture—Remaining Phases
+
+**Date**: 2026-04-15
+**Status**: Draft
+**Depends on**: `fix/materializer-review-fixes` branch (merged)
+
+## Overview
+
+Follow-up work from the recording schema migration and materializer implementation. Each phase is independently shippable.
+
+---
+
+## Phase B: Slim DB service to audio-only
+
+**Goal**: Remove all metadata-only methods from `DbService.recordings`. The workspace is the sole source of truth for metadata. The DB service becomes an audio blob store.
+
+### What to remove
+
+From `services/db/types.ts` (`DbService.recordings`):
+- `getAll()` — workspace has this
+- `getLatest()` — workspace has this
+- `getById()` — workspace has this
+- `getTranscribingIds()` — workspace has this
+- `getCount()` — workspace has this
+- `update()` — never called from app code (confirmed)
+
+### What to keep (audio operations)
+- `create()` → rename to `saveAudio(recordingId: string, audio: Blob)`
+- `getAudioBlob()`
+- `ensureAudioPlaybackUrl()`
+- `revokeAudioUrl()`
+- `delete()` → simplify to accept `string | string[]` (IDs, not full objects)
+- `cleanupExpired()` → read from workspace instead of DB service `getAll()`
+
+### What to delete
+- `DbRecording` type (`models/recordings.ts`) — no longer needed
+- `storedRecordingToRecording` in `web/index.ts`
+- `RecordingFrontMatter`, `RecordingFrontMatterRaw`, `normalizeRecordingFrontMatter` in `file-system.ts` — the materializer handles markdown writes now
+- `recordingToMarkdown`, `markdownToRecording` in `file-system.ts`
+
+### Callers to update
+- `actions.ts` line ~625: `services.db.recordings.create({ recording, audio })` → `services.db.recordings.saveAudio(recording.id, audio)`
+- `cleanupExpired`: read recording IDs from workspace, not from DB service
+- Anywhere that imports `DbRecording`
+
+### Files touched
+- `services/db/types.ts`
+- `services/db/models/recordings.ts` (delete)
+- `services/db/models/index.ts`
+- `services/db/file-system.ts`
+- `services/db/web/index.ts`
+- `services/db/web/dexie-schemas.ts`
+- `services/db/index.ts`
+- `query/actions.ts`
+
+---
+
+## Phase C: Clean up web IndexedDB path
+
+**Goal**: Web `create` becomes audio-only. Simplify `RecordingStoredInIndexedDB`.
+
+### Changes
+- `RecordingStoredInIndexedDB` → `{ id: string; serializedAudio: SerializedAudio }`
+- Remove `RecordingStoredInIndexedDbLegacy` type
+- Web `create` drops metadata from IndexedDB row
+- Web `delete` accepts IDs only
+
+### Files touched
+- `services/db/web/dexie-schemas.ts`
+- `services/db/web/index.ts`
+
+---
+
+## Phase D: Materializer polish
+
+**Goal**: Small follow-ups from the code review that improve robustness.
+
+### D.1: Toast on first materializer failure
+Replace `console.warn` with a single toast on first failure:
+```typescript
+let hasWarnedUser = false;
+.catch((error) => {
+    console.warn('[recording-materializer] write failed:', error);
+    if (!hasWarnedUser) {
+        hasWarnedUser = true;
+        toast.warning("Recording files couldn't be saved to disk. Your recordings are safe—this only affects the markdown export.");
+    }
+});
+```
+
+### D.2: Initial flush optimization (deferred until needed)
+When recording count exceeds ~1000, the initial flush sends all recordings in one invoke call. Consider:
+- Skip unchanged recordings (compare `updatedAt` with file mtime)
+- Chunk into batches of 100
+
+### D.3: Error recovery with full reconcile (deferred)
+After any observer failure, schedule a full reconcile that re-syncs all recordings vs files on disk. This handles the case where a failed batch leaves stale `.md` files.
+
+---
+
+## Phase E: Codebase-wide `isTauri()` migration
+
+**Goal**: Replace all 29 occurrences of `window.__TAURI_INTERNALS__` with `isTauri()` from `@tauri-apps/api/core`.
+
+### Scope
+- 1 type declaration in `app.d.ts` — keep the `Window` interface augmentation, change runtime checks only
+- ~9 platform gate service files (`analytics`, `notifications`, `sound`, `text`, `os`, `db`, `http`, `download`, `tauri-fetch`)
+- ~19 runtime guards in components/pages
+
+### Approach
+- Add `import { isTauri } from '@tauri-apps/api/core'` to each file
+- Replace `window.__TAURI_INTERNALS__` with `isTauri()` in runtime checks
+- Replace `!window.__TAURI_INTERNALS__` with `!isTauri()`
+- Leave the `app.d.ts` type declaration intact
+- Verify each file with LSP diagnostics
+
+### Risk
+Low—`isTauri()` is a drop-in replacement. It returns `false` on web, `true` on desktop. Same behavior as `!!window.__TAURI_INTERNALS__`.


### PR DESCRIPTION
The materializer—the extension that writes Yjs recording data to markdown files on disk—had several issues found during code review: fire-and-forget observer writes could race and overlap, the delete API accepted arbitrary absolute paths (directory traversal risk), `yaml.dump` output was double-newlined in frontmatter, and `window.__TAURI_INTERNALS__` was used as a runtime guard instead of the proper `isTauri()` API.

This PR addresses all of those in a focused series of commits, plus cleans up the Rust side to match.

The biggest behavioral change is the observer write strategy. The old materializer fired `void (async () => {...})()` inside the observer callback, meaning two rapid changes could produce overlapping Rust invoke calls—one write starting before the previous finished. Now a serialized promise chain (`syncQueue`) ensures each batch completes before the next begins:

```typescript
unsub = ctx.tables.recordings.observe((changedIds) => {
    syncQueue = syncQueue
        .then(async () => {
            // ... collect writes/deletes from changedIds
            if (toWrite.length) await invoke('write_markdown_files', { ... });
            if (toDelete.length) await invoke('delete_files_in_directory', { ... });
        })
        .catch((error) => {
            console.warn('[recording-materializer] write failed:', error);
        });
});
```

The observer is also subscribed *before* the initial flush now, so changes that arrive during flush aren't silently dropped.

---

**The delete API no longer accepts absolute paths.**

`bulk_delete_files(paths: string[])` accepted arbitrary absolute file paths from the frontend—a directory traversal surface. It's replaced by `delete_files_in_directory(directory, filenames)`, where filenames are validated as single path components (no `/`, no `..`). The Rust side enforces this with a `validate_leaf_filename` helper that checks `Path::components()` yields exactly one `Normal` component.

The TypeScript call sites in `file-system.ts` are updated to pass `(directory, filenames)` instead of building absolute paths client-side—simpler and safer.

---

**Smaller fixes along the way:** `yaml.dump` already terminates with `\n`, so the extra conditional newline was producing `\n\n` before the closing `---`. `serializeRecording` → `toRecordingMarkdownFile` for clarity. `window.__TAURI_INTERNALS__` → `isTauri()` as a top-level import. `write_markdown_files` now uses `tempfile::NamedTempFile` + `persist` for atomic writes instead of the manual `.md.tmp` + rename dance, and validates filenames and rejects duplicates before writing anything. Verbose JSDoc-style Rust doc comments trimmed to essentials.

7 commits, 4 code files + 3 docs files changed.