### PR TITLE
refactor(whispering): canonical CPAL recorder + Float32Array | Blob audio payload

### DIFF
--- a/apps/whispering/specs/20260526T150401-canonical-recorder.md
+++ b/apps/whispering/specs/20260526T150401-canonical-recorder.md
@@ -696,10 +696,10 @@ async function prepareForService(artifact: AudioArtifact, service: string): Prom
 - `src-tauri/src/lib.rs`: registered `encode_upload_pcm`.
 
 **TypeScript**:
-- `src/lib/services/recorder/types.ts`: added `AudioArtifact` tagged union (`pcm | file | blob`). Updated `Recording.stop` to return `{ artifact, recordingId, durationMs }`. Added `mode` to `CpalRecordingParams`. Removed unused `RecorderError` variants (`NotRecording`, `NoFilePath`, `EmptyRecording`, `FileDeleteFailed`).
-- `src/lib/services/recorder/artifact.ts` new: `artifactToBlob` materializes any artifact to a `Blob` (in-memory WAV synthesis for `pcm`, fs read for `file`, identity for `blob`).
+- `src/lib/services/recorder/types.ts`: added `AudioArtifact` tagged union (`pcm | blob`). The artifact describes the audio payload only; `Recording.stop` returns `{ artifact, recordingId, durationMs }` for capture-session metadata. Removed unused `RecorderError` variants (`NotRecording`, `NoFilePath`, `EmptyRecording`, `FileDeleteFailed`).
+- `src/lib/services/recorder/artifact.ts` new: `artifactToBlob` materializes any artifact to a `Blob` (in-memory WAV synthesis for `pcm`, identity for `blob`).
 - `src/lib/services/recorder/cpal.tauri.ts` rewritten: `Recording.stop` returns the artifact; `samples: number[]` from IPC is hydrated to `Float32Array`; cancel goes through new `cancel_recording` command without the explicit `stop_recording`/file-delete dance.
-- `src/lib/services/recorder/navigator.ts`: stops emit `{ kind: 'blob', blob, durationSeconds }`.
+- `src/lib/services/recorder/navigator.ts`: stops emit `{ artifact: { kind: 'blob', blob }, recordingId, durationMs }`.
 - `src/lib/state/manual-recorder.svelte.ts`: passes `mode: 'dictation'` in cpal start params.
 - `src/lib/tauri.tauri.ts`: added `audioEncoder.encodePcmToOpusOgg({ samples, rate, channels })`.
 - `src/lib/operations/transcribe.ts`: new `transcribeArtifact(artifact)`. Pcm + cloud upload skips the WAV round-trip and goes straight through `encodePcmToOpusOgg`. `transcribeBlob` is now a thin wrapper for the history re-transcribe path.
@@ -728,7 +728,7 @@ The catalogs above sketched a richer config surface than the work actually needs
 - **Dropped `RecorderPolicy` struct and `SinkKind` enum**: every axis is determined by `RecorderMode`. The struct was a "would be nice if we ever needed it" speculation; nothing varies independently. Now `recorder.rs::init_session` and `run_consumer` match on `RecorderMode` directly.
 - **Dropped `AudioChunk` enum**: the wrapper had one variant (`Samples(Vec<f32>)`). The channel is now `mpsc::Sender<Vec<f32>>` directly.
 - **Dropped `Default for RecorderMode` and `mode: Option<RecorderMode>` in the Tauri command**: the JS caller always passes `mode` explicitly. The Option/default was defensive ceremony.
-- **Dropped `durationSeconds` from `AudioArtifact::Blob`**: four of five `kind: 'blob'` producers passed `0` because JS does not know the duration without decoding. Now only `pcm` and `file` carry `durationSeconds` (Rust computes it). The canonical "how long was this recording" number lives on `Recording.stop`'s return.
+- **Dropped `durationSeconds` from `AudioArtifact`**: blob producers cannot know duration without decoding, and PCM duration is derivable from `samples`, `rate`, and `channels`. The canonical "how long was this recording" number lives on `Recording.stop`'s return.
 - **Tightened cancel**: `cancel_recording` now does the full Rust-side cleanup in one call; the JS-side follow-up `close_recording_session` invoke was removed. One IPC round trip per cancel instead of two.
 - **Trimmed `recorder/mod.rs` re-exports**: removed `AudioContainer` and `RecorderPolicy` from the public surface (they were unused outside the module).
 

--- a/apps/whispering/src-tauri/src/audio/command.rs
+++ b/apps/whispering/src-tauri/src/audio/command.rs
@@ -13,6 +13,11 @@ use tauri::ipc::{InvokeBody, Request, Response};
 
 use super::encode::{encode_pcm_to_opus_ogg, encode_wav_to_opus_ogg};
 
+/// The sample rate at which the cpal recorder emits captured PCM. The
+/// Rust recorder resamples every device to this rate before finalize, so
+/// every `encode_upload_pcm` payload arrives at this rate.
+const RECORDER_OUTPUT_RATE: u32 = 16_000;
+
 /// Compress a WAV audio blob into OGG/Opus for cloud transcription upload.
 ///
 /// Audio bytes arrive as the raw IPC body. The output bitrate is fixed at
@@ -46,21 +51,17 @@ pub async fn encode_upload_audio(request: Request<'_>) -> Result<Response, Strin
 
 /// Compress an in-memory PCM buffer into OGG/Opus for cloud transcription
 /// upload. Used by the dictation cpal path: the recorder produces a mono
-/// f32 buffer in memory, we hand it straight to libopus without any WAV
-/// round-trip.
+/// 16 kHz f32 buffer in memory, we hand it straight to libopus without any
+/// WAV round-trip.
 ///
-/// Body layout (little-endian):
-/// ```text
-///   bytes 0..4    : u32   sample_rate
-///   bytes 4..6    : u16   channels
-///   bytes 6..8    : u16   reserved (pad)
-///   bytes 8..     : f32[] interleaved samples
-/// ```
+/// Body layout: raw little-endian f32 samples back to back, no header.
+/// The recorder's contract is "16 kHz mono"; this handler hardcodes those
+/// values when calling the general-purpose encoder. If the contract ever
+/// changes, both sides grow a header together.
 ///
 /// JS call shape:
 /// ```js
-/// const buf = packPcm(rate, channels, samples);
-/// const compressed = await invoke('encode_upload_pcm', buf);
+/// const compressed = await invoke('encode_upload_pcm', samples.buffer);
 /// ```
 #[tauri::command]
 pub async fn encode_upload_pcm(request: Request<'_>) -> Result<Response, String> {
@@ -73,30 +74,20 @@ pub async fn encode_upload_pcm(request: Request<'_>) -> Result<Response, String>
         }
     };
 
-    if body.len() < 8 {
+    if body.len() % 4 != 0 {
         return Err(format!(
-            "PCM body too short: expected at least 8 header bytes, got {}",
+            "PCM byte length not a multiple of 4 (f32 size): got {} bytes",
             body.len()
         ));
     }
 
-    let rate = u32::from_le_bytes([body[0], body[1], body[2], body[3]]);
-    let channels = u16::from_le_bytes([body[4], body[5]]);
-    let samples_bytes = &body[8..];
-    if samples_bytes.len() % 4 != 0 {
-        return Err(format!(
-            "PCM sample bytes not a multiple of 4 (f32 size): got {} trailing bytes",
-            samples_bytes.len()
-        ));
-    }
-
-    let samples: Vec<f32> = samples_bytes
+    let samples: Vec<f32> = body
         .chunks_exact(4)
         .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
         .collect();
 
     tauri::async_runtime::spawn_blocking(move || {
-        encode_pcm_to_opus_ogg(&samples, rate, channels)
+        encode_pcm_to_opus_ogg(&samples, RECORDER_OUTPUT_RATE, 1)
     })
     .await
     .map_err(|e| format!("background encode task failed: {e}"))?

--- a/apps/whispering/src-tauri/src/recorder/artifact.rs
+++ b/apps/whispering/src-tauri/src/recorder/artifact.rs
@@ -4,8 +4,8 @@
 //! (it resamples to that rate inside the consumer worker), so there's
 //! no need for a tagged union here.
 //!
-//! IPC: the artifact is serialized as a binary response, not JSON. See
-//! `commands.rs::stop_recording` for the wire layout.
+//! IPC: the artifact is serialized as a binary response, not JSON. The
+//! `to_binary` method below is the wire-layout source of truth.
 
 /// Captured audio: mono PCM samples plus metadata.
 #[derive(Debug, Clone)]
@@ -22,7 +22,7 @@ impl AudioArtifact {
     /// ```text
     ///   bytes 0..4   : u32  rate
     ///   bytes 4..6   : u16  channels
-    ///   bytes 6..8   : u16  reserved (alignment)
+    ///   bytes 6..8   : u16  padding (aligns samples to f32 boundary)
     ///   bytes 8..    : f32[] samples
     /// ```
     /// JS reinterprets the trailing bytes as a `Float32Array` view, no

--- a/apps/whispering/src-tauri/src/recorder/artifact.rs
+++ b/apps/whispering/src-tauri/src/recorder/artifact.rs
@@ -1,38 +1,32 @@
 //! The audio captured by a recording session.
 //!
-//! One struct, one shape. The recorder always emits mono PCM at 16 kHz
-//! (it resamples to that rate inside the consumer worker), so there's
-//! no need for a tagged union here.
+//! One struct, one shape, no header. The recorder always emits mono PCM
+//! at 16 kHz (the consumer worker resamples to that rate before finalize),
+//! so the wire format is just the f32 samples back-to-back.
 //!
 //! IPC: the artifact is serialized as a binary response, not JSON. The
 //! `to_binary` method below is the wire-layout source of truth.
 
-/// Captured audio: mono PCM samples plus metadata.
+/// Captured audio: mono 16 kHz PCM samples.
+///
+/// `rate` and `channels` are intentionally not stored on this struct. They
+/// would be constants in every consumer (16 kHz / 1) and shipping them
+/// over the IPC boundary would let a future mismatch silently lie about
+/// the data. The recorder's contract is "16 kHz mono f32"; if that ever
+/// changes, this struct gains a header and so does `to_binary`.
 #[derive(Debug, Clone)]
-pub struct AudioArtifact {
+pub struct CapturedPcm {
     pub samples: Vec<f32>,
-    pub rate: u32,
-    pub channels: u16,
 }
 
-impl AudioArtifact {
+impl CapturedPcm {
     /// Serialize as a binary IPC body for Tauri's `Response::new`.
     ///
-    /// Layout (little-endian):
-    /// ```text
-    ///   bytes 0..4   : u32  rate
-    ///   bytes 4..6   : u16  channels
-    ///   bytes 6..8   : u16  padding (aligns samples to f32 boundary)
-    ///   bytes 8..    : f32[] samples
-    /// ```
-    /// JS reinterprets the trailing bytes as a `Float32Array` view, no
-    /// JSON, no decimal round-trip, no extra copy.
+    /// Layout: f32 little-endian samples back to back, no header.
+    /// JS reinterprets the bytes as a `Float32Array` view — no JSON, no
+    /// decimal round-trip, no extra copy.
     pub fn to_binary(&self) -> Vec<u8> {
-        let header_size = 8;
-        let mut buf = Vec::with_capacity(header_size + self.samples.len() * 4);
-        buf.extend_from_slice(&self.rate.to_le_bytes());
-        buf.extend_from_slice(&self.channels.to_le_bytes());
-        buf.extend_from_slice(&0u16.to_le_bytes());
+        let mut buf = Vec::with_capacity(self.samples.len() * 4);
         for sample in &self.samples {
             buf.extend_from_slice(&sample.to_le_bytes());
         }

--- a/apps/whispering/src-tauri/src/recorder/commands.rs
+++ b/apps/whispering/src-tauri/src/recorder/commands.rs
@@ -75,24 +75,24 @@ pub async fn start_recording(
     Ok(())
 }
 
-/// Returns the captured artifact as a binary IPC body, not JSON. The
-/// wire layout is documented on `AudioArtifact::to_binary`. Avoids the
-/// 5-7 MB JSON serialize/parse round trip a 30 s clip would cost
-/// otherwise.
+/// Returns the captured PCM as a binary IPC body, not JSON. The wire
+/// layout is documented on `CapturedPcm::to_binary`: raw little-endian
+/// f32 samples, no header. Avoids the 5-7 MB JSON serialize/parse round
+/// trip a 30 s clip would cost otherwise.
 #[tauri::command]
 pub async fn stop_recording(
     recorder: State<'_, Mutex<Recorder>>,
     app_handle: AppHandle,
 ) -> Result<Response> {
     info!("Stopping recording");
-    let artifact = {
+    let pcm = {
         let mut recorder = recorder
             .lock()
             .map_err(|e| format!("Failed to lock recorder: {e}"))?;
         recorder.stop_recording()?
     };
     emit_recording_state(&app_handle, RecordingState::Idle);
-    Ok(Response::new(artifact.to_binary()))
+    Ok(Response::new(pcm.to_binary()))
 }
 
 #[tauri::command]

--- a/apps/whispering/src-tauri/src/recorder/recorder.rs
+++ b/apps/whispering/src-tauri/src/recorder/recorder.rs
@@ -14,7 +14,7 @@
 //! The cpal callback never blocks: it downmixes to mono and ships
 //! samples through an mpsc channel. The consumer worker accumulates,
 //! resamples to 16 kHz at finalize, pads sub-1s clips, and emits the
-//! canonical [`AudioArtifact`].
+//! canonical [`CapturedPcm`].
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{Device, SampleFormat, Stream};
@@ -25,7 +25,7 @@ use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use crate::audio::resample_mono;
-use crate::recorder::artifact::AudioArtifact;
+use crate::recorder::artifact::CapturedPcm;
 
 /// Simple result type using String for errors. Errors cross the IPC
 /// boundary as plain strings so the JS side renders them in toasts.
@@ -46,7 +46,7 @@ const SHORT_RECORDING_PAD_SAMPLES: usize = 20_000;
 #[derive(Debug)]
 enum RecorderCmd {
     Start(mpsc::Sender<()>),
-    Stop(mpsc::Sender<Result<AudioArtifact>>),
+    Stop(mpsc::Sender<Result<CapturedPcm>>),
     Cancel(mpsc::Sender<Result<()>>),
     Shutdown,
 }
@@ -175,8 +175,8 @@ impl Recorder {
         Ok(())
     }
 
-    /// Stop recording and consume the worker's artifact.
-    pub fn stop_recording(&mut self) -> Result<AudioArtifact> {
+    /// Stop recording and consume the worker's PCM.
+    pub fn stop_recording(&mut self) -> Result<CapturedPcm> {
         let tx = self
             .cmd_tx
             .as_ref()
@@ -187,11 +187,10 @@ impl Recorder {
         let result = reply_rx
             .recv()
             .map_err(|e| format!("Worker dropped stop reply: {e}"))?;
-        let artifact = result?;
-        let duration_seconds =
-            artifact.samples.len() as f32 / artifact.rate as f32 / artifact.channels as f32;
+        let pcm = result?;
+        let duration_seconds = pcm.samples.len() as f32 / TARGET_RATE as f32;
         info!("Recording stopped: {duration_seconds:.2}s");
-        Ok(artifact)
+        Ok(pcm)
     }
 
     /// Cancel the active recording, discarding any in-flight samples.
@@ -290,8 +289,8 @@ fn run_consumer(
     }
 }
 
-/// Resample to 16 kHz if needed, pad short clips, build the artifact.
-fn finalize(buffer: Vec<f32>, device_rate: u32) -> Result<AudioArtifact> {
+/// Resample to 16 kHz if needed, pad short clips, build the PCM.
+fn finalize(buffer: Vec<f32>, device_rate: u32) -> Result<CapturedPcm> {
     let samples = if device_rate == TARGET_RATE {
         buffer
     } else {
@@ -308,11 +307,7 @@ fn finalize(buffer: Vec<f32>, device_rate: u32) -> Result<AudioArtifact> {
         samples.resize(SHORT_RECORDING_PAD_SAMPLES, 0.0);
     }
 
-    Ok(AudioArtifact {
-        samples,
-        rate: TARGET_RATE,
-        channels: 1,
-    })
+    Ok(CapturedPcm { samples })
 }
 
 /// Find a recording device by name. Treats "default" case-insensitively.
@@ -595,17 +590,14 @@ mod tests {
     }
 
     #[test]
-    fn artifact_to_binary_writes_header_and_samples() {
-        let artifact = AudioArtifact {
+    fn captured_pcm_to_binary_writes_samples_only() {
+        let pcm = CapturedPcm {
             samples: vec![0.5, -0.5, 0.25],
-            rate: 16_000,
-            channels: 1,
         };
-        let bytes = artifact.to_binary();
-        assert_eq!(&bytes[0..4], 16_000u32.to_le_bytes());
-        assert_eq!(&bytes[4..6], 1u16.to_le_bytes());
-        assert_eq!(&bytes[6..8], 0u16.to_le_bytes());
-        assert_eq!(bytes.len(), 8 + 3 * 4);
-        assert_eq!(&bytes[8..12], 0.5f32.to_le_bytes());
+        let bytes = pcm.to_binary();
+        assert_eq!(bytes.len(), 3 * 4);
+        assert_eq!(&bytes[0..4], 0.5f32.to_le_bytes());
+        assert_eq!(&bytes[4..8], (-0.5f32).to_le_bytes());
+        assert_eq!(&bytes[8..12], 0.25f32.to_le_bytes());
     }
 }

--- a/apps/whispering/src-tauri/src/recorder/recorder.rs
+++ b/apps/whispering/src-tauri/src/recorder/recorder.rs
@@ -595,7 +595,7 @@ mod tests {
     }
 
     #[test]
-    fn artifact_to_binary_round_trip_header() {
+    fn artifact_to_binary_writes_header_and_samples() {
         let artifact = AudioArtifact {
             samples: vec![0.5, -0.5, 0.25],
             rate: 16_000,

--- a/apps/whispering/src/lib/constants/audio/index.ts
+++ b/apps/whispering/src/lib/constants/audio/index.ts
@@ -21,6 +21,7 @@ export {
 } from './recording-states';
 export {
 	DEFAULT_SAMPLE_RATE,
+	RECORDER_OUTPUT_RATE,
 	SAMPLE_RATE_OPTIONS,
 	SAMPLE_RATES,
 	type SampleRate,

--- a/apps/whispering/src/lib/constants/audio/sample-rate.ts
+++ b/apps/whispering/src/lib/constants/audio/sample-rate.ts
@@ -29,3 +29,16 @@ export const SAMPLE_RATE_OPTIONS = SAMPLE_RATES.map((rate) => ({
 
 export const DEFAULT_SAMPLE_RATE =
 	'16000' as const satisfies (typeof SAMPLE_RATES)[number];
+
+/**
+ * The sample rate at which the cpal recorder emits captured PCM. The Rust
+ * recorder resamples every device to this rate before handing samples to
+ * the consumer worker. The user-facing `SAMPLE_RATES` setting above is a
+ * hint that picks which cpal device config to open; it does not change the
+ * recorder's output rate.
+ *
+ * Mirrored in:
+ *   src-tauri/src/recorder/recorder.rs (`TARGET_RATE`)
+ *   src-tauri/src/audio/command.rs (`RECORDER_OUTPUT_RATE`)
+ */
+export const RECORDER_OUTPUT_RATE = 16_000;

--- a/apps/whispering/src/lib/operations/pipeline.ts
+++ b/apps/whispering/src/lib/operations/pipeline.ts
@@ -57,10 +57,9 @@ export async function processRecordingPipeline({
 	recordings.set(recording);
 	// History save still consumes a Blob today. Materialize once and run
 	// the save in parallel with transcription; for Pcm artifacts this is
-	// in-memory WAV synthesis (cheap), for File it's a disk read.
+	// in-memory WAV synthesis; for Blob artifacts it is identity.
 	const saveAudioPromise = (async () => {
-		const { data: blob, error } = await artifactToBlob(artifact);
-		if (error) return { data: null, error } as const;
+		const blob = artifactToBlob(artifact);
 		return await services.blobs.audio.save(recording.id, blob);
 	})();
 	const transcribePromise = transcribeArtifact(artifact);

--- a/apps/whispering/src/lib/operations/pipeline.ts
+++ b/apps/whispering/src/lib/operations/pipeline.ts
@@ -8,7 +8,7 @@ import { sound } from '$lib/operations/sound';
 import { transcribeAudio } from '$lib/operations/transcribe';
 import { runTransformation } from '$lib/operations/transform';
 import { services } from '$lib/services';
-import { pcmToWavBlob } from '$lib/services/recorder/artifact';
+import { pcmToWavBlob } from '$lib/services/recorder/pcm-to-wav';
 import type { RecorderAudio } from '$lib/services/recorder/types';
 import { recordings } from '$lib/state/recordings.svelte';
 import { settings } from '$lib/state/settings.svelte';

--- a/apps/whispering/src/lib/operations/pipeline.ts
+++ b/apps/whispering/src/lib/operations/pipeline.ts
@@ -5,11 +5,11 @@ import {
 } from '$lib/operations/delivery';
 import { notify } from '$lib/operations/notify';
 import { sound } from '$lib/operations/sound';
-import { transcribeArtifact } from '$lib/operations/transcribe';
+import { transcribeAudio } from '$lib/operations/transcribe';
 import { runTransformation } from '$lib/operations/transform';
 import { services } from '$lib/services';
-import { artifactToBlob } from '$lib/services/recorder/artifact';
-import type { AudioArtifact } from '$lib/services/recorder/types';
+import { pcmToWavBlob } from '$lib/services/recorder/artifact';
+import type { RecorderAudio } from '$lib/services/recorder/types';
 import { recordings } from '$lib/state/recordings.svelte';
 import { settings } from '$lib/state/settings.svelte';
 import { transformations } from '$lib/state/transformations.svelte';
@@ -22,14 +22,16 @@ import { transformations } from '$lib/state/transformations.svelte';
  * When omitted (e.g., VAD recording, file uploads), a new ID is generated here.
  */
 export async function processRecordingPipeline({
-	artifact,
+	audio,
 	recordingId,
+	durationMs,
 	toastId,
 	completionTitle,
 	completionDescription,
 }: {
-	artifact: AudioArtifact;
+	audio: RecorderAudio;
 	recordingId?: string;
+	durationMs: number | null;
 	toastId: string;
 	completionTitle: string;
 	completionDescription: string;
@@ -43,7 +45,7 @@ export async function processRecordingPipeline({
 		recordedAt: now,
 		updatedAt: now,
 		transcript: '',
-		duration: null,
+		duration: durationMs,
 		transcriptionStatus: 'UNPROCESSED',
 	} as const;
 
@@ -55,14 +57,13 @@ export async function processRecordingPipeline({
 	});
 
 	recordings.set(recording);
-	// History save still consumes a Blob today. Materialize once and run
-	// the save in parallel with transcription; for Pcm artifacts this is
-	// in-memory WAV synthesis; for Blob artifacts it is identity.
+	// History save consumes a Blob: PCM gets WAV-synthesized once, Blob is
+	// passed through. Run the save in parallel with transcription.
 	const saveAudioPromise = (async () => {
-		const blob = artifactToBlob(artifact);
+		const blob = audio instanceof Blob ? audio : pcmToWavBlob(audio);
 		return await services.blobs.audio.save(recording.id, blob);
 	})();
-	const transcribePromise = transcribeArtifact(artifact);
+	const transcribePromise = transcribeAudio(audio);
 
 	const { data: transcribedText, error: transcribeError } =
 		await transcribePromise;

--- a/apps/whispering/src/lib/operations/recording.ts
+++ b/apps/whispering/src/lib/operations/recording.ts
@@ -3,10 +3,7 @@ import { analytics } from '$lib/operations/analytics';
 import { notify } from '$lib/operations/notify';
 import { processRecordingPipeline } from '$lib/operations/pipeline';
 import { sound } from '$lib/operations/sound';
-import type {
-	AudioArtifact,
-	DeviceAcquisitionOutcome,
-} from '$lib/services/recorder/types';
+import type { DeviceAcquisitionOutcome } from '$lib/services/recorder/types';
 import { deviceConfig } from '$lib/state/device-config.svelte';
 import { manualRecorder } from '$lib/state/manual-recorder.svelte';
 import { settings } from '$lib/state/settings.svelte';
@@ -122,7 +119,8 @@ export async function stopManualRecording() {
 
 	analytics.logEvent({
 		type: 'manual_recording_completed',
-		blob_size: artifactByteSize(artifact),
+		blob_size:
+			artifact.kind === 'pcm' ? artifact.samples.byteLength : artifact.blob.size,
 		duration: durationMs,
 	});
 
@@ -133,12 +131,6 @@ export async function stopManualRecording() {
 		completionTitle: '✨ Recording Complete!',
 		completionDescription: 'Recording saved and session closed successfully',
 	});
-}
-
-function artifactByteSize(artifact: AudioArtifact): number {
-	return artifact.kind === 'pcm'
-		? artifact.samples.byteLength
-		: artifact.blob.size;
 }
 
 export async function toggleManualRecording() {

--- a/apps/whispering/src/lib/operations/recording.ts
+++ b/apps/whispering/src/lib/operations/recording.ts
@@ -107,7 +107,7 @@ export async function stopManualRecording() {
 		return;
 	}
 
-	const { artifact, recordingId, durationMs } = data;
+	const { audio, recordingId, durationMs } = data;
 
 	notify.success({
 		id: toastId,
@@ -119,14 +119,14 @@ export async function stopManualRecording() {
 
 	analytics.logEvent({
 		type: 'manual_recording_completed',
-		blob_size:
-			artifact.kind === 'pcm' ? artifact.samples.byteLength : artifact.blob.size,
+		blob_size: audio instanceof Blob ? audio.size : audio.byteLength,
 		duration: durationMs,
 	});
 
 	await processRecordingPipeline({
-		artifact,
+		audio,
 		recordingId,
+		durationMs,
 		toastId,
 		completionTitle: '✨ Recording Complete!',
 		completionDescription: 'Recording saved and session closed successfully',
@@ -211,7 +211,8 @@ export async function startVadRecording() {
 			});
 
 			await processRecordingPipeline({
-				artifact: { kind: 'blob', blob },
+				audio: blob,
+				durationMs: null,
 				toastId: speechToastId,
 				completionTitle: '✨ Voice activated capture complete!',
 				completionDescription:

--- a/apps/whispering/src/lib/operations/transcribe.ts
+++ b/apps/whispering/src/lib/operations/transcribe.ts
@@ -29,10 +29,10 @@ function isUploadTranscriptionService(
 }
 
 /**
- * Heuristic that catches WAV blobs (the longform `File` artifact form
- * after `pathToBlob`, plus any legacy WAV inputs). The Opus encoder
- * rejects non-WAV input anyway; this avoids paying the IPC round-trip
- * when we already know the blob is something else.
+ * Heuristic that catches WAV blobs from synthesized PCM, VAD captures,
+ * file uploads, history replays, and legacy WAV inputs. The Opus encoder
+ * rejects non-WAV input anyway; this avoids paying the IPC round-trip when
+ * we already know the blob is something else.
  */
 function blobLooksLikeWav(blob: Blob): boolean {
 	const type = blob.type.toLowerCase();
@@ -101,9 +101,8 @@ async function prepareForService(
 
 	const blob = artifactToBlob(artifact);
 
-	// WAV uploads (VAD captures, file uploads, history re-transcribes
-	// that came from a Pcm artifact's synthesized WAV): still worth
-	// compressing for cloud.
+	// WAV uploads and synthesized PCM blobs are still worth compressing
+	// for cloud transcription.
 	if (isUpload && tauri && blobLooksLikeWav(blob)) {
 		const { data: oggBlob, error: encodeError } =
 			await tauri.audioEncoder.encodeWavToOpusOgg(blob);
@@ -136,8 +135,8 @@ async function prepareForService(
  * Transcribe an audio artifact through the configured service. This is
  * the canonical entry point for recorder output. Cloud transcription of
  * a `Pcm` artifact skips the WAV synthesis + decode roundtrip entirely;
- * a `File` artifact takes the same encode-from-WAV path as before; a
- * `Blob` artifact (navigator + file upload) passes through unchanged.
+ * a `Blob` artifact (navigator, VAD, file upload, history replay) passes
+ * through unchanged unless it is a WAV blob for an upload service.
  */
 export async function transcribeArtifact(
 	artifact: AudioArtifact,

--- a/apps/whispering/src/lib/operations/transcribe.ts
+++ b/apps/whispering/src/lib/operations/transcribe.ts
@@ -8,7 +8,7 @@ import { analytics } from '$lib/operations/analytics';
 import { notify } from '$lib/operations/notify';
 import { WhisperingErr, type WhisperingError } from '$lib/result';
 import { services } from '$lib/services';
-import { pcmToWavBlob } from '$lib/services/recorder/artifact';
+import { pcmToWavBlob } from '$lib/services/recorder/pcm-to-wav';
 import type { RecorderAudio } from '$lib/services/recorder/types';
 import { TRANSCRIPTION_SERVICES } from '$lib/services/transcription/registry';
 import { deviceConfig } from '$lib/state/device-config.svelte';
@@ -173,17 +173,6 @@ export async function transcribeAudio(
 	}
 
 	return transcriptionResult;
-}
-
-/**
- * Transcribe a pre-existing Blob. Kept for the history re-transcribe
- * path (`services.blobs.audio.getBlob` returns a Blob). Routes through
- * `transcribeAudio`, which narrows on `instanceof Blob`.
- */
-export async function transcribeBlob(
-	blob: Blob,
-): Promise<Result<string, WhisperingError>> {
-	return transcribeAudio(blob);
 }
 
 async function dispatchTranscription(

--- a/apps/whispering/src/lib/operations/transcribe.ts
+++ b/apps/whispering/src/lib/operations/transcribe.ts
@@ -8,8 +8,8 @@ import { analytics } from '$lib/operations/analytics';
 import { notify } from '$lib/operations/notify';
 import { WhisperingErr, type WhisperingError } from '$lib/result';
 import { services } from '$lib/services';
-import { artifactToBlob } from '$lib/services/recorder/artifact';
-import type { AudioArtifact } from '$lib/services/recorder/types';
+import { pcmToWavBlob } from '$lib/services/recorder/artifact';
+import type { RecorderAudio } from '$lib/services/recorder/types';
 import { TRANSCRIPTION_SERVICES } from '$lib/services/transcription/registry';
 import { deviceConfig } from '$lib/state/device-config.svelte';
 import { settings } from '$lib/state/settings.svelte';
@@ -52,28 +52,25 @@ function getOutputLanguage(): SupportedLanguage {
 }
 
 /**
- * Pick the cheapest valid Blob shape for a given service + artifact.
+ * Pick the cheapest valid Blob shape for a given service + audio payload.
  *
- * Cloud / self-hosted services want compressed bytes for upload:
- * `Pcm` artifacts go straight through libopus (one encode hop, no
- * container synthesis), `Blob` artifacts that look like WAV go through
- * the WAV-bytes encoder (one decode + one encode). Local engines decode
- * the blob in-process via Symphonia, so we just materialize whichever
- * Blob is nearest.
+ * Cloud / self-hosted services want compressed bytes for upload: PCM
+ * (Float32Array) goes straight through libopus (one encode hop, no
+ * container synthesis), Blob payloads that look like WAV go through the
+ * WAV-bytes encoder (one decode + one encode). Local engines decode the
+ * blob in-process via Symphonia, so we just materialize whichever Blob
+ * is nearest.
  */
 async function prepareForService(
-	artifact: AudioArtifact,
+	audio: RecorderAudio,
 	service: TranscriptionServiceId,
 ): Promise<Result<Blob, WhisperingError>> {
 	const isUpload = isUploadTranscriptionService(service);
 
-	// Fast path: Pcm + cloud upload. One opus encode, no WAV synthesis.
-	if (isUpload && tauri && artifact.kind === 'pcm') {
-		const { data: oggBlob, error } = await tauri.audioEncoder.encodePcmToOpusOgg({
-			samples: artifact.samples,
-			rate: artifact.rate,
-			channels: artifact.channels,
-		});
+	// Fast path: PCM + cloud upload. One opus encode, no WAV synthesis.
+	if (isUpload && tauri && audio instanceof Float32Array) {
+		const { data: oggBlob, error } =
+			await tauri.audioEncoder.encodePcmToOpusOgg(audio);
 		if (error) {
 			notify.warning({
 				title: 'Audio compression skipped',
@@ -89,17 +86,17 @@ async function prepareForService(
 			analytics.logEvent({
 				type: 'compression_completed',
 				provider: service,
-				original_size: artifact.samples.byteLength,
+				original_size: audio.byteLength,
 				compressed_size: oggBlob.size,
 				compression_ratio: Math.round(
-					(1 - oggBlob.size / artifact.samples.byteLength) * 100,
+					(1 - oggBlob.size / audio.byteLength) * 100,
 				),
 			});
 			return Ok(oggBlob);
 		}
 	}
 
-	const blob = artifactToBlob(artifact);
+	const blob = audio instanceof Blob ? audio : pcmToWavBlob(audio);
 
 	// WAV uploads and synthesized PCM blobs are still worth compressing
 	// for cloud transcription.
@@ -132,14 +129,15 @@ async function prepareForService(
 }
 
 /**
- * Transcribe an audio artifact through the configured service. This is
- * the canonical entry point for recorder output. Cloud transcription of
- * a `Pcm` artifact skips the WAV synthesis + decode roundtrip entirely;
- * a `Blob` artifact (navigator, VAD, file upload, history replay) passes
- * through unchanged unless it is a WAV blob for an upload service.
+ * Transcribe a recorder audio payload through the configured service.
+ * This is the canonical entry point for recorder output. Cloud
+ * transcription of an in-memory PCM payload skips the WAV synthesis +
+ * decode roundtrip entirely; a Blob payload (navigator, VAD, file
+ * upload, history replay) passes through unchanged unless it is a WAV
+ * blob for an upload service.
  */
-export async function transcribeArtifact(
-	artifact: AudioArtifact,
+export async function transcribeAudio(
+	audio: RecorderAudio,
 ): Promise<Result<string, WhisperingError>> {
 	const selectedService = settings.get('transcription.service');
 
@@ -150,7 +148,7 @@ export async function transcribeArtifact(
 	});
 
 	const { data: audioToTranscribe, error: prepareError } =
-		await prepareForService(artifact, selectedService);
+		await prepareForService(audio, selectedService);
 	if (prepareError) return Err(prepareError);
 
 	const transcriptionResult = await dispatchTranscription(
@@ -179,14 +177,13 @@ export async function transcribeArtifact(
 
 /**
  * Transcribe a pre-existing Blob. Kept for the history re-transcribe
- * path (`services.blobs.audio.getBlob` returns a Blob) and the file
- * upload UI. Internally wraps the Blob as a `kind: 'blob'` artifact and
- * routes through `transcribeArtifact`.
+ * path (`services.blobs.audio.getBlob` returns a Blob). Routes through
+ * `transcribeAudio`, which narrows on `instanceof Blob`.
  */
 export async function transcribeBlob(
 	blob: Blob,
 ): Promise<Result<string, WhisperingError>> {
-	return transcribeArtifact({ kind: 'blob', blob });
+	return transcribeAudio(blob);
 }
 
 async function dispatchTranscription(

--- a/apps/whispering/src/lib/operations/transcribe.ts
+++ b/apps/whispering/src/lib/operations/transcribe.ts
@@ -99,13 +99,7 @@ async function prepareForService(
 		}
 	}
 
-	const { data: blob, error: blobError } = await artifactToBlob(artifact);
-	if (blobError) {
-		return WhisperingErr({
-			title: '⚠️ Failed to read recording',
-			description: blobError.message,
-		});
-	}
+	const blob = artifactToBlob(artifact);
 
 	// WAV uploads (VAD captures, file uploads, history re-transcribes
 	// that came from a Pcm artifact's synthesized WAV): still worth

--- a/apps/whispering/src/lib/operations/upload.ts
+++ b/apps/whispering/src/lib/operations/upload.ts
@@ -62,7 +62,8 @@ export async function uploadRecordings({
 
 			const toastId = nanoid();
 			await processRecordingPipeline({
-				artifact: { kind: 'blob', blob: audioBlob },
+				audio: audioBlob,
+				durationMs: null,
 				toastId,
 				completionTitle: '📁 File uploaded successfully!',
 				completionDescription: file.name,

--- a/apps/whispering/src/lib/rpc/transcription.ts
+++ b/apps/whispering/src/lib/rpc/transcription.ts
@@ -1,5 +1,5 @@
 import { Err, Ok, partitionResults, type Result } from 'wellcrafted/result';
-import { transcribeBlob } from '$lib/operations/transcribe';
+import { transcribeAudio } from '$lib/operations/transcribe';
 import { WhisperingErr, type WhisperingError } from '$lib/result';
 import { defineMutation, queryClient } from '$lib/rpc/client';
 import { services } from '$lib/services';
@@ -35,7 +35,7 @@ export const transcription = {
 
 			recordings.update(recording.id, { transcriptionStatus: 'TRANSCRIBING' });
 			const { data: transcribedText, error: transcribeError } =
-				await transcribeBlob(audioBlob);
+				await transcribeAudio(audioBlob);
 			if (transcribeError) {
 				recordings.update(recording.id, { transcriptionStatus: 'FAILED' });
 				return Err(transcribeError);
@@ -64,7 +64,7 @@ export const transcription = {
 						});
 					}
 
-					return await transcribeBlob(audioBlob);
+					return await transcribeAudio(audioBlob);
 				}),
 			);
 			const partitionedResults = partitionResults(results);

--- a/apps/whispering/src/lib/services/recorder/artifact.ts
+++ b/apps/whispering/src/lib/services/recorder/artifact.ts
@@ -1,33 +1,28 @@
-import type { AudioArtifact } from './types';
+import { RECORDER_OUTPUT_RATE } from '$lib/constants/audio';
 
 /**
- * Materialize an artifact as a `Blob`. Used at the boundary with code
- * paths that consume Blobs (history persistence, the legacy
- * navigator-shaped transcription dispatch).
+ * Materialize in-memory PCM as a WAV blob. Used at the boundary with
+ * code paths that consume Blobs (history persistence, the navigator-shaped
+ * transcription dispatch).
  *
- * - `pcm` -> in-memory WAV synthesis (IEEE Float, mono). Cheap; bounded
- *   by recording length.
- * - `blob` -> identity.
+ * Mono 16 kHz is the recorder's contract (`RECORDER_OUTPUT_RATE`); both
+ * are baked into the WAV header here. If the contract ever changes, this
+ * grows back to taking rate/channels parameters.
  */
-export function artifactToBlob(artifact: AudioArtifact): Blob {
-	if (artifact.kind === 'blob') return artifact.blob;
-	const wavBuffer = encodePcmAsWav(artifact);
-	return new Blob([wavBuffer], { type: 'audio/wav' });
+export function pcmToWavBlob(samples: Float32Array): Blob {
+	return new Blob([encodePcmAsWav(samples)], { type: 'audio/wav' });
 }
 
 /**
- * Build a minimal IEEE Float 32-bit WAV file in memory from a mono PCM
- * artifact. Matches the format the previous Rust WAV writer produced,
- * so downstream decoders see one shape.
+ * Build a minimal IEEE Float 32-bit mono WAV file in memory from the
+ * recorder's PCM samples. Matches the format the previous Rust WAV writer
+ * produced, so downstream decoders see one shape.
  */
-function encodePcmAsWav(artifact: {
-	samples: Float32Array;
-	rate: number;
-	channels: number;
-}): ArrayBuffer {
-	const { samples, rate, channels } = artifact;
+function encodePcmAsWav(samples: Float32Array): ArrayBuffer {
 	const bitsPerSample = 32;
 	const bytesPerSample = bitsPerSample / 8;
+	const channels = 1;
+	const rate = RECORDER_OUTPUT_RATE;
 	const dataSize = samples.byteLength;
 	const fileSize = 36 + dataSize;
 	const buf = new ArrayBuffer(44 + dataSize);

--- a/apps/whispering/src/lib/services/recorder/artifact.ts
+++ b/apps/whispering/src/lib/services/recorder/artifact.ts
@@ -1,5 +1,4 @@
-import { Ok, type Result } from 'wellcrafted/result';
-import type { AudioArtifact, RecorderError } from './types';
+import type { AudioArtifact } from './types';
 
 /**
  * Materialize an artifact as a `Blob`. Used at the boundary with code
@@ -9,16 +8,11 @@ import type { AudioArtifact, RecorderError } from './types';
  * - `pcm` -> in-memory WAV synthesis (IEEE Float, mono). Cheap; bounded
  *   by recording length.
  * - `blob` -> identity.
- *
- * Returns `Result` for symmetry with code that branches on error, though
- * neither variant can actually fail today.
  */
-export async function artifactToBlob(
-	artifact: AudioArtifact,
-): Promise<Result<Blob, RecorderError>> {
-	if (artifact.kind === 'blob') return Ok(artifact.blob);
+export function artifactToBlob(artifact: AudioArtifact): Blob {
+	if (artifact.kind === 'blob') return artifact.blob;
 	const wavBuffer = encodePcmAsWav(artifact);
-	return Ok(new Blob([wavBuffer], { type: 'audio/wav' }));
+	return new Blob([wavBuffer], { type: 'audio/wav' });
 }
 
 /**

--- a/apps/whispering/src/lib/services/recorder/cpal.tauri.ts
+++ b/apps/whispering/src/lib/services/recorder/cpal.tauri.ts
@@ -29,11 +29,11 @@ const log = createLogger('whispering/recorder/cpal');
  * decimal-decoded array of doubles. For a 30 s clip this collapses the
  * post-stop critical path by ~150-300 ms compared to JSON `Vec<f32>`.
  */
-function parseArtifact(
+function parsePcmIpcBody(
 	buffer: ArrayBuffer,
 ): Result<Float32Array, RecorderError> {
 	if (buffer.byteLength % 4 !== 0) {
-		return RecorderError.InvalidArtifactIpc({
+		return RecorderError.InvalidPcmIpc({
 			reason: `byte length not a multiple of 4 (f32 size)`,
 			byteLength: buffer.byteLength,
 		});
@@ -153,7 +153,7 @@ function createCpalRecorder(): RecorderService {
 					return RecorderError.StopFailed({ cause: stopRecordingError });
 				}
 
-				const { data: samples, error: parseError } = parseArtifact(buffer);
+				const { data: samples, error: parseError } = parsePcmIpcBody(buffer);
 				if (parseError) {
 					await closeAndTeardown(recording, sendStatus);
 					return Err(parseError);

--- a/apps/whispering/src/lib/services/recorder/cpal.tauri.ts
+++ b/apps/whispering/src/lib/services/recorder/cpal.tauri.ts
@@ -1,11 +1,14 @@
 import { invoke as tauriInvoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { createLogger } from 'wellcrafted/logger';
 import { Err, Ok, type Result, tryAsync } from 'wellcrafted/result';
-import type { WhisperingRecordingState } from '$lib/constants/audio';
+import {
+	RECORDER_OUTPUT_RATE,
+	type WhisperingRecordingState,
+} from '$lib/constants/audio';
 import { categorizeRecorderError } from '$lib/services/recorder/categorize-error';
 import {
 	asDeviceIdentifier,
-	type AudioArtifact,
 	type CpalRecordingParams,
 	type Device,
 	type DeviceAcquisitionOutcome,
@@ -14,28 +17,28 @@ import {
 	type Recording,
 } from '$lib/services/recorder/types';
 
+const log = createLogger('whispering/recorder/cpal');
+
 /**
- * Parse the binary response from `stop_recording`. Wire layout (LE):
- *   bytes 0..4   : u32  rate
- *   bytes 4..6   : u16  channels
- *   bytes 6..8   : u16  padding (aligns samples to f32 boundary)
- *   bytes 8..    : f32[] samples
+ * Parse the binary response from `stop_recording`. Wire layout: raw
+ * little-endian f32 samples, no header. The recorder's contract is "16 kHz
+ * mono" (see `RECORDER_OUTPUT_RATE`), so rate and channels are not on the
+ * wire; if the contract ever changes, both sides grow a header together.
  *
  * The `Float32Array` is a zero-copy view over the IPC body, not a
  * decimal-decoded array of doubles. For a 30 s clip this collapses the
  * post-stop critical path by ~150-300 ms compared to JSON `Vec<f32>`.
  */
-function parseArtifact(buffer: ArrayBuffer): Extract<AudioArtifact, { kind: 'pcm' }> {
-	const view = new DataView(buffer);
-	const rate = view.getUint32(0, true);
-	const channels = view.getUint16(4, true);
-	const samples = new Float32Array(buffer, 8);
-	return {
-		kind: 'pcm',
-		samples,
-		rate,
-		channels,
-	};
+function parseArtifact(
+	buffer: ArrayBuffer,
+): Result<Float32Array, RecorderError> {
+	if (buffer.byteLength % 4 !== 0) {
+		return RecorderError.InvalidArtifactIpc({
+			reason: `byte length not a multiple of 4 (f32 size)`,
+			byteLength: buffer.byteLength,
+		});
+	}
+	return Ok(new Float32Array(buffer));
 }
 
 /**
@@ -116,6 +119,28 @@ function createCpalRecorder(): RecorderService {
 			notify('IDLE');
 		};
 
+		// Close the Rust-side session and tear down JS state. Used by both
+		// the happy path and the parse-failure path so a malformed IPC body
+		// can't leave a zombie session in Rust or a stale activeRecording
+		// pointer in JS. Takes `recording` explicitly for the same TDZ
+		// reason `teardown` does.
+		const closeAndTeardown = async (
+			recording: Recording,
+			sendStatus: (args: { title: string; description: string }) => void,
+		) => {
+			sendStatus({
+				title: '🔄 Closing Session',
+				description: 'Cleaning up recording resources...',
+			});
+			const { error: closeError } = await invoke<void>(
+				'close_recording_session',
+			);
+			if (closeError) {
+				log.error(closeError);
+			}
+			teardown(recording);
+		};
+
 		const recording: Recording = {
 			recordingId,
 			backend: 'cpal',
@@ -128,24 +153,18 @@ function createCpalRecorder(): RecorderService {
 					return RecorderError.StopFailed({ cause: stopRecordingError });
 				}
 
-				const artifact = parseArtifact(buffer);
-				const durationMs = Math.round(
-					(artifact.samples.length / artifact.rate / artifact.channels) * 1000,
-				);
-
-				sendStatus({
-					title: '🔄 Closing Session',
-					description: 'Cleaning up recording resources...',
-				});
-				const { error: closeError } = await invoke<void>(
-					'close_recording_session',
-				);
-				if (closeError) {
-					console.error('Failed to close recording session:', closeError);
+				const { data: samples, error: parseError } = parseArtifact(buffer);
+				if (parseError) {
+					await closeAndTeardown(recording, sendStatus);
+					return Err(parseError);
 				}
 
-				teardown(recording);
-				return Ok({ artifact, recordingId, durationMs });
+				const durationMs = Math.round(
+					(samples.length / RECORDER_OUTPUT_RATE) * 1000,
+				);
+
+				await closeAndTeardown(recording, sendStatus);
+				return Ok({ audio: samples, recordingId, durationMs });
 			},
 
 			cancel: async ({ sendStatus }) => {

--- a/apps/whispering/src/lib/services/recorder/cpal.tauri.ts
+++ b/apps/whispering/src/lib/services/recorder/cpal.tauri.ts
@@ -18,7 +18,7 @@ import {
  * Parse the binary response from `stop_recording`. Wire layout (LE):
  *   bytes 0..4   : u32  rate
  *   bytes 4..6   : u16  channels
- *   bytes 6..8   : u16  reserved
+ *   bytes 6..8   : u16  padding (aligns samples to f32 boundary)
  *   bytes 8..    : f32[] samples
  *
  * The `Float32Array` is a zero-copy view over the IPC body, not a

--- a/apps/whispering/src/lib/services/recorder/navigator.ts
+++ b/apps/whispering/src/lib/services/recorder/navigator.ts
@@ -99,11 +99,7 @@ function createNavigatorRecorder(): RecorderService {
 					title: '✅ Recording Saved',
 					description: 'Your recording is ready for transcription!',
 				});
-				return Ok({
-					artifact: { kind: 'blob' as const, blob },
-					recordingId,
-					durationMs,
-				});
+				return Ok({ audio: blob, recordingId, durationMs });
 			},
 
 			cancel: async ({ sendStatus }) => {

--- a/apps/whispering/src/lib/services/recorder/pcm-to-wav.ts
+++ b/apps/whispering/src/lib/services/recorder/pcm-to-wav.ts
@@ -1,24 +1,15 @@
 import { RECORDER_OUTPUT_RATE } from '$lib/constants/audio';
 
 /**
- * Materialize in-memory PCM as a WAV blob. Used at the boundary with
- * code paths that consume Blobs (history persistence, the navigator-shaped
- * transcription dispatch).
+ * Materialize the recorder's in-memory PCM as a mono 16 kHz IEEE Float
+ * WAV blob. Used at the boundary with code paths that consume Blobs
+ * (history persistence, the navigator-shaped transcription dispatch).
  *
  * Mono 16 kHz is the recorder's contract (`RECORDER_OUTPUT_RATE`); both
  * are baked into the WAV header here. If the contract ever changes, this
  * grows back to taking rate/channels parameters.
  */
 export function pcmToWavBlob(samples: Float32Array): Blob {
-	return new Blob([encodePcmAsWav(samples)], { type: 'audio/wav' });
-}
-
-/**
- * Build a minimal IEEE Float 32-bit mono WAV file in memory from the
- * recorder's PCM samples. Matches the format the previous Rust WAV writer
- * produced, so downstream decoders see one shape.
- */
-function encodePcmAsWav(samples: Float32Array): ArrayBuffer {
 	const bitsPerSample = 32;
 	const bytesPerSample = bitsPerSample / 8;
 	const channels = 1;
@@ -53,7 +44,7 @@ function encodePcmAsWav(samples: Float32Array): ArrayBuffer {
 		new Uint8Array(samples.buffer, samples.byteOffset, samples.byteLength),
 	);
 
-	return buf;
+	return new Blob([buf], { type: 'audio/wav' });
 }
 
 function writeAscii(view: DataView, offset: number, str: string): void {

--- a/apps/whispering/src/lib/services/recorder/types.ts
+++ b/apps/whispering/src/lib/services/recorder/types.ts
@@ -198,7 +198,7 @@ export const RecorderError = defineErrors({
 		command,
 		cause,
 	}),
-	InvalidArtifactIpc: ({
+	InvalidPcmIpc: ({
 		reason,
 		byteLength,
 	}: {

--- a/apps/whispering/src/lib/services/recorder/types.ts
+++ b/apps/whispering/src/lib/services/recorder/types.ts
@@ -198,6 +198,17 @@ export const RecorderError = defineErrors({
 		command,
 		cause,
 	}),
+	InvalidArtifactIpc: ({
+		reason,
+		byteLength,
+	}: {
+		reason: string;
+		byteLength: number;
+	}) => ({
+		message: `Malformed PCM IPC body (${byteLength} bytes): ${reason}`,
+		reason,
+		byteLength,
+	}),
 });
 export type RecorderError = InferErrors<typeof RecorderError>;
 
@@ -226,30 +237,23 @@ export type NavigatorRecordingParams = BaseRecordingParams & {
 };
 
 /**
- * Canonical audio artifact emitted by every recorder path.
- * Describes only the audio payload. Capture-session metadata such as
- * `recordingId` and `durationMs` belongs to the `Recording.stop()` result.
+ * Audio payload accepted by the pipeline and the transcribe layer.
+ * Describes only the bytes. Capture-session metadata such as `recordingId`
+ * and `durationMs` belongs to the `Recording.stop()` result, not here.
  *
- * Two variants only:
- * - `pcm`: in-memory mono PCM @ 16 kHz from the cpal recorder. Cheapest
- *   input for both cloud (direct opus encode) and local (no decode)
- *   transcription.
- * - `blob`: container bytes from anywhere else: navigator (Opus/WebM
- *   or mp4/AAC), VAD speech captures, file uploads, history replays.
- *   The transcribe layer either passes it through or compresses if the
- *   bytes look like an unencoded WAV.
+ * Two physical shapes:
+ * - `Float32Array`: in-memory mono PCM at 16 kHz from the cpal recorder.
+ *   The sample rate is a recorder contract (`RECORDER_OUTPUT_RATE`), not
+ *   a per-payload field. Cheapest input for both cloud (direct opus
+ *   encode) and local (no decode) transcription.
+ * - `Blob`: container bytes from anywhere else, navigator (Opus/WebM or
+ *   mp4/AAC), VAD speech captures, file uploads, history replays. The
+ *   transcribe layer either passes it through or compresses if the bytes
+ *   look like an unencoded WAV.
+ *
+ * Branches with `instanceof Blob`; the alternative is `Float32Array`.
  */
-export type AudioArtifact =
-	| {
-			kind: 'pcm';
-			samples: Float32Array;
-			rate: number;
-			channels: number;
-	  }
-	| {
-			kind: 'blob';
-			blob: Blob;
-	  };
+export type RecorderAudio = Float32Array | Blob;
 
 /**
  * Discriminated union for recording parameters based on method
@@ -278,7 +282,7 @@ export type Recording = {
 		sendStatus: UpdateStatusMessageFn;
 	}): Promise<
 		Result<
-			{ artifact: AudioArtifact; recordingId: string; durationMs: number },
+			{ audio: RecorderAudio; recordingId: string; durationMs: number },
 			RecorderError
 		>
 	>;

--- a/apps/whispering/src/lib/services/recorder/types.ts
+++ b/apps/whispering/src/lib/services/recorder/types.ts
@@ -227,6 +227,8 @@ export type NavigatorRecordingParams = BaseRecordingParams & {
 
 /**
  * Canonical audio artifact emitted by every recorder path.
+ * Describes only the audio payload. Capture-session metadata such as
+ * `recordingId` and `durationMs` belongs to the `Recording.stop()` result.
  *
  * Two variants only:
  * - `pcm`: in-memory mono PCM @ 16 kHz from the cpal recorder. Cheapest

--- a/apps/whispering/src/lib/tauri.tauri.ts
+++ b/apps/whispering/src/lib/tauri.tauri.ts
@@ -309,32 +309,27 @@ const audioEncoder = {
 	},
 
 	/**
-	 * Compress a mono f32 PCM buffer into OGG/Opus. Used by the dictation
-	 * cpal path: the recorder returns samples already in memory, so we
-	 * skip the WAV synthesis + decode round-trip and hand the samples
-	 * straight to libopus.
+	 * Compress the recorder's in-memory mono 16 kHz PCM into OGG/Opus.
+	 * Used by the dictation cpal path: the recorder returns samples already
+	 * in memory, so we skip the WAV synthesis + decode round-trip and hand
+	 * the samples straight to libopus.
 	 *
-	 * Body packing mirrors the Rust `encode_upload_pcm` handler:
-	 * `[u32 rate][u16 channels][u16 pad][f32 samples...]` (little-endian).
+	 * Wire format mirrors `encode_upload_pcm`: raw little-endian f32 samples,
+	 * no header. The rate/channels are a recorder contract, not on the wire.
 	 */
-	async encodePcmToOpusOgg(args: {
-		samples: Float32Array;
-		rate: number;
-		channels: number;
-	}): Promise<Result<Blob, AudioEncoderError>> {
-		const { samples, rate, channels } = args;
-		const headerSize = 8;
-		const buf = new ArrayBuffer(headerSize + samples.byteLength);
-		const view = new DataView(buf);
-		view.setUint32(0, rate, true);
-		view.setUint16(4, channels, true);
-		view.setUint16(6, 0, true); // reserved
-		new Uint8Array(buf, headerSize).set(
-			new Uint8Array(samples.buffer, samples.byteOffset, samples.byteLength),
+	async encodePcmToOpusOgg(
+		samples: Float32Array,
+	): Promise<Result<Blob, AudioEncoderError>> {
+		// Tauri's IPC body accepts a Uint8Array (or ArrayBuffer). A typed-array
+		// view over the samples is zero-copy; no need to allocate a copy.
+		const body = new Uint8Array(
+			samples.buffer,
+			samples.byteOffset,
+			samples.byteLength,
 		);
 
 		const { data: oggBytes, error } = await tryAsync({
-			try: () => invoke<ArrayBuffer>('encode_upload_pcm', buf),
+			try: () => invoke<ArrayBuffer>('encode_upload_pcm', body),
 			catch: (cause) => AudioEncoderError.EncodeFailed({ cause }),
 		});
 


### PR DESCRIPTION
The Whispering recorder path had picked up three different shapes for the same thing: a live recording session, an audio artifact, and the actual bytes we send to transcription. That made the CPAL path pay for conversions that did not describe real domain choices anymore: raw PCM became a tagged artifact, then often became WAV, then got decoded again before upload compression.

This PR makes the recorder boundary say the quiet part plainly: a recorder returns audio bytes, plus session metadata. CPAL returns in-memory `Float32Array` PCM. Navigator, file upload, VAD, and history paths use `Blob`. The transcription layer can now choose the cheapest valid shape for the selected provider without carrying speculative artifact vocabulary through the system.

```
Before
cpal stop
  -> AudioArtifact { kind: "pcm", samples, rate, channels }
  -> artifactToBlob()
  -> WAV synthesis
  -> Symphonia decode
  -> Opus encode
  -> upload

After
cpal stop
  -> Float32Array
  -> Opus encode
  -> upload
```

The key design decision is that sample rate and channel count are no longer payload fields. The recorder output contract is 16 kHz mono, mirrored in Rust and TypeScript. The old header always carried those constants, so it looked like runtime metadata while behaving like a fixed protocol assumption.

```ts
// Before
type AudioArtifact =
	| { kind: 'pcm'; samples: Float32Array; rate: number; channels: number }
	| { kind: 'blob'; blob: Blob };

// After
type RecorderAudio = Float32Array | Blob;
```

That also tightens the `Recording.stop()` contract. The live session owns `recordingId` and `durationMs`; the audio value owns only the bytes.

```ts
// Before
Recording.stop() -> {
	artifact: AudioArtifact;
	recordingId: string;
	durationMs: number;
}

// After
Recording.stop() -> {
	audio: RecorderAudio;
	recordingId: string;
	durationMs: number;
}
```

The CPAL IPC path now returns raw little-endian `f32` samples with no header. TypeScript parses that body as a zero-copy `Float32Array`, validates alignment before constructing it, and tears down the Rust session even if parsing fails.

```
Rust recorder worker
  -> CapturedPcm { samples }
  -> binary response: f32[] samples
  -> ArrayBuffer
  -> Float32Array view
```

This removed the stale `artifact` naming from the public surface too:

```text
services/recorder/artifact.ts  -> services/recorder/pcm-to-wav.ts
parseArtifact                  -> parsePcmIpcBody
InvalidArtifactIpc             -> InvalidPcmIpc
transcribeArtifact             -> transcribeAudio
```

There are a few small hardening fixes bundled with the collapse because they sit directly on the same boundary:

- CPAL stop now closes and tears down the active recording on parse failure instead of leaving the session pointer and Tauri listener live.
- Recorder library code logs close-session failures through `wellcrafted/logger` instead of `console.error`.
- `processRecordingPipeline` now persists `durationMs` into the existing `recordings.duration` column instead of always writing `null`.

For a typical 30 second dictation upload, this removes the JSON `Vec<f32>` path and the WAV synth/decode loop. The cloud upload case now sends CPAL PCM straight into `encode_upload_pcm`; local transcription still receives a `Blob`, synthesized only when the selected service actually needs one.

Verification:

- `bun run typecheck`: 0 errors in `apps/whispering`, with 11 unrelated existing Svelte warnings
- `cargo check`: clean
- `cargo test --lib recorder`: 11/11 passing, including `captured_pcm_to_binary_writes_samples_only`

Manual smoke testing is still worth doing for record to transcribe on cloud and local providers, plus file upload and VAD paths. The `sampleRate` setting remains intentionally present: it is a CPAL device configuration hint, not a change to the recorder output contract.
