### PR TITLE
refactor(blob-store): flatten BlobStore to composable interface

### DIFF
--- a/apps/whispering/src/lib/services/blob-store/desktop.ts
+++ b/apps/whispering/src/lib/services/blob-store/desktop.ts
@@ -5,10 +5,10 @@ import { BlobError } from './types';
 import { createBlobStoreWeb } from './web';
 
 /**
- * Desktop blob store service — audio blob store with dual-source fallback.
+ * Desktop blob store with dual-source fallback.
  *
  * Recording metadata lives in the workspace (Yjs CRDT). The blob store
- * only manages audio blobs. Audio reads check file system first, then
+ * only manages binary blobs. Reads check file system first, then
  * fall back to IndexedDB for unmigrated data.
  *
  */
@@ -18,106 +18,104 @@ export function createBlobStoreDesktop(): BlobStore {
 	const indexedDb = createBlobStoreWeb();
 
 	return {
-		audio: {
-			save: async (recordingId, audio) => {
-				// SINGLE WRITE: Only to file system
-				return fileSystemDb.audio.save(recordingId, audio);
-			},
+		save: async (recordingId, audio) => {
+			// SINGLE WRITE: Only to file system
+			return fileSystemDb.save(recordingId, audio);
+		},
 
-			delete: async (idOrIds) => {
-				const ids = Array.isArray(idOrIds) ? idOrIds : [idOrIds];
-				// Delete from BOTH sources to ensure complete removal
-				const [fsResult, idbResult] = await Promise.all([
-					fileSystemDb.audio.delete(ids),
-					indexedDb.audio.delete(ids),
-				]);
+		delete: async (idOrIds) => {
+			const ids = Array.isArray(idOrIds) ? idOrIds : [idOrIds];
+			// Delete from BOTH sources to ensure complete removal
+			const [fsResult, idbResult] = await Promise.all([
+				fileSystemDb.delete(ids),
+				indexedDb.delete(ids),
+			]);
 
-				// If both failed, return an error
-				if (fsResult.error && idbResult.error) {
-					return BlobError.WriteFailed({ cause: fsResult.error });
-				}
+			// If both failed, return an error
+			if (fsResult.error && idbResult.error) {
+				return BlobError.WriteFailed({ cause: fsResult.error });
+			}
 
-				// Success if at least one succeeded
-				return Ok(undefined);
-			},
+			// Success if at least one succeeded
+			return Ok(undefined);
+		},
 
-			getBlob: async (recordingId) => {
-				// DUAL READ: Check file system first, fallback to IndexedDB
-				const fsResult = await fileSystemDb.audio.getBlob(recordingId);
+		getBlob: async (recordingId) => {
+			// DUAL READ: Check file system first, fallback to IndexedDB
+			const fsResult = await fileSystemDb.getBlob(recordingId);
 
-				// If found in file system, return it
-				if (fsResult.data) {
-					return Ok(fsResult.data);
-				}
+			// If found in file system, return it
+			if (fsResult.data) {
+				return Ok(fsResult.data);
+			}
 
-				// Not in file system, check IndexedDB
-				const idbResult = await indexedDb.audio.getBlob(recordingId);
+			// Not in file system, check IndexedDB
+			const idbResult = await indexedDb.getBlob(recordingId);
 
-				// If found in IndexedDB, return it
-				if (idbResult.data) {
-					return Ok(idbResult.data);
-				}
+			// If found in IndexedDB, return it
+			if (idbResult.data) {
+				return Ok(idbResult.data);
+			}
 
-				// If both failed, return an error
-				if (fsResult.error && idbResult.error) {
-					return BlobError.ReadFailed({ cause: fsResult.error });
-				}
+			// If both failed, return an error
+			if (fsResult.error && idbResult.error) {
+				return BlobError.ReadFailed({ cause: fsResult.error });
+			}
 
-				// Not found in either source (but no errors)
-				return BlobError.ReadFailed({
-					cause: new Error(`Audio not found for recording ${recordingId}`),
-				});
-			},
+			// Not found in either source (but no errors)
+			return BlobError.ReadFailed({
+				cause: new Error(`Audio not found for recording ${recordingId}`),
+			});
+		},
 
-			ensurePlaybackUrl: async (recordingId) => {
-				// DUAL READ: Check file system first, fallback to IndexedDB
-				const fsResult =
-					await fileSystemDb.audio.ensurePlaybackUrl(recordingId);
+		ensurePlaybackUrl: async (recordingId) => {
+			// DUAL READ: Check file system first, fallback to IndexedDB
+			const fsResult =
+				await fileSystemDb.ensurePlaybackUrl(recordingId);
 
-				// If found in file system, return it
-				if (fsResult.data) {
-					return Ok(fsResult.data);
-				}
+			// If found in file system, return it
+			if (fsResult.data) {
+				return Ok(fsResult.data);
+			}
 
-				// Not in file system, check IndexedDB
-				const idbResult = await indexedDb.audio.ensurePlaybackUrl(recordingId);
+			// Not in file system, check IndexedDB
+			const idbResult = await indexedDb.ensurePlaybackUrl(recordingId);
 
-				// If found in IndexedDB, return it
-				if (idbResult.data) {
-					return Ok(idbResult.data);
-				}
+			// If found in IndexedDB, return it
+			if (idbResult.data) {
+				return Ok(idbResult.data);
+			}
 
-				// If both failed, return an error
-				if (fsResult.error && idbResult.error) {
-					return BlobError.ReadFailed({ cause: fsResult.error });
-				}
+			// If both failed, return an error
+			if (fsResult.error && idbResult.error) {
+				return BlobError.ReadFailed({ cause: fsResult.error });
+			}
 
-				// Not found in either source (but no errors)
-				return BlobError.ReadFailed({
-					cause: new Error(`Audio not found for recording ${recordingId}`),
-				});
-			},
+			// Not found in either source (but no errors)
+			return BlobError.ReadFailed({
+				cause: new Error(`Audio not found for recording ${recordingId}`),
+			});
+		},
 
-			revokeUrl: (recordingId) => {
-				// Revoke from BOTH sources
-				fileSystemDb.audio.revokeUrl(recordingId);
-				indexedDb.audio.revokeUrl(recordingId);
-			},
+		revokeUrl: (recordingId) => {
+			// Revoke from BOTH sources
+			fileSystemDb.revokeUrl(recordingId);
+			indexedDb.revokeUrl(recordingId);
+		},
 
-			clear: async () => {
-				// Clear from BOTH sources
-				const [fsResult, idbResult] = await Promise.all([
-					fileSystemDb.audio.clear(),
-					indexedDb.audio.clear(),
-				]);
+		clear: async () => {
+			// Clear from BOTH sources
+			const [fsResult, idbResult] = await Promise.all([
+				fileSystemDb.clear(),
+				indexedDb.clear(),
+			]);
 
-				// Return error only if both failed
-				if (fsResult.error && idbResult.error) {
-					return BlobError.WriteFailed({ cause: fsResult.error });
-				}
+			// Return error only if both failed
+			if (fsResult.error && idbResult.error) {
+				return BlobError.WriteFailed({ cause: fsResult.error });
+			}
 
-				return Ok(undefined);
-			},
+			return Ok(undefined);
 		},
 	};
 }

--- a/apps/whispering/src/lib/services/blob-store/file-system.ts
+++ b/apps/whispering/src/lib/services/blob-store/file-system.ts
@@ -52,116 +52,114 @@ async function deleteFilesInDirectory(
  */
 export function createFileSystemBlobStore(): BlobStore {
 	return {
-		audio: {
-			async save(recordingId, audio) {
-				return tryAsync({
-					try: async () => {
-						const recordingsPath = await PATHS.DB.RECORDINGS();
-						await mkdir(recordingsPath, { recursive: true });
+		async save(recordingId, audio) {
+			return tryAsync({
+				try: async () => {
+					const recordingsPath = await PATHS.DB.RECORDINGS();
+					await mkdir(recordingsPath, { recursive: true });
 
-						const extension = mime.getExtension(audio.type) ?? 'bin';
-						const audioPath = await PATHS.DB.RECORDING_AUDIO(
-							recordingId,
-							extension,
+					const extension = mime.getExtension(audio.type) ?? 'bin';
+					const audioPath = await PATHS.DB.RECORDING_AUDIO(
+						recordingId,
+						extension,
+					);
+					const arrayBuffer = await audio.arrayBuffer();
+					await tauriWriteFile(audioPath, new Uint8Array(arrayBuffer));
+				},
+				catch: (error) => BlobError.WriteFailed({ cause: error }),
+			});
+		},
+
+		async delete(idOrIds) {
+			const ids = Array.isArray(idOrIds) ? idOrIds : [idOrIds];
+			return tryAsync({
+				try: async () => {
+					const recordingsPath = await PATHS.DB.RECORDINGS();
+					const idsToDelete = new Set(ids);
+					const allFiles = await readDir(recordingsPath);
+					const filenames = allFiles
+						.filter((file) => {
+							const id = file.name.split('.')[0] ?? '';
+							return idsToDelete.has(id);
+						})
+						.map((file) => file.name);
+					await deleteFilesInDirectory(recordingsPath, filenames);
+				},
+				catch: (error) => BlobError.WriteFailed({ cause: error }),
+			});
+		},
+
+		async getBlob(recordingId: string) {
+			return tryAsync({
+				try: async () => {
+					const recordingsPath = await PATHS.DB.RECORDINGS();
+					const audioFilename = await findAudioFile(
+						recordingsPath,
+						recordingId,
+					);
+
+					if (!audioFilename) {
+						throw new Error(
+							`Audio file not found for recording ${recordingId}`,
 						);
-						const arrayBuffer = await audio.arrayBuffer();
-						await tauriWriteFile(audioPath, new Uint8Array(arrayBuffer));
-					},
-					catch: (error) => BlobError.WriteFailed({ cause: error }),
-				});
-			},
+					}
 
-			async delete(idOrIds) {
-				const ids = Array.isArray(idOrIds) ? idOrIds : [idOrIds];
-				return tryAsync({
-					try: async () => {
-						const recordingsPath = await PATHS.DB.RECORDINGS();
-						const idsToDelete = new Set(ids);
-						const allFiles = await readDir(recordingsPath);
-						const filenames = allFiles
-							.filter((file) => {
-								const id = file.name.split('.')[0] ?? '';
-								return idsToDelete.has(id);
-							})
-							.map((file) => file.name);
-						await deleteFilesInDirectory(recordingsPath, filenames);
-					},
-					catch: (error) => BlobError.WriteFailed({ cause: error }),
-				});
-			},
+					const audioPath = await PATHS.DB.RECORDING_FILE(audioFilename);
 
-			async getBlob(recordingId: string) {
-				return tryAsync({
-					try: async () => {
-						const recordingsPath = await PATHS.DB.RECORDINGS();
-						const audioFilename = await findAudioFile(
-							recordingsPath,
-							recordingId,
+					// Use existing fsService.pathToBlob utility
+					const { data: blob, error } =
+						await FsServiceLive.pathToBlob(audioPath);
+					if (error) throw error;
+
+					return blob;
+				},
+				catch: (error) => BlobError.ReadFailed({ cause: error }),
+			});
+		},
+
+		async ensurePlaybackUrl(recordingId: string) {
+			return tryAsync({
+				try: async () => {
+					const recordingsPath = await PATHS.DB.RECORDINGS();
+					const audioFilename = await findAudioFile(
+						recordingsPath,
+						recordingId,
+					);
+
+					if (!audioFilename) {
+						throw new Error(
+							`Audio file not found for recording ${recordingId}`,
 						);
+					}
 
-						if (!audioFilename) {
-							throw new Error(
-								`Audio file not found for recording ${recordingId}`,
-							);
-						}
+					const audioPath = await PATHS.DB.RECORDING_FILE(audioFilename);
+					const assetUrl = convertFileSrc(audioPath);
 
-						const audioPath = await PATHS.DB.RECORDING_FILE(audioFilename);
+					// Return the URL as-is from convertFileSrc()
+					// The Tauri backend handles URL decoding automatically
+					return assetUrl;
+				},
+				catch: (error) => BlobError.ReadFailed({ cause: error }),
+			});
+		},
 
-						// Use existing fsService.pathToBlob utility
-						const { data: blob, error } =
-							await FsServiceLive.pathToBlob(audioPath);
-						if (error) throw error;
+		revokeUrl(_recordingId: string) {
+			// No-op on desktop, URLs are asset:// protocol managed by Tauri
+		},
 
-						return blob;
-					},
-					catch: (error) => BlobError.ReadFailed({ cause: error }),
-				});
-			},
+		async clear() {
+			return tryAsync({
+				try: async () => {
+					const recordingsPath = await PATHS.DB.RECORDINGS();
+					const dirExists = await exists(recordingsPath);
+					if (!dirExists) return undefined;
 
-			async ensurePlaybackUrl(recordingId: string) {
-				return tryAsync({
-					try: async () => {
-						const recordingsPath = await PATHS.DB.RECORDINGS();
-						const audioFilename = await findAudioFile(
-							recordingsPath,
-							recordingId,
-						);
-
-						if (!audioFilename) {
-							throw new Error(
-								`Audio file not found for recording ${recordingId}`,
-							);
-						}
-
-						const audioPath = await PATHS.DB.RECORDING_FILE(audioFilename);
-						const assetUrl = convertFileSrc(audioPath);
-
-						// Return the URL as-is from convertFileSrc()
-						// The Tauri backend handles URL decoding automatically
-						return assetUrl;
-					},
-					catch: (error) => BlobError.ReadFailed({ cause: error }),
-				});
-			},
-
-			revokeUrl(_recordingId: string) {
-				// No-op on desktop, URLs are asset:// protocol managed by Tauri
-			},
-
-			async clear() {
-				return tryAsync({
-					try: async () => {
-						const recordingsPath = await PATHS.DB.RECORDINGS();
-						const dirExists = await exists(recordingsPath);
-						if (!dirExists) return undefined;
-
-						const allFiles = await readDir(recordingsPath);
-						const filenames = allFiles.map((file) => file.name);
-						await deleteFilesInDirectory(recordingsPath, filenames);
-					},
-					catch: (error) => BlobError.WriteFailed({ cause: error }),
-				});
-			},
+					const allFiles = await readDir(recordingsPath);
+					const filenames = allFiles.map((file) => file.name);
+					await deleteFilesInDirectory(recordingsPath, filenames);
+				},
+				catch: (error) => BlobError.WriteFailed({ cause: error }),
+			});
 		},
 	};
 }

--- a/apps/whispering/src/lib/services/blob-store/index.ts
+++ b/apps/whispering/src/lib/services/blob-store/index.ts
@@ -4,6 +4,6 @@ import { createBlobStoreWeb } from './web';
 export type { BlobStore } from './types';
 export { BlobError } from './types';
 
-export const BlobStoreLive = window.__TAURI_INTERNALS__
+export const AudioBlobStoreLive = window.__TAURI_INTERNALS__
 	? createBlobStoreDesktop()
 	: createBlobStoreWeb();

--- a/apps/whispering/src/lib/services/blob-store/types.ts
+++ b/apps/whispering/src/lib/services/blob-store/types.ts
@@ -18,30 +18,28 @@ export const BlobError = defineErrors({
 export type BlobError = InferErrors<typeof BlobError>;
 
 export type BlobStore = {
-	audio: {
-		save(recordingId: string, audio: Blob): Promise<Result<void, BlobError>>;
-		delete(id: string | string[]): Promise<Result<void, BlobError>>;
-		clear(): Promise<Result<void, BlobError>>;
+	save(recordingId: string, audio: Blob): Promise<Result<void, BlobError>>;
+	delete(id: string | string[]): Promise<Result<void, BlobError>>;
+	clear(): Promise<Result<void, BlobError>>;
 
-		/**
-		 * Get audio blob by recording ID. Fetches audio on-demand.
-		 * - Desktop: Reads file from predictable path using services.fs.pathToBlob()
-		 * - Web: Fetches from IndexedDB by ID, converts serializedAudio to Blob
-		 */
-		getBlob(recordingId: string): Promise<Result<Blob, BlobError>>;
+	/**
+	 * Get blob by key. Fetches on-demand.
+	 * - Desktop: Reads file from predictable path using services.fs.pathToBlob()
+	 * - Web: Fetches from IndexedDB by ID, converts serialized data to Blob
+	 */
+	getBlob(recordingId: string): Promise<Result<Blob, BlobError>>;
 
-		/**
-		 * Get audio playback URL. Creates and caches URL.
-		 * - Desktop: Uses convertFileSrc() to create asset:// URL
-		 * - Web: Creates and caches object URL, manages lifecycle
-		 */
-		ensurePlaybackUrl(recordingId: string): Promise<Result<string, BlobError>>;
+	/**
+	 * Get playback URL for blob. Creates and caches URL.
+	 * - Desktop: Uses convertFileSrc() to create asset:// URL
+	 * - Web: Creates and caches object URL, manages lifecycle
+	 */
+	ensurePlaybackUrl(recordingId: string): Promise<Result<string, BlobError>>;
 
-		/**
-		 * Revoke audio URL if cached. Cleanup method.
-		 * - Desktop: No-op (asset:// URLs managed by Tauri)
-		 * - Web: Calls URL.revokeObjectURL() and removes from cache
-		 */
-		revokeUrl(recordingId: string): void;
-	};
+	/**
+	 * Revoke cached URL if present. Cleanup method.
+	 * - Desktop: No-op (asset:// URLs managed by Tauri)
+	 * - Web: Calls URL.revokeObjectURL() and removes from cache
+	 */
+	revokeUrl(recordingId: string): void;
 };

--- a/apps/whispering/src/lib/services/blob-store/web/index.ts
+++ b/apps/whispering/src/lib/services/blob-store/web/index.ts
@@ -35,93 +35,91 @@ export function createBlobStoreWeb(): BlobStore {
 	const audioUrlCache = new Map<string, string>();
 
 	return {
-		audio: {
-			async save(recordingId, audio) {
-				const serializedAudio = await blobToSerializedAudio(audio);
-				return tryAsync({
-					try: async () => {
-						await db.recordings.put({ id: recordingId, serializedAudio });
-					},
-					catch: (error) => BlobError.WriteFailed({ cause: error }),
-				});
-			},
+		async save(recordingId, audio) {
+			const serializedAudio = await blobToSerializedAudio(audio);
+			return tryAsync({
+				try: async () => {
+					await db.recordings.put({ id: recordingId, serializedAudio });
+				},
+				catch: (error) => BlobError.WriteFailed({ cause: error }),
+			});
+		},
 
-			delete: async (idOrIds) => {
-				const ids = Array.isArray(idOrIds) ? idOrIds : [idOrIds];
-				return tryAsync({
-					try: () => db.recordings.bulkDelete(ids),
-					catch: (error) => BlobError.WriteFailed({ cause: error }),
-				});
-			},
+		delete: async (idOrIds) => {
+			const ids = Array.isArray(idOrIds) ? idOrIds : [idOrIds];
+			return tryAsync({
+				try: () => db.recordings.bulkDelete(ids),
+				catch: (error) => BlobError.WriteFailed({ cause: error }),
+			});
+		},
 
-			getBlob: async (recordingId) => {
-				return tryAsync({
-					try: async () => {
-						const recordingWithAudio = await db.recordings.get(recordingId);
+		getBlob: async (recordingId) => {
+			return tryAsync({
+				try: async () => {
+					const recordingWithAudio = await db.recordings.get(recordingId);
 
-						if (!recordingWithAudio) {
-							throw new Error(`Recording ${recordingId} not found`);
-						}
+					if (!recordingWithAudio) {
+						throw new Error(`Recording ${recordingId} not found`);
+					}
 
-						if (!recordingWithAudio.serializedAudio) {
-							throw new Error(`No audio found for recording ${recordingId}`);
-						}
+					if (!recordingWithAudio.serializedAudio) {
+						throw new Error(`No audio found for recording ${recordingId}`);
+					}
 
-						const blob = serializedAudioToBlob(
-							recordingWithAudio.serializedAudio,
-						);
-						return blob;
-					},
-					catch: (error) => BlobError.ReadFailed({ cause: error }),
-				});
-			},
+					const blob = serializedAudioToBlob(
+						recordingWithAudio.serializedAudio,
+					);
+					return blob;
+				},
+				catch: (error) => BlobError.ReadFailed({ cause: error }),
+			});
+		},
 
-			ensurePlaybackUrl: async (recordingId) => {
-				return tryAsync({
-					try: async () => {
-						// Check cache first
-						const cachedUrl = audioUrlCache.get(recordingId);
-						if (cachedUrl) {
-							return cachedUrl;
-						}
+		ensurePlaybackUrl: async (recordingId) => {
+			return tryAsync({
+				try: async () => {
+					// Check cache first
+					const cachedUrl = audioUrlCache.get(recordingId);
+					if (cachedUrl) {
+						return cachedUrl;
+					}
 
-						// Fetch blob from IndexedDB
-						const recordingWithAudio = await db.recordings.get(recordingId);
+					// Fetch blob from IndexedDB
+					const recordingWithAudio = await db.recordings.get(recordingId);
 
-						if (!recordingWithAudio) {
-							throw new Error(`Recording ${recordingId} not found`);
-						}
+					if (!recordingWithAudio) {
+						throw new Error(`Recording ${recordingId} not found`);
+					}
 
-						if (!recordingWithAudio.serializedAudio) {
-							throw new Error(`No audio found for recording ${recordingId}`);
-						}
+					if (!recordingWithAudio.serializedAudio) {
+						throw new Error(`No audio found for recording ${recordingId}`);
+					}
 
-						const blob = serializedAudioToBlob(
-							recordingWithAudio.serializedAudio,
-						);
-						const objectUrl = URL.createObjectURL(blob);
-						audioUrlCache.set(recordingId, objectUrl);
+					const blob = serializedAudioToBlob(
+						recordingWithAudio.serializedAudio,
+					);
+					const objectUrl = URL.createObjectURL(blob);
+					audioUrlCache.set(recordingId, objectUrl);
 
-						return objectUrl;
-					},
-					catch: (error) => BlobError.ReadFailed({ cause: error }),
-				});
-			},
+					return objectUrl;
+				},
+				catch: (error) => BlobError.ReadFailed({ cause: error }),
+			});
+		},
 
-			revokeUrl: (recordingId) => {
-				const url = audioUrlCache.get(recordingId);
-				if (url) {
-					URL.revokeObjectURL(url);
-					audioUrlCache.delete(recordingId);
-				}
-			},
+		revokeUrl: (recordingId) => {
+			const url = audioUrlCache.get(recordingId);
+			if (url) {
+				URL.revokeObjectURL(url);
+				audioUrlCache.delete(recordingId);
+			}
+		},
 
-			clear: async () => {
-				return tryAsync({
-					try: () => db.recordings.clear(),
-					catch: (error) => BlobError.WriteFailed({ cause: error }),
-				});
-			},
-		}, // End of audio namespace
+		clear: async () => {
+			return tryAsync({
+				try: () => db.recordings.clear(),
+				catch: (error) => BlobError.WriteFailed({ cause: error }),
+			});
+		},
 	};
 }

--- a/apps/whispering/src/lib/services/index.ts
+++ b/apps/whispering/src/lib/services/index.ts
@@ -1,5 +1,5 @@
 import { AnalyticsServiceLive } from './analytics';
-import { BlobStoreLive } from './blob-store';
+import { AudioBlobStoreLive } from './blob-store';
 import * as completions from './completion';
 import { DownloadServiceLive } from './download';
 import { LocalShortcutManagerLive } from './local-shortcut-manager';
@@ -19,7 +19,7 @@ export const services = {
 	analytics: AnalyticsServiceLive,
 	text: TextServiceLive,
 	completions,
-	blobs: BlobStoreLive,
+	blobs: { audio: AudioBlobStoreLive },
 	download: DownloadServiceLive,
 	localShortcutManager: LocalShortcutManagerLive,
 	notification: NotificationServiceLive,


### PR DESCRIPTION
The `BlobStore` type had an `audio:` namespace baked into the interface itself, which meant every implementation (filesystem, IndexedDB, desktop dual-source) returned `{ audio: { save, getBlob, delete, ... } }`. That worked fine with one content type, but it wires "audio" into the type system where it doesn't belong—the store doesn't care what kind of blob it holds.

This flattens `BlobStore` to a generic interface and moves the namespacing to the services registry:

```typescript
// Before — namespace inside the type
type BlobStore = {
  audio: {
    save(recordingId: string, audio: Blob): ...;
    getBlob(recordingId: string): ...;
    // ...
  };
};

services.blobs       // BlobStore (with audio: inside)

// After — flat type, composed at registry
type BlobStore = {
  save(recordingId: string, audio: Blob): ...;
  getBlob(recordingId: string): ...;
  // ...
};

services.blobs.audio // BlobStore instance
```

Call sites are identical before and after—`services.blobs.audio.save(...)` resolves the same way, just through registry composition instead of type nesting. This mirrors how `CompletionService` already works: a flat interface with multiple named instances (`services.completions.anthropic`, `services.completions.google`, etc.).

```
services/
├── index.ts             blobs: { audio: AudioBlobStoreLive }
└── blob-store/
    ├── types.ts          flat BlobStore interface
    ├── index.ts          AudioBlobStoreLive (platform detection)
    ├── desktop.ts        dual-source compositor (fs → idb fallback)
    ├── file-system.ts    Tauri filesystem implementation
    └── web/index.ts      IndexedDB/Dexie implementation
```

When a second content type needs blob storage (attachments, thumbnails, etc.), adding it is now just creating another `BlobStore` instance and registering it: `blobs: { audio: ..., attachments: ... }`.

6 files changed, zero call-site modifications.