### PR TITLE
test: add shared result test helpers

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -56,6 +56,7 @@
 		"yjs": "catalog:"
 	},
 	"devDependencies": {
+		"@epicenter/test-utils": "workspace:*",
 		"@types/bun": "catalog:",
 		"@types/pg": "^8.18.0",
 		"atmn": "^1.1.5",

--- a/apps/api/src/sync-handlers.test.ts
+++ b/apps/api/src/sync-handlers.test.ts
@@ -19,8 +19,8 @@ import {
 	MESSAGE_TYPE,
 	SYNC_MESSAGE_TYPE,
 } from '@epicenter/sync';
+import { expectOk } from '@epicenter/test-utils/result';
 import * as encoding from 'lib0/encoding';
-import type { Result } from 'wellcrafted/result';
 import { Awareness, encodeAwarenessUpdate } from 'y-protocols/awareness';
 import * as Y from 'yjs';
 
@@ -71,12 +71,6 @@ function makeConnection(
 		installationId,
 	});
 	return { ws, connection };
-}
-
-function expectOk<T>(result: Result<T, unknown>): T {
-	expect(result.error).toBeNull();
-	if (result.error !== null) throw result.error;
-	return result.data as T;
 }
 
 function frameSingleByte(messageType: number): Uint8Array {

--- a/bun.lock
+++ b/bun.lock
@@ -43,6 +43,7 @@
         "yjs": "catalog:",
       },
       "devDependencies": {
+        "@epicenter/test-utils": "workspace:*",
         "@types/bun": "catalog:",
         "@types/pg": "^8.18.0",
         "atmn": "^1.1.5",
@@ -520,6 +521,7 @@
         "wellcrafted": "catalog:",
       },
       "devDependencies": {
+        "@epicenter/test-utils": "workspace:*",
         "@types/bun": "catalog:",
         "typescript": "catalog:",
       },
@@ -561,6 +563,7 @@
         "@epicenter/api": "workspace:*",
         "@epicenter/honeycrisp": "workspace:*",
         "@epicenter/tab-manager": "workspace:*",
+        "@epicenter/test-utils": "workspace:*",
         "@types/bun": "catalog:",
         "@types/yargs": "catalog:",
         "typescript": "catalog:",
@@ -677,6 +680,17 @@
         "yjs": "catalog:",
       },
     },
+    "packages/test-utils": {
+      "name": "@epicenter/test-utils",
+      "version": "0.1.0",
+      "dependencies": {
+        "wellcrafted": "catalog:",
+      },
+      "devDependencies": {
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "packages/ui": {
       "name": "@epicenter/ui",
       "version": "0.1.0",
@@ -749,6 +763,7 @@
         "y-protocols": "catalog:",
       },
       "devDependencies": {
+        "@epicenter/test-utils": "workspace:*",
         "@noble/ciphers": "^2.1.1",
         "@noble/hashes": "^2.0.1",
         "@types/diff": "^8.0.0",
@@ -1044,6 +1059,8 @@
     "@epicenter/sync": ["@epicenter/sync@workspace:packages/sync"],
 
     "@epicenter/tab-manager": ["@epicenter/tab-manager@workspace:apps/tab-manager"],
+
+    "@epicenter/test-utils": ["@epicenter/test-utils@workspace:packages/test-utils"],
 
     "@epicenter/ui": ["@epicenter/ui@workspace:packages/ui"],
 

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -24,6 +24,7 @@
 		"wellcrafted": "catalog:"
 	},
 	"devDependencies": {
+		"@epicenter/test-utils": "workspace:*",
 		"@types/bun": "catalog:",
 		"typescript": "catalog:"
 	},

--- a/packages/auth/src/node/machine-tokens-store.test.ts
+++ b/packages/auth/src/node/machine-tokens-store.test.ts
@@ -11,6 +11,9 @@ import { randomUUID } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+
+import { expectErr, expectOk } from '@epicenter/test-utils/result';
+
 import type { PersistedAuth } from '../auth-types.js';
 import {
 	loadMachineTokens,
@@ -59,10 +62,10 @@ test('round trip: save then load returns the same PersistedAuth', async () => {
 	const filePath = tmpAuthPath();
 	const cell = makeCell();
 	const saved = await saveMachineTokens(cell, { filePath });
-	expect(saved.error).toBeNull();
+	expectOk(saved);
 	const loaded = await loadMachineTokens({ filePath });
-	expect(loaded.error).toBeNull();
-	expect(loaded.data).toEqual(cell);
+	const loadedData = expectOk(loaded);
+	expect(loadedData).toEqual(cell);
 });
 
 test('save writes file with mode 0o600 and parent dir 0o700', async () => {
@@ -79,17 +82,17 @@ test('save(null) removes the file; subsequent load returns Ok(null)', async () =
 	const filePath = tmpAuthPath();
 	await saveMachineTokens(makeCell(), { filePath });
 	const cleared = await saveMachineTokens(null, { filePath });
-	expect(cleared.error).toBeNull();
+	expectOk(cleared);
 	const loaded = await loadMachineTokens({ filePath });
-	expect(loaded.error).toBeNull();
-	expect(loaded.data).toBeNull();
+	const loadedData = expectOk(loaded);
+	expect(loadedData).toBeNull();
 });
 
 test('load against a missing file returns Ok(null)', async () => {
 	const filePath = tmpAuthPath();
 	const loaded = await loadMachineTokens({ filePath });
-	expect(loaded.error).toBeNull();
-	expect(loaded.data).toBeNull();
+	const loadedData = expectOk(loaded);
+	expect(loadedData).toBeNull();
 });
 
 test('load against corrupt JSON returns Ok(null)', async () => {
@@ -97,8 +100,8 @@ test('load against corrupt JSON returns Ok(null)', async () => {
 	await fs.mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
 	await fs.writeFile(filePath, '{not valid json', { mode: 0o600 });
 	const loaded = await loadMachineTokens({ filePath });
-	expect(loaded.error).toBeNull();
-	expect(loaded.data).toBeNull();
+	const loadedData = expectOk(loaded);
+	expect(loadedData).toBeNull();
 });
 
 test('load refuses when permissions are too open', async () => {
@@ -107,5 +110,6 @@ test('load refuses when permissions are too open', async () => {
 	await saveMachineTokens(makeCell(), { filePath });
 	await fs.chmod(filePath, 0o644);
 	const loaded = await loadMachineTokens({ filePath });
-	expect(loaded.error?.name).toBe('PermissionsTooOpen');
+	const error = expectErr(loaded);
+	expect(error.name).toBe('PermissionsTooOpen');
 });

--- a/packages/auth/src/node/oob-launcher.test.ts
+++ b/packages/auth/src/node/oob-launcher.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { expect, test } from 'bun:test';
+import { expectErr, expectOk } from '@epicenter/test-utils/result';
 import type { AuthFetch } from '../create-oauth-app-auth.js';
 import { createOobOAuthLauncher } from './oob-launcher.js';
 
@@ -89,9 +90,9 @@ function setup({
 
 test('happy path returns a 3-field OAuthTokenGrant', async () => {
 	const { launcher, printed, tokenRequests } = setup();
-	const result = await launcher.startSignIn();
-	expect(result.error).toBeNull();
-	expect(result.data).toEqual({
+	const data = expectOk(await launcher.startSignIn());
+	if (!data) throw new Error('Expected non-null token grant');
+	expect(data).toEqual({
 		accessToken: 'a',
 		refreshToken: 'r',
 		accessTokenExpiresAt: NOW + 3_600_000,
@@ -131,8 +132,7 @@ test('PKCE verifier and challenge are linked', async () => {
 		openBrowser: async () => {},
 		readCode: async () => 'CODE',
 	});
-	const result = await launcher.startSignIn();
-	expect(result.error).toBeNull();
+	expectOk(await launcher.startSignIn());
 	expect(receivedVerifier).toBeTruthy();
 	const urlLine = printed[0];
 	expect(urlLine).toBeDefined();
@@ -154,10 +154,9 @@ test('cancellation: empty paste returns Err(AuthorizationCancelled) and no netwo
 			return new Response(null, { status: 500 });
 		},
 	});
-	const result = await launcher.startSignIn();
+	const err = expectErr(await launcher.startSignIn()) as { name?: string };
 	expect(fetched).toBe(false);
-	const err = result.error as { name?: string } | null;
-	expect(err?.name).toBe('AuthorizationCancelled');
+	expect(err.name).toBe('AuthorizationCancelled');
 });
 
 test('invalid token_type returns Err(InvalidTokenResponse)', async () => {
@@ -170,9 +169,8 @@ test('invalid token_type returns Err(InvalidTokenResponse)', async () => {
 				token_type: 'mac',
 			}),
 	});
-	const result = await launcher.startSignIn();
-	const err = result.error as { name?: string } | null;
-	expect(err?.name).toBe('InvalidTokenResponse');
+	const err = expectErr(await launcher.startSignIn()) as { name?: string };
+	expect(err.name).toBe('InvalidTokenResponse');
 });
 
 test('server 400 returns Err(TokenExchangeFailed) with status + body', async () => {
@@ -183,15 +181,14 @@ test('server 400 returns Err(TokenExchangeFailed) with status + body', async () 
 				headers: { 'content-type': 'application/json' },
 			}),
 	});
-	const result = await launcher.startSignIn();
-	const err = result.error as {
+	const err = expectErr(await launcher.startSignIn()) as {
 		name?: string;
 		status?: number;
 		body?: string;
-	} | null;
-	expect(err?.name).toBe('TokenExchangeFailed');
-	expect(err?.status).toBe(400);
-	expect(err?.body).toContain('invalid_grant');
+	};
+	expect(err.name).toBe('TokenExchangeFailed');
+	expect(err.status).toBe(400);
+	expect(err.body).toContain('invalid_grant');
 });
 
 test('openBrowser failure does not abort the flow', async () => {
@@ -200,9 +197,9 @@ test('openBrowser failure does not abort the flow', async () => {
 			throw new Error('no browser available');
 		},
 	});
-	const result = await launcher.startSignIn();
-	expect(result.error).toBeNull();
-	expect(result.data?.accessToken).toBe('a');
+	const data = expectOk(await launcher.startSignIn());
+	if (!data) throw new Error('Expected non-null token grant');
+	expect(data.accessToken).toBe('a');
 });
 
 test('case-insensitive token_type check', async () => {
@@ -215,7 +212,7 @@ test('case-insensitive token_type check', async () => {
 				token_type: 'Bearer',
 			}),
 	});
-	const result = await launcher.startSignIn();
-	expect(result.error).toBeNull();
-	expect(result.data?.accessToken).toBe('a');
+	const data = expectOk(await launcher.startSignIn());
+	if (!data) throw new Error('Expected non-null token grant');
+	expect(data.accessToken).toBe('a');
 });

--- a/packages/auth/src/oauth-launchers/index.test.ts
+++ b/packages/auth/src/oauth-launchers/index.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { expect, test } from 'bun:test';
+import { expectErr, expectOk } from '@epicenter/test-utils/result';
 import type { AuthFetch } from '../create-oauth-app-auth.js';
 import { createOAuthClient, type OAuthTemporaryStorage } from './index.js';
 
@@ -75,17 +76,16 @@ test('createAuthorizationUrl stores verifier state and returns PKCE URL', async 
 		fetch: createFetch(),
 	});
 
-	const { data: url, error } = await client.createAuthorizationUrl();
+	const url = expectOk(await client.createAuthorizationUrl());
 
-	expect(error).toBeNull();
-	expect(url?.searchParams.get('response_type')).toBe('code');
-	expect(url?.searchParams.get('client_id')).toBe('client-1');
-	expect(url?.searchParams.get('scope')).toBe(
+	expect(url.searchParams.get('response_type')).toBe('code');
+	expect(url.searchParams.get('client_id')).toBe('client-1');
+	expect(url.searchParams.get('scope')).toBe(
 		'openid profile email offline_access workspaces:open',
 	);
-	expect(url?.searchParams.get('resource')).toBe('http://auth.test');
-	expect(url?.searchParams.get('code_challenge_method')).toBe('S256');
-	expect(url?.searchParams.get('code_challenge')).toBeTruthy();
+	expect(url.searchParams.get('resource')).toBe('http://auth.test');
+	expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+	expect(url.searchParams.get('code_challenge')).toBeTruthy();
 	expect(values.size).toBe(1);
 });
 
@@ -100,11 +100,13 @@ test('handleCallback rejects missing stored transaction', async () => {
 		fetch: createFetch(),
 	});
 
-	const { error } = await client.handleCallback(
-		'http://app.test/auth/callback?code=code-1&state=state-1',
+	const error = expectErr(
+		await client.handleCallback(
+			'http://app.test/auth/callback?code=code-1&state=state-1',
+		),
 	);
 
-	expect(error?.name).toBe('MissingCallbackTransaction');
+	expect(error.name).toBe('MissingCallbackTransaction');
 });
 
 test('handleCallback reports callback authorization errors', async () => {
@@ -124,8 +126,10 @@ test('handleCallback reports callback authorization errors', async () => {
 		fetch: createFetch(),
 	});
 
-	const { error } = await client.handleCallback(
-		'http://app.test/auth/callback?error=access_denied&error_description=Denied&state=state-1',
+	const error = expectErr(
+		await client.handleCallback(
+			'http://app.test/auth/callback?error=access_denied&error_description=Denied&state=state-1',
+		),
 	);
 
 	expect(error).toEqual(
@@ -159,11 +163,13 @@ test('handleCallback rejects state mismatch before token exchange', async () => 
 		}),
 	});
 
-	const { error } = await client.handleCallback(
-		'http://app.test/auth/callback?code=code-1&state=state-2',
+	const error = expectErr(
+		await client.handleCallback(
+			'http://app.test/auth/callback?code=code-1&state=state-2',
+		),
 	);
 
-	expect(error?.name).toBe('StateMismatch');
+	expect(error.name).toBe('StateMismatch');
 	expect(tokenRequests).toBe(0);
 });
 
@@ -190,14 +196,16 @@ test('handleCallback returns token result after successful exchange', async () =
 		}),
 	});
 
-	const { data, error } = await client.handleCallback(
-		'http://app.test/auth/callback?code=code-1&state=state-1',
+	const data = expectOk(
+		await client.handleCallback(
+			'http://app.test/auth/callback?code=code-1&state=state-1',
+		),
 	);
+	if (!data) throw new Error('Expected non-null token grant');
 
-	expect(error).toBeNull();
-	expect(data?.accessToken).toBe('access-token');
-	expect(data?.refreshToken).toBe('refresh-token');
-	expect(data?.accessTokenExpiresAt).toBeGreaterThanOrEqual(now + 899_000);
+	expect(data.accessToken).toBe('access-token');
+	expect(data.refreshToken).toBe('refresh-token');
+	expect(data.accessTokenExpiresAt).toBeGreaterThanOrEqual(now + 899_000);
 	expect(tokenBody?.get('resource')).toBe('http://auth.test');
 	expect(values.size).toBe(0);
 });
@@ -219,11 +227,13 @@ test('handleCallback reports token exchange failure', async () => {
 		fetch: createFetch({ tokenStatus: 400 }),
 	});
 
-	const { error } = await client.handleCallback(
-		'http://app.test/auth/callback?code=code-1&state=state-1',
+	const error = expectErr(
+		await client.handleCallback(
+			'http://app.test/auth/callback?code=code-1&state=state-1',
+		),
 	);
 
-	expect(error?.name).toBe('TokenExchangeFailed');
+	expect(error.name).toBe('TokenExchangeFailed');
 });
 
 test('handleCallback rejects a token response without access token', async () => {
@@ -249,11 +259,13 @@ test('handleCallback rejects a token response without access token', async () =>
 		}),
 	});
 
-	const { error } = await client.handleCallback(
-		'http://app.test/auth/callback?code=code-1&state=state-1',
+	const error = expectErr(
+		await client.handleCallback(
+			'http://app.test/auth/callback?code=code-1&state=state-1',
+		),
 	);
 
-	expect(error?.name).toBe('TokenExchangeFailed');
+	expect(error.name).toBe('TokenExchangeFailed');
 });
 
 test('handleCallback rejects a token response without refresh token', async () => {
@@ -279,11 +291,13 @@ test('handleCallback rejects a token response without refresh token', async () =
 		}),
 	});
 
-	const { error } = await client.handleCallback(
-		'http://app.test/auth/callback?code=code-1&state=state-1',
+	const error = expectErr(
+		await client.handleCallback(
+			'http://app.test/auth/callback?code=code-1&state=state-1',
+		),
 	);
 
-	expect(error?.name).toBe('MissingRefreshToken');
+	expect(error.name).toBe('MissingRefreshToken');
 });
 
 test('handleCallback rejects a token response without expires_in', async () => {
@@ -309,11 +323,13 @@ test('handleCallback rejects a token response without expires_in', async () => {
 		}),
 	});
 
-	const { error } = await client.handleCallback(
-		'http://app.test/auth/callback?code=code-1&state=state-1',
+	const error = expectErr(
+		await client.handleCallback(
+			'http://app.test/auth/callback?code=code-1&state=state-1',
+		),
 	);
 
-	expect(error?.name).toBe('MissingExpiresIn');
+	expect(error.name).toBe('MissingExpiresIn');
 });
 
 test('handleCallback rejects a non-bearer token response', async () => {
@@ -340,9 +356,11 @@ test('handleCallback rejects a non-bearer token response', async () => {
 		}),
 	});
 
-	const { error } = await client.handleCallback(
-		'http://app.test/auth/callback?code=code-1&state=state-1',
+	const error = expectErr(
+		await client.handleCallback(
+			'http://app.test/auth/callback?code=code-1&state=state-1',
+		),
 	);
 
-	expect(error?.name).toBe('TokenExchangeFailed');
+	expect(error.name).toBe('TokenExchangeFailed');
 });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,6 +42,7 @@
 		"@epicenter/api": "workspace:*",
 		"@epicenter/honeycrisp": "workspace:*",
 		"@epicenter/tab-manager": "workspace:*",
+		"@epicenter/test-utils": "workspace:*",
 		"@types/bun": "catalog:",
 		"@types/yargs": "catalog:",
 		"typescript": "catalog:"

--- a/packages/cli/src/commands/up.test.ts
+++ b/packages/cli/src/commands/up.test.ts
@@ -25,6 +25,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { expectErr, expectOk } from '@epicenter/test-utils/result';
 import {
 	claimDaemonLease,
 	metadataPathFor,
@@ -33,7 +34,7 @@ import {
 	writeMetadata,
 } from '@epicenter/workspace/node';
 import { Hono } from 'hono';
-import { Ok, type Result } from 'wellcrafted/result';
+import { Ok } from 'wellcrafted/result';
 import { runUp } from './up';
 
 let originalXdg: string | undefined;
@@ -45,12 +46,6 @@ let homeRoot: string;
 function servePingDaemon(socketPath: string): Bun.Server<undefined> {
 	const app = new Hono().post('/ping', (c) => c.json(Ok('pong' as const)));
 	return Bun.serve({ unix: socketPath, fetch: app.fetch });
-}
-
-function expectOk<T>(result: Result<T, unknown>): T {
-	expect(result.error).toBeNull();
-	if (result.error !== null) throw result.error;
-	return result.data as T;
 }
 
 beforeEach(() => {
@@ -77,8 +72,7 @@ beforeEach(() => {
 				keyring: [
 					{
 						version: 1,
-						subjectKeyBase64:
-							'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=',
+						subjectKeyBase64: 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=',
 					},
 				],
 			},
@@ -208,12 +202,14 @@ describe('runUp: failure cleanup', () => {
 			};
 		`);
 
-		const { error } = await runUp({
-			projectDir: workDir,
-			quiet: true,
-		});
+		const error = expectErr(
+			await runUp({
+				projectDir: workDir,
+				quiet: true,
+			}),
+		);
 
-		expect(error?.name).toBe('WorkspaceOpenFailed');
+		expect(error.name).toBe('WorkspaceOpenFailed');
 		const lease = expectOk(claimDaemonLease(workDir));
 		lease.release();
 	});
@@ -222,12 +218,14 @@ describe('runUp: failure cleanup', () => {
 		writeRuntimeDaemon();
 		mkdirSync(metadataPathFor(workDir));
 
-		const { error } = await runUp({
-			projectDir: workDir,
-			quiet: true,
-		});
+		const error = expectErr(
+			await runUp({
+				projectDir: workDir,
+				quiet: true,
+			}),
+		);
 
-		expect(error?.name).toBe('MetadataWriteFailed');
+		expect(error.name).toBe('MetadataWriteFailed');
 		expect(existsSync(socketPathFor(workDir))).toBe(false);
 		const lease = expectOk(claimDaemonLease(workDir));
 		lease.release();
@@ -252,10 +250,12 @@ describe('runUp: already running', () => {
 		});
 
 		try {
-			const { error } = await runUp({
-				projectDir: workDir,
-				quiet: true,
-			});
+			const error = expectErr(
+				await runUp({
+					projectDir: workDir,
+					quiet: true,
+				}),
+			);
 			expect(error).toMatchObject({
 				name: 'AlreadyRunning',
 				pid: process.pid,
@@ -274,12 +274,14 @@ describe('runUp: already running', () => {
 		writeRuntimeDaemon({ onImportMarker: importMarker });
 
 		try {
-			const { error } = await runUp({
-				projectDir: workDir,
-				quiet: true,
-			});
+			const error = expectErr(
+				await runUp({
+					projectDir: workDir,
+					quiet: true,
+				}),
+			);
 
-			expect(error?.name).toBe('AlreadyRunning');
+			expect(error.name).toBe('AlreadyRunning');
 			expect(existsSync(importMarker)).toBe(false);
 		} finally {
 			lease.release();

--- a/packages/cli/test/e2e-up-cross-peer.test.ts
+++ b/packages/cli/test/e2e-up-cross-peer.test.ts
@@ -83,8 +83,7 @@ function makeEnv(): EnvOverrides {
 				keyring: [
 					{
 						version: 1,
-						subjectKeyBase64:
-							'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=',
+						subjectKeyBase64: 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=',
 					},
 				],
 			},

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "@epicenter/test-utils",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"description": "Shared test helpers for Epicenter packages.",
+	"exports": {
+		"./result": "./src/result.ts"
+	},
+	"scripts": {
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"wellcrafted": "catalog:"
+	},
+	"devDependencies": {
+		"@types/bun": "catalog:",
+		"typescript": "catalog:"
+	},
+	"license": "MIT"
+}

--- a/packages/test-utils/src/result.ts
+++ b/packages/test-utils/src/result.ts
@@ -1,0 +1,14 @@
+import { expect } from 'bun:test';
+import type { Result } from 'wellcrafted/result';
+
+export function expectOk<T>(result: Result<T, unknown>): T {
+	expect(result.error).toBeNull();
+	if (result.error !== null) throw result.error;
+	return result.data as T;
+}
+
+export function expectErr<E>(result: Result<unknown, E>): E {
+	expect(result.error).not.toBeNull();
+	if (result.error === null) throw new Error('Expected Err result');
+	return result.error;
+}

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"lib": ["ESNext"],
+		"types": ["bun"],
+		"noUnusedLocals": true,
+		"noUnusedParameters": true
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -79,6 +79,7 @@
 		"yjs": "catalog:"
 	},
 	"devDependencies": {
+		"@epicenter/test-utils": "workspace:*",
 		"@noble/ciphers": "^2.1.1",
 		"@noble/hashes": "^2.0.1",
 		"@types/diff": "^8.0.0",

--- a/packages/workspace/src/daemon/client.test.ts
+++ b/packages/workspace/src/daemon/client.test.ts
@@ -8,6 +8,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { expectErr, expectOk } from '@epicenter/test-utils/result';
 
 import { Hono } from 'hono';
 import { Ok } from 'wellcrafted/result';
@@ -69,15 +70,14 @@ describe('daemonClient', () => {
 		});
 		servers.push(server);
 
-		const { data, error } = await daemonClient(socketPath).peers();
-		expect(error).toBeNull();
+		const data = expectOk(await daemonClient(socketPath).peers());
 		expect(data).toEqual([]);
 	});
 
 	test('returns Unreachable when socket is missing', async () => {
 		const missing = join(tmpdir(), `definitely-not-here-${Date.now()}.sock`);
-		const { error } = await daemonClient(missing).peers();
-		expect(error?.name).toBe('Unreachable');
+		const error = expectErr(await daemonClient(missing).peers());
+		expect(error.name).toBe('Unreachable');
 	});
 
 	test('returns Timeout when route hangs past the deadline', async () => {
@@ -88,8 +88,8 @@ describe('daemonClient', () => {
 		});
 		servers.push(server);
 
-		const { error } = await daemonClient(socketPath, 100).peers();
-		expect(error?.name).toBe('Timeout');
+		const error = expectErr(await daemonClient(socketPath, 100).peers());
+		expect(error.name).toBe('Timeout');
 	});
 
 	test('returns HandlerCrashed on a 500 from the daemon', async () => {
@@ -102,7 +102,7 @@ describe('daemonClient', () => {
 		});
 		servers.push(server);
 
-		const { error } = await daemonClient(socketPath).peers();
-		expect(error?.name).toBe('HandlerCrashed');
+		const error = expectErr(await daemonClient(socketPath).peers());
+		expect(error.name).toBe('HandlerCrashed');
 	});
 });

--- a/packages/workspace/src/daemon/lease.test.ts
+++ b/packages/workspace/src/daemon/lease.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, test } from 'bun:test';
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { expectErr, expectOk } from '@epicenter/test-utils/result';
 
 import { claimDaemonLease } from './lease.js';
 
@@ -35,22 +36,15 @@ function setup() {
 	};
 }
 
-function expectClaimedLease(result: ReturnType<typeof claimDaemonLease>) {
-	expect(result.error).toBeNull();
-	if (result.error !== null) throw result.error;
-	return result.data;
-}
-
 describe('claimDaemonLease', () => {
 	test('second claimant receives AlreadyRunning while first lease is held', () => {
 		const { workDir, cleanup } = setup();
 		const first = claimDaemonLease(workDir);
 		try {
-			expectClaimedLease(first);
+			expectOk(first);
 
-			const second = claimDaemonLease(workDir);
-			expect(second.data).toBeNull();
-			expect(second.error?.name).toBe('AlreadyRunning');
+			const error = expectErr(claimDaemonLease(workDir));
+			expect(error.name).toBe('AlreadyRunning');
 		} finally {
 			if (first.error === null) first.data.release();
 			cleanup();
@@ -60,13 +54,13 @@ describe('claimDaemonLease', () => {
 	test('release allows a later claimant to acquire the lease', () => {
 		const { workDir, cleanup } = setup();
 		try {
-			const first = expectClaimedLease(claimDaemonLease(workDir));
+			const first = expectOk(claimDaemonLease(workDir));
 			expect(existsSync(first.leasePath)).toBe(true);
 			first.release();
 
 			const second = claimDaemonLease(workDir);
 			try {
-				expectClaimedLease(second);
+				expectOk(second);
 			} finally {
 				if (second.error === null) second.data.release();
 			}
@@ -78,11 +72,11 @@ describe('claimDaemonLease', () => {
 	test('release is idempotent and leaves the lease claimable', () => {
 		const { workDir, cleanup } = setup();
 		try {
-			const first = expectClaimedLease(claimDaemonLease(workDir));
+			const first = expectOk(claimDaemonLease(workDir));
 			first.release();
 			expect(() => first.release()).not.toThrow();
 
-			const second = expectClaimedLease(claimDaemonLease(workDir));
+			const second = expectOk(claimDaemonLease(workDir));
 			second.release();
 		} finally {
 			cleanup();
@@ -102,9 +96,8 @@ describe('claimDaemonLease', () => {
 		process.env.XDG_RUNTIME_DIR = runtimeRootFile;
 
 		try {
-			const result = claimDaemonLease(workDir);
-			expect(result.data).toBeNull();
-			expect(result.error?.name).toBe('LeaseFailed');
+			const error = expectErr(claimDaemonLease(workDir));
+			expect(error.name).toBe('LeaseFailed');
 		} finally {
 			if (oldXdg === undefined) delete process.env.XDG_RUNTIME_DIR;
 			else process.env.XDG_RUNTIME_DIR = oldXdg;

--- a/packages/workspace/src/daemon/run-handler.test.ts
+++ b/packages/workspace/src/daemon/run-handler.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
+import { expectErr, expectOk } from '@epicenter/test-utils/result';
 import type { Result } from 'wellcrafted/result';
 
 import {
@@ -80,12 +81,13 @@ describe('executeRun peer dispatch', () => {
 			waitMs: 25,
 		});
 
-		expect(result.error?.name).toBe('PeerNotFound');
-		if (result.error?.name !== 'PeerNotFound') {
-			throw new Error(`expected PeerNotFound, got ${result.error?.name}`);
+		const error = expectErr(result);
+		expect(error.name).toBe('PeerNotFound');
+		if (error.name !== 'PeerNotFound') {
+			throw new Error(`expected PeerNotFound, got ${error.name}`);
 		}
-		expect(result.error.peerTarget).toBe('ghost');
-		expect(result.error.syncStatus).toEqual(runSyncStatus);
+		expect(error.peerTarget).toBe('ghost');
+		expect(error.syncStatus).toEqual(runSyncStatus);
 	});
 
 	test('remote dispatch sends the resolved installationId and action key', async () => {
@@ -107,7 +109,7 @@ describe('executeRun peer dispatch', () => {
 			waitMs: 25,
 		});
 
-		expect(result.error).toBeNull();
+		expectOk(result);
 		expect(invokedAction).toBe('tabs_list');
 		expect(invokedTo).toBe('mac');
 	});
@@ -129,11 +131,12 @@ describe('executeRun peer dispatch', () => {
 			waitMs: 25,
 		});
 
-		expect(result.error?.name).toBe('RemoteCallFailed');
-		if (result.error?.name !== 'RemoteCallFailed') {
+		const error = expectErr(result);
+		expect(error.name).toBe('RemoteCallFailed');
+		if (error.name !== 'RemoteCallFailed') {
 			throw new Error('expected RemoteCallFailed');
 		}
-		expect(result.error.cause).toMatchObject({ name: 'ActionFailed' });
+		expect(error.cause).toMatchObject({ name: 'ActionFailed' });
 	});
 
 	test('RecipientOffline from the relay surfaces as RemoteCallFailed', async () => {
@@ -152,11 +155,12 @@ describe('executeRun peer dispatch', () => {
 			waitMs: 25,
 		});
 
-		expect(result.error?.name).toBe('RemoteCallFailed');
-		if (result.error?.name !== 'RemoteCallFailed') {
+		const error = expectErr(result);
+		expect(error.name).toBe('RemoteCallFailed');
+		if (error.name !== 'RemoteCallFailed') {
 			throw new Error('expected RemoteCallFailed');
 		}
-		expect(result.error.cause).toMatchObject({ name: 'RecipientOffline' });
+		expect(error.cause).toMatchObject({ name: 'RecipientOffline' });
 	});
 });
 
@@ -177,8 +181,8 @@ describe('executeRun route-prefixed routing', () => {
 			waitMs: 25,
 		});
 
-		expect(result.error).toBeNull();
-		expect(result.data).toEqual({ body: 'hello' });
+		const data = expectOk(result);
+		expect(data).toEqual({ body: 'hello' });
 	});
 
 	test('missing prefix suggests action-root-relative sibling', async () => {
@@ -197,11 +201,12 @@ describe('executeRun route-prefixed routing', () => {
 			waitMs: 25,
 		});
 
-		expect(result.error?.name).toBe('UsageError');
-		if (result.error?.name !== 'UsageError') {
+		const error = expectErr(result);
+		expect(error.name).toBe('UsageError');
+		if (error.name !== 'UsageError') {
 			throw new Error('expected UsageError');
 		}
-		expect(result.error.suggestions).toEqual(['  notes.notes_add  (mutation)']);
+		expect(error.suggestions).toEqual(['  notes.notes_add  (mutation)']);
 	});
 
 	test('unknown route returns available route suggestions', async () => {
@@ -214,13 +219,14 @@ describe('executeRun route-prefixed routing', () => {
 			},
 		);
 
-		expect(result.error?.name).toBe('UsageError');
-		if (result.error?.name !== 'UsageError') {
+		const error = expectErr(result);
+		expect(error.name).toBe('UsageError');
+		if (error.name !== 'UsageError') {
 			throw new Error('expected UsageError');
 		}
-		expect(result.error.message).toBe(
+		expect(error.message).toBe(
 			'No daemon route "missing". Available: demo, tasks',
 		);
-		expect(result.error.suggestions).toEqual(['  demo', '  tasks']);
+		expect(error.suggestions).toEqual(['  demo', '  tasks']);
 	});
 });

--- a/packages/workspace/src/daemon/server.test.ts
+++ b/packages/workspace/src/daemon/server.test.ts
@@ -17,6 +17,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { expectErr, expectOk } from '@epicenter/test-utils/result';
 import { type ActionRegistry, defineQuery } from '../shared/actions.js';
 import { daemonClient } from './client.js';
 import { claimDaemonLease, type DaemonLease } from './lease.js';
@@ -44,18 +45,7 @@ function makeRuntime(
 }
 
 function claimTestLease(): DaemonLease {
-	const lease = claimDaemonLease(workDir);
-	expect(lease.error).toBeNull();
-	if (lease.error !== null) throw new Error('expected daemon lease');
-	return lease.data;
-}
-
-function expectStartedServer(
-	result: Awaited<ReturnType<typeof startDaemonServer>>,
-) {
-	expect(result.error).toBeNull();
-	if (result.error !== null) throw result.error;
-	return result.data;
+	return expectOk(claimDaemonLease(workDir));
 }
 
 beforeEach(() => {
@@ -82,11 +72,10 @@ describe('startDaemonServer', () => {
 		});
 
 		try {
-			const server = expectStartedServer(serverResult);
+			const server = expectOk(serverResult);
 
-			const result = await daemonClient(server.socketPath).peers();
-			expect(result.error).toBeNull();
-			expect(result.data).toEqual([]);
+			const data = expectOk(await daemonClient(server.socketPath).peers());
+			expect(data).toEqual([]);
 		} finally {
 			if (serverResult.error === null) await serverResult.data.close();
 			lease.release();
@@ -96,15 +85,16 @@ describe('startDaemonServer', () => {
 	test('returns RouteNameRejected before binding duplicate routes', async () => {
 		const lease = claimTestLease();
 		try {
-			const result = await startDaemonServer({
-				lease,
-				routes: [
-					{ route: 'demo', runtime: makeRuntime() },
-					{ route: 'demo', runtime: makeRuntime() },
-				],
-			});
-			expect(result.data).toBeNull();
-			expect(result.error).toMatchObject({
+			const error = expectErr(
+				await startDaemonServer({
+					lease,
+					routes: [
+						{ route: 'demo', runtime: makeRuntime() },
+						{ route: 'demo', runtime: makeRuntime() },
+					],
+				}),
+			);
+			expect(error).toMatchObject({
 				name: 'RouteNameRejected',
 				route: 'demo',
 				reason: 'duplicate',
@@ -118,12 +108,13 @@ describe('startDaemonServer', () => {
 	test('returns RouteNameRejected before binding invalid routes', async () => {
 		const lease = claimTestLease();
 		try {
-			const result = await startDaemonServer({
-				lease,
-				routes: [{ route: 'bad.route', runtime: makeRuntime() }],
-			});
-			expect(result.data).toBeNull();
-			expect(result.error).toMatchObject({
+			const error = expectErr(
+				await startDaemonServer({
+					lease,
+					routes: [{ route: 'bad.route', runtime: makeRuntime() }],
+				}),
+			);
+			expect(error).toMatchObject({
 				name: 'RouteNameRejected',
 				route: 'bad.route',
 				reason: 'invalid',
@@ -142,7 +133,7 @@ describe('startDaemonServer', () => {
 		});
 
 		try {
-			const server = expectStartedServer(serverResult);
+			const server = expectOk(serverResult);
 			expect(existsSync(server.socketPath)).toBe(true);
 
 			await server.close();
@@ -165,15 +156,15 @@ describe('startDaemonServer', () => {
 		});
 
 		try {
-			const server = expectStartedServer(serverResult);
-			const result = await daemonClient(server.socketPath).run({
-				actionPath: 'demo.echo',
-				input: null,
-				waitMs: 25,
-			});
-
-			expect(result.error).toBeNull();
-			expect(result.data).toBe('hello');
+			const server = expectOk(serverResult);
+			const data = expectOk(
+				await daemonClient(server.socketPath).run({
+					actionPath: 'demo.echo',
+					input: null,
+					waitMs: 25,
+				}),
+			);
+			expect(data).toBe('hello');
 		} finally {
 			if (serverResult.error === null) await serverResult.data.close();
 			lease.release();
@@ -187,12 +178,13 @@ describe('startDaemonServer', () => {
 			fetch: () => new Response('ok'),
 		});
 		try {
-			const second = await startDaemonServer({
-				lease,
-				routes: [{ route: 'demo', runtime: makeRuntime() }],
-			});
-			expect(second.data).toBeNull();
-			expect(second.error?.name).toBe('AlreadyRunning');
+			const error = expectErr(
+				await startDaemonServer({
+					lease,
+					routes: [{ route: 'demo', runtime: makeRuntime() }],
+				}),
+			);
+			expect(error.name).toBe('AlreadyRunning');
 		} finally {
 			await occupant.stop(true).catch(() => {
 				// best-effort

--- a/packages/workspace/src/daemon/unix-socket.test.ts
+++ b/packages/workspace/src/daemon/unix-socket.test.ts
@@ -17,6 +17,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { expectErr, expectOk } from '@epicenter/test-utils/result';
 
 import { Hono } from 'hono';
 
@@ -130,17 +131,16 @@ describe('bindOrRecover', () => {
 
 	test('clean bind: succeeds and returns the server', async () => {
 		const sock = socketPathFor(workDir);
-		const result = await bindOrRecover({
-			socketPath: sock,
-			projectDir: workDir,
-			fetch: fetchOk,
-			isSocketResponsive: async () => false,
-		});
-		expect(result.error).toBeNull();
-		if (result.error === null) {
-			servers.push(result.data);
-			expect(existsSync(sock)).toBe(true);
-		}
+		const server = expectOk(
+			await bindOrRecover({
+				socketPath: sock,
+				projectDir: workDir,
+				fetch: fetchOk,
+				isSocketResponsive: async () => false,
+			}),
+		);
+		servers.push(server);
+		expect(existsSync(sock)).toBe(true);
 	});
 
 	test('ping-finds-occupant: returns AlreadyRunning with metadata pid', async () => {
@@ -158,15 +158,16 @@ describe('bindOrRecover', () => {
 			discoveredAt: new Date(0).toISOString(),
 		});
 
-		const result = await bindOrRecover({
-			socketPath: sock,
-			projectDir: workDir,
-			fetch: fetchOk,
-			isSocketResponsive: async () => true,
-		});
-		expect(result.data).toBeNull();
-		if (result.error?.name === 'AlreadyRunning') {
-			expect(result.error.pid).toBe(4242);
+		const error = expectErr(
+			await bindOrRecover({
+				socketPath: sock,
+				projectDir: workDir,
+				fetch: fetchOk,
+				isSocketResponsive: async () => true,
+			}),
+		);
+		if (error.name === 'AlreadyRunning') {
+			expect(error.pid).toBe(4242);
 		} else {
 			throw new Error('expected AlreadyRunning');
 		}
@@ -185,17 +186,16 @@ describe('bindOrRecover', () => {
 			discoveredAt: new Date(0).toISOString(),
 		});
 
-		const result = await bindOrRecover({
-			socketPath: sock,
-			projectDir: workDir,
-			fetch: fetchOk,
-			isSocketResponsive: async () => false,
-		});
-		expect(result.error).toBeNull();
-		if (result.error === null) {
-			servers.push(result.data);
-			expect(existsSync(sock)).toBe(true);
-		}
+		const server = expectOk(
+			await bindOrRecover({
+				socketPath: sock,
+				projectDir: workDir,
+				fetch: fetchOk,
+				isSocketResponsive: async () => false,
+			}),
+		);
+		servers.push(server);
+		expect(existsSync(sock)).toBe(true);
 		// Stale metadata is swept on the recovery branch.
 		expect(existsSync(metadataPathFor(workDir))).toBe(false);
 	});

--- a/packages/workspace/src/document/create-table.test.ts
+++ b/packages/workspace/src/document/create-table.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
+import { expectErr, expectOk } from '@epicenter/test-utils/result';
 import { type } from 'arktype';
 import * as Y from 'yjs';
 import { createEncryptedYkvLww } from '../shared/y-keyvalue/y-keyvalue-lww-encrypted.js';
@@ -76,8 +77,7 @@ describe('createTable', () => {
 
 			helper.set({ id: '1', name: 'Alice', _v: 1 });
 
-			const { data, error } = helper.get('1');
-			expect(error).toBeNull();
+			const data = expectOk(helper.get('1'));
 			expect(data).toEqual({ id: '1', name: 'Alice', _v: 1 });
 		});
 
@@ -116,8 +116,7 @@ describe('createTable', () => {
 			);
 			const helper = createTable(ykv, definition, 'test');
 
-			const { data, error } = helper.get('nonexistent');
-			expect(error).toBeNull();
+			const data = expectOk(helper.get('nonexistent'));
 			expect(data).toBeNull();
 		});
 
@@ -131,15 +130,13 @@ describe('createTable', () => {
 			// Insert invalid data directly
 			yarray.push([{ key: '1', val: { id: '1', name: 123, _v: 1 }, ts: 0 }]); // name should be string
 
-			const { data, error } = helper.get('1');
-			expect(data).toBeNull();
-			expect(error).not.toBeNull();
-			expect(error?.name).toBe('ValidationFailed');
-			if (error?.name === 'ValidationFailed') {
-				expect(error.id).toBe('1');
-				expect(error.issues.length).toBeGreaterThan(0);
-				expect(error.row).toEqual({ id: '1', name: 123, _v: 1 });
-			}
+			const error = expectErr(helper.get('1'));
+			expect(error.name).toBe('ValidationFailed');
+			if (error.name !== 'ValidationFailed')
+				throw new Error('Expected ValidationFailed');
+			expect(error.id).toBe('1');
+			expect(error.issues.length).toBeGreaterThan(0);
+			expect(error.row).toEqual({ id: '1', name: 123, _v: 1 });
 		});
 
 		test('getAll / getAllValid / getAllInvalid partition results by validity', () => {
@@ -270,9 +267,8 @@ describe('createTable', () => {
 			const helper = createTable(ykv, definition, 'test');
 
 			helper.set({ id: '1', name: 'Alice', age: 25, _v: 1 });
-			const { data, error } = helper.update('1', { age: 30 });
+			const data = expectOk(helper.update('1', { age: 30 }));
 
-			expect(error).toBeNull();
 			expect(data).toEqual({ id: '1', name: 'Alice', age: 30, _v: 1 });
 
 			// Verify the row is actually saved
@@ -287,9 +283,8 @@ describe('createTable', () => {
 			);
 			const helper = createTable(ykv, definition, 'test');
 
-			const { data, error } = helper.update('nonexistent', { name: 'Bob' });
+			const data = expectOk(helper.update('nonexistent', { name: 'Bob' }));
 
-			expect(error).toBeNull();
 			expect(data).toBeNull();
 		});
 
@@ -302,9 +297,8 @@ describe('createTable', () => {
 			const update = helper.update;
 
 			helper.set({ id: '1', name: 'Alice', _v: 1 });
-			const { data, error } = update('1', { name: 'Bob' });
+			const data = expectOk(update('1', { name: 'Bob' }));
 
-			expect(error).toBeNull();
 			expect(data).toEqual({ id: '1', name: 'Bob', _v: 1 });
 			expect(helper.get('1').data).toEqual({ id: '1', name: 'Bob', _v: 1 });
 		});
@@ -319,15 +313,13 @@ describe('createTable', () => {
 			// Insert invalid data directly
 			yarray.push([{ key: '1', val: { id: '1', name: 123, _v: 1 }, ts: 0 }]); // name should be string
 
-			const { data, error } = helper.update('1', { name: 'Valid' });
-
-			expect(data).toBeNull();
-			expect(error?.name).toBe('ValidationFailed');
-			if (error?.name === 'ValidationFailed') {
-				expect(error.id).toBe('1');
-				expect(error.issues.length).toBeGreaterThan(0);
-				expect(error.row).toEqual({ id: '1', name: 123, _v: 1 });
-			}
+			const error = expectErr(helper.update('1', { name: 'Valid' }));
+			expect(error.name).toBe('ValidationFailed');
+			if (error.name !== 'ValidationFailed')
+				throw new Error('Expected ValidationFailed');
+			expect(error.id).toBe('1');
+			expect(error.issues.length).toBeGreaterThan(0);
+			expect(error.row).toEqual({ id: '1', name: 123, _v: 1 });
 		});
 
 		test('update preserves id field', () => {
@@ -338,7 +330,7 @@ describe('createTable', () => {
 			const helper = createTable(ykv, definition, 'test');
 
 			helper.set({ id: '1', name: 'Alice', _v: 1 });
-			const { data } = helper.update('1', { name: 'Bob' });
+			const data = expectOk(helper.update('1', { name: 'Bob' }));
 
 			expect(data?.id).toBe('1');
 			expect(data?.name).toBe('Bob');
@@ -560,8 +552,7 @@ describe('createTable', () => {
 				{ key: '1', val: { id: '1', name: 'Alice', _v: 1 }, ts: 0 },
 			]);
 
-			const { data, error } = helper.get('1');
-			expect(error).toBeNull();
+			const data = expectOk(helper.get('1'));
 			expect(data).toEqual({ id: '1', name: 'Alice', age: 0, _v: 2 });
 		});
 
@@ -578,8 +569,7 @@ describe('createTable', () => {
 
 			helper.set({ id: '1', name: 'Alice', age: 30, _v: 2 });
 
-			const { data, error } = helper.get('1');
-			expect(error).toBeNull();
+			const data = expectOk(helper.get('1'));
 			expect(data).toEqual({ id: '1', name: 'Alice', age: 30, _v: 2 });
 		});
 
@@ -643,14 +633,13 @@ describe('createTable', () => {
 				{ key: '1', val: { id: '1', name: 'Alice', _v: 1 }, ts: 0 },
 			]);
 
-			const { data, error } = helper.get('1');
-			expect(data).toBeNull();
-			expect(error?.name).toBe('MigrationFailed');
-			if (error?.name === 'MigrationFailed') {
-				expect(error.id).toBe('1');
-				expect(error.cause).toBeInstanceOf(Error);
-				expect((error.cause as Error).message).toBe('migration broke');
-			}
+			const error = expectErr(helper.get('1'));
+			expect(error.name).toBe('MigrationFailed');
+			if (error.name !== 'MigrationFailed')
+				throw new Error('Expected MigrationFailed');
+			expect(error.id).toBe('1');
+			expect(error.cause).toBeInstanceOf(Error);
+			expect((error.cause as Error).message).toBe('migration broke');
 		});
 	});
 
@@ -676,12 +665,11 @@ describe('createTable', () => {
 			// Any stored row triggers parseRow, which must detect the Promise.
 			ykv.set('1', { id: '1', name: 'Alice', _v: 1 });
 
-			const { data, error } = helper.get('1');
-			expect(data).toBeNull();
-			expect(error?.name).toBe('AsyncSchemaNotSupported');
-			if (error?.name === 'AsyncSchemaNotSupported') {
-				expect(error.id).toBe('1');
-			}
+			const error = expectErr(helper.get('1'));
+			expect(error.name).toBe('AsyncSchemaNotSupported');
+			if (error.name !== 'AsyncSchemaNotSupported')
+				throw new Error('Expected AsyncSchemaNotSupported');
+			expect(error.id).toBe('1');
 		});
 	});
 
@@ -696,12 +684,13 @@ describe('createTable', () => {
 			helper.set({ id: '1', name: 'Alice', age: 25, _v: 1 });
 
 			// Current row is valid; the partial update violates age>0.
-			const { data, error } = helper.update('1', {
-				age: -5,
-			} as unknown as Partial<{ name: string; age: number }>);
+			const error = expectErr(
+				helper.update('1', {
+					age: -5,
+				} as unknown as Partial<{ name: string; age: number }>),
+			);
 
-			expect(data).toBeNull();
-			expect(error?.name).toBe('ValidationFailed');
+			expect(error.name).toBe('ValidationFailed');
 
 			// And the stored row is unchanged.
 			expect(helper.get('1').data).toEqual({

--- a/packages/workspace/src/document/dispatch.test.ts
+++ b/packages/workspace/src/document/dispatch.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { expectErr, expectOk } from '@epicenter/test-utils/result';
 import Type from 'typebox';
 import { Err, Ok, type Result } from 'wellcrafted/result';
 import { Awareness } from 'y-protocols/awareness';
@@ -23,9 +24,9 @@ import { defineMutation, defineQuery } from '../shared/actions.js';
 import {
 	type ActionInput,
 	type ActionOutput,
+	DispatchError,
 	deriveDispatchUrl,
 	dispatch,
-	DispatchError,
 	getOnlineInstallationIds,
 	runInboundDispatch,
 	typedDispatch,
@@ -112,7 +113,10 @@ describe('runInboundDispatch', () => {
 			input: undefined,
 		});
 
-		const response = await runInboundDispatch({ rawFrame: inbound, actions: {} });
+		const response = await runInboundDispatch({
+			rawFrame: inbound,
+			actions: {},
+		});
 
 		const parsed = JSON.parse(response!);
 		expect(parsed.result.error.name).toBe('ActionNotFound');
@@ -164,7 +168,9 @@ describe('runInboundDispatch', () => {
 	});
 
 	test('malformed frame: returns null (do not tear down the socket)', async () => {
-		expect(await runInboundDispatch({ rawFrame: '{not json', actions: {} })).toBeNull();
+		expect(
+			await runInboundDispatch({ rawFrame: '{not json', actions: {} }),
+		).toBeNull();
 		expect(
 			await runInboundDispatch({
 				rawFrame: JSON.stringify({ type: 'not_dispatch' }),
@@ -229,8 +235,8 @@ describe('dispatch', () => {
 			req: { to: 'R_phone', action: 'tabs_close', input: { tabIds: [1, 2] } },
 		});
 
-		expect(result.error).toBeNull();
-		expect((result.data as { closed: number } | null)?.closed).toBe(2);
+		const data = expectOk(result) as { closed: number };
+		expect(data.closed).toBe(2);
 		const sent = JSON.parse(capturedBody);
 		expect(sent).toEqual({
 			from: 'R_laptop',
@@ -241,51 +247,57 @@ describe('dispatch', () => {
 	});
 
 	test('RecipientOffline: decodes from Err body', async () => {
-		installFetch(async () =>
-			new Response(
-				JSON.stringify(
-					Err({
-						name: 'RecipientOffline',
-						to: 'R_phone',
-						message: 'Recipient "R_phone" is offline',
-					}),
+		installFetch(
+			async () =>
+				new Response(
+					JSON.stringify(
+						Err({
+							name: 'RecipientOffline',
+							to: 'R_phone',
+							message: 'Recipient "R_phone" is offline',
+						}),
+					),
+					{ status: 200, headers: { 'content-type': 'application/json' } },
 				),
-				{ status: 200, headers: { 'content-type': 'application/json' } },
-			),
 		);
 
-		const result = await dispatch({
-			dispatchUrl: 'https://api.example.com/rooms/wid/dispatch',
-			installationId: 'R_laptop',
-			req: { to: 'R_phone', action: 'tabs_close', input: {} },
-		});
+		const error = expectErr(
+			await dispatch({
+				dispatchUrl: 'https://api.example.com/rooms/wid/dispatch',
+				installationId: 'R_laptop',
+				req: { to: 'R_phone', action: 'tabs_close', input: {} },
+			}),
+		);
 
-		expect(result.error?.name).toBe('RecipientOffline');
+		expect(error.name).toBe('RecipientOffline');
 	});
 
 	test('ActionNotFound: decoded with action key', async () => {
-		installFetch(async () =>
-			new Response(
-				JSON.stringify(
-					Err({
-						name: 'ActionNotFound',
-						action: 'tabs_close',
-						message: 'no handler',
-					}),
+		installFetch(
+			async () =>
+				new Response(
+					JSON.stringify(
+						Err({
+							name: 'ActionNotFound',
+							action: 'tabs_close',
+							message: 'no handler',
+						}),
+					),
+					{ status: 200, headers: { 'content-type': 'application/json' } },
 				),
-				{ status: 200, headers: { 'content-type': 'application/json' } },
-			),
 		);
 
-		const result = await dispatch({
-			dispatchUrl: 'https://api.example.com/rooms/wid/dispatch',
-			installationId: 'R_laptop',
-			req: { to: 'R_phone', action: 'tabs_close', input: {} },
-		});
+		const error = expectErr(
+			await dispatch({
+				dispatchUrl: 'https://api.example.com/rooms/wid/dispatch',
+				installationId: 'R_laptop',
+				req: { to: 'R_phone', action: 'tabs_close', input: {} },
+			}),
+		);
 
-		expect(result.error?.name).toBe('ActionNotFound');
-		if (result.error?.name !== 'ActionNotFound') throw new Error('unreachable');
-		expect(result.error.action).toBe('tabs_close');
+		expect(error.name).toBe('ActionNotFound');
+		if (error.name !== 'ActionNotFound') throw new Error('unreachable');
+		expect(error.action).toBe('tabs_close');
 	});
 
 	test('caller aborts: surfaces as Cancelled with the signal reason', async () => {
@@ -311,11 +323,11 @@ describe('dispatch', () => {
 		});
 		await Promise.resolve();
 		controller.abort('user-cancel');
-		const result = await pending;
+		const error = expectErr(await pending);
 
-		expect(result.error?.name).toBe('Cancelled');
-		if (result.error?.name !== 'Cancelled') throw new Error('unreachable');
-		expect(result.error.reason).toBe('user-cancel');
+		expect(error.name).toBe('Cancelled');
+		if (error.name !== 'Cancelled') throw new Error('unreachable');
+		expect(error.reason).toBe('user-cancel');
 	});
 
 	test('network failure (fetch throws, no abort): NetworkFailed', async () => {
@@ -323,13 +335,15 @@ describe('dispatch', () => {
 			throw new TypeError('connect ECONNREFUSED');
 		});
 
-		const result = await dispatch({
-			dispatchUrl: 'https://api.example.com/rooms/wid/dispatch',
-			installationId: 'R_laptop',
-			req: { to: 'R_phone', action: 'tabs_close', input: {} },
-		});
+		const error = expectErr(
+			await dispatch({
+				dispatchUrl: 'https://api.example.com/rooms/wid/dispatch',
+				installationId: 'R_laptop',
+				req: { to: 'R_phone', action: 'tabs_close', input: {} },
+			}),
+		);
 
-		expect(result.error?.name).toBe('NetworkFailed');
+		expect(error.name).toBe('NetworkFailed');
 	});
 });
 
@@ -383,8 +397,8 @@ describe('typedDispatch', () => {
 			action: 'tabs_close',
 			input: { tabIds: [1, 2] },
 		});
-		expect(result.error).toBeNull();
-		expect(result.data?.closedCount).toBe(2);
+		const data = expectOk(result);
+		expect(data.closedCount).toBe(2);
 	});
 });
 

--- a/packages/workspace/src/shared/actions.test.ts
+++ b/packages/workspace/src/shared/actions.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
+import { expectErr, expectOk } from '@epicenter/test-utils/result';
 import Type from 'typebox';
 import { Err, Ok } from 'wellcrafted/result';
 import {
@@ -29,27 +30,30 @@ describe('invokeAction', () => {
 			const action = defineMutation({
 				handler: () => ({ count: 7 }),
 			});
-			const result = await invokeAction<{ count: number }>(action, undefined);
-			expect(result.error).toBeNull();
-			expect(result.data).toEqual({ count: 7 });
+			const data = expectOk(
+				await invokeAction<{ count: number }>(action, undefined),
+			);
+			expect(data).toEqual({ count: 7 });
 		});
 
 		test('Ok-wraps a raw return value from an async handler', async () => {
 			const action = defineMutation({
 				handler: async () => ({ count: 11 }),
 			});
-			const result = await invokeAction<{ count: number }>(action, undefined);
-			expect(result.error).toBeNull();
-			expect(result.data).toEqual({ count: 11 });
+			const data = expectOk(
+				await invokeAction<{ count: number }>(action, undefined),
+			);
+			expect(data).toEqual({ count: 11 });
 		});
 
 		test('passes through an Ok from a Result-returning handler unchanged', async () => {
 			const action = defineMutation({
 				handler: () => Ok({ ok: true }),
 			});
-			const result = await invokeAction<{ ok: boolean }>(action, undefined);
-			expect(result.error).toBeNull();
-			expect(result.data).toEqual({ ok: true });
+			const data = expectOk(
+				await invokeAction<{ ok: boolean }>(action, undefined),
+			);
+			expect(data).toEqual({ ok: true });
 		});
 
 		test('passes through an Err from a Result-returning handler unchanged', async () => {
@@ -57,9 +61,8 @@ describe('invokeAction', () => {
 			const action = defineMutation({
 				handler: () => Err(customError) as unknown as ReturnType<typeof Ok>,
 			});
-			const result = await invokeAction(action, undefined);
-			expect(result.data).toBeNull();
-			expect(result.error as unknown).toEqual(customError);
+			const error = expectErr(await invokeAction(action, undefined));
+			expect(error as unknown).toEqual(customError);
 		});
 
 		test('isResult discrimination is structural and passes through {data,error}-shaped values', async () => {
@@ -71,9 +74,8 @@ describe('invokeAction', () => {
 			const action = defineMutation({
 				handler: () => lookalike as unknown as ReturnType<typeof Ok>,
 			});
-			const result = await invokeAction<string>(action, undefined);
-			expect(result.error).toBeNull();
-			expect(result.data).toBe('fake');
+			const data = expectOk(await invokeAction<string>(action, undefined));
+			expect(data).toBe('fake');
 		});
 	});
 
@@ -85,9 +87,8 @@ describe('invokeAction', () => {
 					throw cause;
 				},
 			});
-			const result = await invokeAction(action, undefined);
-			expect(result.data).toBeNull();
-			expect(result.error).toBe(cause);
+			const error = expectErr(await invokeAction(action, undefined));
+			expect(error).toBe(cause);
 		});
 
 		test('catches an async rejection and returns Err(cause) with the raw cause', async () => {
@@ -97,9 +98,8 @@ describe('invokeAction', () => {
 					throw cause;
 				},
 			});
-			const result = await invokeAction(action, undefined);
-			expect(result.data).toBeNull();
-			expect(result.error).toBe(cause);
+			const error = expectErr(await invokeAction(action, undefined));
+			expect(error).toBe(cause);
 		});
 
 		test('catches a thrown non-Error value and preserves it as-is', async () => {
@@ -108,8 +108,8 @@ describe('invokeAction', () => {
 					throw 'string-throw';
 				},
 			});
-			const result = await invokeAction(action, undefined);
-			expect(result.error).toBe('string-throw');
+			const error = expectErr(await invokeAction(action, undefined));
+			expect(error).toBe('string-throw');
 		});
 	});
 
@@ -136,9 +136,9 @@ describe('invokeAction', () => {
 					return input.x * 2;
 				},
 			});
-			const result = await invokeAction<number>(action, { x: 21 });
+			const data = expectOk(await invokeAction<number>(action, { x: 21 }));
 			expect(seenInputs).toEqual([{ x: 21 }]);
-			expect(result.data).toBe(42);
+			expect(data).toBe(42);
 		});
 	});
 
@@ -150,16 +150,14 @@ describe('invokeAction', () => {
 			const mutation = defineMutation({
 				handler: () => ({ kind: 'mutation' as const }),
 			});
-			const queryResult = await invokeAction<{ kind: 'query' }>(
-				query,
-				undefined,
+			const queryData = expectOk(
+				await invokeAction<{ kind: 'query' }>(query, undefined),
 			);
-			const mutationResult = await invokeAction<{ kind: 'mutation' }>(
-				mutation,
-				undefined,
+			const mutationData = expectOk(
+				await invokeAction<{ kind: 'mutation' }>(mutation, undefined),
 			);
-			expect(queryResult.data).toEqual({ kind: 'query' });
-			expect(mutationResult.data).toEqual({ kind: 'mutation' });
+			expect(queryData).toEqual({ kind: 'query' });
+			expect(mutationData).toEqual({ kind: 'mutation' });
 		});
 	});
 });

--- a/packages/workspace/src/workspace-apps/discover.test.ts
+++ b/packages/workspace/src/workspace-apps/discover.test.ts
@@ -13,6 +13,8 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { expectErr, expectOk } from '@epicenter/test-utils/result';
+
 import { discoverWorkspaceApps } from './discover.js';
 
 let projectDir: string;
@@ -53,8 +55,8 @@ function makeWorkspace(
 describe('discoverWorkspaceApps', () => {
 	test('returns an empty list when workspaces/ does not exist', () => {
 		const result = discoverWorkspaceApps(projectDir);
-		expect(result.error).toBeNull();
-		expect(result.data).toEqual([]);
+		const data = expectOk(result);
+		expect(data).toEqual([]);
 	});
 
 	test('resolves each workspace folder with its execution paths', () => {
@@ -62,10 +64,8 @@ describe('discoverWorkspaceApps', () => {
 		const opensidianDir = makeWorkspace('opensidian');
 
 		const result = discoverWorkspaceApps(projectDir);
-		expect(result.error).toBeNull();
-		const entries = result.data!.slice().sort((a, b) =>
-			a.route.localeCompare(b.route),
-		);
+		const data = expectOk(result);
+		const entries = data.slice().sort((a, b) => a.route.localeCompare(b.route));
 		expect(entries).toEqual([
 			{
 				route: 'fuji',
@@ -84,8 +84,8 @@ describe('discoverWorkspaceApps', () => {
 		makeWorkspace('.DS_Store', { withDaemon: false });
 
 		const result = discoverWorkspaceApps(projectDir);
-		expect(result.error).toBeNull();
-		expect(result.data!.map((entry) => entry.route)).toEqual(['fuji']);
+		const data = expectOk(result);
+		expect(data.map((entry) => entry.route)).toEqual(['fuji']);
 	});
 
 	test('skips a workspace folder missing daemon.ts', () => {
@@ -93,8 +93,8 @@ describe('discoverWorkspaceApps', () => {
 		makeWorkspace('headless', { withDaemon: false });
 
 		const result = discoverWorkspaceApps(projectDir);
-		expect(result.error).toBeNull();
-		expect(result.data!.map((entry) => entry.route)).toEqual(['fuji']);
+		const data = expectOk(result);
+		expect(data.map((entry) => entry.route)).toEqual(['fuji']);
 	});
 
 	test('rejects invalid folder names before requiring daemon.ts', () => {
@@ -107,9 +107,9 @@ describe('discoverWorkspaceApps', () => {
 		);
 
 		const result = discoverWorkspaceApps(projectDir);
-		expect(result.data).toBeNull();
-		expect(result.error?.name).toBe('WorkspaceFolderInvalid');
-		expect(result.error).toMatchObject({
+		const error = expectErr(result);
+		expect(error.name).toBe('WorkspaceFolderInvalid');
+		expect(error).toMatchObject({
 			folderName: '__proto__',
 			reason: 'invalid-name',
 		});
@@ -122,13 +122,12 @@ describe('discoverWorkspaceApps', () => {
 			makeWorkspace('Fuji');
 
 			const result = discoverWorkspaceApps(projectDir);
-			expect(result.data).toBeNull();
-			expect(result.error?.name).toBe('WorkspaceFolderCollision');
-			expect(result.error).toMatchObject({ route: 'fuji' });
-			const folderNames = (result.error as {
-				folderNames: readonly string[];
-			}).folderNames;
-			expect(folderNames.slice().sort()).toEqual(['Fuji', 'fuji']);
+			const error = expectErr(result);
+			if (error.name !== 'WorkspaceFolderCollision') {
+				throw new Error(`Expected WorkspaceFolderCollision, got ${error.name}`);
+			}
+			expect(error).toMatchObject({ route: 'fuji' });
+			expect(error.folderNames.slice().sort()).toEqual(['Fuji', 'fuji']);
 		},
 	);
 });

--- a/packages/workspace/src/workspace-apps/start-daemon-workspace-apps.test.ts
+++ b/packages/workspace/src/workspace-apps/start-daemon-workspace-apps.test.ts
@@ -10,16 +10,12 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import {
-	mkdirSync,
-	mkdtempSync,
-	rmSync,
-	writeFileSync,
-} from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import type { AuthClient } from '@epicenter/auth';
+import { expectErr, expectOk } from '@epicenter/test-utils/result';
 
 import { startDaemonWorkspaceApps } from './start-daemon-workspace-apps.js';
 
@@ -82,8 +78,8 @@ describe('startDaemonWorkspaceApps', () => {
 			projectDir,
 			auth: stubAuthClient(),
 		});
-		expect(result.error).toBeNull();
-		const routes = result.data!.routes
+		const data = expectOk(result);
+		const routes = data.routes
 			.map((entry) => entry.route)
 			.slice()
 			.sort();
@@ -121,9 +117,9 @@ describe('startDaemonWorkspaceApps', () => {
 			projectDir,
 			auth: stubAuthClient(),
 		});
-		expect(result.data).toBeNull();
-		expect(result.error?.name).toBe('WorkspaceOpenFailed');
-		expect(result.error).toMatchObject({ route: 'bad' });
+		const error = expectErr(result);
+		expect(error.name).toBe('WorkspaceOpenFailed');
+		expect(error).toMatchObject({ route: 'bad' });
 
 		expect(await Bun.file(goodMarker).exists()).toBe(true);
 	});
@@ -139,9 +135,9 @@ describe('startDaemonWorkspaceApps', () => {
 			projectDir,
 			auth: stubAuthClient(),
 		});
-		expect(result.data).toBeNull();
-		expect(result.error?.name).toBe('WorkspaceDaemonInvalidExport');
-		expect(result.error).toMatchObject({ route: 'broken' });
+		const error = expectErr(result);
+		expect(error.name).toBe('WorkspaceDaemonInvalidExport');
+		expect(error).toMatchObject({ route: 'broken' });
 	});
 
 	test('returns an empty result when there is no workspaces/ directory', async () => {
@@ -149,8 +145,8 @@ describe('startDaemonWorkspaceApps', () => {
 			projectDir,
 			auth: stubAuthClient(),
 		});
-		expect(result.error).toBeNull();
-		expect(result.data!.routes).toEqual([]);
+		const data = expectOk(result);
+		expect(data.routes).toEqual([]);
 	});
 
 	test('refuses to open workspaces when machine auth is signed out', async () => {
@@ -168,7 +164,7 @@ describe('startDaemonWorkspaceApps', () => {
 			projectDir,
 			auth: { state: { status: 'signed-out' } } as AuthClient,
 		});
-		expect(result.data).toBeNull();
-		expect(result.error?.name).toBe('WorkspaceAuthSignedOut');
+		const error = expectErr(result);
+		expect(error.name).toBe('WorkspaceAuthSignedOut');
 	});
 });

--- a/packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts
+++ b/packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts
@@ -18,7 +18,7 @@
 
 import { resolve } from 'node:path';
 import type { AuthClient } from '@epicenter/auth';
-import { Ok, type Result } from 'wellcrafted/result';
+import { Err, Ok, type Result } from 'wellcrafted/result';
 import type * as Y from 'yjs';
 
 import type { DaemonWorkspaceContext } from '../daemon/define-daemon-workspace.js';
@@ -89,7 +89,7 @@ export async function startDaemonWorkspaceApps(
 
 	if (firstError !== null) {
 		await disposeOpenedRuntimes(opened);
-		return { data: null, error: firstError };
+		return Err(firstError);
 	}
 
 	return Ok({ routes: opened });

--- a/specs/20260519T080853-shared-result-test-helpers.md
+++ b/specs/20260519T080853-shared-result-test-helpers.md
@@ -1,0 +1,310 @@
+# Shared Result Test Helpers
+
+Date: 2026-05-19
+Status: planned
+Owner: Braden
+
+## 1. Context
+
+Tests across the repo often work with `wellcrafted/result` values:
+
+```ts
+const { data, error } = await client.handleCallback(url);
+
+expect(error).toBeNull();
+expect(data?.accessToken).toBe('access-token');
+```
+
+The runtime assertion is fine, but TypeScript does not learn from `expect(error).toBeNull()`. The optional chain is a type workaround, not part of the test's claim. The test means "this result is Ok, now inspect the data."
+
+The same pattern appears on error paths:
+
+```ts
+const { error } = await resolveBearerIdentity(args);
+
+expect(error?.name).toBe('InvalidToken');
+```
+
+That test means "this result is Err, now inspect the error." Optional chaining weakens the assertion shape and makes later property checks harder to narrow.
+
+## 2. Current Evidence
+
+Grep pass on 2026-05-19:
+
+```sh
+rg "expect\([^)]*error[^)]*\)\.toBeNull\(\)" apps packages -g "*.test.ts" -n
+```
+
+Result: `52` matches.
+
+```sh
+rg "const \{ data, error \}|const \{ error, data \}|const \{ data: [^,}]+, error \}|const \{ error, data: [^,}]+ \}" apps packages -g "*.test.ts" -n
+```
+
+Result: `24` matches.
+
+```sh
+rg "result\.data\?\.|data\?\." apps packages -g "*.test.ts" -n
+```
+
+Result: `22` matches. Some are not `Result` values, so each hit needs review.
+
+```sh
+rg -U "expect\((?:error|result\.error|[a-zA-Z]+\.error)\)\.toBeNull\(\);\n(?:.*\n){0,6}.*(?:data|result\.data|[a-zA-Z]+\.data)\?\." apps packages -g "*.test.ts" -n
+```
+
+Result: `18` likely success-path `Result` matches.
+
+Existing precedent:
+
+```ts
+function expectOk<T>(result: Result<T, unknown>): T {
+	expect(result.error).toBeNull();
+	if (result.error !== null) throw result.error;
+	return result.data as T;
+}
+```
+
+This already exists locally in `packages/cli/src/commands/up.test.ts` and `apps/api/src/sync-handlers.test.ts`.
+
+## 3. Target State
+
+Use one shared test-only helper module:
+
+```ts
+import { expectErr, expectOk } from '@epicenter/test-utils/result';
+
+const data = expectOk(await client.handleCallback(url));
+expect(data.accessToken).toBe('access-token');
+
+const error = expectErr(await resolveBearerIdentity(args));
+expect(error.name).toBe('InvalidToken');
+```
+
+The helpers should do one thing: convert a `Result<T, E>` into the branch the test claims it expects.
+
+```txt
+Result<T, E>
+   │
+   ├─ expectOk(result)  -> T
+   │
+   └─ expectErr(result) -> E
+```
+
+Do not add helper variants for specific domain unions, such as `expectEffectAction`. Those are too narrow. Domain-specific narrowing should stay inline:
+
+```ts
+const effect = expectOk(applyMessage(args));
+
+expect(effect?.action).toBe('broadcast');
+if (effect?.action !== 'broadcast') {
+	throw new Error('Expected broadcast effect');
+}
+
+expect(effect.learnedClientIDs).toEqual([clientID]);
+```
+
+`expectOk` unwraps the `Result`. It does not prove that nullable success data is present. If a function returns `Result<T | null, E>`, the test still needs to assert the `null` contract or narrow the value.
+
+## 4. Placement Decision
+
+Create a new private workspace package:
+
+```txt
+packages/test-utils/
+  package.json
+  tsconfig.json
+  src/
+    result.ts
+```
+
+Package name:
+
+```json
+"name": "@epicenter/test-utils"
+```
+
+Export:
+
+```json
+"exports": {
+  "./result": "./src/result.ts"
+}
+```
+
+Why not `@epicenter/workspace/test-utils`: auth, API, and CLI tests should not import the workspace package just to unwrap a `Result`. That creates the wrong dependency direction and makes a test helper look domain-owned.
+
+Why not a root `test-utils/` folder: package tests already resolve workspace packages through package exports. A private workspace package gives the helper a stable import path, clear ownership, and no relative path churn.
+
+Why not put it in `wellcrafted`: this is a Bun test assertion helper, not a result primitive. It imports `expect` from `bun:test`, so it belongs in test-only project code.
+
+## 5. Helper Contract
+
+Implement only these exports:
+
+```ts
+import { expect } from 'bun:test';
+import type { Result } from 'wellcrafted/result';
+
+export function expectOk<T>(result: Result<T, unknown>): T {
+	expect(result.error).toBeNull();
+	if (result.error !== null) throw result.error;
+	return result.data;
+}
+
+export function expectErr<E>(result: Result<unknown, E>): E {
+	expect(result.error).not.toBeNull();
+	if (result.error === null) throw new Error('Expected Err result');
+	return result.error;
+}
+```
+
+Prefer returning without casts. If TypeScript fails to narrow the generic `Result`, use the smallest cast inside the helper and nowhere else.
+
+Do not add:
+
+```ts
+expectResultName(...)
+expectValidationFailed(...)
+expectEffectAction(...)
+```
+
+Those hide domain behavior. Use `expectErr` or `expectOk`, then write the domain assertion in the test.
+
+## 6. Implementation Plan
+
+### Phase 1: Add The Package
+
+- [ ] **1.1** Create `packages/test-utils/package.json` with `@epicenter/test-utils`, private package metadata, an export for `./result`, and scripts for `typecheck` and `test` if needed.
+- [ ] **1.2** Create `packages/test-utils/tsconfig.json` extending the repo base config and including `src/**/*.ts`.
+- [ ] **1.3** Create `packages/test-utils/src/result.ts` with `expectOk` and `expectErr`.
+- [ ] **1.4** Run `bun run --cwd packages/test-utils typecheck`.
+
+### Phase 2: Wire Consumers
+
+- [ ] **2.1** Add `@epicenter/test-utils: workspace:*` as a `devDependency` to every package or app whose tests import it.
+- [ ] **2.2** Start with the packages already known to need it: `apps/api`, `packages/auth`, `packages/cli`, and `packages/workspace`.
+- [ ] **2.3** Do not add it to packages that do not import it.
+
+### Phase 3: Migrate Existing Local Helpers
+
+- [ ] **3.1** Replace the local `expectOk` in `packages/cli/src/commands/up.test.ts` with the shared import.
+- [ ] **3.2** Replace the local `expectOk` in `apps/api/src/sync-handlers.test.ts` with the shared import.
+- [ ] **3.3** Keep the current inline `effect.action` narrowing in `sync-handlers.test.ts`; do not introduce `expectEffectAction`.
+
+### Phase 4: Migrate Success Paths
+
+Use this shape:
+
+```ts
+const result = await operation();
+const data = expectOk(result);
+expect(data.value).toBe(expected);
+```
+
+or inline when it reads cleanly:
+
+```ts
+const data = expectOk(await operation());
+expect(data.value).toBe(expected);
+```
+
+Targets from the current grep:
+
+- [ ] **4.1** `packages/auth/src/oauth-launchers/index.test.ts`: replace success-path `data?.` checks after `expect(error).toBeNull()`.
+- [ ] **4.2** `apps/api/src/auth/resource-boundary.test.ts`: replace success-path `data?.` checks after `expect(error).toBeNull()`.
+- [ ] **4.3** `packages/auth/src/node/oob-launcher.test.ts`: replace `result.data?.accessToken` after `expect(result.error).toBeNull()`.
+- [ ] **4.4** `packages/auth/src/node/machine-auth.test.ts`: replace `result.data?.identity` and `result.data?.status` after `expect(result.error).toBeNull()`.
+- [ ] **4.5** `packages/workspace/src/document/dispatch.test.ts`: replace `result.data?.closed` after `expect(result.error).toBeNull()`.
+- [ ] **4.6** Review `packages/workspace/src/document/create-table.test.ts` hits where tests destructure only `data`. If the test assumes an Ok result, migrate to `expectOk`.
+
+### Phase 5: Migrate Clear Error Paths
+
+Use this shape:
+
+```ts
+const error = expectErr(await operation());
+expect(error.name).toBe('InvalidToken');
+```
+
+For discriminated error variants, keep the explicit guard:
+
+```ts
+const error = expectErr(result);
+expect(error.name).toBe('ValidationFailed');
+if (error.name !== 'ValidationFailed') {
+	throw new Error('Expected ValidationFailed');
+}
+expect(error.issues.length).toBeGreaterThan(0);
+```
+
+- [ ] **5.1** Migrate simple `error?.name` assertions where the full `Result` value can be kept.
+- [ ] **5.2** Leave non-Result optional chains alone, such as array indexing, captured fetch `init?.body`, map lookups, and mock callback arguments.
+- [ ] **5.3** Do not rewrite error checks where optional chaining is documenting real absence instead of compensating for a Result branch.
+
+## 7. Verification
+
+Run formatting, typechecks, and focused tests:
+
+```sh
+bun x biome check --write --linter-enabled=false packages/test-utils apps/api packages/auth packages/cli packages/workspace
+bun run --cwd packages/test-utils typecheck
+bun run --cwd apps/api typecheck
+bun run --cwd packages/auth typecheck
+bun run --cwd packages/workspace typecheck
+bun test apps/api/src/sync-handlers.test.ts
+bun test packages/auth/src/oauth-launchers/index.test.ts packages/auth/src/node/oob-launcher.test.ts packages/auth/src/node/machine-auth.test.ts
+bun test packages/workspace/src/document/dispatch.test.ts packages/workspace/src/document/create-table.test.ts
+```
+
+Then run the no-straggler checks.
+
+Success-path stragglers:
+
+```sh
+rg -U "expect\((?:error|result\.error|[a-zA-Z]+\.error)\)\.toBeNull\(\);\n(?:.*\n){0,6}.*(?:data|result\.data|[a-zA-Z]+\.data)\?\." apps packages -g "*.test.ts" -n
+```
+
+Expected result: no matches, unless a match is explicitly documented in the final report as not a `Result` branch.
+
+Local helper stragglers:
+
+```sh
+rg "function expectOk|function expectErr|const expectOk|const expectErr" apps packages -g "*.test.ts" -n
+```
+
+Expected result: no local definitions outside `packages/test-utils/src/result.ts`.
+
+Broad review scan:
+
+```sh
+rg "result\.data\?\.|data\?\.|result\.error\?\.|error\?\." apps packages -g "*.test.ts" -n
+```
+
+Expected result: remaining matches are either non-Result optional chains, nullable success data that is intentionally nullable, or error-shape checks that need a domain guard and were deliberately left for a follow-up.
+
+If the focused no-straggler checks pass, the implementation report should include:
+
+1. The number of migrated `expectOk` call sites.
+2. The number of migrated `expectErr` call sites.
+3. Any remaining broad-scan optional chains, grouped by reason.
+4. A short recommendation for the next cleanup scope if the broad scan shows another repeated pattern.
+
+## 8. Non-goals
+
+- Do not create a custom matcher API.
+- Do not add global Bun expect extensions.
+- Do not add domain-specific unwrap helpers.
+- Do not migrate non-Result optional chaining.
+- Do not change production `Result` APIs.
+- Do not move package-local test setup helpers into `@epicenter/test-utils` unless they are Result-related.
+
+## 9. Stop Conditions
+
+Stop when:
+
+1. `expectOk` and `expectErr` live in one shared test-only package.
+2. Existing local `expectOk` helpers are gone.
+3. Success-path `expect(error).toBeNull()` plus `data?.` patterns are gone or explicitly justified.
+4. Focused test and typecheck commands pass.
+5. The final report lists remaining broad optional-chain matches instead of pretending they do not exist.


### PR DESCRIPTION
Re-opens the merged #1780 against the correct base after the stack was reordered so that test-utils sits below the api-session clean break (which now depends on `@epicenter/test-utils/result`).

A lot of tests were repeating the same Result assertions by hand: check `ok`, narrow the branch, then inspect `value` or `error`. This PR extracts those assertions into a small `@epicenter/test-utils` package so tests across API, auth, CLI, and workspace can use the same `expectOk` and `expectErr` helpers.

```typescript
const value = expectOk(result);
const error = expectErr(result);
```

## Test plan
- [x] `bun test` in `packages/auth` (`contract.test.ts`, `node/machine-auth.test.ts`) — 30 pass
- [x] `bun test packages/workspace/src/document/dispatch.test.ts` — 17 pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->