### PR TITLE
refactor(blob-store): clean up post-flattening code smells

### DIFF
--- a/apps/whispering/src/lib/services/blob-store/desktop.ts
+++ b/apps/whispering/src/lib/services/blob-store/desktop.ts
@@ -18,9 +18,9 @@ export function createBlobStoreDesktop(): BlobStore {
 	const indexedDb = createBlobStoreWeb();
 
 	return {
-		save: async (recordingId, audio) => {
+		save: async (key, blob) => {
 			// SINGLE WRITE: Only to file system
-			return fileSystemDb.save(recordingId, audio);
+			return fileSystemDb.save(key, blob);
 		},
 
 		delete: async (idOrIds) => {
@@ -40,9 +40,9 @@ export function createBlobStoreDesktop(): BlobStore {
 			return Ok(undefined);
 		},
 
-		getBlob: async (recordingId) => {
+		getBlob: async (key) => {
 			// DUAL READ: Check file system first, fallback to IndexedDB
-			const fsResult = await fileSystemDb.getBlob(recordingId);
+			const fsResult = await fileSystemDb.getBlob(key);
 
 			// If found in file system, return it
 			if (fsResult.data) {
@@ -50,7 +50,7 @@ export function createBlobStoreDesktop(): BlobStore {
 			}
 
 			// Not in file system, check IndexedDB
-			const idbResult = await indexedDb.getBlob(recordingId);
+			const idbResult = await indexedDb.getBlob(key);
 
 			// If found in IndexedDB, return it
 			if (idbResult.data) {
@@ -64,14 +64,14 @@ export function createBlobStoreDesktop(): BlobStore {
 
 			// Not found in either source (but no errors)
 			return BlobError.ReadFailed({
-				cause: new Error(`Audio not found for recording ${recordingId}`),
+				cause: new Error(`Blob not found for key ${key}`),
 			});
 		},
 
-		ensurePlaybackUrl: async (recordingId) => {
+		ensurePlaybackUrl: async (key) => {
 			// DUAL READ: Check file system first, fallback to IndexedDB
 			const fsResult =
-				await fileSystemDb.ensurePlaybackUrl(recordingId);
+				await fileSystemDb.ensurePlaybackUrl(key);
 
 			// If found in file system, return it
 			if (fsResult.data) {
@@ -79,7 +79,7 @@ export function createBlobStoreDesktop(): BlobStore {
 			}
 
 			// Not in file system, check IndexedDB
-			const idbResult = await indexedDb.ensurePlaybackUrl(recordingId);
+			const idbResult = await indexedDb.ensurePlaybackUrl(key);
 
 			// If found in IndexedDB, return it
 			if (idbResult.data) {
@@ -93,14 +93,14 @@ export function createBlobStoreDesktop(): BlobStore {
 
 			// Not found in either source (but no errors)
 			return BlobError.ReadFailed({
-				cause: new Error(`Audio not found for recording ${recordingId}`),
+				cause: new Error(`Blob not found for key ${key}`),
 			});
 		},
 
-		revokeUrl: (recordingId) => {
+		revokeUrl: (key) => {
 			// Revoke from BOTH sources
-			fileSystemDb.revokeUrl(recordingId);
-			indexedDb.revokeUrl(recordingId);
+			fileSystemDb.revokeUrl(key);
+			indexedDb.revokeUrl(key);
 		},
 
 		clear: async () => {

--- a/apps/whispering/src/lib/services/blob-store/file-system.ts
+++ b/apps/whispering/src/lib/services/blob-store/file-system.ts
@@ -13,20 +13,6 @@ import type { BlobStore } from './types';
 import { BlobError } from './types';
 
 /**
- * Reads all markdown files from a directory using the Rust command.
- * This is a single FFI call that reads all .md files natively in Rust,
- * avoiding thousands of individual async calls for path joining and file reading.
- *
- * @param directoryPath - Absolute path to the directory containing .md files
- * @returns Array of markdown file contents as strings
- */
-async function readMarkdownFiles(
-	directoryPath: string,
-): Promise<string[]> {
-	return invoke('read_markdown_files', { directoryPath });
-}
-
-/**
  * Deletes files inside a directory by filename.
  * Validates that filenames are single path components (no traversal).
  *
@@ -52,18 +38,18 @@ async function deleteFilesInDirectory(
  */
 export function createFileSystemBlobStore(): BlobStore {
 	return {
-		async save(recordingId, audio) {
+		async save(key, blob) {
 			return tryAsync({
 				try: async () => {
 					const recordingsPath = await PATHS.DB.RECORDINGS();
 					await mkdir(recordingsPath, { recursive: true });
 
-					const extension = mime.getExtension(audio.type) ?? 'bin';
+					const extension = mime.getExtension(blob.type) ?? 'bin';
 					const audioPath = await PATHS.DB.RECORDING_AUDIO(
-						recordingId,
+						key,
 						extension,
 					);
-					const arrayBuffer = await audio.arrayBuffer();
+					const arrayBuffer = await blob.arrayBuffer();
 					await tauriWriteFile(audioPath, new Uint8Array(arrayBuffer));
 				},
 				catch: (error) => BlobError.WriteFailed({ cause: error }),
@@ -89,18 +75,18 @@ export function createFileSystemBlobStore(): BlobStore {
 			});
 		},
 
-		async getBlob(recordingId: string) {
+		async getBlob(key: string) {
 			return tryAsync({
 				try: async () => {
 					const recordingsPath = await PATHS.DB.RECORDINGS();
 					const audioFilename = await findAudioFile(
 						recordingsPath,
-						recordingId,
+						key,
 					);
 
 					if (!audioFilename) {
 						throw new Error(
-							`Audio file not found for recording ${recordingId}`,
+						`Audio file not found for key ${key}`,
 						);
 					}
 
@@ -117,18 +103,18 @@ export function createFileSystemBlobStore(): BlobStore {
 			});
 		},
 
-		async ensurePlaybackUrl(recordingId: string) {
+		async ensurePlaybackUrl(key: string) {
 			return tryAsync({
 				try: async () => {
 					const recordingsPath = await PATHS.DB.RECORDINGS();
 					const audioFilename = await findAudioFile(
 						recordingsPath,
-						recordingId,
+						key,
 					);
 
 					if (!audioFilename) {
 						throw new Error(
-							`Audio file not found for recording ${recordingId}`,
+						`Audio file not found for key ${key}`,
 						);
 					}
 
@@ -143,7 +129,7 @@ export function createFileSystemBlobStore(): BlobStore {
 			});
 		},
 
-		revokeUrl(_recordingId: string) {
+		revokeUrl(_key: string) {
 			// No-op on desktop, URLs are asset:// protocol managed by Tauri
 		},
 

--- a/apps/whispering/src/lib/services/blob-store/types.ts
+++ b/apps/whispering/src/lib/services/blob-store/types.ts
@@ -19,7 +19,7 @@ export type BlobError = InferErrors<typeof BlobError>;
 
 export type BlobStore = {
 	save(key: string, blob: Blob): Promise<Result<void, BlobError>>;
-	delete(id: string | string[]): Promise<Result<void, BlobError>>;
+	delete(key: string | string[]): Promise<Result<void, BlobError>>;
 	clear(): Promise<Result<void, BlobError>>;
 
 	/**

--- a/apps/whispering/src/lib/services/blob-store/types.ts
+++ b/apps/whispering/src/lib/services/blob-store/types.ts
@@ -18,7 +18,7 @@ export const BlobError = defineErrors({
 export type BlobError = InferErrors<typeof BlobError>;
 
 export type BlobStore = {
-	save(recordingId: string, audio: Blob): Promise<Result<void, BlobError>>;
+	save(key: string, blob: Blob): Promise<Result<void, BlobError>>;
 	delete(id: string | string[]): Promise<Result<void, BlobError>>;
 	clear(): Promise<Result<void, BlobError>>;
 
@@ -27,19 +27,19 @@ export type BlobStore = {
 	 * - Desktop: Reads file from predictable path using services.fs.pathToBlob()
 	 * - Web: Fetches from IndexedDB by ID, converts serialized data to Blob
 	 */
-	getBlob(recordingId: string): Promise<Result<Blob, BlobError>>;
+	getBlob(key: string): Promise<Result<Blob, BlobError>>;
 
 	/**
 	 * Get playback URL for blob. Creates and caches URL.
 	 * - Desktop: Uses convertFileSrc() to create asset:// URL
 	 * - Web: Creates and caches object URL, manages lifecycle
 	 */
-	ensurePlaybackUrl(recordingId: string): Promise<Result<string, BlobError>>;
+	ensurePlaybackUrl(key: string): Promise<Result<string, BlobError>>;
 
 	/**
 	 * Revoke cached URL if present. Cleanup method.
 	 * - Desktop: No-op (asset:// URLs managed by Tauri)
 	 * - Web: Calls URL.revokeObjectURL() and removes from cache
 	 */
-	revokeUrl(recordingId: string): void;
+	revokeUrl(key: string): void;
 };

--- a/apps/whispering/src/lib/services/blob-store/web/index.ts
+++ b/apps/whispering/src/lib/services/blob-store/web/index.ts
@@ -31,15 +31,15 @@ function serializedAudioToBlob(serializedAudio: SerializedAudio): Blob {
 
 export function createBlobStoreWeb(): BlobStore {
 	const db = new WhisperingDatabase();
-	/** Cache for audio object URLs to avoid recreating them. */
-	const audioUrlCache = new Map<string, string>();
+	/** Cache for blob object URLs to avoid recreating them. */
+	const urlCache = new Map<string, string>();
 
 	return {
-		async save(recordingId, audio) {
-			const serializedAudio = await blobToSerializedAudio(audio);
+		async save(key, blob) {
+			const serializedAudio = await blobToSerializedAudio(blob);
 			return tryAsync({
 				try: async () => {
-					await db.recordings.put({ id: recordingId, serializedAudio });
+					await db.recordings.put({ id: key, serializedAudio });
 				},
 				catch: (error) => BlobError.WriteFailed({ cause: error }),
 			});
@@ -53,17 +53,17 @@ export function createBlobStoreWeb(): BlobStore {
 			});
 		},
 
-		getBlob: async (recordingId) => {
+		getBlob: async (key) => {
 			return tryAsync({
 				try: async () => {
-					const recordingWithAudio = await db.recordings.get(recordingId);
+					const recordingWithAudio = await db.recordings.get(key);
 
 					if (!recordingWithAudio) {
-						throw new Error(`Recording ${recordingId} not found`);
+						throw new Error(`Blob ${key} not found`);
 					}
 
 					if (!recordingWithAudio.serializedAudio) {
-						throw new Error(`No audio found for recording ${recordingId}`);
+						throw new Error(`No blob data found for ${key}`);
 					}
 
 					const blob = serializedAudioToBlob(
@@ -75,31 +75,31 @@ export function createBlobStoreWeb(): BlobStore {
 			});
 		},
 
-		ensurePlaybackUrl: async (recordingId) => {
+		ensurePlaybackUrl: async (key) => {
 			return tryAsync({
 				try: async () => {
 					// Check cache first
-					const cachedUrl = audioUrlCache.get(recordingId);
+					const cachedUrl = urlCache.get(key);
 					if (cachedUrl) {
 						return cachedUrl;
 					}
 
 					// Fetch blob from IndexedDB
-					const recordingWithAudio = await db.recordings.get(recordingId);
+					const recordingWithAudio = await db.recordings.get(key);
 
 					if (!recordingWithAudio) {
-						throw new Error(`Recording ${recordingId} not found`);
+						throw new Error(`Blob ${key} not found`);
 					}
 
 					if (!recordingWithAudio.serializedAudio) {
-						throw new Error(`No audio found for recording ${recordingId}`);
+						throw new Error(`No blob data found for ${key}`);
 					}
 
 					const blob = serializedAudioToBlob(
 						recordingWithAudio.serializedAudio,
 					);
 					const objectUrl = URL.createObjectURL(blob);
-					audioUrlCache.set(recordingId, objectUrl);
+					urlCache.set(key, objectUrl);
 
 					return objectUrl;
 				},
@@ -107,11 +107,11 @@ export function createBlobStoreWeb(): BlobStore {
 			});
 		},
 
-		revokeUrl: (recordingId) => {
-			const url = audioUrlCache.get(recordingId);
+		revokeUrl: (key) => {
+			const url = urlCache.get(key);
 			if (url) {
 				URL.revokeObjectURL(url);
-				audioUrlCache.delete(recordingId);
+				urlCache.delete(key);
 			}
 		},
 


### PR DESCRIPTION
Follow-up to #1688. That PR flattened `BlobStore` from a namespaced type to a composable interface but deliberately left two code smells to keep the refactor purely structural. This cleans them up.

`readMarkdownFiles` in `file-system.ts` had zero callers—it was dead code left over from the Dexie migration cleanup. Removed it along with the now-unnecessary `invoke` import change (kept `invoke` since `deleteFilesInDirectory` still uses it).

The `BlobStore` interface parameters were still audio-domain-specific (`recordingId`, `audio`) even though the type is now generic. Renamed to `key` and `blob` across the type and all three implementations (filesystem, web, desktop compositor). Internal implementation variables that reference audio-specific paths (`RECORDING_AUDIO`, `findAudioFile`) are left as-is—the filesystem store IS audio-specific, and those names correctly describe what the paths point to.

```typescript
// Before
type BlobStore = {
  save(recordingId: string, audio: Blob): ...;
  getBlob(recordingId: string): ...;
};

// After
type BlobStore = {
  save(key: string, blob: Blob): ...;
  getBlob(key: string): ...;
};
```

4 files changed, -14 net lines.