### PR TITLE
fix(workspace): resolve pre-existing type errors across production files

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -660,6 +660,7 @@
       },
       "devDependencies": {
         "@types/diff": "^8.0.0",
+        "@types/mdast": "^4.0.4",
         "@types/node": "catalog:",
         "better-sqlite3": "^12.4.1",
         "drizzle-kit": "catalog:",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -74,12 +74,12 @@
 	},
 	"devDependencies": {
 		"@types/diff": "^8.0.0",
+		"@types/mdast": "^4.0.4",
 		"@types/node": "catalog:",
 		"better-sqlite3": "^12.4.1",
 		"drizzle-kit": "catalog:",
 		"filenamify": "^7.0.1",
 		"typescript": "catalog:",
-		"yjs": "catalog:",
-		"@types/mdast": "^4.0.4"
+		"yjs": "catalog:"
 	}
 }

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -79,6 +79,7 @@
 		"drizzle-kit": "catalog:",
 		"filenamify": "^7.0.1",
 		"typescript": "catalog:",
-		"yjs": "catalog:"
+		"yjs": "catalog:",
+		"@types/mdast": "^4.0.4"
 	}
 }

--- a/packages/workspace/src/extensions/materializer/markdown/materializer.ts
+++ b/packages/workspace/src/extensions/materializer/markdown/materializer.ts
@@ -124,6 +124,7 @@ export function createMarkdownMaterializer<
 		dir: string,
 	) => {
 		const table = ctx.tables[name];
+		if (!table) throw new Error(`Table "${name}" not found in workspace`);
 		const tableConfig = tableConfigs[name];
 		const directory = join(dir, tableConfig?.dir ?? name);
 		const filenames = new Map<string, string>();
@@ -238,6 +239,7 @@ export function createMarkdownMaterializer<
 
 			for (const name of tableNames) {
 				const table = ctx.tables[name];
+				if (!table) continue;
 				const tableConfig = tableConfigs[name];
 				const directory = join(dir, tableConfig?.dir ?? name);
 
@@ -286,6 +288,7 @@ export function createMarkdownMaterializer<
 
 			for (const name of tableNames) {
 				const table = ctx.tables[name];
+				if (!table) continue;
 				const tableConfig = tableConfigs[name];
 				const directory = join(dir, tableConfig?.dir ?? name);
 

--- a/packages/workspace/src/extensions/materializer/markdown/parse-markdown-file.ts
+++ b/packages/workspace/src/extensions/materializer/markdown/parse-markdown-file.ts
@@ -30,7 +30,9 @@ export function parseMarkdownFile(content: string): {
 	const match = input.match(FRONTMATTER_PATTERN);
 	if (!match) return null;
 
-	const frontmatter = YAML.parse(match[1]);
+	const raw = match[1];
+	if (!raw) return null;
+	const frontmatter = YAML.parse(raw);
 	if (typeof frontmatter !== 'object' || frontmatter === null) return null;
 
 	const rawBody = input

--- a/packages/workspace/src/extensions/sync/websocket.ts
+++ b/packages/workspace/src/extensions/sync/websocket.ts
@@ -385,7 +385,7 @@ export function createSyncExtension(config: SyncExtensionConfig): (
 			}
 
 			const { data, error } = await tryAsync({
-				try: () => target(rpc.input),
+				try: async () => target(rpc.input),
 				catch: (err) =>
 					RpcError.ActionFailed({ action: rpc.action, cause: err }),
 			});

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -94,6 +94,7 @@ export type {
 } from './timeline';
 export {
 	computeMidpoint,
+	generateInitialOrders,
 	type Timeline,
 } from './timeline';
 // ════════════════════════════════════════════════════════════════════════════

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
@@ -352,15 +352,16 @@ export function createEncryptedYkvLww<T>(
 				inner.bulkSet(entries);
 				return;
 			}
+			const enc = encryption;
 
 			inner.bulkSet(
 				entries.map(({ key, val }) => ({
 					key,
 					val: encryptValue(
 						JSON.stringify(val),
-						encryption.currentKey,
+						enc.currentKey,
 						textEncoder.encode(key),
-						encryption.currentVersion,
+						enc.currentVersion,
 					),
 				})),
 			);

--- a/packages/workspace/src/workspace/create-documents.ts
+++ b/packages/workspace/src/workspace/create-documents.ts
@@ -150,7 +150,7 @@ export function createDocuments<
 	TBinding extends ContentHandle = ContentHandle,
 >(
 	config: CreateDocumentsConfig<TRow, TAwarenessDefinitions, TBinding>,
-): Documents<TRow, Record<string, unknown>, TAwarenessDefinitions, TBinding> {
+): Documents<TRow, TBinding> {
 	const {
 		id,
 		tableName,
@@ -188,7 +188,7 @@ export function createDocuments<
 		}
 	});
 
-	const documents: Documents<TRow, Record<string, unknown>, TAwarenessDefinitions, TBinding> = {
+	const documents: Documents<TRow, TBinding> = {
 		async open(
 			input: TRow | string,
 		): Promise<TBinding> {

--- a/packages/workspace/src/workspace/types.ts
+++ b/packages/workspace/src/workspace/types.ts
@@ -379,8 +379,6 @@ export type DocumentContext<
  */
 export type Documents<
 	TRow extends BaseRow,
-	TDocExtensions extends Record<string, unknown> = Record<string, unknown>,
-	TAwarenessDefs extends AwarenessDefinitions = Record<string, never>,
 	TBinding = ContentHandle,
 > = {
 	/**
@@ -446,17 +444,6 @@ export type AllDocumentNames<TTableDefs extends TableDefinitions> = {
 		: never;
 }[keyof TTableDefs];
 
-/** Extract the awareness definitions from a DocumentConfig. */
-type InferDocumentAwareness<T> = T extends DocumentConfig<
-	string,
-	BaseRow,
-	infer TAwarenessDefs,
-	// biome-ignore lint/suspicious/noExplicitAny: inference position
-	any
->
-	? TAwarenessDefs
-	: Record<string, never>;
-
 /** Extract the content binding type from a DocumentConfig. */
 type InferDocumentBinding<T> = T extends DocumentConfig<
 	string,
@@ -474,10 +461,7 @@ type InferDocumentBinding<T> = T extends DocumentConfig<
  * Maps each doc name to a `Documents<TLatest>` where `TLatest` is the
  * table's latest row type (inferred from the `migrate` function's return type).
  */
-export type DocumentsOf<
-	T,
-	TDocExtensions extends Record<string, unknown> = Record<string, unknown>,
-> = T extends {
+export type DocumentsOf<T> = T extends {
 	documents: infer TDocuments;
 	migrate: (...args: never[]) => infer TLatest;
 }
@@ -485,8 +469,6 @@ export type DocumentsOf<
 		? {
 				[K in keyof TDocuments]: Documents<
 					TLatest,
-					TDocExtensions,
-					InferDocumentAwareness<TDocuments[K]>,
 					InferDocumentBinding<TDocuments[K]>
 				>;
 			}
@@ -510,13 +492,12 @@ export type DocumentsOf<
  */
 export type DocumentsHelper<
 	TTableDefinitions extends TableDefinitions,
-	TDocExtensions extends Record<string, unknown> = Record<string, unknown>,
 > = {
 	[K in keyof TTableDefinitions as HasDocuments<
 		TTableDefinitions[K]
 	> extends true
 		? K
-		: never]: DocumentsOf<TTableDefinitions[K], TDocExtensions>;
+		: never]: DocumentsOf<TTableDefinitions[K]>;
 };
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -1160,8 +1141,7 @@ export type WorkspaceClientBuilder<
 	TTableDefinitions,
 	TKvDefinitions,
 	TAwarenessDefinitions,
-	TExtensions,
-	TDocExtensions
+	TExtensions
 > & {
 	/** Accumulated actions from `.withActions()` calls. Empty object when none declared. */
 	actions: TActions;
@@ -1327,8 +1307,7 @@ export type WorkspaceClientBuilder<
 				TTableDefinitions,
 				TKvDefinitions,
 				TAwarenessDefinitions,
-				TExtensions,
-				TDocExtensions
+				TExtensions
 			>,
 		) => TNewActions,
 	): WorkspaceClientBuilder<
@@ -1442,7 +1421,6 @@ export type WorkspaceClient<
 	TKvDefinitions extends KvDefinitions,
 	TAwarenessDefinitions extends AwarenessDefinitions,
 	TExtensions extends Record<string, unknown>,
-	TDocExtensions extends Record<string, unknown> = Record<string, unknown>,
 > = {
 	/** Workspace identifier */
 	id: TId;
@@ -1457,7 +1435,7 @@ export type WorkspaceClient<
 	/** Typed table helpers — pure CRUD, no document management */
 	tables: TablesHelper<TTableDefinitions>;
 	/** Document managers — only tables with `.withDocument()` appear here */
-	documents: DocumentsHelper<TTableDefinitions, TDocExtensions>;
+	documents: DocumentsHelper<TTableDefinitions>;
 	/** Typed KV helper */
 	kv: KvHelper<TKvDefinitions>;
 	/** Typed awareness helper — always present, like tables and kv */
@@ -1601,7 +1579,6 @@ export type AnyWorkspaceClient = WorkspaceClient<
 	TableDefinitions,
 	KvDefinitions,
 	AwarenessDefinitions,
-	Record<string, unknown>,
 	Record<string, unknown>
 > & {
 	actions?: Actions;


### PR DESCRIPTION
## Why

The workspace package had 8 pre-existing type errors in production files (non-test, non-script). These accumulated across PRs because each one was either unrelated to the PR at hand or would cascade into a larger refactor. This PR fixes all of them in one pass—zero production-file type errors remain.

## What changed

**9 files, net −14 lines.**

### Type parameter cleanup (`types.ts`, `create-documents.ts`)

`Documents<TRow, TDocExtensions, TAwarenessDefs, TBinding>` carried two generic params that were never referenced in its body. They flowed through `DocumentsOf → DocumentsHelper → WorkspaceClient` doing nothing.

**Before:** `Documents<TRow, TDocExtensions, TAwarenessDefs, TBinding>` (4 params)
**After:** `Documents<TRow, TBinding>` (2 params)

`TDocExtensions` is kept on `WorkspaceClientBuilder` where it's actively used for `withDocumentExtension` type accumulation—it just no longer leaks into the runtime client type. Removed the now-dead `InferDocumentAwareness` helper type.

### Trivial fixes

| Fix | File | What |
|---|---|---|
| Missing barrel export | `src/index.ts` | Added `generateInitialOrders`—`@epicenter/filesystem` imports it from `@epicenter/workspace` |
| Module not found | `package.json` | Added `@types/mdast` devDep—`richtext.ts` imports types from `mdast`, which is a README-only package; actual types live in `@types/mdast` |
| `encryption` possibly undefined | `y-keyvalue-lww-encrypted.ts` | Captured `let encryption` into `const enc` before `.map()` callback—TS can't narrow `let` bindings inside closures |
| `table` possibly undefined | `materializer.ts` | Added guards for `ctx.tables[name]` index access (`noUncheckedIndexedAccess` flag) |
| `match[1]` possibly undefined | `parse-markdown-file.ts` | Guarded regex capture group (same flag) |
| `unknown` not assignable to `Promise` | `websocket.ts` | Wrapped action handler in `async` for `tryAsync` signature compatibility |

### Known follow-ups (not in this PR)

- `TAwarenessDefs` is still a dead param on `CreateDocumentsConfig` / `createDocuments()` — removing it touches `create-workspace.ts` config construction, separate PR
- Stale `@epicenter/workspace/static` reference in `index.ts` JSDoc