### PR TITLE
feat(whispering): close the recorder state-sync loop

### DIFF
--- a/.agents/skills/attach-primitive/SKILL.md
+++ b/.agents/skills/attach-primitive/SKILL.md
@@ -11,10 +11,19 @@ Every persistence, sync, materializer, and binding in `packages/workspace` (plus
 
 | Prefix     | Meaning                                                                                                                      |
 | ---------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `attach*`  | Side-effectful. Registers observers, destroy listeners, or subscription state. Returns a plain object whose surface is fixed at call time. |
-| `create*`  | Pure construction. No listeners, no subscriptions, no destroy registration at call time. Cache constructors qualify, e.g. `createFileContentDocs` returns a `createDisposableCache` result; nothing attaches until `.open(id)` is called. |
+| `attach*`  | Side-effectful. Registers observers, destroy listeners, or subscription state **onto a subject argument**. Returns a plain object whose surface is fixed at call time. |
+| `create*`  | Pure construction OR module-singleton bootstrap. No subject argument. Cache constructors qualify (e.g. `createFileContentDocs` returns a `createDisposableCache` result; nothing attaches until `.open(id)` is called). Module-singleton factories that bootstrap themselves at construction time (e.g. `createManualRecorder` registering a global event listener) also use `create*`: the side effects belong to the singleton itself, not to an external subject. |
 
-Both return plain objects. The distinction is **what happens at call time**, not what the return value looks like.
+Both return plain objects. The distinction is **whether the call modifies a subject argument**, not just whether side effects fire at call time.
+
+### Scope of this contract
+
+These rules apply to `packages/workspace` primitives and other functions that take a *subject* (a Y.Doc, an attachment, or a comparable composable target) and decorate it. They do **not** apply to:
+
+- Module-level factory singletons in app code (e.g. UI state containers, service clients) — even if those factories perform I/O at construction time. Use `create*`.
+- Top-level orchestrators that own their own lifecycle and aren't attached to anything external.
+
+The discriminator is **"what is being attached to what?"** If there's no `subject` on the left side of that question, it's `create*`.
 
 ## The shape
 
@@ -167,7 +176,7 @@ Use it whenever a primitive's startup must follow another's. Examples:
 - **Don't expose `dispose()` on a ydoc-bound attachment.** Destroy the Y.Doc.
 - **Don't duck-type an attachment.** If you need to brand it, use a `Symbol.for` marker. See `skills/typescript`: runtime shape-checking is a code smell.
 - **Don't take an `id` on a ydoc-bound primitive.** Use `ydoc.guid`.
-- **Don't use `createX` for a side-effectful primitive.** If it registers listeners, it's `attach*`.
+- **Don't use `createX` for a side-effectful primitive that takes a subject argument.** If it registers listeners on a subject passed in, it's `attach*`. (Module-singleton factories that bootstrap themselves are still `create*` ; see scope section.)
 - **Don't introduce a separate top-level encrypted-X helper.** When a primitive must derive keys and construct sibling handles atomically, pass the definition records as named slots on a single call (`attachEncryption(ydoc, { keyring, tables, kv })`) and return the constructed handles destructurable at the call site.
 
 ## Reference implementations

--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 use log::{info, warn};
+use std::sync::Mutex;
 use tauri::Manager;
 use tauri_plugin_aptabase::EventTracker;
 use tauri_plugin_log::{Target, TargetKind};
@@ -6,8 +7,9 @@ use tauri_plugin_log::{Target, TargetKind};
 pub mod recorder;
 use recorder::commands::{
     cancel_recording, close_recording_session, enumerate_recording_devices,
-    get_current_recording_id, init_recording_session, start_recording, stop_recording, AppData,
+    get_current_recording_id, init_recording_session, start_recording, stop_recording,
 };
+use recorder::recorder::Recorder;
 
 pub mod transcription;
 use transcription::{
@@ -130,7 +132,7 @@ pub async fn run() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_opener::init())
-        .manage(AppData::new())
+        .manage(Mutex::new(Recorder::new()))
         .manage(ModelManager::new());
 
     #[cfg(desktop)]

--- a/apps/whispering/src-tauri/src/recorder/commands.rs
+++ b/apps/whispering/src-tauri/src/recorder/commands.rs
@@ -1,8 +1,27 @@
 use crate::recorder::recorder::{AudioRecording, RecorderState, Result};
+use serde::Serialize;
 use std::path::PathBuf;
 use std::sync::Mutex;
-use tauri::State;
-use log::{debug, info};
+use tauri::{AppHandle, Emitter, State};
+use log::{debug, info, warn};
+
+const RECORDER_STATE_CHANGED: &str = "recorder:state-changed";
+
+#[derive(Serialize, Clone, Copy, Debug)]
+#[serde(rename_all = "UPPERCASE")]
+enum RecorderStateEvent {
+    Idle,
+    Recording,
+}
+
+fn emit_recorder_state(app: &AppHandle, state: RecorderStateEvent) {
+    if let Err(e) = app.emit(RECORDER_STATE_CHANGED, state) {
+        warn!(
+            "Failed to emit {} = {:?}: {}",
+            RECORDER_STATE_CHANGED, state, e
+        );
+    }
+}
 
 /// Application state containing the recorder
 pub struct AppData {
@@ -34,23 +53,20 @@ pub async fn init_recording_session(
     output_folder: String,
     sample_rate: Option<u32>,
     state: State<'_, AppData>,
-    _app_handle: tauri::AppHandle,
+    app_handle: AppHandle,
 ) -> Result<()> {
     info!(
         "Initializing recording session: device={}, id={}, folder={}, sample_rate={:?}",
         device_identifier, recording_id, output_folder, sample_rate
     );
 
-    // Use the provided output folder
     let recordings_dir = PathBuf::from(output_folder);
 
-    // Create the directory if it doesn't exist
     if !recordings_dir.exists() {
         std::fs::create_dir_all(&recordings_dir)
             .map_err(|e| format!("Failed to create output folder: {}", e))?;
     }
 
-    // Validate it's a directory (not a file)
     if !recordings_dir.is_dir() {
         return Err(format!(
             "Output path is not a directory: {:?}",
@@ -58,52 +74,86 @@ pub async fn init_recording_session(
         ));
     }
 
-    // Initialize the session with optional sample rate
-    let mut recorder = state
-        .recorder
-        .lock()
-        .map_err(|e| format!("Failed to lock recorder: {}", e))?;
-    recorder.init_session(device_identifier, recordings_dir, recording_id, sample_rate)
+    {
+        let mut recorder = state
+            .recorder
+            .lock()
+            .map_err(|e| format!("Failed to lock recorder: {}", e))?;
+        recorder.init_session(device_identifier, recordings_dir, recording_id, sample_rate)?;
+    }
+    // init_session calls close_session internally as cleanup. If the previous
+    // session was actively recording, that transition is silent at the domain
+    // layer; emit IDLE here so the JS state never diverges from reality.
+    emit_recorder_state(&app_handle, RecorderStateEvent::Idle);
+    Ok(())
 }
 
 #[tauri::command]
-pub async fn start_recording(state: State<'_, AppData>) -> Result<()> {
+pub async fn start_recording(
+    state: State<'_, AppData>,
+    app_handle: AppHandle,
+) -> Result<()> {
     info!("Starting recording");
-    let mut recorder = state
-        .recorder
-        .lock()
-        .map_err(|e| format!("Failed to lock recorder: {}", e))?;
-    recorder.start_recording()
+    {
+        let mut recorder = state
+            .recorder
+            .lock()
+            .map_err(|e| format!("Failed to lock recorder: {}", e))?;
+        recorder.start_recording()?;
+    }
+    emit_recorder_state(&app_handle, RecorderStateEvent::Recording);
+    Ok(())
 }
 
 #[tauri::command]
-pub async fn stop_recording(state: State<'_, AppData>) -> Result<AudioRecording> {
+pub async fn stop_recording(
+    state: State<'_, AppData>,
+    app_handle: AppHandle,
+) -> Result<AudioRecording> {
     info!("Stopping recording");
-    let mut recorder = state
-        .recorder
-        .lock()
-        .map_err(|e| format!("Failed to lock recorder: {}", e))?;
-    recorder.stop_recording()
+    let recording = {
+        let mut recorder = state
+            .recorder
+            .lock()
+            .map_err(|e| format!("Failed to lock recorder: {}", e))?;
+        recorder.stop_recording()?
+    };
+    emit_recorder_state(&app_handle, RecorderStateEvent::Idle);
+    Ok(recording)
 }
 
 #[tauri::command]
-pub async fn cancel_recording(state: State<'_, AppData>) -> Result<()> {
+pub async fn cancel_recording(
+    state: State<'_, AppData>,
+    app_handle: AppHandle,
+) -> Result<()> {
     info!("Cancelling recording");
-    let mut recorder = state
-        .recorder
-        .lock()
-        .map_err(|e| format!("Failed to lock recorder: {}", e))?;
-    recorder.cancel_recording()
+    {
+        let mut recorder = state
+            .recorder
+            .lock()
+            .map_err(|e| format!("Failed to lock recorder: {}", e))?;
+        recorder.cancel_recording()?;
+    }
+    emit_recorder_state(&app_handle, RecorderStateEvent::Idle);
+    Ok(())
 }
 
 #[tauri::command]
-pub async fn close_recording_session(state: State<'_, AppData>) -> Result<()> {
+pub async fn close_recording_session(
+    state: State<'_, AppData>,
+    app_handle: AppHandle,
+) -> Result<()> {
     info!("Closing recording session");
-    let mut recorder = state
-        .recorder
-        .lock()
-        .map_err(|e| format!("Failed to lock recorder: {}", e))?;
-    recorder.close_session()
+    {
+        let mut recorder = state
+            .recorder
+            .lock()
+            .map_err(|e| format!("Failed to lock recorder: {}", e))?;
+        recorder.close_session()?;
+    }
+    emit_recorder_state(&app_handle, RecorderStateEvent::Idle);
+    Ok(())
 }
 
 #[tauri::command]

--- a/apps/whispering/src-tauri/src/recorder/commands.rs
+++ b/apps/whispering/src-tauri/src/recorder/commands.rs
@@ -1,4 +1,4 @@
-use crate::recorder::recorder::{AudioRecording, RecorderState, Result};
+use crate::recorder::recorder::{AudioRecording, Recorder, Result};
 use serde::Serialize;
 use std::path::PathBuf;
 use std::sync::Mutex;
@@ -9,12 +9,12 @@ const RECORDER_STATE_CHANGED: &str = "recorder:state-changed";
 
 #[derive(Serialize, Clone, Copy, Debug)]
 #[serde(rename_all = "UPPERCASE")]
-enum RecorderStateEvent {
+enum RecordingState {
     Idle,
     Recording,
 }
 
-fn emit_recorder_state(app: &AppHandle, state: RecorderStateEvent) {
+fn emit_recording_state(app: &AppHandle, state: RecordingState) {
     if let Err(e) = app.emit(RECORDER_STATE_CHANGED, state) {
         warn!(
             "Failed to emit {} = {:?}: {}",
@@ -23,24 +23,12 @@ fn emit_recorder_state(app: &AppHandle, state: RecorderStateEvent) {
     }
 }
 
-/// Application state containing the recorder
-pub struct AppData {
-    pub recorder: Mutex<RecorderState>,
-}
-
-impl AppData {
-    pub fn new() -> Self {
-        Self {
-            recorder: Mutex::new(RecorderState::new()),
-        }
-    }
-}
-
 #[tauri::command]
-pub async fn enumerate_recording_devices(state: State<'_, AppData>) -> Result<Vec<String>> {
+pub async fn enumerate_recording_devices(
+    recorder: State<'_, Mutex<Recorder>>,
+) -> Result<Vec<String>> {
     debug!("Enumerating recording devices");
-    let recorder = state
-        .recorder
+    let recorder = recorder
         .lock()
         .map_err(|e| format!("Failed to lock recorder: {}", e))?;
     recorder.enumerate_devices()
@@ -52,7 +40,7 @@ pub async fn init_recording_session(
     recording_id: String,
     output_folder: String,
     sample_rate: Option<u32>,
-    state: State<'_, AppData>,
+    recorder: State<'_, Mutex<Recorder>>,
     app_handle: AppHandle,
 ) -> Result<()> {
     info!(
@@ -75,8 +63,7 @@ pub async fn init_recording_session(
     }
 
     {
-        let mut recorder = state
-            .recorder
+        let mut recorder = recorder
             .lock()
             .map_err(|e| format!("Failed to lock recorder: {}", e))?;
         recorder.init_session(device_identifier, recordings_dir, recording_id, sample_rate)?;
@@ -84,83 +71,80 @@ pub async fn init_recording_session(
     // init_session calls close_session internally as cleanup. If the previous
     // session was actively recording, that transition is silent at the domain
     // layer; emit IDLE here so the JS state never diverges from reality.
-    emit_recorder_state(&app_handle, RecorderStateEvent::Idle);
+    emit_recording_state(&app_handle, RecordingState::Idle);
     Ok(())
 }
 
 #[tauri::command]
 pub async fn start_recording(
-    state: State<'_, AppData>,
+    recorder: State<'_, Mutex<Recorder>>,
     app_handle: AppHandle,
 ) -> Result<()> {
     info!("Starting recording");
     {
-        let mut recorder = state
-            .recorder
+        let mut recorder = recorder
             .lock()
             .map_err(|e| format!("Failed to lock recorder: {}", e))?;
         recorder.start_recording()?;
     }
-    emit_recorder_state(&app_handle, RecorderStateEvent::Recording);
+    emit_recording_state(&app_handle, RecordingState::Recording);
     Ok(())
 }
 
 #[tauri::command]
 pub async fn stop_recording(
-    state: State<'_, AppData>,
+    recorder: State<'_, Mutex<Recorder>>,
     app_handle: AppHandle,
 ) -> Result<AudioRecording> {
     info!("Stopping recording");
     let recording = {
-        let mut recorder = state
-            .recorder
+        let mut recorder = recorder
             .lock()
             .map_err(|e| format!("Failed to lock recorder: {}", e))?;
         recorder.stop_recording()?
     };
-    emit_recorder_state(&app_handle, RecorderStateEvent::Idle);
+    emit_recording_state(&app_handle, RecordingState::Idle);
     Ok(recording)
 }
 
 #[tauri::command]
 pub async fn cancel_recording(
-    state: State<'_, AppData>,
+    recorder: State<'_, Mutex<Recorder>>,
     app_handle: AppHandle,
 ) -> Result<()> {
     info!("Cancelling recording");
     {
-        let mut recorder = state
-            .recorder
+        let mut recorder = recorder
             .lock()
             .map_err(|e| format!("Failed to lock recorder: {}", e))?;
         recorder.cancel_recording()?;
     }
-    emit_recorder_state(&app_handle, RecorderStateEvent::Idle);
+    emit_recording_state(&app_handle, RecordingState::Idle);
     Ok(())
 }
 
 #[tauri::command]
 pub async fn close_recording_session(
-    state: State<'_, AppData>,
+    recorder: State<'_, Mutex<Recorder>>,
     app_handle: AppHandle,
 ) -> Result<()> {
     info!("Closing recording session");
     {
-        let mut recorder = state
-            .recorder
+        let mut recorder = recorder
             .lock()
             .map_err(|e| format!("Failed to lock recorder: {}", e))?;
         recorder.close_session()?;
     }
-    emit_recorder_state(&app_handle, RecorderStateEvent::Idle);
+    emit_recording_state(&app_handle, RecordingState::Idle);
     Ok(())
 }
 
 #[tauri::command]
-pub async fn get_current_recording_id(state: State<'_, AppData>) -> Result<Option<String>> {
+pub async fn get_current_recording_id(
+    recorder: State<'_, Mutex<Recorder>>,
+) -> Result<Option<String>> {
     debug!("Getting current recording ID");
-    let recorder = state
-        .recorder
+    let recorder = recorder
         .lock()
         .map_err(|e| format!("Failed to lock recorder: {}", e))?;
     Ok(recorder.get_current_recording_id())

--- a/apps/whispering/src-tauri/src/recorder/mod.rs
+++ b/apps/whispering/src-tauri/src/recorder/mod.rs
@@ -5,8 +5,8 @@ pub mod wav_writer;
 // Export everything from commands for easy access
 pub use commands::{
     cancel_recording, close_recording_session, enumerate_recording_devices,
-    get_current_recording_id, init_recording_session, start_recording, stop_recording, AppData,
+    get_current_recording_id, init_recording_session, start_recording, stop_recording,
 };
 
 // Export key types from recorder
-pub use recorder::AudioRecording;
+pub use recorder::{AudioRecording, Recorder};

--- a/apps/whispering/src-tauri/src/recorder/recorder.rs
+++ b/apps/whispering/src-tauri/src/recorder/recorder.rs
@@ -30,8 +30,9 @@ enum RecorderCmd {
     Shutdown,
 }
 
-/// Simplified recorder state
-pub struct RecorderState {
+/// CPAL-backed audio recorder. Owns the worker thread, command channel,
+/// and WAV writer for the active session (if any).
+pub struct Recorder {
     cmd_tx: Option<mpsc::Sender<RecorderCmd>>,
     worker_handle: Option<JoinHandle<()>>,
     writer: Option<Arc<Mutex<WavWriter>>>,
@@ -41,7 +42,7 @@ pub struct RecorderState {
     file_path: Option<PathBuf>,
 }
 
-impl RecorderState {
+impl Recorder {
     pub fn new() -> Self {
         Self {
             cmd_tx: None,
@@ -470,7 +471,7 @@ fn build_input_stream(
     Ok(stream)
 }
 
-impl Drop for RecorderState {
+impl Drop for Recorder {
     fn drop(&mut self) {
         let _ = self.close_session();
     }

--- a/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
+++ b/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
@@ -1,4 +1,5 @@
 import { invoke as tauriInvoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
 import { remove } from '@tauri-apps/plugin-fs';
 import { Err, Ok, type Result, tryAsync } from 'wellcrafted/result';
 import type {
@@ -324,6 +325,19 @@ export const CpalRecorderServiceLive: RecorderService = {
 		}
 
 		return Ok({ status: 'cancelled' });
+	},
+
+	subscribe(handler) {
+		// Rust emits 'recorder:state-changed' from every mutation path (see
+		// src-tauri/src/recorder/commands.rs). Wrap the Tauri listener so this
+		// service exposes the same subscribe shape as the navigator service.
+		const unlistenPromise = listen<WhisperingRecordingState>(
+			'recorder:state-changed',
+			(event) => handler(event.payload),
+		);
+		return () => {
+			void unlistenPromise.then((unlisten) => unlisten());
+		};
 	},
 };
 

--- a/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
+++ b/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
@@ -27,13 +27,6 @@ type AudioRecording = {
 };
 
 /**
- * Tracks the recordingId the JS caller passed to startRecording so we can
- * return it from stopRecording without a Rust round-trip. Cleared on stop or
- * cancel.
- */
-let activeRecording: { recordingId: string } | null = null;
-
-/**
  * Enumerates available recording devices from the system.
  */
 const enumerateDevices = async (): Promise<Result<Device[], RecorderError>> => {
@@ -57,289 +50,305 @@ const enumerateDevices = async (): Promise<Result<Device[], RecorderError>> => {
  * CPAL recorder service that uses the Rust CPAL method.
  * This service handles device enumeration, recording start/stop operations, and file management
  * for desktop audio recording using the CPAL library.
+ *
+ * Constructed via a factory so `activeRecording` lives in the closure rather
+ * than at module scope. The exported `CpalRecorderServiceLive` is the single
+ * application-level instance; tests can call `createCpalRecorder()` for an
+ * isolated one.
  */
-export const CpalRecorderServiceLive: RecorderService = {
-	/**
-	 * Gets the current state of the recorder.
-	 */
-	getRecorderState: async (): Promise<
-		Result<WhisperingRecordingState, RecorderError>
-	> => {
-		const { data: recordingId, error: getRecorderStateError } = await invoke<
-			string | null
-		>('get_current_recording_id');
-		if (getRecorderStateError)
-			return RecorderError.GetStateFailed({
-				cause: getRecorderStateError,
-			});
+function createCpalRecorder(): RecorderService {
+	// Tracks the recordingId the JS caller passed to startRecording so we can
+	// return it from stopRecording without a Rust round-trip. Cleared on stop
+	// or cancel.
+	let activeRecording: { recordingId: string } | null = null;
 
-		return Ok(recordingId ? 'RECORDING' : 'IDLE');
-	},
-
-	enumerateDevices,
-
-	/**
-	 * Starts a recording session with the specified parameters.
-	 * Handles device selection, fallback logic, and recording initialization.
-	 *
-	 * @param params - Recording parameters including device ID, recording ID, output folder, and sample rate
-	 * @param callbacks - Callback functions for status updates
-	 */
-	startRecording: async (
-		{
-			selectedDeviceId,
-			recordingId,
-			outputFolder,
-			sampleRate,
-		}: CpalRecordingParams,
-		{ sendStatus },
-	): Promise<Result<DeviceAcquisitionOutcome, RecorderError>> => {
-		const { data: devices, error: enumerateError } = await enumerateDevices();
-		if (enumerateError) return Err(enumerateError);
-
+	return {
 		/**
-		 * Acquires a recording device, either the selected one or a fallback.
+		 * Gets the current state of the recorder.
 		 */
-		const acquireDevice = (): Result<
-			DeviceAcquisitionOutcome,
-			RecorderError
+		getRecorderState: async (): Promise<
+			Result<WhisperingRecordingState, RecorderError>
 		> => {
-			const deviceIds = devices.map((d) => d.id);
-			const fallbackDeviceId = deviceIds.at(0);
-			if (!fallbackDeviceId) {
-				return RecorderError.NoDevice({
-					message: selectedDeviceId
-						? "We couldn't find the selected microphone. Make sure it's connected and try again!"
-						: "We couldn't find any microphones. Make sure they're connected and try again!",
-				});
-			}
-
-			if (!selectedDeviceId) {
-				sendStatus({
-					title: '🔍 No Device Selected',
-					description:
-						"No worries! We'll find the best microphone for you automatically...",
-				});
-				return Ok({
-					outcome: 'fallback',
-					reason: 'no-device-selected',
-					deviceId: fallbackDeviceId,
-				});
-			}
-
-			// Check if the selected device exists in the devices array
-			const deviceExists = deviceIds.includes(selectedDeviceId);
-
-			if (deviceExists)
-				return Ok({ outcome: 'success', deviceId: selectedDeviceId });
-
-			sendStatus({
-				title: '⚠️ Finding a New Microphone',
-				description:
-					"That microphone isn't available. Let's try finding another one...",
-			});
-
-			return Ok({
-				outcome: 'fallback',
-				reason: 'preferred-device-unavailable',
-				deviceId: fallbackDeviceId,
-			});
-		};
-
-		const { data: deviceOutcome, error: acquireDeviceError } = acquireDevice();
-		if (acquireDeviceError) return Err(acquireDeviceError);
-
-		// Use the device from the outcome
-		const deviceIdentifier = deviceOutcome.deviceId;
-
-		// Now initialize recording with the chosen device
-		sendStatus({
-			title: '🎤 Setting Up',
-			description:
-				'Initializing your recording session and checking microphone access...',
-		});
-
-		// Convert sample rate string to number if provided
-		const sampleRateNum = sampleRate
-			? Number.parseInt(sampleRate, 10)
-			: undefined;
-
-		const { error: initRecordingSessionError } = await invoke(
-			'init_recording_session',
-			{
-				deviceIdentifier,
-				recordingId,
-				outputFolder,
-				sampleRate: sampleRateNum,
-			},
-		);
-		if (initRecordingSessionError)
-			return RecorderError.InitFailed({
-				cause: initRecordingSessionError,
-			});
-
-		sendStatus({
-			title: '🎙️ Starting Recording',
-			description:
-				'Recording session initialized, now starting to capture audio...',
-		});
-		const { error: startRecordingError } =
-			await invoke<void>('start_recording');
-		if (startRecordingError)
-			return RecorderError.StartFailed({ cause: startRecordingError });
-
-		activeRecording = { recordingId };
-		return Ok(deviceOutcome);
-	},
-
-	/**
-	 * Stops the current recording session and returns the recorded audio as a Blob.
-	 * Handles file reading, session cleanup, and resource management.
-	 *
-	 * @param callbacks - Callback functions for status updates
-	 */
-	stopRecording: async ({
-		sendStatus,
-	}): Promise<Result<{ blob: Blob; recordingId: string }, RecorderError>> => {
-		// Fast path uses the recordingId captured at startRecording. After a JS
-		// reload mid-recording the closure is gone but Rust is still going; fall
-		// back to asking Rust which recording is currently active.
-		let recordingId: string;
-		if (activeRecording) {
-			recordingId = activeRecording.recordingId;
-			activeRecording = null;
-		} else {
-			const { data: liveRecordingId, error: getIdError } = await invoke<
+			const { data: recordingId, error: getRecorderStateError } = await invoke<
 				string | null
 			>('get_current_recording_id');
-			if (getIdError) {
-				return RecorderError.GetStateFailed({ cause: getIdError });
-			}
-			if (!liveRecordingId) {
-				return RecorderError.NotRecording({
-					message:
-						'Cannot stop recording because no active recording session was found. Make sure you have started recording before attempting to stop it.',
+			if (getRecorderStateError)
+				return RecorderError.GetStateFailed({
+					cause: getRecorderStateError,
 				});
-			}
-			recordingId = liveRecordingId;
-		}
 
-		const { data: audioRecording, error: stopRecordingError } =
-			await invoke<AudioRecording>('stop_recording');
-		if (stopRecordingError) {
-			return RecorderError.StopFailed({ cause: stopRecordingError });
-		}
+			return Ok(recordingId ? 'RECORDING' : 'IDLE');
+		},
 
-		const { filePath } = audioRecording;
-		// Desktop recorder should always write to a file
-		if (!filePath) {
-			return RecorderError.NoFilePath();
-		}
+		enumerateDevices,
 
-		// Read the WAV file from disk
-		sendStatus({
-			title: '📁 Reading Recording',
-			description: 'Loading your recording from disk...',
-		});
+		/**
+		 * Starts a recording session with the specified parameters.
+		 * Handles device selection, fallback logic, and recording initialization.
+		 *
+		 * @param params - Recording parameters including device ID, recording ID, output folder, and sample rate
+		 * @param callbacks - Callback functions for status updates
+		 */
+		startRecording: async (
+			{
+				selectedDeviceId,
+				recordingId,
+				outputFolder,
+				sampleRate,
+			}: CpalRecordingParams,
+			{ sendStatus },
+		): Promise<Result<DeviceAcquisitionOutcome, RecorderError>> => {
+			const { data: devices, error: enumerateError } = await enumerateDevices();
+			if (enumerateError) return Err(enumerateError);
 
-		const { data: blob, error: readRecordingFileError } =
-			await FsServiceLive.pathToBlob(filePath);
-		if (readRecordingFileError)
-			return RecorderError.ReadFileFailed({
-				cause: readRecordingFileError,
-			});
-		// Close the recording session after stopping
-		sendStatus({
-			title: '🔄 Closing Session',
-			description: 'Cleaning up recording resources...',
-		});
-		const { error: closeError } = await invoke<void>('close_recording_session');
-		if (closeError) {
-			// Log but don't fail the stop operation
-			console.error('Failed to close recording session:', closeError);
-		}
+			/**
+			 * Acquires a recording device, either the selected one or a fallback.
+			 */
+			const acquireDevice = (): Result<
+				DeviceAcquisitionOutcome,
+				RecorderError
+			> => {
+				const deviceIds = devices.map((d) => d.id);
+				const fallbackDeviceId = deviceIds.at(0);
+				if (!fallbackDeviceId) {
+					return RecorderError.NoDevice({
+						message: selectedDeviceId
+							? "We couldn't find the selected microphone. Make sure it's connected and try again!"
+							: "We couldn't find any microphones. Make sure they're connected and try again!",
+					});
+				}
 
-		return Ok({ blob, recordingId });
-	},
+				if (!selectedDeviceId) {
+					sendStatus({
+						title: '🔍 No Device Selected',
+						description:
+							"No worries! We'll find the best microphone for you automatically...",
+					});
+					return Ok({
+						outcome: 'fallback',
+						reason: 'no-device-selected',
+						deviceId: fallbackDeviceId,
+					});
+				}
 
-	/**
-	 * Cancels the current recording session and cleans up resources.
-	 * Deletes any temporary recording files and closes the recording session.
-	 *
-	 * @param callbacks - Callback functions for status updates
-	 */
-	cancelRecording: async ({
-		sendStatus,
-	}): Promise<Result<CancelRecordingResult, RecorderError>> => {
-		// Check current state first
-		const { data: recordingId, error: getRecordingIdError } = await invoke<
-			string | null
-		>('get_current_recording_id');
-		if (getRecordingIdError) {
-			return RecorderError.GetStateFailed({
-				cause: getRecordingIdError,
-			});
-		}
+				// Check if the selected device exists in the devices array
+				const deviceExists = deviceIds.includes(selectedDeviceId);
 
-		if (!recordingId) {
-			activeRecording = null;
-			return Ok({ status: 'no-recording' });
-		}
+				if (deviceExists)
+					return Ok({ outcome: 'success', deviceId: selectedDeviceId });
 
-		activeRecording = null;
-
-		sendStatus({
-			title: '🛑 Cancelling',
-			description:
-				'Safely stopping your recording and cleaning up resources...',
-		});
-
-		// First get the recording data to know if there's a file to delete
-		const { data: audioRecording } =
-			await invoke<AudioRecording>('stop_recording');
-
-		// If there's a file path, delete the file using Tauri FS plugin
-		if (audioRecording?.filePath) {
-			const filePath = audioRecording.filePath;
-			const { error: removeError } = await tryAsync({
-				try: () => remove(filePath),
-				catch: (error) => RecorderError.FileDeleteFailed({ cause: error }),
-			});
-			if (removeError)
 				sendStatus({
-					title: '❌ Error Deleting Recording File',
+					title: '⚠️ Finding a New Microphone',
 					description:
-						"We couldn't delete the recording file. Continuing with the cancellation process...",
+						"That microphone isn't available. Let's try finding another one...",
 				});
-		}
 
-		// Close the recording session after cancelling
-		sendStatus({
-			title: '🔄 Closing Session',
-			description: 'Cleaning up recording resources...',
-		});
-		const { error: closeError } = await invoke<void>('close_recording_session');
-		if (closeError) {
-			// Log but don't fail the cancel operation
-			console.error('Failed to close recording session:', closeError);
-		}
+				return Ok({
+					outcome: 'fallback',
+					reason: 'preferred-device-unavailable',
+					deviceId: fallbackDeviceId,
+				});
+			};
 
-		return Ok({ status: 'cancelled' });
-	},
+			const { data: deviceOutcome, error: acquireDeviceError } = acquireDevice();
+			if (acquireDeviceError) return Err(acquireDeviceError);
 
-	subscribe(handler) {
-		// Rust emits 'recorder:state-changed' from every mutation path (see
-		// src-tauri/src/recorder/commands.rs). Wrap the Tauri listener so this
-		// service exposes the same subscribe shape as the navigator service.
-		const unlistenPromise = listen<WhisperingRecordingState>(
-			'recorder:state-changed',
-			(event) => handler(event.payload),
-		);
-		return () => {
-			void unlistenPromise.then((unlisten) => unlisten());
-		};
-	},
-};
+			// Use the device from the outcome
+			const deviceIdentifier = deviceOutcome.deviceId;
+
+			// Now initialize recording with the chosen device
+			sendStatus({
+				title: '🎤 Setting Up',
+				description:
+					'Initializing your recording session and checking microphone access...',
+			});
+
+			// Convert sample rate string to number if provided
+			const sampleRateNum = sampleRate
+				? Number.parseInt(sampleRate, 10)
+				: undefined;
+
+			const { error: initRecordingSessionError } = await invoke(
+				'init_recording_session',
+				{
+					deviceIdentifier,
+					recordingId,
+					outputFolder,
+					sampleRate: sampleRateNum,
+				},
+			);
+			if (initRecordingSessionError)
+				return RecorderError.InitFailed({
+					cause: initRecordingSessionError,
+				});
+
+			sendStatus({
+				title: '🎙️ Starting Recording',
+				description:
+					'Recording session initialized, now starting to capture audio...',
+			});
+			const { error: startRecordingError } =
+				await invoke<void>('start_recording');
+			if (startRecordingError)
+				return RecorderError.StartFailed({ cause: startRecordingError });
+
+			activeRecording = { recordingId };
+			return Ok(deviceOutcome);
+		},
+
+		/**
+		 * Stops the current recording session and returns the recorded audio as a Blob.
+		 * Handles file reading, session cleanup, and resource management.
+		 *
+		 * @param callbacks - Callback functions for status updates
+		 */
+		stopRecording: async ({
+			sendStatus,
+		}): Promise<Result<{ blob: Blob; recordingId: string }, RecorderError>> => {
+			// Fast path uses the recordingId captured at startRecording. After a JS
+			// reload mid-recording the closure is gone but Rust is still going; fall
+			// back to asking Rust which recording is currently active.
+			let recordingId: string;
+			if (activeRecording) {
+				recordingId = activeRecording.recordingId;
+				activeRecording = null;
+			} else {
+				const { data: liveRecordingId, error: getIdError } = await invoke<
+					string | null
+				>('get_current_recording_id');
+				if (getIdError) {
+					return RecorderError.GetStateFailed({ cause: getIdError });
+				}
+				if (!liveRecordingId) {
+					return RecorderError.NotRecording({
+						message:
+							'Cannot stop recording because no active recording session was found. Make sure you have started recording before attempting to stop it.',
+					});
+				}
+				recordingId = liveRecordingId;
+			}
+
+			const { data: audioRecording, error: stopRecordingError } =
+				await invoke<AudioRecording>('stop_recording');
+			if (stopRecordingError) {
+				return RecorderError.StopFailed({ cause: stopRecordingError });
+			}
+
+			const { filePath } = audioRecording;
+			// Desktop recorder should always write to a file
+			if (!filePath) {
+				return RecorderError.NoFilePath();
+			}
+
+			// Read the WAV file from disk
+			sendStatus({
+				title: '📁 Reading Recording',
+				description: 'Loading your recording from disk...',
+			});
+
+			const { data: blob, error: readRecordingFileError } =
+				await FsServiceLive.pathToBlob(filePath);
+			if (readRecordingFileError)
+				return RecorderError.ReadFileFailed({
+					cause: readRecordingFileError,
+				});
+			// Close the recording session after stopping
+			sendStatus({
+				title: '🔄 Closing Session',
+				description: 'Cleaning up recording resources...',
+			});
+			const { error: closeError } =
+				await invoke<void>('close_recording_session');
+			if (closeError) {
+				// Log but don't fail the stop operation
+				console.error('Failed to close recording session:', closeError);
+			}
+
+			return Ok({ blob, recordingId });
+		},
+
+		/**
+		 * Cancels the current recording session and cleans up resources.
+		 * Deletes any temporary recording files and closes the recording session.
+		 *
+		 * @param callbacks - Callback functions for status updates
+		 */
+		cancelRecording: async ({
+			sendStatus,
+		}): Promise<Result<CancelRecordingResult, RecorderError>> => {
+			// Check current state first
+			const { data: recordingId, error: getRecordingIdError } = await invoke<
+				string | null
+			>('get_current_recording_id');
+			if (getRecordingIdError) {
+				return RecorderError.GetStateFailed({
+					cause: getRecordingIdError,
+				});
+			}
+
+			if (!recordingId) {
+				activeRecording = null;
+				return Ok({ status: 'no-recording' });
+			}
+
+			activeRecording = null;
+
+			sendStatus({
+				title: '🛑 Cancelling',
+				description:
+					'Safely stopping your recording and cleaning up resources...',
+			});
+
+			// First get the recording data to know if there's a file to delete
+			const { data: audioRecording } =
+				await invoke<AudioRecording>('stop_recording');
+
+			// If there's a file path, delete the file using Tauri FS plugin
+			if (audioRecording?.filePath) {
+				const filePath = audioRecording.filePath;
+				const { error: removeError } = await tryAsync({
+					try: () => remove(filePath),
+					catch: (error) => RecorderError.FileDeleteFailed({ cause: error }),
+				});
+				if (removeError)
+					sendStatus({
+						title: '❌ Error Deleting Recording File',
+						description:
+							"We couldn't delete the recording file. Continuing with the cancellation process...",
+					});
+			}
+
+			// Close the recording session after cancelling
+			sendStatus({
+				title: '🔄 Closing Session',
+				description: 'Cleaning up recording resources...',
+			});
+			const { error: closeError } =
+				await invoke<void>('close_recording_session');
+			if (closeError) {
+				// Log but don't fail the cancel operation
+				console.error('Failed to close recording session:', closeError);
+			}
+
+			return Ok({ status: 'cancelled' });
+		},
+
+		subscribe(handler) {
+			// Rust emits 'recorder:state-changed' from every mutation path (see
+			// src-tauri/src/recorder/commands.rs). Wrap the Tauri listener so this
+			// service exposes the same subscribe shape as the navigator service.
+			const unlistenPromise = listen<WhisperingRecordingState>(
+				'recorder:state-changed',
+				(event) => handler(event.payload),
+			);
+			return () => {
+				void unlistenPromise.then((unlisten) => unlisten());
+			};
+		},
+	};
+}
+
+export const CpalRecorderServiceLive: RecorderService = createCpalRecorder();
 
 /**
  * Wrapper function for Tauri invoke calls that handles errors consistently.

--- a/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
+++ b/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
@@ -150,7 +150,8 @@ function createCpalRecorder(): RecorderService {
 				});
 			};
 
-			const { data: deviceOutcome, error: acquireDeviceError } = acquireDevice();
+			const { data: deviceOutcome, error: acquireDeviceError } =
+				acquireDevice();
 			if (acquireDeviceError) return Err(acquireDeviceError);
 
 			// Use the device from the outcome
@@ -257,8 +258,9 @@ function createCpalRecorder(): RecorderService {
 				title: '🔄 Closing Session',
 				description: 'Cleaning up recording resources...',
 			});
-			const { error: closeError } =
-				await invoke<void>('close_recording_session');
+			const { error: closeError } = await invoke<void>(
+				'close_recording_session',
+			);
 			if (closeError) {
 				// Log but don't fail the stop operation
 				console.error('Failed to close recording session:', closeError);
@@ -323,8 +325,9 @@ function createCpalRecorder(): RecorderService {
 				title: '🔄 Closing Session',
 				description: 'Cleaning up recording resources...',
 			});
-			const { error: closeError } =
-				await invoke<void>('close_recording_session');
+			const { error: closeError } = await invoke<void>(
+				'close_recording_session',
+			);
 			if (closeError) {
 				// Log but don't fail the cancel operation
 				console.error('Failed to close recording session:', closeError);

--- a/apps/whispering/src/lib/services/recorder/navigator.ts
+++ b/apps/whispering/src/lib/services/recorder/navigator.ts
@@ -27,6 +27,12 @@ type ActiveRecording = {
 
 let activeRecording: ActiveRecording | null = null;
 
+const subscribers = new Set<(state: WhisperingRecordingState) => void>();
+
+function notify(state: WhisperingRecordingState) {
+	for (const handler of subscribers) handler(state);
+}
+
 /**
  * Navigator recorder service that uses the MediaRecorder API.
  * Available in both browser and desktop environments.
@@ -105,6 +111,7 @@ export const NavigatorRecorderServiceLive: RecorderService = {
 
 		// Start recording
 		mediaRecorder.start(TIMESLICE_MS);
+		notify('RECORDING');
 
 		// Return the device acquisition outcome
 		return Ok(deviceOutcome);
@@ -145,6 +152,7 @@ export const NavigatorRecorderServiceLive: RecorderService = {
 
 		// Always clean up the stream
 		cleanupRecordingStream(recording.stream);
+		notify('IDLE');
 
 		if (stopError) return Err(stopError);
 
@@ -175,6 +183,7 @@ export const NavigatorRecorderServiceLive: RecorderService = {
 
 		// Clean up the stream
 		cleanupRecordingStream(recording.stream);
+		notify('IDLE');
 
 		sendStatus({
 			title: '✨ Cancelled',
@@ -182,6 +191,13 @@ export const NavigatorRecorderServiceLive: RecorderService = {
 		});
 
 		return Ok({ status: 'cancelled' });
+	},
+
+	subscribe(handler) {
+		subscribers.add(handler);
+		return () => {
+			subscribers.delete(handler);
+		};
 	},
 };
 

--- a/apps/whispering/src/lib/services/recorder/navigator.ts
+++ b/apps/whispering/src/lib/services/recorder/navigator.ts
@@ -25,181 +25,191 @@ type ActiveRecording = {
 	recordedChunks: Blob[];
 };
 
-let activeRecording: ActiveRecording | null = null;
-
-const subscribers = new Set<(state: WhisperingRecordingState) => void>();
-
-function notify(state: WhisperingRecordingState) {
-	for (const handler of subscribers) handler(state);
-}
-
 /**
  * Navigator recorder service that uses the MediaRecorder API.
  * Available in both browser and desktop environments.
+ *
+ * Constructed via a factory so all mutable state (`activeRecording`,
+ * `subscribers`) lives in the closure rather than at module scope. The
+ * exported `NavigatorRecorderServiceLive` is the single application-level
+ * instance; tests can call `createNavigatorRecorder()` for an isolated one.
  */
-export const NavigatorRecorderServiceLive: RecorderService = {
-	getRecorderState: async (): Promise<
-		Result<WhisperingRecordingState, RecorderError>
-	> => {
-		return Ok(activeRecording ? 'RECORDING' : 'IDLE');
-	},
+function createNavigatorRecorder(): RecorderService {
+	let activeRecording: ActiveRecording | null = null;
 
-	enumerateDevices: async () => {
-		const { data: devices, error } = await enumerateDevices();
-		if (error) {
-			return RecorderError.EnumerateDevices({ cause: error });
-		}
-		return Ok(devices);
-	},
+	const subscribers = new Set<(state: WhisperingRecordingState) => void>();
 
-	startRecording: async (
-		{ selectedDeviceId, recordingId, bitrateKbps }: NavigatorRecordingParams,
-		{ sendStatus },
-	): Promise<Result<DeviceAcquisitionOutcome, RecorderError>> => {
-		// Ensure we're not already recording
-		if (activeRecording) {
-			return RecorderError.AlreadyRecording();
-		}
+	const notify = (state: WhisperingRecordingState) => {
+		for (const handler of subscribers) handler(state);
+	};
 
-		sendStatus({
-			title: '🎙️ Starting Recording',
-			description: 'Setting up your microphone...',
-		});
+	return {
+		getRecorderState: async (): Promise<
+			Result<WhisperingRecordingState, RecorderError>
+		> => {
+			return Ok(activeRecording ? 'RECORDING' : 'IDLE');
+		},
 
-		// Get the recording stream
-		const { data: streamResult, error: acquireStreamError } =
-			await getRecordingStream({ selectedDeviceId, sendStatus });
-		if (acquireStreamError) {
-			return RecorderError.StreamAcquisition({ cause: acquireStreamError });
-		}
+		enumerateDevices: async () => {
+			const { data: devices, error } = await enumerateDevices();
+			if (error) {
+				return RecorderError.EnumerateDevices({ cause: error });
+			}
+			return Ok(devices);
+		},
 
-		const { stream, deviceOutcome } = streamResult;
+		startRecording: async (
+			{ selectedDeviceId, recordingId, bitrateKbps }: NavigatorRecordingParams,
+			{ sendStatus },
+		): Promise<Result<DeviceAcquisitionOutcome, RecorderError>> => {
+			// Ensure we're not already recording
+			if (activeRecording) {
+				return RecorderError.AlreadyRecording();
+			}
 
-		const mimeType = getSupportedAudioMimeType();
-		const { data: mediaRecorder, error: recorderError } = trySync({
-			try: () =>
-				new MediaRecorder(stream, {
-					bitsPerSecond: Number(bitrateKbps) * 1000,
-					mimeType,
-				}),
-			catch: (error) => RecorderError.InitFailed({ cause: error }),
-		});
-
-		if (recorderError) {
-			// Clean up stream if recorder creation fails
-			cleanupRecordingStream(stream);
-			return Err(recorderError);
-		}
-
-		// Set up recording state and event handlers
-		const recordedChunks: Blob[] = [];
-
-		// Store active recording state
-		activeRecording = {
-			recordingId,
-			selectedDeviceId,
-			bitrateKbps,
-			stream,
-			mediaRecorder,
-			recordedChunks,
-		};
-
-		// Set up event handlers
-		mediaRecorder.addEventListener('dataavailable', (event: BlobEvent) => {
-			if (event.data.size) recordedChunks.push(event.data);
-		});
-
-		// Start recording
-		mediaRecorder.start(TIMESLICE_MS);
-		notify('RECORDING');
-
-		// Return the device acquisition outcome
-		return Ok(deviceOutcome);
-	},
-
-	stopRecording: async ({
-		sendStatus,
-	}): Promise<Result<{ blob: Blob; recordingId: string }, RecorderError>> => {
-		if (!activeRecording) {
-			return RecorderError.NotRecording({
-				message:
-					'Cannot stop recording because no active recording session was found. Make sure you have started recording before attempting to stop it.',
+			sendStatus({
+				title: '🎙️ Starting Recording',
+				description: 'Setting up your microphone...',
 			});
-		}
 
-		const recording = activeRecording;
-		activeRecording = null; // Clear immediately to prevent race conditions
+			// Get the recording stream
+			const { data: streamResult, error: acquireStreamError } =
+				await getRecordingStream({ selectedDeviceId, sendStatus });
+			if (acquireStreamError) {
+				return RecorderError.StreamAcquisition({ cause: acquireStreamError });
+			}
 
-		sendStatus({
-			title: '⏸️ Finishing Recording',
-			description: 'Saving your audio...',
-		});
+			const { stream, deviceOutcome } = streamResult;
 
-		// Stop the recorder and wait for the final data
-		const { data: blob, error: stopError } = await tryAsync({
-			try: () =>
-				new Promise<Blob>((resolve) => {
-					recording.mediaRecorder.addEventListener('stop', () => {
-						const audioBlob = new Blob(recording.recordedChunks, {
-							type: recording.mediaRecorder.mimeType,
+			const mimeType = getSupportedAudioMimeType();
+			const { data: mediaRecorder, error: recorderError } = trySync({
+				try: () =>
+					new MediaRecorder(stream, {
+						bitsPerSecond: Number(bitrateKbps) * 1000,
+						mimeType,
+					}),
+				catch: (error) => RecorderError.InitFailed({ cause: error }),
+			});
+
+			if (recorderError) {
+				// Clean up stream if recorder creation fails
+				cleanupRecordingStream(stream);
+				return Err(recorderError);
+			}
+
+			// Set up recording state and event handlers
+			const recordedChunks: Blob[] = [];
+
+			// Store active recording state
+			activeRecording = {
+				recordingId,
+				selectedDeviceId,
+				bitrateKbps,
+				stream,
+				mediaRecorder,
+				recordedChunks,
+			};
+
+			// Set up event handlers
+			mediaRecorder.addEventListener('dataavailable', (event: BlobEvent) => {
+				if (event.data.size) recordedChunks.push(event.data);
+			});
+
+			// Start recording
+			mediaRecorder.start(TIMESLICE_MS);
+			notify('RECORDING');
+
+			// Return the device acquisition outcome
+			return Ok(deviceOutcome);
+		},
+
+		stopRecording: async ({
+			sendStatus,
+		}): Promise<Result<{ blob: Blob; recordingId: string }, RecorderError>> => {
+			if (!activeRecording) {
+				return RecorderError.NotRecording({
+					message:
+						'Cannot stop recording because no active recording session was found. Make sure you have started recording before attempting to stop it.',
+				});
+			}
+
+			const recording = activeRecording;
+			activeRecording = null; // Clear immediately to prevent race conditions
+
+			sendStatus({
+				title: '⏸️ Finishing Recording',
+				description: 'Saving your audio...',
+			});
+
+			// Stop the recorder and wait for the final data
+			const { data: blob, error: stopError } = await tryAsync({
+				try: () =>
+					new Promise<Blob>((resolve) => {
+						recording.mediaRecorder.addEventListener('stop', () => {
+							const audioBlob = new Blob(recording.recordedChunks, {
+								type: recording.mediaRecorder.mimeType,
+							});
+							resolve(audioBlob);
 						});
-						resolve(audioBlob);
-					});
-					recording.mediaRecorder.stop();
-				}),
-			catch: (error) => RecorderError.StopFailed({ cause: error }),
-		});
+						recording.mediaRecorder.stop();
+					}),
+				catch: (error) => RecorderError.StopFailed({ cause: error }),
+			});
 
-		// Always clean up the stream
-		cleanupRecordingStream(recording.stream);
-		notify('IDLE');
+			// Always clean up the stream
+			cleanupRecordingStream(recording.stream);
+			notify('IDLE');
 
-		if (stopError) return Err(stopError);
+			if (stopError) return Err(stopError);
 
-		sendStatus({
-			title: '✅ Recording Saved',
-			description: 'Your recording is ready for transcription!',
-		});
-		return Ok({ blob, recordingId: recording.recordingId });
-	},
+			sendStatus({
+				title: '✅ Recording Saved',
+				description: 'Your recording is ready for transcription!',
+			});
+			return Ok({ blob, recordingId: recording.recordingId });
+		},
 
-	cancelRecording: async ({
-		sendStatus,
-	}): Promise<Result<CancelRecordingResult, RecorderError>> => {
-		if (!activeRecording) {
-			return Ok({ status: 'no-recording' });
-		}
+		cancelRecording: async ({
+			sendStatus,
+		}): Promise<Result<CancelRecordingResult, RecorderError>> => {
+			if (!activeRecording) {
+				return Ok({ status: 'no-recording' });
+			}
 
-		const recording = activeRecording;
-		activeRecording = null; // Clear immediately
+			const recording = activeRecording;
+			activeRecording = null; // Clear immediately
 
-		sendStatus({
-			title: '🛑 Cancelling',
-			description: 'Discarding your recording...',
-		});
+			sendStatus({
+				title: '🛑 Cancelling',
+				description: 'Discarding your recording...',
+			});
 
-		// Stop the recorder
-		recording.mediaRecorder.stop();
+			// Stop the recorder
+			recording.mediaRecorder.stop();
 
-		// Clean up the stream
-		cleanupRecordingStream(recording.stream);
-		notify('IDLE');
+			// Clean up the stream
+			cleanupRecordingStream(recording.stream);
+			notify('IDLE');
 
-		sendStatus({
-			title: '✨ Cancelled',
-			description: 'Recording discarded successfully!',
-		});
+			sendStatus({
+				title: '✨ Cancelled',
+				description: 'Recording discarded successfully!',
+			});
 
-		return Ok({ status: 'cancelled' });
-	},
+			return Ok({ status: 'cancelled' });
+		},
 
-	subscribe(handler) {
-		subscribers.add(handler);
-		return () => {
-			subscribers.delete(handler);
-		};
-	},
-};
+		subscribe(handler) {
+			subscribers.add(handler);
+			return () => {
+				subscribers.delete(handler);
+			};
+		},
+	};
+}
+
+export const NavigatorRecorderServiceLive: RecorderService =
+	createNavigatorRecorder();
 
 /**
  * Determines the best supported audio MIME type for the current browser.

--- a/apps/whispering/src/lib/services/recorder/types.ts
+++ b/apps/whispering/src/lib/services/recorder/types.ts
@@ -276,4 +276,23 @@ export type RecorderService = {
 	cancelRecording(callbacks: {
 		sendStatus: UpdateStatusMessageFn;
 	}): Promise<Result<CancelRecordingResult, RecorderError>>;
+
+	/**
+	 * Subscribe to state changes from this service. The handler is invoked
+	 * synchronously whenever the service transitions between IDLE and RECORDING.
+	 *
+	 * This is the single source of truth for state changes. Consumers should
+	 * subscribe at construction time and let the handler drive their local
+	 * state ; no eager mirror writes from the consumer side.
+	 *
+	 * Inactive services never fire (a CPAL subscription stays silent in web
+	 * mode, a navigator subscription stays silent in CPAL mode), so it is
+	 * safe to subscribe to every available service at once.
+	 *
+	 * Returns an unsubscribe function. Module-singleton consumers can ignore
+	 * the return value; ephemeral consumers should call it on teardown.
+	 */
+	subscribe(
+		handler: (state: WhisperingRecordingState) => void,
+	): () => void;
 };

--- a/apps/whispering/src/lib/services/recorder/types.ts
+++ b/apps/whispering/src/lib/services/recorder/types.ts
@@ -292,7 +292,5 @@ export type RecorderService = {
 	 * Returns an unsubscribe function. Module-singleton consumers can ignore
 	 * the return value; ephemeral consumers should call it on teardown.
 	 */
-	subscribe(
-		handler: (state: WhisperingRecordingState) => void,
-	): () => void;
+	subscribe(handler: (state: WhisperingRecordingState) => void): () => void;
 };

--- a/apps/whispering/src/lib/state/manual-recorder.svelte.ts
+++ b/apps/whispering/src/lib/state/manual-recorder.svelte.ts
@@ -1,5 +1,4 @@
 import { isTauri } from '@tauri-apps/api/core';
-import { listen } from '@tauri-apps/api/event';
 import { nanoid } from 'nanoid/non-secure';
 import { Ok } from 'wellcrafted/result';
 import type { WhisperingRecordingState } from '$lib/constants/audio';
@@ -18,18 +17,22 @@ import { deviceConfig } from '$lib/state/device-config.svelte';
 /**
  * Creates the manual recorder with reactive state.
  *
- * State is owned by this module via Svelte's $state rune for synchronous
+ * State is owned by this module via Svelte's `$state` rune for synchronous
  * reactivity. Mirrors the shape of `vadRecorder` in `vad-recorder.svelte.ts`:
  *
  * - Reactive access: `manualRecorder.state` (triggers effects on change)
  * - Operations: `manualRecorder.startRecording({ toastId })` etc.
  * - Device enumeration as a TanStack Query for loading states in selectors
  *
+ * State writes flow through a single channel: every recorder service exposes
+ * `subscribe(handler)`, this module registers one handler at construction
+ * time, and the active service drives `_state` directly. Inactive services
+ * (e.g. a CPAL subscription in web mode) emit nothing.
+ *
  * On Tauri, state is bootstrapped from the active service's `getRecorderState`
- * once at module init (a Rust CPAL session can outlive a JS reload). A Tauri
- * `recorder:state-changed` listener is registered to receive future Rust-side
- * transitions. The Rust emit side is not yet wired; the listener is a no-op
- * until that lands and harmless in the meantime.
+ * once at module init (a Rust CPAL session can outlive a JS reload). The
+ * subscribe handler covers every subsequent transition, including ones Rust
+ * initiates without a JS command (future auto-stop, device disconnect, etc.).
  */
 function recorderService() {
 	if (!isTauri()) return services.navigatorRecorder;
@@ -74,11 +77,11 @@ function createManualRecorder() {
 			if (data) _state = data;
 		});
 
-	if (isTauri()) {
-		void listen<WhisperingRecordingState>('recorder:state-changed', (event) => {
-			_state = event.payload;
-		});
-	}
+	const writeState = (state: WhisperingRecordingState) => {
+		_state = state;
+	};
+	services.navigatorRecorder.subscribe(writeState);
+	if (isTauri()) desktopServices.cpalRecorder.subscribe(writeState);
 
 	return {
 		get state(): WhisperingRecordingState {
@@ -113,7 +116,6 @@ function createManualRecorder() {
 				});
 			}
 
-			_state = 'RECORDING';
 			return Ok(deviceAcquisitionOutcome);
 		},
 
@@ -122,8 +124,6 @@ function createManualRecorder() {
 				await recorderService().stopRecording({
 					sendStatus: (options) => notify.loading({ id: toastId, ...options }),
 				});
-
-			_state = 'IDLE';
 
 			if (stopRecordingError) {
 				return WhisperingErr({
@@ -140,8 +140,6 @@ function createManualRecorder() {
 				await recorderService().cancelRecording({
 					sendStatus: (options) => notify.loading({ id: toastId, ...options }),
 				});
-
-			_state = 'IDLE';
 
 			if (cancelRecordingError) {
 				return WhisperingErr({


### PR DESCRIPTION
PR #1816 moved the manual recorder's state from a TanStack-Query poll into a `$state`-owned singleton, and registered a `'recorder:state-changed'` Tauri event listener that was a no-op placeholder. Rust never emitted, so any state change Rust initiated outside a JS-driven mutation (auto-stop on silence, device disconnect, crash recovery ; none today, all on the roadmap) would silently desync the UI. This branch closes the loop: Rust now announces every transition, the JS-side service layer relays it, and the dual-write that mirrored every JS-driven mutation has been collapsed into a single subscribe channel.

```
Before                                  After
──────                                  ─────
Rust mutates  ──────  silent            Rust mutates  ──emit──▶  Tauri event
                                                                        │
JS sets _state  ───▶  _state                                            ▼
(eager mirror in 3 methods)             cpalRecorder.subscribe ──▶ writeState ──▶ _state
                                                                        ▲
Listener registered, no-op              navigatorRecorder.subscribe ────┘
                                        (active service drives _state; inactive is silent)
```

The first commit is the feature itself. Five commands gain `emit` at the command boundary ; `start_recording`, `stop_recording`, `cancel_recording`, `close_recording_session`, and `init_recording_session`. The last one needed coverage because `init_session` calls `close_session` internally as cleanup, which is a real mutation path: a re-init mid-recording would otherwise transition `RECORDING → IDLE` silently.

Three implementation choices worth flagging. The payload is a typed `serde` enum, not a string literal, so a typo on the Rust side is now a compile error:

```rust
#[derive(Serialize, Clone, Copy, Debug)]
#[serde(rename_all = "UPPERCASE")]
enum RecordingState { Idle, Recording }
```

The mutex guard is dropped before emit ; every command uses a scope block, mutates, and emits after the `MutexGuard` falls out of scope. DeepWiki confirms this is the canonical pattern for Tauri 2 commands: holding `std::sync::Mutex` across `app_handle.emit(...)` is a reentrancy risk if an event handler ever reaches back into the same state. No deadlock today (the JS listener just writes a `$state`), but the structural guarantee comes free.

Emit failures are logged at warn level, not propagated. A failed emit is exactly the failure mode this PR exists to detect, but it should not fail the command ; the user's recording still succeeded:

```rust
fn emit_recording_state(app: &AppHandle, state: RecordingState) {
    if let Err(e) = app.emit(RECORDER_STATE_CHANGED, state) {
        warn!("Failed to emit {} = {:?}: {}", RECORDER_STATE_CHANGED, state, e);
    }
}
```

---

**The second commit renames domain types so they pass the one-sentence test.**

Before: `RecorderState` was the Rust struct holding threads, channels, the WAV writer, and atomics. `RecorderStateEvent` was the wire payload `IDLE | RECORDING`. Both lived adjacent and shared a name root, so a first-time reader sees `RecorderState` and `RecorderStateEvent` next to each other and reasonably assumes they're the same concept. They aren't.

```
recorder.rs    RecorderState (struct of threads, writer, atomics)  ──▶  Recorder
commands.rs    RecorderStateEvent (wire payload IDLE | RECORDING)  ──▶  RecordingState
commands.rs    emit_recorder_state                                 ──▶  emit_recording_state
```

Now each name fits in a sentence:

> A `Recorder` is the recorder.
> A `RecordingState` is whether we're recording.

This commit also drops the `AppData` wrapper. It held one field (`recorder: Mutex<Recorder>`), was the only place named after "application data" in the crate, and existed for hypothetical future growth that didn't happen. Tauri now manages `Mutex<Recorder>` directly:

```rust
// Before                              After
.manage(AppData::new())                .manage(Mutex::new(Recorder::new()))
state: State<'_, AppData>              recorder: State<'_, Mutex<Recorder>>
state.recorder.lock()                  recorder.lock()
```

If a second piece of Tauri-managed state shows up later, introduce a struct then. YAGNI applied.

---

**The third commit clarifies the `attach-primitive` skill's scope.**

The skill's "use `attach*` for side-effectful primitives" rule was being misapplied to factories outside `packages/workspace`. The rule is contextual: `attach*` specifically means "side effects registered onto a *subject argument*" (a Y.Doc or sibling attachment). `createManualRecorder` doesn't take a subject ; it builds a module-singleton that bootstraps itself. The new rule:

> The discriminator is "what is being attached to what?" If there's no subject on the left side of that question, it's `create*`.

Module-singleton factories like `createManualRecorder` keep the `create*` prefix even when they perform I/O at construction time. The side effects belong to the singleton itself, not to an external subject.

---

**The fourth commit is the asymmetric win on the JS side: unify all state writes through `service.subscribe(handler)`.**

Before, recorder state was written eagerly in `manualRecorder.startRecording`/`stopRecording`/`cancelRecording` AND via the Tauri event listener. Both wrote the same value (idempotent), but "who is the source of truth" had no clear answer, and JS- vs Rust-initiated state transitions took different code paths.

Now every recorder service exposes `subscribe(handler)` and is the sole publisher of its own state changes:

```typescript
// types.ts ; the new contract
interface RecorderService {
    // ... existing methods
    subscribe(handler: (state: WhisperingRecordingState) => void): () => void;
}

// navigator.ts ; fires notify('RECORDING' | 'IDLE') from its own success paths
const subscribers = new Set<(state: WhisperingRecordingState) => void>();
const notify = (state) => { for (const h of subscribers) h(state); };

// cpal.ts ; wraps the existing Rust 'recorder:state-changed' Tauri event
subscribe(handler) {
    const unlistenPromise = listen<WhisperingRecordingState>(
        'recorder:state-changed',
        (event) => handler(event.payload),
    );
    return () => { void unlistenPromise.then((unlisten) => unlisten()); };
}

// manualRecorder ; one handler, two subscriptions, zero eager writes
const writeState = (state) => { _state = state; };
services.navigatorRecorder.subscribe(writeState);
if (isTauri()) desktopServices.cpalRecorder.subscribe(writeState);
```

`manualRecorder` subscribes to both at construction (cpal only on Tauri). The active service drives `_state`; the inactive one stays silent. The eager writes inside the three mutation methods are gone ; the subscribe handler covers every transition.

Why this is a real win, not just shape-shuffling. Single source of truth per mode: web mode, navigator owns it; CPAL mode, Rust owns it and the cpal service relays. No "JS optimistic write that has to be kept in sync with what the service actually does." Rust-initiated state changes (the future auto-stop, device disconnect, crash recovery paths) automatically reach the UI through the same channel JS-initiated changes use. Future modes (cloud recorder, etc.) plug in by implementing `subscribe()` ; no extra wiring in `manualRecorder`.

The bootstrap call (`getRecorderState()` at module load) stays. It covers the gap between page reload and the first subscribe event: a Rust CPAL session can outlive a JS reload, so the initial snapshot is needed to recover the pre-reload state before any new transition fires.

---

**The fifth commit pulls module-level mutable state into factory closures.**

Both service files held `let activeRecording` (and, after the subscribe refactor, navigator also held `const subscribers`) at module scope, with the service exported as a pre-built object literal. That made the singleton-ness implicit, leaked state across tests, and didn't match the rest of the codebase's `create*` factory convention. Wrapping each in a `createNavigatorRecorder()` / `createCpalRecorder()` factory fixes all three without changing the public surface:

```typescript
// Before
let activeRecording: ... | null = null;
const subscribers = new Set<...>();
export const NavigatorRecorderServiceLive: RecorderService = { ... };

// After
function createNavigatorRecorder(): RecorderService {
    let activeRecording: ... | null = null;
    const subscribers = new Set<...>();
    return { ... };
}
export const NavigatorRecorderServiceLive: RecorderService =
    createNavigatorRecorder();
```

Same singleton at the application level (one `*Live` instance per import), but state now lives in the factory closure. Tests can construct an isolated instance via `createNavigatorRecorder()`. The cpal diff is large mostly due to re-indentation; the only semantic change is moving `activeRecording` into the factory closure.

The `*Live` export name is preserved to stay consistent with the 40+ other services in the codebase. A broader sweep to drop the vestigial `Live` suffix (no `*Test` counterparts exist anywhere) is a separate concern.

---

**Known follow-ups that came out of the design review and are not in this PR.**

Today `recorderService()` re-resolves which service to use on every call, so a settings toggle between `startRecording` and `stopRecording` would start on one backend and try to stop on the other. A session-based API (`startRecording(opts) => Recording` where the returned `Recording` owns `stop`/`cancel`) would fix this latent bug, but it's a bigger refactor and the bug is mostly theoretical.

A separate research task was kicked off comparing this architecture to `cjpais/Handy` ; specifically whether progressive WAV writing earns its complexity vs Handy's in-memory `Vec<f32>` approach, plus possible adoptions for cross-platform mute, error categorization helpers, open/start split for an always-on mic mode, and short-recording padding. That report will inform whether to invest in larger structural changes.