### PR TITLE
refactor(whispering): collapse redundant async wrappers

### DIFF
--- a/apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelDownloadCard.svelte
@@ -56,7 +56,7 @@
 				if (!(await exists(modelsDir))) {
 					await mkdir(modelsDir, { recursive: true });
 				}
-				return await join(modelsDir, model.file.filename);
+				return join(modelsDir, model.file.filename);
 			}
 			case 'parakeet': {
 				// Parakeet models are stored in a directory
@@ -65,7 +65,7 @@
 				if (!(await exists(parakeetModelsDir))) {
 					await mkdir(parakeetModelsDir, { recursive: true });
 				}
-				return await join(parakeetModelsDir, model.directoryName);
+				return join(parakeetModelsDir, model.directoryName);
 			}
 			case 'moonshine': {
 				// Moonshine models are stored in a directory
@@ -74,7 +74,7 @@
 				if (!(await exists(moonshineModelsDir))) {
 					await mkdir(moonshineModelsDir, { recursive: true });
 				}
-				return await join(moonshineModelsDir, model.directoryName);
+				return join(moonshineModelsDir, model.directoryName);
 			}
 		}
 	}

--- a/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
+++ b/apps/whispering/src/lib/components/settings/LocalModelSelector.svelte
@@ -61,7 +61,7 @@
 	const modelName = $derived.by(async () => {
 		const path = value;
 		if (!path) return '';
-		return await basename(path);
+		return basename(path);
 	});
 
 	// Check if current model is pre-built

--- a/apps/whispering/src/lib/constants/paths.ts
+++ b/apps/whispering/src/lib/constants/paths.ts
@@ -20,19 +20,19 @@ export const PATHS = {
 		async WHISPER() {
 			const { appDataDir, join } = await import('@tauri-apps/api/path');
 			const dir = await appDataDir();
-			return await join(dir, 'models', 'whisper');
+			return join(dir, 'models', 'whisper');
 		},
 		/** Directory for Parakeet model files */
 		async PARAKEET() {
 			const { appDataDir, join } = await import('@tauri-apps/api/path');
 			const dir = await appDataDir();
-			return await join(dir, 'models', 'parakeet');
+			return join(dir, 'models', 'parakeet');
 		},
 		/** Directory for Moonshine model files */
 		async MOONSHINE() {
 			const { appDataDir, join } = await import('@tauri-apps/api/path');
 			const dir = await appDataDir();
-			return await join(dir, 'models', 'moonshine');
+			return join(dir, 'models', 'moonshine');
 		},
 	},
 
@@ -96,7 +96,7 @@ export const PATHS = {
 		async RECORDINGS() {
 			const { appDataDir, join } = await import('@tauri-apps/api/path');
 			const dir = await appDataDir();
-			return await join(dir, 'recordings');
+			return join(dir, 'recordings');
 		},
 
 		/**
@@ -121,7 +121,7 @@ export const PATHS = {
 		async RECORDING_MD(id: string) {
 			const { appDataDir, join } = await import('@tauri-apps/api/path');
 			const dir = await appDataDir();
-			return await join(dir, 'recordings', `${id}.md`);
+			return join(dir, 'recordings', `${id}.md`);
 		},
 
 		/**
@@ -144,7 +144,7 @@ export const PATHS = {
 		async RECORDING_AUDIO(id: string, extension: string) {
 			const { appDataDir, join } = await import('@tauri-apps/api/path');
 			const dir = await appDataDir();
-			return await join(dir, 'recordings', `${id}.${extension}`);
+			return join(dir, 'recordings', `${id}.${extension}`);
 		},
 
 		/**
@@ -180,7 +180,7 @@ export const PATHS = {
 		async RECORDING_FILE(filename: string) {
 			const { appDataDir, join } = await import('@tauri-apps/api/path');
 			const dir = await appDataDir();
-			return await join(dir, 'recordings', filename);
+			return join(dir, 'recordings', filename);
 		},
 
 		/*
@@ -214,7 +214,7 @@ export const PATHS = {
 		async TRANSFORMATIONS() {
 			const { appDataDir, join } = await import('@tauri-apps/api/path');
 			const dir = await appDataDir();
-			return await join(dir, 'transformations');
+			return join(dir, 'transformations');
 		},
 
 		/**
@@ -237,7 +237,7 @@ export const PATHS = {
 		async TRANSFORMATION_MD(id: string) {
 			const { appDataDir, join } = await import('@tauri-apps/api/path');
 			const dir = await appDataDir();
-			return await join(dir, 'transformations', `${id}.md`);
+			return join(dir, 'transformations', `${id}.md`);
 		},
 
 		/*
@@ -271,7 +271,7 @@ export const PATHS = {
 		async TRANSFORMATION_RUNS() {
 			const { appDataDir, join } = await import('@tauri-apps/api/path');
 			const dir = await appDataDir();
-			return await join(dir, 'transformation-runs');
+			return join(dir, 'transformation-runs');
 		},
 
 		/**
@@ -295,7 +295,7 @@ export const PATHS = {
 		async TRANSFORMATION_RUN_MD(id: string) {
 			const { appDataDir, join } = await import('@tauri-apps/api/path');
 			const dir = await appDataDir();
-			return await join(dir, 'transformation-runs', `${id}.md`);
+			return join(dir, 'transformation-runs', `${id}.md`);
 		},
 	},
 };

--- a/apps/whispering/src/lib/operations/recording.ts
+++ b/apps/whispering/src/lib/operations/recording.ts
@@ -120,11 +120,11 @@ export async function stopManualRecording() {
 	});
 }
 
-export async function toggleManualRecording() {
+export function toggleManualRecording() {
 	if (manualRecorder.state === 'RECORDING') {
-		return await stopManualRecording();
+		return stopManualRecording();
 	}
-	return await startManualRecording();
+	return startManualRecording();
 }
 
 export async function cancelManualRecording() {
@@ -239,12 +239,12 @@ export async function stopVadRecording() {
 	sound.playSoundIfEnabled('vad-stop');
 }
 
-export async function toggleVadRecording() {
+export function toggleVadRecording() {
 	if (
 		vadRecorder.state === 'LISTENING' ||
 		vadRecorder.state === 'SPEECH_DETECTED'
 	) {
-		return await stopVadRecording();
+		return stopVadRecording();
 	}
-	return await startVadRecording();
+	return startVadRecording();
 }

--- a/apps/whispering/src/lib/operations/sound.ts
+++ b/apps/whispering/src/lib/operations/sound.ts
@@ -22,6 +22,6 @@ export const sound = {
 		if (!settings.get(soundSettingKeyMap[soundName])) {
 			return Ok(undefined);
 		}
-		return await services.sound.playSound(soundName);
+		return services.sound.playSound(soundName);
 	},
 };

--- a/apps/whispering/src/lib/operations/transcribe.ts
+++ b/apps/whispering/src/lib/operations/transcribe.ts
@@ -78,10 +78,7 @@ async function loadForCloudUpload(
 		});
 	}
 
-	const { data: rawBlob, error: blobError } =
-		await services.blobs.audio.getBlob(recordingId);
-	if (blobError) return Err(blobError);
-	return Ok(rawBlob);
+	return services.blobs.audio.getBlob(recordingId);
 }
 
 /**
@@ -249,80 +246,54 @@ async function dispatchCloudTranscription(
 
 	switch (selectedService) {
 		case 'OpenAI': {
-			const { data, error } = await services.transcriptions.openai.transcribe(
-				audio,
-				{
-					outputLanguage,
-					prompt,
-					apiKey: deviceConfig.get('apiKeys.openai'),
-					modelName: settings.get('transcription.openai.model'),
-					baseURL: deviceConfig.get('apiEndpoints.openai') || undefined,
-				},
-			);
-			if (error) return Err(error);
-			return Ok(data);
+			return services.transcriptions.openai.transcribe(audio, {
+				outputLanguage,
+				prompt,
+				apiKey: deviceConfig.get('apiKeys.openai'),
+				modelName: settings.get('transcription.openai.model'),
+				baseURL: deviceConfig.get('apiEndpoints.openai') || undefined,
+			});
 		}
 		case 'Groq': {
-			const { data, error } = await services.transcriptions.groq.transcribe(
-				audio,
-				{
-					outputLanguage,
-					prompt,
-					apiKey: deviceConfig.get('apiKeys.groq'),
-					modelName: settings.get('transcription.groq.model'),
-					baseURL: deviceConfig.get('apiEndpoints.groq') || undefined,
-				},
-			);
-			if (error) return Err(error);
-			return Ok(data);
+			return services.transcriptions.groq.transcribe(audio, {
+				outputLanguage,
+				prompt,
+				apiKey: deviceConfig.get('apiKeys.groq'),
+				modelName: settings.get('transcription.groq.model'),
+				baseURL: deviceConfig.get('apiEndpoints.groq') || undefined,
+			});
 		}
 		case 'speaches': {
-			const { data: speachesData, error: speachesError } =
-				await services.transcriptions.speaches.transcribe(audio, {
-					outputLanguage,
-					prompt,
-					modelId: deviceConfig.get('transcription.speaches.modelId'),
-					baseUrl: deviceConfig.get('transcription.speaches.baseUrl'),
-				});
-			if (speachesError) return Err(speachesError);
-			return Ok(speachesData);
+			return services.transcriptions.speaches.transcribe(audio, {
+				outputLanguage,
+				prompt,
+				modelId: deviceConfig.get('transcription.speaches.modelId'),
+				baseUrl: deviceConfig.get('transcription.speaches.baseUrl'),
+			});
 		}
 		case 'ElevenLabs': {
-			const { data, error } =
-				await services.transcriptions.elevenlabs.transcribe(audio, {
-					outputLanguage,
-					prompt,
-					apiKey: deviceConfig.get('apiKeys.elevenlabs'),
-					modelName: settings.get('transcription.elevenlabs.model'),
-				});
-			if (error) return Err(error);
-			return Ok(data);
+			return services.transcriptions.elevenlabs.transcribe(audio, {
+				outputLanguage,
+				prompt,
+				apiKey: deviceConfig.get('apiKeys.elevenlabs'),
+				modelName: settings.get('transcription.elevenlabs.model'),
+			});
 		}
 		case 'Deepgram': {
-			const { data, error } = await services.transcriptions.deepgram.transcribe(
-				audio,
-				{
-					outputLanguage,
-					prompt,
-					apiKey: deviceConfig.get('apiKeys.deepgram'),
-					modelName: settings.get('transcription.deepgram.model'),
-				},
-			);
-			if (error) return Err(error);
-			return Ok(data);
+			return services.transcriptions.deepgram.transcribe(audio, {
+				outputLanguage,
+				prompt,
+				apiKey: deviceConfig.get('apiKeys.deepgram'),
+				modelName: settings.get('transcription.deepgram.model'),
+			});
 		}
 		case 'Mistral': {
-			const { data, error } = await services.transcriptions.mistral.transcribe(
-				audio,
-				{
-					outputLanguage,
-					prompt,
-					apiKey: deviceConfig.get('apiKeys.mistral'),
-					modelName: settings.get('transcription.mistral.model'),
-				},
-			);
-			if (error) return Err(error);
-			return Ok(data);
+			return services.transcriptions.mistral.transcribe(audio, {
+				outputLanguage,
+				prompt,
+				apiKey: deviceConfig.get('apiKeys.mistral'),
+				modelName: settings.get('transcription.mistral.model'),
+			});
 		}
 		default:
 			return TranscriptionOperationError.NoTranscriptionServiceSelected();

--- a/apps/whispering/src/lib/operations/transform.ts
+++ b/apps/whispering/src/lib/operations/transform.ts
@@ -73,13 +73,15 @@ export const TransformError = defineErrors({
 });
 export type TransformError = InferErrors<typeof TransformError>;
 
+type StepError = string | { message: string };
+
 async function handleStep({
 	input,
 	step,
 }: {
 	input: string;
 	step: TransformationStep;
-}): Promise<Result<string, string>> {
+}): Promise<Result<string, StepError>> {
 	switch (step.type) {
 		case 'find_replace': {
 			const { findText, replaceText, useRegex } = step;
@@ -116,28 +118,24 @@ async function handleStep({
 					?.trim();
 				const baseUrl = stepBaseUrl || defaultBaseUrl || '';
 
-				const { data, error } = await services.completions.custom.complete({
+				return services.completions.custom.complete({
 					apiKey: deviceConfig.get('apiKeys.custom'),
 					model,
 					baseUrl,
 					systemPrompt,
 					userPrompt,
 				});
-				if (error) return Err(error.message);
-				return Ok(data);
 			}
 
 			const config = STANDARD_PROVIDER_CONFIG[inferenceProvider];
 			if (!config) return Err(`Unsupported provider: ${inferenceProvider}`);
 
-			const { data, error } = await config.service.complete({
+			return config.service.complete({
 				apiKey: deviceConfig.get(config.apiKeyPath),
 				model: step[config.modelKey] as string,
 				systemPrompt,
 				userPrompt,
 			});
-			if (error) return Err(error.message);
-			return Ok(data);
 		}
 
 		default:
@@ -210,13 +208,14 @@ export async function runTransformation({
 		});
 
 		if (isErr(handleStepResult)) {
+			const stepError = extractErrorMessage(handleStepResult.error);
 			const failedNow = new Date().toISOString();
 			transformationStepRuns.set({
 				...stepRun,
 				result: {
 					status: 'failed',
 					completedAt: failedNow,
-					error: handleStepResult.error,
+					error: stepError,
 				},
 			});
 			transformationRuns.set({
@@ -224,10 +223,10 @@ export async function runTransformation({
 				result: {
 					status: 'failed',
 					completedAt: failedNow,
-					error: handleStepResult.error,
+					error: stepError,
 				},
 			} satisfies TransformationRun);
-			return TransformError.StepFailed({ message: handleStepResult.error });
+			return TransformError.StepFailed({ message: stepError });
 		}
 
 		const handleStepOutput = handleStepResult.data;

--- a/apps/whispering/src/lib/rpc/download.ts
+++ b/apps/whispering/src/lib/rpc/download.ts
@@ -21,7 +21,7 @@ export const download = {
 
 			if (getAudioBlobError) return Err(getAudioBlobError);
 
-			return await services.download.downloadBlob({
+			return services.download.downloadBlob({
 				name: `whispering_recording_${recording.id}`,
 				blob: audioBlob,
 			});

--- a/apps/whispering/src/lib/services/download/index.tauri.ts
+++ b/apps/whispering/src/lib/services/download/index.tauri.ts
@@ -1,6 +1,6 @@
 import { save } from '@tauri-apps/plugin-dialog';
 import { writeFile } from '@tauri-apps/plugin-fs';
-import { Err, Ok, tryAsync } from 'wellcrafted/result';
+import { Err, tryAsync } from 'wellcrafted/result';
 import { getAudioExtension } from '$lib/services/transcription/utils';
 import type { DownloadService } from './types';
 import { DownloadError } from './types';
@@ -21,14 +21,12 @@ export const DownloadServiceLive = {
 		if (path === null) {
 			return DownloadError.SaveCancelled();
 		}
-		const { error: writeError } = await tryAsync({
+		return tryAsync({
 			try: async () => {
 				const contents = new Uint8Array(await blob.arrayBuffer());
 				await writeFile(path, contents);
 			},
 			catch: (error) => DownloadError.WriteFailed({ cause: error }),
 		});
-		if (writeError) return Err(writeError);
-		return Ok(undefined);
 	},
 } satisfies DownloadService;

--- a/apps/whispering/src/lib/state/manual-recorder.svelte.ts
+++ b/apps/whispering/src/lib/state/manual-recorder.svelte.ts
@@ -1,9 +1,5 @@
 import { nanoid } from 'nanoid/non-secure';
-import {
-	defineErrors,
-	extractErrorMessage,
-	type InferErrors,
-} from 'wellcrafted/error';
+import { defineErrors, extractErrorMessage } from 'wellcrafted/error';
 import { defineKeys } from 'wellcrafted/query';
 import { Err, Ok } from 'wellcrafted/result';
 import type { WhisperingRecordingState } from '$lib/constants/audio';
@@ -33,7 +29,6 @@ const ManualRecorderError = defineErrors({
 		message: 'No active recording session to stop. Start a recording first.',
 	}),
 });
-type ManualRecorderError = InferErrors<typeof ManualRecorderError>;
 
 export const manualRecorderKeys = defineKeys({
 	devices: ['recorder', 'devices'],
@@ -76,9 +71,7 @@ function resolveServiceForStart(): RecorderService {
 	return services.navigatorRecorder;
 }
 
-async function buildStartParams(
-	recordingId: string,
-): Promise<StartRecordingParams> {
+function buildStartParams(recordingId: string): StartRecordingParams {
 	const useCpal = !!tauri && deviceConfig.get('recording.method') === 'cpal';
 
 	if (useCpal) {
@@ -163,7 +156,7 @@ function createManualRecorder() {
 			await bootstrapped;
 			if (_current) return ManualRecorderError.AlreadyRecording();
 			const service = resolveServiceForStart();
-			const params = await buildStartParams(nanoid());
+			const params = buildStartParams(nanoid());
 			const { data, error: startRecordingError } = await service.startRecording(
 				params,
 				{ sendStatus },
@@ -178,13 +171,7 @@ function createManualRecorder() {
 		async stopRecording({ sendStatus }: { sendStatus: UpdateStatusMessageFn }) {
 			await bootstrapped;
 			if (!_current) return ManualRecorderError.NoActiveRecording();
-			const { data, error: stopRecordingError } = await _current.stop({
-				sendStatus,
-			});
-
-			if (stopRecordingError) return Err(stopRecordingError);
-
-			return Ok(data);
+			return _current.stop({ sendStatus });
 		},
 
 		async cancelRecording({
@@ -194,12 +181,7 @@ function createManualRecorder() {
 		}) {
 			await bootstrapped;
 			if (!_current) return Ok({ status: 'no-recording' as const });
-			const { data: cancelResult, error: cancelRecordingError } =
-				await _current.cancel({ sendStatus });
-
-			if (cancelRecordingError) return Err(cancelRecordingError);
-
-			return Ok(cancelResult);
+			return _current.cancel({ sendStatus });
 		},
 	};
 }

--- a/apps/whispering/src/lib/tauri.tauri.ts
+++ b/apps/whispering/src/lib/tauri.tauri.ts
@@ -87,7 +87,6 @@ const FsError = defineErrors({
 		cause,
 	}),
 });
-type FsError = InferErrors<typeof FsError>;
 
 async function readFileWithMimeType(path: string): Promise<{
 	bytes: Uint8Array<ArrayBuffer>;
@@ -130,7 +129,6 @@ const CommandError = defineErrors({
 		cause,
 	}),
 });
-type CommandError = InferErrors<typeof CommandError>;
 
 const command = {
 	/**
@@ -165,7 +163,6 @@ const PermissionsError = defineErrors({
 		cause,
 	}),
 });
-type PermissionsError = InferErrors<typeof PermissionsError>;
 
 const permissions = {
 	accessibility: {
@@ -176,7 +173,7 @@ const permissions = {
 					const { checkAccessibilityPermission } = await import(
 						'tauri-plugin-macos-permissions-api'
 					);
-					return await checkAccessibilityPermission();
+					return checkAccessibilityPermission();
 				},
 				catch: (error) => PermissionsError.CheckAccessibility({ cause: error }),
 			});
@@ -189,7 +186,7 @@ const permissions = {
 					const { requestAccessibilityPermission } = await import(
 						'tauri-plugin-macos-permissions-api'
 					);
-					return await requestAccessibilityPermission();
+					return requestAccessibilityPermission();
 				},
 				catch: (error) =>
 					PermissionsError.RequestAccessibility({ cause: error }),
@@ -205,7 +202,7 @@ const permissions = {
 					const { checkMicrophonePermission } = await import(
 						'tauri-plugin-macos-permissions-api'
 					);
-					return await checkMicrophonePermission();
+					return checkMicrophonePermission();
 				},
 				catch: (error) => PermissionsError.CheckMicrophone({ cause: error }),
 			});
@@ -218,7 +215,7 @@ const permissions = {
 					const { requestMicrophonePermission } = await import(
 						'tauri-plugin-macos-permissions-api'
 					);
-					return await requestMicrophonePermission();
+					return requestMicrophonePermission();
 				},
 				catch: (error) => PermissionsError.RequestMicrophone({ cause: error }),
 			});
@@ -238,7 +235,6 @@ const TrayError = defineErrors({
 		cause,
 	}),
 });
-type TrayError = InferErrors<typeof TrayError>;
 
 const TRAY_ID = 'whispering-tray';
 let trayPromise: ReturnType<typeof initTray> | null = null;
@@ -399,7 +395,6 @@ const AutostartError = defineErrors({
 		cause,
 	}),
 });
-type AutostartError = InferErrors<typeof AutostartError>;
 
 // Public namespaces ------------------------------------------------
 // Each capability picks ONE shape per method: TanStack where reactivity,


### PR DESCRIPTION
Several Whispering paths were unpacking async Result envelopes or awaiting tail promises only to rebuild the same shape. That made the actual branches harder to scan: compression fallback, no-active-recording guards, save cancellation, permission errors, and transformation run failure persistence were mixed with identity plumbing.

This PR keeps those behavior branches and returns service calls directly where the callee already owns the Result shape.

Before:

```ts
const { data, error } = await services.transcriptions.openai.transcribe(audio, opts);
if (error) return Err(error);
return Ok(data);
```

After:

```ts
return services.transcriptions.openai.transcribe(audio, opts);
```

The same cleanup applies to cloud transcription dispatch, blob loading fallback, manual recorder stop and cancel, download writes, Tauri path helpers, permission callbacks, sound playback, recording toggles, and local model path helpers.

`transform.ts` now lets completion services return their Result envelopes directly. Provider errors still get persisted as strings, but the normalization happens once at the failed-step boundary where the transformation run and step run are written.

Left alone: recorder device enumeration still wraps service errors in `ManualRecorderError`, save cancellation stays explicit, and local model directory setup remains in the download path helper because those branches own user-visible behavior or filesystem policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/EpicenterHQ/codesmith/epicenter/pr/1841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782465087&installation_id=128463665&pr_number=1841&repository=EpicenterHQ%2Fepicenter&return_to=https%3A%2F%2Fgithub.com%2FEpicenterHQ%2Fepicenter%2Fpull%2F1841&signature=ab8dc625907c216016ca6d4e467643c9d1663cddff7e58da29f8ecd33d79ed55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->