### PR TITLE
refactor(workspace): tighten collaboration API surface

### DIFF
--- a/.agents/skills/attach-primitive/SKILL.md
+++ b/.agents/skills/attach-primitive/SKILL.md
@@ -29,7 +29,7 @@ Examples of the common form:
 ```ts
 attachIndexedDb(ydoc)                   // Y.Doc subject
 attachSqlite(ydoc, { filePath })
-attachSync(ydoc, { url, getToken })
+openCollaboration(ydoc, { url, openWebSocket, replicaId, actions })
 attachBroadcastChannel(ydoc)
 attachEncryption(ydoc, { encryptionKeys })
 attachTable(ydoc, name, def)            // Y.Doc subject + slot key + def
@@ -123,20 +123,20 @@ const cache = createDisposableCache((id: string) => {
   const unlock     = attachSessionUnlock(encryption, {          // non-ydoc subject
     sessions, serverUrl, waitFor: idb.whenLoaded,
   });
-  const sync       = attachSync(ydoc, {
-    url, getToken,
+  const collaboration = openCollaboration(ydoc, {
+    url, openWebSocket, replicaId, actions,
     waitFor: Promise.all([idb.whenLoaded, unlock.whenChecked]),
   });
   const markdown   = attachMarkdownMaterializer(ydoc, {           // chainable return
-    dir, waitFor: sync.whenConnected,
+    dir, waitFor: collaboration.whenConnected,
   }).table(tables.posts, { filename: slugFilename('title') });
 
   return {
-    ydoc, tables, encryption, idb, sync, markdown,
-    whenReady: Promise.all([idb.whenLoaded, unlock.whenChecked, sync.whenConnected]),
+    ydoc, tables, encryption, idb, collaboration, markdown,
+    whenReady: Promise.all([idb.whenLoaded, unlock.whenChecked, collaboration.whenConnected]),
     async wipe() {
       ydoc.destroy();
-      await sync.whenDisposed;
+      await collaboration.whenDisposed;
       await idb.whenDisposed;
       await idb.clearLocal();
     },
@@ -151,12 +151,12 @@ The bundle aggregates child `whenLoaded` / `whenConnected` / `whenChecked` into 
 
 ## The `waitFor` convention
 
-Primitives that perform a gated startup (sync, session-unlock) accept `waitFor?: Promise<unknown>` in their options. The primitive awaits it before taking its first action. This replaces the old extension-chain "init pipeline": sequencing is now explicit at the call site, visible in one file, with no hidden ordering.
+Primitives that perform a gated startup (collaboration, session-unlock) accept `waitFor?: Promise<unknown>` in their options. The primitive awaits it before taking its first action. This replaces the old extension-chain "init pipeline": sequencing is now explicit at the call site, visible in one file, with no hidden ordering.
 
 Use it whenever a primitive's startup must follow another's. Examples:
-- `attachSync` after local hydrate: `waitFor: idb.whenLoaded`
+- `openCollaboration` after local hydrate: `waitFor: idb.whenLoaded`
 - `attachSessionUnlock` after hydrate (so stored keys don't clobber freshly-hydrated plaintext mid-replay): `waitFor: persistence.whenLoaded`
-- `attachSync` after both hydrate AND unlock: `waitFor: Promise.all([idb.whenLoaded, unlock.whenChecked])`
+- `openCollaboration` after both hydrate AND unlock: `waitFor: Promise.all([idb.whenLoaded, unlock.whenChecked])`
 
 ## Anti-patterns
 
@@ -171,7 +171,7 @@ Use it whenever a primitive's startup must follow another's. Examples:
 ## Reference implementations
 
 - `packages/workspace/src/document/attach-indexed-db.ts` — the canonical 40-line example.
-- `packages/workspace/src/document/attach-sync.ts` — network variant with `whenConnected` + `waitFor`.
+- `packages/workspace/src/document/open-collaboration.ts` — document collaboration surface with sync, presence, peers, and action dispatch.
 - `packages/workspace/src/document/attach-encryption.ts` — state-owning coordinator; exposes `attachTable` / `attachTables` / `attachKv` as methods.
 - `packages/workspace/src/document/materializer/markdown/materializer.ts` — chainable builder with `.table()/.kv()`.
 - `apps/whispering/src/lib/client.ts`: full singleton composition.

--- a/.agents/skills/auth/SKILL.md
+++ b/.agents/skills/auth/SKILL.md
@@ -227,11 +227,12 @@ requests. Storage writes are awaited before the refreshed token is used.
 Use `auth.openWebSocket` for sync:
 
 ```ts
-const sync = attachSync(ydoc, {
-	url: toWsUrl(`${APP_URLS.API}/workspaces/${ydoc.guid}`),
+const collaboration = openCollaboration(ydoc, {
+	url: websocketUrl(`${APP_URLS.API}/workspaces/${ydoc.guid}`),
 	waitFor: idb.whenLoaded,
 	openWebSocket: auth.openWebSocket,
-	awareness,
+	replicaId,
+	actions,
 });
 ```
 

--- a/.agents/skills/code-audit/SKILL.md
+++ b/.agents/skills/code-audit/SKILL.md
@@ -88,8 +88,8 @@ const log = createLogger('module-name');
 // Optional parameter (for libraries that may want a caller-supplied logger)
 function createX({ log = createLogger('x') }: { log?: Logger } = {}) { ... }
 
-// Config-injected (used in attachSync)
-const log = config.log ?? createLogger('attachSync');
+// Config-injected (used in openCollaboration)
+const log = config.log ?? createLogger('collaboration');
 ```
 
 **Triage**: this category is verified periodically: the codebase has historically been clean. Treat any hit as a regression and route through `wellcrafted/logger` before merging. New `console.*` in library code should be refused at PR review unless the call site is explicitly a CLI command, test, or benchmark.

--- a/.agents/skills/git/references/pull-request-guidelines.md
+++ b/.agents/skills/git/references/pull-request-guidelines.md
@@ -604,13 +604,14 @@ RESPONSE: [101] [1=RES] [requestId] [requesterClientId]                         
 The DO is a dumb relay. It forwards a REQUEST to the target peer if they're connected, or synthesizes a PeerOffline RESPONSE if they're not. No RPC logic lives in the server — it just routes bytes.
 
 ```typescript
-const peers = workspace.extensions.sync.peers();
-const ext = peers.find(p => p.client === 'browser-extension');
+const ext = workspace.collaboration.peers
+  .list()
+  .find((p) => p.replicaId === 'browser-extension');
 
-const { data, error } = await workspace.extensions.sync.rpc(
-  ext.clientId,
-  'tabs.close',
-  { tabIds: [1, 2] }
+const { data, error } = await workspace.collaboration.dispatch(
+  'tabs_close',
+  { tabIds: [1, 2] },
+  { to: ext.connId, signal: AbortSignal.timeout(10_000) },
 );
 ```
 

--- a/.agents/skills/logging/SKILL.md
+++ b/.agents/skills/logging/SKILL.md
@@ -74,7 +74,7 @@ Streamed append via Bun's `FileSink`. Parent directory auto-created. The returne
 
 ```ts
 await using sink = jsonlFileSink(join(DATA_DIR, 'app.log.jsonl'));
-const log = createLogger('attachSync', sink);
+const log = createLogger('collaboration', sink);
 // ... do work ...
 // scope exit → flush + close the writer
 ```
@@ -123,7 +123,7 @@ No module-level logger registry. No `setDefaultLogger()`. Each attach primitive 
 ```ts
 const markdown = attachMarkdownMaterializer(ydoc, { dir, log });
 const sqlite   = attachSqliteMaterializer(ydoc, { db, log });
-const sync     = attachSync(ydoc, { url, log });
+const collaboration = openCollaboration(ydoc, { url, log, openWebSocket, replicaId });
 ```
 
 Share one sink across loggers (avoids interleaved writes on the same file):

--- a/.agents/skills/workspace-api/SKILL.md
+++ b/.agents/skills/workspace-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workspace-api
-description: Workspace API patterns for defineTable, defineKv, versioning, migrations, data access (CRUD + observation), createDisposableCache, attach* primitives, and action composition. Use when the user mentions workspace, defineTable, defineKv, createDisposableCache, attachTables, attachSync, attachIndexedDb, attachYjsLog, defineQuery, defineMutation, connectWorkspace, or when defining schemas, reading/writing table data, observing changes, writing migrations, composing attachments inline, or attaching actions to a document bundle.
+description: Workspace API patterns for defineTable, defineKv, versioning, migrations, data access (CRUD + observation), createDisposableCache, attach* primitives, openCollaboration, and action composition. Use when the user mentions workspace, defineTable, defineKv, createDisposableCache, attachTables, openCollaboration, attachIndexedDb, attachYjsLog, defineQuery, defineMutation, connectWorkspace, or when defining schemas, reading/writing table data, observing changes, writing migrations, composing attachments inline, or attaching actions to a document bundle.
 metadata:
   author: epicenter
   version: '6.0'
@@ -24,7 +24,7 @@ Type-safe schema definitions for tables and KV stores.
 - Reading, writing, or observing table/KV data
 - Composing a live document with a direct builder plus `attach*` primitives
 - Adding `createDisposableCache(builder)` for per-row or otherwise fan-out documents
-- Attaching persistence (`attachIndexedDb`, `attachYjsLog`), sync (`attachSync`), or materializers (`attachSqliteMaterializer`, `attachMarkdownMaterializer`) inline
+- Attaching persistence (`attachIndexedDb`, `attachYjsLog`), opening collaboration (`openCollaboration`), or materializers (`attachSqliteMaterializer`, `attachMarkdownMaterializer`) inline
 - Writing server-side Bun scripts with `connectWorkspace()`
 ## Tables
 
@@ -200,20 +200,21 @@ export function createBlogActions({ tables, batch }) {
 
 Actions have **two** type surfaces depending on how they're invoked. **Local**
 callers see the handler's signature verbatim — sync stays sync, raw stays raw,
-throws throw. **Remote** callers (via `createRemoteActions` or `sync.rpc()`)
-always get `Promise<Result<T, E | ActionFailed>>`: the transport wraps raw
-values in `Ok`, converts thrown errors into `Err(RpcError.ActionFailed)`, and
-passes existing `Result`s through.
+throws throw. **Remote** callers (via `collaboration.dispatch()`)
+always get `Promise<Result<T, DispatchError>>`: the transport wraps raw values
+in `Ok` and converts thrown errors or returned `Err`s into
+`Err(DispatchError.ActionFailed)`.
 
 **Rule of thumb:**
 
-- **Return `Err(TypedError)`** for failures your caller should branch on.
+- **Return `Err(TypedError)`** for failures local callers should branch on.
 - **Throw** for bugs / invariants. On the wire, throws become `ActionFailed`
   — the caller loses the stack and can only say "something broke."
 - **Return raw** when failure isn't a meaningful concept for the operation.
 
-If you need structured errors on the wire, `return Err(...)` explicitly —
-don't throw and hope.
+Remote peer calls currently expose `DispatchError`, not each handler's typed
+error union. If a remote caller needs a narrower failure contract, add an
+explicit action surface for that workflow.
 
 For the full matrix (every caller's view of every handler shape, all the
 decision trees, and the normalization boundaries), read
@@ -255,7 +256,8 @@ src/lib/
 │   └── index.ts                        ← Barrel: re-exports definition + actions only
 │
 └── client.ts                           ← Runtime singleton: openX() builder composing
-                                           attachTables, attachIndexedDb/attachYjsLog, attachSync,
+                                           attachTables, attachIndexedDb/attachYjsLog,
+                                           openCollaboration,
                                            attachEncryption, and runtime-specific actions
 ```
 
@@ -278,7 +280,7 @@ src/lib/
 │ client.ts    │   │ server-client.ts │   │ cli-client.ts    │
 │ (browser)    │   │ (Node/Bun)       │   │ (CLI)            │
 │ attachIndex… │   │ attachYjsLog     │   │ attachYjsLog     │
-│ attachSync   │   │ attachSync       │   │ (no sync)        │
+│ openCollab   │   │ openCollab       │   │ (no sync)        │
 │ Chrome APIs  │   │ Node fs APIs     │   │                  │
 └──────────────┘   └──────────────────┘   └──────────────────┘
 ```
@@ -342,25 +344,29 @@ function openMyApp() {
   const ydoc = new Y.Doc({ guid: 'epicenter.myapp' });
   const tables = attachTables(ydoc, myAppTables);
   const idb = attachIndexedDb(ydoc);
-  const sync = attachSync(ydoc, { url, waitFor: idb.whenLoaded });
   const batch = (fn) => ydoc.transact(fn);
 
-  const actions = {
+  const actions = defineActions({
     ...createMyAppActions({ tables, batch }),
-    tabs: {
-      close: defineMutation({
-        title: 'Close Tabs',
-        description: 'Close browser tabs by ID.',
-        input: Type.Object({ tabIds: Type.Array(Type.Number()) }),
-        handler: async ({ tabIds }) => {
-          await browser.tabs.remove(tabIds);  // Chrome API
-          return { closedCount: tabIds.length };
-        },
-      }),
-    },
-  };
+    tabs_close: defineMutation({
+      title: 'Close Tabs',
+      description: 'Close browser tabs by ID.',
+      input: Type.Object({ tabIds: Type.Array(Type.Number()) }),
+      handler: async ({ tabIds }) => {
+        await browser.tabs.remove(tabIds);  // Chrome API
+        return { closedCount: tabIds.length };
+      },
+    }),
+  });
+  const collaboration = openCollaboration(ydoc, {
+    url,
+    waitFor: idb.whenLoaded,
+    openWebSocket,
+    replicaId,
+    actions,
+  });
 
-  return { ydoc, tables, idb, sync, actions, batch, /* whenReady, ... */ };
+  return { ydoc, tables, idb, collaboration, actions, batch, /* whenReady, ... */ };
 }
 
 export const workspace = openMyApp();
@@ -368,45 +374,46 @@ export const workspace = openMyApp();
 
 ## Attachment Ordering
 
-Attachments compose through plain lexical scope, so ordering is explicit: if `sync` needs to wait for local state, its `waitFor` option reads `idb.whenLoaded` — and `idb` must be defined first.
+Attachments compose through plain lexical scope, so ordering is explicit: if `openCollaboration` needs to wait for local state, its `waitFor` option reads `idb.whenLoaded`, and `idb` must be defined first.
 
 | Attachment | Typical `waitFor` | Behavior |
 |---|---|---|
 | `attachYjsLog` | — | Starts loading the Yjs update log immediately |
 | `attachIndexedDb` | — | Starts loading IndexedDB immediately |
 | `attachEncryption` | (none, sync) | Reads `encryptionKeys()` synchronously at each registration site |
-| `attachSync` | `idb.whenLoaded` (or `persistence.whenLoaded`) | Opens WebSocket after local replay |
+| `openCollaboration` | `idb.whenLoaded` (or another local-load promise) | Opens WebSocket after local replay |
 
-The standard shape is **persistence first, then sync with `waitFor`**:
+The standard shape is **persistence first, then collaboration with `waitFor`**:
 
 ```
 attachIndexedDb  ────────────→ idb.whenLoaded resolves
                                        ↓
-attachSync({ waitFor: idb.whenLoaded }) ────→ WebSocket opens → synced
+openCollaboration({ waitFor: idb.whenLoaded }) ────→ WebSocket opens → synced
 ```
 
 This ordering matters because sync only exchanges the delta between local state and the server. Without persistence loading first, every cold start downloads the full document.
 
 ```typescript
-// ✅ Correct: persistence loads first, sync waits for idb, exchanges delta only
+// Correct: persistence loads first, collaboration waits for idb, exchanges delta only
 createDisposableCache((id) => {
   const ydoc = new Y.Doc({ guid: id });
   const tables = attachTables(ydoc, myTables);
-  const persistence = attachYjsLog(ydoc, { filePath: '...' });
-  const sync = attachSync(ydoc, {
-    url: (docId) => toWsUrl(`${serverUrl}/workspaces/${docId}`),
-    getToken,
-    waitFor: persistence.whenLoaded,
+  const idb = attachIndexedDb(ydoc);
+  const collaboration = openCollaboration(ydoc, {
+    url: toWsUrl(`${serverUrl}/workspaces/${ydoc.guid}`),
+    waitFor: idb.whenLoaded,
+    openWebSocket,
+    replicaId,
   });
-  return { id, ydoc, tables, persistence, sync, /* ... */ };
+  return { id, ydoc, tables, idb, collaboration, /* ... */ };
 });
 
-// ❌ Wrong: sync starts before local state is loaded, downloads full document
+// Wrong: collaboration starts before local state is loaded, downloads full document
 createDisposableCache((id) => {
   const ydoc = new Y.Doc({ guid: id });
-  const sync = attachSync(ydoc, { url, getToken }); // no waitFor
-  const persistence = attachYjsLog(ydoc, { filePath: '...' });
-  return { id, ydoc, persistence, sync, /* ... */ };
+  const collaboration = openCollaboration(ydoc, { url, openWebSocket, replicaId });
+  const idb = attachIndexedDb(ydoc);
+  return { id, ydoc, idb, collaboration, /* ... */ };
 });
 ```
 
@@ -445,8 +452,8 @@ Load these on demand based on what you're working on:
 
 - If working with **table migrations** (migration function rules, direct-to-latest strategy, migration anti-patterns, `as const` note), read [references/table-migrations.md](references/table-migrations.md)
 - If working with **table/KV CRUD or observation** (`get`, `set`, `update`, `observe`, Svelte observer guidance), read [references/table-kv-crud-observation.md](references/table-kv-crud-observation.md)
-- If working with **per-row or standalone Y.Docs** (raw `new Y.Doc({ guid, gc })` + `attachRichText`/`attachPlainText`, `attachIndexedDb`, `attachSync`, `whenLoaded` vs `whenConnected`), read [references/primitive-api.md](references/primitive-api.md)
-- If working with **action return shapes, throw vs `Err`, remote error envelopes, `createRemoteActions`, `RemoteActions<A>`, `ActionFailed`, or the local/remote type-surface split**, read [references/action-return-shapes.md](references/action-return-shapes.md)
+- If working with **per-row or standalone Y.Docs** (raw `new Y.Doc({ guid, gc })` + `attachRichText`/`attachPlainText`, `attachIndexedDb`, `openCollaboration`, `whenLoaded` vs `whenConnected`), read [references/primitive-api.md](references/primitive-api.md)
+- If working with **action return shapes, throw vs `Err`, remote error envelopes, `collaboration.dispatch()`, `DispatchError`, or the local/remote type-surface split**, read [references/action-return-shapes.md](references/action-return-shapes.md)
 
 Code references:
 
@@ -455,6 +462,6 @@ Code references:
 - `packages/workspace/src/cache/disposable-cache.ts`
 - `packages/workspace/src/document/attach-table.ts`
 - `packages/workspace/src/document/attach-kv.ts`
-- `packages/workspace/src/document/attach-sync.ts`
+- `packages/workspace/src/document/open-collaboration.ts`
 - `packages/workspace/src/document/attach-indexed-db.ts`
 - `packages/workspace/src/document/attach-yjs-log.ts`

--- a/.agents/skills/workspace-api/references/action-return-shapes.md
+++ b/.agents/skills/workspace-api/references/action-return-shapes.md
@@ -1,250 +1,99 @@
-# Action return shapes — local vs. remote contract
+# Action Return Shapes: Local Vs Remote
 
-Actions have **two** type surfaces, not one. The same `defineQuery` /
-`defineMutation` is typed differently depending on how it's invoked. This
-reference explains what each caller sees, when to throw vs. return `Err`,
-and how the wrapping happens at each boundary.
+Actions have two type surfaces. A local caller sees the handler exactly as it
+was written. A remote caller goes through `collaboration.dispatch()`, so the
+result is always a `Result<T, DispatchError>`.
 
-## The three call contexts
+## Call Contexts
 
 ```
- 1. LOCAL      workspace.actions.tabs_close({...})
-                (same process, direct function call, zero wrapping)
+1. LOCAL
+   workspace.actions.tabs_close({...})
+   Same process, direct function call, no wrapping.
 
- 2. ADAPTER    epicenter run app.tabs_close        (CLI)
-               LLM calls tabs_close tool           (AI bridge)
-                (in-process, formatter peels the Result envelope)
+2. ADAPTER
+   epicenter run app.tabs_close
+   LLM calls tabs_close tool
+   In process, adapter formats the handler result for its surface.
 
- 3. REMOTE     createRemoteActions(...).tabs_close({...})
-               sync.rpc(peer, 'tabs_close', ...)
-                (crosses the wire, always Result-wrapped)
+3. REMOTE
+   collaboration.dispatch('tabs_close', {...}, { to, signal })
+   Crosses the collaboration wire, always Result-wrapped.
 ```
 
-## One handler, every caller's view
+## One Handler, Every Caller's View
 
-Given this handler:
+| Caller | Ok path | Err(BrowserApiFailed) | Handler throws |
+| --- | --- | --- | --- |
+| Local | `{data:{closedCount:1}, error:null}` | `{data:null, error:BrowserApiFailed}` | throws at `await` |
+| CLI `epicenter run` | prints `{"closedCount":1}`, exit 0 | stderr + exit 1 | stderr stack trace + exit 1 |
+| AI bridge | AI sees `{closedCount:1}` | AI sees tool failure | propagates as tool failure |
+| `collaboration.dispatch()` | `Ok({closedCount:1})` | `Err(DispatchError.ActionFailed{cause: BrowserApiFailed})` | `Err(DispatchError.ActionFailed{cause})` |
+
+Remote dispatch coarsens handler errors into `DispatchError.ActionFailed`.
+Keep typed `Err` values for local callers and in-process adapters. Once a call
+crosses the collaboration wire, the remote caller branches on `DispatchError`.
+
+## Where Wrapping Happens
+
+```
+Target (handler owner)                 Caller
+----------------------                 ------
+attachActionRunner                     collaboration.dispatch
+  raw value    -> Ok(raw)               waits for response row
+  Result Ok    -> Ok(data)              returns Result<T, DispatchError>
+  Result Err   -> ActionFailed(cause)
+  throw        -> ActionFailed(cause)
+```
+
+Target-side normalization runs inside `attachActionRunner` in
+`packages/workspace/src/document/rpc.ts`. The caller receives exactly the
+response row through `collaboration.dispatch()`.
+
+## Handler Rule
+
+Return `Err` for failures local callers should branch on. Throw for bugs and
+invariants. Remote callers always see either your successful data or a
+`DispatchError` variant.
+
+## Example
 
 ```typescript
-tabs_close: defineMutation({
-  input: Type.Object({ tabIds: Type.Array(Type.Number()) }),
-  handler: async ({ tabIds }) => {
-    const { error } = await tryAsync({
-      try: () => browser.tabs.remove(tabIds),
-      catch: (cause) => TabError.BrowserApiFailed({
-        operation: 'tabs.remove',
-        cause,
-      }),
-    });
-    if (error) return Err(error);
-    return Ok({ closedCount: tabIds.length });
-  },
-})
-```
-
-| Caller                        | Ok path                          | Err(BrowserApiFailed)                            | Handler throws                                     |
-| ----------------------------- | -------------------------------- | ------------------------------------------------ | -------------------------------------------------- |
-| **Local** (in-process)        | `{data:{closedCount:1}, error:null}` | `{data:null, error:BrowserApiFailed}`        | throws at `await`                                  |
-| **CLI** `epicenter run`       | prints `{"closedCount":1}`, exit 0 | stderr + exit 1                                | stderr stack trace + exit 1                        |
-| **AI bridge** (TanStack AI)   | AI sees `{closedCount:1}`        | AI sees "tool call failed: …"                    | propagates — AI sees failure                       |
-| **`createRemoteActions`**     | `Ok({closedCount:1})`            | `Err(BrowserApiFailed)` — typed, no re-wrap      | `Err(RpcError.ActionFailed{cause: <throw>})`       |
-| **`sync.rpc()`** (peer RPC)   | `Ok({closedCount:1})`            | `Err(RpcError.ActionFailed{cause: BrowserApiFailed})` — **E erased** | `Err(RpcError.ActionFailed{cause: <throw>})` |
-
-The `sync.rpc()` row's Err column is the only place the typed error is
-coarsened — this is a property of that specific API (which is typed
-`Result<T, RpcError>`), not of the handler design. For typed errors on
-the wire, use `createRemoteActions`.
-
-## Where the wrapping happens
-
-On the wire path (remote), there are exactly **two normalization points**:
-
-```
-Server (handler-owner)                 Client (caller)
-─────────────────────                  ───────────────
-attach-sync.ts handleRpcRequest        remote-actions.ts makeLeaf
-  raw value    → Ok(raw)                 got {data,error}? → passthrough
-  Result       → passthrough             got raw value?    → Ok(raw)
-  throw        → RpcError.ActionFailed   transport threw?  → RpcError.ActionFailed
-```
-
-Server-side normalization runs inside `attachSync`. The client-side
-normalization lives in `createRemoteActions`. Both sides emit the same
-nominal `RpcError.ActionFailed` — no nested `{cause: <nested action error>}`
-re-wrapping.
-
-The legacy `sync.rpc()` outbound method has an additional wrap on the client
-(at `attach-sync.ts:816`) that converts any non-`RpcError` value in the
-error channel to `RpcError.ActionFailed({cause})` — which is why its typed
-surface is `Result<T, RpcError>` rather than `Result<T, E | ActionFailed>`.
-
-## Decision tree for handler authors
-
-```
-Does failure need a specific UX on the caller side?
-│
-├── YES → return Result, name the error variant
-│         (BrowserApiFailed, NotFound, ValidationFailed, …)
-│         Callers pattern-match on error.name.
-│
-└── NO  → can it realistically fail?
-          │
-          ├── YES (network, filesystem, flaky external) → try/catch + throw,
-          │        OR return Err(generic) if a caller might want to branch
-          │
-          └── NO (invariant, bug) → throw — no need to dress up a
-                                    programmer error as a Result
-```
-
-**Rule of thumb:** return `Err` for things your caller should handle; throw
-for bugs. Remote callers *always* see some discriminant in the error channel
-— your typed `Err(X)` if you named the failure, or `ActionFailed` if you
-threw. There's no "I don't handle errors" path once the call crosses the wire.
-
-## Decision tree for callers
-
-```
-Am I calling locally or remotely?
-│
-├── LOCAL → does the handler return Result?
-│           │
-│           ├── YES → destructure {data, error}, switch on error.name
-│           │
-│           └── NO  → just use the value; try/catch if you want to handle
-│                     throws
-│
-└── REMOTE → always destructure {data, error}
-             ├── Ok path: use data
-             └── Err path: switch on error.name
-                  ·  your typed errors if the handler returned Err
-                  ·  'ActionFailed' for throws and transport/server bugs
-```
-
-## Call-site examples
-
-### Pattern 1 — Handler returns raw (can't meaningfully fail)
-
-```typescript
-// HANDLER
-bookmarks_remove_all: defineMutation({
-  handler: () => {
-    const all = tables.bookmarks.getAllValid();
-    batch(() => {
-      for (const b of all) tables.bookmarks.delete(b.id);
-    });
-    return { removedCount: all.length };
-  },
-})
-
-// LOCAL
-const { removedCount } = workspace.actions.bookmarks_remove_all();
-
-// REMOTE (createRemoteActions)
-const { data, error } = await remote.bookmarks_remove_all();
-if (error) toast.error('Operation failed');  // only transport/server bug
-else toast.success(`Removed ${data.removedCount}`);
-```
-
-### Pattern 2 — Handler returns Result (typed failure is contract)
-
-```typescript
-// LOCAL
-const { data, error } = await workspace.actions.tabs_close({ tabIds: [1] });
-if (error) {
-  // error.name === 'BrowserApiFailed', known and typed
-  toast.error(error.message);
+const local = await workspace.actions.tabs_close({ tabIds: [1] });
+if (local.error) {
+  toast.error(local.error.message);
   return;
 }
-toast.success(`Closed ${data.closedCount}`);
 
-// REMOTE (createRemoteActions)
-const { data, error } = await remote.tabs_close({ tabIds: [1] });
-if (error) {
-  switch (error.name) {
-    case 'BrowserApiFailed': toast.error(error.message); break;
-    case 'ActionFailed':     toast.error('Connection problem'); break;
+const remote = await collaboration.dispatch(
+  'tabs_close',
+  { tabIds: [1] },
+  { to: peer.connId, signal: AbortSignal.timeout(10_000) },
+);
+if (remote.error) {
+  switch (remote.error.name) {
+    case 'ActionFailed':
+      toast.error('Action failed');
+      break;
+    case 'ActionNotFound':
+      toast.error('Action not found');
+      break;
+    case 'Cancelled':
+      toast.error('Request cancelled');
+      break;
   }
-  return;
 }
 ```
 
-Call sites are structurally identical. Remote just widens the error union
-by `ActionFailed`.
-
-### Pattern 3 — Handler throws (bug-flavored, not part of contract)
-
-```typescript
-// HANDLER
-devices_rename: defineMutation({
-  input: Type.Object({ id: Type.String(), name: Type.String() }),
-  handler: ({ id, name }) => {
-    const existing = tables.devices.get(id);
-    if (!existing) throw new Error(`Device ${id} not found`);
-    tables.devices.set({ ...existing, name });
-    return { renamed: true };
-  },
-})
-
-// LOCAL: standard JS try/catch
-try {
-  workspace.actions.devices_rename({ id, name });
-} catch (err) {
-  toast.error(String(err));
-}
-
-// REMOTE: the throw becomes ActionFailed on the wire
-const { data, error } = await remote.devices_rename({ id, name });
-if (error) {
-  // error.name === 'ActionFailed' — can't distinguish "not found" from
-  // "server crashed". If that distinction matters, promote to Err.
-  toast.error(error.message);
-}
-```
-
-**If the remote caller needs to branch on the failure mode, promote the
-throw to a typed `Err`:**
-
-```typescript
-handler: ({ id, name }) => {
-  const existing = tables.devices.get(id);
-  if (!existing) return Err(DeviceError.NotFound({ id }));
-  tables.devices.set({ ...existing, name });
-  return Ok({ renamed: true });
-},
-```
-
-## The shape matrix
-
-```
-                 HANDLER
-                 ─────────────────────────────────────────────────────
-                 raw              Result                   throw
-LOCAL CALLER   ┌─────────────────┬──────────────────────┬───────────────────┐
-               │ value           │ {data, error}        │ try/catch or      │
-               │ (or await)      │ destructure          │ let it crash      │
-               │                 │                      │                   │
-REMOTE CALLER  │ {data, error}   │ {data, error}        │ {data, error}     │
-               │ error? =        │ error? =             │ error? =          │
-               │ ActionFailed    │ E | ActionFailed     │ ActionFailed      │
-               │ (transport/bug) │ (your typed E kept)  │ (no typed info)   │
-               └─────────────────┴──────────────────────┴───────────────────┘
-```
-
-Local mirrors native JS behavior — what you write is what you get. Remote
-always hands you an envelope; the only question is how rich the error
-channel is.
+If the remote caller needs to know "not found" separately from "handler
+crashed", make that a typed local error and add a narrower remote action
+surface later. The current peer dispatch API intentionally exposes
+`DispatchError`, not each handler's internal error union.
 
 ## Invariants
 
-1. **Local callers never see `ActionFailed`** — it only appears in
-   `RemoteAction<A>` signatures and in remote error channels.
-2. **Handlers can be sync, async, return raw, return `Result`, or throw** —
-   all five are valid. `defineQuery` and `defineMutation` don't care.
-3. **Server-side normalization runs exactly once** per RPC, inside
-   `attachSync`'s inbound handler. Raw gets `Ok`-wrapped; throws become
-   `RpcError.ActionFailed`; Results pass through.
-4. **Client-side receivers expect `{data, error}`** — both
-   `createRemoteActions` (new path) and `attachSync.rpc()` (legacy peer path)
-   consume the envelope. They differ in how they type the error channel.
-5. **`ActionFailed` is a `RpcError` variant sourced from `@epicenter/sync`** —
-   workspace re-exports it as a type alias. One nominal type across the
-   whole system, no re-wrapping.
+1. Local callers never see `DispatchError`.
+2. Handlers can be sync, async, return raw, return `Result`, or throw.
+3. Remote normalization runs exactly once per RPC, inside `attachActionRunner`.
+4. Remote receivers expect `{ data, error }` from `collaboration.dispatch()`.
+5. `DispatchError` lives in `packages/workspace/src/document/rpc.ts` and is re-exported from `@epicenter/workspace`.

--- a/.agents/skills/workspace-api/references/primitive-api.md
+++ b/.agents/skills/workspace-api/references/primitive-api.md
@@ -14,8 +14,8 @@ You construct a `Y.Doc` yourself and call `attach*` functions on it. `ydoc.destr
 import {
   attachIndexedDb,
   attachRichText,
-  attachSync,
   onLocalUpdate,
+  openCollaboration,
 } from '@epicenter/workspace';
 import * as Y from 'yjs';
 
@@ -26,7 +26,12 @@ function buildMyDoc(id: string) {
 
   const content = attachRichText(ydoc);
   const idb = attachIndexedDb(ydoc);
-  const sync = attachSync(ydoc, { url, getToken, waitFor: idb.whenLoaded });
+  const collaboration = openCollaboration(ydoc, {
+    url,
+    openWebSocket,
+    replicaId,
+    waitFor: idb.whenLoaded,
+  });
 
   onLocalUpdate(ydoc, () => { /* bump parent row updatedAt, etc. */ });
 
@@ -34,7 +39,7 @@ function buildMyDoc(id: string) {
     ydoc,
     content,
     idb,
-    sync,
+    collaboration,
     [Symbol.dispose]() { ydoc.destroy(); },
   };
 }
@@ -57,16 +62,15 @@ Each helper takes a `Y.Doc` and registers cleanup on `ydoc.on('destroy')`. Each 
 | Helper | Returns |
 |---|---|
 | `attachIndexedDb(ydoc)` | `{ whenLoaded, clearLocal, whenDisposed }` |
-| `attachSync(ydoc, { url, getToken?, waitFor?, awareness? })` | `{ whenConnected, status, onStatusChange, reconnect, whenDisposed }` |
+| `openCollaboration(ydoc, { url, openWebSocket?, replicaId, actions?, waitFor? })` | `{ whenConnected, status, onStatusChange, reconnect, whenDisposed, peers, dispatch }` |
 | `attachRichText(ydoc)` | `RichTextAttachment`: `{ read, write, binding: Y.XmlFragment }` |
 | `attachPlainText(ydoc)` | `PlainTextAttachment`: `{ read, write, binding: Y.Text }` |
 | `attachTable(ydoc, name, def)` | Typed row helper over `Y.Map` |
 | `attachKv(ydoc, defs)` | Typed KV helper |
-| `attachAwareness(ydoc, defs)` | Typed awareness helper |
 
-`attachSync`'s `waitFor` gates the first connection attempt on another promise, typically `idb.whenLoaded`, so the first handshake exchanges only a delta, not the full document.
+`openCollaboration`'s `waitFor` gates the first connection attempt on another promise, typically `idb.whenLoaded`, so the first handshake exchanges only a delta, not the full document.
 
-> **`attach*` is NOT idempotent.** Hold the reference from the first call. Calling any `attach*` helper twice against the same `Y.Doc` + slot is a caller bug; the framework does not catch it. For observer-installing primitives (`attachTable`, `attachKv`, `attachAwareness`, `attachEncryption`) double-attach silently installs duplicate observers, causing undefined behavior. One attach site per slot, one reference, held for the life of the `Y.Doc`.
+> **`attach*` is NOT idempotent.** Hold the reference from the first call. Calling any `attach*` helper twice against the same `Y.Doc` + slot is a caller bug; the framework does not catch it. For observer-installing primitives (`attachTable`, `attachKv`, `attachEncryption`) double-attach silently installs duplicate observers, causing undefined behavior. One attach site per slot, one reference, held for the life of the `Y.Doc`.
 
 ## Encrypted Variants (from `@epicenter/workspace`)
 
@@ -97,16 +101,16 @@ Encryption is opt-in per slot; the coordinator carries the intent. Plaintext `at
 
 > **Never mix plaintext and encrypted wrappers on the same slot name.** Yjs returns the same underlying `Y.Array` to `attachTable(ydoc, 'posts', ...)` and `encryption.attachTable('posts', ...)` because `ydoc.getArray('table:posts')` is idempotent. If both run, the plaintext wrapper writes plaintext into the same yarray the encrypted wrapper thinks it owns, a silent data-at-rest leak. The framework does not catch this; the grep-able call-site shape (`encryption.attach*` vs top-level `attach*`) is the defense. One slot name, one variant, one intent.
 
-IDB / broadcast / sync / sqlite transitively see already-encrypted bytes once encryption is registered. The Yjs update stream carries ciphertext blobs inside it. No additional encryption setup is needed at those transport layers.
+IDB / broadcast / collaboration / sqlite transitively see already-encrypted bytes once encryption is registered. The Yjs update stream carries ciphertext blobs inside it. No additional encryption setup is needed at those transport layers.
 
 ## Readiness Signals: Split, Don't Precompose
 
 Each helper returns what it actually knows. Callers compose at the call site.
 
 - `idb.whenLoaded`: "local draft is in memory, edits are safe" (offline-first UI usually only needs this).
-- `sync.whenConnected`: "transport established, first sync exchange finished" (CLIs that need remote state await this).
+- `collaboration.whenConnected`: "transport established, first sync exchange finished" (CLIs that need remote state await this).
 
-There is no `whenSynced` composite. If you need both, call `Promise.all([idb.whenLoaded, sync.whenConnected])` at the call site. This is intentional: `y-indexeddb`'s upstream `whenSynced` is a misnomer (it's local load, not convergence).
+There is no `whenSynced` composite. If you need both, call `Promise.all([idb.whenLoaded, collaboration.whenConnected])` at the call site. This is intentional: `y-indexeddb`'s upstream `whenSynced` is a misnomer (it's local load, not convergence).
 
 ## Canonical Per-Row Content Doc
 
@@ -117,11 +121,11 @@ Replaces the old `.withDocument('content', { content: richText, guid: 'id', onUp
 import {
   attachIndexedDb,
   attachRichText,
-  attachSync,
   createDisposableCache,
   docGuid,
   onLocalUpdate,
-  toWsUrl,
+  openCollaboration,
+  websocketUrl,
 } from '@epicenter/workspace';
 import * as Y from 'yjs';
 import { auth, workspace } from '$lib/client';
@@ -139,9 +143,10 @@ export const entryContentDocs = createDisposableCache((entryId: EntryId) => {
 
   const content = attachRichText(ydoc);
   const idb = attachIndexedDb(ydoc);
-  const sync = attachSync(ydoc, {
-    url: (docId) => toWsUrl(`${APP_URLS.API}/docs/${docId}`),
-    getToken: async () => auth.token,
+  const collaboration = openCollaboration(ydoc, {
+    url: websocketUrl(`${APP_URLS.API}/docs/${ydoc.guid}`),
+    openWebSocket: auth.openWebSocket,
+    replicaId,
     waitFor: idb.whenLoaded,
   });
 
@@ -155,12 +160,12 @@ export const entryContentDocs = createDisposableCache((entryId: EntryId) => {
     ydoc,
     content,
     idb,
-    sync,
+    collaboration,
     // Consumers await `handle.idb.whenLoaded` directly. Add a
     // `whenReady: Promise.all([...])` field only when the bundle has
     // two or more subsystem signals to compose into one barrier
     // (e.g. `Promise.all([persistence.whenLoaded, unlock.whenChecked,
-    // sync.whenConnected])`). A flat `whenReady: idb.whenLoaded`
+    // collaboration.whenConnected])`). A flat `whenReady: idb.whenLoaded`
     // alias lies about composition; expose the subsystem instead.
     // See specs/20260506T020000-expose-attachments-not-aliases.md.
     [Symbol.dispose]() { ydoc.destroy(); },
@@ -287,10 +292,10 @@ handle.content.binding;  // for editor bindings (Y.XmlFragment / Y.Text)
 ```
 
 ```typescript
-// ❌ Don't compose a "whenSynced" that Promise.alls idb + sync
+// Don't compose a "whenSynced" that Promise.alls idb + collaboration
 // You're hiding which signal the caller actually depends on.
 
-// ✅ Expose atoms; compose at the call site only when you truly need both
+// Expose atoms; compose at the call site only when you truly need both
 await doc.whenLoaded;                                         // typical UI
 await Promise.all([doc.whenLoaded, doc.whenConnected]);       // CLI needing remote state
 ```
@@ -305,13 +310,13 @@ new Y.Doc({ guid, gc: false });
 
 ## One primitive for every doc
 
-There is no separate workspace/document split anymore. The app's top-level workspace doc is usually a direct `openX()` builder with `attachTables` + `attachKv` + `attachAwareness` + persistence + sync inside. Per-row content docs use `createDisposableCache` with `attachRichText` / `attachPlainText` / `attachTimeline` + their own persistence + sync. Those are keyed by id and refcounted by the cache.
+There is no separate workspace/document split anymore. The app's top-level workspace doc is usually a direct `openX()` builder with `attachTables` + `attachKv` + persistence + `openCollaboration` inside. Per-row content docs use `createDisposableCache` with `attachRichText` / `attachPlainText` / `attachTimeline` + their own persistence + `openCollaboration`. Those are keyed by id and refcounted by the cache.
 
 ## Code References
 
 - `packages/workspace/src/cache/disposable-cache.ts`: the cache + refcount primitive
 - `packages/workspace/src/document/attach-indexed-db.ts`: persistence attach
-- `packages/workspace/src/document/attach-sync.ts`: sync attach (supervisor, backoff, awareness)
+- `packages/workspace/src/document/open-collaboration.ts`: sync, presence, peers, and remote dispatch
 - `packages/workspace/src/document/attach-rich-text.ts`, `attach-plain-text.ts`
 - `apps/fuji/src/lib/entry-content-doc.ts`: canonical per-row example
 - `apps/tab-manager/src/lib/client.ts`: canonical workspace-scale example

--- a/.agents/skills/workspace-app-layout/SKILL.md
+++ b/.agents/skills/workspace-app-layout/SKILL.md
@@ -19,7 +19,7 @@ apps/<app>/src/lib/
 `- session.svelte.ts                singleton: createSession + HMR + getSignedInSession()
 apps/<app>/src/routes/(signed-in)/<app>/
 |- index.ts                         iso doc factory: open<App>Doc({ encryptionKeys })
-|- browser.ts                       browser factory: open<App>({ userId, peer, bearerToken, encryptionKeys })
+|- browser.ts                       browser factory: open<App>({ userId, replicaId, openWebSocket, encryptionKeys })
 |- daemon.ts                        long-lived daemon factory (cli-side)
 |- script.ts                        one-shot script factory (cli-side)
 `- integration.test.ts
@@ -60,10 +60,10 @@ state, network) live only in the singleton (`session.svelte.ts` for shape A,
 | File | Shape | Job | Imports | Returns |
 | --- | --- | --- | --- | --- |
 | `index.ts` or `core.ts` | A + B | Isomorphic doc factory | Workspace core, schemas, pure action factories | `ydoc`, tables, kv, encryption, actions, batch, dispose |
-| `browser.ts` | A + B | Browser factory | Iso factory plus IndexedDB, BroadcastChannel, sync, browser caches | Doc bundle plus browser resources |
+| `browser.ts` | A + B | Browser factory | Iso factory plus IndexedDB, BroadcastChannel, collaboration, browser caches | Doc bundle plus browser resources |
 | `extension.ts` / `tauri.ts` | B | Env binding for non-web runtimes | Iso factory plus chrome.storage / Tauri APIs | Doc bundle plus runtime resources |
-| `daemon.ts` | A + B | Long-lived daemon factory | Iso factory plus `attachYjsLog`, `attachSync`, materializers | Doc bundle plus writer persistence and sync |
-| `script.ts` | A + B | One-shot script factory | Iso factory plus `attachYjsLogReader`, `attachSync` | Doc bundle plus readonly warm hydrate and sync |
+| `daemon.ts` | A + B | Long-lived daemon factory | Iso factory plus `attachYjsLog`, `openCollaboration`, materializers | Doc bundle plus writer persistence and collaboration |
+| `script.ts` | A + B | One-shot script factory | Iso factory plus `attachYjsLogReader`, `openCollaboration` | Doc bundle plus readonly warm hydrate and collaboration |
 | `auth.ts` | A | Auth client construction | `createCookieAuth` (or `createBearerAuth`) | `auth` |
 | `session.svelte.ts` | A | App singleton + lifecycle | `createSession` from `@epicenter/svelte`, env factory, auth | `session`, `InferSignedIn`, module-level `getSignedInSession()` |
 | `client.ts` | B | App singleton + auth wait | One env factory plus auth/session lifecycle | `auth` plus a running app singleton; module-level `await session.whenReady` |
@@ -122,40 +122,37 @@ Rules:
 
 ## Browser Factory
 
-Browser factories hydrate local IndexedDB first and then attach sync with the
-current public remote-action API.
+Browser factories hydrate local IndexedDB first and then open collaboration
+with the current remote-action API.
 
 ```ts
 export function openFuji({
 	userId,
-	peer,
-	bearerToken,
+	replicaId,
+	openWebSocket,
 	encryptionKeys,
 }: {
 	userId: string;
-	peer: PeerIdentity;
-	bearerToken?: () => string | null;
+	replicaId: string;
+	openWebSocket?: OpenWebSocket;
 	encryptionKeys: () => EncryptionKeys;
 }) {
 	const doc = openFujiDoc({ encryptionKeys });
 	const idb = doc.encryption.attachIndexedDb(doc.ydoc, { userId });
 	attachOwnedBroadcastChannel(doc.ydoc, { userId });
-	const awareness = attachAwareness(doc.ydoc, {
-		schema: { peer: PeerIdentity },
-		initial: { peer },
+	const collaboration = openCollaboration(doc.ydoc, {
+		url: websocketUrl(`${APP_URLS.API}/workspaces/${doc.ydoc.guid}`),
+		waitFor: idb.whenLoaded,
+		openWebSocket,
+		replicaId,
+		actions: doc.actions,
 	});
-	const sync = attachSync(doc, {
-		url: toWsUrl(`${APP_URLS.API}/workspaces/${doc.ydoc.guid}`),
-		waitFor: idb,
-		bearerToken,
-		awareness,
-	});
-	return { ...doc, idb, awareness, sync };
+	return { ...doc, idb, collaboration };
 }
 ```
 
 Do not restore `sync.peer()` or `describePeer()`. Remote calls use
-`createRemoteActions`; manifest fetches use `describeRemoteActions`.
+`collaboration.dispatch()`; peer lookup uses `collaboration.peers`.
 
 ## Daemon Factory
 
@@ -163,16 +160,16 @@ Daemon factories own the writer side of local persistence.
 
 ```ts
 export function openFuji({
-	bearerToken,
+	openWebSocket,
 	encryptionKeys,
-	device,
+	replicaId,
 	projectDir = findEpicenterDir(),
 	clientID = hashClientId(projectDir),
 	apiUrl = EPICENTER_API_URL,
 }: {
-	bearerToken?: () => string | null;
+	openWebSocket?: OpenWebSocket;
 	encryptionKeys: () => EncryptionKeys;
-	device: DeviceDescriptor;
+	replicaId: string;
 	projectDir?: ProjectDir;
 	clientID?: number;
 	apiUrl?: string;
@@ -181,11 +178,13 @@ export function openFuji({
 	const persistence = attachYjsLog(doc.ydoc, {
 		filePath: yjsPath(projectDir, doc.ydoc.guid),
 	});
-	const sync = attachSync(doc, {
-		url: toWsUrl(`${apiUrl}/workspaces/${doc.ydoc.guid}`),
-		bearerToken,
+	const collaboration = openCollaboration(doc.ydoc, {
+		url: websocketUrl(`${apiUrl}/workspaces/${doc.ydoc.guid}`),
+		openWebSocket,
+		replicaId,
+		actions: doc.actions,
 	});
-	return { ...doc, persistence, sync };
+	return { ...doc, persistence, collaboration };
 }
 ```
 
@@ -200,18 +199,21 @@ factories as `epicenter serve` consumers.
 
 ## Script Factory
 
-Script factories read the daemon's local Yjs log and write through sync.
+Script factories read the daemon's local Yjs log and write through
+collaboration.
 
 ```ts
 export function openFuji({
-	bearerToken,
+	openWebSocket,
 	encryptionKeys,
+	replicaId,
 	projectDir = findEpicenterDir(),
 	clientID = hashClientId(Bun.main),
 	apiUrl = EPICENTER_API_URL,
 }: {
-	bearerToken?: () => string | null;
+	openWebSocket?: OpenWebSocket;
 	encryptionKeys: () => EncryptionKeys;
+	replicaId: string;
 	projectDir?: ProjectDir;
 	clientID?: number;
 	apiUrl?: string;
@@ -220,11 +222,13 @@ export function openFuji({
 	const persistence = attachYjsLogReader(doc.ydoc, {
 		filePath: yjsPath(projectDir, doc.ydoc.guid),
 	});
-	const sync = attachSync(doc, {
-		url: toWsUrl(`${apiUrl}/workspaces/${doc.ydoc.guid}`),
-		bearerToken,
+	const collaboration = openCollaboration(doc.ydoc, {
+		url: websocketUrl(`${apiUrl}/workspaces/${doc.ydoc.guid}`),
+		openWebSocket,
+		replicaId,
+		actions: doc.actions,
 	});
-	return { ...doc, persistence, sync };
+	return { ...doc, persistence, collaboration };
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -203,10 +203,9 @@ import { type } from 'arktype';
 import * as Y from 'yjs';
 import {
   attachIndexedDb,
-  attachSync,
   attachTables,
-  defineDocument,
   defineTable,
+  openCollaboration,
   websocketUrl,
 } from '@epicenter/workspace';
 
@@ -214,22 +213,23 @@ const posts = defineTable(
   type({ id: 'string', title: 'string', published: 'boolean', _v: '1' }),
 );
 
-const blog = defineDocument((id: string) => {
+function openBlog(id: string, replicaId: string) {
   const ydoc = new Y.Doc({ guid: id });
   const tables = attachTables(ydoc, { posts });
   const idb = attachIndexedDb(ydoc);
-  const sync = attachSync(ydoc, {
-    url: (docId) => websocketUrl(`http://localhost:3913/rooms/${docId}`),
+  const collaboration = openCollaboration(ydoc, {
+    url: websocketUrl(`http://localhost:3913/rooms/${ydoc.guid}`),
     waitFor: idb.whenLoaded,
+    replicaId,
   });
 
   return {
-    id, ydoc, tables, idb, sync,
+    id, ydoc, tables, idb, collaboration,
     [Symbol.dispose]() { ydoc.destroy(); },
   };
-});
+}
 
-const workspace = await blog.load('epicenter.blog');
+const workspace = openBlog('epicenter.blog', 'browser-dev');
 workspace.tables.posts.set({ id: '1', title: 'Hello', published: false, _v: 1 });
 ```
 

--- a/apps/api/src/base-sync-room.ts
+++ b/apps/api/src/base-sync-room.ts
@@ -4,8 +4,8 @@
  * Everything a sync room needs lives in this file: SQLite persistence,
  * WebSocket lifecycle, connection management, presence writes, and the
  * abstract base class. The only external dependency is `sync-handlers.ts`
- * for the Yjs wire protocol (encode/decode/dispatch). Subclasses
- * (`WorkspaceRoom`, `DocumentRoom`) import from here and nowhere else.
+ * for the Yjs wire protocol (encode/decode/dispatch). `SyncRoom` imports
+ * from here and nowhere else.
  *
  * ## Module structure
  *
@@ -22,11 +22,9 @@ import {
 	parseSubprotocols,
 	stateVectorsEqual,
 } from '@epicenter/sync';
-import {
-	PRESENCE_KEY,
-	type PresenceEntry,
-	YKeyValueLww,
-} from '@epicenter/workspace';
+import { type PresenceEntry } from '@epicenter/workspace';
+import { PRESENCE_KEY } from '@epicenter/workspace/document/keys';
+import { YKeyValueLww } from '@epicenter/workspace/document/y-keyvalue/y-keyvalue-lww';
 import * as Y from 'yjs';
 import { MAX_PAYLOAD_BYTES } from './constants';
 import {
@@ -53,8 +51,8 @@ type SyncRoomConfig = {
 	/**
 	 * Whether to enable Yjs garbage collection.
 	 *
-	 * - `true`: workspace rooms that don't need version history
-	 * - `false`: document rooms that preserve delete history so
+	 * - `true`: compact current-state rooms
+	 * - `false`: retained-history rooms that preserve delete history so
 	 *   `Y.snapshot()` can reconstruct past states
 	 */
 	gc: boolean;
@@ -109,7 +107,7 @@ export class PresenceWriteForbidden extends Error {
  *
  * The Hono Worker in `app.ts` calls into DOs via two mechanisms:
  *
- * - **RPC** (`stub.sync()`, `stub.getDoc()`): for HTTP sync and snapshot
+ * - **RPC** (`stub.sync()`, `stub.getDoc()`): for HTTP sync and bootstrap
  *   bootstrap. Direct method calls avoid Request/Response serialization
  *   overhead for binary payloads. The Worker handles HTTP concerns (status
  *   codes, content-type headers); the DO handles only Yjs logic.
@@ -138,15 +136,14 @@ export class PresenceWriteForbidden extends Error {
  * re-validate (it trusts the Worker boundary).
  *
  * DO names are user-scoped: the Worker constructs
- * `user:{userId}:{type}:{name}` before calling `idFromName()`, where
- * `{type}` is `workspace` or `document`.
+ * `user:{userId}:sync:{room}` before calling `idFromName()`.
  * This ensures each user's data is isolated in separate DO instances, even
- * if multiple users create workspaces with the same name (e.g., "epicenter.tab-manager").
+ * if multiple users sync rooms with the same name (e.g., "epicenter.tab-manager").
  *
  * We chose user-scoped DO names (Google Docs model) over org-scoped names
- * (Vercel/Supabase model) because most workspaces hold personal data.
+ * (Vercel/Supabase model) because most rooms hold personal data.
  * For enterprise self-hosted, the deployment itself is the org boundary.
- * See `getWorkspaceStub` in app.ts for the full rationale.
+ * See `getSyncStub` in app.ts for the full rationale.
  */
 export class BaseSyncRoom extends DurableObject {
 	/**
@@ -164,7 +161,7 @@ export class BaseSyncRoom extends DurableObject {
 	 * 2. **Synchronous async callback**: The callback passed to
 	 *    `blockConcurrencyWhile` contains no `await`, so it executes to
 	 *    completion synchronously. This means `doc` is assigned before the
-	 *    constructor returns, so subclass constructors (e.g. `DocumentRoom`)
+	 *    constructor returns, so subclass constructors (e.g. `SyncRoom`)
 	 *    can safely access `this.doc` after `super()`.
 	 *
 	 * If an `await` is ever added to the `blockConcurrencyWhile` callback,
@@ -262,7 +259,7 @@ export class BaseSyncRoom extends DurableObject {
 	// --- fetch: WebSocket upgrades only ---
 
 	/**
-	 * Only handles WebSocket upgrades. HTTP operations (sync, snapshot) are
+	 * Only handles WebSocket upgrades. HTTP sync operations are
 	 * exposed as RPC methods called directly on the stub, avoiding the overhead
 	 * of constructing/parsing Request/Response objects for binary payloads.
 	 */
@@ -476,8 +473,7 @@ export class BaseSyncRoom extends DurableObject {
 	 * the remote end).
 	 *
 	 * When the last connection leaves, calls {@link onAllDisconnected} for
-	 * subclass cleanup (e.g. auto-saving snapshots in `DocumentRoom`) and
-	 * schedules a deferred compaction alarm.
+	 * subclass cleanup and schedules a deferred compaction alarm.
 	 */
 	override async webSocketClose(
 		ws: WebSocket,
@@ -527,8 +523,6 @@ export class BaseSyncRoom extends DurableObject {
 	 * Hook called when the last WebSocket client disconnects.
 	 *
 	 * Override in subclasses to perform cleanup when all clients leave.
-	 * For example, `DocumentRoom` overrides this to auto-save a snapshot
-	 * if the document changed since the last save.
 	 *
 	 * Called before the compaction alarm is scheduled. The base
 	 * implementation is a no-op.
@@ -562,8 +556,8 @@ export class BaseSyncRoom extends DurableObject {
 /**
  * Extract the owning user id (`subject`) from the DO name.
  *
- * DO names are formatted by `getWorkspaceStub` / `getDocumentStub` in app.ts
- * as `user:{userId}:{workspace|document}:{name}`. Every connection to this
+ * DO names are formatted by `getSyncStub` in app.ts as
+ * `user:{userId}:sync:{room}`. Every connection to this
  * DO shares the same auth context, so `subject` is room-scoped, not
  * connection-scoped. Parsing once at construction lets the value survive
  * hibernation without extra plumbing through `WsAttachment`.
@@ -578,7 +572,7 @@ function subjectFromDoName(name: string | undefined): string {
 	if (!match) {
 		throw new Error(
 			`[base-sync-room] DO name does not match expected ` +
-				`"user:{userId}:{workspace|document}:{name}" format: ${JSON.stringify(name)}`,
+				`"user:{userId}:sync:{room}" format: ${JSON.stringify(name)}`,
 		);
 	}
 	return match[1] as string;

--- a/apps/api/src/sync-handlers.test.ts
+++ b/apps/api/src/sync-handlers.test.ts
@@ -16,7 +16,7 @@ import {
 	MESSAGE_TYPE,
 	SYNC_MESSAGE_TYPE,
 } from '@epicenter/sync';
-import { PRESENCE_KEY } from '@epicenter/workspace';
+import { PRESENCE_KEY } from '@epicenter/workspace/document/keys';
 import * as encoding from 'lib0/encoding';
 import * as Y from 'yjs';
 

--- a/apps/api/src/sync-handlers.ts
+++ b/apps/api/src/sync-handlers.ts
@@ -37,7 +37,7 @@ import {
 	SYNC_MESSAGE_TYPE,
 	type SyncMessageType,
 } from '@epicenter/sync';
-import { PRESENCE_KEY } from '@epicenter/workspace';
+import { PRESENCE_KEY } from '@epicenter/workspace/document/keys';
 import * as decoding from 'lib0/decoding';
 import { defineErrors, extractErrorMessage } from 'wellcrafted/error';
 import { Ok, trySync } from 'wellcrafted/result';

--- a/apps/fuji/src/routes/(signed-in)/fuji/browser.ts
+++ b/apps/fuji/src/routes/(signed-in)/fuji/browser.ts
@@ -66,6 +66,7 @@ export function openFujiBrowser({
 			waitFor: childIdb.whenLoaded,
 			openWebSocket,
 			replicaId,
+			actions: {},
 		});
 
 		onLocalUpdate(ydoc, () => {

--- a/apps/honeycrisp/blocks/script.ts
+++ b/apps/honeycrisp/blocks/script.ts
@@ -38,6 +38,7 @@ export async function openHoneycrispScript({
 		url: websocketUrl(`${EPICENTER_API_URL}/workspaces/${ydoc.guid}`),
 		openWebSocket: session.openWebSocket,
 		replicaId: 'honeycrisp-script',
+		actions: {},
 	});
 
 	return {

--- a/apps/honeycrisp/src/routes/(signed-in)/honeycrisp/browser.ts
+++ b/apps/honeycrisp/src/routes/(signed-in)/honeycrisp/browser.ts
@@ -65,6 +65,7 @@ export function openHoneycrispBrowser({
 			waitFor: childIdb.whenLoaded,
 			openWebSocket,
 			replicaId,
+			actions: {},
 		});
 
 		onLocalUpdate(ydoc, () => {

--- a/apps/opensidian/blocks/daemon-route.ts
+++ b/apps/opensidian/blocks/daemon-route.ts
@@ -40,6 +40,7 @@ export function defineOpensidianDaemon({
 				url: websocketUrl(`${EPICENTER_API_URL}/workspaces/${ydoc.guid}`),
 				openWebSocket: session.openWebSocket,
 				replicaId: 'opensidian-daemon',
+				actions: {},
 			});
 
 			return {

--- a/apps/opensidian/blocks/script.ts
+++ b/apps/opensidian/blocks/script.ts
@@ -38,6 +38,7 @@ export async function openOpensidianScript({
 		url: websocketUrl(`${EPICENTER_API_URL}/workspaces/${ydoc.guid}`),
 		openWebSocket: session.openWebSocket,
 		replicaId: 'opensidian-script',
+		actions: {},
 	});
 
 	return {

--- a/apps/opensidian/src/lib/components/editor/extensions/link-decorations.ts
+++ b/apps/opensidian/src/lib/components/editor/extensions/link-decorations.ts
@@ -13,7 +13,7 @@ import {
 	EPICENTER_LINK_RE,
 	type EpicenterLink,
 	parseEpicenterLink,
-} from '@epicenter/workspace';
+} from '@epicenter/workspace/links';
 
 /**
  * Configuration for the link decoration plugin.

--- a/apps/opensidian/src/lib/components/editor/extensions/wikilink-autocomplete.ts
+++ b/apps/opensidian/src/lib/components/editor/extensions/wikilink-autocomplete.ts
@@ -4,7 +4,7 @@ import {
 	type CompletionContext,
 	type CompletionResult,
 } from '@codemirror/autocomplete';
-import { makeEpicenterLink } from '@epicenter/workspace';
+import { makeEpicenterLink } from '@epicenter/workspace/links';
 
 /**
  * Configuration for the wikilink autocomplete extension.

--- a/apps/tab-manager/src/lib/chat/chat-state.svelte.ts
+++ b/apps/tab-manager/src/lib/chat/chat-state.svelte.ts
@@ -109,10 +109,6 @@ export function createAiChatState({
 		ReturnType<typeof createConversationHandle>
 	>();
 
-	/** Internal lifecycle closures, not exposed on ConversationHandle. */
-	const destroyFns = new Map<ConversationId, () => void>();
-	const refreshFns = new Map<ConversationId, () => void>();
-
 	// ── Conversation Handle Factory ──────────────────────────────────
 
 	/**
@@ -171,13 +167,6 @@ export function createAiChatState({
 				});
 				updateConversation(conversationId, {});
 			},
-		});
-
-		// Register internal lifecycle closures
-		destroyFns.set(conversationId, () => chat.stop());
-		refreshFns.set(conversationId, () => {
-			if (chat.isLoading) return;
-			chat.setMessages(loadMessages(conversationId));
 		});
 
 		return {
@@ -357,6 +346,19 @@ export function createAiChatState({
 				chat.stop();
 			},
 
+			/**
+			 * Reload messages from the Y.Doc into the chat instance.
+			 * Skips while a stream is in flight (`isLoading`) to avoid the
+			 * observer racing the chat's own message append: the user message
+			 * is written to Y.Doc immediately after `chat.sendMessage`, and if
+			 * this fired during the stream it would feed Svelte two copies of
+			 * the same id and crash.
+			 */
+			refreshFromDoc() {
+				if (chat.isLoading) return;
+				chat.setMessages(loadMessages(conversationId));
+			},
+
 			approveToolCall(approvalId: string) {
 				void chat.addToolApprovalResponse({ id: approvalId, approved: true });
 			},
@@ -379,9 +381,7 @@ export function createAiChatState({
 
 	/** Stop client and remove the handle for a conversation. */
 	function destroyConversation(id: ConversationId) {
-		destroyFns.get(id)?.();
-		destroyFns.delete(id);
-		refreshFns.delete(id);
+		handles.get(id)?.stop();
 		handles.delete(id);
 	}
 
@@ -419,7 +419,7 @@ export function createAiChatState({
 		},
 	);
 	const _unobserveChatMessages = tabManager.tables.chatMessages.observe(() => {
-		refreshFns.get(activeConversationId)?.();
+		handles.get(activeConversationId)?.refreshFromDoc();
 	});
 
 	// Initialize after persistence loads
@@ -469,7 +469,7 @@ export function createAiChatState({
 
 	function switchConversation(conversationId: ConversationId) {
 		activeConversationId = conversationId;
-		refreshFns.get(conversationId)?.();
+		handles.get(conversationId)?.refreshFromDoc();
 	}
 
 	function deleteConversation(conversationId: ConversationId) {

--- a/apps/whispering/src/lib/recording-materializer.ts
+++ b/apps/whispering/src/lib/recording-materializer.ts
@@ -7,7 +7,9 @@
  * changes never produce overlapping writes.
  */
 
-import type { MaybePromise, Table } from '@epicenter/workspace';
+import type { Table } from '@epicenter/workspace';
+
+type MaybePromise<T> = T | Promise<T>;
 import { invoke, isTauri } from '@tauri-apps/api/core';
 import yaml from 'js-yaml';
 import type * as Y from 'yjs';

--- a/apps/whispering/src/lib/services/text/types.ts
+++ b/apps/whispering/src/lib/services/text/types.ts
@@ -1,4 +1,3 @@
-import type { MaybePromise } from '@epicenter/workspace';
 import {
 	defineErrors,
 	extractErrorMessage,
@@ -6,6 +5,8 @@ import {
 } from 'wellcrafted/error';
 import type { Result } from 'wellcrafted/result';
 import type { WhisperingError } from '$lib/result';
+
+type MaybePromise<T> = T | Promise<T>;
 
 export const TextError = defineErrors({
 	ClipboardRead: ({ cause }: { cause: unknown }) => ({

--- a/apps/whispering/src/lib/state/vad-recorder.svelte.ts
+++ b/apps/whispering/src/lib/state/vad-recorder.svelte.ts
@@ -26,9 +26,8 @@ import { deviceConfig } from '$lib/state/device-config.svelte';
  */
 function createVadRecorder() {
 	// Private state
-	let _maybeVad: MicVAD | null = null;
+	let _session: { vad: MicVAD; stream: MediaStream } | null = null;
 	let _state = $state<VadState>('IDLE');
-	let _currentStream: MediaStream | null = null;
 
 	return {
 		/**
@@ -75,7 +74,7 @@ function createVadRecorder() {
 			onSpeechRealStart?: () => void;
 		}) {
 			// Prevent starting if already active
-			if (_maybeVad) {
+			if (_session) {
 				return WhisperingErr({
 					title: '⚠️ VAD already active',
 					description: 'Stop the current session before starting a new one.',
@@ -109,7 +108,6 @@ function createVadRecorder() {
 			}
 
 			const { stream, deviceOutcome } = streamResult;
-			_currentStream = stream;
 
 			// Create VAD with the validated stream
 			const { data: newVad, error: initializeVadError } = await tryAsync({
@@ -148,7 +146,6 @@ function createVadRecorder() {
 			if (initializeVadError) {
 				// Clean up stream if VAD initialization fails
 				cleanupRecordingStream(stream);
-				_currentStream = null;
 				return Err(initializeVadError);
 			}
 
@@ -170,12 +167,10 @@ function createVadRecorder() {
 					catch: () => Ok(undefined),
 				});
 				cleanupRecordingStream(stream);
-				_maybeVad = null;
-				_currentStream = null;
 				return Err(startError);
 			}
 
-			_maybeVad = newVad;
+			_session = { vad: newVad, stream };
 			_state = 'LISTENING';
 			return Ok(deviceOutcome);
 		},
@@ -185,11 +180,11 @@ function createVadRecorder() {
 		 * Sets `state` back to 'IDLE'.
 		 */
 		async stopActiveListening() {
-			if (!_maybeVad) return Ok(undefined);
+			if (!_session) return Ok(undefined);
 
-			const vadInstance = _maybeVad;
+			const { vad, stream } = _session;
 			const { error: destroyError } = trySync({
-				try: () => vadInstance.destroy(),
+				try: () => vad.destroy(),
 				catch: (error) =>
 					WhisperingErr({
 						title: '❌ Failed to stop VAD',
@@ -199,14 +194,9 @@ function createVadRecorder() {
 			});
 
 			// Always clean up, even if dispose had an error
-			_maybeVad = null;
+			_session = null;
 			_state = 'IDLE';
-
-			// Clean up our managed stream
-			if (_currentStream) {
-				cleanupRecordingStream(_currentStream);
-				_currentStream = null;
-			}
+			cleanupRecordingStream(stream);
 
 			if (destroyError) return Err(destroyError);
 			return Ok(undefined);

--- a/apps/zhongwen/blocks/daemon-route.ts
+++ b/apps/zhongwen/blocks/daemon-route.ts
@@ -40,6 +40,7 @@ export function defineZhongwenDaemon({
 				url: websocketUrl(`${EPICENTER_API_URL}/workspaces/${ydoc.guid}`),
 				openWebSocket: session.openWebSocket,
 				replicaId: 'zhongwen-daemon',
+				actions: {},
 			});
 
 			return {

--- a/apps/zhongwen/blocks/script.ts
+++ b/apps/zhongwen/blocks/script.ts
@@ -42,6 +42,7 @@ export async function openZhongwenScript({
 		url: websocketUrl(`${EPICENTER_API_URL}/workspaces/${ydoc.guid}`),
 		openWebSocket: session.openWebSocket,
 		replicaId: 'zhongwen-script',
+		actions: {},
 	});
 
 	return {

--- a/packages/filesystem/src/formats/sheet.ts
+++ b/packages/filesystem/src/formats/sheet.ts
@@ -3,14 +3,14 @@
  * re-exported from @epicenter/workspace.
  */
 
-import { computeMidpoint } from '@epicenter/workspace';
+import { computeMidpoint } from '@epicenter/workspace/document/attach-timeline';
 import type * as Y from 'yjs';
 
 // Re-export ordering helpers from workspace (canonical location)
 export {
 	computeMidpoint,
 	generateInitialOrders,
-} from '@epicenter/workspace';
+} from '@epicenter/workspace/document/attach-timeline';
 
 /**
  * Reorder a row by updating its fractional order property.

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -33,7 +33,11 @@
 		"./node": "./src/node.ts",
 		"./document/materializer/sqlite": "./src/document/materializer/sqlite/index.ts",
 		"./logger/jsonl-sink": "./src/shared/logger/jsonl-sink.ts",
-		"./test-utils": "./src/shared/test-utils.ts"
+		"./test-utils": "./src/shared/test-utils.ts",
+		"./links": "./src/links.ts",
+		"./document/keys": "./src/document/keys.ts",
+		"./document/y-keyvalue/y-keyvalue-lww": "./src/document/y-keyvalue/y-keyvalue-lww.ts",
+		"./document/attach-timeline": "./src/document/attach-timeline/index.ts"
 	},
 	"license": "MIT",
 	"scripts": {

--- a/packages/workspace/src/__tests__/create-tables.ts
+++ b/packages/workspace/src/__tests__/create-tables.ts
@@ -1,5 +1,9 @@
 import type * as Y from 'yjs';
-import { attachTable, type TableDefinitions, type Tables } from '../index.js';
+import {
+	attachTable,
+	type TableDefinitions,
+	type Tables,
+} from '../document/attach-table.js';
 
 /**
  * Test-only convenience: attach every table in a definitions map to a Y.Doc.

--- a/packages/workspace/src/ai/tool-bridge.test.ts
+++ b/packages/workspace/src/ai/tool-bridge.test.ts
@@ -8,7 +8,7 @@ import {
 	type ActionRegistry,
 	defineMutation,
 	defineQuery,
-} from '@epicenter/workspace';
+} from '../shared/actions.js';
 import { Err, Ok } from 'wellcrafted/result';
 import { actionsToAiTools } from './tool-bridge.js';
 

--- a/packages/workspace/src/document/attach-encrypted-indexed-db.ts
+++ b/packages/workspace/src/document/attach-encrypted-indexed-db.ts
@@ -135,7 +135,10 @@ export function attachEncryptedIndexedDb(
 			plaintext: update,
 			aad,
 		});
-		await idb.addAutoKey(updatesStore, ciphertext as unknown as string);
+		// lib0's `addAutoKey` types `item` narrower than IDB structured-clone
+		// accepts. Uint8Array is supported at runtime; the cast widens the type
+		// signature, not the runtime contract.
+		await idb.addAutoKey(updatesStore, ciphertext as unknown as ArrayBuffer);
 	}
 
 	async function fetchUpdates(

--- a/packages/workspace/src/document/define-table.ts
+++ b/packages/workspace/src/document/define-table.ts
@@ -81,7 +81,7 @@ export function defineTable<TSchema extends CombinedStandardSchema<BaseRow>>(
 		return {
 			schema,
 			migrate: (row: unknown) => row as BaseRow,
-		} as unknown as TableDefinition<[TSchema]>;
+		} as TableDefinition<[TSchema]>;
 	}
 
 	const versions = args as CombinedStandardSchema[];
@@ -93,7 +93,7 @@ export function defineTable<TSchema extends CombinedStandardSchema<BaseRow>>(
 				migrate: fn,
 			};
 		},
-	} as unknown as {
+	} as {
 		migrate(
 			fn: (row: unknown) => unknown,
 		): TableDefinition<CombinedStandardSchema<BaseRow>[]>;

--- a/packages/workspace/src/document/open-collaboration.ts
+++ b/packages/workspace/src/document/open-collaboration.ts
@@ -120,7 +120,7 @@ export function openCollaboration<TActions extends ActionRegistry>(
 	ydoc: Y.Doc,
 	config: OpenCollaborationConfig<TActions>,
 ): Collaboration<TActions> {
-	const userActions = (config.actions ?? ({} as TActions)) as TActions;
+	const userActions = config.actions ?? ({} as TActions);
 
 	for (const key of Object.keys(userActions)) {
 		if (!ACTION_KEY_PATTERN.test(key)) {

--- a/packages/workspace/src/document/open-collaboration.ts
+++ b/packages/workspace/src/document/open-collaboration.ts
@@ -19,9 +19,8 @@
  * does not hide that choice behind a `find` verb.
  *
  * Content docs (rich-text bodies, attachments, anything nested under a parent
- * that syncs independently) use this same primitive with `actions` omitted:
- * the default registry is `{}`, the action runner is skipped entirely, and
- * the byte transport is identical.
+ * that syncs independently) use this same primitive with `actions: {}`: the
+ * action runner is skipped entirely and the byte transport is identical.
  */
 
 import type { Logger } from 'wellcrafted/logger';
@@ -52,9 +51,7 @@ import { YKeyValueLww } from './y-keyvalue/y-keyvalue-lww.js';
 // PUBLIC TYPES
 // ════════════════════════════════════════════════════════════════════════════
 
-export type OpenCollaborationConfig<
-	TActions extends ActionRegistry = ActionRegistry,
-> = {
+export type OpenCollaborationConfig<TActions extends ActionRegistry> = {
 	url: string;
 	waitFor?: Promise<unknown>;
 	openWebSocket?: OpenWebSocket;
@@ -66,11 +63,11 @@ export type OpenCollaborationConfig<
 	 */
 	replicaId: string;
 	/**
-	 * Local action registry. Defaults to `{}` for content docs and
-	 * consume-only participants. When the registry is empty, no action
-	 * runner observer is attached: pure listeners pay zero handler cost.
+	 * Local action registry. Pass `{}` for content docs and consume-only
+	 * participants. When the registry is empty, no action runner observer is
+	 * attached: pure listeners pay zero handler cost.
 	 */
-	actions?: TActions;
+	actions: TActions;
 };
 
 export type Collaboration<TActions extends ActionRegistry = ActionRegistry> = {
@@ -120,7 +117,7 @@ export function openCollaboration<TActions extends ActionRegistry>(
 	ydoc: Y.Doc,
 	config: OpenCollaborationConfig<TActions>,
 ): Collaboration<TActions> {
-	const userActions = config.actions ?? ({} as TActions);
+	const userActions = config.actions;
 
 	for (const key of Object.keys(userActions)) {
 		if (!ACTION_KEY_PATTERN.test(key)) {

--- a/packages/workspace/src/document/rpc.test.ts
+++ b/packages/workspace/src/document/rpc.test.ts
@@ -27,12 +27,7 @@ import {
 	defineQuery,
 } from '../shared/actions.js';
 import { RPC_KEY } from './keys.js';
-import {
-	attachActionRunner,
-	type Call,
-	DispatchError,
-	dispatch,
-} from './rpc.js';
+import { attachActionRunner, type Call, dispatch } from './rpc.js';
 import { YKeyValueLww } from './y-keyvalue/y-keyvalue-lww.js';
 
 function setup(actions: ActionRegistry, targetConnId = 'target') {

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -38,6 +38,7 @@
  *   waitFor: idb.whenLoaded,
  *   openWebSocket,
  *   replicaId,
+ *   actions: {},
  * });
  *
  * // Content docs use the same primitive with an empty action registry.
@@ -58,6 +59,7 @@
  *       waitFor: bodyIdb.whenLoaded,
  *       openWebSocket,
  *       replicaId,
+ *       actions: {},
  *     });
  *     return {
  *       ydoc: bodyYdoc,

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -1,10 +1,10 @@
 /**
  * Epicenter: YJS-First Collaborative Workspace System
  *
- * This root export provides the browser-safe workspace API and shared
- * utilities.
- *
- * - `@epicenter/workspace`: browser-safe API (documents, tables, KV, sync)
+ * `@epicenter/workspace` attaches typed primitives — tables, KV, plain/rich
+ * text, presence, timeline, and an action registry — to a `Y.Doc`, then
+ * wires the result to IndexedDB persistence, end-to-end encryption, and
+ * WebSocket sync via `openCollaboration`.
  *
  * @example
  * ```typescript
@@ -17,6 +17,7 @@
  *   defineTable,
  *   docGuid,
  *   openCollaboration,
+ *   syncRoomUrl,
  * } from '@epicenter/workspace';
  * import { type } from 'arktype';
  * import * as Y from 'yjs';
@@ -34,7 +35,7 @@
  * const tables = attachTables(ydoc, { posts });
  * const idb = attachIndexedDb(ydoc);
  * const collaboration = openCollaboration(ydoc, {
- *   url: `wss://api.example.com/workspaces/${ydoc.guid}`,
+ *   url: syncRoomUrl('https://api.example.com', ydoc.guid),
  *   waitFor: idb.whenLoaded,
  *   openWebSocket,
  *   replicaId,
@@ -55,7 +56,7 @@
  *     });
  *     const bodyIdb = attachIndexedDb(bodyYdoc);
  *     const bodySync = openCollaboration(bodyYdoc, {
- *       url: `wss://api.example.com/documents/${bodyYdoc.guid}`,
+ *       url: syncRoomUrl('https://api.example.com', bodyYdoc.guid),
  *       waitFor: bodyIdb.whenLoaded,
  *       openWebSocket,
  *       replicaId,
@@ -82,215 +83,81 @@
 // ACTION SYSTEM
 // ════════════════════════════════════════════════════════════════════════════
 
-export type {
-	Action,
-	ActionManifest,
-	ActionRegistry,
-} from './shared/actions';
+export type { Action, ActionManifest } from './shared/actions';
 export {
-	ACTION_KEY_PATTERN,
 	defineActions,
 	defineMutation,
 	defineQuery,
-	invokeAction,
-	isAction,
-	toActionMeta,
 } from './shared/actions';
-
-// ════════════════════════════════════════════════════════════════════════════
-// REMOTE CALLS
-// ════════════════════════════════════════════════════════════════════════════
-
-export type { EncryptionKeys } from '@epicenter/encryption';
 
 // ════════════════════════════════════════════════════════════════════════════
 // REPLICA IDENTITY
 // ════════════════════════════════════════════════════════════════════════════
 
 export {
-	type AsyncStorage,
 	createReplicaId,
 	createReplicaIdAsync,
-	type SimpleStorage,
 } from './document/replica-id.js';
 
 // ════════════════════════════════════════════════════════════════════════════
-// SHARED TYPES
+// PATH TYPES (for daemon callers)
 // ════════════════════════════════════════════════════════════════════════════
 
-export type { MaybePromise } from './shared/types';
+export type { ProjectDir } from './shared/types';
 
 // ════════════════════════════════════════════════════════════════════════════
-// ERROR TYPES
-// ════════════════════════════════════════════════════════════════════════════
-
-export { ExtensionError } from './shared/errors';
-
-// JSONL file sink (Bun-only) lives at the `@epicenter/workspace/logger/jsonl-sink`
-// subpath. Keeping it out of this barrel matters: re-exporting it pulls
-// `node:fs`/`node:path` into every browser bundle that touches `@epicenter/workspace`,
-// which breaks SvelteKit/Vite SSR to client builds (see `__vite-browser-external`
-// "mkdirSync is not exported" errors). Import the sink directly from the subpath
-// in Bun/Node entry points; the logger core (`createLogger`, `consoleSink`, etc.)
-// still comes from `wellcrafted/logger`.
-
-// ════════════════════════════════════════════════════════════════════════════
-// CORE TYPES
-// ════════════════════════════════════════════════════════════════════════════
-
-export type { AbsolutePath, ProjectDir } from './shared/types';
-
-// ════════════════════════════════════════════════════════════════════════════
-// ID UTILITIES
+// ID + DATE PRIMITIVES
 // ════════════════════════════════════════════════════════════════════════════
 
 export type { Guid, Id } from './shared/id';
-export { generateGuid, generateId, Id as createId } from './shared/id';
-
-// ════════════════════════════════════════════════════════════════════════════
-// DATE UTILITIES
-// ════════════════════════════════════════════════════════════════════════════
-
-export type {
-	DateIsoString,
-	ParsedDateTimeString,
-	TimezoneId,
-} from './shared/datetime-string';
+export { generateGuid, generateId } from './shared/id';
 export { DateTimeString } from './shared/datetime-string';
 
 // ════════════════════════════════════════════════════════════════════════════
-// DOCUMENT PRIMITIVES: attach*, define*, refcounted cache, encryption,
-// timeline, storage keys, types: everything in src/document/ + src/cache/
-// flows through its barrel.
+// DOCUMENT PRIMITIVES
 // ════════════════════════════════════════════════════════════════════════════
 
 export {
 	createDisposableCache,
 	type DisposableCache,
-	DisposableCacheError,
 } from './cache/disposable-cache.js';
 
-export {
-	attachBroadcastChannel,
-	BC_ORIGIN,
-} from './document/attach-broadcast-channel.js';
-export {
-	type AttachEncryptionOptions,
-	attachEncryption,
-	type EncryptionAttachment,
-} from './document/attach-encryption.js';
+export { attachBroadcastChannel } from './document/attach-broadcast-channel.js';
+export { attachEncryption } from './document/attach-encryption.js';
 export {
 	createLocalOwner,
 	type LocalOwner,
 } from './document/local-owner.js';
-export {
-	attachIndexedDb,
-	type IndexedDbAttachment,
-} from './document/attach-indexed-db.js';
+export { attachIndexedDb } from './document/attach-indexed-db.js';
 export {
 	attachKv,
 	type InferKvValue,
 	type Kv,
-	type KvChange,
-	type KvDefinition,
 	type KvDefinitions,
 } from './document/attach-kv.js';
+export { attachPlainText } from './document/attach-plain-text.js';
+export { attachRichText } from './document/attach-rich-text.js';
 export {
-	attachPlainText,
-	type PlainTextAttachment,
-} from './document/attach-plain-text.js';
-export {
-	attachRichText,
-	type RichTextAttachment,
-	xmlFragmentToPlaintext,
-} from './document/attach-rich-text.js';
-export {
-	attachReadonlyTable,
-	attachReadonlyTables,
 	attachTable,
 	attachTables,
 	type BaseRow,
 	type InferTableRow,
-	type LastSchema,
-	type ReadonlyTable,
-	type ReadonlyTables,
 	type Table,
-	type TableDefinition,
-	type TableDefinitions,
-	TableParseError,
 	type Tables,
 } from './document/attach-table.js';
-export {
-	attachTimeline,
-	type ContentType,
-	computeMidpoint,
-	generateInitialOrders,
-	parseSheetFromCsv,
-	populateFragmentFromText,
-	type RichTextEntry,
-	type SheetBinding,
-	type SheetEntry,
-	serializeSheetToCsv,
-	type TextEntry,
-	type Timeline,
-	type TimelineEntry,
-} from './document/attach-timeline/index.js';
+export { attachTimeline } from './document/attach-timeline/index.js';
 export { defineKv } from './document/define-kv.js';
 export { defineTable } from './document/define-table.js';
 export { docGuid } from './document/doc-guid.js';
 export {
 	type OpenWebSocket,
-	type SyncError,
-	SyncFailedError,
-	type SyncFailedReason,
 	type SyncStatus,
-	SyncSupervisorError,
 } from './document/internal/sync-supervisor.js';
-export {
-	KV_KEY,
-	type KvKey,
-	PRESENCE_KEY,
-	RPC_KEY,
-	TableKey,
-} from './document/keys.js';
 export { onLocalUpdate } from './document/on-local-update.js';
 export {
 	type Collaboration,
-	type OpenCollaborationConfig,
 	openCollaboration,
 } from './document/open-collaboration.js';
-export {
-	createPresenceSurface,
-	type PresenceEntry,
-	type PresenceSurface,
-} from './document/presence.js';
-export {
-	attachActionRunner,
-	type Call,
-	DispatchError,
-	type DispatchOptions,
-	dispatch,
-} from './document/rpc.js';
-export type { CombinedStandardSchema } from './document/standard-schema.js';
-export { websocketUrl } from './document/transport.js';
-export type {
-	KvEntry,
-	KvStoreChange,
-} from './document/y-keyvalue/observable-kv-store.js';
-export {
-	YKeyValueLww,
-	type YKeyValueLwwEntry,
-} from './document/y-keyvalue/y-keyvalue-lww.js';
-// ════════════════════════════════════════════════════════════════════════════
-// EPICENTER LINKS
-// ════════════════════════════════════════════════════════════════════════════
-
-export {
-	convertEpicenterLinksToWikilinks,
-	convertWikilinksToEpicenterLinks,
-	EPICENTER_LINK_RE,
-	type EpicenterLink,
-	isEpicenterLink,
-	makeEpicenterLink,
-	parseEpicenterLink,
-} from './links.js';
+export { type PresenceEntry } from './document/presence.js';
+export { DispatchError } from './document/rpc.js';
+export { syncRoomUrl, websocketUrl } from './document/transport.js';

--- a/packages/workspace/src/shared/actions.ts
+++ b/packages/workspace/src/shared/actions.ts
@@ -257,10 +257,7 @@ export function defineQuery<TInput extends TSchema, R>(
 ): Action<TInput, R, 'query'>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function defineQuery({ handler, ...rest }: any): Action {
-	return Object.assign(handler, {
-		type: 'query' as const,
-		...rest,
-	}) as unknown as Action;
+	return Object.assign(handler, { type: 'query' as const, ...rest });
 }
 
 /**
@@ -280,10 +277,7 @@ export function defineMutation<TInput extends TSchema, R>(
 ): Action<TInput, R, 'mutation'>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function defineMutation({ handler, ...rest }: any): Action {
-	return Object.assign(handler, {
-		type: 'mutation' as const,
-		...rest,
-	}) as unknown as Action;
+	return Object.assign(handler, { type: 'mutation' as const, ...rest });
 }
 
 /**

--- a/playground/opensidian-e2e/epicenter.config.ts
+++ b/playground/opensidian-e2e/epicenter.config.ts
@@ -19,24 +19,23 @@
  *   # Runs until Ctrl+C.
  *   bun run playground/opensidian-e2e/epicenter.config.ts
  *
- *   # Invoke the markdown.prepare mutation.
- *   epicenter run opensidian.markdown.prepare '{"directory":"./some/dir"}' \
+ *   # Invoke the markdown_prepare mutation.
+ *   epicenter run opensidian.markdown_prepare '{"directory":"./some/dir"}' \
  *     -C playground/opensidian-e2e
  */
 
 import { Database } from 'bun:sqlite';
 import { mkdirSync } from 'node:fs';
 import { join } from 'node:path';
-import {
-	createMachineAuth,
-	createMachineTokenGetter,
-} from '@epicenter/auth/node';
-import { createFileContentDoc } from '@epicenter/filesystem';
+import { createMachineAuthClient, requireIdentity } from '@epicenter/auth/node';
+import { fileContentDocGuid } from '@epicenter/filesystem';
 import {
 	attachEncryption,
-	attachSync,
+	attachTimeline,
 	createDisposableCache,
+	defineActions,
 	defineMutation,
+	openCollaboration,
 	websocketUrl,
 } from '@epicenter/workspace';
 import { defineConfig } from '@epicenter/workspace/daemon';
@@ -57,42 +56,17 @@ const MATERIALIZER_DIR = join(import.meta.dir, '.epicenter', 'materializer');
 mkdirSync(MATERIALIZER_DIR, { recursive: true });
 
 const WORKSPACE_ID = 'opensidian';
-const machineAuth = createMachineAuth();
-
-const { data: keys, error: keysError } =
-	await machineAuth.getActiveEncryptionKeys({ serverOrigin: SERVER_URL });
-if (keysError) throw keysError;
-if (!keys) {
-	throw new Error(
-		'[opensidian-playground] no active encryption keys. Run `epicenter auth login` first.',
-	);
-}
+const auth = await createMachineAuthClient();
 
 const ydoc = new Y.Doc({ guid: WORKSPACE_ID, gc: false });
-const encryption = attachEncryption(ydoc, { encryptionKeys: () => keys });
+const encryption = attachEncryption(ydoc, {
+	encryptionKeys: () => requireIdentity(auth).encryptionKeys,
+});
 const tables = encryption.attachTables(opensidianTables);
 const kv = encryption.attachKv({});
 
 const persistence = attachYjsLog(ydoc, {
 	filePath: epicenterPaths.persistence(WORKSPACE_ID),
-});
-
-const sync = attachSync(ydoc, {
-	url: websocketUrl(`${SERVER_URL}/workspaces/${ydoc.guid}`),
-	waitFor: Promise.resolve(),
-	// TODO(claude-review): `SyncAttachmentConfig` has no `getToken` field; the
-	// supported auth field is `bearerToken?: () => string | null`. Real apps use
-	// `bearerToken: () => auth.bearerToken` against an `AuthClient` from
-	// `createMachineAuthClient()`. This playground imports `createMachineAuth`
-	// and `createMachineTokenGetter` from `@epicenter/auth/node`, but neither
-	// export exists today (only `createMachineAuthClient` is exported). The
-	// correct shape for `createMachineTokenGetter`'s return cannot be determined
-	// because the function itself is gone. Rewire to `createMachineAuthClient`
-	// + `bearerToken: () => auth.bearerToken` once the intended API is decided.
-	getToken: createMachineTokenGetter({
-		serverOrigin: SERVER_URL,
-		machineAuth,
-	}),
 });
 
 /**
@@ -107,26 +81,57 @@ const CONTENT_DIR = join(
 	'content',
 );
 const fileContentDocs = createDisposableCache(
-	(fileId: string) =>
-		createFileContentDoc({
-			fileId: fileId as never,
-			workspaceId: WORKSPACE_ID,
-			filesTable: tables.files,
-			attachPersistence: (contentDoc) =>
-				attachYjsLog(contentDoc, {
-					filePath: join(CONTENT_DIR, `${contentDoc.guid}.db`),
-				}),
-		}),
+	(fileId: string) => {
+		const contentYdoc = new Y.Doc({
+			guid: fileContentDocGuid({
+				workspaceId: WORKSPACE_ID,
+				fileId: fileId as never,
+			}),
+			gc: false,
+		});
+		const contentPersistence = attachYjsLog(contentYdoc, {
+			filePath: join(CONTENT_DIR, `${contentYdoc.guid}.db`),
+		});
+		return {
+			ydoc: contentYdoc,
+			content: attachTimeline(contentYdoc),
+			persistence: contentPersistence,
+			[Symbol.dispose]() {
+				contentYdoc.destroy();
+			},
+		};
+	},
 	{ gcTime: 5_000 },
 );
 
 async function readContent(rowId: string): Promise<string | undefined> {
 	await using handle = fileContentDocs.open(rowId);
-	await handle.whenReady;
 	return handle.content.read();
 }
 
-const whenReady = Promise.all([Promise.resolve(), sync.whenConnected]);
+/**
+ * Scan a directory for `.md` files and inject a unique `id` into the YAML
+ * frontmatter of any file that doesn't already have one. Errors if duplicate
+ * IDs are detected across files.
+ */
+const actions = defineActions({
+	markdown_prepare: defineMutation({
+		title: 'Prepare Markdown Files',
+		description:
+			'Add unique IDs to markdown files missing them in YAML frontmatter',
+		input: Type.Object({ directory: Type.String() }),
+		handler: async ({ directory }) => prepareMarkdownFiles(directory),
+	}),
+});
+
+const collaboration = openCollaboration(ydoc, {
+	url: websocketUrl(`${SERVER_URL}/workspaces/${ydoc.guid}`),
+	openWebSocket: auth.openWebSocket,
+	replicaId: 'opensidian-playground-daemon',
+	actions,
+});
+
+const whenReady = collaboration.whenConnected;
 
 const markdown = attachMarkdownMaterializer(ydoc, {
 	dir: MARKDOWN_DIR,
@@ -169,52 +174,14 @@ const sqlite = attachSqliteMaterializer(ydoc, {
 	waitFor: whenReady,
 }).table(tables.files, { fts: ['name'] });
 
-/**
- * Scan a directory for `.md` files and inject a unique `id` into the YAML
- * frontmatter of any file that doesn't already have one. Errors if duplicate
- * IDs are detected across files.
- */
-const actions = {
-	markdown: {
-		prepare: defineMutation({
-			title: 'Prepare Markdown Files',
-			description:
-				'Add unique IDs to markdown files missing them in YAML frontmatter',
-			input: Type.Object({ directory: Type.String() }),
-			handler: async ({ directory }) => prepareMarkdownFiles(directory),
-		}),
-	},
-};
-// TODO(claude-review): `sync.attachPresence(...)` no longer exists on
-// `SyncAttachment` (only `attachRpc` remains). Presence/awareness moved to a
-// top-level `attachAwareness(ydoc, { schema, initial })` that must be created
-// BEFORE `attachSync` and passed in as `attachSync(ydoc, { awareness, ... })`
-// (see apps/opensidian/blocks/daemon-route.ts for the canonical
-// pattern). Migrating here requires reshuffling the file so awareness is
-// constructed before `sync` and updating the exported `presence` field below.
-// Commented out so the daemon runtime contract still typechecks; restore once
-// the surrounding structure is reworked.
-// const presence = sync.attachPresence({
-// 	peer: {
-// 		id: 'opensidian-playground-daemon',
-// 		name: 'Opensidian Playground Daemon',
-// 		platform: 'node',
-// 	},
-// });
-const rpc = sync.attachRpc(actions);
-
 export const opensidian = {
 	workspaceId: ydoc.guid,
 	whenReady,
 	actions,
-	sync,
-	// TODO(claude-review): restore `presence` once `attachAwareness` migration
-	// above is completed.
-	// presence,
-	rpc,
+	collaboration,
 	async [Symbol.asyncDispose]() {
 		ydoc.destroy();
-		await sync.whenDisposed;
+		await collaboration.whenDisposed;
 	},
 	// Extras for direct script use, not part of the hosted daemon runtime contract.
 	id: WORKSPACE_ID,

--- a/playground/opensidian-e2e/push-from-markdown.ts
+++ b/playground/opensidian-e2e/push-from-markdown.ts
@@ -13,7 +13,7 @@ import type { FileRow } from '@epicenter/filesystem';
 import {
 	convertWikilinksToEpicenterLinks,
 	makeEpicenterLink,
-} from '@epicenter/workspace';
+} from '@epicenter/workspace/links';
 import { parseMarkdownFile } from '@epicenter/workspace/document/materializer/markdown';
 import type { opensidian } from './epicenter.config';
 

--- a/playground/tab-manager-e2e/epicenter.config.ts
+++ b/playground/tab-manager-e2e/epicenter.config.ts
@@ -19,17 +19,12 @@
  */
 
 import { join } from 'node:path';
-import {
-	createMachineAuth,
-	createMachineTokenGetter,
-} from '@epicenter/auth/node';
-import {
-	tabManagerAwarenessDefs,
-	tabManagerTables,
-} from '@epicenter/tab-manager';
+import { createMachineAuthClient, requireIdentity } from '@epicenter/auth/node';
+import { tabManagerTables } from '@epicenter/tab-manager';
 import {
 	attachEncryption,
-	attachSync,
+	defineActions,
+	openCollaboration,
 	websocketUrl,
 } from '@epicenter/workspace';
 import { defineConfig } from '@epicenter/workspace/daemon';
@@ -44,19 +39,12 @@ const SERVER_URL = 'https://api.epicenter.so';
 const MARKDOWN_DIR = join(import.meta.dir, 'data');
 const WORKSPACE_ID = 'epicenter.tab-manager';
 
-const machineAuth = createMachineAuth();
-
-const { data: keys, error: keysError } =
-	await machineAuth.getActiveEncryptionKeys({ serverOrigin: SERVER_URL });
-if (keysError) throw keysError;
-if (!keys) {
-	throw new Error(
-		'[tab-manager-playground] no active encryption keys. Run `epicenter auth login` first.',
-	);
-}
+const auth = await createMachineAuthClient();
 
 const ydoc = new Y.Doc({ guid: WORKSPACE_ID, gc: false });
-const encryption = attachEncryption(ydoc, { encryptionKeys: () => keys });
+const encryption = attachEncryption(ydoc, {
+	encryptionKeys: () => requireIdentity(auth).encryptionKeys,
+});
 const tables = encryption.attachTables(tabManagerTables);
 // Empty kv: tabManager has no KV definitions, but `.kv()` on the materializer
 // serializes the shared kv store. Keep an empty encrypted kv attached so the
@@ -67,55 +55,40 @@ const persistence = attachYjsLog(ydoc, {
 	filePath: epicenterPaths.persistence(WORKSPACE_ID),
 });
 
-const sync = attachSync(ydoc, {
+const actions = defineActions({});
+
+const collaboration = openCollaboration(ydoc, {
 	url: websocketUrl(`${SERVER_URL}/workspaces/${ydoc.guid}`),
-	// Gate connection on local hydrate so the handshake only exchanges the
-	// delta, not the whole document.
-	waitFor: Promise.resolve(),
-	getToken: createMachineTokenGetter({
-		serverOrigin: SERVER_URL,
-		machineAuth,
-	}),
+	openWebSocket: auth.openWebSocket,
+	replicaId: 'tab-manager-playground-daemon',
+	actions,
 });
 
-const whenReady = Promise.all([Promise.resolve(), sync.whenConnected]);
+const whenReady = collaboration.whenConnected;
 
-const markdown = attachMarkdownMaterializer(
-	{ tables, kv, whenReady },
-	{ dir: MARKDOWN_DIR },
-)
-	.table('savedTabs', { filename: slugFilename('title') })
-	.table('bookmarks', { filename: slugFilename('title') })
-	.table('devices')
-	.kv();
-
-const actions = {};
-const presence = sync.attachPresence({
-	peer: {
-		id: 'tab-manager-playground-daemon',
-		name: 'Tab Manager Playground Daemon',
-		platform: 'node',
-	},
-});
-const rpc = sync.attachRpc(actions);
+const markdown = attachMarkdownMaterializer(ydoc, {
+	dir: MARKDOWN_DIR,
+	waitFor: whenReady,
+})
+	.table(tables.savedTabs, { filename: slugFilename('title') })
+	.table(tables.bookmarks, { filename: slugFilename('title') })
+	.table(tables.devices)
+	.kv(kv);
 
 export const tabManager = {
 	workspaceId: ydoc.guid,
 	whenReady,
 	actions,
-	sync,
-	presence,
-	rpc,
+	collaboration,
 	async [Symbol.asyncDispose]() {
 		ydoc.destroy();
-		await sync.whenDisposed;
+		await collaboration.whenDisposed;
 	},
 	// Extras for direct script use, not part of the hosted daemon runtime contract.
 	id: WORKSPACE_ID,
 	ydoc,
 	tables,
 	kv,
-	awarenessDefs: tabManagerAwarenessDefs,
 	encryption,
 	persistence,
 	markdown,

--- a/specs/20260512T234944-source-installed-app-runtime-vision.md
+++ b/specs/20260512T234944-source-installed-app-runtime-vision.md
@@ -1,0 +1,637 @@
+# Source Installed App Runtime Vision
+
+**Date**: 2026-05-12
+**Status**: Vision split for implementation
+**Author**: AI-assisted
+
+## Overview
+
+Epicenter should let users install readable source apps, review or edit their UI, and run those apps inside the Epicenter desktop shell. The first runtime should be simple: a trusted source-installed SPA runs in a Tauri webview and calls a typed Epicenter bridge backed by Rust commands.
+
+Actions, scripts, peer invocation, Bun, and WASM still matter, but they should come after the SPA bridge proves the product shape. Phase 1 should not require `actions.ts`, a handler context object, or a Bun action runtime.
+
+## One Sentence
+
+```txt
+Epicenter apps are source-installed SPAs that run in a trusted Tauri webview and call typed Epicenter commands.
+```
+
+## Execution Note
+
+Current status: this document is still live as a product vision, but it is not directly executable as one implementation wave. The current code already settled two adjacent foundations that this vision must respect: workspace actions are flat `defineActions({...})` registries keyed by snake_case strings, and remote action dispatch now rides Yjs state through `collab.dispatch(action, input, { to: connId, signal })`. Those choices are the source of truth for any later script, peer, or action lane.
+
+Implemented now: this pass creates a smaller follow-up spec for the next concrete slice, `specs/20260514T013918-source-app-manifest-bridge-slice.md`. That slice defines the source app manifest and typed invoke bridge contract only. It does not load apps, add a marketplace, introduce a Bun action runtime, or rewrite existing apps.
+
+Out of scope now: no broad public packaging work across all apps, no Tauri webview loader, no Rust command implementation, no action runtime, no handler context object, no peer or worker invocation, and no changes to the current `rpc-on-yjs-state` or `defineActions` behavior.
+
+## Execution Checklist
+
+- [x] Read the full vision and confirmed it is not directly executable as one implementation wave.
+- [x] Inspected current actions, RPC, package layout, and Whispering Tauri invoke usage.
+- [x] Preserved current `rpc-on-yjs-state` dispatch behavior and `defineActions` snake_case behavior as source of truth.
+- [x] Created the next concrete implementation slice in `specs/20260514T013918-source-app-manifest-bridge-slice.md`.
+- [x] Deferred app loading, Rust commands, permission UI, Bun actions, handler contexts, peer invocation, and marketplace work.
+
+## Current State
+
+Epicenter already has the pieces for this direction:
+
+```txt
+apps/whispering
+  Svelte UI
+  Tauri invoke calls
+  Rust native commands
+  CPAL audio recording
+  transcription providers
+
+packages/workspace
+  local-first workspace data
+  Yjs documents
+  action discovery
+  daemon action dispatch
+  sync RPC
+
+packages/cli
+  loads epicenter.config.ts
+  invokes registered actions through /run
+```
+
+Whispering is the clearest prototype:
+
+```txt
+Svelte UI
+  -> Tauri invoke
+  -> Rust command
+  -> CPAL recorder
+  -> audio asset
+  -> transcription
+```
+
+That model is already understandable. The app UI lives in the webview. Native effects live in Rust. The bridge between them is Tauri IPC.
+
+## Desired State
+
+Installed apps should start as source bundles:
+
+```txt
+app/
+  app.json
+  ui/
+```
+
+Optional future additions:
+
+```txt
+app/
+  actions.ts  later, when reusable invocation is needed
+  wasm/       later, for sandboxed computation
+```
+
+The installed SPA can call Epicenter through a typed bridge:
+
+```ts
+import { epicenter } from "@epicenter/app";
+
+const recording = await epicenter.audio.record({
+	deviceId,
+});
+
+const transcript = await epicenter.transcription.run({
+	audioAssetId: recording.assetId,
+});
+
+await epicenter.documents.append({
+	documentId,
+	text: transcript.text,
+});
+```
+
+Under the hood, the bridge can be a thin wrapper around Tauri `invoke`:
+
+```ts
+import { invoke } from "@tauri-apps/api/core";
+
+export const epicenter = {
+	audio: {
+		record(input: AudioRecordInput) {
+			return invoke<AudioRecordResult>("audio_record", input);
+		},
+	},
+	documents: {
+		append(input: DocumentAppendInput) {
+			return invoke<DocumentAppendResult>("documents_append", input);
+		},
+	},
+};
+```
+
+The app can also call `invoke` directly where that is clearer:
+
+```ts
+await invoke("window_set_title", { title: "Whispering" });
+```
+
+The best-practice default is the typed bridge. Direct `invoke` is acceptable for one-off local UI behavior, but the bridge is better for commands that apps will call repeatedly.
+
+## Requirements
+
+### Product Requirements
+
+| Requirement | Meaning |
+| --- | --- |
+| Source install | Users receive readable app source, not an opaque binary or package only. |
+| SPA first | The first installable app shape is a single page app copied into Epicenter. |
+| Trusted desktop shell | The SPA runs inside an Epicenter-owned Tauri webview. |
+| Typed command bridge | Apps call Epicenter through typed TypeScript functions backed by Tauri commands. |
+| Native effects in Rust | Audio, windows, dialogs, tray, filesystem grants, and native lifecycle stay in Rust/Tauri. |
+| User review | Installing or enabling an app is an explicit user decision. |
+| Scripts separate | Scripts are user-authored or agent-authored workflows that call available commands or future actions. |
+| Actions later | Reusable actions are extracted when scripts, agents, peers, or cloud execution need them. |
+| Personal apps first | The first trust model is local and personal, not a public marketplace. |
+
+### Technical Requirements
+
+| Requirement | Meaning |
+| --- | --- |
+| App manifest | `app.json` names the app, entry point, and requested command families. |
+| Tauri bridge | The SPA can call Tauri commands through `@tauri-apps/api/core` or a typed wrapper. |
+| Typed client package | A small TypeScript package exposes `epicenter.audio.record`, `epicenter.documents.append`, and similar methods. |
+| Rust command ownership | Rust owns command implementation, native permissions, and OS integration. |
+| Serializable IPC | Inputs and outputs should stay serializable across Tauri IPC. |
+| Shared schemas | Command inputs and outputs should be typed from the owning command contract where practical. |
+| No Bun required | Phase 1 does not need Bun to load app actions. |
+| No handler context required | Phase 1 does not pass a special context object into app code. |
+
+## App Bundle Shape
+
+### Manifest
+
+```json
+{
+	"id": "whispering",
+	"name": "Whispering",
+	"entry": "./ui/index.html",
+	"permissions": [
+		"workspace:read",
+		"documents:write",
+		"assets:write",
+		"audio:record",
+		"window:manage"
+	]
+}
+```
+
+### UI Source
+
+```txt
+ui/
+  index.html
+  src/
+    App.svelte
+    lib/
+      recorder.ts
+      documents.ts
+```
+
+The SPA can import the bridge from a stable Epicenter package:
+
+```ts
+import { epicenter } from "@epicenter/app";
+```
+
+or, for command-specific cases:
+
+```ts
+import { invoke } from "@tauri-apps/api/core";
+```
+
+## Bridge Design
+
+The bridge should be boring. It should name the product operation and hide command string details.
+
+```ts
+export function createEpicenterBridge({ invoke }: EpicenterBridgeOptions) {
+	return {
+		audio: {
+			record(input: AudioRecordInput) {
+				return invoke<AudioRecordResult>("audio_record", input);
+			},
+		},
+		transcription: {
+			run(input: TranscriptionRunInput) {
+				return invoke<TranscriptionRunResult>("transcription_run", input);
+			},
+		},
+		documents: {
+			append(input: DocumentAppendInput) {
+				return invoke<DocumentAppendResult>("documents_append", input);
+			},
+		},
+		window: {
+			resize(input: WindowResizeInput) {
+				return invoke<void>("window_resize", input);
+			},
+		},
+	};
+}
+```
+
+The public app code stays simple:
+
+```ts
+const recording = await epicenter.audio.record({ deviceId });
+const transcript = await epicenter.transcription.run({
+	audioAssetId: recording.assetId,
+});
+await epicenter.documents.append({
+	documentId,
+	text: transcript.text,
+});
+```
+
+The bridge gives us the good parts of direct `invoke` without spreading raw command names through every installed app.
+
+## Best-Practice Rules
+
+```txt
+Use the typed bridge for repeated product operations.
+Use direct invoke for small, local, UI-native behavior when a wrapper adds no clarity.
+Keep command inputs and outputs serializable.
+Keep Rust command names stable and boring.
+Keep native effects in Rust/Tauri.
+Do not introduce Bun, handler context objects, or actions until a caller outside the SPA needs the operation.
+```
+
+Good direct `invoke` candidates:
+
+```txt
+set current window title
+resize this window
+open a native dialog
+toggle always-on-top
+subscribe to a local native event
+```
+
+Good bridge candidates:
+
+```txt
+record audio
+write an asset
+append to a document
+run transcription
+read workspace state
+export a project
+```
+
+Good future action candidates:
+
+```txt
+operations a script should call
+operations an agent should call
+operations another device should call
+operations that should run in a daemon, worker, or synced peer
+```
+
+## Future Actions
+
+Actions are still useful, but they are no longer the first runtime primitive.
+
+The extraction rule is:
+
+```txt
+Start with SPA plus typed bridge.
+When an operation needs to be called outside the SPA, promote it into an action.
+```
+
+Future action shape:
+
+```ts
+export const actions = {
+	recordAndAppend: defineMutation({
+		input: RecordAndAppendInput,
+		handler: async (input) => {
+			const recording = await epicenter.audio.record({
+				deviceId: input.deviceId,
+			});
+
+			const transcript = await epicenter.transcription.run({
+				audioAssetId: recording.assetId,
+			});
+
+			return epicenter.documents.append({
+				documentId: input.documentId,
+				text: transcript.text,
+			});
+		},
+	}),
+};
+```
+
+If this action later needs to run outside the SPA, the runtime can inject or import an equivalent bridge for that environment. The action should depend on the same product operations, not raw platform details.
+
+## Runtime Lanes
+
+```txt
+Lane 1: Source-installed SPA
+  Current default.
+  Svelte or other frontend source copied into Epicenter.
+  Runs in Tauri webview.
+  Calls typed bridge or direct invoke.
+
+Lane 2: User or agent scripts
+  Dynamic workflows written after install.
+  Can call the typed bridge locally.
+  Can call future actions when action discovery exists.
+
+Lane 3: Reusable actions
+  Extracted when behavior must be callable by scripts, agents, CLI, peers, or workers.
+  Uses defineQuery / defineMutation if that remains the best local primitive.
+
+Lane 4: WASM extensions
+  Later sandbox lane for parsers, transforms, importers, exporters, and policy checks.
+
+Lane 5: Peer or worker invocation
+  Later distributed lane.
+  Uses serializable actions, not direct Tauri commands.
+```
+
+## Security Position
+
+Readable source plus review is useful. It is not sandboxing.
+
+The honest model for phase 1 is:
+
+```txt
+If the SPA runs in the trusted Epicenter webview, the user is trusting that source.
+If the SPA calls a Tauri command, the Rust command owns the native effect.
+If the SPA uses direct invoke, the command surface must still be reviewed.
+```
+
+That is acceptable for personal apps. A public marketplace would need stronger review, signing, provenance, update diffs, and permission UX.
+
+## Design Decisions
+
+| Decision | Class | Choice | Rationale |
+| --- | --- | --- | --- |
+| First runtime primitive | 2 coherence | Source-installed SPA | This matches the actual desktop product shape and Whispering precedent. |
+| Native invocation | 2 coherence | Tauri commands | The SPA already runs in a Tauri webview, and Rust owns native effects. |
+| App author API | 3 taste | Typed bridge over raw invoke by default | It keeps app code readable and command names centralized. |
+| Direct invoke | 3 taste | Allowed for local UI behavior | Trusted source apps should not be forced through ceremony for tiny native calls. |
+| Bun action runtime | Deferred | Not in phase 1 | It adds a second execution environment before the SPA bridge proves the model. |
+| Handler context object | 2 coherence | Not needed in phase 1 | The SPA can import or receive a bridge directly. |
+| Reusable actions | Deferred | Extract later | They become useful when behavior needs scripts, agents, peers, CLI, or workers. |
+| WASM | Deferred | Later sandbox lane | WASM is good for computation, not the first desktop SPA bridge. |
+| Marketplace | Deferred | Personal apps first | Marketplace trust needs signing, provenance, review, and stronger permission UX. |
+
+## Radical Options Considered
+
+### Option A: Start With Bun Actions
+
+```txt
+App ships actions.ts.
+Bun loads action handlers.
+SPA calls those actions.
+Actions call native capabilities.
+```
+
+Why not:
+
+```txt
+It adds another runtime before we need one.
+The first app already lives in a Tauri webview.
+The SPA can call Rust directly today.
+```
+
+Verdict:
+
+```txt
+Do not start here.
+Promote operations into actions only when non-SPA callers need them.
+```
+
+### Option B: Force Every Native Call Through A Wrapper
+
+```txt
+SPA cannot call invoke directly.
+Every native behavior needs a typed bridge method first.
+```
+
+Why not:
+
+```txt
+Some UI-native calls are too small to justify a wrapper.
+Trusted audited source does not need fake safety ceremony.
+```
+
+Verdict:
+
+```txt
+Prefer the bridge, but allow direct invoke where it is clearer.
+```
+
+### Option C: Raw Invoke Everywhere
+
+```txt
+SPA imports invoke and calls Rust command names directly everywhere.
+```
+
+Why not:
+
+```txt
+Command strings spread through app source.
+Repeated operations lose a stable typed product name.
+Future actions and scripts have less obvious operations to reuse.
+```
+
+Verdict:
+
+```txt
+Use raw invoke as an escape hatch.
+Use the typed bridge for repeated product operations.
+```
+
+### Option D: App Backend Servers
+
+```txt
+Every installed app runs its own local backend server.
+```
+
+Why not:
+
+```txt
+Ports, lifecycle, auth, permissions, logs, crashes, and upgrades multiply per app.
+The product becomes hard to explain.
+```
+
+Verdict:
+
+```txt
+Do not make backend servers the primitive.
+The first primitive is a trusted SPA in the Epicenter webview.
+```
+
+## Phased Vision
+
+### Phase 1: Trusted Source-Installed SPAs
+
+- [ ] **1.1** Define an `app.json` manifest with id, name, entry, and permissions.
+- [ ] **1.2** Define an install location for readable app source.
+- [ ] **1.3** Load the installed SPA into an Epicenter Tauri webview.
+- [ ] **1.4** Expose a minimal typed bridge package to installed SPAs.
+- [ ] **1.5** Back the first bridge methods with Rust Tauri commands.
+- [ ] **1.6** Allow direct `invoke` for small local UI behavior.
+- [ ] **1.7** Show install review: files changed, manifest, requested permissions.
+- [ ] **1.8** Prove the path with a Whispering-shaped source app.
+
+### Phase 2: Bridge Coverage
+
+- [ ] **2.1** Add `epicenter.documents`.
+- [ ] **2.2** Add `epicenter.assets`.
+- [ ] **2.3** Add `epicenter.window`.
+- [ ] **2.4** Add `epicenter.audio` backed by Rust/Tauri for recording.
+- [ ] **2.5** Add `epicenter.transcription`.
+- [ ] **2.6** Decide which operations stay direct invoke only.
+
+### Phase 3: Dynamic Scripts
+
+- [ ] **3.1** Add a user-authored script entry point convention.
+- [ ] **3.2** Let local scripts call the typed bridge where possible.
+- [ ] **3.3** Keep scripts user-invoked by default.
+- [ ] **3.4** Add an audit view for script source and granted permissions.
+
+### Phase 4: Reusable Actions
+
+- [ ] **4.1** Identify operations that need non-SPA callers.
+- [ ] **4.2** Define the smallest action shape for those operations.
+- [ ] **4.3** Keep action inputs and outputs serializable.
+- [ ] **4.4** Reuse bridge-level product operations from actions.
+- [ ] **4.5** Register actions for scripts, agents, CLI, peers, or workers.
+
+### Phase 5: Peer And Worker Invocation
+
+- [ ] **5.1** Advertise available actions through peer awareness.
+- [ ] **5.2** Route non-local calls through sync RPC or worker RPC.
+- [ ] **5.3** Represent files and streams as asset IDs, URLs, or path grants.
+- [ ] **5.4** Keep transport details out of action definitions unless proven necessary.
+
+### Phase 6: Marketplace Readiness
+
+- [ ] **6.1** Add source provenance and signatures.
+- [ ] **6.2** Add stronger permission UX.
+- [ ] **6.3** Add install/update diffs.
+- [ ] **6.4** Add app trust levels.
+- [ ] **6.5** Add review automation that can summarize what an app can do.
+
+## What This Refuses For Now
+
+```txt
+No Bun action runtime in phase 1.
+No required actions.ts in phase 1.
+No handler context object in phase 1.
+No generic per-app backend servers as the primary primitive.
+No silent background execution by default.
+No marketplace trust story in phase 1.
+No requirement that every app compile to WASM.
+No requirement that every app be a separate OS application.
+No requirement that every installed app include script source.
+No default REST endpoint for every operation.
+No transport matrix until reusable actions actually need one.
+```
+
+## Open Questions
+
+1. Should installed app source live inside each workspace, inside a global Epicenter app directory, or both?
+2. What is the package name for the typed SPA bridge: `@epicenter/app`, `@epicenter/bridge`, or something else?
+3. Should the bridge be globally injected into the webview, imported as a package, or both?
+4. Which commands should be wrapped immediately, and which should stay direct `invoke`?
+5. How should TypeScript command input/output types be derived from Rust command contracts?
+6. What permission review UI is enough for personal source apps?
+7. What should happen when installed source changes while the app is running?
+8. Should app updates preserve local edits, or require an explicit merge flow?
+9. What is the smallest useful Whispering extraction that proves the model?
+10. When should an operation graduate from bridge method to reusable action?
+
+## Continuation Prompt
+
+Use this prompt to continue the design:
+
+```txt
+We are designing Epicenter's source-installed app runtime. Read specs/20260512T234944-source-installed-app-runtime-vision.md first.
+
+The current thesis is:
+
+  Epicenter apps are source-installed SPAs that run in a trusted Tauri webview and call typed Epicenter commands.
+
+Please continue the architecture conversation from that thesis. The simplified preferred shape is:
+
+  - Phase 1 is SPA-first, not actions-first.
+  - Installed app source is app.json plus ui/.
+  - The SPA runs in an Epicenter-owned Tauri webview.
+  - The SPA can call Tauri invoke directly.
+  - Repeated product operations should use a typed bridge like epicenter.audio.record.
+  - Rust/Tauri owns native effects.
+  - Bun, actions.ts, handler context objects, peer invocation, worker invocation, and WASM are deferred.
+  - Actions are introduced only when scripts, agents, CLI, peers, or workers need to call the same behavior outside the SPA.
+
+Do not reintroduce a handler context object unless you can show why direct import or typed invoke fails. Do not make per-app backend servers the primitive. Do not require a Bun action runtime in phase 1.
+
+Help refine:
+
+  1. the app manifest,
+  2. the typed bridge package,
+  3. direct invoke versus bridge method rules,
+  4. Rust command naming and typing,
+  5. the install/review flow,
+  6. the smallest Whispering-shaped prototype that proves the design.
+```
+
+## Bridge Best-Practices Prompt
+
+Use this prompt to pressure-test implementation details:
+
+```txt
+We are designing the TypeScript bridge for trusted source-installed SPAs in Epicenter. Read specs/20260512T234944-source-installed-app-runtime-vision.md first.
+
+Apply the radical-options skill. Start from this product sentence:
+
+  Installed SPAs call typed Epicenter commands. The bridge is a convenience over Tauri invoke, not a new runtime.
+
+Please simplify the bridge design before implementation.
+
+Answer in this shape:
+
+Current path:
+  What complexity would we introduce if every native operation became a layered service, action, handler context object, and transport adapter?
+
+Friction:
+  Which layers are not needed for a trusted same-device SPA?
+
+Radical option:
+  What is the smallest typed invoke wrapper that still gives app authors good ergonomics?
+
+Deletion prize:
+  What concepts disappear if phase 1 is only SPA plus Tauri bridge?
+
+User loss:
+  What real behavior is lost by deferring Bun actions and peer invocation?
+
+Decision:
+  Pick the bridge shape and explain it in one sentence.
+
+Constraints:
+  - Same-device SPAs must be able to call Tauri/Rust without cloud.
+  - Direct invoke is allowed for trusted audited source.
+  - Repeated product operations should have typed bridge methods.
+  - Command inputs and outputs must be serializable.
+  - Rust owns native effects.
+  - No handler context object in phase 1.
+
+End with the smallest prototype:
+
+  SPA button
+    -> epicenter.audio.record
+    -> Rust CPAL command
+    -> assetId
+    -> epicenter.transcription.run
+    -> epicenter.documents.append
+```

--- a/specs/20260513T105808-tauri-specta-bindings.md
+++ b/specs/20260513T105808-tauri-specta-bindings.md
@@ -1,0 +1,345 @@
+# Tauri Specta Bindings
+
+**Date**: 2026-05-13
+**Status**: Draft
+**Author**: Codex
+
+## One-Sentence Test
+
+Whispering should replace raw stringly Tauri `invoke(...)` calls with checked-in `tauri-specta` generated bindings so Rust commands, TypeScript call sites, and IPC payload types fail together instead of drifting apart.
+
+## Overview
+
+This spec proposes adopting `tauri-specta` v2 for the Whispering Tauri boundary. The immediate goal is typed command wrappers for `apps/whispering`; the broader goal is a repeatable convention for any future Tauri surface in the monorepo.
+
+This is a planning document. It does not implement the migration.
+
+## Motivation
+
+### Current State
+
+Whispering registers commands through Tauri's generated handler:
+
+```rust
+let builder = builder.invoke_handler(tauri::generate_handler![
+    write_text,
+    simulate_enter_keystroke,
+    get_current_recording_id,
+    enumerate_recording_devices,
+    init_recording_session,
+    close_recording_session,
+    start_recording,
+    stop_recording,
+    cancel_recording,
+    transcribe_audio_whisper,
+    transcribe_audio_parakeet,
+    transcribe_audio_moonshine,
+    send_sigint,
+    execute_command,
+    spawn_command,
+    read_markdown_files,
+    count_markdown_files,
+    delete_files_in_directory,
+    write_markdown_files,
+]);
+```
+
+Frontend code calls those commands by string:
+
+```ts
+const result = await invoke<ChildProcess<string>>('execute_command', {
+	command,
+});
+```
+
+Some services wrap raw `invoke` with `tryAsync`; others expect an application-level `Result` shape:
+
+```ts
+const { data: recordingId, error: getRecorderStateError } = await invoke<
+	string | null
+>('get_current_recording_id');
+```
+
+That creates problems:
+
+1. **Command names are untyped**: Renaming a Rust command can leave stale TypeScript strings behind.
+2. **Arguments are manually mirrored**: TypeScript object keys must match Rust parameter names, but there is no generated contract.
+3. **Return types are assertions**: `invoke<T>` trusts the caller. It does not prove Rust actually returns `T`.
+4. **Result semantics are inconsistent**: Raw Tauri rejections, `wellcrafted/result`, and generated `Result<T, E>` wrappers can look similar at the call site while behaving differently.
+5. **Migration pressure grows with command count**: Whispering already has recorder, transcription, command execution, markdown, text insertion, and shutdown commands.
+
+### Desired State
+
+Rust owns the command contract:
+
+```rust
+#[tauri::command]
+#[specta::specta]
+async fn execute_command(command: String) -> Result<CommandOutput, String> {
+    // ...
+}
+```
+
+Generated TypeScript owns the frontend command client:
+
+```ts
+import { commands } from '$lib/tauri/bindings.gen';
+
+const result = await commands.executeCommand(command);
+```
+
+Generated files are checked in. CI regenerates them and fails if the working tree changes.
+
+## Research Findings
+
+Sources checked:
+
+```txt
+https://github.com/specta-rs/specta
+https://github.com/specta-rs/tauri-specta
+https://docs.rs/specta/latest/specta/
+https://docs.rs/tauri-specta/latest/tauri_specta/
+https://docs.rs/ts-rs/latest/ts_rs/
+https://github.com/fastrepl/anarlog
+```
+
+### Anarlog Uses Tauri Specta
+
+The `fastrepl/anarlog` repository uses `tauri-specta`, `specta`, and `specta-typescript` for Tauri command bindings.
+
+Their app-level pattern:
+
+```rust
+tauri_specta::Builder::<R>::new()
+    .commands(tauri_specta::collect_commands![...])
+    .error_handling(tauri_specta::ErrorHandlingMode::Result)
+```
+
+They mount the generated invoke handler:
+
+```rust
+.invoke_handler(specta_builder.invoke_handler())
+```
+
+They generate `apps/desktop/src/types/tauri.gen.ts` from a Rust test named `export_types`. Their custom Tauri plugins repeat the same pattern and emit `plugins/<plugin>/js/bindings.gen.ts`.
+
+**Key finding**: A serious Tauri v2 app is already using `tauri-specta` for checked-in generated command clients.
+
+**Implication**: The pattern is not theoretical. It works in a large command surface with plugins, events, and generated TypeScript.
+
+### Specta v2 Is Active But Not Stable
+
+As of 2026-05-13, crates.io reports:
+
+```txt
+specta          2.0.0-rc.25
+tauri-specta    2.0.0-rc.25
+specta-typescript 0.0.12
+```
+
+GitHub activity checked on 2026-05-13:
+
+```txt
+specta-rs/specta
+  stars: 582
+  open issues: 16
+  pushed_at: 2026-05-13T04:34:43Z
+
+specta-rs/tauri-specta
+  stars: 715
+  open issues: 27
+  pushed_at: 2026-05-13T03:05:47Z
+```
+
+Recent Specta commits include fixes for serde enum TypeScript rendering. That is good maintenance signal and also a reminder that the v2 line is still hardening.
+
+**Key finding**: Specta v2 is the active line for Tauri v2, but it is still an RC line.
+
+**Implication**: We can use it, but we should pin exact versions and make generated output reproducible.
+
+### Alternatives
+
+| Option | Fit | Stability | Notes |
+| --- | --- | --- | --- |
+| `tauri-specta` v2 | Best Tauri v2 command fit | Medium | Generates command wrappers and can support events. Still RC-line. |
+| `ts-rs` | Good DTO exporter | High | Mature for shared types, but does not generate Tauri command clients. |
+| `tauri-typegen` | Interesting command generator | Low to medium | Can scan commands and generate TypeScript, with optional Zod. Smaller ecosystem. |
+| `TauRPC` | Strong RPC abstraction | Medium | More opinionated than normal Tauri commands. |
+| `rspc` | Full router/RPC layer | Medium | Useful if the IPC boundary becomes a router. Too much for the current need. |
+| Manual `invoke<T>` | Simple | High | Leaves command names and arguments stringly typed. |
+
+**Key finding**: `ts-rs` is more mature, but it solves only the shared type problem. `tauri-specta` solves the command boundary problem.
+
+**Implication**: Use `tauri-specta` for the Tauri IPC surface. Do not add `ts-rs` unless a separate non-Tauri DTO export problem appears.
+
+## Design Decisions
+
+| Decision | Class | Choice | Rationale |
+| --- | --- | --- | --- |
+| Binding tool | 1 evidence | `tauri-specta` v2 | It is the active Tauri v2 binding line and generates command wrappers, not just DTOs. |
+| Version policy | 1 evidence | Pin exact RC versions | The crates are still `2.0.0-rc.*`; exact pins prevent surprise generator changes. |
+| Generated output | 2 coherence | Check in generated TypeScript | Generated IPC clients are part of the contract and should be reviewable. |
+| Generation trigger | 2 coherence | Rust test plus package script | The Anarlog pattern is simple and keeps generation close to command registration. |
+| Migration scope | 2 coherence | Start with `apps/whispering` only | It is the only current Tauri app with raw app commands in this repo. |
+| Frontend import location | 3 taste | `$lib/tauri/bindings.gen` | Keeps generated app bindings near other Whispering frontend code. |
+| Result handling | Deferred | Decide during implementation | We need to inspect each command return shape and choose whether to use generated `Result<T, E>` wrappers or preserve existing `tryAsync` wrappers around thrown errors. |
+| Event bindings | Deferred | Do not migrate events in phase 1 | The current problem is command drift. Tauri event imports can stay direct until there is a typed event need. |
+
+## Architecture
+
+### Before
+
+```txt
+Rust command
+  #[tauri::command]
+        |
+        v
+tauri::generate_handler![command_name]
+        |
+        v
+Frontend
+  invoke<ClaimedReturn>('command_name', { claimedArg })
+```
+
+The command name, argument names, and return type are repeated by hand.
+
+### After
+
+```txt
+Rust command
+  #[tauri::command]
+  #[specta::specta]
+        |
+        v
+make_specta_builder()
+  collect_commands![command_name]
+        |
+        +-- runtime: specta_builder.invoke_handler()
+        |
+        +-- codegen: export_types test
+                 |
+                 v
+          src/lib/tauri/bindings.gen.ts
+                 |
+                 v
+          Frontend
+            commands.commandName(...)
+```
+
+The Rust signature becomes the source of truth.
+
+### File Shape
+
+```txt
+apps/whispering
+  src-tauri
+    Cargo.toml
+    src
+      lib.rs
+      recorder/commands.rs
+      transcription/mod.rs
+      command.rs
+      markdown.rs
+
+  src
+    lib
+      tauri
+        bindings.gen.ts
+        commands.ts
+```
+
+`bindings.gen.ts` is generated. `commands.ts` is optional, handwritten, and can adapt generated command results into existing app service conventions if that keeps the first migration smaller.
+
+## Implementation Plan
+
+### Phase 1: Prove Generation Without Migrating Call Sites
+
+- [ ] **1.1** Add exact pinned Rust dependencies in `apps/whispering/src-tauri/Cargo.toml`: `specta`, `specta-typescript`, and `tauri-specta` with `derive` and `typescript`.
+- [ ] **1.2** Enable the Tauri `specta` feature if required by the selected `tauri-specta` version.
+- [ ] **1.3** Add `#[specta::specta]` to each app command currently registered in `tauri::generate_handler!`.
+- [ ] **1.4** Create `make_specta_builder<R: tauri::Runtime>()`.
+- [ ] **1.5** Add an `export_types` Rust test that writes `../src/lib/tauri/bindings.gen.ts`.
+- [ ] **1.6** Run the export test and commit the generated file.
+- [ ] **1.7** Keep `tauri::generate_handler!` unchanged until generated output is verified.
+
+### Phase 2: Switch Runtime Registration
+
+- [ ] **2.1** Replace `tauri::generate_handler![...]` with `specta_builder.invoke_handler()`.
+- [ ] **2.2** Confirm the Tauri app still starts.
+- [ ] **2.3** Run command smoke checks for recorder device enumeration, markdown file operations, command execution, and one local transcription path where feasible.
+
+### Phase 3: Migrate Frontend Call Sites
+
+- [ ] **3.1** Replace direct `invoke` calls in desktop service modules with generated `commands.*` calls.
+- [ ] **3.2** Keep non-command Tauri APIs direct: path, fs plugin, shell plugin types, window, event, tray, menu, and updater APIs do not move through generated app bindings.
+- [ ] **3.3** Remove hand-written return type assertions that duplicate generated types.
+- [ ] **3.4** Add or update service tests where command result handling changes.
+
+### Phase 4: CI And Guardrails
+
+- [ ] **4.1** Add an app script such as `bindings:tauri`.
+- [ ] **4.2** Add a root or app check that regenerates bindings and fails on diff.
+- [ ] **4.3** Document the command authoring rule near Whispering's Tauri source: new commands need both `#[tauri::command]` and `#[specta::specta]`.
+- [ ] **4.4** Add a grep check or review checklist item to avoid new raw `invoke('app_command')` calls.
+
+### Phase 5: Follow-Up Cleanup
+
+- [ ] **5.1** Decide whether app-specific command error shapes should move from `String` to typed Rust error enums.
+- [ ] **5.2** Consider typed Tauri event bindings if event payloads become app-owned contracts.
+- [ ] **5.3** Revisit `tauri-specta` when `2.0.0` final lands and decide whether to unpin to a narrow compatible range.
+
+## Testing Plan
+
+Generation checks:
+
+```bash
+bun run --cwd apps/whispering tauri
+cargo test --manifest-path apps/whispering/src-tauri/Cargo.toml export_types
+git diff -- apps/whispering/src/lib/tauri/bindings.gen.ts
+```
+
+Frontend checks:
+
+```bash
+bun run --cwd apps/whispering typecheck
+```
+
+Runtime smoke checks:
+
+```txt
+1. Start Whispering with bun run --cwd apps/whispering dev:local.
+2. Confirm the app opens.
+3. Enumerate microphones from the recording settings.
+4. Start and stop a short recording.
+5. Run a command-backed ffmpeg check from the app path that already does this today.
+6. Save or materialize markdown output and confirm files are written.
+```
+
+## Risks
+
+### RC Dependency Churn
+
+Specta v2 is active but not stable. The mitigation is exact pins, checked-in generated output, and CI diff checks.
+
+### Type Export Gaps
+
+Some Rust types may not export cleanly on the first pass, especially types borrowed from external crates. The mitigation is to introduce local serializable DTOs at the command boundary instead of exporting internal implementation types.
+
+### Result Shape Confusion
+
+`tauri-specta` can generate `Result<T, E>` wrappers, while existing frontend code often uses `tryAsync` around raw `invoke`. The migration should choose one convention per service and avoid mixing both in the same function.
+
+### Over-Broad Migration
+
+Tauri plugin APIs should not move into app command bindings. The migration is only for app-owned `#[tauri::command]` functions.
+
+## Open Questions
+
+1. Should generated bindings live at `$lib/tauri/bindings.gen.ts` or `$lib/services/desktop/tauri.gen.ts`?
+2. Should we keep a handwritten `$lib/tauri/commands.ts` adapter during migration, or migrate services directly to generated `commands`?
+3. Should Rust command errors stay as `String` for phase 1, or should high-traffic commands move to typed serializable error enums first?
+4. Should the generated file include `// @ts-nocheck`, as Anarlog does, or should we keep it type-checked and fix generator output if needed?
+
+## Recommendation
+
+Adopt `tauri-specta` v2 for Whispering, but treat it as an actively maintained RC dependency. The right posture is deliberate: exact pins, generated files in git, a regeneration diff check, and a small first migration. If that proves clean, migrate all app-owned Whispering commands and make the pattern the default for future Tauri work.

--- a/specs/20260513T120000-action-runtime-one-envelope.md
+++ b/specs/20260513T120000-action-runtime-one-envelope.md
@@ -1,0 +1,302 @@
+# Action Runtime: openCollaboration Hosts Actions
+
+**Date**: 2026-05-13
+**Status**: Superseded by `specs/20260513T235000-rpc-on-yjs-state.md`
+**Reason**: The `peer.ts`, `peer.invoke`, `peer.describe()`, `attachAwareness`, runtime-request envelope, and `SelfInvocationError` / `PeerLeftError` surfaces referenced throughout this document no longer exist. The shipped model is `collab.dispatch(action, input, { to: connId, signal })` against the `PresenceSurface` in `packages/workspace/src/document/presence.ts` and the LWW-row dispatch in `packages/workspace/src/document/rpc.ts`. Actions are flat snake_case (see `specs/20260513T231157-actions-snake-case-only-no-dots.md`), not dot-path. Keep this file for the audit trail; do not implement.
+**Author**: AI-assisted
+**Original status**: Draft (rev 3; superseded rev 2 of this file)
+
+## Why This Rewrite
+
+Rev 1 described a separate Bun host, JSON-RPC envelope, `ctx.host` capability layer, loopback HTTP transport, and new `@epicenter/action-client` package.
+
+Rev 2 corrected the instinct: the repo already had typed actions, local invocation, peer routing, and sync transport machinery. But it named the old primitive, `attachRpc`, and preserved the old idea that `system.describe` was just another action.
+
+The current tree has moved again. `openCollaboration` is now the public primitive. It opens sync on a workspace document, publishes `{ identity, actionPaths }` in awareness, hosts local actions, exposes `collaboration.actions` for local calls, and exposes `collaboration.peers` for cross-peer calls. Runtime introspection uses a separate runtime wire plane, not the user action namespace.
+
+## One Sentence
+
+```txt
+Actions are typed functions defined with defineQuery / defineMutation;
+openCollaboration publishes the local action paths and hosts the handlers;
+local callers use collaboration.actions or invokeAction; remote callers use
+peer.invoke(path, input) over the same WebSocket that syncs the workspace doc.
+```
+
+## Current Model
+
+The current runtime has three layers:
+
+```txt
+document
+  Y.Doc, tables, kv, batch, persistence
+
+collaboration
+  openCollaboration(ydoc, { url, identity, actions, ... })
+    -> sync supervisor
+    -> awareness: { identity, actionPaths }
+    -> inbound action dispatch
+    -> runtime requests such as peer.describe()
+    -> peers surface
+
+app binding
+  app-specific handle that returns document pieces, persistence, collaboration,
+  wipe, and disposal
+```
+
+The important shape is small:
+
+```ts
+const collaboration = openCollaboration(ydoc, {
+	url: websocketUrl(RELAY_URL),
+	waitFor: idb.whenLoaded,
+	openWebSocket: auth.openWebSocket,
+	identity: peer,
+	actions,
+});
+```
+
+That one call replaces the old attach chain:
+
+```txt
+attachSync + attachAwareness + attachRpc + createRemoteClient
+```
+
+## What Already Exists
+
+| Primitive | Location | What it does |
+| --- | --- | --- |
+| `openCollaboration(ydoc, config)` | `packages/workspace/src/document/open-collaboration.ts` | Opens sync, publishes identity and action paths, hosts local actions, exposes peers. |
+| `attachYjsSync(ydoc, config)` | `packages/workspace/src/document/attach-yjs-sync.ts` | Sync-only sibling for content docs. No presence, actions, or peers. |
+| `Peer.invoke(path, input)` | `packages/workspace/src/document/peer.ts` | Cross-peer action call by typed dot path. |
+| `Peer.describe()` | `packages/workspace/src/document/peer.ts` | Runtime-plane request that returns an `ActionManifest`. |
+| `defineQuery` / `defineMutation` | `packages/workspace/src/shared/actions.ts` | Defines action contracts and handlers. |
+| `invokeAction(action, input, label)` | `packages/workspace/src/shared/actions.ts` | In-process action invocation with validation and Result wrapping. |
+| `describeActions(actions)` | `packages/workspace/src/shared/actions.ts` | Turns an action tree into the manifest returned by `peer.describe()`. |
+| `SelfInvocationError` / `PeerLeftError` | `packages/workspace/src/document/peer.ts` | Workspace-layer remote call errors that are not sync protocol errors. |
+
+The transport is still the workspace sync WebSocket. There is no second action HTTP server, no action-client package, and no separate peer registry.
+
+## Action Definition
+
+Handlers use the app's existing services and document binding. There is no `ctx.host`.
+
+```ts
+import { defineMutation } from '@epicenter/workspace';
+import { type } from 'arktype';
+import { services } from '$lib/services';
+import { whispering } from '$lib/workspace';
+
+const StartRecordingInput = type({ deviceId: 'string' });
+const StopAndAppendInput = type({
+	sessionId: 'string',
+	documentId: 'string',
+});
+
+export const actions = {
+	whispering: {
+		startRecording: defineMutation({
+			input: StartRecordingInput,
+			handler: async (input) => {
+				const session = await services.recorder.start({
+					deviceId: input.deviceId,
+				});
+				return { sessionId: session.id };
+			},
+		}),
+
+		stopAndAppend: defineMutation({
+			input: StopAndAppendInput,
+			handler: async (input) => {
+				const recording = await services.recorder.stop({
+					sessionId: input.sessionId,
+				});
+				const transcript = await services.transcriptions.run({
+					audioAssetId: recording.assetId,
+				});
+				await whispering.documents.append({
+					documentId: input.documentId,
+					text: transcript.text,
+				});
+				return {
+					appended: true,
+					charCount: transcript.text.length,
+				};
+			},
+		}),
+	},
+} as const;
+
+export type WhisperingActions = typeof actions;
+```
+
+Rules:
+
+```txt
+- Handlers import services and the app binding the same way SPA code does.
+- Different platforms wire different service implementations.
+- Handler output must be JSON-serializable when remote callers may invoke it.
+- Return raw values for success; invokeAction wraps them as Ok.
+- Return Err(...) when the handler has a typed domain error to preserve.
+- Thrown errors are converted to ActionFailed at the action boundary.
+- User actions may use the `system` key. Runtime verbs are on a separate plane.
+```
+
+## Local Calls
+
+Known local callers can call the typed action tree directly when that reads best:
+
+```ts
+const result = await collaboration.actions.whispering.startRecording({
+	deviceId,
+});
+```
+
+Unknown or boundary-style callers should use `invokeAction`:
+
+```ts
+import { invokeAction } from '@epicenter/workspace';
+
+const { data, error } = await invokeAction(
+	collaboration.actions.whispering.startRecording,
+	{ deviceId },
+	'whispering.startRecording',
+);
+
+if (error) {
+	services.toast.error(error.message);
+	return;
+}
+
+sessionId = data.sessionId;
+```
+
+`invokeAction` validates input, runs the handler, and normalizes the result. No fetch, port, envelope, or RPC path is involved for local work.
+
+## Remote Calls
+
+Cross-peer callers route through the peers surface:
+
+```ts
+const target = collaboration.peers
+	.list()
+	.find((peer) => peer.actionPaths.includes('whispering.startRecording'));
+
+if (!target) return;
+
+const { data, error } = await target.invoke(
+	'whispering.startRecording',
+	{ deviceId: 'default' },
+);
+```
+
+When the target type is known, `peers.find<TActions>(id)` narrows the path and payload types:
+
+```ts
+const peer = collaboration.peers.find<WhisperingActions>(peerId);
+const result = await peer?.invoke('whispering.startRecording', {
+	deviceId: 'default',
+});
+```
+
+Self is not reachable through `peers.list()` or `peers.find()`. A stale client id that reaches the wire fallback returns `SelfInvocationError`, with guidance to call `collaboration.actions.<path>` locally.
+
+## Discovery
+
+Awareness tells you which peers are online and which action paths they host:
+
+```ts
+const candidates = collaboration.peers
+	.list()
+	.filter((peer) => peer.actionPaths.includes('whispering.stopAndAppend'));
+```
+
+Full schemas and descriptions come from `peer.describe()`:
+
+```ts
+const manifest = await peer.describe();
+```
+
+That distinction matters:
+
+```txt
+awareness
+  small, live, frequently updated
+  identity + actionPaths only
+
+peer.describe()
+  explicit runtime request
+  full ActionManifest with schemas and descriptions
+```
+
+## Whispering Phase 1 Direction
+
+Whispering currently has its own query and service layers plus raw Tauri calls. The first action-runtime phase should stay boring:
+
+```txt
+1. Create an app action registry around existing recorder, transcription,
+   and document-append paths.
+
+2. Mount that registry with openCollaboration once Whispering has a
+   collaboration-backed app binding.
+
+3. Keep platform effects in services. The desktop implementation can use
+   Tauri/CPAL; the web implementation can use browser APIs.
+
+4. Convert only the call sites that benefit from a typed action boundary.
+   Do not force every local service call through actions.
+```
+
+This is not a source-install runtime yet. It is the shared action surface that future source-installed apps can call once the shell and permission model exist.
+
+## CLI Direction
+
+The CLI should remain a peer-facing tool, not a separate protocol.
+
+```txt
+epicenter list
+  local daemon route -> collaboration.actions / peer.describe
+
+epicenter run <path> <input>
+  local target -> invokeAction
+  remote target -> peer.invoke(path, input)
+
+epicenter peers
+  collaboration.peers.list()
+```
+
+The daemon already owns the long-lived collaboration runtime. The CLI should keep using the daemon socket for local process management and use the collaboration surface behind it for action discovery and invocation.
+
+## What This Spec Refuses
+
+```txt
+- A second action wire format beside the sync protocol.
+- A new @epicenter/action-client package.
+- ctx.host as a handler argument or capability surface.
+- A Bun sidecar in phase 1.
+- Loopback HTTP between the webview and bundled JavaScript.
+- A peer registry separate from awareness.
+- Full action schemas in awareness.
+- Treating runtime verbs as user actions.
+```
+
+## Deferred
+
+```txt
+- Headless Bun daemon as an always-on peer.
+- Source-installed apps with capability-gated services.
+- Manifest review UX, signing, and marketplace trust.
+- Per-action permission grants surfaced to the user.
+- Typed Tauri command generation for native bridge calls.
+- WASM extension lane.
+```
+
+## Related
+
+- `packages/workspace/src/document/open-collaboration.ts`
+- `packages/workspace/src/document/peer.ts`
+- `packages/workspace/src/document/peer-identity.ts`
+- `packages/workspace/src/shared/actions.ts`
+- `packages/workspace/SYNC_ARCHITECTURE.md`
+- `specs/20260512T234944-source-installed-app-runtime-vision.md`
+- `specs/20260513T105808-tauri-specta-bindings.md`

--- a/specs/20260513T190000-schema-on-npm-runtime-on-jsrepo.md
+++ b/specs/20260513T190000-schema-on-npm-runtime-on-jsrepo.md
@@ -1,9 +1,9 @@
 # Schema on npm, Runtime on jsrepo
 
 **Date**: 2026-05-13
-**Status**: Draft
+**Status**: Implemented
 **Author**: AI-assisted
-**Branch**: TBD
+**Branch**: feat/miscellaneous-spec-implementations
 
 ## Overview
 
@@ -283,11 +283,11 @@ Verification commands (used at the end of each phase):
 
 For Fuji, Honeycrisp, Opensidian, Zhongwen (Tab Manager skipped):
 
-- [ ] **1.1** Pre-inline prep, app-specific:
+- [x] **1.1** Pre-inline prep, app-specific:
   - **Fuji**: move `export const FUJI_WORKSPACE_ID = 'epicenter.fuji'` from `document.ts` to `workspace.ts`. (Daemon doesn't import it today, but the constant must survive.)
   - **Honeycrisp / Opensidian**: no prep; doc layer hardcodes the guid string.
   - **Zhongwen**: confirm `zhongwenKv` is exported from `workspace/index.ts` (it already is); inlined files will import it.
-- [ ] **1.2** In `browser.ts`, replace `const doc = openXDocument(...)` with the inlined body:
+- [x] **1.2** In `browser.ts`, replace `const doc = openXDocument(...)` with the inlined body:
   ```ts
   const ydoc = new Y.Doc({ guid: '<app-guid>', gc: false });
   const encryption = attachEncryption(ydoc, { encryptionKeys });
@@ -295,11 +295,11 @@ For Fuji, Honeycrisp, Opensidian, Zhongwen (Tab Manager skipped):
   const kv = encryption.attachKv(<kvSchema>);  // Zhongwen: zhongwenKv. Others: {}
   ```
   Then update all subsequent `doc.X` references (`doc.ydoc` → `ydoc`, `doc.tables` → `tables`, `doc.encryption` → `encryption`, `doc.kv` → `kv`, `doc.batch` → inline `(fn) => ydoc.transact(fn)` where used). Update the `[Symbol.dispose]` to `ydoc.destroy()`. Delete the `import { openXDocument } from './document.js'` line.
-- [ ] **1.3** Same inlining for `script.ts` (if present).
-- [ ] **1.4** Same inlining for `daemon.ts` (if present).
-- [ ] **1.5** Delete `apps/<app>/src/.../document.ts`.
-- [ ] **1.6** Remove `"./document": "..."` from `apps/<app>/package.json` `exports`.
-- [ ] **1.7** Grep the app's directory for `XDocument` (the type) and `openXDocument` (the function); confirm zero hits.
+- [x] **1.3** Same inlining for `script.ts` (if present).
+- [x] **1.4** Same inlining for `daemon.ts` (if present).
+- [x] **1.5** Delete `apps/<app>/src/.../document.ts`.
+- [x] **1.6** Remove `"./document": "..."` from `apps/<app>/package.json` `exports`.
+- [x] **1.7** Grep the app's directory for `XDocument` (the type) and `openXDocument` (the function); confirm zero hits.
 
 Fuji has TWO call sites in `script.ts` (`openFujiSnapshot` and `openFujiScript`): inline into both.
 
@@ -309,18 +309,20 @@ Verification after each app: `bun run --cwd apps/<app> typecheck` and `bun run -
 
 For each app, in one commit:
 
-- [ ] **2.1** Edit `apps/<app>/package.json` exports map to replace `"./workspace": "<path>"` with `".": "<path>"`. Targets:
+- [x] **2.1** Edit `apps/<app>/package.json` exports map to replace `"./workspace": "<path>"` with `".": "<path>"`. Targets:
   - Honeycrisp: `./src/routes/(signed-in)/honeycrisp/workspace.ts`
   - Fuji: `./src/routes/(signed-in)/fuji/workspace.ts`
   - Zhongwen: `./src/routes/(signed-in)/zhongwen/workspace/index.ts`
   - Opensidian: `./src/lib/workspace/definition.ts`
   - Tab Manager: `./src/lib/workspace/index.ts`
-- [ ] **2.2** Update every cross-package consumer to import from the package root:
+- [x] **2.2** Update every cross-package consumer to import from the package root:
   - `playground/tab-manager-e2e/epicenter.config.ts`: `'@epicenter/tab-manager/workspace'` → `'@epicenter/tab-manager'`
   - `playground/opensidian-e2e/epicenter.config.ts`: `'opensidian/workspace'` → `'opensidian'`
   - `playground/opensidian-e2e/epicenter.config.test.ts`: same.
   - `packages/workspace/src/client/connect-daemon-actions.ts:16` (JSDoc): `'@epicenter/fuji/workspace'` → `'@epicenter/fuji'`.
-- [ ] **2.3** Grep the repo for `'@epicenter/(honeycrisp|fuji|zhongwen|tab-manager)/workspace'` and `'opensidian/workspace'`; expect zero hits.
+- [x] **2.3** Grep the repo for `'@epicenter/(honeycrisp|fuji|zhongwen|tab-manager)/workspace'` and `'opensidian/workspace'`; expect zero hits.
+
+2026-05-14 note: the current tree exports `./blocks/workspace.ts` as the package root for Honeycrisp, Fuji, Opensidian, and Zhongwen. Tab Manager still exports `./src/lib/workspace/index.ts`. This keeps the schema as the package-root npm contract and also makes the four app schemas available as jsrepo blocks.
 
 Verification: `bun run typecheck` (root). `bun run test` (root).
 
@@ -330,7 +332,7 @@ The browser file already lives inside the app's `src/` tree; `apps/<app>/src/lib
 
 For each app:
 
-- [ ] **3.1** Remove `"./browser": "..."` from `apps/<app>/package.json` exports.
+- [x] **3.1** Remove `"./browser": "..."` from `apps/<app>/package.json` exports.
 
 Verification: `bun run typecheck`.
 
@@ -338,23 +340,23 @@ Verification: `bun run typecheck`.
 
 For Fuji, Honeycrisp, Opensidian, Zhongwen (Tab Manager skipped):
 
-- [ ] **4.1** Create `apps/<app>/blocks/` directory.
-- [ ] **4.2** Move `apps/<app>/src/.../script.ts` to `apps/<app>/blocks/script.ts`.
-- [ ] **4.3** Move `apps/<app>/src/.../daemon.ts` to `apps/<app>/blocks/daemon-route.ts`.
-- [ ] **4.4** Inside the moved files, rewrite the schema import to use the package root (depends on Phase 2):
+- [x] **4.1** Create `apps/<app>/blocks/` directory.
+- [x] **4.2** Move `apps/<app>/src/.../script.ts` to `apps/<app>/blocks/script.ts`.
+- [x] **4.3** Move `apps/<app>/src/.../daemon.ts` to `apps/<app>/blocks/daemon-route.ts`.
+- [x] **4.4** Inside the moved files, rewrite the schema import to use the package root (depends on Phase 2):
   - Was: `import { <appTables>, ... } from './workspace.js'` (or `'./workspace/index.js'` for Zhongwen, `'../workspace/definition.js'` for Opensidian).
   - Now: `import { <appTables>, ... } from '@epicenter/<app>'` (or `'opensidian'` for Opensidian).
-- [ ] **4.5** Fuji-specific: `daemon.ts` exports both `defineFujiDaemon` and `connectFujiDaemonActions`. Both move into `blocks/daemon-route.ts`. `blocks/script.ts` imports them via relative path `'./daemon-route.js'`.
-- [ ] **4.6** Update Fuji's `blocks/script.ts` import of `openFujiDocument` (which was deleted in Phase 1; the body is now inlined). The remaining schema import in `script.ts` is `EncryptionKeys` from `@epicenter/encryption` and `ProjectDir` from `@epicenter/workspace`: these stay.
-- [ ] **4.7** Remove `"./script": "..."` and `"./daemon": "..."` from `apps/<app>/package.json` exports.
+- [x] **4.5** Fuji-specific: `daemon.ts` exports both `defineFujiDaemon` and `connectFujiDaemonActions`. Both move into `blocks/daemon-route.ts`. `blocks/script.ts` imports them via relative path `'./daemon-route.js'`.
+- [x] **4.6** Update Fuji's `blocks/script.ts` import of `openFujiDocument` (which was deleted in Phase 1; the body is now inlined). The remaining schema import in `script.ts` is `EncryptionKeys` from `@epicenter/encryption` and `ProjectDir` from `@epicenter/workspace`: these stay.
+- [x] **4.7** Remove `"./script": "..."` and `"./daemon": "..."` from `apps/<app>/package.json` exports.
 
 Verification: `bun run typecheck`. The block files now compile against the package root, the same way a third-party consumer's copy will.
 
 ### Phase 5a: jsrepo build config (no hosting decision needed)
 
-- [ ] **5a.1** Add `jsrepo-build-config.json` at the monorepo root. Block category: `blocks` glob `apps/*/blocks/*.ts`. Each app's blocks become a category named after the app (e.g. `epicenter/honeycrisp/script`).
-- [ ] **5a.2** Run `bunx jsrepo build` locally; verify a manifest is produced with the expected block list.
-- [ ] **5a.3** Add `bun run jsrepo:build` to root `package.json` scripts so the manifest can be regenerated on demand.
+- [x] **5a.1** Add `jsrepo.config.ts` at the monorepo root. Block category: `blocks` glob `apps/*/blocks/*.ts`. Each app's blocks become a category named after the app (e.g. `epicenter/honeycrisp/script`).
+- [x] **5a.2** Run `bun run jsrepo:build` locally; verify a manifest is produced with the expected block list.
+- [x] **5a.3** Add `bun run jsrepo:build` to root `package.json` scripts so the manifest can be regenerated on demand.
 
 Verification: manifest contains four blocks per app (script, daemon-route, plus Fuji's snapshot variant if split out), no unexpected entries.
 
@@ -384,14 +386,14 @@ Verification: manifest contains four blocks per app (script, daemon-route, plus 
   bun run playground/tab-manager-e2e/epicenter.config.ts
   ```
   Confirm both connect, sync, and exit cleanly on Ctrl+C.
-- [ ] **6.5** Final grep sweep, expect zero hits in source (excluding `specs/` and `docs/articles/`):
+- [x] **6.5** Final grep sweep, expect zero hits in source (excluding `specs/` and `docs/articles/`):
   ```
   rg 'openXDocument|XDocument\b' --type=ts        # X is each app name
   rg "'@epicenter/[^/]+/(workspace|document|browser|script|daemon)'" --type=ts --type=svelte
   rg "'opensidian/(workspace|document|browser|script|daemon)'" --type=ts
   rg 'src/.*/(document|script|daemon)\.ts'        # any straggler runtime file outside blocks/
   ```
-- [ ] **6.6** Confirm each app's `package.json` exports has exactly one entry: `"."`.
+- [x] **6.6** Confirm each app's `package.json` exports has exactly one entry: `"."`.
 
 ## Edge Cases
 
@@ -465,19 +467,19 @@ Phase 3 no longer moves the browser file. The file stays at `apps/<app>/src/.../
 
 ## Success Criteria
 
-- [ ] Each app's `package.json` lists exactly one export entry: `"."`.
-- [ ] No file named `document.ts` exists under `apps/*/src/`.
-- [ ] No file named `script.ts` or `daemon.ts` exists under `apps/*/src/` (Fuji, Honeycrisp, Opensidian, Zhongwen recipes live in `apps/*/blocks/`; Tab Manager has none).
-- [ ] `browser.ts` still exists at `apps/*/src/.../browser.ts` (or `extension.ts` for Tab Manager); only its package subpath export is gone.
-- [ ] `rg "'@epicenter/(honeycrisp|fuji|zhongwen|tab-manager)/(workspace|document|browser|script|daemon)'"` returns zero hits in source.
-- [ ] `rg "'opensidian/(workspace|document|browser|script|daemon)'"` returns zero hits in source.
-- [ ] `rg 'openXDocument|XDocument\b'` (X = each app) returns zero hits.
+- [x] Each app's `package.json` lists exactly one export entry: `"."`.
+- [x] No file named `document.ts` exists under `apps/*/src/`.
+- [x] No file named `script.ts` or `daemon.ts` exists under `apps/*/src/` (Fuji, Honeycrisp, Opensidian, Zhongwen recipes live in `apps/*/blocks/`; Tab Manager has none).
+- [x] `browser.ts` still exists at `apps/*/src/.../browser.ts` (or `extension.ts` for Tab Manager); only its package subpath export is gone.
+- [x] `rg "'@epicenter/(honeycrisp|fuji|zhongwen|tab-manager)/(workspace|document|browser|script|daemon)'"` returns zero hits in source.
+- [x] `rg "'opensidian/(workspace|document|browser|script|daemon)'"` returns zero hits in source.
+- [x] `rg 'openXDocument|XDocument\b'` (X = each app) returns zero hits.
 - [ ] `bun run typecheck` passes at the repo root.
 - [ ] `bun run test` passes at the repo root.
 - [ ] Every app's `bun run --cwd apps/<app> dev:local` starts and the signed-in route opens its workspace successfully.
 - [ ] `bun run playground/opensidian-e2e/epicenter.config.ts` runs without errors until Ctrl+C.
 - [ ] `bun run playground/tab-manager-e2e/epicenter.config.ts` runs without errors until Ctrl+C.
-- [ ] `jsrepo-build-config.json` exists at the monorepo root and `bunx jsrepo build` produces a manifest covering every block under `apps/*/blocks/`.
+- [x] `jsrepo.config.ts` exists at the monorepo root and `bun run jsrepo:build` produces a manifest covering every block under `apps/*/blocks/`.
 
 ## References
 
@@ -517,11 +519,15 @@ Phase 3 no longer moves the browser file. The file stays at `apps/<app>/src/.../
   - `openXDocument|XDocument\b` (across all five apps) -> 0 hits.
   - `find apps -type f \( -name 'document.ts' -o -name 'script.ts' -o -name 'daemon.ts' \) -not -path '*/blocks/*'` -> 0 hits.
 - **6.6 package.json exports**: every app has exactly one entry, `"."`:
-  - `@epicenter/honeycrisp` -> `./src/routes/(signed-in)/honeycrisp/workspace.ts`
-  - `@epicenter/fuji` -> `./src/routes/(signed-in)/fuji/workspace.ts`
-  - `@epicenter/zhongwen` -> `./src/routes/(signed-in)/zhongwen/workspace/index.ts`
-  - `opensidian` -> `./src/lib/workspace/definition.ts`
+  - `@epicenter/honeycrisp` -> `./blocks/workspace.ts`
+  - `@epicenter/fuji` -> `./blocks/workspace.ts`
+  - `@epicenter/zhongwen` -> `./blocks/workspace.ts`
+  - `opensidian` -> `./blocks/workspace.ts`
   - `@epicenter/tab-manager` -> `./src/lib/workspace/index.ts`
+
+### Status finalization
+
+On 2026-05-14, the current tree already matched the implemented distribution shape. No source files were changed in this pass. This update marks the spec implemented and records the current package-root export paths.
 
 ### Spec discrepancies discovered during execution
 

--- a/specs/20260513T200000-workspace-surface-clean-break-vision.md
+++ b/specs/20260513T200000-workspace-surface-clean-break-vision.md
@@ -1,0 +1,541 @@
+# Workspace Surface Clean Break Vision
+
+**Date**: 2026-05-13
+**Status**: Partially superseded
+**Landed**: flat action registry (under snake_case via `specs/20260513T231157-actions-snake-case-only-no-dots.md`).
+**Reversed**: dot-path action keys (`'entries.create'`) became snake_case (`entries_create`); `attachYjsSync` was deleted and content docs now use `openCollaboration(ydoc, { actions: {} })` (see `packages/workspace/src/document/open-collaboration.ts:1-25, 71-74`).
+**Still live**: markdown link helpers exported from the root `@epicenter/workspace` barrel (`packages/workspace/src/index.ts:281-292`); script-vs-daemon overlap in `apps/honeycrisp`, `apps/opensidian`, `apps/zhongwen` (only Fuji is on the snapshot+proxy reference shape).
+**Author**: Braden + Codex
+
+## Overview
+
+This spec turns the six audit prompts into one implementation direction: flatten the action system, keep the sync and collaboration primitives split, standardize app runtime files, and move markdown link helpers out of the root workspace barrel.
+
+The clean sentence:
+
+```txt
+Apps build a typed Y.Doc bundle, open collaboration for workspace docs, attach sync for content docs, and expose flat dot-path actions locally or by peer.
+```
+
+## Spoon Feed The Vision
+
+The final shape should feel boring in the best way.
+
+```txt
+document.ts
+  creates local app data
+  no network
+  no auth
+  no IndexedDB user keys
+  no daemon
+
+browser.ts or extension.ts
+  adds browser persistence
+  adds local tab sync
+  opens collaboration
+  owns wipe
+
+daemon.ts
+  adds machine auth
+  writes Yjs logs and materializers
+  opens collaboration
+  owns async teardown
+
+script.ts
+  reads local snapshots
+  calls daemon actions
+  does not open a second live synced workspace
+```
+
+In code, workspace docs look like this:
+
+```ts
+const doc = openFujiDocument({ encryptionKeys });
+const idb = doc.encryption.attachIndexedDb(doc.ydoc, { userId });
+
+const collaboration = openCollaboration(doc.ydoc, {
+	url: websocketUrl(`${APP_URLS.API}/workspaces/${doc.ydoc.guid}`),
+	waitFor: idb.whenLoaded,
+	openWebSocket,
+	identity: peer,
+	actions: createFujiActions(doc.tables),
+});
+```
+
+Content docs look like this:
+
+```ts
+const ydoc = new Y.Doc({ guid: entryContentDocGuid({ workspaceId, entryId }) });
+const idb = doc.encryption.attachIndexedDb(ydoc, { userId });
+
+const sync = attachYjsSync(ydoc, {
+	url: websocketUrl(`${APP_URLS.API}/documents/${ydoc.guid}`),
+	waitFor: idb.whenLoaded,
+	openWebSocket,
+});
+```
+
+Actions become flat:
+
+```ts
+export function createFujiActions(tables: FujiTables) {
+	return {
+		'entries.get': defineQuery({ ... }),
+		'entries.create': defineMutation({ ... }),
+		'entries.update': defineMutation({ ... }),
+		'entries.delete': defineMutation({ ... }),
+	} as const;
+}
+```
+
+Local calls use the same path the daemon, peers, CLI, and AI tools see:
+
+```ts
+fuji.collaboration.actions['entries.create']({});
+
+await peer.invoke('entries.update', {
+	id,
+	title,
+});
+```
+
+That is the point. One action address, everywhere.
+
+## Current State
+
+Parts of the target already exist on this branch.
+
+```txt
+packages/workspace/src/document/open-collaboration.ts
+  openCollaboration(ydoc, config)
+  publishes identity and action paths
+  hosts inbound actions
+  exposes peers
+
+packages/workspace/src/document/attach-yjs-sync.ts
+  attachYjsSync(ydoc, config)
+  sync-only content doc primitive
+
+packages/workspace/src/document/internal/sync-supervisor.ts
+  shared transport, reconnect, liveness, awareness frames, RPC frames
+
+apps/*/.../document.ts
+  pure encrypted Y.Doc constructors already exist for several apps
+```
+
+The remaining mismatch is the public action shape and a few stale ownership seams.
+
+```ts
+// Current action registry
+return {
+	entries: {
+		create: defineMutation({ ... }),
+		update: defineMutation({ ... }),
+	},
+};
+
+// Target action registry
+return {
+	'entries.create': defineMutation({ ... }),
+	'entries.update': defineMutation({ ... }),
+};
+```
+
+Current `script.ts` files are inconsistent:
+
+```txt
+Fuji script.ts
+  local readonly snapshot
+  daemon action proxy
+  good target shape
+
+Honeycrisp, Opensidian, Zhongwen script.ts
+  machine auth
+  live attachYjsSync
+  yjs log reader
+  no clear async disposer
+  overlaps daemon.ts
+```
+
+The root workspace barrel still exports markdown link helpers:
+
+```ts
+export {
+	convertEpicenterLinksToWikilinks,
+	convertWikilinksToEpicenterLinks,
+	EPICENTER_LINK_RE,
+	makeEpicenterLink,
+	parseEpicenterLink,
+} from './links.js';
+```
+
+Those helpers are useful, but they are markdown/editor format helpers. They do not belong to the root sentence for `@epicenter/workspace`.
+
+## Product Sentences
+
+### Workspace Package
+
+```txt
+@epicenter/workspace defines typed Yjs-backed workspace data and actions, then attaches persistence, local sync, WebSocket sync, awareness, encryption, and RPC to a caller-owned Y.Doc.
+```
+
+### Collaboration
+
+```txt
+Workspace docs expose live peers and remote actions; content docs sync quietly as leaves.
+```
+
+### Actions
+
+```txt
+Apps define typed query and mutation actions that are callable locally and invokable remotely by peer through one flat dot-path address.
+```
+
+### App Runtime Files
+
+```txt
+document.ts creates data, browser.ts opens the browser runtime, daemon.ts opens the daemon runtime, and script.ts talks to the daemon or reads a local snapshot.
+```
+
+## Design Decisions
+
+| Decision | Choice | Why |
+| --- | --- | --- |
+| Public sync shape | Keep `openCollaboration` and `attachYjsSync` separate | A single optional config bag recreates the old mixed `attachSync` problem. Presence and RPC are collaboration features, not sync-only features. |
+| Shared sync implementation | Keep `createSyncSupervisor` internal | Transport lifecycle is shared, but callers should not choose partial collaboration modes. |
+| Action registry | Flat dot-path record | The daemon, peer RPC, CLI, AI tools, errors, and manifests already speak dot paths. Nested local ergonomics force the largest code family. |
+| Dot-path strings | Keep | Tuple addresses would still need serialization at every boundary. Dot paths are the common language. |
+| `query` vs `mutation` | Keep | AI/tool approval and user trust depend on read/write classification. This is part of the product sentence. |
+| `title` and `description` | Keep | AI tools, UI labels, and action discovery need friendly metadata. The code cost is modest. |
+| Runtime introspection | Keep on runtime plane | `peer.describe()` should stay separate from user actions. No reserved `system.*` action namespace. |
+| Scripts | Refuse live script workspaces | Scripts should read snapshots or call daemon actions. They should not become a second daemon. |
+| Root markdown links | Move to a subpath | Link conversion is useful, but it is not root workspace composition. |
+
+## Architecture
+
+```txt
+App document constructor
+  openFujiDocument()
+    -> Y.Doc
+    -> encryption
+    -> tables
+    -> kv
+    -> pure local helpers
+
+Browser runtime
+  openFujiBrowser()
+    -> document
+    -> IndexedDB
+    -> BroadcastChannel
+    -> child content docs
+    -> openCollaboration()
+    -> wipe()
+
+Daemon runtime
+  defineFujiDaemon().start()
+    -> machine auth
+    -> document
+    -> Yjs log writer
+    -> materializers
+    -> openCollaboration()
+    -> async dispose
+
+Script facade
+  openFujiScript()
+    -> readonly local snapshot
+    -> connectDaemonActions()
+```
+
+Action flow:
+
+```txt
+Definition:
+  createFujiActions()
+    -> { 'entries.create': defineMutation(...) }
+
+Local:
+  collaboration.actions['entries.create'](input)
+
+Boundary:
+  invokeAction(actions['entries.create'], input, 'entries.create')
+
+Peer:
+  peer.invoke('entries.create', input)
+
+Daemon:
+  client.run({ actionPath: 'fuji.entries.create', input })
+
+AI:
+  action path 'entries.create'
+    -> tool name 'entries_create'
+```
+
+Sync flow:
+
+```txt
+openCollaboration()
+  -> attach awareness
+  -> publish identity and flat action paths
+  -> createSyncSupervisor({ awareness, onActionRequest, onRuntimeRequest })
+  -> create peers surface
+
+attachYjsSync()
+  -> createSyncSupervisor({ no awareness, no RPC handlers })
+```
+
+## Implementation Plan
+
+### Phase 1: Flatten The Action System
+
+- [ ] Replace `Actions` recursive type with a flat `ActionRegistry` type.
+- [ ] Add `ActionPath` validation helpers for flat keys.
+- [ ] Replace `walkActions(actions)` with `actionEntries(actions)`.
+- [ ] Replace `resolveActionPath(actions, path)` with direct lookup plus validation.
+- [ ] Make `describeActions(actions)` map flat keys directly to `ActionMeta`.
+- [ ] Update `openCollaboration` to publish `Object.keys(actions).sort()`.
+- [ ] Update `run-handler.ts` suggestions to work from flat entries.
+- [ ] Update `actionsToAiTools` to derive tool names from flat dot paths.
+- [ ] Update `DaemonActions<T>` so flat action keys produce bracket-callable methods.
+- [ ] Update tests for `shared/actions`, `open-collaboration`, daemon run, daemon action client, and AI tools.
+
+Target core shape:
+
+```ts
+export type ActionRegistry = Record<string, Action>;
+
+export function actionEntries(
+	actions: ActionRegistry,
+): Array<[path: string, action: Action]> {
+	return Object.entries(actions);
+}
+
+export function resolveActionPath(
+	actions: ActionRegistry,
+	path: string,
+): Action | undefined {
+	return actions[path];
+}
+```
+
+### Phase 2: Migrate App Actions
+
+- [ ] Fuji: flatten `createFujiActions`.
+- [ ] Honeycrisp: flatten `createHoneycrispActions`.
+- [ ] Opensidian: flatten `createOpensidianActions`.
+- [ ] Tab Manager: flatten `createTabManagerActions`.
+- [ ] Skills package and Skills app: flatten skill actions if they are on this same public action surface.
+- [ ] Update all local action calls to bracket syntax.
+- [ ] Update type references that index nested action members.
+
+Examples:
+
+```ts
+// Before
+fuji.collaboration.actions.entries.update({ id, title });
+
+// After
+fuji.collaboration.actions['entries.update']({ id, title });
+```
+
+```ts
+// Before
+Parameters<typeof fuji.collaboration.actions.entries.update>[0]
+
+// After
+Parameters<typeof fuji.collaboration.actions['entries.update']>[0]
+```
+
+### Phase 3: Prove Flat Actions
+
+- [ ] Run `bun test packages/workspace/src/shared/actions.test.ts`.
+- [ ] Run `bun test packages/workspace/src/document/open-collaboration.test.ts`.
+- [ ] Run `bun test packages/workspace/src/daemon/run-handler.test.ts`.
+- [ ] Run `bun test packages/workspace/src/client/daemon-actions.test.ts`.
+- [ ] Run `bun test packages/workspace/src/ai/tool-bridge.test.ts`.
+- [ ] Run package or app typechecks for changed apps.
+- [ ] Search for `walkActions`, nested `.actions.foo.bar`, and `Actions` recursive assumptions.
+
+Do not delete compatibility helpers until this phase passes.
+
+### Phase 4: Standardize Script Facades
+
+- [ ] Keep Fuji as the reference shape: `openFujiSnapshot()` plus `openFujiScript()`.
+- [ ] For Honeycrisp, Opensidian, and Zhongwen, choose one:
+  - add snapshot plus daemon action proxy, if scripts are needed
+  - delete `script.ts`, if no script facade is needed yet
+- [ ] Ensure scripts do not call `createMachineAuthClient`.
+- [ ] Ensure scripts do not call `attachYjsSync`.
+- [ ] Ensure scripts either own a readonly local snapshot or a daemon client proxy, not both live runtime ownership and daemon overlap.
+
+Target script shape:
+
+```ts
+export async function openHoneycrispSnapshot(options = {}) {
+	// read local Yjs log
+	// return readonly tables
+}
+
+export async function openHoneycrispScript(options = {}) {
+	return {
+		snapshot: await openHoneycrispSnapshot(options),
+		actions: await connectHoneycrispDaemonActions(options),
+	};
+}
+```
+
+### Phase 5: Move Link Helpers Out Of Root Barrel
+
+- [ ] Add an explicit package export such as `@epicenter/workspace/links`.
+- [ ] Move public imports in Opensidian from `@epicenter/workspace` to `@epicenter/workspace/links`.
+- [ ] Keep internal relative imports in workspace materializers as-is unless a local barrel makes that clearer.
+- [ ] Remove link helpers from `packages/workspace/src/index.ts`.
+- [ ] Run link tests and Opensidian typecheck.
+
+Target:
+
+```ts
+import { makeEpicenterLink } from '@epicenter/workspace/links';
+```
+
+Root `@epicenter/workspace` should stop answering markdown/editor link questions.
+
+### Phase 6: Smaller Smell Sweep
+
+- [ ] Remove inert pending request fields in the sync supervisor.
+- [ ] Move pending request bookkeeping before send if tests can model synchronous responses.
+- [ ] Replace single-member sync mini-unions with plain fields or add real variants.
+- [ ] Route `apps/api` background logging through one diagnostics boundary.
+- [ ] Decide whether `defineTable` keeps the overload casts or gets a separate builder shape.
+- [ ] Remove unused exported protocol types or use them in decoder return types.
+
+These are cleanup follow-ups. They should not block the action and runtime clean break.
+
+## Build, Prove, Remove
+
+Use this sequence for the action migration:
+
+```txt
+Build:
+  add flat helpers
+  migrate package internals
+  migrate apps
+
+Prove:
+  run focused tests
+  run typechecks
+  grep for old nested assumptions
+
+Remove:
+  delete recursive walking
+  delete plain-object branch handling
+  delete class-instance skip tests
+  delete docs that explain nested action trees
+```
+
+Use this sequence for script cleanup:
+
+```txt
+Build:
+  add snapshot plus daemon action facade where needed
+
+Prove:
+  verify scripts compile
+  verify daemon action proxy still works
+
+Remove:
+  delete live script sync setup
+  delete machine-auth script ownership
+```
+
+## Edge Cases
+
+### Flat Key Validation
+
+Flat keys are public action addresses. They must be non-empty and must not contain empty segments.
+
+```txt
+valid:
+  entries.create
+  files.read
+  bash.exec
+
+invalid:
+  ""
+  ".create"
+  "entries."
+  "entries..create"
+```
+
+Underscores remain valid in action paths, but AI tool conversion must still guard against collisions when converting dots to underscores.
+
+### Local Ergonomics Loss
+
+Bracket syntax is less cute than nested property calls.
+
+```ts
+actions['entries.create'](input);
+```
+
+That is acceptable because the action path is the durable public address. The old local nicety forced recursive runtime and type machinery everywhere else.
+
+### Reserved Names
+
+There should be no reserved `system` action namespace. Runtime verbs stay on the runtime request plane.
+
+```txt
+peer.invoke('system.foo')
+  user action, if the app defines that flat key
+
+peer.describe()
+  runtime request, not user action
+```
+
+### Peer Discovery
+
+Awareness should publish only flat action paths, not schemas. Full metadata still comes from `peer.describe()`.
+
+```txt
+awareness:
+  identity
+  actionPaths
+
+runtime request:
+  describe-actions -> ActionManifest
+```
+
+## Open Questions
+
+1. **Should `ActionRegistry` allow non-action values during migration?**
+   - Option A: strict `Record<string, Action>` immediately.
+   - Option B: temporary `Record<string, unknown>` with validation.
+   - Recommendation: strict immediately. This is a clean break, and loose input preserves the old ambiguity.
+
+2. **Should app call sites get a helper to avoid bracket syntax?**
+   - Option A: no helper, use `actions['entries.create']`.
+   - Option B: add app-local aliases for hot paths.
+   - Recommendation: no framework helper. App-local aliases are fine where they improve component readability.
+
+3. **Should `script.ts` be deleted for apps without a real script consumer?**
+   - Option A: delete until needed.
+   - Option B: keep a placeholder snapshot facade.
+   - Recommendation: delete. Empty facades become stale boundaries.
+
+4. **Should link helpers live at `@epicenter/workspace/links` or under a markdown subpath?**
+   - Option A: `@epicenter/workspace/links`.
+   - Option B: `@epicenter/workspace/document/markdown-links`.
+   - Recommendation: `@epicenter/workspace/links`, because the helpers are generic Epicenter link format utilities, not only markdown materializer internals.
+
+## Final State Checklist
+
+- [ ] Root workspace exports describe caller-owned Y.Doc composition.
+- [ ] `openCollaboration` is the only workspace-doc collaboration primitive.
+- [ ] `attachYjsSync` is the only content-doc sync primitive.
+- [ ] `createSyncSupervisor` stays internal.
+- [ ] Actions are flat dot-path records.
+- [ ] Local, peer, daemon, CLI, and AI action surfaces use the same path.
+- [ ] App `document.ts` files have no runtime side effects beyond constructing local document attachments.
+- [ ] App `browser.ts` or `extension.ts` files own browser runtime wiring.
+- [ ] App `daemon.ts` files own Bun daemon runtime wiring.
+- [ ] App `script.ts` files either read snapshots and call daemon actions, or do not exist.
+- [ ] Markdown link helpers are imported from a link subpath, not the root workspace barrel.
+

--- a/specs/20260513T210000-collaboration-identity-roster-clean-break.md
+++ b/specs/20260513T210000-collaboration-identity-roster-clean-break.md
@@ -1,0 +1,408 @@
+# Collaboration Identity: Server-Owned Roster (Clean Break)
+
+**Date**: 2026-05-13
+**Status**: Superseded by `specs/20260513T235000-rpc-on-yjs-state.md`
+**Reason**: Identity, presence, and remote calls moved into Y.Doc state (see `packages/workspace/src/document/presence.ts`, `packages/workspace/src/document/rpc.ts`, `packages/sync/src/index.ts:7-13`). The HELLO / ROSTER / ROSTER_DIFF wire envelopes proposed here were never implemented; the wire now carries only Yjs sync frames. `packages/workspace/src/document/peer.ts` no longer exists, so the `Peer` type, `peer.invoke`, `peer.describe()`, `PeerLeftError`, and the runtime-request plane referenced throughout this document are gone. Keep this file for the audit trail; do not implement.
+**Author**: Braden + Claude
+**Original supersedes**: the awareness-as-identity model carried by `20260213T102800-workspace-awareness.md`, `20260403T161046-unify-awareness-with-sync-transport.md`, `20260425T000000-device-actions-via-awareness.md`, `20260426T130000-fold-awareness-into-sync.md`, and `20260426T230000-drop-manifest-from-awareness.md`. Those specs incrementally trimmed awareness toward "identity only." This spec finishes the move by removing identity from awareness entirely.
+
+## Why This Exists
+
+Two findings forced the rewrite.
+
+**Finding 1: nothing reads `replica.platform`.** A grep across `packages/` and `apps/` returns zero call sites that branch on `replica.platform`. Every site only writes it. The field is decoration. Today's `Replica { id, platform }` is a one-field object with a decorative second field.
+
+**Finding 2: Yjs awareness is the wrong protocol for our topology.** Awareness is a peer-gossip CRDT designed for symmetric multi-peer state replication with TTL heartbeats. Our wire is hub-and-spoke through a Cloudflare Durable Object: every awareness frame goes client -> DO -> client. We then added a second envelope (`AWARENESS_ATTESTED`) specifically to override awareness's "trust the publisher" default and stamp a server-authoritative `subject`. Two protocols cooperating to undo each other's defaults is a smell.
+
+The killer sentence the model must survive:
+
+```
+When I see an online thing, I can explain who owns it, what exact thing it is,
+whether it is live, what it can do, and what the UI should call it.
+```
+
+The roster model below answers each clause with one field and one source.
+
+## One Sentence
+
+```
+Identity is server-owned and lives in a ROSTER pushed over the same WebSocket
+that syncs the workspace doc: server-stamped subject, client-claimed install
+id, and a static per-connection action key list.
+```
+
+## The Model
+
+```
+        subject (server-stamped, trust boundary, always present)
+           │
+           └─ owns ─┐
+                    ▼
+              replicaId (client-claimed, install-stable, flat string)
+                    │
+                    └─ advertises ─┐
+                                    ▼
+                              actionKeys (static per connection)
+                                    │
+                                    └─ described by ─┐
+                                                      ▼
+                                                ActionManifest
+                                                (fetched on demand via
+                                                 the describe-actions
+                                                 runtime verb)
+
+Liveness:    in the ROSTER  <=>  socket open
+Trust:       subject        <=>  server says so
+Address:     replicaId      <=>  client claimed, stable across reconnects
+Capability:  actionKeys     <=>  declared at HELLO, frozen for connection
+Permission:  PermissionDenied at invoke() time, separate axis from capability
+```
+
+### Invariants (locked)
+
+1. **`actionKeys` are immutable for the lifetime of a connection.** To change them, close the WebSocket and reconnect. Captures the fact that `actionKeys` is already computed once at `openCollaboration` startup and frozen.
+2. **`subject` is always populated** for any peer in the roster. The server adds a peer only after auth validation. If auth dies mid-connection, server closes the socket; the peer leaves the roster cleanly.
+3. **`replicaId` is required, flat, and client-claimed.** The server does not vouch for it. Vouching for who you are is `subject`'s job.
+4. **No `platform` field anywhere on the wire or in the public API.** If a future feature needs platform-shaped branching, that is a capability question and belongs in `actionKeys`.
+5. **No `profile` / `display` / avatar in the core protocol.** Human-facing labels live in app-side Yjs tables keyed by `replicaId`.
+6. **`clientID` is internal.** Address peers by `replicaId`. The Yjs awareness `clientID` (and the new server-minted `connId`) are not in the public `Peer` type.
+7. **Capability and permission are separate channels.** `actionKeys` declares what code is loaded. `invoke()` failure declares what the caller is allowed to run.
+
+## Wire Protocol
+
+```
+WIRE, BEFORE                            WIRE, AFTER
+────────────────────────────            ────────────────────────────
+ACTION_REQUEST  / RESPONSE              ACTION_REQUEST  / RESPONSE
+RUNTIME_REQUEST / RESPONSE              HELLO        client -> server
+AWARENESS                               ROSTER       server -> client
+AWARENESS_ATTESTED                      ROSTER_DIFF  server -> client
+SYNC_STEP1 / STEP2 / UPDATE             SYNC_STEP1 / STEP2 / UPDATE
+```
+
+Two envelope planes deleted: the awareness pair AND the runtime-request pair. The runtime plane had exactly one consumer (`describe-actions`); inlining the manifest in HELLO leaves it with zero consumers, so it goes too.
+
+### HELLO (client -> server, exactly once after socket open)
+
+```
+{
+  replicaId:      string,
+  actionManifest: ActionManifest   // full JSON-Schema-bearing manifest
+}
+```
+
+`actionKeys` is not on the wire. Clients derive it as `Object.keys(actionManifest).sort()` on receive for fast filtering.
+
+### ROSTER (server -> client, once on connect)
+
+```
+{
+  self:  ConnId,                 // the receiving client's own connId, so it can self-filter
+  peers: RosterEntry[]           // includes self; client filters
+}
+
+RosterEntry = {
+  connId:         string,           // server-minted, per-connection
+  subject:        Subject,          // server-known from auth session
+  replicaId:      string,           // from HELLO
+  actionManifest: ActionManifest    // from HELLO
+}
+```
+
+### ROSTER_DIFF (server -> client, on every roster mutation)
+
+```
+{
+  joined?: RosterEntry[],
+  left?:   ConnId[]
+}
+```
+
+There is no `updated` shape. Action manifests are immutable per connection by invariant 1.
+
+### Bandwidth analysis
+
+Under the static invariant, each peer's manifest is sent **at most once per recipient per peer-existence window**. There is no awareness-style cadence or TTL refresh.
+
+```
+Typical manifest:          ~5-20 actions x ~500 bytes/schema = 2.5-10 KB
+Worst realistic case:      10 peers, 10 KB manifests, one fresh join
+  - joining peer:          downloads ~100 KB once
+  - existing peers:        receive ~10 KB each, once
+  - lifetime total / pair: bounded; cannot re-broadcast
+```
+
+A single Y.Doc snapshot dwarfs this. The wire cost is structurally negligible.
+
+### Why inline (not on-demand)
+
+```
+SCENARIO                              INLINE         ON-DEMAND
+─────────────────────────────────     ────────       ─────────
+Consumer never reads manifest         pays ~10KB     pays 0
+Consumer reads manifest once          pays ~10KB     pays ~10KB + RTT
+Consumer needs synchronous routing    free           blocked on RTT
+Wire plane count                      4              5
+peer.describe() exists                no             yes (RTT-bound)
+```
+
+Inline pays a fixed, bounded bandwidth cost in exchange for deleting a whole wire plane (`RUNTIME_REQUEST` / `RUNTIME_RESPONSE`) and making capability discovery synchronous. The static invariant guarantees the cost cannot grow with time.
+
+## Public API
+
+```ts
+// packages/workspace/src/document/peer.ts (after migration)
+
+export type Subject = string;
+
+export type Peer<TActions = unknown> = {
+  readonly subject: Subject;                  // ALWAYS populated, never empty string
+  readonly replicaId: string;
+  readonly actionManifest: ActionManifest;    // full schema, available immediately
+  readonly actionKeys: readonly string[];     // derived view of manifest keys, sorted
+
+  invoke<TMap, TPath>(
+    path: TPath,
+    input: TMap[TPath]['input'],
+    options?: RemoteCallOptions,
+  ): Promise<Result<TMap[TPath]['output'], RemoteCallError>>;
+
+  // peer.describe() is GONE. peer.actionManifest is the answer.
+};
+
+export type PeersSurface = {
+  list(): Peer[];
+  find<TActions>(replicaId: string): Peer<TActions> | undefined;
+  observe(callback: () => void): () => void;
+};
+```
+
+```ts
+// packages/workspace/src/document/open-collaboration.ts (after migration)
+
+openCollaboration(ydoc, {
+  url,
+  waitFor: idb.whenLoaded,
+  openWebSocket,
+  replicaId: createReplicaId({ storage: localStorage }),  // FLAT, was config.replica
+  actions,
+});
+```
+
+## What Disappears
+
+```
+packages/workspace/src/document/
+  attach-awareness.ts          DELETE from openCollaboration usage
+                               (file kept available for per-doc cursor UX later)
+  attach-awareness.test.ts     UPDATE to test the standalone primitive only
+  peer-identity.ts             COLLAPSE: Replica schema, Platform type, nested
+                               peerAwarenessSchema.replica all gone
+  internal/sync-supervisor.ts  DELETE peerMetadata + currentEnvelopeSubject
+                               + handleRemoteAwarenessAttested + the
+                               AWARENESS_ATTESTED switch branch
+                               DELETE sendRuntimeRequest implementation
+                               DELETE onRuntimeRequest config + dispatch
+  peer.ts                      DELETE PeerLeftError + the dispatch() watchdog;
+                               server returns PeerNotFound synchronously
+                               DELETE peer.describe() method
+                               DELETE PeerWireHooks.sendRuntimeRequest
+  replica-id.ts                DELETE createReplicaIdAsync (sync variant suffices)
+
+packages/sync/
+  AWARENESS envelope kind + codec       DELETE
+  AWARENESS_ATTESTED envelope kind      DELETE
+  decodeAwarenessAttestedPayload        DELETE
+  RUNTIME_REQUEST envelope kind         DELETE
+  RUNTIME_RESPONSE envelope kind        DELETE
+  RuntimeVerb type                      DELETE
+  encodeRuntimeRequest/decodeRuntimeRequest  DELETE
+
+packages/workspace/src/document/open-collaboration.ts:
+  onRuntimeRequest config field         DELETE
+  the entire onRuntimeRequest switch    DELETE (its one branch went into HELLO)
+```
+
+## What Appears
+
+```
+packages/sync/src/wire/
+  HELLO        envelope kind + codec    NEW (~30 lines)
+  ROSTER       envelope kind + codec    NEW
+  ROSTER_DIFF  envelope kind + codec    NEW
+
+packages/workspace/src/document/
+  roster.ts                              NEW (~80 lines)
+    createRosterMirror(supervisor)
+      subscribes to ROSTER + ROSTER_DIFF
+      exposes a Map<ConnId, RosterEntry>
+      drives the existing peers surface signature
+  internal/sync-supervisor.ts            REPLACE awareness wiring with HELLO
+                                          send-on-connect and roster ingest
+
+apps/api/src/sync-handlers.ts            NEW server-side roster:
+                                            - per-DO Map<ConnId, RosterEntry>
+                                            - HELLO ingest -> validate -> insert
+                                              -> send ROSTER to new conn
+                                              -> broadcast ROSTER_DIFF to others
+                                            - onclose -> remove + broadcast LEFT
+```
+
+Net code: roughly flat in lines. Net conceptual weight: substantial reduction (one protocol instead of two, server-authoritative state, no join-at-read-time pattern).
+
+## Public Surface Changes (caller migration)
+
+```
+// AWARENESS PAYLOAD
+{ replica: { id, platform }, actionKeys }   ->   { replicaId, actionKeys }
+
+// CONFIG
+openCollaboration(ydoc, { ..., replica: { id, platform } })
+  ->   openCollaboration(ydoc, { ..., replicaId })
+
+// PEER FIELDS
+peer.replica.id            ->   peer.replicaId
+peer.replica.platform      ->   REMOVED
+peer.clientID              ->   REMOVED from public type
+peer.subject               ->   STILL THERE, now non-nullable Subject
+peer.actionKeys            ->   STILL THERE, derived view of manifest keys
+peer.actionManifest        ->   NEW: full manifest available synchronously
+peer.describe()            ->   REMOVED (use peer.actionManifest)
+
+// ERROR TYPES
+PeerLeftError              ->   REMOVED (use RpcError.PeerNotFound)
+
+// EXPORTS FROM packages/workspace
+export { Replica, Platform }           ->   REMOVED
+export type { PeerAwarenessState }     ->   REMOVED (no public schema anymore)
+```
+
+## Call Sites Affected
+
+```
+apps/fuji/blocks/daemon-route.ts       replica: { id, platform } -> replicaId
+apps/fuji/src/lib/session.ts           same
+apps/honeycrisp/blocks/script.ts       same
+apps/honeycrisp/blocks/daemon-route.ts same
+apps/honeycrisp/src/lib/session.ts     same
+apps/opensidian/blocks/script.ts       same
+apps/opensidian/blocks/daemon-route.ts same
+apps/opensidian/src/lib/session.ts     same
+apps/zhongwen/blocks/script.ts         same
+apps/zhongwen/blocks/daemon-route.ts   same
+apps/tab-manager/src/lib/device.ts     same
+apps/api/src/sync-handlers.ts          rewrite for HELLO/ROSTER ingest
+apps/api/src/sync-handlers.test.ts     update test fixtures
+
+packages/cli/src/commands/up.ts        peer.replica.id -> peer.replicaId
+                                       drop clientID printing
+packages/workspace/src/daemon/app.ts   peer.replica -> peer.replicaId
+                                       drop subject empty-string handling
+packages/workspace/src/daemon/run-handler.ts   no change (already uses replicaId)
+```
+
+## Implementation Plan
+
+This is a **single clean break** at the wire. No dual-protocol grace period. Pre-GA tolerates this; post-GA would not.
+
+### Wave 1: Wire shapes and codecs (`@epicenter/sync`)
+
+- [ ] Add `HELLO`, `ROSTER`, `ROSTER_DIFF` envelope kinds with arktype-validated payloads. HELLO and RosterEntry both carry the full `ActionManifest`.
+- [ ] Remove `AWARENESS` and `AWARENESS_ATTESTED` envelope kinds and their codecs.
+- [ ] Remove `RUNTIME_REQUEST` and `RUNTIME_RESPONSE` envelope kinds, the `RuntimeVerb` type, and their codecs.
+- [ ] Update wire docs.
+
+### Wave 2: Server-side roster (`apps/api`)
+
+- [ ] In the workspace DO, maintain `Map<ConnId, RosterEntry>` per workspace.
+- [ ] Validate auth at the Hono WS upgrade; attach `subject` to the connection.
+- [ ] On HELLO: validate `replicaId` and `actionKeys` against `ACTION_KEY_PATTERN`; insert into roster; send `ROSTER` to the new conn; broadcast `ROSTER_DIFF { joined }`.
+- [ ] On socket close: remove from roster; broadcast `ROSTER_DIFF { left }`.
+- [ ] On `ACTION_REQUEST` whose target `connId` is not in the roster: return `RpcError.PeerNotFound` synchronously without relaying.
+- [ ] Update `apps/api/src/sync-handlers.test.ts` fixtures.
+
+### Wave 3: Client-side roster mirror (`packages/workspace`)
+
+- [ ] Add `roster.ts` exporting `createRosterMirror` that subscribes to `ROSTER`/`ROSTER_DIFF` and exposes a `Map<ConnId, RosterEntry>` plus observer.
+- [ ] Rewrite `peer.ts` `createPeersSurface` to read from the roster mirror instead of awareness states + peerMetadata.
+- [ ] Drop `dispatch()` watchdog. `invoke()` returns server's `PeerNotFound` directly.
+- [ ] Remove `PeerLeftError`.
+- [ ] Update `Peer` type: `subject: Subject` (non-nullable), `replicaId: string`, `actionManifest: ActionManifest`, derived `actionKeys: readonly string[]`. Drop `clientID`, drop `replica`, drop `describe()`.
+- [ ] Remove `onRuntimeRequest` config from `openCollaboration` and the entire runtime-verb switch.
+- [ ] Remove `sendRuntimeRequest` from supervisor and `PeerWireHooks`.
+
+### Wave 4: Collapse `Replica` to `replicaId`
+
+- [ ] In `open-collaboration.ts`, change `config.replica: Replica` to `config.replicaId: string`.
+- [ ] Delete the `Replica` arktype, `Platform` type, and `peerAwarenessSchema` (or shrink to a one-field HELLO validator scoped inside `roster.ts`).
+- [ ] Remove `Replica` and `Platform` from `packages/workspace/src/index.ts` exports.
+- [ ] Stop importing `y-protocols/awareness` from `open-collaboration.ts`. (The `attach-awareness.ts` file stays as an opt-in primitive for future per-doc cursor UX; it is no longer used by the collaboration primitive.)
+- [ ] Drop `createReplicaIdAsync`; keep `createReplicaId`.
+
+### Wave 5: Sweep call sites
+
+- [ ] Update every `replica: { id, platform }` site listed in "Call Sites Affected."
+- [ ] Update CLI/daemon log strings (`peer.replica.id` -> `peer.replicaId`; drop `clientID`).
+- [ ] Update example in `packages/workspace/src/index.ts` JSDoc.
+- [ ] Update `docs/architecture.md`.
+
+### Wave 6: Tests
+
+- [ ] Rewrite `peer.test.ts` against the roster mirror (no awareness mocks).
+- [ ] Update `open-collaboration.test.ts` to assert HELLO is sent and ROSTER is consumed.
+- [ ] Update or delete `attach-awareness.test.ts` depending on whether the primitive stays.
+- [ ] Add new tests for `apps/api/sync-handlers` covering HELLO validation, ROSTER push, ROSTER_DIFF on join/leave, and PeerNotFound on invoke to absent connId.
+
+### Wave 7: Post-implementation review
+
+- [ ] Run the `post-implementation-review` skill: re-read every touched file, audit for stale comments referencing awareness/AWARENESS_ATTESTED/PeerLeft/`Replica`, confirm exports in `index.ts` match the new surface, confirm the killer sentence holds end-to-end.
+
+## What This Closes (Honest Downsides)
+
+1. **Live capability tuning by reconnect.** "User upgraded to Pro, now expose `pro_export_pdf`" requires the client to close and reopen the WebSocket. Acceptable; reconnects are cheap; subscription-state changes are infrequent. The right alternative for permission-gated UX is a separate `permittedActions` view, not mutating `actionKeys`.
+2. **Runtime plugin loading.** Apps that install code at runtime need a reconnect for peers to see the new actions. Most plugin systems already require a restart at the module-resolution layer; reconnect on top is free.
+3. **Hiding buttons by permission.** UIs that want to hide rather than show-and-fail can't use `actionKeys` for it. Either accept show-and-fail (recommended), or model permissions as a separate roster-side concern later.
+
+These are bounded. None of them are current product features.
+
+## What This Does Not Touch
+
+```
+Y.Doc sync protocol (SYNC_STEP1/2/UPDATE)   unchanged
+attachIndexedDb / BroadcastChannel          orthogonal
+attachTable / attachKv / attachTimeline     orthogonal
+@epicenter/encryption                       orthogonal
+ActionRegistry / defineQuery / defineMutation  unchanged
+Action dispatch core in sync-supervisor     unchanged
+```
+
+The blast radius is scoped to the identity + presence layer. Resist the temptation to bundle adjacent cleanups.
+
+## Open Questions
+
+1. **`attachAwareness` as a public primitive going forward.** Keep it exported for future per-doc live-cursor UX, or delete outright? Recommend keep, drop from collaboration, document the per-doc use case in JSDoc.
+2. **Roster on DO eviction.** DO storage vs. memory-only? Memory-only is correct (sockets die on eviction anyway), but confirm the eviction-then-reconnect path doesn't leave a stale roster snapshot for clients that reconnected to a respun DO.
+3. **`connId` minting strategy.** Crypto-random 128-bit? Counter? Either works; pick one and document.
+4. **Reconnection identity continuity.** Client reconnects with same `replicaId`; server treats it as a fresh peer (new `connId`, ROSTER_DIFF emits `left` for the old + `joined` for the new). Confirm this is the policy and document it.
+5. **`subject` exposure cross-workspace.** If one client app opens connections to two workspaces, do both report the same `subject` value? They should (it's the better-auth user id). Verify before relying on it for cross-workspace UX.
+
+## Migration Direction Summary
+
+| Field / Concept     | Action     | Rationale                                                   |
+| ------------------- | ---------- | ----------------------------------------------------------- |
+| `Replica.platform`  | DELETE     | Zero readers in codebase                                    |
+| `Replica` (object)  | FLATTEN    | One-field object; collapses to `replicaId: string`          |
+| `Platform` type     | DELETE     | No consumers                                                |
+| `Peer.clientID`     | INTERNAL   | Debug-only today; not part of the public model              |
+| `Peer.subject`      | KEEP+TIGHTEN | Now non-nullable `Subject`, never empty string             |
+| `Peer.actionKeys`   | KEEP       | Static per connection, advertised in HELLO                  |
+| `AWARENESS` envelope| DELETE     | Replaced by `ROSTER`                                        |
+| `AWARENESS_ATTESTED`| DELETE     | Subject lives in roster entry, server-authored             |
+| `peerMetadata` map  | DELETE     | Roster replaces it; no join-at-read-time                   |
+| `PeerLeftError`     | DELETE     | Server returns `PeerNotFound` synchronously                 |
+| `createReplicaIdAsync` | DELETE  | Sync variant suffices; async init can run before open      |
+| `attachAwareness`   | DEMOTE     | Opt-in per-doc primitive; not used by `openCollaboration`   |
+| `ActionManifest`    | INLINE     | Rides HELLO/ROSTER; deletes the entire RUNTIME_REQUEST plane |
+| `describe-actions`  | DELETE     | Zero consumers once manifest is inline                       |
+| `peer.describe()`   | DELETE     | Replaced by `peer.actionManifest` (synchronous accessor)     |
+| `RUNTIME_REQUEST/RESPONSE` | DELETE | Had one consumer; manifest inlining left it empty         |

--- a/specs/20260514T000000-actions-docs-rewrite-tier2.md
+++ b/specs/20260514T000000-actions-docs-rewrite-tier2.md
@@ -1,7 +1,7 @@
 # Tier 2: Actions Documentation Rewrite
 
 **Date**: 2026-05-14
-**Status**: Proposed
+**Status**: Implemented
 **Author**: Braden + Claude
 **Follow-up to**: `20260513T233714-define-actions-typed-key-validation.md`
 
@@ -27,6 +27,16 @@ This is a documentation pass, not a code refactor. Drafted as a separate spec so
 - New examples that aren't already in the existing docs.
 - The articles in `docs/articles/` (each is point-in-time prose; leave historical accuracy alone unless a claim is misleading today).
 - The historical specs (`20260513T200000-workspace-surface-clean-break-vision.md`, `20260513T210000-actions-path-first-clean-break.md`, `20260513T231157-actions-snake-case-only-no-dots.md`). Status fields are already set; bodies are records of decisions.
+
+## Execution note
+
+Current status: already implemented in the published docs. `packages/workspace/README.md`, `packages/workspace/SYNC_ARCHITECTURE.md`, and `packages/ai/README.md` already describe flat `ActionRegistry` authoring with `defineActions({...})`, snake_case action keys, `Object.entries(...)` iteration, and AI tool names that equal action keys verbatim.
+
+Implemented now: marked this spec as implemented and kept the docs unchanged because the current tracked files already match the source barrel in `packages/workspace/src/index.ts`.
+
+Out of scope now: no source changes, no article rewrites, and no historical spec rewrites.
+
+Validation: stale-term greps below should return zero hits except generic words such as `Actions` in headings or type names like `Collaboration<TActions>`.
 
 ## Affected files
 
@@ -56,7 +66,7 @@ You are updating three published documentation files to match the current state 
 
 ### File 1: `packages/workspace/README.md`
 
-Audit the whole `## Core Concepts` → `### Actions` section (around line 395) and the worked examples around lines 1085–1280. The pattern of stale claims is:
+Audit the whole `## Core Concepts` to `### Actions` section (around line 395) and the worked examples around lines 1085-1280. The pattern of stale claims is:
 
 - Authoring shape: examples use `actions = { posts: { list: defineQuery(...) } }`. Rewrite to flat:
   ```ts
@@ -152,7 +162,7 @@ grep -rn "walkActions\|describeActions\|type Mutation\|type Query\|DotsToUndersc
 
 ### Constraints
 
-- No em dashes (`—`) or en dashes (`–`). Use colon, comma, semicolon, parenthesis, or sentence break.
+- No em dash or en dash characters. Use colon, comma, semicolon, parenthesis, or sentence break.
 - No emojis (existing docs do not use them).
 - Keep section ordering and headings unless a heading is itself stale.
 - Where two equivalent phrasings exist, prefer the one that names the actual API in `packages/workspace/src/index.ts`.
@@ -205,7 +215,7 @@ Keep this spec file open in a fourth tab.
 
 ### Step 1: workspace README, the imports block (line ~1489)
 
-Search for `### Actions` in `packages/workspace/README.md`. There are two — find the one inside `## Public adapter surface` (around line 1489).
+Search for `### Actions` in `packages/workspace/README.md`. There are two; find the one inside `## Public adapter surface` (around line 1489).
 
 Current:
 ```typescript
@@ -242,7 +252,7 @@ Why each change:
 - `defineActions` and `toActionMeta` are the new helpers worth surfacing.
 - `ActionRegistry` is the type to name when documenting the registry shape.
 
-### Step 2: workspace README, the introspection example (lines 1235–1280)
+### Step 2: workspace README, the introspection example (lines 1235-1280)
 
 Look for `### Introspection` (around line 1236).
 
@@ -321,7 +331,7 @@ if (createAction.type === 'mutation') {
 
 Why: `isQuery`/`isMutation` were dropped from the barrel; consumers narrow on `action.type` directly. The discriminant is carried by `Action<_, _, TType>`.
 
-### Step 3: workspace README, the queries example (lines 1080–1130)
+### Step 3: workspace README, the queries example (lines 1080-1130)
 
 Search for `### Query actions`. Replace nested authoring with flat + `defineActions`:
 
@@ -352,7 +362,7 @@ const actionType = workspace.actions.posts.list.type;
 const actionType = workspace.actions.posts_list.type;
 ```
 
-### Step 4: workspace README, the mutations example (lines 1145–1200)
+### Step 4: workspace README, the mutations example (lines 1145-1200)
 
 Search for `### Mutation actions`. Same treatment:
 
@@ -403,7 +413,7 @@ There's a bullet list of exported names. Search for `walkActions`:
 - Add `- \`defineActions(actions)\``.
 - Add `- \`toActionMeta(action)\``.
 
-### Step 8: workspace README, the long-form walkActions description (lines 1576–1660)
+### Step 8: workspace README, the long-form walkActions description (lines 1576-1660)
 
 Search for `walkActions(source)` paragraph. Rewrite:
 

--- a/specs/20260514T013918-source-app-manifest-bridge-slice.md
+++ b/specs/20260514T013918-source-app-manifest-bridge-slice.md
@@ -1,0 +1,187 @@
+# Source App Manifest And Bridge Slice
+
+**Date**: 2026-05-14
+**Status**: Queued
+**Author**: Braden + Codex
+**Follow-up to**: `20260512T234944-source-installed-app-runtime-vision.md`
+
+## Sentence
+
+Define the first source-installed app contract in TypeScript: manifest parsing plus typed invoke bridge factories, without loading an app into Tauri yet.
+
+## Current Code Truth
+
+The source runtime package does not exist yet. There is no `@epicenter/app` package, no installed app loader, and no generic Epicenter Tauri shell for source apps.
+
+The shipped action and RPC model is already settled for now:
+
+```txt
+actions
+  defineActions({...})
+  flat snake_case keys
+
+remote dispatch
+  collab.dispatch(action, input, { to: connId, signal })
+  RPC rows stored in Yjs state
+```
+
+This slice must not change that model. The bridge is for trusted same-device SPAs calling Tauri commands. If a later operation needs scripts, agents, CLI, peers, or workers, a later spec can promote it into a flat snake_case action.
+
+Whispering already proves the native side of the pattern with direct Tauri invoke calls for CPAL recording and transcription. This slice extracts the author-facing contract without moving Whispering or adding a loader.
+
+## Scope
+
+Implement a new package:
+
+```txt
+packages/app/
+  package.json
+  src/
+    index.ts
+    manifest.ts
+    bridge.ts
+    bridge.test.ts
+    manifest.test.ts
+  tsconfig.json
+```
+
+Package name:
+
+```json
+{
+  "name": "@epicenter/app"
+}
+```
+
+Exports:
+
+```ts
+export {
+  AppManifest,
+  AppPermission,
+  AppManifestError,
+  parseAppManifest,
+  type SourceInstalledAppManifest,
+} from './manifest.js';
+
+export {
+  createEpicenterBridge,
+  type EpicenterBridge,
+  type EpicenterInvoke,
+} from './bridge.js';
+```
+
+## Manifest Contract
+
+Define the phase 1 manifest shape:
+
+```ts
+type SourceInstalledAppManifest = {
+  id: string;
+  name: string;
+  entry: string;
+  permissions: AppPermission[];
+};
+```
+
+Initial permission union:
+
+```ts
+type AppPermission =
+  | 'workspace:read'
+  | 'documents:write'
+  | 'assets:write'
+  | 'audio:record'
+  | 'window:manage';
+```
+
+Validation rules:
+
+```txt
+id: lowercase ASCII slug, max 64 chars
+name: non-empty string, max 80 chars
+entry: relative path ending in .html
+permissions: known strings only, deduped in original order
+unknown keys: rejected
+```
+
+Use `arktype` for the runtime schema, following the existing package pattern in `packages/auth`, `packages/encryption`, and `packages/filesystem`.
+
+Return a `Result<SourceInstalledAppManifest, AppManifestError>` instead of throwing. Use `defineErrors` for at least:
+
+```txt
+InvalidManifest
+InvalidEntry
+UnknownPermission
+```
+
+## Bridge Contract
+
+The bridge is a typed wrapper around an injected invoke function:
+
+```ts
+export type EpicenterInvoke = <T>(
+  command: string,
+  args?: Record<string, unknown>,
+) => Promise<T>;
+
+export function createEpicenterBridge(options: {
+  invoke: EpicenterInvoke;
+}): EpicenterBridge;
+```
+
+Initial bridge methods:
+
+```ts
+epicenter.audio.record(input)
+epicenter.transcription.run(input)
+epicenter.documents.append(input)
+epicenter.window.resize(input)
+```
+
+For this slice, define serializable TypeScript input and output types next to the bridge. Do not derive them from Rust yet. The command names should stay snake_case and boring:
+
+```txt
+audio_record
+transcription_run
+documents_append
+window_resize
+```
+
+Bridge tests should inject a fake invoke and assert that each method calls the expected command with the expected payload.
+
+## Out Of Scope
+
+- No installed source directory yet.
+- No app copying, update flow, or merge flow.
+- No Tauri webview loader.
+- No Rust command changes.
+- No Whispering extraction.
+- No permission review UI.
+- No Bun action runtime.
+- No `actions.ts` convention.
+- No handler context object.
+- No peer, worker, or CLI invocation.
+- No changes to `packages/workspace` RPC, presence, or action key behavior.
+
+## Implementation Plan
+
+- [ ] **1.1** Add `packages/app/package.json` and `tsconfig.json`.
+- [ ] **1.2** Add `manifest.ts` with `AppManifest`, `AppPermission`, `parseAppManifest`, and `AppManifestError`.
+- [ ] **1.3** Add manifest tests for valid input, unknown keys, bad entry paths, duplicate permissions, and unknown permissions.
+- [ ] **1.4** Add `bridge.ts` with `createEpicenterBridge`, `EpicenterBridge`, `EpicenterInvoke`, and serializable method input/output types.
+- [ ] **1.5** Add bridge tests with a fake invoke.
+- [ ] **1.6** Export the package surface from `src/index.ts`.
+- [ ] **1.7** Run `bun test packages/app` and `bun run --cwd packages/app typecheck`.
+
+## Acceptance
+
+- `@epicenter/app` exists as a small TypeScript-only package.
+- Manifest validation rejects malformed app source before any loader exists.
+- The typed bridge centralizes command names without changing Rust or existing apps.
+- No existing app imports `@epicenter/app` in this slice.
+- No action runtime, handler context object, or peer dispatch abstraction is introduced.
+
+## Notes For The Implementer
+
+Keep this boring. The package should be a contract and a convenience wrapper, not a runtime. If implementation pressure starts pulling in app loading, file copying, Tauri window creation, permissions UI, or action promotion, stop and write the next follow-up spec instead.


### PR DESCRIPTION
The workspace package had accumulated a broad root barrel, optional collaboration actions, and docs that still described older `attachSync` names. That made the public surface feel larger than the actual primitives and let collaboration peers omit an action registry even though the daemon and app call sites now treat actions as part of the runtime contract.

This branch tightens that shape:

```ts
openCollaboration(ydoc, {
	url,
	openWebSocket,
	replicaId,
	actions,
});
```

The root barrel now favors primitives, with materializers, daemon helpers, and other secondary surfaces living behind subpaths. A few dishonest type assertions are removed while touching the same API layer.

The docs/spec side is bundled here because it follows the same cleanup wave: stale `attachSync` references are updated, action docs are refreshed, source-installed app runtime specs are added, and older clean-break planning notes are marked with their superseding direction.

Verification: covered by the stacked app/workspace typecheck from the top branch.

```sh
bun run typecheck --filter=@epicenter/api --filter=@epicenter/workspace --filter=@epicenter/fuji --filter=@epicenter/honeycrisp --filter=opensidian --filter=@epicenter/tab-manager --filter=@epicenter/zhongwen --filter=@examples/notes-cross-peer
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->