### PR TITLE
refactor: convert const annotations to satisfies

### DIFF
--- a/apps/api/src/billing/routes.ts
+++ b/apps/api/src/billing/routes.ts
@@ -99,7 +99,6 @@ billingRoutes.get('/plans', async (c) => c.json(await svc(c).listPlans()));
 
 billingRoutes.get('/models', (c) => {
 	const models = Object.entries(MODEL_CREDITS)
-		.filter((entry): entry is [string, number] => entry[1] !== undefined)
 		.map(([model, credits]) => ({
 			model,
 			provider: providerOf(model),

--- a/apps/opensidian/src/lib/chat/providers.ts
+++ b/apps/opensidian/src/lib/chat/providers.ts
@@ -26,5 +26,5 @@ export const PROVIDER_MODELS = {
 
 export type Provider = keyof typeof PROVIDER_MODELS;
 
-export const DEFAULT_PROVIDER: Provider = 'openai';
+export const DEFAULT_PROVIDER = 'openai' satisfies Provider;
 export const DEFAULT_MODEL = PROVIDER_MODELS[DEFAULT_PROVIDER][0];

--- a/apps/tab-manager/src/lib/chat/providers.ts
+++ b/apps/tab-manager/src/lib/chat/providers.ts
@@ -26,6 +26,6 @@ export const PROVIDER_MODELS = {
 
 export type Provider = keyof typeof PROVIDER_MODELS;
 
-export const DEFAULT_PROVIDER: Provider = 'openai';
+export const DEFAULT_PROVIDER = 'openai' satisfies Provider;
 export const DEFAULT_MODEL = PROVIDER_MODELS[DEFAULT_PROVIDER][0];
 export const AVAILABLE_PROVIDERS = Object.keys(PROVIDER_MODELS) as Provider[];

--- a/apps/whispering/src/lib/constants/audio/sample-rate.ts
+++ b/apps/whispering/src/lib/constants/audio/sample-rate.ts
@@ -9,14 +9,14 @@ export type SampleRate = (typeof SAMPLE_RATES)[number];
 /**
  * Sample rate metadata for generating options with descriptions
  */
-const SAMPLE_RATE_METADATA: Record<
-	SampleRate,
-	{ shortLabel: string; description: string }
-> = {
+const SAMPLE_RATE_METADATA = {
 	'16000': { shortLabel: '16 kHz', description: 'Optimized for speech' },
 	'44100': { shortLabel: '44.1 kHz', description: 'CD quality' },
 	'48000': { shortLabel: '48 kHz', description: 'Studio quality' },
-};
+} as const satisfies Record<
+	SampleRate,
+	{ shortLabel: string; description: string }
+>;
 
 /**
  * Sample rate options with descriptive labels

--- a/apps/whispering/src/lib/constants/keyboard/accelerator-conversions.ts
+++ b/apps/whispering/src/lib/constants/keyboard/accelerator-conversions.ts
@@ -17,9 +17,7 @@ import type {
  *
  * @see https://www.electronjs.org/docs/latest/api/accelerator
  */
-export const KEYBOARD_EVENT_SPECIAL_KEY_TO_ACCELERATOR_KEY_CODE_MAP: Partial<
-	Record<string, AcceleratorKeyCode>
-> = {
+export const KEYBOARD_EVENT_SPECIAL_KEY_TO_ACCELERATOR_KEY_CODE_MAP = {
 	// Arrow keys
 	arrowup: 'Up',
 	arrowdown: 'Down',
@@ -55,7 +53,7 @@ export const KEYBOARD_EVENT_SPECIAL_KEY_TO_ACCELERATOR_KEY_CODE_MAP: Partial<
 	capslock: 'Capslock',
 	numlock: 'Numlock',
 	scrolllock: 'Scrolllock',
-} as const;
+} as const satisfies Partial<Record<string, AcceleratorKeyCode>>;
 
 /**
  * Defines the standard sort priority for accelerator modifiers.
@@ -71,10 +69,7 @@ export const KEYBOARD_EVENT_SPECIAL_KEY_TO_ACCELERATOR_KEY_CODE_MAP: Partial<
  * );
  * ```
  */
-export const ACCELERATOR_MODIFIER_SORT_PRIORITY: Record<
-	AcceleratorModifier,
-	number
-> = {
+export const ACCELERATOR_MODIFIER_SORT_PRIORITY = {
 	Command: 1,
 	Cmd: 1,
 	Control: 1,
@@ -85,4 +80,4 @@ export const ACCELERATOR_MODIFIER_SORT_PRIORITY: Record<
 	Shift: 4,
 	Super: 5,
 	Meta: 5,
-} as const;
+} as const satisfies Record<AcceleratorModifier, number>;

--- a/apps/whispering/src/lib/constants/keyboard/display-labels.ts
+++ b/apps/whispering/src/lib/constants/keyboard/display-labels.ts
@@ -5,9 +5,7 @@ import { FUNCTION_KEY_PATTERN } from './patterns';
  * Display labels for browser keys that need human-readable representation.
  * Exhaustive mapping for all non-trivial keys.
  */
-const BROWSER_KEY_DISPLAY_LABELS: Partial<
-	Record<KeyboardEventSupportedKey, string>
-> = {
+const BROWSER_KEY_DISPLAY_LABELS = {
 	// Whitespace (PRIMARY FIX)
 	' ': 'Space',
 	enter: 'Enter',
@@ -80,7 +78,7 @@ const BROWSER_KEY_DISPLAY_LABELS: Partial<
 	select: 'Select',
 	zoomout: 'Zoom Out',
 	zoomin: 'Zoom In',
-};
+} as const satisfies Partial<Record<KeyboardEventSupportedKey, string>>;
 
 /**
  * Gets display label for a full shortcut string.
@@ -106,7 +104,12 @@ export function getShortcutDisplayLabel(shortcut: string | null): string {
  * Internal helper: formats a single key for display.
  */
 function formatKeyForDisplay(key: string): string {
-	const label = BROWSER_KEY_DISPLAY_LABELS[key as KeyboardEventSupportedKey];
+	const label =
+		key in BROWSER_KEY_DISPLAY_LABELS
+			? BROWSER_KEY_DISPLAY_LABELS[
+					key as keyof typeof BROWSER_KEY_DISPLAY_LABELS
+				]
+			: null;
 	if (label) return label;
 
 	// Single letters: uppercase

--- a/apps/whispering/src/lib/constants/keyboard/macos-option-key-map.ts
+++ b/apps/whispering/src/lib/constants/keyboard/macos-option-key-map.ts
@@ -6,7 +6,7 @@ import type { KeyboardEventPossibleKey } from './browser/possible-keys';
  * instead of the normal key events. This mapping allows us to normalize these
  * back to their original keys for consistent shortcut handling.
  */
-const OPTION_KEY_CHARACTER_MAP: Record<string, KeyboardEventPossibleKey> = {
+const OPTION_KEY_CHARACTER_MAP = {
 	// Option + Letters (A-Z)
 	å: 'a', // Option+A
 	'∫': 'b', // Option+B
@@ -47,7 +47,7 @@ const OPTION_KEY_CHARACTER_MAP: Record<string, KeyboardEventPossibleKey> = {
 	'÷': '/', // Option+/
 	'≥': '.', // Option+.
 	'≤': ',', // Option+,
-};
+} as const satisfies Record<string, KeyboardEventPossibleKey>;
 
 /**
  * Normalizes macOS Option+Key special characters back to their base keys.
@@ -71,7 +71,11 @@ export function normalizeOptionKeyCharacter(
 	if (key.length !== 1) return key;
 
 	// Return the normalized key or the original if not found
-	return OPTION_KEY_CHARACTER_MAP[key] ?? key;
+	const normalizedKey =
+		key in OPTION_KEY_CHARACTER_MAP
+			? OPTION_KEY_CHARACTER_MAP[key as keyof typeof OPTION_KEY_CHARACTER_MAP]
+			: null;
+	return normalizedKey ?? key;
 }
 
 /**

--- a/apps/whispering/src/lib/constants/ui/nav-items.ts
+++ b/apps/whispering/src/lib/constants/ui/nav-items.ts
@@ -21,7 +21,7 @@ const matchesRoute = (href: string) => (pathname: string) =>
  * Add new top-level routes here — both `VerticalNav` and `BottomNav` consume
  * this array, so changes propagate automatically.
  */
-export const NAV_ITEMS: NavItem[] = [
+export const NAV_ITEMS = [
 	{
 		label: 'Home',
 		href: '/',
@@ -46,4 +46,4 @@ export const NAV_ITEMS: NavItem[] = [
 		icon: SettingsIcon,
 		isActive: matchesRoute('/settings'),
 	},
-];
+] as const satisfies readonly NavItem[];

--- a/apps/whispering/src/lib/migration/migrate-settings.ts
+++ b/apps/whispering/src/lib/migration/migrate-settings.ts
@@ -90,7 +90,8 @@ export async function migrateOldSettings(): Promise<void> {
 	// fires once with all changes, not 43 individual updates.
 
 	whispering.ydoc.transact(() => {
-		for (const { oldKey, newKey, convert } of WORKSPACE_KEY_MAP) {
+		for (const keyMapping of WORKSPACE_KEY_MAP) {
+			const { oldKey, newKey } = keyMapping;
 			trySync({
 				try: () => {
 					const raw = oldSettings?.[oldKey];
@@ -99,7 +100,7 @@ export async function migrateOldSettings(): Promise<void> {
 					// First-write-wins: skip if user already changed this setting
 					if (getKv(newKey) !== getKvDefault(newKey)) return;
 
-					const value = convert ? convert(raw) : raw;
+					const value = 'convert' in keyMapping ? keyMapping.convert(raw) : raw;
 					if (value === undefined) return;
 
 					setKv(newKey, value);
@@ -175,11 +176,7 @@ function toInteger(raw: unknown): number | undefined {
  * Maps old `whispering-settings` blob keys to new workspace KV keys.
  * Two keys require type conversion (string → number).
  */
-const WORKSPACE_KEY_MAP: readonly {
-	oldKey: string;
-	newKey: string;
-	convert?: (raw: unknown) => unknown;
-}[] = [
+const WORKSPACE_KEY_MAP = [
 	// Sound toggles
 	{ oldKey: 'sound.playOn.manual-start', newKey: 'sound.manualStart' },
 	{ oldKey: 'sound.playOn.manual-stop', newKey: 'sound.manualStop' },
@@ -295,7 +292,11 @@ const WORKSPACE_KEY_MAP: readonly {
 		oldKey: 'shortcuts.local.runTransformationOnClipboard',
 		newKey: 'shortcut.runTransformationOnClipboard',
 	},
-] as const;
+] as const satisfies readonly {
+	oldKey: string;
+	newKey: string;
+	convert?: (raw: unknown) => unknown;
+}[];
 
 /**
  * Maps old blob keys to new device config keys.
@@ -304,7 +305,7 @@ const WORKSPACE_KEY_MAP: readonly {
  *   2. `whispering-device-config` monolithic blob (from brief interim period)
  *   3. `whispering-settings` original blob
  */
-const DEVICE_KEY_MAP: readonly { oldKey: string; newKey: string }[] = [
+const DEVICE_KEY_MAP = [
 	// API keys
 	{ oldKey: 'apiKeys.openai', newKey: 'apiKeys.openai' },
 	{ oldKey: 'apiKeys.anthropic', newKey: 'apiKeys.anthropic' },
@@ -387,4 +388,4 @@ const DEVICE_KEY_MAP: readonly { oldKey: string; newKey: string }[] = [
 		oldKey: 'shortcuts.global.runTransformationOnClipboard',
 		newKey: 'shortcuts.global.runTransformationOnClipboard',
 	},
-] as const;
+] as const satisfies readonly { oldKey: string; newKey: string }[];

--- a/apps/whispering/src/lib/report/index.ts
+++ b/apps/whispering/src/lib/report/index.ts
@@ -70,12 +70,12 @@ export const log = {
 // ── Internals ─────────────────────────────────────────────────────────────
 
 function emit(level: Level, notice: Notice, id?: string): void {
-	const event: ReportEvent = {
+	const event = {
 		ts: Date.now(),
 		level,
 		source: SOURCE,
 		data: id !== undefined ? { ...notice, id } : notice,
-	};
+	} satisfies ReportEvent;
 	consoleSink(event);
 	toastSink(event);
 	osNotifySink(event);

--- a/apps/whispering/src/lib/services/os/index.browser.ts
+++ b/apps/whispering/src/lib/services/os/index.browser.ts
@@ -48,15 +48,19 @@ function getPlatformFromClientHints(
 	const platform = navigator.userAgentData.platform.toLowerCase();
 
 	// Direct mapping from client hints to OsType
-	const platformMap: Record<string, OsType> = {
+	const platformMap = {
 		windows: 'windows',
 		macos: 'macos',
 		linux: 'linux',
 		android: 'android',
 		ios: 'ios',
-	};
+	} as const satisfies Record<string, OsType>;
 
-	return platformMap[platform] ?? null;
+	const detectedPlatform =
+		platform in platformMap
+			? platformMap[platform as keyof typeof platformMap]
+			: null;
+	return detectedPlatform ?? null;
 }
 
 /** iOS device user agent pattern */

--- a/apps/whispering/src/lib/services/os/index.browser.ts
+++ b/apps/whispering/src/lib/services/os/index.browser.ts
@@ -48,19 +48,15 @@ function getPlatformFromClientHints(
 	const platform = navigator.userAgentData.platform.toLowerCase();
 
 	// Direct mapping from client hints to OsType
-	const platformMap = {
+	const platformMap: Record<string, OsType> = {
 		windows: 'windows',
 		macos: 'macos',
 		linux: 'linux',
 		android: 'android',
 		ios: 'ios',
-	} as const satisfies Record<string, OsType>;
+	};
 
-	const detectedPlatform =
-		platform in platformMap
-			? platformMap[platform as keyof typeof platformMap]
-			: null;
-	return detectedPlatform ?? null;
+	return platformMap[platform] ?? null;
 }
 
 /** iOS device user agent pattern */

--- a/apps/whispering/src/lib/services/recorder/cpal.tauri.ts
+++ b/apps/whispering/src/lib/services/recorder/cpal.tauri.ts
@@ -53,10 +53,10 @@ const enumerateDevices = async (): Promise<Result<Device[], RecorderError>> => {
  * to `<appDataDir>/recordings/{id}.wav` and the JS side refers to the
  * recording by id from then on. There is no raw PCM on the wire.
  */
-function createCpalRecorder(): RecorderService {
+function createCpalRecorder() {
 	let activeSession: RecordingSession | null = null;
 
-	function buildSession(recordingId: string): RecordingSession {
+	function buildSession(recordingId: string) {
 		const subscribers = new Set<(s: WhisperingRecordingState) => void>();
 		let currentState: WhisperingRecordingState = 'RECORDING';
 		let tauriUnlisten: Promise<UnlistenFn> | null = null;
@@ -276,7 +276,8 @@ function createCpalRecorder(): RecorderService {
 			activeSession = session;
 			return Ok({ session, deviceAcquisition: deviceOutcome });
 		},
-	};
+	} satisfies RecorderService;
 }
 
-export const CpalRecorderServiceLive: RecorderService = createCpalRecorder();
+export const CpalRecorderServiceLive =
+	createCpalRecorder() satisfies RecorderService;

--- a/apps/whispering/src/lib/services/recorder/cpal.tauri.ts
+++ b/apps/whispering/src/lib/services/recorder/cpal.tauri.ts
@@ -98,7 +98,7 @@ function createCpalRecorder(): RecorderService {
 			notify('IDLE');
 		};
 
-		const session: RecordingSession = {
+		const session = {
 			recordingId,
 			backend: 'cpal',
 
@@ -162,7 +162,7 @@ function createCpalRecorder(): RecorderService {
 					subscribers.delete(handler);
 				};
 			},
-		};
+		} satisfies RecordingSession;
 
 		return session;
 	}

--- a/apps/whispering/src/lib/services/recorder/navigator.ts
+++ b/apps/whispering/src/lib/services/recorder/navigator.ts
@@ -34,7 +34,7 @@ type ActiveSession = {
  * `RecordingSession` so toggling the backend setting mid-recording does not
  * misroute teardown.
  */
-function createNavigatorRecorder(): RecorderService {
+function createNavigatorRecorder() {
 	let activeSession: ActiveSession | null = null;
 
 	function buildSession(args: {
@@ -43,7 +43,7 @@ function createNavigatorRecorder(): RecorderService {
 		mediaRecorder: MediaRecorder;
 		recordedChunks: Blob[];
 		startedAtMs: number;
-	}): { activeSession: ActiveSession; session: RecordingSession } {
+	}) {
 		const { recordingId, stream, mediaRecorder, recordedChunks, startedAtMs } =
 			args;
 		const subscribers = new Set<(s: WhisperingRecordingState) => void>();
@@ -136,7 +136,13 @@ function createNavigatorRecorder(): RecorderService {
 			recordedChunks,
 			session: recordingSession,
 		} satisfies ActiveSession;
-		return { activeSession: sessionRecord, session: recordingSession };
+		return {
+			activeSession: sessionRecord,
+			session: recordingSession,
+		} satisfies {
+			activeSession: ActiveSession;
+			session: RecordingSession;
+		};
 	}
 
 	return {
@@ -216,11 +222,11 @@ function createNavigatorRecorder(): RecorderService {
 
 			return Ok({ session, deviceAcquisition: deviceOutcome });
 		},
-	};
+	} satisfies RecorderService;
 }
 
-export const NavigatorRecorderServiceLive: RecorderService =
-	createNavigatorRecorder();
+export const NavigatorRecorderServiceLive =
+	createNavigatorRecorder() satisfies RecorderService;
 
 /**
  * Determines the best supported audio MIME type for the current browser.

--- a/apps/whispering/src/lib/services/recorder/navigator.ts
+++ b/apps/whispering/src/lib/services/recorder/navigator.ts
@@ -65,7 +65,7 @@ function createNavigatorRecorder(): RecorderService {
 			notify('IDLE');
 		};
 
-		const recordingSession: RecordingSession = {
+		const recordingSession = {
 			recordingId,
 			backend: 'navigator',
 
@@ -128,14 +128,14 @@ function createNavigatorRecorder(): RecorderService {
 					subscribers.delete(handler);
 				};
 			},
-		};
+		} satisfies RecordingSession;
 
-		const sessionRecord: ActiveSession = {
+		const sessionRecord = {
 			stream,
 			mediaRecorder,
 			recordedChunks,
 			session: recordingSession,
-		};
+		} satisfies ActiveSession;
 		return { activeSession: sessionRecord, session: recordingSession };
 	}
 

--- a/apps/whispering/src/lib/services/transcription/utils.ts
+++ b/apps/whispering/src/lib/services/transcription/utils.ts
@@ -21,6 +21,13 @@ export function getAudioExtension(mimeType: string): string {
 	// - 'weba' for audio/webm (should be 'webm')
 	// - 'oga' for audio/ogg (should be 'ogg')
 	// Groq/OpenAI/Mistral support: flac, mp3, mp4, mpeg, mpga, m4a, ogg, opus, wav, webm
-	const extensionMapping: Record<string, string> = { weba: 'webm', oga: 'ogg' };
-	return extensionMapping[extension] ?? extension;
+	const extensionMapping = {
+		weba: 'webm',
+		oga: 'ogg',
+	} as const satisfies Record<string, string>;
+	const mappedExtension =
+		extension in extensionMapping
+			? extensionMapping[extension as keyof typeof extensionMapping]
+			: null;
+	return mappedExtension ?? extension;
 }

--- a/apps/whispering/src/lib/services/transcription/utils.ts
+++ b/apps/whispering/src/lib/services/transcription/utils.ts
@@ -21,13 +21,9 @@ export function getAudioExtension(mimeType: string): string {
 	// - 'weba' for audio/webm (should be 'webm')
 	// - 'oga' for audio/ogg (should be 'ogg')
 	// Groq/OpenAI/Mistral support: flac, mp3, mp4, mpeg, mpga, m4a, ogg, opus, wav, webm
-	const extensionMapping = {
+	const extensionMapping: Record<string, string> = {
 		weba: 'webm',
 		oga: 'ogg',
-	} as const satisfies Record<string, string>;
-	const mappedExtension =
-		extension in extensionMapping
-			? extensionMapping[extension as keyof typeof extensionMapping]
-			: null;
-	return mappedExtension ?? extension;
+	};
+	return extensionMapping[extension] ?? extension;
 }

--- a/apps/whispering/src/lib/utils/accelerator.ts
+++ b/apps/whispering/src/lib/utils/accelerator.ts
@@ -112,7 +112,12 @@ function convertToKeyCode(
 	if (FUNCTION_KEY_PATTERN.test(key)) {
 		return key.toUpperCase() as AcceleratorKeyCode;
 	}
-	const mappedKey = KEYBOARD_EVENT_SPECIAL_KEY_TO_ACCELERATOR_KEY_CODE_MAP[key];
+	const mappedKey =
+		key in KEYBOARD_EVENT_SPECIAL_KEY_TO_ACCELERATOR_KEY_CODE_MAP
+			? KEYBOARD_EVENT_SPECIAL_KEY_TO_ACCELERATOR_KEY_CODE_MAP[
+					key as keyof typeof KEYBOARD_EVENT_SPECIAL_KEY_TO_ACCELERATOR_KEY_CODE_MAP
+				]
+			: null;
 	if (mappedKey) return mappedKey;
 	if (
 		ACCELERATOR_PUNCTUATION_KEYS.includes(

--- a/apps/whispering/src/routes/(app)/_layout-utils/register-commands.ts
+++ b/apps/whispering/src/routes/(app)/_layout-utils/register-commands.ts
@@ -14,24 +14,24 @@ import { tauri } from '$lib/tauri';
 import type { Accelerator } from '$lib/utils/accelerator';
 
 /** Default values for in-app (local) shortcuts. Keyed by command id string. */
-const DEFAULT_LOCAL_SHORTCUTS: Record<string, string | null> = {
+const DEFAULT_LOCAL_SHORTCUTS = {
 	pushToTalk: 'p',
 	toggleManualRecording: ' ',
 	cancelManualRecording: 'c',
 	toggleVadRecording: 'v',
 	openTransformationPicker: 't',
 	runTransformationOnClipboard: 'r',
-};
+} as const satisfies Record<string, string | null>;
 
 /** Default values for global OS shortcuts. Keyed by command id string. */
-const DEFAULT_GLOBAL_SHORTCUTS: Record<string, string | null> = {
+const DEFAULT_GLOBAL_SHORTCUTS = {
 	pushToTalk: `${CommandOrAlt}+Shift+D`,
 	toggleManualRecording: `${CommandOrControl}+Shift+;`,
 	cancelManualRecording: `${CommandOrControl}+Shift+'`,
 	toggleVadRecording: null,
 	openTransformationPicker: `${CommandOrControl}+Shift+X`,
 	runTransformationOnClipboard: `${CommandOrControl}+Shift+R`,
-};
+} as const satisfies Record<string, string | null>;
 
 type LocalShortcutKey =
 	| 'shortcut.toggleManualRecording'

--- a/apps/whispering/src/routes/(app)/_layout-utils/register-commands.ts
+++ b/apps/whispering/src/routes/(app)/_layout-utils/register-commands.ts
@@ -1,6 +1,6 @@
 import { partitionResults } from 'wellcrafted/result';
 import { goto } from '$app/navigation';
-import { commands } from '$lib/commands';
+import { type Command, commands } from '$lib/commands';
 import { CommandOrAlt, CommandOrControl } from '$lib/constants/keyboard';
 import { localShortcuts } from '$lib/operations/shortcuts';
 import { report } from '$lib/report';
@@ -21,7 +21,7 @@ const DEFAULT_LOCAL_SHORTCUTS = {
 	toggleVadRecording: 'v',
 	openTransformationPicker: 't',
 	runTransformationOnClipboard: 'r',
-} as const satisfies Record<string, string | null>;
+} as const satisfies Record<Command['id'], string | null>;
 
 /** Default values for global OS shortcuts. Keyed by command id string. */
 const DEFAULT_GLOBAL_SHORTCUTS = {
@@ -31,7 +31,7 @@ const DEFAULT_GLOBAL_SHORTCUTS = {
 	toggleVadRecording: null,
 	openTransformationPicker: `${CommandOrControl}+Shift+X`,
 	runTransformationOnClipboard: `${CommandOrControl}+Shift+R`,
-} as const satisfies Record<string, string | null>;
+} as const satisfies Record<Command['id'], string | null>;
 
 type LocalShortcutKey =
 	| 'shortcut.toggleManualRecording'

--- a/apps/whispering/src/routes/(app)/_layout-utils/register-commands.ts
+++ b/apps/whispering/src/routes/(app)/_layout-utils/register-commands.ts
@@ -33,28 +33,15 @@ const DEFAULT_GLOBAL_SHORTCUTS = {
 	runTransformationOnClipboard: `${CommandOrControl}+Shift+R`,
 } as const satisfies Record<Command['id'], string | null>;
 
-type LocalShortcutKey =
-	| 'shortcut.toggleManualRecording'
-	| 'shortcut.cancelManualRecording'
-	| 'shortcut.toggleVadRecording'
-	| 'shortcut.pushToTalk'
-	| 'shortcut.openTransformationPicker'
-	| 'shortcut.runTransformationOnClipboard';
+type LocalShortcutKey = `shortcut.${Command['id']}`;
+type GlobalShortcutKey = `shortcuts.global.${Command['id']}`;
 
-type GlobalShortcutKey =
-	| 'shortcuts.global.toggleManualRecording'
-	| 'shortcuts.global.cancelManualRecording'
-	| 'shortcuts.global.toggleVadRecording'
-	| 'shortcuts.global.pushToTalk'
-	| 'shortcuts.global.openTransformationPicker'
-	| 'shortcuts.global.runTransformationOnClipboard';
-
-function getLocalShortcutKey(commandId: string): LocalShortcutKey {
-	return `shortcut.${commandId}` as LocalShortcutKey;
+function getLocalShortcutKey(commandId: Command['id']): LocalShortcutKey {
+	return `shortcut.${commandId}`;
 }
 
-function getGlobalShortcutKey(commandId: string): GlobalShortcutKey {
-	return `shortcuts.global.${commandId}` as GlobalShortcutKey;
+function getGlobalShortcutKey(commandId: Command['id']): GlobalShortcutKey {
+	return `shortcuts.global.${commandId}`;
 }
 
 /**

--- a/apps/zhongwen/src/routes/(signed-in)/chat/providers.ts
+++ b/apps/zhongwen/src/routes/(signed-in)/chat/providers.ts
@@ -16,5 +16,5 @@ export const PROVIDER_MODELS = {
 
 export type Provider = keyof typeof PROVIDER_MODELS;
 
-export const DEFAULT_PROVIDER: Provider = 'gemini';
+export const DEFAULT_PROVIDER = 'gemini' satisfies Provider;
 export const DEFAULT_MODEL = 'gemini-3.1-flash-lite-preview' as const;

--- a/apps/zhongwen/src/routes/(signed-in)/chat/providers.ts
+++ b/apps/zhongwen/src/routes/(signed-in)/chat/providers.ts
@@ -17,4 +17,7 @@ export const PROVIDER_MODELS = {
 export type Provider = keyof typeof PROVIDER_MODELS;
 
 export const DEFAULT_PROVIDER = 'gemini' satisfies Provider;
-export const DEFAULT_MODEL = 'gemini-3.1-flash-lite-preview' as const;
+type DefaultProviderModel =
+	(typeof PROVIDER_MODELS)[typeof DEFAULT_PROVIDER][number];
+export const DEFAULT_MODEL =
+	'gemini-3.1-flash-lite-preview' satisfies DefaultProviderModel;

--- a/packages/auth/src/oauth-launchers/index.ts
+++ b/packages/auth/src/oauth-launchers/index.ts
@@ -168,10 +168,10 @@ export function createOAuthClient({
 	fetch: fetchImpl,
 }: OAuthClientConfig) {
 	const storageKey = `epicenter.oauth.${clientId}`;
-	const client: oauth.Client = {
+	const client = {
 		client_id: clientId,
 		token_endpoint_auth_method: 'none',
-	};
+	} satisfies oauth.Client;
 
 	const httpOptions = {
 		[oauth.allowInsecureRequests]: new URL(issuer).protocol === 'http:',

--- a/packages/billing/src/ai-model-pricing.ts
+++ b/packages/billing/src/ai-model-pricing.ts
@@ -17,7 +17,7 @@ type SupportedModel =
 	| (typeof OPENAI_CHAT_MODELS)[number]
 	| (typeof GeminiTextModels)[number];
 
-export const MODEL_CREDITS: Partial<Record<SupportedModel, number>> = {
+export const MODEL_CREDITS = {
 	// OpenAI: nano/mini (1 credit)
 	'gpt-5-nano': 1,
 	'gpt-4.1-nano': 1,
@@ -88,7 +88,7 @@ export const MODEL_CREDITS: Partial<Record<SupportedModel, number>> = {
 	'gemini-3.1-pro-preview': 5,
 	'gemini-3-pro-preview': 5,
 	'gemini-2.5-pro': 5,
-};
+} as const satisfies Partial<Record<SupportedModel, number>>;
 
 /** Coarse provider classification used by the dashboard model-cost
  *  table. Models that do not match any prefix are labeled "Unknown"

--- a/packages/sync/src/origins.ts
+++ b/packages/sync/src/origins.ts
@@ -32,8 +32,14 @@ export const BC_ORIGIN = Symbol.for('@epicenter/sync/bc-origin');
  * Realtime transport listeners use this list to avoid forwarding an update
  * back through another realtime transport.
  */
-const TRANSPORT_ORIGINS: readonly unknown[] = [SYNC_ORIGIN, BC_ORIGIN];
+const TRANSPORT_ORIGINS = [
+	SYNC_ORIGIN,
+	BC_ORIGIN,
+] as const satisfies readonly unknown[];
 
 export function isTransportOrigin(origin: unknown): boolean {
-	return TRANSPORT_ORIGINS.includes(origin);
+	return (
+		typeof origin === 'symbol' &&
+		TRANSPORT_ORIGINS.some((transportOrigin) => transportOrigin === origin)
+	);
 }

--- a/packages/workspace/src/client/daemon-actions.test.ts
+++ b/packages/workspace/src/client/daemon-actions.test.ts
@@ -15,14 +15,14 @@ function makeStubClient() {
 	const unreachable = () => {
 		throw new Error('stub: not used by these tests');
 	};
-	const client: DaemonClient = {
+	const client = {
 		peers: unreachable as DaemonClient['peers'],
 		list: unreachable as DaemonClient['list'],
 		run: (input: RunRequest) => {
 			calls.push({ method: 'run', arg: input });
 			return Promise.resolve(Ok(null)) as ReturnType<DaemonClient['run']>;
 		},
-	};
+	} satisfies DaemonClient;
 	return { client, calls };
 }
 

--- a/packages/workspace/src/daemon/run-handler.test.ts
+++ b/packages/workspace/src/daemon/run-handler.test.ts
@@ -55,11 +55,11 @@ function fakeEntry({
 
 describe('executeRun peer dispatch', () => {
 	test('relay RecipientOffline surfaces as PeerNotFound with sync status', async () => {
-		const syncStatus: SyncStatus = {
+		const syncStatus = {
 			phase: 'connecting',
 			retries: 2,
 			lastError: { type: 'connection' },
-		};
+		} as const satisfies SyncStatus;
 		const runSyncStatus = {
 			phase: 'connecting',
 			retries: 2,

--- a/packages/workspace/src/document/attach-encrypted-indexed-db.ts
+++ b/packages/workspace/src/document/attach-encrypted-indexed-db.ts
@@ -120,11 +120,11 @@ export function attachEncryptedIndexedDb(
 		]);
 	});
 
-	const attachment: IndexedDbAttachment = {
+	const attachment = {
 		whenLoaded,
 		clearLocal: () => clearDocument(databaseName),
 		whenDisposed,
-	};
+	} satisfies IndexedDbAttachment;
 
 	async function addEncryptedUpdate(
 		updatesStore: IDBObjectStore,

--- a/packages/workspace/src/document/materializer/sqlite/core.ts
+++ b/packages/workspace/src/document/materializer/sqlite/core.ts
@@ -374,7 +374,7 @@ export function attachSqliteMaterializerCore<
 
 	const whenFlushed = initialize();
 
-	const base: SqliteMaterializerCommon = {
+	const base = {
 		whenFlushed,
 		count: defineQuery({
 			title: 'Row count',
@@ -388,7 +388,7 @@ export function attachSqliteMaterializerCore<
 			input: Type.Object({ table: Type.Optional(Type.String()) }),
 			handler: ({ table: tableName }) => rebuild(tableName),
 		}),
-	};
+	} satisfies SqliteMaterializerCommon;
 
 	// The conditional return type collapses to `base` when no FTS was passed.
 	// The cast is local: the runtime branch matches the type-level branch.

--- a/packages/workspace/src/document/materializer/sqlite/turso.ts
+++ b/packages/workspace/src/document/materializer/sqlite/turso.ts
@@ -127,7 +127,7 @@ export function attachTursoMaterializer<
 	// Turso's Statement (Promise-returning run/get/all) is structurally
 	// compatible with MirrorStatement (MaybePromise-returning), so prepare()
 	// can return the native Statement directly. No wrapper.
-	const db: MirrorDatabase = {
+	const db = {
 		async run(sql) {
 			const client = await clientPromise;
 			await client.exec(sql);
@@ -136,7 +136,7 @@ export function attachTursoMaterializer<
 			const client = await clientPromise;
 			return client.prepare(sql);
 		},
-	};
+	} satisfies MirrorDatabase;
 
 	const core = attachSqliteMaterializerCore<TTables, TFts>(ydoc, {
 		db,

--- a/packages/workspace/src/index.browser-safe.test.ts
+++ b/packages/workspace/src/index.browser-safe.test.ts
@@ -19,7 +19,7 @@ import { fileURLToPath } from 'node:url';
 
 const ROOT_BARREL = fileURLToPath(new URL('./index.ts', import.meta.url));
 
-const FORBIDDEN_PATTERNS: { pattern: RegExp; label: string }[] = [
+const FORBIDDEN_PATTERNS = [
 	{ pattern: /\bfrom\s+['"]node:/, label: "import from 'node:*'" },
 	{ pattern: /\bfrom\s+['"]bun:/, label: "import from 'bun:*'" },
 	{ pattern: /\bfrom\s+['"]env-paths['"]/, label: "import from 'env-paths'" },
@@ -32,7 +32,7 @@ const FORBIDDEN_PATTERNS: { pattern: RegExp; label: string }[] = [
 	},
 	{ pattern: /\bBun\s*\./, label: 'reference to Bun.*' },
 	{ pattern: /\bprocess\s*\.\s*env\b/, label: 'reference to process.env' },
-];
+] as const satisfies readonly { pattern: RegExp; label: string }[];
 
 /**
  * Strip `import type` / `export type` lines so type-only references to

--- a/packages/workspace/src/links.test.ts
+++ b/packages/workspace/src/links.test.ts
@@ -83,12 +83,12 @@ describe('convertEpicenterLinksToWikilinks', () => {
 
 describe('convertWikilinksToEpicenterLinks', () => {
 	const resolve = (name: string) => {
-		const lookup = {
+		const lookup: Record<string, string> = {
 			'First Note': SAMPLE_REF,
 			'Project Plan': 'epicenter://opensidian/files/def-456',
-		} as const satisfies Record<string, string>;
+		};
 
-		return name in lookup ? lookup[name as keyof typeof lookup] : null;
+		return lookup[name] ?? null;
 	};
 
 	test('converts wikilinks to epicenter links', () => {

--- a/packages/workspace/src/links.test.ts
+++ b/packages/workspace/src/links.test.ts
@@ -83,12 +83,12 @@ describe('convertEpicenterLinksToWikilinks', () => {
 
 describe('convertWikilinksToEpicenterLinks', () => {
 	const resolve = (name: string) => {
-		const lookup: Record<string, string> = {
+		const lookup = {
 			'First Note': SAMPLE_REF,
 			'Project Plan': 'epicenter://opensidian/files/def-456',
-		};
+		} as const satisfies Record<string, string>;
 
-		return lookup[name] ?? null;
+		return name in lookup ? lookup[name as keyof typeof lookup] : null;
 	};
 
 	test('converts wikilinks to epicenter links', () => {

--- a/packages/workspace/src/workspace-apps/start-daemon-workspace-apps.test.ts
+++ b/packages/workspace/src/workspace-apps/start-daemon-workspace-apps.test.ts
@@ -64,7 +64,7 @@ function testRuntime(
 
 describe('startDaemonWorkspaceApps', () => {
 	test('opens every configured daemon route and returns the started routes', async () => {
-		const routes: Record<string, DaemonWorkspaceDefinition> = {
+		const routes = {
 			alpha: {
 				async open(ctx: DaemonWorkspaceContext) {
 					expect(ctx.route).toBe('alpha');
@@ -77,7 +77,7 @@ describe('startDaemonWorkspaceApps', () => {
 					return testRuntime();
 				},
 			},
-		};
+		} satisfies Record<string, DaemonWorkspaceDefinition>;
 
 		const result = await startDaemonWorkspaceApps({
 			projectDir,
@@ -94,7 +94,7 @@ describe('startDaemonWorkspaceApps', () => {
 
 	test('disposes successfully opened runtimes when a sibling open fails', async () => {
 		const goodMarker = disposeMarkerPath('good');
-		const routes: Record<string, DaemonWorkspaceDefinition> = {
+		const routes = {
 			good: {
 				async open() {
 					return testRuntime(() => writeFileSync(goodMarker, 'disposed'));
@@ -105,7 +105,7 @@ describe('startDaemonWorkspaceApps', () => {
 					throw new Error('boom');
 				},
 			},
-		};
+		} satisfies Record<string, DaemonWorkspaceDefinition>;
 
 		const result = await startDaemonWorkspaceApps({
 			projectDir,

--- a/packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts
+++ b/packages/workspace/src/workspace-apps/start-daemon-workspace-apps.ts
@@ -113,7 +113,7 @@ async function openOneDaemonRoute({
 	auth: WorkspaceAuthClient;
 	ownerId: OwnerId;
 }): Promise<Result<StartedDaemonRoute, WorkspaceAppError>> {
-	const ctx: DaemonWorkspaceContext = {
+	const ctx = {
 		projectDir,
 		route,
 		yDocClientId: hashYDocClientId(projectDir),
@@ -125,7 +125,7 @@ async function openOneDaemonRoute({
 		// reference directly is safe (no `.bind(auth)` needed).
 		openWebSocket: auth.openWebSocket,
 		onReconnectSignal: auth.onStateChange,
-	};
+	} satisfies DaemonWorkspaceContext;
 	try {
 		const runtime = await definition.open(ctx);
 		return Ok({ route, runtime });


### PR DESCRIPTION
This refactor moves selected const checks from left-side annotations to right-side `satisfies` checks. The point is not syntax churn. The point is to keep literal information alive where the value is the source of truth, while still making TypeScript validate the value against the intended contract.

```ts
// Before: the annotation validates, but also widens the value.
const table: Record<Key, Value> = {
  alpha: { mode: 'fast' },
};

// After: the literal shape stays narrow, and the contract is still checked.
const table = {
  alpha: { mode: 'fast' },
} as const satisfies Record<Key, Value>;
```

The review rule I used was: `satisfies` has to buy something. Static configs, finite maps, exported literal defaults, private factories checked against a port, and values derived from an existing registry usually qualify. Dynamic lookup tables, accumulators, generic collections, and tiny test-only shorthands usually do not.

```
Before
  const value: Contract = literal
        |          |
        |          +-- validates against Contract
        +------------- widens value before callers can use literals

After
  const value = literal satisfies Contract
        |        |
        |        +-- validates against Contract
        +----------- preserves the inferred literal shape
```

What changed:

- Whispering static maps and default config records now preserve literal keys and values where downstream code benefits from them.
- Workspace, billing, sync, and focused test records use `satisfies` where the object literal is the source of truth.
- Private recorder factory return annotations were dropped in favor of checking the returned object with `satisfies RecorderService`, keeping go-to-definition on the implementation while still enforcing the service port.
- The final review pass deliberately backed out a few low-value conversions where exact keys only forced casts for dynamic string indexing.
- Shortcut setting keys now derive from `Command['id']`, and Zhongwen's hardcoded default model is checked against the selected provider model list.

Suggested review path:

```
f23a947e5  whispering maps, defaults, recorder sessions
34ababb11  workspace runtime objects
3a8a14c63  workspace tests
4a96bad79  billing and sync maps
e195f984e  review cleanup and missed high-value sites
ba3a55a48  derived shortcut keys and default model contract
```

The main thing to check is that the converted sites are really static values, not mutable accumulators. The noisy cases were left alone rather than converted for consistency.

Verification:

```sh
bun typecheck
bun test packages/workspace/src/links.test.ts
bun test packages/auth/src/oauth-launchers/index.test.ts
```
