### PR TITLE
fix(whispering): hotkey overhaul (gating + Alt+Space default + layout-independent capture)

### DIFF
--- a/apps/whispering/package.json
+++ b/apps/whispering/package.json
@@ -64,7 +64,7 @@
 		"@tauri-apps/plugin-dialog": "^2.3.2",
 		"@tauri-apps/plugin-fs": "catalog:",
 		"@tauri-apps/plugin-global-shortcut": "^2.3.0",
-		"@tauri-apps/plugin-http": "^2.5.1",
+		"@tauri-apps/plugin-http": "2.5.4",
 		"@tauri-apps/plugin-log": "~2",
 		"@tauri-apps/plugin-notification": "^2.3.0",
 		"@tauri-apps/plugin-opener": "catalog:",

--- a/apps/whispering/src/lib/constants/keyboard/browser/code-to-key.ts
+++ b/apps/whispering/src/lib/constants/keyboard/browser/code-to-key.ts
@@ -1,0 +1,93 @@
+import type { KeyboardEventPossibleKey } from './possible-keys';
+
+/**
+ * Translates a W3C `KeyboardEvent.code` (physical key position) to the
+ * lowercase logical key value our supported-key set uses (the same form that
+ * `e.key.toLowerCase()` would return on a US ANSI layout).
+ *
+ * The pipeline previously read `e.key` for everything, which captures the
+ * character produced by the current keyboard layout: on FI ISO the physical
+ * Semicolon-position key reports `e.key === 'Ö'`, which is not in the
+ * supported set and gets silently dropped during recording. Using `e.code`
+ * gives us the layout-independent physical position (`Semicolon`) which we
+ * map back to the canonical `;` token. Downstream conversion
+ * (`pressedKeysToTauriAccelerator`) then produces an accelerator like
+ * `Command+Shift+;`, which Tauri's `plugin-global-shortcut` binds to the
+ * same physical position the user pressed.
+ *
+ * Modifier codes (ShiftLeft/Right, ControlLeft/Right, AltLeft/Right,
+ * MetaLeft/Right, OSLeft/Right, AltGraph) intentionally return `null` so
+ * callers fall back to `e.key`, which already reports the canonical modifier
+ * name (`Shift`, `Control`, ...) consistently across platforms.
+ *
+ * Returns `null` for unknown codes so the caller can fall back to `e.key`.
+ */
+export function codeToLogicalKey(
+	code: string,
+): KeyboardEventPossibleKey | null {
+	// Letters: KeyA..KeyZ → a..z
+	if (code.startsWith('Key') && code.length === 4) {
+		return code.slice(3).toLowerCase() as KeyboardEventPossibleKey;
+	}
+	// Top-row digits: Digit0..Digit9 → 0..9
+	if (code.startsWith('Digit') && code.length === 6) {
+		return code.slice(5) as KeyboardEventPossibleKey;
+	}
+	// Numpad digits: Numpad0..Numpad9 → 0..9 (lose numlock distinction; matches e.key with NumLock on)
+	if (code.startsWith('Numpad') && code.length === 7) {
+		const last = code.slice(6);
+		if (last >= '0' && last <= '9') return last as KeyboardEventPossibleKey;
+	}
+	// Function keys: F1..F24 (as-is, lowercased)
+	if (/^F([1-9]|1[0-9]|2[0-4])$/.test(code)) {
+		return code.toLowerCase() as KeyboardEventPossibleKey;
+	}
+	return SPECIAL_CODE_MAP[code] ?? null;
+}
+
+const SPECIAL_CODE_MAP: Record<string, KeyboardEventPossibleKey> = {
+	// Whitespace
+	Space: ' ',
+	Enter: 'enter',
+	NumpadEnter: 'enter',
+	Tab: 'tab',
+	// Editing
+	Backspace: 'backspace',
+	Delete: 'delete',
+	Insert: 'insert',
+	Escape: 'escape',
+	// Navigation
+	ArrowUp: 'arrowup',
+	ArrowDown: 'arrowdown',
+	ArrowLeft: 'arrowleft',
+	ArrowRight: 'arrowright',
+	Home: 'home',
+	End: 'end',
+	PageUp: 'pageup',
+	PageDown: 'pagedown',
+	// Punctuation: canonical US-ANSI character regardless of current layout
+	Minus: '-',
+	Equal: '=',
+	BracketLeft: '[',
+	BracketRight: ']',
+	Backslash: '\\',
+	Semicolon: ';',
+	Quote: "'",
+	Backquote: '`',
+	Comma: ',',
+	Period: '.',
+	Slash: '/',
+	// Numpad operators
+	NumpadAdd: '+',
+	NumpadSubtract: '-',
+	NumpadMultiply: '*',
+	NumpadDivide: '/',
+	NumpadDecimal: '.',
+	// Misc
+	CapsLock: 'capslock',
+	NumLock: 'numlock',
+	ScrollLock: 'scrolllock',
+	ContextMenu: 'contextmenu',
+	PrintScreen: 'printscreen',
+	Pause: 'pause',
+};

--- a/apps/whispering/src/lib/constants/keyboard/browser/parse-manual-shortcut.ts
+++ b/apps/whispering/src/lib/constants/keyboard/browser/parse-manual-shortcut.ts
@@ -1,0 +1,95 @@
+import type { KeyboardEventPossibleKey } from './possible-keys';
+import { isSupportedKey, type KeyboardEventSupportedKey } from './supported-keys';
+
+/**
+ * User-friendly aliases that map to canonical W3C key names (the lowercase
+ * form `e.key.toLowerCase()` produces). Lets the user type the names they
+ * actually know (`ctrl`, `cmd`, `option`, `space`, `esc`) instead of memorising
+ * the W3C set.
+ */
+const ALIAS_MAP: Record<string, KeyboardEventPossibleKey> = {
+	// Modifiers
+	ctrl: 'control',
+	control: 'control',
+	cmd: 'meta',
+	command: 'meta',
+	'⌘': 'meta',
+	meta: 'meta',
+	win: 'meta',
+	super: 'meta',
+	option: 'alt',
+	opt: 'alt',
+	'⌥': 'alt',
+	alt: 'alt',
+	shift: 'shift',
+	'⇧': 'shift',
+	altgr: 'altgraph',
+	altgraph: 'altgraph',
+	// Common named keys
+	space: ' ',
+	spacebar: ' ',
+	esc: 'escape',
+	escape: 'escape',
+	ret: 'enter',
+	return: 'enter',
+	enter: 'enter',
+	tab: 'tab',
+	bs: 'backspace',
+	backspace: 'backspace',
+	del: 'delete',
+	delete: 'delete',
+	ins: 'insert',
+	insert: 'insert',
+	home: 'home',
+	end: 'end',
+	pgup: 'pageup',
+	pageup: 'pageup',
+	pgdn: 'pagedown',
+	pagedown: 'pagedown',
+	up: 'arrowup',
+	down: 'arrowdown',
+	left: 'arrowleft',
+	right: 'arrowright',
+	arrowup: 'arrowup',
+	arrowdown: 'arrowdown',
+	arrowleft: 'arrowleft',
+	arrowright: 'arrowright',
+};
+
+function aliasToCanonical(token: string): KeyboardEventPossibleKey | null {
+	const t = token.trim().toLowerCase();
+	if (!t) return null;
+	const mapped = ALIAS_MAP[t];
+	if (mapped) return mapped;
+	// Pass-through: letters, digits, punctuation, function keys, etc.
+	// isSupportedKey downstream validates that the token is actually usable.
+	return t as KeyboardEventPossibleKey;
+}
+
+/**
+ * Parses a `+`-separated manual shortcut entry like `"ctrl+shift+a"` or
+ * `"cmd+option+space"` into a list of canonical keys plus any tokens that
+ * could not be normalised. The recorder UI surfaces `invalidTokens` as a
+ * validation error so the user gets honest feedback instead of the legacy
+ * "silently drop unrecognised tokens" behaviour.
+ */
+export function parseManualShortcut(input: string): {
+	keys: KeyboardEventSupportedKey[];
+	invalidTokens: string[];
+} {
+	const tokens = input
+		.split('+')
+		.map((token) => token.trim())
+		.filter((token) => token.length > 0);
+	const keys: KeyboardEventSupportedKey[] = [];
+	const invalidTokens: string[] = [];
+	for (const token of tokens) {
+		const canonical = aliasToCanonical(token);
+		if (canonical && isSupportedKey(canonical)) {
+			keys.push(canonical);
+		} else {
+			invalidTokens.push(token);
+		}
+	}
+	return { keys, invalidTokens };
+}

--- a/apps/whispering/src/lib/constants/keyboard/index.ts
+++ b/apps/whispering/src/lib/constants/keyboard/index.ts
@@ -14,6 +14,8 @@ export {
 	KEYBOARD_EVENT_SPECIAL_KEY_TO_ACCELERATOR_KEY_CODE_MAP,
 } from './accelerator-conversions';
 
+export { codeToLogicalKey } from './browser/code-to-key';
+export { parseManualShortcut } from './browser/parse-manual-shortcut';
 export type { KeyboardEventPossibleKey } from './browser/possible-keys';
 
 export {

--- a/apps/whispering/src/lib/services/desktop/global-shortcut-manager.ts
+++ b/apps/whispering/src/lib/services/desktop/global-shortcut-manager.ts
@@ -122,15 +122,13 @@ export const GlobalShortcutManagerLive = {
 			catch: (error) =>
 				ShortcutError.RegisterFailed({ accelerator, cause: error }),
 		});
-		/**
-		 * NOTE: We often get "RegisterEventHotKey failed for <key>" errors when
-		 * registering global shortcuts, even though the shortcut was valid and
-		 * registered successfully. This is a known issue with the underlying system
-		 * API on certain platforms. We gracefully return Ok(undefined) in these
-		 * cases to avoid propagating the error as an unnecessary error toast,
-		 * allowing the shortcut system to continue functioning for other valid keys.
-		 */
-		if (registerError) return Ok(undefined);
+		// Surface the registration failure to the caller so the error toast
+		// plumbing in syncGlobalShortcutsWithSettings can show the actual cause
+		// (reserved by OS, accelerator parse failure, etc.). Previously this was
+		// swallowed because the underlying plugin emitted false-positive errors
+		// for some valid registrations; if that resurfaces we will gate per-error
+		// rather than swallowing the whole class.
+		if (registerError) return Err(registerError);
 
 		return Ok(undefined);
 	},

--- a/apps/whispering/src/lib/utils/createPressedKeys.svelte.ts
+++ b/apps/whispering/src/lib/utils/createPressedKeys.svelte.ts
@@ -1,11 +1,20 @@
 import { on } from 'svelte/events';
 import {
+	codeToLogicalKey,
 	isSupportedKey,
 	type KeyboardEventPossibleKey,
 	type KeyboardEventSupportedKey,
 	normalizeOptionKeyCharacter,
 } from '$lib/constants/keyboard';
 import { IS_MACOS } from '$lib/constants/platform';
+
+const MODIFIER_KEYS = new Set<KeyboardEventPossibleKey>([
+	'control',
+	'shift',
+	'alt',
+	'meta',
+	'altgraph',
+]);
 
 /**
  * Creates a reactive state manager for tracking pressed keyboard keys.
@@ -62,17 +71,36 @@ export function createPressedKeys({
 			if (preventDefault) {
 				e.preventDefault();
 			}
+			if (import.meta.env.DEV) {
+				// Layout-debugging instrumentation: keep this until the e.code-based
+				// capture is verified working on every keyboard layout users report.
+				console.debug('[hotkey:keydown]', {
+					key: e.key,
+					code: e.code,
+					metaKey: e.metaKey,
+					altKey: e.altKey,
+					ctrlKey: e.ctrlKey,
+					shiftKey: e.shiftKey,
+				});
+			}
 			let key = e.key.toLowerCase() as KeyboardEventPossibleKey;
 
-			// macOS Option key normalization:
-			// On macOS, the Option key (Alt) triggers special character insertion.
-			// For example, Option+A produces "å" instead of registering as "alt+a".
-			// This breaks keyboard shortcut detection because we get the special
-			// character instead of the actual key that was pressed.
+			// For non-modifier keys, prefer the e.code-derived value so capture is
+			// layout-independent: pressing the physical Semicolon-position key on a
+			// FI layout (which produces 'Ö' via e.key) maps to ';' via e.code, the
+			// same canonical token a US user would see. Modifier keys keep using
+			// e.key, which already gives the right name on every platform.
 			//
-			// To fix this, when Option is held on macOS, we normalize these special
-			// characters back to their base keys (e.g., "å" → "a", "ç" → "c").
-			// This ensures keyboard shortcuts work consistently across platforms.
+			// Fall back to e.key when codeToLogicalKey returns null (unmapped codes
+			// like NumpadEqual or vendor-specific keys).
+			if (!MODIFIER_KEYS.has(key)) {
+				key = codeToLogicalKey(e.code) ?? key;
+			}
+
+			// macOS Option-key character normalization is now only a fallback for
+			// cases where we had to use e.key above (unmapped e.code). When
+			// codeToLogicalKey succeeds we already have the layout-neutral key, so
+			// the Option-character mapping is a no-op.
 			if (IS_MACOS && pressedKeys.includes('alt')) {
 				key = normalizeOptionKeyCharacter(key);
 			}
@@ -88,7 +116,12 @@ export function createPressedKeys({
 		});
 
 		const keyup = on(window, 'keyup', (e) => {
-			const key = e.key.toLowerCase() as KeyboardEventPossibleKey;
+			let key = e.key.toLowerCase() as KeyboardEventPossibleKey;
+			// Mirror the keydown translation so the value we look for in
+			// pressedKeys matches what we stored on press (layout-neutral form).
+			if (!MODIFIER_KEYS.has(key)) {
+				key = codeToLogicalKey(e.code) ?? key;
+			}
 
 			if (!isSupportedKey(key)) return;
 

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -329,8 +329,16 @@ const analytics = {
  * In-app keyboard shortcuts. System-global shortcuts are device-specific and stay
  * in localStorage — these are only the shortcuts within the Whispering window.
  * `null` = unbound.
+ *
+ * `shortcuts.local.enabled` and `shortcuts.global.enabled` are master switches
+ * for each subsystem. Local defaults OFF (most users only need global, and the
+ * local listener can interfere with shortcut recording); global defaults ON.
+ * Existing users with configured local shortcuts are migrated to local=ON via
+ * `grandfatherLocalShortcutsEnabled()` in `register-commands.ts`.
  */
 const shortcuts = {
+	'shortcuts.local.enabled': defineKv(type('boolean'), false),
+	'shortcuts.global.enabled': defineKv(type('boolean'), true),
 	'shortcut.toggleManualRecording': defineKv(type('string | null'), ' '),
 	'shortcut.startManualRecording': defineKv(type('string | null'), null),
 	'shortcut.stopManualRecording': defineKv(type('string | null'), null),

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/global/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/global/+page.svelte
@@ -1,13 +1,16 @@
 <script lang="ts">
 	import { Button, buttonVariants } from '@epicenter/ui/button';
 	import * as Empty from '@epicenter/ui/empty';
+	import { Label } from '@epicenter/ui/label';
 	import { Link } from '@epicenter/ui/link';
 	import * as SectionHeader from '@epicenter/ui/section-header';
 	import { Separator } from '@epicenter/ui/separator';
+	import { Switch } from '@epicenter/ui/switch';
 	import Layers2Icon from '@lucide/svelte/icons/layers-2';
 	import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
 	import { rpc } from '$lib/query';
 	import { desktopRpc } from '$lib/query/desktop';
+	import { settings } from '$lib/state/settings.svelte';
 	import { resetGlobalShortcuts } from '$routes/(app)/_layout-utils/register-commands';
 	import ShortcutFormatHelp from '../keyboard-shortcut-recorder/ShortcutFormatHelp.svelte';
 	import ShortcutTable from '../keyboard-shortcut-recorder/ShortcutTable.svelte';
@@ -39,6 +42,7 @@
 			<Button
 				variant="outline"
 				size="sm"
+				disabled={!settings.get('shortcuts.global.enabled')}
 				onclick={async () => {
 					await desktopRpc.globalShortcuts.unregisterAll();
 					resetGlobalShortcuts();
@@ -56,7 +60,34 @@
 
 		<Separator class="my-6" />
 
-		<ShortcutTable type="global" />
+		<div class="mb-6 flex items-start justify-between gap-4 rounded-md border p-4">
+			<div class="space-y-1">
+				<Label for="global-shortcuts-toggle" class="text-base font-medium">
+					Enable global shortcuts
+				</Label>
+				<p class="text-sm text-muted-foreground">
+					On by default. Turn off to free all configured combos system-wide
+					(your settings stay; flipping back on restores them).
+				</p>
+			</div>
+			<Switch
+				id="global-shortcuts-toggle"
+				bind:checked={
+					() => settings.get('shortcuts.global.enabled'),
+					(checked) => settings.set('shortcuts.global.enabled', checked)
+				}
+				class="shrink-0"
+			/>
+		</div>
+
+		<div
+			class={settings.get('shortcuts.global.enabled')
+				? ''
+				: 'pointer-events-none opacity-50'}
+			aria-disabled={!settings.get('shortcuts.global.enabled')}
+		>
+			<ShortcutTable type="global" />
+		</div>
 	</section>
 {:else}
 	<Empty.Root>

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/KeyboardShortcutRecorder.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/KeyboardShortcutRecorder.svelte
@@ -1,19 +1,17 @@
 <script lang="ts">
-	import * as Alert from '@epicenter/ui/alert';
 	import { Button } from '@epicenter/ui/button';
 	import { Input } from '@epicenter/ui/input';
 	import * as Kbd from '@epicenter/ui/kbd';
 	import * as Popover from '@epicenter/ui/popover';
 	import { cn } from '@epicenter/ui/utils';
-	import AlertTriangle from '@lucide/svelte/icons/alert-triangle';
 	import Keyboard from '@lucide/svelte/icons/keyboard';
 	import Pencil from '@lucide/svelte/icons/pencil';
 	import XIcon from '@lucide/svelte/icons/x';
 	import {
 		getShortcutDisplayLabel,
-		type KeyboardEventSupportedKey,
+		parseManualShortcut,
 	} from '$lib/constants/keyboard';
-	import { IS_MACOS } from '$lib/constants/platform';
+	import { rpc } from '$lib/query';
 	import { type KeyRecorder } from './create-key-recorder.svelte';
 
 	const {
@@ -99,20 +97,6 @@
 					</p>
 				</div>
 
-				{#if IS_MACOS && !isManualMode}
-					<Alert.Root variant="warning" class="text-xs">
-						<AlertTriangle class="size-4" />
-						<Alert.Title class="text-xs font-medium"
-							>macOS Option Key Note</Alert.Title
-						>
-						<Alert.Description class="text-xs">
-							Some Option+key combinations (E, I, N, U, `) may not record
-							properly. Try recording in reverse (press letter first, then
-							Option) or edit manually.
-						</Alert.Description>
-					</Alert.Root>
-				{/if}
-
 				{#if !isManualMode}
 					<!-- Recording mode -->
 					<button
@@ -193,12 +177,18 @@
 					<form
 						onsubmit={(e) => {
 							e.preventDefault();
-							if (manualValue) {
-								keyRecorder.register(
-									manualValue.split('+') as KeyboardEventSupportedKey[],
-								);
-								isManualMode = false;
+							if (!manualValue) return;
+							const { keys, invalidTokens } = parseManualShortcut(manualValue);
+							if (invalidTokens.length > 0) {
+								rpc.notify.error({
+									title: 'Invalid shortcut',
+									description: `Could not recognize: ${invalidTokens.join(', ')}. Try aliases like ctrl, cmd, option, shift, space, or a single letter / digit / punctuation key.`,
+								});
+								return;
 							}
+							if (keys.length === 0) return;
+							keyRecorder.register(keys);
+							isManualMode = false;
 						}}
 						class="space-y-3"
 					>

--- a/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/local/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/shortcuts/local/+page.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
 	import { Button } from '@epicenter/ui/button';
+	import { Label } from '@epicenter/ui/label';
 	import * as SectionHeader from '@epicenter/ui/section-header';
 	import { Separator } from '@epicenter/ui/separator';
+	import { Switch } from '@epicenter/ui/switch';
 	import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
 	import { rpc } from '$lib/query';
+	import { settings } from '$lib/state/settings.svelte';
 	import { resetLocalShortcuts } from '$routes/(app)/_layout-utils/register-commands';
 	import ShortcutFormatHelp from '../keyboard-shortcut-recorder/ShortcutFormatHelp.svelte';
 	import ShortcutTable from '../keyboard-shortcut-recorder/ShortcutTable.svelte';
@@ -33,6 +36,7 @@
 		<Button
 			variant="outline"
 			size="sm"
+			disabled={!settings.get('shortcuts.local.enabled')}
 			onclick={() => {
 				resetLocalShortcuts();
 				rpc.notify.success({
@@ -49,5 +53,32 @@
 
 	<Separator class="my-6" />
 
-	<ShortcutTable type="local" />
+	<div class="mb-6 flex items-start justify-between gap-4 rounded-md border p-4">
+		<div class="space-y-1">
+			<Label for="local-shortcuts-toggle" class="text-base font-medium">
+				Enable local shortcuts
+			</Label>
+			<p class="text-sm text-muted-foreground">
+				Off by default. Most users only need global shortcuts; the local
+				listener can interfere with recording new global combos.
+			</p>
+		</div>
+		<Switch
+			id="local-shortcuts-toggle"
+			bind:checked={
+				() => settings.get('shortcuts.local.enabled'),
+				(checked) => settings.set('shortcuts.local.enabled', checked)
+			}
+			class="shrink-0"
+		/>
+	</div>
+
+	<div
+		class={settings.get('shortcuts.local.enabled')
+			? ''
+			: 'pointer-events-none opacity-50'}
+		aria-disabled={!settings.get('shortcuts.local.enabled')}
+	>
+		<ShortcutTable type="local" />
+	</div>
 </section>

--- a/apps/whispering/src/routes/(app)/+layout.svelte
+++ b/apps/whispering/src/routes/(app)/+layout.svelte
@@ -7,6 +7,7 @@
 	import { migrateOldSettings } from '$lib/migration/migrate-settings';
 	import { rpc } from '$lib/query';
 	import { services } from '$lib/services';
+	import { settings } from '$lib/state/settings.svelte';
 	import AppLayout from './_components/AppLayout.svelte';
 	import BottomNav from './_components/BottomNav.svelte';
 	import VerticalNav from './_components/VerticalNav.svelte';
@@ -22,7 +23,10 @@
 	// Sidebar when wide, bottom bar on narrow viewports (phone, small window).
 	const isNarrow = new MediaQuery('(max-width: 767px)');
 
+	// Local shortcut listener is gated on shortcuts.local.enabled. Reads
+	// reactively so toggling the setting starts/stops the listener immediately.
 	$effect(() => {
+		if (!settings.get('shortcuts.local.enabled')) return;
 		const unlisten = services.localShortcutManager.listen();
 		return () => unlisten();
 	});

--- a/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
+++ b/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
@@ -27,6 +27,7 @@
 	import { checkForUpdates } from '../_layout-utils/check-for-updates';
 	import {
 		grandfatherLocalShortcutsEnabled,
+		migrateGlobalToggleDefaultToOptionSpace,
 		resetGlobalShortcutsToDefaultIfDuplicates,
 		resetLocalShortcutsToDefaultIfDuplicates,
 		syncGlobalShortcutsWithSettings,
@@ -63,6 +64,9 @@
 		migrationDialog.check();
 
 		if (window.__TAURI_INTERNALS__) {
+			// Seed Alt+Space toggle default for fresh installs and retire the
+			// US-only Cmd+Shift+; default for existing users; runs once via marker.
+			migrateGlobalToggleDefaultToOptionSpace();
 			syncGlobalShortcutsWithSettings();
 			resetGlobalShortcutsToDefaultIfDuplicates();
 

--- a/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
+++ b/apps/whispering/src/routes/(app)/_components/AppLayout.svelte
@@ -26,6 +26,7 @@
 	} from '../_layout-utils/check-ffmpeg';
 	import { checkForUpdates } from '../_layout-utils/check-for-updates';
 	import {
+		grandfatherLocalShortcutsEnabled,
 		resetGlobalShortcutsToDefaultIfDuplicates,
 		resetLocalShortcutsToDefaultIfDuplicates,
 		syncGlobalShortcutsWithSettings,
@@ -49,6 +50,9 @@
 		// Sync operations - run immediately, these are fast
 		window.commands = commandCallbacks;
 		window.goto = goto;
+		// Grandfather existing users with configured local shortcuts so they
+		// keep working; new installs default to local OFF (see register-commands.ts).
+		grandfatherLocalShortcutsEnabled();
 		syncLocalShortcutsWithSettings();
 		resetLocalShortcutsToDefaultIfDuplicates();
 		registerOnboarding();
@@ -97,6 +101,19 @@
 		services.blobs.audio.delete(idsToDelete);
 		// Delete recording metadata from workspace (single-scan bulk)
 		recordings.bulkDelete(idsToDelete);
+	});
+
+	// Reactive re-sync when either subsystem toggle changes. Reading the setting
+	// inside the effect creates the dependency; flipping the switch immediately
+	// (un)registers shortcuts without an app restart.
+	$effect(() => {
+		settings.get('shortcuts.local.enabled');
+		void syncLocalShortcutsWithSettings();
+	});
+	$effect(() => {
+		if (!window.__TAURI_INTERNALS__) return;
+		settings.get('shortcuts.global.enabled');
+		void syncGlobalShortcutsWithSettings();
 	});
 
 	let { children } = $props();

--- a/apps/whispering/src/routes/(app)/_layout-utils/register-commands.ts
+++ b/apps/whispering/src/routes/(app)/_layout-utils/register-commands.ts
@@ -1,6 +1,5 @@
 import { partitionResults } from 'wellcrafted/result';
 import { commands } from '$lib/commands';
-import { CommandOrAlt, CommandOrControl } from '$lib/constants/keyboard';
 import { rpc } from '$lib/query';
 import { desktopRpc } from '$lib/query/desktop';
 import type { Accelerator } from '$lib/services/desktop/global-shortcut-manager';
@@ -41,6 +40,37 @@ export function grandfatherLocalShortcutsEnabled() {
 	window.localStorage.setItem(GRANDFATHER_MARKER_KEY, 'done');
 }
 
+/**
+ * One-time migration that seeds the new `Alt+Space` toggle default and
+ * retires the old US-layout `Cmd+Shift+;` / `Ctrl+Shift+;` default.
+ *
+ * Behavior:
+ * - If the user has no toggle shortcut stored (fresh install, or never reset
+ *   to defaults), set it to `Alt+Space`.
+ * - If the user has exactly the old default stored (resolved form for either
+ *   platform), reset it to `Alt+Space` so they get a working combo on any
+ *   layout.
+ * - If the user has a custom value, leave it alone.
+ *
+ * Idempotent via a localStorage marker.
+ */
+const TOGGLE_DEFAULT_MARKER_KEY = 'whispering.shortcuts.global.toggleDefault.migrated';
+const TOGGLE_KEY = 'shortcuts.global.toggleManualRecording' as const;
+const NEW_TOGGLE_DEFAULT = 'Alt+Space';
+const OLD_TOGGLE_DEFAULTS = ['Command+Shift+;', 'Control+Shift+;'];
+
+export function migrateGlobalToggleDefaultToOptionSpace() {
+	if (window.localStorage.getItem(TOGGLE_DEFAULT_MARKER_KEY) === 'done') return;
+	const current = deviceConfig.get(TOGGLE_KEY);
+	const shouldSeed =
+		current == null ||
+		(typeof current === 'string' && OLD_TOGGLE_DEFAULTS.includes(current));
+	if (shouldSeed) {
+		deviceConfig.set(TOGGLE_KEY, NEW_TOGGLE_DEFAULT);
+	}
+	window.localStorage.setItem(TOGGLE_DEFAULT_MARKER_KEY, 'done');
+}
+
 /** Default values for in-app (local) shortcuts. Keyed by command id string. */
 const DEFAULT_LOCAL_SHORTCUTS: Record<string, string | null> = {
 	pushToTalk: 'p',
@@ -55,18 +85,31 @@ const DEFAULT_LOCAL_SHORTCUTS: Record<string, string | null> = {
 	runTransformationOnClipboard: 'r',
 };
 
-/** Default values for global OS shortcuts. Keyed by command id string. */
+/**
+ * Default values for global OS shortcuts. Keyed by command id string.
+ *
+ * One sensible default (toggle recording with Alt+Space) so the app works
+ * out of the box on any keyboard layout. The prior US-punctuation defaults
+ * (`Cmd+Shift+;`, etc.) were unusable on non-US layouts because Tauri's
+ * plugin-global-shortcut maps the accelerator to the W3C physical key code
+ * (Semicolon), which on FI / DE / other ISO layouts is a key labeled `Ö` /
+ * `Ü` / similar that the user has no reason to press.
+ *
+ * `Alt+Space` resolves to the Option-Space physical position on macOS and
+ * Alt-Space on Windows/Linux. Both are layout-independent (the spacebar is
+ * always the spacebar) and unreserved by the OS in their default state.
+ */
 const DEFAULT_GLOBAL_SHORTCUTS: Record<string, string | null> = {
-	pushToTalk: `${CommandOrAlt}+Shift+D`,
-	toggleManualRecording: `${CommandOrControl}+Shift+;`,
+	pushToTalk: null,
+	toggleManualRecording: 'Alt+Space',
 	startManualRecording: null,
 	stopManualRecording: null,
-	cancelManualRecording: `${CommandOrControl}+Shift+'`,
+	cancelManualRecording: null,
 	startVadRecording: null,
 	stopVadRecording: null,
 	toggleVadRecording: null,
-	openTransformationPicker: `${CommandOrControl}+Shift+X`,
-	runTransformationOnClipboard: `${CommandOrControl}+Shift+R`,
+	openTransformationPicker: null,
+	runTransformationOnClipboard: null,
 };
 
 type LocalShortcutKey =

--- a/apps/whispering/src/routes/(app)/_layout-utils/register-commands.ts
+++ b/apps/whispering/src/routes/(app)/_layout-utils/register-commands.ts
@@ -11,6 +11,36 @@ import {
 import { deviceConfig } from '$lib/state/device-config.svelte';
 import { settings } from '$lib/state/settings.svelte';
 
+/**
+ * Grandfather migration: users who were already on Whispering before the
+ * local-subsystem toggle landed keep `shortcuts.local.enabled = true` so their
+ * existing in-app shortcuts keep working. Fresh installs get the new default
+ * (false).
+ *
+ * Detection: we treat the user as pre-existing if EITHER (a) the prior
+ * monolithic-to-per-key migration has completed (`whispering.settings.migration
+ * === 'completed'`) OR (b) the old monolithic `whispering-settings` blob is
+ * still present (migration runs async and may not have completed yet by the
+ * time we get here on first boot of the new build). Brand-new installs match
+ * neither and stay OFF.
+ *
+ * Idempotent via its own marker so it only flips the setting once.
+ */
+const GRANDFATHER_MARKER_KEY = 'whispering.shortcuts.local.enabled.grandfathered';
+const OLD_SETTINGS_MIGRATION_KEY = 'whispering.settings.migration';
+const OLD_SETTINGS_BLOB_KEY = 'whispering-settings';
+
+export function grandfatherLocalShortcutsEnabled() {
+	if (window.localStorage.getItem(GRANDFATHER_MARKER_KEY) === 'done') return;
+	const isExistingUser =
+		window.localStorage.getItem(OLD_SETTINGS_MIGRATION_KEY) === 'completed' ||
+		window.localStorage.getItem(OLD_SETTINGS_BLOB_KEY) !== null;
+	if (isExistingUser) {
+		settings.set('shortcuts.local.enabled', true);
+	}
+	window.localStorage.setItem(GRANDFATHER_MARKER_KEY, 'done');
+}
+
 /** Default values for in-app (local) shortcuts. Keyed by command id string. */
 const DEFAULT_LOCAL_SHORTCUTS: Record<string, string | null> = {
 	pushToTalk: 'p',
@@ -73,11 +103,15 @@ function getGlobalShortcutKey(commandId: string): GlobalShortcutKey {
 
 /**
  * Synchronizes local keyboard shortcuts with the current settings.
+ * - Returns early if the local subsystem is disabled (the window listener in
+ *   +layout.svelte is already gated on the same setting, so any registrations
+ *   left in the in-memory Map are inert until the listener restarts)
  * - Registers shortcuts that have key combinations defined in settings
  * - Unregisters shortcuts that don't have key combinations defined
  * - Shows error toast if any registration/unregistration fails
  */
 export async function syncLocalShortcutsWithSettings() {
+	if (!settings.get('shortcuts.local.enabled')) return;
 	const results = await Promise.all(
 		commands
 			.map((command) => {
@@ -106,11 +140,17 @@ export async function syncLocalShortcutsWithSettings() {
 
 /**
  * Synchronizes global keyboard shortcuts with the current settings.
+ * - Tears down all OS-level registrations and returns early if the global
+ *   subsystem is disabled (so disabling actually frees the hotkeys system-wide)
  * - Registers shortcuts that have key combinations defined in settings
  * - Unregisters shortcuts that don't have key combinations defined
  * - Shows error toast if any registration/unregistration fails
  */
 export async function syncGlobalShortcutsWithSettings() {
+	if (!settings.get('shortcuts.global.enabled')) {
+		await desktopRpc.globalShortcuts.unregisterAll();
+		return;
+	}
 	const commandsWithAccelerators = commands
 		.map((command) => {
 			const accelerator = deviceConfig.get(

--- a/bun.lock
+++ b/bun.lock
@@ -157,6 +157,7 @@
         "@epicenter/auth": "workspace:*",
         "@epicenter/auth-svelte": "workspace:*",
         "@epicenter/constants": "workspace:*",
+        "@epicenter/encryption": "workspace:*",
         "@epicenter/svelte": "workspace:*",
         "@epicenter/workspace": "workspace:*",
         "@tanstack/svelte-query": "catalog:",
@@ -391,7 +392,7 @@
         "@tauri-apps/plugin-dialog": "^2.3.2",
         "@tauri-apps/plugin-fs": "catalog:",
         "@tauri-apps/plugin-global-shortcut": "^2.3.0",
-        "@tauri-apps/plugin-http": "^2.5.1",
+        "@tauri-apps/plugin-http": "2.5.4",
         "@tauri-apps/plugin-log": "~2",
         "@tauri-apps/plugin-notification": "^2.3.0",
         "@tauri-apps/plugin-opener": "catalog:",
@@ -1665,7 +1666,7 @@
 
     "@tauri-apps/plugin-global-shortcut": ["@tauri-apps/plugin-global-shortcut@2.3.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-vr40W2N6G63dmBPaha1TsBQLLURXG538RQbH5vAm0G/ovVZyXJrmZR1HF1W+WneNloQvwn4dm8xzwpEXRW560g=="],
 
-    "@tauri-apps/plugin-http": ["@tauri-apps/plugin-http@2.5.8", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-oxd7oypzQeu8kAfFCrw534Kq7Cw+NzozcnCY21O4rz3A+veJiIiuSCMIprgGcZOcLAXFP9GmDhKUbhuKWcunRw=="],
+    "@tauri-apps/plugin-http": ["@tauri-apps/plugin-http@2.5.4", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-/i4U/9za3mrytTgfRn5RHneKubZE/dwRmshYwyMvNRlkWjvu1m4Ma72kcbVJMZFGXpkbl+qLyWMGrihtWB76Zg=="],
 
     "@tauri-apps/plugin-log": ["@tauri-apps/plugin-log@2.8.0", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-a+7rOq3MJwpTOLLKbL8d0qGZ85hgHw5pNOWusA9o3cf7cEgtYHiGY/+O8fj8MvywQIGqFv0da2bYQDlrqLE7rw=="],
 

--- a/specs/20260518T121956-hotkey-overhaul.md
+++ b/specs/20260518T121956-hotkey-overhaul.md
@@ -277,33 +277,31 @@ Goal: make recording work on FI (and any) layout, make manual entry honest, stop
 
 #### Wave 3.1: Add diagnostic logging (gated by DEV)
 
-- [ ] **3.1.1** In `createPressedKeys.svelte.ts`, log `{ key: e.key, code: e.code, metaKey, altKey, ctrlKey, shiftKey }` at the top of the keydown handler, gated by `import.meta.env.DEV`.
-- [ ] **3.1.2** In `global-shortcut-manager.ts:125-133`, log the swallowed error (still swallow for now) so we can see what Tauri actually says when the user's FI keyboard tries to register the default combo.
-- [ ] **3.1.3** User runs the app with these logs on, reports back what `e.key` and `e.code` look like for the FI keycaps they care about. (Out-of-band step; pause here for evidence before writing the fix.)
+- [x] **3.1.1** `createPressedKeys.svelte.ts` keydown handler logs `{key, code, metaKey, altKey, ctrlKey, shiftKey}` via `console.debug` under `import.meta.env.DEV`. Stays on as long as we may need FI-layout evidence.
+- [x] **3.1.2** Skipped: superseded by Wave 3.4. We stopped swallowing the error entirely instead of logging it.
+- [-] **3.1.3** Skipped (per user request to bundle Phase 1-3 testing). Evidence to be gathered post-hoc by user if Phase 3 fix doesn't work first try.
 
 #### Wave 3.2: Switch capture to `e.code`-based key
 
-- [ ] **3.2.1** Introduce a `codeToAcceleratorKey(code: string)` helper in `$lib/constants/keyboard/` that maps W3C `code` values to Tauri accelerator names (`KeyA` → `A`, `Digit5` → `5`, `Semicolon` → `;`, `Minus` → `-`, `Space` → `Space`, etc.). Reference: <https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values>.
-- [ ] **3.2.2** Modify `createPressedKeys.svelte.ts` to push the code-derived key for non-modifiers; keep using `e.key` for modifier detection (`'meta'`, `'alt'`, `'control'`, `'shift'`).
-- [ ] **3.2.3** Display: in the recorder UI, label the captured key using the current `e.key` value so the user sees what is printed on their keycap. Store the code-derived value.
-- [ ] **3.2.4** Verify FI user can now record `Cmd+Shift+the-Ö-physical-key` and have it stored as `Command+Shift+;` (which is what Tauri's plugin will match against the same physical key at runtime).
+- [x] **3.2.1** New `$lib/constants/keyboard/browser/code-to-key.ts` exports `codeToLogicalKey(code)` mapping W3C codes (`Semicolon`, `Minus`, `KeyA`, `Digit0`, `F1-F24`, `Space`, arrows, navigation, editing, numpad) to the lowercase logical form (`;`, `-`, `a`, `0`, `f1`, ` `, ...). Exported from `keyboard/index.ts`.
+- [x] **3.2.2** Both keydown and keyup in `createPressedKeys.svelte.ts` now translate the non-modifier key through `codeToLogicalKey` first, falling back to `e.key` only when the code is unmapped. Modifier keys (`MODIFIER_KEYS` Set) continue to use e.key.
+- [x] **3.2.3** Display remains unchanged: the recorder UI displays the stored accelerator (which is the canonical form), not the in-progress pressedKeys. Acceptable per the spec note.
+- [-] **3.2.4** Pending user verification on FI hardware.
 
-#### Wave 3.3: Honest manual entry
+#### Wave 3.3: Honest manual entry (Option A: alias normalization)
 
-Pick A or B per Open Question 1 before starting.
-
-- [ ] **3.3.1 (A)** Add an alias-and-normalize step in `KeyboardShortcutRecorder.svelte` before splitting: `ctrl→Control`, `cmd|command|⌘→Command`, `option|opt|⌥→Option`, `alt→Alt`, `shift|⇧→Shift`, `space→Space`, etc. Case-insensitive. Surface a validation error toast if any token does not normalize.
-- [ ] **3.3.1 (B)** Replace the text input with modifier checkboxes (Cmd/Option/Ctrl/Shift) plus a key dropdown. No free-text path.
+- [x] **3.3.1 (A)** New `$lib/constants/keyboard/browser/parse-manual-shortcut.ts` exports `parseManualShortcut(input)` returning `{keys, invalidTokens}`. Alias map covers `ctrl|cmd|command|⌘|win|super|option|opt|⌥|alt|shift|⇧|altgr|space|spacebar|esc|escape|ret|return|enter|tab|bs|backspace|del|delete|ins|insert|home|end|pgup|pageup|pgdn|pagedown|up|down|left|right|arrow*`. Case-insensitive. Unmapped tokens pass through (handles `a`, `5`, `;`, `f5`, etc.).
+- [x] **3.3.1** `KeyboardShortcutRecorder.svelte` onsubmit replaces the naive split-and-cast with `parseManualShortcut`. Invalid tokens trigger an error toast naming them; empty result is a silent no-op. The obsolete macOS Option-dead-key warning is removed (e.code fixes that path too).
 
 #### Wave 3.4: Surface registration errors
 
-- [ ] **3.4.1** In `global-shortcut-manager.ts:125-133`, replace `if (registerError) return Ok(undefined);` with `if (registerError) return Err(registerError);`.
-- [ ] **3.4.2** Verify the existing error-toast plumbing in `syncGlobalShortcutsWithSettings` (`register-commands.ts:113-137`) shows the cause; if message is opaque, include the raw plugin error.
-- [ ] **3.4.3** Confirm with a deliberately-bad combo (e.g. `Cmd+Space` which macOS reserves) that the toast appears and the shortcut row reflects "not set".
+- [x] **3.4.1** `global-shortcut-manager.ts` no longer swallows `tauriRegister` errors. The previous `return Ok(undefined)` on error is replaced with `return Err(registerError)`. Comment updated to explain the prior swallow was speculative; if false positives resurface we will gate per-error rather than swallow the whole class.
+- [x] **3.4.2** Existing `syncGlobalShortcutsWithSettings` plumbing already shows the error message in a toast (`register-commands.ts:144-148`). No changes needed.
+- [-] **3.4.3** Pending user verification (try `Cmd+Space` on macOS, expect error toast).
 
 #### Wave 3.5: Cleanup
 
-- [ ] **3.5.1** Remove or hide the diagnostic logging from 3.1 once 3.2-3.4 are verified. If keeping, gate fully behind `import.meta.env.DEV`.
+- [ ] **3.5.1** Diagnostic log left in place behind `import.meta.env.DEV` (no-op in production builds). Pull out in a follow-up commit once FI verification is confirmed clean.
 
 ## Edge Cases
 
@@ -355,6 +353,8 @@ Pick A or B per Open Question 1 before starting.
 - Keep `OPTION_KEY_CHARACTER_MAP` for now: constraint is that even with Phase 2.2 in place, users on the macOS Safari/WebView combo may still get layout-dependent characters in edge cases (Option held while typing). Revisit when: confirmed via the Phase 2.1 logs that `e.code` is reliably populated in the Tauri webview.
 - Keep duplicated Switch-block markup in `local/+page.svelte` and `global/+page.svelte`: constraint is two instances do not justify a shared component yet; extraction would be premature abstraction. Revisit when: a third subsystem toggle is added anywhere in settings.
 - Phase 1 invariant: `syncLocalShortcutsWithSettings` is a no-op while `shortcuts.local.enabled === false`. The window listener is gated on the same setting in `+layout.svelte`. Flipping the toggle back to true re-runs the sync (via reactive `$effect` in `AppLayout.svelte`) and re-mounts the listener.
+- Keep `OPTION_KEY_CHARACTER_MAP` and `OPTION_DEAD_KEYS`: constraint is that they are no longer needed for the recorder path (e.code translation in `createPressedKeys.svelte.ts` bypasses Option dead keys and per-layout characters). `OPTION_KEY_CHARACTER_MAP` is still wired as a defensive fallback in `createPressedKeys`. `OPTION_DEAD_KEYS` is unused dead code. Revisit when: cleaning up after FI-keyboard verification confirms e.code is reliably populated in the Tauri webview.
+- Local shortcut manager (`local-shortcut-manager.ts`) was not updated to use e.code in Phase 3. It still uses raw `e.key`. Grandfathered users with local enabled will see the layout-blind capture there. Revisit when: a user reports the issue on local shortcuts, OR when removing local hotkeys is reconsidered.
 
 ## Success Criteria
 

--- a/specs/20260518T121956-hotkey-overhaul.md
+++ b/specs/20260518T121956-hotkey-overhaul.md
@@ -263,11 +263,11 @@ Commit boundary: Phase 1 ships as one PR.
 
 Goal: give the FI user (and everyone else on non-US layouts) a working default that doesn't depend on US punctuation positions.
 
-- [ ] **2.1** In `register-commands.ts`, replace `DEFAULT_GLOBAL_SHORTCUTS` with `{ toggleManualRecording: 'Alt+Space' }`; set all other entries to `null`.
-- [ ] **2.2** Verify the legacy-replacement code at `query/desktop/shortcuts.ts:25-28` leaves `Alt` as `Alt` on macOS (it should; Alt is the W3C name and Tauri's plugin handles platform rendering). If not, hardcode `Option+Space` for macOS.
-- [ ] **2.3** Conditional migration: if the user's stored `shortcuts.global.toggleManualRecording` equals the literal old default (`Command+Shift+;`) AND registration for that combo failed on the last app start, reset it to the new default. (Less surprising than a blind reset; see Open Question 3.)
-- [ ] **2.4** Update any docs/help text mentioning the old defaults.
-- [ ] **2.5** Smoke-test on FI keyboard: fresh install → press Option+Space → recording toggles.
+- [x] **2.1** `DEFAULT_GLOBAL_SHORTCUTS` rewritten in `register-commands.ts`: `{ toggleManualRecording: 'Alt+Space' }`, all others `null`.
+- [x] **2.2** Legacy replacement at `query/desktop/shortcuts.ts:25-28` only rewrites `CommandOrControl`; `Alt` passes through unchanged. Tauri's `plugin-global-shortcut` accepts `Alt` and routes it to the Option key on macOS automatically (Alt is the W3C name).
+- [x] **2.3** `migrateGlobalToggleDefaultToOptionSpace()` added: idempotent (localStorage marker), reseats `toggleManualRecording` to `Alt+Space` only when the current value is null OR exactly the old default (`Command+Shift+;` / `Control+Shift+;`). Custom user values are preserved. Wired into `AppLayout.svelte` onMount before `syncGlobalShortcutsWithSettings()`.
+- [x] **2.4** No user-facing docs reference the old default (grep on README and code confirmed only an internal comment). Nothing to update.
+- [ ] **2.5** Smoke-test on FI keyboard: fresh install → press Option+Space → recording toggles. (User to verify alongside Phase 1 and Phase 3.)
 
 Commit boundary: Phase 2 ships as one PR.
 

--- a/specs/20260518T121956-hotkey-overhaul.md
+++ b/specs/20260518T121956-hotkey-overhaul.md
@@ -1,0 +1,386 @@
+# Whispering Hotkey Overhaul
+
+**Date**: 2026-05-18
+**Status**: Draft
+**Author**: AI-assisted (with Mika Rummukainen)
+**Branch**: TBD (suggested: `fix/whispering-hotkeys`)
+
+## Overview
+
+Make Whispering's hotkey system usable on non-US keyboard layouts and macOS by gating each hotkey subsystem (local, global) behind a user-facing toggle with local defaulting OFF, shipping a single sensible global default (Option+Space toggle), fixing the recorder's layout-blind capture, and surfacing registration errors that are currently swallowed. Local hotkeys stay in the codebase; users who want them can flip the switch on.
+
+## Motivation
+
+### Current State
+
+Whispering ships two parallel hotkey subsystems, both bound to `window`:
+
+```
+                          window keydown / keyup
+                                    │
+                ┌───────────────────┴────────────────────┐
+                ▼                                        ▼
+   LocalShortcutManagerLive               createPressedKeys (recorder UI)
+   local-shortcut-manager.ts:69-218       createPressedKeys.svelte.ts:60-136
+   (registered at +layout.svelte:26)      (registered while popover is open)
+```
+
+Defaults at `src/routes/(app)/_layout-utils/register-commands.ts:15-40`:
+
+```ts
+const DEFAULT_LOCAL_SHORTCUTS = {
+  pushToTalk: 'p', toggleManualRecording: ' ', cancelManualRecording: 'c',
+  toggleVadRecording: 'v', openTransformationPicker: 't',
+  runTransformationOnClipboard: 'r', ...
+};
+
+const DEFAULT_GLOBAL_SHORTCUTS = {
+  pushToTalk: `${CommandOrAlt}+Shift+D`,
+  toggleManualRecording: `${CommandOrControl}+Shift+;`,
+  cancelManualRecording: `${CommandOrControl}+Shift+'`,
+  openTransformationPicker: `${CommandOrControl}+Shift+X`,
+  runTransformationOnClipboard: `${CommandOrControl}+Shift+R`,
+  ...
+};
+```
+
+Recorder capture pipeline:
+
+```
+e.key (layout-dependent character)
+    │
+    ▼ toLowerCase + Option-character map (US-only)
+isSupportedKey(key)  ─── fails for ö/ä/etc. ───▶  onUnsupportedKey, dropped
+    │
+    ▼ pressedKeysToTauriAccelerator
+convertToModifier switch:  cases are 'control' | 'shift' | 'alt' | 'meta' | ...
+    │                      (no 'ctrl', 'cmd', 'command', 'option')
+    ▼
+tauriRegister(accelerator)  ─── any error is silently swallowed at line 125-133
+```
+
+This creates problems:
+
+1. **Local shortcuts fire while editing global shortcuts.** Both listeners are siblings on `window`. The recorder popover focuses a `<button>`, not an input, so `isTypingInInput()` (`local-shortcut-manager.ts:278-312`) returns false. `preventDefault()` doesn't stop sibling listeners; `stopImmediatePropagation` is never called. Pressing keys to record a combo also triggers the local action bound to those keys.
+2. **Finnish (and other non-US) layouts cannot record punctuation shortcuts.** `e.key` returns layout-dependent characters. On FI ISO, the physical Semicolon-position key produces `Ö`. `'ö'` is not in `OPTION_KEY_CHARACTER_MAP` (`macos-option-key-map.ts:9-50`, US-only) and not in `KEYBOARD_EVENT_SUPPORTED_KEYS`. The key is rejected, recording fails with `NoKeyCode`.
+3. **Manual text entry silently drops aliases.** `KeyboardShortcutRecorder.svelte:197-199` does `manualValue.split('+') as KeyboardEventSupportedKey[]` with zero validation. `convertToModifier` (`global-shortcut-manager.ts:276-317`) is a case-sensitive switch with only the W3C key names (`control`/`shift`/`alt`/`meta`/...). User types matching the placeholder ("e.g., ctrl+shift+a") drop `ctrl`/`cmd`/`command`/`option` entirely, leaving the bare key as the accelerator.
+4. **macOS Option dead keys (E, I, N, U, `) cannot be recorded.** The UI warns about this (`KeyboardShortcutRecorder.svelte:108`) but nothing handles it. `OPTION_DEAD_KEYS` is defined in code (`macos-option-key-map.ts:82`) and never imported anywhere.
+5. **Registration failures are silently swallowed.** `global-shortcut-manager.ts:125-133` returns `Ok(undefined)` on every `tauriRegister` error. Real failures (OS-reserved combo, parser rejection, conflict) produce a "shortcut saved" UX with no actual binding.
+6. **Default combos are US-layout-specific.** `Cmd+Shift+;`, `Cmd+Shift+'`, `Cmd+Shift+X` all assume US ANSI. On FI ISO, those physical positions produce different characters and the on-screen labels mean a different key than the one that will trigger.
+
+### Desired State
+
+Two opt-in subsystems with explicit settings toggles. Local hotkeys default OFF (most users don't need them and they cause bug #1's interference). Global hotkeys default ON. One sensible global default (Option+Space toggles recording). Recorder captures the physical key so layout doesn't matter. Manual entry accepts common aliases or rejects with a clear error. Registration failures surface as errors instead of "saved" lies.
+
+```ts
+// Target defaults
+const DEFAULT_GLOBAL_SHORTCUTS = {
+  toggleManualRecording: 'Alt+Space',  // platform-aliased to Option+Space on macOS
+  // everything else: null. User adds combos they actually want.
+};
+
+// New settings entries
+shortcuts.local.enabled  = false  // OFF by default
+shortcuts.global.enabled = true   // ON by default
+```
+
+## Research Findings
+
+### How other transcription apps handle this
+
+| App | Toggle recording | Cancel | Notes |
+| --- | --- | --- | --- |
+| Superwhisper | Configurable; common: hold Fn or Option | Esc (window-local) | Single combo by default, holds and toggles |
+| MacWhisper | Configurable; defaults to a function-row key | Window-local close | Aggressively avoids US-punctuation defaults |
+| Wispr Flow | Hold Fn or Right Option | Releases on key-up | Single physical-key default |
+| Whispering (current) | Cmd+Shift+; (US-only) | Cmd+Shift+' (US-only) | Plus four more defaults, plus local duplicates |
+
+**Key finding**: Mature apps ship one default combo and leave the rest empty. They prefer modifier+space or modifier+function-key because both work on every Latin keyboard layout. None of them ship a default that depends on US-only punctuation positions.
+
+**Implication**: Reducing defaults to one Alt+Space combo is the conservative, layout-portable choice and matches the dominant pattern in this category.
+
+### What Tauri's `plugin-global-shortcut` actually expects
+
+Underlying crate: `global-hotkey` (used by Tauri v2 plugin). Accelerator strings are parsed into a `HotKey` struct that uses W3C `KeyboardEvent.code` values for the non-modifier portion (`Semicolon`, `Minus`, `Space`, `KeyA`, etc.). These are **physical key positions**, not layout-dependent characters. The same physical key on US and FI keyboards has the same `code` even though `key` differs.
+
+**Implication**: The capture path must use `e.code` (physical) for the non-modifier key, not `e.key` (logical). `e.key` is fine for the modifier keys themselves (`'Meta'`, `'Alt'`, etc.) and for the *displayed* label.
+
+### What `KeyboardEvent.code` looks like on different physical keys
+
+| Physical key | `e.code` | `e.key` on US | `e.key` on FI ISO |
+| --- | --- | --- | --- |
+| The "Semicolon" position | `Semicolon` | `;` / `:` | `ö` / `Ö` |
+| The "Minus" position | `Minus` | `-` / `_` | `+` / `?` |
+| Spacebar | `Space` | ` ` | ` ` |
+| Letter A | `KeyA` | `a` / `A` | `a` / `A` |
+| Left Option | `AltLeft` | `Alt` | `Alt` |
+
+**Implication**: Capturing `e.code` and translating it back to a Tauri accelerator name (`KeyA` → `A`, `Semicolon` → `;`, `Minus` → `-`) gives consistent behavior across layouts. The displayed label can still use `e.key` so the user sees the character on their keycap.
+
+## Design Decisions
+
+| Decision | Class | Choice | Rationale |
+| --- | --- | --- | --- |
+| Gate each hotkey subsystem behind a setting | 3 taste | Toggle (not removal) | User preference: preserve the code path for the minority who want local hotkeys; default local OFF, global ON. Symmetric so either can be disabled independently. |
+| Default local hotkeys to OFF for new installs; grandfather existing users | 3 taste | Grandfather | User decided: existing users with at least one local shortcut configured keep local=ON; only fresh installs and users with no local shortcuts default to OFF. Preserves existing workflows; accepts that power users still face bug #2 until they discover the toggle. |
+| Settings storage for the two new toggles | 2 coherence | Synced user settings | User decided: lives in the same store as `analytics.enabled` etc., not deviceConfig. Toggle is a preference, not a per-machine concern. |
+| Capture key via `e.code` (physical) instead of `e.key` | 1 evidence | `e.code` | Verified that Tauri's `plugin-global-shortcut` uses W3C `code` namespace under the hood; `e.key` is layout-dependent. |
+| Default global combo | 2 coherence | `Alt+Space` only | Matches Superwhisper/Wispr pattern; Alt+Space is unreserved on macOS/Win/Linux; no other defaults to reduce surprise. |
+| Cancel-recording default combo | Deferred | Open question | Esc is unreliable as a global hotkey; needs explicit user call. See Open Questions. |
+| Surface `tauriRegister` errors | 2 coherence | Stop swallowing | Current behavior misleads users; the "RegisterEventHotKey false-positive" claim is unsubstantiated. Show real errors. |
+| Manual entry: alias map or restructured UI | Deferred | Open question | Two viable paths with different effort. See Open Questions. |
+| Diagnostic logging | 3 taste | Add early, behind gate, remove or hide before merge | User asked for it; helps verify FI keyboard fix; gated by `import.meta.env.DEV` so production stays quiet. |
+| macOS Option dead-key handling | 3 taste | Show clearer recorder message, do not invest in fix | Real fix requires reading `e.code` (already in scope for the layout fix), which incidentally resolves this. No extra work needed if Phase 2 lands. |
+| Security hardening from prior audit | 2 coherence | Defer to separate branch | User explicitly scoped it out; not entangled with hotkey logic. |
+
+## Architecture
+
+### Before
+
+```
+window keydown/keyup
+   │
+   ├──▶ LocalShortcutManagerLive ──▶ shortcuts Map ──▶ in-app actions
+   │    (always listening,                              (interferes with recorder)
+   │     isTypingInInput guard
+   │     misses non-input focus)
+   │
+   └──▶ createPressedKeys (recorder, when popover open)
+        e.key.toLowerCase()  ──▶  pressedKeysToTauriAccelerator
+                                    │
+                                    ▼
+                                 tauriRegister(accelerator) ──▶ OS
+                                    error swallowed at line 125-133
+```
+
+### After
+
+```
+settings.shortcuts.local.enabled  (default false)
+settings.shortcuts.global.enabled (default true)
+                │
+                ▼
+window keydown/keyup
+   │
+   ├──▶ LocalShortcutManagerLive (only if local.enabled)
+   │    same code as today; just conditionally mounted
+   │
+   └──▶ createPressedKeys (recorder, when popover open)
+        e.code (physical)        ──▶ codeToAcceleratorKey (KeyA -> A, Semicolon -> ;)
+        e.metaKey/altKey/...     ──▶ modifier list
+                                    │
+                                    ▼
+                                 pressedKeysToTauriAccelerator
+                                    │
+                                    ▼
+                                 tauriRegister(accelerator)         ──▶ OS
+                                 (only if global.enabled at sync time)
+                                    error: shown in toast with the actual cause
+```
+
+### File-by-file impact
+
+```
+NEW SETTINGS  shortcuts.local.enabled  : boolean = false
+              shortcuts.global.enabled : boolean = true
+              (added to settings schema; persist in synced user settings, not deviceConfig,
+              so the preference travels with the user)
+
+EDIT    src/routes/(app)/+layout.svelte
+          wrap services.localShortcutManager.listen() in an $effect that reads
+          settings.get('shortcuts.local.enabled') and starts/stops accordingly
+EDIT    src/routes/(app)/(config)/settings/shortcuts/local/+page.svelte
+          add a master Switch at the top of the local table; when off, show explainer
+EDIT    src/routes/(app)/(config)/settings/shortcuts/global/+page.svelte
+          same: master Switch for global; when off, unregister all and show explainer
+EDIT    src/routes/(app)/_layout-utils/register-commands.ts
+          syncLocalShortcutsWithSettings: early-return if local.enabled is false
+          syncGlobalShortcutsWithSettings: early-return + unregisterAll if global.enabled is false
+          shrink DEFAULT_GLOBAL_SHORTCUTS to { toggleManualRecording: 'Alt+Space' }
+EDIT    src/lib/state/settings.svelte.ts (or equivalent)
+          add the two new settings entries
+EDIT    src/lib/utils/createPressedKeys.svelte.ts
+          capture e.code-based key alongside (or instead of) e.key
+EDIT    src/lib/services/desktop/global-shortcut-manager.ts
+          (1) stop swallowing tauriRegister errors at line 125-133
+          (2) accept code-derived keys in convertToKeyCode
+EDIT    src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/KeyboardShortcutRecorder.svelte
+          either: add alias normalization for manual entry
+          or:    replace manual input with structured editor (see Open Questions)
+
+KEEP    src/lib/services/local-shortcut-manager.ts (no changes)
+KEEP    src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/LocalKeyboardShortcutRecorder.svelte
+        (kept so users who flip local back on have a functional editor)
+```
+
+## Implementation Plan
+
+Three phases, ordered for fastest user value:
+
+- Phase 1: Gating (small, fully resolves bug #2 in the default-OFF case)
+- Phase 2: Sensible default (small, gives FI users a working out-of-box combo)
+- Phase 3: Capture pipeline fix (largest, unlocks custom combos on any layout)
+
+Each phase is a separate PR / merge commit so any can be reverted independently.
+
+### Phase 1: Gate hotkey subsystems behind toggles
+
+Goal: stop the local listener from interfering with the recorder for the 95% of users who don't use local hotkeys, without removing the feature.
+
+#### Wave 1.1: Add settings entries
+
+- [x] **1.1.1** Added `shortcuts.local.enabled` (default `false`) and `shortcuts.global.enabled` (default `true`) to `apps/whispering/src/lib/workspace/definition.ts` in the `shortcuts` group.
+- [x] **1.1.2** Entries flow through `whisperingKv` → `settings` store; reactive via the existing SvelteMap observer.
+
+#### Wave 1.2: Gate the listeners
+
+- [x] **1.2.1** `+layout.svelte` effect now reads `settings.get('shortcuts.local.enabled')` and only starts the listener when true. Cleanup returned conditionally.
+- [x] **1.2.2** `syncLocalShortcutsWithSettings()` early-returns if local disabled. Map registrations are inert without the listener; flip back ON re-runs the sync.
+- [x] **1.2.3** `syncGlobalShortcutsWithSettings()` calls `desktopRpc.globalShortcuts.unregisterAll()` and early-returns when global disabled, freeing OS hotkeys.
+- [x] **1.2.4** Two `$effect`s in `AppLayout.svelte` re-run sync on toggle change.
+
+#### Wave 1.3: UI toggles
+
+- [x] **1.3.1** Master Switch added to `local/+page.svelte`. Table dimmed via `pointer-events-none opacity-50` when OFF. Reset-to-defaults button disabled when OFF.
+- [x] **1.3.2** Same pattern in `global/+page.svelte`.
+- [x] **1.3.3** Toggle changes propagate via reactive effects; no restart needed (pending manual verification by user).
+
+#### Wave 1.4: Grandfather migration
+
+- [x] **1.4.1** `grandfatherLocalShortcutsEnabled()` runs once via `whispering.shortcuts.local.enabled.grandfathered` localStorage marker. Detects existing users via `whispering.settings.migration === 'completed'` OR presence of the old `whispering-settings` blob (handles the async race with `migrateOldSettings`).
+- [x] **1.4.2** Fresh installs match neither signal → stay at default `false`.
+
+#### Wave 1.5: Verify
+
+- [ ] **1.5.1** `bun run typecheck` and `bun run build` pass for `apps/whispering`. (User to run; bun not available in agent env.)
+- [ ] **1.5.2** Manual smoke: fresh install → local tab shows OFF → open global shortcut editor → record a combo → no local action fires.
+- [ ] **1.5.3** Manual smoke: flip local ON → set a local shortcut → confirm it fires.
+- [ ] **1.5.4** Manual smoke: flip global OFF → confirm registered global shortcuts no longer fire systemwide → flip back ON → confirm they fire again.
+
+Commit boundary: Phase 1 ships as one PR.
+
+### Phase 2: Sensible default (Option+Space)
+
+Goal: give the FI user (and everyone else on non-US layouts) a working default that doesn't depend on US punctuation positions.
+
+- [ ] **2.1** In `register-commands.ts`, replace `DEFAULT_GLOBAL_SHORTCUTS` with `{ toggleManualRecording: 'Alt+Space' }`; set all other entries to `null`.
+- [ ] **2.2** Verify the legacy-replacement code at `query/desktop/shortcuts.ts:25-28` leaves `Alt` as `Alt` on macOS (it should; Alt is the W3C name and Tauri's plugin handles platform rendering). If not, hardcode `Option+Space` for macOS.
+- [ ] **2.3** Conditional migration: if the user's stored `shortcuts.global.toggleManualRecording` equals the literal old default (`Command+Shift+;`) AND registration for that combo failed on the last app start, reset it to the new default. (Less surprising than a blind reset; see Open Question 3.)
+- [ ] **2.4** Update any docs/help text mentioning the old defaults.
+- [ ] **2.5** Smoke-test on FI keyboard: fresh install → press Option+Space → recording toggles.
+
+Commit boundary: Phase 2 ships as one PR.
+
+### Phase 3: Fix global hotkey capture and surface errors
+
+Goal: make recording work on FI (and any) layout, make manual entry honest, stop hiding errors.
+
+#### Wave 3.1: Add diagnostic logging (gated by DEV)
+
+- [ ] **3.1.1** In `createPressedKeys.svelte.ts`, log `{ key: e.key, code: e.code, metaKey, altKey, ctrlKey, shiftKey }` at the top of the keydown handler, gated by `import.meta.env.DEV`.
+- [ ] **3.1.2** In `global-shortcut-manager.ts:125-133`, log the swallowed error (still swallow for now) so we can see what Tauri actually says when the user's FI keyboard tries to register the default combo.
+- [ ] **3.1.3** User runs the app with these logs on, reports back what `e.key` and `e.code` look like for the FI keycaps they care about. (Out-of-band step; pause here for evidence before writing the fix.)
+
+#### Wave 3.2: Switch capture to `e.code`-based key
+
+- [ ] **3.2.1** Introduce a `codeToAcceleratorKey(code: string)` helper in `$lib/constants/keyboard/` that maps W3C `code` values to Tauri accelerator names (`KeyA` → `A`, `Digit5` → `5`, `Semicolon` → `;`, `Minus` → `-`, `Space` → `Space`, etc.). Reference: <https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values>.
+- [ ] **3.2.2** Modify `createPressedKeys.svelte.ts` to push the code-derived key for non-modifiers; keep using `e.key` for modifier detection (`'meta'`, `'alt'`, `'control'`, `'shift'`).
+- [ ] **3.2.3** Display: in the recorder UI, label the captured key using the current `e.key` value so the user sees what is printed on their keycap. Store the code-derived value.
+- [ ] **3.2.4** Verify FI user can now record `Cmd+Shift+the-Ö-physical-key` and have it stored as `Command+Shift+;` (which is what Tauri's plugin will match against the same physical key at runtime).
+
+#### Wave 3.3: Honest manual entry
+
+Pick A or B per Open Question 1 before starting.
+
+- [ ] **3.3.1 (A)** Add an alias-and-normalize step in `KeyboardShortcutRecorder.svelte` before splitting: `ctrl→Control`, `cmd|command|⌘→Command`, `option|opt|⌥→Option`, `alt→Alt`, `shift|⇧→Shift`, `space→Space`, etc. Case-insensitive. Surface a validation error toast if any token does not normalize.
+- [ ] **3.3.1 (B)** Replace the text input with modifier checkboxes (Cmd/Option/Ctrl/Shift) plus a key dropdown. No free-text path.
+
+#### Wave 3.4: Surface registration errors
+
+- [ ] **3.4.1** In `global-shortcut-manager.ts:125-133`, replace `if (registerError) return Ok(undefined);` with `if (registerError) return Err(registerError);`.
+- [ ] **3.4.2** Verify the existing error-toast plumbing in `syncGlobalShortcutsWithSettings` (`register-commands.ts:113-137`) shows the cause; if message is opaque, include the raw plugin error.
+- [ ] **3.4.3** Confirm with a deliberately-bad combo (e.g. `Cmd+Space` which macOS reserves) that the toast appears and the shortcut row reflects "not set".
+
+#### Wave 3.5: Cleanup
+
+- [ ] **3.5.1** Remove or hide the diagnostic logging from 3.1 once 3.2-3.4 are verified. If keeping, gate fully behind `import.meta.env.DEV`.
+
+## Edge Cases
+
+### Option+Space conflicts with another app's hotkey
+
+1. User has Raycast or Spotlight (with custom binding) on Option+Space.
+2. Tauri's `register("Alt+Space")` returns an error or registers but never fires.
+3. With Phase 2.4 in place, the user sees a toast on app start: "Could not register Alt+Space (already in use)".
+4. The settings page shows the combo as unregistered.
+
+### Existing user has customized `toggleManualRecording`
+
+1. User has `Cmd+Shift+;` working (US keyboard) or has set a custom combo.
+2. Phase 3 migration logic: only reset if value equals the *literal old default*. Custom values left alone.
+
+### User on FI ISO records a shortcut, then a US-layout user runs the same install
+
+1. FI user records `Cmd+Shift+the-Ö-physical-key`. Stored as `Command+Shift+;`.
+2. The install is portable (deviceConfig is per-machine, per the existing design at `device-config.svelte.ts:25`), so this is mostly a non-issue. But if config syncs (it does not today), the US user would see `Cmd+Shift+;` and physical Semicolon would trigger; same physical position; consistent.
+
+### `e.code` is empty (older browsers, some Linux X11 quirks)
+
+1. Recorder falls back to `e.key`-based detection if `e.code` is empty.
+2. Surface a debug log; this should not happen in the bundled webview but worth defending against.
+
+### Recording while another popover or dialog is open
+
+1. Out of scope; the recorder is the only consumer of `createPressedKeys` now that local hotkeys are gone.
+
+## Open Questions
+
+1. **Cancel-recording default combo: ship one or not?**
+   - Options: (a) ship nothing, user adds if they want; (b) `Alt+Shift+Space`; (c) `Alt+Esc`.
+   - **Recommendation**: (a). User said "what else do you really need to get started — maybe none?". Ship one combo (toggle), let the user discover they want cancel and add it. Less is more.
+2. **Manual entry: alias normalization (3.3.1 A) or structured editor (3.3.1 B)?**
+   - (A) is ~30 lines, preserves muscle memory of typing combos, but always has edge cases (`win`? `super`? `⌘`?).
+   - (B) is ~80 lines but eliminates the entire class of invalid-input bugs and is more accessible. Most modern apps (Raycast, Linear) use this.
+   - **Recommendation**: (B). The manual-entry path is the bug origin and a structured editor closes it permanently. (A) is acceptable as a stopgap if (B) feels like scope creep.
+3. **`pushToTalk` as a global hotkey: is the current architecture able to deliver press vs release events reliably across OSes?**
+   - The existing `on: ShortcutEventState[]` plumbing distinguishes `'Pressed'` from `'Released'` for local shortcuts. Tauri's global-shortcut plugin emits a single event on activation; press/release semantics differ by OS.
+   - **Recommendation**: Defer. PTT-as-global is its own design problem, not blocking the current bugs.
+4. **Default-OFF for existing users with configured local hotkeys: silent flip, one-time toast, or grandfather them in?**
+   - **Resolved**: Grandfather. Users with at least one local shortcut configured keep local=ON; everyone else (including fresh installs) defaults to OFF. See Wave 1.4 for the migration mechanism.
+
+## Decisions Log
+
+- Keep `DEFAULT_GLOBAL_SHORTCUTS` as a map rather than a single string constant: constraint is that the schema in `register-commands.ts` already iterates `commands` and looks up by command id; turning it into a single value would require a separate code path. Revisit when: the commands list is refactored to a tagged-union shape that includes its own default metadata.
+- Keep `CommandOrAlt`/`CommandOrControl` aliases: constraint is that they are still referenced from a handful of comments/docs and from `query/desktop/shortcuts.ts:25-28`. Revisit when: those references are gone and only literal `Alt`/`Command`/`Control` strings remain in defaults.
+- Keep `OPTION_KEY_CHARACTER_MAP` for now: constraint is that even with Phase 2.2 in place, users on the macOS Safari/WebView combo may still get layout-dependent characters in edge cases (Option held while typing). Revisit when: confirmed via the Phase 2.1 logs that `e.code` is reliably populated in the Tauri webview.
+- Keep duplicated Switch-block markup in `local/+page.svelte` and `global/+page.svelte`: constraint is two instances do not justify a shared component yet; extraction would be premature abstraction. Revisit when: a third subsystem toggle is added anywhere in settings.
+- Phase 1 invariant: `syncLocalShortcutsWithSettings` is a no-op while `shortcuts.local.enabled === false`. The window listener is gated on the same setting in `+layout.svelte`. Flipping the toggle back to true re-runs the sync (via reactive `$effect` in `AppLayout.svelte`) and re-mounts the listener.
+
+## Success Criteria
+
+- [ ] Two settings toggles exist and work: `shortcuts.local.enabled` (default OFF), `shortcuts.global.enabled` (default ON). Flipping either takes effect immediately.
+- [ ] With local OFF, recording a global shortcut does not trigger any in-app action (bug #2 resolved by default).
+- [ ] With local ON, local shortcuts work the same as today.
+- [ ] FI keyboard user can record a global shortcut on a punctuation key (verified by user testing on their machine).
+- [ ] Manual entry of `ctrl+shift+a` (or whatever the chosen normalization accepts) registers the intended combo. Manual entry of garbage produces a visible error.
+- [ ] A deliberately-failing registration (e.g. `Cmd+Space` on macOS) produces a user-visible error toast instead of silent "saved".
+- [ ] Fresh install: `Option+Space` toggles recording on macOS, `Alt+Space` toggles on Win/Linux. No other defaults.
+- [ ] Existing users on customized combos are not disrupted.
+- [ ] `bun run typecheck` and `bun run build` pass for `apps/whispering`.
+- [ ] No new dependencies added.
+
+## References
+
+- `apps/whispering/src/routes/(app)/+layout.svelte:26-28` (kill site for local listener)
+- `apps/whispering/src/lib/services/local-shortcut-manager.ts` (whole file, slated for deletion)
+- `apps/whispering/src/lib/utils/createPressedKeys.svelte.ts:60-136` (capture pipeline)
+- `apps/whispering/src/lib/services/desktop/global-shortcut-manager.ts` (accelerator builder; lines 117, 125-133, 208-248, 276-357)
+- `apps/whispering/src/routes/(app)/(config)/settings/shortcuts/keyboard-shortcut-recorder/KeyboardShortcutRecorder.svelte:194-202` (manual entry bug)
+- `apps/whispering/src/routes/(app)/_layout-utils/register-commands.ts:15-40` (defaults)
+- `apps/whispering/src/lib/constants/keyboard/macos-option-key-map.ts` (option-char map, OPTION_DEAD_KEYS dead code)
+- `apps/whispering/src/lib/constants/platform/is-macos.ts` (platform constant)
+- W3C `KeyboardEvent.code` reference: <https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values>
+
+## Review
+
+(To be filled in after implementation.)

--- a/specs/20260518T121956-hotkey-overhaul.md
+++ b/specs/20260518T121956-hotkey-overhaul.md
@@ -383,4 +383,67 @@ Goal: make recording work on FI (and any) layout, make manual entry honest, stop
 
 ## Review
 
-(To be filled in after implementation.)
+**Status**: Implemented across 3 commits on branch `fix/whispering-hotkeys`. Pending user smoke test (combined Phase 1+2+3 verification per user request).
+
+### Commits
+
+```
+c2c6b7a4d  fix(whispering): make global hotkey capture layout-independent       (Phase 3)
+52833f158  feat(whispering): ship Alt+Space as the only global hotkey default   (Phase 2)
+438ca3653  feat(whispering): gate hotkey subsystems behind toggles              (Phase 1)
+```
+
+### What landed
+
+**Phase 1: Subsystem toggles** (6 files modified, ~520 lines including spec)
+- Two new settings: `shortcuts.local.enabled` (default `false`), `shortcuts.global.enabled` (default `true`).
+- Local listener mounts only when enabled. Global registrations unregister system-wide when disabled. Reactive `$effect`s re-sync on toggle change.
+- Master `Switch` on each shortcuts settings page; reset-to-defaults button disabled when subsystem off.
+- Grandfather migration: existing users (detected via prior migration marker OR presence of old `whispering-settings` blob) keep local enabled; fresh installs get OFF.
+
+**Phase 2: Sensible default** (3 files modified, ~60 lines)
+- `DEFAULT_GLOBAL_SHORTCUTS` reduced to `{ toggleManualRecording: 'Alt+Space' }`; all others `null`.
+- One-shot `migrateGlobalToggleDefaultToOptionSpace()` seeds `Alt+Space` when toggle is null OR exactly matches the old `Cmd+Shift+;` / `Ctrl+Shift+;` default. Custom user values preserved.
+- Removed unused `CommandOrAlt`/`CommandOrControl` imports from `register-commands.ts`.
+
+**Phase 3: Layout-independent capture + honest errors** (7 files, 268 lines incl. 2 new helpers)
+- New `codeToLogicalKey(code)` translates W3C `KeyboardEvent.code` values to canonical lowercase keys. Used in both keydown and keyup of `createPressedKeys` for non-modifier keys.
+- New `parseManualShortcut(input)` normalizes user-friendly aliases (`ctrl`, `cmd`, `option`, `space`, etc.) and returns invalid tokens for visible error feedback.
+- `tauriRegister` errors now propagate to the existing toast plumbing instead of being swallowed.
+- DEV-gated `console.debug` log on every keydown captures `{key, code, modifiers}` for diagnosing layout edge cases.
+- Removed obsolete macOS Option-dead-key warning from the recorder (e.code bypasses it).
+
+### Post-implementation review findings
+
+| Phase | Issue | Severity | Disposition |
+|---|---|---|---|
+| 1 | Initial double-sync on cold mount (onMount + reactive effect both fire) | low | Acceptable; idempotent. Could simplify in a future cleanup. |
+| 1 | Toggle UI markup duplicated across local/global pages | medium | Two instances does not justify extraction. Decisions Log entry to revisit if a third toggle appears. |
+| 1 | Local-listener gating means local Map can drift from settings while subsystem is off | medium | Documented as an invariant: sync is no-op while off; flip-to-on re-runs sync. No data corruption possible since UI is disabled. |
+| 2 | `OLD_TOGGLE_DEFAULTS` hardcodes two strings | low | Acceptable: those are the only two values the old default ever resolved to. |
+| 3 | `OPTION_KEY_CHARACTER_MAP` is now mostly fallback-only; `OPTION_DEAD_KEYS` still unused dead code | low | Leave as defensive fallback until FI verification confirms e.code is reliably populated. |
+| 3 | Local shortcut manager (`local-shortcut-manager.ts`) still uses raw `e.key` | low | Out of scope per user direction. Grandfathered local users will not benefit from the FI fix on local shortcuts. |
+| 3 | DEV-gated log does not fire in production builds | medium | Communicated as a constraint; user runs dev for diagnostics. |
+
+### What was deliberately not done
+
+- Security hardening from prior audit (CSP, capability narrowing) — scoped to a separate branch per user direction.
+- `pushToTalk` as a global hotkey — deferred (different press/release semantics across OSes via Tauri's plugin).
+- Manual-entry restructured UI (modifier checkboxes + key dropdown) — chose alias normalization (Option A in OQ2) for minimal change. Decisions Log notes the long-term answer is the structured editor.
+- Local subsystem layout fix — Phase 3 only touched the global capture path. Grandfathered local users may still see the FI-keyboard issue on local shortcuts.
+
+### Pending user verification
+
+- [ ] **Phase 1**: Fresh install shows local OFF; existing-user upgrade shows local ON. Toggle either subsystem and confirm immediate effect.
+- [ ] **Phase 2**: Fresh install + Tauri → `Alt+Space` registered on first boot → pressing it toggles recording.
+- [ ] **Phase 3 (FI keyboard)**: Open global shortcut editor, record `Cmd+Shift+<physical-Semicolon-position-key>` → stored accelerator is `Command+Shift+;` → triggering that physical combo fires the shortcut.
+- [ ] **Phase 3 (manual entry)**: Type `ctrl+shift+a` → registers successfully. Type `garbage+foo` → error toast naming the invalid tokens.
+- [ ] **Phase 3 (error surfacing)**: Try to register `Cmd+Space` on macOS (Spotlight reserves it) → error toast appears.
+
+### Follow-up scope (not in this branch)
+
+- Delete `OPTION_DEAD_KEYS` (unused).
+- Apply the same e.code translation to `local-shortcut-manager.ts`.
+- Consider replacing the manual-entry text input with a structured editor (OQ2 Option B).
+- Cleanup pass: remove the DEV-gated log once FI verification is green.
+- The original security hardening branch (CSP, fs scope, shell capability) per the prior audit.


### PR DESCRIPTION
## Why this PR exists

The Whispering hotkey system had three independent bugs that made the app effectively unusable on a Finnish (ISO) keyboard on macOS Tahoe, plus one runtime bug that prevented the local Parakeet model from downloading at all. Symptoms reported during testing:

```
1. Global hotkeys "are created with some std US keyboard layout in mind and
   thus fail to work in FI keyboard layout."

2. "The local shortcuts stupidly activate when / if you are trying to modify
   the global hotkeys."

3. "Reading mac keypresses (like option + command + space or option + command + -)
   never actually get interpreted correctly; and even with the manual editing,
   I have no clue what to type and it gives you errors still or at least produces
   a non working combo."

4. Runtime: "Failed to download model / invalid args 'streamChannel' for command
   'fetch_read_body': command fetch_read_body missing required key streamChannel"
```

Each has a distinct root cause; this PR addresses all four. Full design rationale, decisions log, post-implementation review, and follow-up scope are in [`specs/20260518T121956-hotkey-overhaul.md`](./specs/20260518T121956-hotkey-overhaul.md).

## Architecture: before and after

The recorder and the local listener were both bound to `window` and both fired for the same keydown. Recording any global combo also triggered any local shortcut that matched the keys being recorded.

**Before**

```
                          window keydown / keyup
                                    │
                ┌───────────────────┴────────────────────┐
                ▼                                        ▼
   LocalShortcutManagerLive               createPressedKeys (recorder UI)
   (always listening,                     (e.key.toLowerCase,
    isTypingInInput guard fails           layout-dependent character,
    on non-input focus)                    dropped if unsupported)
                │                                        │
                ▼                                        ▼
        in-app actions                         pressedKeysToTauriAccelerator
                                                         │
                                                         ▼
                                          tauriRegister(accelerator)
                                          error swallowed at line 125-133
```

**After**

```
settings.shortcuts.local.enabled  (default false)
settings.shortcuts.global.enabled (default true)
                │
                ▼
window keydown / keyup
                │
                ├──▶ LocalShortcutManagerLive (only if local.enabled)
                │
                └──▶ createPressedKeys (recorder, when popover open)
                     e.code (physical, layout-neutral)  ──▶ codeToLogicalKey
                     e.key (modifiers only)             ──▶ as-is
                                                              │
                                                              ▼
                                                pressedKeysToTauriAccelerator
                                                              │
                                                              ▼
                                                tauriRegister(accelerator)
                                                error: surfaced to user toast
```

## Changes in detail

### 1. Subsystem toggles (Phase 1)

Two new settings, both in synced user settings (alongside `analytics.enabled`):

```ts
// apps/whispering/src/lib/workspace/definition.ts
'shortcuts.local.enabled':  defineKv(type('boolean'), false),  // OFF by default
'shortcuts.global.enabled': defineKv(type('boolean'), true),   // ON by default
```

The local listener now only mounts when enabled:

```svelte
<!-- apps/whispering/src/routes/(app)/+layout.svelte -->
$effect(() => {
    if (!settings.get('shortcuts.local.enabled')) return;
    const unlisten = services.localShortcutManager.listen();
    return () => unlisten();
});
```

`syncLocalShortcutsWithSettings()` early-returns when local is off. `syncGlobalShortcutsWithSettings()` calls `desktopRpc.globalShortcuts.unregisterAll()` and returns when global is off, so flipping global off actually frees the OS hotkeys system-wide. Both sync functions re-run via reactive `$effect`s on toggle change, so no app restart needed.

UI: a `<Switch>` at the top of each shortcuts settings page. When OFF, the table below is dimmed and the "Reset to defaults" button is disabled. Existing-user grandfathering uses a one-shot localStorage marker and detects pre-existing installs via the prior monolithic-to-per-key migration marker OR presence of the legacy `whispering-settings` blob (handles the async race with `migrateOldSettings`).

### 2. Sensible default (Phase 2)

Drops the entire US-punctuation-default set, ships one cross-layout combo:

```diff
-const DEFAULT_GLOBAL_SHORTCUTS: Record<string, string | null> = {
-    pushToTalk: `${CommandOrAlt}+Shift+D`,
-    toggleManualRecording: `${CommandOrControl}+Shift+;`,
-    startManualRecording: null,
-    stopManualRecording: null,
-    cancelManualRecording: `${CommandOrControl}+Shift+'`,
-    startVadRecording: null,
-    stopVadRecording: null,
-    toggleVadRecording: null,
-    openTransformationPicker: `${CommandOrControl}+Shift+X`,
-    runTransformationOnClipboard: `${CommandOrControl}+Shift+R`,
-};
+const DEFAULT_GLOBAL_SHORTCUTS: Record<string, string | null> = {
+    pushToTalk: null,
+    toggleManualRecording: 'Alt+Space',
+    startManualRecording: null,
+    stopManualRecording: null,
+    cancelManualRecording: null,
+    startVadRecording: null,
+    stopVadRecording: null,
+    toggleVadRecording: null,
+    openTransformationPicker: null,
+    runTransformationOnClipboard: null,
+};
```

Rationale: Tauri's `plugin-global-shortcut` accepts `Alt` and routes to the Option key on macOS automatically. Spacebar is layout-independent. Matches Superwhisper / Wispr Flow conventions (single default combo, users add the rest).

A one-shot migration `migrateGlobalToggleDefaultToOptionSpace()` seeds `Alt+Space` when the toggle is unset (fresh install) or exactly matches the literal old default (`Command+Shift+;` / `Control+Shift+;`). Custom user values are preserved.

### 3. Layout-independent capture via `e.code` (Phase 3)

The core fix for the Finnish keyboard bug. The recorder previously read `e.key.toLowerCase()` for every pressed key, which is the layout-dependent character. On FI ISO, the physical Semicolon-position key reports `e.key === 'Ö'`. That value is not in the supported-key set and was silently dropped, so FI users could not record any shortcut whose non-modifier key was a non-letter.

```
       Recorder side                              Tauri / OS side
       ─────────────                              ───────────────
       e.key.toLowerCase()                        Accelerator like "Command+Shift+Semicolon"
       (layout-dependent character)               maps to a Code (layout-independent physical key)

                       ┌─────────────────────────────────────┐
                       │  MISMATCH — what gets recorded was  │
                       │  layout-aware, what gets registered │
                       │  was supposed to be physical        │
                       └─────────────────────────────────────┘
```

New helper:

```ts
// apps/whispering/src/lib/constants/keyboard/browser/code-to-key.ts
export function codeToLogicalKey(code: string): KeyboardEventPossibleKey | null {
    if (code.startsWith('Key')   && code.length === 4) return code.slice(3).toLowerCase();  // KeyA → a
    if (code.startsWith('Digit') && code.length === 6) return code.slice(5);                // Digit5 → 5
    if (code.startsWith('Numpad')&& code.length === 7) { /* numpad digits */ }
    if (/^F([1-9]|1[0-9]|2[0-4])$/.test(code)) return code.toLowerCase();                   // F1..F24
    return SPECIAL_CODE_MAP[code] ?? null;  // Semicolon → ';', Space → ' ', ArrowUp → 'arrowup', etc.
}
```

Both keydown and keyup in `createPressedKeys.svelte.ts` translate non-modifier keys through this; modifier keys still use `e.key` because that name is already platform-canonical. The `OPTION_KEY_CHARACTER_MAP` is now a defensive fallback for unmapped codes.

Side benefit: bypasses the macOS Option dead-key recording bug (Option+E producing `e.key === 'Dead'`) because `e.code === 'KeyE'` regardless. The recorder UI warning about Option dead keys was removed since it no longer applies.

### 4. Honest manual entry (Phase 3)

Old behavior:

```ts
// User types "ctrl+cmd+-" in the popover text input.
keyRecorder.register(manualValue.split('+') as KeyboardEventSupportedKey[]);

// → split: ['ctrl', 'cmd', '-']
// → pressedKeysToTauriAccelerator: convertToModifier switch is case-sensitive
//   and only knows 'control' | 'shift' | 'alt' | 'meta' | ...
//   'ctrl' → null  → silently dropped
//   'cmd'  → null  → silently dropped
//   '-'    → in punctuation set, kept
// → Accelerator: "-"  (just the dash, no modifiers)
// → tauriRegister: registers a bare minus globally, OR silently fails (next bug).
```

New behavior:

```ts
// apps/whispering/src/lib/constants/keyboard/browser/parse-manual-shortcut.ts
export function parseManualShortcut(input: string): {
    keys: KeyboardEventSupportedKey[];
    invalidTokens: string[];
};

// Recognises aliases: ctrl|cmd|command|⌘|option|opt|⌥|alt|shift|⇧|space|esc|...
// Returns invalidTokens for any token that does not normalise to a supported key.
```

The recorder onsubmit now uses this and shows an error toast naming any invalid tokens:

```svelte
const { keys, invalidTokens } = parseManualShortcut(manualValue);
if (invalidTokens.length > 0) {
    rpc.notify.error({
        title: 'Invalid shortcut',
        description: `Could not recognize: ${invalidTokens.join(', ')}. Try aliases like ctrl, cmd, option, shift, space, or a single letter / digit / punctuation key.`,
    });
    return;
}
```

### 5. Surface registration errors (Phase 3)

```diff
- // NOTE: We often get "RegisterEventHotKey failed for <key>" errors when
- // registering global shortcuts, even though the shortcut was valid and
- // registered successfully. (...) We gracefully return Ok(undefined) in these
- // cases to avoid propagating the error as an unnecessary error toast,
- // allowing the shortcut system to continue functioning for other valid keys.
- if (registerError) return Ok(undefined);
+ // Surface the registration failure to the caller so the error toast plumbing
+ // in syncGlobalShortcutsWithSettings can show the actual cause (reserved by
+ // OS, accelerator parse failure, etc.).
+ if (registerError) return Err(registerError);
```

The previous swallow was speculative ("we often get"). The cost was that real failures (OS-reserved combos like `Cmd+Space`, accelerator parse errors, conflicts) produced a misleading "shortcut saved" UX that bound nothing. If a false-positive recurs in practice, we will gate per-error rather than swallow the whole class.

### 6. Pin `@tauri-apps/plugin-http` to 2.5.4

The Rust workspace resolved `tauri-plugin-http` to 2.5.4 (constrained by the resolved Tauri crate version). The JS package was declared as `^2.5.1`, which bun resolved to 2.5.8. The two versions disagree on the `fetch_read_body` IPC payload shape: 2.5.8 sends one key name, 2.5.4 expects another. Manifested at runtime when downloading any local transcription model (Parakeet, Moonshine, Whisper C++):

```
Failed to download model
invalid args 'streamChannel' for command 'fetch_read_body':
command fetch_read_body missing required key streamChannel
```

Tried bumping the Rust side to 2.5.8 first; that cascaded Tauri to 2.10.3 and broke `tauri-runtime-wry 2.10.1` (trait impl + `Sync` constraint mismatch). Pinning the JS side down to 2.5.4 is the minimal change.

## Migration behavior (what existing users see)

| Scenario | Behavior |
|---|---|
| Fresh install | `shortcuts.local.enabled = false`. `shortcuts.global.enabled = true`. No global shortcut bound; first launch of the global settings page lets the user record one or use the new `Alt+Space` default after a reset. |
| Existing user, any local shortcut configured | `shortcuts.local.enabled = true` (grandfathered). Existing local shortcuts continue working. |
| Existing user, stored global toggle is `Cmd+Shift+;` or `Control+Shift+;` | Reseat to `Alt+Space` on first boot. Other formerly-defaulted global bindings (`pushToTalk`, etc.) untouched. |
| Existing user, customized global toggle | Untouched. |
| Existing user upgrading from a build with the version-skew bug | Local Parakeet model downloads work for the first time. |

No data is deleted; the local subsystem code path is still present and re-enables instantly.

## Test plan

### Smoke (manual)

- [ ] **Subsystem toggles.** Fresh install: local OFF, global ON. Existing-user upgrade: local ON (grandfathered). Flip either toggle → effect immediate (no app restart).
- [ ] **Default.** Existing user on stock settings has `Cmd+Shift+;` auto-flipped to `Alt+Space` on first boot. Custom values preserved. Press `Option+Space` → recording toggles.
- [ ] **FI keyboard capture.** Open global shortcut editor, record `Cmd+Shift+<physical-Semicolon-position-key>` (labeled `Ö` on FI ISO) → stored accelerator is `Command+Shift+;` → triggering the same physical combo fires the shortcut.
- [ ] **Manual entry.** Type `ctrl+shift+a` → registers. Type `cmd+option+space` → registers. Type `garbage+foo` → red toast naming the invalid tokens.
- [ ] **Error surfacing.** Try to register a known-reserved combo like `Cmd+Space` on macOS → error toast appears (no silent "saved").
- [ ] **Recorder vs local listener.** With local enabled, open the global shortcut editor and record a combo that matches a local shortcut → the local action does NOT fire while the recorder is open.
- [ ] **Local model download** (Parakeet end-to-end on macOS aarch64). Stream completes without the `streamChannel` IPC error.

### Automated

- [x] `bun run typecheck` clean for `apps/whispering` on every commit. 21 pre-existing errors in unrelated files (transformations, migrations) remain; zero new errors or warnings introduced.
- [x] `bun tauri build` succeeds end-to-end on macOS aarch64 (unsigned, used for local verification).

## Risk assessment

| Risk | Likelihood | Mitigation |
|---|---|---|
| `e.code` translator misses a key on a layout we did not test | medium | DEV-gated `console.debug` log emits `{key, code, modifiers}` on every keydown. Falls back to `e.key` when `codeToLogicalKey` returns null. |
| Grandfather detection misclassifies a fresh install as existing | low | Dual signal (migration marker OR old blob present); fresh installs match neither. Idempotent via own marker. |
| Surfacing `tauriRegister` errors floods users with toasts | low | The pre-existing toast plumbing already deduplicates and only fires on real registration failures. If recurrent false positives appear, gate per-error rather than swallow the whole class. |
| Local users flipped to OFF on upgrade miss configured local shortcuts | n/a | Grandfather migration leaves existing local users at ON. Only users with zero local shortcuts configured get OFF. |
| Tauri plugin-http version pin (2.5.4) blocks future plugin upgrades | low | Pin documented in commit; can be relaxed once the Rust side upgrades transitively via a future Tauri bump. |

## Commits

```
945373556  fix(whispering): pin @tauri-apps/plugin-http to 2.5.4 to match Rust crate
71d26b914  docs(whispering): add spec review section after Phase 1-3 implementation
c2c6b7a4d  fix(whispering): make global hotkey capture layout-independent
52833f158  feat(whispering): ship Alt+Space as the only global hotkey default
438ca3653  feat(whispering): gate hotkey subsystems behind toggles
```

Each phase is one commit and one logical unit; any can be reverted independently if needed.

## Out of scope (follow-ups noted in the spec)

- Remove the DEV-gated `console.debug` diagnostic in `createPressedKeys.svelte.ts` once layout coverage is confirmed.
- Apply the same `e.code` translation to `local-shortcut-manager.ts` (still uses raw `e.key`; only matters for users who re-enable local).
- Delete unused `OPTION_DEAD_KEYS` set in `macos-option-key-map.ts` (only documented an unaddressed bug, never imported).
- Consider replacing the manual-entry text input with a structured editor (modifier checkboxes + key dropdown).
- Tauri capability hardening from the prior security audit (CSP, narrow `shell:allow-execute`, narrow `fs:scope`, narrow `assetProtocol.scope`) is a separate effort on its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
