### PR TITLE
refactor(workspace)!: attachEncryption takes tables/kv as named slots

### DIFF
--- a/.agents/skills/attach-primitive/SKILL.md
+++ b/.agents/skills/attach-primitive/SKILL.md
@@ -31,7 +31,7 @@ attachIndexedDb(ydoc)                   // Y.Doc subject
 attachSqlite(ydoc, { filePath })
 openCollaboration(ydoc, { url, openWebSocket, replicaId, actions })
 attachBroadcastChannel(ydoc)
-attachEncryption(ydoc, { encryptionKeys })
+attachEncryption(ydoc, { keyring, tables, kv })
 attachTable(ydoc, name, def)            // Y.Doc subject + slot key + def
 attachTables(ydoc, defs)
 attachKv(ydoc, defs)
@@ -87,23 +87,21 @@ This is rare: one example in the whole codebase. It lives in `@epicenter/cli` an
 
 If the primitive is in-package with its coordinator, prefer method-on-coordinator (below) over a top-level `attachX(attachment, opts)`.
 
-## Coordinator pattern (the encryption case)
+## Constructor primitives (the encryption case)
 
-When one attachment registers additional sibling attachments into itself, it owns the method surface:
-
-```ts
-const encryption = attachEncryption(ydoc, { encryptionKeys });
-const tables = encryption.attachTables(defs);      // method on coordinator
-const kv = encryption.attachKv(defs);
-```
-
-vs. the top-level form that would read:
+When a primitive must construct several sibling handles atomically (one keyring derivation, N stores activated together), it takes the definition records as named slots and returns the constructed handles as a record:
 
 ```ts
-const tables = attachEncryptedTables(ydoc, encryption, defs);   // ← not used; coordinator owns this
+const { tables, kv } = attachEncryption(ydoc, {
+  keyring,
+  tables: defs,
+  kv: kvDefs,
+});
 ```
 
-The method form says "use the encryption's attach-tables" directly. Preferred when the coordinator and its siblings live in the same package.
+The slot names mirror the plaintext primitives (`tables`, `kv`): same definition records in, but the primitive constructs the encrypted variants instead of the caller wiring `attachTable`/`attachKv` by hand. One call, atomic registration, no temporal window for mid-session attachment.
+
+The materializer primitives follow the same "named slots in, constructed handle out" pattern (see the materializer block above); encryption is the constructor case where the slots are *definitions*, materializer is the mirror case where the slots are already-constructed *handles*.
 
 ## Invariants
 
@@ -128,15 +126,13 @@ Primitives compose inside a build closure:
 ```ts
 const cache = createDisposableCache((id: string) => {
   const ydoc       = new Y.Doc({ guid: id, gc: false });
-  const encryption = attachEncryption(ydoc, { encryptionKeys });
-  const tables     = encryption.attachTables(schema);     // coordinator method
-  const idb        = attachIndexedDb(ydoc);
-  const unlock     = attachSessionUnlock(encryption, {          // non-ydoc subject
-    sessions, serverUrl, waitFor: idb.whenLoaded,
+  const { tables, kv } = attachEncryption(ydoc, {
+    keyring, tables: schema, kv: kvDefs,
   });
+  const idb        = attachIndexedDb(ydoc);
   const collaboration = openCollaboration(ydoc, {
     url, openWebSocket, replicaId, actions,
-    waitFor: Promise.all([idb.whenLoaded, unlock.whenChecked]),
+    waitFor: idb.whenLoaded,
   });
   const markdown   = attachMarkdownMaterializer(ydoc, {
     dir,
@@ -146,8 +142,8 @@ const cache = createDisposableCache((id: string) => {
   });
 
   return {
-    ydoc, tables, encryption, idb, collaboration, markdown,
-    whenReady: Promise.all([idb.whenLoaded, unlock.whenChecked, collaboration.whenConnected]),
+    ydoc, tables, kv, idb, collaboration, markdown,
+    whenReady: Promise.all([idb.whenLoaded, collaboration.whenConnected]),
     async wipe() {
       ydoc.destroy();
       await collaboration.whenDisposed;
@@ -180,12 +176,12 @@ Use it whenever a primitive's startup must follow another's. Examples:
 - **Don't duck-type an attachment.** If you need to brand it, use a `Symbol.for` marker. See `skills/typescript`: runtime shape-checking is a code smell.
 - **Don't take an `id` on a ydoc-bound primitive.** Use `ydoc.guid`.
 - **Don't use `createX` for a side-effectful primitive.** If it registers listeners, it's `attach*`.
-- **Don't introduce `attachEncryptedX(ydoc, encryption, ...)` top-level exports.** Use `encryption.attachX(...)`: the coordinator owns its siblings.
+- **Don't introduce a separate top-level encrypted-X helper.** When a primitive must derive keys and construct sibling handles atomically, pass the definition records as named slots on a single call (`attachEncryption(ydoc, { keyring, tables, kv })`) and return the constructed handles destructurable at the call site.
 
 ## Reference implementations
 
 - `packages/workspace/src/document/attach-indexed-db.ts` ; the canonical 40-line example.
 - `packages/workspace/src/document/open-collaboration.ts` ; document collaboration surface with sync, presence, peers, and action dispatch.
-- `packages/workspace/src/document/attach-encryption.ts` ; state-owning coordinator; exposes `attachTable` / `attachTables` / `attachKv` as methods.
+- `packages/workspace/src/document/attach-encryption.ts` ; constructor primitive; takes `{ keyring, tables, kv }` and returns `{ tables, kv }` after one atomic keyring derivation.
 - `packages/workspace/src/document/materializer/markdown/materializer.ts` ; tables and optional `perTable` / `kv` in the options bag, keyed by table name.
 - `apps/whispering/src/lib/client.ts`: full singleton composition.

--- a/.agents/skills/attach-primitive/SKILL.md
+++ b/.agents/skills/attach-primitive/SKILL.md
@@ -75,17 +75,9 @@ Per-table customization lives in `perTable: { [tableName]: { ... } }` (markdown)
 
 The SQLite result surfaces FTS on a nested namespace: `sqlite.fts.search({ table, query })` exists when `fts: {...}` was passed; when omitted, `sqlite.fts` is absent from the return type entirely. Single attach call, single `whenFlushed` barrier; the FTS DDL and triggers run between table DDL and the bulk insert so triggers populate `<table>_fts` for free.
 
-## The One Exception: Non-Ydoc Subject
+## Non-Ydoc Subject (rare)
 
-When a primitive modifies a sibling attachment and the coordination is cross-package (so it can't be a method on the coordinator), it's a top-level function with the attachment as first arg:
-
-```ts
-attachSessionUnlock(encryption, { sessions, serverUrl, waitFor })
-```
-
-This is rare: one example in the whole codebase. It lives in `@epicenter/cli` and operates on an `EncryptionAttachment` defined in `@epicenter/workspace`; making it a method on the workspace type would couple packages backwards, so it stays a top-level function.
-
-If the primitive is in-package with its coordinator, prefer method-on-coordinator (below) over a top-level `attachX(attachment, opts)`.
+When a primitive operates on a sibling attachment rather than the Y.Doc itself (cross-package coordination, for example), the subject is that attachment and the call shape stays `attachX(subject, opts)`. No examples currently in the repo; the pattern is documented in case it ever surfaces.
 
 ## Constructor primitives (the encryption case)
 

--- a/.agents/skills/workspace-api/references/actions-layout-and-attachments.md
+++ b/.agents/skills/workspace-api/references/actions-layout-and-attachments.md
@@ -222,7 +222,7 @@ Attachments compose through plain lexical scope, so ordering is explicit: if `op
 |---|---|---|
 | `attachYjsLog` | none | Starts loading the Yjs update log immediately |
 | `attachIndexedDb` | none | Starts loading IndexedDB immediately |
-| `attachEncryption` | (none, sync) | Reads `encryptionKeys()` synchronously at each registration site |
+| `attachEncryption` | (none, sync) | Reads `keyring()` once at construction, derives the per-workspace HKDF keyring, activates every store, returns `{ tables, kv }` |
 | `openCollaboration` | `idb.whenLoaded` (or another local-load promise) | Opens WebSocket after local replay |
 
 The standard shape is **persistence first, then collaboration with `waitFor`**:

--- a/.agents/skills/workspace-api/references/primitive-api.md
+++ b/.agents/skills/workspace-api/references/primitive-api.md
@@ -74,32 +74,28 @@ Each helper takes a `Y.Doc` and registers cleanup on `ydoc.on('destroy')`. Each 
 
 ## Encrypted Variants (from `@epicenter/workspace`)
 
-For workspaces that need at-rest encryption, the coordinator owns the sibling attachments as methods. There are no top-level `attachEncryptedX` exports.
+`attachEncryption` is a constructor primitive: pass the same definition records you'd hand to the plaintext primitives plus a `keyring` callback, and it returns the constructed encrypted handles atomically.
 
 | Helper | Purpose |
 |---|---|
-| `attachEncryption(ydoc, { encryptionKeys })` | Per-ydoc encryption coordinator. Returns `{ attachTable, attachTables, attachKv, attachIndexedDb, ... }`. Reads `encryptionKeys()` synchronously at every registration site. Teardown is synchronous and cascades from `ydoc.destroy()`. |
-| `encryption.attachTable(name, def)` | Singular encrypted table; self-registers with the coordinator and is activated with the current keyring before being returned. |
-| `encryption.attachTables(defs)` | Batch sugar over `encryption.attachTable`. |
-| `encryption.attachKv(defs)` | Encrypted KV singleton. |
-| `encryption.attachIndexedDb(targetYdoc, { userId })` | Encrypted local IndexedDB persistence for a root or child Y.Doc. |
+| `attachEncryption(ydoc, { keyring, tables, kv })` | Derives the per-workspace HKDF keyring once, constructs one encrypted store per table and one encrypted KV singleton, activates every store, and returns `{ tables, kv }`. Teardown is synchronous and cascades from `ydoc.destroy()`. |
 
 Standard composition:
 
 ```ts
-const ydoc       = new Y.Doc({ guid: id, gc: false });
-const encryption = attachEncryption(ydoc, {
-	encryptionKeys: () => requireSignedIn(auth).encryptionKeys,
+const ydoc = new Y.Doc({ guid: id, gc: false });
+const { tables, kv } = attachEncryption(ydoc, {
+	keyring: () => requireSignedIn(auth).keyring,
+	tables: myTables,
+	kv: myKv,
 });
-const tables     = encryption.attachTables(myTables);
-const kv         = encryption.attachKv(myKv);
 ```
 
-Keys are read through the `encryptionKeys` callback when an encrypted resource is attached. There is no separate `applyKeys` step: registration and activation happen in one call. Already-attached encrypted stores keep the keyring they derived at attach time; same-user key rotation needs a re-attach to affect those stores. `encryptionKeys()` should throw if no keys are available (for example, signed-out): a throw means the workspace outlived its signed-in scope, which is a caller bug. The `requireSignedIn(auth)` helper from `@epicenter/auth` does exactly that.
+Keys are read through the `keyring` callback once at construction. There is no separate `applyKeys` step and no temporal registration window: registration and activation happen in one call. Same-owner key rotation requires a fresh `attachEncryption` call (and therefore a fresh Y.Doc) for those stores to pick up rotated keys. `keyring()` should throw if no keys are available (for example, signed-out): a throw means the workspace outlived its signed-in scope, which is a caller bug. The `requireSignedIn(auth)` helper from `@epicenter/auth` does exactly that.
 
-Encryption is opt-in per slot; the coordinator carries the intent. Plaintext `attachTable(ydoc, name, def)` (top-level) and encrypted `encryption.attachTable(name, def)` (method) are both available; pick one per slot.
+Encryption is opt-in per slot; the primitive carries the intent. Plaintext `attachTable(ydoc, name, def)` (top-level) and encrypted entries inside `attachEncryption({ tables })` are both available; pick one per slot.
 
-> **Never mix plaintext and encrypted wrappers on the same slot name.** Yjs returns the same underlying `Y.Array` to `attachTable(ydoc, 'posts', ...)` and `encryption.attachTable('posts', ...)` because `ydoc.getArray('table:posts')` is idempotent. If both run, the plaintext wrapper writes plaintext into the same yarray the encrypted wrapper thinks it owns, a silent data-at-rest leak. The framework does not catch this; the grep-able call-site shape (`encryption.attach*` vs top-level `attach*`) is the defense. One slot name, one variant, one intent.
+> **Never pair a plaintext `attachTable` with the same slot name in `attachEncryption({ tables })`.** Yjs returns the same underlying `Y.Array` from `ydoc.getArray('table:posts')` to both, so a plaintext wrapper would write plaintext into the same yarray the encrypted wrapper thinks it owns: a silent data-at-rest leak. The framework does not catch this. One slot name, one variant, one intent.
 
 IDB / broadcast / collaboration / sqlite transitively see already-encrypted bytes once encryption is registered. The Yjs update stream carries ciphertext blobs inside it. No additional encryption setup is needed at those transport layers.
 

--- a/.agents/skills/workspace-app-layout/SKILL.md
+++ b/.agents/skills/workspace-app-layout/SKILL.md
@@ -78,28 +78,30 @@ The iso factory accepts an optional `clientID` so daemon and script peers can
 use stable Yjs identities.
 
 ```ts
-import { attachEncryption, type EncryptionKeys } from '@epicenter/workspace';
+import type { Keyring } from '@epicenter/encryption';
+import { attachEncryption } from '@epicenter/workspace';
 import * as Y from 'yjs';
 import { createFujiActions, fujiTables } from '../workspace.js';
 
 export function openFuji({
-	encryptionKeys,
+	keyring,
 	clientID,
 }: {
-	encryptionKeys: () => EncryptionKeys;
+	keyring: () => Keyring;
 	clientID?: number;
 }) {
 	const ydoc = new Y.Doc({ guid: 'epicenter.fuji', gc: false });
 	if (clientID !== undefined) ydoc.clientID = clientID;
-	const encryption = attachEncryption(ydoc, { encryptionKeys });
-	const tables = encryption.attachTables(fujiTables);
-	const kv = encryption.attachKv({});
+	const { tables, kv } = attachEncryption(ydoc, {
+		keyring,
+		tables: fujiTables,
+		kv: {},
+	});
 	const actions = createFujiActions(tables);
 	return {
 		ydoc,
 		tables,
 		kv,
-		encryption,
 		actions,
 		batch: (fn: () => void) => ydoc.transact(fn),
 		[Symbol.dispose]() {

--- a/apps/fuji/README.md
+++ b/apps/fuji/README.md
@@ -50,9 +50,11 @@ export function openFujiBrowser({
   deviceId: string;
 }) {
   const ydoc = new Y.Doc({ guid: FUJI_ID, gc: true });
-  const encryption = attachEncryption(ydoc, { keyring: signedIn.keyring });
-  const tables = encryption.attachTables(fujiTables);
-  const kv = encryption.attachKv({});
+  const { tables, kv } = attachEncryption(ydoc, {
+    keyring: signedIn.keyring,
+    tables: fujiTables,
+    kv: {},
+  });
   const actions = createFujiActions(tables);
 
   const idb = attachLocalStorage(ydoc, {

--- a/apps/fuji/daemon.ts
+++ b/apps/fuji/daemon.ts
@@ -42,9 +42,11 @@ export function openFujiDaemon({
 }: DaemonWorkspaceContext) {
 	const ydoc = new Y.Doc({ guid: FUJI_ID, gc: true });
 	ydoc.clientID = yDocClientId;
-	const encryption = attachEncryption(ydoc, { keyring });
-	const tables = encryption.attachTables(fujiTables);
-	encryption.attachKv({});
+	const { tables } = attachEncryption(ydoc, {
+		keyring,
+		tables: fujiTables,
+		kv: {},
+	});
 	const actions = createFujiActions(tables);
 
 	attachBunSqliteMaterializer(ydoc, {

--- a/apps/fuji/src/lib/browser.ts
+++ b/apps/fuji/src/lib/browser.ts
@@ -46,9 +46,11 @@ export function openFujiBrowser({
 	deviceId: DeviceId;
 }) {
 	const ydoc = new Y.Doc({ guid: FUJI_ID, gc: true });
-	const encryption = attachEncryption(ydoc, { keyring: signedIn.keyring });
-	const tables = encryption.attachTables(fujiTables);
-	const kv = encryption.attachKv({});
+	const { tables, kv } = attachEncryption(ydoc, {
+		keyring: signedIn.keyring,
+		tables: fujiTables,
+		kv: {},
+	});
 	const actions = createFujiActions(tables);
 
 	const idb = attachLocalStorage(ydoc, {

--- a/apps/honeycrisp/browser.ts
+++ b/apps/honeycrisp/browser.ts
@@ -46,9 +46,11 @@ export function openHoneycrispBrowser({
 	deviceId: DeviceId;
 }) {
 	const ydoc = new Y.Doc({ guid: HONEYCRISP_ID, gc: true });
-	const encryption = attachEncryption(ydoc, { keyring: signedIn.keyring });
-	const tables = encryption.attachTables(honeycrispTables);
-	const kv = encryption.attachKv({});
+	const { tables, kv } = attachEncryption(ydoc, {
+		keyring: signedIn.keyring,
+		tables: honeycrispTables,
+		kv: {},
+	});
 	const actions = createHoneycrispActions(tables);
 
 	const idb = attachLocalStorage(ydoc, {

--- a/apps/honeycrisp/daemon.ts
+++ b/apps/honeycrisp/daemon.ts
@@ -47,9 +47,11 @@ export function openHoneycrispDaemon({
 }: DaemonWorkspaceContext) {
 	const ydoc = new Y.Doc({ guid: HONEYCRISP_ID, gc: true });
 	ydoc.clientID = yDocClientId;
-	const encryption = attachEncryption(ydoc, { keyring });
-	const tables = encryption.attachTables(honeycrispTables);
-	encryption.attachKv({});
+	const { tables } = attachEncryption(ydoc, {
+		keyring,
+		tables: honeycrispTables,
+		kv: {},
+	});
 	const actions = createHoneycrispActions(tables);
 
 	attachBunSqliteMaterializer(ydoc, {

--- a/apps/opensidian/daemon.ts
+++ b/apps/opensidian/daemon.ts
@@ -32,9 +32,11 @@ export function openOpensidianDaemon({
 }: DaemonWorkspaceContext) {
 	const ydoc = new Y.Doc({ guid: OPENSIDIAN_ID, gc: true });
 	ydoc.clientID = yDocClientId;
-	const encryption = attachEncryption(ydoc, { keyring });
-	encryption.attachTables(opensidianTables);
-	encryption.attachKv({});
+	attachEncryption(ydoc, {
+		keyring,
+		tables: opensidianTables,
+		kv: {},
+	});
 
 	return attachDaemonInfrastructure(ydoc, {
 		projectDir,

--- a/apps/opensidian/src/lib/opensidian/browser.ts
+++ b/apps/opensidian/src/lib/opensidian/browser.ts
@@ -52,9 +52,11 @@ export function openOpensidianBrowser({
 	deviceId: DeviceId;
 }) {
 	const ydoc = new Y.Doc({ guid: OPENSIDIAN_ID, gc: true });
-	const encryption = attachEncryption(ydoc, { keyring: signedIn.keyring });
-	const tables = encryption.attachTables(opensidianTables);
-	const kv = encryption.attachKv({});
+	const { tables, kv } = attachEncryption(ydoc, {
+		keyring: signedIn.keyring,
+		tables: opensidianTables,
+		kv: {},
+	});
 
 	const idb = attachLocalStorage(ydoc, {
 		server: signedIn.server,

--- a/apps/tab-manager/src/lib/tab-manager/extension.ts
+++ b/apps/tab-manager/src/lib/tab-manager/extension.ts
@@ -47,9 +47,11 @@ export function openTabManagerBrowser({
 	deviceId: DeviceId;
 }) {
 	const ydoc = new Y.Doc({ guid: TAB_MANAGER_ID, gc: true });
-	const encryption = attachEncryption(ydoc, { keyring: signedIn.keyring });
-	const tables = encryption.attachTables(tabManagerTables);
-	const kv = encryption.attachKv({});
+	const { tables, kv } = attachEncryption(ydoc, {
+		keyring: signedIn.keyring,
+		tables: tabManagerTables,
+		kv: {},
+	});
 	const actions = createTabManagerActions({
 		tables,
 		batch: (fn) => ydoc.transact(fn),

--- a/apps/tab-manager/src/lib/workspace/definition.ts
+++ b/apps/tab-manager/src/lib/workspace/definition.ts
@@ -276,10 +276,9 @@ export type ToolTrust = InferTableRow<typeof toolTrustTable>;
 
 /**
  * Table definitions for the tab-manager workspace. Composed in
- * `lib/tab-manager/extension.ts` via `encryption.attachTables(tabManagerTables)`
- * against an `attachEncryption(ydoc, { keyring })` attachment.
- * Kept separate so actions and future consumers can derive their input
- * types from one source of truth.
+ * `lib/tab-manager/extension.ts` via `attachEncryption(ydoc, { keyring,
+ * tables: tabManagerTables, kv })`. Kept separate so actions and future
+ * consumers can derive their input types from one source of truth.
  */
 export const tabManagerTables = {
 	devices: devicesTable,

--- a/apps/zhongwen/daemon.ts
+++ b/apps/zhongwen/daemon.ts
@@ -24,9 +24,11 @@ export function openZhongwenDaemon({
 }: DaemonWorkspaceContext) {
 	const ydoc = new Y.Doc({ guid: ZHONGWEN_ID, gc: true });
 	ydoc.clientID = yDocClientId;
-	const encryption = attachEncryption(ydoc, { keyring });
-	encryption.attachTables(zhongwenTables);
-	encryption.attachKv(zhongwenKv);
+	attachEncryption(ydoc, {
+		keyring,
+		tables: zhongwenTables,
+		kv: zhongwenKv,
+	});
 
 	return attachDaemonInfrastructure(ydoc, {
 		projectDir,

--- a/apps/zhongwen/src/routes/(signed-in)/zhongwen/browser.ts
+++ b/apps/zhongwen/src/routes/(signed-in)/zhongwen/browser.ts
@@ -34,9 +34,11 @@ export function openZhongwenBrowser({
 	deviceId: DeviceId;
 }) {
 	const ydoc = new Y.Doc({ guid: ZHONGWEN_ID, gc: true });
-	const encryption = attachEncryption(ydoc, { keyring: signedIn.keyring });
-	const tables = encryption.attachTables(zhongwenTables);
-	const kv = encryption.attachKv(zhongwenKv);
+	const { tables, kv } = attachEncryption(ydoc, {
+		keyring: signedIn.keyring,
+		tables: zhongwenTables,
+		kv: zhongwenKv,
+	});
 
 	const idb = attachLocalStorage(ydoc, {
 		server: signedIn.server,

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -50,7 +50,7 @@ The HKDF info string at the owner derivation step is the literal `owner:{ownerId
 
 On the server, `apps/api/src/auth/encryption.ts` reads `ENCRYPTION_SECRETS` from the worker env and calls `@epicenter/encryption`'s `deriveKeyring` to parse the root keyring and derive a per-owner keyring.
 It returns one `{ version, keyBytesBase64 }` entry per configured root keyring version.
-On the client, the encryption coordinator (`attachEncryption(ydoc, { keyring })`) reads `keyring()` synchronously at every `attachTable` / `attachTables` / `attachKv` site, decodes each `keyBytesBase64`, runs `deriveWorkspaceKey(ownerKey, workspaceId)`, and gets a 32-byte workspace key with `info = workspace:{workspaceId}`.
+On the client, `attachEncryption(ydoc, { keyring, tables, kv })` reads `keyring()` once at construction, decodes each `keyBytesBase64`, runs `deriveWorkspaceKey(ownerKey, workspaceId)`, and gets a 32-byte workspace key with `info = workspace:{workspaceId}`. The derived keyring activates every encrypted store atomically before any handle is returned.
 The highest version becomes the current key for new writes.
 
 ## How keys reach the client
@@ -58,7 +58,7 @@ Keys come through `/api/session`.
 `apps/api/src/app.ts` mounts `GET /api/session` behind cookie-or-bearer authentication. A valid Better Auth cookie session or a valid API-audience bearer token for the user can fetch `{ user: { id, email }, ownerId, keyring, mode }`, where `ownerId` is a branded id (the user's id in personal mode, the literal `team` in team mode) and `mode` is the orthogonal `OwnershipMode` flag.
 `@epicenter/auth` calls `/api/session` at sign-in and at cold-boot when online, persists `{ ownerId, keyring, mode }` alongside the OAuth grant in the persisted auth cell, and exposes them through `auth.state.ownerId` / `auth.state.keyring` / `auth.state.mode` whenever the auth state is not `signed-out`.
 Cold-boot offline keeps the cached `{ ownerId, keyring, mode }` so the workspace can decrypt local Yjs data without a network roundtrip; the bearer is not attached to outbound requests until `/api/session` re-confirms the cell in this runtime.
-The workspace does not hold an independently mutable copy of the keys. `attachEncryption` takes a `keyring` callback and calls it when an encrypted table or KV store attaches; `attachLocalStorage` takes the same callback and calls it on every persisted update. Each attached store keeps the keyring derived at that attachment boundary. Browser app session modules receive a flat `SignedIn` payload from `createSession`; that payload carries the lazy keyring reader and the stable owner:
+The workspace does not hold an independently mutable copy of the keys. `attachEncryption` takes a `keyring` callback and calls it once at construction; `attachLocalStorage` takes the same callback and calls it on every persisted update. Each encrypted store keeps the keyring derived at its `attachEncryption` boundary. Browser app session modules receive a flat `SignedIn` payload from `createSession`; that payload carries the lazy keyring reader and the stable owner:
 ```ts
 import { createSession, type SignedIn } from '@epicenter/svelte';
 
@@ -73,7 +73,7 @@ export const session = createSession({
 ```
 `SignedIn` is `{ server: string; ownerId: OwnerId; mode: OwnershipMode; keyring: () => Keyring; auth: AuthClient }`. `ownerId` and `mode` are derived from the auth signed-in state and stay stable for the lifetime of a single `SignedIn` payload. `keyring` is a callback that reads the current `keyring` from `auth.state`, so same-owner rotations (e.g. `reauth-required` -> identity-bearing) are picked up on the next call without rebuilding the payload. `auth` is the live `AuthClient`; `openCollaboration({ openWebSocket, onReconnectSignal })` uses `auth.openWebSocket` to open the relay socket and subscribes to `auth.onStateChange` to drive reconnect, so per-app openers do not write reconnect glue. A different-owner sign-in publishes a `signed-out` gap first, which disposes the payload and rebuilds with the new owner.
 
-Same-owner identity updates do not remount the workspace. Auth callbacks read `auth.state` at the boundary that asks for them: sync can see refreshed bearer tokens on connection attempts, encrypted-store registrations re-derive on each new `attachTable` / `attachKv` call, and `attachLocalStorage`'s IDB writes pick up rotated keys on the next persisted update. Already-attached encrypted tables and KVs keep the keyring they derived when they were attached.
+Same-owner identity updates do not remount the workspace. Auth callbacks read `auth.state` at the boundary that asks for them: sync can see refreshed bearer tokens on connection attempts, and `attachLocalStorage`'s IDB writes pick up rotated keys on the next persisted update. Already-attached encrypted tables and KVs keep the keyring they derived when `attachEncryption` was called; a fresh `attachEncryption` (and therefore a fresh Y.Doc) is required for them to pick up rotated keys.
 
 Daemon-side openers receive the same shape via `DaemonWorkspaceContext`: `{ projectDir, route, yDocClientId, installationId, ownerId, keyring: () => Keyring, openWebSocket, onReconnectSignal }`. The host's `keyring` closure throws when auth is signed-out, so a late sign-out becomes a thrown error at the next encrypted-write or registration site rather than silent ciphertext loss. The `openWebSocket` and `onReconnectSignal` refs flow through to `attachDaemonInfrastructure({ openWebSocket, onReconnectSignal })` for cloud sync.
 
@@ -81,7 +81,7 @@ Daemon-side openers receive the same shape via `DaemonWorkspaceContext`: `{ proj
 Authenticated browser workspaces open local IndexedDB only after auth has settled into an identity-bearing state. The session module guarantees that boundary: it builds the workspace lazily once auth produces a `SignedIn` payload and disposes it on sign-out.
 
 Two attachments cover the local-data surface and they read directly off the same `SignedIn` payload:
-- `attachEncryption(ydoc, { keyring })` binds the per-workspace HKDF keyring across `attachTable(s)` and `attachKv` calls. The coordinator does not own local storage: it only derives keys and activates the encrypted CRDT wrappers.
+- `attachEncryption(ydoc, { keyring, tables, kv })` derives the per-workspace HKDF keyring and constructs every encrypted table and KV store in one atomic call. The primitive does not own local storage: it only derives keys and activates the encrypted CRDT wrappers.
 - `attachLocalStorage(ydoc, { server, ownerId, keyring })` opens `(server, ownerId)`-scoped encrypted IndexedDB persistence and pairs it with a matching `BroadcastChannel` under the same name. The `server` and `ownerId` are snapshotted at attach time (stable for the attachment lifetime), and `keyring` is a callback so the IDB layer picks up rotated keys on the next persisted update.
 
 The browser factory shape is (from `apps/fuji/src/lib/browser.ts`):
@@ -94,9 +94,11 @@ export function openFujiBrowser({
 	installationId: string;
 }) {
 	const ydoc = new Y.Doc({ guid: FUJI_ID, gc: true });
-	const encryption = attachEncryption(ydoc, { keyring: signedIn.keyring });
-	const tables = encryption.attachTables(fujiTables);
-	const kv = encryption.attachKv({});
+	const { tables, kv } = attachEncryption(ydoc, {
+		keyring: signedIn.keyring,
+		tables: fujiTables,
+		kv: {},
+	});
 
 	const idb = attachLocalStorage(ydoc, {
 		server: signedIn.server,
@@ -249,7 +251,7 @@ Before activation, the wrapper is a passthrough store and `set()` writes plainte
 After activation, `set()` always encrypts.
 The active state holds the full keyring, the current key, and the current key version.
 Calling `activateEncryption()` again updates that state to a new keyring, but it does not switch the store back to plaintext mode.
-The document builder reinforces that shape: `attachEncryption(ydoc, { keyring })` returns a coordinator whose `encryption.attachTable(name, def)` / `encryption.attachTables(defs)` / `encryption.attachKv(defs)` methods register every table and KV store as encrypted wrappers from the start. The coordinator calls `keyring()` synchronously at each registration site, derives the per-workspace keyring with `deriveWorkspaceKeyring(ownerKeyring, ydoc.guid)`, and activates the store before handing it back. There is no separate `applyKeys` mutation step: key read, registration, and activation happen in one call.
+The document builder reinforces that shape: `attachEncryption(ydoc, { keyring, tables, kv })` takes the full table and KV definition record up front and returns the constructed encrypted handles atomically. It reads `keyring()` once, derives the per-workspace keyring with `deriveWorkspaceKeyring(ownerKeyring, ydoc.guid)`, and activates every store before any handle is returned. There is no separate `applyKeys` mutation step and no temporal registration window: key read, registration, and activation happen in one call.
 
 ## What activation re-encrypts
 Activation rewrites every decryptable entry that is not already stored under the current key version.

--- a/docs/guides/consuming-epicenter-api.md
+++ b/docs/guides/consuming-epicenter-api.md
@@ -62,9 +62,11 @@ export function openMyAppBrowser({
 	installationId: string;
 }) {
 	const ydoc = new Y.Doc({ guid: MY_APP_ID, gc: true });
-	const encryption = attachEncryption(ydoc, { keyring: signedIn.keyring });
-	const tables = encryption.attachTables(myAppTables);
-	const kv = encryption.attachKv({});
+	const { tables, kv } = attachEncryption(ydoc, {
+		keyring: signedIn.keyring,
+		tables: myAppTables,
+		kv: {},
+	});
 	const actions = {
 		notes_create: async ({ id, title }: { id: string; title: string }) => {
 			tables.notes.create({ id, title, _v: 1 });

--- a/examples/fuji/epicenter.config.ts
+++ b/examples/fuji/epicenter.config.ts
@@ -43,9 +43,11 @@ export default defineWorkspace({
 	}) {
 		const ydoc = new Y.Doc({ guid: FUJI_ID, gc: true });
 		ydoc.clientID = yDocClientId;
-		const encryption = attachEncryption(ydoc, { keyring });
-		const tables = encryption.attachTables(fujiTables);
-		encryption.attachKv({});
+		const { tables } = attachEncryption(ydoc, {
+			keyring,
+			tables: fujiTables,
+			kv: {},
+		});
 		const actions = createFujiActions(tables);
 
 		// Runtime cache: hidden under .epicenter/ at the project root.

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -112,7 +112,7 @@ Every exported function in this package falls into one of three verbs. The prefi
 | Verb | Side effect | Input | Output | Examples |
 |---|---|---|---|---|
 | `define*` | **None**: pure data | Schemas, defaults | Plain config object | `defineTable`, `defineKv`, `defineMutation`, `defineQuery` |
-| `attach*` | **Mutates a Y.Doc**: binds a slot, registers `ydoc.on('destroy')` | An existing `Y.Doc` + config | Typed handle, non-idempotent, hold the reference | `attachTable`, `attachTables`, `attachKv`, `attachRichText`, `attachPlainText`, `attachTimeline`, `attachIndexedDb`, `attachYjsLog`, `attachBroadcastChannel`, `attachEncryption` (with `.attachTable` / `.attachTables` / `.attachKv` methods), `attachMarkdownMaterializer`, `attachSqliteMaterializer` |
+| `attach*` | **Mutates a Y.Doc**: binds a slot, registers `ydoc.on('destroy')` | An existing `Y.Doc` + config | Typed handle, non-idempotent, hold the reference | `attachTable`, `attachTables`, `attachKv`, `attachRichText`, `attachPlainText`, `attachTimeline`, `attachIndexedDb`, `attachYjsLog`, `attachBroadcastChannel`, `attachEncryption` (constructs `{ tables, kv }` from definitions), `attachMarkdownMaterializer`, `attachSqliteMaterializer` |
 | `create*` | **Pure construction**: no listeners, no subscriptions, no destroy registration at call time. | Definitions or a builder closure | A usable definition or cache | `createDisposableCache` |
 | `open*` | **Opens a runtime over a Y.Doc or a local resource**: returns a typed handle with its own teardown. The Y.Doc-bound case (`openCollaboration`) registers `ydoc.on('destroy')` like `attach*` does; the resource case (`openSqliteReader`) takes no Y.Doc and returns a `[Symbol.dispose]()` handle. | Y.Doc + config, or resource config | Typed runtime handle | `openCollaboration`, `openSqliteReader`, `openWriterSqlite` |
 
@@ -126,9 +126,9 @@ refcounting, and the `gcTime` grace period between last dispose and teardown.
 Both variants ship from this package. Pick by adversary: plaintext for
 data that never leaves the device, encrypted for data the server stores.
 
-Plaintext (`attachTable`, `attachTables`, `attachKv`) binds a typed helper directly to the Y.Doc. Encrypted: the methods on the `EncryptionAttachment` coordinator returned by `attachEncryption(ydoc, { keyring })` (`encryption.attachTable`, `encryption.attachTables`, `encryption.attachKv`) additionally register their backing store with that coordinator. The coordinator reads `keyring()` synchronously at each registration site, derives the per-workspace keyring, and activates the store before handing it back. Already-attached encrypted stores keep their derived keyring; same-owner key rotation needs a re-attach to affect those stores.
+Plaintext (`attachTable`, `attachTables`, `attachKv`) binds a typed helper directly to the Y.Doc. Encrypted: `attachEncryption(ydoc, { keyring, tables, kv })` takes the same definition maps as the plaintext primitives plus a `keyring` callback, derives the per-workspace keyring once, activates every encrypted store, and returns `{ tables, kv }` atomically. Same-owner key rotation requires a fresh `attachEncryption` call (and therefore a fresh Y.Doc) to take effect.
 
-Don't mix plaintext and encrypted wrappers on the same slot name: Yjs hands both calls the same underlying `Y.Array` and you get a silent plaintext-over-ciphertext race. The verb (`encryption.attachTable` vs plain `attachTable`) is the primary defense; review call sites accordingly. One slot name, one attach site, one intent.
+Don't pair a plaintext `attachTable` with a `tables:` entry on `attachEncryption` targeting the same slot name: Yjs hands both calls the same underlying `Y.Array` and you get a silent plaintext-over-ciphertext race. One slot name, one attach site, one intent.
 
 Minimal encrypted browser workspace: encryption + owner-scoped IndexedDB + cross-tab + collaboration (sync + presence + dispatch) wired together:
 
@@ -155,8 +155,11 @@ export function openApp({
 }) {
 	const ydoc = new Y.Doc({ guid: 'epicenter.my-app', gc: true });
 
-	const encryption = attachEncryption(ydoc, { keyring: signedIn.keyring });
-	const tables = encryption.attachTables(appTables);
+	const { tables } = attachEncryption(ydoc, {
+		keyring: signedIn.keyring,
+		tables: appTables,
+		kv: {},
+	});
 
 	// Server + owner scoped encrypted IDB + cross-tab BroadcastChannel in one call.
 	const idb = attachLocalStorage(ydoc, {

--- a/packages/workspace/src/document/README.md
+++ b/packages/workspace/src/document/README.md
@@ -15,7 +15,7 @@ The pattern: a vanilla `openX()` function constructs the workspace's `Y.Doc`, co
 | function openBlog(): { ydoc, tables, ...; dispose }            |
 +----------------------------------------------------------------+
 | attachTable / attachTables / attachKv                          |
-| attachEncryption -> .attachTable / .attachTables / .attachKv    |
+| attachEncryption({ keyring, tables, kv }) -> { tables, kv }    |
 | attachIndexedDb / attachYjsLog / attachBroadcastChannel        |
 | attachLocalStorage(ydoc, { server, ownerId, keyring })  // encrypted IDB + scoped BC |
 | wipeLocalStorage({ server, ownerId })           // delete local data for owner |
@@ -69,7 +69,7 @@ The factory body is where you wire everything. Because you own the return shape,
 
 ### Encryption (server-managed value encryption)
 
-The encryption coordinator owns sibling attachments: `attachTable` / `attachTables` / `attachKv` are methods on it, not top-level exports.
+`attachEncryption(ydoc, { keyring, tables, kv })` takes the same definition maps as the plaintext primitives, derives the per-workspace keyring once, activates every encrypted store, and returns the constructed handles in one call.
 
 ```typescript
 import { attachEncryption } from '@epicenter/workspace';
@@ -77,10 +77,12 @@ import type { Keyring } from '@epicenter/encryption';
 
 function openBlog({ keyring }: { keyring: () => Keyring }) {
   const ydoc = new Y.Doc({ guid: 'blog' });
-  const encryption = attachEncryption(ydoc, { keyring });
-  const tables = encryption.attachTables(myTables);
-  const kv = encryption.attachKv(myKv);
-  return { ydoc, tables, kv, encryption, [Symbol.dispose]() { ydoc.destroy(); } };
+  const { tables, kv } = attachEncryption(ydoc, {
+    keyring,
+    tables: myTables,
+    kv: myKv,
+  });
+  return { ydoc, tables, kv, [Symbol.dispose]() { ydoc.destroy(); } };
 }
 ```
 
@@ -110,8 +112,11 @@ function openBlog({
   deviceId: string;
 }) {
   const ydoc = new Y.Doc({ guid: 'blog' });
-  const encryption = attachEncryption(ydoc, { keyring: signedIn.keyring });
-  const tables = encryption.attachTables(myTables);
+  const { tables } = attachEncryption(ydoc, {
+    keyring: signedIn.keyring,
+    tables: myTables,
+    kv: {},
+  });
 
   // Server + owner scoped encrypted IDB + cross-tab BroadcastChannel in one call.
   const idb = attachLocalStorage(ydoc, {

--- a/packages/workspace/src/document/attach-encryption.test.ts
+++ b/packages/workspace/src/document/attach-encryption.test.ts
@@ -1,6 +1,6 @@
 /**
- * attachEncryption tests: keyring lookup failures surface at registration,
- * and readonly helpers expose encrypted reads without write methods.
+ * attachEncryption tests: keyring lookup failures surface at construction,
+ * and constructed table/kv handles are typed and active.
  *
  * Encrypted IndexedDB and owner-scoped BroadcastChannel behavior live on
  * `attachLocalStorage`; see `attach-local-storage.test.ts` for those
@@ -11,81 +11,66 @@ import { describe, expect, test } from 'bun:test';
 import type { Keyring } from '@epicenter/encryption';
 import { bytesToBase64 } from '@epicenter/encryption';
 import { randomBytes } from '@noble/ciphers/utils.js';
+import { Type } from 'typebox';
 import * as Y from 'yjs';
 import { attachEncryption } from './attach-encryption.js';
 import { column } from './column/index.js';
+import { defineKv } from './define-kv.js';
 import { defineTable } from './define-table.js';
 
 function toKeyring(key: Uint8Array): Keyring {
 	return [{ version: 1, keyBytesBase64: bytesToBase64(key) }];
 }
 
-const encryptedRowDefinition = defineTable({
+const entries = defineTable({
 	id: column.string(),
 	title: column.string(),
 });
 
 describe('attachEncryption', () => {
-	test('keyring callback throwing at registration surfaces the throw', () => {
+	test('keyring callback throwing at construction surfaces the throw', () => {
 		const ydoc = new Y.Doc({ guid: 'enc-no-keys', gc: true });
-		const encryption = attachEncryption(ydoc, {
-			keyring: () => {
-				throw new Error('not signed-in');
-			},
-		});
-		expect(() => encryption.attachTable('a', encryptedRowDefinition)).toThrow(
-			'not signed-in',
-		);
+		expect(() =>
+			attachEncryption(ydoc, {
+				keyring: () => {
+					throw new Error('not signed-in');
+				},
+				tables: { entries },
+				kv: {},
+			}),
+		).toThrow('not signed-in');
 	});
 
-	test('attachReadonlyTable reads encrypted rows without exposing writes', () => {
+	test('returns typed encrypted table handles keyed by definition name', () => {
 		const keyring = toKeyring(randomBytes(32));
-		const ydoc = new Y.Doc({ guid: 'enc-readonly-table', gc: true });
-		const encryption = attachEncryption(ydoc, { keyring: () => keyring });
-		const definition = defineTable({
-			id: column.string(),
-			title: column.string(),
+		const ydoc = new Y.Doc({ guid: 'enc-tables', gc: true });
+		const { tables } = attachEncryption(ydoc, {
+			keyring: () => keyring,
+			tables: { entries },
+			kv: {},
 		});
-		const writer = encryption.attachTable('entries', definition);
-		const reader = encryption.attachReadonlyTable('entries', definition);
 
-		writer.set({ id: '1', title: 'Secret row' });
+		tables.entries.set({ id: '1', title: 'Secret row' });
 
-		expect(reader.get('1').data).toEqual({
+		expect(tables.entries.get('1').data).toEqual({
 			id: '1',
 			title: 'Secret row',
 		});
-		expect('set' in reader).toBe(false);
-		expect('bulkSet' in reader).toBe(false);
-		expect('update' in reader).toBe(false);
-		expect('delete' in reader).toBe(false);
-		expect('bulkDelete' in reader).toBe(false);
-		expect('clear' in reader).toBe(false);
 	});
 
-	test('attachReadonlyTables returns readonly helpers keyed by definition', () => {
+	test('returns a typed encrypted KV handle backed by the same ydoc', () => {
 		const keyring = toKeyring(randomBytes(32));
-		const ydoc = new Y.Doc({ guid: 'enc-readonly-tables', gc: true });
-		const encryption = attachEncryption(ydoc, { keyring: () => keyring });
-		const definition = defineTable({
-			id: column.string(),
-			title: column.string(),
-		});
-		const writers = encryption.attachTables({ entries: definition });
-		const readers = encryption.attachReadonlyTables({
-			entries: definition,
+		const ydoc = new Y.Doc({ guid: 'enc-kv', gc: true });
+		const { kv } = attachEncryption(ydoc, {
+			keyring: () => keyring,
+			tables: {},
+			kv: {
+				theme: defineKv(Type.String(), () => 'dark'),
+			},
 		});
 
-		writers.entries.set({ id: '1', title: 'Secret row' });
-
-		expect(readers.entries.getAllValid()).toEqual([
-			{ id: '1', title: 'Secret row' },
-		]);
-		expect('set' in readers.entries).toBe(false);
-		expect('bulkSet' in readers.entries).toBe(false);
-		expect('update' in readers.entries).toBe(false);
-		expect('delete' in readers.entries).toBe(false);
-		expect('bulkDelete' in readers.entries).toBe(false);
-		expect('clear' in readers.entries).toBe(false);
+		expect(kv.get('theme')).toBe('dark');
+		kv.set('theme', 'light');
+		expect(kv.get('theme')).toBe('light');
 	});
 });

--- a/packages/workspace/src/document/attach-encryption.ts
+++ b/packages/workspace/src/document/attach-encryption.ts
@@ -1,8 +1,8 @@
 /**
- * attachEncryption: per-ydoc encryption coordinator.
+ * attachEncryption: per-ydoc constructor for the workspace's encrypted stores.
  *
  * A workspace owns several `EncryptedYKeyValueLww` stores (one per table plus
- * the KV store). This attachment derives a per-workspace HKDF keyring at
+ * the KV store). This primitive derives a per-workspace HKDF keyring at
  * construction time, activates every store, and returns the constructed
  * encrypted handles atomically:
  *

--- a/packages/workspace/src/document/attach-encryption.ts
+++ b/packages/workspace/src/document/attach-encryption.ts
@@ -3,32 +3,34 @@
  *
  * A workspace owns several `EncryptedYKeyValueLww` stores (one per table plus
  * the KV store). This attachment derives a per-workspace HKDF keyring at
- * attach time and calls `activateEncryption(keyring)` on each store before
- * the caller gets it back. Call the methods on the returned attachment to
- * register encrypted resources:
+ * construction time, activates every store, and returns the constructed
+ * encrypted handles atomically:
  *
  * ```ts
- * const encryption = attachEncryption(ydoc, { keyring: () => ownerKeyring });
- * const tables = encryption.attachTables(defs);
- * const kv = encryption.attachKv(defs);
+ * const { tables, kv } = attachEncryption(ydoc, {
+ *   keyring: () => ownerKeyring,
+ *   tables: tableDefs,
+ *   kv: kvDefs,
+ * });
  * ```
  *
- * The method names mirror the plaintext primitives (`attachTable`,
- * `attachTables`, `attachKv`) so the pattern reads symmetrically:
- * "encryption's attach-tables" vs "plain attach-tables."
+ * Slots are *definition maps* (not handles): encryption constructs the
+ * encrypted store for every entry. Compare to the materializer primitives,
+ * whose `tables:` slot takes already-constructed handles to mirror; here
+ * `tables:` takes the same `TableDefinitions` you'd hand to plaintext
+ * `attachTables`, and encryption returns the constructed `Tables<T>`.
  *
- * ## Key source: lazy callback
+ * ## Key source: lazy callback, single derivation
  *
- * `keyring` is a callback into whoever owns identity. The coordinator calls
- * it synchronously at every `attachTable` / `attachKv` site, derives the
- * per-workspace keyring, and activates the store. The keyring is not cached
- * on the attachment: each attach call is its own derivation, which keeps
- * state out of this layer entirely.
+ * `keyring` is a callback into whoever owns identity. It's invoked once at
+ * construction, derived into a per-workspace keyring via HKDF, and that
+ * keyring activates every store before any handle is returned. Throw inside
+ * `keyring()` if no keyring is available (e.g. signed-out): a throw here
+ * means the workspace outlived its signed-in scope, which is a caller bug.
  *
  * Same-owner identity updates (key rotation, profile edits) do not flow
  * through this attachment. Authenticated apps reload the page on
- * different-owner transitions; same-owner updates are observed lazily
- * via the `keyring` callback the next time it runs.
+ * different-owner transitions.
  *
  * ## Local persistence concerns live elsewhere
  *
@@ -41,21 +43,20 @@
  *
  * ## Disposal
  *
- * Each attached store hooks `ydoc.once('destroy', ...)` at attach time,
- * mirroring the plaintext `attachTable` / `attachKv` primitives. Callers tear
- * down encryption by calling `ydoc.destroy()`: the attachment does not expose
- * a standalone `dispose()` method.
+ * Each store hooks `ydoc.once('destroy', ...)` at construction, mirroring the
+ * plaintext `attachTable` / `attachKv` primitives. Callers tear down
+ * encryption by calling `ydoc.destroy()`: the attachment does not expose a
+ * standalone `dispose()` method.
  *
  * ## What this attachment does NOT do
  *
  * - It does not wipe local storage. `wipeLocalStorage({ server, ownerId })` owns that.
  * - It does not validate that every encryption-capable slot on the Y.Doc got
  *   registered. The caller owns the composition: if you pair a plaintext
- *   `attachTable` with `encryption.attachTable` targeting the *same slot
- *   name*, Yjs hands both calls the same underlying `Y.Array` and you get a
- *   silent plaintext-over-ciphertext race. The verb (`encryption.attachTable`
- *   vs plain `attachTable`) is the primary defense; review call sites
- *   accordingly. One slot name, one attach site, one intent.
+ *   `attachTable` with a `tables:` entry on `attachEncryption` targeting the
+ *   *same slot name*, Yjs hands both calls the same underlying `Y.Array` and
+ *   you get a silent plaintext-over-ciphertext race. One slot name, one
+ *   attach site, one intent.
  *
  * ## Why `workspaceId` is read from `ydoc.guid`
  *
@@ -70,125 +71,76 @@
 
 import type { Keyring } from '@epicenter/encryption';
 import type * as Y from 'yjs';
+import { createEncryptedYkvLww } from '../shared/y-keyvalue/y-keyvalue-lww-encrypted.js';
+import { createKv, type KvDefinitions } from './attach-kv.js';
 import {
-	createEncryptedYkvLww,
-	type EncryptedYKeyValueLww,
-} from '../shared/y-keyvalue/y-keyvalue-lww-encrypted.js';
-import { createKv, type Kv, type KvDefinitions } from './attach-kv.js';
-import {
-	createReadonlyTable,
 	createTable,
-	type InferTableRow,
-	type ReadonlyTable,
-	type ReadonlyTables,
-	type Table,
-	type TableDefinition,
 	type TableDefinitions,
 	type Tables,
 } from './attach-table.js';
 import { deriveWorkspaceKeyring } from './derive-workspace-keyring.js';
 import { KV_KEY, TableKey } from './keys.js';
 
-export type AttachEncryptionOptions = {
-	/**
-	 * Lazy reader for the current owner keyring.
-	 *
-	 * Called synchronously at every `attachTable` / `attachKv` site. Throw if
-	 * no keyring is available (e.g. signed-out): a throw here means the
-	 * workspace outlived its signed-in scope, which is a caller bug.
-	 */
+export type AttachEncryptionOptions<
+	TTables extends TableDefinitions,
+	TKv extends KvDefinitions,
+> = {
+	/** Lazy reader for the current owner keyring; invoked once at construction. */
 	keyring: () => Keyring;
-};
-
-export type EncryptionAttachment = {
 	/**
-	 * Attach an encrypted table to the coordinator's Y.Doc. The store is
-	 * activated with the current keyring (via `keyring()`) before being
-	 * returned.
+	 * Table definitions to register as encrypted stores, keyed by table name.
+	 * Pass the same record you'd hand to plaintext `attachTables`.
 	 */
-	attachTable<
-		// biome-ignore lint/suspicious/noExplicitAny: variance-friendly: defineTable already constrains schemas
-		TTableDefinition extends TableDefinition<any>,
-	>(
-		name: string,
-		definition: TTableDefinition,
-	): Table<InferTableRow<TTableDefinition>>;
-
-	attachReadonlyTable<
-		// biome-ignore lint/suspicious/noExplicitAny: variance-friendly
-		TTableDefinition extends TableDefinition<any>,
-	>(
-		name: string,
-		definition: TTableDefinition,
-	): ReadonlyTable<InferTableRow<TTableDefinition>>;
-
+	tables: TTables;
 	/**
-	 * Batch sugar over `attachTable`: one encrypted store per entry, keyed by
-	 * name.
+	 * KV definitions to register on the encrypted KV singleton. Pass `{}` to
+	 * register the slot without any typed keys (apps that don't read KV through
+	 * the typed helper still want the slot claimed so the daemon syncs it).
 	 */
-	attachTables<T extends TableDefinitions>(definitions: T): Tables<T>;
-
-	attachReadonlyTables<T extends TableDefinitions>(
-		definitions: T,
-	): ReadonlyTables<T>;
-
-	/**
-	 * Attach the encrypted KV singleton to the coordinator's Y.Doc.
-	 */
-	attachKv<T extends KvDefinitions>(definitions: T): Kv<T>;
+	kv: TKv;
 };
 
 /**
- * Create an encryption coordinator bound to `ydoc`.
+ * Create the encrypted stores for a workspace Y.Doc and return them keyed by
+ * name.
  *
- * The returned coordinator owns `attachTable` / `attachTables` / `attachKv`
- * methods: call them to register encrypted resources. The coordinator reads
- * `options.keyring()` synchronously at each registration site and
- * activates the resource before returning it.
+ * Atomic: derives one per-workspace keyring, activates every store, and
+ * returns the constructed `{ tables, kv }` bundle in a single call. No
+ * temporal registration window, no mid-session attachment.
  */
-export function attachEncryption(
+export function attachEncryption<
+	TTables extends TableDefinitions,
+	TKv extends KvDefinitions,
+>(
 	ydoc: Y.Doc,
-	options: AttachEncryptionOptions,
-): EncryptionAttachment {
-	const workspaceId = ydoc.guid;
+	{
+		keyring,
+		tables: tableDefs,
+		kv: kvDefs,
+	}: AttachEncryptionOptions<TTables, TKv>,
+) {
+	const workspaceKeyring = deriveWorkspaceKeyring(keyring(), ydoc.guid);
 
-	// biome-ignore lint/suspicious/noExplicitAny: variance
-	function attachStore(key: string): EncryptedYKeyValueLww<any> {
+	function attachStore(key: string) {
 		const store = createEncryptedYkvLww(ydoc, key);
 		ydoc.once('destroy', () => store[Symbol.dispose]());
-		store.activateEncryption(
-			deriveWorkspaceKeyring(options.keyring(), workspaceId),
-		);
+		store.activateEncryption(workspaceKeyring);
 		return store;
 	}
 
-	const attachment: EncryptionAttachment = {
-		attachTable(name, definition) {
-			return createTable(attachStore(TableKey(name)), definition, name);
-		},
-		attachReadonlyTable(name, definition) {
-			return createReadonlyTable(attachStore(TableKey(name)), definition, name);
-		},
-		attachTables(definitions) {
-			return Object.fromEntries(
-				Object.entries(definitions).map(([name, def]) => [
-					name,
-					attachment.attachTable(name, def),
-				]),
-			) as Tables<typeof definitions>;
-		},
-		attachReadonlyTables(definitions) {
-			return Object.fromEntries(
-				Object.entries(definitions).map(([name, def]) => [
-					name,
-					attachment.attachReadonlyTable(name, def),
-				]),
-			) as ReadonlyTables<typeof definitions>;
-		},
-		attachKv(definitions) {
-			return createKv(attachStore(KV_KEY), definitions);
-		},
-	};
+	const tables = Object.fromEntries(
+		Object.entries(tableDefs).map(([name, def]) => [
+			name,
+			createTable(attachStore(TableKey(name)), def, name),
+		]),
+	) as Tables<TTables>;
 
-	return attachment;
+	const kv = createKv(attachStore(KV_KEY), kvDefs);
+
+	return { tables, kv };
 }
+
+export type EncryptionAttachment<
+	TTables extends TableDefinitions,
+	TKv extends KvDefinitions,
+> = ReturnType<typeof attachEncryption<TTables, TKv>>;

--- a/packages/workspace/src/document/attach-kv.ts
+++ b/packages/workspace/src/document/attach-kv.ts
@@ -6,8 +6,9 @@
  * invalid or missing values return the result of the definition's
  * `defaultValue()` factory.
  *
- * For encrypted storage, call `encryption.attachKv` on the coordinator
- * returned by `attachEncryption(ydoc, { keyring })`.
+ * For encrypted storage, pass KV definitions via the `kv:` slot on
+ * `attachEncryption(ydoc, { keyring, tables, kv })` and destructure the
+ * constructed `kv` handle from the return.
  *
  * `attachKv` and `createKv` accept an optional `{ logger? }`: when provided,
  * validation failures emit `logger.warn(KvError.ValidationFailed({ key, raw }))`

--- a/packages/workspace/src/document/attach-table.ts
+++ b/packages/workspace/src/document/attach-table.ts
@@ -10,8 +10,9 @@
  * and (for multi-version tables) one migrate function. The user-facing row
  * type contains only the user's columns.
  *
- * For encrypted storage, call `encryption.attachTable` on the coordinator
- * returned by `attachEncryption(ydoc, { keyring })`.
+ * For encrypted storage, pass table definitions via the `tables:` slot on
+ * `attachEncryption(ydoc, { keyring, tables, kv })` and destructure the
+ * constructed handles from the return.
  */
 
 import { type Static, type TObject, type TSchema, Type } from 'typebox';

--- a/packages/workspace/src/document/materializer/markdown/materializer.test.ts
+++ b/packages/workspace/src/document/materializer/markdown/materializer.test.ts
@@ -26,8 +26,8 @@ import {
 	defineTable,
 } from '../../../index.js';
 import { parseMarkdownFile } from '../../../markdown/parse-markdown-file.js';
-import { column } from '../../column/index.js';
 import type { Table } from '../../attach-table.js';
+import { column } from '../../column/index.js';
 import {
 	attachMarkdownMaterializer,
 	type MarkdownShape,
@@ -135,7 +135,9 @@ async function setup({ build }: SetupOptions = {}) {
 
 describe('push', () => {
 	test('imports markdown files into workspace tables', async () => {
-		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
+		const { workspace } = await setup({
+			build: (t) => ({ tables: { posts: t.posts } }),
+		});
 		await writeTestFile(
 			'posts/hello.md',
 			'---\nid: post-1\ntitle: Hello World\npublished: true\n---\n',
@@ -162,7 +164,9 @@ describe('push', () => {
 	});
 
 	test('skips non-.md files', async () => {
-		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
+		const { workspace } = await setup({
+			build: (t) => ({ tables: { posts: t.posts } }),
+		});
 		await writeTestFile(
 			'posts/valid.md',
 			'---\nid: p1\ntitle: Valid\npublished: false\n---\n',
@@ -179,7 +183,9 @@ describe('push', () => {
 	});
 
 	test('skips files without valid frontmatter', async () => {
-		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
+		const { workspace } = await setup({
+			build: (t) => ({ tables: { posts: t.posts } }),
+		});
 		await writeTestFile(
 			'posts/valid.md',
 			'---\nid: p1\ntitle: Valid\npublished: false\n---\n',
@@ -198,7 +204,9 @@ describe('push', () => {
 	});
 
 	test('silently skips tables whose directories do not exist', async () => {
-		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
+		const { workspace } = await setup({
+			build: (t) => ({ tables: { posts: t.posts } }),
+		});
 		// Don't create the posts directory. It should not exist.
 		const result = await workspace.materializer.push();
 
@@ -210,7 +218,9 @@ describe('push', () => {
 	});
 
 	test('emits error event when frontmatter fails schema validation', async () => {
-		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
+		const { workspace } = await setup({
+			build: (t) => ({ tables: { posts: t.posts } }),
+		});
 		// Valid frontmatter structure but wrong type: title must be a string,
 		// here it's a number. `fromMarkdown` happily returns it; `table.parse()`
 		// catches the schema violation.
@@ -268,7 +278,9 @@ describe('push', () => {
 	});
 
 	test('counts match event kinds (invariant)', async () => {
-		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
+		const { workspace } = await setup({
+			build: (t) => ({ tables: { posts: t.posts } }),
+		});
 		await writeTestFile(
 			'posts/good.md',
 			'---\nid: p1\ntitle: Good\npublished: true\n---\n',
@@ -342,7 +354,9 @@ describe('push', () => {
 	});
 
 	test('overwrites existing rows (set is insert-or-replace)', async () => {
-		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
+		const { workspace } = await setup({
+			build: (t) => ({ tables: { posts: t.posts } }),
+		});
 		// First import
 		await writeTestFile(
 			'posts/p1.md',
@@ -398,7 +412,9 @@ describe('push', () => {
 
 describe('pull', () => {
 	test('writes all valid rows to disk', async () => {
-		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
+		const { workspace } = await setup({
+			build: (t) => ({ tables: { posts: t.posts } }),
+		});
 		workspace.tables.posts.set({
 			id: 'p1',
 			title: 'First',
@@ -473,7 +489,9 @@ describe('pull', () => {
 	});
 
 	test('writes nothing when table is empty', async () => {
-		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
+		const { workspace } = await setup({
+			build: (t) => ({ tables: { posts: t.posts } }),
+		});
 		const result = await workspace.materializer.pull();
 
 		expect(result.written).toBe(0);
@@ -510,7 +528,9 @@ describe('pull', () => {
 
 describe('rebuild', () => {
 	test('removes orphan files and rewrites existing valid rows', async () => {
-		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
+		const { workspace } = await setup({
+			build: (t) => ({ tables: { posts: t.posts } }),
+		});
 		// Seed disk with rows + an orphan file
 		workspace.tables.posts.set({
 			id: 'p1',
@@ -563,7 +583,9 @@ describe('rebuild', () => {
 	});
 
 	test('throws on unknown table name', async () => {
-		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
+		const { workspace } = await setup({
+			build: (t) => ({ tables: { posts: t.posts } }),
+		});
 		await expect(workspace.materializer.rebuild('notAThing')).rejects.toThrow(
 			/not in the materialized table set/,
 		);
@@ -572,7 +594,9 @@ describe('rebuild', () => {
 	});
 
 	test('is idempotent: rebuild twice produces identical filesystem state', async () => {
-		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
+		const { workspace } = await setup({
+			build: (t) => ({ tables: { posts: t.posts } }),
+		});
 		workspace.tables.posts.set({
 			id: 'p1',
 			title: 'A',

--- a/packages/workspace/src/document/materializer/sqlite/core.test.ts
+++ b/packages/workspace/src/document/materializer/sqlite/core.test.ts
@@ -566,7 +566,9 @@ describe('attachSqliteMaterializerCore', () => {
 					await testSetup.workspace.sqlite.whenFlushed;
 
 					const sqliteWithFts = testSetup.workspace.sqlite as unknown as {
-						fts: { search: (input: Record<string, unknown>) => Promise<unknown> };
+						fts: {
+							search: (input: Record<string, unknown>) => Promise<unknown>;
+						};
 					};
 					const results = (await sqliteWithFts.fts.search({
 						table: 'posts',

--- a/playground/opensidian-e2e/workspace.test.ts
+++ b/playground/opensidian-e2e/workspace.test.ts
@@ -47,11 +47,11 @@ function dbPath(id: string) {
 /** Create a workspace client with filesystem persistence for testing. */
 function createTestClient() {
 	const ydoc = new Y.Doc({ guid: WORKSPACE_ID, gc: true });
-	const encryption = attachEncryption(ydoc, {
+	const { tables, kv } = attachEncryption(ydoc, {
 		keyring: () => TEST_ENCRYPTION_KEYS,
+		tables: opensidianTables,
+		kv: {},
 	});
-	const tables = encryption.attachTables(opensidianTables);
-	const kv = encryption.attachKv({});
 	const persistence = attachYjsLog(ydoc, {
 		filePath: dbPath(WORKSPACE_ID),
 	});

--- a/playground/opensidian-e2e/workspace.test.ts
+++ b/playground/opensidian-e2e/workspace.test.ts
@@ -195,11 +195,11 @@ describe('e2e: opensidian pushFromMarkdown', () => {
 
 	function createImportClient() {
 		const ydoc = new Y.Doc({ guid: WORKSPACE_ID, gc: true });
-		const encryption = attachEncryption(ydoc, {
+		const { tables, kv } = attachEncryption(ydoc, {
 			keyring: () => TEST_ENCRYPTION_KEYS,
+			tables: opensidianTables,
+			kv: {},
 		});
-		const tables = encryption.attachTables(opensidianTables);
-		const kv = encryption.attachKv({});
 		const persistence = attachYjsLog(ydoc, {
 			filePath: join(IMPORT_PERSISTENCE, 'opensidian.db'),
 		});

--- a/playground/opensidian-e2e/workspaces/opensidian/daemon.ts
+++ b/playground/opensidian-e2e/workspaces/opensidian/daemon.ts
@@ -49,9 +49,11 @@ async function openOpensidianPlayground({
 }: DaemonWorkspaceContext) {
 	const ydoc = new Y.Doc({ guid: WORKSPACE_ID, gc: true });
 	ydoc.clientID = yDocClientId;
-	const encryption = attachEncryption(ydoc, { keyring });
-	const tables = encryption.attachTables(opensidianTables);
-	const kv = encryption.attachKv({});
+	const { tables, kv } = attachEncryption(ydoc, {
+		keyring,
+		tables: opensidianTables,
+		kv: {},
+	});
 
 	const persistence = attachYjsLog(ydoc, {
 		filePath: yjsPath(projectDir, WORKSPACE_ID),

--- a/playground/tab-manager-e2e/workspaces/tabManager/daemon.ts
+++ b/playground/tab-manager-e2e/workspaces/tabManager/daemon.ts
@@ -39,9 +39,11 @@ export default defineWorkspace({
 	}) {
 		const ydoc = new Y.Doc({ guid: WORKSPACE_ID, gc: true });
 		ydoc.clientID = yDocClientId;
-		const encryption = attachEncryption(ydoc, { keyring });
-		const tables = encryption.attachTables(tabManagerTables);
-		const kv = encryption.attachKv({});
+		const { tables, kv } = attachEncryption(ydoc, {
+			keyring,
+			tables: tabManagerTables,
+			kv: {},
+		});
 
 		const persistence = attachYjsLog(ydoc, {
 			filePath: yjsPath(projectDir, WORKSPACE_ID),


### PR DESCRIPTION
## Summary

`attachEncryption` now takes the full table and KV definition records as named slots and returns the constructed `{ tables, kv }` atomically. The old multi-call coordinator shape is gone.

```ts
// Before
const encryption = attachEncryption(ydoc, { keyring });
const tables = encryption.attachTables(honeycrispTables);
encryption.attachKv({});           // result discarded; slot only

// After
const { tables } = attachEncryption(ydoc, {
  keyring,
  tables: honeycrispTables,
  kv: {},
});
```

Three statements collapse to one. The discarded-handle pattern (5 call sites called `attachKv({})` purely for the slot side effect, throwing away the return) becomes impossible to write accidentally.

## Why we did it this way

This PR generalizes the spirit of the materializer record-tables refactor (the foundation commit at the base of this stack) one level up: **named sibling slots, atomic registration, no temporal window.**

### Before: the smell

The old shape was a coordinator-with-methods. Three things were wrong with it in practice:

1. **Discarded handles.** `encryption.attachKv({})` was being called purely to register the slot in the Y.Doc, and the returned handle was thrown away. 5 of 14 call sites did this. The API couldn't tell you whether you were forgetting to use the handle or intentionally registering for the side effect.
2. **Temporal coupling.** The JSDoc explicitly said \"called synchronously at every `attachTable` / `attachKv` site.\" That contract was load-bearing for nothing: no call site uses mid-session attachment, but every call site paid for the indirection.
3. **N keyring derivations.** Each `attachTable` / `attachKv` site called `keyring()` and re-derived the per-workspace HKDF keyring. Wasted work, dressed up as flexibility nobody used.

### After: what collapses

- `EncryptionAttachment` (as a method-bearing object) — the return type is now plain `{ tables, kv }`. The exported `EncryptionAttachment<TTables, TKv>` type now derives from the factory via `ReturnType<typeof attachEncryption<...>>`.
- `attachTable` / `attachTables` / `attachReadonlyTable` / `attachReadonlyTables` / `attachKv` methods on the returned object
- The \"called synchronously at every site\" JSDoc and the single-derivation pattern (one `keyring()` call at construction, one HKDF derivation, every store activated atomically)
- The readonly methods on the encryption variant (no production call site used them; defer until needed)

### Honest trade-off

This loses the symmetry between encrypted setup (`encryption.attachTables(defs)`) and plaintext setup (`attachTables(ydoc, defs)`). After this change, encrypted and plaintext setup *structurally diverge*: encrypted is a single-call constructor, plaintext is a per-slot helper. That symmetry was real, but it cost two calls instead of one and a discarded handle in the KV case. The new shape is honest about what encryption actually is: a constructor for several encrypted stores that all share a derived keyring.

### Asymmetry vs the materializer slot

The materializer's `tables:` slot takes *handles* (mirror these). Encryption's `tables:` slot takes *definitions* (construct these). Same word, different role — because materializer is a mirror primitive and encryption is a constructor primitive. The JSDoc on `attachEncryption` calls this out explicitly so future readers don't assume cross-primitive symmetry that doesn't exist.

## Scope

- 14 call sites migrated across `apps/`, `examples/`, `playground/`, and tests
- Tests rewritten for the new shape (3 focused tests covering: keyring throw, table round-trip, KV round-trip)
- JSDocs swept across `attach-table.ts`, `attach-kv.ts`, `tab-manager/definition.ts`
- READMEs updated: `packages/workspace/README.md`, `packages/workspace/src/document/README.md`, `apps/fuji/README.md`, `docs/encryption.md`, `docs/guides/consuming-epicenter-api.md`
- Skills updated: `attach-primitive/SKILL.md`, `workspace-api/references/{primitive-api,actions-layout-and-attachments}.md`, `workspace-app-layout/SKILL.md`

## Stacked on

This PR's base is `braden-w/pull-origin-main`, which holds the materializer record-tables refactor (the design this generalizes). When the materializer branch lands, this rebases cleanly onto main.

## Test plan

- [x] `bun run typecheck` clean in `packages/workspace`
- [x] All 308 `packages/workspace/src/document` tests pass
- [x] Consumer apps typecheck clean: honeycrisp, zhongwen, fuji, opensidian, tab-manager
- [x] Grep for stale references comes back clean: no remaining `encryption.attachTable` / `encryption.attachKv` / `encryption coordinator` in non-historical files

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782338213&installation_id=128463665&pr_number=1814&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1814&signature=2a726294166855b435cdd43f92f24663b91c227c49ff01c2d36ccbcceb4bb66a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->