### PR TITLE
feat(workspace): add project config foundation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -751,6 +751,7 @@
         "diff": "^8.0.3",
         "drizzle-orm": "catalog:",
         "elysia": "^1.2.25",
+        "env-paths": "^3.0.0",
         "fflate": "catalog:",
         "hono": "catalog:",
         "lib0": "catalog:",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -63,6 +63,7 @@
 		"diff": "^8.0.3",
 		"drizzle-orm": "catalog:",
 		"elysia": "^1.2.25",
+		"env-paths": "^3.0.0",
 		"fflate": "catalog:",
 		"hono": "catalog:",
 		"lib0": "catalog:",

--- a/packages/workspace/src/client/find-project-root.test.ts
+++ b/packages/workspace/src/client/find-project-root.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { ProjectDir } from '../shared/types.js';
+import { findProjectRoot } from './find-project-root.js';
+
+let root: string;
+
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), 'find-project-root-'));
+});
+
+afterEach(() => {
+	rmSync(root, { recursive: true, force: true });
+});
+
+function writeProjectConfig(dir: string = root): void {
+	writeFileSync(join(dir, 'epicenter.config.ts'), 'export default {};\n');
+}
+
+describe('findProjectRoot', () => {
+	test('finds a project by epicenter.config.ts', () => {
+		writeProjectConfig();
+
+		expect(findProjectRoot(root)).toBe(root as ProjectDir);
+	});
+
+	test('walks up from a nested subdirectory', () => {
+		writeProjectConfig();
+		const nested = join(root, 'a', 'b', 'c');
+		mkdirSync(nested, { recursive: true });
+
+		expect(findProjectRoot(nested)).toBe(root as ProjectDir);
+	});
+
+	test('ignores workspaces and .epicenter as project markers', () => {
+		mkdirSync(join(root, 'workspaces'));
+		mkdirSync(join(root, '.epicenter'));
+
+		expect(() => findProjectRoot(root)).toThrow(
+			/no epicenter\.config\.ts found/,
+		);
+	});
+
+	test('throws if no config is found before the filesystem root', () => {
+		expect(() => findProjectRoot(root)).toThrow(
+			`findProjectRoot: no epicenter.config.ts found walking up from ${root}.`,
+		);
+	});
+});

--- a/packages/workspace/src/client/find-project-root.ts
+++ b/packages/workspace/src/client/find-project-root.ts
@@ -1,0 +1,22 @@
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { PROJECT_CONFIG_FILENAME } from '../config/define-config.js';
+import type { ProjectDir } from '../shared/types.js';
+
+export function findProjectRoot(start: string = process.cwd()): ProjectDir {
+	let current = resolve(start);
+	while (true) {
+		if (existsSync(join(current, PROJECT_CONFIG_FILENAME))) {
+			return current as ProjectDir;
+		}
+
+		const parent = dirname(current);
+		if (parent === current) {
+			throw new Error(
+				`findProjectRoot: no ${PROJECT_CONFIG_FILENAME} found walking up from ${start}. ` +
+					`Run \`epicenter daemon up\` to create one.`,
+			);
+		}
+		current = parent;
+	}
+}

--- a/packages/workspace/src/config/define-config.test.ts
+++ b/packages/workspace/src/config/define-config.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { DaemonWorkspaceModule } from '../daemon/define-daemon-workspace.js';
+import { defineConfig, type EpicenterConfig } from './define-config.js';
+
+type Expect<TValue extends true> = TValue;
+type Equal<TActual, TExpected> =
+	(<T>() => T extends TActual ? 1 : 2) extends <T>() => T extends TExpected
+		? 1
+		: 2
+		? true
+		: false;
+
+describe('defineConfig', () => {
+	test('returns the config unchanged', () => {
+		const route = {
+			open: () => {
+				throw new Error('test route should not open');
+			},
+		} satisfies DaemonWorkspaceModule;
+		const config = { routes: [route] };
+
+		expect(defineConfig(config)).toBe(config);
+	});
+
+	test('accepts an empty config', () => {
+		expect(defineConfig({})).toEqual({});
+	});
+});
+
+const inferred = defineConfig({});
+export type InferredConfigIsEpicenterConfig = Expect<
+	Equal<typeof inferred, EpicenterConfig>
+>;
+
+// @ts-expect-error routes must be daemon workspace modules.
+defineConfig({ routes: [{ open: 1 }] });
+
+// @ts-expect-error routes must be an array.
+defineConfig({ routes: {} });

--- a/packages/workspace/src/config/define-config.ts
+++ b/packages/workspace/src/config/define-config.ts
@@ -1,0 +1,11 @@
+import type { DaemonWorkspaceModule } from '../daemon/define-daemon-workspace.js';
+
+export const PROJECT_CONFIG_FILENAME = 'epicenter.config.ts';
+
+export type EpicenterConfig = {
+	routes?: DaemonWorkspaceModule[];
+};
+
+export function defineConfig(config: EpicenterConfig): EpicenterConfig {
+	return config;
+}

--- a/packages/workspace/src/config/load-project-config.test.ts
+++ b/packages/workspace/src/config/load-project-config.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { loadProjectConfig } from './load-project-config.js';
+
+let projectDir: string;
+
+beforeEach(() => {
+	projectDir = mkdtempSync(join(tmpdir(), 'load-project-config-'));
+});
+
+afterEach(() => {
+	rmSync(projectDir, { recursive: true, force: true });
+});
+
+function writeConfig(source: string): void {
+	writeFileSync(join(projectDir, 'epicenter.config.ts'), source);
+}
+
+describe('loadProjectConfig', () => {
+	test('returns a typed not-found error when the config is missing', async () => {
+		const { data, error } = await loadProjectConfig(projectDir);
+		expect(data).toBeNull();
+		if (error === null) throw new Error('Expected ProjectConfigNotFound');
+		expect(error).toMatchObject({
+			name: 'ProjectConfigNotFound',
+			projectConfigPath: join(projectDir, 'epicenter.config.ts'),
+		});
+	});
+
+	test('loads an empty config', async () => {
+		writeConfig('export default {};\n');
+
+		const { data, error } = await loadProjectConfig(projectDir);
+		if (error !== null) throw new Error(error.message);
+		expect(data).toEqual({});
+	});
+
+	test('loads routes from the config default export', async () => {
+		writeConfig('export default { routes: [{ open() {} }] };\n');
+
+		const { data, error } = await loadProjectConfig(projectDir);
+		if (error !== null) throw new Error(error.message);
+		expect(data.routes).toHaveLength(1);
+		expect(data.routes?.[0]?.open).toBeFunction();
+	});
+
+	test('throws with the config path when the default export is invalid', async () => {
+		writeConfig('export default { routes: {} };\n');
+
+		await expect(loadProjectConfig(projectDir)).rejects.toThrow(
+			`loadProjectConfig: ${join(projectDir, 'epicenter.config.ts')} is invalid`,
+		);
+	});
+
+	test('throws with the config path when the default export is missing', async () => {
+		writeConfig('export const config = {};\n');
+
+		await expect(loadProjectConfig(projectDir)).rejects.toThrow(
+			`loadProjectConfig: ${join(projectDir, 'epicenter.config.ts')} must default-export`,
+		);
+	});
+
+	test('throws with the config path when the config has bad syntax', async () => {
+		writeConfig('export default {;\n');
+
+		await expect(loadProjectConfig(projectDir)).rejects.toThrow(
+			`loadProjectConfig: failed to load ${join(projectDir, 'epicenter.config.ts')}`,
+		);
+	});
+});

--- a/packages/workspace/src/config/load-project-config.ts
+++ b/packages/workspace/src/config/load-project-config.ts
@@ -1,0 +1,73 @@
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { type } from 'arktype';
+import {
+	defineErrors,
+	extractErrorMessage,
+	type InferErrors,
+} from 'wellcrafted/error';
+import { Ok, type Result } from 'wellcrafted/result';
+
+import type { ProjectDir } from '../shared/types.js';
+import {
+	type EpicenterConfig,
+	PROJECT_CONFIG_FILENAME,
+} from './define-config.js';
+
+const EpicenterConfigSchema = type({
+	'routes?': type({ open: 'Function' }).array(),
+});
+
+export const ProjectConfigError = defineErrors({
+	ProjectConfigNotFound: ({
+		projectConfigPath,
+	}: {
+		projectConfigPath: string;
+	}) => ({
+		message: `Project config not found at ${projectConfigPath}`,
+		projectConfigPath,
+	}),
+});
+export type ProjectConfigError = InferErrors<typeof ProjectConfigError>;
+
+export async function loadProjectConfig(
+	projectDir: ProjectDir | string,
+): Promise<Result<EpicenterConfig, ProjectConfigError>> {
+	const projectConfigPath = join(resolve(projectDir), PROJECT_CONFIG_FILENAME);
+	if (!existsSync(projectConfigPath)) {
+		return ProjectConfigError.ProjectConfigNotFound({ projectConfigPath });
+	}
+
+	const module = await importProjectConfig(projectConfigPath);
+	if (!('default' in module)) {
+		throw new Error(
+			`loadProjectConfig: ${projectConfigPath} must default-export defineConfig(...).`,
+		);
+	}
+
+	const loaded = EpicenterConfigSchema(module.default);
+	if (loaded instanceof type.errors) {
+		throw new Error(
+			`loadProjectConfig: ${projectConfigPath} is invalid: ${loaded.toString()}`,
+		);
+	}
+
+	return Ok(loaded as EpicenterConfig);
+}
+
+async function importProjectConfig(
+	projectConfigPath: string,
+): Promise<{ default?: unknown }> {
+	try {
+		return (await import(pathToFileURL(projectConfigPath).href)) as {
+			default?: unknown;
+		};
+	} catch (cause) {
+		throw new Error(
+			`loadProjectConfig: failed to load ${projectConfigPath}: ${extractErrorMessage(cause)}`,
+			{ cause },
+		);
+	}
+}

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -106,6 +106,23 @@ export {
 // PATH TYPES (for daemon callers)
 // ════════════════════════════════════════════════════════════════════════════
 
+export { findProjectRoot } from './client/find-project-root.js';
+export {
+	defineConfig,
+	type EpicenterConfig,
+	PROJECT_CONFIG_FILENAME,
+} from './config/define-config.js';
+export {
+	loadProjectConfig,
+	ProjectConfigError,
+	type ProjectConfigError as ProjectConfigErrorType,
+} from './config/load-project-config.js';
+export {
+	userCacheDir,
+	userConfigDir,
+	userDataDir,
+	userLogDir,
+} from './paths/user-paths.js';
 export type { ProjectDir } from './shared/types';
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -157,9 +174,9 @@ export {
 	typedDispatch,
 } from './document/dispatch.js';
 export { docGuid } from './document/doc-guid.js';
-export {
-	type OpenWebSocket,
-	type SyncStatus,
+export type {
+	OpenWebSocket,
+	SyncStatus,
 } from './document/internal/sync-supervisor.js';
 export {
 	createLocalOwner,

--- a/packages/workspace/src/paths/user-paths.test.ts
+++ b/packages/workspace/src/paths/user-paths.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+import { isAbsolute } from 'node:path';
+
+import {
+	userCacheDir,
+	userConfigDir,
+	userDataDir,
+	userLogDir,
+} from './user-paths.js';
+
+describe('user paths', () => {
+	test('uses platform absolute paths for every user path', () => {
+		expect(isAbsolute(userConfigDir)).toBe(true);
+		expect(isAbsolute(userDataDir)).toBe(true);
+		expect(isAbsolute(userCacheDir)).toBe(true);
+		expect(isAbsolute(userLogDir)).toBe(true);
+	});
+
+	test('uses the plain epicenter app name without the env-paths nodejs suffix', () => {
+		for (const path of [userConfigDir, userDataDir, userCacheDir, userLogDir]) {
+			expect(path).toContain('epicenter');
+			expect(path).not.toContain('epicenter-nodejs');
+		}
+	});
+});

--- a/packages/workspace/src/paths/user-paths.ts
+++ b/packages/workspace/src/paths/user-paths.ts
@@ -1,0 +1,8 @@
+import envPaths from 'env-paths';
+
+const paths = envPaths('epicenter', { suffix: '' });
+
+export const userConfigDir = paths.config;
+export const userDataDir = paths.data;
+export const userCacheDir = paths.cache;
+export const userLogDir = paths.log;


### PR DESCRIPTION
Workspace projects need a single explicit marker before daemon routes can move out of folder discovery. This adds `epicenter.config.ts` as that marker and gives the workspace package the small foundation pieces needed to load it, discover a project root, and expose platform user paths consistently.

The new config helper is intentionally light: it preserves inference while making the project config file recognizable to tooling.

```ts
import { defineConfig } from "@epicenter/workspace";

export default defineConfig({});
```

Project discovery now walks upward for `epicenter.config.ts` instead of treating `workspaces/` or `.epicenter/` as identity markers. That keeps source layout and generated project data separate from the project boundary.

Verification:

```bash
bun run --cwd packages/workspace typecheck
bun test packages/workspace/src/config/define-config.test.ts packages/workspace/src/config/load-project-config.test.ts packages/workspace/src/client/find-project-root.test.ts packages/workspace/src/paths/user-paths.test.ts
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->