### PR TITLE
refactor(workspace): simplify daemon route startup

### DIFF
--- a/.agents/skills/workspace-api/references/actions-layout-and-attachments.md
+++ b/.agents/skills/workspace-api/references/actions-layout-and-attachments.md
@@ -273,7 +273,7 @@ await workspace.dispose();
 
 Writes propagate through sync to the daemon, which owns the materializer (markdown, SQLite mirror, etc.).
 
-Use `connectWorkspace` for one-off scripts and agent-written automation. Use a folder-routed `workspaces/<route>/daemon.ts` (`defineDaemonWorkspace({ open })`) for long-running daemons and materializers that need persistence and custom workspace-specific extensions.
+Use `connectWorkspace` for one-off scripts and agent-written automation. Use `epicenter.config.ts` to register long-running daemon modules and materializers that need persistence and custom workspace-specific extensions. A per-route `daemon.ts` file is a conventional module layout, not a discovery rule.
 
 
 ## The `_v` Convention

--- a/apps/README.md
+++ b/apps/README.md
@@ -12,7 +12,7 @@ apps/<app>/
 └── package.json     "exports": { ".": "./workspace.ts" }
 ```
 
-The repo root has `workspaces -> apps`, so `epicenter daemon up -C <repoRoot>` discovers app daemons exactly like an installed project discovers `workspaces/<route>/daemon.ts`.
+The repo root `epicenter.config.ts` registers app daemon modules. `epicenter daemon up -C <repoRoot>` starts those configured routes; `apps/<app>/daemon.ts` is the local module each app can expose.
 
 ## Boundaries
 

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -21,9 +21,12 @@ const db = openWorkspaceSqlite(projectDir, FUJI_WORKSPACE_ID);
 const urgent = db.query('SELECT * FROM entries WHERE tag = ?').all('urgent');
 
 // writes: typed proxy over unix socket to the daemon
-const fuji = await connectDaemonActions<FujiActions>({ route: 'fuji', projectDir });
+const fuji = await connectDaemonActions<FujiActions>({
+	route: 'fuji',
+	projectDir,
+});
 for (const note of urgent) {
-  await fuji.entries_update({ id: note.id, tags: ['triaged'] });
+	await fuji.entries_update({ id: note.id, tags: ['triaged'] });
 }
 
 db.close();

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -10,7 +10,7 @@ Each verb is a one-line shell shortcut for one workspace primitive:
                  +--------+---------------------------------------------+
    Enumerate     | list   | Object.entries(collaboration.actions)       |
    Invoke        | run    | actions[key](input) or dispatch(peer, ...)  |
-   Presence      | peers  | collaboration.peers.list()                  |
+   Presence      | peers  | collaboration.devices.list()                |
                  +--------+---------------------------------------------+
 
  Supporting systems: auth (machine session), daemon (process lifecycle)

--- a/packages/cli/src/commands/up.test.ts
+++ b/packages/cli/src/commands/up.test.ts
@@ -139,10 +139,9 @@ function writeRuntimeDaemon({
 			whenConnected: new Promise(() => {}),
 			status: { phase: 'connected' },
 			onStatusChange: () => () => {},
-			peers: {
+			devices: {
 				list: () => [],
-				find: () => undefined,
-				observe: () => () => {},
+				subscribe: () => () => {},
 			},
 			dispatch: async () => {
 				throw new Error('fixture does not dispatch');
@@ -222,6 +221,9 @@ describe('runUp: failure cleanup', () => {
 	test('does not overwrite an existing config when provisioning project data', async () => {
 		const original = ['export default {};', '', '// keep me', ''].join('\n');
 		writeFileSync(join(workDir, 'epicenter.config.ts'), original);
+		const gitignore = 'custom-rule\n';
+		mkdirSync(join(workDir, '.epicenter'), { recursive: true });
+		writeFileSync(join(workDir, '.epicenter', '.gitignore'), gitignore);
 
 		const handle = expectOk(
 			await runUp({
@@ -234,6 +236,9 @@ describe('runUp: failure cleanup', () => {
 			expect(readFileSync(join(workDir, 'epicenter.config.ts'), 'utf8')).toBe(
 				original,
 			);
+			expect(
+				readFileSync(join(workDir, '.epicenter', '.gitignore'), 'utf8'),
+			).toBe(gitignore);
 		} finally {
 			await handle.teardown();
 		}

--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -60,7 +60,7 @@ function logSyncStatus(message: string): void {
 	process.stderr.write(`${message}\n`);
 }
 
-export type UpOptions = {
+type UpOptions = {
 	projectDir: string;
 	quiet: boolean;
 	cliVersion?: string;
@@ -78,7 +78,7 @@ export type UpOptions = {
  * - `teardown()` closes the server, asyncDisposes the runtimes, releases the
  *   lease, and unlinks metadata + socket. Idempotent.
  */
-export type UpHandle = {
+type UpHandle = {
 	runtimes: StartedDaemonRoute[];
 	metadata: DaemonMetadata;
 	teardown: () => Promise<void>;

--- a/packages/cli/src/util/common-options.test.ts
+++ b/packages/cli/src/util/common-options.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { join } from 'node:path';
 import yargs from 'yargs';
 
 import { projectOption } from './common-options.js';
@@ -17,7 +17,7 @@ afterEach(() => {
 function tempProject() {
 	const root = mkdtempSync(join(tmpdir(), 'ep-cli-project-'));
 	roots.push(root);
-	mkdirSync(join(root, 'workspaces'));
+	writeFileSync(join(root, 'epicenter.config.ts'), 'export default {};\n');
 	const nested = join(root, 'nested', 'child');
 	mkdirSync(nested, { recursive: true });
 	return { root, nested };
@@ -28,14 +28,18 @@ describe('projectOption', () => {
 		const { root, nested } = tempProject();
 		const argv = yargs().option('C', projectOption).parseSync(['-C', nested]);
 
-		expect(argv.C).toBe(root);
+		expect(argv.C).toBe(root as typeof argv.C);
 	});
 
-	test('falls back to an absolute start path when discovery misses', () => {
+	test('fails when discovery misses', () => {
 		const root = mkdtempSync(join(tmpdir(), 'ep-cli-no-project-'));
 		roots.push(root);
-		const argv = yargs().option('C', projectOption).parseSync(['-C', root]);
 
-		expect(argv.C).toBe(resolve(root));
+		expect(() =>
+			yargs()
+				.exitProcess(false)
+				.option('C', projectOption)
+				.parseSync(['-C', root]),
+		).toThrow('findProjectRoot: no epicenter.config.ts found');
 	});
 });

--- a/packages/cli/src/util/common-options.ts
+++ b/packages/cli/src/util/common-options.ts
@@ -5,18 +5,8 @@
  * current working directory. `-C <dir>` changes the discovery start point.
  */
 
-import { resolve } from 'node:path';
-
 import { findProjectRoot } from '@epicenter/workspace/node';
 import type { Options } from 'yargs';
-
-function resolveProjectDir(start: string): string {
-	try {
-		return findProjectRoot(start);
-	} catch {
-		return resolve(start);
-	}
-}
 
 export const projectOption = {
 	type: 'string',
@@ -24,5 +14,5 @@ export const projectOption = {
 		'Project root (or any directory under it; discovery walks up to the nearest `epicenter.config.ts`).',
 	default: () => process.cwd(),
 	defaultDescription: 'current working directory',
-	coerce: resolveProjectDir,
+	coerce: findProjectRoot,
 } satisfies Options;

--- a/packages/cli/test/e2e-up-cross-peer.test.ts
+++ b/packages/cli/test/e2e-up-cross-peer.test.ts
@@ -61,7 +61,7 @@ const BIN_PATH = join(import.meta.dir, '..', 'src', 'bin.ts');
 type EnvOverrides = Disposable & {
 	/** Stable `runtimeDir()` root: $XDG_RUNTIME_DIR/epicenter. */
 	xdgRoot: string;
-	/** Stable `epicenterPaths.home()`: $HOME/.epicenter (logs land here). */
+	/** Stable auth home; user logs resolve from this HOME via env-paths. */
 	home: string;
 };
 

--- a/packages/workspace/src/config/load-project-config.test.ts
+++ b/packages/workspace/src/config/load-project-config.test.ts
@@ -88,9 +88,7 @@ describe('loadProjectConfig', () => {
 	});
 
 	test('throws when daemon routes are still an array', async () => {
-		writeConfig(
-			'export default { daemon: { routes: [{ open() {} }] } };\n',
-		);
+		writeConfig('export default { daemon: { routes: [{ open() {} }] } };\n');
 
 		await expect(loadProjectConfig(projectDir)).rejects.toThrow(
 			`loadProjectConfig: ${join(projectDir, 'epicenter.config.ts')} is invalid`,

--- a/packages/workspace/src/daemon/action-path.ts
+++ b/packages/workspace/src/daemon/action-path.ts
@@ -7,17 +7,6 @@
  * route-local action key. Valid action keys are snake_case, so additional dots
  * remain part of an invalid key and resolve as ActionNotFound.
  */
-import {
-	type ActionManifest,
-	type ActionRegistry,
-	toActionMeta,
-} from '../shared/actions.js';
-
-type RouteActionSource = {
-	route: string;
-	actions: ActionRegistry;
-};
-
 type ParsedDaemonActionPath = {
 	routeName: string;
 	localPath: string;
@@ -52,23 +41,4 @@ export function parseDaemonActionPath(
 		routeName,
 		localPath: rest.join('.'),
 	};
-}
-
-/**
- * Project hosted route action registries into the flat `/list` manifest.
- *
- * The daemon keeps each route's registry local, but the CLI needs one manifest
- * keyed by the same paths that `/run` accepts. This is the production bridge
- * between those two views.
- */
-export function createRouteActionManifest(
-	routes: readonly RouteActionSource[],
-): ActionManifest {
-	const manifest: ActionManifest = {};
-	for (const entry of routes) {
-		for (const [path, action] of Object.entries(entry.actions)) {
-			manifest[joinDaemonActionPath(entry.route, path)] = toActionMeta(action);
-		}
-	}
-	return manifest;
 }

--- a/packages/workspace/src/daemon/app.ts
+++ b/packages/workspace/src/daemon/app.ts
@@ -19,7 +19,8 @@ import { sValidator } from '@hono/standard-validator';
 import { type } from 'arktype';
 import { Hono } from 'hono';
 import { Ok } from 'wellcrafted/result';
-import { createRouteActionManifest } from './action-path.js';
+import { type ActionManifest, toActionMeta } from '../shared/actions.js';
+import { joinDaemonActionPath } from './action-path.js';
 import { executeRun } from './run-handler.js';
 import type { DaemonServedRoute } from './types.js';
 
@@ -69,14 +70,14 @@ export type PeerSnapshot = typeof PeerSnapshot.infer;
  * locally or over RPC.
  */
 export function buildDaemonApp(
-	runtimes: readonly DaemonServedRoute[],
+	routes: readonly DaemonServedRoute[],
 	triggerShutdown?: () => void,
 ) {
 	return new Hono()
 		.post('/ping', (c) => c.json(Ok('pong' as const)))
 		.post('/peers', (c) => {
 			const rows: PeerSnapshot[] = [];
-			for (const entry of runtimes) {
+			for (const entry of routes) {
 				for (const device of entry.runtime.collaboration.devices.list()) {
 					rows.push({
 						route: entry.route,
@@ -87,20 +88,20 @@ export function buildDaemonApp(
 			return c.json(Ok(rows));
 		})
 		.post('/list', (c) => {
-			return c.json(
-				Ok(
-					createRouteActionManifest(
-						runtimes.map((entry) => ({
-							route: entry.route,
-							actions: entry.runtime.collaboration.actions,
-						})),
-					),
-				),
-			);
+			const manifest: ActionManifest = {};
+			for (const entry of routes) {
+				for (const [path, action] of Object.entries(
+					entry.runtime.collaboration.actions,
+				)) {
+					manifest[joinDaemonActionPath(entry.route, path)] =
+						toActionMeta(action);
+				}
+			}
+			return c.json(Ok(manifest));
 		})
 		.post('/run', sValidator('json', RunRequest), async (c) => {
 			const request = c.req.valid('json');
-			return c.json(await executeRun(runtimes, request));
+			return c.json(await executeRun(routes, request));
 		})
 		.post('/shutdown', (c) => {
 			setTimeout(() => triggerShutdown?.(), 0);

--- a/packages/workspace/src/daemon/best-effort.ts
+++ b/packages/workspace/src/daemon/best-effort.ts
@@ -1,16 +1,7 @@
-import { Ok, tryAsync, trySync } from 'wellcrafted/result';
+import { Ok, trySync } from 'wellcrafted/result';
 
 export function bestEffortSync(action: () => void): void {
 	void trySync({
-		try: action,
-		catch: () => Ok(undefined),
-	});
-}
-
-export async function bestEffortAsync(
-	action: () => Promise<void>,
-): Promise<void> {
-	await tryAsync({
 		try: action,
 		catch: () => Ok(undefined),
 	});

--- a/packages/workspace/src/daemon/list-route.test.ts
+++ b/packages/workspace/src/daemon/list-route.test.ts
@@ -8,12 +8,34 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { defineQuery } from '../shared/actions.js';
-import {
-	createRouteActionManifest,
-	joinDaemonActionPath,
-	parseDaemonActionPath,
-} from './action-path.js';
+import { expectOk } from '@epicenter/test-utils/result';
+import type { Result } from 'wellcrafted/result';
+import { type ActionManifest, defineQuery } from '../shared/actions.js';
+import { joinDaemonActionPath, parseDaemonActionPath } from './action-path.js';
+import { buildDaemonApp } from './app.js';
+import type { DaemonServedRoute } from './types.js';
+
+function makeRoute({
+	route,
+	actions,
+}: {
+	route: string;
+	actions: DaemonServedRoute['runtime']['collaboration']['actions'];
+}): DaemonServedRoute {
+	return {
+		route,
+		runtime: {
+			collaboration: {
+				actions,
+				devices: {
+					list: () => [],
+				},
+				status: { phase: 'connected' },
+				dispatch: async () => ({ data: null, error: null }) as never,
+			},
+		},
+	};
+}
 
 describe('daemon action path helpers', () => {
 	test('joinDaemonActionPath prefixes local action paths with the route', () => {
@@ -42,9 +64,9 @@ describe('daemon action path helpers', () => {
 });
 
 describe('/list route', () => {
-	test('returns route-prefixed paths under the action root', () => {
-		const manifest = createRouteActionManifest([
-			{
+	test('returns route-prefixed paths under the action root', async () => {
+		const res = await buildDaemonApp([
+			makeRoute({
 				route: 'demo',
 				actions: {
 					counter_get: defineQuery({
@@ -52,37 +74,46 @@ describe('/list route', () => {
 						handler: () => 0,
 					}),
 				},
-			},
-		]);
+			}),
+		]).request('/list', { method: 'POST' });
 
+		const manifest = expectOk(
+			(await res.json()) as Result<ActionManifest, never>,
+		);
 		expect(Object.keys(manifest).sort()).toEqual(['demo.counter_get']);
 		expect(manifest['demo.counter_get']?.description).toBe('Read the counter');
 	});
 
-	test('returns an empty manifest when the collaboration has no actions', () => {
-		const manifest = createRouteActionManifest([
-			{ route: 'demo', actions: {} },
-		]);
+	test('returns an empty manifest when the collaboration has no actions', async () => {
+		const res = await buildDaemonApp([
+			makeRoute({ route: 'demo', actions: {} }),
+		]).request('/list', { method: 'POST' });
 
+		const manifest = expectOk(
+			(await res.json()) as Result<ActionManifest, never>,
+		);
 		expect(manifest).toEqual({});
 	});
 
-	test('prefixes actions from every daemon route', () => {
-		const manifest = createRouteActionManifest([
-			{
+	test('prefixes actions from every daemon route', async () => {
+		const res = await buildDaemonApp([
+			makeRoute({
 				route: 'notes',
 				actions: {
 					notes_add: defineQuery({ handler: () => null }),
 				},
-			},
-			{
+			}),
+			makeRoute({
 				route: 'tasks',
 				actions: {
 					tasks_list: defineQuery({ handler: () => [] }),
 				},
-			},
-		]);
+			}),
+		]).request('/list', { method: 'POST' });
 
+		const manifest = expectOk(
+			(await res.json()) as Result<ActionManifest, never>,
+		);
 		expect(Object.keys(manifest).sort()).toEqual([
 			'notes.notes_add',
 			'tasks.tasks_list',

--- a/packages/workspace/src/daemon/route-validation.ts
+++ b/packages/workspace/src/daemon/route-validation.ts
@@ -1,10 +1,3 @@
-/**
- * Conventional folder name for route modules (`<projectDir>/workspaces/<route>`).
- * It is not a project marker or registry; `epicenter.config.ts` owns route
- * registration.
- */
-export const WORKSPACES_DIRNAME = 'workspaces';
-
 const ROUTE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
 // Route names become object keys in `/list` action manifests.
 const RESERVED_OBJECT_ROUTE_KEYS = new Set([

--- a/packages/workspace/src/daemon/run-handler.ts
+++ b/packages/workspace/src/daemon/run-handler.ts
@@ -35,15 +35,15 @@ import {
 import type { DaemonServedRoute } from './types.js';
 
 export async function executeRun(
-	runtimes: readonly DaemonServedRoute[],
+	routes: readonly DaemonServedRoute[],
 	{ actionPath, input: actionInput, peerTarget, waitMs }: RunRequest,
 ): Promise<RunResponse> {
 	const { routeName, localPath } = parseDaemonActionPath(actionPath);
-	const routeRuntime = runtimes.find(
+	const routeRuntime = routes.find(
 		(candidate) => candidate.route === routeName,
 	);
 	if (!routeRuntime) {
-		const available = runtimes.map((candidate) => candidate.route);
+		const available = routes.map((candidate) => candidate.route);
 		return RunError.UsageError({
 			message: `No daemon route "${routeName}". Available: ${available.join(', ')}`,
 			suggestions: available.map((name) => `  ${name}`),

--- a/packages/workspace/src/daemon/server.ts
+++ b/packages/workspace/src/daemon/server.ts
@@ -12,10 +12,9 @@
  * See spec: `20260429T004302-workspace-as-daemon-transport.md` § Phase 2.
  */
 
-import { Ok, type Result } from 'wellcrafted/result';
+import { Ok, type Result, tryAsync } from 'wellcrafted/result';
 
 import { buildDaemonApp } from './app.js';
-import { bestEffortAsync } from './best-effort.js';
 import { pingDaemon } from './client.js';
 import type { DaemonLease } from './lease.js';
 import { validateDaemonRouteNames } from './route-validation.js';
@@ -79,7 +78,10 @@ export async function startDaemonServer({
 		async close() {
 			if (isClosed) return;
 			isClosed = true;
-			await bestEffortAsync(() => server.stop(true));
+			await tryAsync({
+				try: () => server.stop(true),
+				catch: () => Ok(undefined),
+			});
 			unlinkSocketFile(socketPath);
 		},
 	});

--- a/packages/workspace/src/workspace-apps/errors.ts
+++ b/packages/workspace/src/workspace-apps/errors.ts
@@ -33,7 +33,7 @@ export const WorkspaceAppError = defineErrors({
 		route: string;
 		cause: unknown;
 	}) => ({
-		message: `Workspace "${route}" failed to open: ${extractErrorMessage(cause)}`,
+		message: `Daemon route "${route}" failed to open: ${extractErrorMessage(cause)}`,
 		route,
 		cause,
 	}),

--- a/packages/workspace/src/workspace-apps/start-daemon-workspace-apps.test.ts
+++ b/packages/workspace/src/workspace-apps/start-daemon-workspace-apps.test.ts
@@ -2,7 +2,7 @@
  * Startup tests for `startDaemonWorkspaceApps`.
  *
  * Pin three contracts:
- * - happy path opens every configured workspace in parallel and returns the
+ * - happy path opens every configured daemon route in parallel and returns the
  *   started routes
  * - if any sibling `open(ctx)` rejects, all successfully opened runtimes are
  *   asyncDispose'd before the structured error propagates

--- a/packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts
+++ b/packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts
@@ -11,9 +11,6 @@
  * `attachEncryption` and `openWebSocket` already carry the auth bindings.
  * Daemon code never touches the auth client directly: it consumes the
  * capabilities in the context and composes a runtime.
- *
- * Returns only routes. Static-app serving was removed; the daemon has no UI
- * surface.
  */
 
 import { resolve } from 'node:path';
@@ -30,10 +27,7 @@ import { validateDaemonRouteNames } from '../daemon/route-validation.js';
 import { attachEncryption } from '../document/attach-encryption.js';
 import { hashClientId } from '../shared/client-id.js';
 import type { ProjectDir } from '../shared/types.js';
-import {
-	WorkspaceAppError,
-	type WorkspaceAppError as WorkspaceAppErrorType,
-} from './errors.js';
+import { WorkspaceAppError } from './errors.js';
 
 export type StartDaemonWorkspaceAppsOptions = {
 	projectDir: ProjectDir | string;
@@ -50,7 +44,7 @@ export type StartDaemonWorkspaceAppsOptions = {
  */
 export async function startDaemonWorkspaceApps(
 	options: StartDaemonWorkspaceAppsOptions,
-): Promise<Result<StartedDaemonRoute[], WorkspaceAppErrorType>> {
+): Promise<Result<StartedDaemonRoute[], WorkspaceAppError>> {
 	const { auth, routes } = options;
 	const projectDir = resolve(options.projectDir) as ProjectDir;
 	if (auth.state.status === 'signed-out') {
@@ -72,7 +66,7 @@ export async function startDaemonWorkspaceApps(
 	);
 
 	const opened: StartedDaemonRoute[] = [];
-	let firstError: WorkspaceAppErrorType | null = null;
+	let firstError: WorkspaceAppError | null = null;
 
 	for (const result of settled) {
 		if (result.status !== 'fulfilled') {
@@ -100,20 +94,18 @@ export async function startDaemonWorkspaceApps(
 	return Ok(opened);
 }
 
-type OpenOneRouteOptions = {
-	route: string;
-	definition: DaemonWorkspaceDefinition;
-	projectDir: ProjectDir;
-	auth: AuthClient;
-};
-
 async function openOneDaemonRoute({
 	route,
 	definition,
 	projectDir,
 	auth,
-}: OpenOneRouteOptions): Promise<
-	Result<StartedDaemonRoute, WorkspaceAppErrorType>
+}: {
+	route: string;
+	definition: DaemonWorkspaceDefinition;
+	projectDir: ProjectDir;
+	auth: AuthClient;
+}): Promise<
+	Result<StartedDaemonRoute, WorkspaceAppError>
 > {
 	const ctx: DaemonWorkspaceContext = {
 		projectDir,

--- a/packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts
+++ b/packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts
@@ -104,9 +104,7 @@ async function openOneDaemonRoute({
 	definition: DaemonWorkspaceDefinition;
 	projectDir: ProjectDir;
 	auth: AuthClient;
-}): Promise<
-	Result<StartedDaemonRoute, WorkspaceAppError>
-> {
+}): Promise<Result<StartedDaemonRoute, WorkspaceAppError>> {
 	const ctx: DaemonWorkspaceContext = {
 		projectDir,
 		route,

--- a/specs/20260519T161500-config-route-collapse-pass/01-workspace-apps-audit.prompt.md
+++ b/specs/20260519T161500-config-route-collapse-pass/01-workspace-apps-audit.prompt.md
@@ -1,0 +1,5 @@
+# Workspace Apps Audit Prompt
+
+```txt
+/goal Audit stale folder-discovery concepts in `packages/workspace/src/workspace-apps` after the move to `epicenter.config.ts` route registration. Do not edit source files. First read AGENTS.md, the collapse-pass skill, and the last two commits with `git show --stat HEAD~1..HEAD`. Then inspect `packages/workspace/src/workspace-apps/**` and grep for `daemonEntryPath`, `DAEMON_ENTRY_FILENAME`, `WorkspaceFolder`, `WorkspaceDaemonInvalidExport`, `folder-routed`, `discoverWorkspaceApps`, and stale discovery wording. Write findings to `specs/20260519T161500-config-route-collapse-pass/reports/workspace-apps.md` with file:line citations, caller counts, one-sentence-test notes, proposed collapses, and targeted validation commands. Stop after writing the report.
+```

--- a/specs/20260519T161500-config-route-collapse-pass/02-client-cli-audit.prompt.md
+++ b/specs/20260519T161500-config-route-collapse-pass/02-client-cli-audit.prompt.md
@@ -1,0 +1,5 @@
+# Client And CLI Audit Prompt
+
+```txt
+/goal Audit stale client, project-root, and CLI behavior after `epicenter.config.ts` became the project marker and route registry. Do not edit source files. First read AGENTS.md, the collapse-pass skill, and the last two commits with `git show --stat HEAD~1..HEAD`. Scope: `packages/workspace/src/client/**`, `packages/workspace/src/node.ts`, `packages/workspace/src/daemon/paths.ts`, and `packages/cli/src/**`. Grep for `findEpicenterDir`, `findProjectRoot`, `.epicenter` as marker, `workspaces/` as marker, `MissingConfig`, project socket wording, and old `epicenter up` wording. Write findings to `specs/20260519T161500-config-route-collapse-pass/reports/client-cli.md` with file:line citations, caller counts, proposed collapses, and targeted validation commands. Stop after writing the report.
+```

--- a/specs/20260519T161500-config-route-collapse-pass/03-docs-api-surface-audit.prompt.md
+++ b/specs/20260519T161500-config-route-collapse-pass/03-docs-api-surface-audit.prompt.md
@@ -1,0 +1,5 @@
+# Docs And API Surface Audit Prompt
+
+```txt
+/goal Audit docs and public exports affected by the config-routed daemon migration. Do not edit source files. First read AGENTS.md, the collapse-pass skill, the writing-voice skill, and the last two commits with `git show --stat HEAD~1..HEAD`. Scope: `packages/workspace/src/index.ts`, `packages/workspace/src/node.ts`, `packages/workspace/src/config/**`, `docs/scripting.md`, `packages/cli/README.md`, app READMEs touched by the last two commits, and relevant agent skills. Grep for stale folder-routed language, `.epicenter` as discovery marker, `workspaces/<route>/daemon.ts` as an authority, and exports with no current callers. Write findings to `specs/20260519T161500-config-route-collapse-pass/reports/docs-api-surface.md` with file:line citations, caller counts, proposed collapses, and targeted validation commands. Stop after writing the report.
+```

--- a/specs/20260519T161500-config-route-collapse-pass/04-implementation.prompt.md
+++ b/specs/20260519T161500-config-route-collapse-pass/04-implementation.prompt.md
@@ -1,0 +1,5 @@
+# Implementation Prompt
+
+```txt
+/goal Implement the safe findings from `specs/20260519T161500-config-route-collapse-pass/reports/*.md` until stale config-route migration cleanup is either complete or explicitly deferred. First read AGENTS.md, the collapse-pass skill, the post-implementation-review skill, and all three audit reports. Build a short queue in `specs/20260519T161500-config-route-collapse-pass/reports/implementation.md`, ordered by lowest risk first. For each checkpoint, surface the collapse-pass finding before editing, make one mechanical simplification, run the targeted validation command from the report, re-grep removed symbols, and update `implementation.md` with changed files, validation output, and remaining risk. Pause before deleting public exports with plausible external consumers, changing default config semantics, changing durable strings, or touching unrelated code. Stop when the queue is empty, three consecutive findings are rejected as not worth changing, or a regression cannot be fixed in one follow-up.
+```

--- a/specs/20260519T161500-config-route-collapse-pass/README.md
+++ b/specs/20260519T161500-config-route-collapse-pass/README.md
@@ -1,0 +1,58 @@
+# Config Route Collapse Pass
+
+Purpose: clean up dead code, stale wording, and avoidable indirection left behind by the move from folder-routed daemon discovery to `epicenter.config.ts` as the project marker and route registry.
+
+Run this in two waves.
+
+## Wave 1: Parallel Audits
+
+Open three fresh agents and give each one prompt:
+
+- `01-workspace-apps-audit.prompt.md`
+- `02-client-cli-audit.prompt.md`
+- `03-docs-api-surface-audit.prompt.md`
+
+Each audit writes findings to its matching report file:
+
+- `reports/workspace-apps.md`
+- `reports/client-cli.md`
+- `reports/docs-api-surface.md`
+
+These agents must not edit source files.
+
+## Wave 2: Implementation
+
+After all three reports exist, open one implementation agent with:
+
+- `04-implementation.prompt.md`
+
+That agent reads the reports, builds a small queue, applies safe collapse-pass edits, and writes:
+
+- `reports/implementation.md`
+
+## Why This Shape
+
+The audits parallelize safely because they are read-only. The implementation is intentionally serial because the findings can overlap across config loading, CLI startup, tests, and docs.
+
+This keeps orchestration simple:
+
+```txt
+parallel:
+  audit workspace-apps
+  audit client-cli
+  audit docs-api-surface
+
+then serial:
+  implement the best findings
+  validate
+```
+
+## Final Validation Greps
+
+The implementation agent should run these before finishing:
+
+```bash
+rg "findEpicenterDir|DAEMON_ENTRY_FILENAME|daemonEntryPath|WorkspaceFolder|WorkspaceDaemonInvalidExport|MissingConfig|folder-routed|\\.epicenter/daemon\\.sock|workspaces/<route>/daemon\\.ts"
+```
+
+Any remaining hit should be either removed or justified in `reports/implementation.md`.

--- a/specs/20260519T161500-config-route-collapse-pass/reports/client-cli.md
+++ b/specs/20260519T161500-config-route-collapse-pass/reports/client-cli.md
@@ -1,0 +1,162 @@
+# Client And CLI Audit
+
+Scope audited:
+
+- `packages/workspace/src/client/**`
+- `packages/workspace/src/node.ts`
+- `packages/workspace/src/daemon/paths.ts`
+- `packages/cli/src/**`
+
+Commands run:
+
+```bash
+sed -n '1,220p' AGENTS.md
+sed -n '1,260p' specs/20260519T161500-config-route-collapse-pass/02-client-cli-audit.prompt.md
+sed -n '1,260p' /Users/braden/Code/epicenter/.agents/skills/collapse-pass/SKILL.md
+git show --stat HEAD~1..HEAD
+sed -n '1,240p' /Users/braden/Code/epicenter/.agents/skills/collapse-pass/references/report-format.md
+sed -n '1,220p' /Users/braden/Code/epicenter/.agents/skills/collapse-pass/references/never-touch.md
+sed -n '1,220p' /Users/braden/Code/epicenter/.agents/skills/writing-voice/SKILL.md
+rg -n "findEpicenterDir|findProjectRoot|\\.epicenter|workspaces/|MissingConfig|project socket|socket|epicenter up|project root|config" packages/workspace/src/client packages/workspace/src/node.ts packages/workspace/src/daemon/paths.ts packages/cli/src
+rg -n "findEpicenterDir|findProjectRoot|\\.epicenter|workspaces/|MissingConfig|project socket|old|epicenter up|project root" specs/20260519T161500-config-route-collapse-pass packages/cli/README.md docs/scripting.md
+ls -la specs/20260519T161500-config-route-collapse-pass/reports
+git status --short
+nl -ba packages/workspace/src/client/find-project-root.ts
+nl -ba packages/workspace/src/client/connect-daemon-actions.ts
+nl -ba packages/workspace/src/daemon/paths.ts
+nl -ba packages/cli/src/commands/up.ts
+rg -n "findProjectRoot\\b" packages/workspace/src packages/cli/src --glob '!**/*.test.ts'
+rg -n "resolveProjectForUp\\b|provisionProject\\b|DEFAULT_PROJECT_CONFIG_SOURCE\\b|socketPathFor\\b|metadataPathFor\\b|leasePathFor\\b|runtimeDir\\b|dirHash\\b|logPathFor\\b" packages/workspace/src packages/cli/src --glob '!**/*.test.ts'
+nl -ba packages/cli/src/util/common-options.ts
+nl -ba packages/workspace/src/node.ts
+rg -n "epicenter up|daemon up|project socket|daemon socket|workspaces/|workspaces<|\\.epicenter|MissingConfig|findEpicenterDir|findProjectRoot|project root" packages/cli/src packages/workspace/src/client packages/workspace/src/node.ts packages/workspace/src/daemon/paths.ts
+rg -n "ProjectConfigError|MissingConfig|NoConfig|Config" packages/workspace/src/config packages/workspace/src/workspace-apps packages/cli/src
+rg -n "command:|describe:|description:" packages/cli/src/commands packages/cli/src/cli.ts packages/cli/src/util
+nl -ba packages/workspace/src/daemon/client.ts | sed -n '1,240p'
+nl -ba packages/cli/src/commands/run.ts
+nl -ba packages/cli/src/commands/list.ts
+nl -ba packages/cli/src/commands/peers.ts
+nl -ba packages/cli/src/commands/down.ts
+nl -ba packages/cli/src/commands/logs.ts
+nl -ba packages/cli/src/commands/ps.ts
+nl -ba packages/cli/src/commands/daemon.ts
+sed -n '1,180p' specs/20260519T161500-config-route-collapse-pass/README.md
+rg -n "projectOption\\b|resolveProjectDir\\b" packages/cli/src --glob '!**/*.test.ts'
+rg -n "resolveProjectForUp\\b|provisionProject\\b|safeDisposeStartedRoutes\\b|printPeersSnapshot\\b|subscribePeers\\b|subscribeSyncStatus\\b" packages/cli/src --glob '!**/*.test.ts'
+```
+
+Last commit context:
+
+```txt
+373a4e0 refactor(workspace): collapse route discovery helper
+11 files changed, 79 insertions(+), 141 deletions(-)
+Removed packages/workspace/src/workspace-apps/discover.ts and discover.test.ts.
+Updated packages/cli/src/commands/up.ts and packages/cli/README.md for config-routed daemon startup.
+```
+
+## Finding 1: Shared project option still carries `daemon up` provisioning fallback
+
+The shared `projectOption` tries `findProjectRoot(start)` and falls back to `resolve(start)` when no `epicenter.config.ts` exists (`packages/cli/src/util/common-options.ts:13`, `packages/cli/src/util/common-options.ts:15`, `packages/cli/src/util/common-options.ts:17`). That fallback is right for `daemon up`, because `runUp` provisions a missing `epicenter.config.ts` (`packages/cli/src/commands/up.ts:94`, `packages/cli/src/commands/up.ts:95`, `packages/cli/src/commands/up.ts:266`, `packages/cli/src/commands/up.ts:269`). It is stale for commands that require an existing project and daemon.
+
+Caller count:
+
+```txt
+projectOption non-test CLI callers: 6
+  packages/cli/src/commands/run.ts:58
+  packages/cli/src/commands/list.ts:37
+  packages/cli/src/commands/down.ts:73
+  packages/cli/src/commands/peers.ts:29
+  packages/cli/src/commands/up.ts:201
+  packages/cli/src/commands/logs.ts:127
+
+resolveProjectDir callers: 1
+  packages/cli/src/util/common-options.ts:27
+
+resolveProjectForUp callers: 1
+  packages/cli/src/commands/up.ts:94
+```
+
+Inline check:
+
+```txt
+run/list/peers:
+  projectOption.coerce
+    -> findProjectRoot(start)
+    -> catch
+    -> resolve(start)
+    -> getDaemon(argv.C)
+    -> socketPathFor(resolved non-project dir)
+    -> DaemonError.Required("no daemon running for ...; start one with `epicenter daemon up` first")
+
+down/logs:
+  projectOption.coerce
+    -> same fallback
+    -> readMetadata/logPathFor on a hash of the non-project dir
+```
+
+The visible result is that `run`, `list`, `peers`, `down`, and `logs` silently treat any directory as a project address. After `epicenter.config.ts` became the project marker, those commands should either resolve an existing config-backed project or fail at the project lookup boundary. Only `daemon up` needs the "no config yet, use this directory and create one" path.
+
+Proposed collapse:
+
+Split the option behavior so the fallback lives only in `daemon up`.
+
+```txt
+packages/cli/src/util/common-options.ts
+  projectOption:
+    coerce -> findProjectRoot(start)
+
+packages/cli/src/commands/up.ts
+  upProjectOption or handler-local resolution:
+    coerce/resolve -> findProjectRoot(start) catch resolve(start)
+```
+
+Then remove one of the duplicated fallbacks:
+
+- If `upProjectOption` does the fallback, `resolveProjectForUp` can collapse into direct `realpathSync(options.projectDir)`.
+- If `runUp` keeps the fallback for direct unit-test calls, `upCommand` should not reuse the strict shared option.
+
+What stays the same:
+
+- `findProjectRoot` remains config-based (`packages/workspace/src/client/find-project-root.ts:9`, `packages/workspace/src/client/find-project-root.ts:16`).
+- `daemon up` still creates `epicenter.config.ts` when starting from a non-project directory (`packages/cli/src/commands/up.ts:267`, `packages/cli/src/commands/up.ts:269`).
+- Project data still lives under `<projectDir>/.epicenter` (`packages/cli/src/commands/up.ts:274`, `packages/workspace/src/daemon/paths.ts:9`).
+- Runtime sockets and metadata remain OS-runtime keyed by project directory hash (`packages/workspace/src/daemon/paths.ts:33`, `packages/workspace/src/daemon/paths.ts:57`, `packages/workspace/src/daemon/paths.ts:69`).
+
+Targeted validation commands:
+
+```bash
+bun test packages/cli/src/commands/up.test.ts
+bun test packages/workspace/src/client/find-project-root.test.ts
+bun run --filter @epicenter/cli typecheck
+```
+
+Suggested follow-up test coverage:
+
+```txt
+packages/cli/src/commands/run.test.ts or a focused common-options test:
+  Given cwd under a directory without epicenter.config.ts,
+  `run/list/peers/logs/down` should fail project discovery instead of hashing the raw cwd.
+
+packages/cli/src/commands/up.test.ts:
+  Keep the existing "writes the default config and starts with no routes when config is missing" coverage.
+```
+
+## No-Finding Checks
+
+`findEpicenterDir`: no hits in the assigned scope.
+
+`MissingConfig`: no hits in the assigned scope. The current config error is `ProjectConfigNotFound` in `packages/workspace/src/config/load-project-config.ts:25`, outside the assigned client/CLI surface except through `loadProjectConfig` usage in `packages/cli/src/commands/up.ts:141`.
+
+`.epicenter` as project marker: no production hits in the assigned scope. Remaining `.epicenter` hits describe project-local data (`packages/cli/src/commands/up.ts:274`, `packages/workspace/src/daemon/paths.ts:9`, `packages/workspace/src/client/epicenter-paths.ts:5`) or machine-local auth/home state (`packages/cli/src/commands/auth.ts:8`, `packages/workspace/src/client/epicenter-paths.ts:13`). The test at `packages/workspace/src/client/find-project-root.test.ts:38` explicitly verifies `.epicenter` is not a marker.
+
+`workspaces/` as project marker: no production hits in the assigned scope. The remaining scoped hit is test fixture import text in `packages/cli/src/commands/up.test.ts:113`, not marker logic.
+
+Old `epicenter up` wording: no hits in the assigned scope. Current CLI and errors use `epicenter daemon up` (`packages/workspace/src/client/find-project-root.ts:17`, `packages/workspace/src/daemon/client.ts:49`, `packages/cli/src/commands/up.ts:2`, `packages/cli/src/commands/down.ts:71`, `packages/cli/src/commands/ps.ts:58`).
+
+Project socket wording: no stale `.epicenter/daemon.sock` style path found. Socket helpers are runtime-directory based (`packages/workspace/src/daemon/paths.ts:27`, `packages/workspace/src/daemon/paths.ts:57`).
+
+## Considered But Not Collapsed
+
+- `findProjectRoot`: kept. It has three non-test direct callers in the audited CLI/client path (`packages/workspace/src/client/connect-daemon-actions.ts:53`, `packages/cli/src/commands/up.ts:260`, `packages/cli/src/util/common-options.ts:15`) plus public exports (`packages/workspace/src/node.ts:15`, `packages/workspace/src/index.ts:109`). It is now the config marker lookup and remains a useful API.
+- `connectDaemonActions`: kept. Its docs are already route-config based and point to `epicenter.config.ts` (`packages/workspace/src/client/connect-daemon-actions.ts:38`, `packages/workspace/src/client/connect-daemon-actions.ts:44`).
+- `socketPathFor` and daemon path helpers: kept. They have multiple non-test callers across daemon client, metadata, lease, runtime cleanup, and CLI commands. The comments now distinguish runtime files from project-local `.epicenter` data (`packages/workspace/src/daemon/paths.ts:4`, `packages/workspace/src/daemon/paths.ts:9`).

--- a/specs/20260519T161500-config-route-collapse-pass/reports/docs-api-surface.md
+++ b/specs/20260519T161500-config-route-collapse-pass/reports/docs-api-surface.md
@@ -1,0 +1,225 @@
+# Docs And API Surface Audit
+
+Scope audited:
+
+- `packages/workspace/src/index.ts`
+- `packages/workspace/src/node.ts`
+- `packages/workspace/src/config/**`
+- `docs/scripting.md`
+- `packages/cli/README.md`
+- app READMEs touched by the last two commits: none
+- relevant agent skills: `.agents/skills/workspace-api/**`, `.agents/skills/workspace-app-layout/**`
+
+Last two commits checked:
+
+```txt
+cbdeb93 refactor(workspace): remove workspace apps barrel
+373a4e0 refactor(workspace): collapse route discovery helper
+```
+
+## Findings
+
+### Finding 1: folder-routed daemon docs still present in agent skill
+
+Citation: `.agents/skills/workspace-api/references/actions-layout-and-attachments.md:276`
+
+The skill still tells agents to use a "folder-routed `workspaces/<route>/daemon.ts`" for long-running daemons. That conflicts with the current model where `epicenter.config.ts` is the project marker and route registry, while the daemon module path is just an import chosen by the project config.
+
+Caller count:
+
+- `rg -n "folder-routed|workspaces/<route>/daemon\\.ts" .agents/skills docs packages/cli/README.md apps/README.md apps/fuji/README.md`: 1 stale skill hit, plus 1 stale `apps/README.md` hit covered in Finding 2
+- This exact skill line is agent-facing documentation, not a source symbol.
+
+Proposed collapse:
+
+- Replace the folder-routed sentence with config-routed wording: use `epicenter.config.ts` to register daemon modules, and treat `workspaces/<route>/daemon.ts` as only one conventional file layout.
+- Do not change the durable route string or daemon module contract.
+
+Targeted validation:
+
+```bash
+rg -n "folder-routed|workspaces/<route>/daemon\\.ts" .agents/skills docs packages/cli/README.md apps/README.md apps/fuji/README.md
+```
+
+### Finding 2: `apps/README.md` still describes symlink discovery
+
+Citation: `apps/README.md:15`
+
+The repo-level app README says `epicenter daemon up -C <repoRoot>` discovers app daemons through `workspaces -> apps`, matching the old folder discovery model. This was outside the "app READMEs touched by the last two commits" set, because no app README was touched by `HEAD~2..HEAD`, but the grep found it and it is directly stale.
+
+Caller count:
+
+- `rg -n "discovers app daemons|workspaces/<route>/daemon\\.ts" apps/README.md`: 1 stale hit
+- Not a source symbol.
+
+Proposed collapse:
+
+- Rewrite the line so the repo root `epicenter.config.ts` owns registration.
+- Keep the layout guidance that each app can expose a `daemon.ts`; remove the claim that discovery depends on `workspaces -> apps`.
+
+Targeted validation:
+
+```bash
+rg -n "discovers app daemons|workspaces/<route>/daemon\\.ts|workspaces -> apps" apps/README.md
+```
+
+### Finding 3: CLI README over-authorizes `workspaces/fuji/daemon.ts`
+
+Citations:
+
+- `packages/cli/README.md:73`
+- `packages/cli/README.md:80`
+- `packages/cli/README.md:94`
+
+The README correctly says `epicenter.config.ts` is the route registry at `packages/cli/README.md:59`, but then repeatedly describes `workspaces/fuji/daemon.ts` as if that path carries authority. After the migration, the import path is illustrative; only `routes: [fuji]` plus the module's `route` field matters.
+
+Caller count:
+
+- `rg -n "workspaces/fuji/daemon\\.ts" packages/cli/README.md`: 3 hits
+- Not a source symbol.
+
+Proposed collapse:
+
+- Keep one example import path.
+- Change surrounding prose to say "the imported module" or "the Fuji daemon module" instead of repeating `workspaces/fuji/daemon.ts` as the actor.
+
+Targeted validation:
+
+```bash
+rg -n "workspaces/fuji/daemon\\.ts" packages/cli/README.md
+```
+
+### Finding 4: config exports are split across root and node barrels with different audiences
+
+Citations:
+
+- `packages/workspace/src/index.ts:109`
+- `packages/workspace/src/index.ts:111`
+- `packages/workspace/src/index.ts:112`
+- `packages/workspace/src/index.ts:113`
+- `packages/workspace/src/index.ts:114`
+- `packages/workspace/src/index.ts:117`
+- `packages/workspace/src/index.ts:118`
+- `packages/workspace/src/index.ts:119`
+- `packages/workspace/src/node.ts:15`
+- `packages/workspace/src/node.ts:16`
+- `packages/workspace/src/node.ts:18`
+- `packages/workspace/src/node.ts:19`
+
+The root barrel exports both user-facing config authoring helpers and node-only loading helpers. `findProjectRoot` and `loadProjectConfig` are also exported from `@epicenter/workspace/node`, which is the path used by CLI and script docs. Browser consumers should not need project-root walking or dynamic Bun config loading from the root barrel.
+
+Caller count:
+
+- `findProjectRoot`: 5 non-test production or docs callers outside its implementation: `docs/scripting.md:10`, `docs/scripting.md:15`, `docs/scripting.md:52`, `packages/cli/src/commands/up.ts:28`, plus `packages/cli/src/util/common-options.ts:10` outside this audit's main docs scope.
+- `loadProjectConfig`: 1 non-test production caller outside implementation: `packages/cli/src/commands/up.ts:29`.
+- `DEFAULT_PROJECT_CONFIG_SOURCE`: 1 non-test production caller outside implementation and barrels: `packages/cli/src/commands/up.ts:27`.
+- `PROJECT_CONFIG_FILENAME`: 1 non-test source caller outside implementation and barrels: `packages/workspace/src/client/find-project-root.ts:3`.
+- `ProjectConfigError`: 0 non-test callers outside implementation and barrels.
+- `ProjectConfigErrorType`: 0 non-test callers outside `packages/workspace/src/index.ts`.
+
+Proposed collapse:
+
+- Keep `defineConfig`, `EpicenterConfig`, and probably `PROJECT_CONFIG_FILENAME` in the root barrel, because `epicenter.config.ts` imports from `@epicenter/workspace` and `findProjectRoot` uses the filename constant.
+- Move or remove root-barrel exports for `findProjectRoot`, `loadProjectConfig`, `DEFAULT_PROJECT_CONFIG_SOURCE`, `ProjectConfigError`, and `ProjectConfigErrorType` unless there is an intentional external SDK contract. These are node/runtime concerns and already fit `@epicenter/workspace/node`.
+- If `DEFAULT_PROJECT_CONFIG_SOURCE` remains public, prefer `@epicenter/workspace/node` only; its only production caller is CLI provisioning at `packages/cli/src/commands/up.ts:269`.
+
+Targeted validation:
+
+```bash
+rg -n "findProjectRoot|loadProjectConfig|DEFAULT_PROJECT_CONFIG_SOURCE|ProjectConfigError|ProjectConfigErrorType" packages apps docs .agents examples --glob '!*.test.ts'
+bun run typecheck
+bun test packages/workspace/src/config/load-project-config.test.ts packages/workspace/src/config/define-config.test.ts packages/cli/src/commands/up.test.ts
+```
+
+### Finding 5: `StartDaemonWorkspaceApps*` types have no external callers
+
+Citations:
+
+- `packages/workspace/src/node.ts:96`
+- `packages/workspace/src/node.ts:97`
+- `packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts:38`
+- `packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts:44`
+- `packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts:55`
+
+`startDaemonWorkspaceApps` has one production caller in `packages/cli/src/commands/up.ts:33` and `packages/cli/src/commands/up.ts:150`. Its public option and result types have no callers outside their defining module and node barrel. They are derived from the function signature and do not currently buy a public consumer anything.
+
+Caller count:
+
+- `startDaemonWorkspaceApps`: 1 production caller outside implementation and tests: `packages/cli/src/commands/up.ts`.
+- `StartDaemonWorkspaceAppsOptions`: 0 callers outside `packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts` and `packages/workspace/src/node.ts`.
+- `StartDaemonWorkspaceAppsResult`: 0 callers outside `packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts` and `packages/workspace/src/node.ts`.
+
+Proposed collapse:
+
+- Stop exporting `StartDaemonWorkspaceAppsOptions` and `StartDaemonWorkspaceAppsResult` from `@epicenter/workspace/node`, or derive them locally with `Parameters<typeof startDaemonWorkspaceApps>[0]` and awaited result inference if an internal caller appears.
+- Keep `startDaemonWorkspaceApps` public only if CLI remains an external package consumer of `@epicenter/workspace/node`.
+
+Targeted validation:
+
+```bash
+rg -n "StartDaemonWorkspaceAppsOptions|StartDaemonWorkspaceAppsResult|startDaemonWorkspaceApps" packages apps docs .agents examples --glob '!*.test.ts'
+bun run typecheck
+bun test packages/workspace/src/workspace-apps/start-daemon-workspace-apps.test.ts packages/cli/src/commands/up.test.ts
+```
+
+### Finding 6: `ProjectConfigError` is public but not consumed as a public type
+
+Citations:
+
+- `packages/workspace/src/config/load-project-config.ts:24`
+- `packages/workspace/src/config/load-project-config.ts:34`
+- `packages/workspace/src/index.ts:118`
+- `packages/workspace/src/index.ts:119`
+- `packages/workspace/src/node.ts:19`
+
+`loadProjectConfig` returns a structured `ProjectConfigError`, but no non-test caller imports or narrows the exported error factory or the root alias. The CLI immediately converts the error to `new Error(error.message)` at `packages/cli/src/commands/up.ts:141` and `packages/cli/src/commands/up.ts:142`.
+
+Caller count:
+
+- `ProjectConfigError`: 0 non-test callers outside `load-project-config.ts` and barrels.
+- `ProjectConfigErrorType`: 0 non-test callers outside the root barrel.
+
+Proposed collapse:
+
+- Remove `ProjectConfigErrorType` from the root barrel first; it is an alias with no callers.
+- Consider keeping `ProjectConfigError` internal to `load-project-config.ts` unless external consumers need structured config error matching. This crosses a published package boundary, so pause before deletion.
+
+Targeted validation:
+
+```bash
+rg -n "ProjectConfigError|ProjectConfigErrorType" packages apps docs .agents examples --glob '!*.test.ts'
+bun run typecheck
+bun test packages/workspace/src/config/load-project-config.test.ts packages/cli/src/commands/up.test.ts
+```
+
+## Non-findings
+
+### `.epicenter` as data directory is current
+
+Citations:
+
+- `docs/scripting.md:37`
+- `packages/cli/README.md:96`
+- `apps/fuji/README.md:97`
+- `.agents/skills/workspace-app-layout/SKILL.md:212`
+
+These references describe `.epicenter/` as project-local data, not as a discovery marker. They should stay.
+
+### `workspace-app-layout` skill has the corrected marker wording
+
+Citations:
+
+- `.agents/skills/workspace-app-layout/SKILL.md:201`
+- `.agents/skills/workspace-app-layout/SKILL.md:212`
+- `.agents/skills/workspace-app-layout/SKILL.md:213`
+
+This skill still uses `./workspaces/fuji/daemon.ts` in an example import, but it explicitly says `epicenter.config.ts` is the project marker and route registry. That is acceptable unless the project wants to stop recommending the `workspaces/` folder convention entirely.
+
+## Validation Commands For A Follow-Up Patch
+
+```bash
+rg -n "folder-routed|workspaces/<route>/daemon\\.ts|discovers app daemons|workspaces -> apps" docs packages/cli/README.md apps/README.md apps/fuji/README.md .agents/skills
+rg -n "findProjectRoot|loadProjectConfig|DEFAULT_PROJECT_CONFIG_SOURCE|PROJECT_CONFIG_FILENAME|ProjectConfigError|ProjectConfigErrorType|StartDaemonWorkspaceAppsOptions|StartDaemonWorkspaceAppsResult|startDaemonWorkspaceApps" packages apps docs .agents examples --glob '!*.test.ts'
+bun run typecheck
+bun test packages/workspace/src/config/define-config.test.ts packages/workspace/src/config/load-project-config.test.ts packages/workspace/src/workspace-apps/start-daemon-workspace-apps.test.ts packages/cli/src/commands/up.test.ts
+```

--- a/specs/20260519T161500-config-route-collapse-pass/reports/implementation.md
+++ b/specs/20260519T161500-config-route-collapse-pass/reports/implementation.md
@@ -1,0 +1,144 @@
+# Implementation Queue
+
+Scope: safe findings from the three audit reports. Public export deletions are deferred unless explicitly approved, because `@epicenter/workspace` and `@epicenter/workspace/node` are published API surfaces.
+
+## Queue
+
+1. CLI project discovery split: make shared `projectOption` strict, keep the missing-config provisioning fallback only in `daemon up`.
+2. Workspace route startup wording: update stale "configured workspace" test wording, rename the private helper, and change the `WorkspaceOpenFailed` message to name daemon routes.
+3. Docs wording: replace stale folder-discovery wording in the workspace API skill, `apps/README.md`, and `packages/cli/README.md`.
+4. Public export cleanup: defer deletion of `StartDaemonWorkspaceAppsOptions`, `StartDaemonWorkspaceAppsResult`, root config loader exports, and `ProjectConfigErrorType` pending explicit API approval.
+
+## Checkpoint 1: CLI Project Discovery Split
+
+Finding: shared `projectOption` carries the old `daemon up` provisioning fallback.
+
+Inline check: `run`, `list`, `peers`, `down`, and `logs` all use `projectOption`; when discovery misses, the current option resolves any raw directory and lets downstream daemon lookup hash it as a project. Only `daemon up` should accept a non-project directory so it can create `epicenter.config.ts`.
+
+Fix: make `projectOption` call `findProjectRoot(start)` directly, then give `daemon up` its own option that preserves the fallback.
+
+What stays the same: `findProjectRoot` remains config-based, `daemon up` still provisions a missing default config, and `.epicenter/` remains project-local data.
+
+Changed files:
+
+- `packages/cli/src/util/common-options.ts`
+- `packages/cli/src/util/common-options.test.ts`
+- `packages/cli/src/commands/up.ts`
+
+Validation:
+
+- `bun test packages/workspace/src/client/find-project-root.test.ts`: passed.
+- `bun test packages/cli/src/util/common-options.test.ts packages/cli/src/commands/up.test.ts`: failed in the default sandbox because Bun could not bind Unix sockets (`EPERM`). Re-run with escalation passed: 11 tests, 0 failures.
+- `bun test packages/cli/src/util/common-options.test.ts`: passed after the final type-only test adjustment.
+- `bun x tsc --noEmit -p packages/cli/tsconfig.json`: passed.
+- `rg -n "resolveProjectDir|falls back to an absolute start path" packages/cli/src/util packages/cli/src/commands/up.ts`: no hits.
+
+Remaining risk: yargs still prints help while the strict coercion failure is asserted in the unit test. That behavior predates this change and is only visible on parse failure.
+
+## Checkpoint 2: Workspace Route Startup Wording
+
+Finding: route startup internals still carry old workspace-app wording.
+
+Inline check: `openOneWorkspaceApp` receives a `DaemonWorkspaceModule`, builds a context for that module's `route`, and calls `module.open(ctx)`. It does not know about workspace app folders.
+
+Fix: rename the private helper and option type to daemon-route names, update stale test wording, and change `WorkspaceOpenFailed` text from `Workspace` to `Daemon route`.
+
+What stays the same: exported `WorkspaceAppError` and `startDaemonWorkspaceApps` names stay in place; route validation, auth behavior, and runtime disposal behavior do not change.
+
+Changed files:
+
+- `packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts`
+- `packages/workspace/src/workspace-apps/start-daemon-workspace-apps.test.ts`
+- `packages/workspace/src/workspace-apps/errors.ts`
+
+Validation:
+
+- `bun test packages/workspace/src/workspace-apps/start-daemon-workspace-apps.test.ts`: passed.
+- `bun test packages/cli/src/commands/up.test.ts`: failed in the default sandbox because Bun could not bind Unix sockets (`EPERM`). Re-run with escalation passed: 9 tests, 0 failures.
+- `bun run typecheck` from `packages/workspace`: passed.
+- `rg -n "configured workspace|openOneWorkspaceApp|OpenOneOptions|Workspace \"" packages/workspace/src/workspace-apps packages/cli/src`: no hits.
+
+Remaining risk: the exported `WorkspaceAppError` variant name remains stale by design. Renaming it would cross the published package boundary.
+
+## Checkpoint 3: Docs Wording
+
+Finding: agent and CLI docs still describe folder discovery or over-authorize `workspaces/fuji/daemon.ts`.
+
+Inline check: the current runtime reads `epicenter.config.ts` and starts the imported daemon modules in `routes`; `workspaces/<route>/daemon.ts` is only a conventional import location.
+
+Fix: rewrite the stale docs to name the config route registry as the authority while preserving the conventional app file layout.
+
+What stays the same: durable route names, daemon module shape, and the `workspaces/` example layout stay available as examples.
+
+Changed files:
+
+- `.agents/skills/workspace-api/references/actions-layout-and-attachments.md`
+- `apps/README.md`
+- `packages/cli/README.md`
+
+Validation:
+
+- `rg -n "folder-routed|workspaces/<route>/daemon\\.ts|discovers app daemons|workspaces -> apps" .agents/skills/workspace-api/references/actions-layout-and-attachments.md packages/cli/README.md apps/README.md apps/fuji/README.md`: no hits.
+- `rg -n "folder-routed|workspaces/<route>/daemon\\.ts|discovers app daemons|workspaces -> apps" docs packages/cli/README.md apps/README.md apps/fuji/README.md .agents/skills`: one remaining hit in `docs/articles/workspace-apps-share-one-origin-on-purpose.md`, a historical article outside the audit findings and outside this safe implementation queue.
+- `rg -n "workspaces/fuji/daemon\\.ts" packages/cli/README.md`: one hit remains, the example import path.
+
+Remaining risk: historical docs articles still describe the old model. I left them alone because the audit findings targeted current docs, README files, and agent-facing skills.
+
+## Checkpoint 4: Public Export Cleanup
+
+Finding: several exported config and route-startup types have no in-repo consumers.
+
+Inline check: the zero-consumer names are exported from `@epicenter/workspace` or `@epicenter/workspace/node`, which are published package surfaces. External SDK or CLI consumers could still import them.
+
+Fix: defer deletion pending explicit API approval.
+
+What stays the same: all public exported names remain available.
+
+Changed files: none.
+
+Validation:
+
+- Not run for this deferred checkpoint.
+
+Remaining risk: stale public names remain in the package API until a coordinated public API cleanup decides whether to remove, rename, or alias them.
+
+## Overall Validation
+
+- `bun run --filter @epicenter/cli typecheck`: failed because this repo's Bun script setup did not match that filter command (`No packages matched the filter`).
+- `bun run typecheck`: failed in unrelated packages before completing the repo. Observed failures were in `apps/landing` (`@astrojs/svelte` resolution from UI Svelte files) and `apps/honeycrisp` (pre-existing Svelte/type errors in its app state and components).
+- `bun x tsc --noEmit -p packages/cli/tsconfig.json`: passed.
+- `bun run typecheck` from `packages/workspace`: passed.
+- `rg -n "<em dash>|<en dash>" <touched files>`: no hits.
+
+## Post Implementation Review
+
+Files re-read:
+
+```txt
+.agents/skills/workspace-api/references/
+`-- actions-layout-and-attachments.md
+apps/
+`-- README.md
+packages/
+|-- cli/
+|   |-- README.md
+|   `-- src/
+|       |-- commands/
+|       |   `-- up.ts
+|       `-- util/
+|           |-- common-options.test.ts
+|           `-- common-options.ts
+`-- workspace/
+    `-- src/workspace-apps/
+        |-- errors.ts
+        |-- start-daemon-workspace-apps.test.ts
+        `-- start-daemon-workspace-apps.ts
+specs/20260519T161500-config-route-collapse-pass/reports/
+`-- implementation.md
+```
+
+Review findings:
+
+- Fixed one formatting issue in `packages/workspace/src/workspace-apps/errors.ts`.
+- Left the `up.ts` startup cleanup shape as-is after validating it, because it preserves teardown behavior and shrinks repeated cleanup calls.
+- Left public exported names in place because deleting them needs an explicit API decision.

--- a/specs/20260519T161500-config-route-collapse-pass/reports/workspace-apps.md
+++ b/specs/20260519T161500-config-route-collapse-pass/reports/workspace-apps.md
@@ -1,0 +1,156 @@
+# Workspace Apps Audit
+
+Scope: `packages/workspace/src/workspace-apps/**` after the move from folder discovery to `epicenter.config.ts` route registration.
+
+Commit context: `git show --stat HEAD~1..HEAD` shows `373a4e0 refactor(workspace): collapse route discovery helper`, which removed `packages/workspace/src/workspace-apps/discover.ts` and its tests, updated CLI `up`, and kept `start-daemon-workspace-apps.ts` as the route startup path.
+
+## Grep Results
+
+No hits inside `packages/workspace/src/workspace-apps/**`:
+
+```txt
+daemonEntryPath
+DAEMON_ENTRY_FILENAME
+WorkspaceFolder
+WorkspaceDaemonInvalidExport
+folder-routed
+discoverWorkspaceApps
+folder discovery
+folder-discovery
+```
+
+Remaining local wording hits:
+
+```txt
+packages/workspace/src/workspace-apps/start-daemon-workspace-apps.test.ts:5
+packages/workspace/src/workspace-apps/start-daemon-workspace-apps.test.ts:57
+packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts:72
+packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts:110
+packages/workspace/src/workspace-apps/errors.ts:16
+packages/workspace/src/workspace-apps/errors.ts:36
+```
+
+## Findings
+
+### Finding 1: test wording still says "configured workspace"
+
+Citation:
+
+```txt
+packages/workspace/src/workspace-apps/start-daemon-workspace-apps.test.ts:5
+packages/workspace/src/workspace-apps/start-daemon-workspace-apps.test.ts:57
+```
+
+Caller count: documentation string only, 0 runtime callers.
+
+One-sentence test: `startDaemonWorkspaceApps` opens configured daemon route modules and returns started routes.
+
+Inline check: The test data is a `DaemonWorkspaceModule[]` passed as `routes`; there is no folder scan, workspace directory enumeration, or daemon entry path lookup in the happy path.
+
+Proposed collapse: Change both test strings from "configured workspace" to "configured route" or "configured daemon route". This is a mechanical wording cleanup with no behavior change.
+
+Targeted validation:
+
+```bash
+bun test packages/workspace/src/workspace-apps/start-daemon-workspace-apps.test.ts
+```
+
+### Finding 2: `openOneWorkspaceApp` carries the old install-unit name
+
+Citation:
+
+```txt
+packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts:72
+packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts:104
+packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts:110
+```
+
+Caller count: 1 internal non-test caller, at `packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts:72`.
+
+One-sentence test: The helper builds a daemon context for one config route and calls that route module's `open(ctx)`.
+
+Inline check: The helper does not know about workspace app folders. It receives a `DaemonWorkspaceModule`, uses `module.route`, and returns `StartedDaemonRoute`.
+
+Proposed collapse: Rename `OpenOneOptions` to `OpenOneRouteOptions` and `openOneWorkspaceApp` to `openOneDaemonRoute`, or inline the helper if the caller reads better with the context construction in the `routes.map` body. The rename is safer because the helper owns the try/catch boundary for `WorkspaceOpenFailed`.
+
+Targeted validation:
+
+```bash
+bun test packages/workspace/src/workspace-apps/start-daemon-workspace-apps.test.ts
+bun run typecheck
+```
+
+### Finding 3: public error names still say `WorkspaceApp`
+
+Citation:
+
+```txt
+packages/workspace/src/workspace-apps/errors.ts:16
+packages/workspace/src/workspace-apps/errors.ts:42
+packages/workspace/src/node.ts:94
+packages/cli/src/commands/up.ts:35
+packages/cli/src/commands/up.ts:93
+```
+
+Caller count: 1 non-test public barrel export, 1 CLI type consumer, and internal construction sites in `start-daemon-workspace-apps.ts`.
+
+One-sentence test: These errors describe route validation, signed-out machine auth, and failures thrown by configured daemon route `open(ctx)` calls.
+
+Inline check: The error object is not about discovering or validating a workspace app folder. `WorkspaceRouteRejected` already names routes; `WorkspaceAuthSignedOut` names daemon extensions; `WorkspaceOpenFailed` is the only variant whose message still says `Workspace "${route}" failed to open`.
+
+Proposed collapse: Keep the exported `WorkspaceAppError` name until the public API cleanup is coordinated, but change the user-facing `WorkspaceOpenFailed` message to `Daemon route "${route}" failed to open: ...`. A later public API pass can decide whether to alias or rename `WorkspaceAppError` to a route-startup name.
+
+Targeted validation:
+
+```bash
+bun test packages/workspace/src/workspace-apps/start-daemon-workspace-apps.test.ts packages/cli/src/commands/up.test.ts
+bun run typecheck
+```
+
+### Finding 4: exported startup types have no in-repo consumers
+
+Citation:
+
+```txt
+packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts:38
+packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts:44
+packages/workspace/src/node.ts:96
+packages/workspace/src/node.ts:97
+```
+
+Caller count: 0 non-test consumers outside the defining function annotations and `node.ts` re-export.
+
+One-sentence test: `StartDaemonWorkspaceAppsOptions` and `StartDaemonWorkspaceAppsResult` describe the options and result of one exported route startup function.
+
+Inline check: The CLI calls `startDaemonWorkspaceApps` directly and lets inference carry the result at the call site; no repo code imports these type names.
+
+Proposed collapse: Remove the public re-export from `packages/workspace/src/node.ts` if the package does not intend these as SDK surface. If they are kept for external consumers, leave them as explicit exports and document them as route startup types rather than workspace app discovery types.
+
+Targeted validation:
+
+```bash
+rg "StartDaemonWorkspaceAppsOptions|StartDaemonWorkspaceAppsResult" packages apps
+bun run typecheck
+```
+
+## Deferred Public-Shape Work
+
+The folder name and exported function still use `workspace-apps` and `startDaemonWorkspaceApps`. That name now means "configured daemon route startup", not "folder-discovered workspace apps":
+
+```txt
+packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts:4
+packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts:55
+packages/workspace/src/node.ts:98
+packages/cli/src/commands/up.ts:150
+```
+
+Caller count: 1 non-test runtime caller, 1 public barrel export, 6 direct test calls.
+
+Do not rename this in a drive-by cleanup. It crosses the `@epicenter/workspace/node` public surface and the CLI startup path. The clean collapse is probably a coordinated rename to a route-startup module with compatibility exports, or a deliberate decision that "workspace app" remains the product term even though folder discovery is gone.
+
+## Rejected Smells
+
+- `WorkspaceRouteRejected`: not stale; the variant names the current config route validation boundary.
+- `WorkspaceAuthSignedOut`: not stale enough to rename alone; it is part of the exported `WorkspaceAppError` union.
+- `startDaemonWorkspaceApps`: stale wording, but public-surface impact makes it a deferred API decision rather than a local collapse.
+- `packages/workspace/src/workspace-apps/errors.ts`: keep as a separate file for now; the error union is exported through `node.ts` and shared by the startup function and CLI typing.


### PR DESCRIPTION
Once daemon routes are explicitly configured, the startup path no longer needs route discovery helpers or legacy workspace-app barrels. This cleanup removes that leftover machinery and lets the daemon startup code operate directly on configured route entries.

The shape after the previous PR is:

```text
epicenter.config.ts
  daemon.routes
    route key -> daemon definition
      open(ctx) -> daemon runtime
```

This PR keeps that path direct. The daemon validates route names, opens each definition, returns started route runtimes, and disposes opened siblings if startup fails. The cleanup also tightens names around routes rather than generic served collections.

Before:

```text
config routes -> discovery helper -> workspace app entries -> startup
```

After:

```text
config route map -> validated entries -> startup
```

Verification:

```bash
bun run --cwd packages/workspace typecheck
bun test packages/workspace/src/config/define-config.test.ts packages/workspace/src/config/load-project-config.test.ts packages/workspace/src/workspace-apps/start-daemon-workspace-apps.test.ts
bun test packages/cli/src/commands/up.test.ts
```

Note: the CLI daemon test binds local Unix sockets.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->