### PR TITLE
feat(whispering): allow custom model name for openai api

### DIFF
--- a/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
@@ -47,6 +47,12 @@
 		label: model.name,
 		...model,
 	}));
+	const CUSTOM_OPENAI_MODEL = 'custom';
+	const isCustomOpenaiModel = $derived(
+		!openaiModelItems.some(
+			(item) => item.value === settings.get('transcription.openai.model'),
+		),
+	);
 
 	const groqModelItems = TRANSCRIPTION.Groq.models.map((model) => ({
 		value: model.name,
@@ -74,9 +80,11 @@
 
 	// Selected labels for select triggers
 	const openaiModelLabel = $derived(
-		openaiModelItems.find(
-			(i) => i.value === settings.get('transcription.openai.model'),
-		)?.label,
+		isCustomOpenaiModel
+			? 'Custom'
+			: openaiModelItems.find(
+					(i) => i.value === settings.get('transcription.openai.model'),
+				)?.label,
 	);
 
 	const groqModelLabel = $derived(
@@ -132,8 +140,14 @@
 				<Field.Label for="openai-model">OpenAI Model</Field.Label>
 				<Select.Root
 					type="single"
-					bind:value={() => settings.get('transcription.openai.model'),
-						(v) => settings.set('transcription.openai.model', v)}
+					bind:value={() => isCustomOpenaiModel
+							? CUSTOM_OPENAI_MODEL
+							: settings.get('transcription.openai.model'),
+						(v) =>
+							settings.set(
+								'transcription.openai.model',
+								v === CUSTOM_OPENAI_MODEL ? '' : v,
+							)}
 				>
 					<Select.Trigger id="openai-model" class="w-full">
 						{openaiModelLabel ?? 'Select a model'}
@@ -144,6 +158,7 @@
 								{@render renderModelOption({ item })}
 							</Select.Item>
 						{/each}
+						<Select.Item value={CUSTOM_OPENAI_MODEL} label="Custom Model" />
 					</Select.Content>
 				</Select.Root>
 				<Field.Description>
@@ -157,6 +172,18 @@
 					.
 				</Field.Description>
 			</Field.Field>
+			{#if isCustomOpenaiModel}
+				<Field.Field>
+					<Field.Label for="openai-custom-model">Custom Model Name</Field.Label>
+					<Input
+						id="openai-custom-model"
+						placeholder="gpt-114514"
+						autocomplete="off"
+						bind:value={() => settings.get('transcription.openai.model'),
+							(value) => settings.set('transcription.openai.model', value)}
+					/>
+				</Field.Field>
+			{/if}
 			<OpenAiApiKeyInput />
 		{:else if settings.get('transcription.service') === 'Groq'}
 			<Field.Field>


### PR DESCRIPTION
This commit adds frontend tweaks so that users can supply their desiered model name in addition to API endpoint for OpenAI transcription API. Allows users to use models other than those that are baked in the frontend.

Fixes #1581

NOTE that this is only tested against parent commit 8ea1bd082, see https://discord.com/channels/1391098486178582549/1401973085686726698/1499321342414290955

<!--
Open with WHAT changed (one crisp sentence), then explain WHY.

For API changes, include before/after code examples.
For refactors, show before/after snippets.
Don't list files changed—the diff tab does that.
-->



## Changelog

<!--
One line per user-visible change. Imperative mood. Written for end users, not developers.
Required for feat: and fix: PRs. Omit this section entirely for chore/refactor/docs.
-->

- 

Closes #

<!-- Paste screenshots or recordings here for UI changes -->

> PRs touching `apps/api/`, `packages/sync/`, or `packages/sync-client/` require @braden-w review per CODEOWNERS.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->