### PR TITLE
feat(ui): adopt shadcn-svelte luma preset with taupe base

### DIFF
--- a/apps/fuji/src/lib/components/EntryEditor.svelte
+++ b/apps/fuji/src/lib/components/EntryEditor.svelte
@@ -7,14 +7,14 @@
 		toDateTimeString,
 	} from '@epicenter/ui/natural-language-date-input';
 	import * as Popover from '@epicenter/ui/popover';
+	import { Spinner } from '@epicenter/ui/spinner';
 	import * as StarRating from '@epicenter/ui/star-rating';
 	import { TimezoneCombobox } from '@epicenter/ui/timezone-combobox';
-	import { Spinner } from '@epicenter/ui/spinner';
+	import type { RichTextHandle } from '@epicenter/workspace';
 	import { DateTimeString } from '@epicenter/workspace';
 	import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
 	import Trash2Icon from '@lucide/svelte/icons/trash-2';
 	import { format } from 'date-fns';
-	import type { RichTextHandle } from '@epicenter/workspace';
 	import { goto } from '$app/navigation';
 	import { workspace } from '$lib/client';
 	import type { Entry } from '$lib/workspace';
@@ -76,7 +76,7 @@
 			<span class="text-sm text-muted-foreground">Back to entries</span>
 		</div>
 		<Button
-			variant="ghost-destructive"
+			variant="destructive"
 			size="icon-sm"
 			onclick={() => {
 				confirmationDialog.open({

--- a/apps/fuji/src/routes/trash/+page.svelte
+++ b/apps/fuji/src/routes/trash/+page.svelte
@@ -82,7 +82,7 @@
 										<RotateCcwIcon class="size-4" />
 									</Button>
 									<Button
-										variant="ghost-destructive"
+										variant="destructive"
 										size="icon-sm"
 										title="Delete permanently"
 										onclick={() => {

--- a/apps/tab-manager/src/lib/components/chat/ChatErrorBanner.svelte
+++ b/apps/tab-manager/src/lib/components/chat/ChatErrorBanner.svelte
@@ -25,11 +25,11 @@
 	>
 		<span class="min-w-0 flex-1">{displayMessage}</span>
 		<div class="flex shrink-0 items-center gap-1">
-			<Button variant="ghost-destructive" onclick={onRetry}>
+			<Button variant="destructive" onclick={onRetry}>
 				<RotateCcwIcon class="size-3" />
 				Retry
 			</Button>
-			<Button variant="ghost-destructive" size="icon-xs" onclick={onDismiss}>
+			<Button variant="destructive" size="icon-xs" onclick={onDismiss}>
 				<XIcon class="size-3" />
 			</Button>
 		</div>

--- a/apps/tab-manager/src/lib/components/chat/ConversationPicker.svelte
+++ b/apps/tab-manager/src/lib/components/chat/ConversationPicker.svelte
@@ -121,7 +121,7 @@
 											>{formatRelativeTime(conv.updatedAt)}</span
 										>
 										<Button
-											variant="ghost-destructive"
+											variant="destructive"
 											size="icon-xs"
 											class="opacity-0 group-hover:opacity-100"
 											onclick={(e: MouseEvent) => {

--- a/apps/whispering/src/lib/components/transformations-editor/RunStatusBadge.svelte
+++ b/apps/whispering/src/lib/components/transformations-editor/RunStatusBadge.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { Badge } from '@epicenter/ui/badge';
+	import { Spinner } from '@epicenter/ui/spinner';
+	import CircleCheckIcon from '@lucide/svelte/icons/circle-check';
+	import CircleXIcon from '@lucide/svelte/icons/circle-x';
+
+	type Status = 'completed' | 'failed' | 'running';
+	let { status }: { status: Status } = $props();
+</script>
+
+<Badge
+	variant="outline"
+	class={status === 'completed'
+		? 'text-green-600 dark:text-green-400'
+		: status === 'failed'
+			? 'text-red-600 dark:text-red-400'
+			: 'text-blue-600 dark:text-blue-400'}
+>
+	{#if status === 'completed'}
+		<CircleCheckIcon class="size-3" />
+	{:else if status === 'failed'}
+		<CircleXIcon class="size-3" />
+	{:else}
+		<Spinner class="size-3" />
+	{/if}
+	{status}
+</Badge>

--- a/apps/whispering/src/lib/components/transformations-editor/Runs.svelte
+++ b/apps/whispering/src/lib/components/transformations-editor/Runs.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { Badge } from '@epicenter/ui/badge';
 	import { Button } from '@epicenter/ui/button';
 	import * as Card from '@epicenter/ui/card';
 	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
@@ -17,6 +16,7 @@
 	import type { TransformationRun } from '$lib/state/transformation-runs.svelte';
 	import { transformationRuns } from '$lib/state/transformation-runs.svelte';
 	import { viewTransition } from '$lib/utils/viewTransitions';
+	import RunStatusBadge from './RunStatusBadge.svelte';
 
 	let { runs }: { runs: TransformationRun[] } = $props();
 
@@ -96,9 +96,7 @@
 									{/if}
 								</Button>
 							</Table.Cell>
-							<Table.Cell>
-								<Badge variant={`status.${run.status}`}> {run.status} </Badge>
-							</Table.Cell>
+							<Table.Cell> <RunStatusBadge status={run.status} /> </Table.Cell>
 							<Table.Cell> {formatDate(run.startedAt)} </Table.Cell>
 							<Table.Cell>
 								{run.completedAt ? formatDate(run.completedAt) : '-'}
@@ -160,9 +158,7 @@
 														{#each run.stepRuns as stepRun}
 															<Table.Row>
 																<Table.Cell>
-																	<Badge variant={`status.${stepRun.status}`}>
-																		{stepRun.status}
-																	</Badge>
+																	<RunStatusBadge status={stepRun.status} />
 																</Table.Cell>
 																<Table.Cell>
 																	{formatDate(stepRun.startedAt)}

--- a/bun.lock
+++ b/bun.lock
@@ -591,13 +591,15 @@
       "name": "@epicenter/ui",
       "version": "0.1.0",
       "dependencies": {
-        "@fontsource-variable/manrope": "^5.2.6",
+        "@fontsource-variable/inter": "^5.2.6",
+        "@fontsource-variable/lora": "^5.2.6",
         "@lucide/svelte": "^1.7.0",
         "@tanstack/svelte-table": "catalog:",
         "bits-ui": "^2.16.5",
         "chrono-node": "2.9.0",
         "clsx": "^2.1.1",
         "paneforge": "^1.0.2",
+        "shadcn-svelte": "^1.2.7",
         "tailwind-merge": "^3.5.0",
         "tailwind-variants": "^3.2.2",
       },
@@ -1018,7 +1020,9 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
-    "@fontsource-variable/manrope": ["@fontsource-variable/manrope@5.2.8", "", {}, "sha512-nc9lOuCRz73UHnovDE2bwXUdghE2SEOc7Aii0qGe3CLyE03W1a7VnY5Z6euRiapiKbCkGS+eXbY3s/kvWeGeSw=="],
+    "@fontsource-variable/inter": ["@fontsource-variable/inter@5.2.8", "", {}, "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ=="],
+
+    "@fontsource-variable/lora": ["@fontsource-variable/lora@5.2.8", "", {}, "sha512-cxjTJ9BbOWIzusewR4UMBLVePvTSWV6dtNaNsCkF/oKoyA68fJGWfaYCILOOP1BObE4dmjfZ3xo6m9hdHhtYhg=="],
 
     "@google/genai": ["@google/genai@1.48.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-plonYK4ML2PrxsRD9SeqmFt76eREWkQdPCglOA6aYDzL1AAbE+7PUnT54SvpWGfws13L0AZEqGSpL7+1IPnTxQ=="],
 
@@ -3240,6 +3244,8 @@
 
     "sha.js": ["sha.js@2.4.12", "", { "dependencies": { "inherits": "^2.0.4", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.0" }, "bin": { "sha.js": "bin.js" } }, "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w=="],
 
+    "shadcn-svelte": ["shadcn-svelte@1.2.7", "", { "dependencies": { "commander": "^14.0.0", "node-fetch-native": "^1.6.4", "postcss": "^8.5.5", "tailwind-merge": "^3.0.0" }, "peerDependencies": { "svelte": "^5.0.0" }, "bin": { "shadcn-svelte": "dist/index.mjs" } }, "sha512-mWuQk4H4gtV+J2wJQ7nEPKNnB/v86AALFryZU0SSM7ChHmJJMZ1kH+qIuxYKrXm9vOOOcSWHRsWzPDB71DnjYA=="],
+
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
@@ -3720,6 +3726,10 @@
 
     "@epicenter/filesystem/drizzle-orm": ["drizzle-orm@0.38.4", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/react": ">=18", "@types/sql.js": "*", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "react": ">=18", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/react", "@types/sql.js", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "knex", "kysely", "mysql2", "pg", "postgres", "react", "sql.js", "sqlite3"] }, "sha512-s7/5BpLKO+WJRHspvpqTydxFob8i1vo2rEx4pY6TGY7QSMuUfWUuzaY0DIpXCkgHOo37BaFC+SJQb99dDUXT3Q=="],
 
+    "@epicenter/fuji/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "@epicenter/honeycrisp/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
     "@epicenter/skills/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@epicenter/sync/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
@@ -3727,6 +3737,8 @@
     "@epicenter/ui/@lucide/svelte": ["@lucide/svelte@1.8.0", "", { "peerDependencies": { "svelte": "^5" } }, "sha512-+zYQUKqEOVP5lxbGmxL1OVgGMQtRK91eIJ0bR+3Cr1ts4oQEsQfxyzzd5X47psJlblAuGFrl2xm4YuATjR9oaA=="],
 
     "@epicenter/ui/layerchart": ["layerchart@2.0.0-next.48", "", { "dependencies": { "@dagrejs/dagre": "^2.0.4", "@layerstack/svelte-actions": "1.0.1-next.18", "@layerstack/svelte-state": "0.1.0-next.23", "@layerstack/tailwind": "2.0.0-next.21", "@layerstack/utils": "2.0.0-next.18", "@types/d3-contour": "^3.0.6", "d3-array": "^3.2.4", "d3-chord": "^3.0.1", "d3-color": "^3.1.0", "d3-contour": "^4.0.2", "d3-delaunay": "^6.0.4", "d3-dsv": "^3.0.1", "d3-force": "^3.0.0", "d3-geo": "^3.1.1", "d3-geo-voronoi": "^2.1.0", "d3-hierarchy": "^3.1.2", "d3-interpolate": "^3.0.1", "d3-interpolate-path": "^2.3.0", "d3-path": "^3.1.0", "d3-quadtree": "^3.0.1", "d3-random": "^3.0.1", "d3-sankey": "^0.12.3", "d3-scale": "^4.0.2", "d3-scale-chromatic": "^3.1.0", "d3-shape": "^3.2.0", "d3-tile": "^1.0.0", "d3-time": "^3.1.0", "memoize": "^10.2.0", "runed": "^0.37.1" }, "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-XoEYBztamA8lMxtF/Jz3aDX0HMk8dI+o4fK9fSl8ecT2Tdx3DQUjtKGtlQAOFdwC/AWifeLmKq5cMTQt9COZPQ=="],
+
+    "@epicenter/whispering/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "@epicenter/workspace/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
@@ -3964,6 +3976,8 @@
 
     "onnx-proto/protobufjs": ["protobufjs@6.11.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/long": "^4.0.1", "@types/node": ">=13.7.0", "long": "^4.0.0" }, "bin": { "pbjs": "bin/pbjs", "pbts": "bin/pbts" } }, "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw=="],
 
+    "opensidian/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
     "p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "paneforge/runed": ["runed@0.23.4", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA=="],
@@ -4009,6 +4023,8 @@
     "run-jxa/type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
 
     "sha.js/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "skills/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -116,6 +116,78 @@ When extending shadcn-svelte components with custom styles, we use a specific pa
 
 This pattern makes component updates much clearer: shadcn's style updates show in the first `cn()` argument, while our customizations remain visually separate in subsequent arguments.
 
+## Theming
+
+Theming lives in [`src/app.css`](./src/app.css). Every component reads CSS variables (`var(--primary)`, `var(--radius)`, etc.) — never hard-coded colors. To change the look, change the variables. No CLI, no recompute, no component edits.
+
+### Adjust a color or radius
+
+Edit the variable in `:root` (light mode) and/or `.dark` (dark mode). Hot reload picks it up.
+
+```css
+:root {
+    --radius: 0.625rem;     /* one value drives all radius sizes */
+    --primary: oklch(0.214 0.009 43.1);
+    --background: oklch(1 0 0);
+}
+```
+
+The radius scale is derived once in `@theme inline`:
+
+```css
+--radius-sm: calc(var(--radius) - 4px);
+--radius-md: calc(var(--radius) - 2px);
+--radius-lg: var(--radius);
+--radius-xl: calc(var(--radius) + 4px);
+--radius-2xl: calc(var(--radius) * 1.8);
+--radius-3xl: calc(var(--radius) * 2.2);
+--radius-4xl: calc(var(--radius) * 2.6);
+```
+
+So a single `--radius` change cascades into button (`rounded-4xl`), badge (`rounded-3xl`), dialog (`rounded-4xl`), and everything else proportionally.
+
+### Swap fonts
+
+Fonts are not managed by the shadcn-svelte CLI. We import them via `@fontsource-variable/*` packages and reference them in `@theme inline`:
+
+```css
+@import "@fontsource-variable/inter";
+@import "@fontsource-variable/lora";
+
+@theme inline {
+    --font-sans: "Inter Variable", sans-serif;
+    --font-heading: "Lora Variable", serif;
+}
+```
+
+Headings are wired via the registry's per-component `class="font-heading"` (CardTitle, AlertDialogTitle, etc.) — that's the idiomatic Luma pattern, no global `h1–h6` rule needed.
+
+### Wholesale restyle (rare)
+
+When a single-variable edit isn't enough — switching base color family (taupe → mauve), changing styles (Luma → New York), or adopting a brand-new preset — re-run the CLI. This rewrites `app.css`'s palette and (depending on flags) registry components, so it's destructive on purpose.
+
+```bash
+# Single base-color swap
+bun x shadcn-svelte@latest init --overwrite --no-deps \
+  --base-color mauve --css src/app.css \
+  --components-alias '#' --lib-alias '#/lib' \
+  --utils-alias '#/utils' --hooks-alias '#/hooks' --ui-alias '#'
+
+# Whole new preset (build one at https://shadcn-svelte.com/create)
+bun x shadcn-svelte@latest init --overwrite --no-deps \
+  --preset PRESET_ID --css src/app.css \
+  --components-alias '#' --lib-alias '#/lib' \
+  --utils-alias '#/utils' --hooks-alias '#/hooks' --ui-alias '#'
+```
+
+Available base colors: `neutral`, `stone`, `zinc`, `mauve`, `olive`, `mist`, `taupe`.
+
+**Always commit before running this.** The CLI will wipe Epicenter customizations: custom `--warning`/`--success` tokens, the dark-mode `--sidebar-primary` retint, font imports, the `prose.css` import, etc. After the rewrite, `git diff` shows what got clobbered. Restore by grepping for `// Custom:` and `// Custom override:` comments in the diff — those mark every intentional Epicenter deviation.
+
+### What not to edit
+
+Component class strings (`rounded-4xl`, `bg-primary`, etc.) reference theme variables. Don't search-and-replace them — change the underlying variable instead. The whole point of the variable layer is that one edit propagates everywhere.
+
 ## Component Management Workflow
 
 ### Adding New Components

--- a/packages/ui/components.json
+++ b/packages/ui/components.json
@@ -2,7 +2,7 @@
 	"$schema": "https://shadcn-svelte.com/schema.json",
 	"tailwind": {
 		"css": "src/app.css",
-		"baseColor": "slate"
+		"baseColor": "taupe"
 	},
 	"aliases": {
 		"components": "#",
@@ -12,5 +12,9 @@
 		"lib": "#/lib"
 	},
 	"typescript": true,
-	"registry": "https://shadcn-svelte.com/registry"
+	"registry": "https://shadcn-svelte.com/registry",
+	"style": "luma",
+	"iconLibrary": "lucide",
+	"menuColor": "default",
+	"menuAccent": "subtle"
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -36,13 +36,15 @@
 		"typecheck": "svelte-check"
 	},
 	"dependencies": {
-		"@fontsource-variable/manrope": "^5.2.6",
+		"@fontsource-variable/inter": "^5.2.6",
+		"@fontsource-variable/lora": "^5.2.6",
 		"@lucide/svelte": "^1.7.0",
 		"@tanstack/svelte-table": "catalog:",
 		"bits-ui": "^2.16.5",
 		"chrono-node": "2.9.0",
 		"clsx": "^2.1.1",
 		"paneforge": "^1.0.2",
+		"shadcn-svelte": "^1.2.7",
 		"tailwind-merge": "^3.5.0",
 		"tailwind-variants": "^3.2.2"
 	},

--- a/packages/ui/src/accordion/accordion-content.svelte
+++ b/packages/ui/src/accordion/accordion-content.svelte
@@ -13,8 +13,15 @@
 <AccordionPrimitive.Content
 	bind:ref
 	data-slot="accordion-content"
-	class="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+	class="data-open:animate-accordion-down data-closed:animate-accordion-up px-4 text-sm overflow-hidden"
 	{...restProps}
 >
-	<div class={cn('pb-4 pt-0', className)}>{@render children?.()}</div>
+	<div
+		class={cn(
+			"pt-0 pb-4 [&_a]:hover:text-foreground [&_a]:underline [&_a]:underline-offset-3 [&_p:not(:last-child)]:mb-4",
+			className
+		)}
+	>
+		{@render children?.()}
+	</div>
 </AccordionPrimitive.Content>

--- a/packages/ui/src/accordion/accordion-item.svelte
+++ b/packages/ui/src/accordion/accordion-item.svelte
@@ -12,6 +12,6 @@
 <AccordionPrimitive.Item
 	bind:ref
 	data-slot="accordion-item"
-	class={cn('border-b last:border-b-0', className)}
+	class={cn("data-open:bg-muted/50 not-last:border-b", className)}
 	{...restProps}
 />

--- a/packages/ui/src/accordion/accordion-trigger.svelte
+++ b/packages/ui/src/accordion/accordion-trigger.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+	import ChevronUpIcon from '@lucide/svelte/icons/chevron-up';
 	import { Accordion as AccordionPrimitive } from 'bits-ui';
 	import { cn, type WithoutChild } from '#/utils.js';
 
@@ -19,14 +20,19 @@
 		data-slot="accordion-trigger"
 		bind:ref
 		class={cn(
-			'focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-start text-sm font-medium outline-none transition-all hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180',
-			className,
+			"**:data-[slot=accordion-trigger-icon]:text-muted-foreground gap-6 p-4 text-left text-sm font-medium hover:underline **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 items-start justify-between border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50",
+			className
 		)}
 		{...restProps}
 	>
 		{@render children?.()}
 		<ChevronDownIcon
-			class="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200"
+			data-slot="accordion-trigger-icon"
+			class="cn-accordion-trigger-icon pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+		/>
+		<ChevronUpIcon
+			data-slot="accordion-trigger-icon"
+			class="cn-accordion-trigger-icon pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
 		/>
 	</AccordionPrimitive.Trigger>
 </AccordionPrimitive.Header>

--- a/packages/ui/src/accordion/accordion.svelte
+++ b/packages/ui/src/accordion/accordion.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { Accordion as AccordionPrimitive } from 'bits-ui';
+	import { cn } from '#/utils.js';
 
 	let {
 		ref = $bindable(null),
 		value = $bindable(),
+		class: className,
 		...restProps
 	}: AccordionPrimitive.RootProps = $props();
 </script>
@@ -12,5 +14,6 @@
 	bind:ref
 	bind:value={value as never}
 	data-slot="accordion"
+	class={cn("overflow-hidden rounded-2xl border flex w-full flex-col", className)}
 	{...restProps}
 />

--- a/packages/ui/src/alert-dialog/alert-dialog-action.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-action.svelte
@@ -1,18 +1,27 @@
 <script lang="ts">
 	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
-	import { buttonVariants } from '#/button/index.js';
+	import {
+		type ButtonSize,
+		type ButtonVariant,
+		buttonVariants,
+	} from '#/button/index.js';
 	import { cn } from '#/utils.js';
 
 	let {
 		ref = $bindable(null),
 		class: className,
+		variant = 'default',
+		size = 'default',
 		...restProps
-	}: AlertDialogPrimitive.ActionProps = $props();
+	}: AlertDialogPrimitive.ActionProps & {
+		variant?: ButtonVariant;
+		size?: ButtonSize;
+	} = $props();
 </script>
 
 <AlertDialogPrimitive.Action
 	bind:ref
 	data-slot="alert-dialog-action"
-	class={cn(buttonVariants(), className)}
+	class={cn(buttonVariants({ variant, size }), "cn-alert-dialog-action", className)}
 	{...restProps}
 />

--- a/packages/ui/src/alert-dialog/alert-dialog-cancel.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-cancel.svelte
@@ -1,18 +1,27 @@
 <script lang="ts">
 	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
-	import { buttonVariants } from '#/button/index.js';
+	import {
+		type ButtonSize,
+		type ButtonVariant,
+		buttonVariants,
+	} from '#/button/index.js';
 	import { cn } from '#/utils.js';
 
 	let {
 		ref = $bindable(null),
 		class: className,
+		variant = 'outline',
+		size = 'default',
 		...restProps
-	}: AlertDialogPrimitive.CancelProps = $props();
+	}: AlertDialogPrimitive.CancelProps & {
+		variant?: ButtonVariant;
+		size?: ButtonSize;
+	} = $props();
 </script>
 
 <AlertDialogPrimitive.Cancel
 	bind:ref
 	data-slot="alert-dialog-cancel"
-	class={cn(buttonVariants({ variant: 'outline' }), className)}
+	class={cn(buttonVariants({ variant, size }), "cn-alert-dialog-cancel", className)}
 	{...restProps}
 />

--- a/packages/ui/src/alert-dialog/alert-dialog-content.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-content.svelte
@@ -1,31 +1,38 @@
 <script lang="ts">
 	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+	import type { ComponentProps } from 'svelte';
 	import {
 		cn,
 		type WithoutChild,
 		type WithoutChildrenOrChild,
 	} from '#/utils.js';
 	import AlertDialogOverlay from './alert-dialog-overlay.svelte';
+	import AlertDialogPortal from './alert-dialog-portal.svelte';
 
 	let {
 		ref = $bindable(null),
 		class: className,
+		size = 'default',
 		portalProps,
 		...restProps
 	}: WithoutChild<AlertDialogPrimitive.ContentProps> & {
-		portalProps?: WithoutChildrenOrChild<AlertDialogPrimitive.PortalProps>;
+		size?: 'default' | 'sm';
+		portalProps?: WithoutChildrenOrChild<
+			ComponentProps<typeof AlertDialogPortal>
+		>;
 	} = $props();
 </script>
 
-<AlertDialogPrimitive.Portal {...portalProps}>
+<AlertDialogPortal {...portalProps}>
 	<AlertDialogOverlay />
 	<AlertDialogPrimitive.Content
 		bind:ref
 		data-slot="alert-dialog-content"
+		data-size={size}
 		class={cn(
-			'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed start-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
-			className,
+			"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-popover text-popover-foreground ring-foreground/5 dark:ring-foreground/10 gap-6 rounded-4xl p-6 shadow-xl ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-md group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+			className
 		)}
 		{...restProps}
 	/>
-</AlertDialogPrimitive.Portal>
+</AlertDialogPortal>

--- a/packages/ui/src/alert-dialog/alert-dialog-description.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-description.svelte
@@ -12,6 +12,6 @@
 <AlertDialogPrimitive.Description
 	bind:ref
 	data-slot="alert-dialog-description"
-	class={cn('text-muted-foreground text-sm', className)}
+	class={cn("text-muted-foreground *:[a]:hover:text-foreground text-sm text-balance md:text-pretty *:[a]:underline *:[a]:underline-offset-3", className)}
 	{...restProps}
 />

--- a/packages/ui/src/alert-dialog/alert-dialog-footer.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-footer.svelte
@@ -14,8 +14,8 @@
 	bind:this={ref}
 	data-slot="alert-dialog-footer"
 	class={cn(
-		'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
-		className,
+		"cn-alert-dialog-footer flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+		className
 	)}
 	{...restProps}
 >

--- a/packages/ui/src/alert-dialog/alert-dialog-header.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-header.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="alert-dialog-header"
-	class={cn('flex flex-col gap-2 text-center sm:text-start', className)}
+	class={cn("grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-6 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/alert-dialog/alert-dialog-media.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-media.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { cn, type WithElementRef } from '#/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-dialog-media"
+	class={cn("bg-muted mb-2 inline-flex size-16 items-center justify-center rounded-full sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-8", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/alert-dialog/alert-dialog-overlay.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-overlay.svelte
@@ -12,9 +12,6 @@
 <AlertDialogPrimitive.Overlay
 	bind:ref
 	data-slot="alert-dialog-overlay"
-	class={cn(
-		'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
-		className,
-	)}
+	class={cn("data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/30 duration-100 supports-backdrop-filter:backdrop-blur-sm fixed inset-0 z-50", className)}
 	{...restProps}
 />

--- a/packages/ui/src/alert-dialog/alert-dialog-portal.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+
+	let { ...restProps }: AlertDialogPrimitive.PortalProps = $props();
+</script>
+
+<AlertDialogPrimitive.Portal {...restProps} />

--- a/packages/ui/src/alert-dialog/alert-dialog-title.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog-title.svelte
@@ -12,6 +12,6 @@
 <AlertDialogPrimitive.Title
 	bind:ref
 	data-slot="alert-dialog-title"
-	class={cn('text-lg font-semibold', className)}
+	class={cn("font-heading text-lg font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2", className)}
 	{...restProps}
 />

--- a/packages/ui/src/alert-dialog/alert-dialog.svelte
+++ b/packages/ui/src/alert-dialog/alert-dialog.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+
+	let {
+		open = $bindable(false),
+		...restProps
+	}: AlertDialogPrimitive.RootProps = $props();
+</script>
+
+<AlertDialogPrimitive.Root bind:open {...restProps} />

--- a/packages/ui/src/alert-dialog/index.ts
+++ b/packages/ui/src/alert-dialog/index.ts
@@ -1,16 +1,15 @@
-import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+import Root from './alert-dialog.svelte';
 import Action from './alert-dialog-action.svelte';
 import Cancel from './alert-dialog-cancel.svelte';
 import Content from './alert-dialog-content.svelte';
 import Description from './alert-dialog-description.svelte';
 import Footer from './alert-dialog-footer.svelte';
 import Header from './alert-dialog-header.svelte';
+import Media from './alert-dialog-media.svelte';
 import Overlay from './alert-dialog-overlay.svelte';
+import Portal from './alert-dialog-portal.svelte';
 import Title from './alert-dialog-title.svelte';
 import Trigger from './alert-dialog-trigger.svelte';
-
-const Root = AlertDialogPrimitive.Root;
-const Portal = AlertDialogPrimitive.Portal;
 
 export {
 	Action,
@@ -25,6 +24,8 @@ export {
 	Footer as AlertDialogFooter,
 	Header,
 	Header as AlertDialogHeader,
+	Media,
+	Media as AlertDialogMedia,
 	Overlay,
 	Overlay as AlertDialogOverlay,
 	Portal,

--- a/packages/ui/src/alert/alert-action.svelte
+++ b/packages/ui/src/alert/alert-action.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { cn, type WithElementRef } from '#/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-action"
+	class={cn("absolute top-2.5 right-3", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/alert/alert-description.svelte
+++ b/packages/ui/src/alert/alert-description.svelte
@@ -14,8 +14,8 @@
 	bind:this={ref}
 	data-slot="alert-description"
 	class={cn(
-		'text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed',
-		className,
+		"text-muted-foreground text-sm text-balance md:text-pretty [&_p:not(:last-child)]:mb-4 [&_a]:hover:text-foreground [&_a]:underline [&_a]:underline-offset-3",
+		className
 	)}
 	{...restProps}
 >

--- a/packages/ui/src/alert/alert-title.svelte
+++ b/packages/ui/src/alert/alert-title.svelte
@@ -14,8 +14,8 @@
 	bind:this={ref}
 	data-slot="alert-title"
 	class={cn(
-		'col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight',
-		className,
+		"font-heading font-medium group-has-[>svg]/alert:col-start-2 [&_a]:hover:text-foreground [&_a]:underline [&_a]:underline-offset-3",
+		className
 	)}
 	{...restProps}
 >

--- a/packages/ui/src/alert/alert.svelte
+++ b/packages/ui/src/alert/alert.svelte
@@ -2,14 +2,12 @@
 	import { tv, type VariantProps } from 'tailwind-variants';
 
 	export const alertVariants = tv({
-		base: 'relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current',
+		base: "grid gap-0.5 rounded-2xl border px-4 py-3 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2.5 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4 group/alert relative w-full",
 		variants: {
 			variant: {
 				default: 'bg-card text-card-foreground',
 				destructive:
-					'text-destructive bg-card *:data-[slot=alert-description]:text-destructive/90 [&>svg]:text-current',
-				warning:
-					'text-warning bg-card *:data-[slot=alert-description]:text-warning/90 [&>svg]:text-current',
+					'text-destructive bg-card *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current',
 			},
 		},
 		defaultVariants: {
@@ -38,9 +36,9 @@
 <div
 	bind:this={ref}
 	data-slot="alert"
+	role="alert"
 	class={cn(alertVariants({ variant }), className)}
 	{...restProps}
-	role="alert"
 >
 	{@render children?.()}
 </div>

--- a/packages/ui/src/alert/index.ts
+++ b/packages/ui/src/alert/index.ts
@@ -1,10 +1,13 @@
 import Root from './alert.svelte';
+import Action from './alert-action.svelte';
 import Description from './alert-description.svelte';
 import Title from './alert-title.svelte';
 
 export { type AlertVariant, alertVariants } from './alert.svelte';
 
 export {
+	Action,
+	Action as AlertAction,
 	Description,
 	Description as AlertDescription,
 	Root,

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -1,9 +1,14 @@
 @import "tailwindcss";
-/* @import '@fontsource-variable/manrope'; */
 
 @import "tw-animate-css";
 
 @import "./prose.css";
+
+@import "shadcn-svelte/tailwind.css";
+
+@import "@fontsource-variable/inter";
+
+@import "@fontsource-variable/lora";
 
 @source "./**/*.{svelte,ts}";
 
@@ -23,89 +28,94 @@
 	::file-selector-button {
 		border-color: var(--color-gray-200, currentcolor);
 	}
+	* {
+		@apply border-border outline-ring/50;
+	}
+	body {
+		@apply bg-background text-foreground;
+	}
+	html {
+		@apply font-sans;
+	}
 }
 
 @custom-variant dark (&:is(.dark *));
 
 :root {
-	--font-sans:
-		"Manrope Variable", system-ui, -apple-system, BlinkMacSystemFont,
-		"Segoe UI", Roboto, sans-serif;
 	--radius: 0.625rem;
 	--background: oklch(1 0 0);
-	--foreground: oklch(0.129 0.042 264.695);
+	--foreground: oklch(0.147 0.004 49.3);
 	--card: oklch(1 0 0);
-	--card-foreground: oklch(0.129 0.042 264.695);
+	--card-foreground: oklch(0.147 0.004 49.3);
 	--popover: oklch(1 0 0);
-	--popover-foreground: oklch(0.129 0.042 264.695);
-	--primary: oklch(0.208 0.042 265.755);
-	--primary-foreground: oklch(0.984 0.003 247.858);
-	--secondary: oklch(0.968 0.007 247.896);
-	--secondary-foreground: oklch(0.208 0.042 265.755);
-	--muted: oklch(0.968 0.007 247.896);
-	--muted-foreground: oklch(0.554 0.046 257.417);
-	--accent: oklch(0.968 0.007 247.896);
-	--accent-foreground: oklch(0.208 0.042 265.755);
+	--popover-foreground: oklch(0.147 0.004 49.3);
+	--primary: oklch(0.214 0.009 43.1);
+	--primary-foreground: oklch(0.986 0.002 67.8);
+	--secondary: oklch(0.96 0.002 17.2);
+	--secondary-foreground: oklch(0.214 0.009 43.1);
+	--muted: oklch(0.96 0.002 17.2);
+	--muted-foreground: oklch(0.547 0.021 43.1);
+	--accent: oklch(0.96 0.002 17.2);
+	--accent-foreground: oklch(0.214 0.009 43.1);
 	--destructive: oklch(0.577 0.245 27.325);
 	--warning: oklch(0.666 0.179 58.318);
 	--success: oklch(0.736 0.196 144.128);
-	--border: oklch(0.929 0.013 255.508);
-	--input: oklch(0.929 0.013 255.508);
-	--ring: oklch(0.704 0.04 256.788);
-	--chart-1: oklch(0.646 0.222 41.116);
-	--chart-2: oklch(0.6 0.118 184.704);
-	--chart-3: oklch(0.398 0.07 227.392);
-	--chart-4: oklch(0.828 0.189 84.429);
-	--chart-5: oklch(0.769 0.188 70.08);
-	--sidebar: oklch(0.985 0 0);
-	--sidebar-foreground: oklch(0.145 0 0);
-	--sidebar-primary: oklch(0.205 0 0);
-	--sidebar-primary-foreground: oklch(0.985 0 0);
-	--sidebar-accent: oklch(0.97 0 0);
-	--sidebar-accent-foreground: oklch(0.205 0 0);
-	--sidebar-border: oklch(0.922 0 0);
-	--sidebar-ring: oklch(0.708 0 0);
+	--border: oklch(0.922 0.005 34.3);
+	--input: oklch(0.922 0.005 34.3);
+	--ring: oklch(0.714 0.014 41.2);
+	--chart-1: oklch(0.868 0.007 39.5);
+	--chart-2: oklch(0.547 0.021 43.1);
+	--chart-3: oklch(0.438 0.017 39.3);
+	--chart-4: oklch(0.367 0.016 35.7);
+	--chart-5: oklch(0.268 0.011 36.5);
+	--sidebar: oklch(0.986 0.002 67.8);
+	--sidebar-foreground: oklch(0.147 0.004 49.3);
+	--sidebar-primary: oklch(0.214 0.009 43.1);
+	--sidebar-primary-foreground: oklch(0.986 0.002 67.8);
+	--sidebar-accent: oklch(0.96 0.002 17.2);
+	--sidebar-accent-foreground: oklch(0.214 0.009 43.1);
+	--sidebar-border: oklch(0.922 0.005 34.3);
+	--sidebar-ring: oklch(0.714 0.014 41.2);
 }
 
 .dark {
-	--font-sans: "Manrope Variable", sans-serif;
-	--background: oklch(0.129 0.042 264.695);
-	--foreground: oklch(0.984 0.003 247.858);
-	--card: oklch(0.208 0.042 265.755);
-	--card-foreground: oklch(0.984 0.003 247.858);
-	--popover: oklch(0.208 0.042 265.755);
-	--popover-foreground: oklch(0.984 0.003 247.858);
-	--primary: oklch(0.929 0.013 255.508);
-	--primary-foreground: oklch(0.208 0.042 265.755);
-	--secondary: oklch(0.279 0.041 260.031);
-	--secondary-foreground: oklch(0.984 0.003 247.858);
-	--muted: oklch(0.279 0.041 260.031);
-	--muted-foreground: oklch(0.704 0.04 256.788);
-	--accent: oklch(0.279 0.041 260.031);
-	--accent-foreground: oklch(0.984 0.003 247.858);
+	--background: oklch(0.147 0.004 49.3);
+	--foreground: oklch(0.986 0.002 67.8);
+	--card: oklch(0.214 0.009 43.1);
+	--card-foreground: oklch(0.986 0.002 67.8);
+	--popover: oklch(0.214 0.009 43.1);
+	--popover-foreground: oklch(0.986 0.002 67.8);
+	--primary: oklch(0.922 0.005 34.3);
+	--primary-foreground: oklch(0.214 0.009 43.1);
+	--secondary: oklch(0.268 0.011 36.5);
+	--secondary-foreground: oklch(0.986 0.002 67.8);
+	--muted: oklch(0.268 0.011 36.5);
+	--muted-foreground: oklch(0.714 0.014 41.2);
+	--accent: oklch(0.268 0.011 36.5);
+	--accent-foreground: oklch(0.986 0.002 67.8);
 	--destructive: oklch(0.704 0.191 22.216);
 	--warning: oklch(0.769 0.188 70.08);
 	--success: oklch(0.64 0.169 145.386);
 	--border: oklch(1 0 0 / 10%);
 	--input: oklch(1 0 0 / 15%);
-	--ring: oklch(0.551 0.027 264.364);
-	--chart-1: oklch(0.488 0.243 264.376);
-	--chart-2: oklch(0.696 0.17 162.48);
-	--chart-3: oklch(0.769 0.188 70.08);
-	--chart-4: oklch(0.627 0.265 303.9);
-	--chart-5: oklch(0.645 0.246 16.439);
-	--sidebar: oklch(0.205 0 0);
-	--sidebar-foreground: oklch(0.985 0 0);
-	--sidebar-primary: oklch(0.488 0.243 264.376);
-	--sidebar-primary-foreground: oklch(0.985 0 0);
-	--sidebar-accent: oklch(0.269 0 0);
-	--sidebar-accent-foreground: oklch(0.985 0 0);
+	--ring: oklch(0.547 0.021 43.1);
+	--chart-1: oklch(0.868 0.007 39.5);
+	--chart-2: oklch(0.547 0.021 43.1);
+	--chart-3: oklch(0.438 0.017 39.3);
+	--chart-4: oklch(0.367 0.016 35.7);
+	--chart-5: oklch(0.268 0.011 36.5);
+	--sidebar: oklch(0.214 0.009 43.1);
+	--sidebar-foreground: oklch(0.986 0.002 67.8);
+	--sidebar-primary: oklch(0.922 0.005 34.3);
+	--sidebar-primary-foreground: oklch(0.214 0.009 43.1);
+	--sidebar-accent: oklch(0.268 0.011 36.5);
+	--sidebar-accent-foreground: oklch(0.986 0.002 67.8);
 	--sidebar-border: oklch(1 0 0 / 10%);
-	--sidebar-ring: oklch(0.439 0 0);
+	--sidebar-ring: oklch(0.547 0.021 43.1);
 }
 
 @theme inline {
-	--font-sans: var(--font-sans);
+	--font-sans: "Inter Variable", sans-serif;
 	--radius-sm: calc(var(--radius) - 4px);
 	--radius-md: calc(var(--radius) - 2px);
 	--radius-lg: var(--radius);
@@ -146,13 +156,8 @@
 	/* Custom breakpoints */
 	--breakpoint-xxs: 196px;
 	--breakpoint-xs: 320px;
-}
-
-@layer base {
-	* {
-		@apply border-border outline-ring/50;
-	}
-	body {
-		@apply bg-background text-foreground;
-	}
+	--font-heading: "Lora Variable", serif;
+	--radius-2xl: calc(var(--radius) * 1.8);
+	--radius-3xl: calc(var(--radius) * 2.2);
+	--radius-4xl: calc(var(--radius) * 2.6);
 }

--- a/packages/ui/src/avatar/avatar-badge.svelte
+++ b/packages/ui/src/avatar/avatar-badge.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { cn, type WithElementRef } from '#/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLSpanElement>> = $props();
+</script>
+
+<span
+	bind:this={ref}
+	data-slot="avatar-badge"
+	class={cn(
+		"bg-primary text-primary-foreground ring-background absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-blend-color ring-2 select-none",
+		"group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+		"group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
+		"group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</span>

--- a/packages/ui/src/avatar/avatar-fallback.svelte
+++ b/packages/ui/src/avatar/avatar-fallback.svelte
@@ -13,8 +13,8 @@
 	bind:ref
 	data-slot="avatar-fallback"
 	class={cn(
-		'bg-muted flex size-full items-center justify-center rounded-full',
-		className,
+		"bg-muted text-muted-foreground rounded-full flex size-full items-center justify-center text-sm group-data-[size=sm]/avatar:text-xs",
+		className
 	)}
 	{...restProps}
 />

--- a/packages/ui/src/avatar/avatar-group-count.svelte
+++ b/packages/ui/src/avatar/avatar-group-count.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { cn, type WithElementRef } from '#/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="avatar-group-count"
+	class={cn(
+		"bg-muted text-muted-foreground size-8 rounded-full text-sm group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3 ring-background relative flex shrink-0 items-center justify-center ring-2",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/avatar/avatar-group.svelte
+++ b/packages/ui/src/avatar/avatar-group.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { cn, type WithElementRef } from '#/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="avatar-group"
+	class={cn(
+		"cn-avatar-group *:data-[slot=avatar]:ring-background group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/avatar/avatar-image.svelte
+++ b/packages/ui/src/avatar/avatar-image.svelte
@@ -12,6 +12,6 @@
 <AvatarPrimitive.Image
 	bind:ref
 	data-slot="avatar-image"
-	class={cn('aspect-square size-full', className)}
+	class={cn("rounded-full aspect-square size-full object-cover", className)}
 	{...restProps}
 />

--- a/packages/ui/src/avatar/avatar.svelte
+++ b/packages/ui/src/avatar/avatar.svelte
@@ -5,18 +5,22 @@
 	let {
 		ref = $bindable(null),
 		loadingStatus = $bindable('loading'),
+		size = 'default',
 		class: className,
 		...restProps
-	}: AvatarPrimitive.RootProps = $props();
+	}: AvatarPrimitive.RootProps & {
+		size?: 'default' | 'sm' | 'lg';
+	} = $props();
 </script>
 
 <AvatarPrimitive.Root
 	bind:ref
 	bind:loadingStatus
 	data-slot="avatar"
+	data-size={size}
 	class={cn(
-		'relative flex size-8 shrink-0 overflow-hidden rounded-full',
-		className,
+		"size-8 rounded-full after:rounded-full data-[size=lg]:size-10 data-[size=sm]:size-6 after:border-border group/avatar relative flex shrink-0 select-none after:absolute after:inset-0 after:border after:mix-blend-darken dark:after:mix-blend-lighten",
+		className
 	)}
 	{...restProps}
 />

--- a/packages/ui/src/avatar/index.ts
+++ b/packages/ui/src/avatar/index.ts
@@ -1,10 +1,19 @@
 import Root from './avatar.svelte';
+import Badge from './avatar-badge.svelte';
 import Fallback from './avatar-fallback.svelte';
+import Group from './avatar-group.svelte';
+import GroupCount from './avatar-group-count.svelte';
 import Image from './avatar-image.svelte';
 
 export {
+	Badge,
+	Badge as AvatarBadge,
 	Fallback,
 	Fallback as AvatarFallback,
+	Group,
+	Group as AvatarGroup,
+	GroupCount,
+	GroupCount as AvatarGroupCount,
 	Image,
 	Image as AvatarImage,
 	Root,

--- a/packages/ui/src/badge/badge.svelte
+++ b/packages/ui/src/badge/badge.svelte
@@ -18,9 +18,6 @@
 				success:
 					'bg-success/10 text-success [a]:hover:bg-success/20 focus-visible:ring-success/20 dark:focus-visible:ring-success/40 dark:bg-success/20',
 				id: 'rounded-md bg-muted text-muted-foreground [a]:hover:bg-muted/90 px-1.5 font-mono text-xs font-normal',
-				'status.completed': 'bg-green-500/10 text-green-500',
-				'status.failed': 'bg-red-500/10 text-red-500',
-				'status.running': 'bg-blue-500/10 text-blue-500',
 			},
 		},
 		defaultVariants: {

--- a/packages/ui/src/badge/badge.svelte
+++ b/packages/ui/src/badge/badge.svelte
@@ -2,23 +2,25 @@
 	import { tv, type VariantProps } from 'tailwind-variants';
 
 	export const badgeVariants = tv({
-		base: 'focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden whitespace-nowrap rounded-full border px-2 py-0.5 text-xs font-medium transition-[color,box-shadow] focus-visible:ring-[3px] [&>svg]:pointer-events-none [&>svg]:size-3',
+		base: 'h-5 gap-1 rounded-3xl border border-transparent px-2 py-0.5 text-xs font-medium transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive group/badge inline-flex w-fit shrink-0 items-center justify-center overflow-hidden whitespace-nowrap transition-colors focus-visible:ring-[3px] [&>svg]:pointer-events-none',
 		variants: {
 			variant: {
-				default:
-					'bg-primary text-primary-foreground [a&]:hover:bg-primary/90 border-transparent',
+				default: 'bg-primary text-primary-foreground [a]:hover:bg-primary/80',
 				secondary:
-					'bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90 border-transparent',
+					'bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80',
 				destructive:
-					'bg-destructive [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/70 border-transparent text-white',
+					'bg-destructive/10 [a]:hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 text-destructive dark:bg-destructive/20',
 				outline:
-					'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
-				id: 'px-1.5 bg-muted text-muted-foreground [a&]:hover:bg-muted/90 border-transparent font-mono text-xs rounded-md font-normal',
+					'border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground',
+				ghost:
+					'hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50',
+				link: 'text-primary underline-offset-4 hover:underline',
+				success:
+					'bg-success/10 text-success [a]:hover:bg-success/20 focus-visible:ring-success/20 dark:focus-visible:ring-success/40 dark:bg-success/20',
+				id: 'rounded-md bg-muted text-muted-foreground [a]:hover:bg-muted/90 px-1.5 font-mono text-xs font-normal',
 				'status.completed': 'bg-green-500/10 text-green-500',
 				'status.failed': 'bg-red-500/10 text-red-500',
 				'status.running': 'bg-blue-500/10 text-blue-500',
-				success:
-					'bg-success [a&]:hover:bg-success/90 focus-visible:ring-success/20 dark:focus-visible:ring-success/40 dark:bg-success/80 border-transparent text-white',
 			},
 		},
 		defaultVariants: {
@@ -46,7 +48,7 @@
 </script>
 
 <svelte:element
-	this={href ? 'a' : 'span'}
+	this={href ? "a" : "span"}
 	bind:this={ref}
 	data-slot="badge"
 	{href}

--- a/packages/ui/src/breadcrumb/breadcrumb-ellipsis.svelte
+++ b/packages/ui/src/breadcrumb/breadcrumb-ellipsis.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import EllipsisIcon from '@lucide/svelte/icons/ellipsis';
+	import MoreHorizontalIcon from '@lucide/svelte/icons/more-horizontal';
 	import type { HTMLAttributes } from 'svelte/elements';
 	import { cn, type WithElementRef, type WithoutChildren } from '#/utils.js';
 
@@ -17,9 +17,9 @@
 	data-slot="breadcrumb-ellipsis"
 	role="presentation"
 	aria-hidden="true"
-	class={cn('flex size-9 items-center justify-center', className)}
+	class={cn("size-5 [&>svg]:size-4 flex items-center justify-center", className)}
 	{...restProps}
 >
-	<EllipsisIcon class="size-4" />
+	<MoreHorizontalIcon />
 	<span class="sr-only">More</span>
 </span>

--- a/packages/ui/src/breadcrumb/breadcrumb-item.svelte
+++ b/packages/ui/src/breadcrumb/breadcrumb-item.svelte
@@ -13,7 +13,7 @@
 <li
 	bind:this={ref}
 	data-slot="breadcrumb-item"
-	class={cn('inline-flex items-center gap-1.5', className)}
+	class={cn("gap-1.5 inline-flex items-center", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/breadcrumb/breadcrumb-list.svelte
+++ b/packages/ui/src/breadcrumb/breadcrumb-list.svelte
@@ -13,10 +13,7 @@
 <ol
 	bind:this={ref}
 	data-slot="breadcrumb-list"
-	class={cn(
-		'text-muted-foreground flex flex-wrap items-center gap-1.5 break-words text-sm sm:gap-2.5',
-		className,
-	)}
+	class={cn("text-muted-foreground gap-1.5 text-sm sm:gap-2.5 flex flex-wrap items-center wrap-break-word", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/breadcrumb/breadcrumb-page.svelte
+++ b/packages/ui/src/breadcrumb/breadcrumb-page.svelte
@@ -16,7 +16,7 @@
 	role="link"
 	aria-disabled="true"
 	aria-current="page"
-	class={cn('text-foreground font-normal', className)}
+	class={cn("text-foreground font-normal", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/breadcrumb/breadcrumb-separator.svelte
+++ b/packages/ui/src/breadcrumb/breadcrumb-separator.svelte
@@ -16,7 +16,7 @@
 	data-slot="breadcrumb-separator"
 	role="presentation"
 	aria-hidden="true"
-	class={cn('[&>svg]:size-3.5', className)}
+	class={cn("[&>svg]:size-3.5", className)}
 	{...restProps}
 >
 	{#if children}

--- a/packages/ui/src/breadcrumb/breadcrumb.svelte
+++ b/packages/ui/src/breadcrumb/breadcrumb.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { HTMLAttributes } from 'svelte/elements';
 	import type { WithElementRef } from '#/utils.js';
+	import { cn } from '#/utils.js';
 
 	let {
 		ref = $bindable(null),
@@ -13,8 +14,8 @@
 <nav
 	bind:this={ref}
 	data-slot="breadcrumb"
-	class={className}
 	aria-label="breadcrumb"
+	class={cn("cn-breadcrumb", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/button-group/button-group-separator.svelte
+++ b/packages/ui/src/button-group/button-group-separator.svelte
@@ -16,8 +16,8 @@
 	data-slot="button-group-separator"
 	{orientation}
 	class={cn(
-		'bg-input relative !m-0 self-stretch data-[orientation=vertical]:h-auto',
-		className,
+		"bg-input relative self-stretch data-[orientation=horizontal]:mx-px data-[orientation=horizontal]:w-auto data-[orientation=vertical]:my-px data-[orientation=vertical]:h-auto",
+		className
 	)}
 	{...restProps}
 />

--- a/packages/ui/src/button-group/button-group-text.svelte
+++ b/packages/ui/src/button-group/button-group-text.svelte
@@ -15,9 +15,10 @@
 	const mergedProps = $derived({
 		...restProps,
 		class: cn(
-			"bg-muted shadow-xs flex items-center gap-2 rounded-md border px-4 text-sm font-medium [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none",
+			"bg-muted gap-2 rounded-4xl border px-2.5 text-sm font-medium [&_svg:not([class*='size-'])]:size-4 flex items-center [&_svg]:pointer-events-none",
 			className,
 		),
+		'data-slot': 'button-group-text',
 	});
 </script>
 

--- a/packages/ui/src/button-group/button-group.svelte
+++ b/packages/ui/src/button-group/button-group.svelte
@@ -2,13 +2,13 @@
 	import { tv, type VariantProps } from 'tailwind-variants';
 
 	export const buttonGroupVariants = tv({
-		base: "flex w-fit items-stretch has-[>[data-slot=button-group]]:gap-2 [&>*]:focus-visible:relative [&>*]:focus-visible:z-10 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-e-md [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
+		base: "has-[>[data-variant=outline]]:[&>input]:border-border has-[>[data-variant=outline]]:[&>input:focus-visible]:border-ring has-[>[data-variant=outline]]:*:data-[slot=input-group]:border-border has-[>[data-variant=outline]]:[&>[data-slot=input-group]:has(:focus-visible)]:border-ring has-[>[data-variant=outline]]:*:data-[slot=select-trigger]:border-border has-[>[data-variant=outline]]:[&>[data-slot=select-trigger]:focus-visible]:border-ring has-[>[data-slot=button-group]]:gap-2 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-4xl flex w-fit items-stretch [&>*]:focus-visible:relative [&>*]:focus-visible:z-10 [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
 		variants: {
 			orientation: {
 				horizontal:
-					'[&>*:not(:first-child)]:rounded-s-none [&>*:not(:first-child)]:border-s-0 [&>*:not(:last-child)]:rounded-e-none',
+					'[&>[data-slot]:not(:has(~[data-slot]))]:rounded-r-4xl! [&>[data-slot]]:rounded-r-none [&>[data-slot]~[data-slot]]:rounded-l-none [&>[data-slot]~[data-slot]]:border-l-0',
 				vertical:
-					'flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:border-t-0 [&>*:not(:last-child)]:rounded-b-none',
+					'[&>[data-slot]:not(:has(~[data-slot]))]:rounded-b-4xl! flex-col [&>[data-slot]]:rounded-b-none [&>[data-slot]~[data-slot]]:rounded-t-none [&>[data-slot]~[data-slot]]:border-t-0',
 			},
 		},
 		defaultVariants: {

--- a/packages/ui/src/button-group/index.ts
+++ b/packages/ui/src/button-group/index.ts
@@ -1,8 +1,13 @@
-import Root from './button-group.svelte';
+import Root, {
+	type ButtonGroupOrientation,
+	buttonGroupVariants,
+} from './button-group.svelte';
 import Separator from './button-group-separator.svelte';
 import Text from './button-group-text.svelte';
 
 export {
+	type ButtonGroupOrientation,
+	buttonGroupVariants,
 	Root,
 	//
 	Root as ButtonGroup,

--- a/packages/ui/src/button/button.svelte
+++ b/packages/ui/src/button/button.svelte
@@ -74,6 +74,7 @@
 
 {#snippet buttonContent(tooltipProps?: Record<string, unknown>)}
 	{#if href}
+		<!-- biome-ignore lint/a11y/useValidAriaRole: conditional role is valid -->
 		<a
 			bind:this={ref}
 			data-slot="button"

--- a/packages/ui/src/button/button.svelte
+++ b/packages/ui/src/button/button.svelte
@@ -7,26 +7,26 @@
 	import { cn, type WithElementRef } from '#/utils.js';
 
 	export const buttonVariants = tv({
-		base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium outline-none transition-all focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		base: "focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-4xl border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 active:not-aria-[haspopup]:translate-y-px aria-invalid:ring-3 [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		variants: {
 			variant: {
-				default:
-					'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',
-				destructive:
-					'bg-destructive shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60 text-white',
+				default: 'bg-primary text-primary-foreground hover:bg-primary/80',
 				outline:
-					'bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 border',
+					'border-border bg-background hover:bg-muted hover:text-foreground dark:hover:bg-input/30 aria-expanded:bg-muted aria-expanded:text-foreground dark:bg-transparent',
 				secondary:
-					'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
+					'bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground',
 				ghost:
-					'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
-				'ghost-destructive':
-					'text-destructive hover:bg-destructive/10 hover:text-destructive dark:hover:bg-destructive/20',
+					'hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground',
+				destructive:
+					'bg-destructive/10 hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/20 text-destructive focus-visible:border-destructive/40 dark:hover:bg-destructive/30',
+				link: 'text-primary underline-offset-4 hover:underline',
 			},
 			size: {
-				default: 'h-9 px-4 py-2 has-[>svg]:px-3',
-				sm: 'h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5',
-				lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+				default:
+					'h-9 gap-1.5 px-3 has-data-[icon=inline-end]:pr-2.5 has-data-[icon=inline-start]:pl-2.5',
+				xs: "h-6 gap-1 px-2.5 text-xs has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 [&_svg:not([class*='size-'])]:size-3",
+				sm: 'h-8 gap-1 px-3 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2',
+				lg: 'h-10 gap-1.5 px-4 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3',
 				icon: 'size-9',
 				'icon-xs': "size-6 [&_svg:not([class*='size-'])]:size-3",
 				'icon-sm': 'size-8',
@@ -72,9 +72,8 @@
 	}: ButtonProps = $props();
 </script>
 
-{#snippet buttonContent(tooltipProps?: Record)}
+{#snippet buttonContent(tooltipProps?: Record<string, unknown>)}
 	{#if href}
-		<!-- biome-ignore lint/a11y/useValidAriaRole: conditional role is valid -->
 		<a
 			bind:this={ref}
 			data-slot="button"
@@ -103,10 +102,6 @@
 	{/if}
 {/snippet}
 
-<!--
-	When using the tooltip prop, this component requires a parent Tooltip.Provider.
-	Wrap your app root with <Tooltip.Provider> to enable tooltip coordination.
--->
 {#if tooltip}
 	<Tooltip.Root>
 		<Tooltip.Trigger>
@@ -114,7 +109,7 @@
 				{@render buttonContent(props)}
 			{/snippet}
 		</Tooltip.Trigger>
-		<Tooltip.Content class="max-w-xs text-center"> {tooltip} </Tooltip.Content>
+		<Tooltip.Content class="max-w-xs text-center">{tooltip}</Tooltip.Content>
 	</Tooltip.Root>
 {:else}
 	{@render buttonContent()}

--- a/packages/ui/src/card/card-action.svelte
+++ b/packages/ui/src/card/card-action.svelte
@@ -14,8 +14,8 @@
 	bind:this={ref}
 	data-slot="card-action"
 	class={cn(
-		'col-start-2 row-span-2 row-start-1 self-start justify-self-end',
-		className,
+		"cn-card-action col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+		className
 	)}
 	{...restProps}
 >

--- a/packages/ui/src/card/card-content.svelte
+++ b/packages/ui/src/card/card-content.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="card-content"
-	class={cn('px-6', className)}
+	class={cn("px-6 group-data-[size=sm]/card:px-4", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/card/card-description.svelte
+++ b/packages/ui/src/card/card-description.svelte
@@ -13,7 +13,7 @@
 <p
 	bind:this={ref}
 	data-slot="card-description"
-	class={cn('text-muted-foreground text-sm', className)}
+	class={cn("text-muted-foreground text-sm", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/card/card-footer.svelte
+++ b/packages/ui/src/card/card-footer.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="card-footer"
-	class={cn('[.border-t]:pt-6 flex items-center px-6', className)}
+	class={cn("rounded-b-4xl px-6 group-data-[size=sm]/card:px-4 [.border-t]:pt-6 group-data-[size=sm]/card:[.border-t]:pt-4 flex items-center", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/card/card-header.svelte
+++ b/packages/ui/src/card/card-header.svelte
@@ -14,8 +14,8 @@
 	bind:this={ref}
 	data-slot="card-header"
 	class={cn(
-		'@container/card-header has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6 grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6',
-		className,
+		"gap-1.5 rounded-t-4xl px-6 group-data-[size=sm]/card:px-4 [.border-b]:pb-6 group-data-[size=sm]/card:[.border-b]:pb-4 group/card-header @container/card-header grid auto-rows-min items-start has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto]",
+		className
 	)}
 	{...restProps}
 >

--- a/packages/ui/src/card/card-title.svelte
+++ b/packages/ui/src/card/card-title.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="card-title"
-	class={cn('font-semibold leading-none', className)}
+	class={cn("font-heading text-base font-medium", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/card/card.svelte
+++ b/packages/ui/src/card/card.svelte
@@ -6,17 +6,18 @@
 		ref = $bindable(null),
 		class: className,
 		children,
+		size = 'default',
 		...restProps
-	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		size?: 'default' | 'sm';
+	} = $props();
 </script>
 
 <div
 	bind:this={ref}
 	data-slot="card"
-	class={cn(
-		'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
-		className,
-	)}
+	data-size={size}
+	class={cn("bg-card text-card-foreground ring-foreground/5 dark:ring-foreground/10 gap-6 overflow-hidden rounded-4xl py-6 text-sm shadow-md ring-1 has-[>img:first-child]:pt-0 data-[size=sm]:gap-4 data-[size=sm]:py-4 *:[img:first-child]:rounded-t-4xl *:[img:last-child]:rounded-b-4xl group/card flex flex-col", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/chart/chart-utils.ts
+++ b/packages/ui/src/chart/chart-utils.ts
@@ -22,7 +22,7 @@ export function getPayloadConfigFromPayload(
 	config: ChartConfig,
 	payload: TooltipPayload,
 	key: string,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	// biome-ignore lint/suspicious/noExplicitAny: inherited from shadcn-svelte
 	data?: Record<string, any> | null,
 ) {
 	if (typeof payload !== 'object' || payload === null) return undefined;

--- a/packages/ui/src/checkbox/checkbox.svelte
+++ b/packages/ui/src/checkbox/checkbox.svelte
@@ -17,19 +17,22 @@
 	bind:ref
 	data-slot="checkbox"
 	class={cn(
-		'border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive shadow-xs peer flex size-4 shrink-0 items-center justify-center rounded-[4px] border outline-none transition-shadow focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
-		className,
+		"bg-input/90 data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary data-checked:border-primary aria-invalid:aria-checked:border-primary aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 flex size-4 items-center justify-center rounded-[5px] border border-transparent transition-shadow group-has-disabled/field:opacity-50 focus-visible:ring-3 aria-invalid:ring-3 peer relative shrink-0 outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50",
+		className
 	)}
 	bind:checked
 	bind:indeterminate
 	{...restProps}
 >
 	{#snippet children({ checked, indeterminate })}
-		<div data-slot="checkbox-indicator" class="text-current transition-none">
+		<div
+			data-slot="checkbox-indicator"
+			class="[&>svg]:size-3.5 grid place-content-center text-current transition-none"
+		>
 			{#if checked}
-				<CheckIcon class="size-3.5" />
+				<CheckIcon />
 			{:else if indeterminate}
-				<MinusIcon class="size-3.5" />
+				<MinusIcon />
 			{/if}
 		</div>
 	{/snippet}

--- a/packages/ui/src/command/command-dialog.svelte
+++ b/packages/ui/src/command/command-dialog.svelte
@@ -5,7 +5,7 @@
 	} from 'bits-ui';
 	import type { Snippet } from 'svelte';
 	import * as Dialog from '#/dialog/index.js';
-	import type { WithoutChildrenOrChild } from '#/utils.js';
+	import { cn, type WithoutChildrenOrChild } from '#/utils.js';
 	import Command from './command.svelte';
 
 	let {
@@ -13,9 +13,11 @@
 		ref = $bindable(null),
 		value = $bindable(''),
 		title = 'Command Palette',
-		description = 'Search for a command to run',
+		description = 'Search for a command to run...',
+		showCloseButton = false,
 		portalProps,
 		children,
+		class: className,
 		...restProps
 	}: WithoutChildrenOrChild<DialogPrimitive.RootProps> &
 		WithoutChildrenOrChild<CommandPrimitive.RootProps> & {
@@ -23,6 +25,8 @@
 			children: Snippet;
 			title?: string;
 			description?: string;
+			showCloseButton?: boolean;
+			class?: string;
 		} = $props();
 </script>
 
@@ -31,13 +35,11 @@
 		<Dialog.Title>{title}</Dialog.Title>
 		<Dialog.Description>{description}</Dialog.Description>
 	</Dialog.Header>
-	<Dialog.Content class="overflow-hidden p-0" {portalProps}>
-		<Command
-			class="**:data-[slot=command-input-wrapper]:h-12 [&_[data-command-group]:not([hidden])_~[data-command-group]]:pt-0 [&_[data-command-group]]:px-2 [&_[data-command-input-wrapper]_svg]:h-5 [&_[data-command-input-wrapper]_svg]:w-5 [&_[data-command-input]]:h-12 [&_[data-command-item]]:px-2 [&_[data-command-item]]:py-3 [&_[data-command-item]_svg]:h-5 [&_[data-command-item]_svg]:w-5"
-			{...restProps}
-			bind:value
-			bind:ref
-			{children}
-		/>
+	<Dialog.Content
+		class={cn("rounded-4xl! p-0 top-1/3 translate-y-0 overflow-hidden p-0", className)}
+		{showCloseButton}
+		{portalProps}
+	>
+		<Command {...restProps} bind:value bind:ref {children} />
 	</Dialog.Content>
 </Dialog.Root>

--- a/packages/ui/src/command/command-empty.svelte
+++ b/packages/ui/src/command/command-empty.svelte
@@ -12,6 +12,6 @@
 <CommandPrimitive.Empty
 	bind:ref
 	data-slot="command-empty"
-	class={cn('py-6 text-center text-sm', className)}
+	class={cn("py-6 text-center text-sm", className)}
 	{...restProps}
 />

--- a/packages/ui/src/command/command-group.svelte
+++ b/packages/ui/src/command/command-group.svelte
@@ -17,7 +17,7 @@
 <CommandPrimitive.Group
 	bind:ref
 	data-slot="command-group"
-	class={cn('text-foreground overflow-hidden p-1', className)}
+	class={cn("text-foreground **:[[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1.5 **:[[cmdk-group-heading]]:px-3 **:[[cmdk-group-heading]]:py-2 **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:font-medium", className)}
 	value={value ?? heading ?? `----${useId()}`}
 	{...restProps}
 >

--- a/packages/ui/src/command/command-input.svelte
+++ b/packages/ui/src/command/command-input.svelte
@@ -1,33 +1,34 @@
 <script lang="ts">
 	import SearchIcon from '@lucide/svelte/icons/search';
 	import { Command as CommandPrimitive } from 'bits-ui';
+	import * as InputGroup from '#/input-group/index.js';
 	import { cn } from '#/utils.js';
 
 	let {
 		ref = $bindable(null),
 		class: className,
 		value = $bindable(''),
-		children,
 		...restProps
 	}: CommandPrimitive.InputProps = $props();
 </script>
 
-<div
-	class={cn('flex h-9 items-center gap-2 border-b ps-3', children ? 'pe-2' : 'pe-8')}
-	data-slot="command-input-wrapper"
->
-	<SearchIcon class="size-4 shrink-0 opacity-50" />
-	<CommandPrimitive.Input
-		data-slot="command-input"
-		class={cn(
-			'placeholder:text-muted-foreground outline-hidden flex h-10 w-full rounded-md bg-transparent py-3 text-sm disabled:cursor-not-allowed disabled:opacity-50',
-			className,
-		)}
-		bind:ref
-		{...restProps}
-		bind:value
-	/>
-	{#if children}
-		{@render children()}
-	{/if}
+<div data-slot="command-input-wrapper" class="p-1 pb-0">
+	<InputGroup.Root class="bg-input/50 h-9">
+		<CommandPrimitive.Input
+			{value}
+			data-slot="command-input"
+			class={cn(
+				"w-full text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+				className
+			)}
+			{...restProps}
+		>
+			{#snippet child({ props })}
+				<InputGroup.Input {...props} bind:value bind:ref />
+			{/snippet}
+		</CommandPrimitive.Input>
+		<InputGroup.Addon>
+			<SearchIcon class="size-4 shrink-0 opacity-50" />
+		</InputGroup.Addon>
+	</InputGroup.Root>
 </div>

--- a/packages/ui/src/command/command-item.svelte
+++ b/packages/ui/src/command/command-item.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
+	import CheckIcon from '@lucide/svelte/icons/check';
 	import { Command as CommandPrimitive } from 'bits-ui';
 	import { cn } from '#/utils.js';
 
 	let {
 		ref = $bindable(null),
 		class: className,
+		children,
 		...restProps
 	}: CommandPrimitive.ItemProps = $props();
 </script>
@@ -13,8 +15,13 @@
 	bind:ref
 	data-slot="command-item"
 	class={cn(
-		"aria-selected:bg-accent aria-selected:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-		className,
+		"group/command-item data-selected:bg-muted data-selected:text-foreground data-selected:*:[svg]:text-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none in-data-[slot=dialog-content]:rounded-lg! data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+		className
 	)}
 	{...restProps}
-/>
+>
+	{@render children?.()}
+	<CheckIcon
+		class="cn-command-item-indicator ml-auto opacity-0 group-has-[[data-slot=command-shortcut]]/command-item:hidden group-data-[checked=true]/command-item:opacity-100"
+	/>
+</CommandPrimitive.Item>

--- a/packages/ui/src/command/command-link-item.svelte
+++ b/packages/ui/src/command/command-link-item.svelte
@@ -13,8 +13,8 @@
 	bind:ref
 	data-slot="command-item"
 	class={cn(
-		"aria-selected:bg-accent aria-selected:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-		className,
+		"aria-selected:bg-accent aria-selected:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+		className
 	)}
 	{...restProps}
 />

--- a/packages/ui/src/command/command-list.svelte
+++ b/packages/ui/src/command/command-list.svelte
@@ -12,9 +12,6 @@
 <CommandPrimitive.List
 	bind:ref
 	data-slot="command-list"
-	class={cn(
-		'max-h-[300px] scroll-py-1 overflow-y-auto overflow-x-hidden',
-		className,
-	)}
+	class={cn("no-scrollbar max-h-72 scroll-py-1 outline-none overflow-x-hidden overflow-y-auto", className)}
 	{...restProps}
 />

--- a/packages/ui/src/command/command-loading.svelte
+++ b/packages/ui/src/command/command-loading.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	import { Command as CommandPrimitive } from 'bits-ui';
+
+	let { ref = $bindable(null), ...restProps }: CommandPrimitive.LoadingProps =
+		$props();
+</script>
+
+<CommandPrimitive.Loading bind:ref {...restProps} />

--- a/packages/ui/src/command/command-separator.svelte
+++ b/packages/ui/src/command/command-separator.svelte
@@ -12,6 +12,6 @@
 <CommandPrimitive.Separator
 	bind:ref
 	data-slot="command-separator"
-	class={cn('bg-border -mx-1 h-px', className)}
+	class={cn("bg-border/50 my-1.5 h-px", className)}
 	{...restProps}
 />

--- a/packages/ui/src/command/command-shortcut.svelte
+++ b/packages/ui/src/command/command-shortcut.svelte
@@ -13,7 +13,7 @@
 <span
 	bind:this={ref}
 	data-slot="command-shortcut"
-	class={cn('text-muted-foreground ms-auto text-xs tracking-widest', className)}
+	class={cn("text-muted-foreground group-data-selected/command-item:text-foreground ml-auto text-xs tracking-widest", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/command/command.svelte
+++ b/packages/ui/src/command/command.svelte
@@ -20,9 +20,6 @@
 	bind:value
 	bind:ref
 	data-slot="command"
-	class={cn(
-		'bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md',
-		className,
-	)}
+	class={cn("bg-popover text-popover-foreground rounded-4xl p-1 flex size-full flex-col overflow-hidden", className)}
 	{...restProps}
 />

--- a/packages/ui/src/command/index.ts
+++ b/packages/ui/src/command/index.ts
@@ -1,5 +1,3 @@
-import { Command as CommandPrimitive } from 'bits-ui';
-
 import Root from './command.svelte';
 import Dialog from './command-dialog.svelte';
 import Empty from './command-empty.svelte';
@@ -8,10 +6,9 @@ import Input from './command-input.svelte';
 import Item from './command-item.svelte';
 import LinkItem from './command-link-item.svelte';
 import List from './command-list.svelte';
+import Loading from './command-loading.svelte';
 import Separator from './command-separator.svelte';
 import Shortcut from './command-shortcut.svelte';
-
-const Loading = CommandPrimitive.Loading;
 
 export {
 	Dialog,

--- a/packages/ui/src/context-menu/context-menu-checkbox-item.svelte
+++ b/packages/ui/src/context-menu/context-menu-checkbox-item.svelte
@@ -9,9 +9,11 @@
 		checked = $bindable(false),
 		indeterminate = $bindable(false),
 		class: className,
+		inset,
 		children: childrenProp,
 		...restProps
 	}: WithoutChildrenOrChild<ContextMenuPrimitive.CheckboxItemProps> & {
+		inset?: boolean;
 		children?: Snippet;
 	} = $props();
 </script>
@@ -21,18 +23,17 @@
 	bind:checked
 	bind:indeterminate
 	data-slot="context-menu-checkbox-item"
+	data-inset={inset}
 	class={cn(
-		"data-highlighted:bg-accent data-highlighted:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 ps-8 pe-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-		className,
+		"focus:bg-accent focus:text-accent-foreground gap-2.5 rounded-2xl py-2 pr-8 pl-3 text-sm font-medium data-inset:pl-9.5 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
 	)}
 	{...restProps}
 >
 	{#snippet children({ checked })}
-		<span
-			class="pointer-events-none absolute start-2 flex size-3.5 items-center justify-center"
-		>
+		<span class="absolute right-2 pointer-events-none">
 			{#if checked}
-				<CheckIcon class="size-4" />
+				<CheckIcon />
 			{/if}
 		</span>
 		{@render childrenProp?.()}

--- a/packages/ui/src/context-menu/context-menu-content.svelte
+++ b/packages/ui/src/context-menu/context-menu-content.svelte
@@ -22,8 +22,8 @@
 		bind:ref
 		data-slot="context-menu-content"
 		class={cn(
-			'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-end-2 data-[side=right]:slide-in-from-start-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--bits-context-menu-content-available-height) min-w-[8rem] origin-(--bits-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
-			className,
+			"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/5 dark:ring-foreground/10 bg-popover text-popover-foreground min-w-48 rounded-3xl p-1.5 shadow-lg ring-1 duration-100 z-50 overflow-x-hidden overflow-y-auto outline-none",
+			className
 		)}
 		{...restProps}
 	/>

--- a/packages/ui/src/context-menu/context-menu-group-heading.svelte
+++ b/packages/ui/src/context-menu/context-menu-group-heading.svelte
@@ -16,9 +16,6 @@
 	bind:ref
 	data-slot="context-menu-group-heading"
 	data-inset={inset}
-	class={cn(
-		'text-foreground px-2 py-1.5 text-sm font-medium data-[inset]:ps-8',
-		className,
-	)}
+	class={cn("text-foreground px-2 py-1.5 text-sm font-medium data-inset:ps-8", className)}
 	{...restProps}
 />

--- a/packages/ui/src/context-menu/context-menu-item.svelte
+++ b/packages/ui/src/context-menu/context-menu-item.svelte
@@ -20,8 +20,8 @@
 	data-inset={inset}
 	data-variant={variant}
 	class={cn(
-		"data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:data-highlighted:bg-destructive/10 dark:data-[variant=destructive]:data-highlighted:bg-destructive/20 data-[variant=destructive]:data-highlighted:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:ps-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-		className,
+		"focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive focus:*:[svg]:text-accent-foreground gap-2.5 rounded-2xl px-3 py-2 text-sm font-medium data-inset:pl-9.5 [&_svg:not([class*='size-'])]:size-4 group/context-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
 	)}
 	{...restProps}
 />

--- a/packages/ui/src/context-menu/context-menu-label.svelte
+++ b/packages/ui/src/context-menu/context-menu-label.svelte
@@ -17,10 +17,7 @@
 	bind:this={ref}
 	data-slot="context-menu-label"
 	data-inset={inset}
-	class={cn(
-		'text-foreground px-2 py-1.5 text-sm font-medium data-[inset]:ps-8',
-		className,
-	)}
+	class={cn("text-muted-foreground px-3 py-2.5 text-xs data-inset:pl-9.5 data-inset:pl-8", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/context-menu/context-menu-radio-item.svelte
+++ b/packages/ui/src/context-menu/context-menu-radio-item.svelte
@@ -1,31 +1,33 @@
 <script lang="ts">
-	import CircleIcon from '@lucide/svelte/icons/circle';
+	import CheckIcon from '@lucide/svelte/icons/check';
 	import { ContextMenu as ContextMenuPrimitive } from 'bits-ui';
 	import { cn, type WithoutChild } from '#/utils.js';
 
 	let {
 		ref = $bindable(null),
 		class: className,
+		inset,
 		children: childrenProp,
 		...restProps
-	}: WithoutChild<ContextMenuPrimitive.RadioItemProps> = $props();
+	}: WithoutChild<ContextMenuPrimitive.RadioItemProps> & {
+		inset?: boolean;
+	} = $props();
 </script>
 
 <ContextMenuPrimitive.RadioItem
 	bind:ref
 	data-slot="context-menu-radio-item"
+	data-inset={inset}
 	class={cn(
-		"data-highlighted:bg-accent data-highlighted:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 ps-8 pe-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-		className,
+		"focus:bg-accent focus:text-accent-foreground gap-2.5 rounded-2xl py-2 pr-8 pl-3 text-sm font-medium data-inset:pl-9.5 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
 	)}
 	{...restProps}
 >
 	{#snippet children({ checked })}
-		<span
-			class="pointer-events-none absolute start-2 flex size-3.5 items-center justify-center"
-		>
+		<span class="absolute right-2 pointer-events-none">
 			{#if checked}
-				<CircleIcon class="size-2 fill-current" />
+				<CheckIcon />
 			{/if}
 		</span>
 		{@render childrenProp?.({ checked })}

--- a/packages/ui/src/context-menu/context-menu-separator.svelte
+++ b/packages/ui/src/context-menu/context-menu-separator.svelte
@@ -12,6 +12,6 @@
 <ContextMenuPrimitive.Separator
 	bind:ref
 	data-slot="context-menu-separator"
-	class={cn('bg-border -mx-1 my-1 h-px', className)}
+	class={cn("bg-border/50 -mx-1.5 my-1.5 h-px", className)}
 	{...restProps}
 />

--- a/packages/ui/src/context-menu/context-menu-shortcut.svelte
+++ b/packages/ui/src/context-menu/context-menu-shortcut.svelte
@@ -13,7 +13,7 @@
 <span
 	bind:this={ref}
 	data-slot="context-menu-shortcut"
-	class={cn('text-muted-foreground ms-auto text-xs tracking-widest', className)}
+	class={cn("text-muted-foreground group-focus/context-menu-item:text-accent-foreground ml-auto text-xs tracking-widest", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/context-menu/context-menu-sub-content.svelte
+++ b/packages/ui/src/context-menu/context-menu-sub-content.svelte
@@ -12,9 +12,6 @@
 <ContextMenuPrimitive.SubContent
 	bind:ref
 	data-slot="context-menu-sub-content"
-	class={cn(
-		'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-end-2 data-[side=right]:slide-in-from-start-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--bits-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
-		className,
-	)}
+	class={cn("data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/5 dark:ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-3xl p-1.5 shadow-lg ring-1 duration-100", className)}
 	{...restProps}
 />

--- a/packages/ui/src/context-menu/context-menu-sub-trigger.svelte
+++ b/packages/ui/src/context-menu/context-menu-sub-trigger.svelte
@@ -19,11 +19,11 @@
 	data-slot="context-menu-sub-trigger"
 	data-inset={inset}
 	class={cn(
-		"data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:ps-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-		className,
+		"focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground rounded-2xl px-3 py-2 text-sm font-medium data-inset:pl-9.5 [&_svg:not([class*='size-'])]:size-4 flex cursor-default items-center outline-hidden select-none data-inset:ps-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
 	)}
 	{...restProps}
 >
 	{@render children?.()}
-	<ChevronRightIcon class="ms-auto" />
+	<ChevronRightIcon class="ml-auto" />
 </ContextMenuPrimitive.SubTrigger>

--- a/packages/ui/src/context-menu/context-menu-trigger.svelte
+++ b/packages/ui/src/context-menu/context-menu-trigger.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import { ContextMenu as ContextMenuPrimitive } from 'bits-ui';
+	import { cn } from '#/utils.js';
 
 	let {
 		ref = $bindable(null),
+		class: className,
 		...restProps
 	}: ContextMenuPrimitive.TriggerProps = $props();
 </script>
@@ -10,5 +12,6 @@
 <ContextMenuPrimitive.Trigger
 	bind:ref
 	data-slot="context-menu-trigger"
+	class={cn("cn-context-menu-trigger select-none", className)}
 	{...restProps}
 />

--- a/packages/ui/src/dialog/dialog-close.svelte
+++ b/packages/ui/src/dialog/dialog-close.svelte
@@ -1,8 +1,16 @@
 <script lang="ts">
 	import { Dialog as DialogPrimitive } from 'bits-ui';
 
-	let { ref = $bindable(null), ...restProps }: DialogPrimitive.CloseProps =
-		$props();
+	let {
+		ref = $bindable(null),
+		type = 'button',
+		...restProps
+	}: DialogPrimitive.CloseProps = $props();
 </script>
 
-<DialogPrimitive.Close bind:ref data-slot="dialog-close" {...restProps} />
+<DialogPrimitive.Close
+	bind:ref
+	data-slot="dialog-close"
+	{type}
+	{...restProps}
+/>

--- a/packages/ui/src/dialog/dialog-content.svelte
+++ b/packages/ui/src/dialog/dialog-content.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import XIcon from '@lucide/svelte/icons/x';
 	import { Dialog as DialogPrimitive } from 'bits-ui';
-	import type { Snippet } from 'svelte';
+	import type { ComponentProps, Snippet } from 'svelte';
+	import { Button } from '#/button/index.js';
 	import { cn, type WithoutChildrenOrChild } from '#/utils.js';
+	import DialogPortal from './dialog-portal.svelte';
 	import * as Dialog from './index.js';
 
 	let {
@@ -13,36 +15,43 @@
 		showCloseButton = true,
 		...restProps
 	}: WithoutChildrenOrChild<DialogPrimitive.ContentProps> & {
-		portalProps?: DialogPrimitive.PortalProps;
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof DialogPortal>>;
 		children: Snippet;
 		showCloseButton?: boolean;
 	} = $props();
 </script>
 
-<Dialog.Portal {...portalProps}>
+<DialogPortal {...portalProps}>
 	<Dialog.Overlay />
 	<DialogPrimitive.Content
 		bind:ref
 		data-slot="dialog-content"
 		class={cn(
-			'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed start-[50%] top-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+			"bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/5 dark:ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-6 rounded-4xl p-6 text-sm shadow-xl ring-1 duration-100 sm:max-w-md fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
 			// Custom: Enable scrolling for dialogs with tall content. max-h limits height to viewport
 			// minus breathing room, overflow-y-auto enables vertical scroll only when needed.
-			'overflow-y-auto max-h-[calc(100vh-2rem)]',
+			"max-h-[calc(100vh-2rem)] overflow-y-auto",
 			// Custom: Override to z-40 to ensure alert-dialogs (z-50) appear above regular dialogs
-			'z-40',
+			"z-40",
 			className,
 		)}
 		{...restProps}
 	>
 		{@render children?.()}
 		{#if showCloseButton}
-			<DialogPrimitive.Close
-				class="ring-offset-background focus:ring-ring rounded-xs focus:outline-hidden absolute end-4 top-4 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0"
-			>
-				<XIcon />
-				<span class="sr-only">Close</span>
+			<DialogPrimitive.Close data-slot="dialog-close">
+				{#snippet child({ props })}
+					<Button
+						variant="ghost"
+						class="bg-secondary absolute top-4 right-4"
+						size="icon-sm"
+						{...props}
+					>
+						<XIcon />
+						<span class="sr-only">Close</span>
+					</Button>
+				{/snippet}
 			</DialogPrimitive.Close>
 		{/if}
 	</DialogPrimitive.Content>
-</Dialog.Portal>
+</DialogPortal>

--- a/packages/ui/src/dialog/dialog-description.svelte
+++ b/packages/ui/src/dialog/dialog-description.svelte
@@ -12,6 +12,6 @@
 <DialogPrimitive.Description
 	bind:ref
 	data-slot="dialog-description"
-	class={cn('text-muted-foreground text-sm', className)}
+	class={cn("text-muted-foreground *:[a]:hover:text-foreground text-sm *:[a]:underline *:[a]:underline-offset-3", className)}
 	{...restProps}
 />

--- a/packages/ui/src/dialog/dialog-footer.svelte
+++ b/packages/ui/src/dialog/dialog-footer.svelte
@@ -1,23 +1,32 @@
 <script lang="ts">
+	import { Dialog as DialogPrimitive } from 'bits-ui';
 	import type { HTMLAttributes } from 'svelte/elements';
+	import { Button } from '#/button/index.js';
 	import { cn, type WithElementRef } from '#/utils.js';
 
 	let {
 		ref = $bindable(null),
 		class: className,
 		children,
+		showCloseButton = false,
 		...restProps
-	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		showCloseButton?: boolean;
+	} = $props();
 </script>
 
 <div
 	bind:this={ref}
 	data-slot="dialog-footer"
-	class={cn(
-		'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
-		className,
-	)}
+	class={cn("gap-2 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
 	{...restProps}
 >
 	{@render children?.()}
+	{#if showCloseButton}
+		<DialogPrimitive.Close>
+			{#snippet child({ props })}
+				<Button variant="outline" {...props}>Close</Button>
+			{/snippet}
+		</DialogPrimitive.Close>
+	{/if}
 </div>

--- a/packages/ui/src/dialog/dialog-header.svelte
+++ b/packages/ui/src/dialog/dialog-header.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="dialog-header"
-	class={cn('flex flex-col gap-2 text-center sm:text-start', className)}
+	class={cn("gap-1.5 flex flex-col", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/dialog/dialog-overlay.svelte
+++ b/packages/ui/src/dialog/dialog-overlay.svelte
@@ -13,9 +13,9 @@
 	bind:ref
 	data-slot="dialog-overlay"
 	class={cn(
-		'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+		"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/30 duration-100 supports-backdrop-filter:backdrop-blur-sm fixed inset-0 isolate z-50",
 		// Override to z-40 to ensure that alert-dialogs (which are at z-50) are always on top of dialogs
-		'z-40',
+		"z-40",
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/dialog/dialog-portal.svelte
+++ b/packages/ui/src/dialog/dialog-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Dialog as DialogPrimitive } from 'bits-ui';
+
+	let { ...restProps }: DialogPrimitive.PortalProps = $props();
+</script>
+
+<DialogPrimitive.Portal {...restProps} />

--- a/packages/ui/src/dialog/dialog-title.svelte
+++ b/packages/ui/src/dialog/dialog-title.svelte
@@ -12,6 +12,6 @@
 <DialogPrimitive.Title
 	bind:ref
 	data-slot="dialog-title"
-	class={cn('text-lg font-semibold leading-none', className)}
+	class={cn("font-heading text-base leading-none font-medium", className)}
 	{...restProps}
 />

--- a/packages/ui/src/dialog/dialog-trigger.svelte
+++ b/packages/ui/src/dialog/dialog-trigger.svelte
@@ -1,8 +1,16 @@
 <script lang="ts">
 	import { Dialog as DialogPrimitive } from 'bits-ui';
 
-	let { ref = $bindable(null), ...restProps }: DialogPrimitive.TriggerProps =
-		$props();
+	let {
+		ref = $bindable(null),
+		type = 'button',
+		...restProps
+	}: DialogPrimitive.TriggerProps = $props();
 </script>
 
-<DialogPrimitive.Trigger bind:ref data-slot="dialog-trigger" {...restProps} />
+<DialogPrimitive.Trigger
+	bind:ref
+	data-slot="dialog-trigger"
+	{type}
+	{...restProps}
+/>

--- a/packages/ui/src/dialog/dialog.svelte
+++ b/packages/ui/src/dialog/dialog.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	import { Dialog as DialogPrimitive } from 'bits-ui';
+
+	let { open = $bindable(false), ...restProps }: DialogPrimitive.RootProps =
+		$props();
+</script>
+
+<DialogPrimitive.Root bind:open {...restProps} />

--- a/packages/ui/src/dialog/index.ts
+++ b/packages/ui/src/dialog/index.ts
@@ -1,15 +1,13 @@
-import { Dialog as DialogPrimitive } from 'bits-ui';
+import Root from './dialog.svelte';
 import Close from './dialog-close.svelte';
 import Content from './dialog-content.svelte';
 import Description from './dialog-description.svelte';
 import Footer from './dialog-footer.svelte';
 import Header from './dialog-header.svelte';
 import Overlay from './dialog-overlay.svelte';
+import Portal from './dialog-portal.svelte';
 import Title from './dialog-title.svelte';
 import Trigger from './dialog-trigger.svelte';
-
-const Root = DialogPrimitive.Root;
-const Portal = DialogPrimitive.Portal;
 
 export {
 	Close,

--- a/packages/ui/src/drawer/drawer-content.svelte
+++ b/packages/ui/src/drawer/drawer-content.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
+	import type { ComponentProps } from 'svelte';
 	import { Drawer as DrawerPrimitive } from 'vaul-svelte';
+	import type { WithoutChildrenOrChild } from '#/utils.js';
 	import { cn } from '#/utils.js';
 	import DrawerOverlay from './drawer-overlay.svelte';
+	import DrawerPortal from './drawer-portal.svelte';
 
 	let {
 		ref = $bindable(null),
@@ -10,11 +13,11 @@
 		children,
 		...restProps
 	}: DrawerPrimitive.ContentProps & {
-		portalProps?: DrawerPrimitive.PortalProps;
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof DrawerPortal>>;
 	} = $props();
 </script>
 
-<DrawerPrimitive.Portal {...portalProps}>
+<DrawerPortal {...portalProps}>
 	<DrawerOverlay />
 	<!-- TODO: Remove onOpenAutoFocus workaround when vaul-svelte releases a version compatible with bits-ui 2.x.
 	     vaul-svelte 1.0.0-next.7 depends on bits-ui ^1.1.0, causing an infinite handleFocus recursion
@@ -24,22 +27,18 @@
 		onOpenAutoFocus={(e) => e.preventDefault()}
 		data-slot="drawer-content"
 		class={cn(
-			'group/drawer-content bg-background fixed z-50 flex h-auto flex-col',
-			'data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b',
-			'data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t',
-			'data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:end-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-s data-[vaul-drawer-direction=right]:sm:max-w-sm',
-			'data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:start-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-e data-[vaul-drawer-direction=left]:sm:max-w-sm',
+			"before:bg-popover before:border-border relative flex h-auto flex-col bg-transparent p-4 text-sm before:absolute before:inset-2 before:-z-10 before:rounded-4xl before:border before:shadow-xl data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=left]:sm:max-w-sm data-[vaul-drawer-direction=right]:sm:max-w-sm group/drawer-content fixed z-50",
 			// Override to z-40 to ensure that alert-dialogs (which are at z-50) are always on top of drawers
-			'z-40',
+			"z-40",
 			className,
 		)}
 		{...restProps}
 	>
 		<div
-			class="bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block"
+			class="bg-muted mx-auto mt-4 hidden h-1.5 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block"
 		></div>
 		<!-- Custom: Scrollable content area. flex-1 takes remaining space after drag handle,
 		     overflow-y-auto enables vertical scrolling when content exceeds drawer height. -->
 		<div class="flex-1 overflow-y-auto">{@render children?.()}</div>
 	</DrawerPrimitive.Content>
-</DrawerPrimitive.Portal>
+</DrawerPortal>

--- a/packages/ui/src/drawer/drawer-description.svelte
+++ b/packages/ui/src/drawer/drawer-description.svelte
@@ -12,6 +12,6 @@
 <DrawerPrimitive.Description
 	bind:ref
 	data-slot="drawer-description"
-	class={cn('text-muted-foreground text-sm', className)}
+	class={cn("text-muted-foreground text-sm", className)}
 	{...restProps}
 />

--- a/packages/ui/src/drawer/drawer-footer.svelte
+++ b/packages/ui/src/drawer/drawer-footer.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="drawer-footer"
-	class={cn('mt-auto flex flex-col gap-2 p-4', className)}
+	class={cn("gap-2 p-4 mt-auto flex flex-col", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/drawer/drawer-header.svelte
+++ b/packages/ui/src/drawer/drawer-header.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="drawer-header"
-	class={cn('flex flex-col gap-1.5 p-4', className)}
+	class={cn("gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-1.5 md:text-left flex flex-col", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/drawer/drawer-overlay.svelte
+++ b/packages/ui/src/drawer/drawer-overlay.svelte
@@ -13,9 +13,9 @@
 	bind:ref
 	data-slot="drawer-overlay"
 	class={cn(
-		'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+		"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/30 supports-backdrop-filter:backdrop-blur-sm fixed inset-0 z-50",
 		// Override to z-40 to ensure that alert-dialogs (which are at z-50) are always on top of drawers
-		'z-40',
+		"z-40",
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/drawer/drawer-portal.svelte
+++ b/packages/ui/src/drawer/drawer-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Drawer as DrawerPrimitive } from 'vaul-svelte';
+
+	let { ...restProps }: DrawerPrimitive.PortalProps = $props();
+</script>
+
+<DrawerPrimitive.Portal {...restProps} />

--- a/packages/ui/src/drawer/drawer-title.svelte
+++ b/packages/ui/src/drawer/drawer-title.svelte
@@ -12,6 +12,6 @@
 <DrawerPrimitive.Title
 	bind:ref
 	data-slot="drawer-title"
-	class={cn('text-foreground font-semibold', className)}
+	class={cn("font-heading text-foreground text-base font-medium", className)}
 	{...restProps}
 />

--- a/packages/ui/src/drawer/index.ts
+++ b/packages/ui/src/drawer/index.ts
@@ -1,5 +1,3 @@
-import { Drawer as DrawerPrimitive } from 'vaul-svelte';
-
 import Root from './drawer.svelte';
 import Close from './drawer-close.svelte';
 import Content from './drawer-content.svelte';
@@ -8,10 +6,9 @@ import Footer from './drawer-footer.svelte';
 import Header from './drawer-header.svelte';
 import NestedRoot from './drawer-nested.svelte';
 import Overlay from './drawer-overlay.svelte';
+import Portal from './drawer-portal.svelte';
 import Title from './drawer-title.svelte';
 import Trigger from './drawer-trigger.svelte';
-
-const Portal: typeof DrawerPrimitive.Portal = DrawerPrimitive.Portal;
 
 export {
 	Close,

--- a/packages/ui/src/dropdown-menu/dropdown-menu-checkbox-group.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-checkbox-group.svelte
@@ -3,7 +3,7 @@
 
 	let {
 		ref = $bindable(null),
-		value = $bindable(),
+		value = $bindable([]),
 		...restProps
 	}: DropdownMenuPrimitive.CheckboxGroupProps = $props();
 </script>

--- a/packages/ui/src/dropdown-menu/dropdown-menu-checkbox-item.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-checkbox-item.svelte
@@ -23,19 +23,20 @@
 	bind:indeterminate
 	data-slot="dropdown-menu-checkbox-item"
 	class={cn(
-		"focus:bg-accent focus:text-accent-foreground outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pe-2 ps-8 text-sm data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-		className,
+		"focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-2.5 rounded-2xl py-2 pr-8 pl-3 text-sm font-medium data-inset:pl-9.5 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
 	)}
 	{...restProps}
 >
 	{#snippet children({ checked, indeterminate })}
 		<span
-			class="pointer-events-none absolute start-2 flex size-3.5 items-center justify-center"
+			class="absolute right-2 flex items-center justify-center pointer-events-none"
+			data-slot="dropdown-menu-checkbox-item-indicator"
 		>
 			{#if indeterminate}
-				<MinusIcon class="size-4" />
-			{:else}
-				<CheckIcon class={cn('size-4', !checked && 'text-transparent')} />
+				<MinusIcon />
+			{:else if checked}
+				<CheckIcon />
 			{/if}
 		</span>
 		{@render childrenProp?.()}

--- a/packages/ui/src/dropdown-menu/dropdown-menu-content.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-content.svelte
@@ -1,27 +1,33 @@
 <script lang="ts">
 	import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
-	import { cn } from '#/utils.js';
+	import type { ComponentProps } from 'svelte';
+	import { cn, type WithoutChildrenOrChild } from '#/utils.js';
+	import DropdownMenuPortal from './dropdown-menu-portal.svelte';
 
 	let {
 		ref = $bindable(null),
 		sideOffset = 4,
+		align = 'start',
 		portalProps,
 		class: className,
 		...restProps
 	}: DropdownMenuPrimitive.ContentProps & {
-		portalProps?: DropdownMenuPrimitive.PortalProps;
+		portalProps?: WithoutChildrenOrChild<
+			ComponentProps<typeof DropdownMenuPortal>
+		>;
 	} = $props();
 </script>
 
-<DropdownMenuPrimitive.Portal {...portalProps}>
+<DropdownMenuPortal {...portalProps}>
 	<DropdownMenuPrimitive.Content
 		bind:ref
 		data-slot="dropdown-menu-content"
 		{sideOffset}
+		{align}
 		class={cn(
-			'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-end-2 data-[side=right]:slide-in-from-start-2 data-[side=top]:slide-in-from-bottom-2 max-h-(--bits-dropdown-menu-content-available-height) origin-(--bits-dropdown-menu-content-transform-origin) z-50 min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border p-1 shadow-md outline-none',
-			className,
+			"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/5 dark:ring-foreground/10 bg-popover text-popover-foreground min-w-48 rounded-3xl p-1.5 shadow-lg ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-50 w-(--bits-dropdown-menu-anchor-width) overflow-x-hidden overflow-y-auto outline-none data-closed:overflow-hidden",
+			className
 		)}
 		{...restProps}
 	/>
-</DropdownMenuPrimitive.Portal>
+</DropdownMenuPortal>

--- a/packages/ui/src/dropdown-menu/dropdown-menu-group-heading.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-group-heading.svelte
@@ -17,6 +17,6 @@
 	bind:ref
 	data-slot="dropdown-menu-group-heading"
 	data-inset={inset}
-	class={cn('px-2 py-1.5 text-sm font-semibold data-[inset]:ps-8', className)}
+	class={cn("px-2 py-1.5 text-sm font-semibold data-[inset]:ps-8", className)}
 	{...restProps}
 />

--- a/packages/ui/src/dropdown-menu/dropdown-menu-item.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-item.svelte
@@ -20,8 +20,8 @@
 	data-inset={inset}
 	data-variant={variant}
 	class={cn(
-		"data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:data-highlighted:bg-destructive/10 dark:data-[variant=destructive]:data-highlighted:bg-destructive/20 data-[variant=destructive]:data-highlighted:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm data-[disabled]:pointer-events-none data-[inset]:ps-8 data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-		className,
+		"focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive not-data-[variant=destructive]:focus:**:text-accent-foreground gap-2.5 rounded-2xl px-3 py-2 text-sm font-medium data-inset:pl-9.5 [&_svg:not([class*='size-'])]:size-4 group/dropdown-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
 	)}
 	{...restProps}
 />

--- a/packages/ui/src/dropdown-menu/dropdown-menu-label.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-label.svelte
@@ -17,7 +17,7 @@
 	bind:this={ref}
 	data-slot="dropdown-menu-label"
 	data-inset={inset}
-	class={cn('px-2 py-1.5 text-sm font-semibold data-[inset]:ps-8', className)}
+	class={cn("text-muted-foreground px-3 py-2.5 text-xs data-inset:pl-9.5 data-[inset]:pl-8", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/dropdown-menu/dropdown-menu-portal.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+
+	let { ...restProps }: DropdownMenuPrimitive.PortalProps = $props();
+</script>
+
+<DropdownMenuPrimitive.Portal {...restProps} />

--- a/packages/ui/src/dropdown-menu/dropdown-menu-radio-item.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-radio-item.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import CircleIcon from '@lucide/svelte/icons/circle';
+	import CheckIcon from '@lucide/svelte/icons/check';
 	import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
 	import { cn, type WithoutChild } from '#/utils.js';
 
@@ -15,17 +15,18 @@
 	bind:ref
 	data-slot="dropdown-menu-radio-item"
 	class={cn(
-		"focus:bg-accent focus:text-accent-foreground outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pe-2 ps-8 text-sm data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-		className,
+		"focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-2.5 rounded-2xl py-2 pr-8 pl-3 text-sm font-medium data-inset:pl-9.5 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
 	)}
 	{...restProps}
 >
 	{#snippet children({ checked })}
 		<span
-			class="pointer-events-none absolute start-2 flex size-3.5 items-center justify-center"
+			class="absolute right-2 flex items-center justify-center pointer-events-none"
+			data-slot="dropdown-menu-radio-item-indicator"
 		>
 			{#if checked}
-				<CircleIcon class="size-2 fill-current" />
+				<CheckIcon />
 			{/if}
 		</span>
 		{@render childrenProp?.({ checked })}

--- a/packages/ui/src/dropdown-menu/dropdown-menu-separator.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-separator.svelte
@@ -12,6 +12,6 @@
 <DropdownMenuPrimitive.Separator
 	bind:ref
 	data-slot="dropdown-menu-separator"
-	class={cn('bg-border -mx-1 my-1 h-px', className)}
+	class={cn("bg-border/50 -mx-1.5 my-1.5 h-px", className)}
 	{...restProps}
 />

--- a/packages/ui/src/dropdown-menu/dropdown-menu-shortcut.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-shortcut.svelte
@@ -13,7 +13,7 @@
 <span
 	bind:this={ref}
 	data-slot="dropdown-menu-shortcut"
-	class={cn('text-muted-foreground ms-auto text-xs tracking-widest', className)}
+	class={cn("text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground ml-auto text-xs tracking-widest", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/dropdown-menu/dropdown-menu-sub-content.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-sub-content.svelte
@@ -12,9 +12,6 @@
 <DropdownMenuPrimitive.SubContent
 	bind:ref
 	data-slot="dropdown-menu-sub-content"
-	class={cn(
-		'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-end-2 data-[side=right]:slide-in-from-start-2 data-[side=top]:slide-in-from-bottom-2 origin-(--bits-dropdown-menu-content-transform-origin) z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-lg',
-		className,
-	)}
+	class={cn("data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/5 dark:ring-foreground/10 bg-popover text-popover-foreground min-w-36 rounded-3xl p-1.5 shadow-lg ring-1 duration-100 w-auto", className)}
 	{...restProps}
 />

--- a/packages/ui/src/dropdown-menu/dropdown-menu-sub-trigger.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-sub-trigger.svelte
@@ -19,11 +19,11 @@
 	data-slot="dropdown-menu-sub-trigger"
 	data-inset={inset}
 	class={cn(
-		"data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground outline-hidden [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm data-[disabled]:pointer-events-none data-[inset]:ps-8 data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-		className,
+		"focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-2 rounded-2xl px-3 py-2 text-sm font-medium data-inset:pl-9.5 [&_svg:not([class*='size-'])]:size-4 flex cursor-default items-center outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
 	)}
 	{...restProps}
 >
 	{@render children?.()}
-	<ChevronRightIcon class="ms-auto size-4" />
+	<ChevronRightIcon class="ml-auto" />
 </DropdownMenuPrimitive.SubTrigger>

--- a/packages/ui/src/dropdown-menu/dropdown-menu-sub.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu-sub.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+
+	let {
+		open = $bindable(false),
+		...restProps
+	}: DropdownMenuPrimitive.SubProps = $props();
+</script>
+
+<DropdownMenuPrimitive.Sub bind:open {...restProps} />

--- a/packages/ui/src/dropdown-menu/dropdown-menu.svelte
+++ b/packages/ui/src/dropdown-menu/dropdown-menu.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+
+	let {
+		open = $bindable(false),
+		...restProps
+	}: DropdownMenuPrimitive.RootProps = $props();
+</script>
+
+<DropdownMenuPrimitive.Root bind:open {...restProps} />

--- a/packages/ui/src/dropdown-menu/index.ts
+++ b/packages/ui/src/dropdown-menu/index.ts
@@ -1,4 +1,4 @@
-import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+import Root from './dropdown-menu.svelte';
 import CheckboxGroup from './dropdown-menu-checkbox-group.svelte';
 import CheckboxItem from './dropdown-menu-checkbox-item.svelte';
 import Content from './dropdown-menu-content.svelte';
@@ -6,16 +6,15 @@ import Group from './dropdown-menu-group.svelte';
 import GroupHeading from './dropdown-menu-group-heading.svelte';
 import Item from './dropdown-menu-item.svelte';
 import Label from './dropdown-menu-label.svelte';
+import Portal from './dropdown-menu-portal.svelte';
 import RadioGroup from './dropdown-menu-radio-group.svelte';
 import RadioItem from './dropdown-menu-radio-item.svelte';
 import Separator from './dropdown-menu-separator.svelte';
 import Shortcut from './dropdown-menu-shortcut.svelte';
+import Sub from './dropdown-menu-sub.svelte';
 import SubContent from './dropdown-menu-sub-content.svelte';
 import SubTrigger from './dropdown-menu-sub-trigger.svelte';
 import Trigger from './dropdown-menu-trigger.svelte';
-
-const Sub = DropdownMenuPrimitive.Sub;
-const Root = DropdownMenuPrimitive.Root;
 
 export {
 	CheckboxGroup,
@@ -32,6 +31,8 @@ export {
 	Item,
 	Label as DropdownMenuLabel,
 	Label,
+	Portal,
+	Portal as DropdownMenuPortal,
 	RadioGroup as DropdownMenuRadioGroup,
 	RadioGroup,
 	RadioItem as DropdownMenuRadioItem,

--- a/packages/ui/src/empty/empty-content.svelte
+++ b/packages/ui/src/empty/empty-content.svelte
@@ -14,8 +14,8 @@
 	bind:this={ref}
 	data-slot="empty-content"
 	class={cn(
-		'flex w-full min-w-0 max-w-sm flex-col items-center gap-4 text-balance text-sm',
-		className,
+		"gap-4 text-sm flex w-full max-w-sm min-w-0 flex-col items-center text-balance",
+		className
 	)}
 	{...restProps}
 >

--- a/packages/ui/src/empty/empty-description.svelte
+++ b/packages/ui/src/empty/empty-description.svelte
@@ -14,8 +14,8 @@
 	bind:this={ref}
 	data-slot="empty-description"
 	class={cn(
-		'text-muted-foreground [&>a:hover]:text-primary text-sm/relaxed [&>a]:underline [&>a]:underline-offset-4',
-		className,
+		"text-sm/relaxed text-muted-foreground [&>a:hover]:text-primary text-sm/relaxed [&>a]:underline [&>a]:underline-offset-4",
+		className
 	)}
 	{...restProps}
 >

--- a/packages/ui/src/empty/empty-header.svelte
+++ b/packages/ui/src/empty/empty-header.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="empty-header"
-	class={cn('flex max-w-sm flex-col items-center gap-2 text-center', className)}
+	class={cn("gap-2 flex max-w-sm flex-col items-center", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/empty/empty-media.svelte
+++ b/packages/ui/src/empty/empty-media.svelte
@@ -6,7 +6,7 @@
 		variants: {
 			variant: {
 				default: 'bg-transparent',
-				icon: "bg-muted text-foreground flex size-10 shrink-0 items-center justify-center rounded-lg [&_svg:not([class*='size-'])]:size-6",
+				icon: "bg-muted text-foreground flex size-10 shrink-0 items-center justify-center rounded-xl [&_svg:not([class*='size-'])]:size-5",
 			},
 		},
 		defaultVariants: {

--- a/packages/ui/src/empty/empty-title.svelte
+++ b/packages/ui/src/empty/empty-title.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="empty-title"
-	class={cn('text-lg font-medium tracking-tight', className)}
+	class={cn("font-heading text-lg font-medium tracking-tight", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/empty/empty.svelte
+++ b/packages/ui/src/empty/empty.svelte
@@ -14,8 +14,8 @@
 	bind:this={ref}
 	data-slot="empty"
 	class={cn(
-		'flex min-w-0 flex-1 flex-col items-center justify-center gap-6 text-balance rounded-lg border-dashed p-6 text-center md:p-12',
-		className,
+		"gap-4 rounded-2xl border-dashed p-12 flex w-full min-w-0 flex-1 flex-col items-center justify-center text-center text-balance",
+		className
 	)}
 	{...restProps}
 >

--- a/packages/ui/src/field/field-content.svelte
+++ b/packages/ui/src/field/field-content.svelte
@@ -13,10 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="field-content"
-	class={cn(
-		'group/field-content flex flex-1 flex-col gap-1.5 leading-snug',
-		className,
-	)}
+	class={cn("gap-1 group/field-content flex flex-1 flex-col leading-snug", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/field/field-description.svelte
+++ b/packages/ui/src/field/field-description.svelte
@@ -14,10 +14,10 @@
 	bind:this={ref}
 	data-slot="field-description"
 	class={cn(
-		'text-muted-foreground text-sm font-normal leading-normal group-has-[[data-orientation=horizontal]]/field:text-balance',
-		'nth-last-2:-mt-1 last:mt-0 [[data-variant=legend]+&]:-mt-1.5',
-		'[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4',
-		className,
+		"text-muted-foreground text-left text-sm [[data-variant=legend]+&]:-mt-1.5 leading-normal font-normal group-has-[[data-orientation=horizontal]]/field:text-balance",
+		"last:mt-0 nth-last-2:-mt-1",
+		"[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4",
+		className
 	)}
 	{...restProps}
 >

--- a/packages/ui/src/field/field-error.svelte
+++ b/packages/ui/src/field/field-error.svelte
@@ -19,7 +19,7 @@
 		if (children) return true;
 
 		// no errors
-		if (!errors) return false;
+		if (!errors || errors.length === 0) return false;
 
 		// has an error but no message
 		if (errors.length === 1 && !errors[0]?.message) {
@@ -40,7 +40,7 @@
 		bind:this={ref}
 		role="alert"
 		data-slot="field-error"
-		class={cn('text-destructive text-sm font-normal', className)}
+		class={cn("text-destructive text-sm font-normal", className)}
 		{...restProps}
 	>
 		{#if children}
@@ -48,7 +48,7 @@
 		{:else if singleErrorMessage}
 			{singleErrorMessage}
 		{:else if isMultipleErrors}
-			<ul class="ms-4 flex list-disc flex-col gap-1">
+			<ul class="ml-4 flex list-disc flex-col gap-1">
 				{#each errors ?? [] as error, index (index)}
 					{#if error?.message}
 						<li>{error.message}</li>

--- a/packages/ui/src/field/field-group.svelte
+++ b/packages/ui/src/field/field-group.svelte
@@ -14,8 +14,8 @@
 	bind:this={ref}
 	data-slot="field-group"
 	class={cn(
-		'group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 [&>[data-slot=field-group]]:gap-4',
-		className,
+		"gap-7 data-[slot=checkbox-group]:gap-3 *:data-[slot=field-group]:gap-4 group/field-group @container/field-group flex w-full flex-col",
+		className
 	)}
 	{...restProps}
 >

--- a/packages/ui/src/field/field-label.svelte
+++ b/packages/ui/src/field/field-label.svelte
@@ -15,10 +15,9 @@
 	bind:ref
 	data-slot="field-label"
 	class={cn(
-		'group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50',
-		'has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border [&>*]:data-[slot=field]:p-4',
-		'has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10',
-		className,
+		"has-data-checked:bg-input/30 gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-[>[data-slot=field]]:rounded-2xl has-[>[data-slot=field]]:border *:data-[slot=field]:p-4 group/field-label peer/field-label flex w-fit leading-snug",
+		"has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col",
+		className
 	)}
 	{...restProps}
 >

--- a/packages/ui/src/field/field-legend.svelte
+++ b/packages/ui/src/field/field-legend.svelte
@@ -17,12 +17,7 @@
 	bind:this={ref}
 	data-slot="field-legend"
 	data-variant={variant}
-	class={cn(
-		'mb-3 font-medium',
-		'data-[variant=legend]:text-base',
-		'data-[variant=label]:text-sm',
-		className,
-	)}
+	class={cn("mb-3 font-medium data-[variant=label]:text-sm data-[variant=legend]:text-base", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/field/field-separator.svelte
+++ b/packages/ui/src/field/field-separator.svelte
@@ -20,16 +20,13 @@
 	bind:this={ref}
 	data-slot="field-separator"
 	data-content={hasContent}
-	class={cn(
-		'relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2',
-		className,
-	)}
+	class={cn("-my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2 relative", className)}
 	{...restProps}
 >
 	<Separator class="absolute inset-0 top-1/2" />
 	{#if children}
 		<span
-			class="bg-background text-muted-foreground relative mx-auto block w-fit px-2"
+			class="text-muted-foreground px-2 bg-background relative mx-auto block w-fit"
 			data-slot="field-separator-content"
 		>
 			{@render children()}

--- a/packages/ui/src/field/field-set.svelte
+++ b/packages/ui/src/field/field-set.svelte
@@ -13,11 +13,7 @@
 <fieldset
 	bind:this={ref}
 	data-slot="field-set"
-	class={cn(
-		'flex flex-col gap-6',
-		'has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3',
-		className,
-	)}
+	class={cn("gap-6 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3 flex flex-col", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/field/field-title.svelte
+++ b/packages/ui/src/field/field-title.svelte
@@ -12,11 +12,8 @@
 
 <div
 	bind:this={ref}
-	data-slot="field-title"
-	class={cn(
-		'flex w-fit items-center gap-2 text-sm font-medium leading-snug group-data-[disabled=true]/field:opacity-50',
-		className,
-	)}
+	data-slot="field-label"
+	class={cn("font-heading gap-2 text-sm leading-snug font-medium group-data-[disabled=true]/field:opacity-50 flex w-fit items-center leading-snug", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/field/field.svelte
+++ b/packages/ui/src/field/field.svelte
@@ -2,20 +2,15 @@
 	import { tv, type VariantProps } from 'tailwind-variants';
 
 	export const fieldVariants = tv({
-		base: 'group/field data-[invalid=true]:text-destructive flex w-full gap-3',
+		base: 'data-[invalid=true]:text-destructive gap-3 group/field flex w-full',
 		variants: {
 			orientation: {
-				vertical: 'flex-col [&>*]:w-full [&>.sr-only]:w-auto',
-				horizontal: [
-					'flex-row items-center',
-					'[&>[data-slot=field-label]]:flex-auto',
-					'has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px has-[>[data-slot=field-content]]:items-start',
-				],
-				responsive: [
-					'@md/field-group:flex-row @md/field-group:items-center @md/field-group:[&>*]:w-auto flex-col [&>*]:w-full [&>.sr-only]:w-auto',
-					'@md/field-group:[&>[data-slot=field-label]]:flex-auto',
-					'@md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px',
-				],
+				vertical:
+					'cn-field-orientation-vertical flex-col [&>*]:w-full [&>.sr-only]:w-auto',
+				horizontal:
+					'cn-field-orientation-horizontal flex-row items-center has-[>[data-slot=field-content]]:items-start [&>[data-slot=field-label]]:flex-auto has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px',
+				responsive:
+					'cn-field-orientation-responsive flex-col @md/field-group:flex-row @md/field-group:items-center @md/field-group:has-[>[data-slot=field-content]]:items-start [&>*]:w-full @md/field-group:[&>*]:w-auto [&>.sr-only]:w-auto @md/field-group:[&>[data-slot=field-label]]:flex-auto @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px',
 			},
 		},
 		defaultVariants: {

--- a/packages/ui/src/field/index.ts
+++ b/packages/ui/src/field/index.ts
@@ -1,13 +1,11 @@
 import Field from './field.svelte';
 import Content from './field-content.svelte';
 import Description from './field-description.svelte';
-// biome-ignore lint/suspicious/noShadowRestrictedNames: Component name matches its purpose
 import Error from './field-error.svelte';
 import Group from './field-group.svelte';
 import Label from './field-label.svelte';
 import Legend from './field-legend.svelte';
 import Separator from './field-separator.svelte';
-// biome-ignore lint/suspicious/noShadowRestrictedNames: Component name matches its purpose
 import Set from './field-set.svelte';
 import Title from './field-title.svelte';
 

--- a/packages/ui/src/github-button/github-button.svelte
+++ b/packages/ui/src/github-button/github-button.svelte
@@ -18,10 +18,10 @@
 </script>
 
 <script lang="ts">
-	import Button from '#/button/button.svelte';
-	import { cn } from '#/utils';
 	import { cubicInOut } from 'svelte/easing';
 	import { Tween } from 'svelte/motion';
+	import Button from '#/button/button.svelte';
+	import { cn } from '#/utils';
 
 	let {
 		starsTweenedDuration = 5000,

--- a/packages/ui/src/github-button/index.ts
+++ b/packages/ui/src/github-button/index.ts
@@ -16,7 +16,7 @@ import Root from './github-button.svelte';
 export async function getStars({
 	owner,
 	repo: repoName,
-	fallback = 0
+	fallback = 0,
 }: {
 	owner: string;
 	repo: string;

--- a/packages/ui/src/hooks/is-mobile.svelte.ts
+++ b/packages/ui/src/hooks/is-mobile.svelte.ts
@@ -1,0 +1,9 @@
+import { MediaQuery } from 'svelte/reactivity';
+
+const DEFAULT_MOBILE_BREAKPOINT = 768;
+
+export class IsMobile extends MediaQuery {
+	constructor(breakpoint: number = DEFAULT_MOBILE_BREAKPOINT) {
+		super(`max-width: ${breakpoint - 1}px`);
+	}
+}

--- a/packages/ui/src/input-group/input-group-addon.svelte
+++ b/packages/ui/src/input-group/input-group-addon.svelte
@@ -1,17 +1,15 @@
 <script lang="ts" module>
 	import { tv, type VariantProps } from 'tailwind-variants';
 	export const inputGroupAddonVariants = tv({
-		base: "text-muted-foreground flex h-auto cursor-text select-none items-center justify-center gap-2 py-1.5 text-sm font-medium group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
+		base: "text-muted-foreground **:data-[slot=kbd]:bg-muted-foreground/10 h-auto gap-2 py-2 text-sm font-medium group-data-[disabled=true]/input-group:opacity-50 **:data-[slot=kbd]:rounded-3xl **:data-[slot=kbd]:px-1.5 [&>svg:not([class*='size-'])]:size-4 flex cursor-text items-center justify-center select-none",
 		variants: {
 			align: {
-				'inline-start':
-					'order-first ps-3 has-[>button]:ms-[-0.45rem] has-[>kbd]:ms-[-0.35rem]',
-				'inline-end':
-					'order-last pe-3 has-[>button]:me-[-0.45rem] has-[>kbd]:me-[-0.35rem]',
+				'inline-start': 'pl-3 has-[>button]:-ml-1 has-[>kbd]:-ml-1 order-first',
+				'inline-end': 'pr-3 has-[>button]:-mr-1 has-[>kbd]:-mr-1 order-last',
 				'block-start':
-					'[.border-b]:pb-3 order-first w-full justify-start px-3 pt-3 group-has-[>input]/input-group:pt-2.5',
+					'px-3 pt-3 group-has-[>input]/input-group:pt-3.5 [.border-b]:pb-3.5 order-first w-full justify-start',
 				'block-end':
-					'[.border-t]:pt-3 order-last w-full justify-start px-3 pb-3 group-has-[>input]/input-group:pb-2.5',
+					'px-3 pb-3 group-has-[>input]/input-group:pb-3.5 [.border-t]:pt-3.5 order-last w-full justify-start',
 			},
 		},
 		defaultVariants: {
@@ -46,10 +44,10 @@
 	data-align={align}
 	class={cn(inputGroupAddonVariants({ align }), className)}
 	onclick={(e) => {
-		if ((e.target as HTMLElement).closest('button')) {
+		if ((e.target as HTMLElement).closest("button")) {
 			return;
 		}
-		e.currentTarget.parentElement?.querySelector('input')?.focus();
+		e.currentTarget.parentElement?.querySelector("input")?.focus();
 	}}
 	{...restProps}
 >

--- a/packages/ui/src/input-group/input-group-button.svelte
+++ b/packages/ui/src/input-group/input-group-button.svelte
@@ -2,13 +2,12 @@
 	import { tv, type VariantProps } from 'tailwind-variants';
 
 	const inputGroupButtonVariants = tv({
-		base: 'flex items-center gap-2 text-sm shadow-none',
+		base: 'gap-2 rounded-4xl text-sm flex items-center shadow-none',
 		variants: {
 			size: {
-				xs: "h-6 gap-1 rounded-[calc(var(--radius)-5px)] px-2 has-[>svg]:px-2 [&>svg:not([class*='size-'])]:size-3.5",
-				sm: 'h-8 gap-1.5 rounded-md px-2.5 has-[>svg]:px-2.5',
-				'icon-xs':
-					'size-6 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0',
+				xs: "h-6 gap-1 rounded-xl px-1.5 [&>svg:not([class*='size-'])]:size-3.5",
+				sm: 'cn-input-group-button-size-sm',
+				'icon-xs': 'size-6 rounded-xl p-0 has-[>svg]:p-0',
 				'icon-sm': 'size-8 p-0 has-[>svg]:p-0',
 			},
 		},

--- a/packages/ui/src/input-group/input-group-input.svelte
+++ b/packages/ui/src/input-group/input-group-input.svelte
@@ -14,10 +14,7 @@
 <Input
 	bind:ref
 	data-slot="input-group-control"
-	class={cn(
-		'flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0 dark:bg-transparent',
-		className,
-	)}
+	class={cn("rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent flex-1", className)}
 	bind:value
 	{...props}
 />

--- a/packages/ui/src/input-group/input-group-text.svelte
+++ b/packages/ui/src/input-group/input-group-text.svelte
@@ -12,10 +12,7 @@
 
 <span
 	bind:this={ref}
-	class={cn(
-		"text-muted-foreground flex items-center gap-2 text-sm [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none",
-		className,
-	)}
+	class={cn("text-muted-foreground gap-2 text-sm [&_svg:not([class*='size-'])]:size-4 flex items-center [&_svg]:pointer-events-none", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/input-group/input-group-textarea.svelte
+++ b/packages/ui/src/input-group/input-group-textarea.svelte
@@ -14,10 +14,7 @@
 <Textarea
 	bind:ref
 	data-slot="input-group-control"
-	class={cn(
-		'flex-1 resize-none rounded-none border-0 bg-transparent py-3 shadow-none focus-visible:ring-0 dark:bg-transparent',
-		className,
-	)}
+	class={cn("rounded-none border-0 bg-transparent py-2.5 shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent flex-1 resize-none", className)}
 	bind:value
 	{...props}
 />

--- a/packages/ui/src/input-group/input-group.svelte
+++ b/packages/ui/src/input-group/input-group.svelte
@@ -15,22 +15,8 @@
 	data-slot="input-group"
 	role="group"
 	class={cn(
-		'group/input-group border-input dark:bg-input/30 shadow-xs relative flex w-full items-center rounded-md border outline-none transition-[color,box-shadow]',
-		'h-9 has-[>textarea]:h-auto',
-
-		// Variants based on alignment.
-		'has-[>[data-align=inline-start]]:[&>input]:ps-2',
-		'has-[>[data-align=inline-end]]:[&>input]:pe-2',
-		'has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3',
-		'has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3',
-
-		// Focus state.
-		'has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot=input-group-control]:focus-visible]:ring-[3px]',
-
-		// Error state.
-		'has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[[data-slot][aria-invalid=true]]:border-destructive dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40',
-
-		className,
+		"group/input-group bg-input/50 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/30 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[[data-slot][aria-invalid=true]]:border-destructive dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 h-9 rounded-4xl border border-transparent transition-[color,box-shadow,background-color] in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-data-[align=block-end]:rounded-3xl has-data-[align=block-start]:rounded-3xl has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-3 has-[textarea]:rounded-2xl has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5 relative flex w-full min-w-0 items-center outline-none has-[>textarea]:h-auto",
+		className
 	)}
 	{...props}
 >

--- a/packages/ui/src/input/input.svelte
+++ b/packages/ui/src/input/input.svelte
@@ -26,15 +26,13 @@
 	}: Props = $props();
 </script>
 
-{#if type === 'file'}
+{#if type === "file"}
 	<input
 		bind:this={ref}
 		data-slot={dataSlot}
 		class={cn(
-			'selection:bg-primary dark:bg-input/30 selection:text-primary-foreground border-input ring-offset-background placeholder:text-muted-foreground shadow-xs flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 pt-1.5 text-sm font-medium outline-none transition-[color,box-shadow] disabled:cursor-not-allowed disabled:opacity-50',
-			'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
-			'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
-			className,
+			"bg-input/50 focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-9 rounded-3xl border border-transparent px-3 py-1 text-base transition-[color,box-shadow,background-color] file:h-7 file:text-sm file:font-medium focus-visible:ring-3 aria-invalid:ring-3 md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+			className
 		)}
 		type="file"
 		bind:files
@@ -46,10 +44,8 @@
 		bind:this={ref}
 		data-slot={dataSlot}
 		class={cn(
-			'border-input bg-background selection:bg-primary dark:bg-input/30 selection:text-primary-foreground ring-offset-background placeholder:text-muted-foreground shadow-xs flex h-9 w-full min-w-0 rounded-md border px-3 py-1 text-base outline-none transition-[color,box-shadow] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
-			'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
-			'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
-			className,
+			"bg-input/50 focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-9 rounded-3xl border border-transparent px-3 py-1 text-base transition-[color,box-shadow,background-color] file:h-7 file:text-sm file:font-medium focus-visible:ring-3 aria-invalid:ring-3 md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+			className
 		)}
 		{type}
 		bind:value

--- a/packages/ui/src/item/item-actions.svelte
+++ b/packages/ui/src/item/item-actions.svelte
@@ -4,34 +4,16 @@
 
 	let {
 		ref = $bindable(null),
-		showOnHover = false,
 		class: className,
 		children,
 		...restProps
-	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
-		/** When true, actions are hidden by default and shown on hover of the parent `group/item`. */
-		showOnHover?: boolean;
-	} = $props();
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
 </script>
 
 <div
 	bind:this={ref}
 	data-slot="item-actions"
-	class={cn(
-		'flex items-center gap-2',
-		showOnHover && [
-			// Overlay the right side of the item instead of taking flex space, so the
-			// title gets full width when actions are hidden. Solid bg-accent masks the
-			// text underneath — matches the item's hover background.
-			'absolute inset-y-0 right-0 bg-accent pl-2 pr-4',
-			// Fade in/out on hover of the parent group/item.
-			'opacity-0 transition-opacity group-hover/item:opacity-100',
-			// Pseudo-element gradient on the left edge so text fades out smoothly
-			// rather than hard-clipping against the solid background.
-			'before:pointer-events-none before:absolute before:inset-y-0 before:-left-4 before:w-4 before:bg-linear-to-r before:from-transparent before:to-accent',
-		],
-		className,
-	)}
+	class={cn("gap-2 flex items-center", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/item/item-content.svelte
+++ b/packages/ui/src/item/item-content.svelte
@@ -14,9 +14,9 @@
 	bind:this={ref}
 	data-slot="item-content"
 	class={cn(
-		'flex flex-1 flex-col gap-1 [&+[data-slot=item-content]]:flex-none',
+		"gap-1 group-data-[size=xs]/item:gap-0.5 flex flex-1 flex-col [&+[data-slot=item-content]]:flex-none",
 		// Custom override: enables text truncation inside flex containers
-		'min-w-0',
+		"min-w-0",
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/item/item-description.svelte
+++ b/packages/ui/src/item/item-description.svelte
@@ -14,9 +14,8 @@
 	bind:this={ref}
 	data-slot="item-description"
 	class={cn(
-		'text-muted-foreground line-clamp-2 text-sm leading-normal font-normal text-balance',
-		'[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4',
-		className,
+		"text-muted-foreground text-left text-sm [&>a:hover]:text-primary line-clamp-2 font-normal [&>a]:underline [&>a]:underline-offset-4",
+		className
 	)}
 	{...restProps}
 >

--- a/packages/ui/src/item/item-footer.svelte
+++ b/packages/ui/src/item/item-footer.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="item-footer"
-	class={cn('flex basis-full items-center justify-between gap-2', className)}
+	class={cn("gap-2 flex basis-full items-center justify-between", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/item/item-group.svelte
+++ b/packages/ui/src/item/item-group.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	role="list"
 	data-slot="item-group"
-	class={cn('group/item-group flex flex-col', className)}
+	class={cn("gap-4 has-data-[size=sm]:gap-2.5 has-data-[size=xs]:gap-2 group/item-group flex w-full flex-col", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/item/item-header.svelte
+++ b/packages/ui/src/item/item-header.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="item-header"
-	class={cn('flex basis-full items-center justify-between gap-2', className)}
+	class={cn("gap-2 flex basis-full items-center justify-between", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/item/item-media.svelte
+++ b/packages/ui/src/item/item-media.svelte
@@ -2,13 +2,13 @@
 	import { tv, type VariantProps } from 'tailwind-variants';
 
 	export const itemMediaVariants = tv({
-		base: 'flex shrink-0 items-center justify-center gap-2 group-has-[[data-slot=item-description]]/item:translate-y-0.5 group-has-[[data-slot=item-description]]/item:self-start [&_svg]:pointer-events-none',
+		base: 'gap-2 group-has-data-[slot=item-description]/item:translate-y-0.5 group-has-data-[slot=item-description]/item:self-start flex shrink-0 items-center justify-center [&_svg]:pointer-events-none',
 		variants: {
 			variant: {
 				default: 'bg-transparent',
-				icon: "bg-muted size-8 rounded-sm border [&_svg:not([class*='size-'])]:size-4",
+				icon: "[&_svg:not([class*='size-'])]:size-4",
 				image:
-					'size-10 overflow-hidden rounded-sm [&_img]:size-full [&_img]:object-cover',
+					'size-10 overflow-hidden rounded-xl group-data-[size=sm]/item:size-8 group-data-[size=xs]/item:size-6 group-data-[size=xs]/item:rounded-lg [&_img]:size-full [&_img]:object-cover',
 			},
 		},
 		defaultVariants: {

--- a/packages/ui/src/item/item-separator.svelte
+++ b/packages/ui/src/item/item-separator.svelte
@@ -14,6 +14,6 @@
 	bind:ref
 	data-slot="item-separator"
 	orientation="horizontal"
-	class={cn('my-0', className)}
+	class={cn("my-2", className)}
 	{...restProps}
 />

--- a/packages/ui/src/item/item-title.svelte
+++ b/packages/ui/src/item/item-title.svelte
@@ -14,10 +14,10 @@
 	bind:this={ref}
 	data-slot="item-title"
 	class={cn(
-		'flex items-center gap-2 text-sm leading-snug font-medium',
-		// Custom override: upstream uses `w-fit` here. We use `min-w-0` instead
+		"font-heading gap-2 text-sm leading-snug font-medium underline-offset-4 line-clamp-1 flex w-fit items-center",
+		// Custom override: upstream uses `w-fit` here. We use `w-auto min-w-0` instead
 		// to enable text truncation inside flex containers.
-		'min-w-0',
+		"w-auto min-w-0",
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/item/item.svelte
+++ b/packages/ui/src/item/item.svelte
@@ -3,16 +3,17 @@
 
 	export const itemVariants = tv({
 		// Custom override: `relative` needed for absolute-positioned showOnHover Actions
-		base: 'group/item relative [a]:hover:bg-accent/50 focus-visible:border-ring focus-visible:ring-ring/50 flex flex-wrap items-center rounded-md border border-transparent text-sm transition-colors duration-100 outline-none focus-visible:ring-[3px] [a]:transition-colors',
+		base: 'relative [a]:hover:bg-muted rounded-2xl border text-sm group/item focus-visible:border-ring focus-visible:ring-ring/50 flex w-full flex-wrap items-center transition-colors duration-100 outline-none focus-visible:ring-[3px] [a]:transition-colors',
 		variants: {
 			variant: {
-				default: 'bg-transparent',
+				default: 'border-transparent',
 				outline: 'border-border',
-				muted: 'bg-muted/50',
+				muted: 'bg-muted/50 border-transparent',
 			},
 			size: {
-				default: 'gap-4 p-4',
-				sm: 'gap-2.5 px-4 py-3',
+				default: 'gap-3.5 px-4 py-3.5',
+				sm: 'gap-3.5 px-3.5 py-3',
+				xs: 'gap-2.5 px-3 py-2.5 in-data-[slot=dropdown-menu-content]:p-0',
 			},
 		},
 		defaultVariants: {

--- a/packages/ui/src/kbd/kbd-group.svelte
+++ b/packages/ui/src/kbd/kbd-group.svelte
@@ -13,7 +13,7 @@
 <kbd
 	bind:this={ref}
 	data-slot="kbd-group"
-	class={cn('inline-flex items-center gap-1', className)}
+	class={cn("gap-1 inline-flex items-center", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/kbd/kbd.svelte
+++ b/packages/ui/src/kbd/kbd.svelte
@@ -14,10 +14,8 @@
 	bind:this={ref}
 	data-slot="kbd"
 	class={cn(
-		'bg-muted text-muted-foreground pointer-events-none inline-flex h-5 w-fit min-w-5 select-none items-center justify-center gap-1 rounded-sm px-1 font-sans text-xs font-medium',
-		"[&_svg:not([class*='size-'])]:size-3",
-		'[[data-slot=tooltip-content]_&]:bg-background/20 [[data-slot=tooltip-content]_&]:text-background dark:[[data-slot=tooltip-content]_&]:bg-background/10',
-		className,
+		"bg-muted text-muted-foreground in-data-[slot=tooltip-content]:bg-background/20 in-data-[slot=tooltip-content]:text-background dark:in-data-[slot=tooltip-content]:bg-background/10 in-data-[slot=input-group]:bg-input h-5.5 w-fit min-w-5.5 gap-1 rounded-lg px-1.5 font-sans text-xs font-medium [&_svg:not([class*='size-'])]:size-3 pointer-events-none inline-flex items-center justify-center select-none",
+		className
 	)}
 	{...restProps}
 >

--- a/packages/ui/src/label/label.svelte
+++ b/packages/ui/src/label/label.svelte
@@ -13,8 +13,8 @@
 	bind:ref
 	data-slot="label"
 	class={cn(
-		'flex select-none items-center gap-2 text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-50 group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50',
-		className,
+		"gap-2 text-sm leading-none font-medium group-data-[disabled=true]:opacity-50 peer-disabled:opacity-50 flex items-center select-none group-data-[disabled=true]:pointer-events-none peer-disabled:cursor-not-allowed",
+		className
 	)}
 	{...restProps}
 />

--- a/packages/ui/src/natural-language-date-input/datetime-string.test.ts
+++ b/packages/ui/src/natural-language-date-input/datetime-string.test.ts
@@ -4,7 +4,10 @@ import { localTimezone, toDateTimeString } from './datetime-string.js';
 
 describe('toDateTimeString', () => {
 	it('formats UTC date and timezone with a pipe separator', () => {
-		const value = toDateTimeString(new Date('2024-01-01T20:00:00.000Z'), 'America/New_York');
+		const value = toDateTimeString(
+			new Date('2024-01-01T20:00:00.000Z'),
+			'America/New_York',
+		);
 
 		expect(value).toBe('2024-01-01T20:00:00.000Z|America/New_York');
 		expect(value).toContain('|');

--- a/packages/ui/src/natural-language-date-input/datetime-string.ts
+++ b/packages/ui/src/natural-language-date-input/datetime-string.ts
@@ -22,7 +22,10 @@ import type { DateTimeString } from '@epicenter/workspace';
  * // "2024-01-01T20:00:00.000Z|America/New_York"
  * ```
  */
-export function toDateTimeString(utcDate: Date, timezone: string): DateTimeString {
+export function toDateTimeString(
+	utcDate: Date,
+	timezone: string,
+): DateTimeString {
 	return `${utcDate.toISOString()}|${timezone}` as DateTimeString;
 }
 

--- a/packages/ui/src/natural-language-date-input/index.ts
+++ b/packages/ui/src/natural-language-date-input/index.ts
@@ -1,3 +1,3 @@
-export { default as NaturalLanguageDateInput } from './natural-language-date-input.svelte';
-export type { NaturalLanguageDateInputProps } from './natural-language-date-input.svelte';
 export { localTimezone, toDateTimeString } from './datetime-string.js';
+export type { NaturalLanguageDateInputProps } from './natural-language-date-input.svelte';
+export { default as NaturalLanguageDateInput } from './natural-language-date-input.svelte';

--- a/packages/ui/src/natural-language-date-input/natural-language-date-input.svelte
+++ b/packages/ui/src/natural-language-date-input/natural-language-date-input.svelte
@@ -8,14 +8,14 @@
 </script>
 
 <script lang="ts">
-	import * as Command from '#/command';
 	import * as chrono from 'chrono-node';
+	import * as Command from '#/command';
 
 	let {
 		placeholder = 'E.g. "tomorrow at 5pm" or "in 2 hours"',
 		min,
 		max,
-		onChoice
+		onChoice,
 	}: NaturalLanguageDateInputProps = $props();
 
 	let value = $state('');
@@ -47,9 +47,7 @@
 					}}
 				>
 					<div class="flex w-full place-items-center justify-between gap-2">
-						<span>
-							{suggestion.label}
-						</span>
+						<span> {suggestion.label} </span>
 						<span class="text-muted-foreground">
 							{suggestion.date.toDateString()}
 							{suggestion.date.toLocaleTimeString()}

--- a/packages/ui/src/natural-language-date-input/parse-date.test.ts
+++ b/packages/ui/src/natural-language-date-input/parse-date.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'bun:test';
 
-import { localTimezone, parseNaturalLanguageDate, toDateTimeString } from './parse-date.js';
+import {
+	localTimezone,
+	parseNaturalLanguageDate,
+	toDateTimeString,
+} from './parse-date.js';
 
 function getTomorrowLocalDate() {
 	const date = new Date();
@@ -16,7 +20,10 @@ describe('parseNaturalLanguageDate', () => {
 
 	it('parses tomorrow at 3pm with the expected components', () => {
 		const expected = getTomorrowLocalDate();
-		const parsed = parseNaturalLanguageDate('tomorrow at 3pm', 'America/New_York');
+		const parsed = parseNaturalLanguageDate(
+			'tomorrow at 3pm',
+			'America/New_York',
+		);
 
 		expect(parsed).not.toBeNull();
 		if (!parsed) {
@@ -48,7 +55,10 @@ describe('parseNaturalLanguageDate', () => {
 	});
 
 	it('returns different UTC dates for different timezones', () => {
-		const newYork = parseNaturalLanguageDate('tomorrow at 3pm', 'America/New_York');
+		const newYork = parseNaturalLanguageDate(
+			'tomorrow at 3pm',
+			'America/New_York',
+		);
 		const utc = parseNaturalLanguageDate('tomorrow at 3pm', 'UTC');
 		const tokyo = parseNaturalLanguageDate('tomorrow at 3pm', 'Asia/Tokyo');
 
@@ -69,7 +79,10 @@ describe('parseNaturalLanguageDate', () => {
 
 describe('toDateTimeString', () => {
 	it('formats UTC date and timezone with a pipe separator', () => {
-		const value = toDateTimeString(new Date('2024-01-01T20:00:00.000Z'), 'America/New_York');
+		const value = toDateTimeString(
+			new Date('2024-01-01T20:00:00.000Z'),
+			'America/New_York',
+		);
 
 		expect(value).toBe('2024-01-01T20:00:00.000Z|America/New_York');
 		expect(value).toContain('|');

--- a/packages/ui/src/natural-language-date-input/parse-date.ts
+++ b/packages/ui/src/natural-language-date-input/parse-date.ts
@@ -93,7 +93,10 @@ export function parseNaturalLanguageDate(
 		return null;
 	}
 
-	const offsetMilliseconds = getOffsetMillisecondsForTimezone(roughUtcDate, timezone);
+	const offsetMilliseconds = getOffsetMillisecondsForTimezone(
+		roughUtcDate,
+		timezone,
+	);
 	if (offsetMilliseconds === null) {
 		return null;
 	}
@@ -141,7 +144,10 @@ export function parseNaturalLanguageDate(
  *   : null;
  * ```
  */
-export function toDateTimeString(utcDate: Date, timezone: string): DateTimeString {
+export function toDateTimeString(
+	utcDate: Date,
+	timezone: string,
+): DateTimeString {
 	return `${utcDate.toISOString()}|${timezone}` as DateTimeString;
 }
 
@@ -193,7 +199,10 @@ function extractDateComponents(
 	};
 }
 
-function getOffsetMillisecondsForTimezone(instant: Date, timezone: string): number | null {
+function getOffsetMillisecondsForTimezone(
+	instant: Date,
+	timezone: string,
+): number | null {
 	try {
 		const formatter = new Intl.DateTimeFormat('en-US', {
 			timeZone: timezone,

--- a/packages/ui/src/natural-language-date-input/timezone-combobox.svelte
+++ b/packages/ui/src/natural-language-date-input/timezone-combobox.svelte
@@ -43,9 +43,7 @@
 	const selectedTimeZone = $derived(
 		timeZoneOptions.find((timeZoneOption) => timeZoneOption.timeZone === value),
 	);
-	const triggerLabel = $derived(
-		selectedTimeZone?.label ?? 'Select timezone',
-	);
+	const triggerLabel = $derived(selectedTimeZone?.label ?? 'Select timezone');
 </script>
 
 <Popover.Root bind:open={combobox.open}>

--- a/packages/ui/src/popover/index.ts
+++ b/packages/ui/src/popover/index.ts
@@ -1,18 +1,28 @@
-import { Popover as PopoverPrimitive } from 'bits-ui';
+import Root from './popover.svelte';
+import Close from './popover-close.svelte';
 import Content from './popover-content.svelte';
+import Description from './popover-description.svelte';
+import Header from './popover-header.svelte';
+import Portal from './popover-portal.svelte';
+import Title from './popover-title.svelte';
 import Trigger from './popover-trigger.svelte';
-
-const Root = PopoverPrimitive.Root;
-const Close = PopoverPrimitive.Close;
 
 export {
 	Close,
 	Close as PopoverClose,
 	Content,
 	Content as PopoverContent,
+	Description,
+	Description as PopoverDescription,
+	Header,
+	Header as PopoverHeader,
+	Portal,
+	Portal as PopoverPortal,
 	Root,
 	//
 	Root as Popover,
+	Title,
+	Title as PopoverTitle,
 	Trigger,
 	Trigger as PopoverTrigger,
 };

--- a/packages/ui/src/popover/popover-close.svelte
+++ b/packages/ui/src/popover/popover-close.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	import { Popover as PopoverPrimitive } from 'bits-ui';
+
+	let { ref = $bindable(null), ...restProps }: PopoverPrimitive.CloseProps =
+		$props();
+</script>
+
+<PopoverPrimitive.Close bind:ref data-slot="popover-close" {...restProps} />

--- a/packages/ui/src/popover/popover-content.svelte
+++ b/packages/ui/src/popover/popover-content.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { Popover as PopoverPrimitive } from 'bits-ui';
-	import { cn } from '#/utils.js';
+	import type { ComponentProps } from 'svelte';
+	import { cn, type WithoutChildrenOrChild } from '#/utils.js';
+	import PopoverPortal from './popover-portal.svelte';
 
 	let {
 		ref = $bindable(null),
@@ -10,20 +12,20 @@
 		portalProps,
 		...restProps
 	}: PopoverPrimitive.ContentProps & {
-		portalProps?: PopoverPrimitive.PortalProps;
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof PopoverPortal>>;
 	} = $props();
 </script>
 
-<PopoverPrimitive.Portal {...portalProps}>
+<PopoverPortal {...portalProps}>
 	<PopoverPrimitive.Content
 		bind:ref
 		data-slot="popover-content"
 		{sideOffset}
 		{align}
 		class={cn(
-			'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-end-2 data-[side=right]:slide-in-from-start-2 data-[side=top]:slide-in-from-bottom-2 origin-(--bits-popover-content-transform-origin) outline-hidden z-50 w-72 rounded-md border p-4 shadow-md',
-			className,
+			"bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/5 dark:ring-foreground/10 flex flex-col gap-4 rounded-3xl p-4 text-sm shadow-lg ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-50 w-72 origin-(--transform-origin) outline-hidden",
+			className
 		)}
 		{...restProps}
 	/>
-</PopoverPrimitive.Portal>
+</PopoverPortal>

--- a/packages/ui/src/popover/popover-description.svelte
+++ b/packages/ui/src/popover/popover-description.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { cn, type WithElementRef } from '#/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="popover-description"
+	class={cn("text-muted-foreground", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/popover/popover-header.svelte
+++ b/packages/ui/src/popover/popover-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { cn, type WithElementRef } from '#/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="popover-header"
+	class={cn("flex flex-col gap-1 text-sm", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/popover/popover-portal.svelte
+++ b/packages/ui/src/popover/popover-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Popover as PopoverPrimitive } from 'bits-ui';
+
+	let { ...restProps }: PopoverPrimitive.PortalProps = $props();
+</script>
+
+<PopoverPrimitive.Portal {...restProps} />

--- a/packages/ui/src/popover/popover-title.svelte
+++ b/packages/ui/src/popover/popover-title.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { cn, type WithElementRef } from '#/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="popover-title"
+	class={cn("font-heading text-base font-medium", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/popover/popover-trigger.svelte
+++ b/packages/ui/src/popover/popover-trigger.svelte
@@ -12,6 +12,6 @@
 <PopoverPrimitive.Trigger
 	bind:ref
 	data-slot="popover-trigger"
-	class={cn('', className)}
+	class={cn("", className)}
 	{...restProps}
 />

--- a/packages/ui/src/popover/popover.svelte
+++ b/packages/ui/src/popover/popover.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	import { Popover as PopoverPrimitive } from 'bits-ui';
+
+	let { open = $bindable(false), ...restProps }: PopoverPrimitive.RootProps =
+		$props();
+</script>
+
+<PopoverPrimitive.Root bind:open {...restProps} />

--- a/packages/ui/src/progress/progress.svelte
+++ b/packages/ui/src/progress/progress.svelte
@@ -14,17 +14,14 @@
 <ProgressPrimitive.Root
 	bind:ref
 	data-slot="progress"
-	class={cn(
-		'bg-primary/20 relative h-2 w-full overflow-hidden rounded-full',
-		className,
-	)}
+	class={cn("bg-muted h-3 rounded-full relative flex w-full items-center overflow-x-hidden", className)}
 	{value}
 	{max}
 	{...restProps}
 >
 	<div
 		data-slot="progress-indicator"
-		class="bg-primary h-full w-full flex-1 transition-all"
+		class="bg-primary size-full flex-1 transition-all"
 		style="transform: translateX(-{100 - (100 * (value ?? 0)) / (max ?? 1)}%)"
 	></div>
 </ProgressPrimitive.Root>

--- a/packages/ui/src/radio-group/radio-group-item.svelte
+++ b/packages/ui/src/radio-group/radio-group-item.svelte
@@ -14,19 +14,19 @@
 	bind:ref
 	data-slot="radio-group-item"
 	class={cn(
-		'border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 shadow-xs aspect-square size-4 shrink-0 rounded-full border outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
-		className,
+		"bg-input/90 data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary aria-invalid:border-destructive focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/50 flex size-4 rounded-full border border-transparent focus-visible:ring-3 aria-invalid:ring-3 group/radio-group-item peer relative aspect-square shrink-0 border outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50",
+		className
 	)}
 	{...restProps}
 >
 	{#snippet children({ checked })}
 		<div
 			data-slot="radio-group-indicator"
-			class="relative flex items-center justify-center"
+			class="flex size-4 items-center justify-center"
 		>
 			{#if checked}
 				<CircleIcon
-					class="fill-primary absolute start-1/2 top-1/2 size-2 -translate-x-1/2 -translate-y-1/2"
+					class="bg-primary-foreground absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full dark:size-2.5"
 				/>
 			{/if}
 		</div>

--- a/packages/ui/src/radio-group/radio-group.svelte
+++ b/packages/ui/src/radio-group/radio-group.svelte
@@ -14,6 +14,6 @@
 	bind:ref
 	bind:value
 	data-slot="radio-group"
-	class={cn('grid gap-3', className)}
+	class={cn("grid gap-3 w-full", className)}
 	{...restProps}
 />

--- a/packages/ui/src/resizable/resizable-handle.svelte
+++ b/packages/ui/src/resizable/resizable-handle.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import GripVerticalIcon from '@lucide/svelte/icons/grip-vertical';
 	import * as ResizablePrimitive from 'paneforge';
 	import { cn, type WithoutChildrenOrChild } from '#/utils.js';
 
@@ -17,16 +16,12 @@
 	bind:ref
 	data-slot="resizable-handle"
 	class={cn(
-		'bg-border focus-visible:ring-ring focus-visible:outline-hidden relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:start-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 data-[direction=vertical]:h-px data-[direction=vertical]:w-full data-[direction=vertical]:after:start-0 data-[direction=vertical]:after:h-1 data-[direction=vertical]:after:w-full data-[direction=vertical]:after:-translate-y-1/2 data-[direction=vertical]:after:translate-x-0 [&[data-direction=vertical]>div]:rotate-90',
-		className,
+		"cn-resizable-handle bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[direction=vertical]:h-px data-[direction=vertical]:w-full data-[direction=vertical]:after:left-0 data-[direction=vertical]:after:h-1 data-[direction=vertical]:after:w-full data-[direction=vertical]:after:translate-x-0 data-[direction=vertical]:after:-translate-y-1/2 [&[data-direction=vertical]>div]:rotate-90",
+		className
 	)}
 	{...restProps}
 >
 	{#if withHandle}
-		<div
-			class="bg-border rounded-xs z-10 flex h-4 w-3 items-center justify-center border"
-		>
-			<GripVerticalIcon class="size-2.5" />
-		</div>
+		<div class="bg-border h-6 w-1 rounded-lg z-10 flex shrink-0"></div>
 	{/if}
 </ResizablePrimitive.PaneResizer>

--- a/packages/ui/src/resizable/resizable-pane-group.svelte
+++ b/packages/ui/src/resizable/resizable-pane-group.svelte
@@ -13,12 +13,13 @@
 </script>
 
 <ResizablePrimitive.PaneGroup
+	bind:ref
 	bind:this={paneGroup}
 	data-slot="resizable-pane-group"
 	class={cn(
-		'flex h-full w-full data-[direction=vertical]:flex-col',
+		"cn-resizable-panel-group flex h-full w-full data-[direction=vertical]:flex-col",
 		// Custom: Add spacing between resizable panes for visual separation
-		'gap-2',
+		"gap-2",
 		className,
 	)}
 	{...restProps}

--- a/packages/ui/src/scroll-area/scroll-area-scrollbar.svelte
+++ b/packages/ui/src/scroll-area/scroll-area-scrollbar.svelte
@@ -14,19 +14,17 @@
 <ScrollAreaPrimitive.Scrollbar
 	bind:ref
 	data-slot="scroll-area-scrollbar"
+	data-orientation={orientation}
 	{orientation}
 	class={cn(
-		'flex touch-none select-none p-px transition-colors',
-		orientation === 'vertical' && 'h-full w-2.5 border-s border-s-transparent',
-		orientation === 'horizontal' &&
-			'h-2.5 flex-col border-t border-t-transparent',
-		className,
+		"data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent flex touch-none p-px transition-colors select-none",
+		className
 	)}
 	{...restProps}
 >
 	{@render children?.()}
 	<ScrollAreaPrimitive.Thumb
 		data-slot="scroll-area-thumb"
-		class="bg-border relative flex-1 rounded-full"
+		class="rounded-full bg-border relative flex-1"
 	/>
 </ScrollAreaPrimitive.Scrollbar>

--- a/packages/ui/src/scroll-area/scroll-area.svelte
+++ b/packages/ui/src/scroll-area/scroll-area.svelte
@@ -23,20 +23,20 @@
 <ScrollAreaPrimitive.Root
 	bind:ref
 	data-slot="scroll-area"
-	class={cn('relative', className)}
+	class={cn("relative", className)}
 	{...restProps}
 >
 	<ScrollAreaPrimitive.Viewport
 		bind:ref={viewportRef}
 		data-slot="scroll-area-viewport"
-		class="ring-ring/10 dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] focus-visible:outline-1 focus-visible:ring-4"
+		class="cn-scroll-area-viewport focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
 	>
 		{@render children?.()}
 	</ScrollAreaPrimitive.Viewport>
-	{#if orientation === 'vertical' || orientation === 'both'}
+	{#if orientation === "vertical" || orientation === "both"}
 		<Scrollbar orientation="vertical" class={scrollbarYClasses} />
 	{/if}
-	{#if orientation === 'horizontal' || orientation === 'both'}
+	{#if orientation === "horizontal" || orientation === "both"}
 		<Scrollbar orientation="horizontal" class={scrollbarXClasses} />
 	{/if}
 	<ScrollAreaPrimitive.Corner />

--- a/packages/ui/src/select/index.ts
+++ b/packages/ui/src/select/index.ts
@@ -1,15 +1,14 @@
-import { Select as SelectPrimitive } from 'bits-ui';
+import Root from './select.svelte';
 import Content from './select-content.svelte';
 import Group from './select-group.svelte';
 import GroupHeading from './select-group-heading.svelte';
 import Item from './select-item.svelte';
 import Label from './select-label.svelte';
+import Portal from './select-portal.svelte';
 import ScrollDownButton from './select-scroll-down-button.svelte';
 import ScrollUpButton from './select-scroll-up-button.svelte';
 import Separator from './select-separator.svelte';
 import Trigger from './select-trigger.svelte';
-
-const Root = SelectPrimitive.Root;
 
 export {
 	Content,
@@ -22,6 +21,8 @@ export {
 	Item as SelectItem,
 	Label,
 	Label as SelectLabel,
+	Portal,
+	Portal as SelectPortal,
 	Root,
 	//
 	Root as Select,

--- a/packages/ui/src/select/select-content.svelte
+++ b/packages/ui/src/select/select-content.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import { Select as SelectPrimitive } from 'bits-ui';
+	import type { ComponentProps } from 'svelte';
+	import type { WithoutChildrenOrChild } from '#/utils.js';
 	import { cn, type WithoutChild } from '#/utils.js';
+	import SelectPortal from './select-portal.svelte';
 	import SelectScrollDownButton from './select-scroll-down-button.svelte';
 	import SelectScrollUpButton from './select-scroll-up-button.svelte';
 
@@ -13,20 +16,20 @@
 		preventScroll = true,
 		...restProps
 	}: WithoutChild<SelectPrimitive.ContentProps> & {
-		portalProps?: SelectPrimitive.PortalProps;
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof SelectPortal>>;
 	} = $props();
 </script>
 
-<SelectPrimitive.Portal {...portalProps}>
+<SelectPortal {...portalProps}>
 	<SelectPrimitive.Content
 		bind:ref
 		{sideOffset}
 		{preventScroll}
 		data-slot="select-content"
 		class={cn(
-			'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-end-2 data-[side=right]:slide-in-from-start-2 data-[side=top]:slide-in-from-bottom-2 max-h-(--bits-select-content-available-height) origin-(--bits-select-content-transform-origin) relative z-50 min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border shadow-md data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+			"bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/5 dark:ring-foreground/10 min-w-36 rounded-3xl shadow-lg ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 relative isolate z-50 overflow-x-hidden overflow-y-auto",
 			// Custom: Prevent dropdown from expanding wider than trigger when content overflows
-			'max-w-min',
+			"max-w-min",
 			className,
 		)}
 		{...restProps}
@@ -34,11 +37,11 @@
 		<SelectScrollUpButton />
 		<SelectPrimitive.Viewport
 			class={cn(
-				'h-(--bits-select-anchor-height) min-w-(--bits-select-anchor-width) w-full scroll-my-1 p-1',
+				"h-(--bits-select-anchor-height) w-full min-w-(--bits-select-anchor-width) scroll-my-1"
 			)}
 		>
 			{@render children?.()}
 		</SelectPrimitive.Viewport>
 		<SelectScrollDownButton />
 	</SelectPrimitive.Content>
-</SelectPrimitive.Portal>
+</SelectPortal>

--- a/packages/ui/src/select/select-group-heading.svelte
+++ b/packages/ui/src/select/select-group-heading.svelte
@@ -14,7 +14,7 @@
 <SelectPrimitive.GroupHeading
 	bind:ref
 	data-slot="select-group-heading"
-	class={cn('text-muted-foreground px-2 py-1.5 text-xs', className)}
+	class={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/select/select-group.svelte
+++ b/packages/ui/src/select/select-group.svelte
@@ -1,8 +1,17 @@
 <script lang="ts">
 	import { Select as SelectPrimitive } from 'bits-ui';
+	import { cn } from '#/utils.js';
 
-	let { ref = $bindable(null), ...restProps }: SelectPrimitive.GroupProps =
-		$props();
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: SelectPrimitive.GroupProps = $props();
 </script>
 
-<SelectPrimitive.Group data-slot="select-group" {...restProps} />
+<SelectPrimitive.Group
+	bind:ref
+	data-slot="select-group"
+	class={cn("scroll-my-1.5 p-1.5", className)}
+	{...restProps}
+/>

--- a/packages/ui/src/select/select-item.svelte
+++ b/packages/ui/src/select/select-item.svelte
@@ -18,15 +18,15 @@
 	{value}
 	data-slot="select-item"
 	class={cn(
-		"data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground outline-hidden *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2 relative flex w-full cursor-default select-none items-center gap-2 rounded-sm py-1.5 pe-8 ps-2 text-sm data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-		className,
+		"focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-2.5 rounded-2xl py-2 pr-8 pl-3 text-sm font-medium [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2 focus:bg-accent data-highlighted:bg-accent data-highlighted:text-accent-foreground focus:text-accent-foreground relative flex w-full cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
 	)}
 	{...restProps}
 >
 	{#snippet children({ selected, highlighted })}
 		<span class="absolute end-2 flex size-3.5 items-center justify-center">
 			{#if selected}
-				<CheckIcon class="size-4" />
+				<CheckIcon class="cn-select-item-indicator-icon" />
 			{/if}
 		</span>
 		{#if childrenProp}

--- a/packages/ui/src/select/select-label.svelte
+++ b/packages/ui/src/select/select-label.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="select-label"
-	class={cn('text-muted-foreground px-2 py-1.5 text-xs', className)}
+	class={cn("text-muted-foreground px-3 py-2.5 text-xs", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/select/select-portal.svelte
+++ b/packages/ui/src/select/select-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Select as SelectPrimitive } from 'bits-ui';
+
+	let { ...restProps }: SelectPrimitive.PortalProps = $props();
+</script>
+
+<SelectPrimitive.Portal {...restProps} />

--- a/packages/ui/src/select/select-scroll-down-button.svelte
+++ b/packages/ui/src/select/select-scroll-down-button.svelte
@@ -13,8 +13,8 @@
 <SelectPrimitive.ScrollDownButton
 	bind:ref
 	data-slot="select-scroll-down-button"
-	class={cn('flex cursor-default items-center justify-center py-1', className)}
+	class={cn("bg-popover z-10 flex cursor-default items-center justify-center py-1 [&_svg:not([class*='size-'])]:size-4 bottom-0 w-full", className)}
 	{...restProps}
 >
-	<ChevronDownIcon class="size-4" />
+	<ChevronDownIcon />
 </SelectPrimitive.ScrollDownButton>

--- a/packages/ui/src/select/select-scroll-up-button.svelte
+++ b/packages/ui/src/select/select-scroll-up-button.svelte
@@ -13,8 +13,8 @@
 <SelectPrimitive.ScrollUpButton
 	bind:ref
 	data-slot="select-scroll-up-button"
-	class={cn('flex cursor-default items-center justify-center py-1', className)}
+	class={cn("bg-popover z-10 flex cursor-default items-center justify-center py-1 [&_svg:not([class*='size-'])]:size-4 top-0 w-full", className)}
 	{...restProps}
 >
-	<ChevronUpIcon class="size-4" />
+	<ChevronUpIcon />
 </SelectPrimitive.ScrollUpButton>

--- a/packages/ui/src/select/select-separator.svelte
+++ b/packages/ui/src/select/select-separator.svelte
@@ -13,6 +13,6 @@
 <Separator
 	bind:ref
 	data-slot="select-separator"
-	class={cn('bg-border pointer-events-none -mx-1 my-1 h-px', className)}
+	class={cn("bg-border -mx-1.5 my-1.5 h-px pointer-events-none", className)}
 	{...restProps}
 />

--- a/packages/ui/src/select/select-trigger.svelte
+++ b/packages/ui/src/select/select-trigger.svelte
@@ -19,11 +19,11 @@
 	data-slot="select-trigger"
 	data-size={size}
 	class={cn(
-		"border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 shadow-xs flex w-fit select-none items-center justify-between gap-2 whitespace-nowrap rounded-md border bg-transparent px-3 py-2 text-sm outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-		className,
+		"bg-input/50 data-placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 gap-1.5 rounded-3xl border border-transparent px-3 py-2 text-sm transition-[color,box-shadow,background-color] focus-visible:ring-3 aria-invalid:ring-3 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:flex *:data-[slot=select-value]:gap-1.5 [&_svg:not([class*='size-'])]:size-4 flex w-fit items-center justify-between whitespace-nowrap outline-none disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
 	)}
 	{...restProps}
 >
 	{@render children?.()}
-	<ChevronDownIcon class="size-4 opacity-50" />
+	<ChevronDownIcon class="text-muted-foreground size-4 pointer-events-none" />
 </SelectPrimitive.Trigger>

--- a/packages/ui/src/select/select.svelte
+++ b/packages/ui/src/select/select.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import { Select as SelectPrimitive } from 'bits-ui';
+
+	let {
+		open = $bindable(false),
+		value = $bindable(),
+		...restProps
+	}: SelectPrimitive.RootProps = $props();
+</script>
+
+<SelectPrimitive.Root bind:open bind:value={value as never} {...restProps} />

--- a/packages/ui/src/separator/separator.svelte
+++ b/packages/ui/src/separator/separator.svelte
@@ -14,8 +14,10 @@
 	bind:ref
 	data-slot={dataSlot}
 	class={cn(
-		'bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=vertical]:h-full data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px',
-		className,
+		"bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px",
+		// this is different in shadcn/ui but self-stretch breaks things for us
+		"data-[orientation=vertical]:h-full",
+		className
 	)}
 	{...restProps}
 />

--- a/packages/ui/src/sheet/sheet-content.svelte
+++ b/packages/ui/src/sheet/sheet-content.svelte
@@ -1,29 +1,12 @@
 <script lang="ts" module>
-	import { tv, type VariantProps } from 'tailwind-variants';
-	export const sheetVariants = tv({
-		base: 'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
-		variants: {
-			side: {
-				top: 'data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b',
-				bottom:
-					'data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t',
-				left: 'data-[state=closed]:slide-out-to-start data-[state=open]:slide-in-from-start inset-y-0 start-0 h-full w-3/4 border-e sm:max-w-sm',
-				right:
-					'data-[state=closed]:slide-out-to-end data-[state=open]:slide-in-from-end inset-y-0 end-0 h-full w-3/4 border-s sm:max-w-sm',
-			},
-		},
-		defaultVariants: {
-			side: 'right',
-		},
-	});
-
-	export type Side = VariantProps<typeof sheetVariants>['side'];
+	export type Side = 'top' | 'right' | 'bottom' | 'left';
 </script>
 
 <script lang="ts">
 	import XIcon from '@lucide/svelte/icons/x';
 	import { Dialog as SheetPrimitive } from 'bits-ui';
 	import type { ComponentProps, Snippet } from 'svelte';
+	import { Button } from '#/button/index.js';
 	import { cn, type WithoutChildrenOrChild } from '#/utils.js';
 	import SheetOverlay from './sheet-overlay.svelte';
 	import SheetPortal from './sheet-portal.svelte';
@@ -32,12 +15,14 @@
 		ref = $bindable(null),
 		class: className,
 		side = 'right',
+		showCloseButton = true,
 		portalProps,
 		children,
 		...restProps
 	}: WithoutChildrenOrChild<SheetPrimitive.ContentProps> & {
 		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof SheetPortal>>;
 		side?: Side;
+		showCloseButton?: boolean;
 		children: Snippet;
 	} = $props();
 </script>
@@ -47,15 +32,28 @@
 	<SheetPrimitive.Content
 		bind:ref
 		data-slot="sheet-content"
-		class={cn(sheetVariants({ side }), className)}
+		data-side={side}
+		class={cn(
+			"bg-popover text-popover-foreground fixed z-50 flex flex-col bg-clip-padding text-sm shadow-xl transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10",
+			className
+		)}
 		{...restProps}
 	>
 		{@render children?.()}
-		<SheetPrimitive.Close
-			class="ring-offset-background focus-visible:ring-ring rounded-xs focus-visible:outline-hidden absolute end-4 top-4 opacity-70 transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none"
-		>
-			<XIcon class="size-4" />
-			<span class="sr-only">Close</span>
-		</SheetPrimitive.Close>
+		{#if showCloseButton}
+			<SheetPrimitive.Close data-slot="sheet-close">
+				{#snippet child({ props })}
+					<Button
+						variant="ghost"
+						class="bg-secondary absolute top-4 right-4"
+						size="icon-sm"
+						{...props}
+					>
+						<XIcon />
+						<span class="sr-only">Close</span>
+					</Button>
+				{/snippet}
+			</SheetPrimitive.Close>
+		{/if}
 	</SheetPrimitive.Content>
 </SheetPortal>

--- a/packages/ui/src/sheet/sheet-description.svelte
+++ b/packages/ui/src/sheet/sheet-description.svelte
@@ -12,6 +12,6 @@
 <SheetPrimitive.Description
 	bind:ref
 	data-slot="sheet-description"
-	class={cn('text-muted-foreground text-sm', className)}
+	class={cn("text-muted-foreground text-sm", className)}
 	{...restProps}
 />

--- a/packages/ui/src/sheet/sheet-footer.svelte
+++ b/packages/ui/src/sheet/sheet-footer.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="sheet-footer"
-	class={cn('mt-auto flex flex-col gap-2 p-4', className)}
+	class={cn("gap-2 p-6 mt-auto flex flex-col", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/sheet/sheet-header.svelte
+++ b/packages/ui/src/sheet/sheet-header.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="sheet-header"
-	class={cn('flex flex-col gap-1.5 p-4', className)}
+	class={cn("gap-1.5 p-6 flex flex-col", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/sheet/sheet-overlay.svelte
+++ b/packages/ui/src/sheet/sheet-overlay.svelte
@@ -12,9 +12,6 @@
 <SheetPrimitive.Overlay
 	bind:ref
 	data-slot="sheet-overlay"
-	class={cn(
-		'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
-		className,
-	)}
+	class={cn("bg-black/30 supports-backdrop-filter:backdrop-blur-sm fixed inset-0 z-50", className)}
 	{...restProps}
 />

--- a/packages/ui/src/sheet/sheet-title.svelte
+++ b/packages/ui/src/sheet/sheet-title.svelte
@@ -12,6 +12,6 @@
 <SheetPrimitive.Title
 	bind:ref
 	data-slot="sheet-title"
-	class={cn('text-foreground font-semibold', className)}
+	class={cn("font-heading text-foreground text-base font-medium", className)}
 	{...restProps}
 />

--- a/packages/ui/src/sidebar/constants.ts
+++ b/packages/ui/src/sidebar/constants.ts
@@ -1,5 +1,6 @@
 export const SIDEBAR_COOKIE_NAME = 'sidebar:state';
 export const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 export const SIDEBAR_WIDTH = '16rem';
+export const SIDEBAR_WIDTH_MOBILE = '18rem';
 export const SIDEBAR_WIDTH_ICON = '3rem';
 export const SIDEBAR_KEYBOARD_SHORTCUT = 'b';

--- a/packages/ui/src/sidebar/context.svelte.ts
+++ b/packages/ui/src/sidebar/context.svelte.ts
@@ -1,4 +1,5 @@
 import { getContext, setContext } from 'svelte';
+import { IsMobile } from '#/hooks/is-mobile.svelte.js';
 import { SIDEBAR_KEYBOARD_SHORTCUT } from './constants.js';
 
 type Getter<T> = () => T;
@@ -22,12 +23,21 @@ export type SidebarStateProps = {
 class SidebarState {
 	readonly props: SidebarStateProps;
 	open = $derived.by(() => this.props.open());
+	openMobile = $state(false);
 	setOpen: SidebarStateProps['setOpen'];
+	#isMobile: IsMobile;
 	state = $derived.by(() => (this.open ? 'expanded' : 'collapsed'));
 
 	constructor(props: SidebarStateProps) {
 		this.setOpen = props.setOpen;
+		this.#isMobile = new IsMobile();
 		this.props = props;
+	}
+
+	// Convenience getter for checking if the sidebar is mobile
+	// without this, we would need to use `sidebar.isMobile.current` everywhere
+	get isMobile() {
+		return this.#isMobile.current;
 	}
 
 	// Event handler to apply to the `<svelte:window>`
@@ -38,8 +48,14 @@ class SidebarState {
 		}
 	};
 
+	setOpenMobile = (value: boolean) => {
+		this.openMobile = value;
+	};
+
 	toggle = () => {
-		return this.setOpen(!this.open);
+		return this.#isMobile.current
+			? (this.openMobile = !this.openMobile)
+			: this.setOpen(!this.open);
 	};
 }
 

--- a/packages/ui/src/sidebar/sidebar-content.svelte
+++ b/packages/ui/src/sidebar/sidebar-content.svelte
@@ -15,8 +15,8 @@
 	data-slot="sidebar-content"
 	data-sidebar="content"
 	class={cn(
-		'flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden',
-		className,
+		"no-scrollbar gap-2 [--radius:var(--radius-xl)] flex min-h-0 flex-1 flex-col overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+		className
 	)}
 	{...restProps}
 >

--- a/packages/ui/src/sidebar/sidebar-footer.svelte
+++ b/packages/ui/src/sidebar/sidebar-footer.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="sidebar-footer"
 	data-sidebar="footer"
-	class={cn('flex flex-col gap-2 p-2', className)}
+	class={cn("gap-2 p-2 flex flex-col", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/sidebar/sidebar-group-action.svelte
+++ b/packages/ui/src/sidebar/sidebar-group-action.svelte
@@ -15,10 +15,7 @@
 
 	const mergedProps = $derived({
 		class: cn(
-			'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground outline-hidden absolute end-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
-			// Increases the hit area of the button on mobile.
-			'after:absolute after:-inset-2 md:after:hidden',
-			'group-data-[collapsible=icon]:hidden',
+			'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 w-5 rounded-xl p-0 focus-visible:ring-2 [&>svg]:size-4 flex aspect-square items-center justify-center outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 md:after:hidden [&>svg]:shrink-0',
 			className,
 		),
 		'data-slot': 'sidebar-group-action',

--- a/packages/ui/src/sidebar/sidebar-group-content.svelte
+++ b/packages/ui/src/sidebar/sidebar-group-content.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="sidebar-group-content"
 	data-sidebar="group-content"
-	class={cn('w-full text-sm', className)}
+	class={cn("text-sm w-full", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/sidebar/sidebar-group-label.svelte
+++ b/packages/ui/src/sidebar/sidebar-group-label.svelte
@@ -15,8 +15,7 @@
 
 	const mergedProps = $derived({
 		class: cn(
-			'text-sidebar-foreground/70 ring-sidebar-ring outline-hidden flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
-			'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0',
+			'text-sidebar-foreground/70 ring-sidebar-ring h-8 rounded-xl px-3 text-xs font-medium transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 flex shrink-0 items-center outline-hidden [&>svg]:shrink-0',
 			className,
 		),
 		'data-slot': 'sidebar-group-label',

--- a/packages/ui/src/sidebar/sidebar-group.svelte
+++ b/packages/ui/src/sidebar/sidebar-group.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="sidebar-group"
 	data-sidebar="group"
-	class={cn('relative flex w-full min-w-0 flex-col p-2', className)}
+	class={cn("p-2 relative flex w-full min-w-0 flex-col", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/sidebar/sidebar-header.svelte
+++ b/packages/ui/src/sidebar/sidebar-header.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="sidebar-header"
 	data-sidebar="header"
-	class={cn('flex flex-col gap-2 p-2', className)}
+	class={cn("gap-2 p-2 [--radius:var(--radius-xl)] flex flex-col", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/sidebar/sidebar-input.svelte
+++ b/packages/ui/src/sidebar/sidebar-input.svelte
@@ -16,6 +16,6 @@
 	bind:value
 	data-slot="sidebar-input"
 	data-sidebar="input"
-	class={cn('bg-background h-8 w-full shadow-none', className)}
+	class={cn("bg-input/50 h-8 w-full shadow-none", className)}
 	{...restProps}
 />

--- a/packages/ui/src/sidebar/sidebar-inset.svelte
+++ b/packages/ui/src/sidebar/sidebar-inset.svelte
@@ -13,11 +13,7 @@
 <main
 	bind:this={ref}
 	data-slot="sidebar-inset"
-	class={cn(
-		'bg-background relative flex min-w-0 flex-1 flex-col',
-		'md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ms-0 md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ms-2 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm',
-		className,
-	)}
+	class={cn("bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-2xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 relative flex w-full flex-1 flex-col", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/sidebar/sidebar-menu-action.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu-action.svelte
@@ -17,15 +17,9 @@
 
 	const mergedProps = $derived({
 		class: cn(
-			'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground outline-hidden absolute end-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
-			// Increases the hit area of the button on mobile.
-			'after:absolute after:-inset-2 md:after:hidden',
-			'peer-data-[size=sm]/menu-button:top-1',
-			'peer-data-[size=default]/menu-button:top-1.5',
-			'peer-data-[size=lg]/menu-button:top-2.5',
-			'group-data-[collapsible=icon]:hidden',
+			'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 aspect-square w-5 rounded-xl p-0 peer-data-[size=default]/menu-button:top-2 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 focus-visible:ring-2 [&>svg]:size-4 flex items-center justify-center outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 md:after:hidden [&>svg]:shrink-0',
 			showOnHover &&
-				'peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0',
+				'peer-data-active/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-open:opacity-100 md:opacity-0',
 			className,
 		),
 		'data-slot': 'sidebar-menu-action',

--- a/packages/ui/src/sidebar/sidebar-menu-badge.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu-badge.svelte
@@ -15,13 +15,8 @@
 	data-slot="sidebar-menu-badge"
 	data-sidebar="menu-badge"
 	class={cn(
-		'text-sidebar-foreground pointer-events-none absolute end-1 flex h-5 min-w-5 select-none items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums',
-		'peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground',
-		'peer-data-[size=sm]/menu-button:top-1',
-		'peer-data-[size=default]/menu-button:top-1.5',
-		'peer-data-[size=lg]/menu-button:top-2.5',
-		'group-data-[collapsible=icon]:hidden',
-		className,
+		"text-sidebar-foreground peer-hover/menu-button:text-sidebar-accent-foreground peer-data-active/menu-button:text-sidebar-accent-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 rounded-xl px-1 text-xs font-medium peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 flex items-center justify-center tabular-nums select-none group-data-[collapsible=icon]:hidden",
+		className
 	)}
 	{...restProps}
 >

--- a/packages/ui/src/sidebar/sidebar-menu-button.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu-button.svelte
@@ -2,17 +2,17 @@
 	import { tv, type VariantProps } from 'tailwind-variants';
 
 	export const sidebarMenuButtonVariants = tv({
-		base: 'peer/menu-button outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground group-has-data-[sidebar=menu-action]/menu-item:pe-8 data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-start text-sm transition-[width,height,padding] focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:font-medium [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
+		base: 'ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground gap-2 rounded-xl px-3 py-2 text-left text-sm transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! focus-visible:ring-2 data-active:font-medium peer/menu-button group/menu-button flex w-full items-center overflow-hidden outline-hidden disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate',
 		variants: {
 			variant: {
 				default: 'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
 				outline:
-					'bg-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_var(--sidebar-border)] hover:shadow-[0_0_0_1px_var(--sidebar-accent)]',
+					'bg-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]',
 			},
 			size: {
-				default: 'h-8 text-sm',
-				sm: 'h-7 text-xs',
-				lg: 'group-data-[collapsible=icon]:p-0! h-12 text-sm',
+				default: 'h-9 text-sm',
+				sm: 'h-8 text-xs',
+				lg: 'h-14 px-3 text-sm group-data-[collapsible=icon]:p-0!',
 			},
 		},
 		defaultVariants: {
@@ -75,7 +75,7 @@
 	});
 </script>
 
-{#snippet Button({ props }: { props?: Record })}
+{#snippet Button({ props }: { props?: Record<string, unknown> })}
 	{@const mergedProps = mergeProps(buttonProps, props)}
 	{#if child}
 		{@render child({ props: mergedProps })}
@@ -96,10 +96,10 @@
 		<Tooltip.Content
 			side="right"
 			align="center"
-			hidden={sidebar.state !== 'collapsed'}
+			hidden={sidebar.state !== "collapsed" || sidebar.isMobile}
 			{...tooltipContentProps}
 		>
-			{#if typeof tooltipContent === 'string'}
+			{#if typeof tooltipContent === "string"}
 				{tooltipContent}
 			{:else if tooltipContent}
 				{@render tooltipContent()}

--- a/packages/ui/src/sidebar/sidebar-menu-item.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu-item.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="sidebar-menu-item"
 	data-sidebar="menu-item"
-	class={cn('group/menu-item relative', className)}
+	class={cn("group/menu-item relative", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/sidebar/sidebar-menu-skeleton.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu-skeleton.svelte
@@ -21,14 +21,14 @@
 	bind:this={ref}
 	data-slot="sidebar-menu-skeleton"
 	data-sidebar="menu-skeleton"
-	class={cn('flex h-8 items-center gap-2 rounded-md px-2', className)}
+	class={cn("h-8 gap-2 rounded-xl px-2 flex items-center", className)}
 	{...restProps}
 >
 	{#if showIcon}
-		<Skeleton class="size-4 rounded-md" data-sidebar="menu-skeleton-icon" />
+		<Skeleton class="size-4 rounded-xl" data-sidebar="menu-skeleton-icon" />
 	{/if}
 	<Skeleton
-		class="max-w-(--skeleton-width) h-4 flex-1"
+		class="h-4 max-w-(--skeleton-width) flex-1"
 		data-sidebar="menu-skeleton-text"
 		style="--skeleton-width: {width};"
 	/>

--- a/packages/ui/src/sidebar/sidebar-menu-sub-button.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu-sub-button.svelte
@@ -19,11 +19,7 @@
 
 	const mergedProps = $derived({
 		class: cn(
-			'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground outline-hidden flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
-			'data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground',
-			size === 'sm' && 'text-xs',
-			size === 'md' && 'text-sm',
-			'group-data-[collapsible=icon]:hidden',
+			'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground h-7 gap-2 rounded-xl px-3 focus-visible:ring-2 data-[size=md]:text-sm data-[size=sm]:text-xs [&>svg]:size-4 flex min-w-0 -translate-x-px items-center overflow-hidden outline-hidden group-data-[collapsible=icon]:hidden disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:shrink-0',
 			className,
 		),
 		'data-slot': 'sidebar-menu-sub-button',

--- a/packages/ui/src/sidebar/sidebar-menu-sub-item.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu-sub-item.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="sidebar-menu-sub-item"
 	data-sidebar="menu-sub-item"
-	class={cn('group/menu-sub-item relative', className)}
+	class={cn("group/menu-sub-item relative", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/sidebar/sidebar-menu-sub.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu-sub.svelte
@@ -14,11 +14,7 @@
 	bind:this={ref}
 	data-slot="sidebar-menu-sub"
 	data-sidebar="menu-sub"
-	class={cn(
-		'border-sidebar-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-s px-2.5 py-0.5',
-		'group-data-[collapsible=icon]:hidden',
-		className,
-	)}
+	class={cn("border-sidebar-border mx-3.5 translate-x-px gap-1 border-l px-2.5 py-0.5 group-data-[collapsible=icon]:hidden flex min-w-0 flex-col", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/sidebar/sidebar-menu.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu.svelte
@@ -17,7 +17,7 @@
 	bind:this={ref}
 	data-slot="sidebar-menu"
 	data-sidebar="menu"
-	class={cn('flex w-full min-w-0 flex-col gap-1', className)}
+	class={cn("gap-0.5 flex w-full min-w-0 flex-col", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/sidebar/sidebar-provider.svelte
+++ b/packages/ui/src/sidebar/sidebar-provider.svelte
@@ -30,7 +30,6 @@
 			onOpenChange(value);
 
 			// This sets the cookie to keep the sidebar state.
-			// biome-ignore lint/suspicious/noDocumentCookie: intentional cookie for sidebar persistence
 			document.cookie = `${SIDEBAR_COOKIE_NAME}=${open}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
 		},
 	});
@@ -43,8 +42,8 @@
 		data-slot="sidebar-wrapper"
 		style="--sidebar-width: {SIDEBAR_WIDTH}; --sidebar-width-icon: {SIDEBAR_WIDTH_ICON}; {style}"
 		class={cn(
-			'group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full',
-			className,
+			"group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
+			className
 		)}
 		bind:this={ref}
 		{...restProps}

--- a/packages/ui/src/sidebar/sidebar-rail.svelte
+++ b/packages/ui/src/sidebar/sidebar-rail.svelte
@@ -21,17 +21,17 @@
 	data-sidebar="rail"
 	data-slot="sidebar-rail"
 	aria-label="Toggle Sidebar"
-	tabIndex={-1}
+	tabindex={-1}
 	onclick={sidebar.toggle}
 	title="Toggle Sidebar"
 	class={cn(
-		'hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:start-[calc(1/2*100%-1px)] after:w-[2px] group-data-[side=left]:-end-4 group-data-[side=right]:start-0 sm:flex',
-		'in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize',
-		'[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize',
-		'hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:start-full',
-		'[[data-side=left][data-collapsible=offcanvas]_&]:-end-2',
-		'[[data-side=right][data-collapsible=offcanvas]_&]:-start-2',
-		className,
+		"hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
+		"in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
+		"[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+		"hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",
+		"[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+		"[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+		className
 	)}
 	{...restProps}
 >

--- a/packages/ui/src/sidebar/sidebar-separator.svelte
+++ b/packages/ui/src/sidebar/sidebar-separator.svelte
@@ -14,6 +14,6 @@
 	bind:ref
 	data-slot="sidebar-separator"
 	data-sidebar="separator"
-	class={cn('bg-sidebar-border', className)}
+	class={cn("bg-sidebar-border mx-2 w-auto", className)}
 	{...restProps}
 />

--- a/packages/ui/src/sidebar/sidebar-trigger.svelte
+++ b/packages/ui/src/sidebar/sidebar-trigger.svelte
@@ -18,11 +18,12 @@
 </script>
 
 <Button
+	bind:ref
 	data-sidebar="trigger"
 	data-slot="sidebar-trigger"
 	variant="ghost"
-	size="icon"
-	class={cn('size-7', className)}
+	size="icon-sm"
+	class={cn("cn-sidebar-trigger", className)}
 	type="button"
 	onclick={(e) => {
 		onclick?.(e);

--- a/packages/ui/src/sidebar/sidebar.svelte
+++ b/packages/ui/src/sidebar/sidebar.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import type { HTMLAttributes } from 'svelte/elements';
+	import * as Sheet from '#/sheet/index.js';
 	import { cn, type WithElementRef } from '#/utils.js';
+	import { SIDEBAR_WIDTH_MOBILE } from './constants.js';
 	import { useSidebar } from './context.svelte.js';
 
 	let {
@@ -20,23 +22,47 @@
 	const sidebar = useSidebar();
 </script>
 
-{#if collapsible === 'none'}
+{#if collapsible === "none"}
 	<div
 		class={cn(
-			'bg-sidebar text-sidebar-foreground w-(--sidebar-width) flex h-full flex-col',
-			className,
+			"bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col",
+			className
 		)}
 		bind:this={ref}
 		{...restProps}
 	>
 		{@render children?.()}
 	</div>
+{:else if sidebar.isMobile}
+	<Sheet.Root
+		bind:open={() => sidebar.openMobile, (v) => sidebar.setOpenMobile(v)}
+		{...restProps}
+	>
+		<Sheet.Content
+			bind:ref
+			data-sidebar="sidebar"
+			data-slot="sidebar"
+			data-mobile="true"
+			class={cn(
+				"bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden",
+				className
+			)}
+			style="--sidebar-width: {SIDEBAR_WIDTH_MOBILE};"
+			{side}
+		>
+			<Sheet.Header class="sr-only">
+				<Sheet.Title>Sidebar</Sheet.Title>
+				<Sheet.Description>Displays the mobile sidebar.</Sheet.Description>
+			</Sheet.Header>
+			<div class="flex h-full w-full flex-col">{@render children?.()}</div>
+		</Sheet.Content>
+	</Sheet.Root>
 {:else}
 	<div
 		bind:this={ref}
-		class="text-sidebar-foreground group peer block"
+		class="text-sidebar-foreground group peer hidden md:block"
 		data-state={sidebar.state}
-		data-collapsible={sidebar.state === 'collapsed' ? collapsible : ''}
+		data-collapsible={sidebar.state === "collapsed" ? collapsible : ""}
 		data-variant={variant}
 		data-side={side}
 		data-slot="sidebar"
@@ -45,33 +71,33 @@
 		<div
 			data-slot="sidebar-gap"
 			class={cn(
-				'w-(--sidebar-width) relative bg-transparent transition-[width] duration-200 ease-linear',
-				'group-data-[collapsible=offcanvas]:w-0',
-				'group-data-[side=right]:rotate-180',
-				variant === 'floating' || variant === 'inset'
-					? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]'
-					: 'group-data-[collapsible=icon]:w-(--sidebar-width-icon)',
+				"transition-[width] duration-200 ease-linear relative w-(--sidebar-width) bg-transparent",
+				"group-data-[collapsible=offcanvas]:w-0",
+				"group-data-[side=right]:rotate-180",
+				variant === "floating" || variant === "inset"
+					? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
+					: "group-data-[collapsible=icon]:w-(--sidebar-width-icon)"
 			)}
 		></div>
 		<div
 			data-slot="sidebar-container"
 			class={cn(
-				'w-(--sidebar-width) fixed inset-y-0 z-10 flex h-svh transition-[left,right,width] duration-200 ease-linear',
-				side === 'left'
-					? 'start-0 group-data-[collapsible=offcanvas]:start-[calc(var(--sidebar-width)*-1)]'
-					: 'end-0 group-data-[collapsible=offcanvas]:end-[calc(var(--sidebar-width)*-1)]',
+				"fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+				side === "left"
+					? "start-0 group-data-[collapsible=offcanvas]:start-[calc(var(--sidebar-width)*-1)]"
+					: "end-0 group-data-[collapsible=offcanvas]:end-[calc(var(--sidebar-width)*-1)]",
 				// Adjust the padding for floating and inset variants.
-				variant === 'floating' || variant === 'inset'
-					? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]'
-					: 'group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-e group-data-[side=right]:border-s',
-				className,
+				variant === "floating" || variant === "inset"
+					? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
+					: "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-e group-data-[side=right]:border-s",
+				className
 			)}
 			{...restProps}
 		>
 			<div
 				data-sidebar="sidebar"
 				data-slot="sidebar-inner"
-				class="bg-sidebar group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
+				class="bg-sidebar group-data-[variant=floating]:ring-sidebar-border group-data-[variant=floating]:rounded-2xl group-data-[variant=floating]:shadow-sm group-data-[variant=floating]:ring-1 flex size-full flex-col"
 			>
 				{@render children?.()}
 			</div>

--- a/packages/ui/src/skeleton/skeleton.svelte
+++ b/packages/ui/src/skeleton/skeleton.svelte
@@ -12,6 +12,6 @@
 <div
 	bind:this={ref}
 	data-slot="skeleton"
-	class={cn('bg-accent animate-pulse rounded-md', className)}
+	class={cn("bg-muted rounded-2xl animate-pulse", className)}
 	{...restProps}
 ></div>

--- a/packages/ui/src/sonner/sonner.svelte
+++ b/packages/ui/src/sonner/sonner.svelte
@@ -14,12 +14,12 @@
 </script>
 
 <Sonner
-	richColors
 	theme={mode.current}
 	class="toaster group"
 	style="--normal-bg: var(--color-popover); --normal-text: var(--color-popover-foreground); --normal-border: var(--color-border);"
 	{...restProps}
-	>{#snippet loadingIcon()}
+>
+	{#snippet loadingIcon()}
 		<Loader2Icon class="size-4 animate-spin" />
 	{/snippet}
 	{#snippet successIcon()}

--- a/packages/ui/src/sonner/toast-on-error.ts
+++ b/packages/ui/src/sonner/toast-on-error.ts
@@ -27,10 +27,9 @@ import type { Result } from 'wellcrafted/result';
  * bookmarkState.toggle(tab).then((r) => toastOnError(r, 'Failed to toggle bookmark'));
  * ```
  */
-export function toastOnError<TInput extends Result<unknown, AnyTaggedError> | AnyTaggedError>(
-	resultOrError: TInput,
-	title: string,
-): TInput {
+export function toastOnError<
+	TInput extends Result<unknown, AnyTaggedError> | AnyTaggedError,
+>(resultOrError: TInput, title: string): TInput {
 	const error = 'data' in resultOrError ? resultOrError.error : resultOrError;
 	if (error) {
 		toast.error(title, { description: error.message });

--- a/packages/ui/src/spinner/spinner.svelte
+++ b/packages/ui/src/spinner/spinner.svelte
@@ -1,15 +1,26 @@
 <script lang="ts">
 	import Loader2Icon from '@lucide/svelte/icons/loader-2';
-	import type { ComponentProps } from 'svelte';
+	import type { SVGAttributes } from 'svelte/elements';
 	import { cn } from '#/utils.js';
 
-	let { class: className, ...restProps }: ComponentProps<typeof Loader2Icon> =
-		$props();
+	let {
+		class: className,
+		role = 'status',
+		// we add name, color, and stroke for compatibility with different icon libraries props
+		name,
+		color,
+		stroke,
+		'aria-label': ariaLabel = 'Loading',
+		...restProps
+	}: SVGAttributes<SVGSVGElement> = $props();
 </script>
 
 <Loader2Icon
-	role="status"
-	aria-label="Loading"
-	class={cn('size-4 animate-spin', className)}
+	{role}
+	name={name === null ? undefined : name}
+	color={color === null ? undefined : color}
+	stroke={stroke === null ? undefined : stroke}
+	aria-label={ariaLabel}
+	class={cn("size-4 animate-spin", className)}
 	{...restProps}
 />

--- a/packages/ui/src/star-rating/star-rating-star.svelte
+++ b/packages/ui/src/star-rating/star-rating-star.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import { cn } from '../utils.js';
-	import StarHalfIcon from '@lucide/svelte/icons/star-half';
 	import StarIcon from '@lucide/svelte/icons/star';
+	import StarHalfIcon from '@lucide/svelte/icons/star-half';
 	import { RatingGroup } from 'bits-ui';
+	import { cn } from '../utils.js';
 	import type { StarRatingStarProps } from './types';
 
 	let { index, state, class: className }: StarRatingStarProps = $props();

--- a/packages/ui/src/star-rating/star-rating.svelte
+++ b/packages/ui/src/star-rating/star-rating.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { cn } from '../utils.js';
 	import { RatingGroup, type RatingGroupRootProps } from 'bits-ui';
+	import { cn } from '../utils.js';
 
 	let {
 		value = $bindable(0),

--- a/packages/ui/src/switch/switch.svelte
+++ b/packages/ui/src/switch/switch.svelte
@@ -6,24 +6,26 @@
 		ref = $bindable(null),
 		class: className,
 		checked = $bindable(false),
+		size = 'default',
 		...restProps
-	}: WithoutChildrenOrChild<SwitchPrimitive.RootProps> = $props();
+	}: WithoutChildrenOrChild<SwitchPrimitive.RootProps> & {
+		size?: 'sm' | 'default';
+	} = $props();
 </script>
 
 <SwitchPrimitive.Root
 	bind:ref
 	bind:checked
 	data-slot="switch"
+	data-size={size}
 	class={cn(
-		'data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 shadow-xs peer inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent outline-none transition-all focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
-		className,
+		"data-checked:bg-primary data-unchecked:bg-input/90 data-checked:border-primary focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 shrink-0 rounded-full border-2 focus-visible:ring-3 aria-invalid:ring-3 data-unchecked:border-transparent data-[size=default]:h-5 data-[size=default]:w-11 data-[size=sm]:h-4 data-[size=sm]:w-7 peer group/switch relative inline-flex items-center transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+		className
 	)}
 	{...restProps}
 >
 	<SwitchPrimitive.Thumb
 		data-slot="switch-thumb"
-		class={cn(
-			'bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0',
-		)}
+		class="bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full shadow-sm not-dark:bg-clip-padding group-data-[size=default]/switch:h-4 group-data-[size=default]/switch:w-6 group-data-[size=sm]/switch:h-3 group-data-[size=sm]/switch:w-4 data-checked:translate-x-[calc(100%-8px)] data-unchecked:translate-x-0 pointer-events-none block ring-0 transition-transform rtl:data-[state=checked]:translate-x-[calc(-100%)]"
 	/>
 </SwitchPrimitive.Root>

--- a/packages/ui/src/table/index.ts
+++ b/packages/ui/src/table/index.ts
@@ -1,5 +1,3 @@
-import SelectAllPopover from './SelectAllPopover.svelte';
-import SortableTableHeader from './SortableTableHeader.svelte';
 import Root from './table.svelte';
 import Body from './table-body.svelte';
 import Caption from './table-caption.svelte';
@@ -27,6 +25,4 @@ export {
 	Root as Table,
 	Row,
 	Row as TableRow,
-	SelectAllPopover,
-	SortableTableHeader,
 };

--- a/packages/ui/src/table/index.ts
+++ b/packages/ui/src/table/index.ts
@@ -1,3 +1,5 @@
+import SelectAllPopover from './SelectAllPopover.svelte';
+import SortableTableHeader from './SortableTableHeader.svelte';
 import Root from './table.svelte';
 import Body from './table-body.svelte';
 import Caption from './table-caption.svelte';
@@ -25,4 +27,6 @@ export {
 	Root as Table,
 	Row,
 	Row as TableRow,
+	SelectAllPopover,
+	SortableTableHeader,
 };

--- a/packages/ui/src/table/table-body.svelte
+++ b/packages/ui/src/table/table-body.svelte
@@ -13,7 +13,7 @@
 <tbody
 	bind:this={ref}
 	data-slot="table-body"
-	class={cn('[&_tr:last-child]:border-0', className)}
+	class={cn("[&_tr:last-child]:border-0", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/table/table-caption.svelte
+++ b/packages/ui/src/table/table-caption.svelte
@@ -13,7 +13,7 @@
 <caption
 	bind:this={ref}
 	data-slot="table-caption"
-	class={cn('text-muted-foreground mt-4 text-sm', className)}
+	class={cn("text-muted-foreground mt-4 text-sm", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/table/table-cell.svelte
+++ b/packages/ui/src/table/table-cell.svelte
@@ -6,22 +6,14 @@
 		ref = $bindable(null),
 		class: className,
 		children,
-		variant = 'default',
 		...restProps
-	}: WithElementRef<HTMLTdAttributes> & {
-		variant?: 'default' | 'muted' | 'numeric';
-	} = $props();
+	}: WithElementRef<HTMLTdAttributes> = $props();
 </script>
 
 <td
 	bind:this={ref}
 	data-slot="table-cell"
-	class={cn(
-		'whitespace-nowrap bg-clip-padding p-2 align-middle [&:has([role=checkbox])]:pe-0',
-		variant === 'muted' && 'text-muted-foreground',
-		variant === 'numeric' && 'text-right font-mono',
-		className,
-	)}
+	class={cn("p-3 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/table/table-footer.svelte
+++ b/packages/ui/src/table/table-footer.svelte
@@ -13,10 +13,7 @@
 <tfoot
 	bind:this={ref}
 	data-slot="table-footer"
-	class={cn(
-		'bg-muted/50 border-t font-medium [&>tr]:last:border-b-0',
-		className,
-	)}
+	class={cn("bg-muted/50 border-t font-medium [&>tr]:last:border-b-0", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/table/table-head.svelte
+++ b/packages/ui/src/table/table-head.svelte
@@ -13,10 +13,7 @@
 <th
 	bind:this={ref}
 	data-slot="table-head"
-	class={cn(
-		'text-foreground h-10 whitespace-nowrap bg-clip-padding px-2 text-start align-middle font-medium [&:has([role=checkbox])]:pe-0',
-		className,
-	)}
+	class={cn("text-foreground h-12 px-3 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/table/table-header.svelte
+++ b/packages/ui/src/table/table-header.svelte
@@ -13,7 +13,7 @@
 <thead
 	bind:this={ref}
 	data-slot="table-header"
-	class={cn('[&_tr]:border-b', className)}
+	class={cn("[&_tr]:border-b", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/table/table-row.svelte
+++ b/packages/ui/src/table/table-row.svelte
@@ -13,10 +13,7 @@
 <tr
 	bind:this={ref}
 	data-slot="table-row"
-	class={cn(
-		'hover:[&,&>svelte-css-wrapper]:[&>th,td]:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors',
-		className,
-	)}
+	class={cn("hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/packages/ui/src/table/table.svelte
+++ b/packages/ui/src/table/table.svelte
@@ -14,7 +14,7 @@
 	<table
 		bind:this={ref}
 		data-slot="table"
-		class={cn('w-full caption-bottom text-sm', className)}
+		class={cn("w-full caption-bottom text-sm", className)}
 		{...restProps}
 	>
 		{@render children?.()}

--- a/packages/ui/src/tabs/index.ts
+++ b/packages/ui/src/tabs/index.ts
@@ -1,6 +1,9 @@
 import Root from './tabs.svelte';
 import Content from './tabs-content.svelte';
-import List from './tabs-list.svelte';
+import List, {
+	type TabsListVariant,
+	tabsListVariants,
+} from './tabs-list.svelte';
 import Trigger from './tabs-trigger.svelte';
 
 export {
@@ -11,6 +14,8 @@ export {
 	Root,
 	//
 	Root as Tabs,
+	type TabsListVariant,
 	Trigger,
 	Trigger as TabsTrigger,
+	tabsListVariants,
 };

--- a/packages/ui/src/tabs/tabs-content.svelte
+++ b/packages/ui/src/tabs/tabs-content.svelte
@@ -12,6 +12,6 @@
 <TabsPrimitive.Content
 	bind:ref
 	data-slot="tabs-content"
-	class={cn('outline-none', className)}
+	class={cn("text-sm flex-1 outline-none", className)}
 	{...restProps}
 />

--- a/packages/ui/src/tabs/tabs-list.svelte
+++ b/packages/ui/src/tabs/tabs-list.svelte
@@ -1,20 +1,42 @@
+<script lang="ts" module>
+	import { tv, type VariantProps } from 'tailwind-variants';
+
+	export const tabsListVariants = tv({
+		base: 'rounded-full p-1 group-data-horizontal/tabs:h-9 group-data-vertical/tabs:rounded-2xl data-[variant=line]:rounded-none group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col',
+		variants: {
+			variant: {
+				default: 'cn-tabs-list-variant-default bg-muted',
+				line: 'cn-tabs-list-variant-line gap-1 bg-transparent',
+			},
+		},
+		defaultVariants: {
+			variant: 'default',
+		},
+	});
+
+	export type TabsListVariant = VariantProps<
+		typeof tabsListVariants
+	>['variant'];
+</script>
+
 <script lang="ts">
 	import { Tabs as TabsPrimitive } from 'bits-ui';
 	import { cn } from '#/utils.js';
 
 	let {
 		ref = $bindable(null),
+		variant = 'default',
 		class: className,
 		...restProps
-	}: TabsPrimitive.ListProps = $props();
+	}: TabsPrimitive.ListProps & {
+		variant?: TabsListVariant;
+	} = $props();
 </script>
 
 <TabsPrimitive.List
 	bind:ref
 	data-slot="tabs-list"
-	class={cn(
-		'bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]',
-		className,
-	)}
+	data-variant={variant}
+	class={cn(tabsListVariants({ variant }), className)}
 	{...restProps}
 />

--- a/packages/ui/src/tabs/tabs-trigger.svelte
+++ b/packages/ui/src/tabs/tabs-trigger.svelte
@@ -13,8 +13,11 @@
 	bind:ref
 	data-slot="tabs-trigger"
 	class={cn(
-		"data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent px-2 py-1 text-sm font-medium transition-[color,box-shadow] focus-visible:outline-1 focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-		className,
+		"gap-2 rounded-full border border-transparent! px-3 py-1 text-sm font-medium group-data-vertical/tabs:rounded-2xl group-data-vertical/tabs:px-3 group-data-vertical/tabs:py-1.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 [&_svg:not([class*='size-'])]:size-4 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center whitespace-nowrap transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		"group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
+		"data-active:bg-background dark:data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 data-active:text-foreground",
+		"after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+		className
 	)}
 	{...restProps}
 />

--- a/packages/ui/src/tabs/tabs.svelte
+++ b/packages/ui/src/tabs/tabs.svelte
@@ -14,6 +14,6 @@
 	bind:ref
 	bind:value
 	data-slot="tabs"
-	class={cn('flex flex-col gap-2', className)}
+	class={cn("gap-2 group/tabs flex data-[orientation=horizontal]:flex-col", className)}
 	{...restProps}
 />

--- a/packages/ui/src/textarea/textarea.svelte
+++ b/packages/ui/src/textarea/textarea.svelte
@@ -15,8 +15,8 @@
 	bind:this={ref}
 	data-slot={dataSlot}
 	class={cn(
-		'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 field-sizing-content shadow-xs flex min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
-		className,
+		"bg-input/50 focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 resize-none rounded-2xl border border-transparent px-3 py-3 text-base transition-[color,box-shadow,background-color] focus-visible:ring-3 aria-invalid:ring-3 md:text-sm placeholder:text-muted-foreground flex field-sizing-content min-h-16 w-full outline-none disabled:cursor-not-allowed disabled:opacity-50",
+		className
 	)}
 	bind:value
 	{...restProps}

--- a/packages/ui/src/timezone-combobox/timezone-combobox.svelte
+++ b/packages/ui/src/timezone-combobox/timezone-combobox.svelte
@@ -43,9 +43,7 @@
 	const selectedTimeZone = $derived(
 		timeZoneOptions.find((timeZoneOption) => timeZoneOption.timeZone === value),
 	);
-	const triggerLabel = $derived(
-		selectedTimeZone?.label ?? 'Select timezone',
-	);
+	const triggerLabel = $derived(selectedTimeZone?.label ?? 'Select timezone');
 </script>
 
 <Popover.Root bind:open={combobox.open}>

--- a/packages/ui/src/toggle-group/toggle-group-item.svelte
+++ b/packages/ui/src/toggle-group/toggle-group-item.svelte
@@ -21,13 +21,14 @@
 	data-slot="toggle-group-item"
 	data-variant={ctx.variant || variant}
 	data-size={ctx.size || size}
+	data-spacing={ctx.spacing}
 	class={cn(
+		"data-[state=on]:bg-muted group-data-[spacing=0]/toggle-group:rounded-none group-data-[spacing=0]/toggle-group:px-3 group-data-[spacing=0]/toggle-group:shadow-none group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pr-2.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:pl-2.5 group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-l-3xl group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-3xl group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-r-3xl group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-3xl shrink-0 focus:z-10 focus-visible:z-10 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t",
 		toggleVariants({
 			variant: ctx.variant || variant,
 			size: ctx.size || size,
 		}),
-		'min-w-0 flex-1 shrink-0 rounded-none shadow-none first:rounded-s-md last:rounded-e-md focus:z-10 focus-visible:z-10 data-[variant=outline]:border-s-0 data-[variant=outline]:first:border-s',
-		className,
+		className
 	)}
 	{value}
 	{...restProps}

--- a/packages/ui/src/toggle-group/toggle-group.svelte
+++ b/packages/ui/src/toggle-group/toggle-group.svelte
@@ -1,12 +1,21 @@
 <script lang="ts" module>
 	import { getContext, setContext } from 'svelte';
-	import type { ToggleVariants } from '#/toggle/index.js';
-	export function setToggleGroupCtx(props: ToggleVariants) {
+	import type { VariantProps } from 'tailwind-variants';
+	import { toggleVariants } from '#/toggle/index.js';
+
+	type ToggleVariants = VariantProps<typeof toggleVariants>;
+
+	interface ToggleGroupContext extends ToggleVariants {
+		spacing?: number;
+		orientation?: 'horizontal' | 'vertical';
+	}
+
+	export function setToggleGroupCtx(props: ToggleGroupContext) {
 		setContext('toggleGroup', props);
 	}
 
 	export function getToggleGroupCtx() {
-		return getContext<ToggleVariants>('toggleGroup');
+		return getContext<Required<ToggleGroupContext>>('toggleGroup');
 	}
 </script>
 
@@ -19,17 +28,28 @@
 		value = $bindable(),
 		class: className,
 		size = 'default',
+		spacing = 0,
+		orientation = 'horizontal',
 		variant = 'default',
 		...restProps
-	}: ToggleGroupPrimitive.RootProps & ToggleVariants = $props();
+	}: ToggleGroupPrimitive.RootProps &
+		ToggleVariants & {
+			spacing?: number;
+			orientation?: 'horizontal' | 'vertical';
+		} = $props();
 
-	// Use getters so child components receive reactive values when props change
 	setToggleGroupCtx({
 		get variant() {
 			return variant;
 		},
 		get size() {
 			return size;
+		},
+		get spacing() {
+			return spacing;
+		},
+		get orientation() {
+			return orientation;
 		},
 	});
 </script>
@@ -41,12 +61,15 @@ get along, so we shut typescript up by casting `value` to `never`.
 <ToggleGroupPrimitive.Root
 	bind:value={value as never}
 	bind:ref
+	{orientation}
 	data-slot="toggle-group"
 	data-variant={variant}
 	data-size={size}
+	data-spacing={spacing}
+	style={`--gap: ${spacing}`}
 	class={cn(
-		'group/toggle-group data-[variant=outline]:shadow-xs flex w-fit items-center rounded-md',
-		className,
+		"data-[spacing=0]:data-[variant=outline]:rounded-3xl group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] data-vertical:flex-col data-vertical:items-stretch",
+		className
 	)}
 	{...restProps}
 />

--- a/packages/ui/src/toggle/toggle.svelte
+++ b/packages/ui/src/toggle/toggle.svelte
@@ -2,17 +2,17 @@
 	import { tv, type VariantProps } from 'tailwind-variants';
 
 	export const toggleVariants = tv({
-		base: "hover:bg-muted hover:text-muted-foreground data-[state=on]:bg-accent data-[state=on]:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		base: "hover:text-foreground aria-pressed:bg-muted focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive gap-1 rounded-3xl text-sm font-medium transition-colors [&_svg:not([class*='size-'])]:size-4 group/toggle hover:bg-muted inline-flex items-center justify-center whitespace-nowrap outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		variants: {
 			variant: {
 				default: 'bg-transparent',
-				outline:
-					'border-input shadow-xs hover:bg-accent hover:text-accent-foreground border bg-transparent',
+				outline: 'border-input hover:bg-muted border bg-transparent',
 			},
 			size: {
-				default: 'h-9 min-w-9 px-2',
-				sm: 'h-8 min-w-8 px-1.5',
-				lg: 'h-10 min-w-10 px-2.5',
+				default:
+					'h-9 min-w-9 px-3 has-data-[icon=inline-end]:pr-2.5 has-data-[icon=inline-start]:pl-2.5',
+				sm: 'h-8 min-w-8 px-3 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2',
+				lg: 'h-10 min-w-10 px-4 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3',
 			},
 		},
 		defaultVariants: {

--- a/packages/ui/src/tooltip/tooltip-content.svelte
+++ b/packages/ui/src/tooltip/tooltip-content.svelte
@@ -27,8 +27,8 @@
 		{sideOffset}
 		{side}
 		class={cn(
-			'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-end-2 data-[side=right]:slide-in-from-start-2 data-[side=top]:slide-in-from-bottom-2 origin-(--bits-tooltip-content-transform-origin) z-50 w-fit text-balance rounded-md px-3 py-1.5 text-xs',
-			className,
+			"data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 inline-flex items-center gap-1.5 rounded-xl px-3 py-1.5 text-xs has-data-[slot=kbd]:pr-1.5 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-lg bg-foreground text-background z-50 w-fit max-w-xs origin-(--bits-tooltip-content-transform-origin)",
+			className
 		)}
 		{...restProps}
 	>
@@ -37,12 +37,12 @@
 			{#snippet child({ props })}
 				<div
 					class={cn(
-						'bg-primary z-50 size-2.5 rotate-45 rounded-[2px]',
-						'data-[side=top]:translate-x-1/2 data-[side=top]:translate-y-[calc(-50%_+_2px)]',
-						'data-[side=bottom]:-translate-x-1/2 data-[side=bottom]:-translate-y-[calc(-50%_+_1px)]',
-						'data-[side=right]:translate-x-[calc(50%_+_2px)] data-[side=right]:translate-y-1/2',
-						'data-[side=left]:-translate-y-[calc(50%_-_3px)]',
-						arrowClasses,
+						"size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] data-[side=left]:translate-x-[-1.5px] data-[side=right]:translate-x-[1.5px] bg-foreground fill-foreground z-50",
+						"data-[side=top]:translate-x-1/2 data-[side=top]:translate-y-[calc(-50%+2px)]",
+						"data-[side=bottom]:-translate-x-1/2 data-[side=bottom]:-translate-y-[calc(-50%+1px)]",
+						"data-[side=right]:translate-x-[calc(50%+2px)] data-[side=right]:translate-y-1/2",
+						"data-[side=left]:-translate-y-[calc(50%-3px)]",
+						arrowClasses
 					)}
 					{...props}
 				></div>


### PR DESCRIPTION
`packages/ui` was sitting on a pre-1.0 shadcn-svelte setup: slate base color, Manrope everywhere, no `style` field, no `iconLibrary`/`menuColor`/`menuAccent` in `components.json`. shadcn-svelte has since shipped the **Luma** style with its own preset picker, and the one we want is `b4IyDhFRSq` — Luma style, taupe base, Lora headings, Inter body, Lucide icons, subtle menu accent. Time to adopt it.

The idiomatic path per the docs is `shadcn-svelte init --overwrite`: it rewrites `components.json`, regenerates the CSS variable block in `app.css`, and reinstalls every registry component in place. That's a "clean break" file-by-file — not a directory nuke — which is both cheaper than rewriting by hand and gives us whatever registry fixes have landed upstream. The downside: it also wipes every Epicenter-local customization the CLI doesn't know about. Finding and surgically re-applying those on top of the new Luma baseline is most of what this PR is.

```bash
bun x shadcn-svelte@latest init --preset b4IyDhFRSq --overwrite --no-deps \
  --css src/app.css --components-alias '#' --lib-alias '#/lib' \
  --utils-alias '#/utils' --hooks-alias '#/hooks' --ui-alias '#'
```

One nice surprise during review: Luma applies `class=\"font-heading\"` directly inside component titles (CardTitle, AlertDialogTitle, AlertTitle, etc.) rather than relying on a global `h1–h6` rule. That's the idiomatic pattern for the Luma style, and the CLI wires it up automatically. Define `--font-heading: \"Lora Variable\", serif` once in `@theme inline` and Lora renders wherever a registry title component is used. No consumer changes, no global CSS reset.

```css
@theme inline {
    --font-sans: \"Inter Variable\", sans-serif;
    --font-heading: \"Lora Variable\", serif;
    /* taupe-derived tokens, chart colors, sidebar tokens… */
}
```

The surgical restorations fall into three buckets. **First, plain exports the CLI clobbered.** `sonner/index.ts` lost its `toast` and `toastOnError` re-exports (used in ten-plus files across apps). `table/index.ts` dropped `SelectAllPopover` and `SortableTableHeader` (both Epicenter-custom, consumed by Whispering's recordings and transformations pages). `utils.ts` and `chart-utils.ts` had their `biome-ignore` comments replaced with `eslint-disable-next-line` — wrong linter for this repo. All restored.

**Second, genuine component behavior that would regress silently.** `button.svelte` lost its custom `tooltip` prop that wraps the button in `<Tooltip.Root>` when set — 67 call sites across Whispering and tab-manager depended on it. `badge.svelte` lost `success` and `id` variants (semantic pills used for status and entity IDs) and three `status.*` variants (more on those below). The whole drawer/dialog z-index story got flattened: everything Luma-generated sits at `z-50`, which works by accident via DOM order but breaks the moment an alert-dialog opens from inside a drawer. Pre-Luma we pinned drawers and regular dialogs to `z-40` so alert-dialogs (at `z-50`) always win. Restored. Same for the vaul-svelte focus-recursion workaround on drawer content (`onOpenAutoFocus={(e) => e.preventDefault()}`), which is still needed because `vaul-svelte@1.0.0-next.7` still depends on `bits-ui@^1` while we're on `^2` — [huntabyte/vaul-svelte#135](https://github.com/huntabyte/vaul-svelte/issues/135). Luma also dropped the scroll wrapper inside drawer/dialog content, so tall content clipped at viewport. Restored.

**Third, behaviors you'd only notice later.** Tooltip provider defaults went from our `300ms`/`150ms` (the desktop-app sweet spot) to Luma's `0ms` — every hover would instantly pop a tooltip across 67 button sites. The Item component lost `relative` on its base (needed for absolute-positioned hover actions), `min-w-0` on title and content (needed for flex text truncation), and Luma's `w-fit` actively prevented shrinking. The Select dropdown lost its `max-w-min` clamp, so long options would expand the dropdown wider than the trigger. Resizable pane-group lost its `gap-2` spacing. All restored, each with a `// Custom:` or `// Custom override:` comment so the next CLI refresh has a prayer of surviving.

Two Luma-design decisions we accepted rather than fought: **destructive variants are now tinted by default** on both button and badge (subtle `bg-destructive/10` instead of solid red), and **RTL logical properties were swept registry-wide** (`ps-/pe-/ms-/me-` → `pl-/pr-/ml-/mr-`). The tinted-destructive shift means we don't need a separate `ghost-destructive` variant anymore — Luma's default `destructive` looks very close to what `ghost-destructive` was. Five call sites across `apps/fuji` and `apps/tab-manager` now use `variant=\"destructive\"` instead. RTL isn't a current concern for these English-primary apps; if it becomes one, it's a separate project.

```typescript
// Before
<Button variant=\"ghost-destructive\" onclick={onRetry}>

// After
<Button variant=\"destructive\" onclick={onRetry}>
```

One sidequest: the `status.completed`/`status.failed`/`status.running` badge variants were a real code smell. They existed to support a dynamic template-literal lookup in `Runs.svelte`:

```svelte
<!-- Before — no compile-time check that status matches a real variant -->
<Badge variant={`status.${run.status}`}>{run.status}</Badge>
```

Deepwiki confirmed what we suspected: shadcn-svelte's idiomatic pattern for status indicators is **composition**, not custom variants — `<Badge variant=\"outline\">` + a Lucide icon + a Tailwind color class. That's what the `DataTableStatus` snippet in the data-table block does. So the three `status.*` variants are out, replaced with a small local `RunStatusBadge` component that maps `'completed' | 'failed' | 'running'` to `CircleCheckIcon` / `CircleXIcon` / `Spinner` plus a green/red/blue text color. Type-safe at the call site, Badge surface aligned with the registry, component lives where it belongs (Whispering, not `@epicenter/ui`).

```svelte
<!-- After — compile-time enforced, idiomatic composition -->
<RunStatusBadge status={run.status} />
```

One known gap worth calling out: tab-manager's `svelte-check` produces nine new \"Cannot find module `#/utils.js`\" errors in the newly-added registry files (`avatar-badge`, `avatar-group`, `avatar-group-count`, plus some item subcomponents). The root cause is pre-existing — `packages/ui/package.json` declares `imports: { \"#*\": ... }` but tab-manager's tsconfig doesn't mirror those as `paths`. It resolves fine at runtime; only svelte-check cares. Fix is a tsconfig paths entry in tab-manager, orthogonal to this PR. Whispering's typecheck is clean against main (27 pre-existing errors in other concerns, zero regressions from this change).

Net change across 249 files: +1292/-834.