### PR TITLE
refactor(workspace): remove Timeline.ydoc escape hatch

### DIFF
--- a/packages/workspace/src/timeline/timeline.ts
+++ b/packages/workspace/src/timeline/timeline.ts
@@ -41,8 +41,6 @@ export type TimelineEntry = TextEntry | RichTextEntry | SheetEntry;
 export type ContentType = TimelineEntry['type'];
 
 export type Timeline = {
-	/** The Y.Doc this timeline is bound to. */
-	readonly ydoc: Y.Doc;
 	/** Number of entries in the timeline. */
 	readonly length: number;
 	/**
@@ -255,9 +253,6 @@ export function createTimeline(ydoc: Y.Doc): Timeline {
 	// ── Public API ────────────────────────────────────────────────────────
 
 	return {
-		get ydoc() {
-			return ydoc;
-		},
 		get length() {
 			return timeline.length;
 		},

--- a/packages/workspace/src/workspace/create-documents.test.ts
+++ b/packages/workspace/src/workspace/create-documents.test.ts
@@ -271,9 +271,9 @@ describe('createDocuments', () => {
 			});
 
 			const content = await documents.open('f1');
-			const contentYdoc = content.asText().doc;
-			expect(contentYdoc).toBeDefined();
-			// asText() creates a timeline entry which triggers onUpdate — reset updatedAt
+			// Get the underlying Y.Doc via a shared type — Timeline no longer exposes ydoc directly.
+			// asText() creates a timeline entry which triggers onUpdate, so reset updatedAt after.
+			const contentYdoc = content.asText().doc!;
 			tables.files.update('f1', { updatedAt: 0 });
 
 			// Apply a remote update with no origin (e.g., IndexedDB load)
@@ -281,7 +281,7 @@ describe('createDocuments', () => {
 			remoteDoc.getText('content').insert(0, 'remote edit');
 			const remoteUpdate = Y.encodeStateAsUpdate(remoteDoc);
 
-			Y.applyUpdate(contentYdoc as Y.Doc, remoteUpdate);
+			Y.applyUpdate(contentYdoc, remoteUpdate);
 
 			const result = tables.files.get('f1');
 			expect(result.status).toBe('valid');
@@ -302,9 +302,9 @@ describe('createDocuments', () => {
 			});
 
 			const content = await documents.open('f1');
-			const contentYdoc = content.asText().doc;
-			expect(contentYdoc).toBeDefined();
-			// asText() creates a timeline entry which triggers onUpdate — reset updatedAt
+			// Get the underlying Y.Doc via a shared type — Timeline no longer exposes ydoc directly.
+			// asText() creates a timeline entry which triggers onUpdate, so reset updatedAt after.
+			const contentYdoc = content.asText().doc!;
 			tables.files.update('f1', { updatedAt: 0 });
 
 			// Apply a remote update with a Symbol origin (simulating sync/broadcast)
@@ -313,7 +313,7 @@ describe('createDocuments', () => {
 			remoteDoc.getText('content').insert(0, 'synced edit');
 			const remoteUpdate = Y.encodeStateAsUpdate(remoteDoc);
 
-			Y.applyUpdate(contentYdoc as Y.Doc, remoteUpdate, FAKE_TRANSPORT);
+			Y.applyUpdate(contentYdoc, remoteUpdate, FAKE_TRANSPORT);
 
 			const result = tables.files.get('f1');
 			expect(result.status).toBe('valid');

--- a/packages/workspace/src/workspace/create-documents.test.ts
+++ b/packages/workspace/src/workspace/create-documents.test.ts
@@ -271,13 +271,17 @@ describe('createDocuments', () => {
 			});
 
 			const content = await documents.open('f1');
+			const contentYdoc = content.asText().doc;
+			expect(contentYdoc).toBeDefined();
+			// asText() creates a timeline entry which triggers onUpdate — reset updatedAt
+			tables.files.update('f1', { updatedAt: 0 });
 
 			// Apply a remote update with no origin (e.g., IndexedDB load)
 			const remoteDoc = new Y.Doc({ guid: 'f1', gc: false });
 			remoteDoc.getText('content').insert(0, 'remote edit');
 			const remoteUpdate = Y.encodeStateAsUpdate(remoteDoc);
 
-			Y.applyUpdate(content.ydoc, remoteUpdate);
+			Y.applyUpdate(contentYdoc as Y.Doc, remoteUpdate);
 
 			const result = tables.files.get('f1');
 			expect(result.status).toBe('valid');
@@ -298,6 +302,10 @@ describe('createDocuments', () => {
 			});
 
 			const content = await documents.open('f1');
+			const contentYdoc = content.asText().doc;
+			expect(contentYdoc).toBeDefined();
+			// asText() creates a timeline entry which triggers onUpdate — reset updatedAt
+			tables.files.update('f1', { updatedAt: 0 });
 
 			// Apply a remote update with a Symbol origin (simulating sync/broadcast)
 			const FAKE_TRANSPORT = Symbol('fake-transport');
@@ -305,7 +313,7 @@ describe('createDocuments', () => {
 			remoteDoc.getText('content').insert(0, 'synced edit');
 			const remoteUpdate = Y.encodeStateAsUpdate(remoteDoc);
 
-			Y.applyUpdate(content.ydoc, remoteUpdate, FAKE_TRANSPORT);
+			Y.applyUpdate(contentYdoc as Y.Doc, remoteUpdate, FAKE_TRANSPORT);
 
 			const result = tables.files.get('f1');
 			expect(result.status).toBe('valid');

--- a/packages/workspace/src/workspace/strategies.ts
+++ b/packages/workspace/src/workspace/strategies.ts
@@ -123,9 +123,6 @@ export const richText: (ydoc: Y.Doc) => RichTextHandle = (ydoc) => {
  * that toggle between source markdown and rich text editing, or spreadsheet
  * files that can also be viewed as CSV text.
  *
- * > **Note**: Timeline also exposes a `ydoc` property. This is a follow-up
- * > candidate for removal — consumers should use the strategy's own methods
- * > rather than reaching into the raw Y.Doc.
  *
  * @example
  * ```typescript

--- a/packages/workspace/src/workspace/strategies.ts
+++ b/packages/workspace/src/workspace/strategies.ts
@@ -123,7 +123,6 @@ export const richText: (ydoc: Y.Doc) => RichTextHandle = (ydoc) => {
  * that toggle between source markdown and rich text editing, or spreadsheet
  * files that can also be viewed as CSV text.
  *
- *
  * @example
  * ```typescript
  * const filesTable = defineTable(


### PR DESCRIPTION
The document handle refactor (PR #1682) flattened `open()` so consumers get the content object directly. Timeline still exposed a `.ydoc` escape hatch—the only remaining path a consumer could reach the raw Y.Doc through. The spec explicitly flagged it for removal (line 327 of the facade spec):

> "Remove `ydoc` from Timeline's public type in a follow-up. Timeline shouldn't expose its internal doc. Its `batch()` method already wraps `ydoc.transact()`."

Grep confirmed zero runtime consumers. Extensions receive ydoc via `ctx.ydoc` in the factory call, and internal code accesses it through `DocEntry.ydoc` (the internal map)—neither path goes through Timeline.

The only usage was in two test lines simulating remote updates via `Y.applyUpdate(content.ydoc, ...)`. These tests need the raw Y.Doc to apply updates, so they now extract it through a shared type:

```typescript
// Before — Timeline exposed ydoc directly
Y.applyUpdate(content.ydoc, remoteUpdate);

// After — get Y.Doc from a shared type's .doc property
const contentYdoc = content.asText().doc!;
tables.files.update('f1', { updatedAt: 0 }); // reset after asText() side-effect
Y.applyUpdate(contentYdoc, remoteUpdate);
```

`asText()` creates a timeline entry as a side effect (which triggers onUpdate and bumps `updatedAt`), so both tests reset `updatedAt` to 0 before applying the remote update they're actually testing. This is a minor test ergonomics cost of sealing the abstraction—acceptable given zero runtime consumers needed the property.

3 files changed, +11/-13.