### PR TITLE
refactor(workspace): inline table schemas, split fuji actions

### DIFF
--- a/apps/fuji/src/lib/actions.ts
+++ b/apps/fuji/src/lib/actions.ts
@@ -1,0 +1,268 @@
+/**
+ * Fuji actions: typed query/mutation registry layered on the workspace tables.
+ *
+ * Split from `./workspace.ts` for navigation: workspace.ts owns schema + the
+ * `createFujiWorkspace` factory; this file owns the action surface that the
+ * browser and daemon expose over `openCollaboration` / `attachDaemonInfrastructure`.
+ *
+ * The `@epicenter/fuji` package re-exports `createFujiActions` and `FujiActions`
+ * from `./workspace.ts` so external consumers keep importing from one place.
+ */
+
+import {
+	column,
+	DateTimeString,
+	defineActions,
+	defineMutation,
+	defineQuery,
+	generateId,
+	type IanaTimeZone,
+} from '@epicenter/workspace';
+import { Type } from 'typebox';
+import { asEntryId, type EntryId, type FujiWorkspace } from './workspace';
+
+export function createFujiActions(workspace: FujiWorkspace) {
+	const { tables } = workspace;
+	return defineActions({
+		entries_get: defineQuery({
+			title: 'Get Entry',
+			description: 'Read one entry by ID from the daemon workspace.',
+			input: Type.Object({
+				id: Type.String({ description: 'Entry ID to read' }),
+			}),
+			handler: ({ id }) => {
+				return tables.entries.get(id);
+			},
+		}),
+		entries_get_all_valid: defineQuery({
+			title: 'List Valid Entries',
+			description: 'Read all valid entries from the daemon workspace.',
+			input: Type.Object({}),
+			handler: () => {
+				return tables.entries.getAllValid();
+			},
+		}),
+		entries_count: defineQuery({
+			title: 'Count Entries',
+			description: 'Count entries in the daemon workspace.',
+			input: Type.Object({}),
+			handler: () => {
+				return tables.entries.count();
+			},
+		}),
+		entries_has: defineQuery({
+			title: 'Has Entry',
+			description: 'Check whether an entry exists in the daemon workspace.',
+			input: Type.Object({
+				id: Type.String({ description: 'Entry ID to check' }),
+			}),
+			handler: ({ id }) => {
+				return tables.entries.has(id);
+			},
+		}),
+		entries_create: defineMutation({
+			title: 'Create Entry',
+			description:
+				'Create a new CMS entry with optional title, subtitle, type, tags, and rating.',
+			input: Type.Object({
+				title: Type.Optional(Type.String({ description: 'Entry title' })),
+				subtitle: Type.Optional(
+					Type.String({ description: 'Subtitle for blog listings' }),
+				),
+				type: Type.Optional(
+					Type.Array(Type.String(), {
+						description: 'Type classifications',
+					}),
+				),
+				tags: Type.Optional(
+					Type.Array(Type.String(), { description: 'Freeform tags' }),
+				),
+				rating: Type.Optional(
+					Type.Number({ description: 'Rating from 0-5 (0 = unrated)' }),
+				),
+				dateZone: Type.Optional(
+					Type.String({
+						description:
+							'IANA timezone the entry was authored in. Defaults to UTC.',
+					}),
+				),
+			}),
+			handler: ({
+				title,
+				subtitle,
+				type: entryType,
+				tags,
+				rating,
+				dateZone,
+			}) => {
+				const id = generateId<EntryId>();
+				const now = DateTimeString.now();
+				tables.entries.set({
+					id,
+					title: title ?? '',
+					subtitle: subtitle ?? '',
+					type: entryType ?? [],
+					tags: tags ?? [],
+					pinned: false,
+					rating: rating ?? 0,
+					deletedAt: null,
+					date: now,
+					dateZone: (dateZone ?? 'UTC') as IanaTimeZone,
+					createdAt: now,
+					updatedAt: now,
+				});
+				return { id };
+			},
+		}),
+		entries_upsert: defineMutation({
+			title: 'Upsert Entry',
+			description: 'Insert or replace a full entry row.',
+			input: Type.Object({
+				id: Type.String({ description: 'Entry ID' }),
+				title: Type.String({ description: 'Entry title' }),
+				subtitle: Type.String({ description: 'Subtitle for blog listings' }),
+				type: Type.Array(Type.String(), {
+					description: 'Type classifications',
+				}),
+				tags: Type.Array(Type.String(), { description: 'Freeform tags' }),
+				pinned: Type.Boolean({ description: 'Whether the entry is pinned' }),
+				rating: Type.Number({ description: 'Rating from 0 to 5' }),
+				deletedAt: column.nullable(
+					column.dateTime({ description: 'Soft deletion timestamp' }),
+				),
+				date: Type.Unsafe<DateTimeString>({
+					type: 'string',
+					description: 'User-defined date for the entry (UTC ISO 8601)',
+				}),
+				dateZone: Type.String({
+					description: 'IANA timezone for displaying the entry date',
+				}),
+				createdAt: Type.Unsafe<DateTimeString>({
+					type: 'string',
+					description: 'Creation timestamp',
+				}),
+				updatedAt: Type.Unsafe<DateTimeString>({
+					type: 'string',
+					description: 'Last update timestamp',
+				}),
+			}),
+			handler: (row) => {
+				tables.entries.set({
+					...row,
+					id: asEntryId(row.id),
+					dateZone: row.dateZone as IanaTimeZone,
+				});
+				return { id: row.id };
+			},
+		}),
+		entries_update: defineMutation({
+			title: 'Update Entry',
+			description:
+				'Update entry metadata fields. Automatically bumps updatedAt.',
+			input: Type.Object({
+				id: Type.String({ description: 'Entry ID to update' }),
+				title: Type.Optional(Type.String({ description: 'Entry title' })),
+				subtitle: Type.Optional(
+					Type.String({ description: 'Subtitle for blog listings' }),
+				),
+				type: Type.Optional(
+					Type.Array(Type.String(), {
+						description: 'Type classifications',
+					}),
+				),
+				tags: Type.Optional(
+					Type.Array(Type.String(), { description: 'Freeform tags' }),
+				),
+				rating: Type.Optional(
+					Type.Number({ description: 'Rating from 0-5 (0 = unrated)' }),
+				),
+				date: Type.Optional(
+					Type.Unsafe<DateTimeString>({
+						type: 'string',
+						description: 'User-defined date for the entry (UTC ISO 8601)',
+					}),
+				),
+				dateZone: Type.Optional(
+					Type.String({
+						description: 'IANA timezone for displaying the entry date',
+					}),
+				),
+			}),
+			handler: ({ id, dateZone, ...fields }) => {
+				return tables.entries.update(id, {
+					...fields,
+					...(dateZone !== undefined && {
+						dateZone: dateZone as IanaTimeZone,
+					}),
+					updatedAt: DateTimeString.now(),
+				});
+			},
+		}),
+		entries_delete: defineMutation({
+			title: 'Delete Entry',
+			description: 'Soft-delete an entry by setting deletedAt to now.',
+			input: Type.Object({
+				id: Type.String({ description: 'Entry ID to soft-delete' }),
+			}),
+			handler: ({ id }) => {
+				return tables.entries.update(id, {
+					deletedAt: DateTimeString.now(),
+					updatedAt: DateTimeString.now(),
+				});
+			},
+		}),
+		entries_restore: defineMutation({
+			title: 'Restore Entry',
+			description: 'Restore a soft-deleted entry by clearing deletedAt.',
+			input: Type.Object({
+				id: Type.String({ description: 'Entry ID to restore' }),
+			}),
+			handler: ({ id }) => {
+				return tables.entries.update(id, {
+					deletedAt: null,
+					updatedAt: DateTimeString.now(),
+				});
+			},
+		}),
+		entries_bulk_create: defineMutation({
+			title: 'Bulk Create Entries',
+			description:
+				'Create multiple entries at once from title + (date, dateZone) pairs.',
+			input: Type.Object({
+				dateZone: Type.String({
+					description:
+						'IANA timezone the entries were authored in. Applied to every row.',
+				}),
+				entries: Type.Array(
+					Type.Object({
+						title: Type.String({ description: 'Entry title' }),
+						date: Type.String({
+							description: 'UTC ISO 8601 instant for the entry',
+						}),
+					}),
+				),
+			}),
+			handler: async ({ dateZone, entries: items }) => {
+				const now = DateTimeString.now();
+				const rows = items.map(({ title, date }) => ({
+					id: generateId<EntryId>(),
+					title,
+					subtitle: '',
+					type: [] as string[],
+					tags: [] as string[],
+					pinned: false,
+					rating: 0,
+					deletedAt: null,
+					date: date as DateTimeString,
+					dateZone: dateZone as IanaTimeZone,
+					createdAt: now,
+					updatedAt: now,
+				}));
+				await tables.entries.bulkSet(rows);
+				return { count: rows.length };
+			},
+		}),
+	});
+}
+
+export type FujiActions = ReturnType<typeof createFujiActions>;

--- a/apps/fuji/src/lib/workspace.ts
+++ b/apps/fuji/src/lib/workspace.ts
@@ -1,6 +1,7 @@
 /**
- * Fuji workspace schema: id, branded types, tables, actions, and per-row
- * derived guids. Pure data. No Y.Doc, no encryption, no openers.
+ * Fuji workspace schema: id, branded types, table definitions, the workspace
+ * factory, and per-row derived guids. Pure data. No Y.Doc, no encryption, no
+ * openers.
  *
  * Distribution: `apps/fuji/package.json` exports this file as the
  * `@epicenter/fuji` package root. Browser code, daemon code, and tests all
@@ -12,22 +13,19 @@
  *  - `apps/fuji/src/lib/browser.ts`  → `openFujiBrowser({ signedIn, deviceId })`
  *  - `apps/fuji/daemon.ts`           → `openFujiDaemon(ctx)`
  *  - `examples/fuji/epicenter.config.ts` → canonical project layout composition
+ *
+ * The action registry lives in `./actions.ts` and is re-exported at the bottom
+ * of this file so `@epicenter/fuji` exposes a single import surface.
  */
 
 import {
 	column,
 	createWorkspace,
-	DateTimeString,
-	defineActions,
-	defineMutation,
-	defineQuery,
 	defineTable,
 	docGuid,
-	generateId,
 	type IanaTimeZone,
 	type InferTableRow,
 	type Keyring,
-	type Tables,
 } from '@epicenter/workspace';
 import { Type } from 'typebox';
 import type { Brand } from 'wellcrafted/brand';
@@ -102,9 +100,6 @@ const entriesTable = defineTable(
 
 export type Entry = InferTableRow<typeof entriesTable>;
 
-export const fujiTables = { entries: entriesTable };
-export type FujiTables = Tables<typeof fujiTables>;
-
 /**
  * Build a Fuji workspace bundle: `{ ydoc, tables, kv, [Symbol.dispose] }`.
  *
@@ -115,7 +110,7 @@ export function createFujiWorkspace(opts: { keyring: () => Keyring }) {
 	return createWorkspace({
 		id: FUJI_ID,
 		keyring: opts.keyring,
-		tables: fujiTables,
+		tables: { entries: entriesTable },
 		kv: {},
 	});
 }
@@ -136,248 +131,4 @@ export function entryContentDocGuid(entryId: EntryId): string {
 	});
 }
 
-export function createFujiActions(workspace: FujiWorkspace) {
-	const { tables } = workspace;
-	return defineActions({
-		entries_get: defineQuery({
-			title: 'Get Entry',
-			description: 'Read one entry by ID from the daemon workspace.',
-			input: Type.Object({
-				id: Type.String({ description: 'Entry ID to read' }),
-			}),
-			handler: ({ id }) => {
-				return tables.entries.get(id);
-			},
-		}),
-		entries_get_all_valid: defineQuery({
-			title: 'List Valid Entries',
-			description: 'Read all valid entries from the daemon workspace.',
-			input: Type.Object({}),
-			handler: () => {
-				return tables.entries.getAllValid();
-			},
-		}),
-		entries_count: defineQuery({
-			title: 'Count Entries',
-			description: 'Count entries in the daemon workspace.',
-			input: Type.Object({}),
-			handler: () => {
-				return tables.entries.count();
-			},
-		}),
-		entries_has: defineQuery({
-			title: 'Has Entry',
-			description: 'Check whether an entry exists in the daemon workspace.',
-			input: Type.Object({
-				id: Type.String({ description: 'Entry ID to check' }),
-			}),
-			handler: ({ id }) => {
-				return tables.entries.has(id);
-			},
-		}),
-		entries_create: defineMutation({
-			title: 'Create Entry',
-			description:
-				'Create a new CMS entry with optional title, subtitle, type, tags, and rating.',
-			input: Type.Object({
-				title: Type.Optional(Type.String({ description: 'Entry title' })),
-				subtitle: Type.Optional(
-					Type.String({ description: 'Subtitle for blog listings' }),
-				),
-				type: Type.Optional(
-					Type.Array(Type.String(), {
-						description: 'Type classifications',
-					}),
-				),
-				tags: Type.Optional(
-					Type.Array(Type.String(), { description: 'Freeform tags' }),
-				),
-				rating: Type.Optional(
-					Type.Number({ description: 'Rating from 0-5 (0 = unrated)' }),
-				),
-				dateZone: Type.Optional(
-					Type.String({
-						description:
-							'IANA timezone the entry was authored in. Defaults to UTC.',
-					}),
-				),
-			}),
-			handler: ({
-				title,
-				subtitle,
-				type: entryType,
-				tags,
-				rating,
-				dateZone,
-			}) => {
-				const id = generateId<EntryId>();
-				const now = DateTimeString.now();
-				tables.entries.set({
-					id,
-					title: title ?? '',
-					subtitle: subtitle ?? '',
-					type: entryType ?? [],
-					tags: tags ?? [],
-					pinned: false,
-					rating: rating ?? 0,
-					deletedAt: null,
-					date: now,
-					dateZone: (dateZone ?? 'UTC') as IanaTimeZone,
-					createdAt: now,
-					updatedAt: now,
-				});
-				return { id };
-			},
-		}),
-		entries_upsert: defineMutation({
-			title: 'Upsert Entry',
-			description: 'Insert or replace a full entry row.',
-			input: Type.Object({
-				id: Type.String({ description: 'Entry ID' }),
-				title: Type.String({ description: 'Entry title' }),
-				subtitle: Type.String({ description: 'Subtitle for blog listings' }),
-				type: Type.Array(Type.String(), {
-					description: 'Type classifications',
-				}),
-				tags: Type.Array(Type.String(), { description: 'Freeform tags' }),
-				pinned: Type.Boolean({ description: 'Whether the entry is pinned' }),
-				rating: Type.Number({ description: 'Rating from 0 to 5' }),
-				deletedAt: column.nullable(
-					column.dateTime({ description: 'Soft deletion timestamp' }),
-				),
-				date: Type.Unsafe<DateTimeString>({
-					type: 'string',
-					description: 'User-defined date for the entry (UTC ISO 8601)',
-				}),
-				dateZone: Type.String({
-					description: 'IANA timezone for displaying the entry date',
-				}),
-				createdAt: Type.Unsafe<DateTimeString>({
-					type: 'string',
-					description: 'Creation timestamp',
-				}),
-				updatedAt: Type.Unsafe<DateTimeString>({
-					type: 'string',
-					description: 'Last update timestamp',
-				}),
-			}),
-			handler: (row) => {
-				tables.entries.set({
-					...row,
-					id: asEntryId(row.id),
-					dateZone: row.dateZone as IanaTimeZone,
-				});
-				return { id: row.id };
-			},
-		}),
-		entries_update: defineMutation({
-			title: 'Update Entry',
-			description:
-				'Update entry metadata fields. Automatically bumps updatedAt.',
-			input: Type.Object({
-				id: Type.String({ description: 'Entry ID to update' }),
-				title: Type.Optional(Type.String({ description: 'Entry title' })),
-				subtitle: Type.Optional(
-					Type.String({ description: 'Subtitle for blog listings' }),
-				),
-				type: Type.Optional(
-					Type.Array(Type.String(), {
-						description: 'Type classifications',
-					}),
-				),
-				tags: Type.Optional(
-					Type.Array(Type.String(), { description: 'Freeform tags' }),
-				),
-				rating: Type.Optional(
-					Type.Number({ description: 'Rating from 0-5 (0 = unrated)' }),
-				),
-				date: Type.Optional(
-					Type.Unsafe<DateTimeString>({
-						type: 'string',
-						description: 'User-defined date for the entry (UTC ISO 8601)',
-					}),
-				),
-				dateZone: Type.Optional(
-					Type.String({
-						description: 'IANA timezone for displaying the entry date',
-					}),
-				),
-			}),
-			handler: ({ id, dateZone, ...fields }) => {
-				return tables.entries.update(id, {
-					...fields,
-					...(dateZone !== undefined && {
-						dateZone: dateZone as IanaTimeZone,
-					}),
-					updatedAt: DateTimeString.now(),
-				});
-			},
-		}),
-		entries_delete: defineMutation({
-			title: 'Delete Entry',
-			description: 'Soft-delete an entry by setting deletedAt to now.',
-			input: Type.Object({
-				id: Type.String({ description: 'Entry ID to soft-delete' }),
-			}),
-			handler: ({ id }) => {
-				return tables.entries.update(id, {
-					deletedAt: DateTimeString.now(),
-					updatedAt: DateTimeString.now(),
-				});
-			},
-		}),
-		entries_restore: defineMutation({
-			title: 'Restore Entry',
-			description: 'Restore a soft-deleted entry by clearing deletedAt.',
-			input: Type.Object({
-				id: Type.String({ description: 'Entry ID to restore' }),
-			}),
-			handler: ({ id }) => {
-				return tables.entries.update(id, {
-					deletedAt: null,
-					updatedAt: DateTimeString.now(),
-				});
-			},
-		}),
-		entries_bulk_create: defineMutation({
-			title: 'Bulk Create Entries',
-			description:
-				'Create multiple entries at once from title + (date, dateZone) pairs.',
-			input: Type.Object({
-				dateZone: Type.String({
-					description:
-						'IANA timezone the entries were authored in. Applied to every row.',
-				}),
-				entries: Type.Array(
-					Type.Object({
-						title: Type.String({ description: 'Entry title' }),
-						date: Type.String({
-							description: 'UTC ISO 8601 instant for the entry',
-						}),
-					}),
-				),
-			}),
-			handler: async ({ dateZone, entries: items }) => {
-				const now = DateTimeString.now();
-				const rows = items.map(({ title, date }) => ({
-					id: generateId<EntryId>(),
-					title,
-					subtitle: '',
-					type: [] as string[],
-					tags: [] as string[],
-					pinned: false,
-					rating: 0,
-					deletedAt: null,
-					date: date as DateTimeString,
-					dateZone: dateZone as IanaTimeZone,
-					createdAt: now,
-					updatedAt: now,
-				}));
-				await tables.entries.bulkSet(rows);
-				return { count: rows.length };
-			},
-		}),
-	});
-}
-
-export type FujiActions = ReturnType<typeof createFujiActions>;
+export { createFujiActions, type FujiActions } from './actions';

--- a/apps/honeycrisp/workspace.ts
+++ b/apps/honeycrisp/workspace.ts
@@ -23,7 +23,6 @@ import {
 	generateId,
 	type InferTableRow,
 	type Keyring,
-	type Tables,
 } from '@epicenter/workspace';
 import Type from 'typebox';
 import type { Brand } from 'wellcrafted/brand';
@@ -128,18 +127,13 @@ const notesTable = defineTable(
 });
 export type Note = InferTableRow<typeof notesTable>;
 
-// ─── Table map ─────────────────────────────────────────────────────────────────
-
-export const honeycrispTables = { folders: foldersTable, notes: notesTable };
-export type HoneycrispTables = Tables<typeof honeycrispTables>;
-
 // ─── Workspace factory ────────────────────────────────────────────────────────
 
 export function createHoneycrispWorkspace(opts: { keyring: () => Keyring }) {
 	return createWorkspace({
 		id: HONEYCRISP_ID,
 		keyring: opts.keyring,
-		tables: honeycrispTables,
+		tables: { folders: foldersTable, notes: notesTable },
 		kv: {},
 	});
 }

--- a/apps/opensidian/workspace.ts
+++ b/apps/opensidian/workspace.ts
@@ -26,7 +26,6 @@ import {
 	type Id,
 	type InferTableRow,
 	type Keyring,
-	type Tables,
 } from '@epicenter/workspace';
 import { Type } from 'typebox';
 import type { Brand } from 'wellcrafted/brand';
@@ -133,21 +132,10 @@ const toolTrustTable = defineTable({
 export type ToolTrust = InferTableRow<typeof toolTrustTable>;
 
 /**
- * Opensidian workspace table schema.
+ * Build an Opensidian workspace bundle: `{ ydoc, tables, kv, [Symbol.dispose] }`.
  *
  * Combines the filesystem-backed notes table with the chat tables so the app
  * can store notes, conversations, messages, and tool approvals in one schema.
- */
-export const opensidianTables = {
-	files: filesTable,
-	conversations: conversationsTable,
-	chatMessages: chatMessagesTable,
-	toolTrust: toolTrustTable,
-};
-export type OpensidianTables = Tables<typeof opensidianTables>;
-
-/**
- * Build an Opensidian workspace bundle: `{ ydoc, tables, kv, [Symbol.dispose] }`.
  *
  * Encrypted under the supplied keyring. Used by browser, daemon, and tests.
  */
@@ -155,7 +143,12 @@ export function createOpensidianWorkspace(opts: { keyring: () => Keyring }) {
 	return createWorkspace({
 		id: OPENSIDIAN_ID,
 		keyring: opts.keyring,
-		tables: opensidianTables,
+		tables: {
+			files: filesTable,
+			conversations: conversationsTable,
+			chatMessages: chatMessagesTable,
+			toolTrust: toolTrustTable,
+		},
 		kv: {},
 	});
 }

--- a/apps/zhongwen/workspace.ts
+++ b/apps/zhongwen/workspace.ts
@@ -23,7 +23,6 @@ import {
 	type Id,
 	type InferTableRow,
 	type Keyring,
-	type Tables,
 } from '@epicenter/workspace';
 import { Type } from 'typebox';
 import type { Brand } from 'wellcrafted/brand';
@@ -81,20 +80,6 @@ const chatMessagesTable = defineTable({
 export type ChatMessage = InferTableRow<typeof chatMessagesTable>;
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Schema Records
-// ─────────────────────────────────────────────────────────────────────────────
-
-export const zhongwenTables = {
-	conversations: conversationsTable,
-	chatMessages: chatMessagesTable,
-};
-export type ZhongwenTables = Tables<typeof zhongwenTables>;
-
-export const zhongwenKv = {
-	showPinyin: defineKv(Type.Boolean(), () => true),
-};
-
-// ─────────────────────────────────────────────────────────────────────────────
 // Workspace Factory
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -102,8 +87,13 @@ export function createZhongwenWorkspace(opts: { keyring: () => Keyring }) {
 	return createWorkspace({
 		id: ZHONGWEN_ID,
 		keyring: opts.keyring,
-		tables: zhongwenTables,
-		kv: zhongwenKv,
+		tables: {
+			conversations: conversationsTable,
+			chatMessages: chatMessagesTable,
+		},
+		kv: {
+			showPinyin: defineKv(Type.Boolean(), () => true),
+		},
 	});
 }
 export type ZhongwenWorkspace = ReturnType<typeof createZhongwenWorkspace>;

--- a/playground/opensidian-e2e/workspace.test.ts
+++ b/playground/opensidian-e2e/workspace.test.ts
@@ -14,20 +14,21 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { mkdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
-import { type FileId, fileContentDocGuid } from '@epicenter/filesystem';
+import type { FileId } from '@epicenter/filesystem';
 import {
 	attachTimeline,
 	createDisposableCache,
-	createWorkspace,
 	generateId,
 } from '@epicenter/workspace';
 import { assembleMarkdown } from '@epicenter/workspace/markdown';
 import { attachYjsLog } from '@epicenter/workspace/node';
-import { opensidianTables } from 'opensidian';
+import {
+	createOpensidianWorkspace,
+	opensidianFileContentDocGuid,
+} from 'opensidian';
 import * as Y from 'yjs';
 import { pushFromMarkdown } from './push-from-markdown';
 
-const WORKSPACE_ID = 'opensidian';
 const TEST_ENCRYPTION_KEYS = [
 	{
 		version: 1,
@@ -46,20 +47,17 @@ function dbPath(id: string) {
 
 /** Create a workspace client with filesystem persistence for testing. */
 function createTestClient() {
-	const workspace = createWorkspace({
-		id: WORKSPACE_ID,
+	const workspace = createOpensidianWorkspace({
 		keyring: () => TEST_ENCRYPTION_KEYS,
-		tables: opensidianTables,
-		kv: {},
 	});
 	attachYjsLog(workspace.ydoc, {
-		filePath: dbPath(WORKSPACE_ID),
+		filePath: dbPath(workspace.ydoc.guid),
 	});
 
 	const contentDocs = createDisposableCache(
 		(fileId: FileId) => {
 			const contentDoc = new Y.Doc({
-				guid: fileContentDocGuid({ workspaceId: WORKSPACE_ID, fileId }),
+				guid: opensidianFileContentDocGuid(fileId),
 				gc: true,
 			});
 			attachYjsLog(contentDoc, {
@@ -78,7 +76,7 @@ function createTestClient() {
 	);
 
 	const client = {
-		id: WORKSPACE_ID,
+		id: workspace.ydoc.guid,
 		ydoc: workspace.ydoc,
 		tables: workspace.tables,
 		kv: workspace.kv,
@@ -194,20 +192,17 @@ describe('e2e: opensidian pushFromMarkdown', () => {
 	const IMPORT_FILES_DIR = join(IMPORT_DIR, 'files');
 
 	function createImportClient() {
-		const workspace = createWorkspace({
-			id: WORKSPACE_ID,
+		const workspace = createOpensidianWorkspace({
 			keyring: () => TEST_ENCRYPTION_KEYS,
-			tables: opensidianTables,
-			kv: {},
 		});
 		attachYjsLog(workspace.ydoc, {
-			filePath: join(IMPORT_PERSISTENCE, 'opensidian.db'),
+			filePath: join(IMPORT_PERSISTENCE, `${workspace.ydoc.guid}.db`),
 		});
 
 		const contentDocs = createDisposableCache(
 			(fileId: FileId) => {
 				const contentDoc = new Y.Doc({
-					guid: fileContentDocGuid({ workspaceId: WORKSPACE_ID, fileId }),
+					guid: opensidianFileContentDocGuid(fileId),
 					gc: true,
 				});
 				attachYjsLog(contentDoc, {
@@ -230,7 +225,7 @@ describe('e2e: opensidian pushFromMarkdown', () => {
 		);
 
 		const client = {
-			id: WORKSPACE_ID,
+			id: workspace.ydoc.guid,
 			ydoc: workspace.ydoc,
 			tables: workspace.tables,
 			kv: workspace.kv,

--- a/playground/opensidian-e2e/workspaces/opensidian/daemon.ts
+++ b/playground/opensidian-e2e/workspaces/opensidian/daemon.ts
@@ -9,11 +9,10 @@
  * ```
  */
 
-import { fileContentDocGuid } from '@epicenter/filesystem';
+import type { FileId } from '@epicenter/filesystem';
 import {
 	attachTimeline,
 	createDisposableCache,
-	createWorkspace,
 	defineActions,
 	defineMutation,
 	defineWorkspace,
@@ -30,13 +29,15 @@ import {
 	sqlitePath,
 	yjsPath,
 } from '@epicenter/workspace/node';
-import { opensidianTables } from 'opensidian';
+import {
+	createOpensidianWorkspace,
+	opensidianFileContentDocGuid,
+} from 'opensidian';
 import Type from 'typebox';
 import * as Y from 'yjs';
 import { prepareMarkdownFiles } from '../../prepare-markdown-files';
 
 const SERVER_URL = process.env.EPICENTER_SERVER ?? 'https://api.epicenter.so';
-const WORKSPACE_ID = 'opensidian';
 
 async function openOpensidianPlayground({
 	projectDir,
@@ -47,26 +48,19 @@ async function openOpensidianPlayground({
 	openWebSocket,
 	onReconnectSignal,
 }: DaemonWorkspaceContext) {
-	const workspace = createWorkspace({
-		id: WORKSPACE_ID,
-		keyring,
-		tables: opensidianTables,
-		kv: {},
-	});
+	const workspace = createOpensidianWorkspace({ keyring });
 	workspace.ydoc.clientID = yDocClientId;
 	const { ydoc, tables, kv } = workspace;
+	const workspaceId = ydoc.guid;
 
 	const persistence = attachYjsLog(ydoc, {
-		filePath: yjsPath(projectDir, WORKSPACE_ID),
+		filePath: yjsPath(projectDir, workspaceId),
 	});
 
 	const fileContentDocs = createDisposableCache(
 		(fileId: string) => {
 			const contentYdoc = new Y.Doc({
-				guid: fileContentDocGuid({
-					workspaceId: WORKSPACE_ID,
-					fileId: fileId as never,
-				}),
+				guid: opensidianFileContentDocGuid(fileId as FileId),
 				gc: true,
 			});
 			const contentPersistence = attachYjsLog(contentYdoc, {
@@ -113,7 +107,7 @@ async function openOpensidianPlayground({
 
 	const whenReady = collaboration.whenConnected;
 	const markdown = attachMarkdownMaterializer(workspace, {
-		dir: markdownPath(projectDir, WORKSPACE_ID),
+		dir: markdownPath(projectDir, workspaceId),
 		waitFor: whenReady,
 		perTable: {
 			files: {
@@ -152,7 +146,7 @@ async function openOpensidianPlayground({
 	});
 
 	const sqlite = attachBunSqliteMaterializer(workspace, {
-		filePath: sqlitePath(projectDir, WORKSPACE_ID),
+		filePath: sqlitePath(projectDir, workspaceId),
 		waitFor: whenReady,
 		fts: { files: ['name'] },
 	});


### PR DESCRIPTION
## What's going on

The Epicenter workspace API is already in pretty good shape: a `createWorkspace` factory returns a storage bundle (`ydoc + tables + kv`), and each app wraps it with a `createXWorkspace({ keyring })` that fills in `id`, `tables`, and `kv`. Nothing about that needed to change.

What did need to change was a small smell in the wrappers themselves. Every app declared its tables as a named top-level constant, then immediately passed that constant back into `createWorkspace` one line later, and exported a `XTables` type alias for the result. We checked. Across Fuji, Honeycrisp, Zhongwen, and Opensidian, those table constants and aliases had **zero downstream importers**. They existed as bookkeeping for nobody.

So this PR deletes the bookkeeping and inlines the schema literal into the factory body. The schema lives in exactly one place. There is no `fujiTables` name to maintain.

### Before (Fuji)

```ts
export const fujiTables = { entries: entriesTable };
export type FujiTables = Tables<typeof fujiTables>;

export function createFujiWorkspace(opts: { keyring: () => Keyring }) {
  return createWorkspace({
    id: FUJI_ID,
    keyring: opts.keyring,
    tables: fujiTables,
    kv: {},
  });
}
```

### After

```ts
export function createFujiWorkspace(opts: { keyring: () => Keyring }) {
  return createWorkspace({
    id: FUJI_ID,
    keyring: opts.keyring,
    tables: { entries: entriesTable },
    kv: {},
  });
}
export type FujiWorkspace = ReturnType<typeof createFujiWorkspace>;
```

Same logic across Honeycrisp, Zhongwen, and Opensidian. Row types like `Entry`, `Note`, `Folder` stay exported untouched, because those have real UI consumers.

## Splitting Fuji's actions for cohesion

Fuji's `workspace.ts` was 380 lines, most of which was a 240-line `createFujiActions` registry sitting below the workspace factory. Honeycrisp has one action; Fuji has ten queries and mutations with full TypeBox schemas. At Fuji's size, the actions deserve their own file.

The split is purely organizational. `createFujiActions` and `type FujiActions` now live in `apps/fuji/src/lib/actions.ts` and are re-exported from `workspace.ts`:

```ts
// bottom of apps/fuji/src/lib/workspace.ts
export { createFujiActions, type FujiActions } from './actions';
```

The `@epicenter/fuji` package surface is byte-identical from a caller's perspective. `examples/fuji/epicenter.config.ts`, `apps/fuji/src/lib/browser.ts`, `apps/fuji/daemon.ts`, and the docs all keep importing from `@epicenter/fuji` exactly as before. Zero call-site churn.

## The Opensidian playground migration

`opensidianTables` was the one table constant with real external consumers: two files in `playground/opensidian-e2e/` imported it and re-implemented the workspace bundle themselves:

```ts
// playground/opensidian-e2e/workspace.test.ts (before)
import { opensidianTables } from 'opensidian';

const workspace = createWorkspace({
  id: WORKSPACE_ID,
  keyring: () => TEST_ENCRYPTION_KEYS,
  tables: opensidianTables,
  kv: {},
});
```

The playground wasn't doing anything special with the tables, just paying for ceremony. Routed it through the factory and used the existing `opensidianFileContentDocGuid` helper for sub-doc identity:

```ts
// after
import {
  createOpensidianWorkspace,
  opensidianFileContentDocGuid,
} from 'opensidian';

const workspace = createOpensidianWorkspace({
  keyring: () => TEST_ENCRYPTION_KEYS,
});
```

With both playground sites going through the factory, `opensidianTables` had no external consumers left, so it was inlined too.

## Why this doesn't touch the actions composition API

We considered baking actions into `createWorkspace`, or adding a `withActions(workspace, factory)` helper, or having app wrappers return `{ workspace, actions }`. None of those survive Opensidian: its browser actions need `YjsFileSystem + SqliteIndex + Bash`, none of which exist on the daemon side, so the daemon intentionally passes `actions: {}`. A workspace that ships its own actions either lies about what it exposes or pushes runtime branching into the base factory. The current linear composition (`createWorkspace -> createActions -> openCollaboration`) makes that browser/daemon asymmetry explicit and visible, and is the shape this PR preserves.

## Summary

- 7 files changed: +315 / -330 (one new: `apps/fuji/src/lib/actions.ts`)
- All four apps typecheck clean: `@epicenter/fuji`, `@epicenter/honeycrisp`, `@epicenter/zhongwen`, `opensidian`
- No public API changes: `@epicenter/fuji`, `@epicenter/honeycrisp`, `@epicenter/zhongwen`, `opensidian` package surfaces all unchanged
- No wire-format, storage-format, or sync-protocol changes

## Test plan

- [x] `bun run typecheck` clean for each touched app individually
- [x] Smoke-run Fuji browser to confirm `createFujiActions` still wires through the package re-export
- [x] Smoke-run an Opensidian playground daemon to confirm the factory route still materializes correctly

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782366730&installation_id=128463665&pr_number=1822&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1822&signature=4a22a116adc027b7def59482675b0413506dd74ccd937a7e5fa81065eadbe225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->