### PR TITLE
refactor(daemon): inject shared auth into routes

### DIFF
--- a/apps/fuji/blocks/daemon-route.ts
+++ b/apps/fuji/blocks/daemon-route.ts
@@ -1,4 +1,3 @@
-import { createMachineAuthClient } from '@epicenter/auth/node';
 import { EPICENTER_API_URL } from '@epicenter/constants/apps';
 import {
 	attachEncryption,
@@ -30,8 +29,7 @@ import {
 export function defineFujiDaemon({ route = 'fuji' }: { route?: string } = {}) {
 	return {
 		route,
-		async start({ projectDir }) {
-			const auth = await createMachineAuthClient();
+		async start({ auth, projectDir }) {
 			if (auth.state.status === 'signed-out') {
 				throw new Error('[fuji-daemon] auth signed-out at start.');
 			}

--- a/apps/honeycrisp/blocks/daemon-route.ts
+++ b/apps/honeycrisp/blocks/daemon-route.ts
@@ -1,4 +1,3 @@
-import { createMachineAuthClient } from '@epicenter/auth/node';
 import { EPICENTER_API_URL } from '@epicenter/constants/apps';
 import {
 	attachEncryption,
@@ -23,8 +22,7 @@ export function defineHoneycrispDaemon({
 } = {}) {
 	return {
 		route,
-		async start({ projectDir }) {
-			const auth = await createMachineAuthClient();
+		async start({ auth, projectDir }) {
 			if (auth.state.status === 'signed-out') {
 				throw new Error('[honeycrisp-daemon] auth signed-out at start.');
 			}

--- a/apps/opensidian/blocks/daemon-route.ts
+++ b/apps/opensidian/blocks/daemon-route.ts
@@ -1,4 +1,3 @@
-import { createMachineAuthClient } from '@epicenter/auth/node';
 import { EPICENTER_API_URL } from '@epicenter/constants/apps';
 import {
 	attachEncryption,
@@ -19,8 +18,7 @@ export function defineOpensidianDaemon({
 } = {}) {
 	return {
 		route,
-		async start({ projectDir }) {
-			const auth = await createMachineAuthClient();
+		async start({ auth, projectDir }) {
 			if (auth.state.status === 'signed-out') {
 				throw new Error('[opensidian-daemon] auth signed-out at start.');
 			}

--- a/apps/zhongwen/blocks/daemon-route.ts
+++ b/apps/zhongwen/blocks/daemon-route.ts
@@ -1,4 +1,3 @@
-import { createMachineAuthClient } from '@epicenter/auth/node';
 import { EPICENTER_API_URL } from '@epicenter/constants/apps';
 import {
 	attachEncryption,
@@ -23,8 +22,7 @@ export function defineZhongwenDaemon({
 } = {}) {
 	return {
 		route,
-		async start({ projectDir }) {
-			const auth = await createMachineAuthClient();
+		async start({ auth, projectDir }) {
 			if (auth.state.status === 'signed-out') {
 				throw new Error('[zhongwen-daemon] auth signed-out at start.');
 			}

--- a/packages/auth/src/create-oauth-app-auth.ts
+++ b/packages/auth/src/create-oauth-app-auth.ts
@@ -260,7 +260,8 @@ export function createOAuthAppAuth({
 		} else {
 			headers.delete('Authorization');
 		}
-		return fetchImpl(normalizeFetchInput(input, baseURL), {
+		const normalizedInput = normalizeFetchInput(input, baseURL);
+		return fetchImpl(normalizedInput as Parameters<typeof fetchImpl>[0], {
 			...init,
 			headers,
 			credentials: 'omit',

--- a/packages/cli/src/load-config.test.ts
+++ b/packages/cli/src/load-config.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import type { AuthClient } from '@epicenter/auth';
 import {
 	CONFIG_FILENAME,
 	loadDaemonConfig,
@@ -40,6 +41,18 @@ const daemonTransportFields = `
 	},
 `;
 
+function fakeAuthClient(): AuthClient {
+	return {
+		state: { status: 'signed-out' },
+		onStateChange: () => () => undefined,
+		startSignIn: async () => ({ data: undefined, error: null }),
+		signOut: async () => ({ data: undefined, error: null }),
+		fetch: globalThis.fetch.bind(globalThis),
+		openWebSocket: async (url, protocols) => new WebSocket(url, protocols),
+		[Symbol.dispose]() {},
+	};
+}
+
 describe('loadDaemonConfig', () => {
 	test('loads helper config without starting route definitions', async () => {
 		writeConfig(`
@@ -50,11 +63,12 @@ describe('loadDaemonConfig', () => {
 				daemon: {
 					routes: [{
 						route: 'demo',
-						start: ({ projectDir, route }) => {
+						start: ({ auth, projectDir, route }) => {
 							globalThis.__loadConfigEvents.push('started');
 							return {
 								collaboration: {
 									actions: {
+										paths_auth_status: { handler: () => auth.state.status },
 										paths_project_dir: { handler: () => projectDir },
 										paths_route: { handler: () => route }
 									},
@@ -82,7 +96,9 @@ describe('loadDaemonConfig', () => {
 		).toEqual([]);
 
 		if (loaded.error !== null) return;
-		const started = await startDaemonRoutes(loaded.data);
+		const started = await startDaemonRoutes(loaded.data, {
+			auth: fakeAuthClient(),
+		});
 
 		expect(started.error).toBeNull();
 		expect(started.data?.map((entry) => entry.route)).toEqual(['demo']);
@@ -91,6 +107,7 @@ describe('loadDaemonConfig', () => {
 			| undefined;
 		expect(actions?.paths_project_dir?.handler()).toBe(workDir);
 		expect(actions?.paths_route?.handler()).toBe('demo');
+		expect(actions?.paths_auth_status?.handler()).toBe('signed-out');
 		expect(
 			(globalThis as { __loadConfigEvents?: string[] }).__loadConfigEvents,
 		).toEqual(['started']);
@@ -185,7 +202,8 @@ describe('loadDaemonConfig', () => {
 		expect(loaded.error).toBeNull();
 		if (loaded.error !== null) return;
 
-		const started = await startDaemonRoutes(loaded.data);
+		const auth = fakeAuthClient();
+		const started = await startDaemonRoutes(loaded.data, { auth });
 		expect(started.error).toBeNull();
 		expect(started.data?.[0]?.route).toBe('demo');
 	});
@@ -223,7 +241,9 @@ describe('loadDaemonConfig', () => {
 		expect(loaded.error).toBeNull();
 		if (loaded.error !== null) return;
 
-		const started = await startDaemonRoutes(loaded.data);
+		const started = await startDaemonRoutes(loaded.data, {
+			auth: fakeAuthClient(),
+		});
 		expect(started.data).toBeNull();
 		expect(started.error?.name).toBe('InvalidRouteRuntime');
 	});
@@ -247,7 +267,9 @@ describe('loadDaemonConfig', () => {
 		expect(loaded.error).toBeNull();
 		if (loaded.error !== null) return;
 
-		const started = await startDaemonRoutes(loaded.data);
+		const started = await startDaemonRoutes(loaded.data, {
+			auth: fakeAuthClient(),
+		});
 		expect(started.error).toBeNull();
 		expect(started.data?.[0]?.route).toBe('demo');
 	});
@@ -281,7 +303,9 @@ describe('loadDaemonConfig', () => {
 		expect(loaded.error).toBeNull();
 		if (loaded.error !== null) return;
 
-		const started = await startDaemonRoutes(loaded.data);
+		const started = await startDaemonRoutes(loaded.data, {
+			auth: fakeAuthClient(),
+		});
 
 		expect(started.data).toBeNull();
 		expect(started.error?.name).toBe('RouteFailed');

--- a/packages/cli/src/load-config.ts
+++ b/packages/cli/src/load-config.ts
@@ -7,6 +7,8 @@
  */
 
 import { join, resolve } from 'node:path';
+import type { AuthClient } from '@epicenter/auth';
+import { createMachineAuthClient } from '@epicenter/auth/node';
 import type { ProjectDir } from '@epicenter/workspace';
 import type {
 	DaemonRouteDefinition,
@@ -32,6 +34,10 @@ export type LoadedDaemonConfig = {
 	projectDir: ProjectDir;
 	configPath: string;
 	routes: readonly DaemonRouteDefinition[];
+};
+
+export type StartDaemonRoutesOptions = {
+	auth?: AuthClient;
 };
 
 export const DaemonConfigError = defineErrors({
@@ -245,18 +251,23 @@ export async function loadDaemonConfig(
 
 export async function startDaemonRoutes(
 	config: LoadedDaemonConfig,
+	options: StartDaemonRoutesOptions = {},
 ): Promise<Result<StartedDaemonRoute[], DaemonConfigError>> {
 	const runtimes: StartedDaemonRoute[] = [];
+	const auth = options.auth ?? (await createMachineAuthClient());
+	const ownsAuth = options.auth === undefined;
 
 	for (const definition of config.routes) {
 		let runtime: unknown;
 		try {
 			runtime = await definition.start({
+				auth,
 				projectDir: config.projectDir,
 				route: definition.route,
 			});
 		} catch (cause) {
 			await disposeStartedDaemonRoutes(runtimes);
+			if (ownsAuth) auth[Symbol.dispose]();
 			return DaemonConfigError.RouteFailed({
 				configPath: config.configPath,
 				route: definition.route,
@@ -266,6 +277,7 @@ export async function startDaemonRoutes(
 
 		if (!hasDaemonRuntimeShape(runtime)) {
 			await disposeStartedDaemonRoutes(runtimes);
+			if (ownsAuth) auth[Symbol.dispose]();
 			return DaemonConfigError.InvalidRouteRuntime({
 				configPath: config.configPath,
 				route: definition.route,

--- a/packages/workspace/src/daemon/types.ts
+++ b/packages/workspace/src/daemon/types.ts
@@ -13,6 +13,7 @@
  */
 
 import type { Result } from 'wellcrafted/result';
+import type { AuthClient } from '@epicenter/auth';
 import type { SyncStatus } from '../document/internal/sync-supervisor.js';
 import type { Collaboration } from '../document/open-collaboration.js';
 import type { PresenceEntry } from '../document/presence.js';
@@ -23,6 +24,7 @@ import type { MaybePromise, ProjectDir } from '../shared/types.js';
 export type DaemonRouteContext = {
 	projectDir: ProjectDir;
 	route: string;
+	auth: AuthClient;
 };
 
 /**

--- a/packages/workspace/src/daemon/types.ts
+++ b/packages/workspace/src/daemon/types.ts
@@ -12,8 +12,8 @@
  * `epicenter.config.ts`.
  */
 
-import type { Result } from 'wellcrafted/result';
 import type { AuthClient } from '@epicenter/auth';
+import type { Result } from 'wellcrafted/result';
 import type { SyncStatus } from '../document/internal/sync-supervisor.js';
 import type { Collaboration } from '../document/open-collaboration.js';
 import type { PresenceEntry } from '../document/presence.js';

--- a/specs/20260514T170000-single-daemon-multi-workspace.md
+++ b/specs/20260514T170000-single-daemon-multi-workspace.md
@@ -1,7 +1,7 @@
 # Single Daemon, Many Workspaces
 
 **Date**: 2026-05-14
-**Status**: Feasibility (no implementation yet)
+**Status**: Phase 1 in progress
 **Author**: Braden + Claude
 **Related**: `20260514T160000-script-surfaces-resolution.md` (scripts call into this daemon over unix socket).
 
@@ -154,6 +154,8 @@ Do this after the auth-injection refactor lands; it's a clean-break naming move 
 **Phase 0 (this spec):** decision recorded, no code changes.
 
 **Phase 1: shared auth client.** Smallest, highest-correctness change. Inject `auth` into `DaemonRouteDefinition.start()`. Update each `define*Daemon()` to consume the injected client. Bonus: write a regression test that two routes in one process don't race on keychain writes.
+
+Implementation note: branch `codex/daemon-shared-auth` injects a single `AuthClient` from `startDaemonRoutes()` into every route start context. Fuji, Honeycrisp, Opensidian, and Zhongwen now consume the injected client instead of calling `createMachineAuthClient()` inside their route factories. `startDaemonRoutes()` still accepts an explicit auth client for tests so config-loader tests do not require a persisted machine session.
 
 **Phase 2: root config + naming pass.** Land single-`epicenter.config.ts` at the project root listing all routes. Rename `define*Daemon` to `define*Route`. Update CLI docs.
 


### PR DESCRIPTION
Multiple daemon routes in the same process should not each construct their own machine auth client. They all point at the same persisted machine session, so independent clients can race refresh-token writes and drift from one another.

This PR moves machine auth construction to `startDaemonRoutes()` and passes the shared `AuthClient` through `DaemonRouteContext`. Fuji, Honeycrisp, Opensidian, and Zhongwen now consume the injected client instead of calling `createMachineAuthClient()` in their route factories.

The route startup shape is now:

```ts
start({ auth, projectDir, route }) {
  // route owns its workspace resources
  // CLI owns shared machine auth construction
}
```

Tests can still pass an explicit auth client to `startDaemonRoutes()` so config-loader tests do not require a real persisted machine session. The single-daemon spec also records this Phase 1 implementation note.

Verification:

```bash
bun test packages/cli/src/load-config.test.ts
bun --cwd packages/workspace typecheck
bun --cwd apps/api typecheck
rg "createMachineAuthClient" apps/*/blocks/daemon-route.ts
```

`bun run typecheck` is still blocked by existing `@epicenter/ui` type errors in emoji picker, casing utilities, and natural-language date input; the touched packages above pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->