### PR TITLE
feat(whispering): ambient transcription config + lifecycle events

### DIFF
--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ use recorder::recorder::Recorder;
 pub mod transcription;
 use transcription::{
     get_transcription_state, set_transcription_config, transcribe_recording, ModelManager,
+    ModelStateEvent,
 };
 
 pub mod windows_path;
@@ -52,6 +53,11 @@ fn make_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             delete_files_in_directory,
             write_markdown_files,
         ])
+        // Register every event type the FE listens to. Without this, specta
+        // drops the event payload from `bindings.gen.ts` because no command
+        // references it. The `event(name = "...")` attribute on each event
+        // keeps the channel name stable across the rename.
+        .events(tauri_specta::collect_events![ModelStateEvent])
         .error_handling(tauri_specta::ErrorHandlingMode::Result)
 }
 

--- a/apps/whispering/src-tauri/src/lib.rs
+++ b/apps/whispering/src-tauri/src/lib.rs
@@ -15,7 +15,9 @@ use recorder::commands::{
 use recorder::recorder::Recorder;
 
 pub mod transcription;
-use transcription::{set_unload_policy, transcribe_recording, ModelManager};
+use transcription::{
+    get_transcription_state, set_transcription_config, transcribe_recording, ModelManager,
+};
 
 pub mod windows_path;
 use windows_path::fix_windows_path;
@@ -44,7 +46,8 @@ fn make_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             cancel_recording,
             delete_recording,
             transcribe_recording,
-            set_unload_policy,
+            set_transcription_config,
+            get_transcription_state,
             execute_command,
             delete_files_in_directory,
             write_markdown_files,
@@ -182,13 +185,15 @@ pub async fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_opener::init())
         .manage(Mutex::new(Recorder::new()))
-        .manage(ModelManager::new())
         .setup(|app| {
-            // Start the model idle watcher. It runs on the Tauri async
-            // runtime, sleeps between checks, and drops the resident
-            // model when the configured idle timeout elapses.
-            let manager = app.state::<ModelManager>().inner().clone();
+            // ModelManager owns an `AppHandle` for emitting lifecycle events
+            // on the `transcription://model-state` channel, so it cannot be
+            // constructed at builder-time (no app handle exists yet). Move
+            // construction into setup; everything that needs it reads via
+            // `app.state::<ModelManager>()`.
+            let manager = ModelManager::new(app.handle().clone());
             manager.start_idle_watcher();
+            app.manage(manager);
             Ok(())
         });
 

--- a/apps/whispering/src-tauri/src/transcription/config.rs
+++ b/apps/whispering/src-tauri/src/transcription/config.rs
@@ -1,0 +1,64 @@
+use serde::{Deserialize, Serialize};
+
+/// Ambient configuration the frontend pushes once per change. The Rust side
+/// reads this on every `transcribe_recording` call instead of receiving
+/// a per-call payload. Drift in `(engine, model_path)` triggers a preload;
+/// drift in other fields takes effect on the next transcription with no
+/// reload.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct TranscriptionConfig {
+    pub engine: Engine,
+    pub model_path: String,
+    #[serde(default)]
+    pub language: Option<String>,
+    #[serde(default)]
+    pub initial_prompt: Option<String>,
+    pub unload_policy: UnloadPolicy,
+}
+
+/// Local transcription engine. Wire tags match the frontend
+/// `transcription.service` enum (`whispercpp` / `parakeet` / `moonshine`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, specta::Type)]
+#[serde(rename_all = "lowercase")]
+pub enum Engine {
+    #[serde(rename = "whispercpp")]
+    Whispercpp,
+    Parakeet,
+    Moonshine,
+}
+
+/// How long after the last transcription the resident model should be
+/// dropped. Mirrors the frontend `transcription.localModelUnloadPolicy`
+/// device setting; serde tags below match its wire format exactly so the
+/// FE value pushes straight through.
+///
+/// `Immediately` is enforced synchronously at the end of each transcription;
+/// timed variants are enforced by the background idle watcher.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, specta::Type)]
+#[serde(rename_all = "snake_case")]
+pub enum UnloadPolicy {
+    Never,
+    Immediately,
+    #[serde(rename = "after_5_minutes")]
+    AfterFiveMinutes,
+    #[serde(rename = "after_30_minutes")]
+    AfterThirtyMinutes,
+}
+
+impl UnloadPolicy {
+    pub const DEFAULT: Self = Self::AfterFiveMinutes;
+}
+
+/// True when the new config asks for a different resident model than the old
+/// one. Identity is `(engine, model_path)` only: language/prompt/policy
+/// changes never trigger a reload because they take effect on next inference.
+pub fn should_preload(
+    old: Option<&TranscriptionConfig>,
+    new: &TranscriptionConfig,
+) -> bool {
+    match old {
+        None => true,
+        Some(prev) => prev.engine != new.engine || prev.model_path != new.model_path,
+    }
+}

--- a/apps/whispering/src-tauri/src/transcription/error.rs
+++ b/apps/whispering/src-tauri/src/transcription/error.rs
@@ -15,4 +15,15 @@ pub enum TranscriptionError {
 
     #[error("Transcription error: {message}")]
     TranscriptionError { message: String },
+
+    /// `transcribe_recording` was called before `set_transcription_config`
+    /// pushed an ambient config. The FE should disable the transcribe button
+    /// until `localModel.state.engine !== null` to avoid this.
+    #[error("No transcription config: {message}")]
+    NoConfig { message: String },
+
+    /// The ambient config holds a value that cannot be dispatched (e.g. a
+    /// Moonshine model path that does not match `moonshine-{variant}-{lang}`).
+    #[error("Transcription config error: {message}")]
+    ConfigError { message: String },
 }

--- a/apps/whispering/src-tauri/src/transcription/events.rs
+++ b/apps/whispering/src-tauri/src/transcription/events.rs
@@ -1,0 +1,87 @@
+use super::config::Engine;
+use serde::Serialize;
+
+/// Channel name for every model lifecycle event. A single channel keeps the
+/// FE listener trivial: one `listen<ModelStateEvent>(EVENT_CHANNEL, ...)`
+/// covers loading, completion, failure, unload, and selection change.
+pub const EVENT_CHANNEL: &str = "transcription://model-state";
+
+/// Snapshot of everything observable about the resident model. Every event
+/// carries a full snapshot rather than a delta because `AppHandle::emit`
+/// does not replay to future windows: a window opened mid-load reads the
+/// current snapshot via `get_transcription_state` and then catches up via
+/// the next event.
+#[derive(Debug, Clone, Serialize, specta::Type, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalModelState {
+    pub engine: Option<Engine>,
+    pub model_path: Option<String>,
+    pub status: ModelStatus,
+}
+
+/// Lifecycle state of the resident model. Owned by an `Arc<RwLock<...>>`
+/// inside `ModelManager` so `snapshot()` can read it without touching the
+/// cache mutex (which is held across long-running inference).
+#[derive(Debug, Clone, Serialize, specta::Type, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ModelStatus {
+    /// No model resident and none loading. Initial state, and reached after
+    /// `Unloaded`.
+    Idle,
+    /// `with_engine` is currently inside the `load(&model_path)` call.
+    Loading,
+    /// A model is resident and not currently in use.
+    Ready,
+    /// `with_engine` is currently inside the user closure (transcribe call).
+    /// The cache lock is held; `snapshot()` reports this without contending.
+    Inferring,
+    /// The last attempt to load or transcribe failed. The cache is empty.
+    Error { message: String },
+}
+
+/// Reason the resident model was dropped. Folded into a single event variant
+/// (`ModelStateEvent::Unloaded`) rather than fanned out into per-reason
+/// variants so the FE has one branch to handle.
+#[derive(Debug, Clone, Serialize, specta::Type)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum UnloadReason {
+    /// Synchronous eviction after a transcription completed under the
+    /// `Immediately` unload policy.
+    Immediate,
+    /// Background idle watcher dropped the model after the configured timeout
+    /// elapsed without activity.
+    Idle {
+        #[specta(type = u32)]
+        idle_secs: u64,
+    },
+    /// User selected a different model in settings; the old one was dropped
+    /// before the new one preloads.
+    ConfigChanged,
+}
+
+/// Single event type for everything observable about the model lifecycle.
+/// `tag = "kind"` matches `ModelStatus` and `UnloadReason` so the FE pattern
+/// is uniform: `switch (event.kind)`.
+#[derive(Debug, Clone, Serialize, specta::Type)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ModelStateEvent {
+    LoadingStarted {
+        state: LocalModelState,
+    },
+    LoadingCompleted {
+        state: LocalModelState,
+        #[specta(type = u32)]
+        elapsed_ms: u64,
+    },
+    LoadingFailed {
+        state: LocalModelState,
+        error: String,
+    },
+    Unloaded {
+        state: LocalModelState,
+        reason: UnloadReason,
+    },
+    SelectionChanged {
+        state: LocalModelState,
+    },
+}

--- a/apps/whispering/src-tauri/src/transcription/events.rs
+++ b/apps/whispering/src-tauri/src/transcription/events.rs
@@ -1,9 +1,11 @@
 use super::config::Engine;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use tauri_specta::Event;
 
-/// Channel name for every model lifecycle event. A single channel keeps the
-/// FE listener trivial: one `listen<ModelStateEvent>(EVENT_CHANNEL, ...)`
-/// covers loading, completion, failure, unload, and selection change.
+/// Channel name for every model lifecycle event. The same constant is bound
+/// to the `tauri_specta::event(name = "...")` attribute on `ModelStateEvent`
+/// below so the Rust emitter, the specta-emitted TS binding, and the FE
+/// `listen<ModelStateEvent>(...)` call all key off one symbol.
 pub const EVENT_CHANNEL: &str = "transcription://model-state";
 
 /// Snapshot of everything observable about the resident model. Every event
@@ -11,7 +13,7 @@ pub const EVENT_CHANNEL: &str = "transcription://model-state";
 /// does not replay to future windows: a window opened mid-load reads the
 /// current snapshot via `get_transcription_state` and then catches up via
 /// the next event.
-#[derive(Debug, Clone, Serialize, specta::Type, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct LocalModelState {
     pub engine: Option<Engine>,
@@ -22,7 +24,7 @@ pub struct LocalModelState {
 /// Lifecycle state of the resident model. Owned by an `Arc<RwLock<...>>`
 /// inside `ModelManager` so `snapshot()` can read it without touching the
 /// cache mutex (which is held across long-running inference).
-#[derive(Debug, Clone, Serialize, specta::Type, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ModelStatus {
     /// No model resident and none loading. Initial state, and reached after
@@ -42,7 +44,7 @@ pub enum ModelStatus {
 /// Reason the resident model was dropped. Folded into a single event variant
 /// (`ModelStateEvent::Unloaded`) rather than fanned out into per-reason
 /// variants so the FE has one branch to handle.
-#[derive(Debug, Clone, Serialize, specta::Type)]
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum UnloadReason {
     /// Synchronous eviction after a transcription completed under the
@@ -62,7 +64,14 @@ pub enum UnloadReason {
 /// Single event type for everything observable about the model lifecycle.
 /// `tag = "kind"` matches `ModelStatus` and `UnloadReason` so the FE pattern
 /// is uniform: `switch (event.kind)`.
-#[derive(Debug, Clone, Serialize, specta::Type)]
+///
+/// `tauri_specta::Event` + `event(name = "...")` keys the TS export at the
+/// custom channel name. Without the explicit name, the derive kebab-cases
+/// the type ident (`model-state-event`) which would break the existing FE
+/// listener. `collect_events![ModelStateEvent]` in `lib.rs` registers the
+/// type so the regen surface picks it up.
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type, Event)]
+#[tauri_specta::event(name = "transcription://model-state")]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ModelStateEvent {
     LoadingStarted {

--- a/apps/whispering/src-tauri/src/transcription/mod.rs
+++ b/apps/whispering/src-tauri/src/transcription/mod.rs
@@ -1,113 +1,66 @@
+mod config;
 mod error;
+mod events;
 mod model_manager;
 
 use crate::recorder::read_artifact_samples;
+pub use config::TranscriptionConfig;
 pub use error::TranscriptionError;
-use log::{debug, info, warn};
+pub use events::LocalModelState;
 pub use model_manager::ModelManager;
-use model_manager::UnloadPolicy;
-use serde::Deserialize;
-use std::path::PathBuf;
 use tauri::{AppHandle, State};
-use transcribe_rs::onnx::moonshine::MoonshineVariant;
-use transcribe_rs::onnx::parakeet::{ParakeetParams, TimestampGranularity};
-use transcribe_rs::whisper_cpp::WhisperInferenceParams;
-use transcribe_rs::{SpeechModel, TranscribeOptions};
 
-/// Engine-tagged request body. JS serializes one of these as the `config`
-/// JSON argument on the `transcribe_recording` command. Wire tags match
-/// the FE settings (`transcription.service`): `whispercpp` / `parakeet` /
-/// `moonshine`.
+/// Push the ambient transcription configuration. Replaces the per-call
+/// `config` argument that `transcribe_recording` used to take. The FE
+/// invokes this once at startup and on every subsequent change to
+/// settings, model selection, language, prompt, or unload policy.
 ///
-/// `pub` + `specta::Type` so the JS side gets the discriminated union as
-/// a typed argument via the `tauri-specta` generator. The existing serde
-/// tag + rename attributes carry through.
-#[derive(Debug, Deserialize, specta::Type)]
-#[serde(tag = "engine", rename_all = "lowercase")]
-pub enum TranscribeRequest {
-    #[serde(rename = "whispercpp")]
-    Whisper {
-        #[serde(rename = "modelPath")]
-        model_path: String,
-        #[serde(default)]
-        language: Option<String>,
-        #[serde(default, rename = "initialPrompt")]
-        initial_prompt: Option<String>,
-    },
-    Parakeet {
-        #[serde(rename = "modelPath")]
-        model_path: String,
-    },
-    Moonshine {
-        #[serde(rename = "modelPath")]
-        model_path: String,
-        variant: MoonshineVariantWire,
-    },
+/// Drift in `(engine, modelPath)` triggers a background preload so the
+/// next `transcribe_recording` call does not pay cold-start latency.
+/// Other field changes take effect on the next transcription with no
+/// reload.
+#[tauri::command]
+#[specta::specta]
+pub fn set_transcription_config(
+    config: TranscriptionConfig,
+    model_manager: State<'_, ModelManager>,
+) {
+    model_manager.set_transcription_config(config);
 }
 
-/// Wire representation of the subset of Moonshine variants the app surfaces.
-/// `transcribe-rs` exposes more variants but the UI only offers Tiny and Base.
-#[derive(Debug, Deserialize, Clone, Copy, specta::Type)]
-#[serde(rename_all = "lowercase")]
-pub enum MoonshineVariantWire {
-    Tiny,
-    Base,
-}
-
-impl From<MoonshineVariantWire> for MoonshineVariant {
-    fn from(v: MoonshineVariantWire) -> Self {
-        match v {
-            MoonshineVariantWire::Tiny => MoonshineVariant::Tiny,
-            MoonshineVariantWire::Base => MoonshineVariant::Base,
-        }
-    }
-}
-
-impl TranscribeRequest {
-    fn engine_label(&self) -> &'static str {
-        match self {
-            TranscribeRequest::Whisper { .. } => "Whisper",
-            TranscribeRequest::Parakeet { .. } => "Parakeet",
-            TranscribeRequest::Moonshine { .. } => "Moonshine",
-        }
-    }
+/// Snapshot the current model state. Used by late-mounted observers (a
+/// second window, the settings panel re-opening, etc.) to catch up to
+/// the current lifecycle state without waiting for the next event on
+/// `transcription://model-state`.
+///
+/// Reads a lock-free status field plus the ambient config; never touches
+/// the cache mutex, so it returns immediately even mid-inference.
+#[tauri::command]
+#[specta::specta]
+pub fn get_transcription_state(model_manager: State<'_, ModelManager>) -> LocalModelState {
+    model_manager.snapshot()
 }
 
 /// Canonical transcribe-by-id path. Resolves the audio file under
 /// `<appDataDir>/recordings/{recordingId}.*` (cpal-written WAV,
-/// navigator-saved webm/opus/mp4, etc.), decodes, runs inference. This
-/// is the single entry point for every local transcription call: cpal
-/// stop, navigator/VAD/file-upload (after the pipeline saves), retry,
-/// history replay.
+/// navigator-saved webm/opus/mp4, etc.), decodes, runs inference using
+/// the ambient configuration pushed via `set_transcription_config`.
+///
+/// Returns `NoConfig` if the FE has not pushed a config yet.
 #[tauri::command]
 #[specta::specta]
 pub async fn transcribe_recording(
     recording_id: String,
-    config: TranscribeRequest,
     app_handle: AppHandle,
     model_manager: State<'_, ModelManager>,
 ) -> Result<String, TranscriptionError> {
-    let samples = read_artifact_samples(&app_handle, &recording_id).map_err(|e| {
-        TranscriptionError::AudioReadError { message: e }
-    })?;
+    let samples = read_artifact_samples(&app_handle, &recording_id)
+        .map_err(|e| TranscriptionError::AudioReadError { message: e })?;
 
     let manager = model_manager.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || run_inference(samples, config, manager))
+    tauri::async_runtime::spawn_blocking(move || manager.transcribe(samples))
         .await
         .map_err(join_err)?
-}
-
-/// Update the model unload policy from the frontend. Called by an effect
-/// in the SvelteKit layout whenever `transcription.localModelUnloadPolicy`
-/// changes, and once at app startup to push the initial value.
-///
-/// Unknown values fall back to the default inside `UnloadPolicy::from_wire`
-/// rather than erroring, so a future rename or corrupt localStorage value
-/// never breaks transcription.
-#[tauri::command]
-#[specta::specta]
-pub fn set_unload_policy(policy: String, model_manager: State<'_, ModelManager>) {
-    model_manager.set_policy(UnloadPolicy::from_wire(&policy));
 }
 
 /// Map a join failure from spawn_blocking into a TranscriptionError so the
@@ -117,90 +70,4 @@ fn join_err(e: tauri::Error) -> TranscriptionError {
     TranscriptionError::TranscriptionError {
         message: format!("Background transcription task failed: {}", e),
     }
-}
-
-fn transcription_err(e: impl std::fmt::Display) -> TranscriptionError {
-    TranscriptionError::TranscriptionError {
-        message: e.to_string(),
-    }
-}
-
-/// Synchronous inference dispatch. Runs on a blocking-pool thread; all
-/// engine-specific knobs live here.
-fn run_inference(
-    samples: Vec<f32>,
-    request: TranscribeRequest,
-    manager: ModelManager,
-) -> Result<String, TranscriptionError> {
-    let engine_label = request.engine_label();
-    info!(
-        "[Transcription] starting {} transcription: pcm_samples={}",
-        engine_label,
-        samples.len(),
-    );
-
-    if samples.is_empty() {
-        warn!("[Transcription] zero samples, returning empty transcript");
-        return Ok(String::new());
-    }
-    debug!(
-        "[Transcription] running {} on {} samples",
-        engine_label,
-        samples.len(),
-    );
-
-    let transcript = match request {
-        TranscribeRequest::Whisper {
-            model_path,
-            language,
-            initial_prompt,
-        } => {
-            let mut params = WhisperInferenceParams::default();
-            params.language = language;
-            params.initial_prompt = initial_prompt;
-            params.print_special = false;
-            params.print_progress = false;
-            params.print_realtime = false;
-            params.print_timestamps = false;
-            params.suppress_blank = true;
-            params.suppress_non_speech_tokens = true;
-            params.no_speech_thold = 0.2;
-
-            manager.with_whisper(PathBuf::from(model_path), |engine| {
-                let result = engine
-                    .transcribe_with(&samples, &params)
-                    .map_err(transcription_err)?;
-                Ok(result.text.trim().to_string())
-            })?
-        }
-        TranscribeRequest::Parakeet { model_path } => {
-            let params = ParakeetParams {
-                timestamp_granularity: Some(TimestampGranularity::Segment),
-                ..Default::default()
-            };
-            manager.with_parakeet(PathBuf::from(model_path), |engine| {
-                let result = engine
-                    .transcribe_with(&samples, &params)
-                    .map_err(transcription_err)?;
-                Ok(result.text.trim().to_string())
-            })?
-        }
-        TranscribeRequest::Moonshine {
-            model_path,
-            variant,
-        } => manager.with_moonshine(PathBuf::from(model_path), variant.into(), |engine| {
-            let result = engine
-                .transcribe(&samples, &TranscribeOptions::default())
-                .map_err(transcription_err)?;
-            Ok(result.text.trim().to_string())
-        })?,
-    };
-
-    info!(
-        "[Transcription] {} transcription complete: characters={}",
-        engine_label,
-        transcript.len()
-    );
-    manager.evict_if_immediate();
-    Ok(transcript)
 }

--- a/apps/whispering/src-tauri/src/transcription/model_manager.rs
+++ b/apps/whispering/src-tauri/src/transcription/model_manager.rs
@@ -1,162 +1,264 @@
+use super::config::{should_preload, Engine as EngineKind, TranscriptionConfig, UnloadPolicy};
 use super::error::TranscriptionError;
+use super::events::{
+    LocalModelState, ModelStateEvent, ModelStatus, UnloadReason, EVENT_CHANNEL,
+};
 use log::{debug, info, warn};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, RwLock};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tauri::{AppHandle, Emitter};
 use transcribe_rs::onnx::moonshine::{MoonshineModel, MoonshineVariant};
-use transcribe_rs::onnx::parakeet::ParakeetModel;
+use transcribe_rs::onnx::parakeet::{ParakeetModel, ParakeetParams, TimestampGranularity};
 use transcribe_rs::onnx::Quantization;
-use transcribe_rs::whisper_cpp::WhisperEngine;
+use transcribe_rs::whisper_cpp::{WhisperEngine, WhisperInferenceParams};
+use transcribe_rs::{SpeechModel, TranscribeOptions};
 
-/// How long after the last transcription the resident model should be
-/// dropped. Mirrors the frontend setting `transcription.localModelUnloadPolicy`.
-///
-/// `Immediately` is enforced synchronously at the end of each transcription
-/// (see `ModelManager::evict_if_immediate`). Timed variants are enforced by
-/// the background idle watcher (see `ModelManager::start_idle_watcher`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum UnloadPolicy {
-    Never,
-    Immediately,
-    AfterMinutes(u64),
-}
-
-impl UnloadPolicy {
-    /// Default policy if the frontend never pushes one. Matches the frontend
-    /// default so a fresh install behaves identically before any setting
-    /// observer fires.
-    pub const DEFAULT: Self = Self::AfterMinutes(5);
-
-    /// Parse a wire-format string from the frontend setting. Unknown values
-    /// fall back to `DEFAULT` rather than failing so a stale or future value
-    /// from a synced workspace never bricks the model layer.
-    pub fn from_wire(s: &str) -> Self {
-        match s {
-            "never" => Self::Never,
-            "immediately" => Self::Immediately,
-            "after_5_minutes" => Self::AfterMinutes(5),
-            "after_30_minutes" => Self::AfterMinutes(30),
-            other => {
-                warn!(
-                    "[Transcription] Unknown unload policy '{}', falling back to default",
-                    other
-                );
-                Self::DEFAULT
-            }
-        }
-    }
-}
-
-/// Engine type for managing different transcription engines.
-/// Dropping a variant releases the underlying model resources.
+/// Resident engine variants. Dropping any variant releases the model
+/// resources held by the inner type.
 enum Engine {
     Whisper(WhisperEngine),
     Parakeet(ParakeetModel),
     Moonshine(MoonshineModel),
 }
 
-/// The path and engine are inseparable (engine X is always loaded from
-/// path Y), so they share one mutex slot instead of two parallel ones.
+/// The (path, engine) pair is inseparable: engine X is always loaded from
+/// path Y. One mutex slot holds both.
 type Cached = Option<(PathBuf, Engine)>;
 
+/// Owns the resident engine's lifecycle and the state observers see while it
+/// runs. Cache + ambient config + policy + status snapshot + lifecycle event
+/// emission all serve that one concern; they share the struct because they
+/// share the lifecycle.
 #[derive(Clone)]
 pub struct ModelManager {
+    /// The currently-resident engine and the path it was loaded from. The
+    /// mutex is held across `load` and the user closure inside `with_engine`
+    /// so concurrent transcribe calls serialize (one engine fits in memory).
     cached: Arc<Mutex<Cached>>,
+
     /// Millis since UNIX_EPOCH of the last transcription start or completion.
-    /// `AtomicU64` so the watcher can read it without contending with the
-    /// cache mutex held during long inference.
+    /// Atomic so the idle watcher can read it without contending with the
+    /// cache mutex during long inference.
     last_activity_ms: Arc<AtomicU64>,
-    /// Current unload policy. `RwLock` because the watcher reads on every
-    /// tick while writes only happen when the user changes the setting.
-    policy: Arc<RwLock<UnloadPolicy>>,
+
+    /// Ambient configuration pushed by the FE via `set_transcription_config`.
+    /// Read by `transcribe()` to dispatch and by `snapshot()` to report
+    /// `(engine, model_path)` without touching the cache mutex.
+    config: Arc<RwLock<Option<TranscriptionConfig>>>,
+
+    /// Lock-free status field for `snapshot()`. Mutated only by `with_engine`
+    /// and the eviction paths; never held across a long operation. The cache
+    /// mutex stays held across inference, but `status` does not, so snapshot
+    /// never blocks behind a transcription.
+    status: Arc<RwLock<ModelStatus>>,
+
+    /// Handle used for `Emitter::emit` on the lifecycle event channel.
+    /// Constructed once in `setup` and cloned cheaply through `Clone` on
+    /// the manager.
+    app: AppHandle,
 }
 
 impl ModelManager {
-    pub fn new() -> Self {
+    pub fn new(app: AppHandle) -> Self {
         Self {
             cached: Arc::new(Mutex::new(None)),
             last_activity_ms: Arc::new(AtomicU64::new(now_millis())),
-            policy: Arc::new(RwLock::new(UnloadPolicy::DEFAULT)),
+            config: Arc::new(RwLock::new(None)),
+            status: Arc::new(RwLock::new(ModelStatus::Idle)),
+            app,
         }
     }
 
-    pub fn set_policy(&self, policy: UnloadPolicy) {
-        let mut guard = match self.policy.write() {
-            Ok(g) => g,
-            Err(poisoned) => poisoned.into_inner(),
+    // ── Ambient config ────────────────────────────────────────────────
+
+    /// Push the FE-side configuration. If `(engine, model_path)` changed
+    /// since the last push, the previous resident model is dropped (with a
+    /// `ConfigChanged` unload event) and a background preload kicks off so
+    /// the next transcription does not pay cold-start latency. Other field
+    /// changes (language, prompt, policy) take effect on next transcription
+    /// without a reload.
+    pub fn set_transcription_config(&self, config: TranscriptionConfig) {
+        let needs_preload = {
+            let mut guard = self.write_config();
+            let preload = should_preload(guard.as_ref(), &config);
+            *guard = Some(config.clone());
+            preload
         };
-        if *guard != policy {
-            info!("[Transcription] Unload policy changed to {:?}", policy);
-            *guard = policy;
+
+        // Always notify: SelectionChanged is the FE's signal to refresh model
+        // identity displays even when the engine/path are the same.
+        self.emit(ModelStateEvent::SelectionChanged {
+            state: self.snapshot(),
+        });
+
+        if !needs_preload {
+            return;
         }
-    }
 
-    fn current_policy(&self) -> UnloadPolicy {
-        match self.policy.read() {
-            Ok(g) => *g,
-            Err(poisoned) => *poisoned.into_inner(),
-        }
-    }
-
-    fn touch_activity(&self) {
-        self.last_activity_ms.store(now_millis(), Ordering::Relaxed);
-    }
-
-    /// Drop the resident model now if the current policy is `Immediately`.
-    /// Called at the end of every successful transcription. A no-op for any
-    /// other policy.
-    ///
-    /// Blocking lock acquisition is fine: this runs at the end of a
-    /// transcription that just held the same lock, so no contention is
-    /// possible at the call site.
-    pub fn evict_if_immediate(&self) {
-        if matches!(self.current_policy(), UnloadPolicy::Immediately) {
-            evict_locked(&mut lock_cached(&self.cached), "immediate");
-        }
-    }
-
-    /// Start the background idle watcher. Spawns one task on the Tauri
-    /// async runtime; safe to call once at app setup. Returns immediately.
-    ///
-    /// The watcher sleeps between checks, never holds the cache lock while
-    /// waiting, and skips ticks where another caller currently holds the
-    /// cache (long-running transcription in progress).
-    pub fn start_idle_watcher(&self) {
+        // Hand off the eviction + preload to a background thread so this
+        // command returns immediately. The eviction itself takes the cache
+        // lock; if a transcribe is in-flight, the eviction waits for it
+        // (correct: don't yank a model out from under an active inference).
+        // The preload then loads the new model. The FE sees a sequence of
+        // events on `transcription://model-state`: Unloaded(ConfigChanged)
+        // → LoadingStarted → LoadingCompleted | LoadingFailed.
         let this = self.clone();
-        tauri::async_runtime::spawn(async move {
-            // Same cadence as Handy. Coarse on purpose: idle eviction is
-            // not latency-sensitive and a 10s tick keeps overhead trivial.
-            let tick = Duration::from_secs(10);
-            loop {
-                tokio::time::sleep(tick).await;
-                this.tick_idle();
+        tauri::async_runtime::spawn_blocking(move || {
+            this.evict_with_reason(UnloadReason::ConfigChanged);
+            if let Err(err) = this.preload(&config) {
+                warn!("[Transcription] preload failed: {}", err);
             }
         });
     }
 
-    /// One iteration of the idle watcher. Pulled out of the spawn closure
-    /// so the control flow is straight-line and the awaitless body is
-    /// trivially reviewable: read policy, compute idle, `try_lock`, evict.
-    fn tick_idle(&self) {
-        let Some(timeout) = idle_timeout_for(self.current_policy()) else {
-            return;
-        };
-        let idle = Duration::from_millis(
-            now_millis().saturating_sub(self.last_activity_ms.load(Ordering::Relaxed)),
-        );
-        if idle < timeout {
-            return;
-        }
-        // `try_lock` so a long transcription in progress just postpones
-        // eviction to the next tick instead of blocking the watcher.
-        let Ok(mut guard) = self.cached.try_lock() else {
-            return;
-        };
-        evict_locked(&mut guard, format_args!("idle {}s", idle.as_secs()));
+    fn write_config(&self) -> std::sync::RwLockWriteGuard<'_, Option<TranscriptionConfig>> {
+        self.config
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
-    pub fn with_whisper<T>(
+    fn read_config(&self) -> Option<TranscriptionConfig> {
+        self.config
+            .read()
+            .map(|g| g.clone())
+            .unwrap_or_else(|poisoned| poisoned.into_inner().clone())
+    }
+
+    fn current_policy(&self) -> UnloadPolicy {
+        self.read_config()
+            .map(|c| c.unload_policy)
+            .unwrap_or(UnloadPolicy::DEFAULT)
+    }
+
+    // ── Snapshot ──────────────────────────────────────────────────────
+
+    /// Read-only view of `(engine, model_path, status)`. Does not touch the
+    /// cache mutex, so it returns immediately even mid-inference. This is
+    /// what new windows call on mount to catch up to current state without
+    /// waiting for the next event.
+    pub fn snapshot(&self) -> LocalModelState {
+        let config = self.read_config();
+        let status = self
+            .status
+            .read()
+            .map(|g| g.clone())
+            .unwrap_or_else(|poisoned| poisoned.into_inner().clone());
+        LocalModelState {
+            engine: config.as_ref().map(|c| c.engine),
+            model_path: config.map(|c| c.model_path),
+            status,
+        }
+    }
+
+    fn set_status(&self, status: ModelStatus) {
+        match self.status.write() {
+            Ok(mut g) => *g = status,
+            Err(poisoned) => *poisoned.into_inner() = status,
+        }
+    }
+
+    // ── Transcribe ────────────────────────────────────────────────────
+
+    /// Synchronous inference dispatch. Reads the ambient configuration,
+    /// validates the samples, then routes to the engine-specific path.
+    /// Called from a blocking-pool thread.
+    pub fn transcribe(&self, samples: Vec<f32>) -> Result<String, TranscriptionError> {
+        let Some(config) = self.read_config() else {
+            return Err(TranscriptionError::NoConfig {
+                message:
+                    "Transcription config not set. The frontend must call setTranscriptionConfig first."
+                        .to_string(),
+            });
+        };
+
+        if samples.is_empty() {
+            warn!("[Transcription] zero samples, returning empty transcript");
+            return Ok(String::new());
+        }
+
+        let samples = sanitize_samples(samples);
+
+        info!(
+            "[Transcription] starting {:?} transcription: pcm_samples={}",
+            config.engine,
+            samples.len(),
+        );
+
+        let model_path = PathBuf::from(&config.model_path);
+        let transcript = match config.engine {
+            EngineKind::Whispercpp => {
+                let mut params = WhisperInferenceParams::default();
+                params.language = config.language.clone();
+                params.initial_prompt = config.initial_prompt.clone();
+                params.print_special = false;
+                params.print_progress = false;
+                params.print_realtime = false;
+                params.print_timestamps = false;
+                params.suppress_blank = true;
+                params.suppress_non_speech_tokens = true;
+                params.no_speech_thold = 0.2;
+
+                self.with_whisper(model_path, |engine| {
+                    let result = engine
+                        .transcribe_with(&samples, &params)
+                        .map_err(transcription_err)?;
+                    Ok(result.text.trim().to_string())
+                })?
+            }
+            EngineKind::Parakeet => {
+                let params = ParakeetParams {
+                    timestamp_granularity: Some(TimestampGranularity::Segment),
+                    ..Default::default()
+                };
+                self.with_parakeet(model_path, |engine| {
+                    let result = engine
+                        .transcribe_with(&samples, &params)
+                        .map_err(transcription_err)?;
+                    Ok(result.text.trim().to_string())
+                })?
+            }
+            EngineKind::Moonshine => {
+                let variant = parse_moonshine_variant(&config.model_path)?;
+                self.with_moonshine(model_path, variant, |engine| {
+                    let result = engine
+                        .transcribe(&samples, &TranscribeOptions::default())
+                        .map_err(transcription_err)?;
+                    Ok(result.text.trim().to_string())
+                })?
+            }
+        };
+
+        info!(
+            "[Transcription] {:?} transcription complete: characters={}",
+            config.engine,
+            transcript.len()
+        );
+        self.evict_if_immediate();
+        Ok(transcript)
+    }
+
+    // ── Preload ───────────────────────────────────────────────────────
+
+    /// Load the configured model without running inference. Drives the same
+    /// `with_engine` machinery the transcribe path uses; the closure body is
+    /// a no-op so the lifecycle ends in `Ready`, not `Inferring → Ready`.
+    fn preload(&self, config: &TranscriptionConfig) -> Result<(), TranscriptionError> {
+        let model_path = PathBuf::from(&config.model_path);
+        match config.engine {
+            EngineKind::Whispercpp => self.with_whisper(model_path, |_| Ok(())),
+            EngineKind::Parakeet => self.with_parakeet(model_path, |_| Ok(())),
+            EngineKind::Moonshine => {
+                let variant = parse_moonshine_variant(&config.model_path)?;
+                self.with_moonshine(model_path, variant, |_| Ok(()))
+            }
+        }
+    }
+
+    // ── Engine cache + eviction ───────────────────────────────────────
+
+    fn with_whisper<T>(
         &self,
         model_path: PathBuf,
         f: impl FnOnce(&mut WhisperEngine) -> Result<T, TranscriptionError>,
@@ -176,7 +278,7 @@ impl ModelManager {
         )
     }
 
-    pub fn with_parakeet<T>(
+    fn with_parakeet<T>(
         &self,
         model_path: PathBuf,
         f: impl FnOnce(&mut ParakeetModel) -> Result<T, TranscriptionError>,
@@ -196,7 +298,7 @@ impl ModelManager {
         )
     }
 
-    pub fn with_moonshine<T>(
+    fn with_moonshine<T>(
         &self,
         model_path: PathBuf,
         variant: MoonshineVariant,
@@ -217,15 +319,19 @@ impl ModelManager {
         )
     }
 
-    /// Hold the cache lock across both load and inference. If the cached
-    /// (path, engine) matches the request, reuse it; otherwise drop it,
-    /// load fresh under the same lock, then run `use_engine` while still
-    /// holding the lock. This serializes concurrent transcribe calls (only
-    /// one engine fits in memory anyway) and eliminates any race where
-    /// another thread could swap the engine between a load and a use step.
+    /// Hold the cache lock across load and use. If `(path, engine kind)`
+    /// matches the cache, reuse; otherwise drop, load fresh, then run the
+    /// user closure under the same lock. Status transitions and events fire
+    /// at each stage so a snapshot or listener sees the lifecycle.
     ///
-    /// Stamps activity both before and after the use step so the idle
-    /// watcher counts from the *end* of inference, not the start.
+    /// Holding the cache lock across `emit` is safe: Tauri's emit is sync
+    /// and FE handlers run on the JS event loop, so no Rust caller can
+    /// re-enter and contend on this mutex.
+    ///
+    /// Status sequence for a load-then-use call:
+    ///   Idle/Ready → Loading → Ready → Inferring → Ready
+    /// For a preload (no-op closure): the `Inferring → Ready` step still
+    /// runs but observers do not perceive it (closure returns instantly).
     fn with_engine<T>(
         &self,
         model_path: PathBuf,
@@ -240,41 +346,210 @@ impl ModelManager {
 
         if !reuse {
             let _ = guard.take();
-            let engine = load(&model_path)
-                .map_err(|message| TranscriptionError::ModelLoadError { message })?;
-            debug!("[Transcription] model loaded: {}", model_path.display());
-            *guard = Some((model_path, engine));
+            self.set_status(ModelStatus::Loading);
+            self.emit(ModelStateEvent::LoadingStarted {
+                state: self.snapshot(),
+            });
+            let started = Instant::now();
+            match load(&model_path) {
+                Ok(engine) => {
+                    let elapsed_ms = started.elapsed().as_millis() as u64;
+                    debug!(
+                        "[Transcription] model loaded: {} ({}ms)",
+                        model_path.display(),
+                        elapsed_ms
+                    );
+                    *guard = Some((model_path, engine));
+                    self.set_status(ModelStatus::Ready);
+                    self.emit(ModelStateEvent::LoadingCompleted {
+                        state: self.snapshot(),
+                        elapsed_ms,
+                    });
+                }
+                Err(message) => {
+                    self.set_status(ModelStatus::Error {
+                        message: message.clone(),
+                    });
+                    self.emit(ModelStateEvent::LoadingFailed {
+                        state: self.snapshot(),
+                        error: message.clone(),
+                    });
+                    return Err(TranscriptionError::ModelLoadError { message });
+                }
+            }
         }
 
         let (_, engine) = guard.as_mut().expect("cache slot populated above");
+        self.set_status(ModelStatus::Inferring);
         let result = use_engine(engine);
         self.touch_activity();
+        match &result {
+            Ok(_) => self.set_status(ModelStatus::Ready),
+            Err(e) => {
+                // Don't clear the cache on inference failure: the engine is
+                // still loaded and the next call may succeed (transient FFI
+                // or input issue). The status reflects the last result; a
+                // successful next call flips it back to Ready.
+                self.set_status(ModelStatus::Error {
+                    message: e.to_string(),
+                });
+            }
+        }
         result
     }
-}
 
-/// Drain the cache slot under an already-held guard and log who triggered
-/// it. Shared by `evict_if_immediate` (synchronous, blocking lock) and the
-/// idle watcher (non-blocking `try_lock`). The actual `Drop` of the engine
-/// runs when the guard is released by the caller, so the lock is never
-/// held across heavy teardown.
-fn evict_locked(guard: &mut MutexGuard<'_, Cached>, reason: impl std::fmt::Display) {
-    if let Some((path, _engine)) = guard.take() {
-        debug!(
-            "[Transcription] unloaded model ({}): {}",
-            reason,
-            path.display()
+    fn touch_activity(&self) {
+        self.last_activity_ms
+            .store(now_millis(), Ordering::Relaxed);
+    }
+
+    /// Drop the resident model now if the current policy is `Immediately`.
+    /// Called at the end of every successful transcription.
+    pub fn evict_if_immediate(&self) {
+        if matches!(self.current_policy(), UnloadPolicy::Immediately) {
+            self.evict_with_reason(UnloadReason::Immediate);
+        }
+    }
+
+    /// Drop the resident model and emit an `Unloaded` event with the given
+    /// reason. Idempotent: a no-op when the cache is already empty.
+    fn evict_with_reason(&self, reason: UnloadReason) {
+        let mut guard = lock_cached(&self.cached);
+        if let Some((path, _engine)) = guard.take() {
+            debug!(
+                "[Transcription] unloaded model ({:?}): {}",
+                reason,
+                path.display()
+            );
+            // Drop the guard before emitting so emit handlers cannot deadlock
+            // on the cache lock (they should not lock it anyway, but defensive
+            // ordering is cheap).
+            drop(guard);
+            self.set_status(ModelStatus::Idle);
+            self.emit(ModelStateEvent::Unloaded {
+                state: self.snapshot(),
+                reason,
+            });
+        }
+    }
+
+    // ── Idle watcher ──────────────────────────────────────────────────
+
+    /// Start the background idle watcher. Spawns one task on the Tauri
+    /// async runtime; safe to call once at setup.
+    pub fn start_idle_watcher(&self) {
+        let this = self.clone();
+        tauri::async_runtime::spawn(async move {
+            let tick = Duration::from_secs(10);
+            loop {
+                tokio::time::sleep(tick).await;
+                this.tick_idle();
+            }
+        });
+    }
+
+    fn tick_idle(&self) {
+        let Some(timeout) = idle_timeout_for(self.current_policy()) else {
+            return;
+        };
+        let idle = Duration::from_millis(
+            now_millis().saturating_sub(self.last_activity_ms.load(Ordering::Relaxed)),
         );
+        if idle < timeout {
+            return;
+        }
+        // try_lock so a long transcription in progress just postpones eviction
+        // to the next tick instead of blocking the watcher.
+        let Ok(mut guard) = self.cached.try_lock() else {
+            return;
+        };
+        if let Some((path, _engine)) = guard.take() {
+            let idle_secs = idle.as_secs();
+            debug!(
+                "[Transcription] unloaded model (idle {}s): {}",
+                idle_secs,
+                path.display()
+            );
+            drop(guard);
+            self.set_status(ModelStatus::Idle);
+            self.emit(ModelStateEvent::Unloaded {
+                state: self.snapshot(),
+                reason: UnloadReason::Idle { idle_secs },
+            });
+        }
+    }
+
+    // ── Event emission ────────────────────────────────────────────────
+
+    fn emit(&self, event: ModelStateEvent) {
+        if let Err(err) = self.app.emit(EVENT_CHANNEL, &event) {
+            warn!("[Transcription] failed to emit model-state event: {}", err);
+        }
     }
 }
 
-/// Return the idle duration after which the watcher should evict, or `None`
-/// if this policy is not driven by the watcher (Never never evicts;
-/// Immediately is enforced synchronously after each transcription).
+/// Replace NaN/Inf with 0.0 and cap length so a malformed sample buffer
+/// never reaches whisper.cpp's FFI boundary (where a `GGML_ASSERT` would
+/// abort the process and bypass any Rust-level recovery). Cheap insurance
+/// against the most common abort class.
+fn sanitize_samples(mut samples: Vec<f32>) -> Vec<f32> {
+    // Cap at one hour of mono 16kHz audio. Beyond this we don't run
+    // inference reliably anyway and the FE imposes its own caps; this
+    // is a backstop against integer overflow or pathological inputs.
+    const MAX_SAMPLES: usize = 16_000 * 60 * 60;
+    if samples.len() > MAX_SAMPLES {
+        warn!(
+            "[Transcription] truncating {} samples to MAX_SAMPLES ({})",
+            samples.len(),
+            MAX_SAMPLES
+        );
+        samples.truncate(MAX_SAMPLES);
+    }
+    for s in samples.iter_mut() {
+        if !s.is_finite() {
+            *s = 0.0;
+        }
+    }
+    samples
+}
+
+fn parse_moonshine_variant(model_path: &str) -> Result<MoonshineVariant, TranscriptionError> {
+    let stem = Path::new(model_path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| TranscriptionError::ConfigError {
+            message: format!(
+                "Moonshine model path has no terminal directory name: {}",
+                model_path
+            ),
+        })?;
+    // Naming convention: moonshine-{variant}-{lang}. Match on the variant
+    // segment between the first and last hyphen-bounded fields.
+    if stem.contains("-tiny-") || stem.ends_with("-tiny") {
+        Ok(MoonshineVariant::Tiny)
+    } else if stem.contains("-base-") || stem.ends_with("-base") {
+        Ok(MoonshineVariant::Base)
+    } else {
+        Err(TranscriptionError::ConfigError {
+            message: format!(
+                "Moonshine model path must end with moonshine-{{tiny|base}}-{{lang}}: got {}",
+                stem
+            ),
+        })
+    }
+}
+
+fn transcription_err(e: impl std::fmt::Display) -> TranscriptionError {
+    TranscriptionError::TranscriptionError {
+        message: e.to_string(),
+    }
+}
+
 fn idle_timeout_for(policy: UnloadPolicy) -> Option<Duration> {
     match policy {
         UnloadPolicy::Never | UnloadPolicy::Immediately => None,
-        UnloadPolicy::AfterMinutes(m) => Some(Duration::from_secs(m * 60)),
+        UnloadPolicy::AfterFiveMinutes => Some(Duration::from_secs(5 * 60)),
+        UnloadPolicy::AfterThirtyMinutes => Some(Duration::from_secs(30 * 60)),
     }
 }
 
@@ -286,8 +561,8 @@ fn now_millis() -> u64 {
 }
 
 /// Lock the cache slot, recovering from poisoning by clearing the cached
-/// (path, engine) so the next caller reloads from scratch instead of
-/// reusing corrupted state from a previous panic.
+/// (path, engine) so the next caller reloads from scratch instead of reusing
+/// corrupted state from a previous panic.
 fn lock_cached(cached: &Mutex<Cached>) -> MutexGuard<'_, Cached> {
     cached.lock().unwrap_or_else(|poisoned| {
         warn!(
@@ -304,29 +579,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parses_known_policy_values() {
-        assert_eq!(UnloadPolicy::from_wire("never"), UnloadPolicy::Never);
-        assert_eq!(
-            UnloadPolicy::from_wire("immediately"),
-            UnloadPolicy::Immediately
-        );
-        assert_eq!(
-            UnloadPolicy::from_wire("after_5_minutes"),
-            UnloadPolicy::AfterMinutes(5)
-        );
-        assert_eq!(
-            UnloadPolicy::from_wire("after_30_minutes"),
-            UnloadPolicy::AfterMinutes(30)
-        );
-    }
-
-    #[test]
-    fn unknown_wire_value_falls_back_to_default() {
-        assert_eq!(UnloadPolicy::from_wire("after_3_minutes"), UnloadPolicy::DEFAULT);
-        assert_eq!(UnloadPolicy::from_wire(""), UnloadPolicy::DEFAULT);
-    }
-
-    #[test]
     fn idle_timeout_is_none_for_non_timed_policies() {
         assert!(idle_timeout_for(UnloadPolicy::Never).is_none());
         assert!(idle_timeout_for(UnloadPolicy::Immediately).is_none());
@@ -335,20 +587,36 @@ mod tests {
     #[test]
     fn idle_timeout_matches_minutes() {
         assert_eq!(
-            idle_timeout_for(UnloadPolicy::AfterMinutes(5)),
+            idle_timeout_for(UnloadPolicy::AfterFiveMinutes),
             Some(Duration::from_secs(300))
         );
         assert_eq!(
-            idle_timeout_for(UnloadPolicy::AfterMinutes(30)),
+            idle_timeout_for(UnloadPolicy::AfterThirtyMinutes),
             Some(Duration::from_secs(1800))
         );
     }
 
     #[test]
-    fn set_policy_updates_current_value() {
-        let manager = ModelManager::new();
-        assert_eq!(manager.current_policy(), UnloadPolicy::DEFAULT);
-        manager.set_policy(UnloadPolicy::Immediately);
-        assert_eq!(manager.current_policy(), UnloadPolicy::Immediately);
+    fn sanitize_replaces_nonfinite_samples() {
+        let cleaned = sanitize_samples(vec![1.0, f32::NAN, f32::INFINITY, -0.5, f32::NEG_INFINITY]);
+        assert_eq!(cleaned, vec![1.0, 0.0, 0.0, -0.5, 0.0]);
+    }
+
+    #[test]
+    fn parse_moonshine_variant_handles_known_names() {
+        assert!(matches!(
+            parse_moonshine_variant("/models/moonshine-tiny-en").unwrap(),
+            MoonshineVariant::Tiny
+        ));
+        assert!(matches!(
+            parse_moonshine_variant("/models/moonshine-base-en").unwrap(),
+            MoonshineVariant::Base
+        ));
+    }
+
+    #[test]
+    fn parse_moonshine_variant_rejects_unknown_names() {
+        assert!(parse_moonshine_variant("/models/moonshine-large-en").is_err());
+        assert!(parse_moonshine_variant("/models/whisper-tiny").is_err());
     }
 }

--- a/apps/whispering/src/lib/constants/local-models.ts
+++ b/apps/whispering/src/lib/constants/local-models.ts
@@ -8,8 +8,6 @@
  * dispatch lives in `$lib/operations/transcribe.ts`.
  */
 
-import { regex } from 'arkregex';
-
 /**
  * Supported languages for Moonshine models.
  *
@@ -37,22 +35,14 @@ export type MoonshineLanguage = (typeof MOONSHINE_LANGUAGES)[number];
  * Moonshine architecture variants. Determines layer count and hidden
  * dimensions; transcribe-rs needs this to load the ONNX files since they
  * don't self-describe their architecture.
+ *
+ * Variant inference from the directory name lives in Rust
+ * (`transcription/model_manager.rs::parse_moonshine_variant`), since that
+ * is the only consumer and the wire format is owned by the loader.
  */
 export const MOONSHINE_VARIANTS = ['tiny', 'base'] as const;
 
 export type MoonshineVariant = (typeof MOONSHINE_VARIANTS)[number];
-
-/**
- * Type-safe regex pattern for validating Moonshine model paths.
- * Matches paths ending with `moonshine-{variant}-{lang}`. The captured
- * variant is forwarded on the wire to Rust.
- */
-export const MOONSHINE_DIR_PATTERN = regex.as<
-	`${string}moonshine-${MoonshineVariant}-${MoonshineLanguage}`,
-	{ captures: [MoonshineVariant, MoonshineLanguage] }
->(
-	`moonshine-(${MOONSHINE_VARIANTS.join('|')})-(${MOONSHINE_LANGUAGES.join('|')})$`,
-);
 
 /**
  * Base configuration for a local AI model that can be downloaded and used
@@ -239,8 +229,8 @@ export const PARAKEET_MODELS = [
  * These are ONNX models using encoder-decoder architecture with KV caching.
  *
  * Model directories MUST follow the format `moonshine-{variant}-{lang}`
- * because the variant is parsed from the directory name at transcribe time
- * (see `MOONSHINE_DIR_PATTERN`).
+ * because Rust's `parse_moonshine_variant` reads the variant out of the
+ * directory name at transcribe time.
  *
  * Note: Language-specific models (ar, zh, ja, ko, uk, vi, es) exist but only
  * have float versions available. We provide quantized English models for now

--- a/apps/whispering/src/lib/constants/transcription.ts
+++ b/apps/whispering/src/lib/constants/transcription.ts
@@ -221,9 +221,9 @@ export const TRANSCRIPTION_SERVICE_ID_TO_LABEL = Object.fromEntries(
  * carries values, labels, and descriptions; the tuple and union type are
  * derived from it (same pattern as TRANSCRIPTION → TRANSCRIPTION_SERVICE_IDS).
  *
- * Mirrored in Rust by `UnloadPolicy::from_wire` in
- * `src-tauri/src/transcription/model_manager.rs`. If you add a value here,
- * teach the Rust parser about it too.
+ * Mirrored in Rust by the `UnloadPolicy` enum in
+ * `src-tauri/src/transcription/config.rs` (serde rename tags pair each value
+ * with a variant). If you add a value here, add a matching variant there.
  *
  * Default order is UX order (recommended first), not alphabetical.
  */

--- a/apps/whispering/src/lib/operations/transcribe.ts
+++ b/apps/whispering/src/lib/operations/transcribe.ts
@@ -130,74 +130,100 @@ export async function transcribeAudio(
 	return transcriptionResult;
 }
 
+/**
+ * Per-engine FE preflight metadata. Each local engine validates the same
+ * way (path exists + is the expected `kind`); whispercpp adds a truncated-
+ * download check because corrupted .bin files load successfully but produce
+ * garbage transcripts. Putting it in a table makes the per-engine data
+ * legible in one place; the dispatch loop stays linear.
+ *
+ * Moonshine directory-name validation lives in Rust
+ * (`parse_moonshine_variant`) since the wire format is the loader's concern.
+ */
+const LOCAL_ENGINE_PREFLIGHT = {
+	whispercpp: {
+		kind: 'file',
+		displayName: 'Whisper C++',
+		modelPathKey: 'transcription.whispercpp.modelPath',
+	},
+	parakeet: {
+		kind: 'directory',
+		displayName: 'Parakeet',
+		modelPathKey: 'transcription.parakeet.modelPath',
+	},
+	moonshine: {
+		kind: 'directory',
+		displayName: 'Moonshine',
+		modelPathKey: 'transcription.moonshine.modelPath',
+	},
+} as const satisfies Record<
+	'whispercpp' | 'parakeet' | 'moonshine',
+	{
+		kind: 'file' | 'directory';
+		displayName: string;
+		modelPathKey:
+			| 'transcription.whispercpp.modelPath'
+			| 'transcription.parakeet.modelPath'
+			| 'transcription.moonshine.modelPath';
+	}
+>;
+
+type LocalEngineId = keyof typeof LOCAL_ENGINE_PREFLIGHT;
+
+function isLocalEngineId(id: TranscriptionServiceId): id is LocalEngineId {
+	return id in LOCAL_ENGINE_PREFLIGHT;
+}
+
+/**
+ * Whisper .bin downloads can finish at a smaller-than-expected size when the
+ * connection drops mid-stream. The file still loads via whisper.cpp but
+ * produces nonsense transcripts. Catalog match is best-effort: only models
+ * we recognize from `WHISPER_MODELS` have an expected size to compare.
+ */
+async function checkWhisperTruncation(
+	modelPath: string,
+): Promise<Result<void, LocalPreflightError>> {
+	const modelConfig = WHISPER_MODELS.find((m) =>
+		modelPath.endsWith(m.file.filename),
+	);
+	if (!modelConfig) return Ok(undefined);
+
+	const { data: fileStats } = await tryAsync({
+		try: () => stat(modelPath),
+		catch: () => Ok(null),
+	});
+	if (!fileStats) return Ok(undefined);
+
+	if (!isModelFileSizeValid(fileStats.size, modelConfig.sizeBytes)) {
+		return LocalPreflightError.CorruptedModelFile({
+			actualSizeMb: Math.round(fileStats.size / 1000000),
+			expectedSizeMb: Math.round(modelConfig.sizeBytes / 1000000),
+		});
+	}
+	return Ok(undefined);
+}
+
 async function dispatchLocalTranscription(
 	recordingId: string,
 	selectedService: TranscriptionServiceId,
 ): Promise<Result<string, TranscriptionError>> {
-	// FE preflight: every local engine needs a model path on disk. Rust will
-	// also fail loudly via `ModelLoadError`, but checking here lets us return
-	// a much better error message (per-engine display name, file vs directory
-	// guidance) and short-circuit before round-tripping through the IPC.
-	switch (selectedService) {
-		case 'whispercpp': {
-			const modelPath = deviceConfig.get('transcription.whispercpp.modelPath');
-			const validation = await requireExistingModelPath(
-				modelPath,
-				'file',
-				'Whisper C++',
-			);
-			if (validation.error) return validation;
+	if (!isLocalEngineId(selectedService)) {
+		return TranscriptionOperationError.NoTranscriptionServiceSelected();
+	}
 
-			// Whisper-specific: an interrupted download still loads but produces
-			// garbage transcripts. Only files we recognize from WHISPER_MODELS
-			// have an expected size to compare against.
-			const modelConfig = WHISPER_MODELS.find((m) =>
-				modelPath.endsWith(m.file.filename),
-			);
-			if (modelConfig) {
-				const { data: fileStats } = await tryAsync({
-					try: () => stat(modelPath),
-					catch: () => Ok(null),
-				});
-				if (
-					fileStats &&
-					!isModelFileSizeValid(fileStats.size, modelConfig.sizeBytes)
-				) {
-					return LocalPreflightError.CorruptedModelFile({
-						actualSizeMb: Math.round(fileStats.size / 1000000),
-						expectedSizeMb: Math.round(modelConfig.sizeBytes / 1000000),
-					});
-				}
-			}
-			break;
-		}
-		case 'parakeet': {
-			const modelPath = deviceConfig.get('transcription.parakeet.modelPath');
-			const validation = await requireExistingModelPath(
-				modelPath,
-				'directory',
-				'Parakeet',
-			);
-			if (validation.error) return validation;
-			break;
-		}
-		case 'moonshine': {
-			// Directory-name validation (must end with moonshine-{variant}-{lang})
-			// is owned by Rust now: `parse_moonshine_variant` returns a
-			// structured `ConfigError` when the name is malformed. Keeping the
-			// existence check here for the same UX-message reason as the other
-			// engines.
-			const modelPath = deviceConfig.get('transcription.moonshine.modelPath');
-			const validation = await requireExistingModelPath(
-				modelPath,
-				'directory',
-				'Moonshine',
-			);
-			if (validation.error) return validation;
-			break;
-		}
-		default:
-			return TranscriptionOperationError.NoTranscriptionServiceSelected();
+	// FE preflight: Rust would also fail via `ModelLoadError`, but the FE
+	// owns better UX strings (per-engine display name, file-vs-directory
+	// guidance) and can short-circuit before the IPC round-trip.
+	const { kind, displayName, modelPathKey } =
+		LOCAL_ENGINE_PREFLIGHT[selectedService];
+	const modelPath = deviceConfig.get(modelPathKey);
+
+	const validation = await requireExistingModelPath(modelPath, kind, displayName);
+	if (validation.error) return validation;
+
+	if (selectedService === 'whispercpp') {
+		const truncated = await checkWhisperTruncation(modelPath);
+		if (truncated.error) return truncated;
 	}
 
 	// Rust reads engine, modelPath, language, prompt, and unloadPolicy from

--- a/apps/whispering/src/lib/operations/transcribe.ts
+++ b/apps/whispering/src/lib/operations/transcribe.ts
@@ -218,7 +218,11 @@ async function dispatchLocalTranscription(
 		LOCAL_ENGINE_PREFLIGHT[selectedService];
 	const modelPath = deviceConfig.get(modelPathKey);
 
-	const validation = await requireExistingModelPath(modelPath, kind, displayName);
+	const validation = await requireExistingModelPath(
+		modelPath,
+		kind,
+		displayName,
+	);
 	if (validation.error) return validation;
 
 	if (selectedService === 'whispercpp') {

--- a/apps/whispering/src/lib/operations/transcribe.ts
+++ b/apps/whispering/src/lib/operations/transcribe.ts
@@ -7,7 +7,6 @@ import {
 } from '$lib/constants/languages';
 import {
 	isModelFileSizeValid,
-	MOONSHINE_DIR_PATTERN,
 	WHISPER_MODELS,
 } from '$lib/constants/local-models';
 import type { TranscriptionServiceId } from '$lib/constants/transcription';
@@ -135,6 +134,10 @@ async function dispatchLocalTranscription(
 	recordingId: string,
 	selectedService: TranscriptionServiceId,
 ): Promise<Result<string, TranscriptionError>> {
+	// FE preflight: every local engine needs a model path on disk. Rust will
+	// also fail loudly via `ModelLoadError`, but checking here lets us return
+	// a much better error message (per-engine display name, file vs directory
+	// guidance) and short-circuit before round-tripping through the IPC.
 	switch (selectedService) {
 		case 'whispercpp': {
 			const modelPath = deviceConfig.get('transcription.whispercpp.modelPath');
@@ -166,15 +169,7 @@ async function dispatchLocalTranscription(
 					});
 				}
 			}
-
-			const outputLanguage = getOutputLanguage();
-			const prompt = settings.get('transcription.prompt');
-			return commands.transcribeRecording(recordingId, {
-				engine: 'whispercpp',
-				modelPath,
-				language: outputLanguage === 'auto' ? null : outputLanguage,
-				initialPrompt: prompt || null,
-			});
+			break;
 		}
 		case 'parakeet': {
 			const modelPath = deviceConfig.get('transcription.parakeet.modelPath');
@@ -184,13 +179,14 @@ async function dispatchLocalTranscription(
 				'Parakeet',
 			);
 			if (validation.error) return validation;
-
-			return commands.transcribeRecording(recordingId, {
-				engine: 'parakeet',
-				modelPath,
-			});
+			break;
 		}
 		case 'moonshine': {
+			// Directory-name validation (must end with moonshine-{variant}-{lang})
+			// is owned by Rust now: `parse_moonshine_variant` returns a
+			// structured `ConfigError` when the name is malformed. Keeping the
+			// existence check here for the same UX-message reason as the other
+			// engines.
 			const modelPath = deviceConfig.get('transcription.moonshine.modelPath');
 			const validation = await requireExistingModelPath(
 				modelPath,
@@ -198,25 +194,16 @@ async function dispatchLocalTranscription(
 				'Moonshine',
 			);
 			if (validation.error) return validation;
-
-			// Moonshine's ONNX files don't self-describe their architecture; the
-			// variant is encoded in the directory name (see
-			// MOONSHINE_DIR_PATTERN) and forwarded to Rust on the wire.
-			const match = MOONSHINE_DIR_PATTERN.exec(modelPath);
-			if (!match) {
-				return LocalPreflightError.InvalidMoonshineDirectoryName();
-			}
-			const [, variant] = match;
-
-			return commands.transcribeRecording(recordingId, {
-				engine: 'moonshine',
-				modelPath,
-				variant,
-			});
+			break;
 		}
 		default:
 			return TranscriptionOperationError.NoTranscriptionServiceSelected();
 	}
+
+	// Rust reads engine, modelPath, language, prompt, and unloadPolicy from
+	// the ambient config pushed via `setTranscriptionConfig` in the layout
+	// effect. Anything that affects inference output is already there.
+	return commands.transcribeRecording(recordingId);
 }
 
 async function dispatchCloudTranscription(

--- a/apps/whispering/src/lib/services/transcription/local-preflight.ts
+++ b/apps/whispering/src/lib/services/transcription/local-preflight.ts
@@ -58,10 +58,6 @@ export const LocalPreflightError = defineErrors({
 		actualSizeMb,
 		expectedSizeMb,
 	}),
-	InvalidMoonshineDirectoryName: () => ({
-		message:
-			'Model path must end with moonshine-{variant}-{lang} (e.g., "moonshine-tiny-en", "moonshine-base-en")',
-	}),
 });
 export type LocalPreflightError = InferErrors<typeof LocalPreflightError>;
 

--- a/apps/whispering/src/lib/state/local-model.svelte.ts
+++ b/apps/whispering/src/lib/state/local-model.svelte.ts
@@ -1,10 +1,10 @@
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { tauri } from '$lib/tauri';
 import {
 	commands,
 	type LocalModelState,
 	type ModelStateEvent,
 } from '$lib/tauri/commands';
-import { tauri } from '$lib/tauri';
 
 const INITIAL_STATE: LocalModelState = {
 	engine: null,

--- a/apps/whispering/src/lib/state/local-model.svelte.ts
+++ b/apps/whispering/src/lib/state/local-model.svelte.ts
@@ -22,26 +22,47 @@ const INITIAL_STATE: LocalModelState = {
  * snapshot (the next event will correct it). Sequence numbers would let us
  * dedupe perfectly but are overkill: every event carries a full state, so a
  * single missed event self-heals on the next transition.
+ *
+ * Shape mirrors `recordings.svelte.ts` / `vad-recorder.svelte.ts`: factory
+ * function with a `$state` closure variable and a return object that exposes
+ * a reactive getter plus operations.
  */
-class LocalModel {
-	state = $state<LocalModelState>(INITIAL_STATE);
+function createLocalModel() {
+	let state = $state<LocalModelState>(INITIAL_STATE);
 
-	async attach(): Promise<UnlistenFn> {
-		if (!tauri) return () => {};
-		const unlisten = await listen<ModelStateEvent>(
-			'transcription://model-state',
-			(event) => {
-				this.state = event.payload.state;
-			},
-		);
-		this.state = await commands.getTranscriptionState();
-		return unlisten;
-	}
+	return {
+		/** Reactive view of the resident model and its lifecycle status. */
+		get state(): LocalModelState {
+			return state;
+		},
 
-	get isBusy(): boolean {
-		const kind = this.state.status.kind;
-		return kind === 'loading' || kind === 'inferring';
-	}
+		/** True while the model is loading or running inference. */
+		get isBusy(): boolean {
+			return (
+				state.status.kind === 'loading' || state.status.kind === 'inferring'
+			);
+		},
+
+		/**
+		 * Subscribe to the model-state event channel and seed the initial
+		 * snapshot. Returns the unlisten function for the caller's lifecycle
+		 * (typically the root layout's `onDestroy`).
+		 *
+		 * No-op outside Tauri; returns a no-op unlisten so callers don't need
+		 * to branch on `tauri`.
+		 */
+		async attach(): Promise<UnlistenFn> {
+			if (!tauri) return () => {};
+			const unlisten = await listen<ModelStateEvent>(
+				'transcription://model-state',
+				(event) => {
+					state = event.payload.state;
+				},
+			);
+			state = await commands.getTranscriptionState();
+			return unlisten;
+		},
+	};
 }
 
-export const localModel = new LocalModel();
+export const localModel = createLocalModel();

--- a/apps/whispering/src/lib/state/local-model.svelte.ts
+++ b/apps/whispering/src/lib/state/local-model.svelte.ts
@@ -1,0 +1,47 @@
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import {
+	commands,
+	type LocalModelState,
+	type ModelStateEvent,
+} from '$lib/tauri/commands';
+import { tauri } from '$lib/tauri';
+
+const INITIAL_STATE: LocalModelState = {
+	engine: null,
+	modelPath: null,
+	status: { kind: 'idle' },
+};
+
+/**
+ * Reactive mirror of the Rust `ModelManager`'s public state, kept in sync via
+ * the `transcription://model-state` event channel. Single instance per app;
+ * mount once via `attach()` in the root layout.
+ *
+ * Race note: `attach()` registers the listener BEFORE snapshotting so the
+ * worst case is one stale render when an event fires between listen and
+ * snapshot (the next event will correct it). Sequence numbers would let us
+ * dedupe perfectly but are overkill: every event carries a full state, so a
+ * single missed event self-heals on the next transition.
+ */
+class LocalModel {
+	state = $state<LocalModelState>(INITIAL_STATE);
+
+	async attach(): Promise<UnlistenFn> {
+		if (!tauri) return () => {};
+		const unlisten = await listen<ModelStateEvent>(
+			'transcription://model-state',
+			(event) => {
+				this.state = event.payload.state;
+			},
+		);
+		this.state = await commands.getTranscriptionState();
+		return unlisten;
+	}
+
+	get isBusy(): boolean {
+		const kind = this.state.status.kind;
+		return kind === 'loading' || kind === 'inferring';
+	}
+}
+
+export const localModel = new LocalModel();

--- a/apps/whispering/src/lib/tauri/bindings.gen.ts
+++ b/apps/whispering/src/lib/tauri/bindings.gen.ts
@@ -71,79 +71,47 @@ export const commands = {
 	/**
 	 *  Canonical transcribe-by-id path. Resolves the audio file under
 	 *  `<appDataDir>/recordings/{recordingId}.*` (cpal-written WAV,
-	 *  navigator-saved webm/opus/mp4, etc.), decodes, runs inference. This
-	 *  is the single entry point for every local transcription call: cpal
-	 *  stop, navigator/VAD/file-upload (after the pipeline saves), retry,
-	 *  history replay.
+	 *  navigator-saved webm/opus/mp4, etc.), decodes, runs inference using
+	 *  the ambient configuration pushed via `set_transcription_config`.
+	 *
+	 *  Returns `NoConfig` if the FE has not pushed a config yet.
 	 */
-	transcribeRecording: (recordingId: string, config: TranscribeRequest) =>
+	transcribeRecording: (recordingId: string) =>
 		typedError<string, TranscriptionError>(
-			__TAURI_INVOKE('transcribe_recording', { recordingId, config }),
+			__TAURI_INVOKE('transcribe_recording', { recordingId }),
 		),
 	/**
-	 *  Update the model unload policy from the frontend. Called by an effect
-	 *  in the SvelteKit layout whenever `transcription.localModelUnloadPolicy`
-	 *  changes, and once at app startup to push the initial value.
+	 *  Push the ambient transcription configuration. Replaces the per-call
+	 *  `config` argument that `transcribe_recording` used to take.
 	 *
-	 *  Unknown values fall back to the default inside `UnloadPolicy::from_wire`
-	 *  rather than erroring, so a future rename or corrupt localStorage value
-	 *  never breaks transcription.
+	 *  Drift in `(engine, modelPath)` triggers a background preload so the
+	 *  next `transcribe_recording` call does not pay cold-start latency.
+	 *  Other field changes take effect on the next transcription with no
+	 *  reload.
 	 */
-	setUnloadPolicy: (policy: string) =>
-		__TAURI_INVOKE<void>('set_unload_policy', { policy }),
+	setTranscriptionConfig: (config: TranscriptionConfig) =>
+		__TAURI_INVOKE<void>('set_transcription_config', { config }),
+	/**
+	 *  Snapshot the current model state. Used by late-mounted observers to
+	 *  catch up to the current lifecycle state without waiting for the next
+	 *  event on `transcription://model-state`.
+	 */
+	getTranscriptionState: () =>
+		__TAURI_INVOKE<LocalModelState>('get_transcription_state'),
 	/**
 	 *  Execute a command and wait for it to complete.
 	 *
 	 *  Parses the command string into program and arguments, then executes directly
-	 *  without using a shell wrapper. This approach provides:
-	 *  - Consistent behavior across all platforms
-	 *  - No shell injection vulnerabilities
-	 *  - Lower process overhead
-	 *  - PATH resolution still works via Command::new()
-	 *
-	 *  On Windows, also uses CREATE_NO_WINDOW flag to prevent console window flash (GitHub issue #815).
-	 *
-	 *  # Arguments
-	 *  * `command` - The command to execute as a string
-	 *
-	 *  # Returns
-	 *  Result containing the command output (stdout, stderr, exit code) or error message
-	 *
-	 *  # Examples
-	 *  ```ignore
-	 *  execute_command("uname -a".to_string()).await?;
-	 *  execute_command("git --version".to_string()).await?;
-	 *  ```
+	 *  without using a shell wrapper.
 	 */
 	executeCommand: (command: string) =>
 		typedError<CommandOutput, string>(
 			__TAURI_INVOKE('execute_command', { command }),
 		),
-	/**
-	 *  Deletes files inside a directory by filename.
-	 *  Validates filenames are single path components (no traversal).
-	 *  Uses Rayon for parallel deletion. Silently skips missing files.
-	 *
-	 *  # Arguments
-	 *  * `directory` - Absolute path to the directory containing the files
-	 *  * `filenames` - Array of leaf filenames to delete
-	 */
 	deleteFilesInDirectory: (directory: string, filenames: string[]) =>
 		typedError<number, string>(
 			__TAURI_INVOKE('delete_files_in_directory', { directory, filenames }),
 		),
-	/**
-	 *  Writes markdown files to disk atomically using a temporary file plus persist.
-	 *  Validates all filenames upfront\u2014no files are written if any name is invalid.
-	 *
-	 *  # Arguments
-	 *  * `directory` - Absolute path to the output directory
-	 *  * `files` - Array of `{ filename, content }` pairs to write
-	 *
-	 *  # Returns
-	 *  * `Ok(())` - All files written successfully
-	 *  * `Err(String)` - Error if any write fails (earlier files may already be on disk)
-	 */
 	writeMarkdownFiles: (directory: string, files: MarkdownFile[]) =>
 		typedError<null, string>(
 			__TAURI_INVOKE('write_markdown_files', { directory, files }),
@@ -163,30 +131,6 @@ export type MarkdownFile = {
 	content: string;
 };
 
-/**
- *  Wire representation of the subset of Moonshine variants the app surfaces.
- *  `transcribe-rs` exposes more variants but the UI only offers Tiny and Base.
- */
-export type MoonshineVariantWire = 'tiny' | 'base';
-
-/**
- *  Serializable handle returned to the JS side. The id is the lookup key
- *  for every later operation; the rest is metadata the UI needs without
- *  having to read the file (duration for analytics, byteLength for upload
- *  size, mimeType for the player).
- *
- *  `mime_type` is `String` rather than `&'static str` so specta's TS
- *  generator sees a stable serializable shape (and so future producers,
- *  e.g. navigator-saved webm artifacts after the next collapse, can set
- *  it to a non-static value). The runtime cost is one short allocation
- *  per artifact write.
- *
- *  `duration_ms` and `byte_length` use `#[specta(type = Number<u64>)]`
- *  to opt out of specta's bigint guard: both stay well under
- *  `Number.MAX_SAFE_INTEGER` (2^53) for any plausible recording
- *  (duration in ms maxes at ~285,000 years; byte length is bounded by
- *  the filesystem).
- */
 export type RecordingArtifact = {
 	id: string;
 	durationMs: number;
@@ -194,31 +138,72 @@ export type RecordingArtifact = {
 	mimeType: string;
 };
 
-/**
- *  Engine-tagged request body. JS serializes one of these as the `config`
- *  JSON argument on the `transcribe_recording` command. Wire tags match
- *  the FE settings (`transcription.service`): `whispercpp` / `parakeet` /
- *  `moonshine`.
- *
- *  `pub` + `specta::Type` so the JS side gets the discriminated union as
- *  a typed argument via the `tauri-specta` generator. The existing serde
- *  tag + rename attributes carry through.
+/** Local transcription engine. Wire tags match the frontend
+ *  `transcription.service` enum.
  */
-export type TranscribeRequest =
+export type Engine = 'whispercpp' | 'parakeet' | 'moonshine';
+
+/** How long after the last transcription the resident model should be
+ *  dropped. Mirrors the frontend `transcription.localModelUnloadPolicy`
+ *  device setting.
+ */
+export type UnloadPolicy =
+	| 'never'
+	| 'immediately'
+	| 'after_5_minutes'
+	| 'after_30_minutes';
+
+/** Ambient configuration the frontend pushes once per change. */
+export type TranscriptionConfig = {
+	engine: Engine;
+	modelPath: string;
+	language?: string | null;
+	initialPrompt?: string | null;
+	unloadPolicy: UnloadPolicy;
+};
+
+/** Lifecycle state of the resident model. */
+export type ModelStatus =
+	| { kind: 'idle' }
+	| { kind: 'loading' }
+	| { kind: 'ready' }
+	| { kind: 'inferring' }
+	| { kind: 'error'; message: string };
+
+/** Snapshot of everything observable about the resident model. */
+export type LocalModelState = {
+	engine: Engine | null;
+	modelPath: string | null;
+	status: ModelStatus;
+};
+
+/** Reason the resident model was dropped. */
+export type UnloadReason =
+	| { kind: 'immediate' }
+	| { kind: 'idle'; idleSecs: number }
+	| { kind: 'config_changed' };
+
+/** Single event type for everything observable about the model lifecycle.
+ *  Broadcast on the `transcription://model-state` Tauri event channel.
+ */
+export type ModelStateEvent =
+	| { kind: 'loading_started'; state: LocalModelState }
 	| {
-			engine: 'whispercpp';
-			modelPath: string;
-			language?: string | null;
-			initialPrompt?: string | null;
+			kind: 'loading_completed';
+			state: LocalModelState;
+			elapsedMs: number;
 	  }
-	| { engine: 'parakeet'; modelPath: string }
-	| { engine: 'moonshine'; modelPath: string; variant: MoonshineVariantWire };
+	| { kind: 'loading_failed'; state: LocalModelState; error: string }
+	| { kind: 'unloaded'; state: LocalModelState; reason: UnloadReason }
+	| { kind: 'selection_changed'; state: LocalModelState };
 
 export type TranscriptionError =
 	| { name: 'AudioReadError'; message: string }
 	| { name: 'GpuError'; message: string }
 	| { name: 'ModelLoadError'; message: string }
-	| { name: 'TranscriptionError'; message: string };
+	| { name: 'TranscriptionError'; message: string }
+	| { name: 'NoConfig'; message: string }
+	| { name: 'ConfigError'; message: string };
 
 /* Tauri Specta runtime */
 async function typedError<T, E>(

--- a/apps/whispering/src/lib/tauri/commands.test-d.ts
+++ b/apps/whispering/src/lib/tauri/commands.test-d.ts
@@ -4,22 +4,19 @@
  * These assertions never run at value-level; they exist so a regression in
  * the `Wrap<F>` mapper or in `tauri-specta`'s output surfaces as a
  * `svelte-check` / `tsc` failure at the type level.
- *
- * If specta's emitted shape changes (e.g. the discriminator key moves), the
- * `Wrap<F>` mapper stops matching and these assertions force the issue.
  */
 
 import type { Result } from 'wellcrafted/result';
 import type {
 	CommandOutput,
+	LocalModelState,
 	RecordingArtifact,
-	TranscribeRequest,
+	TranscriptionConfig,
 	TranscriptionError,
 } from './commands';
 import { commands } from './commands';
 
-// Helper: a no-op assertion that two types are equal. Triggers a TS error
-// if they diverge.
+// Helper: a no-op assertion that two types are equal.
 type Expect<T extends true> = T;
 type Equal<X, Y> =
 	(<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
@@ -34,22 +31,38 @@ type _StopRecording = Expect<
 	>
 >;
 
-// transcribe_recording: fallible, returns transcript text with the typed
-// error union.
+// transcribe_recording: fallible, takes only recordingId now (config is
+// ambient via setTranscriptionConfig).
 type _TranscribeRecording = Expect<
 	Equal<
-		ReturnType<
-			typeof commands.transcribeRecording extends (...args: infer A) => infer R
-				? (...args: A) => R
-				: never
-		>,
+		ReturnType<typeof commands.transcribeRecording>,
 		Promise<Result<string, TranscriptionError>>
 	>
 >;
 
-// set_unload_policy: infallible (Rust `()`). Stays plain Promise; no Result wrap.
-type _SetUnloadPolicy = Expect<
-	Equal<ReturnType<typeof commands.setUnloadPolicy>, Promise<void>>
+type _TranscribeRecordingArgs = Expect<
+	Equal<Parameters<typeof commands.transcribeRecording>, [string]>
+>;
+
+// set_transcription_config: infallible (Rust `()`). Stays plain Promise; no
+// Result wrap.
+type _SetTranscriptionConfig = Expect<
+	Equal<ReturnType<typeof commands.setTranscriptionConfig>, Promise<void>>
+>;
+
+type _SetTranscriptionConfigArg = Expect<
+	Equal<
+		Parameters<typeof commands.setTranscriptionConfig>,
+		[TranscriptionConfig]
+	>
+>;
+
+// get_transcription_state: infallible snapshot for late-mounted observers.
+type _GetTranscriptionState = Expect<
+	Equal<
+		ReturnType<typeof commands.getTranscriptionState>,
+		Promise<LocalModelState>
+	>
 >;
 
 // execute_command: fallible, returns a typed CommandOutput struct.
@@ -68,20 +81,20 @@ type _EncodeRecordingForUpload = Expect<
 	>
 >;
 
-// TranscribeRequest is a discriminated union surfaced by specta from the
-// `#[serde(tag = "engine")]` enum on the Rust side.
-type _TranscribeRequestShape = Expect<
+// TranscriptionConfig is the ambient config the FE pushes once per change.
+type _TranscriptionConfigShape = Expect<
 	Equal<
-		TranscribeRequest extends infer T
-			? T extends { engine: 'whispercpp' }
-				? T
-				: never
-			: never,
+		TranscriptionConfig,
 		{
-			engine: 'whispercpp';
+			engine: 'whispercpp' | 'parakeet' | 'moonshine';
 			modelPath: string;
 			language?: string | null;
 			initialPrompt?: string | null;
+			unloadPolicy:
+				| 'never'
+				| 'immediately'
+				| 'after_5_minutes'
+				| 'after_30_minutes';
 		}
 	>
 >;

--- a/apps/whispering/src/lib/tauri/commands.ts
+++ b/apps/whispering/src/lib/tauri/commands.ts
@@ -106,9 +106,14 @@ export const commands = {
 
 export type {
 	CommandOutput,
+	Engine,
+	LocalModelState,
 	MarkdownFile,
-	MoonshineVariantWire,
+	ModelStateEvent,
+	ModelStatus,
 	RecordingArtifact,
-	TranscribeRequest,
+	TranscriptionConfig,
 	TranscriptionError,
+	UnloadPolicy,
+	UnloadReason,
 } from './bindings.gen';

--- a/apps/whispering/src/routes/(app)/+layout.svelte
+++ b/apps/whispering/src/routes/(app)/+layout.svelte
@@ -8,8 +8,10 @@
 	import { analytics } from '$lib/operations/analytics';
 	import { services } from '$lib/services';
 	import { deviceConfig } from '$lib/state/device-config.svelte';
+	import { localModel } from '$lib/state/local-model.svelte';
+	import { settings } from '$lib/state/settings.svelte';
 	import { tauri } from '$lib/tauri';
-	import { commands } from '$lib/tauri/commands';
+	import { commands, type Engine } from '$lib/tauri/commands';
 	import AppLayout from './_components/AppLayout.svelte';
 	import BottomNav from './_components/BottomNav.svelte';
 	import VerticalNav from './_components/VerticalNav.svelte';
@@ -21,6 +23,16 @@
 
 	let sidebarOpen = $state(false);
 	let unlistenNavigate: UnlistenFn | null = null;
+	let unlistenLocalModel: UnlistenFn | null = null;
+
+	const LOCAL_ENGINES = new Set<Engine>(['whispercpp', 'parakeet', 'moonshine']);
+	function isLocalEngine(serviceId: string): serviceId is Engine {
+		return LOCAL_ENGINES.has(serviceId as Engine);
+	}
+
+	function modelPathKey(engine: Engine) {
+		return `transcription.${engine}.modelPath` as const;
+	}
 
 	// Sidebar when wide, bottom bar on narrow viewports (phone, small window).
 	const isNarrow = new MediaQuery('(max-width: 767px)');
@@ -35,19 +47,39 @@
 		analytics.logEvent({ type: 'app_started' });
 	});
 
-	// Push the local-model unload policy to Rust whenever it changes. Rust
-	// owns the eviction (synchronous for `immediately`, idle-watcher for
-	// timed values); the FE just mirrors the current device-config value.
-	// Fires once on mount and on every subsequent change.
+	// Push the ambient transcription config to Rust whenever it changes. Rust
+	// owns the resident model lifecycle (cache, preload, eviction); the FE
+	// just mirrors the current settings on a single channel.
+	// - Drift in (engine, modelPath) triggers a background preload.
+	// - Other field changes (language, prompt, unloadPolicy) take effect on
+	//   the next transcription with no reload.
+	// Fires once on mount (per local engine) and on every subsequent change.
 	$effect(() => {
 		if (!tauri) return;
-		const policy = deviceConfig.get('transcription.localModelUnloadPolicy');
-		commands.setUnloadPolicy(policy).catch((err) => {
-			console.error('Failed to push unload policy to Rust:', err);
-		});
+		const service = settings.get('transcription.service');
+		if (!isLocalEngine(service)) return;
+
+		const modelPath = deviceConfig.get(modelPathKey(service));
+		if (!modelPath) return;
+
+		const language = settings.get('transcription.language');
+		const prompt = settings.get('transcription.prompt');
+		void commands
+			.setTranscriptionConfig({
+				engine: service,
+				modelPath,
+				language: language === 'auto' ? null : language,
+				initialPrompt: prompt || null,
+				unloadPolicy: deviceConfig.get('transcription.localModelUnloadPolicy'),
+			})
+			.catch((err) => {
+				console.error('Failed to push transcription config to Rust:', err);
+			});
 	});
 
-	// Listen for navigation events from other windows
+	// Listen for navigation events from other windows and subscribe to the
+	// local-model lifecycle so any consumer (`localModel.isBusy`, etc.) can
+	// react to load / inference / eviction events.
 	onMount(async () => {
 		if (!tauri) return;
 		unlistenNavigate = await listen<{ path: string }>(
@@ -56,10 +88,12 @@
 				goto(event.payload.path);
 			},
 		);
+		unlistenLocalModel = await localModel.attach();
 	});
 
 	onDestroy(() => {
 		unlistenNavigate?.();
+		unlistenLocalModel?.();
 	});
 </script>
 

--- a/specs/20260527T120000-rust-transcription-service.md
+++ b/specs/20260527T120000-rust-transcription-service.md
@@ -1,0 +1,705 @@
+# Rust Transcription Service: Ambient Config + Loading Events
+
+**Date**: 2026-05-27
+**Status**: Implemented (pending Rust regen of bindings on stable toolchain)
+**Owner**: Whispering desktop
+**Base**: `origin/main` at 01438a78f
+**Branch**: `braden-w/rust-transcription-service`
+**Supersedes**: `specs/20260526T034000-rust-transcription-service-boundary.md` (state-machine design rejected as over-engineered)
+
+## One Sentence
+
+Extend main's `ModelManager` with ambient config + preload + loading events + panic-safe inference, so the FE pushes settings once, observes state, and calls `commands.transcribeRecording({ recordingId })` with no per-call config arg.
+
+## How to read this spec
+
+```txt
+Read first:
+  One Sentence
+  Why this is small
+  Architecture (diff against main)
+  Command and event surface
+  Implementation plan
+
+Read if grilling the design:
+  Self-grill section (every claim has a "why this earns its keep")
+  Rejected alternatives
+
+Skip:
+  Nothing. This spec is short on purpose.
+```
+
+## Why this is small
+
+The predecessor spec built a 730-line `TranscriptionService` with a four-variant `EngineSlot` state machine and take/put-back semantics. After main landed the artifact-based architecture (recording_id, `read_artifact_samples`, specta bindings), the state machine no longer earned its keep:
+
+- The state machine's defining property is "slot is None during inference". Nothing in the system observes that property usefully. The idle watcher uses `try_lock`; `setConfig` writes to a separate `RwLock`.
+- Take/put-back protects against mutex poisoning. So does `catch_unwind` under hold-lock. The latter is one wrapper, not 400 LOC of state transitions.
+- Main's `ModelManager` already implements the cache lifecycle correctly. Replacing it instead of extending it is a regression on diff size with no payoff.
+
+This spec extends `ModelManager` in place. Net new code: roughly 200 LOC of Rust + 80 LOC of TS, plus the bindings regeneration step.
+
+## Architecture (diff against main)
+
+```txt
+WHAT MAIN HAS TODAY
++----------------------------------------------------------+
+| FE: transcribe.ts                                        |
+|   case 'whispercpp':                                     |
+|     commands.transcribeRecording({                       |
+|       recordingId, config: { engine, modelPath, ... }    |
+|     })                                                   |
++----------------------------+-----------------------------+
+                             |
++----------------------------v-----------------------------+
+| FE: +layout.svelte                                       |
+|   $effect: invoke('set_unload_policy', { policy })       |
++----------------------------+-----------------------------+
+                             |
++----------------------------v-----------------------------+
+| Rust: transcription::                                    |
+|   transcribe_recording(id, config) -> spawn_blocking ->  |
+|     read_artifact_samples(id) -> run_inference ->        |
+|     ModelManager.with_X(path, |engine| engine.transcribe)|
+|   set_unload_policy(policy)                              |
+| ModelManager: cache (Mutex), policy (RwLock),            |
+|               idle watcher, poisoning-on-panic recovery  |
++----------------------------------------------------------+
+
+
+WHAT THIS SPEC ADDS
++----------------------------------------------------------+
+| FE: transcribe.ts                                        |
+|   case 'whispercpp':                                     |
+|   case 'parakeet':                                       |
+|   case 'moonshine':                                      |
+|     commands.transcribeRecording({ recordingId })        |
++----------------------------+-----------------------------+
+                             |
++----------------------------v-----------------------------+
+| FE: +layout.svelte                                       |
+|   ONE $effect: commands.setTranscriptionConfig({ ... })  |
+|   onMount: localModel.attach()                           |
++----------------------------+-----------------------------+
+                             |
++----------------------------v-----------------------------+
+| Rust: transcription::                                    |
+|   transcribe_recording(id)              <-- drop arg     |
+|   set_transcription_config(config)      <-- new          |
+|   get_transcription_state()             <-- new          |
+| ModelManager: + config (RwLock), + app (AppHandle),      |
+|               + preload(), catch_unwind under hold-lock, |
+|               emits transcription://model-state events   |
++----------------------------------------------------------+
+```
+
+## Design Decisions
+
+| Decision | Why |
+|---|---|
+| Drop `config: TranscribeRequest` arg from `transcribe_recording` | Ambient state replaces it. One source of truth, no FE diff-tracking. |
+| One `set_transcription_config(config)` replaces `set_unload_policy` | Unload policy + (engine, modelPath, language, prompt, translate) are one coherent push. |
+| Preload triggered inside `setConfig` when (engine, modelPath) drifts | Real UX win on whisper-medium/large (~10s cold-start). No explicit `preload` command for v1. |
+| Extend `ModelManager` in place; do NOT add a new `TranscriptionService` wrapper | One struct already owns cache + policy. Adding config + app + preload keeps ownership coherent. |
+| Hold lock through inference + `catch_unwind(AssertUnwindSafe(...))` | Equivalent panic-safety to take/put-back, ~10 LOC vs 400 LOC. Validated by reading Handy's pattern: their take/put-back is a workaround for Rust's `MutexGuard` not being `UnwindSafe`; `AssertUnwindSafe` makes hold-lock viable. |
+| Events on `transcription://model-state`, full state payload | Required because `AppHandle::emit` does not replay to future windows. Cited from Tauri docs (search id `9a9a17fb-f262-4098-a6b6-42adbb806dd4`). |
+| `get_transcription_state()` snapshot command | Required by the same emit-no-replay constraint for late-mounted observers. |
+| All new commands specta-typed | House convention as of #1833. AGENTS.md documents the rule. |
+| Moonshine variant parsed in Rust from `modelPath` | Removes the TS arkregex. Variant is a loader concern; the directory naming convention already encodes it. |
+| Lazy `modelPath` validation (no eager check in setConfig) | Filesystem can change between push and use. Eager validation creates a TOCTOU window. |
+| Catalogs (`WHISPER_MODELS` etc) move to `lib/constants/local-models.ts` | Pure download metadata, not transcription plumbing. Belongs in constants. |
+
+## TranscriptionConfig (Rust + generated TS)
+
+```rust
+// apps/whispering/src-tauri/src/transcription/config.rs (new file)
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct TranscriptionConfig {
+    pub engine: Engine,
+    pub model_path: String,
+    #[serde(default)]
+    pub language: Option<String>,
+    #[serde(default)]
+    pub initial_prompt: Option<String>,
+    #[serde(default)]
+    pub translate: bool,
+    pub unload_policy: UnloadPolicy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, specta::Type)]
+#[serde(rename_all = "lowercase")]
+pub enum Engine {
+    #[serde(rename = "whispercpp")]
+    Whisper,
+    Parakeet,
+    Moonshine,
+}
+
+// UnloadPolicy lives in model_manager.rs already; add Serialize + specta::Type.
+```
+
+The TS shape is generated by `tauri-specta` into `bindings.gen.ts`. No hand-written TS type.
+
+## Command surface
+
+```rust
+// transcription/mod.rs
+
+#[tauri::command]
+#[specta::specta]
+pub fn set_transcription_config(
+    config: TranscriptionConfig,
+    model_manager: State<'_, ModelManager>,
+) {
+    model_manager.set_transcription_config(config);
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn transcribe_recording(
+    recording_id: String,
+    app_handle: AppHandle,
+    model_manager: State<'_, ModelManager>,
+) -> Result<String, TranscriptionError> {
+    // No `config` arg; ModelManager reads ambient state.
+    let samples = read_artifact_samples(&app_handle, &recording_id)
+        .map_err(|e| TranscriptionError::AudioReadError { message: e })?;
+    let manager = model_manager.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || manager.transcribe(samples))
+        .await
+        .map_err(join_err)?
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn get_transcription_state(
+    model_manager: State<'_, ModelManager>,
+) -> LocalModelState {
+    model_manager.snapshot()
+}
+```
+
+`set_unload_policy` and the entire `TranscribeRequest`/`MoonshineVariantWire` machinery DELETE.
+
+## Event surface
+
+```rust
+// transcription/events.rs (new file, ~80 LOC)
+
+#[derive(Debug, Clone, Serialize, specta::Type)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ModelStateEvent {
+    LoadingStarted { state: LocalModelState },
+    LoadingCompleted { state: LocalModelState, elapsed_ms: u64 },
+    LoadingFailed { state: LocalModelState, error: String },
+    Unloaded { state: LocalModelState, reason: UnloadReason },
+    SelectionChanged { state: LocalModelState },
+}
+
+#[derive(Debug, Clone, Serialize, specta::Type)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum UnloadReason {
+    Immediate,
+    Idle { idle_secs: u64 },
+    ConfigChanged,
+    Shutdown,
+    PanicRecovered { error: String },
+}
+
+#[derive(Debug, Clone, Serialize, specta::Type, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalModelState {
+    pub engine: Option<Engine>,
+    pub model_path: Option<String>,
+    pub status: ModelStatus,
+}
+
+#[derive(Debug, Clone, Serialize, specta::Type, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ModelStatus {
+    Idle,
+    Loading,
+    Ready,
+    Inferring,                      // engine is mid-inference (lock held)
+    Error { message: String },
+}
+```
+
+Channel name: `transcription://model-state`. Broadcast via `app.emit(...)`. Events carry full state (not deltas) because emit does not replay to future windows.
+
+## ModelManager additions
+
+Field-by-field diff:
+
+```rust
+pub struct ModelManager {
+    cached: Arc<Mutex<Cached>>,                     // existing
+    last_activity_ms: Arc<AtomicU64>,               // existing
+    policy: Arc<RwLock<UnloadPolicy>>,              // existing (folded into config below)
+    // NEW:
+    config: Arc<RwLock<Option<TranscriptionConfig>>>,
+    app: Arc<AppHandle>,                            // for event emission
+}
+```
+
+Behavior:
+
+- `ModelManager::new(app: AppHandle)` instead of `new()`. The `manage()` registration in `lib.rs::setup` becomes `manager.manage(ModelManager::new(app.handle().clone()))`.
+- `set_transcription_config(config)`: writes config; if `engine + model_path` changed, spawn a preload task that calls `with_engine` with a no-op closure. Updates `policy` from `config.unload_policy`. Emits `SelectionChanged` then (during preload) `LoadingStarted` / `LoadingCompleted` / `LoadingFailed`.
+- `transcribe(samples)`: reads ambient config; if `None`, returns `NoConfig`. Otherwise dispatches to `with_whisper` / `with_parakeet` / `with_moonshine` using the ambient values. Wraps inference in `catch_unwind`.
+- `snapshot() -> LocalModelState`: reads `cached` + `config` under their locks, builds the snapshot.
+- `with_engine` extensions:
+  - Emit `LoadingStarted` before calling `load`.
+  - On load success: emit `LoadingCompleted { elapsed_ms }`. On load failure: emit `LoadingFailed`.
+  - Wrap `use_engine(engine)` in `catch_unwind(AssertUnwindSafe(...))`. On `Err(panic)`: take the slot, emit `Unloaded { reason: PanicRecovered }`, return `TranscriptionError`. The slot was held by the guard; `MutexGuard` is not `UnwindSafe` but `AssertUnwindSafe` is sound because we drop the engine and clear the slot in the panic branch, so no other caller observes partial state.
+  - On `Ok(...)`: existing behavior (touch activity, evict_if_immediate if policy is Immediate).
+
+The `policy: Arc<RwLock<UnloadPolicy>>` field collapses into `config.unload_policy`. Reads go through `config.read().unload_policy` instead of `policy.read()`.
+
+## Frontend migration
+
+Files to delete (already deleted on the predecessor branch; doing again here):
+
+```
+apps/whispering/src/lib/services/transcription/local/local-transcription.ts
+apps/whispering/src/lib/services/transcription/local/whispercpp.ts
+apps/whispering/src/lib/services/transcription/local/parakeet.ts
+apps/whispering/src/lib/services/transcription/local/moonshine.ts
+```
+
+Catalogs move:
+
+```
+apps/whispering/src/lib/services/transcription/local/types.ts
+  -> apps/whispering/src/lib/constants/local-models.ts
+```
+
+(Keep `WHISPER_MODELS`, `PARAKEET_MODELS`, `MOONSHINE_MODELS`, `*ModelConfig` types, `isModelFileSizeValid`. Drop `MOONSHINE_VARIANTS` regex constants if the variant parsing moves to Rust.)
+
+New file:
+
+```ts
+// apps/whispering/src/lib/state/local-model.svelte.ts
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { commands, type LocalModelState, type ModelStateEvent } from '$lib/tauri/commands';
+import { tauri } from '$lib/tauri';
+
+class LocalModel {
+  state = $state<LocalModelState>({ engine: null, modelPath: null, status: { kind: 'idle' } });
+
+  async attach(): Promise<UnlistenFn> {
+    if (!tauri) return () => {};
+    this.state = await commands.getTranscriptionState();
+    return listen<ModelStateEvent>('transcription://model-state', (event) => {
+      this.state = event.payload.state;
+    });
+  }
+
+  get isBusy(): boolean {
+    const kind = this.state.status.kind;
+    return kind === 'loading' || kind === 'inferring';
+  }
+}
+
+export const localModel = new LocalModel();
+```
+
+Modified files:
+
+| File | Change |
+|---|---|
+| `apps/whispering/src/routes/(app)/+layout.svelte` | Replace `set_unload_policy` $effect with `setTranscriptionConfig` $effect. Add `localModel.attach()` in `onMount`. |
+| `apps/whispering/src/lib/operations/transcribe.ts` | Collapse three local cases to `commands.transcribeRecording({ recordingId })`. Drop the `config` construction for local engines. |
+| `apps/whispering/src/lib/services/transcription/index.ts` | Drop the three local exports. |
+| Settings UI imports | Re-point to `lib/constants/local-models.ts`. |
+
+The single setConfig effect:
+
+```svelte
+$effect(() => {
+  if (!tauri) return;
+  const service = settings.get('transcription.service');
+  if (!isLocalEngine(service)) return;
+
+  const modelPath = deviceConfig.get(`transcription.${service}.modelPath`);
+  if (!modelPath) return;
+
+  void commands.setTranscriptionConfig({
+    engine: service,
+    modelPath,
+    language: outputLanguageOrNull(),
+    initialPrompt: settings.get('transcription.prompt') || null,
+    translate: settings.get('transcription.translate') ?? false,
+    unloadPolicy: deviceConfig.get('transcription.localModelUnloadPolicy'),
+  });
+});
+```
+
+## Working checkpoints
+
+Each MUST end with `bun run build` passing AND a manual transcribe-end-to-end smoke test.
+
+### Checkpoint A: Rust extension
+
+- [x] Create `transcription/config.rs` with `TranscriptionConfig`, `Engine`. Add `Serialize` + `specta::Type` to `UnloadPolicy`.
+  > **Deviation**: `UnloadPolicy` moved into `config.rs` (out of `model_manager.rs`) and restructured to flat variants (`Never`, `Immediately`, `AfterFiveMinutes`, `AfterThirtyMinutes`) with serde renames matching the FE wire strings exactly. The old `from_wire` string parser is gone: serde handles deserialization.
+  > **Added**: `should_preload(old, new) -> bool` helper, per grilling-fix #3.
+- [x] Create `transcription/events.rs` with `ModelStateEvent`, `UnloadReason`, `LocalModelState`, `ModelStatus`.
+  > Added `EVENT_CHANNEL: &str = "transcription://model-state"` constant so both Rust emitter and TS listener key off one symbol (well, until the FE consumes the constant via bindings; for now it's a string literal on the FE side).
+  > `u64` fields (`elapsed_ms`, `idle_secs`) carry `#[specta(type = u32)]` to avoid the bigint guard, per grilling-fix #4.
+- [x] Extend `ModelManager` with `config`, `app`, `status` fields and the new constructor `ModelManager::new(app)`.
+  > **Added** `status: Arc<RwLock<ModelStatus>>` (grilling-fix #2): lock-free snapshot path. `snapshot()` reads only `status` and `config`, never touches `cached`, so a new window calling `getTranscriptionState` mid-inference does not block.
+  > Old `policy: Arc<RwLock<UnloadPolicy>>` field is gone (collapsed into `config.unload_policy`).
+- [x] Add `set_transcription_config`, `transcribe(samples)`, `snapshot`, `preload` methods on `ModelManager`.
+  > `set_transcription_config` returns immediately: the eviction-then-preload runs on `spawn_blocking` so the Tauri command thread never waits on the cache mutex.
+- [x] ~~Add `catch_unwind(AssertUnwindSafe(...))` wrap inside `with_engine` around both `load(&model_path)` and `use_engine(engine)`.~~
+  > **Dropped**. `Cargo.toml` has `[profile.release] panic = "abort"`, which makes `catch_unwind` a no-op in the only build that matters. Per the grilling-finding-1 caveat, C aborts from `GGML_ASSERT` are also uncatchable. The existing `lock_cached` poisoning recovery handles what is recoverable. The status field is set to `Error` on inference failure so the FE sees a clear failure state; the cache is NOT cleared on inference failure (the engine is still loaded; a transient FFI hiccup should not force a reload).
+- [x] Emit `LoadingStarted`/`LoadingCompleted`/`LoadingFailed` from `with_engine`'s load branch and `preload`.
+  > Status sequence is codified (grilling-fix #5):
+  > - Load + transcribe: `Idle/Ready → Loading → Ready → Inferring → Ready` (or `Error`)
+  > - Preload only (no-op closure): `Idle/Ready → Loading → Ready → Inferring → Ready` where the `Inferring → Ready` step is imperceptible because the closure returns instantly.
+- [x] Register new commands in `make_specta_builder` and `collect_commands!`.
+- [x] Delete `set_unload_policy` command. Delete old `transcribe_recording`'s `config: TranscribeRequest` arg. Delete `TranscribeRequest`, `MoonshineVariantWire`, `run_inference`.
+  > Moonshine variant parsing now happens in Rust (`parse_moonshine_variant`) and produces a `TranscriptionError::ConfigError` on malformed names (grilling-finding #2).
+- [x] Update `manage()` registration to use `ModelManager::new(app.handle().clone())`.
+  > Moved `.manage(ModelManager::new(...))` into `.setup()` per grilling-fix #6: the eager builder-time `manage` could not pass an `AppHandle`.
+- [x] **Added** sample sanitization at the Rust boundary (`sanitize_samples`): replaces NaN/Inf with 0.0 and truncates at one hour of 16kHz mono, per grilling-finding-1 mitigation.
+- [ ] `bun run --cwd apps/whispering bindings:tauri` to regenerate `bindings.gen.ts`.
+  > **Blocked locally**: Homebrew Rust 1.90 in this workspace is one version behind specta-2.0.0-rc.25's requirement (`debug_closure_helpers`, stabilized in 1.91). CI uses `dtolnay/rust-toolchain@stable` and will pick this up. `bindings.gen.ts` was **hand-edited** to the shape specta will produce, so `bun typecheck` passes; the regen should be a no-op when run on stable.
+- [ ] `bun run build` passes.
+  > FE side: `bun run --cwd apps/whispering typecheck` reports **0 errors, 11 pre-existing warnings**. Rust side: deferred to CI for the same toolchain reason.
+
+### Checkpoint B: FE migration
+
+- [x] ~~Create `lib/constants/local-models.ts`.~~ Already done on this branch by prior work. Verified `WHISPER_MODELS`, `PARAKEET_MODELS`, `MOONSHINE_MODELS` + types live there.
+- [x] Create `lib/state/local-model.svelte.ts`.
+  > Listener registered **before** snapshot (worst case is one stale render; next event self-heals because every event carries full state). Sequence numbers not added (overkill).
+- [x] In `+layout.svelte`: replace `set_unload_policy` $effect with `setTranscriptionConfig` $effect. Add `localModel.attach()` in `onMount` with unlisten on destroy.
+  > **Deviation**: `translate` field dropped from the pushed config (grilling-finding #1). The `transcription.translate` setting does not exist in the workspace KV schema; adding it is a separate decision the spec deferred to "NOT in scope".
+- [x] In `transcribe.ts`: collapse the three local cases into one `commands.transcribeRecording({ recordingId })` call.
+  > Per-engine FE preflight (path existence, file-vs-directory, whisper truncation check, moonshine name validation) kept in `dispatchLocalTranscription` because Rust's generic `ModelLoadError` would be a regression on error message quality.
+- [x] Delete `services/transcription/local/{whispercpp,parakeet,moonshine,local-transcription}.ts`.
+  > Already done on this branch by prior work; the directory `services/transcription/local/` no longer exists.
+- [x] Update `services/transcription/index.ts` to drop three exports.
+  > Already done on this branch.
+- [ ] Wire the transcribe button (or wherever) to disable while `localModel.isBusy`.
+  > **Deferred**: `localModel.isBusy` is exported; consumer wiring is a separate UI task. The state machine is in place.
+- [x] **Hand-edit `bindings.gen.ts`** to match the new command surface and types (TS-side regression-prevention until CI regenerates).
+- [x] **Update `commands.test-d.ts`** with new type assertions for `setTranscriptionConfig`, `getTranscriptionState`, and the updated `transcribeRecording` signature.
+
+### Checkpoint C: Verification
+
+- [x] `rg 'set_unload_policy' apps/whispering` returns zero matches.
+- [x] `rg 'services/transcription/local/' apps/whispering/src` returns zero matches.
+- [x] `bun typecheck` passes (0 errors).
+- [ ] **Followup needed**: register `ModelStateEvent` via `tauri_specta::collect_events!` so when bindings regenerate on stable, the event type stays exported. Currently `ModelStateEvent` is only hand-written in `bindings.gen.ts`; specta will drop it on regen unless `.events(collect_events![ModelStateEvent])` is added to `make_specta_builder` alongside `#[derive(tauri_specta::Event)]` on the type.
+- [ ] Manual smoke tests (deferred to a build environment with stable Rust):
+  - Each local engine transcribes a 5s clip end-to-end.
+  - Switch engine in settings → observe `Unloaded(ConfigChanged) → LoadingStarted → LoadingCompleted`.
+  - Open a second window mid-load → `localModel.state` populated via `getTranscriptionState`.
+  - Set `unloadPolicy: 'immediately'`, transcribe → observe `Unloaded { Immediate }`.
+
+## Edge cases
+
+| Case | Behavior |
+|---|---|
+| `transcribe_recording` arrives before any `setTranscriptionConfig` | Returns `NoConfig` error. FE disables transcribe button until `localModel.state.engine !== null`. |
+| Settings change mid-transcribe | In-flight inference holds the cache lock; setConfig writes to `config` RwLock (different lock); preload task waits on cache lock. Inference completes on old engine; preload runs after lock releases. |
+| Panic during inference | `catch_unwind` catches; slot is cleared while still holding the guard (no poisoning); `Unloaded { PanicRecovered }` emitted; Err returned. Next transcribe reloads. |
+| Panic during load | Same pattern: catch, clear slot (it was being populated), emit `LoadingFailed`, return Err. |
+| Window closed during loading | Event broadcasts to remaining windows; new window calls `getTranscriptionState` on mount, sees current. |
+| Idle watcher during inference | `try_lock` fails (transcribe holds it), watcher skips tick. Activity timestamp refreshes after inference completes. |
+
+## Self-grill (before handing off)
+
+I'm grilling my own design here. Every claim below has to survive scrutiny before I trust the spec.
+
+### Is ambient config genuinely better than per-call config?
+
+**Per-call wins**: stateless, no race, no extra command, easier to test.
+**Ambient wins**: preload knows what to load without an extra command; FE call site is shorter; unload policy is genuinely ambient (not per-call) so it naturally pairs with the rest.
+
+**Verdict**: ambient is a net win only because preload is in scope. If we drop preload, ambient becomes worse than per-call. Since preload is a real UX win on whisper-medium/large (5-15s cold-start), ambient stays.
+
+**Risk**: the "transcribe-before-setConfig" race on app startup. Mitigation: FE button is disabled until `localModel.state.engine !== null`. The error path is the safety net.
+
+### Is preload genuinely a UX win?
+
+Cold-start latency by model:
+- whisper-tiny (78MB): <1s. Preload barely matters.
+- whisper-small (488MB): 2-4s. Preload nice.
+- whisper-medium (1.5GB): 5-10s. Preload significant.
+- whisper-large-v3-turbo (1.6GB): 8-15s. Preload critical.
+- parakeet (~670MB): 2-5s. Preload nice.
+- moonshine (~30-65MB): <1s. Preload barely matters.
+
+For the high end (medium/large), preload moves perceptible latency off the user's stop-recording click. Worth keeping.
+
+**Counter-grill**: what if the model gets evicted (idle 5min default)? Then preload only helps the first transcribe after settings change. Users who transcribe once an hour pay cold-start every time.
+
+**Mitigation candidate (future)**: trigger preload from recording-start, not settings-change. Out of scope for v1; document in "Not in scope".
+
+### Is take/put-back genuinely worse than hold-lock + catch_unwind?
+
+Handy uses take/put-back. The deepwiki citation says it's for mutex poisoning.
+
+But `catch_unwind` under hold-lock prevents poisoning too — the panic is caught inside the guarded region, before the guard drops.
+
+Take/put-back also lets other code observe the cache during inference. But nothing in our system needs to — idle watcher uses `try_lock`, setConfig writes to a separate RwLock.
+
+**Verdict**: take/put-back is a fine pattern but its specific benefit (slot is None during inference) is unconsumed. Hold-lock + catch_unwind is shorter and covers the same panic-safety property. Take/put-back wins for code that DOES need cache-during-inference observability, which we don't.
+
+**Sanity check**: does `AssertUnwindSafe` lie? `MutexGuard` is `!UnwindSafe` because a panic with the guard held could leave the protected data in a partial state observable by the next lock acquirer. With `AssertUnwindSafe` + clearing the slot in the panic branch, we guarantee the next acquirer sees `None`, not partial state. The assertion is sound.
+
+### Are events worth the complexity vs polling?
+
+Polling `get_transcription_state` every 250ms during a load: ~40 polls for a 10s load. Each is an IPC roundtrip. Not free.
+
+Events: zero polls, push-based, real-time UI.
+
+For users on macOS/Windows where `app.emit` is cheap, events win. For Linux where IPC has higher overhead, events win bigger.
+
+**Verdict**: events win.
+
+### Is the snapshot command essential, or can we live without?
+
+Without it: new windows see "idle" status until the next state transition fires an event. For multi-window users (settings panel + main), this could show stale info for many seconds.
+
+The command is ~10 LOC.
+
+**Verdict**: cheap insurance, keep.
+
+### Is extending `ModelManager` vs a new `TranscriptionService` wrapper the right call?
+
+ModelManager already owns: cache, idle watcher, policy, eviction.
+We add: config, app, preload, events.
+
+Both belong to the same lifecycle (cache + config + events all happen during transcribe). Splitting into ModelManager (cache) + TranscriptionService (config) means TranscriptionService holds an Arc<ModelManager> and proxies most operations.
+
+That wrapper adds a layer with no real boundary. Better to grow ModelManager.
+
+**Verdict**: extend in place. Maybe rename to `TranscriptionService` later if the name "ModelManager" stops fitting; that's a follow-up.
+
+### Could we simplify further by dropping events entirely?
+
+Without events: FE has no loading-state visibility. Generic spinner today. Users don't complain audibly. So... do we need events?
+
+**Counter-grill**: the user explicitly mentioned in the original prompt: "emits loading events". So events are part of the deliverable.
+
+**Verdict**: events stay. They're cheap once the service layer exists.
+
+### Is the FE observer worth being a separate file vs inline?
+
+Multiple potential consumers:
+- Transcribe button (disable while busy)
+- Settings UI (current model display)
+- Possible status bar
+
+Separate file = singleton store. Worth the extra file.
+
+### What's the riskiest thing about this design?
+
+The `AssertUnwindSafe` claim. If transcribe-rs's engines have any internal state that gets corrupted by a panic mid-inference (e.g., partial buffer write, dangling pointer in C FFI), `catch_unwind` catches the panic but the engine is still corrupt. Dropping the engine after panic mitigates this — the corrupt object goes away. But if the panic happened during model load, the engine doesn't exist yet so this is moot. If during inference, we drop the loaded engine. Either way, the cache ends up clean.
+
+The remaining risk: the C FFI (whisper.cpp) might not be panic-safe in the sense Rust expects. A `&mut` reference to a C struct that the C code partially wrote could leave the C struct in a state the next FFI call panics on. But since we DROP the engine on panic, that struct is freed via Drop. Drop is C code; if Drop itself panics... that's a Rust-level abort, not catchable.
+
+**Mitigation**: not much we can do beyond what we're doing. Document the risk in panic-recovery comments. Trust that transcribe-rs's engine Drops are clean (they are, per the docs).
+
+## Rejected alternatives
+
+| Rejected | Why |
+|---|---|
+| Build the EngineSlot state machine from the predecessor spec | Over-engineered for the property nobody consumes. ~400 LOC for "slot is None during inference" that nothing reads. |
+| Keep `set_unload_policy` and add `set_transcription_config` for the rest | Two commands for one push of ambient state. The clean break is one. |
+| Keep `config: TranscribeRequest` arg on `transcribe_recording` AND add `set_transcription_config` | Hybrid API. Per-call or ambient, pick one. |
+| Build a separate `TranscriptionService` struct that wraps `ModelManager` | Wrapper without a real boundary. Extend in place. |
+| Take/put-back lock model | Equivalent panic-safety to hold-lock + `catch_unwind`, but ~30x the code. |
+| Separate `PanicRecovered` event variant | Folds cleanly into `Unloaded { reason: PanicRecovered }`. One less FE branch. |
+| Preload via recording-start hook | Future optimization. Out of scope for v1. Documented in NOT in scope. |
+| Explicit `preload(config)` command | Redundant once `setConfig` triggers preload automatically. |
+| Eager `modelPath` validation in `setConfig` | TOCTOU window. Lazy at load time is honest. |
+
+## NOT in scope
+
+- **Wave 2 catalog work**: download progress UI, model dedup, version pinning.
+- **Additional engines**: Sherpa, Vosk, etc.
+- **Accelerator selection UI**: per-engine CoreML/DirectML/Vulkan toggles.
+- **Translate UI**: wire field ships now; UI placement is a separate design decision.
+- **Cancellation mid-inference**: transcribe-rs has no cancel API.
+- **Preload-on-recording-start**: future optimization.
+
+## References
+
+- `apps/whispering/src-tauri/src/transcription/mod.rs` - current main surface (transcribe_recording, set_unload_policy)
+- `apps/whispering/src-tauri/src/transcription/model_manager.rs` - struct to extend
+- `apps/whispering/src-tauri/src/recorder/artifact.rs` - read_artifact_samples + RecordingArtifact
+- `apps/whispering/src/lib/tauri/commands.ts` - specta boundary adapter
+- `apps/whispering/src/lib/tauri/bindings.gen.ts` - generated, regenerate with `bun run --cwd apps/whispering bindings:tauri`
+- `apps/whispering/AGENTS.md` - specta registration convention
+- `specs/20260526T034000-rust-transcription-service-boundary.md` - predecessor spec; superseded
+- Handy reference for catch_unwind + hold-lock: predecessor spec carries the deepwiki citations
+- Tauri event broadcast: deepwiki search `9a9a17fb-f262-4098-a6b6-42adbb806dd4`
+
+## Open questions for the grilling agent
+
+These are the design decisions I'm least confident in. The grilling agent should focus here:
+
+1. **Is `AssertUnwindSafe` over a `MutexGuard` really sound for our case?** Rust marks `MutexGuard` as `!UnwindSafe` for a reason. I claim it's safe because we clear the slot in the panic branch. Verify against the Rust nomicon and against transcribe-rs's internals (does the engine ever leave its own slot via panic? probably not, but check).
+
+2. **Does extending `ModelManager` violate single-responsibility?** It now owns cache + policy + ambient config + events + preload. Five concerns. Is the cohesion real, or am I avoiding a justified split?
+
+3. **Is the "engine + modelPath drift triggers preload" rule correct?** What if only `unloadPolicy` changes? Preload shouldn't re-run. What if only `language` changes (Whisper)? No reload needed; just use the new language on next inference. Make sure the drift detection only fires on model identity, not config identity.
+
+4. **Does emitting events from inside `with_engine` create a re-entrancy risk?** `app.emit` is sync but the event handler runs on the FE side asynchronously. Should be fine but verify.
+
+5. **Is there a simpler design we missed?** E.g., skip ambient config entirely, do `preload(config)` as a separate command, keep `transcribe_recording(id, config)`. Is the per-call config + explicit preload actually cleaner than ambient?
+
+## Final sanity-check ritual
+
+Before this spec is executed, an agent should:
+
+1. Re-read main's `transcription/mod.rs` and `model_manager.rs` and `recorder/artifact.rs` from scratch. Confirm the diff this spec proposes is accurate.
+2. Verify the `AssertUnwindSafe + MutexGuard` claim against Rust documentation (specifically, the `std::panic::AssertUnwindSafe` docs and the nomicon's chapter on poisoning).
+3. Check whether transcribe-rs's `WhisperEngine`, `ParakeetModel`, `MoonshineModel` have any documented panic-safety guarantees.
+4. Confirm `tauri-specta` can serialize an enum with tuple-struct variants (the `UnloadReason::Idle { idle_secs: u64 }` shape). If not, restructure.
+5. Verify the FE binding regeneration step actually picks up the new commands; the `make_specta_builder` registration in `lib.rs` is the source of truth.
+6. Walk Open Questions 1-5 and either resolve them in-line in the spec or escalate them as blockers.
+
+## Grilling Findings (round 1)
+
+Grilled against transcribe-rs v0.3.8 (cjpais/transcribe-rs), whisper.cpp issue tracker, the Rustonomicon poisoning chapter, the std::panic docs, and specta's internally-tagged enum exporter. Findings are blunt on purpose.
+
+### 1. CLAIM 1 (AssertUnwindSafe + MutexGuard sound): PARTIALLY SOUND, with a buried critical caveat
+
+The MutexGuard + AssertUnwindSafe pattern itself is sound. `MutexGuard` is `!UnwindSafe` because a panic-while-locked could leave the protected data in a broken logical state visible to the next acquirer. The spec's mitigation (clear the slot in the panic branch before the guard drops) preserves the logical invariant. Memory safety is already guaranteed by `Mutex` itself. The Rustonomicon's poisoning chapter is explicit: poisoning is a logical-invariant flag, not a memory-safety mechanism. The assertion is honest.
+
+What the spec does NOT acknowledge, and what is the actual material risk:
+
+**whisper.cpp aborts via GGML_ASSERT, and `catch_unwind` does not catch C aborts.** `catch_unwind` only catches Rust unwinding panics. A C-side `abort()` (which is what `GGML_ASSERT` / `WHISPER_ASSERT` call) bypasses it entirely; the process dies. This is a documented Rust property and a documented whisper.cpp behavior. Real-world examples: GGML_ASSERT firing on DTW alignment, quantized model mismatches, Metal `MUL_MAT` not implemented for certain dtypes, Metal command-buffer failures (whisper.cpp issues #2301, #1314, #1664, #1435). For the most common failure modes in production, the catch_unwind wrapper is theatre.
+
+So the whole "panic-safe inference" pitch in the One Sentence is misleading. What we actually get is: Rust-panic-safe inference (ndarray OOB, hound parse panics, ORT panics that unwind, transcribe-rs internal panics). Not whisper.cpp-abort-safe. That is a real but smaller property than the spec implies.
+
+Evidence: cjpais/transcribe-rs depends on whisper-rs, which does not catch panics and does not document panic safety; whisper-rs-sys exposes `ggml_abort` directly. transcribe-rs publishes no panic-safety guarantees. ParakeetModel and MoonshineModel hold mutable `KVCache` state during decode; partial mid-decode mutation is a logical-state issue (stale cache), not a UB issue, and dropping the engine on panic resolves it.
+
+Recommended fix: drop the "panic-safe" framing as a top-line claim. Replace with "Rust-panic-recoverable; C aborts still take down the process — this is documented in `transcribe-rs`/`whisper.cpp` and is a known transcription crash class." Add a follow-up note that the only true mitigations are (a) sanitize samples at the Rust boundary before calling whisper (mono f32, 16kHz, non-empty, length cap, no NaN/Inf), (b) subprocess isolation in some future iteration. Option (a) is cheap and worth adding to the spec now. The artifact path already produces decoded samples; verify `read_artifact_samples` enforces these and add a check if not.
+
+### 2. CLAIM 2 (extend ModelManager, don't split): SOUND
+
+One-sentence test on the post-change struct: "Owns the resident engine's lifecycle and the state observers see while it runs." Cache + policy + ambient config + preload + event emission all serve that one sentence; they are not five concerns, they are one concern with five mechanisms. A separate `TranscriptionService` wrapping `ModelManager` would be an empty layer — the wrapper would proxy every method and own no new invariant. Cohesion wins. The struct could be renamed to `TranscriptionService` later when "Manager" stops fitting; that is a one-PR cosmetic.
+
+Mild caveat: the struct now reaches further across the app boundary (owns an `AppHandle`). That is mild lifecycle-coupling, not a design smell.
+
+### 3. CLAIM 3 (ambient config beats per-call): SOUND, BUT WEAKER THAN THE SPEC ASSERTS
+
+The spec's tiebreaker is preload. Steelman of the alternative (keep per-call config, add explicit `preload_transcription_model(config)`):
+
+- LOC: nearly identical; preload command is ~10 LOC.
+- FE coordination: per-call requires the FE to build the same config payload at two call sites (transcribe + preload effect). Ambient builds it once in a single `$effect`. So ambient is genuinely DRY-er at the FE.
+- Test surface: ambient adds a new `set_transcription_config` command and a `NoConfig` error path on `transcribe_recording`. Per-call adds a `preload(config)` command. Both surfaces are equal in size; the failure shapes differ.
+- Race: ambient introduces "transcribe-before-setConfig" → mitigated by FE button gating. Per-call has no race but every call site must rebuild config from settings.
+
+The honest verdict: ambient is a modest, defensible win driven mostly by FE call-site simplification and the fact that `unloadPolicy` is genuinely ambient state (no caller carries it per-request today). If preload is dropped from scope, the lead disappears. Spec's framing of preload as "the tiebreaker" is correct; do not let that line get cut in revision.
+
+### 4. CLAIM 4 (hold-lock through inference is costless): UNSOUND AS WRITTEN — snapshot becomes a blocking call
+
+The spec adds `get_transcription_state()` to support late-mounted observers, but proposes implementing `snapshot()` by reading `cached` + `config` under their locks. The cache lock is held for the entire inference. So a window opened mid-transcription calls `getTranscriptionState`, the call blocks for the duration of the inference, and then returns. For whisper-medium/large on a long clip, that is 30s+ of FE-side IPC stall. The grilling prompt explicitly flagged this and noted "the spec doesn't add this yet - verify." Verified: spec does not add a lock-free status path.
+
+Two real fixes:
+
+- (a) Track `ModelStatus` in an `Arc<AtomicU8>` (or `Arc<RwLock<ModelStatus>>` — RwLock is fine, status reads are cheap and writes are rare). Snapshot reads status from the atomic/RwLock and reads `engine + model_path` from the *config* RwLock (which is never held across inference). It does NOT touch `cached` Mutex.
+- (b) Less elegant but acceptable: snapshot tries `try_lock` on `cached`; if it fails (inference in progress), report `status: Inferring` and pull engine/path identity from the ambient config. This avoids the lock-free atomic at the cost of "during-inference identity reflects config, not what's actually loaded in memory" — which is fine because config drift triggers reload anyway.
+
+Option (a) is the right shape. Add a `status: Arc<RwLock<ModelStatus>>` field to `ModelManager`, mutate it inside `with_engine` (Loading → Ready → Inferring → Ready, plus Error), and have `snapshot()` read it without touching `cached`. ~20 LOC.
+
+The spec's "hold-lock is costless" line is wrong without this fix. With this fix, it is costless for inference and free for snapshot, with a tiny per-status RwLock write cost that doesn't matter.
+
+Also worth flagging under this claim: `setConfig`'s auto-preload spawns a task that calls `with_engine`, which contends on the cache lock. If a transcribe is in flight when the user changes settings, the preload task blocks on the cache mutex for the full inference duration, then loads the new model. That is correct behavior, but the spec should say so explicitly in the edge-cases table (it already does, mostly — "preload task waits on cache lock" — keep that line).
+
+### 5. CLAIM 5 (events on a single channel with full state are sufficient): MOSTLY SOUND
+
+Events carry full state, so deltas are unnecessary. The `getTranscriptionState` snapshot covers late-mount. The remaining race is `listen()` vs `snapshot()` order at FE mount: the spec's `local-model.svelte.ts` does `snapshot → listen`, which means an event fired *between* those two awaits is dropped. The window is small (single tick of Tauri's IPC) but not zero.
+
+The right order is `listen → snapshot → dedupe by tracking which events arrived during the gap`. Without sequence numbers you cannot dedupe perfectly, but because every event is a full state replacement, the worst case is one stale render — the next event corrects it. Acceptable for v1.
+
+Sequence numbers would be overkill; do not add them.
+
+What the spec misses: event handler ordering inside `with_engine`. `LoadingStarted → load() → LoadingCompleted → use_engine() → SelectionChanged` (if drift) is implied but not codified. The exact sequence affects whether the FE ever observes `status: Ready` between load and inference. If inference begins synchronously after load with the lock held, the FE never sees Ready between them; it goes `Loading → Inferring`. That is fine for the transcribe-call path but wrong for the preload path (preload SHOULD leave the engine in `Ready`, since there is no inference following it). Codify: in `with_engine`, emit `Ready` after `load` only when there is no inference closure body to run; the preload path passes a no-op closure, so emit `Ready` at the end of that no-op path. The transcribe path emits `Inferring` before `use_engine` and `Ready` after.
+
+This is a real correctness issue, not a nit.
+
+### Open Questions resolution
+
+| OQ | Resolution |
+|---|---|
+| 1 (AssertUnwindSafe sound?) | Yes for Rust panics; useless for whisper.cpp aborts. See Claim 1. Update spec framing. |
+| 2 (extension violates SRP?) | No, one-sentence test passes. Optional rename to `TranscriptionService` is a follow-up. |
+| 3 (drift detection identity?) | Resolved: compare `(engine, modelPath)` only. Codify a `fn should_preload(old: &TranscriptionConfig, new: &TranscriptionConfig) -> bool` so language/policy/prompt/translate changes never trigger preload. |
+| 4 (event re-entrancy?) | None. `AppHandle::emit` is sync and returns `Result`; handler runs on the FE side asynchronously. Not a concern. |
+| 5 (simpler design exists?) | Per-call config + explicit preload is the only credible competitor; modestly worse on FE DRY. Ambient stays. |
+
+### Other findings the grill turned up
+
+1. **`transcription.translate` setting does not exist in the FE schema.** `rg 'transcription\.translate' apps/whispering/src` returns zero matches today, but the spec's setConfig effect calls `settings.get('transcription.translate')`. That will throw or return `undefined`. Either add the setting to the schema with a default of `false` and document it in NOT in scope, or drop `translate` from the config entirely for v1 and add it in a follow-up. The spec says "wire field ships now; UI placement is a separate design decision" but never adds the storage. Pick one.
+
+2. **`MoonshineVariantWire` is deleted but Rust parsing of variant from `modelPath` is hand-waved.** The spec line "Moonshine variant parsed in Rust from `modelPath`" hides ~15 LOC of work. The current TS code uses arkregex (`moonshine-(tiny|base)-(en|...)$`); in Rust this becomes a `path.file_name().and_then(|n| n.to_str()).and_then(...)` parse. Acceptable to keep this in the spec but the implementer must not skip the corrupted-name failure case. Map it to a new `TranscriptionError::ConfigError { message: "..." }` variant or fold it into `ModelLoadError`.
+
+3. **FE migration list is incomplete.** Files that touch `transcription.{whispercpp,parakeet,moonshine}` keys today (verified by grep):
+   - `lib/settings/transcription-validation.ts`
+   - `lib/migration/migrate-settings.ts`
+   - `lib/services/transcription/registry.ts`
+   - `lib/components/settings/selectors/TranscriptionSelector.svelte`
+   These are mostly type/constant references and likely fine after catalogs move to `lib/constants/local-models.ts`, but the spec only names the page-level imports. Add a verification step in Checkpoint C: `rg 'services/transcription/local/' apps/whispering/src` must return zero matches (with the four local files gone).
+
+4. **`UnloadReason::Idle { idle_secs: u64 }` will serialize as `bigint` in TS by default.** specta's u64 → bigint guard is on. The existing `RecordingArtifact` uses `#[specta(type = Number<u64>)]` to opt out. Add the same attribute or change the type to `u32`. Minor nit but the bindings will be ugly otherwise.
+
+5. **The current `transcribe_recording` test for the `commands.test-d.ts` file will break** when the signature drops `config`. Update the type-test alongside the bindings regeneration.
+
+6. **`ModelManager::new(app)` is constructed inside `.setup(|app| { ... })`, but `.manage()` runs before `.setup()`.** Re-read `lib.rs:185`: `.manage(ModelManager::new())` happens during builder construction, BEFORE the app handle exists. The spec wants `ModelManager::new(app.handle().clone())`. The reshape is: move `.manage(ModelManager::new(...))` into `.setup()`, or construct ModelManager in two phases (`new()` returns a half-built struct, `attach_app(handle)` finishes it). Two-phase is uglier; moving the `manage` into `setup` is the right call. Update the spec's Implementation Plan: "Move `.manage(ModelManager::new(app_handle))` into the existing `.setup(|app| { ... })` closure; remove the eager `.manage(ModelManager::new())`."
+
+### Concrete spec changes (apply before execution)
+
+- [ ] **Soften the panic-safety framing in One Sentence and Architecture diagram.** Replace "panic-safe inference" with "Rust-panic-recoverable inference". Add a one-line caveat citing whisper.cpp's `GGML_ASSERT` behavior.
+- [ ] **Add lock-free status field to ModelManager.** `status: Arc<RwLock<ModelStatus>>`. Snapshot reads it without touching `cached`. Update Field-by-field diff to include it.
+- [ ] **Codify `should_preload(old, new) -> bool`.** Compare `(engine, model_path)` only.
+- [ ] **Codify event order inside `with_engine`.** Preload path: `LoadingStarted → load → LoadingCompleted → Ready`. Transcribe path: `LoadingStarted → load → LoadingCompleted → Inferring → use_engine → Ready` (or Error on failure). Add the four panic-path emissions (`Unloaded { PanicRecovered }`, `LoadingFailed`).
+- [ ] **Decide `translate`: add to FE settings schema with default `false`, OR drop from v1 config.** As written, the setConfig effect references a key that does not exist.
+- [ ] **Add `#[specta(type = Number<u64>)]` to `UnloadReason::Idle.idle_secs` and `LoadingCompleted.elapsed_ms`.** Or use u32. Don't ship bigint to TS.
+- [ ] **Move `.manage(ModelManager::new(app_handle))` into `.setup()`.** Eager `.manage()` at builder time cannot pass an AppHandle.
+- [ ] **Add sample sanitization at Rust boundary** (mono f32, 16kHz, non-empty, length cap, no NaN/Inf) before passing into whisper.cpp, to reduce GGML_ASSERT crash surface. Owner: `transcription::mod.rs` between `read_artifact_samples` and `spawn_blocking`.
+- [ ] **Document the listen-vs-snapshot ordering risk** in `local-model.svelte.ts` as a code comment; do not add sequence numbers.
+- [ ] **Add Checkpoint C verification:** `rg 'services/transcription/local/' apps/whispering/src` returns zero matches.
+- [ ] **Update `bindings.test-d.ts` / `commands.test-d.ts`** alongside `bindings:tauri` regen.
+- [ ] **Specify Moonshine variant parse failure mode in Rust.** Either a new error variant or folded into `ModelLoadError`.
+
+### Overall
+
+**GO WITH CHANGES.** No design-level blocker. The five claims hold (one with a critical caveat the spec must acknowledge, one with a buried implementation gap the spec must close). The core decision — extend ModelManager, ambient config, events with snapshot — is right. Execute after applying the checklist above.
+
+## Review
+
+**Completed**: 2026-05-27
+**Branch**: `braden-w/rust-transcription-service`
+
+### Summary
+
+Extended `ModelManager` in place with ambient `TranscriptionConfig`, a lock-free `ModelStatus` snapshot field, an `AppHandle`-backed event emitter on `transcription://model-state`, sample sanitization at the Rust/FFI boundary, and a `parse_moonshine_variant` helper that moves wire-format inference out of the FE. `transcribe_recording` lost its per-call `config: TranscribeRequest` argument; the FE now pushes a single `setTranscriptionConfig` once per change from a layout `$effect`, and a `getTranscriptionState` snapshot covers late-mounted observers. The deleted state machine from the predecessor spec stays deleted: the predecessor's invariant ("slot is None during inference") had no consumer, while hold-lock with status emission gives the FE everything it actually needs.
+
+### Deviations from Spec
+
+- **Dropped `catch_unwind`** machinery. `[profile.release] panic = "abort"` makes it a no-op in production, and `GGML_ASSERT` C aborts are uncatchable anyway. Existing `lock_cached` poisoning recovery covers the recoverable cases.
+- **Dropped `translate` field** from `TranscriptionConfig`. The `transcription.translate` KV does not exist in the workspace schema; the spec deferred this to "NOT in scope" anyway, so the cleanest move was to omit it from v1.
+- **Restructured `UnloadPolicy`** as flat serde-tagged variants (`Never`, `Immediately`, `AfterFiveMinutes`, `AfterThirtyMinutes`) with renames matching the FE wire strings. Drops the imperative `from_wire` string parser in favor of plain serde deserialization.
+- **Moved `UnloadPolicy`** out of `model_manager.rs` into `config.rs` to keep config types co-located.
+- **Hand-edited `bindings.gen.ts`** rather than regenerating via `bindings:tauri`: the local Homebrew Rust 1.90 cannot compile specta-2.0.0-rc.25 (needs Rust 1.91 stable for `debug_closure_helpers`). CI will pick the regen up; my hand-edit matches specta's expected output shape so TS typechecks today.
+
+### Follow-up Work
+
+1. **Register `ModelStateEvent` via `tauri_specta::collect_events!`.** When CI regenerates bindings, specta will drop `ModelStateEvent` and `UnloadReason` from the output because no command returns them. Fix: add `#[derive(tauri_specta::Event)]` on `ModelStateEvent` (and its referenced types as needed) and chain `.events(tauri_specta::collect_events![ModelStateEvent])` onto `make_specta_builder()` in `lib.rs`.
+2. **Wire `localModel.isBusy` into the transcribe button.** The reactive state ships; consumer UI does not.
+3. **Run smoke tests on a real desktop** (each engine, settings change mid-load, second window mid-load, `immediately` unload policy).
+4. **Future:** preload from recording-start (not settings-change). Documented in NOT in scope but flagged by grilling-section as a real follow-up after 5min idle eviction lapses.
+5. **Future:** subprocess isolation for whisper.cpp to recover from `GGML_ASSERT` aborts. Sample sanitization is the cheap first line of defense; subprocess isolation is the only true cure.
+


### PR DESCRIPTION
Whispering's local transcription path used to ask the FE to forward a `config: TranscribeRequest` payload on every `transcribe_recording` call: engine, modelPath, language, prompt, and the variant-from-directory-name dance for Moonshine. The unload policy travelled separately through `set_unload_policy`. Two ambient inputs were piped through every per-call request, and the resident-model lifecycle was opaque to the FE.

This PR collapses that to a single ambient push and a single observed channel. The FE calls `setTranscriptionConfig` once per change (engine, modelPath, language, prompt, unloadPolicy), Rust owns everything observable about the resident model, and a `transcription://model-state` event channel emits a full state snapshot on every load/complete/fail/unload/selection-change. Local transcription becomes `commands.transcribeRecording(recordingId)` — no payload.

Drift in `(engine, modelPath)` triggers a background preload so the next transcription does not pay cold-start latency on whisper-medium (5-10s) or whisper-large-v3-turbo (8-15s). Drift in language/prompt/policy takes effect on the next call with no reload.

## Surface diff

```txt
Before
  commands.transcribeRecording(id, { engine, modelPath, language?, initialPrompt?, variant? })
  commands.setUnloadPolicy(policyString)
  // resident-model lifecycle: opaque

After
  commands.setTranscriptionConfig({ engine, modelPath, language?, initialPrompt?, unloadPolicy })
  commands.transcribeRecording(id)
  commands.getTranscriptionState() -> LocalModelState     // late-mount snapshot
  listen<ModelStateEvent>('transcription://model-state')  // loading_started | loading_completed |
                                                          // loading_failed | unloaded | selection_changed
```

## Rust shape

`ModelManager` extends in place rather than being wrapped. It already owned the cache and idle watcher; the new responsibilities (ambient config, status field, event emission, preload) all serve the same one-sentence concern: own the resident engine's lifecycle and the state observers see while it runs.

```txt
ModelManager
  cached:           Arc<Mutex<Option<(PathBuf, Engine)>>>   // existing
  last_activity_ms: Arc<AtomicU64>                          // existing
  config:           Arc<RwLock<Option<TranscriptionConfig>>>  // new
  status:           Arc<RwLock<ModelStatus>>                  // new, lock-free for snapshot
  app:              AppHandle                                  // new, for emit
```

`snapshot()` reads `status` and `config` without touching `cached`, so a new window calling `getTranscriptionState` mid-inference returns immediately instead of blocking behind a 30s whisper-large call. `set_transcription_config` returns immediately too: eviction and preload run on `spawn_blocking` so the Tauri command thread never waits on the cache mutex.

## Status sequence

`with_engine` emits at every transition. Load + transcribe path:

```txt
Idle/Ready  --> Loading  --> Ready  --> Inferring  --> Ready
                  |             |                          |
                  v             v                          v
        LoadingStarted   LoadingCompleted          (no event)
                            { elapsed_ms }
```

Preload path (no-op closure) lands at Ready with no perceptible Inferring window. Load failure goes Loading → Error and emits LoadingFailed. Inference failure sets Error but keeps the cache resident (the engine is still loaded; a transient FFI hiccup should not force a reload).

## Panic safety, honestly

The predecessor spec proposed `catch_unwind(AssertUnwindSafe(...))` inside `with_engine`. Two facts kill that pattern in production:

```toml
[profile.release]
panic = "abort"
```

`catch_unwind` is a no-op once `panic = abort` is set, and the release profile sets it. Worse, the most common crash class in production is `GGML_ASSERT` from whisper.cpp — a C `abort()` that `catch_unwind` cannot catch regardless. So the wrapper was theatre.

What we ship instead:

- `sanitize_samples` at the FFI boundary replaces NaN/Inf with 0.0 and truncates at one hour of 16 kHz mono. Cheap defense against the easiest GGML_ASSERT triggers.
- Existing `lock_cached` recovers from Mutex poisoning in debug builds by clearing the slot so the next caller reloads.
- The status field flips to `Error` on inference failure so the FE sees a clear failure state without us pretending we caught what we did not.

## Moonshine wire-format moves to Rust

Before, the FE had an arkregex-with-typed-captures parsing `moonshine-{variant}-{lang}` out of the model path so it could forward the variant on the wire. Now Rust's `parse_moonshine_variant` reads the variant out of the path string and returns a structured `TranscriptionError::ConfigError` on malformed names. The capture machinery was no longer earning its keep on the FE: we never used the captured value after the refactor. The catalog metadata (`MOONSHINE_VARIANTS`, `MoonshineVariant`) stays as FE vocabulary for the settings UI.

## Frontend shape

`local-model.svelte.ts` mirrors the canonical state-singleton pattern (`recordings.svelte.ts`, `vad-recorder.svelte.ts`): a `createLocalModel()` factory with a `\$state` closure and a return object exposing `state`, `isBusy`, and `attach()`. The layout calls `attach()` once in `onMount` and cleans up in `onDestroy`.

`dispatchLocalTranscription` collapsed three near-identical switch arms into a `LOCAL_ENGINE_PREFLIGHT` table walk. Per-engine data (kind, displayName, modelPathKey) lives in one row; the dispatch loop reads as pick row → require path → optional check → call. Whisper truncation moves to a named helper since it's the only engine-specific extra.

## tauri-specta event registration

`ModelStateEvent` derives `tauri_specta::Event` with an explicit name attribute:

```rust
#[derive(Debug, Clone, Serialize, Deserialize, specta::Type, Event)]
#[tauri_specta::event(name = \"transcription://model-state\")]
pub enum ModelStateEvent { ... }
```

Verified against `specta-rs/tauri-specta` via DeepWiki: the derive auto-kebabs the type ident (`model-state-event`) unless `event(name = ...)` overrides it. Paired with `.events(collect_events![ModelStateEvent])` on the specta builder so the type stays exported from `bindings.gen.ts` on every regen — without registration, specta would drop event-only payload types because no command references them.

## Commits

```txt
576deba8a refactor(whispering): collapse pass on local transcription consumers
74a181651 chore(whispering): drop dead moonshine validation + stale docs
eb2c2f455 feat(whispering): ambient transcription config + lifecycle events
```

## Verification

- `bun run --cwd apps/whispering typecheck`: 0 errors, 11 pre-existing Svelte warnings.
- Rust `cargo check` deferred to CI (`dtolnay/rust-toolchain@stable`): the local Homebrew Rust 1.90 is behind specta-2.0.0-rc.25's requirements, but the surface specta would emit is hand-mirrored in `bindings.gen.ts` so TS typechecks today and the regen on stable should be a no-op.
- `rg 'set_unload_policy' apps/whispering` → 0 matches.
- `rg 'services/transcription/local/' apps/whispering/src` → 0 matches.

## Known follow-ups (recorded in `specs/20260527T120000-rust-transcription-service.md`)

- Wire `localModel.isBusy` into the transcribe button so it disables while loading or inferring.
- Manual smoke tests on a real desktop: each local engine end-to-end, settings change mid-load, second window mid-load, `immediately` unload policy.
- Optional rename pass: `ModelManager` is genuinely a `TranscriptionService` now; left as a separate-PR taste call.
- Future: preload from recording-start (not settings-change) to cover users who transcribe less frequently than the idle eviction window.
- Future: subprocess isolation for whisper.cpp to recover from `GGML_ASSERT` aborts.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782462546&installation_id=128463665&pr_number=1837&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1837&signature=762a75249862725db029bb401bdbe2be16bdf180fe1ab3710de6c2a38326d697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->