### PR TITLE
feat: add whenConnected promise to sync extension

### DIFF
--- a/packages/cli/src/connect.ts
+++ b/packages/cli/src/connect.ts
@@ -2,6 +2,7 @@ import { filesystemPersistence } from '@epicenter/workspace/extensions/persisten
 import { createSyncExtension } from '@epicenter/workspace/extensions/sync/websocket';
 import { createSessionStore } from './auth/store.js';
 import { createCliUnlock } from './extensions.js';
+import { EPICENTER_PATHS } from './paths.js';
 import type {
 	AwarenessDefinitions,
 	KvDefinitions,
@@ -13,9 +14,12 @@ import type {
  * Connect a workspace factory to the Epicenter API with authentication,
  * persistence, and sync — ready to use in one `await`.
  *
- * Chains extensions in the correct order (persistence → unlock → sync) so
- * the sync handshake only exchanges the delta between local state and the
- * server. Persistence is stored at `~/.epicenter/persistence/<workspace-id>.db`.
+ * Chains extensions in the correct order (persistence → unlock → sync),
+ * waits for local persistence to load, then waits for the WebSocket sync
+ * to reach `connected` phase. The returned workspace has both local and
+ * remote data.
+ *
+ * Persistence is stored at `~/.epicenter/persistence/<workspace-id>.db`.
  *
  * Requires a prior `epicenter auth login` to store session credentials at
  * `~/.epicenter/auth/sessions.json`.
@@ -32,6 +36,7 @@ import type {
  *
  * const workspace = await connectWorkspace(createFujiWorkspace);
  *
+ * // Safe to read — has both local persistence and remote sync data
  * const entries = workspace.tables.entries.filter(e => !e.deletedAt);
  * for (const entry of entries) {
  *   workspace.tables.entries.update(entry.id, { tags: [...entry.tags, 'Journal'] });
@@ -74,5 +79,6 @@ export async function connectWorkspace<
 		);
 
 	await client.whenReady;
+	await client.extensions.sync.whenConnected;
 	return client;
 }

--- a/packages/workspace/src/extensions/sync/websocket.ts
+++ b/packages/workspace/src/extensions/sync/websocket.ts
@@ -121,6 +121,25 @@ export type SyncExtensionExports = {
 	reconnect(): void;
 
 	/**
+	 * Promise that resolves when the sync extension first reaches `connected` phase.
+	 *
+	 * Unlike `whenReady` (which resolves after the supervisor loop starts),
+	 * `whenConnected` waits for the WebSocket handshake to complete and the
+	 * first sync exchange to finish. Use this in CLI scripts and tools that
+	 * need remote data before proceeding.
+	 *
+	 * Browser apps should use `whenReady` instead—it resolves instantly from
+	 * local persistence and doesn't block on network availability.
+	 *
+	 * @example
+	 * ```typescript
+	 * await workspace.whenReady;                        // local data ready
+	 * await workspace.extensions.sync.whenConnected;    // remote data ready
+	 * ```
+	 */
+	readonly whenConnected: Promise<void>;
+
+	/**
 	 * Invoke an action on a remote peer in this room.
 	 *
 	 * Pass a type map (from `InferRpcMap`) for full type safety, or omit it
@@ -242,6 +261,7 @@ export function createSyncExtension(config: SyncExtensionConfig): (
 	context: SharedExtensionContext,
 ) => SyncExtensionExports & {
 	whenReady: Promise<unknown>;
+	whenConnected: Promise<void>;
 	dispose: () => void;
 } {
 	return ({ ydoc: doc, awareness: ctxAwareness, whenReady: priorReady }) => {
@@ -263,6 +283,7 @@ export function createSyncExtension(config: SyncExtensionConfig): (
 		// ── Zone 2: Mutable state ──
 
 		const status = createStatusEmitter<SyncStatus>({ phase: 'offline' });
+		const { promise: whenConnected, resolve: resolveConnected } = Promise.withResolvers<void>();
 		const backoff = createBackoff();
 
 		/** User intent: should we be connected? Set by connect()/goOffline(). */
@@ -671,6 +692,7 @@ export function createSyncExtension(config: SyncExtensionConfig): (
 								phase: 'connected',
 								hasLocalChanges: localVersion > ackedVersion,
 							});
+							resolveConnected();
 						}
 						break;
 					}
@@ -768,6 +790,8 @@ export function createSyncExtension(config: SyncExtensionConfig): (
 			},
 
 			onStatusChange: status.subscribe,
+
+			whenConnected,
 
 			reconnect() {
 				if (desired !== 'online') return;


### PR DESCRIPTION
CLI scripts that call `connectWorkspace` need remote data, but `whenReady` resolves the instant local persistence loads—before WebSocket sync has time to connect and exchange its delta with the server. Scripts reading immediately got stale local-only data instead of the full remote dataset.

The sync extension already tracked connection state internally (the supervisor loop sets `phase: 'connected'` after the handshake), but never surfaced it as a promise. Adding `whenConnected` to the sync extension is ~10 lines and lets `connectWorkspace` do the right thing natively:

```typescript
// Before — whenReady returns before sync connects
await client.whenReady;
return client; // stale local data only

// After — waits for the sync handshake to complete
await client.whenReady;
await client.extensions.sync.whenConnected;
return client; // local + remote data
```

The promise uses `Promise.withResolvers` and resolves when the first sync handshake reaches `connected` phase. Calling `resolve()` on an already-resolved promise is a no-op, so no boolean guard is needed—reconnections after the first are irrelevant.

```
whenReady (instant)          whenConnected (~2-5s)
     │                              │
     ▼                              ▼
┌──────────┐  ┌──────────┐  ┌─────────────┐
│ Y.Doc    │  │ persist  │  │  WebSocket  │
│ created  │→ │ loaded   │→ │  handshake  │→  ready to read
└──────────┘  └──────────┘  └─────────────┘
```

Browser apps still use `whenReady` (offline-first, instant). CLI scripts get `whenConnected` for when they need the network. No duck-typed utility functions, no timeout parameters, no bolt-on workarounds.

2 files changed, +33/-3.