### PR TITLE
docs(spec): workspace project layout + canonical fuji example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,24 @@ epicenter/
 
 Currently, **Whispering** (`apps/whispering`) is the most mature application and the best place to start contributing. Check the [Whispering README](apps/whispering/README.md) for specific details about that application.
 
+### Working without Infisical access
+
+Most of the repo does not need Infisical. Whispering, the Tab Manager extension, the CLI, and every shared package (`@epicenter/workspace`, `@epicenter/ui`, and the rest) build and run from a fresh clone with nothing more than `bun install`.
+
+The only app that requires Infisical is `apps/api` (the hosted hub). Running it (`bun run dev:api` from the repo root, or `bun run dev` from `apps/api/`) needs real API keys and the auth secret, so the dev script refuses to start without an `infisical login`.
+
+You can still contribute to the API schema without Infisical access. From `apps/api/`:
+
+| Script | What it does |
+| --- | --- |
+| `bun run db:generate` | Generate a migration from schema files (no database touched) |
+| `bun run db:push:local` | Push the schema to your local Postgres |
+| `bun run db:studio:local` | Open Drizzle Studio against your local Postgres |
+
+Write the migration, push it locally, open a PR. A maintainer with Infisical prod access applies it via `bun run db:migrate:remote`.
+
+The convention in one line: `:local` works on a fresh clone, `:remote` wraps with `infisical run --env=prod` and is admin-only. See [`docs/articles/local-remote-script-convention.md`](docs/articles/local-remote-script-convention.md) for the full story.
+
 ## Development Workflow
 
 1. **Create a branch** for your feature or fix

--- a/apps/api/scripts/dev.ts
+++ b/apps/api/scripts/dev.ts
@@ -21,7 +21,9 @@ const auth = await Bun.$`infisical --silent user get token --plain`
 
 if (auth.exitCode !== 0 || !auth.stdout.toString().trim()) {
 	console.error('Not logged into Infisical.');
-	console.error('Run `infisical login`, then retry `bun run dev:api`.');
+	console.error('Running `apps/api` requires Infisical access for dev secrets (API keys, auth secret).');
+	console.error('Run `infisical login`, then rerun the same command.');
+	console.error('If you do not have Infisical access, see CONTRIBUTING.md for what you can work on without it.');
 	process.exit(1);
 }
 

--- a/docs/articles/local-remote-script-convention.md
+++ b/docs/articles/local-remote-script-convention.md
@@ -93,19 +93,23 @@ Inside that script: `infisical run --silent --path=/api -- wrangler dev` with th
 
 The production worker never uses `DATABASE_URL` directly. It uses `env.HYPERDRIVE` — the Cloudflare binding — which handles connection pooling and routing through Hyperdrive's edge network. So there's no single URL that can target production directly from drizzle-kit. That's intentional.
 
-## Remote Doesn't Mean Production
+## Who `:remote` Is For
 
-This is important: `:remote` targets a **development branch** of your database, not production. If you use a database provider with branching — PlanetScale, Supabase, Neon — your Infisical `DATABASE_URL` should point to the dev branch. That's the whole point. You get a real Postgres environment with the same engine and extensions as production, but it's isolated. Schema changes on the dev branch don't touch production data.
+`:remote` is not "development on a remote branch." It is production administration. The `infisical run --env=prod --path=/api --` prefix injects the live `DATABASE_URL`, and the script runs against the same Postgres that real users hit. Treat every `:remote` command as a deploy-class action.
+
+That means `:remote` is for team members with Infisical prod access only. Outside contributors run `:local` scripts against their own Postgres, write migrations, open PRs. A maintainer with prod access applies the migration via `db:migrate:remote`.
 
 The flow looks like this:
 
 ```
-:local   → localhost Postgres       → your machine only
-:remote  → dev branch Postgres      → shared dev environment
-deploy   → Hyperdrive → production  → real users
+:local   → localhost Postgres                       → your machine only
+:remote  → production Postgres (Infisical prod env) → team members only
+deploy   → Hyperdrive → production runtime          → real users
 ```
 
-Three environments, three levels of blast radius. `:local` can't break anything beyond your machine. `:remote` can break the shared dev branch but not production. And production is only reachable through Hyperdrive at runtime — no URL you can accidentally paste into a drizzle-kit command.
+Three environments, three levels of blast radius. `:local` can't break anything beyond your machine. `:remote` reaches prod data and is admin-only. And the production worker itself only reaches prod through Hyperdrive at runtime: no URL you can accidentally paste into a drizzle-kit command from the running app.
+
+If you want a shared dev branch (PlanetScale, Supabase, Neon), add a third environment in Infisical and a separate suffix (`db:migrate:dev`, for example). Don't blur it into `:remote`. The suffix names the blast radius; making `:remote` mean two different things defeats the whole point.
 
 ## The Contributor Experience
 

--- a/examples/fuji/.gitignore
+++ b/examples/fuji/.gitignore
@@ -1,0 +1,6 @@
+# Epicenter: all durable runtime state and materializer caches.
+# Regenerable from committed markdown in entries/.
+.epicenter/
+
+# Bun / Node
+node_modules/

--- a/examples/fuji/README.md
+++ b/examples/fuji/README.md
@@ -1,0 +1,95 @@
+# `@examples/fuji`
+
+The canonical Epicenter project layout demonstrated against `@epicenter/fuji`.
+
+## What this shows
+
+One project, one workspace, defined inline in `epicenter.config.ts`. Table
+data lives as markdown at the project root and is committed to git. Runtime
+state (Yjs persistence, SQLite materializer) lives under `.epicenter/` and is
+gitignored.
+
+This example is the reference implementation of the layout spec at
+`specs/20260522T220000-workspace-project-layout.md`. If the spec changes,
+this example changes with it.
+
+## Layout
+
+```
+examples/fuji/
+├── package.json           dependencies (this file)
+├── tsconfig.json          extends the repo base
+├── epicenter.config.ts    REQUIRED. Marker + workspace definition.
+├── .gitignore             Epicenter-managed (.epicenter/)
+├── entries/               table data as markdown (committed)
+│   ├── welcome.md
+│   └── hello-fuji.md
+└── .epicenter/            created on first daemon run; gitignored
+    ├── yjs.db
+    └── sqlite.db
+```
+
+## Run it
+
+```sh
+bun install
+bun x epicenter daemon up -C examples/fuji
+```
+
+On first run the daemon creates `.epicenter/` and writes `yjs.db` and
+`sqlite.db`. The markdown files in `entries/` are the source of truth; the
+daemon reads them to populate the Yjs document (once markdown → Y.Doc
+hydration lands; see §7.2 of the spec).
+
+## Inspect the SQL mirror
+
+```sh
+sqlite3 examples/fuji/.epicenter/sqlite.db
+sqlite> .tables
+sqlite> SELECT id, title FROM entries;
+```
+
+The SQLite mirror is regenerable from `yjs.db`, which is regenerable from
+the markdown in `entries/`. Anything under `.epicenter/` can be deleted; the
+daemon will rebuild it on next run.
+
+## Edit a note
+
+Open `entries/welcome.md` in your editor and change the body. The daemon's
+reverse watcher (see spec §7.2) picks up the change and applies it to the
+Y.Doc, which propagates to the SQL mirror and to any connected peers.
+
+You can also drive changes through the daemon's RPC actions. Use the CLI:
+
+```sh
+bun x epicenter run fuji.entries_get '{"id":"01HM0000000000000000000000"}' -C examples/fuji
+```
+
+The action set is defined by `@epicenter/fuji` and re-exposed through this
+example's `epicenter.config.ts`.
+
+## Add a new entry
+
+Two equivalent ways:
+
+1. **Write a markdown file.** Create `entries/my-new-entry.md` with the same
+   front-matter shape as the existing examples. The daemon ingests it.
+2. **Call a mutation.** Use the CLI's `run` subcommand to invoke the
+   workspace's add action.
+
+Both paths produce the same row in the `entries` table.
+
+## What this example deliberately omits
+
+- Auth and sync. The example is local-only; no `epicenter auth login` step.
+- Browser or Tauri frontend. The example is daemon-only.
+- Custom path overrides. Materializer paths use the spec's default
+  (`.epicenter/sqlite.db` and `./entries/`).
+- Multi-workspace orchestration. One workspace per project is the canonical
+  shape; multi-workspace is a monorepo with sibling projects.
+
+## See also
+
+- `specs/20260522T220000-workspace-project-layout.md` for the full spec.
+- `examples/notes-cross-peer/` for a two-peer sync demo (predates this layout).
+- `apps/fuji/` for the full Tauri/Svelte app that consumes the same workspace.

--- a/examples/fuji/architecture.test.ts
+++ b/examples/fuji/architecture.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Pins examples/fuji to the project layout spec.
+ *
+ * Static checks only: marker presence, gitignore content, seed markdown,
+ * package.json shape, config file uses the new path conventions. Daemon
+ * behavior is covered by `apps/fuji/architecture.test.ts` and the playground
+ * e2e tests; this file catches drift between the committed tree and
+ * `specs/20260522T220000-workspace-project-layout.md`.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, test } from 'bun:test';
+
+const DIR = import.meta.dir;
+
+describe('examples/fuji follows the project layout spec', () => {
+	test('marker file at project root', () => {
+		expect(existsSync(join(DIR, 'epicenter.config.ts'))).toBe(true);
+	});
+
+	test('seed markdown is committed under entries/', () => {
+		expect(existsSync(join(DIR, 'entries/welcome.md'))).toBe(true);
+		expect(existsSync(join(DIR, 'entries/hello-fuji.md'))).toBe(true);
+	});
+
+	test('.gitignore has the .epicenter/ rule', () => {
+		const gitignore = readFileSync(join(DIR, '.gitignore'), 'utf-8');
+		expect(gitignore).toMatch(/^\.epicenter\/$/m);
+	});
+
+	test('package.json declares the required workspace deps', () => {
+		const pkg = JSON.parse(
+			readFileSync(join(DIR, 'package.json'), 'utf-8'),
+		) as { dependencies?: Record<string, string> };
+		expect(pkg.dependencies?.['@epicenter/workspace']).toBeDefined();
+		expect(pkg.dependencies?.['@epicenter/fuji']).toBeDefined();
+	});
+
+	test('epicenter.config.ts uses the new path conventions', () => {
+		const src = readFileSync(join(DIR, 'epicenter.config.ts'), 'utf-8');
+		// SQLite mirror lives under .epicenter/ at the project root.
+		expect(src).toContain('.epicenter');
+		expect(src).toContain('sqlite.db');
+		// Markdown materializer roots at the project (table name auto-appended).
+		expect(src).toContain('dir: projectDir');
+		// Legacy per-workspaceId helpers must not be used here.
+		expect(src).not.toContain('markdownPath(');
+		expect(src).not.toContain('sqlitePath(');
+	});
+});

--- a/examples/fuji/entries/hello-fuji.md
+++ b/examples/fuji/entries/hello-fuji.md
@@ -1,0 +1,27 @@
+---
+id: 01HM0000000000000000000001
+title: Hello Fuji
+subtitle: A second entry to show one-file-per-row materialization
+type: []
+tags: ["example"]
+pinned: false
+date: 2026-05-22T00:00:00Z
+createdAt: 2026-05-22T00:00:00Z
+updatedAt: 2026-05-22T00:00:00Z
+rating: 0
+_v: 2
+---
+
+# Hello Fuji
+
+The markdown materializer writes one file per row in the `entries` table.
+The filename is derived from the row's `title` by `slugFilename('title')`.
+
+The `id` in the front-matter is the stable workspace identifier (a ULID by
+convention); the filename can change as the title changes. The daemon
+reconciles the two when a file is renamed.
+
+This file is sibling to `welcome.md`, both in the `entries/` directory.
+Adding a third entry means adding a third file. Removing an entry means
+deleting its file (the daemon picks up the change and applies the deletion
+to the Y.Doc).

--- a/examples/fuji/entries/welcome.md
+++ b/examples/fuji/entries/welcome.md
@@ -1,0 +1,42 @@
+---
+id: 01HM0000000000000000000000
+title: Welcome to Fuji
+subtitle: A canonical Epicenter project layout
+type: []
+tags: ["welcome"]
+pinned: true
+date: 2026-05-22T00:00:00Z
+createdAt: 2026-05-22T00:00:00Z
+updatedAt: 2026-05-22T00:00:00Z
+rating: 0
+_v: 2
+---
+
+# Welcome to Fuji
+
+This file is the committed, human-editable source of truth for one entry in a
+Fuji workspace. The daemon reads files like this on startup, hydrates the
+in-memory Yjs document, and keeps the markdown and Yjs in sync as either side
+changes.
+
+You can edit this file in any editor. The daemon picks up the change and
+applies it to the workspace. You can also drive edits through the daemon's
+actions (queries and mutations defined by `@epicenter/fuji`). Either path
+produces the same end state.
+
+## Layout
+
+The project's data layout is documented in `specs/20260522T220000-workspace-project-layout.md`:
+
+- `epicenter.config.ts` is both the project marker and the workspace definition.
+- `entries/` (this directory) holds the markdown source of truth.
+- `.epicenter/` is the runtime cache (gitignored).
+
+## Try it
+
+    bun install
+    bun x epicenter daemon up
+
+The daemon materializes `.epicenter/yjs.db` and `.epicenter/sqlite.db` on
+first run. Inspect the SQLite mirror with `sqlite3 .epicenter/sqlite.db` for
+queryable access to the same data.

--- a/examples/fuji/epicenter.config.ts
+++ b/examples/fuji/epicenter.config.ts
@@ -1,0 +1,78 @@
+/**
+ * Canonical Epicenter project: one workspace, defined inline.
+ *
+ * Layout (per specs/20260522T220000-workspace-project-layout.md):
+ *   epicenter.config.ts       this file: marker + workspace definition
+ *   entries/                  table data as markdown (committed)
+ *   .epicenter/               runtime cache (gitignored)
+ *     yjs.db                  Yjs persistence
+ *     sqlite.db               SQL materializer
+ *
+ * This uses the current `defineConfig({ daemon: { routes: { ... } } })` API
+ * with a single route. The spec's target API is `defineWorkspace({...})` as
+ * the direct default export; that rename is a separate refactor.
+ */
+
+import { defineConfig } from '@epicenter/workspace';
+import { defineDaemonWorkspace } from '@epicenter/workspace/daemon';
+import {
+	attachMarkdownMaterializer,
+	slugFilename,
+} from '@epicenter/workspace/document/materializer/markdown';
+import { attachSqliteMaterializer } from '@epicenter/workspace/document/materializer/sqlite';
+import {
+	attachDaemonInfrastructure,
+	openWriterSqlite,
+} from '@epicenter/workspace/node';
+import { openFujiWorkspace } from '@epicenter/fuji';
+import { join } from 'node:path';
+import { createLogger } from 'wellcrafted/logger';
+
+const fuji = defineDaemonWorkspace({
+	async open({
+		projectDir,
+		route,
+		clientId,
+		installationId,
+		attachEncryption,
+		openWebSocket,
+	}) {
+		const workspace = openFujiWorkspace(attachEncryption, { clientId });
+
+		const infra = attachDaemonInfrastructure(workspace.ydoc, {
+			projectDir,
+			openWebSocket,
+			installationId,
+			actions: workspace.actions,
+		});
+
+		// Runtime cache: hidden under .epicenter/ at the project root.
+		// The spec's future helper is `sqlitePath(projectDir)`; we inline the
+		// path here so the example runs against today's package surface.
+		const sqliteDb = openWriterSqlite({
+			filePath: join(projectDir, '.epicenter', 'sqlite.db'),
+			log: createLogger(`${route}-sqlite`),
+		});
+		workspace.ydoc.once('destroy', () => sqliteDb.close());
+
+		attachSqliteMaterializer(workspace.ydoc, { db: sqliteDb }).table(
+			workspace.tables.entries,
+		);
+
+		// Markdown: visible at project root, one directory per table.
+		// Committed to git as the source of truth. The materializer appends
+		// the table name to `dir`, so `dir: projectDir` produces
+		// `<projectDir>/entries/<slug>.md` for the `entries` table.
+		attachMarkdownMaterializer(workspace.ydoc, {
+			dir: projectDir,
+		}).table(workspace.tables.entries, { filename: slugFilename('title') });
+
+		return infra;
+	},
+});
+
+export default defineConfig({
+	daemon: {
+		routes: { fuji },
+	},
+});

--- a/examples/fuji/package.json
+++ b/examples/fuji/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "@examples/fuji",
+	"version": "0.0.1",
+	"private": true,
+	"type": "module",
+	"description": "Canonical Epicenter project layout demonstrated against the @epicenter/fuji workspace.",
+	"scripts": {
+		"test": "bun test"
+	},
+	"dependencies": {
+		"@epicenter/cli": "workspace:*",
+		"@epicenter/fuji": "workspace:*",
+		"@epicenter/workspace": "workspace:*",
+		"wellcrafted": "catalog:",
+		"yjs": "catalog:"
+	},
+	"devDependencies": {
+		"@types/bun": "catalog:",
+		"typescript": "catalog:"
+	}
+}

--- a/examples/fuji/tsconfig.json
+++ b/examples/fuji/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"types": ["bun"]
+	},
+	"include": ["epicenter.config.ts"]
+}

--- a/specs/20260522T220000-workspace-project-layout.md
+++ b/specs/20260522T220000-workspace-project-layout.md
@@ -1,0 +1,907 @@
+# Workspace project layout: `epicenter.config.ts`, markdown as canon, `~/.epicenter/`
+
+Status: draft
+Owner: braden
+Date: 2026-05-22
+
+## 1. Goal
+
+Pin down the on-disk layout for any Epicenter-using project so that:
+
+- A developer cloning a project can identify it as Epicenter at a glance.
+- A daemon, a CLI, and a Tauri app on the same machine all read and write the same shared user state without coordination via env vars.
+- Markdown is the canonical, human-editable, git-friendly representation of workspace data. Yjs is the runtime collaboration layer; SQLite is a queryable mirror.
+- One workspace per project. Multi-workspace is a monorepo, not a directory-of-workspaces.
+- The platform reserves two things in a project tree, and one in the user's home. Nothing else.
+
+This spec replaces ad-hoc usage of `env-paths`, the `<projectDir>/.epicenter/<resource>/<wsId>` per-resource layout, and the assumption that yjs.db is the committed source of truth.
+
+## 2. The reservations
+
+```
+At a project root:
+  epicenter.config.ts             ← FILE, required. Marker + workspace definition.
+  .epicenter/                     ← DIR, runtime cache. Auto-created. Gitignored.
+
+In user home:
+  ~/.epicenter/                   ← DIR, cross-app user state. Auto-created.
+```
+
+That's it. No `workspaces/` container. No `workspace.ts` companion file. No `<route>/` subdirectories. One workspace per project; the file at root defines it.
+
+By convention, table data lives in directories at the project root named after the table:
+
+```
+<project>/<tableName>/<slug>.md
+```
+
+This is convention, not reservation. The actual paths are whatever the developer passes to the markdown materializer in `epicenter.config.ts`. The spec documents the default; the materializer accepts any path.
+
+### 2.1 What each reservation is
+
+`epicenter.config.ts` is the *identity* and *definition* of an Epicenter project. `findProjectRoot()` walks up from `process.cwd()` looking for this exact filename. It also default-exports the daemon definition: schema, materializer attachments, sync setup, all inline. Marker and definition collapse into one file because there is one workspace per project.
+
+`<project>/.epicenter/` is *project-local runtime cache*. The Yjs persistence file, the SQLite materializer mirror, the WAL sidecars. Gitignored. Regenerable. Analogous to `.next/`, `.svelte-kit/`, `.turbo/` for other tools.
+
+`~/.epicenter/` is *user-and-machine-scoped shared state*. Auth tokens (or a keychain fallback pointer), local device identity, settings shared across Epicenter apps on this machine, logs, schema version stamp. Same absolute path on macOS, Linux, and Windows: `${homedir()}/.epicenter/`. One rule.
+
+### 2.2 What this changes from the previous draft and from current code
+
+```
+Concept                       Previous draft               This spec
+-------                       --------------               ---------
+Project marker                epicenter.config.ts          epicenter.config.ts
+                              (just a registry)            (registry AND workspace definition)
+
+Workspaces per project        many                         one
+                              (under workspaces/<r>/)      (project = workspace)
+
+Per-workspace definition      workspaces/<r>/workspace.ts  inline in epicenter.config.ts
+
+Source of truth in git        workspaces/<r>/yjs.db        committed markdown (./<tableName>/*.md)
+
+Local runtime cache           workspaces/<r>/sqlite.db     .epicenter/sqlite.db
+                              workspaces/<r>/yjs.db        .epicenter/yjs.db (NOT committed)
+                              workspaces/<r>/md/           (markdown lives at project root)
+
+Multi-workspace               daemon.routes registry       monorepo: sibling projects
+
+Daemon route concept          required                     vestigial (one workspace = no route prefix)
+```
+
+The deepest shift is the source-of-truth inversion. Today, yjs.db is canonical and markdown is derived. This spec makes markdown canonical and yjs.db a regenerable runtime cache. See §7 for the architectural consequences.
+
+## 3. `~/.epicenter/` (user-level shared state)
+
+### 3.1 Path resolution
+
+```ts
+// packages/constants/src/platform-paths.ts
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const root = process.env.EPICENTER_HOME ?? join(homedir(), '.epicenter');
+
+export const platformPaths = {
+  root,
+  authDir:     join(root, 'auth'),
+  identityDir: join(root, 'identity'),
+  logsDir:     join(root, 'logs'),
+  cacheDir:    join(root, 'cache'),
+  settingsFile: join(root, 'settings.json'),
+  versionFile: join(root, 'version.json'),
+} as const;
+```
+
+```rust
+// Tauri Rust counterpart
+pub fn root() -> PathBuf {
+    std::env::var("EPICENTER_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| dirs::home_dir().expect("home dir").join(".epicenter"))
+}
+```
+
+Identical absolute paths because the formula is `home_dir() + ".epicenter"`. No platform branching. `EPICENTER_HOME` overrides for CI and tests.
+
+### 3.2 Tree
+
+```
+~/.epicenter/
+├── version.json              ← { "schemaVersion": 1 }; gate for forward compat
+├── settings.json             ← cross-app user prefs (theme, etc.); not auth
+├── auth/
+│   └── <host>.json           ← fallback when OS keychain is unavailable
+│                               mode 0600, atomic rename writes
+├── identity/
+│   └── local-identity.json   ← device key material (per-machine, not per-app)
+├── logs/
+│   └── <projectHash>/        ← dirHash(projectDir) for namespacing
+│       └── daemon.log
+└── cache/                    ← free-form: download caches, model weights, etc.
+```
+
+`<projectHash>` is the existing 64-bit SHA256 prefix from `packages/workspace/src/daemon/paths.ts`, already used to key daemon socket/meta/lease files in `$XDG_RUNTIME_DIR/epicenter/`. Logs follow the same scheme for symmetry.
+
+### 3.3 Secrets policy
+
+Auth tokens prefer OS keychain when available:
+
+```
+macOS    Keychain.app via tauri-plugin-stronghold (desktop) or `keyring` crate (CLI)
+Windows  Credential Manager via the same crate
+Linux    libsecret if available; file fallback otherwise
+```
+
+`~/.epicenter/auth/<host>.json` is the file fallback (mode 0600 on Unix, atomic rename writes, host name in filename). Separate workstream from this spec; referenced for completeness.
+
+### 3.4 Schema versioning
+
+```json
+{
+  "schemaVersion": 1,
+  "writers": [
+    { "process": "cli", "version": "0.4.0", "lastSeen": "2026-05-22T22:00:00Z" }
+  ]
+}
+```
+
+Every Epicenter process reads `version.json` on startup. If `schemaVersion > knownVersion`, the process refuses to write and prints a clear "your CLI is older than this directory" message.
+
+## 4. `epicenter.config.ts` (the marker and the definition)
+
+### 4.1 The contract
+
+- Exact filename: `epicenter.config.ts`. Resolved by `PROJECT_CONFIG_FILENAME` in `packages/workspace/src/config/define-config.ts`.
+- Default-exports a `defineWorkspace({...})` (or equivalent) call that returns a `DaemonWorkspaceDefinition`.
+- Lives at the project root.
+- It is the only file that makes a directory an Epicenter project.
+- Defines the schema, attaches materializers, and configures sync. All inline. No separate config + workspace files.
+
+### 4.2 Shape
+
+The file composes a daemon. The composition produces (a) a workspace's schema, (b) materializer attachments with explicit paths, (c) sync infrastructure setup.
+
+```ts
+// epicenter.config.ts (canonical shape)
+import { defineWorkspace } from '@epicenter/workspace';
+import {
+  attachDaemonInfrastructure,
+  openWriterSqlite,
+} from '@epicenter/workspace/node';
+import { attachSqliteMaterializer } from '@epicenter/workspace/document/materializer/sqlite';
+import {
+  attachMarkdownMaterializer,
+  slugFilename,
+} from '@epicenter/workspace/document/materializer/markdown';
+import { attachTables, defineTable } from '@epicenter/workspace';
+import { type } from 'arktype';
+import * as Y from 'yjs';
+import { createLogger } from 'wellcrafted/logger';
+
+const WORKSPACE_GUID = 'epicenter.fuji';
+
+const Entry = defineTable(type({
+  id: 'string',
+  title: 'string',
+  body: 'string',
+}));
+
+export default defineWorkspace({
+  guid: WORKSPACE_GUID,
+
+  async open({ projectDir, openWebSocket, installationId }) {
+    const ydoc = new Y.Doc({ guid: WORKSPACE_GUID });
+    const tables = attachTables(ydoc, { entries: Entry });
+
+    const infra = attachDaemonInfrastructure(ydoc, {
+      projectDir,
+      openWebSocket,
+      installationId,
+      actions: { /* queries, mutations */ },
+    });
+
+    // Materializer paths are explicit and relative to projectDir.
+    // The developer chooses where outputs land.
+    const sqliteDb = openWriterSqlite({
+      filePath: join(projectDir, '.epicenter', 'sqlite.db'),
+      log: createLogger('sqlite'),
+    });
+    ydoc.once('destroy', () => sqliteDb.close());
+
+    attachSqliteMaterializer(ydoc, { db: sqliteDb }).table(tables.entries);
+
+    // The markdown materializer appends `table.name` (or a per-table `dir`
+    // override) to its base `dir`. Passing `dir: projectDir` produces
+    // `<projectDir>/entries/<slug>.md` for the `entries` table.
+    attachMarkdownMaterializer(ydoc, {
+      dir: projectDir,
+    }).table(tables.entries, { filename: slugFilename('title') });
+
+    return infra;
+  },
+});
+```
+
+Three things to notice:
+
+1. **No route concept at the disk layer.** One workspace per project; the daemon serves one set of RPCs; no `route.<name>` prefix needed in path computation. (The wire-protocol may keep a route name for compatibility; that's a separate concern.)
+2. **Materializer paths are explicit.** `dir: join(projectDir, 'entries')` says where the markdown goes. There is no implicit "table name becomes directory name" magic; the developer writes it. The convention is just what the example does.
+3. **Yjs.db lives under `.epicenter/`.** That's the developer's choice in the `openWriterSqlite` call. Convention: hidden runtime state under `.epicenter/`.
+
+### 4.3 Project-side helpers
+
+To avoid every project repeating `join(projectDir, '.epicenter', 'sqlite.db')`, the workspace package exposes two path helpers:
+
+```ts
+// packages/workspace/src/document/project-paths.ts
+import { join } from 'node:path';
+
+const HIDDEN_DIR = '.epicenter';
+
+export function epicenterCacheDir(projectDir: string): string {
+  return join(projectDir, HIDDEN_DIR);
+}
+
+export function yjsPath(projectDir: string): string {
+  return join(epicenterCacheDir(projectDir), 'yjs.db');
+}
+
+export function sqlitePath(projectDir: string): string {
+  return join(epicenterCacheDir(projectDir), 'sqlite.db');
+}
+```
+
+There is no `tableMarkdownDir` helper. The markdown materializer's `dir` is its *base*, and the table name is auto-appended (or overridable per-table via `.table(t, { dir: 'custom' })`). To put tables at the project root, pass `projectDir` directly:
+
+```ts
+import { sqlitePath } from '@epicenter/workspace/node';
+
+// ...
+const sqliteDb = openWriterSqlite({
+  filePath: sqlitePath(projectDir),
+  log: createLogger('sqlite'),
+});
+
+// Table `entries` lands at <projectDir>/entries/<slug>.md (table name appended).
+attachMarkdownMaterializer(ydoc, { dir: projectDir })
+  .table(tables.entries, { filename: slugFilename('title') });
+
+// Or to nest under data/: <projectDir>/data/entries/<slug>.md
+attachMarkdownMaterializer(ydoc, { dir: join(projectDir, 'data') })
+  .table(tables.entries, { filename: slugFilename('title') });
+
+// Or to put one table at a non-conventional path:
+attachMarkdownMaterializer(ydoc, { dir: projectDir })
+  .table(tables.entries, { dir: 'notes', filename: slugFilename('title') });
+// → <projectDir>/notes/<slug>.md
+```
+
+Helpers exist for the paths that always look the same (`.epicenter/yjs.db`, `.epicenter/sqlite.db`). Markdown paths are left as direct `dir:` arguments because the developer's intent (root vs nested vs per-table override) is a choice, not a convention.
+
+### 4.4 No more `daemon.routes` registry
+
+Today `defineConfig({ daemon: { routes: { fuji } } })` registers many routes under one project. With one workspace per project, the registry has nothing to register. `defineWorkspace({...})` returns the workspace definition directly.
+
+The existing `defineConfig` API is renamed to `defineWorkspace` to match the new semantics. Backwards compatibility is documented in §11.
+
+## 5. Project layout (one workspace, flat)
+
+### 5.1 Canonical tree
+
+```
+<project>/
+├── package.json                         ← bun init writes this
+├── tsconfig.json                        ← bun init writes this
+├── README.md                            ← bun init writes this
+├── epicenter.config.ts                  ← REQUIRED. Marker + definition.
+├── .gitignore                           ← Epicenter-managed; one rule (`.epicenter/`)
+├── entries/                             ← table data as markdown (committable)
+│   ├── welcome.md
+│   └── hello-fuji.md
+├── (other table directories)/           ← if the workspace has multiple tables
+└── .epicenter/                          ← runtime cache; gitignored
+    ├── yjs.db                           ← Yjs persistence (regenerable)
+    ├── yjs.db-wal
+    ├── yjs.db-shm
+    ├── sqlite.db                        ← SQL materializer (regenerable)
+    ├── sqlite.db-wal
+    └── sqlite.db-shm
+```
+
+### 5.2 What's at the project root
+
+Everything visible at the project root is either user code (`package.json`, `tsconfig.json`, source files), Epicenter's marker (`epicenter.config.ts`), or the workspace's committed data (`entries/`, `tasks/`, etc.).
+
+The hidden `.epicenter/` directory holds everything regenerable. It is created lazily by the daemon on first run.
+
+### 5.3 What's a "table directory"
+
+A table directory is the markdown materializer's output for one table. Its path is:
+
+```
+<materializer.dir>/<table.name>/<filename>.md
+```
+
+where:
+- `materializer.dir` is the base argument passed to `attachMarkdownMaterializer({ dir })`.
+- `table.name` is the table's name, auto-appended by the materializer. Overridable per-table via `.table(t, { dir: 'custom' })`.
+- `filename` comes from the per-table `filename` strategy (default: slug from `id`; commonly `slugFilename('title')`).
+
+Default convention: `dir: projectDir`, no per-table override. Files land at `<projectDir>/<table.name>/<slug>.md`. For the `entries` table, that's `<projectDir>/entries/<slug>.md`.
+
+For workspaces with multiple tables:
+
+```
+<project>/
+├── epicenter.config.ts
+├── entries/                     ← table 1
+│   ├── welcome.md
+│   └── hello-fuji.md
+├── tags/                        ← table 2
+│   └── work.md
+├── projects/                    ← table 3
+│   ├── alpha.md
+│   └── beta.md
+└── .epicenter/
+```
+
+Each table = one top-level directory. If a table name collides with a directory the developer needs for other purposes, they pick a different table name or pass a custom `dir` to the materializer (e.g., `./data/entries`).
+
+### 5.4 Collision handling
+
+Table names collide with directories like `src/`, `tests/`, `docs/`, `node_modules/` in principle. In practice this is a developer choice: they name their tables, and they avoid names that collide. Sensible table names (`entries`, `notes`, `tasks`, `journal`, `quotes`) don't collide with typical project structure.
+
+For projects that want explicit isolation:
+
+```
+<project>/
+├── epicenter.config.ts
+├── data/                        ← chosen explicit prefix
+│   ├── entries/
+│   └── tags/
+└── .epicenter/
+```
+
+Achieved by passing `dir: join(projectDir, 'data')` to the materializer. Both tables still get their `<table.name>` subdirectory appended. The spec does not enforce nesting; it enables it.
+
+## 6. The `.gitignore` standard
+
+### 6.1 Location and content
+
+`<project>/.gitignore`. Written by `epicenter init`. Augments whatever the developer already has (does not overwrite).
+
+```gitignore
+# Epicenter: all durable runtime state and materializer caches.
+# Regenerable from committed markdown in table directories.
+.epicenter/
+```
+
+That's it. One rule. The hidden directory holds everything Epicenter wants gitignored.
+
+### 6.2 Why this works
+
+- `.epicenter/` contains `yjs.db`, `sqlite.db`, and their WAL sidecars. All hidden, all ignored.
+- Markdown lives at the project root (`entries/`, `tasks/`, etc.). Visible. Committed by default because it's not ignored.
+- The developer can choose to ignore specific table directories if they don't want them in git:
+
+```gitignore
+.epicenter/
+
+# Optional: don't commit markdown for a private table
+private-notes/
+```
+
+- No `*` glob patterns required. Direct paths only.
+
+### 6.3 What `epicenter init` does to the gitignore
+
+If `<project>/.gitignore` doesn't exist: create with just the Epicenter rule.
+
+If it exists: append the Epicenter rule if not already present, with a comment marking it as Epicenter-managed:
+
+```gitignore
+# (existing user content unchanged)
+
+# Epicenter
+.epicenter/
+```
+
+Idempotent: re-running `epicenter init` after init does not duplicate the rule.
+
+### 6.4 Optional commit of materializer caches
+
+If a developer wants to commit `sqlite.db` (e.g., to ship a precomputed query database with the repo), they comment out `.epicenter/` and add specific paths:
+
+```gitignore
+# Epicenter: keep sqlite, ignore yjs and WAL
+.epicenter/yjs.db
+.epicenter/yjs.db-wal
+.epicenter/yjs.db-shm
+.epicenter/sqlite.db-wal
+.epicenter/sqlite.db-shm
+```
+
+This is an explicit choice; the default is gitignore everything in `.epicenter/`.
+
+## 7. Markdown as the source of truth
+
+### 7.1 The architectural shift
+
+```
+Today:                              This spec:
+yjs.db = source of truth            ./<tableName>/*.md = source of truth (in git)
+md/ = derived from yjs.db           .epicenter/yjs.db = derived from markdown
+                                    (runtime cache; rebuilt on demand)
+```
+
+Git becomes the merge surface. Two peers can edit `entries/welcome.md` independently, push, merge, and git's line-based merge does the work. No binary conflicts on yjs.db because yjs.db isn't in git.
+
+### 7.2 What this requires (dependency on future work)
+
+The current implementation writes one-way: `Y.Doc → markdown`. The reverse direction (`markdown → Y.Doc`) does not exist.
+
+To make markdown canonical, three pieces of plumbing are needed:
+
+1. **Hydration**: on daemon start, read markdown files, parse front-matter + body, populate the Y.Doc. If `.epicenter/yjs.db` exists and is consistent with the markdown, skip the rehydration; otherwise rebuild.
+2. **Reverse watcher**: when a markdown file changes outside the daemon (via editor, git pull, etc.), the daemon picks it up and applies a Y.Doc update.
+3. **Round-trip fidelity**: serialization must round-trip without loss. Markdown front-matter holds non-body fields; the body is the markdown. Yjs CRDT properties (character-level merging) are sacrificed at the markdown layer.
+
+These three are out of scope for this layout spec but assumed as the architectural target. The layout works without them (yjs.db is just gitignored runtime state), but the full architectural payoff requires them.
+
+### 7.3 Single-peer vs multi-peer behavior
+
+```
+Single peer:
+  - One yjs.db in .epicenter/, one set of markdown files.
+  - Edit via daemon → Y.Doc → markdown.
+  - Edit markdown directly → daemon picks up via reverse watcher → Y.Doc.
+  - Either path produces the same state.
+
+Multi-peer (real-time):
+  - Sync server replicates Y.Doc updates across peers.
+  - Each peer materializes markdown locally.
+  - No git involvement.
+
+Multi-peer (async, via git):
+  - Each peer edits markdown, commits, pushes.
+  - Pulling reapplies markdown changes locally.
+  - Daemon's reverse watcher rehydrates Y.Doc from the new markdown.
+  - Conflicts: git's line-based merge resolves them at the markdown layer.
+```
+
+### 7.4 Why yjs.db is no longer committed
+
+```
+Reasons:
+  - Binary; git can't auto-merge.
+  - Append-only growing log; bloats the repo.
+  - Regenerable from markdown (after §7.2 lands).
+  - The sync server is the canonical multi-peer truth; git is for content, not state.
+
+Consequence: workspaces ship via markdown. A clone gets entries/*.md.
+The daemon rebuilds .epicenter/yjs.db on first run.
+```
+
+## 8. WAL safety
+
+Less load-bearing now that yjs.db isn't committed. Still relevant for two cases:
+
+1. **Backup**: if a user backs up `.epicenter/yjs.db` (e.g., via Time Machine, rsync), the backup should be consistent. Stop the daemon or run `epicenter checkpoint` before backup.
+2. **Manual inspection**: opening `.epicenter/yjs.db` with `sqlite3` while the daemon is running may show stale state. Stop the daemon first.
+
+`epicenter checkpoint` (new CLI subcommand, separate work) runs `PRAGMA wal_checkpoint(TRUNCATE)` on `yjs.db` and `sqlite.db`. Optional pre-backup hook recipe documented but not auto-installed.
+
+## 9. CLI resolution: walk up, then scan one level down
+
+```
+function findEpicenterProjects(cwd: string): ProjectDir[] {
+  // Step 1: walk UP looking for epicenter.config.ts.
+  let current = cwd;
+  while (current !== dirname(current)) {
+    if (existsSync(join(current, 'epicenter.config.ts'))) {
+      return [current];   // single workspace project
+    }
+    current = dirname(current);
+  }
+
+  // Step 2: not found above. Scan immediate children of cwd.
+  const children = readdirSync(cwd, { withFileTypes: true })
+    .filter(d => d.isDirectory())
+    .filter(d => !d.name.startsWith('.') && d.name !== 'node_modules')
+    .filter(d => existsSync(join(cwd, d.name, 'epicenter.config.ts')))
+    .map(d => join(cwd, d.name) as ProjectDir);
+
+  if (children.length > 0) {
+    return children;   // monorepo with N workspaces
+  }
+
+  throw new Error('Not an Epicenter project.');
+}
+```
+
+Properties:
+
+- **Up takes priority.** If you're inside a project, that project wins, even if you're in a subdir that happens to look like a sibling.
+- **Down is one level only.** Scans `cwd/*/epicenter.config.ts`. Does not recurse. Avoids `node_modules/.../epicenter.config.ts` surprises.
+- **Hidden directories and `node_modules` are skipped.** Standard ignored directories.
+
+### 9.1 Examples
+
+```
+Layout:                                Run from:                  Resolves to:
+my-project/                            my-project/                my-project (single)
+├── epicenter.config.ts                my-project/src/            my-project (walks up)
+└── src/
+
+my-monorepo/                           my-monorepo/               [notes, tasks] (two)
+├── notes/epicenter.config.ts          my-monorepo/notes/         my-monorepo/notes (walks up)
+└── tasks/epicenter.config.ts          my-monorepo/tasks/         my-monorepo/tasks (walks up)
+                                       my-monorepo/notes/src/     my-monorepo/notes (walks up)
+
+random/folder/                         random/folder/             error (no project found)
+```
+
+### 9.2 Monorepo daemon orchestration
+
+When `findEpicenterProjects(cwd)` returns multiple projects (monorepo case), the daemon-up command starts one daemon per project. Each daemon is independent: own socket, own metadata, own lease. No cross-project coordination.
+
+A future spec can define an "orchestrator" mode (one process serves all projects in a monorepo via routed RPC), but the canonical layout treats them as independent daemons.
+
+## 10. `epicenter init` scaffolding
+
+### 10.1 Invocation
+
+```
+$ epicenter init
+```
+
+### 10.2 Behavior
+
+Reads cwd. If `epicenter.config.ts` already exists, prints "already initialized" and exits.
+
+Otherwise:
+
+1. Writes `epicenter.config.ts` with a minimal default-export `defineWorkspace({...})` call.
+2. Writes or appends `.gitignore` with `.epicenter/` rule (idempotent).
+3. Does NOT create `.epicenter/` (lazy on first daemon run).
+4. Does NOT create any table directories (lazy on first materializer write).
+5. Does NOT write `package.json` or `tsconfig.json` (those are `bun init`'s job).
+6. Prints next steps:
+
+```
+✓ Created epicenter.config.ts
+✓ Updated .gitignore
+
+Next steps:
+  1. bun add @epicenter/workspace
+  2. Edit epicenter.config.ts to define your workspace schema.
+  3. Run `epicenter daemon up` to start.
+```
+
+### 10.3 The default `epicenter.config.ts`
+
+```ts
+import { defineWorkspace } from '@epicenter/workspace';
+import * as Y from 'yjs';
+
+export default defineWorkspace({
+  guid: 'epicenter.default',
+  async open({ projectDir, openWebSocket, installationId }) {
+    const ydoc = new Y.Doc({ guid: 'epicenter.default' });
+    // TODO: define your schema, attach materializers, return infrastructure.
+    throw new Error('epicenter.config.ts: not yet configured.');
+  },
+});
+```
+
+Throws on first daemon run with a clear message. The developer replaces the throw with their schema and materializer attachments. Minimum-viable scaffolding without pretending to be runnable.
+
+## 11. Migration
+
+### 11.1 What needs to move
+
+```
+Today's layout                          New layout
+--------------                          ----------
+<proj>/.epicenter/yjs/<id>.db           <proj>/.epicenter/yjs.db
+<proj>/.epicenter/sqlite/<id>.db        <proj>/.epicenter/sqlite.db
+<proj>/.epicenter/md/<id>/              <proj>/<tableName>/*.md (writeback target)
+<proj>/.epicenter/log/                  ~/.epicenter/logs/<projectHash>/
+<proj>/.epicenter/persistence/<id>.db   <proj>/.epicenter/yjs.db (rename)
+workspaces -> apps symlink at root      (deleted)
+
+API changes
+-----------
+defineConfig({ daemon: { routes: { ... } } })  → defineWorkspace({...}) (one workspace)
+yjsPath(projectDir, workspaceId)               → yjsPath(projectDir)
+sqlitePath(projectDir, workspaceId)            → sqlitePath(projectDir)
+markdownPath(projectDir, workspaceId)          → tableMarkdownDir(projectDir, tableName)
+```
+
+### 11.2 Migration command
+
+`epicenter migrate` (one-shot, idempotent). Steps:
+
+1. Detect: read `<proj>/.epicenter/{yjs,sqlite,persistence}/*.db` if present.
+2. For each existing yjs file (in `.epicenter/yjs/` or `.epicenter/persistence/`):
+   - There must be exactly one workspace's data. If multiple, prompt the developer to pick which is "the" workspace (the rest become orphans to delete manually).
+   - Move `.epicenter/yjs/<id>.db` to `.epicenter/yjs.db`. Similarly for sqlite.
+3. Materialize markdown from the migrated yjs.db into `<proj>/<tableName>/` for each table. The new markdown becomes the committed source of truth.
+4. Move daemon logs to `~/.epicenter/logs/<projectHash>/`.
+5. Delete now-empty `.epicenter/yjs/`, `.epicenter/sqlite/`, `.epicenter/md/`, `.epicenter/persistence/`, `.epicenter/log/`.
+6. Delete `workspaces -> apps` symlink if present.
+7. Update `epicenter.config.ts`: convert `defineConfig({ daemon: { routes: { fuji } } })` to `export default fuji` (re-exporting the single workspace definition that was registered).
+8. Write `.gitignore` with `.epicenter/` rule if absent.
+9. Write `~/.epicenter/version.json` with `schemaVersion: 1`.
+10. Report what moved.
+
+### 11.3 Multi-workspace projects (the monorepo migration)
+
+If today's `epicenter.config.ts` registers multiple routes, the developer chooses between:
+
+- **Stay multi-route**: keep the old shape with a compatibility flag (deprecated; removed in next major).
+- **Promote to monorepo**: each route becomes a subdirectory with its own `epicenter.config.ts`, and the old root config becomes either empty or a workspace orchestrator.
+
+The migrate command surfaces this as a prompt with the two options.
+
+### 11.4 Backwards compatibility window
+
+One release with warnings; next release removes legacy support. Daemons on the old layout print:
+
+```
+Legacy layout detected (workspaces/<r>/yjs.db). Run `epicenter migrate` to upgrade.
+Continuing with legacy layout for this run.
+```
+
+## 12. The canonical example: `examples/fuji/`
+
+### 12.1 Location
+
+`examples/fuji/`. Demonstrates the layout using fuji's existing workspace definition.
+
+### 12.2 Tree
+
+```
+examples/fuji/
+├── package.json                       ← bun + @epicenter/workspace, @epicenter/fuji
+├── tsconfig.json                      ← extends repo base
+├── README.md                          ← walkthrough
+├── epicenter.config.ts                ← imports openFujiWorkspace, attaches materializers
+├── .gitignore                         ← just `.epicenter/`
+└── entries/                           ← seed markdown files; committed
+    ├── welcome.md
+    └── hello-fuji.md
+```
+
+`.epicenter/` is absent in the committed tree. It appears on first daemon run and stays gitignored thereafter.
+
+### 12.3 The `epicenter.config.ts`
+
+```ts
+import { defineWorkspace } from '@epicenter/workspace';
+import { openFujiWorkspace } from '@epicenter/fuji';
+import {
+  attachDaemonInfrastructure,
+  openWriterSqlite,
+  sqlitePath,
+} from '@epicenter/workspace/node';
+import { attachSqliteMaterializer } from '@epicenter/workspace/document/materializer/sqlite';
+import {
+  attachMarkdownMaterializer,
+  slugFilename,
+} from '@epicenter/workspace/document/materializer/markdown';
+import { createLogger } from 'wellcrafted/logger';
+
+export default defineWorkspace({
+  guid: 'epicenter.fuji',
+  async open({ projectDir, clientId, installationId, attachEncryption, openWebSocket }) {
+    const workspace = openFujiWorkspace(attachEncryption, { clientId });
+
+    const infra = attachDaemonInfrastructure(workspace.ydoc, {
+      projectDir,
+      openWebSocket,
+      installationId,
+      actions: workspace.actions,
+    });
+
+    const db = openWriterSqlite({
+      filePath: sqlitePath(projectDir),
+      log: createLogger('sqlite'),
+    });
+    workspace.ydoc.once('destroy', () => db.close());
+
+    attachSqliteMaterializer(workspace.ydoc, { db }).table(workspace.tables.entries);
+
+    // `dir: projectDir` + auto-appended table name → <projectDir>/entries/<slug>.md
+    attachMarkdownMaterializer(workspace.ydoc, {
+      dir: projectDir,
+    }).table(workspace.tables.entries, { filename: slugFilename('title') });
+
+    return infra;
+  },
+});
+```
+
+### 12.4 The seed markdown
+
+```markdown
+<!-- examples/fuji/entries/welcome.md -->
+---
+id: 01HM0000000000000000000000
+---
+# Welcome to Fuji
+
+This is a sample entry in a Fuji workspace. Edit this file directly, or use
+the daemon to drive changes. Either way, both representations stay in sync.
+```
+
+```markdown
+<!-- examples/fuji/entries/hello-fuji.md -->
+---
+id: 01HM0000000000000000000001
+---
+# Hello Fuji
+
+A second entry to show that the markdown materializer writes one file per row.
+The `id` in the front-matter is the workspace's stable identifier; the
+filename is derived from the title for human friendliness.
+```
+
+### 12.5 The README walkthrough
+
+```markdown
+# examples/fuji
+
+A canonical Epicenter project. One workspace, one `epicenter.config.ts`,
+table data as markdown at the project root.
+
+## Run it
+
+    bun install
+    epicenter daemon up
+
+## Layout
+
+    epicenter.config.ts   ← the marker; composes the workspace
+    entries/              ← table data (committed; this is the source of truth)
+    .epicenter/           ← runtime cache (gitignored; regenerable)
+        yjs.db
+        sqlite.db
+
+## Edit a note
+
+Edit `entries/welcome.md` in any editor. The daemon picks up the change
+and applies it to the Y.Doc; the SQLite materializer reflects it; peers
+on the sync receive the update.
+
+You can also drive edits via the daemon's actions (queries and mutations
+defined in `epicenter.config.ts`).
+```
+
+### 12.6 CI assertions
+
+```
+Assertions (run after `epicenter daemon up` in CI):
+  - .epicenter/yjs.db exists and is non-empty
+  - .epicenter/sqlite.db exists
+  - entries/welcome.md exists (was committed)
+  - entries/hello-fuji.md exists (was committed)
+  - .epicenter/ is gitignored (no tracked files inside)
+  - .gitignore contains the `.epicenter/` rule
+```
+
+If the spec changes, the example and its assertions change with it.
+
+## 13. Edge cases
+
+### 13.1 Yjs.db absent on first run
+
+`epicenter daemon up` finds no `.epicenter/yjs.db`. It reads markdown from configured table directories, hydrates the Y.Doc, then writes the initial yjs.db. Subsequent runs use the existing yjs.db; the hydration step is skipped unless markdown is detected as newer.
+
+(This depends on the markdown → Y.Doc hydration work described in §7.2.)
+
+### 13.2 Yjs.db present but markdown missing
+
+User clones a repo with `.epicenter/` accidentally committed. Markdown directories are missing. Daemon materializes from yjs.db on first run, writing the markdown files. Source of truth is whatever the developer commits next.
+
+### 13.3 Conflicting markdown front-matter
+
+Two peers edit the same row's front-matter (e.g., both change `status`). Git's line-based merge produces a conflict marker. User resolves manually, commits. The daemon then applies the resolved version to the Y.Doc.
+
+For body conflicts: git resolves at line level. Yjs's character-level CRDT properties are not preserved through this path. Trade-off: cleaner git workflow at the cost of finer-grained merge resolution.
+
+### 13.4 Sync server and git both in use
+
+Real-time collaboration via sync server. Async collaboration via git. The two are not synchronized: a peer's local Y.Doc may diverge from `entries/*.md` between materializer flushes. The reverse-watcher applies external markdown changes when detected. Possible state: server-canonical Y.Doc, locally-modified markdown, both eventually consistent via the daemon.
+
+This is the "git as async sync" model. It works because markdown is the persistence shared by both layers.
+
+### 13.5 Table renames
+
+Renaming a table means renaming its markdown directory: `mv entries/ notes/`. Update the `dir:` argument in `epicenter.config.ts`. The daemon's markdown materializer now writes to `notes/`. Y.Doc table key changes accordingly. Migration of existing rows is the developer's responsibility (it's a schema change, not a layout question).
+
+### 13.6 Multiple daemons writing the same project
+
+The lease sqlite at `$XDG_RUNTIME_DIR/epicenter/<projectHash>.lease.sqlite` ensures only one daemon writes a given project's yjs.db at a time. Second daemon refuses to start. Behavior unchanged from current implementation.
+
+## 14. Out of scope
+
+- The `defineTable`, `attachTables`, `defineMutation`, `defineQuery` APIs internally.
+- OS keychain integration. The auth file path is fixed in §3.3; the keychain abstraction is its own spec.
+- Markdown → Y.Doc hydration. Assumed as the architectural target in §7.2; the actual implementation is separate work.
+- Tauri capabilities cleanup (`apps/whispering/src-tauri/capabilities/default.json` has `"path": "**"` and shell `"validator": ".*"`; both are independent security work).
+- The `epicenter compact` command for large yjs.db files.
+- Sync protocol versioning over the wire.
+
+## 15. Open questions (closed where possible)
+
+### 15.1 Should `epicenter.config.ts` ever do more than define one workspace?
+
+No, for now. The file's purpose is to define exactly one workspace's schema, daemon, and materializer composition. Cross-project settings (auth target, sync server URL) live in `~/.epicenter/settings.json` or env vars. If a need for project-level non-workspace config emerges, revisit.
+
+### 15.2 What if a project legitimately needs multiple workspaces in one daemon process?
+
+Not supported in the canonical layout. The answer is a monorepo with one project per workspace, each with its own daemon. If a process-sharing orchestrator becomes necessary, it's a new tool (an "epicenter orchestrator" config file at the monorepo root), not a complication of the basic project layout.
+
+### 15.3 Should table directories be visible or hidden?
+
+Visible. Markdown is human-editable content. Hiding it under `.epicenter/md/` (the old layout) understated its role. Promoting it to project root and committing it makes the data and the code coexist at the same level.
+
+### 15.4 Should the migration tool auto-pick the "main" workspace in multi-route projects?
+
+No. Prompt the developer; let them choose. Auto-picking risks data loss if the heuristic gets it wrong.
+
+### 15.5 Does the spec affect existing apps (whispering, fuji, opensidian, etc.)?
+
+Yes for their `apps/*/daemon.ts` shape and for how the root `epicenter.config.ts` registers them. The migration covers this. Existing first-party apps move to the new shape one at a time.
+
+## 16. Summary, in one tree
+
+```
+<project>/                                  Epicenter project
+├── package.json                            your file (bun init writes this)
+├── tsconfig.json                           your file
+├── README.md                               your file
+├── epicenter.config.ts                     REQUIRED. Marker + workspace definition.
+│                                           Default-exports defineWorkspace({...}).
+├── .gitignore                              Epicenter-managed: `.epicenter/`
+├── <tableName>/                            convention: one dir per table at root,
+│   └── *.md                                visible, COMMITTED. Materializer writes here.
+└── .epicenter/                             runtime cache, GITIGNORED.
+    ├── yjs.db                              Yjs persistence (regenerable from markdown).
+    ├── yjs.db-wal, .db-shm                 WAL sidecars.
+    ├── sqlite.db                           SQL materializer (regenerable).
+    ├── sqlite.db-wal, .db-shm              WAL sidecars.
+    └── (other materializer outputs over time)
+
+~/.epicenter/                               user-and-machine shared state
+├── version.json                            schema version stamp.
+├── settings.json                           cross-app user prefs.
+├── auth/<host>.json                        fallback when OS keychain unavailable.
+├── identity/local-identity.json            device key material.
+├── logs/<projectHash>/daemon.log           daemon logs (per project).
+└── cache/                                  free-form caches.
+
+$XDG_RUNTIME_DIR/epicenter/                 volatile (unchanged from today)
+├── <projectHash>.sock                      daemon IPC.
+├── <projectHash>.meta.json                 daemon metadata.
+└── <projectHash>.lease.sqlite              single-writer lease.
+```
+
+Two reservations in the project (one file, one hidden dir). One reservation in user home. One canonical convention (table dirs at project root) that's developer-configurable.
+
+## 17. Implementation order (suggested)
+
+1. **Path resolver swap.** Create `packages/constants/src/platform-paths.ts`. Replace `epicenterEnv` usage with `platformPaths`. Drop env-paths dependency.
+2. **API rename.** `defineConfig` → `defineWorkspace`. Update existing consumers. Keep a deprecated alias for one release.
+3. **Project-side helpers.** Add `yjsPath(projectDir)`, `sqlitePath(projectDir)`, `tableMarkdownDir(projectDir, tableName)` to the workspace package.
+4. **`epicenter init` and `epicenter migrate`.** Implement per §10 and §11.
+5. **Examples/fuji.** Create the canonical example per §12. Wire CI assertions per §12.6.
+6. **Markdown → Y.Doc hydration.** The architectural prerequisite for §7. Substantial; separate workstream.
+7. **Reverse watcher.** Pick up external markdown edits and apply to Y.Doc. Also separate.
+8. **CLI walk-up + scan-down-one resolution.** Implement per §9.
+9. **Schema version stamp.** Add `~/.epicenter/version.json` write-on-startup and refuse-if-newer check.
+10. **Drop legacy layout support.** One release after `epicenter migrate` lands.
+
+Each item is independently shippable. Items 6 and 7 are the largest and gate the full architectural payoff; until they land, yjs.db is gitignored runtime state but not yet "regenerable from markdown."


### PR DESCRIPTION
Working in this codebase produced a layout that ran but was never written down: `env-paths('epicenter', { suffix: '' })` for CLI state, `.epicenter/{yjs,sqlite,md}/<workspaceId>.db` for project state, a `workspaces -> apps` symlink at the repo root, a top-level `epicenter.config.ts` registering many daemon routes, yjs.db as the committed source of truth. Each piece had its reason at the time. Together they read as accidental rather than designed. This branch writes down the layout we want, and the example shows it concretely.

The shape is three reservations:

```
<project>/
├── epicenter.config.ts        ← REQUIRED. Marker + workspace definition.
├── .gitignore                 ← Epicenter-managed: one rule, `.epicenter/`
├── <tableName>/               ← table data as markdown (COMMITTED)
│   └── *.md
└── .epicenter/                ← runtime cache (GITIGNORED)
    ├── yjs.db
    └── sqlite.db

~/.epicenter/                  ← user-and-machine shared state
├── auth/<host>.json           ← fallback when OS keychain unavailable
├── identity/local-identity.json
└── settings.json, logs/, cache/
```

Three deep shifts from what the code does today.

**One workspace per project.** The `daemon.routes` registry was always typed as "many" but every leaf project only ever had one. Replace `defineConfig({ daemon: { routes: { fuji } } })` with a `defineWorkspace({...})` direct default export. Multi-workspace becomes a monorepo with sibling project directories, each with its own `epicenter.config.ts`. The CLI walks up for the config file; if it doesn't find one, it scans one level down for sibling projects.

\`\`\`
single project:                          monorepo:
  my-project/                              my-monorepo/
  ├── epicenter.config.ts                  ├── notes/
  └── ...                                  │   └── epicenter.config.ts
                                           └── tasks/
                                               └── epicenter.config.ts
\`\`\`

**Markdown becomes the committed source of truth.** Today yjs.db is the committed binary; markdown is derived. The cost is unmergeable binary conflicts on multi-peer git workflows. Inverting it makes git the merge surface:

```
                            Before                            After
git tracks                  workspaces/<r>/yjs.db             <project>/<tableName>/*.md
shape                       binary, append-only growing log   line-based text, GitHub-rendered
multi-peer merging          unmergeable binary                standard line diff + front-matter
source of truth             yjs.db                            markdown
yjs.db role                 source                            local cache, regenerable
materializer direction      Y.Doc → markdown (one-way)        round-trip
```

The inversion depends on plumbing that doesn't exist yet: a markdown → Y.Doc hydration step plus a reverse watcher that picks up external markdown edits. The spec calls these out explicitly as the architectural target (§7.2), not as something this PR delivers. Until they land, yjs.db sits gitignored under `.epicenter/` as runtime cache and the seed markdown is documentary.

**`~/.epicenter/` literally, on every OS.** Earlier conversations explored sharing env-paths' output with Tauri's `dataDir()`, then sharing Tauri's `appDataDir()` with the CLI. Both routes diverged silently on Windows. The clean break: drop env-paths from the CLI, drop `dataDir()` for shared state on the Tauri side, both compute the same path from `homedir() + '.epicenter'`.

```
                          Before                                       After
macOS    (env-paths)      ~/Library/Application Support/epicenter      ~/.epicenter/
Linux    (env-paths)      ~/.local/share/epicenter                     ~/.epicenter/
Windows  CLI (env-paths)  %LOCALAPPDATA%\epicenter\Data                ~/.epicenter/
Windows  Tauri (dataDir)  %APPDATA%\<bundleId>                         ~/.epicenter/
                                                       ↑ divergent ↑
```

Single override env var (`EPICENTER_HOME`) replaces four per-resource variables. Follows the precedent of `~/.claude/`, `~/.codex/`, `~/.aws/`, `~/.docker/`, `~/.kube/`.

The `examples/fuji/` directory demonstrates all of this concretely. It composes `@epicenter/fuji`'s existing `openFujiWorkspace` against the new path conventions: SQLite under `.epicenter/sqlite.db`, markdown materializer rooted at `projectDir` so the table name auto-appends to `<projectDir>/entries/*.md`. Ships with two seed markdown files with the right front-matter shape, a one-rule `.gitignore`, and an `architecture.test.ts` that pins the committed tree to the spec.

\`\`\`
examples/fuji/
├── epicenter.config.ts       composes openFujiWorkspace, attaches materializers
├── entries/
│   ├── welcome.md            seed entry (committed)
│   └── hello-fuji.md         seed entry (committed)
├── .gitignore                .epicenter/ + node_modules/
├── architecture.test.ts      pins layout to spec
├── package.json              workspace deps
├── tsconfig.json             extends repo base
└── README.md                 walkthrough
\`\`\`

What's NOT in this PR. The spec's §17 lists ten implementation items; each is its own follow-up PR:

```
Near-term, each its own small PR:
  1.  Drop env-paths; add platformPaths resolver
  2.  defineConfig → defineWorkspace API rename
  3.  Project-side helpers: yjsPath(projectDir), sqlitePath(projectDir)
  4.  epicenter init + migrate commands
  5.  CLI walk-up + scan-down-one resolution

Larger workstreams:
  6.  Markdown → Y.Doc hydration  (§7.2; the architectural target)
  7.  Reverse watcher: external markdown edits → Y.Doc
  8.  OS keychain for auth tokens
  9.  Schema version stamp at ~/.epicenter/version.json
  10. Drop legacy layout support
```

This PR is the spec plus example; everything else stacks on the merged spec as its contract.

Net change: 2 commits, 9 files, +1234 lines (907 spec + 327 example/test).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782108508&installation_id=128463665&pr_number=1797&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1797&signature=0620cf46ac1f685f7c1af558586d041459b5dca62ba0421288251de462b7edfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->