### PR TITLE
feat(workspace): add defineWorkspace as the single-workspace shape

### DIFF
--- a/apps/api/scripts/dev.ts
+++ b/apps/api/scripts/dev.ts
@@ -21,9 +21,13 @@ const auth = await Bun.$`infisical --silent user get token --plain`
 
 if (auth.exitCode !== 0 || !auth.stdout.toString().trim()) {
 	console.error('Not logged into Infisical.');
-	console.error('Running `apps/api` requires Infisical access for dev secrets (API keys, auth secret).');
+	console.error(
+		'Running `apps/api` requires Infisical access for dev secrets (API keys, auth secret).',
+	);
 	console.error('Run `infisical login`, then rerun the same command.');
-	console.error('If you do not have Infisical access, see CONTRIBUTING.md for what you can work on without it.');
+	console.error(
+		'If you do not have Infisical access, see CONTRIBUTING.md for what you can work on without it.',
+	);
 	process.exit(1);
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -487,6 +487,21 @@
         "vite": "catalog:",
       },
     },
+    "examples/fuji": {
+      "name": "@examples/fuji",
+      "version": "0.0.1",
+      "dependencies": {
+        "@epicenter/cli": "workspace:*",
+        "@epicenter/fuji": "workspace:*",
+        "@epicenter/workspace": "workspace:*",
+        "wellcrafted": "catalog:",
+        "yjs": "catalog:",
+      },
+      "devDependencies": {
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "examples/notes-cross-peer": {
       "name": "@examples/notes-cross-peer",
       "version": "0.0.1",
@@ -1124,6 +1139,8 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@examples/fuji": ["@examples/fuji@workspace:examples/fuji"],
 
     "@examples/notes-cross-peer": ["@examples/notes-cross-peer@workspace:examples/notes-cross-peer"],
 

--- a/examples/fuji/architecture.test.ts
+++ b/examples/fuji/architecture.test.ts
@@ -8,9 +8,9 @@
  * `specs/20260522T220000-workspace-project-layout.md`.
  */
 
+import { describe, expect, test } from 'bun:test';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { describe, expect, test } from 'bun:test';
 
 const DIR = import.meta.dir;
 

--- a/examples/fuji/architecture.test.ts
+++ b/examples/fuji/architecture.test.ts
@@ -48,4 +48,15 @@ describe('examples/fuji follows the project layout spec', () => {
 		expect(src).not.toContain('markdownPath(');
 		expect(src).not.toContain('sqlitePath(');
 	});
+
+	test('epicenter.config.ts uses defineWorkspace (single-workspace shape)', () => {
+		const src = readFileSync(join(DIR, 'epicenter.config.ts'), 'utf-8');
+		// Single-workspace shape: defineWorkspace default-exported directly,
+		// not wrapped in defineConfig({ daemon: { routes: { ... } } }).
+		expect(src).toContain('defineWorkspace');
+		expect(src).toContain('export default defineWorkspace(');
+		expect(src).not.toContain('defineConfig(');
+		expect(src).not.toContain('daemon.routes');
+		expect(src).not.toContain('daemon: { routes');
+	});
 });

--- a/examples/fuji/epicenter.config.ts
+++ b/examples/fuji/epicenter.config.ts
@@ -8,13 +8,15 @@
  *     yjs.db                  Yjs persistence
  *     sqlite.db               SQL materializer
  *
- * This uses the current `defineConfig({ daemon: { routes: { ... } } })` API
- * with a single route. The spec's target API is `defineWorkspace({...})` as
- * the direct default export; that rename is a separate refactor.
+ * The default export is a single `defineWorkspace({...})` call. The loader
+ * wraps it as `{ daemon: { routes: { <basename>: ... } } }` internally,
+ * deriving the route name from this project directory's name. For the
+ * `examples/fuji` directory the route name is `fuji`, so CLI commands
+ * address it as `fuji.<action>` exactly as they did under the previous
+ * `defineConfig({ daemon: { routes: { fuji } } })` shape.
  */
 
-import { defineConfig } from '@epicenter/workspace';
-import { defineDaemonWorkspace } from '@epicenter/workspace/daemon';
+import { defineWorkspace } from '@epicenter/workspace';
 import {
 	attachMarkdownMaterializer,
 	slugFilename,
@@ -28,7 +30,7 @@ import { openFujiWorkspace } from '@epicenter/fuji';
 import { join } from 'node:path';
 import { createLogger } from 'wellcrafted/logger';
 
-const fuji = defineDaemonWorkspace({
+export default defineWorkspace({
 	async open({
 		projectDir,
 		route,
@@ -68,11 +70,5 @@ const fuji = defineDaemonWorkspace({
 		}).table(workspace.tables.entries, { filename: slugFilename('title') });
 
 		return infra;
-	},
-});
-
-export default defineConfig({
-	daemon: {
-		routes: { fuji },
 	},
 });

--- a/examples/fuji/epicenter.config.ts
+++ b/examples/fuji/epicenter.config.ts
@@ -16,6 +16,8 @@
  * `defineConfig({ daemon: { routes: { fuji } } })` shape.
  */
 
+import { join } from 'node:path';
+import { openFujiWorkspace } from '@epicenter/fuji';
 import { defineWorkspace } from '@epicenter/workspace';
 import {
 	attachMarkdownMaterializer,
@@ -26,8 +28,6 @@ import {
 	attachDaemonInfrastructure,
 	openWriterSqlite,
 } from '@epicenter/workspace/node';
-import { openFujiWorkspace } from '@epicenter/fuji';
-import { join } from 'node:path';
 import { createLogger } from 'wellcrafted/logger';
 
 export default defineWorkspace({

--- a/packages/workspace/src/config/define-config.test.ts
+++ b/packages/workspace/src/config/define-config.test.ts
@@ -1,9 +1,15 @@
-import { defineConfig, type EpicenterConfig } from './define-config.js';
+import type { DaemonWorkspaceDefinition } from '../daemon/define-daemon-workspace.js';
+import type { DaemonRuntime } from '../daemon/types.js';
+import {
+	defineConfig,
+	defineWorkspace,
+	type EpicenterConfig,
+} from './define-config.js';
 
-// `defineConfig` is `(config) => config`. The contract worth pinning is
-// type inference, asserted below via @ts-expect-error and the Equal
-// type-level test. The runtime identity behavior is JS-trivial and
-// covered indirectly by load-project-config.test.ts.
+// `defineConfig` and `defineWorkspace` are both `(x) => x`. The contract worth
+// pinning is type inference, asserted via @ts-expect-error and the Equal
+// type-level test. Runtime identity is JS-trivial and covered indirectly by
+// load-project-config.test.ts.
 
 type Expect<TValue extends true> = TValue;
 type Equal<TActual, TExpected> =
@@ -29,3 +35,22 @@ defineConfig({ daemon: { routes: [] } });
 
 // @ts-expect-error top-level routes are no longer accepted.
 defineConfig({ routes: [] });
+
+// `defineWorkspace` takes a `DaemonWorkspaceDefinition` directly and returns
+// it. The inferred type preserves the runtime generic; declaring the return
+// type of `open()` as `DaemonRuntime` pins TRuntime concretely so the Equal
+// check below compares against the default-typed definition.
+const workspace = defineWorkspace({
+	async open(): Promise<DaemonRuntime> {
+		return undefined as unknown as DaemonRuntime;
+	},
+});
+export type InferredWorkspaceIsDefinition = Expect<
+	Equal<typeof workspace, DaemonWorkspaceDefinition<DaemonRuntime>>
+>;
+
+// @ts-expect-error a workspace definition must expose open().
+defineWorkspace({});
+
+// @ts-expect-error open() must be a function.
+defineWorkspace({ open: 1 });

--- a/packages/workspace/src/config/define-config.ts
+++ b/packages/workspace/src/config/define-config.ts
@@ -1,4 +1,5 @@
 import type { DaemonWorkspaceDefinition } from '../daemon/define-daemon-workspace.js';
+import type { DaemonRuntime } from '../daemon/types.js';
 
 export const PROJECT_CONFIG_FILENAME = 'epicenter.config.ts';
 export const DEFAULT_PROJECT_CONFIG_SOURCE = `import { defineConfig } from '@epicenter/workspace';
@@ -12,6 +13,41 @@ export type EpicenterConfig = {
 	};
 };
 
+/**
+ * Define a multi-route project config. Used in monorepo dev configs that
+ * register multiple daemon workspaces under one project root.
+ *
+ * For single-workspace projects (the canonical shape per
+ * `specs/20260522T220000-workspace-project-layout.md`), prefer
+ * `defineWorkspace` and default-export it directly.
+ */
 export function defineConfig(config: EpicenterConfig): EpicenterConfig {
 	return config;
+}
+
+/**
+ * Define a single-workspace project. The returned definition is the
+ * project's sole daemon workspace; the loader assigns the route name from
+ * the project directory's basename so existing route-addressable code paths
+ * (CLI, materializer logs) keep working without explicit registration.
+ *
+ * For monorepo dev configs that register many workspaces under one project,
+ * use `defineConfig({ daemon: { routes: { ... } } })` instead.
+ *
+ * @example
+ * ```ts
+ * // <project>/epicenter.config.ts
+ * import { defineWorkspace } from '@epicenter/workspace';
+ *
+ * export default defineWorkspace({
+ *   async open({ projectDir, route, openWebSocket, installationId }) {
+ *     // build the workspace, attach materializers, return infrastructure
+ *   },
+ * });
+ * ```
+ */
+export function defineWorkspace<TRuntime extends DaemonRuntime>(
+	definition: DaemonWorkspaceDefinition<TRuntime>,
+): DaemonWorkspaceDefinition<TRuntime> {
+	return definition;
 }

--- a/packages/workspace/src/config/load-project-config.test.ts
+++ b/packages/workspace/src/config/load-project-config.test.ts
@@ -14,7 +14,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 
 import { loadProjectConfig } from './load-project-config.js';
 
@@ -59,6 +59,23 @@ describe('loadProjectConfig', () => {
 		const { data, error } = await loadProjectConfig(projectDir);
 		if (error !== null) throw new Error(error.message);
 		expect(data.daemon?.routes?.demo?.open).toBeFunction();
+	});
+
+	test('wraps a defineWorkspace default export under a single derived route', async () => {
+		// Direct workspace definition (the shape `defineWorkspace` returns):
+		// the loader wraps it as `{ daemon: { routes: { <basename>: def } } }`,
+		// keying the route by the project directory's basename so the CLI
+		// addresses it under the name the developer typed.
+		writeConfig('export default { open() {} };\n');
+
+		const { data, error } = await loadProjectConfig(projectDir);
+		if (error !== null) throw new Error(error.message);
+
+		const routes = data.daemon?.routes;
+		expect(routes).toBeDefined();
+		const routeNames = Object.keys(routes ?? {});
+		expect(routeNames).toEqual([basename(projectDir)]);
+		expect(routes?.[routeNames[0]!]?.open).toBeFunction();
 	});
 
 	test('throws with the config path when the default export is invalid', async () => {

--- a/packages/workspace/src/config/load-project-config.ts
+++ b/packages/workspace/src/config/load-project-config.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { basename, join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import { type } from 'arktype';
@@ -10,6 +10,7 @@ import {
 } from 'wellcrafted/error';
 import { Ok, type Result } from 'wellcrafted/result';
 
+import type { DaemonWorkspaceDefinition } from '../daemon/define-daemon-workspace.js';
 import type { ProjectDir } from '../shared/types.js';
 import {
 	DEFAULT_PROJECT_CONFIG_SOURCE,
@@ -50,8 +51,19 @@ export async function loadProjectConfig(
 	const module = await importProjectConfig(projectConfigPath);
 	if (!('default' in module)) {
 		throw new Error(
-			`loadProjectConfig: ${projectConfigPath} must default-export defineConfig(...).`,
+			`loadProjectConfig: ${projectConfigPath} must default-export defineConfig(...) or defineWorkspace(...).`,
 		);
+	}
+
+	// `defineWorkspace` shape: the default export IS the daemon workspace
+	// definition. Wrap it into the EpicenterConfig shape, deriving the route
+	// name from the project directory's basename so route-addressable code
+	// (CLI, materializer logs) sees the same identifier the developer typed.
+	if (isWorkspaceDefinition(module.default)) {
+		const routeName = basename(resolve(projectDir));
+		return Ok({
+			daemon: { routes: { [routeName]: module.default } },
+		});
 	}
 
 	const loaded = EpicenterConfigSchema(module.default);
@@ -67,6 +79,23 @@ export async function loadProjectConfig(
 	}
 
 	return Ok(loaded as EpicenterConfig);
+}
+
+/**
+ * Narrow a default-exported value to a `DaemonWorkspaceDefinition`. The
+ * structural test is "has an `open` function"; the route-map shape doesn't
+ * match (it has `daemon.routes`, not `open`), so the two cases are mutually
+ * exclusive.
+ */
+function isWorkspaceDefinition(
+	value: unknown,
+): value is DaemonWorkspaceDefinition {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		'open' in value &&
+		typeof (value as { open: unknown }).open === 'function'
+	);
 }
 
 async function importProjectConfig(

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -117,6 +117,7 @@ export {
 export {
 	DEFAULT_PROJECT_CONFIG_SOURCE,
 	defineConfig,
+	defineWorkspace,
 	type EpicenterConfig,
 	PROJECT_CONFIG_FILENAME,
 } from './config/define-config.js';


### PR DESCRIPTION
The layout spec (`specs/20260522T220000-workspace-project-layout.md`, merged in #1797) calls for one workspace per project. Today every leaf project wraps its sole workspace in `defineConfig({ daemon: { routes: { name } } })` even though there's nothing else to register. This adds `defineWorkspace` as the direct shape and teaches the loader to wrap it into the existing `EpicenterConfig` internally.

```ts
// Before (still works for multi-route monorepo dev configs)
export default defineConfig({
  daemon: { routes: { fuji } },
});

// After (canonical shape for single-workspace projects)
export default defineWorkspace({
  async open(ctx) {
    // build the workspace, attach materializers, return infra
  },
});
```

`defineConfig` keeps working unchanged. Both shapes can coexist in the same codebase; the monorepo's own root `epicenter.config.ts` continues to use `defineConfig` because it legitimately registers many routes for development.

The loader detection is structural and the two shapes are mutually exclusive:

```
default export                              loader path
──────────────                              ───────────
{ daemon: { routes: { ... } } }             EpicenterConfigSchema; pass through
{ open: fn, ... }                           wrap as { daemon: { routes: { <basename(projectDir)>: def } } }
```

The new shape's route name comes from the project directory's basename. `examples/fuji/epicenter.config.ts` → route `fuji`. CLI commands continue to address it as `fuji.<action>`, no other change. If a project directory's name isn't a valid route identifier (letters, digits, `-`, `_`), the existing route-name validation surfaces a clear error.

The migration in this PR demonstrates the new shape against `@epicenter/fuji`:

```
examples/fuji/epicenter.config.ts
  -  const fuji = defineDaemonWorkspace({ async open(ctx) {...} });
  -  export default defineConfig({ daemon: { routes: { fuji } } });
  +  export default defineWorkspace({ async open(ctx) {...} });
```

Tests cover both the type-level inference (`defineWorkspace` returns a typed `DaemonWorkspaceDefinition`, `defineConfig` returns `EpicenterConfig`, the `@ts-expect-error` lines refuse wrong shapes) and the runtime loader path (a `{ open: fn }` default export wraps cleanly into a single-entry route map keyed by `basename(projectDir)`). The `examples/fuji/architecture.test.ts` gains an assertion that the example uses `defineWorkspace` and not the `defineConfig` wrapper.

This unblocks the rest of spec §17. The next dependent items are project-side path helpers (`yjsPath(projectDir)`, `sqlitePath(projectDir)`) and the `epicenter init` scaffolder, each of which can land in its own small PR.

Two commits, +135 / -20 lines across 7 files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782109273&installation_id=128463665&pr_number=1798&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1798&signature=7d8f79e4353da01c4bf8c95795209598cbcfc5f39a2b52a7224f93e9950e2647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->