### PR TITLE
fix(whispering): robust ffmpeg device enumeration on windows

### DIFF
--- a/apps/whispering/src/lib/services/desktop/recorder/ffmpeg.test.ts
+++ b/apps/whispering/src/lib/services/desktop/recorder/ffmpeg.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+// Mock platform constant before loading ffmpeg
+mock.module('$lib/constants/platform', () => ({
+	PLATFORM_TYPE: 'windows',
+}));
+
+// Mock other modules that might cause issues in Bun environment
+mock.module('@tauri-apps/api/core', () => ({
+	invoke: mock(() => {}),
+}));
+
+mock.module('@tauri-apps/api/path', () => ({
+	join: mock(() => {}),
+}));
+
+mock.module('@tauri-apps/plugin-fs', () => ({
+	exists: mock(() => {}),
+	remove: mock(() => {}),
+	stat: mock(() => {}),
+}));
+
+mock.module('@tauri-apps/plugin-shell', () => ({
+	Child: class {
+		kill = mock(() => {});
+	},
+}));
+
+mock.module('@epicenter/svelte', () => ({
+	createPersistedState: mock(() => ({
+		current: null,
+	})),
+}));
+
+// Mock services that might be imported
+mock.module('$lib/services/desktop/command', () => ({
+	asShellCommand: (s: string) => s,
+	CommandServiceLive: {},
+}));
+
+mock.module('$lib/services/desktop/fs', () => ({
+	FsServiceLive: {},
+}));
+
+// Now import parseDevices and asDeviceIdentifier
+const { parseDevices } = await import('./ffmpeg');
+const { asDeviceIdentifier } = await import('$lib/services/types');
+
+describe('ffmpeg parseDevices (Windows)', () => {
+	it('should parse modern DirectShow audio devices (with [dshow] prefix)', () => {
+		const output = `
+[dshow @ 00000164eeb0e380] DirectShow video devices (some may be both video and audio devices)
+[dshow @ 00000164eeb0e380] "Generic USB Video Device" (video)
+[dshow @ 00000164eeb0e380]   Alternative name "@device_pnp_\\\\?\\\\usb#vid_0000&pid_0000&mi_00#0&0000000&0&0000#{65e8773d-8f56-11d0-a3b9-00a0c9223196}\\global"
+[dshow @ 00000164eeb0e380] DirectShow audio devices
+[dshow @ 00000164eeb0e380] "External Microphone" (audio)
+[dshow @ 00000164eeb0e380]   Alternative name "@device_cm_{00000000-0000-0000-0000-000000000000}\\wave_{00000000-0000-0000-0000-000000000000}"
+[dshow @ 00000164eeb0e380] "Internal Microphone" (audio)
+[dshow @ 00000164eeb0e380]   Alternative name "@device_cm_{00000000-0000-0000-0000-000000000000}\\wave_{00000000-0000-0000-0000-000000000000}"
+		`;
+
+		const devices = parseDevices(output);
+
+		expect(devices).toHaveLength(2);
+		expect(devices[0]).toEqual({
+			id: asDeviceIdentifier('External Microphone'),
+			label: 'External Microphone',
+		});
+		expect(devices[1]).toEqual({
+			id: asDeviceIdentifier('Internal Microphone'),
+			label: 'Internal Microphone',
+		});
+	});
+
+	it('should parse legacy DirectShow audio devices (without [dshow] prefix)', () => {
+		const output = `
+DirectShow audio devices
+  "Legacy Microphone" (audio)
+		`;
+
+		const devices = parseDevices(output);
+
+		expect(devices).toHaveLength(1);
+		expect(devices[0]).toEqual({
+			id: asDeviceIdentifier('Legacy Microphone'),
+			label: 'Legacy Microphone',
+		});
+	});
+
+	it('should return empty array if no audio devices are found', () => {
+		const output = `
+[dshow @ 00000164eeb0e380] DirectShow video devices (some may be both video and audio devices)
+[dshow @ 00000164eeb0e380] "Generic Camera" (video)
+		`;
+
+		const devices = parseDevices(output);
+
+		expect(devices).toHaveLength(0);
+	});
+});

--- a/apps/whispering/src/lib/services/desktop/recorder/ffmpeg.ts
+++ b/apps/whispering/src/lib/services/desktop/recorder/ffmpeg.ts
@@ -533,7 +533,7 @@ export const FfmpegRecorderServiceLive: RecorderService = {
 /**
  * Parse FFmpeg device enumeration output based on platform
  */
-function parseDevices(output: string): Device[] {
+export function parseDevices(output: string): Device[] {
 	// Platform-specific parsing configuration
 	// Note: Regex capture groups are guaranteed to exist when the regex matches.
 	// We use optional chaining with fallbacks to satisfy the linter.
@@ -547,8 +547,11 @@ function parseDevices(output: string): Device[] {
 			}),
 		},
 		windows: {
-			// Windows DirectShow format: "Microphone Name" (audio)
-			regex: /^\s*"(.+?)"\s+\(audio\)/,
+			// Windows DirectShow format:
+			// - Modern: [dshow @ ...] "Microphone Name" (audio)
+			// - Legacy: "Microphone Name" (audio)
+			// Supports both for broader FFmpeg version compatibility.
+			regex: /^\s*(?:\[dshow.*?\]\s+)?\s*"(.+?)"\s+\(audio\)/,
 			extractDevice: (match: RegExpMatchArray) => ({
 				id: asDeviceIdentifier(match[1] ?? ''),
 				label: match[1] ?? '',


### PR DESCRIPTION
Improve the reliability of microphone discovery on Windows when using the FFmpeg recorder.

Previously, the FFmpeg device parser failed to recognize recording devices on some Windows systems because it expected the output to start exactly with a quote. However, many FFmpeg versions prefix DirectShow devices with a `[dshow @ ...]` tag, causing a "No recording devices found" error even when hardware was correctly connected. This PR makes the parser resilient to both modern prefixed output and legacy formats.

### Technical Implementation

We refactored the device parsing logic to be more flexible and added a dedicated test suite to prevent regressions.

**1. Resilient Regex Parsing**
Updated the Windows-specific regex in `ffmpeg.ts` to support optional DirectShow prefixes. The new regex `^\s*(?:\[dshow.*?\]\s+)?\s*"(.+?)"\s+\(audio\)/` allows for:
- Optional `[dshow @ 0x...]` tags.
- Variable whitespace handling.
- Compatibility with older FFmpeg versions that omit the prefix.

**2. Test Coverage**
Added `src/lib/services/desktop/recorder/ffmpeg.test.ts` using `bun:test`. 
- Validates both modern and legacy output patterns.
- Uses generic hardware labels ("External Microphone", "Generic USB Video Device") to ensure focus on logic correctness.
- Mocks platform constants to ensure consistent test results regardless of the host OS.

**3. Internal Refactoring**
Exported the `parseDevices` function from the FFmpeg service to allow for isolated unit testing without requiring a full service initialization.

## Changelog

- Fix microphone discovery on Windows when FFmpeg output includes DirectShow prefixes
- Support both modern and legacy FFmpeg device listing formats
- Add unit tests for FFmpeg audio device parsing logic

Closes #
