### PR TITLE
Share API trusted origins between CORS and auth

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -26,6 +26,7 @@ import { createAutumn } from './autumn';
 import { billingRoutes } from './billing-routes';
 import { MAX_PAYLOAD_BYTES } from './constants';
 import * as schema from './db/schema';
+import { TRUSTED_ORIGINS } from './trusted-origins';
 
 export { DocumentRoom } from './document-room';
 // Re-export so wrangler types generates DurableObjectNamespace<WorkspaceRoom|DocumentRoom>
@@ -96,24 +97,13 @@ export type Env = {
 
 const factory = createFactory<Env>({
 	initApp: (app) => {
-		// CORS — skip WebSocket upgrades (101 response headers are immutable).
-		// Allowed origins derived from APPS so adding an app automatically allows it.
-		const allowedOrigins = new Set([
-			'tauri://localhost',
-			...Object.values(APPS).flatMap((a) => [
-				...a.urls,
-				`http://localhost:${a.port}`,
-			]),
-		]);
+		// CORS: skip WebSocket upgrades (101 response headers are immutable).
+		// Trusted origins live in `./trusted-origins.ts`, shared with Better Auth.
 		app.use('*', async (c, next) => {
 			if (c.req.header('upgrade') === 'websocket') return next();
 			return cors({
-				origin: (origin) => {
-					if (!origin) return origin;
-					if (allowedOrigins.has(origin)) return origin;
-					if (origin.startsWith('chrome-extension://')) return origin;
-					return undefined;
-				},
+				origin: (origin) =>
+					origin && TRUSTED_ORIGINS.includes(origin) ? origin : undefined,
 				credentials: true,
 				allowHeaders: ['Content-Type', 'Authorization', 'Upgrade'],
 				allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
@@ -121,7 +111,7 @@ const factory = createFactory<Env>({
 			})(c, next);
 		});
 
-		// Layer 1: Database — per-request pg.Client lifecycle (connect/end).
+		// Layer 1: Database: per-request pg.Client lifecycle (connect/end).
 		// Uses Client (not Pool) because Hyperdrive IS the connection pool.
 		app.use('*', async (c, next) => {
 			// 1. Create a fresh pg connection and afterResponse queue for this request.
@@ -139,19 +129,19 @@ const factory = createFactory<Env>({
 				//    promises (e.g. upsertDoInstance) into afterResponse.
 				await next();
 			} finally {
-				// 4. The response has already left — Hono streams it during `await next()`.
+				// 4. The response has already left; Hono streams it during `await next()`.
 				//    But the fire-and-forget promises are still in-flight. CF Workers
 				//    would kill the isolate as soon as the response finishes, so we use
 				//    `waitUntil()` to keep it alive. `drain()` settles every queued
 				//    promise via `Promise.allSettled`, then `.then()` closes the pg
-				//    connection — guaranteeing the client outlives all its queries.
+				//    connection, guaranteeing the client outlives all its queries.
 				c.executionCtx.waitUntil(
 					afterResponse.drain().then(() => client.end()),
 				);
 			}
 		});
 
-		// Layer 2: Auth — pure, reads db from context.
+		// Layer 2: Auth: pure, reads db from context.
 		// Wrangler dev uses the custom domain from routes config as the Host header,
 		// producing http://api.epicenter.so (no TLS). Detect this and use localhost.
 		app.use('*', async (c, next) => {
@@ -182,7 +172,7 @@ app.get(
 	(c) => c.json({ mode: 'hub', version: '0.1.0', runtime: 'cloudflare' }),
 );
 
-// Auth pages — server-rendered Hono JSX
+// Auth pages: server-rendered Hono JSX
 app.get('/sign-in', async (c) => {
 	const session = await c.var.auth.api.getSession({
 		headers: c.req.raw.headers,
@@ -198,7 +188,7 @@ app.get('/sign-in', async (c) => {
 		if (callbackURL?.startsWith('/')) {
 			return c.redirect(callbackURL);
 		}
-		// Already signed in, no redirect needed — show signed-in confirmation
+		// Already signed in, no redirect needed, show signed-in confirmation
 		const displayName = session.user.name ?? session.user.email;
 		return c.html(
 			renderSignedInPage({ displayName, email: session.user.email }),
@@ -272,7 +262,7 @@ app.get(
 	(c) => oauthProviderAuthServerMetadata(c.var.auth)(c.req.raw),
 );
 
-// Asset reads — unauthenticated (unguessable URL is the credential).
+// Asset reads: unauthenticated (unguessable URL is the credential).
 // Must be mounted BEFORE requireSession so GET requests aren't blocked.
 app.route('/api/assets', assetPublicRoutes);
 
@@ -325,10 +315,10 @@ app.use('/ai/*', async (c, next) => {
 	await next();
 });
 
-// Billing — redirect legacy page to dashboard SPA
+// Billing: redirect legacy page to dashboard SPA
 app.get('/billing', (c) => c.redirect('/dashboard'));
 
-// Dashboard SPA — static assets served by Workers Static Assets (wrangler.jsonc).
+// Dashboard SPA: static assets served by Workers Static Assets (wrangler.jsonc).
 // This catch-all handles SPA client-side routing: when no static file matches,
 // serve index.html so the SvelteKit router takes over.
 app.get('/dashboard/*', async (c) => {
@@ -344,10 +334,10 @@ app.get('/dashboard', async (c) => {
 	return assets.fetch(new Request(indexUrl.toString(), c.req.raw));
 });
 
-// Billing API routes — typed JSON routes consumed by the dashboard SPA via hc<AppType>
+// Billing API routes: typed JSON routes consumed by the dashboard SPA via hc<AppType>
 app.route('/api/billing', billingRoutes);
 
-// Asset routes — upload + delete (authed, mounted after requireSession)
+// Asset routes: upload + delete (authed, mounted after requireSession)
 app.route('/api/assets', assetAuthedRoutes);
 
 // AI chat
@@ -361,7 +351,7 @@ app.post(
 );
 
 // ---------------------------------------------------------------------------
-// Workspace routes — one WorkspaceRoom DO per workspace (gc: true)
+// Workspace routes: one WorkspaceRoom DO per workspace (gc: true)
 // ---------------------------------------------------------------------------
 
 /**
@@ -388,7 +378,7 @@ app.post(
  * name stays the same, an ACL table grants access to other users, and auth
  * middleware checks "is this user the owner OR in the ACL?"
  *
- * Multi-tenant cloud isolation (if needed later) is a platform-layer concern—
+ * Multi-tenant cloud isolation (if needed later) is a platform-layer concern,
  * a tenant prefix added at the routing layer, not embedded in the app's data model.
  */
 
@@ -416,7 +406,7 @@ function getDocumentStub(c: Context<Env>) {
  * Records that a user accessed a DO, optionally updating storage bytes.
  * Uses INSERT ON CONFLICT so the first access creates the row and
  * subsequent accesses update `lastAccessedAt` (and `storageBytes` when
- * provided). Errors are caught and logged—this is best-effort telemetry,
+ * provided). Errors are caught and logged, this is best-effort telemetry,
  * not billing authority.
  */
 function upsertDoInstance(
@@ -524,7 +514,7 @@ app.post(
 );
 
 // ---------------------------------------------------------------------------
-// Document routes — one DocumentRoom DO per document (gc: false, snapshots)
+// Document routes: one DocumentRoom DO per document (gc: false, snapshots)
 // ---------------------------------------------------------------------------
 
 app.get(

--- a/apps/api/src/auth/create-auth.ts
+++ b/apps/api/src/auth/create-auth.ts
@@ -1,6 +1,5 @@
 import { oauthProvider } from '@better-auth/oauth-provider';
 import type { BetterAuthSessionResponse } from '@epicenter/auth/contracts';
-import { APPS } from '@epicenter/constants/apps';
 import { EPICENTER_CLI_OAUTH_CLIENT_ID } from '@epicenter/constants/oauth';
 import { type BetterAuthOptions, betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
@@ -13,6 +12,7 @@ import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { createAutumn } from '../autumn';
 import { FEATURE_IDS } from '../billing-plans';
 import * as schema from '../db/schema';
+import { TRUSTED_ORIGINS } from '../trusted-origins';
 import { BASE_AUTH_CONFIG } from './base-config';
 import { deriveUserEncryptionKeys } from './encryption';
 
@@ -156,24 +156,7 @@ export function createAuth({
 				},
 			},
 		},
-		trustedOrigins: (request) => {
-			const origins = [
-				'tauri://localhost',
-				...Object.values(APPS).flatMap((app) => [
-					...app.urls,
-					`http://localhost:${app.port}`,
-				]),
-				// Wrangler dev serves at the custom domain over plain HTTP (no TLS).
-				// The browser sends Origin: http://api.epicenter.so which doesn't
-				// match https://api.epicenter.so. Add the HTTP variant.
-				`http://${new URL(APPS.API.urls[0]).host}`,
-			];
-			const origin = request?.headers.get('origin');
-			if (origin?.startsWith('chrome-extension://')) {
-				origins.push(origin);
-			}
-			return origins;
-		},
+		trustedOrigins: TRUSTED_ORIGINS,
 		// secondaryStorage = Cloudflare KV as a read-through cache.
 		// Postgres (Germany) is always the source of truth. KV avoids the
 		// ~150ms round-trip on repeated session reads from distant edges.

--- a/apps/api/src/trusted-origins.ts
+++ b/apps/api/src/trusted-origins.ts
@@ -1,0 +1,37 @@
+import { APPS } from '@epicenter/constants/apps';
+
+/**
+ * Pinned Chrome extension origin for the tab-manager.
+ *
+ * Stable across all installs because `apps/tab-manager/wxt.config.ts`
+ * pins the manifest `key`. Allowlisting this exact origin replaces an
+ * earlier `chrome-extension://*` wildcard that defeated CSRF protection.
+ */
+const TAB_MANAGER_CHROME_EXTENSION_ORIGIN =
+	'chrome-extension://mkbnicfhpacdofmoocppnjjmdfmkkgda';
+
+/**
+ * Origins permitted by both CORS and Better Auth's CSRF check.
+ *
+ * Adding an app to `APPS` auto-extends this. Browser extensions are added
+ * explicitly with their pinned origin: Chrome via the WXT `key`, Firefox
+ * via `browser_specific_settings.gecko.id` plus AMO signing (required, no
+ * exceptions; self-distributed XPIs get a random per-install UUID).
+ *
+ * Localhost dev URLs are trusted in production by design so developers can
+ * iterate against the deployed API from `localhost:<port>`. Session cookies
+ * are still per-origin scoped, so this is not a CSRF vector.
+ *
+ * The `http://api.epicenter.so` entry is for `wrangler dev`, which serves
+ * the custom domain over plain HTTP. In production Cloudflare upgrades the
+ * domain to HTTPS, so this Origin is never sent by a real browser there.
+ */
+export const TRUSTED_ORIGINS: string[] = [
+	'tauri://localhost',
+	TAB_MANAGER_CHROME_EXTENSION_ORIGIN,
+	...Object.values(APPS).flatMap((app) => [
+		...app.urls,
+		`http://localhost:${app.port}`,
+	]),
+	`http://${new URL(APPS.API.urls[0]).host}`,
+];


### PR DESCRIPTION
This PR makes the API origin policy explicit and shared. Before this change, CORS and Better Auth each built their own trusted origin list, and both had special handling for browser extension origins. That meant the security boundary was split across two call sites.

The new `trusted-origins.ts` file is the single source for origins accepted by both CORS and Better Auth's CSRF checks. It still derives app URLs and localhost development URLs from `APPS`, keeps the `tauri://localhost` desktop origin, and preserves the `http://api.epicenter.so` wrangler-dev origin. The material behavior change is that Tab Manager's Chrome extension origin is now pinned to the stable extension ID from `wxt.config.ts` instead of accepting every `chrome-extension://*` origin.

That is intentionally stricter. The tab-manager manifest pins the Chrome extension ID, so the API can allow that exact extension without opening CORS and auth trust to arbitrary extensions installed in the same browser.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->