### PR TITLE
refactor(workspace): inline DocumentClient into DocumentContext

### DIFF
--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -148,7 +148,6 @@ export type {
 	BaseRow,
 	ContentHandle,
 	ContentStrategy,
-	DocumentClient,
 	DocumentConfig,
 	Documents,
 	DocumentsHelper,

--- a/packages/workspace/src/workspace/index.ts
+++ b/packages/workspace/src/workspace/index.ts
@@ -134,7 +134,6 @@ export type {
 	// Content handle types
 	ContentHandle,
 	ContentStrategy,
-	DocumentClient,
 	DocumentConfig,
 	Documents,
 	DocumentsHelper,

--- a/packages/workspace/src/workspace/types.ts
+++ b/packages/workspace/src/workspace/types.ts
@@ -283,23 +283,31 @@ export type ClaimedDocumentColumns<
 > = TDocuments[keyof TDocuments]['guid'];
 
 // ════════════════════════════════════════════════════════════════════════════
-// DOCUMENT CLIENT — The document's API surface (mirrors WorkspaceClient)
+// DOCUMENT CONTEXT — What extension factories receive at document open time
 // ════════════════════════════════════════════════════════════════════════════
 
 /**
- * The full API surface of an open content document.
+ * Context passed to document extension factories registered via `withDocumentExtension()`.
  *
- * The document's core type that `DocumentContext` derives from via `Pick`.
+ * Contains the fields extension factories need to inspect and operate on an open
+ * content document. Factories inspect `tableName` and `documentName` to decide
+ * whether to activate. Return `void` to skip a specific document.
  *
- * @typeParam TDocExtensions - Accumulated document extension exports
- * @typeParam TBinding - The content binding type returned by the content strategy
+ * Excludes `content` (the typed binding consumers use) and `dispose()` (lifecycle
+ * managed by the runtime) — factories don't need either.
+ *
+ * ```typescript
+ * .withDocumentExtension('persistence', ({ ydoc }) => { ... })
+ * .withDocumentExtension('sync', ({ id, tableName, documentName, ydoc }) => { ... })
+ * ```
+ *
+ * @typeParam TDocExtensions - Accumulated document extension exports from prior calls.
+ *   Defaults to `Record<string, unknown>` so `DocumentExtensionRegistration` can
+ *   store factories with the wide type.
  */
-export type DocumentClient<
-	TDocExtensions extends Record<string, unknown> = Record<string, never>,
-	TBinding extends ContentHandle = ContentHandle,
+export type DocumentContext<
+	TDocExtensions extends Record<string, unknown> = Record<string, unknown>,
 > = {
-	/** The typed content binding returned by the content strategy. */
-	content: TBinding;
 	/** The workspace identifier. */
 	id: string;
 	/** The table this document belongs to (e.g., 'files', 'notes'). */
@@ -323,37 +331,6 @@ export type DocumentClient<
 	};
 	/** Composite whenReady of all document extensions. */
 	whenReady: Promise<void>;
-	/** Cleanup all document extension resources. */
-	dispose(): Promise<void>;
-};
-
-/**
- * Context passed to document extension factories registered via `withDocumentExtension()`.
- *
- * Picks the fields factories need from `DocumentClient`. Factories inspect
- * `tableName` and `documentName` to decide whether to activate.
- * Return `void` to skip a specific document.
- *
- * ```typescript
- * .withDocumentExtension('persistence', ({ ydoc }) => { ... })
- * .withDocumentExtension('sync', ({ id, tableName, documentName, ydoc }) => { ... })
- * ```
- *
- * @typeParam TDocExtensions - Accumulated document extension exports from prior calls.
- *   Defaults to `Record<string, unknown>` so `DocumentExtensionRegistration` can
- *   store factories with the wide type.
- */
-export type DocumentContext<
-	TDocExtensions extends Record<string, unknown> = Record<string, unknown>,
-> = Pick<
-	DocumentClient<TDocExtensions>,
-	| 'id'
-	| 'tableName'
-	| 'documentName'
-	| 'ydoc'
-	| 'extensions'
-	| 'whenReady'
-> & {
 	/**
 	 * Raw awareness instance for this document scope.
 	 *


### PR DESCRIPTION
PR #1682 deleted `DocumentHandle`, which was `Omit<DocumentClient, 'dispose'> & { awareness }`. That left `DocumentClient` with exactly one consumer: `DocumentContext`, which picked 6 of its 8 fields via `Pick<DocumentClient, ...>`. A type whose only purpose is to be a `Pick` source for one other type—with no runtime representation and zero external imports—is indirection that doesn't earn its keep.

```typescript
// Before — type exists solely as a Pick source
export type DocumentClient<TDocExtensions, TBinding> = {
  content: TBinding;        // ← not picked
  id: string;
  tableName: string;
  documentName: string;
  ydoc: Y.Doc;
  extensions: { ... };
  whenReady: Promise<void>;
  dispose(): Promise<void>; // ← not picked
};

export type DocumentContext<TDocExtensions> = Pick<
  DocumentClient<TDocExtensions>,
  'id' | 'tableName' | 'documentName' | 'ydoc' | 'extensions' | 'whenReady'
> & { awareness: { raw: Awareness } };

// After — fields declared directly
export type DocumentContext<TDocExtensions> = {
  id: string;
  tableName: string;
  documentName: string;
  ydoc: Y.Doc;
  extensions: { ... };
  whenReady: Promise<void>;
  awareness: { raw: Awareness };
};
```

The remaining context types (`ExtensionContext = Omit<WorkspaceClient, ...>` and `SharedExtensionContext`) still earn their existence—`WorkspaceClient` is a real runtime type returned by `createWorkspace()`, and `SharedExtensionContext` is the genuine intersection of workspace and document scopes. `DocumentClient` was the odd one out: a phantom type with no runtime.

Also removes the dead barrel re-exports of `DocumentClient` from `workspace/index.ts` and `src/index.ts`. Zero external consumers existed (confirmed via codebase-wide grep).

3 files changed, 18 insertions, 43 deletions.