### PR TITLE
feat(whispering): enable CoreML acceleration for Parakeet and Moonshine on macOS

### DIFF
--- a/apps/whispering/src-tauri/Cargo.toml
+++ b/apps/whispering/src-tauri/Cargo.toml
@@ -62,7 +62,7 @@ windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_
 transcribe-rs = { version = "=0.3.8", features = ["whisper-vulkan", "ort-directml"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-transcribe-rs = { version = "=0.3.8", features = ["whisper-cpp", "whisper-metal", "onnx"] }
+transcribe-rs = { version = "=0.3.8", features = ["whisper-cpp", "whisper-metal", "onnx", "ort-coreml"] }
 accessibility-sys =  "0.1.3"
 core-foundation-sys =  "0.8.7"
 

--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -95,11 +95,14 @@ pub async fn run() {
     // This ensures child processes can find ffmpeg on Windows
     fix_windows_path();
 
-    // OrtAccelerator::Auto deliberately excludes DirectML because DirectML
-    // requires sequential ORT session settings. On Windows, select it
-    // explicitly so the compiled-in `ort-directml` feature is actually used.
-    // Other platforms rely on the default Auto, which picks CoreML/CUDA where
-    // those features are compiled in.
+    // ONNX Runtime accelerator for Parakeet and Moonshine. `OrtAccelerator::Auto`
+    // picks the best provider that's compiled in (CoreML on macOS, CPU on Linux),
+    // but it deliberately excludes DirectML because DirectML needs sequential ORT
+    // session settings that would penalize other backends. So on Windows we
+    // select DirectML explicitly to honor the compiled-in `ort-directml` feature.
+    // transcribe-rs always appends CPU to the EP list, so a CoreML or DirectML
+    // init failure degrades to CPU rather than failing the transcription. Set
+    // `ORT_LOG_SEVERITY_LEVEL=0` to confirm which EP ORT actually selected.
     #[cfg(target_os = "windows")]
     transcribe_rs::accel::set_ort_accelerator(transcribe_rs::accel::OrtAccelerator::DirectMl);
 


### PR DESCRIPTION
Parakeet and Moonshine run through ONNX Runtime, and on macOS they've been silently CPU-only this whole time because the `ort-coreml` feature wasn't enabled in the transcribe-rs target config. Whisper already had its `whisper-metal` path on macOS, so it was easy to miss that the ONNX engines weren't getting any Apple Silicon acceleration at all. On an M-series Mac, every Parakeet or Moonshine transcription was burning CPU cores while the Neural Engine sat idle.

The fix is a one-line Cargo feature addition. transcribe-rs 0.3.x exposes `ort-coreml`, which compiles in the ONNX Runtime CoreML execution provider. Once that EP is available, transcribe-rs's `OrtAccelerator::Auto` (the default) already prioritizes CoreML above CPU, so the runtime picks it up automatically on macOS — no explicit `set_ort_accelerator` call required.

```toml
[target.'cfg(target_os = "macos")'.dependencies]
transcribe-rs = { version = "=0.3.8", features = ["whisper-cpp", "whisper-metal", "onnx", "ort-coreml"] }
```

This intentionally mirrors how the rest of the platform matrix already works. Windows is the asymmetric case: `Auto` deliberately excludes DirectML (DirectML needs sequential ORT session settings that would penalize other backends), so the Windows-only `set_ort_accelerator(DirectMl)` call in `lib.rs` is required to honor the compiled-in `ort-directml` feature. macOS has no such exclusion — Auto handles it. Linux compiles in no GPU ONNX providers, so Auto resolves to CPU. Three platforms, one honest pattern:

```
              ┌──────────────────────────────────────────────────────────┐
              │  transcribe-rs ONNX accelerator selection                │
              ├──────────────────────────────────────────────────────────┤
              │  macOS    →  Auto → CoreML  (ort-coreml feature flag)    │
              │  Windows  →  explicit DirectMl (Auto excludes it)        │
              │  Linux    →  Auto → CPU      (no GPU EPs compiled in)    │
              └──────────────────────────────────────────────────────────┘
```

I'd initially also added an explicit `set_ort_accelerator(CoreMl)` on macOS for the sake of "platform intent auditable from one place," but that was fake symmetry. The Windows call exists because Auto's behavior forces it; the macOS call would have been behaviorally redundant. The comment in `lib.rs` now explains the asymmetry directly and points at `ORT_LOG_SEVERITY_LEVEL=0` as the verification command.

On the failure-mode side, transcribe-rs's `execution_providers()` always appends `CPU::default().build()` as the last entry in the EP list, so a CoreML init failure or unsupported op subgraph degrades to CPU rather than failing the transcription. That CPU-append is what makes this safe to enable across the whole macOS target — Apple Silicon, Intel, and any older OS version where the CoreML EP might misbehave all converge on a working code path. Intel Macs in particular don't have a Neural Engine, but the CoreML EP still runs on CPU+GPU there; if it ever turns out to be slower than the pure CPU EP on a specific workload, the per-op fallback takes care of it without the user noticing.

One downside worth naming: Parakeet loads with `Quantization::Int8`, and the CoreML EP's Int8 support is uneven. The graph may run partly on ANE and partly on CPU, with data transfer in between, which can in pathological cases be slower than pure CPU. Moonshine (float) is the cleaner Apple Silicon win. If benchmarks ever show Parakeet regressing on Apple Silicon vs the old CPU path, the follow-up is to either pin Parakeet to float quantization on macOS or wait for ORT to expose `CoreMLExecutionProviderOptions` knobs through transcribe-rs. Not pre-engineering that today — the per-op fallback keeps things correct, and the typical case (Moonshine + Apple Silicon) is unambiguously better.

For comparison, Handy (which is also on transcribe-rs) currently does not enable `ort-coreml` for macOS — their Cargo pin is on 0.3.3 and likely predates the feature being exposed. So enabling this puts Whispering slightly ahead of the comparable app on the Apple Silicon perf front for ONNX engines.

To confirm the active provider after this lands: launch with `ORT_LOG_SEVERITY_LEVEL=0` in the environment to see ORT's EP list at session-build time, or watch Activity Monitor's ANE Energy column during a Parakeet/Moonshine transcription on an M-series Mac.

## Changelog
- Speed up Parakeet and Moonshine transcription on Apple Silicon by enabling CoreML acceleration

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782372443&installation_id=128463665&pr_number=1823&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1823&signature=15e9ea899d0f6965a6811e0e211abaea7e96e5fc191b16bb83ba5574cfdd56f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->