### PR TITLE
refactor(cli): remove persistence from connectWorkspace for ephemeral script use

### DIFF
--- a/.agents/skills/workspace-api/SKILL.md
+++ b/.agents/skills/workspace-api/SKILL.md
@@ -345,20 +345,22 @@ createWorkspace(definition)
 
 ### `connectWorkspace` (CLI/Script Shortcut)
 
-For server-side Bun scripts, `connectWorkspace` from `@epicenter/cli` handles the entire persistence → unlock → sync chain automatically:
+For server-side Bun scripts, `connectWorkspace` from `@epicenter/cli` handles the unlock → sync chain automatically. It is **ephemeral by design — no local persistence**, so a script can coexist with a long-running `epicenter start` daemon without fighting over the same SQLite file:
 
 ```typescript
 import { connectWorkspace } from '@epicenter/cli';
 import { createFujiWorkspace } from '@epicenter/fuji/workspace';
 
 const workspace = await connectWorkspace(createFujiWorkspace);
-// Ready. Authenticated. Syncing. Persistence loaded.
+// Ready. Authenticated. Syncing. Full doc downloaded from server.
 
 const entries = workspace.tables.entries.getAllValid();
 await workspace.dispose();
 ```
 
-Use `connectWorkspace` for one-off scripts and agent-written automation. Use `epicenter.config.ts` for long-running daemons and materializers that need custom workspace-specific extensions.
+Writes propagate through sync to the daemon, which owns the materializer (markdown, SQLite mirror, etc.).
+
+Use `connectWorkspace` for one-off scripts and agent-written automation. Use `epicenter.config.ts` for long-running daemons and materializers that need persistence and custom workspace-specific extensions.
 
 
 ## The `_v` Convention

--- a/packages/cli/src/connect.ts
+++ b/packages/cli/src/connect.ts
@@ -1,8 +1,6 @@
-import { filesystemPersistence } from '@epicenter/workspace/extensions/persistence/sqlite';
 import { createSyncExtension } from '@epicenter/workspace/extensions/sync/websocket';
 import { createSessionStore } from './auth/store.js';
 import { createCliUnlock } from './extensions.js';
-import { EPICENTER_PATHS } from './paths.js';
 import type {
 	AwarenessDefinitions,
 	KvDefinitions,
@@ -11,21 +9,19 @@ import type {
 } from '@epicenter/workspace';
 
 /**
- * Connect a workspace factory to the Epicenter API with authentication,
- * persistence, and sync — ready to use in one `await`.
+ * Connect a workspace factory to the Epicenter API with authentication
+ * and sync—ready to use in one `await`.
  *
- * Chains extensions in the correct order (persistence → unlock → sync),
- * waits for local persistence to load, then waits for the WebSocket sync
- * to reach `connected` phase. The returned workspace has both local and
- * remote data.
- *
- * Persistence is stored at `~/.epicenter/persistence/<workspace-id>.db`.
+ * Designed for ephemeral scripts: chains unlock and sync (no local persistence),
+ * downloads the full workspace state from the server, and returns a live client.
+ * Safe to run while an `epicenter start` daemon is running against the same
+ * workspace—there is no shared SQLite file to conflict over.
  *
  * Requires a prior `epicenter auth login` to store session credentials at
  * `~/.epicenter/auth/sessions.json`.
  *
  * @param factory - Workspace factory function (e.g. `createFujiWorkspace`).
- *   Must return a workspace builder — typically `createWorkspace(def).withActions(...)`.
+ *   Must return a workspace builder—typically `createWorkspace(def).withActions(...)`.
  * @param opts.server - Epicenter API server URL. Defaults to
  *   `process.env.EPICENTER_SERVER ?? 'https://api.epicenter.so'`.
  *
@@ -36,7 +32,7 @@ import type {
  *
  * const workspace = await connectWorkspace(createFujiWorkspace);
  *
- * // Safe to read — has both local persistence and remote sync data
+ * // Safe to read—full state downloaded from server via sync
  * const entries = workspace.tables.entries.filter(e => !e.deletedAt);
  * for (const entry of entries) {
  *   workspace.tables.entries.update(entry.id, { tags: [...entry.tags, 'Journal'] });
@@ -62,12 +58,6 @@ export async function connectWorkspace<
 	const base = factory();
 
 	const client = base
-		.withExtension(
-			'persistence',
-			filesystemPersistence({
-				filePath: EPICENTER_PATHS.persistence(base.id),
-			}),
-		)
 		.withWorkspaceExtension('unlock', createCliUnlock(sessions, server))
 		.withExtension(
 			'sync',

--- a/specs/20260414T023253-connect-workspace.md
+++ b/specs/20260414T023253-connect-workspace.md
@@ -1,8 +1,10 @@
 # `connectWorkspace` — One-Line Authenticated Workspace for Scripts
 
 **Date**: 2026-04-14
-**Status**: Draft
+**Status**: Superseded in part — 2026-04-18
 **Author**: AI-assisted
+
+> **2026-04-18 Update**: `connectWorkspace` no longer attaches filesystem persistence. It now chains only `unlock → sync` and is ephemeral by design. Rationale: scripts are short-lived and the sync handshake downloads the full doc on connect, so paying for a second SQLite writer only created lock contention with a concurrently running `epicenter start` daemon on the same workspace. Persistence remains the daemon's responsibility; see `epicenter.config.ts` examples. References below that show `persistence` in the chain are historical.
 
 ## Overview
 

--- a/specs/20260415T120000-standardize-persistence-location.md
+++ b/specs/20260415T120000-standardize-persistence-location.md
@@ -1,8 +1,10 @@
 # Standardize Persistence Location
 
 **Date**: 2026-04-15
-**Status**: In Progress
+**Status**: Partially superseded — 2026-04-18
 **Author**: AI-assisted
+
+> **2026-04-18 Update**: `connectWorkspace` no longer uses persistence at all — the "global is correct" row below no longer applies to scripts. `EPICENTER_PATHS.persistence()` remains the standard location for daemon configs (`epicenter.config.ts`). The guidance for playground/daemon configs in this spec is unchanged.
 
 ## Overview
 


### PR DESCRIPTION
Scripts that use `connectWorkspace` are ephemeral—they run for a few seconds, load workspace state from the server via sync, make changes, and dispose. There's no benefit to caching state to a local SQLite database for something that doesn't survive the process.

More importantly, removing persistence eliminates SQLite contention between scripts and the `epicenter start` daemon. Before this change, a script using `connectWorkspace` and a long-running daemon both using the same persistence path could both try to write to `~/.epicenter/persistence/<workspace-id>.db` simultaneously, causing SQLITE_BUSY errors and race conditions.

Now the two paths are clearly separated:

**Script path** (`await connectWorkspace(factory)`): unlock → sync (in-memory only). Full workspace state downloads from the server. Safe to run alongside the daemon.

**Daemon path** (`epicenter start . ` via `epicenter.config.ts`): persistence → unlock → sync (durable SQLite). Single owner of the on-disk database, manages materialization (markdown files, SQLite mirror for AI queries, etc.).

Both paths sync to the same remote workspace via WebSocket. Changes from scripts propagate to the daemon's SQLite and vice versa. No file contention, no lockfiles needed.