### PR TITLE
Fix macOS FFmpeg false-negative detection

### DIFF
--- a/apps/whispering/src/lib/services/desktop/ffmpeg.ts
+++ b/apps/whispering/src/lib/services/desktop/ffmpeg.ts
@@ -7,10 +7,10 @@ import {
 	type InferErrors,
 } from 'wellcrafted/error';
 import { Err, Ok, tryAsync } from 'wellcrafted/result';
+import { IS_MACOS } from '$lib/constants/platform';
 import { asShellCommand, CommandServiceLive } from './command';
 import { FsServiceLive } from './fs';
 import { getFileExtensionFromFfmpegOptions } from './recorder/ffmpeg';
-import { IS_MACOS } from '$lib/constants/platform';
 
 export const FfmpegError = defineErrors({
 	InstallCheckFailed: ({ cause }: { cause: unknown }) => ({

--- a/apps/whispering/src/lib/services/desktop/ffmpeg.ts
+++ b/apps/whispering/src/lib/services/desktop/ffmpeg.ts
@@ -10,6 +10,7 @@ import { Err, Ok, tryAsync } from 'wellcrafted/result';
 import { asShellCommand, CommandServiceLive } from './command';
 import { FsServiceLive } from './fs';
 import { getFileExtensionFromFfmpegOptions } from './recorder/ffmpeg';
+import { IS_MACOS } from '$lib/constants/platform';
 
 export const FfmpegError = defineErrors({
 	InstallCheckFailed: ({ cause }: { cause: unknown }) => ({
@@ -40,6 +41,19 @@ export const FfmpegServiceLive = {
 						await CommandServiceLive.execute(asShellCommand('ffmpeg -version'));
 
 					if (commandError) throw commandError;
+
+					if (result.code !== 0 && IS_MACOS) {
+						const { data: macosResult, error: macosCommandError } =
+							await CommandServiceLive.execute(
+								asShellCommand(
+									'PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" ffmpeg -version',
+								),
+							);
+
+						if (macosCommandError) throw macosCommandError;
+						return macosResult;
+					}
+
 					return result;
 				},
 				catch: (error) => FfmpegError.InstallCheckFailed({ cause: error }),


### PR DESCRIPTION
Fixes #1147 with a minimal, targeted change in FFmpeg install detection.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->