### PR TITLE
feat(svelte-utils): redesign fromTable as readonly view

### DIFF
--- a/.agents/skills/svelte/SKILL.md
+++ b/.agents/skills/svelte/SKILL.md
@@ -202,13 +202,16 @@ Reserve `$derived.by()` for multi-statement logic where you genuinely need a fun
 
 See `docs/articles/record-lookup-over-nested-ternaries.md` for rationale.
 
-# When to Use SvelteMap vs $state
+# When to Use fromTable, SvelteMap, and $state
 
-Use `SvelteMap` when items have stable IDs and you need keyed lookup. Use `$state` for primitives, local UI booleans, and sequential data without identity.
+Use `fromTable()` for workspace table rows. It returns a readonly view with
+`all` and `byId(id)`, backed by `createSubscriber`. Use `SvelteMap` for
+non-workspace keyed data that needs local per-key mutation. Use `$state` for
+primitives, local UI booleans, and sequential data without identity.
 
 | Data Shape | Use | Example |
 |---|---|---|
-| Workspace table rows (have IDs) | `fromTable()` → `SvelteMap` | recordings, conversations, notes |
+| Workspace table rows (have IDs) | `fromTable()` readonly view | recordings, conversations, notes |
 | Workspace KV (single key) | `fromKv()` | selectedFolderId, sortBy |
 | Browser API keyed data | `new SvelteMap()` + listeners | Chrome tabs, windows |
 | Primitive value | `$state(value)` | `$state(false)`, `$state('')`, `$state(0)` |
@@ -218,16 +221,16 @@ Use `SvelteMap` when items have stable IDs and you need keyed lookup. Use `$stat
 ### Anti-Pattern: $state for ID-Keyed Collections
 
 ```typescript
-// ❌ BAD: O(n) lookups, coarse reactivity, referential instability
+// BAD: O(n) lookups, coarse reactivity, referential instability
 let conversations = $state<Conversation[]>(readAll());
 const metadata = $derived(conversations.find((c) => c.id === id)); // O(n) scan
 
-// ✅ GOOD: O(1) lookups, per-key reactivity, stable $derived array
-const conversationsMap = fromTable(workspace.tables.conversations);
+// GOOD: table lookup, cached derived array
+const conversationsView = fromTable(workspace.tables.conversations);
 const conversations = $derived(
-	conversationsMap.values().toArray().sort((a, b) => b.updatedAt - a.updatedAt),
+	conversationsView.all.toSorted((a, b) => b.updatedAt - a.updatedAt),
 );
-const metadata = $derived(conversationsMap.get(id)); // O(1) lookup
+const metadata = $derived(conversationsView.byId(id));
 ```
 
 Three problems with `$state<T[]>` for keyed data:
@@ -243,28 +246,29 @@ See `docs/articles/sveltemap-over-state-for-keyed-collections.md` for the full r
 When a factory function exposes workspace table data via `fromTable`, follow this three-layer convention:
 
 ```typescript
-// 1. Map — reactive source (private, suffixed with Map)
-const foldersMap = fromTable(workspaceClient.tables.folders);
+// 1. View: reactive source (private, suffixed with View)
+const foldersView = fromTable(workspaceClient.tables.folders);
 
-// 2. Derived array — cached materialization (private, no suffix)
-const folders = $derived(foldersMap.values().toArray());
+// 2. Derived array: cached materialization (private, no suffix)
+const folders = $derived(foldersView.all);
 
-// 3. Getter — public API (matches the derived name)
+// 3. Getter: public API (matches the derived name)
 return {
 	get folders() {
 		return folders;
 	},
+	byId: foldersView.byId,
 };
 ```
 
-Naming: `{name}Map` (private source) → `{name}` (cached derived) → `get {name}()` (public getter).
+Naming: `{name}View` (private source) → `{name}` (cached derived) → `get {name}()` (public getter).
 
 ### With Sort or Filter
 
-Chain operations inside `$derived` — the entire pipeline is cached:
+Chain operations inside `$derived`; the entire pipeline is cached:
 
 ```typescript
-const tabs = $derived(tabsMap.values().toArray().sort((a, b) => b.savedAt - a.savedAt));
+const tabs = $derived(tabsView.all.toSorted((a, b) => b.savedAt - a.savedAt));
 const notes = $derived(allNotes.filter((n) => n.deletedAt === undefined));
 ```
 
@@ -272,15 +276,15 @@ See the `typescript` skill for iterator helpers (`.toArray()`, `.filter()`, `.fi
 
 ### Template Props
 
-For component props expecting `T[]`, derive in the script block — never materialize in the template:
+For component props expecting `T[]`, derive in the script block. Never materialize in the template:
 
 ```svelte
 <!-- Bad: re-creates array on every render -->
-<FujiSidebar entries={entries.values().toArray()} />
+<FujiSidebar entries={entriesView.all.toSorted(sortEntries)} />
 
 <!-- Good: cached via $derived -->
 <script>
-	const entriesArray = $derived(entries.values().toArray());
+	const entriesArray = $derived(entriesView.all.toSorted(sortEntries));
 </script>
 <FujiSidebar entries={entriesArray} />
 ```
@@ -301,11 +305,12 @@ State modules use a factory function that returns a flat object with getters and
 
 ```typescript
 function createBookmarkState() {
-	const bookmarksMap = fromTable(workspaceClient.tables.bookmarks);
-	const bookmarks = $derived(bookmarksMap.values().toArray());
+	const bookmarksView = fromTable(workspaceClient.tables.bookmarks);
+	const bookmarks = $derived(bookmarksView.all);
 
 	return {
 		get bookmarks() { return bookmarks; },
+		byId: bookmarksView.byId,
 		async add(tab: Tab) { /* ... */ },
 		remove(id: BookmarkId) { /* ... */ },
 	};
@@ -928,7 +933,10 @@ For more complex repeated patterns (e.g., toolbar buttons with tooltips), use `{
 
 ## The Problem: New Array = Infinite Loop with TanStack Table
 
-When feeding data from a reactive SvelteMap (or any signal-based store) into `createSvelteTable`, the `get data()` getter must return a **referentially stable** array. If it creates a new array on every access, TanStack Table's internal `$derived` enters an infinite loop:
+When feeding data from a reactive table view, SvelteMap, or any signal-based
+store into `createSvelteTable`, the `get data()` getter must return a
+**referentially stable** array. If it creates a new array on every access,
+TanStack Table's internal `$derived` enters an infinite loop:
 
 ```
 1. $derived calls get data() → new array (Array.from().sort())
@@ -938,23 +946,26 @@ When feeding data from a reactive SvelteMap (or any signal-based store) into `cr
 5. → infinite loop → page freeze
 ```
 
-TanStack Query hid this problem because its cache returns the **same reference** until a refetch. SvelteMap getters that do `Array.from(map.values()).sort()` create a new array every call.
+TanStack Query hid this problem because its cache returns the **same reference**
+until a refetch. Direct table view getters like `view.all.toSorted(...)` create
+a new array every call.
 
 ## The Fix: Memoize with `$derived`
 
-In `.svelte.ts` modules, use `$derived` to compute the sorted/filtered array once per SvelteMap change:
+In `.svelte.ts` modules, use `$derived` to compute the sorted/filtered array
+once per table view change:
 
 ```typescript
-// ❌ BAD: New array on every access → infinite loop with TanStack Table
+// BAD: New array on every access causes an infinite loop with TanStack Table
 get sorted(): Recording[] {
-    return Array.from(map.values()).sort(
+    return view.all.toSorted(
         (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
     );
 }
 
-// ✅ GOOD: $derived caches the result, stable reference between SvelteMap changes
+// GOOD: $derived caches the result between table view changes
 const sorted = $derived(
-    Array.from(map.values()).sort(
+    view.all.toSorted(
         (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
     ),
 );
@@ -969,10 +980,10 @@ get sorted(): Recording[] {
 
 The infinite loop only happens when the array is consumed by something that **tracks reference identity in a reactive context**:
 
-- `createSvelteTable({ get data() { ... } })` — **DANGEROUS** (infinite loop)
-- `$derived(someStore.sorted)` where the result feeds back into state — **DANGEROUS**
-- `{#each someStore.sorted as item}` in a template — **SAFE** (Svelte's each block diffs by value, renders once per change)
-- `$derived(someStore.get(id))` — **SAFE** (returns existing object reference from SvelteMap.get())
+- `createSvelteTable({ get data() { ... } })`: **DANGEROUS** (infinite loop)
+- `$derived(someStore.sorted)` where the result feeds back into state: **DANGEROUS**
+- `{#each someStore.sorted as item}` in a template: **SAFE** (Svelte's each block diffs by value, renders once per change)
+- `$derived(someStore.byId(id))`: **SAFE** (returns the table row or undefined)
 
 ## Rule of Thumb
 

--- a/apps/api/drizzle/meta/0000_snapshot.json
+++ b/apps/api/drizzle/meta/0000_snapshot.json
@@ -1,1208 +1,1144 @@
 {
-  "id": "d593ffd3-784f-4eb2-b204-e3e9bdd37c59",
-  "prevId": "00000000-0000-0000-0000-000000000000",
-  "version": "7",
-  "dialect": "postgresql",
-  "tables": {
-    "public.account": {
-      "name": "account",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "account_id": {
-          "name": "account_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "provider_id": {
-          "name": "provider_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "access_token": {
-          "name": "access_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "refresh_token": {
-          "name": "refresh_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "id_token": {
-          "name": "id_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "access_token_expires_at": {
-          "name": "access_token_expires_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "refresh_token_expires_at": {
-          "name": "refresh_token_expires_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scope": {
-          "name": "scope",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "password": {
-          "name": "password",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "account_userId_idx": {
-          "name": "account_userId_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "account_user_id_user_id_fk": {
-          "name": "account_user_id_user_id_fk",
-          "tableFrom": "account",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.asset": {
-      "name": "asset",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "content_type": {
-          "name": "content_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "size_bytes": {
-          "name": "size_bytes",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "original_name": {
-          "name": "original_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "uploaded_at": {
-          "name": "uploaded_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "asset_user_id_idx": {
-          "name": "asset_user_id_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "asset_user_id_user_id_fk": {
-          "name": "asset_user_id_user_id_fk",
-          "tableFrom": "asset",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.device_code": {
-      "name": "device_code",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "device_code": {
-          "name": "device_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_code": {
-          "name": "user_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "last_polled_at": {
-          "name": "last_polled_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "polling_interval": {
-          "name": "polling_interval",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "client_id": {
-          "name": "client_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scope": {
-          "name": "scope",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.durable_object_instance": {
-      "name": "durable_object_instance",
-      "schema": "",
-      "columns": {
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "do_type": {
-          "name": "do_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "resource_name": {
-          "name": "resource_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "do_name": {
-          "name": "do_name",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "storage_bytes": {
-          "name": "storage_bytes",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "last_accessed_at": {
-          "name": "last_accessed_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "storage_measured_at": {
-          "name": "storage_measured_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "doi_user_id_idx": {
-          "name": "doi_user_id_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "durable_object_instance_user_id_user_id_fk": {
-          "name": "durable_object_instance_user_id_user_id_fk",
-          "tableFrom": "durable_object_instance",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.jwks": {
-      "name": "jwks",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "public_key": {
-          "name": "public_key",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "private_key": {
-          "name": "private_key",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.oauth_access_token": {
-      "name": "oauth_access_token",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "token": {
-          "name": "token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "client_id": {
-          "name": "client_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "session_id": {
-          "name": "session_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "reference_id": {
-          "name": "reference_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "refresh_id": {
-          "name": "refresh_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scopes": {
-          "name": "scopes",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "oauth_access_token_client_id_oauth_client_client_id_fk": {
-          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
-          "tableFrom": "oauth_access_token",
-          "tableTo": "oauth_client",
-          "columnsFrom": [
-            "client_id"
-          ],
-          "columnsTo": [
-            "client_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "oauth_access_token_session_id_session_id_fk": {
-          "name": "oauth_access_token_session_id_session_id_fk",
-          "tableFrom": "oauth_access_token",
-          "tableTo": "session",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        },
-        "oauth_access_token_user_id_user_id_fk": {
-          "name": "oauth_access_token_user_id_user_id_fk",
-          "tableFrom": "oauth_access_token",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
-          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
-          "tableFrom": "oauth_access_token",
-          "tableTo": "oauth_refresh_token",
-          "columnsFrom": [
-            "refresh_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "oauth_access_token_token_unique": {
-          "name": "oauth_access_token_token_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "token"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.oauth_client": {
-      "name": "oauth_client",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "client_id": {
-          "name": "client_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "client_secret": {
-          "name": "client_secret",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "disabled": {
-          "name": "disabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "skip_consent": {
-          "name": "skip_consent",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "enable_end_session": {
-          "name": "enable_end_session",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scopes": {
-          "name": "scopes",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "uri": {
-          "name": "uri",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "icon": {
-          "name": "icon",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "contacts": {
-          "name": "contacts",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "tos": {
-          "name": "tos",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "policy": {
-          "name": "policy",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "software_id": {
-          "name": "software_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "software_version": {
-          "name": "software_version",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "software_statement": {
-          "name": "software_statement",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "redirect_uris": {
-          "name": "redirect_uris",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "post_logout_redirect_uris": {
-          "name": "post_logout_redirect_uris",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "token_endpoint_auth_method": {
-          "name": "token_endpoint_auth_method",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "grant_types": {
-          "name": "grant_types",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "response_types": {
-          "name": "response_types",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "public": {
-          "name": "public",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "type": {
-          "name": "type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "require_pkce": {
-          "name": "require_pkce",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "reference_id": {
-          "name": "reference_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "oauth_client_user_id_user_id_fk": {
-          "name": "oauth_client_user_id_user_id_fk",
-          "tableFrom": "oauth_client",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "oauth_client_client_id_unique": {
-          "name": "oauth_client_client_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "client_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.oauth_consent": {
-      "name": "oauth_consent",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "client_id": {
-          "name": "client_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "reference_id": {
-          "name": "reference_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scopes": {
-          "name": "scopes",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "oauth_consent_client_id_oauth_client_client_id_fk": {
-          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
-          "tableFrom": "oauth_consent",
-          "tableTo": "oauth_client",
-          "columnsFrom": [
-            "client_id"
-          ],
-          "columnsTo": [
-            "client_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "oauth_consent_user_id_user_id_fk": {
-          "name": "oauth_consent_user_id_user_id_fk",
-          "tableFrom": "oauth_consent",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.oauth_refresh_token": {
-      "name": "oauth_refresh_token",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "token": {
-          "name": "token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "client_id": {
-          "name": "client_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "session_id": {
-          "name": "session_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "reference_id": {
-          "name": "reference_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "revoked": {
-          "name": "revoked",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "auth_time": {
-          "name": "auth_time",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scopes": {
-          "name": "scopes",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
-          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
-          "tableFrom": "oauth_refresh_token",
-          "tableTo": "oauth_client",
-          "columnsFrom": [
-            "client_id"
-          ],
-          "columnsTo": [
-            "client_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "oauth_refresh_token_session_id_session_id_fk": {
-          "name": "oauth_refresh_token_session_id_session_id_fk",
-          "tableFrom": "oauth_refresh_token",
-          "tableTo": "session",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        },
-        "oauth_refresh_token_user_id_user_id_fk": {
-          "name": "oauth_refresh_token_user_id_user_id_fk",
-          "tableFrom": "oauth_refresh_token",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.session": {
-      "name": "session",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "token": {
-          "name": "token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "ip_address": {
-          "name": "ip_address",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_agent": {
-          "name": "user_agent",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "session_userId_idx": {
-          "name": "session_userId_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "session_user_id_user_id_fk": {
-          "name": "session_user_id_user_id_fk",
-          "tableFrom": "session",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "session_token_unique": {
-          "name": "session_token_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "token"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.user": {
-      "name": "user",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "email": {
-          "name": "email",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "email_verified": {
-          "name": "email_verified",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "image": {
-          "name": "image",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "user_email_unique": {
-          "name": "user_email_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "email"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.verification": {
-      "name": "verification",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "identifier": {
-          "name": "identifier",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "value": {
-          "name": "value",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "verification_identifier_idx": {
-          "name": "verification_identifier_idx",
-          "columns": [
-            {
-              "expression": "identifier",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    }
-  },
-  "enums": {},
-  "schemas": {},
-  "sequences": {},
-  "roles": {},
-  "policies": {},
-  "views": {},
-  "_meta": {
-    "columns": {},
-    "schemas": {},
-    "tables": {}
-  }
+	"id": "d593ffd3-784f-4eb2-b204-e3e9bdd37c59",
+	"prevId": "00000000-0000-0000-0000-000000000000",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.account": {
+			"name": "account",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"account_userId_idx": {
+					"name": "account_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.asset": {
+			"name": "asset",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"content_type": {
+					"name": "content_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"size_bytes": {
+					"name": "size_bytes",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"original_name": {
+					"name": "original_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"uploaded_at": {
+					"name": "uploaded_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"asset_user_id_idx": {
+					"name": "asset_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"asset_user_id_user_id_fk": {
+					"name": "asset_user_id_user_id_fk",
+					"tableFrom": "asset",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.device_code": {
+			"name": "device_code",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"device_code": {
+					"name": "device_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_code": {
+					"name": "user_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_polled_at": {
+					"name": "last_polled_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"polling_interval": {
+					"name": "polling_interval",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.durable_object_instance": {
+			"name": "durable_object_instance",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"do_type": {
+					"name": "do_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"resource_name": {
+					"name": "resource_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"do_name": {
+					"name": "do_name",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"storage_bytes": {
+					"name": "storage_bytes",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"last_accessed_at": {
+					"name": "last_accessed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"storage_measured_at": {
+					"name": "storage_measured_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"doi_user_id_idx": {
+					"name": "doi_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"durable_object_instance_user_id_user_id_fk": {
+					"name": "durable_object_instance_user_id_user_id_fk",
+					"tableFrom": "durable_object_instance",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.jwks": {
+			"name": "jwks",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"public_key": {
+					"name": "public_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"private_key": {
+					"name": "private_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.oauth_access_token": {
+			"name": "oauth_access_token",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_id": {
+					"name": "refresh_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_access_token_client_id_oauth_client_client_id_fk": {
+					"name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+					"tableFrom": "oauth_access_token",
+					"tableTo": "oauth_client",
+					"columnsFrom": ["client_id"],
+					"columnsTo": ["client_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"oauth_access_token_session_id_session_id_fk": {
+					"name": "oauth_access_token_session_id_session_id_fk",
+					"tableFrom": "oauth_access_token",
+					"tableTo": "session",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"oauth_access_token_user_id_user_id_fk": {
+					"name": "oauth_access_token_user_id_user_id_fk",
+					"tableFrom": "oauth_access_token",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+					"name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+					"tableFrom": "oauth_access_token",
+					"tableTo": "oauth_refresh_token",
+					"columnsFrom": ["refresh_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"oauth_access_token_token_unique": {
+					"name": "oauth_access_token_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.oauth_client": {
+			"name": "oauth_client",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_secret": {
+					"name": "client_secret",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"disabled": {
+					"name": "disabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"skip_consent": {
+					"name": "skip_consent",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"enable_end_session": {
+					"name": "enable_end_session",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"uri": {
+					"name": "uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"icon": {
+					"name": "icon",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"contacts": {
+					"name": "contacts",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tos": {
+					"name": "tos",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"policy": {
+					"name": "policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"software_id": {
+					"name": "software_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"software_version": {
+					"name": "software_version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"software_statement": {
+					"name": "software_statement",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"redirect_uris": {
+					"name": "redirect_uris",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"post_logout_redirect_uris": {
+					"name": "post_logout_redirect_uris",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"token_endpoint_auth_method": {
+					"name": "token_endpoint_auth_method",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"grant_types": {
+					"name": "grant_types",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"response_types": {
+					"name": "response_types",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"public": {
+					"name": "public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"require_pkce": {
+					"name": "require_pkce",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_client_user_id_user_id_fk": {
+					"name": "oauth_client_user_id_user_id_fk",
+					"tableFrom": "oauth_client",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"oauth_client_client_id_unique": {
+					"name": "oauth_client_client_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["client_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.oauth_consent": {
+			"name": "oauth_consent",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_consent_client_id_oauth_client_client_id_fk": {
+					"name": "oauth_consent_client_id_oauth_client_client_id_fk",
+					"tableFrom": "oauth_consent",
+					"tableTo": "oauth_client",
+					"columnsFrom": ["client_id"],
+					"columnsTo": ["client_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"oauth_consent_user_id_user_id_fk": {
+					"name": "oauth_consent_user_id_user_id_fk",
+					"tableFrom": "oauth_consent",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.oauth_refresh_token": {
+			"name": "oauth_refresh_token",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked": {
+					"name": "revoked",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"auth_time": {
+					"name": "auth_time",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+					"name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+					"tableFrom": "oauth_refresh_token",
+					"tableTo": "oauth_client",
+					"columnsFrom": ["client_id"],
+					"columnsTo": ["client_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"oauth_refresh_token_session_id_session_id_fk": {
+					"name": "oauth_refresh_token_session_id_session_id_fk",
+					"tableFrom": "oauth_refresh_token",
+					"tableTo": "session",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"oauth_refresh_token_user_id_user_id_fk": {
+					"name": "oauth_refresh_token_user_id_user_id_fk",
+					"tableFrom": "oauth_refresh_token",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session": {
+			"name": "session",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"session_userId_idx": {
+					"name": "session_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user": {
+			"name": "user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.verification": {
+			"name": "verification",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"verification_identifier_idx": {
+					"name": "verification_identifier_idx",
+					"columns": [
+						{
+							"expression": "identifier",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
 }

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -1,13 +1,13 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1776083464858,
-      "tag": "0000_equal_thor_girl",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1776083464858,
+			"tag": "0000_equal_thor_girl",
+			"breakpoints": true
+		}
+	]
 }

--- a/apps/api/src/asset-routes.ts
+++ b/apps/api/src/asset-routes.ts
@@ -17,6 +17,7 @@ import { customAlphabet } from 'nanoid';
  * Cloudflare Worker bundle, where wrangler can't resolve it.
  */
 const generateGuid = customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789', 15);
+
 import { and, desc, eq, sql } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';

--- a/apps/api/src/asset-routes.ts
+++ b/apps/api/src/asset-routes.ts
@@ -9,25 +9,24 @@
  * through this Worker, which sets security headers and supports ETag/range.
  */
 
-import { customAlphabet } from 'nanoid';
-
-/**
- * 15-char alphanumeric ID generator—same spec as `generateGuid` in @epicenter/workspace.
- * Inlined here to avoid pulling workspace (and its Yjs dependency tree) into the
- * Cloudflare Worker bundle, where wrangler can't resolve it.
- */
-const generateGuid = customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789', 15);
-
 import { and, desc, eq, sql } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { describeRoute } from 'hono-openapi';
+import { customAlphabet } from 'nanoid';
 import { defineErrors } from 'wellcrafted/error';
 import type { Env } from './app.js';
 import { createAutumn } from './autumn.js';
 import { FEATURE_IDS } from './billing-plans.js';
 import { MAX_ASSET_BYTES } from './constants.js';
 import * as schema from './db/schema.js';
+
+/**
+ * 15-char alphanumeric ID generator, same spec as `generateGuid` in @epicenter/workspace.
+ * Inlined here to avoid pulling workspace (and its Yjs dependency tree) into the
+ * Cloudflare Worker bundle, where wrangler can't resolve it.
+ */
+const generateGuid = customAlphabet('abcdefghijklmnopqrstuvwxyz0123456789', 15);
 
 const ALLOWED_MIME_TYPES = new Set([
 	'image/png',

--- a/apps/api/src/base-sync-room.ts
+++ b/apps/api/src/base-sync-room.ts
@@ -14,8 +14,8 @@
 
 import { DurableObject } from 'cloudflare:workers';
 import {
-	MAIN_SUBPROTOCOL,
 	decodeSyncRequest,
+	MAIN_SUBPROTOCOL,
 	parseSubprotocols,
 	stateVectorsEqual,
 } from '@epicenter/sync';

--- a/apps/breddit/src/lib/workspace/ingest/reddit/parse.ts
+++ b/apps/breddit/src/lib/workspace/ingest/reddit/parse.ts
@@ -75,7 +75,9 @@ function findMatchingEntries(
 	const stem = csvFile.replace('.csv', '');
 	return Object.entries(files)
 		.filter(([name]) => {
-			const basename = name.includes('/') ? (name.split('/').pop() ?? name) : name;
+			const basename = name.includes('/')
+				? (name.split('/').pop() ?? name)
+				: name;
 			return (
 				basename === csvFile ||
 				(basename.startsWith(`${stem}_`) && basename.endsWith('.csv'))

--- a/apps/breddit/src/lib/workspace/ingest/reddit/workspace.ts
+++ b/apps/breddit/src/lib/workspace/ingest/reddit/workspace.ts
@@ -6,325 +6,326 @@
  * Uses arktype schemas for type validation and inference.
  */
 
-import { type } from 'arktype';
 import {
 	attachKv,
 	attachTables,
+	defineKv,
+	defineTable,
 } from '@epicenter/workspace';
-import { defineKv, defineTable } from '@epicenter/workspace';
+import { type } from 'arktype';
 import * as Y from 'yjs';
 
 const redditTables = {
-		/** posts.csv */
-		posts: defineTable(
-			type({
-				id: 'string',
-				permalink: 'string | null',
-				date: 'string | null',
-				subreddit: 'string',
-				gildings: 'number',
-				'title?': 'string',
-				'url?': 'string',
-				'body?': 'string',
-				_v: '1',
-			}),
-		),
+	/** posts.csv */
+	posts: defineTable(
+		type({
+			id: 'string',
+			permalink: 'string | null',
+			date: 'string | null',
+			subreddit: 'string',
+			gildings: 'number',
+			'title?': 'string',
+			'url?': 'string',
+			'body?': 'string',
+			_v: '1',
+		}),
+	),
 
-		/** comments.csv */
-		comments: defineTable(
-			type({
-				id: 'string', // Composite: `${targetType}:${targetId}`
-				permalink: 'string | null',
-				date: 'string | null',
-				subreddit: 'string',
-				gildings: 'number',
-				link: 'string',
-				'parent?': 'string',
-				'body?': 'string',
-				'media?': 'string',
-				_v: '1',
-			}),
-		),
+	/** comments.csv */
+	comments: defineTable(
+		type({
+			id: 'string', // Composite: `${targetType}:${targetId}`
+			permalink: 'string | null',
+			date: 'string | null',
+			subreddit: 'string',
+			gildings: 'number',
+			link: 'string',
+			'parent?': 'string',
+			'body?': 'string',
+			'media?': 'string',
+			_v: '1',
+		}),
+	),
 
-		/** drafts.csv */
-		drafts: defineTable(
-			type({
-				id: 'string',
-				'title?': 'string',
-				'body?': 'string',
-				'kind?': 'string',
-				created: 'string | null',
-				'spoiler?': 'string',
-				'nsfw?': 'string',
-				'original_content?': 'string',
-				'content_category?': 'string',
-				'flair_id?': 'string',
-				'flair_text?': 'string',
-				'send_replies?': 'string',
-				'subreddit?': 'string',
-				'is_public_link?': 'string',
-				_v: '1',
-			}),
-		),
+	/** drafts.csv */
+	drafts: defineTable(
+		type({
+			id: 'string',
+			'title?': 'string',
+			'body?': 'string',
+			'kind?': 'string',
+			created: 'string | null',
+			'spoiler?': 'string',
+			'nsfw?': 'string',
+			'original_content?': 'string',
+			'content_category?': 'string',
+			'flair_id?': 'string',
+			'flair_text?': 'string',
+			'send_replies?': 'string',
+			'subreddit?': 'string',
+			'is_public_link?': 'string',
+			_v: '1',
+		}),
+	),
 
-		/** post_votes.csv */
-		postVotes: defineTable(
-			type({
-				id: 'string',
-				permalink: 'string',
-				direction: "'up' | 'down' | 'none' | 'removed'",
-				_v: '1',
-			}),
-		),
+	/** post_votes.csv */
+	postVotes: defineTable(
+		type({
+			id: 'string',
+			permalink: 'string',
+			direction: "'up' | 'down' | 'none' | 'removed'",
+			_v: '1',
+		}),
+	),
 
-		/** comment_votes.csv */
-		commentVotes: defineTable(
-			type({
-				id: 'string',
-				permalink: 'string',
-				direction: "'up' | 'down' | 'none' | 'removed'",
-				_v: '1',
-			}),
-		),
+	/** comment_votes.csv */
+	commentVotes: defineTable(
+		type({
+			id: 'string',
+			permalink: 'string',
+			direction: "'up' | 'down' | 'none' | 'removed'",
+			_v: '1',
+		}),
+	),
 
-		/** poll_votes.csv */
-		pollVotes: defineTable(
-			type({
-				id: 'string', // Composite: `${post_id}|${user_selection ?? ''}|${text ?? ''}`
-				post_id: 'string',
-				'user_selection?': 'string',
-				'text?': 'string',
-				'image_url?': 'string',
-				'is_prediction?': 'string',
-				'stake_amount?': 'string',
-				_v: '1',
-			}),
-		),
+	/** poll_votes.csv */
+	pollVotes: defineTable(
+		type({
+			id: 'string', // Composite: `${post_id}|${user_selection ?? ''}|${text ?? ''}`
+			post_id: 'string',
+			'user_selection?': 'string',
+			'text?': 'string',
+			'image_url?': 'string',
+			'is_prediction?': 'string',
+			'stake_amount?': 'string',
+			_v: '1',
+		}),
+	),
 
-		/** saved_posts.csv */
-		savedPosts: defineTable(
-			type({
-				id: 'string',
-				permalink: 'string',
-				_v: '1',
-			}),
-		),
+	/** saved_posts.csv */
+	savedPosts: defineTable(
+		type({
+			id: 'string',
+			permalink: 'string',
+			_v: '1',
+		}),
+	),
 
-		/** saved_comments.csv */
-		savedComments: defineTable(
-			type({
-				id: 'string',
-				permalink: 'string',
-				_v: '1',
-			}),
-		),
+	/** saved_comments.csv */
+	savedComments: defineTable(
+		type({
+			id: 'string',
+			permalink: 'string',
+			_v: '1',
+		}),
+	),
 
-		/** hidden_posts.csv */
-		hiddenPosts: defineTable(
-			type({
-				id: 'string',
-				permalink: 'string',
-				_v: '1',
-			}),
-		),
+	/** hidden_posts.csv */
+	hiddenPosts: defineTable(
+		type({
+			id: 'string',
+			permalink: 'string',
+			_v: '1',
+		}),
+	),
 
-		/** messages.csv (optional) */
-		messages: defineTable(
-			type({
-				id: 'string',
-				permalink: 'string',
-				thread_id: 'string | null',
-				date: 'string | null',
-				'from?': 'string',
-				'to?': 'string',
-				'subject?': 'string',
-				'body?': 'string',
-				_v: '1',
-			}),
-		),
+	/** messages.csv (optional) */
+	messages: defineTable(
+		type({
+			id: 'string',
+			permalink: 'string',
+			thread_id: 'string | null',
+			date: 'string | null',
+			'from?': 'string',
+			'to?': 'string',
+			'subject?': 'string',
+			'body?': 'string',
+			_v: '1',
+		}),
+	),
 
-		/** messages_archive.csv */
-		messagesArchive: defineTable(
-			type({
-				id: 'string',
-				permalink: 'string',
-				thread_id: 'string | null',
-				date: 'string | null',
-				'from?': 'string',
-				'to?': 'string',
-				'subject?': 'string',
-				'body?': 'string',
-				_v: '1',
-			}),
-		),
+	/** messages_archive.csv */
+	messagesArchive: defineTable(
+		type({
+			id: 'string',
+			permalink: 'string',
+			thread_id: 'string | null',
+			date: 'string | null',
+			'from?': 'string',
+			'to?': 'string',
+			'subject?': 'string',
+			'body?': 'string',
+			_v: '1',
+		}),
+	),
 
-		/** chat_history.csv */
-		chatHistory: defineTable(
-			type({
-				id: 'string', // message_id from CSV
-				created_at: 'string | null',
-				updated_at: 'string | null',
-				username: 'string | null',
-				message: 'string | null',
-				thread_parent_message_id: 'string | null',
-				channel_url: 'string | null',
-				subreddit: 'string | null',
-				channel_name: 'string | null',
-				conversation_type: 'string | null',
-				_v: '1',
-			}),
-		),
+	/** chat_history.csv */
+	chatHistory: defineTable(
+		type({
+			id: 'string', // message_id from CSV
+			created_at: 'string | null',
+			updated_at: 'string | null',
+			username: 'string | null',
+			message: 'string | null',
+			thread_parent_message_id: 'string | null',
+			channel_url: 'string | null',
+			subreddit: 'string | null',
+			channel_name: 'string | null',
+			conversation_type: 'string | null',
+			_v: '1',
+		}),
+	),
 
-		/** subscribed_subreddits.csv */
-		subscribedSubreddits: defineTable(
-			type({
-				id: 'string', // subreddit
-				subreddit: 'string',
-				_v: '1',
-			}),
-		),
+	/** subscribed_subreddits.csv */
+	subscribedSubreddits: defineTable(
+		type({
+			id: 'string', // subreddit
+			subreddit: 'string',
+			_v: '1',
+		}),
+	),
 
-		/** moderated_subreddits.csv */
-		moderatedSubreddits: defineTable(
-			type({
-				id: 'string', // subreddit
-				subreddit: 'string',
-				_v: '1',
-			}),
-		),
+	/** moderated_subreddits.csv */
+	moderatedSubreddits: defineTable(
+		type({
+			id: 'string', // subreddit
+			subreddit: 'string',
+			_v: '1',
+		}),
+	),
 
-		/** approved_submitter_subreddits.csv */
-		approvedSubmitterSubreddits: defineTable(
-			type({
-				id: 'string', // subreddit
-				subreddit: 'string',
-				_v: '1',
-			}),
-		),
+	/** approved_submitter_subreddits.csv */
+	approvedSubmitterSubreddits: defineTable(
+		type({
+			id: 'string', // subreddit
+			subreddit: 'string',
+			_v: '1',
+		}),
+	),
 
-		/** multireddits.csv */
-		multireddits: defineTable(
-			type({
-				id: 'string',
-				'display_name?': 'string',
-				date: 'string | null',
-				'description?': 'string',
-				'privacy?': 'string',
-				'subreddits?': 'string', // Comma-separated list
-				'image_url?': 'string',
-				'is_owner?': 'string',
-				'favorited?': 'string',
-				'followers?': 'string',
-				_v: '1',
-			}),
-		),
+	/** multireddits.csv */
+	multireddits: defineTable(
+		type({
+			id: 'string',
+			'display_name?': 'string',
+			date: 'string | null',
+			'description?': 'string',
+			'privacy?': 'string',
+			'subreddits?': 'string', // Comma-separated list
+			'image_url?': 'string',
+			'is_owner?': 'string',
+			'favorited?': 'string',
+			'followers?': 'string',
+			_v: '1',
+		}),
+	),
 
-		/** gilded_content.csv */
-		gildedContent: defineTable(
-			type({
-				id: 'string', // Composite: `${content_link}|${date ?? ''}|${award ?? ''}|${amount ?? ''}`
-				content_link: 'string',
-				'award?': 'string',
-				'amount?': 'string',
-				date: 'string | null',
-				_v: '1',
-			}),
-		),
+	/** gilded_content.csv */
+	gildedContent: defineTable(
+		type({
+			id: 'string', // Composite: `${content_link}|${date ?? ''}|${award ?? ''}|${amount ?? ''}`
+			content_link: 'string',
+			'award?': 'string',
+			'amount?': 'string',
+			date: 'string | null',
+			_v: '1',
+		}),
+	),
 
-		/** gold_received.csv */
-		goldReceived: defineTable(
-			type({
-				id: 'string', // Composite: `${content_link}|${date ?? ''}|${gold_received ?? ''}|${gilder_username ?? ''}`
-				content_link: 'string',
-				'gold_received?': 'string',
-				'gilder_username?': 'string',
-				date: 'string | null',
-				_v: '1',
-			}),
-		),
+	/** gold_received.csv */
+	goldReceived: defineTable(
+		type({
+			id: 'string', // Composite: `${content_link}|${date ?? ''}|${gold_received ?? ''}|${gilder_username ?? ''}`
+			content_link: 'string',
+			'gold_received?': 'string',
+			'gilder_username?': 'string',
+			date: 'string | null',
+			_v: '1',
+		}),
+	),
 
-		/** purchases.csv */
-		purchases: defineTable(
-			type({
-				id: 'string', // transaction_id
-				'processor?': 'string',
-				transaction_id: 'string',
-				'product?': 'string',
-				date: 'string | null',
-				'cost?': 'string',
-				'currency?': 'string',
-				'status?': 'string',
-				_v: '1',
-			}),
-		),
+	/** purchases.csv */
+	purchases: defineTable(
+		type({
+			id: 'string', // transaction_id
+			'processor?': 'string',
+			transaction_id: 'string',
+			'product?': 'string',
+			date: 'string | null',
+			'cost?': 'string',
+			'currency?': 'string',
+			'status?': 'string',
+			_v: '1',
+		}),
+	),
 
-		/** subscriptions.csv */
-		subscriptions: defineTable(
-			type({
-				id: 'string', // subscription_id
-				'processor?': 'string',
-				subscription_id: 'string',
-				'product?': 'string',
-				'product_id?': 'string',
-				'product_name?': 'string',
-				'status?': 'string',
-				start_date: 'string | null',
-				end_date: 'string | null',
-				_v: '1',
-			}),
-		),
+	/** subscriptions.csv */
+	subscriptions: defineTable(
+		type({
+			id: 'string', // subscription_id
+			'processor?': 'string',
+			subscription_id: 'string',
+			'product?': 'string',
+			'product_id?': 'string',
+			'product_name?': 'string',
+			'status?': 'string',
+			start_date: 'string | null',
+			end_date: 'string | null',
+			_v: '1',
+		}),
+	),
 
-		/** payouts.csv */
-		payouts: defineTable(
-			type({
-				id: 'string', // payout_id ?? date
-				'payout_amount_usd?': 'string',
-				date: 'string | null',
-				'payout_id?': 'string',
-				_v: '1',
-			}),
-		),
+	/** payouts.csv */
+	payouts: defineTable(
+		type({
+			id: 'string', // payout_id ?? date
+			'payout_amount_usd?': 'string',
+			date: 'string | null',
+			'payout_id?': 'string',
+			_v: '1',
+		}),
+	),
 
-		/** friends.csv */
-		friends: defineTable(
-			type({
-				id: 'string', // username
-				username: 'string',
-				'note?': 'string',
-				_v: '1',
-			}),
-		),
+	/** friends.csv */
+	friends: defineTable(
+		type({
+			id: 'string', // username
+			username: 'string',
+			'note?': 'string',
+			_v: '1',
+		}),
+	),
 
-		/** announcements.csv */
-		announcements: defineTable(
-			type({
-				id: 'string', // announcement_id from CSV
-				announcement_id: 'string',
-				sent_at: 'string | null',
-				read_at: 'string | null',
-				from_id: 'string | null',
-				from_username: 'string | null',
-				subject: 'string | null',
-				body: 'string | null',
-				url: 'string | null',
-				_v: '1',
-			}),
-		),
+	/** announcements.csv */
+	announcements: defineTable(
+		type({
+			id: 'string', // announcement_id from CSV
+			announcement_id: 'string',
+			sent_at: 'string | null',
+			read_at: 'string | null',
+			from_id: 'string | null',
+			from_username: 'string | null',
+			subject: 'string | null',
+			body: 'string | null',
+			url: 'string | null',
+			_v: '1',
+		}),
+	),
 
-		/** scheduled_posts.csv */
-		scheduledPosts: defineTable(
-			type({
-				id: 'string', // scheduled_post_id from CSV
-				scheduled_post_id: 'string',
-				'subreddit?': 'string',
-				'title?': 'string',
-				'body?': 'string',
-				'url?': 'string',
-				submission_time: 'string | null',
-				'recurrence?': 'string',
-				_v: '1',
-			}),
-		),
+	/** scheduled_posts.csv */
+	scheduledPosts: defineTable(
+		type({
+			id: 'string', // scheduled_post_id from CSV
+			scheduled_post_id: 'string',
+			'subreddit?': 'string',
+			'title?': 'string',
+			'body?': 'string',
+			'url?': 'string',
+			submission_time: 'string | null',
+			'recurrence?': 'string',
+			_v: '1',
+		}),
+	),
 };
 
 const redditKv = {

--- a/apps/dashboard/src/lib/components/TopModels.svelte
+++ b/apps/dashboard/src/lib/components/TopModels.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+	import { FEATURE_IDS } from '@epicenter/api/billing-plans';
 	import * as Card from '@epicenter/ui/card';
 	import * as Empty from '@epicenter/ui/empty';
 	import { Skeleton } from '@epicenter/ui/skeleton';
 	import * as Table from '@epicenter/ui/table';
 	import { createQuery } from '@tanstack/svelte-query';
-	import { FEATURE_IDS } from '@epicenter/api/billing-plans';
 	import { usageQueryOptions } from '$lib/query/billing';
 
 	const usage = createQuery(() =>

--- a/apps/dashboard/src/routes/+page.svelte
+++ b/apps/dashboard/src/routes/+page.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import * as Alert from '@epicenter/ui/alert';
 	import { Button } from '@epicenter/ui/button';
+	import { toastOnError } from '@epicenter/ui/sonner';
 	import { Spinner } from '@epicenter/ui/spinner';
 	import * as Tabs from '@epicenter/ui/tabs';
 	import { createMutation, createQuery } from '@tanstack/svelte-query';
 	import { toast } from 'svelte-sonner';
 	import { extractErrorMessage } from 'wellcrafted/error';
-	import { toastOnError } from '@epicenter/ui/sonner';
 	import { api } from '$lib/api';
 	import ActivityFeed from '$lib/components/ActivityFeed.svelte';
 	import CreditBalance from '$lib/components/CreditBalance.svelte';

--- a/apps/fuji/src/lib/components/ProseMirrorEditor.svelte
+++ b/apps/fuji/src/lib/components/ProseMirrorEditor.svelte
@@ -1,26 +1,26 @@
 <script lang="ts">
 	import { baseKeymap, toggleMark } from 'prosemirror-commands';
 	import {
-		inputRules,
-		wrappingInputRule,
-		textblockTypeInputRule,
-		smartQuotes,
-		emDash,
 		ellipsis,
+		emDash,
+		inputRules,
+		smartQuotes,
+		textblockTypeInputRule,
+		wrappingInputRule,
 	} from 'prosemirror-inputrules';
 	import { keymap } from 'prosemirror-keymap';
-	import { Schema, type MarkSpec } from 'prosemirror-model';
+	import { type MarkSpec, Schema } from 'prosemirror-model';
+	import { schema as basicSchema } from 'prosemirror-schema-basic';
 	import {
 		addListNodes,
-		splitListItem,
 		liftListItem,
 		sinkListItem,
+		splitListItem,
 	} from 'prosemirror-schema-list';
-	import { schema as basicSchema } from 'prosemirror-schema-basic';
 	import { EditorState, Plugin } from 'prosemirror-state';
 	import { Decoration, DecorationSet, EditorView } from 'prosemirror-view';
 	import 'prosemirror-view/style/prosemirror.css';
-	import { ySyncPlugin, yUndoPlugin, undo, redo } from 'y-prosemirror';
+	import { redo, undo, ySyncPlugin, yUndoPlugin } from 'y-prosemirror';
 	import type * as Y from 'yjs';
 
 	let {

--- a/apps/fuji/src/lib/session.svelte.ts
+++ b/apps/fuji/src/lib/session.svelte.ts
@@ -23,18 +23,18 @@ export const session = createSession({
 			bearerToken: () => auth.bearerToken,
 			encryptionKeys: () => requireSignedIn(auth).encryptionKeys,
 		});
-		const entriesMap = fromTable(fuji.tables.entries);
+		const entriesView = fromTable(fuji.tables.entries);
 		const active = $derived(
-			[...entriesMap.values()].filter((e) => e.deletedAt === undefined),
+			entriesView.all.filter((e) => e.deletedAt === undefined),
 		);
 		const deleted = $derived(
-			[...entriesMap.values()].filter((e) => e.deletedAt !== undefined),
+			entriesView.all.filter((e) => e.deletedAt !== undefined),
 		);
 		return {
 			userId,
 			fuji,
 			entries: {
-				get: (id: EntryId) => entriesMap.get(id),
+				byId: (id: EntryId) => entriesView.byId(id),
 				get active() {
 					return active;
 				},
@@ -43,7 +43,6 @@ export const session = createSession({
 				},
 			},
 			[Symbol.dispose]() {
-				entriesMap[Symbol.dispose]();
 				fuji[Symbol.dispose]();
 			},
 		};

--- a/apps/fuji/src/routes/(signed-in)/components/EntriesSidebar.svelte
+++ b/apps/fuji/src/routes/(signed-in)/components/EntriesSidebar.svelte
@@ -9,8 +9,8 @@
 	import { VList } from 'virtua/svelte';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
-	import { getSignedInSession } from '$lib/session.svelte';
 	import { matchesEntrySearch } from '$lib/entries-search';
+	import { getSignedInSession } from '$lib/session.svelte';
 	import { viewState } from '../state/view.svelte';
 
 	const signedIn = getSignedInSession();

--- a/apps/fuji/src/routes/(signed-in)/components/EntriesTable.svelte
+++ b/apps/fuji/src/routes/(signed-in)/components/EntriesTable.svelte
@@ -19,12 +19,12 @@
 		getSortedRowModel,
 	} from '@tanstack/table-core';
 	import { goto } from '$app/navigation';
-	import { getSignedInSession } from '$lib/session.svelte';
+	import BadgeList from '$lib/components/BadgeList.svelte';
 	import { matchesEntrySearch } from '$lib/entries-search';
 	import { relativeTime } from '$lib/format';
-	import { viewState } from '../state/view.svelte';
+	import { getSignedInSession } from '$lib/session.svelte';
 	import type { Entry } from '../fuji/workspace';
-	import BadgeList from '$lib/components/BadgeList.svelte';
+	import { viewState } from '../state/view.svelte';
 
 	let { entries, title }: { entries: Entry[]; title?: string } = $props();
 	const signedIn = getSignedInSession();
@@ -262,11 +262,7 @@
 										>Create your first entry to get started.</Empty.Description
 									>
 									<Empty.Content>
-										<Button
-											variant="outline"
-											size="sm"
-											onclick={createEntry}
-										>
+										<Button variant="outline" size="sm" onclick={createEntry}>
 											<PlusIcon class="mr-1.5 size-4" />
 											New Entry
 										</Button>

--- a/apps/fuji/src/routes/(signed-in)/components/EntriesTimeline.svelte
+++ b/apps/fuji/src/routes/(signed-in)/components/EntriesTimeline.svelte
@@ -15,10 +15,10 @@
 	import { format, isToday, isYesterday } from 'date-fns';
 	import { VList } from 'virtua/svelte';
 	import { goto } from '$app/navigation';
-	import { getSignedInSession } from '$lib/session.svelte';
 	import { matchesEntrySearch } from '$lib/entries-search';
-	import { viewState } from '../state/view.svelte';
+	import { getSignedInSession } from '$lib/session.svelte';
 	import type { Entry } from '../fuji/workspace';
+	import { viewState } from '../state/view.svelte';
 
 	let { entries, title }: { entries: Entry[]; title?: string } = $props();
 	const signedIn = getSignedInSession();
@@ -165,11 +165,7 @@
 						>Create your first entry to get started.</Empty.Description
 					>
 					<Empty.Content>
-						<Button
-							variant="outline"
-							size="sm"
-							onclick={createEntry}
-						>
+						<Button variant="outline" size="sm" onclick={createEntry}>
 							<PlusIcon class="mr-1.5 size-4" />
 							New Entry
 						</Button>

--- a/apps/fuji/src/routes/(signed-in)/components/EntryEditor.svelte
+++ b/apps/fuji/src/routes/(signed-in)/components/EntryEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { fromDisposableCache } from '@epicenter/svelte';
+	import { useCacheHandle } from '@epicenter/svelte';
 	import { Button } from '@epicenter/ui/button';
 	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import { Loading } from '@epicenter/ui/loading';
@@ -17,10 +17,10 @@
 	import Trash2Icon from '@lucide/svelte/icons/trash-2';
 	import { format } from 'date-fns';
 	import { goto } from '$app/navigation';
-	import { getSignedInSession } from '$lib/session.svelte';
-	import type { Entry } from '../fuji/workspace';
 	import ProseMirrorEditor from '$lib/components/ProseMirrorEditor.svelte';
 	import TagInput from '$lib/components/TagInput.svelte';
+	import { getSignedInSession } from '$lib/session.svelte';
+	import type { Entry } from '../fuji/workspace';
 
 	let { entry }: { entry: Entry } = $props();
 	const signedIn = getSignedInSession();
@@ -37,7 +37,7 @@
 		);
 	}
 
-	const contentDoc = fromDisposableCache(
+	const contentDoc = useCacheHandle(
 		signedIn.fuji.entryContentDocs,
 		() => entry.id,
 	);

--- a/apps/fuji/src/routes/(signed-in)/entries/[id]/+page.svelte
+++ b/apps/fuji/src/routes/(signed-in)/entries/[id]/+page.svelte
@@ -8,7 +8,9 @@
 
 	const signedIn = getSignedInSession();
 	const entryId = $derived(page.params.id as EntryId);
-	const entry = $derived(entryId ? (signedIn.entries.get(entryId) ?? null) : null);
+	const entry = $derived(
+		entryId ? (signedIn.entries.byId(entryId) ?? null) : null,
+	);
 </script>
 
 <main class="flex h-full flex-1 flex-col overflow-hidden">

--- a/apps/fuji/src/routes/(signed-in)/fuji/daemon.ts
+++ b/apps/fuji/src/routes/(signed-in)/fuji/daemon.ts
@@ -1,7 +1,4 @@
-import {
-	createMachineAuthClient,
-	requireSignedIn,
-} from '@epicenter/auth/node';
+import { createMachineAuthClient, requireSignedIn } from '@epicenter/auth/node';
 import { EPICENTER_API_URL } from '@epicenter/constants/apps';
 import {
 	attachAwareness,

--- a/apps/fuji/src/routes/(signed-in)/tag/[tag]/+page.svelte
+++ b/apps/fuji/src/routes/(signed-in)/tag/[tag]/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { getSignedInSession } from '$lib/session.svelte';
 	import EntriesTable from '../../components/EntriesTable.svelte';
 	import EntriesTimeline from '../../components/EntriesTimeline.svelte';
-	import { getSignedInSession } from '$lib/session.svelte';
 	import { viewState } from '../../state/view.svelte';
 
 	const signedIn = getSignedInSession();

--- a/apps/fuji/src/routes/(signed-in)/trash/+page.svelte
+++ b/apps/fuji/src/routes/(signed-in)/trash/+page.svelte
@@ -8,8 +8,8 @@
 	import Trash2Icon from '@lucide/svelte/icons/trash-2';
 	import XIcon from '@lucide/svelte/icons/x';
 	import { goto } from '$app/navigation';
-	import { getSignedInSession } from '$lib/session.svelte';
 	import { relativeTime } from '$lib/format';
+	import { getSignedInSession } from '$lib/session.svelte';
 
 	const signedIn = getSignedInSession();
 

--- a/apps/fuji/src/routes/(signed-in)/type/[type]/+page.svelte
+++ b/apps/fuji/src/routes/(signed-in)/type/[type]/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { getSignedInSession } from '$lib/session.svelte';
 	import EntriesTable from '../../components/EntriesTable.svelte';
 	import EntriesTimeline from '../../components/EntriesTimeline.svelte';
-	import { getSignedInSession } from '$lib/session.svelte';
 	import { viewState } from '../../state/view.svelte';
 
 	const signedIn = getSignedInSession();

--- a/apps/honeycrisp/src/lib/editor/Editor.svelte
+++ b/apps/honeycrisp/src/lib/editor/Editor.svelte
@@ -389,9 +389,7 @@
 {#snippet groupItem(value: string, Icon: typeof BoldIcon, label: string)}
 	<Tooltip.Root>
 		<Tooltip.Trigger>
-			<ToggleGroup.Item {value}>
-				<Icon class="size-4" />
-			</ToggleGroup.Item>
+			<ToggleGroup.Item {value}> <Icon class="size-4" /> </ToggleGroup.Item>
 		</Tooltip.Trigger>
 		<Tooltip.Content>{label}</Tooltip.Content>
 	</Tooltip.Root>

--- a/apps/honeycrisp/src/lib/session.svelte.ts
+++ b/apps/honeycrisp/src/lib/session.svelte.ts
@@ -1,9 +1,9 @@
 import { requireSignedIn } from '@epicenter/auth';
 import { createSession, type InferSignedIn } from '@epicenter/svelte';
 import { getOrCreateInstallationId } from '@epicenter/workspace';
-import { auth } from './auth';
 import { openHoneycrisp } from '../routes/(signed-in)/honeycrisp/browser';
 import { createHoneycrispState } from '../routes/(signed-in)/state';
+import { auth } from './auth';
 
 export const session = createSession({
 	auth,
@@ -25,7 +25,6 @@ export const session = createSession({
 			honeycrisp,
 			state,
 			[Symbol.dispose]() {
-				state[Symbol.dispose]();
 				honeycrisp[Symbol.dispose]();
 			},
 		};

--- a/apps/honeycrisp/src/routes/(signed-in)/+page.svelte
+++ b/apps/honeycrisp/src/routes/(signed-in)/+page.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import * as Resizable from '@epicenter/ui/resizable';
 	import { SidebarProvider } from '@epicenter/ui/sidebar';
+	import { getSignedInSession } from '$lib/session.svelte';
 	import CommandPalette from './components/CommandPalette.svelte';
 	import NoteBodyPane from './components/NoteBodyPane.svelte';
 	import NoteList from './components/NoteList.svelte';
 	import HoneycripSidebar from './components/Sidebar.svelte';
-	import { getSignedInSession } from '$lib/session.svelte';
 
 	const { foldersState, notesState, viewState } = getSignedInSession().state;
 </script>

--- a/apps/honeycrisp/src/routes/(signed-in)/components/NoteBodyPane.svelte
+++ b/apps/honeycrisp/src/routes/(signed-in)/components/NoteBodyPane.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { fromDisposableCache } from '@epicenter/svelte';
+	import { useCacheHandle } from '@epicenter/svelte';
 	import { Loading } from '@epicenter/ui/loading';
 	import HoneycripEditor from '$lib/editor/Editor.svelte';
 	import { getSignedInSession } from '$lib/session.svelte';
@@ -9,7 +9,7 @@
 
 	let { noteId }: { noteId: string } = $props();
 
-	const doc = fromDisposableCache(signedIn.honeycrisp.noteBodyDocs, () => noteId);
+	const doc = useCacheHandle(signedIn.honeycrisp.noteBodyDocs, () => noteId);
 </script>
 
 {#await doc.current.idb.whenLoaded}

--- a/apps/honeycrisp/src/routes/(signed-in)/components/NoteCard.svelte
+++ b/apps/honeycrisp/src/routes/(signed-in)/components/NoteCard.svelte
@@ -2,13 +2,13 @@
 	import * as AlertDialog from '@epicenter/ui/alert-dialog';
 	import { Button } from '@epicenter/ui/button';
 	import * as ContextMenu from '@epicenter/ui/context-menu';
+	import { DateTimeString } from '@epicenter/workspace';
 	import ArchiveRestoreIcon from '@lucide/svelte/icons/archive-restore';
 	import FileTextIcon from '@lucide/svelte/icons/file-text';
 	import FolderIcon from '@lucide/svelte/icons/folder';
 	import PinIcon from '@lucide/svelte/icons/pin';
 	import TrashIcon from '@lucide/svelte/icons/trash-2';
 	import { format } from 'date-fns';
-	import { DateTimeString } from '@epicenter/workspace';
 	import { getSignedInSession } from '$lib/session.svelte';
 	import type { Note } from '../honeycrisp/workspace';
 

--- a/apps/honeycrisp/src/routes/(signed-in)/components/NoteList.svelte
+++ b/apps/honeycrisp/src/routes/(signed-in)/components/NoteList.svelte
@@ -5,9 +5,9 @@
 	import ArrowUpDownIcon from '@lucide/svelte/icons/arrow-up-down';
 	import CheckIcon from '@lucide/svelte/icons/check';
 	import PlusIcon from '@lucide/svelte/icons/plus';
-	import NoteCard from '../components/NoteCard.svelte';
 	import { getSignedInSession } from '$lib/session.svelte';
 	import { getDateLabel } from '$lib/utils/date';
+	import NoteCard from '../components/NoteCard.svelte';
 	import type { Note } from '../honeycrisp/workspace';
 
 	const { notesState, viewState } = getSignedInSession().state;

--- a/apps/honeycrisp/src/routes/(signed-in)/honeycrisp/browser.ts
+++ b/apps/honeycrisp/src/routes/(signed-in)/honeycrisp/browser.ts
@@ -15,8 +15,8 @@ import {
 	wipeOwnerLocalYjsData,
 } from '@epicenter/workspace';
 import * as Y from 'yjs';
-import type { NoteId } from './workspace';
 import { openHoneycrisp as openHoneycrispDoc } from './index';
+import type { NoteId } from './workspace';
 
 function noteBodyDocGuid({
 	workspaceId,

--- a/apps/honeycrisp/src/routes/(signed-in)/honeycrisp/daemon.ts
+++ b/apps/honeycrisp/src/routes/(signed-in)/honeycrisp/daemon.ts
@@ -1,7 +1,4 @@
-import {
-	createMachineAuthClient,
-	requireSignedIn,
-} from '@epicenter/auth/node';
+import { createMachineAuthClient, requireSignedIn } from '@epicenter/auth/node';
 import { EPICENTER_API_URL } from '@epicenter/constants/apps';
 import {
 	attachAwareness,

--- a/apps/honeycrisp/src/routes/(signed-in)/honeycrisp/script.ts
+++ b/apps/honeycrisp/src/routes/(signed-in)/honeycrisp/script.ts
@@ -1,7 +1,4 @@
-import {
-	createMachineAuthClient,
-	requireSignedIn,
-} from '@epicenter/auth/node';
+import { createMachineAuthClient, requireSignedIn } from '@epicenter/auth/node';
 import { EPICENTER_API_URL } from '@epicenter/constants/apps';
 import { attachSync, type ProjectDir, toWsUrl } from '@epicenter/workspace';
 import {

--- a/apps/honeycrisp/src/routes/(signed-in)/state/folders.svelte.ts
+++ b/apps/honeycrisp/src/routes/(signed-in)/state/folders.svelte.ts
@@ -29,22 +29,18 @@ import { searchParams } from './search-params.svelte';
 export function createFoldersState(honeycrisp: Honeycrisp) {
 	// ─── Reactive State ──────────────────────────────────────────────────
 
-	const foldersMap = fromTable(honeycrisp.tables.folders);
+	const foldersView = fromTable(honeycrisp.tables.folders);
 
-	const folders = $derived([...foldersMap.values()]);
+	const folders = $derived(foldersView.all);
 
 	// ─── Public API ──────────────────────────────────────────────────────
 
 	return {
-		[Symbol.dispose]() {
-			foldersMap[Symbol.dispose]();
-		},
-
 		/**
 		 * Look up a folder by ID. Returns `undefined` if not found.
 		 */
-		get(id: FolderId) {
-			return foldersMap.get(id);
+		byId(id: FolderId) {
+			return foldersView.byId(id);
 		},
 
 		get folders() {
@@ -68,7 +64,7 @@ export function createFoldersState(honeycrisp: Honeycrisp) {
 			honeycrisp.tables.folders.set({
 				id,
 				name: 'New Folder',
-				sortOrder: foldersMap.size,
+				sortOrder: foldersView.all.length,
 				_v: 1,
 			});
 		},

--- a/apps/honeycrisp/src/routes/(signed-in)/state/index.ts
+++ b/apps/honeycrisp/src/routes/(signed-in)/state/index.ts
@@ -12,9 +12,5 @@ export function createHoneycrispState(honeycrisp: Honeycrisp) {
 		foldersState,
 		notesState,
 		viewState,
-		[Symbol.dispose]() {
-			foldersState[Symbol.dispose]();
-			notesState[Symbol.dispose]();
-		},
 	};
 }

--- a/apps/honeycrisp/src/routes/(signed-in)/state/notes.svelte.ts
+++ b/apps/honeycrisp/src/routes/(signed-in)/state/notes.svelte.ts
@@ -24,8 +24,8 @@ import { fromTable } from '@epicenter/svelte';
 import { DateTimeString, generateId } from '@epicenter/workspace';
 import type { Honeycrisp } from '../honeycrisp/browser';
 import type { FolderId, NoteId } from '../honeycrisp/workspace';
-import { searchParams } from './search-params.svelte';
 import type { createFoldersState } from './folders.svelte';
+import { searchParams } from './search-params.svelte';
 
 export function createNotesState({
 	foldersState,
@@ -36,10 +36,10 @@ export function createNotesState({
 }) {
 	// ─── Reactive State ──────────────────────────────────────────────────
 
-	const allNotesMap = fromTable(honeycrisp.tables.notes);
+	const allNotesView = fromTable(honeycrisp.tables.notes);
 
 	/** All valid notes (including deleted). Cached — only recomputes when table changes. */
-	const allNotes = $derived([...allNotesMap.values()]);
+	const allNotes = $derived(allNotesView.all);
 
 	// ─── Derived State ───────────────────────────────────────────────────
 
@@ -65,15 +65,11 @@ export function createNotesState({
 	// ─── Public API ──────────────────────────────────────────────────────
 
 	return {
-		[Symbol.dispose]() {
-			allNotesMap[Symbol.dispose]();
-		},
-
 		/**
 		 * Look up a note by ID. Returns `undefined` if not found.
 		 */
-		get(id: NoteId) {
-			return allNotesMap.get(id);
+		byId(id: NoteId) {
+			return allNotesView.byId(id);
 		},
 
 		get allNotes() {
@@ -154,7 +150,7 @@ export function createNotesState({
 		 * ```
 		 */
 		restoreNote(noteId: NoteId) {
-			const note = allNotesMap.get(noteId);
+			const note = allNotesView.byId(noteId);
 			if (!note) return;
 			const folderExists = note.folderId
 				? foldersState.folders.some((f) => f.id === note.folderId)
@@ -197,7 +193,7 @@ export function createNotesState({
 		 * ```
 		 */
 		pinNote(noteId: NoteId) {
-			const note = allNotesMap.get(noteId);
+			const note = allNotesView.byId(noteId);
 			if (!note) return;
 			honeycrisp.tables.notes.update(noteId, {
 				pinned: !note.pinned,

--- a/apps/honeycrisp/src/routes/(signed-in)/state/view.svelte.ts
+++ b/apps/honeycrisp/src/routes/(signed-in)/state/view.svelte.ts
@@ -24,10 +24,10 @@
  * ```
  */
 
-import { searchParams, type SortBy } from './search-params.svelte';
 import type { FolderId, NoteId } from '../honeycrisp/workspace';
 import type { createFoldersState } from './folders.svelte';
 import type { createNotesState } from './notes.svelte';
+import { type SortBy, searchParams } from './search-params.svelte';
 
 export function createViewState({
 	foldersState,
@@ -64,14 +64,14 @@ export function createViewState({
 	const folderName = $derived.by(() => {
 		const folderId = searchParams.folder;
 		return folderId
-			? (foldersState.get(folderId)?.name ?? 'Notes')
+			? (foldersState.byId(folderId)?.name ?? 'Notes')
 			: 'All Notes';
 	});
 
 	/** The currently selected note (can be active or deleted). */
 	const selectedNote = $derived.by(() => {
 		const noteId = searchParams.note;
-		return noteId ? (notesState.get(noteId) ?? null) : null;
+		return noteId ? (notesState.byId(noteId) ?? null) : null;
 	});
 
 	// ─── Public API ──────────────────────────────────────────────────────

--- a/apps/honeycrisp/src/routes/+layout.svelte
+++ b/apps/honeycrisp/src/routes/+layout.svelte
@@ -4,10 +4,10 @@
 	import { ConfirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import { Loading } from '@epicenter/ui/loading';
 	import { Toaster } from '@epicenter/ui/sonner';
+	import * as Tooltip from '@epicenter/ui/tooltip';
 	import { QueryClientProvider } from '@tanstack/svelte-query';
 	import { SvelteQueryDevtools } from '@tanstack/svelte-query-devtools';
 	import { ModeWatcher } from 'mode-watcher';
-	import * as Tooltip from '@epicenter/ui/tooltip';
 	import { auth } from '$lib/auth';
 	import { queryClient } from '$lib/query/client';
 	import { session } from '$lib/session.svelte';

--- a/apps/opensidian/src/lib/chat/chat-state.svelte.ts
+++ b/apps/opensidian/src/lib/chat/chat-state.svelte.ts
@@ -16,6 +16,7 @@ import {
 } from '$lib/chat/system-prompt';
 import { toUiMessage } from '$lib/chat/ui-message';
 import { auth, opensidian, workspaceAiTools } from '$lib/opensidian/client';
+import { searchParams } from '$lib/search-params.svelte';
 import { skillState } from '$lib/state/skill-state.svelte';
 import {
 	type ChatMessageId,
@@ -24,7 +25,6 @@ import {
 	generateChatMessageId,
 	generateConversationId,
 } from '$lib/workspace/definition';
-import { searchParams } from '$lib/search-params.svelte';
 
 function getStringValue(value: JsonValue | undefined, fallback: string) {
 	return typeof value === 'string' ? value : fallback;
@@ -35,12 +35,11 @@ function getNumberValue(value: JsonValue | undefined, fallback = 0) {
 }
 
 function createAiChatState() {
-	const conversationsMap = fromTable(opensidian.tables.conversations);
+	const conversationsView = fromTable(opensidian.tables.conversations);
 	const conversations = $derived(
-		[...conversationsMap.values()]
-			.sort(
-				(a, b) => getNumberValue(b.updatedAt) - getNumberValue(a.updatedAt),
-			),
+		conversationsView.all.toSorted(
+			(a, b) => getNumberValue(b.updatedAt) - getNumberValue(a.updatedAt),
+		),
 	);
 
 	function ensureDefaultConversation(): ConversationId | undefined {
@@ -87,7 +86,7 @@ function createAiChatState() {
 	const refreshFns = new Map<ConversationId, () => void>();
 
 	function createConversationHandle(conversationId: ConversationId) {
-		const metadata = $derived(conversationsMap.get(conversationId));
+		const metadata = $derived(conversationsView.byId(conversationId));
 
 		const chat = createChat({
 			initialMessages: loadMessages(conversationId),
@@ -253,7 +252,9 @@ function createAiChatState() {
 			reload() {
 				const lastMessage = chat.messages.at(-1);
 				if (lastMessage?.role === 'assistant') {
-					opensidian.tables.chatMessages.delete(lastMessage.id as ChatMessageId);
+					opensidian.tables.chatMessages.delete(
+						lastMessage.id as ChatMessageId,
+					);
 				}
 
 				void chat.reload();
@@ -282,13 +283,13 @@ function createAiChatState() {
 
 	function reconcileHandles() {
 		for (const conversationId of handles.keys()) {
-			if (!conversationsMap.has(conversationId as string)) {
+			if (!conversationsView.byId(conversationId as string)) {
 				destroyConversation(conversationId);
 			}
 		}
 
-		for (const conversationId of conversationsMap.keys()) {
-			const id = conversationId as ConversationId;
+		for (const conversation of conversationsView.all) {
+			const id = conversation.id as ConversationId;
 			if (!handles.has(id)) {
 				handles.set(id, createConversationHandle(id));
 			}
@@ -307,9 +308,11 @@ function createAiChatState() {
 		(searchParams.chat ?? '') as ConversationId,
 	);
 
-	const _unobserveConversations = opensidian.tables.conversations.observe(() => {
-		reconcileHandles();
-	});
+	const _unobserveConversations = opensidian.tables.conversations.observe(
+		() => {
+			reconcileHandles();
+		},
+	);
 	const _unobserveChatMessages = opensidian.tables.chatMessages.observe(() => {
 		refreshFns.get(activeConversationId)?.();
 	});
@@ -369,7 +372,6 @@ function createAiChatState() {
 		[Symbol.dispose]() {
 			_unobserveConversations();
 			_unobserveChatMessages();
-			conversationsMap[Symbol.dispose]();
 			for (const conversationId of handles.keys()) {
 				destroyConversation(conversationId);
 			}

--- a/apps/opensidian/src/lib/components/editor/ContentEditor.svelte
+++ b/apps/opensidian/src/lib/components/editor/ContentEditor.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { autocompletion } from '@codemirror/autocomplete';
 	import type { FileId } from '@epicenter/filesystem';
-	import { fromDisposableCache } from '@epicenter/svelte';
+	import { useCacheHandle } from '@epicenter/svelte';
 	import { Loading } from '@epicenter/ui/loading';
 	import { opensidian } from '$lib/opensidian/client';
 	import { fsState } from '$lib/state/fs-state.svelte';
@@ -19,7 +19,7 @@
 		filename.endsWith('.md') || !filename.includes('.'),
 	);
 
-	const doc = fromDisposableCache(opensidian.fileContentDocs, () => fileId);
+	const doc = useCacheHandle(opensidian.fileContentDocs, () => fileId);
 
 	const sharedLinkDecorations = linkDecorations({
 		onNavigate: (ref) => fsState.selectFile(ref.id as FileId),

--- a/apps/opensidian/src/lib/opensidian/client.ts
+++ b/apps/opensidian/src/lib/opensidian/client.ts
@@ -1,9 +1,9 @@
+import { requireSignedIn } from '@epicenter/auth';
 import {
 	BearerSession,
 	createBearerAuth,
 	waitForAuthState,
 } from '@epicenter/auth-svelte';
-import { requireSignedIn } from '@epicenter/auth';
 import { APP_URLS } from '@epicenter/constants/vite';
 import { createPersistedState } from '@epicenter/svelte';
 import { getOrCreateInstallationId } from '@epicenter/workspace';

--- a/apps/opensidian/src/lib/opensidian/daemon.ts
+++ b/apps/opensidian/src/lib/opensidian/daemon.ts
@@ -1,7 +1,4 @@
-import {
-	createMachineAuthClient,
-	requireSignedIn,
-} from '@epicenter/auth/node';
+import { createMachineAuthClient, requireSignedIn } from '@epicenter/auth/node';
 import { EPICENTER_API_URL } from '@epicenter/constants/apps';
 import {
 	attachAwareness,

--- a/apps/opensidian/src/lib/opensidian/script.ts
+++ b/apps/opensidian/src/lib/opensidian/script.ts
@@ -1,7 +1,4 @@
-import {
-	createMachineAuthClient,
-	requireSignedIn,
-} from '@epicenter/auth/node';
+import { createMachineAuthClient, requireSignedIn } from '@epicenter/auth/node';
 import { EPICENTER_API_URL } from '@epicenter/constants/apps';
 import { attachSync, type ProjectDir, toWsUrl } from '@epicenter/workspace';
 import {

--- a/apps/opensidian/src/lib/search-params.svelte.ts
+++ b/apps/opensidian/src/lib/search-params.svelte.ts
@@ -22,9 +22,9 @@
  * ```
  */
 
+import type { FileId } from '@epicenter/filesystem';
 import { goto } from '$app/navigation';
 import { page } from '$app/state';
-import type { FileId } from '@epicenter/filesystem';
 import type { ConversationId } from '$lib/workspace/definition';
 
 /**

--- a/apps/opensidian/src/lib/state/fs-state.svelte.ts
+++ b/apps/opensidian/src/lib/state/fs-state.svelte.ts
@@ -1,8 +1,8 @@
 import type { FileId, FileRow } from '@epicenter/filesystem';
 import { fromTable } from '@epicenter/svelte';
 import { toast } from '@epicenter/ui/sonner';
-import { extractErrorMessage } from 'wellcrafted/error';
 import { SvelteSet } from 'svelte/reactivity';
+import { extractErrorMessage } from 'wellcrafted/error';
 import { opensidian } from '$lib/opensidian/client';
 import { searchParams } from '$lib/search-params.svelte';
 
@@ -23,11 +23,10 @@ type InteractionMode =
  * Follows the tab-manager pattern: factory function creates all state,
  * exports a single const. Components import and read directly.
  *
- * Reactivity: `fromTable()` provides a reactive `SvelteMap` that updates
- * granularly per-row. `childrenOf` derives tree structure eagerly (O(n)
- * iteration on any row change—acceptable for <5000 files). Paths are
- * computed lazily via `computePath()`—only the accessed file's ancestor
- * chain is tracked, so `selected` and `PathBreadcrumb` stay fine-grained.
+ * Reactivity: `fromTable()` provides a readonly table view. `childrenOf`
+ * derives tree structure eagerly (O(n) iteration on any row change,
+ * acceptable for <5000 files). Paths are computed lazily via `computePath()`,
+ * but table invalidation is global in this version of the primitive.
  *
  * @example
  * ```svelte
@@ -39,7 +38,7 @@ type InteractionMode =
  */
 function createFsState() {
 	// ── Reactive source ──────────────────────────────────────────────
-	const filesMap = fromTable(opensidian.tables.files);
+	const filesView = fromTable(opensidian.tables.files);
 
 	// ── Reactive state ───────────────────────────────────────────────
 	const openFileIds = new SvelteSet<FileId>();
@@ -58,18 +57,18 @@ function createFsState() {
 
 	// ── Derived tree structure ───────────────────────────────────────
 	//
-	// childrenOf iterates the full filesMap (creating an all-key dependency),
-	// so it recomputes on ANY row change—even non-structural edits like
-	// updatedAt bumps. At O(n) Map iteration for <5000 files this is <1ms,
+	// childrenOf iterates the full files view, so it recomputes on ANY row
+	// change, even non-structural edits like updatedAt bumps.
+	// At O(n) iteration for <5000 files this is <1ms,
 	// an intentional trade-off over the complexity of structural-only tracking.
 
 	/** Parent→children mapping. Groups non-trashed file IDs by parentId. */
 	const childrenOf = $derived.by(() => {
 		const map = new Map<FileId | null, FileId[]>();
-		for (const [id, row] of filesMap) {
+		for (const row of filesView.all) {
 			if (row.trashedAt !== null) continue;
 			const siblings = map.get(row.parentId) ?? [];
-			siblings.push(id);
+			siblings.push(row.id);
 			map.set(row.parentId, siblings);
 		}
 		return map;
@@ -80,32 +79,31 @@ function createFsState() {
 	/**
 	 * Build the full POSIX path for a file by walking up the ancestor chain.
 	 *
-	 * O(depth) per call—typically 3–5 `filesMap.get()` lookups. In a reactive
-	 * context (`$derived`), this creates fine-grained dependencies on only the
-	 * accessed file's ancestors, not every row in the tree. In an imperative
-	 * context (action methods), it's a plain lookup with no reactive cost.
+	 * O(depth) per call, typically 3 to 5 lookups. In a reactive context
+	 * (`$derived`), this subscribes through the table view. In an imperative
+	 * context (action methods), it's a plain lookup with no observer.
 	 *
 	 * Replaces the previous eager `pathIndex` derived which rebuilt all paths
 	 * (O(n) string concatenation) on any row change.
 	 *
 	 * @example
 	 * ```typescript
-	 * // In $derived — tracks only activeFile + ancestors
+	 * // In $derived
 	 * const path = $derived(computePath(activeFileId));
 	 *
-	 * // In action — plain lookup, no reactive tracking
+	 * // In action
 	 * const oldPath = computePath(id);
 	 * ```
 	 */
 	function computePath(id: FileId): string | null {
-		const row = filesMap.get(id);
+		const row = filesView.byId(id);
 		if (!row || row.trashedAt !== null) return null;
 
 		const parts: string[] = [row.name];
 		let parentId = row.parentId;
 
 		while (parentId !== null) {
-			const parent = filesMap.get(parentId);
+			const parent = filesView.byId(parentId);
 			if (!parent || parent.trashedAt !== null) return null;
 			parts.unshift(parent.name);
 			parentId = parent.parentId;
@@ -120,19 +118,16 @@ function createFsState() {
 	/**
 	 * Active file's row data.
 	 *
-	 * Fine-grained: only tracks the active file's row via `filesMap.get()`.
-	 * Unrelated row changes don't trigger recomputation.
+	 * Tracks the active file's row through the table view.
 	 */
 	const selectedNode = $derived.by(() => {
 		const fileId = searchParams.file;
-		return fileId ? (filesMap.get(fileId) ?? null) : null;
+		return fileId ? (filesView.byId(fileId) ?? null) : null;
 	});
 	/**
 	 * Active file's full POSIX path.
 	 *
-	 * Fine-grained: only tracks the active file's name and ancestor chain
-	 * (via `computePath`). A `size` or `updatedAt` change on a sibling file
-	 * won't trigger recomputation—only name/ancestry changes matter.
+	 * Tracks the active file's path through the table view.
 	 */
 	const selectedPath = $derived.by(() => {
 		const fileId = searchParams.file;
@@ -230,14 +225,13 @@ function createFsState() {
 		 * Returns null if the row is deleted/invalid.
 		 */
 		getFile(id: FileId): FileRow | null {
-			return filesMap.get(id) ?? null;
+			return filesView.byId(id) ?? null;
 		},
 
 		/**
 		 * Build the full POSIX path for a file by walking up its ancestor chain.
 		 *
-		 * In reactive contexts (e.g., inside `$derived`), creates fine-grained
-		 * dependencies on only the accessed file's ancestors. In imperative
+		 * In reactive contexts, subscribes through the table view. In imperative
 		 * contexts (action methods), it's a plain O(depth) lookup.
 		 *
 		 * @returns The full path (e.g., `/docs/api/reference.md`) or null if trashed/deleted.
@@ -275,7 +269,7 @@ function createFsState() {
 			const results: T[] = [];
 			function walk(pid: FileId | null) {
 				for (const childId of childrenOf.get(pid) ?? []) {
-					const row = filesMap.get(childId);
+					const row = filesView.byId(childId);
 					if (!row || row.trashedAt !== null) continue;
 					const { collect, descend } = visitor(childId, row);
 					if (collect !== undefined) results.push(collect);
@@ -418,7 +412,6 @@ function createFsState() {
 		},
 
 		[Symbol.dispose]() {
-			filesMap[Symbol.dispose]();
 			opensidian.fs.index.dispose();
 			opensidian.fs.dispose();
 		},

--- a/apps/opensidian/src/lib/state/skill-state.svelte.ts
+++ b/apps/opensidian/src/lib/state/skill-state.svelte.ts
@@ -1,5 +1,5 @@
-import { Ok, tryAsync } from 'wellcrafted/result';
 import { skillsActions } from '@epicenter/skills';
+import { Ok, tryAsync } from 'wellcrafted/result';
 import { opensidian } from '$lib/opensidian/client';
 
 /** A global skill loaded from the @epicenter/skills workspace. */

--- a/apps/opensidian/src/lib/state/terminal-state.svelte.ts
+++ b/apps/opensidian/src/lib/state/terminal-state.svelte.ts
@@ -207,7 +207,6 @@ function createTerminalState() {
 		clear() {
 			history = [];
 		},
-
 	};
 }
 

--- a/apps/skills/src/lib/components/editor/ExpandedReference.svelte
+++ b/apps/skills/src/lib/components/editor/ExpandedReference.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import { fromDisposableCache } from '@epicenter/svelte';
+	import { useCacheHandle } from '@epicenter/svelte';
 	import { skills } from '$lib/skills/client';
 	import CodeMirrorEditor from './CodeMirrorEditor.svelte';
 
 	let { id }: { id: string } = $props();
 
-	const doc = fromDisposableCache(skills.referenceDocs, () => id);
+	const doc = useCacheHandle(skills.referenceDocs, () => id);
 </script>
 
 <div class="h-48 border-t">

--- a/apps/skills/src/lib/components/editor/InstructionsEditor.svelte
+++ b/apps/skills/src/lib/components/editor/InstructionsEditor.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import { fromDisposableCache } from '@epicenter/svelte';
+	import { useCacheHandle } from '@epicenter/svelte';
 	import { skills } from '$lib/skills/client';
 	import CodeMirrorEditor from './CodeMirrorEditor.svelte';
 
 	let { skillId }: { skillId: string } = $props();
 
-	const doc = fromDisposableCache(skills.instructionsDocs, () => skillId);
+	const doc = useCacheHandle(skills.instructionsDocs, () => skillId);
 </script>
 
 <CodeMirrorEditor ytext={doc.current.instructions.binding} />

--- a/apps/skills/src/lib/skills/index.ts
+++ b/apps/skills/src/lib/skills/index.ts
@@ -1,1 +1,1 @@
-export { openSkills, type OpenSkillsOptions } from '@epicenter/skills';
+export { type OpenSkillsOptions, openSkills } from '@epicenter/skills';

--- a/apps/skills/src/lib/state/skills-state.svelte.ts
+++ b/apps/skills/src/lib/state/skills-state.svelte.ts
@@ -7,7 +7,7 @@ import { skills as skillsWorkspace } from '$lib/skills/client';
  * Reactive skills state singleton.
  *
  * Follows the canonical monorepo pattern: factory function creates
- * `fromTable()` reactive maps, `$derived` arrays, and CRUD methods.
+ * `fromTable()` reactive views, `$derived` arrays, and CRUD methods.
  * Components import the singleton and read directly.
  *
  * @example
@@ -22,34 +22,28 @@ import { skills as skillsWorkspace } from '$lib/skills/client';
  * ```
  */
 function createSkillsState() {
-	const skillsMap = fromTable(skillsWorkspace.tables.skills);
-	const referencesMap = fromTable(skillsWorkspace.tables.references);
+	const skillsView = fromTable(skillsWorkspace.tables.skills);
+	const referencesView = fromTable(skillsWorkspace.tables.references);
 
 	const skills = $derived(
-		[...skillsMap.values()]
-			.sort((a, b) => a.name.localeCompare(b.name)),
+		skillsView.all.toSorted((a, b) => a.name.localeCompare(b.name)),
 	);
 
 	let selectedSkillId = $state<string | null>(null);
 
 	const selectedSkill = $derived.by(() => {
 		if (!selectedSkillId) return null;
-		return skillsMap.get(selectedSkillId) ?? null;
+		return skillsView.byId(selectedSkillId) ?? null;
 	});
 
 	const selectedReferences = $derived.by(() => {
 		if (!selectedSkillId) return [];
-		return [...referencesMap.values()]
+		return referencesView.all
 			.filter((r) => r.skillId === selectedSkillId)
 			.sort((a, b) => a.path.localeCompare(b.path));
 	});
 
 	return {
-		[Symbol.dispose]() {
-			skillsMap[Symbol.dispose]();
-			referencesMap[Symbol.dispose]();
-		},
-
 		/** All skills, sorted alphabetically by name. */
 		get skills() {
 			return skills;
@@ -82,8 +76,8 @@ function createSkillsState() {
 		 *
 		 * @returns The skill row, or `undefined` if it doesn't exist.
 		 */
-		get(id: string) {
-			return skillsMap.get(id);
+		byId(id: string) {
+			return skillsView.byId(id);
 		},
 
 		/**
@@ -138,7 +132,7 @@ function createSkillsState() {
 		 */
 		deleteSkill(id: string) {
 			skillsWorkspace.batch(() => {
-				for (const ref of referencesMap.values()) {
+				for (const ref of referencesView.all) {
 					if (ref.skillId === id) {
 						skillsWorkspace.tables.references.delete(ref.id);
 					}
@@ -177,7 +171,3 @@ function createSkillsState() {
 }
 
 export const skillsState = createSkillsState();
-
-if (import.meta.hot) {
-	import.meta.hot.dispose(() => skillsState[Symbol.dispose]());
-}

--- a/apps/tab-manager/src/lib/chat/chat-state.svelte.ts
+++ b/apps/tab-manager/src/lib/chat/chat-state.svelte.ts
@@ -62,9 +62,9 @@ import {
 function createAiChatState() {
 	// ── Conversation List (Y.Doc-backed) ──────────────────────────────
 
-	const conversationsMap = fromTable(tabManager.tables.conversations);
+	const conversationsView = fromTable(tabManager.tables.conversations);
 	const conversations = $derived(
-		[...conversationsMap.values()].sort((a, b) => b.updatedAt - a.updatedAt),
+		conversationsView.all.toSorted((a, b) => b.updatedAt - a.updatedAt),
 	);
 
 	/**
@@ -138,7 +138,7 @@ function createAiChatState() {
 		let inputValue = $state('');
 		let dismissedError = $state<string | null>(null);
 
-		const metadata = $derived(conversationsMap.get(conversationId));
+		const metadata = $derived(conversationsView.byId(conversationId));
 
 		const chat = createChat({
 			initialMessages: loadMessages(conversationId),
@@ -395,7 +395,7 @@ function createAiChatState() {
 	}
 
 	/**
-	 * Sync handles with the conversationsMap.
+	 * Sync handles with the conversations table.
 	 *
 	 * Creates handles for new conversation IDs, destroys handles
 	 * for deleted IDs. Existing handles survive, so their chat instance
@@ -403,15 +403,15 @@ function createAiChatState() {
 	 */
 	function reconcileHandles() {
 		for (const id of handles.keys()) {
-			if (!conversationsMap.has(id as string)) {
+			if (!conversationsView.byId(id as string)) {
 				destroyConversation(id);
 			}
 		}
 
-		for (const id of conversationsMap.keys()) {
-			const convId = id as ConversationId;
-			if (!handles.has(convId)) {
-				handles.set(convId, createConversationHandle(convId));
+		for (const conversation of conversationsView.all) {
+			const id = conversation.id as ConversationId;
+			if (!handles.has(id)) {
+				handles.set(id, createConversationHandle(id));
 			}
 		}
 	}
@@ -522,7 +522,6 @@ function createAiChatState() {
 		[Symbol.dispose]() {
 			_unobserveConversations();
 			_unobserveChatMessages();
-			conversationsMap[Symbol.dispose]();
 			for (const id of handles.keys()) {
 				destroyConversation(id);
 			}

--- a/apps/tab-manager/src/lib/components/chat/ConversationPicker.svelte
+++ b/apps/tab-manager/src/lib/components/chat/ConversationPicker.svelte
@@ -111,9 +111,7 @@
 											>{conv.title}</span
 										>
 										{#if conv.isLoading}
-											<Spinner
-												class="size-3 shrink-0 text-muted-foreground"
-											/>
+											<Spinner class="size-3 shrink-0 text-muted-foreground" />
 										{/if}
 									</span>
 									<span class="flex shrink-0 items-center gap-1">

--- a/apps/tab-manager/src/lib/components/chat/ToolCallPart.svelte
+++ b/apps/tab-manager/src/lib/components/chat/ToolCallPart.svelte
@@ -6,8 +6,11 @@
 	import ShieldCheckIcon from '@lucide/svelte/icons/shield-check';
 	import WrenchIcon from '@lucide/svelte/icons/wrench';
 	import type { ToolCallPart as TanStackToolCallPart } from '@tanstack/ai-client';
-	import { type WorkspaceTools, workspaceAiTools } from '$lib/tab-manager/client';
 	import { toolTrustState } from '$lib/state/tool-trust.svelte';
+	import {
+		type WorkspaceTools,
+		workspaceAiTools,
+	} from '$lib/tab-manager/client';
 	import CollapsibleSection from '../CollapsibleSection.svelte';
 
 	let {

--- a/apps/tab-manager/src/lib/components/chat/TrustSettings.svelte
+++ b/apps/tab-manager/src/lib/components/chat/TrustSettings.svelte
@@ -3,8 +3,8 @@
 	import * as Popover from '@epicenter/ui/popover';
 	import { Switch } from '@epicenter/ui/switch';
 	import SettingsIcon from '@lucide/svelte/icons/settings';
-	import { workspaceAiTools } from '$lib/tab-manager/client';
 	import { toolTrustState } from '$lib/state/tool-trust.svelte';
+	import { workspaceAiTools } from '$lib/tab-manager/client';
 
 	const trustedTools = $derived(
 		toolTrustState.entries.filter(([, level]) => level === 'always'),

--- a/apps/tab-manager/src/lib/components/tabs/UnifiedTabList.svelte
+++ b/apps/tab-manager/src/lib/components/tabs/UnifiedTabList.svelte
@@ -174,7 +174,7 @@
 								variant="ghost"
 								size="icon-xs"
 								tooltip="Restore"
-							onclick={() =>
+								onclick={() =>
 							savedTabState.restore(tab).then((r) => toastOnError(r, 'Failed to restore tab'))}
 							>
 								<RotateCcwIcon />
@@ -217,7 +217,7 @@
 								variant="ghost"
 								size="icon-xs"
 								tooltip="Open"
-							onclick={() => bookmarkState.open(bookmark).then((r) => toastOnError(r, 'Failed to open bookmark'))}
+								onclick={() => bookmarkState.open(bookmark).then((r) => toastOnError(r, 'Failed to open bookmark'))}
 							>
 								<ExternalLinkIcon />
 							</Button>

--- a/apps/tab-manager/src/lib/state/bookmark-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/bookmark-state.svelte.ts
@@ -1,9 +1,8 @@
 /**
  * Reactive bookmark state for the side panel.
  *
- * Read-only reactive layer backed by `fromTable()` — provides granular
- * per-row reactivity via `SvelteMap`. All write operations are delegated
- * to workspace actions defined in `client.ts`.
+ * Read-only reactive layer backed by `fromTable()`. All write operations are
+ * delegated to workspace actions defined in `client.ts`.
  *
  * The public API exposes a `$derived` sorted array (access pattern is
  * always "render the full sorted list") plus a URL lookup set for O(1)
@@ -27,34 +26,29 @@
 
 import { fromTable } from '@epicenter/svelte';
 import { SvelteSet } from 'svelte/reactivity';
-import { tabManager } from '$lib/tab-manager/client';
 import type { BrowserTab } from '$lib/state/browser-state.svelte';
+import { tabManager } from '$lib/tab-manager/client';
 import type { Bookmark, BookmarkId } from '$lib/workspace';
 
 function createBookmarkState() {
-	const bookmarksMap = fromTable(tabManager.tables.bookmarks);
+	const bookmarksView = fromTable(tabManager.tables.bookmarks);
 
 	/** All bookmarks, sorted by most recently created first. Cached via $derived. */
 	const bookmarks = $derived(
-		[...bookmarksMap.values()]
-			.sort((a, b) => b.createdAt - a.createdAt),
+		bookmarksView.all.toSorted((a, b) => b.createdAt - a.createdAt),
 	);
 
 	/**
 	 * Reactive set of bookmarked URLs for O(1) lookup.
 	 *
-	 * Uses `SvelteSet` so `.has()` is a tracked reactive read—Svelte 5
+	 * Uses `SvelteSet` so `.has()` is a tracked reactive read. Svelte 5
 	 * re-renders any component that calls `isUrlBookmarked` when the set changes.
 	 */
 	const bookmarkedUrls = $derived(
-		new SvelteSet(bookmarksMap.values().map((b) => b.url)),
+		new SvelteSet(bookmarksView.all.map((b) => b.url)),
 	);
 
 	return {
-		[Symbol.dispose]() {
-			bookmarksMap[Symbol.dispose]();
-		},
-
 		get bookmarks() {
 			return bookmarks;
 		},
@@ -63,7 +57,7 @@ function createBookmarkState() {
 		 * Check whether a URL is currently bookmarked.
 		 *
 		 * O(1) lookup via `SvelteSet.has()`, which is a tracked reactive
-		 * read in Svelte 5—safe to call per-row in a list render.
+		 * read in Svelte 5. Safe to call per-row in a list render.
 		 */
 		isUrlBookmarked(url: string | undefined): boolean {
 			if (!url) return false;
@@ -101,7 +95,3 @@ function createBookmarkState() {
 }
 
 export const bookmarkState = createBookmarkState();
-
-if (import.meta.hot) {
-	import.meta.hot.dispose(() => bookmarkState[Symbol.dispose]());
-}

--- a/apps/tab-manager/src/lib/state/browser-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/browser-state.svelte.ts
@@ -323,8 +323,7 @@ function createBrowserState() {
 		tabsByWindow(windowId: number): BrowserTab[] {
 			const state = windowStates.get(windowId);
 			if (!state) return [];
-			return [...state.tabs.values()]
-				.sort((a, b) => a.index - b.index);
+			return [...state.tabs.values()].sort((a, b) => a.index - b.index);
 		},
 
 		/**

--- a/apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts
+++ b/apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts
@@ -1,9 +1,8 @@
 /**
  * Reactive saved tab state for the side panel.
  *
- * Read-only reactive layer backed by `fromTable()` — provides granular
- * per-row reactivity via `SvelteMap`. All write operations are delegated
- * to workspace actions defined in `client.ts`.
+ * Read-only reactive layer backed by `fromTable()`. All write operations are
+ * delegated to workspace actions defined in `client.ts`.
  *
  * The public API exposes a `$derived` sorted array since the access
  * pattern is always "render the full sorted list."
@@ -25,24 +24,17 @@
  */
 
 import { fromTable } from '@epicenter/svelte';
-import { tabManager } from '$lib/tab-manager/client';
 import type { BrowserTab } from '$lib/state/browser-state.svelte';
+import { tabManager } from '$lib/tab-manager/client';
 import type { SavedTab, SavedTabId } from '$lib/workspace';
 
 function createSavedTabState() {
-	const tabsMap = fromTable(tabManager.tables.savedTabs);
+	const tabsView = fromTable(tabManager.tables.savedTabs);
 
 	/** All saved tabs, sorted by most recently saved first. Cached via $derived. */
-	const tabs = $derived(
-		[...tabsMap.values()]
-			.sort((a, b) => b.savedAt - a.savedAt),
-	);
+	const tabs = $derived(tabsView.all.toSorted((a, b) => b.savedAt - a.savedAt));
 
 	return {
-		[Symbol.dispose]() {
-			tabsMap[Symbol.dispose]();
-		},
-
 		get tabs() {
 			return tabs;
 		},
@@ -100,7 +92,3 @@ function createSavedTabState() {
 }
 
 export const savedTabState = createSavedTabState();
-
-if (import.meta.hot) {
-	import.meta.hot.dispose(() => savedTabState[Symbol.dispose]());
-}

--- a/apps/tab-manager/src/lib/state/tool-trust.svelte.ts
+++ b/apps/tab-manager/src/lib/state/tool-trust.svelte.ts
@@ -28,18 +28,13 @@ export type TrustLevel = ToolTrust['trust'];
 // ─────────────────────────────────────────────────────────────────────────────
 
 function createToolTrustState() {
-	const trustMap = fromTable(tabManager.tables.toolTrust);
+	const trustView = fromTable(tabManager.tables.toolTrust);
 
-	/** Cached projection of trust entries — stable reference via $derived. */
+	/** Cached projection of trust entries. Stable reference via $derived. */
 	const trustEntries = $derived(
-		[...trustMap.values()]
-			.map((t): [string, TrustLevel] => [t.id, t.trust]),
+		trustView.all.map((t): [string, TrustLevel] => [t.id, t.trust]),
 	);
 	return {
-		[Symbol.dispose]() {
-			trustMap[Symbol.dispose]();
-		},
-
 		/**
 		 * Get the trust level for a tool.
 		 *
@@ -54,7 +49,7 @@ function createToolTrustState() {
 		 * ```
 		 */
 		get(name: string): TrustLevel {
-			return trustMap.get(name)?.trust ?? 'ask';
+			return trustView.byId(name)?.trust ?? 'ask';
 		},
 
 		/**
@@ -94,14 +89,14 @@ function createToolTrustState() {
 		 * ```
 		 */
 		shouldAutoApprove(name: string): boolean {
-			return (trustMap.get(name)?.trust ?? 'ask') === 'always';
+			return (trustView.byId(name)?.trust ?? 'ask') === 'always';
 		},
 
 		/**
 		 * All trust entries as a cached reactive array.
 		 *
 		 * Returns `[toolName, trustLevel]` tuples. Stable reference via `$derived`—
-		 * recomputes only when the underlying trustMap changes.
+		 * recomputes only when the underlying trust table changes.
 		 *
 		 * @example
 		 * ```typescript
@@ -117,7 +112,3 @@ function createToolTrustState() {
 }
 
 export const toolTrustState = createToolTrustState();
-
-if (import.meta.hot) {
-	import.meta.hot.dispose(() => toolTrustState[Symbol.dispose]());
-}

--- a/apps/tab-manager/src/lib/state/tool-trust.svelte.ts
+++ b/apps/tab-manager/src/lib/state/tool-trust.svelte.ts
@@ -55,9 +55,8 @@ function createToolTrustState() {
 		/**
 		 * Set the trust level for a tool.
 		 *
-		 * Writes to the workspace table (Y.Doc-backed), which triggers
-		 * the observer to update the internal trust map reactively. Syncs
-		 * across devices via CRDT.
+		 * Writes to the workspace table. The readonly table view updates
+		 * reactive readers and syncs across devices via CRDT.
 		 *
 		 * @example
 		 * ```typescript
@@ -95,7 +94,7 @@ function createToolTrustState() {
 		/**
 		 * All trust entries as a cached reactive array.
 		 *
-		 * Returns `[toolName, trustLevel]` tuples. Stable reference via `$derived`—
+		 * Returns `[toolName, trustLevel]` tuples. Stable reference via `$derived`,
 		 * recomputes only when the underlying trust table changes.
 		 *
 		 * @example

--- a/apps/tab-manager/src/lib/workspace/actions.ts
+++ b/apps/tab-manager/src/lib/workspace/actions.ts
@@ -14,7 +14,11 @@ import {
 	type InferErrors,
 } from 'wellcrafted/error';
 import { Err, Ok, tryAsync } from 'wellcrafted/result';
-import { type DeviceId, generateBookmarkId, generateSavedTabId } from './definition';
+import {
+	type DeviceId,
+	generateBookmarkId,
+	generateSavedTabId,
+} from './definition';
 import type { Tables } from './tables';
 
 export const TabError = defineErrors({
@@ -119,8 +123,7 @@ export function createTabManagerActions({
 			}),
 			open: defineMutation({
 				title: 'Open Tab',
-				description:
-					'Open a new tab with the given URL on the current device.',
+				description: 'Open a new tab with the given URL on the current device.',
 				input: Type.Object({ url: Type.String() }),
 				handler: async ({ url }) =>
 					tryAsync({
@@ -263,7 +266,8 @@ export function createTabManagerActions({
 						tabIds.map((id) => browser.tabs.reload(id)),
 					);
 					return {
-						reloadedCount: results.filter((r) => r.status === 'fulfilled').length,
+						reloadedCount: results.filter((r) => r.status === 'fulfilled')
+							.length,
 					};
 				},
 			}),

--- a/apps/tab-manager/src/lib/workspace/index.ts
+++ b/apps/tab-manager/src/lib/workspace/index.ts
@@ -1,3 +1,4 @@
+export { createTabManagerActions } from './actions';
 export {
 	type Bookmark,
 	BookmarkId,
@@ -13,7 +14,6 @@ export {
 	generateSavedTabId,
 	type SavedTab,
 	SavedTabId,
-	tabManagerTables,
 	type ToolTrust,
+	tabManagerTables,
 } from './definition';
-export { createTabManagerActions } from './actions';

--- a/apps/whispering/ARCHITECTURE.md
+++ b/apps/whispering/ARCHITECTURE.md
@@ -83,7 +83,7 @@ async function transcribeBlob(blob: Blob) {
 }
 ```
 
-**Workspace State** - After migrating to Yjs CRDTs, domain data (recordings, transformations, transformation runs) lives in reactive workspace state modules (`$lib/state/*.svelte.ts`). These use SvelteMap backed by Yjs documents for instant reactivity—no cache invalidation or optimistic updates needed.
+**Workspace State** - After migrating to Yjs CRDTs, domain data (recordings, transformations, transformation runs) lives in reactive workspace state modules (`$lib/state/*.svelte.ts`). These use readonly table views backed by Yjs documents for instant reactivity, with no cache invalidation or optimistic updates needed.
 
 The query layer's role has narrowed to things that don't fit in CRDTs:
 

--- a/apps/whispering/src/lib/components/copyable/TranscriptDialog.svelte
+++ b/apps/whispering/src/lib/components/copyable/TranscriptDialog.svelte
@@ -12,7 +12,7 @@
 	 * ```svelte
 	 * <TranscriptDialog
 	 *   recordingId={recording.id}
- *   transcript={recording.transcript}
+	 *   transcript={recording.transcript}
 	 *   rows={1}
 	 * />
 	 * ```
@@ -22,7 +22,7 @@
 	 * <!-- With loading state -->
 	 * <TranscriptDialog
 	 *   recordingId={recording.id}
- *   transcript="..."
+	 *   transcript="..."
 	 *   loading={true}
 	 * />
 	 * ```
@@ -32,7 +32,7 @@
 	 * <!-- With delete button -->
 	 * <TranscriptDialog
 	 *   recordingId={recording.id}
- *   transcript={recording.transcript}
+	 *   transcript={recording.transcript}
 	 *   onDelete={() => handleDelete(recording)}
 	 * />
 	 * ```

--- a/apps/whispering/src/lib/components/settings/selectors/TransformationSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/selectors/TransformationSelector.svelte
@@ -13,8 +13,8 @@
 	import { rpc } from '$lib/query';
 	import { settings } from '$lib/state/settings.svelte';
 	import { transformations } from '$lib/state/transformations.svelte';
-	import type { Transformation } from '$lib/workspace';
 	import { viewTransition } from '$lib/utils/viewTransitions';
+	import type { Transformation } from '$lib/workspace';
 
 	const sortedTransformations = $derived(transformations.sorted);
 

--- a/apps/whispering/src/lib/components/transformations-editor/Runs.svelte
+++ b/apps/whispering/src/lib/components/transformations-editor/Runs.svelte
@@ -15,8 +15,8 @@
 	import TextPreviewDialog from '$lib/components/copyable/TextPreviewDialog.svelte';
 	import { rpc } from '$lib/query';
 	import { transformationRuns } from '$lib/state/transformation-runs.svelte';
-	import type { TransformationRun } from '$lib/workspace';
 	import { viewTransition } from '$lib/utils/viewTransitions';
+	import type { TransformationRun } from '$lib/workspace';
 
 	let { runs }: { runs: TransformationRun[] } = $props();
 

--- a/apps/whispering/src/lib/migration/migration-dialog.svelte.ts
+++ b/apps/whispering/src/lib/migration/migration-dialog.svelte.ts
@@ -1,7 +1,7 @@
 import { nanoid } from 'nanoid/non-secure';
 import { Ok, tryAsync } from 'wellcrafted/result';
-import { whispering } from '$lib/whispering/client';
 import { ToastServiceLive } from '$lib/services/toast';
+import { whispering } from '$lib/whispering/client';
 import {
 	type DbMigrationState,
 	getDatabaseMigrationState,
@@ -174,10 +174,9 @@ function createMigrationDialog() {
 			isSeeding = true;
 			logs = [];
 
-			const {
-				createMigrationTestData,
-				MOCK_RECORDING_COUNT,
-			} = await import('./migration-test-data');
+			const { createMigrationTestData, MOCK_RECORDING_COUNT } = await import(
+				'./migration-test-data'
+			);
 			const testData = createMigrationTestData();
 
 			await tryAsync({

--- a/apps/whispering/src/lib/query/README.md
+++ b/apps/whispering/src/lib/query/README.md
@@ -1010,7 +1010,7 @@ Understanding how RPC fits into the bigger picture:
 Pure functions that do the actual work:
 
 ```typescript
-// services/db.ts — still used for audio blobs and run lifecycle
+// services/db.ts: still used for audio blobs and run lifecycle
 export async function ensureAudioPlaybackUrl(
 	recordingId: string,
 ): Promise<Result<string, DbError>> {
@@ -1020,14 +1020,14 @@ export async function ensureAudioPlaybackUrl(
 
 ### 2. Workspace State (`/lib/state/workspace-*.svelte.ts`)
 
-Reactive SvelteMap modules backed by Yjs CRDTs. These replaced TanStack Query for all domain data CRUD:
+Reactive workspace state modules backed by Yjs CRDTs. These replaced TanStack Query for all domain data CRUD:
 
 ```typescript
 // Workspace state is the primary data layer for recordings, transformations, runs
 import { recordings } from '$lib/state/recordings.svelte';
 
-// Direct reactive access — no queries needed
-const recording = recordings.get(id);
+// Direct reactive access, no queries needed
+const recording = recordings.byId(id);
 const allRecordings = recordings.sorted;
 ```
 
@@ -1036,7 +1036,7 @@ const allRecordings = recordings.sorted;
 Wraps services with reactivity and caching for things that don't fit in workspace state:
 
 ```typescript
-// query/audio.ts — audio blobs are too large for Yjs CRDTs
+// query/audio.ts: audio blobs are too large for Yjs CRDTs
 export const audio = {
 	getPlaybackUrl: (id: Accessor<string>) =>
 		defineQuery({

--- a/apps/whispering/src/lib/query/actions.ts
+++ b/apps/whispering/src/lib/query/actions.ts
@@ -516,7 +516,7 @@ export const actions = {
 			}
 
 			// Get the transformation from workspace state
-			const transformation = transformations.get(transformationId);
+			const transformation = transformations.byId(transformationId);
 
 			if (!transformation) {
 				settings.set('transformation.selectedId', null);
@@ -694,7 +694,7 @@ async function processRecordingPipeline({
 
 	// Check if transformation is valid if specified
 	if (!transformationId) return;
-	const transformation = transformations.get(transformationId);
+	const transformation = transformations.byId(transformationId);
 
 	if (!transformation) {
 		settings.set('transformation.selectedId', null);

--- a/apps/whispering/src/lib/query/notify.ts
+++ b/apps/whispering/src/lib/query/notify.ts
@@ -14,7 +14,10 @@ const createNotifyMutation = (
 		mutationFn: async (
 			options: Omit<UnifiedNotificationOptions, 'variant'>,
 		) => {
-			const fullOptions = { ...options, variant } satisfies UnifiedNotificationOptions;
+			const fullOptions = {
+				...options,
+				variant,
+			} satisfies UnifiedNotificationOptions;
 
 			// Log in dev mode
 			if (dev) {

--- a/apps/whispering/src/lib/query/transcription.ts
+++ b/apps/whispering/src/lib/query/transcription.ts
@@ -162,17 +162,15 @@ export async function transcribeBlob(
 
 			switch (selectedService) {
 				case 'OpenAI': {
-					const { data, error } = await services.transcriptions.openai.transcribe(
-						audioToTranscribe,
-						{
+					const { data, error } =
+						await services.transcriptions.openai.transcribe(audioToTranscribe, {
 							outputLanguage,
 							prompt,
 							temperature,
 							apiKey: deviceConfig.get('apiKeys.openai'),
 							modelName: settings.get('transcription.openai.model'),
 							baseURL: deviceConfig.get('apiEndpoints.openai') || undefined,
-						},
-					);
+						});
 					if (error) return openaiErrorToWhisperingErr(error);
 					return Ok(data);
 				}

--- a/apps/whispering/src/lib/query/transformer.ts
+++ b/apps/whispering/src/lib/query/transformer.ts
@@ -5,7 +5,6 @@ import {
 	type InferErrors,
 } from 'wellcrafted/error';
 import { Err, isErr, Ok, type Result } from 'wellcrafted/result';
-import { whispering } from '$lib/whispering/client';
 import { defineMutation } from '$lib/query/client';
 import {
 	WhisperingErr,
@@ -17,13 +16,14 @@ import { deviceConfig } from '$lib/state/device-config.svelte';
 import { recordings } from '$lib/state/recordings.svelte';
 import { transformationRuns } from '$lib/state/transformation-runs.svelte';
 import { transformationSteps } from '$lib/state/transformation-steps.svelte';
+import { asTemplateString, interpolateTemplate } from '$lib/utils/template';
+import { whispering } from '$lib/whispering/client';
 import type {
 	Transformation,
 	TransformationRun,
 	TransformationStep,
 	TransformationStepRun,
 } from '$lib/workspace';
-import { asTemplateString, interpolateTemplate } from '$lib/utils/template';
 
 type TransformationRunRunning = Extract<
 	TransformationRun,
@@ -177,7 +177,7 @@ export const transformer = {
 				WhisperingError
 			>
 		> => {
-			const recording = recordings.get(recordingId);
+			const recording = recordings.byId(recordingId);
 			if (!recording) {
 				return WhisperingErr({
 					title: '⚠️ Recording not found',

--- a/apps/whispering/src/lib/recording-materializer.ts
+++ b/apps/whispering/src/lib/recording-materializer.ts
@@ -70,7 +70,10 @@ export function attachRecordingMarkdownFiles(
 				}
 
 				if (toWrite.length) {
-					await invoke('write_markdown_files', { directory: dir, files: toWrite });
+					await invoke('write_markdown_files', {
+						directory: dir,
+						files: toWrite,
+					});
 				}
 				if (toDelete.length) {
 					await invoke('delete_files_in_directory', {

--- a/apps/whispering/src/lib/result.ts
+++ b/apps/whispering/src/lib/result.ts
@@ -96,4 +96,3 @@ export const WhisperingWarningErr = (args: WhisperingErrorInput) =>
  * @template T - The type of the success value
  */
 export type WhisperingResult<T> = Ok<T> | Err<WhisperingError>;
-

--- a/apps/whispering/src/lib/services/blob-store/desktop.ts
+++ b/apps/whispering/src/lib/services/blob-store/desktop.ts
@@ -70,8 +70,7 @@ export function createBlobStoreDesktop(): BlobStore {
 
 		ensurePlaybackUrl: async (key) => {
 			// DUAL READ: Check file system first, fallback to IndexedDB
-			const fsResult =
-				await fileSystemDb.ensurePlaybackUrl(key);
+			const fsResult = await fileSystemDb.ensurePlaybackUrl(key);
 
 			// If found in file system, return it
 			if (fsResult.data) {

--- a/apps/whispering/src/lib/services/blob-store/file-system.ts
+++ b/apps/whispering/src/lib/services/blob-store/file-system.ts
@@ -45,10 +45,7 @@ export function createFileSystemBlobStore(): BlobStore {
 					await mkdir(recordingsPath, { recursive: true });
 
 					const extension = mime.getExtension(blob.type) ?? 'bin';
-					const audioPath = await PATHS.DB.RECORDING_AUDIO(
-						key,
-						extension,
-					);
+					const audioPath = await PATHS.DB.RECORDING_AUDIO(key, extension);
 					const arrayBuffer = await blob.arrayBuffer();
 					await tauriWriteFile(audioPath, new Uint8Array(arrayBuffer));
 				},
@@ -79,15 +76,10 @@ export function createFileSystemBlobStore(): BlobStore {
 			return tryAsync({
 				try: async () => {
 					const recordingsPath = await PATHS.DB.RECORDINGS();
-					const audioFilename = await findAudioFile(
-						recordingsPath,
-						key,
-					);
+					const audioFilename = await findAudioFile(recordingsPath, key);
 
 					if (!audioFilename) {
-						throw new Error(
-						`Audio file not found for key ${key}`,
-						);
+						throw new Error(`Audio file not found for key ${key}`);
 					}
 
 					const audioPath = await PATHS.DB.RECORDING_FILE(audioFilename);
@@ -107,15 +99,10 @@ export function createFileSystemBlobStore(): BlobStore {
 			return tryAsync({
 				try: async () => {
 					const recordingsPath = await PATHS.DB.RECORDINGS();
-					const audioFilename = await findAudioFile(
-						recordingsPath,
-						key,
-					);
+					const audioFilename = await findAudioFile(recordingsPath, key);
 
 					if (!audioFilename) {
-						throw new Error(
-						`Audio file not found for key ${key}`,
-						);
+						throw new Error(`Audio file not found for key ${key}`);
 					}
 
 					const audioPath = await PATHS.DB.RECORDING_FILE(audioFilename);

--- a/apps/whispering/src/lib/services/blob-store/web/dexie-schemas.ts
+++ b/apps/whispering/src/lib/services/blob-store/web/dexie-schemas.ts
@@ -34,4 +34,3 @@ export type AudioStoredInIndexedDB = {
 	id: string;
 	serializedAudio: SerializedAudio | undefined;
 };
-

--- a/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
+++ b/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
@@ -7,14 +7,12 @@ import type {
 } from '$lib/constants/audio';
 import { FsServiceLive } from '$lib/services/desktop/fs';
 import {
-	type CpalRecordingParams,
-	RecorderError,
-	type RecorderService,
-} from '$lib/services/recorder/types';
-import {
 	asDeviceIdentifier,
+	type CpalRecordingParams,
 	type Device,
 	type DeviceAcquisitionOutcome,
+	RecorderError,
+	type RecorderService,
 } from '$lib/services/recorder/types';
 
 /**

--- a/apps/whispering/src/lib/services/desktop/recorder/ffmpeg.ts
+++ b/apps/whispering/src/lib/services/desktop/recorder/ffmpeg.ts
@@ -18,15 +18,13 @@ import {
 } from '$lib/services/desktop/command';
 import { FsServiceLive } from '$lib/services/desktop/fs';
 import {
-	type FfmpegRecordingParams,
-	RecorderError,
-	type RecorderService,
-} from '$lib/services/recorder/types';
-import {
 	asDeviceIdentifier,
 	type Device,
 	type DeviceAcquisitionOutcome,
 	type DeviceIdentifier,
+	type FfmpegRecordingParams,
+	RecorderError,
+	type RecorderService,
 } from '$lib/services/recorder/types';
 
 /**

--- a/apps/whispering/src/lib/services/text/types.ts
+++ b/apps/whispering/src/lib/services/text/types.ts
@@ -1,10 +1,10 @@
+import type { MaybePromise } from '@epicenter/workspace';
 import {
 	defineErrors,
 	extractErrorMessage,
 	type InferErrors,
 } from 'wellcrafted/error';
 import type { Result } from 'wellcrafted/result';
-import type { MaybePromise } from '@epicenter/workspace';
 import type { WhisperingError } from '$lib/result';
 
 export const TextError = defineErrors({

--- a/apps/whispering/src/lib/services/transcription/cloud/deepgram.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/deepgram.ts
@@ -25,13 +25,7 @@ export const DeepgramError = defineErrors({
 	MissingApiKey: () => ({
 		message: 'Deepgram API key is required',
 	}),
-	FileTooLarge: ({
-		sizeMb,
-		maxMb,
-	}: {
-		sizeMb: number;
-		maxMb: number;
-	}) => ({
+	FileTooLarge: ({ sizeMb, maxMb }: { sizeMb: number; maxMb: number }) => ({
 		message: `File size ${sizeMb.toFixed(1)}MB exceeds ${maxMb}MB limit`,
 		sizeMb,
 		maxMb,

--- a/apps/whispering/src/lib/services/transcription/cloud/elevenlabs.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/elevenlabs.ts
@@ -12,13 +12,7 @@ export const ElevenLabsError = defineErrors({
 	MissingApiKey: () => ({
 		message: 'ElevenLabs API key is required',
 	}),
-	FileTooLarge: ({
-		sizeMb,
-		maxMb,
-	}: {
-		sizeMb: number;
-		maxMb: number;
-	}) => ({
+	FileTooLarge: ({ sizeMb, maxMb }: { sizeMb: number; maxMb: number }) => ({
 		message: `File size ${sizeMb.toFixed(1)}MB exceeds ${maxMb}MB limit`,
 		sizeMb,
 		maxMb,

--- a/apps/whispering/src/lib/services/transcription/cloud/groq.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/groq.ts
@@ -19,13 +19,7 @@ export const GroqError = defineErrors({
 	InvalidApiKeyFormat: () => ({
 		message: 'Groq API keys must start with "gsk_" or "xai-"',
 	}),
-	FileTooLarge: ({
-		sizeMb,
-		maxMb,
-	}: {
-		sizeMb: number;
-		maxMb: number;
-	}) => ({
+	FileTooLarge: ({ sizeMb, maxMb }: { sizeMb: number; maxMb: number }) => ({
 		message: `File size ${sizeMb.toFixed(1)}MB exceeds ${maxMb}MB limit`,
 		sizeMb,
 		maxMb,

--- a/apps/whispering/src/lib/services/transcription/cloud/mistral.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/mistral.ts
@@ -15,13 +15,7 @@ export const MistralTranscriptionError = defineErrors({
 	MissingApiKey: () => ({
 		message: 'Mistral API key is required',
 	}),
-	FileTooLarge: ({
-		sizeMb,
-		maxMb,
-	}: {
-		sizeMb: number;
-		maxMb: number;
-	}) => ({
+	FileTooLarge: ({ sizeMb, maxMb }: { sizeMb: number; maxMb: number }) => ({
 		message: `File size ${sizeMb.toFixed(1)}MB exceeds ${maxMb}MB limit`,
 		sizeMb,
 		maxMb,

--- a/apps/whispering/src/lib/services/transcription/cloud/openai.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/openai.ts
@@ -19,13 +19,7 @@ export const OpenaiError = defineErrors({
 	InvalidApiKeyFormat: () => ({
 		message: 'OpenAI API keys must start with "sk-"',
 	}),
-	FileTooLarge: ({
-		sizeMb,
-		maxMb,
-	}: {
-		sizeMb: number;
-		maxMb: number;
-	}) => ({
+	FileTooLarge: ({ sizeMb, maxMb }: { sizeMb: number; maxMb: number }) => ({
 		message: `File size ${sizeMb.toFixed(1)}MB exceeds ${maxMb}MB limit`,
 		sizeMb,
 		maxMb,

--- a/apps/whispering/src/lib/state/README.md
+++ b/apps/whispering/src/lib/state/README.md
@@ -16,7 +16,7 @@ Singleton reactive state that stays in sync with the application. Unlike the que
 
 ### `settings.svelte.ts`
 
-Synced workspace settings backed by Yjs KV. Settings here roam across devices via CRDT sync. Uses a SvelteMap for per-key reactivity.
+Synced workspace settings backed by Yjs KV. Settings here roam across devices via CRDT sync.
 
 ```typescript
 import { settings } from '$lib/state/settings.svelte';
@@ -24,22 +24,22 @@ import { settings } from '$lib/state/settings.svelte';
 // Read settings reactively (re-renders on change)
 const mode = settings.get('recording.mode');
 
-// Update settings (writes to Yjs KV → syncs to other devices)
+// Update settings (writes to Yjs KV and syncs to other devices)
 settings.set('recording.mode', 'vad');
 ```
 
 ### `recordings.svelte.ts`
 
-Recording metadata backed by Yjs workspace table. SvelteMap provides per-key reactivity—updating one recording doesn't re-render the entire list. Audio blobs are NOT stored here (too large for CRDTs); use `DbService.recordings.getAudioBlob()` for audio access.
+Recording metadata backed by Yjs workspace table. The readonly table view invalidates reactive readers when workspace rows change. Audio blobs are NOT stored here (too large for CRDTs); use `DbService.recordings.getAudioBlob()` for audio access.
 
 ```typescript
 import { recordings } from '$lib/state/recordings.svelte';
 
 // Read recordings reactively
-const recording = recordings.get(id);
+const recording = recordings.byId(id);
 const sorted = recordings.sorted; // newest first
 
-// Write (Yjs observer auto-updates SvelteMap)
+// Write (Yjs observer invalidates reactive readers)
 recordings.set(recording);
 recordings.update(id, { transcriptionStatus: 'DONE' });
 recordings.delete(id);
@@ -52,7 +52,7 @@ Transformation metadata backed by Yjs workspace table. Steps are stored in a sep
 ```typescript
 import { transformations } from '$lib/state/transformations.svelte';
 
-const transformation = transformations.get(id);
+const transformation = transformations.byId(id);
 const sorted = transformations.sorted; // alphabetical
 ```
 
@@ -80,7 +80,7 @@ const latest = transformationRuns.getLatestByRecordingId(recordingId);
 
 ### `device-config.svelte.ts`
 
-Device-bound configuration backed by per-key localStorage. Secrets, hardware IDs, filesystem paths, and global OS shortcuts that should never sync across devices. Uses a SvelteMap for per-key reactivity with cross-tab sync via storage events.
+Device-bound configuration backed by per-key localStorage. Secrets, hardware IDs, filesystem paths, and global OS shortcuts should never sync across devices.
 
 ```typescript
 import { deviceConfig } from '$lib/state/device-config.svelte';

--- a/apps/whispering/src/lib/state/recordings.svelte.ts
+++ b/apps/whispering/src/lib/state/recordings.svelte.ts
@@ -12,7 +12,7 @@
  * import { recordings } from '$lib/state/recordings.svelte';
  *
  * // Read reactively (re-renders on change)
- * const recording = recordings.get(id);
+ * const recording = recordings.byId(id);
  * const all = recordings.sorted; // newest first
  *
  * // Write (Yjs observer auto-updates SvelteMap → components re-render)
@@ -28,32 +28,24 @@ import type { Recording } from '$lib/workspace';
 export type { Recording } from '$lib/workspace';
 
 function createRecordings() {
-	const map = fromTable(whispering.tables.recordings);
+	const view = fromTable(whispering.tables.recordings);
 
 	// Memoize sorted array with $derived so consumers get a stable reference.
-	// Without this, every access creates a new array → TanStack Table's $derived
-	// sees "new data" → updates internal $state → re-triggers $derived → infinite loop.
+	// Without this, every access creates a new array, which can make TanStack
+	// Table's $derived loop on internal row model updates.
 	const sorted = $derived(
-		[...map.values()].sort(
+		view.all.toSorted(
 			(a, b) =>
 				new Date(b.recordedAt).getTime() - new Date(a.recordedAt).getTime(),
 		),
 	);
 
 	return {
-		[Symbol.dispose]() {
-			map[Symbol.dispose]();
-		},
-
 		/**
-		 * All recordings as a reactive SvelteMap.
-		 *
-		 * Components reading this re-render per-key when recordings change.
-		 * Use `.sorted` for a pre-sorted array, or iterate directly for
-		 * custom ordering.
+		 * All recordings as a reactive readonly array.
 		 */
 		get all() {
-			return map;
+			return view.all;
 		},
 
 		/**
@@ -62,16 +54,15 @@ function createRecordings() {
 		 * Reads from the reactive SvelteMap—triggers re-render if the
 		 * recording changes or is deleted.
 		 */
-		get(id: string) {
-			return map.get(id);
+		byId(id: string) {
+			return view.byId(id);
 		},
 
 		/**
 		 * All recordings as a sorted array (newest first by recordedAt).
 		 *
-		 * Memoized via `$derived`—returns a stable reference until the
-		 * SvelteMap actually changes. This is critical for TanStack Table,
-		 * which uses reference equality to detect data changes.
+		 * Memoized via `$derived`, so TanStack Table receives a stable
+		 * reference until the table changes.
 		 */
 		get sorted(): Recording[] {
 			return sorted;
@@ -120,13 +111,9 @@ function createRecordings() {
 
 		/** Total number of recordings. */
 		get count() {
-			return map.size;
+			return view.all.length;
 		},
 	};
 }
 
 export const recordings = createRecordings();
-
-if (import.meta.hot) {
-	import.meta.hot.dispose(() => recordings[Symbol.dispose]());
-}

--- a/apps/whispering/src/lib/state/recordings.svelte.ts
+++ b/apps/whispering/src/lib/state/recordings.svelte.ts
@@ -15,7 +15,7 @@
  * const recording = recordings.byId(id);
  * const all = recordings.sorted; // newest first
  *
- * // Write (Yjs observer invalidates reactive readers)
+ * // Write (table view updates reactive readers)
  * recordings.set(recording);
  * recordings.delete(id);
  * ```
@@ -72,7 +72,7 @@ function createRecordings() {
 		 * Create or update a recording. Writes to Yjs invalidate the table view.
 		 *
 		 * Accepts a recording without `_v` (version tag is added automatically).
-		 * No manual cache invalidation needed. The observer handles UI updates.
+		 * No manual cache invalidation needed. The table view updates reactive readers.
 		 */
 		set(recording: Omit<Recording, '_v'>) {
 			whispering.tables.recordings.set({ ...recording, _v: 2 } as Recording);
@@ -91,7 +91,7 @@ function createRecordings() {
 		/**
 		 * Delete a recording by ID.
 		 *
-		 * Fire-and-forget. The Yjs observer invalidates reactive readers.
+		 * Fire-and-forget. The table view updates reactive readers.
 		 * Callers should clean up audio URLs before calling this.
 		 */
 		delete(id: string) {

--- a/apps/whispering/src/lib/state/recordings.svelte.ts
+++ b/apps/whispering/src/lib/state/recordings.svelte.ts
@@ -1,9 +1,9 @@
 /**
  * Reactive recording state backed by Yjs workspace tables.
  *
- * Replaces TanStack Query + BlobStore for recording CRUD. SvelteMap provides
- * per-key reactivity—updating one recording doesn't re-render the entire list.
- * The Yjs observer fires on local writes, remote CRDT sync, and migration.
+ * Replaces TanStack Query + BlobStore for recording CRUD. The readonly table
+ * view invalidates reactive readers on local writes, remote CRDT sync, and
+ * migration.
  *
  * Audio blob access still goes through BlobStore (blobs are too large for CRDTs).
  *
@@ -15,7 +15,7 @@
  * const recording = recordings.byId(id);
  * const all = recordings.sorted; // newest first
  *
- * // Write (Yjs observer auto-updates SvelteMap → components re-render)
+ * // Write (Yjs observer invalidates reactive readers)
  * recordings.set(recording);
  * recordings.delete(id);
  * ```
@@ -51,7 +51,7 @@ function createRecordings() {
 		/**
 		 * Get a recording by ID. Returns undefined if not found.
 		 *
-		 * Reads from the reactive SvelteMap—triggers re-render if the
+		 * Reads from the reactive table view. Components re-render if the
 		 * recording changes or is deleted.
 		 */
 		byId(id: string) {
@@ -69,10 +69,10 @@ function createRecordings() {
 		},
 
 		/**
-		 * Create or update a recording. Writes to Yjs → observer updates SvelteMap.
+		 * Create or update a recording. Writes to Yjs invalidate the table view.
 		 *
 		 * Accepts a recording without `_v` (version tag is added automatically).
-		 * No manual cache invalidation needed—the observer handles UI updates.
+		 * No manual cache invalidation needed. The observer handles UI updates.
 		 */
 		set(recording: Omit<Recording, '_v'>) {
 			whispering.tables.recordings.set({ ...recording, _v: 2 } as Recording);
@@ -91,7 +91,7 @@ function createRecordings() {
 		/**
 		 * Delete a recording by ID.
 		 *
-		 * Fire-and-forget—Yjs observer fires `map.delete(id)` automatically.
+		 * Fire-and-forget. The Yjs observer invalidates reactive readers.
 		 * Callers should clean up audio URLs before calling this.
 		 */
 		delete(id: string) {

--- a/apps/whispering/src/lib/state/transformation-runs.svelte.ts
+++ b/apps/whispering/src/lib/state/transformation-runs.svelte.ts
@@ -22,21 +22,17 @@ import { whispering } from '$lib/whispering/client';
 import type { TransformationRun } from '$lib/workspace';
 
 function createTransformationRuns() {
-	const map = fromTable(whispering.tables.transformationRuns);
+	const view = fromTable(whispering.tables.transformationRuns);
 
 	return {
-		[Symbol.dispose]() {
-			map[Symbol.dispose]();
-		},
-
-		/** All transformation runs as a reactive SvelteMap. */
+		/** All transformation runs as a reactive readonly array. */
 		get all() {
-			return map;
+			return view.all;
 		},
 
 		/** Get a run by ID. */
-		get(id: string) {
-			return map.get(id);
+		byId(id: string) {
+			return view.byId(id);
 		},
 
 		/**
@@ -45,7 +41,7 @@ function createTransformationRuns() {
 		 * @param transformationId - FK to the parent transformation
 		 */
 		getByTransformationId(transformationId: string): TransformationRun[] {
-			return Array.from(map.values())
+			return view.all
 				.filter((run) => run.transformationId === transformationId)
 				.sort(
 					(a, b) =>
@@ -59,7 +55,7 @@ function createTransformationRuns() {
 		 * @param recordingId - FK to the recording
 		 */
 		getByRecordingId(recordingId: string): TransformationRun[] {
-			return Array.from(map.values())
+			return view.all
 				.filter((run) => run.recordingId === recordingId)
 				.sort(
 					(a, b) =>
@@ -93,13 +89,9 @@ function createTransformationRuns() {
 
 		/** Total number of runs. */
 		get count() {
-			return map.size;
+			return view.all.length;
 		},
 	};
 }
 
 export const transformationRuns = createTransformationRuns();
-
-if (import.meta.hot) {
-	import.meta.hot.dispose(() => transformationRuns[Symbol.dispose]());
-}

--- a/apps/whispering/src/lib/state/transformation-steps.svelte.ts
+++ b/apps/whispering/src/lib/state/transformation-steps.svelte.ts
@@ -44,7 +44,7 @@ function createTransformationSteps() {
 		/**
 		 * Get all steps for a transformation, sorted by order.
 		 *
-		 * This is the primary query method—replaces the old `transformation.steps[]`
+		 * This is the primary query method. It replaces the old `transformation.steps[]`
 		 * nested array pattern. Steps are now a separate table with `transformationId` FK.
 		 *
 		 * @param transformationId - FK to the parent transformation
@@ -57,7 +57,7 @@ function createTransformationSteps() {
 		},
 
 		/**
-		 * Create or update a step. Writes to Yjs → observer updates SvelteMap.
+		 * Create or update a step. Writes to Yjs invalidate the table view.
 		 */
 		set(step: TransformationStep) {
 			whispering.tables.transformationSteps.set(step);
@@ -83,7 +83,7 @@ function createTransformationSteps() {
 		/**
 		 * Delete all steps for a transformation.
 		 *
-		 * Useful when deleting a transformation—removes all child steps.
+		 * Useful when deleting a transformation. Removes all child steps.
 		 */
 		deleteByTransformationId(transformationId: string) {
 			for (const step of view.all) {

--- a/apps/whispering/src/lib/state/transformation-steps.svelte.ts
+++ b/apps/whispering/src/lib/state/transformation-steps.svelte.ts
@@ -24,25 +24,21 @@ import { whispering } from '$lib/whispering/client';
 import type { TransformationStep } from '$lib/workspace';
 
 function createTransformationSteps() {
-	const map = fromTable(whispering.tables.transformationSteps);
+	const view = fromTable(whispering.tables.transformationSteps);
 
 	return {
-		[Symbol.dispose]() {
-			map[Symbol.dispose]();
-		},
-
 		/**
-		 * All transformation steps as a reactive SvelteMap.
+		 * All transformation steps as a reactive readonly array.
 		 */
 		get all() {
-			return map;
+			return view.all;
 		},
 
 		/**
 		 * Get a step by ID. Returns undefined if not found.
 		 */
-		get(id: string) {
-			return map.get(id);
+		byId(id: string) {
+			return view.byId(id);
 		},
 
 		/**
@@ -55,7 +51,7 @@ function createTransformationSteps() {
 		 * @returns Steps sorted by `order` field (ascending)
 		 */
 		getByTransformationId(transformationId: string): TransformationStep[] {
-			return Array.from(map.values())
+			return view.all
 				.filter((step) => step.transformationId === transformationId)
 				.sort((a, b) => a.order - b.order);
 		},
@@ -90,25 +86,21 @@ function createTransformationSteps() {
 		 * Useful when deleting a transformation—removes all child steps.
 		 */
 		deleteByTransformationId(transformationId: string) {
-			for (const [id, step] of map) {
+			for (const step of view.all) {
 				if (step.transformationId === transformationId) {
-					whispering.tables.transformationSteps.delete(id);
+					whispering.tables.transformationSteps.delete(step.id);
 				}
 			}
 		},
 
 		/** Total number of steps across all transformations. */
 		get count() {
-			return map.size;
+			return view.all.length;
 		},
 	};
 }
 
 export const transformationSteps = createTransformationSteps();
-
-if (import.meta.hot) {
-	import.meta.hot.dispose(() => transformationSteps[Symbol.dispose]());
-}
 
 /**
  * Generate a default transformation step with sensible defaults.

--- a/apps/whispering/src/lib/state/transformations.svelte.ts
+++ b/apps/whispering/src/lib/state/transformations.svelte.ts
@@ -10,7 +10,7 @@
  * import { transformations } from '$lib/state/transformations.svelte';
  *
  * // Read reactively
- * const transformation = transformations.get(id);
+ * const transformation = transformations.byId(id);
  * const all = transformations.sorted; // alphabetical by title
  *
  * // Write
@@ -26,37 +26,31 @@ import type { Transformation, TransformationStep } from '$lib/workspace';
 import { transformationSteps } from './transformation-steps.svelte';
 
 function createTransformations() {
-	const map = fromTable(whispering.tables.transformations);
+	const view = fromTable(whispering.tables.transformations);
 
 	// Memoize sorted array with $derived for referential stability.
 	const sorted = $derived(
-		[...map.values()].sort((a, b) => a.title.localeCompare(b.title)),
+		view.all.toSorted((a, b) => a.title.localeCompare(b.title)),
 	);
 
 	return {
-		[Symbol.dispose]() {
-			map[Symbol.dispose]();
-		},
-
 		/**
-		 * All transformations as a reactive SvelteMap.
-		 *
-		 * Components reading this re-render per-key when transformations change.
+		 * All transformations as a reactive readonly array.
 		 */
 		get all() {
-			return map;
+			return view.all;
 		},
 
 		/**
 		 * Get a transformation by ID. Returns undefined if not found.
 		 */
-		get(id: string) {
-			return map.get(id);
+		byId(id: string) {
+			return view.byId(id);
 		},
 
 		/**
 		 * All transformations as a sorted array (alphabetical by title).
-		 * Memoized via `$derived`—stable reference until SvelteMap changes.
+		 * Memoized via `$derived`, stable until the table changes.
 		 */
 		get sorted(): Transformation[] {
 			return sorted;
@@ -85,16 +79,12 @@ function createTransformations() {
 
 		/** Total number of transformations. */
 		get count() {
-			return map.size;
+			return view.all.length;
 		},
 	};
 }
 
 export const transformations = createTransformations();
-
-if (import.meta.hot) {
-	import.meta.hot.dispose(() => transformations[Symbol.dispose]());
-}
 
 /**
  * Generate a default transformation with sensible defaults.

--- a/apps/whispering/src/lib/state/transformations.svelte.ts
+++ b/apps/whispering/src/lib/state/transformations.svelte.ts
@@ -3,7 +3,7 @@
  *
  * Replaces TanStack Query + BlobStore for transformation CRUD. The workspace
  * model stores transformations as metadata rows (title, description, timestamps)
- * without embedded steps—steps live in a separate `transformationSteps` table.
+ * without embedded steps. Steps live in a separate `transformationSteps` table.
  *
  * @example
  * ```typescript
@@ -57,7 +57,7 @@ function createTransformations() {
 		},
 
 		/**
-		 * Create or update a transformation. Writes to Yjs → observer updates SvelteMap.
+		 * Create or update a transformation. Writes to Yjs invalidate the table view.
 		 */
 		set(transformation: Transformation) {
 			whispering.tables.transformations.set(transformation);

--- a/apps/whispering/src/lib/whispering/tauri.ts
+++ b/apps/whispering/src/lib/whispering/tauri.ts
@@ -1,9 +1,6 @@
 /** `recordingsFs` is a no-op in non-Tauri environments. */
 
-import {
-	attachBroadcastChannel,
-	attachIndexedDb,
-} from '@epicenter/workspace';
+import { attachBroadcastChannel, attachIndexedDb } from '@epicenter/workspace';
 import { PATHS } from '$lib/constants/paths';
 import { attachRecordingMarkdownFiles } from '$lib/recording-materializer';
 import { openWhispering as openWhisperingDoc } from './index';

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -1,4 +1,8 @@
-import { defineKv, defineTable, type InferTableRow } from '@epicenter/workspace';
+import {
+	defineKv,
+	defineTable,
+	type InferTableRow,
+} from '@epicenter/workspace';
 import { type } from 'arktype';
 
 // ── Constant imports ─────────────────────────────────────────────────────────
@@ -187,7 +191,9 @@ const transformationStepRuns = defineTable(
 );
 
 /** Transformation step run row type inferred from the latest workspace table schema version. */
-export type TransformationStepRun = InferTableRow<typeof transformationStepRuns>;
+export type TransformationStepRun = InferTableRow<
+	typeof transformationStepRuns
+>;
 
 /**
  * Synced settings stored as individual KV entries with last-write-wins resolution.

--- a/apps/whispering/src/lib/workspace/index.ts
+++ b/apps/whispering/src/lib/workspace/index.ts
@@ -1,9 +1,9 @@
 export {
-	whisperingTables,
-	whisperingKv,
 	type Recording,
 	type Transformation,
-	type TransformationStep,
 	type TransformationRun,
+	type TransformationStep,
 	type TransformationStepRun,
+	whisperingKv,
+	whisperingTables,
 } from './definition';

--- a/apps/whispering/src/routes/(app)/(config)/debug/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/debug/+page.svelte
@@ -37,7 +37,10 @@
 
 	function createMetrics() {
 		const tableDefs = [
-			{ label: 'Recordings', count: () => whispering.tables.recordings.count() },
+			{
+				label: 'Recordings',
+				count: () => whispering.tables.recordings.count(),
+			},
 			{
 				label: 'Transformations',
 				count: () => whispering.tables.transformations.count(),

--- a/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/+page.svelte
@@ -431,12 +431,12 @@
 						{#if transcribeRecordings.isPending}
 							<EllipsisIcon class="size-4" />
 						{:else if selectedRecordingRows.some(({ id }) => {
-							const currentRow = recordings.get(id);
+							const currentRow = recordings.byId(id);
 							return currentRow?.transcriptionStatus === 'TRANSCRIBING';
 						})}
 							<LoadingTranscriptionIcon class="size-4" />
 						{:else if selectedRecordingRows.some(({ id }) => {
-							const currentRow = recordings.get(id);
+							const currentRow = recordings.byId(id);
 							return currentRow?.transcriptionStatus === 'DONE';
 						})}
 							<RetryTranscriptionIcon class="size-4" />

--- a/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/RecordingRowActions.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/recordings/row-actions/RecordingRowActions.svelte
@@ -37,7 +37,7 @@
 		transformationRuns.getLatestByRecordingId(recordingId),
 	);
 
-	const recording = $derived(recordings.get(recordingId));
+	const recording = $derived(recordings.byId(recordingId));
 </script>
 
 <div class="flex items-center gap-1">

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutTable.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/ShortcutTable.svelte
@@ -2,7 +2,6 @@
 	import { Input } from '@epicenter/ui/input';
 	import * as Table from '@epicenter/ui/table';
 	import Search from '@lucide/svelte/icons/search';
-	import { whisperingKv } from '$lib/workspace';
 	import { commands } from '$lib/commands';
 	import { rpc } from '$lib/query';
 	import {
@@ -10,6 +9,7 @@
 		deviceConfig,
 	} from '$lib/state/device-config.svelte';
 	import { createPressedKeys } from '$lib/utils/createPressedKeys.svelte';
+	import { whisperingKv } from '$lib/workspace';
 	import GlobalKeyboardShortcutRecorder from './GlobalKeyboardShortcutRecorder.svelte';
 	import LocalKeyboardShortcutRecorder from './LocalKeyboardShortcutRecorder.svelte';
 
@@ -20,10 +20,7 @@
 	/** Look up the definition default for a shortcut key from the correct store. */
 	function getDefaultShortcut(commandId: string): string | null {
 		if (type === 'local') {
-			const defs = whisperingKv as Record<
-				string,
-				{ defaultValue: unknown }
-			>;
+			const defs = whisperingKv as Record<string, { defaultValue: unknown }>;
 			return (
 				(defs[`shortcut.${commandId}`]?.defaultValue as string | null) ?? null
 			);

--- a/apps/whispering/src/routes/(app)/(config)/transformations/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/transformations/+page.svelte
@@ -35,8 +35,8 @@
 	import { PATHS } from '$lib/constants/paths';
 	import { rpc } from '$lib/query';
 	import { transformations } from '$lib/state/transformations.svelte';
-	import type { Transformation } from '$lib/workspace';
 	import { viewTransition } from '$lib/utils/viewTransitions';
+	import type { Transformation } from '$lib/workspace';
 	import CreateTransformationButton from './CreateTransformationButton.svelte';
 	import MarkTransformationActiveButton from './MarkTransformationActiveButton.svelte';
 	import TransformationRowActions from './TransformationRowActions.svelte';

--- a/apps/whispering/src/routes/(app)/(config)/transformations/TransformationRowActions.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/transformations/TransformationRowActions.svelte
@@ -9,7 +9,7 @@
 
 	let { transformationId }: { transformationId: string } = $props();
 
-	const transformation = $derived(transformations.get(transformationId));
+	const transformation = $derived(transformations.byId(transformationId));
 </script>
 
 <div class="flex items-center gap-1">

--- a/apps/whispering/src/routes/(app)/+page.svelte
+++ b/apps/whispering/src/routes/(app)/+page.svelte
@@ -18,7 +18,6 @@
 	import { extractErrorMessage } from 'wellcrafted/error';
 	import { partitionResults, tryAsync } from 'wellcrafted/result';
 	import { commandCallbacks } from '$lib/commands';
-	import { WhisperingErr } from '$lib/result';
 	import TranscriptDialog from '$lib/components/copyable/TranscriptDialog.svelte';
 	import {
 		CompressionSelector,
@@ -35,6 +34,7 @@
 	} from '$lib/constants/audio';
 	import { getShortcutDisplayLabel } from '$lib/constants/keyboard';
 	import { rpc } from '$lib/query';
+	import { WhisperingErr } from '$lib/result';
 	import { services } from '$lib/services';
 	import { desktopServices } from '$lib/services/desktop';
 	import { deviceConfig } from '$lib/state/device-config.svelte';

--- a/apps/whispering/src/routes/(app)/_layout-utils/register-permissions.ts
+++ b/apps/whispering/src/routes/(app)/_layout-utils/register-permissions.ts
@@ -73,7 +73,11 @@ export function registerMicrophonePermission() {
 						const { error: requestError } =
 							await desktopServices.permissions.microphone.request();
 
-						if (requestError) return toastOnError(requestError, 'Failed to request microphone permission');
+						if (requestError)
+							return toastOnError(
+								requestError,
+								'Failed to request microphone permission',
+							);
 						// Dismiss the toast after requesting
 						toast.dismiss(microphoneToastId);
 					},

--- a/apps/zhongwen/src/lib/session.svelte.ts
+++ b/apps/zhongwen/src/lib/session.svelte.ts
@@ -1,7 +1,7 @@
 import { requireSignedIn } from '@epicenter/auth';
 import { createSession, type InferSignedIn } from '@epicenter/svelte';
-import { auth } from './auth';
 import { openZhongwen } from '../routes/(signed-in)/zhongwen/browser';
+import { auth } from './auth';
 
 export const session = createSession({
 	auth,

--- a/apps/zhongwen/src/routes/(signed-in)/+page.svelte
+++ b/apps/zhongwen/src/routes/(signed-in)/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { requireSignedIn } from '@epicenter/auth';
 	import { fromKv } from '@epicenter/svelte';
 	import { Button } from '@epicenter/ui/button';
 	import * as Chat from '@epicenter/ui/chat';
@@ -9,7 +10,6 @@
 	import { extractErrorMessage } from 'wellcrafted/error';
 	import { auth } from '$lib/auth';
 	import { getSignedInSession } from '$lib/session.svelte';
-	import { requireSignedIn } from '@epicenter/auth';
 	import { createChatState } from './chat/chat-state.svelte';
 	import ChatInput from './components/ChatInput.svelte';
 	import ChatMessage from './components/ChatMessage.svelte';

--- a/apps/zhongwen/src/routes/(signed-in)/chat/chat-state.svelte.ts
+++ b/apps/zhongwen/src/routes/(signed-in)/chat/chat-state.svelte.ts
@@ -12,6 +12,14 @@ import { createChat, fetchServerSentEvents } from '@tanstack/ai-svelte';
 import { SvelteMap } from 'svelte/reactivity';
 import type { JsonValue } from 'wellcrafted/json';
 import { auth } from '$lib/auth';
+import { getSignedInSession } from '$lib/session.svelte';
+import {
+	type ChatMessageId,
+	type Conversation,
+	type ConversationId,
+	generateChatMessageId,
+	generateConversationId,
+} from '../zhongwen/workspace';
 import {
 	DEFAULT_MODEL,
 	DEFAULT_PROVIDER,
@@ -20,14 +28,6 @@ import {
 } from './providers';
 import { ZHONGWEN_SYSTEM_PROMPT } from './system-prompt';
 import { toUiMessage } from './ui-message';
-import {
-	type ChatMessageId,
-	type Conversation,
-	type ConversationId,
-	generateChatMessageId,
-	generateConversationId,
-} from '../zhongwen/workspace';
-import { getSignedInSession } from '$lib/session.svelte';
 
 const asChatMessageId = (id: string) => id as ChatMessageId;
 
@@ -38,9 +38,9 @@ export function createChatState() {
 
 	// ── Conversation List (Y.Doc-backed) ──
 
-	const conversationsMap = fromTable(signedIn.zhongwen.tables.conversations);
+	const conversationsView = fromTable(signedIn.zhongwen.tables.conversations);
 	const conversations = $derived(
-		[...conversationsMap.values()].sort((a, b) => b.updatedAt - a.updatedAt),
+		conversationsView.all.toSorted((a, b) => b.updatedAt - a.updatedAt),
 	);
 
 	/** Returns the ID to activate, either the first existing conversation or a newly created default. */
@@ -95,7 +95,7 @@ export function createChatState() {
 	function createConversationHandle(conversationId: ConversationId) {
 		let inputValue = $state('');
 
-		const metadata = $derived(conversationsMap.get(conversationId));
+		const metadata = $derived(conversationsView.byId(conversationId));
 
 		const chat = createChat({
 			initialMessages: loadMessages(conversationId),
@@ -210,7 +210,9 @@ export function createChatState() {
 			reload() {
 				const lastMessage = chat.messages.at(-1);
 				if (lastMessage?.role === 'assistant') {
-					signedIn.zhongwen.tables.chatMessages.delete(asChatMessageId(lastMessage.id));
+					signedIn.zhongwen.tables.chatMessages.delete(
+						asChatMessageId(lastMessage.id),
+					);
 				}
 				void chat.reload();
 			},
@@ -230,15 +232,15 @@ export function createChatState() {
 
 	function reconcileHandles() {
 		for (const id of handles.keys()) {
-			if (!conversationsMap.has(id)) {
+			if (!conversationsView.byId(id)) {
 				destroyConversation(id);
 			}
 		}
 
-		for (const id of conversationsMap.keys()) {
-			const convId = id as ConversationId;
-			if (!handles.has(convId)) {
-				handles.set(convId, createConversationHandle(convId));
+		for (const conversation of conversationsView.all) {
+			const id = conversation.id as ConversationId;
+			if (!handles.has(id)) {
+				handles.set(id, createConversationHandle(id));
 			}
 		}
 	}
@@ -247,12 +249,16 @@ export function createChatState() {
 
 	// fromTable owns the reactive data; this observer only handles
 	// imperative handle lifecycle (creating/destroying chat instances).
-	const unobserveConversations = signedIn.zhongwen.tables.conversations.observe(() => {
-		reconcileHandles();
-	});
-	const unobserveChatMessages = signedIn.zhongwen.tables.chatMessages.observe(() => {
-		handles.get(activeConversationId)?.syncMessages();
-	});
+	const unobserveConversations = signedIn.zhongwen.tables.conversations.observe(
+		() => {
+			reconcileHandles();
+		},
+	);
+	const unobserveChatMessages = signedIn.zhongwen.tables.chatMessages.observe(
+		() => {
+			handles.get(activeConversationId)?.syncMessages();
+		},
+	);
 
 	// Initialize after persistence loads
 	void signedIn.zhongwen.idb.whenLoaded.then(() => {
@@ -337,7 +343,6 @@ export function createChatState() {
 		[Symbol.dispose]() {
 			unobserveConversations();
 			unobserveChatMessages();
-			conversationsMap[Symbol.dispose]();
 			for (const id of handles.keys()) {
 				destroyConversation(id);
 			}

--- a/apps/zhongwen/src/routes/(signed-in)/zhongwen/daemon.ts
+++ b/apps/zhongwen/src/routes/(signed-in)/zhongwen/daemon.ts
@@ -1,7 +1,4 @@
-import {
-	createMachineAuthClient,
-	requireSignedIn,
-} from '@epicenter/auth/node';
+import { createMachineAuthClient, requireSignedIn } from '@epicenter/auth/node';
 import { EPICENTER_API_URL } from '@epicenter/constants/apps';
 import {
 	attachAwareness,

--- a/apps/zhongwen/src/routes/(signed-in)/zhongwen/script.ts
+++ b/apps/zhongwen/src/routes/(signed-in)/zhongwen/script.ts
@@ -1,7 +1,4 @@
-import {
-	createMachineAuthClient,
-	requireSignedIn,
-} from '@epicenter/auth/node';
+import { createMachineAuthClient, requireSignedIn } from '@epicenter/auth/node';
 import { EPICENTER_API_URL } from '@epicenter/constants/apps';
 import { attachSync, type ProjectDir, toWsUrl } from '@epicenter/workspace';
 import {

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/docs/articles/derived-vs-getter-caching-matters.md
+++ b/docs/articles/derived-vs-getter-caching-matters.md
@@ -1,6 +1,9 @@
-# `$derived` vs Getter—Both Reactive, Only One Caches
+# `$derived` vs Getter: Both Reactive, Only One Caches
 
-A getter that reads from a `SvelteMap` is reactive. Svelte tracks the `SvelteMap` read, and anything consuming the getter re-renders when the map changes. So why bother with `$derived`?
+A getter that reads from a reactive source is reactive. For workspace tables,
+that source is usually a `fromTable()` view. Svelte tracks `view.all` or
+`view.byId(id)` when the read happens inside a reactive context. So why bother
+with `$derived`?
 
 Caching.
 
@@ -8,48 +11,65 @@ Caching.
 
 ```typescript
 function createSavedTabState() {
-  const tabsMap = fromTable(workspaceClient.tables.savedTabs);
+	const tabsView = fromTable(workspaceClient.tables.savedTabs);
 
-  // Option A: $derived — computes once, caches until tabsMap changes
-  const tabs = $derived(tabsMap.values().toArray().sort((a, b) => b.savedAt - a.savedAt));
+	// Option A: $derived computes once, then caches until tabsView changes
+	const tabs = $derived(
+		tabsView.all.toSorted((a, b) => b.savedAt - a.savedAt),
+	);
 
-  return {
-    get tabs() { return tabs; },
-  };
+	return {
+		get tabs() {
+			return tabs;
+		},
+	};
 
-  // Option B: plain getter — recomputes on every access
-  return {
-    get tabs() {
-      return tabsMap.values().toArray().sort((a, b) => b.savedAt - a.savedAt);
-    },
-  };
+	// Option B: plain getter recomputes on every access
+	return {
+		get tabs() {
+			return tabsView.all.toSorted((a, b) => b.savedAt - a.savedAt);
+		},
+	};
 }
 ```
 
-Both are reactive. Both return fresh data. The difference is what happens when `tabs` is read multiple times in the same render cycle.
+Both are reactive. Both return fresh table data. The difference is what happens
+when `tabs` is read multiple times in the same render cycle.
 
 ## What Each Does
 
-**`$derived`** creates a reactive signal. The expression runs once when its dependencies change, and the result is memoized. Ten reads in the same cycle—template, a count badge, a conditional, a child component—all hit the cache. The sort runs once.
+`$derived` creates a reactive signal. The expression runs once when its
+dependencies change, and the result is memoized. Ten reads in the same cycle
+all hit the cache. The sort runs once.
 
-**A plain getter** is just a JavaScript getter. Every access runs `values().toArray().sort()` from scratch. Ten reads means ten sorts. Svelte doesn't know it's a computed value—it only tracks the `SvelteMap` reads inside the getter body.
+A plain getter is just a JavaScript getter. Every access runs
+`view.all.toSorted(...)` from scratch. Ten reads means ten array snapshots and
+ten sorts.
 
 ## Why It Matters
 
-For a list of 20 saved tabs, the performance difference is negligible. But the principle scales. As the dataset grows, as more consumers read the same derived value, caching pays off. And `$derived` is the idiomatic Svelte 5 way to express "computed from reactive state"—it communicates intent.
-
-Both approaches are reactive because both ultimately read from a `SvelteMap` that Svelte's runtime tracks. The getter doesn't break reactivity. `$derived` adds caching on top.
+For a list of 20 saved tabs, the performance difference is negligible. The
+principle matters because state modules are public surfaces. As datasets grow
+or more consumers read the same derived value, caching pays off. `$derived` is
+also the idiomatic Svelte 5 way to say "computed from reactive state."
 
 ## The Rule
 
-Prefer `$derived` for any computation derived from reactive state. Use a getter only to expose the derived value as a public API—not to house the computation itself.
+Prefer `$derived` for any computation derived from reactive state. Use a getter
+only to expose the derived value as a public API.
 
 ```typescript
-// Correct: $derived holds the computation, getter exposes it
-const tabs = $derived(tabsMap.values().toArray().sort((a, b) => b.savedAt - a.savedAt));
+const tabs = $derived(
+	tabsView.all.toSorted((a, b) => b.savedAt - a.savedAt),
+);
+
 return {
-  get tabs() { return tabs; },
+	get tabs() {
+		return tabs;
+	},
 };
 ```
 
-This is the three-layer pattern: `fromTable` (reactive source) → `$derived` (cached computation) → `get` (public API). The getter is a pass-through, not a computation site.
+This is the three-layer pattern: `fromTable` reactive view, `$derived` cached
+computation, then a public getter. The getter is a pass-through, not a
+computation site.

--- a/docs/articles/how-createsubscriber-works.md
+++ b/docs/articles/how-createsubscriber-works.md
@@ -183,4 +183,4 @@ If your external events mutate `$state` directly, skip `createSubscriber`. The `
 
 ## Further Reading
 
-For a consumer-focused guide with practical examples (BroadcastChannel, IntersectionObserver, and more), see [Using createSubscriber](./using-createsubscriber.md). For choosing between `$state` and `createSubscriber` when both could work, see [`$state` vs `createSubscriber`: Who Owns the Reactivity?](./state-vs-createsubscriber-who-owns-reactivity.md). For a Yjs-specific example with shadow state and bidirectional sync, see [Syncing External State with createSubscriber](./svelte-5-createsubscriber-pattern.md).
+For a consumer-focused guide with practical examples (BroadcastChannel, IntersectionObserver, and more), see [Using createSubscriber](./using-createsubscriber.md). For choosing between `$state` and `createSubscriber` when both could work, see [`$state` vs `createSubscriber`: Who Owns the Reactivity?](./state-vs-createsubscriber-who-owns-reactivity.md). For a Yjs-specific readonly view example, see [Syncing External State with createSubscriber](./svelte-5-createsubscriber-pattern.md).

--- a/docs/articles/state-vs-createsubscriber-who-owns-reactivity.md
+++ b/docs/articles/state-vs-createsubscriber-who-owns-reactivity.md
@@ -179,4 +179,4 @@ For more worked examples—ResizeObserver, network status, SSE, RxJS, page visib
 
 ## Further Reading
 
-For a practical guide on using `createSubscriber` with real browser APIs, see [Using createSubscriber](./using-createsubscriber.md). For the version signal, reference counting, and `render_effect` internals, see [How createSubscriber Works](./how-createsubscriber-works.md). For a Yjs-specific example with shadow state and bidirectional sync, see [Syncing External State with createSubscriber](./svelte-5-createsubscriber-pattern.md).
+For a practical guide on using `createSubscriber` with real browser APIs, see [Using createSubscriber](./using-createsubscriber.md). For the version signal, reference counting, and `render_effect` internals, see [How createSubscriber Works](./how-createsubscriber-works.md). For a Yjs-specific readonly view example, see [Syncing External State with createSubscriber](./svelte-5-createsubscriber-pattern.md).

--- a/docs/articles/svelte-5-createsubscriber-pattern.md
+++ b/docs/articles/svelte-5-createsubscriber-pattern.md
@@ -95,38 +95,26 @@ export function reactiveCounter(externalStore: ExternalStore) {
 2. **Auto cleanup**: When no reactive consumers exist, `createSubscriber` calls your cleanup function
 3. **Single source of truth**: External store owns the data; `$state` is just a reactive mirror
 
-## Real World: Yjs CRDT to SvelteMap
+## Real World: Yjs Table to Readonly View
 
 ```typescript
-import { SvelteMap } from 'svelte/reactivity';
 import { createSubscriber } from 'svelte/reactivity';
 
-export function reactiveTable(yjsTable: YjsTableHelper) {
-	// Shadow state: SvelteMap for O(1) lookups
-	const rows = new SvelteMap<string, Row>();
-
-	// Initialize from current state
-	for (const row of yjsTable.getAll()) {
-		rows.set(row.id, row);
-	}
-
+export function readonlyTable(yjsTable: YjsTableHelper) {
 	const subscribe = createSubscriber((update) => {
-		return yjsTable.observeChanges((changes) => {
-			for (const [id, change] of changes) {
-				if (change.action === 'delete') rows.delete(id);
-				else rows.set(id, change.row);
-			}
+		return yjsTable.observeChanges(() => {
 			update();
 		});
 	});
 
 	return {
-		get rows() {
+		get all(): Row[] {
 			subscribe();
-			return rows;
+			return yjsTable.getAllValid();
 		},
-		upsert(row: Row) {
-			yjsTable.upsert(row); // Yjs handles it, observer updates SvelteMap
+		byId(id: string): Row | undefined {
+			subscribe();
+			return yjsTable.get(id);
 		},
 	};
 }
@@ -135,7 +123,7 @@ export function reactiveTable(yjsTable: YjsTableHelper) {
 ## The Flow
 
 ```
-Component calls upsert({ id: '1', title: 'Hello' })
+Component calls yjsTable.upsert({ id: '1', title: 'Hello' })
     │
     ▼
 yjsTable.upsert() ─── writes to ──► Yjs Y.Map
@@ -145,20 +133,16 @@ yjsTable.upsert() ─── writes to ──► Yjs Y.Map
 observeChanges callback fires
     │
     ▼
-rows.set('1', newRow) ─── updates ──► SvelteMap shadow state
-    │
-    ▼
 update() called
     │
     ▼
-Svelte re-renders components reading `rows`
+Svelte re-renders components reading `all` or `byId(id)`
 ```
 
-**No manual invalidation. No stale state. No race conditions.**
+No manual invalidation. No stale mirror state. No writable view API.
 
----
-
-This pattern has been solid for syncing Yjs CRDTs in a local-first app. Works great for any external store with an observe/subscribe API.
+The pattern is not Yjs-specific. It works for any external store with an
+observe or subscribe API where the external store remains the source of truth.
 
 ## Further Reading
 

--- a/docs/articles/svelte-5-createsubscriber-pattern.md
+++ b/docs/articles/svelte-5-createsubscriber-pattern.md
@@ -20,8 +20,8 @@ You have an external data source (WebSocket, IndexedDB, Yjs, Firebase, etc.) wit
 │                    createSubscriber                         │
 │                                                             │
 │   ┌─────────────┐    update()     ┌──────────────────┐     │
-│   │   Shadow    │ ◄────────────── │    Observer      │     │
-│   │   $state    │                 │    Callback      │     │
+│   │  Reactive   │ ◄────────────── │    Observer      │     │
+│   │   Signal    │                 │    Callback      │     │
 │   └─────────────┘                 └──────────────────┘     │
 │         │                                                   │
 │         │ subscribe()                                       │
@@ -42,7 +42,10 @@ You have an external data source (WebSocket, IndexedDB, Yjs, Firebase, etc.) wit
 └─────────────────────────────────────────────────────────────┘
 ```
 
-**Key insight**: Mutations go UP to the source. The source notifies the observer. The observer updates shadow state. Svelte reacts. You never mutate `$state` directly from components.
+**Key insight**: Mutations go UP to the source. The source notifies the observer.
+The observer calls `update()` and Svelte reacts. Your getter can either return a
+local mirror or live-read the external source, but components should not mutate
+the reactive facade directly.
 
 ## Minimal Example
 
@@ -93,7 +96,7 @@ export function reactiveCounter(externalStore: ExternalStore) {
 
 1. **Lazy subscription**: Observer only attaches when `value` is read in a reactive context (`$effect`, `$derived`, template)
 2. **Auto cleanup**: When no reactive consumers exist, `createSubscriber` calls your cleanup function
-3. **Single source of truth**: External store owns the data; `$state` is just a reactive mirror
+3. **Single source of truth**: External store owns the data; any local `$state` is only a mirror for reads
 
 ## Real World: Yjs Table to Readonly View
 

--- a/docs/articles/sveltemap-over-state-for-keyed-collections.md
+++ b/docs/articles/sveltemap-over-state-for-keyed-collections.md
@@ -1,8 +1,9 @@
-# Reactive Views Over $state for Keyed Collections
+# Keyed Collections: SvelteMap, fromTable, or $state
 
-When your data has IDs, workspace rows, conversations, recordings, and similar
-records should not live in a `$state` array. Use the domain source directly and
-derive the array form with `$derived` when you need it for rendering.
+When your data has IDs, workspace rows, conversations, recordings, browser
+tabs, and similar records should not default to a `$state` array. Use the
+keyed source that owns the data, then derive the array form with `$derived`
+when you need it for rendering.
 
 ## The Problem
 
@@ -22,7 +23,7 @@ That is O(n) on every access. Svelte also tracks the whole array, so updating
 one conversation re-renders anything that reads `conversations`, even if a
 component only cares about a single row.
 
-## Workspace Tables
+## Workspace Tables: fromTable
 
 Workspace tables use `fromTable()` from `@epicenter/svelte`. It returns a
 readonly view with two reads:
@@ -100,8 +101,20 @@ the last tracked reader is gone.
 ## When SvelteMap Still Fits
 
 Use `SvelteMap` for non-workspace keyed state that you own locally, such as
-browser tabs keyed by native tab ID. It is still the right primitive when the
-map itself is the mutable source.
+browser tabs keyed by native tab ID:
+
+```typescript
+const tabsById = new SvelteMap<number, BrowserTab>();
+
+const activeTab = $derived(tabsById.get(activeTabId));
+const visibleTabs = $derived(
+	tabsById.values().toArray().filter((tab) => !tab.hidden),
+);
+```
+
+It is still the right primitive when the map itself is the mutable source. A
+keyed read like `tabsById.get(activeTabId)` can update independently from a
+full-list read like `tabsById.values()`.
 
 Use `$state<T[]>` when:
 

--- a/docs/articles/sveltemap-over-state-for-keyed-collections.md
+++ b/docs/articles/sveltemap-over-state-for-keyed-collections.md
@@ -1,6 +1,8 @@
-# SvelteMap Over $state for Keyed Collections
+# Reactive Views Over $state for Keyed Collections
 
-When your data has IDs—workspace rows, conversations, recordings—store it in a `SvelteMap`, not a `$state` array. Derive the array form with `$derived` when you need it for rendering.
+When your data has IDs, workspace rows, conversations, recordings, and similar
+records should not live in a `$state` array. Use the domain source directly and
+derive the array form with `$derived` when you need it for rendering.
 
 ## The Problem
 
@@ -16,133 +18,97 @@ This works until you need to look one up:
 const metadata = $derived(conversations.find((c) => c.id === conversationId));
 ```
 
-That's O(n) on every access. Worse, Svelte's reactivity tracks the entire array—updating one conversation re-renders everything that reads `conversations`, even if they only care about a single item.
+That is O(n) on every access. Svelte also tracks the whole array, so updating
+one conversation re-renders anything that reads `conversations`, even if a
+component only cares about a single row.
 
-## The Fix: SvelteMap + $derived
+## Workspace Tables
+
+Workspace tables use `fromTable()` from `@epicenter/svelte`. It returns a
+readonly view with two reads:
 
 ```typescript
-const conversationsMap = fromTable(workspace.tables.conversations);
+const conversationsView = fromTable(workspace.tables.conversations);
 
 const conversations = $derived(
-    conversationsMap.values().toArray().sort((a, b) => b.updatedAt - a.updatedAt),
+	conversationsView.all.toSorted((a, b) => b.updatedAt - a.updatedAt),
 );
+
+const metadata = $derived(conversationsView.byId(conversationId));
 ```
 
-Two lines. The `SvelteMap` gives you O(1) lookups (`map.get(id)`), and Svelte tracks each key independently—updating conversation A doesn't re-render a component that only reads conversation B.
+`view.all` returns the current valid rows as an array. `view.byId(id)` returns
+one row or `undefined`. Both reads subscribe when used in a Svelte reactive
+context and read live table data without subscribing when used imperatively.
 
-The `$derived` array is a cached materialization. It recomputes only when the map changes, and it gives you a stable reference (critical for TanStack Table, which enters an infinite loop if `get data()` returns a new array on every call).
+The `$derived` array is a cached materialization. It recomputes when the table
+view invalidates, and it gives consumers a stable reference until then. That is
+important for TanStack Table, which can loop if `get data()` returns a new
+array on every access.
 
 ## The Three-Layer Pattern
 
-Every workspace-backed collection in this codebase follows this shape:
+Every workspace-backed collection in this codebase should follow this shape:
 
 ```typescript
-// 1. Map — reactive source (private, suffixed with Map)
-const recordingsMap = fromTable(workspace.tables.recordings);
+// 1. View: reactive source, private, suffixed with View
+const recordingsView = fromTable(workspace.tables.recordings);
 
-// 2. Derived array — cached materialization (private, no suffix)
+// 2. Derived array: cached materialization, private, no suffix
 const recordings = $derived(
-    recordingsMap.values().toArray().sort((a, b) => b.timestamp - a.timestamp),
+	recordingsView.all.toSorted((a, b) => b.timestamp - a.timestamp),
 );
 
-// 3. Getter — public API (matches the derived name)
+// 3. Getter: public API
 return {
-    get recordings() {
-        return recordings;
-    },
-    get(id: string) {
-        return recordingsMap.get(id);
-    },
+	get recordings() {
+		return recordings;
+	},
+	byId: recordingsView.byId,
 };
 ```
 
-Naming convention: `{name}Map` → `{name}` → `get {name}()`.
+Naming convention: `{name}View` to `{name}` to `get {name}()`.
 
-## What fromTable Does Under the Hood
+## What fromTable Does
 
-`fromTable()` from `@epicenter/svelte` wraps the manual SvelteMap + observe pattern into a single call:
+`fromTable()` wraps a workspace table with Svelte's public `createSubscriber`
+primitive:
 
 ```typescript
-export function fromTable<TRow extends BaseRow>(
-    table: TableHelper<TRow>,
-): SvelteMap<string, TRow> & { destroy: () => void } {
-    const map = new SvelteMap<string, TRow>();
+export function fromTable<TRow extends BaseRow>(table: Table<TRow>) {
+	const subscribe = createSubscriber((update) => table.observe(update));
 
-    // Seed with current valid rows
-    for (const row of table.getAllValid()) {
-        map.set(row.id, row);
-    }
-
-    // Granular updates — only touch changed rows
-    const unobserve = table.observe((changedIds) => {
-        for (const id of changedIds) {
-            const result = table.get(id);
-            switch (result.status) {
-                case 'valid':
-                    map.set(id, result.row);
-                    break;
-                case 'not_found':
-                case 'invalid':
-                    map.delete(id);
-                    break;
-            }
-        }
-    });
-
-    return Object.assign(map, { destroy: unobserve });
+	return {
+		get all(): TRow[] {
+			subscribe();
+			return table.getAllValid();
+		},
+		byId(id: string): TRow | undefined {
+			subscribe();
+			return table.get(id).data ?? undefined;
+		},
+	};
 }
 ```
 
-The observer fires on local writes, remote CRDT sync, and migration. You write to the workspace table (`workspace.tables.X.set()`), the observer picks it up, and the SvelteMap updates. Unidirectional—never write to the SvelteMap directly.
+The table remains the source of truth. Writes go through the workspace table or
+workspace actions. The view has no write methods and no manual dispose method.
+Svelte attaches the observer when a tracked read appears and detaches it after
+the last tracked reader is gone.
 
-## Why Not $state<T[]>?
+## When SvelteMap Still Fits
 
-Three concrete problems:
+Use `SvelteMap` for non-workspace keyed state that you own locally, such as
+browser tabs keyed by native tab ID. It is still the right primitive when the
+map itself is the mutable source.
 
-**1. O(n) lookups.** Every `.find(item => item.id === id)` scans the whole array. With a SvelteMap, `.get(id)` is O(1).
+Use `$state<T[]>` when:
 
-**2. Coarse reactivity.** Svelte's deep proxy on `$state` arrays tracks the array structure. Mutating one item re-triggers any `$derived` that reads the array, even if it only cares about a different item. SvelteMap tracks each key independently.
+- Items do not have stable IDs, such as terminal history entries.
+- Order is the primary concern, such as open file tab order.
+- The list is small local UI state.
+- Values are primitives without row identity.
 
-**3. Referential instability.** If you derive a sorted array inside a getter (not `$derived`), every access creates a new array. TanStack Table's internal `$derived` sees "data changed" → updates internal `$state` → re-triggers `$derived` → infinite loop → page freeze.
-
-`$derived` caches the result, so consumers get the same reference until the underlying SvelteMap actually changes.
-
-## When $state Arrays Are Fine
-
-Not every array needs a SvelteMap. Use `$state<T[]>` when:
-
-- **Items don't have stable IDs.** Terminal history entries, command history strings—sequential data without identity.
-- **Order is the primary concern.** Open file tabs (`$state<FileId[]>`) where the position in the array is the point, not keyed lookup.
-- **The list is local UI state.** Small arrays that aren't workspace-backed and don't need granular per-item reactivity.
-- **Primitives.** `$state<string[]>` for a list of tags—no identity, no object structure to track granularly.
-
-The rule: if items have IDs and you'll ever need `.find()` or `.get()`, use SvelteMap.
-
-## The .observe() Sync Mechanism
-
-The workspace `.observe()` callback receives a `Set<string>` of changed IDs. This is how SvelteMap stays in sync across multiple clients:
-
-```
-User A writes → Yjs CRDT updates → observer fires on User A's device
-                                 → CRDT syncs to User B
-                                 → observer fires on User B's device
-                                 → SvelteMap.set() → UI re-renders
-```
-
-Both `fromTable()` and manual `.observe()` implementations follow the same loop: re-read each changed ID from the table, update or delete in the SvelteMap. The table is the source of truth—the SvelteMap is a reactive projection.
-
-## Decision Tree
-
-```
-Your data has items with IDs?
-├─ YES → Use SvelteMap
-│   ├─ Workspace table? → fromTable()
-│   ├─ Workspace KV (single key)? → fromKv()
-│   ├─ Browser API (Chrome tabs)? → new SvelteMap() + event listeners
-│   └─ Need sorted/filtered array? → $derived(map.values().toArray().sort(...))
-│
-└─ NO → $state is fine
-    ├─ Primitives (boolean, string, number) → $state(value)
-    ├─ Sequential data without IDs → $state<T[]>([])
-    └─ Ordered list where position matters → $state<T[]>([])
-```
+The rule: if it is a workspace table, use `fromTable()`. If it is local keyed
+state, use `SvelteMap`. If it is sequential local state, use `$state<T[]>`.

--- a/docs/articles/using-createsubscriber.md
+++ b/docs/articles/using-createsubscriber.md
@@ -409,4 +409,4 @@ The external source is the state. `createSubscriber` is the notification channel
 
 ## Further Reading
 
-For a Yjs-specific example with shadow `SvelteMap` state and bidirectional mutations, see [Syncing External State with createSubscriber](./svelte-5-createsubscriber-pattern.md). For the version signal, reference counting, and `render_effect` internals, see [How createSubscriber Works](./how-createsubscriber-works.md). For choosing between `$state` and `createSubscriber` when both could work, see [`$state` vs `createSubscriber`: Who Owns the Reactivity?](./state-vs-createsubscriber-who-owns-reactivity.md).
+For a Yjs-specific readonly view example, see [Syncing External State with createSubscriber](./svelte-5-createsubscriber-pattern.md). For the version signal, reference counting, and `render_effect` internals, see [How createSubscriber Works](./how-createsubscriber-works.md). For choosing between `$state` and `createSubscriber` when both could work, see [`$state` vs `createSubscriber`: Who Owns the Reactivity?](./state-vs-createsubscriber-who-owns-reactivity.md).

--- a/docs/articles/vite-hmr-is-not-a-page-reload.md
+++ b/docs/articles/vite-hmr-is-not-a-page-reload.md
@@ -13,65 +13,69 @@ observers, intervals, or sockets are still alive.
 That means this can be fine for the page lifetime:
 
 ```typescript
-function createBookmarkState() {
-	const bookmarksMap = fromTable(workspace.tables.bookmarks);
-	const bookmarks = $derived([...bookmarksMap.values()]);
+function createSidebarState() {
+	let width = $state(280);
+
+	const unwatchStorage = watchStorage('sidebar-width', (nextWidth) => {
+		width = nextWidth;
+	});
 
 	return {
-		get bookmarks() {
-			return bookmarks;
+		get width() {
+			return width;
 		},
 	};
 }
 
-export const bookmarkState = createBookmarkState();
+export const sidebarState = createSidebarState();
 ```
 
-But during HMR, every updated module copy can add another table observer. The
+But during HMR, every updated module copy can add another storage watcher. The
 page did not reload, so nothing automatically removed the previous one.
 
 Make the singleton disposable:
 
 ```typescript
-function createBookmarkState() {
-	const bookmarksMap = fromTable(workspace.tables.bookmarks);
-	const bookmarks = $derived([...bookmarksMap.values()]);
+function createSidebarState() {
+	let width = $state(280);
+
+	const unwatchStorage = watchStorage('sidebar-width', (nextWidth) => {
+		width = nextWidth;
+	});
 
 	return {
 		[Symbol.dispose]() {
-			bookmarksMap[Symbol.dispose]();
+			unwatchStorage();
 		},
 
-		get bookmarks() {
-			return bookmarks;
+		get width() {
+			return width;
 		},
 	};
 }
 
-export const bookmarkState = createBookmarkState();
+export const sidebarState = createSidebarState();
 
 if (import.meta.hot) {
-	import.meta.hot.dispose(() => bookmarkState[Symbol.dispose]());
+	import.meta.hot.dispose(() => sidebarState[Symbol.dispose]());
 }
 ```
 
-This is not a `fromTable()` rule. `fromTable()` is just the example in front of
-us. The more general rule is ownership: the module created a persistent side
-effect, so the module owns the HMR teardown.
+This is an ownership rule. The module created a persistent side effect, so the
+module owns the HMR teardown.
 
 ```txt
-fromTable()
-  owns one Yjs observer
+watchStorage()
+  owns one browser storage listener
 
-createBookmarkState()
-  owns the fromTable() map
+createSidebarState()
+  owns the storage watcher
 
-bookmark-state.svelte.ts
+sidebar-state.svelte.ts
   owns the module singleton during HMR
 ```
 
-The same shape applies to a storage watcher, a browser event listener, an
-interval, or a socket:
+The same shape applies to a browser event listener, an interval, or a socket:
 
 ```typescript
 function createSidebarState() {
@@ -106,6 +110,11 @@ if (import.meta.hot) {
 
 Vite documents `hot.dispose(cb)` as the hook for persistent side effects created
 by the old module copy. That is the exact situation here.
+
+`fromTable()` is different now. It returns a readonly view backed by
+`createSubscriber`; the table observer attaches while reactive consumers read
+`view.all` or `view.byId(id)`, then detaches when those consumers are gone. Do
+not add HMR cleanup just to dispose a `fromTable()` view.
 
 Do not put this cleanup in a random component. The component did not create the
 module singleton. The module did.

--- a/docs/specs/20260406T150000 opensidian-internal-links-handoff.md
+++ b/docs/specs/20260406T150000 opensidian-internal-links-handoff.md
@@ -95,7 +95,7 @@ export const fs = createYjsFileSystem(
 - `fsState.selectFile(id)` — navigate to a file (sets activeFileId + opens tab)
 - `fsState.getFile(id)` — get FileRow by ID
 - `fsState.walkTree(visitor)` — walk the file tree, collecting results
-- `fromTable(workspace.tables.files)` — reactive SvelteMap of all file rows
+- `fromTable(workspace.tables.files)`: readonly view of all file rows via `all` and `byId(id)`
 
 ### Current Editor Components
 

--- a/packages/auth/src/create-auth.ts
+++ b/packages/auth/src/create-auth.ts
@@ -9,11 +9,11 @@ import {
 	type InferErrors,
 } from 'wellcrafted/error';
 import { Ok, type Result } from 'wellcrafted/result';
+import type { AuthIdentity, AuthUser, BearerSession } from './auth-types.ts';
 import {
 	type BetterAuthSessionResponse,
 	bearerSessionFromBetterAuthSessionResponse,
 } from './contracts/auth-session.ts';
-import type { AuthIdentity, AuthUser, BearerSession } from './auth-types.ts';
 
 export const AuthError = defineErrors({
 	InvalidCredentials: () => ({

--- a/packages/auth/src/node.ts
+++ b/packages/auth/src/node.ts
@@ -1,14 +1,14 @@
 export {
 	createMachineAuthClient,
-	MachineAuthRequestError,
 	DeviceTokenError,
 	loginWithDeviceCode,
-	status,
 	logout,
+	MachineAuthRequestError,
+	status,
 } from './node/machine-auth.js';
 export {
 	loadMachineSession,
-	saveMachineSession,
 	MachineAuthStorageError,
+	saveMachineSession,
 } from './node/machine-session-store.js';
 export { requireSignedIn } from './require-signed-in.ts';

--- a/packages/auth/src/node/machine-auth.test.ts
+++ b/packages/auth/src/node/machine-auth.test.ts
@@ -16,11 +16,7 @@ import type { BetterAuthOptions } from 'better-auth';
 import { createAuthClient, InferPlugin } from 'better-auth/client';
 import { deviceAuthorizationClient } from 'better-auth/client/plugins';
 import type { customSession } from 'better-auth/plugins';
-import {
-	createLogger,
-	memorySink,
-	type Logger,
-} from 'wellcrafted/logger';
+import { createLogger, type Logger, memorySink } from 'wellcrafted/logger';
 import type { BearerSession } from '../auth-types.js';
 import type { BetterAuthSessionResponse } from '../contracts/auth-session.js';
 import {
@@ -32,8 +28,8 @@ import {
 } from './machine-auth.js';
 import {
 	loadMachineSession,
-	saveMachineSession,
 	type MachineAuthStorageError,
+	saveMachineSession,
 } from './machine-session-store.js';
 
 type Expect<TValue extends true> = TValue;
@@ -300,7 +296,9 @@ describe('machine auth free functions', () => {
 
 	test('logout signs out and clears the stored session', async () => {
 		const backend = makeMemoryKeychainBackend();
-		await saveMachineSession(makeSession({ token: 'logout-token' }), { backend });
+		await saveMachineSession(makeSession({ token: 'logout-token' }), {
+			backend,
+		});
 		const seenTokens: string[] = [];
 		const fetchImpl = (async (_input, init) => {
 			seenTokens.push(new Headers(init?.headers).get('authorization') ?? '');

--- a/packages/auth/src/node/machine-auth.ts
+++ b/packages/auth/src/node/machine-auth.ts
@@ -36,10 +36,11 @@ const rawDefaultAuthClient = createAuthClient({
 	],
 });
 
-const defaultAuthClient = rawDefaultAuthClient as typeof rawDefaultAuthClient & {
-	deviceCode: typeof rawDefaultAuthClient.device.code;
-	deviceToken: typeof rawDefaultAuthClient.device.token;
-};
+const defaultAuthClient =
+	rawDefaultAuthClient as typeof rawDefaultAuthClient & {
+		deviceCode: typeof rawDefaultAuthClient.device.code;
+		deviceToken: typeof rawDefaultAuthClient.device.token;
+	};
 
 type MachineAuthClient = typeof defaultAuthClient;
 

--- a/packages/auth/src/node/machine-session-store.ts
+++ b/packages/auth/src/node/machine-session-store.ts
@@ -4,7 +4,7 @@ import {
 	type InferErrors,
 } from 'wellcrafted/error';
 import { createLogger, type Logger } from 'wellcrafted/logger';
-import { Err, Ok, tryAsync, type Result } from 'wellcrafted/result';
+import { Err, Ok, type Result, tryAsync } from 'wellcrafted/result';
 import {
 	BearerSession,
 	type BearerSession as BearerSessionType,

--- a/packages/cli/src/commands/run-peer-errors.test.ts
+++ b/packages/cli/src/commands/run-peer-errors.test.ts
@@ -8,10 +8,7 @@
  */
 
 import { afterEach, describe, expect, spyOn, test } from 'bun:test';
-import {
-	PeerAddressError,
-	RpcError,
-} from '@epicenter/workspace';
+import { PeerAddressError, RpcError } from '@epicenter/workspace';
 import type { RunSyncStatus } from '@epicenter/workspace/node';
 import type { AwarenessState } from '../load-config';
 import { emitRemoteCallError } from './run';

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -24,8 +24,8 @@ import {
 } from '@epicenter/workspace';
 import {
 	type DaemonError,
-	getDaemon,
 	type RunError as DaemonRunError,
+	getDaemon,
 	type RunRequest,
 	type RunSyncStatus,
 } from '@epicenter/workspace/node';
@@ -176,7 +176,11 @@ export function emitRemoteCallError(
 			emitMissError(cause.peerTarget, cause.sawPeers, cause.waitMs, syncStatus);
 			return;
 		case 'PeerLeft':
-			emitPeerLeftError(cause.peerTarget, cause.targetClientId, cause.peerState);
+			emitPeerLeftError(
+				cause.peerTarget,
+				cause.targetClientId,
+				cause.peerState,
+			);
 			return;
 		case 'ActionNotFound':
 		case 'Timeout':

--- a/packages/cli/src/util/format-output.test.ts
+++ b/packages/cli/src/util/format-output.test.ts
@@ -10,8 +10,7 @@ import { output } from './format-output.js';
 function captureStdout(fn: () => void): string {
 	const original = console.log;
 	const lines: string[] = [];
-	console.log = (...args: unknown[]) =>
-		lines.push(args.map(String).join(' '));
+	console.log = (...args: unknown[]) => lines.push(args.map(String).join(' '));
 	try {
 		fn();
 	} finally {

--- a/packages/cli/test/fixtures/inline-actions/epicenter.config.ts
+++ b/packages/cli/test/fixtures/inline-actions/epicenter.config.ts
@@ -6,9 +6,9 @@
  */
 
 import {
+	type AwarenessAttachment,
 	defineMutation,
 	defineQuery,
-	type AwarenessAttachment,
 	type PeerAwarenessSchema,
 	type RemoteClient,
 	type SyncAttachment,

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -1,7 +1,7 @@
 export { SKILLS_WORKSPACE_ID } from './constants.js';
 export { referenceContentDocGuid } from './reference-content-docs.js';
-export { createSkillsActions, type SkillsTables } from './skills-actions.js';
 export { skillInstructionsDocGuid } from './skill-instructions-docs.js';
+export { createSkillsActions, type SkillsTables } from './skills-actions.js';
 export type { Reference, Skill } from './tables.js';
 export { referencesTable, skillsTable } from './tables.js';
-export { openSkills, type OpenSkillsOptions } from './workspace.js';
+export { type OpenSkillsOptions, openSkills } from './workspace.js';

--- a/packages/skills/src/node.ts
+++ b/packages/skills/src/node.ts
@@ -30,13 +30,13 @@ import {
 	onLocalUpdate,
 } from '@epicenter/workspace';
 import Type from 'typebox';
-import * as Y from 'yjs';
 import {
 	defineErrors,
 	extractErrorMessage,
 	type InferErrors,
 } from 'wellcrafted/error';
 import { Ok, tryAsync } from 'wellcrafted/result';
+import * as Y from 'yjs';
 import { parseSkillMd } from './parse.js';
 import { referenceContentDocGuid } from './reference-content-docs.js';
 import { serializeSkillMd } from './serialize.js';
@@ -45,8 +45,8 @@ import { createSkillsActions } from './skills-actions.js';
 import type { Skill } from './tables.js';
 import { openSkills } from './workspace.js';
 
-export type { Reference, Skill } from './tables.js';
 export { SKILLS_WORKSPACE_ID } from './constants.js';
+export type { Reference, Skill } from './tables.js';
 export { referencesTable, skillsTable } from './tables.js';
 
 const DirInput = Type.Object({ dir: Type.String() });

--- a/packages/svelte-utils/package.json
+++ b/packages/svelte-utils/package.json
@@ -40,6 +40,7 @@
 		"typescript": "catalog:"
 	},
 	"scripts": {
+		"test": "bun test --conditions browser src/*.test.ts",
 		"typecheck": "svelte-check --tsconfig ./tsconfig.json"
 	},
 	"license": "MIT"

--- a/packages/svelte-utils/src/auth-form/auth-form.svelte
+++ b/packages/svelte-utils/src/auth-form/auth-form.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
+	import type { AuthClient } from '@epicenter/auth-svelte';
 	import { Button } from '@epicenter/ui/button';
 	import * as Field from '@epicenter/ui/field';
 	import { Input } from '@epicenter/ui/input';
 	import { Spinner } from '@epicenter/ui/spinner';
-	import type { AuthClient } from '@epicenter/auth-svelte';
 
 	let {
 		auth,

--- a/packages/svelte-utils/src/from-kv.svelte.ts
+++ b/packages/svelte-utils/src/from-kv.svelte.ts
@@ -1,8 +1,4 @@
-import type {
-	InferKvValue,
-	KvDefinitions,
-	Kv,
-} from '@epicenter/workspace';
+import type { InferKvValue, Kv, KvDefinitions } from '@epicenter/workspace';
 import { createSubscriber } from 'svelte/reactivity';
 
 /**
@@ -33,10 +29,7 @@ import { createSubscriber } from 'svelte/reactivity';
 export function fromKv<
 	TDefs extends KvDefinitions,
 	K extends keyof TDefs & string,
->(
-	kv: Kv<TDefs>,
-	key: K,
-): { current: InferKvValue<TDefs[K]> } {
+>(kv: Kv<TDefs>, key: K): { current: InferKvValue<TDefs[K]> } {
 	const subscribe = createSubscriber((update) => {
 		return kv.observe(key, update);
 	});

--- a/packages/svelte-utils/src/from-table.svelte.test.ts
+++ b/packages/svelte-utils/src/from-table.svelte.test.ts
@@ -1,0 +1,217 @@
+/**
+ * fromTable Tests
+ *
+ * Verifies the readonly table view wraps workspace tables with Svelte's
+ * createSubscriber lifecycle instead of a mirrored SvelteMap.
+ *
+ * Key behaviors:
+ * - First tracked read attaches a table observer
+ * - Last tracked reader teardown detaches the observer
+ * - Untracked reads return live table data without subscribing
+ * - Table writes invalidate derived readers
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { BaseRow, Table } from '@epicenter/workspace';
+import type { Component } from 'svelte';
+import { flushSync, mount, unmount } from 'svelte';
+import { compile } from 'svelte/compiler';
+import { fromTable } from './from-table.svelte.js';
+
+type TestRow = BaseRow & {
+	_v: 1;
+	value: string;
+};
+
+type TableView = ReturnType<typeof fromTable<TestRow>>;
+type TestComponent = Component<{
+	report(value: string): void;
+	view: TableView;
+}>;
+
+class TestNode {
+	childNodes: TestNode[] = [];
+	parentNode: TestNode | null = null;
+	nodeType = 1;
+	nodeName: string;
+	private text = '';
+
+	constructor(nodeName: string) {
+		this.nodeName = nodeName;
+	}
+
+	get firstChild(): TestNode | null {
+		return this.childNodes[0] ?? null;
+	}
+
+	get nextSibling(): TestNode | null {
+		if (this.parentNode === null) return null;
+		const index = this.parentNode.childNodes.indexOf(this);
+		return this.parentNode.childNodes[index + 1] ?? null;
+	}
+
+	get textContent(): string {
+		return this.text;
+	}
+
+	set textContent(value: string) {
+		this.text = value;
+	}
+
+	appendChild(node: TestNode): TestNode {
+		this.childNodes.push(node);
+		node.parentNode = this;
+		return node;
+	}
+
+	insertBefore(node: TestNode, anchor: TestNode | null): TestNode {
+		const index = anchor === null ? -1 : this.childNodes.indexOf(anchor);
+		if (index >= 0) {
+			this.childNodes.splice(index, 0, node);
+		} else {
+			this.childNodes.push(node);
+		}
+		node.parentNode = this;
+		return node;
+	}
+
+	removeChild(node: TestNode): TestNode {
+		const index = this.childNodes.indexOf(node);
+		if (index >= 0) this.childNodes.splice(index, 1);
+		node.parentNode = null;
+		return node;
+	}
+}
+
+class TestElement extends TestNode {}
+class TestText extends TestNode {}
+
+function installBrowserGlobals(): void {
+	const document = {
+		createComment: () => new TestNode('#comment'),
+		createElement: (name: string) => new TestElement(name),
+		createTextNode: (text: string) => {
+			const node = new TestText('#text');
+			node.textContent = text;
+			return node;
+		},
+	};
+
+	Object.assign(globalThis, {
+		document,
+		Element: TestElement,
+		navigator: { userAgent: 'bun-test' },
+		Node: TestNode,
+		Text: TestText,
+		window: { document },
+	});
+}
+
+async function compileCounterComponent(): Promise<TestComponent> {
+	const source = `
+		<script>
+			let { view, report } = $props();
+			const rows = $derived(view.all);
+			$effect(() => {
+				report(rows.map((row) => row.value).join(','));
+			});
+		</script>
+	`;
+	const { js } = compile(source, { generate: 'client' });
+	const url = `data:text/javascript;base64,${Buffer.from(js.code).toString('base64')}`;
+	const module = await import(url);
+	return module.default as TestComponent;
+}
+
+function setupTable(initialRows: TestRow[] = []) {
+	const rows = new Map(initialRows.map((row) => [row.id, row]));
+	const observers = new Set<() => void>();
+
+	const table = {
+		get(id: string) {
+			return { data: rows.get(id) ?? null };
+		},
+		getAllValid() {
+			return [...rows.values()];
+		},
+		observe(update: () => void) {
+			observers.add(update);
+			return () => {
+				observers.delete(update);
+			};
+		},
+	} as unknown as Table<TestRow>;
+
+	return {
+		observers,
+		set(row: TestRow) {
+			rows.set(row.id, row);
+			for (const update of [...observers]) update();
+		},
+		table,
+	};
+}
+
+function row(id: string, value: string): TestRow {
+	return { id, value, _v: 1 };
+}
+
+describe('fromTable', () => {
+	test('tracked read attaches the observer and teardown detaches it', async () => {
+		installBrowserGlobals();
+		const Counter = await compileCounterComponent();
+		const setup = setupTable([row('a', 'alpha')]);
+		const view = fromTable(setup.table);
+		const reports: string[] = [];
+
+		const component = mount(Counter, {
+			target: new TestElement('main') as unknown as Element,
+			props: { view, report: (value: string) => reports.push(value) },
+		});
+
+		flushSync();
+		expect(setup.observers.size).toBe(1);
+		expect(reports).toEqual(['alpha']);
+
+		await unmount(component);
+		await Promise.resolve();
+
+		expect(setup.observers.size).toBe(0);
+	});
+
+	test('untracked reads return live table data without subscribing', () => {
+		const setup = setupTable([row('a', 'alpha')]);
+		const view = fromTable(setup.table);
+
+		expect(view.all).toEqual([row('a', 'alpha')]);
+		expect(view.byId('a')).toEqual(row('a', 'alpha'));
+		expect(setup.observers.size).toBe(0);
+
+		setup.set(row('b', 'beta'));
+
+		expect(view.all).toEqual([row('a', 'alpha'), row('b', 'beta')]);
+		expect(view.byId('b')).toEqual(row('b', 'beta'));
+		expect(setup.observers.size).toBe(0);
+	});
+
+	test('table writes propagate to a derived reader', async () => {
+		installBrowserGlobals();
+		const Counter = await compileCounterComponent();
+		const setup = setupTable([row('a', 'alpha')]);
+		const view = fromTable(setup.table);
+		const reports: string[] = [];
+
+		const component = mount(Counter, {
+			target: new TestElement('main') as unknown as Element,
+			props: { view, report: (value: string) => reports.push(value) },
+		});
+
+		flushSync();
+		setup.set(row('b', 'beta'));
+		flushSync();
+
+		expect(reports).toEqual(['alpha', 'alpha,beta']);
+
+		await unmount(component);
+	});
+});

--- a/packages/svelte-utils/src/from-table.svelte.test.ts
+++ b/packages/svelte-utils/src/from-table.svelte.test.ts
@@ -2,7 +2,7 @@
  * fromTable Tests
  *
  * Verifies the readonly table view wraps workspace tables with Svelte's
- * createSubscriber lifecycle instead of a mirrored SvelteMap.
+ * createSubscriber lifecycle.
  *
  * Key behaviors:
  * - First tracked read attaches a table observer

--- a/packages/svelte-utils/src/from-table.svelte.ts
+++ b/packages/svelte-utils/src/from-table.svelte.ts
@@ -1,77 +1,32 @@
 import type { BaseRow, Table } from '@epicenter/workspace';
-import { SvelteMap } from 'svelte/reactivity';
-
-export type ReactiveTableMap<TRow extends BaseRow> = SvelteMap<string, TRow> &
-	Disposable;
+import { createSubscriber } from 'svelte/reactivity';
 
 /**
- * Create a reactive SvelteMap binding to a workspace table.
+ * Create a reactive readonly view over a workspace table.
  *
- * Returns a `SvelteMap<id, Row>` that stays in sync with the underlying
- * Yjs table via granular per-row updates. Only changed rows trigger
- * re-renders, not the entire collection.
- *
- * Read-only: mutations go through `table.set()`, `table.update()`, etc.
- * The observer picks up changes from both local writes and remote CRDT sync.
- *
- * The returned map is disposable. Call `[Symbol.dispose]()` when the binding
- * has a shorter lifetime than the workspace, such as component teardown,
- * workspace switching, HMR, or tests.
+ * The returned view reads live Yjs state on every access. Reading `all` or
+ * `byId(id)` inside a Svelte effect subscribes to table updates; outside an
+ * effect, the same access returns current data without opening an observer.
  *
  * @example
  * ```typescript
  * const entries = fromTable(workspaceClient.tables.entries);
  *
- * // Per-item access (reactive):
- * const entry = entries.get(id);
- *
- * // Iterate (reactive):
- * for (const [id, entry] of entries) { ... }
- *
- * // Array access:
- * const all = [...entries.values()];
- *
- * // Derived state:
- * const filtered = $derived([...entries.values()].filter(e => !e.deletedAt));
- *
- * // Teardown:
- * entries[Symbol.dispose]();
+ * const all = $derived(entries.all);
+ * const selected = $derived(entries.byId(selectedId));
  * ```
  */
-export function fromTable<TRow extends BaseRow>(
-	table: Table<TRow>,
-): ReactiveTableMap<TRow> {
-	const map = new SvelteMap<string, TRow>();
+export function fromTable<TRow extends BaseRow>(table: Table<TRow>) {
+	const subscribe = createSubscriber((update) => table.observe(update));
 
-	// Seed with current valid rows
-	for (const row of table.getAllValid()) {
-		map.set(row.id, row);
-	}
-
-	// Granular updates: only touch changed rows
-	const unobserve = table.observe((changedIds) => {
-		for (const id of changedIds) {
-			const { data: row, error } = table.get(id);
-			if (error || row === null) {
-				// This map only exposes valid rows. Invalid stored data and missing
-				// rows both leave the reactive view.
-				map.delete(id);
-				continue;
-			}
-
-			map.set(id, row);
-		}
-	});
-	let disposed = false;
-
-	Object.defineProperty(map, Symbol.dispose, {
-		value() {
-			if (disposed) return;
-			disposed = true;
-			unobserve();
+	return {
+		get all(): TRow[] {
+			subscribe();
+			return table.getAllValid();
 		},
-		enumerable: false,
-	});
-
-	return map as ReactiveTableMap<TRow>;
+		byId(id: string): TRow | undefined {
+			subscribe();
+			return table.get(id).data ?? undefined;
+		},
+	};
 }

--- a/packages/svelte-utils/src/from-table.svelte.ts
+++ b/packages/svelte-utils/src/from-table.svelte.ts
@@ -1,21 +1,7 @@
 import type { BaseRow, Table } from '@epicenter/workspace';
 import { createSubscriber } from 'svelte/reactivity';
 
-/**
- * Create a reactive readonly view over a workspace table.
- *
- * The returned view reads live Yjs state on every access. Reading `all` or
- * `byId(id)` inside a Svelte effect subscribes to table updates; outside an
- * effect, the same access returns current data without opening an observer.
- *
- * @example
- * ```typescript
- * const entries = fromTable(workspaceClient.tables.entries);
- *
- * const all = $derived(entries.all);
- * const selected = $derived(entries.byId(selectedId));
- * ```
- */
+/** Create a reactive readonly view over a workspace table. */
 export function fromTable<TRow extends BaseRow>(table: Table<TRow>) {
 	const subscribe = createSubscriber((update) => table.observe(update));
 

--- a/packages/svelte-utils/src/index.ts
+++ b/packages/svelte-utils/src/index.ts
@@ -1,7 +1,6 @@
 export { createAiChatFetch } from './create-ai-chat-fetch.js';
 export { fromKv } from './from-kv.svelte.js';
-export { fromTable, type ReactiveTableMap } from './from-table.svelte.js';
-export { useCacheHandle } from './use-cache-handle.svelte.js';
+export { fromTable } from './from-table.svelte.js';
 export {
 	createPersistedMap,
 	defineEntry,
@@ -17,3 +16,4 @@ export {
 	type Session,
 	type SignedInBase,
 } from './session.svelte.js';
+export { useCacheHandle } from './use-cache-handle.svelte.js';

--- a/packages/svelte-utils/src/index.ts
+++ b/packages/svelte-utils/src/index.ts
@@ -1,7 +1,7 @@
 export { createAiChatFetch } from './create-ai-chat-fetch.js';
-export { fromDisposableCache } from './from-disposable-cache.svelte.js';
 export { fromKv } from './from-kv.svelte.js';
 export { fromTable, type ReactiveTableMap } from './from-table.svelte.js';
+export { useCacheHandle } from './use-cache-handle.svelte.js';
 export {
 	createPersistedMap,
 	defineEntry,

--- a/packages/svelte-utils/src/use-cache-handle.svelte.ts
+++ b/packages/svelte-utils/src/use-cache-handle.svelte.ts
@@ -1,8 +1,12 @@
 import type { DisposableCache } from '@epicenter/workspace';
 
 /**
- * Reactive binding to a disposable cache. Opens a handle for the current id
- * and disposes it on unmount or id swap.
+ * Component-scoped binding to a disposable cache. Opens a handle for the
+ * current id and disposes it on unmount or id swap.
+ *
+ * Component-only: this helper uses `$effect`, so it must be called from a
+ * `.svelte` component (or another `$effect` context). It cannot be called
+ * from a `.svelte.ts` factory at module top.
  *
  * The id is read through `idFn` inside a `$derived`, so the handle tracks
  * prop/state changes. When the id changes, the cache opens a handle for the
@@ -13,7 +17,7 @@ import type { DisposableCache } from '@epicenter/workspace';
  * `state_referenced_locally` warning. Passing a function keeps the read
  * inside the derived's closure.
  */
-export function fromDisposableCache<
+export function useCacheHandle<
 	TId extends string | number,
 	TValue extends Disposable,
 >(

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -8,6 +8,19 @@
  * `@epicenter/sync/server` instead.
  */
 
+// WebSocket subprotocol auth (shared client/server constants + helpers)
+export {
+	BEARER_SUBPROTOCOL_PREFIX,
+	extractBearerToken,
+	MAIN_SUBPROTOCOL,
+	parseSubprotocols,
+} from './auth-subprotocol';
+// Transport origin sentinels (shared across all sync layers)
+export {
+	BC_ORIGIN,
+	isTransportOrigin,
+	SYNC_ORIGIN,
+} from './origins';
 // Protocol (encode/decode for WS messages and HTTP sync requests)
 export {
 	type DecodedRpcMessage,
@@ -32,21 +45,5 @@ export {
 	type SyncMessageType,
 	stateVectorsEqual,
 } from './protocol';
-
 // RPC error variants and type guard (used by both server and client)
 export { isRpcError, RpcError } from './rpc-errors';
-
-// Transport origin sentinels (shared across all sync layers)
-export {
-	BC_ORIGIN,
-	SYNC_ORIGIN,
-	isTransportOrigin,
-} from './origins';
-
-// WebSocket subprotocol auth (shared client/server constants + helpers)
-export {
-	BEARER_SUBPROTOCOL_PREFIX,
-	MAIN_SUBPROTOCOL,
-	extractBearerToken,
-	parseSubprotocols,
-} from './auth-subprotocol';

--- a/packages/sync/src/origins.ts
+++ b/packages/sync/src/origins.ts
@@ -32,10 +32,7 @@ export const BC_ORIGIN = Symbol.for('@epicenter/sync/bc-origin');
  * Realtime transport listeners use this list to avoid forwarding an update
  * back through another realtime transport.
  */
-const TRANSPORT_ORIGINS: readonly unknown[] = [
-	SYNC_ORIGIN,
-	BC_ORIGIN,
-];
+const TRANSPORT_ORIGINS: readonly unknown[] = [SYNC_ORIGIN, BC_ORIGIN];
 
 export function isTransportOrigin(origin: unknown): boolean {
 	return TRANSPORT_ORIGINS.includes(origin);

--- a/packages/sync/src/protocol.test.ts
+++ b/packages/sync/src/protocol.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
+import { Ok } from 'wellcrafted/result';
 import {
 	Awareness,
 	applyAwarenessUpdate,
@@ -34,7 +35,6 @@ import {
 	RPC_TYPE,
 	SYNC_MESSAGE_TYPE,
 } from './protocol';
-import { Ok } from 'wellcrafted/result';
 import { RpcError } from './rpc-errors';
 
 // ============================================================================
@@ -49,7 +49,6 @@ describe('MESSAGE_TYPE constants', () => {
 		expect(MESSAGE_TYPE.AUTH).toBe(2);
 		expect(MESSAGE_TYPE.QUERY_AWARENESS).toBe(3);
 	});
-
 });
 
 // ============================================================================

--- a/packages/ui/src/github-button/github-button.svelte
+++ b/packages/ui/src/github-button/github-button.svelte
@@ -18,10 +18,10 @@
 </script>
 
 <script lang="ts">
-	import Button from '#/button/button.svelte';
-	import { cn } from '#/utils';
 	import { cubicInOut } from 'svelte/easing';
 	import { Tween } from 'svelte/motion';
+	import Button from '#/button/button.svelte';
+	import { cn } from '#/utils';
 
 	let {
 		starsTweenedDuration = 5000,

--- a/packages/ui/src/github-button/index.ts
+++ b/packages/ui/src/github-button/index.ts
@@ -16,7 +16,7 @@ import Root from './github-button.svelte';
 export async function getStars({
 	owner,
 	repo: repoName,
-	fallback = 0
+	fallback = 0,
 }: {
 	owner: string;
 	repo: string;

--- a/packages/ui/src/natural-language-date-input/datetime-string.test.ts
+++ b/packages/ui/src/natural-language-date-input/datetime-string.test.ts
@@ -4,7 +4,10 @@ import { localTimezone, toDateTimeString } from './datetime-string.js';
 
 describe('toDateTimeString', () => {
 	it('formats UTC date and timezone with a pipe separator', () => {
-		const value = toDateTimeString(new Date('2024-01-01T20:00:00.000Z'), 'America/New_York');
+		const value = toDateTimeString(
+			new Date('2024-01-01T20:00:00.000Z'),
+			'America/New_York',
+		);
 
 		expect(value).toBe('2024-01-01T20:00:00.000Z|America/New_York');
 		expect(value).toContain('|');

--- a/packages/ui/src/natural-language-date-input/datetime-string.ts
+++ b/packages/ui/src/natural-language-date-input/datetime-string.ts
@@ -22,7 +22,10 @@ import type { DateTimeString } from '@epicenter/workspace';
  * // "2024-01-01T20:00:00.000Z|America/New_York"
  * ```
  */
-export function toDateTimeString(utcDate: Date, timezone: string): DateTimeString {
+export function toDateTimeString(
+	utcDate: Date,
+	timezone: string,
+): DateTimeString {
 	return `${utcDate.toISOString()}|${timezone}` as DateTimeString;
 }
 

--- a/packages/ui/src/natural-language-date-input/index.ts
+++ b/packages/ui/src/natural-language-date-input/index.ts
@@ -1,3 +1,3 @@
-export { default as NaturalLanguageDateInput } from './natural-language-date-input.svelte';
-export type { NaturalLanguageDateInputProps } from './natural-language-date-input.svelte';
 export { localTimezone, toDateTimeString } from './datetime-string.js';
+export type { NaturalLanguageDateInputProps } from './natural-language-date-input.svelte';
+export { default as NaturalLanguageDateInput } from './natural-language-date-input.svelte';

--- a/packages/ui/src/natural-language-date-input/natural-language-date-input.svelte
+++ b/packages/ui/src/natural-language-date-input/natural-language-date-input.svelte
@@ -8,14 +8,14 @@
 </script>
 
 <script lang="ts">
-	import * as Command from '#/command';
 	import * as chrono from 'chrono-node';
+	import * as Command from '#/command';
 
 	let {
 		placeholder = 'E.g. "tomorrow at 5pm" or "in 2 hours"',
 		min,
 		max,
-		onChoice
+		onChoice,
 	}: NaturalLanguageDateInputProps = $props();
 
 	let value = $state('');
@@ -47,9 +47,7 @@
 					}}
 				>
 					<div class="flex w-full place-items-center justify-between gap-2">
-						<span>
-							{suggestion.label}
-						</span>
+						<span> {suggestion.label} </span>
 						<span class="text-muted-foreground">
 							{suggestion.date.toDateString()}
 							{suggestion.date.toLocaleTimeString()}

--- a/packages/ui/src/natural-language-date-input/parse-date.test.ts
+++ b/packages/ui/src/natural-language-date-input/parse-date.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'bun:test';
 
-import { localTimezone, parseNaturalLanguageDate, toDateTimeString } from './parse-date.js';
+import {
+	localTimezone,
+	parseNaturalLanguageDate,
+	toDateTimeString,
+} from './parse-date.js';
 
 function getTomorrowLocalDate() {
 	const date = new Date();
@@ -16,7 +20,10 @@ describe('parseNaturalLanguageDate', () => {
 
 	it('parses tomorrow at 3pm with the expected components', () => {
 		const expected = getTomorrowLocalDate();
-		const parsed = parseNaturalLanguageDate('tomorrow at 3pm', 'America/New_York');
+		const parsed = parseNaturalLanguageDate(
+			'tomorrow at 3pm',
+			'America/New_York',
+		);
 
 		expect(parsed).not.toBeNull();
 		if (!parsed) {
@@ -48,7 +55,10 @@ describe('parseNaturalLanguageDate', () => {
 	});
 
 	it('returns different UTC dates for different timezones', () => {
-		const newYork = parseNaturalLanguageDate('tomorrow at 3pm', 'America/New_York');
+		const newYork = parseNaturalLanguageDate(
+			'tomorrow at 3pm',
+			'America/New_York',
+		);
 		const utc = parseNaturalLanguageDate('tomorrow at 3pm', 'UTC');
 		const tokyo = parseNaturalLanguageDate('tomorrow at 3pm', 'Asia/Tokyo');
 
@@ -69,7 +79,10 @@ describe('parseNaturalLanguageDate', () => {
 
 describe('toDateTimeString', () => {
 	it('formats UTC date and timezone with a pipe separator', () => {
-		const value = toDateTimeString(new Date('2024-01-01T20:00:00.000Z'), 'America/New_York');
+		const value = toDateTimeString(
+			new Date('2024-01-01T20:00:00.000Z'),
+			'America/New_York',
+		);
 
 		expect(value).toBe('2024-01-01T20:00:00.000Z|America/New_York');
 		expect(value).toContain('|');

--- a/packages/ui/src/natural-language-date-input/parse-date.ts
+++ b/packages/ui/src/natural-language-date-input/parse-date.ts
@@ -93,7 +93,10 @@ export function parseNaturalLanguageDate(
 		return null;
 	}
 
-	const offsetMilliseconds = getOffsetMillisecondsForTimezone(roughUtcDate, timezone);
+	const offsetMilliseconds = getOffsetMillisecondsForTimezone(
+		roughUtcDate,
+		timezone,
+	);
 	if (offsetMilliseconds === null) {
 		return null;
 	}
@@ -141,7 +144,10 @@ export function parseNaturalLanguageDate(
  *   : null;
  * ```
  */
-export function toDateTimeString(utcDate: Date, timezone: string): DateTimeString {
+export function toDateTimeString(
+	utcDate: Date,
+	timezone: string,
+): DateTimeString {
 	return `${utcDate.toISOString()}|${timezone}` as DateTimeString;
 }
 
@@ -193,7 +199,10 @@ function extractDateComponents(
 	};
 }
 
-function getOffsetMillisecondsForTimezone(instant: Date, timezone: string): number | null {
+function getOffsetMillisecondsForTimezone(
+	instant: Date,
+	timezone: string,
+): number | null {
 	try {
 		const formatter = new Intl.DateTimeFormat('en-US', {
 			timeZone: timezone,

--- a/packages/ui/src/natural-language-date-input/timezone-combobox.svelte
+++ b/packages/ui/src/natural-language-date-input/timezone-combobox.svelte
@@ -43,9 +43,7 @@
 	const selectedTimeZone = $derived(
 		timeZoneOptions.find((timeZoneOption) => timeZoneOption.timeZone === value),
 	);
-	const triggerLabel = $derived(
-		selectedTimeZone?.label ?? 'Select timezone',
-	);
+	const triggerLabel = $derived(selectedTimeZone?.label ?? 'Select timezone');
 </script>
 
 <Popover.Root bind:open={combobox.open}>

--- a/packages/ui/src/sonner/toast-on-error.ts
+++ b/packages/ui/src/sonner/toast-on-error.ts
@@ -27,10 +27,9 @@ import type { Result } from 'wellcrafted/result';
  * bookmarkState.toggle(tab).then((r) => toastOnError(r, 'Failed to toggle bookmark'));
  * ```
  */
-export function toastOnError<TInput extends Result<unknown, AnyTaggedError> | AnyTaggedError>(
-	resultOrError: TInput,
-	title: string,
-): TInput {
+export function toastOnError<
+	TInput extends Result<unknown, AnyTaggedError> | AnyTaggedError,
+>(resultOrError: TInput, title: string): TInput {
 	const error = 'data' in resultOrError ? resultOrError.error : resultOrError;
 	if (error) {
 		toast.error(title, { description: error.message });

--- a/packages/ui/src/star-rating/star-rating-star.svelte
+++ b/packages/ui/src/star-rating/star-rating-star.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import { cn } from '../utils.js';
-	import StarHalfIcon from '@lucide/svelte/icons/star-half';
 	import StarIcon from '@lucide/svelte/icons/star';
+	import StarHalfIcon from '@lucide/svelte/icons/star-half';
 	import { RatingGroup } from 'bits-ui';
+	import { cn } from '../utils.js';
 
 	type StarRatingStarProps = {
 		index: number;

--- a/packages/ui/src/star-rating/star-rating.svelte
+++ b/packages/ui/src/star-rating/star-rating.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { cn } from '../utils.js';
 	import { RatingGroup, type RatingGroupRootProps } from 'bits-ui';
+	import { cn } from '../utils.js';
 
 	let {
 		value = $bindable(0),

--- a/packages/ui/src/timezone-combobox/timezone-combobox.svelte
+++ b/packages/ui/src/timezone-combobox/timezone-combobox.svelte
@@ -43,9 +43,7 @@
 	const selectedTimeZone = $derived(
 		timeZoneOptions.find((timeZoneOption) => timeZoneOption.timeZone === value),
 	);
-	const triggerLabel = $derived(
-		selectedTimeZone?.label ?? 'Select timezone',
-	);
+	const triggerLabel = $derived(selectedTimeZone?.label ?? 'Select timezone');
 </script>
 
 <Popover.Root bind:open={combobox.open}>

--- a/packages/workspace/scripts/yjs-benchmarks/data-structures.ts
+++ b/packages/workspace/scripts/yjs-benchmarks/data-structures.ts
@@ -525,10 +525,7 @@ function benchmarkArrayYMap(
 	doc.transact(() => {
 		for (let i = 0; i < CONFIG.NUM_RECREATIONS; i++) {
 			yarray.push([
-				createYMapRow(
-					`${CONFIG.NUM_ROWS - CONFIG.NUM_DELETIONS + i}`,
-					'-v2',
-				),
+				createYMapRow(`${CONFIG.NUM_ROWS - CONFIG.NUM_DELETIONS + i}`, '-v2'),
 			]);
 		}
 	});
@@ -794,7 +791,11 @@ async function main() {
 `);
 
 	const allResults: BenchmarkResult[] = [];
-	const strategies = ['single-column', 'full-row', 'mixed'] satisfies UpdateStrategy[];
+	const strategies = [
+		'single-column',
+		'full-row',
+		'mixed',
+	] satisfies UpdateStrategy[];
 	const benchmarks = [
 		benchmarkMapPlain,
 		benchmarkArrayPlain,

--- a/packages/workspace/scripts/yjs-benchmarks/gc-impact.ts
+++ b/packages/workspace/scripts/yjs-benchmarks/gc-impact.ts
@@ -8,7 +8,6 @@ type BenchmarkResult = {
 	operations: number;
 };
 
-
 /**
  * Benchmark 1: Y.Text Heavy Editing
  * Simulates Google Docs-like typing and deleting

--- a/packages/workspace/scripts/yjs-benchmarks/persistence-growth.ts
+++ b/packages/workspace/scripts/yjs-benchmarks/persistence-growth.ts
@@ -50,7 +50,6 @@ const eventDefinition = defineTable(
 // Helpers
 // ═══════════════════════════════════════════════════════════════════════════════
 
-
 const samplePayload = JSON.stringify({
 	userId: 'usr-001',
 	action: 'click',
@@ -132,7 +131,7 @@ function main() {
 
 	// ── Setup ────────────────────────────────────────────────────────────────
 	const ydoc = new Y.Doc();
-	const tables = { events: attachTable(ydoc, "events", eventDefinition) };
+	const tables = { events: attachTable(ydoc, 'events', eventDefinition) };
 	const idb = createIdbSimulator(ydoc);
 
 	// ── Seed steady-state rows ──────────────────────────────────────────────
@@ -388,7 +387,9 @@ function main() {
 	const finalState = Y.encodeStateAsUpdate(ydoc);
 	const freshDoc = new Y.Doc();
 	Y.applyUpdate(freshDoc, finalState);
-	const freshTables = { events: attachTable(freshDoc, "events", eventDefinition) };
+	const freshTables = {
+		events: attachTable(freshDoc, 'events', eventDefinition),
+	};
 	const freshSize = Y.encodeStateAsUpdate(freshDoc).byteLength;
 
 	console.log(

--- a/packages/workspace/scripts/yjs-benchmarks/stress-add-delete.ts
+++ b/packages/workspace/scripts/yjs-benchmarks/stress-add-delete.ts
@@ -11,8 +11,7 @@
 import { unlinkSync } from 'node:fs';
 import { type } from 'arktype';
 import * as Y from 'yjs';
-import { attachTable } from '../../src/index.js';
-import { defineTable } from '../../src/index.js';
+import { attachTable, defineTable } from '../../src/index.js';
 import { formatBytes, measureTime } from './helpers.js';
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -52,7 +51,7 @@ function generateId(index: number): string {
 
 async function main() {
 	const ydoc = new Y.Doc();
-	const tables = { events: attachTable(ydoc, "events", eventDefinition) };
+	const tables = { events: attachTable(ydoc, 'events', eventDefinition) };
 
 	console.log(`\n=== Static API Stress Test ===`);
 	console.log(`Events per cycle: ${EVENTS_PER_CYCLE.toLocaleString()}`);
@@ -136,7 +135,7 @@ async function main() {
 	// ── Bonus: what does a fresh doc from this snapshot look like? ──────
 	const ydoc2 = new Y.Doc();
 	Y.applyUpdate(ydoc2, finalUpdate);
-	const tables2 = { events: attachTable(ydoc2, "events", eventDefinition) };
+	const tables2 = { events: attachTable(ydoc2, 'events', eventDefinition) };
 	console.log(`\n=== Snapshot Verification ===`);
 	console.log(`Rows after loading snapshot: ${tables2.events.count()}`);
 

--- a/packages/workspace/src/__benchmarks__/conflict-resolution.bench.ts
+++ b/packages/workspace/src/__benchmarks__/conflict-resolution.bench.ts
@@ -13,8 +13,6 @@ import * as Y from 'yjs';
 import {
 	YKeyValue,
 	type YKeyValueEntry,
-} from '../document/y-keyvalue/index.js';
-import {
 	YKeyValueLww,
 	type YKeyValueLwwEntry,
 } from '../document/y-keyvalue/index.js';

--- a/packages/workspace/src/__benchmarks__/deserialization.bench.ts
+++ b/packages/workspace/src/__benchmarks__/deserialization.bench.ts
@@ -30,7 +30,7 @@ describe('cold start: load from binary', () => {
 		test(`load ${count.toLocaleString()} small rows from binary`, () => {
 			// Build source doc
 			const sourceDoc = new Y.Doc();
-			const tables = { posts: attachTable(sourceDoc, "posts", postDefinition) };
+			const tables = { posts: attachTable(sourceDoc, 'posts', postDefinition) };
 			for (let i = 0; i < count; i++) {
 				tables.posts.set({
 					id: generateId(i),
@@ -55,7 +55,7 @@ describe('cold start: load from binary', () => {
 
 	test('load 1,000 notes with 500 chars each', () => {
 		const sourceDoc = new Y.Doc();
-		const tables = { notes: attachTable(sourceDoc, "notes", noteDefinition) };
+		const tables = { notes: attachTable(sourceDoc, 'notes', noteDefinition) };
 		const content = 'x'.repeat(400);
 		for (let i = 0; i < 1_000; i++) {
 			tables.notes.set({
@@ -82,7 +82,9 @@ describe('cold start: load from binary', () => {
 
 	test('load 5 heavy docs (50K chars each)', () => {
 		const sourceDoc = new Y.Doc();
-		const tables = { notes: attachTable(sourceDoc, "notes", heavyNoteDefinition) };
+		const tables = {
+			notes: attachTable(sourceDoc, 'notes', heavyNoteDefinition),
+		};
 		for (let i = 0; i < 5; i++) {
 			tables.notes.set(makeHeavyRow(`doc-${i}`, 50_000));
 		}
@@ -107,7 +109,7 @@ describe('snapshot encoding time', () => {
 	for (const count of [1_000, 10_000, 50_000]) {
 		test(`encode ${count.toLocaleString()} small rows to binary`, () => {
 			const ydoc = new Y.Doc();
-			const tables = { posts: attachTable(ydoc, "posts", postDefinition) };
+			const tables = { posts: attachTable(ydoc, 'posts', postDefinition) };
 			for (let i = 0; i < count; i++) {
 				tables.posts.set({
 					id: generateId(i),
@@ -135,7 +137,7 @@ describe('snapshot encoding time', () => {
 describe('incremental update size', () => {
 	test('single row edit: delta vs full snapshot', () => {
 		const ydoc = new Y.Doc();
-		const tables = { posts: attachTable(ydoc, "posts", postDefinition) };
+		const tables = { posts: attachTable(ydoc, 'posts', postDefinition) };
 
 		// Insert 1000 rows
 		for (let i = 0; i < 1_000; i++) {

--- a/packages/workspace/src/__benchmarks__/memory-pressure.bench.ts
+++ b/packages/workspace/src/__benchmarks__/memory-pressure.bench.ts
@@ -46,7 +46,7 @@ describe('heap usage: small rows', () => {
 			const heapBefore = getHeapUsed();
 
 			const ydoc = new Y.Doc();
-			const tables = { posts: attachTable(ydoc, "posts", postDefinition) };
+			const tables = { posts: attachTable(ydoc, 'posts', postDefinition) };
 
 			for (let i = 0; i < count; i++) {
 				tables.posts.set({
@@ -96,7 +96,7 @@ describe('heap usage: content-heavy rows', () => {
 			const heapBefore = getHeapUsed();
 
 			const ydoc = new Y.Doc();
-			const tables = { notes: attachTable(ydoc, "notes", heavyNoteDefinition) };
+			const tables = { notes: attachTable(ydoc, 'notes', heavyNoteDefinition) };
 
 			for (let i = 0; i < rows; i++) {
 				tables.notes.set(makeHeavyRow(`doc-${i}`, content));
@@ -125,7 +125,7 @@ describe('heap overhead: binary vs in-memory', () => {
 		const heapBefore = getHeapUsed();
 
 		const ydoc = new Y.Doc();
-		const tables = { notes: attachTable(ydoc, "notes", noteDefinition) };
+		const tables = { notes: attachTable(ydoc, 'notes', noteDefinition) };
 
 		const content = 'x'.repeat(400);
 		for (let i = 0; i < 5_000; i++) {

--- a/packages/workspace/src/__benchmarks__/operations.bench.ts
+++ b/packages/workspace/src/__benchmarks__/operations.bench.ts
@@ -8,17 +8,13 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import * as Y from 'yjs';
 import { type } from 'arktype';
-import { createEncryptedYkvLww } from '../shared/y-keyvalue/y-keyvalue-lww-encrypted.js';
-import { attachTable } from '../index.js';
-import { createKv } from '../document/internal.js';
+import * as Y from 'yjs';
 import { defineKv } from '../document/define-kv.js';
-import {
-	generateId,
-	measureTime,
-	postDefinition,
-} from './helpers.js';
+import { createKv } from '../document/internal.js';
+import { attachTable } from '../index.js';
+import { createEncryptedYkvLww } from '../shared/y-keyvalue/y-keyvalue-lww-encrypted.js';
+import { generateId, measureTime, postDefinition } from './helpers.js';
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Table Operations
@@ -27,7 +23,7 @@ import {
 describe('table operations', () => {
 	test('insert 1,000 rows', () => {
 		const ydoc = new Y.Doc();
-		const tables = { posts: attachTable(ydoc, "posts", postDefinition) };
+		const tables = { posts: attachTable(ydoc, 'posts', postDefinition) };
 
 		const { durationMs } = measureTime(() => {
 			for (let i = 0; i < 1_000; i++) {
@@ -40,14 +36,16 @@ describe('table operations', () => {
 			}
 		});
 
-		console.log(`Insert 1,000 rows: ${durationMs.toFixed(2)}ms (${Math.round(1_000 / (durationMs / 1_000))} ops/sec)`);
+		console.log(
+			`Insert 1,000 rows: ${durationMs.toFixed(2)}ms (${Math.round(1_000 / (durationMs / 1_000))} ops/sec)`,
+		);
 		console.log(`Average per insert: ${(durationMs / 1_000).toFixed(4)}ms`);
 		expect(tables.posts.count()).toBe(1_000);
 	});
 
 	test('insert 10,000 rows', () => {
 		const ydoc = new Y.Doc();
-		const tables = { posts: attachTable(ydoc, "posts", postDefinition) };
+		const tables = { posts: attachTable(ydoc, 'posts', postDefinition) };
 
 		const { durationMs } = measureTime(() => {
 			for (let i = 0; i < 10_000; i++) {
@@ -60,14 +58,16 @@ describe('table operations', () => {
 			}
 		});
 
-		console.log(`Insert 10,000 rows: ${durationMs.toFixed(2)}ms (${Math.round(10_000 / (durationMs / 1_000))} ops/sec)`);
+		console.log(
+			`Insert 10,000 rows: ${durationMs.toFixed(2)}ms (${Math.round(10_000 / (durationMs / 1_000))} ops/sec)`,
+		);
 		console.log(`Average per insert: ${(durationMs / 10_000).toFixed(4)}ms`);
 		expect(tables.posts.count()).toBe(10_000);
 	});
 
 	test('get 10,000 rows by ID', () => {
 		const ydoc = new Y.Doc();
-		const tables = { posts: attachTable(ydoc, "posts", postDefinition) };
+		const tables = { posts: attachTable(ydoc, 'posts', postDefinition) };
 
 		for (let i = 0; i < 10_000; i++) {
 			tables.posts.set({
@@ -90,7 +90,7 @@ describe('table operations', () => {
 
 	test('getAll / getAllValid / filter with 10,000 rows', () => {
 		const ydoc = new Y.Doc();
-		const tables = { posts: attachTable(ydoc, "posts", postDefinition) };
+		const tables = { posts: attachTable(ydoc, 'posts', postDefinition) };
 
 		for (let i = 0; i < 10_000; i++) {
 			tables.posts.set({
@@ -116,7 +116,7 @@ describe('table operations', () => {
 
 	test('delete 1,000 rows', () => {
 		const ydoc = new Y.Doc();
-		const tables = { posts: attachTable(ydoc, "posts", postDefinition) };
+		const tables = { posts: attachTable(ydoc, 'posts', postDefinition) };
 
 		for (let i = 0; i < 1_000; i++) {
 			tables.posts.set({
@@ -140,7 +140,7 @@ describe('table operations', () => {
 
 	test('batch insert vs individual insert (1,000 rows)', () => {
 		const ydoc1 = new Y.Doc();
-		const tables1 = { posts: attachTable(ydoc1, "posts", postDefinition) };
+		const tables1 = { posts: attachTable(ydoc1, 'posts', postDefinition) };
 
 		const { durationMs: individualMs } = measureTime(() => {
 			for (let i = 0; i < 1_000; i++) {
@@ -154,7 +154,7 @@ describe('table operations', () => {
 		});
 
 		const ydoc2 = new Y.Doc();
-		const tables2 = { posts: attachTable(ydoc2, "posts", postDefinition) };
+		const tables2 = { posts: attachTable(ydoc2, 'posts', postDefinition) };
 
 		const { durationMs: batchMs } = measureTime(() => {
 			ydoc2.transact(() => {

--- a/packages/workspace/src/__benchmarks__/production-scenarios.bench.ts
+++ b/packages/workspace/src/__benchmarks__/production-scenarios.bench.ts
@@ -54,7 +54,7 @@ describe('autosave scenario', () => {
 
 		// ── YKV ──
 		const ykvDoc = new Y.Doc();
-		const tables = { notes: attachTable(ykvDoc, "notes", heavyNoteDefinition) };
+		const tables = { notes: attachTable(ykvDoc, 'notes', heavyNoteDefinition) };
 		for (let i = 0; i < 5; i++) {
 			tables.notes.set(makeRow(`doc-${i}`, baseContent));
 		}
@@ -154,8 +154,9 @@ describe('all-day editing scenario', () => {
 
 		// ── YKV ──
 		const ykvDoc = new Y.Doc();
-		const tables = { notes: attachTable(ykvDoc, "notes", heavyNoteDefinition) };
-		for (let i = 0; i < 5; i++) tables.notes.set(makeRowAtRevision(`doc-${i}`, 0));
+		const tables = { notes: attachTable(ykvDoc, 'notes', heavyNoteDefinition) };
+		for (let i = 0; i < 5; i++)
+			tables.notes.set(makeRowAtRevision(`doc-${i}`, 0));
 		for (let s = 1; s <= totalSaves; s++) {
 			const docIdx = s % 3; // rotate across 3 active documents
 			tables.notes.set(makeRowAtRevision(`doc-${docIdx}`, s));
@@ -174,7 +175,9 @@ describe('all-day editing scenario', () => {
 		for (let s = 1; s <= totalSaves; s++) {
 			const docIdx = s % 3;
 			const row = fieldRoot.get(`doc-${docIdx}`) as Y.Map<unknown>;
-			for (const [k, v] of Object.entries(makeRowAtRevision(`doc-${docIdx}`, s)))
+			for (const [k, v] of Object.entries(
+				makeRowAtRevision(`doc-${docIdx}`, s),
+			))
 				row.set(k, v);
 		}
 		const fieldSize = Y.encodeStateAsUpdate(fieldDoc).byteLength;

--- a/packages/workspace/src/__benchmarks__/scaling-ceiling.bench.ts
+++ b/packages/workspace/src/__benchmarks__/scaling-ceiling.bench.ts
@@ -22,8 +22,8 @@
 
 import { describe, test } from 'bun:test';
 import * as Y from 'yjs';
-import { attachTable } from '../index.js';
 import { createTables } from '../__tests__/create-tables.js';
+import { attachTable } from '../index.js';
 import {
 	formatBytes,
 	generateId,
@@ -101,7 +101,7 @@ describe('scaling ceiling: small rows (posts)', () => {
 
 		for (const N of ROW_COUNTS) {
 			const ydoc = new Y.Doc();
-			const tables = { posts: attachTable(ydoc, "posts", postDefinition) };
+			const tables = { posts: attachTable(ydoc, 'posts', postDefinition) };
 
 			// ── Insert N rows ──
 			const { durationMs: insertMs } = measureTime(() => {
@@ -197,7 +197,7 @@ describe('scaling ceiling: realistic rows (notes)', () => {
 
 		for (const N of ROW_COUNTS) {
 			const ydoc = new Y.Doc();
-			const tables = { notes: attachTable(ydoc, "notes", noteDefinition) };
+			const tables = { notes: attachTable(ydoc, 'notes', noteDefinition) };
 
 			const { durationMs: insertMs } = measureTime(() => {
 				for (let i = 0; i < N; i++) {
@@ -293,10 +293,16 @@ describe('scaling ceiling: multi-table write strategies', () => {
 	 */
 	test('population strategies: bulkSet vs sequential set vs interleaved set', () => {
 		console.log('\n=== MULTI-TABLE: WRITE STRATEGY COMPARISON ===');
-		console.log('3 tables sharing one Y.Doc. Same data, different insert patterns.\n');
+		console.log(
+			'3 tables sharing one Y.Doc. Same data, different insert patterns.\n',
+		);
 
-		console.log('| Total rows | bulkSet    | seq set()  | interleaved set() | bulk speedup |');
-		console.log('|------------|------------|------------|-------------------|--------------|');
+		console.log(
+			'| Total rows | bulkSet    | seq set()  | interleaved set() | bulk speedup |',
+		);
+		console.log(
+			'|------------|------------|------------|-------------------|--------------|',
+		);
 
 		for (const N of TOTAL_ROW_COUNTS) {
 			const perTable = Math.floor(N / 3);
@@ -310,13 +316,22 @@ describe('scaling ceiling: multi-table write strategies', () => {
 			});
 
 			const postRows = Array.from({ length: perTable }, (_, i) => ({
-				id: generateId(i), title: `Post ${i}`, views: i, _v: 1 as const,
+				id: generateId(i),
+				title: `Post ${i}`,
+				views: i,
+				_v: 1 as const,
 			}));
 			const bookmarkRows = Array.from({ length: perTable }, (_, i) => ({
-				id: generateId(i), title: `Bookmark ${i}`, views: i, _v: 1 as const,
+				id: generateId(i),
+				title: `Bookmark ${i}`,
+				views: i,
+				_v: 1 as const,
 			}));
 			const eventRows = Array.from({ length: perTable }, (_, i) => ({
-				id: generateId(i), title: `Event ${i}`, views: i, _v: 1 as const,
+				id: generateId(i),
+				title: `Event ${i}`,
+				views: i,
+				_v: 1 as const,
 			}));
 
 			const { durationMs: bulkMs } = measureTime(() => {
@@ -336,13 +351,28 @@ describe('scaling ceiling: multi-table write strategies', () => {
 
 			const { durationMs: seqMs } = measureTime(() => {
 				for (let i = 0; i < perTable; i++) {
-					seqTables.posts.set({ id: generateId(i), title: `Post ${i}`, views: i, _v: 1 });
+					seqTables.posts.set({
+						id: generateId(i),
+						title: `Post ${i}`,
+						views: i,
+						_v: 1,
+					});
 				}
 				for (let i = 0; i < perTable; i++) {
-					seqTables.bookmarks.set({ id: generateId(i), title: `Bookmark ${i}`, views: i, _v: 1 });
+					seqTables.bookmarks.set({
+						id: generateId(i),
+						title: `Bookmark ${i}`,
+						views: i,
+						_v: 1,
+					});
 				}
 				for (let i = 0; i < perTable; i++) {
-					seqTables.events.set({ id: generateId(i), title: `Event ${i}`, views: i, _v: 1 });
+					seqTables.events.set({
+						id: generateId(i),
+						title: `Event ${i}`,
+						views: i,
+						_v: 1,
+					});
 				}
 			});
 			seqDoc.destroy();
@@ -357,9 +387,24 @@ describe('scaling ceiling: multi-table write strategies', () => {
 
 			const { durationMs: intMs } = measureTime(() => {
 				for (let i = 0; i < perTable; i++) {
-					intTables.posts.set({ id: generateId(i), title: `Post ${i}`, views: i, _v: 1 });
-					intTables.bookmarks.set({ id: generateId(i), title: `Bookmark ${i}`, views: i, _v: 1 });
-					intTables.events.set({ id: generateId(i), title: `Event ${i}`, views: i, _v: 1 });
+					intTables.posts.set({
+						id: generateId(i),
+						title: `Post ${i}`,
+						views: i,
+						_v: 1,
+					});
+					intTables.bookmarks.set({
+						id: generateId(i),
+						title: `Bookmark ${i}`,
+						views: i,
+						_v: 1,
+					});
+					intTables.events.set({
+						id: generateId(i),
+						title: `Event ${i}`,
+						views: i,
+						_v: 1,
+					});
 				}
 			});
 			intDoc.destroy();
@@ -373,7 +418,9 @@ describe('scaling ceiling: multi-table write strategies', () => {
 		console.log('');
 		console.log('bulkSet = O(n) deferred conflict resolution via observer');
 		console.log('seq set() = one table at a time, V8 JIT stays hot');
-		console.log('interleaved set() = alternating arrays, toArray() thrash — NEVER do this in bulk');
+		console.log(
+			'interleaved set() = alternating arrays, toArray() thrash — NEVER do this in bulk',
+		);
 	}, 120_000);
 
 	test('post-population: random updates across 3 tables (realistic usage)', () => {
@@ -391,15 +438,30 @@ describe('scaling ceiling: multi-table write strategies', () => {
 				events: postDefinition,
 			});
 
-			tables.posts.bulkSet(Array.from({ length: perTable }, (_, i) => ({
-				id: generateId(i), title: `Post ${i}`, views: i, _v: 1 as const,
-			})));
-			tables.bookmarks.bulkSet(Array.from({ length: perTable }, (_, i) => ({
-				id: generateId(i), title: `Bookmark ${i}`, views: i, _v: 1 as const,
-			})));
-			tables.events.bulkSet(Array.from({ length: perTable }, (_, i) => ({
-				id: generateId(i), title: `Event ${i}`, views: i, _v: 1 as const,
-			})));
+			tables.posts.bulkSet(
+				Array.from({ length: perTable }, (_, i) => ({
+					id: generateId(i),
+					title: `Post ${i}`,
+					views: i,
+					_v: 1 as const,
+				})),
+			);
+			tables.bookmarks.bulkSet(
+				Array.from({ length: perTable }, (_, i) => ({
+					id: generateId(i),
+					title: `Bookmark ${i}`,
+					views: i,
+					_v: 1 as const,
+				})),
+			);
+			tables.events.bulkSet(
+				Array.from({ length: perTable }, (_, i) => ({
+					id: generateId(i),
+					title: `Event ${i}`,
+					views: i,
+					_v: 1 as const,
+				})),
+			);
 
 			// Now simulate realistic usage: random updates across tables
 			const { durationMs } = measureTime(() => {
@@ -408,11 +470,26 @@ describe('scaling ceiling: multi-table write strategies', () => {
 					// Randomly pick a table (simulates user editing different things)
 					const pick = i % 3;
 					if (pick === 0) {
-						tables.posts.set({ id: generateId(idx), title: `Updated ${idx}`, views: idx, _v: 1 });
+						tables.posts.set({
+							id: generateId(idx),
+							title: `Updated ${idx}`,
+							views: idx,
+							_v: 1,
+						});
 					} else if (pick === 1) {
-						tables.bookmarks.set({ id: generateId(idx), title: `Updated ${idx}`, views: idx, _v: 1 });
+						tables.bookmarks.set({
+							id: generateId(idx),
+							title: `Updated ${idx}`,
+							views: idx,
+							_v: 1,
+						});
 					} else {
-						tables.events.set({ id: generateId(idx), title: `Updated ${idx}`, views: idx, _v: 1 });
+						tables.events.set({
+							id: generateId(idx),
+							title: `Updated ${idx}`,
+							views: idx,
+							_v: 1,
+						});
 					}
 				}
 			});
@@ -443,7 +520,7 @@ describe('scaling ceiling: per-operation degradation', () => {
 		);
 
 		const ydoc = new Y.Doc();
-		const tables = { posts: attachTable(ydoc, "posts", postDefinition) };
+		const tables = { posts: attachTable(ydoc, 'posts', postDefinition) };
 
 		const milestones = [0, 10_000, 20_000, 30_000, 40_000, 50_000];
 		let totalInserted = 0;

--- a/packages/workspace/src/__benchmarks__/scaling-ceiling.bench.ts
+++ b/packages/workspace/src/__benchmarks__/scaling-ceiling.bench.ts
@@ -419,7 +419,7 @@ describe('scaling ceiling: multi-table write strategies', () => {
 		console.log('bulkSet = O(n) deferred conflict resolution via observer');
 		console.log('seq set() = one table at a time, V8 JIT stays hot');
 		console.log(
-			'interleaved set() = alternating arrays, toArray() thrash — NEVER do this in bulk',
+			'interleaved set() = alternating arrays, toArray() thrash: NEVER do this in bulk',
 		);
 	}, 120_000);
 

--- a/packages/workspace/src/__benchmarks__/storage-overhead.bench.ts
+++ b/packages/workspace/src/__benchmarks__/storage-overhead.bench.ts
@@ -29,7 +29,7 @@ import {
 describe('CRDT overhead vs raw JSON', () => {
 	test('small row: actual payload vs Y.Doc overhead', () => {
 		const ydoc = new Y.Doc();
-		const tables = { posts: attachTable(ydoc, "posts", postDefinition) };
+		const tables = { posts: attachTable(ydoc, 'posts', postDefinition) };
 
 		// Example row
 		const row = { id: 'id-000001', title: 'Post 1', views: 42 };
@@ -71,7 +71,7 @@ describe('CRDT overhead vs raw JSON', () => {
 
 	test('realistic row: notes with 500 chars of content', () => {
 		const ydoc = new Y.Doc();
-		const tables = { notes: attachTable(ydoc, "notes", noteDefinition) };
+		const tables = { notes: attachTable(ydoc, 'notes', noteDefinition) };
 
 		const sampleContent = `This is a realistic note with actual content. 
 It might contain multiple paragraphs and various formatting.
@@ -115,15 +115,21 @@ Let's add a bit more to make it realistic. The quick brown fox jumps over the la
 
 	test('actual ceiling measurements at 1K / 10K / 50K rows', () => {
 		console.log('\n=== PRACTICAL LIMITS (measured) ===');
-		console.log('| Rows     | Small Posts  | Notes (~500 chars) | Insert Time  |');
-		console.log('|----------|--------------|--------------------| -------------|');
+		console.log(
+			'| Rows     | Small Posts  | Notes (~500 chars) | Insert Time  |',
+		);
+		console.log(
+			'|----------|--------------|--------------------| -------------|',
+		);
 
 		const sampleContent = 'x'.repeat(400);
 
 		for (const count of [1_000, 10_000, 50_000]) {
 			// Small rows
 			const smallDoc = new Y.Doc();
-			const smallTables = { posts: attachTable(smallDoc, "posts", postDefinition) };
+			const smallTables = {
+				posts: attachTable(smallDoc, 'posts', postDefinition),
+			};
 			const smallStart = performance.now();
 			for (let i = 0; i < count; i++) {
 				smallTables.posts.set({
@@ -138,7 +144,9 @@ Let's add a bit more to make it realistic. The quick brown fox jumps over the la
 
 			// Notes with content
 			const noteDoc = new Y.Doc();
-			const noteTables = { notes: attachTable(noteDoc, "notes", noteDefinition) };
+			const noteTables = {
+				notes: attachTable(noteDoc, 'notes', noteDefinition),
+			};
 			for (let i = 0; i < count; i++) {
 				noteTables.notes.set({
 					id: generateId(i),
@@ -156,7 +164,7 @@ Let's add a bit more to make it realistic. The quick brown fox jumps over the la
 				`| ${String(count).padStart(8)} | ${formatBytes(smallSize).padEnd(12)} | ${formatBytes(noteSize).padEnd(18)} | ${smallMs.toFixed(0).padStart(8)}ms    |`,
 			);
 		}
-	}, 120_000);  // 50K rows takes a while
+	}, 120_000); // 50K rows takes a while
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -164,10 +172,9 @@ Let's add a bit more to make it realistic. The quick brown fox jumps over the la
 // ═══════════════════════════════════════════════════════════════════════════════
 
 describe('update growth', () => {
-
 	test('Y.Doc size growth after updates (same rows updated 5 times)', () => {
 		const ydoc = new Y.Doc();
-		const tables = { posts: attachTable(ydoc, "posts", postDefinition) };
+		const tables = { posts: attachTable(ydoc, 'posts', postDefinition) };
 
 		for (let i = 0; i < 1_000; i++) {
 			tables.posts.set({
@@ -209,7 +216,7 @@ describe('heavy text baseline sizes', () => {
 	for (const contentChars of [10_000, 50_000, 100_000]) {
 		test(`5 rows with ${formatBytes(contentChars)} chars each`, () => {
 			const ydoc = new Y.Doc();
-			const tables = { notes: attachTable(ydoc, "notes", heavyNoteDefinition) };
+			const tables = { notes: attachTable(ydoc, 'notes', heavyNoteDefinition) };
 
 			const rows = Array.from({ length: 5 }, (_, i) =>
 				makeHeavyRow(`doc-${i}`, contentChars),
@@ -226,7 +233,9 @@ describe('heavy text baseline sizes', () => {
 			console.log(
 				`  CRDT overhead:     ${((encoded.byteLength / jsonSize - 1) * 100).toFixed(1)}%`,
 			);
-			console.log(`  Per row:           ${formatBytes(encoded.byteLength / 5)}`);
+			console.log(
+				`  Per row:           ${formatBytes(encoded.byteLength / 5)}`,
+			);
 		});
 	}
 
@@ -237,7 +246,7 @@ describe('heavy text baseline sizes', () => {
 
 		for (const chars of [1_000, 5_000, 10_000, 50_000, 100_000, 500_000]) {
 			const ydoc = new Y.Doc();
-			const tables = { notes: attachTable(ydoc, "notes", heavyNoteDefinition) };
+			const tables = { notes: attachTable(ydoc, 'notes', heavyNoteDefinition) };
 
 			const row = makeHeavyRow('doc-0', chars);
 			tables.notes.set(row);

--- a/packages/workspace/src/__benchmarks__/stress-cycles.bench.ts
+++ b/packages/workspace/src/__benchmarks__/stress-cycles.bench.ts
@@ -25,7 +25,7 @@ import {
 describe('repeated add/remove cycles', () => {
 	test('1,000 items: add and remove 5 cycles', () => {
 		const ydoc = new Y.Doc();
-		const tables = { posts: attachTable(ydoc, "posts", postDefinition) };
+		const tables = { posts: attachTable(ydoc, 'posts', postDefinition) };
 
 		const cycleTimes: number[] = [];
 
@@ -62,7 +62,7 @@ describe('repeated add/remove cycles', () => {
 
 	test('1,000 items: Y.Doc size growth over 5 cycles', () => {
 		const ydoc = new Y.Doc();
-		const tables = { posts: attachTable(ydoc, "posts", postDefinition) };
+		const tables = { posts: attachTable(ydoc, 'posts', postDefinition) };
 
 		const docSizes: number[] = [];
 
@@ -98,7 +98,7 @@ describe('repeated add/remove cycles', () => {
 describe('event log stress', () => {
 	test('1,000 events: add, delete, measure binary size over 5 cycles', () => {
 		const ydoc = new Y.Doc();
-		const tables = { events: attachTable(ydoc, "events", eventDefinition) };
+		const tables = { events: attachTable(ydoc, 'events', eventDefinition) };
 
 		const sizes: number[] = [];
 
@@ -136,7 +136,7 @@ describe('event log stress', () => {
 
 	test('binary size: 1,000 events retained vs after deletion', () => {
 		const ydoc = new Y.Doc();
-		const tables = { events: attachTable(ydoc, "events", eventDefinition) };
+		const tables = { events: attachTable(ydoc, 'events', eventDefinition) };
 
 		for (let i = 0; i < 1_000; i++) {
 			tables.events.set({

--- a/packages/workspace/src/__benchmarks__/sync-cost.bench.ts
+++ b/packages/workspace/src/__benchmarks__/sync-cost.bench.ts
@@ -33,7 +33,7 @@ describe('sync delta size', () => {
 		const docA = new Y.Doc();
 		const docB = new Y.Doc();
 
-		const tablesA = { posts: attachTable(docA, "posts", postDefinition) };
+		const tablesA = { posts: attachTable(docA, 'posts', postDefinition) };
 
 		// Shared baseline: 100 rows
 		for (let i = 0; i < 100; i++) {
@@ -75,8 +75,8 @@ describe('sync delta size', () => {
 		const docA = new Y.Doc();
 		const docB = new Y.Doc();
 
-		const tablesA = { posts: attachTable(docA, "posts", postDefinition) };
-		const tablesB = { posts: attachTable(docB, "posts", postDefinition) };
+		const tablesA = { posts: attachTable(docA, 'posts', postDefinition) };
+		const tablesB = { posts: attachTable(docB, 'posts', postDefinition) };
 
 		// Shared baseline: 100 rows
 		for (let i = 0; i < 100; i++) {
@@ -125,8 +125,8 @@ describe('sync delta size', () => {
 		const docA = new Y.Doc();
 		const docB = new Y.Doc();
 
-		const tablesA = { posts: attachTable(docA, "posts", postDefinition) };
-		const tablesB = { posts: attachTable(docB, "posts", postDefinition) };
+		const tablesA = { posts: attachTable(docA, 'posts', postDefinition) };
+		const tablesB = { posts: attachTable(docB, 'posts', postDefinition) };
 
 		// Shared baseline
 		for (let i = 0; i < 100; i++) {
@@ -184,7 +184,7 @@ describe('merge time at scale', () => {
 			const docA = new Y.Doc();
 			const docB = new Y.Doc();
 
-			const tablesA = { posts: attachTable(docA, "posts", postDefinition) };
+			const tablesA = { posts: attachTable(docA, 'posts', postDefinition) };
 
 			// Baseline
 			for (let i = 0; i < 1_000; i++) {

--- a/packages/workspace/src/__benchmarks__/tombstones.bench.ts
+++ b/packages/workspace/src/__benchmarks__/tombstones.bench.ts
@@ -20,7 +20,7 @@ describe('tombstone residue after delete + replace', () => {
 	for (const contentChars of [10_000, 50_000, 100_000]) {
 		test(`${formatBytes(contentChars)}/row: delete 2 of 5, add 2 new`, () => {
 			const ydoc = new Y.Doc();
-			const tables = { notes: attachTable(ydoc, "notes", heavyNoteDefinition) };
+			const tables = { notes: attachTable(ydoc, 'notes', heavyNoteDefinition) };
 
 			// Step 1: Insert 5 heavy rows
 			for (let i = 0; i < 5; i++) {

--- a/packages/workspace/src/__benchmarks__/ykv-vs-ymap.bench.ts
+++ b/packages/workspace/src/__benchmarks__/ykv-vs-ymap.bench.ts
@@ -85,7 +85,7 @@ describe('YKV vs Y.Map: size and tombstones', () => {
 
 		// ── Approach 1: YKeyValueLww (Workspace API) ──
 		const ykvDoc = new Y.Doc();
-		const tables = { notes: attachTable(ykvDoc, "notes", heavyNoteDefinition) };
+		const tables = { notes: attachTable(ykvDoc, 'notes', heavyNoteDefinition) };
 
 		for (let i = 0; i < 5; i++) tables.notes.set(makeRowData(`doc-${i}`));
 		const ykvSize5 = Y.encodeStateAsUpdate(ykvDoc).byteLength;
@@ -209,7 +209,9 @@ describe('YKV vs Y.Map: size and tombstones', () => {
 		for (const rounds of updateRounds) {
 			// ── YKV approach ──
 			const ykvDoc = new Y.Doc();
-			const tables = { notes: attachTable(ykvDoc, "notes", heavyNoteDefinition) };
+			const tables = {
+				notes: attachTable(ykvDoc, 'notes', heavyNoteDefinition),
+			};
 			for (let i = 0; i < 5; i++) tables.notes.set(makeRowData(`doc-${i}`, 0));
 			for (let r = 1; r <= rounds; r++) {
 				for (let i = 0; i < 5; i++)

--- a/packages/workspace/src/__tests__/create-tables.ts
+++ b/packages/workspace/src/__tests__/create-tables.ts
@@ -1,9 +1,5 @@
-import {
-	attachTable,
-	type TableDefinitions,
-	type Tables,
-} from '../index.js';
 import type * as Y from 'yjs';
+import { attachTable, type TableDefinitions, type Tables } from '../index.js';
 
 /**
  * Test-only convenience: attach every table in a definitions map to a Y.Doc.

--- a/packages/workspace/src/ai/tool-bridge.ts
+++ b/packages/workspace/src/ai/tool-bridge.ts
@@ -138,9 +138,7 @@ export type ToolDefinition = {
  *   .find(d => d.name === 'tabs_close')?.title; // → 'Close Tabs'
  * ```
  */
-export function actionsToAiTools<T>(
-	source: T,
-): {
+export function actionsToAiTools<T>(source: T): {
 	tools: (AnyClientTool & { name: ActionNames<T> })[];
 	definitions: ToolDefinition[];
 } {

--- a/packages/workspace/src/client/connect-daemon-actions.ts
+++ b/packages/workspace/src/client/connect-daemon-actions.ts
@@ -47,7 +47,9 @@ import { findEpicenterDir } from './find-epicenter-dir.js';
  * Start one with `epicenter up`. There is no auto-spawn: explicit lifecycle
  * is the contract.
  */
-export async function connectDaemonActions<TActions extends Record<string, unknown>>({
+export async function connectDaemonActions<
+	TActions extends Record<string, unknown>,
+>({
 	route,
 	projectDir = findEpicenterDir(),
 }: {

--- a/packages/workspace/src/daemon/metadata.test.ts
+++ b/packages/workspace/src/daemon/metadata.test.ts
@@ -31,7 +31,9 @@ afterEach(() => {
 	rmSync(workDir, { recursive: true, force: true });
 });
 
-const sampleMeta = (overrides: Partial<DaemonMetadata> = {}): DaemonMetadata => ({
+const sampleMeta = (
+	overrides: Partial<DaemonMetadata> = {},
+): DaemonMetadata => ({
 	pid: process.pid,
 	dir: workDir,
 	startedAt: new Date(0).toISOString(),

--- a/packages/workspace/src/daemon/run-errors.ts
+++ b/packages/workspace/src/daemon/run-errors.ts
@@ -17,10 +17,7 @@ import {
 } from 'wellcrafted/error';
 import type { Result } from 'wellcrafted/result';
 
-import type {
-	SyncError,
-	SyncFailedReason,
-} from '../document/attach-sync.js';
+import type { SyncError, SyncFailedReason } from '../document/attach-sync.js';
 import type { RemoteCallError } from '../rpc/remote-actions.js';
 
 export type RunSyncStatus =

--- a/packages/workspace/src/daemon/run-handler.test.ts
+++ b/packages/workspace/src/daemon/run-handler.test.ts
@@ -12,8 +12,8 @@ import type { SyncStatus } from '../document/attach-sync.js';
 import type { PeerAwarenessSchema } from '../document/peer-identity.js';
 import type { RemoteClient } from '../rpc/remote-actions.js';
 import { defineMutation, defineQuery } from '../shared/actions.js';
-import { executeRun } from './run-handler.js';
 import type { RunSyncStatus } from './run-errors.js';
+import { executeRun } from './run-handler.js';
 import type { StartedDaemonRoute } from './types.js';
 
 type Runtime = StartedDaemonRoute['runtime'];

--- a/packages/workspace/src/daemon/run-handler.ts
+++ b/packages/workspace/src/daemon/run-handler.ts
@@ -17,13 +17,13 @@
  */
 
 import { Ok } from 'wellcrafted/result';
+import type { SyncStatus } from '../document/attach-sync.js';
 import {
 	invokeAction,
 	resolveActionPath,
 	walkActions,
 } from '../shared/actions.js';
 import type { RunRequest } from './app.js';
-import type { SyncStatus } from '../document/attach-sync.js';
 import {
 	RunError,
 	type RunResponse,

--- a/packages/workspace/src/daemon/server.test.ts
+++ b/packages/workspace/src/daemon/server.test.ts
@@ -28,9 +28,7 @@ let originalXdg: string | undefined;
 let runtimeRoot: string;
 let workDir: string;
 
-function makeRuntime(
-	actions: DaemonRuntime['actions'] = {},
-): DaemonRuntime {
+function makeRuntime(actions: DaemonRuntime['actions'] = {}): DaemonRuntime {
 	return {
 		actions,
 		async [Symbol.asyncDispose]() {

--- a/packages/workspace/src/document/attach-encryption.test.ts
+++ b/packages/workspace/src/document/attach-encryption.test.ts
@@ -121,9 +121,9 @@ describe('attachEncryption', () => {
 				throw new Error('not signed-in');
 			},
 		});
-		expect(() =>
-			encryption.attachTable('a', encryptedRowDefinition),
-		).toThrow('not signed-in');
+		expect(() => encryption.attachTable('a', encryptedRowDefinition)).toThrow(
+			'not signed-in',
+		);
 	});
 
 	test('attachReadonlyTable reads encrypted rows without exposing writes', () => {

--- a/packages/workspace/src/document/attach-encryption.ts
+++ b/packages/workspace/src/document/attach-encryption.ts
@@ -197,7 +197,9 @@ export function attachEncryption(
 
 	function register(store: AnyEncryptedStore): void {
 		stores.push(store);
-		store.activateEncryption(deriveKeyring(options.encryptionKeys(), workspaceId));
+		store.activateEncryption(
+			deriveKeyring(options.encryptionKeys(), workspaceId),
+		);
 	}
 
 	const attachment: EncryptionAttachment = {

--- a/packages/workspace/src/document/attach-markdown.ts
+++ b/packages/workspace/src/document/attach-markdown.ts
@@ -6,10 +6,10 @@ import {
 	extractErrorMessage,
 	type InferErrors,
 } from 'wellcrafted/error';
+import { createLogger, type Logger } from 'wellcrafted/logger';
 import { tryAsync } from 'wellcrafted/result';
 import type * as Y from 'yjs';
 import { defineMutation } from '../shared/actions.js';
-import { createLogger, type Logger } from 'wellcrafted/logger';
 import type { MaybePromise } from '../shared/types.js';
 import type { Kv } from './attach-kv.js';
 import {
@@ -178,7 +178,9 @@ const defaultFromMarkdown = (parsed: MarkdownShape): BaseRow =>
  * Default KV serializer: pretty-printed JSON in `kv.json`. Used whenever a
  * registered kv's `config.serialize` isn't provided.
  */
-const defaultKvSerialize = (data: Record<string, unknown>): SerializeResult => ({
+const defaultKvSerialize = (
+	data: Record<string, unknown>,
+): SerializeResult => ({
 	filename: 'kv.json',
 	content: JSON.stringify(data, null, 2),
 });
@@ -523,7 +525,10 @@ export function attachMarkdown(
 
 			await mkdir(directory, { recursive: true });
 			for (const row of entry.table.getAllValid()) {
-				const { filename, content } = await rowToMarkdownFile(row, entry.config);
+				const { filename, content } = await rowToMarkdownFile(
+					row,
+					entry.config,
+				);
 				await writeMarkdownFile(directory, filename, content);
 				written++;
 			}

--- a/packages/workspace/src/document/attach-rich-text.test.ts
+++ b/packages/workspace/src/document/attach-rich-text.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import * as Y from 'yjs';
-import {
-	attachRichText,
-	xmlFragmentToPlaintext,
-} from './attach-rich-text.js';
+import { attachRichText, xmlFragmentToPlaintext } from './attach-rich-text.js';
 
 /** Helper: build a paragraph XmlElement with text content (standalone, for insertion). */
 function makeParagraph(content: string): Y.XmlElement {

--- a/packages/workspace/src/document/attach-sqlite-reader.test.ts
+++ b/packages/workspace/src/document/attach-sqlite-reader.test.ts
@@ -12,10 +12,7 @@ import { join } from 'node:path';
 import { type } from 'arktype';
 import * as Y from 'yjs';
 
-import {
-	attachTables,
-	defineTable,
-} from '../index.js';
+import { attachTables, defineTable } from '../index.js';
 import { attachSqlite } from './attach-sqlite.js';
 import { attachSqliteReader } from './attach-sqlite-reader.js';
 
@@ -38,7 +35,10 @@ afterEach(() => {
 	rmSync(workDir, { recursive: true, force: true });
 });
 
-async function seedMirrorFile(filePath: string, rows: Array<{ id: string; title: string; body: string }>) {
+async function seedMirrorFile(
+	filePath: string,
+	rows: Array<{ id: string; title: string; body: string }>,
+) {
 	const ydoc = new Y.Doc({ guid: 'test-mirror' });
 	const tables = attachTables(ydoc, { entries: entriesTable });
 	const materializer = attachSqlite(ydoc, {
@@ -79,7 +79,9 @@ describe('attachSqliteReader', () => {
 
 		using mirror = attachSqliteReader({ filePath });
 		expect(() =>
-			mirror.db.run("INSERT INTO entries (id, title, body) VALUES ('c', 't', 'b')"),
+			mirror.db.run(
+				"INSERT INTO entries (id, title, body) VALUES ('c', 't', 'b')",
+			),
 		).toThrow();
 	});
 
@@ -107,9 +109,7 @@ describe('attachSqliteReader', () => {
 		// exists but `entries_fts` does not.
 		const ydoc = new Y.Doc({ guid: 'no-fts' });
 		const tables = attachTables(ydoc, { entries: entriesTable });
-		const m = attachSqlite(ydoc, { filePath }).table(
-			tables.entries,
-		);
+		const m = attachSqlite(ydoc, { filePath }).table(tables.entries);
 		await m.whenLoaded;
 		ydoc.destroy();
 

--- a/packages/workspace/src/document/attach-sqlite-reader.ts
+++ b/packages/workspace/src/document/attach-sqlite-reader.ts
@@ -25,10 +25,7 @@
 import { Database } from 'bun:sqlite';
 import { quoteIdentifier } from './sqlite/ddl.js';
 import { ftsSearch } from './sqlite/fts.js';
-import type {
-	SearchOptions,
-	SearchResult,
-} from './sqlite/types.js';
+import type { SearchOptions, SearchResult } from './sqlite/types.js';
 
 /**
  * Options for {@link attachSqliteReader}.
@@ -136,4 +133,3 @@ export function attachSqliteReader({
 		[Symbol.dispose]: dispose,
 	};
 }
-

--- a/packages/workspace/src/document/attach-sqlite.ts
+++ b/packages/workspace/src/document/attach-sqlite.ts
@@ -24,11 +24,11 @@ import { createLogger, type Logger } from 'wellcrafted/logger';
 import type * as Y from 'yjs';
 import { defineMutation, defineQuery } from '../shared/actions.js';
 import { standardSchemaToJsonSchema } from '../shared/standard-schema.js';
-import { openWriterSqlite } from './sqlite-writer.js';
 import type { BaseRow, Table, TableDefinition } from './attach-table.js';
 import { generateDdl, quoteIdentifier } from './sqlite/ddl.js';
 import { ftsSearch } from './sqlite/fts.js';
 import type { SearchOptions, SearchResult } from './sqlite/types.js';
+import { openWriterSqlite } from './sqlite-writer.js';
 
 export { generateDdl } from './sqlite/ddl.js';
 export type { SearchOptions, SearchResult } from './sqlite/types.js';
@@ -210,24 +210,22 @@ export function attachSqlite(
 	// One Yjs transact = one SQL transaction. `db.transaction()` auto-begins,
 	// auto-commits on return, and auto-rolls-back on throw, replacing a
 	// manual BEGIN/COMMIT/ROLLBACK block with no recovery branch needed.
-	const flushTx = db.transaction(
-		(currentPending: Map<string, Set<string>>) => {
-			for (const [tableName, ids] of currentPending) {
-				const entry = registered.get(tableName);
-				if (entry === undefined) continue;
+	const flushTx = db.transaction((currentPending: Map<string, Set<string>>) => {
+		for (const [tableName, ids] of currentPending) {
+			const entry = registered.get(tableName);
+			if (entry === undefined) continue;
 
-				for (const id of ids) {
-					const { data: row, error } = entry.table.get(id);
-					if (error || row === null) {
-						// Invalid or missing → drop from mirror.
-						deleteRow(tableName, id);
-						continue;
-					}
-					insertRow(tableName, row);
+			for (const id of ids) {
+				const { data: row, error } = entry.table.get(id);
+				if (error || row === null) {
+					// Invalid or missing → drop from mirror.
+					deleteRow(tableName, id);
+					continue;
 				}
+				insertRow(tableName, row);
 			}
-		},
-	);
+		}
+	});
 
 	function flushPendingSync() {
 		if (isDisposed) return;
@@ -274,8 +272,7 @@ export function attachSqlite(
 	const rebuildAllTx = db.transaction(() => {
 		for (const [name] of registered)
 			db.run(`DELETE FROM ${quoteIdentifier(name)}`);
-		for (const [name, entry] of registered)
-			fullLoadTable(name, entry.table);
+		for (const [name, entry] of registered) fullLoadTable(name, entry.table);
 	});
 
 	function rebuild(tableName?: string): void {

--- a/packages/workspace/src/document/attach-sync.test.ts
+++ b/packages/workspace/src/document/attach-sync.test.ts
@@ -3,12 +3,12 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import {
 	BC_ORIGIN,
+	BEARER_SUBPROTOCOL_PREFIX,
 	decodeRpcPayload,
 	encodeAwarenessStates,
 	encodeRpcRequest,
 	encodeRpcResponse,
 	encodeSyncStep2,
-	BEARER_SUBPROTOCOL_PREFIX,
 	MAIN_SUBPROTOCOL,
 	MESSAGE_TYPE,
 } from '@epicenter/sync';
@@ -356,5 +356,4 @@ describe('attachSync split surface', () => {
 
 		ydoc.destroy();
 	});
-
 });

--- a/packages/workspace/src/document/attach-sync.ts
+++ b/packages/workspace/src/document/attach-sync.ts
@@ -1,6 +1,7 @@
 /// <reference lib="dom" />
 
 import {
+	BEARER_SUBPROTOCOL_PREFIX,
 	decodeRpcPayload,
 	encodeAwareness,
 	encodeAwarenessStates,
@@ -10,13 +11,12 @@ import {
 	encodeSyncUpdate,
 	handleSyncPayload,
 	isRpcError,
-	BEARER_SUBPROTOCOL_PREFIX,
+	isTransportOrigin,
 	MAIN_SUBPROTOCOL,
 	MESSAGE_TYPE,
 	RpcError,
 	SYNC_MESSAGE_TYPE,
 	SYNC_ORIGIN,
-	isTransportOrigin,
 	type SyncMessageType,
 } from '@epicenter/sync';
 import * as decoding from 'lib0/decoding';

--- a/packages/workspace/src/document/attach-table.ts
+++ b/packages/workspace/src/document/attach-table.ts
@@ -508,7 +508,10 @@ export function createTable<
 			if (current === null) return Ok(null);
 
 			const merged = { ...current, ...partial, id };
-			const { data: validated, error: mergedError } = readonly.parse(id, merged);
+			const { data: validated, error: mergedError } = readonly.parse(
+				id,
+				merged,
+			);
 			if (mergedError) return Err(mergedError);
 
 			ykv.set(validated.id, validated);

--- a/packages/workspace/src/document/attach-timeline/richtext.test.ts
+++ b/packages/workspace/src/document/attach-timeline/richtext.test.ts
@@ -1,6 +1,6 @@
-import { xmlFragmentToPlaintext } from '../attach-rich-text.js';
 import { describe, expect, test } from 'bun:test';
 import * as Y from 'yjs';
+import { xmlFragmentToPlaintext } from '../attach-rich-text.js';
 import { populateFragmentFromText } from './richtext.js';
 import { attachTimeline } from './timeline.js';
 

--- a/packages/workspace/src/document/attach-timeline/timeline.test.ts
+++ b/packages/workspace/src/document/attach-timeline/timeline.test.ts
@@ -5,9 +5,9 @@
  * mode conversion, and snapshot restore.
  */
 
-import { xmlFragmentToPlaintext } from '../attach-rich-text.js';
 import { describe, expect, test } from 'bun:test';
 import * as Y from 'yjs';
+import { xmlFragmentToPlaintext } from '../attach-rich-text.js';
 import { attachTimeline } from './timeline.js';
 
 function setup() {

--- a/packages/workspace/src/document/attach-yjs-log-reader.test.ts
+++ b/packages/workspace/src/document/attach-yjs-log-reader.test.ts
@@ -6,10 +6,10 @@
  */
 
 import { Database } from 'bun:sqlite';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as Y from 'yjs';
 import { attachYjsLog } from './attach-yjs-log.js';
 import { attachYjsLogReader } from './attach-yjs-log-reader.js';

--- a/packages/workspace/src/document/attach-yjs-log-reader.ts
+++ b/packages/workspace/src/document/attach-yjs-log-reader.ts
@@ -20,8 +20,8 @@
  * function returns; no `whenLoaded` field.
  */
 
-import { existsSync } from 'node:fs';
 import { Database } from 'bun:sqlite';
+import { existsSync } from 'node:fs';
 import * as Y from 'yjs';
 
 export type YjsLogReaderAttachment = {

--- a/packages/workspace/src/document/attach-yjs-log.test.ts
+++ b/packages/workspace/src/document/attach-yjs-log.test.ts
@@ -9,10 +9,10 @@
  */
 
 import { Database } from 'bun:sqlite';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as Y from 'yjs';
 import { attachYjsLog } from './attach-yjs-log.js';
 

--- a/packages/workspace/src/document/create-kv.test.ts
+++ b/packages/workspace/src/document/create-kv.test.ts
@@ -5,9 +5,9 @@
 import { expect, test } from 'bun:test';
 import { type } from 'arktype';
 import * as Y from 'yjs';
-import { createKv } from './internal.js';
 import { createEncryptedYkvLww } from '../shared/y-keyvalue/y-keyvalue-lww-encrypted.js';
 import { defineKv } from './define-kv.js';
+import { createKv } from './internal.js';
 import { KV_KEY } from './keys.js';
 
 test('set stores a value that get returns', () => {

--- a/packages/workspace/src/document/create-table.test.ts
+++ b/packages/workspace/src/document/create-table.test.ts
@@ -5,10 +5,10 @@
 import { describe, expect, test } from 'bun:test';
 import { type } from 'arktype';
 import * as Y from 'yjs';
-import { createReadonlyTable, createTable } from './internal.js';
 import { createEncryptedYkvLww } from '../shared/y-keyvalue/y-keyvalue-lww-encrypted.js';
-import { defineTable } from './define-table.js';
 import { attachReadonlyTable, attachTable } from './attach-table.js';
+import { defineTable } from './define-table.js';
+import { createReadonlyTable, createTable } from './internal.js';
 
 /** Creates Yjs infrastructure for testing */
 function setup() {
@@ -27,9 +27,7 @@ describe('createTable', () => {
 			const helper = createReadonlyTable(ykv, definition, 'test');
 			ykv.set('1', { id: '1', name: 'Alice', _v: 1 });
 
-			expect(helper.getAllValid()).toEqual([
-				{ id: '1', name: 'Alice', _v: 1 },
-			]);
+			expect(helper.getAllValid()).toEqual([{ id: '1', name: 'Alice', _v: 1 }]);
 			expect(helper.count()).toBe(1);
 			expect(helper.has('1')).toBe(true);
 			expect('set' in helper).toBe(false);

--- a/packages/workspace/src/document/define-table.test.ts
+++ b/packages/workspace/src/document/define-table.test.ts
@@ -28,7 +28,6 @@ describe('defineTable', () => {
 			});
 			expect(result).not.toHaveProperty('issues');
 		});
-
 	});
 
 	describe('variadic syntax', () => {
@@ -145,9 +144,14 @@ describe('defineTable', () => {
 			});
 
 			// v3 passes through unchanged
-			const latest = { id: '1', title: 'Test', views: 5, author: 'a', _v: 3 as const };
+			const latest = {
+				id: '1',
+				title: 'Test',
+				views: 5,
+				author: 'a',
+				_v: 3 as const,
+			};
 			expect(posts.migrate(latest)).toEqual(latest);
 		});
 	});
-
 });

--- a/packages/workspace/src/document/define-table.ts
+++ b/packages/workspace/src/document/define-table.ts
@@ -29,11 +29,7 @@
  */
 
 import type { StandardSchemaV1 } from '@standard-schema/spec';
-import type {
-	BaseRow,
-	LastSchema,
-	TableDefinition,
-} from './attach-table.js';
+import type { BaseRow, LastSchema, TableDefinition } from './attach-table.js';
 import { createUnionSchema } from './schema-union.js';
 import type { CombinedStandardSchema } from './standard-schema.js';
 

--- a/packages/workspace/src/document/internal.ts
+++ b/packages/workspace/src/document/internal.ts
@@ -17,5 +17,5 @@ export type InternalEncryptedIndexedDbAttachment = IndexedDbAttachment & {
 	activateEncryption(keyring: ReadonlyMap<number, Uint8Array>): void;
 };
 
-export { createReadonlyTable, createTable } from './attach-table.js';
 export { createKv } from './attach-kv.js';
+export { createReadonlyTable, createTable } from './attach-table.js';

--- a/packages/workspace/src/document/markdown/serializers.ts
+++ b/packages/workspace/src/document/markdown/serializers.ts
@@ -65,4 +65,3 @@ export function slugFilename<TRow extends BaseRow>(
 		);
 	};
 }
-

--- a/packages/workspace/src/document/materializer/markdown/index.ts
+++ b/packages/workspace/src/document/materializer/markdown/index.ts
@@ -1,8 +1,8 @@
 export { assembleMarkdown, type SerializeResult } from './markdown.js';
 export {
 	attachMarkdownMaterializer,
-	MaterializerPushError,
 	type MarkdownShape,
+	MaterializerPushError,
 	type PushEvent,
 	type PushResult,
 } from './materializer.js';

--- a/packages/workspace/src/document/materializer/markdown/materializer.ts
+++ b/packages/workspace/src/document/materializer/markdown/materializer.ts
@@ -6,10 +6,10 @@ import {
 	extractErrorMessage,
 	type InferErrors,
 } from 'wellcrafted/error';
+import { createLogger, type Logger } from 'wellcrafted/logger';
 import { tryAsync } from 'wellcrafted/result';
 import type * as Y from 'yjs';
 import { defineMutation } from '../../../shared/actions.js';
-import { createLogger, type Logger } from 'wellcrafted/logger';
 import type { MaybePromise } from '../../../shared/types.js';
 import type { Kv } from '../../attach-kv.js';
 import {
@@ -165,7 +165,9 @@ const defaultFromMarkdown = (parsed: MarkdownShape): BaseRow =>
  * Default KV serializer: pretty-printed JSON in `kv.json`. Used whenever a
  * registered kv's `config.serialize` isn't provided.
  */
-const defaultKvSerialize = (data: Record<string, unknown>): SerializeResult => ({
+const defaultKvSerialize = (
+	data: Record<string, unknown>,
+): SerializeResult => ({
 	filename: 'kv.json',
 	content: JSON.stringify(data, null, 2),
 });
@@ -273,7 +275,8 @@ export function attachMarkdownMaterializer(
 	 */
 	let isRegistrationOpen = true;
 
-	const resolveDir = async () => (typeof dir === 'function' ? await dir() : dir);
+	const resolveDir = async () =>
+		typeof dir === 'function' ? await dir() : dir;
 
 	// ── Per-table materialization ───────────────────────────────
 
@@ -515,7 +518,10 @@ export function attachMarkdownMaterializer(
 
 			await mkdir(directory, { recursive: true });
 			for (const row of entry.table.getAllValid()) {
-				const { filename, content } = await rowToMarkdownFile(row, entry.config);
+				const { filename, content } = await rowToMarkdownFile(
+					row,
+					entry.config,
+				);
 				await writeMarkdownFile(directory, filename, content);
 				written++;
 			}

--- a/packages/workspace/src/document/materializer/markdown/serializers.ts
+++ b/packages/workspace/src/document/materializer/markdown/serializers.ts
@@ -65,4 +65,3 @@ export function slugFilename<TRow extends BaseRow>(
 		);
 	};
 }
-

--- a/packages/workspace/src/document/materializer/sqlite/sqlite.ts
+++ b/packages/workspace/src/document/materializer/sqlite/sqlite.ts
@@ -17,9 +17,9 @@ import {
 	extractErrorMessage,
 	type InferErrors,
 } from 'wellcrafted/error';
+import { createLogger, type Logger } from 'wellcrafted/logger';
 import type * as Y from 'yjs';
 import { defineMutation, defineQuery } from '../../../shared/actions.js';
-import { createLogger, type Logger } from 'wellcrafted/logger';
 import { standardSchemaToJsonSchema } from '../../../shared/standard-schema.js';
 import type { BaseRow, Table, TableDefinition } from '../../attach-table.js';
 import { generateDdl, quoteIdentifier } from './ddl.js';
@@ -52,7 +52,9 @@ export const SqliteMaterializerError = defineErrors({
 		cause,
 	}),
 });
-export type SqliteMaterializerError = InferErrors<typeof SqliteMaterializerError>;
+export type SqliteMaterializerError = InferErrors<
+	typeof SqliteMaterializerError
+>;
 
 /**
  * Per-table configuration, generic over the specific row type so `fts` narrows

--- a/packages/workspace/src/document/on-local-update.ts
+++ b/packages/workspace/src/document/on-local-update.ts
@@ -19,8 +19,8 @@ import {
 	extractErrorMessage,
 	type InferErrors,
 } from 'wellcrafted/error';
-import type * as Y from 'yjs';
 import { createLogger, type Logger } from 'wellcrafted/logger';
+import type * as Y from 'yjs';
 
 /** Error produced when the user-supplied `fn` throws synchronously. */
 export const OnLocalUpdateError = defineErrors({

--- a/packages/workspace/src/document/schema-union.test.ts
+++ b/packages/workspace/src/document/schema-union.test.ts
@@ -11,8 +11,8 @@
 
 import { describe, expect, test } from 'bun:test';
 import { type } from 'arktype';
-import type { CombinedStandardSchema } from './standard-schema.js';
 import { createUnionSchema } from './schema-union.js';
+import type { CombinedStandardSchema } from './standard-schema.js';
 
 describe('createUnionSchema', () => {
 	test('validates against first matching schema', () => {

--- a/packages/workspace/src/document/sqlite-writer.ts
+++ b/packages/workspace/src/document/sqlite-writer.ts
@@ -21,9 +21,9 @@
  * pick up the change in lockstep.
  */
 
+import { Database } from 'bun:sqlite';
 import { mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
-import { Database } from 'bun:sqlite';
 import {
 	defineErrors,
 	extractErrorMessage,
@@ -43,7 +43,10 @@ export const SqliteWriterError = defineErrors({
 	PragmaSetupFailed: ({
 		pragma,
 		cause,
-	}: { pragma: string; cause: unknown }) => ({
+	}: {
+		pragma: string;
+		cause: unknown;
+	}) => ({
 		message: `[sqlite-writer] PRAGMA ${pragma} failed: ${extractErrorMessage(cause)}`,
 		pragma,
 		cause,
@@ -97,7 +100,9 @@ export function openWriterSqlite({
 	if (walResult.error !== null) {
 		log.warn(walResult.error);
 	} else if (walResult.data !== 'wal') {
-		log.warn(SqliteWriterError.WalSilentFallback({ actualMode: walResult.data }));
+		log.warn(
+			SqliteWriterError.WalSilentFallback({ actualMode: walResult.data }),
+		);
 	}
 
 	const syncResult = trySync({

--- a/packages/workspace/src/document/wipe-owner-local-yjs-data.test.ts
+++ b/packages/workspace/src/document/wipe-owner-local-yjs-data.test.ts
@@ -43,7 +43,9 @@ async function databaseNames(): Promise<string[]> {
 
 describe('wipeOwnerLocalYjsData', () => {
 	afterEach(async () => {
-		await Promise.all((await databaseNames()).map((name) => deleteDatabase(name)));
+		await Promise.all(
+			(await databaseNames()).map((name) => deleteDatabase(name)),
+		);
 	});
 
 	test('clears known scoped document keys', async () => {

--- a/packages/workspace/src/document/y-keyvalue/index.ts
+++ b/packages/workspace/src/document/y-keyvalue/index.ts
@@ -16,12 +16,10 @@ export {
 	type YKeyValueChangeHandler,
 	type YKeyValueEntry,
 } from './_reference/y-keyvalue.js';
-
-export { YKeyValueLww, type YKeyValueLwwEntry } from './y-keyvalue-lww.js';
-
 export type {
 	KvEntry,
 	KvStoreChange,
 	KvStoreChangeHandler,
 	ObservableKvStore,
 } from './observable-kv-store.js';
+export { YKeyValueLww, type YKeyValueLwwEntry } from './y-keyvalue-lww.js';

--- a/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.test.ts
+++ b/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.test.ts
@@ -15,8 +15,8 @@
  */
 import { describe, expect, test } from 'bun:test';
 import * as Y from 'yjs';
-import { YKeyValueLww, type YKeyValueLwwEntry } from './y-keyvalue-lww';
 import { YKeyValue, type YKeyValueEntry } from './_reference/y-keyvalue';
+import { YKeyValueLww, type YKeyValueLwwEntry } from './y-keyvalue-lww';
 
 describe('YKeyValueLww', () => {
 	describe('Basic Operations', () => {

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -189,8 +189,8 @@ export {
 	BC_ORIGIN,
 } from './document/attach-broadcast-channel.js';
 export {
-	attachEncryption,
 	type AttachEncryptionOptions,
+	attachEncryption,
 	type EncryptionAttachment,
 } from './document/attach-encryption.js';
 export {

--- a/packages/workspace/src/rpc/remote-actions.test.ts
+++ b/packages/workspace/src/rpc/remote-actions.test.ts
@@ -79,7 +79,10 @@ function setupRemoteOptions({
 
 	const initialPeers = Array.isArray(present)
 		? present
-		: Object.entries(present).map(([peerId, clientId]) => ({ peerId, clientId }));
+		: Object.entries(present).map(([peerId, clientId]) => ({
+				peerId,
+				clientId,
+			}));
 
 	const addPeer = (peerId: string, clientId: number) => {
 		const remoteDoc = new Y.Doc({ guid: peerId });

--- a/packages/workspace/src/shared/device-id.test.ts
+++ b/packages/workspace/src/shared/device-id.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'bun:test';
 import { getOrCreateInstallationId, type SimpleStorage } from './device-id.js';
 
-function makeMemoryStorage(initial: Record<string, string> = {}): SimpleStorage {
+function makeMemoryStorage(
+	initial: Record<string, string> = {},
+): SimpleStorage {
 	const store = new Map(Object.entries(initial));
 	return {
 		getItem: (k) => store.get(k) ?? null,

--- a/packages/workspace/src/shared/device-id.ts
+++ b/packages/workspace/src/shared/device-id.ts
@@ -31,9 +31,9 @@ export function getOrCreateInstallationId<T extends string = string>(
 	return fresh as unknown as T;
 }
 
-export async function getOrCreateInstallationIdAsync<
-	T extends string = string,
->(storage: AsyncStorage): Promise<T> {
+export async function getOrCreateInstallationIdAsync<T extends string = string>(
+	storage: AsyncStorage,
+): Promise<T> {
 	const existing = await storage.getItem(KEY);
 	if (existing) return existing as T;
 	const fresh = generateGuid();

--- a/packages/workspace/src/shared/logger/jsonl-sink.test.ts
+++ b/packages/workspace/src/shared/logger/jsonl-sink.test.ts
@@ -1,7 +1,7 @@
+import { afterEach, describe, expect, test } from 'bun:test';
 import { readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, test } from 'bun:test';
 import { defineErrors, extractErrorMessage } from 'wellcrafted/error';
 import { composeSinks, createLogger } from 'wellcrafted/logger';
 import { jsonlFileSink } from './jsonl-sink.js';
@@ -51,7 +51,10 @@ describe('jsonlFileSink', () => {
 		const second = JSON.parse(lines[1] as string);
 		expect(second.level).toBe('warn');
 		expect(second.data.name).toBe('Boom');
-		expect(second.data.cause).toMatchObject({ name: 'Error', message: 'kaboom' });
+		expect(second.data.cause).toMatchObject({
+			name: 'Error',
+			message: 'kaboom',
+		});
 	});
 
 	test('auto-creates parent directory', async () => {

--- a/packages/workspace/src/shared/standard-schema.ts
+++ b/packages/workspace/src/shared/standard-schema.ts
@@ -4,8 +4,8 @@ import {
 	extractErrorMessage,
 	type InferErrors,
 } from 'wellcrafted/error';
-import { Ok, trySync } from 'wellcrafted/result';
 import { createLogger } from 'wellcrafted/logger';
+import { Ok, trySync } from 'wellcrafted/result';
 
 const log = createLogger('standard-schema');
 

--- a/playground/opensidian-e2e/epicenter.config.test.ts
+++ b/playground/opensidian-e2e/epicenter.config.test.ts
@@ -19,8 +19,8 @@ import { createFileContentDoc, type FileId } from '@epicenter/filesystem';
 import {
 	attachEncryption,
 	createDisposableCache,
-	generateId,
 	type EncryptionKeys,
+	generateId,
 } from '@epicenter/workspace';
 import { attachSqlite } from '@epicenter/workspace/document/attach-sqlite';
 import { assembleMarkdown } from '@epicenter/workspace/document/materializer/markdown';

--- a/specs/20260312T210000-whispering-settings-separation.md
+++ b/specs/20260312T210000-whispering-settings-separation.md
@@ -8,7 +8,7 @@
 
 Split Whispering's unified `settings.svelte.ts` (localStorage-backed, ~80 keys) into two reactive state files reflecting a real architectural boundary:
 
-- **`workspace-settings.svelte.ts`** — ~42 synced preferences backed by Yjs KV (SvelteMap + observer)
+- **`workspace-settings.svelte.ts`**: ~42 synced preferences backed by Yjs KV through reactive views
 - **`device-config.svelte.ts`** — ~36 device-bound keys backed by localStorage (`createPersistedState`)
 
 This wave creates the reactive layer that Wave 3 (migration) writes into.
@@ -22,15 +22,15 @@ This wave creates the reactive layer that Wave 3 (migration) writes into.
 │  workspace-settings.svelte.ts                                    │
 │                                                                  │
 │  ┌──────────────┐  observeAll()  ┌───────────────┐  .get(key)  │
-│  │  Yjs KV      │───────────────►│  SvelteMap    │────────────►UI│
-│  │  (Y.Array)   │               │  (reactive)   │              │
+│  │  Yjs KV      │───────────────►│ reactive view │────────────►UI│
+│  │  (Y.Array)   │               │               │              │
 │  │  42 entries   │               │  42 entries   │              │
 │  └──────┬───────┘               └───────────────┘              │
 │         ▲                              │                        │
 │         │     kv.set(key, value)       │                        │
 │         └──────────────────────────────┘                        │
 │           write goes to Yjs first,                              │
-│           observer updates SvelteMap                            │
+│           observer invalidates the view                         │
 └─────────────────────────────────────────────────────────────────┘
 ```
 

--- a/specs/20260315T070000-query-layer-switch-to-workspace-tables.md
+++ b/specs/20260315T070000-query-layer-switch-to-workspace-tables.md
@@ -212,7 +212,7 @@ function createWorkspaceRecordings() {
             );
         },
 
-        /** Create or update a recording. Writes to Yjs → observer updates SvelteMap. */
+        /** Create or update a recording. Writes to Yjs; reactive table views invalidate from table changes. */
         set(recording: Recording) {
             workspace.tables.recordings.set(recording);
         },
@@ -352,7 +352,7 @@ The old model had `transformation.steps[]` as a nested array. The workspace mode
 
 ### Summary
 
-Replaced TanStack Query + DbService read/write path with reactive SvelteMap state modules backed by Yjs workspace tables for recordings. The recordings data flow is now fully workspace-backed: components read from SvelteMap, writes go directly to workspace tables, Yjs observers keep the SvelteMap in sync. Transformations are partially migrated—reads and deletes use workspace state, but create/update still go through TanStack Query mutations because the Editor component uses the old dot-notation field schema.
+Replaced TanStack Query + DbService read/write path with reactive table state backed by Yjs workspace tables for recordings. The recordings data flow is now fully workspace-backed: components read readonly table views, writes go directly to workspace tables, and table changes invalidate the view. Transformations are partially migrated because reads and deletes use workspace state, but create and update still go through TanStack Query mutations because the Editor component uses the old dot-notation field schema.
 
 ### Deviations from Spec
 

--- a/specs/20260315T210229-clean-up-dead-rpc-db-code.md
+++ b/specs/20260315T210229-clean-up-dead-rpc-db-code.md
@@ -2,10 +2,10 @@
 
 ## Context
 
-We migrated recordings, transformations, transformation steps, and transformation runs from TanStack Query + DbService to reactive SvelteMap state modules backed by Yjs workspace tables. The data flow is now:
+We migrated recordings, transformations, transformation steps, and transformation runs from TanStack Query + DbService to reactive table state backed by Yjs workspace tables. The current table view API is readonly: `all` and `byId(id)`.
 
 ```
-Workspace (Yjs) → SvelteMap state modules → Components
+Workspace (Yjs) -> readonly table views -> Components
 ```
 
 Instead of:

--- a/specs/20260318T234754-rename-svelte-package-and-add-fromKv.md
+++ b/specs/20260318T234754-rename-svelte-package-and-add-fromKv.md
@@ -180,7 +180,10 @@ All writes: `workspaceClient.kv.set('selectedFolderId', v)` → `selectedFolderI
 Svelte 5's own `fromStore()` establishes the convention: convert an external data source into reactive Svelte state. The `from*` family scales: `fromKv`, `fromTable`, future `fromKvAll`.
 
 ### Why `.current` on `fromKv` but not `fromTable`
-`fromKv` wraps a scalar value → needs a box (`{ current }`). `fromTable` wraps a collection → IS a collection (SvelteMap). Same distinction as `$state(value)` vs `SvelteMap`.
+Current API note: `fromKv` wraps a scalar value, so it uses `{ current }`.
+`fromTable` returns a readonly table view with `all` and `byId(id)`. The first
+implementation returned a `SvelteMap`, which is why the historical migration
+notes below mention `.get()` and `.values()`.
 
 ### Why `destroy` (not `dispose` or `Symbol.dispose`)
 - `destroy` matches the workspace codebase convention (extensions, WorkspaceClient all use `destroy`)
@@ -256,10 +259,10 @@ With 3 utilities (`fromKv`, `fromTable`, `createPersistedState`), one entry poin
 **Phase 2 — First migrations:**
 - Added `@epicenter/svelte` dep to honeycrisp + fuji `package.json`
 - Migrated honeycrisp `view.svelte.ts`: 3 `$state` + 3 `kv.observe` → 3 `fromKv` calls. Updated all `.current` reads/writes.
-- Migrated fuji `+page.svelte`: removed `$effect` wrapper, replaced 2 KV observers with `fromKv`, 1 table observer with `fromTable`. Updated derived state to use SvelteMap `.get()` and `[...values()]`.
+- Migrated fuji `+page.svelte`: removed `$effect` wrapper, replaced 2 KV observers with `fromKv`, 1 table observer with `fromTable`. At the time, derived state used SvelteMap `.get()` and `[...values()]`; current code should use `view.byId(id)` and `view.all`.
 
 **Phase 3 — Full rollout:**
-- Migrated honeycrisp `notes.svelte.ts`: replaced `allNotes` array + observe with `fromTable`. Derived `notes`, `deletedNotes`, `noteCounts` now read from `[...allNotesMap.values()]`.
+- Migrated honeycrisp `notes.svelte.ts`: replaced `allNotes` array + observe with `fromTable`. At the time, derived `notes`, `deletedNotes`, and `noteCounts` read from `[...allNotesMap.values()]`; current code should use `view.all`.
 - Migrated honeycrisp `folders.svelte.ts`: replaced `folders` array + observe with `fromTable`.
 - Migrated tab-manager `saved-tab-state.svelte.ts`: replaced `tabs` array + observe with `fromTable`.
 - Migrated tab-manager `bookmark-state.svelte.ts`: replaced `bookmarks` array + observe with `fromTable`.

--- a/specs/20260331T120000-skills-editor-domain-migration.md
+++ b/specs/20260331T120000-skills-editor-domain-migration.md
@@ -78,11 +78,11 @@ const workspace = createWorkspace(honeycrisp)
 
 Two patterns exist:
 
-**Pattern A: `fromTable()`** (honeycrisp, tab-manager, zhongwen, fuji)—preferred for domain tables:
+**Pattern A: `fromTable()`** (honeycrisp, tab-manager, zhongwen, fuji): preferred for domain tables:
 
 ```typescript
-const skillsMap = fromTable(workspace.tables.skills);
-const skills = $derived(skillsMap.values().toArray().sort((a, b) => a.name.localeCompare(b.name)));
+const skillsView = fromTable(workspace.tables.skills);
+const skills = $derived(skillsView.all.toSorted((a, b) => a.name.localeCompare(b.name)));
 ```
 
 **Pattern B: Manual `SvelteMap` + `observe()`** (whispering)—used when custom logic is needed on each change event. Not needed here.

--- a/specs/20260502T233446-sync-token-source-and-disposable-child-docs.md
+++ b/specs/20260502T233446-sync-token-source-and-disposable-child-docs.md
@@ -312,7 +312,7 @@ Run app typechecks where practical. If they fail on existing unrelated Svelte or
 
 ### Deviations From Spec
 
-- `fromDocumentFamily` was replaced with `fromDisposableCache` because five Svelte call sites shared the same reactive open and dispose pattern. The helper earns the one-sentence test: bind a plain disposable cache to a reactive id and dispose the previous handle on id changes.
+- `fromDocumentFamily` was replaced with `fromDisposableCache`, now named `useCacheHandle`, because five Svelte call sites shared the same reactive open and dispose pattern. The helper earns the one-sentence test: bind a plain disposable cache to a reactive id and dispose the previous handle on id changes.
 - Zhongwen has no compatible browser sync setup in its current client path, so there was no token-source browser sync call site to update.
 
 ### Verification

--- a/specs/20260506T010807-signed-in-owns-the-workspace.md
+++ b/specs/20260506T010807-signed-in-owns-the-workspace.md
@@ -147,7 +147,7 @@ function createEntriesStateForFuji() {
 Three concerns:
 
 1. **Reactive views over fuji** (`active`, `deleted`): pure data, belongs on fuji.
-2. **Lifecycle wrapper** (`fromTable` + `[Symbol.dispose]`): belongs on fuji, tied to fuji's `[Symbol.dispose]`.
+2. **Lifecycle wrapper at the time** (`fromTable` + `[Symbol.dispose]`): this was obsolete after `fromTable` became a readonly view with its own `createSubscriber` lifecycle.
 3. **`createEntry` with navigation**: UI policy. Two lines in a click handler.
 
 Refusal: drop the bundled `createEntry()`. Move reactive views onto `fuji.entries`. Let the click handler call `fuji.actions.entries.create()` then `goto()`. The `entries-state.svelte.ts` file deletes.

--- a/specs/20260506T123741-from-table-readonly-view-redesign.md
+++ b/specs/20260506T123741-from-table-readonly-view-redesign.md
@@ -1,7 +1,7 @@
 # `fromTable` Readonly View Redesign
 
 **Date**: 2026-05-06
-**Status**: In Progress; refreshed 2026-05-07
+**Status**: Implemented; verification blocked by baseline tooling
 **Author**: AI-assisted
 **Branch**: feat/from-table-readonly-view
 **Refresh note**: The May 7 session cleanup moved Fuji's `fromTable` usage
@@ -274,6 +274,7 @@ Build, prove, remove. Phases 1 to 4 are sequential; within Phase 2 the per-app m
 - [x] **0.2** Keep all `other resource cleanup` paths. Known examples: Fuji workspace disposal, OpenSidian `fs.index` and `fs` disposal, chat message observers, chat handles, and workspace handles.
 - [x] **0.3** In OpenSidian filesystem state, rewrite comments that claim ancestor-only or key-level tracking if this migration accepts global invalidation.
 - [ ] **0.4** Measure or smoke-test OpenSidian filesystem interactions with a large sample tree before merging the global-subscriber version.
+  > **Not run**: remains an explicit manual pre-merge check because the dev-server smoke pass was not completed in this execution session.
 
 ### Phase 1: Build the new primitive
 
@@ -312,17 +313,24 @@ Each file changes per the translation table below. No file change depends on ano
 ### Phase 3: Verify
 
 - [ ] **3.1** `bun run typecheck` across the monorepo passes with zero new errors.
+  > **Blocked**: full typecheck does not reach a green gate on `origin/main` shape. `apps/zhongwen/.svelte-kit/tsconfig.json` was missing until `bun run --cwd apps/zhongwen svelte-kit sync`. The rerun then failed in `@epicenter/landing` because `svelte-check` is not available after `astro check`, and focused changed-package checks also hit existing `@epicenter/ui` alias resolution errors from app typechecks. Grepping the focused output did not surface errors in the files changed by this implementation.
 - [ ] **3.2** `bun run test` passes.
+  > **Blocked**: full monorepo `bun run test` stops in `@epicenter/zhongwen` because its test script targets `./src/routes/(signed-in)/zhongwen`, where Bun reports no matching test files. Focused verification for `@epicenter/svelte` passes: `bun run test --filter=@epicenter/svelte`.
 - [ ] **3.3** Manual smoke: launch whispering, fuji, honeycrisp, tab-manager. Exercise per-app create/update/delete flows for at least one tabular view. Confirm no regressions in TanStack Table sorting or row updates.
+  > **Not run**: app-level dev-server smoke was left for PR review because the automated verification gates above are blocked by baseline setup issues.
 - [ ] **3.4** HMR check: edit one of the migrated wrapper files (e.g. `recordings.svelte.ts`), confirm hot replace does not leak observers (open devtools, check Yjs document for accumulated handlers if any.)
+  > **Not run**: same manual-smoke constraint as 3.3.
 - [ ] **3.5** Sign-out smoke: in fuji, sign out and back in. Confirm the rebuilt session payload does not retain stale entries data.
+  > **Not run**: same manual-smoke constraint as 3.3.
 
 ### Phase 4: Remove
 
-- [ ] **4.1** Delete the `ReactiveTableMap` type export reference (already done in 1.2; this phase confirms nothing imports it).
-- [ ] **4.2** Search-and-fail: `grep -rn "ReactiveTableMap" packages/ apps/` returns zero hits.
-- [ ] **4.3** Search-and-fail: no cleanup remains whose only purpose is disposing a `fromTable` view. Cleanup for other resources may remain.
-- [ ] **4.4** Update `docs/articles/sveltemap-over-state-for-keyed-collections.md` and `docs/articles/derived-vs-getter-caching-matters.md` if the new primitive contradicts examples.
+- [x] **4.1** Delete the `ReactiveTableMap` type export reference (already done in 1.2; this phase confirms nothing imports it).
+- [x] **4.2** Search-and-fail: `grep -rn "ReactiveTableMap" packages/ apps/` returns zero hits.
+- [x] **4.3** Search-and-fail: no cleanup remains whose only purpose is disposing a `fromTable` view. Cleanup for other resources may remain.
+  > **Audit**: remaining `[Symbol.dispose]()` and HMR cleanup in fromTable-adjacent files belongs to chat handles, table observers, filesystem indexes, workspace handles, or app bundles.
+- [x] **4.4** Update `docs/articles/sveltemap-over-state-for-keyed-collections.md` and `docs/articles/derived-vs-getter-caching-matters.md` if the new primitive contradicts examples.
+  > **Updated**: both docs now describe workspace table views as live readonly views over Yjs instead of SvelteMap mirrors.
 
 ### Call site translation table
 
@@ -469,13 +477,85 @@ createSubscriber refcounts. Two `$derived` reading `recordings.all` produce one 
 
 ## Success Criteria
 
-- [ ] `packages/svelte-utils/src/from-table.svelte.ts` is < 30 lines and uses only `svelte/reactivity` public exports.
-- [ ] Zero `Symbol.dispose` references remain in app code paths that consume `fromTable`.
-- [ ] Zero `import.meta.hot.dispose(...)` related to `fromTable` consumers.
-- [ ] Zero `onDestroy(...)` calls related to `fromTable` consumers.
+- [x] `packages/svelte-utils/src/from-table.svelte.ts` is < 30 lines and uses only `svelte/reactivity` public exports.
+- [x] Zero `Symbol.dispose` references remain in app code paths that consume `fromTable`.
+- [x] Zero `import.meta.hot.dispose(...)` related to `fromTable` consumers.
+- [x] Zero `onDestroy(...)` calls related to `fromTable` consumers.
 - [ ] `bun run typecheck` and `bun run test` pass.
 - [ ] Manual smoke across whispering, fuji, honeycrisp, tab-manager passes for create/update/delete on at least one tabular view per app.
 - [ ] HMR replace of a migrated wrapper file does not produce a stale-observer warning or duplicate row updates.
+
+## Post Implementation Review
+
+Files read:
+
+```txt
+.agents/
+`-- skills/svelte/SKILL.md
+apps/
+|-- fuji/src/
+|   |-- lib/session.svelte.ts
+|   `-- routes/(signed-in)/
+|       |-- components/EntryEditor.svelte
+|       `-- entries/[id]/+page.svelte
+|-- honeycrisp/src/
+|   |-- lib/session.svelte.ts
+|   `-- routes/(signed-in)/
+|       |-- components/NoteBodyPane.svelte
+|       `-- state/
+|           |-- folders.svelte.ts
+|           |-- index.ts
+|           |-- notes.svelte.ts
+|           `-- view.svelte.ts
+|-- opensidian/src/lib/
+|   |-- chat/chat-state.svelte.ts
+|   |-- components/editor/ContentEditor.svelte
+|   `-- state/fs-state.svelte.ts
+|-- skills/src/lib/
+|   |-- components/editor/
+|   |   |-- ExpandedReference.svelte
+|   |   `-- InstructionsEditor.svelte
+|   `-- state/skills-state.svelte.ts
+|-- tab-manager/src/lib/
+|   |-- chat/chat-state.svelte.ts
+|   `-- state/
+|       |-- bookmark-state.svelte.ts
+|       |-- saved-tab-state.svelte.ts
+|       `-- tool-trust.svelte.ts
+|-- whispering/src/
+|   |-- lib/query/
+|   |   |-- README.md
+|   |   |-- actions.ts
+|   |   `-- transformer.ts
+|   |-- lib/state/
+|   |   |-- README.md
+|   |   |-- recordings.svelte.ts
+|   |   |-- transformation-runs.svelte.ts
+|   |   |-- transformation-steps.svelte.ts
+|   |   `-- transformations.svelte.ts
+|   `-- routes/(app)/(config)/
+|       |-- recordings/+page.svelte
+|       |-- recordings/row-actions/RecordingRowActions.svelte
+|       `-- transformations/TransformationRowActions.svelte
+`-- zhongwen/src/routes/(signed-in)/chat/chat-state.svelte.ts
+docs/articles/
+|-- derived-vs-getter-caching-matters.md
+`-- sveltemap-over-state-for-keyed-collections.md
+packages/svelte-utils/
+|-- package.json
+`-- src/
+    |-- from-table.svelte.test.ts
+    |-- from-table.svelte.ts
+    |-- index.ts
+    `-- use-cache-handle.svelte.ts
+```
+
+Review result:
+
+- No old `fromTable` public shape remains in app or package call sites.
+- Remaining cleanup in fromTable-adjacent files owns other resources, not the table view.
+- Focused `@epicenter/svelte` tests pass after the review edits.
+- Full monorepo typecheck, full monorepo test, and manual smoke remain blocked or not run as documented in Phase 3.
 
 ## References
 

--- a/specs/20260506T123741-from-table-readonly-view-redesign.md
+++ b/specs/20260506T123741-from-table-readonly-view-redesign.md
@@ -269,9 +269,10 @@ Build, prove, remove. Phases 1 to 4 are sequential; within Phase 2 the per-app m
 
 ### Phase 0: Reconfirm lifecycle and granularity
 
-- [ ] **0.1** For every Phase 2 file, list each `[Symbol.dispose]()` or HMR cleanup and mark it as `fromTable observer cleanup` or `other resource cleanup`.
-- [ ] **0.2** Keep all `other resource cleanup` paths. Known examples: Fuji workspace disposal, OpenSidian `fs.index` and `fs` disposal, chat message observers, chat handles, and workspace handles.
-- [ ] **0.3** In OpenSidian filesystem state, rewrite comments that claim ancestor-only or key-level tracking if this migration accepts global invalidation.
+- [x] **0.1** For every Phase 2 file, list each `[Symbol.dispose]()` or HMR cleanup and mark it as `fromTable observer cleanup` or `other resource cleanup`.
+  > **Audit**: Honeycrisp folders/notes/state, Fuji entries view, skills state, tab-manager saved tabs/bookmarks/tool trust, and Whispering table wrappers only owned fromTable observer cleanup. Tab-manager chat, Zhongwen chat, OpenSidian chat, OpenSidian filesystem state, Fuji session, and Honeycrisp session keep other resource cleanup for chat handles, table observers, filesystem indexes, workspace handles, or app bundles.
+- [x] **0.2** Keep all `other resource cleanup` paths. Known examples: Fuji workspace disposal, OpenSidian `fs.index` and `fs` disposal, chat message observers, chat handles, and workspace handles.
+- [x] **0.3** In OpenSidian filesystem state, rewrite comments that claim ancestor-only or key-level tracking if this migration accepts global invalidation.
 - [ ] **0.4** Measure or smoke-test OpenSidian filesystem interactions with a large sample tree before merging the global-subscriber version.
 
 ### Phase 1: Build the new primitive
@@ -290,22 +291,23 @@ Build, prove, remove. Phases 1 to 4 are sequential; within Phase 2 the per-app m
 
 Each file changes per the translation table below. No file change depends on another file's change.
 
-- [ ] **2.1** `apps/honeycrisp/src/routes/(signed-in)/state/folders.svelte.ts`
-- [ ] **2.2** `apps/honeycrisp/src/routes/(signed-in)/state/notes.svelte.ts`
-- [ ] **2.3** `apps/zhongwen/src/routes/(signed-in)/chat/chat-state.svelte.ts`
-- [ ] **2.4** `apps/fuji/src/lib/session.svelte.ts`
-- [ ] **2.5** removed: Fuji no longer has `SignedInSessionProvider.svelte`
-- [ ] **2.6** `apps/tab-manager/src/lib/chat/chat-state.svelte.ts`
-- [ ] **2.7** `apps/opensidian/src/lib/chat/chat-state.svelte.ts`
-- [ ] **2.8** `apps/whispering/src/lib/state/transformation-steps.svelte.ts`
-- [ ] **2.9** `apps/whispering/src/lib/state/transformation-runs.svelte.ts`
-- [ ] **2.10** `apps/whispering/src/lib/state/transformations.svelte.ts`
-- [ ] **2.11** `apps/whispering/src/lib/state/recordings.svelte.ts`
-- [ ] **2.12** `apps/opensidian/src/lib/state/fs-state.svelte.ts`
-- [ ] **2.13** `apps/tab-manager/src/lib/state/tool-trust.svelte.ts`
-- [ ] **2.14** `apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts`
-- [ ] **2.15** `apps/tab-manager/src/lib/state/bookmark-state.svelte.ts`
-- [ ] **2.16** `apps/skills/src/lib/state/skills-state.svelte.ts`
+- [x] **2.1** `apps/honeycrisp/src/routes/(signed-in)/state/folders.svelte.ts`
+- [x] **2.2** `apps/honeycrisp/src/routes/(signed-in)/state/notes.svelte.ts`
+- [x] **2.3** `apps/zhongwen/src/routes/(signed-in)/chat/chat-state.svelte.ts`
+- [x] **2.4** `apps/fuji/src/lib/session.svelte.ts`
+  > **Note**: Also updated `apps/fuji/src/routes/(signed-in)/components/EntryEditor.svelte` from `fromDisposableCache` to `useCacheHandle`; this call site was added after the cherry-picked rename commit.
+- [x] **2.5** removed: Fuji no longer has `SignedInSessionProvider.svelte`
+- [x] **2.6** `apps/tab-manager/src/lib/chat/chat-state.svelte.ts`
+- [x] **2.7** `apps/opensidian/src/lib/chat/chat-state.svelte.ts`
+- [x] **2.8** `apps/whispering/src/lib/state/transformation-steps.svelte.ts`
+- [x] **2.9** `apps/whispering/src/lib/state/transformation-runs.svelte.ts`
+- [x] **2.10** `apps/whispering/src/lib/state/transformations.svelte.ts`
+- [x] **2.11** `apps/whispering/src/lib/state/recordings.svelte.ts`
+- [x] **2.12** `apps/opensidian/src/lib/state/fs-state.svelte.ts`
+- [x] **2.13** `apps/tab-manager/src/lib/state/tool-trust.svelte.ts`
+- [x] **2.14** `apps/tab-manager/src/lib/state/saved-tab-state.svelte.ts`
+- [x] **2.15** `apps/tab-manager/src/lib/state/bookmark-state.svelte.ts`
+- [x] **2.16** `apps/skills/src/lib/state/skills-state.svelte.ts`
 
 ### Phase 3: Verify
 

--- a/specs/20260506T123741-from-table-readonly-view-redesign.md
+++ b/specs/20260506T123741-from-table-readonly-view-redesign.md
@@ -1,9 +1,9 @@
 # `fromTable` Readonly View Redesign
 
 **Date**: 2026-05-06
-**Status**: Draft; refreshed 2026-05-07; risky before execution
+**Status**: In Progress; refreshed 2026-05-07
 **Author**: AI-assisted
-**Branch**: feat/encrypted-local-workspace-storage
+**Branch**: feat/from-table-readonly-view
 **Refresh note**: The May 7 session cleanup moved Fuji's `fromTable` usage
 from `apps/fuji/src/routes/(signed-in)/state/entries.svelte.ts` and
 `SignedInSessionProvider.svelte` into `apps/fuji/src/lib/session.svelte.ts`.
@@ -276,10 +276,11 @@ Build, prove, remove. Phases 1 to 4 are sequential; within Phase 2 the per-app m
 
 ### Phase 1: Build the new primitive
 
-- [ ] **1.1** Rewrite `packages/svelte-utils/src/from-table.svelte.ts` to the new shape. Drop `ReactiveTableMap` type export; the inferred return type is sufficient.
-- [ ] **1.2** Update `packages/svelte-utils/src/index.ts` to remove the `ReactiveTableMap` re-export.
-- [ ] **1.3** Update `.agents/skills/svelte/SKILL.md` and `.agents/skills/workspace-api/SKILL.md` references that mention `fromTable` returning a SvelteMap or requiring dispose.
-- [ ] **1.4** Add a focused test in `packages/svelte-utils/src/from-table.svelte.test.ts` verifying:
+- [x] **1.1** Rewrite `packages/svelte-utils/src/from-table.svelte.ts` to the new shape. Drop `ReactiveTableMap` type export; the inferred return type is sufficient.
+- [x] **1.2** Update `packages/svelte-utils/src/index.ts` to remove the `ReactiveTableMap` re-export.
+- [x] **1.3** Update `.agents/skills/svelte/SKILL.md` and `.agents/skills/workspace-api/SKILL.md` references that mention `fromTable` returning a SvelteMap or requiring dispose.
+  > **Note**: `.agents/skills/svelte/SKILL.md` contained the stale SvelteMap guidance. `.agents/skills/workspace-api/SKILL.md` only links to the Svelte skill and did not contradict the new primitive.
+- [x] **1.4** Add a focused test in `packages/svelte-utils/src/from-table.svelte.test.ts` verifying:
   - First read inside `$effect.root` attaches the observer
   - Last reader teardown detaches the observer (microtask)
   - Outside-effect reads return current Yjs state without subscribing


### PR DESCRIPTION
## Summary

- Redesigns `fromTable` as a readonly `all` plus `byId(id)` view backed by Svelte `createSubscriber`, with live reads from the workspace table and no SvelteMap mirror.
- Migrates app consumers from Map APIs (`values`, `get`, `has`, `keys`, `size`) to the new view shape and removes fromTable-only dispose and HMR cleanup.
- Carries the sibling `fromKv` shape from the resolved branch state: `createSubscriber` plus live reads, no mirror, no explicit destroy method.
- Updates docs and the spec at `specs/20260506T123741-from-table-readonly-view-redesign.md`.

## Cherry-picks

- `525b5f7` was cherry-picked as `b7e850896`: `fromDisposableCache` to `useCacheHandle`.
- `59cf03e2c` was already present on `origin/main` through the encrypted local workspace storage merge, so no additional cherry-pick commit was needed.

## Verification

- Passed: `bun run test --filter=@epicenter/svelte`
- Passed: `git diff --check origin/main..HEAD`
- Passed: added-line scan for em dash and en dash in branch diff
- Blocked: full `bun run typecheck` is not green on the current baseline. Details are recorded in the spec.
- Blocked: full `bun run test` stops in `@epicenter/zhongwen` because its script targets a path with no matching test files. Details are recorded in the spec.
- Not run: manual app smoke, HMR smoke, Fuji sign-out smoke, and OpenSidian large tree smoke.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->