### PR TITLE
chore(deps): bump wellcrafted catalog to 0.38.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "epicenter",
@@ -914,7 +913,7 @@
     "typescript": "^5.9.3",
     "virtua": "^0.48.5",
     "vite": "^7.2.4",
-    "wellcrafted": "^0.37.0",
+    "wellcrafted": "^0.38.0",
     "wrangler": "^4.71.0",
     "y-indexeddb": "^9.0.12",
     "y-protocols": "^1.0.7",
@@ -3794,7 +3793,7 @@
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
-    "wellcrafted": ["wellcrafted@0.37.0", "", {}, "sha512-gsX07pbZh6oO8fZ4HDfYdKy8ln3JbzO6yiVE07SU/G3Jjx5hcXCA6ATG8ZWy6e7Ct4Ma17/bxJfzTRoiR4729g=="],
+    "wellcrafted": ["wellcrafted@0.38.0", "", {}, "sha512-T6t5pKxlJxSeXG+ZiBW6BuciJVkEuKObQXDBjFTpxm7bRyVZa5Ig2ZvHL8jwrxnUlHk/7MOZEE93dv8B/QcJsg=="],
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 			"drizzle-kit": "^0.31.7",
 			"drizzle-orm": "^0.44.7",
 			"nanoid": "latest",
-			"wellcrafted": "^0.37.0",
+			"wellcrafted": "^0.38.0",
 			"date-fns": "^4.1.0",
 			"@biomejs/biome": "^2.4.10",
 			"turbo": "^2.6.1",


### PR DESCRIPTION
Bump the shared wellcrafted catalog entry from 0.37.0 to 0.38.0, which is the current npm latest.

```text
origin/main
    |
    +-- package.json: wellcrafted ^0.38.0
    +-- bun.lock: wellcrafted@0.38.0
```

Verification:
- bun run typecheck