### PR TITLE
refactor: convert type annotations to `satisfies` where beneficial

### DIFF
--- a/apps/breddit/src/lib/workspace/ingest/utils/csv.ts
+++ b/apps/breddit/src/lib/workspace/ingest/utils/csv.ts
@@ -25,7 +25,7 @@ export type CsvOptions = {
 	comment?: string;
 };
 
-const defaultOpts: Required<CsvOptions> = {
+const defaultOpts = {
 	delimiter: ',',
 	quote: '"',
 	escape: '"',
@@ -33,7 +33,7 @@ const defaultOpts: Required<CsvOptions> = {
 	headers: true,
 	skipEmptyLines: true,
 	comment: '#',
-};
+} satisfies Required<CsvOptions>;
 
 /**
  * Parse CSV text into objects (headers=true) or raw 2D array (headers=false).

--- a/apps/fuji/src/lib/components/EntriesTable.svelte
+++ b/apps/fuji/src/lib/components/EntriesTable.svelte
@@ -27,7 +27,7 @@
 
 	let { entries, title }: { entries: Entry[]; title?: string } = $props();
 
-	const columns: ColumnDef<Entry>[] = [
+	const columns = [
 		{
 			id: 'title',
 			accessorKey: 'title',
@@ -132,7 +132,7 @@
 				}),
 			cell: ({ getValue }) => relativeTime(getValue<string>()),
 		},
-	];
+	] satisfies ColumnDef<Entry>[];
 
 	const sorting = $derived<SortingState>([
 		{ id: viewState.sortBy, desc: viewState.sortBy !== 'title' },

--- a/apps/fuji/src/lib/components/EntriesTimeline.svelte
+++ b/apps/fuji/src/lib/components/EntriesTimeline.svelte
@@ -23,13 +23,13 @@
 
 	// ─── TanStack Table (sort + filter model) ──────────────────────────────
 
-	const columns: ColumnDef<Entry>[] = [
+	const columns = [
 		{ id: 'title', accessorKey: 'title' },
 		{ id: 'rating', accessorKey: 'rating' },
 		{ id: 'date', accessorKey: 'date' },
 		{ id: 'createdAt', accessorKey: 'createdAt' },
 		{ id: 'updatedAt', accessorKey: 'updatedAt' },
-	];
+	] satisfies ColumnDef<Entry>[];
 
 	/** Multi-sort: non-date fields sort within date groups. */
 	const sorting = $derived(

--- a/apps/fuji/src/lib/components/ProseMirrorEditor.svelte
+++ b/apps/fuji/src/lib/components/ProseMirrorEditor.svelte
@@ -37,7 +37,7 @@
 
 	// ─── Schema ──────────────────────────────────────────────────────────────
 
-	const extraMarks: Record<string, MarkSpec> = {
+	const extraMarks = {
 		strikethrough: {
 			parseDOM: [
 				{ tag: 's' },
@@ -54,7 +54,7 @@
 				return ['u', 0];
 			},
 		},
-	};
+	} satisfies Record<string, MarkSpec>;
 
 	const schema = new Schema({
 		nodes: addListNodes(basicSchema.spec.nodes, 'paragraph block*', 'block'),

--- a/apps/fuji/src/lib/view-state.svelte.ts
+++ b/apps/fuji/src/lib/view-state.svelte.ts
@@ -31,11 +31,11 @@ type SearchParams = {
 	q: string;
 };
 
-const DEFAULTS: SearchParams = {
+const DEFAULTS = {
 	view: 'table',
 	sort: 'date',
 	q: '',
-};
+} satisfies SearchParams;
 
 /** Batch-update URL search params in a single navigation. */
 function update(changes: Partial<SearchParams>) {

--- a/apps/honeycrisp/src/lib/editor/Editor.svelte
+++ b/apps/honeycrisp/src/lib/editor/Editor.svelte
@@ -53,14 +53,14 @@
 	import { redo, undo, ySyncPlugin, yUndoPlugin } from 'y-prosemirror';
 	import type * as Y from 'yjs';
 
-	const taskList: NodeSpec = {
+	const taskList = {
 		group: 'block',
 		content: 'taskItem+',
 		parseDOM: [{ tag: 'ul.task-list' }],
 		toDOM: () => ['ul', { class: 'task-list' }, 0],
-	};
+	} satisfies NodeSpec;
 
-	const taskItem: NodeSpec = {
+	const taskItem = {
 		content: 'paragraph block*',
 		attrs: { checked: { default: false } },
 		parseDOM: [
@@ -91,14 +91,14 @@
 			],
 			['div', 0],
 		],
-	};
+	} satisfies NodeSpec;
 
-	const underline: MarkSpec = {
+	const underline = {
 		parseDOM: [{ tag: 'u' }, { style: 'text-decoration=underline' }],
 		toDOM: () => ['u', 0],
-	};
+	} satisfies MarkSpec;
 
-	const strike: MarkSpec = {
+	const strike = {
 		parseDOM: [
 			{ tag: 's' },
 			{ tag: 'del' },
@@ -106,7 +106,7 @@
 			{ style: 'text-decoration=line-through' },
 		],
 		toDOM: () => ['s', 0],
-	};
+	} satisfies MarkSpec;
 
 	const nodes = addListNodes(
 		basicSchema.spec.nodes.append({ taskList, taskItem }),

--- a/apps/honeycrisp/src/lib/search-params.svelte.ts
+++ b/apps/honeycrisp/src/lib/search-params.svelte.ts
@@ -44,15 +44,15 @@ type SearchParams = {
 };
 
 /** Values that get elided from the URL — presence in the URL means non-default. */
-const DEFAULTS: SearchParams = {
+const DEFAULTS = {
 	folder: null,
 	note: null,
 	view: null,
 	sort: 'dateEdited',
 	q: '',
-};
+} satisfies SearchParams;
 
-const SORT_KEYS: SortBy[] = ['dateEdited', 'dateCreated', 'title'];
+const SORT_KEYS = ['dateEdited', 'dateCreated', 'title'] satisfies SortBy[];
 
 function createSearchParams() {
 	/**

--- a/apps/landing/src/components/CorePrinciples.svelte
+++ b/apps/landing/src/components/CorePrinciples.svelte
@@ -8,7 +8,7 @@
 		icon?: string;
 	};
 
-	const userPrinciples: Principle[] = [
+	const userPrinciples = [
 		{
 			title: 'Own your data',
 			description:
@@ -22,9 +22,9 @@
 			title: 'Preserve authenticity',
 			description: 'No middleman. Direct connection to your tools and models.',
 		},
-	];
+	] satisfies Principle[];
 
-	const developerPrinciples: Principle[] = [
+	const developerPrinciples = [
 		{
 			title: 'Free and open source',
 			description: 'Audit the code. Fork it. Make it yours.',
@@ -39,7 +39,7 @@
 			description:
 				'CRDTs, local-first architecture, and the bleeding edge of web tech.',
 		},
-	];
+	] satisfies Principle[];
 
 	type Props = {
 		class?: string;

--- a/apps/opensidian/src/lib/search-params.svelte.ts
+++ b/apps/opensidian/src/lib/search-params.svelte.ts
@@ -39,10 +39,10 @@ type SearchParams = {
 };
 
 /** Values that get elided from the URL — presence means non-default. */
-const DEFAULTS: SearchParams = {
+const DEFAULTS = {
 	file: null,
 	chat: null,
-};
+} satisfies SearchParams;
 
 function createSearchParams() {
 	/**

--- a/apps/whispering/src/lib/migration/migrate-database.ts
+++ b/apps/whispering/src/lib/migration/migrate-database.ts
@@ -51,11 +51,11 @@ export async function migrateDatabaseToWorkspace({
 	workspace: typeof workspace;
 	onProgress: (message: string) => void;
 }): Promise<Result<MigrationResult, MigrationError>> {
-	const result: MigrationResult = {
+	const result = {
 		recordings: { total: 0, migrated: 0, skipped: 0, failed: 0 },
 		transformations: { total: 0, migrated: 0, skipped: 0, failed: 0 },
 		steps: { total: 0, migrated: 0, skipped: 0, failed: 0 },
-	};
+	} satisfies MigrationResult;
 
 	const { error: readyError } = await tryAsync({
 		try: () => ws.whenReady,

--- a/apps/whispering/src/lib/query/notify.ts
+++ b/apps/whispering/src/lib/query/notify.ts
@@ -14,7 +14,7 @@ const createNotifyMutation = (
 		mutationFn: async (
 			options: Omit<UnifiedNotificationOptions, 'variant'>,
 		) => {
-			const fullOptions: UnifiedNotificationOptions = { ...options, variant };
+			const fullOptions = { ...options, variant } satisfies UnifiedNotificationOptions;
 
 			// Log in dev mode
 			if (dev) {

--- a/apps/whispering/src/lib/query/transformer.ts
+++ b/apps/whispering/src/lib/query/transformer.ts
@@ -352,42 +352,42 @@ async function runTransformation({
 
 		if (isErr(handleStepResult)) {
 			const failedNow = new Date().toISOString();
-			const failedStepRun: TransformationStepRunFailed = {
+			const failedStepRun = {
 				...stepRun,
 				status: 'failed',
 				completedAt: failedNow,
 				error: handleStepResult.error,
-			};
+			} satisfies TransformationStepRunFailed;
 			workspace.tables.transformationStepRuns.set(failedStepRun);
-			const failedRun: TransformationRunFailed = {
+			const failedRun = {
 				...transformationRun,
 				status: 'failed',
 				completedAt: failedNow,
 				error: handleStepResult.error,
-			};
+			} satisfies TransformationRunFailed;
 			transformationRuns.set(failedRun);
 			return Ok(failedRun);
 		}
 
 		const handleStepOutput = handleStepResult.data;
 
-		const completedStepRun: TransformationStepRunCompleted = {
+		const completedStepRun = {
 			...stepRun,
 			status: 'completed',
 			completedAt: new Date().toISOString(),
 			output: handleStepOutput,
-		};
+		} satisfies TransformationStepRunCompleted;
 		workspace.tables.transformationStepRuns.set(completedStepRun);
 
 		currentInput = handleStepOutput;
 	}
 
-	const completedRun: TransformationRunCompleted = {
+	const completedRun = {
 		...transformationRun,
 		status: 'completed',
 		completedAt: new Date().toISOString(),
 		output: currentInput,
-	};
+	} satisfies TransformationRunCompleted;
 	transformationRuns.set(completedRun);
 	return Ok(completedRun);
 }

--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -83,7 +83,7 @@
 	);
 	const DATE_FORMAT = 'PP p'; // e.g., Aug 13, 2025, 10:00 AM
 
-	const columns: ColumnDef<Recording>[] = [
+	const columns = [
 		{
 			id: 'select',
 			header: ({ table }) =>
@@ -227,7 +227,7 @@
 				});
 			},
 		},
-	];
+	] satisfies ColumnDef<Recording>[];
 
 	let sorting = createPersistedState({
 		key: 'whispering-recordings-data-table-sorting',

--- a/apps/whispering/src/routes/(app)/(config)/transformations/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/transformations/+page.svelte
@@ -43,7 +43,7 @@
 	import MarkTransformationActiveButton from './MarkTransformationActiveButton.svelte';
 	import TransformationRowActions from './TransformationRowActions.svelte';
 
-	const columns: ColumnDef<Transformation>[] = [
+	const columns = [
 		{
 			id: 'select',
 			header: ({ table }) =>
@@ -105,7 +105,7 @@
 				});
 			},
 		},
-	];
+	] satisfies ColumnDef<Transformation>[];
 
 	let sorting = createPersistedState({
 		key: 'whispering-transformations-data-table-sorting',

--- a/packages/workspace/scripts/yjs-benchmarks/data-structures.ts
+++ b/packages/workspace/scripts/yjs-benchmarks/data-structures.ts
@@ -194,14 +194,14 @@ function benchmarkMapPlain(
 	const doc = new Y.Doc({ gc: gcEnabled });
 	const ymap = doc.getMap<PlainRow>('data');
 
-	const result: BenchmarkResult = {
+	const result = {
 		name: 'Y.Map<id, PlainObject>',
 		gcEnabled,
 		updateStrategy: strategy,
 		timings: { insert: 0, update: 0, delete: 0, recreate: 0 },
 		sizes: { afterInsert: 0, afterUpdate: 0, afterDelete: 0, afterRecreate: 0 },
 		structs: { total: 0, deleted: 0, gc: 0 },
-	};
+	} satisfies BenchmarkResult;
 
 	// INSERT
 	let start = performance.now();
@@ -276,14 +276,14 @@ function benchmarkArrayPlain(
 	const doc = new Y.Doc({ gc: gcEnabled });
 	const yarray = doc.getArray<PlainRow>('data');
 
-	const result: BenchmarkResult = {
+	const result = {
 		name: 'Y.Array<PlainObject>',
 		gcEnabled,
 		updateStrategy: strategy,
 		timings: { insert: 0, update: 0, delete: 0, recreate: 0 },
 		sizes: { afterInsert: 0, afterUpdate: 0, afterDelete: 0, afterRecreate: 0 },
 		structs: { total: 0, deleted: 0, gc: 0 },
-	};
+	} satisfies BenchmarkResult;
 
 	// INSERT
 	let start = performance.now();
@@ -357,14 +357,14 @@ function benchmarkMapYMap(
 	const doc = new Y.Doc({ gc: gcEnabled });
 	const ymap = doc.getMap<Y.Map<unknown>>('data');
 
-	const result: BenchmarkResult = {
+	const result = {
 		name: 'Y.Map<id, Y.Map>',
 		gcEnabled,
 		updateStrategy: strategy,
 		timings: { insert: 0, update: 0, delete: 0, recreate: 0 },
 		sizes: { afterInsert: 0, afterUpdate: 0, afterDelete: 0, afterRecreate: 0 },
 		structs: { total: 0, deleted: 0, gc: 0 },
-	};
+	} satisfies BenchmarkResult;
 
 	// INSERT
 	let start = performance.now();
@@ -454,14 +454,14 @@ function benchmarkArrayYMap(
 	const doc = new Y.Doc({ gc: gcEnabled });
 	const yarray = doc.getArray<Y.Map<unknown>>('data');
 
-	const result: BenchmarkResult = {
+	const result = {
 		name: 'Y.Array<Y.Map>',
 		gcEnabled,
 		updateStrategy: strategy,
 		timings: { insert: 0, update: 0, delete: 0, recreate: 0 },
 		sizes: { afterInsert: 0, afterUpdate: 0, afterDelete: 0, afterRecreate: 0 },
 		structs: { total: 0, deleted: 0, gc: 0 },
-	};
+	} satisfies BenchmarkResult;
 
 	// INSERT
 	let start = performance.now();
@@ -718,7 +718,7 @@ function printAnalysis(allResults: BenchmarkResult[]) {
 	console.log('\n  GC IMPACT');
 	console.log(`  ${'─'.repeat(70)}`);
 
-	const strategies: UpdateStrategy[] = ['single-column', 'full-row'];
+	const strategies = ['single-column', 'full-row'] satisfies UpdateStrategy[];
 	for (const strategy of strategies) {
 		const label = strategy === 'single-column' ? 'Single Column' : 'Full Row';
 		console.log(`\n  ${label} Updates:`);
@@ -794,7 +794,7 @@ async function main() {
 `);
 
 	const allResults: BenchmarkResult[] = [];
-	const strategies: UpdateStrategy[] = ['single-column', 'full-row', 'mixed'];
+	const strategies = ['single-column', 'full-row', 'mixed'] satisfies UpdateStrategy[];
 	const benchmarks = [
 		benchmarkMapPlain,
 		benchmarkArrayPlain,

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
@@ -402,11 +402,11 @@ export function createEncryptedYkvLww<T>(
 			const nextVersion = Math.max(...keyring.keys());
 			const nextKey = keyring.get(nextVersion);
 			if (!nextKey) throw new Error(`Missing key for version ${nextVersion}`);
-			const nextEncryption: EncryptionState = {
+			const nextEncryption = {
 				keyring,
 				currentKey: nextKey,
 				currentVersion: nextVersion,
-			};
+			} satisfies EncryptionState;
 			encryption = nextEncryption;
 
 			const newlyReadable = new Map<string, T>();

--- a/packages/workspace/src/workspace/create-workspace.test.ts
+++ b/packages/workspace/src/workspace/create-workspace.test.ts
@@ -1023,14 +1023,14 @@ describe('applyEncryptionKeys', () => {
 		const { client } = setupEncryptedWorkspace();
 		const keyV1 = randomBytes(32);
 		const keyV2 = randomBytes(32);
-		const keysAsc: EncryptionKeys = [
+		const keysAsc = [
 			{ version: 1, userKeyBase64: bytesToBase64(keyV1) },
 			{ version: 2, userKeyBase64: bytesToBase64(keyV2) },
-		];
-		const keysDesc: EncryptionKeys = [
+		] satisfies EncryptionKeys;
+		const keysDesc = [
 			{ version: 2, userKeyBase64: bytesToBase64(keyV2) },
 			{ version: 1, userKeyBase64: bytesToBase64(keyV1) },
-		];
+		] satisfies EncryptionKeys;
 
 		client.applyEncryptionKeys(keysAsc);
 		client.tables.posts.set({ id: '1', title: 'Order test', _v: 1 });


### PR DESCRIPTION
Converts `const x: T = { ... }` to `const x = { ... } satisfies T` in 17 files across 6 apps and 1 package, where the rewrite preserves narrower literal types without losing the conformance check.

## Why

`: T =` widens the inferred type to `T`, throwing away literal information. `satisfies T` keeps the inferred literal shape while still asserting the value fits `T`. Tangible wins:

- `DEFAULTS.sort` stays `'dateEdited'` (not `SortBy`)
- `SORT_KEYS` / benchmark `strategies` stay literal tuples
- `ColumnDef<T>[]` entries keep their accessor literal types for downstream helpers
- Discriminated-union returns (`TransformationStepRunFailed`, etc.) keep the correct tag

## Scope

**Converted (17 files):**
- ProseMirror `NodeSpec` / `MarkSpec` — `Editor.svelte`, `ProseMirrorEditor.svelte`
- `DEFAULTS` / `SORT_KEYS` — honeycrisp, fuji, opensidian search-params/view-state
- TanStack `ColumnDef<T>[]` — 4 table files
- Transformer discriminated-union returns — `transformer.ts` (4 objects)
- `fullOptions`, `defaultOpts: Required<CsvOptions>`, `MigrationResult`, `EncryptionState`
- Benchmark `BenchmarkResult` and `UpdateStrategy[]` arrays
- Landing `Principle[]` arrays, test `EncryptionKeys` arrays

**Deliberately left as `: T =`:**
- `Record<string, X>` maps that are indexed dynamically — `satisfies` narrows keys to literals and breaks `map[someString]` access. Applies to `EXTENSION_ICONS`, `OPTION_KEY_CHARACTER_MAP`, `DEFAULT_LOCAL_SHORTCUTS`, `DEFAULT_GLOBAL_SHORTCUTS`, `platformMap`, `extensionMapping`.
- `defaultState` / `stats` — fields initialized to `null` / `{}` get reassigned to wider types later, which `satisfies` would reject.

## Test plan

- [ ] `bun run check` passes
- [ ] No runtime behavior change (refactor-only)