### PR TITLE
refactor(cli): namespace daemon commands

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -13,7 +13,7 @@ Each verb is a one-line shell shortcut for one workspace primitive:
    Presence      | peers  | collaboration.peers.list()                       |
                  +--------+--------------------------------------------------+
 
- Cross-cutting: auth (machine session, pre-workspace)
+ Supporting systems: auth (machine session), daemon (process lifecycle)
 ```
 
 `list` is the local view of what *this* device exposes across all hosted
@@ -42,7 +42,7 @@ The package exposes the `epicenter` binary via `src/bin.ts`.
 
 ## Commands
 
-`run`, `list`, and `peers` dispatch to the local `epicenter up` daemon for the discovered project. Start it once at the top of your session (`epicenter up &`), then run as many shell-shortcut commands as you want. Without `up`, those three verbs error with a hint pointing back here. `up`, `down`, `ps`, `logs`, and `auth` work without a daemon.
+`run`, `list`, and `peers` dispatch to the local `epicenter daemon up` process for the discovered project. Start it once at the top of your session (`epicenter daemon up &`), then run as many shell-shortcut commands as you want. Without `daemon up`, those three verbs error with a hint pointing back here. `daemon up`, `daemon down`, `daemon ps`, `daemon logs`, and `auth` work without a daemon.
 
 ```bash
 # auth: machine session (pre-workspace; no project flag)
@@ -50,9 +50,12 @@ epicenter auth login
 epicenter auth status
 epicenter auth logout
 
-# up: bring every hosted route online as a callable peer (run once per session)
-epicenter up &
-epicenter up -C examples/notes-cross-peer/peer-b &
+# daemon: bring every hosted route online as a callable peer (run once per session)
+epicenter daemon up &
+epicenter daemon up -C examples/notes-cross-peer/peer-b &
+epicenter daemon ps
+epicenter daemon logs
+epicenter daemon down
 
 # list: what actions are exposed on this device
 epicenter list                                      # full tree
@@ -95,7 +98,7 @@ Peer awareness has a ~30s liveness window: a peer that crashed recently may stil
 
 | Flag | Alias | Commands | Purpose |
 | ---- | ----- | -------- | ------- |
-| `-C` | none | `up`, `down`, `logs`, `list`, `run`, `peers` | Start directory for project discovery. Defaults to the current directory. |
+| `-C` | none | `daemon up`, `daemon down`, `daemon logs`, `list`, `run`, `peers` | Start directory for project discovery. Defaults to the current directory. |
 | `--peer` | none | `run` | Address a remote peer by `deviceId`. Dispatches the invocation over the selected route's RPC channel. |
 | `--wait` | none | `run --peer` (default 5000) | Ms to wait for peer resolution and the RPC call. |
 | `--format` | none | `list`, `run`, `peers` | `json` or `jsonl`. Pretty-prints on TTY, compact when piped. Without it, commands emit their human-readable shape (tree / value / table). |

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1,14 +1,14 @@
 /**
  * CLI entry-point tests.
  *
- * The binary surfaces four commands: `auth`, `list`, `peers`, `run`. These
- * tests assert registration via `--help` output so they stay decoupled from
- * command semantics.
+ * The binary surfaces daily workspace commands plus namespaced supporting
+ * systems. These tests assert registration via `--help` output so they stay
+ * decoupled from command semantics.
  */
 import { describe, expect, spyOn, test } from 'bun:test';
 import { createCLI } from './cli';
 
-function captureHelp(): Promise<string> {
+function captureHelp(argv: string[] = ['--help']): Promise<string> {
 	const chunks: string[] = [];
 	const logSpy = spyOn(console, 'log').mockImplementation(
 		(...args: unknown[]) => {
@@ -21,7 +21,7 @@ function captureHelp(): Promise<string> {
 		},
 	);
 	return createCLI()
-		.run(['--help'])
+		.run(argv)
 		.catch(() => {})
 		.finally(() => {
 			logSpy.mockRestore();
@@ -50,12 +50,48 @@ describe('createCLI', () => {
 		errorSpy.mockRestore();
 	});
 
-	test('help output registers auth, list, peers, and run', async () => {
+	test('help output registers auth, daemon, list, peers, and run', async () => {
 		const help = await captureHelp();
 		expect(help).toMatch(/\bauth\b/);
+		expect(help).toMatch(/\bdaemon\b/);
 		expect(help).toMatch(/\blist\b/);
 		expect(help).toMatch(/\bpeers\b/);
 		expect(help).toMatch(/\brun\b/);
+		expect(help).not.toMatch(/\bup\b/);
+		expect(help).not.toMatch(/\bdown\b/);
+		expect(help).not.toMatch(/\bps\b/);
+		expect(help).not.toMatch(/\blogs\b/);
+	});
+
+	test('daemon help output registers lifecycle subcommands', async () => {
+		const help = await captureHelp(['daemon', '--help']);
+		expect(help).toMatch(/\bup\b/);
+		expect(help).toMatch(/\bdown\b/);
+		expect(help).toMatch(/\bps\b/);
+		expect(help).toMatch(/\blogs\b/);
+	});
+
+	test('daemon without a subcommand shows daemon guidance', async () => {
+		const help = await captureHelp(['daemon']);
+		expect(help).toContain('Specify a subcommand: up, down, ps, or logs');
+		expect(help).toMatch(/\bup\b/);
+		expect(help).toMatch(/\bdown\b/);
+		expect(help).toMatch(/\bps\b/);
+		expect(help).toMatch(/\blogs\b/);
+	});
+
+	test('top-level daemon lifecycle commands are unknown', async () => {
+		const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+		try {
+			for (const command of ['up', 'down', 'ps', 'logs']) {
+				await expect(createCLI().run([command])).rejects.toThrow(
+					`Unknown command: ${command}`,
+				);
+			}
+		} finally {
+			errorSpy.mockRestore();
+		}
 	});
 
 	test('auth status rejects extra positionals', async () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,12 +1,11 @@
 import yargs from 'yargs';
 import { authCommand } from './commands/auth';
-import { downCommand } from './commands/down';
+import { daemonCommand } from './commands/daemon';
 import { listCommand } from './commands/list';
-import { logsCommand } from './commands/logs';
 import { peersCommand } from './commands/peers';
-import { psCommand } from './commands/ps';
 import { runCommand } from './commands/run';
-import { upCommand } from './commands/up';
+
+const REMOVED_DAEMON_COMMANDS = new Set(['up', 'down', 'ps', 'logs']);
 
 /**
  * Create the Epicenter CLI instance.
@@ -15,6 +14,7 @@ import { upCommand } from './commands/up';
  * `epicenter.config.ts`, either locally or on a peer that's online right now.
  *
  *   - `auth`:  manage the local machine auth session (pre-workspace)
+ *   - `daemon`: operate daemon lifecycle commands
  *   - `list`:  tree view of runnable actions (local schema is authoritative)
  *   - `run`:   invoke one by route-qualified action key; `--peer` dispatches over RPC
  *   - `peers`: enumerate other clients currently online via the workspace presence row
@@ -25,16 +25,18 @@ import { upCommand } from './commands/up';
 export function createCLI() {
 	return {
 		run: async (argv: string[]) => {
+			const [command] = argv;
+			if (command && REMOVED_DAEMON_COMMANDS.has(command)) {
+				throw new Error(`Unknown command: ${command}`);
+			}
+
 			const cli = yargs()
 				.scriptName('epicenter')
 				.command(authCommand)
-				.command(downCommand)
+				.command(daemonCommand)
 				.command(listCommand)
-				.command(logsCommand)
 				.command(peersCommand)
-				.command(psCommand)
 				.command(runCommand)
-				.command(upCommand)
 				.demandCommand(1)
 				.strict()
 				.exitProcess(false)

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -1,0 +1,20 @@
+import { cmd } from '../util/cmd.js';
+import { downCommand } from './down.js';
+import { logsCommand } from './logs.js';
+import { psCommand } from './ps.js';
+import { upCommand } from './up.js';
+
+export const daemonCommand = cmd({
+	command: 'daemon',
+	describe: 'Operate the local Epicenter daemon.',
+	builder: (yargs) =>
+		yargs
+			.command(upCommand)
+			.command(downCommand)
+			.command(psCommand)
+			.command(logsCommand)
+			.demandCommand(1, 'Specify a subcommand: up, down, ps, or logs')
+			.strict()
+			.help(),
+	handler: () => {},
+});

--- a/packages/cli/src/commands/down.ts
+++ b/packages/cli/src/commands/down.ts
@@ -1,5 +1,5 @@
 /**
- * `epicenter down`: stop a running `up` daemon.
+ * `epicenter daemon down`: stop a running `daemon up` daemon.
  *
  * Default: shut down the daemon for the discovered project via IPC
  * `shutdown` (1 s budget).
@@ -68,7 +68,7 @@ async function shutdownOne(meta: DaemonMetadata): Promise<Outcome> {
 
 export const downCommand = cmd({
 	command: 'down',
-	describe: 'Stop a running `epicenter up` daemon.',
+	describe: 'Stop a running `epicenter daemon up` daemon.',
 	builder: {
 		C: projectOption,
 		all: {

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -8,7 +8,8 @@
  * daemon's route-qualified action surface only.
  *
  * `epicenter list` requires a running daemon for the discovered project.
- * Without `up`, the handler errors with a hint pointing at `epicenter up`.
+ * Without `daemon up`, the handler errors with a hint pointing at
+ * `epicenter daemon up`.
  */
 
 import type { ActionManifest } from '@epicenter/workspace';

--- a/packages/cli/src/commands/logs.test.ts
+++ b/packages/cli/src/commands/logs.test.ts
@@ -1,5 +1,5 @@
 /**
- * Wave 7 unit tests for `epicenter logs` helpers.
+ * Wave 7 unit tests for `epicenter daemon logs` helpers.
  *
  * Covers:
  *   - `tailLines` returns the last N lines of a file (mirrors `tail`).

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -1,5 +1,5 @@
 /**
- * `epicenter logs`: tail the rotating log file for a running daemon.
+ * `epicenter daemon logs`: tail the rotating log file for a running daemon.
  *
  * Default: print the last 50 lines and exit (mirrors `tail` defaults).
  * `--follow`: stream new bytes via `node:fs.watch`, reopening on rotation

--- a/packages/cli/src/commands/peers.ts
+++ b/packages/cli/src/commands/peers.ts
@@ -5,7 +5,8 @@
  * replica id, subject, and the session-local connection id.
  *
  * `epicenter peers` requires a running daemon for the discovered project.
- * Without `up`, the handler errors with a hint pointing at `epicenter up`.
+ * Without `daemon up`, the handler errors with a hint pointing at
+ * `epicenter daemon up`.
  *
  * Prints `no peers connected` to stderr when every workspace is empty (text
  * mode only; JSON mode always emits a valid array, even if empty).

--- a/packages/cli/src/commands/ps.ts
+++ b/packages/cli/src/commands/ps.ts
@@ -1,5 +1,5 @@
 /**
- * `epicenter ps`: list running `up` daemons (this user, this machine).
+ * `epicenter daemon ps`: list running `daemon up` daemons (this user, this machine).
  *
  * Enumerates `<runtimeDir>/*.meta.json`, pings each socket to confirm
  * liveness, and renders a compact table. Dead-pid metadata and socket files
@@ -72,7 +72,8 @@ function humanUptime(startedAt: string): string {
 
 export const psCommand = cmd({
 	command: 'ps',
-	describe: 'List running `epicenter up` daemons (this user, this machine).',
+	describe:
+		'List running `epicenter daemon up` daemons (this user, this machine).',
 	handler: async () => {
 		const rows: PsRow[] = [];
 		for (const meta of enumerateDaemons()) {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,14 +1,15 @@
 /**
  * `epicenter run <route.action_key> [input]`: invoke a `defineQuery` /
  * `defineMutation` by route-qualified action key through the local
- * `epicenter up` daemon.
+ * `epicenter daemon up` daemon.
  *
  * `input` is JSON: inline positional, `@file.json` (curl convention), or stdin.
  * With `--peer <target>`, the invocation is dispatched over the selected
  * route's RPC channel to a remote peer instead of running locally.
  *
  * `epicenter run` requires a running daemon for the discovered project.
- * Without `up`, the handler errors with a hint pointing at `epicenter up`.
+ * Without `daemon up`, the handler errors with a hint pointing at
+ * `epicenter daemon up`.
  *
  * Exit codes:
  *   1: usage error (unknown route, unknown action, invalid input for

--- a/packages/cli/src/commands/up.test.ts
+++ b/packages/cli/src/commands/up.test.ts
@@ -1,5 +1,5 @@
 /**
- * Wave 5 unit-level tests for `epicenter up`.
+ * Wave 5 unit-level tests for `epicenter daemon up`.
  *
  * These tests run `runUp` in-process with a fake `DaemonRuntime` /
  * `SyncAttachment` so we never spawn a child or call `process.exit`. The

--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -1,9 +1,9 @@
 /**
- * `epicenter up`: start the long-lived foreground daemon for one project.
+ * `epicenter daemon up`: start the long-lived foreground daemon for one project.
  *
  * Loads every daemon route declared by `epicenter.config.ts` and exposes a
  * Unix-socket IPC channel for that project. `peers`, `list`, and `run`
- * dispatch to this daemon over IPC; without `up` they error with a hint
+ * dispatch to this daemon over IPC; without `daemon up` they error with a hint
  * pointing back here.
  *
  * One daemon per project; that daemon serves every route in the config.
@@ -32,7 +32,8 @@ import {
 import { Ok, type Result, trySync } from 'wellcrafted/result';
 /**
  * Read once at module load. Bun resolves the JSON import relative to this
- * file at build/run time, so no runtime fs work happens per `up` invocation.
+ * file at build/run time, so no runtime fs work happens per `daemon up`
+ * invocation.
  */
 import packageJson from '../../package.json' with { type: 'json' };
 import {
@@ -201,7 +202,7 @@ export async function runUp(
 }
 
 /**
- * Yargs `up` command. Thin glue: parses argv, calls {@link runUp}, prints
+ * Yargs `daemon up` command. Thin glue: parses argv, calls {@link runUp}, prints
  * the operator-facing banner + initial peers snapshot, wires SIGINT/SIGTERM,
  * subscribes to presence/status across every loaded workspace, and parks
  * until a signal triggers teardown.

--- a/packages/cli/test/e2e-up-cross-peer.test.ts
+++ b/packages/cli/test/e2e-up-cross-peer.test.ts
@@ -1,5 +1,5 @@
 /**
- * Wave 8 end-to-end coverage for `epicenter up` lifecycle.
+ * Wave 8 end-to-end coverage for `epicenter daemon up` lifecycle.
  *
  * ## Acceptance-criteria coverage map
  *
@@ -7,18 +7,18 @@
  * § "Acceptance criteria". Each line below cites the criterion and the test
  * that exercises it (or the infra gap that blocks coverage).
  *
- *   [ok] `up` prints "online (routes=[...])" on stderr,
+ *   [ok] `daemon up` prints "online (routes=[...])" on stderr,
  *        followed by the initial peers snapshot.
- *        Covered by `up lifecycle: online banner + peers snapshot + clean exit`.
+ *        Covered by `daemon up lifecycle: online banner + peers snapshot + clean exit`.
  *   [ok] Ctrl-C / SIGTERM exits cleanly with no orphan socket / metadata.
  *        Covered by the same test, which asserts files are gone post-shutdown.
- *   [ok] `epicenter ps` lists the running daemon (deviceId / pid / uptime).
+ *   [ok] `epicenter daemon ps` lists the running daemon (deviceId / pid / uptime).
  *        Covered by `ps lists the running daemon while up is alive`.
- *   [ok] `epicenter logs -C <p>` tails the rotating log (default 50 lines).
+ *   [ok] `epicenter daemon logs -C <p>` tails the rotating log (default 50 lines).
  *        Covered by `logs prints recent lines from the daemon's log file`.
- *   [ok] `epicenter down -C <p>` shuts down gracefully.
+ *   [ok] `epicenter daemon down -C <p>` shuts down gracefully.
  *        Covered by `down terminates the daemon gracefully via IPC`.
- *   [ok] Two `up`s same project: second exits 1 with
+ *   [ok] Two `daemon up`s same project: second exits 1 with
  *        "daemon already running (pid=X)".
  *        Covered by `second up against the same dir exits 1`.
  *   [gap] Stale-auth fast-fail with literal "401 Unauthorized" message.
@@ -87,13 +87,13 @@ function childEnv(env: EnvOverrides): NodeJS.ProcessEnv {
 }
 
 /**
- * Spawn `epicenter up -C <fixture>` and wait until it prints the
+ * Spawn `epicenter daemon up -C <fixture>` and wait until it prints the
  * "online" banner on stderr. Returns the child + a buffered stderr string
  * the caller can keep reading from. The caller is responsible for
  * sending SIGTERM and awaiting exit.
  */
 async function spawnUp(env: EnvOverrides, dir: string) {
-	const child = spawn('bun', ['run', BIN_PATH, 'up', '-C', dir], {
+	const child = spawn('bun', ['run', BIN_PATH, 'daemon', 'up', '-C', dir], {
 		cwd: dir,
 		env: childEnv(env),
 		stdio: ['ignore', 'pipe', 'pipe'],
@@ -158,7 +158,7 @@ function runtimeLeftovers(runtimeRoot: string): string[] {
 	);
 }
 
-describe('up lifecycle (scaled down, no real cross-peer)', () => {
+describe('daemon up lifecycle (scaled down, no real cross-peer)', () => {
 	test('online banner + peers snapshot + clean exit on SIGTERM', async () => {
 		const env = makeEnv();
 		try {
@@ -195,7 +195,7 @@ describe('up lifecycle (scaled down, no real cross-peer)', () => {
 		try {
 			const { child } = await spawnUp(env, FIXTURE_DIR);
 			try {
-				const result = await runCli(env, ['ps']);
+				const result = await runCli(env, ['daemon', 'ps']);
 				expect(result.exitCode).toBe(0);
 				// console.table renders pid + dir as plain text columns.
 				expect(result.stdout).toContain(String(child.pid));
@@ -213,7 +213,7 @@ describe('up lifecycle (scaled down, no real cross-peer)', () => {
 		const env = makeEnv();
 		try {
 			const { child } = await spawnUp(env, FIXTURE_DIR);
-			const result = await runCli(env, ['down', '-C', FIXTURE_DIR]);
+			const result = await runCli(env, ['daemon', 'down', '-C', FIXTURE_DIR]);
 			expect(result.exitCode).toBe(0);
 			const code = await awaitExit(child);
 			expect(code).toBe(0);
@@ -234,7 +234,12 @@ describe('up lifecycle (scaled down, no real cross-peer)', () => {
 		try {
 			const { child } = await spawnUp(env, FIXTURE_DIR);
 			try {
-				const result = await runCli(env, ['logs', '-C', FIXTURE_DIR]);
+				const result = await runCli(env, [
+					'daemon',
+					'logs',
+					'-C',
+					FIXTURE_DIR,
+				]);
 				// Log file is written under $HOME/.epicenter/log/<h>.log; if
 				// the daemon has emitted anything by now, `logs` succeeds with
 				// some output. A bare exitCode=0 is the load-bearing assertion.
@@ -253,7 +258,12 @@ describe('up lifecycle (scaled down, no real cross-peer)', () => {
 		try {
 			const { child } = await spawnUp(env, FIXTURE_DIR);
 			try {
-				const result = await runCli(env, ['up', '-C', FIXTURE_DIR]);
+				const result = await runCli(env, [
+					'daemon',
+					'up',
+					'-C',
+					FIXTURE_DIR,
+				]);
 				expect(result.exitCode).toBe(1);
 				expect(result.stderr).toContain('daemon already running (pid=');
 			} finally {

--- a/packages/cli/test/e2e-up-cross-peer.test.ts
+++ b/packages/cli/test/e2e-up-cross-peer.test.ts
@@ -234,12 +234,7 @@ describe('daemon up lifecycle (scaled down, no real cross-peer)', () => {
 		try {
 			const { child } = await spawnUp(env, FIXTURE_DIR);
 			try {
-				const result = await runCli(env, [
-					'daemon',
-					'logs',
-					'-C',
-					FIXTURE_DIR,
-				]);
+				const result = await runCli(env, ['daemon', 'logs', '-C', FIXTURE_DIR]);
 				// Log file is written under $HOME/.epicenter/log/<h>.log; if
 				// the daemon has emitted anything by now, `logs` succeeds with
 				// some output. A bare exitCode=0 is the load-bearing assertion.
@@ -258,12 +253,7 @@ describe('daemon up lifecycle (scaled down, no real cross-peer)', () => {
 		try {
 			const { child } = await spawnUp(env, FIXTURE_DIR);
 			try {
-				const result = await runCli(env, [
-					'daemon',
-					'up',
-					'-C',
-					FIXTURE_DIR,
-				]);
+				const result = await runCli(env, ['daemon', 'up', '-C', FIXTURE_DIR]);
 				expect(result.exitCode).toBe(1);
 				expect(result.stderr).toContain('daemon already running (pid=');
 			} finally {

--- a/packages/workspace/src/client/connect-daemon-actions.ts
+++ b/packages/workspace/src/client/connect-daemon-actions.ts
@@ -44,8 +44,8 @@ import { findEpicenterDir } from './find-epicenter-dir.js';
  *
  * Throws `DaemonError.MissingConfig` when the project has no config, or
  * `DaemonError.Required` when no daemon is listening on the resolved socket.
- * Start one with `epicenter up`. There is no auto-spawn: explicit lifecycle
- * is the contract.
+ * Start one with `epicenter daemon up`. There is no auto-spawn: explicit
+ * lifecycle is the contract.
  */
 export async function connectDaemonActions<TActions extends ActionRegistry>({
 	route,

--- a/packages/workspace/src/client/find-epicenter-dir.ts
+++ b/packages/workspace/src/client/find-epicenter-dir.ts
@@ -13,7 +13,7 @@
  * Used by `connectDaemonActions` and per-app `script.ts` factories so vault
  * scripts don't have to pass `projectDir` explicitly: running a script from
  * anywhere inside the vault tree resolves the same daemon socket the
- * surrounding `epicenter up` is bound to.
+ * surrounding `epicenter daemon up` is bound to.
  *
  * Throws if no marker is found before reaching the filesystem root.
  * Catching is deliberate: callers that want a "run anywhere, cold-sync

--- a/packages/workspace/src/daemon/app.ts
+++ b/packages/workspace/src/daemon/app.ts
@@ -1,5 +1,5 @@
 /**
- * Hono app for the `epicenter up` daemon. Single source of truth for the
+ * Hono app for the `epicenter daemon up` daemon. Single source of truth for the
  * routes; the daemon server wires its fetch handler into Bun's listener and
  * the hand-rolled `daemonClient` in `./client.ts` POSTs against it.
  *

--- a/packages/workspace/src/daemon/client.ts
+++ b/packages/workspace/src/daemon/client.ts
@@ -1,5 +1,5 @@
 /**
- * Hand-rolled typed client for the `epicenter up` daemon. Three surfaces:
+ * Hand-rolled typed client for the `epicenter daemon up` daemon. Three surfaces:
  *
  * - {@link pingDaemon}: cheap liveness probe; never throws, never returns
  *   Result. Boolean is the right shape for a fast-path predicate.
@@ -40,7 +40,7 @@ const CONFIG_FILENAME = 'epicenter.config.ts';
  * call sites narrow once on `result.error.name`. No class hierarchy, no
  * throwing across the seam.
  *
- * - `Required`: no daemon is running for this directory; user must `up`.
+ * - `Required`: no daemon is running for this directory; user must `daemon up`.
  * - `Timeout`: the per-call AbortSignal fired before the daemon answered.
  * - `Unreachable`: socket missing, ECONNREFUSED, transport closed.
  * - `HandlerCrashed`: the daemon answered with a non-2xx status. Reserved
@@ -53,7 +53,7 @@ export const DaemonError = defineErrors({
 		projectDir,
 	}),
 	Required: ({ projectDir }: { projectDir: string }) => ({
-		message: `no daemon running for ${projectDir}; start one with \`epicenter up\` first`,
+		message: `no daemon running for ${projectDir}; start one with \`epicenter daemon up\` first`,
 		projectDir,
 	}),
 	Timeout: ({
@@ -189,9 +189,9 @@ export type DaemonClient = ReturnType<typeof daemonClient>;
  *
  *   - `MissingConfig`: no `epicenter.config.ts` in `projectDir`. Surfaced
  *     distinctly from `Required` so unconfigured users don't get pointed
- *     at `epicenter up` (which would fail and mislead).
+ *     at `epicenter daemon up` (which would fail and mislead).
  *   - `Required`: config exists but no daemon is running. Renderer
- *     prints the start-with-`up` hint.
+ *     prints the start-with-`daemon up` hint.
  *
  * `run`, `list`, and `peers` are mandatory-daemon commands; if they hit
  * neither variant they have a typed client to dispatch against.

--- a/packages/workspace/src/daemon/metadata.ts
+++ b/packages/workspace/src/daemon/metadata.ts
@@ -1,6 +1,6 @@
 /**
  * Server metadata sidecar: the JSON-on-disk record that lets `bindOrRecover`
- * surface a useful "already running (pid=X)" error when a second `up`
+ * surface a useful "already running (pid=X)" error when a second `daemon up`
  * tries to take the same socket.
  *
  * One `<runtimeDir>/<dirHash>.meta.json` per running server. Written once at

--- a/packages/workspace/src/daemon/paths.ts
+++ b/packages/workspace/src/daemon/paths.ts
@@ -10,7 +10,7 @@
  * For per-workspace data layout (yjs/sqlite/markdown under `<projectDir>/.epicenter/`),
  * see `document/workspace-paths.ts`. Different audience, different rationale.
  *
- * Pure helpers: no side effects, no directory creation. The `up` command
+ * Pure helpers: no side effects, no directory creation. The `daemon up` command
  * owns the `mkdir`/`chmod` work; consumers here are free to call these from
  * anywhere without worrying about filesystem mutation.
  */
@@ -30,7 +30,7 @@ function epicenterHome(): string {
  * - Linux with `XDG_RUNTIME_DIR` uses `$XDG_RUNTIME_DIR/epicenter` (tmpfs,
  *   reboot-cleaned by the OS).
  * - macOS / Windows / Linux without XDG uses `~/.epicenter/run` (orphan
- *   cleanup at `up` startup substitutes for the missing tmpfs reset).
+ *   cleanup at `daemon up` startup substitutes for the missing tmpfs reset).
  */
 export function runtimeDir(): string {
 	if (process.env.XDG_RUNTIME_DIR) {

--- a/packages/workspace/src/daemon/server.ts
+++ b/packages/workspace/src/daemon/server.ts
@@ -1,7 +1,7 @@
 /**
  * Daemon server starter: build the app for started routes and bind a unix
  * socket. The "build + bind" core extracted from the CLI's
- * `epicenter up` command so any bun process (CLI, vault, embedded) can
+ * `epicenter daemon up` command so any bun process (CLI, vault, embedded) can
  * stand up the daemon transport without depending on `@epicenter/cli`.
  *
  * Lifecycle (metadata sidecar, signal handlers, log routing, dispose

--- a/specs/20260512T222257-cli-daemon-command-clean-break.md
+++ b/specs/20260512T222257-cli-daemon-command-clean-break.md
@@ -1,0 +1,558 @@
+# CLI Daemon Command Clean Break
+
+**Date**: 2026-05-12
+**Status**: Implemented
+**Author**: AI-assisted
+**Branch**: `codex/app-resource-auth-cleanup`
+
+## One Sentence
+
+```txt
+Top-level commands expose workspace and auth workflows; daemon subcommands operate the daemon lifecycle.
+```
+
+Anything that keeps daemon lifecycle verbs at the top level preserves the old mixed model and is out of scope.
+
+## Overview
+
+The CLI currently presents action commands (`list`, `run`, `peers`) beside daemon lifecycle commands (`up`, `down`, `ps`, `logs`) as if they are the same kind of operation. This spec makes the lifecycle boundary explicit by moving lifecycle commands under `epicenter daemon` and removing the old top-level lifecycle commands with no compatibility aliases.
+
+## Execution note
+
+Current status: mostly implemented in the CLI. `createCLI()` registers `daemonCommand` instead of top-level `up`, `down`, `ps`, or `logs`; `packages/cli/src/commands/daemon.ts` composes the lifecycle commands; CLI help tests assert the new namespace and active CLI docs already teach `epicenter daemon ...`. The remaining live gap was that yargs reported old top-level lifecycle verbs as unknown arguments instead of unknown commands.
+
+Implemented now: enabled root `strictCommands()` so `epicenter up`, `epicenter down`, `epicenter ps`, and `epicenter logs` fail as unknown commands, matching the clean-break test boundary.
+
+Out of scope now: no daemon process behavior changes, no auto-start policy, no file tree migration under `commands/daemon/`, and no historical spec rewrites.
+
+The target command surface is:
+
+```txt
+epicenter auth ...
+epicenter list ...
+epicenter run ...
+epicenter peers ...
+
+epicenter daemon up
+epicenter daemon down
+epicenter daemon ps
+epicenter daemon logs
+```
+
+## Motivation
+
+### Current State
+
+The current top-level CLI mixes two products:
+
+```txt
+epicenter up       # operate the daemon
+epicenter down     # operate the daemon
+epicenter ps       # inspect daemon processes
+epicenter logs     # inspect daemon logs
+
+epicenter list     # inspect exposed actions
+epicenter run      # invoke an action
+epicenter peers    # inspect connected peers
+epicenter auth     # manage machine auth
+```
+
+The command registration reflects the mixed surface:
+
+```ts
+yargs()
+  .command(authCommand)
+  .command(downCommand)
+  .command(listCommand)
+  .command(logsCommand)
+  .command(peersCommand)
+  .command(psCommand)
+  .command(runCommand)
+  .command(upCommand);
+```
+
+This creates problems:
+
+1. **Mixed ownership**: `list`, `run`, and `peers` depend on a daemon, but do not own daemon lifecycle. `up`, `down`, `ps`, and `logs` own lifecycle, but sit beside action commands as peer verbs.
+2. **Weak test boundary**: `runDown` is exported mainly because the daemon shutdown body is a command internal living in a top-level command file. `ps` is already tested through `createCLI().run(['ps'])`, so its migration is an argument-boundary update rather than a helper-export cleanup.
+3. **README drift**: The README describes the CLI as a scripting surface, but the command list gives daemon operation equal top-level weight.
+4. **Future command pressure**: Any new daemon operator command would either bloat the top-level command list or force a later namespace migration.
+
+### Desired State
+
+Lifecycle commands live under one namespace:
+
+```txt
+epicenter daemon up
+epicenter daemon down
+epicenter daemon ps
+epicenter daemon logs
+```
+
+Action and auth commands stay top-level:
+
+```txt
+epicenter auth login
+epicenter list
+epicenter run route.action
+epicenter peers
+```
+
+The CLI now has a rule a new reader can apply without knowing the implementation:
+
+```txt
+If the command starts, stops, lists, or tails the daemon:
+  it belongs under `daemon`.
+
+If the command inspects or invokes workspace action behavior:
+  it stays top-level.
+```
+
+No compatibility aliases are added. `epicenter up`, `epicenter down`, `epicenter ps`, and `epicenter logs` should become unknown commands in this clean break.
+
+## Research Findings
+
+### Local Command Surface
+
+| Current command | Current owner file | Target command | Target owner |
+| --- | --- | --- | --- |
+| `auth` | `commands/auth.ts` | `auth` | unchanged |
+| `list` | `commands/list.ts` | `list` | unchanged |
+| `run` | `commands/run.ts` | `run` | unchanged |
+| `peers` | `commands/peers.ts` | `peers` | unchanged |
+| `up` | `commands/up.ts` | `daemon up` | daemon command group |
+| `down` | `commands/down.ts` | `daemon down` | daemon command group |
+| `ps` | `commands/ps.ts` | `daemon ps` | daemon command group |
+| `logs` | `commands/logs.ts` | `daemon logs` | daemon command group |
+
+### Current Test Shape
+
+| Test file | Current boundary | After this spec |
+| --- | --- | --- |
+| `cli.test.ts` | Top-level help includes lifecycle commands | Top-level help includes `daemon`, not `up/down/ps/logs` |
+| `commands/up.test.ts` | Calls `runUp` directly | Keep direct startup-body tests, plus CLI registration through `daemon up` where cheap |
+| `commands/down.test.ts` | Calls `runDown` directly | Prefer `createCLI().run(['daemon', 'down', ...])`; make `runDown` private after tests move |
+| `commands/ps.test.ts` | Already calls `createCLI().run(['ps'])` | Change command arguments to `['daemon', 'ps']`; no `runPs` helper exists |
+| `commands/run-peer-errors.test.ts` | Uses top-level `run` | unchanged |
+
+### Active Old-Command Text
+
+The command registration is not the only user-facing surface. Active source text still teaches the old shape:
+
+| Location | Current text shape | Target |
+| --- | --- | --- |
+| `packages/workspace/src/daemon/client.ts` | `start one with \`epicenter up\` first` | `start one with \`epicenter daemon up\` first` |
+| `packages/workspace/src/client/connect-daemon-actions.ts` | `Start one with \`epicenter up\`.` | `Start one with \`epicenter daemon up\`.` |
+| `packages/cli/src/commands/run.ts` | local `epicenter up` daemon and hint comments | local `epicenter daemon up` daemon and hint comments |
+| `packages/cli/src/commands/list.ts` | hint comments point at `epicenter up` | hint comments point at `epicenter daemon up` |
+| `packages/cli/src/commands/peers.ts` | hint comments point at `epicenter up` | hint comments point at `epicenter daemon up` |
+| `packages/cli/src/commands/up.ts` | command JSDoc says `epicenter up` | command JSDoc says `epicenter daemon up` |
+| `packages/cli/src/commands/down.ts` | command JSDoc and description say `epicenter down` / `epicenter up` | command JSDoc and description say `epicenter daemon down` / `epicenter daemon up` |
+| `packages/cli/src/commands/ps.ts` | command JSDoc and description say `epicenter ps` / `epicenter up` | command JSDoc and description say `epicenter daemon ps` / `epicenter daemon up` |
+| `packages/cli/src/commands/logs.ts` | command JSDoc says `epicenter logs` | command JSDoc says `epicenter daemon logs` |
+
+Historical specs can keep old command examples when they document past work. Active source, README, command descriptions, and runtime error strings must teach the new shape only.
+
+### Why Not Auto-Start
+
+Auto-start is a different product decision:
+
+```txt
+Current explicit model:
+  user starts daemon
+    -> user runs action commands
+
+Auto-start model:
+  user runs action command
+    -> CLI starts daemon as needed
+    -> CLI decides daemon lifetime
+```
+
+Auto-start would remove ceremony, but it changes ownership of process lifetime, config reload, failure reporting, and cleanup. This spec keeps lifecycle explicit. It only names the lifecycle boundary honestly.
+
+### Why No Compatibility Alias
+
+Compatibility aliases would keep both shapes alive:
+
+```txt
+Old:
+  epicenter up
+
+New:
+  epicenter daemon up
+```
+
+That breaks the clean-break sentence. The point of the spec is to teach one model:
+
+```txt
+daemon lifecycle lives under daemon
+```
+
+Aliases would require duplicate help behavior, duplicate README branches, and tests that preserve the old path. The user loss is small: scripts using top-level lifecycle commands must update once.
+
+## Design Decisions
+
+| Decision | Class | Choice | Rationale |
+| --- | --- | --- | --- |
+| Lifecycle namespace | 2 coherence | Move `up/down/ps/logs` under `daemon` | Matches the one-sentence rule. Lifecycle commands operate the daemon; workspace and auth workflows stay top-level. |
+| Compatibility | 2 coherence | No aliases for `up/down/ps/logs` | Aliases preserve the mixed model and keep old tests/docs alive. This is a clean break. |
+| Binary name | 2 coherence | Keep one `epicenter` binary | A second binary such as `epicenterd` would split install and docs without deleting much code. The problem is command family ownership, not binary packaging. |
+| Auto-start | Deferred | Do not auto-start daemons in this spec | Auto-start changes lifecycle policy. This spec only reorganizes ownership. |
+| `runUp` test seam | 2 coherence | Keep direct `runUp` tests for startup lifecycle | `daemon up` parks the process, so direct startup-body tests still earn their keep. |
+| `runDown` export | 2 coherence | Make private after `down` tests move to the command boundary | The export is test-shaped once lifecycle has a command namespace. `ps` already has a private body and command-boundary tests. |
+| File names | 3 taste | Prefer `commands/daemon.ts` group plus existing implementation files in first wave | Minimal movement proves the command shape first. Deeper file moves can follow once tests pass. |
+| README examples | 2 coherence | Update all lifecycle examples to `epicenter daemon ...` | Documentation should teach the new model only. |
+| Bare `epicenter daemon` | 2 coherence | Fail with daemon help-shaped guidance | The namespace is not itself an operation. It should guide the user to `up`, `down`, `ps`, or `logs`. |
+
+## From-Scratch Design Notes
+
+The searches do not point to a from-scratch CLI redesign. The intended implementation is a small command namespace plus text and tests that prove the old top-level lifecycle commands are gone.
+
+Do build from scratch:
+
+```txt
+commands/daemon.ts
+  owns the daemon namespace
+  composes up/down/ps/logs
+  demands exactly one daemon subcommand
+```
+
+Do not rebuild from scratch:
+
+```txt
+up.ts       keep runUp and command behavior
+down.ts     keep shutdown semantics, then make runDown private after tests move
+ps.ts       keep collectPsRows private and update command path tests
+logs.ts     keep tail/follow behavior
+createCLI   keep the same factory shape, only change registered commands
+```
+
+The implementation is therefore:
+
+```txt
+new namespace
+  -> existing lifecycle commands
+  -> updated help, tests, README, and runtime hints
+```
+
+Not:
+
+```txt
+new binary
+new daemon process model
+new CLI framework
+auto-start daemon policy
+file tree migration under commands/daemon/
+```
+
+## Long-Term CLI Boundary Vision
+
+The long-term CLI shape should use a thin top level with strong namespaces:
+
+```txt
+Top-level commands are daily workspace workflows.
+Namespaced commands operate supporting systems.
+```
+
+That gives future commands a durable placement rule:
+
+```txt
+If the command uses the daemon to expose workspace behavior:
+  it can stay top-level.
+
+If the command starts, stops, inspects, or repairs daemon machinery:
+  it belongs under `daemon`.
+
+If the command changes machine identity or session state:
+  it belongs under `auth`.
+
+If the command validates or explains project declaration:
+  it belongs under `config`.
+
+If the command diagnoses multiple systems at once:
+  it belongs under `doctor`.
+```
+
+The root should stay small because it is the daily workspace surface:
+
+```txt
+epicenter run <action>
+epicenter list [path]
+epicenter peers
+epicenter auth ...
+epicenter daemon ...
+epicenter config ...
+epicenter doctor ...
+```
+
+The namespaces should own real invariants:
+
+```txt
+daemon
+  process lifecycle
+  daemon logs
+  running daemon inventory
+  daemon repair and cleanup
+
+auth
+  machine login/logout
+  session status
+  token refresh or repair
+
+config
+  config validation
+  route inspection
+  resolved project metadata
+
+doctor
+  cross-boundary diagnosis
+  auth + config + daemon + network checks
+```
+
+Future examples:
+
+```txt
+epicenter daemon restart
+epicenter daemon status
+epicenter daemon prune
+
+epicenter auth login
+epicenter auth logout
+epicenter auth status
+
+epicenter config check
+epicenter config routes
+epicenter config print
+
+epicenter doctor
+epicenter doctor daemon
+```
+
+Avoid both extremes:
+
+```txt
+Too flat:
+  epicenter up
+  epicenter down
+  epicenter logs
+  epicenter restart
+  epicenter status
+  epicenter run
+  epicenter list
+
+Too nested:
+  epicenter workspace run
+  epicenter workspace list
+  epicenter workspace peers
+```
+
+The flat shape ages into a junk drawer. The fully nested shape makes the daily workspace path heavier than it needs to be. `run`, `list`, and `peers` are the product surface; `daemon`, `auth`, `config`, and `doctor` are supporting systems.
+
+This spec implements the first cleanup under that vision:
+
+```txt
+Before:
+  daemon lifecycle shared the root with workspace workflows
+
+After:
+  workspace workflows stay top-level
+  daemon lifecycle moves under `daemon`
+```
+
+## Architecture
+
+Current:
+
+```txt
+createCLI
+  auth
+  up
+  down
+  ps
+  logs
+  list
+  run
+  peers
+```
+
+Target:
+
+```txt
+createCLI
+  auth
+  list
+  run
+  peers
+  daemon
+    up
+    down
+    ps
+    logs
+```
+
+Ownership:
+
+```txt
+commands/auth.ts
+  machine auth session
+
+commands/list.ts
+commands/run.ts
+commands/peers.ts
+  action and peer use through an existing daemon
+
+commands/daemon.ts
+commands/up.ts
+commands/down.ts
+commands/ps.ts
+commands/logs.ts
+  daemon lifecycle and daemon inspection
+```
+
+Recommended first implementation shape:
+
+```ts
+// commands/daemon.ts
+export const daemonCommand = cmd({
+  command: 'daemon',
+  describe: 'Operate the local Epicenter daemon.',
+  builder: (yargs) =>
+    yargs
+      .command(upCommand)
+      .command(downCommand)
+      .command(psCommand)
+      .command(logsCommand)
+      .demandCommand(1, 'Specify a subcommand: up, down, ps, or logs')
+      .strict(),
+  handler: () => {},
+});
+```
+
+Then `createCLI` registers `daemonCommand` and stops registering lifecycle commands directly.
+
+## Implementation Plan
+
+### Phase 1: Build the Daemon Namespace
+
+- [x] **1.1** Add `packages/cli/src/commands/daemon.ts`.
+- [x] **1.2** Register `daemonCommand` in `createCLI`.
+- [x] **1.3** Stop registering `upCommand`, `downCommand`, `psCommand`, and `logsCommand` as top-level commands.
+- [x] **1.4** Keep `up.ts`, `down.ts`, `ps.ts`, and `logs.ts` file-local command exports for composition under `daemon`.
+- [x] **1.5** Update top-level help tests to expect `daemon` and reject top-level lifecycle commands.
+- [x] **1.6** Add daemon help tests for `epicenter daemon --help` and `epicenter daemon` with no subcommand.
+
+### Phase 2: Move Tests to the New Boundary
+
+- [x] **2.1** Update lifecycle CLI tests to call `createCLI().run(['daemon', 'down', ...])`, `['daemon', 'ps']`, and similar forms.
+- [x] **2.2** Keep direct `runUp` tests for startup-body behavior that would otherwise park the test process.
+- [x] **2.3** Convert `down.test.ts` from direct `runDown` calls to command-boundary assertions where practical.
+- [x] **2.4** Make `runDown` private if no production consumer remains. `DownOptions`, `DownOutcome`, and `DownResult` are already private.
+- [x] **2.5** Update `ps.test.ts` from `['ps']` to `['daemon', 'ps']`. There is no `runPs` helper to remove.
+
+### Phase 3: Update Documentation and Examples
+
+- [x] **3.1** Update `packages/cli/README.md` command examples.
+- [x] **3.2** Update README common flag table so `-C` lists `daemon up`, `daemon down`, `daemon logs`, `list`, `run`, and `peers`.
+- [x] **3.3** Search specs, docs, and fixtures for `epicenter up`, `epicenter down`, `epicenter ps`, and `epicenter logs`; update only current user-facing guidance. Historical specs can remain if they document old work, but active handoff docs should move.
+- [x] **3.4** Update command descriptions so `daemon` is the top-level lifecycle entry point.
+- [x] **3.5** Update active CLI and workspace source comments that teach the old lifecycle paths.
+- [x] **3.6** Update `DaemonError.Required` so runtime hints point at `epicenter daemon up`.
+
+### Phase 4: Verify and Remove Old Paths
+
+- [x] **4.1** Verify `epicenter daemon up --help`, `epicenter daemon down --help`, `epicenter daemon ps --help`, and `epicenter daemon logs --help`.
+- [x] **4.2** Verify `epicenter up --help` fails as an unknown command.
+- [x] **4.3** Run CLI package typecheck.
+- [x] **4.4** Run targeted CLI tests.
+- [x] **4.5** Run broader test selection if command registration touches shared CLI tests.
+
+## Edge Cases
+
+### `daemon up` Parks the Process
+
+`upCommand` still parks the process after startup. Tests should not rely on `createCLI().run(['daemon', 'up'])` returning unless the test explicitly runs it in a child process and sends a signal. Keep direct `runUp` tests for startup-body behavior.
+
+### `daemon logs --follow` Parks the Process
+
+`logsCommand` returns after printing the default tail, but `--follow` parks until a signal. Tests should verify `daemon logs --help` and non-follow behavior through `createCLI().run(...)`; follow-mode tests need a child process or a direct helper around the follow body.
+
+### Shell Scripts Using Old Commands
+
+This is a breaking change:
+
+```bash
+epicenter up &
+epicenter down
+```
+
+must become:
+
+```bash
+epicenter daemon up &
+epicenter daemon down
+```
+
+No alias, no warning period. The cost is a one-time script edit.
+
+### README Historical Specs
+
+Historical specs that describe already-landed old behavior do not need to be rewritten unless they are active implementation guidance. The active CLI README must teach only the new form.
+
+### Help Text
+
+The top-level help should show `daemon`, not all lifecycle subcommands. The daemon help should show `up`, `down`, `ps`, and `logs`.
+
+### Runtime Hints
+
+`run`, `list`, and `peers` surface `DaemonError.Required` from `packages/workspace`. The error message must say `epicenter daemon up`, or the clean break will ship with a dead first-run hint.
+
+## Rejected Alternatives
+
+### Keep Top-Level Lifecycle Commands
+
+This preserves the mixed model:
+
+```txt
+epicenter up
+epicenter run
+```
+
+The code can be cleaned locally, but the product sentence stays muddy. Rejected.
+
+### Add `daemon` While Keeping Aliases
+
+This gives users two ways to express the same lifecycle operation. It makes migration gentle but keeps the old model in help, docs, tests, and muscle memory. Rejected because the user explicitly chose a clean break.
+
+### Split Into `epicenterd`
+
+This is more radical than needed. The lifecycle commands are related to the same installed package and project config. A command namespace gives the ownership win without splitting packaging, docs, or install behavior.
+
+### Auto-Start on `run/list/peers`
+
+Auto-start may be worth exploring later, but it changes lifecycle policy. It asks:
+
+```txt
+Who owns daemon lifetime after an action command starts it?
+When does it stop?
+How are config changes detected?
+How are startup failures reported?
+```
+
+This spec does not answer those questions.
+
+## Success Criteria
+
+- [x] `epicenter daemon up/down/ps/logs` are the only lifecycle command paths.
+- [x] `epicenter up/down/ps/logs` are unknown commands.
+- [x] Top-level help shows `auth`, `daemon`, `list`, `peers`, and `run`.
+- [x] Daemon help shows `up`, `down`, `ps`, and `logs`.
+- [x] `runDown` no longer needs to be exported for tests.
+- [x] README examples teach the daemon namespace only.
+- [x] Runtime no-daemon hints teach `epicenter daemon up`.
+- [x] CLI typecheck and targeted CLI tests pass.
+
+## Resolved Grilling Answers
+
+1. Use "Operate" for the daemon group description because `logs` and `ps` inspect rather than manage.
+2. Wait on moving files into `commands/daemon/`. Command shape first, file move second if it still feels worth doing.
+3. `epicenter daemon` without a subcommand should fail with daemon help-shaped guidance. The namespace is not an operation.


### PR DESCRIPTION
The daemon lifecycle commands had grown into top-level CLI verbs, which made the command surface harder to scan and left daemon-specific help scattered across unrelated entries. This moves that lifecycle under a single `daemon` namespace so the CLI reads as one primary action runner plus one daemon control surface.

Before:

```sh
epicenter up
epicenter down
epicenter ps
epicenter logs
```

After:

```sh
epicenter daemon up
epicenter daemon down
epicenter daemon ps
epicenter daemon logs
```

The old top-level lifecycle commands now fail as unknown commands, and the CLI help points users at the daemon subcommands instead. The daemon internals keep the same socket, metadata, log, and process behavior. This is a command shape cleanup, not a runtime rewrite.

Verification:

```sh
bun test packages/cli
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->