### PR TITLE
refactor(whispering): per-Recording lifecycle + recorder hardening

### DIFF
--- a/apps/whispering/src-tauri/src/recorder/recorder.rs
+++ b/apps/whispering/src-tauri/src/recorder/recorder.rs
@@ -476,3 +476,85 @@ impl Drop for Recorder {
         let _ = self.close_session();
     }
 }
+
+/// Categorize a raw cpal/audio error message as "microphone access was denied".
+///
+/// cpal surfaces permission denials as opaque platform strings; we string-match
+/// them so the JS side can show a "please grant mic permission" UI instead of a
+/// generic error toast.
+///
+/// Inspired by Handy (MIT licensed):
+/// https://github.com/cjpais/Handy/blob/main/src-tauri/src/audio_toolkit/audio/recorder.rs
+/// (`is_microphone_access_denied`)
+pub fn is_microphone_access_denied(error_message: &str) -> bool {
+    let normalized = error_message.to_lowercase();
+    normalized.contains("access is denied")
+        || normalized.contains("permission denied")
+        // Windows WASAPI HRESULT E_ACCESSDENIED.
+        || normalized.contains("0x80070005")
+}
+
+/// Categorize a raw cpal/audio error message as "no input device available".
+///
+/// CoreAudio in particular produces an unhelpful "Failed to fetch preferred
+/// config" / "An unknown error" string when no input device is connected;
+/// match it here so the JS side can show a "please plug in a microphone" UI.
+///
+/// Inspired by Handy (MIT licensed):
+/// https://github.com/cjpais/Handy/blob/main/src-tauri/src/audio_toolkit/audio/recorder.rs
+/// (`is_no_input_device_error`)
+pub fn is_no_input_device_error(error_message: &str) -> bool {
+    let normalized = error_message.to_lowercase();
+    normalized.contains("no input device found")
+        || normalized.contains("no default input device available")
+        || (normalized.contains("failed to fetch preferred config")
+            && normalized.contains("coreaudio"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_access_is_denied() {
+        assert!(is_microphone_access_denied("Access is denied"));
+    }
+
+    #[test]
+    fn detects_permission_denied() {
+        assert!(is_microphone_access_denied("permission denied"));
+    }
+
+    #[test]
+    fn detects_windows_error_code() {
+        assert!(is_microphone_access_denied("WASAPI error: 0x80070005"));
+    }
+
+    #[test]
+    fn does_not_match_unrelated_permission_errors() {
+        assert!(!is_microphone_access_denied("device not found"));
+    }
+
+    #[test]
+    fn detects_no_input_device() {
+        assert!(is_no_input_device_error("No input device found"));
+    }
+
+    #[test]
+    fn detects_no_default_input_device() {
+        assert!(is_no_input_device_error("No default input device available"));
+    }
+
+    #[test]
+    fn detects_coreaudio_config_error() {
+        assert!(is_no_input_device_error(
+            "Failed to fetch preferred config: A backend-specific error has occurred: An unknown error unknown to the coreaudio-rs API occurred"
+        ));
+    }
+
+    #[test]
+    fn does_not_match_permission_errors_as_no_device() {
+        assert!(!is_no_input_device_error("permission denied"));
+        assert!(!is_no_input_device_error("device not found"));
+    }
+}

--- a/apps/whispering/src-tauri/src/recorder/wav_writer.rs
+++ b/apps/whispering/src-tauri/src/recorder/wav_writer.rs
@@ -165,6 +165,7 @@ impl WavWriter {
 
     /// Finalize the WAV file with correct headers
     pub fn finalize(&mut self) -> io::Result<()> {
+        self.pad_short_recording()?;
         self.update_headers()?;
         self.writer.flush()?;
 
@@ -175,6 +176,46 @@ impl WavWriter {
             self.get_duration_seconds()
         );
 
+        Ok(())
+    }
+
+    /// Pad recordings shorter than 1 second up to 1.25 seconds with silence.
+    ///
+    /// Whisper is unreliable on very short clips and tends to hallucinate
+    /// common phrases like "Thank you for watching!" on near-silent or
+    /// sub-second inputs. Padding to 1.25s suppresses this across model
+    /// sizes without meaningfully changing the user's transcript.
+    ///
+    /// Inspired by Handy's stop_recording padding (MIT licensed):
+    /// https://github.com/cjpais/Handy/blob/main/src-tauri/src/managers/audio.rs
+    /// (search for "Pad if very short")
+    ///
+    /// Empty recordings (0 samples) are left alone; they indicate an init
+    /// failure, not a genuine short clip, and should surface as such.
+    fn pad_short_recording(&mut self) -> io::Result<()> {
+        let samples_per_second = self.sample_rate as u64 * self.channels as u64;
+        let pad_target = samples_per_second * 5 / 4; // 1.25 seconds
+
+        if self.samples_written == 0 || self.samples_written >= samples_per_second {
+            return Ok(());
+        }
+
+        let samples_to_add = pad_target - self.samples_written;
+        let zero_bytes = 0.0f32.to_le_bytes();
+        for _ in 0..samples_to_add {
+            self.writer.write_all(&zero_bytes)?;
+        }
+
+        debug!(
+            "Padded short recording: added {} silent samples ({} -> {} total, {:.2}s)",
+            samples_to_add,
+            self.samples_written,
+            self.samples_written + samples_to_add,
+            (self.samples_written + samples_to_add) as f32
+                / (self.sample_rate as f32 * self.channels as f32)
+        );
+
+        self.samples_written += samples_to_add;
         Ok(())
     }
 

--- a/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
+++ b/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
@@ -67,6 +67,11 @@ function createCpalRecorder(): RecorderService {
 		let tauriUnlisten: Promise<UnlistenFn> | null = null;
 
 		const notify = (state: WhisperingRecordingState) => {
+			// Idempotent: same-state notifications collapse to a no-op. Rust
+			// emits 'recorder:state-changed' IDLE from `stop_recording`, then
+			// our explicit `teardown()` also notifies IDLE; without this
+			// guard we'd fire the handler twice for one transition.
+			if (currentState === state) return;
 			currentState = state;
 			for (const handler of subscribers) handler(state);
 		};

--- a/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
+++ b/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
@@ -1,11 +1,8 @@
 import { invoke as tauriInvoke } from '@tauri-apps/api/core';
-import { listen } from '@tauri-apps/api/event';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { remove } from '@tauri-apps/plugin-fs';
 import { Err, Ok, type Result, tryAsync } from 'wellcrafted/result';
-import type {
-	CancelRecordingResult,
-	WhisperingRecordingState,
-} from '$lib/constants/audio';
+import type { WhisperingRecordingState } from '$lib/constants/audio';
 import { FsServiceLive } from '$lib/services/desktop/fs';
 import { categorizeRecorderError } from '$lib/services/recorder/categorize-error';
 import {
@@ -14,6 +11,7 @@ import {
 	type Device,
 	type DeviceAcquisitionOutcome,
 	RecorderError,
+	type Recording,
 	type RecorderService,
 } from '$lib/services/recorder/types';
 
@@ -48,48 +46,178 @@ const enumerateDevices = async (): Promise<Result<Device[], RecorderError>> => {
 };
 
 /**
- * CPAL recorder service that uses the Rust CPAL method.
- * This service handles device enumeration, recording start/stop operations, and file management
- * for desktop audio recording using the CPAL library.
+ * CPAL recorder service that uses the Rust CPAL backend.
  *
- * Constructed via a factory so `activeRecording` lives in the closure rather
- * than at module scope. The exported `CpalRecorderServiceLive` is the single
- * application-level instance; tests can call `createCpalRecorder()` for an
- * isolated one.
+ * Constructed via a factory so the per-session lifecycle (stop/cancel/
+ * subscribe) lives on the returned `Recording`. The service itself only
+ * holds a pointer to the active session for rehydration through
+ * `getActiveRecording`; once stop/cancel runs, that pointer clears.
+ *
+ * Unlike navigator, a cpal session can outlive a JS reload because the
+ * Rust process keeps the cpal stream alive. `getActiveRecording` consults
+ * Rust via `get_current_recording_id` and reattaches a new `Recording`
+ * wrapper if Rust still has one going.
  */
 function createCpalRecorder(): RecorderService {
-	// Tracks the recordingId the JS caller passed to startRecording so we can
-	// return it from stopRecording without a Rust round-trip. Cleared on stop
-	// or cancel.
-	let activeRecording: { recordingId: string } | null = null;
+	let activeRecording: Recording | null = null;
 
-	return {
-		/**
-		 * Gets the current state of the recorder.
-		 */
-		getRecorderState: async (): Promise<
-			Result<WhisperingRecordingState, RecorderError>
-		> => {
-			const { data: recordingId, error: getRecorderStateError } = await invoke<
-				string | null
-			>('get_current_recording_id');
-			if (getRecorderStateError)
-				return RecorderError.GetStateFailed({
-					cause: getRecorderStateError,
+	function buildRecording(recordingId: string): Recording {
+		const subscribers = new Set<(s: WhisperingRecordingState) => void>();
+		let currentState: WhisperingRecordingState = 'RECORDING';
+		let tauriUnlisten: Promise<UnlistenFn> | null = null;
+
+		const notify = (state: WhisperingRecordingState) => {
+			currentState = state;
+			for (const handler of subscribers) handler(state);
+		};
+
+		const ensureTauriListener = () => {
+			if (tauriUnlisten) return;
+			// Rust emits 'recorder:state-changed' from every mutation path (see
+			// src-tauri/src/recorder/commands.rs). Forward to subscribers so
+			// Rust-initiated transitions (future auto-stop, device disconnect)
+			// reach the UI.
+			tauriUnlisten = listen<WhisperingRecordingState>(
+				'recorder:state-changed',
+				(event) => notify(event.payload),
+			);
+		};
+
+		const teardown = () => {
+			if (activeRecording === recording) activeRecording = null;
+			if (tauriUnlisten) {
+				void tauriUnlisten.then((unlisten) => unlisten());
+				tauriUnlisten = null;
+			}
+			notify('IDLE');
+		};
+
+		const recording: Recording = {
+			recordingId,
+			backend: 'cpal',
+
+			stop: async ({ sendStatus }) => {
+				const { data: audioRecording, error: stopRecordingError } =
+					await invoke<AudioRecording>('stop_recording');
+				if (stopRecordingError) {
+					teardown();
+					return RecorderError.StopFailed({ cause: stopRecordingError });
+				}
+
+				const { filePath } = audioRecording;
+				if (!filePath) {
+					teardown();
+					return RecorderError.NoFilePath();
+				}
+
+				sendStatus({
+					title: '📁 Reading Recording',
+					description: 'Loading your recording from disk...',
 				});
 
-			return Ok(recordingId ? 'RECORDING' : 'IDLE');
+				const { data: blob, error: readRecordingFileError } =
+					await FsServiceLive.pathToBlob(filePath);
+				if (readRecordingFileError) {
+					teardown();
+					return RecorderError.ReadFileFailed({
+						cause: readRecordingFileError,
+					});
+				}
+
+				sendStatus({
+					title: '🔄 Closing Session',
+					description: 'Cleaning up recording resources...',
+				});
+				const { error: closeError } = await invoke<void>(
+					'close_recording_session',
+				);
+				if (closeError) {
+					// Log but don't fail the stop operation
+					console.error('Failed to close recording session:', closeError);
+				}
+
+				teardown();
+				return Ok({ blob, recordingId });
+			},
+
+			cancel: async ({ sendStatus }) => {
+				sendStatus({
+					title: '🛑 Cancelling',
+					description:
+						'Safely stopping your recording and cleaning up resources...',
+				});
+
+				// First get the recording data to know if there's a file to delete
+				const { data: audioRecording } =
+					await invoke<AudioRecording>('stop_recording');
+
+				if (audioRecording?.filePath) {
+					const filePath = audioRecording.filePath;
+					const { error: removeError } = await tryAsync({
+						try: () => remove(filePath),
+						catch: (error) => RecorderError.FileDeleteFailed({ cause: error }),
+					});
+					if (removeError)
+						sendStatus({
+							title: '❌ Error Deleting Recording File',
+							description:
+								"We couldn't delete the recording file. Continuing with the cancellation process...",
+						});
+				}
+
+				sendStatus({
+					title: '🔄 Closing Session',
+					description: 'Cleaning up recording resources...',
+				});
+				const { error: closeError } = await invoke<void>(
+					'close_recording_session',
+				);
+				if (closeError) {
+					console.error('Failed to close recording session:', closeError);
+				}
+
+				teardown();
+				return Ok({ status: 'cancelled' });
+			},
+
+			subscribe(handler) {
+				ensureTauriListener();
+				subscribers.add(handler);
+				// Fire current state immediately so callers don't have to mirror
+				// 'RECORDING' at attach time.
+				handler(currentState);
+				return () => {
+					subscribers.delete(handler);
+				};
+			},
+		};
+
+		return recording;
+	}
+
+	return {
+		getActiveRecording: async (): Promise<
+			Result<Recording | null, RecorderError>
+		> => {
+			// If we still hold the in-memory pointer, prefer it; otherwise probe
+			// Rust in case a recording outlived a JS reload.
+			if (activeRecording) return Ok(activeRecording);
+
+			const { data: liveRecordingId, error: getIdError } = await invoke<
+				string | null
+			>('get_current_recording_id');
+			if (getIdError) {
+				return RecorderError.GetStateFailed({ cause: getIdError });
+			}
+			if (!liveRecordingId) return Ok(null);
+
+			const rehydrated = buildRecording(liveRecordingId);
+			activeRecording = rehydrated;
+			return Ok(rehydrated);
 		},
 
 		enumerateDevices,
 
-		/**
-		 * Starts a recording session with the specified parameters.
-		 * Handles device selection, fallback logic, and recording initialization.
-		 *
-		 * @param params - Recording parameters including device ID, recording ID, output folder, and sample rate
-		 * @param callbacks - Callback functions for status updates
-		 */
 		startRecording: async (
 			{
 				selectedDeviceId,
@@ -98,74 +226,58 @@ function createCpalRecorder(): RecorderService {
 				sampleRate,
 			}: CpalRecordingParams,
 			{ sendStatus },
-		): Promise<Result<DeviceAcquisitionOutcome, RecorderError>> => {
+		) => {
 			const { data: devices, error: enumerateError } = await enumerateDevices();
 			if (enumerateError) return Err(enumerateError);
 
-			/**
-			 * Acquires a recording device, either the selected one or a fallback.
-			 */
-			const acquireDevice = (): Result<
-				DeviceAcquisitionOutcome,
-				RecorderError
-			> => {
-				const deviceIds = devices.map((d) => d.id);
-				const fallbackDeviceId = deviceIds.at(0);
-				if (!fallbackDeviceId) {
-					return RecorderError.NoDevice({
-						message: selectedDeviceId
-							? "We couldn't find the selected microphone. Make sure it's connected and try again!"
-							: "We couldn't find any microphones. Make sure they're connected and try again!",
-					});
-				}
+			const deviceIds = devices.map((d) => d.id);
+			const fallbackDeviceId = deviceIds.at(0);
+			if (!fallbackDeviceId) {
+				return RecorderError.NoDevice({
+					message: selectedDeviceId
+						? "We couldn't find the selected microphone. Make sure it's connected and try again!"
+						: "We couldn't find any microphones. Make sure they're connected and try again!",
+				});
+			}
 
+			const deviceOutcome: DeviceAcquisitionOutcome = (() => {
 				if (!selectedDeviceId) {
 					sendStatus({
 						title: '🔍 No Device Selected',
 						description:
 							"No worries! We'll find the best microphone for you automatically...",
 					});
-					return Ok({
+					return {
 						outcome: 'fallback',
 						reason: 'no-device-selected',
 						deviceId: fallbackDeviceId,
-					});
+					};
 				}
 
-				// Check if the selected device exists in the devices array
-				const deviceExists = deviceIds.includes(selectedDeviceId);
-
-				if (deviceExists)
-					return Ok({ outcome: 'success', deviceId: selectedDeviceId });
+				if (deviceIds.includes(selectedDeviceId)) {
+					return { outcome: 'success', deviceId: selectedDeviceId };
+				}
 
 				sendStatus({
 					title: '⚠️ Finding a New Microphone',
 					description:
 						"That microphone isn't available. Let's try finding another one...",
 				});
-
-				return Ok({
+				return {
 					outcome: 'fallback',
 					reason: 'preferred-device-unavailable',
 					deviceId: fallbackDeviceId,
-				});
-			};
+				};
+			})();
 
-			const { data: deviceOutcome, error: acquireDeviceError } =
-				acquireDevice();
-			if (acquireDeviceError) return Err(acquireDeviceError);
-
-			// Use the device from the outcome
 			const deviceIdentifier = deviceOutcome.deviceId;
 
-			// Now initialize recording with the chosen device
 			sendStatus({
 				title: '🎤 Setting Up',
 				description:
 					'Initializing your recording session and checking microphone access...',
 			});
 
-			// Convert sample rate string to number if provided
 			const sampleRateNum = sampleRate
 				? Number.parseInt(sampleRate, 10)
 				: undefined;
@@ -200,160 +312,9 @@ function createCpalRecorder(): RecorderService {
 					RecorderError.StartFailed({ cause: startRecordingError })
 				);
 
-			activeRecording = { recordingId };
-			return Ok(deviceOutcome);
-		},
-
-		/**
-		 * Stops the current recording session and returns the recorded audio as a Blob.
-		 * Handles file reading, session cleanup, and resource management.
-		 *
-		 * @param callbacks - Callback functions for status updates
-		 */
-		stopRecording: async ({
-			sendStatus,
-		}): Promise<Result<{ blob: Blob; recordingId: string }, RecorderError>> => {
-			// Fast path uses the recordingId captured at startRecording. After a JS
-			// reload mid-recording the closure is gone but Rust is still going; fall
-			// back to asking Rust which recording is currently active.
-			let recordingId: string;
-			if (activeRecording) {
-				recordingId = activeRecording.recordingId;
-				activeRecording = null;
-			} else {
-				const { data: liveRecordingId, error: getIdError } = await invoke<
-					string | null
-				>('get_current_recording_id');
-				if (getIdError) {
-					return RecorderError.GetStateFailed({ cause: getIdError });
-				}
-				if (!liveRecordingId) {
-					return RecorderError.NotRecording({
-						message:
-							'Cannot stop recording because no active recording session was found. Make sure you have started recording before attempting to stop it.',
-					});
-				}
-				recordingId = liveRecordingId;
-			}
-
-			const { data: audioRecording, error: stopRecordingError } =
-				await invoke<AudioRecording>('stop_recording');
-			if (stopRecordingError) {
-				return RecorderError.StopFailed({ cause: stopRecordingError });
-			}
-
-			const { filePath } = audioRecording;
-			// Desktop recorder should always write to a file
-			if (!filePath) {
-				return RecorderError.NoFilePath();
-			}
-
-			// Read the WAV file from disk
-			sendStatus({
-				title: '📁 Reading Recording',
-				description: 'Loading your recording from disk...',
-			});
-
-			const { data: blob, error: readRecordingFileError } =
-				await FsServiceLive.pathToBlob(filePath);
-			if (readRecordingFileError)
-				return RecorderError.ReadFileFailed({
-					cause: readRecordingFileError,
-				});
-			// Close the recording session after stopping
-			sendStatus({
-				title: '🔄 Closing Session',
-				description: 'Cleaning up recording resources...',
-			});
-			const { error: closeError } = await invoke<void>(
-				'close_recording_session',
-			);
-			if (closeError) {
-				// Log but don't fail the stop operation
-				console.error('Failed to close recording session:', closeError);
-			}
-
-			return Ok({ blob, recordingId });
-		},
-
-		/**
-		 * Cancels the current recording session and cleans up resources.
-		 * Deletes any temporary recording files and closes the recording session.
-		 *
-		 * @param callbacks - Callback functions for status updates
-		 */
-		cancelRecording: async ({
-			sendStatus,
-		}): Promise<Result<CancelRecordingResult, RecorderError>> => {
-			// Check current state first
-			const { data: recordingId, error: getRecordingIdError } = await invoke<
-				string | null
-			>('get_current_recording_id');
-			if (getRecordingIdError) {
-				return RecorderError.GetStateFailed({
-					cause: getRecordingIdError,
-				});
-			}
-
-			if (!recordingId) {
-				activeRecording = null;
-				return Ok({ status: 'no-recording' });
-			}
-
-			activeRecording = null;
-
-			sendStatus({
-				title: '🛑 Cancelling',
-				description:
-					'Safely stopping your recording and cleaning up resources...',
-			});
-
-			// First get the recording data to know if there's a file to delete
-			const { data: audioRecording } =
-				await invoke<AudioRecording>('stop_recording');
-
-			// If there's a file path, delete the file using Tauri FS plugin
-			if (audioRecording?.filePath) {
-				const filePath = audioRecording.filePath;
-				const { error: removeError } = await tryAsync({
-					try: () => remove(filePath),
-					catch: (error) => RecorderError.FileDeleteFailed({ cause: error }),
-				});
-				if (removeError)
-					sendStatus({
-						title: '❌ Error Deleting Recording File',
-						description:
-							"We couldn't delete the recording file. Continuing with the cancellation process...",
-					});
-			}
-
-			// Close the recording session after cancelling
-			sendStatus({
-				title: '🔄 Closing Session',
-				description: 'Cleaning up recording resources...',
-			});
-			const { error: closeError } = await invoke<void>(
-				'close_recording_session',
-			);
-			if (closeError) {
-				// Log but don't fail the cancel operation
-				console.error('Failed to close recording session:', closeError);
-			}
-
-			return Ok({ status: 'cancelled' });
-		},
-
-		subscribe(handler) {
-			// Rust emits 'recorder:state-changed' from every mutation path (see
-			// src-tauri/src/recorder/commands.rs). Wrap the Tauri listener so this
-			// service exposes the same subscribe shape as the navigator service.
-			const unlistenPromise = listen<WhisperingRecordingState>(
-				'recorder:state-changed',
-				(event) => handler(event.payload),
-			);
-			return () => {
-				void unlistenPromise.then((unlisten) => unlisten());
-			};
+			const recording = buildRecording(recordingId);
+			activeRecording = recording;
+			return Ok({ recording, deviceAcquisition: deviceOutcome });
 		},
 	};
 }

--- a/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
+++ b/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
@@ -11,8 +11,8 @@ import {
 	type Device,
 	type DeviceAcquisitionOutcome,
 	RecorderError,
-	type Recording,
 	type RecorderService,
+	type Recording,
 } from '$lib/services/recorder/types';
 
 /**

--- a/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
+++ b/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
@@ -7,6 +7,7 @@ import type {
 	WhisperingRecordingState,
 } from '$lib/constants/audio';
 import { FsServiceLive } from '$lib/services/desktop/fs';
+import { categorizeRecorderError } from '$lib/services/recorder/categorize-error';
 import {
 	asDeviceIdentifier,
 	type CpalRecordingParams,
@@ -179,9 +180,12 @@ function createCpalRecorder(): RecorderService {
 				},
 			);
 			if (initRecordingSessionError)
-				return RecorderError.InitFailed({
-					cause: initRecordingSessionError,
-				});
+				return (
+					categorizeRecorderError(initRecordingSessionError) ??
+					RecorderError.InitFailed({
+						cause: initRecordingSessionError,
+					})
+				);
 
 			sendStatus({
 				title: '🎙️ Starting Recording',
@@ -191,7 +195,10 @@ function createCpalRecorder(): RecorderService {
 			const { error: startRecordingError } =
 				await invoke<void>('start_recording');
 			if (startRecordingError)
-				return RecorderError.StartFailed({ cause: startRecordingError });
+				return (
+					categorizeRecorderError(startRecordingError) ??
+					RecorderError.StartFailed({ cause: startRecordingError })
+				);
 
 			activeRecording = { recordingId };
 			return Ok(deviceOutcome);

--- a/apps/whispering/src/lib/services/recorder/categorize-error.ts
+++ b/apps/whispering/src/lib/services/recorder/categorize-error.ts
@@ -1,0 +1,72 @@
+import { RecorderError } from './types';
+
+/**
+ * Inspect a raw recorder-related error cause and, if it matches a known
+ * permission-denied or no-input-device pattern, return the typed RecorderError
+ * variant (already wrapped in Err). Callers fall back to a generic variant
+ * (InitFailed, StartFailed, StreamAcquisition, etc.) when this returns null.
+ *
+ * Mirrors the Rust-side helpers in src-tauri/src/recorder/recorder.rs
+ * (`is_microphone_access_denied`, `is_no_input_device_error`), and also
+ * handles browser DOMException names from getUserMedia and wellcrafted
+ * tagged errors from device-stream.
+ *
+ * Inspired by Handy (MIT licensed):
+ * https://github.com/cjpais/Handy/blob/main/src-tauri/src/audio_toolkit/audio/recorder.rs
+ */
+export function categorizeRecorderError(cause: unknown) {
+	// wellcrafted tagged errors (e.g. DeviceStreamError) expose a `name` field.
+	if (cause && typeof cause === 'object' && 'name' in cause) {
+		const name = (cause as { name: unknown }).name;
+		// Browser: getUserMedia DOMException codes.
+		if (name === 'NotAllowedError' || name === 'SecurityError') {
+			return RecorderError.MicrophonePermissionDenied({ cause });
+		}
+		if (name === 'NotFoundError' || name === 'OverconstrainedError') {
+			return RecorderError.NoInputDevice({ cause });
+		}
+		// device-stream's own tag (we re-categorize so the toast layer can
+		// branch on RecorderError variants without importing DeviceStreamError).
+		if (name === 'PermissionDenied') {
+			return RecorderError.MicrophonePermissionDenied({ cause });
+		}
+		if (name === 'NoDevicesFound') {
+			return RecorderError.NoInputDevice({ cause });
+		}
+	}
+
+	// Rust returns errors as plain strings via Tauri invoke. String-match the
+	// same patterns the Rust-side helpers do so JS callers get typed variants.
+	const message = extractMessageString(cause);
+	if (!message) return null;
+	const normalized = message.toLowerCase();
+
+	if (
+		normalized.includes('access is denied') ||
+		normalized.includes('permission denied') ||
+		// Windows WASAPI HRESULT E_ACCESSDENIED.
+		normalized.includes('0x80070005')
+	) {
+		return RecorderError.MicrophonePermissionDenied({ cause });
+	}
+
+	if (
+		normalized.includes('no input device found') ||
+		normalized.includes('no default input device available') ||
+		(normalized.includes('failed to fetch preferred config') &&
+			normalized.includes('coreaudio'))
+	) {
+		return RecorderError.NoInputDevice({ cause });
+	}
+
+	return null;
+}
+
+function extractMessageString(cause: unknown): string | null {
+	if (typeof cause === 'string') return cause;
+	if (cause && typeof cause === 'object' && 'message' in cause) {
+		const message = (cause as { message: unknown }).message;
+		if (typeof message === 'string') return message;
+	}
+	return null;
+}

--- a/apps/whispering/src/lib/services/recorder/navigator.ts
+++ b/apps/whispering/src/lib/services/recorder/navigator.ts
@@ -13,6 +13,7 @@ import type {
 	DeviceAcquisitionOutcome,
 	DeviceIdentifier,
 } from '$lib/services/recorder/types';
+import { categorizeRecorderError } from './categorize-error';
 import type { NavigatorRecordingParams, RecorderService } from './types';
 import { RecorderError } from './types';
 
@@ -76,7 +77,10 @@ function createNavigatorRecorder(): RecorderService {
 			const { data: streamResult, error: acquireStreamError } =
 				await getRecordingStream({ selectedDeviceId, sendStatus });
 			if (acquireStreamError) {
-				return RecorderError.StreamAcquisition({ cause: acquireStreamError });
+				return (
+					categorizeRecorderError(acquireStreamError) ??
+					RecorderError.StreamAcquisition({ cause: acquireStreamError })
+				);
 			}
 
 			const { stream, deviceOutcome } = streamResult;

--- a/apps/whispering/src/lib/services/recorder/navigator.ts
+++ b/apps/whispering/src/lib/services/recorder/navigator.ts
@@ -48,6 +48,11 @@ function createNavigatorRecorder(): RecorderService {
 		let currentState: WhisperingRecordingState = 'RECORDING';
 
 		const notify = (state: WhisperingRecordingState) => {
+			// Idempotent: same-state notifications collapse to a no-op. Keeps
+			// the teardown safe to call from multiple paths without double
+			// firing 'IDLE' (e.g. an external listener and an explicit
+			// teardown for the same transition).
+			if (currentState === state) return;
 			currentState = state;
 			for (const handler of subscribers) handler(state);
 		};

--- a/apps/whispering/src/lib/services/recorder/navigator.ts
+++ b/apps/whispering/src/lib/services/recorder/navigator.ts
@@ -1,6 +1,5 @@
 import { Err, Ok, type Result, tryAsync, trySync } from 'wellcrafted/result';
 import {
-	type CancelRecordingResult,
 	TIMESLICE_MS,
 	type WhisperingRecordingState,
 } from '$lib/constants/audio';
@@ -9,46 +8,137 @@ import {
 	enumerateDevices,
 	getRecordingStream,
 } from '$lib/services/device-stream';
-import type {
-	DeviceAcquisitionOutcome,
-	DeviceIdentifier,
-} from '$lib/services/recorder/types';
 import { categorizeRecorderError } from './categorize-error';
-import type { NavigatorRecordingParams, RecorderService } from './types';
+import type {
+	NavigatorRecordingParams,
+	Recording,
+	RecorderService,
+} from './types';
 import { RecorderError } from './types';
 
-type ActiveRecording = {
-	recordingId: string;
-	selectedDeviceId: DeviceIdentifier | null;
-	bitrateKbps: string;
+type ActiveSession = {
 	stream: MediaStream;
 	mediaRecorder: MediaRecorder;
 	recordedChunks: Blob[];
+	recording: Recording;
 };
 
 /**
  * Navigator recorder service that uses the MediaRecorder API.
  * Available in both browser and desktop environments.
  *
- * Constructed via a factory so all mutable state (`activeRecording`,
- * `subscribers`) lives in the closure rather than at module scope. The
- * exported `NavigatorRecorderServiceLive` is the single application-level
- * instance; tests can call `createNavigatorRecorder()` for an isolated one.
+ * Constructed via a factory so module-level state is just the single
+ * in-flight session, if any. The exposed surface is `startRecording`
+ * (factory), `getActiveRecording` (bootstrap), and `enumerateDevices`.
+ * Per-session lifecycle (stop/cancel/subscribe) lives on the returned
+ * `Recording` so toggling the backend setting mid-recording does not
+ * misroute teardown.
  */
 function createNavigatorRecorder(): RecorderService {
-	let activeRecording: ActiveRecording | null = null;
+	let activeSession: ActiveSession | null = null;
 
-	const subscribers = new Set<(state: WhisperingRecordingState) => void>();
+	function buildRecording(args: {
+		recordingId: string;
+		stream: MediaStream;
+		mediaRecorder: MediaRecorder;
+		recordedChunks: Blob[];
+	}): { session: ActiveSession; recording: Recording } {
+		const { recordingId, stream, mediaRecorder, recordedChunks } = args;
+		const subscribers = new Set<(s: WhisperingRecordingState) => void>();
+		let currentState: WhisperingRecordingState = 'RECORDING';
 
-	const notify = (state: WhisperingRecordingState) => {
-		for (const handler of subscribers) handler(state);
-	};
+		const notify = (state: WhisperingRecordingState) => {
+			currentState = state;
+			for (const handler of subscribers) handler(state);
+		};
+
+		const teardown = () => {
+			activeSession = null;
+			cleanupRecordingStream(stream);
+			notify('IDLE');
+		};
+
+		const recording: Recording = {
+			recordingId,
+			backend: 'navigator',
+
+			stop: async ({ sendStatus }) => {
+				sendStatus({
+					title: '⏸️ Finishing Recording',
+					description: 'Saving your audio...',
+				});
+
+				const { data: blob, error: stopError } = await tryAsync({
+					try: () =>
+						new Promise<Blob>((resolve) => {
+							mediaRecorder.addEventListener('stop', () => {
+								const audioBlob = new Blob(recordedChunks, {
+									type: mediaRecorder.mimeType,
+								});
+								resolve(audioBlob);
+							});
+							mediaRecorder.stop();
+						}),
+					catch: (error) => RecorderError.StopFailed({ cause: error }),
+				});
+
+				teardown();
+
+				if (stopError) return Err(stopError);
+
+				sendStatus({
+					title: '✅ Recording Saved',
+					description: 'Your recording is ready for transcription!',
+				});
+				return Ok({ blob, recordingId });
+			},
+
+			cancel: async ({ sendStatus }) => {
+				sendStatus({
+					title: '🛑 Cancelling',
+					description: 'Discarding your recording...',
+				});
+
+				mediaRecorder.stop();
+				teardown();
+
+				sendStatus({
+					title: '✨ Cancelled',
+					description: 'Recording discarded successfully!',
+				});
+
+				return Ok({ status: 'cancelled' });
+			},
+
+			subscribe(handler) {
+				subscribers.add(handler);
+				// Fire current state immediately so callers don't have to mirror
+				// 'RECORDING' themselves at attach time.
+				handler(currentState);
+				return () => {
+					subscribers.delete(handler);
+				};
+			},
+		};
+
+		const session: ActiveSession = {
+			stream,
+			mediaRecorder,
+			recordedChunks,
+			recording,
+		};
+		return { session, recording };
+	}
 
 	return {
-		getRecorderState: async (): Promise<
-			Result<WhisperingRecordingState, RecorderError>
+		getActiveRecording: async (): Promise<
+			Result<Recording | null, RecorderError>
 		> => {
-			return Ok(activeRecording ? 'RECORDING' : 'IDLE');
+			// Navigator state lives in this closure, so a JS reload zeroes it
+			// out; the MediaStream/MediaRecorder are also gone in that case.
+			// Always null after a reload; non-null only if startRecording fired
+			// within this module's lifetime and the session is still live.
+			return Ok(activeSession?.recording ?? null);
 		},
 
 		enumerateDevices: async () => {
@@ -62,9 +152,8 @@ function createNavigatorRecorder(): RecorderService {
 		startRecording: async (
 			{ selectedDeviceId, recordingId, bitrateKbps }: NavigatorRecordingParams,
 			{ sendStatus },
-		): Promise<Result<DeviceAcquisitionOutcome, RecorderError>> => {
-			// Ensure we're not already recording
-			if (activeRecording) {
+		) => {
+			if (activeSession) {
 				return RecorderError.AlreadyRecording();
 			}
 
@@ -73,7 +162,6 @@ function createNavigatorRecorder(): RecorderService {
 				description: 'Setting up your microphone...',
 			});
 
-			// Get the recording stream
 			const { data: streamResult, error: acquireStreamError } =
 				await getRecordingStream({ selectedDeviceId, sendStatus });
 			if (acquireStreamError) {
@@ -96,118 +184,26 @@ function createNavigatorRecorder(): RecorderService {
 			});
 
 			if (recorderError) {
-				// Clean up stream if recorder creation fails
 				cleanupRecordingStream(stream);
 				return Err(recorderError);
 			}
 
-			// Set up recording state and event handlers
 			const recordedChunks: Blob[] = [];
-
-			// Store active recording state
-			activeRecording = {
-				recordingId,
-				selectedDeviceId,
-				bitrateKbps,
-				stream,
-				mediaRecorder,
-				recordedChunks,
-			};
-
-			// Set up event handlers
 			mediaRecorder.addEventListener('dataavailable', (event: BlobEvent) => {
 				if (event.data.size) recordedChunks.push(event.data);
 			});
 
-			// Start recording
+			const { session, recording } = buildRecording({
+				recordingId,
+				stream,
+				mediaRecorder,
+				recordedChunks,
+			});
+			activeSession = session;
+
 			mediaRecorder.start(TIMESLICE_MS);
-			notify('RECORDING');
 
-			// Return the device acquisition outcome
-			return Ok(deviceOutcome);
-		},
-
-		stopRecording: async ({
-			sendStatus,
-		}): Promise<Result<{ blob: Blob; recordingId: string }, RecorderError>> => {
-			if (!activeRecording) {
-				return RecorderError.NotRecording({
-					message:
-						'Cannot stop recording because no active recording session was found. Make sure you have started recording before attempting to stop it.',
-				});
-			}
-
-			const recording = activeRecording;
-			activeRecording = null; // Clear immediately to prevent race conditions
-
-			sendStatus({
-				title: '⏸️ Finishing Recording',
-				description: 'Saving your audio...',
-			});
-
-			// Stop the recorder and wait for the final data
-			const { data: blob, error: stopError } = await tryAsync({
-				try: () =>
-					new Promise<Blob>((resolve) => {
-						recording.mediaRecorder.addEventListener('stop', () => {
-							const audioBlob = new Blob(recording.recordedChunks, {
-								type: recording.mediaRecorder.mimeType,
-							});
-							resolve(audioBlob);
-						});
-						recording.mediaRecorder.stop();
-					}),
-				catch: (error) => RecorderError.StopFailed({ cause: error }),
-			});
-
-			// Always clean up the stream
-			cleanupRecordingStream(recording.stream);
-			notify('IDLE');
-
-			if (stopError) return Err(stopError);
-
-			sendStatus({
-				title: '✅ Recording Saved',
-				description: 'Your recording is ready for transcription!',
-			});
-			return Ok({ blob, recordingId: recording.recordingId });
-		},
-
-		cancelRecording: async ({
-			sendStatus,
-		}): Promise<Result<CancelRecordingResult, RecorderError>> => {
-			if (!activeRecording) {
-				return Ok({ status: 'no-recording' });
-			}
-
-			const recording = activeRecording;
-			activeRecording = null; // Clear immediately
-
-			sendStatus({
-				title: '🛑 Cancelling',
-				description: 'Discarding your recording...',
-			});
-
-			// Stop the recorder
-			recording.mediaRecorder.stop();
-
-			// Clean up the stream
-			cleanupRecordingStream(recording.stream);
-			notify('IDLE');
-
-			sendStatus({
-				title: '✨ Cancelled',
-				description: 'Recording discarded successfully!',
-			});
-
-			return Ok({ status: 'cancelled' });
-		},
-
-		subscribe(handler) {
-			subscribers.add(handler);
-			return () => {
-				subscribers.delete(handler);
-			};
+			return Ok({ recording, deviceAcquisition: deviceOutcome });
 		},
 	};
 }
@@ -223,7 +219,7 @@ export const NavigatorRecorderServiceLive: RecorderService =
  * because:
  *
  * 1. Firefox (and forks like Zen) may leave `mediaRecorder.mimeType` empty when
- *    no type is specified at construction — see https://bugzilla.mozilla.org/show_bug.cgi?id=1512175
+ *    no type is specified at construction, see https://bugzilla.mozilla.org/show_bug.cgi?id=1512175
  * 2. Safari only supports `audio/mp4`, not `audio/webm`.
  * 3. Specifying upfront means the constructor throws `NotSupportedError` if invalid,
  *    rather than silently producing a blob with an empty type.

--- a/apps/whispering/src/lib/services/recorder/navigator.ts
+++ b/apps/whispering/src/lib/services/recorder/navigator.ts
@@ -11,8 +11,8 @@ import {
 import { categorizeRecorderError } from './categorize-error';
 import type {
 	NavigatorRecordingParams,
-	Recording,
 	RecorderService,
+	Recording,
 } from './types';
 import { RecorderError } from './types';
 

--- a/apps/whispering/src/lib/services/recorder/types.ts
+++ b/apps/whispering/src/lib/services/recorder/types.ts
@@ -247,14 +247,45 @@ export type StartRecordingParams =
 	| NavigatorRecordingParams;
 
 /**
- * Recorder service interface shared by all methods
+ * A live recording session bound to the backend that started it.
+ *
+ * The `Recording` is the unit of lifecycle: it knows its own backend, owns
+ * its own teardown, and exposes per-session state changes. Toggling
+ * `recording.method` after construction has no effect on an in-flight
+ * Recording, which is what fixes the swap-mid-recording leak.
+ *
+ * The `subscribe` handler is invoked synchronously with the current state on
+ * subscribe (so callers don't have to mirror "I just started" themselves),
+ * then again whenever the session transitions, ending with 'IDLE' on
+ * stop/cancel.
+ */
+export type Recording = {
+	readonly recordingId: string;
+	readonly backend: 'navigator' | 'cpal';
+	stop(callbacks: {
+		sendStatus: UpdateStatusMessageFn;
+	}): Promise<Result<{ blob: Blob; recordingId: string }, RecorderError>>;
+	cancel(callbacks: {
+		sendStatus: UpdateStatusMessageFn;
+	}): Promise<Result<CancelRecordingResult, RecorderError>>;
+	subscribe(handler: (state: WhisperingRecordingState) => void): () => void;
+};
+
+/**
+ * Factory for `Recording` sessions. Services no longer carry mutable
+ * start/stop state directly; instead `startRecording` returns a Recording
+ * whose methods are bound to the backend that produced it.
  */
 export type RecorderService = {
 	/**
-	 * Get the current recorder state
-	 * Returns 'IDLE' if no recording is active, 'RECORDING' if recording is in progress
+	 * Probe for a Recording that already exists at module-load time. CPAL
+	 * sessions can outlive a JS reload because the Rust process keeps the
+	 * stream; navigator sessions cannot survive a reload and will always
+	 * return null after one.
+	 *
+	 * Returns the live Recording bound to this backend, or null if none.
 	 */
-	getRecorderState(): Promise<Result<WhisperingRecordingState, RecorderError>>;
+	getActiveRecording(): Promise<Result<Recording | null, RecorderError>>;
 
 	/**
 	 * Enumerate available recording devices with their labels and identifiers
@@ -262,45 +293,22 @@ export type RecorderService = {
 	enumerateDevices(): Promise<Result<Device[], RecorderError>>;
 
 	/**
-	 * Start a new recording session
+	 * Start a new recording session, returning the Recording handle along
+	 * with the device acquisition outcome. The caller holds the Recording
+	 * and uses its `stop`/`cancel`/`subscribe` for the rest of the session.
 	 */
 	startRecording(
 		params: StartRecordingParams,
 		callbacks: {
 			sendStatus: UpdateStatusMessageFn;
 		},
-	): Promise<Result<DeviceAcquisitionOutcome, RecorderError>>;
-
-	/**
-	 * Stop the current recording. Returns the audio blob alongside the
-	 * recordingId that was supplied to startRecording, so callers don't need to
-	 * remember it across the start/stop boundary.
-	 */
-	stopRecording(callbacks: {
-		sendStatus: UpdateStatusMessageFn;
-	}): Promise<Result<{ blob: Blob; recordingId: string }, RecorderError>>;
-
-	/**
-	 * Cancel the current recording without saving
-	 */
-	cancelRecording(callbacks: {
-		sendStatus: UpdateStatusMessageFn;
-	}): Promise<Result<CancelRecordingResult, RecorderError>>;
-
-	/**
-	 * Subscribe to state changes from this service. The handler is invoked
-	 * synchronously whenever the service transitions between IDLE and RECORDING.
-	 *
-	 * This is the single source of truth for state changes. Consumers should
-	 * subscribe at construction time and let the handler drive their local
-	 * state ; no eager mirror writes from the consumer side.
-	 *
-	 * Inactive services never fire (a CPAL subscription stays silent in web
-	 * mode, a navigator subscription stays silent in CPAL mode), so it is
-	 * safe to subscribe to every available service at once.
-	 *
-	 * Returns an unsubscribe function. Module-singleton consumers can ignore
-	 * the return value; ephemeral consumers should call it on teardown.
-	 */
-	subscribe(handler: (state: WhisperingRecordingState) => void): () => void;
+	): Promise<
+		Result<
+			{
+				recording: Recording;
+				deviceAcquisition: DeviceAcquisitionOutcome;
+			},
+			RecorderError
+		>
+	>;
 };

--- a/apps/whispering/src/lib/services/recorder/types.ts
+++ b/apps/whispering/src/lib/services/recorder/types.ts
@@ -155,6 +155,16 @@ export const RecorderError = defineErrors({
 	NoDevice: ({ message }: { message: string }) => ({
 		message,
 	}),
+	MicrophonePermissionDenied: ({ cause }: { cause?: unknown } = {}) => ({
+		message:
+			'Microphone access was denied. Please grant microphone permission in your system or browser settings and try again.',
+		cause,
+	}),
+	NoInputDevice: ({ cause }: { cause?: unknown } = {}) => ({
+		message:
+			"We couldn't find any microphone to record from. Please connect a microphone and try again.",
+		cause,
+	}),
 	AlreadyRecording: () => ({
 		message:
 			'A recording is already in progress. Please stop the current recording before starting a new one.',

--- a/apps/whispering/src/lib/state/manual-recorder.svelte.ts
+++ b/apps/whispering/src/lib/state/manual-recorder.svelte.ts
@@ -10,6 +10,7 @@ import { services } from '$lib/services';
 import { desktopServices } from '$lib/services/desktop';
 import {
 	asDeviceIdentifier,
+	type Recording,
 	type RecorderService,
 	type StartRecordingParams,
 } from '$lib/services/recorder/types';
@@ -25,17 +26,22 @@ import { deviceConfig } from '$lib/state/device-config.svelte';
  * - Operations: `manualRecorder.startRecording({ toastId })` etc.
  * - Device enumeration as a TanStack Query for loading states in selectors
  *
- * State writes flow through a single channel: every recorder service exposes
- * `subscribe(handler)`, this module registers one handler at construction
- * time, and the active service drives `_state` directly. Inactive services
- * (e.g. a CPAL subscription in web mode) emit nothing.
+ * Each recording is a `Recording` object returned by the backend that
+ * started it. The Recording owns its own stop/cancel/subscribe; the
+ * recorder service is only consulted at start time, so toggling
+ * `recording.method` mid-recording can't misroute teardown (the in-flight
+ * Recording stays bound to its original backend).
  *
- * On Tauri, state is bootstrapped from the active service's `getRecorderState`
- * once at module init (a Rust CPAL session can outlive a JS reload). The
- * subscribe handler covers every subsequent transition, including ones Rust
- * initiates without a JS command (future auto-stop, device disconnect, etc.).
+ * Subscription is per-Recording rather than per-service. The previous
+ * model subscribed to both navigator and cpal at module init even though
+ * only one would ever fire; now `attach()` subscribes to the live
+ * Recording and `detach()` cleans up on stop/cancel.
+ *
+ * On Tauri, state is bootstrapped from each backend's `getActiveRecording`
+ * at module init (a Rust CPAL session can outlive a JS reload).
  */
-function recorderService() {
+
+function resolveServiceForStart(): RecorderService {
 	if (!isTauri()) return services.navigatorRecorder;
 	return deviceConfig.get('recording.method') === 'cpal'
 		? desktopServices.cpalRecorder
@@ -71,40 +77,37 @@ async function buildStartParams(
 
 function createManualRecorder() {
 	let _state = $state<WhisperingRecordingState>('IDLE');
+	let _current: Recording | null = null;
+	let _unsubscribe: (() => void) | null = null;
 
-	/**
-	 * Tracks the service that owns the in-flight recording so stop/cancel
-	 * route to the same backend that started it.
-	 *
-	 * Without this, toggling `recording.method` between start and stop would
-	 * call stop on a backend that has no session (failing with NotRecording)
-	 * while leaving the original backend's stream/MediaRecorder alive and the
-	 * mic LED on. The bug is rare in click-driven UI but real for hotkey
-	 * flows where the recording is invisible. Resolving the service once at
-	 * start time and binding it to the lifecycle makes mid-recording toggles
-	 * a no-op for the in-flight session; the next start picks up the new
-	 * setting normally.
-	 */
-	let _activeService: RecorderService | null = null;
-
-	// Bootstrap: only cpal can outlive a JS reload (Rust process keeps the
-	// stream), so probe cpal directly rather than going through the current
-	// setting. If the user toggled to navigator after a reload but a cpal
-	// recording is still live, we still bind to cpal for the rest of its life.
-	if (isTauri()) {
-		void desktopServices.cpalRecorder.getRecorderState().then(({ data }) => {
-			if (data === 'RECORDING') {
-				_activeService = desktopServices.cpalRecorder;
-				_state = 'RECORDING';
-			}
+	function attach(recording: Recording) {
+		_unsubscribe?.();
+		_current = recording;
+		_unsubscribe = recording.subscribe((s) => {
+			_state = s;
+			if (s === 'IDLE') detach();
 		});
 	}
 
-	const writeState = (state: WhisperingRecordingState) => {
-		_state = state;
-	};
-	services.navigatorRecorder.subscribe(writeState);
-	if (isTauri()) desktopServices.cpalRecorder.subscribe(writeState);
+	function detach() {
+		_unsubscribe?.();
+		_unsubscribe = null;
+		_current = null;
+		_state = 'IDLE';
+	}
+
+	// Bootstrap: ask each backend whether it owns a live session. Navigator
+	// always returns null after a JS reload (its state lives in the closure);
+	// cpal can return non-null because the Rust process keeps the stream alive.
+	void Promise.all([
+		services.navigatorRecorder.getActiveRecording(),
+		isTauri()
+			? desktopServices.cpalRecorder.getActiveRecording()
+			: Promise.resolve({ data: null, error: null } as const),
+	]).then(([nav, cpal]) => {
+		const found = nav.data ?? cpal.data ?? null;
+		if (found) attach(found);
+	});
 
 	return {
 		get state(): WhisperingRecordingState {
@@ -114,7 +117,7 @@ function createManualRecorder() {
 		enumerateDevices: defineQuery({
 			queryKey: ['recorder', 'devices'],
 			queryFn: async () => {
-				const { data, error } = await recorderService().enumerateDevices();
+				const { data, error } = await resolveServiceForStart().enumerateDevices();
 				if (error) {
 					return WhisperingErr({
 						title: '❌ Failed to enumerate devices',
@@ -126,12 +129,14 @@ function createManualRecorder() {
 		}),
 
 		async startRecording({ toastId }: { toastId: string }) {
+			const service = resolveServiceForStart();
 			const params = await buildStartParams(nanoid());
-			const service = recorderService();
-			const { data: deviceAcquisitionOutcome, error: startRecordingError } =
-				await service.startRecording(params, {
+			const { data, error: startRecordingError } = await service.startRecording(
+				params,
+				{
 					sendStatus: (options) => notify.loading({ id: toastId, ...options }),
-				});
+				},
+			);
 
 			if (startRecordingError) {
 				return WhisperingErr({
@@ -140,13 +145,19 @@ function createManualRecorder() {
 				});
 			}
 
-			_activeService = service;
-			return Ok(deviceAcquisitionOutcome);
+			attach(data.recording);
+			return Ok(data.deviceAcquisition);
 		},
 
 		async stopRecording({ toastId }: { toastId: string }) {
-			const service = _activeService ?? recorderService();
-			const { data, error: stopRecordingError } = await service.stopRecording({
+			if (!_current) {
+				return WhisperingErr({
+					title: '❌ Failed to stop recording',
+					description:
+						'No active recording session to stop. Start a recording first.',
+				});
+			}
+			const { data, error: stopRecordingError } = await _current.stop({
 				sendStatus: (options) => notify.loading({ id: toastId, ...options }),
 			});
 
@@ -157,14 +168,13 @@ function createManualRecorder() {
 				});
 			}
 
-			_activeService = null;
 			return Ok(data);
 		},
 
 		async cancelRecording({ toastId }: { toastId: string }) {
-			const service = _activeService ?? recorderService();
+			if (!_current) return Ok({ status: 'no-recording' as const });
 			const { data: cancelResult, error: cancelRecordingError } =
-				await service.cancelRecording({
+				await _current.cancel({
 					sendStatus: (options) => notify.loading({ id: toastId, ...options }),
 				});
 
@@ -175,7 +185,6 @@ function createManualRecorder() {
 				});
 			}
 
-			_activeService = null;
 			return Ok(cancelResult);
 		},
 	};

--- a/apps/whispering/src/lib/state/manual-recorder.svelte.ts
+++ b/apps/whispering/src/lib/state/manual-recorder.svelte.ts
@@ -10,8 +10,8 @@ import { services } from '$lib/services';
 import { desktopServices } from '$lib/services/desktop';
 import {
 	asDeviceIdentifier,
-	type Recording,
 	type RecorderService,
+	type Recording,
 	type StartRecordingParams,
 } from '$lib/services/recorder/types';
 import { deviceConfig } from '$lib/state/device-config.svelte';
@@ -122,7 +122,8 @@ function createManualRecorder() {
 		enumerateDevices: defineQuery({
 			queryKey: ['recorder', 'devices'],
 			queryFn: async () => {
-				const { data, error } = await resolveServiceForStart().enumerateDevices();
+				const { data, error } =
+					await resolveServiceForStart().enumerateDevices();
 				if (error) {
 					return WhisperingErr({
 						title: '❌ Failed to enumerate devices',

--- a/apps/whispering/src/lib/state/manual-recorder.svelte.ts
+++ b/apps/whispering/src/lib/state/manual-recorder.svelte.ts
@@ -99,7 +99,12 @@ function createManualRecorder() {
 	// Bootstrap: ask each backend whether it owns a live session. Navigator
 	// always returns null after a JS reload (its state lives in the closure);
 	// cpal can return non-null because the Rust process keeps the stream alive.
-	void Promise.all([
+	//
+	// The promise is awaited before any stop/cancel/start runs. Without
+	// that gate, a user action that fires before bootstrap resolves sees a
+	// stale `_current === null` and either no-ops the cancel (leaking the
+	// Rust session) or double-starts on top of a rehydrated one.
+	const bootstrapped = Promise.all([
 		services.navigatorRecorder.getActiveRecording(),
 		isTauri()
 			? desktopServices.cpalRecorder.getActiveRecording()
@@ -129,6 +134,14 @@ function createManualRecorder() {
 		}),
 
 		async startRecording({ toastId }: { toastId: string }) {
+			await bootstrapped;
+			if (_current) {
+				return WhisperingErr({
+					title: '❌ Already recording',
+					description:
+						'A recording is already in progress. Stop the current one before starting a new one.',
+				});
+			}
 			const service = resolveServiceForStart();
 			const params = await buildStartParams(nanoid());
 			const { data, error: startRecordingError } = await service.startRecording(
@@ -150,6 +163,7 @@ function createManualRecorder() {
 		},
 
 		async stopRecording({ toastId }: { toastId: string }) {
+			await bootstrapped;
 			if (!_current) {
 				return WhisperingErr({
 					title: '❌ Failed to stop recording',
@@ -172,6 +186,7 @@ function createManualRecorder() {
 		},
 
 		async cancelRecording({ toastId }: { toastId: string }) {
+			await bootstrapped;
 			if (!_current) return Ok({ status: 'no-recording' as const });
 			const { data: cancelResult, error: cancelRecordingError } =
 				await _current.cancel({

--- a/apps/whispering/src/lib/state/manual-recorder.svelte.ts
+++ b/apps/whispering/src/lib/state/manual-recorder.svelte.ts
@@ -10,6 +10,7 @@ import { services } from '$lib/services';
 import { desktopServices } from '$lib/services/desktop';
 import {
 	asDeviceIdentifier,
+	type RecorderService,
 	type StartRecordingParams,
 } from '$lib/services/recorder/types';
 import { deviceConfig } from '$lib/state/device-config.svelte';
@@ -71,11 +72,33 @@ async function buildStartParams(
 function createManualRecorder() {
 	let _state = $state<WhisperingRecordingState>('IDLE');
 
-	void recorderService()
-		.getRecorderState()
-		.then(({ data }) => {
-			if (data) _state = data;
+	/**
+	 * Tracks the service that owns the in-flight recording so stop/cancel
+	 * route to the same backend that started it.
+	 *
+	 * Without this, toggling `recording.method` between start and stop would
+	 * call stop on a backend that has no session (failing with NotRecording)
+	 * while leaving the original backend's stream/MediaRecorder alive and the
+	 * mic LED on. The bug is rare in click-driven UI but real for hotkey
+	 * flows where the recording is invisible. Resolving the service once at
+	 * start time and binding it to the lifecycle makes mid-recording toggles
+	 * a no-op for the in-flight session; the next start picks up the new
+	 * setting normally.
+	 */
+	let _activeService: RecorderService | null = null;
+
+	// Bootstrap: only cpal can outlive a JS reload (Rust process keeps the
+	// stream), so probe cpal directly rather than going through the current
+	// setting. If the user toggled to navigator after a reload but a cpal
+	// recording is still live, we still bind to cpal for the rest of its life.
+	if (isTauri()) {
+		void desktopServices.cpalRecorder.getRecorderState().then(({ data }) => {
+			if (data === 'RECORDING') {
+				_activeService = desktopServices.cpalRecorder;
+				_state = 'RECORDING';
+			}
 		});
+	}
 
 	const writeState = (state: WhisperingRecordingState) => {
 		_state = state;
@@ -104,8 +127,9 @@ function createManualRecorder() {
 
 		async startRecording({ toastId }: { toastId: string }) {
 			const params = await buildStartParams(nanoid());
+			const service = recorderService();
 			const { data: deviceAcquisitionOutcome, error: startRecordingError } =
-				await recorderService().startRecording(params, {
+				await service.startRecording(params, {
 					sendStatus: (options) => notify.loading({ id: toastId, ...options }),
 				});
 
@@ -116,14 +140,15 @@ function createManualRecorder() {
 				});
 			}
 
+			_activeService = service;
 			return Ok(deviceAcquisitionOutcome);
 		},
 
 		async stopRecording({ toastId }: { toastId: string }) {
-			const { data, error: stopRecordingError } =
-				await recorderService().stopRecording({
-					sendStatus: (options) => notify.loading({ id: toastId, ...options }),
-				});
+			const service = _activeService ?? recorderService();
+			const { data, error: stopRecordingError } = await service.stopRecording({
+				sendStatus: (options) => notify.loading({ id: toastId, ...options }),
+			});
 
 			if (stopRecordingError) {
 				return WhisperingErr({
@@ -132,12 +157,14 @@ function createManualRecorder() {
 				});
 			}
 
+			_activeService = null;
 			return Ok(data);
 		},
 
 		async cancelRecording({ toastId }: { toastId: string }) {
+			const service = _activeService ?? recorderService();
 			const { data: cancelResult, error: cancelRecordingError } =
-				await recorderService().cancelRecording({
+				await service.cancelRecording({
 					sendStatus: (options) => notify.loading({ id: toastId, ...options }),
 				});
 
@@ -148,6 +175,7 @@ function createManualRecorder() {
 				});
 			}
 
+			_activeService = null;
 			return Ok(cancelResult);
 		},
 	};

--- a/apps/whispering/src/lib/state/vad-recorder.svelte.ts
+++ b/apps/whispering/src/lib/state/vad-recorder.svelte.ts
@@ -24,10 +24,21 @@ import { deviceConfig } from '$lib/state/device-config.svelte';
  * - Stop listening: `await vadRecorder.stopActiveListening()`
  * - Enumerate devices: `createQuery(() => vadRecorder.enumerateDevices.options)`
  */
+/**
+ * Active VAD session, or null when idle. Collapses the previous
+ * `_session` + `_state` pair into a single reactive field so the
+ * invariant `vad/stream exist iff state !== 'IDLE'` is type-enforced:
+ * there is no way to spell a non-idle state without the underlying
+ * MicVAD and MediaStream that produced it.
+ */
+type VadSession = {
+	state: 'LISTENING' | 'SPEECH_DETECTED';
+	vad: MicVAD;
+	stream: MediaStream;
+};
+
 function createVadRecorder() {
-	// Private state
-	let _session: { vad: MicVAD; stream: MediaStream } | null = null;
-	let _state = $state<VadState>('IDLE');
+	let _session = $state<VadSession | null>(null);
 
 	return {
 		/**
@@ -35,7 +46,7 @@ function createVadRecorder() {
 		 * cause the effect to re-run when the state changes.
 		 */
 		get state(): VadState {
-			return _state;
+			return _session?.state ?? 'IDLE';
 		},
 
 		/**
@@ -116,17 +127,17 @@ function createVadRecorder() {
 						stream,
 						submitUserSpeechOnPause: true,
 						onSpeechStart: () => {
-							_state = 'SPEECH_DETECTED';
+							if (_session) _session.state = 'SPEECH_DETECTED';
 							onSpeechStart();
 						},
 						onSpeechEnd: (audio) => {
-							_state = 'LISTENING';
+							if (_session) _session.state = 'LISTENING';
 							const wavBuffer = utils.encodeWAV(audio);
 							const blob = new Blob([wavBuffer], { type: 'audio/wav' });
 							onSpeechEnd(blob);
 						},
 						onVADMisfire: () => {
-							_state = 'LISTENING';
+							if (_session) _session.state = 'LISTENING';
 							onVADMisfire?.();
 						},
 						onSpeechRealStart: () => {
@@ -170,8 +181,7 @@ function createVadRecorder() {
 				return Err(startError);
 			}
 
-			_session = { vad: newVad, stream };
-			_state = 'LISTENING';
+			_session = { state: 'LISTENING', vad: newVad, stream };
 			return Ok(deviceOutcome);
 		},
 
@@ -195,7 +205,6 @@ function createVadRecorder() {
 
 			// Always clean up, even if dispose had an error
 			_session = null;
-			_state = 'IDLE';
 			cleanupRecordingStream(stream);
 
 			if (destroyError) return Err(destroyError);


### PR DESCRIPTION
A user toggling the recording method (cpal ↔ navigator) between starting and stopping a recording would leak the original backend's resources, because the manual recorder re-resolved which backend to use on every method call. Start a navigator recording, switch to cpal, click stop, and stop would call cpal's stop (no session there, fails) while the navigator's `MediaStream` stayed acquired (mic LED on) and the `MediaRecorder` kept running. Rare in click-driven UI, real for hotkey flows where the recording is invisible.

Investigating the fix forced a service-shape change. The old `RecorderService` was a stateful object with `start/stop/cancel/subscribe` methods, and every call had to re-resolve which backend was current. The new shape makes services factories that produce a `Recording` session bound to whichever backend started it:

```typescript
// Old: stateful service, lifecycle resolves per method
const { error } = await recorderService().stopRecording(callbacks);
// Mid-recording setting toggle? Stop misroutes silently.

// New: service is a factory; Recording owns its own teardown
const { data } = await service.startRecording(params, callbacks);
const recording = data.recording;  // bound to the backend that produced it

// Later: stop routes to the exact backend that started, regardless of settings
await recording.stop(callbacks);
await recording.cancel(callbacks);
```

The manual recorder now holds a single `_current: Promise<Recording | null>` and routes `stop`/`cancel` through it. Toggling settings mid-recording becomes a no-op for the in-flight session; the next start picks up the new setting normally.

```
Before:
  manualRecorder
    └── recorderService()             ← re-resolves per call from setting
          ├── navigatorRecorder.{start, stop, cancel, subscribe}
          └── cpalRecorder.{start, stop, cancel, subscribe}

After:
  manualRecorder
    └── _current: Recording | null    ← bound at start time
          ├── recording.stop()         ─┐ both routed to the
          ├── recording.cancel()       ─┤ backend that produced
          └── recording.subscribe()    ─┘ this Recording
```

Bootstrap deserves its own note because it surfaced a race. `_current` is null until both backends finish their `getActiveRecording` probe (only cpal can rehydrate after a JS reload; navigator state dies with the page). A stop or cancel that fires in that window saw a stale null and either no-op'd, leaking a rehydrated Rust session, or for start, would silently overwrite the rehydrated `_current` and leak the same. The fix holds the bootstrap result as a promise and awaits it at every entry point:

```typescript
const bootstrap = Promise.all([
  navigatorRecorder.getActiveRecording(),
  isTauri() ? cpalRecorder.getActiveRecording() : Promise.resolve({ data: null }),
]).then(([nav, cpal]) => nav.data ?? cpal.data ?? null);

async startRecording(...) {
  if (await bootstrap) return AlreadyRecording;
  // ...
}
```

This points at a broader orchestration question worth noting but not solving here: the manual recorder owns cross-backend selection, the per-Recording factories own per-session lifecycle, and bootstrap straddles both. A more explicit state machine (`bootstrapping → idle → recording`) would make these boundaries crisper. Filed for later; the current await-the-promise approach is correct, just informal.

Three independent improvements came along for the ride.

**Sub-second recordings get padded to 1.25s with silence.** Whisper is unreliable on near-silent or sub-one-second inputs and tends to hallucinate common phrases like "Thank you for watching!" Padding suppresses this without changing the transcript. Implemented in `WavWriter::finalize` so it triggers on stop and on Drop-based crash recovery, but not on cancel (which deletes the file before finalize runs). Inspired by Handy's `stop_recording` logic.

**Mic permission denied and no-input-device errors are now typed.** Previously cpal errors surfaced as opaque strings wrapped in generic `InitFailed`/`StartFailed`/`StreamAcquisition` variants — users saw the same toast whether they had denied permission, had no mic, or hit an unrelated audio glitch. Adds two new `RecorderError` variants and a `categorizeRecorderError` helper that runs the same string-match heuristics as new Rust-side helpers (`is_microphone_access_denied`, `is_no_input_device_error`, with tests). The helper also recognizes `getUserMedia` DOMException names (`NotAllowedError`, `NotFoundError`) so the navigator path gets typed errors too.

**VAD recorder's `_session` and `_state` collapse into one reactive field.** The invariant "vad/stream exist iff state !== 'IDLE'" was true but not enforced. Type-narrowing now makes it impossible to spell a non-idle state without the underlying `MicVAD` and `MediaStream`.

A pair of known follow-ups worth tracking but not blocking on. The cpal teardown closure references `recording` in its `if (activeRecording === recording)` check before the const initializer; works in practice because teardown only runs after assignment, but TDZ-fragile if someone moves teardown to a new call path. And there's no unit test for the swap-mid-recording fix; the per-Recording factory shape would make it a tight test (start → mutate setting → stop → assert no leak).

## Changelog
- Pad sub-second recordings to 1.25s so Whisper stops hallucinating "Thank you for watching!" on accidentally-short clips
- Show specific "microphone permission denied" and "no microphone found" errors instead of a generic recording failure toast
- Fix microphone staying active when changing recording method (CPAL/Navigator) mid-recording

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782349968&installation_id=128463665&pr_number=1819&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1819&signature=90e22ecece82656f58324851450bbee8607696a946e1bc790a8742b68a6dff1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->