### PR TITLE
Refine workspace app layout guidance and Honeycrisp state names

### DIFF
--- a/.agents/skills/workspace-app-layout/SKILL.md
+++ b/.agents/skills/workspace-app-layout/SKILL.md
@@ -3,46 +3,74 @@ name: workspace-app-layout
 description: How each app under apps/* lays out its workspace package, pure environment factories, daemon/script bindings, and app singleton. Use when creating workspace-backed apps, adding daemon or script consumers, or deciding where browser-only, Bun-only, or platform-specific imports belong.
 metadata:
   author: epicenter
-  version: '3.0'
+  version: '4.0'
 ---
 
 # Workspace App Layout
 
-Workspace apps split construction from runtime side effects.
+Workspace apps split construction from runtime side effects. Two shipped
+shapes; pick by whether the app gates UI on signed-in identity.
+
+**Shape A**: auth-gated SvelteKit web apps (fuji, honeycrisp, zhongwen):
 
 ```txt
 apps/<app>/src/lib/
-|- client.ts              optional singleton when the app has been lifted
-`- <app>/
-    |- index.ts           iso doc factory, or core.ts after a larger relocation
-    |- browser.ts         browser factory
-    |- daemon.ts          long-lived daemon factory
-    |- script.ts          one-shot script factory
-    `- integration.test.ts
+|- auth.ts                          createCookieAuth(), exports `auth`
+`- session.svelte.ts                singleton: createSession + HMR + getSignedInSession()
+apps/<app>/src/routes/(signed-in)/<app>/
+|- index.ts                         iso doc factory: open<App>Doc({ encryptionKeys })
+|- browser.ts                       browser factory: open<App>({ userId, peer, bearerToken, encryptionKeys })
+|- daemon.ts                        long-lived daemon factory (cli-side)
+|- script.ts                        one-shot script factory (cli-side)
+`- integration.test.ts
 ```
 
-Current apps may still keep `client.ts` inside `src/lib/<app>/`. When changing
-only daemon transport, do not relocate the singleton unless the requested work
-needs that review churn. The important boundary is that `client.ts` is the only
-singleton with side effects, while `index.ts`, `browser.ts`, `daemon.ts`, and
-`script.ts` stay pure construction surfaces.
+No `client.ts`. The singleton lives in `session.svelte.ts`, where
+`createSession({ auth, build })` owns the workspace lifecycle. The iso and
+browser factories sit beside the signed-in routes because the app isn't a
+running thing until identity exists.
 
-Some SvelteKit apps scope their browser workspace to `routes/(signed-in)/`
-instead of `src/lib/`. Use the owner of the lifecycle as the deciding rule:
-if `$lib/session.svelte.ts` builds the workspace through `createSession` and
-exports `getSignedInSession()`, keep the app factory beside the signed-in
-routes. If a `$lib` client singleton owns the auth wait and workspace
-singleton, keep the factory beside that client until the app is migrated.
+**Shape B**: module-level singleton apps (opensidian, tab-manager, whispering):
+
+```txt
+apps/<app>/src/lib/<app>/
+|- index.ts                         iso doc factory
+|- browser.ts | extension.ts | tauri.ts   env binding (browser / chrome ext / Tauri)
+|- client.ts                        singleton: auth wait + module-level open<App>(...)
+|- daemon.ts                        long-lived daemon factory (if applicable)
+|- script.ts                        one-shot script factory (if applicable)
+`- integration.test.ts
+```
+
+`client.ts` is the only singleton with side effects; it blocks on
+`session.whenReady` / `waitForAuthState` and exports a constructed handle.
+Whispering is the simplest variant (no auth, no encryption, Tauri singleton).
+Opensidian and tab-manager are scheduled to migrate to shape A
+(`specs/20260507T054727-opensidian-tab-manager-create-session.md`); until
+then, do not move their singleton during unrelated changes; review churn
+isn't worth it.
+
+For both shapes, `index.ts`, `browser.ts`, `daemon.ts`, and `script.ts` stay
+pure construction surfaces. Side effects (auth subscriptions, HMR, persisted
+state, network) live only in the singleton (`session.svelte.ts` for shape A,
+`client.ts` for shape B).
 
 ## Layers
 
-| File | Job | Imports | Returns |
-| --- | --- | --- | --- |
-| `index.ts` or `core.ts` | Isomorphic doc factory | Workspace core, schemas, pure action factories | `ydoc`, tables, kv, encryption, actions, batch, dispose |
-| `browser.ts` | Browser factory | Iso factory plus IndexedDB, BroadcastChannel, sync, browser caches | Doc bundle plus browser resources |
-| `daemon.ts` | Long-lived daemon factory | Iso factory plus `attachYjsLog`, `attachSync`, materializers | Doc bundle plus writer persistence and sync |
-| `script.ts` | One-shot script factory | Iso factory plus `attachYjsLogReader`, `attachSync` | Doc bundle plus readonly warm hydrate and sync |
-| `client.ts` | App singleton or auth owner | One env factory plus auth/session lifecycle | `auth`, or `auth` plus a running app singleton for apps not yet on `createSession` |
+| File | Shape | Job | Imports | Returns |
+| --- | --- | --- | --- | --- |
+| `index.ts` or `core.ts` | A + B | Isomorphic doc factory | Workspace core, schemas, pure action factories | `ydoc`, tables, kv, encryption, actions, batch, dispose |
+| `browser.ts` | A + B | Browser factory | Iso factory plus IndexedDB, BroadcastChannel, sync, browser caches | Doc bundle plus browser resources |
+| `extension.ts` / `tauri.ts` | B | Env binding for non-web runtimes | Iso factory plus chrome.storage / Tauri APIs | Doc bundle plus runtime resources |
+| `daemon.ts` | A + B | Long-lived daemon factory | Iso factory plus `attachYjsLog`, `attachSync`, materializers | Doc bundle plus writer persistence and sync |
+| `script.ts` | A + B | One-shot script factory | Iso factory plus `attachYjsLogReader`, `attachSync` | Doc bundle plus readonly warm hydrate and sync |
+| `auth.ts` | A | Auth client construction | `createCookieAuth` (or `createBearerAuth`) | `auth` |
+| `session.svelte.ts` | A | App singleton + lifecycle | `createSession` from `@epicenter/svelte`, env factory, auth | `session`, `InferSignedIn`, module-level `getSignedInSession()` |
+| `client.ts` | B | App singleton + auth wait | One env factory plus auth/session lifecycle | `auth` plus a running app singleton; module-level `await session.whenReady` |
+
+Daemon and script factories live in the same directory as the iso/browser
+factories regardless of shape; they're consumed by the `cli` package for
+`epicenter up` (daemon) and one-shot script entry points.
 
 ## Iso Factory
 
@@ -249,4 +277,6 @@ script observes rows from attachYjsLogReader replay
 - Restoring `serve` as the public lifecycle command.
 - Restoring `sync.peer()` or `describePeer()` as the primary remote action API.
 - Inlining Opensidian actions back into `browser.ts`.
-- Relocating `client.ts` during a daemon-only change without a review reason.
+- Relocating `client.ts` (shape B) or `session.svelte.ts` (shape A) during a daemon-only change without a review reason.
+- Adding a `client.ts` to a shape A app: the singleton already lives in `session.svelte.ts`. There is no second home.
+- Putting auth subscriptions or workspace construction in a Svelte component: it belongs in the singleton (`session.svelte.ts` or `client.ts`).

--- a/.claude/skills/workspace-app-layout/SKILL.md
+++ b/.claude/skills/workspace-app-layout/SKILL.md
@@ -3,46 +3,74 @@ name: workspace-app-layout
 description: How each app under apps/* lays out its workspace package, pure environment factories, daemon/script bindings, and app singleton. Use when creating workspace-backed apps, adding daemon or script consumers, or deciding where browser-only, Bun-only, or platform-specific imports belong.
 metadata:
   author: epicenter
-  version: '3.0'
+  version: '4.0'
 ---
 
 # Workspace App Layout
 
-Workspace apps split construction from runtime side effects.
+Workspace apps split construction from runtime side effects. Two shipped
+shapes; pick by whether the app gates UI on signed-in identity.
+
+**Shape A**: auth-gated SvelteKit web apps (fuji, honeycrisp, zhongwen):
 
 ```txt
 apps/<app>/src/lib/
-|- client.ts              optional singleton when the app has been lifted
-`- <app>/
-    |- index.ts           iso doc factory, or core.ts after a larger relocation
-    |- browser.ts         browser factory
-    |- daemon.ts          long-lived daemon factory
-    |- script.ts          one-shot script factory
-    `- integration.test.ts
+|- auth.ts                          createCookieAuth(), exports `auth`
+`- session.svelte.ts                singleton: createSession + HMR + getSignedInSession()
+apps/<app>/src/routes/(signed-in)/<app>/
+|- index.ts                         iso doc factory: open<App>Doc({ encryptionKeys })
+|- browser.ts                       browser factory: open<App>({ userId, peer, bearerToken, encryptionKeys })
+|- daemon.ts                        long-lived daemon factory (cli-side)
+|- script.ts                        one-shot script factory (cli-side)
+`- integration.test.ts
 ```
 
-Current apps may still keep `client.ts` inside `src/lib/<app>/`. When changing
-only daemon transport, do not relocate the singleton unless the requested work
-needs that review churn. The important boundary is that `client.ts` is the only
-singleton with side effects, while `index.ts`, `browser.ts`, `daemon.ts`, and
-`script.ts` stay pure construction surfaces.
+No `client.ts`. The singleton lives in `session.svelte.ts`, where
+`createSession({ auth, build })` owns the workspace lifecycle. The iso and
+browser factories sit beside the signed-in routes because the app isn't a
+running thing until identity exists.
 
-Some SvelteKit apps scope their browser workspace to `routes/(signed-in)/`
-instead of `src/lib/`. Use the owner of the lifecycle as the deciding rule:
-if `$lib/session.svelte.ts` builds the workspace through `createSession` and
-exports `getSignedInSession()`, keep the app factory beside the signed-in
-routes. If a `$lib` client singleton owns the auth wait and workspace
-singleton, keep the factory beside that client until the app is migrated.
+**Shape B**: module-level singleton apps (opensidian, tab-manager, whispering):
+
+```txt
+apps/<app>/src/lib/<app>/
+|- index.ts                         iso doc factory
+|- browser.ts | extension.ts | tauri.ts   env binding (browser / chrome ext / Tauri)
+|- client.ts                        singleton: auth wait + module-level open<App>(...)
+|- daemon.ts                        long-lived daemon factory (if applicable)
+|- script.ts                        one-shot script factory (if applicable)
+`- integration.test.ts
+```
+
+`client.ts` is the only singleton with side effects; it blocks on
+`session.whenReady` / `waitForAuthState` and exports a constructed handle.
+Whispering is the simplest variant (no auth, no encryption, Tauri singleton).
+Opensidian and tab-manager are scheduled to migrate to shape A
+(`specs/20260507T054727-opensidian-tab-manager-create-session.md`); until
+then, do not move their singleton during unrelated changes; review churn
+isn't worth it.
+
+For both shapes, `index.ts`, `browser.ts`, `daemon.ts`, and `script.ts` stay
+pure construction surfaces. Side effects (auth subscriptions, HMR, persisted
+state, network) live only in the singleton (`session.svelte.ts` for shape A,
+`client.ts` for shape B).
 
 ## Layers
 
-| File | Job | Imports | Returns |
-| --- | --- | --- | --- |
-| `index.ts` or `core.ts` | Isomorphic doc factory | Workspace core, schemas, pure action factories | `ydoc`, tables, kv, encryption, actions, batch, dispose |
-| `browser.ts` | Browser factory | Iso factory plus IndexedDB, BroadcastChannel, sync, browser caches | Doc bundle plus browser resources |
-| `daemon.ts` | Long-lived daemon factory | Iso factory plus `attachYjsLog`, `attachSync`, materializers | Doc bundle plus writer persistence and sync |
-| `script.ts` | One-shot script factory | Iso factory plus `attachYjsLogReader`, `attachSync` | Doc bundle plus readonly warm hydrate and sync |
-| `client.ts` | App singleton or auth owner | One env factory plus auth/session lifecycle | `auth`, or `auth` plus a running app singleton for apps not yet on `createSession` |
+| File | Shape | Job | Imports | Returns |
+| --- | --- | --- | --- | --- |
+| `index.ts` or `core.ts` | A + B | Isomorphic doc factory | Workspace core, schemas, pure action factories | `ydoc`, tables, kv, encryption, actions, batch, dispose |
+| `browser.ts` | A + B | Browser factory | Iso factory plus IndexedDB, BroadcastChannel, sync, browser caches | Doc bundle plus browser resources |
+| `extension.ts` / `tauri.ts` | B | Env binding for non-web runtimes | Iso factory plus chrome.storage / Tauri APIs | Doc bundle plus runtime resources |
+| `daemon.ts` | A + B | Long-lived daemon factory | Iso factory plus `attachYjsLog`, `attachSync`, materializers | Doc bundle plus writer persistence and sync |
+| `script.ts` | A + B | One-shot script factory | Iso factory plus `attachYjsLogReader`, `attachSync` | Doc bundle plus readonly warm hydrate and sync |
+| `auth.ts` | A | Auth client construction | `createCookieAuth` (or `createBearerAuth`) | `auth` |
+| `session.svelte.ts` | A | App singleton + lifecycle | `createSession` from `@epicenter/svelte`, env factory, auth | `session`, `InferSignedIn`, module-level `getSignedInSession()` |
+| `client.ts` | B | App singleton + auth wait | One env factory plus auth/session lifecycle | `auth` plus a running app singleton; module-level `await session.whenReady` |
+
+Daemon and script factories live in the same directory as the iso/browser
+factories regardless of shape; they're consumed by the `cli` package for
+`epicenter up` (daemon) and one-shot script entry points.
 
 ## Iso Factory
 
@@ -249,4 +277,6 @@ script observes rows from attachYjsLogReader replay
 - Restoring `serve` as the public lifecycle command.
 - Restoring `sync.peer()` or `describePeer()` as the primary remote action API.
 - Inlining Opensidian actions back into `browser.ts`.
-- Relocating `client.ts` during a daemon-only change without a review reason.
+- Relocating `client.ts` (shape B) or `session.svelte.ts` (shape A) during a daemon-only change without a review reason.
+- Adding a `client.ts` to a shape A app: the singleton already lives in `session.svelte.ts`. There is no second home.
+- Putting auth subscriptions or workspace construction in a Svelte component: it belongs in the singleton (`session.svelte.ts` or `client.ts`).

--- a/apps/honeycrisp/src/routes/(signed-in)/+page.svelte
+++ b/apps/honeycrisp/src/routes/(signed-in)/+page.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import * as Resizable from '@epicenter/ui/resizable';
 	import { SidebarProvider } from '@epicenter/ui/sidebar';
+	import { getSignedInSession } from '$lib/session.svelte';
 	import CommandPalette from './components/CommandPalette.svelte';
 	import NoteBodyPane from './components/NoteBodyPane.svelte';
 	import NoteList from './components/NoteList.svelte';
 	import HoneycripSidebar from './components/Sidebar.svelte';
-	import { getSignedInSession } from '$lib/session.svelte';
 
-	const { foldersState, notesState, viewState } = getSignedInSession().state;
+	const signedIn = getSignedInSession();
 </script>
 
 <svelte:window
@@ -17,11 +17,11 @@
 
 		if (e.key === 'n' && e.shiftKey) {
 			e.preventDefault();
-			foldersState.createFolder();
+			signedIn.state.folders.create();
 		} else if (e.key === 'n') {
 			e.preventDefault();
-			const { id } = notesState.createNote(viewState.selectedFolderId);
-			viewState.selectNote(id);
+			const { id } = signedIn.state.notes.create(signedIn.state.view.selectedFolderId);
+			signedIn.state.view.selectNote(id);
 		}
 	}}
 />
@@ -32,25 +32,13 @@
 	<main class="flex h-screen flex-1 overflow-hidden">
 		<Resizable.PaneGroup direction="horizontal">
 			<Resizable.Pane defaultSize={35} minSize={20}>
-				{#if viewState.isRecentlyDeletedView}
-					<NoteList
-						notes={notesState.deletedNotes}
-						title="Recently Deleted"
-						showControls={false}
-						emptyMessage="No deleted notes"
-					/>
-				{:else}
-					<NoteList
-						notes={viewState.filteredNotes}
-						title={viewState.folderName}
-					/>
-				{/if}
+				<NoteList />
 			</Resizable.Pane>
 			<Resizable.Handle />
 			<Resizable.Pane defaultSize={65} minSize={30} class="flex flex-col">
-				{#if viewState.selectedNote && viewState.selectedNoteId}
-					{#key viewState.selectedNoteId}
-						<NoteBodyPane noteId={viewState.selectedNoteId} />
+				{#if signedIn.state.view.selectedNote && signedIn.state.view.selectedNoteId}
+					{#key signedIn.state.view.selectedNoteId}
+						<NoteBodyPane noteId={signedIn.state.view.selectedNoteId} />
 					{/key}
 				{:else}
 					<div class="flex h-full flex-col items-center justify-center gap-2">

--- a/apps/honeycrisp/src/routes/(signed-in)/components/CommandPalette.svelte
+++ b/apps/honeycrisp/src/routes/(signed-in)/components/CommandPalette.svelte
@@ -6,7 +6,7 @@
 	import PlusIcon from '@lucide/svelte/icons/plus';
 	import { getSignedInSession } from '$lib/session.svelte';
 
-	const { foldersState, notesState, viewState } = getSignedInSession().state;
+	const signedIn = getSignedInSession();
 
 	let isOpen = $state(false);
 </script>
@@ -28,17 +28,17 @@
 		<Command.Group heading="Folders">
 			<Command.Item
 				onSelect={() => {
-					viewState.selectFolder(null);
+					signedIn.state.view.selectFolder(null);
 					isOpen = false;
 				}}
 			>
 				<FileTextIcon class="mr-2 size-4" />
 				All Notes
 			</Command.Item>
-			{#each foldersState.folders as folder (folder.id)}
+			{#each signedIn.state.folders.all as folder (folder.id)}
 				<Command.Item
 					onSelect={() => {
-						viewState.selectFolder(folder.id);
+						signedIn.state.view.selectFolder(folder.id);
 						isOpen = false;
 					}}
 				>
@@ -55,10 +55,10 @@
 		<Command.Separator />
 
 		<Command.Group heading="Notes">
-			{#each notesState.notes as note (note.id)}
+			{#each signedIn.state.notes.all as note (note.id)}
 				<Command.Item
 					onSelect={() => {
-					viewState.selectNote(note.id);
+					signedIn.state.view.selectNote(note.id);
 						isOpen = false;
 					}}
 				>
@@ -80,8 +80,8 @@
 		<Command.Group heading="Actions">
 			<Command.Item
 				onSelect={() => {
-					const { id } = notesState.createNote(viewState.selectedFolderId);
-					viewState.selectNote(id);
+					const { id } = signedIn.state.notes.create(signedIn.state.view.selectedFolderId);
+					signedIn.state.view.selectNote(id);
 				}}
 			>
 				<PlusIcon class="mr-2 size-4" />
@@ -89,7 +89,7 @@
 			</Command.Item>
 			<Command.Item
 				onSelect={() => {
-				foldersState.createFolder();
+				signedIn.state.folders.create();
 					isOpen = false;
 				}}
 			>

--- a/apps/honeycrisp/src/routes/(signed-in)/components/FolderMenuItem.svelte
+++ b/apps/honeycrisp/src/routes/(signed-in)/components/FolderMenuItem.svelte
@@ -9,7 +9,7 @@
 	import { getSignedInSession } from '$lib/session.svelte';
 	import type { Folder } from '../honeycrisp/workspace';
 
-	const { foldersState, notesState, viewState } = getSignedInSession().state;
+	const signedIn = getSignedInSession();
 
 	let { folder }: { folder: Folder } = $props();
 
@@ -20,7 +20,7 @@
 
 	function commitRename() {
 		if (editingName.trim()) {
-			foldersState.renameFolder(folder.id, editingName.trim());
+			signedIn.state.folders.rename(folder.id, editingName.trim());
 		}
 		isEditing = false;
 		editingName = '';
@@ -51,8 +51,8 @@
 		</div>
 	{:else}
 		<Sidebar.MenuButton
-			isActive={viewState.selectedFolderId === folder.id}
-			onclick={() => viewState.selectFolder(folder.id)}
+			isActive={signedIn.state.view.selectedFolderId === folder.id}
+			onclick={() => signedIn.state.view.selectFolder(folder.id)}
 		>
 			{#if folder.icon}
 				<span class="text-base leading-none">{folder.icon}</span>
@@ -61,7 +61,7 @@
 			{/if}
 			<span>{folder.name}</span>
 			<span class="ml-auto text-xs text-muted-foreground">
-				{notesState.noteCounts[folder.id] ?? 0}
+				{signedIn.state.notes.countsByFolder[folder.id] ?? 0}
 			</span>
 		</Sidebar.MenuButton>
 		<DropdownMenu.Root>
@@ -108,7 +108,7 @@
 			<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
 			<AlertDialog.Action
 				class="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-				onclick={() => foldersState.deleteFolder(folder.id)}
+				onclick={() => signedIn.state.folders.delete(folder.id)}
 			>
 				Delete
 			</AlertDialog.Action>

--- a/apps/honeycrisp/src/routes/(signed-in)/components/NoteBodyPane.svelte
+++ b/apps/honeycrisp/src/routes/(signed-in)/components/NoteBodyPane.svelte
@@ -3,13 +3,16 @@
 	import { Loading } from '@epicenter/ui/loading';
 	import HoneycripEditor from '$lib/editor/Editor.svelte';
 	import { getSignedInSession } from '$lib/session.svelte';
+	import type { NoteId } from '../honeycrisp/workspace';
 
 	const signedIn = getSignedInSession();
-	const { notesState } = signedIn.state;
 
-	let { noteId }: { noteId: string } = $props();
+	let { noteId }: { noteId: NoteId } = $props();
 
-	const doc = fromDisposableCache(signedIn.honeycrisp.noteBodyDocs, () => noteId);
+	const doc = fromDisposableCache(
+		signedIn.honeycrisp.noteBodyDocs,
+		() => noteId,
+	);
 </script>
 
 {#await doc.current.idb.whenLoaded}
@@ -17,6 +20,6 @@
 {:then _}
 	<HoneycripEditor
 		yxmlfragment={doc.current.body.binding}
-		onContentChange={(change) => notesState.updateNoteContent(change)}
+		onContentChange={(change) => signedIn.state.notes.updateContent(noteId, change)}
 	/>
 {/await}

--- a/apps/honeycrisp/src/routes/(signed-in)/components/NoteCard.svelte
+++ b/apps/honeycrisp/src/routes/(signed-in)/components/NoteCard.svelte
@@ -2,17 +2,17 @@
 	import * as AlertDialog from '@epicenter/ui/alert-dialog';
 	import { Button } from '@epicenter/ui/button';
 	import * as ContextMenu from '@epicenter/ui/context-menu';
+	import { DateTimeString } from '@epicenter/workspace';
 	import ArchiveRestoreIcon from '@lucide/svelte/icons/archive-restore';
 	import FileTextIcon from '@lucide/svelte/icons/file-text';
 	import FolderIcon from '@lucide/svelte/icons/folder';
 	import PinIcon from '@lucide/svelte/icons/pin';
 	import TrashIcon from '@lucide/svelte/icons/trash-2';
 	import { format } from 'date-fns';
-	import { DateTimeString } from '@epicenter/workspace';
 	import { getSignedInSession } from '$lib/session.svelte';
 	import type { Note } from '../honeycrisp/workspace';
 
-	const { foldersState, notesState } = getSignedInSession().state;
+	const signedIn = getSignedInSession();
 
 	let {
 		note,
@@ -24,7 +24,7 @@
 		onSelect: () => void;
 	} = $props();
 
-	/** Derive deleted status from the note itself — no need to check view mode. */
+	/** Derive deleted status from the note itself, no need to check view mode. */
 	const isDeleted = $derived(note.deletedAt !== undefined);
 
 	let confirmingPermanentDelete = $state(false);
@@ -67,7 +67,7 @@
 						class="size-6"
 						onclick={(e) => {
 						e.stopPropagation();
-						notesState.restoreNote(note.id);
+						signedIn.state.notes.restore(note.id);
 					}}
 					>
 						<ArchiveRestoreIcon class="size-3" />
@@ -96,7 +96,7 @@
 						class="size-6"
 						onclick={(e) => {
 							e.stopPropagation();
-					notesState.pinNote(note.id);
+					signedIn.state.notes.togglePin(note.id);
 						}}
 					>
 						<PinIcon class="size-3 {note.pinned ? 'fill-current' : ''}" />
@@ -107,7 +107,7 @@
 						class="size-6 text-destructive hover:text-destructive"
 						onclick={(e) => {
 							e.stopPropagation();
-					notesState.softDeleteNote(note.id);
+					signedIn.state.notes.softDelete(note.id);
 						}}
 					>
 						<TrashIcon class="size-3" />
@@ -119,7 +119,7 @@
 
 	<ContextMenu.Content class="w-48">
 		{#if isDeleted}
-			<ContextMenu.Item onclick={() => notesState.restoreNote(note.id)}>
+			<ContextMenu.Item onclick={() => signedIn.state.notes.restore(note.id)}>
 				<ArchiveRestoreIcon class="mr-2 size-4" />
 				Restore
 			</ContextMenu.Item>
@@ -134,7 +134,7 @@
 				Delete Permanently
 			</ContextMenu.Item>
 		{:else}
-			<ContextMenu.Item onclick={() => notesState.pinNote(note.id)}>
+			<ContextMenu.Item onclick={() => signedIn.state.notes.togglePin(note.id)}>
 				<PinIcon class="mr-2 size-4 {note.pinned ? 'fill-current' : ''}" />
 				{note.pinned ? 'Unpin' : 'Pin'}
 			</ContextMenu.Item>
@@ -146,15 +146,15 @@
 				</ContextMenu.SubTrigger>
 				<ContextMenu.SubContent class="w-48">
 					<ContextMenu.Item
-						onclick={() => notesState.moveNoteToFolder(note.id, undefined)}
+						onclick={() => signedIn.state.notes.moveToFolder(note.id, undefined)}
 					>
 						<FileTextIcon class="mr-2 size-4" />
 						Unfiled
 					</ContextMenu.Item>
 					<ContextMenu.Separator />
-					{#each foldersState.folders as folder (folder.id)}
+					{#each signedIn.state.folders.all as folder (folder.id)}
 						<ContextMenu.Item
-							onclick={() => notesState.moveNoteToFolder(note.id, folder.id)}
+							onclick={() => signedIn.state.notes.moveToFolder(note.id, folder.id)}
 						>
 							{#if folder.icon}
 								<span class="mr-2 text-base leading-none">{folder.icon}</span>
@@ -169,7 +169,7 @@
 			<ContextMenu.Separator />
 			<ContextMenu.Item
 				class="text-destructive focus:text-destructive"
-				onclick={() => notesState.softDeleteNote(note.id)}
+				onclick={() => signedIn.state.notes.softDelete(note.id)}
 			>
 				<TrashIcon class="mr-2 size-4" />
 				Delete
@@ -189,7 +189,7 @@
 		<AlertDialog.Footer>
 			<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
 			<AlertDialog.Action
-				onclick={() => notesState.permanentlyDeleteNote(note.id)}
+				onclick={() => signedIn.state.notes.permanentlyDelete(note.id)}
 				>Delete</AlertDialog.Action
 			>
 		</AlertDialog.Footer>

--- a/apps/honeycrisp/src/routes/(signed-in)/components/NoteList.svelte
+++ b/apps/honeycrisp/src/routes/(signed-in)/components/NoteList.svelte
@@ -5,24 +5,12 @@
 	import ArrowUpDownIcon from '@lucide/svelte/icons/arrow-up-down';
 	import CheckIcon from '@lucide/svelte/icons/check';
 	import PlusIcon from '@lucide/svelte/icons/plus';
-	import NoteCard from '../components/NoteCard.svelte';
 	import { getSignedInSession } from '$lib/session.svelte';
 	import { getDateLabel } from '$lib/utils/date';
+	import NoteCard from '../components/NoteCard.svelte';
 	import type { Note } from '../honeycrisp/workspace';
 
-	const { notesState, viewState } = getSignedInSession().state;
-
-	let {
-		notes,
-		title,
-		showControls = true,
-		emptyMessage = 'No notes yet. Click + to create one.',
-	}: {
-		notes: Note[];
-		title: string;
-		showControls?: boolean;
-		emptyMessage?: string;
-	} = $props();
+	const signedIn = getSignedInSession();
 
 	const sortOptions = [
 		{ value: 'dateEdited' as const, label: 'Date Edited' },
@@ -31,6 +19,7 @@
 	];
 
 	const groupedNotes = $derived.by(() => {
+		const notes = signedIn.state.view.currentNotes;
 		const pinned = notes
 			.filter((n) => n.pinned)
 			.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
@@ -82,28 +71,30 @@
 		if (flatNoteIds.length === 0) return;
 		e.preventDefault();
 
-		const currentIndex = viewState.selectedNoteId
-			? flatNoteIds.indexOf(viewState.selectedNoteId)
+		const currentIndex = signedIn.state.view.selectedNoteId
+			? flatNoteIds.indexOf(signedIn.state.view.selectedNoteId)
 			: -1;
 
 		if (e.key === 'ArrowDown') {
 			const nextIndex =
 				currentIndex < flatNoteIds.length - 1 ? currentIndex + 1 : 0;
-			viewState.selectNote(flatNoteIds[nextIndex]!);
+			signedIn.state.view.selectNote(flatNoteIds[nextIndex]!);
 		} else {
 			const prevIndex =
 				currentIndex > 0 ? currentIndex - 1 : flatNoteIds.length - 1;
-			viewState.selectNote(flatNoteIds[prevIndex]!);
+			signedIn.state.view.selectNote(flatNoteIds[prevIndex]!);
 		}
 	}}
 	tabindex="-1"
 >
 	<div class="flex items-center justify-between border-b px-4 py-3">
 		<div class="flex items-center gap-2">
-			<h2 class="text-sm font-semibold">{title}</h2>
-			<span class="text-xs text-muted-foreground">{notes.length}</span>
+			<h2 class="text-sm font-semibold">{signedIn.state.view.currentTitle}</h2>
+			<span class="text-xs text-muted-foreground"
+				>{signedIn.state.view.currentNotes.length}</span
+			>
 		</div>
-		{#if showControls}
+		{#if signedIn.state.view.currentShowControls}
 			<div class="flex items-center gap-1">
 				<DropdownMenu.Root>
 					<DropdownMenu.Trigger>
@@ -116,9 +107,9 @@
 					<DropdownMenu.Content align="end" class="w-44">
 						{#each sortOptions as option}
 							<DropdownMenu.Item
-								onclick={() => viewState.setSortBy(option.value)}
+								onclick={() => signedIn.state.view.setSortBy(option.value)}
 							>
-								{#if viewState.sortBy === option.value}
+								{#if signedIn.state.view.sortBy === option.value}
 									<CheckIcon class="mr-2 size-4" />
 								{:else}
 									<span class="mr-2 size-4"></span>
@@ -133,8 +124,10 @@
 					size="icon"
 					class="size-7"
 					onclick={() => {
-						const { id } = notesState.createNote(viewState.selectedFolderId);
-						viewState.selectNote(id);
+						const { id } = signedIn.state.notes.create(
+							signedIn.state.view.selectedFolderId,
+						);
+						signedIn.state.view.selectNote(id);
 					}}
 				>
 					<PlusIcon class="size-4" />
@@ -144,11 +137,11 @@
 	</div>
 
 	<ScrollArea.Root class="flex-1">
-		{#if notes.length === 0}
+		{#if signedIn.state.view.currentNotes.length === 0}
 			<div
 				class="flex h-full items-center justify-center p-8 text-center text-muted-foreground"
 			>
-				<p class="text-sm">{emptyMessage}</p>
+				<p class="text-sm">{signedIn.state.view.currentEmptyMessage}</p>
 			</div>
 		{:else}
 			<div class="flex flex-col gap-4 p-2">
@@ -160,8 +153,8 @@
 						{#each group.entries as note (note.id)}
 							<NoteCard
 								{note}
-								isSelected={note.id === viewState.selectedNoteId}
-								onSelect={() => viewState.selectNote(note.id)}
+								isSelected={note.id === signedIn.state.view.selectedNoteId}
+								onSelect={() => signedIn.state.view.selectNote(note.id)}
 							/>
 						{/each}
 					</div>

--- a/apps/honeycrisp/src/routes/(signed-in)/components/Sidebar.svelte
+++ b/apps/honeycrisp/src/routes/(signed-in)/components/Sidebar.svelte
@@ -10,7 +10,6 @@
 	import FolderMenuItem from '../components/FolderMenuItem.svelte';
 
 	const signedIn = getSignedInSession();
-	const { foldersState, notesState, viewState } = signedIn.state;
 
 	async function forgetHoneycrispDevice(): Promise<void> {
 		await signedIn.honeycrisp.wipe();
@@ -40,8 +39,8 @@
 		<div class="px-2 pb-1">
 			<Sidebar.Input
 				placeholder="Search notes…"
-				value={viewState.searchQuery}
-				oninput={(e) => viewState.setSearchQuery(e.currentTarget.value)}
+				value={signedIn.state.view.searchQuery}
+				oninput={(e) => signedIn.state.view.setSearchQuery(e.currentTarget.value)}
 			/>
 		</div>
 	</Sidebar.Header>
@@ -52,26 +51,26 @@
 				<Sidebar.Menu>
 					<Sidebar.MenuItem>
 						<Sidebar.MenuButton
-							isActive={viewState.selectedFolderId === null && !viewState.isRecentlyDeletedView}
-							onclick={() => viewState.selectFolder(null)}
+							isActive={signedIn.state.view.selectedFolderId === null && !signedIn.state.view.isRecentlyDeletedView}
+							onclick={() => signedIn.state.view.selectFolder(null)}
 						>
 							<FileTextIcon class="size-4" />
 							<span>All Notes</span>
 							<span class="ml-auto text-xs text-muted-foreground">
-								{notesState.notes.length}
+								{signedIn.state.notes.all.length}
 							</span>
 						</Sidebar.MenuButton>
 					</Sidebar.MenuItem>
 					<Sidebar.MenuItem>
 						<Sidebar.MenuButton
-							isActive={viewState.isRecentlyDeletedView && viewState.selectedFolderId === null}
-							onclick={() => viewState.selectRecentlyDeleted()}
+							isActive={signedIn.state.view.isRecentlyDeletedView && signedIn.state.view.selectedFolderId === null}
+							onclick={() => signedIn.state.view.selectRecentlyDeleted()}
 						>
 							<TrashIcon class="size-4" />
 							<span>Recently Deleted</span>
-							{#if notesState.deletedNotes.length > 0}
+							{#if signedIn.state.notes.deleted.length > 0}
 								<span class="ml-auto text-xs text-muted-foreground">
-									{notesState.deletedNotes.length}
+									{signedIn.state.notes.deleted.length}
 								</span>
 							{/if}
 						</Sidebar.MenuButton>
@@ -87,7 +86,7 @@
 				</Collapsible.Trigger>
 				<Sidebar.GroupAction
 					title="New Folder"
-					onclick={() => foldersState.createFolder()}
+					onclick={() => signedIn.state.folders.create()}
 				>
 					<PlusIcon />
 					<span class="sr-only">New Folder</span>
@@ -95,7 +94,7 @@
 				<Collapsible.Content>
 					<Sidebar.GroupContent>
 						<Sidebar.Menu>
-							{#each foldersState.folders as folder (folder.id)}
+							{#each signedIn.state.folders.all as folder (folder.id)}
 								<FolderMenuItem {folder} />
 							{:else}
 								<Sidebar.MenuItem>

--- a/apps/honeycrisp/src/routes/(signed-in)/honeycrisp/workspace.ts
+++ b/apps/honeycrisp/src/routes/(signed-in)/honeycrisp/workspace.ts
@@ -136,7 +136,7 @@ export function createHoneycrispActions(tables: HoneycrispTables) {
 			 *
 			 * Re-parents every note in the folder (sets `folderId` to undefined)
 			 * and deletes the folder row. Selection clearing is handled by the
-			 * Svelte state layer (foldersState) via URL search params.
+			 * Svelte state layer (folders) via URL search params.
 			 */
 			delete: defineMutation({
 				description: 'Delete a folder and re-parent its notes to unfiled',

--- a/apps/honeycrisp/src/routes/(signed-in)/state/folders.svelte.ts
+++ b/apps/honeycrisp/src/routes/(signed-in)/state/folders.svelte.ts
@@ -10,13 +10,13 @@
  * <script>
  *   import { getSignedInSession } from '$lib/session.svelte';
  *
- *   const { foldersState } = getSignedInSession().state;
+ *   const signedIn = getSignedInSession();
  * </script>
  *
- * {#each foldersState.folders as folder (folder.id)}
+ * {#each signedIn.state.folders.all as folder (folder.id)}
  *   <p>{folder.name}</p>
  * {/each}
- * <button onclick={() => foldersState.createFolder()}>New Folder</button>
+ * <button onclick={() => signedIn.state.folders.create()}>New Folder</button>
  * ```
  */
 
@@ -26,12 +26,12 @@ import type { Honeycrisp } from '../honeycrisp/browser';
 import type { FolderId } from '../honeycrisp/workspace';
 import { searchParams } from './search-params.svelte';
 
-export function createFoldersState(honeycrisp: Honeycrisp) {
+export function createFolders(honeycrisp: Honeycrisp) {
 	// ─── Reactive State ──────────────────────────────────────────────────
 
 	const foldersMap = fromTable(honeycrisp.tables.folders);
 
-	const folders = $derived([...foldersMap.values()]);
+	const all = $derived([...foldersMap.values()]);
 
 	// ─── Public API ──────────────────────────────────────────────────────
 
@@ -47,8 +47,8 @@ export function createFoldersState(honeycrisp: Honeycrisp) {
 			return foldersMap.get(id);
 		},
 
-		get folders() {
-			return folders;
+		get all() {
+			return all;
 		},
 
 		/**
@@ -59,11 +59,11 @@ export function createFoldersState(honeycrisp: Honeycrisp) {
 		 *
 		 * @example
 		 * ```typescript
-		 * foldersState.createFolder();
+		 * signedIn.state.folders.create();
 		 * // Folder appears in sidebar with name "New Folder"
 		 * ```
 		 */
-		createFolder() {
+		create() {
 			const id = generateId() as FolderId;
 			honeycrisp.tables.folders.set({
 				id,
@@ -81,10 +81,10 @@ export function createFoldersState(honeycrisp: Honeycrisp) {
 		 *
 		 * @example
 		 * ```typescript
-		 * foldersState.renameFolder(folderId, 'Work');
+		 * signedIn.state.folders.rename(folderId, 'Work');
 		 * ```
 		 */
-		renameFolder(folderId: FolderId, name: string) {
+		rename(folderId: FolderId, name: string) {
 			honeycrisp.tables.folders.update(folderId, { name });
 		},
 
@@ -97,11 +97,11 @@ export function createFoldersState(honeycrisp: Honeycrisp) {
 		 *
 		 * @example
 		 * ```typescript
-		 * foldersState.deleteFolder(folderId);
+		 * signedIn.state.folders.delete(folderId);
 		 * // Folder disappears from sidebar, its notes move to "All Notes"
 		 * ```
 		 */
-		deleteFolder(folderId: FolderId) {
+		delete(folderId: FolderId) {
 			honeycrisp.actions.folders.delete({ folderId });
 			if (searchParams.folder === folderId) {
 				searchParams.update({ folder: null, note: null });

--- a/apps/honeycrisp/src/routes/(signed-in)/state/index.ts
+++ b/apps/honeycrisp/src/routes/(signed-in)/state/index.ts
@@ -1,20 +1,21 @@
 import type { Honeycrisp } from '../honeycrisp/browser';
-import { createFoldersState } from './folders.svelte';
-import { createNotesState } from './notes.svelte';
-import { createViewState } from './view.svelte';
+import { createFolders } from './folders.svelte';
+import { createNotes } from './notes.svelte';
+import { createView } from './view.svelte';
 
 export function createHoneycrispState(honeycrisp: Honeycrisp) {
-	const foldersState = createFoldersState(honeycrisp);
-	const notesState = createNotesState({ foldersState, honeycrisp });
-	const viewState = createViewState({ foldersState, notesState });
+	const folders = createFolders(honeycrisp);
+	const notes = createNotes({ folders, honeycrisp });
+	const view = createView({ folders, notes });
 
 	return {
-		foldersState,
-		notesState,
-		viewState,
+		folders,
+		notes,
+		view,
 		[Symbol.dispose]() {
-			foldersState[Symbol.dispose]();
-			notesState[Symbol.dispose]();
+			view[Symbol.dispose]();
+			notes[Symbol.dispose]();
+			folders[Symbol.dispose]();
 		},
 	};
 }

--- a/apps/honeycrisp/src/routes/(signed-in)/state/notes.svelte.ts
+++ b/apps/honeycrisp/src/routes/(signed-in)/state/notes.svelte.ts
@@ -10,13 +10,13 @@
  * <script>
  *   import { getSignedInSession } from '$lib/session.svelte';
  *
- *   const { notesState } = getSignedInSession().state;
+ *   const signedIn = getSignedInSession();
  * </script>
  *
- * {#each notesState.notes as note (note.id)}
+ * {#each signedIn.state.notes.all as note (note.id)}
  *   <p>{note.title}</p>
  * {/each}
- * <button onclick={() => notesState.createNote()}>New Note</button>
+ * <button onclick={() => signedIn.state.notes.create()}>New Note</button>
  * ```
  */
 
@@ -24,37 +24,35 @@ import { fromTable } from '@epicenter/svelte';
 import { DateTimeString, generateId } from '@epicenter/workspace';
 import type { Honeycrisp } from '../honeycrisp/browser';
 import type { FolderId, NoteId } from '../honeycrisp/workspace';
+import type { createFolders } from './folders.svelte';
 import { searchParams } from './search-params.svelte';
-import type { createFoldersState } from './folders.svelte';
 
-export function createNotesState({
-	foldersState,
+export function createNotes({
+	folders,
 	honeycrisp,
 }: {
-	foldersState: ReturnType<typeof createFoldersState>;
+	folders: ReturnType<typeof createFolders>;
 	honeycrisp: Honeycrisp;
 }) {
 	// ─── Reactive State ──────────────────────────────────────────────────
 
 	const allNotesMap = fromTable(honeycrisp.tables.notes);
 
-	/** All valid notes (including deleted). Cached — only recomputes when table changes. */
+	/** All valid notes (including deleted). Cached, only recomputes when table changes. */
 	const allNotes = $derived([...allNotesMap.values()]);
 
 	// ─── Derived State ───────────────────────────────────────────────────
 
-	/** Active notes — not soft-deleted. */
-	const notes = $derived(allNotes.filter((n) => n.deletedAt === undefined));
+	/** Active notes, not soft-deleted. */
+	const all = $derived(allNotes.filter((n) => n.deletedAt === undefined));
 
 	/** Soft-deleted notes for the Recently Deleted view. */
-	const deletedNotes = $derived(
-		allNotes.filter((n) => n.deletedAt !== undefined),
-	);
+	const deleted = $derived(allNotes.filter((n) => n.deletedAt !== undefined));
 
 	/** Per-folder note counts for the sidebar (active notes only). */
-	const noteCounts = $derived.by(() => {
+	const countsByFolder = $derived.by(() => {
 		const counts: Record<string, number> = {};
-		for (const note of notes) {
+		for (const note of all) {
 			if (note.folderId) {
 				counts[note.folderId] = (counts[note.folderId] ?? 0) + 1;
 			}
@@ -76,17 +74,14 @@ export function createNotesState({
 			return allNotesMap.get(id);
 		},
 
-		get allNotes() {
-			return allNotes;
+		get all() {
+			return all;
 		},
-		get notes() {
-			return notes;
+		get deleted() {
+			return deleted;
 		},
-		get deletedNotes() {
-			return deletedNotes;
-		},
-		get noteCounts() {
-			return noteCounts;
+		get countsByFolder() {
+			return countsByFolder;
 		},
 
 		/**
@@ -98,11 +93,11 @@ export function createNotesState({
 		 *
 		 * @example
 		 * ```typescript
-		 * const { id } = notesState.createNote(viewState.selectedFolderId);
-		 * viewState.selectNote(id);
+		 * const { id } = signedIn.state.notes.create(signedIn.state.view.selectedFolderId);
+		 * signedIn.state.view.selectNote(id);
 		 * ```
 		 */
-		createNote(folderId?: FolderId | null) {
+		create(folderId?: FolderId | null) {
 			const id = generateId() as NoteId;
 			honeycrisp.tables.notes.set({
 				id,
@@ -120,7 +115,7 @@ export function createNotesState({
 		},
 
 		/**
-		 * Soft-delete a note — moves it to Recently Deleted.
+		 * Soft-delete a note, moves it to Recently Deleted.
 		 *
 		 * The note is marked with a `deletedAt` timestamp but not permanently
 		 * removed. It can be restored from the Recently Deleted view. If the
@@ -128,11 +123,11 @@ export function createNotesState({
 		 *
 		 * @example
 		 * ```typescript
-		 * notesState.softDeleteNote(noteId);
+		 * signedIn.state.notes.softDelete(noteId);
 		 * // Note moves to Recently Deleted, editor closes
 		 * ```
 		 */
-		softDeleteNote(noteId: NoteId) {
+		softDelete(noteId: NoteId) {
 			honeycrisp.tables.notes.update(noteId, {
 				deletedAt: DateTimeString.now(),
 			});
@@ -149,15 +144,15 @@ export function createNotesState({
 		 *
 		 * @example
 		 * ```typescript
-		 * notesState.restoreNote(noteId);
+		 * signedIn.state.notes.restore(noteId);
 		 * // Note reappears in its original folder (or unfiled)
 		 * ```
 		 */
-		restoreNote(noteId: NoteId) {
+		restore(noteId: NoteId) {
 			const note = allNotesMap.get(noteId);
 			if (!note) return;
 			const folderExists = note.folderId
-				? foldersState.folders.some((f) => f.id === note.folderId)
+				? folders.all.some((f) => f.id === note.folderId)
 				: true;
 			honeycrisp.tables.notes.update(noteId, {
 				deletedAt: undefined,
@@ -166,18 +161,18 @@ export function createNotesState({
 		},
 
 		/**
-		 * Permanently delete a note — no recovery.
+		 * Permanently delete a note, no recovery.
 		 *
 		 * Removes the note from the database completely. This cannot be undone.
 		 * If the deleted note was selected, the selection is cleared.
 		 *
 		 * @example
 		 * ```typescript
-		 * notesState.permanentlyDeleteNote(noteId);
+		 * signedIn.state.notes.permanentlyDelete(noteId);
 		 * // Note is removed from Recently Deleted and database
 		 * ```
 		 */
-		permanentlyDeleteNote(noteId: NoteId) {
+		permanentlyDelete(noteId: NoteId) {
 			honeycrisp.tables.notes.delete(noteId);
 			if (searchParams.note === noteId) {
 				searchParams.update({ note: null });
@@ -192,11 +187,11 @@ export function createNotesState({
 		 *
 		 * @example
 		 * ```typescript
-		 * notesState.pinNote(noteId);
-		 * // Note moves to the top of the list
+		 * signedIn.state.notes.togglePin(noteId);
+		 * // Note moves to the top of the list (or unpins)
 		 * ```
 		 */
-		pinNote(noteId: NoteId) {
+		togglePin(noteId: NoteId) {
 			const note = allNotesMap.get(noteId);
 			if (!note) return;
 			honeycrisp.tables.notes.update(noteId, {
@@ -212,47 +207,45 @@ export function createNotesState({
 		 *
 		 * @example
 		 * ```typescript
-		 * notesState.moveNoteToFolder(noteId, folderId);
+		 * signedIn.state.notes.moveToFolder(noteId, folderId);
 		 *
 		 * // Move a note to unfiled
-		 * notesState.moveNoteToFolder(noteId, undefined);
+		 * signedIn.state.notes.moveToFolder(noteId, undefined);
 		 * ```
 		 */
-		moveNoteToFolder(noteId: NoteId, folderId: FolderId | undefined) {
+		moveToFolder(noteId: NoteId, folderId: FolderId | undefined) {
 			honeycrisp.tables.notes.update(noteId, { folderId });
 		},
 
 		/**
-		 * Update the title, preview, and word count of the currently selected note.
+		 * Update the title, preview, and word count of a note.
 		 *
-		 * Called when the editor content changes. Only updates if a note is
-		 * currently selected.
+		 * Called when the editor content changes. Caller passes the noteId
+		 * explicitly: the note is whichever note the editor is bound to,
+		 * which is not necessarily what the URL search param says.
 		 *
 		 * @example
 		 * ```typescript
-		 * notesState.updateNoteContent({
+		 * signedIn.state.notes.updateContent(noteId, {
 		 *   title: 'My Note Title',
 		 *   preview: 'First line of content...',
 		 *   wordCount: 42,
 		 * });
 		 * ```
 		 */
-		updateNoteContent({
-			title,
-			preview,
-			wordCount,
-		}: {
-			title: string;
-			preview: string;
-			wordCount: number;
-		}) {
-			const selectedNoteId = searchParams.note;
-			if (!selectedNoteId) return;
-			honeycrisp.tables.notes.update(selectedNoteId, {
+		updateContent(
+			noteId: NoteId,
+			{
 				title,
 				preview,
 				wordCount,
-			});
+			}: {
+				title: string;
+				preview: string;
+				wordCount: number;
+			},
+		) {
+			honeycrisp.tables.notes.update(noteId, { title, preview, wordCount });
 		},
 	};
 }

--- a/apps/honeycrisp/src/routes/(signed-in)/state/view.svelte.ts
+++ b/apps/honeycrisp/src/routes/(signed-in)/state/view.svelte.ts
@@ -1,40 +1,41 @@
 /**
  * Reactive view state for Honeycrisp, backed by URL search params.
  *
- * Manages navigation, selection, search, sort, and view mode. Cross-cutting
- * derivations (filteredNotes, folderName, selectedNote) live here because
- * they combine data from multiple domains.
+ * The lens the user is currently looking through. Owns navigation,
+ * selection, search, sort, view mode, and the derived "what notes does
+ * the user see right now" question (`currentNotes` plus its title and
+ * empty-state messaging).
  *
  * State lives in the URL so it's bookmarkable, shareable, and works with
  * browser back/forward. Default values are elided from the URL to keep it
- * clean—`/` means all defaults (all notes, sorted by date edited, no search).
+ * clean: `/` means all defaults (all notes, sorted by date edited, no search).
  *
  * @example
  * ```svelte
  * <script>
  *   import { getSignedInSession } from '$lib/session.svelte';
  *
- *   const { viewState } = getSignedInSession().state;
+ *   const signedIn = getSignedInSession();
  * </script>
  *
- * {#each viewState.filteredNotes as note (note.id)}
+ * {#each signedIn.state.view.currentNotes as note (note.id)}
  *   <p>{note.title}</p>
  * {/each}
- * <p>Current folder: {viewState.folderName}</p>
+ * <p>Current title: {signedIn.state.view.currentTitle}</p>
  * ```
  */
 
-import { searchParams, type SortBy } from './search-params.svelte';
 import type { FolderId, NoteId } from '../honeycrisp/workspace';
-import type { createFoldersState } from './folders.svelte';
-import type { createNotesState } from './notes.svelte';
+import type { createFolders } from './folders.svelte';
+import type { createNotes } from './notes.svelte';
+import { type SortBy, searchParams } from './search-params.svelte';
 
-export function createViewState({
-	foldersState,
-	notesState,
+export function createView({
+	folders,
+	notes,
 }: {
-	foldersState: ReturnType<typeof createFoldersState>;
-	notesState: ReturnType<typeof createNotesState>;
+	folders: ReturnType<typeof createFolders>;
+	notes: ReturnType<typeof createNotes>;
 }) {
 	// ─── Derived State ───────────────────────────────────────────────────
 
@@ -44,7 +45,7 @@ export function createViewState({
 		const q = searchParams.q.trim().toLowerCase();
 		const sort = searchParams.sort;
 
-		return notesState.notes
+		return notes.all
 			.filter((n) => folderId === null || n.folderId === folderId)
 			.filter(
 				(n) =>
@@ -60,23 +61,22 @@ export function createViewState({
 			});
 	});
 
-	/** Human-readable name for the current folder (used as NoteList title). */
+	/** Human-readable name for the current folder. Feeds `currentTitle`. */
 	const folderName = $derived.by(() => {
 		const folderId = searchParams.folder;
-		return folderId
-			? (foldersState.get(folderId)?.name ?? 'Notes')
-			: 'All Notes';
+		return folderId ? (folders.get(folderId)?.name ?? 'Notes') : 'All Notes';
 	});
 
 	/** The currently selected note (can be active or deleted). */
 	const selectedNote = $derived.by(() => {
 		const noteId = searchParams.note;
-		return noteId ? (notesState.get(noteId) ?? null) : null;
+		return noteId ? (notes.get(noteId) ?? null) : null;
 	});
 
 	// ─── Public API ──────────────────────────────────────────────────────
 
 	return {
+		[Symbol.dispose]() {},
 		get selectedFolderId(): FolderId | null {
 			return searchParams.folder;
 		},
@@ -95,11 +95,27 @@ export function createViewState({
 		get isRecentlyDeletedView() {
 			return searchParams.isDeletedView;
 		},
-		get folderName() {
-			return folderName;
+
+		/**
+		 * The list of notes the user currently sees: deleted notes when in
+		 * Recently Deleted, otherwise the folder/search-filtered + sorted list.
+		 */
+		get currentNotes() {
+			return searchParams.isDeletedView ? notes.deleted : filteredNotes;
 		},
-		get filteredNotes() {
-			return filteredNotes;
+		/** The header title for the current notes list. */
+		get currentTitle(): string {
+			return searchParams.isDeletedView ? 'Recently Deleted' : folderName;
+		},
+		/** Whether the sort + new-note controls should appear. Off in Recently Deleted. */
+		get currentShowControls(): boolean {
+			return !searchParams.isDeletedView;
+		},
+		/** The empty-state message for the current notes list. */
+		get currentEmptyMessage(): string {
+			return searchParams.isDeletedView
+				? 'No deleted notes'
+				: 'No notes yet. Click + to create one.';
 		},
 
 		/**
@@ -111,10 +127,10 @@ export function createViewState({
 		 *
 		 * @example
 		 * ```typescript
-		 * viewState.selectFolder(folderId);
+		 * signedIn.state.view.selectFolder(folderId);
 		 *
 		 * // Show all notes
-		 * viewState.selectFolder(null);
+		 * signedIn.state.view.selectFolder(null);
 		 * ```
 		 */
 		selectFolder(folderId: FolderId | null) {
@@ -129,7 +145,7 @@ export function createViewState({
 		 *
 		 * @example
 		 * ```typescript
-		 * viewState.selectRecentlyDeleted();
+		 * signedIn.state.view.selectRecentlyDeleted();
 		 * ```
 		 */
 		selectRecentlyDeleted() {
@@ -141,7 +157,7 @@ export function createViewState({
 		 *
 		 * @example
 		 * ```typescript
-		 * viewState.selectNote(noteId);
+		 * signedIn.state.view.selectNote(noteId);
 		 * ```
 		 */
 		selectNote(noteId: NoteId) {
@@ -156,8 +172,8 @@ export function createViewState({
 		 *
 		 * @example
 		 * ```typescript
-		 * viewState.setSortBy('title');
-		 * viewState.setSortBy('dateEdited');
+		 * signedIn.state.view.setSortBy('title');
+		 * signedIn.state.view.setSortBy('dateEdited');
 		 * ```
 		 */
 		setSortBy(value: SortBy) {
@@ -173,8 +189,8 @@ export function createViewState({
 		 *
 		 * @example
 		 * ```typescript
-		 * viewState.setSearchQuery('meeting');
-		 * viewState.setSearchQuery(''); // clear
+		 * signedIn.state.view.setSearchQuery('meeting');
+		 * signedIn.state.view.setSearchQuery(''); // clear
 		 * ```
 		 */
 		setSearchQuery(query: string) {

--- a/packages/ui/src/button/button.svelte
+++ b/packages/ui/src/button/button.svelte
@@ -72,7 +72,7 @@
 	}: ButtonProps = $props();
 </script>
 
-{#snippet buttonContent(tooltipProps?: Record)}
+{#snippet buttonContent(tooltipProps?: Record<string, unknown>)}
 	{#if href}
 		<!-- biome-ignore lint/a11y/useValidAriaRole: conditional role is valid -->
 		<a

--- a/packages/ui/src/sidebar/sidebar-menu-button.svelte
+++ b/packages/ui/src/sidebar/sidebar-menu-button.svelte
@@ -75,7 +75,7 @@
 	});
 </script>
 
-{#snippet Button({ props }: { props?: Record })}
+{#snippet Button({ props }: { props?: Record<string, unknown> })}
 	{@const mergedProps = mergeProps(buttonProps, props)}
 	{#if child}
 		{@render child({ props: mergedProps })}

--- a/packages/ui/src/sonner/toast-on-error.ts
+++ b/packages/ui/src/sonner/toast-on-error.ts
@@ -1,17 +1,17 @@
 import { toast } from 'svelte-sonner';
 import type { AnyTaggedError } from 'wellcrafted/error';
-import type { Result } from 'wellcrafted/result';
+import { isResult, type Result } from 'wellcrafted/result';
 
 /**
  * Show an error toast and pass through the value unchanged.
  *
  * Accepts either a full `Result` or a bare tagged error. When given a Result,
  * it toasts only if the error branch is present. When given a bare error, it
- * always toasts. Either way the input is returned unchanged—so you can wrap
+ * always toasts. Either way the input is returned unchanged, so you can wrap
  * expressions or slot it into `return` statements without disrupting control flow.
  *
- * The title appears as the bold headline. The error's `.message`—typically the
- * detailed output from `defineErrors`—is shown as the muted description below.
+ * The title appears as the bold headline. The error's `.message`, typically the
+ * detailed output from `defineErrors`, is shown as the muted description below.
  *
  * @param resultOrError - A `Result` to inspect, or a bare tagged error to toast
  * @param title - Human-readable headline shown in the toast
@@ -27,13 +27,15 @@ import type { Result } from 'wellcrafted/result';
  * bookmarkState.toggle(tab).then((r) => toastOnError(r, 'Failed to toggle bookmark'));
  * ```
  */
-export function toastOnError<TInput extends Result<unknown, AnyTaggedError> | AnyTaggedError>(
-	resultOrError: TInput,
-	title: string,
-): TInput {
-	const error = 'data' in resultOrError ? resultOrError.error : resultOrError;
-	if (error) {
-		toast.error(title, { description: error.message });
+export function toastOnError<
+	TInput extends Result<unknown, AnyTaggedError> | AnyTaggedError,
+>(resultOrError: TInput, title: string): TInput {
+	if (isResult<unknown, AnyTaggedError>(resultOrError)) {
+		if (resultOrError.error !== null) {
+			toast.error(title, { description: resultOrError.error.message });
+		}
+		return resultOrError;
 	}
+	toast.error(title, { description: resultOrError.message });
 	return resultOrError;
 }

--- a/specs/20260507T013000-honeycrisp-state-namespace-clean-break.md
+++ b/specs/20260507T013000-honeycrisp-state-namespace-clean-break.md
@@ -1,0 +1,502 @@
+# Honeycrisp signed-in state namespace clean break
+
+**Date**: 2026-05-07
+**Status**: Implemented
+**Branch**: chore/workspace-app-layout-skill-audit
+
+## One-sentence thesis
+
+```txt
+The signed-in session keeps two layers: identity/resources at the top
+(`userId`, `honeycrisp`) and Svelte view models grouped under `state`,
+where the children are domain-named (`notes`, `folders`, `view`) and their
+members carry no redundant `Note`/`Folder`/`State` suffixes.
+```
+
+If the sentence needs an "or" or a compatibility clause to stay true, the
+break is incomplete.
+
+## Overview
+
+Rename the Honeycrisp signed-in session's reactive layer so call sites read
+`signedIn.state.notes.create(folderId)` instead of
+`getSignedInSession().state.notesState.createNote(folderId)`. The outer
+`state` namespace stays; the `State` suffix on its children is removed; the
+collection getters and methods drop their domain-name stutter.
+
+This is a one-pass rename inside `apps/honeycrisp`. No new abstractions, no
+shared types extracted, no behavior changes.
+
+## Motivation
+
+### Current State
+
+```ts
+// apps/honeycrisp/src/lib/session.svelte.ts
+return {
+  userId,
+  honeycrisp,
+  state, // { foldersState, notesState, viewState, [Symbol.dispose] }
+  [Symbol.dispose]() { ... },
+};
+```
+
+```ts
+// apps/honeycrisp/src/routes/(signed-in)/state/index.ts
+return {
+  foldersState,
+  notesState,
+  viewState,
+  [Symbol.dispose]() { ... },
+};
+```
+
+```ts
+// representative call site
+const { foldersState, notesState, viewState } = getSignedInSession().state;
+
+notesState.createNote(viewState.selectedFolderId);
+notesState.notes;          // active notes
+notesState.deletedNotes;   // soft-deleted notes
+notesState.noteCounts;     // counts by folder
+foldersState.folders;      // all folders
+foldersState.createFolder();
+```
+
+### Problems
+
+1. **Stutter at every read.** `state.notesState`, `notesState.notes`,
+   `notesState.createNote`, `foldersState.folders`,
+   `foldersState.createFolder`. The namespace already says "notes" or
+   "folders"; repeating it on every member is ceremony.
+2. **Suffix is always the same.** Inside a namespace whose entire purpose
+   is reactive view models, naming each child `xxxState` tells a reader
+   nothing. It is a receipt for not having a namespace at all.
+3. **Destructure-and-dot-access is the local shortcut.** Every component
+   destructures `state` into three local names because the member names
+   are too long to use directly. That breaks the codebase rule against
+   destructuring reactive accessors and hides which session you read from.
+
+### Desired State
+
+```ts
+// apps/honeycrisp/src/lib/session.svelte.ts (unchanged shape)
+return {
+  userId,
+  honeycrisp,
+  state, // { folders, notes, view, [Symbol.dispose] }
+  [Symbol.dispose]() { ... },
+};
+```
+
+```ts
+// representative call site
+const signedIn = getSignedInSession();
+
+signedIn.state.notes.create(signedIn.state.view.selectedFolderId);
+signedIn.state.notes.all;          // active notes
+signedIn.state.notes.deleted;      // soft-deleted notes
+signedIn.state.notes.countsByFolder;
+signedIn.state.folders.all;
+signedIn.state.folders.create();
+signedIn.state.view.selectFolder(folderId);
+```
+
+Two layers, one obvious shape, no suffixes, no stutter.
+
+## Design decisions
+
+| Decision | Class | Choice | Rationale |
+| --- | --- | --- | --- |
+| Keep `state` as a grouping namespace under `signedIn`. | 2 coherence | Keep grouped (`signedIn.state.notes`), not flat (`signedIn.notes`). | Identity/resources (`userId`, `honeycrisp`) are not view models. The split is real and will grow. Reflection in [thesis-discussion]. |
+| Rename `notesState` -> `notes`, `foldersState` -> `folders`, `viewState` -> `view` on the `state` group. | 2 coherence | Drop the `State` suffix from all three. | Inside `state.*`, the suffix is ceremony. |
+| Drop the domain-name stutter on members of `notes` and `folders`. | 2 coherence | `notes.notes` -> `notes.all`, `notes.createNote` -> `notes.create`, `folders.folders` -> `folders.all`, `folders.createFolder` -> `folders.create`, etc. See full rename table. | The whole point of moving into a namespace is so members can be qualified by it. |
+| Drop `notesState.allNotes` from the public surface. | 1 evidence | Remove the getter. | Verified: no external caller uses it. Only the internal `notes` and `deletedNotes` derivations consume the underlying `allNotes` value, which becomes a private `const` inside the factory. |
+| Rename `pinNote` -> `togglePin`. | 2 coherence | Honest name. | The implementation toggles `pinned`; calling it `pin` is a lie. |
+| Rename factories to match: `createNotesState` -> `createNotes`, `createFoldersState` -> `createFolders`, `createViewState` -> `createView`. | 2 coherence | Rename. | The factory builds a `notes` namespace, not a `notesState` blob. |
+| Keep `createHoneycrispState` as the outer factory name. | 3 taste keep | Keep. | It builds the `state` group; the name still describes the lifecycle moment. Revisit when: another app copies this pattern and a shared name emerges. |
+| Bind once at script init (`const signedIn = getSignedInSession()`). | 2 coherence | Mandatory at every call site. | Already the documented rule. The rename removes the temptation to destructure into shorter local names. |
+| Do not add aliases for the old names. | 2 coherence | No aliases, no fallback parsers. | Single app, single sweep, no external consumers. Hybrid surface would defeat the point. |
+
+## Full rename table
+
+### `state.*` (was top-level of `createHoneycrispState`)
+
+| Was | Becomes |
+| --- | --- |
+| `state.foldersState` | `state.folders` |
+| `state.notesState` | `state.notes` |
+| `state.viewState` | `state.view` |
+
+### `state.notes.*` (was `notesState.*`)
+
+| Was | Becomes | Notes |
+| --- | --- | --- |
+| `notesState.allNotes` | (removed from public surface) | Becomes a private `$derived` inside `createNotes`. |
+| `notesState.notes` | `state.notes.all` | Active (not soft-deleted). |
+| `notesState.deletedNotes` | `state.notes.deleted` | |
+| `notesState.noteCounts` | `state.notes.countsByFolder` | More descriptive than `counts`. |
+| `notesState.get(id)` | `state.notes.get(id)` | Unchanged. |
+| `notesState.createNote(folderId)` | `state.notes.create(folderId)` | |
+| `notesState.softDeleteNote(id)` | `state.notes.softDelete(id)` | |
+| `notesState.restoreNote(id)` | `state.notes.restore(id)` | |
+| `notesState.permanentlyDeleteNote(id)` | `state.notes.permanentlyDelete(id)` | |
+| `notesState.pinNote(id)` | `state.notes.togglePin(id)` | Honest: implementation toggles. |
+| `notesState.moveNoteToFolder(id, folderId)` | `state.notes.moveToFolder(id, folderId)` | |
+| `notesState.updateNoteContent({...})` | `state.notes.updateContent({...})` | |
+
+### `state.folders.*` (was `foldersState.*`)
+
+| Was | Becomes |
+| --- | --- |
+| `foldersState.folders` | `state.folders.all` |
+| `foldersState.get(id)` | `state.folders.get(id)` |
+| `foldersState.createFolder()` | `state.folders.create()` |
+| `foldersState.renameFolder(id, name)` | `state.folders.rename(id, name)` |
+| `foldersState.deleteFolder(id)` | `state.folders.delete(id)` |
+
+### `state.view.*` (was `viewState.*`)
+
+All members keep their existing names. No stutter to remove. Only the
+namespace path changes from `viewState.X` to `state.view.X`.
+
+```txt
+state.view.selectedFolderId
+state.view.selectedNoteId
+state.view.selectedNote
+state.view.searchQuery
+state.view.sortBy
+state.view.isRecentlyDeletedView
+state.view.folderName
+state.view.filteredNotes
+state.view.selectFolder(id | null)
+state.view.selectRecentlyDeleted()
+state.view.selectNote(id)
+state.view.setSortBy(value)
+state.view.setSearchQuery(query)
+```
+
+### Factory function renames
+
+| Was | Becomes | File |
+| --- | --- | --- |
+| `createNotesState` | `createNotes` | `routes/(signed-in)/state/notes.svelte.ts` |
+| `createFoldersState` | `createFolders` | `routes/(signed-in)/state/folders.svelte.ts` |
+| `createViewState` | `createView` | `routes/(signed-in)/state/view.svelte.ts` |
+| `createHoneycrispState` | (unchanged) | `routes/(signed-in)/state/index.ts` |
+
+## Architecture
+
+### Before
+
+```txt
+signedIn  (HoneycrispSignedIn)
+├── userId
+├── honeycrisp
+├── state
+│   ├── foldersState
+│   │   ├── folders            <- stutter: foldersState.folders
+│   │   ├── createFolder       <- stutter: foldersState.createFolder
+│   │   ├── renameFolder
+│   │   ├── deleteFolder
+│   │   └── get
+│   ├── notesState
+│   │   ├── allNotes
+│   │   ├── notes              <- stutter: notesState.notes
+│   │   ├── deletedNotes
+│   │   ├── noteCounts
+│   │   ├── createNote         <- stutter: notesState.createNote
+│   │   ├── softDeleteNote
+│   │   ├── restoreNote
+│   │   ├── permanentlyDeleteNote
+│   │   ├── pinNote            <- dishonest: actually toggles
+│   │   ├── moveNoteToFolder
+│   │   ├── updateNoteContent
+│   │   └── get
+│   └── viewState
+│       └── ...
+└── [Symbol.dispose]
+```
+
+### After
+
+```txt
+signedIn  (HoneycrispSignedIn)
+├── userId
+├── honeycrisp
+├── state
+│   ├── folders
+│   │   ├── all
+│   │   ├── get(id)
+│   │   ├── create()
+│   │   ├── rename(id, name)
+│   │   └── delete(id)
+│   ├── notes
+│   │   ├── all
+│   │   ├── deleted
+│   │   ├── countsByFolder
+│   │   ├── get(id)
+│   │   ├── create(folderId?)
+│   │   ├── softDelete(id)
+│   │   ├── restore(id)
+│   │   ├── permanentlyDelete(id)
+│   │   ├── togglePin(id)
+│   │   ├── moveToFolder(id, folderId)
+│   │   └── updateContent({ title, preview, wordCount })
+│   └── view
+│       └── ... (names unchanged, only path is now state.view.X)
+└── [Symbol.dispose]
+```
+
+### File tree (unchanged)
+
+```txt
+apps/honeycrisp/src/routes/(signed-in)/state/
+├── folders.svelte.ts        (createFolders)
+├── index.ts                 (createHoneycrispState)
+├── notes.svelte.ts          (createNotes)
+├── search-params.svelte.ts  (unchanged)
+└── view.svelte.ts           (createView)
+```
+
+No file moves. No new files. The directory name `state/` keeps mapping to
+the `state` namespace.
+
+## Call site rule
+
+Every consumer must follow this shape:
+
+```ts
+const signedIn = getSignedInSession();
+
+// Reads:
+{#each signedIn.state.notes.all as note (note.id)}
+{signedIn.state.notes.deleted.length}
+{signedIn.state.folders.all}
+
+// Writes:
+onclick={() => signedIn.state.notes.create(signedIn.state.view.selectedFolderId)}
+onclick={() => signedIn.state.folders.create()}
+```
+
+Forbidden patterns:
+
+```ts
+// Do NOT destructure into local names:
+const { notes, folders, view } = getSignedInSession().state;        // forbidden
+const { folders, notes, view } = signedIn.state;                    // forbidden
+
+// Do NOT inline getSignedInSession() into templates or handlers:
+{#each getSignedInSession().state.notes.all as note}                // forbidden
+onclick={() => getSignedInSession().state.notes.create()}           // forbidden
+```
+
+The reasoning lives in
+`apps/honeycrisp/src/lib/session.svelte.ts` JSDoc and in
+`feedback_no_destructure_reactive.md` memory. Update the JSDoc example to
+match the new names.
+
+## Implementation plan
+
+### Wave 1: Rename factories and their public surfaces
+
+- [ ] **1.1** `apps/honeycrisp/src/routes/(signed-in)/state/folders.svelte.ts`
+  - Rename `createFoldersState` -> `createFolders`.
+  - Rename returned members per the table: `folders` -> `all`,
+    `createFolder` -> `create`, `renameFolder` -> `rename`,
+    `deleteFolder` -> `delete`.
+  - Update JSDoc examples to use `signedIn.state.folders.X`.
+- [ ] **1.2** `apps/honeycrisp/src/routes/(signed-in)/state/notes.svelte.ts`
+  - Rename `createNotesState` -> `createNotes`.
+  - Drop `allNotes` from the returned object; keep the internal
+    `$derived` if it is still needed by `notes` and `deletedNotes`
+    (it is, it powers both filters).
+  - Rename returned members per the table.
+  - Update JSDoc examples and the `restoreNote` -> `restore` internal
+    reference to `foldersState.folders` (it now reads
+    `foldersState.all`, but in this file the parameter is still typed
+    via `ReturnType<typeof createFolders>`, so update the property
+    access to `.all`).
+  - Rename `pinNote` -> `togglePin`.
+- [ ] **1.3** `apps/honeycrisp/src/routes/(signed-in)/state/view.svelte.ts`
+  - Rename `createViewState` -> `createView`.
+  - Update the parameter type from `{ foldersState, notesState }` to
+    `{ folders, notes }`, typed as
+    `ReturnType<typeof createFolders>` and
+    `ReturnType<typeof createNotes>`.
+  - Update internal reads: `notesState.notes` -> `notes.all`,
+    `foldersState.get` -> `folders.get`, `notesState.get` -> `notes.get`.
+  - JSDoc examples now read `signedIn.state.view.X`.
+- [ ] **1.4** `apps/honeycrisp/src/routes/(signed-in)/state/index.ts`
+  - Update imports to the renamed factories.
+  - Build `folders`, `notes`, `view` (no `State` suffix) and return
+    `{ folders, notes, view, [Symbol.dispose] }`.
+  - Dispose order unchanged: notes, folders. View has no dispose.
+
+### Wave 2: Update call sites
+
+Use the rename table. Each call site MUST follow the bind-once rule.
+Components to update (verified by grep):
+
+- [ ] **2.1** `apps/honeycrisp/src/routes/(signed-in)/+page.svelte`
+- [ ] **2.2** `apps/honeycrisp/src/routes/(signed-in)/components/CommandPalette.svelte`
+- [ ] **2.3** `apps/honeycrisp/src/routes/(signed-in)/components/FolderMenuItem.svelte`
+- [ ] **2.4** `apps/honeycrisp/src/routes/(signed-in)/components/NoteBodyPane.svelte`
+- [ ] **2.5** `apps/honeycrisp/src/routes/(signed-in)/components/NoteCard.svelte`
+- [ ] **2.6** `apps/honeycrisp/src/routes/(signed-in)/components/NoteList.svelte`
+- [ ] **2.7** `apps/honeycrisp/src/routes/(signed-in)/components/Sidebar.svelte`
+
+For each: replace any `const { ... } = getSignedInSession().state` (or
+component-prop equivalents) with `const signedIn = getSignedInSession()`,
+then dot-access through `signedIn.state.notes`, `signedIn.state.folders`,
+`signedIn.state.view`.
+
+### Wave 3: Update docs and JSDoc
+
+- [ ] **3.1** `apps/honeycrisp/src/lib/session.svelte.ts` JSDoc:
+  the example block already shows `signedIn.state.X`; verify it does not
+  reference any old member names.
+- [ ] **3.2** `apps/honeycrisp/src/routes/(signed-in)/honeycrisp/workspace.ts`
+  line 139 mentions `foldersState`; update to `folders`.
+- [ ] **3.3** Inside the renamed state files, ensure example blocks use
+  `signedIn.state.notes.X`, `signedIn.state.folders.X`,
+  `signedIn.state.view.X` consistently.
+
+### Wave 4: Verify
+
+- [ ] **4.1** `bun run typecheck` (or the equivalent app-scoped command;
+  confirm with `bun run --filter @epicenter/honeycrisp` or whatever the
+  Honeycrisp app exposes).
+- [ ] **4.2** `bun run check` if the Svelte app has a `svelte-check` step.
+- [ ] **4.3** Final grep sweep for old vocabulary inside
+  `apps/honeycrisp/src/`:
+  - `notesState`
+  - `foldersState`
+  - `viewState`
+  - `createNotesState`
+  - `createFoldersState`
+  - `createViewState`
+  - `createNote\b` (allow within prose docs only if outside src/)
+  - `createFolder\b`
+  - `deleteFolder\b`
+  - `renameFolder\b`
+  - `pinNote\b`
+  - `softDeleteNote\b`
+  - `restoreNote\b`
+  - `permanentlyDeleteNote\b`
+  - `moveNoteToFolder\b`
+  - `updateNoteContent\b`
+  - `noteCounts\b`
+  - `deletedNotes\b`
+  - `\.allNotes\b`
+  Each remaining hit must be inside `specs/`, prior commit messages, or
+  truly unrelated code. Report any other hit before declaring done.
+
+### Wave 5: Smoke (manual)
+
+- [ ] **5.1** Start the Honeycrisp dev server, sign in, and confirm:
+  create folder, rename folder, delete folder, create note, edit note
+  body, move note between folders, soft-delete note, restore from
+  Recently Deleted, permanently delete, toggle pin, search filter,
+  sort change, command palette folder/note jump, deleted-notes view
+  toggle. The plan touches every code path in the call-site grep, so
+  this is the verification that the renames did not silently break a
+  binding.
+
+## Edge cases
+
+### Internal cross-state reads
+
+`view.svelte.ts` consumes the notes and folders namespaces. After
+rename, the parameter object is `{ folders, notes }` and its internal
+reads are `notes.all`, `folders.get`, `notes.get`. The implementer must
+update both the destructure on line 32 and every dot-access in the file.
+
+`notes.svelte.ts` consumes folders inside `restore` to check whether a
+note's original folder still exists. The current code reads
+`foldersState.folders.some(...)`. After rename, the parameter is
+`folders` and the read becomes `folders.all.some(...)`.
+
+### Shared search params
+
+`search-params.svelte.ts` is not renamed and is not exposed through the
+state namespace. It is consumed by the factories internally. Leave it.
+
+### Dispose order
+
+`createHoneycrispState`'s dispose currently calls
+`notesState[Symbol.dispose]()` then `foldersState[Symbol.dispose]()`.
+Keep the order; only the local variable names change.
+
+### `HoneycrispSignedIn` type
+
+The exported `HoneycrispSignedIn` type is `InferSignedIn<typeof session>`,
+so it is derived from the `build` return shape. No manual type update is
+needed; TypeScript will reflect the new member names automatically.
+
+## Open questions
+
+1. **`countsByFolder` vs `counts`.**
+   - Options: (a) `state.notes.countsByFolder`, (b) `state.notes.counts`.
+   - **Recommendation**: `countsByFolder`. `counts` alone is
+     ambiguous in a future where total/active/deleted counts might be
+     exposed. Leave open if the implementer finds `counts` reads better
+     in context.
+
+2. **`updateContent` parameter shape.**
+   - The current implementation takes `{ title, preview, wordCount }`
+     and applies them to whichever note the URL search param says is
+     selected. This implicit selection is a separate smell.
+   - Options: (a) keep implicit selection, (b) require the caller to
+     pass `noteId` explicitly.
+   - **Recommendation**: Keep implicit for this spec. Refactoring the
+     update flow to take `noteId` is a separate change and would balloon
+     this rename. Note as a follow-up if it bothers the implementer.
+
+3. **Should `view`'s methods drop `select` prefixes?**
+   - For example `state.view.folder = id` via a setter, or
+     `state.view.toFolder(id)`.
+   - **Recommendation**: No. `selectFolder`/`selectNote` are honest
+     verbs that name the lifecycle moment ("select"). Renaming them is
+     scope creep.
+
+## Decisions log
+
+- Keep `state` as a namespace (do not flatten to `signedIn.notes`).
+  Constraint: identity/resources and reactive view models are different
+  layers, and the resource layer is expected to grow (sync clients,
+  presence, additional workspace handles).
+  Revisit when: the resource layer is provably stable at three members
+  for two consecutive significant releases, or another app copies the
+  pattern and the grouping looks redundant in that app.
+- Keep the file name `state/` and `createHoneycrispState`.
+  Constraint: filename matches the namespace it builds.
+  Revisit when: a second app needs the same shape and the name should
+  generalize.
+
+## Success criteria
+
+- [ ] No occurrence of `notesState`, `foldersState`, `viewState`,
+  `createNotesState`, `createFoldersState`, or `createViewState` inside
+  `apps/honeycrisp/src/`.
+- [ ] No call site destructures from `getSignedInSession().state`.
+- [ ] No call site inlines `getSignedInSession()` into a template or
+  event handler.
+- [ ] Typecheck passes (`bun run typecheck` or equivalent).
+- [ ] Manual smoke (Wave 5) succeeds for every listed flow.
+- [ ] JSDoc examples in the three state files and in
+  `session.svelte.ts` show only the new names.
+
+## References
+
+- `apps/honeycrisp/src/lib/session.svelte.ts` (signed-in shape, JSDoc rules)
+- `apps/honeycrisp/src/routes/(signed-in)/state/index.ts`
+- `apps/honeycrisp/src/routes/(signed-in)/state/folders.svelte.ts`
+- `apps/honeycrisp/src/routes/(signed-in)/state/notes.svelte.ts`
+- `apps/honeycrisp/src/routes/(signed-in)/state/view.svelte.ts`
+- `apps/honeycrisp/src/routes/(signed-in)/state/search-params.svelte.ts`
+- `apps/honeycrisp/src/routes/(signed-in)/+page.svelte`
+- `apps/honeycrisp/src/routes/(signed-in)/components/*.svelte`
+- Memory: `feedback_no_destructure_reactive.md`
+  (bind once, never destructure reactive accessors)
+- Skill: `cohesive-clean-breaks` (no aliases, no hybrid surface)

--- a/specs/20260507T080909-workspace-app-layout-skill-realign.md
+++ b/specs/20260507T080909-workspace-app-layout-skill-realign.md
@@ -1,0 +1,112 @@
+# Realign workspace-app-layout skill with the two shipped layouts
+
+> The skill currently leads with `apps/<app>/src/lib/<app>/{index, browser, client}.ts` as the default shape, with the route-group variant as a side note. The audit shows that's backwards: the post-spec-3 web apps (fuji, honeycrisp, zhongwen) use the route-group shape and don't have a `client.ts` at all, while the lib-singleton shape lives on in apps that haven't migrated to `createSession`. Reframe the skill around two co-equal shapes; surface `session.svelte.ts` as the singleton home for shape A.
+
+**Date**: 2026-05-07
+**Status**: Implemented (2026-05-07)
+**Branch**: `chore/workspace-app-layout-skill-audit`
+
+## One-sentence thesis
+
+```txt
+Two layouts ship today; the skill should describe both as first-class
+shapes and point at the real files in each, not lead with one and footnote
+the other.
+```
+
+## Audit findings
+
+```
+Shape A: auth-gated SvelteKit web apps (fuji, honeycrisp, zhongwen)
+  apps/<app>/src/lib/auth.ts
+    └── createCookieAuth() → exported `auth`
+  apps/<app>/src/lib/session.svelte.ts                    ← singleton home
+    ├── createSession({ auth, build })
+    ├── HMR disposal
+    └── module-level getSignedInSession() helper
+  apps/<app>/src/routes/(signed-in)/<app>/index.ts        ← iso factory
+    └── open<App>Doc({ encryptionKeys, clientID? })
+  apps/<app>/src/routes/(signed-in)/<app>/browser.ts      ← env binding
+    └── open<App>({ userId, peer, bearerToken, encryptionKeys })
+
+  No client.ts. Singleton lives in session.svelte.ts. Iso + env factories
+  live under the (signed-in) route group, not src/lib/<app>/.
+
+Shape B: module-level singleton apps (opensidian, tab-manager, whispering)
+  apps/<app>/src/lib/<app>/index.ts                       ← iso factory
+  apps/<app>/src/lib/<app>/{browser,extension,tauri}.ts   ← env binding
+  apps/<app>/src/lib/<app>/client.ts                      ← singleton + auth wait
+    ├── module-level await session.whenReady
+    ├── waitForAuthState(auth, ...)
+    └── module-level open<App>(...) export
+
+  No session.svelte.ts. Auth integration is inline at module init.
+```
+
+The skill currently does mention shape A (lines 30-35: "Some SvelteKit apps scope their browser workspace to `routes/(signed-in)/`"), but as a deviation from the lib-singleton default. It should be the other way around: shape A is the post-refactor target; shape B is the legacy that opensidian/tab-manager are scheduled to migrate away from per `specs/20260507T054727-opensidian-tab-manager-create-session.md`.
+
+## Specific gaps in current SKILL.md
+
+```
+LINE(S)            ISSUE                                                         FIX
+─────────────────  ──────────────────────────────────────────────────────────    ─────────────────────────────────
+13-22              Single tree shows lib/<app>/ as default, client.ts            Replace with two parallel trees,
+                   "optional", routes/(signed-in)/ unmentioned                   one per shape.
+
+30-35              Shape A described as a deviation                              Reframe as a peer shape; remove
+                                                                                 "if a $lib client singleton owns
+                                                                                 the auth wait" framing as fallback.
+
+39-45 (Layers      No row for session.svelte.ts                                  Add row: "session.svelte.ts | App
+table)                                                                           singleton + lifecycle | createSession,
+                                                                                 auth, HMR | session export,
+                                                                                 getSignedInSession()"
+
+41-45              client.ts row reads "App singleton or auth                    Split into two rows or qualify:
+                   owner ... apps not yet on createSession"                      shape A has no client.ts; shape B's
+                                                                                 client.ts is the singleton.
+
+176-230 (daemon /  Daemon and script content is correct but                      No change needed; clarify upfront
+script + package   conflated with browser-singleton work                         that daemon/script factories are
+exports)                                                                         shared across both shapes via the
+                                                                                 cli package.
+
+252                "Relocating client.ts during a daemon-only                    Qualify as shape-B-only; add
+                   change" anti-pattern                                          shape-A equivalent ("don't move
+                                                                                 createSession out of session.svelte.ts
+                                                                                 during a routing change").
+```
+
+## Whispering note
+
+Whispering is its own shape: Tauri desktop, no remote auth, no encryption keys, workspace = always-on singleton. Mentioning it as shape B is approximately right (it has `client.ts`), but the skill should call out that it doesn't pass `encryptionKeys` and doesn't have an auth path. Omit it from the migration discussion.
+
+## Out of scope (separate specs)
+
+- **Opensidian/tab-manager createSession migration** is its own work, already scoped at `specs/20260507T054727-opensidian-tab-manager-create-session.md`. That spec is correct post-audit:
+  - Opensidian section: actionable now; migrate `client.ts` shape into `auth.ts` + `session.svelte.ts` + iso/env factories under route group. Same shape A as fuji.
+  - Tab-manager section: blocked on async-construction decision (`openTabManager` is async today; `createSession.build` is sync). The spec correctly defers this; do not unblock here.
+- **Tab-manager async construction** needs its own design call (sync construction + async readiness vs. an explicit `createSessionAsync` factory variant). Not unlocked by this skill rewrite.
+
+## Execution
+
+Single wave, single commit:
+
+1. Edit `.claude/skills/workspace-app-layout/SKILL.md` per the gaps table above.
+2. Verify by re-reading the skill cold: would an agent scaffolding a new auth-gated web app land on shape A first? Would an agent maintaining opensidian land on shape B with a clear "this is being migrated" pointer?
+3. Smoke check: every file path mentioned in code blocks should resolve in the current tree (`apps/zhongwen/src/lib/zhongwen/...` references that no longer exist must be updated to `apps/zhongwen/src/routes/(signed-in)/zhongwen/...`).
+
+## Verification
+
+```
+☐ skill leads with both shapes; neither is a side note
+☐ shape A tree shows session.svelte.ts as the singleton home
+☐ Layers table has a session.svelte.ts row
+☐ every file path in code blocks resolves
+☐ daemon/script content unchanged in substance
+☐ no agent reading this fresh would scaffold a new web app under src/lib/<app>/
+```
+
+## Why this spec, not a "rewrite the skill" spec
+
+The skill is ~70% right post-spec-3. A targeted realign earns the cleanup without committing to a full rewrite that would also need to absorb the (still-pending) tab-manager async question. If `createSession.build` becomes async-capable later, the skill grows one more variant; better to land structural fixes now than wait for a feature that may not happen.


### PR DESCRIPTION
This PR cleans up two related pieces of workspace-app architecture: the docs that explain where app lifecycle code belongs, and Honeycrisp's signed-in state surface.

The layout skill now describes the two shipped shapes directly. Auth-gated SvelteKit apps such as Fuji, Honeycrisp, and Zhongwen keep their singleton lifecycle in `session.svelte.ts`; module-level singleton apps such as Opensidian, Tab Manager, and Whispering keep that lifecycle in `client.ts` or the runtime-specific equivalent. The point is to make the expected home for side effects obvious before someone adds another `client.ts` to an app that already has a session singleton.

Honeycrisp now follows that same clarity rule inside its signed-in state. The state children are named by domain, so call sites read `signedIn.state.notes.create(...)`, `signedIn.state.folders.all`, and `signedIn.state.view.currentNotes` instead of carrying `notesState`, `foldersState`, `createNote`, and similar repeated suffixes. The page-level note list rendering also moved behind `NoteList`, so `view` owns the current notes, title, controls flag, and empty message as one coherent view model.

This PR also includes three small shared UI type fixes because Honeycrisp imports those components during `svelte-check`. The fixes are mechanical: snippet prop records get explicit key/value types, and `toastOnError` uses Wellcrafted's `isResult` guard before reading the error channel.

Verification:

```txt
bun install --frozen-lockfile
bun run typecheck   # from apps/honeycrisp
bun format:check .agents/skills/workspace-app-layout/SKILL.md .claude/skills/workspace-app-layout/SKILL.md specs/20260507T080909-workspace-app-layout-skill-realign.md specs/20260507T013000-honeycrisp-state-namespace-clean-break.md apps/honeycrisp/src/routes/'(signed-in)'/+page.svelte apps/honeycrisp/src/routes/'(signed-in)'/components/CommandPalette.svelte apps/honeycrisp/src/routes/'(signed-in)'/components/FolderMenuItem.svelte apps/honeycrisp/src/routes/'(signed-in)'/components/NoteBodyPane.svelte apps/honeycrisp/src/routes/'(signed-in)'/components/NoteCard.svelte apps/honeycrisp/src/routes/'(signed-in)'/components/NoteList.svelte apps/honeycrisp/src/routes/'(signed-in)'/components/Sidebar.svelte apps/honeycrisp/src/routes/'(signed-in)'/honeycrisp/workspace.ts apps/honeycrisp/src/routes/'(signed-in)'/state/folders.svelte.ts apps/honeycrisp/src/routes/'(signed-in)'/state/index.ts apps/honeycrisp/src/routes/'(signed-in)'/state/notes.svelte.ts apps/honeycrisp/src/routes/'(signed-in)'/state/view.svelte.ts packages/ui/src/button/button.svelte packages/ui/src/sidebar/sidebar-menu-button.svelte packages/ui/src/sonner/toast-on-error.ts
git diff --check origin/main...HEAD
rg "foldersState|notesState|viewState|createFoldersState|createNotesState|createViewState|createNote\\b|softDeleteNote\\b|restoreNote\\b|permanentlyDeleteNote\\b|pinNote\\b|moveNoteToFolder\\b|updateNoteContent\\b|noteCounts\\b|deletedNotes\\b|\\.allNotes\\b" apps/honeycrisp/src
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->