### PR TITLE
feat(whispering): send no_verbatim for ElevenLabs scribe_v2

### DIFF
--- a/apps/whispering/src/lib/services/transcription/cloud/elevenlabs.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/elevenlabs.ts
@@ -1,12 +1,12 @@
-import { ElevenLabsClient } from 'elevenlabs';
 import {
 	defineErrors,
 	extractErrorMessage,
 	type InferErrors,
 } from 'wellcrafted/error';
-import { type Result, tryAsync } from 'wellcrafted/result';
+import { Err, type Result, tryAsync } from 'wellcrafted/result';
 
 const MAX_FILE_SIZE_MB = 1000 as const;
+const ELEVENLABS_STT_URL = 'https://api.elevenlabs.io/v1/speech-to-text';
 
 export const ElevenLabsError = defineErrors({
 	MissingApiKey: () => ({
@@ -22,6 +22,17 @@ export const ElevenLabsError = defineErrors({
 		message: `File size ${sizeMb.toFixed(1)}MB exceeds ${maxMb}MB limit`,
 		sizeMb,
 		maxMb,
+	}),
+	ApiError: ({
+		status,
+		body,
+	}: {
+		status: number;
+		body: string;
+	}) => ({
+		message: `ElevenLabs API error ${status}: ${body}`,
+		status,
+		body,
 	}),
 	Unexpected: ({ cause }: { cause: unknown }) => ({
 		message: extractErrorMessage(cause),
@@ -51,23 +62,42 @@ export const ElevenLabsTranscriptionServiceLive = {
 			});
 		}
 
-		const client = new ElevenLabsClient({ apiKey: options.apiKey });
+		const formData = new FormData();
+		formData.append('file', audioBlob);
+		formData.append('model_id', options.modelName);
+		if (options.outputLanguage !== 'auto') {
+			formData.append('language_code', options.outputLanguage);
+		}
+		formData.append('tag_audio_events', 'false');
+		formData.append('diarize', 'true');
+		// Remove filler words, false starts, and non-speech sounds. Only
+		// supported on scribe_v2 per ElevenLabs API; ignored on other models.
+		if (options.modelName === 'scribe_v2') {
+			formData.append('no_verbatim', 'true');
+		}
+
+		const { data: response, error: fetchError } = await tryAsync({
+			try: () =>
+				fetch(ELEVENLABS_STT_URL, {
+					method: 'POST',
+					headers: { 'xi-api-key': options.apiKey },
+					body: formData,
+				}),
+			catch: (cause) => ElevenLabsError.Unexpected({ cause }),
+		});
+		if (fetchError) return Err(fetchError);
+
+		if (!response.ok) {
+			const body = await response.text().catch(() => '');
+			return ElevenLabsError.ApiError({ status: response.status, body });
+		}
 
 		return tryAsync({
 			try: async () => {
-				const transcription = await client.speechToText.convert({
-					file: audioBlob,
-					model_id: options.modelName,
-					language_code:
-						options.outputLanguage !== 'auto'
-							? options.outputLanguage
-							: undefined,
-					tag_audio_events: false,
-					diarize: true,
-				});
-				return transcription.text.trim();
+				const data = (await response.json()) as { text: string };
+				return data.text.trim();
 			},
-			catch: (error) => ElevenLabsError.Unexpected({ cause: error }),
+			catch: (cause) => ElevenLabsError.Unexpected({ cause }),
 		});
 	},
 };


### PR DESCRIPTION
## What

When the user selects ElevenLabs `scribe_v2`, send `no_verbatim=true` to `/v1/speech-to-text`. ElevenLabs strips filler words, false starts, and non-speech sounds at the model, so the output is dictation-ready without a downstream transformation step.

No-op on `scribe_v1` / `scribe_v1_experimental` (the parameter is ignored when not supported), so existing flows are unaffected.

Ref: https://elevenlabs.io/docs/api-reference/speech-to-text/convert

## Why direct fetch

The bundled SDK is the legacy `elevenlabs@1.59.0` package, which predates `scribe_v2` and exposes neither the new model id nor `no_verbatim` in its `BodySpeechToTextV1SpeechToTextPost` type. Upgrading to `@elevenlabs/elevenlabs-js@2.x` is a package rename plus a breaking-change migration. To keep the diff small and avoid touching the lockfile, this patch posts the multipart form directly. The other adapters in this folder follow the same multipart pattern (see `groq.ts`, `openai.ts`), so this is consistent with the rest of the cloud transcription services.

## Notes

- Adds a typed `ApiError` variant so non-2xx responses surface the status and body instead of being flattened into `Unexpected`.
- File-size guard (1000 MB) is preserved.
- Diarization, language code, and tag-audio-events behavior unchanged.

Draft for now while I confirm the build artifact runs cleanly on Windows; happy to mark ready or split into a settings-toggle follow-up if maintainers prefer opt-in.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->