### PR TITLE
refactor(workspace): remove dead document-level awareness generics

### DIFF
--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -4,7 +4,6 @@
  * This root export provides the full workspace API and shared utilities.
  *
  * - `@epicenter/workspace` - Full API (workspace creation, tables, KV, extensions)
- * - `@epicenter/workspace/static` - Alias (kept for backward compatibility)
  * - `@epicenter/workspace/extensions` - Extension plugins (persistence, sync)
  *
  * @example

--- a/packages/workspace/src/workspace/create-documents.test.ts
+++ b/packages/workspace/src/workspace/create-documents.test.ts
@@ -20,7 +20,6 @@ import {
 import { createTables } from './create-tables.js';
 import { defineTable } from './define-table.js';
 import { timeline } from './strategies.js';
-import type { AwarenessDefinitions } from './types.js';
 
 const fileSchema = type({
 	id: 'string',
@@ -39,9 +38,7 @@ function setup(
 	overrides?: Pick<
 		CreateDocumentsConfig<typeof fileSchema.infer>,
 		'documentExtensions'
-	> & {
-		awarenessDefinitions?: AwarenessDefinitions;
-	},
+	>,
 ) {
 	const { ydoc, tables } = setupTables();
 	const documents = createDocuments({

--- a/packages/workspace/src/workspace/create-documents.ts
+++ b/packages/workspace/src/workspace/create-documents.ts
@@ -54,7 +54,6 @@ import {
 	startDisposeLifo,
 } from './lifecycle.js';
 import type {
-	AwarenessDefinitions,
 	BaseRow,
 	ContentHandle,
 	ContentStrategy,
@@ -92,7 +91,6 @@ type DocEntry<TBinding extends ContentHandle = ContentHandle> = {
  */
 export type CreateDocumentsConfig<
 	TRow extends BaseRow,
-	TAwarenessDefinitions extends AwarenessDefinitions = Record<string, never>,
 	TBinding extends ContentHandle = ContentHandle,
 > = {
 	/**
@@ -127,9 +125,8 @@ export type CreateDocumentsConfig<
 	 * Each registration has a key and factory.
 	 */
 	documentExtensions?: DocumentExtensionRegistration[];
-	/** Optional typed awareness schemas for this document scope. */
-	awarenessDefinitions?: TAwarenessDefinitions;
 };
+
 
 /**
  * Create a runtime documents manager — a bidirectional link between table rows
@@ -146,10 +143,9 @@ export type CreateDocumentsConfig<
  */
 export function createDocuments<
 	TRow extends BaseRow,
-	TAwarenessDefinitions extends AwarenessDefinitions = Record<string, never>,
 	TBinding extends ContentHandle = ContentHandle,
 >(
-	config: CreateDocumentsConfig<TRow, TAwarenessDefinitions, TBinding>,
+	config: CreateDocumentsConfig<TRow, TBinding>,
 ): Documents<TRow, TBinding> {
 	const {
 		id,

--- a/packages/workspace/src/workspace/create-workspace.ts
+++ b/packages/workspace/src/workspace/create-workspace.ts
@@ -216,7 +216,7 @@ export function createWorkspace<
 		const tableDocumentsNamespace: Record<string, Documents<BaseRow>> = {};
 
 		for (const [docName, rawConfig] of Object.entries(tableDef.documents)) {
-			const { content, guid, onUpdate, awareness } =
+			const { content, guid, onUpdate } =
 				rawConfig as DocumentConfig;
 
 			const documents = createDocuments({
@@ -229,7 +229,6 @@ export function createWorkspace<
 				tableHelper,
 				ydoc,
 				documentExtensions: documentExtensionRegistrations,
-				awarenessDefinitions: awareness,
 			});
 
 			tableDocumentsNamespace[docName] = documents;

--- a/packages/workspace/src/workspace/define-table.ts
+++ b/packages/workspace/src/workspace/define-table.ts
@@ -49,7 +49,6 @@ import type { StandardSchemaV1 } from '@standard-schema/spec';
 import type { CombinedStandardSchema } from '../shared/standard-schema.js';
 import { createUnionSchema } from './schema-union.js';
 import type {
-	AwarenessDefinitions,
 	BaseRow,
 	ClaimedDocumentColumns,
 	ContentHandle,
@@ -116,7 +115,6 @@ type TableDefinitionWithDocBuilder<
 			StringKeysOf<StandardSchemaV1.InferOutput<LastSchema<TVersions>>>,
 			ClaimedDocumentColumns<TDocuments>
 		>,
-		const TAwarenessDefs extends AwarenessDefinitions = Record<string, never>,
 		TBinding extends ContentHandle = ContentHandle,
 	>(
 		name: TName,
@@ -126,7 +124,6 @@ type TableDefinitionWithDocBuilder<
 			onUpdate: () => Partial<
 				Omit<StandardSchemaV1.InferOutput<LastSchema<TVersions>>, 'id'>
 			>;
-			awareness?: TAwarenessDefs;
 		},
 	): TableDefinitionWithDocBuilder<
 		TVersions,
@@ -136,7 +133,6 @@ type TableDefinitionWithDocBuilder<
 				DocumentConfig<
 					TGuid,
 					StandardSchemaV1.InferOutput<LastSchema<TVersions>>,
-					TAwarenessDefs,
 					TBinding
 				>
 			>
@@ -265,7 +261,6 @@ function attachDocumentBuilder<
 						content: config.content,
 						guid: config.guid,
 						onUpdate: config.onUpdate,
-						awareness: config.awareness,
 					},
 				},
 			});

--- a/packages/workspace/src/workspace/types.ts
+++ b/packages/workspace/src/workspace/types.ts
@@ -221,7 +221,6 @@ export type RichTextHandle = ContentHandle & {
 export type DocumentConfig<
 	TGuid extends string = string,
 	TRow extends BaseRow = BaseRow,
-	TAwarenessDefs extends AwarenessDefinitions = Record<string, never>,
 	TBinding extends ContentHandle = ContentHandle,
 > = {
 	/** Content strategy — receives the document Y.Doc, returns the content object from `open()`. */
@@ -234,8 +233,6 @@ export type DocumentConfig<
 	 * other consumers learn that content changed. Return at least one field.
 	 */
 	onUpdate: () => Partial<Omit<TRow, 'id'>>;
-	/** Optional awareness schemas for this document scope. */
-	awareness?: TAwarenessDefs;
 };
 
 /**
@@ -448,8 +445,6 @@ export type AllDocumentNames<TTableDefs extends TableDefinitions> = {
 type InferDocumentBinding<T> = T extends DocumentConfig<
 	string,
 	BaseRow,
-	// biome-ignore lint/suspicious/noExplicitAny: inference position
-	any,
 	infer TBinding
 >
 	? TBinding


### PR DESCRIPTION
PR #1690 removed unused generics from `Documents<>` and its upstream chain, but left `TAwarenessDefs` on `DocumentConfig` and `TAwarenessDefinitions` on `CreateDocumentsConfig`/`createDocuments()`. These were dead plumbing—`createDocuments()` destructured the config and never accessed `awarenessDefinitions`. The `awareness` field on `DocumentConfig` was stored by `withDocument()` but nothing at runtime ever read it.

The document awareness story today: `createDocuments()` creates a raw `Awareness` instance per content Y.Doc and hands `{ raw }` to extension factories via `DocumentContext`. The schemas declared via `withDocument({ awareness })` were carried through the builder, stored on the definition object, and then dropped on the floor. Rather than wire up typed document awareness that nobody consumes yet, this removes the dead slot entirely. Adding it back later is a clean additive change—`DocumentConfig.awareness` was optional, so no consumer could have depended on it.

```typescript
// Before — 4 generic params, dead awareness slot
type DocumentConfig<TGuid, TRow, TAwarenessDefs, TBinding> = {
  content: ContentStrategy<TBinding>;
  guid: TGuid;
  onUpdate: () => Partial<Omit<TRow, 'id'>>;
  awareness?: TAwarenessDefs;  // ← stored, never read
};

// After — 3 generic params, clean alignment with 3 fields
type DocumentConfig<TGuid, TRow, TBinding> = {
  content: ContentStrategy<TBinding>;
  guid: TGuid;
  onUpdate: () => Partial<Omit<TRow, 'id'>>;
};
```

The same cleanup flows through `CreateDocumentsConfig` (loses its own `TAwarenessDefinitions` + `awarenessDefinitions?` field), `createDocuments()` (3→2 generic params), `withDocument()` on the builder (no longer accepts `awareness` in config), and `InferDocumentBinding` (no longer needs a `biome-ignore` for the awareness `any` inference slot).

Workspace-level awareness (`createWorkspace`, `WorkspaceDefinition`, `AwarenessHelper`, `createAwareness`) is untouched—only document-scoped awareness plumbing removed.

A stale JSDoc line in `index.ts` referencing `@epicenter/workspace/static` as a backward-compatibility alias was also removed—that export doesn't exist in `package.json`.

Net: 4 insertions, 23 deletions across 6 files. Zero new production type errors.