### PR TITLE
feat(workspace,cli): extension action introspection for describeWorkspace and CLI

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -6,7 +6,7 @@
  * the result.
  */
 
-import type { Action } from '@epicenter/workspace';
+import type { Action, Actions } from '@epicenter/workspace';
 import { iterateActions } from '@epicenter/workspace';
 import type { Argv } from 'yargs';
 import {
@@ -41,23 +41,46 @@ export const runActionCommand = defineCommand({
 		await runCommand(
 			{ dir: argv.dir, workspaceId: argv.workspace },
 			async (client) => {
-				if (!client.actions) {
-					throw new Error('This workspace has no actions defined');
+				// Find action by dot-path — check client.actions first, then extensions
+				let found: Action | undefined;
+				if (client.actions) {
+					for (const [action, path] of iterateActions(client.actions)) {
+						if (path.join('.') === actionPath.join('.')) {
+							found = action;
+							break;
+						}
+					}
 				}
 
-				// Find action by dot-path
-				let found: Action | undefined;
-				for (const [action, path] of iterateActions(client.actions)) {
-					if (path.join('.') === actionPath.join('.')) {
-						found = action;
-						break;
+				// Fall through to extensions if not found in actions
+				if (!found && client.extensions) {
+					for (const [extKey, extValue] of Object.entries(client.extensions)) {
+						if (extValue == null || typeof extValue !== 'object') continue;
+						for (const [action, path] of iterateActions(extValue as Actions)) {
+							const extPath = [extKey, ...path].join('.');
+							if (extPath === actionPath.join('.')) {
+								found = action;
+								break;
+							}
+						}
+						if (found) break;
 					}
 				}
 
 				if (!found) {
 					const available: string[] = [];
-					for (const [, path] of iterateActions(client.actions)) {
-						available.push(path.join('.'));
+					if (client.actions) {
+						for (const [, path] of iterateActions(client.actions)) {
+							available.push(path.join('.'));
+						}
+					}
+					if (client.extensions) {
+						for (const [extKey, extValue] of Object.entries(client.extensions)) {
+							if (extValue == null || typeof extValue !== 'object') continue;
+							for (const [, path] of iterateActions(extValue as Actions)) {
+								available.push([extKey, ...path].join('.'));
+							}
+						}
 					}
 					const msg =
 						available.length > 0

--- a/packages/workspace/src/extensions/materializer/sqlite/fts.ts
+++ b/packages/workspace/src/extensions/materializer/sqlite/fts.ts
@@ -116,23 +116,25 @@ export async function ftsSearch(
 	try {
 		const qt = quoteIdentifier(tableName);
 		const qfts = quoteIdentifier(ftsTableName);
-		const rows = await db
-			.prepare(
-				`SELECT ${qt}.${quoteIdentifier('id')} AS id,\n` +
-					`  snippet(${qfts}, ${snippetColumnIndex}, '<mark>', '</mark>', '...', 64) AS snippet,\n` +
-					`  rank\n` +
-					`FROM ${qfts}\n` +
-					`JOIN ${qt} ON ${qt}.rowid = ${qfts}.rowid\n` +
-					`WHERE ${qfts} MATCH ?\n` +
-					`ORDER BY rank LIMIT ?`,
-			)
-			.all(trimmed, limit);
+		const stmt = await db.prepare(
+			`SELECT ${qt}.${quoteIdentifier('id')} AS id,\n` +
+				`  snippet(${qfts}, ${snippetColumnIndex}, '<mark>', '</mark>', '...', 64) AS snippet,\n` +
+				`  rank\n` +
+				`FROM ${qfts}\n` +
+				`JOIN ${qt} ON ${qt}.rowid = ${qfts}.rowid\n` +
+				`WHERE ${qfts} MATCH ?\n` +
+				`ORDER BY rank LIMIT ?`,
+		);
+		const rows = await stmt.all(trimmed, limit);
 
-		return rows.map((row) => ({
-			id: String(row.id),
-			snippet: String(row.snippet ?? ''),
-			rank: Number(row.rank ?? 0),
-		}));
+		return rows.map((row) => {
+			const r = row as Record<string, unknown>;
+			return {
+				id: String(r.id),
+				snippet: String(r.snippet ?? ''),
+				rank: Number(r.rank ?? 0),
+			};
+		});
 	} catch (error: unknown) {
 		console.warn('[createSqliteMaterializer] FTS search failed.', error);
 		return [];

--- a/packages/workspace/src/extensions/materializer/sqlite/sqlite.test.ts
+++ b/packages/workspace/src/extensions/materializer/sqlite/sqlite.test.ts
@@ -21,6 +21,8 @@ import { type } from 'arktype';
 import { createWorkspace, defineTable } from '../../../workspace/index.js';
 import { createSqliteMaterializer } from './sqlite.js';
 import type { MirrorDatabase } from './types.js';
+import { isAction, isQuery, isMutation } from '../../../shared/actions.js';
+import type { MirrorDatabase } from './types.js';
 
 const postsTable = defineTable(
 	type({ id: 'string', _v: '1', title: 'string', 'published?': 'boolean' }),
@@ -326,7 +328,7 @@ describe('createSqliteMaterializer', () => {
 
 				expect(getRows(testSetup.db, 'posts')).toEqual([]);
 
-				await testSetup.workspace.extensions.sqlite.rebuild();
+				await testSetup.workspace.extensions.sqlite.rebuild({});
 
 				expect(getRows(testSetup.db, 'posts')).toEqual([
 					{ id: 'post-1', _v: 1, published: null, title: 'Persisted in Yjs' },
@@ -357,7 +359,7 @@ describe('createSqliteMaterializer', () => {
 				expect(getRows(testSetup.db, 'posts')).toEqual([]);
 				expect(getRows(testSetup.db, 'notes')).toHaveLength(1);
 
-				await testSetup.workspace.extensions.sqlite.rebuild('posts');
+				await testSetup.workspace.extensions.sqlite.rebuild({ table: 'posts' });
 
 				expect(getRows(testSetup.db, 'posts')).toEqual([
 					{ id: 'post-1', _v: 1, published: null, title: 'Post row' },
@@ -375,10 +377,9 @@ describe('createSqliteMaterializer', () => {
 				await testSetup.workspace.extensions.sqlite.whenReady;
 
 				await expect(
-					testSetup.workspace.extensions.sqlite.rebuild(
-						// @ts-expect-error -- testing runtime guard for invalid table name
-						'nonexistent',
-					),
+					testSetup.workspace.extensions.sqlite.rebuild({
+						table: 'nonexistent',
+					}),
 				).rejects.toThrow('not in the materialized table set');
 			} finally {
 				await cleanup(testSetup);
@@ -404,8 +405,8 @@ describe('createSqliteMaterializer', () => {
 
 				await testSetup.workspace.extensions.sqlite.whenReady;
 
-				expect(await testSetup.workspace.extensions.sqlite.count('posts')).toBe(2);
-				expect(await testSetup.workspace.extensions.sqlite.count('notes')).toBe(0);
+				expect(await testSetup.workspace.extensions.sqlite.count({ table: 'posts' })).toBe(2);
+				expect(await testSetup.workspace.extensions.sqlite.count({ table: 'notes' })).toBe(0);
 			} finally {
 				await cleanup(testSetup);
 			}
@@ -418,10 +419,9 @@ describe('createSqliteMaterializer', () => {
 				await testSetup.workspace.extensions.sqlite.whenReady;
 
 				expect(
-					await testSetup.workspace.extensions.sqlite.count(
-						// @ts-expect-error -- testing runtime guard for invalid table name
-						'nonexistent',
-					),
+					await testSetup.workspace.extensions.sqlite.count({
+						table: 'nonexistent',
+					}),
 				).toBe(0);
 			} finally {
 				await cleanup(testSetup);
@@ -476,7 +476,7 @@ describe('createSqliteMaterializer', () => {
 				await testSetup.workspace.extensions.sqlite.whenReady;
 
 				expect(
-					await testSetup.workspace.extensions.sqlite.search('posts', 'hello'),
+					await testSetup.workspace.extensions.sqlite.search({ table: 'posts', query: 'hello' }),
 				).toEqual([]);
 			} finally {
 				await cleanup(testSetup);
@@ -506,11 +506,11 @@ describe('createSqliteMaterializer', () => {
 
 					await testSetup.workspace.extensions.sqlite.whenReady;
 
-					const results = await testSetup.workspace.extensions.sqlite.search(
-						'posts',
-						'mirror',
-						{ snippetColumn: 'title', limit: 10 },
-					);
+					const results = await testSetup.workspace.extensions.sqlite.search({
+						table: 'posts',
+						query: 'mirror',
+						limit: 10,
+					});
 
 					expect(results).toHaveLength(1);
 					expect(results[0]?.id).toBe('post-1');
@@ -521,5 +521,31 @@ describe('createSqliteMaterializer', () => {
 				}
 			});
 		}
+	});
+
+	// ============================================================================
+	// ACTION BRAND Tests
+	// ============================================================================
+
+	describe('action brand', () => {
+		test('search, count, rebuild are detectable via isAction()', async () => {
+			const testSetup = setup();
+
+			try {
+				const { sqlite } = testSetup.workspace.extensions;
+				expect(isAction(sqlite.search)).toBe(true);
+				expect(isAction(sqlite.count)).toBe(true);
+				expect(isAction(sqlite.rebuild)).toBe(true);
+
+				expect(isQuery(sqlite.search)).toBe(true);
+				expect(isQuery(sqlite.count)).toBe(true);
+				expect(isMutation(sqlite.rebuild)).toBe(true);
+
+				// Lifecycle hooks are NOT actions
+				expect(isAction(sqlite.dispose)).toBe(false);
+			} finally {
+				await cleanup(testSetup);
+			}
+		});
 	});
 });

--- a/packages/workspace/src/extensions/materializer/sqlite/sqlite.test.ts
+++ b/packages/workspace/src/extensions/materializer/sqlite/sqlite.test.ts
@@ -119,11 +119,11 @@ async function waitForSyncCycle() {
 }
 
 function getRows(db: TestDb, tableName: string) {
-	return db.prepare(`SELECT * FROM "${tableName}" ORDER BY "id"`).all() as Record<string, unknown>[];
+	return db.raw.prepare(`SELECT * FROM "${tableName}" ORDER BY "id"`).all() as Record<string, unknown>[];
 }
 
 function hasTable(db: TestDb, tableName: string) {
-	const row = db
+	const row = db.raw
 		.prepare('SELECT name FROM sqlite_master WHERE type = ? AND name = ?')
 		.get('table', tableName);
 	return row != null;

--- a/packages/workspace/src/extensions/materializer/sqlite/sqlite.test.ts
+++ b/packages/workspace/src/extensions/materializer/sqlite/sqlite.test.ts
@@ -22,7 +22,6 @@ import { createWorkspace, defineTable } from '../../../workspace/index.js';
 import { createSqliteMaterializer } from './sqlite.js';
 import type { MirrorDatabase } from './types.js';
 import { isAction, isQuery, isMutation } from '../../../shared/actions.js';
-import type { MirrorDatabase } from './types.js';
 
 const postsTable = defineTable(
 	type({ id: 'string', _v: '1', title: 'string', 'published?': 'boolean' }),
@@ -510,7 +509,7 @@ describe('createSqliteMaterializer', () => {
 						table: 'posts',
 						query: 'mirror',
 						limit: 10,
-					});
+					}) as Array<{ id: string; snippet: string; rank: number }>;
 
 					expect(results).toHaveLength(1);
 					expect(results[0]?.id).toBe('post-1');

--- a/packages/workspace/src/extensions/materializer/sqlite/sqlite.ts
+++ b/packages/workspace/src/extensions/materializer/sqlite/sqlite.ts
@@ -15,6 +15,8 @@
 
 import type { StandardJSONSchemaV1 } from '@standard-schema/spec';
 import { standardSchemaToJsonSchema } from '../../../shared/standard-schema.js';
+import Type from 'typebox';
+import { defineMutation, defineQuery } from '../../../shared/actions.js';
 import type { BaseRow, TableHelper } from '../../../workspace/types.js';
 import { generateDdl, quoteIdentifier } from './ddl.js';
 import { ftsSearch, setupFtsTable } from './fts.js';
@@ -394,14 +396,13 @@ export function createSqliteMaterializer<
 		): MaterializerBuilder;
 		whenReady: Promise<void>;
 		dispose(): void;
-		search(
-			table: keyof TTables & string,
-			query: string,
-			options?: SearchOptions,
-		): Promise<SearchResult[]>;
-		count(table: keyof TTables & string): Promise<number>;
-		rebuild(table?: keyof TTables & string): Promise<void>;
 		db: MirrorDatabase;
+		/** FTS5 search across a materialized table. Only present when at least one table has `fts` configured. */
+		search: ReturnType<typeof defineQuery>;
+		/** Row count for a materialized table. */
+		count: ReturnType<typeof defineQuery>;
+		/** Rebuild all materialized tables from Yjs source of truth. */
+		rebuild: ReturnType<typeof defineMutation>;
 	};
 
 	const builder: MaterializerBuilder = {
@@ -411,10 +412,34 @@ export function createSqliteMaterializer<
 		},
 		whenReady: initialize(),
 		dispose,
-		search,
-		count,
-		rebuild,
 		db,
+		search: defineQuery({
+			title: 'Full-text search',
+			description: 'FTS5 search across materialized table rows',
+			input: Type.Object({
+				table: Type.String(),
+				query: Type.String(),
+				limit: Type.Optional(Type.Number()),
+			}),
+			handler: ({ table: tableName, query: q, limit: lim }) =>
+				search(tableName, q, lim !== undefined ? { limit: lim } : undefined),
+		}),
+		count: defineQuery({
+			title: 'Row count',
+			description: 'Count rows in a materialized table',
+			input: Type.Object({
+				table: Type.String(),
+			}),
+			handler: ({ table: tableName }) => count(tableName),
+		}),
+		rebuild: defineMutation({
+			title: 'Rebuild materializer',
+			description: 'Drop and rebuild all materialized tables from Yjs source',
+			input: Type.Object({
+				table: Type.Optional(Type.String()),
+			}),
+			handler: ({ table: tableName }) => rebuild(tableName),
+		}),
 	};
 
 	return builder;

--- a/packages/workspace/src/extensions/materializer/sqlite/sqlite.ts
+++ b/packages/workspace/src/extensions/materializer/sqlite/sqlite.ts
@@ -91,15 +91,17 @@ export function createSqliteMaterializer<
 		const values = keys.map((key) => serialize(row[key]));
 		const columns = keys.map(quoteIdentifier).join(', ');
 
-		await db.prepare(
+		const stmt = await db.prepare(
 			`INSERT OR REPLACE INTO ${quoteIdentifier(tableName)} (${columns}) VALUES (${placeholders})`,
-		).run(...values);
+		);
+		await stmt.run(...values);
 	}
 
 	async function deleteRow(tableName: string, id: string) {
-		await db.prepare(
+		const stmt = await db.prepare(
 			`DELETE FROM ${quoteIdentifier(tableName)} WHERE ${quoteIdentifier('id')} = ?`,
-		).run(id);
+		);
+		await stmt.run(id);
 	}
 
 	// ── Full load ────────────────────────────────────────────────
@@ -117,7 +119,7 @@ export function createSqliteMaterializer<
 		const keys = Object.keys(rows[0]!);
 		const placeholders = keys.map(() => '?').join(', ');
 		const columns = keys.map(quoteIdentifier).join(', ');
-		const stmt = db.prepare(
+		const stmt = await db.prepare(
 			`INSERT OR REPLACE INTO ${quoteIdentifier(tableName)} (${columns}) VALUES (${placeholders})`,
 		);
 
@@ -232,9 +234,10 @@ export function createSqliteMaterializer<
 		}
 
 		try {
-			const row = await db
-				.prepare(`SELECT COUNT(*) AS count FROM ${quoteIdentifier(tableName)}`)
-				.get();
+			const stmt = await db.prepare(
+				`SELECT COUNT(*) AS count FROM ${quoteIdentifier(tableName)}`,
+			);
+			const row = await stmt.get() as Record<string, unknown> | null;
 			return Number(row?.count ?? 0);
 		} catch {
 			return 0;

--- a/packages/workspace/src/extensions/materializer/sqlite/types.ts
+++ b/packages/workspace/src/extensions/materializer/sqlite/types.ts
@@ -34,7 +34,7 @@ export type MirrorDatabase = {
 	run(sql: string): MaybePromise<unknown>;
 
 	/** Prepare a reusable statement for repeated reads or writes. */
-	prepare(sql: string): MirrorStatement;
+	prepare(sql: string): MaybePromise<MirrorStatement>;
 };
 
 /**
@@ -55,10 +55,10 @@ export type MirrorStatement = {
 	run(...params: unknown[]): MaybePromise<unknown>;
 
 	/** Fetch all matching rows as plain objects. */
-	all(...params: unknown[]): MaybePromise<Record<string, unknown>[]>;
+	all(...params: unknown[]): MaybePromise<unknown[]>;
 
 	/** Fetch the first matching row, or null if none found. */
-	get(...params: unknown[]): MaybePromise<Record<string, unknown> | null>;
+	get(...params: unknown[]): MaybePromise<unknown>;
 };
 
 /**

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -25,6 +25,7 @@
 
 export type { Action, Actions, Mutation, Query } from './shared/actions';
 export {
+	ACTION_BRAND,
 	defineMutation,
 	defineQuery,
 	isAction,

--- a/packages/workspace/src/shared/actions.ts
+++ b/packages/workspace/src/shared/actions.ts
@@ -421,7 +421,7 @@ export function* iterateActions(
 		const currentPath = [...path, key];
 		if (isAction(value)) {
 			yield [value, currentPath];
-		} else {
+		} else if (value != null && typeof value === 'object' && !Array.isArray(value) && !(value instanceof Promise)) {
 			yield* iterateActions(value as Actions, currentPath);
 		}
 	}

--- a/packages/workspace/src/shared/actions.ts
+++ b/packages/workspace/src/shared/actions.ts
@@ -64,6 +64,15 @@
 
 import type { Static, TSchema } from 'typebox';
 
+/**
+ * Global symbol brand used to reliably detect actions across package boundaries.
+ *
+ * `Symbol.for()` returns the same reference regardless of which copy of
+ * `@epicenter/workspace` stamps or checks it—critical for monorepo setups
+ * where multiple copies of the package may coexist.
+ */
+export const ACTION_BRAND: unique symbol = Symbol.for('epicenter.action');
+
 // ════════════════════════════════════════════════════════════════════════════
 // ACTION DEFINITION TYPES
 // ════════════════════════════════════════════════════════════════════════════
@@ -141,6 +150,7 @@ type ActionConfig<
  * the handler. Call the action directly instead of accessing `.handler`.
  */
 type ActionMeta<TInput extends TSchema | undefined = TSchema | undefined> = {
+	[ACTION_BRAND]: true;
 	type: 'query' | 'mutation';
 	/** Short, human-readable display name for UI surfaces (e.g. 'Close Tabs'). Falls back to path-derived name if omitted. */
 	title?: string;
@@ -284,6 +294,7 @@ export function defineQuery<TInput extends TSchema, TOutput = unknown>(
 ): Query<TInput, TOutput>;
 export function defineQuery({ handler, ...rest }: ActionConfig): Query {
 	return Object.assign(handler, {
+		[ACTION_BRAND]: true as const,
 		type: 'query' as const,
 		...rest,
 	}) as unknown as Query;
@@ -330,6 +341,7 @@ export function defineMutation<TInput extends TSchema, TOutput = unknown>(
 ): Mutation<TInput, TOutput>;
 export function defineMutation({ handler, ...rest }: ActionConfig): Mutation {
 	return Object.assign(handler, {
+		[ACTION_BRAND]: true as const,
 		type: 'mutation' as const,
 		...rest,
 	}) as unknown as Mutation;
@@ -353,11 +365,7 @@ export function defineMutation({ handler, ...rest }: ActionConfig): Mutation {
  * ```
  */
 export function isAction(value: unknown): value is Action {
-	return (
-		typeof value === 'function' &&
-		'type' in value &&
-		(value.type === 'query' || value.type === 'mutation')
-	);
+	return typeof value === 'function' && ACTION_BRAND in value;
 }
 
 /**

--- a/packages/workspace/src/workspace/describe-workspace.test.ts
+++ b/packages/workspace/src/workspace/describe-workspace.test.ts
@@ -264,4 +264,61 @@ describe('describeWorkspace', () => {
 		);
 		expect(createAction?.title).toBeUndefined();
 	});
+
+	test('workspace without extensions returns empty extensions record', () => {
+		const posts = defineTable(type({ id: 'string', title: 'string', _v: '1' }));
+
+		const client = createWorkspace({
+			id: 'no-extensions',
+			tables: { posts },
+		});
+
+		const descriptor = describeWorkspace(client);
+
+		expect(descriptor.extensions).toEqual({});
+	});
+
+	test('workspace extensions with defineQuery/defineMutation are discovered', () => {
+		const posts = defineTable(type({ id: 'string', title: 'string', _v: '1' }));
+
+		const client = createWorkspace({
+			id: 'with-extensions',
+			tables: { posts },
+		}).withWorkspaceExtension('myExt', () => ({
+			searchStuff: defineQuery({
+				title: 'Search Stuff',
+				description: 'Search for stuff',
+				handler: () => [],
+			}),
+			rebuildStuff: defineMutation({
+				title: 'Rebuild Stuff',
+				handler: () => {},
+			}),
+			// Non-action properties should be ignored
+			whenReady: Promise.resolve(),
+			dispose() {},
+		}));
+
+		const descriptor = describeWorkspace(client);
+
+		// Extensions discovered
+		expect(Object.keys(descriptor.extensions)).toEqual(['myExt']);
+		expect(descriptor.extensions.myExt).toHaveLength(2);
+
+		const searchAction = descriptor.extensions.myExt?.find(
+			(a) => a.path.join('.') === 'searchStuff',
+		);
+		expect(searchAction).toBeDefined();
+		expect(searchAction?.type).toBe('query');
+		expect(searchAction?.title).toBe('Search Stuff');
+
+		const rebuildAction = descriptor.extensions.myExt?.find(
+			(a) => a.path.join('.') === 'rebuildStuff',
+		);
+		expect(rebuildAction).toBeDefined();
+		expect(rebuildAction?.type).toBe('mutation');
+
+		// Actions from extensions are NOT in the top-level actions array
+		expect(descriptor.actions).toEqual([]);
+	});
 });

--- a/packages/workspace/src/workspace/describe-workspace.ts
+++ b/packages/workspace/src/workspace/describe-workspace.ts
@@ -26,7 +26,7 @@
 
 import type { StandardJSONSchemaV1 } from '@standard-schema/spec';
 import type { TSchema } from 'typebox';
-import { iterateActions } from '../shared/actions.js';
+import { type Actions, iterateActions } from '../shared/actions.js';
 import { standardSchemaToJsonSchema } from '../shared/standard-schema.js';
 import type { AnyWorkspaceClient } from './types.js';
 
@@ -61,6 +61,7 @@ export type WorkspaceDescriptor = {
 	kv: Record<string, SchemaDescriptor>;
 	awareness: Record<string, SchemaDescriptor>;
 	actions: ActionDescriptor[];
+	extensions: Record<string, ActionDescriptor[]>;
 };
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -84,6 +85,23 @@ function describeSchemas(
 			},
 		]),
 	);
+}
+
+/** Walk an action tree and return an array of action descriptors. */
+function collectActionDescriptors(actions: Actions): ActionDescriptor[] {
+	const result: ActionDescriptor[] = [];
+	for (const [action, path] of iterateActions(actions)) {
+		result.push({
+			path,
+			type: action.type,
+			...(action.title !== undefined && { title: action.title }),
+			...(action.description !== undefined && {
+				description: action.description,
+			}),
+			...(action.input !== undefined && { input: action.input }),
+		});
+	}
+	return result;
 }
 
 /**
@@ -114,18 +132,18 @@ function describeSchemas(
 export function describeWorkspace(
 	client: AnyWorkspaceClient,
 ): WorkspaceDescriptor {
-	const actions: ActionDescriptor[] = [];
-	if (client.actions) {
-		for (const [action, path] of iterateActions(client.actions)) {
-			actions.push({
-				path,
-				type: action.type,
-				...(action.title !== undefined && { title: action.title }),
-				...(action.description !== undefined && {
-					description: action.description,
-				}),
-				...(action.input !== undefined && { input: action.input }),
-			});
+	const actions: ActionDescriptor[] = client.actions
+		? collectActionDescriptors(client.actions)
+		: [];
+
+	const extensions: Record<string, ActionDescriptor[]> = {};
+	if (client.extensions) {
+		for (const [extKey, extValue] of Object.entries(client.extensions)) {
+			if (extValue == null || typeof extValue !== 'object' || Array.isArray(extValue)) continue;
+			const extActions = collectActionDescriptors(extValue as Actions);
+			if (extActions.length > 0) {
+				extensions[extKey] = extActions;
+			}
 		}
 	}
 
@@ -135,5 +153,6 @@ export function describeWorkspace(
 		kv: describeSchemas(client.definitions.kv),
 		awareness: describeSchemas(client.definitions.awareness),
 		actions,
+		extensions,
 	};
 }

--- a/packages/workspace/src/workspace/index.ts
+++ b/packages/workspace/src/workspace/index.ts
@@ -61,6 +61,7 @@
 // Action system
 export type { Action, Actions, Mutation, Query } from '../shared/actions.js';
 export {
+	ACTION_BRAND,
 	defineMutation,
 	defineQuery,
 	isAction,

--- a/specs/20260415T130224-extension-action-introspection-handoff.md
+++ b/specs/20260415T130224-extension-action-introspection-handoff.md
@@ -1,0 +1,384 @@
+# Handoff: Extension Action Introspection
+
+## Task
+
+Implement three changes to `@epicenter/workspace` and `@epicenter/cli`:
+
+1. **Add `Symbol.for('epicenter.action')` brand** to `defineQuery`/`defineMutation` and update `isAction()` to check the symbol
+2. **Widen `MirrorDatabase`/`MirrorStatement` types** so `bun:sqlite`'s `Database` satisfies them structurally
+3. **Rewrite the SQLite materializer's public API** from plain methods to `defineQuery`/`defineMutation` actions (generic, not per-table)
+4. **Update `describeWorkspace()`** to also walk `client.extensions` and return extension actions
+5. **Update `epicenter run`** to fall through to `client.extensions` when an action isn't found in `client.actions`
+
+Read the full spec at `specs/20260415T130224-extension-action-introspection.md` for design rationale, resolved questions, and architecture diagrams.
+
+## Skills to Load
+
+Load these before starting: `monorepo`, `typescript`, `testing`, `workspace-api`, `error-handling`, `define-errors`
+
+## Build & Test Commands
+
+```bash
+bun test packages/workspace/src/extensions/materializer/sqlite/   # materializer tests
+bun test packages/workspace/src/shared/actions.ts                  # action system tests
+bun test packages/workspace/src/workspace/describe-workspace.test.ts  # describe tests
+bun test packages/workspace/src/workspace/create-workspace.test.ts    # builder tests
+bun run typecheck                                                  # full monorepo typecheck (turbo)
+```
+
+## Context: What Exists Today
+
+### Action System (`packages/workspace/src/shared/actions.ts`)
+
+`defineQuery` and `defineMutation` return callable functions with metadata stamped via `Object.assign`. Detection is currently structural:
+
+```typescript
+// Current defineQuery implementation (line 285):
+export function defineQuery({ handler, ...rest }: ActionConfig): Query {
+  return Object.assign(handler, {
+    type: 'query' as const,
+    ...rest,
+  }) as unknown as Query;
+}
+
+// Current defineMutation implementation (line 331):
+export function defineMutation({ handler, ...rest }: ActionConfig): Mutation {
+  return Object.assign(handler, {
+    type: 'mutation' as const,
+    ...rest,
+  }) as unknown as Mutation;
+}
+
+// Current isAction guard (line 355):
+export function isAction(value: unknown): value is Action {
+  return (
+    typeof value === 'function' &&
+    'type' in value &&
+    (value.type === 'query' || value.type === 'mutation')
+  );
+}
+
+// iterateActions walks an action tree, yielding [action, path] tuples (line 408):
+export function* iterateActions(
+  actions: Actions,
+  path: string[] = [],
+): Generator<[Action, string[]]> {
+  for (const [key, value] of Object.entries(actions)) {
+    const currentPath = [...path, key];
+    if (isAction(value)) {
+      yield [value, currentPath];
+    } else {
+      yield* iterateActions(value as Actions, currentPath);
+    }
+  }
+}
+```
+
+`isAction` is the single chokepoint—all detection flows through it:
+- `iterateActions()` in `actions.ts`
+- `isQuery()` / `isMutation()` in `actions.ts` (delegate to `isAction()`)
+- Sync RPC dispatch in `websocket.ts` line 358
+- `describeWorkspace()` uses `iterateActions()`
+- `epicenter run` in `run.ts` uses `iterateActions()`
+- Tool bridge in `tool-bridge.ts` uses `iterateActions()`
+
+34 files call `defineQuery`/`defineMutation`. All go through the factory functions. The symbol addition is purely additive.
+
+### MirrorDatabase Types (`packages/workspace/src/extensions/materializer/sqlite/types.ts`)
+
+Current types are too narrow for `bun:sqlite`:
+
+```typescript
+export type MirrorDatabase = {
+  run(sql: string): MaybePromise<unknown>;
+  prepare(sql: string): MirrorStatement;  // BUG: should be MaybePromise<MirrorStatement> for Turso
+};
+
+export type MirrorStatement = {
+  run(...params: unknown[]): MaybePromise<unknown>;
+  all(...params: unknown[]): MaybePromise<Record<string, unknown>[]>;  // BUG: bun:sqlite returns unknown[]
+  get(...params: unknown[]): MaybePromise<Record<string, unknown> | null>;  // BUG: same issue
+};
+```
+
+`bun:sqlite`'s `Statement<ReturnType=unknown>.all()` returns `unknown[]`, not `Record<string, unknown>[]`. Fix: widen `all()` to `MaybePromise<unknown[]>` and `get()` to `MaybePromise<unknown>`. Widen `prepare()` to `MaybePromise<MirrorStatement>` for async drivers.
+
+### SQLite Materializer (`packages/workspace/src/extensions/materializer/sqlite/sqlite.ts`)
+
+Currently returns plain methods. The builder pattern at the bottom:
+
+```typescript
+type MaterializerBuilder = {
+  table<TName extends keyof TTables & string>(
+    name: TName,
+    tableConfig?: TableMaterializerConfig,
+  ): MaterializerBuilder;
+  whenReady: Promise<void>;
+  dispose(): void;
+  search(table: keyof TTables & string, query: string, options?: SearchOptions): Promise<SearchResult[]>;
+  count(table: keyof TTables & string): Promise<number>;
+  rebuild(table?: keyof TTables & string): Promise<void>;
+  db: MirrorDatabase;
+};
+
+const builder: MaterializerBuilder = {
+  table(name, tableConfig) { tableConfigs.set(name, tableConfig ?? {}); return builder; },
+  whenReady: initialize(),
+  dispose,
+  search,
+  count,
+  rebuild,
+  db,
+};
+
+return builder;
+```
+
+Replace `search`, `count`, `rebuild` with `defineQuery`/`defineMutation` wrappers. The table name parameter becomes a TypeBox-validated input field with a union of configured table names.
+
+### describeWorkspace (`packages/workspace/src/workspace/describe-workspace.ts`)
+
+Currently only walks `client.actions`:
+
+```typescript
+export type WorkspaceDescriptor = {
+  id: string;
+  tables: Record<string, SchemaDescriptor>;
+  kv: Record<string, SchemaDescriptor>;
+  awareness: Record<string, SchemaDescriptor>;
+  actions: ActionDescriptor[];
+};
+
+// In describeWorkspace():
+if (client.actions) {
+  for (const [action, path] of iterateActions(client.actions)) {
+    actions.push({ path, type: action.type, ... });
+  }
+}
+```
+
+Add `extensions: Record<string, ActionDescriptor[]>` field. Walk each `client.extensions[key]` with `iterateActions`, collect action descriptors grouped by extension key.
+
+### epicenter run (`packages/cli/src/commands/run.ts`)
+
+Currently resolves only against `client.actions`:
+
+```typescript
+// Current lookup:
+for (const [action, path] of iterateActions(client.actions)) {
+  if (path.join('.') === actionPath.join('.')) { found = action; break; }
+}
+```
+
+Add extension fallback: if not found in `client.actions`, walk each `client.extensions[key]` and check if `extensionKey + '.' + path.join('.')` matches. This is a clean break—no backward compat concerns.
+
+## What to Change
+
+### Change 1: Symbol brand in `actions.ts`
+
+```typescript
+// Add at top of file:
+export const ACTION_BRAND = Symbol.for('epicenter.action');
+
+// Update defineQuery:
+export function defineQuery({ handler, ...rest }: ActionConfig): Query {
+  return Object.assign(handler, {
+    [ACTION_BRAND]: true,
+    type: 'query' as const,
+    ...rest,
+  }) as unknown as Query;
+}
+
+// Update defineMutation:
+export function defineMutation({ handler, ...rest }: ActionConfig): Mutation {
+  return Object.assign(handler, {
+    [ACTION_BRAND]: true,
+    type: 'mutation' as const,
+    ...rest,
+  }) as unknown as Mutation;
+}
+
+// Update isAction:
+export function isAction(value: unknown): value is Action {
+  return typeof value === 'function' && ACTION_BRAND in value;
+}
+```
+
+Keep `.type` property — `isQuery`/`isMutation` still discriminate on `.type === 'query' | 'mutation'`.
+
+Also update the `ActionMeta` type to include the brand:
+
+```typescript
+type ActionMeta<TInput extends TSchema | undefined = TSchema | undefined> = {
+  [ACTION_BRAND]: true;
+  type: 'query' | 'mutation';
+  title?: string;
+  description?: string;
+  input?: TInput;
+};
+```
+
+And export `ACTION_BRAND` from the barrel files (`packages/workspace/src/index.ts`, `packages/workspace/src/workspace/index.ts`).
+
+### Change 2: Widen MirrorDatabase types in `types.ts`
+
+```typescript
+export type MirrorDatabase = {
+  run(sql: string): MaybePromise<unknown>;
+  prepare(sql: string): MaybePromise<MirrorStatement>;
+};
+
+export type MirrorStatement = {
+  run(...params: unknown[]): MaybePromise<unknown>;
+  all(...params: unknown[]): MaybePromise<unknown[]>;
+  get(...params: unknown[]): MaybePromise<unknown>;
+};
+```
+
+Then in `sqlite.ts`, add casts where the materializer reads rows — `(row as Record<string, unknown>)`. Safe because SQLite always returns row objects.
+
+Also: every call to `db.prepare(...)` must now be awaited, since it returns `MaybePromise<MirrorStatement>`. Update internal usages in `sqlite.ts`:
+- `const stmt = await db.prepare(...)` (previously no await needed)
+- The `fullLoadTable` and `insertRow`/`deleteRow` functions already await `.run()` on the statement, so the pattern is `(await db.prepare(...)).run(...)`.
+
+### Change 3: Materializer returns `defineQuery`/`defineMutation`
+
+Replace the `MaterializerBuilder` return type. The builder still chains `.table()`, but the final returned object exports actions instead of plain methods:
+
+```typescript
+import { defineQuery, defineMutation } from '../../../shared/actions.js';
+import Type from 'typebox';
+
+// Inside createSqliteMaterializer, after builder finishes collecting tables:
+// Generate TypeBox union of FTS-configured table names
+const ftsTableNames = [...tableConfigs.entries()]
+  .filter(([, config]) => config.fts && config.fts.length > 0)
+  .map(([name]) => name);
+
+const allTableNames = [...tableConfigs.keys()];
+
+// Build the return object with defineQuery/defineMutation:
+return {
+  table: builder.table,  // keep builder chainable
+
+  search: ftsTableNames.length > 0
+    ? defineQuery({
+        title: 'Full-text search',
+        description: 'FTS5 search across materialized table rows',
+        input: Type.Object({
+          table: Type.Union(ftsTableNames.map(n => Type.Literal(n))),
+          query: Type.String(),
+          limit: Type.Optional(Type.Number()),
+        }),
+        handler: ({ table, query, limit }) => search(table, query, { limit }),
+      })
+    : undefined,
+
+  count: defineQuery({
+    title: 'Row count',
+    description: 'Count rows in a materialized table',
+    input: Type.Object({
+      table: Type.Union(allTableNames.map(n => Type.Literal(n))),
+    }),
+    handler: ({ table }) => count(table),
+  }),
+
+  rebuild: defineMutation({
+    title: 'Rebuild materializer',
+    description: 'Drop and rebuild all materialized tables from Yjs source',
+    handler: () => rebuild(),
+  }),
+
+  // Lifecycle (not actions — no symbol, skipped by walker)
+  whenReady: initialize(),
+  dispose,
+  db,
+};
+```
+
+Note: this is a breaking API change. The materializer has zero external consumers calling `.search()` programmatically (configs just register the extension, they don't call methods on it). Safe to break.
+
+### Change 4: Update `describeWorkspace()` in `describe-workspace.ts`
+
+```typescript
+export type WorkspaceDescriptor = {
+  id: string;
+  tables: Record<string, SchemaDescriptor>;
+  kv: Record<string, SchemaDescriptor>;
+  awareness: Record<string, SchemaDescriptor>;
+  actions: ActionDescriptor[];
+  extensions: Record<string, ActionDescriptor[]>;  // NEW
+};
+
+// In describeWorkspace():
+const extensionActions: Record<string, ActionDescriptor[]> = {};
+if (client.extensions) {
+  for (const [extKey, extValue] of Object.entries(client.extensions)) {
+    if (extValue == null || typeof extValue !== 'object') continue;
+    const extActions: ActionDescriptor[] = [];
+    for (const [action, path] of iterateActions(extValue as Actions)) {
+      extActions.push({
+        path,
+        type: action.type,
+        ...(action.title !== undefined && { title: action.title }),
+        ...(action.description !== undefined && { description: action.description }),
+        ...(action.input !== undefined && { input: action.input }),
+      });
+    }
+    if (extActions.length > 0) {
+      extensionActions[extKey] = extActions;
+    }
+  }
+}
+
+return { id: client.id, tables: ..., kv: ..., awareness: ..., actions, extensions: extensionActions };
+```
+
+### Change 5: Update `epicenter run` in `run.ts`
+
+After the existing `iterateActions(client.actions)` lookup fails, add extension fallback:
+
+```typescript
+// Existing: search client.actions
+let found: Action | undefined;
+if (client.actions) {
+  for (const [action, path] of iterateActions(client.actions)) {
+    if (path.join('.') === actionPath.join('.')) { found = action; break; }
+  }
+}
+
+// NEW: fall through to client.extensions
+if (!found && client.extensions) {
+  for (const [extKey, extValue] of Object.entries(client.extensions)) {
+    if (extValue == null || typeof extValue !== 'object') continue;
+    for (const [action, path] of iterateActions(extValue as Actions)) {
+      const extPath = [extKey, ...path].join('.');
+      if (extPath === actionPath.join('.')) { found = action; break; }
+    }
+    if (found) break;
+  }
+}
+```
+
+## MUST DO
+
+- Load skills: `monorepo`, `typescript`, `testing`, `workspace-api` before implementing
+- Use `type` instead of `interface` everywhere
+- Use `Symbol.for('epicenter.action')` — NOT `Symbol('epicenter.action')` (must work cross-package)
+- Keep `.type` property on actions alongside the symbol (used by `isQuery`/`isMutation`)
+- Export `ACTION_BRAND` from barrel files
+- Cast row results in materializer internals where types were widened (`as Record<string, unknown>`)
+- Await `db.prepare(...)` in all materializer internal usages
+- Run `bun test packages/workspace` and `bun run typecheck` after each phase
+- Update `describe-workspace.test.ts` with test for new `extensions` field
+- Update materializer tests for new API shape
+
+## MUST NOT DO
+
+- Do not suppress type errors with `as any` or `@ts-ignore`
+- Do not delete or skip existing tests
+- Do not modify files outside `packages/workspace/` and `packages/cli/` (except barrel re-exports)
+- Do not auto-register extension actions into `client.actions` — they stay in `client.extensions`
+- Do not remove the `.type` property from actions — only add the symbol alongside it
+- Do not change the `iterateActions` walker logic — only change what `isAction` checks
+- Do not commit unless explicitly asked

--- a/specs/20260415T130224-extension-action-introspection-impl.md
+++ b/specs/20260415T130224-extension-action-introspection-impl.md
@@ -1,0 +1,53 @@
+# Extension Action Introspection — Implementation Plan
+
+**Date**: 2026-04-15
+**Spec**: `specs/20260415T130224-extension-action-introspection.md`
+**Handoff**: `specs/20260415T130224-extension-action-introspection-handoff.md`
+
+## Summary
+
+Five changes across `packages/workspace` and `packages/cli` to make extension actions discoverable by the CLI. The core idea: stamp `defineQuery`/`defineMutation` with a symbol brand, rewrite the SQLite materializer to export actions instead of plain methods, and teach `describeWorkspace` + `epicenter run` to walk `client.extensions`.
+
+## Todo List
+
+### Phase 1: Action Brand Symbol
+
+- [ ] **1.1** Add `ACTION_BRAND = Symbol.for('epicenter.action')` to `packages/workspace/src/shared/actions.ts`, export it
+- [ ] **1.2** Stamp `[ACTION_BRAND]: true` in both `defineQuery` and `defineMutation` factory functions
+- [ ] **1.3** Update `isAction()` to check `ACTION_BRAND in value` instead of structural `.type` check
+- [ ] **1.4** Add `[ACTION_BRAND]: true` to the `ActionMeta` type
+- [ ] **1.5** Export `ACTION_BRAND` from barrel files (`src/index.ts`, `src/workspace/index.ts`)
+- [ ] **1.6** Run tests: `bun test packages/workspace/src/shared/` and `bun test packages/workspace/src/workspace/describe-workspace.test.ts`
+
+### Phase 2: Widen MirrorDatabase Types
+
+- [ ] **2.1** In `types.ts`: widen `MirrorStatement.all()` return to `MaybePromise<unknown[]>`, `get()` to `MaybePromise<unknown>`, `prepare()` to `MaybePromise<MirrorStatement>`
+- [ ] **2.2** In `sqlite.ts`: `await` all `db.prepare(...)` calls (since `prepare` now returns `MaybePromise`)
+- [ ] **2.3** In `sqlite.ts`: cast row results where needed (`as Record<string, unknown>`)
+- [ ] **2.4** Run tests: `bun test packages/workspace/src/extensions/materializer/sqlite/`
+
+### Phase 3: Materializer Returns defineQuery/defineMutation
+
+- [ ] **3.1** Import `defineQuery`, `defineMutation` and `Type` from typebox into `sqlite.ts`
+- [ ] **3.2** Replace `search`, `count`, `rebuild` plain methods with `defineQuery`/`defineMutation` wrappers using generic table-union inputs
+- [ ] **3.3** Update `MaterializerBuilder` type to reflect new API shape
+- [ ] **3.4** Update tests to call new API shape: `materializer.search({ table: 'posts', query: '...' })` instead of `materializer.search('posts', '...')`
+- [ ] **3.5** Verify `isAction(materializer.search)` returns true in tests
+- [ ] **3.6** Run tests: `bun test packages/workspace/src/extensions/materializer/sqlite/`
+
+### Phase 4: CLI Extension Introspection
+
+- [ ] **4.1** Add `extensions: Record<string, ActionDescriptor[]>` to `WorkspaceDescriptor` type in `describe-workspace.ts`
+- [ ] **4.2** Update `describeWorkspace()` to walk `client.extensions` with `iterateActions`
+- [ ] **4.3** Add test for new `extensions` field in `describe-workspace.test.ts`
+- [ ] **4.4** Update `epicenter run` in `run.ts` to fall through to `client.extensions` when action not found in `client.actions`
+- [ ] **4.5** Run tests: `bun test packages/workspace/src/workspace/describe-workspace.test.ts`
+
+### Phase 5: Final Verification
+
+- [ ] **5.1** Run full workspace test suite: `bun test packages/workspace`
+- [ ] **5.2** Run typecheck: `bun run typecheck`
+
+## Review
+
+_(To be filled after implementation)_

--- a/specs/20260415T130224-extension-action-introspection.md
+++ b/specs/20260415T130224-extension-action-introspection.md
@@ -1,0 +1,284 @@
+# Extension Action Introspection
+
+**Date**: 2026-04-15
+**Status**: Draft
+**Author**: AI-assisted
+**Branch**: feat/fuji-bulk-add-modal
+
+## Overview
+
+Extensions export `defineQuery`/`defineMutation` as their primary API surface—no plain methods. A `Symbol.for('epicenter.action')` brand ensures reliable detection when walking extension exports. The CLI discovers and invokes them directly. Users spread extension exports into `.withActions()` if they want RPC/MCP exposure.
+
+## Motivation
+
+### Current State
+
+The SQLite materializer returns plain methods on `client.extensions.sqlite`:
+
+```typescript
+client.extensions.sqlite.search('entries', 'hello')  // plain function, invisible to CLI
+client.extensions.sqlite.count('entries')             // plain function, invisible to CLI
+```
+
+The CLI can't see any of these. `epicenter describe` only walks `client.actions`. To expose search, you manually wire a `defineQuery` into `.withActions()`:
+
+```typescript
+.withActions(({ extensions }) => ({
+  searchEntries: defineQuery({
+    input: Type.Object({ query: Type.String() }),
+    handler: ({ query }) => extensions.sqlite.search('entries', query),
+  }),
+}))
+```
+
+Every config repeats this. The materializer already knows which tables have FTS. And `defineQuery` returns a callable function anyway—there's no reason to have separate plain methods and action wrappers.
+
+### Problems
+
+1. **Boilerplate**: Every config with FTS needs identical `.withActions()` wiring.
+2. **Invisible to CLI**: Extensions are a black box to `epicenter describe` and `epicenter run`.
+3. **No discoverability**: A user configures `fts: ['title', 'subtitle']` and has no way to invoke search without reading the programmatic API docs.
+
+### Desired State
+
+Extensions export `defineQuery`/`defineMutation` directly—these ARE the API. No plain methods, no separate `.actions` property. Since `defineQuery` returns a callable function with metadata attached, `client.extensions.sqlite.search({ table: 'entries', query: 'hello' })` works programmatically AND is discoverable by the CLI.
+
+```typescript
+// Config — this is all you write:
+.withWorkspaceExtension('sqlite', (ctx) =>
+  createSqliteMaterializer(ctx, { db })
+    .table('entries', { fts: ['title', 'subtitle'] })
+)
+
+// Programmatic — call it like a function:
+client.extensions.sqlite.search({ table: 'entries', query: 'hello' })
+
+// CLI — works immediately:
+// epicenter describe  →  shows search, count, rebuild under extensions.sqlite
+// epicenter run sqlite.search --table entries --query "hello"
+
+// Optional promotion to client.actions for RPC/MCP:
+.withActions(({ extensions }) => extensions.sqlite)
+```
+
+## Research Findings
+
+### Action Detection Mechanism
+
+`defineQuery`/`defineMutation` stamp both a `Symbol.for('epicenter.action')` brand and a `.type` property on the handler function:
+
+```typescript
+const ACTION_BRAND = Symbol.for('epicenter.action');
+
+// defineQuery returns:
+Object.assign(handler, { [ACTION_BRAND]: true, type: 'query' as const, ...rest })
+
+// defineMutation returns:
+Object.assign(handler, { [ACTION_BRAND]: true, type: 'mutation' as const, ...rest })
+```
+
+Detection uses the symbol as the primary check:
+
+```typescript
+const ACTION_BRAND = Symbol.for('epicenter.action');
+
+function isAction(value: unknown): value is Action {
+  return typeof value === 'function' && ACTION_BRAND in value;
+}
+```
+
+`iterateActions()` recursively walks an object tree, yielding `[action, path]` tuples for every leaf that passes `isAction()`. Non-action values are treated as namespace branches and recursed into.
+
+**Why `Symbol.for()` instead of `Symbol()`**: `Symbol.for('epicenter.action')` is a global symbol—the same reference across package boundaries. If a consumer imports `defineQuery` from one copy of `@epicenter/workspace` and `isAction` from another, the check still works. `Symbol()` would create unique symbols per import, breaking cross-package detection.
+
+**Why a symbol instead of structural checks**: We're expanding `iterateActions` from walking curated `client.actions` trees (where everything IS an action by construction) to walking arbitrary `client.extensions.*` (where extensions can have any shape). The symbol makes the contract explicit—only `defineQuery`/`defineMutation` produce it. No false positives possible, regardless of what extensions export.
+
+**All existing detection paths go through `isAction()`** (verified):
+- `iterateActions()` in `actions.ts` — calls `isAction()` for leaf detection
+- `isQuery()` / `isMutation()` in `actions.ts` — delegate to `isAction()` first
+- Sync RPC dispatch in `websocket.ts` — calls `isAction(target)` before invoking
+- `describeWorkspace()` — uses `iterateActions()` which calls `isAction()`
+- `epicenter run` in `run.ts` — uses `iterateActions()` which calls `isAction()`
+- Tool bridge in `tool-bridge.ts` — uses `iterateActions()`
+
+Single point of change. All 34 files that call `defineQuery`/`defineMutation` go through the factory functions which stamp the symbol. Purely additive—existing actions gain a new property, nothing breaks.
+
+### Current CLI Dispatch
+
+- `epicenter describe` calls `describeWorkspace(client)`, which calls `iterateActions(client.actions)`.
+- `epicenter run <action>` resolves a dot-path against `iterateActions(client.actions)`, validates input via TypeBox-to-yargs conversion, and invokes locally.
+- `epicenter rpc <action>` dispatches through `sync.rpc()` to a remote peer. Inbound RPC uses `registeredActions` set by `sync.registerActions()`.
+- Neither `epicenter describe` nor `epicenter run` read from `client.extensions`. Only `epicenter rpc` accesses `client.extensions.sync`.
+
+**Implication**: `epicenter run` exists but only resolves against `client.actions`. Extension introspection means teaching it (and `describeWorkspace`) to also walk `client.extensions`.
+
+### Extension Lifecycle
+
+- `withWorkspaceExtension(key, factory)` calls `factory(ctx)` and stores the return value at `client.extensions[key]`.
+- Extension returns can include lifecycle hooks: `whenReady`, `dispose`, `clearLocalData`.
+- Extensions cannot currently contribute to `client.actions`—that's `.withActions()` only.
+- `describeWorkspace()` only walks `client.actions`, not `client.extensions`.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Where extension actions live | `client.extensions.<key>` only | No auto-registration into `client.actions`. User promotes via `.withActions(({ extensions }) => extensions.sqlite)`. |
+| Extension API surface | `defineQuery`/`defineMutation` only, no plain methods | Actions are callable functions. One API, not two. Generic `search({ table, query })` not per-table. |
+| How CLI discovers extension actions | Walk `client.extensions` with `iterateActions` | Same walker, now safe via symbol brand. |
+| Detection mechanism | `Symbol.for('epicenter.action')` brand | Bulletproof for walking arbitrary extension exports. `isAction()` is the single chokepoint — one-line change. |
+| RPC/MCP exposure | Explicit via `.withActions()` | Security boundary: user decides what's remotely callable. |
+| Extension action generation | Materializer generates generic `defineQuery` with table union input | Table name validated via TypeBox `Type.Union([Type.Literal('entries'), ...])`. One action, not N. |
+| Local action invocation | Extend existing `epicenter run` | Resolves `client.actions` first, falls through to `client.extensions.*`. No prefix. Clean break from old behavior. |
+
+## Architecture
+
+```
+Extension Author (materializer)
+─────────────────────────────────
+createSqliteMaterializer(ctx, { db })
+  .table('entries', { fts: ['title', 'subtitle'] })
+  .table('posts')
+
+Returns:
+{
+  search: defineQuery({                ← one generic action, table validated by input schema
+    input: Type.Object({
+      table: Type.Union([Type.Literal('entries')]),  // only FTS-configured tables
+      query: Type.String(),
+      limit: Type.Optional(Type.Number()),
+    }),
+    handler: ({ table, query, limit }) => …
+  })
+
+  count: defineQuery({                 ← one generic action, all tables
+    input: Type.Object({
+      table: Type.Union([Type.Literal('entries'), Type.Literal('posts')]),
+    }),
+    handler: ({ table }) => …
+  })
+
+  rebuild: defineMutation({            ← rebuild FTS indexes
+    handler: () => …
+  })
+
+  dispose()                            ← lifecycle (no symbol, skipped by walker)
+  whenReady: Promise<void>             ← lifecycle (skipped)
+}
+
+
+CLI Introspection
+─────────────────
+epicenter describe:
+  walks client.actions        (existing)
+  walks client.extensions.*   (NEW — same iterateActions, now symbol-safe)
+  returns separate extensions field in WorkspaceDescriptor
+
+epicenter run sqlite.search --table entries --query "hello":
+  checks client.actions       (not found)
+  walks client.extensions.*   (found at sqlite → search)
+  validates input against action.input schema (table must be 'entries')
+  calls action({ table: 'entries', query: 'hello' })
+  prints result
+
+
+User Promotion (optional)
+──────────────────────────
+.withActions(({ extensions }) => extensions.sqlite)
+
+→ client.actions.search, client.actions.count, client.actions.rebuild
+→ sync.registerActions() called automatically
+```
+
+## Implementation Plan
+
+### Phase 1: Action Brand Symbol + MirrorDatabase Type Fix
+
+- [ ] **1.1** Add `ACTION_BRAND = Symbol.for('epicenter.action')` to `actions.ts`, export it
+- [ ] **1.2** Stamp `[ACTION_BRAND]: true` in `defineQuery` and `defineMutation` factory functions
+- [ ] **1.3** Update `isAction()` to check `ACTION_BRAND in value` instead of structural `.type` check
+- [ ] **1.4** Keep `.type` property on actions (used by `isQuery`/`isMutation` and consumers) — symbol is for detection only
+- [ ] **1.5** Verify all existing tests pass (34 files use defineQuery/defineMutation — all go through factory)
+- [ ] **1.6** Widen `MirrorStatement.all()` return from `MaybePromise<Record<string, unknown>[]>` to `MaybePromise<unknown[]>`
+- [ ] **1.7** Widen `MirrorStatement.get()` return from `MaybePromise<Record<string, unknown> | null>` to `MaybePromise<unknown>`
+- [ ] **1.8** Widen `MirrorDatabase.prepare()` return from `MirrorStatement` to `MaybePromise<MirrorStatement>`
+- [ ] **1.9** Update materializer internals to cast where needed (safe — SQLite always returns row objects)
+- [ ] **1.10** Verify `bun:sqlite` Database satisfies `MirrorDatabase` structurally
+- [ ] **1.11** Run tests: `bun test packages/workspace/src/extensions/materializer/sqlite/`
+
+### Phase 2: Materializer Exports Generic Actions
+
+- [ ] **2.1** Replace `search(table, query)` with `search: defineQuery({ input: { table: Union<configured FTS tables>, query: String }, handler })` 
+- [ ] **2.2** Replace `count(table)` with `count: defineQuery({ input: { table: Union<all tables> }, handler })`
+- [ ] **2.3** Wrap `rebuild(table?)` as `rebuild: defineMutation({ handler })`
+- [ ] **2.4** Keep `dispose()` and `whenReady` as plain lifecycle hooks (no symbol, walker skips them)
+- [ ] **2.5** Builder generates TypeBox `Type.Union([Type.Literal('entries'), ...])` from configured table names for input validation
+- [ ] **2.6** Ensure return type is generic over `TTables` so TypeScript narrows the table union correctly
+- [ ] **2.7** Add tests: `isAction(materializer.search)` returns true, `materializer.search({ table: 'entries', query: 'hello' })` returns results
+- [ ] **2.8** Update vault and opensidian configs if needed
+
+### Phase 3: CLI Extension Introspection
+
+- [ ] **3.1** Update `describeWorkspace()` to walk `client.extensions` with `iterateActions`, adding `extensions: Record<string, ActionDescriptor[]>` to `WorkspaceDescriptor`
+- [ ] **3.2** Update `epicenter run`: resolve `client.actions` first, then walk `client.extensions.*`. Clean break—no backward compat with old bare-path-to-actions behavior
+- [ ] **3.3** Add `epicenter search` as sugar for `epicenter run sqlite.search --table <table> --query "…"` (optional convenience command)
+- [ ] **3.4** Test: `epicenter describe` on opensidian-e2e shows extension actions under `extensions.sqlite`
+- [ ] **3.5** Test: `epicenter run sqlite.search --table files --query "hello"` invokes search via extension fallback
+
+### Phase 4: Documentation
+
+- [ ] **4.1** Update materializer JSDoc with examples showing the defineQuery-as-API pattern
+- [ ] **4.2** Document the convention: extension authors export `defineQuery`/`defineMutation` for user-facing operations, plain functions for lifecycle only
+
+## Edge Cases
+
+### ~~Extension exports a plain function with `.type` property~~
+
+No longer an issue. Detection uses `Symbol.for('epicenter.action')` — only `defineQuery`/`defineMutation` produce it. A plain function with `.type = 'query'` won't have the symbol and is correctly skipped.
+
+### Multiple extensions export actions with the same dot-path
+
+Two extensions both export `search.entries`. When resolving via `epicenter run search.entries`, the CLI walks extensions in registration order and picks the first match. This is unlikely—extension actions are naturally namespaced under their extension key (`sqlite.search.entries` vs `elastic.search.entries`). If the user spreads both into `.withActions()`, standard JS object spread applies (last wins).
+
+### Extension action references disposed resources
+
+A materializer's `defineQuery` handler closes over the materializer instance. If `dispose()` is called, the handler may fail. This is the same lifecycle contract as any extension method—callers shouldn't use an extension after disposing it. No special handling needed.
+
+## Resolved Questions
+
+1. **Action naming** — **Decided: Generic with table input, not per-table.** `search: defineQuery({ input: { table, query } })`. One action per operation. Table validated via TypeBox union of configured names. Keeps `epicenter describe` clean.
+
+2. **Path resolution in `epicenter run`** — **Decided: No prefix. Actions first, extension fallback.** Clean break from old behavior. Collisions practically impossible; if one occurs, actions wins (explicitly promoted).
+
+3. **`describeWorkspace()` shape** — **Decided: Separate `extensions` field.** `describeWorkspace` just describes. New `extensions: Record<string, ActionDescriptor[]>` alongside existing `actions`.
+
+4. **Symbols vs `isAction()`** — **Decided: Symbol brand.** `Symbol.for('epicenter.action')` stamped by `defineQuery`/`defineMutation`. Bulletproof for walking arbitrary extension exports. `Symbol.for()` ensures cross-package compatibility. Structural `.type` check stays for `isQuery`/`isMutation` discrimination.
+
+5. **Plain methods vs defineQuery** — **Decided: defineQuery only.** Actions are callable functions. One API surface, not two. The extension return IS the action tree (plus lifecycle hooks that the walker skips).
+
+## Success Criteria
+
+- [ ] `Symbol.for('epicenter.action')` stamped on all `defineQuery`/`defineMutation` return values
+- [ ] `isAction()` checks symbol, not structural `.type`
+- [ ] All existing action tests pass (34 files)
+- [ ] `new Database(':memory:')` from `bun:sqlite` satisfies `MirrorDatabase` with no cast
+- [ ] SQLite materializer returns generic `defineQuery` actions: `materializer.search`, `materializer.count`, `materializer.rebuild`
+- [ ] `isAction(materializer.search)` returns `true`
+- [ ] `materializer.search({ table: 'entries', query: 'hello' })` returns search results
+- [ ] `describeWorkspace()` returns `extensions` field with discovered action descriptors
+- [ ] `epicenter describe` on opensidian-e2e shows extension actions under `extensions.sqlite`
+- [ ] `epicenter run sqlite.search --table files --query "test"` resolves via extension fallback
+- [ ] Existing tests pass, no regressions
+- [ ] `.withActions(({ extensions }) => extensions.sqlite)` promotes all extension actions to `client.actions`
+
+## References
+
+- `packages/workspace/src/shared/actions.ts` — `defineQuery`, `defineMutation`, `isAction`, `iterateActions`
+- `packages/workspace/src/workspace/describe-workspace.ts` — `describeWorkspace()` implementation
+- `packages/workspace/src/workspace/create-workspace.ts` — builder, `withWorkspaceExtension`, `withActions`
+- `packages/workspace/src/extensions/materializer/sqlite/sqlite.ts` — materializer builder
+- `packages/workspace/src/extensions/materializer/sqlite/types.ts` — `MirrorDatabase`, `MirrorStatement`
+- `packages/cli/src/commands/describe.ts` — CLI describe command
+- `packages/cli/src/commands/rpc.ts` — CLI rpc command (remote action invocation)
+- `playground/opensidian-e2e/epicenter.config.ts` — first consumer config
+- `packages/cli/src/commands/run.ts` — CLI run command (local action invocation, needs extension resolution)


### PR DESCRIPTION
Workspace extensions like the SQLite materializer define useful operations—search, count, rebuild—but there's no way for tooling to discover them. `describeWorkspace` only walks `client.actions`, so anything hanging off `client.extensions.sqlite.search` is invisible to the CLI and to MCP/OpenAPI generation.

This adds a `Symbol.for('epicenter.action')` brand to every `defineQuery` and `defineMutation` return value. The brand replaces the old duck-type check (`typeof value === 'function' && value.type === 'query'`) with a reliable cross-package-boundary detection that works even when multiple copies of `@epicenter/workspace` coexist in a monorepo.

With the brand in place, `describeWorkspace` now walks `client.extensions` in addition to `client.actions`, yielding an `extensions` record keyed by extension name:

```typescript
const descriptor = describeWorkspace(client);

descriptor.actions;     // top-level actions (unchanged)
descriptor.extensions;  // { sqlite: [{ path: ['search'], type: 'query', ... }, ...] }
```

The CLI `epicenter run` command follows the same pattern—it searches `client.actions` first, then falls through to `client.extensions`, so `epicenter run sqlite.search '{"table":"posts","query":"hello"}'` works out of the box.

---

The SQLite materializer's `search`, `count`, and `rebuild` methods are now proper `defineQuery`/`defineMutation` actions with TypeBox input schemas. This is a **breaking API change**—positional args become named object args:

```typescript
// Before
await workspace.extensions.sqlite.search('posts', 'hello', { limit: 10 });
await workspace.extensions.sqlite.count('posts');
await workspace.extensions.sqlite.rebuild('posts');

// After
await workspace.extensions.sqlite.search({ table: 'posts', query: 'hello', limit: 10 });
await workspace.extensions.sqlite.count({ table: 'posts' });
await workspace.extensions.sqlite.rebuild({ table: 'posts' });
```

No app code outside tests was calling these directly—the breaking change is contained to the materializer test file.

`iterateActions` also got hardened to skip `null`, arrays, and Promises when walking extension objects, which prevents it from recursing into `whenReady` or other non-action properties on extension return values.