### PR TITLE
fix(auth): type normalized fetch input for workers

### DIFF
--- a/packages/auth/src/create-oauth-app-auth.ts
+++ b/packages/auth/src/create-oauth-app-auth.ts
@@ -260,7 +260,8 @@ export function createOAuthAppAuth({
 		} else {
 			headers.delete('Authorization');
 		}
-		return fetchImpl(normalizeFetchInput(input, baseURL), {
+		const normalizedInput = normalizeFetchInput(input, baseURL);
+		return fetchImpl(normalizedInput as Parameters<typeof fetchImpl>[0], {
 			...init,
 			headers,
 			credentials: 'omit',


### PR DESCRIPTION
Cloudflare Worker typechecking sees a different `Request` overload than the DOM fetch type. The auth client already normalizes relative URLs before calling the injected fetch implementation; this PR keeps the runtime behavior the same and narrows the normalized input at that injected fetch boundary so `apps/api` can typecheck.

This is intentionally split from the daemon shared-auth work so the daemon PR stays focused.

Verification:

```bash
bun --cwd apps/api typecheck
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->