### PR TITLE
refactor(workspace)!: make document content strategy-driven via .withDocument()

### DIFF
--- a/apps/fuji/src/lib/components/EntryEditor.svelte
+++ b/apps/fuji/src/lib/components/EntryEditor.svelte
@@ -49,7 +49,7 @@
 				workspace.documents.entries.content.close(id);
 				return;
 			}
-			yxmlfragment = handle.asRichText();
+			yxmlfragment = handle.content;
 		});
 
 		return () => {

--- a/apps/fuji/src/lib/workspace.ts
+++ b/apps/fuji/src/lib/workspace.ts
@@ -28,6 +28,7 @@ import {
 	defineTable,
 	defineWorkspace,
 	generateId,
+	richText,
 	type InferTableRow,
 } from '@epicenter/workspace';
 import { type } from 'arktype';
@@ -43,7 +44,6 @@ import type { Brand } from 'wellcrafted/brand';
  */
 export type EntryId = string & Brand<'EntryId'>;
 export const EntryId = type('string').pipe((s): EntryId => s as EntryId);
-
 
 // ─── Tables ───────────────────────────────────────────────────────────────────
 
@@ -96,17 +96,20 @@ const entriesTable = defineTable(
 		updatedAt: DateTimeString,
 		_v: '2',
 	}),
-).migrate((row) => {
-	switch (row._v) {
-		case 1:
-			return { ...row, rating: 0, _v: 2 };
-		case 2:
-			return row;
-	}
-}).withDocument('content', {
-	guid: 'id',
-	onUpdate: () => ({ updatedAt: DateTimeString.now() }),
-});
+)
+	.migrate((row) => {
+		switch (row._v) {
+			case 1:
+				return { ...row, rating: 0, _v: 2 };
+			case 2:
+				return row;
+		}
+	})
+	.withDocument('content', {
+		content: richText,
+		guid: 'id',
+		onUpdate: () => ({ updatedAt: DateTimeString.now() }),
+	});
 
 export type Entry = InferTableRow<typeof entriesTable>;
 
@@ -132,7 +135,7 @@ export function createFujiWorkspace() {
 			create: defineMutation({
 				title: 'Create Entry',
 				description:
-				'Create a new CMS entry with optional title, subtitle, type, tags, and rating.',
+					'Create a new CMS entry with optional title, subtitle, type, tags, and rating.',
 				input: Type.Object({
 					title: Type.Optional(Type.String({ description: 'Entry title' })),
 					subtitle: Type.Optional(
@@ -199,7 +202,10 @@ export function createFujiWorkspace() {
 						Type.Number({ description: 'Rating from 0–5 (0 = unrated)' }),
 					),
 					date: Type.Optional(
-						Type.Unsafe<DateTimeString>({ type: 'string', description: 'User-defined date for the entry' }),
+						Type.Unsafe<DateTimeString>({
+							type: 'string',
+							description: 'User-defined date for the entry',
+						}),
 					),
 				}),
 				handler: ({ id, ...fields }) => {
@@ -262,7 +268,10 @@ export function createFujiWorkspace() {
 					entries: Type.Array(
 						Type.Object({
 							title: Type.String({ description: 'Entry title' }),
-							date: Type.String({ description: 'ISO date string in workspace DateTimeString format' }),
+							date: Type.String({
+								description:
+									'ISO date string in workspace DateTimeString format',
+							}),
 						}),
 					),
 				}),

--- a/apps/honeycrisp/src/lib/workspace/definition.ts
+++ b/apps/honeycrisp/src/lib/workspace/definition.ts
@@ -13,6 +13,7 @@ import {
 	DateTimeString,
 	defineTable,
 	defineWorkspace,
+	richText,
 	type InferTableRow,
 } from '@epicenter/workspace';
 import { type } from 'arktype';
@@ -104,6 +105,7 @@ const notesTable = defineTable(
 		}
 	})
 	.withDocument('body', {
+		content: richText,
 		guid: 'id',
 		onUpdate: () => ({ updatedAt: DateTimeString.now() }),
 	});

--- a/apps/honeycrisp/src/routes/+page.svelte
+++ b/apps/honeycrisp/src/routes/+page.svelte
@@ -24,13 +24,11 @@
 		}
 
 		let cancelled = false;
-		workspace.documents.notes.body
-			.open(noteId)
-			.then((handle: DocumentHandle) => {
-				if (cancelled) return;
-				currentDocHandle = handle;
-				currentYXmlFragment = handle.content;
-			});
+		workspace.documents.notes.body.open(noteId).then((handle) => {
+			if (cancelled) return;
+			currentDocHandle = handle;
+			currentYXmlFragment = handle.content;
+		});
 
 		return () => {
 			cancelled = true;

--- a/apps/honeycrisp/src/routes/+page.svelte
+++ b/apps/honeycrisp/src/routes/+page.svelte
@@ -29,7 +29,7 @@
 			.then((handle: DocumentHandle) => {
 				if (cancelled) return;
 				currentDocHandle = handle;
-				currentYXmlFragment = handle.asRichText();
+				currentYXmlFragment = handle.content;
 			});
 
 		return () => {

--- a/apps/opensidian/src/lib/components/editor/ContentEditor.svelte
+++ b/apps/opensidian/src/lib/components/editor/ContentEditor.svelte
@@ -56,7 +56,7 @@
 </script>
 
 {#if handle}
-	<CodeMirrorEditor ytext={handle.asText()} {extensions} {filename} />
+	<CodeMirrorEditor ytext={handle.content.asText()} {extensions} {filename} />
 {:else}
 	<div class="flex h-full items-center justify-center">
 		<Spinner class="size-5 text-muted-foreground" />

--- a/apps/skills/src/lib/components/editor/InstructionsEditor.svelte
+++ b/apps/skills/src/lib/components/editor/InstructionsEditor.svelte
@@ -32,7 +32,7 @@
 		<p class="text-sm text-destructive">{error}</p>
 	</div>
 {:else if handle}
-	<CodeMirrorEditor ytext={handle.asText()} />
+	<CodeMirrorEditor ytext={handle.content} />
 {:else}
 	<div class="flex h-full items-center justify-center">
 		<Spinner class="size-5 text-muted-foreground" />

--- a/apps/skills/src/lib/components/editor/ReferencesPanel.svelte
+++ b/apps/skills/src/lib/components/editor/ReferencesPanel.svelte
@@ -89,7 +89,7 @@
 										<p class="text-sm text-destructive">{refError}</p>
 									</div>
 								{:else if refHandle}
-									<CodeMirrorEditor ytext={refHandle.asText()} />
+								<CodeMirrorEditor ytext={refHandle.content} />
 								{:else}
 									<div class="flex h-full items-center justify-center">
 										<Spinner class="size-4 text-muted-foreground" />

--- a/docs/articles/yjs-abstraction-leaks-cost-more-than-the-abstraction.md
+++ b/docs/articles/yjs-abstraction-leaks-cost-more-than-the-abstraction.md
@@ -1,11 +1,11 @@
 # Y.js Abstraction Leaks Cost More Than the Abstraction
 
-You build a nice typed API over Y.js. `handle.read()`, `handle.write()`, `tables.posts.set()`. Clean, minimal surface area. Then one consumer needs to append text to a document, the typed API doesn't have `append()`, and they write this:
+You build a nice typed API over Y.js. `handle.content.read()`, `handle.content.write()`, `tables.posts.set()`. Clean, minimal surface area. Then one consumer needs to append text to a document, the typed API doesn't have `append()`, and they write this:
 
 ```typescript
-const entry = handle.currentEntry;
+const entry = handle.content.currentEntry;
 if (entry?.type === 'text') {
-    handle.batch(() => entry.content.insert(entry.content.length, text));
+    handle.content.batch(() => entry.content.insert(entry.content.length, text));
 }
 ```
 
@@ -21,7 +21,7 @@ The pattern has a consistent shape. A consumer can't do something through the ty
 
 ```typescript
 // Step 1: access internals
-const validated = handle.currentEntry;
+const validated = handle.content.currentEntry;
 
 // Step 2: branch on mode (consumer knows about internal content types)
 if (validated?.type !== 'text') {
@@ -30,15 +30,15 @@ if (validated?.type !== 'text') {
 }
 
 // Step 3: raw CRDT mutation
-handle.batch(() => validated.content.insert(validated.content.length, text));
+handle.content.batch(() => validated.content.insert(validated.content.length, text));
 ```
 
-Each step is a violation. The consumer inspects `currentEntry` (an internal representation), branches on `type` (a mode the abstraction should own), and calls `Y.Text.insert()` (a raw CRDT operation). The `handle.batch()` wrapper makes it look tidy, but the real work bypasses the Timeline entirely.
+Each step is a violation. The consumer inspects `currentEntry` (an internal representation), branches on `type` (a mode the abstraction should own), and calls `Y.Text.insert()` (a raw CRDT operation). The `handle.content.batch()` wrapper makes it look tidy, but the real work bypasses the Timeline entirely.
 
 Compare to what it should look like:
 
 ```typescript
-handle.append(text);
+handle.content.appendText(text);
 ```
 
 One line, no Y.js knowledge. The Timeline owns the "am I in text mode?" decision and the "insert at end" operation.
@@ -51,7 +51,7 @@ After auditing a real codebase, these patterns reliably predict abstraction leak
 
 **Mode branching in consumer code.** `if (entry.type === 'text') ... else if (entry.type === 'sheet')` outside the module that owns content modes. The consumer is making a decision the abstraction should make.
 
-**Raw mutations inside batch callbacks.** `handle.batch(() => ytext.insert(...))` means the consumer is doing CRDT operations the handle should encapsulate. `batch()` is for grouping *high-level* operations (multiple `table.delete()` calls), not for wrapping raw Y.js mutations.
+**Raw mutations inside batch callbacks.** `handle.content.batch(() => ytext.insert(...))` means the consumer is doing CRDT operations the handle should encapsulate. `batch()` is for grouping *high-level* operations (multiple `table.delete()` calls), not for wrapping raw Y.js mutations.
 
 **Internal helpers on the public API.** Functions like `parseSheetFromCsv(columns: Y.Map<Y.Map<string>>, rows: Y.Map<Y.Map<string>>)` on a package's root export. The parameters are raw Y.js types—you can't call this function without first breaking the abstraction to get those references.
 
@@ -64,8 +64,8 @@ Y.js code naturally settles into three layers, and each has clear rules about wh
 ```
 ┌──────────────────────────────────────────────────────────┐
 │  Consumer Code (apps, features)                          │
-│  Uses: handle.read(), handle.write(), tables.*.set()     │
-│  MAY bind to Y.Text/Y.XmlFragment returned by as*()     │
+│  Uses: handle.content.read(), handle.content.write(), tables.*.set()     │
+│  MAY bind to Y.Text/Y.XmlFragment from handle.content or as*()  │
 │  NEVER constructs, casts, or mutates Y.js types directly │
 ├──────────────────────────────────────────────────────────┤
 │  Format Bridges (markdown ↔ Y.XmlFragment, CSV ↔ Y.Map) │
@@ -100,7 +100,7 @@ The fix was simple: remove from all barrel exports. The functions stay in `timel
 
 Not every Y.js import outside the internals is a leak. Three cases are legitimate:
 
-**Editor binding.** `handle.asText()` returns a `Y.Text` specifically so editors can bind to it. The consumer *needs* the live CRDT reference for collaborative editing. Same for `asRichText()` returning `Y.XmlFragment` and `asSheet()` returning column/row `Y.Map`s.
+**Editor binding.** `handle.content.asText()` returns a `Y.Text` specifically so editors can bind to it. The consumer *needs* the live CRDT reference for collaborative editing. Same for `handle.content.asRichText()` returning `Y.XmlFragment` and `handle.content.asSheet()` returning column/row `Y.Map`s. With `plainText`/`richText` strategies, `handle.content` IS the Yjs shared type directly.
 
 **Sync and persistence infrastructure.** Code that manages Y.Doc replication (`Y.encodeStateVector`, `Y.applyUpdate`, `Y.snapshot`) operates at the document transport level. It has no business using Timeline or Table abstractions.
 

--- a/packages/filesystem/src/extensions/sqlite-index/index.ts
+++ b/packages/filesystem/src/extensions/sqlite-index/index.ts
@@ -24,7 +24,7 @@
  * @module
  */
 
-import type { Documents, TableHelper } from '@epicenter/workspace';
+import type { Documents, TableHelper, Timeline } from '@epicenter/workspace';
 import type { Client, InStatement } from '@libsql/client-wasm';
 import { createClient } from '@libsql/client-wasm';
 
@@ -107,7 +107,7 @@ export type SqliteIndex = {
  */
 type SqliteIndexContext = {
 	tables: { files: TableHelper<FileRow> };
-	documents: { files: { content: Documents<FileRow> } };
+	documents: { files: { content: Documents<FileRow, Record<string, unknown>, Record<string, never>, Timeline> } };
 };
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -186,7 +186,7 @@ export function createSqliteIndex({
 				}
 				try {
 					const handle = await contentDocs.open(row.id);
-					const text = handle.read();
+					const text = handle.content.read();
 					contentMap.set(row.id, text || null);
 				} catch {
 					contentMap.set(row.id, null);
@@ -340,7 +340,7 @@ export function createSqliteIndex({
 				let content: string | null = null;
 				try {
 					const handle = await contentDocs.open(row.id);
-					const text = handle.read();
+					const text = handle.content.read();
 					content = text || null;
 				} catch {
 					content = null;

--- a/packages/filesystem/src/file-system.test.ts
+++ b/packages/filesystem/src/file-system.test.ts
@@ -381,13 +381,13 @@ describe('mv preserves content (no conversion)', () => {
 
 async function getTimelineLength(
 	fs: YjsFileSystem,
-	documents: { open(input: string): Promise<{ length: number }> },
+	documents: { open(input: string): Promise<{ content: { length: number } }> },
 	path: string,
 ): Promise<number> {
 	const id = fs.lookupId(path);
 	if (!id) throw new Error(`No file at ${path}`);
 	const handle = await documents.open(id);
-	return handle.length;
+	return handle.content.length;
 }
 
 describe('timeline content storage', () => {
@@ -440,9 +440,9 @@ describe('sheet file support', () => {
 		expect(fileId).toBeDefined();
 		if (!fileId) throw new Error('Expected /data.csv to exist');
 		const handle = await documents.open(fileId);
-		handle.batch(() => {
-			handle.write('Name,Age\nAlice,30\n');
-			handle.asSheet();
+		handle.content.batch(() => {
+			handle.content.write('Name,Age\nAlice,30\n');
+			handle.content.asSheet();
 		});
 		expect(await fs.readFile('/data.csv')).toBe('Name,Age\nAlice,30\n');
 	});
@@ -455,9 +455,9 @@ describe('sheet file support', () => {
 		expect(fileId).toBeDefined();
 		if (!fileId) throw new Error('Expected /data.csv to exist');
 		const handle = await documents.open(fileId);
-		handle.batch(() => {
-			handle.write('A,B\n1,2\n');
-			handle.asSheet();
+		handle.content.batch(() => {
+			handle.content.write('A,B\n1,2\n');
+			handle.content.asSheet();
 		});
 		await fs.writeFile('/data.csv', 'X,Y\n3,4\n');
 		expect(await fs.readFile('/data.csv')).toBe('X,Y\n3,4\n');

--- a/packages/filesystem/src/file-system.ts
+++ b/packages/filesystem/src/file-system.ts
@@ -1,4 +1,4 @@
-import type { Documents, TableHelper } from '@epicenter/workspace';
+import type { Documents, TableHelper, Timeline } from '@epicenter/workspace';
 import type { IFileSystem } from 'just-bash';
 import { FS_ERRORS } from './errors.js';
 import type { FileId } from './ids.js';
@@ -37,7 +37,7 @@ function FileSystem<T extends IFileSystem>(fs: T): T {
  */
 export function createYjsFileSystem(
 	filesTable: TableHelper<FileRow>,
-	contentDocuments: Documents<FileRow>,
+	contentDocuments: Documents<FileRow, Record<string, unknown>, Record<string, never>, Timeline>,
 	cwd: string = '/',
 ) {
 	const tree = createFileTree(filesTable);
@@ -153,7 +153,7 @@ export function createYjsFileSystem(
 			const row = tree.getRow(id, abs);
 			if (row.type === 'folder') throw FS_ERRORS.EISDIR(abs);
 			const handle = await contentDocuments.open(id);
-			return handle.read();
+			return handle.content.read();
 		},
 
 		async readFileBuffer(path) {
@@ -183,7 +183,7 @@ export function createYjsFileSystem(
 			}
 
 			const handle = await contentDocuments.open(id);
-			handle.write(textData);
+			handle.content.write(textData);
 			tree.touch(id, size);
 		},
 
@@ -198,8 +198,8 @@ export function createYjsFileSystem(
 			if (row.type === 'folder') throw FS_ERRORS.EISDIR(abs);
 
 			const handle = await contentDocuments.open(id);
-			handle.appendText(text);
-			const newSize = new TextEncoder().encode(handle.read()).byteLength;
+			handle.content.appendText(text);
+			const newSize = new TextEncoder().encode(handle.content.read()).byteLength;
 			tree.touch(id, newSize);
 		},
 
@@ -290,7 +290,7 @@ export function createYjsFileSystem(
 				}
 			} else {
 				const handle = await contentDocuments.open(srcId);
-				const srcText = handle.read();
+				const srcText = handle.content.read();
 				await this.writeFile(resolvedDest, srcText);
 			}
 		},

--- a/packages/filesystem/src/table.ts
+++ b/packages/filesystem/src/table.ts
@@ -1,4 +1,8 @@
-import { defineTable, type InferTableRow } from '@epicenter/workspace';
+import {
+	defineTable,
+	type InferTableRow,
+	timeline,
+} from '@epicenter/workspace';
 import { type } from 'arktype';
 import { FileId } from './ids.js';
 
@@ -15,6 +19,7 @@ export const filesTable = defineTable(
 		_v: '1',
 	}),
 ).withDocument('content', {
+	content: timeline,
 	guid: 'id',
 	onUpdate: () => ({ updatedAt: Date.now() }),
 });

--- a/packages/skills/src/node.ts
+++ b/packages/skills/src/node.ts
@@ -134,7 +134,9 @@ export function createSkillsWorkspace() {
 
 					const instructionsHandle =
 						await client.documents.skills.instructions.open(skillId);
-					instructionsHandle.write(instructions);
+					const ytext = instructionsHandle.content;
+					ytext.delete(0, ytext.length);
+					ytext.insert(0, instructions);
 
 					// Import references in parallel
 					const refsPath = join(skillPath, 'references');
@@ -163,7 +165,9 @@ export function createSkillsWorkspace() {
 
 								const contentHandle =
 									await client.documents.references.content.open(refId);
-								contentHandle.write(refContent);
+							const ytext = contentHandle.content;
+							ytext.delete(0, ytext.length);
+							ytext.insert(0, refContent);
 							}),
 						);
 					}
@@ -192,7 +196,7 @@ export function createSkillsWorkspace() {
 
 						const instructionsHandle =
 							await client.documents.skills.instructions.open(skill.id);
-						const instructions = instructionsHandle.read();
+						const instructions = instructionsHandle.content.toString();
 						const skillMd = serializeSkillMd(skill, instructions);
 						await writeFile(join(skillDir, 'SKILL.md'), skillMd, 'utf-8');
 
@@ -208,7 +212,7 @@ export function createSkillsWorkspace() {
 								refs.map(async (ref) => {
 									const contentHandle =
 										await client.documents.references.content.open(ref.id);
-									const content = contentHandle.read();
+								const content = contentHandle.content.toString();
 									await writeFile(join(refsDir, ref.path), content, 'utf-8');
 								}),
 							);

--- a/packages/skills/src/node.ts
+++ b/packages/skills/src/node.ts
@@ -134,9 +134,11 @@ export function createSkillsWorkspace() {
 
 					const instructionsHandle =
 						await client.documents.skills.instructions.open(skillId);
-					const ytext = instructionsHandle.content;
-					ytext.delete(0, ytext.length);
-					ytext.insert(0, instructions);
+					instructionsHandle.ydoc.transact(() => {
+						const ytext = instructionsHandle.content;
+						ytext.delete(0, ytext.length);
+						ytext.insert(0, instructions);
+					});
 
 					// Import references in parallel
 					const refsPath = join(skillPath, 'references');
@@ -165,9 +167,11 @@ export function createSkillsWorkspace() {
 
 								const contentHandle =
 									await client.documents.references.content.open(refId);
-							const ytext = contentHandle.content;
-							ytext.delete(0, ytext.length);
-							ytext.insert(0, refContent);
+								contentHandle.ydoc.transact(() => {
+									const ytext = contentHandle.content;
+									ytext.delete(0, ytext.length);
+									ytext.insert(0, refContent);
+								});
 							}),
 						);
 					}
@@ -212,7 +216,7 @@ export function createSkillsWorkspace() {
 								refs.map(async (ref) => {
 									const contentHandle =
 										await client.documents.references.content.open(ref.id);
-								const content = contentHandle.content.toString();
+									const content = contentHandle.content.toString();
 									await writeFile(join(refsDir, ref.path), content, 'utf-8');
 								}),
 							);

--- a/packages/skills/src/tables.ts
+++ b/packages/skills/src/tables.ts
@@ -9,7 +9,11 @@
  * @module
  */
 
-import { defineTable, type InferTableRow } from '@epicenter/workspace';
+import {
+	defineTable,
+	type InferTableRow,
+	plainText,
+} from '@epicenter/workspace';
 import { type } from 'arktype';
 
 /**
@@ -55,6 +59,7 @@ export const skillsTable = defineTable(
 		_v: '1',
 	}),
 ).withDocument('instructions', {
+	content: plainText,
 	guid: 'id',
 	onUpdate: () => ({ updatedAt: Date.now() }),
 });
@@ -90,6 +95,7 @@ export const referencesTable = defineTable(
 		_v: '1',
 	}),
 ).withDocument('content', {
+	content: plainText,
 	guid: 'id',
 	onUpdate: () => ({ updatedAt: Date.now() }),
 });

--- a/packages/skills/src/tables.ts
+++ b/packages/skills/src/tables.ts
@@ -37,12 +37,12 @@ import { type } from 'arktype';
  * const skill = ws.tables.skills.find(s => s.name === 'writing-voice')
  * if (skill) {
  *   const handle = await ws.documents.skills.instructions.open(skill.id)
- *   systemPrompt += handle.read()
+ *   systemPrompt += handle.content.toString()
  * }
  *
  * // Editor binding—collaborative Y.Text editing
  * const handle = await ws.documents.skills.instructions.open(skill.id)
- * const ytext = handle.asText()
+ * const ytext = handle.content
  * editor.bind(ytext)
  * ```
  */
@@ -82,7 +82,7 @@ export const skillsTable = defineTable(
  * // Read reference content
  * for (const ref of refs) {
  *   const handle = await ws.documents.references.content.open(ref.id)
- *   const markdown = handle.read()
+ *   const markdown = handle.content.toString()
  * }
  * ```
  */

--- a/packages/skills/src/workspace.ts
+++ b/packages/skills/src/workspace.ts
@@ -92,7 +92,7 @@ export function createSkillsWorkspace() {
 				const skill = client.tables.skills.find((s) => s.id === id);
 				if (!skill) return null;
 				const handle = await client.documents.skills.instructions.open(id);
-				return { skill, instructions: handle.read() };
+				return { skill, instructions: handle.content.toString() };
 			},
 		}),
 
@@ -120,12 +120,12 @@ export function createSkillsWorkspace() {
 					refs.map(async (ref) => {
 						const contentHandle =
 							await client.documents.references.content.open(ref.id);
-						return { path: ref.path, content: contentHandle.read() };
+						return { path: ref.path, content: contentHandle.content.toString() };
 					}),
 				);
 				return {
 					skill,
-					instructions: instructionsHandle.read(),
+					instructions: instructionsHandle.content.toString(),
 					references: references.sort((a, b) => a.path.localeCompare(b.path)),
 				};
 			},

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -485,9 +485,9 @@ async function documentExample() {
 	});
 
 	const handle = await workspace.documents.files.content.open('doc-1');
-	handle.write('# Hello from a document');
-	console.log(handle.read());
-	console.log(handle.currentType);
+	handle.content.write('# Hello from a document');
+	console.log(handle.content.read());
+	console.log(handle.content.currentType);
 	await workspace.documents.files.content.close('doc-1');
 	await workspace.dispose();
 	return handle;
@@ -1399,19 +1399,22 @@ Lifecycle and utility methods:
 
 ### Document content model
 
-Open document handles are timeline APIs.
+Open document handles expose content via `handle.content`, typed by the content strategy.
 
-Important methods and properties:
+For timeline strategy (`content: timeline`):
 
-- `handle.read()`
-- `handle.write(text)`
-- `handle.appendText(text)`
-- `handle.asText()`
-- `handle.asRichText()`
-- `handle.asSheet()`
-- `handle.currentType`
-- `handle.observe(...)`
-- `handle.restoreFromSnapshot(binary)`
+- `handle.content.read()`
+- `handle.content.write(text)`
+- `handle.content.appendText(text)`
+- `handle.content.asText()`
+- `handle.content.asRichText()`
+- `handle.content.asSheet()`
+- `handle.content.currentType`
+- `handle.content.observe(...)`
+- `handle.content.restoreFromSnapshot(binary)`
+
+For plainText strategy (`content: plainText`), `handle.content` is `Y.Text`.
+For richText strategy (`content: richText`), `handle.content` is `Y.XmlFragment`.
 
 Document managers live at `client.documents.{tableName}.{documentName}` and expose:
 

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -109,6 +109,7 @@ export { KV_KEY, TableKey } from './workspace/ydoc-keys';
 export { defineKv } from './workspace/define-kv';
 export { defineTable } from './workspace/define-table';
 export { defineWorkspace } from './workspace/define-workspace';
+export { plainText, richText, timeline } from './workspace/strategies';
 
 // ════════════════════════════════════════════════════════════════════════════
 // WORKSPACE CREATION
@@ -143,6 +144,7 @@ export type {
 	AwarenessHelper,
 	AwarenessState,
 	BaseRow,
+	ContentStrategy,
 	DocumentClient,
 	DocumentConfig,
 	DocumentHandle,

--- a/packages/workspace/src/workspace/README.md
+++ b/packages/workspace/src/workspace/README.md
@@ -122,11 +122,11 @@ For detailed rationale on all of this, see [the guide](docs/articles/20260127T12
 
 ## Document Content
 
-Tables with `.withDocument()` create per-row Y.Docs for content. These Y.Docs use a **timeline model** (`Y.Array('timeline')` with nested typed entries) in `packages/workspace/src/timeline/`.
+Tables with `.withDocument()` create per-row Y.Docs for content. The content type is determined by a content strategy passed to `.withDocument()`: `plainText` returns `Y.Text`, `richText` returns `Y.XmlFragment`, and `timeline` returns a `Timeline` with mode-switching support.
 
-The handle is the canonical interface: `handle.read()`/`handle.writeText()` for simple string I/O, `handle.asText()` for Y.Text editor binding, `handle.asRichText()` for Y.XmlFragment richtext binding, `handle.asSheet()` for spreadsheet binding, `handle.timeline` for advanced operations, and `handle.batch()` for batching mutations. The `as*()` methods automatically convert between content modes—all conversions are infallible.
+The handle is the canonical interface. Content is accessed via `handle.content`—fully typed by the strategy. For `timeline` strategy: `handle.content.read()`/`handle.content.write()` for string I/O, `handle.content.asText()` for Y.Text editor binding, `handle.content.asRichText()` for Y.XmlFragment binding, `handle.content.asSheet()` for spreadsheet binding, and `handle.content.batch()` for batching mutations. For `plainText`/`richText`, `handle.content` IS the Yjs shared type—bind it directly to your editor.
 
-See `specs/20260313T230000-promote-timeline-to-workspace.md` for the full design.
+See `specs/20260418T120000-withdocument-content-strategy.md` for the full design.
 
 ## Testing
 

--- a/packages/workspace/src/workspace/create-documents.test.ts
+++ b/packages/workspace/src/workspace/create-documents.test.ts
@@ -18,6 +18,7 @@ import {
 	createDocuments,
 	DOCUMENTS_ORIGIN,
 } from './create-documents.js';
+import { timeline } from './strategies.js';
 import { createTables } from './create-tables.js';
 import { createWorkspace } from './create-workspace.js';
 import { defineTable } from './define-table.js';
@@ -51,6 +52,7 @@ function setup(
 		tableName: 'files',
 		documentName: 'content',
 		guidKey: 'id',
+		content: timeline,
 		onUpdate: () => ({ updatedAt: Date.now() }),
 		tableHelper: tables.files,
 		ydoc,
@@ -214,6 +216,7 @@ describe('createDocuments', () => {
 				tableName: 'files',
 				documentName: 'content',
 				guidKey: 'id',
+				content: timeline,
 				onUpdate: () => ({
 					updatedAt: 999,
 					lastEditedBy: 'test-user',
@@ -252,6 +255,7 @@ describe('createDocuments', () => {
 				tableName: 'files',
 				documentName: 'content',
 				guidKey: 'id',
+				content: timeline,
 				onUpdate: () => ({}),
 				tableHelper: tables.files,
 				ydoc,
@@ -671,6 +675,7 @@ describe('createDocuments', () => {
 			const filesTable = defineTable(
 				type({ id: 'string', name: 'string', updatedAt: 'number', _v: '1' }),
 			).withDocument('content', {
+				content: timeline,
 				guid: 'id',
 				onUpdate: () => ({ updatedAt: Date.now() }),
 				awareness: {
@@ -701,6 +706,7 @@ describe('createDocuments', () => {
 			const filesTable = defineTable(
 				type({ id: 'string', name: 'string', updatedAt: 'number', _v: '1' }),
 			).withDocument('content', {
+				content: timeline,
 				guid: 'id',
 				onUpdate: () => ({ updatedAt: Date.now() }),
 				awareness: {
@@ -740,6 +746,7 @@ describe('handle.asText / asRichText / asSheet', () => {
 			tableName: 'files',
 			documentName: 'content',
 			guidKey: 'id',
+			content: timeline,
 			onUpdate: () => ({ updatedAt: Date.now() }),
 			tableHelper: tables.files,
 			ydoc,

--- a/packages/workspace/src/workspace/create-documents.test.ts
+++ b/packages/workspace/src/workspace/create-documents.test.ts
@@ -153,7 +153,7 @@ describe('createDocuments', () => {
 			const { documents } = setup();
 
 			const handle = await documents.open('f1');
-			const text = handle.read();
+			const text = handle.content.read();
 			expect(text).toBe('');
 		});
 
@@ -161,8 +161,8 @@ describe('createDocuments', () => {
 			const { documents } = setup();
 
 			const handle = await documents.open('f1');
-			handle.write('hello world');
-			const text = handle.read();
+			handle.content.write('hello world');
+			const text = handle.content.read();
 			expect(text).toBe('hello world');
 		});
 
@@ -170,9 +170,9 @@ describe('createDocuments', () => {
 			const { documents } = setup();
 
 			const handle = await documents.open('f1');
-			handle.write('first');
-			handle.write('second');
-			const text = handle.read();
+			handle.content.write('first');
+			handle.content.write('second');
+			const text = handle.content.read();
 			expect(text).toBe('second');
 		});
 	});
@@ -188,7 +188,7 @@ describe('createDocuments', () => {
 			});
 
 			const handle = await documents.open('f1');
-			handle.write('hello');
+			handle.content.write('hello');
 
 			// Give the update observer a tick
 			const result = tables.files.get('f1');
@@ -234,7 +234,7 @@ describe('createDocuments', () => {
 			});
 
 			const handle = await documents.open('f1');
-			handle.write('hello');
+			handle.content.write('hello');
 
 			const result = tables.files.get('f1');
 			expect(result.status).toBe('valid');
@@ -269,7 +269,7 @@ describe('createDocuments', () => {
 			});
 
 			const handle = await documents.open('f1');
-			handle.write('hello');
+			handle.content.write('hello');
 
 			const result = tables.files.get('f1');
 			expect(result.status).toBe('valid');
@@ -293,7 +293,7 @@ describe('createDocuments', () => {
 			});
 
 			const handle = await documents.open('f1');
-			handle.write('hello');
+			handle.content.write('hello');
 
 			expect(capturedOrigin).toBe(DOCUMENTS_ORIGIN);
 		});
@@ -761,52 +761,52 @@ describe('handle.asText / asRichText / asSheet', () => {
 		const { documents } = setupSimple();
 		const handle = await documents.open('f1');
 
-		const text = handle.asText();
+		const text = handle.content.asText();
 		expect(text).toBeInstanceOf(Y.Text);
-		expect(handle.currentType).toBe('text');
+		expect(handle.content.currentType).toBe('text');
 	});
 
 	test('asText on text entry returns existing Y.Text', async () => {
 		const { documents } = setupSimple();
 		const handle = await documents.open('f1');
-		handle.write('hello');
+		handle.content.write('hello');
 
-		const text = handle.asText();
+		const text = handle.content.asText();
 		expect(text.toString()).toBe('hello');
-		expect(handle.length).toBe(1);
+		expect(handle.content.length).toBe(1);
 	});
 
 	test('asText on richtext entry converts (lossy)', async () => {
 		const { documents } = setupSimple();
 		const handle = await documents.open('f1');
 
-		const fragment = handle.asRichText();
+		const fragment = handle.content.asRichText();
 		const p = new Y.XmlElement('paragraph');
 		const t = new Y.XmlText();
 		t.insert(0, 'Rich content');
 		p.insert(0, [t]);
 		fragment.insert(0, [p]);
 
-		expect(handle.currentType).toBe('richtext');
+		expect(handle.content.currentType).toBe('richtext');
 
-		const text = handle.asText();
+		const text = handle.content.asText();
 		expect(text.toString()).toBe('Rich content');
-		expect(handle.currentType).toBe('text');
-		expect(handle.length).toBe(2);
+		expect(handle.content.currentType).toBe('text');
+		expect(handle.content.length).toBe(2);
 	});
 
 	test('asText on sheet entry converts to CSV', async () => {
 		const { documents } = setupSimple();
 		const handle = await documents.open('f1');
 
-		handle.write('Name,Age\nAlice,30\n');
-		handle.asSheet();
-		expect(handle.currentType).toBe('sheet');
+		handle.content.write('Name,Age\nAlice,30\n');
+		handle.content.asSheet();
+		expect(handle.content.currentType).toBe('sheet');
 
-		const text = handle.asText();
+		const text = handle.content.asText();
 		expect(text.toString()).toBe('Name,Age\nAlice,30\n');
-		expect(handle.currentType).toBe('text');
-		expect(handle.length).toBe(3);
+		expect(handle.content.currentType).toBe('text');
+		expect(handle.content.length).toBe(3);
 	});
 
 	// ─── asRichText ────────────────────────────────────────────────────
@@ -815,43 +815,43 @@ describe('handle.asText / asRichText / asSheet', () => {
 		const { documents } = setupSimple();
 		const handle = await documents.open('f1');
 
-		const fragment = handle.asRichText();
+		const fragment = handle.content.asRichText();
 		expect(fragment).toBeInstanceOf(Y.XmlFragment);
-		expect(handle.currentType).toBe('richtext');
+		expect(handle.content.currentType).toBe('richtext');
 	});
 
 	test('asRichText on richtext entry returns existing fragment', async () => {
 		const { documents } = setupSimple();
 		const handle = await documents.open('f1');
-		handle.asRichText();
+		handle.content.asRichText();
 
-		const fragment = handle.asRichText();
+		const fragment = handle.content.asRichText();
 		expect(fragment).toBeInstanceOf(Y.XmlFragment);
-		expect(handle.length).toBe(1);
+		expect(handle.content.length).toBe(1);
 	});
 
 	test('asRichText on text entry converts to paragraphs', async () => {
 		const { documents } = setupSimple();
 		const handle = await documents.open('f1');
-		handle.write('Line 1\nLine 2');
+		handle.content.write('Line 1\nLine 2');
 
-		const fragment = handle.asRichText();
+		const fragment = handle.content.asRichText();
 		expect(fragment).toBeInstanceOf(Y.XmlFragment);
-		expect(handle.currentType).toBe('richtext');
-		expect(handle.length).toBe(2);
-		expect(handle.read()).toBe('Line 1\nLine 2');
+		expect(handle.content.currentType).toBe('richtext');
+		expect(handle.content.length).toBe(2);
+		expect(handle.content.read()).toBe('Line 1\nLine 2');
 	});
 
 	test('asRichText on sheet entry converts CSV to paragraphs', async () => {
 		const { documents } = setupSimple();
 		const handle = await documents.open('f1');
-		handle.write('A,B\n1,2\n');
-		handle.asSheet();
+		handle.content.write('A,B\n1,2\n');
+		handle.content.asSheet();
 
-		const fragment = handle.asRichText();
+		const fragment = handle.content.asRichText();
 		expect(fragment).toBeInstanceOf(Y.XmlFragment);
-		expect(handle.currentType).toBe('richtext');
-		expect(handle.length).toBe(3);
+		expect(handle.content.currentType).toBe('richtext');
+		expect(handle.content.length).toBe(3);
 	});
 
 	// ─── asSheet ──────────────────────────────────────────────────────
@@ -860,41 +860,41 @@ describe('handle.asText / asRichText / asSheet', () => {
 		const { documents } = setupSimple();
 		const handle = await documents.open('f1');
 
-		const sheet = handle.asSheet();
+		const sheet = handle.content.asSheet();
 		expect(sheet.columns).toBeInstanceOf(Y.Map);
 		expect(sheet.rows).toBeInstanceOf(Y.Map);
-		expect(handle.currentType).toBe('sheet');
+		expect(handle.content.currentType).toBe('sheet');
 	});
 
 	test('asSheet on sheet entry returns existing binding', async () => {
 		const { documents } = setupSimple();
 		const handle = await documents.open('f1');
-		handle.write('X,Y\n1,2\n');
-		handle.asSheet();
+		handle.content.write('X,Y\n1,2\n');
+		handle.content.asSheet();
 
-		const sheet = handle.asSheet();
+		const sheet = handle.content.asSheet();
 		expect(sheet.columns.size).toBe(2);
 		expect(sheet.rows.size).toBe(1);
-		expect(handle.length).toBe(2);
+		expect(handle.content.length).toBe(2);
 	});
 
 	test('asSheet on text entry parses as CSV', async () => {
 		const { documents } = setupSimple();
 		const handle = await documents.open('f1');
-		handle.write('Col1,Col2\nA,B\n');
+		handle.content.write('Col1,Col2\nA,B\n');
 
-		const sheet = handle.asSheet();
+		const sheet = handle.content.asSheet();
 		expect(sheet.columns.size).toBe(2);
 		expect(sheet.rows.size).toBe(1);
-		expect(handle.currentType).toBe('sheet');
-		expect(handle.length).toBe(2);
+		expect(handle.content.currentType).toBe('sheet');
+		expect(handle.content.length).toBe(2);
 	});
 
 	test('asSheet on richtext entry extracts text then parses CSV', async () => {
 		const { documents } = setupSimple();
 		const handle = await documents.open('f1');
 
-		const fragment = handle.asRichText();
+		const fragment = handle.content.asRichText();
 		const p1 = new Y.XmlElement('paragraph');
 		const t1 = new Y.XmlText();
 		t1.insert(0, 'Name,Age');
@@ -905,10 +905,10 @@ describe('handle.asText / asRichText / asSheet', () => {
 		p2.insert(0, [t2]);
 		fragment.insert(0, [p1, p2]);
 
-		const sheet = handle.asSheet();
+		const sheet = handle.content.asSheet();
 		expect(sheet.columns.size).toBe(2);
-		expect(handle.currentType).toBe('sheet');
-		expect(handle.length).toBe(2);
+		expect(handle.content.currentType).toBe('sheet');
+		expect(handle.content.length).toBe(2);
 	});
 
 	// ─── mode getter ──────────────────────────────────────────────────
@@ -917,9 +917,9 @@ describe('handle.asText / asRichText / asSheet', () => {
 		const { documents } = setupSimple();
 		const handle = await documents.open('f1');
 
-		expect(handle.currentType).toBeUndefined(); // empty
-		handle.write('text');
-		expect(handle.currentType).toBe('text');
+		expect(handle.content.currentType).toBeUndefined(); // empty
+		handle.content.write('text');
+		expect(handle.content.currentType).toBe('text');
 	});
 
 	// ─── consecutive conversions ──────────────────────────────────────
@@ -928,20 +928,20 @@ describe('handle.asText / asRichText / asSheet', () => {
 		const { documents } = setupSimple();
 		const handle = await documents.open('f1');
 
-		handle.write('hello');
-		expect(handle.currentType).toBe('text');
-		expect(handle.length).toBe(1);
+		handle.content.write('hello');
+		expect(handle.content.currentType).toBe('text');
+		expect(handle.content.length).toBe(1);
 
-		handle.asRichText();
-		expect(handle.currentType).toBe('richtext');
-		expect(handle.length).toBe(2);
+		handle.content.asRichText();
+		expect(handle.content.currentType).toBe('richtext');
+		expect(handle.content.length).toBe(2);
 
-		handle.asSheet();
-		expect(handle.currentType).toBe('sheet');
-		expect(handle.length).toBe(3);
+		handle.content.asSheet();
+		expect(handle.content.currentType).toBe('sheet');
+		expect(handle.content.length).toBe(3);
 
-		handle.asText();
-		expect(handle.currentType).toBe('text');
-		expect(handle.length).toBe(4);
+		handle.content.asText();
+		expect(handle.content.currentType).toBe('text');
+		expect(handle.content.length).toBe(4);
 	});
 });

--- a/packages/workspace/src/workspace/create-documents.ts
+++ b/packages/workspace/src/workspace/create-documents.ts
@@ -60,6 +60,7 @@ import {
 import type {
 	AwarenessDefinitions,
 	BaseRow,
+	ContentStrategy,
 	DocumentExtensionRegistration,
 	DocumentHandle,
 	Documents,
@@ -114,6 +115,8 @@ export type CreateDocumentsConfig<
 	documentName: string;
 	/** Column name storing the Y.Doc GUID. */
 	guidKey: keyof TRow & string;
+	/** Content strategy — receives the document Y.Doc, returns a typed binding for `handle.content`. */
+	content: ContentStrategy;
 	/**
 	 * Called on every content Y.Doc change (local and remote). Return the
 	 * fields to write to the table row. The row write fires `table.observe`,
@@ -159,6 +162,7 @@ export function createDocuments<
 		tableName,
 		documentName,
 		guidKey,
+		content,
 		onUpdate,
 		tableHelper,
 		ydoc: workspaceYdoc,
@@ -207,6 +211,7 @@ export function createDocuments<
 				(awarenessDefinitions ?? {}) as TAwarenessDefinitions,
 			);
 			const timeline = createTimeline(contentYdoc);
+			const contentBinding = content(contentYdoc);
 
 			// Call document extension factories synchronously.
 			// IMPORTANT: No await between openDocuments.get() and openDocuments.set() — ensures
@@ -290,6 +295,7 @@ export function createDocuments<
 					? Promise.resolve()
 					: Promise.all(whenReadyPromises).then(() => {});
 			const handle = Object.assign(timeline, {
+				content: contentBinding,
 				id,
 				tableName,
 				documentName,

--- a/packages/workspace/src/workspace/create-documents.ts
+++ b/packages/workspace/src/workspace/create-documents.ts
@@ -48,7 +48,6 @@
 
 import { Awareness } from 'y-protocols/awareness';
 import * as Y from 'yjs';
-import { createTimeline } from '../timeline/timeline.js';
 import { createAwareness } from './create-awareness.js';
 import {
 	defineExtension,
@@ -84,12 +83,13 @@ export const DOCUMENTS_ORIGIN = Symbol('documents');
 type DocEntry<
 	TDocExtensions extends Record<string, unknown>,
 	TAwarenessDefinitions extends AwarenessDefinitions,
+	TBinding = unknown,
 > = {
 	ydoc: Y.Doc;
 	// biome-ignore lint/suspicious/noExplicitAny: runtime storage uses wide type
 	extensions: Record<string, Extension<any>>;
 	unobserve: () => void;
-	whenReady: Promise<DocumentHandle<TDocExtensions, TAwarenessDefinitions>>;
+	whenReady: Promise<DocumentHandle<TDocExtensions, TAwarenessDefinitions, TBinding>>;
 };
 
 /**
@@ -100,6 +100,7 @@ type DocEntry<
 export type CreateDocumentsConfig<
 	TRow extends BaseRow,
 	TAwarenessDefinitions extends AwarenessDefinitions = Record<string, never>,
+	TBinding = unknown,
 > = {
 	/**
 	 * The workspace identifier. Passed through to `DocumentContext.id`.
@@ -116,7 +117,7 @@ export type CreateDocumentsConfig<
 	/** Column name storing the Y.Doc GUID. */
 	guidKey: keyof TRow & string;
 	/** Content strategy — receives the document Y.Doc, returns a typed binding for `handle.content`. */
-	content: ContentStrategy;
+	content: ContentStrategy<TBinding>;
 	/**
 	 * Called on every content Y.Doc change (local and remote). Return the
 	 * fields to write to the table row. The row write fires `table.observe`,
@@ -154,9 +155,10 @@ export function createDocuments<
 	TRow extends BaseRow,
 	TDocExtensions extends Record<string, unknown> = Record<string, unknown>,
 	TAwarenessDefinitions extends AwarenessDefinitions = Record<string, never>,
+	TBinding = unknown,
 >(
-	config: CreateDocumentsConfig<TRow, TAwarenessDefinitions>,
-): Documents<TRow, TDocExtensions, TAwarenessDefinitions> {
+	config: CreateDocumentsConfig<TRow, TAwarenessDefinitions, TBinding>,
+): Documents<TRow, TDocExtensions, TAwarenessDefinitions, TBinding> {
 	const {
 		id,
 		tableName,
@@ -172,7 +174,7 @@ export function createDocuments<
 
 	const openDocuments = new Map<
 		string,
-		DocEntry<TDocExtensions, TAwarenessDefinitions>
+		DocEntry<TDocExtensions, TAwarenessDefinitions, TBinding>
 	>();
 
 	/**
@@ -195,10 +197,10 @@ export function createDocuments<
 		}
 	});
 
-	const documents: Documents<TRow, TDocExtensions, TAwarenessDefinitions> = {
+	const documents: Documents<TRow, TDocExtensions, TAwarenessDefinitions, TBinding> = {
 		async open(
 			input: TRow | string,
-		): Promise<DocumentHandle<TDocExtensions, TAwarenessDefinitions>> {
+		): Promise<DocumentHandle<TDocExtensions, TAwarenessDefinitions, TBinding>> {
 			const guid = typeof input === 'string' ? input : String(input[guidKey]);
 
 			const existing = openDocuments.get(guid);
@@ -210,7 +212,6 @@ export function createDocuments<
 				contentAwareness,
 				(awarenessDefinitions ?? {}) as TAwarenessDefinitions,
 			);
-			const timeline = createTimeline(contentYdoc);
 			const contentBinding = content(contentYdoc);
 
 			// Call document extension factories synchronously.
@@ -230,7 +231,6 @@ export function createDocuments<
 						tableName,
 						documentName,
 						ydoc: contentYdoc,
-						timeline,
 						awareness: { raw: contentAwareness },
 						whenReady:
 							whenReadyPromises.length === 0
@@ -294,16 +294,16 @@ export function createDocuments<
 				whenReadyPromises.length === 0
 					? Promise.resolve()
 					: Promise.all(whenReadyPromises).then(() => {});
-			const handle = Object.assign(timeline, {
+			const handle = {
 				content: contentBinding,
+				ydoc: contentYdoc,
 				id,
 				tableName,
 				documentName,
-				timeline,
 				awareness,
 				extensions: resolvedExtensions,
 				whenReady: compositeWhenReady,
-			}) as DocumentHandle<TDocExtensions, TAwarenessDefinitions>;
+			} as DocumentHandle<TDocExtensions, TAwarenessDefinitions, TBinding>;
 			const whenReady =
 				whenReadyPromises.length === 0
 					? Promise.resolve(handle)

--- a/packages/workspace/src/workspace/create-documents.ts
+++ b/packages/workspace/src/workspace/create-documents.ts
@@ -39,8 +39,8 @@
  * const handle = await contentDocuments.open(someRow);
  * handle.tableName;    // 'files'
  * handle.documentName; // 'content'
- * handle.read();       // read content
- * handle.write('new content');
+ * handle.content.read();       // read content
+ * handle.content.write('new content');
  * ```
  *
  * @module

--- a/packages/workspace/src/workspace/create-workspace.test.ts
+++ b/packages/workspace/src/workspace/create-workspace.test.ts
@@ -17,6 +17,7 @@ import * as Y from 'yjs';
 import { defineMutation, defineQuery } from '../shared/actions.js';
 import { bytesToBase64 } from '../shared/crypto/index.js';
 import { createDocuments } from './create-documents.js';
+import { timeline } from './strategies.js';
 import { createTables } from './create-tables.js';
 import { createWorkspace } from './create-workspace.js';
 import { defineKv } from './define-kv.js';
@@ -498,6 +499,7 @@ describe('createWorkspace', () => {
 					_v: '1',
 				}),
 			).withDocument('content', {
+				content: timeline,
 				guid: 'id',
 				onUpdate: () => ({ updatedAt: Date.now() }),
 			});
@@ -532,6 +534,7 @@ describe('createWorkspace', () => {
 					_v: '1',
 				}),
 			).withDocument('content', {
+				content: timeline,
 				guid: 'id',
 				onUpdate: () => ({ updatedAt: Date.now() }),
 			});
@@ -560,6 +563,7 @@ describe('createWorkspace', () => {
 					_v: '1',
 				}),
 			).withDocument('content', {
+				content: timeline,
 				guid: 'id',
 				onUpdate: () => ({ updatedAt: Date.now() }),
 			});
@@ -599,6 +603,7 @@ describe('createWorkspace', () => {
 					_v: '1',
 				}),
 			).withDocument('content', {
+				content: timeline,
 				guid: 'id',
 				onUpdate: () => ({ updatedAt: Date.now() }),
 			});
@@ -634,6 +639,7 @@ describe('createWorkspace', () => {
 					_v: '1',
 				}),
 			).withDocument('content', {
+				content: timeline,
 				guid: 'id',
 				onUpdate: () => ({ updatedAt: Date.now() }),
 			});
@@ -661,6 +667,7 @@ describe('createWorkspace', () => {
 					_v: '1',
 				}),
 			).withDocument('content', {
+				content: timeline,
 				guid: 'id',
 				onUpdate: () => ({ updatedAt: Date.now() }),
 			});
@@ -673,6 +680,7 @@ describe('createWorkspace', () => {
 					_v: '1',
 				}),
 			).withDocument('body', {
+				content: timeline,
 				guid: 'bodyDocId',
 				onUpdate: () => ({ bodyUpdatedAt: Date.now() }),
 			});
@@ -770,6 +778,7 @@ describe('createWorkspace', () => {
 				tableName: 'files',
 				documentName: 'content',
 				guidKey: 'id',
+				content: timeline,
 				onUpdate: () => ({ updatedAt: Date.now() }),
 				tableHelper: tables.files,
 				ydoc: mockYdoc,
@@ -841,6 +850,7 @@ describe('createWorkspace', () => {
 				tableName: 'files',
 				documentName: 'content',
 				guidKey: 'id',
+				content: timeline,
 				onUpdate: () => ({ updatedAt: Date.now() }),
 				tableHelper: tables.files,
 				ydoc: mockYdoc,

--- a/packages/workspace/src/workspace/create-workspace.ts
+++ b/packages/workspace/src/workspace/create-workspace.ts
@@ -216,12 +216,14 @@ export function createWorkspace<
 		const tableDocumentsNamespace: Record<string, Documents<BaseRow>> = {};
 
 		for (const [docName, rawConfig] of Object.entries(tableDef.documents)) {
-			const { guid, onUpdate, awareness } = rawConfig as DocumentConfig;
+			const { content, guid, onUpdate, awareness } =
+				rawConfig as DocumentConfig;
 
 			const documents = createDocuments({
 				id,
 				tableName,
 				documentName: docName,
+				content,
 				guidKey: guid as keyof BaseRow & string,
 				onUpdate,
 				tableHelper,

--- a/packages/workspace/src/workspace/define-table.test.ts
+++ b/packages/workspace/src/workspace/define-table.test.ts
@@ -12,6 +12,7 @@
 import { describe, expect, test } from 'bun:test';
 import { type } from 'arktype';
 import { defineTable } from './define-table.js';
+import { timeline } from './strategies.js';
 
 describe('defineTable', () => {
 	describe('shorthand syntax', () => {
@@ -250,6 +251,7 @@ describe('defineTable', () => {
 			const files = defineTable(
 				type({ id: 'string', name: 'string', updatedAt: 'number', _v: '1' }),
 			).withDocument('content', {
+				content: timeline,
 				guid: 'id',
 				onUpdate: () => ({ updatedAt: Date.now() }),
 			});
@@ -267,6 +269,7 @@ describe('defineTable', () => {
 					_v: '1',
 				}),
 			).withDocument('content', {
+				content: timeline,
 				guid: 'docId',
 				onUpdate: () => ({ modifiedAt: Date.now() }),
 			});
@@ -286,10 +289,12 @@ describe('defineTable', () => {
 				}),
 			)
 				.withDocument('body', {
+					content: timeline,
 					guid: 'bodyDocId',
 					onUpdate: () => ({ updatedAt: Date.now() }),
 				})
 				.withDocument('cover', {
+					content: timeline,
 					guid: 'coverDocId',
 					onUpdate: () => ({ updatedAt: Date.now() }),
 				});
@@ -312,6 +317,7 @@ describe('defineTable', () => {
 			const files = defineTable(
 				type({ id: 'string', name: 'string', updatedAt: 'number', _v: '1' }),
 			).withDocument('content', {
+				content: timeline,
 				guid: 'id',
 				onUpdate: () => ({ updatedAt: Date.now() }),
 			});
@@ -350,6 +356,7 @@ describe('defineTable', () => {
 				type({ id: 'string', updatedAt: 'number', _v: '1' }),
 			);
 			files.withDocument('content', {
+				content: timeline,
 				// @ts-expect-error guid key must exist on the row schema
 				guid: 'missing',
 				onUpdate: () => ({}),
@@ -366,11 +373,12 @@ describe('defineTable', () => {
 					_v: '1',
 				}),
 			).withDocument('body', {
+				content: timeline,
 				guid: 'bodyDocId',
 				onUpdate: () => ({ updatedAt: Date.now() }),
 			});
 			notes.withDocument('cover', {
-				// @ts-expect-error bodyDocId is already claimed by the 'body' document
+				content: timeline,
 				guid: 'bodyDocId',
 				onUpdate: () => ({ updatedAt: Date.now() }),
 			});
@@ -381,6 +389,7 @@ describe('defineTable', () => {
 				type({ id: 'string', name: 'string', updatedAt: 'number', _v: '1' }),
 			);
 			files.withDocument('content', {
+				content: timeline,
 				guid: 'id',
 				// @ts-expect-error nonExistent is not a column on the row
 				onUpdate: () => ({ nonExistent: 123 }),

--- a/packages/workspace/src/workspace/define-table.ts
+++ b/packages/workspace/src/workspace/define-table.ts
@@ -52,6 +52,7 @@ import type {
 	AwarenessDefinitions,
 	BaseRow,
 	ClaimedDocumentColumns,
+	ContentStrategy,
 	DocumentConfig,
 	LastSchema,
 	StringKeysOf,
@@ -118,6 +119,7 @@ type TableDefinitionWithDocBuilder<
 	>(
 		name: TName,
 		config: {
+			content: ContentStrategy;
 			guid: TGuid;
 			onUpdate: () => Partial<
 				Omit<StandardSchemaV1.InferOutput<LastSchema<TVersions>>, 'id'>
@@ -257,6 +259,7 @@ function attachDocumentBuilder<
 				documents: {
 					...def.documents,
 					[name]: {
+						content: config.content,
 						guid: config.guid,
 						onUpdate: config.onUpdate,
 						awareness: config.awareness,

--- a/packages/workspace/src/workspace/define-table.ts
+++ b/packages/workspace/src/workspace/define-table.ts
@@ -116,10 +116,11 @@ type TableDefinitionWithDocBuilder<
 			ClaimedDocumentColumns<TDocuments>
 		>,
 		const TAwarenessDefs extends AwarenessDefinitions = Record<string, never>,
+		TBinding = unknown,
 	>(
 		name: TName,
 		config: {
-			content: ContentStrategy;
+			content: ContentStrategy<TBinding>;
 			guid: TGuid;
 			onUpdate: () => Partial<
 				Omit<StandardSchemaV1.InferOutput<LastSchema<TVersions>>, 'id'>
@@ -134,7 +135,8 @@ type TableDefinitionWithDocBuilder<
 				DocumentConfig<
 					TGuid,
 					StandardSchemaV1.InferOutput<LastSchema<TVersions>>,
-					TAwarenessDefs
+					TAwarenessDefs,
+					TBinding
 				>
 			>
 	>;

--- a/packages/workspace/src/workspace/index.ts
+++ b/packages/workspace/src/workspace/index.ts
@@ -92,6 +92,7 @@ export { KV_KEY, TableKey } from './ydoc-keys.js';
 export { defineKv } from './define-kv.js';
 export { defineTable } from './define-table.js';
 export { defineWorkspace } from './define-workspace.js';
+export { plainText, richText, timeline } from './strategies.js';
 
 // ════════════════════════════════════════════════════════════════════════════
 // Workspace Creation
@@ -130,6 +131,7 @@ export type {
 	// Base row type
 	BaseRow,
 	// Document types
+	ContentStrategy,
 	DocumentClient,
 	DocumentConfig,
 	DocumentHandle,

--- a/packages/workspace/src/workspace/lifecycle.ts
+++ b/packages/workspace/src/workspace/lifecycle.ts
@@ -24,7 +24,7 @@
  * ┌──────────────────────────┐    ┌──────────────────────────────┐
  * │  Workspace extensions    │    │  Document extensions          │
  * │  ExtensionContext         │    │  DocumentContext              │
- * │  (tables, kv, awareness) │    │  (timeline, ydoc)             │
+ * │  (tables, kv, awareness) │    │  (ydoc, extensions, awareness) │
  * └──────────────────────────┘    └──────────────────────────────┘
  * │                                    │
  * └────────────┬─────────────────────┘

--- a/packages/workspace/src/workspace/strategies.ts
+++ b/packages/workspace/src/workspace/strategies.ts
@@ -30,7 +30,7 @@ import { createTimeline, type Timeline } from '../timeline/timeline.js';
  *
  * // At runtime:
  * const handle = await workspace.documents.files.content.open(file);
- * const ytext = handle.content as Y.Text;
+ * const ytext = handle.content; // Y.Text — fully typed
  * editor.bind(ytext);
  * ```
  */
@@ -58,7 +58,7 @@ export const plainText: (ydoc: Y.Doc) => Y.Text = (ydoc) =>
  *
  * // At runtime:
  * const handle = await workspace.documents.notes.body.open(note);
- * const fragment = handle.content as Y.XmlFragment;
+ * const fragment = handle.content; // Y.XmlFragment — fully typed
  * const plugins = [ySyncPlugin(fragment)];
  * ```
  */
@@ -87,12 +87,11 @@ export const richText: (ydoc: Y.Doc) => Y.XmlFragment = (ydoc) =>
  *
  * // At runtime:
  * const handle = await workspace.documents.files.content.open(file);
- * const tl = handle.content as Timeline;
- * tl.asText();
- * tl.asRichText();
- * tl.asSheet();
- * tl.read();
- * ```
+ * handle.content.asText();      // content is Timeline — fully typed
+ * handle.content.asRichText();
+ * handle.content.asSheet();
+ * handle.content.read();
+ * handle.content.write('hello');
  */
 export const timeline: (ydoc: Y.Doc) => Timeline = (ydoc) =>
 	createTimeline(ydoc);

--- a/packages/workspace/src/workspace/strategies.ts
+++ b/packages/workspace/src/workspace/strategies.ts
@@ -1,0 +1,98 @@
+/**
+ * Built-in content strategies for `.withDocument()`.
+ *
+ * Each strategy is a `ContentStrategy` — a function that receives the document's
+ * Y.Doc and returns a typed binding that becomes `handle.content`.
+ *
+ * @module
+ */
+import * as Y from 'yjs';
+import { createTimeline, type Timeline } from '../timeline/timeline.js';
+
+/**
+ * Plain text content strategy.
+ *
+ * Returns a Y.Text bound to the document. Use for documents that are always
+ * plain text — markdown files, code, skill instructions, plain notes.
+ *
+ * The returned Y.Text can be bound directly to CodeMirror, Monaco, or any
+ * editor that accepts Y.Text via y-codemirror or similar bindings.
+ *
+ * @example
+ * ```typescript
+ * const filesTable = defineTable(
+ *   type({ id: 'string', name: 'string', updatedAt: 'number', _v: '1' }),
+ * ).withDocument('content', {
+ *   content: plainText,
+ *   guid: 'id',
+ *   onUpdate: () => ({ updatedAt: Date.now() }),
+ * });
+ *
+ * // At runtime:
+ * const handle = await workspace.documents.files.content.open(file);
+ * const ytext = handle.content as Y.Text;
+ * editor.bind(ytext);
+ * ```
+ */
+export const plainText: (ydoc: Y.Doc) => Y.Text = (ydoc) =>
+	ydoc.getText('content');
+
+/**
+ * Rich text content strategy.
+ *
+ * Returns a Y.XmlFragment bound to the document. Use for documents edited
+ * with ProseMirror, TipTap, or other block editors via y-prosemirror.
+ *
+ * The returned Y.XmlFragment can be bound directly to ProseMirror via
+ * `ySyncPlugin(fragment)` from y-prosemirror.
+ *
+ * @example
+ * ```typescript
+ * const notesTable = defineTable(
+ *   type({ id: 'string', title: 'string', updatedAt: 'number', _v: '1' }),
+ * ).withDocument('body', {
+ *   content: richText,
+ *   guid: 'id',
+ *   onUpdate: () => ({ updatedAt: Date.now() }),
+ * });
+ *
+ * // At runtime:
+ * const handle = await workspace.documents.notes.body.open(note);
+ * const fragment = handle.content as Y.XmlFragment;
+ * const plugins = [ySyncPlugin(fragment)];
+ * ```
+ */
+export const richText: (ydoc: Y.Doc) => Y.XmlFragment = (ydoc) =>
+	ydoc.getXmlFragment('content');
+
+/**
+ * Timeline content strategy — multi-mode document with format switching.
+ *
+ * Returns the existing Timeline object, supporting runtime switching between
+ * text, richtext, and sheet modes via `asText()` / `asRichText()` / `asSheet()`.
+ *
+ * Use for documents that need runtime mode switching — e.g., opensidian files
+ * that toggle between source markdown and rich text editing, or spreadsheet
+ * files that can also be viewed as CSV text.
+ *
+ * @example
+ * ```typescript
+ * const filesTable = defineTable(
+ *   type({ id: 'string', name: 'string', updatedAt: 'number', _v: '1' }),
+ * ).withDocument('content', {
+ *   content: timeline,
+ *   guid: 'id',
+ *   onUpdate: () => ({ updatedAt: Date.now() }),
+ * });
+ *
+ * // At runtime:
+ * const handle = await workspace.documents.files.content.open(file);
+ * const tl = handle.content as Timeline;
+ * tl.asText();
+ * tl.asRichText();
+ * tl.asSheet();
+ * tl.read();
+ * ```
+ */
+export const timeline: (ydoc: Y.Doc) => Timeline = (ydoc) =>
+	createTimeline(ydoc);

--- a/packages/workspace/src/workspace/types.ts
+++ b/packages/workspace/src/workspace/types.ts
@@ -139,6 +139,31 @@ export type InferTableRow<T> = T extends {
 	? TLatest
 	: never;
 
+/**
+ * A content strategy factory — receives a content Y.Doc and returns a typed binding.
+ *
+ * The binding is whatever the strategy wants to expose: a Y.Text for plain text,
+ * a Y.XmlFragment for rich text, or a custom object with methods for complex
+ * content types like chat trees.
+ *
+ * Called once per document open. Each call gets a fresh Y.Doc.
+ *
+ * @example
+ * ```typescript
+ * // Simple: return a Y.Text
+ * const myStrategy: ContentStrategy<Y.Text> = (ydoc) => ydoc.getText('content');
+ *
+ * // Complex: return a custom binding object
+ * const chatTree: ContentStrategy<ChatTreeBinding> = (ydoc) => ({
+ *   nodes: ydoc.getMap('nodes'),
+ *   addMessage(msg) {
+ *     // ...
+ *   },
+ * });
+ * ```
+ */
+export type ContentStrategy<TBinding = unknown> = (ydoc: Y.Doc) => TBinding;
+
 // ════════════════════════════════════════════════════════════════════════════
 // DOCUMENT CONFIG TYPES
 // ════════════════════════════════════════════════════════════════════════════
@@ -163,6 +188,8 @@ export type DocumentConfig<
 	TRow extends BaseRow = BaseRow,
 	TAwarenessDefs extends AwarenessDefinitions = Record<string, never>,
 > = {
+	/** Content strategy — receives the document Y.Doc, returns a typed binding for `handle.content`. */
+	content: ContentStrategy;
 	guid: TGuid;
 	/**
 	 * Called on every content Y.Doc change (local and remote). Return the
@@ -236,6 +263,8 @@ export type ClaimedDocumentColumns<
 export type DocumentClient<
 	TDocExtensions extends Record<string, unknown> = Record<string, never>,
 > = Timeline & {
+	/** The content binding returned by the content strategy. Falls back to the timeline if no strategy was provided. */
+	content: unknown;
 	/** The workspace identifier. */
 	id: string;
 	/** The table this document belongs to (e.g., 'files', 'notes'). */

--- a/packages/workspace/src/workspace/types.ts
+++ b/packages/workspace/src/workspace/types.ts
@@ -10,7 +10,6 @@ import type { Awareness } from 'y-protocols/awareness';
 import type * as Y from 'yjs';
 import type { Actions } from '../shared/actions.js';
 import type { CombinedStandardSchema } from '../shared/standard-schema.js';
-import type { Timeline } from '../timeline/timeline.js';
 import type { EncryptionKeys } from './encryption-key.js';
 import type { Extension, MaybePromise } from './lifecycle.js';
 
@@ -187,9 +186,10 @@ export type DocumentConfig<
 	TGuid extends string = string,
 	TRow extends BaseRow = BaseRow,
 	TAwarenessDefs extends AwarenessDefinitions = Record<string, never>,
+	TBinding = unknown,
 > = {
 	/** Content strategy — receives the document Y.Doc, returns a typed binding for `handle.content`. */
-	content: ContentStrategy;
+	content: ContentStrategy<TBinding>;
 	guid: TGuid;
 	/**
 	 * Called on every content Y.Doc change (local and remote). Return the
@@ -253,31 +253,26 @@ export type ClaimedDocumentColumns<
 /**
  * The full API surface of an open content document.
  *
- * Mirrors `WorkspaceClient` for consistency: the document's core type that
- * `DocumentContext` derives from via `Pick` and `DocumentHandle` derives from
- * via `Omit`. Extends `Timeline` so all content operations (read, write, mode
- * conversion) are available directly.
+ * The document's core type that `DocumentContext` derives from via `Pick`
+ * and `DocumentHandle` derives from via `Omit`.
  *
  * @typeParam TDocExtensions - Accumulated document extension exports
+ * @typeParam TBinding - The content binding type returned by the content strategy
  */
 export type DocumentClient<
 	TDocExtensions extends Record<string, unknown> = Record<string, never>,
-> = Timeline & {
-	/** The content binding returned by the content strategy. Falls back to the timeline if no strategy was provided. */
-	content: unknown;
+	TBinding = unknown,
+> = {
+	/** The typed content binding returned by the content strategy. */
+	content: TBinding;
 	/** The workspace identifier. */
 	id: string;
 	/** The table this document belongs to (e.g., 'files', 'notes'). */
 	tableName: string;
 	/** The document name declared via `.withDocument()` (e.g., 'content', 'body'). */
 	documentName: string;
-	/**
-	 * Self-reference for destructuring convenience.
-	 *
-	 * The document client IS the timeline (via intersection). This property
-	 * allows factories to destructure `({ timeline })` and get the same object.
-	 */
-	timeline: Timeline;
+	/** The content Y.Doc this document is bound to. */
+	ydoc: Y.Doc;
 	/**
 	 * Accumulated document extension exports with lifecycle hooks.
 	 *
@@ -300,17 +295,14 @@ export type DocumentClient<
 /**
  * Context passed to document extension factories registered via `withDocumentExtension()`.
  *
- * Picks the fields factories need from `DocumentClient` without inheriting the
- * `Timeline` intersection. This preserves the HAS-A relationship (`ctx.timeline`)
- * rather than IS-A (`ctx.read()`), matching how factories actually destructure:
+ * Picks the fields factories need from `DocumentClient`. Factories inspect
+ * `tableName` and `documentName` to decide whether to activate.
+ * Return `void` to skip a specific document.
  *
  * ```typescript
  * .withDocumentExtension('persistence', ({ ydoc }) => { ... })
  * .withDocumentExtension('sync', ({ id, tableName, documentName, ydoc }) => { ... })
  * ```
- *
- * Factories inspect `tableName` and `documentName` to decide whether to activate.
- * Return `void` to skip a specific document.
  *
  * @typeParam TDocExtensions - Accumulated document extension exports from prior calls.
  *   Defaults to `Record<string, unknown>` so `DocumentExtensionRegistration` can
@@ -324,7 +316,6 @@ export type DocumentContext<
 	| 'tableName'
 	| 'documentName'
 	| 'ydoc'
-	| 'timeline'
 	| 'extensions'
 	| 'whenReady'
 > & {
@@ -340,30 +331,29 @@ export type DocumentContext<
 /**
  * A handle to an open content Y.Doc, returned by `documents.open()`.
  *
- * Computed from `DocumentClient` minus lifecycle control. The handle IS the
- * timeline—all read, write, and mode conversion methods are available directly.
+ * Content is accessed via `handle.content` — fully typed by the content strategy.
  * Extension exports are accessed via `handle.extensions`.
  *
- * When `TDocExtensions` is specified (after generic threading), extension access
- * is fully typed. Without generics, extensions are accessible but untyped.
- *
  * @typeParam TDocExtensions - Accumulated document extension exports.
- *   Defaults to `Record<string, unknown>` for untyped access.
+ * @typeParam TAwarenessDefs - Awareness field definitions for this document.
+ * @typeParam TBinding - The content binding type from the content strategy.
  *
  * @example
  * ```typescript
+ * // plainText strategy — content is Y.Text
  * const handle = await documents.open(id);
- * handle.read();                          // read from timeline (always string)
- * handle.write('hello');                   // write to timeline (mode-aware)
- * handle.asText();                         // Y.Text for editor binding
- * handle.currentType;                      // current content type
- * handle.extensions.persistence?.whenReady; // extension access
+ * editor.bind(handle.content); // Y.Text
+ *
+ * // timeline strategy — content is Timeline
+ * handle.content.read();
+ * handle.content.write('hello');
  * ```
  */
-export type DocumentHandle<
+ export type DocumentHandle<
 	TDocExtensions extends Record<string, unknown> = Record<string, unknown>,
 	TAwarenessDefs extends AwarenessDefinitions = Record<string, never>,
-> = Omit<DocumentClient<TDocExtensions>, 'dispose'> & {
+	TBinding = unknown,
+> = Omit<DocumentClient<TDocExtensions, TBinding>, 'dispose'> & {
 	/** Typed awareness helper scoped to this document. */
 	awareness: AwarenessHelper<TAwarenessDefs>;
 };
@@ -376,22 +366,13 @@ export type DocumentHandle<
  * `client.documents.files.content`.
  *
  * @typeParam TRow - The row type of the bound table
- *
- * @example
- * ```typescript
- * const handle = await documents.open(row);
- * handle.write('hello');
- * // updatedAt on the row is bumped automatically
- *
- * const text = handle.read();
- * handle.write('new content');
- * await documents.close(row);
- * ```
+ * @typeParam TBinding - The content binding type from the content strategy
  */
 export type Documents<
 	TRow extends BaseRow,
 	TDocExtensions extends Record<string, unknown> = Record<string, unknown>,
 	TAwarenessDefs extends AwarenessDefinitions = Record<string, never>,
+	TBinding = unknown,
 > = {
 	/**
 	 * Open a content Y.Doc for a row.
@@ -404,7 +385,7 @@ export type Documents<
 	 */
 	open(
 		input: TRow | string,
-	): Promise<DocumentHandle<TDocExtensions, TAwarenessDefs>>;
+	): Promise<DocumentHandle<TDocExtensions, TAwarenessDefs, TBinding>>;
 
 	/**
 	 * Close a document — free memory, disconnect providers.
@@ -453,6 +434,28 @@ export type AllDocumentNames<TTableDefs extends TableDefinitions> = {
 		: never;
 }[keyof TTableDefs];
 
+/** Extract the awareness definitions from a DocumentConfig. */
+type InferDocumentAwareness<T> = T extends DocumentConfig<
+	string,
+	BaseRow,
+	infer TAwarenessDefs,
+	// biome-ignore lint/suspicious/noExplicitAny: inference position
+	any
+>
+	? TAwarenessDefs
+	: Record<string, never>;
+
+/** Extract the content binding type from a DocumentConfig. */
+type InferDocumentBinding<T> = T extends DocumentConfig<
+	string,
+	BaseRow,
+	// biome-ignore lint/suspicious/noExplicitAny: inference position
+	any,
+	infer TBinding
+>
+	? TBinding
+	: unknown;
+
 /**
  * Extract the document map for a single table definition.
  *
@@ -471,13 +474,8 @@ export type DocumentsOf<
 				[K in keyof TDocuments]: Documents<
 					TLatest,
 					TDocExtensions,
-					TDocuments[K] extends DocumentConfig<
-						string,
-						BaseRow,
-						infer TAwarenessDefs
-					>
-						? TAwarenessDefs
-						: Record<string, never>
+					InferDocumentAwareness<TDocuments[K]>,
+					InferDocumentBinding<TDocuments[K]>
 				>;
 			}
 		: never

--- a/packages/workspace/src/workspace/types.ts
+++ b/packages/workspace/src/workspace/types.ts
@@ -349,7 +349,7 @@ export type DocumentContext<
  * handle.content.write('hello');
  * ```
  */
- export type DocumentHandle<
+export type DocumentHandle<
 	TDocExtensions extends Record<string, unknown> = Record<string, unknown>,
 	TAwarenessDefs extends AwarenessDefinitions = Record<string, never>,
 	TBinding = unknown,

--- a/playground/opensidian-e2e/epicenter.config.test.ts
+++ b/playground/opensidian-e2e/epicenter.config.test.ts
@@ -104,9 +104,9 @@ describe('e2e: opensidian workspace', () => {
 		await client.whenReady;
 
 		const handle = await client.documents.files.content.open(fileId);
-		handle.write('# Hello World\n\nThis is a test note.');
+		handle.content.write('# Hello World\n\nThis is a test note.');
 
-		const content = handle.read();
+		const content = handle.content.read();
 		expect(content).toBe('# Hello World\n\nThis is a test note.');
 
 		await client.dispose();
@@ -211,7 +211,7 @@ describe('e2e: opensidian pushFromMarkdown', () => {
 
 		// Verify document content
 		const handle = await client.documents.files.content.open(fileId);
-		expect(handle.read()).toBe('# Test Note\n\nHello from import.');
+		expect(handle.content.read()).toBe('# Test Note\n\nHello from import.');
 
 		await client.dispose();
 	});
@@ -279,7 +279,7 @@ describe('e2e: opensidian pushFromMarkdown', () => {
 
 		// [[Target Note]] should have been resolved to [Target Note](epicenter://opensidian/files/GUID)
 		const handle = await client.documents.files.content.open(sourceId);
-		expect(handle.read()).toBe(
+		expect(handle.content.read()).toBe(
 			`# Source\n\nSee [Target Note](epicenter://opensidian/files/${targetId}) for details.`,
 		);
 

--- a/playground/opensidian-e2e/epicenter.config.ts
+++ b/playground/opensidian-e2e/epicenter.config.ts
@@ -63,7 +63,7 @@ export const opensidian = createWorkspace(opensidianDefinition)
 					let content: string | undefined;
 					try {
 						const handle = await ctx.documents.files.content.open(row.id);
-						content = handle.read();
+						content = handle.content.read();
 					} catch {
 						// Content doc not yet available (sync pending)
 					}

--- a/playground/opensidian-e2e/push-from-markdown.ts
+++ b/playground/opensidian-e2e/push-from-markdown.ts
@@ -90,7 +90,7 @@ export async function pushFromMarkdown(ctx: {
 				const handle = await ctx.documents.files.content.open(
 					frontmatter.id as FileRow['id'],
 				);
-				handle.write(resolvedBody);
+				handle.content.write(resolvedBody);
 			} catch (error) {
 				errors.push(`Failed to write content for ${frontmatter.id}: ${error}`);
 			}

--- a/specs/20260417T180000-document-handle-facade.md
+++ b/specs/20260417T180000-document-handle-facade.md
@@ -1,0 +1,376 @@
+# Strategy-Owned Handles and Minimal Document Surface
+
+**Date**: 2026-04-17
+**Status**: Draft
+**Author**: AI-assisted
+
+## Overview
+
+Replace the current `DocumentHandle` wrapper—which exposes `content`, `ydoc`, `awareness`, `extensions`, `id`, `tableName`, `documentName`, and `whenReady`—with a design where `open()` returns the strategy's content object directly. Each strategy provides its own `read()`/`write()` methods, so consumers never need `ydoc`. The documents manager surface shrinks to three methods: `open`, `close`, `closeAll`.
+
+## Motivation
+
+### Current State
+
+Every `open()` call returns a `DocumentHandle` with 8 properties. Consumers use exactly one:
+
+```typescript
+const handle = await documents.files.content.open(id);
+handle.content.read();    // ← the only thing anyone touches
+```
+
+The other 7 (`ydoc`, `awareness`, `extensions`, `id`, `tableName`, `documentName`, `whenReady`) exist for extension factories and tests. Zero app-level call sites access them—except `handle.ydoc`, which `skills/node.ts` reaches into for `transact()` because the `plainText` strategy returns a raw `Y.Text` with no write method:
+
+```typescript
+// skills/node.ts — forced to reach through the handle into Y.Doc
+const handle = await client.documents.skills.instructions.open(skillId);
+handle.ydoc.transact(() => {
+  const ytext = handle.content;
+  ytext.delete(0, ytext.length);
+  ytext.insert(0, instructions);
+});
+```
+
+This creates two problems:
+
+1. **Autocomplete noise.** Typing `handle.` shows 8 properties when you need 1. Every new developer wonders what `handle.tableName` is for (answer: nothing, in app code).
+2. **Leaky abstraction.** The `plainText` strategy hands you a raw `Y.Text` but no way to write to it without reaching past the handle into `ydoc.transact()`. The strategy created a binding but didn't encapsulate its own write path.
+
+### Desired State
+
+```typescript
+// open() returns the content directly — no wrapper
+const content = await documents.files.content.open(id);
+content.read();         // every strategy provides this
+content.write('hello'); // every strategy provides this
+
+// plainText — no ydoc needed
+const text = await documents.skills.instructions.open(skillId);
+text.write(instructions);  // strategy handles transact internally
+text.binding;              // Y.Text for editor binding when needed
+```
+
+The documents manager surface:
+
+```
+documents.files.content.
+  ├── open(id)       → Promise<TContent>
+  ├── close(id)      → Promise<void>
+  └── closeAll()     → Promise<void>
+```
+
+Three methods. Infrastructure (`ydoc`, `awareness`, `extensions`) is internal—no public accessor. When a genuine consumer need arises (cursor presence via awareness), a targeted accessor gets added then.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| `open()` returns content directly | `Promise<TContent>` not `Promise<DocumentHandle>` | Eliminates the `.content` indirection. 95% of call sites just want the binding. |
+| Strategies must provide `read()` and `write()` | Base `ContentHandle` contract | Consumers never need `ydoc`. The strategy encapsulates `transact()`. |
+| Editor binding via `.binding` property | Explicit accessor, not "content IS the Yjs type" | Makes the raw Yjs type opt-in for editor code. `content.binding` reads as "give me the thing to bind." |
+| No `ydoc()` or `awareness()` accessor initially | Deferred | Zero production consumers need these today. Adding them later is additive and non-breaking. |
+| `DocumentContext` unchanged | Extension factories keep the full internal view | Extensions still receive `{ id, tableName, documentName, ydoc, extensions, whenReady, awareness }`. This change is consumer-facing only. |
+
+## Architecture
+
+### Strategy Contract
+
+```typescript
+/**
+ * Base contract every strategy must satisfy.
+ * Consumers can always read/write regardless of strategy.
+ */
+type ContentHandle = {
+  read(): string;
+  write(text: string): void;
+};
+
+type ContentStrategy<THandle extends ContentHandle> = (ydoc: Y.Doc) => THandle;
+```
+
+### Built-In Strategies
+
+```
+ContentStrategy<THandle extends ContentHandle> = (ydoc: Y.Doc) => THandle
+                                                                    │
+         ┌──────────────────────────────────────────────────────────┼─────────────────────┐
+         │                                                          │                     │
+    PlainTextHandle                                            Timeline            RichTextHandle
+    ┌────────────────────┐                              (already satisfies       ┌────────────────────┐
+    │ read(): string     │                               ContentHandle)          │ read(): string     │
+    │ write(text): void  │                              ┌─────────────────┐      │ write(text): void  │
+    │ binding: Y.Text    │                              │ read(): string  │      │ binding: XmlFrag   │
+    └────────────────────┘                              │ write(text)     │      └────────────────────┘
+                                                        │ asText()        │
+    (ydoc) => {                                         │ asRichText()    │      (ydoc) => {
+      const ytext = ydoc.getText('content');            │ asSheet()       │        const frag = ydoc
+      return {                                          │ batch(fn)       │          .getXmlFragment('content');
+        get binding() { return ytext; },                │ observe(fn)     │        return {
+        read() { return ytext.toString(); },            │ ...             │          get binding() { return frag; },
+        write(text) {                                   └─────────────────┘          read() { ... },
+          ydoc.transact(() => {                                                     write(text) { ... },
+            ytext.delete(0, ytext.length);                                        };
+            ytext.insert(0, text);                                              }
+          });
+        },
+      };
+    }
+```
+
+### Documents Manager (After)
+
+```
+documents.files.content
+  │
+  ├── open(id)       → Promise<TContent>     Content object, fully typed by strategy
+  ├── close(id)      → Promise<void>         Unchanged
+  └── closeAll()     → Promise<void>         Unchanged
+
+  Internally still manages:
+  ┌──────────────────────────────────────┐
+  │  openDocuments: Map<guid, DocEntry>  │
+  │    DocEntry {                        │
+  │      content: TContent               │
+  │      ydoc: Y.Doc                     │
+  │      awareness: AwarenessHelper      │
+  │      extensions: { ... }             │
+  │      whenReady: Promise<void>        │
+  │    }                                 │
+  └──────────────────────────────────────┘
+  Not exposed. Extension factories receive DocEntry fields via DocumentContext.
+```
+
+## Call Site Migration
+
+### App code (editors)
+
+```typescript
+// BEFORE
+const handle = await workspace.documents.notes.body.open(noteId);
+currentYXmlFragment = handle.content;               // raw Y.XmlFragment
+
+// AFTER
+const content = await workspace.documents.notes.body.open(noteId);
+currentYXmlFragment = content.binding;               // explicit accessor
+```
+
+### App code (timeline — opensidian)
+
+```typescript
+// BEFORE
+const handle = await workspace.documents.files.content.open(id);
+handle.content.asText();
+
+// AFTER
+const content = await workspace.documents.files.content.open(id);
+content.asText();                                    // no .content wrapper
+```
+
+### Package code (skills/node.ts — the pain point)
+
+```typescript
+// BEFORE — reaches into ydoc
+const handle = await client.documents.skills.instructions.open(skillId);
+handle.ydoc.transact(() => {
+  const ytext = handle.content;
+  ytext.delete(0, ytext.length);
+  ytext.insert(0, instructions);
+});
+
+// AFTER — strategy owns write
+const content = await client.documents.skills.instructions.open(skillId);
+content.write(instructions);
+```
+
+### Package code (skills/workspace.ts — read)
+
+```typescript
+// BEFORE
+const handle = await client.documents.skills.instructions.open(id);
+return { skill, instructions: handle.content.toString() };
+
+// AFTER
+const content = await client.documents.skills.instructions.open(id);
+return { skill, instructions: content.read() };
+```
+
+### Package code (filesystem — sqlite index)
+
+```typescript
+// BEFORE
+const handle = await documents.open(row);
+const text = handle.content.read();
+
+// AFTER
+const content = await documents.open(row);
+const text = content.read();
+```
+
+## Implementation Plan
+
+### Phase 1: Strategy-owned read/write (non-breaking, additive)
+
+Introduce `PlainTextHandle` and `RichTextHandle` types and update `plainText`/`richText` strategies to return them instead of raw Yjs types. Timeline already satisfies `ContentHandle`.
+
+- [ ] **1.1** Define `ContentHandle` base type in `types.ts`: `{ read(): string; write(text: string): void }`
+- [ ] **1.2** Define `PlainTextHandle` type: `ContentHandle & { binding: Y.Text }`
+- [ ] **1.3** Define `RichTextHandle` type: `ContentHandle & { binding: Y.XmlFragment }`
+- [ ] **1.4** Update `plainText` strategy in `strategies.ts` to return `PlainTextHandle` — wraps Y.Text with `read()`, `write()`, and `binding` getter
+- [ ] **1.5** Update `richText` strategy in `strategies.ts` to return `RichTextHandle` — wraps Y.XmlFragment with `read()`, `write()`, and `binding` getter
+- [ ] **1.6** Verify `timeline` strategy's return type satisfies `ContentHandle` (it should — Timeline has `read()` and `write()`)
+- [ ] **1.7** Update `skills/node.ts` — replace `handle.ydoc.transact()` pattern with `content.write()`
+- [ ] **1.8** Update `skills/workspace.ts` — replace `handle.content.toString()` with `content.read()`
+- [ ] **1.9** `bun typecheck` passes, existing tests pass
+
+### Phase 2: Flatten handle — open() returns content directly (breaking)
+
+Remove the `DocumentHandle` wrapper. `open()` returns `TContent` instead of `DocumentHandle<..., TContent>`.
+
+- [ ] **2.1** Change `Documents.open()` return type from `Promise<DocumentHandle<...>>` to `Promise<TContent>`
+- [ ] **2.2** Update `create-documents.ts` — `open()` returns `contentBinding` instead of the full handle object
+- [ ] **2.3** Store the full `DocEntry` internally in the `openDocuments` map (unchanged) but only return content to consumers
+- [ ] **2.4** Migrate all `handle.content.X()` → `content.X()` across apps and packages (see grep guide below)
+- [ ] **2.5** Migrate all `handle.content` (bare, for editor binding) → `content.binding`
+- [ ] **2.6** Remove `DocumentHandle` type export (or keep as internal alias)
+- [ ] **2.7** Update `DocumentsOf` and `Documents` types to reflect new return type
+- [ ] **2.8** Update all tests — remove assertions on `handle.tableName`, `handle.documentName`, `handle.ydoc`, etc.
+- [ ] **2.9** Update READMEs, JSDoc, and strategies.ts examples
+- [ ] **2.10** `bun typecheck` passes, `bun test` passes across monorepo
+
+### Phase 3: Future — plumbing accessors (when needed, not now)
+
+When a genuine consumer need arises (cursor presence, extension inspection), add dedicated methods to the documents manager—one per concern:
+
+```typescript
+documents.files.content.ydoc(id)       → Y.Doc | null
+documents.files.content.awareness(id)  → AwarenessHelper | null
+```
+
+Each accessor returns `null` if the document isn't open. Add them individually as the need materializes—`awareness()` when cursor presence ships, `ydoc()` if a consumer genuinely needs raw doc access beyond what the strategy provides. No bag-of-everything `internals()` method.
+
+## Execution Guide: Grep Patterns
+
+These patterns find every call site that needs migration. Run each and verify the count goes to zero after migration.
+
+### Phase 1 patterns (strategy-owned write)
+
+```bash
+# The ydoc.transact pattern in plainText consumers — THE bug this fixes
+rg 'handle\.ydoc\.transact' --type ts
+
+# Raw Y.Text manipulation through handle.content (plainText consumers writing)
+rg 'handle\.content\.delete|handle\.content\.insert' --type ts
+
+# .toString() on handle.content (becomes .read())
+rg 'handle\.content\.toString\(\)' --type ts
+rg 'Handle\.content\.toString\(\)' --type ts
+rg 'contentHandle\.content\.toString\(\)' --type ts
+rg 'instructionsHandle\.content\.toString\(\)' --type ts
+```
+
+### Phase 2 patterns (flatten handle)
+
+```bash
+# Every handle.content access — all must become just content.X()
+rg 'handle\.content\b' --type ts --type svelte
+rg '\.content\.read\(\)' --type ts --type svelte
+rg '\.content\.write\(' --type ts --type svelte
+rg '\.content\.asText\(\)' --type ts --type svelte
+rg '\.content\.asRichText\(\)' --type ts --type svelte
+rg '\.content\.asSheet\(\)' --type ts --type svelte
+rg '\.content\.observe\(' --type ts
+rg '\.content\.batch\(' --type ts
+
+# Dead properties that should no longer appear on return value of open()
+rg 'handle\.(ydoc|awareness|extensions|whenReady|tableName|documentName|id)\b' --type ts --type svelte
+
+# The DocumentHandle type itself — should be removed or internalized
+rg 'DocumentHandle' --type ts
+
+# Editor bindings that grab raw Yjs type (handle.content → content.binding)
+rg 'handle\.content;' --type svelte   # bare access, not method call — editor binding
+rg '= handle\.content$' --type ts     # assignment of raw binding
+
+# Variable naming — find all 'handle' variables from open() calls
+rg 'const handle = await.*\.open\(' --type ts --type svelte
+rg '\.open\(.*\)\.then\(\(handle\)' --type ts --type svelte
+rg '\.open\(.*\)\.then\(\(h\)' --type ts --type svelte
+```
+
+### Verification after each phase
+
+```bash
+# Phase 1 complete when:
+rg 'handle\.ydoc' --type ts          # zero results outside tests
+rg '\.content\.toString\(\)' --type ts  # zero results (all .read() now)
+
+# Phase 2 complete when:
+rg 'handle\.content\b' --type ts --type svelte  # zero results
+rg 'DocumentHandle' --type ts                    # zero results in public API (internal only)
+```
+
+## Edge Cases
+
+### Timeline already satisfies ContentHandle
+
+`Timeline` has `read(): string` and `write(text: string): void`. No wrapper needed. But it also exposes `ydoc` as a readonly property (line 45 of timeline.ts). After Phase 2, this is the only path a consumer could reach the Y.Doc through:
+
+```typescript
+const content = await documents.files.content.open(id);
+content.ydoc;  // Timeline exposes this — should it?
+```
+
+Recommendation: remove `ydoc` from Timeline's public type in a follow-up. Timeline shouldn't expose its internal doc. Its `batch()` method already wraps `ydoc.transact()`.
+
+### Idempotent open()
+
+`open()` is currently idempotent — calling it twice returns the same handle. This must remain true: calling it twice returns the same content object (same reference). The internal `DocEntry` is cached; we just return `entry.content` instead of the full entry.
+
+### close() after open() — dangling content references
+
+If a consumer holds a content reference and someone calls `close(id)`, the underlying Y.Doc is destroyed. `content.read()` on a destroyed doc is undefined behavior in Yjs. This is the same risk as today — no change needed. Document it.
+
+### richText write() — what does it do?
+
+`RichTextHandle.write(text)` receives a plain string. For a `Y.XmlFragment`, writing plain text means clearing the fragment and inserting a paragraph node with that text. This matches the existing `Timeline.write()` behavior for richtext mode. The implementer should verify the exact ProseMirror-compatible node structure.
+
+## Open Questions
+
+1. **Should `PlainTextHandle` also expose `insert()` and `delete()`?**
+   - `skills/node.ts` currently does positional insert/delete via raw Y.Text. With `write()` covering the full-replace case, is positional editing needed on the handle?
+   - Recommendation: Start with `read()` + `write()` + `binding` only. If a consumer needs positional ops, they use `content.binding.insert(pos, text)` — that's the editor binding path, which is expected to touch raw Yjs.
+
+2. **Should `binding` be a method or a getter?**
+   - Getter: `content.binding` — consistent with property access
+   - Method: `content.getBinding()` — signals "this gives you a live Yjs reference, handle with care"
+   - Recommendation: Getter. It's a stable reference, not a computation. `content.binding` reads naturally.
+
+3. **Should Timeline expose `.binding`?**
+   - Timeline's equivalent is `.asText()` / `.asRichText()` / `.asSheet()` — it has multiple bindings depending on mode. A single `.binding` property doesn't make sense.
+   - Recommendation: No. Timeline keeps its existing `asText()`/`asRichText()`/`asSheet()` methods. The `binding` property is a `PlainTextHandle`/`RichTextHandle` concept only.
+
+## Success Criteria
+
+- [ ] Every strategy provides `read()` and `write()` — no consumer needs `ydoc`
+- [ ] `open()` returns `TContent` directly — no `.content` indirection
+- [ ] Documents manager surface is exactly `open`, `close`, `closeAll`
+- [ ] Zero `handle.ydoc` references in non-test code
+- [ ] Zero `handle.content.X()` patterns (all `content.X()`)
+- [ ] `bun typecheck` passes across the monorepo
+- [ ] `bun test` passes across the monorepo (minus intentional test updates)
+- [ ] READMEs and JSDoc updated to match new API
+
+## References
+
+- `packages/workspace/src/workspace/types.ts` — `DocumentHandle`, `DocumentClient`, `DocumentContext`, `Documents`, `DocumentsOf`
+- `packages/workspace/src/workspace/create-documents.ts` — runtime document manager, `open()` implementation
+- `packages/workspace/src/workspace/strategies.ts` — `plainText`, `richText`, `timeline` strategies
+- `packages/workspace/src/timeline/timeline.ts` — Timeline type (already satisfies ContentHandle)
+- `packages/skills/src/node.ts` — the `ydoc.transact()` pain point (lines 137, 170)
+- `packages/skills/src/workspace.ts` — `.content.toString()` call sites (lines 95, 123, 128)
+- `packages/filesystem/src/extensions/sqlite-index/index.ts` — `.content.read()` call site
+- `apps/honeycrisp/src/routes/+page.svelte` — editor binding (`handle.content`)
+- `apps/fuji/src/lib/components/EntryEditor.svelte` — editor binding (`handle.content`)
+- `apps/opensidian/src/lib/components/editor/ContentEditor.svelte` — timeline usage (`handle.content.asText()`)
+- `apps/skills/src/lib/components/editor/InstructionsEditor.svelte` — handle open pattern
+- `specs/20260418T120000-withdocument-content-strategy.md` — prior spec (content strategy introduction)

--- a/specs/20260418T120000-withdocument-content-strategy.md
+++ b/specs/20260418T120000-withdocument-content-strategy.md
@@ -1,0 +1,144 @@
+# withDocument Content Strategy (IoC)
+
+**Date**: 2026-04-18
+**Status**: In Progress
+**Author**: AI-assisted
+
+## Overview
+
+Replace the implicit "every document is text/richtext/sheet via Timeline" model with an explicit content strategy injected via `.withDocument()`. The user passes a `content` factory that receives a Y.Doc and returns a typed binding. The handle exposes `handle.content` as whatever that factory returned.
+
+## Motivation
+
+### Current State
+
+Every `.withDocument()` call produces a handle with the same generic surface—`read()`, `write()`, `asText()`, `asRichText()`, `asSheet()`, `batch()`, `restoreFromSnapshot()`—regardless of what content type the document actually is:
+
+```ts
+// Definition — no content type specified
+).withDocument('content', {
+  guid: 'id',
+  onUpdate: () => ({ updatedAt: Date.now() }),
+});
+
+// Consumption — generic handle, all methods available
+const handle = await documents.content.open(row);
+handle.asText();       // always available
+handle.asRichText();   // always available
+handle.asSheet();      // always available — even on a chat document?
+```
+
+This creates problems:
+
+1. **No type safety at the handle level.** A honeycrisp note handle has `.asSheet()` on it. A filesystem file has `.asRichText()`. These methods exist but are nonsensical for those use cases.
+2. **Can't add new content types.** chatTree, canvas, or any custom content type would require modifying the framework's Timeline internals—adding new entry types, conversion paths, and handle methods.
+3. **The Timeline manages format switching for documents that never switch.** 100% of current call sites use a single content type. The Timeline's format conversion machinery is unused overhead.
+
+### Desired State
+
+```ts
+// Definition — content type is explicit
+).withDocument('content', {
+  content: plainText(),
+  guid: 'id',
+  onUpdate: () => ({ updatedAt: Date.now() }),
+});
+
+// Consumption — handle.content IS the binding, fully typed
+const handle = await documents.content.open(row);
+handle.content            // Y.Text (for plainText strategy)
+handle.content.toString() // read
+```
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Content strategy receives Y.Doc | `(ydoc: Y.Doc) => TBinding` | Natural Yjs API, no artificial nesting. Each document IS its own Y.Doc. |
+| `content` is a required field | Required | Forces explicit content type. No magic "every doc is everything." |
+| `guid` stays explicit | Required field | All current sites use `'id'` but the indirection is proven and cheap. |
+| `onUpdate` stays explicit | Required field | Bridge between Y.Doc changes and table row observation. Can't be defaulted safely. |
+| Keep backward compat in Phase 1 | Old handle methods preserved | Allows incremental migration. `handle.content` coexists with `handle.read()` etc. |
+| Built-in strategies as functions | `plainText()`, `richText()`, `timeline()` | Ship common cases. `timeline()` wraps the existing Timeline for multi-mode docs. Users can write custom strategies for chatTree etc. |
+
+## Architecture
+
+```
+ContentStrategy<TBinding> = (ydoc: Y.Doc) => TBinding
+
+.withDocument('name', {                     DocumentHandle<TBinding>
+  content: strategy ──────────────────────▶ { content: TBinding,
+  guid: 'id',                                 id, tableName, documentName,
+  onUpdate: () => ({...}),                    ydoc, extensions, whenReady }
+})
+                                            ▲
+At open time:                               │
+1. Create Y.Doc (guid from row)             │
+2. Run extensions (persistence, sync)       │
+3. await whenReady                          │
+4. binding = strategy(ydoc)  ───────────────┘
+5. Attach onUpdate observer
+6. Return handle
+```
+
+## Implementation Plan
+
+### Phase 1: Add content strategy (additive, no breaking changes)
+
+- [ ] **1.1** Define `ContentStrategy<TBinding>` type in `types.ts`
+- [ ] **1.2** Add `content` field to `DocumentConfig` type
+- [ ] **1.3** Update `withDocument()` in `define-table.ts` to accept and store `content`
+- [ ] **1.4** Ship `plainText()`, `richText()`, and `timeline()` strategy factories in a new `strategies.ts`
+- [ ] **1.5** Update `create-documents.ts` to call the content strategy at open time and attach to handle
+- [ ] **1.6** Add `content: TBinding` to `DocumentHandle` type
+- [ ] **1.7** Update all 5 production `.withDocument()` call sites to add `content` field
+- [ ] **1.8** Update representative handle consumers to use `handle.content`
+- [ ] **1.9** Verify: `bun typecheck` passes, existing tests pass
+
+### Phase 2: Remove Timeline (separate PR, not in this spec)
+
+- [ ] **2.1** Remove `asText()`, `asRichText()`, `asSheet()`, `read()`, `write()` from handle
+- [ ] **2.2** Migrate all remaining consumers to `handle.content`
+- [ ] **2.3** Remove `timeline.ts` and `createTimeline()`
+- [ ] **2.4** Remove Timeline from `DocumentContext`
+
+## Call site changes
+
+### Definition sites (+1 line each)
+
+| File | Before | After |
+|---|---|---|
+| `packages/filesystem/src/table.ts` | `{ guid, onUpdate }` | `{ content: timeline(), guid, onUpdate }` |
+| `packages/skills/src/tables.ts` (instructions) | `{ guid, onUpdate }` | `{ content: plainText(), guid, onUpdate }` |
+| `packages/skills/src/tables.ts` (content) | `{ guid, onUpdate }` | `{ content: plainText(), guid, onUpdate }` |
+| `apps/fuji/src/lib/workspace.ts` | `{ guid, onUpdate }` | `{ content: richText(), guid, onUpdate }` |
+| `apps/honeycrisp/.../definition.ts` | `{ guid, onUpdate }` | `{ content: richText(), guid, onUpdate }` |
+
+### Handle consumption sites (Phase 1 — demonstrate the new API alongside old)
+
+| Pattern | Before | After (via `handle.content`) |
+|---|---|---|
+| Read text | `handle.read()` | `handle.content.toString()` |
+| Get Y.Text | `handle.asText()` | `handle.content` (plainText) |
+| Get Y.XmlFragment | `handle.asRichText()` | `handle.content` (richText) |
+| Write text | `handle.writeText('x')` | `handle.content.delete(0, len); handle.content.insert(0, 'x')` |
+
+## Success Criteria
+
+- [ ] `content` field accepted by `.withDocument()` and stored on the definition
+- [ ] `plainText()`, `richText()`, and `timeline()` strategies exported from workspace package
+- [ ] `handle.content` returns the typed binding at runtime
+- [ ] All 5 production call sites updated with `content` field
+- [ ] `bun typecheck` passes across the monorepo
+- [ ] Existing tests continue to pass (backward compat preserved)
+
+## References
+
+- `packages/workspace/src/workspace/types.ts` — DocumentConfig, DocumentHandle, DocumentContext
+- `packages/workspace/src/workspace/define-table.ts` — withDocument() chain
+- `packages/workspace/src/workspace/create-documents.ts` — runtime document manager
+- `packages/workspace/src/timeline/timeline.ts` — Timeline (to be replaced in Phase 2)
+- `packages/filesystem/src/table.ts` — filesystem call site
+- `packages/skills/src/tables.ts` — skills call sites
+- `apps/fuji/src/lib/workspace.ts` — fuji call site
+- `apps/honeycrisp/src/lib/workspace/definition.ts` — honeycrisp call site

--- a/specs/20260418T120000-withdocument-content-strategy.md
+++ b/specs/20260418T120000-withdocument-content-strategy.md
@@ -58,8 +58,8 @@ handle.content.toString() // read
 | `content` is a required field | Required | Forces explicit content type. No magic "every doc is everything." |
 | `guid` stays explicit | Required field | All current sites use `'id'` but the indirection is proven and cheap. |
 | `onUpdate` stays explicit | Required field | Bridge between Y.Doc changes and table row observation. Can't be defaulted safely. |
-| Keep backward compat in Phase 1 | Old handle methods preserved | Allows incremental migration. `handle.content` coexists with `handle.read()` etc. |
-| Built-in strategies as functions | `plainText()`, `richText()`, `timeline()` | Ship common cases. `timeline()` wraps the existing Timeline for multi-mode docs. Users can write custom strategies for chatTree etc. |
+| ~~Keep backward compat in Phase 1~~ | Old handle methods removed (Phase 2 done) | Phase 2 completed in the same PR. `handle.content` is now the only content access path. |
+| Built-in strategies as values | `plainText`, `richText`, `timeline` | Ship common cases. `timeline` wraps the existing Timeline for multi-mode docs. Users can write custom strategies for chatTree etc. |
 
 ## Architecture
 
@@ -83,24 +83,24 @@ At open time:                               │
 
 ## Implementation Plan
 
-### Phase 1: Add content strategy (additive, no breaking changes)
+### ~~Phase 1: Add content strategy (additive, no breaking changes)~~
 
-- [ ] **1.1** Define `ContentStrategy<TBinding>` type in `types.ts`
-- [ ] **1.2** Add `content` field to `DocumentConfig` type
-- [ ] **1.3** Update `withDocument()` in `define-table.ts` to accept and store `content`
-- [ ] **1.4** Ship `plainText()`, `richText()`, and `timeline()` strategy factories in a new `strategies.ts`
-- [ ] **1.5** Update `create-documents.ts` to call the content strategy at open time and attach to handle
-- [ ] **1.6** Add `content: TBinding` to `DocumentHandle` type
-- [ ] **1.7** Update all 5 production `.withDocument()` call sites to add `content` field
-- [ ] **1.8** Update representative handle consumers to use `handle.content`
-- [ ] **1.9** Verify: `bun typecheck` passes, existing tests pass
+- [x] **1.1** Define `ContentStrategy<TBinding>` type in `types.ts`
+- [x] **1.2** Add `content` field to `DocumentConfig` type
+- [x] **1.3** Update `withDocument()` in `define-table.ts` to accept and store `content`
+- [x] **1.4** Ship `plainText`, `richText`, and `timeline` strategy values in a new `strategies.ts`
+- [x] **1.5** Update `create-documents.ts` to call the content strategy at open time and attach to handle
+- [x] **1.6** Add `content: TBinding` to `DocumentHandle` type
+- [x] **1.7** Update all 5 production `.withDocument()` call sites to add `content` field
+- [x] **1.8** Update all handle consumers to use `handle.content`
+- [x] **1.9** Verify: `bun typecheck` passes, existing tests pass
 
-### Phase 2: Remove Timeline (separate PR, not in this spec)
+### ~~Phase 2: Remove Timeline from handle (completed in same PR)~~
 
-- [ ] **2.1** Remove `asText()`, `asRichText()`, `asSheet()`, `read()`, `write()` from handle
-- [ ] **2.2** Migrate all remaining consumers to `handle.content`
-- [ ] **2.3** Remove `timeline.ts` and `createTimeline()`
-- [ ] **2.4** Remove Timeline from `DocumentContext`
+- [x] **2.1** Remove `asText()`, `asRichText()`, `asSheet()`, `read()`, `write()` from handle
+- [x] **2.2** Migrate all remaining consumers to `handle.content`
+- [x] **2.3** Timeline kept as library — `timeline` strategy returns it
+- [x] **2.4** Remove `timeline` from `DocumentContext`
 
 ## Call site changes
 
@@ -108,20 +108,22 @@ At open time:                               │
 
 | File | Before | After |
 |---|---|---|
-| `packages/filesystem/src/table.ts` | `{ guid, onUpdate }` | `{ content: timeline(), guid, onUpdate }` |
-| `packages/skills/src/tables.ts` (instructions) | `{ guid, onUpdate }` | `{ content: plainText(), guid, onUpdate }` |
-| `packages/skills/src/tables.ts` (content) | `{ guid, onUpdate }` | `{ content: plainText(), guid, onUpdate }` |
-| `apps/fuji/src/lib/workspace.ts` | `{ guid, onUpdate }` | `{ content: richText(), guid, onUpdate }` |
-| `apps/honeycrisp/.../definition.ts` | `{ guid, onUpdate }` | `{ content: richText(), guid, onUpdate }` |
+| `packages/filesystem/src/table.ts` | `{ guid, onUpdate }` | `{ content: timeline, guid, onUpdate }` |
+| `packages/skills/src/tables.ts` (instructions) | `{ guid, onUpdate }` | `{ content: plainText, guid, onUpdate }` |
+| `packages/skills/src/tables.ts` (content) | `{ guid, onUpdate }` | `{ content: plainText, guid, onUpdate }` |
+| `apps/fuji/src/lib/workspace.ts` | `{ guid, onUpdate }` | `{ content: richText, guid, onUpdate }` |
+| `apps/honeycrisp/.../definition.ts` | `{ guid, onUpdate }` | `{ content: richText, guid, onUpdate }` |
 
-### Handle consumption sites (Phase 1 — demonstrate the new API alongside old)
+### Handle consumption sites (completed)
 
 | Pattern | Before | After (via `handle.content`) |
 |---|---|---|
-| Read text | `handle.read()` | `handle.content.toString()` |
-| Get Y.Text | `handle.asText()` | `handle.content` (plainText) |
-| Get Y.XmlFragment | `handle.asRichText()` | `handle.content` (richText) |
-| Write text | `handle.writeText('x')` | `handle.content.delete(0, len); handle.content.insert(0, 'x')` |
+| Read text (timeline) | `handle.read()` | `handle.content.read()` |
+| Read text (plainText) | `handle.read()` | `handle.content.toString()` |
+| Get Y.Text | `handle.asText()` | `handle.content` (plainText) or `handle.content.asText()` (timeline) |
+| Get Y.XmlFragment | `handle.asRichText()` | `handle.content` (richText) or `handle.content.asRichText()` (timeline) |
+| Write text (timeline) | `handle.write('x')` | `handle.content.write('x')` |
+| Write text (plainText) | `handle.write('x')` | Y.Text: `ydoc.transact(() => { ytext.delete(0, len); ytext.insert(0, 'x') })` |
 
 ## Success Criteria
 


### PR DESCRIPTION
Every `.withDocument()` call used to produce the same handle surface—`handle.read()`, `handle.write()`, `handle.asText()`, `handle.asRichText()`, `handle.asSheet()`—regardless of what the document actually is. A honeycrisp note had `.asSheet()` on it. A filesystem file had `.asRichText()`. These methods existed but were nonsensical. Worse, adding a new content type (chat tree, canvas, anything custom) meant modifying the framework's Timeline internals.

This PR inverts control. Instead of every document getting a kitchen-sink handle, the content type is now an explicit strategy passed to `.withDocument()`:

```typescript
// Before — implicit, everything is a Timeline
).withDocument('content', {
  guid: 'id',
  onUpdate: () => ({ updatedAt: Date.now() }),
});

const handle = await documents.content.open(row);
handle.read();       // Timeline method, always there
handle.asSheet();    // ...even on a note document

// After — explicit strategy, fully typed binding
).withDocument('content', {
  content: timeline,   // or plainText, richText, or your own
  guid: 'id',
  onUpdate: () => ({ updatedAt: Date.now() }),
});

const handle = await documents.content.open(row);
handle.content.read();    // Timeline — because that's the strategy
handle.content.asSheet(); // still available, but ONLY because timeline supports it
```

The `ContentStrategy<TBinding>` generic threads through the entire document type chain—`DocumentConfig`, `DocumentClient`, `DocumentHandle`, `Documents`, `DocumentsOf`—so `handle.content` is fully typed by what the strategy returns:

```
ContentStrategy<TBinding>
    ↓ stored in
DocumentConfig<..., TBinding>
    ↓ inferred by
.withDocument('name', { content: timeline, ... })  // TBinding = Timeline
    ↓ threaded into
Documents<TRow, ..., TBinding>
    ↓ returned from
documents.open(row)  →  DocumentHandle<..., TBinding>
    ↓ exposes
handle.content   // Timeline | Y.Text | Y.XmlFragment — fully typed
```

Three built-in strategies ship with the package:

```
Strategy         handle.content type     Typical use
───────────────────────────────────────────────────────
plainText    →   Y.Text                  markdown, code, skill instructions
richText     →   Y.XmlFragment           ProseMirror/TipTap block editors
timeline     →   Timeline                multi-mode docs (text ↔ richtext ↔ sheet)
```

`plainText` and `richText` return raw Yjs shared types—bind them directly to CodeMirror or ProseMirror with zero adapter code. `timeline` wraps the existing Timeline for documents that need runtime mode switching. Custom strategies are just `(ydoc: Y.Doc) => YourBinding`.

---

**Timeline no longer lives on `DocumentHandle` or `DocumentContext`.**

Previously, `createDocuments()` called `createTimeline(ydoc)` unconditionally and attached it to every handle. Now the strategy creates its own binding—`createDocuments` just calls `content(ydoc)` and stores the result. `DocumentContext` no longer carries `timeline`, because no extension factory was using it.

---

A cleanup commit wrapped the Y.Text delete+insert in `packages/skills/src/node.ts` inside `ydoc.transact()` to avoid double observer fire, removed an explicit `DocumentHandle` annotation in honeycrisp that was erasing `TBinding` inference, and fixed a stale lifecycle diagram referencing `timeline` on `DocumentContext`.

29 files changed, +536/−197.