### PR TITLE
docs + refactor(whispering): platform/settings binding article + cpal teardown TDZ fix

### DIFF
--- a/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
+++ b/apps/whispering/src/lib/services/desktop/recorder/cpal.ts
@@ -88,7 +88,13 @@ function createCpalRecorder(): RecorderService {
 			);
 		};
 
-		const teardown = () => {
+		// Takes `recording` as an argument rather than closing over the const
+		// declared below. Both work because teardown only runs from stop/cancel
+		// handlers (which can only fire after `recording` is bound), but the
+		// explicit argument keeps the function TDZ-safe if a future caller
+		// invokes teardown from a path declared above the `recording = ...`
+		// initializer.
+		const teardown = (recording: Recording) => {
 			if (activeRecording === recording) activeRecording = null;
 			if (tauriUnlisten) {
 				void tauriUnlisten.then((unlisten) => unlisten());
@@ -105,13 +111,13 @@ function createCpalRecorder(): RecorderService {
 				const { data: audioRecording, error: stopRecordingError } =
 					await invoke<AudioRecording>('stop_recording');
 				if (stopRecordingError) {
-					teardown();
+					teardown(recording);
 					return RecorderError.StopFailed({ cause: stopRecordingError });
 				}
 
 				const { filePath } = audioRecording;
 				if (!filePath) {
-					teardown();
+					teardown(recording);
 					return RecorderError.NoFilePath();
 				}
 
@@ -123,7 +129,7 @@ function createCpalRecorder(): RecorderService {
 				const { data: blob, error: readRecordingFileError } =
 					await FsServiceLive.pathToBlob(filePath);
 				if (readRecordingFileError) {
-					teardown();
+					teardown(recording);
 					return RecorderError.ReadFileFailed({
 						cause: readRecordingFileError,
 					});
@@ -141,7 +147,7 @@ function createCpalRecorder(): RecorderService {
 					console.error('Failed to close recording session:', closeError);
 				}
 
-				teardown();
+				teardown(recording);
 				return Ok({ blob, recordingId });
 			},
 
@@ -181,7 +187,7 @@ function createCpalRecorder(): RecorderService {
 					console.error('Failed to close recording session:', closeError);
 				}
 
-				teardown();
+				teardown(recording);
 				return Ok({ status: 'cancelled' });
 			},
 

--- a/docs/articles/20260526T030000-bind-platform-once-bind-settings-every-time.md
+++ b/docs/articles/20260526T030000-bind-platform-once-bind-settings-every-time.md
@@ -1,0 +1,108 @@
+# Bind Platform Once. Bind Settings Every Time.
+
+Some dependencies never change after the app starts. Others change every time the user opens settings. Treat them the same and you ship subtle bugs.
+
+Epicenter has two kinds of swappable dependencies. The first kind is platform: web vs desktop. The second kind is settings: cpal vs navigator recorder, OpenAI vs Groq transcription, compression on vs off. Each kind needs a different binding strategy, and the difference is not academic; mixing them up is how we shipped a microphone-stays-on bug that took a month to surface.
+
+## Platform never changes. Resolve once, cache the result.
+
+You can't switch from Tauri to a browser without restarting the app. Whether you're running inside the Tauri shell is fixed at startup and stays fixed. So we resolve it once, at module load, and assign the result to a constant.
+
+```typescript
+// apps/whispering/src/lib/services/text/index.ts
+import { isTauri } from '@tauri-apps/api/core';
+import { createTextServiceDesktop } from './desktop';
+import { createTextServiceWeb } from './web';
+
+export const TextServiceLive: TextService = isTauri()
+    ? createTextServiceDesktop()
+    : createTextServiceWeb();
+```
+
+`isTauri()` reads a global flag (`globalThis.isTauri`) that Tauri sets when it injects its runtime. The check happens once when this file is first imported. `TextServiceLive` is a regular value after that. Every caller imports the same constant; there's nothing to re-evaluate.
+
+```typescript
+import { TextServiceLive } from '$lib/services/text';
+
+await TextServiceLive.copyToClipboard(text);  // resolved at import time
+```
+
+This pattern is consistent across the app. Text, OS, HTTP, downloads, sounds, notifications, analytics, blob storage. All of them do exactly this dance: `isTauri() ? createXDesktop() : createXWeb()`, assigned to one const. You read the desktop file or the web file once when you want to understand what a service does, and you never have to think about which one is active at any given moment because the question can't be asked.
+
+## Settings change. Resolve every call.
+
+The recording method (`cpal` vs `navigator`) lives in user settings. The user can flip it at any time, including while a recording is in progress. So the service has to be re-resolved on each method call. There's no constant to cache; there's a function.
+
+```typescript
+// apps/whispering/src/lib/state/manual-recorder.svelte.ts
+function recorderService() {
+    if (!isTauri()) return services.navigatorRecorder;
+    return deviceConfig.get('recording.method') === 'cpal'
+        ? desktopServices.cpalRecorder
+        : services.navigatorRecorder;
+}
+```
+
+The shape is the same as the platform pattern, but it's wrapped in a function instead of assigned to a constant. Every call site invokes it fresh:
+
+```typescript
+await recorderService().enumerateDevices();
+await recorderService().startRecording(params, callbacks);
+```
+
+This looks like overhead. Why call a function when you could cache the result? Because the setting can change between calls. If the user toggled `recording.method` from `cpal` to `navigator` between `enumerateDevices` and `startRecording`, you want the second call to use the new value. A cached const wouldn't.
+
+The same pattern shows up everywhere settings drive behavior. The transcription service is read from settings on every transcribe:
+
+```typescript
+// apps/whispering/src/lib/query/transcription.ts
+export async function transcribeBlob(blob: Blob) {
+    const selectedService = settings.get('transcription.service');
+    // ... dispatch to the right transcriber
+}
+```
+
+So is whether compression runs:
+
+```typescript
+if (settings.get('transcription.compressionEnabled')) {
+    const { data: compressedBlob } =
+        await desktopServices.ffmpeg.compressAudioBlob(blob, ...);
+}
+```
+
+None of these are cached. They're all read fresh on each operation, because all of them can change between operations.
+
+## The trap is when a settings dependency spans an operation
+
+Reading a setting at the start of one operation works. Reading it at the start AND the end of the same operation, and assuming the values match, doesn't.
+
+The manual recorder had this exact bug for a month. The old code resolved the service on every method call. Start a navigator recording (resolved: navigator), toggle to cpal in settings, click stop. Stop re-resolved: cpal. Stop ran on a cpal session that didn't exist, returned `NotRecording`, while the navigator's `MediaStream` stayed acquired and the mic LED stayed on. Rare in click-driven UI; real for keyboard-shortcut flows where the recording is invisible.
+
+The fix was to bind the service at the start of the operation and stash it on the instance for the duration:
+
+```typescript
+let _activeService: RecorderService | null = null;
+
+async startRecording({ toastId }) {
+    const service = recorderService();          // resolve here
+    const { data, error } = await service.startRecording(...);
+    if (error) return WhisperingErr({ ... });
+    _activeService = service;                    // bind to the lifecycle
+    return Ok(data);
+}
+
+async stopRecording({ toastId }) {
+    const service = _activeService ?? recorderService();   // use the bound one
+    // ...
+    _activeService = null;
+}
+```
+
+The rule that came out of it: settings binding is per-call by default, but anything that owns a lifecycle longer than one call (a recording session, an upload, a long-running mutation) has to capture the binding at the start and hold it until done. Otherwise a setting change mid-lifecycle silently routes the second half of the operation somewhere different from the first half.
+
+## The two-line rule
+
+Platform binding is a constant; settings binding is a function. If the dependency can change while the app is running, you can't cache it; if it can't, you should. The trickier case is the middle one, where a dependency can change but shouldn't change inside a single in-flight operation. Those need to be resolved once at the operation's start and held for its duration.
+
+The cost of getting this wrong is not a crash. It's the kind of bug where everything looks fine in the logs, the user's UI looks fine, but the microphone LED stays on for the rest of the session and nobody notices until somebody walks past their laptop.


### PR DESCRIPTION
Two small follow-ups to the recorder work that landed in #1819.

The first is a docs/articles writeup that names the pattern behind the swap-mid-recording bug we fixed: platform binding vs settings binding. Platform binding (web vs Tauri) gets resolved once at module load because it never changes, so `TextServiceLive`, `OsServiceLive`, etc. are constants. Settings binding (cpal vs navigator recorder, OpenAI vs Groq transcription) has to be resolved at the call site because the user can flip it any time, so `recorderService()` is a function. The trickier third case is a settings dependency that has to stay stable across a multi-step operation; that's exactly where the swap-mid-recording leak lived, and naming the pattern explicitly should make the trap easier to spot next time.

The second is a small refactor in `apps/whispering/src/lib/services/desktop/recorder/cpal.ts`. The `teardown` closure referenced `recording` from a `const` declared on the line below:

```typescript
const teardown = () => {
    if (activeRecording === recording) activeRecording = null;
    //                    ^ declared at line 100, captured here at line 92
};

const recording: Recording = { ... };
```

This works in practice because `teardown` is only called from inside `recording.stop` and `recording.cancel`, both of which run long after the assignment completes. But TDZ-fragile: a future caller (a new auto-teardown path, an error-recovery branch in `buildRecording` itself) declared above the const initializer would hit a `ReferenceError` that the type system doesn't catch.

Passing `recording` as an argument makes the order safe and the dependency explicit at every call site.

```
Before:
  const teardown = () => { if (activeRecording === recording) ... }
  const recording: Recording = { ... }

After:
  const teardown = (recording: Recording) => { if (activeRecording === recording) ... }
  const recording: Recording = { ... }
  // call sites: teardown(recording)
```

The other known follow-up (a regression test for the swap-mid-recording fix) isn't here. Whispering has zero test files today, so bootstrapping vitest, MediaRecorder/MediaStream mocks, getUserMedia mocks, and Tauri invoke mocks for one test would be a multi-hour infrastructure project. Filing it as a deliberate "set up testing for whispering" effort rather than smuggling it in here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782351095&installation_id=128463665&pr_number=1820&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1820&signature=2612afd277d06651741e8165677a23e4f89e12f1122c6fd45fdba815744a9e38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->