### PR TITLE
refactor(workspace)!: nest FTS surface under materializer.fts namespace

### DIFF
--- a/.agents/skills/attach-primitive/SKILL.md
+++ b/.agents/skills/attach-primitive/SKILL.md
@@ -73,6 +73,8 @@ attachBunSqliteMaterializer(ydoc, {
 
 Per-table customization lives in `perTable: { [tableName]: { ... } }` (markdown) and FTS column opt-in lives in `fts: { [tableName]: ColumnKey[] }` (SQLite). Both slots narrow against `keyof tables`, so keys autocomplete and typos error at the call site. Passing the bare `tables` record mirrors every entry; an object subset (`tables: { files: tables.files }`) mirrors only what you list.
 
+The SQLite result surfaces FTS on a nested namespace: `sqlite.fts.search({ table, query })` exists when `fts: {...}` was passed; when omitted, `sqlite.fts` is absent from the return type entirely. Single attach call, single `whenFlushed` barrier; the FTS DDL and triggers run between table DDL and the bulk insert so triggers populate `<table>_fts` for free.
+
 ## The One Exception: Non-Ydoc Subject
 
 When a primitive modifies a sibling attachment and the coordination is cross-package (so it can't be a method on the coordinator), it's a top-level function with the attachment as first arg:

--- a/.agents/skills/attach-primitive/SKILL.md
+++ b/.agents/skills/attach-primitive/SKILL.md
@@ -39,40 +39,29 @@ attachAwareness(ydoc, defs)
 attachRichText(ydoc) / attachPlainText(ydoc) / attachTimeline(ydoc)
 ```
 
-**Per-entity registration goes in the options bag, not in a chained builder.** Materializers follow the same `attachX(ydoc, opts)` shape, with tables (and optional KV) listed up front as either a bare reference or a `[ref, config]` tuple:
+**Chainable return is allowed** when per-entity configuration is incremental. Materializers follow the same `attachX(ydoc, opts)` shape: the builder registers specific table/kv references via `.table(ref, cfg)`:
 
 ```ts
-attachMarkdownMaterializer(ydoc, {
-  dir,
-  waitFor,
-  tables: [
-    [
-      tables.files,
-      {
-        filename: slugFilename('title'),
-        // Most real tables store body content in a separate Y.Doc (via
-        // createDisposableCache), so toMarkdown / fromMarkdown are typically
-        // bespoke callbacks; no sugar helper can abstract the async
-        // open/await/dispose cycle usefully.
-        toMarkdown: async (row) => {
-          using doc = fileContentDocs.open(row.id);
-          await doc.whenReady;
-          return { frontmatter: { id: row.id, name: row.name }, body: doc.content.read() };
-        },
-      },
-    ],
-  ],
-  kv,
-});
+attachMarkdownMaterializer(ydoc, { dir, waitFor })
+  .table(tables.files, {
+    filename: slugFilename('title'),
+    // Most real tables store body content in a separate Y.Doc (via
+    // createDisposableCache), so toMarkdown / fromMarkdown are typically
+    // bespoke callbacks; no sugar helper can abstract the async
+    // open/await/dispose cycle usefully.
+    toMarkdown: async (row) => {
+      using doc = fileContentDocs.open(row.id);
+      await doc.whenReady;
+      return { frontmatter: { id: row.id, name: row.name }, body: doc.content.read() };
+    },
+  })
+  .kv(kv);
 
-attachBunSqliteMaterializer(ydoc, {
-  filePath,
-  waitFor,
-  tables: [[tables.posts, { fts: ['title'] }]],
-});
+attachSqliteMaterializer(ydoc, { db, waitFor })
+  .table(tables.posts, { fts: ['title'] });
 ```
 
-Passing `tables.files` directly (rather than a string name) mirrors y-prosemirror / y-codemirror: take the specific shared resource, not a bag plus a lookup key. The materializer reads `table.name` and `table.definition` off the reference internally. Tuple entries with `[ref, cfg]` narrow per entry, so `fts: ['typo']` errors at the offending entry rather than collapsing to `keyof never`.
+Passing `tables.files` directly (rather than a string name) mirrors y-prosemirror / y-codemirror: take the specific shared resource, not a bag plus a lookup key. The materializer reads `table.name` and `table.definition` off the reference internally. All `.table()` / `.kv()` registrations must happen synchronously after construction; calls after `whenFlushed` resolves throw.
 
 ## The One Exception: Non-Ydoc Subject
 
@@ -138,10 +127,9 @@ const cache = createDisposableCache((id: string) => {
     url, openWebSocket, replicaId, actions,
     waitFor: Promise.all([idb.whenLoaded, unlock.whenChecked]),
   });
-  const markdown   = attachMarkdownMaterializer(ydoc, {
+  const markdown   = attachMarkdownMaterializer(ydoc, {           // chainable return
     dir, waitFor: collaboration.whenConnected,
-    tables: [[tables.posts, { filename: slugFilename('title') }]],
-  });
+  }).table(tables.posts, { filename: slugFilename('title') });
 
   return {
     ydoc, tables, encryption, idb, collaboration, markdown,
@@ -185,5 +173,5 @@ Use it whenever a primitive's startup must follow another's. Examples:
 - `packages/workspace/src/document/attach-indexed-db.ts` ; the canonical 40-line example.
 - `packages/workspace/src/document/open-collaboration.ts` ; document collaboration surface with sync, presence, peers, and action dispatch.
 - `packages/workspace/src/document/attach-encryption.ts` ; state-owning coordinator; exposes `attachTable` / `attachTables` / `attachKv` as methods.
-- `packages/workspace/src/document/materializer/markdown/materializer.ts` ; tables/kv listed in the options bag as bare references or `[ref, config]` tuples.
+- `packages/workspace/src/document/materializer/markdown/materializer.ts` ; chainable builder with `.table()/.kv()`.
 - `apps/whispering/src/lib/client.ts`: full singleton composition.

--- a/.agents/skills/attach-primitive/SKILL.md
+++ b/.agents/skills/attach-primitive/SKILL.md
@@ -39,29 +39,40 @@ attachAwareness(ydoc, defs)
 attachRichText(ydoc) / attachPlainText(ydoc) / attachTimeline(ydoc)
 ```
 
-**Chainable return is allowed** when per-entity configuration is incremental. Materializers follow the same `attachX(ydoc, opts)` shape: the builder registers specific table/kv references via `.table(ref, cfg)`:
+**Per-entity registration goes in the options bag, not in a chained builder.** Materializers follow the same `attachX(ydoc, opts)` shape, with tables (and optional KV) listed up front as either a bare reference or a `[ref, config]` tuple:
 
 ```ts
-attachMarkdownMaterializer(ydoc, { dir, waitFor })
-  .table(tables.files, {
-    filename: slugFilename('title'),
-    // Most real tables store body content in a separate Y.Doc (via
-    // createDisposableCache), so toMarkdown / fromMarkdown are typically
-    // bespoke callbacks; no sugar helper can abstract the async
-    // open/await/dispose cycle usefully.
-    toMarkdown: async (row) => {
-      using doc = fileContentDocs.open(row.id);
-      await doc.whenReady;
-      return { frontmatter: { id: row.id, name: row.name }, body: doc.content.read() };
-    },
-  })
-  .kv(kv);
+attachMarkdownMaterializer(ydoc, {
+  dir,
+  waitFor,
+  tables: [
+    [
+      tables.files,
+      {
+        filename: slugFilename('title'),
+        // Most real tables store body content in a separate Y.Doc (via
+        // createDisposableCache), so toMarkdown / fromMarkdown are typically
+        // bespoke callbacks; no sugar helper can abstract the async
+        // open/await/dispose cycle usefully.
+        toMarkdown: async (row) => {
+          using doc = fileContentDocs.open(row.id);
+          await doc.whenReady;
+          return { frontmatter: { id: row.id, name: row.name }, body: doc.content.read() };
+        },
+      },
+    ],
+  ],
+  kv,
+});
 
-attachSqliteMaterializer(ydoc, { db, waitFor })
-  .table(tables.posts, { fts: ['title'] });
+attachBunSqliteMaterializer(ydoc, {
+  filePath,
+  waitFor,
+  tables: [[tables.posts, { fts: ['title'] }]],
+});
 ```
 
-Passing `tables.files` directly (rather than a string name) mirrors y-prosemirror / y-codemirror: take the specific shared resource, not a bag plus a lookup key. The materializer reads `table.name` and `table.definition` off the reference internally. All `.table()` / `.kv()` registrations must happen synchronously after construction; calls after `whenFlushed` resolves throw.
+Passing `tables.files` directly (rather than a string name) mirrors y-prosemirror / y-codemirror: take the specific shared resource, not a bag plus a lookup key. The materializer reads `table.name` and `table.definition` off the reference internally. Tuple entries with `[ref, cfg]` narrow per entry, so `fts: ['typo']` errors at the offending entry rather than collapsing to `keyof never`.
 
 ## The One Exception: Non-Ydoc Subject
 
@@ -127,9 +138,10 @@ const cache = createDisposableCache((id: string) => {
     url, openWebSocket, replicaId, actions,
     waitFor: Promise.all([idb.whenLoaded, unlock.whenChecked]),
   });
-  const markdown   = attachMarkdownMaterializer(ydoc, {           // chainable return
+  const markdown   = attachMarkdownMaterializer(ydoc, {
     dir, waitFor: collaboration.whenConnected,
-  }).table(tables.posts, { filename: slugFilename('title') });
+    tables: [[tables.posts, { filename: slugFilename('title') }]],
+  });
 
   return {
     ydoc, tables, encryption, idb, collaboration, markdown,
@@ -173,5 +185,5 @@ Use it whenever a primitive's startup must follow another's. Examples:
 - `packages/workspace/src/document/attach-indexed-db.ts` ; the canonical 40-line example.
 - `packages/workspace/src/document/open-collaboration.ts` ; document collaboration surface with sync, presence, peers, and action dispatch.
 - `packages/workspace/src/document/attach-encryption.ts` ; state-owning coordinator; exposes `attachTable` / `attachTables` / `attachKv` as methods.
-- `packages/workspace/src/document/materializer/markdown/materializer.ts` ; chainable builder with `.table()/.kv()`.
+- `packages/workspace/src/document/materializer/markdown/materializer.ts` ; tables/kv listed in the options bag as bare references or `[ref, config]` tuples.
 - `apps/whispering/src/lib/client.ts`: full singleton composition.

--- a/.agents/skills/attach-primitive/SKILL.md
+++ b/.agents/skills/attach-primitive/SKILL.md
@@ -11,10 +11,10 @@ Every persistence, sync, materializer, and binding in `packages/workspace` (plus
 
 | Prefix     | Meaning                                                                                                                      |
 | ---------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `attach*`  | Side-effectful. Registers observers, destroy listeners, or subscription state. Return shape is free: fixed surface *or* chainable builder, both are `attach*`. |
+| `attach*`  | Side-effectful. Registers observers, destroy listeners, or subscription state. Returns a plain object whose surface is fixed at call time. |
 | `create*`  | Pure construction. No listeners, no subscriptions, no destroy registration at call time. Cache constructors qualify, e.g. `createFileContentDocs` returns a `createDisposableCache` result; nothing attaches until `.open(id)` is called. |
 
-Both return plain objects. The distinction is **what happens at call time**, not what the return value looks like. A chainable builder with `.table()/.kv()` that registers `table.observe(...)` is still `attach*`; chainability is a return-shape concern, orthogonal to naming.
+Both return plain objects. The distinction is **what happens at call time**, not what the return value looks like.
 
 ## The shape
 
@@ -39,29 +39,39 @@ attachAwareness(ydoc, defs)
 attachRichText(ydoc) / attachPlainText(ydoc) / attachTimeline(ydoc)
 ```
 
-**Chainable return is allowed** when per-entity configuration is incremental. Materializers follow the same `attachX(ydoc, opts)` shape: the builder registers specific table/kv references via `.table(ref, cfg)`:
+**Materializers** follow the same `attachX(ydoc, opts)` shape: pass the `tables` record (or an object subset) to choose what to mirror, and keep per-table customization in sibling option slots keyed by table name:
 
 ```ts
-attachMarkdownMaterializer(ydoc, { dir, waitFor })
-  .table(tables.files, {
-    filename: slugFilename('title'),
-    // Most real tables store body content in a separate Y.Doc (via
-    // createDisposableCache), so toMarkdown / fromMarkdown are typically
-    // bespoke callbacks; no sugar helper can abstract the async
-    // open/await/dispose cycle usefully.
-    toMarkdown: async (row) => {
-      using doc = fileContentDocs.open(row.id);
-      await doc.whenReady;
-      return { frontmatter: { id: row.id, name: row.name }, body: doc.content.read() };
+attachMarkdownMaterializer(ydoc, {
+  dir,
+  waitFor,
+  tables,
+  perTable: {
+    files: {
+      filename: slugFilename('title'),
+      // Most real tables store body content in a separate Y.Doc (via
+      // createDisposableCache), so toMarkdown / fromMarkdown are typically
+      // bespoke callbacks; no sugar helper can abstract the async
+      // open/await/dispose cycle usefully.
+      toMarkdown: async (row) => {
+        using doc = fileContentDocs.open(row.id);
+        await doc.whenReady;
+        return { frontmatter: { id: row.id, name: row.name }, body: doc.content.read() };
+      },
     },
-  })
-  .kv(kv);
+  },
+  kv,
+});
 
-attachSqliteMaterializer(ydoc, { db, waitFor })
-  .table(tables.posts, { fts: ['title'] });
+attachBunSqliteMaterializer(ydoc, {
+  filePath,
+  waitFor,
+  tables,
+  fts: { posts: ['title'] },
+});
 ```
 
-Passing `tables.files` directly (rather than a string name) mirrors y-prosemirror / y-codemirror: take the specific shared resource, not a bag plus a lookup key. The materializer reads `table.name` and `table.definition` off the reference internally. All `.table()` / `.kv()` registrations must happen synchronously after construction; calls after `whenFlushed` resolves throw.
+Per-table customization lives in `perTable: { [tableName]: { ... } }` (markdown) and FTS column opt-in lives in `fts: { [tableName]: ColumnKey[] }` (SQLite). Both slots narrow against `keyof tables`, so keys autocomplete and typos error at the call site. Passing the bare `tables` record mirrors every entry; an object subset (`tables: { files: tables.files }`) mirrors only what you list.
 
 ## The One Exception: Non-Ydoc Subject
 
@@ -99,7 +109,6 @@ The method form says "use the encryption's attach-tables" directly. Preferred wh
 2. **Teardown hooked to the subject's lifecycle.**
    - Y.Doc subject: `ydoc.once('destroy', ...)`. Never expose a `.destroy()` method on the attachment.
    - Attachment subject: use the subject attachment's disposal signal; or no teardown if there are no listeners.
-   - Chainable builders (materializers): `[Symbol.dispose]()` method on the builder, unsubscribes observers.
 3. **Idempotent cleanup.** If the underlying library also registers a destroy handler (like `y-indexeddb`), your handler must be safe to run alongside it.
 4. **Plain data returned.** The attachment is a record of promises, functions, and occasionally mutable state. No ES classes, no getters that lazy-init.
 5. **No id option on ydoc-bound primitives.** `ydoc.guid` is the identity. Read it off the doc.
@@ -127,9 +136,12 @@ const cache = createDisposableCache((id: string) => {
     url, openWebSocket, replicaId, actions,
     waitFor: Promise.all([idb.whenLoaded, unlock.whenChecked]),
   });
-  const markdown   = attachMarkdownMaterializer(ydoc, {           // chainable return
-    dir, waitFor: collaboration.whenConnected,
-  }).table(tables.posts, { filename: slugFilename('title') });
+  const markdown   = attachMarkdownMaterializer(ydoc, {
+    dir,
+    waitFor: collaboration.whenConnected,
+    tables,
+    perTable: { posts: { filename: slugFilename('title') } },
+  });
 
   return {
     ydoc, tables, encryption, idb, collaboration, markdown,
@@ -173,5 +185,5 @@ Use it whenever a primitive's startup must follow another's. Examples:
 - `packages/workspace/src/document/attach-indexed-db.ts` ; the canonical 40-line example.
 - `packages/workspace/src/document/open-collaboration.ts` ; document collaboration surface with sync, presence, peers, and action dispatch.
 - `packages/workspace/src/document/attach-encryption.ts` ; state-owning coordinator; exposes `attachTable` / `attachTables` / `attachKv` as methods.
-- `packages/workspace/src/document/materializer/markdown/materializer.ts` ; chainable builder with `.table()/.kv()`.
+- `packages/workspace/src/document/materializer/markdown/materializer.ts` ; tables and optional `perTable` / `kv` in the options bag, keyed by table name.
 - `apps/whispering/src/lib/client.ts`: full singleton composition.

--- a/apps/fuji/daemon.ts
+++ b/apps/fuji/daemon.ts
@@ -50,10 +50,12 @@ export function openFujiDaemon({
 	attachBunSqliteMaterializer(ydoc, {
 		filePath: sqlitePath(projectDir, ydoc.guid),
 		log: createLogger(`${route}-sqlite`),
-	}).table(tables.entries);
+		tables: [tables.entries],
+	});
 	attachMarkdownMaterializer(ydoc, {
 		dir: markdownPath(projectDir, ydoc.guid),
-	}).table(tables.entries, { filename: slugFilename('title') });
+		tables: [[tables.entries, { filename: slugFilename('title') }]],
+	});
 
 	return attachDaemonInfrastructure(ydoc, {
 		projectDir,

--- a/apps/fuji/daemon.ts
+++ b/apps/fuji/daemon.ts
@@ -50,10 +50,13 @@ export function openFujiDaemon({
 	attachBunSqliteMaterializer(ydoc, {
 		filePath: sqlitePath(projectDir, ydoc.guid),
 		log: createLogger(`${route}-sqlite`),
-	}).table(tables.entries);
+		tables,
+	});
 	attachMarkdownMaterializer(ydoc, {
 		dir: markdownPath(projectDir, ydoc.guid),
-	}).table(tables.entries, { filename: slugFilename('title') });
+		tables,
+		perTable: { entries: { filename: slugFilename('title') } },
+	});
 
 	return attachDaemonInfrastructure(ydoc, {
 		projectDir,

--- a/apps/fuji/daemon.ts
+++ b/apps/fuji/daemon.ts
@@ -50,12 +50,10 @@ export function openFujiDaemon({
 	attachBunSqliteMaterializer(ydoc, {
 		filePath: sqlitePath(projectDir, ydoc.guid),
 		log: createLogger(`${route}-sqlite`),
-		tables: [tables.entries],
-	});
+	}).table(tables.entries);
 	attachMarkdownMaterializer(ydoc, {
 		dir: markdownPath(projectDir, ydoc.guid),
-		tables: [[tables.entries, { filename: slugFilename('title') }]],
-	});
+	}).table(tables.entries, { filename: slugFilename('title') });
 
 	return attachDaemonInfrastructure(ydoc, {
 		projectDir,

--- a/apps/honeycrisp/daemon.ts
+++ b/apps/honeycrisp/daemon.ts
@@ -52,16 +52,16 @@ export function openHoneycrispDaemon({
 	encryption.attachKv({});
 	const actions = createHoneycrispActions(tables);
 
-	const sqlite = attachBunSqliteMaterializer(ydoc, {
+	attachBunSqliteMaterializer(ydoc, {
 		filePath: sqlitePath(projectDir, ydoc.guid),
 		log: createLogger(`${route}-sqlite`),
+		tables: [tables.folders, tables.notes],
 	});
-	sqlite.table(tables.folders);
-	sqlite.table(tables.notes);
 
 	attachMarkdownMaterializer(ydoc, {
 		dir: markdownPath(projectDir, ydoc.guid),
-	}).table(tables.notes, { filename: slugFilename('title') });
+		tables: [[tables.notes, { filename: slugFilename('title') }]],
+	});
 
 	return attachDaemonInfrastructure(ydoc, {
 		projectDir,

--- a/apps/honeycrisp/daemon.ts
+++ b/apps/honeycrisp/daemon.ts
@@ -52,16 +52,17 @@ export function openHoneycrispDaemon({
 	encryption.attachKv({});
 	const actions = createHoneycrispActions(tables);
 
-	const sqlite = attachBunSqliteMaterializer(ydoc, {
+	attachBunSqliteMaterializer(ydoc, {
 		filePath: sqlitePath(projectDir, ydoc.guid),
 		log: createLogger(`${route}-sqlite`),
+		tables,
 	});
-	sqlite.table(tables.folders);
-	sqlite.table(tables.notes);
 
 	attachMarkdownMaterializer(ydoc, {
 		dir: markdownPath(projectDir, ydoc.guid),
-	}).table(tables.notes, { filename: slugFilename('title') });
+		tables: { notes: tables.notes },
+		perTable: { notes: { filename: slugFilename('title') } },
+	});
 
 	return attachDaemonInfrastructure(ydoc, {
 		projectDir,

--- a/apps/honeycrisp/daemon.ts
+++ b/apps/honeycrisp/daemon.ts
@@ -52,16 +52,16 @@ export function openHoneycrispDaemon({
 	encryption.attachKv({});
 	const actions = createHoneycrispActions(tables);
 
-	attachBunSqliteMaterializer(ydoc, {
+	const sqlite = attachBunSqliteMaterializer(ydoc, {
 		filePath: sqlitePath(projectDir, ydoc.guid),
 		log: createLogger(`${route}-sqlite`),
-		tables: [tables.folders, tables.notes],
 	});
+	sqlite.table(tables.folders);
+	sqlite.table(tables.notes);
 
 	attachMarkdownMaterializer(ydoc, {
 		dir: markdownPath(projectDir, ydoc.guid),
-		tables: [[tables.notes, { filename: slugFilename('title') }]],
-	});
+	}).table(tables.notes, { filename: slugFilename('title') });
 
 	return attachDaemonInfrastructure(ydoc, {
 		projectDir,

--- a/examples/fuji/epicenter.config.ts
+++ b/examples/fuji/epicenter.config.ts
@@ -53,7 +53,8 @@ export default defineWorkspace({
 		attachBunSqliteMaterializer(ydoc, {
 			filePath: join(projectDir, '.epicenter', 'sqlite.db'),
 			log: createLogger(`${route}-sqlite`),
-		}).table(tables.entries);
+			tables,
+		});
 
 		// Markdown: visible at project root, one directory per table.
 		// Committed to git as the source of truth. The materializer appends
@@ -61,7 +62,9 @@ export default defineWorkspace({
 		// `<projectDir>/entries/<slug>.md` for the `entries` table.
 		attachMarkdownMaterializer(ydoc, {
 			dir: projectDir,
-		}).table(tables.entries, { filename: slugFilename('title') });
+			tables,
+			perTable: { entries: { filename: slugFilename('title') } },
+		});
 
 		return attachDaemonInfrastructure(ydoc, {
 			projectDir,

--- a/examples/fuji/epicenter.config.ts
+++ b/examples/fuji/epicenter.config.ts
@@ -53,8 +53,7 @@ export default defineWorkspace({
 		attachBunSqliteMaterializer(ydoc, {
 			filePath: join(projectDir, '.epicenter', 'sqlite.db'),
 			log: createLogger(`${route}-sqlite`),
-			tables: [tables.entries],
-		});
+		}).table(tables.entries);
 
 		// Markdown: visible at project root, one directory per table.
 		// Committed to git as the source of truth. The materializer appends
@@ -62,8 +61,7 @@ export default defineWorkspace({
 		// `<projectDir>/entries/<slug>.md` for the `entries` table.
 		attachMarkdownMaterializer(ydoc, {
 			dir: projectDir,
-			tables: [[tables.entries, { filename: slugFilename('title') }]],
-		});
+		}).table(tables.entries, { filename: slugFilename('title') });
 
 		return attachDaemonInfrastructure(ydoc, {
 			projectDir,

--- a/examples/fuji/epicenter.config.ts
+++ b/examples/fuji/epicenter.config.ts
@@ -53,7 +53,8 @@ export default defineWorkspace({
 		attachBunSqliteMaterializer(ydoc, {
 			filePath: join(projectDir, '.epicenter', 'sqlite.db'),
 			log: createLogger(`${route}-sqlite`),
-		}).table(tables.entries);
+			tables: [tables.entries],
+		});
 
 		// Markdown: visible at project root, one directory per table.
 		// Committed to git as the source of truth. The materializer appends
@@ -61,7 +62,8 @@ export default defineWorkspace({
 		// `<projectDir>/entries/<slug>.md` for the `entries` table.
 		attachMarkdownMaterializer(ydoc, {
 			dir: projectDir,
-		}).table(tables.entries, { filename: slugFilename('title') });
+			tables: [[tables.entries, { filename: slugFilename('title') }]],
+		});
 
 		return attachDaemonInfrastructure(ydoc, {
 			projectDir,

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -962,8 +962,7 @@ function openNotes() {
 	});
 	const markdown = attachMarkdownMaterializer(ydoc, {
 		dir: '/tmp/epicenter/markdown',
-		tables: [[tables.notes, { filename: slugFilename('title') }]],
-	});
+	}).table(tables.notes, { filename: slugFilename('title') });
 
 	return {
 		get id() { return ydoc.guid; },
@@ -980,7 +979,7 @@ void openNotes;
 
 ### SQLite materializer
 
-The SQLite materializer is exported from `@epicenter/workspace/document/materializer/sqlite`. It mirrors table rows into queryable SQLite tables with optional FTS5 full-text search, with per-table opt-in via the `tables` option.
+The SQLite materializer is exported from `@epicenter/workspace/document/materializer/sqlite`. It mirrors table rows into queryable SQLite tables with optional FTS5 full-text search, using a builder pattern with `.table()` opt-in.
 
 ```typescript
 import { Database } from 'bun:sqlite';
@@ -1004,9 +1003,8 @@ function openBlog() {
 	const tables = attachTables(ydoc, { posts });
 	const db = new Database('/tmp/epicenter/blog.db');
 	ydoc.once('destroy', () => db.close());
-	const mirror = attachSqliteMaterializer(ydoc, {
-		db,
-		tables: [[tables.posts, { fts: ['title', 'body'] }]],
+	const mirror = attachSqliteMaterializer(ydoc, { db }).table(tables.posts, {
+		fts: ['title', 'body'],
 	});
 
 	return {

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -962,7 +962,9 @@ function openNotes() {
 	});
 	const markdown = attachMarkdownMaterializer(ydoc, {
 		dir: '/tmp/epicenter/markdown',
-	}).table(tables.notes, { filename: slugFilename('title') });
+		tables: { notes: tables.notes },
+		perTable: { notes: { filename: slugFilename('title') } },
+	});
 
 	return {
 		get id() { return ydoc.guid; },
@@ -979,7 +981,7 @@ void openNotes;
 
 ### SQLite materializer
 
-The SQLite materializer is exported from `@epicenter/workspace/document/materializer/sqlite`. It mirrors table rows into queryable SQLite tables with optional FTS5 full-text search, using a builder pattern with `.table()` opt-in.
+The SQLite materializer is exported from `@epicenter/workspace/document/materializer/sqlite`. It mirrors table rows into queryable SQLite tables with optional FTS5 full-text search. Pass the `tables` record to mirror every entry, and use the keyed `fts` slot to opt specific columns into FTS5.
 
 ```typescript
 import { Database } from 'bun:sqlite';
@@ -1003,8 +1005,10 @@ function openBlog() {
 	const tables = attachTables(ydoc, { posts });
 	const db = new Database('/tmp/epicenter/blog.db');
 	ydoc.once('destroy', () => db.close());
-	const mirror = attachSqliteMaterializer(ydoc, { db }).table(tables.posts, {
-		fts: ['title', 'body'],
+	const mirror = attachSqliteMaterializer(ydoc, {
+		db,
+		tables: { posts: tables.posts },
+		fts: { posts: ['title', 'body'] },
 	});
 
 	return {

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -984,14 +984,13 @@ void openNotes;
 The SQLite materializer is exported from `@epicenter/workspace/document/materializer/sqlite`. It mirrors table rows into queryable SQLite tables with optional FTS5 full-text search. Pass the `tables` record to mirror every entry, and use the keyed `fts` slot to opt specific columns into FTS5.
 
 ```typescript
-import { Database } from 'bun:sqlite';
 import * as Y from 'yjs';
 import {
 	attachTables,
 	column,
 	defineTable,
 } from '@epicenter/workspace';
-import { attachSqliteMaterializer } from '@epicenter/workspace/document/materializer/sqlite';
+import { attachBunSqliteMaterializer } from '@epicenter/workspace/document/materializer/sqlite';
 
 const posts = defineTable({
 	id: column.string(),
@@ -1003,10 +1002,8 @@ const posts = defineTable({
 function openBlog() {
 	const ydoc = new Y.Doc({ guid: 'epicenter.blog' });
 	const tables = attachTables(ydoc, { posts });
-	const db = new Database('/tmp/epicenter/blog.db');
-	ydoc.once('destroy', () => db.close());
-	const mirror = attachSqliteMaterializer(ydoc, {
-		db,
+	const mirror = attachBunSqliteMaterializer(ydoc, {
+		filePath: '/tmp/epicenter/blog.db',
 		tables: { posts: tables.posts },
 		fts: { posts: ['title', 'body'] },
 	});
@@ -1021,13 +1018,13 @@ function openBlog() {
 }
 
 // After mirror.whenFlushed:
-// blog.mirror.search('posts', 'hello');
-// blog.mirror.count('posts');
-// blog.mirror.rebuild('posts');
+// blog.mirror.fts.search({ table: 'posts', query: 'hello' });
+// blog.mirror.count({ table: 'posts' });
+// blog.mirror.rebuild({ table: 'posts' });
 void openBlog;
 ```
 
-The `MirrorDatabase` interface is structurally compatible with `bun:sqlite`'s `Database` and `better-sqlite3`'s `Database`: no wrapper needed. Pass your driver directly.
+The materializer owns the SQLite file end-to-end. When you pass `fts: {...}`, the result exposes a nested `mirror.fts` namespace with the search action; omit `fts` and `mirror.fts` is absent from the return type entirely.
 
 ## Workspace Dependencies
 

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -962,7 +962,8 @@ function openNotes() {
 	});
 	const markdown = attachMarkdownMaterializer(ydoc, {
 		dir: '/tmp/epicenter/markdown',
-	}).table(tables.notes, { filename: slugFilename('title') });
+		tables: [[tables.notes, { filename: slugFilename('title') }]],
+	});
 
 	return {
 		get id() { return ydoc.guid; },
@@ -979,7 +980,7 @@ void openNotes;
 
 ### SQLite materializer
 
-The SQLite materializer is exported from `@epicenter/workspace/document/materializer/sqlite`. It mirrors table rows into queryable SQLite tables with optional FTS5 full-text search, using a builder pattern with `.table()` opt-in.
+The SQLite materializer is exported from `@epicenter/workspace/document/materializer/sqlite`. It mirrors table rows into queryable SQLite tables with optional FTS5 full-text search, with per-table opt-in via the `tables` option.
 
 ```typescript
 import { Database } from 'bun:sqlite';
@@ -1003,8 +1004,9 @@ function openBlog() {
 	const tables = attachTables(ydoc, { posts });
 	const db = new Database('/tmp/epicenter/blog.db');
 	ydoc.once('destroy', () => db.close());
-	const mirror = attachSqliteMaterializer(ydoc, { db }).table(tables.posts, {
-		fts: ['title', 'body'],
+	const mirror = attachSqliteMaterializer(ydoc, {
+		db,
+		tables: [[tables.posts, { fts: ['title', 'body'] }]],
 	});
 
 	return {

--- a/packages/workspace/src/document/drizzle-schema.test.ts
+++ b/packages/workspace/src/document/drizzle-schema.test.ts
@@ -64,7 +64,8 @@ async function seedMirror(filePath: string, rows: EntryRow[]) {
 	const materializer = attachBunSqliteMaterializer(ydoc, {
 		filePath,
 		debounceMs: 0,
-	}).table(tables.entries);
+		tables: [tables.entries],
+	});
 	await materializer.whenFlushed;
 	for (const row of rows) tables.entries.set(row);
 	await new Promise<void>((resolve) => setTimeout(resolve, 0));

--- a/packages/workspace/src/document/drizzle-schema.test.ts
+++ b/packages/workspace/src/document/drizzle-schema.test.ts
@@ -64,8 +64,7 @@ async function seedMirror(filePath: string, rows: EntryRow[]) {
 	const materializer = attachBunSqliteMaterializer(ydoc, {
 		filePath,
 		debounceMs: 0,
-		tables: [tables.entries],
-	});
+	}).table(tables.entries);
 	await materializer.whenFlushed;
 	for (const row of rows) tables.entries.set(row);
 	await new Promise<void>((resolve) => setTimeout(resolve, 0));

--- a/packages/workspace/src/document/drizzle-schema.test.ts
+++ b/packages/workspace/src/document/drizzle-schema.test.ts
@@ -64,7 +64,8 @@ async function seedMirror(filePath: string, rows: EntryRow[]) {
 	const materializer = attachBunSqliteMaterializer(ydoc, {
 		filePath,
 		debounceMs: 0,
-	}).table(tables.entries);
+		tables: { entries: tables.entries },
+	});
 	await materializer.whenFlushed;
 	for (const row of rows) tables.entries.set(row);
 	await new Promise<void>((resolve) => setTimeout(resolve, 0));

--- a/packages/workspace/src/document/materializer/markdown/materializer.test.ts
+++ b/packages/workspace/src/document/materializer/markdown/materializer.test.ts
@@ -29,6 +29,7 @@ import { parseMarkdownFile } from '../../../markdown/parse-markdown-file.js';
 import { column } from '../../column/index.js';
 import {
 	attachMarkdownMaterializer,
+	type MarkdownTableEntry,
 	type MarkdownShape,
 } from './materializer.js';
 
@@ -82,16 +83,13 @@ async function listTestDir(relativePath: string) {
 }
 
 type AttachedTables = ReturnType<typeof attachTables<typeof tableDefinitions>>;
-type Materializer = ReturnType<typeof attachMarkdownMaterializer>;
-type TableRegistration = {
-	table: Parameters<Materializer['table']>[0];
-	config?: Parameters<Materializer['table']>[1];
-};
+// biome-ignore lint/suspicious/noExplicitAny: heterogeneous test table entries
+type TableEntries = readonly MarkdownTableEntry<any>[];
 
 async function setup({
-	tables: tableRegistrations,
+	tables: tableEntries,
 }: {
-	tables?: (t: AttachedTables) => TableRegistration[];
+	tables?: (t: AttachedTables) => TableEntries;
 } = {}) {
 	const cache = createDisposableCache(
 		(id: string) => {
@@ -100,17 +98,8 @@ async function setup({
 
 			const materializer = attachMarkdownMaterializer(ydoc, {
 				dir: TEST_DIR,
+				tables: tableEntries?.(tables) ?? [tables.posts, tables.notes],
 			});
-
-			const registrations =
-				tableRegistrations?.(tables) ??
-				([
-					{ table: tables.posts },
-					{ table: tables.notes },
-				] as TableRegistration[]);
-			for (const { table, config } of registrations) {
-				materializer.table(table, config);
-			}
 
 			return {
 				ydoc,
@@ -136,7 +125,7 @@ async function setup({
 
 describe('push', () => {
 	test('imports markdown files into workspace tables', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ tables: (t) => [t.posts] });
 		await writeTestFile(
 			'posts/hello.md',
 			'---\nid: post-1\ntitle: Hello World\npublished: true\n---\n',
@@ -163,7 +152,7 @@ describe('push', () => {
 	});
 
 	test('skips non-.md files', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ tables: (t) => [t.posts] });
 		await writeTestFile(
 			'posts/valid.md',
 			'---\nid: p1\ntitle: Valid\npublished: false\n---\n',
@@ -180,7 +169,7 @@ describe('push', () => {
 	});
 
 	test('skips files without valid frontmatter', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ tables: (t) => [t.posts] });
 		await writeTestFile(
 			'posts/valid.md',
 			'---\nid: p1\ntitle: Valid\npublished: false\n---\n',
@@ -199,7 +188,7 @@ describe('push', () => {
 	});
 
 	test('silently skips tables whose directories do not exist', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ tables: (t) => [t.posts] });
 		// Don't create the posts directory. It should not exist.
 		const result = await workspace.materializer.push();
 
@@ -211,7 +200,7 @@ describe('push', () => {
 	});
 
 	test('emits error event when frontmatter fails schema validation', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ tables: (t) => [t.posts] });
 		// Valid frontmatter structure but wrong type: title must be a string,
 		// here it's a number. `fromMarkdown` happily returns it; `table.parse()`
 		// catches the schema violation.
@@ -240,14 +229,14 @@ describe('push', () => {
 	test('emits error event when fromMarkdown callback throws', async () => {
 		const { workspace } = await setup({
 			tables: (t) => [
-				{
-					table: t.notes,
-					config: {
+				[
+					t.notes,
+					{
 						fromMarkdown: () => {
 							throw new Error('simulated callback failure');
 						},
 					},
-				},
+				],
 			],
 		});
 		await writeTestFile(
@@ -269,7 +258,7 @@ describe('push', () => {
 	});
 
 	test('counts match event kinds (invariant)', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ tables: (t) => [t.posts] });
 		await writeTestFile(
 			'posts/good.md',
 			'---\nid: p1\ntitle: Good\npublished: true\n---\n',
@@ -296,15 +285,15 @@ describe('push', () => {
 	test('uses custom fromMarkdown callback', async () => {
 		const { workspace } = await setup({
 			tables: (t) => [
-				{
-					table: t.notes,
-					config: {
+				[
+					t.notes,
+					{
 						fromMarkdown: (parsed) => ({
 							id: parsed.frontmatter.id as string,
 							body: parsed.body ?? '',
 						}),
 					},
-				},
+				],
 			],
 		});
 		await writeTestFile(
@@ -324,7 +313,7 @@ describe('push', () => {
 
 	test('uses custom table directory', async () => {
 		const { workspace } = await setup({
-			tables: (t) => [{ table: t.posts, config: { dir: 'blog' } }],
+			tables: (t) => [[t.posts, { dir: 'blog' }]],
 		});
 		await writeTestFile(
 			'blog/hello.md',
@@ -340,7 +329,7 @@ describe('push', () => {
 	});
 
 	test('overwrites existing rows (set is insert-or-replace)', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ tables: (t) => [t.posts] });
 		// First import
 		await writeTestFile(
 			'posts/p1.md',
@@ -396,7 +385,7 @@ describe('push', () => {
 
 describe('pull', () => {
 	test('writes all valid rows to disk', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ tables: (t) => [t.posts] });
 		workspace.tables.posts.set({
 			id: 'p1',
 			title: 'First',
@@ -425,16 +414,16 @@ describe('pull', () => {
 	test('uses custom filename and toMarkdown callbacks', async () => {
 		const { workspace } = await setup({
 			tables: (t) => [
-				{
-					table: t.notes,
-					config: {
+				[
+					t.notes,
+					{
 						filename: (row) => `${row.id}-custom.md`,
 						toMarkdown: (row) => ({
 							frontmatter: { id: row.id },
-							body: (row as unknown as { body: string }).body,
+							body: row.body,
 						}),
 					},
-				},
+				],
 			],
 		});
 		workspace.tables.notes.set({ id: 'n1', body: 'Custom body' });
@@ -451,7 +440,7 @@ describe('pull', () => {
 
 	test('uses custom table directory', async () => {
 		const { workspace } = await setup({
-			tables: (t) => [{ table: t.posts, config: { dir: 'blog' } }],
+			tables: (t) => [[t.posts, { dir: 'blog' }]],
 		});
 		workspace.tables.posts.set({
 			id: 'p1',
@@ -468,7 +457,7 @@ describe('pull', () => {
 	});
 
 	test('writes nothing when table is empty', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ tables: (t) => [t.posts] });
 		const result = await workspace.materializer.pull();
 
 		expect(result.written).toBe(0);
@@ -505,7 +494,7 @@ describe('pull', () => {
 
 describe('rebuild', () => {
 	test('removes orphan files and rewrites existing valid rows', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ tables: (t) => [t.posts] });
 		// Seed disk with rows + an orphan file
 		workspace.tables.posts.set({
 			id: 'p1',
@@ -558,7 +547,7 @@ describe('rebuild', () => {
 	});
 
 	test('throws on unknown table name', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ tables: (t) => [t.posts] });
 		await expect(workspace.materializer.rebuild('notAThing')).rejects.toThrow(
 			/not in the materialized table set/,
 		);
@@ -567,7 +556,7 @@ describe('rebuild', () => {
 	});
 
 	test('is idempotent: rebuild twice produces identical filesystem state', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ tables: (t) => [t.posts] });
 		workspace.tables.posts.set({
 			id: 'p1',
 			title: 'A',
@@ -616,7 +605,8 @@ describe('round-trip', () => {
 			const tables = attachTables(ydoc, tableDefinitions);
 			const materializer = attachMarkdownMaterializer(ydoc, {
 				dir: TEST_DIR,
-			}).table(tables.posts);
+				tables: [tables.posts],
+			});
 			return {
 				ydoc,
 				tables,
@@ -657,7 +647,8 @@ describe('round-trip', () => {
 			const tables = attachTables(ydoc, tableDefinitions);
 			const materializer = attachMarkdownMaterializer(ydoc, {
 				dir: TEST_DIR,
-			}).table(tables.posts);
+				tables: [tables.posts],
+			});
 			return {
 				ydoc,
 				tables,
@@ -692,22 +683,21 @@ describe('round-trip', () => {
 		// row field: `notes.body` here. Inline callbacks keep the intent
 		// at the call site; no helper abstracts the destructure.
 		const { workspace } = await setup({
-			tables: (t) =>
+			tables: (t) => [
 				[
+					t.notes,
 					{
-						table: t.notes,
-						config: {
-							toMarkdown: (row: { id: string; body: string }) => {
-								const { body, ...frontmatter } = row;
-								return { frontmatter, body };
-							},
-							fromMarkdown: (parsed: MarkdownShape) => ({
-								id: parsed.frontmatter.id as string,
-								body: parsed.body ?? '',
-							}),
+						toMarkdown: (row) => {
+							const { body, ...frontmatter } = row;
+							return { frontmatter, body };
 						},
+						fromMarkdown: (parsed: MarkdownShape) => ({
+							id: parsed.frontmatter.id as string,
+							body: parsed.body ?? '',
+						}),
 					},
-				] as unknown as TableRegistration[],
+				],
+			],
 		});
 
 		const original = { id: 'n1', body: 'Body content here' };

--- a/packages/workspace/src/document/materializer/markdown/materializer.test.ts
+++ b/packages/workspace/src/document/materializer/markdown/materializer.test.ts
@@ -29,7 +29,6 @@ import { parseMarkdownFile } from '../../../markdown/parse-markdown-file.js';
 import { column } from '../../column/index.js';
 import {
 	attachMarkdownMaterializer,
-	type MarkdownTableEntry,
 	type MarkdownShape,
 } from './materializer.js';
 
@@ -83,13 +82,16 @@ async function listTestDir(relativePath: string) {
 }
 
 type AttachedTables = ReturnType<typeof attachTables<typeof tableDefinitions>>;
-// biome-ignore lint/suspicious/noExplicitAny: heterogeneous test table entries
-type TableEntries = readonly MarkdownTableEntry<any>[];
+type Materializer = ReturnType<typeof attachMarkdownMaterializer>;
+type TableRegistration = {
+	table: Parameters<Materializer['table']>[0];
+	config?: Parameters<Materializer['table']>[1];
+};
 
 async function setup({
-	tables: tableEntries,
+	tables: tableRegistrations,
 }: {
-	tables?: (t: AttachedTables) => TableEntries;
+	tables?: (t: AttachedTables) => TableRegistration[];
 } = {}) {
 	const cache = createDisposableCache(
 		(id: string) => {
@@ -98,8 +100,17 @@ async function setup({
 
 			const materializer = attachMarkdownMaterializer(ydoc, {
 				dir: TEST_DIR,
-				tables: tableEntries?.(tables) ?? [tables.posts, tables.notes],
 			});
+
+			const registrations =
+				tableRegistrations?.(tables) ??
+				([
+					{ table: tables.posts },
+					{ table: tables.notes },
+				] as TableRegistration[]);
+			for (const { table, config } of registrations) {
+				materializer.table(table, config);
+			}
 
 			return {
 				ydoc,
@@ -125,7 +136,7 @@ async function setup({
 
 describe('push', () => {
 	test('imports markdown files into workspace tables', async () => {
-		const { workspace } = await setup({ tables: (t) => [t.posts] });
+		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
 		await writeTestFile(
 			'posts/hello.md',
 			'---\nid: post-1\ntitle: Hello World\npublished: true\n---\n',
@@ -152,7 +163,7 @@ describe('push', () => {
 	});
 
 	test('skips non-.md files', async () => {
-		const { workspace } = await setup({ tables: (t) => [t.posts] });
+		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
 		await writeTestFile(
 			'posts/valid.md',
 			'---\nid: p1\ntitle: Valid\npublished: false\n---\n',
@@ -169,7 +180,7 @@ describe('push', () => {
 	});
 
 	test('skips files without valid frontmatter', async () => {
-		const { workspace } = await setup({ tables: (t) => [t.posts] });
+		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
 		await writeTestFile(
 			'posts/valid.md',
 			'---\nid: p1\ntitle: Valid\npublished: false\n---\n',
@@ -188,7 +199,7 @@ describe('push', () => {
 	});
 
 	test('silently skips tables whose directories do not exist', async () => {
-		const { workspace } = await setup({ tables: (t) => [t.posts] });
+		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
 		// Don't create the posts directory. It should not exist.
 		const result = await workspace.materializer.push();
 
@@ -200,7 +211,7 @@ describe('push', () => {
 	});
 
 	test('emits error event when frontmatter fails schema validation', async () => {
-		const { workspace } = await setup({ tables: (t) => [t.posts] });
+		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
 		// Valid frontmatter structure but wrong type: title must be a string,
 		// here it's a number. `fromMarkdown` happily returns it; `table.parse()`
 		// catches the schema violation.
@@ -229,14 +240,14 @@ describe('push', () => {
 	test('emits error event when fromMarkdown callback throws', async () => {
 		const { workspace } = await setup({
 			tables: (t) => [
-				[
-					t.notes,
-					{
+				{
+					table: t.notes,
+					config: {
 						fromMarkdown: () => {
 							throw new Error('simulated callback failure');
 						},
 					},
-				],
+				},
 			],
 		});
 		await writeTestFile(
@@ -258,7 +269,7 @@ describe('push', () => {
 	});
 
 	test('counts match event kinds (invariant)', async () => {
-		const { workspace } = await setup({ tables: (t) => [t.posts] });
+		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
 		await writeTestFile(
 			'posts/good.md',
 			'---\nid: p1\ntitle: Good\npublished: true\n---\n',
@@ -285,15 +296,15 @@ describe('push', () => {
 	test('uses custom fromMarkdown callback', async () => {
 		const { workspace } = await setup({
 			tables: (t) => [
-				[
-					t.notes,
-					{
+				{
+					table: t.notes,
+					config: {
 						fromMarkdown: (parsed) => ({
 							id: parsed.frontmatter.id as string,
 							body: parsed.body ?? '',
 						}),
 					},
-				],
+				},
 			],
 		});
 		await writeTestFile(
@@ -313,7 +324,7 @@ describe('push', () => {
 
 	test('uses custom table directory', async () => {
 		const { workspace } = await setup({
-			tables: (t) => [[t.posts, { dir: 'blog' }]],
+			tables: (t) => [{ table: t.posts, config: { dir: 'blog' } }],
 		});
 		await writeTestFile(
 			'blog/hello.md',
@@ -329,7 +340,7 @@ describe('push', () => {
 	});
 
 	test('overwrites existing rows (set is insert-or-replace)', async () => {
-		const { workspace } = await setup({ tables: (t) => [t.posts] });
+		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
 		// First import
 		await writeTestFile(
 			'posts/p1.md',
@@ -385,7 +396,7 @@ describe('push', () => {
 
 describe('pull', () => {
 	test('writes all valid rows to disk', async () => {
-		const { workspace } = await setup({ tables: (t) => [t.posts] });
+		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
 		workspace.tables.posts.set({
 			id: 'p1',
 			title: 'First',
@@ -414,16 +425,16 @@ describe('pull', () => {
 	test('uses custom filename and toMarkdown callbacks', async () => {
 		const { workspace } = await setup({
 			tables: (t) => [
-				[
-					t.notes,
-					{
+				{
+					table: t.notes,
+					config: {
 						filename: (row) => `${row.id}-custom.md`,
 						toMarkdown: (row) => ({
 							frontmatter: { id: row.id },
-							body: row.body,
+							body: (row as unknown as { body: string }).body,
 						}),
 					},
-				],
+				},
 			],
 		});
 		workspace.tables.notes.set({ id: 'n1', body: 'Custom body' });
@@ -440,7 +451,7 @@ describe('pull', () => {
 
 	test('uses custom table directory', async () => {
 		const { workspace } = await setup({
-			tables: (t) => [[t.posts, { dir: 'blog' }]],
+			tables: (t) => [{ table: t.posts, config: { dir: 'blog' } }],
 		});
 		workspace.tables.posts.set({
 			id: 'p1',
@@ -457,7 +468,7 @@ describe('pull', () => {
 	});
 
 	test('writes nothing when table is empty', async () => {
-		const { workspace } = await setup({ tables: (t) => [t.posts] });
+		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
 		const result = await workspace.materializer.pull();
 
 		expect(result.written).toBe(0);
@@ -494,7 +505,7 @@ describe('pull', () => {
 
 describe('rebuild', () => {
 	test('removes orphan files and rewrites existing valid rows', async () => {
-		const { workspace } = await setup({ tables: (t) => [t.posts] });
+		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
 		// Seed disk with rows + an orphan file
 		workspace.tables.posts.set({
 			id: 'p1',
@@ -547,7 +558,7 @@ describe('rebuild', () => {
 	});
 
 	test('throws on unknown table name', async () => {
-		const { workspace } = await setup({ tables: (t) => [t.posts] });
+		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
 		await expect(workspace.materializer.rebuild('notAThing')).rejects.toThrow(
 			/not in the materialized table set/,
 		);
@@ -556,7 +567,7 @@ describe('rebuild', () => {
 	});
 
 	test('is idempotent: rebuild twice produces identical filesystem state', async () => {
-		const { workspace } = await setup({ tables: (t) => [t.posts] });
+		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
 		workspace.tables.posts.set({
 			id: 'p1',
 			title: 'A',
@@ -605,8 +616,7 @@ describe('round-trip', () => {
 			const tables = attachTables(ydoc, tableDefinitions);
 			const materializer = attachMarkdownMaterializer(ydoc, {
 				dir: TEST_DIR,
-				tables: [tables.posts],
-			});
+			}).table(tables.posts);
 			return {
 				ydoc,
 				tables,
@@ -647,8 +657,7 @@ describe('round-trip', () => {
 			const tables = attachTables(ydoc, tableDefinitions);
 			const materializer = attachMarkdownMaterializer(ydoc, {
 				dir: TEST_DIR,
-				tables: [tables.posts],
-			});
+			}).table(tables.posts);
 			return {
 				ydoc,
 				tables,
@@ -683,21 +692,22 @@ describe('round-trip', () => {
 		// row field: `notes.body` here. Inline callbacks keep the intent
 		// at the call site; no helper abstracts the destructure.
 		const { workspace } = await setup({
-			tables: (t) => [
+			tables: (t) =>
 				[
-					t.notes,
 					{
-						toMarkdown: (row) => {
-							const { body, ...frontmatter } = row;
-							return { frontmatter, body };
+						table: t.notes,
+						config: {
+							toMarkdown: (row: { id: string; body: string }) => {
+								const { body, ...frontmatter } = row;
+								return { frontmatter, body };
+							},
+							fromMarkdown: (parsed: MarkdownShape) => ({
+								id: parsed.frontmatter.id as string,
+								body: parsed.body ?? '',
+							}),
 						},
-						fromMarkdown: (parsed: MarkdownShape) => ({
-							id: parsed.frontmatter.id as string,
-							body: parsed.body ?? '',
-						}),
 					},
-				],
-			],
+				] as unknown as TableRegistration[],
 		});
 
 		const original = { id: 'n1', body: 'Body content here' };

--- a/packages/workspace/src/document/materializer/markdown/materializer.test.ts
+++ b/packages/workspace/src/document/materializer/markdown/materializer.test.ts
@@ -27,9 +27,11 @@ import {
 } from '../../../index.js';
 import { parseMarkdownFile } from '../../../markdown/parse-markdown-file.js';
 import { column } from '../../column/index.js';
+import type { Table } from '../../attach-table.js';
 import {
 	attachMarkdownMaterializer,
 	type MarkdownShape,
+	type PerTableConfig,
 } from './materializer.js';
 
 // ============================================================================
@@ -82,35 +84,32 @@ async function listTestDir(relativePath: string) {
 }
 
 type AttachedTables = ReturnType<typeof attachTables<typeof tableDefinitions>>;
-type Materializer = ReturnType<typeof attachMarkdownMaterializer>;
-type TableRegistration = {
-	table: Parameters<Materializer['table']>[0];
-	config?: Parameters<Materializer['table']>[1];
+
+// biome-ignore lint/suspicious/noExplicitAny: heterogeneous row types in a record
+type AnyTablesRecord = Record<string, Table<any>>;
+
+type SetupOptions = {
+	build?: (t: AttachedTables) => {
+		tables: AnyTablesRecord;
+		perTable?: PerTableConfig<AnyTablesRecord>;
+	};
 };
 
-async function setup({
-	tables: tableRegistrations,
-}: {
-	tables?: (t: AttachedTables) => TableRegistration[];
-} = {}) {
+async function setup({ build }: SetupOptions = {}) {
 	const cache = createDisposableCache(
 		(id: string) => {
 			const ydoc = new Y.Doc({ guid: id });
 			const tables = attachTables(ydoc, tableDefinitions);
 
+			const { tables: mirrored, perTable } = build?.(tables) ?? {
+				tables: { posts: tables.posts, notes: tables.notes },
+			};
+
 			const materializer = attachMarkdownMaterializer(ydoc, {
 				dir: TEST_DIR,
+				tables: mirrored,
+				perTable,
 			});
-
-			const registrations =
-				tableRegistrations?.(tables) ??
-				([
-					{ table: tables.posts },
-					{ table: tables.notes },
-				] as TableRegistration[]);
-			for (const { table, config } of registrations) {
-				materializer.table(table, config);
-			}
 
 			return {
 				ydoc,
@@ -136,7 +135,7 @@ async function setup({
 
 describe('push', () => {
 	test('imports markdown files into workspace tables', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
 		await writeTestFile(
 			'posts/hello.md',
 			'---\nid: post-1\ntitle: Hello World\npublished: true\n---\n',
@@ -163,7 +162,7 @@ describe('push', () => {
 	});
 
 	test('skips non-.md files', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
 		await writeTestFile(
 			'posts/valid.md',
 			'---\nid: p1\ntitle: Valid\npublished: false\n---\n',
@@ -180,7 +179,7 @@ describe('push', () => {
 	});
 
 	test('skips files without valid frontmatter', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
 		await writeTestFile(
 			'posts/valid.md',
 			'---\nid: p1\ntitle: Valid\npublished: false\n---\n',
@@ -199,7 +198,7 @@ describe('push', () => {
 	});
 
 	test('silently skips tables whose directories do not exist', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
 		// Don't create the posts directory. It should not exist.
 		const result = await workspace.materializer.push();
 
@@ -211,7 +210,7 @@ describe('push', () => {
 	});
 
 	test('emits error event when frontmatter fails schema validation', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
 		// Valid frontmatter structure but wrong type: title must be a string,
 		// here it's a number. `fromMarkdown` happily returns it; `table.parse()`
 		// catches the schema violation.
@@ -239,16 +238,16 @@ describe('push', () => {
 
 	test('emits error event when fromMarkdown callback throws', async () => {
 		const { workspace } = await setup({
-			tables: (t) => [
-				{
-					table: t.notes,
-					config: {
+			build: (t) => ({
+				tables: { notes: t.notes },
+				perTable: {
+					notes: {
 						fromMarkdown: () => {
 							throw new Error('simulated callback failure');
 						},
 					},
 				},
-			],
+			}),
 		});
 		await writeTestFile(
 			'notes/boom.md',
@@ -269,7 +268,7 @@ describe('push', () => {
 	});
 
 	test('counts match event kinds (invariant)', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
 		await writeTestFile(
 			'posts/good.md',
 			'---\nid: p1\ntitle: Good\npublished: true\n---\n',
@@ -295,17 +294,17 @@ describe('push', () => {
 
 	test('uses custom fromMarkdown callback', async () => {
 		const { workspace } = await setup({
-			tables: (t) => [
-				{
-					table: t.notes,
-					config: {
+			build: (t) => ({
+				tables: { notes: t.notes },
+				perTable: {
+					notes: {
 						fromMarkdown: (parsed) => ({
 							id: parsed.frontmatter.id as string,
 							body: parsed.body ?? '',
 						}),
 					},
 				},
-			],
+			}),
 		});
 		await writeTestFile(
 			'notes/my-note.md',
@@ -324,7 +323,10 @@ describe('push', () => {
 
 	test('uses custom table directory', async () => {
 		const { workspace } = await setup({
-			tables: (t) => [{ table: t.posts, config: { dir: 'blog' } }],
+			build: (t) => ({
+				tables: { posts: t.posts },
+				perTable: { posts: { dir: 'blog' } },
+			}),
 		});
 		await writeTestFile(
 			'blog/hello.md',
@@ -340,7 +342,7 @@ describe('push', () => {
 	});
 
 	test('overwrites existing rows (set is insert-or-replace)', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
 		// First import
 		await writeTestFile(
 			'posts/p1.md',
@@ -396,7 +398,7 @@ describe('push', () => {
 
 describe('pull', () => {
 	test('writes all valid rows to disk', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
 		workspace.tables.posts.set({
 			id: 'p1',
 			title: 'First',
@@ -424,10 +426,10 @@ describe('pull', () => {
 
 	test('uses custom filename and toMarkdown callbacks', async () => {
 		const { workspace } = await setup({
-			tables: (t) => [
-				{
-					table: t.notes,
-					config: {
+			build: (t) => ({
+				tables: { notes: t.notes },
+				perTable: {
+					notes: {
 						filename: (row) => `${row.id}-custom.md`,
 						toMarkdown: (row) => ({
 							frontmatter: { id: row.id },
@@ -435,7 +437,7 @@ describe('pull', () => {
 						}),
 					},
 				},
-			],
+			}),
 		});
 		workspace.tables.notes.set({ id: 'n1', body: 'Custom body' });
 
@@ -451,7 +453,10 @@ describe('pull', () => {
 
 	test('uses custom table directory', async () => {
 		const { workspace } = await setup({
-			tables: (t) => [{ table: t.posts, config: { dir: 'blog' } }],
+			build: (t) => ({
+				tables: { posts: t.posts },
+				perTable: { posts: { dir: 'blog' } },
+			}),
 		});
 		workspace.tables.posts.set({
 			id: 'p1',
@@ -468,7 +473,7 @@ describe('pull', () => {
 	});
 
 	test('writes nothing when table is empty', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
 		const result = await workspace.materializer.pull();
 
 		expect(result.written).toBe(0);
@@ -505,7 +510,7 @@ describe('pull', () => {
 
 describe('rebuild', () => {
 	test('removes orphan files and rewrites existing valid rows', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
 		// Seed disk with rows + an orphan file
 		workspace.tables.posts.set({
 			id: 'p1',
@@ -558,7 +563,7 @@ describe('rebuild', () => {
 	});
 
 	test('throws on unknown table name', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
 		await expect(workspace.materializer.rebuild('notAThing')).rejects.toThrow(
 			/not in the materialized table set/,
 		);
@@ -567,7 +572,7 @@ describe('rebuild', () => {
 	});
 
 	test('is idempotent: rebuild twice produces identical filesystem state', async () => {
-		const { workspace } = await setup({ tables: (t) => [{ table: t.posts }] });
+		const { workspace } = await setup({ build: (t) => ({ tables: { posts: t.posts } }) });
 		workspace.tables.posts.set({
 			id: 'p1',
 			title: 'A',
@@ -616,7 +621,8 @@ describe('round-trip', () => {
 			const tables = attachTables(ydoc, tableDefinitions);
 			const materializer = attachMarkdownMaterializer(ydoc, {
 				dir: TEST_DIR,
-			}).table(tables.posts);
+				tables: { posts: tables.posts },
+			});
 			return {
 				ydoc,
 				tables,
@@ -657,7 +663,8 @@ describe('round-trip', () => {
 			const tables = attachTables(ydoc, tableDefinitions);
 			const materializer = attachMarkdownMaterializer(ydoc, {
 				dir: TEST_DIR,
-			}).table(tables.posts);
+				tables: { posts: tables.posts },
+			});
 			return {
 				ydoc,
 				tables,
@@ -692,22 +699,24 @@ describe('round-trip', () => {
 		// row field: `notes.body` here. Inline callbacks keep the intent
 		// at the call site; no helper abstracts the destructure.
 		const { workspace } = await setup({
-			tables: (t) =>
-				[
-					{
-						table: t.notes,
-						config: {
-							toMarkdown: (row: { id: string; body: string }) => {
-								const { body, ...frontmatter } = row;
-								return { frontmatter, body };
-							},
-							fromMarkdown: (parsed: MarkdownShape) => ({
-								id: parsed.frontmatter.id as string,
-								body: parsed.body ?? '',
-							}),
+			build: (t) => ({
+				tables: { notes: t.notes },
+				perTable: {
+					notes: {
+						toMarkdown: (row) => {
+							const { body, ...frontmatter } = row as {
+								id: string;
+								body: string;
+							};
+							return { frontmatter, body };
 						},
+						fromMarkdown: (parsed: MarkdownShape) => ({
+							id: parsed.frontmatter.id as string,
+							body: parsed.body ?? '',
+						}),
 					},
-				] as unknown as TableRegistration[],
+				},
+			}),
 		});
 
 		const original = { id: 'n1', body: 'Body content here' };

--- a/packages/workspace/src/document/materializer/markdown/materializer.ts
+++ b/packages/workspace/src/document/materializer/markdown/materializer.ts
@@ -112,7 +112,11 @@ export type MarkdownShape = {
 	body: string | undefined;
 };
 
-type TableConfig<TRow extends BaseRow> = {
+/**
+ * Per-table customization slot for the markdown materializer. Each field is
+ * optional; omitted fields fall back to the module-level defaults.
+ */
+export type MarkdownTableConfig<TRow extends BaseRow> = {
 	/** Subdirectory (joined onto the base `dir`) for this table's files. Default: `table.name`. */
 	dir?: string;
 	/** Compute the on-disk filename for a row. Default: `${row.id}.md`. */
@@ -123,24 +127,29 @@ type TableConfig<TRow extends BaseRow> = {
 	fromMarkdown?: (parsed: MarkdownShape) => MaybePromise<TRow>;
 };
 
-type KvConfig = {
-	/** Serialize the full KV state to a single file. Default: `kv.json` with JSON.stringify. */
-	serialize?: (data: Record<string, unknown>) => {
-		filename: string;
-		content: string;
-	};
+// biome-ignore lint/suspicious/noExplicitAny: heterogeneous row types in a record
+type TablesRecord = Record<string, Table<any>>;
+
+/**
+ * Mapped per-table config keyed by `tables`. Each value sees the right row
+ * type for its callbacks. Keys outside `tables` are rejected at the type
+ * level.
+ */
+export type PerTableConfig<TTables extends TablesRecord> = {
+	[K in keyof TTables]?: TTables[K] extends Table<infer R>
+		? MarkdownTableConfig<R>
+		: never;
 };
 
 type RegisteredTable = {
 	table: AnyTable;
 	// biome-ignore lint/suspicious/noExplicitAny: internal storage, variance across heterogeneous row types
-	config: TableConfig<any>;
+	config: MarkdownTableConfig<any>;
 	unsubscribe?: () => void;
 };
 
 type RegisteredKv = {
 	kv: AnyKv;
-	config: KvConfig;
 	unsubscribe?: () => void;
 };
 
@@ -177,7 +186,7 @@ const defaultKvSerialize = (data: Record<string, unknown>) => ({
  */
 async function rowToMarkdownFile<TRow extends BaseRow>(
 	row: TRow,
-	config: TableConfig<TRow>,
+	config: MarkdownTableConfig<TRow>,
 ): Promise<{ filename: string; content: string }> {
 	const filenameFn = config.filename ?? defaultFilename;
 	const toMarkdownFn = config.toMarkdown ?? defaultToMarkdown;
@@ -211,14 +220,15 @@ async function writeMarkdownFile(
 /**
  * Create a bidirectional markdown materializer for workspace data.
  *
- * `attachMarkdownMaterializer(ydoc, { dir })` returns a chainable builder where
- * `.table(tableRef, config?)` opts in per table and `.kv(kvRef, config?)` opts
- * in a single KV mirror. Nothing materializes by default.
+ * Pass the workspace `tables` record (or an object subset) and the
+ * materializer mirrors every entry as a directory of .md files. Customize
+ * filename / serializer behavior per table via `perTable`. Pass `kv` to
+ * mirror the workspace KV as a single file alongside the tables.
  *
  * Exposes three mutations:
- * - `push`: disk → workspace. Import .md files as rows (additive).
- * - `pull`: workspace → disk. Write every row as .md file (additive).
- * - `rebuild`: workspace → disk, destructive. Clear output dir then rewrite
+ * - `push`: disk to workspace. Import .md files as rows (additive).
+ * - `pull`: workspace to disk. Write every row as .md file (additive).
+ * - `rebuild`: workspace to disk, destructive. Clear output dir then rewrite
  *   all rows. Use for orphan cleanup or after config changes.
  *   Matches the sqlite materializer's `rebuild` for cross-materializer parity.
  *
@@ -235,25 +245,42 @@ async function writeMarkdownFile(
  * const markdown = attachMarkdownMaterializer(ydoc, {
  *   dir: './data',
  *   waitFor: idb.whenLoaded,
- * })
- *   .table(tables.posts, {
- *     filename: slugFilename('title'),
+ *   tables,
+ *   perTable: {
+ *     posts: { filename: slugFilename('title') },
  *     // Inline toMarkdown / fromMarkdown callbacks when needed:
  *     // most real tables split metadata (on the row) from body
  *     // content (in a separate content-doc via createDisposableCache).
- *   })
- *   .kv(kv);
+ *   },
+ *   kv,
+ * });
  * ```
  */
-export function attachMarkdownMaterializer(
+export function attachMarkdownMaterializer<TTables extends TablesRecord>(
 	ydoc: Y.Doc,
 	{
 		dir,
+		tables,
+		perTable,
+		kv,
 		waitFor,
 		log = createLogger('markdown-materializer'),
 	}: {
 		/** Base output directory. Accepts a string or async getter for lazy path resolution. */
 		dir: string | (() => MaybePromise<string>);
+		/**
+		 * Tables to mirror. Pass the full `tables` record to mirror everything,
+		 * or an object subset like `{ notes: tables.notes }` to mirror a slice.
+		 */
+		tables: TTables;
+		/**
+		 * Optional per-table customization keyed by table name. Each entry can
+		 * override `dir`, `filename`, `toMarkdown`, and `fromMarkdown` for that
+		 * table only.
+		 */
+		perTable?: PerTableConfig<TTables>;
+		/** Optional workspace KV to mirror as a single file (default `kv.json`). */
+		kv?: AnyKv;
 		/**
 		 * Gate: the materializer awaits this before the initial filesystem flush.
 		 * Matches the `waitFor` convention used by `openCollaboration`. Omit for
@@ -261,21 +288,22 @@ export function attachMarkdownMaterializer(
 		 */
 		waitFor?: Promise<unknown>;
 		/**
-		 * Logger for background write-observer failures (table row → file,
-		 * KV state → file). Defaults to a console-backed logger.
+		 * Logger for background write-observer failures (table row to file,
+		 * KV state to file). Defaults to a console-backed logger.
 		 */
 		log?: Logger;
 	},
 ) {
 	const registered = new Map<string, RegisteredTable>();
-	let registeredKv: RegisteredKv | undefined;
+	for (const [name, table] of Object.entries(tables)) {
+		const config =
+			(perTable as Record<string, MarkdownTableConfig<BaseRow>> | undefined)?.[
+				name
+			] ?? {};
+		registered.set(name, { table: table as AnyTable, config });
+	}
+	const registeredKv: RegisteredKv | undefined = kv ? { kv } : undefined;
 	let isDisposed = false;
-	/**
-	 * Closed once `initialize()` commits (past `await waitFor`). Any `.table()`
-	 * / `.kv()` call after this throws: the materializer is past the point
-	 * where late registrations would be picked up for initial flush.
-	 */
-	let isRegistrationOpen = true;
 
 	const resolveDir = async () =>
 		typeof dir === 'function' ? await dir() : dir;
@@ -334,12 +362,11 @@ export function attachMarkdownMaterializer(
 
 	async function materializeKv(
 		baseDir: string,
-		{ kv, config }: RegisteredKv,
+		{ kv }: RegisteredKv,
 	): Promise<() => void> {
 		const state: Record<string, unknown> = { ...kv.getAll() };
-		const serialize = config.serialize ?? defaultKvSerialize;
 
-		const initial = serialize(state);
+		const initial = defaultKvSerialize(state);
 		await writeFile(join(baseDir, initial.filename), initial.content);
 
 		return kv.observeAll((changes) => {
@@ -348,7 +375,7 @@ export function attachMarkdownMaterializer(
 					if (change.type === 'set') state[key] = change.value;
 					else delete state[key];
 				}
-				const result = serialize(state);
+				const result = defaultKvSerialize(state);
 				await writeFile(join(baseDir, result.filename), result.content);
 			})().catch((cause) => {
 				log.warn(MaterializerWriteError.KvWriteFailed({ cause }));
@@ -361,9 +388,6 @@ export function attachMarkdownMaterializer(
 	function dispose() {
 		if (isDisposed) return;
 		isDisposed = true;
-		// Close the registration window even if `initialize()` never ran
-		// (e.g., waitFor stalled and the ydoc was destroyed before init).
-		isRegistrationOpen = false;
 		for (const entry of registered.values()) entry.unsubscribe?.();
 		registeredKv?.unsubscribe?.();
 	}
@@ -373,12 +397,9 @@ export function attachMarkdownMaterializer(
 	// ── Initial flush ────────────────────────────────────────────
 
 	async function initialize() {
-		// Always yield a microtask so callers can finish synchronous setup
-		// (including `.table()` / `.kv()` registrations) before the first flush.
+		// Always yield a microtask so callers can seed `.set()` writes between
+		// construction and `await whenFlushed` before the first filesystem flush.
 		await waitFor;
-		// Close the registration window: any further `.table()` / `.kv()` call
-		// throws, even if init errors or disposes mid-flight below.
-		isRegistrationOpen = false;
 		if (isDisposed) return;
 
 		const baseDir = await resolveDir();
@@ -555,10 +576,9 @@ export function attachMarkdownMaterializer(
 
 		// Re-materialize KV if registered and this is a full reindex.
 		if (tableName === undefined && registeredKv) {
-			const { kv, config } = registeredKv;
-			const serialize = config.serialize ?? defaultKvSerialize;
+			const { kv } = registeredKv;
 			const state = { ...kv.getAll() };
-			const result = serialize(state);
+			const result = defaultKvSerialize(state);
 			await writeFile(join(baseDir, result.filename), result.content);
 			written++;
 		}
@@ -586,9 +606,9 @@ export function attachMarkdownMaterializer(
 		return { written };
 	}
 
-	// ── Builder ──────────────────────────────────────────────────
+	// ── Public API ───────────────────────────────────────────────
 
-	const api = {
+	return {
 		whenFlushed,
 		/** Read markdown files from disk and import rows into registered tables. */
 		push: pushMarkdownFiles,
@@ -601,53 +621,4 @@ export function attachMarkdownMaterializer(
 		 */
 		rebuild: rebuildMarkdownFiles,
 	};
-
-	type MaterializerBuilder = typeof api & {
-		/**
-		 * Opt in a workspace table for markdown materialization.
-		 *
-		 * Must be called synchronously after construction, before `whenFlushed`
-		 * resolves.
-		 */
-		table<TRow extends BaseRow>(
-			table: Table<TRow>,
-			config?: TableConfig<TRow>,
-		): MaterializerBuilder;
-		/**
-		 * Opt in the workspace Kv for markdown materialization. Single file on
-		 * disk (default `kv.json`) keeps the full Kv state.
-		 *
-		 * Must be called synchronously after construction, before `whenFlushed`
-		 * resolves.
-		 */
-		kv(kv: AnyKv, config?: KvConfig): MaterializerBuilder;
-	};
-
-	const builder: MaterializerBuilder = {
-		...api,
-		table(table, config) {
-			if (!isRegistrationOpen)
-				throw new Error(
-					`attachMarkdownMaterializer: .table("${table.name}") called after initial flush. All .table() registrations must happen synchronously after construction.`,
-				);
-			registered.set(table.name, {
-				table: table as AnyTable,
-				config: config ?? {},
-			});
-			return builder;
-		},
-		kv(kv, config) {
-			if (!isRegistrationOpen)
-				throw new Error(
-					'attachMarkdownMaterializer: .kv() called after initial flush. All .kv() registrations must happen synchronously after construction.',
-				);
-			registeredKv = {
-				kv: kv as AnyKv,
-				config: config ?? {},
-			};
-			return builder;
-		},
-	};
-
-	return builder;
 }

--- a/packages/workspace/src/document/materializer/markdown/materializer.ts
+++ b/packages/workspace/src/document/materializer/markdown/materializer.ts
@@ -112,7 +112,7 @@ export type MarkdownShape = {
 	body: string | undefined;
 };
 
-export type MarkdownTableConfig<TRow extends BaseRow> = {
+type TableConfig<TRow extends BaseRow> = {
 	/** Subdirectory (joined onto the base `dir`) for this table's files. Default: `table.name`. */
 	dir?: string;
 	/** Compute the on-disk filename for a row. Default: `${row.id}.md`. */
@@ -123,7 +123,7 @@ export type MarkdownTableConfig<TRow extends BaseRow> = {
 	fromMarkdown?: (parsed: MarkdownShape) => MaybePromise<TRow>;
 };
 
-export type MarkdownKvConfig = {
+type KvConfig = {
 	/** Serialize the full KV state to a single file. Default: `kv.json` with JSON.stringify. */
 	serialize?: (data: Record<string, unknown>) => {
 		filename: string;
@@ -131,42 +131,16 @@ export type MarkdownKvConfig = {
 	};
 };
 
-/**
- * One element of the materializer's `tables` option. Either a bare table
- * reference (when no per-table config is needed) or a `[table, config]`
- * tuple. `config` narrows per entry so `filename: (row) => row.title`
- * sees the specific row type.
- */
-export type MarkdownTableEntry<TRow extends BaseRow> =
-	| Table<TRow>
-	| readonly [Table<TRow>, MarkdownTableConfig<TRow>?];
-
-/**
- * Variadic mapped type over a tuple of row types. Each element of the
- * outer tuple is `MarkdownTableEntry<Rows[K]>`, so the row type is inferred
- * per entry from the table reference.
- */
-export type MarkdownTableEntries<TRows extends readonly BaseRow[]> = {
-	[K in keyof TRows]: MarkdownTableEntry<TRows[K]>;
-};
-
-/**
- * The `kv` option: either a bare Kv reference or a `[kv, config]` tuple.
- * Single value (not an array of entries), because the markdown materializer
- * mirrors at most one KV per workspace.
- */
-export type MarkdownKvEntry = AnyKv | readonly [AnyKv, MarkdownKvConfig?];
-
 type RegisteredTable = {
 	table: AnyTable;
 	// biome-ignore lint/suspicious/noExplicitAny: internal storage, variance across heterogeneous row types
-	config: MarkdownTableConfig<any>;
+	config: TableConfig<any>;
 	unsubscribe?: () => void;
 };
 
 type RegisteredKv = {
 	kv: AnyKv;
-	config: MarkdownKvConfig;
+	config: KvConfig;
 	unsubscribe?: () => void;
 };
 
@@ -203,7 +177,7 @@ const defaultKvSerialize = (data: Record<string, unknown>) => ({
  */
 async function rowToMarkdownFile<TRow extends BaseRow>(
 	row: TRow,
-	config: MarkdownTableConfig<TRow>,
+	config: TableConfig<TRow>,
 ): Promise<{ filename: string; content: string }> {
 	const filenameFn = config.filename ?? defaultFilename;
 	const toMarkdownFn = config.toMarkdown ?? defaultToMarkdown;
@@ -237,8 +211,9 @@ async function writeMarkdownFile(
 /**
  * Create a bidirectional markdown materializer for workspace data.
  *
- * Tables and (optionally) a KV are passed as options; nothing materializes
- * until they're listed in `tables` / `kv`.
+ * `attachMarkdownMaterializer(ydoc, { dir })` returns a chainable builder where
+ * `.table(tableRef, config?)` opts in per table and `.kv(kvRef, config?)` opts
+ * in a single KV mirror. Nothing materializes by default.
  *
  * Exposes three mutations:
  * - `push`: disk → workspace. Import .md files as rows (additive).
@@ -260,39 +235,25 @@ async function writeMarkdownFile(
  * const markdown = attachMarkdownMaterializer(ydoc, {
  *   dir: './data',
  *   waitFor: idb.whenLoaded,
- *   tables: [
- *     [tables.posts, { filename: slugFilename('title') }],
- *     tables.devices,
- *   ],
- *   kv,
- * });
+ * })
+ *   .table(tables.posts, {
+ *     filename: slugFilename('title'),
+ *     // Inline toMarkdown / fromMarkdown callbacks when needed:
+ *     // most real tables split metadata (on the row) from body
+ *     // content (in a separate content-doc via createDisposableCache).
+ *   })
+ *   .kv(kv);
  * ```
  */
-export function attachMarkdownMaterializer<
-	const TRows extends readonly BaseRow[],
->(
+export function attachMarkdownMaterializer(
 	ydoc: Y.Doc,
 	{
 		dir,
-		tables,
-		kv,
 		waitFor,
 		log = createLogger('markdown-materializer'),
 	}: {
 		/** Base output directory. Accepts a string or async getter for lazy path resolution. */
 		dir: string | (() => MaybePromise<string>);
-		/**
-		 * Workspace tables to materialize. Each entry is either the table
-		 * reference directly (no per-table config) or a `[table, config]` tuple.
-		 * Per-table `filename` / `toMarkdown` / `fromMarkdown` callbacks see the
-		 * row's specific type.
-		 */
-		tables: MarkdownTableEntries<TRows>;
-		/**
-		 * Optional KV to materialize as a single on-disk file. Pass the Kv
-		 * directly or as `[kv, config]` for serializer overrides.
-		 */
-		kv?: MarkdownKvEntry;
 		/**
 		 * Gate: the materializer awaits this before the initial filesystem flush.
 		 * Matches the `waitFor` convention used by `openCollaboration`. Omit for
@@ -307,25 +268,14 @@ export function attachMarkdownMaterializer<
 	},
 ) {
 	const registered = new Map<string, RegisteredTable>();
-	for (const entry of tables) {
-		const [table, config] = Array.isArray(entry)
-			? (entry as readonly [AnyTable, MarkdownTableConfig<BaseRow>?])
-			: ([entry as AnyTable, undefined] as const);
-		registered.set(table.name, {
-			table,
-			config: config ?? {},
-		});
-	}
-
 	let registeredKv: RegisteredKv | undefined;
-	if (kv) {
-		const [kvRef, kvConfig] = Array.isArray(kv)
-			? (kv as readonly [AnyKv, MarkdownKvConfig?])
-			: ([kv as AnyKv, undefined] as const);
-		registeredKv = { kv: kvRef, config: kvConfig ?? {} };
-	}
-
 	let isDisposed = false;
+	/**
+	 * Closed once `initialize()` commits (past `await waitFor`). Any `.table()`
+	 * / `.kv()` call after this throws: the materializer is past the point
+	 * where late registrations would be picked up for initial flush.
+	 */
+	let isRegistrationOpen = true;
 
 	const resolveDir = async () =>
 		typeof dir === 'function' ? await dir() : dir;
@@ -411,6 +361,9 @@ export function attachMarkdownMaterializer<
 	function dispose() {
 		if (isDisposed) return;
 		isDisposed = true;
+		// Close the registration window even if `initialize()` never ran
+		// (e.g., waitFor stalled and the ydoc was destroyed before init).
+		isRegistrationOpen = false;
 		for (const entry of registered.values()) entry.unsubscribe?.();
 		registeredKv?.unsubscribe?.();
 	}
@@ -420,7 +373,12 @@ export function attachMarkdownMaterializer<
 	// ── Initial flush ────────────────────────────────────────────
 
 	async function initialize() {
+		// Always yield a microtask so callers can finish synchronous setup
+		// (including `.table()` / `.kv()` registrations) before the first flush.
 		await waitFor;
+		// Close the registration window: any further `.table()` / `.kv()` call
+		// throws, even if init errors or disposes mid-flight below.
+		isRegistrationOpen = false;
 		if (isDisposed) return;
 
 		const baseDir = await resolveDir();
@@ -628,7 +586,9 @@ export function attachMarkdownMaterializer<
 		return { written };
 	}
 
-	return {
+	// ── Builder ──────────────────────────────────────────────────
+
+	const api = {
 		whenFlushed,
 		/** Read markdown files from disk and import rows into registered tables. */
 		push: pushMarkdownFiles,
@@ -641,4 +601,53 @@ export function attachMarkdownMaterializer<
 		 */
 		rebuild: rebuildMarkdownFiles,
 	};
+
+	type MaterializerBuilder = typeof api & {
+		/**
+		 * Opt in a workspace table for markdown materialization.
+		 *
+		 * Must be called synchronously after construction, before `whenFlushed`
+		 * resolves.
+		 */
+		table<TRow extends BaseRow>(
+			table: Table<TRow>,
+			config?: TableConfig<TRow>,
+		): MaterializerBuilder;
+		/**
+		 * Opt in the workspace Kv for markdown materialization. Single file on
+		 * disk (default `kv.json`) keeps the full Kv state.
+		 *
+		 * Must be called synchronously after construction, before `whenFlushed`
+		 * resolves.
+		 */
+		kv(kv: AnyKv, config?: KvConfig): MaterializerBuilder;
+	};
+
+	const builder: MaterializerBuilder = {
+		...api,
+		table(table, config) {
+			if (!isRegistrationOpen)
+				throw new Error(
+					`attachMarkdownMaterializer: .table("${table.name}") called after initial flush. All .table() registrations must happen synchronously after construction.`,
+				);
+			registered.set(table.name, {
+				table: table as AnyTable,
+				config: config ?? {},
+			});
+			return builder;
+		},
+		kv(kv, config) {
+			if (!isRegistrationOpen)
+				throw new Error(
+					'attachMarkdownMaterializer: .kv() called after initial flush. All .kv() registrations must happen synchronously after construction.',
+				);
+			registeredKv = {
+				kv: kv as AnyKv,
+				config: config ?? {},
+			};
+			return builder;
+		},
+	};
+
+	return builder;
 }

--- a/packages/workspace/src/document/materializer/markdown/materializer.ts
+++ b/packages/workspace/src/document/materializer/markdown/materializer.ts
@@ -136,8 +136,8 @@ type TablesRecord = Record<string, Table<any>>;
  * level.
  */
 export type PerTableConfig<TTables extends TablesRecord> = {
-	[K in keyof TTables]?: TTables[K] extends Table<infer R>
-		? MarkdownTableConfig<R>
+	[K in keyof TTables]?: TTables[K] extends Table<infer TRow>
+		? MarkdownTableConfig<TRow>
 		: never;
 };
 
@@ -167,14 +167,8 @@ const defaultToMarkdown = (row: BaseRow) =>
 const defaultFromMarkdown = (parsed: MarkdownShape): BaseRow =>
 	parsed.frontmatter as BaseRow;
 
-/**
- * Default KV serializer: pretty-printed JSON in `kv.json`. Used whenever a
- * registered kv's `config.serialize` isn't provided.
- */
-const defaultKvSerialize = (data: Record<string, unknown>) => ({
-	filename: 'kv.json',
-	content: JSON.stringify(data, null, 2),
-});
+/** Filename for the KV mirror: a single pretty-printed JSON file. */
+const KV_FILENAME = 'kv.json';
 
 /**
  * Compose a row into the full on-disk artifact: filename + content string.
@@ -365,9 +359,9 @@ export function attachMarkdownMaterializer<TTables extends TablesRecord>(
 		{ kv }: RegisteredKv,
 	): Promise<() => void> {
 		const state: Record<string, unknown> = { ...kv.getAll() };
+		const kvPath = join(baseDir, KV_FILENAME);
 
-		const initial = defaultKvSerialize(state);
-		await writeFile(join(baseDir, initial.filename), initial.content);
+		await writeFile(kvPath, JSON.stringify(state, null, 2));
 
 		return kv.observeAll((changes) => {
 			void (async () => {
@@ -375,8 +369,7 @@ export function attachMarkdownMaterializer<TTables extends TablesRecord>(
 					if (change.type === 'set') state[key] = change.value;
 					else delete state[key];
 				}
-				const result = defaultKvSerialize(state);
-				await writeFile(join(baseDir, result.filename), result.content);
+				await writeFile(kvPath, JSON.stringify(state, null, 2));
 			})().catch((cause) => {
 				log.warn(MaterializerWriteError.KvWriteFailed({ cause }));
 			});
@@ -535,20 +528,7 @@ export function attachMarkdownMaterializer<TTables extends TablesRecord>(
 		let deleted = 0;
 		let written = 0;
 
-		const targets =
-			tableName !== undefined
-				? ([registered.get(tableName)].filter(
-						(entry): entry is RegisteredTable => entry !== undefined,
-					) as RegisteredTable[])
-				: [...registered.values()];
-
-		if (tableName !== undefined && targets.length === 0) {
-			throw new Error(
-				`Cannot rebuild "${tableName}": not in the materialized table set.`,
-			);
-		}
-
-		for (const entry of targets) {
+		async function rebuildOne(entry: RegisteredTable) {
 			const directory = join(baseDir, entry.config.dir ?? entry.table.name);
 
 			// Sweep existing .md files
@@ -574,12 +554,26 @@ export function attachMarkdownMaterializer<TTables extends TablesRecord>(
 			}
 		}
 
-		// Re-materialize KV if registered and this is a full reindex.
-		if (tableName === undefined && registeredKv) {
-			const { kv } = registeredKv;
-			const state = { ...kv.getAll() };
-			const result = defaultKvSerialize(state);
-			await writeFile(join(baseDir, result.filename), result.content);
+		if (tableName !== undefined) {
+			const entry = registered.get(tableName);
+			if (entry === undefined) {
+				throw new Error(
+					`Cannot rebuild "${tableName}": not in the materialized table set.`,
+				);
+			}
+			await rebuildOne(entry);
+			return { deleted, written };
+		}
+
+		for (const entry of registered.values()) await rebuildOne(entry);
+
+		// Full reindex: re-materialize KV if registered.
+		if (registeredKv) {
+			const state = { ...registeredKv.kv.getAll() };
+			await writeFile(
+				join(baseDir, KV_FILENAME),
+				JSON.stringify(state, null, 2),
+			);
 			written++;
 		}
 

--- a/packages/workspace/src/document/materializer/markdown/materializer.ts
+++ b/packages/workspace/src/document/materializer/markdown/materializer.ts
@@ -112,7 +112,7 @@ export type MarkdownShape = {
 	body: string | undefined;
 };
 
-type TableConfig<TRow extends BaseRow> = {
+export type MarkdownTableConfig<TRow extends BaseRow> = {
 	/** Subdirectory (joined onto the base `dir`) for this table's files. Default: `table.name`. */
 	dir?: string;
 	/** Compute the on-disk filename for a row. Default: `${row.id}.md`. */
@@ -123,7 +123,7 @@ type TableConfig<TRow extends BaseRow> = {
 	fromMarkdown?: (parsed: MarkdownShape) => MaybePromise<TRow>;
 };
 
-type KvConfig = {
+export type MarkdownKvConfig = {
 	/** Serialize the full KV state to a single file. Default: `kv.json` with JSON.stringify. */
 	serialize?: (data: Record<string, unknown>) => {
 		filename: string;
@@ -131,16 +131,42 @@ type KvConfig = {
 	};
 };
 
+/**
+ * One element of the materializer's `tables` option. Either a bare table
+ * reference (when no per-table config is needed) or a `[table, config]`
+ * tuple. `config` narrows per entry so `filename: (row) => row.title`
+ * sees the specific row type.
+ */
+export type MarkdownTableEntry<TRow extends BaseRow> =
+	| Table<TRow>
+	| readonly [Table<TRow>, MarkdownTableConfig<TRow>?];
+
+/**
+ * Variadic mapped type over a tuple of row types. Each element of the
+ * outer tuple is `MarkdownTableEntry<Rows[K]>`, so the row type is inferred
+ * per entry from the table reference.
+ */
+export type MarkdownTableEntries<TRows extends readonly BaseRow[]> = {
+	[K in keyof TRows]: MarkdownTableEntry<TRows[K]>;
+};
+
+/**
+ * The `kv` option: either a bare Kv reference or a `[kv, config]` tuple.
+ * Single value (not an array of entries), because the markdown materializer
+ * mirrors at most one KV per workspace.
+ */
+export type MarkdownKvEntry = AnyKv | readonly [AnyKv, MarkdownKvConfig?];
+
 type RegisteredTable = {
 	table: AnyTable;
 	// biome-ignore lint/suspicious/noExplicitAny: internal storage, variance across heterogeneous row types
-	config: TableConfig<any>;
+	config: MarkdownTableConfig<any>;
 	unsubscribe?: () => void;
 };
 
 type RegisteredKv = {
 	kv: AnyKv;
-	config: KvConfig;
+	config: MarkdownKvConfig;
 	unsubscribe?: () => void;
 };
 
@@ -177,7 +203,7 @@ const defaultKvSerialize = (data: Record<string, unknown>) => ({
  */
 async function rowToMarkdownFile<TRow extends BaseRow>(
 	row: TRow,
-	config: TableConfig<TRow>,
+	config: MarkdownTableConfig<TRow>,
 ): Promise<{ filename: string; content: string }> {
 	const filenameFn = config.filename ?? defaultFilename;
 	const toMarkdownFn = config.toMarkdown ?? defaultToMarkdown;
@@ -211,9 +237,8 @@ async function writeMarkdownFile(
 /**
  * Create a bidirectional markdown materializer for workspace data.
  *
- * `attachMarkdownMaterializer(ydoc, { dir })` returns a chainable builder where
- * `.table(tableRef, config?)` opts in per table and `.kv(kvRef, config?)` opts
- * in a single KV mirror. Nothing materializes by default.
+ * Tables and (optionally) a KV are passed as options; nothing materializes
+ * until they're listed in `tables` / `kv`.
  *
  * Exposes three mutations:
  * - `push`: disk → workspace. Import .md files as rows (additive).
@@ -235,25 +260,39 @@ async function writeMarkdownFile(
  * const markdown = attachMarkdownMaterializer(ydoc, {
  *   dir: './data',
  *   waitFor: idb.whenLoaded,
- * })
- *   .table(tables.posts, {
- *     filename: slugFilename('title'),
- *     // Inline toMarkdown / fromMarkdown callbacks when needed:
- *     // most real tables split metadata (on the row) from body
- *     // content (in a separate content-doc via createDisposableCache).
- *   })
- *   .kv(kv);
+ *   tables: [
+ *     [tables.posts, { filename: slugFilename('title') }],
+ *     tables.devices,
+ *   ],
+ *   kv,
+ * });
  * ```
  */
-export function attachMarkdownMaterializer(
+export function attachMarkdownMaterializer<
+	const TRows extends readonly BaseRow[],
+>(
 	ydoc: Y.Doc,
 	{
 		dir,
+		tables,
+		kv,
 		waitFor,
 		log = createLogger('markdown-materializer'),
 	}: {
 		/** Base output directory. Accepts a string or async getter for lazy path resolution. */
 		dir: string | (() => MaybePromise<string>);
+		/**
+		 * Workspace tables to materialize. Each entry is either the table
+		 * reference directly (no per-table config) or a `[table, config]` tuple.
+		 * Per-table `filename` / `toMarkdown` / `fromMarkdown` callbacks see the
+		 * row's specific type.
+		 */
+		tables: MarkdownTableEntries<TRows>;
+		/**
+		 * Optional KV to materialize as a single on-disk file. Pass the Kv
+		 * directly or as `[kv, config]` for serializer overrides.
+		 */
+		kv?: MarkdownKvEntry;
 		/**
 		 * Gate: the materializer awaits this before the initial filesystem flush.
 		 * Matches the `waitFor` convention used by `openCollaboration`. Omit for
@@ -268,14 +307,25 @@ export function attachMarkdownMaterializer(
 	},
 ) {
 	const registered = new Map<string, RegisteredTable>();
+	for (const entry of tables) {
+		const [table, config] = Array.isArray(entry)
+			? (entry as readonly [AnyTable, MarkdownTableConfig<BaseRow>?])
+			: ([entry as AnyTable, undefined] as const);
+		registered.set(table.name, {
+			table,
+			config: config ?? {},
+		});
+	}
+
 	let registeredKv: RegisteredKv | undefined;
+	if (kv) {
+		const [kvRef, kvConfig] = Array.isArray(kv)
+			? (kv as readonly [AnyKv, MarkdownKvConfig?])
+			: ([kv as AnyKv, undefined] as const);
+		registeredKv = { kv: kvRef, config: kvConfig ?? {} };
+	}
+
 	let isDisposed = false;
-	/**
-	 * Closed once `initialize()` commits (past `await waitFor`). Any `.table()`
-	 * / `.kv()` call after this throws: the materializer is past the point
-	 * where late registrations would be picked up for initial flush.
-	 */
-	let isRegistrationOpen = true;
 
 	const resolveDir = async () =>
 		typeof dir === 'function' ? await dir() : dir;
@@ -361,9 +411,6 @@ export function attachMarkdownMaterializer(
 	function dispose() {
 		if (isDisposed) return;
 		isDisposed = true;
-		// Close the registration window even if `initialize()` never ran
-		// (e.g., waitFor stalled and the ydoc was destroyed before init).
-		isRegistrationOpen = false;
 		for (const entry of registered.values()) entry.unsubscribe?.();
 		registeredKv?.unsubscribe?.();
 	}
@@ -373,12 +420,7 @@ export function attachMarkdownMaterializer(
 	// ── Initial flush ────────────────────────────────────────────
 
 	async function initialize() {
-		// Always yield a microtask so callers can finish synchronous setup
-		// (including `.table()` / `.kv()` registrations) before the first flush.
 		await waitFor;
-		// Close the registration window: any further `.table()` / `.kv()` call
-		// throws, even if init errors or disposes mid-flight below.
-		isRegistrationOpen = false;
 		if (isDisposed) return;
 
 		const baseDir = await resolveDir();
@@ -586,9 +628,7 @@ export function attachMarkdownMaterializer(
 		return { written };
 	}
 
-	// ── Builder ──────────────────────────────────────────────────
-
-	const api = {
+	return {
 		whenFlushed,
 		/** Read markdown files from disk and import rows into registered tables. */
 		push: pushMarkdownFiles,
@@ -601,53 +641,4 @@ export function attachMarkdownMaterializer(
 		 */
 		rebuild: rebuildMarkdownFiles,
 	};
-
-	type MaterializerBuilder = typeof api & {
-		/**
-		 * Opt in a workspace table for markdown materialization.
-		 *
-		 * Must be called synchronously after construction, before `whenFlushed`
-		 * resolves.
-		 */
-		table<TRow extends BaseRow>(
-			table: Table<TRow>,
-			config?: TableConfig<TRow>,
-		): MaterializerBuilder;
-		/**
-		 * Opt in the workspace Kv for markdown materialization. Single file on
-		 * disk (default `kv.json`) keeps the full Kv state.
-		 *
-		 * Must be called synchronously after construction, before `whenFlushed`
-		 * resolves.
-		 */
-		kv(kv: AnyKv, config?: KvConfig): MaterializerBuilder;
-	};
-
-	const builder: MaterializerBuilder = {
-		...api,
-		table(table, config) {
-			if (!isRegistrationOpen)
-				throw new Error(
-					`attachMarkdownMaterializer: .table("${table.name}") called after initial flush. All .table() registrations must happen synchronously after construction.`,
-				);
-			registered.set(table.name, {
-				table: table as AnyTable,
-				config: config ?? {},
-			});
-			return builder;
-		},
-		kv(kv, config) {
-			if (!isRegistrationOpen)
-				throw new Error(
-					'attachMarkdownMaterializer: .kv() called after initial flush. All .kv() registrations must happen synchronously after construction.',
-				);
-			registeredKv = {
-				kv: kv as AnyKv,
-				config: config ?? {},
-			};
-			return builder;
-		},
-	};
-
-	return builder;
 }

--- a/packages/workspace/src/document/materializer/markdown/slug-filename.ts
+++ b/packages/workspace/src/document/materializer/markdown/slug-filename.ts
@@ -3,11 +3,15 @@ import type { BaseRow } from '../../attach-table.js';
 
 /**
  * Build a `filename` slot that produces `{slug}-{id}.md` using a row field
- * as the slug source. Pass to `.table(t, { filename: slugFilename('title') })`.
+ * as the slug source. Pass inside a `tables` entry of
+ * `attachMarkdownMaterializer`.
  *
  * @example
  * ```typescript
- * .table(tables.posts, { filename: slugFilename('title') })
+ * attachMarkdownMaterializer(ydoc, {
+ *   dir,
+ *   tables: [[tables.posts, { filename: slugFilename('title') }]],
+ * });
  * // row with title "Hello World", id "abc123" => "hello-world-abc123.md"
  * ```
  */

--- a/packages/workspace/src/document/materializer/markdown/slug-filename.ts
+++ b/packages/workspace/src/document/materializer/markdown/slug-filename.ts
@@ -3,18 +3,22 @@ import type { BaseRow } from '../../attach-table.js';
 
 /**
  * Build a `filename` slot that produces `{slug}-{id}.md` using a row field
- * as the slug source. Pass to `.table(t, { filename: slugFilename('title') })`.
+ * as the slug source. Pass via `perTable[tableName].filename`.
  *
  * @example
  * ```typescript
- * .table(tables.posts, { filename: slugFilename('title') })
+ * attachMarkdownMaterializer(ydoc, {
+ *   dir,
+ *   tables,
+ *   perTable: { posts: { filename: slugFilename('title') } },
+ * });
  * // row with title "Hello World", id "abc123" => "hello-world-abc123.md"
  * ```
  */
-export function slugFilename<TRow extends BaseRow>(
-	field: keyof TRow & string,
-): (row: TRow) => string {
-	return (row) => {
+export function slugFilename<TField extends string>(field: TField) {
+	return <TRow extends BaseRow & { [P in TField]: unknown }>(
+		row: TRow,
+	): string => {
 		const value = row[field];
 		return toSlugFilename(
 			typeof value === 'string' ? value : undefined,

--- a/packages/workspace/src/document/materializer/markdown/slug-filename.ts
+++ b/packages/workspace/src/document/materializer/markdown/slug-filename.ts
@@ -3,15 +3,11 @@ import type { BaseRow } from '../../attach-table.js';
 
 /**
  * Build a `filename` slot that produces `{slug}-{id}.md` using a row field
- * as the slug source. Pass inside a `tables` entry of
- * `attachMarkdownMaterializer`.
+ * as the slug source. Pass to `.table(t, { filename: slugFilename('title') })`.
  *
  * @example
  * ```typescript
- * attachMarkdownMaterializer(ydoc, {
- *   dir,
- *   tables: [[tables.posts, { filename: slugFilename('title') }]],
- * });
+ * .table(tables.posts, { filename: slugFilename('title') })
  * // row with title "Hello World", id "abc123" => "hello-world-abc123.md"
  * ```
  */

--- a/packages/workspace/src/document/materializer/sqlite/bun-sqlite.ts
+++ b/packages/workspace/src/document/materializer/sqlite/bun-sqlite.ts
@@ -1,5 +1,5 @@
 /**
- * `attachBunSqliteMaterializer(ydoc, { filePath, tables })`: bun:sqlite-backed
+ * `attachBunSqliteMaterializer(ydoc, { filePath })`: bun:sqlite-backed
  * materializer. Owns the database file end-to-end: opens it (with the
  * writer-side WAL pragmas), mirrors Y.Doc table rows into it, and closes
  * the handle when the ydoc is destroyed.
@@ -12,8 +12,7 @@
  * const materializer = attachBunSqliteMaterializer(ydoc, {
  *   filePath: sqlitePath(projectDir, ydoc.guid),
  *   waitFor: idb.whenLoaded,
- *   tables: [[tables.entries, { fts: ['title', 'body'] }]],
- * });
+ * }).table(tables.entries, { fts: ['title', 'body'] });
  *
  * // Daemon-local typed reads:
  * const schema = tablesToDrizzleSchema(definitions);
@@ -27,32 +26,20 @@
 import type { Database } from 'bun:sqlite';
 import { createLogger, type Logger } from 'wellcrafted/logger';
 import type * as Y from 'yjs';
-import type { BaseRow } from '../../attach-table.js';
+import type { BaseRow, Table } from '../../attach-table.js';
 import { openWriterSqlite } from '../../sqlite-writer.js';
-import {
-	attachSqliteMaterializerCore,
-	type TableEntries,
-} from './core.js';
+import { attachSqliteMaterializerCore, type TableConfig } from './core.js';
 
 /**
  * Options for {@link attachBunSqliteMaterializer}.
  */
-export type AttachBunSqliteMaterializerOptions<
-	TRows extends readonly BaseRow[],
-> = {
+export type AttachBunSqliteMaterializerOptions = {
 	/**
 	 * Absolute path to the bun:sqlite mirror file, or `':memory:'` for an
 	 * ephemeral in-memory mirror. The parent directory is created on demand
 	 * (no-op for `:memory:`).
 	 */
 	filePath: ':memory:' | (string & {});
-
-	/**
-	 * Workspace tables to mirror. Each entry is either the table reference
-	 * directly (no per-table config) or a `[table, config]` tuple. `config.fts`
-	 * narrows to the row's column names per entry.
-	 */
-	tables: TableEntries<TRows>;
 
 	/**
 	 * Debounce window for the materializer's incremental row flush. Defaults
@@ -77,33 +64,49 @@ export type AttachBunSqliteMaterializerOptions<
 };
 
 /**
+ * Builder returned by {@link attachBunSqliteMaterializer}. Mirrors the core
+ * builder shape but threads `.client` through the chained `.table()` calls,
+ * so consumers can write
+ * `attachBunSqliteMaterializer(...).table(...).client` without losing the
+ * augmentation through the chain.
+ */
+export type AttachBunSqliteMaterializerBuilder = Omit<
+	ReturnType<typeof attachSqliteMaterializerCore>,
+	'table'
+> & {
+	table<TRow extends BaseRow>(
+		table: Table<TRow>,
+		config?: TableConfig<TRow>,
+	): AttachBunSqliteMaterializerBuilder;
+	/**
+	 * The underlying bun:sqlite Database handle. Use it directly or wrap in
+	 * Drizzle (`drizzle(materializer.client, { schema })`) for typed reads.
+	 */
+	client: Database;
+};
+
+/**
  * Attach a bun:sqlite-backed materializer to a Y.Doc. The materializer
  * opens the file at `filePath`, applies the writer-side WAL pragmas, and
  * closes the handle on `ydoc.destroy()`.
  *
- * The returned object exposes the underlying `Database` as `.client`, so
+ * The returned builder exposes the underlying `Database` as `.client`, so
  * callers can wrap it in Drizzle (`drizzle(materializer.client, { schema })`)
  * for typed reads against the same file.
  */
-export function attachBunSqliteMaterializer<
-	const TRows extends readonly BaseRow[],
->(
+export function attachBunSqliteMaterializer(
 	ydoc: Y.Doc,
 	{
 		filePath,
-		tables,
 		debounceMs,
 		waitFor,
 		log = createLogger('attachBunSqliteMaterializer'),
-	}: AttachBunSqliteMaterializerOptions<TRows>,
-): ReturnType<typeof attachSqliteMaterializerCore<TRows>> & {
-	client: Database;
-} {
+	}: AttachBunSqliteMaterializerOptions,
+): AttachBunSqliteMaterializerBuilder {
 	const client = openWriterSqlite({ filePath, log });
 
-	const core = attachSqliteMaterializerCore(ydoc, {
+	const coreBuilder = attachSqliteMaterializerCore(ydoc, {
 		db: client,
-		tables,
 		debounceMs,
 		waitFor,
 		log,
@@ -125,5 +128,15 @@ export function attachBunSqliteMaterializer<
 		}
 	});
 
-	return { ...core, client };
+	const augmented: AttachBunSqliteMaterializerBuilder = {
+		...coreBuilder,
+		// Re-bind .table so chained calls keep returning the augmented builder
+		// (with .client), not the bare core builder.
+		table(table, config) {
+			coreBuilder.table(table, config);
+			return augmented;
+		},
+		client,
+	};
+	return augmented;
 }

--- a/packages/workspace/src/document/materializer/sqlite/bun-sqlite.ts
+++ b/packages/workspace/src/document/materializer/sqlite/bun-sqlite.ts
@@ -1,5 +1,5 @@
 /**
- * `attachBunSqliteMaterializer(ydoc, { filePath })`: bun:sqlite-backed
+ * `attachBunSqliteMaterializer(ydoc, { filePath, tables })`: bun:sqlite-backed
  * materializer. Owns the database file end-to-end: opens it (with the
  * writer-side WAL pragmas), mirrors Y.Doc table rows into it, and closes
  * the handle when the ydoc is destroyed.
@@ -12,7 +12,8 @@
  * const materializer = attachBunSqliteMaterializer(ydoc, {
  *   filePath: sqlitePath(projectDir, ydoc.guid),
  *   waitFor: idb.whenLoaded,
- * }).table(tables.entries, { fts: ['title', 'body'] });
+ *   tables: [[tables.entries, { fts: ['title', 'body'] }]],
+ * });
  *
  * // Daemon-local typed reads:
  * const schema = tablesToDrizzleSchema(definitions);
@@ -26,20 +27,32 @@
 import type { Database } from 'bun:sqlite';
 import { createLogger, type Logger } from 'wellcrafted/logger';
 import type * as Y from 'yjs';
-import type { BaseRow, Table } from '../../attach-table.js';
+import type { BaseRow } from '../../attach-table.js';
 import { openWriterSqlite } from '../../sqlite-writer.js';
-import { attachSqliteMaterializerCore, type TableConfig } from './core.js';
+import {
+	attachSqliteMaterializerCore,
+	type TableEntries,
+} from './core.js';
 
 /**
  * Options for {@link attachBunSqliteMaterializer}.
  */
-export type AttachBunSqliteMaterializerOptions = {
+export type AttachBunSqliteMaterializerOptions<
+	TRows extends readonly BaseRow[],
+> = {
 	/**
 	 * Absolute path to the bun:sqlite mirror file, or `':memory:'` for an
 	 * ephemeral in-memory mirror. The parent directory is created on demand
 	 * (no-op for `:memory:`).
 	 */
 	filePath: ':memory:' | (string & {});
+
+	/**
+	 * Workspace tables to mirror. Each entry is either the table reference
+	 * directly (no per-table config) or a `[table, config]` tuple. `config.fts`
+	 * narrows to the row's column names per entry.
+	 */
+	tables: TableEntries<TRows>;
 
 	/**
 	 * Debounce window for the materializer's incremental row flush. Defaults
@@ -64,49 +77,33 @@ export type AttachBunSqliteMaterializerOptions = {
 };
 
 /**
- * Builder returned by {@link attachBunSqliteMaterializer}. Mirrors the core
- * builder shape but threads `.client` through the chained `.table()` calls,
- * so consumers can write
- * `attachBunSqliteMaterializer(...).table(...).client` without losing the
- * augmentation through the chain.
- */
-export type AttachBunSqliteMaterializerBuilder = Omit<
-	ReturnType<typeof attachSqliteMaterializerCore>,
-	'table'
-> & {
-	table<TRow extends BaseRow>(
-		table: Table<TRow>,
-		config?: TableConfig<TRow>,
-	): AttachBunSqliteMaterializerBuilder;
-	/**
-	 * The underlying bun:sqlite Database handle. Use it directly or wrap in
-	 * Drizzle (`drizzle(materializer.client, { schema })`) for typed reads.
-	 */
-	client: Database;
-};
-
-/**
  * Attach a bun:sqlite-backed materializer to a Y.Doc. The materializer
  * opens the file at `filePath`, applies the writer-side WAL pragmas, and
  * closes the handle on `ydoc.destroy()`.
  *
- * The returned builder exposes the underlying `Database` as `.client`, so
+ * The returned object exposes the underlying `Database` as `.client`, so
  * callers can wrap it in Drizzle (`drizzle(materializer.client, { schema })`)
  * for typed reads against the same file.
  */
-export function attachBunSqliteMaterializer(
+export function attachBunSqliteMaterializer<
+	const TRows extends readonly BaseRow[],
+>(
 	ydoc: Y.Doc,
 	{
 		filePath,
+		tables,
 		debounceMs,
 		waitFor,
 		log = createLogger('attachBunSqliteMaterializer'),
-	}: AttachBunSqliteMaterializerOptions,
-): AttachBunSqliteMaterializerBuilder {
+	}: AttachBunSqliteMaterializerOptions<TRows>,
+): ReturnType<typeof attachSqliteMaterializerCore<TRows>> & {
+	client: Database;
+} {
 	const client = openWriterSqlite({ filePath, log });
 
-	const coreBuilder = attachSqliteMaterializerCore(ydoc, {
+	const core = attachSqliteMaterializerCore(ydoc, {
 		db: client,
+		tables,
 		debounceMs,
 		waitFor,
 		log,
@@ -128,15 +125,5 @@ export function attachBunSqliteMaterializer(
 		}
 	});
 
-	const augmented: AttachBunSqliteMaterializerBuilder = {
-		...coreBuilder,
-		// Re-bind .table so chained calls keep returning the augmented builder
-		// (with .client), not the bare core builder.
-		table(table, config) {
-			coreBuilder.table(table, config);
-			return augmented;
-		},
-		client,
-	};
-	return augmented;
+	return { ...core, client };
 }

--- a/packages/workspace/src/document/materializer/sqlite/bun-sqlite.ts
+++ b/packages/workspace/src/document/materializer/sqlite/bun-sqlite.ts
@@ -25,7 +25,6 @@
  * @module
  */
 
-import type { Database } from 'bun:sqlite';
 import { createLogger, type Logger } from 'wellcrafted/logger';
 import type * as Y from 'yjs';
 import { openWriterSqlite } from '../../sqlite-writer.js';
@@ -103,13 +102,7 @@ export function attachBunSqliteMaterializer<TTables extends TablesRecord>(
 		waitFor,
 		log = createLogger('attachBunSqliteMaterializer'),
 	}: AttachBunSqliteMaterializerOptions<TTables>,
-): ReturnType<typeof attachSqliteMaterializerCore<TTables>> & {
-	/**
-	 * The underlying bun:sqlite Database handle. Use it directly or wrap in
-	 * Drizzle (`drizzle(materializer.client, { schema })`) for typed reads.
-	 */
-	client: Database;
-} {
+) {
 	const client = openWriterSqlite({ filePath, log });
 
 	const core = attachSqliteMaterializerCore(ydoc, {

--- a/packages/workspace/src/document/materializer/sqlite/bun-sqlite.ts
+++ b/packages/workspace/src/document/materializer/sqlite/bun-sqlite.ts
@@ -1,5 +1,5 @@
 /**
- * `attachBunSqliteMaterializer(ydoc, { filePath })`: bun:sqlite-backed
+ * `attachBunSqliteMaterializer(ydoc, { filePath, tables })`: bun:sqlite-backed
  * materializer. Owns the database file end-to-end: opens it (with the
  * writer-side WAL pragmas), mirrors Y.Doc table rows into it, and closes
  * the handle when the ydoc is destroyed.
@@ -12,7 +12,9 @@
  * const materializer = attachBunSqliteMaterializer(ydoc, {
  *   filePath: sqlitePath(projectDir, ydoc.guid),
  *   waitFor: idb.whenLoaded,
- * }).table(tables.entries, { fts: ['title', 'body'] });
+ *   tables,
+ *   fts: { entries: ['title', 'body'] },
+ * });
  *
  * // Daemon-local typed reads:
  * const schema = tablesToDrizzleSchema(definitions);
@@ -26,20 +28,39 @@
 import type { Database } from 'bun:sqlite';
 import { createLogger, type Logger } from 'wellcrafted/logger';
 import type * as Y from 'yjs';
-import type { BaseRow, Table } from '../../attach-table.js';
 import { openWriterSqlite } from '../../sqlite-writer.js';
-import { attachSqliteMaterializerCore, type TableConfig } from './core.js';
+import {
+	attachSqliteMaterializerCore,
+	type FtsConfig,
+	type TablesRecord,
+} from './core.js';
 
 /**
  * Options for {@link attachBunSqliteMaterializer}.
  */
-export type AttachBunSqliteMaterializerOptions = {
+export type AttachBunSqliteMaterializerOptions<
+	TTables extends TablesRecord,
+> = {
 	/**
 	 * Absolute path to the bun:sqlite mirror file, or `':memory:'` for an
 	 * ephemeral in-memory mirror. The parent directory is created on demand
 	 * (no-op for `:memory:`).
 	 */
 	filePath: ':memory:' | (string & {});
+
+	/**
+	 * Workspace tables to mirror. Each entry becomes a SQLite table named
+	 * after the record key. Pass the whole `tables` record to mirror
+	 * everything, or an object literal subset like `{ notes: tables.notes }`
+	 * to mirror a strict subset.
+	 */
+	tables: TTables;
+
+	/**
+	 * Optional FTS5 configuration. Keys must match `tables` keys; values
+	 * list the columns of that table's row to include in the FTS index.
+	 */
+	fts?: FtsConfig<TTables>;
 
 	/**
 	 * Debounce window for the materializer's incremental row flush. Defaults
@@ -64,49 +85,37 @@ export type AttachBunSqliteMaterializerOptions = {
 };
 
 /**
- * Builder returned by {@link attachBunSqliteMaterializer}. Mirrors the core
- * builder shape but threads `.client` through the chained `.table()` calls,
- * so consumers can write
- * `attachBunSqliteMaterializer(...).table(...).client` without losing the
- * augmentation through the chain.
+ * Attach a bun:sqlite-backed materializer to a Y.Doc. The materializer
+ * opens the file at `filePath`, applies the writer-side WAL pragmas, and
+ * closes the handle on `ydoc.destroy()`.
+ *
+ * The returned object exposes the underlying `Database` as `.client`, so
+ * callers can wrap it in Drizzle (`drizzle(materializer.client, { schema })`)
+ * for typed reads against the same file.
  */
-export type AttachBunSqliteMaterializerBuilder = Omit<
-	ReturnType<typeof attachSqliteMaterializerCore>,
-	'table'
-> & {
-	table<TRow extends BaseRow>(
-		table: Table<TRow>,
-		config?: TableConfig<TRow>,
-	): AttachBunSqliteMaterializerBuilder;
+export function attachBunSqliteMaterializer<TTables extends TablesRecord>(
+	ydoc: Y.Doc,
+	{
+		filePath,
+		tables,
+		fts,
+		debounceMs,
+		waitFor,
+		log = createLogger('attachBunSqliteMaterializer'),
+	}: AttachBunSqliteMaterializerOptions<TTables>,
+): ReturnType<typeof attachSqliteMaterializerCore<TTables>> & {
 	/**
 	 * The underlying bun:sqlite Database handle. Use it directly or wrap in
 	 * Drizzle (`drizzle(materializer.client, { schema })`) for typed reads.
 	 */
 	client: Database;
-};
-
-/**
- * Attach a bun:sqlite-backed materializer to a Y.Doc. The materializer
- * opens the file at `filePath`, applies the writer-side WAL pragmas, and
- * closes the handle on `ydoc.destroy()`.
- *
- * The returned builder exposes the underlying `Database` as `.client`, so
- * callers can wrap it in Drizzle (`drizzle(materializer.client, { schema })`)
- * for typed reads against the same file.
- */
-export function attachBunSqliteMaterializer(
-	ydoc: Y.Doc,
-	{
-		filePath,
-		debounceMs,
-		waitFor,
-		log = createLogger('attachBunSqliteMaterializer'),
-	}: AttachBunSqliteMaterializerOptions,
-): AttachBunSqliteMaterializerBuilder {
+} {
 	const client = openWriterSqlite({ filePath, log });
 
-	const coreBuilder = attachSqliteMaterializerCore(ydoc, {
+	const core = attachSqliteMaterializerCore(ydoc, {
 		db: client,
+		tables,
+		fts,
 		debounceMs,
 		waitFor,
 		log,
@@ -128,15 +137,5 @@ export function attachBunSqliteMaterializer(
 		}
 	});
 
-	const augmented: AttachBunSqliteMaterializerBuilder = {
-		...coreBuilder,
-		// Re-bind .table so chained calls keep returning the augmented builder
-		// (with .client), not the bare core builder.
-		table(table, config) {
-			coreBuilder.table(table, config);
-			return augmented;
-		},
-		client,
-	};
-	return augmented;
+	return { ...core, client };
 }

--- a/packages/workspace/src/document/materializer/sqlite/bun-sqlite.ts
+++ b/packages/workspace/src/document/materializer/sqlite/bun-sqlite.ts
@@ -39,6 +39,7 @@ import {
  */
 export type AttachBunSqliteMaterializerOptions<
 	TTables extends TablesRecord,
+	TFts extends FtsConfig<TTables> | undefined = undefined,
 > = {
 	/**
 	 * Absolute path to the bun:sqlite mirror file, or `':memory:'` for an
@@ -58,8 +59,10 @@ export type AttachBunSqliteMaterializerOptions<
 	/**
 	 * Optional FTS5 configuration. Keys must match `tables` keys; values
 	 * list the columns of that table's row to include in the FTS index.
+	 * When provided, the result exposes `sqlite.fts.search(...)`; when
+	 * omitted, the `fts` namespace is absent from the return type.
 	 */
-	fts?: FtsConfig<TTables>;
+	fts?: TFts;
 
 	/**
 	 * Debounce window for the materializer's incremental row flush. Defaults
@@ -92,7 +95,10 @@ export type AttachBunSqliteMaterializerOptions<
  * callers can wrap it in Drizzle (`drizzle(materializer.client, { schema })`)
  * for typed reads against the same file.
  */
-export function attachBunSqliteMaterializer<TTables extends TablesRecord>(
+export function attachBunSqliteMaterializer<
+	TTables extends TablesRecord,
+	TFts extends FtsConfig<TTables> | undefined = undefined,
+>(
 	ydoc: Y.Doc,
 	{
 		filePath,
@@ -101,11 +107,11 @@ export function attachBunSqliteMaterializer<TTables extends TablesRecord>(
 		debounceMs,
 		waitFor,
 		log = createLogger('attachBunSqliteMaterializer'),
-	}: AttachBunSqliteMaterializerOptions<TTables>,
+	}: AttachBunSqliteMaterializerOptions<TTables, TFts>,
 ) {
 	const client = openWriterSqlite({ filePath, log });
 
-	const core = attachSqliteMaterializerCore(ydoc, {
+	const core = attachSqliteMaterializerCore<TTables, TFts>(ydoc, {
 		db: client,
 		tables,
 		fts,

--- a/packages/workspace/src/document/materializer/sqlite/core.test.ts
+++ b/packages/workspace/src/document/materializer/sqlite/core.test.ts
@@ -25,7 +25,11 @@ import {
 } from '../../../index.js';
 import { isAction, isMutation, isQuery } from '../../../shared/actions.js';
 import { column } from '../../column/index.js';
-import { attachSqliteMaterializerCore, type MirrorDatabase } from './core.js';
+import {
+	attachSqliteMaterializerCore,
+	type MirrorDatabase,
+	type TableEntry,
+} from './core.js';
 
 const postsTable = defineTable({
 	id: column.string(),
@@ -70,18 +74,15 @@ function createTestDb(): TestDb {
 }
 
 type AttachedTables = ReturnType<typeof attachTables<typeof tableDefinitions>>;
-type Materializer = ReturnType<typeof attachSqliteMaterializerCore>;
-type TableRegistration = {
-	table: Parameters<Materializer['table']>[0];
-	config?: Parameters<Materializer['table']>[1];
-};
+// biome-ignore lint/suspicious/noExplicitAny: heterogeneous test table entries
+type TableEntries = readonly TableEntry<any>[];
 
 type SetupOptions = {
-	tables?: (t: AttachedTables) => TableRegistration[];
+	tables?: (t: AttachedTables) => TableEntries;
 	debounceMs?: number;
 };
 
-function setup({ tables: tableRegistrations, debounceMs }: SetupOptions = {}) {
+function setup({ tables: tableEntries, debounceMs }: SetupOptions = {}) {
 	const db = createTestDb();
 
 	const cache = createDisposableCache(
@@ -92,17 +93,8 @@ function setup({ tables: tableRegistrations, debounceMs }: SetupOptions = {}) {
 			const materializer = attachSqliteMaterializerCore(ydoc, {
 				db,
 				debounceMs,
+				tables: tableEntries?.(tables) ?? [tables.posts, tables.notes],
 			});
-
-			const registrations =
-				tableRegistrations?.(tables) ??
-				([
-					{ table: tables.posts },
-					{ table: tables.notes },
-				] as TableRegistration[]);
-			for (const { table, config } of registrations) {
-				materializer.table(table, config);
-			}
 
 			return {
 				ydoc,
@@ -182,9 +174,8 @@ describe('attachSqliteMaterializerCore', () => {
 					const materializer = attachSqliteMaterializerCore(ydoc, {
 						db,
 						waitFor: gate.promise,
-					})
-						.table(tables.posts)
-						.table(tables.notes);
+						tables: [tables.posts, tables.notes],
+					});
 
 					return {
 						ydoc,
@@ -249,7 +240,7 @@ describe('attachSqliteMaterializerCore', () => {
 		});
 
 		test('mirrors only specified tables when tables option is provided', async () => {
-			const testSetup = setup({ tables: (t) => [{ table: t.posts }] });
+			const testSetup = setup({ tables: (t) => [t.posts] });
 
 			try {
 				testSetup.workspace.tables.posts.set({
@@ -546,11 +537,7 @@ describe('attachSqliteMaterializerCore', () => {
 		if (hasFts5) {
 			test('search returns ranked results with snippets when fts is configured', async () => {
 				const testSetup = setup({
-					tables: (t) =>
-						[
-							{ table: t.posts, config: { fts: ['title'] } },
-							{ table: t.notes },
-						] as TableRegistration[],
+					tables: (t) => [[t.posts, { fts: ['title'] }], t.notes],
 				});
 
 				try {

--- a/packages/workspace/src/document/materializer/sqlite/core.test.ts
+++ b/packages/workspace/src/document/materializer/sqlite/core.test.ts
@@ -70,18 +70,19 @@ function createTestDb(): TestDb {
 }
 
 type AttachedTables = ReturnType<typeof attachTables<typeof tableDefinitions>>;
-type Materializer = ReturnType<typeof attachSqliteMaterializerCore>;
-type TableRegistration = {
-	table: Parameters<Materializer['table']>[0];
-	config?: Parameters<Materializer['table']>[1];
+
+type SetupBuildResult = {
+	// biome-ignore lint/suspicious/noExplicitAny: tests build heterogeneous subsets
+	tables: Record<string, any>;
+	fts?: Record<string, string[]>;
 };
 
 type SetupOptions = {
-	tables?: (t: AttachedTables) => TableRegistration[];
+	build?: (t: AttachedTables) => SetupBuildResult;
 	debounceMs?: number;
 };
 
-function setup({ tables: tableRegistrations, debounceMs }: SetupOptions = {}) {
+function setup({ build, debounceMs }: SetupOptions = {}) {
 	const db = createTestDb();
 
 	const cache = createDisposableCache(
@@ -89,20 +90,17 @@ function setup({ tables: tableRegistrations, debounceMs }: SetupOptions = {}) {
 			const ydoc = new Y.Doc({ guid: id });
 			const tables = attachTables(ydoc, tableDefinitions);
 
+			const built: SetupBuildResult = build?.(tables) ?? {
+				tables: { posts: tables.posts, notes: tables.notes },
+			};
+
 			const materializer = attachSqliteMaterializerCore(ydoc, {
 				db,
 				debounceMs,
+				tables: built.tables,
+				// biome-ignore lint/suspicious/noExplicitAny: tests erase row types through the setup helper
+				fts: built.fts as any,
 			});
-
-			const registrations =
-				tableRegistrations?.(tables) ??
-				([
-					{ table: tables.posts },
-					{ table: tables.notes },
-				] as TableRegistration[]);
-			for (const { table, config } of registrations) {
-				materializer.table(table, config);
-			}
 
 			return {
 				ydoc,
@@ -182,9 +180,8 @@ describe('attachSqliteMaterializerCore', () => {
 					const materializer = attachSqliteMaterializerCore(ydoc, {
 						db,
 						waitFor: gate.promise,
-					})
-						.table(tables.posts)
-						.table(tables.notes);
+						tables: { posts: tables.posts, notes: tables.notes },
+					});
 
 					return {
 						ydoc,
@@ -249,7 +246,9 @@ describe('attachSqliteMaterializerCore', () => {
 		});
 
 		test('mirrors only specified tables when tables option is provided', async () => {
-			const testSetup = setup({ tables: (t) => [{ table: t.posts }] });
+			const testSetup = setup({
+				build: (t) => ({ tables: { posts: t.posts } }),
+			});
 
 			try {
 				testSetup.workspace.tables.posts.set({
@@ -546,11 +545,10 @@ describe('attachSqliteMaterializerCore', () => {
 		if (hasFts5) {
 			test('search returns ranked results with snippets when fts is configured', async () => {
 				const testSetup = setup({
-					tables: (t) =>
-						[
-							{ table: t.posts, config: { fts: ['title'] } },
-							{ table: t.notes },
-						] as TableRegistration[],
+					build: (t) => ({
+						tables: { posts: t.posts, notes: t.notes },
+						fts: { posts: ['title'] },
+					}),
 				});
 
 				try {

--- a/packages/workspace/src/document/materializer/sqlite/core.test.ts
+++ b/packages/workspace/src/document/materializer/sqlite/core.test.ts
@@ -525,18 +525,18 @@ describe('attachSqliteMaterializerCore', () => {
 	// ============================================================================
 
 	describe('search', () => {
-		test('search returns empty array when fts is not configured', async () => {
+		test('fts namespace is absent when fts is not configured', async () => {
 			const testSetup = setup();
 
 			try {
 				await testSetup.workspace.sqlite.whenFlushed;
 
+				// The setup helper's build callback erases the FTS generic, so
+				// the runtime value is what we assert against: no FTS was passed,
+				// so the layer was never constructed, so `fts` is undefined.
 				expect(
-					await testSetup.workspace.sqlite.search({
-						table: 'posts',
-						query: 'hello',
-					}),
-				).toEqual([]);
+					(testSetup.workspace.sqlite as { fts?: unknown }).fts,
+				).toBeUndefined();
 			} finally {
 				await cleanup(testSetup);
 			}
@@ -565,7 +565,10 @@ describe('attachSqliteMaterializerCore', () => {
 
 					await testSetup.workspace.sqlite.whenFlushed;
 
-					const results = (await testSetup.workspace.sqlite.search({
+					const sqliteWithFts = testSetup.workspace.sqlite as unknown as {
+						fts: { search: (input: Record<string, unknown>) => Promise<unknown> };
+					};
+					const results = (await sqliteWithFts.fts.search({
 						table: 'posts',
 						query: 'mirror',
 						limit: 10,
@@ -587,21 +590,41 @@ describe('attachSqliteMaterializerCore', () => {
 	// ============================================================================
 
 	describe('action brand', () => {
-		test('search, count, rebuild are detectable via isAction()', async () => {
+		test('count and rebuild are detectable via isAction()', async () => {
 			const testSetup = setup();
 
 			try {
 				const { sqlite } = testSetup.workspace;
-				expect(isAction(sqlite.search)).toBe(true);
 				expect(isAction(sqlite.count)).toBe(true);
 				expect(isAction(sqlite.rebuild)).toBe(true);
 
-				expect(isQuery(sqlite.search)).toBe(true);
 				expect(isQuery(sqlite.count)).toBe(true);
 				expect(isMutation(sqlite.rebuild)).toBe(true);
 			} finally {
 				await cleanup(testSetup);
 			}
 		});
+
+		if (hasFts5) {
+			test('fts.search is detectable via isAction() when configured', async () => {
+				const testSetup = setup({
+					build: (t) => ({
+						tables: { posts: t.posts },
+						fts: { posts: ['title'] },
+					}),
+				});
+
+				try {
+					await testSetup.workspace.sqlite.whenFlushed;
+					const sqliteWithFts = testSetup.workspace.sqlite as unknown as {
+						fts: { search: unknown };
+					};
+					expect(isAction(sqliteWithFts.fts.search)).toBe(true);
+					expect(isQuery(sqliteWithFts.fts.search)).toBe(true);
+				} finally {
+					await cleanup(testSetup);
+				}
+			});
+		}
 	});
 });

--- a/packages/workspace/src/document/materializer/sqlite/core.test.ts
+++ b/packages/workspace/src/document/materializer/sqlite/core.test.ts
@@ -25,11 +25,7 @@ import {
 } from '../../../index.js';
 import { isAction, isMutation, isQuery } from '../../../shared/actions.js';
 import { column } from '../../column/index.js';
-import {
-	attachSqliteMaterializerCore,
-	type MirrorDatabase,
-	type TableEntry,
-} from './core.js';
+import { attachSqliteMaterializerCore, type MirrorDatabase } from './core.js';
 
 const postsTable = defineTable({
 	id: column.string(),
@@ -74,15 +70,18 @@ function createTestDb(): TestDb {
 }
 
 type AttachedTables = ReturnType<typeof attachTables<typeof tableDefinitions>>;
-// biome-ignore lint/suspicious/noExplicitAny: heterogeneous test table entries
-type TableEntries = readonly TableEntry<any>[];
+type Materializer = ReturnType<typeof attachSqliteMaterializerCore>;
+type TableRegistration = {
+	table: Parameters<Materializer['table']>[0];
+	config?: Parameters<Materializer['table']>[1];
+};
 
 type SetupOptions = {
-	tables?: (t: AttachedTables) => TableEntries;
+	tables?: (t: AttachedTables) => TableRegistration[];
 	debounceMs?: number;
 };
 
-function setup({ tables: tableEntries, debounceMs }: SetupOptions = {}) {
+function setup({ tables: tableRegistrations, debounceMs }: SetupOptions = {}) {
 	const db = createTestDb();
 
 	const cache = createDisposableCache(
@@ -93,8 +92,17 @@ function setup({ tables: tableEntries, debounceMs }: SetupOptions = {}) {
 			const materializer = attachSqliteMaterializerCore(ydoc, {
 				db,
 				debounceMs,
-				tables: tableEntries?.(tables) ?? [tables.posts, tables.notes],
 			});
+
+			const registrations =
+				tableRegistrations?.(tables) ??
+				([
+					{ table: tables.posts },
+					{ table: tables.notes },
+				] as TableRegistration[]);
+			for (const { table, config } of registrations) {
+				materializer.table(table, config);
+			}
 
 			return {
 				ydoc,
@@ -174,8 +182,9 @@ describe('attachSqliteMaterializerCore', () => {
 					const materializer = attachSqliteMaterializerCore(ydoc, {
 						db,
 						waitFor: gate.promise,
-						tables: [tables.posts, tables.notes],
-					});
+					})
+						.table(tables.posts)
+						.table(tables.notes);
 
 					return {
 						ydoc,
@@ -240,7 +249,7 @@ describe('attachSqliteMaterializerCore', () => {
 		});
 
 		test('mirrors only specified tables when tables option is provided', async () => {
-			const testSetup = setup({ tables: (t) => [t.posts] });
+			const testSetup = setup({ tables: (t) => [{ table: t.posts }] });
 
 			try {
 				testSetup.workspace.tables.posts.set({
@@ -537,7 +546,11 @@ describe('attachSqliteMaterializerCore', () => {
 		if (hasFts5) {
 			test('search returns ranked results with snippets when fts is configured', async () => {
 				const testSetup = setup({
-					tables: (t) => [[t.posts, { fts: ['title'] }], t.notes],
+					tables: (t) =>
+						[
+							{ table: t.posts, config: { fts: ['title'] } },
+							{ table: t.notes },
+						] as TableRegistration[],
 				});
 
 				try {

--- a/packages/workspace/src/document/materializer/sqlite/core.ts
+++ b/packages/workspace/src/document/materializer/sqlite/core.ts
@@ -29,8 +29,7 @@ import { defineMutation, defineQuery } from '../../../shared/actions.js';
 import type { MaybePromise } from '../../../shared/types.js';
 import type { BaseRow, Table } from '../../attach-table.js';
 import { generateDdl, quoteIdentifier } from './ddl.js';
-import type { SearchOptions, SearchResult } from './fts.js';
-import { ftsSearch, setupFtsTable } from './fts.js';
+import { createSqliteFtsLayer } from './fts.js';
 
 // ════════════════════════════════════════════════════════════════════════════
 // INTERNAL SQL EXECUTOR CONTRACT
@@ -111,9 +110,31 @@ export type SqliteMaterializerError = InferErrors<
 
 type RegisteredTable = {
 	table: AnyTable;
-	ftsColumns?: string[];
 	unsubscribe?: () => void;
 };
+
+/**
+ * Common shape returned by `attachSqliteMaterializerCore`. Each backend factory
+ * wraps this with its own additions (`client`, `whenConnected`).
+ */
+type SqliteMaterializerCommon = {
+	whenFlushed: Promise<void>;
+	count: ReturnType<typeof defineQuery>;
+	rebuild: ReturnType<typeof defineMutation>;
+};
+
+/**
+ * FTS slice of the materializer result. Conditional on whether `fts` was
+ * passed: when omitted, `fts` is absent from the type entirely.
+ */
+type SqliteMaterializerFts<TFts> = [TFts] extends [undefined]
+	? // biome-ignore lint/complexity/noBannedTypes: intentional empty branch when no FTS was configured
+		{}
+	: { fts: { search: ReturnType<typeof defineQuery> } };
+
+/** Result of `attachSqliteMaterializerCore`. `fts` is present iff `fts` opt was passed. */
+export type SqliteMaterializerCoreResult<TFts> = SqliteMaterializerCommon &
+	SqliteMaterializerFts<TFts>;
 
 /**
  * Internal shared materializer body. Each per-backend factory
@@ -125,7 +146,10 @@ type RegisteredTable = {
  *
  * @internal
  */
-export function attachSqliteMaterializerCore<TTables extends TablesRecord>(
+export function attachSqliteMaterializerCore<
+	TTables extends TablesRecord,
+	TFts extends FtsConfig<TTables> | undefined = undefined,
+>(
 	ydoc: Y.Doc,
 	{
 		db,
@@ -143,9 +167,12 @@ export function attachSqliteMaterializerCore<TTables extends TablesRecord>(
 		tables: TTables;
 		/**
 		 * Optional FTS5 configuration. Keyed by the same names as `tables`,
-		 * with values listing the columns to include in the FTS index.
+		 * with values listing the columns to include in the FTS index. When
+		 * provided, the returned materializer exposes a nested `fts` namespace
+		 * with the `search` action; when omitted, `fts` is absent from the
+		 * return type entirely.
 		 */
-		fts?: FtsConfig<TTables>;
+		fts?: TFts;
 		debounceMs?: number;
 		/**
 		 * Gate: the materializer awaits this before the initial DDL + full-load.
@@ -159,17 +186,18 @@ export function attachSqliteMaterializerCore<TTables extends TablesRecord>(
 		 */
 		log?: Logger;
 	},
-) {
+): SqliteMaterializerCoreResult<TFts> {
 	const registered = new Map<string, RegisteredTable>();
 	for (const [tableName, table] of Object.entries(tables)) {
-		const ftsColumns = fts?.[tableName as keyof TTables] as
-			| string[]
-			| undefined;
-		registered.set(tableName, {
-			table: table as AnyTable,
-			ftsColumns,
-		});
+		registered.set(tableName, { table: table as AnyTable });
 	}
+
+	// FTS lives entirely in its own layer when configured. Core knows nothing
+	// about FTS state, columns, or search SQL.
+	const ftsLayer =
+		fts !== undefined
+			? createSqliteFtsLayer<TTables>({ db, fts, log })
+			: undefined;
 
 	let pendingSync = new Map<string, Set<string>>();
 	let syncQueue = Promise.resolve();
@@ -254,18 +282,6 @@ export function attachSqliteMaterializerCore<TTables extends TablesRecord>(
 
 	// ── Query / mutation surface ─────────────────────────────────
 
-	async function search(
-		tableName: string,
-		query: string,
-		options?: SearchOptions,
-	): Promise<SearchResult[]> {
-		if (isDisposed) return [];
-		const entry = registered.get(tableName);
-		const ftsColumns = entry?.ftsColumns;
-		if (ftsColumns === undefined || ftsColumns.length === 0) return [];
-		return ftsSearch(db, tableName, ftsColumns, query, options, log);
-	}
-
 	async function count(tableName: string): Promise<number> {
 		if (isDisposed) return 0;
 		if (!registered.has(tableName)) return 0;
@@ -335,9 +351,12 @@ export function attachSqliteMaterializerCore<TTables extends TablesRecord>(
 
 		for (const [tableName, entry] of registered) {
 			await db.run(generateDdl(tableName, entry.table.schema));
-			if (entry.ftsColumns && entry.ftsColumns.length > 0)
-				await setupFtsTable(db, tableName, entry.ftsColumns);
 		}
+
+		// FTS DDL + triggers run after table DDL and before the bulk insert, so
+		// the AFTER INSERT triggers populate `<table>_fts` for free during the
+		// existing full-load. This is the load-bearing ordering invariant.
+		await ftsLayer?.beforeFullLoad();
 
 		if (isDisposed) return;
 
@@ -362,19 +381,8 @@ export function attachSqliteMaterializerCore<TTables extends TablesRecord>(
 
 	const whenFlushed = initialize();
 
-	return {
+	const base: SqliteMaterializerCommon = {
 		whenFlushed,
-		search: defineQuery({
-			title: 'Full-text search',
-			description: 'FTS5 search across materialized table rows',
-			input: Type.Object({
-				table: Type.String(),
-				query: Type.String(),
-				limit: Type.Optional(Type.Number()),
-			}),
-			handler: ({ table: tableName, query: q, limit: lim }) =>
-				search(tableName, q, lim !== undefined ? { limit: lim } : undefined),
-		}),
 		count: defineQuery({
 			title: 'Row count',
 			description: 'Count rows in a materialized table',
@@ -388,6 +396,16 @@ export function attachSqliteMaterializerCore<TTables extends TablesRecord>(
 			handler: ({ table: tableName }) => rebuild(tableName),
 		}),
 	};
+
+	// The conditional return type collapses to `base` when no FTS was passed.
+	// The cast is local: the runtime branch matches the type-level branch.
+	if (ftsLayer === undefined) {
+		return base as SqliteMaterializerCoreResult<TFts>;
+	}
+	return {
+		...base,
+		fts: { search: ftsLayer.search },
+	} as SqliteMaterializerCoreResult<TFts>;
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/packages/workspace/src/document/materializer/sqlite/core.ts
+++ b/packages/workspace/src/document/materializer/sqlite/core.ts
@@ -77,6 +77,26 @@ export type MirrorStatement = {
 // biome-ignore lint/suspicious/noExplicitAny: generic bound for heterogeneous table helpers
 type AnyTable = Table<any>;
 
+/**
+ * Record of workspace tables to materialize. Keys become the mirror table
+ * names; values are the workspace table refs returned by `attachTables`.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: heterogeneous row types in a record
+export type TablesRecord = Record<string, Table<any>>;
+
+/**
+ * Optional FTS configuration, keyed by the same names as `tables`. Each
+ * value lists the columns of that table's row to include in the FTS5 index.
+ *
+ * The mapped type narrows the value to the row's column names, so typos
+ * become compile errors at the call site.
+ */
+export type FtsConfig<TTables extends TablesRecord> = {
+	[K in keyof TTables]?: TTables[K] extends Table<infer TRow>
+		? (keyof TRow & string)[]
+		: never;
+};
+
 /** Errors surfaced by the SQLite materializer's async background sync loop. */
 export const SqliteMaterializerError = defineErrors({
 	/** Debounced flush of pending row writes to the mirror database failed. */
@@ -89,21 +109,9 @@ export type SqliteMaterializerError = InferErrors<
 	typeof SqliteMaterializerError
 >;
 
-/**
- * Per-table configuration, generic over the specific row type so `fts` narrows
- * to valid column names at the call site.
- */
-export type TableConfig<TRow extends BaseRow> = {
-	/** Column names to include in FTS5 full-text search index. */
-	fts?: (keyof TRow & string)[];
-	/** Optional per-column value serializer override. */
-	serialize?: (value: unknown) => unknown;
-};
-
 type RegisteredTable = {
 	table: AnyTable;
-	// biome-ignore lint/suspicious/noExplicitAny: internal storage, variance across heterogeneous row types
-	config: TableConfig<any>;
+	ftsColumns?: string[];
 	unsubscribe?: () => void;
 };
 
@@ -117,15 +125,27 @@ type RegisteredTable = {
  *
  * @internal
  */
-export function attachSqliteMaterializerCore(
+export function attachSqliteMaterializerCore<TTables extends TablesRecord>(
 	ydoc: Y.Doc,
 	{
 		db,
+		tables,
+		fts,
 		debounceMs = 100,
 		waitFor,
 		log = createLogger('sqlite-materializer'),
 	}: {
 		db: MirrorDatabase;
+		/**
+		 * Workspace tables to mirror. Each entry becomes a SQLite table named
+		 * after the record key.
+		 */
+		tables: TTables;
+		/**
+		 * Optional FTS5 configuration. Keyed by the same names as `tables`,
+		 * with values listing the columns to include in the FTS index.
+		 */
+		fts?: FtsConfig<TTables>;
 		debounceMs?: number;
 		/**
 		 * Gate: the materializer awaits this before the initial DDL + full-load.
@@ -141,15 +161,19 @@ export function attachSqliteMaterializerCore(
 	},
 ) {
 	const registered = new Map<string, RegisteredTable>();
+	for (const [tableName, table] of Object.entries(tables)) {
+		const ftsColumns = fts?.[tableName as keyof TTables] as
+			| string[]
+			| undefined;
+		registered.set(tableName, {
+			table: table as AnyTable,
+			ftsColumns,
+		});
+	}
+
 	let pendingSync = new Map<string, Set<string>>();
 	let syncQueue = Promise.resolve();
 	let isDisposed = false;
-	/**
-	 * Closed once `initialize()` commits (past `await waitFor`). Any `.table()`
-	 * call after this throws: the materializer is past the point where late
-	 * registrations would be picked up for DDL + full-load.
-	 */
-	let isRegistrationOpen = true;
 
 	// ── SQL primitives ───────────────────────────────────────────
 
@@ -157,10 +181,8 @@ export function attachSqliteMaterializerCore(
 		tableName: string,
 		row: BaseRow & Record<string, unknown>,
 	) {
-		const config = registered.get(tableName)?.config;
-		const serialize = config?.serialize ?? serializeValue;
 		const keys = Object.keys(row);
-		const values = keys.map((key) => serialize(row[key]));
+		const values = keys.map((key) => serializeValue(row[key]));
 
 		const stmt = await db.prepare(buildUpsertSql(tableName, keys));
 		await stmt.run(...values);
@@ -174,8 +196,6 @@ export function attachSqliteMaterializerCore(
 	}
 
 	async function fullLoadTable(tableName: string, table: AnyTable) {
-		const config = registered.get(tableName)?.config;
-		const serialize = config?.serialize ?? serializeValue;
 		const rows = table.getAllValid();
 		if (rows.length === 0) return;
 
@@ -183,7 +203,7 @@ export function attachSqliteMaterializerCore(
 		const stmt = await db.prepare(buildUpsertSql(tableName, keys));
 
 		for (const row of rows) {
-			const values = keys.map((key) => serialize(row[key]));
+			const values = keys.map((key) => serializeValue(row[key]));
 			await stmt.run(...values);
 		}
 	}
@@ -241,7 +261,7 @@ export function attachSqliteMaterializerCore(
 	): Promise<SearchResult[]> {
 		if (isDisposed) return [];
 		const entry = registered.get(tableName);
-		const ftsColumns = entry?.config.fts;
+		const ftsColumns = entry?.ftsColumns;
 		if (ftsColumns === undefined || ftsColumns.length === 0) return [];
 		return ftsSearch(db, tableName, ftsColumns, query, options, log);
 	}
@@ -298,9 +318,6 @@ export function attachSqliteMaterializerCore(
 	function dispose() {
 		if (isDisposed) return;
 		isDisposed = true;
-		// Close the registration window even if `initialize()` never ran
-		// (e.g., waitFor stalled and the ydoc was destroyed before init).
-		isRegistrationOpen = false;
 		flushAfterDebounce.cancel();
 		for (const entry of registered.values()) entry.unsubscribe?.();
 	}
@@ -310,18 +327,16 @@ export function attachSqliteMaterializerCore(
 	// ── Initial flush ────────────────────────────────────────────
 
 	async function initialize() {
-		// Always yield a microtask so callers can finish synchronous setup
-		// (including writing initial rows) before the full-load runs.
+		// Always yield a microtask so callers can seed synchronous writes
+		// (e.g. `tables.posts.set(...)`) before the full-load reads
+		// `getAllValid()`.
 		await waitFor;
-		// Close the registration window: any further `.table()` call throws,
-		// even if init errors or disposes mid-flight below.
-		isRegistrationOpen = false;
 		if (isDisposed) return;
 
 		for (const [tableName, entry] of registered) {
 			await db.run(generateDdl(tableName, entry.table.schema));
-			if (entry.config.fts && entry.config.fts.length > 0)
-				await setupFtsTable(db, tableName, entry.config.fts);
+			if (entry.ftsColumns && entry.ftsColumns.length > 0)
+				await setupFtsTable(db, tableName, entry.ftsColumns);
 		}
 
 		if (isDisposed) return;
@@ -347,9 +362,7 @@ export function attachSqliteMaterializerCore(
 
 	const whenFlushed = initialize();
 
-	// ── Builder ──────────────────────────────────────────────────
-
-	const api = {
+	return {
 		whenFlushed,
 		search: defineQuery({
 			title: 'Full-text search',
@@ -375,39 +388,6 @@ export function attachSqliteMaterializerCore(
 			handler: ({ table: tableName }) => rebuild(tableName),
 		}),
 	};
-
-	type MaterializerBuilder = typeof api & {
-		/**
-		 * Opt in a workspace table for SQLite materialization.
-		 *
-		 * `fts` and `serialize` are narrowed to the specific row type, so typos
-		 * in column names become compile errors.
-		 *
-		 * Must be called synchronously after construction, before `whenFlushed`
-		 * resolves. Calls after the initial flush throw.
-		 */
-		table<TRow extends BaseRow>(
-			table: Table<TRow>,
-			config?: TableConfig<TRow>,
-		): MaterializerBuilder;
-	};
-
-	const builder: MaterializerBuilder = {
-		...api,
-		table(table, config) {
-			if (!isRegistrationOpen)
-				throw new Error(
-					`materializer: .table("${table.name}") called after initial flush. All .table() registrations must happen synchronously after construction.`,
-				);
-			registered.set(table.name, {
-				table: table as AnyTable,
-				config: config ?? {},
-			});
-			return builder;
-		},
-	};
-
-	return builder;
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/packages/workspace/src/document/materializer/sqlite/core.ts
+++ b/packages/workspace/src/document/materializer/sqlite/core.ts
@@ -100,25 +100,6 @@ export type TableConfig<TRow extends BaseRow> = {
 	serialize?: (value: unknown) => unknown;
 };
 
-/**
- * One element of the materializer's `tables` option. Either a bare table
- * reference (when no per-table config is needed) or a `[table, config]` tuple
- * with row-specific narrowing on `fts` / `serialize`.
- */
-export type TableEntry<TRow extends BaseRow> =
-	| Table<TRow>
-	| readonly [Table<TRow>, TableConfig<TRow>?];
-
-/**
- * Variadic mapped type over a tuple of row types. Each element of the
- * outer tuple is `TableEntry<Rows[K]>`, so the row type is inferred per
- * entry from the table reference, and `fts: ['typo']` errors at the
- * offending entry rather than collapsing to `keyof never`.
- */
-export type TableEntries<TRows extends readonly BaseRow[]> = {
-	[K in keyof TRows]: TableEntry<TRows[K]>;
-};
-
 type RegisteredTable = {
 	table: AnyTable;
 	// biome-ignore lint/suspicious/noExplicitAny: internal storage, variance across heterogeneous row types
@@ -136,24 +117,15 @@ type RegisteredTable = {
  *
  * @internal
  */
-export function attachSqliteMaterializerCore<
-	const TRows extends readonly BaseRow[],
->(
+export function attachSqliteMaterializerCore(
 	ydoc: Y.Doc,
 	{
 		db,
-		tables,
 		debounceMs = 100,
 		waitFor,
 		log = createLogger('sqlite-materializer'),
 	}: {
 		db: MirrorDatabase;
-		/**
-		 * Workspace tables to mirror. Each entry is either the table reference
-		 * directly (no per-table config) or a `[table, config]` tuple. `config.fts`
-		 * narrows to the row's column names per entry.
-		 */
-		tables: TableEntries<TRows>;
 		debounceMs?: number;
 		/**
 		 * Gate: the materializer awaits this before the initial DDL + full-load.
@@ -169,19 +141,15 @@ export function attachSqliteMaterializerCore<
 	},
 ) {
 	const registered = new Map<string, RegisteredTable>();
-	for (const entry of tables) {
-		const [table, config] = Array.isArray(entry)
-			? (entry as readonly [AnyTable, TableConfig<BaseRow>?])
-			: ([entry as AnyTable, undefined] as const);
-		registered.set(table.name, {
-			table,
-			config: config ?? {},
-		});
-	}
-
 	let pendingSync = new Map<string, Set<string>>();
 	let syncQueue = Promise.resolve();
 	let isDisposed = false;
+	/**
+	 * Closed once `initialize()` commits (past `await waitFor`). Any `.table()`
+	 * call after this throws: the materializer is past the point where late
+	 * registrations would be picked up for DDL + full-load.
+	 */
+	let isRegistrationOpen = true;
 
 	// ── SQL primitives ───────────────────────────────────────────
 
@@ -330,6 +298,9 @@ export function attachSqliteMaterializerCore<
 	function dispose() {
 		if (isDisposed) return;
 		isDisposed = true;
+		// Close the registration window even if `initialize()` never ran
+		// (e.g., waitFor stalled and the ydoc was destroyed before init).
+		isRegistrationOpen = false;
 		flushAfterDebounce.cancel();
 		for (const entry of registered.values()) entry.unsubscribe?.();
 	}
@@ -339,7 +310,12 @@ export function attachSqliteMaterializerCore<
 	// ── Initial flush ────────────────────────────────────────────
 
 	async function initialize() {
+		// Always yield a microtask so callers can finish synchronous setup
+		// (including writing initial rows) before the full-load runs.
 		await waitFor;
+		// Close the registration window: any further `.table()` call throws,
+		// even if init errors or disposes mid-flight below.
+		isRegistrationOpen = false;
 		if (isDisposed) return;
 
 		for (const [tableName, entry] of registered) {
@@ -371,7 +347,9 @@ export function attachSqliteMaterializerCore<
 
 	const whenFlushed = initialize();
 
-	return {
+	// ── Builder ──────────────────────────────────────────────────
+
+	const api = {
 		whenFlushed,
 		search: defineQuery({
 			title: 'Full-text search',
@@ -397,6 +375,39 @@ export function attachSqliteMaterializerCore<
 			handler: ({ table: tableName }) => rebuild(tableName),
 		}),
 	};
+
+	type MaterializerBuilder = typeof api & {
+		/**
+		 * Opt in a workspace table for SQLite materialization.
+		 *
+		 * `fts` and `serialize` are narrowed to the specific row type, so typos
+		 * in column names become compile errors.
+		 *
+		 * Must be called synchronously after construction, before `whenFlushed`
+		 * resolves. Calls after the initial flush throw.
+		 */
+		table<TRow extends BaseRow>(
+			table: Table<TRow>,
+			config?: TableConfig<TRow>,
+		): MaterializerBuilder;
+	};
+
+	const builder: MaterializerBuilder = {
+		...api,
+		table(table, config) {
+			if (!isRegistrationOpen)
+				throw new Error(
+					`materializer: .table("${table.name}") called after initial flush. All .table() registrations must happen synchronously after construction.`,
+				);
+			registered.set(table.name, {
+				table: table as AnyTable,
+				config: config ?? {},
+			});
+			return builder;
+		},
+	};
+
+	return builder;
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/packages/workspace/src/document/materializer/sqlite/core.ts
+++ b/packages/workspace/src/document/materializer/sqlite/core.ts
@@ -100,6 +100,25 @@ export type TableConfig<TRow extends BaseRow> = {
 	serialize?: (value: unknown) => unknown;
 };
 
+/**
+ * One element of the materializer's `tables` option. Either a bare table
+ * reference (when no per-table config is needed) or a `[table, config]` tuple
+ * with row-specific narrowing on `fts` / `serialize`.
+ */
+export type TableEntry<TRow extends BaseRow> =
+	| Table<TRow>
+	| readonly [Table<TRow>, TableConfig<TRow>?];
+
+/**
+ * Variadic mapped type over a tuple of row types. Each element of the
+ * outer tuple is `TableEntry<Rows[K]>`, so the row type is inferred per
+ * entry from the table reference, and `fts: ['typo']` errors at the
+ * offending entry rather than collapsing to `keyof never`.
+ */
+export type TableEntries<TRows extends readonly BaseRow[]> = {
+	[K in keyof TRows]: TableEntry<TRows[K]>;
+};
+
 type RegisteredTable = {
 	table: AnyTable;
 	// biome-ignore lint/suspicious/noExplicitAny: internal storage, variance across heterogeneous row types
@@ -117,15 +136,24 @@ type RegisteredTable = {
  *
  * @internal
  */
-export function attachSqliteMaterializerCore(
+export function attachSqliteMaterializerCore<
+	const TRows extends readonly BaseRow[],
+>(
 	ydoc: Y.Doc,
 	{
 		db,
+		tables,
 		debounceMs = 100,
 		waitFor,
 		log = createLogger('sqlite-materializer'),
 	}: {
 		db: MirrorDatabase;
+		/**
+		 * Workspace tables to mirror. Each entry is either the table reference
+		 * directly (no per-table config) or a `[table, config]` tuple. `config.fts`
+		 * narrows to the row's column names per entry.
+		 */
+		tables: TableEntries<TRows>;
 		debounceMs?: number;
 		/**
 		 * Gate: the materializer awaits this before the initial DDL + full-load.
@@ -141,15 +169,19 @@ export function attachSqliteMaterializerCore(
 	},
 ) {
 	const registered = new Map<string, RegisteredTable>();
+	for (const entry of tables) {
+		const [table, config] = Array.isArray(entry)
+			? (entry as readonly [AnyTable, TableConfig<BaseRow>?])
+			: ([entry as AnyTable, undefined] as const);
+		registered.set(table.name, {
+			table,
+			config: config ?? {},
+		});
+	}
+
 	let pendingSync = new Map<string, Set<string>>();
 	let syncQueue = Promise.resolve();
 	let isDisposed = false;
-	/**
-	 * Closed once `initialize()` commits (past `await waitFor`). Any `.table()`
-	 * call after this throws: the materializer is past the point where late
-	 * registrations would be picked up for DDL + full-load.
-	 */
-	let isRegistrationOpen = true;
 
 	// ── SQL primitives ───────────────────────────────────────────
 
@@ -298,9 +330,6 @@ export function attachSqliteMaterializerCore(
 	function dispose() {
 		if (isDisposed) return;
 		isDisposed = true;
-		// Close the registration window even if `initialize()` never ran
-		// (e.g., waitFor stalled and the ydoc was destroyed before init).
-		isRegistrationOpen = false;
 		flushAfterDebounce.cancel();
 		for (const entry of registered.values()) entry.unsubscribe?.();
 	}
@@ -310,12 +339,7 @@ export function attachSqliteMaterializerCore(
 	// ── Initial flush ────────────────────────────────────────────
 
 	async function initialize() {
-		// Always yield a microtask so callers can finish synchronous setup
-		// (including writing initial rows) before the full-load runs.
 		await waitFor;
-		// Close the registration window: any further `.table()` call throws,
-		// even if init errors or disposes mid-flight below.
-		isRegistrationOpen = false;
 		if (isDisposed) return;
 
 		for (const [tableName, entry] of registered) {
@@ -347,9 +371,7 @@ export function attachSqliteMaterializerCore(
 
 	const whenFlushed = initialize();
 
-	// ── Builder ──────────────────────────────────────────────────
-
-	const api = {
+	return {
 		whenFlushed,
 		search: defineQuery({
 			title: 'Full-text search',
@@ -375,39 +397,6 @@ export function attachSqliteMaterializerCore(
 			handler: ({ table: tableName }) => rebuild(tableName),
 		}),
 	};
-
-	type MaterializerBuilder = typeof api & {
-		/**
-		 * Opt in a workspace table for SQLite materialization.
-		 *
-		 * `fts` and `serialize` are narrowed to the specific row type, so typos
-		 * in column names become compile errors.
-		 *
-		 * Must be called synchronously after construction, before `whenFlushed`
-		 * resolves. Calls after the initial flush throw.
-		 */
-		table<TRow extends BaseRow>(
-			table: Table<TRow>,
-			config?: TableConfig<TRow>,
-		): MaterializerBuilder;
-	};
-
-	const builder: MaterializerBuilder = {
-		...api,
-		table(table, config) {
-			if (!isRegistrationOpen)
-				throw new Error(
-					`materializer: .table("${table.name}") called after initial flush. All .table() registrations must happen synchronously after construction.`,
-				);
-			registered.set(table.name, {
-				table: table as AnyTable,
-				config: config ?? {},
-			});
-			return builder;
-		},
-	};
-
-	return builder;
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/packages/workspace/src/document/materializer/sqlite/fts.ts
+++ b/packages/workspace/src/document/materializer/sqlite/fts.ts
@@ -1,20 +1,23 @@
 /**
- * FTS5 full-text search setup for the SQLite materializer.
+ * FTS5 full-text search for the SQLite materializer.
  *
- * Pure functions that generate FTS5 virtual tables and content-sync triggers,
- * plus the search query builder. Separated from the main materializer so
- * FTS concerns don't pollute the core sync logic.
+ * Owns the FTS5 virtual table DDL, content-sync triggers, the search SQL, and
+ * the `search` action exposed on the materializer's nested `fts` namespace.
+ * Kept out of `core.ts` so the materializer body only knows about Y.Doc →
+ * SQLite mirroring; the SQLite → FTS5 step lives entirely here.
  *
  * @module
  */
 
+import Type from 'typebox';
 import {
 	defineErrors,
 	extractErrorMessage,
 	type InferErrors,
 } from 'wellcrafted/error';
 import type { Logger } from 'wellcrafted/logger';
-import type { MirrorDatabase } from './core.js';
+import { defineQuery } from '../../../shared/actions.js';
+import type { FtsConfig, MirrorDatabase, TablesRecord } from './core.js';
 import { quoteIdentifier } from './ddl.js';
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -82,18 +85,15 @@ export type SearchResult = {
 
 /**
  * Create FTS5 virtual table and content-sync triggers for a materializer table.
+ * Module-private: only `createSqliteFtsLayer` below calls this.
  *
  * Sets up:
  * 1. `CREATE VIRTUAL TABLE IF NOT EXISTS {table}_fts USING fts5(...)` with content sync
  * 2. AFTER INSERT trigger to index new rows
  * 3. AFTER DELETE trigger to remove deleted rows
  * 4. AFTER UPDATE trigger to re-index changed rows
- *
- * @param db - The mirror database to execute DDL against
- * @param tableName - The source table name
- * @param columns - Column names to include in the FTS index
  */
-export async function setupFtsTable(
+async function setupFtsTable(
 	db: MirrorDatabase,
 	tableName: string,
 	columns: string[],
@@ -148,19 +148,13 @@ export async function setupFtsTable(
 
 /**
  * Execute a FTS5 search query against a materialized table.
+ * Module-private: called by `createSqliteFtsLayer`'s `search` handler.
  *
  * Returns ranked results with snippet text. The query is trimmed and
  * empty queries return an empty array. If the FTS table doesn't exist
  * or the query fails, returns an empty array with a warning.
- *
- * @param db - The mirror database to query
- * @param tableName - The source table name (FTS table is `{tableName}_fts`)
- * @param ftsColumns - The columns indexed in FTS5 (needed for snippet column index)
- * @param query - The FTS5 search query string
- * @param options - Optional search configuration (limit, snippet column)
- * @returns Array of search results sorted by relevance
  */
-export async function ftsSearch(
+async function ftsSearch(
 	db: MirrorDatabase,
 	tableName: string,
 	ftsColumns: string[],
@@ -210,6 +204,75 @@ export async function ftsSearch(
 		);
 		return [];
 	}
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// INTERNAL FTS LAYER
+// ════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Internal factory that owns the materializer's FTS surface.
+ *
+ * Constructed by `attachSqliteMaterializerCore` only when the caller passed an
+ * `fts` option. Holds the FTS column map, exposes a `beforeFullLoad()` setup
+ * pass that runs after table DDL and before the bulk insert (so triggers
+ * populate `<table>_fts` for free during the existing full-load), and surfaces
+ * the `search` action that lands on `materializer.fts.search`.
+ *
+ * Pure construction at call time: registers no listeners and runs no DDL.
+ * Returning the factory unconditionally would be fine; the caller decides
+ * whether to call it based on whether `fts` was provided, so the materializer's
+ * return type can omit `fts` entirely when no FTS was configured.
+ *
+ * @internal
+ */
+export function createSqliteFtsLayer<TTables extends TablesRecord>({
+	db,
+	fts,
+	log,
+}: {
+	db: MirrorDatabase;
+	fts: FtsConfig<TTables>;
+	log: Logger;
+}) {
+	const ftsColumns = new Map<string, string[]>();
+	for (const [tableName, columns] of Object.entries(fts)) {
+		if (Array.isArray(columns) && columns.length > 0) {
+			ftsColumns.set(tableName, columns as string[]);
+		}
+	}
+
+	async function beforeFullLoad(): Promise<void> {
+		for (const [tableName, columns] of ftsColumns) {
+			await setupFtsTable(db, tableName, columns);
+		}
+	}
+
+	const search = defineQuery({
+		title: 'Full-text search',
+		description: 'FTS5 search across materialized table rows',
+		input: Type.Object({
+			table: Type.String(),
+			query: Type.String(),
+			limit: Type.Optional(Type.Number()),
+		}),
+		handler: ({ table, query, limit }) => {
+			const columns = ftsColumns.get(table);
+			if (columns === undefined || columns.length === 0) {
+				return Promise.resolve<SearchResult[]>([]);
+			}
+			return ftsSearch(
+				db,
+				table,
+				columns,
+				query,
+				limit !== undefined ? { limit } : undefined,
+				log,
+			);
+		},
+	});
+
+	return { beforeFullLoad, search };
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/packages/workspace/src/document/materializer/sqlite/turso.test.ts
+++ b/packages/workspace/src/document/materializer/sqlite/turso.test.ts
@@ -46,8 +46,7 @@ describe('attachTursoMaterializer', () => {
 
 		const materializer = attachTursoMaterializer(ydoc, {
 			path: ':memory:',
-			tables: [tables.entries],
-		});
+		}).table(tables.entries);
 
 		await materializer.whenFlushed;
 

--- a/packages/workspace/src/document/materializer/sqlite/turso.test.ts
+++ b/packages/workspace/src/document/materializer/sqlite/turso.test.ts
@@ -46,7 +46,8 @@ describe('attachTursoMaterializer', () => {
 
 		const materializer = attachTursoMaterializer(ydoc, {
 			path: ':memory:',
-		}).table(tables.entries);
+			tables: [tables.entries],
+		});
 
 		await materializer.whenFlushed;
 

--- a/packages/workspace/src/document/materializer/sqlite/turso.test.ts
+++ b/packages/workspace/src/document/materializer/sqlite/turso.test.ts
@@ -46,7 +46,8 @@ describe('attachTursoMaterializer', () => {
 
 		const materializer = attachTursoMaterializer(ydoc, {
 			path: ':memory:',
-		}).table(tables.entries);
+			tables: { entries: tables.entries },
+		});
 
 		await materializer.whenFlushed;
 

--- a/packages/workspace/src/document/materializer/sqlite/turso.ts
+++ b/packages/workspace/src/document/materializer/sqlite/turso.ts
@@ -1,5 +1,5 @@
 /**
- * `attachTursoMaterializer(ydoc, { path, tables })`: Turso-backed materializer.
+ * `attachTursoMaterializer(ydoc, { path })`: Turso-backed materializer.
  *
  * Built on `@tursodatabase/database` (Turso's Rust SQLite rewrite, formerly
  * Limbo). The same package powers both native (Bun/Node) via the platform
@@ -19,8 +19,7 @@
  * const materializer = attachTursoMaterializer(ydoc, {
  *   path: ':memory:',                // in-memory; rebuilds from Y.Doc each session
  *   waitFor: idb.whenLoaded,
- *   tables: [[tables.entries, { fts: ['title'] }]],
- * });
+ * }).table(tables.entries, { fts: ['title'] });
  *
  * await materializer.whenFlushed;
  * const client = await materializer.client;
@@ -43,19 +42,17 @@
 import { connect, type Database } from '@tursodatabase/database';
 import { createLogger, type Logger } from 'wellcrafted/logger';
 import type * as Y from 'yjs';
-import type { BaseRow } from '../../attach-table.js';
+import type { BaseRow, Table } from '../../attach-table.js';
 import {
 	attachSqliteMaterializerCore,
 	type MirrorDatabase,
-	type TableEntries,
+	type TableConfig,
 } from './core.js';
 
 /**
  * Options for {@link attachTursoMaterializer}.
  */
-export type AttachTursoMaterializerOptions<
-	TRows extends readonly BaseRow[],
-> = {
+export type AttachTursoMaterializerOptions = {
 	/**
 	 * Path or URL that Turso's `connect()` accepts:
 	 *
@@ -67,13 +64,6 @@ export type AttachTursoMaterializerOptions<
 	 * `:memory:`).
 	 */
 	path: string;
-
-	/**
-	 * Workspace tables to mirror. Each entry is either the table reference
-	 * directly (no per-table config) or a `[table, config]` tuple. `config.fts`
-	 * narrows to the row's column names per entry.
-	 */
-	tables: TableEntries<TRows>;
 
 	/** Forwarded to the materializer core. Defaults to 100 ms. */
 	debounceMs?: number;
@@ -93,6 +83,29 @@ export type AttachTursoMaterializerOptions<
 };
 
 /**
+ * Builder returned by {@link attachTursoMaterializer}. Mirrors the core
+ * builder shape but threads `.client` + `.whenConnected` through chained
+ * `.table()` calls so the augmented props survive the chain.
+ */
+export type AttachTursoMaterializerBuilder = Omit<
+	ReturnType<typeof attachSqliteMaterializerCore>,
+	'table'
+> & {
+	table<TRow extends BaseRow>(
+		table: Table<TRow>,
+		config?: TableConfig<TRow>,
+	): AttachTursoMaterializerBuilder;
+	/** Resolves once Turso's `connect()` has completed. */
+	whenConnected: Promise<void>;
+	/**
+	 * The underlying Turso `Database` handle. Async because `connect()` is
+	 * async; most callers `await materializer.whenFlushed` first, by which
+	 * point the promise has already resolved.
+	 */
+	client: Promise<Database>;
+};
+
+/**
  * Attach a Turso-backed materializer to a Y.Doc.
  *
  * Returns synchronously per the attach-primitive convention. The async
@@ -101,21 +114,15 @@ export type AttachTursoMaterializerOptions<
  * underlying handle await `materializer.client` or wait for
  * `materializer.whenConnected`.
  */
-export function attachTursoMaterializer<
-	const TRows extends readonly BaseRow[],
->(
+export function attachTursoMaterializer(
 	ydoc: Y.Doc,
 	{
 		path,
-		tables,
 		debounceMs,
 		waitFor,
 		log = createLogger('attachTursoMaterializer'),
-	}: AttachTursoMaterializerOptions<TRows>,
-): ReturnType<typeof attachSqliteMaterializerCore<TRows>> & {
-	whenConnected: Promise<void>;
-	client: Promise<Database>;
-} {
+	}: AttachTursoMaterializerOptions,
+): AttachTursoMaterializerBuilder {
 	const clientPromise = connect(path);
 	const whenConnected = clientPromise.then(() => undefined);
 
@@ -137,9 +144,8 @@ export function attachTursoMaterializer<
 		},
 	};
 
-	const core = attachSqliteMaterializerCore(ydoc, {
+	const coreBuilder = attachSqliteMaterializerCore(ydoc, {
 		db,
-		tables,
 		debounceMs,
 		waitFor:
 			waitFor === undefined
@@ -163,5 +169,16 @@ export function attachTursoMaterializer<
 			});
 	});
 
-	return { ...core, whenConnected, client: clientPromise };
+	const augmented: AttachTursoMaterializerBuilder = {
+		...coreBuilder,
+		// Re-bind .table so chained calls keep returning the augmented builder
+		// (with .client + .whenConnected), not the bare core builder.
+		table(table, config) {
+			coreBuilder.table(table, config);
+			return augmented;
+		},
+		whenConnected,
+		client: clientPromise,
+	};
+	return augmented;
 }

--- a/packages/workspace/src/document/materializer/sqlite/turso.ts
+++ b/packages/workspace/src/document/materializer/sqlite/turso.ts
@@ -1,5 +1,5 @@
 /**
- * `attachTursoMaterializer(ydoc, { path })`: Turso-backed materializer.
+ * `attachTursoMaterializer(ydoc, { path, tables })`: Turso-backed materializer.
  *
  * Built on `@tursodatabase/database` (Turso's Rust SQLite rewrite, formerly
  * Limbo). The same package powers both native (Bun/Node) via the platform
@@ -11,15 +11,17 @@
  * Turso engine than the SQLite project's own pace.
  *
  * `connect()` is async, so the materializer's startup is gated behind
- * {@link whenConnected}. Callers wanting the underlying handle await
- * `.client` (a `Promise<Database>`).
+ * {@link AttachTursoMaterializerResult.whenConnected}. Callers wanting the
+ * underlying handle await `.client` (a `Promise<Database>`).
  *
  * @example
  * ```ts
  * const materializer = attachTursoMaterializer(ydoc, {
  *   path: ':memory:',                // in-memory; rebuilds from Y.Doc each session
  *   waitFor: idb.whenLoaded,
- * }).table(tables.entries, { fts: ['title'] });
+ *   tables,
+ *   fts: { entries: ['title'] },
+ * });
  *
  * await materializer.whenFlushed;
  * const client = await materializer.client;
@@ -42,17 +44,17 @@
 import { connect, type Database } from '@tursodatabase/database';
 import { createLogger, type Logger } from 'wellcrafted/logger';
 import type * as Y from 'yjs';
-import type { BaseRow, Table } from '../../attach-table.js';
 import {
 	attachSqliteMaterializerCore,
+	type FtsConfig,
 	type MirrorDatabase,
-	type TableConfig,
+	type TablesRecord,
 } from './core.js';
 
 /**
  * Options for {@link attachTursoMaterializer}.
  */
-export type AttachTursoMaterializerOptions = {
+export type AttachTursoMaterializerOptions<TTables extends TablesRecord> = {
 	/**
 	 * Path or URL that Turso's `connect()` accepts:
 	 *
@@ -64,6 +66,20 @@ export type AttachTursoMaterializerOptions = {
 	 * `:memory:`).
 	 */
 	path: string;
+
+	/**
+	 * Workspace tables to mirror. Each entry becomes a SQLite table named
+	 * after the record key. Pass the whole `tables` record to mirror
+	 * everything, or an object literal subset like `{ notes: tables.notes }`
+	 * to mirror a strict subset.
+	 */
+	tables: TTables;
+
+	/**
+	 * Optional FTS5 configuration. Keys must match `tables` keys; values
+	 * list the columns of that table's row to include in the FTS index.
+	 */
+	fts?: FtsConfig<TTables>;
 
 	/** Forwarded to the materializer core. Defaults to 100 ms. */
 	debounceMs?: number;
@@ -83,29 +99,6 @@ export type AttachTursoMaterializerOptions = {
 };
 
 /**
- * Builder returned by {@link attachTursoMaterializer}. Mirrors the core
- * builder shape but threads `.client` + `.whenConnected` through chained
- * `.table()` calls so the augmented props survive the chain.
- */
-export type AttachTursoMaterializerBuilder = Omit<
-	ReturnType<typeof attachSqliteMaterializerCore>,
-	'table'
-> & {
-	table<TRow extends BaseRow>(
-		table: Table<TRow>,
-		config?: TableConfig<TRow>,
-	): AttachTursoMaterializerBuilder;
-	/** Resolves once Turso's `connect()` has completed. */
-	whenConnected: Promise<void>;
-	/**
-	 * The underlying Turso `Database` handle. Async because `connect()` is
-	 * async; most callers `await materializer.whenFlushed` first, by which
-	 * point the promise has already resolved.
-	 */
-	client: Promise<Database>;
-};
-
-/**
  * Attach a Turso-backed materializer to a Y.Doc.
  *
  * Returns synchronously per the attach-primitive convention. The async
@@ -114,15 +107,26 @@ export type AttachTursoMaterializerBuilder = Omit<
  * underlying handle await `materializer.client` or wait for
  * `materializer.whenConnected`.
  */
-export function attachTursoMaterializer(
+export function attachTursoMaterializer<TTables extends TablesRecord>(
 	ydoc: Y.Doc,
 	{
 		path,
+		tables,
+		fts,
 		debounceMs,
 		waitFor,
 		log = createLogger('attachTursoMaterializer'),
-	}: AttachTursoMaterializerOptions,
-): AttachTursoMaterializerBuilder {
+	}: AttachTursoMaterializerOptions<TTables>,
+): ReturnType<typeof attachSqliteMaterializerCore<TTables>> & {
+	/** Resolves once Turso's `connect()` has completed. */
+	whenConnected: Promise<void>;
+	/**
+	 * The underlying Turso `Database` handle. Async because `connect()` is
+	 * async; most callers `await materializer.whenFlushed` first, by which
+	 * point the promise has already resolved.
+	 */
+	client: Promise<Database>;
+} {
 	const clientPromise = connect(path);
 	const whenConnected = clientPromise.then(() => undefined);
 
@@ -144,8 +148,10 @@ export function attachTursoMaterializer(
 		},
 	};
 
-	const coreBuilder = attachSqliteMaterializerCore(ydoc, {
+	const core = attachSqliteMaterializerCore(ydoc, {
 		db,
+		tables,
+		fts,
 		debounceMs,
 		waitFor:
 			waitFor === undefined
@@ -169,16 +175,5 @@ export function attachTursoMaterializer(
 			});
 	});
 
-	const augmented: AttachTursoMaterializerBuilder = {
-		...coreBuilder,
-		// Re-bind .table so chained calls keep returning the augmented builder
-		// (with .client + .whenConnected), not the bare core builder.
-		table(table, config) {
-			coreBuilder.table(table, config);
-			return augmented;
-		},
-		whenConnected,
-		client: clientPromise,
-	};
-	return augmented;
+	return { ...core, whenConnected, client: clientPromise };
 }

--- a/packages/workspace/src/document/materializer/sqlite/turso.ts
+++ b/packages/workspace/src/document/materializer/sqlite/turso.ts
@@ -1,5 +1,5 @@
 /**
- * `attachTursoMaterializer(ydoc, { path })`: Turso-backed materializer.
+ * `attachTursoMaterializer(ydoc, { path, tables })`: Turso-backed materializer.
  *
  * Built on `@tursodatabase/database` (Turso's Rust SQLite rewrite, formerly
  * Limbo). The same package powers both native (Bun/Node) via the platform
@@ -19,7 +19,8 @@
  * const materializer = attachTursoMaterializer(ydoc, {
  *   path: ':memory:',                // in-memory; rebuilds from Y.Doc each session
  *   waitFor: idb.whenLoaded,
- * }).table(tables.entries, { fts: ['title'] });
+ *   tables: [[tables.entries, { fts: ['title'] }]],
+ * });
  *
  * await materializer.whenFlushed;
  * const client = await materializer.client;
@@ -42,17 +43,19 @@
 import { connect, type Database } from '@tursodatabase/database';
 import { createLogger, type Logger } from 'wellcrafted/logger';
 import type * as Y from 'yjs';
-import type { BaseRow, Table } from '../../attach-table.js';
+import type { BaseRow } from '../../attach-table.js';
 import {
 	attachSqliteMaterializerCore,
 	type MirrorDatabase,
-	type TableConfig,
+	type TableEntries,
 } from './core.js';
 
 /**
  * Options for {@link attachTursoMaterializer}.
  */
-export type AttachTursoMaterializerOptions = {
+export type AttachTursoMaterializerOptions<
+	TRows extends readonly BaseRow[],
+> = {
 	/**
 	 * Path or URL that Turso's `connect()` accepts:
 	 *
@@ -64,6 +67,13 @@ export type AttachTursoMaterializerOptions = {
 	 * `:memory:`).
 	 */
 	path: string;
+
+	/**
+	 * Workspace tables to mirror. Each entry is either the table reference
+	 * directly (no per-table config) or a `[table, config]` tuple. `config.fts`
+	 * narrows to the row's column names per entry.
+	 */
+	tables: TableEntries<TRows>;
 
 	/** Forwarded to the materializer core. Defaults to 100 ms. */
 	debounceMs?: number;
@@ -83,29 +93,6 @@ export type AttachTursoMaterializerOptions = {
 };
 
 /**
- * Builder returned by {@link attachTursoMaterializer}. Mirrors the core
- * builder shape but threads `.client` + `.whenConnected` through chained
- * `.table()` calls so the augmented props survive the chain.
- */
-export type AttachTursoMaterializerBuilder = Omit<
-	ReturnType<typeof attachSqliteMaterializerCore>,
-	'table'
-> & {
-	table<TRow extends BaseRow>(
-		table: Table<TRow>,
-		config?: TableConfig<TRow>,
-	): AttachTursoMaterializerBuilder;
-	/** Resolves once Turso's `connect()` has completed. */
-	whenConnected: Promise<void>;
-	/**
-	 * The underlying Turso `Database` handle. Async because `connect()` is
-	 * async; most callers `await materializer.whenFlushed` first, by which
-	 * point the promise has already resolved.
-	 */
-	client: Promise<Database>;
-};
-
-/**
  * Attach a Turso-backed materializer to a Y.Doc.
  *
  * Returns synchronously per the attach-primitive convention. The async
@@ -114,15 +101,21 @@ export type AttachTursoMaterializerBuilder = Omit<
  * underlying handle await `materializer.client` or wait for
  * `materializer.whenConnected`.
  */
-export function attachTursoMaterializer(
+export function attachTursoMaterializer<
+	const TRows extends readonly BaseRow[],
+>(
 	ydoc: Y.Doc,
 	{
 		path,
+		tables,
 		debounceMs,
 		waitFor,
 		log = createLogger('attachTursoMaterializer'),
-	}: AttachTursoMaterializerOptions,
-): AttachTursoMaterializerBuilder {
+	}: AttachTursoMaterializerOptions<TRows>,
+): ReturnType<typeof attachSqliteMaterializerCore<TRows>> & {
+	whenConnected: Promise<void>;
+	client: Promise<Database>;
+} {
 	const clientPromise = connect(path);
 	const whenConnected = clientPromise.then(() => undefined);
 
@@ -144,8 +137,9 @@ export function attachTursoMaterializer(
 		},
 	};
 
-	const coreBuilder = attachSqliteMaterializerCore(ydoc, {
+	const core = attachSqliteMaterializerCore(ydoc, {
 		db,
+		tables,
 		debounceMs,
 		waitFor:
 			waitFor === undefined
@@ -169,16 +163,5 @@ export function attachTursoMaterializer(
 			});
 	});
 
-	const augmented: AttachTursoMaterializerBuilder = {
-		...coreBuilder,
-		// Re-bind .table so chained calls keep returning the augmented builder
-		// (with .client + .whenConnected), not the bare core builder.
-		table(table, config) {
-			coreBuilder.table(table, config);
-			return augmented;
-		},
-		whenConnected,
-		client: clientPromise,
-	};
-	return augmented;
+	return { ...core, whenConnected, client: clientPromise };
 }

--- a/packages/workspace/src/document/materializer/sqlite/turso.ts
+++ b/packages/workspace/src/document/materializer/sqlite/turso.ts
@@ -41,7 +41,7 @@
  * @module
  */
 
-import { connect, type Database } from '@tursodatabase/database';
+import { connect } from '@tursodatabase/database';
 import { createLogger, type Logger } from 'wellcrafted/logger';
 import type * as Y from 'yjs';
 import {
@@ -117,16 +117,7 @@ export function attachTursoMaterializer<TTables extends TablesRecord>(
 		waitFor,
 		log = createLogger('attachTursoMaterializer'),
 	}: AttachTursoMaterializerOptions<TTables>,
-): ReturnType<typeof attachSqliteMaterializerCore<TTables>> & {
-	/** Resolves once Turso's `connect()` has completed. */
-	whenConnected: Promise<void>;
-	/**
-	 * The underlying Turso `Database` handle. Async because `connect()` is
-	 * async; most callers `await materializer.whenFlushed` first, by which
-	 * point the promise has already resolved.
-	 */
-	client: Promise<Database>;
-} {
+) {
 	const clientPromise = connect(path);
 	const whenConnected = clientPromise.then(() => undefined);
 

--- a/packages/workspace/src/document/materializer/sqlite/turso.ts
+++ b/packages/workspace/src/document/materializer/sqlite/turso.ts
@@ -54,7 +54,10 @@ import {
 /**
  * Options for {@link attachTursoMaterializer}.
  */
-export type AttachTursoMaterializerOptions<TTables extends TablesRecord> = {
+export type AttachTursoMaterializerOptions<
+	TTables extends TablesRecord,
+	TFts extends FtsConfig<TTables> | undefined = undefined,
+> = {
 	/**
 	 * Path or URL that Turso's `connect()` accepts:
 	 *
@@ -78,8 +81,10 @@ export type AttachTursoMaterializerOptions<TTables extends TablesRecord> = {
 	/**
 	 * Optional FTS5 configuration. Keys must match `tables` keys; values
 	 * list the columns of that table's row to include in the FTS index.
+	 * When provided, the result exposes `materializer.fts.search(...)`;
+	 * when omitted, the `fts` namespace is absent from the return type.
 	 */
-	fts?: FtsConfig<TTables>;
+	fts?: TFts;
 
 	/** Forwarded to the materializer core. Defaults to 100 ms. */
 	debounceMs?: number;
@@ -107,7 +112,10 @@ export type AttachTursoMaterializerOptions<TTables extends TablesRecord> = {
  * underlying handle await `materializer.client` or wait for
  * `materializer.whenConnected`.
  */
-export function attachTursoMaterializer<TTables extends TablesRecord>(
+export function attachTursoMaterializer<
+	TTables extends TablesRecord,
+	TFts extends FtsConfig<TTables> | undefined = undefined,
+>(
 	ydoc: Y.Doc,
 	{
 		path,
@@ -116,7 +124,7 @@ export function attachTursoMaterializer<TTables extends TablesRecord>(
 		debounceMs,
 		waitFor,
 		log = createLogger('attachTursoMaterializer'),
-	}: AttachTursoMaterializerOptions<TTables>,
+	}: AttachTursoMaterializerOptions<TTables, TFts>,
 ) {
 	const clientPromise = connect(path);
 	const whenConnected = clientPromise.then(() => undefined);
@@ -139,7 +147,7 @@ export function attachTursoMaterializer<TTables extends TablesRecord>(
 		},
 	};
 
-	const core = attachSqliteMaterializerCore(ydoc, {
+	const core = attachSqliteMaterializerCore<TTables, TFts>(ydoc, {
 		db,
 		tables,
 		fts,

--- a/packages/workspace/src/document/open-sqlite-reader.test.ts
+++ b/packages/workspace/src/document/open-sqlite-reader.test.ts
@@ -39,13 +39,13 @@ async function seedMirrorFile(
 	const tables = attachTables(ydoc, { entries: entriesTable });
 	// debounceMs: 0 so each set() flushes on the next microtask, matching the
 	// "seed then read" shape of these tests.
-	const builder = attachBunSqliteMaterializer(ydoc, {
+	const materializer = attachBunSqliteMaterializer(ydoc, {
 		filePath,
 		debounceMs: 0,
+		tables: fts
+			? [[tables.entries, { fts: ['title', 'body'] }]]
+			: [tables.entries],
 	});
-	const materializer = fts
-		? builder.table(tables.entries, { fts: ['title', 'body'] })
-		: builder.table(tables.entries);
 	await materializer.whenFlushed;
 	for (const row of rows) tables.entries.set({ ...row });
 	// Yield once for the debounced flush, then once more for the awaited

--- a/packages/workspace/src/document/open-sqlite-reader.test.ts
+++ b/packages/workspace/src/document/open-sqlite-reader.test.ts
@@ -39,13 +39,12 @@ async function seedMirrorFile(
 	const tables = attachTables(ydoc, { entries: entriesTable });
 	// debounceMs: 0 so each set() flushes on the next microtask, matching the
 	// "seed then read" shape of these tests.
-	const builder = attachBunSqliteMaterializer(ydoc, {
+	const materializer = attachBunSqliteMaterializer(ydoc, {
 		filePath,
 		debounceMs: 0,
+		tables: { entries: tables.entries },
+		...(fts ? { fts: { entries: ['title', 'body'] } } : {}),
 	});
-	const materializer = fts
-		? builder.table(tables.entries, { fts: ['title', 'body'] })
-		: builder.table(tables.entries);
 	await materializer.whenFlushed;
 	for (const row of rows) tables.entries.set({ ...row });
 	// Yield once for the debounced flush, then once more for the awaited

--- a/packages/workspace/src/document/open-sqlite-reader.test.ts
+++ b/packages/workspace/src/document/open-sqlite-reader.test.ts
@@ -39,13 +39,13 @@ async function seedMirrorFile(
 	const tables = attachTables(ydoc, { entries: entriesTable });
 	// debounceMs: 0 so each set() flushes on the next microtask, matching the
 	// "seed then read" shape of these tests.
-	const materializer = attachBunSqliteMaterializer(ydoc, {
+	const builder = attachBunSqliteMaterializer(ydoc, {
 		filePath,
 		debounceMs: 0,
-		tables: fts
-			? [[tables.entries, { fts: ['title', 'body'] }]]
-			: [tables.entries],
 	});
+	const materializer = fts
+		? builder.table(tables.entries, { fts: ['title', 'body'] })
+		: builder.table(tables.entries);
 	await materializer.whenFlushed;
 	for (const row of rows) tables.entries.set({ ...row });
 	// Yield once for the debounced flush, then once more for the awaited

--- a/playground/opensidian-e2e/workspaces/opensidian/daemon.ts
+++ b/playground/opensidian-e2e/workspaces/opensidian/daemon.ts
@@ -112,50 +112,43 @@ async function openOpensidianPlayground({
 	const markdown = attachMarkdownMaterializer(ydoc, {
 		dir: markdownPath(projectDir, WORKSPACE_ID),
 		waitFor: whenReady,
-		tables: [
-			[
-				tables.files,
-				{
-					filename: (row) =>
-						row.type === 'folder'
-							? `${row.id}.md`
-							: toSlugFilename(row.name.replace(/\.md$/i, ''), row.id),
-					toMarkdown: async (row) => {
-						if (row.type === 'folder') {
-							return {
-								frontmatter: { id: row.id, name: row.name, type: 'folder' },
-								body: undefined,
-							};
-						}
-						let body: string | undefined;
-						try {
-							body = await readContent(row.id);
-						} catch {
-							// Content doc not yet available (sync pending).
-						}
-						return {
-							frontmatter: {
-								id: row.id,
-								name: row.name,
-								parentId: row.parentId,
-								size: row.size,
-								createdAt: row.createdAt,
-								updatedAt: row.updatedAt,
-								trashedAt: row.trashedAt,
-							},
-							body,
-						};
-					},
+	}).table(tables.files, {
+		filename: (row) =>
+			row.type === 'folder'
+				? `${row.id}.md`
+				: toSlugFilename(row.name.replace(/\.md$/i, ''), row.id),
+		toMarkdown: async (row) => {
+			if (row.type === 'folder') {
+				return {
+					frontmatter: { id: row.id, name: row.name, type: 'folder' },
+					body: undefined,
+				};
+			}
+			let body: string | undefined;
+			try {
+				body = await readContent(row.id);
+			} catch {
+				// Content doc not yet available (sync pending).
+			}
+			return {
+				frontmatter: {
+					id: row.id,
+					name: row.name,
+					parentId: row.parentId,
+					size: row.size,
+					createdAt: row.createdAt,
+					updatedAt: row.updatedAt,
+					trashedAt: row.trashedAt,
 				},
-			],
-		],
+				body,
+			};
+		},
 	});
 
 	const sqlite = attachBunSqliteMaterializer(ydoc, {
 		filePath: sqlitePath(projectDir, WORKSPACE_ID),
 		waitFor: whenReady,
-		tables: [[tables.files, { fts: ['name'] }]],
-	});
+	}).table(tables.files, { fts: ['name'] });
 
 	return {
 		workspaceId: ydoc.guid,

--- a/playground/opensidian-e2e/workspaces/opensidian/daemon.ts
+++ b/playground/opensidian-e2e/workspaces/opensidian/daemon.ts
@@ -112,43 +112,49 @@ async function openOpensidianPlayground({
 	const markdown = attachMarkdownMaterializer(ydoc, {
 		dir: markdownPath(projectDir, WORKSPACE_ID),
 		waitFor: whenReady,
-	}).table(tables.files, {
-		filename: (row) =>
-			row.type === 'folder'
-				? `${row.id}.md`
-				: toSlugFilename(row.name.replace(/\.md$/i, ''), row.id),
-		toMarkdown: async (row) => {
-			if (row.type === 'folder') {
-				return {
-					frontmatter: { id: row.id, name: row.name, type: 'folder' },
-					body: undefined,
-				};
-			}
-			let body: string | undefined;
-			try {
-				body = await readContent(row.id);
-			} catch {
-				// Content doc not yet available (sync pending).
-			}
-			return {
-				frontmatter: {
-					id: row.id,
-					name: row.name,
-					parentId: row.parentId,
-					size: row.size,
-					createdAt: row.createdAt,
-					updatedAt: row.updatedAt,
-					trashedAt: row.trashedAt,
+		tables: { files: tables.files },
+		perTable: {
+			files: {
+				filename: (row) =>
+					row.type === 'folder'
+						? `${row.id}.md`
+						: toSlugFilename(row.name.replace(/\.md$/i, ''), row.id),
+				toMarkdown: async (row) => {
+					if (row.type === 'folder') {
+						return {
+							frontmatter: { id: row.id, name: row.name, type: 'folder' },
+							body: undefined,
+						};
+					}
+					let body: string | undefined;
+					try {
+						body = await readContent(row.id);
+					} catch {
+						// Content doc not yet available (sync pending).
+					}
+					return {
+						frontmatter: {
+							id: row.id,
+							name: row.name,
+							parentId: row.parentId,
+							size: row.size,
+							createdAt: row.createdAt,
+							updatedAt: row.updatedAt,
+							trashedAt: row.trashedAt,
+						},
+						body,
+					};
 				},
-				body,
-			};
+			},
 		},
 	});
 
 	const sqlite = attachBunSqliteMaterializer(ydoc, {
 		filePath: sqlitePath(projectDir, WORKSPACE_ID),
 		waitFor: whenReady,
-	}).table(tables.files, { fts: ['name'] });
+		tables: { files: tables.files },
+		fts: { files: ['name'] },
+	});
 
 	return {
 		workspaceId: ydoc.guid,

--- a/playground/opensidian-e2e/workspaces/opensidian/daemon.ts
+++ b/playground/opensidian-e2e/workspaces/opensidian/daemon.ts
@@ -112,43 +112,50 @@ async function openOpensidianPlayground({
 	const markdown = attachMarkdownMaterializer(ydoc, {
 		dir: markdownPath(projectDir, WORKSPACE_ID),
 		waitFor: whenReady,
-	}).table(tables.files, {
-		filename: (row) =>
-			row.type === 'folder'
-				? `${row.id}.md`
-				: toSlugFilename(row.name.replace(/\.md$/i, ''), row.id),
-		toMarkdown: async (row) => {
-			if (row.type === 'folder') {
-				return {
-					frontmatter: { id: row.id, name: row.name, type: 'folder' },
-					body: undefined,
-				};
-			}
-			let body: string | undefined;
-			try {
-				body = await readContent(row.id);
-			} catch {
-				// Content doc not yet available (sync pending).
-			}
-			return {
-				frontmatter: {
-					id: row.id,
-					name: row.name,
-					parentId: row.parentId,
-					size: row.size,
-					createdAt: row.createdAt,
-					updatedAt: row.updatedAt,
-					trashedAt: row.trashedAt,
+		tables: [
+			[
+				tables.files,
+				{
+					filename: (row) =>
+						row.type === 'folder'
+							? `${row.id}.md`
+							: toSlugFilename(row.name.replace(/\.md$/i, ''), row.id),
+					toMarkdown: async (row) => {
+						if (row.type === 'folder') {
+							return {
+								frontmatter: { id: row.id, name: row.name, type: 'folder' },
+								body: undefined,
+							};
+						}
+						let body: string | undefined;
+						try {
+							body = await readContent(row.id);
+						} catch {
+							// Content doc not yet available (sync pending).
+						}
+						return {
+							frontmatter: {
+								id: row.id,
+								name: row.name,
+								parentId: row.parentId,
+								size: row.size,
+								createdAt: row.createdAt,
+								updatedAt: row.updatedAt,
+								trashedAt: row.trashedAt,
+							},
+							body,
+						};
+					},
 				},
-				body,
-			};
-		},
+			],
+		],
 	});
 
 	const sqlite = attachBunSqliteMaterializer(ydoc, {
 		filePath: sqlitePath(projectDir, WORKSPACE_ID),
 		waitFor: whenReady,
-	}).table(tables.files, { fts: ['name'] });
+		tables: [[tables.files, { fts: ['name'] }]],
+	});
 
 	return {
 		workspaceId: ydoc.guid,

--- a/playground/tab-manager-e2e/workspaces/tabManager/daemon.ts
+++ b/playground/tab-manager-e2e/workspaces/tabManager/daemon.ts
@@ -65,11 +65,13 @@ export default defineWorkspace({
 		const markdown = attachMarkdownMaterializer(ydoc, {
 			dir: markdownPath(projectDir, WORKSPACE_ID),
 			waitFor: whenReady,
-		})
-			.table(tables.savedTabs, { filename: slugFilename('title') })
-			.table(tables.bookmarks, { filename: slugFilename('title') })
-			.table(tables.devices)
-			.kv(kv);
+			tables: [
+				[tables.savedTabs, { filename: slugFilename('title') }],
+				[tables.bookmarks, { filename: slugFilename('title') }],
+				tables.devices,
+			],
+			kv,
+		});
 
 		return {
 			workspaceId: ydoc.guid,

--- a/playground/tab-manager-e2e/workspaces/tabManager/daemon.ts
+++ b/playground/tab-manager-e2e/workspaces/tabManager/daemon.ts
@@ -65,13 +65,11 @@ export default defineWorkspace({
 		const markdown = attachMarkdownMaterializer(ydoc, {
 			dir: markdownPath(projectDir, WORKSPACE_ID),
 			waitFor: whenReady,
-			tables: [
-				[tables.savedTabs, { filename: slugFilename('title') }],
-				[tables.bookmarks, { filename: slugFilename('title') }],
-				tables.devices,
-			],
-			kv,
-		});
+		})
+			.table(tables.savedTabs, { filename: slugFilename('title') })
+			.table(tables.bookmarks, { filename: slugFilename('title') })
+			.table(tables.devices)
+			.kv(kv);
 
 		return {
 			workspaceId: ydoc.guid,

--- a/playground/tab-manager-e2e/workspaces/tabManager/daemon.ts
+++ b/playground/tab-manager-e2e/workspaces/tabManager/daemon.ts
@@ -65,11 +65,17 @@ export default defineWorkspace({
 		const markdown = attachMarkdownMaterializer(ydoc, {
 			dir: markdownPath(projectDir, WORKSPACE_ID),
 			waitFor: whenReady,
-		})
-			.table(tables.savedTabs, { filename: slugFilename('title') })
-			.table(tables.bookmarks, { filename: slugFilename('title') })
-			.table(tables.devices)
-			.kv(kv);
+			tables: {
+				savedTabs: tables.savedTabs,
+				bookmarks: tables.bookmarks,
+				devices: tables.devices,
+			},
+			perTable: {
+				savedTabs: { filename: slugFilename('title') },
+				bookmarks: { filename: slugFilename('title') },
+			},
+			kv,
+		});
 
 		return {
 			workspaceId: ydoc.guid,

--- a/specs/20260525T134351-materializer-tables-as-record.md
+++ b/specs/20260525T134351-materializer-tables-as-record.md
@@ -1,0 +1,504 @@
+# Materializer `tables` as a record, FTS as a keyed sibling
+
+**Date**: 2026-05-25
+**Status**: Draft
+**Owner**: Braden / workspace
+**Branch**: braden-w/pull-origin-main
+
+## One Sentence
+
+Both materializers take `tables: Tables<TDefs>` (the whole record from `attachTables`) and mirror every entry by default; SQLite gets a sibling `fts: { [tableName]: ColumnKeys[] }` for the rare opt-in, and markdown gets a sibling `perTable: { [tableName]: PerTableConfig }` for filename and serializer overrides.
+
+## Why this exists
+
+The current API requires the caller to enumerate tables via a chained `.table(ref, cfg)` builder:
+
+```ts
+attachBunSqliteMaterializer(ydoc, { filePath })
+  .table(tables.entries, { fts: ['title', 'body'] });
+
+attachMarkdownMaterializer(ydoc, { dir })
+  .table(tables.savedTabs, { filename: slugFilename('title') })
+  .table(tables.bookmarks, { filename: slugFilename('title') })
+  .table(tables.devices)
+  .kv(kv);
+```
+
+That enumeration was forced when TypeBox columns did **not** map 1:1 to Drizzle/SQLite types — some columns weren't materializable, so the caller had to pick. After the recent materializer surface cleanup (commit `d411eab64`) and the schema mapping work (commit `760eb8376`), every column a TypeBox table can declare is now materializable. The "pick which tables to mirror" requirement is a constraint paying off a problem that no longer exists.
+
+A side-effect of the chain was per-backend factory rebinding (each of `attachBunSqliteMaterializer`, `attachTursoMaterializer` rebinds `.table()` to thread `.client` / `.whenConnected` through the chain). That code disappears when registration moves out of the chain.
+
+The shape this spec rejects: tuple-array (`tables: [[ref, cfg], ref, [ref, cfg]]`). It was attempted and reverted (commit `0b90d7158` → `f4a79a28e`). The variadic mapped-type inference was brittle, the double-bracket call shape regressed the 80% single-table case, and it kept the "enumerate every table" requirement that this spec removes.
+
+## Current state
+
+```ts
+// SQLite
+attachBunSqliteMaterializer(ydoc, opts)
+  .table(ref, cfg)
+  .table(ref, cfg)
+  // ^^ .table re-bound in each per-backend factory to thread .client + .whenConnected
+
+// Markdown
+attachMarkdownMaterializer(ydoc, opts)
+  .table(ref, cfg)
+  .table(ref, cfg)
+  .kv(kvRef, cfg)
+```
+
+Registration window is open between construction and the resolution of `whenFlushed`. Calls to `.table()` / `.kv()` after that throw a runtime error.
+
+Internal flags (`isRegistrationOpen`) and runtime guard messages enforce this.
+
+## Target shape
+
+### SQLite (bun and Turso)
+
+```ts
+attachBunSqliteMaterializer(ydoc, {
+  filePath: sqlitePath(projectDir, ydoc.guid),
+  tables,                              // mirrors everything in the record
+});
+
+// With FTS on specific columns of specific tables:
+attachBunSqliteMaterializer(ydoc, {
+  filePath: ...,
+  tables,
+  fts: {
+    posts: ['title', 'body'],          // key: keyof tables; value: column keys of posts row
+  },
+});
+
+// Subset (rare): pick the tables you want to mirror
+attachBunSqliteMaterializer(ydoc, {
+  filePath: ...,
+  tables: { notes: tables.notes },
+});
+```
+
+### Markdown
+
+```ts
+attachMarkdownMaterializer(ydoc, {
+  dir,
+  tables,                              // mirrors everything in the record
+  kv,                                  // optional: pass the Kv directly
+});
+
+// With per-table customization:
+attachMarkdownMaterializer(ydoc, {
+  dir,
+  tables,
+  perTable: {
+    posts: { filename: slugFilename('title') },
+    files: {
+      filename: (row) => row.type === 'folder' ? `${row.id}.md` : toSlugFilename(row.name, row.id),
+      toMarkdown: async (row) => { /* ... */ },
+    },
+  },
+  kv,
+});
+
+// Subset:
+attachMarkdownMaterializer(ydoc, {
+  dir,
+  tables: { notes: tables.notes },
+});
+```
+
+`kv` accepts the bare `Kv` reference. KV serializer overrides aren't used anywhere in the repo; defer until needed.
+
+## Type design
+
+### Tables record
+
+```ts
+// biome-ignore lint/suspicious/noExplicitAny: heterogeneous row types in a record
+type TablesRecord = Record<string, Table<any>>;
+
+// Infer over the tables record directly, not over a TableDefinitions roundtrip
+function attach<TTables extends TablesRecord>(
+  ydoc: Y.Doc,
+  opts: {
+    tables: TTables;
+    fts?: FtsConfig<TTables>;          // SQLite only
+    perTable?: PerTableConfig<TTables>; // Markdown only
+    // ... other options
+  },
+);
+```
+
+### FTS narrowing (SQLite)
+
+```ts
+type FtsConfig<TTables extends TablesRecord> = {
+  [K in keyof TTables]?: TTables[K] extends Table<infer R>
+    ? (keyof R & string)[]
+    : never;
+};
+```
+
+Verified inference (probed before writing this spec):
+
+| Call site | Result |
+|---|---|
+| `fts: { posts: ['title'] }` | ✅ compiles |
+| `fts: { typo: [...] }` | ❌ key error |
+| `fts: { posts: ['badColumn'] }` | ❌ value error |
+| `fts: { posts: ['title', 'badColumn'] }` | ❌ error on the bad one only |
+| Subset `tables: { posts: ... }`, then `fts: { notes: ... }` | ❌ key error (notes not in subset) |
+| Omit `fts` | ✅ optional |
+| Autocomplete on `fts.posts` | ✅ suggests row columns |
+
+### Per-table config narrowing (markdown)
+
+```ts
+type MarkdownPerTableConfig<TRow extends BaseRow> = {
+  dir?: string;
+  filename?: (row: TRow) => MaybePromise<string>;
+  toMarkdown?: (row: TRow) => MaybePromise<MarkdownShape>;
+  fromMarkdown?: (parsed: MarkdownShape) => MaybePromise<TRow>;
+};
+
+type PerTableConfig<TTables extends TablesRecord> = {
+  [K in keyof TTables]?: TTables[K] extends Table<infer R>
+    ? MarkdownPerTableConfig<R>
+    : never;
+};
+```
+
+Same inference pattern as `fts`. Each per-table block sees the right row type for its callbacks.
+
+## What collapses
+
+### sqlite/core.ts
+
+- Drop `isRegistrationOpen` flag and assignments.
+- Drop `MaterializerBuilder` type, `builder` object, `.table()` method.
+- Drop `TableConfig.serialize` (the per-column value serializer override — unused in the repo). Keep `serializeValue` as the only value serializer.
+- Drop the runtime "called after initial flush" error.
+- Take `tables: TTables` and `fts?: FtsConfig<TTables>` in options.
+- Populate the `registered` map synchronously before `initialize()`.
+- Return a plain object.
+
+### sqlite/bun-sqlite.ts
+
+- Drop the `.table()` re-binding block that threaded `.client`.
+- Drop the exported `AttachBunSqliteMaterializerBuilder` augmented type (only used internally; not consumed outside this package per repo grep).
+- Return `{ ...core, client }` directly.
+
+### sqlite/turso.ts
+
+- Drop the `.table()` / `.client` / `.whenConnected` re-binding block.
+- Drop the exported `AttachTursoMaterializerBuilder` augmented type.
+- Return `{ ...core, whenConnected, client: clientPromise }` directly.
+
+### markdown/materializer.ts
+
+- Drop `isRegistrationOpen` flag and the "called after initial flush" errors for both `.table()` and `.kv()`.
+- Drop `MaterializerBuilder` type, `builder` object, `.table()` / `.kv()` methods.
+- Take `tables: TTables`, `kv?: Kv<any>`, `perTable?: PerTableConfig<TTables>` in options.
+- Populate `registered` map + `registeredKv` synchronously.
+- Return a plain object.
+
+### JSDoc / comment text to sweep
+
+The `.table()` / `.kv()` methods carry JSDoc that says "Must be called synchronously after construction, before `whenFlushed` resolves. Calls after the initial flush throw." That text dies with the methods. Locations:
+
+- `sqlite/core.ts` `MaterializerBuilder.table` (around line 387) — entire method JSDoc disappears.
+- `markdown/materializer.ts` `MaterializerBuilder.table` and `.kv` (around lines 609-624) — entire method JSDoc disappears.
+- Module-level JSDoc on `attachMarkdownMaterializer` says "returns a chainable builder where `.table(tableRef, config?)` opts in..." (around line 214). Rewrite to describe the options-bag shape.
+
+Inline comments inside `initialize()` reference the removed methods:
+
+- `sqlite/core.ts:313-318` ("Always yield a microtask so callers can finish synchronous setup (including writing initial rows) before the full-load runs. Close the registration window: any further `.table()` call throws..."). The yield is still needed for seeding writes; the registration-window comment dies.
+- `markdown/materializer.ts:376-381` (same shape, mentions `.table()` / `.kv()` registrations). Same edit.
+
+### Preserve destroy-listener ordering
+
+In both `sqlite/bun-sqlite.ts` and `sqlite/turso.ts`, the per-backend factory currently registers its `client.close()` destroy listener AFTER calling `attachSqliteMaterializerCore`. That order is invariant — core's listener runs first (cancels timers, detaches observers) so the database handle isn't closed under live work. When collapsing the augmented builder to `{ ...core, client }`, keep the order: `const core = attachSqliteMaterializerCore(...)` first, `ydoc.once('destroy', () => client.close())` second, `return { ...core, client }` last.
+
+## Call site updates
+
+```
+apps/fuji/daemon.ts:50-56
+apps/honeycrisp/daemon.ts:55-64
+examples/fuji/epicenter.config.ts:53-65
+playground/opensidian-e2e/workspaces/opensidian/daemon.ts:112-151
+playground/tab-manager-e2e/workspaces/tabManager/daemon.ts:65-71
+```
+
+### Subset migration table
+
+`tables` is a required argument. Passing `tables` (the whole record) mirrors every entry; passing `{ k: tables.k }` (an object literal) mirrors only what you list. Several existing call sites mirror a strict subset today; this migration MUST preserve that intent or it silently creates new SQLite tables and markdown directories the app doesn't want.
+
+| Call site | App's full table set | Currently mirrored (SQLite) | Currently mirrored (Markdown) | Action |
+|---|---|---|---|---|
+| `apps/fuji` | `{ entries }` | `entries` | `entries` | Pass `tables` (full set = subset) |
+| `examples/fuji` | `{ entries }` | `entries` | `entries` | Pass `tables` |
+| `apps/honeycrisp` | `{ folders, notes }` | both | `notes` only | SQLite: pass `tables`; Markdown: pass `{ notes: tables.notes }` |
+| `opensidian` (playground) | `{ files, conversations, chatMessages, toolTrust }` | `files` only | `files` only | Both: pass `{ files: tables.files }` |
+| `tab-manager` (playground) | `{ devices, savedTabs, bookmarks, conversations, chatMessages, toolTrust }` | (no SQLite) | `savedTabs, bookmarks, devices` | Markdown: pass `{ savedTabs: tables.savedTabs, bookmarks: tables.bookmarks, devices: tables.devices }` |
+
+### Opensidian before / after (the strict-subset case)
+
+```ts
+// Before
+attachMarkdownMaterializer(ydoc, { dir, waitFor: whenReady })
+  .table(tables.files, {
+    filename: (row) => row.type === 'folder' ? ... : ...,
+    toMarkdown: async (row) => { ... },
+  });
+
+attachBunSqliteMaterializer(ydoc, { filePath, waitFor: whenReady })
+  .table(tables.files, { fts: ['name'] });
+
+// After
+attachMarkdownMaterializer(ydoc, {
+  dir,
+  waitFor: whenReady,
+  tables: { files: tables.files },        // subset: only mirror files
+  perTable: {
+    files: {
+      filename: (row) => row.type === 'folder' ? ... : ...,
+      toMarkdown: async (row) => { ... },
+    },
+  },
+});
+
+attachBunSqliteMaterializer(ydoc, {
+  filePath,
+  waitFor: whenReady,
+  tables: { files: tables.files },        // subset: only mirror files
+  fts: { files: ['name'] },
+});
+```
+
+### Before / after for the tricky cases
+
+**Honeycrisp** (mirror everything to SQLite; only `notes` to markdown):
+
+```ts
+// Before
+const sqlite = attachBunSqliteMaterializer(ydoc, { filePath: ..., log: ... });
+sqlite.table(tables.folders);
+sqlite.table(tables.notes);
+
+attachMarkdownMaterializer(ydoc, { dir: ... })
+  .table(tables.notes, { filename: slugFilename('title') });
+
+// After
+attachBunSqliteMaterializer(ydoc, {
+  filePath: ...,
+  log: ...,
+  tables,
+});
+
+attachMarkdownMaterializer(ydoc, {
+  dir: ...,
+  tables: { notes: tables.notes },
+  perTable: { notes: { filename: slugFilename('title') } },
+});
+```
+
+**Tab-manager** (markdown mirrors 3 of 6 tables, plus KV):
+
+```ts
+// Before
+const markdown = attachMarkdownMaterializer(ydoc, { dir, waitFor: whenReady })
+  .table(tables.savedTabs, { filename: slugFilename('title') })
+  .table(tables.bookmarks, { filename: slugFilename('title') })
+  .table(tables.devices)
+  .kv(kv);
+
+// After (subset: skip conversations / chatMessages / toolTrust)
+const markdown = attachMarkdownMaterializer(ydoc, {
+  dir,
+  waitFor: whenReady,
+  tables: {
+    savedTabs: tables.savedTabs,
+    bookmarks: tables.bookmarks,
+    devices: tables.devices,
+  },
+  perTable: {
+    savedTabs: { filename: slugFilename('title') },
+    bookmarks: { filename: slugFilename('title') },
+  },
+  kv,
+});
+```
+
+**Opensidian** (one table with heavy callbacks):
+
+```ts
+// Before
+attachMarkdownMaterializer(ydoc, { dir, waitFor: whenReady })
+  .table(tables.files, {
+    filename: (row) => row.type === 'folder' ? ... : ...,
+    toMarkdown: async (row) => { ... },
+  });
+
+// After
+attachMarkdownMaterializer(ydoc, {
+  dir,
+  waitFor: whenReady,
+  tables,
+  perTable: {
+    files: {
+      filename: (row) => row.type === 'folder' ? ... : ...,
+      toMarkdown: async (row) => { ... },
+    },
+  },
+});
+```
+
+## Tests to update
+
+```
+packages/workspace/src/document/materializer/sqlite/core.test.ts
+packages/workspace/src/document/materializer/sqlite/turso.test.ts
+packages/workspace/src/document/materializer/markdown/materializer.test.ts
+packages/workspace/src/document/drizzle-schema.test.ts
+packages/workspace/src/document/open-sqlite-reader.test.ts
+```
+
+Each test currently calls `.table(table, config)` on a materializer. Port to passing `tables` + (optional) `fts` / `perTable` in options.
+
+The "registration after initial flush throws" failure mode is impossible by construction. No such tests exist in the current codebase, but if one is added during the refactor, delete it.
+
+### Helper restructuring in core.test.ts and markdown/materializer.test.ts
+
+Both test files define a `TableRegistration` helper derived from the removed methods:
+
+```ts
+type Materializer = ReturnType<typeof attach...Materializer...>;
+type TableRegistration = {
+  table: Parameters<Materializer['table']>[0];
+  config?: Parameters<Materializer['table']>[1];
+};
+```
+
+That helper dies with the method. The `setup()` function in each file currently takes `tables?: (t: AttachedTables) => TableRegistration[]` and runs `materializer.table(t, c)` in a loop. The replacement: `setup()` takes an options builder, e.g.:
+
+```ts
+async function setup(
+  build?: (t: AttachedTables) => {
+    tables: Record<string, Table<any>>;
+    fts?: ...;             // sqlite test
+    perTable?: ...;         // markdown test
+    kv?: AnyKv;             // markdown test
+  },
+) { ... }
+```
+
+`open-sqlite-reader.test.ts:46-48` has a ternary `fts ? builder.table(..., {fts:...}) : builder.table(...)`. Conditional moves to building the `fts` option:
+
+```ts
+const materializer = attachBunSqliteMaterializer(ydoc, {
+  filePath,
+  debounceMs: 0,
+  tables: { entries: tables.entries },
+  ...(fts ? { fts: { entries: ['title', 'body'] } } : {}),
+});
+```
+
+The "ignores notes when only posts is in tables option" test stays semantically meaningful: `tables: { posts: t.posts }` instead of the old subset shape.
+
+## JSDoc / docs updates
+
+- `bun-sqlite.ts:11-21` `@example` block
+- `turso.ts:18-30` `@example` block
+- `markdown/materializer.ts:228-246` `@example` block
+- `markdown/slug-filename.ts:8-13` `@example` block
+- `packages/workspace/README.md` lines 963-965 (markdown example) and 1006-1008 (sqlite example)
+- `.agents/skills/attach-primitive/SKILL.md` lines 42-64 (materializer chain examples) and lines 130-132 (bundle composition example) and line 188 (reference description)
+
+## Verification
+
+```bash
+# 1. Workspace package typechecks alone
+cd packages/workspace && bun run typecheck
+
+# 2. All packages typecheck
+bun run typecheck
+
+# 3. Workspace tests pass
+cd packages/workspace && bun test
+
+# 4. Type-narrowing probe: fts column names error on bad inputs.
+#    The probe file is throwaway, written and deleted during execution.
+
+# 5. Greps for stale shapes
+rg "\.table\(tables\." packages/ apps/ examples/ playground/
+rg "\)\.table\(|materializer\.table\(|sqlite\.table\(|\)\.kv\(" packages/ apps/ examples/ playground/
+rg "isRegistrationOpen|MaterializerBuilder|called after initial flush" packages/
+rg "AttachBunSqliteMaterializerBuilder|AttachTursoMaterializerBuilder" packages/ apps/ examples/ playground/
+# All should return zero hits in source files (specs/ may still reference them historically).
+```
+
+## Design decisions
+
+### Why `Tables<TDefs>` (a record), not an array
+
+- Object subset is a natural way to pick "mirror only these": `tables: { posts: tables.posts }`.
+- Record keys narrow `fts` / `perTable` keys without variadic gymnastics.
+- Default = "mirror everything" matches the 80% case.
+- Type inference is standard (`Record<string, Table<any>>` + mapped types), not variadic-tuple-with-`const` (which needed two iterations to get right last time and still felt fragile).
+
+### Why `fts` and `perTable` are sibling slots, not nested under each table
+
+- The 80% case never touches them, so they don't clutter common calls.
+- Each sibling slot is sparsely populated (FTS is rare; per-table customization is rare).
+- Mapped types over `keyof TTables` narrow cleanly with no `infer R` gymnastics outside the slot itself.
+- Conceptually: the table set is one fact ("what to mirror"), FTS is another fact ("which columns are searchable"), per-table is another ("how to render this specific table"). Three slots, three concepts.
+
+### Why not chain `.withFts(...)`
+
+- No inference benefit over the keyed object — TypeScript narrows just as well.
+- Would re-introduce the per-backend-factory rebinding problem the chain caused.
+- The keyed object is statically inspectable (you can see the FTS config sitting next to the tables in one block); a chain hides it behind another call.
+
+### Why drop `TableConfig.serialize`
+
+- Unused in the repo. The default `serializeValue` handles null/object/boolean correctly for all current callers.
+- If a future caller needs a per-column override, add it back inside `perTable` (e.g., `perTable: { posts: { serialize: ... } }`).
+- The clean break is the right time to refuse unearned surface.
+
+### Why not refactor FTS into a separate `attachFts(materializer, ...)` primitive
+
+Discussed and deferred. It's a real cleanup but bigger than this spec. The FTS slot here is a sibling option, which is forward-compatible with extracting it later.
+
+## Implementation plan
+
+Six independent units of work. Some can run in parallel because they touch different files; others must be sequential (core types first, then dependents).
+
+1. **Wave 1: core types and SQLite**
+   - `sqlite/core.ts`: switch signature, remove builder, return plain object.
+   - `sqlite/bun-sqlite.ts`: remove rebind, forward `tables` + `fts`, return `{ ...core, client }`.
+   - `sqlite/turso.ts`: remove rebind, forward `tables` + `fts`, return `{ ...core, whenConnected, client }`.
+   - Update sqlite tests (`core.test.ts`, `turso.test.ts`, sibling tests in `drizzle-schema.test.ts`, `open-sqlite-reader.test.ts`).
+
+2. **Wave 1 (parallel): markdown**
+   - `markdown/materializer.ts`: switch signature, remove builder, return plain object.
+   - Update markdown tests (`markdown/materializer.test.ts`).
+
+3. **Wave 2: call sites**
+   - `apps/fuji/daemon.ts`
+   - `apps/honeycrisp/daemon.ts`
+   - `examples/fuji/epicenter.config.ts`
+   - `playground/opensidian-e2e/workspaces/opensidian/daemon.ts`
+   - `playground/tab-manager-e2e/workspaces/tabManager/daemon.ts`
+
+4. **Wave 3: docs**
+   - JSDoc `@example` blocks on each materializer.
+   - `slug-filename.ts` JSDoc.
+   - `packages/workspace/README.md` examples.
+   - `.agents/skills/attach-primitive/SKILL.md` materializer examples.
+
+5. **Verification**: typecheck + test pass.
+
+6. **Commit**: one commit with prefix `refactor(workspace)!:`.
+
+## Open questions
+
+None at draft. Add here if implementation surfaces a real ambiguity.

--- a/specs/20260525T212249-sqlite-fts-primitive-split.md
+++ b/specs/20260525T212249-sqlite-fts-primitive-split.md
@@ -1,0 +1,437 @@
+# SQLite FTS Primitive Split
+
+**Date**: 2026-05-25
+**Status**: Implemented (Option A′)
+**Owner**: Braden
+**Branch**: braden-w/pull-origin-main
+
+## One Sentence
+
+Keep the single attach call and the keyed `fts: {...}` option, but move the FTS surface (`search`, plus future `optimize`/`rebuild`) onto a nested `sqlite.fts` namespace whose type-level presence is conditional on whether the caller passed `fts`; lift FTS setup, triggers, and the search action into a private internal FTS layer inside `materializer/sqlite/`.
+
+## Update (post-grilling)
+
+The earlier draft recommended Option C (inline public, split internal) and considered Option B (public `attachFts(sqlite, ...)`) as a rejected alternative. After grilling, the chosen direction is **Option A′** below: same single-attach lifecycle and structural single-attach invariant as Option A, plus the honest namespace Option B offered, without the runtime guard, backfill, or extra barrier B carried. The earlier sections (Option A, Option B, Option C) are kept for context but are no longer the recommendation.
+
+## How to read this spec
+
+```txt
+Read first:
+  One Sentence
+  Current State
+  Mental Model
+  Recommendation
+
+Read if weighing the alternative:
+  Option A / Option B / Option C
+  Type Inference Probe
+  Design Decisions
+
+Read if implementing:
+  Implementation Plan
+  Verification
+```
+
+## Overview
+
+FTS5 setup, triggers, search SQL, and the `search()` action live inline inside `attachSqliteMaterializerCore`. A near-duplicate FTS search implementation lives in `openSqliteReader`. The question: should FTS become its own public `attachFts(sqlite, config)` primitive, or stay inline on the materializer? This spec recommends a third path: keep the inline public API, split the internal layer.
+
+## Current State
+
+### Public API (today on this branch)
+
+```ts
+const tables = attachTables(ydoc, tableDefinitions);
+
+const sqlite = attachBunSqliteMaterializer(ydoc, {
+  filePath: sqlitePath(projectDir, ydoc.guid),
+  tables,
+  fts: { posts: ['title', 'body'] },
+});
+
+const hits = await sqlite.search({ table: 'posts', query: 'hello' });
+```
+
+### Where FTS lives
+
+```txt
+packages/workspace/src/document/materializer/sqlite/
+  core.ts         attachSqliteMaterializerCore, ftsColumns stored per RegisteredTable
+                  initialize() calls setupFtsTable inline
+                  search() method dispatches to ftsSearch
+  fts.ts          setupFtsTable (DDL + 3 triggers), ftsSearch (query + snippet SQL)
+  bun-sqlite.ts   forwards { tables, fts } to core
+  turso.ts        forwards { tables, fts } to core
+  index.ts        re-exports SearchOptions, SearchResult
+
+packages/workspace/src/document/
+  open-sqlite-reader.ts   duplicates the FTS search SQL (no shared helper)
+                          discovers fts columns via PRAGMA table_info instead
+```
+
+### What FTS depends on
+
+| Dependency | Why FTS needs it |
+| --- | --- |
+| `MirrorDatabase` (SQL executor) | DDL for the virtual table, triggers, and search query. |
+| Source table name | Triggers reference `<table>` and write to `<table>_fts`. |
+| Source row column names | Trigger column list and snippet column index. |
+| Registered table row type | Type-level: `FtsConfig<TTables>` narrows column keys per table. |
+| Initial-flush ordering | FTS virtual table + triggers must exist before the full-load INSERT loop so the triggers populate the FTS index automatically. |
+
+FTS does **not** depend on:
+
+- The Y.Doc observer pipeline. The triggers fire on the SQLite side; FTS knows nothing about Yjs.
+- The debounced sync queue. Once the source row lands via UPSERT/DELETE, the trigger updates FTS in the same transaction.
+- The `RegisteredTable.unsubscribe` slot. FTS has no observers of its own.
+
+### Implementation note: trigger-driven population
+
+`initialize()` runs in this order:
+
+```txt
+await waitFor
+
+for each table:
+  db.run(generateDdl)        // CREATE TABLE
+  setupFtsTable(...)          // CREATE VIRTUAL TABLE + 3 triggers
+
+BEGIN
+for each table:
+  fullLoadTable               // INSERT ... ON CONFLICT DO UPDATE
+                              // triggers populate <table>_fts as rows land
+COMMIT
+
+for each table:
+  table.observe(...)          // attach Yjs observer
+```
+
+This ordering is load-bearing for the "set up FTS first, then bulk insert" property. Any split must preserve it or accept a follow-up backfill.
+
+## Mental Model
+
+```txt
+Y.Doc table materialization (mirroring):
+
+  Y.Doc tables (Y.Map of rows)
+    -> observer / debounced flush
+      -> SQLite real tables  ─────── owned by core
+
+
+FTS indexing (derived, secondary):
+
+  SQLite real tables
+    -> AFTER INSERT/UPDATE/DELETE triggers
+      -> SQLite <table>_fts virtual tables
+        -> search() SQL surface  ─── owned by fts.ts (no Yjs awareness)
+```
+
+FTS is a secondary, derived index over the materialized SQLite tables. It is coupled to SQLite (uses FTS5, triggers, the same `MirrorDatabase` handle) but it is **not** coupled to the Yjs-side mirroring. That gap is the boundary the split should follow.
+
+## Option A: Keep FTS Inline (status quo)
+
+```ts
+attachBunSqliteMaterializer(ydoc, {
+  filePath,
+  tables,
+  fts: { posts: ['title', 'body'] },
+});
+```
+
+| Pros | Cons |
+| --- | --- |
+| One call, one barrier (`whenFlushed`), one disposal. | `core.ts` carries FTS branches inside `initialize`, `search`, the `RegisteredTable` struct. |
+| FTS table created **before** full-load: triggers populate it for free, no backfill pass. | `open-sqlite-reader.ts` duplicates the FTS search SQL because no shared helper exists. |
+| `FtsConfig<TTables>` narrows from the same `tables` generic; no extra factory plumbing. | `search()` accepts any string; no compile-time narrowing to FTS-enabled tables. |
+| Matches the existing markdown shape (`perTable`). | Adding FTS-specific surface (`rebuild()`, tokenizer config) means widening core options. |
+
+## Option B: Split FTS Into `attachFts`
+
+```ts
+const sqlite = attachBunSqliteMaterializer(ydoc, { filePath, tables });
+
+const fts = attachFts(sqlite, {
+  posts: ['title', 'body'],
+});
+
+const hits = await fts.search('posts', 'query');
+```
+
+| Pros | Cons |
+| --- | --- |
+| FTS becomes a self-contained primitive: own setup, own search, own potential `rebuild()` / `optimize()` / tokenizer config. | Two call sites, two barriers. Caller must `await sqlite.whenFlushed` then run a backfill pass through FTS because triggers were not present during the initial bulk insert. |
+| `search()` can narrow `table` to `keyof TFts` for autocomplete and typo errors. | Adds a public surface that ~5 call sites currently set with one line. Net surface grows. |
+| Naturally extends to "multiple search indexes" (different column sets, different tokenizers) by attaching twice. | `attachFts` needs to read `TTables` off the materializer return type so columns narrow per row. Requires propagating the `TTables` generic through `attachBunSqliteMaterializer<TTables>` / `attachTursoMaterializer<TTables>` results, which the current code does not preserve. |
+| Models FTS-on-Turso symmetrically with FTS-on-bun-sqlite. | Backfill on attach (run `INSERT INTO <fts>(rowid, ...) SELECT rowid, ... FROM <table>`) is the right way to handle "FTS attached late", but that is new code, new failure modes, and new tests. |
+| | Lifecycle: the materializer can flush again after FTS attaches; FTS triggers handle it. But the initial backfill window is racy if the caller writes rows between `whenFlushed` and `attachFts(...)`. Easiest fix is to attach FTS synchronously after the materializer, before any external writes, which is exactly the inline contract by another name. |
+
+## Option C: Inline Public API, Split Internal Layer (recommended)
+
+The public API stays as today. Inside the package, FTS becomes its own attach primitive that lives next to the materializer core but is composed by it.
+
+```ts
+// Public (unchanged)
+const sqlite = attachBunSqliteMaterializer(ydoc, {
+  filePath,
+  tables,
+  fts: { posts: ['title', 'body'] },
+});
+await sqlite.whenFlushed;
+await sqlite.search({ table: 'posts', query: 'hello' });
+```
+
+Internal composition:
+
+```ts
+// packages/workspace/src/document/materializer/sqlite/core.ts
+export function attachSqliteMaterializerCore<TTables extends TablesRecord>(
+  ydoc: Y.Doc,
+  { db, tables, fts, debounceMs, waitFor, log }: ...,
+) {
+  // core no longer holds ftsColumns or knows what FTS is
+  const registered = new Map<string, { table: AnyTable; unsubscribe?: () => void }>();
+  // ... full-load + observe loop, with one explicit hook ...
+
+  // The core exposes a structural "after DDL, before bulk insert" hook so the
+  // FTS layer can plant its virtual table and triggers in the right slot.
+  // The hook is module-private; nothing leaks externally.
+  const ftsLayer = fts
+    ? attachSqliteFts({ db, tables, fts, log })
+    : undefined;
+
+  // initialize:
+  //   await waitFor
+  //   for each table: db.run(ddl)
+  //   ftsLayer?.beforeFullLoad()   // CREATE VIRTUAL TABLE + triggers
+  //   BEGIN ... fullLoadTable ... COMMIT
+  //   attach observers
+
+  return {
+    whenFlushed,
+    search: ftsLayer?.search ?? noopSearch,
+    count: ...,
+    rebuild: ...,
+  };
+}
+```
+
+```ts
+// packages/workspace/src/document/materializer/sqlite/fts.ts
+export function attachSqliteFts<TTables extends TablesRecord>({
+  db,
+  tables,
+  fts,
+  log,
+}: {
+  db: MirrorDatabase;
+  tables: TTables;
+  fts: FtsConfig<TTables>;
+  log: Logger;
+}) {
+  const ftsColumns = new Map<string, string[]>();
+  for (const [name, cols] of Object.entries(fts)) {
+    if (cols && cols.length > 0) ftsColumns.set(name, cols as string[]);
+  }
+
+  async function beforeFullLoad() {
+    for (const [name, cols] of ftsColumns) await setupFtsTable(db, name, cols);
+  }
+
+  const search = defineQuery({
+    title: 'Full-text search',
+    input: Type.Object({ table: Type.String(), query: Type.String(), limit: Type.Optional(Type.Number()) }),
+    handler: ({ table, query, limit }) => {
+      const cols = ftsColumns.get(table);
+      if (!cols) return Promise.resolve([]);
+      return ftsSearch(db, table, cols, query, limit !== undefined ? { limit } : undefined, log);
+    },
+  });
+
+  return { beforeFullLoad, search };
+}
+```
+
+What this buys:
+
+| Win | How |
+| --- | --- |
+| Core stays focused on Y.Doc -> SQLite mirroring. | FTS columns, `setupFtsTable` calls, search SQL, and the FTS error type leave `core.ts`. |
+| Public API unchanged. | `fts: {...}` still narrows from `tables`, still feeds the same path. |
+| `openSqliteReader` can reuse the search query builder. | Extract `buildFtsSearchSql(table, cols, snippetColumn)` from `ftsSearch` and share it between `attachSqliteFts` (writer side) and `openSqliteReader` (reader side). The reader still discovers `cols` via PRAGMA. |
+| Forward-compatible with later public split. | If someone wants `rebuild()` / `optimize()` / tokenizer config later, the internal boundary is already there. Promoting `attachSqliteFts` to public is a rename and one option-bag forwarding edit. |
+| No new lifecycle barriers. | `beforeFullLoad()` runs inside `initialize()` at the existing DDL slot. No `whenFtsReady` promise. |
+
+Trade-offs:
+
+| Cost | Note |
+| --- | --- |
+| One more internal file edge (`core` calls into `fts` at a named slot). | Worth it: that slot is already where the inline `setupFtsTable` call lives. |
+| `search` becomes a no-op when `fts` is undefined. | Already true today (`if (ftsColumns === undefined) return []`). Move the conditional from inside the handler to the assembly site. |
+| No public type narrowing on `search({ table })`. | Same as today. The action handlers are TypeBox-validated at runtime; tightening the input shape is orthogonal to this split. |
+
+## Type Inference Probe
+
+The proposed inline `FtsConfig<TTables>` shape is already on this branch and verified in `specs/20260525T134351-materializer-tables-as-record.md` (see the table at line 142-151). For the split (Option B) the relevant question is whether `attachFts(sqlite, ...)` can preserve the same narrowing.
+
+Sketch (not committed):
+
+```ts
+type MaterializerWithTables<TTables extends TablesRecord> = {
+  __tables: TTables;                       // phantom or actual field
+  db: MirrorDatabase;
+  whenFlushed: Promise<void>;
+  // ...
+};
+
+function attachFts<TTables extends TablesRecord>(
+  sqlite: MaterializerWithTables<TTables>,
+  config: FtsConfig<TTables>,
+): { search: <K extends keyof FtsConfig<TTables>>(table: K, query: string) => Promise<SearchResult[]> };
+```
+
+| Probe | Result expected |
+| --- | --- |
+| `attachFts(sqlite, { posts: ['title'] })` with valid keys | compiles |
+| `attachFts(sqlite, { typo: [...] })` | key error |
+| `attachFts(sqlite, { posts: ['badColumn'] })` | value error |
+| `fts.search('posts', 'q')` | compiles |
+| `fts.search('notes', 'q')` when notes not in FTS config | possible to narrow with a second generic `TFts`, but only if `attachFts` returns the literal config keys, not `keyof TTables` |
+
+The narrowing `search` to FTS-enabled tables only is the one type-level win Option B can claim that Option C cannot. It costs:
+
+- A new generic threaded through `attachBunSqliteMaterializer<TTables>` -> result -> `attachFts<TTables, TFts>` -> result.
+- A phantom `__tables` field or equivalent on the materializer return, so `attachFts` can read `TTables` off it.
+
+This is implementable. It is not free.
+
+For Option C, no probe is needed: the public types are unchanged from the current branch.
+
+## Design Decisions
+
+| Decision | Class | Choice | Rationale |
+| --- | --- | --- | --- |
+| Public API shape | 2 coherence | Keep `fts` inline on the materializer options. | Matches the markdown materializer's `perTable` shape. The 80% case (`fts: { posts: ['title'] }`) stays one line. |
+| Internal boundary | 1 evidence | Extract `attachSqliteFts(core-like deps)` inside `materializer/sqlite/`. | `setupFtsTable`, `ftsSearch`, and `FtsError` already live in `fts.ts`. The remaining state (FTS columns map, search action) is small and self-contained. |
+| Search return surface | 3 taste | Keep `defineQuery` action with `table: string` input. | Tightening to `keyof TFts` requires the Option B generic-threading; not justified for current call sites (one repo-wide `materializer.search(...)` site in `apps/opensidian`). |
+| Migration path | 2 coherence | Internal-only change. No public migration. | Zero call-site churn. Future promotion to public `attachFts` stays open. |
+| Trigger-driven population | 1 evidence | Preserve "FTS DDL before full-load" ordering. | Verified in `core.ts:329-361`. Splitting this order would force a backfill `INSERT INTO <fts> SELECT ...` pass, which is more code and more failure modes. |
+| Code sharing with reader | 1 evidence | Extract `buildFtsSearchSql` helper shared with `openSqliteReader`. | The two SQL strings in `fts.ts:181-191` and `open-sqlite-reader.ts:131-142` are identical modulo formatting. |
+
+## Option A′: Single Attach, Nested `sqlite.fts` Namespace (recommended)
+
+```ts
+const sqlite = attachBunSqliteMaterializer(ydoc, {
+  filePath,
+  tables,
+  fts: { posts: ['title', 'body'] },
+});
+
+await sqlite.whenFlushed;
+sqlite.fts.search({ table: 'posts', query: 'hello' });
+```
+
+When the caller omits `fts`, `sqlite.fts` is absent from the return type. The conditional return type does the narrowing:
+
+```ts
+type Result<TTables, TFts> =
+  & { whenFlushed: Promise<void>; client: Database; count: ...; rebuild: ... }
+  & (TFts extends FtsConfig<TTables> ? { fts: FtsSurface<TTables, TFts> } : {});
+```
+
+What A′ gives us:
+
+| Win | How |
+| --- | --- |
+| Single attach, structural single-attach invariant. | Can't call twice; only one `fts` slot per call. |
+| One barrier (`whenFlushed`), one DDL ordering window. | Triggers populate `_fts` during the existing full-load; no backfill SQL. |
+| Honest namespace. | `sqlite.search` no longer exists. FTS methods live on `sqlite.fts`. |
+| Type-level honesty. | `sqlite.fts` is absent in the type when no FTS was configured. |
+| Core stays focused on Y.Doc → SQLite mirroring. | `RegisteredTable.ftsColumns` leaves the struct; `setupFtsTable` / `ftsSearch` are reached through an internal `createSqliteFtsLayer({ db, fts, log })` factory. |
+| Future FTS features land cleanly. | `sqlite.fts.optimize()` / `sqlite.fts.rebuild()` / tokenizer config grow on the FTS layer, not the materializer's top level. |
+
+What A′ rejects from Option B (public split):
+
+- No second `attachFts(sqlite, ...)` export.
+- No `whenIndexed` barrier (single `whenFlushed`).
+- No backfill SQL (triggers already populate `_fts` during full-load).
+- No race window between materializer flush and FTS attach.
+- No WeakSet guard for double-attach.
+
+The only case Option B would still win is **multiple named FTS indexes per source table** (e.g., `posts_fts_title` and `posts_fts_full` on the same `posts`). Out of scope for V1; revisit when a concrete need appears.
+
+## Recommendation
+
+**Option A′: keep the single attach with the keyed `fts` slot; move the FTS surface onto a nested, conditionally-present `sqlite.fts` namespace; lift FTS internals into `createSqliteFtsLayer` inside `fts.ts`.**
+
+Argument for: structural single-attach invariant, single DDL/full-load window, honest namespace, type-level presence, no migration churn for non-FTS callers, no backfill or extra barrier. The boundary between Y.Doc→SQLite and SQLite→FTS5 is enforced internally; the public surface is one option key (unchanged from the parent spec) and one namespace (`sqlite.fts.search`).
+
+Argument against: requires a conditional return type (`TFts extends FtsConfig<TTables> ? {...} : {}`), which is one more piece of type-level cleverness in the materializer signature. Mitigation: well-localised inside the two backend factories; nothing outside `materializer/sqlite/` needs to read it.
+
+## Implementation Plan (A′)
+
+### Phase 1: Internal extraction and namespace move
+
+- [ ] **1.1** `core.ts`: drop `ftsColumns` from `RegisteredTable`. Struct collapses to `{ table, unsubscribe? }`.
+- [ ] **1.2** `fts.ts`: add `createSqliteFtsLayer({ db, fts, log })` that owns the FTS column map, the `beforeFullLoad()` DDL/trigger pass, and the `search` action. `@internal`.
+- [ ] **1.3** `core.ts`: build the FTS layer iff `fts` is defined. Call `ftsLayer?.beforeFullLoad()` between table DDL and `BEGIN`. Return `{ whenFlushed, count, rebuild, ...(ftsLayer ? { fts: { search: ftsLayer.search } } : {}) }`.
+- [ ] **1.4** `core.ts`: thread `TFts` generic with default `undefined`. The signature reads `<TTables, TFts extends FtsConfig<TTables> | undefined = undefined>` so the return narrows.
+- [ ] **1.5** `bun-sqlite.ts` / `turso.ts`: propagate `TFts` generic, return `{ ...core, client }` (Bun) / `{ ...core, whenConnected, client }` (Turso). `fts` namespace flows through `...core`.
+
+### Phase 2: Test and call-site updates
+
+- [ ] **2.1** `core.test.ts`: change every `sqlite.search({...})` to `sqlite.fts.search({...})`. The "no fts configured" test asserts `sqlite.fts` is `undefined` instead of `sqlite.search` returning `[]`.
+- [ ] **2.2** `core.test.ts` action-brand block: assert `isAction(sqlite.fts.search)` (only when FTS configured).
+- [ ] **2.3** `playground/opensidian-e2e/workspaces/opensidian/daemon.ts`: no change to the call site itself (it doesn't call `.search`), but the return type narrows.
+
+### Phase 3: Verification
+
+- [ ] **3.1** `cd packages/workspace && bun run typecheck`
+- [ ] **3.2** `cd packages/workspace && bun test`
+- [ ] **3.3** `rg "ftsColumns" packages/workspace/src/document/materializer/sqlite/core.ts` → zero hits.
+- [ ] **3.4** `rg "setupFtsTable|ftsSearch" packages/workspace/src/document/materializer/sqlite/core.ts` → zero hits.
+
+### Phase 4: Doc sweep
+
+- [ ] **4.1** `packages/workspace/README.md` SQLite example: align with `attachBunSqliteMaterializer({ filePath, tables, fts })` and `sqlite.fts.search({...})`. (Existing example was already stale on the parent refactor; fixing in this pass.)
+- [ ] **4.2** `.agents/skills/attach-primitive/SKILL.md`: keep the `fts: {...}` option example unchanged; add one line near the materializer example noting the result surface (`sqlite.fts.search(...)`).
+- [ ] **4.3** `createSqliteFtsLayer` carries an `@internal` JSDoc tag.
+
+### Phase 5 (deferred): reader dedup
+
+The `openSqliteReader` ↔ materializer search-SQL duplication is real but orthogonal to A′. Bundle later when a third caller appears or when tokenizer config forces a shared `buildFtsSearchSql({ table, ftsColumns, snippetColumn })`.
+
+## Rejected Alternatives
+
+| Candidate | Why rejected |
+| --- | --- |
+| Public `attachFts(sqlite, config)` (Option B) | Forces a backfill pass or a fragile "attach FTS before any writes" contract. Threads a new `TTables` generic through the materializer return type just to recover the narrowing the inline form gets for free. The public surface grows for marginal type-level gain. |
+| Chained `.withFts({ posts: ['title'] })` | Re-introduces per-backend factory rebinding (the same problem the recent `tables`-as-record refactor removed; see `specs/20260525T134351-materializer-tables-as-record.md`). No inference benefit over the keyed object. |
+| Per-table tuple config (`tables: [[ref, { fts: [...] }]]`) | Attempted and reverted on this branch (commit `0b90d7158` -> `f4a79a28e`). Variadic mapped-type inference is brittle and the double-bracket call shape regresses the single-table case. |
+| Caller manages the virtual table directly | Pushes SQLite FTS5 DDL and trigger management into every app. Defeats the point of the materializer primitive. |
+| Promote `attachSqliteFts` straight to public now | Possible later. Doing it now would change the public API on a branch whose stated direction (the inline `fts` slot) just landed. |
+
+## Verification
+
+```bash
+cd packages/workspace && bun run typecheck
+cd packages/workspace && bun test
+
+# Confirm core no longer mentions FTS internals
+rg "ftsColumns|setupFtsTable|ftsSearch" packages/workspace/src/document/materializer/sqlite/core.ts
+
+# Confirm the shared SQL builder is wired into both sides
+rg "buildFtsSearchSql" packages/workspace/src/document/
+
+# Repo-wide sanity check: public surface untouched
+rg "fts:\s*\{" apps/ examples/ playground/
+```
+
+## Open Questions
+
+1. **Is the reader-dedup phase worth bundling with the materializer split?**
+   - Options: (a) bundle, (b) split into a follow-up.
+   - **Recommendation**: bundle. The duplication is the single strongest evidence that an internal FTS module earns its keep.
+
+2. **Should the `search` action remain a `defineQuery` no-op when `fts` is undefined, or should the property be absent from the return type?**
+   - Options: (a) always present, no-op when unconfigured (today's behavior), (b) `search` is conditionally typed and absent when `fts` is omitted.
+   - **Recommendation**: keep (a). Conditional return types complicate the consumer (`materializer.search?.(...)` everywhere). The no-op path is one line.


### PR DESCRIPTION
The SQLite materializer has carried a `search` action on its top-level surface since FTS landed, and that action returns `[]` whenever no `fts` option was configured. That's a phantom method: a callable shape on every materializer that does nothing for ~95% of call sites. Today it gets a proper home: `sqlite.fts.search({ table, query })` exists exactly when you passed `fts: {...}` and is absent from the return type otherwise.

Same single attach call, same single `whenFlushed` barrier, same DDL ordering window. The change is where the result surface lives, not how it composes.

```ts
// Before — search always on the top level, returns [] when fts wasn't configured:
const sqlite = attachBunSqliteMaterializer(ydoc, { filePath, tables, fts: { posts: ['title', 'body'] } });
await sqlite.whenFlushed;
await sqlite.search({ table: 'posts', query: 'hello' });

// After — search lives on a nested namespace, present iff you opted in to FTS:
const sqlite = attachBunSqliteMaterializer(ydoc, { filePath, tables, fts: { posts: ['title', 'body'] } });
await sqlite.whenFlushed;
await sqlite.fts.search({ table: 'posts', query: 'hello' });

// And without fts, sqlite.fts is gone at the type level:
const sqlite2 = attachBunSqliteMaterializer(ydoc, { filePath, tables });
sqlite2.fts;  // ← Property 'fts' does not exist
```

The mechanism is a conditional return type on the materializer factories. The new `TFts` generic defaults to `undefined`; the return narrows accordingly:

```ts
type SqliteMaterializerFts<TFts> = [TFts] extends [undefined]
  ? {}
  : { fts: { search: ReturnType<typeof defineQuery> } };

type SqliteMaterializerCoreResult<TFts> = SqliteMaterializerCommon & SqliteMaterializerFts<TFts>;
```

The runtime branch and the type branch line up: when `fts === undefined`, `ftsLayer` is `undefined` and the returned object has no `fts` key; when `fts` is an object, the layer is constructed and `fts: { search }` is spread onto the result. Two local `as SqliteMaterializerCoreResult<TFts>` casts at the construction site; nothing leaks outside the file.

While moving the public surface, the FTS internals also leave `core.ts` entirely. The materializer body no longer knows that FTS exists.

```txt
Before:
  attachSqliteMaterializerCore
    RegisteredTable { table, ftsColumns?, unsubscribe? }      ← FTS state in the per-table struct
    initialize:
      for each table: DDL
        if ftsColumns: setupFtsTable                          ← inline FTS DDL
      BEGIN; full-load; COMMIT
    return { whenFlushed, search, count, rebuild }            ← search always on top level

After:
  attachSqliteMaterializerCore
    RegisteredTable { table, unsubscribe? }                   ← FTS gone from the per-table struct
    ftsLayer = fts ? createSqliteFtsLayer({ db, fts, log }) : undefined
    initialize:
      for each table: DDL
      await ftsLayer?.beforeFullLoad()                        ← single hook, FTS layer owns DDL
      BEGIN; full-load; COMMIT
    return { whenFlushed, count, rebuild, ...(ftsLayer && { fts: { search: ftsLayer.search } }) }

  fts.ts
    setupFtsTable      (now module-private)
    ftsSearch          (now module-private)
    createSqliteFtsLayer
      owns the FTS column map
      owns beforeFullLoad() — runs after table DDL, before BEGIN
      owns the search action (defineQuery)
```

The load-bearing invariant — FTS DDL between table DDL and the bulk insert so the AFTER INSERT triggers populate `<table>_fts` during the existing full-load — is preserved by where `await ftsLayer?.beforeFullLoad()` sits in `initialize()`. No backfill SQL, no extra barrier, no race window.

### Why nested namespace, not a separate `attachFts(sqlite, ...)` primitive?

Public split was the obvious shape. A short grilling session showed it pays real lifecycle costs for marginal type-level gain. Two barriers (`whenFlushed` + `whenIndexed`) instead of one. Backfill SQL because triggers wouldn't be present during the first full-load. A WeakSet guard to refuse double-attach since nothing structural prevents it. The only win that survived was multiple named FTS indexes per source table, and no caller wants that today. So this PR refuses the split and gets the namespace win another way: a nested result surface under the existing single attach.

The full reasoning, including the rejected Options A / B / C from the earlier draft, sits in `specs/20260525T212249-sqlite-fts-primitive-split.md`.

### What this branch carries

This is stacked on the recent materializer surface work that this branch already collapsed into:

```
0b90d7158  drop .table() chain; tables move into options bag    ← attempted
f4a79a28e  revert of the above                                   ← reverted
6cf4eacf1  materializer tables as record, fts/perTable keyed     ← landed
7ac61e4a3  post-implementation collapse of materializer surface  ← landed
8f3b7e8b5  nest FTS surface under materializer.fts namespace     ← this PR
```

The two revert commits net to zero. The forward work is the `tables`-as-record refactor (one option key for the table set, sibling option slots for `fts`/`perTable`) followed by today's namespace nest. Both are breaking but only one call site in the repo (`playground/opensidian-e2e/workspaces/opensidian/daemon.ts:156`) actually configures `fts:` against the materializer; the `apps/opensidian` `sqliteIndex.search(...)` calls are a separate `@epicenter/filesystem` extension and untouched.

`bun run typecheck` clean across all 25 packages. `bun test` clean across the workspace package's 487 tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782339266&installation_id=128463665&pr_number=1815&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1815&signature=1df2576af7aaf47a27da2d96512935f0b9426e00b6faa3c9087f1e4c0a0ae66a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->