### PR TITLE
feat(ui): zoned natural-language date input

### DIFF
--- a/apps/fuji/src/lib/workspace.ts
+++ b/apps/fuji/src/lib/workspace.ts
@@ -23,7 +23,7 @@ import {
 	defineTable,
 	docGuid,
 	generateId,
-	IanaTimeZone,
+	type IanaTimeZone,
 	type InferTableRow,
 	type Tables,
 } from '@epicenter/workspace';
@@ -340,7 +340,6 @@ export function createFujiActions(tables: FujiTables) {
 			}),
 			handler: async ({ dateZone, entries: items }) => {
 				const now = DateTimeString.now();
-				const zone = dateZone as IanaTimeZone;
 				const rows = items.map(({ title, date }) => ({
 					id: generateId<EntryId>(),
 					title,
@@ -351,7 +350,7 @@ export function createFujiActions(tables: FujiTables) {
 					rating: 0,
 					deletedAt: null,
 					date: date as DateTimeString,
-					dateZone: zone,
+					dateZone: dateZone as IanaTimeZone,
 					createdAt: now,
 					updatedAt: now,
 				}));

--- a/apps/fuji/src/routes/(signed-in)/components/EntryEditor.svelte
+++ b/apps/fuji/src/routes/(signed-in)/components/EntryEditor.svelte
@@ -3,15 +3,13 @@
 	import { Button } from '@epicenter/ui/button';
 	import { confirmationDialog } from '@epicenter/ui/confirmation-dialog';
 	import { Loading } from '@epicenter/ui/loading';
-	import { NaturalLanguageDateInput } from '@epicenter/ui/natural-language-date-input';
+	import { ZonedNaturalLanguageDateInput } from '@epicenter/ui/natural-language-date-input';
 	import * as Popover from '@epicenter/ui/popover';
 	import { toastOnError } from '@epicenter/ui/sonner';
 	import * as StarRating from '@epicenter/ui/star-rating';
-	import { TimezoneCombobox } from '@epicenter/ui/timezone-combobox';
 	import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
 	import Trash2Icon from '@lucide/svelte/icons/trash-2';
 	import { format } from 'date-fns';
-	import type { DateTimeString } from '@epicenter/workspace';
 	import { goto } from '$app/navigation';
 	import ProseMirrorEditor from '$lib/components/ProseMirrorEditor.svelte';
 	import TagInput from '$lib/components/TagInput.svelte';
@@ -38,7 +36,6 @@
 
 	let wordCount = $state(0);
 	let isDatePopoverOpen = $state(false);
-	let dateTz = $state(entry.dateZone);
 </script>
 
 <div class="flex h-full flex-col">
@@ -143,16 +140,13 @@
 						align="start"
 						class="w-80 space-y-3 p-3"
 					>
-						<NaturalLanguageDateInput
-							onChoice={({ date }) => {
-								updateEntry({
-									date: date.toISOString() as DateTimeString,
-									dateZone: dateTz,
-								});
+						<ZonedNaturalLanguageDateInput
+							initialDateZone={entry.dateZone}
+							onChoice={({ date, dateZone }) => {
+								updateEntry({ date, dateZone });
 								isDatePopoverOpen = false;
 							}}
 						/>
-						<TimezoneCombobox bind:value={dateTz} />
 					</Popover.Content>
 				</Popover.Root>
 			</div>

--- a/apps/fuji/src/routes/(signed-in)/stress-test/+page.svelte
+++ b/apps/fuji/src/routes/(signed-in)/stress-test/+page.svelte
@@ -2,16 +2,17 @@
 	import { Badge } from '@epicenter/ui/badge';
 	import { Button } from '@epicenter/ui/button';
 	import * as Card from '@epicenter/ui/card';
-	import { DateTimeString, generateId, type IanaTimeZone } from '@epicenter/workspace';
+	import { DateTimeString, generateId, IanaTimeZone } from '@epicenter/workspace';
 	import { toast } from 'svelte-sonner';
 	import * as Y from 'yjs';
 	import { requireFuji } from '$lib/session';
-	import type { EntryId } from '$lib/workspace';
+	import type { Entry, EntryId } from '$lib/workspace';
 
 	// ─── Config ──────────────────────────────────────────────────────────────────
 	const fuji = requireFuji();
 
 	const COUNTS = [1_000, 10_000] as const;
+	const STRESS_TEST_TAG = 'stress-test';
 
 	/**
 	 * Small chunk size for bulkSet so the browser event loop yields between
@@ -42,7 +43,7 @@
 	let results = $state<Results | null>(null);
 
 	const stressTestCount = $derived(
-		fuji.entries.active.filter((e) => e.tags.includes('stress-test')).length,
+		fuji.entries.active.filter(isStressTestEntry).length,
 	);
 
 	// ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -57,9 +58,15 @@
 		return shuffled.slice(0, count);
 	}
 
-	const LOCAL_TZ = Intl.DateTimeFormat().resolvedOptions().timeZone as IanaTimeZone;
+	function isStressTestEntry(entry: Entry): boolean {
+		return entry.tags.includes(STRESS_TEST_TAG);
+	}
 
-	function generateEntryRow(index: number, now: DateTimeString) {
+	function generateEntryRow(
+		index: number,
+		now: DateTimeString,
+		dateZone: IanaTimeZone,
+	) {
 		const dateNow = Date.now();
 		const twoYearsMs = 2 * 365 * 24 * 60 * 60 * 1000;
 		const ts = dateNow - twoYearsMs + Math.random() * twoYearsMs;
@@ -69,12 +76,12 @@
 			title: `${pick(TITLES)} #${index + 1}`,
 			subtitle: pick(SUBTITLES),
 			type: pickN(TYPES, 0, 2),
-			tags: ['stress-test', ...pickN(EXTRA_TAGS, 0, 2)],
+			tags: [STRESS_TEST_TAG, ...pickN(EXTRA_TAGS, 0, 2)],
 			pinned: Math.random() < 0.05,
 			rating: Math.random() < 0.7 ? 0 : Math.floor(Math.random() * 5) + 1,
 			deletedAt: null,
 			date: new Date(ts).toISOString() as DateTimeString,
-			dateZone: LOCAL_TZ,
+			dateZone,
 			createdAt: now,
 			updatedAt: now,
 		};
@@ -83,6 +90,12 @@
 	function formatMs(ms: number): string {
 		if (ms < 1000) return `${ms.toFixed(1)}ms`;
 		return `${(ms / 1000).toFixed(2)}s`;
+	}
+
+	function formatBytes(bytes: number): string {
+		if (bytes < 1024) return `${bytes} B`;
+		if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+		return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 	}
 
 	// ─── Actions ─────────────────────────────────────────────────────────────────
@@ -94,8 +107,9 @@
 
 		try {
 			const now = DateTimeString.now();
+			const dateZone = IanaTimeZone.current();
 			const rows = Array.from({ length: count }, (_, i) =>
-				generateEntryRow(i, now),
+				generateEntryRow(i, now, dateZone),
 			);
 
 			const insertStart = performance.now();
@@ -114,9 +128,7 @@
 
 			// Filter performance
 			const filterStart = performance.now();
-			const stressEntries = fuji.tables.entries.filter((e) =>
-				e.tags.includes('stress-test'),
-			);
+			fuji.tables.entries.filter(isStressTestEntry);
 			const filterTimeMs = performance.now() - filterStart;
 
 			// Y.Doc binary size
@@ -146,9 +158,7 @@
 		clearing = true;
 
 		try {
-			const stressEntries = fuji.tables.entries.filter((e) =>
-				e.tags.includes('stress-test'),
-			);
+			const stressEntries = fuji.tables.entries.filter(isStressTestEntry);
 			const ids = stressEntries.map((e) => e.id);
 
 			await fuji.tables.entries.bulkDelete(ids);
@@ -183,7 +193,7 @@
 			<Card.Title class="text-sm">Generate Entries</Card.Title>
 			<Card.Description>
 				All generated entries are tagged
-				<Badge variant="secondary">stress-test</Badge>
+				<Badge variant="secondary">{STRESS_TEST_TAG}</Badge>
 				for easy cleanup.
 			</Card.Description>
 		</Card.Header>
@@ -258,12 +268,7 @@
 					{ label: 'Stress-test rows', value: stressTestCount.toLocaleString() },
 					{
 						label: 'Y.Doc size',
-						value:
-							results.ydocSizeBytes < 1024
-								? `${results.ydocSizeBytes} B`
-								: results.ydocSizeBytes < 1024 * 1024
-									? `${(results.ydocSizeBytes / 1024).toFixed(1)} KB`
-									: `${(results.ydocSizeBytes / (1024 * 1024)).toFixed(1)} MB`,
+						value: formatBytes(results.ydocSizeBytes),
 					},
 					{ label: 'getAllValid() time', value: formatMs(results.readTimeMs) },
 					{ label: 'filter() time', value: formatMs(results.filterTimeMs) },

--- a/packages/ui/src/natural-language-date-input/index.ts
+++ b/packages/ui/src/natural-language-date-input/index.ts
@@ -1,9 +1,9 @@
 export type { NaturalLanguageDateInputProps } from './natural-language-date-input.svelte';
 export { default as NaturalLanguageDateInput } from './natural-language-date-input.svelte';
+export type { ParsedSuggestion, ParseInZoneOptions } from './parse.js';
+export { parseInZone } from './parse.js';
 export type {
 	ZonedDateTimeChoice,
 	ZonedNaturalLanguageDateInputProps,
 } from './zoned-natural-language-date-input.svelte';
 export { default as ZonedNaturalLanguageDateInput } from './zoned-natural-language-date-input.svelte';
-export { parseInZone } from './parse.js';
-export type { ParsedSuggestion, ParseInZoneOptions } from './parse.js';

--- a/packages/ui/src/natural-language-date-input/index.ts
+++ b/packages/ui/src/natural-language-date-input/index.ts
@@ -1,2 +1,9 @@
 export type { NaturalLanguageDateInputProps } from './natural-language-date-input.svelte';
 export { default as NaturalLanguageDateInput } from './natural-language-date-input.svelte';
+export type {
+	ZonedDateTimeChoice,
+	ZonedNaturalLanguageDateInputProps,
+} from './zoned-natural-language-date-input.svelte';
+export { default as ZonedNaturalLanguageDateInput } from './zoned-natural-language-date-input.svelte';
+export { parseInZone } from './parse.js';
+export type { ParsedSuggestion, ParseInZoneOptions } from './parse.js';

--- a/packages/ui/src/natural-language-date-input/natural-language-date-input.svelte
+++ b/packages/ui/src/natural-language-date-input/natural-language-date-input.svelte
@@ -1,5 +1,13 @@
 <script lang="ts" module>
+	import { IanaTimeZone } from '@epicenter/workspace';
+
 	export type NaturalLanguageDateInputProps = {
+		/**
+		 * IANA zone used to interpret bare wall-clock phrases like "5pm" or
+		 * "tomorrow at 9". Defaults to the runtime's resolved zone. The
+		 * component does not render any timezone UI.
+		 */
+		timeZone?: IanaTimeZone;
 		min?: Date;
 		max?: Date;
 		placeholder?: string;
@@ -8,11 +16,12 @@
 </script>
 
 <script lang="ts">
-	import * as chrono from 'chrono-node';
 	import * as Command from '../command/index.js';
+	import { parseInZone } from './parse.js';
 
 	let {
 		placeholder = 'E.g. "tomorrow at 5pm" or "in 2 hours"',
+		timeZone = IanaTimeZone.current(),
 		min,
 		max,
 		onChoice,
@@ -20,20 +29,23 @@
 
 	let value = $state('');
 
-	const suggestions = $derived.by(() => {
-		if (!value.trim()) return [];
-		const parsed = chrono.parse(value, new Date());
-		return parsed
-			.map((result) => ({
-				label: result.text,
-				date: result.start.date(),
-			}))
-			.filter(
-				(s) =>
-					(min === undefined || s.date > min) &&
-					(max === undefined || s.date < max),
-			);
-	});
+	const suggestions = $derived(
+		parseInZone({
+			text: value,
+			referenceNow: new Date(),
+			timeZone,
+			min,
+			max,
+		}),
+	);
+
+	const formatter = $derived(
+		new Intl.DateTimeFormat(undefined, {
+			timeZone,
+			dateStyle: 'medium',
+			timeStyle: 'short',
+		}),
+	);
 </script>
 
 <Command.Root shouldFilter={false} class="border-border h-fit border">
@@ -49,8 +61,7 @@
 					<div class="flex w-full place-items-center justify-between gap-2">
 						<span> {suggestion.label} </span>
 						<span class="text-muted-foreground">
-							{suggestion.date.toDateString()}
-							{suggestion.date.toLocaleTimeString()}
+							{formatter.format(suggestion.date)}
 						</span>
 					</div>
 				</Command.Item>

--- a/packages/ui/src/natural-language-date-input/parse.test.ts
+++ b/packages/ui/src/natural-language-date-input/parse.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'bun:test';
+import type { IanaTimeZone } from '@epicenter/workspace';
+import { parseInZone } from './parse.js';
+
+const LA = 'America/Los_Angeles' as IanaTimeZone;
+const NY = 'America/New_York' as IanaTimeZone;
+const TOKYO = 'Asia/Tokyo' as IanaTimeZone;
+const UTC = 'UTC' as IanaTimeZone;
+
+describe('parseInZone', () => {
+	it('returns no suggestions for empty input', () => {
+		expect(
+			parseInZone({
+				text: '',
+				referenceNow: new Date('2026-05-25T17:00:00Z'),
+				timeZone: LA,
+			}),
+		).toEqual([]);
+	});
+
+	it('resolves "tomorrow at 5pm" in Los Angeles (PDT, UTC-7)', () => {
+		// 2026-05-25 17:00 UTC = 2026-05-25 10:00 PDT, so "tomorrow 5pm PDT"
+		// = 2026-05-26 17:00 PDT = 2026-05-27 00:00 UTC.
+		const out = parseInZone({
+			text: 'tomorrow at 5pm',
+			referenceNow: new Date('2026-05-25T17:00:00Z'),
+			timeZone: LA,
+		});
+		expect(out).toHaveLength(1);
+		expect(out[0]!.date.toISOString()).toBe('2026-05-27T00:00:00.000Z');
+	});
+
+	it('resolves "tomorrow at 5pm" in New York (EDT, UTC-4)', () => {
+		// "tomorrow 5pm EDT" = 2026-05-26 17:00 EDT = 2026-05-26 21:00 UTC.
+		const out = parseInZone({
+			text: 'tomorrow at 5pm',
+			referenceNow: new Date('2026-05-25T17:00:00Z'),
+			timeZone: NY,
+		});
+		expect(out).toHaveLength(1);
+		expect(out[0]!.date.toISOString()).toBe('2026-05-26T21:00:00.000Z');
+	});
+
+	it('resolves "tomorrow at 5pm" in Tokyo (JST, UTC+9)', () => {
+		// 2026-05-25 17:00 UTC = 2026-05-26 02:00 JST, so "tomorrow" in JST
+		// is 2026-05-27. "tomorrow 5pm JST" = 2026-05-27 17:00 JST
+		// = 2026-05-27 08:00 UTC.
+		const out = parseInZone({
+			text: 'tomorrow at 5pm',
+			referenceNow: new Date('2026-05-25T17:00:00Z'),
+			timeZone: TOKYO,
+		});
+		expect(out).toHaveLength(1);
+		expect(out[0]!.date.toISOString()).toBe('2026-05-27T08:00:00.000Z');
+	});
+
+	it('treats "in 2 hours" as relative to referenceNow regardless of zone', () => {
+		const referenceNow = new Date('2026-05-25T17:00:00Z');
+		const inLA = parseInZone({ text: 'in 2 hours', referenceNow, timeZone: LA });
+		const inTokyo = parseInZone({
+			text: 'in 2 hours',
+			referenceNow,
+			timeZone: TOKYO,
+		});
+		expect(inLA[0]!.date.toISOString()).toBe('2026-05-25T19:00:00.000Z');
+		expect(inTokyo[0]!.date.toISOString()).toBe('2026-05-25T19:00:00.000Z');
+	});
+
+	it('filters out suggestions outside [min, max]', () => {
+		// "tomorrow at 5pm" in UTC resolves to 2026-05-26T17:00:00Z.
+		const referenceNow = new Date('2026-05-25T17:00:00Z');
+		const minAfter = parseInZone({
+			text: 'tomorrow at 5pm',
+			referenceNow,
+			timeZone: UTC,
+			min: new Date('2026-05-27T00:00:00Z'),
+		});
+		expect(minAfter).toEqual([]);
+
+		const maxBefore = parseInZone({
+			text: 'tomorrow at 5pm',
+			referenceNow,
+			timeZone: UTC,
+			max: new Date('2026-05-26T00:00:00Z'),
+		});
+		expect(maxBefore).toEqual([]);
+	});
+});

--- a/packages/ui/src/natural-language-date-input/parse.test.ts
+++ b/packages/ui/src/natural-language-date-input/parse.test.ts
@@ -56,7 +56,11 @@ describe('parseInZone', () => {
 
 	it('treats "in 2 hours" as relative to referenceNow regardless of zone', () => {
 		const referenceNow = new Date('2026-05-25T17:00:00Z');
-		const inLA = parseInZone({ text: 'in 2 hours', referenceNow, timeZone: LA });
+		const inLA = parseInZone({
+			text: 'in 2 hours',
+			referenceNow,
+			timeZone: LA,
+		});
 		const inTokyo = parseInZone({
 			text: 'in 2 hours',
 			referenceNow,

--- a/packages/ui/src/natural-language-date-input/parse.ts
+++ b/packages/ui/src/natural-language-date-input/parse.ts
@@ -1,5 +1,5 @@
-import * as chrono from 'chrono-node';
 import type { IanaTimeZone } from '@epicenter/workspace';
+import * as chrono from 'chrono-node';
 
 export type ParsedSuggestion = { label: string; date: Date };
 

--- a/packages/ui/src/natural-language-date-input/parse.ts
+++ b/packages/ui/src/natural-language-date-input/parse.ts
@@ -1,0 +1,68 @@
+import * as chrono from 'chrono-node';
+import type { IanaTimeZone } from '@epicenter/workspace';
+
+export type ParsedSuggestion = { label: string; date: Date };
+
+export type ParseInZoneOptions = {
+	text: string;
+	referenceNow: Date;
+	timeZone: IanaTimeZone;
+	min?: Date;
+	max?: Date;
+};
+
+/**
+ * Parse natural-language datetime phrases as if "now" were in `timeZone`.
+ *
+ * Bare wall-clock phrases like "5pm" or "tomorrow at 9" resolve to the
+ * matching UTC instant in `timeZone`, not in the runtime's local zone.
+ * Relative phrases like "in 2 hours" ignore `timeZone` (chrono adds the
+ * delta to `referenceNow` directly).
+ *
+ * DST note: the zone offset is computed at `referenceNow`. A phrase
+ * straddling a DST transition uses the offset at the reference instant,
+ * not at the resolved instant. This matches chrono's own behavior.
+ */
+export function parseInZone(opts: ParseInZoneOptions): ParsedSuggestion[] {
+	const { text, referenceNow, timeZone, min, max } = opts;
+	if (!text.trim()) return [];
+
+	const offsetMinutes = getZoneOffsetMinutes(timeZone, referenceNow);
+	const parsed = chrono.parse(text, {
+		instant: referenceNow,
+		timezone: offsetMinutes,
+	});
+
+	return parsed
+		.map((result) => ({
+			label: result.text,
+			date: result.start.date(),
+		}))
+		.filter(
+			(s) =>
+				(min === undefined || s.date > min) &&
+				(max === undefined || s.date < max),
+		);
+}
+
+/**
+ * Offset of `timeZone` at `instant`, in positive minutes east of UTC.
+ * Chrono's `ParsingReference.timezone` uses this convention.
+ *
+ * `Intl.DateTimeFormat` with `timeZoneName: 'longOffset'` emits a part like
+ * `GMT-07:00` (PDT) or `GMT+09:00` (JST). Parse it back to minutes.
+ */
+function getZoneOffsetMinutes(timeZone: IanaTimeZone, instant: Date): number {
+	const parts = new Intl.DateTimeFormat('en-US', {
+		timeZone,
+		timeZoneName: 'longOffset',
+	}).formatToParts(instant);
+	const offsetPart = parts.find((p) => p.type === 'timeZoneName')?.value;
+	if (!offsetPart) return 0;
+
+	const match = /(?:GMT|UTC)([+-])(\d{2}):?(\d{2})?/.exec(offsetPart);
+	if (!match) return 0;
+	const [, sign, hh, mm] = match;
+	const magnitude = Number(hh) * 60 + Number(mm ?? 0);
+	return sign === '-' ? -magnitude : magnitude;
+}

--- a/packages/ui/src/natural-language-date-input/zoned-natural-language-date-input.svelte
+++ b/packages/ui/src/natural-language-date-input/zoned-natural-language-date-input.svelte
@@ -1,0 +1,56 @@
+<script lang="ts" module>
+	import { type DateTimeString, IanaTimeZone } from '@epicenter/workspace';
+
+	export type ZonedDateTimeChoice = {
+		label: string;
+		date: DateTimeString;
+		dateZone: IanaTimeZone;
+	};
+
+	export type ZonedNaturalLanguageDateInputProps = {
+		/**
+		 * Seed zone. The component owns the draft internally; later changes to
+		 * this prop do not update the displayed zone.
+		 */
+		initialDateZone?: IanaTimeZone;
+		min?: Date;
+		max?: Date;
+		placeholder?: string;
+		onChoice: (choice: ZonedDateTimeChoice) => void;
+	};
+</script>
+
+<script lang="ts">
+	import { untrack } from 'svelte';
+	import { TimezoneCombobox } from '../timezone-combobox/index.js';
+	import NaturalLanguageDateInput from './natural-language-date-input.svelte';
+
+	let {
+		initialDateZone,
+		min,
+		max,
+		placeholder,
+		onChoice,
+	}: ZonedNaturalLanguageDateInputProps = $props();
+
+	let dateZone = $state<IanaTimeZone>(
+		untrack(() => initialDateZone) ?? IanaTimeZone.current(),
+	);
+</script>
+
+<div class="space-y-2">
+	<NaturalLanguageDateInput
+		timeZone={dateZone}
+		{min}
+		{max}
+		{placeholder}
+		onChoice={({ label, date }) => {
+			onChoice({
+				label,
+				date: date.toISOString() as DateTimeString,
+				dateZone,
+			});
+		}}
+	/>
+	<TimezoneCombobox bind:value={dateZone} />
+</div>

--- a/specs/20260525T194400-zoned-natural-language-date-input.md
+++ b/specs/20260525T194400-zoned-natural-language-date-input.md
@@ -1,0 +1,183 @@
+# Zoned Natural-Language Datetime Input
+
+**Date**: 2026-05-25
+**Status**: Draft
+**Author**: AI-assisted (claude@bradenwong.com)
+**Branch**: braden-w/typebox-table-kv-spec
+
+## Overview
+
+Fix the implicit-zone bug in Fuji's entry date picker by introducing two-layer composition under `packages/ui/src/natural-language-date-input/`:
+
+1. The existing `NaturalLanguageDateInput` (shadcn-style primitive) gains a `timeZone?: IanaTimeZone` prop. Parsing happens in that zone, not the runtime's local zone. Public surface stays one prop wider than upstream.
+2. A new `ZonedNaturalLanguageDateInput` composes the primitive with `TimezoneCombobox`. It owns the zone draft internally, takes one seed prop (`initialDateZone`), and emits a single atomic `onChoice({ label, date, dateZone })` event.
+
+Fuji's `EntryEditor` swaps two children + one `$state` line for one wrapper. The bug where a non-local zone selection produced a UTC instant tied to the runtime's local wall-clock becomes structurally impossible.
+
+## Motivation
+
+`apps/fuji/src/routes/(signed-in)/components/EntryEditor.svelte:146-156` today:
+
+```svelte
+<NaturalLanguageDateInput
+  onChoice={({ date }) => {
+    updateEntry({
+      date: date.toISOString() as DateTimeString,
+      dateZone: dateTz,
+    });
+    isDatePopoverOpen = false;
+  }}
+/>
+<TimezoneCombobox bind:value={dateTz} />
+```
+
+The primitive calls `chrono.parse(value, new Date())` with no `timezone` reference, so "5pm" resolves to 5pm in `Intl.DateTimeFormat().resolvedOptions().timeZone`. If `dateTz` is `Asia/Tokyo` but the runtime is in `America/Los_Angeles`, the stored pair is `(date = 5pm-PT-as-UTC, dateZone = Asia/Tokyo)`. Reading it back as 5pm Tokyo is wrong by the LA-Tokyo offset.
+
+## Design Decisions
+
+### Two components, one new file
+
+```
+packages/ui/src/natural-language-date-input/
+  natural-language-date-input.svelte        # modified
+  zoned-natural-language-date-input.svelte  # new
+  parse.ts                                  # new (pure helper)
+  index.ts                                  # adds wrapper export
+```
+
+The primitive stays a thin shadcn-style cell. Callers who already have a zone context (e.g. a calendar grid pinned to one zone) use the primitive directly. Callers who need user-selectable zone use the wrapper.
+
+### Primitive surface
+
+```ts
+export type NaturalLanguageDateInputProps = {
+  timeZone?: IanaTimeZone;          // defaults to IanaTimeZone.current()
+  min?: Date;
+  max?: Date;
+  placeholder?: string;
+  onChoice?: (choice: { label: string; date: Date }) => void;
+};
+```
+
+- Emits `Date` (UTC instant). The `DateTimeString` brand belongs at the workspace boundary; the primitive doesn't import workspace types except for `IanaTimeZone` (a brand-only type-import).
+- `min`/`max` are UTC instants. Wall-clock constraints are a future concern; no consumer needs them today.
+- No typed-zone parsing ("tomorrow 5pm Tokyo"). Explicit UI is the contract.
+
+### Wrapper surface
+
+```ts
+export type ZonedDateTimeChoice = {
+  label: string;
+  date: DateTimeString;
+  dateZone: IanaTimeZone;
+};
+
+export type ZonedNaturalLanguageDateInputProps = {
+  /** Seed zone. Component owns the draft. Not reactive after mount. */
+  initialDateZone?: IanaTimeZone;
+  min?: Date;
+  max?: Date;
+  placeholder?: string;
+  onChoice: (choice: ZonedDateTimeChoice) => void;
+};
+```
+
+Three deliberate choices, grounded in Svelte 5 docs (see DeepWiki query in the design conversation):
+
+1. **No `date` prop.** The date has no draft state. The text input never displays the entry's existing date. `onChoice` is the only output channel.
+2. **No `bind:dateZone`.** Uncontrolled-mode pattern: the wrapper owns its own zone state seeded from `initialDateZone`. Fuji has no use for the draft zone outside the popover. Adding `bind:dateZone` later is non-breaking (controlled-mode opt-in).
+3. **Single `onChoice` carries both fields.** Atomic commit. The parent never has to read the zone separately; it arrives in the same payload as the date.
+
+This avoids the Svelte 5 anti-pattern of exposing both `$bindable` and a callback that emits the same data.
+
+### Pure parser
+
+```ts
+// packages/ui/src/natural-language-date-input/parse.ts
+
+export type ParsedSuggestion = { label: string; date: Date };
+
+export type ParseInZoneOptions = {
+  text: string;
+  referenceNow: Date;
+  timeZone: IanaTimeZone;
+  min?: Date;
+  max?: Date;
+};
+
+export function parseInZone(opts: ParseInZoneOptions): ParsedSuggestion[];
+```
+
+Implementation: compute the offset (positive minutes east of UTC) of `timeZone` at `referenceNow` via `Intl.DateTimeFormat` `longOffset` parts. Pass it to `chrono.parse(text, { instant: referenceNow, timezone: offsetMinutes })`. chrono uses that offset as the reference timezone when resolving bare wall-clock phrases. Filter by `min`/`max` (strict `>` / `<`, matching current behavior).
+
+DST edge: the offset is computed *at the reference instant*. A phrase like "tomorrow at 2:30am" parsed the day before spring-forward uses today's offset; that's chrono's behavior, not ours to override. Document the limitation in a comment.
+
+### Fuji migration
+
+```svelte
+<ZonedNaturalLanguageDateInput
+  initialDateZone={entry.dateZone}
+  onChoice={({ date, dateZone }) => {
+    updateEntry({ date, dateZone });
+    isDatePopoverOpen = false;
+  }}
+/>
+```
+
+Deletes:
+- `let dateTz = $state(entry.dateZone)` line.
+- `TimezoneCombobox` import.
+- The sibling `<TimezoneCombobox bind:value={dateTz} />` markup.
+
+## Implementation Waves
+
+### Wave A — pure helper + types
+
+Add `packages/ui/src/natural-language-date-input/parse.ts` exporting `parseInZone`, `ParsedSuggestion`, `ParseInZoneOptions`. Type-only import of `IanaTimeZone` from `@epicenter/workspace`.
+
+### Wave B — primitive update
+
+Modify `natural-language-date-input.svelte`:
+- Add `timeZone?: IanaTimeZone` to the prop type.
+- Replace the inline `$derived` chrono parse with `parseInZone({ text: value, referenceNow: new Date(), timeZone, min, max })`.
+- Default `timeZone` to `IanaTimeZone.current()`.
+
+### Wave C — wrapper component
+
+Add `zoned-natural-language-date-input.svelte` with the prop shape above. Internally: one `$state(initialDateZone ?? IanaTimeZone.current())` for the draft zone, one child `<NaturalLanguageDateInput timeZone={dateZone} ...>`, one child `<TimezoneCombobox bind:value={dateZone} />`.
+
+### Wave D — exports
+
+`index.ts` re-exports `ZonedNaturalLanguageDateInput` + `ZonedNaturalLanguageDateInputProps` + `ZonedDateTimeChoice`.
+
+### Wave E — Fuji migration
+
+Edit `apps/fuji/src/routes/(signed-in)/components/EntryEditor.svelte` per the diff above.
+
+### Wave F — typecheck + review
+
+`bun run --filter @epicenter/ui typecheck` and the Fuji equivalent. Post-implementation review pass per `AGENTS.md`.
+
+## Edge Cases & Tests
+
+Tests live next to the helper: `packages/ui/src/natural-language-date-input/parse.test.ts`.
+
+- "tomorrow at 5pm" with `timeZone = America/Los_Angeles`, `referenceNow = 2026-05-25T17:00:00Z` → `date = 2026-05-26T00:00:00Z` (midnight UTC = 5pm PDT).
+- Same input with `timeZone = America/New_York` → `date = 2026-05-25T21:00:00Z`.
+- "in 2 hours" must be unaffected by `timeZone` (relative phrase).
+- `min` filter: a suggestion equal to `min` is filtered out (matches existing `>` semantics).
+- Empty input → `[]`, no chrono call.
+- "noon" with `timeZone = Asia/Tokyo` at the right reference produces a UTC instant 9 hours before local noon Tokyo.
+- A suggestion outside `[min, max]` filtered out cleanly.
+
+Non-tested but documented:
+- DST gap interpretation defers to chrono.
+- Typed timezone names in input are not supported.
+
+## Out of Scope
+
+- `bind:dateZone` (controlled mode). Add when a concrete consumer needs it.
+- `bind:date` ever. Date has no draft state.
+- `wallClockMin` / `wallClockMax`. No consumer.
+- `source: "selected-zone" | "typed-zone"` discriminator. No second source.
+- Migrating `chrono-node` away. The library is already a dependency; the helper is pure and swappable later.


### PR DESCRIPTION
Fuji's entry date popover combined a `NaturalLanguageDateInput` with a sibling `TimezoneCombobox`, expecting the user to flip the zone before typing a phrase. They didn't, because the primitive parsed against the runtime's zone regardless of what the combobox showed. So picking "Tokyo" and typing "5pm" on a laptop in Los Angeles stored a UTC instant tied to 5pm Los Angeles, then labeled it with `dateZone: Asia/Tokyo`. Reading it back was off by the LA-Tokyo offset.

The fix is to make zone selection and parsing share one source of truth, and to commit both fields atomically. That meant a small primitive change and a new composed wrapper.

The primitive now accepts a `timeZone?: IanaTimeZone` prop and routes parsing through a pure helper. It still renders no zone UI itself; the prop is just the zone in which "5pm" means 5pm. Display also follows: each suggestion row formats its parsed instant in the selected zone, so flipping the combobox re-formats the dropdown in place.

```ts
function parseInZone(opts: {
  text: string;
  referenceNow: Date;
  timeZone: IanaTimeZone;
  min?: Date;
  max?: Date;
}): { label: string; date: Date }[];
```

The helper computes the zone's offset at `referenceNow` via `Intl.DateTimeFormat` `longOffset` parts and passes it to `chrono.parse({ instant, timezone })`. Bare wall-clock phrases anchor in the selected zone; relative phrases like "in 2 hours" stay relative to `referenceNow` regardless of zone.

The new `ZonedNaturalLanguageDateInput` composes the primitive with `TimezoneCombobox` and owns the zone draft internally. There is intentionally no `bind:date` and no `bind:dateZone`. The Svelte 5 docs are explicit that exposing both `$bindable` and a callback emitting the same data is redundant, and the two fields have different lifecycles inside this UI anyway: the zone is a draft the user fiddles with before committing; the date doesn't exist until they pick a suggestion. So one input prop, one atomic output:

```ts
type ZonedDateTimeChoice = {
  label: string;
  date: DateTimeString;
  dateZone: IanaTimeZone;
};

type ZonedNaturalLanguageDateInputProps = {
  initialDateZone?: IanaTimeZone;
  min?: Date;
  max?: Date;
  placeholder?: string;
  onChoice: (choice: ZonedDateTimeChoice) => void;
};
```

`initialDateZone` is a seed, read once at mount via `untrack`. Closing the popover discards any uncommitted zone change for free. A future controlled-mode `bind:dateZone` is a non-breaking opt-in if anyone ever needs it; nobody does today.

Fuji's `EntryEditor` collapses from a stateful triple to one component:

```svelte
<!-- Before -->
let dateTz = $state(entry.dateZone);

<NaturalLanguageDateInput
  onChoice={({ date }) => {
    updateEntry({
      date: date.toISOString() as DateTimeString,
      dateZone: dateTz,
    });
    isDatePopoverOpen = false;
  }}
/>
<TimezoneCombobox bind:value={dateTz} />

<!-- After -->
<ZonedNaturalLanguageDateInput
  initialDateZone={entry.dateZone}
  onChoice={({ date, dateZone }) => {
    updateEntry({ date, dateZone });
    isDatePopoverOpen = false;
  }}
/>
```

Composition tree, for orientation:

```
ZonedNaturalLanguageDateInput     (owns dateZone draft, atomic onChoice)
  ├── NaturalLanguageDateInput    (text input + suggestions, parses in timeZone)
  │     └── parseInZone           (pure: text + zone + now -> ParsedSuggestion[])
  └── TimezoneCombobox            (bind:value={dateZone}, internal state)
```

A second commit (`refactor(fuji): tighten IanaTimeZone usage...`) came along for the ride. It's unrelated to the date input: it inlines a one-line cast in the entries action, switches one import from value to type, and extracts a few duplicated helpers in the stress-test page (`STRESS_TEST_TAG`, `isStressTestEntry`, `formatBytes`) that were inline 2-4 times each. Net cosmetic.

Tests for the parser cover LA/NY/Tokyo wall-clock anchoring, relative-phrase independence from zone, and `min`/`max` filter behavior. Full monorepo typecheck passes. Spec for the design conversation, including the Svelte 5 doc check that decided the API shape, is in `specs/20260525T194400-zoned-natural-language-date-input.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782332458&installation_id=128463665&pr_number=1813&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1813&signature=11a76144212e785c88cd26f35326f80ef8eab99bfd6e0e3d5af29f7180994f9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->