### PR TITLE
chore: clean stale dev-tooling docs after .dev.vars removal

### DIFF
--- a/.agents/skills/monorepo/SKILL.md
+++ b/.agents/skills/monorepo/SKILL.md
@@ -44,15 +44,19 @@ Use this pattern when you need to:
 
 ## Dev Scripts
 
-Every app uses explicit `dev:local` / `dev:remote` naming:
+Apps use either a single `dev` script (when there is only one sensible local
+workflow) or a `dev:local` alias (kept for symmetry with `:remote` db scripts).
+The suffix convention applies primarily to database commands:
 
 | Script | Meaning |
 | --- | --- |
-| `dev:local` | Local everything:local API, local secrets |
-| `dev:remote` | Local app, remote/prod resources |
-| `dev` | Alias for `dev:local` (convenience) |
+| `dev` | The default local workflow. May still require Infisical login for app secrets (e.g. API keys), but only ever talks to local infrastructure at runtime. |
+| `dev:local` | Used when an app keeps the `dev` -> `dev:local` alias for explicit naming. Equivalent to `dev`. |
+| `db:*:local` | Runs against local Postgres. Works without Infisical login. |
+| `db:*:remote` | Wraps with `infisical run --env=prod`. Production data; treat as admin. |
 
-Not every app has `dev:remote`:only add it when there's a real use case.
+There is no `dev:remote`. Production data is reached only through `:remote` db
+scripts and `deploy`, never through a development server.
 
 ## CLI (`epicenter`)
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,3 +1,0 @@
-# Autumn billing (https://useautumn.com)
-AUTUMN_SECRET_KEY=am_sk_test_your_test_key_here
-AUTUMN_PROD_SECRET_KEY=am_sk_live_your_live_key_here

--- a/docs/articles/local-remote-script-convention.md
+++ b/docs/articles/local-remote-script-convention.md
@@ -27,17 +27,15 @@ Name every database-touching script with an explicit `:local` or `:remote` suffi
     "db:generate": "drizzle-kit generate",
     "db:drop": "drizzle-kit drop",
     "db:push:local": "drizzle-kit push",
-    "db:push:remote": "infisical run --path=/api -- drizzle-kit push",
-    "db:migrate:local": "drizzle-kit migrate",
-    "db:migrate:remote": "infisical run --path=/api -- drizzle-kit migrate",
+    "db:migrate:remote": "infisical run --env=prod --path=/api -- drizzle-kit migrate",
     "db:studio:local": "drizzle-kit studio",
-    "db:studio:remote": "infisical run --path=/api -- drizzle-kit studio"
+    "db:studio:remote": "infisical run --env=prod --path=/api -- drizzle-kit studio"
 }
 ```
 
 `db:generate` and `db:drop` have no suffix because they never touch a database. `db:generate` diffs your schema files and produces SQL. `db:drop` deletes a local migration file. Both are pure filesystem operations. Suffixing them would be noise.
 
-Everything else gets a suffix. No exceptions.
+Everything that connects to a database gets a suffix. Not every command needs both halves: `db:push:local` exists for fast iteration, but the corresponding `:remote` push is intentionally absent because schema changes against production go through versioned migrations (`db:migrate:remote`), not ad-hoc pushes.
 
 ## The Implementation
 
@@ -61,22 +59,25 @@ If `DATABASE_URL` isn't set in the environment, drizzle-kit falls through to the
 
 ### `:remote` scripts
 
-`:remote` scripts are prefixed with `infisical run --path=/api --`:
+`:remote` scripts are prefixed with `infisical run --env=prod --path=/api --`:
 
 ```
-infisical run --path=/api -- drizzle-kit push
+infisical run --env=prod --path=/api -- drizzle-kit migrate
 ```
 
-Infisical injects `DATABASE_URL` before the command runs. That URL points to the dev-branch or production Postgres, depending on your Infisical environment. drizzle-kit picks it up because it takes priority over the `LOCAL_DATABASE_URL` fallback.
+Infisical injects `DATABASE_URL` (and any other secrets) before the command runs. That URL points to the production Postgres. drizzle-kit picks it up because `process.env.DATABASE_URL` takes priority over the `LOCAL_DATABASE_URL` fallback.
 
-The same pattern applies to `dev`:
+### Why there is no `dev:remote`
+
+You might expect a parallel `dev:remote` that wraps `wrangler dev` with `infisical run`. There isn't one, by design. A development server pointing at production data is a category error: there's no use case for it that isn't better served by either (a) running real migrations against prod via `db:migrate:remote`, or (b) deploying.
+
+The bare `dev` script is the single sensible local workflow. It still requires Infisical login because the API needs dev secrets like API keys and the auth secret, but it never touches production data at runtime: Wrangler's Hyperdrive binding (`localConnectionString` from `wrangler.jsonc`) routes the connection to local Postgres. Secrets pipe through `process.env` via `CLOUDFLARE_INCLUDE_PROCESS_ENV=true`; no `.dev.vars` file is produced.
 
 ```json
-"dev:local": "wrangler dev",
-"dev:remote": "infisical run --watch --path=/api -- wrangler dev",
+"dev": "bun scripts/dev.ts"
 ```
 
-`dev:remote` adds `--watch` so Infisical refreshes secrets if they rotate during a long session.
+Inside that script: `infisical run --silent --path=/api -- wrangler dev` with the env var set. One command, one workflow, no `:remote` variant.
 
 ## The Three-Layer Strategy
 
@@ -117,13 +118,13 @@ docker run -d -p 5432:5432 -e POSTGRES_DB=epicenter postgres
 # Push the schema locally
 bun run db:push:local
 
-# Start the dev server
-bun run dev:local
+# Open Drizzle Studio against the local DB
+bun run db:studio:local
 ```
 
-Zero secrets. Zero environment setup. The `:local` scripts work because the fallback is hardcoded in `drizzle.config.ts`. They can develop locally, write migrations, and open PRs without ever touching Infisical.
+Zero secrets. Zero environment setup. The `:local` scripts work because the fallback is hardcoded in `drizzle.config.ts`. They can write migrations and inspect schema locally without ever touching Infisical.
 
-When they need to test against the real dev database, they get Infisical access and switch to `:remote`. The workflow is the same, the scripts just have different names.
+Running the full API server (`bun run dev`) still requires Infisical access because the app needs real API keys and the auth secret. But schema work, migration authoring, and Drizzle Studio against a clean local DB are all available before the contributor is added to Infisical. When they're ready to write a real migration against production, they get Infisical prod access and use `db:migrate:remote`.
 
 ## The Pattern This Replaces
 
@@ -144,10 +145,10 @@ Or worse, there's just one script and the URL is controlled entirely by which `.
 
 ```json
 "db:push:local": "drizzle-kit push",
-"db:push:remote": "infisical run --path=/api -- drizzle-kit push",
+"db:migrate:remote": "infisical run --env=prod --path=/api -- drizzle-kit migrate",
 ```
 
-Now the command is self-documenting. `db:push:local` cannot accidentally hit the remote database — drizzle-kit will only see `LOCAL_DATABASE_URL`. `db:push:remote` cannot accidentally hit local — Infisical injects the real URL and that takes priority.
+Now the command is self-documenting. `db:push:local` cannot accidentally hit the remote database — drizzle-kit will only see `LOCAL_DATABASE_URL`. `db:migrate:remote` cannot accidentally hit local — Infisical injects the real URL and that takes priority. The asymmetry between `push:local` and `migrate:remote` is intentional: fast ad-hoc pushes are fine for the schema you can nuke, but production gets versioned migrations.
 
 The suffix is not just a label. It enforces the behavior.
 

--- a/specs/20260504T210000-better-auth-1.6.9-upgrade.md
+++ b/specs/20260504T210000-better-auth-1.6.9-upgrade.md
@@ -466,7 +466,7 @@ Single PR. Waves are sequential.
 5. **Risk**: if Better Auth defaults to `https` for non-loopback hosts and the request scheme is `http`, we get protocol mismatch.
 
 Mitigation paths:
-- Set `BETTER_AUTH_URL=http://localhost:8787` in `.dev.vars` and let env override the host. This is the cleanest fix; production already has the same env not set, so the request URL drives.
+- Set `BETTER_AUTH_URL=http://localhost:8787` in Infisical's dev environment and let env override the host. This is the cleanest fix; production already has the same env not set, so the request URL drives.
 - Or: add `localhost:8787` to `allowedHosts` and rely on the wrangler dev custom-domain config to route to localhost. (Wrangler's custom domain in dev is configurable.)
 - Or: keep a one-liner middleware that flips `c.req.url` (not `baseURL`) to the localhost form before Better Auth sees it. Smaller than today's middleware.
 
@@ -498,7 +498,7 @@ Drizzle's minor versions occasionally change generic inference for `select()` an
 
 1. **Should we set `advanced.trustedProxyHeaders: true`?**
    - Cloudflare sets `X-Forwarded-Proto`. Turning this on lets Better Auth honor the upstream protocol, which would resolve the wrangler-dev edge case (§7.1).
-   - **Recommendation**: defer. The object-form `baseURL` plus a `BETTER_AUTH_URL` env var in `.dev.vars` is simpler. Add `trustedProxyHeaders` only if we hit a real production case where the protocol is wrong.
+   - **Recommendation**: defer. The object-form `baseURL` plus a `BETTER_AUTH_URL` env var in Infisical's dev environment is simpler. Add `trustedProxyHeaders` only if we hit a real production case where the protocol is wrong.
 
 2. **Tighten `AuthUser.email` to allow `null` for 1.6.8 nullable provider profiles?**
    - Google always returns email when scope includes it. Apple, Facebook, etc. can omit.

--- a/turbo.json
+++ b/turbo.json
@@ -39,10 +39,6 @@
 		"dev": {
 			"cache": false,
 			"persistent": true
-		},
-		"dev:secrets": {
-			"cache": false,
-			"persistent": true
 		}
 	}
 }


### PR DESCRIPTION
PR #1795 removed `.dev.vars` in favor of Infisical-via-process.env, but five docs and config sites still pointed at the old flow. Reading them now would send a new contributor down a path that no longer works. This PR makes the words match the code.

The most user-visible site is `docs/articles/local-remote-script-convention.md`. The article explained the `dev:local` / `dev:remote` convention with an example script block that didn't match `apps/api/package.json` anymore. It also held up a speculative `dev:remote` script as the pattern to follow, and a speculative `db:push:remote` example to demonstrate it. Both were aspirational; neither exists. The rewrite replaces the example block with what `apps/api` actually ships, adds a "Why there is no dev:remote" section that explains the deliberate absence (a dev server pointing at prod data is a category error, not a missing feature), and uses the real `db:migrate:remote` for the cross-environment example.

The monorepo skill in `.agents/skills/monorepo/SKILL.md` had the same drift: a Dev Scripts table claiming every app exposed both `dev:local` and `dev:remote`. In reality some apps use bare `dev`, some keep `dev` as an alias for `dev:local`, and nothing uses `dev:remote`. The rewrite states that explicitly and points to `db:*:local` / `db:*:remote` as the suffix convention that actually carries weight.

Three smaller sites round out the cleanup:

```
apps/api/.env.example                        orphan template (AUTUMN_SECRET_KEY only)
                                             pre-dating .dev.vars.example becoming
                                             canonical. Deleted.

turbo.json                                   the `dev:secrets` task. Grep confirms
                                             zero callers in any package. Deleted.

specs/20260504T210000-better-auth-1.6.9-     two draft-spec references to setting
upgrade.md                                   BETTER_AUTH_URL in .dev.vars updated
                                             to reference Infisical's dev
                                             environment.
```

Not in scope, but worth flagging: `packages/server/.env` (gitignored, never committed) contains real OpenAI and Anthropic API keys on local disk. Out-of-band rotation needed before that directory is removed.