### PR TITLE
refactor(whispering): drop dead transcription config (temperature, unbound shortcuts, cursor docs)

### DIFF
--- a/.agents/skills/query-layer/references/runtime-dependency-injection.md
+++ b/.agents/skills/query-layer/references/runtime-dependency-injection.md
@@ -23,7 +23,6 @@ async function transcribeBlob(blob: Blob): Promise<Result<string, UserError>> {
 				modelName: settings.value['transcription.openai.model'],
 				outputLanguage: settings.value['transcription.outputLanguage'],
 				prompt: settings.value['transcription.prompt'],
-				temperature: settings.value['transcription.temperature'],
 			});
 		case 'Groq':
 			return await services.transcriptions.groq.transcribe(blob, {
@@ -31,7 +30,6 @@ async function transcribeBlob(blob: Blob): Promise<Result<string, UserError>> {
 				modelName: settings.value['transcription.groq.model'],
 				outputLanguage: settings.value['transcription.outputLanguage'],
 				prompt: settings.value['transcription.prompt'],
-				temperature: settings.value['transcription.temperature'],
 			});
 		// ... more cases
 		default:

--- a/apps/whispering/README.md
+++ b/apps/whispering/README.md
@@ -729,7 +729,6 @@ Adding a new transcription service involves four main steps:
    		audioBlob: Blob,
    		options: {
    			prompt: string;
-   			temperature: string;
    			outputLanguage: string;
    			apiKey: string;
    			modelName: (string & {}) | YourServiceModel['name'];
@@ -827,7 +826,6 @@ Adding a new transcription service involves four main steps:
      return services.transcriptions.yourservice.transcribe(blob, {
        outputLanguage: settings.value['transcription.outputLanguage'],
        prompt: settings.value['transcription.prompt'],
-       temperature: settings.value['transcription.temperature'],
        apiKey: settings.value['apiKeys.yourservice'],
        modelName: settings.value['transcription.yourservice.model'],
      });

--- a/apps/whispering/src/lib/commands.ts
+++ b/apps/whispering/src/lib/commands.ts
@@ -2,9 +2,7 @@ import type { ShortcutEvent } from '@tauri-apps/plugin-global-shortcut';
 import {
 	cancelManualRecording,
 	startManualRecording,
-	startVadRecording,
 	stopManualRecording,
-	stopVadRecording,
 	toggleManualRecording,
 	toggleVadRecording,
 } from '$lib/operations/recording';
@@ -62,34 +60,10 @@ export const commands = [
 		callback: () => toggleManualRecording(),
 	},
 	{
-		id: 'startManualRecording',
-		title: 'Start recording',
-		on: ['Pressed'],
-		callback: () => startManualRecording(),
-	},
-	{
-		id: 'stopManualRecording',
-		title: 'Stop recording',
-		on: ['Pressed'],
-		callback: () => stopManualRecording(),
-	},
-	{
 		id: 'cancelManualRecording',
 		title: 'Cancel recording',
 		on: ['Pressed'],
 		callback: () => cancelManualRecording(),
-	},
-	{
-		id: 'startVadRecording',
-		title: 'Start voice activated recording',
-		on: ['Pressed'],
-		callback: () => startVadRecording(),
-	},
-	{
-		id: 'stopVadRecording',
-		title: 'Stop voice activated recording',
-		on: ['Pressed'],
-		callback: () => stopVadRecording(),
 	},
 	{
 		id: 'toggleVadRecording',

--- a/apps/whispering/src/lib/constants/transcription.ts
+++ b/apps/whispering/src/lib/constants/transcription.ts
@@ -39,7 +39,6 @@ export const TRANSCRIPTION = {
 		],
 		capabilities: {
 			supportsPrompt: true,
-			supportsTemperature: true,
 			supportsLanguage: true,
 		},
 	},
@@ -63,7 +62,6 @@ export const TRANSCRIPTION = {
 		],
 		capabilities: {
 			supportsPrompt: true,
-			supportsTemperature: true,
 			supportsLanguage: true,
 		},
 	},
@@ -93,7 +91,6 @@ export const TRANSCRIPTION = {
 		],
 		capabilities: {
 			supportsPrompt: true,
-			supportsTemperature: true,
 			supportsLanguage: true,
 		},
 	},
@@ -134,7 +131,6 @@ export const TRANSCRIPTION = {
 		],
 		capabilities: {
 			supportsPrompt: true,
-			supportsTemperature: true,
 			supportsLanguage: true,
 		},
 	},
@@ -158,7 +154,6 @@ export const TRANSCRIPTION = {
 		],
 		capabilities: {
 			supportsPrompt: true,
-			supportsTemperature: true,
 			supportsLanguage: true,
 		},
 	},
@@ -172,7 +167,6 @@ export const TRANSCRIPTION = {
 		models: null,
 		capabilities: {
 			supportsPrompt: true,
-			supportsTemperature: false,
 			supportsLanguage: true,
 		},
 	},
@@ -182,7 +176,6 @@ export const TRANSCRIPTION = {
 		models: null,
 		capabilities: {
 			supportsPrompt: false,
-			supportsTemperature: false,
 			supportsLanguage: false,
 		},
 	},
@@ -192,7 +185,6 @@ export const TRANSCRIPTION = {
 		models: null,
 		capabilities: {
 			supportsPrompt: false,
-			supportsTemperature: false,
 			supportsLanguage: false,
 		},
 	},
@@ -205,7 +197,6 @@ export const TRANSCRIPTION = {
 		models: null,
 		capabilities: {
 			supportsPrompt: true,
-			supportsTemperature: true,
 			supportsLanguage: true,
 		},
 	},

--- a/apps/whispering/src/lib/migration/migrate-settings.ts
+++ b/apps/whispering/src/lib/migration/migrate-settings.ts
@@ -293,28 +293,12 @@ const WORKSPACE_KEY_MAP: readonly {
 		newKey: 'shortcut.toggleManualRecording',
 	},
 	{
-		oldKey: 'shortcuts.local.startManualRecording',
-		newKey: 'shortcut.startManualRecording',
-	},
-	{
-		oldKey: 'shortcuts.local.stopManualRecording',
-		newKey: 'shortcut.stopManualRecording',
-	},
-	{
 		oldKey: 'shortcuts.local.cancelManualRecording',
 		newKey: 'shortcut.cancelManualRecording',
 	},
 	{
 		oldKey: 'shortcuts.local.toggleVadRecording',
 		newKey: 'shortcut.toggleVadRecording',
-	},
-	{
-		oldKey: 'shortcuts.local.startVadRecording',
-		newKey: 'shortcut.startVadRecording',
-	},
-	{
-		oldKey: 'shortcuts.local.stopVadRecording',
-		newKey: 'shortcut.stopVadRecording',
 	},
 	{ oldKey: 'shortcuts.local.pushToTalk', newKey: 'shortcut.pushToTalk' },
 	{
@@ -398,28 +382,12 @@ const DEVICE_KEY_MAP: readonly { oldKey: string; newKey: string }[] = [
 		newKey: 'shortcuts.global.toggleManualRecording',
 	},
 	{
-		oldKey: 'shortcuts.global.startManualRecording',
-		newKey: 'shortcuts.global.startManualRecording',
-	},
-	{
-		oldKey: 'shortcuts.global.stopManualRecording',
-		newKey: 'shortcuts.global.stopManualRecording',
-	},
-	{
 		oldKey: 'shortcuts.global.cancelManualRecording',
 		newKey: 'shortcuts.global.cancelManualRecording',
 	},
 	{
 		oldKey: 'shortcuts.global.toggleVadRecording',
 		newKey: 'shortcuts.global.toggleVadRecording',
-	},
-	{
-		oldKey: 'shortcuts.global.startVadRecording',
-		newKey: 'shortcuts.global.startVadRecording',
-	},
-	{
-		oldKey: 'shortcuts.global.stopVadRecording',
-		newKey: 'shortcuts.global.stopVadRecording',
 	},
 	{
 		oldKey: 'shortcuts.global.pushToTalk',

--- a/apps/whispering/src/lib/migration/migrate-settings.ts
+++ b/apps/whispering/src/lib/migration/migrate-settings.ts
@@ -160,15 +160,6 @@ function tryParseJson(raw: string | null): Record<string, unknown> | null {
 	return null;
 }
 
-function toNumber(raw: unknown): number | undefined {
-	if (typeof raw === 'number') return raw;
-	if (typeof raw === 'string') {
-		const value = parseFloat(raw);
-		return Number.isNaN(value) ? undefined : value;
-	}
-	return undefined;
-}
-
 function toInteger(raw: unknown): number | undefined {
 	if (typeof raw === 'number') return Number.isInteger(raw) ? raw : undefined;
 	if (typeof raw === 'string') {
@@ -248,7 +239,7 @@ const WORKSPACE_KEY_MAP: readonly {
 	// Recording
 	{ oldKey: 'recording.mode', newKey: 'recording.mode' },
 
-	// Transcription (temperature: string → number)
+	// Transcription
 	{
 		oldKey: 'transcription.selectedTranscriptionService',
 		newKey: 'transcription.service',
@@ -272,11 +263,6 @@ const WORKSPACE_KEY_MAP: readonly {
 	},
 	{ oldKey: 'transcription.outputLanguage', newKey: 'transcription.language' },
 	{ oldKey: 'transcription.prompt', newKey: 'transcription.prompt' },
-	{
-		oldKey: 'transcription.temperature',
-		newKey: 'transcription.temperature',
-		convert: toNumber,
-	},
 
 	// Transformation
 	{

--- a/apps/whispering/src/lib/operations/transcribe.ts
+++ b/apps/whispering/src/lib/operations/transcribe.ts
@@ -158,7 +158,6 @@ async function dispatchCloudTranscription(
 
 	const outputLanguage = getOutputLanguage();
 	const prompt = settings.get('transcription.prompt');
-	const temperature = String(settings.get('transcription.temperature'));
 
 	switch (selectedService) {
 		case 'OpenAI': {
@@ -167,7 +166,6 @@ async function dispatchCloudTranscription(
 				{
 					outputLanguage,
 					prompt,
-					temperature,
 					apiKey: deviceConfig.get('apiKeys.openai'),
 					modelName: settings.get('transcription.openai.model'),
 					baseURL: deviceConfig.get('apiEndpoints.openai') || undefined,
@@ -182,7 +180,6 @@ async function dispatchCloudTranscription(
 				{
 					outputLanguage,
 					prompt,
-					temperature,
 					apiKey: deviceConfig.get('apiKeys.groq'),
 					modelName: settings.get('transcription.groq.model'),
 					baseURL: deviceConfig.get('apiEndpoints.groq') || undefined,
@@ -196,7 +193,6 @@ async function dispatchCloudTranscription(
 				await services.transcriptions.speaches.transcribe(audio, {
 					outputLanguage,
 					prompt,
-					temperature,
 					modelId: deviceConfig.get('transcription.speaches.modelId'),
 					baseUrl: deviceConfig.get('transcription.speaches.baseUrl'),
 				});
@@ -208,7 +204,6 @@ async function dispatchCloudTranscription(
 				await services.transcriptions.elevenlabs.transcribe(audio, {
 					outputLanguage,
 					prompt,
-					temperature,
 					apiKey: deviceConfig.get('apiKeys.elevenlabs'),
 					modelName: settings.get('transcription.elevenlabs.model'),
 				});
@@ -221,7 +216,6 @@ async function dispatchCloudTranscription(
 				{
 					outputLanguage,
 					prompt,
-					temperature,
 					apiKey: deviceConfig.get('apiKeys.deepgram'),
 					modelName: settings.get('transcription.deepgram.model'),
 				},
@@ -235,7 +229,6 @@ async function dispatchCloudTranscription(
 				{
 					outputLanguage,
 					prompt,
-					temperature,
 					apiKey: deviceConfig.get('apiKeys.mistral'),
 					modelName: settings.get('transcription.mistral.model'),
 				},

--- a/apps/whispering/src/lib/services/README.md
+++ b/apps/whispering/src/lib/services/README.md
@@ -13,7 +13,6 @@ case 'OpenAI': {
 		{
 			outputLanguage,
 			prompt,
-			temperature,
 			apiKey: deviceConfig.get('apiKeys.openai'),
 			modelName: settings.get('transcription.openai.model'),
 			baseURL: deviceConfig.get('apiEndpoints.openai') || undefined,

--- a/apps/whispering/src/lib/services/transcription/cloud/deepgram.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/deepgram.ts
@@ -88,7 +88,6 @@ export const DeepgramTranscriptionServiceLive = {
 		audioBlob: Blob,
 		options: {
 			prompt: string;
-			temperature: string;
 			outputLanguage: string;
 			apiKey: string;
 			modelName: string;

--- a/apps/whispering/src/lib/services/transcription/cloud/elevenlabs.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/elevenlabs.ts
@@ -29,7 +29,6 @@ export const ElevenLabsTranscriptionServiceLive = {
 		audioBlob: Blob,
 		options: {
 			prompt: string;
-			temperature: string;
 			outputLanguage: string;
 			apiKey: string;
 			modelName: string;

--- a/apps/whispering/src/lib/services/transcription/cloud/groq.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/groq.ts
@@ -79,7 +79,6 @@ export const GroqTranscriptionServiceLive = {
 		audioBlob: Blob,
 		options: {
 			prompt: string;
-			temperature: string;
 			outputLanguage: string;
 			apiKey: string;
 			modelName: string;
@@ -127,9 +126,6 @@ export const GroqTranscriptionServiceLive = {
 							? undefined
 							: options.outputLanguage,
 					prompt: options.prompt ? options.prompt : undefined,
-					temperature: options.temperature
-						? Number.parseFloat(options.temperature)
-						: undefined,
 				});
 				return transcription.text.trim();
 			},

--- a/apps/whispering/src/lib/services/transcription/cloud/mistral.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/mistral.ts
@@ -72,7 +72,6 @@ export const MistralTranscriptionServiceLive = {
 		audioBlob: Blob,
 		options: {
 			prompt: string;
-			temperature: string;
 			outputLanguage: string;
 			apiKey: string;
 			modelName: string;
@@ -109,9 +108,6 @@ export const MistralTranscriptionServiceLive = {
 						options.outputLanguage !== 'auto'
 							? options.outputLanguage
 							: undefined,
-					temperature: options.temperature
-						? Number.parseFloat(options.temperature)
-						: undefined,
 				}),
 			catch: (error) => {
 				if (error instanceof MistralConnectionError) {

--- a/apps/whispering/src/lib/services/transcription/cloud/openai.ts
+++ b/apps/whispering/src/lib/services/transcription/cloud/openai.ts
@@ -87,7 +87,6 @@ export const OpenaiTranscriptionServiceLive = {
 		audioBlob: Blob,
 		options: {
 			prompt: string;
-			temperature: string;
 			outputLanguage: string;
 			apiKey: string;
 			modelName: string;
@@ -137,9 +136,6 @@ export const OpenaiTranscriptionServiceLive = {
 							? options.outputLanguage
 							: undefined,
 					prompt: options.prompt || undefined,
-					temperature: options.temperature
-						? Number.parseFloat(options.temperature)
-						: undefined,
 				});
 				return transcription.text.trim();
 			},

--- a/apps/whispering/src/lib/services/transcription/self-hosted/speaches.ts
+++ b/apps/whispering/src/lib/services/transcription/self-hosted/speaches.ts
@@ -81,7 +81,6 @@ export const SpeachesTranscriptionServiceLive = {
 		audioBlob: Blob,
 		options: {
 			prompt: string;
-			temperature: string;
 			outputLanguage: string;
 			modelId: string;
 			baseUrl: string;
@@ -99,8 +98,6 @@ export const SpeachesTranscriptionServiceLive = {
 			formData.append('language', options.outputLanguage);
 		}
 		if (options.prompt) formData.append('prompt', options.prompt);
-		if (options.temperature)
-			formData.append('temperature', options.temperature);
 
 		const { data: whisperApiResponse, error: postError } =
 			await HttpServiceLive.post({

--- a/apps/whispering/src/lib/state/device-config.svelte.ts
+++ b/apps/whispering/src/lib/state/device-config.svelte.ts
@@ -87,14 +87,6 @@ const DEVICE_DEFINITIONS = {
 		type('string | null'),
 		`${CommandOrControl}+Shift+;` as string | null,
 	),
-	'shortcuts.global.startManualRecording': defineEntry(
-		type('string | null'),
-		null,
-	),
-	'shortcuts.global.stopManualRecording': defineEntry(
-		type('string | null'),
-		null,
-	),
 	'shortcuts.global.cancelManualRecording': defineEntry(
 		type('string | null'),
 		`${CommandOrControl}+Shift+'` as string | null,
@@ -103,11 +95,6 @@ const DEVICE_DEFINITIONS = {
 		type('string | null'),
 		null,
 	),
-	'shortcuts.global.startVadRecording': defineEntry(
-		type('string | null'),
-		null,
-	),
-	'shortcuts.global.stopVadRecording': defineEntry(type('string | null'), null),
 	'shortcuts.global.pushToTalk': defineEntry(
 		type('string | null'),
 		`${CommandOrAlt}+Shift+D` as string | null,

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -264,6 +264,13 @@ const sound = {
  * Uses `output.*` prefix to separate post-processing behavior from service
  * configuration: avoids polluting `transcription.*` and `transformation.*`
  * namespaces with unrelated concerns.
+ *
+ * Cursor default asymmetry (transcription=true, transformation=false): when a
+ * transformation runs on the just-finished transcription, the transcription
+ * has already typed itself at the cursor. Defaulting transformation.cursor to
+ * true would double-type. Users who turn off transcription.cursor specifically
+ * to let the transformation be the cursor output can flip the transformation
+ * toggle on.
  */
 const output = {
 	'output.transcription.clipboard': defineKv(column.boolean(), () => true),

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -376,14 +376,6 @@ const shortcuts = {
 		column.nullable(column.string()),
 		(): string | null => ' ',
 	),
-	'shortcut.startManualRecording': defineKv(
-		column.nullable(column.string()),
-		(): string | null => null,
-	),
-	'shortcut.stopManualRecording': defineKv(
-		column.nullable(column.string()),
-		(): string | null => null,
-	),
 	'shortcut.cancelManualRecording': defineKv(
 		column.nullable(column.string()),
 		(): string | null => 'c',
@@ -391,14 +383,6 @@ const shortcuts = {
 	'shortcut.toggleVadRecording': defineKv(
 		column.nullable(column.string()),
 		(): string | null => 'v',
-	),
-	'shortcut.startVadRecording': defineKv(
-		column.nullable(column.string()),
-		(): string | null => null,
-	),
-	'shortcut.stopVadRecording': defineKv(
-		column.nullable(column.string()),
-		(): string | null => null,
 	),
 	'shortcut.pushToTalk': defineKv(
 		column.nullable(column.string()),

--- a/apps/whispering/src/lib/workspace/definition.ts
+++ b/apps/whispering/src/lib/workspace/definition.ts
@@ -307,8 +307,7 @@ const recording = {
  * Transcription service and per-service model selections.
  *
  * Each service's model is its own KV entry so switching from OpenAI to Groq and
- * back preserves your OpenAI model choice. `temperature` is stored as a number
- * (0 to 1): the old settings schema used a string for localStorage.
+ * back preserves your OpenAI model choice.
  *
  * @see {@link https://github.com/EpicenterHQ/epicenter/blob/main/specs/20260312T170000-whispering-workspace-polish-and-migration.md | Spec Decision 2}
  */
@@ -339,10 +338,6 @@ const transcription = {
 	),
 	'transcription.language': defineKv(column.string(), () => 'auto'),
 	'transcription.prompt': defineKv(column.string(), () => ''),
-	'transcription.temperature': defineKv(
-		column.number({ minimum: 0, maximum: 1 }),
-		() => 0,
-	),
 } as const;
 
 /**

--- a/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
+++ b/apps/whispering/src/routes/(app)/(config)/settings/transcription/+page.svelte
@@ -736,28 +736,6 @@
 		</Field.Field>
 
 		<Field.Field>
-			<Field.Label for="temperature">Temperature</Field.Label>
-			<Input
-				id="temperature"
-				type="number"
-				min="0"
-				max="1"
-				step="0.1"
-				placeholder="0"
-				autocomplete="off"
-				disabled={!currentServiceCapabilities.supportsTemperature}
-				bind:value={() => settings.get('transcription.temperature'),
-					(value) =>
-						settings.set('transcription.temperature', Number(value))}
-			/>
-			<Field.Description>
-				{currentServiceCapabilities.supportsTemperature
-					? "Controls randomness in the model's output. 0 is focused and deterministic, 1 is more creative."
-					: 'Temperature is not supported for local models (transcribe-rs)'}
-			</Field.Description>
-		</Field.Field>
-
-		<Field.Field>
 			<Field.Label for="transcription-prompt">System Prompt</Field.Label>
 			<Textarea
 				id="transcription-prompt"

--- a/apps/whispering/src/routes/(app)/_layout-utils/register-commands.ts
+++ b/apps/whispering/src/routes/(app)/_layout-utils/register-commands.ts
@@ -17,11 +17,7 @@ import type { Accelerator } from '$lib/utils/accelerator';
 const DEFAULT_LOCAL_SHORTCUTS: Record<string, string | null> = {
 	pushToTalk: 'p',
 	toggleManualRecording: ' ',
-	startManualRecording: null,
-	stopManualRecording: null,
 	cancelManualRecording: 'c',
-	startVadRecording: null,
-	stopVadRecording: null,
 	toggleVadRecording: 'v',
 	openTransformationPicker: 't',
 	runTransformationOnClipboard: 'r',
@@ -31,11 +27,7 @@ const DEFAULT_LOCAL_SHORTCUTS: Record<string, string | null> = {
 const DEFAULT_GLOBAL_SHORTCUTS: Record<string, string | null> = {
 	pushToTalk: `${CommandOrAlt}+Shift+D`,
 	toggleManualRecording: `${CommandOrControl}+Shift+;`,
-	startManualRecording: null,
-	stopManualRecording: null,
 	cancelManualRecording: `${CommandOrControl}+Shift+'`,
-	startVadRecording: null,
-	stopVadRecording: null,
 	toggleVadRecording: null,
 	openTransformationPicker: `${CommandOrControl}+Shift+X`,
 	runTransformationOnClipboard: `${CommandOrControl}+Shift+R`,
@@ -43,24 +35,16 @@ const DEFAULT_GLOBAL_SHORTCUTS: Record<string, string | null> = {
 
 type LocalShortcutKey =
 	| 'shortcut.toggleManualRecording'
-	| 'shortcut.startManualRecording'
-	| 'shortcut.stopManualRecording'
 	| 'shortcut.cancelManualRecording'
 	| 'shortcut.toggleVadRecording'
-	| 'shortcut.startVadRecording'
-	| 'shortcut.stopVadRecording'
 	| 'shortcut.pushToTalk'
 	| 'shortcut.openTransformationPicker'
 	| 'shortcut.runTransformationOnClipboard';
 
 type GlobalShortcutKey =
 	| 'shortcuts.global.toggleManualRecording'
-	| 'shortcuts.global.startManualRecording'
-	| 'shortcuts.global.stopManualRecording'
 	| 'shortcuts.global.cancelManualRecording'
 	| 'shortcuts.global.toggleVadRecording'
-	| 'shortcuts.global.startVadRecording'
-	| 'shortcuts.global.stopVadRecording'
 	| 'shortcuts.global.pushToTalk'
 	| 'shortcuts.global.openTransformationPicker'
 	| 'shortcuts.global.runTransformationOnClipboard';


### PR DESCRIPTION
Whispering had three small cleanup threads stranded after the Opus encoder work landed: shortcut commands that were never actually bound, a transcription temperature setting that was mostly a foot-gun, and cursor-output defaults whose asymmetry was intentional but undocumented. This PR finishes that cleanup as one narrow pass so the remaining recording and transcription settings describe the product surface we actually support.

The shortcut cleanup removes the split start/stop command IDs from the shortcut registry, workspace KV defaults, device config, migration mapping, and registration tables. The underlying start/stop operations stay because the UI buttons and push-to-talk flow still use them. What disappears is only the shortcut surface that shipped with null defaults while the toggle commands owned the real binding.

The temperature cleanup removes `transcription.temperature` from cloud and self-hosted transcription dispatch, provider option types, capabilities, migration mapping, settings UI, workspace KV, and active docs. For Whisper-style transcription, non-zero temperature is more likely to hallucinate than help. Omitting the field lets providers use their transcription defaults instead of asking users to tune a setting we do not want to recommend.

The cursor note documents the existing default asymmetry:

```txt
output.transcription.cursor   true
output.transformation.cursor  false
```

That default prevents a just-typed transcription from being typed a second time when a transformation also runs. Users can still flip the transformation cursor toggle on when they intentionally turn transcription cursor output off and want the transformed text to own the cursor output. This is related to #1204, but it does not close it because the settings UI still allows advanced combinations.

## Cleanup Shape

```txt
Before
  shortcut.toggleManualRecording     bound
  shortcut.startManualRecording      null
  shortcut.stopManualRecording       null
  shortcut.toggleVadRecording        bound or configurable
  shortcut.startVadRecording         null
  shortcut.stopVadRecording          null

After
  shortcut.toggleManualRecording     bound
  shortcut.cancelManualRecording     bound
  shortcut.toggleVadRecording        bound or configurable
  shortcut.pushToTalk                bound
```

## Verification

- `bun run typecheck` in `apps/whispering`: 0 errors, 11 existing Svelte warnings.
- Swept active Whispering source and docs for `transcription.temperature`, `supportsTemperature`, and removed start/stop shortcut KV keys.
- Remaining `temperature` hits are completion-service settings, not transcription settings.
- Historical timestamped specs still mention the old keys as past migration context; active source and current docs no longer do.
