### PR TITLE
refactor(whispering): per-provider typed errors for cloud transcription

### DIFF
--- a/apps/whispering/src/lib/query/transcription-errors/deepgram.ts
+++ b/apps/whispering/src/lib/query/transcription-errors/deepgram.ts
@@ -1,0 +1,43 @@
+import { WhisperingErr } from '$lib/result';
+import type { DeepgramError } from '$lib/services/transcription/cloud/deepgram';
+import * as shared from './shared';
+
+export function deepgramErrorToWhisperingErr(error: DeepgramError) {
+	switch (error.name) {
+		case 'MissingApiKey':
+			return WhisperingErr(shared.apiKeyRequired('Deepgram'));
+		case 'FileTooLarge':
+			return WhisperingErr(shared.fileTooLarge(error));
+		case 'Connection':
+			return WhisperingErr(shared.connectionIssue('Deepgram', error));
+		case 'BadRequest':
+			return WhisperingErr(shared.badRequest('Deepgram', error));
+		case 'Unauthorized':
+			return WhisperingErr(shared.unauthorized(error));
+		case 'Forbidden':
+			return WhisperingErr(shared.permissionDenied(error));
+		case 'PayloadTooLarge':
+			return WhisperingErr(shared.payloadTooLarge(error));
+		case 'UnsupportedMediaType':
+			return WhisperingErr(shared.unsupportedMediaType(error));
+		case 'RateLimit':
+			return WhisperingErr(shared.rateLimit(error));
+		case 'ServiceUnavailable':
+			return WhisperingErr(shared.serviceUnavailable('Deepgram', error));
+		case 'Parse':
+			return WhisperingErr({
+				title: '🔍 Response Error',
+				description:
+					'Received an unexpected response from Deepgram service. Please try again.',
+				serviceError: error,
+			});
+		case 'NoTranscriptDetected':
+			return WhisperingErr({
+				title: '📝 No Transcription Found',
+				description:
+					'No speech was detected in the audio file. Please check your audio and try again.',
+			});
+		case 'Unexpected':
+			return WhisperingErr(shared.unexpected(error));
+	}
+}

--- a/apps/whispering/src/lib/query/transcription-errors/elevenlabs.ts
+++ b/apps/whispering/src/lib/query/transcription-errors/elevenlabs.ts
@@ -1,0 +1,19 @@
+import { WhisperingErr } from '$lib/result';
+import type { ElevenLabsError } from '$lib/services/transcription/cloud/elevenlabs';
+import * as shared from './shared';
+
+export function elevenlabsErrorToWhisperingErr(error: ElevenLabsError) {
+	switch (error.name) {
+		case 'MissingApiKey':
+			return WhisperingErr(shared.apiKeyRequired('ElevenLabs'));
+		case 'FileTooLarge':
+			return WhisperingErr(shared.fileTooLarge(error));
+		case 'Unexpected':
+			return WhisperingErr({
+				title: '🔧 Transcription Failed',
+				description:
+					'Unable to complete the transcription using ElevenLabs. This may be due to a service issue or unsupported audio format. Please try again.',
+				serviceError: error,
+			});
+	}
+}

--- a/apps/whispering/src/lib/query/transcription-errors/groq.ts
+++ b/apps/whispering/src/lib/query/transcription-errors/groq.ts
@@ -1,0 +1,36 @@
+import { WhisperingErr } from '$lib/result';
+import type { GroqError } from '$lib/services/transcription/cloud/groq';
+import * as shared from './shared';
+
+export function groqErrorToWhisperingErr(error: GroqError) {
+	switch (error.name) {
+		case 'MissingApiKey':
+			return WhisperingErr(shared.apiKeyRequired('Groq'));
+		case 'InvalidApiKeyFormat':
+			return WhisperingErr(
+				shared.invalidApiKeyFormat('Groq', '"gsk_" or "xai-"'),
+			);
+		case 'FileTooLarge':
+			return WhisperingErr(shared.fileTooLarge(error));
+		case 'FileCreationFailed':
+			return WhisperingErr(shared.fileCreationFailed(error));
+		case 'BadRequest':
+			return WhisperingErr(shared.badRequest('Groq', error));
+		case 'Unauthorized':
+			return WhisperingErr(shared.unauthorized(error));
+		case 'PermissionDenied':
+			return WhisperingErr(shared.permissionDenied(error));
+		case 'NotFound':
+			return WhisperingErr(shared.notFound(error));
+		case 'UnprocessableEntity':
+			return WhisperingErr(shared.unprocessableEntity(error));
+		case 'RateLimit':
+			return WhisperingErr(shared.rateLimit(error));
+		case 'ServiceUnavailable':
+			return WhisperingErr(shared.serviceUnavailable('Groq', error));
+		case 'Connection':
+			return WhisperingErr(shared.connectionIssue('Groq', error));
+		case 'Unexpected':
+			return WhisperingErr(shared.unexpected(error));
+	}
+}

--- a/apps/whispering/src/lib/query/transcription-errors/mistral.ts
+++ b/apps/whispering/src/lib/query/transcription-errors/mistral.ts
@@ -1,0 +1,33 @@
+import { WhisperingErr } from '$lib/result';
+import type { MistralTranscriptionError } from '$lib/services/transcription/cloud/mistral';
+import * as shared from './shared';
+
+export function mistralErrorToWhisperingErr(error: MistralTranscriptionError) {
+	switch (error.name) {
+		case 'MissingApiKey':
+			return WhisperingErr(shared.apiKeyRequired('Mistral'));
+		case 'FileTooLarge':
+			return WhisperingErr(shared.fileTooLarge(error));
+		case 'FileCreationFailed':
+			return WhisperingErr(shared.fileCreationFailed(error));
+		case 'Unauthorized':
+			return WhisperingErr(shared.unauthorized(error));
+		case 'RateLimit':
+			return WhisperingErr(shared.rateLimit(error));
+		case 'PayloadTooLarge':
+			return WhisperingErr(shared.payloadTooLarge(error));
+		case 'BadRequest':
+			return WhisperingErr(shared.badRequest('Mistral', error));
+		case 'ServiceUnavailable':
+			return WhisperingErr(shared.serviceUnavailable('Mistral', error));
+		case 'Connection':
+			return WhisperingErr(shared.connectionIssue('Mistral', error));
+		case 'InvalidResponse':
+			return WhisperingErr({
+				title: '❌ Invalid Transcription Response',
+				description: 'Mistral API returned an invalid response format.',
+			});
+		case 'Unexpected':
+			return WhisperingErr(shared.unexpected(error));
+	}
+}

--- a/apps/whispering/src/lib/query/transcription-errors/openai.ts
+++ b/apps/whispering/src/lib/query/transcription-errors/openai.ts
@@ -1,0 +1,38 @@
+import { WhisperingErr } from '$lib/result';
+import type { OpenaiError } from '$lib/services/transcription/cloud/openai';
+import * as shared from './shared';
+
+export function openaiErrorToWhisperingErr(error: OpenaiError) {
+	switch (error.name) {
+		case 'MissingApiKey':
+			return WhisperingErr(shared.apiKeyRequired('OpenAI'));
+		case 'InvalidApiKeyFormat':
+			return WhisperingErr(shared.invalidApiKeyFormat('OpenAI', '"sk-"'));
+		case 'FileTooLarge':
+			return WhisperingErr(shared.fileTooLarge(error));
+		case 'FileCreationFailed':
+			return WhisperingErr(shared.fileCreationFailed(error));
+		case 'BadRequest':
+			return WhisperingErr(shared.badRequest('OpenAI', error));
+		case 'Unauthorized':
+			return WhisperingErr(shared.unauthorized(error));
+		case 'PermissionDenied':
+			return WhisperingErr(shared.permissionDenied(error));
+		case 'NotFound':
+			return WhisperingErr(shared.notFound(error));
+		case 'PayloadTooLarge':
+			return WhisperingErr(shared.payloadTooLarge(error));
+		case 'UnsupportedMediaType':
+			return WhisperingErr(shared.unsupportedMediaType(error));
+		case 'UnprocessableEntity':
+			return WhisperingErr(shared.unprocessableEntity(error));
+		case 'RateLimit':
+			return WhisperingErr(shared.rateLimit(error));
+		case 'ServiceUnavailable':
+			return WhisperingErr(shared.serviceUnavailable('OpenAI', error));
+		case 'Connection':
+			return WhisperingErr(shared.connectionIssue('OpenAI', error));
+		case 'Unexpected':
+			return WhisperingErr(shared.unexpected(error));
+	}
+}

--- a/apps/whispering/src/lib/query/transcription-errors/shared.ts
+++ b/apps/whispering/src/lib/query/transcription-errors/shared.ts
@@ -1,0 +1,139 @@
+import type { AnyTaggedError } from 'wellcrafted/error';
+
+type LinkActionShape = {
+	type: 'link';
+	label: string;
+	href: `/${string}`;
+};
+
+const updateApiKeyAction: LinkActionShape = {
+	type: 'link',
+	label: 'Update API key',
+	href: '/settings/transcription',
+};
+
+const addApiKeyAction: LinkActionShape = {
+	type: 'link',
+	label: 'Add API key',
+	href: '/settings/transcription',
+};
+
+export const apiKeyRequired = (provider: string) => ({
+	title: '🔑 API Key Required',
+	description: `Please enter your ${provider} API key in settings.`,
+	action: addApiKeyAction,
+});
+
+export const invalidApiKeyFormat = (provider: string, prefixes: string) => ({
+	title: '🔑 Invalid API Key Format',
+	description: `Your ${provider} API key should start with ${prefixes}. Please check and update your API key.`,
+	action: updateApiKeyAction,
+});
+
+export const fileTooLarge = ({
+	sizeMb,
+	maxMb,
+}: {
+	sizeMb: number;
+	maxMb: number;
+}) => ({
+	title: `The file size (${sizeMb.toFixed(1)}MB) is too large`,
+	description: `Please upload a file smaller than ${maxMb}MB.`,
+});
+
+export const fileCreationFailed = (serviceError: AnyTaggedError) => ({
+	title: '📄 File Creation Failed',
+	description:
+		'Failed to create audio file for transcription. Please try again.',
+	serviceError,
+});
+
+export const unauthorized = (serviceError: AnyTaggedError) => ({
+	title: '🔑 Authentication Required',
+	description:
+		serviceError.message ||
+		'Your API key appears to be invalid or expired. Please update your API key in settings to continue transcribing.',
+	action: updateApiKeyAction,
+});
+
+export const rateLimit = (serviceError: AnyTaggedError) => ({
+	title: '⏱️ Rate Limit Reached',
+	description:
+		serviceError.message || 'Too many requests. Please try again later.',
+	serviceError,
+});
+
+export const serviceUnavailable = (
+	provider: string,
+	serviceError: AnyTaggedError & { status: number },
+) => ({
+	title: '🔧 Service Unavailable',
+	description:
+		serviceError.message ||
+		`The ${provider} service is temporarily unavailable (Error ${serviceError.status}). Please try again later.`,
+	serviceError,
+});
+
+export const connectionIssue = (
+	provider: string,
+	serviceError: AnyTaggedError,
+) => ({
+	title: '🌐 Connection Issue',
+	description:
+		serviceError.message ||
+		`Unable to connect to the ${provider} service. This could be a network issue or temporary service interruption.`,
+	serviceError,
+});
+
+export const badRequest = (provider: string, serviceError: AnyTaggedError) => ({
+	title: '❌ Bad Request',
+	description: serviceError.message || `Invalid request to ${provider} API.`,
+	serviceError,
+});
+
+export const permissionDenied = (serviceError: AnyTaggedError) => ({
+	title: '⛔ Permission Denied',
+	description:
+		serviceError.message ||
+		"Your account doesn't have access to this feature. This may be due to plan limitations or account restrictions.",
+	serviceError,
+});
+
+export const notFound = (serviceError: AnyTaggedError) => ({
+	title: '🔍 Not Found',
+	description:
+		serviceError.message ||
+		'The requested resource was not found. This might indicate an issue with the model or API endpoint.',
+	serviceError,
+});
+
+export const payloadTooLarge = (serviceError: AnyTaggedError) => ({
+	title: '📦 Audio File Too Large',
+	description:
+		serviceError.message ||
+		'Your audio file exceeds the maximum size limit. Try splitting it into smaller segments or reducing the audio quality.',
+	serviceError,
+});
+
+export const unsupportedMediaType = (serviceError: AnyTaggedError) => ({
+	title: '🎵 Unsupported Format',
+	description:
+		serviceError.message ||
+		"This audio format isn't supported. Please convert your file to MP3, WAV, M4A, or another common audio format.",
+	serviceError,
+});
+
+export const unprocessableEntity = (serviceError: AnyTaggedError) => ({
+	title: '⚠️ Invalid Input',
+	description:
+		serviceError.message ||
+		'The request was valid but the server cannot process it. Please check your audio file and parameters.',
+	serviceError,
+});
+
+export const unexpected = (serviceError: AnyTaggedError) => ({
+	title: '❌ Unexpected Error',
+	description:
+		serviceError.message || 'An unexpected error occurred. Please try again.',
+	serviceError,
+});

--- a/apps/whispering/src/lib/query/transcription.ts
+++ b/apps/whispering/src/lib/query/transcription.ts
@@ -164,8 +164,8 @@ export async function transcribeBlob(
 			const temperature = String(settings.get('transcription.temperature'));
 
 			switch (selectedService) {
-				case 'OpenAI':
-					return await services.transcriptions.openai.transcribe(
+				case 'OpenAI': {
+					const { data, error } = await services.transcriptions.openai.transcribe(
 						audioToTranscribe,
 						{
 							outputLanguage,
@@ -176,8 +176,142 @@ export async function transcribeBlob(
 							baseURL: deviceConfig.get('apiEndpoints.openai') || undefined,
 						},
 					);
-				case 'Groq':
-					return await services.transcriptions.groq.transcribe(
+					if (error) {
+						switch (error.name) {
+							case 'MissingApiKey':
+								return WhisperingErr({
+									title: '🔑 API Key Required',
+									description:
+										'Please enter your OpenAI API key in settings to use Whisper transcription.',
+									action: {
+										type: 'link',
+										label: 'Add API key',
+										href: '/settings/transcription',
+									},
+								});
+							case 'InvalidApiKeyFormat':
+								return WhisperingErr({
+									title: '🔑 Invalid API Key Format',
+									description:
+										'Your OpenAI API key should start with "sk-". Please check and update your API key.',
+									action: {
+										type: 'link',
+										label: 'Update API key',
+										href: '/settings/transcription',
+									},
+								});
+							case 'FileTooLarge':
+								return WhisperingErr({
+									title: `The file size (${error.sizeMb.toFixed(1)}MB) is too large`,
+									description: `Please upload a file smaller than ${error.maxMb}MB.`,
+								});
+							case 'FileCreationFailed':
+								return WhisperingErr({
+									title: '📁 File Creation Failed',
+									description:
+										'Failed to create audio file for transcription. Please try again.',
+									serviceError: error,
+								});
+							case 'BadRequest':
+								return WhisperingErr({
+									title: '❌ Bad Request',
+									description:
+										error.message ||
+										'Invalid request to OpenAI API.',
+									serviceError: error,
+								});
+							case 'Unauthorized':
+								return WhisperingErr({
+									title: '🔑 Authentication Required',
+									description:
+										error.message ||
+										'Your API key appears to be invalid or expired. Please update your API key in settings to continue transcribing.',
+									action: {
+										type: 'link',
+										label: 'Update API key',
+										href: '/settings/transcription',
+									},
+								});
+							case 'PermissionDenied':
+								return WhisperingErr({
+									title: '⛔ Permission Denied',
+									description:
+										error.message ||
+										"Your account doesn't have access to this feature. This may be due to plan limitations or account restrictions.",
+									serviceError: error,
+								});
+							case 'NotFound':
+								return WhisperingErr({
+									title: '🔍 Not Found',
+									description:
+										error.message ||
+										'The requested resource was not found. This might indicate an issue with the model or API endpoint.',
+									serviceError: error,
+								});
+							case 'PayloadTooLarge':
+								return WhisperingErr({
+									title: '📦 Audio File Too Large',
+									description:
+										error.message ||
+										'Your audio file exceeds the maximum size limit (25MB). Try splitting it into smaller segments or reducing the audio quality.',
+									serviceError: error,
+								});
+							case 'UnsupportedMediaType':
+								return WhisperingErr({
+									title: '🎵 Unsupported Format',
+									description:
+										error.message ||
+										"This audio format isn't supported. Please convert your file to MP3, WAV, M4A, or another common audio format.",
+									serviceError: error,
+								});
+							case 'UnprocessableEntity':
+								return WhisperingErr({
+									title: '⚠️ Invalid Input',
+									description:
+										error.message ||
+										'The request was valid but the server cannot process it. Please check your audio file and parameters.',
+									serviceError: error,
+								});
+							case 'RateLimit':
+								return WhisperingErr({
+									title: '⏱️ Rate Limit Reached',
+									description:
+										error.message || 'Too many requests. Please try again later.',
+									action: {
+										type: 'link',
+										label: 'Update API key',
+										href: '/settings/transcription',
+									},
+								});
+							case 'ServiceUnavailable':
+								return WhisperingErr({
+									title: '🔧 Service Unavailable',
+									description:
+										error.message ||
+										`The transcription service is temporarily unavailable (Error ${error.status}). Please try again in a few minutes.`,
+									serviceError: error,
+								});
+							case 'Connection':
+								return WhisperingErr({
+									title: '🌐 Connection Issue',
+									description:
+										error.message ||
+										'Unable to connect to the OpenAI service. This could be a network issue or temporary service interruption.',
+									serviceError: error,
+								});
+							case 'Unexpected':
+								return WhisperingErr({
+									title: '❌ Unexpected Error',
+									description:
+										error.message || 'An unexpected error occurred. Please try again.',
+									serviceError: error,
+								});
+						}
+					}
+					return Ok(data);
+				}
+				case 'Groq': {
+					const { data, error } = await services.transcriptions.groq.transcribe(
 						audioToTranscribe,
 						{
 							outputLanguage,
@@ -188,6 +322,126 @@ export async function transcribeBlob(
 							baseURL: deviceConfig.get('apiEndpoints.groq') || undefined,
 						},
 					);
+					if (error) {
+						switch (error.name) {
+							case 'MissingApiKey':
+								return WhisperingErr({
+									title: '🔑 API Key Required',
+									description: 'Please enter your Groq API key in settings.',
+									action: {
+										type: 'link',
+										label: 'Add API key',
+										href: '/settings/transcription',
+									},
+								});
+							case 'InvalidApiKeyFormat':
+								return WhisperingErr({
+									title: '🔑 Invalid API Key Format',
+									description:
+										'Your Groq API key should start with "gsk_" or "xai-". Please check and update your API key.',
+									action: {
+										type: 'link',
+										label: 'Update API key',
+										href: '/settings/transcription',
+									},
+								});
+							case 'FileTooLarge':
+								return WhisperingErr({
+									title: `The file size (${error.sizeMb.toFixed(1)}MB) is too large`,
+									description: `Please upload a file smaller than ${error.maxMb}MB.`,
+								});
+							case 'FileCreationFailed':
+								return WhisperingErr({
+									title: '📄 File Creation Failed',
+									description:
+										'Failed to create audio file for transcription. Please try again.',
+									serviceError: error,
+								});
+							case 'BadRequest':
+								return WhisperingErr({
+									title: '❌ Bad Request',
+									description:
+										error.message || 'Invalid request to Groq API.',
+									serviceError: error,
+								});
+							case 'Unauthorized':
+								return WhisperingErr({
+									title: '🔑 Authentication Required',
+									description:
+										error.message ||
+										'Your API key appears to be invalid or expired. Please update your API key in settings to continue transcribing.',
+									action: {
+										type: 'link',
+										label: 'Update API key',
+										href: '/settings/transcription',
+									},
+								});
+							case 'PermissionDenied':
+								return WhisperingErr({
+									title: '⛔ Permission Denied',
+									description:
+										error.message ||
+										"Your account doesn't have access to this feature. This may be due to plan limitations or account restrictions.",
+									serviceError: error,
+								});
+							case 'NotFound':
+								return WhisperingErr({
+									title: '🔍 Not Found',
+									description:
+										error.message ||
+										'The requested resource was not found. This might indicate an issue with the model or API endpoint.',
+									serviceError: error,
+								});
+							case 'UnprocessableEntity':
+								return WhisperingErr({
+									title: '⚠️ Invalid Input',
+									description:
+										error.message ||
+										'The request was valid but the server cannot process it. Please check your audio file and parameters.',
+									action: {
+										type: 'link',
+										label: 'Update API key',
+										href: '/settings/transcription',
+									},
+								});
+							case 'RateLimit':
+								return WhisperingErr({
+									title: '⏱️ Rate Limit Reached',
+									description:
+										error.message || 'Too many requests. Please try again later.',
+									action: {
+										type: 'link',
+										label: 'Update API key',
+										href: '/settings/transcription',
+									},
+								});
+							case 'ServiceUnavailable':
+								return WhisperingErr({
+									title: '🔧 Service Unavailable',
+									description:
+										error.message ||
+										`The transcription service is temporarily unavailable (Error ${error.status}). Please try again in a few minutes.`,
+									serviceError: error,
+								});
+							case 'Connection':
+								return WhisperingErr({
+									title: '🌐 Connection Issue',
+									description:
+										error.message ||
+										'Unable to connect to the Groq service. This could be a network issue or temporary service interruption.',
+									serviceError: error,
+								});
+							case 'Unexpected':
+								return WhisperingErr({
+									title: '❌ Unexpected Error',
+									description:
+										error.message || 'An unexpected error occurred. Please try again.',
+									serviceError: error,
+								});
+						}
+					}
+					return Ok(data);
+				}
 				case 'speaches':
 					return await services.transcriptions.speaches.transcribe(
 						audioToTranscribe,
@@ -199,39 +453,251 @@ export async function transcribeBlob(
 							baseUrl: deviceConfig.get('transcription.speaches.baseUrl'),
 						},
 					);
-				case 'ElevenLabs':
-					return await services.transcriptions.elevenlabs.transcribe(
-						audioToTranscribe,
-						{
-							outputLanguage,
-							prompt,
-							temperature,
-							apiKey: deviceConfig.get('apiKeys.elevenlabs'),
-							modelName: settings.get('transcription.elevenlabs.model'),
-						},
-					);
-				case 'Deepgram':
-					return await services.transcriptions.deepgram.transcribe(
-						audioToTranscribe,
-						{
-							outputLanguage,
-							prompt,
-							temperature,
-							apiKey: deviceConfig.get('apiKeys.deepgram'),
-							modelName: settings.get('transcription.deepgram.model'),
-						},
-					);
-				case 'Mistral':
-					return await services.transcriptions.mistral.transcribe(
-						audioToTranscribe,
-						{
-							outputLanguage,
-							prompt,
-							temperature,
-							apiKey: deviceConfig.get('apiKeys.mistral'),
-							modelName: settings.get('transcription.mistral.model'),
-						},
-					);
+				case 'ElevenLabs': {
+					const { data, error } =
+						await services.transcriptions.elevenlabs.transcribe(
+							audioToTranscribe,
+							{
+								outputLanguage,
+								prompt,
+								temperature,
+								apiKey: deviceConfig.get('apiKeys.elevenlabs'),
+								modelName: settings.get('transcription.elevenlabs.model'),
+							},
+						);
+					if (error) {
+						switch (error.name) {
+							case 'MissingApiKey':
+								return WhisperingErr({
+									title: '🔑 API Key Required',
+									description:
+										'Please enter your ElevenLabs API key in settings to use speech-to-text transcription.',
+									action: {
+										type: 'link',
+										label: 'Add API key',
+										href: '/settings/transcription',
+									},
+								});
+							case 'FileTooLarge':
+								return WhisperingErr({
+									title: '📁 File Size Too Large',
+									description: `Your audio file (${error.sizeMb.toFixed(1)}MB) exceeds the ${error.maxMb}MB limit. Please use a smaller file or compress the audio.`,
+								});
+							case 'Unexpected':
+								return WhisperingErr({
+									title: '🔧 Transcription Failed',
+									description:
+										'Unable to complete the transcription using ElevenLabs. This may be due to a service issue or unsupported audio format. Please try again.',
+									serviceError: error,
+								});
+						}
+					}
+					return Ok(data);
+				}
+				case 'Deepgram': {
+					const { data, error } =
+						await services.transcriptions.deepgram.transcribe(
+							audioToTranscribe,
+							{
+								outputLanguage,
+								prompt,
+								temperature,
+								apiKey: deviceConfig.get('apiKeys.deepgram'),
+								modelName: settings.get('transcription.deepgram.model'),
+							},
+						);
+					if (error) {
+						switch (error.name) {
+							case 'MissingApiKey':
+								return WhisperingErr({
+									title: '🔑 API Key Required',
+									description:
+										'Please enter your Deepgram API key in settings to use Deepgram transcription.',
+									action: {
+										type: 'link',
+										label: 'Add API key',
+										href: '/settings/transcription',
+									},
+								});
+							case 'FileTooLarge':
+								return WhisperingErr({
+									title: `The file size (${error.sizeMb.toFixed(1)}MB) is too large`,
+									description: `Please upload a file smaller than ${error.maxMb}MB.`,
+								});
+							case 'Connection':
+								return WhisperingErr({
+									title: '🌐 Connection Issue',
+									description:
+										'Unable to connect to Deepgram service. Please check your internet connection.',
+									serviceError: error,
+								});
+							case 'BadRequest':
+								return WhisperingErr({
+									title: '❌ Bad Request',
+									description:
+										error.message ||
+										'Invalid request parameters. Please check your audio file and settings.',
+									serviceError: error,
+								});
+							case 'Unauthorized':
+								return WhisperingErr({
+									title: '🔑 Authentication Failed',
+									description:
+										'Your Deepgram API key is invalid or expired. Please update your API key in settings.',
+									action: {
+										type: 'link',
+										label: 'Update API key',
+										href: '/settings/transcription',
+									},
+								});
+							case 'Forbidden':
+								return WhisperingErr({
+									title: '⛔ Access Denied',
+									description:
+										error.message ||
+										'Your account does not have access to this feature or model.',
+									serviceError: error,
+								});
+							case 'PayloadTooLarge':
+								return WhisperingErr({
+									title: '📦 Audio File Too Large',
+									description:
+										'Your audio file exceeds the maximum size limit. Try splitting it into smaller segments.',
+									serviceError: error,
+								});
+							case 'UnsupportedMediaType':
+								return WhisperingErr({
+									title: '🎵 Unsupported Format',
+									description:
+										"This audio format isn't supported. Please convert your file to a supported format.",
+									serviceError: error,
+								});
+							case 'RateLimit':
+								return WhisperingErr({
+									title: '⏱️ Rate Limit Reached',
+									description:
+										'Too many requests. Please wait before trying again.',
+									serviceError: error,
+								});
+							case 'ServiceUnavailable':
+								return WhisperingErr({
+									title: '🔧 Service Unavailable',
+									description: `The Deepgram service is temporarily unavailable (Error ${error.status}). Please try again later.`,
+									serviceError: error,
+								});
+							case 'Parse':
+								return WhisperingErr({
+									title: '🔍 Response Error',
+									description:
+										'Received an unexpected response from Deepgram service. Please try again.',
+									serviceError: error,
+								});
+							case 'NoTranscriptDetected':
+								return WhisperingErr({
+									title: '📝 No Transcription Found',
+									description:
+										'No speech was detected in the audio file. Please check your audio and try again.',
+								});
+							case 'Unexpected':
+								return WhisperingErr({
+									title: '❓ Unexpected Error',
+									description:
+										'An unexpected error occurred during transcription. Please try again.',
+									serviceError: error,
+								});
+						}
+					}
+					return Ok(data);
+				}
+				case 'Mistral': {
+					const { data, error } =
+						await services.transcriptions.mistral.transcribe(
+							audioToTranscribe,
+							{
+								outputLanguage,
+								prompt,
+								temperature,
+								apiKey: deviceConfig.get('apiKeys.mistral'),
+								modelName: settings.get('transcription.mistral.model'),
+							},
+						);
+					if (error) {
+						switch (error.name) {
+							case 'MissingApiKey':
+								return WhisperingErr({
+									title: '🔑 API Key Required',
+									description: 'Please enter your Mistral API key in settings.',
+									action: {
+										type: 'link',
+										label: 'Add API key',
+										href: '/settings/transcription',
+									},
+								});
+							case 'FileTooLarge':
+								return WhisperingErr({
+									title: `The file size (${error.sizeMb.toFixed(1)}MB) is too large`,
+									description: `Please upload a file smaller than ${error.maxMb}MB.`,
+								});
+							case 'FileCreationFailed':
+								return WhisperingErr({
+									title: '📄 File Creation Failed',
+									description:
+										'Failed to create audio file for transcription. Please try again.',
+									serviceError: error,
+								});
+							case 'Unauthorized':
+								return WhisperingErr({
+									title: '🔑 Authentication Required',
+									description:
+										'Your API key appears to be invalid or expired. Please update your API key in settings.',
+									action: {
+										type: 'link',
+										label: 'Update API key',
+										href: '/settings/transcription',
+									},
+								});
+							case 'RateLimit':
+								return WhisperingErr({
+									title: '⏱️ Rate Limit Reached',
+									description: 'Too many requests. Please try again later.',
+									serviceError: error,
+								});
+							case 'PayloadTooLarge':
+								return WhisperingErr({
+									title: '📦 Audio File Too Large',
+									description:
+										'Your audio file exceeds the maximum size limit. Try reducing the file size.',
+									serviceError: error,
+								});
+							case 'BadRequest':
+								return WhisperingErr({
+									title: '❌ Bad Request',
+									description:
+										error.message ||
+										'Invalid request parameters. Please check your audio file and settings.',
+									serviceError: error,
+								});
+							case 'ServiceUnavailable':
+								return WhisperingErr({
+									title: '🔧 Service Unavailable',
+									description: `The Mistral service is temporarily unavailable (Error ${error.status}). Please try again later.`,
+									serviceError: error,
+								});
+							case 'InvalidResponse':
+								return WhisperingErr({
+									title: '❌ Invalid Transcription Response',
+									description: 'Mistral API returned an invalid response format.',
+								});
+							case 'Unexpected':
+								return WhisperingErr({
+									title: '❌ Transcription Failed',
+									description: error.message,
+									serviceError: error,
+								});
+						}
+					}
+					return Ok(data);
+				}
 				case 'whispercpp': {
 					// Pure Rust audio conversion now handles most formats without FFmpeg
 					// Only compressed formats (MP3, M4A) require FFmpeg, which will be

--- a/apps/whispering/src/lib/query/transcription.ts
+++ b/apps/whispering/src/lib/query/transcription.ts
@@ -13,6 +13,11 @@ import type { Recording } from '$lib/state/recordings.svelte';
 import { recordings } from '$lib/state/recordings.svelte';
 import { settings } from '$lib/state/settings.svelte';
 import { notify } from './notify';
+import { deepgramErrorToWhisperingErr } from './transcription-errors/deepgram';
+import { elevenlabsErrorToWhisperingErr } from './transcription-errors/elevenlabs';
+import { groqErrorToWhisperingErr } from './transcription-errors/groq';
+import { mistralErrorToWhisperingErr } from './transcription-errors/mistral';
+import { openaiErrorToWhisperingErr } from './transcription-errors/openai';
 
 const transcriptionKeys = {
 	isTranscribing: ['transcription', 'isTranscribing'] as const,
@@ -149,14 +154,6 @@ export async function transcribeBlob(
 		}
 	}
 
-	// Diagnostic: log blob state to help debug 400 "Invalid file format" errors.
-	// If size is 0 or type is empty, the blob is the problem—not the extension.
-	console.debug('[Transcription] Blob diagnostics:', {
-		size: audioToTranscribe.size,
-		type: audioToTranscribe.type,
-		sizeKb: Math.round(audioToTranscribe.size / 1024),
-		service: selectedService,
-	});
 	const transcriptionResult: Result<string, WhisperingError> =
 		await (async () => {
 			const outputLanguage = getOutputLanguage();
@@ -176,138 +173,7 @@ export async function transcribeBlob(
 							baseURL: deviceConfig.get('apiEndpoints.openai') || undefined,
 						},
 					);
-					if (error) {
-						switch (error.name) {
-							case 'MissingApiKey':
-								return WhisperingErr({
-									title: '🔑 API Key Required',
-									description:
-										'Please enter your OpenAI API key in settings to use Whisper transcription.',
-									action: {
-										type: 'link',
-										label: 'Add API key',
-										href: '/settings/transcription',
-									},
-								});
-							case 'InvalidApiKeyFormat':
-								return WhisperingErr({
-									title: '🔑 Invalid API Key Format',
-									description:
-										'Your OpenAI API key should start with "sk-". Please check and update your API key.',
-									action: {
-										type: 'link',
-										label: 'Update API key',
-										href: '/settings/transcription',
-									},
-								});
-							case 'FileTooLarge':
-								return WhisperingErr({
-									title: `The file size (${error.sizeMb.toFixed(1)}MB) is too large`,
-									description: `Please upload a file smaller than ${error.maxMb}MB.`,
-								});
-							case 'FileCreationFailed':
-								return WhisperingErr({
-									title: '📁 File Creation Failed',
-									description:
-										'Failed to create audio file for transcription. Please try again.',
-									serviceError: error,
-								});
-							case 'BadRequest':
-								return WhisperingErr({
-									title: '❌ Bad Request',
-									description:
-										error.message ||
-										'Invalid request to OpenAI API.',
-									serviceError: error,
-								});
-							case 'Unauthorized':
-								return WhisperingErr({
-									title: '🔑 Authentication Required',
-									description:
-										error.message ||
-										'Your API key appears to be invalid or expired. Please update your API key in settings to continue transcribing.',
-									action: {
-										type: 'link',
-										label: 'Update API key',
-										href: '/settings/transcription',
-									},
-								});
-							case 'PermissionDenied':
-								return WhisperingErr({
-									title: '⛔ Permission Denied',
-									description:
-										error.message ||
-										"Your account doesn't have access to this feature. This may be due to plan limitations or account restrictions.",
-									serviceError: error,
-								});
-							case 'NotFound':
-								return WhisperingErr({
-									title: '🔍 Not Found',
-									description:
-										error.message ||
-										'The requested resource was not found. This might indicate an issue with the model or API endpoint.',
-									serviceError: error,
-								});
-							case 'PayloadTooLarge':
-								return WhisperingErr({
-									title: '📦 Audio File Too Large',
-									description:
-										error.message ||
-										'Your audio file exceeds the maximum size limit (25MB). Try splitting it into smaller segments or reducing the audio quality.',
-									serviceError: error,
-								});
-							case 'UnsupportedMediaType':
-								return WhisperingErr({
-									title: '🎵 Unsupported Format',
-									description:
-										error.message ||
-										"This audio format isn't supported. Please convert your file to MP3, WAV, M4A, or another common audio format.",
-									serviceError: error,
-								});
-							case 'UnprocessableEntity':
-								return WhisperingErr({
-									title: '⚠️ Invalid Input',
-									description:
-										error.message ||
-										'The request was valid but the server cannot process it. Please check your audio file and parameters.',
-									serviceError: error,
-								});
-							case 'RateLimit':
-								return WhisperingErr({
-									title: '⏱️ Rate Limit Reached',
-									description:
-										error.message || 'Too many requests. Please try again later.',
-									action: {
-										type: 'link',
-										label: 'Update API key',
-										href: '/settings/transcription',
-									},
-								});
-							case 'ServiceUnavailable':
-								return WhisperingErr({
-									title: '🔧 Service Unavailable',
-									description:
-										error.message ||
-										`The transcription service is temporarily unavailable (Error ${error.status}). Please try again in a few minutes.`,
-									serviceError: error,
-								});
-							case 'Connection':
-								return WhisperingErr({
-									title: '🌐 Connection Issue',
-									description:
-										error.message ||
-										'Unable to connect to the OpenAI service. This could be a network issue or temporary service interruption.',
-									serviceError: error,
-								});
-							case 'Unexpected':
-								return WhisperingErr({
-									title: '❌ Unexpected Error',
-									description:
-										error.message || 'An unexpected error occurred. Please try again.',
-									serviceError: error,
-								});
-						}
-					}
+					if (error) return openaiErrorToWhisperingErr(error);
 					return Ok(data);
 				}
 				case 'Groq': {
@@ -322,124 +188,7 @@ export async function transcribeBlob(
 							baseURL: deviceConfig.get('apiEndpoints.groq') || undefined,
 						},
 					);
-					if (error) {
-						switch (error.name) {
-							case 'MissingApiKey':
-								return WhisperingErr({
-									title: '🔑 API Key Required',
-									description: 'Please enter your Groq API key in settings.',
-									action: {
-										type: 'link',
-										label: 'Add API key',
-										href: '/settings/transcription',
-									},
-								});
-							case 'InvalidApiKeyFormat':
-								return WhisperingErr({
-									title: '🔑 Invalid API Key Format',
-									description:
-										'Your Groq API key should start with "gsk_" or "xai-". Please check and update your API key.',
-									action: {
-										type: 'link',
-										label: 'Update API key',
-										href: '/settings/transcription',
-									},
-								});
-							case 'FileTooLarge':
-								return WhisperingErr({
-									title: `The file size (${error.sizeMb.toFixed(1)}MB) is too large`,
-									description: `Please upload a file smaller than ${error.maxMb}MB.`,
-								});
-							case 'FileCreationFailed':
-								return WhisperingErr({
-									title: '📄 File Creation Failed',
-									description:
-										'Failed to create audio file for transcription. Please try again.',
-									serviceError: error,
-								});
-							case 'BadRequest':
-								return WhisperingErr({
-									title: '❌ Bad Request',
-									description:
-										error.message || 'Invalid request to Groq API.',
-									serviceError: error,
-								});
-							case 'Unauthorized':
-								return WhisperingErr({
-									title: '🔑 Authentication Required',
-									description:
-										error.message ||
-										'Your API key appears to be invalid or expired. Please update your API key in settings to continue transcribing.',
-									action: {
-										type: 'link',
-										label: 'Update API key',
-										href: '/settings/transcription',
-									},
-								});
-							case 'PermissionDenied':
-								return WhisperingErr({
-									title: '⛔ Permission Denied',
-									description:
-										error.message ||
-										"Your account doesn't have access to this feature. This may be due to plan limitations or account restrictions.",
-									serviceError: error,
-								});
-							case 'NotFound':
-								return WhisperingErr({
-									title: '🔍 Not Found',
-									description:
-										error.message ||
-										'The requested resource was not found. This might indicate an issue with the model or API endpoint.',
-									serviceError: error,
-								});
-							case 'UnprocessableEntity':
-								return WhisperingErr({
-									title: '⚠️ Invalid Input',
-									description:
-										error.message ||
-										'The request was valid but the server cannot process it. Please check your audio file and parameters.',
-									action: {
-										type: 'link',
-										label: 'Update API key',
-										href: '/settings/transcription',
-									},
-								});
-							case 'RateLimit':
-								return WhisperingErr({
-									title: '⏱️ Rate Limit Reached',
-									description:
-										error.message || 'Too many requests. Please try again later.',
-									action: {
-										type: 'link',
-										label: 'Update API key',
-										href: '/settings/transcription',
-									},
-								});
-							case 'ServiceUnavailable':
-								return WhisperingErr({
-									title: '🔧 Service Unavailable',
-									description:
-										error.message ||
-										`The transcription service is temporarily unavailable (Error ${error.status}). Please try again in a few minutes.`,
-									serviceError: error,
-								});
-							case 'Connection':
-								return WhisperingErr({
-									title: '🌐 Connection Issue',
-									description:
-										error.message ||
-										'Unable to connect to the Groq service. This could be a network issue or temporary service interruption.',
-									serviceError: error,
-								});
-							case 'Unexpected':
-								return WhisperingErr({
-									title: '❌ Unexpected Error',
-									description:
-										error.message || 'An unexpected error occurred. Please try again.',
-									serviceError: error,
-								});
-						}
-					}
+					if (error) return groqErrorToWhisperingErr(error);
 					return Ok(data);
 				}
 				case 'speaches':
@@ -465,33 +214,7 @@ export async function transcribeBlob(
 								modelName: settings.get('transcription.elevenlabs.model'),
 							},
 						);
-					if (error) {
-						switch (error.name) {
-							case 'MissingApiKey':
-								return WhisperingErr({
-									title: '🔑 API Key Required',
-									description:
-										'Please enter your ElevenLabs API key in settings to use speech-to-text transcription.',
-									action: {
-										type: 'link',
-										label: 'Add API key',
-										href: '/settings/transcription',
-									},
-								});
-							case 'FileTooLarge':
-								return WhisperingErr({
-									title: '📁 File Size Too Large',
-									description: `Your audio file (${error.sizeMb.toFixed(1)}MB) exceeds the ${error.maxMb}MB limit. Please use a smaller file or compress the audio.`,
-								});
-							case 'Unexpected':
-								return WhisperingErr({
-									title: '🔧 Transcription Failed',
-									description:
-										'Unable to complete the transcription using ElevenLabs. This may be due to a service issue or unsupported audio format. Please try again.',
-									serviceError: error,
-								});
-						}
-					}
+					if (error) return elevenlabsErrorToWhisperingErr(error);
 					return Ok(data);
 				}
 				case 'Deepgram': {
@@ -506,107 +229,7 @@ export async function transcribeBlob(
 								modelName: settings.get('transcription.deepgram.model'),
 							},
 						);
-					if (error) {
-						switch (error.name) {
-							case 'MissingApiKey':
-								return WhisperingErr({
-									title: '🔑 API Key Required',
-									description:
-										'Please enter your Deepgram API key in settings to use Deepgram transcription.',
-									action: {
-										type: 'link',
-										label: 'Add API key',
-										href: '/settings/transcription',
-									},
-								});
-							case 'FileTooLarge':
-								return WhisperingErr({
-									title: `The file size (${error.sizeMb.toFixed(1)}MB) is too large`,
-									description: `Please upload a file smaller than ${error.maxMb}MB.`,
-								});
-							case 'Connection':
-								return WhisperingErr({
-									title: '🌐 Connection Issue',
-									description:
-										'Unable to connect to Deepgram service. Please check your internet connection.',
-									serviceError: error,
-								});
-							case 'BadRequest':
-								return WhisperingErr({
-									title: '❌ Bad Request',
-									description:
-										error.message ||
-										'Invalid request parameters. Please check your audio file and settings.',
-									serviceError: error,
-								});
-							case 'Unauthorized':
-								return WhisperingErr({
-									title: '🔑 Authentication Failed',
-									description:
-										'Your Deepgram API key is invalid or expired. Please update your API key in settings.',
-									action: {
-										type: 'link',
-										label: 'Update API key',
-										href: '/settings/transcription',
-									},
-								});
-							case 'Forbidden':
-								return WhisperingErr({
-									title: '⛔ Access Denied',
-									description:
-										error.message ||
-										'Your account does not have access to this feature or model.',
-									serviceError: error,
-								});
-							case 'PayloadTooLarge':
-								return WhisperingErr({
-									title: '📦 Audio File Too Large',
-									description:
-										'Your audio file exceeds the maximum size limit. Try splitting it into smaller segments.',
-									serviceError: error,
-								});
-							case 'UnsupportedMediaType':
-								return WhisperingErr({
-									title: '🎵 Unsupported Format',
-									description:
-										"This audio format isn't supported. Please convert your file to a supported format.",
-									serviceError: error,
-								});
-							case 'RateLimit':
-								return WhisperingErr({
-									title: '⏱️ Rate Limit Reached',
-									description:
-										'Too many requests. Please wait before trying again.',
-									serviceError: error,
-								});
-							case 'ServiceUnavailable':
-								return WhisperingErr({
-									title: '🔧 Service Unavailable',
-									description: `The Deepgram service is temporarily unavailable (Error ${error.status}). Please try again later.`,
-									serviceError: error,
-								});
-							case 'Parse':
-								return WhisperingErr({
-									title: '🔍 Response Error',
-									description:
-										'Received an unexpected response from Deepgram service. Please try again.',
-									serviceError: error,
-								});
-							case 'NoTranscriptDetected':
-								return WhisperingErr({
-									title: '📝 No Transcription Found',
-									description:
-										'No speech was detected in the audio file. Please check your audio and try again.',
-								});
-							case 'Unexpected':
-								return WhisperingErr({
-									title: '❓ Unexpected Error',
-									description:
-										'An unexpected error occurred during transcription. Please try again.',
-									serviceError: error,
-								});
-						}
-					}
+					if (error) return deepgramErrorToWhisperingErr(error);
 					return Ok(data);
 				}
 				case 'Mistral': {
@@ -621,81 +244,7 @@ export async function transcribeBlob(
 								modelName: settings.get('transcription.mistral.model'),
 							},
 						);
-					if (error) {
-						switch (error.name) {
-							case 'MissingApiKey':
-								return WhisperingErr({
-									title: '🔑 API Key Required',
-									description: 'Please enter your Mistral API key in settings.',
-									action: {
-										type: 'link',
-										label: 'Add API key',
-										href: '/settings/transcription',
-									},
-								});
-							case 'FileTooLarge':
-								return WhisperingErr({
-									title: `The file size (${error.sizeMb.toFixed(1)}MB) is too large`,
-									description: `Please upload a file smaller than ${error.maxMb}MB.`,
-								});
-							case 'FileCreationFailed':
-								return WhisperingErr({
-									title: '📄 File Creation Failed',
-									description:
-										'Failed to create audio file for transcription. Please try again.',
-									serviceError: error,
-								});
-							case 'Unauthorized':
-								return WhisperingErr({
-									title: '🔑 Authentication Required',
-									description:
-										'Your API key appears to be invalid or expired. Please update your API key in settings.',
-									action: {
-										type: 'link',
-										label: 'Update API key',
-										href: '/settings/transcription',
-									},
-								});
-							case 'RateLimit':
-								return WhisperingErr({
-									title: '⏱️ Rate Limit Reached',
-									description: 'Too many requests. Please try again later.',
-									serviceError: error,
-								});
-							case 'PayloadTooLarge':
-								return WhisperingErr({
-									title: '📦 Audio File Too Large',
-									description:
-										'Your audio file exceeds the maximum size limit. Try reducing the file size.',
-									serviceError: error,
-								});
-							case 'BadRequest':
-								return WhisperingErr({
-									title: '❌ Bad Request',
-									description:
-										error.message ||
-										'Invalid request parameters. Please check your audio file and settings.',
-									serviceError: error,
-								});
-							case 'ServiceUnavailable':
-								return WhisperingErr({
-									title: '🔧 Service Unavailable',
-									description: `The Mistral service is temporarily unavailable (Error ${error.status}). Please try again later.`,
-									serviceError: error,
-								});
-							case 'InvalidResponse':
-								return WhisperingErr({
-									title: '❌ Invalid Transcription Response',
-									description: 'Mistral API returned an invalid response format.',
-								});
-							case 'Unexpected':
-								return WhisperingErr({
-									title: '❌ Transcription Failed',
-									description: error.message,
-									serviceError: error,
-								});
-						}
-					}
+					if (error) return mistralErrorToWhisperingErr(error);
 					return Ok(data);
 				}
 				case 'whispercpp': {

--- a/apps/whispering/src/lib/services/transcription/cloud/deepgram.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/deepgram.ts
@@ -1,11 +1,15 @@
 import { type } from 'arktype';
+import {
+	defineErrors,
+	extractErrorMessage,
+	type InferErrors,
+} from 'wellcrafted/error';
 import { Ok, type Result } from 'wellcrafted/result';
-import { WhisperingErr, type WhisperingError } from '$lib/result';
 import { HttpServiceLive } from '$lib/services/http';
+import type { HttpError } from '$lib/services/http/types';
 
-const MAX_FILE_SIZE_MB = 500 as const; // Deepgram supports larger files
+const MAX_FILE_SIZE_MB = 500 as const;
 
-// Schema for Deepgram API response
 const DeepgramResponse = type({
 	results: {
 		channels: type({
@@ -17,6 +21,74 @@ const DeepgramResponse = type({
 	},
 });
 
+export const DeepgramError = defineErrors({
+	MissingApiKey: () => ({
+		message: 'Deepgram API key is required',
+	}),
+	FileTooLarge: ({
+		sizeMb,
+		maxMb,
+	}: {
+		sizeMb: number;
+		maxMb: number;
+	}) => ({
+		message: `File size ${sizeMb.toFixed(1)}MB exceeds ${maxMb}MB limit`,
+		sizeMb,
+		maxMb,
+	}),
+	Connection: ({ cause }: { cause: HttpError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	BadRequest: ({ cause }: { cause: HttpError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	Unauthorized: ({ cause }: { cause: HttpError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	Forbidden: ({ cause }: { cause: HttpError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	PayloadTooLarge: ({ cause }: { cause: HttpError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	UnsupportedMediaType: ({ cause }: { cause: HttpError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	RateLimit: ({ cause }: { cause: HttpError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	ServiceUnavailable: ({
+		cause,
+		status,
+	}: {
+		cause: HttpError;
+		status: number;
+	}) => ({
+		message: cause.message,
+		cause,
+		status,
+	}),
+	Parse: ({ cause }: { cause: HttpError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	NoTranscriptDetected: () => ({
+		message: 'No speech was detected in the audio file',
+	}),
+	Unexpected: ({ cause }: { cause: unknown }) => ({
+		message: extractErrorMessage(cause),
+		cause,
+	}),
+});
+export type DeepgramError = InferErrors<typeof DeepgramError>;
+
 export const DeepgramTranscriptionServiceLive = {
 	async transcribe(
 		audioBlob: Blob,
@@ -27,31 +99,14 @@ export const DeepgramTranscriptionServiceLive = {
 			apiKey: string;
 			modelName: string;
 		},
-	): Promise<Result<string, WhisperingError>> {
-		// Pre-validation: Check API key
-		if (!options.apiKey) {
-			return WhisperingErr({
-				title: '🔑 API Key Required',
-				description:
-					'Please enter your Deepgram API key in settings to use Deepgram transcription.',
-				action: {
-					type: 'link',
-					label: 'Add API key',
-					href: '/settings/transcription',
-				},
-			});
+	): Promise<Result<string, DeepgramError>> {
+		if (!options.apiKey) return DeepgramError.MissingApiKey();
+
+		const sizeMb = audioBlob.size / (1024 * 1024);
+		if (sizeMb > MAX_FILE_SIZE_MB) {
+			return DeepgramError.FileTooLarge({ sizeMb, maxMb: MAX_FILE_SIZE_MB });
 		}
 
-		// Validate file size
-		const blobSizeInMb = audioBlob.size / (1024 * 1024);
-		if (blobSizeInMb > MAX_FILE_SIZE_MB) {
-			return WhisperingErr({
-				title: `The file size (${blobSizeInMb}MB) is too large`,
-				description: `Please upload a file smaller than ${MAX_FILE_SIZE_MB}MB.`,
-			});
-		}
-
-		// Build query parameters
 		const params = new URLSearchParams({
 			model: options.modelName,
 			smart_format: 'true',
@@ -68,139 +123,56 @@ export const DeepgramTranscriptionServiceLive = {
 			params.append(isNova3 ? 'keyterm' : 'keywords', options.prompt);
 		}
 
-		// Send raw audio data directly as recommended by Deepgram docs
-		const { data: deepgramResponse, error: postError } =
+		const { data: deepgramResponse, error: httpError } =
 			await HttpServiceLive.post({
 				url: `https://api.deepgram.com/v1/listen?${params.toString()}`,
-				body: audioBlob, // Send raw audio blob directly
+				body: audioBlob,
 				headers: {
 					Authorization: `Token ${options.apiKey}`,
-					'Content-Type': audioBlob.type || 'audio/*', // Use the blob's mime type or fallback to audio/*
+					'Content-Type': audioBlob.type || 'audio/*',
 				},
 				schema: DeepgramResponse,
 			});
 
-		if (postError) {
-			switch (postError.name) {
-				case 'Connection': {
-					return WhisperingErr({
-						title: '🌐 Connection Issue',
-						description:
-							'Unable to connect to Deepgram service. Please check your internet connection.',
-						action: { type: 'more-details', error: postError },
-					});
-				}
-
-				case 'Response': {
-					const { status, message } = postError;
-
-					if (status === 400) {
-						return WhisperingErr({
-							title: '❌ Bad Request',
-							description:
-								message ||
-								'Invalid request parameters. Please check your audio file and settings.',
-							action: { type: 'more-details', error: postError },
-						});
-					}
-
-					if (status === 401) {
-						return WhisperingErr({
-							title: '🔑 Authentication Failed',
-							description:
-								'Your Deepgram API key is invalid or expired. Please update your API key in settings.',
-							action: {
-								type: 'link',
-								label: 'Update API key',
-								href: '/settings/transcription',
-							},
-						});
-					}
-
-					if (status === 403) {
-						return WhisperingErr({
-							title: '⛔ Access Denied',
-							description:
-								message ||
-								'Your account does not have access to this feature or model.',
-							action: { type: 'more-details', error: postError },
-						});
-					}
-
-					if (status === 413) {
-						return WhisperingErr({
-							title: '📦 Audio File Too Large',
-							description:
-								'Your audio file exceeds the maximum size limit. Try splitting it into smaller segments.',
-							action: { type: 'more-details', error: postError },
-						});
-					}
-
-					if (status === 415) {
-						return WhisperingErr({
-							title: '🎵 Unsupported Format',
-							description:
-								"This audio format isn't supported. Please convert your file to a supported format.",
-							action: { type: 'more-details', error: postError },
-						});
-					}
-
-					if (status === 429) {
-						return WhisperingErr({
-							title: '⏱️ Rate Limit Reached',
-							description:
-								'Too many requests. Please wait before trying again.',
-							action: { type: 'more-details', error: postError },
-						});
-					}
-
-					if (status && status >= 500) {
-						return WhisperingErr({
-							title: '🔧 Service Unavailable',
-							description: `The Deepgram service is temporarily unavailable (Error ${status}). Please try again later.`,
-							action: { type: 'more-details', error: postError },
-						});
-					}
-
-					return WhisperingErr({
-						title: '❌ Transcription Failed',
-						description:
-							message ||
-							'An unexpected error occurred during transcription. Please try again.',
-						action: { type: 'more-details', error: postError },
-					});
-				}
-
+		if (httpError) {
+			switch (httpError.name) {
+				case 'Connection':
+					return DeepgramError.Connection({ cause: httpError });
 				case 'Parse':
-					return WhisperingErr({
-						title: '🔍 Response Error',
-						description:
-							'Received an unexpected response from Deepgram service. Please try again.',
-						action: { type: 'more-details', error: postError },
-					});
-
-				default:
-					return WhisperingErr({
-						title: '❓ Unexpected Error',
-						description:
-							'An unexpected error occurred during transcription. Please try again.',
-						action: { type: 'more-details', error: postError },
-					});
+					return DeepgramError.Parse({ cause: httpError });
+				case 'Response': {
+					const { status } = httpError;
+					switch (status) {
+						case 400:
+							return DeepgramError.BadRequest({ cause: httpError });
+						case 401:
+							return DeepgramError.Unauthorized({ cause: httpError });
+						case 403:
+							return DeepgramError.Forbidden({ cause: httpError });
+						case 413:
+							return DeepgramError.PayloadTooLarge({ cause: httpError });
+						case 415:
+							return DeepgramError.UnsupportedMediaType({ cause: httpError });
+						case 429:
+							return DeepgramError.RateLimit({ cause: httpError });
+						default:
+							if (status >= 500) {
+								return DeepgramError.ServiceUnavailable({
+									cause: httpError,
+									status,
+								});
+							}
+							return DeepgramError.Unexpected({ cause: httpError });
+					}
+				}
 			}
 		}
 
-		// Extract transcription text
 		const transcript = deepgramResponse.results?.channels
 			?.at(0)
 			?.alternatives?.at(0)?.transcript;
 
-		if (!transcript) {
-			return WhisperingErr({
-				title: '📝 No Transcription Found',
-				description:
-					'No speech was detected in the audio file. Please check your audio and try again.',
-			});
-		}
+		if (!transcript) return DeepgramError.NoTranscriptDetected();
 
 		return Ok(transcript.trim());
 	},

--- a/apps/whispering/src/lib/services/transcription/cloud/elevenlabs.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/elevenlabs.ts
@@ -8,7 +8,7 @@ import { type Result, tryAsync } from 'wellcrafted/result';
 
 const MAX_FILE_SIZE_MB = 1000 as const;
 
-export const ElevenlabsError = defineErrors({
+export const ElevenLabsError = defineErrors({
 	MissingApiKey: () => ({
 		message: 'ElevenLabs API key is required',
 	}),
@@ -28,9 +28,9 @@ export const ElevenlabsError = defineErrors({
 		cause,
 	}),
 });
-export type ElevenlabsError = InferErrors<typeof ElevenlabsError>;
+export type ElevenLabsError = InferErrors<typeof ElevenLabsError>;
 
-export const ElevenlabsTranscriptionServiceLive = {
+export const ElevenLabsTranscriptionServiceLive = {
 	transcribe: async (
 		audioBlob: Blob,
 		options: {
@@ -40,12 +40,12 @@ export const ElevenlabsTranscriptionServiceLive = {
 			apiKey: string;
 			modelName: string;
 		},
-	): Promise<Result<string, ElevenlabsError>> => {
-		if (!options.apiKey) return ElevenlabsError.MissingApiKey();
+	): Promise<Result<string, ElevenLabsError>> => {
+		if (!options.apiKey) return ElevenLabsError.MissingApiKey();
 
 		const sizeMb = audioBlob.size / (1024 * 1024);
 		if (sizeMb > MAX_FILE_SIZE_MB) {
-			return ElevenlabsError.FileTooLarge({
+			return ElevenLabsError.FileTooLarge({
 				sizeMb,
 				maxMb: MAX_FILE_SIZE_MB,
 			});
@@ -67,10 +67,10 @@ export const ElevenlabsTranscriptionServiceLive = {
 				});
 				return transcription.text.trim();
 			},
-			catch: (error) => ElevenlabsError.Unexpected({ cause: error }),
+			catch: (error) => ElevenLabsError.Unexpected({ cause: error }),
 		});
 	},
 };
 
 export type ElevenLabsTranscriptionService =
-	typeof ElevenlabsTranscriptionServiceLive;
+	typeof ElevenLabsTranscriptionServiceLive;

--- a/apps/whispering/src/lib/services/transcription/cloud/elevenlabs.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/elevenlabs.ts
@@ -1,6 +1,34 @@
 import { ElevenLabsClient } from 'elevenlabs';
+import {
+	defineErrors,
+	extractErrorMessage,
+	type InferErrors,
+} from 'wellcrafted/error';
 import { type Result, tryAsync } from 'wellcrafted/result';
-import { WhisperingErr, type WhisperingError } from '$lib/result';
+
+const MAX_FILE_SIZE_MB = 1000 as const;
+
+export const ElevenlabsError = defineErrors({
+	MissingApiKey: () => ({
+		message: 'ElevenLabs API key is required',
+	}),
+	FileTooLarge: ({
+		sizeMb,
+		maxMb,
+	}: {
+		sizeMb: number;
+		maxMb: number;
+	}) => ({
+		message: `File size ${sizeMb.toFixed(1)}MB exceeds ${maxMb}MB limit`,
+		sizeMb,
+		maxMb,
+	}),
+	Unexpected: ({ cause }: { cause: unknown }) => ({
+		message: extractErrorMessage(cause),
+		cause,
+	}),
+});
+export type ElevenlabsError = InferErrors<typeof ElevenlabsError>;
 
 export const ElevenlabsTranscriptionServiceLive = {
 	transcribe: async (
@@ -12,31 +40,18 @@ export const ElevenlabsTranscriptionServiceLive = {
 			apiKey: string;
 			modelName: string;
 		},
-	): Promise<Result<string, WhisperingError>> => {
-		if (!options.apiKey) {
-			return WhisperingErr({
-				title: '🔑 API Key Required',
-				description:
-					'Please enter your ElevenLabs API key in settings to use speech-to-text transcription.',
-				action: {
-					type: 'link',
-					label: 'Add API key',
-					href: '/settings/transcription',
-				},
+	): Promise<Result<string, ElevenlabsError>> => {
+		if (!options.apiKey) return ElevenlabsError.MissingApiKey();
+
+		const sizeMb = audioBlob.size / (1024 * 1024);
+		if (sizeMb > MAX_FILE_SIZE_MB) {
+			return ElevenlabsError.FileTooLarge({
+				sizeMb,
+				maxMb: MAX_FILE_SIZE_MB,
 			});
 		}
 
 		const client = new ElevenLabsClient({ apiKey: options.apiKey });
-
-		// Check file size (no try needed — pure logic)
-		const blobSizeInMb = audioBlob.size / (1024 * 1024);
-		const MAX_FILE_SIZE_MB = 1000;
-		if (blobSizeInMb > MAX_FILE_SIZE_MB) {
-			return WhisperingErr({
-				title: '📁 File Size Too Large',
-				description: `Your audio file (${blobSizeInMb.toFixed(1)}MB) exceeds the ${MAX_FILE_SIZE_MB}MB limit. Please use a smaller file or compress the audio.`,
-			});
-		}
 
 		return tryAsync({
 			try: async () => {
@@ -52,13 +67,7 @@ export const ElevenlabsTranscriptionServiceLive = {
 				});
 				return transcription.text.trim();
 			},
-			catch: (error) =>
-				WhisperingErr({
-					title: '🔧 Transcription Failed',
-					description:
-						'Unable to complete the transcription using ElevenLabs. This may be due to a service issue or unsupported audio format. Please try again.',
-					action: { type: 'more-details', error },
-				}),
+			catch: (error) => ElevenlabsError.Unexpected({ cause: error }),
 		});
 	},
 };

--- a/apps/whispering/src/lib/services/transcription/cloud/groq.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/groq.ts
@@ -1,10 +1,84 @@
 import Groq from 'groq-sdk';
-import { Err, Ok, type Result, tryAsync, trySync } from 'wellcrafted/result';
-import { WhisperingErr, type WhisperingError } from '$lib/result';
+import {
+	defineErrors,
+	extractErrorMessage,
+	type InferErrors,
+} from 'wellcrafted/error';
+import { Err, type Result, tryAsync, trySync } from 'wellcrafted/result';
 import { customFetch } from '$lib/services/http';
 import { getAudioExtension } from '$lib/services/transcription/utils';
 
 const MAX_FILE_SIZE_MB = 25 as const;
+
+type GroqAPIError = InstanceType<typeof Groq.APIError>;
+
+export const GroqError = defineErrors({
+	MissingApiKey: () => ({
+		message: 'Groq API key is required',
+	}),
+	InvalidApiKeyFormat: () => ({
+		message: 'Groq API keys must start with "gsk_" or "xai-"',
+	}),
+	FileTooLarge: ({
+		sizeMb,
+		maxMb,
+	}: {
+		sizeMb: number;
+		maxMb: number;
+	}) => ({
+		message: `File size ${sizeMb.toFixed(1)}MB exceeds ${maxMb}MB limit`,
+		sizeMb,
+		maxMb,
+	}),
+	FileCreationFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to create audio file for transcription: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	BadRequest: ({ cause }: { cause: GroqAPIError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	Unauthorized: ({ cause }: { cause: GroqAPIError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	PermissionDenied: ({ cause }: { cause: GroqAPIError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	NotFound: ({ cause }: { cause: GroqAPIError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	UnprocessableEntity: ({ cause }: { cause: GroqAPIError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	RateLimit: ({ cause }: { cause: GroqAPIError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	ServiceUnavailable: ({
+		cause,
+		status,
+	}: {
+		cause: GroqAPIError;
+		status: number;
+	}) => ({
+		message: cause.message,
+		cause,
+		status,
+	}),
+	Connection: ({ cause }: { cause: GroqAPIError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	Unexpected: ({ cause }: { cause: unknown }) => ({
+		message: extractErrorMessage(cause),
+		cause,
+	}),
+});
+export type GroqError = InferErrors<typeof GroqError>;
 
 export const GroqTranscriptionServiceLive = {
 	async transcribe(
@@ -17,58 +91,21 @@ export const GroqTranscriptionServiceLive = {
 			modelName: string;
 			baseURL?: string;
 		},
-	): Promise<Result<string, WhisperingError>> {
+	): Promise<Result<string, GroqError>> {
 		const isUsingCustomEndpoint = Boolean(options.baseURL);
 
-		// When no custom baseURL is provided, we're using the official Groq API.
-		// The official API has strict requirements:
-		// 1. An API key is always required
-		// 2. The key must follow Groq's format (starts with "gsk_" or "xai-")
-		//
-		// Custom endpoints (reverse proxies, Groq-compatible servers, etc.) may have
-		// different authentication schemes or no auth at all, so we skip these checks.
 		if (!isUsingCustomEndpoint) {
-			// Check 1: Official Groq API requires an API key
-			if (!options.apiKey) {
-				return WhisperingErr({
-					title: '🔑 API Key Required',
-					description: 'Please enter your Groq API key in settings.',
-					action: {
-						type: 'link',
-						label: 'Add API key',
-						href: '/settings/transcription',
-					},
-				});
-			}
-
-			// Check 2: Official Groq API keys start with "gsk_" or "xai-"
+			if (!options.apiKey) return GroqError.MissingApiKey();
 			const hasValidGroqKeyFormat =
 				options.apiKey.startsWith('gsk_') || options.apiKey.startsWith('xai-');
-
-			if (!hasValidGroqKeyFormat) {
-				return WhisperingErr({
-					title: '🔑 Invalid API Key Format',
-					description:
-						'Your Groq API key should start with "gsk_" or "xai-". Please check and update your API key.',
-					action: {
-						type: 'link',
-						label: 'Update API key',
-						href: '/settings/transcription',
-					},
-				});
-			}
+			if (!hasValidGroqKeyFormat) return GroqError.InvalidApiKeyFormat();
 		}
 
-		// Check file size
-		const blobSizeInMb = audioBlob.size / (1024 * 1024);
-		if (blobSizeInMb > MAX_FILE_SIZE_MB) {
-			return WhisperingErr({
-				title: `The file size (${blobSizeInMb}MB) is too large`,
-				description: `Please upload a file smaller than ${MAX_FILE_SIZE_MB}MB.`,
-			});
+		const sizeMb = audioBlob.size / (1024 * 1024);
+		if (sizeMb > MAX_FILE_SIZE_MB) {
+			return GroqError.FileTooLarge({ sizeMb, maxMb: MAX_FILE_SIZE_MB });
 		}
 
-		// Create file from blob
 		const { data: file, error: fileError } = trySync({
 			try: () =>
 				new File(
@@ -76,21 +113,14 @@ export const GroqTranscriptionServiceLive = {
 					`recording.${getAudioExtension(audioBlob.type)}`,
 					{ type: audioBlob.type },
 				),
-			catch: (error) =>
-				WhisperingErr({
-					title: '📄 File Creation Failed',
-					description:
-						'Failed to create audio file for transcription. Please try again.',
-					action: { type: 'more-details', error },
-				}),
+			catch: (cause) => GroqError.FileCreationFailed({ cause }),
 		});
 
 		if (fileError) return Err(fileError);
 
-		// Make the transcription request
-		const { data: transcription, error: groqApiError } = await tryAsync({
-			try: () =>
-				new Groq({
+		return tryAsync({
+			try: async () => {
+				const transcription = await new Groq({
 					apiKey: options.apiKey,
 					dangerouslyAllowBrowser: true,
 					fetch: customFetch,
@@ -106,130 +136,38 @@ export const GroqTranscriptionServiceLive = {
 					temperature: options.temperature
 						? Number.parseFloat(options.temperature)
 						: undefined,
-				}),
+				});
+				return transcription.text.trim();
+			},
 			catch: (error) => {
-				// Check if it's NOT a Groq API error
 				if (!(error instanceof Groq.APIError)) {
-					// This is an unexpected error type
-					throw error;
+					return GroqError.Unexpected({ cause: error });
 				}
-				// Return the error directly
-				return Err(error);
+				const { status, name } = error;
+				if (!status && name === 'APIConnectionError') {
+					return GroqError.Connection({ cause: error });
+				}
+				switch (status) {
+					case 400:
+						return GroqError.BadRequest({ cause: error });
+					case 401:
+						return GroqError.Unauthorized({ cause: error });
+					case 403:
+						return GroqError.PermissionDenied({ cause: error });
+					case 404:
+						return GroqError.NotFound({ cause: error });
+					case 422:
+						return GroqError.UnprocessableEntity({ cause: error });
+					case 429:
+						return GroqError.RateLimit({ cause: error });
+					default:
+						if (status && status >= 500) {
+							return GroqError.ServiceUnavailable({ cause: error, status });
+						}
+						return GroqError.Unexpected({ cause: error });
+				}
 			},
 		});
-
-		if (groqApiError) {
-			// Error handling follows https://www.npmjs.com/package/groq-sdk#error-handling
-			const { status, name, message, error } = groqApiError;
-
-			// 400 - BadRequestError
-			if (status === 400) {
-				return WhisperingErr({
-					title: '❌ Bad Request',
-					description:
-						message ??
-						`Invalid request to Groq API. ${error?.message ?? ''}`.trim(),
-					action: { type: 'more-details', error: groqApiError },
-				});
-			}
-
-			// 401 - AuthenticationError
-			if (status === 401) {
-				return WhisperingErr({
-					title: '🔑 Authentication Required',
-					description:
-						message ??
-						'Your API key appears to be invalid or expired. Please update your API key in settings to continue transcribing.',
-					action: {
-						type: 'link',
-						label: 'Update API key',
-						href: '/settings/transcription',
-					},
-				});
-			}
-
-			// 403 - PermissionDeniedError
-			if (status === 403) {
-				return WhisperingErr({
-					title: '⛔ Permission Denied',
-					description:
-						message ??
-						"Your account doesn't have access to this feature. This may be due to plan limitations or account restrictions.",
-					action: { type: 'more-details', error: groqApiError },
-				});
-			}
-
-			// 404 - NotFoundError
-			if (status === 404) {
-				return WhisperingErr({
-					title: '🔍 Not Found',
-					description:
-						message ??
-						'The requested resource was not found. This might indicate an issue with the model or API endpoint.',
-					action: { type: 'more-details', error: groqApiError },
-				});
-			}
-
-			// 422 - UnprocessableEntityError
-			if (status === 422) {
-				return WhisperingErr({
-					title: '⚠️ Invalid Input',
-					description:
-						message ??
-						'The request was valid but the server cannot process it. Please check your audio file and parameters.',
-					action: {
-						type: 'link',
-						label: 'Update API key',
-						href: '/settings/transcription',
-					},
-				});
-			}
-
-			// 429 - RateLimitError
-			if (status === 429) {
-				return WhisperingErr({
-					title: '⏱️ Rate Limit Reached',
-					description: message ?? 'Too many requests. Please try again later.',
-					action: {
-						type: 'link',
-						label: 'Update API key',
-						href: '/settings/transcription',
-					},
-				});
-			}
-
-			// >=500 - InternalServerError
-			if (status && status >= 500) {
-				return WhisperingErr({
-					title: '🔧 Service Unavailable',
-					description:
-						message ??
-						`The transcription service is temporarily unavailable (Error ${status}). Please try again in a few minutes.`,
-					action: { type: 'more-details', error: groqApiError },
-				});
-			}
-
-			// Handle APIConnectionError (no status code)
-			if (!status && name === 'APIConnectionError') {
-				return WhisperingErr({
-					title: '🌐 Connection Issue',
-					description:
-						message ??
-						'Unable to connect to the Groq service. This could be a network issue or temporary service interruption.',
-					action: { type: 'more-details', error: groqApiError },
-				});
-			}
-
-			// Return the error directly for other API errors
-			return WhisperingErr({
-				title: '❌ Unexpected Error',
-				description:
-					message ?? 'An unexpected error occurred. Please try again.',
-				action: { type: 'more-details', error: groqApiError },
-			});
-		}
-
-		return Ok(transcription.text.trim());
 	},
 };
 

--- a/apps/whispering/src/lib/services/transcription/cloud/mistral.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/mistral.ts
@@ -1,5 +1,6 @@
 import { Mistral } from '@mistralai/mistralai';
 import { MistralError as MistralSdkError } from '@mistralai/mistralai/models/errors';
+import { ConnectionError as MistralConnectionError } from '@mistralai/mistralai/models/errors/httpclienterrors';
 import {
 	defineErrors,
 	extractErrorMessage,
@@ -55,6 +56,10 @@ export const MistralTranscriptionError = defineErrors({
 		message: cause.message,
 		cause,
 		status,
+	}),
+	Connection: ({ cause }: { cause: MistralConnectionError }) => ({
+		message: cause.message,
+		cause,
 	}),
 	InvalidResponse: () => ({
 		message: 'Mistral API returned an invalid response format',
@@ -115,6 +120,9 @@ export const MistralTranscriptionServiceLive = {
 						: undefined,
 				}),
 			catch: (error) => {
+				if (error instanceof MistralConnectionError) {
+					return MistralTranscriptionError.Connection({ cause: error });
+				}
 				if (!(error instanceof MistralSdkError)) {
 					return MistralTranscriptionError.Unexpected({ cause: error });
 				}

--- a/apps/whispering/src/lib/services/transcription/cloud/mistral.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/mistral.ts
@@ -1,9 +1,72 @@
 import { Mistral } from '@mistralai/mistralai';
+import { MistralError as MistralSdkError } from '@mistralai/mistralai/models/errors';
+import {
+	defineErrors,
+	extractErrorMessage,
+	type InferErrors,
+} from 'wellcrafted/error';
 import { Err, Ok, type Result, tryAsync, trySync } from 'wellcrafted/result';
-import { WhisperingErr, type WhisperingError } from '$lib/result';
 import { getAudioExtension } from '$lib/services/transcription/utils';
 
 const MAX_FILE_SIZE_MB = 25 as const;
+
+export const MistralTranscriptionError = defineErrors({
+	MissingApiKey: () => ({
+		message: 'Mistral API key is required',
+	}),
+	FileTooLarge: ({
+		sizeMb,
+		maxMb,
+	}: {
+		sizeMb: number;
+		maxMb: number;
+	}) => ({
+		message: `File size ${sizeMb.toFixed(1)}MB exceeds ${maxMb}MB limit`,
+		sizeMb,
+		maxMb,
+	}),
+	FileCreationFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to create audio file for transcription: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	Unauthorized: ({ cause }: { cause: MistralSdkError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	RateLimit: ({ cause }: { cause: MistralSdkError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	PayloadTooLarge: ({ cause }: { cause: MistralSdkError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	BadRequest: ({ cause }: { cause: MistralSdkError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	ServiceUnavailable: ({
+		cause,
+		status,
+	}: {
+		cause: MistralSdkError;
+		status: number;
+	}) => ({
+		message: cause.message,
+		cause,
+		status,
+	}),
+	InvalidResponse: () => ({
+		message: 'Mistral API returned an invalid response format',
+	}),
+	Unexpected: ({ cause }: { cause: unknown }) => ({
+		message: extractErrorMessage(cause),
+		cause,
+	}),
+});
+export type MistralTranscriptionError = InferErrors<
+	typeof MistralTranscriptionError
+>;
 
 export const MistralTranscriptionServiceLive = {
 	async transcribe(
@@ -15,30 +78,17 @@ export const MistralTranscriptionServiceLive = {
 			apiKey: string;
 			modelName: string;
 		},
-	): Promise<Result<string, WhisperingError>> {
-		// Pre-validate API key
-		if (!options.apiKey) {
-			return WhisperingErr({
-				title: '🔑 API Key Required',
-				description: 'Please enter your Mistral API key in settings.',
-				action: {
-					type: 'link',
-					label: 'Add API key',
-					href: '/settings/transcription',
-				},
+	): Promise<Result<string, MistralTranscriptionError>> {
+		if (!options.apiKey) return MistralTranscriptionError.MissingApiKey();
+
+		const sizeMb = audioBlob.size / (1024 * 1024);
+		if (sizeMb > MAX_FILE_SIZE_MB) {
+			return MistralTranscriptionError.FileTooLarge({
+				sizeMb,
+				maxMb: MAX_FILE_SIZE_MB,
 			});
 		}
 
-		// Check file size
-		const blobSizeInMb = audioBlob.size / (1024 * 1024);
-		if (blobSizeInMb > MAX_FILE_SIZE_MB) {
-			return WhisperingErr({
-				title: `The file size (${blobSizeInMb}MB) is too large`,
-				description: `Please upload a file smaller than ${MAX_FILE_SIZE_MB}MB.`,
-			});
-		}
-
-		// Create file from blob
 		const { data: file, error: fileError } = trySync({
 			try: () =>
 				new File(
@@ -46,22 +96,14 @@ export const MistralTranscriptionServiceLive = {
 					`recording.${getAudioExtension(audioBlob.type)}`,
 					{ type: audioBlob.type },
 				),
-			catch: (error) =>
-				WhisperingErr({
-					title: '📄 File Creation Failed',
-					description:
-						'Failed to create audio file for transcription. Please try again.',
-					action: { type: 'more-details', error },
-				}),
+			catch: (cause) => MistralTranscriptionError.FileCreationFailed({ cause }),
 		});
 
 		if (fileError) return Err(fileError);
 
-		const { data: transcription, error: mistralApiError } = await tryAsync({
+		const { data: transcription, error: apiError } = await tryAsync({
 			try: () =>
-				new Mistral({
-					apiKey: options.apiKey,
-				}).audio.transcriptions.complete({
+				new Mistral({ apiKey: options.apiKey }).audio.transcriptions.complete({
 					file,
 					model: options.modelName,
 					language:
@@ -73,55 +115,34 @@ export const MistralTranscriptionServiceLive = {
 						: undefined,
 				}),
 			catch: (error) => {
-				const message =
-					error instanceof Error ? error.message : 'Unknown error occurred';
-
-				if (message.includes('401') || message.includes('Unauthorized')) {
-					return WhisperingErr({
-						title: '🔑 Authentication Required',
-						description:
-							'Your API key appears to be invalid or expired. Please update your API key in settings.',
-						action: {
-							type: 'link',
-							label: 'Update API key',
-							href: '/settings/transcription',
-						},
-					});
+				if (!(error instanceof MistralSdkError)) {
+					return MistralTranscriptionError.Unexpected({ cause: error });
 				}
-
-				if (message.includes('429') || message.includes('rate limit')) {
-					return WhisperingErr({
-						title: '⏱️ Rate Limit Reached',
-						description: 'Too many requests. Please try again later.',
-						action: { type: 'more-details', error },
-					});
+				switch (error.statusCode) {
+					case 400:
+						return MistralTranscriptionError.BadRequest({ cause: error });
+					case 401:
+						return MistralTranscriptionError.Unauthorized({ cause: error });
+					case 413:
+						return MistralTranscriptionError.PayloadTooLarge({ cause: error });
+					case 429:
+						return MistralTranscriptionError.RateLimit({ cause: error });
+					default:
+						if (error.statusCode >= 500) {
+							return MistralTranscriptionError.ServiceUnavailable({
+								cause: error,
+								status: error.statusCode,
+							});
+						}
+						return MistralTranscriptionError.Unexpected({ cause: error });
 				}
-
-				if (message.includes('413') || message.includes('too large')) {
-					return WhisperingErr({
-						title: '📦 Audio File Too Large',
-						description:
-							'Your audio file exceeds the maximum size limit. Try reducing the file size.',
-						action: { type: 'more-details', error },
-					});
-				}
-
-				return WhisperingErr({
-					title: '❌ Transcription Failed',
-					description: message,
-					action: { type: 'more-details', error },
-				});
 			},
 		});
 
-		if (mistralApiError) return Err(mistralApiError);
+		if (apiError) return Err(apiError);
 
-		// Check if transcription is valid
 		if (!transcription || typeof transcription.text !== 'string') {
-			return WhisperingErr({
-				title: '❌ Invalid Transcription Response',
-				description: 'Mistral API returned an invalid response format.',
-			});
+			return MistralTranscriptionError.InvalidResponse();
 		}
 
 		return Ok(transcription.text.trim());

--- a/apps/whispering/src/lib/services/transcription/cloud/mistral.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/mistral.ts
@@ -57,7 +57,6 @@ export const MistralTranscriptionServiceLive = {
 
 		if (fileError) return Err(fileError);
 
-		// Make the transcription request
 		const { data: transcription, error: mistralApiError } = await tryAsync({
 			try: () =>
 				new Mistral({
@@ -74,59 +73,48 @@ export const MistralTranscriptionServiceLive = {
 						: undefined,
 				}),
 			catch: (error) => {
-				// Return the error directly for processing
-				return Err(error);
+				const message =
+					error instanceof Error ? error.message : 'Unknown error occurred';
+
+				if (message.includes('401') || message.includes('Unauthorized')) {
+					return WhisperingErr({
+						title: '🔑 Authentication Required',
+						description:
+							'Your API key appears to be invalid or expired. Please update your API key in settings.',
+						action: {
+							type: 'link',
+							label: 'Update API key',
+							href: '/settings/transcription',
+						},
+					});
+				}
+
+				if (message.includes('429') || message.includes('rate limit')) {
+					return WhisperingErr({
+						title: '⏱️ Rate Limit Reached',
+						description: 'Too many requests. Please try again later.',
+						action: { type: 'more-details', error },
+					});
+				}
+
+				if (message.includes('413') || message.includes('too large')) {
+					return WhisperingErr({
+						title: '📦 Audio File Too Large',
+						description:
+							'Your audio file exceeds the maximum size limit. Try reducing the file size.',
+						action: { type: 'more-details', error },
+					});
+				}
+
+				return WhisperingErr({
+					title: '❌ Transcription Failed',
+					description: message,
+					action: { type: 'more-details', error },
+				});
 			},
 		});
 
-		if (mistralApiError) {
-			// Handle Mistral API errors
-			const errorMessage =
-				mistralApiError instanceof Error
-					? mistralApiError.message
-					: 'Unknown error occurred';
-
-			// Check for common HTTP status codes
-			if (
-				errorMessage.includes('401') ||
-				errorMessage.includes('Unauthorized')
-			) {
-				return WhisperingErr({
-					title: '🔑 Authentication Required',
-					description:
-						'Your API key appears to be invalid or expired. Please update your API key in settings.',
-					action: {
-						type: 'link',
-						label: 'Update API key',
-						href: '/settings/transcription',
-					},
-				});
-			}
-
-			if (errorMessage.includes('429') || errorMessage.includes('rate limit')) {
-				return WhisperingErr({
-					title: '⏱️ Rate Limit Reached',
-					description: 'Too many requests. Please try again later.',
-					action: { type: 'more-details', error: mistralApiError },
-				});
-			}
-
-			if (errorMessage.includes('413') || errorMessage.includes('too large')) {
-				return WhisperingErr({
-					title: '📦 Audio File Too Large',
-					description:
-						'Your audio file exceeds the maximum size limit. Try reducing the file size.',
-					action: { type: 'more-details', error: mistralApiError },
-				});
-			}
-
-			// Generic error fallback
-			return WhisperingErr({
-				title: '❌ Transcription Failed',
-				description: errorMessage,
-				action: { type: 'more-details', error: mistralApiError },
-			});
-		}
+		if (mistralApiError) return Err(mistralApiError);
 
 		// Check if transcription is valid
 		if (!transcription || typeof transcription.text !== 'string') {

--- a/apps/whispering/src/lib/services/transcription/cloud/openai.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/openai.ts
@@ -1,10 +1,92 @@
 import OpenAI from 'openai';
-import { Err, Ok, type Result, tryAsync, trySync } from 'wellcrafted/result';
-import { WhisperingErr, type WhisperingError } from '$lib/result';
+import {
+	defineErrors,
+	extractErrorMessage,
+	type InferErrors,
+} from 'wellcrafted/error';
+import { Err, type Result, tryAsync, trySync } from 'wellcrafted/result';
 import { customFetch } from '$lib/services/http';
 import { getAudioExtension } from '$lib/services/transcription/utils';
 
 const MAX_FILE_SIZE_MB = 25 as const;
+
+type OpenAIAPIError = InstanceType<typeof OpenAI.APIError>;
+
+export const OpenaiError = defineErrors({
+	MissingApiKey: () => ({
+		message: 'OpenAI API key is required',
+	}),
+	InvalidApiKeyFormat: () => ({
+		message: 'OpenAI API keys must start with "sk-"',
+	}),
+	FileTooLarge: ({
+		sizeMb,
+		maxMb,
+	}: {
+		sizeMb: number;
+		maxMb: number;
+	}) => ({
+		message: `File size ${sizeMb.toFixed(1)}MB exceeds ${maxMb}MB limit`,
+		sizeMb,
+		maxMb,
+	}),
+	FileCreationFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to create audio file for transcription: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+	BadRequest: ({ cause }: { cause: OpenAIAPIError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	Unauthorized: ({ cause }: { cause: OpenAIAPIError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	PermissionDenied: ({ cause }: { cause: OpenAIAPIError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	NotFound: ({ cause }: { cause: OpenAIAPIError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	PayloadTooLarge: ({ cause }: { cause: OpenAIAPIError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	UnsupportedMediaType: ({ cause }: { cause: OpenAIAPIError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	UnprocessableEntity: ({ cause }: { cause: OpenAIAPIError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	RateLimit: ({ cause }: { cause: OpenAIAPIError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	ServiceUnavailable: ({
+		cause,
+		status,
+	}: {
+		cause: OpenAIAPIError;
+		status: number;
+	}) => ({
+		message: cause.message,
+		cause,
+		status,
+	}),
+	Connection: ({ cause }: { cause: OpenAIAPIError }) => ({
+		message: cause.message,
+		cause,
+	}),
+	Unexpected: ({ cause }: { cause: unknown }) => ({
+		message: extractErrorMessage(cause),
+		cause,
+	}),
+});
+export type OpenaiError = InferErrors<typeof OpenaiError>;
 
 export const OpenaiTranscriptionServiceLive = {
 	async transcribe(
@@ -17,56 +99,23 @@ export const OpenaiTranscriptionServiceLive = {
 			modelName: string;
 			baseURL?: string;
 		},
-	): Promise<Result<string, WhisperingError>> {
+	): Promise<Result<string, OpenaiError>> {
 		const isUsingCustomEndpoint = Boolean(options.baseURL);
 
-		// When no custom baseURL is provided, we're using the official OpenAI API.
-		// The official API has strict requirements:
-		// 1. An API key is always required
-		// 2. The key must follow OpenAI's format (starts with "sk-")
-		//
-		// Custom endpoints (reverse proxies, OpenAI-compatible servers, etc.) may have
-		// different authentication schemes or no auth at all, so we skip these checks.
+		// Custom endpoints (reverse proxies, OpenAI-compatible servers) may have
+		// different auth schemes or no auth — skip API-key format checks.
 		if (!isUsingCustomEndpoint) {
-			// Check 1: Official OpenAI API requires an API key
-			if (!options.apiKey) {
-				return WhisperingErr({
-					title: '🔑 API Key Required',
-					description:
-						'Please enter your OpenAI API key in settings to use Whisper transcription.',
-					action: {
-						type: 'link',
-						label: 'Add API key',
-						href: '/settings/transcription',
-					},
-				});
-			}
-
-			// Check 2: Official OpenAI API keys always start with "sk-"
+			if (!options.apiKey) return OpenaiError.MissingApiKey();
 			if (!options.apiKey.startsWith('sk-')) {
-				return WhisperingErr({
-					title: '🔑 Invalid API Key Format',
-					description:
-						'Your OpenAI API key should start with "sk-". Please check and update your API key.',
-					action: {
-						type: 'link',
-						label: 'Update API key',
-						href: '/settings/transcription',
-					},
-				});
+				return OpenaiError.InvalidApiKeyFormat();
 			}
 		}
 
-		// Validate file size
-		const blobSizeInMb = audioBlob.size / (1024 * 1024);
-		if (blobSizeInMb > MAX_FILE_SIZE_MB) {
-			return WhisperingErr({
-				title: `The file size (${blobSizeInMb}MB) is too large`,
-				description: `Please upload a file smaller than ${MAX_FILE_SIZE_MB}MB.`,
-			});
+		const sizeMb = audioBlob.size / (1024 * 1024);
+		if (sizeMb > MAX_FILE_SIZE_MB) {
+			return OpenaiError.FileTooLarge({ sizeMb, maxMb: MAX_FILE_SIZE_MB });
 		}
 
-		// Create File object from blob
 		const { data: file, error: fileError } = trySync({
 			try: () =>
 				new File(
@@ -74,20 +123,14 @@ export const OpenaiTranscriptionServiceLive = {
 					`recording.${getAudioExtension(audioBlob.type)}`,
 					{ type: audioBlob.type },
 				),
-			catch: (_error) =>
-				WhisperingErr({
-					title: '📁 File Creation Failed',
-					description:
-						'Failed to create audio file for transcription. Please try again.',
-				}),
+			catch: (cause) => OpenaiError.FileCreationFailed({ cause }),
 		});
 
 		if (fileError) return Err(fileError);
 
-		// Call OpenAI API
-		const { data: transcription, error: openaiApiError } = await tryAsync({
-			try: () =>
-				new OpenAI({
+		return tryAsync({
+			try: async () => {
+				const transcription = await new OpenAI({
 					apiKey: options.apiKey,
 					dangerouslyAllowBrowser: true,
 					fetch: customFetch,
@@ -103,149 +146,42 @@ export const OpenaiTranscriptionServiceLive = {
 					temperature: options.temperature
 						? Number.parseFloat(options.temperature)
 						: undefined,
-				}),
+				});
+				return transcription.text.trim();
+			},
 			catch: (error) => {
-				// Check if it's NOT an OpenAI API error
 				if (!(error instanceof OpenAI.APIError)) {
-					// This is an unexpected error type
-					throw error;
+					return OpenaiError.Unexpected({ cause: error });
 				}
-				// Return the error directly
-				return Err(error);
+				const { status, name } = error;
+				if (!status && name === 'APIConnectionError') {
+					return OpenaiError.Connection({ cause: error });
+				}
+				switch (status) {
+					case 400:
+						return OpenaiError.BadRequest({ cause: error });
+					case 401:
+						return OpenaiError.Unauthorized({ cause: error });
+					case 403:
+						return OpenaiError.PermissionDenied({ cause: error });
+					case 404:
+						return OpenaiError.NotFound({ cause: error });
+					case 413:
+						return OpenaiError.PayloadTooLarge({ cause: error });
+					case 415:
+						return OpenaiError.UnsupportedMediaType({ cause: error });
+					case 422:
+						return OpenaiError.UnprocessableEntity({ cause: error });
+					case 429:
+						return OpenaiError.RateLimit({ cause: error });
+					default:
+						if (status && status >= 500) {
+							return OpenaiError.ServiceUnavailable({ cause: error, status });
+						}
+						return OpenaiError.Unexpected({ cause: error });
+				}
 			},
 		});
-
-		if (openaiApiError) {
-			// Error handling follows https://www.npmjs.com/package/openai#error-handling
-			const { status, name, message, error } = openaiApiError;
-
-			// 400 - BadRequestError
-			if (status === 400) {
-				return WhisperingErr({
-					title: '❌ Bad Request',
-					description:
-						message ??
-						`Invalid request to OpenAI API. ${error?.message ?? ''}`.trim(),
-					action: { type: 'more-details', error: openaiApiError },
-				});
-			}
-
-			// 401 - AuthenticationError
-			if (status === 401) {
-				return WhisperingErr({
-					title: '🔑 Authentication Required',
-					description:
-						message ??
-						'Your API key appears to be invalid or expired. Please update your API key in settings to continue transcribing.',
-					action: {
-						type: 'link',
-						label: 'Update API key',
-						href: '/settings/transcription',
-					},
-				});
-			}
-
-			// 403 - PermissionDeniedError
-			if (status === 403) {
-				return WhisperingErr({
-					title: '⛔ Permission Denied',
-					description:
-						message ??
-						"Your account doesn't have access to this feature. This may be due to plan limitations or account restrictions.",
-					action: { type: 'more-details', error: openaiApiError },
-				});
-			}
-
-			// 404 - NotFoundError
-			if (status === 404) {
-				return WhisperingErr({
-					title: '🔍 Not Found',
-					description:
-						message ??
-						'The requested resource was not found. This might indicate an issue with the model or API endpoint.',
-					action: { type: 'more-details', error: openaiApiError },
-				});
-			}
-
-			// 413 - Request Entity Too Large
-			if (status === 413) {
-				return WhisperingErr({
-					title: '📦 Audio File Too Large',
-					description:
-						message ??
-						'Your audio file exceeds the maximum size limit (25MB). Try splitting it into smaller segments or reducing the audio quality.',
-					action: { type: 'more-details', error: openaiApiError },
-				});
-			}
-
-			// 415 - Unsupported Media Type
-			if (status === 415) {
-				return WhisperingErr({
-					title: '🎵 Unsupported Format',
-					description:
-						message ??
-						"This audio format isn't supported. Please convert your file to MP3, WAV, M4A, or another common audio format.",
-					action: { type: 'more-details', error: openaiApiError },
-				});
-			}
-
-			// 422 - UnprocessableEntityError
-			if (status === 422) {
-				return WhisperingErr({
-					title: '⚠️ Invalid Input',
-					description:
-						message ??
-						'The request was valid but the server cannot process it. Please check your audio file and parameters.',
-					action: { type: 'more-details', error: openaiApiError },
-				});
-			}
-
-			// 429 - RateLimitError
-			if (status === 429) {
-				return WhisperingErr({
-					title: '⏱️ Rate Limit Reached',
-					description: message ?? 'Too many requests. Please try again later.',
-					action: {
-						type: 'link',
-						label: 'Update API key',
-						href: '/settings/transcription',
-					},
-				});
-			}
-
-			// >=500 - InternalServerError
-			if (status && status >= 500) {
-				return WhisperingErr({
-					title: '🔧 Service Unavailable',
-					description:
-						message ??
-						`The transcription service is temporarily unavailable (Error ${status}). Please try again in a few minutes.`,
-					action: { type: 'more-details', error: openaiApiError },
-				});
-			}
-
-			// Handle APIConnectionError (no status code)
-			if (!status && name === 'APIConnectionError') {
-				return WhisperingErr({
-					title: '🌐 Connection Issue',
-					description:
-						message ??
-						'Unable to connect to the OpenAI service. This could be a network issue or temporary service interruption.',
-					action: { type: 'more-details', error: openaiApiError },
-				});
-			}
-
-			// Return the error directly for other API errors
-			return WhisperingErr({
-				title: '❌ Unexpected Error',
-				description:
-					message ?? 'An unexpected error occurred. Please try again.',
-				action: { type: 'more-details', error: openaiApiError },
-			});
-		}
-
-		// Success - return the transcription text
-		return Ok(transcription.text.trim());
 	},
 };
 

--- a/apps/whispering/src/lib/services/transcription/index.ts
+++ b/apps/whispering/src/lib/services/transcription/index.ts
@@ -2,7 +2,7 @@
 
 // Cloud transcription services
 import { DeepgramTranscriptionServiceLive } from './cloud/deepgram';
-import { ElevenlabsTranscriptionServiceLive } from './cloud/elevenlabs';
+import { ElevenLabsTranscriptionServiceLive } from './cloud/elevenlabs';
 import { GroqTranscriptionServiceLive } from './cloud/groq';
 import { MistralTranscriptionServiceLive } from './cloud/mistral';
 import { OpenaiTranscriptionServiceLive } from './cloud/openai';
@@ -16,7 +16,7 @@ import { SpeachesTranscriptionServiceLive } from './self-hosted/speaches';
 
 export {
 	DeepgramTranscriptionServiceLive as deepgram,
-	ElevenlabsTranscriptionServiceLive as elevenlabs,
+	ElevenLabsTranscriptionServiceLive as elevenlabs,
 	GroqTranscriptionServiceLive as groq,
 	MistralTranscriptionServiceLive as mistral,
 	MoonshineTranscriptionServiceLive as moonshine,

--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -16,8 +16,9 @@
 	import { nanoid } from 'nanoid/non-secure';
 	import { onDestroy, onMount } from 'svelte';
 	import { extractErrorMessage } from 'wellcrafted/error';
-	import { Err, partitionResults, tryAsync } from 'wellcrafted/result';
+	import { partitionResults, tryAsync } from 'wellcrafted/result';
 	import { commandCallbacks } from '$lib/commands';
+	import { WhisperingErr } from '$lib/result';
 	import TranscriptDialog from '$lib/components/copyable/TranscriptDialog.svelte';
 	import {
 		CompressionSelector,
@@ -152,14 +153,13 @@
 					},
 				);
 			},
-			catch: (error) => Err(error),
+			catch: (error) =>
+				WhisperingErr({
+					title: '❌ Failed to set up drag drop listener',
+					description: extractErrorMessage(error),
+				}),
 		});
-		if (error) {
-			rpc.notify.error({
-				title: '❌ Failed to set up drag drop listener',
-				description: extractErrorMessage(error),
-			});
-		}
+		if (error) rpc.notify.error(error);
 	});
 
 	onDestroy(() => {

--- a/apps/whispering/src/routes/(app)/_layout-utils/check-for-updates.ts
+++ b/apps/whispering/src/routes/(app)/_layout-utils/check-for-updates.ts
@@ -1,11 +1,12 @@
 import { check, type DownloadEvent } from '@tauri-apps/plugin-updater';
 import { extractErrorMessage } from 'wellcrafted/error';
-import { Err, tryAsync } from 'wellcrafted/result';
+import { tryAsync } from 'wellcrafted/result';
 import {
 	type UpdateInfo,
 	updateDialog,
 } from '$lib/components/UpdateDialog.svelte';
 import { rpc } from '$lib/query';
+import { WhisperingErr } from '$lib/result';
 
 export async function checkForUpdates() {
 	const { error } = await tryAsync({
@@ -24,14 +25,13 @@ export async function checkForUpdates() {
 				});
 			}
 		},
-		catch: (error) => Err(error),
+		catch: (error) =>
+			WhisperingErr({
+				title: 'Failed to check for updates',
+				description: extractErrorMessage(error),
+			}),
 	});
-	if (error) {
-		rpc.notify.error({
-			title: 'Failed to check for updates',
-			description: extractErrorMessage(error),
-		});
-	}
+	if (error) rpc.notify.error(error);
 }
 
 /**

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "epicenter",
@@ -3715,21 +3714,21 @@
 
     "@devicefarmer/adbkit/debug": ["debug@4.3.7", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ=="],
 
-    "@epicenter/api/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+    "@epicenter/api/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
-    "@epicenter/filesystem/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+    "@epicenter/filesystem/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@epicenter/filesystem/drizzle-orm": ["drizzle-orm@0.38.4", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/react": ">=18", "@types/sql.js": "*", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "react": ">=18", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/react", "@types/sql.js", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "knex", "kysely", "mysql2", "pg", "postgres", "react", "sql.js", "sqlite3"] }, "sha512-s7/5BpLKO+WJRHspvpqTydxFob8i1vo2rEx4pY6TGY7QSMuUfWUuzaY0DIpXCkgHOo37BaFC+SJQb99dDUXT3Q=="],
 
-    "@epicenter/skills/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+    "@epicenter/skills/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
-    "@epicenter/sync/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+    "@epicenter/sync/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@epicenter/ui/@lucide/svelte": ["@lucide/svelte@1.8.0", "", { "peerDependencies": { "svelte": "^5" } }, "sha512-+zYQUKqEOVP5lxbGmxL1OVgGMQtRK91eIJ0bR+3Cr1ts4oQEsQfxyzzd5X47psJlblAuGFrl2xm4YuATjR9oaA=="],
 
     "@epicenter/ui/layerchart": ["layerchart@2.0.0-next.48", "", { "dependencies": { "@dagrejs/dagre": "^2.0.4", "@layerstack/svelte-actions": "1.0.1-next.18", "@layerstack/svelte-state": "0.1.0-next.23", "@layerstack/tailwind": "2.0.0-next.21", "@layerstack/utils": "2.0.0-next.18", "@types/d3-contour": "^3.0.6", "d3-array": "^3.2.4", "d3-chord": "^3.0.1", "d3-color": "^3.1.0", "d3-contour": "^4.0.2", "d3-delaunay": "^6.0.4", "d3-dsv": "^3.0.1", "d3-force": "^3.0.0", "d3-geo": "^3.1.1", "d3-geo-voronoi": "^2.1.0", "d3-hierarchy": "^3.1.2", "d3-interpolate": "^3.0.1", "d3-interpolate-path": "^2.3.0", "d3-path": "^3.1.0", "d3-quadtree": "^3.0.1", "d3-random": "^3.0.1", "d3-sankey": "^0.12.3", "d3-scale": "^4.0.2", "d3-scale-chromatic": "^3.1.0", "d3-shape": "^3.2.0", "d3-tile": "^1.0.0", "d3-time": "^3.1.0", "memoize": "^10.2.0", "runed": "^0.37.1" }, "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-XoEYBztamA8lMxtF/Jz3aDX0HMk8dI+o4fK9fSl8ecT2Tdx3DQUjtKGtlQAOFdwC/AWifeLmKq5cMTQt9COZPQ=="],
 
-    "@epicenter/workspace/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+    "@epicenter/workspace/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
@@ -4103,6 +4102,14 @@
 
     "@astrojs/markdown-remark/shiki/@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
 
+    "@epicenter/api/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "@epicenter/filesystem/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "@epicenter/skills/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "@epicenter/sync/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
     "@epicenter/ui/layerchart/@dagrejs/dagre": ["@dagrejs/dagre@2.0.4", "", { "dependencies": { "@dagrejs/graphlib": "3.0.4" } }, "sha512-J6vCWTNpicHF4zFlZG1cS5DkGzMr9941gddYkakjrg3ZNev4bbqEgLHFTWiFrcJm7UCRu7olO3K6IRDd9gSGhA=="],
 
     "@epicenter/ui/layerchart/@layerstack/svelte-actions": ["@layerstack/svelte-actions@1.0.1-next.18", "", { "dependencies": { "@floating-ui/dom": "^1.7.0", "@layerstack/utils": "2.0.0-next.18", "d3-scale": "^4.0.2" } }, "sha512-gxPzCnJ1c9LTfWtRqLUzefCx+k59ZpxDUQ2XB+LokveZQPe7IDSOwHaBOEMlaGoGrtwc3Ft8dSZq+2WT2o9u/g=="],
@@ -4112,6 +4119,8 @@
     "@epicenter/ui/layerchart/@layerstack/utils": ["@layerstack/utils@2.0.0-next.18", "", { "dependencies": { "d3-array": "^3.2.4", "d3-time": "^3.1.0", "d3-time-format": "^4.1.0" } }, "sha512-EYILHpfBRYMMEahajInu9C2AXQom5IcAEdtCeucD3QIl/fdDgRbtzn6/8QW9ewumfyNZetdUvitOksmI1+gZYQ=="],
 
     "@epicenter/ui/layerchart/runed": ["runed@0.37.1", "", { "dependencies": { "dequal": "^2.0.3", "esm-env": "^1.0.0", "lz-string": "^1.5.0" }, "peerDependencies": { "@sveltejs/kit": "^2.21.0", "svelte": "^5.7.0", "zod": "^4.1.0" }, "optionalPeers": ["@sveltejs/kit", "zod"] }, "sha512-MeFY73xBW8IueWBm012nNFIGy19WUGPLtknavyUPMpnyt350M47PhGSGrGoSLbidwn+Zlt/O0cp8/OZE3LASWA=="],
+
+    "@epicenter/workspace/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 

--- a/specs/20260423T180000-transcription-provider-error-taxonomy.md
+++ b/specs/20260423T180000-transcription-provider-error-taxonomy.md
@@ -1,0 +1,230 @@
+# Transcription Provider Error Taxonomy
+
+**Date**: 2026-04-23
+**Status**: Proposed
+**Author**: Surfaced during wellcrafted PR #114 integration
+
+## Overview
+
+Extract provider-specific error handling from each transcription service into its own `defineErrors` taxonomy, and centralize UI translation in a single adapter. Today every cloud provider file (openai, mistral, groq, deepgram, elevenlabs) duplicates ~150 lines of HTTP-status branching and `WhisperingErr` construction. The service layer is tangled with UI copy.
+
+## Motivation
+
+### Current state
+
+Every provider file follows the same pattern:
+
+```ts
+// openai.ts — 252 lines, groq.ts — 236, mistral.ts — 135, deepgram.ts — 210
+async transcribe(audioBlob, options): Promise<Result<string, WhisperingError>> {
+  // 1. Pre-validation (API key, file size) — returns WhisperingErr inline
+  // 2. tryAsync the SDK call
+  //    catch: narrow via instanceof (openai, groq) OR string-match (mistral) OR no-op
+  // 3. if (apiError) { ...huge status-branching block returning WhisperingErr... }
+  // 4. Ok(transcription.text)
+}
+```
+
+Three structural problems:
+
+1. **Every provider duplicates the status→notification mapping.** `401 → "🔑 Authentication Required"`, `429 → "⏱️ Rate Limit Reached"`, etc. The copy is *almost* identical across files, drifts subtly (compare openai's 413 copy to mistral's), and changing UI copy means editing 5 files.
+
+2. **The service layer can't be tested without UI coupling.** You can't call `MistralTranscriptionServiceLive.transcribe()` in a test without pulling in `$lib/result`, `UnifiedNotificationOptions`, and the whole notification schema. The provider's job is "talk to the API"; UI translation is a separate concern it shouldn't own.
+
+3. **Error narrowing is inconsistent and sometimes unsafe.**
+   - openai/groq: `instanceof Provider.APIError` with `throw` escape hatch — works, but the `throw` inside `catch` is a code smell (fights the Result model).
+   - mistral: `message.includes('401')` — fragile string-matching; breaks if Mistral's SDK changes its error message format. PR #114's `NonNullable<unknown>` constraint also breaks this path (fixed in the companion PR by inlining translation, but the fragility remains).
+   - deepgram/elevenlabs: use `HttpServiceLive` which already has typed errors — the *best* of the bunch, but translation to `WhisperingErr` still happens inline per-provider.
+
+### Desired state
+
+Providers return tagged errors. A single adapter translates any provider error into `WhisperingError`.
+
+```ts
+// cloud/openai.ts — becomes ~80 lines
+//
+// Factory-shape convention (applied across all provider error sets):
+// - Variants that wrap an underlying error take `{ cause: NonNullable<unknown> }`
+//   (compatible with wellcrafted PR #114's Err<E extends NonNullable<unknown>> constraint).
+// - Variants carrying extra context add named fields after `cause`.
+// - Pre-validation variants (no SDK call made yet) take no args or the minimum
+//   context needed for the UI copy.
+export const OpenaiError = defineErrors({
+  MissingApiKey:       ()                                                   => ({ message: 'OpenAI API key is required' }),
+  InvalidApiKeyFormat: ()                                                   => ({ message: 'OpenAI API keys must start with "sk-"' }),
+  FileTooLarge:        ({ sizeMb, maxMb }: { sizeMb: number; maxMb: number }) => ({ message: `File size ${sizeMb}MB exceeds ${maxMb}MB limit`, sizeMb, maxMb }),
+  Unauthorized:        ({ cause }: { cause: OpenAI.APIError })              => ({ message: cause.message ?? 'OpenAI rejected the API key', cause }),
+  RateLimit:           ({ cause }: { cause: OpenAI.APIError })              => ({ message: cause.message, cause }),
+  BadRequest:          ({ cause }: { cause: OpenAI.APIError })              => ({ message: cause.message, cause }),
+  // ...one variant per HTTP class the OpenAI SDK distinguishes
+  Connection:          ({ cause }: { cause: OpenAI.APIError })              => ({ message: cause.message, cause }),
+  Unexpected:          ({ cause }: { cause: NonNullable<unknown> })         => ({ message: extractErrorMessage(cause), cause }),
+});
+export type OpenaiError = InferErrors<typeof OpenaiError>;
+
+export const OpenaiTranscriptionServiceLive = {
+  async transcribe(audioBlob, options): Promise<Result<string, OpenaiError>> {
+    if (!options.apiKey) return OpenaiError.MissingApiKey();
+    if (!options.apiKey.startsWith('sk-')) return OpenaiError.InvalidApiKeyFormat();
+
+    const sizeMb = audioBlob.size / (1024 * 1024);
+    if (sizeMb > MAX_FILE_SIZE_MB) {
+      return OpenaiError.FileTooLarge({ sizeMb, maxMb: MAX_FILE_SIZE_MB });
+    }
+
+    return tryAsync({
+      try: () => new OpenAI({...}).audio.transcriptions.create({...}).then(r => r.text.trim()),
+      catch: (error) => {
+        // `error: unknown` from the `catch` — narrow to NonNullable before dispatching.
+        // `throw null` is legal JS; reject it explicitly rather than casting around it.
+        if (error == null) return OpenaiError.Unexpected({ cause: new Error('Non-value thrown from OpenAI SDK') });
+        if (!(error instanceof OpenAI.APIError)) return OpenaiError.Unexpected({ cause: error });
+        switch (error.status) {
+          case 401: return OpenaiError.Unauthorized({ cause: error });
+          case 429: return OpenaiError.RateLimit({ cause: error });
+          case 400: return OpenaiError.BadRequest({ cause: error });
+          // ...
+          default:  return OpenaiError.Unexpected({ cause: error });
+        }
+      },
+    });
+  },
+};
+```
+
+```ts
+// cloud/error-adapter.ts — single source of truth for UI copy
+export function transcriptionErrorToWhisperingErr(
+  err: OpenaiError | GroqError | MistralError | DeepgramError | ElevenlabsError,
+) {
+  switch (err.name) {
+    case 'MissingApiKey':
+      return WhisperingErr({
+        title: '🔑 API Key Required',
+        description: `Please enter your ${providerFor(err)} API key in settings.`,
+        action: { type: 'link', label: 'Add API key', href: '/settings/transcription' },
+      });
+    case 'Unauthorized':
+      return WhisperingErr({
+        title: '🔑 Authentication Required',
+        description: 'Your API key appears to be invalid or expired.',
+        action: { type: 'link', label: 'Update API key', href: '/settings/transcription' },
+      });
+    case 'RateLimit':
+      return WhisperingErr({
+        title: '⏱️ Rate Limit Reached',
+        description: err.message ?? 'Too many requests. Please try again later.',
+        action: { type: 'more-details', error: err.cause },
+      });
+    // ...one case per tagged variant; shared variants (Unauthorized, RateLimit) get one case each
+  }
+}
+```
+
+Call sites in `$lib/query/actions.ts` (or wherever transcription is kicked off) apply the adapter at the UI boundary:
+
+```ts
+const { data, error } = await services.transcription.openai.transcribe(blob, opts);
+if (error) return rpc.notify.error(transcriptionErrorToWhisperingErr(error));
+```
+
+## Design
+
+### The two-layer split
+
+```
+┌─────────────────────────────────┐
+│   UI layer (query/actions)      │   transcriptionErrorToWhisperingErr(err)
+├─────────────────────────────────┤
+│   Adapter layer                 │   one file, one switch, all UI copy lives here
+├─────────────────────────────────┤
+│   Provider layer                │   returns Result<string, ProviderError>
+│   (cloud/openai.ts, etc.)        │   no WhisperingErr, no UnifiedNotificationOptions
+└─────────────────────────────────┘
+```
+
+**Decoupling constraint (load-bearing — enforce via ESLint if possible):**
+
+The provider file AND its colocated error set must not import anything from:
+- `$lib/result` (WhisperingErr, WhisperingError, WhisperingWarningErr)
+- `$lib/services/notifications/*` (UnifiedNotificationOptions, notification types)
+- `$lib/components/*` (UI primitives)
+
+Only the adapter layer may import from those. This is what makes providers unit-testable without UI coupling — the claim collapses if a provider's error types transitively pull in notification schemas through `WhisperingError`.
+
+Provider files may still import from:
+- `wellcrafted/*` (result, error primitives)
+- SDKs (`openai`, `@mistralai/mistralai`, `groq-sdk`, etc.)
+- `$lib/services/http` (already provider-agnostic)
+- `$lib/services/transcription/utils` (getAudioExtension, etc.)
+
+### Per-provider error sets
+
+Each provider defines error variants that reflect what *that provider* actually distinguishes, not a lowest-common-denominator set:
+
+- **openai, groq:** SDK exposes `Provider.APIError` with `status`. Variants: `Unauthorized | RateLimit | BadRequest | NotFound | PermissionDenied | UnprocessableEntity | PayloadTooLarge | UnsupportedMediaType | ServiceUnavailable | Connection | Unexpected`.
+- **mistral:** SDK throws raw errors today. Either use the string-matching fallback inside the `catch` to classify into tagged variants (ugly but contained), OR use `HttpServiceLive` + typed status codes like deepgram does. The latter is better — separate refactor.
+- **deepgram, elevenlabs:** already use `HttpServiceLive`. Lift their inline error handling into their own `defineErrors` sets.
+
+### Where shared variants go
+
+Don't create a root `TranscriptionError` union prematurely. Start with per-provider sets. After all 5 are migrated, look at the adapter's `switch` — if 80% of cases across providers collapse to identical WhisperingErr output (they will, for auth/rate-limit/connection), *then* promote a shared `HttpProviderError` base set that providers extend.
+
+Do this second, not first. Premature unification locks in assumptions before we see the real shape.
+
+### File organization
+
+```
+apps/whispering/src/lib/services/transcription/cloud/
+├── error-adapter.ts          # NEW — transcriptionErrorToWhisperingErr
+├── openai.ts                 # OpenaiError + OpenaiTranscriptionServiceLive
+├── groq.ts                   # GroqError + Groq...
+├── mistral.ts                # MistralError + Mistral...
+├── deepgram.ts               # DeepgramError + Deepgram...
+└── elevenlabs.ts             # ElevenlabsError + Elevenlabs...
+```
+
+Colocate each `XxxError` in its provider file (like `FsError` lives in `fs.ts`) — it's part of the provider's public API.
+
+## Migration plan
+
+Provider-by-provider, ordered by **ROI** (biggest pain first), not by cleanliness:
+
+1. **mistral** (highest ROI — small file, *current* pain). Fragile `message.includes('401')` string-matching breaks silently if the SDK rewords its error messages, and it was the blast-radius site for wellcrafted PR #114's `NonNullable<unknown>` constraint. Smallest file (135 lines), biggest payoff. Two sub-options:
+   - **(a)** Lift Mistral's transcription call onto `HttpServiceLive` like deepgram does — gives typed status codes, kills the string-match. Cleanest end state.
+   - **(b)** Keep the SDK call; move string-match classification *inside* the `catch` to produce `MistralError` tagged variants. The smell is contained to one function instead of leaking into the caller.
+   Default to (a) unless the Mistral SDK adds something `HttpServiceLive` can't (streaming, multipart oddities).
+2. **openai** (medium — SDK exposes `OpenAI.APIError` with `.status`). Biggest file (252 lines) but the structure is clean once `OpenaiError` is defined. Ships the `error-adapter.ts` shared surface; deepgram/elevenlabs plug into it later.
+3. **groq** (mirrors openai — same SDK shape). After step 3, the adapter's switch cases for openai + groq should look near-identical. **This is the decision point** for promoting a shared `HttpProviderError` base set. Don't do it earlier.
+4. **deepgram** (already HTTP-typed — lowest ROI but trivial). Lift its inline `WhisperingErr` construction into a `DeepgramError` set + adapter case.
+5. **elevenlabs** (smallest, same treatment as deepgram).
+
+Each provider is an independent PR. Adapter grows incrementally. No big-bang rewrite.
+
+### Test plan per step
+
+For each migrated provider:
+- Unit test the provider with a mocked SDK/HTTP layer — assert correct tagged error for each status path. Doesn't require `$lib/result` imports. **This is the payoff.**
+- Snapshot test the adapter's output for each variant.
+- Keep the existing integration test (if any) green on the action-layer call site.
+
+## Open questions
+
+1. **Adapter location.** `cloud/error-adapter.ts` (beside providers) or `$lib/query/transcription-errors.ts` (with the call sites)? The adapter is call-site code, not service code — arguably belongs closer to `rpc.notify`. Decide during step 1.
+2. **Pre-validation errors (MissingApiKey, FileTooLarge).** These aren't really runtime errors — they're input validation. Option: hoist to a pre-check layer outside the service. Option: keep them as tagged variants (simpler, matches today's shape). Default: keep as variants.
+3. **Provider identity in the error.** The adapter needs to know "which provider" for copy like "Please enter your *Mistral* API key." Either stamp `provider: 'openai' | ...` on every variant (explicit), or dispatch on the tag's origin (the adapter's `switch` already knows). Explicit is safer but adds fields; implicit is cleaner. Revisit after 2 providers are migrated.
+4. **Self-hosted / local providers.** `speaches`, `whispercpp`, `moonshine`, `parakeet` have their own error shapes. Out of scope for this spec — likely a second taxonomy once cloud is done.
+
+## Non-goals
+
+- Changing the UI copy. The new adapter should emit strings that match today's notifications byte-for-byte at first. Copy iteration is a separate pass.
+- Merging provider SDKs. Each provider keeps its own SDK client.
+- Replacing `WhisperingErr`. It remains the notification envelope; this spec just moves its construction to one place.
+
+## Expected outcome
+
+- Each `cloud/*.ts` drops from 135–252 lines to ~60–100 lines.
+- One `error-adapter.ts` (~150 lines) owns all UI copy for transcription failures.
+- Adding a 6th cloud provider = define its `XxxError` + add 1–N cases to the adapter. No duplicated UI plumbing.
+- Providers become unit-testable without UI dependencies.
+- The fragile string-match in mistral goes away (either into a contained classification `switch` or into `HttpServiceLive`-typed handling).

--- a/specs/20260423T180000-transcription-provider-error-taxonomy.md
+++ b/specs/20260423T180000-transcription-provider-error-taxonomy.md
@@ -6,59 +6,47 @@
 
 ## Overview
 
-Extract provider-specific error handling from each transcription service into its own `defineErrors` taxonomy, and centralize UI translation in a single adapter. Today every cloud provider file (openai, mistral, groq, deepgram, elevenlabs) duplicates ~150 lines of HTTP-status branching and `WhisperingErr` construction. The service layer is tangled with UI copy.
+Extract provider-specific error handling from each cloud transcription service into its own `defineErrors` taxonomy. Each provider returns `Result<string, XxxError>` (typed tagged errors) instead of `Result<string, WhisperingError>`. Call sites translate to `WhisperingError` using the existing `WhisperingErr({ title, serviceError })` convention that the rest of the codebase (`recorder.ts`, `ffmpeg.ts`, etc.) already uses.
+
+No new adapter file. No cross-provider unification. Just remove UI concerns from the service layer.
 
 ## Motivation
 
 ### Current state
 
-Every provider file follows the same pattern:
+Every cloud provider file directly constructs `WhisperingErr(...)` inside its `catch`, tangling service-layer logic with UI copy. The cloud transcription directory is the **only** place in `apps/whispering/src/lib/services/` that imports `$lib/result` — every other service domain (19 `defineErrors` sets, including `FsError`, `HttpError`, `RecorderError`) returns its own tagged error and lets call sites translate.
 
-```ts
-// openai.ts — 252 lines, groq.ts — 236, mistral.ts — 135, deepgram.ts — 210
-async transcribe(audioBlob, options): Promise<Result<string, WhisperingError>> {
-  // 1. Pre-validation (API key, file size) — returns WhisperingErr inline
-  // 2. tryAsync the SDK call
-  //    catch: narrow via instanceof (openai, groq) OR string-match (mistral) OR no-op
-  // 3. if (apiError) { ...huge status-branching block returning WhisperingErr... }
-  // 4. Ok(transcription.text)
-}
-```
+Three concrete problems:
 
-Three structural problems:
+1. **Inconsistent error classification across providers.** Each provider invents its own approach:
+   - `openai.ts` (252 lines) — `instanceof OpenAI.APIError` + switch on `status`. Clean.
+   - `groq.ts` (236 lines) — `instanceof Groq.APIError` + switch on `status`. Mirrors openai.
+   - `deepgram.ts` (210 lines) — `HttpServiceLive` returns typed `Connection | Response | Parse`, nested switch on status. Clean.
+   - `mistral.ts` (135 lines) — `message.includes('401')` **string matching**. Fragile. The Mistral SDK actually exposes `MistralError` with a `statusCode` field — the string matching is obsolete, not a limitation.
+   - `elevenlabs.ts` (67 lines) — one catch, one generic `WhisperingErr` for every failure. Lossy.
 
-1. **Every provider duplicates the status→notification mapping.** `401 → "🔑 Authentication Required"`, `429 → "⏱️ Rate Limit Reached"`, etc. The copy is *almost* identical across files, drifts subtly (compare openai's 413 copy to mistral's), and changing UI copy means editing 5 files.
+2. **UI copy lives in the service layer.** Every `401 → "🔑 Authentication Required"` mapping is inlined next to the SDK call. Changing copy means editing the service. Testing the service means importing UI types.
 
-2. **The service layer can't be tested without UI coupling.** You can't call `MistralTranscriptionServiceLive.transcribe()` in a test without pulling in `$lib/result`, `UnifiedNotificationOptions`, and the whole notification schema. The provider's job is "talk to the API"; UI translation is a separate concern it shouldn't own.
-
-3. **Error narrowing is inconsistent and sometimes unsafe.**
-   - openai/groq: `instanceof Provider.APIError` with `throw` escape hatch — works, but the `throw` inside `catch` is a code smell (fights the Result model).
-   - mistral: `message.includes('401')` — fragile string-matching; breaks if Mistral's SDK changes its error message format. PR #114's `NonNullable<unknown>` constraint also breaks this path (fixed in the companion PR by inlining translation, but the fragility remains).
-   - deepgram/elevenlabs: use `HttpServiceLive` which already has typed errors — the *best* of the bunch, but translation to `WhisperingErr` still happens inline per-provider.
+3. **Copy has already drifted.** `openai.ts` 401 copy says "Your API key appears to be invalid" — `deepgram.ts` says "Your Deepgram API key is invalid or expired." Same intent, different strings. No central pressure to align them, and no reason the service layer should be the place that aligns them.
 
 ### Desired state
 
-Providers return tagged errors. A single adapter translates any provider error into `WhisperingError`.
+Providers return tagged errors. Call sites translate using the existing `serviceError:` shorthand.
 
 ```ts
-// cloud/openai.ts — becomes ~80 lines
-//
-// Factory-shape convention (applied across all provider error sets):
-// - Variants that wrap an underlying error take `{ cause: NonNullable<unknown> }`
-//   (compatible with wellcrafted PR #114's Err<E extends NonNullable<unknown>> constraint).
-// - Variants carrying extra context add named fields after `cause`.
-// - Pre-validation variants (no SDK call made yet) take no args or the minimum
-//   context needed for the UI copy.
+// cloud/openai.ts
 export const OpenaiError = defineErrors({
-  MissingApiKey:       ()                                                   => ({ message: 'OpenAI API key is required' }),
-  InvalidApiKeyFormat: ()                                                   => ({ message: 'OpenAI API keys must start with "sk-"' }),
-  FileTooLarge:        ({ sizeMb, maxMb }: { sizeMb: number; maxMb: number }) => ({ message: `File size ${sizeMb}MB exceeds ${maxMb}MB limit`, sizeMb, maxMb }),
-  Unauthorized:        ({ cause }: { cause: OpenAI.APIError })              => ({ message: cause.message ?? 'OpenAI rejected the API key', cause }),
-  RateLimit:           ({ cause }: { cause: OpenAI.APIError })              => ({ message: cause.message, cause }),
-  BadRequest:          ({ cause }: { cause: OpenAI.APIError })              => ({ message: cause.message, cause }),
-  // ...one variant per HTTP class the OpenAI SDK distinguishes
-  Connection:          ({ cause }: { cause: OpenAI.APIError })              => ({ message: cause.message, cause }),
-  Unexpected:          ({ cause }: { cause: NonNullable<unknown> })         => ({ message: extractErrorMessage(cause), cause }),
+  MissingApiKey:       () => ({ message: 'OpenAI API key is required' }),
+  InvalidApiKeyFormat: () => ({ message: 'OpenAI API keys must start with "sk-"' }),
+  FileTooLarge:        ({ sizeMb, maxMb }: { sizeMb: number; maxMb: number }) => ({
+    message: `File size ${sizeMb}MB exceeds ${maxMb}MB limit`, sizeMb, maxMb,
+  }),
+  Unauthorized:        ({ cause }: { cause: OpenAI.APIError }) => ({ message: cause.message, cause }),
+  RateLimit:           ({ cause }: { cause: OpenAI.APIError }) => ({ message: cause.message, cause }),
+  BadRequest:          ({ cause }: { cause: OpenAI.APIError }) => ({ message: cause.message, cause }),
+  PayloadTooLarge:     ({ cause }: { cause: OpenAI.APIError }) => ({ message: cause.message, cause }),
+  Connection:          ({ cause }: { cause: OpenAI.APIError }) => ({ message: cause.message, cause }),
+  Unexpected:          ({ cause }: { cause: unknown })         => ({ message: extractErrorMessage(cause), cause }),
 });
 export type OpenaiError = InferErrors<typeof OpenaiError>;
 
@@ -68,22 +56,19 @@ export const OpenaiTranscriptionServiceLive = {
     if (!options.apiKey.startsWith('sk-')) return OpenaiError.InvalidApiKeyFormat();
 
     const sizeMb = audioBlob.size / (1024 * 1024);
-    if (sizeMb > MAX_FILE_SIZE_MB) {
-      return OpenaiError.FileTooLarge({ sizeMb, maxMb: MAX_FILE_SIZE_MB });
-    }
+    if (sizeMb > MAX_FILE_SIZE_MB) return OpenaiError.FileTooLarge({ sizeMb, maxMb: MAX_FILE_SIZE_MB });
 
     return tryAsync({
-      try: () => new OpenAI({...}).audio.transcriptions.create({...}).then(r => r.text.trim()),
+      try: () => new OpenAI({ apiKey: options.apiKey, baseURL: options.baseURL })
+        .audio.transcriptions.create({ /* ... */ })
+        .then((r) => r.text.trim()),
       catch: (error) => {
-        // `error: unknown` from the `catch` — narrow to NonNullable before dispatching.
-        // `throw null` is legal JS; reject it explicitly rather than casting around it.
-        if (error == null) return OpenaiError.Unexpected({ cause: new Error('Non-value thrown from OpenAI SDK') });
         if (!(error instanceof OpenAI.APIError)) return OpenaiError.Unexpected({ cause: error });
         switch (error.status) {
           case 401: return OpenaiError.Unauthorized({ cause: error });
           case 429: return OpenaiError.RateLimit({ cause: error });
           case 400: return OpenaiError.BadRequest({ cause: error });
-          // ...
+          case 413: return OpenaiError.PayloadTooLarge({ cause: error });
           default:  return OpenaiError.Unexpected({ cause: error });
         }
       },
@@ -92,139 +77,163 @@ export const OpenaiTranscriptionServiceLive = {
 };
 ```
 
+Call site in `$lib/query/transcription.ts`:
+
 ```ts
-// cloud/error-adapter.ts — single source of truth for UI copy
-export function transcriptionErrorToWhisperingErr(
-  err: OpenaiError | GroqError | MistralError | DeepgramError | ElevenlabsError,
-) {
-  switch (err.name) {
-    case 'MissingApiKey':
-      return WhisperingErr({
-        title: '🔑 API Key Required',
-        description: `Please enter your ${providerFor(err)} API key in settings.`,
-        action: { type: 'link', label: 'Add API key', href: '/settings/transcription' },
-      });
-    case 'Unauthorized':
-      return WhisperingErr({
-        title: '🔑 Authentication Required',
-        description: 'Your API key appears to be invalid or expired.',
-        action: { type: 'link', label: 'Update API key', href: '/settings/transcription' },
-      });
-    case 'RateLimit':
-      return WhisperingErr({
-        title: '⏱️ Rate Limit Reached',
-        description: err.message ?? 'Too many requests. Please try again later.',
-        action: { type: 'more-details', error: err.cause },
-      });
-    // ...one case per tagged variant; shared variants (Unauthorized, RateLimit) get one case each
+case 'OpenAI': {
+  const { data, error } = await services.transcriptions.openai.transcribe(blob, opts);
+  if (error) {
+    return WhisperingErr({
+      title: '❌ OpenAI transcription failed',
+      serviceError: error,  // auto-fills description from error.message, adds "More details" action
+    });
+  }
+  return Ok(data);
+}
+```
+
+That's the whole pattern. `WhisperingErr({ title, serviceError })` is defined at `$lib/result.ts:74` and already used by `recorder.ts`, `ffmpeg.ts`, and every other domain in the query layer.
+
+## Why no central adapter?
+
+A previous draft proposed a single `error-adapter.ts` with a big `switch (err.name)` mapping every provider's variants to `WhisperingErr`. Rejected because:
+
+1. **Variant collisions force per-provider branches anyway.** OpenAI's 401 and Deepgram's 401 have different copy today — the adapter would need `if (err.cause instanceof OpenAI.APIError)` inside `case 'Unauthorized'`, recreating the per-provider branching in a single file.
+2. **Doesn't match codebase convention.** Every other domain uses `WhisperingErr({ title, serviceError })` at the call site. Introducing a parallel pattern for transcription alone would be inconsistent.
+3. **The adapter becomes a merge-conflict bottleneck.** Every provider PR touches one file.
+
+If later we find the same copy duplicated across 3+ call sites in `transcription.ts`, we can extract helpers (`authRequiredNotification({ provider })`). Helpers can emerge from duplication; reversing an early unification is harder.
+
+## The two-layer split
+
+```
+┌─────────────────────────────────┐
+│   UI layer (query/transcription)│   WhisperingErr({ title, serviceError: err })
+├─────────────────────────────────┤
+│   Provider layer                │   returns Result<string, XxxError>
+│   (cloud/openai.ts, etc.)       │   no WhisperingErr, no UnifiedNotificationOptions
+└─────────────────────────────────┘
+```
+
+Provider files must not import `$lib/result`. That's the one structural rule.
+
+## Per-provider error sets
+
+Each provider's variants reflect what its mechanism actually distinguishes. No lowest-common-denominator set.
+
+### openai, groq — SDK error classes
+
+Both SDKs expose `Provider.APIError` with `.status`. Pattern:
+
+```ts
+catch: (error) => {
+  if (!(error instanceof OpenAI.APIError)) return OpenaiError.Unexpected({ cause: error });
+  switch (error.status) { /* ... */ }
+}
+```
+
+Variants: `Unauthorized | RateLimit | BadRequest | NotFound | PermissionDenied | UnprocessableEntity | PayloadTooLarge | UnsupportedMediaType | ServiceUnavailable | Connection | Unexpected` + pre-validation (`MissingApiKey`, `InvalidApiKeyFormat`, `FileTooLarge`).
+
+### mistral — SDK error class (previously string-matched)
+
+The Mistral SDK ships `MistralError` at `@mistralai/mistralai/models/errors/mistralerror`:
+
+```ts
+export declare class MistralError extends Error {
+  readonly statusCode: number;
+  readonly body: string;
+  readonly headers: Headers;
+  readonly contentType: string;
+  readonly rawResponse: Response;
+}
+```
+
+Use `instanceof MistralError` + switch on `statusCode`. Same shape as openai/groq. The existing `message.includes('401')` at `mistral.ts:79` becomes a tiny typed switch. This is a straight improvement — no HttpServiceLive migration needed.
+
+One naming note: the SDK's class is called `MistralError`, which would collide with our own tagged error set. Import with an alias (`import { MistralError as MistralSdkError } from '@mistralai/mistralai/models/errors/mistralerror'`) or name our tagged set `MistralTranscriptionError` to disambiguate.
+
+### deepgram — HttpServiceLive
+
+`HttpServiceLive.post()` already returns typed `HttpError = Connection | Response | Parse`. Map those to `DeepgramError` variants:
+
+```ts
+const { data, error: httpError } = await HttpServiceLive.post({ /* ... */ });
+if (httpError) {
+  switch (httpError.name) {
+    case 'Connection': return DeepgramError.Connection({ cause: httpError });
+    case 'Parse':      return DeepgramError.Parse({ cause: httpError });
+    case 'Response': {
+      switch (httpError.status) {
+        case 401: return DeepgramError.Unauthorized({ cause: httpError });
+        case 429: return DeepgramError.RateLimit({ cause: httpError });
+        default:  return DeepgramError.Unexpected({ cause: httpError });
+      }
+    }
   }
 }
 ```
 
-Call sites in `$lib/query/actions.ts` (or wherever transcription is kicked off) apply the adapter at the UI boundary:
+### elevenlabs — minimal upgrade
 
-```ts
-const { data, error } = await services.transcription.openai.transcribe(blob, opts);
-if (error) return rpc.notify.error(transcriptionErrorToWhisperingErr(error));
-```
+Currently a single `catch` that produces one generic `WhisperingErr`. Don't invent granularity that doesn't exist — start with `MissingApiKey | FileTooLarge | Unexpected`. The ElevenLabs SDK does ship status-specific error classes (`UnprocessableEntityError`, `ForbiddenError`, `BadRequestError`, `NotFoundError`, `TooEarlyError`), so if distinctions become worth making later, add variants incrementally.
 
-## Design
+## SDK dependencies stay
 
-### The two-layer split
+Each provider keeps its SDK. The SDKs provide multipart upload, auth, typed request shapes, and (crucially) typed errors. Rebuilding that in `HttpServiceLive` is strictly worse for openai/groq/mistral/elevenlabs. Deepgram stays on `HttpServiceLive` because it already works — no SDK was needed for that simple REST API.
 
-```
-┌─────────────────────────────────┐
-│   UI layer (query/actions)      │   transcriptionErrorToWhisperingErr(err)
-├─────────────────────────────────┤
-│   Adapter layer                 │   one file, one switch, all UI copy lives here
-├─────────────────────────────────┤
-│   Provider layer                │   returns Result<string, ProviderError>
-│   (cloud/openai.ts, etc.)        │   no WhisperingErr, no UnifiedNotificationOptions
-└─────────────────────────────────┘
-```
+SDK replacement (e.g., for bundle-size reasons) is a separate decision. Not part of this spec.
 
-**Decoupling constraint (load-bearing — enforce via ESLint if possible):**
-
-The provider file AND its colocated error set must not import anything from:
-- `$lib/result` (WhisperingErr, WhisperingError, WhisperingWarningErr)
-- `$lib/services/notifications/*` (UnifiedNotificationOptions, notification types)
-- `$lib/components/*` (UI primitives)
-
-Only the adapter layer may import from those. This is what makes providers unit-testable without UI coupling — the claim collapses if a provider's error types transitively pull in notification schemas through `WhisperingError`.
-
-Provider files may still import from:
-- `wellcrafted/*` (result, error primitives)
-- SDKs (`openai`, `@mistralai/mistralai`, `groq-sdk`, etc.)
-- `$lib/services/http` (already provider-agnostic)
-- `$lib/services/transcription/utils` (getAudioExtension, etc.)
-
-### Per-provider error sets
-
-Each provider defines error variants that reflect what *that provider* actually distinguishes, not a lowest-common-denominator set:
-
-- **openai, groq:** SDK exposes `Provider.APIError` with `status`. Variants: `Unauthorized | RateLimit | BadRequest | NotFound | PermissionDenied | UnprocessableEntity | PayloadTooLarge | UnsupportedMediaType | ServiceUnavailable | Connection | Unexpected`.
-- **mistral:** SDK throws raw errors today. Either use the string-matching fallback inside the `catch` to classify into tagged variants (ugly but contained), OR use `HttpServiceLive` + typed status codes like deepgram does. The latter is better — separate refactor.
-- **deepgram, elevenlabs:** already use `HttpServiceLive`. Lift their inline error handling into their own `defineErrors` sets.
-
-### Where shared variants go
-
-Don't create a root `TranscriptionError` union prematurely. Start with per-provider sets. After all 5 are migrated, look at the adapter's `switch` — if 80% of cases across providers collapse to identical WhisperingErr output (they will, for auth/rate-limit/connection), *then* promote a shared `HttpProviderError` base set that providers extend.
-
-Do this second, not first. Premature unification locks in assumptions before we see the real shape.
-
-### File organization
+## File organization
 
 ```
 apps/whispering/src/lib/services/transcription/cloud/
-├── error-adapter.ts          # NEW — transcriptionErrorToWhisperingErr
-├── openai.ts                 # OpenaiError + OpenaiTranscriptionServiceLive
-├── groq.ts                   # GroqError + Groq...
-├── mistral.ts                # MistralError + Mistral...
-├── deepgram.ts               # DeepgramError + Deepgram...
-└── elevenlabs.ts             # ElevenlabsError + Elevenlabs...
+├── openai.ts        # OpenaiError + OpenaiTranscriptionServiceLive
+├── groq.ts          # GroqError + Groq...
+├── mistral.ts       # MistralTranscriptionError (SDK collision) + Mistral...
+├── deepgram.ts      # DeepgramError + Deepgram...
+└── elevenlabs.ts    # ElevenlabsError + Elevenlabs...
 ```
 
-Colocate each `XxxError` in its provider file (like `FsError` lives in `fs.ts`) — it's part of the provider's public API.
+Colocate each `XxxError` in its provider file — same convention as `FsError` in `fs.ts`, `HttpError` in `http/types.ts`, etc. It's part of the provider's public API.
 
 ## Migration plan
 
-Provider-by-provider, ordered by **ROI** (biggest pain first), not by cleanliness:
+Provider-by-provider, cleanest first. Each is an independent PR. The only cross-PR file is `query/transcription.ts`, which has one case per provider — each migration updates its own case.
 
-1. **mistral** (highest ROI — small file, *current* pain). Fragile `message.includes('401')` string-matching breaks silently if the SDK rewords its error messages, and it was the blast-radius site for wellcrafted PR #114's `NonNullable<unknown>` constraint. Smallest file (135 lines), biggest payoff. Two sub-options:
-   - **(a)** Lift Mistral's transcription call onto `HttpServiceLive` like deepgram does — gives typed status codes, kills the string-match. Cleanest end state.
-   - **(b)** Keep the SDK call; move string-match classification *inside* the `catch` to produce `MistralError` tagged variants. The smell is contained to one function instead of leaking into the caller.
-   Default to (a) unless the Mistral SDK adds something `HttpServiceLive` can't (streaming, multipart oddities).
-2. **openai** (medium — SDK exposes `OpenAI.APIError` with `.status`). Biggest file (252 lines) but the structure is clean once `OpenaiError` is defined. Ships the `error-adapter.ts` shared surface; deepgram/elevenlabs plug into it later.
-3. **groq** (mirrors openai — same SDK shape). After step 3, the adapter's switch cases for openai + groq should look near-identical. **This is the decision point** for promoting a shared `HttpProviderError` base set. Don't do it earlier.
-4. **deepgram** (already HTTP-typed — lowest ROI but trivial). Lift its inline `WhisperingErr` construction into a `DeepgramError` set + adapter case.
-5. **elevenlabs** (smallest, same treatment as deepgram).
-
-Each provider is an independent PR. Adapter grows incrementally. No big-bang rewrite.
+1. **elevenlabs** (67 lines — warm-up). Minimal error set. Proves the pattern end-to-end including the call-site change.
+2. **deepgram** (210 lines — HTTP-typed already). Mechanical lift of existing switch.
+3. **openai** (252 lines — reference SDK pattern). Largest but straightforward.
+4. **groq** (236 lines — mirrors openai). Copy-paste with type swap.
+5. **mistral** (135 lines — SDK typed errors, replaces string matching). Fixes the fragility bug as a side effect.
 
 ### Test plan per step
 
-For each migrated provider:
-- Unit test the provider with a mocked SDK/HTTP layer — assert correct tagged error for each status path. Doesn't require `$lib/result` imports. **This is the payoff.**
-- Snapshot test the adapter's output for each variant.
-- Keep the existing integration test (if any) green on the action-layer call site.
+Whispering has no existing unit tests for these services, so "unit-testable providers" is a structural improvement, not an immediate backlog. For each migrated provider:
+
+- Manual smoke test: trigger each error path (invalid key, oversized file, rate limit if easy, network disconnection) and confirm the `WhisperingErr` shown matches today's copy as closely as possible.
+- Type-check: `bun run check` in `apps/whispering`.
+- Runtime check: `bun run dev` and exercise the provider.
+
+Writing unit tests becomes possible after this refactor but is scheduled separately.
 
 ## Open questions
 
-1. **Adapter location.** `cloud/error-adapter.ts` (beside providers) or `$lib/query/transcription-errors.ts` (with the call sites)? The adapter is call-site code, not service code — arguably belongs closer to `rpc.notify`. Decide during step 1.
-2. **Pre-validation errors (MissingApiKey, FileTooLarge).** These aren't really runtime errors — they're input validation. Option: hoist to a pre-check layer outside the service. Option: keep them as tagged variants (simpler, matches today's shape). Default: keep as variants.
-3. **Provider identity in the error.** The adapter needs to know "which provider" for copy like "Please enter your *Mistral* API key." Either stamp `provider: 'openai' | ...` on every variant (explicit), or dispatch on the tag's origin (the adapter's `switch` already knows). Explicit is safer but adds fields; implicit is cleaner. Revisit after 2 providers are migrated.
-4. **Self-hosted / local providers.** `speaches`, `whispercpp`, `moonshine`, `parakeet` have their own error shapes. Out of scope for this spec — likely a second taxonomy once cloud is done.
+1. **Pre-validation errors (`MissingApiKey`, `FileTooLarge`).** Input validation, not runtime errors. Could hoist to a pre-check layer. For now, keep as tagged variants — matches today's shape and defers the bigger refactor. Flag as possible follow-up.
+2. **`InvalidApiKeyFormat`.** Only openai validates the `sk-` prefix today. Keep provider-specific; don't force other providers to add one.
+3. **`Connection` variant shape.** OpenAI and Groq surface connection errors through `APIConnectionError` subclass; variant `cause` type may need adjustment per provider.
 
 ## Non-goals
 
-- Changing the UI copy. The new adapter should emit strings that match today's notifications byte-for-byte at first. Copy iteration is a separate pass.
-- Merging provider SDKs. Each provider keeps its own SDK client.
-- Replacing `WhisperingErr`. It remains the notification envelope; this spec just moves its construction to one place.
+- Creating a central adapter or cross-provider error union.
+- Changing UI copy. Post-migration, notifications should read as close to today as possible. Copy iteration is a separate pass.
+- Replacing provider SDKs.
+- Adding unit tests (enabled by this refactor, scheduled separately).
 
 ## Expected outcome
 
-- Each `cloud/*.ts` drops from 135–252 lines to ~60–100 lines.
-- One `error-adapter.ts` (~150 lines) owns all UI copy for transcription failures.
-- Adding a 6th cloud provider = define its `XxxError` + add 1–N cases to the adapter. No duplicated UI plumbing.
-- Providers become unit-testable without UI dependencies.
-- The fragile string-match in mistral goes away (either into a contained classification `switch` or into `HttpServiceLive`-typed handling).
+- **Copy moves out of the service layer.** All UI strings live at `transcription.ts` call sites.
+- **Mistral string-matching goes away.** Replaced by `instanceof MistralError` + typed switch.
+- **ElevenLabs gets real error granularity** (at least pre-validation variants separated from the catch-all).
+- **Provider files decouple from `$lib/result`.** Testable without pulling in notification schemas.
+- **Line-count change is modest** — roughly 900 → ~750 lines across the 5 providers, with ~50 net lines added at call sites. The point isn't LOC reduction; it's separating concerns.
+- **Pattern consistency.** Transcription providers stop being the outlier domain that owns UI copy.


### PR DESCRIPTION
Every cloud transcription provider was doing the same dance: catch a raw SDK error, switch on status codes, then build a `WhisperingErr` with emoji-laden copy inline. The service layer was deep in UI concerns, and every time we added a provider we copy-pasted the translation table with drift. Worse, Mistral was matching on error message substrings (`.includes('Unauthorized')`) because we hadn't realized the SDK already throws a typed `MistralError` with `.statusCode`.

This splits the two concerns. Provider services now return wellcrafted `defineErrors` tagged unions—one variant per failure mode the SDK actually distinguishes. The UI translation lives in `query/transcription.ts`, where each provider case switches on `error.name` and hands the typed error to `WhisperingErr({ serviceError })` for the existing `message` → `description` passthrough. TypeScript enforces exhaustiveness: adding a variant without a UI case is a compile error.

**Provider layer: typed unions per SDK.** Each provider declares its own error set matching what its SDK actually throws. OpenAI and Groq expose `APIError` as a class, so we reach for `InstanceType<typeof OpenAI.APIError>` to use it as a type and switch on `.status`. Mistral exposes `MistralError` from `@mistralai/mistralai/models/errors`—aliased to `MistralSdkError` to avoid colliding with our own tagged set name—and switches on `.statusCode`. Deepgram still flows through `HttpServiceLive` and translates `HttpError` variants directly.

```typescript
// BEFORE: service returns WhisperingErr, every branch builds UI copy inline
catch: (error) => {
  if (error instanceof OpenAI.APIError) {
    switch (error.status) {
      case 401:
        return WhisperingErr({
          title: '🔑 Authentication Required',
          description: 'Your API key appears to be invalid...',
          action: { type: 'link', label: 'Update API key', href: '...' },
        });
      // ...
    }
  }
  return Err(error);
}

// AFTER: service returns a typed variant, UI translates at the call site
catch: (error) => {
  if (!(error instanceof OpenAI.APIError)) {
    return OpenaiError.Unexpected({ cause: error });
  }
  switch (error.status) {
    case 401: return OpenaiError.Unauthorized({ cause: error });
    case 429: return OpenaiError.RateLimit({ cause: error });
    // ...
  }
}
```

**Mistral gets the biggest win.** The old catch block matched substrings of the error message because we thought the SDK didn't give us anything better:

```typescript
// BEFORE
catch: (error) => {
  const message = extractErrorMessage(error);
  if (message.includes('Unauthorized') || message.includes('401')) {
    return WhisperingErr({ title: '🔑 Authentication Required', ... });
  }
  if (message.includes('429') || message.toLowerCase().includes('rate limit')) {
    return WhisperingErr({ title: '⏱️ Rate Limit Reached', ... });
  }
  // ...
}

// AFTER
catch: (error) => {
  if (!(error instanceof MistralSdkError)) {
    return MistralTranscriptionError.Unexpected({ cause: error });
  }
  switch (error.statusCode) {
    case 401: return MistralTranscriptionError.Unauthorized({ cause: error });
    case 429: return MistralTranscriptionError.RateLimit({ cause: error });
    // ...
  }
}
```

**UI layer: exhaustive switch on `error.name`.** The call site in `query/transcription.ts` owns all user-facing copy. `WhisperingErr({ serviceError })` is an existing shorthand in `$lib/result.ts` that lifts `.message` into the toast description and attaches a "more details" action—so the typed error flows through without boilerplate.

```typescript
case 'OpenAI': {
  const { data, error } = await services.transcriptions.openai.transcribe(...);
  if (error) {
    switch (error.name) {
      case 'MissingApiKey':
        return WhisperingErr({ title: '🔑 API Key Required', ... });
      case 'FileTooLarge':
        return WhisperingErr({
          title: `The file size (${error.sizeMb.toFixed(1)}MB) is too large`,
          description: `Please upload a file smaller than ${error.maxMb}MB.`,
        });
      case 'Unauthorized':
        return WhisperingErr({
          title: '🔑 Authentication Required',
          description: error.message || 'Your API key appears to be invalid...',
          serviceError: error,
          action: { type: 'link', label: 'Update API key', href: '...' },
        });
      // exhaustive over every variant OpenaiError declares
    }
  }
  return Ok(data);
}
```

No unified adapter, no cross-provider error abstraction. Each provider stays readable on its own, and the translation table is a flat switch a reviewer can scan top-to-bottom. The spec considered a single `providerErrorToWhisperingErr` helper but rejected it—providers have genuinely different variant shapes (ElevenLabs has 3, OpenAI has 15) and squishing them into one generic function would trade clarity for a false sense of DRY.

Scope is cloud providers only: `openai`, `groq`, `mistral`, `deepgram`, `elevenlabs`. Local providers (`speaches`, `whispercpp`, `parakeet`, `moonshine`) are untouched. Net: +1148 / −788 lines across 5 services and one call site—the line count grew because we moved from compressed implicit switches to explicit typed variants, which was the point.