### PR TITLE
refactor(whispering): clean-break recorder service boundary

### DIFF
--- a/apps/whispering/src/lib/operations/recording.ts
+++ b/apps/whispering/src/lib/operations/recording.ts
@@ -56,9 +56,7 @@ export async function startManualRecording() {
 		description: 'Setting up your recording environment...',
 	});
 
-	const { data: outcome, error } = await manualRecorder.startRecording({
-		sendStatus: loading.update,
-	});
+	const { data: outcome, error } = await manualRecorder.startRecording();
 
 	if (error) {
 		loading.reject({ cause: error });
@@ -87,9 +85,7 @@ export async function stopManualRecording() {
 		description: 'Finalizing your audio capture...',
 	});
 
-	const { data: source, error } = await manualRecorder.stopRecording({
-		sendStatus: loading.update,
-	});
+	const { data: source, error } = await manualRecorder.stopRecording();
 
 	if (error) {
 		loading.reject({ cause: error });
@@ -133,9 +129,7 @@ export async function cancelManualRecording() {
 		description: 'Cleaning up recording session...',
 	});
 
-	const { data, error } = await manualRecorder.cancelRecording({
-		sendStatus: loading.update,
-	});
+	const { data, error } = await manualRecorder.cancelRecording();
 
 	if (error) {
 		loading.reject({ cause: error });
@@ -172,7 +166,6 @@ export async function startVadRecording() {
 	});
 
 	const { data: outcome, error } = await vadRecorder.startActiveListening({
-		sendStatus: loading.update,
 		onSpeechStart: () => {
 			report.success({
 				title: '🎙️ Speech started',

--- a/apps/whispering/src/lib/report/index.ts
+++ b/apps/whispering/src/lib/report/index.ts
@@ -45,7 +45,6 @@ export const report = {
 		return {
 			resolve: (r) => emit('success', r, id),
 			reject: (r) => emit('error', r, id),
-			update: (r) => emit('loading', r, id),
 		};
 	},
 };

--- a/apps/whispering/src/lib/report/types.ts
+++ b/apps/whispering/src/lib/report/types.ts
@@ -17,7 +17,6 @@ export type Problem = Notice & { cause: AnyTaggedError };
 export type LoadingHandle = {
 	resolve: (r: Notice) => void;
 	reject: (r: Problem) => void;
-	update: (r: Notice) => void;
 };
 
 export type Level = 'error' | 'success' | 'info' | 'loading';

--- a/apps/whispering/src/lib/services/README.md
+++ b/apps/whispering/src/lib/services/README.md
@@ -250,14 +250,13 @@ export function createManualRecorderService() {
 	return {
 		startRecording: async (
 			recordingSettings,
-			{ sendStatus },
 		): Promise<Result<DeviceAcquisitionOutcome, RecorderError>> => {
 			if (activeRecording) {
 				return RecorderError.AlreadyRecording();
 			}
 
 			const { data: streamResult, error: acquireStreamError } =
-				await getRecordingStream(selectedDeviceId, sendStatus);
+				await getRecordingStream({ selectedDeviceId });
 
 			if (acquireStreamError) {
 				return RecorderError.StreamAcquisition({

--- a/apps/whispering/src/lib/services/device-stream.ts
+++ b/apps/whispering/src/lib/services/device-stream.ts
@@ -9,7 +9,6 @@ import type {
 	Device,
 	DeviceAcquisitionOutcome,
 	DeviceIdentifier,
-	UpdateStatusMessageFn,
 } from '$lib/services/recorder/types';
 import { asDeviceIdentifier } from '$lib/services/recorder/types';
 
@@ -131,31 +130,15 @@ async function getStreamForDeviceIdentifier(
 
 export async function getRecordingStream({
 	selectedDeviceId,
-	sendStatus,
 }: {
 	selectedDeviceId: DeviceIdentifier | null;
-	sendStatus: UpdateStatusMessageFn;
 }): Promise<
 	Result<
 		{ stream: MediaStream; deviceOutcome: DeviceAcquisitionOutcome },
 		DeviceStreamError
 	>
 > {
-	// Try preferred device first if specified
-	if (!selectedDeviceId) {
-		// No device selected
-		sendStatus({
-			title: '🔍 No Device Selected',
-			description:
-				"No worries! We'll find the best microphone for you automatically...",
-		});
-	} else {
-		sendStatus({
-			title: '🎯 Connecting Device',
-			description:
-				'Almost there! Just need your permission to use the microphone...',
-		});
-
+	if (selectedDeviceId) {
 		const { data: preferredStream, error: getPreferredStreamError } =
 			await getStreamForDeviceIdentifier(selectedDeviceId);
 
@@ -165,13 +148,6 @@ export async function getRecordingStream({
 				deviceOutcome: { outcome: 'success', deviceId: selectedDeviceId },
 			});
 		}
-
-		// We reach here if the preferred device failed, so we'll fall back to the first available device
-		sendStatus({
-			title: '⚠️ Finding a New Microphone',
-			description:
-				"That microphone isn't working. Let's try finding another one...",
-		});
 	}
 
 	// Try to get any available device as fallback

--- a/apps/whispering/src/lib/services/recorder/cpal.tauri.ts
+++ b/apps/whispering/src/lib/services/recorder/cpal.tauri.ts
@@ -5,11 +5,11 @@ import type { WhisperingRecordingState } from '$lib/constants/audio';
 import { categorizeRecorderError } from '$lib/services/recorder/categorize-error';
 import {
 	asDeviceIdentifier,
+	type CpalRecorderService,
 	type CpalRecordingParams,
 	type Device,
 	type DeviceAcquisitionOutcome,
 	RecorderError,
-	type RecorderService,
 	type RecordingSession,
 } from '$lib/services/recorder/types';
 import { commands } from '$lib/tauri/commands';
@@ -53,7 +53,7 @@ const enumerateDevices = async (): Promise<Result<Device[], RecorderError>> => {
  * to `<appDataDir>/recordings/{id}.wav` and the JS side refers to the
  * recording by id from then on. There is no raw PCM on the wire.
  */
-function createCpalRecorder(): RecorderService {
+function createCpalRecorder() {
 	let activeSession: RecordingSession | null = null;
 
 	function buildSession(recordingId: string): RecordingSession {
@@ -102,11 +102,7 @@ function createCpalRecorder(): RecorderService {
 			recordingId,
 			backend: 'cpal',
 
-			stop: async ({ sendStatus }) => {
-				sendStatus({
-					title: '⏸️ Saving recording',
-					description: 'Writing the WAV artifact to disk...',
-				});
+			stop: async () => {
 				const { data: artifact, error: stopRecordingError } =
 					await commands.stopRecording();
 				if (stopRecordingError !== null) {
@@ -118,10 +114,6 @@ function createCpalRecorder(): RecorderService {
 				// not close the worker; we still own the cpal stream and the
 				// worker thread. Send `close_recording_session` so Rust can
 				// join the worker and free the stream.
-				sendStatus({
-					title: '🔄 Closing Session',
-					description: 'Cleaning up recording resources...',
-				});
 				const { error: closeError } = await commands.closeRecordingSession();
 				if (closeError !== null)
 					log.error(RecorderError.StopFailed({ cause: closeError }));
@@ -130,24 +122,13 @@ function createCpalRecorder(): RecorderService {
 				return Ok({ kind: 'artifact', artifact });
 			},
 
-			cancel: async ({ sendStatus }) => {
-				sendStatus({
-					title: '🛑 Cancelling',
-					description:
-						'Safely stopping your recording and cleaning up resources...',
-				});
-
+			cancel: async () => {
 				// cancel_recording on the Rust side discards the in-flight
 				// samples and tears down the session worker. One round trip.
 				const { error: cancelError } = await commands.cancelRecording();
 				if (cancelError !== null) {
-					sendStatus({
-						title: '❌ Cancel Failed',
-						description:
-							'We hit a problem cancelling; continuing cleanup anyway...',
-					});
+					log.error(RecorderError.StopFailed({ cause: cancelError }));
 				}
-
 				teardown(session);
 				return Ok({ status: 'cancelled' });
 			},
@@ -189,10 +170,11 @@ function createCpalRecorder(): RecorderService {
 
 		enumerateDevices,
 
-		startRecording: async (
-			{ selectedDeviceId, recordingId, sampleRate }: CpalRecordingParams,
-			{ sendStatus },
-		) => {
+		startRecording: async ({
+			selectedDeviceId,
+			recordingId,
+			sampleRate,
+		}: CpalRecordingParams) => {
 			const { data: devices, error: enumerateError } = await enumerateDevices();
 			if (enumerateError !== null) return Err(enumerateError);
 
@@ -208,27 +190,15 @@ function createCpalRecorder(): RecorderService {
 
 			const deviceOutcome: DeviceAcquisitionOutcome = (() => {
 				if (!selectedDeviceId) {
-					sendStatus({
-						title: '🔍 No Device Selected',
-						description:
-							"No worries! We'll find the best microphone for you automatically...",
-					});
 					return {
 						outcome: 'fallback',
 						reason: 'no-device-selected',
 						deviceId: fallbackDeviceId,
 					};
 				}
-
 				if (deviceIds.includes(selectedDeviceId)) {
 					return { outcome: 'success', deviceId: selectedDeviceId };
 				}
-
-				sendStatus({
-					title: '⚠️ Finding a New Microphone',
-					description:
-						"That microphone isn't available. Let's try finding another one...",
-				});
 				return {
 					outcome: 'fallback',
 					reason: 'preferred-device-unavailable',
@@ -237,13 +207,6 @@ function createCpalRecorder(): RecorderService {
 			})();
 
 			const deviceIdentifier = deviceOutcome.deviceId;
-
-			sendStatus({
-				title: '🎤 Setting Up',
-				description:
-					'Initializing your recording session and checking microphone access...',
-			});
-
 			const sampleRateNum = sampleRate ? Number.parseInt(sampleRate, 10) : null;
 
 			const { error: initRecordingSessionError } =
@@ -260,11 +223,6 @@ function createCpalRecorder(): RecorderService {
 					})
 				);
 
-			sendStatus({
-				title: '🎙️ Starting Recording',
-				description:
-					'Recording session initialized, now starting to capture audio...',
-			});
 			const { error: startRecordingError } = await commands.startRecording();
 			if (startRecordingError !== null)
 				return (
@@ -279,4 +237,4 @@ function createCpalRecorder(): RecorderService {
 	};
 }
 
-export const CpalRecorderServiceLive: RecorderService = createCpalRecorder();
+export const CpalRecorderServiceLive: CpalRecorderService = createCpalRecorder();

--- a/apps/whispering/src/lib/services/recorder/cpal.tauri.ts
+++ b/apps/whispering/src/lib/services/recorder/cpal.tauri.ts
@@ -5,11 +5,12 @@ import type { WhisperingRecordingState } from '$lib/constants/audio';
 import { categorizeRecorderError } from '$lib/services/recorder/categorize-error';
 import {
 	asDeviceIdentifier,
-	type CpalRecorderService,
 	type CpalRecordingParams,
 	type Device,
 	type DeviceAcquisitionOutcome,
+	type ProbeActiveCpalRecording,
 	RecorderError,
+	type RecorderService,
 	type RecordingSession,
 } from '$lib/services/recorder/types';
 import { commands } from '$lib/tauri/commands';
@@ -37,23 +38,23 @@ const enumerateDevices = async (): Promise<Result<Device[], RecorderError>> => {
 };
 
 /**
- * CPAL recorder service that uses the Rust CPAL backend.
+ * CPAL recorder backend. Returns both the `RecorderService` implementation
+ * and a separate `probeActiveCpalRecording` function bound to the same
+ * `activeSession` slot.
  *
- * Constructed via a factory so the per-session lifecycle (stop/cancel/
- * subscribe) lives on the returned `RecordingSession`. The service itself
- * only holds a pointer to the active session for rehydration through
- * `getActiveRecording`; once stop/cancel runs, that pointer clears.
- *
- * Unlike navigator, a cpal session can outlive a JS reload because the
- * Rust process keeps the cpal stream alive. `getActiveRecording` consults
- * Rust via `get_current_recording_id` and reattaches a new
- * `RecordingSession` wrapper if Rust still has one going.
+ * Rehydration is intentionally not on the service interface: only cpal can
+ * rehydrate (the Rust process keeps the stream alive across JS reloads), so
+ * the probe is exposed as its own export rather than as a subtype of
+ * `RecorderService`. The manual recorder calls it once at module init.
  *
  * Stop returns a `RecordingArtifact` handle: Rust writes the durable WAV
  * to `<appDataDir>/recordings/{id}.wav` and the JS side refers to the
  * recording by id from then on. There is no raw PCM on the wire.
  */
-function createCpalRecorder() {
+function createCpalRecorder(): {
+	service: RecorderService;
+	probe: ProbeActiveCpalRecording;
+} {
 	let activeSession: RecordingSession | null = null;
 
 	function buildSession(recordingId: string): RecordingSession {
@@ -125,11 +126,14 @@ function createCpalRecorder() {
 			cancel: async () => {
 				// cancel_recording on the Rust side discards the in-flight
 				// samples and tears down the session worker. One round trip.
+				// Run teardown regardless so the UI reflects no-recording, but
+				// propagate the error so the user knows the cancel didn't
+				// fully complete (Rust state may be inconsistent).
 				const { error: cancelError } = await commands.cancelRecording();
-				if (cancelError !== null) {
-					log.error(RecorderError.StopFailed({ cause: cancelError }));
-				}
 				teardown(session);
+				if (cancelError !== null) {
+					return RecorderError.CancelFailed({ cause: cancelError });
+				}
 				return Ok({ status: 'cancelled' });
 			},
 
@@ -148,26 +152,7 @@ function createCpalRecorder() {
 		return session;
 	}
 
-	return {
-		getActiveRecording: async (): Promise<
-			Result<RecordingSession | null, RecorderError>
-		> => {
-			// If we still hold the in-memory pointer, prefer it; otherwise
-			// probe Rust in case a recording session outlived a JS reload.
-			if (activeSession) return Ok(activeSession);
-
-			const { data: liveRecordingId, error: getIdError } =
-				await commands.getCurrentRecordingId();
-			if (getIdError !== null) {
-				return RecorderError.GetStateFailed({ cause: getIdError });
-			}
-			if (!liveRecordingId) return Ok(null);
-
-			const rehydrated = buildSession(liveRecordingId);
-			activeSession = rehydrated;
-			return Ok(rehydrated);
-		},
-
+	const service: RecorderService = {
 		enumerateDevices,
 
 		startRecording: async ({
@@ -235,6 +220,26 @@ function createCpalRecorder() {
 			return Ok({ session, deviceAcquisition: deviceOutcome });
 		},
 	};
+
+	const probe: ProbeActiveCpalRecording = async () => {
+		// Probe Rust directly. The probe is called once at module init when
+		// `activeSession` is null by definition, so there is no in-memory
+		// shortcut to check.
+		const { data: liveRecordingId, error: getIdError } =
+			await commands.getCurrentRecordingId();
+		if (getIdError !== null) {
+			return RecorderError.GetStateFailed({ cause: getIdError });
+		}
+		if (!liveRecordingId) return Ok(null);
+
+		const rehydrated = buildSession(liveRecordingId);
+		activeSession = rehydrated;
+		return Ok(rehydrated);
+	};
+
+	return { service, probe };
 }
 
-export const CpalRecorderServiceLive: CpalRecorderService = createCpalRecorder();
+const cpal = createCpalRecorder();
+export const CpalRecorderServiceLive: RecorderService = cpal.service;
+export const probeActiveCpalRecording: ProbeActiveCpalRecording = cpal.probe;

--- a/apps/whispering/src/lib/services/recorder/index.browser.ts
+++ b/apps/whispering/src/lib/services/recorder/index.browser.ts
@@ -1,5 +1,5 @@
 import { NavigatorRecorderServiceLive } from './navigator';
-import type { RecorderService } from './types';
+import type { CpalRecorderService } from './types';
 
 export type { RecorderError, RecorderService, RecordingSession } from './types';
 
@@ -13,4 +13,4 @@ export { NavigatorRecorderServiceLive };
  * a Tauri bundle, where `index.tauri.ts` overrides this to the real
  * service).
  */
-export const CpalRecorderServiceLive: RecorderService | null = null;
+export const CpalRecorderServiceLive: CpalRecorderService | null = null;

--- a/apps/whispering/src/lib/services/recorder/index.browser.ts
+++ b/apps/whispering/src/lib/services/recorder/index.browser.ts
@@ -1,16 +1,17 @@
 import { NavigatorRecorderServiceLive } from './navigator';
-import type { CpalRecorderService } from './types';
+import type { ProbeActiveCpalRecording, RecorderService } from './types';
 
 export type { RecorderError, RecorderService, RecordingSession } from './types';
 
 export { NavigatorRecorderServiceLive };
 
 /**
- * CPAL is Tauri-only. On web the binding is `null`, so consumers can
- * still import it without a build-time conditional. Callers null-check
+ * CPAL is Tauri-only. On web both bindings are `null`, so consumers can
+ * still import them without a build-time conditional. Callers null-check
  * before use; this is the runtime-DI seam inside the build-time-DI
  * envelope (settings.recording.method = 'cpal' is only ever true inside
- * a Tauri bundle, where `index.tauri.ts` overrides this to the real
- * service).
+ * a Tauri bundle, where `index.tauri.ts` overrides these to the real
+ * implementations).
  */
-export const CpalRecorderServiceLive: CpalRecorderService | null = null;
+export const CpalRecorderServiceLive: RecorderService | null = null;
+export const probeActiveCpalRecording: ProbeActiveCpalRecording | null = null;

--- a/apps/whispering/src/lib/services/recorder/index.tauri.ts
+++ b/apps/whispering/src/lib/services/recorder/index.tauri.ts
@@ -1,6 +1,13 @@
-import { CpalRecorderServiceLive } from './cpal.tauri';
+import {
+	CpalRecorderServiceLive,
+	probeActiveCpalRecording,
+} from './cpal.tauri';
 import { NavigatorRecorderServiceLive } from './navigator';
 
 export type { RecorderError, RecorderService, RecordingSession } from './types';
 
-export { CpalRecorderServiceLive, NavigatorRecorderServiceLive };
+export {
+	CpalRecorderServiceLive,
+	NavigatorRecorderServiceLive,
+	probeActiveCpalRecording,
+};

--- a/apps/whispering/src/lib/services/recorder/navigator.ts
+++ b/apps/whispering/src/lib/services/recorder/navigator.ts
@@ -1,4 +1,4 @@
-import { Err, Ok, type Result, tryAsync, trySync } from 'wellcrafted/result';
+import { Err, Ok, tryAsync, trySync } from 'wellcrafted/result';
 import {
 	TIMESLICE_MS,
 	type WhisperingRecordingState,
@@ -69,12 +69,7 @@ function createNavigatorRecorder(): RecorderService {
 			recordingId,
 			backend: 'navigator',
 
-			stop: async ({ sendStatus }) => {
-				sendStatus({
-					title: '⏸️ Finishing Recording',
-					description: 'Saving your audio...',
-				});
-
+			stop: async () => {
 				const { data: blob, error: stopError } = await tryAsync({
 					try: () =>
 						new Promise<Blob>((resolve) => {
@@ -95,27 +90,12 @@ function createNavigatorRecorder(): RecorderService {
 
 				if (stopError) return Err(stopError);
 
-				sendStatus({
-					title: '✅ Recording Saved',
-					description: 'Your recording is ready for transcription!',
-				});
 				return Ok({ kind: 'blob', blob, recordingId, durationMs });
 			},
 
-			cancel: async ({ sendStatus }) => {
-				sendStatus({
-					title: '🛑 Cancelling',
-					description: 'Discarding your recording...',
-				});
-
+			cancel: async () => {
 				mediaRecorder.stop();
 				teardown();
-
-				sendStatus({
-					title: '✨ Cancelled',
-					description: 'Recording discarded successfully!',
-				});
-
 				return Ok({ status: 'cancelled' });
 			},
 
@@ -140,16 +120,6 @@ function createNavigatorRecorder(): RecorderService {
 	}
 
 	return {
-		getActiveRecording: async (): Promise<
-			Result<RecordingSession | null, RecorderError>
-		> => {
-			// Navigator state lives in this closure, so a JS reload zeroes it
-			// out; the MediaStream/MediaRecorder are also gone in that case.
-			// Always null after a reload; non-null only if startRecording fired
-			// within this module's lifetime and the session is still live.
-			return Ok(activeSession?.session ?? null);
-		},
-
 		enumerateDevices: async () => {
 			const { data: devices, error } = await enumerateDevices();
 			if (error) {
@@ -158,21 +128,17 @@ function createNavigatorRecorder(): RecorderService {
 			return Ok(devices);
 		},
 
-		startRecording: async (
-			{ selectedDeviceId, recordingId, bitrateKbps }: NavigatorRecordingParams,
-			{ sendStatus },
-		) => {
+		startRecording: async ({
+			selectedDeviceId,
+			recordingId,
+			bitrateKbps,
+		}: NavigatorRecordingParams) => {
 			if (activeSession) {
 				return RecorderError.AlreadyRecording();
 			}
 
-			sendStatus({
-				title: '🎙️ Starting Recording',
-				description: 'Setting up your microphone...',
-			});
-
 			const { data: streamResult, error: acquireStreamError } =
-				await getRecordingStream({ selectedDeviceId, sendStatus });
+				await getRecordingStream({ selectedDeviceId });
 			if (acquireStreamError) {
 				return (
 					categorizeRecorderError(acquireStreamError) ??

--- a/apps/whispering/src/lib/services/recorder/types.ts
+++ b/apps/whispering/src/lib/services/recorder/types.ts
@@ -255,9 +255,7 @@ export type RecorderService = {
 	 * with the device acquisition outcome. The caller holds the RecordingSession
 	 * and uses its `stop`/`cancel`/`subscribe` for the rest of the session.
 	 */
-	startRecording(
-		params: StartRecordingParams,
-	): Promise<
+	startRecording(params: StartRecordingParams): Promise<
 		Result<
 			{
 				session: RecordingSession;

--- a/apps/whispering/src/lib/services/recorder/types.ts
+++ b/apps/whispering/src/lib/services/recorder/types.ts
@@ -11,65 +11,10 @@ import type {
 } from '$lib/constants/audio';
 
 /**
- * Callback function for providing real-time status updates during multi-step recording operations.
- * These status messages become user-facing toast notifications that provide encouraging progress
- * feedback during recording workflows. The messages are displayed as loading toasts in the UI,
- * helping users understand what's happening during potentially long-running operations.
- *
- * @example
- * ```typescript
- * // Good: User-friendly with emoji and encouraging tone
- * sendStatus({
- *   title: '🎙️ Starting Recording',
- *   description: 'Setting up your microphone...'
- * });
- *
- * sendStatus({
- *   title: '✅ Recording Saved',
- *   description: 'Your recording is ready for transcription!'
- * });
- *
- * // Bad: Technical language, no emoji, not encouraging
- * sendStatus({
- *   title: 'Initializing MediaStream',
- *   description: 'getUserMedia() call in progress'
- * });
- * ```
- */
-export type UpdateStatusMessageFn = (args: {
-	title: string;
-	description: string;
-}) => void;
-
-/**
  * Device acquisition outcome after attempting to connect to a recording device.
  *
- * This type represents the result of device selection during recording startup.
- * All outcomes include the deviceId that was ultimately used for recording.
- * When the outcome is 'fallback', appropriate status messages are automatically
- * sent via UpdateStatusMessageFn to inform users about device switching.
- *
- * @example
- * ```typescript
- * // Success: User's preferred device worked
- * { outcome: 'success', deviceId: 'preferred-device-id' as DeviceIdentifier }
- *
- * // Fallback: No device selected, used default
- * // Status message: "🔍 No Device Selected" -> "Using your default microphone instead"
- * {
- *   outcome: 'fallback',
- *   reason: 'no-device-selected',
- *   deviceId: 'default' as DeviceIdentifier
- * }
- *
- * // Fallback: Preferred device unavailable, used alternative
- * // Status message: "⚠️ Finding a New Microphone" -> "Using MacBook Pro Microphone instead"
- * {
- *   outcome: 'fallback',
- *   reason: 'preferred-device-unavailable',
- *   deviceId: 'MacBook Pro Microphone' as DeviceIdentifier
- * }
- * ```
+ * Structured fact returned from `startRecording`. The operation layer maps it
+ * to user-facing toast copy; services never emit copy themselves.
  */
 export type DeviceAcquisitionOutcome =
 	| {
@@ -279,12 +224,8 @@ export type StartRecordingParams =
 export type RecordingSession = {
 	readonly recordingId: string;
 	readonly backend: 'navigator' | 'cpal';
-	stop(callbacks: {
-		sendStatus: UpdateStatusMessageFn;
-	}): Promise<Result<RecorderStopResult, RecorderError>>;
-	cancel(callbacks: {
-		sendStatus: UpdateStatusMessageFn;
-	}): Promise<Result<CancelRecordingResult, RecorderError>>;
+	stop(): Promise<Result<RecorderStopResult, RecorderError>>;
+	cancel(): Promise<Result<CancelRecordingResult, RecorderError>>;
 	subscribe(handler: (state: WhisperingRecordingState) => void): () => void;
 };
 
@@ -292,18 +233,14 @@ export type RecordingSession = {
  * Factory for recording sessions. Services no longer carry mutable
  * start/stop state directly; instead `startRecording` returns a RecordingSession
  * whose methods are bound to the backend that produced it.
+ *
+ * Rehydration after a JS reload is intentionally not part of this contract:
+ * only CPAL can survive a reload (the Rust process keeps the stream alive),
+ * so the rehydration probe lives on `CpalRecorderServiceLive` directly. The
+ * navigator backend cannot rehydrate, so pretending it could in this
+ * interface would be a lie. See `manual-recorder.svelte.ts` bootstrap.
  */
 export type RecorderService = {
-	/**
-	 * Probe for a RecordingSession that already exists at module-load time. CPAL
-	 * sessions can outlive a JS reload because the Rust process keeps the
-	 * stream; navigator sessions cannot survive a reload and will always
-	 * return null after one.
-	 *
-	 * Returns the live RecordingSession bound to this backend, or null if none.
-	 */
-	getActiveRecording(): Promise<Result<RecordingSession | null, RecorderError>>;
-
 	/**
 	 * Enumerate available recording devices with their labels and identifiers
 	 */
@@ -316,9 +253,6 @@ export type RecorderService = {
 	 */
 	startRecording(
 		params: StartRecordingParams,
-		callbacks: {
-			sendStatus: UpdateStatusMessageFn;
-		},
 	): Promise<
 		Result<
 			{
@@ -328,4 +262,15 @@ export type RecorderService = {
 			RecorderError
 		>
 	>;
+};
+
+/**
+ * CPAL-only extension of `RecorderService`. CPAL sessions can outlive a JS
+ * reload because the Rust process keeps the stream alive, so the CPAL
+ * service exposes a probe that the manual recorder calls during bootstrap
+ * to rehydrate. Navigator cannot rehydrate, so this method is not on the
+ * base interface.
+ */
+export type CpalRecorderService = RecorderService & {
+	getActiveRecording(): Promise<Result<RecordingSession | null, RecorderError>>;
 };

--- a/apps/whispering/src/lib/services/recorder/types.ts
+++ b/apps/whispering/src/lib/services/recorder/types.ts
@@ -126,6 +126,10 @@ export const RecorderError = defineErrors({
 		message: `Failed to stop recording: ${extractErrorMessage(cause)}`,
 		cause,
 	}),
+	CancelFailed: ({ cause }: { cause: unknown }) => ({
+		message: `Failed to cancel recording: ${extractErrorMessage(cause)}`,
+		cause,
+	}),
 	StreamAcquisition: ({ cause }: { cause: unknown }) => ({
 		message: `Failed to acquire recording stream: ${extractErrorMessage(cause)}`,
 		cause,
@@ -265,12 +269,17 @@ export type RecorderService = {
 };
 
 /**
- * CPAL-only extension of `RecorderService`. CPAL sessions can outlive a JS
- * reload because the Rust process keeps the stream alive, so the CPAL
- * service exposes a probe that the manual recorder calls during bootstrap
- * to rehydrate. Navigator cannot rehydrate, so this method is not on the
- * base interface.
+ * Probe Rust for a cpal recording that outlived the current JS process.
+ *
+ * Rehydration is not part of the recorder service contract; it's a bootstrap
+ * concern specific to CPAL because the Rust process keeps the cpal stream
+ * alive across JS reloads. Navigator state lives in the JS closure and
+ * cannot survive a reload, so there is no navigator equivalent.
+ *
+ * Build-time DI: the Tauri build exports the real probe; the web build
+ * exports `null`. The manual recorder null-checks the binding once at
+ * module init and only awaits the probe when it exists.
  */
-export type CpalRecorderService = RecorderService & {
-	getActiveRecording(): Promise<Result<RecordingSession | null, RecorderError>>;
-};
+export type ProbeActiveCpalRecording = () => Promise<
+	Result<RecordingSession | null, RecorderError>
+>;

--- a/apps/whispering/src/lib/state/manual-recorder.svelte.ts
+++ b/apps/whispering/src/lib/state/manual-recorder.svelte.ts
@@ -15,10 +15,8 @@ import {
 	type RecorderService,
 	type RecordingSession,
 	type StartRecordingParams,
-	type UpdateStatusMessageFn,
 } from '$lib/services/recorder/types';
 import { deviceConfig } from '$lib/state/device-config.svelte';
-import { tauri } from '$lib/tauri';
 
 const ManualRecorderError = defineErrors({
 	EnumerateDevicesFailed: ({ cause }: { cause: unknown }) => ({
@@ -46,7 +44,7 @@ export const manualRecorderKeys = defineKeys({
  * reactivity. Mirrors the shape of `vadRecorder` in `vad-recorder.svelte.ts`:
  *
  * - Reactive access: `manualRecorder.state` (triggers effects on change)
- * - Operations: `manualRecorder.startRecording({ sendStatus })` etc.
+ * - Operations: `manualRecorder.startRecording()` etc.
  * - Device enumeration as a TanStack Query for loading states in selectors
  *
  * Each recording is a `RecordingSession` object returned by the backend that
@@ -60,43 +58,45 @@ export const manualRecorderKeys = defineKeys({
  * only one would ever fire; now `attach()` subscribes to the live
  * RecordingSession and `detach()` cleans up on stop/cancel.
  *
- * On Tauri, state is bootstrapped from each backend's `getActiveRecording`
- * at module init (a Rust CPAL session can outlive a JS reload).
+ * On Tauri, state is bootstrapped from `CpalRecorderServiceLive.getActiveRecording`
+ * at module init (a Rust CPAL session can outlive a JS reload). The navigator
+ * backend cannot rehydrate, so there is no navigator probe.
  */
 
-function resolveServiceForStart(): RecorderService {
-	// CpalRecorderServiceLive is null on web (build-time fact); even when
-	// non-null, the runtime setting decides whether to use it.
+/**
+ * Resolve the backend + start parameters from current settings in a single
+ * decision. CpalRecorderServiceLive is null on web (build-time fact); even
+ * when non-null, the runtime setting decides whether to use it.
+ */
+function resolveStartDecision(recordingId: string): {
+	service: RecorderService;
+	params: StartRecordingParams;
+} {
 	if (
 		CpalRecorderServiceLive &&
 		deviceConfig.get('recording.method') === 'cpal'
 	) {
-		return CpalRecorderServiceLive;
-	}
-	return services.navigatorRecorder;
-}
-
-async function buildStartParams(
-	recordingId: string,
-): Promise<StartRecordingParams> {
-	const useCpal = !!tauri && deviceConfig.get('recording.method') === 'cpal';
-
-	if (useCpal) {
 		const deviceId = deviceConfig.get('recording.cpal.deviceId');
 		return {
-			method: 'cpal',
-			recordingId,
-			selectedDeviceId: deviceId ? asDeviceIdentifier(deviceId) : null,
-			sampleRate: deviceConfig.get('recording.cpal.sampleRate'),
+			service: CpalRecorderServiceLive,
+			params: {
+				method: 'cpal',
+				recordingId,
+				selectedDeviceId: deviceId ? asDeviceIdentifier(deviceId) : null,
+				sampleRate: deviceConfig.get('recording.cpal.sampleRate'),
+			},
 		};
 	}
 
 	const deviceId = deviceConfig.get('recording.navigator.deviceId');
 	return {
-		method: 'navigator',
-		recordingId,
-		selectedDeviceId: deviceId ? asDeviceIdentifier(deviceId) : null,
-		bitrateKbps: deviceConfig.get('recording.navigator.bitrateKbps'),
+		service: services.navigatorRecorder,
+		params: {
+			method: 'navigator',
+			recordingId,
+			selectedDeviceId: deviceId ? asDeviceIdentifier(deviceId) : null,
+			bitrateKbps: deviceConfig.get('recording.navigator.bitrateKbps'),
+		},
 	};
 }
 
@@ -121,23 +121,19 @@ function createManualRecorder() {
 		_state = 'IDLE';
 	}
 
-	// Bootstrap: ask each backend whether it owns a live session. Navigator
-	// always returns null after a JS reload (its state lives in the closure);
-	// cpal can return non-null because the Rust process keeps the stream alive.
+	// Bootstrap: only CPAL can outlive a JS reload (the Rust process keeps the
+	// cpal stream alive across page reloads). Navigator state lives in this JS
+	// process, so a reload zeroes it out by definition; no probe needed.
 	//
-	// The promise is awaited before any stop/cancel/start runs. Without
-	// that gate, a user action that fires before bootstrap resolves sees a
-	// stale `_current === null` and either no-ops the cancel (leaking the
-	// Rust session) or double-starts on top of a rehydrated one.
-	const bootstrapped = Promise.all([
-		services.navigatorRecorder.getActiveRecording(),
-		CpalRecorderServiceLive
-			? CpalRecorderServiceLive.getActiveRecording()
-			: Promise.resolve({ data: null, error: null } as const),
-	]).then(([nav, cpal]) => {
-		const found = nav.data ?? cpal.data ?? null;
-		if (found) attach(found);
-	});
+	// The promise is awaited before any stop/cancel/start runs. Without that
+	// gate, a user action firing before the rehydration probe resolves would
+	// see a stale `_current === null` and either no-op the cancel (leaking
+	// the Rust session) or double-start on top of a rehydrated one.
+	const bootstrapped = CpalRecorderServiceLive
+		? CpalRecorderServiceLive.getActiveRecording().then(({ data }) => {
+				if (data) attach(data);
+			})
+		: Promise.resolve();
 
 	return {
 		get state(): WhisperingRecordingState {
@@ -147,27 +143,20 @@ function createManualRecorder() {
 		enumerateDevices: defineQuery({
 			queryKey: manualRecorderKeys.devices,
 			queryFn: async () => {
-				const { data, error } =
-					await resolveServiceForStart().enumerateDevices();
+				const { service } = resolveStartDecision(nanoid());
+				const { data, error } = await service.enumerateDevices();
 				if (error)
 					return ManualRecorderError.EnumerateDevicesFailed({ cause: error });
 				return Ok(data);
 			},
 		}),
 
-		async startRecording({
-			sendStatus,
-		}: {
-			sendStatus: UpdateStatusMessageFn;
-		}) {
+		async startRecording() {
 			await bootstrapped;
 			if (_current) return ManualRecorderError.AlreadyRecording();
-			const service = resolveServiceForStart();
-			const params = await buildStartParams(nanoid());
-			const { data, error: startRecordingError } = await service.startRecording(
-				params,
-				{ sendStatus },
-			);
+			const { service, params } = resolveStartDecision(nanoid());
+			const { data, error: startRecordingError } =
+				await service.startRecording(params);
 
 			if (startRecordingError) return Err(startRecordingError);
 
@@ -175,30 +164,20 @@ function createManualRecorder() {
 			return Ok(data.deviceAcquisition);
 		},
 
-		async stopRecording({ sendStatus }: { sendStatus: UpdateStatusMessageFn }) {
+		async stopRecording() {
 			await bootstrapped;
 			if (!_current) return ManualRecorderError.NoActiveRecording();
-			const { data, error: stopRecordingError } = await _current.stop({
-				sendStatus,
-			});
-
+			const { data, error: stopRecordingError } = await _current.stop();
 			if (stopRecordingError) return Err(stopRecordingError);
-
 			return Ok(data);
 		},
 
-		async cancelRecording({
-			sendStatus,
-		}: {
-			sendStatus: UpdateStatusMessageFn;
-		}) {
+		async cancelRecording() {
 			await bootstrapped;
 			if (!_current) return Ok({ status: 'no-recording' as const });
 			const { data: cancelResult, error: cancelRecordingError } =
-				await _current.cancel({ sendStatus });
-
+				await _current.cancel();
 			if (cancelRecordingError) return Err(cancelRecordingError);
-
 			return Ok(cancelResult);
 		},
 	};

--- a/apps/whispering/src/lib/state/manual-recorder.svelte.ts
+++ b/apps/whispering/src/lib/state/manual-recorder.svelte.ts
@@ -9,7 +9,10 @@ import { Err, Ok } from 'wellcrafted/result';
 import type { WhisperingRecordingState } from '$lib/constants/audio';
 import { defineQuery } from '$lib/rpc/client';
 import { services } from '$lib/services';
-import { CpalRecorderServiceLive } from '$lib/services/recorder';
+import {
+	CpalRecorderServiceLive,
+	probeActiveCpalRecording,
+} from '$lib/services/recorder';
 import {
 	asDeviceIdentifier,
 	type RecorderService,
@@ -58,9 +61,9 @@ export const manualRecorderKeys = defineKeys({
  * only one would ever fire; now `attach()` subscribes to the live
  * RecordingSession and `detach()` cleans up on stop/cancel.
  *
- * On Tauri, state is bootstrapped from `CpalRecorderServiceLive.getActiveRecording`
- * at module init (a Rust CPAL session can outlive a JS reload). The navigator
- * backend cannot rehydrate, so there is no navigator probe.
+ * On Tauri, state is bootstrapped from `probeActiveCpalRecording()` at module
+ * init (a Rust CPAL session can outlive a JS reload). The navigator backend
+ * cannot rehydrate, so there is no navigator probe.
  */
 
 /**
@@ -129,8 +132,8 @@ function createManualRecorder() {
 	// gate, a user action firing before the rehydration probe resolves would
 	// see a stale `_current === null` and either no-op the cancel (leaking
 	// the Rust session) or double-start on top of a rehydrated one.
-	const bootstrapped = CpalRecorderServiceLive
-		? CpalRecorderServiceLive.getActiveRecording().then(({ data }) => {
+	const bootstrapped = probeActiveCpalRecording
+		? probeActiveCpalRecording().then(({ data }) => {
 				if (data) attach(data);
 			})
 		: Promise.resolve();

--- a/apps/whispering/src/lib/state/vad-recorder.svelte.ts
+++ b/apps/whispering/src/lib/state/vad-recorder.svelte.ts
@@ -105,12 +105,10 @@ function createVadRecorder() {
 			onSpeechStart,
 			onSpeechEnd,
 			onVADMisfire,
-			onSpeechRealStart,
 		}: {
 			onSpeechStart: () => void;
 			onSpeechEnd: (blob: Blob) => void;
 			onVADMisfire?: () => void;
-			onSpeechRealStart?: () => void;
 		}) {
 			// Prevent starting if already active
 			if (_session) return VadRecorderError.AlreadyActive();
@@ -152,9 +150,6 @@ function createVadRecorder() {
 						onVADMisfire: () => {
 							if (_session) _session.state = 'LISTENING';
 							onVADMisfire?.();
-						},
-						onSpeechRealStart: () => {
-							onSpeechRealStart?.();
 						},
 						model: 'v5',
 					}),

--- a/apps/whispering/src/lib/state/vad-recorder.svelte.ts
+++ b/apps/whispering/src/lib/state/vad-recorder.svelte.ts
@@ -13,10 +13,7 @@ import {
 	enumerateDevices,
 	getRecordingStream,
 } from '$lib/services/device-stream';
-import {
-	asDeviceIdentifier,
-	type UpdateStatusMessageFn,
-} from '$lib/services/recorder/types';
+import { asDeviceIdentifier } from '$lib/services/recorder/types';
 import { deviceConfig } from '$lib/state/device-config.svelte';
 
 const VadRecorderError = defineErrors({
@@ -109,13 +106,11 @@ function createVadRecorder() {
 			onSpeechEnd,
 			onVADMisfire,
 			onSpeechRealStart,
-			sendStatus,
 		}: {
 			onSpeechStart: () => void;
 			onSpeechEnd: (blob: Blob) => void;
 			onVADMisfire?: () => void;
 			onSpeechRealStart?: () => void;
-			sendStatus: UpdateStatusMessageFn;
 		}) {
 			// Prevent starting if already active
 			if (_session) return VadRecorderError.AlreadyActive();
@@ -132,7 +127,6 @@ function createVadRecorder() {
 			const { data: streamResult, error: streamError } =
 				await getRecordingStream({
 					selectedDeviceId: deviceId,
-					sendStatus,
 				});
 
 			if (streamError) return Err(streamError);


### PR DESCRIPTION
The recorder service threaded a `sendStatus` callback through seven function signatures, documented an "emoji and encouraging tone" contract on its type, and let four files emit their own intermediate progress toasts. All of that complexity existed to flash rapid-fire chatter the user couldn't read. Starting a recording used to fire five toasts in under 200ms; cancel fired three, including a "❌ Cancel Failed" that appeared *while* the cleanup continued and was replaced a moment later by "✅ All Done!".

The seam was load-bearing only for the people writing it. From the user's chair, every action already shows a loading toast: the intermediate stages added noise, not signal. From a maintenance chair, every backend re-implemented its own "no device selected" string in its own emoji.

This PR refuses the mid-operation status channel entirely. The service boundary now emits structured facts and nothing else. `operations/recording.ts` is the single owner of every user-facing string in the recording flow.

```
BEFORE                                          AFTER
══════                                          ═════

operations/recording.ts                         operations/recording.ts
   │  loading.update ←──┐                          │  (sole owner of toast copy)
   ▼                    │                          ▼
manualRecorder          │                       manualRecorder
   │  sendStatus ───────┤                          ▼
   ▼                    │                       service.startRecording(params)
RecorderService         │                       session.stop() / .cancel()
   │  sendStatus ───────┤                          │
   ├── navigator        │                          ▼
   │      │  sendStatus ┤                       structured returns:
   │      ▼             │                          { deviceAcquisition }
   │   device-stream    │                          { kind:'artifact'|'blob' }
   │      sendStatus  ──┘                          { status:'cancelled' }
   └── cpal                                        + session.subscribe(state)
          sendStatus
                                                operations/recording.ts maps
9 toast strings across 4 files,                 facts → copy in ONE place
+ a documented "emoji + encouraging
tone" contract in the service type
```

What dies, named explicitly: `UpdateStatusMessageFn` (the callback type plus a docblock prescribing tone), the `sendStatus` parameter on `RecorderService.startRecording` / `RecordingSession.stop` / `RecordingSession.cancel` / `getRecordingStream` / `manualRecorder.startRecording` / `manualRecorder.stopRecording` / `manualRecorder.cancelRecording` / `vadRecorder.startActiveListening`, every `sendStatus({title, description})` call inside the recorder services and `device-stream.ts`, `LoadingHandle.update` (its only consumer was `sendStatus`), and the duplicate fallback-toast authoring that lived in both `cpal.tauri.ts` and `device-stream.ts`. The `buildStartParams` + `resolveServiceForStart` pair in the manual recorder collapses into one `resolveStartDecision(recordingId)` that reads `recording.method` exactly once per start.

Concretely, here is the new shape of a start:

```typescript
// operations/recording.ts
const loading = report.loading({
  title: '🎙️ Preparing to record...',
  description: 'Setting up your recording environment...',
});

const { data: outcome, error } = await manualRecorder.startRecording();
if (error) return loading.reject({ cause: error });

loading.resolve(handleDeviceAcquisitionOutcome(outcome, /* ... */));
```

One loading toast in. One resolution toast out, derived from the structured `DeviceAcquisitionOutcome` the service returned. No callback channel, no copy strings inside the service.

---

**The post-implementation review caught a subtype dance pretending to be symmetry.**

After the sendStatus removal, the `RecorderService` interface still carried a `getActiveRecording()` method that probed Rust for a recording session that outlived a JS reload. The navigator backend implemented it as `Ok(activeSession?.session ?? null)`, where `activeSession` was a closure variable that was always `null` at module init by definition. The navigator probe was dead code wearing the costume of polymorphism.

The first pass at fixing this introduced `CpalRecorderService = RecorderService & { getActiveRecording }` and typed the cpal binding accordingly. That worked, but the `&` was the tell: rehydration isn't "extra recorder service capability." It's a bootstrap concern that exists only because the Rust process keeps the cpal stream alive across JS reloads. Pretending it belongs on the recorder contract makes both shapes harder to reason about.

The greenfield fix is to hoist the probe out of the service entirely and ship it as a free function with the same build-time DI pattern we already use for the service:

```typescript
// types.ts — symmetric again
export type RecorderService = {
  enumerateDevices(): Promise<...>;
  startRecording(params): Promise<...>;
};

export type ProbeActiveCpalRecording = () =>
  Promise<Result<RecordingSession | null, RecorderError>>;

// cpal.tauri.ts — both bound to the same `activeSession` slot
export const CpalRecorderServiceLive: RecorderService = cpal.service;
export const probeActiveCpalRecording: ProbeActiveCpalRecording = cpal.probe;

// index.browser.ts — same null-on-web convention
export const CpalRecorderServiceLive: RecorderService | null = null;
export const probeActiveCpalRecording: ProbeActiveCpalRecording | null = null;
```

The manual-recorder bootstrap reads as one ternary instead of a `Promise.all` that always discarded one half:

```typescript
const bootstrapped = probeActiveCpalRecording
  ? probeActiveCpalRecording().then(({ data }) => { if (data) attach(data); })
  : Promise.resolve();
```

And the dead `if (activeSession) return Ok(activeSession)` shortcut inside the probe is gone too. The probe is only ever called once at module init, when `activeSession` is null by definition; the branch could only have fired if someone called the probe twice, and today nobody does.

---

**While here, two flags from the original review got promoted from "deferred" to "in scope."**

The cpal cancel path used to swallow `commands.cancelRecording()` errors. It would log via `wellcrafted/logger` and return `Ok({ status: 'cancelled' })`, so the user saw "✅ All Done!" even if the Rust side had failed to tear down. That was a behavior parity with the pre-clean-break shape, but it lied to the user. Now the session propagates `Err(RecorderError.CancelFailed)` so `operations/recording.ts` can reject the loading toast and the user actually knows. Teardown still runs unconditionally first so the JS-side state can never wedge in `RECORDING`.

The VAD recorder used to accept an unused `onSpeechRealStart` callback that no external consumer ever passed; the MicVAD event was being forwarded to nothing. Removed.

---

**On the bootstrap pattern itself, since it deserves a moment.**

The race the `bootstrapped` promise guards is real: at module init we kick off an async probe of Rust state, and a user action can fire before that probe resolves. Without the gate, a `cancelRecording()` racing the probe would see a stale `_current === null`, no-op the cancel, and leak the Rust session. The fix is to have every operation `await bootstrapped` before doing anything.

This isn't strange, just necessary — there's no synchronous way to ask Rust about its current state, so we either gate on the probe or pay the latency on every action. Gating once is the right trade.

---

**What we lost, honestly.**

The intermediate "Setting Up your microphone…", "Connecting Device…", "Finding a New Microphone…", "Closing Session…" toasts are gone. They flashed for tens of milliseconds and the user never read them. The browser still shows its own permission prompt UI when the page asks for the microphone, so the "🎯 Almost there!" toast was redundant with the OS-level chrome. The "❌ Cancel Failed" intermediate that flickered between "Cancelling" and "All Done!" was actively misleading — it's gone in the new shape, and a real cancel failure now surfaces as a proper error toast with a humanized title.

Each user action now shows exactly two toasts: a loading state going in, a resolution coming out. Errors still flow through the typed `RecorderError` variants and `loading.reject({ cause })`. The flicker chatter is gone; the actual signal is louder.

If we ever genuinely need mid-flight status back, the right replacement isn't another copy channel — it's a typed phase callback like `onPhase: (phase: 'acquiring-stream' | 'initializing-codec' | 'ready') => void`. Phases, not strings. Keeps copy out of services. We don't need it now.