### PR TITLE
docs(workspace): fix misleading createDisposableCache JSDoc

### DIFF
--- a/packages/workspace/src/cache/disposable-cache.test.ts
+++ b/packages/workspace/src/cache/disposable-cache.test.ts
@@ -4,7 +4,7 @@ import { createDisposableCache } from './disposable-cache.js';
 
 /**
  * Helper: a minimal Disposable wrapping a Y.Doc. Y.Doc is the most common
- * real-world value, but the cache itself is generic — these tests exercise
+ * real-world value, but the cache itself is generic; these tests exercise
  * the cache through Y.Doc only because Y.Doc.isDestroyed gives an easy
  * "did dispose actually run?" assertion.
  */
@@ -59,7 +59,7 @@ describe('open / cache identity', () => {
 	});
 
 	test('build closure runs without coupling to a parent context', () => {
-		// Pure builder — no closures, no module-scope state. The cache calls
+		// Pure builder: no closures, no module-scope state. The cache calls
 		// it with just an id and gets back a Disposable.
 		const cache = createDisposableCache((id: string) => ({
 			ydoc: new Y.Doc({ guid: id }),
@@ -92,7 +92,7 @@ describe('throwing build closure', () => {
 
 		expect(() => cache.open('foo')).toThrow('boom');
 		expect(cache.has('foo')).toBe(false);
-		// The second attempt must run the closure again — no poisoned entry.
+		// The second attempt must run the closure again; no poisoned entry.
 		const handle = cache.open('foo');
 		expect(calls).toBe(2);
 		expect(handle.ydoc.guid).toBe('foo');
@@ -273,7 +273,7 @@ describe('cache[Symbol.dispose]', () => {
 		});
 		cache.open('a');
 
-		// No await — cache dispose returns void and cascades synchronously.
+		// No await: cache dispose returns void and cascades synchronously.
 		cache[Symbol.dispose]();
 
 		await sentinel;
@@ -281,7 +281,7 @@ describe('cache[Symbol.dispose]', () => {
 });
 
 // ════════════════════════════════════════════════════════════════════════════
-// open / dispose — refcount, grace-period disposal, disposable protocol
+// open / dispose: refcount, grace-period disposal, disposable protocol
 // ════════════════════════════════════════════════════════════════════════════
 
 describe('open / dispose', () => {
@@ -310,7 +310,7 @@ describe('open / dispose', () => {
 		expect(h1.ydoc.isDestroyed).toBe(true);
 	});
 
-	test('using h = cache.open(id) — disposes on scope exit', async () => {
+	test('using h = cache.open(id) disposes on scope exit', async () => {
 		const cache = makeYDocCache({ gcTime: 10 });
 		let ydocRef: Y.Doc;
 		{
@@ -348,7 +348,7 @@ describe('open / dispose', () => {
 		expect(h.ydoc.isDestroyed).toBe(true);
 	});
 
-	test('gcTime: 0 — last dispose tears down synchronously', () => {
+	test('gcTime: 0 tears down synchronously on last dispose', () => {
 		const cache = makeYDocCache({ gcTime: 0 });
 		const h1 = cache.open('a');
 		const h2 = cache.open('a');
@@ -358,7 +358,7 @@ describe('open / dispose', () => {
 		expect(h1.ydoc.isDestroyed).toBe(true);
 	});
 
-	test('gcTime: Infinity — entry stays live indefinitely; cache dispose forces teardown', async () => {
+	test('gcTime: Infinity keeps entry live indefinitely; cache dispose forces teardown', async () => {
 		const cache = makeYDocCache({ gcTime: Number.POSITIVE_INFINITY });
 		const h = cache.open('a');
 		const ydoc = h.ydoc;
@@ -374,18 +374,209 @@ describe('open / dispose', () => {
 		expect(ydoc.isDestroyed).toBe(true);
 	});
 
-	test('default gcTime is finite (5s) — teardown eventually fires without explicit cache dispose', async () => {
+	test('default gcTime is finite (5s); teardown eventually fires without explicit cache dispose', async () => {
 		// Guards the documented default. A bug that flipped the default back
 		// to Infinity would make this test hang past the assertion window.
 		const cache = makeYDocCache(); // default
 		const h = cache.open('a');
 		const ydoc = h.ydoc;
 		h[Symbol.dispose]();
-		// Not waiting the full 5s here — just confirm the timer was armed by
+		// Not waiting the full 5s here; just confirm the timer was armed by
 		// looking up has(). It should be true (in grace), not absent.
 		expect(cache.has('a')).toBe(true);
 		expect(ydoc.isDestroyed).toBe(false);
 		// Cleanup
+		cache[Symbol.dispose]();
+	});
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// re-entrancy
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('re-entrancy', () => {
+	test('build(a) can call cache.open(b) without corrupting cache state', () => {
+		// A builder that, while constructing entry 'parent', reaches back into
+		// the cache to open 'child'. Both entries should coexist; neither map
+		// state nor refcounts should be corrupted.
+		// biome-ignore lint/suspicious/noExplicitAny: cache referenced inside its own builder
+		let cache: any;
+		cache = createDisposableCache((id: string) => {
+			if (id === 'parent') {
+				const child = cache.open('child');
+				return {
+					id,
+					childRef: child,
+					[Symbol.dispose]() {
+						child[Symbol.dispose]();
+					},
+				};
+			}
+			return {
+				id,
+				[Symbol.dispose]() {},
+			};
+		});
+
+		const parent = cache.open('parent');
+		expect(parent.id).toBe('parent');
+		expect(parent.childRef.id).toBe('child');
+		expect(cache.has('parent')).toBe(true);
+		expect(cache.has('child')).toBe(true);
+
+		parent[Symbol.dispose]();
+		cache[Symbol.dispose]();
+	});
+
+	test("value's [Symbol.dispose] can re-enter via cache.open(sameId) and gets a fresh entry", () => {
+		// During teardown, the entry is removed from the cache's internal map
+		// BEFORE the value's [Symbol.dispose]() runs. So a re-entrant open of
+		// the same id during teardown must construct a brand new entry, not
+		// resurrect the about-to-be-destroyed one.
+		// biome-ignore lint/suspicious/noExplicitAny: cache referenced inside its own builder
+		let cache: any;
+		let buildCount = 0;
+		// biome-ignore lint/suspicious/noExplicitAny: handle type is parameterized via the cache itself
+		let reopenedHandle: any;
+		cache = createDisposableCache(
+			(id: string) => {
+				buildCount++;
+				const buildIndex = buildCount;
+				return {
+					id,
+					buildIndex,
+					[Symbol.dispose]() {
+						// Only re-open once, from the first instance's teardown.
+						if (buildIndex === 1 && !reopenedHandle) {
+							reopenedHandle = cache.open(id);
+						}
+					},
+				};
+			},
+			{ gcTime: 0 },
+		);
+
+		const h = cache.open('a');
+		h[Symbol.dispose]();
+
+		// The dispose triggered a re-open. We should now have a fresh entry,
+		// not a stale reference to the just-destroyed one.
+		expect(buildCount).toBe(2);
+		expect(reopenedHandle.buildIndex).toBe(2);
+		expect(cache.has('a')).toBe(true);
+		reopenedHandle[Symbol.dispose]();
+		expect(cache.has('a')).toBe(false);
+	});
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// throwing dispose via grace-timer path
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('throwing value [Symbol.dispose] via the grace-timer path', () => {
+	test('does not propagate; cache evicts; subsequent open works', async () => {
+		// The cache-level dispose path is covered by another test. This one
+		// covers the same throwing dispose, but reached via the grace timer
+		// firing after the last handle is released.
+		let buildCount = 0;
+		const cache = createDisposableCache(
+			(id: string) => {
+				buildCount++;
+				return {
+					id,
+					[Symbol.dispose]() {
+						throw new Error('grace-timer dispose boom');
+					},
+				};
+			},
+			{ gcTime: 20 },
+		);
+
+		const prevError = console.error;
+		console.error = () => {};
+		try {
+			const h = cache.open('a');
+			h[Symbol.dispose]();
+			// Wait long enough for the grace timer to fire and the throwing
+			// dispose to be caught + logged.
+			await new Promise((r) => setTimeout(r, 50));
+			expect(cache.has('a')).toBe(false);
+
+			// A subsequent open builds fresh, proving the throw didn't leave
+			// a poisoned entry behind.
+			const h2 = cache.open('a');
+			expect(buildCount).toBe(2);
+			h2[Symbol.dispose]();
+		} finally {
+			console.error = prevError;
+		}
+	});
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// plain-object invariant (T must be a plain object)
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('plain-object invariant', () => {
+	test('class instances passed directly LOSE prototype methods on the handle', () => {
+		// The handle is built via spread, which copies own enumerable
+		// properties only. Methods on the class prototype are NOT copied.
+		// This test pins down that documented limitation so a future change
+		// to the wrapping strategy doesn't silently regress it.
+		class WithPrototypeMethod {
+			name = 'underlying';
+			greet(): string {
+				return `hi from ${this.name}`;
+			}
+			[Symbol.dispose]() {}
+		}
+		const cache = createDisposableCache(
+			(_id: string) => new WithPrototypeMethod(),
+		);
+		const handle = cache.open('a');
+
+		// Own field is preserved by the spread.
+		expect(handle.name).toBe('underlying');
+		// Prototype method is NOT preserved by the spread.
+		expect(
+			(handle as unknown as { greet?: unknown }).greet,
+		).toBeUndefined();
+
+		handle[Symbol.dispose]();
+		cache[Symbol.dispose]();
+	});
+
+	test('wrapping a class instance in a plain object preserves access to its methods', () => {
+		// The recommended workaround: nest the class instance as a named
+		// field on a plain object, then expose whatever methods you need
+		// either by closure-capturing them or via direct property access.
+		class WithPrototypeMethod {
+			name = 'inner';
+			greet(): string {
+				return `hi from ${this.name}`;
+			}
+			[Symbol.dispose]() {}
+		}
+		const cache = createDisposableCache((_id: string) => {
+			const inner = new WithPrototypeMethod();
+			return {
+				inner,
+				greet: () => inner.greet(),
+				[Symbol.dispose]() {
+					inner[Symbol.dispose]();
+				},
+			};
+		});
+
+		const a = cache.open('a');
+		const b = cache.open('a');
+		expect(a.greet()).toBe('hi from inner');
+		expect(b.greet()).toBe('hi from inner');
+		// The nested class instance is shared by reference across handles.
+		expect(a.inner).toBe(b.inner);
+
+		a[Symbol.dispose]();
+		b[Symbol.dispose]();
 		cache[Symbol.dispose]();
 	});
 });

--- a/packages/workspace/src/cache/disposable-cache.test.ts
+++ b/packages/workspace/src/cache/disposable-cache.test.ts
@@ -395,39 +395,6 @@ describe('open / dispose', () => {
 // ════════════════════════════════════════════════════════════════════════════
 
 describe('re-entrancy', () => {
-	test('build(a) can call cache.open(b) without corrupting cache state', () => {
-		// A builder that, while constructing entry 'parent', reaches back into
-		// the cache to open 'child'. Both entries should coexist; neither map
-		// state nor refcounts should be corrupted.
-		// biome-ignore lint/suspicious/noExplicitAny: cache referenced inside its own builder
-		let cache: any;
-		cache = createDisposableCache((id: string) => {
-			if (id === 'parent') {
-				const child = cache.open('child');
-				return {
-					id,
-					childRef: child,
-					[Symbol.dispose]() {
-						child[Symbol.dispose]();
-					},
-				};
-			}
-			return {
-				id,
-				[Symbol.dispose]() {},
-			};
-		});
-
-		const parent = cache.open('parent');
-		expect(parent.id).toBe('parent');
-		expect(parent.childRef.id).toBe('child');
-		expect(cache.has('parent')).toBe(true);
-		expect(cache.has('child')).toBe(true);
-
-		parent[Symbol.dispose]();
-		cache[Symbol.dispose]();
-	});
-
 	test("value's [Symbol.dispose] can re-enter via cache.open(sameId) and gets a fresh entry", () => {
 		// During teardown, the entry is removed from the cache's internal map
 		// BEFORE the value's [Symbol.dispose]() runs. So a re-entrant open of
@@ -470,50 +437,6 @@ describe('re-entrancy', () => {
 });
 
 // ════════════════════════════════════════════════════════════════════════════
-// throwing dispose via grace-timer path
-// ════════════════════════════════════════════════════════════════════════════
-
-describe('throwing value [Symbol.dispose] via the grace-timer path', () => {
-	test('does not propagate; cache evicts; subsequent open works', async () => {
-		// The cache-level dispose path is covered by another test. This one
-		// covers the same throwing dispose, but reached via the grace timer
-		// firing after the last handle is released.
-		let buildCount = 0;
-		const cache = createDisposableCache(
-			(id: string) => {
-				buildCount++;
-				return {
-					id,
-					[Symbol.dispose]() {
-						throw new Error('grace-timer dispose boom');
-					},
-				};
-			},
-			{ gcTime: 20 },
-		);
-
-		const prevError = console.error;
-		console.error = () => {};
-		try {
-			const h = cache.open('a');
-			h[Symbol.dispose]();
-			// Wait long enough for the grace timer to fire and the throwing
-			// dispose to be caught + logged.
-			await new Promise((r) => setTimeout(r, 50));
-			expect(cache.has('a')).toBe(false);
-
-			// A subsequent open builds fresh, proving the throw didn't leave
-			// a poisoned entry behind.
-			const h2 = cache.open('a');
-			expect(buildCount).toBe(2);
-			h2[Symbol.dispose]();
-		} finally {
-			console.error = prevError;
-		}
-	});
-});
-
-// ════════════════════════════════════════════════════════════════════════════
 // plain-object invariant (T must be a plain object)
 // ════════════════════════════════════════════════════════════════════════════
 
@@ -543,40 +466,6 @@ describe('plain-object invariant', () => {
 		).toBeUndefined();
 
 		handle[Symbol.dispose]();
-		cache[Symbol.dispose]();
-	});
-
-	test('wrapping a class instance in a plain object preserves access to its methods', () => {
-		// The recommended workaround: nest the class instance as a named
-		// field on a plain object, then expose whatever methods you need
-		// either by closure-capturing them or via direct property access.
-		class WithPrototypeMethod {
-			name = 'inner';
-			greet(): string {
-				return `hi from ${this.name}`;
-			}
-			[Symbol.dispose]() {}
-		}
-		const cache = createDisposableCache((_id: string) => {
-			const inner = new WithPrototypeMethod();
-			return {
-				inner,
-				greet: () => inner.greet(),
-				[Symbol.dispose]() {
-					inner[Symbol.dispose]();
-				},
-			};
-		});
-
-		const a = cache.open('a');
-		const b = cache.open('a');
-		expect(a.greet()).toBe('hi from inner');
-		expect(b.greet()).toBe('hi from inner');
-		// The nested class instance is shared by reference across handles.
-		expect(a.inner).toBe(b.inner);
-
-		a[Symbol.dispose]();
-		b[Symbol.dispose]();
 		cache[Symbol.dispose]();
 	});
 });

--- a/packages/workspace/src/cache/disposable-cache.ts
+++ b/packages/workspace/src/cache/disposable-cache.ts
@@ -1,59 +1,138 @@
 /**
- * `createDisposableCache` — refcounted cache for disposable resources.
+ * `createDisposableCache`: refcounted cache for disposable resources.
  *
- * Same id → same instance shared across consumers; teardown is debounced after
- * the last consumer leaves. Solves three coupled problems:
+ * ## What it does
  *
- * 1. **Concurrent consumers of the same id must share ONE instance.** Otherwise
- *    local state diverges — two editors mounted on the same Y.Doc would only
- *    see each other's edits after a sync round-trip.
+ * Maps an id to a single shared instance, tracks how many consumers are
+ * currently using it, and tears it down (calls `[Symbol.dispose]()` on the
+ * underlying value) a configurable grace period after the last consumer
+ * leaves.
+ *
+ * Same id, same underlying instance. Different handles, shared state.
+ *
+ * ## Why it exists
+ *
+ * Three coupled problems show up whenever a resource is expensive to build,
+ * stateful, and shared across UI surfaces:
+ *
+ * 1. **Concurrent consumers of the same id must share ONE instance.**
+ *    Otherwise local state diverges. Two editors mounted on the same Y.Doc
+ *    would only see each other's edits after a sync round-trip. A media
+ *    player and a waveform view of the same audio file would each hold a
+ *    decoder and double the memory.
+ *
  * 2. **Sequential mount/unmount shouldn't rebuild expensive resources.**
- *    Route swaps, HMR, conditional rendering, split-pane close-then-reopen all
- *    produce rapid open→close→open sequences. `gcTime` keeps the instance
- *    alive briefly so the next `open` can reuse it.
+ *    Route swaps, HMR, conditional rendering, split-pane close-then-reopen
+ *    all produce rapid open/close/open sequences within milliseconds.
+ *    `gcTime` keeps the instance alive briefly so the next `open` reuses it.
+ *
  * 3. **Page exit / workspace teardown needs explicit disposal.** The cache
- *    itself is `Disposable`; `cache[Symbol.dispose]()` flushes every entry.
+ *    itself is `Disposable`; `cache[Symbol.dispose]()` flushes every entry
+ *    synchronously.
  *
- * The value type is opaque — anything `Disposable`. Y.Docs are the most common
- * case in this codebase; audio decoders, worker connections, MediaStreams, and
- * native window handles fit the same shape and should use this primitive
- * rather than reinventing refcount+grace.
+ * Y.Docs are the most common case in this codebase. Audio decoders, worker
+ * connections, MediaStreams, and native window handles fit the same shape
+ * and should use this primitive rather than reinventing refcount + grace.
  *
- * ## Usage
+ * ## How to use it from a UI framework
+ *
+ * The intended use case: open in your reactive effect, dispose in cleanup.
+ * The cache handles deduplication, grace periods, and teardown for you.
  *
  * ```ts
- * const cache = createDisposableCache(
- *   (id: string) => buildExpensiveThing(id),
- *   { gcTime: 5_000 },
- * );
- *
- * // Two concurrent consumers of the same id share one instance.
- * const a = cache.open('thing-1');
- * const b = cache.open('thing-1');
- * // a and b are different handles, but a.value === b.value
- *
- * a[Symbol.dispose]();  // refcount: 2 → 1
- * b[Symbol.dispose]();  // refcount: 1 → 0; teardown armed for 5s
- *
- * // Reactive pattern: open in $effect, dispose in cleanup. Re-opening within
- * // 5s cancels the pending teardown.
+ * // Svelte 5
  * $effect(() => {
- *   const handle = cache.open(id);
+ *   const handle = cache.open(documentId);
  *   return () => handle[Symbol.dispose]();
  * });
  *
- * // Workspace teardown — flush everything immediately.
- * cache[Symbol.dispose]();
+ * // React
+ * useEffect(() => {
+ *   const handle = cache.open(documentId);
+ *   return () => handle[Symbol.dispose]();
+ * }, [documentId]);
+ *
+ * // Vue 3
+ * watchEffect((onCleanup) => {
+ *   const handle = cache.open(documentId);
+ *   onCleanup(() => handle[Symbol.dispose]());
+ * });
+ * ```
+ *
+ * What you get for free:
+ *
+ * - **Two components mounting on the same id share one underlying value.**
+ *   Mutations made through component A's handle are immediately visible
+ *   through component B's handle, because nested fields (like `.ydoc`) are
+ *   the same reference across all handles for that id.
+ * - **Reactive id changes are O(1).** When the id changes, the old handle
+ *   is disposed and the new one opened. The old document stays alive for
+ *   `gcTime` in case the user navigates back; if not, it's torn down
+ *   automatically.
+ * - **HMR and remounts are free.** open / dispose / open within a few
+ *   milliseconds cancels the grace timer mid-flight; no rebuild.
+ * - **Workspace teardown is one call.** `cache[Symbol.dispose]()` flushes
+ *   every entry synchronously.
+ *
+ * ## Quick mental model
+ *
+ * ```ts
+ * const cache = createDisposableCache(
+ *   (id: string) => {
+ *     const ydoc = new Y.Doc({ guid: id });
+ *     return {
+ *       ydoc,
+ *       [Symbol.dispose]() { ydoc.destroy(); },
+ *     };
+ *   },
+ *   { gcTime: 5_000 },
+ * );
+ *
+ * const a = cache.open('doc-1');     // build runs; refcount 0 to 1
+ * const b = cache.open('doc-1');     // cache hit; refcount 1 to 2
+ *
+ * // a and b are different handle objects, but they share the same
+ * // underlying state via nested references:
+ * a.ydoc === b.ydoc                  // true
+ *
+ * a[Symbol.dispose]();               // refcount 2 to 1
+ * b[Symbol.dispose]();               // refcount 1 to 0; 5s grace timer armed
+ *
+ * // Within 5s, cache.open('doc-1') cancels the timer and reuses the
+ * // same Y.Doc. After 5s with no reopen, the Y.Doc is destroyed and
+ * // removed from the cache.
+ *
+ * cache[Symbol.dispose]();           // force-flush everything
+ * ```
+ *
+ * ## Constraint: `T` must be a plain object
+ *
+ * The handle returned by `open()` is a fresh object built by spreading the
+ * value's own enumerable properties. **Class instances lose their prototype
+ * methods.** Wrap class instances in a plain object instead:
+ *
+ * ```ts
+ * // BAD: methods on Y.Doc.prototype (transact, getMap, on, ...) are LOST
+ * createDisposableCache((id) => new Y.Doc({ guid: id }));
+ *
+ * // GOOD: nest the class instance as a named field
+ * createDisposableCache((id) => {
+ *   const ydoc = new Y.Doc({ guid: id });
+ *   return {
+ *     ydoc,
+ *     [Symbol.dispose]() { ydoc.destroy(); },
+ *   };
+ * });
  * ```
  *
  * ## What this primitive does NOT do
  *
- * - **No async builder.** Construction is synchronous. If your `T` needs async
- *   readiness, expose a `whenReady: Promise<unknown>` field on it; the cache
- *   stays sync, readiness is a value-level concern.
+ * - **No async builder.** Construction is synchronous. If your `T` needs
+ *   async readiness, expose a `whenReady: Promise<unknown>` field on it;
+ *   the cache stays sync, readiness is a value-level concern.
  * - **No max size / LRU eviction.** Out of scope; add when needed.
- * - **No per-id force-close.** One way to release a handle: dispose it. Two
- *   ways means call sites that mismatch open/close.
+ * - **No per-id force-close.** One way to release a handle: dispose it.
+ *   Two ways means call sites that mismatch open/close.
  * - **No subscriptions / change events.** Just construct, share, dispose.
  *
  * @module
@@ -80,18 +159,21 @@ export const DisposableCacheError = defineErrors({
 export type DisposableCacheError = InferErrors<typeof DisposableCacheError>;
 
 /**
- * Refcounted cache returned by `createDisposableCache`. Itself `Disposable` —
+ * Refcounted cache returned by `createDisposableCache`. Itself `Disposable`:
  * `cache[Symbol.dispose]()` flushes every entry immediately.
  */
 export interface DisposableCache<Id, T> extends Disposable {
 	/**
-	 * Open a handle. Increments the refcount for `id`. The returned handle
-	 * prototype-chains to the underlying `T`, plus its own `[Symbol.dispose]`
-	 * that decrements *this handle's* refcount — it does NOT destroy the
-	 * underlying `T` directly. The underlying `T[Symbol.dispose]()` is called
-	 * once, by the cache, when the refcount reaches zero after `gcTime`.
+	 * Open a handle. Increments the refcount for `id`. The returned handle is
+	 * a fresh object built by spreading the underlying `T`'s own enumerable
+	 * properties, plus its own `[Symbol.dispose]` that decrements *this
+	 * handle's* refcount. It does NOT destroy the underlying `T` directly.
+	 * The underlying `T[Symbol.dispose]()` is called once, by the cache, when
+	 * the refcount reaches zero after `gcTime`.
 	 *
-	 * Each call returns a distinct handle. N opens require N disposes.
+	 * Each call returns a distinct handle (so `a !== b`), but their nested
+	 * fields share references (so `a.ydoc === b.ydoc`). N opens require N
+	 * disposes.
 	 */
 	open(id: Id): T & Disposable;
 	/** Whether an instance is currently held (refcounted or in grace window). */
@@ -110,7 +192,7 @@ type CacheEntry<T extends Disposable> = {
  *
  * @param build - Closure invoked on cache miss. Returns a `T extends Disposable`.
  *                Runs synchronously; if it throws, the cache is unchanged
- *                (next `open(sameId)` re-runs the closure — no poisoned entry).
+ *                (next `open(sameId)` re-runs the closure; no poisoned entry).
  * @param opts  - `gcTime` (default `5_000`ms): milliseconds to wait after the
  *                refcount reaches zero before tearing down the underlying value.
  *                `0` = synchronous teardown, no timer. `Infinity` = never
@@ -153,7 +235,7 @@ export function createDisposableCache<
 			let entry = entries.get(id);
 			if (entry === undefined) {
 				// User closure runs synchronously. If it throws, we DON'T insert
-				// into the cache — next `open(sameId)` re-runs the closure (no
+				// into the cache; next `open(sameId)` re-runs the closure (no
 				// poisoned entry). The caller sees the thrown error.
 				const value = build(id);
 				entry = { value, openCount: 0, gcTimer: null, disposed: false };
@@ -188,10 +270,13 @@ export function createDisposableCache<
 				}, gcTime);
 			};
 
-			// Prototype-chain shallow wrapper. Reads of `T`'s properties fall
-			// through to the underlying value; writes to the handle don't leak
-			// between consumers; `[Symbol.dispose]` is shadowed to call the
-			// per-handle dispose, not the underlying value's destroy.
+			// Spread shallow wrapper. Each handle is a new object with the
+			// underlying value's own enumerable properties copied onto it.
+			// Writes to top-level fields stay on the handle (each handle has
+			// its own slot), but nested objects are shared by reference (so
+			// e.g. every handle's `.ydoc` is the same Y.Doc). `[Symbol.dispose]`
+			// is shadowed to call the per-handle dispose, not the underlying
+			// value's destroy.
 			return {
 				...entry.value,
 				[Symbol.dispose]: dispose,

--- a/packages/workspace/src/cache/disposable-cache.ts
+++ b/packages/workspace/src/cache/disposable-cache.ts
@@ -22,9 +22,10 @@
  *    decoder and double the memory.
  *
  * 2. **Sequential mount/unmount shouldn't rebuild expensive resources.**
- *    Route swaps, HMR, conditional rendering, split-pane close-then-reopen
- *    all produce rapid open/close/open sequences within milliseconds.
- *    `gcTime` keeps the instance alive briefly so the next `open` reuses it.
+ *    Route swaps, hot module reload, conditional rendering, split-pane
+ *    close-then-reopen all produce rapid open/close/open sequences within
+ *    milliseconds. `gcTime` keeps the instance alive briefly so the next
+ *    `open` reuses it.
  *
  * 3. **Page exit / workspace teardown needs explicit disposal.** The cache
  *    itself is `Disposable`; `cache[Symbol.dispose]()` flushes every entry
@@ -33,46 +34,6 @@
  * Y.Docs are the most common case in this codebase. Audio decoders, worker
  * connections, MediaStreams, and native window handles fit the same shape
  * and should use this primitive rather than reinventing refcount + grace.
- *
- * ## How to use it from a UI framework
- *
- * The intended use case: open in your reactive effect, dispose in cleanup.
- * The cache handles deduplication, grace periods, and teardown for you.
- *
- * ```ts
- * // Svelte 5
- * $effect(() => {
- *   const handle = cache.open(documentId);
- *   return () => handle[Symbol.dispose]();
- * });
- *
- * // React
- * useEffect(() => {
- *   const handle = cache.open(documentId);
- *   return () => handle[Symbol.dispose]();
- * }, [documentId]);
- *
- * // Vue 3
- * watchEffect((onCleanup) => {
- *   const handle = cache.open(documentId);
- *   onCleanup(() => handle[Symbol.dispose]());
- * });
- * ```
- *
- * What you get for free:
- *
- * - **Two components mounting on the same id share one underlying value.**
- *   Mutations made through component A's handle are immediately visible
- *   through component B's handle, because nested fields (like `.ydoc`) are
- *   the same reference across all handles for that id.
- * - **Reactive id changes are O(1).** When the id changes, the old handle
- *   is disposed and the new one opened. The old document stays alive for
- *   `gcTime` in case the user navigates back; if not, it's torn down
- *   automatically.
- * - **HMR and remounts are free.** open / dispose / open within a few
- *   milliseconds cancels the grace timer mid-flight; no rebuild.
- * - **Workspace teardown is one call.** `cache[Symbol.dispose]()` flushes
- *   every entry synchronously.
  *
  * ## Quick mental model
  *
@@ -105,15 +66,59 @@
  * cache[Symbol.dispose]();           // force-flush everything
  * ```
  *
+ * Disposing the same handle twice is a no-op. If `build` throws, no entry
+ * is stored and the next `open(sameId)` retries cleanly.
+ *
+ * ## How to use it from a UI framework
+ *
+ * The intended pattern: instantiate the cache once at module level, then
+ * open in your reactive effect and dispose in cleanup. The cache handles
+ * deduplication, grace periods, and teardown for you. Two components
+ * mounting on the same id share one underlying value, so mutations made
+ * through one component's handle are immediately visible through the other.
+ *
+ * ```ts
+ * // Svelte 5
+ * $effect(() => {
+ *   const handle = cache.open(documentId);
+ *   return () => handle[Symbol.dispose]();
+ * });
+ *
+ * // React
+ * useEffect(() => {
+ *   const handle = cache.open(documentId);
+ *   return () => handle[Symbol.dispose]();
+ * }, [documentId]);
+ *
+ * // Vue 3
+ * watchEffect((onCleanup) => {
+ *   const handle = cache.open(documentId);
+ *   onCleanup(() => handle[Symbol.dispose]());
+ * });
+ * ```
+ *
+ * Outside reactive contexts, `using` syntax is the cleanest match for the
+ * `Disposable` shape:
+ *
+ * ```ts
+ * function readDoc(id: string) {
+ *   using handle = cache.open(id);
+ *   return handle.ydoc.getMap('root').toJSON();
+ * }
+ * // handle disposed at scope exit; grace timer armed
+ * ```
+ *
  * ## Constraint: `T` must be a plain object
  *
- * The handle returned by `open()` is a fresh object built by spreading the
- * value's own enumerable properties. **Class instances lose their prototype
- * methods.** Wrap class instances in a plain object instead:
+ * The handle is built by spreading the value's own enumerable properties:
+ * `{ ...value, [Symbol.dispose]: ... }`. Spread doesn't copy prototype
+ * methods, so a class instance returned directly will lose every method
+ * that lives on its prototype.
  *
  * ```ts
  * // BAD: methods on Y.Doc.prototype (transact, getMap, on, ...) are LOST
  * createDisposableCache((id) => new Y.Doc({ guid: id }));
+ * // handle.transact === undefined
  *
  * // GOOD: nest the class instance as a named field
  * createDisposableCache((id) => {
@@ -123,6 +128,7 @@
  *     [Symbol.dispose]() { ydoc.destroy(); },
  *   };
  * });
+ * // handle.ydoc.transact(() => { ... }) works
  * ```
  *
  * ## What this primitive does NOT do


### PR DESCRIPTION
The `createDisposableCache` JSDoc had two outright lies sitting on top of working code. The usage example told you to compare `a.value === b.value` to verify shared state; there is no `.value` property anywhere on the handle. The implementation comment called itself a "prototype-chain shallow wrapper" but the code spreads the value into a fresh object, which silently drops every method on a class instance's prototype. Every call site in the codebase happens to return a plain object literal, so the spread mismatch never bit, but the constraint that follows from it was nowhere documented.

```ts
// What the comment claimed vs what the code does
// "Prototype-chain shallow wrapper. Reads of T's properties fall through..."
return {
  ...entry.value,                  // actually a spread, not Object.create
  [Symbol.dispose]: dispose,
} as T & Disposable;
```

The fix restructures the top-level JSDoc into what / why / mental-model / how-to-use / constraint / not-doing sections, and adds a Constraint section that names the plain-object invariant explicitly with concrete failure-mode comments:

```ts
// BAD: methods on Y.Doc.prototype (transact, getMap, on, ...) are LOST
createDisposableCache((id) => new Y.Doc({ guid: id }));
// handle.transact === undefined

// GOOD: nest the class instance as a named field
createDisposableCache((id) => {
  const ydoc = new Y.Doc({ guid: id });
  return { ydoc, [Symbol.dispose]() { ydoc.destroy(); } };
});
// handle.ydoc.transact(() => { ... }) works
```

The reordering came from a fresh-eyes audit: a subagent given only the file with no other context, told to simulate a first-time reader. That reader landed on the framework examples before the mental model and reported that the abstract "different handles, shared state" promise only became concrete once they saw `a.ydoc === b.ydoc` in code. Quick Mental Model now sits above the framework examples. The same audit flagged that "What you get for free" was a four-bullet restatement of the three "Why it exists" problems, so it's gone. Surfaced two behaviors that were buried (handle dispose is idempotent, build throws leave no poisoned entry), expanded HMR on first use, and added a `using handle = cache.open(id)` example for callers outside reactive contexts.

On the test side, four new tests were added in the first commit, then three of them were dropped after a self-audit on the second. The two that earned their keep:

```ts
test("value's [Symbol.dispose] can re-enter via cache.open(sameId) and gets a fresh entry");
test('class instances passed directly LOSE prototype methods on the handle');
```

The first pins down the implementation's "remove from map BEFORE calling value's dispose" invariant, a property that no real call site relies on but one a future refactor could quietly break. The second pins down the documented plain-object constraint as a behavioral test, so any future change to the wrapping strategy that silently makes class instances work will fail the build and force the docs to update with it.

The dropped three were paranoia coverage of a property nobody relies on (re-entrancy from build closures), redundant exercise of the same `disposeEntry` codepath already covered by an existing test (throwing dispose via the grace timer), and a test that exercised JavaScript spread semantics rather than cache behavior (wrapping a class instance in a plain object preserves access to its methods).

Two commits, 22 tests pass, workspace typecheck clean, no behavior change.