### PR TITLE
refactor(workspace)!: remove IO/YAML dependency injection from markdown materializer

### DIFF
--- a/packages/workspace/src/extensions/materializer/markdown/index.ts
+++ b/packages/workspace/src/extensions/materializer/markdown/index.ts
@@ -1,5 +1,5 @@
 export { createMarkdownMaterializer } from './materializer.js';
-	export {
+export {
 	markdown,
 	type SerializeResult,
 	toMarkdown,

--- a/packages/workspace/src/extensions/materializer/markdown/index.ts
+++ b/packages/workspace/src/extensions/materializer/markdown/index.ts
@@ -1,8 +1,4 @@
-export {
-	createMarkdownMaterializer,
-	type MaterializerIO,
-	type MaterializerYaml,
-} from './materializer.js';
+export { createMarkdownMaterializer } from './materializer.js';
 	export {
 	markdown,
 	type SerializeResult,

--- a/packages/workspace/src/extensions/materializer/markdown/materializer.test.ts
+++ b/packages/workspace/src/extensions/materializer/markdown/materializer.test.ts
@@ -1,9 +1,10 @@
 /**
  * Markdown Materializer Bidirectional Sync Tests
  *
- * Tests the `pushFromMarkdown` and `pullToMarkdown` methods added to
- * `createMarkdownMaterializer`. Uses an in-memory IO adapter and real
- * Yjs workspace so the materializer exercises actual table set/get paths.
+ * Tests the `pushFromMarkdown` and `pullToMarkdown` methods on
+ * `createMarkdownMaterializer`. Uses real temp directories and Yjs
+ * workspaces so the materializer exercises actual table set/get and
+ * filesystem paths.
  *
  * Key behaviors:
  * - pushFromMarkdown reads `.md` files, parses frontmatter, and calls table.set()
@@ -16,11 +17,13 @@
  * - Round-trip: pullToMarkdown → pushFromMarkdown preserves data
  */
 
-import { describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { type } from 'arktype';
 import { createWorkspace, defineTable } from '../../../workspace/index.js';
 import { createMarkdownMaterializer } from './materializer.js';
-import type { MaterializerIO, MaterializerYaml } from './materializer.js';
+import { parseMarkdownFile } from './parse-markdown-file.js';
 
 // ============================================================================
 // Test Table Definitions
@@ -33,66 +36,36 @@ const postsTable = defineTable(
 const notesTable = defineTable(type({ id: 'string', body: 'string', _v: '1' }));
 
 // ============================================================================
-// In-Memory IO + YAML Adapters
+// Test Directory Setup
 // ============================================================================
 
-type MemoryFS = Map<string, string | string[]>;
+const TEST_DIR = join(import.meta.dir, '__test-materializer__');
 
-function createMemoryIO(fs: MemoryFS): MaterializerIO {
-	return {
-		async mkdir(dir) {
-			if (!fs.has(dir)) fs.set(dir, []);
-		},
-		async writeFile(path, content) {
-			fs.set(path, content);
-			// Track filename in parent directory listing
-			const lastSlash = path.lastIndexOf('/');
-			const parentDir = path.slice(0, lastSlash);
-			const filename = path.slice(lastSlash + 1);
-			const entries = fs.get(parentDir);
-			if (Array.isArray(entries) && !entries.includes(filename)) {
-				entries.push(filename);
-			}
-		},
-		async readFile(path) {
-			const content = fs.get(path);
-			if (typeof content !== 'string') throw new Error(`ENOENT: ${path}`);
-			return content;
-		},
-		async readdir(dir) {
-			const entries = fs.get(dir);
-			if (!Array.isArray(entries)) throw new Error(`ENOENT: ${dir}`);
-			return [...entries];
-		},
-		async removeFile(path) {
-			fs.delete(path);
-			// Clean up parent directory listing
-			const lastSlash = path.lastIndexOf('/');
-			const parentDir = path.slice(0, lastSlash);
-			const filename = path.slice(lastSlash + 1);
-			const entries = fs.get(parentDir);
-			if (Array.isArray(entries)) {
-				const idx = entries.indexOf(filename);
-				if (idx !== -1) entries.splice(idx, 1);
-			}
-		},
-		joinPath(...segments) {
-			return segments.join('/');
-		},
-	};
+beforeEach(async () => {
+	await mkdir(TEST_DIR, { recursive: true });
+});
+
+afterEach(async () => {
+	await rm(TEST_DIR, { recursive: true, force: true });
+});
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+async function writeTestFile(relativePath: string, content: string) {
+	const fullPath = join(TEST_DIR, relativePath);
+	await mkdir(join(fullPath, '..'), { recursive: true });
+	await writeFile(fullPath, content, 'utf-8');
 }
 
-function createTestYaml(): MaterializerYaml {
-	const { YAML } = require('bun') as typeof import('bun');
-	return {
-		stringify: (obj) => YAML.stringify(obj, null, 2) as string,
-		parse: (str) => YAML.parse(str) as unknown,
-	};
+async function readTestFile(relativePath: string) {
+	return readFile(join(TEST_DIR, relativePath), 'utf-8');
 }
 
-// ============================================================================
-// Setup
-// ============================================================================
+async function listTestDir(relativePath: string) {
+	return readdir(join(TEST_DIR, relativePath));
+}
 
 function setup(options?: {
 	tables?: Array<{
@@ -102,18 +75,12 @@ function setup(options?: {
 		>[1];
 	}>;
 }) {
-	const fs: MemoryFS = new Map();
-	const io = createMemoryIO(fs);
-	const yaml = createTestYaml();
-
 	const workspace = createWorkspace({
 		id: 'test.materializer',
 		tables: { posts: postsTable, notes: notesTable },
 	}).withWorkspaceExtension('materializer', (ctx) => {
 		const materializer = createMarkdownMaterializer(ctx, {
-			dir: '/test-data',
-			io,
-			yaml,
+			dir: TEST_DIR,
 		});
 
 		const tablesToRegister = options?.tables ?? [
@@ -127,20 +94,7 @@ function setup(options?: {
 		return materializer;
 	});
 
-	return { fs, workspace };
-}
-
-/**
- * Seed in-memory filesystem with markdown files for a table directory.
- * Each entry is `[filename, content]`.
- */
-function seedFiles(fs: MemoryFS, dir: string, files: Array<[string, string]>) {
-	const filenames: string[] = [];
-	for (const [filename, content] of files) {
-		fs.set(`${dir}/${filename}`, content);
-		filenames.push(filename);
-	}
-	fs.set(dir, filenames);
+	return { workspace };
 }
 
 // ============================================================================
@@ -149,19 +103,17 @@ function seedFiles(fs: MemoryFS, dir: string, files: Array<[string, string]>) {
 
 describe('pushFromMarkdown', () => {
 	test('imports markdown files into workspace tables', async () => {
-		const { fs, workspace } = setup({ tables: [{ name: 'posts' }] });
+		const { workspace } = setup({ tables: [{ name: 'posts' }] });
 		await workspace.whenReady;
 
-		seedFiles(fs, '/test-data/posts', [
-			[
-				'hello.md',
-				'---\nid: post-1\ntitle: Hello World\npublished: true\n_v: 1\n---\n',
-			],
-			[
-				'draft.md',
-				'---\nid: post-2\ntitle: Draft Post\npublished: false\n_v: 1\n---\n',
-			],
-		]);
+		await writeTestFile(
+			'posts/hello.md',
+			'---\nid: post-1\ntitle: Hello World\npublished: true\n_v: 1\n---\n',
+		);
+		await writeTestFile(
+			'posts/draft.md',
+			'---\nid: post-2\ntitle: Draft Post\npublished: false\n_v: 1\n---\n',
+		);
 
 		const result = await workspace.extensions.materializer.pushFromMarkdown();
 
@@ -184,14 +136,15 @@ describe('pushFromMarkdown', () => {
 	});
 
 	test('skips non-.md files', async () => {
-		const { fs, workspace } = setup({ tables: [{ name: 'posts' }] });
+		const { workspace } = setup({ tables: [{ name: 'posts' }] });
 		await workspace.whenReady;
 
-		seedFiles(fs, '/test-data/posts', [
-			['valid.md', '---\nid: p1\ntitle: Valid\npublished: false\n_v: 1\n---\n'],
-			['readme.txt', 'not a markdown file'],
-			['data.json', '{"id": "test"}'],
-		]);
+		await writeTestFile(
+			'posts/valid.md',
+			'---\nid: p1\ntitle: Valid\npublished: false\n_v: 1\n---\n',
+		);
+		await writeTestFile('posts/readme.txt', 'not a markdown file');
+		await writeTestFile('posts/data.json', '{"id": "test"}');
 
 		const result = await workspace.extensions.materializer.pushFromMarkdown();
 
@@ -200,13 +153,17 @@ describe('pushFromMarkdown', () => {
 	});
 
 	test('skips files without valid frontmatter', async () => {
-		const { fs, workspace } = setup({ tables: [{ name: 'posts' }] });
+		const { workspace } = setup({ tables: [{ name: 'posts' }] });
 		await workspace.whenReady;
 
-		seedFiles(fs, '/test-data/posts', [
-			['valid.md', '---\nid: p1\ntitle: Valid\npublished: false\n_v: 1\n---\n'],
-			['no-frontmatter.md', '# Just a heading\n\nSome content\n'],
-		]);
+		await writeTestFile(
+			'posts/valid.md',
+			'---\nid: p1\ntitle: Valid\npublished: false\n_v: 1\n---\n',
+		);
+		await writeTestFile(
+			'posts/no-frontmatter.md',
+			'# Just a heading\n\nSome content\n',
+		);
 
 		const result = await workspace.extensions.materializer.pushFromMarkdown();
 
@@ -214,25 +171,11 @@ describe('pushFromMarkdown', () => {
 		expect(result.skipped).toBe(1);
 	});
 
-	test('reports errors for unreadable files', async () => {
-		const { fs, workspace } = setup({ tables: [{ name: 'posts' }] });
-		await workspace.whenReady;
-
-		// Seed directory listing with a file that doesn't exist in fs
-		fs.set('/test-data/posts', ['ghost.md']);
-
-		const result = await workspace.extensions.materializer.pushFromMarkdown();
-
-		expect(result.imported).toBe(0);
-		expect(result.errors.length).toBe(1);
-		expect(result.errors[0]).toContain('ghost.md');
-	});
-
 	test('silently skips tables whose directories do not exist', async () => {
 		const { workspace } = setup({ tables: [{ name: 'posts' }] });
 		await workspace.whenReady;
 
-		// Don't seed any filesystem entries — directory doesn't exist
+		// Don't create the posts directory — it should not exist
 		const result = await workspace.extensions.materializer.pushFromMarkdown();
 
 		expect(result.imported).toBe(0);
@@ -241,7 +184,7 @@ describe('pushFromMarkdown', () => {
 	});
 
 	test('uses custom deserialize callback', async () => {
-		const { fs, workspace } = setup({
+		const { workspace } = setup({
 			tables: [
 				{
 					name: 'notes',
@@ -257,9 +200,10 @@ describe('pushFromMarkdown', () => {
 		});
 		await workspace.whenReady;
 
-		seedFiles(fs, '/test-data/notes', [
-			['my-note.md', '---\nid: note-1\n---\n\nThis is the body content\n'],
-		]);
+		await writeTestFile(
+			'notes/my-note.md',
+			'---\nid: note-1\n---\n\nThis is the body content\n',
+		);
 
 		const result = await workspace.extensions.materializer.pushFromMarkdown();
 
@@ -273,14 +217,15 @@ describe('pushFromMarkdown', () => {
 	});
 
 	test('uses custom table directory', async () => {
-		const { fs, workspace } = setup({
+		const { workspace } = setup({
 			tables: [{ name: 'posts', config: { dir: 'blog' } }],
 		});
 		await workspace.whenReady;
 
-		seedFiles(fs, '/test-data/blog', [
-			['hello.md', '---\nid: p1\ntitle: Hello\npublished: false\n_v: 1\n---\n'],
-		]);
+		await writeTestFile(
+			'blog/hello.md',
+			'---\nid: p1\ntitle: Hello\npublished: false\n_v: 1\n---\n',
+		);
 
 		const result = await workspace.extensions.materializer.pushFromMarkdown();
 
@@ -289,13 +234,14 @@ describe('pushFromMarkdown', () => {
 	});
 
 	test('overwrites existing rows (set is insert-or-replace)', async () => {
-		const { fs, workspace } = setup({ tables: [{ name: 'posts' }] });
+		const { workspace } = setup({ tables: [{ name: 'posts' }] });
 		await workspace.whenReady;
 
-		// First import: seed a file and import it
-		seedFiles(fs, '/test-data/posts', [
-			['p1.md', '---\nid: p1\ntitle: Original\npublished: false\n_v: 1\n---\n'],
-		]);
+		// First import
+		await writeTestFile(
+			'posts/p1.md',
+			'---\nid: p1\ntitle: Original\npublished: false\n_v: 1\n---\n',
+		);
 
 		const first = await workspace.extensions.materializer.pushFromMarkdown();
 		expect(first.imported).toBe(1);
@@ -310,7 +256,10 @@ describe('pushFromMarkdown', () => {
 		await Bun.sleep(0);
 
 		// Second import: overwrite the same file with different data
-		fs.set('/test-data/posts/p1.md', '---\nid: p1\ntitle: Updated From Disk\npublished: true\n_v: 1\n---\n');
+		await writeTestFile(
+			'posts/p1.md',
+			'---\nid: p1\ntitle: Updated From Disk\npublished: true\n_v: 1\n---\n',
+		);
 
 		const second = await workspace.extensions.materializer.pushFromMarkdown();
 		expect(second.imported).toBe(1);
@@ -324,15 +273,17 @@ describe('pushFromMarkdown', () => {
 	});
 
 	test('imports across multiple tables', async () => {
-		const { fs, workspace } = setup();
+		const { workspace } = setup();
 		await workspace.whenReady;
 
-		seedFiles(fs, '/test-data/posts', [
-			['post.md', '---\nid: p1\ntitle: Post\npublished: false\n_v: 1\n---\n'],
-		]);
-		seedFiles(fs, '/test-data/notes', [
-			['note.md', '---\nid: n1\nbody: Note body\n_v: 1\n---\n'],
-		]);
+		await writeTestFile(
+			'posts/post.md',
+			'---\nid: p1\ntitle: Post\npublished: false\n_v: 1\n---\n',
+		);
+		await writeTestFile(
+			'notes/note.md',
+			'---\nid: n1\nbody: Note body\n_v: 1\n---\n',
+		);
 
 		const result = await workspace.extensions.materializer.pushFromMarkdown();
 
@@ -348,7 +299,7 @@ describe('pushFromMarkdown', () => {
 
 describe('pullToMarkdown', () => {
 	test('writes all valid rows to disk', async () => {
-		const { fs, workspace } = setup({ tables: [{ name: 'posts' }] });
+		const { workspace } = setup({ tables: [{ name: 'posts' }] });
 		await workspace.whenReady;
 
 		workspace.tables.posts.set({
@@ -368,18 +319,16 @@ describe('pullToMarkdown', () => {
 
 		expect(result.written).toBe(2);
 
-		// Verify files were written
-		const content1 = fs.get('/test-data/posts/p1.md');
-		expect(typeof content1).toBe('string');
-		expect(content1 as string).toContain('title: First');
+		// Verify files were written with correct content
+		const content1 = await readTestFile('posts/p1.md');
+		expect(content1).toContain('title: First');
 
-		const content2 = fs.get('/test-data/posts/p2.md');
-		expect(typeof content2).toBe('string');
-		expect(content2 as string).toContain('title: Second');
+		const content2 = await readTestFile('posts/p2.md');
+		expect(content2).toContain('title: Second');
 	});
 
 	test('creates table directory before writing', async () => {
-		const { fs, workspace } = setup({ tables: [{ name: 'posts' }] });
+		const { workspace } = setup({ tables: [{ name: 'posts' }] });
 		await workspace.whenReady;
 
 		workspace.tables.posts.set({
@@ -391,12 +340,12 @@ describe('pullToMarkdown', () => {
 
 		await workspace.extensions.materializer.pullToMarkdown();
 
-		// Directory should exist
-		expect(fs.has('/test-data/posts')).toBe(true);
+		const entries = await listTestDir('posts');
+		expect(entries).toContain('p1.md');
 	});
 
 	test('uses custom serialize callback', async () => {
-		const { fs, workspace } = setup({
+		const { workspace } = setup({
 			tables: [
 				{
 					name: 'notes',
@@ -416,14 +365,13 @@ describe('pullToMarkdown', () => {
 		const result = await workspace.extensions.materializer.pullToMarkdown();
 
 		expect(result.written).toBe(1);
-		expect(fs.has('/test-data/notes/n1-custom.md')).toBe(true);
 
-		const content = fs.get('/test-data/notes/n1-custom.md') as string;
+		const content = await readTestFile('notes/n1-custom.md');
 		expect(content).toContain('Custom body');
 	});
 
 	test('uses custom table directory', async () => {
-		const { fs, workspace } = setup({
+		const { workspace } = setup({
 			tables: [{ name: 'posts', config: { dir: 'blog' } }],
 		});
 		await workspace.whenReady;
@@ -437,7 +385,8 @@ describe('pullToMarkdown', () => {
 
 		await workspace.extensions.materializer.pullToMarkdown();
 
-		expect(fs.has('/test-data/blog/p1.md')).toBe(true);
+		const entries = await listTestDir('blog');
+		expect(entries).toContain('p1.md');
 	});
 
 	test('writes nothing when table is empty', async () => {
@@ -450,7 +399,7 @@ describe('pullToMarkdown', () => {
 	});
 
 	test('writes across multiple tables', async () => {
-		const { fs, workspace } = setup();
+		const { workspace } = setup();
 		await workspace.whenReady;
 
 		workspace.tables.posts.set({
@@ -464,8 +413,12 @@ describe('pullToMarkdown', () => {
 		const result = await workspace.extensions.materializer.pullToMarkdown();
 
 		expect(result.written).toBe(2);
-		expect(fs.has('/test-data/posts/p1.md')).toBe(true);
-		expect(fs.has('/test-data/notes/n1.md')).toBe(true);
+
+		const postsEntries = await listTestDir('posts');
+		expect(postsEntries).toContain('p1.md');
+
+		const notesEntries = await listTestDir('notes');
+		expect(notesEntries).toContain('n1.md');
 	});
 });
 
@@ -475,31 +428,43 @@ describe('pullToMarkdown', () => {
 
 describe('round-trip', () => {
 	test('pullToMarkdown then pushFromMarkdown on fresh workspace preserves row data', async () => {
-		const fs: MemoryFS = new Map();
-		const io = createMemoryIO(fs);
-		const yaml = createTestYaml();
-
 		// First workspace: populate and pull to disk
 		const workspace1 = createWorkspace({
 			id: 'test.roundtrip.1',
 			tables: { posts: postsTable, notes: notesTable },
 		}).withWorkspaceExtension('materializer', (ctx) =>
-			createMarkdownMaterializer(ctx, { dir: '/test-data', io, yaml }).table('posts'),
+			createMarkdownMaterializer(ctx, { dir: TEST_DIR }).table('posts'),
 		);
 		await workspace1.whenReady;
 
-		workspace1.tables.posts.set({ id: 'p1', title: 'Round Trip', published: true, _v: 1 });
-		workspace1.tables.posts.set({ id: 'p2', title: 'Another', published: false, _v: 1 });
+		workspace1.tables.posts.set({
+			id: 'p1',
+			title: 'Round Trip',
+			published: true,
+			_v: 1,
+		});
+		workspace1.tables.posts.set({
+			id: 'p2',
+			title: 'Another',
+			published: false,
+			_v: 1,
+		});
 
 		await workspace1.extensions.materializer.pullToMarkdown();
 		workspace1.extensions.materializer.dispose();
 
-		// Second workspace: fresh instance, push from the same FS
+		// Verify files on disk have valid frontmatter
+		const p1Content = await readTestFile('posts/p1.md');
+		const p1Parsed = parseMarkdownFile(p1Content);
+		expect(p1Parsed).not.toBeNull();
+		expect(p1Parsed!.frontmatter.title).toBe('Round Trip');
+
+		// Second workspace: fresh instance, push from the same directory
 		const workspace2 = createWorkspace({
 			id: 'test.roundtrip.2',
 			tables: { posts: postsTable, notes: notesTable },
 		}).withWorkspaceExtension('materializer', (ctx) =>
-			createMarkdownMaterializer(ctx, { dir: '/test-data', io, yaml }).table('posts'),
+			createMarkdownMaterializer(ctx, { dir: TEST_DIR }).table('posts'),
 		);
 		await workspace2.whenReady;
 

--- a/packages/workspace/src/extensions/materializer/markdown/materializer.ts
+++ b/packages/workspace/src/extensions/materializer/markdown/materializer.ts
@@ -1,32 +1,10 @@
 import { mkdir, readFile, readdir, unlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { YAML } from 'bun';
 import type { MaybePromise } from '../../../workspace/lifecycle.js';
 import type { KvHelper, TableHelper } from '../../../workspace/types.js';
 import type { SerializeResult } from './markdown.js';
-
-/**
- * Build a markdown string from YAML frontmatter and an optional body.
- *
- * Pure function—no I/O. Uses Bun's `YAML.stringify` for spec-compliant
- * serialization. Undefined values are stripped; null values are preserved.
- */
-function buildMarkdown(
-	frontmatter: Record<string, unknown>,
-	body?: string,
-): string {
-	const cleaned: Record<string, unknown> = {};
-	for (const [key, value] of Object.entries(frontmatter)) {
-		if (value !== undefined) {
-			cleaned[key] = value;
-		}
-	}
-	const yamlStr = YAML.stringify(cleaned, null, 2) as string;
-	const yamlBlock = yamlStr.endsWith('\n') ? yamlStr : `${yamlStr}\n`;
-	return body !== undefined
-		? `---\n${yamlBlock}---\n\n${body}\n`
-		: `---\n${yamlBlock}---\n`;
-}
+import { toMarkdown } from './markdown.js';
+import { parseMarkdownFile } from './parse-markdown-file.js';
 
 /**
  * Create a bidirectional markdown materializer for workspace data.
@@ -56,7 +34,7 @@ export function createMarkdownMaterializer<
 >(
 	ctx: { tables: TTables; kv: TKv; whenReady: Promise<void> },
 	config: {
-		/** Base output directory. Accepts a string or async getter for runtimes where the path isn't known until initialization (e.g. Tauri's `appDataDir()`). */
+		/** Base output directory. Accepts a string or async getter for lazy path resolution. */
 		dir: string | (() => MaybePromise<string>);
 	},
 ) {
@@ -154,7 +132,7 @@ export function createMarkdownMaterializer<
 			tableConfig?.serialize ??
 			((row) => ({
 				filename: `${row.id}.md`,
-				content: buildMarkdown({ ...row }),
+				content: toMarkdown({ ...row }),
 			}));
 
 		await mkdir(directory, { recursive: true });
@@ -237,32 +215,6 @@ export function createMarkdownMaterializer<
 		unsubscribers.push(unsubscribe);
 	};
 
-	/** Regex for extracting YAML frontmatter from markdown content. */
-	const FRONTMATTER_PATTERN =
-		/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/;
-
-	/** Parse frontmatter + body from a markdown string. */
-	function parseFrontmatter(content: string): {
-		frontmatter: Record<string, unknown>;
-		body: string | undefined;
-	} | null {
-		const input = content.charCodeAt(0) === 0xfeff ? content.slice(1) : content;
-		const match = input.match(FRONTMATTER_PATTERN);
-		if (!match) return null;
-
-		const frontmatter = YAML.parse(match[1]);
-		if (typeof frontmatter !== 'object' || frontmatter === null) return null;
-
-		const rawBody = input
-			.slice(match[0].length)
-			.replace(/^\r?\n/, '')
-			.replace(/\r?\n$/, '');
-
-		return {
-			frontmatter: frontmatter as Record<string, unknown>,
-			body: rawBody.length > 0 ? rawBody : undefined,
-		};
-	}
 
 	/** Resolve the base directory, handling string or async getter. */
 	const resolveDir = async () =>
@@ -308,7 +260,7 @@ export function createMarkdownMaterializer<
 						continue;
 					}
 
-					const parsed = parseFrontmatter(content);
+					const parsed = parseMarkdownFile(content);
 					if (!parsed) {
 						skipped++;
 						continue;
@@ -344,7 +296,7 @@ export function createMarkdownMaterializer<
 					tableConfig?.serialize ??
 					((row) => ({
 						filename: `${row.id}.md`,
-						content: buildMarkdown({ ...row }),
+					content: toMarkdown({ ...row }),
 					}));
 
 				await mkdir(directory, { recursive: true });

--- a/packages/workspace/src/extensions/materializer/markdown/materializer.ts
+++ b/packages/workspace/src/extensions/materializer/markdown/materializer.ts
@@ -1,67 +1,17 @@
+import { mkdir, readFile, readdir, unlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { YAML } from 'bun';
 import type { MaybePromise } from '../../../workspace/lifecycle.js';
 import type { KvHelper, TableHelper } from '../../../workspace/types.js';
 import type { SerializeResult } from './markdown.js';
 
 /**
- * Filesystem operations the materializer needs. Inject a custom adapter to run
- * in runtimes other than Node/Bun (e.g. Tauri's `@tauri-apps/plugin-fs`).
- *
- * When omitted, defaults to Node's `fs/promises` + `path.join` which also
- * work in Bun.
- */
-export type MaterializerIO = {
-	mkdir(dir: string): Promise<void>;
-	writeFile(path: string, content: string): Promise<void>;
-	readFile(path: string): Promise<string>;
-	readdir(dir: string): Promise<string[]>;
-	removeFile(path: string): Promise<void>;
-	joinPath(...segments: string[]): MaybePromise<string>;
-};
-
-/**
- * YAML serialization adapter. Inject a custom implementation to avoid the
- * `bun` global (e.g. `js-yaml` or `yaml` npm package).
- *
- * When omitted, defaults to `YAML.stringify` from the `bun` global.
- */
-export type MaterializerYaml = {
-	stringify(obj: Record<string, unknown>): string;
-	parse(yaml: string): unknown;
-};
-
-/** Lazily resolve Node/Bun default IO. Only imported when actually used. */
-function createDefaultIO(): MaterializerIO {
-	// Dynamic require avoids top-level import that would fail in browser runtimes.
-	const fs = require('node:fs/promises') as typeof import('node:fs/promises');
-	const path = require('node:path') as typeof import('node:path');
-
-	return {
-		mkdir: (dir) => fs.mkdir(dir, { recursive: true }),
-		writeFile: (filePath, content) => fs.writeFile(filePath, content),
-		readFile: (filePath) => fs.readFile(filePath, 'utf-8'),
-		readdir: (dir) => fs.readdir(dir),
-		removeFile: (filePath) => fs.unlink(filePath).catch(() => {}),
-		joinPath: (...segments) => path.join(...segments),
-	};
-}
-
-/** Lazily resolve Bun YAML default. Only called when no yaml adapter is provided. */
-function createDefaultYaml(): MaterializerYaml {
-	const { YAML } = require('bun') as typeof import('bun');
-	return {
-		stringify: (obj) => YAML.stringify(obj, null, 2) as string,
-		parse: (str) => YAML.parse(str) as unknown,
-	};
-}
-
-/**
  * Build a markdown string from YAML frontmatter and an optional body.
  *
- * Pure function—no I/O. Uses the provided YAML stringifier.
- * Undefined values are stripped; null values are preserved.
+ * Pure function—no I/O. Uses Bun's `YAML.stringify` for spec-compliant
+ * serialization. Undefined values are stripped; null values are preserved.
  */
 function buildMarkdown(
-	yaml: MaterializerYaml,
 	frontmatter: Record<string, unknown>,
 	body?: string,
 ): string {
@@ -71,7 +21,7 @@ function buildMarkdown(
 			cleaned[key] = value;
 		}
 	}
-	const yamlStr = yaml.stringify(cleaned);
+	const yamlStr = YAML.stringify(cleaned, null, 2) as string;
 	const yamlBlock = yamlStr.endsWith('\n') ? yamlStr : `${yamlStr}\n`;
 	return body !== undefined
 		? `---\n${yamlBlock}---\n\n${body}\n`
@@ -88,8 +38,6 @@ function buildMarkdown(
  * The materializer awaits `ctx.whenReady` before reading data, so persistence
  * and sync have loaded before the initial flush. All `.table()` and `.kv()`
  * calls happen synchronously in the factory closure before `whenReady` resolves.
- *
- * Custom `io` and `yaml` adapters can be injected for non-Node/Bun runtimes or testing.
  *
  * @example
  * ```typescript
@@ -110,15 +58,8 @@ export function createMarkdownMaterializer<
 	config: {
 		/** Base output directory. Accepts a string or async getter for runtimes where the path isn't known until initialization (e.g. Tauri's `appDataDir()`). */
 		dir: string | (() => MaybePromise<string>);
-		/** Filesystem adapter. Defaults to Node `fs/promises` + `path.join` (works in Bun). */
-		io?: MaterializerIO;
-		/** YAML serializer. Defaults to `YAML.stringify` from the `bun` global. */
-		yaml?: MaterializerYaml;
 	},
 ) {
-	const io = config.io ?? createDefaultIO();
-	const yaml = config.yaml ?? createDefaultYaml();
-
 	type TableConfigByName = {
 		[TName in keyof TTables & string]?: {
 			dir?: string;
@@ -128,7 +69,9 @@ export function createMarkdownMaterializer<
 			deserialize?: (parsed: {
 				frontmatter: Record<string, unknown>;
 				body: string | undefined;
-			}) => MaybePromise<TTables[TName] extends TableHelper<infer TRow> ? TRow : never>;
+			}) => MaybePromise<
+				TTables[TName] extends TableHelper<infer TRow> ? TRow : never
+			>;
 		};
 	};
 
@@ -147,7 +90,9 @@ export function createMarkdownMaterializer<
 				deserialize?: (parsed: {
 					frontmatter: Record<string, unknown>;
 					body: string | undefined;
-				}) => MaybePromise<TTables[TName] extends TableHelper<infer TRow> ? TRow : never>;
+				}) => MaybePromise<
+					TTables[TName] extends TableHelper<infer TRow> ? TRow : never
+				>;
 			},
 		): MaterializerBuilder;
 		/**
@@ -170,7 +115,11 @@ export function createMarkdownMaterializer<
 		 *
 		 * **This overwrites existing rows**—`table.set()` is insert-or-replace.
 		 */
-		pushFromMarkdown(): Promise<{ imported: number; skipped: number; errors: string[] }>;
+		pushFromMarkdown(): Promise<{
+			imported: number;
+			skipped: number;
+			errors: string[];
+		}>;
 		/**
 		 * Re-materialize all Yjs table data to markdown files on disk.
 		 *
@@ -198,21 +147,21 @@ export function createMarkdownMaterializer<
 	) => {
 		const table = ctx.tables[name];
 		const tableConfig = tableConfigs[name];
-		const directory = await io.joinPath(dir, tableConfig?.dir ?? name);
+		const directory = join(dir, tableConfig?.dir ?? name);
 		const filenames = new Map<string, string>();
 
 		const serialize: (row: TableRow<TName>) => MaybePromise<SerializeResult> =
 			tableConfig?.serialize ??
 			((row) => ({
 				filename: `${row.id}.md`,
-				content: buildMarkdown(yaml, { ...row }),
+				content: buildMarkdown({ ...row }),
 			}));
 
-		await io.mkdir(directory);
+		await mkdir(directory, { recursive: true });
 
 		for (const row of table.getAllValid()) {
 			const result = await serialize(row);
-			await io.writeFile(await io.joinPath(directory, result.filename), result.content);
+			await writeFile(join(directory, result.filename), result.content);
 			filenames.set(row.id, result.filename);
 		}
 
@@ -226,7 +175,7 @@ export function createMarkdownMaterializer<
 					if (getResult.status === 'not_found') {
 						const previousFilename = filenames.get(id);
 						if (previousFilename) {
-							await io.removeFile(await io.joinPath(directory, previousFilename));
+							await unlink(join(directory, previousFilename)).catch(() => {});
 							filenames.delete(id);
 						}
 						continue;
@@ -240,10 +189,10 @@ export function createMarkdownMaterializer<
 					const previousFilename = filenames.get(id);
 
 					if (previousFilename && previousFilename !== result.filename) {
-						await io.removeFile(await io.joinPath(directory, previousFilename));
+						await unlink(join(directory, previousFilename)).catch(() => {});
 					}
 
-					await io.writeFile(await io.joinPath(directory, result.filename), result.content);
+					await writeFile(join(directory, result.filename), result.content);
 					filenames.set(id, result.filename);
 				}
 			})().catch((error) => {
@@ -265,7 +214,7 @@ export function createMarkdownMaterializer<
 
 		// Initial flush with the full snapshot
 		const initial = serialize(kvState);
-		await io.writeFile(await io.joinPath(dir, initial.filename), initial.content);
+		await writeFile(join(dir, initial.filename), initial.content);
 
 		const unsubscribe = ctx.kv.observeAll((changes) => {
 			void (async () => {
@@ -279,7 +228,7 @@ export function createMarkdownMaterializer<
 				}
 
 				const result = serialize(kvState);
-				await io.writeFile(await io.joinPath(dir, result.filename), result.content);
+				await writeFile(join(dir, result.filename), result.content);
 			})().catch((error) => {
 				console.warn('[markdown-materializer] kv write failed:', error);
 			});
@@ -292,7 +241,7 @@ export function createMarkdownMaterializer<
 	const FRONTMATTER_PATTERN =
 		/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/;
 
-	/** Parse frontmatter + body from a markdown string using the injected yaml adapter. */
+	/** Parse frontmatter + body from a markdown string. */
 	function parseFrontmatter(content: string): {
 		frontmatter: Record<string, unknown>;
 		body: string | undefined;
@@ -301,7 +250,7 @@ export function createMarkdownMaterializer<
 		const match = input.match(FRONTMATTER_PATTERN);
 		if (!match) return null;
 
-		const frontmatter = yaml.parse(match[1]);
+		const frontmatter = YAML.parse(match[1]);
 		if (typeof frontmatter !== 'object' || frontmatter === null) return null;
 
 		const rawBody = input
@@ -339,11 +288,11 @@ export function createMarkdownMaterializer<
 			for (const name of tableNames) {
 				const table = ctx.tables[name];
 				const tableConfig = tableConfigs[name];
-				const directory = await io.joinPath(dir, tableConfig?.dir ?? name);
+				const directory = join(dir, tableConfig?.dir ?? name);
 
 				let entries: string[];
 				try {
-					entries = await io.readdir(directory);
+					entries = await readdir(directory);
 				} catch {
 					continue;
 				}
@@ -353,7 +302,7 @@ export function createMarkdownMaterializer<
 
 					let content: string;
 					try {
-						content = await io.readFile(await io.joinPath(directory, filename));
+						content = await readFile(join(directory, filename), 'utf-8');
 					} catch (error) {
 						errors.push(`Failed to read ${filename}: ${error}`);
 						continue;
@@ -366,8 +315,9 @@ export function createMarkdownMaterializer<
 					}
 
 					try {
-						const deserialize = tableConfig?.deserialize
-							?? ((p: { frontmatter: Record<string, unknown> }) => p.frontmatter);
+						const deserialize =
+							tableConfig?.deserialize ??
+							((p: { frontmatter: Record<string, unknown> }) => p.frontmatter);
 						const row = await deserialize(parsed);
 						table.set(row);
 						imported++;
@@ -386,20 +336,22 @@ export function createMarkdownMaterializer<
 			for (const name of tableNames) {
 				const table = ctx.tables[name];
 				const tableConfig = tableConfigs[name];
-				const directory = await io.joinPath(dir, tableConfig?.dir ?? name);
+				const directory = join(dir, tableConfig?.dir ?? name);
 
-				const serialize: (row: TableRow<typeof name>) => MaybePromise<SerializeResult> =
+				const serialize: (
+					row: TableRow<typeof name>,
+				) => MaybePromise<SerializeResult> =
 					tableConfig?.serialize ??
 					((row) => ({
 						filename: `${row.id}.md`,
-						content: buildMarkdown(yaml, { ...row }),
+						content: buildMarkdown({ ...row }),
 					}));
 
-				await io.mkdir(directory);
+				await mkdir(directory, { recursive: true });
 
 				for (const row of table.getAllValid()) {
 					const result = await serialize(row);
-					await io.writeFile(await io.joinPath(directory, result.filename), result.content);
+					await writeFile(join(directory, result.filename), result.content);
 					written++;
 				}
 			}
@@ -409,7 +361,7 @@ export function createMarkdownMaterializer<
 		whenReady: (async () => {
 			await ctx.whenReady;
 			const dir = await resolveDir();
-			await io.mkdir(dir);
+			await mkdir(dir, { recursive: true });
 
 			for (const name of tableNames) {
 				await materializeTable(name, dir);

--- a/packages/workspace/src/extensions/materializer/markdown/materializer.ts
+++ b/packages/workspace/src/extensions/materializer/markdown/materializer.ts
@@ -294,10 +294,10 @@ export function createMarkdownMaterializer<
 					row: TableRow<typeof name>,
 				) => MaybePromise<SerializeResult> =
 					tableConfig?.serialize ??
-					((row) => ({
-						filename: `${row.id}.md`,
+				((row) => ({
+					filename: `${row.id}.md`,
 					content: toMarkdown({ ...row }),
-					}));
+				}));
 
 				await mkdir(directory, { recursive: true });
 


### PR DESCRIPTION
The markdown materializer had two adapter types—`MaterializerIO` (7 methods for filesystem operations) and `MaterializerYaml` (2 methods for YAML serialization)—so that non-Node runtimes like Tauri could inject their own implementations. But Whispering, the only Tauri app in the monorepo, chose Rust commands over JS-side IO injection. The adapter types shipped, got exported from the barrel, had JSDoc examples showing Tauri wiring that nobody copied, and every real consumer just used the defaults.

```typescript
// Before — adapter types that no consumer ever provided
createMarkdownMaterializer(ctx, {
  dir: './data',
  io?: MaterializerIO,    // 7 methods, always defaulted to fs/promises
  yaml?: MaterializerYaml, // 2 methods, always defaulted to bun YAML
})

// After — just the directory
createMarkdownMaterializer(ctx, { dir: './data' })
```

Removing the DI also exposed two internal helpers—`buildMarkdown` and `parseFrontmatter`—that only existed because they needed to call the injected `yaml.stringify`/`yaml.parse` instead of importing directly. With the adapters gone, both are line-for-line duplicates of their siblings `toMarkdown` (from `./markdown.js`) and `parseMarkdownFile` (from `./parse-markdown-file.js`). The second commit replaces them with the existing implementations.

```
Before:
  materializer.ts
    ├── buildMarkdown()        ← duplicate of toMarkdown()
    ├── parseFrontmatter()     ← duplicate of parseMarkdownFile()
    ├── FRONTMATTER_PATTERN    ← duplicate regex
    ├── createDefaultIO()      ← factory for fs/promises wrapper
    └── createDefaultYaml()    ← factory for bun YAML wrapper

After:
  materializer.ts
    ├── import { toMarkdown } from './markdown.js'
    └── import { parseMarkdownFile } from './parse-markdown-file.js'
```

Tests were rewritten to use real temp directories (matching the existing `prepare-markdown-files.test.ts` pattern) instead of in-memory IO mocks that depended on the adapter types. 38 tests pass.

Net change across 3 files: 174 insertions, 316 deletions, -142 lines.

**BREAKING CHANGE:** `MaterializerIO` and `MaterializerYaml` types are removed from the public API. Any consumer that injected custom `io`/`yaml` adapters should implement a custom `withWorkspaceExtension` observer instead (as Whispering does with Rust commands).