### PR TITLE
refactor: standardize on [Symbol.dispose] across owned types

### DIFF
--- a/apps/opensidian/src/lib/opensidian/browser.ts
+++ b/apps/opensidian/src/lib/opensidian/browser.ts
@@ -117,7 +117,7 @@ export function openOpensidian({
 		if (disposed) return;
 		disposed = true;
 		fileContentDocs[Symbol.dispose]();
-		sqliteIndex.dispose();
+		sqliteIndex[Symbol.dispose]();
 		doc[Symbol.dispose]();
 	}
 

--- a/docs/articles/20260420T160000-state-handle-null-is-the-component-lifecycle-in-disguise.md
+++ b/docs/articles/20260420T160000-state-handle-null-is-the-component-lifecycle-in-disguise.md
@@ -13,7 +13,7 @@ I was reviewing five Svelte components that all opened a Yjs doc handle. Four of
 	$effect(() => {
 		const h = fileContentDocs.open(fileId);
 		handle = h;
-		return () => { h.dispose(); handle = null; };
+		return () => { h[Symbol.dispose](); handle = null; };
 	});
 </script>
 
@@ -30,7 +30,7 @@ One of them, `EntryEditor.svelte`, looked like this:
 	const id = entry.id;
 
 	const contentDoc = entryContentDocs.open(id);
-	$effect(() => () => contentDoc.dispose());
+	$effect(() => () => contentDoc[Symbol.dispose]());
 </script>
 
 <Editor yxmlfragment={contentDoc.content.binding} />
@@ -65,7 +65,7 @@ Before (`honeycrisp/+page.svelte`):
 		if (!id) { bodyHandle = null; return; }
 		const handle = noteBodyDocs.open(id);
 		bodyHandle = handle;
-		return () => { handle.dispose(); bodyHandle = null; };
+		return () => { handle[Symbol.dispose](); bodyHandle = null; };
 	});
 </script>
 
@@ -92,7 +92,7 @@ And `NoteBodyPane.svelte`:
 <script lang="ts">
 	let { noteId }: { noteId: string } = $props();
 	const handle = noteBodyDocs.open(noteId);
-	$effect(() => () => handle.dispose());
+	$effect(() => () => handle[Symbol.dispose]());
 </script>
 
 <HoneycripEditor yxmlfragment={handle.body.binding} ... />
@@ -111,12 +111,12 @@ The code DeepWiki produced:
 ```svelte
 $effect(() => {
 	if (externalResource) {
-		externalResource.dispose();
+		externalResource[Symbol.dispose]();
 	}
 	externalResource = openExternalResource(resourceId);
 	return () => {
 		if (externalResource) {
-			externalResource.dispose();
+			externalResource[Symbol.dispose]();
 		}
 	};
 });
@@ -127,7 +127,7 @@ That disposes twice on every prop change. The effect body disposes the previous 
 This isn't a slight against the docs. It's the point. The pattern is hard to write correctly. The equivalent Pattern A version cannot write this bug, because the effect has one line:
 
 ```svelte
-$effect(() => () => handle.dispose());
+$effect(() => () => handle[Symbol.dispose]());
 ```
 
 There is no body to desynchronize from the cleanup, because the body is the cleanup.

--- a/docs/articles/copied-types-are-boundary-leaks.md
+++ b/docs/articles/copied-types-are-boundary-leaks.md
@@ -35,11 +35,11 @@ Inside typed production code, though, `Like` often means the owner was nearby an
 ```typescript
 type WorkspaceLike = {
 	ydoc: Y.Doc;
-	dispose(): void;
+	[Symbol.dispose](): void;
 };
 
 const workspace = value as WorkspaceLike;
-workspace.dispose();
+workspace[Symbol.dispose]();
 ```
 
 If `value` came from our own workspace factory, the factory should own the handle type:
@@ -48,7 +48,7 @@ If `value` came from our own workspace factory, the factory should own the handl
 export type WorkspaceHandle = ReturnType<typeof createWorkspaceHandle>;
 
 const workspace: WorkspaceHandle = createWorkspaceHandle();
-workspace.dispose();
+workspace[Symbol.dispose]();
 ```
 
 If `value` came from outside the system, validate or brand it at the boundary. Do not spread the cast across internal code.

--- a/packages/cli/test/e2e-up-cross-peer.test.ts
+++ b/packages/cli/test/e2e-up-cross-peer.test.ts
@@ -57,13 +57,11 @@ import { join } from 'node:path';
 const FIXTURE_DIR = join(import.meta.dir, 'fixtures/inline-actions');
 const BIN_PATH = join(import.meta.dir, '..', 'src', 'bin.ts');
 
-type EnvOverrides = {
+type EnvOverrides = Disposable & {
 	/** Stable `runtimeDir()` root: $XDG_RUNTIME_DIR/epicenter. */
 	xdgRoot: string;
 	/** Stable `epicenterPaths.home()`: $HOME/.epicenter (logs land here). */
 	home: string;
-	/** Cleanup callback. */
-	dispose: () => void;
 };
 
 function makeEnv(): EnvOverrides {
@@ -73,7 +71,7 @@ function makeEnv(): EnvOverrides {
 	return {
 		xdgRoot,
 		home,
-		dispose: () => {
+		[Symbol.dispose]: () => {
 			rmSync(xdgRoot, { recursive: true, force: true });
 			rmSync(home, { recursive: true, force: true });
 		},
@@ -188,7 +186,7 @@ describe('up lifecycle (scaled down, no real cross-peer)', () => {
 			const leftovers = runtimeLeftovers(runtimeRoot);
 			expect(leftovers).toEqual([]);
 		} finally {
-			env.dispose();
+			env[Symbol.dispose]();
 		}
 	}, 30000);
 
@@ -207,7 +205,7 @@ describe('up lifecycle (scaled down, no real cross-peer)', () => {
 				await awaitExit(child);
 			}
 		} finally {
-			env.dispose();
+			env[Symbol.dispose]();
 		}
 	}, 30000);
 
@@ -227,7 +225,7 @@ describe('up lifecycle (scaled down, no real cross-peer)', () => {
 				: [];
 			expect(leftovers).toEqual([]);
 		} finally {
-			env.dispose();
+			env[Symbol.dispose]();
 		}
 	}, 30000);
 
@@ -246,7 +244,7 @@ describe('up lifecycle (scaled down, no real cross-peer)', () => {
 				await awaitExit(child);
 			}
 		} finally {
-			env.dispose();
+			env[Symbol.dispose]();
 		}
 	}, 30000);
 
@@ -263,7 +261,7 @@ describe('up lifecycle (scaled down, no real cross-peer)', () => {
 				await awaitExit(child);
 			}
 		} finally {
-			env.dispose();
+			env[Symbol.dispose]();
 		}
 	}, 30000);
 });

--- a/packages/filesystem/src/extensions/sqlite-index/index.ts
+++ b/packages/filesystem/src/extensions/sqlite-index/index.ts
@@ -102,7 +102,7 @@ export type SqliteIndex = {
 	/** Readiness signal (same promise as `exports.whenReady`). */
 	init: Promise<void>;
 	/** Dispose observers and close the SQLite database. */
-	dispose: () => void;
+	[Symbol.dispose]: () => void;
 };
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -440,7 +440,7 @@ export function createSqliteIndex(
 				whenReady,
 			},
 			init: whenReady,
-			dispose() {
+			[Symbol.dispose]() {
 				if (syncTimeout) clearTimeout(syncTimeout);
 				unobserve?.();
 				client.close();

--- a/packages/workspace/src/document/attach-encryption.ts
+++ b/packages/workspace/src/document/attach-encryption.ts
@@ -187,7 +187,7 @@ export function attachEncryption(
 	// biome-ignore lint/suspicious/noExplicitAny: variance
 	function attachStore(key: string): EncryptedYKeyValueLww<any> {
 		const store = createEncryptedYkvLww(ydoc, key);
-		ydoc.once('destroy', () => store.dispose());
+		ydoc.once('destroy', () => store[Symbol.dispose]());
 		store.activateEncryption(
 			deriveKeyring(options.encryptionKeys(), workspaceId),
 		);

--- a/packages/workspace/src/document/attach-kv.ts
+++ b/packages/workspace/src/document/attach-kv.ts
@@ -73,7 +73,7 @@ export function attachKv<TKvDefinitions extends KvDefinitions>(
 ): Kv<TKvDefinitions> {
 	const yarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>(KV_KEY);
 	const ykv = new YKeyValueLww<unknown>(yarray);
-	ydoc.once('destroy', () => ykv.dispose());
+	ydoc.once('destroy', () => ykv[Symbol.dispose]());
 	return createKv(ykv, definitions);
 }
 

--- a/packages/workspace/src/document/attach-table.ts
+++ b/packages/workspace/src/document/attach-table.ts
@@ -292,7 +292,7 @@ export function attachTable<
 ): Table<InferTableRow<TTableDefinition>> {
 	const yarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>(TableKey(name));
 	const ykv = new YKeyValueLww<unknown>(yarray);
-	ydoc.once('destroy', () => ykv.dispose());
+	ydoc.once('destroy', () => ykv[Symbol.dispose]());
 	return createTable(ykv, definition, name);
 }
 
@@ -306,7 +306,7 @@ export function attachReadonlyTable<
 ): ReadonlyTable<InferTableRow<TTableDefinition>> {
 	const yarray = ydoc.getArray<YKeyValueLwwEntry<unknown>>(TableKey(name));
 	const ykv = new YKeyValueLww<unknown>(yarray);
-	ydoc.once('destroy', () => ykv.dispose());
+	ydoc.once('destroy', () => ykv[Symbol.dispose]());
 	return createReadonlyTable(ykv, definition, name);
 }
 

--- a/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.ts
+++ b/packages/workspace/src/document/y-keyvalue/y-keyvalue-lww.ts
@@ -197,7 +197,7 @@ export type YKeyValueLwwEntry<T> = { key: string; val: T; ts: number };
  */
 const DEDUP_ORIGIN = Symbol('dedup');
 
-export class YKeyValueLww<T> implements ObservableKvStore<T> {
+export class YKeyValueLww<T> implements ObservableKvStore<T>, Disposable {
 	/** The underlying Y.Array that stores `{key, val, ts}` entries. */
 	readonly yarray: Y.Array<YKeyValueLwwEntry<T>>;
 
@@ -279,7 +279,7 @@ export class YKeyValueLww<T> implements ObservableKvStore<T> {
 	/** Registered change handlers. */
 	private changeHandlers: Set<KvStoreChangeHandler<T>> = new Set();
 
-	/** Stored observer reference for cleanup in dispose(). */
+	/** Stored observer reference for cleanup in [Symbol.dispose](). */
 	private _observer!: (
 		event: Y.YArrayEvent<YKeyValueLwwEntry<T>>,
 		transaction: Y.Transaction,
@@ -867,7 +867,7 @@ export class YKeyValueLww<T> implements ObservableKvStore<T> {
 	 * Unregister the Y.Array observer. Call when this wrapper is no longer needed
 	 * but the underlying Y.Array continues to exist.
 	 */
-	dispose(): void {
+	[Symbol.dispose](): void {
 		this.yarray.unobserve(this._observer);
 	}
 }

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
@@ -395,7 +395,7 @@ export function createEncryptedYkvLww<T>(
 		 * Unregister the inner observer and release resources. Call when this
 		 * wrapper is no longer needed but the underlying Y.Array continues to exist.
 		 */
-		dispose(): void {
+		[Symbol.dispose](): void {
 			inner.unobserve(observer);
 			inner[Symbol.dispose]();
 		},

--- a/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
+++ b/packages/workspace/src/shared/y-keyvalue/y-keyvalue-lww-encrypted.ts
@@ -397,7 +397,7 @@ export function createEncryptedYkvLww<T>(
 		 */
 		dispose(): void {
 			inner.unobserve(observer);
-			inner.dispose();
+			inner[Symbol.dispose]();
 		},
 	};
 }


### PR DESCRIPTION
This PR removes the last owned `dispose()` method names from the repo so teardown has one spelling everywhere: `[Symbol.dispose]()`. The codebase already treats that symbol as the lifecycle contract for workspace bundles, caches, session objects, and attach primitives; these older named methods were the remaining drift.

The API shape changes are intentionally direct:

```typescript
// Before
handle.dispose();

// After
handle[Symbol.dispose]();
```

That applies to `YKeyValueLww`, the encrypted YKV wrapper returned by `createEncryptedYkvLww`, the sqlite-index filesystem extension handle, and the cli e2e `EnvOverrides` helper. The sqlite-index change is the only extension-authoring contract change: extension handles now expose `[Symbol.dispose]` instead of a `dispose` field, and the in-repo opensidian consumer is updated with it.

The cleanup deliberately leaves non-owned disposal APIs alone. Vite HMR still uses `import.meta.hot.dispose(...)`, Y.Doc teardown still flows through `'destroy'` events, and `[Symbol.asyncDispose]` stays as-is because it already uses the symbol protocol.

```txt
Owned handles in this PR
  YKeyValueLww
  createEncryptedYkvLww return value
  sqlite-index extension handle
  cli e2e EnvOverrides
  docs examples that showed owned handle.dispose()

Left alone
  Vite import.meta.hot.dispose(...)
  Y.Doc 'destroy' listeners
  [Symbol.asyncDispose]
```

A couple of autofix formatting commits briefly landed on this branch and touched broad unrelated files. Those were removed before merge; the final PR diff is based directly on `main` and contains only the five scoped commits for this refactor. The final HEAD commit includes `[skip actions]` so `autofix.ci` would not re-add broad formatting noise before merge.

## Test plan

- [x] `bun run typecheck` in `packages/workspace`
- [x] `bun run typecheck` in `packages/filesystem`
- [x] `bun x tsc --noEmit` in `packages/cli`
- [x] `bun run typecheck` in `apps/opensidian`
- [x] `bun test packages/workspace`
- [x] `bun test packages/filesystem`
- [x] `bun test packages/cli`
- [x] Grep sweep for stray `.dispose()` on owned types returns empty

Full monorepo `bun run typecheck` was attempted, but it is currently blocked by unrelated package errors outside this refactor. One run failed in `packages/skills` against workspace peer awareness exports (`PeerAwarenessSchema`, `ResolvedPeer`, and `peer` fields). An earlier run also surfaced unrelated dashboard Svelte errors. The touched package-level checks passed.
