### PR TITLE
feat(whispering): idle eviction for local transcription models

### DIFF
--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -12,7 +12,7 @@ use recorder::commands::{
 use recorder::recorder::Recorder;
 
 pub mod transcription;
-use transcription::{transcribe_audio, ModelManager};
+use transcription::{set_unload_policy, transcribe_audio, ModelManager};
 
 pub mod windows_path;
 use windows_path::fix_windows_path;
@@ -139,7 +139,15 @@ pub async fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_opener::init())
         .manage(Mutex::new(Recorder::new()))
-        .manage(ModelManager::new());
+        .manage(ModelManager::new())
+        .setup(|app| {
+            // Start the model idle watcher. It runs on the Tauri async
+            // runtime, sleeps between checks, and drops the resident
+            // model when the configured idle timeout elapses.
+            let manager = app.state::<ModelManager>().inner().clone();
+            manager.start_idle_watcher();
+            Ok(())
+        });
 
     #[cfg(desktop)]
     {
@@ -169,6 +177,7 @@ pub async fn run() {
         stop_recording,
         cancel_recording,
         transcribe_audio,
+        set_unload_policy,
         send_sigint,
         // Command execution (prevents console window flash on Windows)
         execute_command,

--- a/apps/whispering/src-tauri/src/transcription/mod.rs
+++ b/apps/whispering/src-tauri/src/transcription/mod.rs
@@ -6,6 +6,7 @@ use audio::prepare_samples_for_transcription;
 use error::TranscriptionError;
 use log::info;
 pub use model_manager::ModelManager;
+use model_manager::UnloadPolicy;
 use serde::Deserialize;
 use std::path::PathBuf;
 use tauri::ipc::{InvokeBody, Request};
@@ -122,6 +123,18 @@ pub async fn transcribe_audio(
         .map_err(join_err)?
 }
 
+/// Update the model unload policy from the frontend. Called by an effect
+/// in the SvelteKit layout whenever `transcription.localModelUnloadPolicy`
+/// changes, and once at app startup to push the initial value.
+///
+/// Unknown values fall back to the default inside `UnloadPolicy::from_wire`
+/// rather than erroring, so a future rename or corrupt localStorage value
+/// never breaks transcription.
+#[tauri::command]
+pub fn set_unload_policy(policy: String, model_manager: tauri::State<'_, ModelManager>) {
+    model_manager.set_policy(UnloadPolicy::from_wire(&policy));
+}
+
 /// Map a join failure from spawn_blocking into a TranscriptionError so the
 /// frontend always sees a structured error even when the background task
 /// panics or is cancelled.
@@ -209,5 +222,8 @@ fn run_transcription(
         engine_label,
         transcript.len()
     );
+    // For the `Immediately` policy, drop the resident model now that this
+    // transcription is done. No-op for any other policy.
+    manager.evict_if_immediate();
     Ok(transcript)
 }

--- a/apps/whispering/src-tauri/src/transcription/model_manager.rs
+++ b/apps/whispering/src-tauri/src/transcription/model_manager.rs
@@ -1,11 +1,52 @@
 use super::error::TranscriptionError;
-use log::{debug, warn};
+use log::{debug, info, warn};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard, RwLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use transcribe_rs::onnx::moonshine::{MoonshineModel, MoonshineVariant};
 use transcribe_rs::onnx::parakeet::ParakeetModel;
 use transcribe_rs::onnx::Quantization;
 use transcribe_rs::whisper_cpp::WhisperEngine;
+
+/// How long after the last transcription the resident model should be
+/// dropped. Mirrors the frontend setting `transcription.localModelUnloadPolicy`.
+///
+/// `Immediately` is enforced synchronously at the end of each transcription
+/// (see `ModelManager::evict_if_immediate`). Timed variants are enforced by
+/// the background idle watcher (see `ModelManager::start_idle_watcher`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnloadPolicy {
+    Never,
+    Immediately,
+    AfterMinutes(u64),
+}
+
+impl UnloadPolicy {
+    /// Default policy if the frontend never pushes one. Matches the frontend
+    /// default so a fresh install behaves identically before any setting
+    /// observer fires.
+    pub const DEFAULT: Self = Self::AfterMinutes(5);
+
+    /// Parse a wire-format string from the frontend setting. Unknown values
+    /// fall back to `DEFAULT` rather than failing so a stale or future value
+    /// from a synced workspace never bricks the model layer.
+    pub fn from_wire(s: &str) -> Self {
+        match s {
+            "never" => Self::Never,
+            "immediately" => Self::Immediately,
+            "after_5_minutes" => Self::AfterMinutes(5),
+            "after_30_minutes" => Self::AfterMinutes(30),
+            other => {
+                warn!(
+                    "[Transcription] Unknown unload policy '{}', falling back to default",
+                    other
+                );
+                Self::DEFAULT
+            }
+        }
+    }
+}
 
 /// Engine type for managing different transcription engines.
 /// Dropping a variant releases the underlying model resources.
@@ -22,13 +63,97 @@ type Cached = Option<(PathBuf, Engine)>;
 #[derive(Clone)]
 pub struct ModelManager {
     cached: Arc<Mutex<Cached>>,
+    /// Millis since UNIX_EPOCH of the last transcription start or completion.
+    /// `AtomicU64` so the watcher can read it without contending with the
+    /// cache mutex held during long inference.
+    last_activity_ms: Arc<AtomicU64>,
+    /// Current unload policy. `RwLock` because the watcher reads on every
+    /// tick while writes only happen when the user changes the setting.
+    policy: Arc<RwLock<UnloadPolicy>>,
 }
 
 impl ModelManager {
     pub fn new() -> Self {
         Self {
             cached: Arc::new(Mutex::new(None)),
+            last_activity_ms: Arc::new(AtomicU64::new(now_millis())),
+            policy: Arc::new(RwLock::new(UnloadPolicy::DEFAULT)),
         }
+    }
+
+    pub fn set_policy(&self, policy: UnloadPolicy) {
+        let mut guard = match self.policy.write() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if *guard != policy {
+            info!("[Transcription] Unload policy changed to {:?}", policy);
+            *guard = policy;
+        }
+    }
+
+    fn current_policy(&self) -> UnloadPolicy {
+        match self.policy.read() {
+            Ok(g) => *g,
+            Err(poisoned) => *poisoned.into_inner(),
+        }
+    }
+
+    fn touch_activity(&self) {
+        self.last_activity_ms.store(now_millis(), Ordering::Relaxed);
+    }
+
+    /// Drop the resident model now if the current policy is `Immediately`.
+    /// Called at the end of every successful transcription. A no-op for any
+    /// other policy.
+    ///
+    /// Blocking lock acquisition is fine: this runs at the end of a
+    /// transcription that just held the same lock, so no contention is
+    /// possible at the call site.
+    pub fn evict_if_immediate(&self) {
+        if matches!(self.current_policy(), UnloadPolicy::Immediately) {
+            evict_locked(&mut lock_cached(&self.cached), "immediate");
+        }
+    }
+
+    /// Start the background idle watcher. Spawns one task on the Tauri
+    /// async runtime; safe to call once at app setup. Returns immediately.
+    ///
+    /// The watcher sleeps between checks, never holds the cache lock while
+    /// waiting, and skips ticks where another caller currently holds the
+    /// cache (long-running transcription in progress).
+    pub fn start_idle_watcher(&self) {
+        let this = self.clone();
+        tauri::async_runtime::spawn(async move {
+            // Same cadence as Handy. Coarse on purpose: idle eviction is
+            // not latency-sensitive and a 10s tick keeps overhead trivial.
+            let tick = Duration::from_secs(10);
+            loop {
+                tokio::time::sleep(tick).await;
+                this.tick_idle();
+            }
+        });
+    }
+
+    /// One iteration of the idle watcher. Pulled out of the spawn closure
+    /// so the control flow is straight-line and the awaitless body is
+    /// trivially reviewable: read policy, compute idle, `try_lock`, evict.
+    fn tick_idle(&self) {
+        let Some(timeout) = idle_timeout_for(self.current_policy()) else {
+            return;
+        };
+        let idle = Duration::from_millis(
+            now_millis().saturating_sub(self.last_activity_ms.load(Ordering::Relaxed)),
+        );
+        if idle < timeout {
+            return;
+        }
+        // `try_lock` so a long transcription in progress just postpones
+        // eviction to the next tick instead of blocking the watcher.
+        let Ok(mut guard) = self.cached.try_lock() else {
+            return;
+        };
+        evict_locked(&mut guard, format_args!("idle {}s", idle.as_secs()));
     }
 
     pub fn with_whisper<T>(
@@ -98,6 +223,9 @@ impl ModelManager {
     /// holding the lock. This serializes concurrent transcribe calls (only
     /// one engine fits in memory anyway) and eliminates any race where
     /// another thread could swap the engine between a load and a use step.
+    ///
+    /// Stamps activity both before and after the use step so the idle
+    /// watcher counts from the *end* of inference, not the start.
     fn with_engine<T>(
         &self,
         model_path: PathBuf,
@@ -105,6 +233,7 @@ impl ModelManager {
         load: impl FnOnce(&Path) -> Result<Engine, String>,
         use_engine: impl FnOnce(&mut Engine) -> Result<T, TranscriptionError>,
     ) -> Result<T, TranscriptionError> {
+        self.touch_activity();
         let mut guard = lock_cached(&self.cached);
 
         let reuse = matches!(&*guard, Some((p, e)) if p == &model_path && can_reuse(e));
@@ -118,8 +247,42 @@ impl ModelManager {
         }
 
         let (_, engine) = guard.as_mut().expect("cache slot populated above");
-        use_engine(engine)
+        let result = use_engine(engine);
+        self.touch_activity();
+        result
     }
+}
+
+/// Drain the cache slot under an already-held guard and log who triggered
+/// it. Shared by `evict_if_immediate` (synchronous, blocking lock) and the
+/// idle watcher (non-blocking `try_lock`). The actual `Drop` of the engine
+/// runs when the guard is released by the caller, so the lock is never
+/// held across heavy teardown.
+fn evict_locked(guard: &mut MutexGuard<'_, Cached>, reason: impl std::fmt::Display) {
+    if let Some((path, _engine)) = guard.take() {
+        debug!(
+            "[Transcription] unloaded model ({}): {}",
+            reason,
+            path.display()
+        );
+    }
+}
+
+/// Return the idle duration after which the watcher should evict, or `None`
+/// if this policy is not driven by the watcher (Never never evicts;
+/// Immediately is enforced synchronously after each transcription).
+fn idle_timeout_for(policy: UnloadPolicy) -> Option<Duration> {
+    match policy {
+        UnloadPolicy::Never | UnloadPolicy::Immediately => None,
+        UnloadPolicy::AfterMinutes(m) => Some(Duration::from_secs(m * 60)),
+    }
+}
+
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
 }
 
 /// Lock the cache slot, recovering from poisoning by clearing the cached
@@ -134,4 +297,58 @@ fn lock_cached(cached: &Mutex<Cached>) -> MutexGuard<'_, Cached> {
         *recovered = None;
         recovered
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_known_policy_values() {
+        assert_eq!(UnloadPolicy::from_wire("never"), UnloadPolicy::Never);
+        assert_eq!(
+            UnloadPolicy::from_wire("immediately"),
+            UnloadPolicy::Immediately
+        );
+        assert_eq!(
+            UnloadPolicy::from_wire("after_5_minutes"),
+            UnloadPolicy::AfterMinutes(5)
+        );
+        assert_eq!(
+            UnloadPolicy::from_wire("after_30_minutes"),
+            UnloadPolicy::AfterMinutes(30)
+        );
+    }
+
+    #[test]
+    fn unknown_wire_value_falls_back_to_default() {
+        assert_eq!(UnloadPolicy::from_wire("after_3_minutes"), UnloadPolicy::DEFAULT);
+        assert_eq!(UnloadPolicy::from_wire(""), UnloadPolicy::DEFAULT);
+    }
+
+    #[test]
+    fn idle_timeout_is_none_for_non_timed_policies() {
+        assert!(idle_timeout_for(UnloadPolicy::Never).is_none());
+        assert!(idle_timeout_for(UnloadPolicy::Immediately).is_none());
+    }
+
+    #[test]
+    fn idle_timeout_matches_minutes() {
+        assert_eq!(
+            idle_timeout_for(UnloadPolicy::AfterMinutes(5)),
+            Some(Duration::from_secs(300))
+        );
+        assert_eq!(
+            idle_timeout_for(UnloadPolicy::AfterMinutes(30)),
+            Some(Duration::from_secs(1800))
+        );
+    }
+
+    #[test]
+    fn set_policy_updates_current_value() {
+        let manager = ModelManager::new();
+        assert_eq!(manager.current_policy(), UnloadPolicy::DEFAULT);
+        manager.set_policy(UnloadPolicy::Immediately);
+        assert_eq!(manager.current_policy(), UnloadPolicy::Immediately);
+    }
 }

--- a/apps/whispering/src/lib/constants/transcription.ts
+++ b/apps/whispering/src/lib/constants/transcription.ts
@@ -222,3 +222,48 @@ export const TRANSCRIPTION_SERVICE_IDS = Object.keys(
 export const TRANSCRIPTION_SERVICE_ID_TO_LABEL = Object.fromEntries(
 	TRANSCRIPTION_SERVICE_IDS.map((id) => [id, TRANSCRIPTION[id].label]),
 ) as Record<TranscriptionServiceId, string>;
+
+/**
+ * When to drop the resident local transcription model from memory after the
+ * user stops transcribing. Single source of truth: the OPTIONS array below
+ * carries values, labels, and descriptions; the tuple and union type are
+ * derived from it (same pattern as TRANSCRIPTION → TRANSCRIPTION_SERVICE_IDS).
+ *
+ * Mirrored in Rust by `UnloadPolicy::from_wire` in
+ * `src-tauri/src/transcription/model_manager.rs`. If you add a value here,
+ * teach the Rust parser about it too.
+ *
+ * Default order is UX order (recommended first), not alphabetical.
+ */
+export const LOCAL_MODEL_UNLOAD_POLICY_OPTIONS = [
+	{
+		value: 'after_5_minutes',
+		label: 'After 5 minutes',
+		description: 'Drop the model after 5 minutes of inactivity. Good default.',
+	},
+	{
+		value: 'after_30_minutes',
+		label: 'After 30 minutes',
+		description:
+			'Drop the model after 30 minutes of inactivity. Useful for bursty workflows.',
+	},
+	{
+		value: 'immediately',
+		label: 'Immediately',
+		description:
+			'Drop after every transcription. Minimum memory, slowest next transcription.',
+	},
+	{
+		value: 'never',
+		label: 'Never',
+		description: 'Keep the model resident until the app exits.',
+	},
+] as const;
+
+export type LocalModelUnloadPolicy =
+	(typeof LOCAL_MODEL_UNLOAD_POLICY_OPTIONS)[number]['value'];
+
+/** Convenience array for `type.enumerated(...LOCAL_MODEL_UNLOAD_POLICIES)`. */
+export const LOCAL_MODEL_UNLOAD_POLICIES = LOCAL_MODEL_UNLOAD_POLICY_OPTIONS.map(
+	(o) => o.value,
+) as LocalModelUnloadPolicy[];

--- a/apps/whispering/src/lib/constants/transcription.ts
+++ b/apps/whispering/src/lib/constants/transcription.ts
@@ -264,6 +264,7 @@ export type LocalModelUnloadPolicy =
 	(typeof LOCAL_MODEL_UNLOAD_POLICY_OPTIONS)[number]['value'];
 
 /** Convenience array for `type.enumerated(...LOCAL_MODEL_UNLOAD_POLICIES)`. */
-export const LOCAL_MODEL_UNLOAD_POLICIES = LOCAL_MODEL_UNLOAD_POLICY_OPTIONS.map(
-	(o) => o.value,
-) as LocalModelUnloadPolicy[];
+export const LOCAL_MODEL_UNLOAD_POLICIES =
+	LOCAL_MODEL_UNLOAD_POLICY_OPTIONS.map(
+		(o) => o.value,
+	) as LocalModelUnloadPolicy[];

--- a/apps/whispering/src/lib/state/device-config.svelte.ts
+++ b/apps/whispering/src/lib/state/device-config.svelte.ts
@@ -7,6 +7,7 @@ import { type } from 'arktype';
 import { extractErrorMessage } from 'wellcrafted/error';
 import { BITRATES_KBPS, DEFAULT_BITRATE_KBPS } from '$lib/constants/audio';
 import { CommandOrAlt, CommandOrControl } from '$lib/constants/keyboard';
+import { LOCAL_MODEL_UNLOAD_POLICIES } from '$lib/constants/transcription';
 import { notify } from '$lib/query/notify';
 
 // ── Per-key definitions ──────────────────────────────────────────────────────
@@ -60,6 +61,20 @@ const DEVICE_DEFINITIONS = {
 	'transcription.whispercpp.modelPath': defineEntry(type('string'), ''),
 	'transcription.parakeet.modelPath': defineEntry(type('string'), ''),
 	'transcription.moonshine.modelPath': defineEntry(type('string'), ''),
+
+	// ── Local model lifecycle (per device: memory pressure is physical) ─
+	/**
+	 * When to drop the resident local transcription model. Pushed to Rust
+	 * on change via the `set_unload_policy` Tauri command; the Rust side
+	 * owns the actual eviction (synchronous for `immediately`, idle-watcher
+	 * for timed values). Device-local because the right answer depends on
+	 * available RAM (a 64 GB workstation and a 16 GB laptop want different
+	 * policies for the same workflow).
+	 */
+	'transcription.localModelUnloadPolicy': defineEntry(
+		type.enumerated(...LOCAL_MODEL_UNLOAD_POLICIES),
+		'after_5_minutes',
+	),
 
 	// ── Self-hosted server URLs ───────────────────────────────────────
 	'completion.custom.baseUrl': defineEntry(

--- a/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
@@ -22,7 +22,11 @@
 	import LocalModelSelector from '$lib/components/settings/LocalModelSelector.svelte';
 	import TranscriptionServiceSelect from '$lib/components/settings/TranscriptionServiceSelect.svelte';
 	import { SUPPORTED_LANGUAGES_OPTIONS } from '$lib/constants/languages';
-	import { TRANSCRIPTION } from '$lib/constants/transcription';
+	import {
+		LOCAL_MODEL_UNLOAD_POLICY_OPTIONS,
+		type LocalModelUnloadPolicy,
+		TRANSCRIPTION,
+	} from '$lib/constants/transcription';
 	import { MOONSHINE_MODELS } from '$lib/services/transcription/local/moonshine';
 	import { PARAKEET_MODELS } from '$lib/services/transcription/local/parakeet';
 	import { WHISPER_MODELS } from '$lib/services/transcription/local/whispercpp';
@@ -106,6 +110,17 @@
 	const outputLanguageLabel = $derived(
 		SUPPORTED_LANGUAGES_OPTIONS.find(
 			(i) => i.value === settings.get('transcription.language'),
+		)?.label,
+	);
+
+	const isLocalEngine = $derived(
+		TRANSCRIPTION[settings.get('transcription.service')].location === 'local',
+	);
+
+	const unloadPolicyLabel = $derived(
+		LOCAL_MODEL_UNLOAD_POLICY_OPTIONS.find(
+			(o) =>
+				o.value === deviceConfig.get('transcription.localModelUnloadPolicy'),
 		)?.label,
 	);
 </script>
@@ -756,6 +771,45 @@
 					{/if}
 				{/if}
 			</div>
+		{/if}
+
+		{#if isLocalEngine}
+			<Field.Field>
+				<Field.Label for="local-model-unload-policy">
+					Unload Model When Idle
+				</Field.Label>
+				<Select.Root
+					type="single"
+					bind:value={
+						() => deviceConfig.get('transcription.localModelUnloadPolicy'),
+						(v) =>
+							deviceConfig.set(
+								'transcription.localModelUnloadPolicy',
+								v as LocalModelUnloadPolicy,
+							)
+					}
+				>
+					<Select.Trigger id="local-model-unload-policy" class="w-full">
+						{unloadPolicyLabel ?? 'Select a policy'}
+					</Select.Trigger>
+					<Select.Content>
+						{#each LOCAL_MODEL_UNLOAD_POLICY_OPTIONS as option}
+							<Select.Item value={option.value} label={option.label}>
+								<div class="flex flex-col gap-1 py-1">
+									<div class="font-medium">{option.label}</div>
+									<div class="text-sm text-muted-foreground">
+										{option.description}
+									</div>
+								</div>
+							</Select.Item>
+						{/each}
+					</Select.Content>
+				</Select.Root>
+				<Field.Description>
+					Controls when Whispering drops the loaded transcription model from
+					memory. Lower memory means a fresh load on the next transcription.
+				</Field.Description>
+			</Field.Field>
 		{/if}
 
 		<!-- Audio Compression Settings -->

--- a/apps/whispering/src/routes/(app)/+layout.svelte
+++ b/apps/whispering/src/routes/(app)/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import * as Sidebar from '@epicenter/ui/sidebar';
+	import { invoke } from '@tauri-apps/api/core';
 	import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 	import { onDestroy, onMount } from 'svelte';
 	import { MediaQuery } from 'svelte/reactivity';
@@ -7,6 +8,7 @@
 	import { migrateOldSettings } from '$lib/migration/migrate-settings';
 	import { rpc } from '$lib/query';
 	import { services } from '$lib/services';
+	import { deviceConfig } from '$lib/state/device-config.svelte';
 	import AppLayout from './_components/AppLayout.svelte';
 	import BottomNav from './_components/BottomNav.svelte';
 	import VerticalNav from './_components/VerticalNav.svelte';
@@ -30,6 +32,18 @@
 	// Log app started event once on mount
 	$effect(() => {
 		rpc.analytics.logEvent({ type: 'app_started' });
+	});
+
+	// Push the local-model unload policy to Rust whenever it changes. Rust
+	// owns the eviction (synchronous for `immediately`, idle-watcher for
+	// timed values); the FE just mirrors the current device-config value.
+	// Fires once on mount and on every subsequent change.
+	$effect(() => {
+		if (!window.__TAURI_INTERNALS__) return;
+		const policy = deviceConfig.get('transcription.localModelUnloadPolicy');
+		invoke('set_unload_policy', { policy }).catch((err) => {
+			console.error('Failed to push unload policy to Rust:', err);
+		});
 	});
 
 	// Listen for navigation events from other windows


### PR DESCRIPTION
Loading a local transcription model (Whisper, Parakeet, Moonshine) costs hundreds of MB to several GB of resident memory. Once loaded, Whispering kept the model resident until the app exited or the user switched engines. Users on memory-constrained machines had no way to opt out.

This PR adds a per-device unload policy with synchronous and idle-watcher enforcement, modeled on Handy's prior art (verified via DeepWiki, not copied).

## What the policy says

| value | when the model is dropped | enforced by |
|---|---|---|
| `never` | never | (the watcher is a no-op) |
| `immediately` | right after each completed transcription | synchronous post-transcription path |
| `after_5_minutes` (default) | 5 minutes after the last transcription | background watcher |
| `after_30_minutes` | 30 minutes after the last transcription | background watcher |

## Shape

```
┌───────────────────────────────────────────────────────────┐
│  FE: Select bound to deviceConfig.'transcription.         │
│      localModelUnloadPolicy' (per-device localStorage)    │
└──────────────────────────┬────────────────────────────────┘
                           │ $effect in (app)/+layout.svelte
                           ▼
                  invoke('set_unload_policy', { policy })
                           │
                           ▼
┌───────────────────────────────────────────────────────────┐
│  Rust: ModelManager owns eviction                         │
│    cached:           Arc<Mutex<Option<(Path, Engine)>>>   │
│    last_activity_ms: Arc<AtomicU64>                       │
│    policy:           Arc<RwLock<UnloadPolicy>>            │
│                                                           │
│    with_engine:        touch(); lock; load+use; touch()   │
│    evict_if_immediate: post-transcription, blocking lock  │
│    tick_idle (10s):    read policy; check idle; try_lock; │
│                        evict                              │
└───────────────────────────────────────────────────────────┘
```

## Why device-local, not workspace-synced

Memory pressure is a property of the *device*, not the user. A 64 GB workstation wants `never`; a 16 GB laptop wants `immediately` or `after_5_minutes`. The Whispering settings already split this way: behavioral preferences (output language, temperature, prompt) sync via workspace KV; physical things (model file paths, device IDs, recording method) live in `deviceConfig`. The policy belongs with the physical bucket.

The initial draft put it in workspace KV. Moved to `deviceConfig` after grilling the design.

## Lock discipline

- `with_engine` holds the cache mutex across load + inference, serializing concurrent transcribes (only one engine fits in memory anyway) and eliminating any load/use race.
- `evict_if_immediate` blocks on the same mutex. Safe: it runs immediately after the same call site released the lock, so no contention is possible.
- `tick_idle` uses `try_lock`. A long transcription just postpones eviction to the next 10s tick instead of blocking the watcher.
- The watcher never holds locks across `sleep`.

## Activity stamping

Stamped at both *start* and *end* of `with_engine`. The end-stamp is what matters (idle clock starts after the last inference finishes). The start-stamp is defensive: documents intent and costs one `AtomicU64::store`.

## Unknown-value safety

`UnloadPolicy::from_wire` falls back to the default on unknown values rather than erroring. Cheap insurance against a future rename or a corrupted localStorage value.

## File tree

```
apps/whispering/
├── src-tauri/src/
│   ├── lib.rs                      # register set_unload_policy; .setup hook
│   └── transcription/
│       ├── mod.rs                  # set_unload_policy command; evict_if_immediate call
│       └── model_manager.rs        # UnloadPolicy, activity, watcher, tests
└── src/
    ├── lib/
    │   ├── constants/transcription.ts        # OPTIONS (source of truth)
    │   └── state/device-config.svelte.ts     # localModelUnloadPolicy entry
    └── routes/(app)/
        ├── +layout.svelte                    # $effect: push to Rust on change
        └── (config)/settings/transcription/
            └── +page.svelte                  # Select gated by isLocalEngine
```

## Test plan

- [x] `cargo test transcription::model_manager` (5 tests: wire parsing, idle timeout mapping, set_policy round-trip)
- [x] `bun run typecheck` (0 errors)
- [ ] Manual: set policy to `immediately`, transcribe, tail dev log for `unloaded model (immediate)` right after `transcription complete`
- [ ] Manual: set policy to `never`, transcribe, wait, confirm no eviction
- [ ] Manual: set policy to `after_5_minutes`, transcribe, wait, confirm `unloaded model (idle ~300s)` within one 10s watcher tick after threshold
- [ ] Manual: change policy mid-app (no transcription required); eviction respects the new policy within one watcher tick
- [ ] Manual: kick off a long transcription, immediately toggle to `immediately` — `try_lock` skip means in-flight call completes, then synchronous evict fires at the end

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782373969&installation_id=128463665&pr_number=1824&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1824&signature=f5cdefe1baf5bf4e3d656390c44a55667996733f0cc7a5e28ac8d031ee63b595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->