### PR TITLE
refactor(workspace): fold link conversion into toMarkdown, remove markdown() wrapper

### DIFF
--- a/packages/workspace/src/extensions/materializer/markdown/index.ts
+++ b/packages/workspace/src/extensions/materializer/markdown/index.ts
@@ -1,9 +1,5 @@
+export { type SerializeResult, toMarkdown } from './markdown.js';
 export { createMarkdownMaterializer } from './materializer.js';
-export {
-	markdown,
-	type SerializeResult,
-	toMarkdown,
-} from './markdown.js';
 export { parseMarkdownFile } from './parse-markdown-file.js';
 export { prepareMarkdownFiles } from './prepare-markdown-files.js';
 export {

--- a/packages/workspace/src/extensions/materializer/markdown/markdown.ts
+++ b/packages/workspace/src/extensions/materializer/markdown/markdown.ts
@@ -4,6 +4,9 @@ import { convertEpicenterLinksToWikilinks } from '../../../links.js';
 /**
  * Assemble a markdown string from YAML frontmatter and an optional body.
  *
+ * When a body is provided, epicenter links are automatically converted to
+ * wikilinks before serialization.
+ *
  * Pure function — no I/O. Uses `Bun.YAML.stringify` for spec-compliant
  * serialization (handles quoting of booleans, numeric strings, special
  * characters, newlines, etc.). Undefined frontmatter values are stripped
@@ -22,8 +25,10 @@ export function toMarkdown(
 	}
 	const yaml = YAML.stringify(cleaned, null, 2);
 	const yamlBlock = yaml.endsWith('\n') ? yaml : `${yaml}\n`;
-	return body !== undefined
-		? `---\n${yamlBlock}---\n\n${body}\n`
+	const convertedBody =
+		body !== undefined ? convertEpicenterLinksToWikilinks(body) : undefined;
+	return convertedBody !== undefined
+		? `---\n${yamlBlock}---\n\n${convertedBody}\n`
 		: `---\n${yamlBlock}---\n`;
 }
 
@@ -31,35 +36,3 @@ export type SerializeResult = {
 	filename: string;
 	content: string;
 };
-
-/**
- * Convert frontmatter + body to a markdown file result.
- *
- * Applies epicenter link to wikilink conversion on body content.
- * Handles undefined body (frontmatter-only output).
- *
- * For markdown WITHOUT link conversion, use `toMarkdown()` directly:
- * ```typescript
- * serialize: (row) => ({
- *     filename: `${row.id}.md`,
- *     content: toMarkdown({ id: row.id, title: row.title }, body),
- * })
- * ```
- */
-export function markdown({
-	frontmatter,
-	body,
-	filename,
-}: {
-	frontmatter: Record<string, unknown>;
-	body?: string;
-	filename: string;
-}): SerializeResult {
-	return {
-		filename,
-		content: toMarkdown(
-			frontmatter,
-			body !== undefined ? convertEpicenterLinksToWikilinks(body) : body,
-		),
-	};
-}

--- a/packages/workspace/src/extensions/materializer/markdown/materializer.ts
+++ b/packages/workspace/src/extensions/materializer/markdown/materializer.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, readdir, unlink, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, unlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { MaybePromise } from '../../../workspace/lifecycle.js';
 import type { KvHelper, TableHelper } from '../../../workspace/types.js';
@@ -215,7 +215,6 @@ export function createMarkdownMaterializer<
 		unsubscribers.push(unsubscribe);
 	};
 
-
 	/** Resolve the base directory, handling string or async getter. */
 	const resolveDir = async () =>
 		typeof config.dir === 'function' ? await config.dir() : config.dir;
@@ -294,10 +293,10 @@ export function createMarkdownMaterializer<
 					row: TableRow<typeof name>,
 				) => MaybePromise<SerializeResult> =
 					tableConfig?.serialize ??
-				((row) => ({
-					filename: `${row.id}.md`,
-					content: toMarkdown({ ...row }),
-				}));
+					((row) => ({
+						filename: `${row.id}.md`,
+						content: toMarkdown({ ...row }),
+					}));
 
 				await mkdir(directory, { recursive: true });
 

--- a/packages/workspace/src/extensions/materializer/markdown/serializers.ts
+++ b/packages/workspace/src/extensions/materializer/markdown/serializers.ts
@@ -1,6 +1,6 @@
 import slugify from '@sindresorhus/slugify';
 import filenamify from 'filenamify';
-import { markdown, type SerializeResult } from './markdown.js';
+import { type SerializeResult, toMarkdown } from './markdown.js';
 
 /** Max slug length before the ID suffix. */
 const MAX_SLUG_LENGTH = 50;
@@ -31,7 +31,10 @@ export function toIdFilename(id: string): string {
  * // 'abc123.md'
  * ```
  */
-export function toSlugFilename(title: string | undefined | null, id: string): string {
+export function toSlugFilename(
+	title: string | undefined | null,
+	id: string,
+): string {
 	if (!title || title.trim().length === 0) {
 		return toIdFilename(id);
 	}
@@ -44,21 +47,20 @@ export function toSlugFilename(title: string | undefined | null, id: string): st
 /**
  * Create a serializer that uses a row field to generate `{slug}-{id}.md` filenames.
  * All row fields are written to frontmatter.
- *
- * @remarks Produces markdown output via markdown() internally.
+ * @remarks Produces markdown output via toMarkdown() internally.
  */
 export function slugFilename(
 	fieldName: string,
 ): (row: Record<string, unknown>) => SerializeResult {
 	return (row) => {
 		const titleValue = row[fieldName];
-		return markdown({
-			frontmatter: { ...row },
+		return {
 			filename: toSlugFilename(
 				typeof titleValue === 'string' ? titleValue : undefined,
 				String(row.id),
 			),
-		});
+			content: toMarkdown({ ...row }),
+		};
 	};
 }
 
@@ -66,7 +68,7 @@ export function slugFilename(
  * Create a serializer that moves one field into the markdown body and keeps the
  * remaining row fields in frontmatter.
  *
- * @remarks Produces markdown output via markdown() internally.
+ * @remarks Produces markdown output via toMarkdown() internally.
  */
 export function bodyField(
 	fieldName: string,
@@ -74,13 +76,14 @@ export function bodyField(
 	return (row) => {
 		const { [fieldName]: bodyValue, ...frontmatter } = row;
 
-		return markdown({
-			frontmatter,
-			body:
+		return {
+			filename: toIdFilename(String(row.id)),
+			content: toMarkdown(
+				frontmatter,
 				bodyValue !== undefined && bodyValue !== null
 					? String(bodyValue)
 					: undefined,
-			filename: toIdFilename(String(row.id)),
-		});
+			),
+		};
 	};
 }

--- a/playground/opensidian-e2e/epicenter.config.ts
+++ b/playground/opensidian-e2e/epicenter.config.ts
@@ -26,8 +26,8 @@ import {
 import { createWorkspace, defineMutation } from '@epicenter/workspace';
 import {
 	createMarkdownMaterializer,
-	markdown,
 	prepareMarkdownFiles,
+	toMarkdown,
 	toSlugFilename,
 } from '@epicenter/workspace/extensions/materializer/markdown';
 import { createSqliteMaterializer } from '@epicenter/workspace/extensions/materializer/sqlite';
@@ -55,10 +55,10 @@ export const opensidian = createWorkspace(opensidianDefinition)
 			.table('files', {
 				serialize: async (row) => {
 					if (row.type === 'folder') {
-						return markdown({
-							frontmatter: { id: row.id, name: row.name, type: 'folder' },
+						return {
 							filename: `${row.id}.md`,
-						});
+							content: toMarkdown({ id: row.id, name: row.name, type: 'folder' }),
+						};
 					}
 					let content: string | undefined;
 					try {
@@ -67,22 +67,24 @@ export const opensidian = createWorkspace(opensidianDefinition)
 					} catch {
 						// Content doc not yet available (sync pending)
 					}
-					return markdown({
-						frontmatter: {
-							id: row.id,
-							name: row.name,
-							parentId: row.parentId,
-							size: row.size,
-							createdAt: row.createdAt,
-							updatedAt: row.updatedAt,
-							trashedAt: row.trashedAt,
-						},
-						body: content,
+					return {
 						filename: toSlugFilename(
 							row.name.replace(/\.md$/i, ''),
 							row.id,
 						),
-					});
+						content: toMarkdown(
+							{
+								id: row.id,
+								name: row.name,
+								parentId: row.parentId,
+								size: row.size,
+								createdAt: row.createdAt,
+								updatedAt: row.updatedAt,
+								trashedAt: row.trashedAt,
+							},
+							content,
+						),
+					};
 				},
 			}),
 	)


### PR DESCRIPTION
There was a subtle split between `toMarkdown()` and `markdown()`: the former assembled markdown but skipped link conversion, while the latter wrapped it to add epicenter-to-wikilink conversion. That meant the default serializer, `slugFilename()`, and `prepareMarkdownFiles` all called `toMarkdown()` directly and silently bypassed conversion. No consumer hit this today, but any future caller using the default path with body content would've gotten raw epicenter links on disk.

The fix is to collapse the two into one. `toMarkdown()` now handles link conversion itself when a body is provided, and `markdown()` is deleted since it had no remaining purpose. Call sites that used `markdown()` now call `toMarkdown()` directly with explicit args, and `markdown` is removed from public exports.

Net −27 lines, one fewer export.