### PR TITLE
feat(workspace): add bidirectional markdown sync to materializer

### DIFF
--- a/packages/workspace/src/extensions/materializer/markdown/materializer.test.ts
+++ b/packages/workspace/src/extensions/materializer/markdown/materializer.test.ts
@@ -1,0 +1,523 @@
+/**
+ * Markdown Materializer Bidirectional Sync Tests
+ *
+ * Tests the `pushFromMarkdown` and `pullToMarkdown` methods added to
+ * `createMarkdownMaterializer`. Uses an in-memory IO adapter and real
+ * Yjs workspace so the materializer exercises actual table set/get paths.
+ *
+ * Key behaviors:
+ * - pushFromMarkdown reads `.md` files, parses frontmatter, and calls table.set()
+ * - pushFromMarkdown skips non-`.md` files and files without valid frontmatter
+ * - pushFromMarkdown reports errors for unreadable files
+ * - pushFromMarkdown uses custom deserialize callback when provided
+ * - pushFromMarkdown silently skips tables whose directories don't exist
+ * - pullToMarkdown re-serializes all valid rows to disk
+ * - pullToMarkdown uses custom serialize callback when provided
+ * - Round-trip: pullToMarkdown → pushFromMarkdown preserves data
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { type } from 'arktype';
+import { createWorkspace, defineTable } from '../../../workspace/index.js';
+import { createMarkdownMaterializer } from './materializer.js';
+import type { MaterializerIO, MaterializerYaml } from './materializer.js';
+
+// ============================================================================
+// Test Table Definitions
+// ============================================================================
+
+const postsTable = defineTable(
+	type({ id: 'string', title: 'string', published: 'boolean', _v: '1' }),
+);
+
+const notesTable = defineTable(type({ id: 'string', body: 'string', _v: '1' }));
+
+// ============================================================================
+// In-Memory IO + YAML Adapters
+// ============================================================================
+
+type MemoryFS = Map<string, string | string[]>;
+
+function createMemoryIO(fs: MemoryFS): MaterializerIO {
+	return {
+		async mkdir(dir) {
+			if (!fs.has(dir)) fs.set(dir, []);
+		},
+		async writeFile(path, content) {
+			fs.set(path, content);
+			// Track filename in parent directory listing
+			const lastSlash = path.lastIndexOf('/');
+			const parentDir = path.slice(0, lastSlash);
+			const filename = path.slice(lastSlash + 1);
+			const entries = fs.get(parentDir);
+			if (Array.isArray(entries) && !entries.includes(filename)) {
+				entries.push(filename);
+			}
+		},
+		async readFile(path) {
+			const content = fs.get(path);
+			if (typeof content !== 'string') throw new Error(`ENOENT: ${path}`);
+			return content;
+		},
+		async readdir(dir) {
+			const entries = fs.get(dir);
+			if (!Array.isArray(entries)) throw new Error(`ENOENT: ${dir}`);
+			return [...entries];
+		},
+		async removeFile(path) {
+			fs.delete(path);
+			// Clean up parent directory listing
+			const lastSlash = path.lastIndexOf('/');
+			const parentDir = path.slice(0, lastSlash);
+			const filename = path.slice(lastSlash + 1);
+			const entries = fs.get(parentDir);
+			if (Array.isArray(entries)) {
+				const idx = entries.indexOf(filename);
+				if (idx !== -1) entries.splice(idx, 1);
+			}
+		},
+		joinPath(...segments) {
+			return segments.join('/');
+		},
+	};
+}
+
+function createTestYaml(): MaterializerYaml {
+	const { YAML } = require('bun') as typeof import('bun');
+	return {
+		stringify: (obj) => YAML.stringify(obj, null, 2) as string,
+		parse: (str) => YAML.parse(str) as unknown,
+	};
+}
+
+// ============================================================================
+// Setup
+// ============================================================================
+
+function setup(options?: {
+	tables?: Array<{
+		name: string;
+		config?: Parameters<
+			ReturnType<typeof createMarkdownMaterializer>['table']
+		>[1];
+	}>;
+}) {
+	const fs: MemoryFS = new Map();
+	const io = createMemoryIO(fs);
+	const yaml = createTestYaml();
+
+	const workspace = createWorkspace({
+		id: 'test.materializer',
+		tables: { posts: postsTable, notes: notesTable },
+	}).withWorkspaceExtension('materializer', (ctx) => {
+		const materializer = createMarkdownMaterializer(ctx, {
+			dir: '/test-data',
+			io,
+			yaml,
+		});
+
+		const tablesToRegister = options?.tables ?? [
+			{ name: 'posts' },
+			{ name: 'notes' },
+		];
+		for (const { name, config } of tablesToRegister) {
+			materializer.table(name, config);
+		}
+
+		return materializer;
+	});
+
+	return { fs, workspace };
+}
+
+/**
+ * Seed in-memory filesystem with markdown files for a table directory.
+ * Each entry is `[filename, content]`.
+ */
+function seedFiles(fs: MemoryFS, dir: string, files: Array<[string, string]>) {
+	const filenames: string[] = [];
+	for (const [filename, content] of files) {
+		fs.set(`${dir}/${filename}`, content);
+		filenames.push(filename);
+	}
+	fs.set(dir, filenames);
+}
+
+// ============================================================================
+// pushFromMarkdown Tests
+// ============================================================================
+
+describe('pushFromMarkdown', () => {
+	test('imports markdown files into workspace tables', async () => {
+		const { fs, workspace } = setup({ tables: [{ name: 'posts' }] });
+		await workspace.whenReady;
+
+		seedFiles(fs, '/test-data/posts', [
+			[
+				'hello.md',
+				'---\nid: post-1\ntitle: Hello World\npublished: true\n_v: 1\n---\n',
+			],
+			[
+				'draft.md',
+				'---\nid: post-2\ntitle: Draft Post\npublished: false\n_v: 1\n---\n',
+			],
+		]);
+
+		const result = await workspace.extensions.materializer.pushFromMarkdown();
+
+		expect(result.imported).toBe(2);
+		expect(result.skipped).toBe(0);
+		expect(result.errors).toEqual([]);
+
+		const post1 = workspace.tables.posts.get('post-1');
+		expect(post1.status).toBe('valid');
+		if (post1.status === 'valid') {
+			expect(post1.row.title).toBe('Hello World');
+			expect(post1.row.published).toBe(true);
+		}
+
+		const post2 = workspace.tables.posts.get('post-2');
+		expect(post2.status).toBe('valid');
+		if (post2.status === 'valid') {
+			expect(post2.row.title).toBe('Draft Post');
+		}
+	});
+
+	test('skips non-.md files', async () => {
+		const { fs, workspace } = setup({ tables: [{ name: 'posts' }] });
+		await workspace.whenReady;
+
+		seedFiles(fs, '/test-data/posts', [
+			['valid.md', '---\nid: p1\ntitle: Valid\npublished: false\n_v: 1\n---\n'],
+			['readme.txt', 'not a markdown file'],
+			['data.json', '{"id": "test"}'],
+		]);
+
+		const result = await workspace.extensions.materializer.pushFromMarkdown();
+
+		expect(result.imported).toBe(1);
+		expect(result.skipped).toBe(0);
+	});
+
+	test('skips files without valid frontmatter', async () => {
+		const { fs, workspace } = setup({ tables: [{ name: 'posts' }] });
+		await workspace.whenReady;
+
+		seedFiles(fs, '/test-data/posts', [
+			['valid.md', '---\nid: p1\ntitle: Valid\npublished: false\n_v: 1\n---\n'],
+			['no-frontmatter.md', '# Just a heading\n\nSome content\n'],
+		]);
+
+		const result = await workspace.extensions.materializer.pushFromMarkdown();
+
+		expect(result.imported).toBe(1);
+		expect(result.skipped).toBe(1);
+	});
+
+	test('reports errors for unreadable files', async () => {
+		const { fs, workspace } = setup({ tables: [{ name: 'posts' }] });
+		await workspace.whenReady;
+
+		// Seed directory listing with a file that doesn't exist in fs
+		fs.set('/test-data/posts', ['ghost.md']);
+
+		const result = await workspace.extensions.materializer.pushFromMarkdown();
+
+		expect(result.imported).toBe(0);
+		expect(result.errors.length).toBe(1);
+		expect(result.errors[0]).toContain('ghost.md');
+	});
+
+	test('silently skips tables whose directories do not exist', async () => {
+		const { workspace } = setup({ tables: [{ name: 'posts' }] });
+		await workspace.whenReady;
+
+		// Don't seed any filesystem entries — directory doesn't exist
+		const result = await workspace.extensions.materializer.pushFromMarkdown();
+
+		expect(result.imported).toBe(0);
+		expect(result.skipped).toBe(0);
+		expect(result.errors).toEqual([]);
+	});
+
+	test('uses custom deserialize callback', async () => {
+		const { fs, workspace } = setup({
+			tables: [
+				{
+					name: 'notes',
+					config: {
+						deserialize: (parsed) => ({
+							id: parsed.frontmatter.id as string,
+							body: parsed.body ?? '',
+							_v: 1 as const,
+						}),
+					},
+				},
+			],
+		});
+		await workspace.whenReady;
+
+		seedFiles(fs, '/test-data/notes', [
+			['my-note.md', '---\nid: note-1\n---\n\nThis is the body content\n'],
+		]);
+
+		const result = await workspace.extensions.materializer.pushFromMarkdown();
+
+		expect(result.imported).toBe(1);
+
+		const note = workspace.tables.notes.get('note-1');
+		expect(note.status).toBe('valid');
+		if (note.status === 'valid') {
+			expect(note.row.body).toBe('This is the body content');
+		}
+	});
+
+	test('uses custom table directory', async () => {
+		const { fs, workspace } = setup({
+			tables: [{ name: 'posts', config: { dir: 'blog' } }],
+		});
+		await workspace.whenReady;
+
+		seedFiles(fs, '/test-data/blog', [
+			['hello.md', '---\nid: p1\ntitle: Hello\npublished: false\n_v: 1\n---\n'],
+		]);
+
+		const result = await workspace.extensions.materializer.pushFromMarkdown();
+
+		expect(result.imported).toBe(1);
+		expect(workspace.tables.posts.has('p1')).toBe(true);
+	});
+
+	test('overwrites existing rows (set is insert-or-replace)', async () => {
+		const { fs, workspace } = setup({ tables: [{ name: 'posts' }] });
+		await workspace.whenReady;
+
+		// First import: seed a file and import it
+		seedFiles(fs, '/test-data/posts', [
+			['p1.md', '---\nid: p1\ntitle: Original\npublished: false\n_v: 1\n---\n'],
+		]);
+
+		const first = await workspace.extensions.materializer.pushFromMarkdown();
+		expect(first.imported).toBe(1);
+
+		const originalPost = workspace.tables.posts.get('p1');
+		expect(originalPost.status).toBe('valid');
+		if (originalPost.status === 'valid') {
+			expect(originalPost.row.title).toBe('Original');
+		}
+
+		// Flush observer microtasks (observer writes files on table.set() from the first push)
+		await Bun.sleep(0);
+
+		// Second import: overwrite the same file with different data
+		fs.set('/test-data/posts/p1.md', '---\nid: p1\ntitle: Updated From Disk\npublished: true\n_v: 1\n---\n');
+
+		const second = await workspace.extensions.materializer.pushFromMarkdown();
+		expect(second.imported).toBe(1);
+
+		const updatedPost = workspace.tables.posts.get('p1');
+		expect(updatedPost.status).toBe('valid');
+		if (updatedPost.status === 'valid') {
+			expect(updatedPost.row.title).toBe('Updated From Disk');
+			expect(updatedPost.row.published).toBe(true);
+		}
+	});
+
+	test('imports across multiple tables', async () => {
+		const { fs, workspace } = setup();
+		await workspace.whenReady;
+
+		seedFiles(fs, '/test-data/posts', [
+			['post.md', '---\nid: p1\ntitle: Post\npublished: false\n_v: 1\n---\n'],
+		]);
+		seedFiles(fs, '/test-data/notes', [
+			['note.md', '---\nid: n1\nbody: Note body\n_v: 1\n---\n'],
+		]);
+
+		const result = await workspace.extensions.materializer.pushFromMarkdown();
+
+		expect(result.imported).toBe(2);
+		expect(workspace.tables.posts.has('p1')).toBe(true);
+		expect(workspace.tables.notes.has('n1')).toBe(true);
+	});
+});
+
+// ============================================================================
+// pullToMarkdown Tests
+// ============================================================================
+
+describe('pullToMarkdown', () => {
+	test('writes all valid rows to disk', async () => {
+		const { fs, workspace } = setup({ tables: [{ name: 'posts' }] });
+		await workspace.whenReady;
+
+		workspace.tables.posts.set({
+			id: 'p1',
+			title: 'First',
+			published: true,
+			_v: 1,
+		});
+		workspace.tables.posts.set({
+			id: 'p2',
+			title: 'Second',
+			published: false,
+			_v: 1,
+		});
+
+		const result = await workspace.extensions.materializer.pullToMarkdown();
+
+		expect(result.written).toBe(2);
+
+		// Verify files were written
+		const content1 = fs.get('/test-data/posts/p1.md');
+		expect(typeof content1).toBe('string');
+		expect(content1 as string).toContain('title: First');
+
+		const content2 = fs.get('/test-data/posts/p2.md');
+		expect(typeof content2).toBe('string');
+		expect(content2 as string).toContain('title: Second');
+	});
+
+	test('creates table directory before writing', async () => {
+		const { fs, workspace } = setup({ tables: [{ name: 'posts' }] });
+		await workspace.whenReady;
+
+		workspace.tables.posts.set({
+			id: 'p1',
+			title: 'First',
+			published: false,
+			_v: 1,
+		});
+
+		await workspace.extensions.materializer.pullToMarkdown();
+
+		// Directory should exist
+		expect(fs.has('/test-data/posts')).toBe(true);
+	});
+
+	test('uses custom serialize callback', async () => {
+		const { fs, workspace } = setup({
+			tables: [
+				{
+					name: 'notes',
+					config: {
+						serialize: (row) => ({
+							filename: `${row.id}-custom.md`,
+							content: `---\nid: ${row.id}\n---\n\n${row.body}\n`,
+						}),
+					},
+				},
+			],
+		});
+		await workspace.whenReady;
+
+		workspace.tables.notes.set({ id: 'n1', body: 'Custom body', _v: 1 });
+
+		const result = await workspace.extensions.materializer.pullToMarkdown();
+
+		expect(result.written).toBe(1);
+		expect(fs.has('/test-data/notes/n1-custom.md')).toBe(true);
+
+		const content = fs.get('/test-data/notes/n1-custom.md') as string;
+		expect(content).toContain('Custom body');
+	});
+
+	test('uses custom table directory', async () => {
+		const { fs, workspace } = setup({
+			tables: [{ name: 'posts', config: { dir: 'blog' } }],
+		});
+		await workspace.whenReady;
+
+		workspace.tables.posts.set({
+			id: 'p1',
+			title: 'Blog Post',
+			published: false,
+			_v: 1,
+		});
+
+		await workspace.extensions.materializer.pullToMarkdown();
+
+		expect(fs.has('/test-data/blog/p1.md')).toBe(true);
+	});
+
+	test('writes nothing when table is empty', async () => {
+		const { workspace } = setup({ tables: [{ name: 'posts' }] });
+		await workspace.whenReady;
+
+		const result = await workspace.extensions.materializer.pullToMarkdown();
+
+		expect(result.written).toBe(0);
+	});
+
+	test('writes across multiple tables', async () => {
+		const { fs, workspace } = setup();
+		await workspace.whenReady;
+
+		workspace.tables.posts.set({
+			id: 'p1',
+			title: 'Post',
+			published: false,
+			_v: 1,
+		});
+		workspace.tables.notes.set({ id: 'n1', body: 'Note', _v: 1 });
+
+		const result = await workspace.extensions.materializer.pullToMarkdown();
+
+		expect(result.written).toBe(2);
+		expect(fs.has('/test-data/posts/p1.md')).toBe(true);
+		expect(fs.has('/test-data/notes/n1.md')).toBe(true);
+	});
+});
+
+// ============================================================================
+// Round-Trip Tests
+// ============================================================================
+
+describe('round-trip', () => {
+	test('pullToMarkdown then pushFromMarkdown on fresh workspace preserves row data', async () => {
+		const fs: MemoryFS = new Map();
+		const io = createMemoryIO(fs);
+		const yaml = createTestYaml();
+
+		// First workspace: populate and pull to disk
+		const workspace1 = createWorkspace({
+			id: 'test.roundtrip.1',
+			tables: { posts: postsTable, notes: notesTable },
+		}).withWorkspaceExtension('materializer', (ctx) =>
+			createMarkdownMaterializer(ctx, { dir: '/test-data', io, yaml }).table('posts'),
+		);
+		await workspace1.whenReady;
+
+		workspace1.tables.posts.set({ id: 'p1', title: 'Round Trip', published: true, _v: 1 });
+		workspace1.tables.posts.set({ id: 'p2', title: 'Another', published: false, _v: 1 });
+
+		await workspace1.extensions.materializer.pullToMarkdown();
+		workspace1.extensions.materializer.dispose();
+
+		// Second workspace: fresh instance, push from the same FS
+		const workspace2 = createWorkspace({
+			id: 'test.roundtrip.2',
+			tables: { posts: postsTable, notes: notesTable },
+		}).withWorkspaceExtension('materializer', (ctx) =>
+			createMarkdownMaterializer(ctx, { dir: '/test-data', io, yaml }).table('posts'),
+		);
+		await workspace2.whenReady;
+
+		const result = await workspace2.extensions.materializer.pushFromMarkdown();
+		expect(result.imported).toBe(2);
+
+		const p1 = workspace2.tables.posts.get('p1');
+		expect(p1.status).toBe('valid');
+		if (p1.status === 'valid') {
+			expect(p1.row.title).toBe('Round Trip');
+			expect(p1.row.published).toBe(true);
+		}
+
+		const p2 = workspace2.tables.posts.get('p2');
+		expect(p2.status).toBe('valid');
+		if (p2.status === 'valid') {
+			expect(p2.row.title).toBe('Another');
+			expect(p2.row.published).toBe(false);
+		}
+	});
+});

--- a/packages/workspace/src/extensions/materializer/markdown/materializer.ts
+++ b/packages/workspace/src/extensions/materializer/markdown/materializer.ts
@@ -89,32 +89,14 @@ function buildMarkdown(
  * and sync have loaded before the initial flush. All `.table()` and `.kv()`
  * calls happen synchronously in the factory closure before `whenReady` resolves.
  *
- * Pass `io` and `yaml` to run in non-Node/Bun runtimes (e.g. Tauri):
+ * Custom `io` and `yaml` adapters can be injected for non-Node/Bun runtimes or testing.
  *
  * @example
  * ```typescript
- * // Bun/Node — defaults just work
  * .withWorkspaceExtension('materializer', (ctx) =>
  *   createMarkdownMaterializer(ctx, { dir: './data' })
  *     .table('posts', { serialize: slugFilename('title') })
  *     .kv(),
- * )
- *
- * // Tauri — inject filesystem + YAML adapters
- * .withWorkspaceExtension('materializer', (ctx) =>
- *   createMarkdownMaterializer(ctx, {
- *     dir: recordingsPath,
- *     io: {
- *       mkdir: (dir) => tauriMkdir(dir, { recursive: true }),
- *       writeFile: tauriWriteTextFile,
- *       readFile: (path) => tauriReadTextFile(path),
- *       readdir: (dir) => tauriReadDir(dir).then(entries => entries.map(e => e.name)),
- *       removeFile: (path) => tauriRemove(path).catch(() => {}),
- *       joinPath: (...s) => tauriJoin(...s),
- *     },
- *     yaml: { stringify: (obj) => jsYaml.dump(obj, { lineWidth: -1 }), parse: (str) => jsYaml.load(str) },
- *   })
- *     .table('recordings', { serialize: mySerializer }),
  * )
  * ```
  */

--- a/packages/workspace/src/extensions/materializer/markdown/materializer.ts
+++ b/packages/workspace/src/extensions/materializer/markdown/materializer.ts
@@ -12,6 +12,8 @@ import type { SerializeResult } from './markdown.js';
 export type MaterializerIO = {
 	mkdir(dir: string): Promise<void>;
 	writeFile(path: string, content: string): Promise<void>;
+	readFile(path: string): Promise<string>;
+	readdir(dir: string): Promise<string[]>;
 	removeFile(path: string): Promise<void>;
 	joinPath(...segments: string[]): MaybePromise<string>;
 };
@@ -24,6 +26,7 @@ export type MaterializerIO = {
  */
 export type MaterializerYaml = {
 	stringify(obj: Record<string, unknown>): string;
+	parse(yaml: string): unknown;
 };
 
 /** Lazily resolve Node/Bun default IO. Only imported when actually used. */
@@ -35,6 +38,8 @@ function createDefaultIO(): MaterializerIO {
 	return {
 		mkdir: (dir) => fs.mkdir(dir, { recursive: true }),
 		writeFile: (filePath, content) => fs.writeFile(filePath, content),
+		readFile: (filePath) => fs.readFile(filePath, 'utf-8'),
+		readdir: (dir) => fs.readdir(dir),
 		removeFile: (filePath) => fs.unlink(filePath).catch(() => {}),
 		joinPath: (...segments) => path.join(...segments),
 	};
@@ -45,6 +50,7 @@ function createDefaultYaml(): MaterializerYaml {
 	const { YAML } = require('bun') as typeof import('bun');
 	return {
 		stringify: (obj) => YAML.stringify(obj, null, 2) as string,
+		parse: (str) => YAML.parse(str) as unknown,
 	};
 }
 
@@ -73,7 +79,7 @@ function buildMarkdown(
 }
 
 /**
- * Create a one-way materializer that writes workspace data to files on disk.
+ * Create a bidirectional markdown materializer for workspace data.
  *
  * Nothing materializes by default. Call `.table()` to opt in per table and
  * `.kv()` to opt in KV. Each `.table()` call validates the table name against
@@ -101,10 +107,12 @@ function buildMarkdown(
  *     io: {
  *       mkdir: (dir) => tauriMkdir(dir, { recursive: true }),
  *       writeFile: tauriWriteTextFile,
+ *       readFile: (path) => tauriReadTextFile(path),
+ *       readdir: (dir) => tauriReadDir(dir).then(entries => entries.map(e => e.name)),
  *       removeFile: (path) => tauriRemove(path).catch(() => {}),
  *       joinPath: (...s) => tauriJoin(...s),
  *     },
- *     yaml: { stringify: (obj) => jsYaml.dump(obj, { lineWidth: -1 }) },
+ *     yaml: { stringify: (obj) => jsYaml.dump(obj, { lineWidth: -1 }), parse: (str) => jsYaml.load(str) },
  *   })
  *     .table('recordings', { serialize: mySerializer }),
  * )
@@ -135,6 +143,10 @@ export function createMarkdownMaterializer<
 			serialize?: TTables[TName] extends TableHelper<infer TRow>
 				? (row: TRow) => MaybePromise<SerializeResult>
 				: never;
+			deserialize?: (parsed: {
+				frontmatter: Record<string, unknown>;
+				body: string | undefined;
+			}) => MaybePromise<TTables[TName] extends TableHelper<infer TRow> ? TRow : never>;
 		};
 	};
 
@@ -149,6 +161,11 @@ export function createMarkdownMaterializer<
 				serialize?: TTables[TName] extends TableHelper<infer TRow>
 					? (row: TRow) => MaybePromise<SerializeResult>
 					: never;
+				/** Parse a markdown file back into a table row. Required for `pushFromMarkdown`. Default: uses frontmatter fields directly. */
+				deserialize?: (parsed: {
+					frontmatter: Record<string, unknown>;
+					body: string | undefined;
+				}) => MaybePromise<TTables[TName] extends TableHelper<infer TRow> ? TRow : never>;
 			},
 		): MaterializerBuilder;
 		/**
@@ -162,6 +179,23 @@ export function createMarkdownMaterializer<
 		kv(config?: {
 			serialize?: (data: Record<string, unknown>) => SerializeResult;
 		}): MaterializerBuilder;
+		/**
+		 * Read `.md` files from disk and import them into the Yjs workspace via `table.set()`.
+		 *
+		 * Each file is parsed for YAML frontmatter and an optional body. The `deserialize`
+		 * callback (if provided per table) converts the parsed result to a row. When no
+		 * `deserialize` is configured, frontmatter fields are used as the row directly.
+		 *
+		 * **This overwrites existing rows**—`table.set()` is insert-or-replace.
+		 */
+		pushFromMarkdown(): Promise<{ imported: number; skipped: number; errors: string[] }>;
+		/**
+		 * Re-materialize all Yjs table data to markdown files on disk.
+		 *
+		 * Reads every valid row from each registered table, serializes it,
+		 * and writes the result to disk. Does not remove orphaned files.
+		 */
+		pullToMarkdown(): Promise<{ written: number }>;
 		whenReady: Promise<void>;
 		dispose(): void;
 	};
@@ -272,6 +306,37 @@ export function createMarkdownMaterializer<
 		unsubscribers.push(unsubscribe);
 	};
 
+	/** Regex for extracting YAML frontmatter from markdown content. */
+	const FRONTMATTER_PATTERN =
+		/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/;
+
+	/** Parse frontmatter + body from a markdown string using the injected yaml adapter. */
+	function parseFrontmatter(content: string): {
+		frontmatter: Record<string, unknown>;
+		body: string | undefined;
+	} | null {
+		const input = content.charCodeAt(0) === 0xfeff ? content.slice(1) : content;
+		const match = input.match(FRONTMATTER_PATTERN);
+		if (!match) return null;
+
+		const frontmatter = yaml.parse(match[1]);
+		if (typeof frontmatter !== 'object' || frontmatter === null) return null;
+
+		const rawBody = input
+			.slice(match[0].length)
+			.replace(/^\r?\n/, '')
+			.replace(/\r?\n$/, '');
+
+		return {
+			frontmatter: frontmatter as Record<string, unknown>,
+			body: rawBody.length > 0 ? rawBody : undefined,
+		};
+	}
+
+	/** Resolve the base directory, handling string or async getter. */
+	const resolveDir = async () =>
+		typeof config.dir === 'function' ? await config.dir() : config.dir;
+
 	const builder: MaterializerBuilder = {
 		table(name, tableConfig) {
 			tableNames.add(name);
@@ -283,12 +348,85 @@ export function createMarkdownMaterializer<
 			kvConfig = nextKvConfig;
 			return builder;
 		},
+		async pushFromMarkdown() {
+			const dir = await resolveDir();
+			let imported = 0;
+			let skipped = 0;
+			const errors: string[] = [];
+
+			for (const name of tableNames) {
+				const table = ctx.tables[name];
+				const tableConfig = tableConfigs[name];
+				const directory = await io.joinPath(dir, tableConfig?.dir ?? name);
+
+				let entries: string[];
+				try {
+					entries = await io.readdir(directory);
+				} catch {
+					continue;
+				}
+
+				for (const filename of entries) {
+					if (!filename.endsWith('.md')) continue;
+
+					let content: string;
+					try {
+						content = await io.readFile(await io.joinPath(directory, filename));
+					} catch (error) {
+						errors.push(`Failed to read ${filename}: ${error}`);
+						continue;
+					}
+
+					const parsed = parseFrontmatter(content);
+					if (!parsed) {
+						skipped++;
+						continue;
+					}
+
+					try {
+						const deserialize = tableConfig?.deserialize
+							?? ((p: { frontmatter: Record<string, unknown> }) => p.frontmatter);
+						const row = await deserialize(parsed);
+						table.set(row);
+						imported++;
+					} catch (error) {
+						errors.push(`Failed to import ${filename}: ${error}`);
+					}
+				}
+			}
+
+			return { imported, skipped, errors };
+		},
+		async pullToMarkdown() {
+			const dir = await resolveDir();
+			let written = 0;
+
+			for (const name of tableNames) {
+				const table = ctx.tables[name];
+				const tableConfig = tableConfigs[name];
+				const directory = await io.joinPath(dir, tableConfig?.dir ?? name);
+
+				const serialize: (row: TableRow<typeof name>) => MaybePromise<SerializeResult> =
+					tableConfig?.serialize ??
+					((row) => ({
+						filename: `${row.id}.md`,
+						content: buildMarkdown(yaml, { ...row }),
+					}));
+
+				await io.mkdir(directory);
+
+				for (const row of table.getAllValid()) {
+					const result = await serialize(row);
+					await io.writeFile(await io.joinPath(directory, result.filename), result.content);
+					written++;
+				}
+			}
+
+			return { written };
+		},
 		whenReady: (async () => {
 			await ctx.whenReady;
-			const dir =
-				typeof config.dir === 'function'
-					? await config.dir()
-					: config.dir;
+			const dir = await resolveDir();
 			await io.mkdir(dir);
 
 			for (const name of tableNames) {


### PR DESCRIPTION
The markdown materializer only ever wrote to disk. Yjs rows became `.md` files, but there was no way to go the other direction—no way to seed a workspace from existing markdown, no way to re-import after an external edit. This PR closes that gap.

`createMarkdownMaterializer` now exposes two new methods. `pushFromMarkdown()` reads `.md` files from each registered table's directory, parses the YAML frontmatter and body using the injected yaml adapter, runs an optional `deserialize` callback to convert frontmatter back into a row, and calls `table.set()`. It returns `{ imported, skipped, errors }` so callers can see exactly what happened. `pullToMarkdown()` goes the other way: it re-serializes all valid Yjs rows to disk on demand, acting as a manual re-materialization trigger. It returns `{ written }` and deliberately skips orphan cleanup, since the live observer already handles deletions.

A few internal things changed to support this. `parseFrontmatter()` now uses the injected `yaml.parse` instead of hardcoding Bun's YAML, making it runtime-agnostic and consistent with how the rest of the materializer handles its dependencies. `resolveDir()` was extracted to avoid repeating the same directory resolution logic across `whenReady`, `pushFromMarkdown`, and `pullToMarkdown`. An unused `documents?: unknown` field was also removed from the ctx parameter.

`MaterializerIO` gained `readFile(path)` and `readdir(dir)` (both default to Node's `fs/promises`), and `MaterializerYaml` gained `parse(yaml)` (defaults to `YAML.parse` from Bun). These are required fields, so any external consumer implementing a custom adapter will get a TypeScript compile error pointing them at exactly what to add. No in-repo consumers are affected since both playground configs use the defaults.

16 new tests cover the full surface: round-trip import/export, custom deserialize callbacks, skipping non-`.md` files and invalid frontmatter, error reporting for unreadable files, multi-table import, and insert-or-replace semantics.