### PR TITLE
refactor(workspace)!: make actions the public callable root

### DIFF
--- a/apps/fuji/src/lib/fuji/browser.ts
+++ b/apps/fuji/src/lib/fuji/browser.ts
@@ -42,7 +42,7 @@ export function openFuji({
 		getToken: () => auth.getToken(),
 	});
 	const presence = sync.attachPresence({ peer });
-	const rpc = sync.attachRpc({ actions: { actions: doc.actions } });
+	const rpc = sync.attachRpc(doc.actions);
 
 	return {
 		...doc,

--- a/apps/fuji/src/lib/fuji/daemon.ts
+++ b/apps/fuji/src/lib/fuji/daemon.ts
@@ -46,7 +46,7 @@ export function openFuji({
 		webSocketImpl,
 	});
 	const presence = sync.attachPresence({ peer });
-	const rpc = sync.attachRpc({ actions: { actions: doc.actions } });
+	const rpc = sync.attachRpc(doc.actions);
 	const sqlite = attachSqlite(doc.ydoc, {
 		filePath: sqlitePath(projectDir, doc.ydoc.guid),
 	}).table(doc.tables.entries);

--- a/apps/fuji/src/lib/fuji/script.ts
+++ b/apps/fuji/src/lib/fuji/script.ts
@@ -35,7 +35,7 @@ export function openFuji({
 		getToken,
 		webSocketImpl,
 	});
-	const rpc = sync.attachRpc({ actions: { actions: doc.actions } });
+	const rpc = sync.attachRpc(doc.actions);
 
 	return { ...doc, yjsLog, sync, rpc };
 }

--- a/apps/fuji/src/lib/workspace.ts
+++ b/apps/fuji/src/lib/workspace.ts
@@ -9,7 +9,6 @@
 
 import {
 	DateTimeString,
-	defineActions,
 	defineMutation,
 	defineTable,
 	generateId,
@@ -108,7 +107,7 @@ export type FujiTables = Tables<typeof fujiTables>;
 // ─── Actions ──────────────────────────────────────────────────────────────────
 
 export function createFujiActions(tables: FujiTables) {
-	return defineActions({
+	return {
 		entries: {
 			/**
 			 * Create a new entry with sensible defaults.
@@ -281,5 +280,5 @@ export function createFujiActions(tables: FujiTables) {
 				},
 			}),
 		},
-	});
+	};
 }

--- a/apps/honeycrisp/src/lib/honeycrisp/browser.ts
+++ b/apps/honeycrisp/src/lib/honeycrisp/browser.ts
@@ -42,7 +42,7 @@ export function openHoneycrisp({
 		getToken: () => auth.getToken(),
 	});
 	const presence = sync.attachPresence({ peer });
-	const rpc = sync.attachRpc({ actions: { actions: doc.actions } });
+	const rpc = sync.attachRpc(doc.actions);
 
 	return {
 		...doc,

--- a/apps/honeycrisp/src/lib/honeycrisp/daemon.ts
+++ b/apps/honeycrisp/src/lib/honeycrisp/daemon.ts
@@ -39,7 +39,7 @@ export function openHoneycrisp({
 		webSocketImpl,
 	});
 	const presence = sync.attachPresence({ peer });
-	const rpc = sync.attachRpc({ actions: { actions: doc.actions } });
+	const rpc = sync.attachRpc(doc.actions);
 
 	return { ...doc, yjsLog, sync, presence, rpc };
 }

--- a/apps/honeycrisp/src/lib/honeycrisp/script.ts
+++ b/apps/honeycrisp/src/lib/honeycrisp/script.ts
@@ -35,7 +35,7 @@ export function openHoneycrisp({
 		getToken,
 		webSocketImpl,
 	});
-	const rpc = sync.attachRpc({ actions: { actions: doc.actions } });
+	const rpc = sync.attachRpc(doc.actions);
 
 	return { ...doc, yjsLog, sync, rpc };
 }

--- a/apps/honeycrisp/src/lib/workspace.ts
+++ b/apps/honeycrisp/src/lib/workspace.ts
@@ -13,7 +13,6 @@
 
 import {
 	DateTimeString,
-	defineActions,
 	defineMutation,
 	defineTable,
 	type InferTableRow,
@@ -131,7 +130,7 @@ export type HoneycrispTables = Tables<typeof honeycrispTables>;
  * stays in the Svelte state files.
  */
 export function createHoneycrispActions(tables: HoneycrispTables) {
-	return defineActions({
+	return {
 		folders: {
 			/**
 			 * Delete a folder and move all its notes to unfiled.
@@ -155,5 +154,5 @@ export function createHoneycrispActions(tables: HoneycrispTables) {
 				},
 			}),
 		},
-	});
+	};
 }

--- a/apps/opensidian/src/lib/opensidian/actions.ts
+++ b/apps/opensidian/src/lib/opensidian/actions.ts
@@ -1,5 +1,5 @@
 import type { SqliteIndex, YjsFileSystem } from '@epicenter/filesystem';
-import { defineActions, defineMutation, defineQuery } from '@epicenter/workspace';
+import { defineMutation, defineQuery } from '@epicenter/workspace';
 import type { Bash } from 'just-bash';
 import Type from 'typebox';
 import { Ok } from 'wellcrafted/result';
@@ -13,7 +13,7 @@ export function createOpensidianActions({
 	sqliteIndex: SqliteIndex['exports'];
 	bash: Bash;
 }) {
-	return defineActions({
+	return {
 		files: {
 			search: defineQuery({
 				title: 'Search Notes',
@@ -142,5 +142,5 @@ export function createOpensidianActions({
 				},
 			}),
 		},
-	});
+	};
 }

--- a/apps/opensidian/src/lib/opensidian/browser.ts
+++ b/apps/opensidian/src/lib/opensidian/browser.ts
@@ -54,7 +54,7 @@ export function openOpensidian({
 		getToken: () => auth.getToken(),
 	});
 	const presence = sync.attachPresence({ peer });
-	const rpc = sync.attachRpc({ actions: { actions } });
+	const rpc = sync.attachRpc(actions);
 
 	return {
 		...doc,

--- a/apps/opensidian/src/lib/opensidian/daemon.ts
+++ b/apps/opensidian/src/lib/opensidian/daemon.ts
@@ -43,7 +43,7 @@ export function openOpensidian({
 	// Opensidian file and shell actions because they need browser services.
 	const actions = {};
 	const presence = sync.attachPresence({ peer });
-	const rpc = sync.attachRpc({ actions: { actions } });
+	const rpc = sync.attachRpc(actions);
 
 	return { ...doc, yjsLog, sync, actions, presence, rpc };
 }

--- a/apps/tab-manager/src/lib/state/tool-trust.svelte.ts
+++ b/apps/tab-manager/src/lib/state/tool-trust.svelte.ts
@@ -40,11 +40,11 @@ function createToolTrustState() {
 		 * Get the trust level for a tool.
 		 *
 		 * Returns `'ask'` for tools not in the trust table (the safe default).
-		 * Query tools should not call this—they auto-execute always.
+		 * Query tools should not call this because they auto-execute always.
 		 *
 		 * @example
 		 * ```typescript
-		 * if (toolTrustState.get('actions_tabs_close') === 'always') {
+		 * if (toolTrustState.get('tabs_close') === 'always') {
 		 *   client.approve(toolCallId);
 		 * }
 		 * ```
@@ -63,7 +63,7 @@ function createToolTrustState() {
 		 * @example
 		 * ```typescript
 		 * // User clicks "Always Allow" on the approval UI
-		 * toolTrustState.set('actions_tabs_close', 'always');
+		 * toolTrustState.set('tabs_close', 'always');
 		 * client.approve(toolCallId);
 		 * ```
 		 */

--- a/apps/tab-manager/src/lib/tab-manager/extension.ts
+++ b/apps/tab-manager/src/lib/tab-manager/extension.ts
@@ -45,7 +45,7 @@ export async function openTabManager({
 		getToken: () => auth.getToken(),
 	});
 	const presence = sync.attachPresence({ peer: resolvedPeer });
-	const rpc = sync.attachRpc({ actions: { actions: doc.actions } });
+	const rpc = sync.attachRpc(doc.actions);
 
 	return {
 		...doc,

--- a/apps/tab-manager/src/lib/workspace/actions.ts
+++ b/apps/tab-manager/src/lib/workspace/actions.ts
@@ -6,7 +6,7 @@
  * workspace — Chrome is the sole authority. See `browser-state.svelte.ts`.
  */
 
-import { defineActions, defineMutation, defineQuery } from '@epicenter/workspace';
+import { defineMutation, defineQuery } from '@epicenter/workspace';
 import Type from 'typebox';
 import {
 	defineErrors,
@@ -64,7 +64,7 @@ export function createTabManagerActions({
 	batch: (fn: () => void) => void;
 	deviceId: Promise<DeviceId>;
 }) {
-	return defineActions({
+	return {
 		devices: {
 			list: defineQuery({
 				title: 'List Devices',
@@ -446,5 +446,5 @@ export function createTabManagerActions({
 				},
 			}),
 		},
-	});
+	};
 }

--- a/apps/tab-manager/src/lib/workspace/definition.ts
+++ b/apps/tab-manager/src/lib/workspace/definition.ts
@@ -262,8 +262,8 @@ export type ChatMessage = InferTableRow<typeof chatMessagesTable>;
  * Tools not in this table default to 'ask' (show approval UI). Users can
  * escalate to 'always' (auto-approve) via the inline approval buttons.
  *
- * The `id` is the tool name (e.g. 'actions_tabs_close') - the same string used
- * in action paths and tool definitions.
+ * The `id` is the tool name (e.g. 'tabs_close'), derived from the dot-path
+ * action name used by CLI and RPC surfaces (e.g. 'tabs.close').
  */
 const toolTrustTable = defineTable(
 	type({

--- a/examples/notes-cross-peer/README.md
+++ b/examples/notes-cross-peer/README.md
@@ -27,7 +27,7 @@ bun x epicenter up -C examples/notes-cross-peer/peer-a
 ```bash
 bun x epicenter up -C examples/notes-cross-peer/peer-b &
 bun x epicenter peers -C examples/notes-cross-peer/peer-b
-bun x epicenter run notes.actions.notes.add --peer notes-repro-peer-a '{"body":"from peer-b"}' -C examples/notes-cross-peer/peer-b
+bun x epicenter run notes.notes.add --peer notes-repro-peer-a '{"body":"from peer-b"}' -C examples/notes-cross-peer/peer-b
 ```
 
 To inspect peer-a's full action manifest from peer-b, write a script
@@ -55,8 +55,8 @@ bun run examples/notes-cross-peer/inspect-peer.ts
 ## What confirms it works
 
 - `peers` lists `notes-repro-peer-a`, so awareness round-tripped through the API.
-- `inspect-peer.ts` prints peer-a's manifest with `actions.notes.add` and its input shape, so `system.describe()` carries the schema.
-- `run notes.actions.notes.add --peer notes-repro-peer-a` succeeds, so cross-peer dispatch uses the same RPC channel.
+- `inspect-peer.ts` prints peer-a's manifest with `notes.add` and its input shape, so `system.describe()` carries the schema.
+- `run notes.notes.add --peer notes-repro-peer-a` succeeds, so cross-peer dispatch uses the same RPC channel.
 
 ## What confirms it broke
 

--- a/examples/notes-cross-peer/notes.ts
+++ b/examples/notes-cross-peer/notes.ts
@@ -46,7 +46,7 @@ export function openNotes(peer: PeerDescriptor) {
 			(await sessions.load(SERVER_URL))?.accessToken ?? null,
 	});
 	const presence = sync.attachPresence({ peer });
-	const rpc = sync.attachRpc({ actions: { actions } });
+	const rpc = sync.attachRpc(actions);
 
 	return {
 		actions,

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -9,13 +9,13 @@ This is the pattern from workspace clients:
 ```typescript
 import { actionsToAiTools } from '@epicenter/workspace/ai';
 
-export const workspaceAiTools = actionsToAiTools(workspace);
+export const workspaceAiTools = actionsToAiTools(workspace.actions);
 ```
 
 Under the hood, that split is the whole point:
 
 ```text
-workspace
+workspace.actions
   └─ actionsToAiTools(...)
        ├─ tools        -> client tools with execute()
        └─ definitions  -> JSON payload for the server
@@ -31,13 +31,13 @@ Queries become ordinary client tools. Mutations automatically get `needsApproval
 
 The `definitions` array omits runtime-only fields like `execute` and `__toolSide`. What survives is the wire-safe shape the server needs: tool name, description, schema, approval flag, and title.
 
-One detail matters more than it looks. Input schemas are normalized so `properties` and `required` are always present. The source calls out Anthropic here—some providers reject schemas that omit those keys.
+One detail matters more than it looks. Input schemas are normalized so `properties` and `required` are always present. The source calls out Anthropic here because some providers reject schemas that omit those keys.
 
 ## API overview
 
 ### `actionsToAiTools(source)`
 
-Converts a workspace bundle or action tree into TanStack AI client tools and JSON definitions. Tool names come from the action path, so a nested action like `actions.tabs.close` becomes `actions_tabs_close`.
+Converts an action tree into TanStack AI client tools and JSON definitions. Tool names come from the action path, so a nested action like `tabs.close` becomes `tabs_close`.
 
 ### `ToolDefinition`
 
@@ -48,8 +48,8 @@ The wire-safe tool shape for the HTTP request body.
 Type-level helper that turns an action source into a string union of tool names.
 
 ```typescript
-type Names = ActionNames<typeof workspace>;
-// "actions_tabs_search" | "actions_tabs_close" | ...
+type Names = ActionNames<typeof workspace.actions>;
+// "tabs_search" | "tabs_close" | ...
 ```
 
 ## Relationship to the monorepo

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,7 +8,7 @@ Each verb is a one-line shell shortcut for one workspace primitive:
                  +--------+--------------------------------------+
                  | Verb   | Workspace primitive                  |
                  +--------+--------------------------------------+
-   Enumerate     | list   | describeActions(workspace)           |
+   Enumerate     | list   | describeActions(workspace.actions)   |
    Invoke        | run    | invokeAction(...) / rpc.rpc(...)     |
    Presence      | peers  | presence.peers()                     |
                  +--------+--------------------------------------+
@@ -57,22 +57,22 @@ epicenter up -C examples/notes-cross-peer/peer-b &
 
 # list: what actions are exposed on this device
 epicenter list                                      # full tree
-epicenter list tabManager.actions.savedTabs         # subtree
-epicenter list tabManager.actions.savedTabs.create  # action detail with JSON input shape
+epicenter list tabManager.tabs                      # subtree
+epicenter list tabManager.tabs.open                 # action detail with JSON input shape
 
 # run: do one (locally, or on a remote peer with --peer)
-epicenter run tabManager.actions.savedTabs.list
-epicenter run tabManager.actions.savedTabs.create '{"title":"Hi","url":"https://..."}'
-epicenter run tabManager.actions.savedTabs.create @payload.json
-cat payload.json | epicenter run tabManager.actions.savedTabs.create
-epicenter run tabManager.actions.savedTabs.list --peer 0xabc
+epicenter run tabManager.tabs.list
+epicenter run tabManager.tabs.open '{"url":"https://..."}'
+epicenter run tabManager.tabs.open @payload.json
+cat payload.json | epicenter run tabManager.tabs.open
+epicenter run tabManager.tabs.list --peer 0xabc
 
 # peers: who is online right now (presence snapshot)
 epicenter peers
 epicenter peers -C examples/notes-cross-peer/peer-b
 ```
 
-`run` resolves the first path segment against the named exports of `epicenter.config.ts`; everything after walks through plain object properties on the returned workspace until it hits a `defineQuery` / `defineMutation` action. With `--peer`, the export prefix selects the local RPC attachment, then the inner path is sent to the remote peer.
+`run` resolves the first path segment against the named exports of `epicenter.config.ts`; everything after walks through `workspace.actions` until it hits a `defineQuery` / `defineMutation` action. With `--peer`, the export prefix selects the local RPC attachment, then the inner path is sent to the remote peer.
 
 ### Local vs. remote
 
@@ -173,9 +173,9 @@ return {
     tables,
 
     actions: {
-        savedTabs: {                                   // domain
+        tabs: {                                        // domain
             list: defineQuery({ ... }),                // action
-            delete: defineMutation({ ... }),
+            open: defineMutation({ ... }),
         },
         bookmarks: {
             list: defineQuery({ ... }),
@@ -189,22 +189,22 @@ return {
 };
 ```
 
-CLI paths: `tabManager.actions.savedTabs.list`, `tabManager.actions.bookmarks.list`, `tabManager.actions.importBackup`.
+CLI paths: `tabManager.tabs.list`, `tabManager.bookmarks.list`, `tabManager.importBackup`.
 
-The CLI walks the returned workspace object. It only recurses into plain objects, so class-backed infrastructure such as `ydoc` and most attachments is skipped. Returning an action leaf through a plain object makes that leaf public.
+The CLI walks `workspace.actions`. Infrastructure such as `ydoc`, tables, persistence, sync, and materializers is not public unless you deliberately mount action leaves under `actions`.
 
 ## Naming your exports
 
 Every workspace handle is a **named export**. The export name becomes the first segment of every CLI dot-path. A config with a single workspace can use any name (`tabManager`, `tm`, `w`), but once you add a second workspace, the prefix disambiguates them, so a readable name ages better than a one-letter one.
 
-There is no default-export shorthand. Even a config with one workspace uses a named export. This keeps paths stable when you later add a second workspace: `tabManager.actions.savedTabs.list` on day 1 is still `tabManager.actions.savedTabs.list` on day 180 after you add a second workspace. A default-export shortcut would silently invalidate every script, doc, and CI job using the old path the moment you grew past one workspace.
+There is no default-export shorthand. Even a config with one workspace uses a named export. This keeps paths stable when you later add a second workspace: `tabManager.tabs.list` on day 1 is still `tabManager.tabs.list` on day 180 after you add a second workspace. A default-export shortcut would silently invalidate every script, doc, and CI job using the old path the moment you grew past one workspace.
 
 ```ts
 // epicenter.config.ts
 export const tabManager = openTabManager();
 export const fuji       = openFuji();
-// epicenter run tabManager.actions.savedTabs.list
-// epicenter run fuji.actions.entries.list
+// epicenter run tabManager.tabs.list
+// epicenter run fuji.entries.list
 ```
 
 The Y.Doc GUID (set inside `openX()` via `new Y.Doc({ guid: ... })`) and the export name serve **different purposes**:

--- a/packages/cli/src/commands/list.test.ts
+++ b/packages/cli/src/commands/list.test.ts
@@ -11,8 +11,8 @@ import { filterByPath } from './list';
 
 describe('filterByPath', () => {
 	const entries = {
-		'demo.actions.counter.get': { type: 'query' as const },
-		'demo.actions.counter.set': { type: 'mutation' as const },
+		'demo.counter.get': { type: 'query' as const },
+		'demo.counter.set': { type: 'mutation' as const },
 		'other.thing': { type: 'query' as const },
 	};
 
@@ -21,15 +21,16 @@ describe('filterByPath', () => {
 	});
 
 	test('exact-leaf path returns just that leaf', () => {
-		expect(
-			Object.keys(filterByPath(entries, 'demo.actions.counter.get')),
-		).toEqual(['demo.actions.counter.get']);
+		expect(Object.keys(filterByPath(entries, 'demo.counter.get'))).toEqual([
+			'demo.counter.get',
+		]);
 	});
 
 	test('subtree prefix returns descendants', () => {
-		expect(
-			Object.keys(filterByPath(entries, 'demo.actions.counter')).sort(),
-		).toEqual(['demo.actions.counter.get', 'demo.actions.counter.set']);
+		expect(Object.keys(filterByPath(entries, 'demo.counter')).sort()).toEqual([
+			'demo.counter.get',
+			'demo.counter.set',
+		]);
 	});
 
 	test('non-matching prefix returns empty', () => {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -51,7 +51,7 @@ export const runCommand = cmd({
 			.positional('action', {
 				type: 'string',
 				demandOption: true,
-				describe: 'Export-prefixed action path, e.g. notes.actions.notes.add',
+				describe: 'Export-prefixed action path, e.g. notes.notes.add',
 			})
 			.positional('input', {
 				type: 'string',

--- a/packages/cli/src/commands/up.test.ts
+++ b/packages/cli/src/commands/up.test.ts
@@ -75,6 +75,7 @@ type FakeOptions = {
 
 function makeFakeWorkspace(opts: FakeOptions = {}): LoadedWorkspace {
 	return {
+		actions: {},
 		[Symbol.dispose]() {
 			/* no-op */
 		},
@@ -83,8 +84,6 @@ function makeFakeWorkspace(opts: FakeOptions = {}): LoadedWorkspace {
 			whenConnected: opts.readyPromise ?? Promise.resolve(),
 			status: { phase: 'connected', hasLocalChanges: false },
 			onStatusChange: () => () => {},
-			peers: () => new Map(),
-			observe: () => () => {},
 			// Unused fields; cast through unknown to keep the fake minimal.
 		} as unknown as LoadedWorkspace['sync'],
 	};

--- a/packages/cli/src/load-config.test.ts
+++ b/packages/cli/src/load-config.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { CONFIG_FILENAME, loadConfig } from './load-config';
+
+let workDir: string;
+
+beforeEach(() => {
+	workDir = mkdtempSync(join(tmpdir(), 'ep-load-config-'));
+});
+
+afterEach(() => {
+	rmSync(workDir, { recursive: true, force: true });
+});
+
+function writeConfig(source: string) {
+	mkdirSync(workDir, { recursive: true });
+	writeFileSync(join(workDir, CONFIG_FILENAME), source);
+}
+
+describe('loadConfig', () => {
+	test('rejects disposable workspace exports without an actions object', async () => {
+		writeConfig(`
+			export const demo = {
+				[Symbol.dispose]() {}
+			};
+		`);
+
+		const result = await loadConfig(workDir);
+
+		expect(result.data).toBeNull();
+		expect(result.error?.name).toBe('InvalidWorkspace');
+		if (result.error?.name === 'InvalidWorkspace') {
+			expect(result.error.exportName).toBe('demo');
+		}
+	});
+});

--- a/packages/cli/src/load-config.ts
+++ b/packages/cli/src/load-config.ts
@@ -4,17 +4,17 @@
  * Contract:
  *
  *   A named export becomes a workspace if it implements [Symbol.dispose]
- *   (called at exit; the discriminator). If it also has:
+ *   (called at exit; the discriminator) and exposes an `actions` object.
+ *   If it also has:
  *
  *     whenReady: Promise         awaited before action invocations
  *     sync:      SyncAttachment  awaited during startup and disposal
  *     presence:  PeerPresence    enables `peers` and peer lookup
  *     rpc:       SyncRpc         enables `run --peer`
  *
- *   Actions are read from the workspace object. `walkActions` recurses only
- *   into plain objects, so class-backed infrastructure like `ydoc` and
- *   attachment objects is skipped. Any action leaf reachable through plain
- *   returned objects is public.
+ *   Actions are read from `workspace.actions`. The returned workspace may
+ *   include infrastructure like `ydoc`, `tables`, persistence, or sync
+ *   attachments without making them part of the daemon action surface.
  *
  *   …the CLI uses them. Anything else is the factory's business.
  *
@@ -77,11 +77,12 @@ export type LoadConfigResult = {
 };
 
 /**
- * A workspace is anything with `[Symbol.dispose]`. That's the whole
- * contract; the factory's return shape is the source of truth for
- * everything else.
+ * A workspace is anything with `[Symbol.dispose]` and a canonical `actions`
+ * root. Other fields are optional adapters over that root.
  */
-function isLoadedWorkspace(value: unknown): value is LoadedWorkspace {
+function hasWorkspaceDisposer(
+	value: unknown,
+): value is { [Symbol.dispose](): void } {
 	return (
 		value != null &&
 		typeof value === 'object' &&
@@ -90,8 +91,23 @@ function isLoadedWorkspace(value: unknown): value is LoadedWorkspace {
 	);
 }
 
+function hasActionRoot(
+	value: { [Symbol.dispose](): void },
+): value is LoadedWorkspace {
+	const actions = (value as Record<PropertyKey, unknown>).actions;
+	return (
+		typeof actions === 'object' &&
+		actions !== null &&
+		!Array.isArray(actions)
+	);
+}
+
+function isLoadedWorkspace(value: unknown): value is LoadedWorkspace {
+	return hasWorkspaceDisposer(value) && hasActionRoot(value);
+}
+
 /**
- * Tagged-error variants returned by {@link loadConfig}. All three are
+ * Tagged-error variants returned by {@link loadConfig}. All variants are
  * user-facing (file missing, config crashed at module load, no workspace
  * exports), not panics: callers render them and exit 1.
  *
@@ -121,8 +137,21 @@ export const LoadError = defineErrors({
 		message:
 			`No workspaces found in ${configPath}.\n` +
 			`Export at least one named value implementing [Symbol.dispose], ` +
-			`typically the return of an openFoo() factory.`,
+			`with an actions object, typically the return of an openFoo() factory.`,
 		configPath,
+	}),
+	InvalidWorkspace: ({
+		configPath,
+		exportName,
+	}: {
+		configPath: string;
+		exportName: string;
+	}) => ({
+		message:
+			`Invalid workspace export "${exportName}" in ${configPath}: ` +
+			`expected an actions object.`,
+		configPath,
+		exportName,
 	}),
 });
 export type LoadError = InferErrors<typeof LoadError>;
@@ -151,6 +180,9 @@ export async function loadConfig(
 	const entries: WorkspaceEntry[] = [];
 	for (const [name, value] of Object.entries(module)) {
 		if (name === 'default') continue;
+		if (hasWorkspaceDisposer(value) && !hasActionRoot(value)) {
+			return LoadError.InvalidWorkspace({ configPath, exportName: name });
+		}
 		if (!isLoadedWorkspace(value)) continue;
 		entries.push({ name, workspace: value });
 	}

--- a/packages/cli/test/fixtures/inline-actions/epicenter.config.ts
+++ b/packages/cli/test/fixtures/inline-actions/epicenter.config.ts
@@ -1,9 +1,8 @@
 /**
  * Minimal fixture: one workspace export with inline `defineQuery` /
  * `defineMutation` nodes grouped under `actions:`. No sqlite, sync, or
- * encryption. The CLI walks the bundle itself; dot-paths reflect the
- * structure, so CLI paths are
- * `demo.actions.counter.{get,increment,set}`.
+ * encryption. The CLI walks `workspace.actions`, so CLI paths are
+ * `demo.counter.{get,increment,set}`.
  */
 
 import { defineMutation, defineQuery } from '@epicenter/workspace';

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -1171,7 +1171,6 @@ import {
 	isMutation,
 	isQuery,
 	walkActions,
-	type Actions,
 } from '@epicenter/workspace';
 
 const actions = {
@@ -1182,7 +1181,7 @@ const actions = {
 			handler: ({ title }) => ({ title }),
 		}),
 	},
-} satisfies Actions;
+};
 
 for (const [path, action] of walkActions(actions)) {
 	if (isAction(action)) {
@@ -1401,7 +1400,6 @@ import {
 	isQuery,
 	walkActions,
 	type Action,
-	type Actions,
 	type Mutation,
 	type Query,
 } from '@epicenter/workspace';
@@ -1489,7 +1487,7 @@ import {
 } from '@epicenter/workspace';
 ```
 
-`walkActions(source)` flattens action leaves reachable through plain object properties into `[path, action]` pairs. You can pass a narrow action tree or a full workspace bundle. Combined with each action's `type`, `title`, `description`, and `input` schema, that's enough to build HTTP, CLI, or MCP adapters without coupling the core package to a transport.
+`walkActions(source)` flattens action leaves reachable through plain object properties into `[path, action]` pairs. Pass the canonical action tree, usually `workspace.actions`. Combined with each action's `type`, `title`, `description`, and `input` schema, that is enough to build HTTP, CLI, or MCP adapters without coupling the core package to a transport.
 
 ### IDs and dates
 
@@ -1522,7 +1520,7 @@ These matter when you are writing low-level tooling against raw Yjs structures.
 The core package does not export an MCP server. What it does export is the metadata you need to build one:
 
 - actions with `type`, `title`, `description`, and `input`
-- `walkActions(...)` to flatten a nested action tree or workspace bundle
+- `walkActions(...)` to flatten a nested action tree
 - `isAction` / `isQuery` / `isMutation` type guards
 - `@epicenter/workspace/ai`: `actionsToAiTools(...)` for TanStack AI tool bindings
 
@@ -1536,10 +1534,9 @@ import {
 	defineMutation,
 	defineQuery,
 	walkActions,
-	type Actions,
 } from '@epicenter/workspace';
 
-const actions: Actions = {
+const actions = {
 	posts: {
 		list: defineQuery({
 			title: 'List Posts',

--- a/packages/workspace/SYNC_ARCHITECTURE.md
+++ b/packages/workspace/SYNC_ARCHITECTURE.md
@@ -368,39 +368,45 @@ The architecture scales from "just my devices on Tailscale" to "add a cloud serv
 
 ---
 
-# Inside `attachSync`: the supervisor loop
+# Inside `attachSync`: sync, presence, and RPC
 
-Everything above describes the *topology* — which devices talk to which sync nodes. This section describes what happens inside one `attachSync(doc, config)` call: the WebSocket lifecycle, the supervisor that owns it, the timers that keep it alive, and the RPC dispatch tree.
+Everything above describes the *topology*: which devices talk to which sync nodes. This section describes the current split runtime surface: `attachSync` owns the WebSocket lifecycle, then callers opt into presence and RPC through `sync.attachPresence({ peer })` and `sync.attachRpc(actions)`.
 
-`attachSync` is the entire network surface. One call wires sync, presence (awareness), and RPC dispatch. Understanding the supervisor is the difference between "WebSocket reconnection just works" and being able to debug "why is my CLI hanging."
+Understanding the supervisor is the difference between "WebSocket reconnection just works" and being able to debug "why is my CLI hanging." Presence and RPC ride on the same socket, but they are explicit sibling attachments so a sync-only workspace does not pretend to expose peer lookup or remote actions.
 
 ## What `attachSync` does at construction
 
-One call, four jobs (in `packages/workspace/src/document/attach-sync.ts`):
+The base sync attachment does four jobs (in `packages/workspace/src/document/attach-sync.ts`):
 
 ```
-attachSync(doc, { device, url, getToken, waitFor: idb })
+attachSync(doc, { url, getToken, waitFor: idb })
         │
-        ├── 1. Validate `'system' not in userActions`
-        │      └─ throws at attach time on collision
+        ├── 1. Pick the Y.Doc from a doc or doc bundle
         │
-        ├── 2. Build the dispatch tree:
-        │        actions = {
-        │          ...userActions,   ← yours
-        │          system: {         ← injected
-        │            describe: defineQuery({...}),
-        │          },
-        │        }
+        ├── 2. Wait for optional persistence hydration
         │
-        ├── 3. If `device` was passed, build awareness:
-        │        awareness.setLocal({ device })   ← presence-only, ~150B
+        ├── 3. Start the WebSocket supervisor loop
         │
-        └── 4. Start the supervisor loop
-               └─ owns the WebSocket; reconnects forever
-                  with exponential backoff
+        └── 4. Return attachment methods:
+               status, whenConnected, goOffline, reconnect,
+               attachPresence({ peer }), attachRpc(actions)
 ```
 
 The function returns synchronously. The first connect happens asynchronously after `waitFor` resolves (typically `idb.whenLoaded`).
+
+Presence attaches later:
+
+```ts
+const presence = sync.attachPresence({
+	peer: { id: 'macbook-pro', name: 'MacBook Pro', platform: 'node' },
+});
+```
+
+RPC attaches later:
+
+```ts
+const rpc = sync.attachRpc(workspace.actions);
+```
 
 ## Layer split: doc factory vs runtime wrapper
 
@@ -426,7 +432,7 @@ The function returns synchronously. The first connect happens asynchronously aft
 └─────────────────────────────────────────────────────────┘
 ```
 
-The wrapper takes the doc bundle (which carries `.actions`) and a `device` and hands them to `attachSync`. The doc factory has no awareness, no sync, no platform concerns.
+The wrapper takes the doc bundle and wires sync, presence, and RPC for that runtime. The doc factory has no awareness, no sync, no platform concerns.
 
 ## The dispatch tree
 
@@ -444,7 +450,7 @@ userActions = {
 }
 ```
 
-After `attachSync` runs:
+After `sync.attachRpc(userActions)` runs:
 
 ```
 actions = {
@@ -459,7 +465,7 @@ actions = {
 }
 ```
 
-User and system actions are **structurally identical** — both built with `defineQuery`/`defineMutation`, both reachable via `sync.rpc(target, '<path>', ...)`. The dispatcher (`resolveActionPath`) doesn't distinguish.
+User and system actions are **structurally identical**: both built with `defineQuery`/`defineMutation`, both reachable via `rpc.rpc(target, '<path>', ...)`. The dispatcher (`resolveActionPath`) doesn't distinguish.
 
 The only thing that separates them is the reservation: a top-level `system` key in *your* actions throws at construction. The reservation is shallow (only top-level), follows JSON-RPC's `rpc.*` precedent, and the snapshot is taken at attach time — post-attach mutations to `userActions` don't affect dispatch.
 
@@ -584,35 +590,38 @@ handshake.
 
 ## RPC: peer dispatch surface
 
-`SyncAttachment` is the single source of truth for "who else is here":
+Presence is the source of truth for "who else is here"; RPC is the dispatch surface:
 
 ```ts
-sync.peers()                           // Map<clientId, PeerAwarenessState>
-sync.find(deviceId)                    // FoundPeer | undefined
-sync.observe(callback)                 // unsubscribe fn
-sync.rpc(target, action, input, opts)  // typed remote call
+presence.peers()                       // Map<clientId, PeerAwarenessState>
+presence.find(peerId)                  // Resolved peer or undefined
+presence.observe(callback)             // unsubscribe fn
+rpc.rpc(target, action, input, opts)   // typed remote call
 ```
 
 Cross-device action call:
 
 ```ts
-const macbook = peer<TabManagerActions>(fuji.sync, 'macbook-pro');
+const macbook = createRemoteActions<TabManagerActions>(
+	{ presence: fuji.presence, rpc: fuji.rpc },
+	'macbook-pro',
+);
 const result = await macbook.tabs.close({ tabIds: [1, 2] });
 ```
 
-`peer<T>(sync, deviceId)` returns a typed Proxy. Walking `.tabs.close` builds nested proxies; calling `.tabs.close(input)` dispatches via `sync.rpc(clientId, 'tabs.close', input)`.
+`createRemoteActions<T>({ presence, rpc }, peerId)` returns a typed Proxy. Walking `.tabs.close` builds nested proxies; calling `.tabs.close(input)` resolves the peer through presence and dispatches via `rpc.rpc(clientId, 'tabs.close', input)`.
 
-`describePeer(sync, deviceId)` is a thin wrapper that calls `peer<SystemMeta>(sync, deviceId).system.describe()` to fetch the peer's full action manifest on demand.
+`describeRemoteActions({ presence, rpc }, peerId)` is a thin wrapper that calls the injected `system.describe` action to fetch the peer's full action manifest on demand.
 
 ### Peer-removed race semantics
 
-Both `peer<T>` and `describePeer` race the RPC against a peer-removed signal. If the matched peer disappears mid-call, the in-flight Promise rejects immediately with `RpcError.PeerLeft` rather than waiting the full RPC timeout:
+Both `createRemoteActions<T>` and `describeRemoteActions` race the RPC against a peer-removed signal. If the matched peer disappears mid-call, the in-flight Promise rejects immediately with `RpcError.PeerLeft` rather than waiting the full RPC timeout:
 
 ```
-peer<T>(sync, 'mac').foo()
+createRemoteActions<T>({ presence, rpc }, 'mac').foo()
   │
-  ├─ subscribe to sync.observe(callback)
-  ├─ fire: sync.rpc(...)
+  ├─ subscribe to presence.observe(callback)
+  ├─ fire: rpc.rpc(...)
   │
   ├─ if RPC resolves first:        → return its result
   ├─ if peer leaves awareness first → reject with PeerLeft
@@ -630,17 +639,17 @@ End-to-end. The CLI process is "Fuji"; the peer is "macbook-pro" (a tab-manager 
 └─────────┬──────────┘                     └─────────┬──────────┘
           │                                          │
           │ 1. CLI loads epicenter.config.ts         │
-          │    workspace.sync.peers() returns:       │
-          │    Map { 42 → {device:{id:'macbook-pro'}}}│
+          │    workspace.presence.peers() returns:   │
+          │    Map { 42 → {peer:{id:'macbook-pro'}}}│
           │                                          │
-          │ 2. describePeer(sync, 'macbook-pro')     │
-          │    → peer<SystemMeta>().system.describe()│
+          │ 2. describeRemoteActions(..., peerId)    │
+          │    → system.describe()                   │
           │                                          │
-          │ 3. internally: sync.find('macbook-pro')  │
+          │ 3. internally: presence.find(peerId)     │
           │    returns { clientId: 42, state }       │
           │                                          │
-          │ 4. sync.rpc(42, 'system.describe',       │
-          │             undefined)                   │
+          │ 4. rpc.rpc(42, 'system.describe',        │
+          │            undefined)                    │
           │                                          │
           │    ─── encodeRpcRequest ───────────►     │
           │                                          │
@@ -669,14 +678,18 @@ End-to-end. The CLI process is "Fuji"; the peer is "macbook-pro" (a tab-manager 
 ## Construction → first connect, in time
 
 ```
-t=0ms      attachSync(doc, { device, url, getToken, waitFor: idb })
-              ├─ validates `'system' not in userActions`
-              ├─ injects system.describe
-              ├─ builds awareness, sets {device} synchronously
-              ├─ wires ydoc.on('updateV2'), awareness.on('update')
+t=0ms      attachSync(doc, { url, getToken, waitFor: idb })
+              ├─ wires ydoc.on('updateV2')
               └─ kicks off async waitFor → ensureSupervisor()
 
               returns SyncAttachment immediately
+
+t=0ms      sync.attachPresence({ peer })
+              └─ publishes local peer state when the socket opens
+
+t=0ms      sync.attachRpc(actions)
+              ├─ validates `'system' not in userActions`
+              └─ injects system.describe
 
 t=~10ms    idb.whenLoaded resolves (typical hot start)
 
@@ -703,4 +716,4 @@ t=80ms+    [from here on, four loops run forever:]
 
 ## Mental model in one paragraph
 
-`attachSync(doc, { device })` is the wire. It owns presence (awareness), dispatch (RPC), and the supervisor (reconnect loop). One call, all of it. The dispatch tree is `{ ...userActions, system: { describe } }` with `system.*` reserved. Awareness is identity-only (~150B/peer, broadcast every 15s, 30s TTL). RPC is capability and dispatch (request/response, 5s timeout, racing against peer-removed). Two typed proxies (`peer<T>` for user actions, `describePeer` for system) walk the same wire. The whole thing is one supervisor loop, six timers, a single dispatch tree, and a `runId` cancellation thread.
+`attachSync(doc, config)` is the wire and the supervisor. Presence and RPC are explicit attachments riding on that wire: `sync.attachPresence({ peer })` publishes routable identity, and `sync.attachRpc(actions)` builds the dispatch tree `{ ...userActions, system: { describe } }` with `system.*` reserved. Awareness is identity-only (~150B/peer, broadcast every 15s, 30s TTL). RPC is capability and dispatch (request/response, timeout, racing against peer-removed). Remote proxies use `{ presence, rpc }`, not a monolithic sync object.

--- a/packages/workspace/src/ai/tool-bridge.test.ts
+++ b/packages/workspace/src/ai/tool-bridge.test.ts
@@ -64,6 +64,18 @@ describe('actionsToAiTools', () => {
 	});
 
 	describe('definitions', () => {
+		test('rejects underscore action keys because tool names flatten with underscores', () => {
+			const actions = {
+				foo_bar: defineQuery({
+					handler: () => 'bad',
+				}),
+			};
+
+			expect(() => actionsToAiTools(actions)).toThrow(
+				'Action keys used as AI tools cannot contain "_" at "foo_bar"',
+			);
+		});
+
 		test('produces wire-safe definitions with title', () => {
 			const actions = {
 				search: defineQuery({

--- a/packages/workspace/src/ai/tool-bridge.ts
+++ b/packages/workspace/src/ai/tool-bridge.ts
@@ -30,7 +30,7 @@ import { invokeAction, walkActions } from '../shared/actions';
 /**
  * Recursively extract all tool names from an action source as a string literal union.
  *
- * Leaf `Action` nodes produce their key directly. Nested `Actions` objects
+ * Leaf `Action` nodes produce their key directly. Nested action objects
  * produce `"parent_child"` paths joined with `_`.
  *
  * **Constraint**: Action keys must not contain underscores, or flattened names
@@ -39,8 +39,8 @@ import { invokeAction, walkActions } from '../shared/actions';
  *
  * @example
  * ```ts
- * type Names = ActionNames<typeof workspace>;
- * // "actions_tabs_search" | "actions_tabs_list" | ...
+ * type Names = ActionNames<typeof workspace.actions>;
+ * // "tabs_search" | "tabs_list" | ...
  * ```
  */
 export type ActionNames<T> = {
@@ -105,22 +105,20 @@ export type ToolDefinition = {
  *
  * ```
  * { tabs: { close: defineMutation(...) } }  →  tool named "tabs_close"
- * { actions: { tabs: { close: defineMutation(...) } } }  →  "actions_tabs_close"
+ * { tabs: { close: defineMutation(...) } }  →  "tabs_close"
  * { files: { read: defineQuery(...) } }      →  tool named "files_read"
  * ```
  *
  * Mutations automatically get `needsApproval: true` so the chat UI can show
  * a confirmation dialog before executing them. Queries run immediately.
  *
- * @param source - The workspace bundle (or any object containing actions).
- *   `walkActions` filters to action leaves at runtime, so passing the bundle
- *   directly is safe; non-action keys (`ydoc`, `tables`, etc.) are skipped.
+ * @param source - The action tree to expose as tools.
  *
  * @example
  * ```ts
  * import { actionsToAiTools } from '@epicenter/workspace/ai';
  *
- * export const workspaceAiTools = actionsToAiTools(workspace);
+ * export const workspaceAiTools = actionsToAiTools(workspace.actions);
  *
  * // Pass .tools to TanStack AI's ChatClient for local execution
  * const chat = createChat({
@@ -137,7 +135,7 @@ export type ToolDefinition = {
  *
  * // Show a friendly title in the UI when a tool call comes back
  * const title = workspaceAiTools.definitions
- *   .find(d => d.name === 'actions_tabs_close')?.title; // → 'Close Tabs'
+ *   .find(d => d.name === 'tabs_close')?.title; // → 'Close Tabs'
  * ```
  */
 export function actionsToAiTools<T>(
@@ -148,7 +146,11 @@ export function actionsToAiTools<T>(
 } {
 	const entries = Array.from(
 		walkActions(source as Record<string, unknown>),
-		([path, action]) => [action, path.split('.')] as const,
+		([path, action]) => {
+			const segments = path.split('.');
+			assertToolPathSegments(segments, path);
+			return [action, segments] as const;
+		},
 	);
 
 	const tools = entries.map(([action, path]) => ({
@@ -205,6 +207,16 @@ export function actionsToAiTools<T>(
  * `"foo_bar"`.
  */
 const ACTION_NAME_SEPARATOR = '_';
+
+function assertToolPathSegments(segments: string[], path: string) {
+	for (const segment of segments) {
+		if (segment.includes(ACTION_NAME_SEPARATOR)) {
+			throw new Error(
+				`Action keys used as AI tools cannot contain "_" at "${path}"`,
+			);
+		}
+	}
+}
 
 /** JSON Schema with `properties` and `required` guaranteed present. */
 type NormalizedJsonSchema = JSONSchema &

--- a/packages/workspace/src/client/connect-daemon.ts
+++ b/packages/workspace/src/client/connect-daemon.ts
@@ -4,11 +4,12 @@
  * app-side automation that want to call a running daemon.
  *
  * Generic `TWorkspace` is the in-process workspace shape (typically
- * `ReturnType<typeof openFuji>`); the runtime returns a
- * `DaemonActions<TWorkspace>` proxy backed by a unix-socket `DaemonClient`.
+ * `ReturnType<typeof openFuji>`); the runtime returns an action-root proxy
+ * backed by a unix-socket `DaemonClient`.
  * `TWorkspace` is type-only: no workspace code runs in the caller process.
- * `DaemonActions<TWorkspace>` filters it to branded `defineQuery` /
- * `defineMutation` leaves and rewrites each into the daemon `/run` result.
+ * `DaemonActions<TWorkspace['actions']>` filters the canonical action root to
+ * branded `defineQuery` / `defineMutation` leaves and rewrites each into the
+ * daemon `/run` result.
  *
  * @example
  * ```ts
@@ -18,7 +19,7 @@
  * using fuji = await connectDaemon<ReturnType<typeof openFuji>>({
  *   id: 'fuji',
  * });
- * await fuji.actions.entries.update({ id, tags: ['untagged'] });
+ * await fuji.entries.update({ id, tags: ['untagged'] });
  * ```
  *
  * Daemon-scope calls (peers, list across workspaces) live on `DaemonClient`
@@ -50,7 +51,9 @@ import {
  * Start one with `epicenter up`. There is no auto-spawn: explicit lifecycle
  * is the contract.
  */
-export async function connectDaemon<TWorkspace>({
+export async function connectDaemon<
+	TWorkspace extends { actions: Record<string, unknown> },
+>({
 	id: workspaceExportName,
 	projectDir = findEpicenterDir(),
 }: {
@@ -62,8 +65,8 @@ export async function connectDaemon<TWorkspace>({
 	 * `projectDir` to opt out.
 	 */
 	projectDir?: ProjectDir;
-}): Promise<DaemonActions<TWorkspace>> {
+}): Promise<DaemonActions<TWorkspace['actions']>> {
 	const { data: client, error } = await getDaemon(projectDir);
 	if (error) throw error;
-	return buildDaemonActions<TWorkspace>(client, workspaceExportName);
+	return buildDaemonActions<TWorkspace['actions']>(client, workspaceExportName);
 }

--- a/packages/workspace/src/client/daemon-actions.test.ts
+++ b/packages/workspace/src/client/daemon-actions.test.ts
@@ -8,7 +8,8 @@ import { describe, expect, test } from 'bun:test';
 import { Ok } from 'wellcrafted/result';
 import type { RunRequest } from '../daemon/app.js';
 import type { DaemonClient } from '../daemon/client.js';
-import { buildDaemonActions } from './daemon-actions.js';
+import { defineQuery } from '../shared/actions.js';
+import { buildDaemonActions, type DaemonActions } from './daemon-actions.js';
 
 function makeStubClient() {
 	const calls: { method: 'run' | 'peers' | 'list'; arg: unknown }[] = [];
@@ -33,18 +34,56 @@ function makeStubClient() {
 
 const WORKSPACE = 'demo';
 
+const typedActions = {
+	visible: defineQuery({
+		handler: () => 'visible',
+	}),
+	'bad.key': defineQuery({
+		handler: () => 'bad',
+	}),
+	nested: {
+		'bad.child': defineQuery({
+			handler: () => 'bad child',
+		}),
+	},
+};
+
+type TypedDaemonActions = DaemonActions<typeof typedActions>;
+
+type Expect<TValue extends true> = TValue;
+type Equal<TActual, TExpected> =
+	IsAssignable<TActual, TExpected> extends true
+		? IsAssignable<TExpected, TActual>
+		: false;
+type IsAssignable<TActual, TExpected> = [TActual] extends [TExpected]
+	? true
+	: false;
+type HasKey<TObject, TKey extends PropertyKey> = TKey extends keyof TObject
+	? true
+	: false;
+
+export type DaemonDotKeyExcluded = Expect<
+	Equal<HasKey<TypedDaemonActions, 'bad.key'>, false>
+>;
+export type DaemonBadOnlyBranchPruned = Expect<
+	Equal<HasKey<TypedDaemonActions, 'nested'>, false>
+>;
+export type DaemonValidKeyPreserved = Expect<
+	Equal<HasKey<TypedDaemonActions, 'visible'>, true>
+>;
+
 describe('buildDaemonActions workspace facade', () => {
 	test('domain action dispatches literal workspace path over /run', async () => {
 		const { client, calls } = makeStubClient();
 		// biome-ignore lint/suspicious/noExplicitAny: smoke test: shape is irrelevant
 		const workspace: any = buildDaemonActions(client, WORKSPACE);
 
-		await workspace.actions.entries.get('xyz');
+		await workspace.entries.get('xyz');
 
 		expect(calls).toHaveLength(1);
 		expect(calls[0]!.method).toBe('run');
 		expect(calls[0]!.arg).toMatchObject({
-			actionPath: 'demo.actions.entries.get',
+			actionPath: 'demo.entries.get',
 			input: 'xyz',
 		});
 	});
@@ -55,10 +94,10 @@ describe('buildDaemonActions workspace facade', () => {
 		const workspace: any = buildDaemonActions(client, WORKSPACE);
 		const row = { id: 'a', title: 'hi', _v: 1 };
 
-		await workspace.actions.entries.set(row);
+		await workspace.entries.set(row);
 
 		expect(calls[0]!.arg).toMatchObject({
-			actionPath: 'demo.actions.entries.set',
+			actionPath: 'demo.entries.set',
 			input: row,
 		});
 	});

--- a/packages/workspace/src/client/daemon-actions.ts
+++ b/packages/workspace/src/client/daemon-actions.ts
@@ -1,15 +1,14 @@
 /**
  * `buildDaemonActions`: typed proxy that turns a `DaemonClient` into an
- * workspace-shaped action facade. Local call sites use the same dotted path
- * they would under the returned workspace object
- * (`actions.savedTabs.create(...)`); each call dispatches over the unix socket
- * via `client.run`.
+ * action-root facade. Local call sites use the same dotted path they would
+ * under `workspace.actions` (`tabs.open(...)`); each call dispatches
+ * over the unix socket via `client.run`.
  *
- * The proxy is a single recursive `Proxy` rooted at the workspace shape.
+ * The proxy is a single recursive `Proxy` rooted at the action shape.
  * Property access walks the chain and accumulates path segments; calling
  * the resulting proxy invokes `client.run` with the joined dotted path.
  *
- * `then` is masked at every level so an accidental `await workspace.actions.tabs`
+ * `then` is masked at every level so an accidental `await actions.tabs`
  * does not turn an intermediate namespace into a thenable and pollute the
  * path with a stray `.then` segment.
  */
@@ -27,8 +26,9 @@ const DEFAULT_RUN_WAIT_MS = 5_000;
  * source by walking its type and keeping only branded `defineQuery` /
  * `defineMutation` leaves.
  *
- * Pass the returned workspace type as `T` (typically
- * `ReturnType<typeof openFuji>`) and `DaemonActions<T>` filters it to:
+ * Pass the canonical action root type as `T` (typically
+ * `ReturnType<typeof openFuji>['actions']`) and `DaemonActions<T>` filters it
+ * to:
  *
  * - branded leaves at any depth become wire-callable and `Result`-wrapped
  *   via {@link WrapDaemonAction}
@@ -82,8 +82,10 @@ type HasBrandedLeaves<T, D extends ReadonlyArray<1>> = AtLimit<D> extends true
 		? false
 		: T extends object
 			? true extends {
-					[K in keyof T]-?: IsDaemonKey<T[K], Inc<D>>;
-				}[keyof T]
+					[K in keyof T & string]-?: ActionPathKey<K> extends never
+						? false
+						: IsDaemonKey<T[K], Inc<D>>;
+				}[keyof T & string]
 				? true
 				: false
 			: false;
@@ -115,19 +117,27 @@ export type DaemonActions<T, D extends ReadonlyArray<1> = []> =
 	AtLimit<D> extends true
 		? {}
 		: Simplify<{
-				[K in keyof T as IsDaemonKey<T[K], D> extends true
+				[K in keyof T & string as ActionPathKey<K> extends never
+					? never
+					: IsDaemonKey<T[K], D> extends true
 					? K
 					: never]: T[K] extends Action
 					? WrapDaemonAction<T[K]>
 					: T[K] extends readonly unknown[]
 						? never
 						: T[K] extends object
-							? DaemonActions<T[K], Inc<D>>
-							: never;
+						? DaemonActions<T[K], Inc<D>>
+						: never;
 			}>;
 
+type ActionPathKey<TKey extends string> = TKey extends ''
+	? never
+	: TKey extends `${string}.${string}`
+		? never
+		: TKey;
+
 /**
- * Recursive proxy rooted at the workspace shape. Property access produces another
+ * Recursive proxy rooted at the action shape. Property access produces another
  * proxy carrying the path-so-far; calling the proxy dispatches `client.run`
  * with the joined dotted path.
  *
@@ -162,16 +172,16 @@ function buildDaemonActionProxy(
 }
 
 /**
- * Compose the daemon action facade. Generic `TWorkspace` is the in-process
- * workspace shape; `DaemonActions<TWorkspace>` filters it to branded leaves
+ * Compose the daemon action facade. Generic `TActions` is the in-process
+ * action root shape; `DaemonActions<TActions>` filters it to branded leaves
  * only and rewrites each leaf to the daemon `/run` result.
  */
-export function buildDaemonActions<TWorkspace>(
+export function buildDaemonActions<TActions>(
 	client: DaemonClient,
 	workspaceExportName: string,
-): DaemonActions<TWorkspace> {
+): DaemonActions<TActions> {
 	return buildDaemonActionProxy(
 		client,
 		workspaceExportName,
-	) as DaemonActions<TWorkspace>;
+	) as DaemonActions<TActions>;
 }

--- a/packages/workspace/src/daemon/action-routing.ts
+++ b/packages/workspace/src/daemon/action-routing.ts
@@ -48,7 +48,7 @@ export function workspaceActionSuggestionLines(
 	entry: WorkspaceEntry,
 	prefix: string,
 ): string[] {
-	const entries = [...walkActions(entry.workspace)];
+	const entries = [...walkActions(entry.workspace.actions)];
 	const descendants = entriesUnder(entries, prefix);
 	return descendants.map(
 		([path, action]) =>
@@ -60,7 +60,7 @@ export function workspaceActionNearestSiblingLines(
 	entry: WorkspaceEntry,
 	missedPath: string,
 ): string[] {
-	const entries = [...walkActions(entry.workspace)];
+	const entries = [...walkActions(entry.workspace.actions)];
 	const parts = missedPath.split('.');
 	while (parts.length > 0) {
 		parts.pop();

--- a/packages/workspace/src/daemon/app.ts
+++ b/packages/workspace/src/daemon/app.ts
@@ -6,7 +6,7 @@
  * Each verb is a one-line shell shortcut for one workspace primitive:
  *
  *   /peers  ->  workspace.presence.peers()                    all exports
- *   /list   ->  describeActions({ export: workspace })         all exports
+ *   /list   ->  describeActions({ export: workspace.actions }) all exports
  *   /run    ->  invokeAction(...) | rpc.rpc(...)              export-routed
  *
  * Each route returns the handler's `Result<T, DomainErr>` body directly.
@@ -88,7 +88,7 @@ export function buildApp(
 		})
 		.post('/list', (c) => {
 			const actionRoots = Object.fromEntries(
-				entries.map((entry) => [entry.name, entry.workspace]),
+				entries.map((entry) => [entry.name, entry.workspace.actions]),
 			);
 			return c.json(Ok(describeActions(actionRoots)));
 		})

--- a/packages/workspace/src/daemon/list-route.test.ts
+++ b/packages/workspace/src/daemon/list-route.test.ts
@@ -23,6 +23,7 @@ function fakeEntry(
 ): WorkspaceEntry {
 	const workspace = {
 		whenReady: Promise.resolve(),
+		actions: {},
 		...workspaceShape,
 		[Symbol.dispose]() {},
 	} satisfies LoadedWorkspace;
@@ -40,7 +41,7 @@ async function postList(entries: WorkspaceEntry[]): Promise<ListResult> {
 }
 
 describe('/list route', () => {
-	test('returns literal export-prefixed paths under actions', async () => {
+	test('returns export-prefixed paths under the action root', async () => {
 		const reply = await postList([
 			fakeEntry('demo', {
 				actions: {
@@ -56,18 +57,19 @@ describe('/list route', () => {
 		expect(reply.error).toBeNull();
 		if (reply.error === null) {
 			expect(Object.keys(reply.data).sort()).toEqual([
-				'demo.actions.counter.get',
+				'demo.counter.get',
 			]);
-			expect(reply.data['demo.actions.counter.get']?.description).toBe(
+			expect(reply.data['demo.counter.get']?.description).toBe(
 				'Read the counter',
 			);
 		}
 	});
 
-	test('returns top-level action groups when the workspace exposes them', async () => {
+	test('ignores action leaves outside the canonical action root', async () => {
 		const reply = await postList([
 			fakeEntry('demo', {
-				counter: {
+				actions: {},
+				sqlite: {
 					get: defineQuery({
 						handler: () => 0,
 					}),
@@ -77,7 +79,7 @@ describe('/list route', () => {
 
 		expect(reply.error).toBeNull();
 		if (reply.error === null) {
-			expect(Object.keys(reply.data).sort()).toEqual(['demo.counter.get']);
+			expect(reply.data).toEqual({});
 		}
 	});
 
@@ -106,8 +108,8 @@ describe('/list route', () => {
 		expect(reply.error).toBeNull();
 		if (reply.error === null) {
 			expect(Object.keys(reply.data).sort()).toEqual([
-				'notes.actions.add',
-				'tasks.actions.list',
+				'notes.add',
+				'tasks.list',
 			]);
 		}
 	});

--- a/packages/workspace/src/daemon/run-handler.test.ts
+++ b/packages/workspace/src/daemon/run-handler.test.ts
@@ -56,7 +56,7 @@ describe('executeRun peer dispatch', () => {
 		);
 
 		const result = await executeRun([entry], {
-			actionPath: 'demo.actions.tabs.list',
+			actionPath: 'demo.tabs.list',
 			input: undefined,
 			peerTarget: 'ghost',
 			waitMs: 25,
@@ -98,14 +98,14 @@ describe('executeRun peer dispatch', () => {
 		);
 
 		const result = await executeRun([entry], {
-			actionPath: 'demo.actions.tabs.list',
+			actionPath: 'demo.tabs.list',
 			input: undefined,
 			peerTarget: 'mac',
 			waitMs: 25,
 		});
 
 		expect(result.error).toBeNull();
-		expect(rpcAction).toBe('actions.tabs.list');
+		expect(rpcAction).toBe('tabs.list');
 	});
 });
 
@@ -127,7 +127,7 @@ describe('executeRun export-prefixed routing', () => {
 		};
 
 		const result = await executeRun([entry], {
-			actionPath: 'notes.actions.notes.add',
+			actionPath: 'notes.notes.add',
 			input: { body: 'hello' },
 			waitMs: 25,
 		});
@@ -136,8 +136,9 @@ describe('executeRun export-prefixed routing', () => {
 		expect(result.data).toEqual({ body: 'hello' });
 	});
 
-	test('invokes top-level action groups when the workspace exposes them', async () => {
+	test('ignores action leaves outside the canonical action root', async () => {
 		const workspace = {
+			actions: {},
 			notes: {
 				add: defineMutation({
 					handler: () => ({ body: 'hello' }),
@@ -156,11 +157,10 @@ describe('executeRun export-prefixed routing', () => {
 			waitMs: 25,
 		});
 
-		expect(result.error).toBeNull();
-		expect(result.data).toEqual({ body: 'hello' });
+		expect(result.error?.name).toBe('UsageError');
 	});
 
-	test('missing short path suggests literal actions path', async () => {
+	test('missing path suggests action-root-relative sibling', async () => {
 		const entry = {
 			name: 'notes',
 			workspace: {
@@ -176,7 +176,7 @@ describe('executeRun export-prefixed routing', () => {
 		};
 
 		const result = await executeRun([entry], {
-			actionPath: 'notes.notes.add',
+			actionPath: 'notes.add',
 			input: { body: 'hello' },
 			waitMs: 25,
 		});
@@ -185,9 +185,7 @@ describe('executeRun export-prefixed routing', () => {
 		if (result.error?.name !== 'UsageError') {
 			throw new Error('expected UsageError');
 		}
-		expect(result.error.suggestions).toEqual([
-			'  notes.actions.notes.add  (mutation)',
-		]);
+		expect(result.error.suggestions).toEqual(['  notes.notes.add  (mutation)']);
 	});
 
 	test('unknown export returns available export suggestions', async () => {
@@ -197,6 +195,7 @@ describe('executeRun export-prefixed routing', () => {
 				{
 					name: 'tasks',
 					workspace: {
+						actions: {},
 						[Symbol.dispose]() {},
 					} as WorkspaceEntry['workspace'],
 				},

--- a/packages/workspace/src/daemon/run-handler.ts
+++ b/packages/workspace/src/daemon/run-handler.ts
@@ -48,7 +48,7 @@ export async function executeRun(
 	const { workspace } = entry;
 	if (workspace.whenReady) await workspace.whenReady;
 
-	const action = resolveActionPath(workspace, localPath);
+	const action = resolveActionPath(workspace.actions, localPath);
 	if (!action) {
 		const descendants = workspaceActionSuggestionLines(entry, localPath);
 		if (descendants.length > 0) {

--- a/packages/workspace/src/daemon/types.ts
+++ b/packages/workspace/src/daemon/types.ts
@@ -2,10 +2,9 @@
  * Daemon-side types describing the shape of a hosted workspace.
  *
  * `LoadedWorkspace` is the structural contract every workspace export has
- * to satisfy: the `[Symbol.dispose]` discriminator, plus the optional
- * `whenReady`, `sync`, `presence`, and `rpc` fields the daemon reads when
- * present. Public actions can live anywhere reachable through plain object
- * properties on this returned object.
+ * to satisfy: the `[Symbol.dispose]` discriminator, a required `actions`
+ * root, plus the optional `whenReady`, `sync`, `presence`, and `rpc` fields
+ * the daemon reads when present.
  *
  * `WorkspaceEntry` is one named entry the daemon hosts. The CLI's config
  * loader produces these from `epicenter.config.ts` exports.
@@ -18,10 +17,9 @@ import type {
 import type { PeerPresenceAttachment } from '../document/peer-presence.js';
 
 /**
- * Fields the daemon looks at on each workspace export. Only `[Symbol.dispose]`
- * is required (it's the discriminator); everything else is read when
- * present. Extra fields can still matter to action discovery: any action leaf
- * reachable through returned plain objects becomes public.
+ * Fields the daemon looks at on each workspace export. `[Symbol.dispose]` and
+ * `actions` are required. Other fields are read when present. Extra fields are
+ * direct-use infrastructure and do not affect daemon action discovery.
  */
 export type LoadedWorkspace = {
 	/**
@@ -29,6 +27,12 @@ export type LoadedWorkspace = {
 	 * marks the export as a workspace.
 	 */
 	[Symbol.dispose](): void;
+
+	/**
+	 * Canonical public action root. Daemon paths are relative to this object:
+	 * `workspace.actions.entries.create` is invoked as `<export>.entries.create`.
+	 */
+	readonly actions: Record<string, unknown>;
 
 	/** Awaited before any action invocation, if present. */
 	readonly whenReady?: Promise<unknown>;

--- a/packages/workspace/src/document/attach-sync.test.ts
+++ b/packages/workspace/src/document/attach-sync.test.ts
@@ -145,16 +145,14 @@ describe('attachSync split surface', () => {
 		const calls: unknown[] = [];
 		const sync = attachSync(ydoc, { url: `ws://x/${ydoc.guid}` });
 		const rpc = sync.attachRpc({
-			actions: {
-				tabs: {
-					close: defineMutation({
-						input: Type.Object({ tabIds: Type.Array(Type.Number()) }),
-						handler: (input) => {
-							calls.push(input);
-							return { closedCount: input.tabIds.length };
-						},
-					}),
-				},
+			tabs: {
+				close: defineMutation({
+					input: Type.Object({ tabIds: Type.Array(Type.Number()) }),
+					handler: (input) => {
+						calls.push(input);
+						return { closedCount: input.tabIds.length };
+					},
+				}),
 			},
 		});
 
@@ -222,9 +220,7 @@ describe('attachSync split surface', () => {
 
 		expect(() =>
 			sync.attachRpc({
-				actions: {
-					system: {},
-				},
+				system: {},
 			}),
 		).toThrow(/system/);
 

--- a/packages/workspace/src/document/attach-sync.ts
+++ b/packages/workspace/src/document/attach-sync.ts
@@ -52,7 +52,7 @@ import {
  * **Not included** (workspace-layer concerns):
  * - BroadcastChannel cross-tab sync (separate `attachBroadcastChannel` helper)
  * - Standard peer presence (`sync.attachPresence({ peer })`)
- * - Peer RPC (`sync.attachRpc({ actions })`)
+ * - Peer RPC (`sync.attachRpc(actions)`)
  *
  * Register `attachIndexedDb` first and pass its `whenLoaded`
  * as `waitFor` so the supervisor connects only after local state hydrates:
@@ -186,12 +186,10 @@ export type SyncAttachment = {
 	attachPresence<TPeerId extends string = string>(
 		config: AttachPresenceConfig<TPeerId>,
 	): PeerPresenceAttachment;
-	attachRpc(config: AttachRpcConfig): SyncRpcAttachment;
+	attachRpc(actions: RpcActionSource): SyncRpcAttachment;
 };
 
-export type AttachRpcConfig = {
-	actions: Record<string, unknown>;
-};
+export type RpcActionSource = Record<string, unknown>;
 
 export type SyncRpcAttachment = {
 	rpc<
@@ -475,8 +473,8 @@ export function attachSync(
 	}
 
 	/**
-	 * Handle an inbound RPC request: delegate action lookup to the caller
-	 * via `config.dispatch`, and send the response back to the requester.
+	 * Handle an inbound RPC request: resolve against the attached RPC action
+	 * tree and send the response back to the requester.
 	 *
 	 * When no dispatcher is configured, respond with `ActionNotFound` so the
 	 * caller sees a typed error instead of a timeout.
@@ -920,7 +918,7 @@ export function attachSync(
 			presenceController.sendLocalState();
 			return presence;
 		},
-		attachRpc({ actions: userActions }) {
+		attachRpc(userActions) {
 			if (rpcActions) throw new Error('[attachSync] RPC already attached');
 			if ('system' in userActions) {
 				throw new Error(

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -35,13 +35,11 @@ export type {
 	Action,
 	ActionManifest,
 	ActionMeta,
-	Actions,
 	Mutation,
 	Query,
 	RemoteActionProxy,
 } from './shared/actions';
 export {
-	defineActions,
 	defineMutation,
 	defineQuery,
 	describeActions,
@@ -171,10 +169,10 @@ export {
 	xmlFragmentToPlaintext,
 } from './document/attach-rich-text.js';
 export {
-	type AttachRpcConfig,
 	type AttachSyncDoc,
 	attachSync,
 	PeerMiss,
+	type RpcActionSource,
 	type SyncAttachment,
 	type SyncAttachmentConfig,
 	SyncFailedError,

--- a/packages/workspace/src/rpc/types.ts
+++ b/packages/workspace/src/rpc/types.ts
@@ -13,8 +13,8 @@ import type { Action } from '../shared/actions.js';
  *
  * @example
  * ```typescript
- * // Tab-manager exports its actions type:
- * export type TabManagerRpc = InferSyncRpcMap<typeof workspace>;
+ * // Tab-manager exports its action-root type:
+ * export type TabManagerRpc = InferSyncRpcMap<typeof workspace.actions>;
  * // Resolves to:
  * // {
  * //   'tabs.close': { input: { tabIds: number[] }; output: { closedCount: number } }

--- a/packages/workspace/src/shared/actions.test.ts
+++ b/packages/workspace/src/shared/actions.test.ts
@@ -279,4 +279,25 @@ describe('action path walking', () => {
 		);
 		expect(resolveActionPath(actions, 'bad.key')).toBeUndefined();
 	});
+
+	test('rejects dot-containing object keys on action-bearing branches', () => {
+		const workspace = {
+			settings: {
+				'bad.key': {
+					visible: defineQuery({
+						handler: () => 'visible',
+					}),
+				},
+			},
+			actions: {
+				visible: defineQuery({
+					handler: () => 'visible',
+				}),
+			},
+		};
+
+		expect(() => [...walkActions(workspace)]).toThrow(
+			'Action keys cannot contain "." at "settings.bad.key"',
+		);
+	});
 });

--- a/packages/workspace/src/shared/actions.ts
+++ b/packages/workspace/src/shared/actions.ts
@@ -7,7 +7,7 @@
  *
  * Two shapes for the same data:
  *
- *     Actions                       <->    ActionManifest
+ *     Action tree                   <->    ActionManifest
  *     nested, callable                     flat, metadata-only
  *     local, in-memory                     wire form (system.describe)
  *
@@ -129,40 +129,6 @@ export type Action<
 > = Query<TInput, R> | Mutation<TInput, R>;
 
 /**
- * Shape suggestion for a "pure action tree" authoring style: nested objects
- * whose leaves are all `Action` definitions.
- *
- * Not load-bearing on any public signature. `walkActions` filters action
- * leaves at runtime via `isAction`, so action definitions can sit alongside
- * workspace infrastructure. Use this type if you genuinely want to annotate a
- * return as "tree of actions only"; otherwise let the inferred type do the
- * talking.
- *
- * Uses `any` for the action's input/output positions so specific
- * `Query<I, T>` / `Mutation<I, T>` instances assign cleanly through the
- * variadic-args distribution trick.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type Actions = {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	[key: string]: Action<any, any> | Actions;
-};
-
-/**
- * Mark a plain action registry while preserving its exact inferred shape.
- *
- * This is intentionally an identity function. CLI and RPC adapters do not
- * require this wrapper; they discover any `defineQuery` / `defineMutation`
- * leaves reachable through plain objects. Use `defineActions` when you want
- * to name a grouped set of actions and keep its type tidy.
- */
-export function defineActions<TActions extends Actions>(
-	actions: TActions,
-): TActions {
-	return actions;
-}
-
-/**
  * The runtime-injected `system.*` action namespace. Single canonical type:
  * `attachRpc` constructs `systemActions: SystemActions` and `remote-actions.ts`
  * derives the proxy type `createRemoteActions<{ system: SystemActions }>` from
@@ -254,8 +220,8 @@ export function isMutation(value: unknown): value is Mutation {
  * prototype is `null`). Bounds {@link walkActions} so it doesn't recurse
  * into class instances like `Y.Doc`, arktype `Type`, or `SvelteMap`:
  * those carry methods on their prototype and have no business being walked.
- * This makes passing a full workspace object safe: plain object branches are
- * treated as public path segments, class-backed infrastructure is skipped.
+ * This keeps action-tree walking bounded: plain object branches are treated as
+ * path segments, class-backed infrastructure is skipped.
  */
 function isPlainObject(v: unknown): v is Record<string, unknown> {
 	if (typeof v !== 'object' || v === null) return false;
@@ -279,8 +245,8 @@ function assertValidActionKey(key: string, path: string) {
  * returning the leaf `Action` if the path lands on one. Returns `undefined`
  * for missing paths or paths that resolve to a namespace.
  *
- * Typed `Record<string, unknown>` so callers can pass a full workspace object
- * or a narrower action tree without losing nested path support.
+ * Typed `Record<string, unknown>` so callers can pass a nested action tree
+ * without losing nested path support.
  */
 export function resolveActionPath(
 	actions: Record<string, unknown>,
@@ -305,12 +271,12 @@ export function resolveActionPath(
  *
  * Recursion only descends into plain object literals. Class instances
  * (`Y.Doc`, arktype `Type`, etc.) and functions short-circuit, so a returned
- * workspace bundle can be used directly. Any action leaf reachable through
- * plain object properties is part of the public path surface.
+ * action tree can be used directly. Any action leaf reachable through plain
+ * object properties is part of the path surface for that tree.
  *
  * Pair with `Object.fromEntries`, `Array.from`, or a `for…of` loop:
  * ```ts
- * for (const [path, action] of walkActions(workspace)) {
+ * for (const [path, action] of walkActions(workspace.actions)) {
  *   if (action.type === 'mutation') console.log(path);
  * }
  * ```
@@ -490,9 +456,9 @@ type RemoteSuccessOutput<TOutput> =
  * Filter any object `T` down to its action-shaped leaves and wrap each leaf
  * via {@link WrapAction} so callers see uniform `Promise<Result<T, RpcError>>`.
  *
- * Pass a pure action tree or a workspace bundle: non-action keys are removed
- * at the type level via key-remapping. Subtrees that contain zero actions are
- * also pruned, so consumers only see paths that lead somewhere callable.
+ * Pass a pure action tree: non-action keys are removed at the type level via
+ * key-remapping. Subtrees that contain zero actions are also pruned, so
+ * consumers only see paths that lead somewhere callable.
  *
  * Bracketed `[T[K]] extends [Action]` form is intentional: prevents
  * unwanted distribution if a key's type is a union (e.g., `Foo | undefined`).

--- a/playground/opensidian-e2e/README.md
+++ b/playground/opensidian-e2e/README.md
@@ -35,7 +35,7 @@ Invoke a defined action:
 
 ```bash
 # Scan a directory for markdown files and inject IDs into frontmatter.
-epicenter run opensidian.markdownActions.prepare '{"directory":"./some/dir"}' \
+epicenter run opensidian.markdown.prepare '{"directory":"./some/dir"}' \
   -C playground/opensidian-e2e
 ```
 

--- a/playground/opensidian-e2e/epicenter.config.ts
+++ b/playground/opensidian-e2e/epicenter.config.ts
@@ -11,8 +11,8 @@
  * `~/.epicenter/auth/sessions.json`. Run `epicenter auth login` first.
  *
  * Exports `opensidian`: an object satisfying `LoadedWorkspace` with
- * `whenReady`, `sync`, `[Symbol.dispose]`, and any action namespaces hoisted
- * to the top level. `loadConfig` picks up any named export with that shape.
+ * `whenReady`, `actions`, `sync`, and `[Symbol.dispose]`. Daemon action paths
+ * are relative to `actions`.
  *
  * Usage:
  *   # Run the workspace. Imports this config, which constructs the
@@ -20,8 +20,8 @@
  *   # Runs until Ctrl+C.
  *   bun run playground/opensidian-e2e/epicenter.config.ts
  *
- *   # Invoke the markdownActions.prepare mutation.
- *   epicenter run opensidian.markdownActions.prepare '{"directory":"./some/dir"}' \
+ *   # Invoke the markdown.prepare mutation.
+ *   epicenter run opensidian.markdown.prepare '{"directory":"./some/dir"}' \
  *     -C playground/opensidian-e2e
  */
 
@@ -164,19 +164,21 @@ const sqlite = attachSqliteMaterializer(ydoc, {
  * frontmatter of any file that doesn't already have one. Errors if duplicate
  * IDs are detected across files.
  */
-const markdownActions = {
-	prepare: defineMutation({
-		title: 'Prepare Markdown Files',
-		description:
-			'Add unique IDs to markdown files missing them in YAML frontmatter',
-		input: Type.Object({ directory: Type.String() }),
-		handler: async ({ directory }) => prepareMarkdownFiles(directory),
-	}),
+const actions = {
+	markdown: {
+		prepare: defineMutation({
+			title: 'Prepare Markdown Files',
+			description:
+				'Add unique IDs to markdown files missing them in YAML frontmatter',
+			input: Type.Object({ directory: Type.String() }),
+			handler: async ({ directory }) => prepareMarkdownFiles(directory),
+		}),
+	},
 };
 
 export const opensidian = {
 	whenReady,
-	markdownActions,
+	actions,
 	sync,
 	[Symbol.dispose]() {
 		ydoc.destroy();

--- a/playground/tab-manager-e2e/epicenter.config.ts
+++ b/playground/tab-manager-e2e/epicenter.config.ts
@@ -6,9 +6,8 @@
  * at `~/.epicenter/auth/sessions.json`—run `epicenter auth login` first.
  *
  * Exports `tabManager` — an object satisfying `LoadedWorkspace` with
- * `whenReady`, `sync`, and `[Symbol.dispose]`. No `actions` because no
- * defineQuery/defineMutation wrappers are attached at the playground layer
- * (the tab-manager extension defines actions, not this config).
+ * `whenReady`, `sync`, `actions`, and `[Symbol.dispose]`. `actions` is empty
+ * because the tab-manager extension defines action wrappers, not this config.
  *
  * Usage:
  *   # Run the workspace — imports this config, which constructs the
@@ -16,8 +15,7 @@
  *   # Runs until Ctrl+C.
  *   bun run playground/tab-manager-e2e/epicenter.config.ts
  *
- *   # `epicenter list` against this config shows an empty tree — no
- *   # actions exposed here.
+ *   # `epicenter list` against this config shows an empty tree.
  */
 
 import { join } from 'node:path';
@@ -91,6 +89,7 @@ const markdown = attachMarkdownMaterializer(
 
 export const tabManager = {
 	whenReady,
+	actions: {},
 	sync,
 	[Symbol.dispose]() {
 		ydoc.destroy();


### PR DESCRIPTION
## Why This PR Exists

Stacked on #1722.

#1722 makes the daemon transport and package exports safe without changing command paths. This PR is the separate API cleanup: `workspace.actions` becomes the public callable root, so daemon commands no longer expose the implementation detail that actions live under an `actions` property.

Before:

```txt
epicenter run notes.actions.notes.add
```

After:

```txt
epicenter run notes.notes.add
```

That gives the CLI a cleaner route shape while keeping the config object honest: only the `actions` tree is callable. Other properties on the hosted workspace facade are not accidentally treated as command namespaces.

## What Changed

Hosted workspaces still define actions in the same place:

```ts
export const notes = {
	actions: {
		notes: {
			add: defineMutation({
				handler: async () => {
					// ...
				},
			}),
		},
	},
	[Symbol.dispose]() {},
};
```

The daemon now lists and runs paths relative to `notes.actions`:

```txt
notes.notes.add
```

This also tightens config loading. Disposable workspace exports must expose an `actions` object, because the daemon can only host things it can route to.

## Review Shape

```txt
main
  |
  +-- #1722: browser-safe root exports, daemon transport stays on old paths
        |
        +-- #1723: action-root paths, command shape changes
              |
              +-- next PR: defineEpicenterConfig, HostedWorkspace, hostWorkspace
```

Keep this PR stacked and draft until #1722 is merged or this branch is retargeted to `main` with clean checks. Merging it before #1722 would collapse the split and make the browser fix harder to review.

The explicit daemon host config spec should come after this PR. That work is a config contract change:

```ts
import { openFuji } from '@epicenter/fuji/daemon';
import { defineEpicenterConfig } from '@epicenter/workspace/daemon';

export default defineEpicenterConfig([
	openFuji({
		peer: { id: 'fuji-daemon', name: 'Fuji Daemon', platform: 'node' },
	}),
]);
```

Once `workspace.actions` is the canonical callable root, that follow-up can focus on host declarations instead of also redefining action discovery.

## Merge Plan

1. Merge #1722 after review and required checks are clean.
2. Retarget #1723 to `main`, mark it ready, and merge once checks are clean.
3. Start the explicit daemon host config branch from updated `main`.

## Verified

```txt
bun --filter @epicenter/whispering build
bun run --filter @epicenter/workspace typecheck
bun x tsc --noEmit -p packages/cli/tsconfig.json
bun test packages/workspace
bun test packages/cli
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->
