### PR TITLE
fix(workspace): constrain materializer TableRow with BaseRow intersection

### DIFF
--- a/packages/workspace/src/extensions/materializer/markdown/materializer.ts
+++ b/packages/workspace/src/extensions/materializer/markdown/materializer.ts
@@ -1,7 +1,7 @@
 import { mkdir, readdir, readFile, unlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { MaybePromise } from '../../../workspace/lifecycle.js';
-import type { KvHelper, TableHelper } from '../../../workspace/types.js';
+import type { BaseRow, KvHelper, TableHelper } from '../../../workspace/types.js';
 import type { SerializeResult } from './markdown.js';
 import { toMarkdown } from './markdown.js';
 import { parseMarkdownFile } from './parse-markdown-file.js';
@@ -54,7 +54,7 @@ export function createMarkdownMaterializer<
 	};
 
 	type TableRow<TName extends keyof TTables & string> =
-		TTables[TName] extends TableHelper<infer TRow> ? TRow : never;
+		(TTables[TName] extends TableHelper<infer TRow> ? TRow : never) & BaseRow;
 
 	type MaterializerBuilder = {
 		table<TName extends keyof TTables & string>(


### PR DESCRIPTION
## Why

The markdown materializer's local `TableRow<TName>` type alias was a deferred conditional type—TypeScript couldn't resolve it when `TName` was still generic, so `.id` access and object spread both failed with TS2339/TS2698.

## What changed

**1 file, 2 lines.**

```typescript
// Before — deferred conditional, .id and spread fail
type TableRow<TName extends keyof TTables & string> =
    TTables[TName] extends TableHelper<infer TRow> ? TRow : never;

// After — intersection gives TS the structural guarantee
type TableRow<TName extends keyof TTables & string> =
    (TTables[TName] extends TableHelper<infer TRow> ? TRow : never) & BaseRow;
```

The `& BaseRow` intersection is always truthful because every table row must extend `BaseRow` (which has `id: string` and `_v: number`). It just makes the compiler aware of what the runtime already guarantees.

Fixes all 4 type errors in `materializer.ts` (2× TS2339, 2× TS2698).