### PR TITLE
refactor(api): flatten asset URL to /api/assets/<assetId>

### DIFF
--- a/apps/api/src/asset-routes.ts
+++ b/apps/api/src/asset-routes.ts
@@ -343,6 +343,7 @@ export const assetPublicRoutes = new Hono<Env>()
 				const headers = new Headers();
 				object.writeHttpMetadata(headers);
 				headers.set('etag', object.httpEtag);
+				headers.set('referrer-policy', 'no-referrer');
 				return new Response(null, { status: 304, headers });
 			}
 
@@ -352,6 +353,10 @@ export const assetPublicRoutes = new Hono<Env>()
 			headers.set('etag', object.httpEtag);
 			headers.set('accept-ranges', 'bytes');
 			headers.set('x-content-type-options', 'nosniff');
+			// Capability URL: do not let outgoing sub-resource requests carry
+			// the asset URL as a Referer. The unguessable id is the credential;
+			// keep it out of third-party logs and analytics.
+			headers.set('referrer-policy', 'no-referrer');
 			if (object.uploaded) {
 				headers.set('last-modified', object.uploaded.toUTCString());
 			}

--- a/apps/api/src/asset-routes.ts
+++ b/apps/api/src/asset-routes.ts
@@ -131,10 +131,14 @@ export const assetAuthedRoutes = new Hono<Env>()
 			}
 
 			// -- Store in R2 + Postgres --
+			// The R2 key is just the assetId. Ownership is tracked on the
+			// `asset` row, not in the key path: the unguessable 15-char
+			// nanoid IS the read credential, so embedding the userId in
+			// the key would only leak identity into the URL the row
+			// already implies.
 			const assetId = generateGuid();
-			const key = `${c.var.user.id}/${assetId}`;
 
-			await c.env.ASSETS_BUCKET.put(key, file.stream(), {
+			await c.env.ASSETS_BUCKET.put(assetId, file.stream(), {
 				httpMetadata: {
 					contentType: file.type,
 					contentDisposition: `inline; filename="${sanitizedFilename}"`,
@@ -152,7 +156,7 @@ export const assetAuthedRoutes = new Hono<Env>()
 				});
 			} catch (dbError) {
 				// Compensating delete — don't leave orphaned R2 objects
-				await c.env.ASSETS_BUCKET.delete(key).catch((r2Err) =>
+				await c.env.ASSETS_BUCKET.delete(assetId).catch((r2Err) =>
 					console.error('[upload] R2 cleanup failed:', r2Err),
 				);
 				throw dbError;
@@ -170,7 +174,7 @@ export const assetAuthedRoutes = new Hono<Env>()
 			return c.json(
 				{
 					id: assetId,
-					url: `/api/assets/${c.var.user.id}/${assetId}`,
+					url: `/api/assets/${assetId}`,
 					contentType: file.type,
 					size: file.size,
 					originalName: sanitizedFilename,
@@ -241,8 +245,7 @@ export const assetAuthedRoutes = new Hono<Env>()
 				return c.json(AssetError.NotFound(), 404);
 			}
 
-			const key = `${c.var.user.id}/${assetId}`;
-			await c.env.ASSETS_BUCKET.delete(key);
+			await c.env.ASSETS_BUCKET.delete(assetId);
 
 			// Credit storage back (fire-and-forget after response)
 			const autumn = createAutumn(c.env);
@@ -307,20 +310,26 @@ export const assetAuthedRoutes = new Hono<Env>()
 // Public routes (mounted without requireSession in app.ts)
 // ---------------------------------------------------------------------------
 
-/** Public routes (read). Mounted without requireSession in app.ts. */
+/**
+ * Public routes (read). Mounted without requireSession in app.ts.
+ *
+ * The `:assetId` param is constrained to the exact 15-char lowercase
+ * alphanumeric pattern produced by `generateGuid` so the route does not
+ * shadow sibling management endpoints (`/usage`, `/reconcile`, `/`)
+ * mounted under the same `/api/assets` prefix.
+ */
 export const assetPublicRoutes = new Hono<Env>()
-	// GET /:userId/:assetId — Read (unauthenticated, unguessable URL)
+	// GET /:assetId — Read (unauthenticated; the unguessable 15-char id IS the credential)
 	.get(
-		'/:userId/:assetId',
+		'/:assetId{[a-z0-9]{15}}',
 		describeRoute({
 			description: 'Read an asset by ID (unauthenticated)',
 			tags: ['assets'],
 		}),
 		async (c) => {
-			const { userId, assetId } = c.req.param();
-			const key = `${userId}/${assetId}`;
+			const { assetId } = c.req.param();
 
-			const object = await c.env.ASSETS_BUCKET.get(key, {
+			const object = await c.env.ASSETS_BUCKET.get(assetId, {
 				onlyIf: c.req.raw.headers,
 				range: c.req.raw.headers,
 			});

--- a/apps/api/src/auth/create-auth.ts
+++ b/apps/api/src/auth/create-auth.ts
@@ -116,7 +116,7 @@ export function createAuth({
 							.where(eq(schema.asset.userId, user.id));
 
 						if (assets.length > 0) {
-							const keys = assets.map((a) => `${user.id}/${a.id}`);
+							const keys = assets.map((a) => a.id);
 							await env.ASSETS_BUCKET.delete(keys);
 						}
 


### PR DESCRIPTION
The asset URL `/api/assets/<userId>/<assetId>` had two problems pinned down in `specs/20260522T240000-cloud-asset-access-model.md`: the `userId` segment did no work (the read endpoint is unauthenticated; the unguessable 15-char nanoid is the only thing protecting the bytes) and it leaked a stable user identifier into any link a user copied or shared. This branch flattens the URL to `/api/assets/<assetId>` and pulls `userId` out of the R2 key path entirely, then sets `Referrer-Policy: no-referrer` on the read response so the asset URL does not travel outward as a Referer when content inside the asset makes sub-resource requests.

Ownership tracking is unchanged: it lives on `asset.userId`, where `DELETE` authz and quota counting use it exactly as before. The change is purely about getting identity out of the URL and the storage key, where it was decoration with a cost.

```ts
// upload response — was /api/assets/${userId}/${assetId}
return c.json({ id: assetId, url: `/api/assets/${assetId}`, ... }, 201);

// R2 keys for put / delete / bulk delete — were `${userId}/${assetId}`
await c.env.ASSETS_BUCKET.put(assetId, file.stream(), { ... });
await c.env.ASSETS_BUCKET.delete(assetId);
const keys = assets.map((a) => a.id);
```

One thing the spec did not anticipate: the original two-segment path `/:userId/:assetId` naturally did not collide with sibling endpoints like `GET /usage`, `POST /reconcile`, or `GET /` mounted on the same `/api/assets` prefix, because those are one-segment paths. Flattening to `/:assetId` would have made the public read greedily match anything one segment deep — `GET /api/assets/usage` would be interpreted as `assetId="usage"` and 404 on R2 instead of reaching the authed handler.

The fix is a Hono regex constraint pinning the param to the exact alphabet and length the asset id has:

```ts
.get('/:assetId{[a-z0-9]{15}}', publicReadHandler)
```

`generateGuid` produces 15 lowercase-alphanumeric chars from nanoid's standard alphabet, so this matches every real asset id and refuses `usage`, `reconcile`, the empty string, anything else. The two-router structure (public mounted before the auth middleware, authed mounted after) stays exactly as before.

One thing worth looking at before merging: the R2 key shape changed from `<userId>/<assetId>` to `<assetId>`. Any objects already in the bucket under the old shape become unreachable by the new read handler — the DB row stores just the assetId and the new code reads R2 with that same id. A grep across `apps/` and `packages/` confirmed zero clients persist asset URLs anywhere, so the URL change is greenfield. The R2 bucket itself I cannot check from here — if production has any uploaded assets, those bytes need a one-time rename or to be treated as expendable.

`bun run typecheck` clean. `bun test` reports 86 / 0 across 11 files.

2 commits, 3 files, +28 / -14.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782090425&installation_id=128463665&pr_number=1794&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1794&signature=6f8525d137ddcd58e848c8ecff011278de4e85979c8e46c39e94de69aa6cc306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->