### PR TITLE
refactor(auth): canonicalize auth paths

### DIFF
--- a/apps/api/drizzle/0002_salty_hex.sql
+++ b/apps/api/drizzle/0002_salty_hex.sql
@@ -1,0 +1,1 @@
+DROP TABLE "device_code";

--- a/apps/api/drizzle/meta/0002_snapshot.json
+++ b/apps/api/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1129 @@
+{
+  "id": "f0d547d1-b5cd-4653-b4d6-e6e1c290d0b6",
+  "prevId": "b28ec1b2-02bb-4070-b6b9-741b0e8562ef",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset": {
+      "name": "asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "asset_user_id_idx": {
+          "name": "asset_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "asset_user_id_user_id_fk": {
+          "name": "asset_user_id_user_id_fk",
+          "tableFrom": "asset",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.durable_object_instance": {
+      "name": "durable_object_instance",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_name": {
+          "name": "resource_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "do_name": {
+          "name": "do_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "storage_bytes": {
+          "name": "storage_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "storage_measured_at": {
+          "name": "storage_measured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "doi_user_id_idx": {
+          "name": "doi_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "durable_object_instance_user_id_user_id_fk": {
+          "name": "durable_object_instance_user_id_user_id_fk",
+          "tableFrom": "durable_object_instance",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/0002_snapshot.json
+++ b/apps/api/drizzle/meta/0002_snapshot.json
@@ -1,1129 +1,1065 @@
 {
-  "id": "f0d547d1-b5cd-4653-b4d6-e6e1c290d0b6",
-  "prevId": "b28ec1b2-02bb-4070-b6b9-741b0e8562ef",
-  "version": "7",
-  "dialect": "postgresql",
-  "tables": {
-    "public.account": {
-      "name": "account",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "account_id": {
-          "name": "account_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "provider_id": {
-          "name": "provider_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "access_token": {
-          "name": "access_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "refresh_token": {
-          "name": "refresh_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "id_token": {
-          "name": "id_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "access_token_expires_at": {
-          "name": "access_token_expires_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "refresh_token_expires_at": {
-          "name": "refresh_token_expires_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scope": {
-          "name": "scope",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "password": {
-          "name": "password",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "account_userId_idx": {
-          "name": "account_userId_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "account_user_id_user_id_fk": {
-          "name": "account_user_id_user_id_fk",
-          "tableFrom": "account",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.asset": {
-      "name": "asset",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "content_type": {
-          "name": "content_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "size_bytes": {
-          "name": "size_bytes",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "original_name": {
-          "name": "original_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "uploaded_at": {
-          "name": "uploaded_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "asset_user_id_idx": {
-          "name": "asset_user_id_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "asset_user_id_user_id_fk": {
-          "name": "asset_user_id_user_id_fk",
-          "tableFrom": "asset",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.durable_object_instance": {
-      "name": "durable_object_instance",
-      "schema": "",
-      "columns": {
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "resource_name": {
-          "name": "resource_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "do_name": {
-          "name": "do_name",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "storage_bytes": {
-          "name": "storage_bytes",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "last_accessed_at": {
-          "name": "last_accessed_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "storage_measured_at": {
-          "name": "storage_measured_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "doi_user_id_idx": {
-          "name": "doi_user_id_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "durable_object_instance_user_id_user_id_fk": {
-          "name": "durable_object_instance_user_id_user_id_fk",
-          "tableFrom": "durable_object_instance",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.jwks": {
-      "name": "jwks",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "public_key": {
-          "name": "public_key",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "private_key": {
-          "name": "private_key",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.oauth_access_token": {
-      "name": "oauth_access_token",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "token": {
-          "name": "token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "client_id": {
-          "name": "client_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "session_id": {
-          "name": "session_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "reference_id": {
-          "name": "reference_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "refresh_id": {
-          "name": "refresh_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scopes": {
-          "name": "scopes",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "oauth_access_token_client_id_oauth_client_client_id_fk": {
-          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
-          "tableFrom": "oauth_access_token",
-          "tableTo": "oauth_client",
-          "columnsFrom": [
-            "client_id"
-          ],
-          "columnsTo": [
-            "client_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "oauth_access_token_session_id_session_id_fk": {
-          "name": "oauth_access_token_session_id_session_id_fk",
-          "tableFrom": "oauth_access_token",
-          "tableTo": "session",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        },
-        "oauth_access_token_user_id_user_id_fk": {
-          "name": "oauth_access_token_user_id_user_id_fk",
-          "tableFrom": "oauth_access_token",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
-          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
-          "tableFrom": "oauth_access_token",
-          "tableTo": "oauth_refresh_token",
-          "columnsFrom": [
-            "refresh_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "oauth_access_token_token_unique": {
-          "name": "oauth_access_token_token_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "token"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.oauth_client": {
-      "name": "oauth_client",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "client_id": {
-          "name": "client_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "client_secret": {
-          "name": "client_secret",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "disabled": {
-          "name": "disabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "skip_consent": {
-          "name": "skip_consent",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "enable_end_session": {
-          "name": "enable_end_session",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scopes": {
-          "name": "scopes",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "uri": {
-          "name": "uri",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "icon": {
-          "name": "icon",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "contacts": {
-          "name": "contacts",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "tos": {
-          "name": "tos",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "policy": {
-          "name": "policy",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "software_id": {
-          "name": "software_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "software_version": {
-          "name": "software_version",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "software_statement": {
-          "name": "software_statement",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "redirect_uris": {
-          "name": "redirect_uris",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "post_logout_redirect_uris": {
-          "name": "post_logout_redirect_uris",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "token_endpoint_auth_method": {
-          "name": "token_endpoint_auth_method",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "grant_types": {
-          "name": "grant_types",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "response_types": {
-          "name": "response_types",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "public": {
-          "name": "public",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "type": {
-          "name": "type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "require_pkce": {
-          "name": "require_pkce",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "reference_id": {
-          "name": "reference_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "oauth_client_user_id_user_id_fk": {
-          "name": "oauth_client_user_id_user_id_fk",
-          "tableFrom": "oauth_client",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "oauth_client_client_id_unique": {
-          "name": "oauth_client_client_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "client_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.oauth_consent": {
-      "name": "oauth_consent",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "client_id": {
-          "name": "client_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "reference_id": {
-          "name": "reference_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scopes": {
-          "name": "scopes",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "oauth_consent_client_id_oauth_client_client_id_fk": {
-          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
-          "tableFrom": "oauth_consent",
-          "tableTo": "oauth_client",
-          "columnsFrom": [
-            "client_id"
-          ],
-          "columnsTo": [
-            "client_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "oauth_consent_user_id_user_id_fk": {
-          "name": "oauth_consent_user_id_user_id_fk",
-          "tableFrom": "oauth_consent",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.oauth_refresh_token": {
-      "name": "oauth_refresh_token",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "token": {
-          "name": "token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "client_id": {
-          "name": "client_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "session_id": {
-          "name": "session_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "reference_id": {
-          "name": "reference_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "revoked": {
-          "name": "revoked",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "auth_time": {
-          "name": "auth_time",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scopes": {
-          "name": "scopes",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
-          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
-          "tableFrom": "oauth_refresh_token",
-          "tableTo": "oauth_client",
-          "columnsFrom": [
-            "client_id"
-          ],
-          "columnsTo": [
-            "client_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "oauth_refresh_token_session_id_session_id_fk": {
-          "name": "oauth_refresh_token_session_id_session_id_fk",
-          "tableFrom": "oauth_refresh_token",
-          "tableTo": "session",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        },
-        "oauth_refresh_token_user_id_user_id_fk": {
-          "name": "oauth_refresh_token_user_id_user_id_fk",
-          "tableFrom": "oauth_refresh_token",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.session": {
-      "name": "session",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "token": {
-          "name": "token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "ip_address": {
-          "name": "ip_address",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_agent": {
-          "name": "user_agent",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "session_userId_idx": {
-          "name": "session_userId_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "session_user_id_user_id_fk": {
-          "name": "session_user_id_user_id_fk",
-          "tableFrom": "session",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "session_token_unique": {
-          "name": "session_token_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "token"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.user": {
-      "name": "user",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "email": {
-          "name": "email",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "email_verified": {
-          "name": "email_verified",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "image": {
-          "name": "image",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "user_email_unique": {
-          "name": "user_email_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "email"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.verification": {
-      "name": "verification",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "identifier": {
-          "name": "identifier",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "value": {
-          "name": "value",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "verification_identifier_idx": {
-          "name": "verification_identifier_idx",
-          "columns": [
-            {
-              "expression": "identifier",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    }
-  },
-  "enums": {},
-  "schemas": {},
-  "sequences": {},
-  "roles": {},
-  "policies": {},
-  "views": {},
-  "_meta": {
-    "columns": {},
-    "schemas": {},
-    "tables": {}
-  }
+	"id": "f0d547d1-b5cd-4653-b4d6-e6e1c290d0b6",
+	"prevId": "b28ec1b2-02bb-4070-b6b9-741b0e8562ef",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.account": {
+			"name": "account",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"account_userId_idx": {
+					"name": "account_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.asset": {
+			"name": "asset",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"content_type": {
+					"name": "content_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"size_bytes": {
+					"name": "size_bytes",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"original_name": {
+					"name": "original_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"uploaded_at": {
+					"name": "uploaded_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"asset_user_id_idx": {
+					"name": "asset_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"asset_user_id_user_id_fk": {
+					"name": "asset_user_id_user_id_fk",
+					"tableFrom": "asset",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.durable_object_instance": {
+			"name": "durable_object_instance",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"resource_name": {
+					"name": "resource_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"do_name": {
+					"name": "do_name",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"storage_bytes": {
+					"name": "storage_bytes",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"last_accessed_at": {
+					"name": "last_accessed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"storage_measured_at": {
+					"name": "storage_measured_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"doi_user_id_idx": {
+					"name": "doi_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"durable_object_instance_user_id_user_id_fk": {
+					"name": "durable_object_instance_user_id_user_id_fk",
+					"tableFrom": "durable_object_instance",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.jwks": {
+			"name": "jwks",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"public_key": {
+					"name": "public_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"private_key": {
+					"name": "private_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.oauth_access_token": {
+			"name": "oauth_access_token",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_id": {
+					"name": "refresh_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_access_token_client_id_oauth_client_client_id_fk": {
+					"name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+					"tableFrom": "oauth_access_token",
+					"tableTo": "oauth_client",
+					"columnsFrom": ["client_id"],
+					"columnsTo": ["client_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"oauth_access_token_session_id_session_id_fk": {
+					"name": "oauth_access_token_session_id_session_id_fk",
+					"tableFrom": "oauth_access_token",
+					"tableTo": "session",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"oauth_access_token_user_id_user_id_fk": {
+					"name": "oauth_access_token_user_id_user_id_fk",
+					"tableFrom": "oauth_access_token",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+					"name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+					"tableFrom": "oauth_access_token",
+					"tableTo": "oauth_refresh_token",
+					"columnsFrom": ["refresh_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"oauth_access_token_token_unique": {
+					"name": "oauth_access_token_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.oauth_client": {
+			"name": "oauth_client",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_secret": {
+					"name": "client_secret",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"disabled": {
+					"name": "disabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"skip_consent": {
+					"name": "skip_consent",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"enable_end_session": {
+					"name": "enable_end_session",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"uri": {
+					"name": "uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"icon": {
+					"name": "icon",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"contacts": {
+					"name": "contacts",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tos": {
+					"name": "tos",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"policy": {
+					"name": "policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"software_id": {
+					"name": "software_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"software_version": {
+					"name": "software_version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"software_statement": {
+					"name": "software_statement",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"redirect_uris": {
+					"name": "redirect_uris",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"post_logout_redirect_uris": {
+					"name": "post_logout_redirect_uris",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"token_endpoint_auth_method": {
+					"name": "token_endpoint_auth_method",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"grant_types": {
+					"name": "grant_types",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"response_types": {
+					"name": "response_types",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"public": {
+					"name": "public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"require_pkce": {
+					"name": "require_pkce",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_client_user_id_user_id_fk": {
+					"name": "oauth_client_user_id_user_id_fk",
+					"tableFrom": "oauth_client",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"oauth_client_client_id_unique": {
+					"name": "oauth_client_client_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["client_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.oauth_consent": {
+			"name": "oauth_consent",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_consent_client_id_oauth_client_client_id_fk": {
+					"name": "oauth_consent_client_id_oauth_client_client_id_fk",
+					"tableFrom": "oauth_consent",
+					"tableTo": "oauth_client",
+					"columnsFrom": ["client_id"],
+					"columnsTo": ["client_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"oauth_consent_user_id_user_id_fk": {
+					"name": "oauth_consent_user_id_user_id_fk",
+					"tableFrom": "oauth_consent",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.oauth_refresh_token": {
+			"name": "oauth_refresh_token",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked": {
+					"name": "revoked",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"auth_time": {
+					"name": "auth_time",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+					"name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+					"tableFrom": "oauth_refresh_token",
+					"tableTo": "oauth_client",
+					"columnsFrom": ["client_id"],
+					"columnsTo": ["client_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"oauth_refresh_token_session_id_session_id_fk": {
+					"name": "oauth_refresh_token_session_id_session_id_fk",
+					"tableFrom": "oauth_refresh_token",
+					"tableTo": "session",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"oauth_refresh_token_user_id_user_id_fk": {
+					"name": "oauth_refresh_token_user_id_user_id_fk",
+					"tableFrom": "oauth_refresh_token",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session": {
+			"name": "session",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"session_userId_idx": {
+					"name": "session_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user": {
+			"name": "user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.verification": {
+			"name": "verification",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"verification_identifier_idx": {
+					"name": "verification_identifier_idx",
+					"columns": [
+						{
+							"expression": "identifier",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
 }

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
 			"when": 1778734800000,
 			"tag": "0001_delete_old_sync_rooms",
 			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1778827600452,
+			"tag": "0002_salty_hex",
+			"breakpoints": true
 		}
 	]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -3,7 +3,6 @@ import {
 	bigint,
 	boolean,
 	index,
-	integer,
 	jsonb,
 	pgTable,
 	text,
@@ -88,19 +87,6 @@ export const jwks = pgTable('jwks', {
 	privateKey: text('private_key').notNull(),
 	createdAt: timestamp('created_at').notNull(),
 	expiresAt: timestamp('expires_at'),
-});
-
-export const deviceCode = pgTable('device_code', {
-	id: text('id').primaryKey(),
-	deviceCode: text('device_code').notNull(),
-	userCode: text('user_code').notNull(),
-	userId: text('user_id'),
-	expiresAt: timestamp('expires_at').notNull(),
-	status: text('status').notNull(),
-	lastPolledAt: timestamp('last_polled_at'),
-	pollingInterval: integer('polling_interval'),
-	clientId: text('client_id'),
-	scope: text('scope'),
 });
 
 export const oauthClient = pgTable('oauth_client', {

--- a/apps/tab-manager/src/lib/platform/auth/auth.ts
+++ b/apps/tab-manager/src/lib/platform/auth/auth.ts
@@ -17,7 +17,7 @@ import { createStorageState } from '../../state/storage-state.svelte';
 /**
  * Persisted auth cell in `chrome.storage.local`.
  *
- * Older builds persisted under `local:auth.session` with the OAuthSession
+ * Older builds persisted under `local:auth.session` with a bundled auth
  * shape. After this migration, schema validation fails for the legacy shape
  * and the cell reads as null, forcing a one-time sign-in. Workspace IndexedDB
  * data is keyed by userId and survives the reset.

--- a/bun.lock
+++ b/bun.lock
@@ -663,6 +663,7 @@
       "name": "@epicenter/sync",
       "version": "0.1.0",
       "dependencies": {
+        "@epicenter/constants": "workspace:*",
         "lib0": "catalog:",
         "wellcrafted": "catalog:",
         "y-protocols": "catalog:",

--- a/packages/auth-svelte/src/index.ts
+++ b/packages/auth-svelte/src/index.ts
@@ -1,12 +1,12 @@
 export {
 	AuthError,
+	type AuthFetch,
 	type AuthState,
 	AuthUser,
 	type CreateOAuthAppAuthConfig,
 	type LocalUnlockBundle,
 	type OAuthSignInLauncher,
 	type OAuthTokenGrant,
-	type OAuthTokenRefresher,
 	PersistedAuth,
 	type PersistedAuthStorage,
 } from '@epicenter/auth';

--- a/packages/auth/src/auth-errors.ts
+++ b/packages/auth/src/auth-errors.ts
@@ -22,6 +22,10 @@ export const AuthError = defineErrors({
 		message: `Failed to verify identity: ${extractErrorMessage(cause)}`,
 		cause,
 	}),
+	RefreshGrantFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to refresh OAuth grant: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
 });
 
 export type AuthError = InferErrors<typeof AuthError>;

--- a/packages/auth/src/auth-state-store.ts
+++ b/packages/auth/src/auth-state-store.ts
@@ -1,6 +1,22 @@
 import { encryptionKeysEqual } from '@epicenter/encryption';
+import {
+	defineErrors,
+	extractErrorMessage,
+	type InferErrors,
+} from 'wellcrafted/error';
+import { createLogger } from 'wellcrafted/logger';
 import type { AuthState } from './auth-contract.js';
 import type { LocalUnlockBundle } from './auth-types.js';
+
+export const AuthStateStoreError = defineErrors({
+	SubscriberThrew: ({ cause }: { cause: unknown }) => ({
+		message: `Auth state subscriber threw: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
+});
+export type AuthStateStoreError = InferErrors<typeof AuthStateStoreError>;
+
+const log = createLogger('auth-state-store');
 
 export function createAuthStateStore(initialState: AuthState) {
 	let state = initialState;
@@ -17,7 +33,7 @@ export function createAuthStateStore(initialState: AuthState) {
 				try {
 					listener(next);
 				} catch (error) {
-					console.error('[auth] subscriber threw:', error);
+					log.error(AuthStateStoreError.SubscriberThrew({ cause: error }));
 				}
 			}
 		},

--- a/packages/auth/src/contract.test.ts
+++ b/packages/auth/src/contract.test.ts
@@ -10,11 +10,11 @@
  * - Cold-boot offline keeps signed-in with unlock and no profile field
  */
 
+import { BEARER_SUBPROTOCOL_PREFIX } from '@epicenter/constants/auth';
 import { describe, expect, test } from 'bun:test';
 import { Ok } from 'wellcrafted/result';
 import type {
 	AuthClient,
-	AuthFetch,
 	LocalUnlockBundle,
 	OAuthTokenGrant,
 	PersistedAuth,
@@ -85,24 +85,16 @@ function oauthTokenResponse({
 	expiresIn = 3600,
 }: {
 	accessToken?: string;
-	refreshToken?: string;
+	refreshToken?: string | null;
 	expiresIn?: number;
 } = {}) {
-	return json({
+	const body: Record<string, unknown> = {
 		access_token: accessToken,
-		refresh_token: refreshToken,
 		expires_in: expiresIn,
 		token_type: 'bearer',
-	});
-}
-
-function createFetch(
-	impl: (
-		input: Request | string | URL,
-		init?: RequestInit,
-	) => Promise<Response>,
-): AuthFetch {
-	return impl;
+	};
+	if (refreshToken !== null) body['refresh_token'] = refreshToken;
+	return json(body);
 }
 
 function apiMeBody(userId = 'user-1') {
@@ -171,10 +163,10 @@ test('startSignIn calls /api/me and writes both sections', async () => {
 					accessTokenExpiresAt: now + 3_600_000,
 				}),
 		},
-		fetch: createFetch(async (input) => {
+		fetch: async (input) => {
 			fetches.push(String(input));
 			return json(apiMeBody('user-1'));
-		}),
+		},
 	});
 
 	const result = await auth.startSignIn();
@@ -204,13 +196,13 @@ test('refresh writes ONLY the grant section; unlock byte-identical', async () =>
 		now: () => now,
 		persistedAuthStorage: setup.storage,
 		launcher: { startSignIn: async () => Ok(null) },
-		fetch: createFetch(async (input) => {
+		fetch: async (input) => {
 			if (String(input).endsWith('/api/me')) return json(apiMeBody('user-1'));
 			if (String(input).endsWith('/auth/oauth2/token')) {
 				return oauthTokenResponse();
 			}
 			return new Response(null, { status: 204 });
-		}),
+		},
 	});
 
 	await auth.fetch('http://localhost:8787/resource');
@@ -224,6 +216,33 @@ test('refresh writes ONLY the grant section; unlock byte-identical', async () =>
 	auth[Symbol.dispose]();
 });
 
+test('refresh keeps existing refresh token when token response omits rotation', async () => {
+	const initial = cell({ grant: grant({ accessTokenExpiresAt: now + 1 }) });
+	const setup = createStorage(initial);
+	const auth = createOAuthAppAuth({
+		baseURL: 'http://localhost:8787',
+		clientId: 'client-1',
+		now: () => now,
+		persistedAuthStorage: setup.storage,
+		launcher: { startSignIn: async () => Ok(null) },
+		fetch: async (input) => {
+			if (String(input).endsWith('/api/me')) return json(apiMeBody('user-1'));
+			if (String(input).endsWith('/auth/oauth2/token')) {
+				return oauthTokenResponse({ refreshToken: null });
+			}
+			return new Response(null, { status: 204 });
+		},
+	});
+
+	await auth.fetch('http://localhost:8787/resource');
+	expect(setup.saved.at(-1)?.grant).toEqual({
+		accessToken: 'new-access',
+		refreshToken: 'refresh-token',
+		accessTokenExpiresAt: now + 3_600_000,
+	});
+	auth[Symbol.dispose]();
+});
+
 test('same-user guard wipes the cell when /api/me returns a different userId', async () => {
 	const setup = createStorage(cell({ userId: 'alice' }));
 	const auth = createOAuthAppAuth({
@@ -232,10 +251,10 @@ test('same-user guard wipes the cell when /api/me returns a different userId', a
 		now: () => now,
 		persistedAuthStorage: setup.storage,
 		launcher: { startSignIn: async () => Ok(null) },
-		fetch: createFetch(async (input) => {
+		fetch: async (input) => {
 			if (String(input).endsWith('/api/me')) return json(apiMeBody('bob'));
 			return new Response(null, { status: 204 });
-		}),
+		},
 	});
 
 	const response = await auth.fetch('http://localhost:8787/resource');
@@ -258,11 +277,11 @@ test('network gate: no Authorization header until /api/me confirms same user', a
 		now: () => now,
 		persistedAuthStorage: setup.storage,
 		launcher: { startSignIn: async () => Ok(null) },
-		fetch: createFetch(async (input, init) => {
+		fetch: async (input, init) => {
 			if (String(input).endsWith('/api/me')) return apiMePromise;
 			seenAuth.push(new Headers(init?.headers).get('authorization'));
 			return new Response(null, { status: 204 });
-		}),
+		},
 	});
 
 	const fetchPromise = auth.fetch('http://localhost:8787/resource');
@@ -283,13 +302,13 @@ test('auth.fetch resolves relative API paths against the auth base URL', async (
 		now: () => now,
 		persistedAuthStorage: setup.storage,
 		launcher: { startSignIn: async () => Ok(null) },
-		fetch: createFetch(async (input, init) => {
+		fetch: async (input, init) => {
 			fetches.push({
 				url: String(input),
 				authorization: new Headers(init?.headers).get('authorization'),
 			});
 			return json(apiMeBody('user-1'));
-		}),
+		},
 	});
 
 	const response = await auth.fetch('/api/me');
@@ -321,10 +340,10 @@ test('network gate: no WebSocket bearer protocol until /api/me confirms same use
 		persistedAuthStorage: setup.storage,
 		launcher: { startSignIn: async () => Ok(null) },
 		WebSocket: WebSocketRecorder,
-		fetch: createFetch(async (input) => {
+		fetch: async (input) => {
 			if (String(input).endsWith('/api/me')) return apiMePromise;
 			return new Response(null, { status: 204 });
-		}),
+		},
 	});
 
 	const socketPromise = auth.openWebSocket('ws://localhost:8787/sync', [
@@ -337,7 +356,10 @@ test('network gate: no WebSocket bearer protocol until /api/me confirms same use
 	expect(openings).toEqual([
 		{
 			url: 'ws://localhost:8787/sync',
-			protocols: ['epicenter.v1', 'bearer.access-token'],
+			protocols: [
+				'epicenter.v1',
+				`${BEARER_SUBPROTOCOL_PREFIX}access-token`,
+			],
 		},
 	]);
 	auth[Symbol.dispose]();
@@ -351,9 +373,9 @@ test('cold-boot offline keeps signed-in with unlock and no profile field', async
 		now: () => now,
 		persistedAuthStorage: setup.storage,
 		launcher: { startSignIn: async () => Ok(null) },
-		fetch: createFetch(async () => {
+		fetch: async () => {
 			throw new Error('offline');
-		}),
+		},
 	});
 
 	expect(auth.state).toMatchObject({
@@ -385,7 +407,7 @@ test('signOut clears cell and network pause even when revoke fails', async () =>
 		now: () => now,
 		persistedAuthStorage: setup.storage,
 		launcher: { startSignIn: async () => Ok(null) },
-		fetch: createFetch(async (input, init) => {
+		fetch: async (input, init) => {
 			if (String(input).endsWith('/api/me')) return json(apiMeBody('user-1'));
 			if (String(input).endsWith('/auth/oauth2/token')) {
 				return new Response(null, { status: 503 });
@@ -398,7 +420,7 @@ test('signOut clears cell and network pause even when revoke fails', async () =>
 				return new Response(null, { status: 503 });
 			}
 			return new Response(null, { status: 401 });
-		}),
+		},
 	});
 
 	try {
@@ -442,7 +464,7 @@ test('network verification clears on grant refresh until /api/me confirms new ce
 		now: () => now,
 		persistedAuthStorage: setup.storage,
 		launcher: { startSignIn: async () => Ok(null) },
-		fetch: createFetch(async (input, init) => {
+		fetch: async (input, init) => {
 			const authorization = new Headers(init?.headers).get('authorization');
 			if (String(input).endsWith('/api/me')) {
 				apiMeCalls += 1;
@@ -458,7 +480,7 @@ test('network verification clears on grant refresh until /api/me confirms new ce
 			if (resourceAuths.length === 2)
 				return new Response(null, { status: 401 });
 			return new Response(null, { status: 204 });
-		}),
+		},
 	});
 
 	await auth.fetch('http://localhost:8787/resource');
@@ -507,7 +529,7 @@ test('concurrent refresh shares one promise and signOut during refresh wins', as
 		now: () => now,
 		persistedAuthStorage: setup.storage,
 		launcher: { startSignIn: async () => Ok(null) },
-		fetch: createFetch(async (input, init) => {
+		fetch: async (input, init) => {
 			if (String(input).endsWith('/auth/oauth2/token')) {
 				refreshCalls += 1;
 				markRefreshStarted();
@@ -520,7 +542,7 @@ test('concurrent refresh shares one promise and signOut during refresh wins', as
 			}
 			resourceAuths.push(new Headers(init?.headers).get('authorization'));
 			return new Response(null, { status: 204 });
-		}),
+		},
 	});
 
 	const firstFetch = auth.fetch('http://localhost:8787/first');
@@ -555,7 +577,7 @@ test('/api/me response after signOut is discarded without corrupting state', asy
 		now: () => now,
 		persistedAuthStorage: setup.storage,
 		launcher: { startSignIn: async () => Ok(null) },
-		fetch: createFetch(async (input, init) => {
+		fetch: async (input, init) => {
 			if (String(input).endsWith('/api/me')) return apiMePromise;
 			if (String(input).endsWith('/auth/oauth2/revoke')) {
 				const body = new URLSearchParams(String(init?.body ?? ''));
@@ -564,7 +586,7 @@ test('/api/me response after signOut is discarded without corrupting state', asy
 			}
 			resourceAuths.push(new Headers(init?.headers).get('authorization'));
 			return new Response(null, { status: 204 });
-		}),
+		},
 	});
 
 	const fetchPromise = auth.fetch('http://localhost:8787/resource');
@@ -579,6 +601,56 @@ test('/api/me response after signOut is discarded without corrupting state', asy
 	expect(setup.current).toBeNull();
 	expect(auth.state).toEqual({ status: 'signed-out' });
 	expect(resourceAuths).toEqual([null]);
+	auth[Symbol.dispose]();
+});
+
+test('/api/me key update after signOut is discarded without writing unlock', async () => {
+	const setup = createStorage(cell());
+	const rotatedKeys = [
+		{
+			version: 2,
+			userKeyBase64: 'AQECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=',
+		},
+	] satisfies LocalUnlockBundle['encryptionKeys'];
+	let resolveApiMe!: (response: Response) => void;
+	const apiMePromise = new Promise<Response>((r) => {
+		resolveApiMe = r;
+	});
+	const auth = createOAuthAppAuth({
+		baseURL: 'http://localhost:8787',
+		clientId: 'client-1',
+		now: () => now,
+		persistedAuthStorage: setup.storage,
+		launcher: { startSignIn: async () => Ok(null) },
+		fetch: async (input, init) => {
+			if (String(input).endsWith('/api/me')) return apiMePromise;
+			if (String(input).endsWith('/auth/oauth2/revoke')) {
+				const body = new URLSearchParams(String(init?.body ?? ''));
+				expect(body.get('token')).toBe('refresh-token');
+				return new Response(null, { status: 200 });
+			}
+			return new Response(null, { status: 204 });
+		},
+	});
+
+	const fetchPromise = auth.fetch('http://localhost:8787/resource');
+	await Promise.resolve();
+	const signOutResult = await auth.signOut();
+	expect(signOutResult).toEqual(Ok(undefined));
+
+	resolveApiMe(
+		json({
+			user: { id: 'user-1', email: 'user-1@example.com' },
+			encryptionKeys: rotatedKeys,
+		}),
+	);
+	await fetchPromise;
+	expect(setup.current).toBeNull();
+	expect(setup.saved).not.toContainEqual({
+		grant: grant(),
+		unlock: { userId: 'user-1', encryptionKeys: rotatedKeys },
+	});
+	expect(auth.state).toEqual({ status: 'signed-out' });
 	auth[Symbol.dispose]();
 });
 

--- a/packages/auth/src/contract.test.ts
+++ b/packages/auth/src/contract.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, test } from 'bun:test';
 import { Ok } from 'wellcrafted/result';
 import type {
 	AuthClient,
+	AuthFetch,
 	LocalUnlockBundle,
 	OAuthTokenGrant,
 	PersistedAuth,
@@ -76,6 +77,32 @@ function json(value: unknown, init?: ResponseInit) {
 		...init,
 		headers: { 'content-type': 'application/json', ...init?.headers },
 	});
+}
+
+function oauthTokenResponse({
+	accessToken = 'new-access',
+	refreshToken = 'new-refresh',
+	expiresIn = 3600,
+}: {
+	accessToken?: string;
+	refreshToken?: string;
+	expiresIn?: number;
+} = {}) {
+	return json({
+		access_token: accessToken,
+		refresh_token: refreshToken,
+		expires_in: expiresIn,
+		token_type: 'bearer',
+	});
+}
+
+function createFetch(
+	impl: (
+		input: Request | string | URL,
+		init?: RequestInit,
+	) => Promise<Response>,
+): AuthFetch {
+	return impl;
 }
 
 function apiMeBody(userId = 'user-1') {
@@ -144,10 +171,10 @@ test('startSignIn calls /api/me and writes both sections', async () => {
 					accessTokenExpiresAt: now + 3_600_000,
 				}),
 		},
-		fetch: (async (input: Request | string | URL) => {
+		fetch: createFetch(async (input) => {
 			fetches.push(String(input));
 			return json(apiMeBody('user-1'));
-		}) as unknown as typeof fetch,
+		}),
 	});
 
 	const result = await auth.startSignIn();
@@ -177,15 +204,13 @@ test('refresh writes ONLY the grant section; unlock byte-identical', async () =>
 		now: () => now,
 		persistedAuthStorage: setup.storage,
 		launcher: { startSignIn: async () => Ok(null) },
-		refreshOAuthToken: async () => ({
-			accessToken: 'new-access',
-			refreshToken: 'new-refresh',
-			accessTokenExpiresAt: now + 3_600_000,
-		}),
-		fetch: (async (input: Request | string | URL) => {
+		fetch: createFetch(async (input) => {
 			if (String(input).endsWith('/api/me')) return json(apiMeBody('user-1'));
+			if (String(input).endsWith('/auth/oauth2/token')) {
+				return oauthTokenResponse();
+			}
 			return new Response(null, { status: 204 });
-		}) as unknown as typeof fetch,
+		}),
 	});
 
 	await auth.fetch('http://localhost:8787/resource');
@@ -207,10 +232,10 @@ test('same-user guard wipes the cell when /api/me returns a different userId', a
 		now: () => now,
 		persistedAuthStorage: setup.storage,
 		launcher: { startSignIn: async () => Ok(null) },
-		fetch: (async (input: Request | string | URL) => {
+		fetch: createFetch(async (input) => {
 			if (String(input).endsWith('/api/me')) return json(apiMeBody('bob'));
 			return new Response(null, { status: 204 });
-		}) as unknown as typeof fetch,
+		}),
 	});
 
 	const response = await auth.fetch('http://localhost:8787/resource');
@@ -233,11 +258,11 @@ test('network gate: no Authorization header until /api/me confirms same user', a
 		now: () => now,
 		persistedAuthStorage: setup.storage,
 		launcher: { startSignIn: async () => Ok(null) },
-		fetch: (async (input: Request | string | URL, init?: RequestInit) => {
+		fetch: createFetch(async (input, init) => {
 			if (String(input).endsWith('/api/me')) return apiMePromise;
 			seenAuth.push(new Headers(init?.headers).get('authorization'));
 			return new Response(null, { status: 204 });
-		}) as unknown as typeof fetch,
+		}),
 	});
 
 	const fetchPromise = auth.fetch('http://localhost:8787/resource');
@@ -258,13 +283,13 @@ test('auth.fetch resolves relative API paths against the auth base URL', async (
 		now: () => now,
 		persistedAuthStorage: setup.storage,
 		launcher: { startSignIn: async () => Ok(null) },
-		fetch: (async (input: Request | string | URL, init?: RequestInit) => {
+		fetch: createFetch(async (input, init) => {
 			fetches.push({
 				url: String(input),
 				authorization: new Headers(init?.headers).get('authorization'),
 			});
 			return json(apiMeBody('user-1'));
-		}) as unknown as typeof fetch,
+		}),
 	});
 
 	const response = await auth.fetch('/api/me');
@@ -296,10 +321,10 @@ test('network gate: no WebSocket bearer protocol until /api/me confirms same use
 		persistedAuthStorage: setup.storage,
 		launcher: { startSignIn: async () => Ok(null) },
 		WebSocket: WebSocketRecorder,
-		fetch: (async (input: Request | string | URL) => {
+		fetch: createFetch(async (input) => {
 			if (String(input).endsWith('/api/me')) return apiMePromise;
 			return new Response(null, { status: 204 });
-		}) as unknown as typeof fetch,
+		}),
 	});
 
 	const socketPromise = auth.openWebSocket('ws://localhost:8787/sync', [
@@ -326,9 +351,9 @@ test('cold-boot offline keeps signed-in with unlock and no profile field', async
 		now: () => now,
 		persistedAuthStorage: setup.storage,
 		launcher: { startSignIn: async () => Ok(null) },
-		fetch: (async () => {
+		fetch: createFetch(async () => {
 			throw new Error('offline');
-		}) as unknown as typeof fetch,
+		}),
 	});
 
 	expect(auth.state).toMatchObject({
@@ -347,12 +372,12 @@ test('signOut clears cell and network pause even when revoke fails', async () =>
 	const originalConsoleError = console.error;
 	console.error = () => undefined;
 	let markRevokeStarted!: () => void;
-	let rejectRevoke!: (error: Error) => void;
+	let resolveRevoke!: () => void;
 	const revokeStarted = new Promise<void>((r) => {
 		markRevokeStarted = r;
 	});
-	const revokePromise = new Promise<void>((_, reject) => {
-		rejectRevoke = reject;
+	const revokePromise = new Promise<void>((resolve) => {
+		resolveRevoke = resolve;
 	});
 	const auth = createOAuthAppAuth({
 		baseURL: 'http://localhost:8787',
@@ -360,18 +385,20 @@ test('signOut clears cell and network pause even when revoke fails', async () =>
 		now: () => now,
 		persistedAuthStorage: setup.storage,
 		launcher: { startSignIn: async () => Ok(null) },
-		refreshOAuthToken: async () => {
-			throw new Error('refresh failed');
-		},
-		revokeOAuthRefreshToken: async ({ refreshToken }) => {
-			expect(refreshToken).toBe('refresh-token');
-			markRevokeStarted();
-			await revokePromise;
-		},
-		fetch: (async (input: Request | string | URL) => {
+		fetch: createFetch(async (input, init) => {
 			if (String(input).endsWith('/api/me')) return json(apiMeBody('user-1'));
+			if (String(input).endsWith('/auth/oauth2/token')) {
+				return new Response(null, { status: 503 });
+			}
+			if (String(input).endsWith('/auth/oauth2/revoke')) {
+				const body = new URLSearchParams(String(init?.body ?? ''));
+				expect(body.get('token')).toBe('refresh-token');
+				markRevokeStarted();
+				await revokePromise;
+				return new Response(null, { status: 503 });
+			}
 			return new Response(null, { status: 401 });
-		}) as unknown as typeof fetch,
+		}),
 	});
 
 	try {
@@ -388,7 +415,7 @@ test('signOut clears cell and network pause even when revoke fails', async () =>
 		expect(auth.state).toEqual({ status: 'signed-out' });
 		expect(await signOutPromise).toEqual(Ok(undefined));
 		await revokeStarted;
-		rejectRevoke(new Error('revoke failed'));
+		resolveRevoke();
 		await Promise.resolve();
 	} finally {
 		console.error = originalConsoleError;
@@ -415,15 +442,7 @@ test('network verification clears on grant refresh until /api/me confirms new ce
 		now: () => now,
 		persistedAuthStorage: setup.storage,
 		launcher: { startSignIn: async () => Ok(null) },
-		refreshOAuthToken: async () => ({
-			accessToken: 'new-access',
-			refreshToken: 'new-refresh',
-			accessTokenExpiresAt: now + 3_600_000,
-		}),
-		fetch: (async (
-			input: Request | string | URL,
-			init?: RequestInit,
-		): Promise<Response> => {
+		fetch: createFetch(async (input, init) => {
 			const authorization = new Headers(init?.headers).get('authorization');
 			if (String(input).endsWith('/api/me')) {
 				apiMeCalls += 1;
@@ -432,11 +451,14 @@ test('network verification clears on grant refresh until /api/me confirms new ce
 				markSecondApiMeRequested();
 				return secondApiMePromise;
 			}
+			if (String(input).endsWith('/auth/oauth2/token')) {
+				return oauthTokenResponse();
+			}
 			resourceAuths.push(authorization);
 			if (resourceAuths.length === 2)
 				return new Response(null, { status: 401 });
 			return new Response(null, { status: 204 });
-		}) as unknown as typeof fetch,
+		}),
 	});
 
 	await auth.fetch('http://localhost:8787/resource');
@@ -472,11 +494,11 @@ test('concurrent refresh shares one promise and signOut during refresh wins', as
 	const resourceAuths: Array<string | null> = [];
 	let refreshCalls = 0;
 	let markRefreshStarted!: () => void;
-	let resolveRefresh!: (grant: OAuthTokenGrant) => void;
+	let resolveRefresh!: (response: Response) => void;
 	const refreshStarted = new Promise<void>((r) => {
 		markRefreshStarted = r;
 	});
-	const refreshPromise = new Promise<OAuthTokenGrant>((r) => {
+	const refreshPromise = new Promise<Response>((r) => {
 		resolveRefresh = r;
 	});
 	const auth = createOAuthAppAuth({
@@ -485,18 +507,20 @@ test('concurrent refresh shares one promise and signOut during refresh wins', as
 		now: () => now,
 		persistedAuthStorage: setup.storage,
 		launcher: { startSignIn: async () => Ok(null) },
-		refreshOAuthToken: async () => {
-			refreshCalls += 1;
-			markRefreshStarted();
-			return refreshPromise;
-		},
-		revokeOAuthRefreshToken: async ({ refreshToken }) => {
-			expect(refreshToken).toBe('refresh-token');
-		},
-		fetch: (async (_input: Request | string | URL, init?: RequestInit) => {
+		fetch: createFetch(async (input, init) => {
+			if (String(input).endsWith('/auth/oauth2/token')) {
+				refreshCalls += 1;
+				markRefreshStarted();
+				return refreshPromise;
+			}
+			if (String(input).endsWith('/auth/oauth2/revoke')) {
+				const body = new URLSearchParams(String(init?.body ?? ''));
+				expect(body.get('token')).toBe('refresh-token');
+				return new Response(null, { status: 200 });
+			}
 			resourceAuths.push(new Headers(init?.headers).get('authorization'));
 			return new Response(null, { status: 204 });
-		}) as unknown as typeof fetch,
+		}),
 	});
 
 	const firstFetch = auth.fetch('http://localhost:8787/first');
@@ -510,11 +534,7 @@ test('concurrent refresh shares one promise and signOut during refresh wins', as
 	expect(setup.current).toBeNull();
 	expect(auth.state).toEqual({ status: 'signed-out' });
 
-	resolveRefresh({
-		accessToken: 'new-access',
-		refreshToken: 'new-refresh',
-		accessTokenExpiresAt: now + 3_600_000,
-	});
+	resolveRefresh(oauthTokenResponse());
 	await Promise.all([firstFetch, secondFetch]);
 	expect(setup.current).toBeNull();
 	expect(resourceAuths).toEqual([null, null]);
@@ -535,14 +555,16 @@ test('/api/me response after signOut is discarded without corrupting state', asy
 		now: () => now,
 		persistedAuthStorage: setup.storage,
 		launcher: { startSignIn: async () => Ok(null) },
-		revokeOAuthRefreshToken: async ({ refreshToken }) => {
-			expect(refreshToken).toBe('refresh-token');
-		},
-		fetch: (async (input: Request | string | URL, init?: RequestInit) => {
+		fetch: createFetch(async (input, init) => {
 			if (String(input).endsWith('/api/me')) return apiMePromise;
+			if (String(input).endsWith('/auth/oauth2/revoke')) {
+				const body = new URLSearchParams(String(init?.body ?? ''));
+				expect(body.get('token')).toBe('refresh-token');
+				return new Response(null, { status: 200 });
+			}
 			resourceAuths.push(new Headers(init?.headers).get('authorization'));
 			return new Response(null, { status: 204 });
-		}) as unknown as typeof fetch,
+		}),
 	});
 
 	const fetchPromise = auth.fetch('http://localhost:8787/resource');

--- a/packages/auth/src/contract.test.ts
+++ b/packages/auth/src/contract.test.ts
@@ -10,8 +10,8 @@
  * - Cold-boot offline keeps signed-in with unlock and no profile field
  */
 
-import { BEARER_SUBPROTOCOL_PREFIX } from '@epicenter/constants/auth';
 import { describe, expect, test } from 'bun:test';
+import { BEARER_SUBPROTOCOL_PREFIX } from '@epicenter/constants/auth';
 import { Ok } from 'wellcrafted/result';
 import type {
 	AuthClient,
@@ -356,10 +356,7 @@ test('network gate: no WebSocket bearer protocol until /api/me confirms same use
 	expect(openings).toEqual([
 		{
 			url: 'ws://localhost:8787/sync',
-			protocols: [
-				'epicenter.v1',
-				`${BEARER_SUBPROTOCOL_PREFIX}access-token`,
-			],
+			protocols: ['epicenter.v1', `${BEARER_SUBPROTOCOL_PREFIX}access-token`],
 		},
 	]);
 	auth[Symbol.dispose]();

--- a/packages/auth/src/create-oauth-app-auth.ts
+++ b/packages/auth/src/create-oauth-app-auth.ts
@@ -2,6 +2,7 @@ import { EPICENTER_API_URL } from '@epicenter/constants/apps';
 import { BEARER_SUBPROTOCOL_PREFIX } from '@epicenter/constants/auth';
 import { EncryptionKeys, encryptionKeysEqual } from '@epicenter/encryption';
 import { type } from 'arktype';
+import { createLogger } from 'wellcrafted/logger';
 import { Ok, type Result } from 'wellcrafted/result';
 import type { AuthClient, AuthState } from './auth-contract.js';
 import { AuthError } from './auth-errors.js';
@@ -47,6 +48,8 @@ const ApiMeResponse = type({
 	encryptionKeys: EncryptionKeys,
 });
 type ApiMeResponse = typeof ApiMeResponse.infer;
+
+const log = createLogger('oauth-app-auth');
 
 export type CreateOAuthAppAuthConfig = {
 	baseURL?: string;
@@ -125,7 +128,7 @@ export function createOAuthAppAuth({
 				if (persisted === startedFrom) {
 					networkAuthPaused = true;
 					publishState();
-					console.error('[auth] failed to refresh OAuth grant:', cause);
+					log.error(AuthError.RefreshGrantFailed({ cause }));
 				}
 				return false;
 			} finally {

--- a/packages/auth/src/create-oauth-app-auth.ts
+++ b/packages/auth/src/create-oauth-app-auth.ts
@@ -1,4 +1,5 @@
 import { EPICENTER_API_URL } from '@epicenter/constants/apps';
+import { BEARER_SUBPROTOCOL_PREFIX } from '@epicenter/constants/auth';
 import { EncryptionKeys, encryptionKeysEqual } from '@epicenter/encryption';
 import { type } from 'arktype';
 import { Ok, type Result } from 'wellcrafted/result';
@@ -10,6 +11,7 @@ import {
 	type OAuthTokenGrant,
 	type PersistedAuth as PersistedAuthType,
 } from './auth-types.js';
+import { parseOAuthTokenGrant } from './oauth-token-response.js';
 import { headersFromRequest } from './request-headers.js';
 
 /**
@@ -57,7 +59,6 @@ export type CreateOAuthAppAuthConfig = {
 };
 
 const REFRESH_SKEW_MS = 60_000;
-const BEARER_SUBPROTOCOL_PREFIX = 'bearer.';
 
 export function createOAuthAppAuth({
 	baseURL = EPICENTER_API_URL,
@@ -391,16 +392,10 @@ async function refreshOAuthTokenWithEndpoint({
 		throw new Error(`OAuth refresh failed with ${response.status}.`);
 	}
 	const data = await response.json();
-	const tokenType = readString(data, 'token_type');
-	if (tokenType.toLowerCase() !== 'bearer') {
-		throw new Error(`Expected token_type to be bearer, got ${tokenType}.`);
-	}
-	return {
-		accessToken: readString(data, 'access_token'),
-		refreshToken:
-			readOptionalString(data, 'refresh_token') ?? grant.refreshToken,
-		accessTokenExpiresAt: now() + readPositiveNumber(data, 'expires_in') * 1000,
-	} satisfies OAuthTokenGrant;
+	return parseOAuthTokenGrant(data, {
+		now,
+		fallbackRefreshToken: grant.refreshToken,
+	});
 }
 
 async function revokeOAuthRefreshTokenWithEndpoint({
@@ -428,39 +423,4 @@ async function revokeOAuthRefreshTokenWithEndpoint({
 	if (!response.ok) {
 		throw new Error(`OAuth revoke failed with ${response.status}.`);
 	}
-}
-
-function readRecord(value: unknown): Record<string, unknown> {
-	if (value === null || typeof value !== 'object' || Array.isArray(value)) {
-		throw new Error('Expected OAuth token response to be an object.');
-	}
-	return value as Record<string, unknown>;
-}
-
-function readString(value: unknown, key: string) {
-	const record = readRecord(value);
-	const field = record[key];
-	if (typeof field !== 'string') {
-		throw new Error(`Expected ${key} to be a string.`);
-	}
-	return field;
-}
-
-function readOptionalString(value: unknown, key: string) {
-	const record = readRecord(value);
-	const field = record[key];
-	if (field === undefined || field === null) return null;
-	if (typeof field !== 'string') {
-		throw new Error(`Expected ${key} to be a string.`);
-	}
-	return field;
-}
-
-function readPositiveNumber(value: unknown, key: string) {
-	const record = readRecord(value);
-	const field = record[key];
-	if (typeof field !== 'number' || !Number.isFinite(field) || field <= 0) {
-		throw new Error(`Expected ${key} to be a positive number.`);
-	}
-	return field;
 }

--- a/packages/auth/src/create-oauth-app-auth.ts
+++ b/packages/auth/src/create-oauth-app-auth.ts
@@ -28,20 +28,12 @@ export type OAuthSignInLauncher = {
 	startSignIn(): Promise<Result<OAuthTokenGrant | null, unknown>>;
 };
 
-export type OAuthTokenRefresher = (input: {
-	baseURL: string;
-	clientId: string;
-	grant: OAuthTokenGrant;
-	fetch: typeof fetch;
-	now: () => number;
-}) => Promise<OAuthTokenGrant>;
+type AuthFetchInput = Request | string | URL;
 
-export type OAuthRefreshTokenRevoker = (input: {
-	baseURL: string;
-	clientId: string;
-	refreshToken: string;
-	fetch: typeof fetch;
-}) => Promise<void>;
+export type AuthFetch = (
+	input: AuthFetchInput,
+	init?: RequestInit,
+) => Promise<Response>;
 
 /**
  * Shape returned by `GET /api/me`. Internal; not exported as a top-level
@@ -59,10 +51,8 @@ export type CreateOAuthAppAuthConfig = {
 	clientId: string;
 	persistedAuthStorage: PersistedAuthStorage;
 	launcher: OAuthSignInLauncher;
-	fetch?: typeof fetch;
+	fetch?: AuthFetch;
 	WebSocket?: typeof WebSocket;
-	refreshOAuthToken?: OAuthTokenRefresher;
-	revokeOAuthRefreshToken?: OAuthRefreshTokenRevoker;
 	now?: () => number;
 };
 
@@ -76,8 +66,6 @@ export function createOAuthAppAuth({
 	launcher,
 	fetch: fetchImpl = globalThis.fetch.bind(globalThis),
 	WebSocket: WebSocketImpl = globalThis.WebSocket,
-	refreshOAuthToken = refreshOAuthTokenWithEndpoint,
-	revokeOAuthRefreshToken = revokeOAuthRefreshTokenWithEndpoint,
 	now = Date.now,
 }: CreateOAuthAppAuthConfig): AuthClient {
 	let persisted = persistedAuthStorage.get();
@@ -114,7 +102,7 @@ export function createOAuthAppAuth({
 		const startedFrom = persisted;
 		refreshPromise = (async () => {
 			try {
-				const grant = await refreshOAuthToken({
+				const grant = await refreshOAuthTokenWithEndpoint({
 					baseURL,
 					clientId,
 					grant: startedFrom.grant,
@@ -249,7 +237,7 @@ export function createOAuthAppAuth({
 	}
 
 	async function fetchWithAuth(
-		input: Request | string | URL,
+		input: AuthFetchInput,
 		init: RequestInit | undefined,
 		forceRefresh: boolean,
 	) {
@@ -261,7 +249,7 @@ export function createOAuthAppAuth({
 			headers.delete('Authorization');
 		}
 		const normalizedInput = normalizeFetchInput(input, baseURL);
-		return fetchImpl(normalizedInput as Parameters<typeof fetchImpl>[0], {
+		return fetchImpl(normalizedInput, {
 			...init,
 			headers,
 			credentials: 'omit',
@@ -320,7 +308,7 @@ export function createOAuthAppAuth({
 				if (refreshTokenToRevoke) {
 					void Promise.resolve()
 						.then(() =>
-							revokeOAuthRefreshToken({
+							revokeOAuthRefreshTokenWithEndpoint({
 								baseURL,
 								clientId,
 								refreshToken: refreshTokenToRevoke,
@@ -363,8 +351,11 @@ function shouldRefreshGrant(grant: OAuthTokenGrant, now: number) {
 	return grant.accessTokenExpiresAt <= now + REFRESH_SKEW_MS;
 }
 
-function normalizeFetchInput(input: Request | string | URL, baseURL: string) {
-	if (input instanceof Request) return input.clone();
+function normalizeFetchInput(
+	input: AuthFetchInput,
+	baseURL: string,
+): AuthFetchInput {
+	if (input instanceof Request) return input.clone() as Request;
 	if (typeof input === 'string' && input.startsWith('/')) {
 		return new URL(input, baseURL).toString();
 	}
@@ -381,7 +372,7 @@ async function refreshOAuthTokenWithEndpoint({
 	baseURL: string;
 	clientId: string;
 	grant: OAuthTokenGrant;
-	fetch: typeof globalThis.fetch;
+	fetch: AuthFetch;
 	now: () => number;
 }): Promise<OAuthTokenGrant> {
 	const body = new URLSearchParams({
@@ -421,7 +412,7 @@ async function revokeOAuthRefreshTokenWithEndpoint({
 	baseURL: string;
 	clientId: string;
 	refreshToken: string;
-	fetch: typeof globalThis.fetch;
+	fetch: AuthFetch;
 }) {
 	const body = new URLSearchParams({
 		client_id: clientId,

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -7,10 +7,9 @@ export {
 	PersistedAuth,
 } from './auth-types.js';
 export {
+	type AuthFetch,
 	type CreateOAuthAppAuthConfig,
 	createOAuthAppAuth,
-	type OAuthRefreshTokenRevoker,
 	type OAuthSignInLauncher,
-	type OAuthTokenRefresher,
 	type PersistedAuthStorage,
 } from './create-oauth-app-auth.js';

--- a/packages/auth/src/node/machine-auth.test.ts
+++ b/packages/auth/src/node/machine-auth.test.ts
@@ -13,6 +13,7 @@ import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { PersistedAuth } from '../auth-types.js';
+import type { AuthFetch } from '../create-oauth-app-auth.js';
 import {
 	createMachineAuthClient,
 	loginWithOob,
@@ -76,10 +77,8 @@ type RecordedRequest = {
 
 type Route = (request: RecordedRequest) => Response | Promise<Response>;
 
-type FetchLike = typeof globalThis.fetch;
-
-function asFetch(impl: (input: unknown, init?: unknown) => Promise<Response>) {
-	return impl as unknown as FetchLike;
+function asFetch(impl: AuthFetch): AuthFetch {
+	return impl;
 }
 
 function createFetch({
@@ -91,13 +90,13 @@ function createFetch({
 	apiMeRoute?: Route;
 	revokeRoute?: Route;
 } = {}): {
-	fetch: FetchLike;
+	fetch: AuthFetch;
 	recorded: RecordedRequest[];
 } {
 	const recorded: RecordedRequest[] = [];
 	const fetchImpl = asFetch(async (rawInput, rawInit) => {
-		const input = rawInput as Request | string | URL;
-		const init = rawInit as RequestInit | undefined;
+		const input = rawInput;
+		const init = rawInit;
 		const url =
 			typeof input === 'string'
 				? input
@@ -411,9 +410,7 @@ test('createMachineAuthClient loads file and attaches Bearer after gate', async 
 	await preWriteCell(filePath, 'user-1');
 
 	const recorded: RecordedRequest[] = [];
-	const fetchImpl = asFetch(async (rawInput, rawInit) => {
-		const input = rawInput as Request | string | URL;
-		const init = rawInit as RequestInit | undefined;
+	const fetchImpl = asFetch(async (input, init) => {
 		const url =
 			typeof input === 'string'
 				? input

--- a/packages/auth/src/node/machine-auth.test.ts
+++ b/packages/auth/src/node/machine-auth.test.ts
@@ -77,10 +77,6 @@ type RecordedRequest = {
 
 type Route = (request: RecordedRequest) => Response | Promise<Response>;
 
-function asFetch(impl: AuthFetch): AuthFetch {
-	return impl;
-}
-
 function createFetch({
 	tokenRoute,
 	apiMeRoute,
@@ -94,7 +90,7 @@ function createFetch({
 	recorded: RecordedRequest[];
 } {
 	const recorded: RecordedRequest[] = [];
-	const fetchImpl = asFetch(async (rawInput, rawInit) => {
+	const fetchImpl: AuthFetch = async (rawInput, rawInit) => {
 		const input = rawInput;
 		const init = rawInit;
 		const url =
@@ -131,7 +127,7 @@ function createFetch({
 			return apiMeRoute(request);
 		}
 		return new Response(null, { status: 404 });
-	});
+	};
 	return { fetch: fetchImpl, recorded };
 }
 
@@ -282,9 +278,9 @@ test('status valid when /api/me returns 200 with same userId', async () => {
 test('status unverified on network failure preserves cell', async () => {
 	const filePath = tmpAuthPath();
 	const cell = await preWriteCell(filePath, 'user-1');
-	const fetchImpl = asFetch(async () => {
+	const fetchImpl: AuthFetch = async () => {
 		throw new Error('network down');
-	});
+	};
 	const result = await status({
 		baseURL: BASE_URL,
 		clientId: CLIENT_ID,
@@ -410,7 +406,7 @@ test('createMachineAuthClient loads file and attaches Bearer after gate', async 
 	await preWriteCell(filePath, 'user-1');
 
 	const recorded: RecordedRequest[] = [];
-	const fetchImpl = asFetch(async (input, init) => {
+	const fetchImpl: AuthFetch = async (input, init) => {
 		const url =
 			typeof input === 'string'
 				? input
@@ -440,7 +436,7 @@ test('createMachineAuthClient loads file and attaches Bearer after gate', async 
 			return new Response(null, { status: 200 });
 		}
 		return new Response(null, { status: 404 });
-	});
+	};
 
 	const auth = await createMachineAuthClient({
 		baseURL: BASE_URL,

--- a/packages/auth/src/node/machine-auth.ts
+++ b/packages/auth/src/node/machine-auth.ts
@@ -30,7 +30,10 @@ import { createLogger, type Logger } from 'wellcrafted/logger';
 import { Err, Ok, type Result } from 'wellcrafted/result';
 import type { AuthClient } from '../auth-contract.js';
 import { AuthUser, type PersistedAuth } from '../auth-types.js';
-import { createOAuthAppAuth } from '../create-oauth-app-auth.js';
+import {
+	type AuthFetch,
+	createOAuthAppAuth,
+} from '../create-oauth-app-auth.js';
 import {
 	loadMachineTokens,
 	type MachineAuthStorageError,
@@ -71,7 +74,7 @@ type CommonConfig = {
 	clientId?: string;
 	redirectUri?: string;
 	filePath?: string;
-	fetch?: typeof globalThis.fetch;
+	fetch?: AuthFetch;
 	log?: Logger;
 	now?: () => number;
 };
@@ -334,7 +337,7 @@ async function fetchApiMe({
 }: {
 	baseURL: string;
 	accessToken: string;
-	fetch: typeof globalThis.fetch;
+	fetch: AuthFetch;
 }): Promise<Result<ApiMeResponse, MachineAuthRequestError>> {
 	let response: Response;
 	try {

--- a/packages/auth/src/node/oob-launcher.test.ts
+++ b/packages/auth/src/node/oob-launcher.test.ts
@@ -12,14 +12,13 @@
  */
 
 import { expect, test } from 'bun:test';
+import type { AuthFetch } from '../create-oauth-app-auth.js';
 import { createOobOAuthLauncher } from './oob-launcher.js';
 
 const NOW = 1_700_000_000_000;
 
-type FetchLike = typeof globalThis.fetch;
-
-function asFetch(impl: (input: unknown, init?: unknown) => Promise<Response>) {
-	return impl as unknown as FetchLike;
+function asFetch(impl: AuthFetch): AuthFetch {
+	return impl;
 }
 
 function makeJsonResponse(value: unknown, init?: ResponseInit) {
@@ -58,22 +57,20 @@ function setup({
 }: {
 	readCode?: () => Promise<string>;
 	openBrowser?: (url: string) => Promise<void> | void;
-	fetchImpl?: FetchLike;
+	fetchImpl?: AuthFetch;
 } = {}) {
 	const printed: string[] = [];
 	const tokenRequests: Array<{ url: string; body: URLSearchParams }> = [];
-	const defaultFetch = asFetch(async (input, init) => {
-		const req = input as Request | string | URL;
+	const defaultFetch = asFetch(async (req, init) => {
 		const url =
 			typeof req === 'string'
 				? req
 				: req instanceof URL
 					? req.toString()
 					: req.url;
-		const initObj = init as RequestInit | undefined;
 		tokenRequests.push({
 			url,
-			body: captureBody(initObj?.body ?? null),
+			body: captureBody(init?.body ?? null),
 		});
 		return makeJsonResponse({
 			access_token: 'a',
@@ -124,7 +121,7 @@ test('PKCE verifier and challenge are linked', async () => {
 		baseURL: 'http://localhost:8787',
 		clientId: 'epicenter-cli',
 		fetch: asFetch(async (_input, init) => {
-			const body = captureBody((init as RequestInit | undefined)?.body ?? null);
+			const body = captureBody(init?.body ?? null);
 			receivedVerifier = body.get('code_verifier');
 			return makeJsonResponse({
 				access_token: 'a',
@@ -147,9 +144,8 @@ test('PKCE verifier and challenge are linked', async () => {
 	const challenge = url.searchParams.get('code_challenge');
 	const method = url.searchParams.get('code_challenge_method');
 	expect(method).toBe('S256');
-	expect(challenge).toBe(
-		await base64UrlSha256(receivedVerifier as unknown as string),
-	);
+	if (!receivedVerifier) throw new Error('Expected PKCE verifier.');
+	expect(challenge).toBe(await base64UrlSha256(receivedVerifier));
 });
 
 test('cancellation: empty paste returns Err(AuthorizationCancelled) and no network', async () => {

--- a/packages/auth/src/node/oob-launcher.test.ts
+++ b/packages/auth/src/node/oob-launcher.test.ts
@@ -17,10 +17,6 @@ import { createOobOAuthLauncher } from './oob-launcher.js';
 
 const NOW = 1_700_000_000_000;
 
-function asFetch(impl: AuthFetch): AuthFetch {
-	return impl;
-}
-
 function makeJsonResponse(value: unknown, init?: ResponseInit) {
 	return new Response(JSON.stringify(value), {
 		status: 200,
@@ -61,7 +57,7 @@ function setup({
 } = {}) {
 	const printed: string[] = [];
 	const tokenRequests: Array<{ url: string; body: URLSearchParams }> = [];
-	const defaultFetch = asFetch(async (req, init) => {
+	const defaultFetch: AuthFetch = async (req, init) => {
 		const url =
 			typeof req === 'string'
 				? req
@@ -78,7 +74,7 @@ function setup({
 			expires_in: 3600,
 			token_type: 'bearer',
 		});
-	});
+	};
 	const launcher = createOobOAuthLauncher({
 		baseURL: 'http://localhost:8787',
 		clientId: 'epicenter-cli',
@@ -120,7 +116,7 @@ test('PKCE verifier and challenge are linked', async () => {
 	const launcher = createOobOAuthLauncher({
 		baseURL: 'http://localhost:8787',
 		clientId: 'epicenter-cli',
-		fetch: asFetch(async (_input, init) => {
+		fetch: async (_input, init) => {
 			const body = captureBody(init?.body ?? null);
 			receivedVerifier = body.get('code_verifier');
 			return makeJsonResponse({
@@ -129,7 +125,7 @@ test('PKCE verifier and challenge are linked', async () => {
 				expires_in: 3600,
 				token_type: 'bearer',
 			});
-		}),
+		},
 		now: () => NOW,
 		print: (line) => printed.push(line),
 		openBrowser: async () => {},
@@ -141,6 +137,7 @@ test('PKCE verifier and challenge are linked', async () => {
 	const urlLine = printed[0];
 	expect(urlLine).toBeDefined();
 	const url = new URL(urlLine!);
+	expect(url.searchParams.get('state')).toBeNull();
 	const challenge = url.searchParams.get('code_challenge');
 	const method = url.searchParams.get('code_challenge_method');
 	expect(method).toBe('S256');
@@ -152,10 +149,10 @@ test('cancellation: empty paste returns Err(AuthorizationCancelled) and no netwo
 	let fetched = false;
 	const { launcher } = setup({
 		readCode: async () => '   ',
-		fetchImpl: asFetch(async () => {
+		fetchImpl: async () => {
 			fetched = true;
 			return new Response(null, { status: 500 });
-		}),
+		},
 	});
 	const result = await launcher.startSignIn();
 	expect(fetched).toBe(false);
@@ -165,14 +162,13 @@ test('cancellation: empty paste returns Err(AuthorizationCancelled) and no netwo
 
 test('invalid token_type returns Err(InvalidTokenResponse)', async () => {
 	const { launcher } = setup({
-		fetchImpl: asFetch(async () =>
+		fetchImpl: async () =>
 			makeJsonResponse({
 				access_token: 'a',
 				refresh_token: 'r',
 				expires_in: 3600,
 				token_type: 'mac',
 			}),
-		),
 	});
 	const result = await launcher.startSignIn();
 	const err = result.error as { name?: string } | null;
@@ -181,13 +177,11 @@ test('invalid token_type returns Err(InvalidTokenResponse)', async () => {
 
 test('server 400 returns Err(TokenExchangeFailed) with status + body', async () => {
 	const { launcher } = setup({
-		fetchImpl: asFetch(
-			async () =>
-				new Response(JSON.stringify({ error: 'invalid_grant' }), {
-					status: 400,
-					headers: { 'content-type': 'application/json' },
-				}),
-		),
+		fetchImpl: async () =>
+			new Response(JSON.stringify({ error: 'invalid_grant' }), {
+				status: 400,
+				headers: { 'content-type': 'application/json' },
+			}),
 	});
 	const result = await launcher.startSignIn();
 	const err = result.error as {
@@ -213,14 +207,13 @@ test('openBrowser failure does not abort the flow', async () => {
 
 test('case-insensitive token_type check', async () => {
 	const { launcher } = setup({
-		fetchImpl: asFetch(async () =>
+		fetchImpl: async () =>
 			makeJsonResponse({
 				access_token: 'a',
 				refresh_token: 'r',
 				expires_in: 3600,
 				token_type: 'Bearer',
 			}),
-		),
 	});
 	const result = await launcher.startSignIn();
 	expect(result.error).toBeNull();

--- a/packages/auth/src/node/oob-launcher.ts
+++ b/packages/auth/src/node/oob-launcher.ts
@@ -21,6 +21,7 @@ import {
 import { Err, Ok, type Result } from 'wellcrafted/result';
 import type { OAuthTokenGrant } from '../auth-types.js';
 import type { AuthFetch } from '../create-oauth-app-auth.js';
+import { parseOAuthTokenGrant } from '../oauth-token-response.js';
 
 export const OobLauncherError = defineErrors({
 	TokenExchangeFailed: ({
@@ -101,15 +102,12 @@ export function createOobOAuthLauncher({
 				),
 			);
 			const codeChallenge = base64UrlEncode(challengeBytes);
-			const state = base64UrlEncode(randomBytes(crypto, 16));
-
 			const authorizeUrl = new URL(`${baseURL}/auth/oauth2/authorize`);
 			authorizeUrl.search = new URLSearchParams({
 				response_type: 'code',
 				client_id: clientId,
 				redirect_uri: redirectUri,
 				scope: scopes.join(' '),
-				state,
 				code_challenge: codeChallenge,
 				code_challenge_method: 'S256',
 				resource: baseURL,
@@ -179,53 +177,12 @@ export function createOobOAuthLauncher({
 			}
 
 			try {
-				const grant = parseTokenResponse(payload, now);
+				const grant = parseOAuthTokenGrant(payload, { now });
 				return Ok(grant);
 			} catch (cause) {
 				return Err(OobLauncherError.InvalidTokenResponse({ cause }).error);
 			}
 		},
-	};
-}
-
-function parseTokenResponse(
-	payload: unknown,
-	now: () => number,
-): OAuthTokenGrant {
-	if (
-		payload === null ||
-		typeof payload !== 'object' ||
-		Array.isArray(payload)
-	) {
-		throw new Error('Expected token response to be an object.');
-	}
-	const record = payload as Record<string, unknown>;
-	const tokenType = record['token_type'];
-	if (typeof tokenType !== 'string' || tokenType.toLowerCase() !== 'bearer') {
-		throw new Error(
-			`Expected token_type 'bearer', got ${JSON.stringify(tokenType)}.`,
-		);
-	}
-	const accessToken = record['access_token'];
-	if (typeof accessToken !== 'string') {
-		throw new Error('Expected access_token to be a string.');
-	}
-	const refreshToken = record['refresh_token'];
-	if (typeof refreshToken !== 'string') {
-		throw new Error('Expected refresh_token to be a string.');
-	}
-	const expiresIn = record['expires_in'];
-	if (
-		typeof expiresIn !== 'number' ||
-		!Number.isFinite(expiresIn) ||
-		expiresIn <= 0
-	) {
-		throw new Error('Expected expires_in to be a positive finite number.');
-	}
-	return {
-		accessToken,
-		refreshToken,
-		accessTokenExpiresAt: now() + expiresIn * 1000,
 	};
 }
 

--- a/packages/auth/src/node/oob-launcher.ts
+++ b/packages/auth/src/node/oob-launcher.ts
@@ -20,6 +20,7 @@ import {
 } from 'wellcrafted/error';
 import { Err, Ok, type Result } from 'wellcrafted/result';
 import type { OAuthTokenGrant } from '../auth-types.js';
+import type { AuthFetch } from '../create-oauth-app-auth.js';
 
 export const OobLauncherError = defineErrors({
 	TokenExchangeFailed: ({
@@ -71,7 +72,7 @@ export type CreateOobOAuthLauncherConfig = {
 	openBrowser?: (url: string) => Promise<void> | void;
 	readCode?: () => Promise<string>;
 	print?: (line: string) => void;
-	fetch?: typeof globalThis.fetch;
+	fetch?: AuthFetch;
 	crypto?: Crypto;
 	now?: () => number;
 };

--- a/packages/auth/src/oauth-launchers/index.test.ts
+++ b/packages/auth/src/oauth-launchers/index.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { expect, test } from 'bun:test';
+import type { AuthFetch } from '../create-oauth-app-auth.js';
 import { createOAuthClient, type OAuthTemporaryStorage } from './index.js';
 
 function createMemoryStorage(seed: Record<string, string> = {}) {
@@ -41,8 +42,8 @@ function createFetch({
 	tokenStatus?: number;
 	tokenBody?: Record<string, unknown>;
 	onTokenBody?: (body: URLSearchParams) => void;
-} = {}) {
-	return (async (input: Request | URL | string, init?: RequestInit) => {
+} = {}): AuthFetch {
+	return async (input, init) => {
 		const url = new URL(input instanceof Request ? input.url : input);
 		if (url.pathname === '/.well-known/oauth-authorization-server/auth') {
 			return Response.json({
@@ -60,7 +61,7 @@ function createFetch({
 			);
 		}
 		throw new Error(`Unexpected fetch: ${url.toString()}`);
-	}) as typeof fetch;
+	};
 }
 
 test('createAuthorizationUrl stores verifier state and returns PKCE URL', async () => {

--- a/packages/auth/src/oauth-launchers/index.test.ts
+++ b/packages/auth/src/oauth-launchers/index.test.ts
@@ -315,3 +315,34 @@ test('handleCallback rejects a token response without expires_in', async () => {
 
 	expect(error?.name).toBe('MissingExpiresIn');
 });
+
+test('handleCallback rejects a non-bearer token response', async () => {
+	const { storage } = createMemoryStorage({
+		'epicenter.oauth.client-1': JSON.stringify({
+			state: 'state-1',
+			codeVerifier: 'verifier-1',
+			redirectUri: 'http://app.test/auth/callback',
+		}),
+	});
+	const client = createOAuthClient({
+		issuer: 'http://auth.test/auth',
+		clientId: 'client-1',
+		redirectUri: 'http://app.test/auth/callback',
+		resource: 'http://auth.test',
+		storage,
+		fetch: createFetch({
+			tokenBody: {
+				access_token: 'access-token',
+				refresh_token: 'refresh-token',
+				expires_in: 900,
+				token_type: 'mac',
+			},
+		}),
+	});
+
+	const { error } = await client.handleCallback(
+		'http://app.test/auth/callback?code=code-1&state=state-1',
+	);
+
+	expect(error?.name).toBe('TokenExchangeFailed');
+});

--- a/packages/auth/src/oauth-launchers/index.ts
+++ b/packages/auth/src/oauth-launchers/index.ts
@@ -6,6 +6,7 @@ import {
 } from 'wellcrafted/error';
 import { Ok, type Result } from 'wellcrafted/result';
 import type { OAuthTokenGrant } from '../auth-types.js';
+import type { AuthFetch } from '../create-oauth-app-auth.js';
 
 export const OAuthClientError = defineErrors({
 	MissingCallbackTransaction: () => ({
@@ -62,7 +63,7 @@ export type OAuthClientConfig = {
 	resource: string;
 	scope?: string;
 	storage: OAuthTemporaryStorage;
-	fetch?: typeof fetch;
+	fetch?: AuthFetch;
 };
 
 export type OAuthLauncher = {

--- a/packages/auth/src/oauth-launchers/index.ts
+++ b/packages/auth/src/oauth-launchers/index.ts
@@ -7,6 +7,10 @@ import {
 import { Ok, type Result } from 'wellcrafted/result';
 import type { OAuthTokenGrant } from '../auth-types.js';
 import type { AuthFetch } from '../create-oauth-app-auth.js';
+import {
+	OAuthTokenResponseError,
+	parseOAuthTokenGrant,
+} from '../oauth-token-response.js';
 
 export const OAuthClientError = defineErrors({
 	MissingCallbackTransaction: () => ({
@@ -297,21 +301,24 @@ export function createOAuthClient({
 function parseTokenResult(
 	tokenResponse: oauth.TokenEndpointResponse,
 ): Result<OAuthTokenGrant, OAuthClientError> {
-	if (!tokenResponse.access_token) return OAuthClientError.MissingAccessToken();
-	if (!tokenResponse.refresh_token)
-		return OAuthClientError.MissingRefreshToken();
-	if (
-		typeof tokenResponse.expires_in !== 'number' ||
-		!Number.isFinite(tokenResponse.expires_in) ||
-		tokenResponse.expires_in <= 0
-	) {
-		return OAuthClientError.MissingExpiresIn();
+	try {
+		return Ok(parseOAuthTokenGrant(tokenResponse, { now: Date.now }));
+	} catch (cause) {
+		if (cause instanceof OAuthTokenResponseError) {
+			switch (cause.issue) {
+				case 'missing_access_token':
+					return OAuthClientError.MissingAccessToken();
+				case 'missing_refresh_token':
+					return OAuthClientError.MissingRefreshToken();
+				case 'missing_expires_in':
+					return OAuthClientError.MissingExpiresIn();
+				case 'invalid_response':
+				case 'invalid_token_type':
+					return OAuthClientError.TokenExchangeFailed({ cause });
+			}
+		}
+		return OAuthClientError.TokenExchangeFailed({ cause });
 	}
-	return Ok({
-		accessToken: tokenResponse.access_token,
-		refreshToken: tokenResponse.refresh_token,
-		accessTokenExpiresAt: Date.now() + tokenResponse.expires_in * 1000,
-	});
 }
 
 function currentUrl() {

--- a/packages/auth/src/oauth-token-response.ts
+++ b/packages/auth/src/oauth-token-response.ts
@@ -1,0 +1,88 @@
+import type { OAuthTokenGrant } from './auth-types.js';
+
+export type OAuthTokenResponseIssue =
+	| 'missing_access_token'
+	| 'missing_refresh_token'
+	| 'missing_expires_in'
+	| 'invalid_token_type'
+	| 'invalid_response';
+
+export class OAuthTokenResponseError extends Error {
+	constructor(
+		readonly issue: OAuthTokenResponseIssue,
+		message: string,
+	) {
+		super(message);
+		this.name = 'OAuthTokenResponseError';
+	}
+}
+
+export function parseOAuthTokenGrant(
+	payload: unknown,
+	{
+		now,
+		fallbackRefreshToken,
+	}: {
+		now: () => number;
+		fallbackRefreshToken?: string;
+	},
+): OAuthTokenGrant {
+	const record = readRecord(payload);
+	const tokenType = record['token_type'];
+	if (typeof tokenType !== 'string' || tokenType.toLowerCase() !== 'bearer') {
+		throw new OAuthTokenResponseError(
+			'invalid_token_type',
+			`Expected token_type to be bearer, got ${JSON.stringify(tokenType)}.`,
+		);
+	}
+
+	const accessToken = record['access_token'];
+	if (typeof accessToken !== 'string') {
+		throw new OAuthTokenResponseError(
+			'missing_access_token',
+			'Expected access_token to be a string.',
+		);
+	}
+
+	const refreshToken = record['refresh_token'];
+	if (refreshToken != null && typeof refreshToken !== 'string') {
+		throw new OAuthTokenResponseError(
+			'missing_refresh_token',
+			'Expected refresh_token to be a string.',
+		);
+	}
+	if (refreshToken == null && fallbackRefreshToken === undefined) {
+		throw new OAuthTokenResponseError(
+			'missing_refresh_token',
+			'Expected refresh_token to be a string.',
+		);
+	}
+
+	const expiresIn = record['expires_in'];
+	if (
+		typeof expiresIn !== 'number' ||
+		!Number.isFinite(expiresIn) ||
+		expiresIn <= 0
+	) {
+		throw new OAuthTokenResponseError(
+			'missing_expires_in',
+			'Expected expires_in to be a positive finite number.',
+		);
+	}
+
+	return {
+		accessToken,
+		refreshToken: refreshToken ?? fallbackRefreshToken!,
+		accessTokenExpiresAt: now() + expiresIn * 1000,
+	};
+}
+
+function readRecord(value: unknown): Record<string, unknown> {
+	if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+		throw new OAuthTokenResponseError(
+			'invalid_response',
+			'Expected OAuth token response to be an object.',
+		);
+	}
+	return value as Record<string, unknown>;
+}

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -51,7 +51,8 @@ The persisted shape is `PersistedAuth = { grant, unlock }`:
 
 - `grant` (`{ accessToken, refreshToken, accessTokenExpiresAt }`) is the
   online server-access material. The refresh token rotates on every
-  refresh; revoked on `epicenter auth logout` via RFC 7009.
+  refresh. `epicenter auth logout` clears the local file first, then makes a
+  best-effort RFC 7009 revoke call.
 - `unlock` (`{ userId, encryptionKeys }`) is the local capability to
   decrypt workspace Yjs data without a network roundtrip. Loaded once at
   sign-in from `GET /api/me` and re-confirmed at cold-boot when online.
@@ -161,13 +162,13 @@ import {
 	roomWsUrl,
 } from '@epicenter/workspace';
 import { defineConfig } from '@epicenter/workspace/daemon';
-import { createMachineAuthClient } from '@epicenter/auth/node';
+import type { AuthClient } from '@epicenter/auth';
 import Type from 'typebox';
 import { type } from 'arktype';
 
 const SavedTab = defineTable(type({ id: 'string', title: 'string', url: 'string', _v: '1' }));
 
-async function openTabManagerDaemon() {
+async function openTabManagerDaemon({ auth }: { auth: AuthClient }) {
 	const ydoc = new Y.Doc({ guid: 'epicenter.tab-manager' });
 	const tables = attachTables(ydoc, { savedTabs: SavedTab });
 	const actions = defineActions({
@@ -181,7 +182,6 @@ async function openTabManagerDaemon() {
 			handler: ({ id }) => tables.savedTabs.delete(id),
 		}),
 	});
-	const auth = await createMachineAuthClient();
 	const collaboration = openCollaboration(ydoc, {
 		url: roomWsUrl('https://api.epicenter.so', ydoc.guid),
 		openWebSocket: auth.openWebSocket,
@@ -207,10 +207,20 @@ async function openTabManagerDaemon() {
 
 export default defineConfig({
 	daemon: {
-		routes: [{ route: 'tabManager', start: () => openTabManagerDaemon() }],
+		routes: [
+			{
+				route: 'tabManager',
+				start: ({ auth }) => openTabManagerDaemon({ auth }),
+			},
+		],
 	},
 });
 ```
+
+The CLI loader creates one machine auth client from
+`~/.epicenter/auth.json` and injects it into every route starter as
+`start({ auth, projectDir, route })`. Route modules should consume that
+`auth`; they should not call `createMachineAuthClient()` themselves.
 
 App packages publish their schema on npm. Runtime recipes (script entries,
 daemon routes) ship as jsrepo blocks the consumer copies into their tree.
@@ -229,9 +239,8 @@ export default defineConfig({
 ```
 
 Add the block with `bunx jsrepo add epicenter/fuji/daemon-route`. The block
-defaults auth through `createMachineAuthClient()` from `@epicenter/auth/node`
-and is yours to edit (override the auth source, the sync URL, the route name,
-etc.) without breaking sync compatibility.
+defaults to the injected daemon auth and is yours to edit (override the sync
+URL, the route name, etc.) without breaking sync compatibility.
 
 ## Exposing operations via CLI
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -8,7 +8,7 @@
 import { describe, expect, spyOn, test } from 'bun:test';
 import { createCLI } from './cli';
 
-function captureHelp(argv: string[] = ['--help']): Promise<string> {
+async function captureHelp(argv: string[] = ['--help']): Promise<string> {
 	const chunks: string[] = [];
 	const logSpy = spyOn(console, 'log').mockImplementation(
 		(...args: unknown[]) => {
@@ -20,14 +20,15 @@ function captureHelp(argv: string[] = ['--help']): Promise<string> {
 			chunks.push(args.map((a) => String(a)).join(' '));
 		},
 	);
-	return createCLI()
-		.run(argv)
-		.catch(() => {})
-		.finally(() => {
-			logSpy.mockRestore();
-			errSpy.mockRestore();
-		})
-		.then(() => chunks.join('\n'));
+	try {
+		await createCLI()
+			.run(argv)
+			.catch(() => {});
+		return chunks.join('\n');
+	} finally {
+		logSpy.mockRestore();
+		errSpy.mockRestore();
+	}
 }
 
 describe('createCLI', () => {

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -12,6 +12,7 @@
 	},
 	"exports": {
 		"./apps": "./src/apps.ts",
+		"./auth": "./src/auth.ts",
 		"./oauth": "./src/oauth.ts",
 		"./vite": "./src/vite.ts",
 		"./versions": "./src/versions.ts",

--- a/packages/constants/src/auth.ts
+++ b/packages/constants/src/auth.ts
@@ -1,0 +1,2 @@
+/** Prefix for OAuth bearer tokens carried through WebSocket subprotocols. */
+export const BEARER_SUBPROTOCOL_PREFIX = 'bearer.';

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -28,6 +28,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
+		"@epicenter/constants": "workspace:*",
 		"lib0": "catalog:",
 		"wellcrafted": "catalog:",
 		"y-protocols": "catalog:"

--- a/packages/sync/src/auth-subprotocol.test.ts
+++ b/packages/sync/src/auth-subprotocol.test.ts
@@ -9,8 +9,8 @@
  * - Bearer tokens are extracted from comma-separated subprotocol headers
  */
 
-import { BEARER_SUBPROTOCOL_PREFIX as SHARED_PREFIX } from '@epicenter/constants/auth';
 import { expect, test } from 'bun:test';
+import { BEARER_SUBPROTOCOL_PREFIX as SHARED_PREFIX } from '@epicenter/constants/auth';
 import {
 	BEARER_SUBPROTOCOL_PREFIX,
 	extractBearerToken,

--- a/packages/sync/src/auth-subprotocol.test.ts
+++ b/packages/sync/src/auth-subprotocol.test.ts
@@ -1,0 +1,35 @@
+/**
+ * WebSocket Auth Subprotocol Tests
+ *
+ * Verifies the shared bearer subprotocol helpers used by auth clients and API
+ * middleware.
+ *
+ * Key behaviors:
+ * - Bearer prefix comes from the shared constants package
+ * - Bearer tokens are extracted from comma-separated subprotocol headers
+ */
+
+import { BEARER_SUBPROTOCOL_PREFIX as SHARED_PREFIX } from '@epicenter/constants/auth';
+import { expect, test } from 'bun:test';
+import {
+	BEARER_SUBPROTOCOL_PREFIX,
+	extractBearerToken,
+	MAIN_SUBPROTOCOL,
+	parseSubprotocols,
+} from './auth-subprotocol.js';
+
+test('bearer prefix re-exports the shared auth constant', () => {
+	expect(BEARER_SUBPROTOCOL_PREFIX).toBe(SHARED_PREFIX);
+});
+
+test('extractBearerToken reads the bearer subprotocol entry', () => {
+	const headers = new Headers({
+		'sec-websocket-protocol': `${MAIN_SUBPROTOCOL}, ${BEARER_SUBPROTOCOL_PREFIX}token-1`,
+	});
+
+	expect(parseSubprotocols(headers.get('sec-websocket-protocol'))).toEqual([
+		MAIN_SUBPROTOCOL,
+		`${BEARER_SUBPROTOCOL_PREFIX}token-1`,
+	]);
+	expect(extractBearerToken(headers)).toBe('token-1');
+});

--- a/packages/sync/src/auth-subprotocol.ts
+++ b/packages/sync/src/auth-subprotocol.ts
@@ -1,5 +1,7 @@
+import { BEARER_SUBPROTOCOL_PREFIX } from '@epicenter/constants/auth';
+
 /**
- * WebSocket subprotocol auth — shared client/server constants.
+ * WebSocket subprotocol auth: shared client/server constants.
  *
  * Auth tokens travel inside the `Sec-WebSocket-Protocol` handshake header
  * as `bearer.<token>`, not in the URL's query string. The real threat is
@@ -11,7 +13,7 @@
  * upgrade; only the main protocol name (`epicenter`) is echoed back on
  * the 101 response, so the token never round-trips.
  *
- * The `.` separator is required by RFC compliance — `Sec-WebSocket-Protocol`
+ * The `.` separator is required by RFC compliance: `Sec-WebSocket-Protocol`
  * values are RFC 7230 `token` productions, where `:` is not a valid `tchar`
  * but `.` is. Prior art for `<scheme>.<token>`: Phoenix channels
  * (`phx_bearer.<token>`), Supabase Realtime, and Kubernetes
@@ -21,8 +23,7 @@
 /** Primary subprotocol name every Epicenter client negotiates. */
 export const MAIN_SUBPROTOCOL = 'epicenter';
 
-/** Prefix that identifies a bearer-token subprotocol entry. */
-export const BEARER_SUBPROTOCOL_PREFIX = 'bearer.';
+export { BEARER_SUBPROTOCOL_PREFIX };
 
 /**
  * Parse a `Sec-WebSocket-Protocol` header value into its list of tokens.

--- a/packages/workspace/src/cache/disposable-cache.test.ts
+++ b/packages/workspace/src/cache/disposable-cache.test.ts
@@ -147,9 +147,10 @@ describe('arbitrary fields flow through the handle', () => {
 
 		const handle = cache.open('a');
 		let resolved = false;
-		void handle.whenReady.then(() => {
+		void (async () => {
+			await handle.whenReady;
 			resolved = true;
-		});
+		})();
 
 		await new Promise((r) => setTimeout(r, 5));
 		expect(resolved).toBe(false);

--- a/packages/workspace/src/document/README.md
+++ b/packages/workspace/src/document/README.md
@@ -99,10 +99,10 @@ import { auth } from './auth';
 function openBlog() {
   const ydoc = new Y.Doc({ guid: 'blog' });
   const tables = attachTables(ydoc, myTables);
-  if (auth.state.status !== 'signed-in') return null;
+  if (auth.state.status === 'signed-out') return null;
 
   const idb = attachIndexedDb(ydoc);
-  attachOwnedBroadcastChannel(ydoc, { userId: auth.state.identity.user.id });
+  attachOwnedBroadcastChannel(ydoc, { userId: auth.state.unlock.userId });
   const collaboration = openCollaboration(ydoc, {
     url: roomWsUrl('https://api.example.com', ydoc.guid),
     openWebSocket: auth.openWebSocket,

--- a/packages/workspace/src/document/materializer/sqlite/ddl.ts
+++ b/packages/workspace/src/document/materializer/sqlite/ddl.ts
@@ -14,6 +14,15 @@
 
 type JsonSchema = Record<string, unknown>;
 
+const SQLITE_TYPE_BY_JSON_TYPE: Record<string, string> = {
+	string: 'TEXT',
+	number: 'REAL',
+	integer: 'INTEGER',
+	boolean: 'INTEGER',
+	object: 'TEXT',
+	array: 'TEXT',
+};
+
 // ════════════════════════════════════════════════════════════════════════════
 // PUBLIC API
 // ════════════════════════════════════════════════════════════════════════════
@@ -176,22 +185,10 @@ function columnDef(
 
 	const jsonType =
 		typeof propSchema.type === 'string' ? propSchema.type : undefined;
+	const sqliteType =
+		jsonType === undefined ? undefined : SQLITE_TYPE_BY_JSON_TYPE[jsonType];
 
-	switch (jsonType) {
-		case 'string':
-			return appendNullability(`${quotedName} TEXT`, isRequired);
-		case 'number':
-			return appendNullability(`${quotedName} REAL`, isRequired);
-		case 'integer':
-			return appendNullability(`${quotedName} INTEGER`, isRequired);
-		case 'boolean':
-			return appendNullability(`${quotedName} INTEGER`, isRequired);
-		case 'object':
-		case 'array':
-			return appendNullability(`${quotedName} TEXT`, isRequired);
-		default:
-			return appendNullability(`${quotedName} TEXT`, isRequired);
-	}
+	return appendNullability(`${quotedName} ${sqliteType ?? 'TEXT'}`, isRequired);
 }
 
 function appendNullability(column: string, isRequired: boolean) {

--- a/packages/workspace/src/document/materializer/sqlite/sqlite.ts
+++ b/packages/workspace/src/document/materializer/sqlite/sqlite.ts
@@ -155,7 +155,10 @@ export function attachSqliteMaterializer(
 		const rows = table.getAllValid();
 		if (rows.length === 0) return;
 
-		const keys = Object.keys(rows[0]!);
+		const firstRow = rows[0];
+		if (firstRow === undefined) return;
+
+		const keys = Object.keys(firstRow);
 		const placeholders = keys.map(() => '?').join(', ');
 		const columns = keys.map(quoteIdentifier).join(', ');
 		const stmt = await db.prepare(
@@ -185,11 +188,9 @@ export function attachSqliteMaterializer(
 
 		syncTimeout = setTimeout(() => {
 			syncTimeout = null;
-			syncQueue = syncQueue
-				.then(() => flushPendingSync())
-				.catch((cause: unknown) => {
-					log.error(SqliteMaterializerError.SyncFailed({ cause }));
-				});
+			syncQueue = syncQueue.then(flushPendingSync).catch((cause: unknown) => {
+				log.error(SqliteMaterializerError.SyncFailed({ cause }));
+			});
 		}, debounceMs);
 	}
 

--- a/packages/workspace/src/document/open-collaboration.ts
+++ b/packages/workspace/src/document/open-collaboration.ts
@@ -162,16 +162,18 @@ export function openCollaboration<TActions extends ActionRegistry>(
 	// Client-side orphan sweep. If a previous run crashed between writing a
 	// call and reaching `finally { rpc.delete(id) }`, the entry persists in
 	// the workspace doc. Sweep anything older than 1h once we are online.
-	// Wrapped in `.catch` because the supervisor rejects `whenConnected` on
-	// permanent auth failure, and we do not want to surface that here.
-	void supervisor.whenConnected
-		.then(() => {
+	void (async () => {
+		try {
+			await supervisor.whenConnected;
 			const cutoff = Date.now() - 1000 * 60 * 60;
 			for (const [id, entry] of rpc.entries()) {
 				if (entry.val.sent_at < cutoff) rpc.delete(id);
 			}
-		})
-		.catch(() => {});
+		} catch {
+			// The supervisor rejects `whenConnected` on permanent auth failure, and
+			// orphan cleanup should not surface that failure here.
+		}
+	})();
 
 	return {
 		replicaId,

--- a/specs/20260514T120000-machine-auth-oob-clean-break.md
+++ b/specs/20260514T120000-machine-auth-oob-clean-break.md
@@ -1,8 +1,8 @@
 # Machine Auth: OOB Code Paste + File-Backed Session
 
 **Date**: 2026-05-14
-**Status**: Partially implemented (Phases 1-2 landed via `specs/20260514T200000-api-me-three-field-token-bundle.md` Waves 1-2; Phases 3-4 open).
-**Branch**: `codex/pr-workspace-api-surface` (target; implementation lands on a follow-up branch)
+**Status**: Implemented (2026-05-15). Phases 1-2 landed via `specs/20260514T200000-api-me-three-field-token-bundle.md` Waves 1-2; Phases 3-4 landed via PR #1762 (`specs/20260514T210000-execute-oob-cli-phases-3-4.md`). Only Phase 6 (CLI README OOB walkthrough) is open.
+**Branch**: `codex/pr-workspace-api-surface` (target; implementation landed on `codex/wave1-cli-callback-and-health`, merged via #1762)
 **Depends on**: `specs/20260512T111335-post-oauth-audit-remediation.md` (resolves Phase 4)
 **Composes with**: `specs/20260514T200000-api-me-three-field-token-bundle.md` (defines the persisted shape; this spec is the CLI's flavor of that architecture)
 **Resolves**: `specs/20260512T111335-post-oauth-audit-remediation.md` Open Question 2 ("Is CLI/device login currently shipped to users?")
@@ -16,10 +16,10 @@ Reality on `main` after the `/api/me` spec's Waves 1-4 landed (2026-05-14):
 | --- | --- | --- | --- |
 | 1 | Server callback page + constants + trusted-client projection | Landed in api-me Wave 1 (commits `9f32ea0bc` and follow-ons) | **DONE** |
 | 2 | File-backed `machine-session-store.ts` persisting `OAuthSession` | api-me Wave 2 replaced this with `machine-tokens-store.ts` persisting `PersistedAuth = { grant, unlock }` (commit `58a5e9b36`) | **DONE, with a sharper shape** |
-| 3 | OOB launcher (`oob-launcher.ts`) | Not started | **OPEN** |
-| 4 | Rewrite `machine-auth.ts` to use the OOB launcher | `machine-auth.ts` is stubbed (`PENDING_WAVE_3` errors); needs the OOB rewrite consuming `PersistedAuthStorage` | **OPEN** |
-| 5 | Daemon smoke + consumer audit | Cannot run until Phases 3-4 land; daemons currently throw on boot | **OPEN** |
-| 6 | Docs | api-me Wave 4 already deleted `/workspace-identity` and updated `docs/encryption.md` references | Mostly done; CLI README still needs the OOB walkthrough |
+| 3 | OOB launcher (`oob-launcher.ts`) | Landed in PR #1762 Wave 1 (commit `095ed0833`) | **DONE** |
+| 4 | Rewrite `machine-auth.ts` to use the OOB launcher | Landed in PR #1762 Wave 2 (commit `51efc2853`); CLI wire-up in Wave 3 (`3c5c875e2`); tests in Wave 4 (`f2f04c763`); revoke-ordering fix in `6f15a2c72` | **DONE** |
+| 5 | Daemon smoke + consumer audit | Daemons now boot through the real `createMachineAuthClient` path; orchestration guide moves the next lane to `codex/daemon-shared-auth` (Phase 1 of single-daemon spec) | **DONE for smoke; consumer audit folds into daemon-shared-auth** |
+| 6 | Docs | api-me Wave 4 already deleted `/workspace-identity` and updated `docs/encryption.md` references | Mostly done; CLI README still needs the OOB walkthrough: **OPEN** |
 
 The persisted-shape and identity-source decisions below are **superseded by the api-me spec**. Where this spec says `OAuthSession`, read `PersistedAuth`. Where it says `/workspace-identity`, read `/api/me`. Where it says `machine-session-store.ts`, read `machine-tokens-store.ts`. The narrative below is preserved with these substitutions called out inline.
 
@@ -388,7 +388,7 @@ createOAuthAppAuth({
 
 Ordered patches. Each step lands as one commit unless noted.
 
-### Phase 1: Server callback page  [DONE — api-me Wave 1]
+### Phase 1: Server callback page  [DONE: api-me Wave 1]
 
 Landed in commits `9f32ea0bc` (`/api/me` route) and follow-on Wave 1 commits. The CLI callback page, the `/auth/cli-callback` route, the constants update, and the `toOAuthClientType` collapse are all on `main`. Items below are preserved as the original task list; treat all as `[x]`.
 
@@ -428,7 +428,7 @@ Landed in commits `9f32ea0bc` (`/api/me` route) and follow-on Wave 1 commits. Th
 
 Acceptance: `bun --cwd apps/api run build` passes; `bun --cwd apps/api test` passes; manual smoke clean.
 
-### Phase 2: File-backed session store  [DONE — api-me Wave 2, with a sharper shape]
+### Phase 2: File-backed session store  [DONE: api-me Wave 2, with a sharper shape]
 
 Landed in commit `58a5e9b36` as `packages/auth/src/node/machine-tokens-store.ts` (the file was renamed from `machine-session-store.ts` during the api-me Wave 2 schema break). The persisted shape is `PersistedAuth = { grant, unlock }` per the api-me spec, not `OAuthSession`. The original task list below is preserved as a historical record; for the as-shipped contract, see `specs/20260514T200000-api-me-three-field-token-bundle.md`.
 

--- a/specs/20260514T210000-execute-oob-cli-phases-3-4.md
+++ b/specs/20260514T210000-execute-oob-cli-phases-3-4.md
@@ -2,7 +2,12 @@
 
 **Date**: 2026-05-14
 **Type**: Execution spec for a coding agent
-**Status**: Ready to execute
+**Status**: Landed in PR #1762 (2026-05-15). All four waves shipped on `main`:
+- Wave 1: `095ed0833 feat(auth): add OOB OAuth launcher for CLI sign-in`
+- Wave 2: `51efc2853 feat(auth): replace machine-auth stub with OOB + /api/me flow`
+- Wave 3: `3c5c875e2 feat(cli): wire epicenter auth to OOB flow`
+- Wave 4: `f2f04c763 test(auth): cover OOB launcher and machine-auth flow`
+- Follow-up: `6f15a2c72 fix(auth): clear sign-out before revoke`
 **Drives**:
 - `specs/20260514T120000-machine-auth-oob-clean-break.md` (Phases 3-4 only)
 - `specs/20260514T200000-api-me-three-field-token-bundle.md` (PersistedAuth shape, grant/unlock split, network gate)
@@ -37,16 +42,16 @@ add tests, and verify daemon boot.
    network gate, and the same-user guard. **Where it conflicts with anything
    else, it wins.**
 
-2. `specs/20260514T120000-machine-auth-oob-clean-break.md` — sections
+2. `specs/20260514T120000-machine-auth-oob-clean-break.md`: sections
    `## Status update (post-api-me)`, `## Desired State`, Phase 3, Phase 4. The
    rest is historical context.
 
-3. `packages/auth/src/auth-types.ts` — exact arktype shapes of
+3. `packages/auth/src/auth-types.ts`: exact arktype shapes of
    `OAuthTokenGrant` (3 fields), `LocalUnlockBundle`, `PersistedAuth`.
 
-4. `packages/auth/src/auth-contract.ts` — `AuthClient` and `AuthState` contracts.
+4. `packages/auth/src/auth-contract.ts`: `AuthClient` and `AuthState` contracts.
 
-5. `packages/auth/src/create-oauth-app-auth.ts` — what `createMachineAuthClient`
+5. `packages/auth/src/create-oauth-app-auth.ts`: what `createMachineAuthClient`
    instantiates (for daemons). Pay attention to:
    - the `persistedAuthStorage` parameter shape
    - the `launcher.startSignIn` contract
@@ -55,18 +60,18 @@ add tests, and verify daemon boot.
      `auth.state` carries only `status` + `unlock`; no `email`, no `profile`,
      no `profileStatus`. The CLI fetches `/api/me` itself for display.)
 
-6. `packages/auth/src/node/machine-tokens-store.ts` — `loadMachineTokens` /
+6. `packages/auth/src/node/machine-tokens-store.ts`: `loadMachineTokens` /
    `saveMachineTokens` signatures; the storage adapter you wire in.
 
-7. `packages/auth/src/node/machine-auth.ts` — the stub you are replacing.
+7. `packages/auth/src/node/machine-auth.ts`: the stub you are replacing.
    Preserves public function names; daemon code imports them.
 
-8. `packages/cli/src/commands/auth.ts` — the CLI surface to update.
+8. `packages/cli/src/commands/auth.ts`: the CLI surface to update.
 
-9. `packages/constants/src/oauth.ts` — `EPICENTER_CLI_OAUTH_CLIENT_ID` and the
+9. `packages/constants/src/oauth.ts`: `EPICENTER_CLI_OAUTH_CLIENT_ID` and the
    registered redirect URI (`https://api.epicenter.so/auth/cli-callback`).
 
-10. `apps/api/src/app.ts` (search for `/api/me` and `/auth/oauth2/*`) — confirm
+10. `apps/api/src/app.ts` (search for `/api/me` and `/auth/oauth2/*`): confirm
     the endpoint paths. **No edits.**
 
 After reading, post a one-line acknowledgment of what you're about to do.
@@ -367,7 +372,7 @@ Commit message: `feat(auth): replace machine-auth stub with OOB + /api/me flow`.
 
 ### Wave 3: CLI command + barrel exports
 
-File: `packages/auth/src/node.ts` — drop `loginWithDeviceCode`, `DeviceTokenError`,
+File: `packages/auth/src/node.ts`: drop `loginWithDeviceCode`, `DeviceTokenError`,
 `MachineAuthClient` (alias) re-exports; add `loginWithOob`. Verify no callers
 under `packages/` remain that import the deleted names.
 

--- a/specs/20260515T010000-auth-canonical-path-audit.md
+++ b/specs/20260515T010000-auth-canonical-path-audit.md
@@ -1,45 +1,45 @@
-# Auth Canonical Path Audit
+# Auth, Workspace Session, Local Unlock, And Transport Canonical Path
 
 **Date**: 2026-05-15
-**Status**: In Progress
+**Status**: Recommendation
 **Author**: AI-assisted
 
 ## One Sentence
 
-Epicenter has three defensible auth paths: browser redirect OAuth, extension WebAuthFlow OAuth, and machine OOB OAuth; all three converge on one persisted auth cell, one `/api/me` identity gate, one refresh and revoke surface, and one local-unlock state model.
+Epicenter uses Better Auth as the OAuth server, stores one client-side `PersistedAuth` cell with an online grant and local unlock bundle, mounts workspaces while local unlock exists, and routes all network access through auth-owned HTTP and WebSocket transports.
 
-## Current State
+This is the final recommendation for the current architecture pass. It replaces the older `OAuthSession`, `WorkspaceIdentityStore`, id-token-carried keys, raw token getter, and device-authorization directions.
 
-The center is already smaller than the old specs imply.
+## Recommendation
+
+Keep the landed `{ grant, unlock }` architecture and harden it. Do not split identity into a second workspace store, do not move encryption keys into `id_token`, do not reintroduce raw token getters, and do not revive Better Auth device authorization for the CLI.
+
+The smallest coherent final shape is:
 
 ```txt
 Better Auth
-  owns:
-    /auth/oauth2/authorize
-    /auth/oauth2/token
-    /auth/oauth2/revoke
-    /auth/oauth2/consent
-    /auth/* account/session machinery
+  owns account sessions, login pages, OAuth consent, authorization code,
+  refresh token, revoke, JWKS, and trusted client metadata
 
 Epicenter API
-  owns:
-    /api/me
-    OAuth resource checks
-    trusted first-party client projection
-    CLI callback page
+  owns /api/me and protected-resource authorization
 
-Epicenter clients
-  own:
-    launcher per runtime
-    PersistedAuth storage per runtime
-    AuthClient network gate
-    local unlock lifecycle
+@epicenter/auth
+  owns PersistedAuth, refresh, revoke, /api/me verification,
+  auth.fetch, and auth.openWebSocket
+
+@epicenter/svelte
+  owns workspace session mounting from auth.state
+
+@epicenter/workspace
+  owns LocalOwner, local Yjs persistence, encryption attachment,
+  BroadcastChannel scoping, sync, and wipe
 ```
 
-The durable client shape is one cell:
+The durable cell stays exactly this shape:
 
 ```ts
-PersistedAuth = {
+type PersistedAuth = {
   grant: {
     accessToken: string;
     refreshToken: string;
@@ -52,225 +52,513 @@ PersistedAuth = {
 };
 ```
 
-Evidence:
+The public auth state stays capability-only:
 
-| Surface | Evidence |
-| --- | --- |
-| Persisted shape | `packages/auth/src/auth-types.ts:48` defines `PersistedAuth = { grant, unlock }`. |
-| Auth state | `packages/auth/src/auth-contract.ts:11` defines `signed-out`, `signed-in`, and `reauth-required`; both identity-bearing states carry `unlock`. |
-| Client gate | `packages/auth/src/create-oauth-app-auth.ts:234` refreshes, calls `/api/me`, and refuses to attach bearer credentials until the current cell is verified. |
-| Server identity | `apps/api/src/app.ts:275` mounts `/api/me`; `apps/api/src/auth/resource-boundary.ts:64` verifies token, audience, issuer, subject, scope, and user existence. |
-| Server OAuth | `apps/api/src/app.ts:331` delegates `/auth/*` to Better Auth; `apps/api/src/auth/create-auth.ts:182` configures `oauthProvider`. |
-| Trusted clients | `packages/constants/src/oauth.ts:23` lists dashboard, Fuji, Honeycrisp, Opensidian, Tab Manager, Zhongwen, and CLI. |
-
-## Canonical Paths
-
-There are three canonical paths, not one per app and not one per storage backend.
-
-```txt
-Browser apps
-  createBrowserOAuthLauncher
-    -> full-page redirect
-    -> app /auth/callback route
-    -> /auth/oauth2/token
-    -> createOAuthAppAuth.applySignIn
-    -> /api/me
-    -> localStorage PersistedAuth
-
-Extension
-  createExtensionOAuthLauncher
-    -> browser.identity.launchWebAuthFlow
-    -> chromium extension redirect URL
-    -> /auth/oauth2/token
-    -> createOAuthAppAuth.applySignIn
-    -> /api/me
-    -> chrome.storage.local PersistedAuth
-
-Machine
-  createOobOAuthLauncher
-    -> printed authorize URL
-    -> hosted /auth/cli-callback page
-    -> pasted code
-    -> /auth/oauth2/token
-    -> loginWithOob fetches /api/me
-    -> ~/.epicenter/auth.json PersistedAuth
+```ts
+type AuthState =
+  | { status: 'signed-out' }
+  | { status: 'signed-in'; unlock: LocalUnlockBundle }
+  | { status: 'reauth-required'; unlock: LocalUnlockBundle };
 ```
 
-The runtime-specific parts are launcher and storage only.
+Profile fields are application data. Email, display name, avatar, billing plan, and org membership are fetched by the surfaces that display them. Auth state does not carry them.
 
-| Runtime | Launcher necessity | Storage necessity | Canonical shared core |
-| --- | --- | --- | --- |
-| Browser | Full-page redirect is the normal SPA mechanism. | `localStorage` is synchronous and app-origin scoped. | `createOAuthAppAuth`, `PersistedAuth`, `/api/me`, refresh, revoke, bearer gate. |
-| Extension | Chrome requires `browser.identity.launchWebAuthFlow`. | `chrome.storage.local` survives extension lifecycles. | Same. |
-| Machine | OOB paste is the only one that works consistently across macOS, Linux, Windows, Docker, SSH, CI, and headless sessions. | `~/.epicenter/auth.json` avoids keychain, D-Bus, and desktop-session coupling. | Same after login; daemon uses `createOAuthAppAuth`. |
+## Checkpoint Evidence
 
-Rejected as canonical paths:
+### Checkpoint 1: Current Architecture And Invariants
 
-| Path | Rejection |
-| --- | --- |
-| Device authorization grant | Removed from current server config; it would add a second token endpoint family for the same machine login purpose. |
-| Loopback PKCE for CLI | Better local UX, worse deployment envelope. Docker, SSH, CI, headless Linux, port binding, and callback firewall problems turn it into a platform matrix. |
-| OS keychain storage | It adds platform branches without a reliable security win for unsigned CLI binaries and server-class Linux. |
-| `/workspace-identity` | Superseded by `/api/me`; no current canonical role. |
-| id_token-borne encryption keys | Rejected because encryption keys are capability material, not identity claims. |
+Current code already implements the core split:
 
-## Subagent Findings
+| Concern | Current owner | Evidence |
+| --- | --- | --- |
+| Durable auth shape | `@epicenter/auth` | `packages/auth/src/auth-types.ts` defines `OAuthTokenGrant`, `LocalUnlockBundle`, and `PersistedAuth`. |
+| Auth state | `@epicenter/auth` | `packages/auth/src/auth-contract.ts` defines three states; both identity-bearing states carry `unlock`. |
+| Network gate | `@epicenter/auth` | `packages/auth/src/create-oauth-app-auth.ts` refreshes, calls `/api/me`, and only then attaches bearer credentials. |
+| Svelte reactivity | `@epicenter/auth-svelte` | `packages/auth-svelte/src/create-auth.svelte.ts` wraps core state with `createSubscriber`. |
+| Workspace lifetime | `@epicenter/svelte` | `packages/svelte-utils/src/session.svelte.ts` keeps payload mounted for `signed-in` and `reauth-required`, and disposes only on `signed-out`. |
+| Local owner | `@epicenter/workspace` | `packages/workspace/src/document/local-owner.ts` scopes IDB, BroadcastChannel, encryption, and wipe by `userId`. |
+| API identity | `apps/api` | `apps/api/src/app.ts` mounts `/api/me`; `apps/api/src/auth/resource-boundary.ts` verifies bearer token, issuer, audience, scope, and user existence. |
+| Credential normalization | `apps/api` | `apps/api/src/auth/single-credential.ts` rejects cookie plus bearer ambiguity and lifts WebSocket bearer subprotocol into `Authorization`. |
 
-### Browser And Extension OAuth
+Durable rules:
 
-Browser app auth files are structurally identical: `apps/dashboard/src/lib/platform/auth/auth.ts:13`, `apps/opensidian/src/lib/platform/auth/auth.ts:12`, `apps/fuji/src/lib/platform/auth/auth.ts:11`, `apps/honeycrisp/src/lib/platform/auth/auth.ts:11`, and `apps/zhongwen/src/lib/platform/auth/auth.ts:11` all create `createOAuthAppAuth` with app-specific client id, storage key, and redirect URI.
+1. Raw OAuth tokens stay inside auth storage and auth transport.
+2. `auth.fetch` and `auth.openWebSocket` are the app transport capabilities.
+3. `/api/me` is the only client identity projection: verified bearer token plus Better Auth user plus derived encryption keys.
+4. Local decrypt can continue when network auth is paused.
+5. Browser-local Yjs data is scoped by `(userId, ydoc.guid)`.
+6. `reauth-required` is identity-bearing, not signed out.
+7. Sign-out clears the auth cell but does not wipe Yjs data unless the user takes a separate destructive action.
 
-`packages/auth/src/oauth-launchers/index.ts:85` uses a single method for launch and callback: it first handles a callback URL, then redirects on missing callback state. Browser OAuth state and verifier are written at `packages/auth/src/oauth-launchers/index.ts:178`; callback state is checked at `packages/auth/src/oauth-launchers/index.ts:223`.
+### Checkpoint 2: Candidate Boundaries
 
-The extension has a necessary launcher difference. `apps/tab-manager/src/lib/platform/auth/auth.ts:30` creates `createExtensionOAuthLauncher`; `apps/tab-manager/src/lib/platform/auth/auth.ts:48` calls `browser.identity.launchWebAuthFlow`; temporary OAuth transaction state lives in `browser.storage.session` at `apps/tab-manager/src/lib/platform/auth/auth.ts:35`.
+Four boundaries were compared.
 
-Inconsistencies:
+| Candidate | Shape | Result |
+| --- | --- | --- |
+| A. Bundled session | `OAuthSession = tokens + user + encryptionKeys` | Reject. It couples token rotation to local identity and profile data. It already lost to `PersistedAuth`. |
+| B. Separate workspace identity store | Auth stores tokens; workspace stores identity and keys | Reject. It adds a second lifecycle and same-user guard with no live consumer that needs independent storage. |
+| C. id_token carries encryption keys | OAuth token response becomes identity source | Reject. Encryption keys are capability material, not profile claims. Loggers and libraries treat id tokens as identity objects. |
+| D. One persisted cell with grant and unlock | Auth stores `{ grant, unlock }`; `/api/me` verifies and refreshes unlock | Choose. It matches the current implementation, keeps offline unlock available, and keeps network credentials behind auth transport. |
 
-- Browser callback pages are thin duplicates and redirect after `auth.startSignIn()` succeeds without checking `auth.state.status`; examples: `apps/dashboard/src/routes/auth/callback/+page.svelte:11`, `apps/fuji/src/routes/auth/callback/+page.svelte:10`.
-- Browser apps import `PersistedAuth` from `@epicenter/auth`; Tab Manager imports it from `@epicenter/auth-svelte` at `apps/tab-manager/src/lib/platform/auth/auth.ts:12`.
-- Auth-code token parsing does not validate `token_type` in `packages/auth/src/oauth-launchers/index.ts:296`; refresh parsing does validate bearer token type in `packages/auth/src/create-oauth-app-auth.ts:403`.
-- `bearer.` WebSocket subprotocol prefix is duplicated in `packages/auth/src/create-oauth-app-auth.ts:70` and `packages/sync/src/auth-subprotocol.ts:25`.
+Candidate D is the smallest shape that explains every runtime:
 
-### CLI And Daemon OOB
+```txt
+Browser redirect OAuth
+Extension WebAuthFlow OAuth
+Machine OOB OAuth
+  -> OAuthTokenGrant
+  -> /api/me
+  -> PersistedAuth
+  -> AuthState
+  -> createSession
+  -> LocalOwner
+  -> auth.fetch and auth.openWebSocket
+```
 
-`packages/cli/src/commands/auth.ts:36` calls `loginWithOob()`. The OOB launcher builds the authorize URL at `packages/auth/src/node/oob-launcher.ts:105` and exchanges the pasted code at `packages/auth/src/node/oob-launcher.ts:135`. `packages/auth/src/node/machine-auth.ts:139` calls `/api/me`; `packages/auth/src/node/machine-auth.ts:147` writes `{ grant, unlock }`.
+### Checkpoint 3: Final Boundary
 
-Machine storage is one file. `packages/auth/src/node/machine-tokens-store.ts:38` fixes the default path at `~/.epicenter/auth.json`; writes use a temp file and `0600` mode at `packages/auth/src/node/machine-tokens-store.ts:121`; POSIX reads reject too-open permissions at `packages/auth/src/node/machine-tokens-store.ts:68`.
+The final boundary is not "auth owns identity." That sentence is too broad.
 
-Daemon consumers do not start interactive auth. `packages/cli/src/load-config.ts:257` creates one `AuthClient`, then passes it into daemon route startup at `packages/cli/src/load-config.ts:263`. App daemon routes consume that injected auth: Fuji at `apps/fuji/blocks/daemon-route.ts:32`, Honeycrisp at `apps/honeycrisp/blocks/daemon-route.ts:25`, Opensidian at `apps/opensidian/blocks/daemon-route.ts:21`, Zhongwen at `apps/zhongwen/blocks/daemon-route.ts:25`.
+The final boundary is:
 
-Inconsistencies:
+```txt
+auth owns capabilities:
+  online grant
+  local unlock
+  transport
 
-- Logout deletes local storage before revoke and does not await revoke. `packages/auth/src/create-oauth-app-auth.ts:313` clears storage; `packages/auth/src/create-oauth-app-auth.ts:311` starts revoke as a detached promise. A short-lived CLI can exit before `/auth/oauth2/revoke` completes.
-- OOB `state` is generated at `packages/auth/src/node/oob-launcher.ts:103`, but the CLI reads only code at `packages/auth/src/node/oob-launcher.ts:128` and does not verify state in the token request at `packages/auth/src/node/oob-launcher.ts:139`.
-- The CLI callback page comment says the CLI checks state locally at `apps/api/src/auth-pages/cli-callback-page.tsx:31`; current code does not.
-- Self-hosted or local `baseURL` can default to a redirect URI that is not registered. `packages/auth/src/node/oob-launcher.ts:82` defaults to `${baseURL}/auth/cli-callback`; `packages/constants/src/oauth.ts:77` registers only `https://api.epicenter.so/auth/cli-callback`.
-- Concurrent writes use the fixed temp path `${filePath}.tmp` at `packages/auth/src/node/machine-tokens-store.ts:122`, so concurrent login or refresh is not as robust as the old spec claims.
-- Machine status has its own vocabulary (`signedOut`, `valid`, `unverified`) at `packages/auth/src/node/machine-auth.ts:87`; browser core uses `signed-out`, `signed-in`, `reauth-required`.
+workspace owns local data:
+  Y.Doc
+  local persistence
+  encryption attachment
+  sync attachment
 
-### Server OAuth
+application owns profile:
+  email
+  avatar
+  billing display
+  account labels
+```
 
-`apps/api/src/auth/create-auth.ts:182` configures Better Auth OAuth provider with PKCE, trusted client ids, valid audiences, disabled dynamic registration, and the shared scopes. `apps/api/src/app.ts:173` seeds trusted OAuth clients before creating auth.
+This keeps the product sentence compact:
 
-Trusted projection creates public PKCE authorization-code clients at `apps/api/src/auth/trusted-oauth-clients.ts:21`. Runtime maps browser and extension to `user-agent-based`, native to `native` at `apps/api/src/auth/trusted-oauth-clients.ts:86`.
+```txt
+Sign in once, unlock local encrypted workspaces offline, and use the server only through auth-owned transports when online.
+```
 
-`/api/me` is the single identity endpoint. `apps/api/src/app.ts:275` returns `{ user, encryptionKeys }`. `apps/api/src/auth/resource-boundary.ts:64` verifies the bearer token and `apps/api/src/auth/resource-boundary.ts:79` enforces `workspaces:open`.
+### Checkpoint 4: Spec Output
 
-Inconsistencies:
+This file is the canonical architecture spec. Implementation agents should read it before changing auth, workspace session, local unlock, or network transport code.
 
-- Scope strings are duplicated in provider config, trusted projection, and tests: `apps/api/src/auth/create-auth.ts:189`, `apps/api/src/auth/trusted-oauth-clients.ts:5`, `apps/api/src/test-helpers/oauth.ts:7`.
-- Trusted-client semantics are split between DB row `skipConsent: true` at `apps/api/src/auth/trusted-oauth-clients.ts:33` and provider `cachedTrustedClients` at `apps/api/src/auth/create-auth.ts:186`.
-- PKCE/public-client semantics are repeated in trusted projection, provider config, and test helper setup.
-- The resource-boundary comment says `/api/assets/*` requires `workspaces:open`, but public asset reads intentionally bypass auth through the public route mounted before the guard.
-- Trusted client upsert does not overwrite every nullable client metadata field, so stale fields can survive from earlier DB rows.
+## Runtime Paths
 
-### Consumers And Session Behavior
+There are three launch paths and one shared runtime.
 
-Core semantics are coherent:
+```txt
+Browser app
+  launcher: browser redirect
+  storage: app localStorage
+  callback: app /auth/callback
+
+Extension
+  launcher: browser.identity.launchWebAuthFlow
+  storage: chrome.storage.local
+  callback: browser extension redirect URL
+
+Machine
+  launcher: OOB code paste
+  storage: ~/.epicenter/auth.json with 0600 mode
+  callback: hosted /auth/cli-callback page
+```
+
+After launch, all three converge:
+
+```txt
+grant from /auth/oauth2/token
+  -> GET /api/me with Authorization: Bearer
+  -> write PersistedAuth
+  -> expose AuthState
+  -> build workspace session from unlock
+  -> call protected resources through auth.fetch or auth.openWebSocket
+```
+
+Daemon is not a fourth auth path. Daemons load the machine cell and construct `createOAuthAppAuth` with a noninteractive launcher.
+
+## Ownership
+
+| Surface | Owner | Must not know |
+| --- | --- | --- |
+| OAuth provider routes | Better Auth inside `apps/api` | Workspace storage names, Yjs, local unlock UI. |
+| `/api/me` | Epicenter API | Browser storage adapters, Svelte session lifecycle. |
+| `PersistedAuth` | `@epicenter/auth` | App profile display, workspace tables. |
+| `auth.fetch` | `@epicenter/auth` | Resource-specific retry policy beyond one auth retry. |
+| `auth.openWebSocket` | `@epicenter/auth` | Sync protocol details beyond subprotocol insertion. |
+| `createSession` | `@epicenter/svelte` | Raw OAuth tokens, profile fields. |
+| `LocalOwner` | `@epicenter/workspace` | Refresh tokens, account profile, hosted sign-in. |
+| `openCollaboration` and sync | `@epicenter/workspace` | Token storage, `/api/me`, Better Auth cookies. |
+| Account popover and billing UI | Application or shared UI | Refresh tokens, local encryption key derivation. |
+
+## Storage Shape
+
+Browser and extension storage should validate exactly `PersistedAuth | null`.
+
+Machine storage should validate exactly the same shape, with file permissions enforced before parsing. Keep the filename `~/.epicenter/auth.json` unless a product decision introduces multiple accounts or multiple server profiles.
+
+Do not add:
+
+```txt
+OAuthSession
+AuthIdentity
+WorkspaceIdentityStore
+profile bucket
+token getter cache
+idToken identity cache
+```
+
+Old storage keys are intentionally ignored. Compatibility would create a second session model and make local unlock semantics harder to prove.
+
+## State Machines
+
+### Auth Client
 
 ```txt
 signed-out
-  no persisted cell
-  dispose local workspace
+  persisted = null
+  workspace session = null
+  auth.fetch sends no bearer
+  auth.openWebSocket sends no bearer
 
 signed-in
-  persisted cell exists
-  unlock available immediately
-  network bearer only after /api/me verifies this runtime
+  persisted exists
+  unlock is readable
+  bearer may be attached only after /api/me verifies current cell
 
 reauth-required
-  persisted cell exists
-  unlock remains available
-  network bearer is paused
+  persisted exists
+  unlock is readable
+  network auth is paused
+  workspace session stays mounted
 ```
 
-`packages/svelte-utils/src/session.svelte.ts:27` treats `signed-in` and `reauth-required` as the same local workspace lifetime and disposes only on `signed-out`. The local owner reads encryption keys lazily from current auth state at `packages/svelte-utils/src/session.svelte.ts:37`.
-
-Inconsistencies:
-
-- Dashboard gates its signed-in layout on exact `signed-in` at `apps/dashboard/src/routes/(signed-in)/+layout.svelte:25`, so `reauth-required` is visually treated like signed-out even though local workspace semantics say it is still identity-bearing.
-- Tab Manager handles the distinction more honestly by keeping the app open and showing reauth copy in `apps/tab-manager/src/entrypoints/sidepanel/SignedInApp.svelte:84`.
-- `/api/me` has two jobs: auth-internal verification and account/profile fetch. A cold `auth.fetch('/api/me')` can make two `/api/me` requests, covered by `packages/auth/src/contract.test.ts:270`.
-- Svelte lifecycle behavior has no direct test file under `packages/auth-svelte` or `packages/svelte-utils`; current confidence comes from implementation plus `packages/auth/src/contract.test.ts`.
-
-## Canonical-Path Proposal
-
-Keep exactly three launcher paths:
-
-1. Browser redirect OAuth.
-2. Extension WebAuthFlow OAuth.
-3. Machine OOB OAuth.
-
-Keep exactly one shared auth runtime after launch:
+Transitions:
 
 ```txt
-OAuthTokenGrant
-  -> /api/me
-  -> PersistedAuth
-  -> createOAuthAppAuth
-  -> auth.fetch / auth.openWebSocket
-  -> resource-boundary verification
+startSignIn succeeds
+  grant -> /api/me -> write PersistedAuth -> signed-in
+
+cold boot with cell
+  signed-in immediately for local unlock
+  first network call refreshes if stale, then verifies /api/me
+
+refresh succeeds
+  write grant only
+  clear network verification
+  verify /api/me before next bearer-bearing call
+
+refresh fails
+  keep unlock
+  state = reauth-required
+
+/api/me same-user guard fails
+  clear cell
+  state = signed-out
+
+signOut
+  clear cell
+  state = signed-out
+  revoke refresh token best effort unless a later migration strengthens it
 ```
 
-Do not add a fourth path for daemon, Docker, SSH, CI, local development, or self-hosting. Those are configuration and callback-registration concerns inside the machine OOB path, not separate auth models.
+### Workspace Session
 
-## Collapse Plan
+```txt
+auth signed-out
+  dispose payload
+  current = null
 
-Pause before changing production code. The next implementation spec should decide and then execute these collapses:
+auth signed-in or reauth-required
+  if no payload:
+    build LocalOwner from unlock.userId and lazy encryptionKeys()
+  if payload exists:
+    keep it mounted
+```
 
-- [ ] Make revoke semantics explicit. Either await revoke before reporting logout success for machine auth, or name it best-effort everywhere and test that exact behavior.
-- [ ] Fix OOB state semantics. Either paste and verify `{ code, state }`, render state as part of the copyable callback payload, or remove `state` and comments that claim it is checked. Do not leave security theater.
-- [ ] Decide self-hosted CLI redirect registration. Either register localhost and self-host callback URIs intentionally, or require explicit `redirectUri` for non-production `baseURL`.
-- [ ] Replace fixed `.tmp` auth-file writes with per-process or random temp paths before claiming concurrent login is safe.
-- [ ] Extract the shared OAuth token-response parser used by browser, extension, refresh, and OOB paths, including token type validation.
-- [ ] Extract or import the shared bearer subprotocol prefix instead of defining it in two packages.
-- [ ] Collapse browser callback routes to one shared callback component or helper that redirects only after `auth.state.status === 'signed-in'`.
-- [ ] Normalize `reauth-required` UI handling: identity-bearing layouts stay mounted, network-only controls show reconnect.
-- [ ] Move shared scope strings into one exported server-auth constant and reuse it in provider config, trusted projection, and tests.
-- [ ] Update CLI README examples so daemon routes consume injected `auth`, not route-local `createMachineAuthClient()`.
+The migration must harden the same-user assumption. Today, `createSession` keeps payload when any identity-bearing state follows another. That is coherent only if auth guarantees no same-runtime different-user transition without `signed-out` in between. Make that invariant explicit in tests.
+
+### Local Owner
+
+```txt
+owner.userId
+  -> createOwnedYjsKey(userId, ydoc.guid)
+  -> encrypted IndexedDB database name
+  -> BroadcastChannel key
+  -> wipe prefix
+
+owner.encryptionKeys()
+  -> lazy read from current auth.state.unlock
+  -> lets /api/me key rotation take effect without rebuilding workspace
+```
+
+Local owner is a browser concept. Daemons attach encryption directly and persist by filesystem.
+
+### Network Transport
+
+```txt
+auth.fetch(request)
+  -> refresh grant if near expiry
+  -> verify current cell with /api/me if needed
+  -> attach Authorization: Bearer
+  -> credentials: omit
+  -> one forced refresh and retry on 401
+
+auth.openWebSocket(url, protocols)
+  -> refresh grant if near expiry
+  -> verify current cell with /api/me if needed
+  -> append bearer.<accessToken> subprotocol
+```
+
+Server middleware converts a WebSocket bearer subprotocol into `Authorization` before protected resource middleware runs. Resource routes then verify the token with Better Auth's OAuth resource client.
+
+## Race Handling
+
+These are first-wave hardening items before new architecture work.
+
+| Risk | Current evidence | Required checkpoint |
+| --- | --- | --- |
+| Refresh writes stale grant after sign-out | `refreshGrant` writes storage before the stale check after `set` returns. | Re-check `persisted === startedFrom` before and after storage writes, or make storage writes compare-and-swap. Add a regression test. |
+| `/api/me` key update writes stale unlock after sign-out | `verifyIdentity` writes updated keys before the stale check after `set` returns. | Same stale-write test pattern for key update. |
+| Identity-bearing user changes without signed-out gap | `createSession` keeps existing payload whenever payload exists. | Either enforce signed-out gap in auth or compare `unlock.userId` in `createSession` and rebuild on change. |
+| WebSocket without bearer after verification failure | `openWebSocket` can construct without bearer when `bearerForNetwork` returns null. | For protected sync URLs, return a failed promise or close early instead of opening anonymous. Decide in the sync transport migration. |
+| Fetch retry with non-replayable body | `auth.fetch` retries once after 401. | Document caller constraint and add a test for `Request` clone behavior. Do not hide arbitrary stream replay. |
+| Machine OOB state verification | OOB launcher generates state; current paste flow does not verify it from user input. | Render a copyable `{ code, state }` payload or remove state and comments claiming local verification. |
+| Machine temp-file collision | Machine store uses a fixed temp path. | Use a random or process-specific temp path before claiming concurrent login or refresh safety. |
+
+## External Precedents
+
+| Precedent | What it shows | Consequence for Epicenter |
+| --- | --- | --- |
+| [Better Auth OAuth Provider](https://better-auth.com/docs/plugins/oauth-provider) | OAuth provider owns authorization code, refresh token, revocation, trusted clients, public clients, JWT and JWKS behavior, and resource verification helpers. | Keep Better Auth as the auth server. Do not build OAuth by hand. |
+| [Better Auth resource client](https://better-auth.com/docs/plugins/oauth-provider) | API servers verify `Authorization: Bearer` tokens with issuer, audience, expiration, signature or introspection, and scope checks. | Keep `/api/me` and protected resources behind server-side token verification. |
+| [Cloudflare Durable Object WebSockets](https://developers.cloudflare.com/durable-objects/best-practices/websockets/) | Durable Objects are the right coordination point for long-lived WebSocket sessions. Hibernation resets memory and requires durable or attached state. | Keep Room DOs as room coordinators; do not put auth session truth in DO memory. |
+| [Hono middleware](https://hono.dev/docs/guides/middleware) | Middleware runs in registration order. | Keep `singleCredential` before protected resources and OAuth discovery before `/auth/*` catch-all routes. |
+| [Yjs document updates](https://docs.yjs.dev/api/document-updates) | Updates are commutative, associative, idempotent binary deltas. | Sync should move bytes and presence, not profile or auth state. |
+| [y-protocols awareness](https://docs.yjs.dev/api/about-awareness) | Awareness is network-agnostic presence and schemaless local state, usually implemented by providers. | Treat awareness `replica` as client-claimed presence, not verified account identity. Server-stamped `subject` belongs outside awareness. |
+| [y-indexeddb](https://docs.yjs.dev/ecosystem/database-provider/y-indexeddb) | `docName` is the durable browser database identity and enables offline editing. | Use owner-scoped database names for authenticated browser workspaces. |
+| [Svelte createSubscriber](https://svelte.dev/docs/svelte/svelte-reactivity) | External event sources can be reflected into reactive reads. | Keep `auth-svelte` as a thin reactive wrapper over framework-agnostic auth. |
+| [SvelteKit load](https://svelte.dev/docs/kit/load) | Universal load runs in both server and browser; server load has request-only data. | Keep raw OAuth tokens out of universal app code. Use client auth transport for browser-only resource calls. |
+| [Tauri opener](https://tauri.app/reference/javascript/opener/) | Opening URLs is an explicit platform capability with URL scope configuration. | Browser-launch auth belongs in launchers, not in core auth state. |
+| [WXT storage](https://wxt.dev/storage) | Extension storage is key-based and async, with `local`, `session`, and metadata APIs. | Extension storage is a runtime adapter for the same `PersistedAuth` shape, not a different auth model. |
+| [Drizzle Turso docs](https://orm.drizzle.team/docs/connect-turso) | Drizzle supports runtime-specific database drivers and serverless databases. | Keep database concerns in API composition. Auth clients should not learn DB adapter shapes. |
+| [Cloudflare Workers Turso tutorial](https://developers.cloudflare.com/workers/tutorials/connect-to-turso-using-workers/) | Worker database connections are runtime concerns. | Per-request DB setup stays server-side. |
+| [TanStack AI provider tools](https://tanstack.com/ai/latest/docs/tools/provider-tools) | Provider-specific capabilities are branded and gated at the adapter boundary. | Mirror this: expose `auth.fetch` and `auth.openWebSocket` capabilities, not raw token data. |
+| `~/Code/ai` provider source | `/Users/braden/Code/ai/packages/openai/src/openai-provider.ts` hides API-key header construction inside provider instances. | Capability-owned transport is a local precedent, not just an auth preference. |
+| `~/Code/ai` UI source | `/Users/braden/Code/ai/packages/react/src/use-chat.ts` exposes state and actions, not the provider key. | UI surfaces should consume actions and state, not secrets. |
+| [jsrepo registry](https://jsrepo.dev/docs/registry) | Registry blocks are installed as local source with explicit manifests. | Installed app or component templates should depend on public capabilities, not hidden host auth internals. |
+| [libsignal Sesame](https://signal.org/docs/specifications/sesame/) | Devices store identity and session state locally; servers are not the source of encrypted-session secrets. | Local unlock belongs to the client capability layer, while server auth verifies account access. |
+| [Bitwarden log in vs unlock](https://bitwarden.com/help/understand-log-in-vs-unlock/) | Login requires server access; unlock works against already stored encrypted local data. | `reauth-required` must not unmount local encrypted workspaces. |
+| [shadcn-svelte installation](https://www.shadcn-svelte.com/docs/installation) | Components are copied into local projects and imported through local files. | UI components should receive auth/profile data as props or queries, not import auth internals. |
+| [shadcn-svelte-extras](https://www.shadcn-svelte-extras.com/docs/introduction) | Extras emphasize composability and do not force defaults that belong to the host app. | Shared UI should stay composable around auth state and profile queries. |
+| [TanStack Table Svelte state](https://tanstack.com/table/latest/docs/framework/svelte/guide/table-state) | Control only the state you need; leave the rest internal. | Auth state should expose only capability state. Profile freshness and UI labels should stay outside. |
+| [Autumn usage tracking](https://docs.useautumn.com/documentation/customers/tracking-usage) | Billing tracks usage against a customer id after the customer exists. | Billing depends on verified user id at protected API routes, not profile data in auth state. |
+
+## Call Sites To Preserve
+
+Browser auth clients:
+
+```txt
+apps/dashboard/src/lib/platform/auth/auth.ts
+apps/opensidian/src/lib/platform/auth/auth.ts
+apps/fuji/src/lib/platform/auth/auth.ts
+apps/honeycrisp/src/lib/platform/auth/auth.ts
+apps/zhongwen/src/lib/platform/auth/auth.ts
+apps/tab-manager/src/lib/platform/auth/auth.ts
+```
+
+Workspace session builders:
+
+```txt
+apps/opensidian/src/lib/session.ts
+apps/fuji/src/lib/session.ts
+apps/honeycrisp/src/lib/session.ts
+apps/zhongwen/src/lib/session.ts
+apps/tab-manager/src/lib/session.svelte.ts
+```
+
+Transport consumers:
+
+```txt
+apps/opensidian/src/lib/opensidian/browser.ts
+apps/fuji/src/routes/(signed-in)/fuji/browser.ts
+apps/honeycrisp/src/routes/(signed-in)/honeycrisp/browser.ts
+apps/tab-manager/src/lib/tab-manager/extension.ts
+apps/*/blocks/daemon-route.ts
+packages/workspace/src/document/open-collaboration.ts
+packages/workspace/src/document/internal/sync-supervisor.ts
+```
+
+Server gates:
+
+```txt
+apps/api/src/app.ts
+apps/api/src/auth/create-auth.ts
+apps/api/src/auth/resource-boundary.ts
+apps/api/src/auth/single-credential.ts
+apps/api/src/auth/trusted-oauth-clients.ts
+```
+
+## Migration Checkpoints
+
+### Phase 1: Prove Existing Invariants
+
+- [ ] Add auth tests for stale refresh write after sign-out.
+- [ ] Add auth tests for stale `/api/me` key-update write after sign-out.
+- [ ] Add a session test for same-user identity-bearing transitions.
+- [ ] Add or update a test proving `reauth-required` keeps the workspace mounted.
+- [ ] Add a transport test proving protected sync does not open an anonymous WebSocket when auth verification fails.
+
+### Phase 2: Harden Auth Core
+
+- [ ] Fix stale storage writes in refresh and `/api/me` verification.
+- [ ] Decide whether `AuthClient.signOut()` should await revoke in machine contexts or stay best effort everywhere.
+- [ ] Share the OAuth token response parser across browser, extension, refresh, and OOB launchers.
+- [ ] Import the bearer subprotocol prefix from `@epicenter/sync` or move it to a shared no-cycle package.
+
+### Phase 3: Harden Machine OOB
+
+- [ ] Fix OOB state semantics by copying `{ code, state }`, or remove the local state check language.
+- [ ] Replace the fixed auth temp path with a unique temp path.
+- [ ] Decide self-hosted CLI callback registration. Either require explicit `redirectUri` for non-production `baseURL`, or seed trusted redirect URIs through setup.
+
+### Phase 4: Align App Surfaces
+
+- [ ] Treat `reauth-required` as signed-in for identity-bearing layouts.
+- [ ] Make network-only controls show reconnect while local workspace controls remain usable.
+- [ ] Keep profile queries in account surfaces, not auth state.
+- [ ] Update stale docs that still show `auth.state.identity`, `OAuthSession`, `getToken`, or direct `openWebSocket: auth.openWebSocket` examples that contradict the current transport shape.
+
+### Phase 5: Sync Identity Cleanup
+
+- [ ] Reconcile `20260513T083755-open-workspace-clean-break.md` with `20260513T220000-document-sync-and-identity-collapse.md`.
+- [ ] Use `replica` for client-claimed presence.
+- [ ] Use server-stamped `subject` for verified account identity.
+- [ ] Do not put profile fields in awareness by default.
+
+## Validation Plan
+
+Run these after Phase 1 and again after Phase 2:
+
+```bash
+bun test packages/auth/src/contract.test.ts
+bun test packages/auth/src/node/machine-auth.test.ts
+bun test packages/workspace/src/document/local-owner.test.ts
+bun test packages/workspace/src/document/open-collaboration.test.ts
+```
+
+Run these greps before any implementation PR is marked done:
+
+```bash
+rg -n "OAuthSession|AuthIdentity|WorkspaceIdentityStore|/workspace-identity" packages apps docs specs
+rg -n "getToken\\(|bearerToken|auth\\.state\\.identity|auth\\.state\\.email" packages apps docs specs
+rg -n "deviceAuthorization|deviceAuthorizationClient|device_code|deviceCode" packages apps docs specs
+perl -ne 'print "$ARGV:$.:$_" if /[\x{2013}\x{2014}]/' specs/20260515T010000-auth-canonical-path-audit.md
+```
+
+Expected results:
+
+```txt
+No live package or app references to OAuthSession.
+No live package or app references to AuthIdentity.
+No live package or app raw token getter.
+No live package or app device authorization machine path.
+No profile fields on AuthState.
+No em dash or en dash in changed files.
+```
+
+Historical specs may still contain rejected terms, but new implementation specs must point back here and say they are historical.
 
 ## Rejected Alternatives
 
-| Alternative | Reason |
+| Alternative | Refusal |
 | --- | --- |
-| Add compatibility layers for old `OAuthSession` | `PersistedAuth` is already the landed clean break; compatibility adds another session shape with no current caller. |
-| Restore device authorization | Solves only machine login and reintroduces a second grant family where OOB already works across the deployment matrix. |
-| Make `/api/me` return long-lived profile state for auth | Profile moved to application data; auth should carry unlock and grant, not decorative account labels. |
-| Add per-platform machine auth backends | Creates more storage semantics instead of removing them. File storage is the canonical machine store. |
-| Use browser cookies for first-party SPAs | It is shorter for one browser app, but it breaks the cross-client OAuth resource boundary shared by extension, CLI, daemon, and browser apps. |
+| Raw token getter on `AuthClient` | Refused. It leaks transport details and lets app code race refresh and verification. |
+| Profile data in auth state | Refused. Profile is application data and can be queried where displayed. |
+| `OAuthSession` compatibility shim | Refused. Old storage should fail validation and be ignored. |
+| Better Auth device authorization machine path | Refused. OOB authorization code covers CLI, SSH, Docker, CI, and headless use with one token endpoint family. |
+| Separate workspace identity store | Refused unless a real consumer needs independent identity persistence after auth storage is gone. No such consumer exists. |
+| id-token-carried encryption keys | Refused. Encryption keys are local unlock capability material, not identity claims. |
+| Cookie-first app resource auth | Refused for resource routes. Cookies remain for hosted login pages; app resources use OAuth bearer transport. |
+| Clearing local Yjs data on auth failure | Refused. Local wipe is destructive and user-driven. |
+| Awareness as verified identity | Refused. Awareness is client-claimed presence. Verified identity is server-stamped. |
+| Daemon-specific auth state model | Refused. Daemon uses machine storage plus `createOAuthAppAuth`. |
 
 ## Open Questions
 
-- Should machine logout be stronger than browser logout by awaiting revoke, or should `AuthClient.signOut()` itself expose an awaited revoke mode?
-- Should OOB paste include the state visibly, or should the callback page encode a single copyable payload that the CLI parses?
-- Is self-hosted CLI login a supported product path now, or is it future work behind explicit trusted-client setup?
-- Should `/api/me` split auth verification from account/profile fetching, or is the duplicate cold-call acceptable because it keeps one identity endpoint?
-- Should machine `status` reuse core auth vocabulary, or does CLI output deserve command-specific names?
-- Is `reauth-required` a signed-in route state everywhere, with only network controls paused? If yes, Dashboard currently disagrees.
+These are implementation choices, not architecture blockers:
 
-## Verification Checklist
+1. Should machine logout await revoke, or should all logout remain storage-first and revoke-best-effort?
+2. Should protected sync reject anonymous `openWebSocket` attempts in auth or in workspace sync?
+3. Should `createSession` rebuild on a different `unlock.userId`, or should auth guarantee a signed-out transition first?
+4. Should self-hosted CLI login require explicit trusted-client setup, or should setup seed redirect URIs?
+5. Should `/api/me` remain both network verification and account profile fetch, or should account profile get a separate route later?
 
-Evidence collected:
+## Pause Conditions
 
-- [x] Read `specs/20260514T120000-machine-auth-oob-clean-break.md`.
-- [x] Read `specs/20260514T200000-api-me-three-field-token-bundle.md`.
-- [x] Read `packages/auth/src/create-oauth-app-auth.ts`.
-- [x] Read `packages/auth/src/node/machine-auth.ts`.
-- [x] Read `packages/auth/src/node/oob-launcher.ts`.
-- [x] Read `packages/auth/src/node/machine-tokens-store.ts`.
-- [x] Read `packages/auth/src/auth-types.ts`.
-- [x] Read `packages/constants/src/oauth.ts`.
-- [x] Read `apps/api/src/auth/create-auth.ts`.
-- [x] Read `apps/api/src/app.ts`.
-- [x] Read all `apps/*/src/lib/platform/auth/auth.ts` files.
-- [x] Spawned browser and extension OAuth mapping subagent.
-- [x] Spawned CLI and daemon OOB mapping subagent.
-- [x] Spawned server OAuth mapping subagent.
-- [x] Spawned consumer session behavior mapping subagent.
+Pause implementation if any of these become true:
 
-Validation commands:
+1. Better Auth OAuth provider cannot support the required OOB authorization-code path without unsafe client registration.
+2. `/api/me` cannot derive encryption keys without adding profile data back into auth state.
+3. A real product requirement needs simultaneous multi-account local unlock in one runtime.
+4. A migration would delete encrypted local Yjs data automatically.
+5. A protected sync endpoint must accept anonymous WebSockets for a real shipping use case.
+6. Self-hosted CLI login requires an unresolved product decision about trusted redirect registration.
 
-- [x] `bun test packages/auth`: 47 pass, 0 fail.
-- [x] `bun test apps/api`: 64 pass, 0 fail.
+## Commands Run
 
-No production code has been changed by this audit spec. The collapse plan above includes security and product decisions, so implementation should pause for explicit approval before editing runtime auth behavior, deleting tests, changing OAuth client contracts, or changing persisted auth shape.
+Local commands used while preparing this spec:
+
+```bash
+sed -n '1,240p' AGENTS.md
+sed -n '1,260p' packages/auth/src/auth-contract.ts
+sed -n '1,260p' packages/auth/src/auth-types.ts
+sed -n '1,700p' packages/auth/src/create-oauth-app-auth.ts
+sed -n '1,360p' packages/svelte-utils/src/session.svelte.ts
+sed -n '1,260p' packages/workspace/src/document/local-owner.ts
+sed -n '1,760p' apps/api/src/app.ts
+sed -n '1,260p' apps/api/src/auth/create-auth.ts
+sed -n '1,280p' apps/api/src/auth/resource-boundary.ts
+sed -n '1,260p' apps/api/src/auth/single-credential.ts
+sed -n '1,620p' packages/auth/src/contract.test.ts
+sed -n '1,420p' packages/auth/src/node/machine-auth.ts
+rg -n "(createOAuthAppAuth|createSession|AuthIdentity|OAuthSession|PersistedAuth|LocalUnlockBundle|openWebSocket|requireSignedIn|bearerToken|getToken|accessToken|local owner|localOwner|ownerId|userId)" packages apps specs/202605*.md specs/202604*.md
+rg -n "\"(better-auth|@better-auth/oauth-provider|hono|yjs|y-protocols|y-indexeddb|svelte|@sveltejs/kit|@tauri-apps/plugin-opener|wxt|drizzle-orm|@libsql/client|@tanstack/ai|autumn-js|@tanstack/svelte-table|bits-ui|shadcn-svelte-extras)\"" --glob "package.json"
+rg -n "(createSession\\(|auth\\.state\\.status|reauth-required|auth\\.fetch\\('/api/me'|openWebSocket: auth\\.openWebSocket|createLocalOwner|attachIndexedDb\\(|wipeLocalYjsData)" apps packages --glob "!**/*.test.ts"
+sed -n '1,180p' /Users/braden/Code/ai/packages/react/src/use-chat.ts
+sed -n '1,180p' /Users/braden/Code/ai/packages/openai/src/openai-provider.ts
+sed -n '1,140p' /Users/braden/Code/ai/packages/provider/src/language-model/v1/language-model-v1.ts
+```
+
+External sources consulted:
+
+```txt
+Better Auth OAuth Provider docs
+Cloudflare Durable Objects WebSockets docs
+Hono middleware docs
+Yjs document update docs
+Yjs awareness and y-protocols docs
+y-indexeddb docs
+Svelte createSubscriber docs
+SvelteKit load docs
+Tauri opener docs
+WXT storage docs
+Drizzle Turso docs
+Cloudflare Workers Turso docs
+TanStack AI provider tools docs
+jsrepo registry docs
+Signal Sesame docs
+Bitwarden log in vs unlock docs
+shadcn-svelte installation docs
+shadcn-svelte-extras introduction docs
+TanStack Table Svelte state docs
+Autumn usage tracking docs
+```

--- a/specs/20260515T010000-auth-canonical-path-audit.md
+++ b/specs/20260515T010000-auth-canonical-path-audit.md
@@ -503,8 +503,6 @@ Live contradictions found and handled:
 
 Live non-blocking findings deferred:
 1. `apps/api` still has the historical `device_code` table and migration metadata, but no active device-authorization runtime path was found.
-2. `apps/tab-manager/src/lib/platform/auth/auth.ts` has a legacy-storage comment that mentions `OAuthSession`.
-3. `packages/workspace/src/document/README.md` still has an old `auth.state.identity` example.
 ```
 
 Implemented changes:
@@ -582,8 +580,10 @@ Self-hosted CLI callback registration:
   Deferred pending the trusted-client setup decision.
 
 Broader stale docs:
-  Deferred outside packages/cli/README.md. Historical docs and package READMEs
-  still contain rejected terms and old examples.
+  packages/cli/README.md was fixed in the Phase 1 commit.
+  A follow-up cleanup also removed the live tab-manager OAuthSession comment
+  and the workspace README auth.state.identity example. Historical docs still
+  contain rejected terms and old examples.
 ```
 
 Commands run during Phase 1 execution:
@@ -617,10 +617,8 @@ apps/api tests:
 
 Live grep results:
   device_code remains only in DB schema and migration metadata.
-  OAuthSession remains in a legacy storage comment in tab-manager.
-  auth.state.identity remains in packages/workspace/src/document/README.md.
-  No live runtime raw token getter or device authorization machine path was
-  found in packages or apps.
+  No live package or app OAuthSession, AuthIdentity, auth.state.identity,
+  raw token getter, or device authorization machine path remains.
 
 Dash check:
   Pass after replacing two existing dashes in packages/sync/src/auth-subprotocol.ts.

--- a/specs/20260515T010000-auth-canonical-path-audit.md
+++ b/specs/20260515T010000-auth-canonical-path-audit.md
@@ -624,6 +624,175 @@ Dash check:
   Pass after replacing two existing dashes in packages/sync/src/auth-subprotocol.ts.
 ```
 
+## Device Code Schema Residue Decision
+
+Completed on 2026-05-15.
+
+Falsification gate result:
+
+```txt
+No live route, Better Auth plugin config, client flow, CLI flow, daemon flow,
+or non-historical app/package test uses Better Auth device authorization.
+
+Pre-cleanup live API residue count:
+  1 stale database table export: deviceCode in apps/api/src/db/schema.ts.
+  20 matched strings across 4 files:
+    apps/api/src/db/schema.ts: 5
+    apps/api/drizzle/0000_equal_thor_girl.sql: 3
+    apps/api/drizzle/meta/0000_snapshot.json: 6
+    apps/api/drizzle/meta/0001_snapshot.json: 6
+
+Post-cleanup live API residue count:
+  0 live schema exports.
+  0 live route, plugin, client, CLI, daemon, or test users.
+  16 remaining repo matches across 4 migration-history files:
+    apps/api/drizzle/0000_equal_thor_girl.sql: 3
+    apps/api/drizzle/meta/0000_snapshot.json: 6
+    apps/api/drizzle/meta/0001_snapshot.json: 6
+    apps/api/drizzle/0002_salty_hex.sql: 1
+```
+
+Current evidence:
+
+```txt
+apps/api/src/auth/create-auth.ts
+  Runtime plugins are jwt() and oauthProvider().
+  deviceAuthorization() is not installed.
+
+apps/api/src/app.ts
+  /auth/* is the Better Auth catch-all.
+  There is no /device page and no route that calls deviceCode, deviceToken,
+  deviceApprove, or deviceDeny.
+
+packages/auth/src/node/*
+  Machine login uses OOB OAuth authorization code with PKCE through
+  /auth/oauth2/authorize, /auth/cli-callback, /auth/oauth2/token, and /api/me.
+  Machine logout revokes through /auth/oauth2/revoke.
+
+packages/auth/src/create-oauth-app-auth.ts
+  Shared auth uses authorization_code, refresh_token, /api/me, revoke,
+  auth.fetch, and auth.openWebSocket. It has no device grant path.
+
+packages/cli/README.md
+  Public CLI docs describe the OOB OAuth 2.1 code flow and PersistedAuth.
+```
+
+Upstream ownership check:
+
+```txt
+Better Auth device authorization:
+  deviceAuthorization() owns the deviceCode schema model and /device/*
+  endpoints. The installed source defines the schema at
+  node_modules/better-auth/dist/plugins/device-authorization/schema.mjs and
+  merges it only from the deviceAuthorization plugin entrypoint.
+
+Better Auth OAuth provider:
+  oauthProvider() owns oauthClient, oauthRefreshToken, oauthAccessToken,
+  and oauthConsent. The installed oauth-provider package does not reference
+  deviceCode.
+
+Drizzle migrations:
+  drizzle-kit migrate applies new migration SQL according to the migration
+  log. Editing 0000 or snapshot history would rewrite committed history.
+```
+
+Options:
+
+| Option | Change | Risk | Decision |
+| --- | --- | --- | --- |
+| Keep residue | Leave schema and historical migrations as-is. | Low runtime risk, but the live schema exports a stale table. | Rejected after the local row count was confirmed empty. |
+| Drop with migration | Remove `deviceCode` from `apps/api/src/db/schema.ts` and generate a new `DROP TABLE "device_code"` migration. | Destructive unless the target row count is proven empty and rollback is planned. | Chosen for local cleanup. Remote/prod migration still requires target row-count proof before running. |
+| Ignore historical migration only | Remove the live schema export while keeping 0000 and meta history. | Drizzle will still see drift and likely wants a drop migration. This creates an unclear half-state. | Reject. It hides the table from code while leaving DB drift unresolved. |
+
+Chosen path:
+
+```txt
+Drop with a new forward migration.
+
+Remove the live schema export, keep historical migrations intact, generate
+0002_salty_hex.sql, and apply that migration to the local API database after
+confirming local device_code row count is 0.
+```
+
+Rollback story:
+
+```sql
+-- forward
+DROP TABLE "device_code";
+
+-- rollback
+CREATE TABLE "device_code" (
+  "id" text PRIMARY KEY NOT NULL,
+  "device_code" text NOT NULL,
+  "user_code" text NOT NULL,
+  "user_id" text,
+  "expires_at" timestamp NOT NULL,
+  "status" text NOT NULL,
+  "last_polled_at" timestamp,
+  "polling_interval" integer,
+  "client_id" text,
+  "scope" text
+);
+```
+
+Validation:
+
+```bash
+rg -n --hidden -S "deviceAuthorization|deviceAuthorizationClient|device_code|deviceCode|/auth/device|device\\.code|device\\.token|urn:ietf:params:oauth:grant-type:device_code|user_code" apps packages --glob '!**/node_modules/**'
+rg --count-matches --hidden -S "deviceAuthorization|deviceAuthorizationClient|device_code|deviceCode|/auth/device|device\\.code|device\\.token|urn:ietf:params:oauth:grant-type:device_code|user_code" apps packages --glob '!**/node_modules/**'
+bun x drizzle-kit check
+bun test apps/api
+```
+
+Run the Drizzle command with `apps/api` as the current working directory.
+Drizzle resolves `out: './drizzle'` from the current working directory, so
+running the app config from the repo root can create a root `drizzle/meta`
+artifact.
+
+Results:
+
+```txt
+Live app/package grep:
+  Only apps/api migration artifacts matched.
+
+Residue count:
+  apps/api/drizzle/0000_equal_thor_girl.sql: 3
+  apps/api/drizzle/meta/0001_snapshot.json: 6
+  apps/api/drizzle/meta/0000_snapshot.json: 6
+  apps/api/drizzle/0002_salty_hex.sql: 1
+  Total: 16 matched strings across 4 files.
+
+Local row count:
+  select count(*) from "device_code" returned 0 before the drop.
+
+Generated migration:
+  apps/api/drizzle/0002_salty_hex.sql contains only:
+    DROP TABLE "device_code";
+
+Local migration application:
+  Applied apps/api/drizzle/0002_salty_hex.sql to the local API database.
+  select to_regclass('public.device_code') returned null afterward.
+
+Local database application note:
+  Local dev uses db:push:local, not migrate. The local database already had
+  the 0000 tables but an empty drizzle.__drizzle_migrations log, so a plain
+  drizzle-kit migrate replayed 0000 and exited with code 1. The generated
+  0002 SQL was applied directly after the empty row-count guard. Remote/prod
+  migration was not run.
+
+Drizzle migration check:
+  Pass from the apps/api working directory. drizzle-kit check reported:
+  Everything's fine.
+
+Root Drizzle artifact:
+  A first root-level check created drizzle/meta/_journal.json because the app
+  config has out: './drizzle'. The artifact was removed. A follow-up check
+  confirmed the root drizzle directory is absent.
+
+apps/api tests:
+  Pass. bun test apps/api ran 64 tests across 10 files.
+```
+
 ## Rejected Alternatives
 
 | Alternative | Refusal |

--- a/specs/20260515T010000-auth-canonical-path-audit.md
+++ b/specs/20260515T010000-auth-canonical-path-audit.md
@@ -1,0 +1,276 @@
+# Auth Canonical Path Audit
+
+**Date**: 2026-05-15
+**Status**: In Progress
+**Author**: AI-assisted
+
+## One Sentence
+
+Epicenter has three defensible auth paths: browser redirect OAuth, extension WebAuthFlow OAuth, and machine OOB OAuth; all three converge on one persisted auth cell, one `/api/me` identity gate, one refresh and revoke surface, and one local-unlock state model.
+
+## Current State
+
+The center is already smaller than the old specs imply.
+
+```txt
+Better Auth
+  owns:
+    /auth/oauth2/authorize
+    /auth/oauth2/token
+    /auth/oauth2/revoke
+    /auth/oauth2/consent
+    /auth/* account/session machinery
+
+Epicenter API
+  owns:
+    /api/me
+    OAuth resource checks
+    trusted first-party client projection
+    CLI callback page
+
+Epicenter clients
+  own:
+    launcher per runtime
+    PersistedAuth storage per runtime
+    AuthClient network gate
+    local unlock lifecycle
+```
+
+The durable client shape is one cell:
+
+```ts
+PersistedAuth = {
+  grant: {
+    accessToken: string;
+    refreshToken: string;
+    accessTokenExpiresAt: number;
+  };
+  unlock: {
+    userId: string;
+    encryptionKeys: EncryptionKeys;
+  };
+};
+```
+
+Evidence:
+
+| Surface | Evidence |
+| --- | --- |
+| Persisted shape | `packages/auth/src/auth-types.ts:48` defines `PersistedAuth = { grant, unlock }`. |
+| Auth state | `packages/auth/src/auth-contract.ts:11` defines `signed-out`, `signed-in`, and `reauth-required`; both identity-bearing states carry `unlock`. |
+| Client gate | `packages/auth/src/create-oauth-app-auth.ts:234` refreshes, calls `/api/me`, and refuses to attach bearer credentials until the current cell is verified. |
+| Server identity | `apps/api/src/app.ts:275` mounts `/api/me`; `apps/api/src/auth/resource-boundary.ts:64` verifies token, audience, issuer, subject, scope, and user existence. |
+| Server OAuth | `apps/api/src/app.ts:331` delegates `/auth/*` to Better Auth; `apps/api/src/auth/create-auth.ts:182` configures `oauthProvider`. |
+| Trusted clients | `packages/constants/src/oauth.ts:23` lists dashboard, Fuji, Honeycrisp, Opensidian, Tab Manager, Zhongwen, and CLI. |
+
+## Canonical Paths
+
+There are three canonical paths, not one per app and not one per storage backend.
+
+```txt
+Browser apps
+  createBrowserOAuthLauncher
+    -> full-page redirect
+    -> app /auth/callback route
+    -> /auth/oauth2/token
+    -> createOAuthAppAuth.applySignIn
+    -> /api/me
+    -> localStorage PersistedAuth
+
+Extension
+  createExtensionOAuthLauncher
+    -> browser.identity.launchWebAuthFlow
+    -> chromium extension redirect URL
+    -> /auth/oauth2/token
+    -> createOAuthAppAuth.applySignIn
+    -> /api/me
+    -> chrome.storage.local PersistedAuth
+
+Machine
+  createOobOAuthLauncher
+    -> printed authorize URL
+    -> hosted /auth/cli-callback page
+    -> pasted code
+    -> /auth/oauth2/token
+    -> loginWithOob fetches /api/me
+    -> ~/.epicenter/auth.json PersistedAuth
+```
+
+The runtime-specific parts are launcher and storage only.
+
+| Runtime | Launcher necessity | Storage necessity | Canonical shared core |
+| --- | --- | --- | --- |
+| Browser | Full-page redirect is the normal SPA mechanism. | `localStorage` is synchronous and app-origin scoped. | `createOAuthAppAuth`, `PersistedAuth`, `/api/me`, refresh, revoke, bearer gate. |
+| Extension | Chrome requires `browser.identity.launchWebAuthFlow`. | `chrome.storage.local` survives extension lifecycles. | Same. |
+| Machine | OOB paste is the only one that works consistently across macOS, Linux, Windows, Docker, SSH, CI, and headless sessions. | `~/.epicenter/auth.json` avoids keychain, D-Bus, and desktop-session coupling. | Same after login; daemon uses `createOAuthAppAuth`. |
+
+Rejected as canonical paths:
+
+| Path | Rejection |
+| --- | --- |
+| Device authorization grant | Removed from current server config; it would add a second token endpoint family for the same machine login purpose. |
+| Loopback PKCE for CLI | Better local UX, worse deployment envelope. Docker, SSH, CI, headless Linux, port binding, and callback firewall problems turn it into a platform matrix. |
+| OS keychain storage | It adds platform branches without a reliable security win for unsigned CLI binaries and server-class Linux. |
+| `/workspace-identity` | Superseded by `/api/me`; no current canonical role. |
+| id_token-borne encryption keys | Rejected because encryption keys are capability material, not identity claims. |
+
+## Subagent Findings
+
+### Browser And Extension OAuth
+
+Browser app auth files are structurally identical: `apps/dashboard/src/lib/platform/auth/auth.ts:13`, `apps/opensidian/src/lib/platform/auth/auth.ts:12`, `apps/fuji/src/lib/platform/auth/auth.ts:11`, `apps/honeycrisp/src/lib/platform/auth/auth.ts:11`, and `apps/zhongwen/src/lib/platform/auth/auth.ts:11` all create `createOAuthAppAuth` with app-specific client id, storage key, and redirect URI.
+
+`packages/auth/src/oauth-launchers/index.ts:85` uses a single method for launch and callback: it first handles a callback URL, then redirects on missing callback state. Browser OAuth state and verifier are written at `packages/auth/src/oauth-launchers/index.ts:178`; callback state is checked at `packages/auth/src/oauth-launchers/index.ts:223`.
+
+The extension has a necessary launcher difference. `apps/tab-manager/src/lib/platform/auth/auth.ts:30` creates `createExtensionOAuthLauncher`; `apps/tab-manager/src/lib/platform/auth/auth.ts:48` calls `browser.identity.launchWebAuthFlow`; temporary OAuth transaction state lives in `browser.storage.session` at `apps/tab-manager/src/lib/platform/auth/auth.ts:35`.
+
+Inconsistencies:
+
+- Browser callback pages are thin duplicates and redirect after `auth.startSignIn()` succeeds without checking `auth.state.status`; examples: `apps/dashboard/src/routes/auth/callback/+page.svelte:11`, `apps/fuji/src/routes/auth/callback/+page.svelte:10`.
+- Browser apps import `PersistedAuth` from `@epicenter/auth`; Tab Manager imports it from `@epicenter/auth-svelte` at `apps/tab-manager/src/lib/platform/auth/auth.ts:12`.
+- Auth-code token parsing does not validate `token_type` in `packages/auth/src/oauth-launchers/index.ts:296`; refresh parsing does validate bearer token type in `packages/auth/src/create-oauth-app-auth.ts:403`.
+- `bearer.` WebSocket subprotocol prefix is duplicated in `packages/auth/src/create-oauth-app-auth.ts:70` and `packages/sync/src/auth-subprotocol.ts:25`.
+
+### CLI And Daemon OOB
+
+`packages/cli/src/commands/auth.ts:36` calls `loginWithOob()`. The OOB launcher builds the authorize URL at `packages/auth/src/node/oob-launcher.ts:105` and exchanges the pasted code at `packages/auth/src/node/oob-launcher.ts:135`. `packages/auth/src/node/machine-auth.ts:139` calls `/api/me`; `packages/auth/src/node/machine-auth.ts:147` writes `{ grant, unlock }`.
+
+Machine storage is one file. `packages/auth/src/node/machine-tokens-store.ts:38` fixes the default path at `~/.epicenter/auth.json`; writes use a temp file and `0600` mode at `packages/auth/src/node/machine-tokens-store.ts:121`; POSIX reads reject too-open permissions at `packages/auth/src/node/machine-tokens-store.ts:68`.
+
+Daemon consumers do not start interactive auth. `packages/cli/src/load-config.ts:257` creates one `AuthClient`, then passes it into daemon route startup at `packages/cli/src/load-config.ts:263`. App daemon routes consume that injected auth: Fuji at `apps/fuji/blocks/daemon-route.ts:32`, Honeycrisp at `apps/honeycrisp/blocks/daemon-route.ts:25`, Opensidian at `apps/opensidian/blocks/daemon-route.ts:21`, Zhongwen at `apps/zhongwen/blocks/daemon-route.ts:25`.
+
+Inconsistencies:
+
+- Logout deletes local storage before revoke and does not await revoke. `packages/auth/src/create-oauth-app-auth.ts:313` clears storage; `packages/auth/src/create-oauth-app-auth.ts:311` starts revoke as a detached promise. A short-lived CLI can exit before `/auth/oauth2/revoke` completes.
+- OOB `state` is generated at `packages/auth/src/node/oob-launcher.ts:103`, but the CLI reads only code at `packages/auth/src/node/oob-launcher.ts:128` and does not verify state in the token request at `packages/auth/src/node/oob-launcher.ts:139`.
+- The CLI callback page comment says the CLI checks state locally at `apps/api/src/auth-pages/cli-callback-page.tsx:31`; current code does not.
+- Self-hosted or local `baseURL` can default to a redirect URI that is not registered. `packages/auth/src/node/oob-launcher.ts:82` defaults to `${baseURL}/auth/cli-callback`; `packages/constants/src/oauth.ts:77` registers only `https://api.epicenter.so/auth/cli-callback`.
+- Concurrent writes use the fixed temp path `${filePath}.tmp` at `packages/auth/src/node/machine-tokens-store.ts:122`, so concurrent login or refresh is not as robust as the old spec claims.
+- Machine status has its own vocabulary (`signedOut`, `valid`, `unverified`) at `packages/auth/src/node/machine-auth.ts:87`; browser core uses `signed-out`, `signed-in`, `reauth-required`.
+
+### Server OAuth
+
+`apps/api/src/auth/create-auth.ts:182` configures Better Auth OAuth provider with PKCE, trusted client ids, valid audiences, disabled dynamic registration, and the shared scopes. `apps/api/src/app.ts:173` seeds trusted OAuth clients before creating auth.
+
+Trusted projection creates public PKCE authorization-code clients at `apps/api/src/auth/trusted-oauth-clients.ts:21`. Runtime maps browser and extension to `user-agent-based`, native to `native` at `apps/api/src/auth/trusted-oauth-clients.ts:86`.
+
+`/api/me` is the single identity endpoint. `apps/api/src/app.ts:275` returns `{ user, encryptionKeys }`. `apps/api/src/auth/resource-boundary.ts:64` verifies the bearer token and `apps/api/src/auth/resource-boundary.ts:79` enforces `workspaces:open`.
+
+Inconsistencies:
+
+- Scope strings are duplicated in provider config, trusted projection, and tests: `apps/api/src/auth/create-auth.ts:189`, `apps/api/src/auth/trusted-oauth-clients.ts:5`, `apps/api/src/test-helpers/oauth.ts:7`.
+- Trusted-client semantics are split between DB row `skipConsent: true` at `apps/api/src/auth/trusted-oauth-clients.ts:33` and provider `cachedTrustedClients` at `apps/api/src/auth/create-auth.ts:186`.
+- PKCE/public-client semantics are repeated in trusted projection, provider config, and test helper setup.
+- The resource-boundary comment says `/api/assets/*` requires `workspaces:open`, but public asset reads intentionally bypass auth through the public route mounted before the guard.
+- Trusted client upsert does not overwrite every nullable client metadata field, so stale fields can survive from earlier DB rows.
+
+### Consumers And Session Behavior
+
+Core semantics are coherent:
+
+```txt
+signed-out
+  no persisted cell
+  dispose local workspace
+
+signed-in
+  persisted cell exists
+  unlock available immediately
+  network bearer only after /api/me verifies this runtime
+
+reauth-required
+  persisted cell exists
+  unlock remains available
+  network bearer is paused
+```
+
+`packages/svelte-utils/src/session.svelte.ts:27` treats `signed-in` and `reauth-required` as the same local workspace lifetime and disposes only on `signed-out`. The local owner reads encryption keys lazily from current auth state at `packages/svelte-utils/src/session.svelte.ts:37`.
+
+Inconsistencies:
+
+- Dashboard gates its signed-in layout on exact `signed-in` at `apps/dashboard/src/routes/(signed-in)/+layout.svelte:25`, so `reauth-required` is visually treated like signed-out even though local workspace semantics say it is still identity-bearing.
+- Tab Manager handles the distinction more honestly by keeping the app open and showing reauth copy in `apps/tab-manager/src/entrypoints/sidepanel/SignedInApp.svelte:84`.
+- `/api/me` has two jobs: auth-internal verification and account/profile fetch. A cold `auth.fetch('/api/me')` can make two `/api/me` requests, covered by `packages/auth/src/contract.test.ts:270`.
+- Svelte lifecycle behavior has no direct test file under `packages/auth-svelte` or `packages/svelte-utils`; current confidence comes from implementation plus `packages/auth/src/contract.test.ts`.
+
+## Canonical-Path Proposal
+
+Keep exactly three launcher paths:
+
+1. Browser redirect OAuth.
+2. Extension WebAuthFlow OAuth.
+3. Machine OOB OAuth.
+
+Keep exactly one shared auth runtime after launch:
+
+```txt
+OAuthTokenGrant
+  -> /api/me
+  -> PersistedAuth
+  -> createOAuthAppAuth
+  -> auth.fetch / auth.openWebSocket
+  -> resource-boundary verification
+```
+
+Do not add a fourth path for daemon, Docker, SSH, CI, local development, or self-hosting. Those are configuration and callback-registration concerns inside the machine OOB path, not separate auth models.
+
+## Collapse Plan
+
+Pause before changing production code. The next implementation spec should decide and then execute these collapses:
+
+- [ ] Make revoke semantics explicit. Either await revoke before reporting logout success for machine auth, or name it best-effort everywhere and test that exact behavior.
+- [ ] Fix OOB state semantics. Either paste and verify `{ code, state }`, render state as part of the copyable callback payload, or remove `state` and comments that claim it is checked. Do not leave security theater.
+- [ ] Decide self-hosted CLI redirect registration. Either register localhost and self-host callback URIs intentionally, or require explicit `redirectUri` for non-production `baseURL`.
+- [ ] Replace fixed `.tmp` auth-file writes with per-process or random temp paths before claiming concurrent login is safe.
+- [ ] Extract the shared OAuth token-response parser used by browser, extension, refresh, and OOB paths, including token type validation.
+- [ ] Extract or import the shared bearer subprotocol prefix instead of defining it in two packages.
+- [ ] Collapse browser callback routes to one shared callback component or helper that redirects only after `auth.state.status === 'signed-in'`.
+- [ ] Normalize `reauth-required` UI handling: identity-bearing layouts stay mounted, network-only controls show reconnect.
+- [ ] Move shared scope strings into one exported server-auth constant and reuse it in provider config, trusted projection, and tests.
+- [ ] Update CLI README examples so daemon routes consume injected `auth`, not route-local `createMachineAuthClient()`.
+
+## Rejected Alternatives
+
+| Alternative | Reason |
+| --- | --- |
+| Add compatibility layers for old `OAuthSession` | `PersistedAuth` is already the landed clean break; compatibility adds another session shape with no current caller. |
+| Restore device authorization | Solves only machine login and reintroduces a second grant family where OOB already works across the deployment matrix. |
+| Make `/api/me` return long-lived profile state for auth | Profile moved to application data; auth should carry unlock and grant, not decorative account labels. |
+| Add per-platform machine auth backends | Creates more storage semantics instead of removing them. File storage is the canonical machine store. |
+| Use browser cookies for first-party SPAs | It is shorter for one browser app, but it breaks the cross-client OAuth resource boundary shared by extension, CLI, daemon, and browser apps. |
+
+## Open Questions
+
+- Should machine logout be stronger than browser logout by awaiting revoke, or should `AuthClient.signOut()` itself expose an awaited revoke mode?
+- Should OOB paste include the state visibly, or should the callback page encode a single copyable payload that the CLI parses?
+- Is self-hosted CLI login a supported product path now, or is it future work behind explicit trusted-client setup?
+- Should `/api/me` split auth verification from account/profile fetching, or is the duplicate cold-call acceptable because it keeps one identity endpoint?
+- Should machine `status` reuse core auth vocabulary, or does CLI output deserve command-specific names?
+- Is `reauth-required` a signed-in route state everywhere, with only network controls paused? If yes, Dashboard currently disagrees.
+
+## Verification Checklist
+
+Evidence collected:
+
+- [x] Read `specs/20260514T120000-machine-auth-oob-clean-break.md`.
+- [x] Read `specs/20260514T200000-api-me-three-field-token-bundle.md`.
+- [x] Read `packages/auth/src/create-oauth-app-auth.ts`.
+- [x] Read `packages/auth/src/node/machine-auth.ts`.
+- [x] Read `packages/auth/src/node/oob-launcher.ts`.
+- [x] Read `packages/auth/src/node/machine-tokens-store.ts`.
+- [x] Read `packages/auth/src/auth-types.ts`.
+- [x] Read `packages/constants/src/oauth.ts`.
+- [x] Read `apps/api/src/auth/create-auth.ts`.
+- [x] Read `apps/api/src/app.ts`.
+- [x] Read all `apps/*/src/lib/platform/auth/auth.ts` files.
+- [x] Spawned browser and extension OAuth mapping subagent.
+- [x] Spawned CLI and daemon OOB mapping subagent.
+- [x] Spawned server OAuth mapping subagent.
+- [x] Spawned consumer session behavior mapping subagent.
+
+Validation commands:
+
+- [x] `bun test packages/auth`: 47 pass, 0 fail.
+- [x] `bun test apps/api`: 64 pass, 0 fail.
+
+No production code has been changed by this audit spec. The collapse plan above includes security and product decisions, so implementation should pause for explicit approval before editing runtime auth behavior, deleting tests, changing OAuth client contracts, or changing persisted auth shape.

--- a/specs/20260515T010000-auth-canonical-path-audit.md
+++ b/specs/20260515T010000-auth-canonical-path-audit.md
@@ -411,22 +411,29 @@ apps/api/src/auth/trusted-oauth-clients.ts
 
 ### Phase 1: Prove Existing Invariants
 
-- [ ] Add auth tests for stale refresh write after sign-out.
-- [ ] Add auth tests for stale `/api/me` key-update write after sign-out.
+- [x] Add auth tests for stale refresh write after sign-out.
+  > Evidence: `packages/auth/src/contract.test.ts` covers `concurrent refresh shares one promise and signOut during refresh wins`. The test proves a refresh response that resolves after sign-out does not restore storage, bearer attachment, or signed-in state.
+- [x] Add auth tests for stale `/api/me` key-update write after sign-out.
+  > Evidence: `packages/auth/src/contract.test.ts` covers `/api/me key update after signOut is discarded without writing unlock`. The test resolves `/api/me` with rotated encryption keys after sign-out and proves the rotated unlock is not written.
 - [ ] Add a session test for same-user identity-bearing transitions.
 - [ ] Add or update a test proving `reauth-required` keeps the workspace mounted.
 - [ ] Add a transport test proving protected sync does not open an anonymous WebSocket when auth verification fails.
 
 ### Phase 2: Harden Auth Core
 
-- [ ] Fix stale storage writes in refresh and `/api/me` verification.
-- [ ] Decide whether `AuthClient.signOut()` should await revoke in machine contexts or stay best effort everywhere.
-- [ ] Share the OAuth token response parser across browser, extension, refresh, and OOB launchers.
-- [ ] Import the bearer subprotocol prefix from `@epicenter/sync` or move it to a shared no-cycle package.
+- [x] Fix stale storage writes in refresh and `/api/me` verification.
+  > Evidence: `packages/auth/src/create-oauth-app-auth.ts` re-checks the started cell before and after storage writes, and the two Phase 1 stale-response tests cover refresh and `/api/me` unlock updates after sign-out.
+- [x] Decide whether `AuthClient.signOut()` should await revoke in machine contexts or stay best effort everywhere.
+  > Decision: keep storage-first sign-out plus best-effort revoke everywhere. Evidence: `packages/auth/src/contract.test.ts` covers `signOut clears cell and network pause even when revoke fails`; `packages/auth/src/node/machine-auth.test.ts` covers `logout survives revoke failure and still deletes the file`; `packages/cli/README.md` now says logout clears the local file first, then makes a best-effort RFC 7009 revoke call.
+- [x] Share the OAuth token response parser across browser, extension, refresh, and OOB launchers.
+  > Evidence: `packages/auth/src/oauth-token-response.ts` is used by `packages/auth/src/oauth-launchers/index.ts`, `packages/auth/src/node/oob-launcher.ts`, and `packages/auth/src/create-oauth-app-auth.ts`.
+- [x] Import the bearer subprotocol prefix from `@epicenter/sync` or move it to a shared no-cycle package.
+  > Evidence: `packages/constants/src/auth.ts` owns `BEARER_SUBPROTOCOL_PREFIX`; `packages/sync/src/auth-subprotocol.ts` re-exports it; `packages/auth/src/create-oauth-app-auth.ts` imports the same constant directly. This keeps the dependency direction clean.
 
 ### Phase 3: Harden Machine OOB
 
-- [ ] Fix OOB state semantics by copying `{ code, state }`, or remove the local state check language.
+- [x] Fix OOB state semantics by copying `{ code, state }`, or remove the local state check language.
+  > Evidence: `packages/auth/src/node/oob-launcher.ts` no longer sends an unverifiable `state` parameter in the OOB authorize URL. `packages/auth/src/node/oob-launcher.test.ts` asserts the authorize URL has no `state`.
 - [ ] Replace the fixed auth temp path with a unique temp path.
 - [ ] Decide self-hosted CLI callback registration. Either require explicit `redirectUri` for non-production `baseURL`, or seed trusted redirect URIs through setup.
 
@@ -436,6 +443,7 @@ apps/api/src/auth/trusted-oauth-clients.ts
 - [ ] Make network-only controls show reconnect while local workspace controls remain usable.
 - [ ] Keep profile queries in account surfaces, not auth state.
 - [ ] Update stale docs that still show `auth.state.identity`, `OAuthSession`, `getToken`, or direct `openWebSocket: auth.openWebSocket` examples that contradict the current transport shape.
+  > Partial evidence: `packages/cli/README.md` was updated so daemon route examples consume injected `auth` from `start({ auth })` instead of constructing route-local machine auth. Broader docs remain deferred.
 
 ### Phase 5: Sync Identity Cleanup
 
@@ -477,6 +485,147 @@ No em dash or en dash in changed files.
 
 Historical specs may still contain rejected terms, but new implementation specs must point back here and say they are historical.
 
+## Phase 1 Execution Evidence
+
+Completed on 2026-05-15.
+
+Falsification gate result:
+
+```txt
+No architecture-changing contradiction found.
+
+Live contradictions found and handled:
+1. Machine OOB generated state, but the paste flow only accepted code.
+2. Logout docs implied guaranteed revoke, while code is storage-first plus best-effort revoke.
+3. Auth and sync duplicated the bearer WebSocket subprotocol prefix.
+4. Browser callback, OOB callback, and refresh parsed OAuth token responses separately.
+5. CLI README daemon example constructed machine auth inside the route instead of consuming injected auth.
+
+Live non-blocking findings deferred:
+1. `apps/api` still has the historical `device_code` table and migration metadata, but no active device-authorization runtime path was found.
+2. `apps/tab-manager/src/lib/platform/auth/auth.ts` has a legacy-storage comment that mentions `OAuthSession`.
+3. `packages/workspace/src/document/README.md` still has an old `auth.state.identity` example.
+```
+
+Implemented changes:
+
+```txt
+Canonical launch path count:
+  3 launch paths: browser app, extension, machine OOB.
+  1 shared runtime after launch.
+  Daemon is not a fourth auth path.
+
+Persisted auth naming decision:
+  Keep PersistedAuth = { grant, unlock }.
+  Do not rename grant or unlock in this phase.
+
+OOB state:
+  packages/auth/src/node/oob-launcher.ts
+    removed generated state from the OOB authorize URL because the CLI paste
+    flow does not receive state back from the hosted callback page.
+
+OAuth token parsing:
+  packages/auth/src/oauth-token-response.ts
+    added one shared parser for access_token, refresh_token, expires_in,
+    and bearer token_type validation.
+  packages/auth/src/oauth-launchers/index.ts
+    browser and extension auth-code exchange use the shared parser.
+  packages/auth/src/node/oob-launcher.ts
+    OOB auth-code exchange uses the shared parser.
+  packages/auth/src/create-oauth-app-auth.ts
+    refresh uses the shared parser and keeps the previous refresh token
+    when the refresh response omits rotation.
+
+WebSocket bearer prefix:
+  packages/constants/src/auth.ts
+    owns BEARER_SUBPROTOCOL_PREFIX.
+  packages/sync/src/auth-subprotocol.ts
+    re-exports the shared prefix for server and sync callers.
+  packages/auth/src/create-oauth-app-auth.ts
+    imports the same shared prefix for client WebSocket construction.
+
+Logout semantics:
+  packages/cli/README.md
+    now documents logout as local file clear first, then best-effort RFC 7009
+    revoke.
+  packages/auth/src/contract.test.ts
+    covers local sign-out plus best-effort revoke failure.
+  packages/auth/src/node/machine-auth.test.ts
+    covers machine logout surviving revoke failure and deleting the file.
+
+Daemon docs:
+  packages/cli/README.md
+    daemon route example now receives injected auth through start({ auth })
+    and no longer calls createMachineAuthClient() inside the route.
+```
+
+Deferred changes:
+
+```txt
+Session tests:
+  Same-user identity-bearing transition and reauth-required mounted-session
+  tests remain deferred. The live implementation documents the invariant in
+  packages/svelte-utils/src/session.svelte.ts, but this pass did not add a
+  Svelte-runes test harness.
+
+Protected sync anonymous WebSocket behavior:
+  Deferred because changing openWebSocket failure behavior would alter the
+  auth/sync contract. Current coverage proves bearer insertion waits for
+  /api/me verification, not that protected sync rejects anonymous opens.
+
+Machine temp-file collision:
+  Deferred. packages/auth/src/node/machine-tokens-store.ts still uses a fixed
+  .tmp path. That is Phase 3 hardening and not required for the Phase 1
+  canonicalization pass.
+
+Self-hosted CLI callback registration:
+  Deferred pending the trusted-client setup decision.
+
+Broader stale docs:
+  Deferred outside packages/cli/README.md. Historical docs and package READMEs
+  still contain rejected terms and old examples.
+```
+
+Commands run during Phase 1 execution:
+
+```bash
+bun install
+bun test packages/auth
+bun test packages/sync
+rg -n "OAuthSession|AuthIdentity|WorkspaceIdentityStore|/workspace-identity|getToken\\(|bearerToken|auth\\.state\\.identity|auth\\.state\\.email|deviceAuthorization|deviceAuthorizationClient|device_code|deviceCode" packages apps -g '!**/*.test.ts' -g '!**/*.bench.ts'
+rg -n "createMachineAuthClient\\(" packages apps docs -g '*.md' -g '*.ts' -g '!**/*.test.ts'
+rg -n "const BEARER_SUBPROTOCOL_PREFIX = 'bearer\\.'|parseTokenResponse|readPositiveNumber|readOptionalString|readString\\(" packages/auth/src packages/sync/src packages/constants/src
+LC_ALL=C perl -ne 'print "$ARGV:$.:$_" if /\\xE2\\x80[\\x93\\x94]/' packages/auth/src/create-oauth-app-auth.ts packages/auth/src/oauth-token-response.ts packages/auth/src/oauth-launchers/index.ts packages/auth/src/node/oob-launcher.ts packages/auth/src/contract.test.ts packages/auth/src/oauth-launchers/index.test.ts packages/auth/src/node/oob-launcher.test.ts packages/sync/src/auth-subprotocol.ts packages/sync/src/auth-subprotocol.test.ts packages/constants/src/auth.ts packages/cli/README.md specs/20260515T010000-auth-canonical-path-audit.md
+```
+
+Results:
+
+```txt
+bun install:
+  Pass. Saved lockfile. Checked 1610 installs across 1690 packages.
+
+bun test packages/auth:
+  First run after adding the stale key-update test failed because the test
+  temporarily referenced a removed helper. This was a test edit mistake.
+  Final run passed: 50 pass, 0 fail, 159 expect calls.
+
+bun test packages/sync:
+  Pass: 27 pass, 0 fail, 52 expect calls.
+
+apps/api tests:
+  Not run because no apps/api auth code changed.
+
+Live grep results:
+  device_code remains only in DB schema and migration metadata.
+  OAuthSession remains in a legacy storage comment in tab-manager.
+  auth.state.identity remains in packages/workspace/src/document/README.md.
+  No live runtime raw token getter or device authorization machine path was
+  found in packages or apps.
+
+Dash check:
+  Pass after replacing two existing dashes in packages/sync/src/auth-subprotocol.ts.
+```
+
 ## Rejected Alternatives
 
 | Alternative | Refusal |
@@ -496,11 +645,17 @@ Historical specs may still contain rejected terms, but new implementation specs 
 
 These are implementation choices, not architecture blockers:
 
-1. Should machine logout await revoke, or should all logout remain storage-first and revoke-best-effort?
-2. Should protected sync reject anonymous `openWebSocket` attempts in auth or in workspace sync?
-3. Should `createSession` rebuild on a different `unlock.userId`, or should auth guarantee a signed-out transition first?
-4. Should self-hosted CLI login require explicit trusted-client setup, or should setup seed redirect URIs?
-5. Should `/api/me` remain both network verification and account profile fetch, or should account profile get a separate route later?
+1. Should protected sync reject anonymous `openWebSocket` attempts in auth or in workspace sync?
+2. Should `createSession` rebuild on a different `unlock.userId`, or should auth guarantee a signed-out transition first?
+3. Should self-hosted CLI login require explicit trusted-client setup, or should setup seed redirect URIs?
+4. Should `/api/me` remain both network verification and account profile fetch, or should account profile get a separate route later?
+
+Resolved during Phase 1 execution:
+
+```txt
+Machine logout does not await revoke. All logout remains storage-first and
+revoke-best-effort.
+```
 
 ## Pause Conditions
 


### PR DESCRIPTION
Auth had too many near-identical paths for the same machine-auth and browser-auth flow. Before doing the larger identity vocabulary cleanup, this PR makes the existing path explicit: shared auth constants live in one package, token responses parse through one helper, OOB/browser launchers agree on the same grant shape, and the API schema drops the stale device-code table that no longer belongs to this flow.

The important boundary after this PR is:

```txt
OAuth callback or OOB paste
  -> token grant parser
  -> /api/me verification
  -> persisted auth cell
  -> gated fetch and websocket auth
```

The token parser gives both browser and machine auth the same validation point:

```ts
const grant = parseOAuthTokenGrant(await response.json(), {
  requireRefreshToken: true,
});

await authStore.write({
  grant,
  localIdentity,
});
```

This is intentionally the foundation PR in the stack. The follow-up PRs can rename durable identity concepts without also having to explain where auth grants, API verification, constants, and stale database state live.

Verified locally:

```txt
git diff --check origin/main...HEAD
bun run --silent --filter @epicenter/auth test
bun run --silent --filter @epicenter/api test
```

GitHub code quality is still failing on existing whole-repo lint debt unrelated to this diff, including generated Cloudflare types and unrelated UI files.